### PR TITLE
fix(ci): add missing funnel constants and fix import ordering

### DIFF
--- a/src/engines/scorer.py
+++ b/src/engines/scorer.py
@@ -118,6 +118,12 @@ LINKEDIN_HIGH_CONNECTIONS_BOOST = 2  # 500+ connections (influential)
 LINKEDIN_HIGH_FOLLOWERS_BOOST = 2  # Company 1000+ followers
 LINKEDIN_RECENT_ACTIVITY_BOOST = 1  # Posted in last 30 days
 
+# Phase 24E: Funnel conversion patterns boost (max 12 points boost)
+MAX_FUNNEL_BOOST = 12
+FUNNEL_HIGH_SHOW_RATE_BOOST = 4  # Tier has high show rate (80%+)
+FUNNEL_GOOD_DEAL_RATE_BOOST = 4  # Good meeting-to-deal conversion (40%+)
+FUNNEL_STRONG_WIN_RATE_BOOST = 4  # Strong win rate (30%+)
+
 # Default component weights (Phase 16)
 # These are used when no learned weights are available
 DEFAULT_WEIGHTS = {

--- a/src/integrations/vapi.py
+++ b/src/integrations/vapi.py
@@ -27,11 +27,11 @@ import logging
 import httpx
 from pydantic import BaseModel, Field
 from tenacity import (
+    before_sleep_log,
     retry,
+    retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
-    retry_if_exception_type,
-    before_sleep_log,
 )
 
 from src.config.settings import settings


### PR DESCRIPTION
## Summary
Fixes CI-breaking issues:

### Issue 1: Undefined constants in scorer.py
The file referenced 4 undefined constants that caused CI failures:
- `FUNNEL_STRONG_WIN_RATE_BOOST`
- `FUNNEL_GOOD_DEAL_RATE_BOOST`
- `FUNNEL_HIGH_SHOW_RATE_BOOST`
- `MAX_FUNNEL_BOOST`

Added these constants with values matching the checklist at the bottom of the file:
- `MAX_FUNNEL_BOOST = 12`
- `FUNNEL_HIGH_SHOW_RATE_BOOST = 4`
- `FUNNEL_GOOD_DEAL_RATE_BOOST = 4`
- `FUNNEL_STRONG_WIN_RATE_BOOST = 4`

### Issue 2: Import sorting in vapi.py
Ran `ruff --fix` to auto-fix import ordering.

### Verification
`ruff check src/` passes with all checks.