### PR TITLE
chore: Mark MEMORY.md as deprecated

### DIFF
--- a/governance/MEMORY.md
+++ b/governance/MEMORY.md
@@ -1,4 +1,11 @@
-# MEMORY.md — What I Know
+# MEMORY.md — DEPRECATED
+
+**Migrated to Supabase `elliot_internal.memories` on 2026-02-12.**
+**Read-only reference only. Do not add new entries here.**
+
+---
+
+# MEMORY.md — What I Know (ARCHIVED)
 
 ## Dave
 


### PR DESCRIPTION
## CEO Directive 2026-02-12

MEMORY.md migrated to Supabase `elliot_internal.memories`.

**28 entries created:**
- 21 from MEMORY.md
- 7 from governance/memory/*.md

File is now read-only reference. New entries go to Supabase only (LAW IX).