### PR TITLE
fix(logging): Replace print statements with structured logging

### DIFF
--- a/src/orchestration/flows/crm_sync_flow.py
+++ b/src/orchestration/flows/crm_sync_flow.py
@@ -573,7 +573,7 @@ async def crm_sync_flow(
     Returns:
         Summary of sync results
     """
-    print(f"Starting CRM sync flow (since_hours={since_hours})")
+    logger.info(f"Starting CRM sync flow (since_hours={since_hours})")
 
     total_synced = 0
     total_errors = 0
@@ -591,7 +591,7 @@ async def crm_sync_flow(
             client_uuid = client["id"]
             client_results = []
 
-            print(f"Syncing CRMs for client: {client['company_name']}")
+            logger.info(f"Syncing CRMs for client: {client['company_name']}")
 
             for crm_config in client["crm_configs"]:
                 crm_type = crm_config["type"]
@@ -652,7 +652,7 @@ async def crm_sync_flow(
         "since_hours": since_hours,
     }
 
-    print(f"CRM sync complete: {summary}")
+    logger.info(f"CRM sync complete: {summary}")
     return summary
 
 


### PR DESCRIPTION
## P1-004: Replace print() with logging

### Problem
Print statements in production code don't integrate with application logging, making debugging and monitoring difficult.

### Changes
- Replaced `print()` calls with `logger.info()` in `crm_sync_flow.py`

### Benefits
- CRM sync events now appear in application logs
- Enables log aggregation and monitoring
- Proper log levels for production environments

### Files Changed
- `src/orchestration/flows/crm_sync_flow.py`

### Related
- Part of full codebase audit (P1-004)