### PR TITLE
fix(security): Replace hardcoded URLs with environment variables

### DIFF
--- a/src/api/routes/crm.py
+++ b/src/api/routes/crm.py
@@ -38,6 +38,7 @@ from src.api.dependencies import (
     get_current_user_from_token,
     get_db_session,
 )
+from src.config.settings import settings
 from src.services.crm_push_service import (
     CRMConfig,
     CRMPushService,
@@ -368,9 +369,8 @@ async def hubspot_oauth_callback(
         await crm_service.close()
 
     # Redirect to frontend settings page
-    frontend_url = "https://agency-os-liart.vercel.app"  # TODO: Make configurable
     return RedirectResponse(
-        url=f"{frontend_url}/settings/integrations?crm=hubspot&status=connected",
+        url=f"{settings.frontend_url}/settings/integrations?crm=hubspot&status=connected",
         status_code=status.HTTP_302_FOUND,
     )
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -86,6 +86,13 @@ class Settings(BaseSettings):
         alias="BASE_URL",
     )
 
+    # === Frontend URL ===
+    frontend_url: str = Field(
+        default="http://localhost:3000",
+        description="Frontend application URL (for OAuth callbacks, CRM redirects)",
+        alias="FRONTEND_URL",
+    )
+
     # === Prefect (Workflow Orchestration) ===
     prefect_api_url: str = Field(
         default="http://localhost:4200/api", description="Prefect server API URL"

--- a/src/services/linkedin_connection_service.py
+++ b/src/services/linkedin_connection_service.py
@@ -93,14 +93,8 @@ class LinkedInConnectionService:
         await db.refresh(credential)
 
         # Determine redirect URLs based on environment
-        frontend_url = (
-            settings.ALLOWED_ORIGINS[0] if settings.ALLOWED_ORIGINS else "http://localhost:3000"
-        )
-        api_url = (
-            "https://agency-os-production.up.railway.app"
-            if settings.is_production
-            else "http://localhost:8000"
-        )
+        frontend_url = settings.frontend_url
+        api_url = settings.base_url
 
         try:
             # Generate hosted auth URL from Unipile


### PR DESCRIPTION
## P0-003: Security Fix - Hardcoded URLs

### Problem
Hardcoded production URLs in the codebase would break in different environments and are a security concern.

### Changes
- Added `frontend_url` setting to `config/settings.py`
- Updated `crm.py` to use `settings.frontend_url` for OAuth redirects
- Updated `linkedin_connection_service.py` to use `settings.base_url` and `settings.frontend_url`

### Files Changed
- `src/config/settings.py`
- `src/api/routes/crm.py`
- `src/services/linkedin_connection_service.py`

### Testing
- Set `FRONTEND_URL` environment variable in production
- Verify OAuth redirect flows work correctly

### Related
- Part of full codebase audit (P0-003)