### PR TITLE
fix: Full codebase lint cleanup (Directive #057 follow-up)

### DIFF
--- a/src/api/routes/unipile.py
+++ b/src/api/routes/unipile.py
@@ -322,7 +322,7 @@ async def handle_webhook(
     """
     # Note: Signature verification is optional for Unipile
     # They recommend IP whitelisting instead
-    
+
     try:
         payload = await request.json()
     except Exception:

--- a/src/config/database.py
+++ b/src/config/database.py
@@ -1,6 +1,6 @@
 # Re-export database utilities for backward compatibility
 # Actual implementation is in src.integrations.supabase
 
-from src.integrations.supabase import get_db_session, get_async_engine, AsyncSessionLocal
+from src.integrations.supabase import AsyncSessionLocal, get_async_engine, get_db_session
 
 __all__ = ["get_db_session", "get_async_engine", "AsyncSessionLocal"]

--- a/src/engines/base.py
+++ b/src/engines/base.py
@@ -444,8 +444,9 @@ class BaseEngine(ABC):
             metadata: Additional metadata
         """
         try:
-            from sqlalchemy import text as sql_text
             import json
+
+            from sqlalchemy import text as sql_text
 
             entry = self.log_operation(
                 operation=operation,
@@ -486,7 +487,7 @@ class BaseEngine(ABC):
                 },
             )
             # Note: Don't commit here - let the caller manage the transaction
-            
+
         except Exception as e:
             # Don't fail the operation if logging fails
             import logging

--- a/src/engines/client_intelligence.py
+++ b/src/engines/client_intelligence.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.integrations.anthropic import get_anthropic_client
+
 # NOTE: Apify import removed per FCO-003 deprecation (cost savings)
 # All scraping methods now degrade gracefully
 from src.models.client import Client
@@ -231,7 +232,7 @@ class ClientIntelligenceEngine:
         
         DEPRECATED: Apify integration removed per FCO-003.
         """
-        logger.info(f"Facebook scrape skipped — Apify deprecated (FCO-003)")
+        logger.info("Facebook scrape skipped — Apify deprecated (FCO-003)")
         result.errors.append({
             "source": "facebook",
             "error": "Apify deprecated (FCO-003).",
@@ -276,7 +277,7 @@ class ClientIntelligenceEngine:
         
         DEPRECATED: Apify integration removed per FCO-003.
         """
-        logger.info(f"G2 scrape skipped — Apify deprecated (FCO-003)")
+        logger.info("G2 scrape skipped — Apify deprecated (FCO-003)")
         result.errors.append({
             "source": "g2",
             "error": "Apify deprecated (FCO-003).",
@@ -291,7 +292,7 @@ class ClientIntelligenceEngine:
         
         DEPRECATED: Apify integration removed per FCO-003.
         """
-        logger.info(f"Capterra scrape skipped — Apify deprecated (FCO-003)")
+        logger.info("Capterra scrape skipped — Apify deprecated (FCO-003)")
         result.errors.append({
             "source": "capterra",
             "error": "Apify deprecated (FCO-003).",

--- a/src/engines/closer.py
+++ b/src/engines/closer.py
@@ -185,7 +185,7 @@ class CloserEngine(BaseEngine):
             intent_enum = INTENT_MAP.get(intent_str, IntentType.QUESTION)
             confidence = classification.get("confidence", 0.0)
             reasoning = classification.get("reasoning", "")
-            
+
             # Directive 048 Part F: Flag low confidence replies for human review
             if confidence < 0.6:
                 await self._flag_for_human_review(
@@ -232,6 +232,7 @@ class CloserEngine(BaseEngine):
                 lead=lead,
                 intent=intent_enum,
                 confidence=confidence,
+                channel=channel,
                 reply_analysis=reply_analysis,
             )
 
@@ -441,6 +442,7 @@ class CloserEngine(BaseEngine):
         lead: Lead,
         intent: IntentType,
         confidence: float,
+        channel: ChannelType,
         reply_analysis: dict[str, Any] | None = None,
     ) -> list[str]:
         """
@@ -451,6 +453,7 @@ class CloserEngine(BaseEngine):
             lead: Lead to update
             intent: Classified intent
             confidence: Classification confidence
+            channel: Channel the reply came from
             reply_analysis: Phase 24D reply analysis results
 
         Returns:
@@ -473,7 +476,7 @@ class CloserEngine(BaseEngine):
                     company_name=lead.company,
                     client_id=lead.client_id,
                 )
-                
+
                 # Send automated reply with booking link
                 await send_booking_reply(
                     db=db,
@@ -485,7 +488,7 @@ class CloserEngine(BaseEngine):
             except Exception as e:
                 logger.warning(f"Failed to send booking link for lead {lead.id}: {e}")
                 actions.append("booking_link_failed")
-            
+
             # Status will be updated to CONVERTED when Calendly webhook confirms
             # For now, mark as pending meeting
             lead.status = LeadStatus.IN_SEQUENCE  # Keep in sequence until booking confirmed
@@ -555,13 +558,13 @@ class CloserEngine(BaseEngine):
                 lead.status = LeadStatus.ENRICHED
                 actions.append("stopped_sequence")
             actions.append("referral_received")
-            
+
             # Store referral flag in lead metadata
             if not lead.metadata:
                 lead.metadata = {}
             lead.metadata["has_referral"] = True
             lead.metadata["referral_received_at"] = datetime.utcnow().isoformat()
-            
+
             # Auto-create new lead from referral
             try:
                 referral_lead = await self._create_referral_lead(
@@ -598,14 +601,14 @@ class CloserEngine(BaseEngine):
                 f"ADMIN ALERT: Angry/complaint reply from lead {lead.id} - requires manual review"
             )
             actions.append("admin_review_required")
-            
+
             # Store admin review flag in lead metadata
             if not lead.metadata:
                 lead.metadata = {}
             lead.metadata["admin_review_required"] = True
             lead.metadata["admin_review_reason"] = "angry_or_complaint"
             lead.metadata["admin_review_flagged_at"] = datetime.utcnow().isoformat()
-            
+
             # Directive 048: Fire admin notification via Supabase immediately
             try:
                 await self._fire_admin_notification(
@@ -728,7 +731,7 @@ class CloserEngine(BaseEngine):
         try:
             # Extract referral information using AI
             referral_info = await self._extract_referral_info(reply_analysis)
-            
+
             if not referral_info or not referral_info.get("name"):
                 logger.warning(f"Could not extract referral info from lead {source_lead.id}")
                 return None
@@ -810,11 +813,10 @@ class CloserEngine(BaseEngine):
 
         # Check if topics contain contact info
         topics = reply_analysis.get("topics_mentioned", [])
-        question = reply_analysis.get("question_extracted")
-        
+
         # Basic extraction from topics (name patterns, email patterns)
         referral_info = {}
-        
+
         for topic in topics:
             # Look for email pattern
             if "@" in topic and "." in topic:
@@ -857,7 +859,7 @@ class CloserEngine(BaseEngine):
         """
         try:
             from src.services.alert_service import get_alert_service
-            
+
             alert_service = get_alert_service(db)
             return await alert_service.flag_reply_for_review(
                 lead_id=lead_id,
@@ -897,7 +899,7 @@ class CloserEngine(BaseEngine):
         """
         try:
             import json
-            
+
             query = text("""
                 SELECT create_admin_notification(
                     :notification_type,
@@ -912,7 +914,7 @@ class CloserEngine(BaseEngine):
             """)
 
             title = f"[{severity.upper()}] {notification_type.replace('_', ' ').title()}"
-            
+
             metadata = json.dumps({
                 "lead_email": lead.email,
                 "lead_name": lead.full_name,

--- a/src/engines/email.py
+++ b/src/engines/email.py
@@ -278,7 +278,7 @@ class EmailEngine(OutreachEngine):
         unsubscribe_url = None
         list_unsubscribe_headers = {}
         lead_pool_id = kwargs.get("lead_pool_id")
-        
+
         if lead_pool_id:
             try:
                 unsubscribe_service = get_unsubscribe_token_service()

--- a/src/engines/icp_scraper.py
+++ b/src/engines/icp_scraper.py
@@ -65,9 +65,9 @@ from src.integrations.camoufox_scraper import (
 )
 from src.integrations.clay import get_clay_client
 from src.integrations.siege_waterfall import (
+    EnrichmentTier,
     SiegeWaterfall,
     get_siege_waterfall,
-    EnrichmentTier,
 )
 
 # Portfolio page paths to fetch directly (ICP-FIX-008)
@@ -300,10 +300,7 @@ class ICPScraperEngine(BaseEngine):
         # Check for Australian state abbreviations in name
         au_states = ["nsw", "vic", "qld", "wa", "sa", "tas", "nt", "act"]
         name_words = name_lower.split()
-        if any(state in name_words for state in au_states):
-            return True
-
-        return False
+        return any(state in name_words for state in au_states)
 
     def _extract_social_links(self, raw_html: str) -> SocialLinks:
         """

--- a/src/engines/identity_escalation.py
+++ b/src/engines/identity_escalation.py
@@ -30,14 +30,12 @@ CHANNEL MAPPING:
   - LinkedIn -> linkedin_profile_url
 """
 
-import asyncio
 import logging
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Optional
 from uuid import UUID, uuid4
 
 from sqlalchemy import insert
@@ -121,9 +119,9 @@ class DecisionMaker:
     first_name: str
     last_name: str
     title: str
-    linkedin_url: Optional[str] = None
-    work_email: Optional[str] = None
-    mobile_number: Optional[str] = None
+    linkedin_url: str | None = None
+    work_email: str | None = None
+    mobile_number: str | None = None
     phone_type: PhoneType = PhoneType.UNKNOWN
     confidence: int = 0  # 0-100
     source: str = ""
@@ -134,27 +132,27 @@ class IdentityResult:
     """Result from identity escalation."""
     lead_id: UUID
     company_name: str
-    
+
     # Primary decision maker
-    primary_contact: Optional[DecisionMaker] = None
-    
+    primary_contact: DecisionMaker | None = None
+
     # All found decision makers (top 3)
     decision_makers: list[DecisionMaker] = field(default_factory=list)
-    
+
     # Channel-specific verified fields
-    mobile_number_verified: Optional[str] = None
-    work_email_verified: Optional[str] = None
-    registered_office_address: Optional[str] = None
-    linkedin_profile_url: Optional[str] = None
-    
+    mobile_number_verified: str | None = None
+    work_email_verified: str | None = None
+    registered_office_address: str | None = None
+    linkedin_profile_url: str | None = None
+
     # Escalation tracking
     escalation_triggered: bool = False
-    escalation_reason: Optional[str] = None
+    escalation_reason: str | None = None
     tiers_used: list[str] = field(default_factory=list)
-    
+
     # Costs
     total_cost_aud: Decimal = Decimal("0.00")
-    
+
     # Status
     success: bool = False
     errors: list[str] = field(default_factory=list)
@@ -170,7 +168,7 @@ class IdentityLineageStep:
     success: bool
     contacts_found: int = 0
     data_added: list[str] = field(default_factory=list)
-    error_message: Optional[str] = None
+    error_message: str | None = None
 
 
 # ============================================
@@ -197,7 +195,7 @@ class IdentityEscalationEngine(BaseEngine):
     - Mobile enrichment is expensive (~$0.15-0.30 AUD)
     - Only enrich for leads with ALS > 75
     """
-    
+
     def __init__(
         self,
         lusha_client=None,
@@ -222,15 +220,15 @@ class IdentityEscalationEngine(BaseEngine):
         self._kaspr = kaspr_client
         self._asic = asic_client
         self._scraper = web_scraper
-    
+
     @property
     def name(self) -> str:
         return "identity_escalation"
-    
+
     # ============================================
     # GENERIC EMAIL DETECTION
     # ============================================
-    
+
     def is_generic_email(self, email: str) -> bool:
         """
         Check if an email is a generic inbox.
@@ -243,29 +241,25 @@ class IdentityEscalationEngine(BaseEngine):
         """
         if not email:
             return True
-        
+
         email_lower = email.lower().strip()
-        
-        for pattern in GENERIC_EMAIL_PATTERNS:
-            if re.match(pattern, email_lower):
-                return True
-        
-        return False
-    
+
+        return any(re.match(pattern, email_lower) for pattern in GENERIC_EMAIL_PATTERNS)
+
     def get_generic_reason(self, email: str) -> str:
         """Get the reason why an email is generic."""
         if not email:
             return "No email provided"
-        
+
         email_lower = email.lower().strip()
         local_part = email_lower.split("@")[0]
-        
+
         return f"Generic inbox detected: {local_part}@"
-    
+
     # ============================================
     # PHONE TYPE DETECTION
     # ============================================
-    
+
     def classify_phone(self, phone: str) -> PhoneType:
         """
         Classify an Australian phone number.
@@ -278,18 +272,18 @@ class IdentityEscalationEngine(BaseEngine):
         """
         if not phone:
             return PhoneType.UNKNOWN
-        
+
         # Normalize: remove spaces, dashes, parentheses
         normalized = re.sub(r"[\s\-\(\)]", "", phone)
-        
+
         if re.match(AU_MOBILE_PATTERN, normalized):
             return PhoneType.MOBILE
         elif re.match(AU_LANDLINE_PATTERN, normalized):
             return PhoneType.LANDLINE
         else:
             return PhoneType.UNKNOWN
-    
-    def prioritize_mobile(self, phones: list[str]) -> Optional[str]:
+
+    def prioritize_mobile(self, phones: list[str]) -> str | None:
         """
         From a list of phones, return the mobile number (priority for Voice AI).
         
@@ -302,25 +296,25 @@ class IdentityEscalationEngine(BaseEngine):
         for phone in phones:
             if self.classify_phone(phone) == PhoneType.MOBILE:
                 return phone
-        
+
         return None
-    
+
     # ============================================
     # MAIN ESCALATION FLOW
     # ============================================
-    
+
     async def escalate_identity(
         self,
         db: AsyncSession,
         lead_id: UUID,
         company_name: str,
         company_domain: str,
-        company_linkedin_url: Optional[str],
-        current_email: Optional[str],
-        current_phone: Optional[str],
-        registered_address: Optional[str],
+        company_linkedin_url: str | None,
+        current_email: str | None,
+        current_phone: str | None,
+        registered_address: str | None,
         als_score: int,
-        acn: Optional[str] = None,
+        acn: str | None = None,
     ) -> EngineResult[IdentityResult]:
         """
         Run identity escalation to find direct decision maker contacts.
@@ -345,23 +339,23 @@ class IdentityEscalationEngine(BaseEngine):
             company_name=company_name,
             registered_office_address=registered_address,
         )
-        
+
         lineage_steps: list[IdentityLineageStep] = []
         step_number = 0
         total_cost = Decimal("0.00")
-        
+
         try:
             # ========== CHECK IF ESCALATION NEEDED ==========
             needs_escalation = self.is_generic_email(current_email)
             phone_type = self.classify_phone(current_phone) if current_phone else PhoneType.UNKNOWN
-            
+
             # Also escalate if we only have landline and need mobile for Voice AI
             if phone_type == PhoneType.LANDLINE and als_score > ALS_MOBILE_THRESHOLD:
                 needs_escalation = True
                 result.escalation_reason = "Landline only - need mobile for Voice AI"
             elif needs_escalation:
                 result.escalation_reason = self.get_generic_reason(current_email)
-            
+
             if not needs_escalation:
                 # No escalation needed - use existing data
                 result.work_email_verified = current_email
@@ -369,16 +363,15 @@ class IdentityEscalationEngine(BaseEngine):
                     result.mobile_number_verified = current_phone
                 result.success = True
                 return EngineResult.ok(data=result)
-            
+
             result.escalation_triggered = True
             decision_makers: list[DecisionMaker] = []
-            
+
             # ========== TIER 1: TEAM PAGE SCRAPE ==========
             step_number += 1
-            start_time = datetime.utcnow()
-            
+
             team_contacts = await self._scrape_team_page(company_domain)
-            
+
             step = IdentityLineageStep(
                 step_number=step_number,
                 tier=IdentityTier.TEAM_PAGE_SCRAPE,
@@ -391,9 +384,9 @@ class IdentityEscalationEngine(BaseEngine):
             lineage_steps.append(step)
             total_cost += step.cost_aud
             result.tiers_used.append(IdentityTier.TEAM_PAGE_SCRAPE.value)
-            
+
             decision_makers.extend(team_contacts)
-            
+
             # ========== TIER 2: LINKEDIN EMPLOYEE SEARCH ==========
             # NOTE: Tier 2 (Proxycurl LinkedIn) deprecated per FCO-003 (shutdown July 2025)
             # Skipping this tier entirely - relying on Tier 1 (team page) and Tier 3 (ASIC)
@@ -402,13 +395,13 @@ class IdentityEscalationEngine(BaseEngine):
                 logger.info(
                     f"Tier 2 skipped for {company_name}: Proxycurl deprecated (FCO-003)"
                 )
-            
+
             # ========== TIER 3: ASIC DIRECTOR HUNT ==========
             if acn and len(decision_makers) < 3:
                 step_number += 1
-                
+
                 asic_directors = await self._hunt_asic_directors(acn)
-                
+
                 step = IdentityLineageStep(
                     step_number=step_number,
                     tier=IdentityTier.ASIC_DIRECTOR,
@@ -421,45 +414,45 @@ class IdentityEscalationEngine(BaseEngine):
                 lineage_steps.append(step)
                 total_cost += step.cost_aud
                 result.tiers_used.append(IdentityTier.ASIC_DIRECTOR.value)
-                
+
                 # ASIC directors are high priority
                 for ad in asic_directors:
                     if not any(dm.full_name.lower() == ad.full_name.lower() for dm in decision_makers):
                         decision_makers.insert(0, ad)  # Priority insert
-            
+
             # ========== FILTER TO TOP 3 DECISION MAKERS ==========
             decision_makers = self._rank_decision_makers(decision_makers)[:3]
             result.decision_makers = decision_makers
-            
+
             if decision_makers:
                 result.primary_contact = decision_makers[0]
-                
+
                 # Extract best LinkedIn URL
                 for dm in decision_makers:
                     if dm.linkedin_url:
                         result.linkedin_profile_url = dm.linkedin_url
                         break
-            
+
             # ========== TIER 4/5: MOBILE ENRICHMENT (COGS GATED) ==========
             # Only enrich mobile for ALS > 75
             if als_score > ALS_MOBILE_THRESHOLD and decision_makers:
                 step_number += 1
-                
+
                 # Try Lusha first, then Kaspr
                 mobile_result = await self._enrich_mobile_number(
                     decision_makers[0], company_domain
                 )
-                
+
                 if mobile_result:
                     result.mobile_number_verified = mobile_result.mobile_number
                     result.primary_contact.mobile_number = mobile_result.mobile_number
                     result.primary_contact.phone_type = PhoneType.MOBILE
-                    
+
                     # Also capture work email if found
                     if mobile_result.work_email and not self.is_generic_email(mobile_result.work_email):
                         result.work_email_verified = mobile_result.work_email
                         result.primary_contact.work_email = mobile_result.work_email
-                    
+
                     step = IdentityLineageStep(
                         step_number=step_number,
                         tier=IdentityTier.IDENTITY_GOLD,
@@ -483,25 +476,25 @@ class IdentityEscalationEngine(BaseEngine):
                 result.errors.append(
                     f"Mobile enrichment skipped: ALS {als_score} <= {ALS_MOBILE_THRESHOLD}"
                 )
-            
+
             # ========== FALLBACK: Use best available email ==========
             if not result.work_email_verified:
                 for dm in decision_makers:
                     if dm.work_email and not self.is_generic_email(dm.work_email):
                         result.work_email_verified = dm.work_email
                         break
-            
+
             # ========== FINALIZE ==========
             result.total_cost_aud = total_cost
             result.success = bool(
-                result.work_email_verified or 
-                result.mobile_number_verified or 
+                result.work_email_verified or
+                result.mobile_number_verified or
                 result.linkedin_profile_url
             )
-            
+
             # Log lineage
             await self._log_identity_lineage(db, lead_id, lineage_steps, result)
-            
+
             return EngineResult.ok(
                 data=result,
                 metadata={
@@ -511,17 +504,17 @@ class IdentityEscalationEngine(BaseEngine):
                     "total_cost_aud": str(result.total_cost_aud),
                 },
             )
-            
+
         except Exception as e:
             logger.exception(f"Identity escalation failed for lead {lead_id}")
             result.errors.append(f"Escalation exception: {str(e)}")
             result.total_cost_aud = total_cost
             return EngineResult.error(error=str(e), metadata={"partial_result": result})
-    
+
     # ============================================
     # TIER IMPLEMENTATIONS
     # ============================================
-    
+
     async def _scrape_team_page(self, domain: str) -> list[DecisionMaker]:
         """
         Tier 1: Scrape company website for team/about page contacts.
@@ -529,7 +522,7 @@ class IdentityEscalationEngine(BaseEngine):
         if self._scraper is None:
             logger.warning("Web scraper not configured — skipping team page scrape")
             return []
-        
+
         try:
             # Common team page URLs
             team_urls = [
@@ -540,7 +533,7 @@ class IdentityEscalationEngine(BaseEngine):
                 f"https://{domain}/leadership",
                 f"https://{domain}/people",
             ]
-            
+
             contacts = []
             for url in team_urls:
                 try:
@@ -562,13 +555,13 @@ class IdentityEscalationEngine(BaseEngine):
                             break  # Found contacts, stop searching
                 except Exception:
                     continue
-            
+
             return contacts
-            
+
         except Exception as e:
             logger.error(f"Team page scrape failed: {e}")
             return []
-    
+
     async def _search_linkedin_employees(
         self, company_linkedin_url: str, company_name: str
     ) -> list[DecisionMaker]:
@@ -586,7 +579,7 @@ class IdentityEscalationEngine(BaseEngine):
             "Proxycurl deprecated (FCO-003). Using other identity tiers."
         )
         return []
-    
+
     async def _hunt_asic_directors(self, acn: str) -> list[DecisionMaker]:
         """
         Tier 3: Look up company directors via ASIC extract.
@@ -594,16 +587,16 @@ class IdentityEscalationEngine(BaseEngine):
         if self._asic is None:
             logger.warning("ASIC client not configured — skipping director hunt")
             return []
-        
+
         try:
             extract = await self._asic.get_company_extract(acn)
-            
+
             directors = []
             for director in extract.get("directors", []):
                 # Parse director name
                 full_name = director.get("name", "")
                 name_parts = full_name.split()
-                
+
                 directors.append(DecisionMaker(
                     full_name=full_name,
                     first_name=name_parts[0] if name_parts else "",
@@ -612,16 +605,16 @@ class IdentityEscalationEngine(BaseEngine):
                     source="asic_extract",
                     confidence=95,  # ASIC data is authoritative
                 ))
-            
+
             return directors
-            
+
         except Exception as e:
             logger.error(f"ASIC director hunt failed: {e}")
             return []
-    
+
     async def _enrich_mobile_number(
         self, contact: DecisionMaker, company_domain: str
-    ) -> Optional[DecisionMaker]:
+    ) -> DecisionMaker | None:
         """
         Tier 4/5: Enrich contact with verified mobile number via Lusha/Kaspr.
         
@@ -636,11 +629,11 @@ class IdentityEscalationEngine(BaseEngine):
                     company_domain=company_domain,
                     linkedin_url=contact.linkedin_url,
                 )
-                
+
                 if lusha_result:
                     phones = lusha_result.get("phones", [])
                     mobile = self.prioritize_mobile(phones)
-                    
+
                     if mobile:
                         contact.mobile_number = mobile
                         contact.phone_type = PhoneType.MOBILE
@@ -650,18 +643,18 @@ class IdentityEscalationEngine(BaseEngine):
                         return contact
             except Exception as e:
                 logger.warning(f"Lusha enrichment failed: {e}")
-        
+
         # Fallback to Kaspr
         if self._kaspr:
             try:
                 kaspr_result = await self._kaspr.enrich_person(
                     linkedin_url=contact.linkedin_url,
                 )
-                
+
                 if kaspr_result:
                     phones = kaspr_result.get("phones", [])
                     mobile = self.prioritize_mobile(phones)
-                    
+
                     if mobile:
                         contact.mobile_number = mobile
                         contact.phone_type = PhoneType.MOBILE
@@ -671,21 +664,21 @@ class IdentityEscalationEngine(BaseEngine):
                         return contact
             except Exception as e:
                 logger.warning(f"Kaspr enrichment failed: {e}")
-        
+
         return None
-    
+
     # ============================================
     # HELPER METHODS
     # ============================================
-    
+
     def _is_decision_maker_title(self, title: str) -> bool:
         """Check if a job title indicates a decision maker."""
         if not title:
             return False
-        
+
         title_lower = title.lower()
         return any(dm_title in title_lower for dm_title in DECISION_MAKER_TITLES)
-    
+
     def _rank_decision_makers(
         self, contacts: list[DecisionMaker]
     ) -> list[DecisionMaker]:
@@ -702,7 +695,7 @@ class IdentityEscalationEngine(BaseEngine):
         def score(dm: DecisionMaker) -> int:
             s = dm.confidence
             title_lower = dm.title.lower() if dm.title else ""
-            
+
             # Title scoring
             if "director" in title_lower:
                 s += 50
@@ -712,7 +705,7 @@ class IdentityEscalationEngine(BaseEngine):
                 s += 30
             elif "manager" in title_lower:
                 s += 20
-            
+
             # Data completeness
             if dm.linkedin_url:
                 s += 10
@@ -720,11 +713,11 @@ class IdentityEscalationEngine(BaseEngine):
                 s += 5
             if dm.mobile_number:
                 s += 15
-            
+
             return s
-        
+
         return sorted(contacts, key=score, reverse=True)
-    
+
     async def _log_identity_lineage(
         self,
         db: AsyncSession,
@@ -737,7 +730,7 @@ class IdentityEscalationEngine(BaseEngine):
             for step in steps:
                 # Calculate step number offset (identity escalation is Tier 5+)
                 adjusted_step = step.step_number + 100  # Offset for identity steps
-                
+
                 stmt = insert("lead_lineage_log").values(
                     id=uuid4(),
                     lead_id=lead_id,
@@ -751,7 +744,7 @@ class IdentityEscalationEngine(BaseEngine):
                     created_at=datetime.utcnow(),
                 )
                 await db.execute(stmt)
-            
+
             # Log final "Identity Gold" event if mobile found
             if result.mobile_number_verified:
                 stmt = insert("lead_lineage_log").values(
@@ -774,9 +767,9 @@ class IdentityEscalationEngine(BaseEngine):
                     f"🥇 IDENTITY GOLD: Lead {lead_id} - Mobile verified: "
                     f"{result.mobile_number_verified[:6]}***"
                 )
-            
+
             await db.commit()
-            
+
         except Exception as e:
             logger.error(f"Failed to log identity lineage: {e}")
             await db.rollback()

--- a/src/engines/proxy_waterfall.py
+++ b/src/engines/proxy_waterfall.py
@@ -21,14 +21,12 @@ GOVERNANCE EVENT: FIXED_COST_OPTIMIZATION_PHASE_1
 DESCRIPTION: Proxy waterfall saves ~$11 AUD/month at Ignition tier (1,250 leads)
 """
 
-import asyncio
 import logging
 import random
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Optional
 
 import httpx
 
@@ -92,8 +90,8 @@ class ProxyPool:
     tier: ProxyTier
     proxies: list[str] = field(default_factory=list)
     failures: dict[str, int] = field(default_factory=dict)
-    
-    def get_proxy(self) -> Optional[str]:
+
+    def get_proxy(self) -> str | None:
         """Get a random proxy, avoiding recent failures."""
         available = [p for p in self.proxies if self.failures.get(p, 0) < 3]
         if not available:
@@ -101,11 +99,11 @@ class ProxyPool:
             self.failures.clear()
             available = self.proxies
         return random.choice(available) if available else None
-    
+
     def mark_failure(self, proxy: str) -> None:
         """Mark a proxy as failed."""
         self.failures[proxy] = self.failures.get(proxy, 0) + 1
-    
+
     def mark_success(self, proxy: str) -> None:
         """Reset failure count on success."""
         self.failures[proxy] = 0
@@ -115,23 +113,23 @@ class ProxyPool:
 class WaterfallResult:
     """Result from a waterfall request."""
     success: bool
-    status_code: Optional[int] = None
-    content: Optional[bytes] = None
-    text: Optional[str] = None
-    
+    status_code: int | None = None
+    content: bytes | None = None
+    text: str | None = None
+
     # Cost tracking
-    tier_used: Optional[ProxyTier] = None
+    tier_used: ProxyTier | None = None
     cost_aud: Decimal = Decimal("0.00")
-    
+
     # Escalation tracking
     tiers_attempted: list[str] = field(default_factory=list)
     total_attempts: int = 0
-    
+
     # Timing
-    latency_ms: Optional[int] = None
-    
+    latency_ms: int | None = None
+
     # Error
-    error: Optional[str] = None
+    error: str | None = None
 
 
 # ============================================
@@ -154,12 +152,12 @@ class ProxyWaterfallEngine(BaseEngine):
     - With Waterfall: ~$0.006/request (weighted average)
     - Savings: ~60%
     """
-    
+
     def __init__(
         self,
-        datacenter_proxies: Optional[list[str]] = None,
-        isp_proxies: Optional[list[str]] = None,
-        residential_proxies: Optional[list[str]] = None,
+        datacenter_proxies: list[str] | None = None,
+        isp_proxies: list[str] | None = None,
+        residential_proxies: list[str] | None = None,
     ):
         """
         Initialize with proxy lists.
@@ -174,24 +172,24 @@ class ProxyWaterfallEngine(BaseEngine):
             ProxyTier.ISP: ProxyPool(ProxyTier.ISP, isp_proxies or []),
             ProxyTier.RESIDENTIAL: ProxyPool(ProxyTier.RESIDENTIAL, residential_proxies or []),
         }
-        
+
         self._tier_order = [
             ProxyTier.DATACENTER,
             ProxyTier.ISP,
             ProxyTier.RESIDENTIAL,
         ]
-    
+
     @property
     def name(self) -> str:
         return "proxy_waterfall"
-    
+
     async def fetch(
         self,
         url: str,
         method: str = "GET",
-        headers: Optional[dict] = None,
+        headers: dict | None = None,
         target_type: str = "default",
-        start_tier: Optional[ProxyTier] = None,
+        start_tier: ProxyTier | None = None,
         timeout: float = REQUEST_TIMEOUT,
     ) -> EngineResult[WaterfallResult]:
         """
@@ -211,7 +209,7 @@ class ProxyWaterfallEngine(BaseEngine):
         result = WaterfallResult(success=False)
         total_cost = Decimal("0.00")
         start_time = datetime.utcnow()
-        
+
         # Determine starting tier
         start_idx = 0
         if start_tier:
@@ -219,26 +217,26 @@ class ProxyWaterfallEngine(BaseEngine):
                 start_idx = self._tier_order.index(start_tier)
             except ValueError:
                 start_idx = 0
-        
+
         # Waterfall through tiers
         for tier in self._tier_order[start_idx:]:
             pool = self._pools[tier]
-            
+
             if not pool.proxies:
                 logger.debug(f"No proxies configured for tier {tier.value}, skipping")
                 continue
-            
+
             result.tiers_attempted.append(tier.value)
-            
+
             # Retry within tier
             for attempt in range(MAX_RETRIES_PER_TIER):
                 result.total_attempts += 1
                 proxy = pool.get_proxy()
-                
+
                 if not proxy:
                     logger.warning(f"No available proxies in tier {tier.value}")
                     break
-                
+
                 try:
                     async with httpx.AsyncClient(
                         proxy=proxy,
@@ -250,14 +248,14 @@ class ProxyWaterfallEngine(BaseEngine):
                             url=url,
                             headers=headers or self._default_headers(),
                         )
-                    
+
                     # Track cost regardless of outcome
                     total_cost += PROXY_COSTS_AUD[tier]
-                    
+
                     if response.status_code == 200:
                         # Success!
                         pool.mark_success(proxy)
-                        
+
                         result.success = True
                         result.status_code = response.status_code
                         result.content = response.content
@@ -267,12 +265,12 @@ class ProxyWaterfallEngine(BaseEngine):
                         result.latency_ms = int(
                             (datetime.utcnow() - start_time).total_seconds() * 1000
                         )
-                        
+
                         logger.info(
                             f"Waterfall success: {url} via {tier.value} "
                             f"(cost: ${total_cost} AUD, attempts: {result.total_attempts})"
                         )
-                        
+
                         return EngineResult.ok(
                             data=result,
                             metadata={
@@ -281,7 +279,7 @@ class ProxyWaterfallEngine(BaseEngine):
                                 "attempts": result.total_attempts,
                             },
                         )
-                    
+
                     elif response.status_code in ESCALATION_CODES:
                         # Blocked, escalate to next tier
                         pool.mark_failure(proxy)
@@ -290,38 +288,38 @@ class ProxyWaterfallEngine(BaseEngine):
                             f"escalating..."
                         )
                         break  # Exit retry loop, try next tier
-                    
+
                     else:
                         # Other error, retry same tier
                         pool.mark_failure(proxy)
                         logger.warning(
                             f"Unexpected status {response.status_code} on {tier.value}"
                         )
-                        
+
                 except httpx.TimeoutException:
                     pool.mark_failure(proxy)
                     logger.warning(f"Timeout on {tier.value}, attempt {attempt + 1}")
-                    
+
                 except httpx.ProxyError as e:
                     pool.mark_failure(proxy)
                     logger.warning(f"Proxy error on {tier.value}: {e}")
-                    
+
                 except Exception as e:
                     pool.mark_failure(proxy)
                     logger.error(f"Unexpected error on {tier.value}: {e}")
-        
+
         # All tiers exhausted
         result.cost_aud = total_cost
         result.error = "All proxy tiers exhausted"
         result.latency_ms = int(
             (datetime.utcnow() - start_time).total_seconds() * 1000
         )
-        
+
         logger.error(
             f"Waterfall failed: {url} (cost: ${total_cost} AUD, "
             f"attempts: {result.total_attempts})"
         )
-        
+
         return EngineResult.error(
             error="All proxy tiers exhausted",
             metadata={
@@ -330,7 +328,7 @@ class ProxyWaterfallEngine(BaseEngine):
                 "attempts": result.total_attempts,
             },
         )
-    
+
     async def fetch_json(
         self,
         url: str,
@@ -338,10 +336,10 @@ class ProxyWaterfallEngine(BaseEngine):
     ) -> EngineResult[dict]:
         """Fetch and parse JSON response."""
         result = await self.fetch(url, **kwargs)
-        
+
         if not result.success:
             return EngineResult.error(error=result.error)
-        
+
         try:
             import json
             data = json.loads(result.data.text)
@@ -351,7 +349,7 @@ class ProxyWaterfallEngine(BaseEngine):
             )
         except json.JSONDecodeError as e:
             return EngineResult.error(error=f"JSON decode error: {e}")
-    
+
     def _default_headers(self) -> dict:
         """Default headers for requests."""
         return {
@@ -363,7 +361,7 @@ class ProxyWaterfallEngine(BaseEngine):
             "Connection": "keep-alive",
             "Upgrade-Insecure-Requests": "1",
         }
-    
+
     def _random_user_agent(self) -> str:
         """Return a random modern user agent."""
         agents = [
@@ -373,7 +371,7 @@ class ProxyWaterfallEngine(BaseEngine):
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15",
         ]
         return random.choice(agents)
-    
+
     def get_cost_estimate(self, target_type: str = "default") -> dict:
         """
         Get cost estimate for a target type.
@@ -381,24 +379,24 @@ class ProxyWaterfallEngine(BaseEngine):
         Returns expected cost based on success rates.
         """
         rates = SUCCESS_RATES.get(target_type, SUCCESS_RATES["default"])
-        
+
         # Calculate weighted cost
         # P(datacenter success) * cost_dc + P(dc fail) * P(isp success) * cost_isp + ...
-        
+
         p_dc = rates[ProxyTier.DATACENTER]
         p_isp = rates[ProxyTier.ISP]
         p_res = rates[ProxyTier.RESIDENTIAL]
-        
+
         cost_dc = PROXY_COSTS_AUD[ProxyTier.DATACENTER]
         cost_isp = PROXY_COSTS_AUD[ProxyTier.ISP]
         cost_res = PROXY_COSTS_AUD[ProxyTier.RESIDENTIAL]
-        
+
         expected_cost = (
             p_dc * cost_dc +
             (1 - p_dc) * p_isp * (cost_dc + cost_isp) +
             (1 - p_dc) * (1 - p_isp) * p_res * (cost_dc + cost_isp + cost_res)
         )
-        
+
         return {
             "target_type": target_type,
             "expected_cost_aud": float(expected_cost),
@@ -412,9 +410,9 @@ class ProxyWaterfallEngine(BaseEngine):
 # ============================================
 
 def get_proxy_waterfall(
-    datacenter_proxies: Optional[list[str]] = None,
-    isp_proxies: Optional[list[str]] = None,
-    residential_proxies: Optional[list[str]] = None,
+    datacenter_proxies: list[str] | None = None,
+    isp_proxies: list[str] | None = None,
+    residential_proxies: list[str] | None = None,
 ) -> ProxyWaterfallEngine:
     """Get ProxyWaterfallEngine instance."""
     return ProxyWaterfallEngine(

--- a/src/engines/scorer.py
+++ b/src/engines/scorer.py
@@ -485,16 +485,16 @@ class ScorerEngine(BaseEngine):
         - Country match from ICP: 7 points
         """
         score = 0
-        
+
         # Use ICP config or defaults
         config = icp_config or DEFAULT_ICP_CONFIG
         employee_range = config.get("employee_range", {"min": 5, "max": 50})
         emp_min = employee_range.get("min", 5)
         emp_max = employee_range.get("max", 50)
-        
+
         # Get target countries from ICP config
         icp_countries = config.get("countries", ["Australia"])
-        
+
         # Industries from ICP config or fallback to target_industries or defaults
         industries = config.get("industries") or target_industries or TARGET_INDUSTRIES
 
@@ -526,7 +526,7 @@ class ScorerEngine(BaseEngine):
                 "united states": ["united states", "us", "usa"],
                 "united kingdom": ["united kingdom", "uk", "gb", "great britain"],
             }
-            
+
             # Check if country matches any ICP target country
             country_matched = False
             for icp_country in icp_countries:
@@ -536,16 +536,16 @@ class ScorerEngine(BaseEngine):
                     country_matched = True
                     break
                 # Check alias match
-                for canonical, aliases in country_aliases.items():
+                for _canonical, aliases in country_aliases.items():
                     if icp_lower in aliases and country in aliases:
                         country_matched = True
                         break
                 if country_matched:
                     break
-            
+
             if country_matched:
                 score += SCORE_COUNTRY_AUSTRALIA  # Full points for ICP country match
-            elif country in ["new zealand", "nz", "united states", "us", "usa", 
+            elif country in ["new zealand", "nz", "united states", "us", "usa",
                            "united kingdom", "uk", "gb"]:
                 score += 4  # Partial credit for English-speaking countries
 
@@ -1113,7 +1113,7 @@ class ScorerEngine(BaseEngine):
 
             sources_verified = []
             enrichment_data = row.enrichment_data or {}
-            
+
             if isinstance(enrichment_data, str):
                 import json
                 try:
@@ -1143,7 +1143,7 @@ class ScorerEngine(BaseEngine):
                 sources_verified.append("Apollo")
             if "prospeo" in enrichment_source.lower():
                 sources_verified.append("Prospeo")
-            
+
             # Check if we have multiple enrichment sources in the data
             if enrichment_data.get("siege_waterfall_sources"):
                 waterfall_sources = enrichment_data.get("siege_waterfall_sources", [])
@@ -1160,7 +1160,7 @@ class ScorerEngine(BaseEngine):
 
             # Award boost if 3+ sources confirmed
             source_count = len(sources_verified)
-            
+
             if source_count >= 3:
                 boost_points = MAX_MULTI_SOURCE_BOOST  # 15 points
                 reason = f"Multi-source verified ({source_count} sources: {', '.join(sources_verified)})"
@@ -1170,7 +1170,7 @@ class ScorerEngine(BaseEngine):
                     "sources": sources_verified,
                     "reason": reason,
                 }
-            
+
             return {"boost_points": 0, "sources": sources_verified, "reason": None}
 
         except Exception as e:
@@ -1265,7 +1265,7 @@ class ScorerEngine(BaseEngine):
                 for post in posts:
                     content = (post.post_content or "").lower()
                     post_source = post.source or "linkedin"
-                    
+
                     for signal in SOCIAL_POST_TIMING_SIGNALS:
                         if signal.lower() in content and signal not in signals_found:
                             signals_found.append(signal)
@@ -2044,16 +2044,16 @@ class ScorerEngine(BaseEngine):
         Uses pool-specific company fields.
         """
         score = 0
-        
+
         # Use ICP config or defaults
         config = icp_config or DEFAULT_ICP_CONFIG
         employee_range = config.get("employee_range", {"min": 5, "max": 50})
         emp_min = employee_range.get("min", 5)
         emp_max = employee_range.get("max", 50)
-        
+
         # Get target countries from ICP config
         icp_countries = config.get("countries", ["Australia"])
-        
+
         # Industries from ICP config or fallback
         industries = config.get("industries") or target_industries or TARGET_INDUSTRIES
 
@@ -2087,7 +2087,7 @@ class ScorerEngine(BaseEngine):
                 "united states": ["united states", "us", "usa"],
                 "united kingdom": ["united kingdom", "uk", "gb", "great britain"],
             }
-            
+
             # Check if country matches any ICP target country
             country_matched = False
             for icp_country in icp_countries:
@@ -2095,13 +2095,13 @@ class ScorerEngine(BaseEngine):
                 if country_lower == icp_lower:
                     country_matched = True
                     break
-                for canonical, aliases in country_aliases.items():
+                for _canonical, aliases in country_aliases.items():
                     if icp_lower in aliases and country_lower in aliases:
                         country_matched = True
                         break
                 if country_matched:
                     break
-            
+
             if country_matched:
                 score += SCORE_COUNTRY_AUSTRALIA
             elif country_lower in ["new zealand", "nz", "united states", "us", "usa", "uk", "gb"]:

--- a/src/engines/scout.py
+++ b/src/engines/scout.py
@@ -53,20 +53,18 @@ logger = logging.getLogger(__name__)
 
 # DEPRECATED: FCO-002 (2026-02-05) - SDK enrichment removed, using Siege Waterfall data only
 # from src.agents.sdk_agents.enrichment_agent import run_sdk_enrichment
-from src.agents.sdk_agents.sdk_eligibility import should_use_sdk_enrichment  # Kept for objection routing
 from src.agents.skills.research_skills import DeepResearchSkill
 from src.engines.base import BaseEngine, EngineResult
 from src.integrations.anthropic import AnthropicClient, get_anthropic_client
+
 # REMOVED: from src.integrations.apify import ApifyClient, get_apify_client (FCO-003 deprecation)
-from src.integrations.camoufox_scraper import CamoufoxScraper, CamoufoxScrapeResult
+from src.integrations.camoufox_scraper import CamoufoxScraper
 from src.integrations.clay import ClayClient, get_clay_client
 from src.integrations.redis import enrichment_cache
-from src.integrations.siege_waterfall import SiegeWaterfall, get_siege_waterfall, EnrichmentTier
+from src.integrations.siege_waterfall import EnrichmentTier, SiegeWaterfall, get_siege_waterfall
 from src.models.base import LeadStatus
 from src.models.lead import Lead
 from src.models.lead_social_post import LeadSocialPost
-from src.services.sdk_usage_service import log_sdk_usage
-from src.services.who_refinement_service import get_who_refined_criteria
 
 # Sentry for error tracking
 try:
@@ -454,7 +452,7 @@ class ScoutEngine(BaseEngine):
                     result["confidence"] = 0.75 + (siege_result.sources_used * 0.05)  # Higher confidence with more sources
                     result["source"] = f"siege_waterfall_{siege_result.sources_used}sources"
                     result["enrichment_cost_aud"] = siege_result.total_cost_aud
-                    
+
                     # Log successful SIEGE enrichment
                     await self._log_enrichment_audit(
                         operation="siege_waterfall",
@@ -472,7 +470,7 @@ class ScoutEngine(BaseEngine):
                             ],
                         },
                     )
-                    
+
                     logger.info(
                         f"[Scout] Siege Waterfall enriched AU lead with {siege_result.sources_used} sources, "
                         f"cost: ${siege_result.total_cost_aud:.3f} AUD (no Apollo fallback)"
@@ -493,10 +491,10 @@ class ScoutEngine(BaseEngine):
                         },
                     )
                     logger.info(
-                        f"[Scout] Siege Waterfall found no data for AU lead, "
-                        f"NOT falling back to Apollo (SIEGE is SSOT for AU)"
+                        "[Scout] Siege Waterfall found no data for AU lead, "
+                        "NOT falling back to Apollo (SIEGE is SSOT for AU)"
                     )
-                    
+
             except Exception as e:
                 # Log SIEGE failure for AU lead
                 await self._log_enrichment_audit(
@@ -510,7 +508,7 @@ class ScoutEngine(BaseEngine):
                 )
                 logger.warning(f"[Scout] Siege Waterfall failed for AU lead: {e}")
                 result = None
-            
+
             # Return here for AU leads - no Apollo fallback
             return result
 
@@ -605,8 +603,7 @@ class ScoutEngine(BaseEngine):
         """
         try:
             # Lazy import to avoid circular dependencies
-            from sqlalchemy import text as sql_text
-            
+
             log_entry = {
                 "engine": self.name,
                 "operation_type": "enrichment",
@@ -620,14 +617,14 @@ class ScoutEngine(BaseEngine):
                 "metadata": metadata or {},
                 "created_at": datetime.utcnow().isoformat(),
             }
-            
+
             # Use raw SQL insert to avoid needing a session
             # This logs to audit_logs table
             from src.integrations.supabase import get_supabase_client
-            
+
             supabase = get_supabase_client()
             await supabase.table("audit_logs").insert(log_entry).execute()
-            
+
         except Exception as e:
             # Don't fail enrichment if logging fails - just log to stderr
             logger.warning(f"[Scout] Audit log failed: {e}")
@@ -657,10 +654,7 @@ class ScoutEngine(BaseEngine):
 
         # Check phone number
         phone = getattr(lead, "phone", None)
-        if phone and (phone.startswith("+61") or phone.startswith("61")):
-            return True
-
-        return False
+        return bool(phone and (phone.startswith("+61") or phone.startswith("61")))
 
     async def _enrich_tier2(
         self,
@@ -1102,10 +1096,10 @@ class ScoutEngine(BaseEngine):
         """
         # Apollo removed (CEO Directive #003)
         logger.warning(
-            f"search_and_populate_pool called but Apollo removed. "
-            f"Use pool_population_flow with Siege Waterfall instead."
+            "search_and_populate_pool called but Apollo removed. "
+            "Use pool_population_flow with Siege Waterfall instead."
         )
-        
+
         return EngineResult.ok(
             data={
                 "added": 0,
@@ -1473,7 +1467,7 @@ class ScoutEngine(BaseEngine):
         try:
             # Use Camoufox for anti-detection scraping
             scrape_result = await self.camoufox.scrape(linkedin_url)
-            
+
             if not scrape_result.success:
                 logger.warning(
                     f"[Scout] LinkedIn person scrape failed: {scrape_result.failure_reason}"
@@ -1484,7 +1478,7 @@ class ScoutEngine(BaseEngine):
             # NOTE: Full LinkedIn parsing would require a dedicated HTML parser
             # For now, return minimal data indicating scrape success
             raw_html = scrape_result.raw_html
-            
+
             # Basic title extraction from HTML
             headline = None
             if "<title>" in raw_html:
@@ -1530,7 +1524,7 @@ class ScoutEngine(BaseEngine):
         try:
             # Use Camoufox for anti-detection scraping
             scrape_result = await self.camoufox.scrape(linkedin_url)
-            
+
             if not scrape_result.success:
                 logger.warning(
                     f"[Scout] LinkedIn company scrape failed: {scrape_result.failure_reason}"
@@ -1539,7 +1533,7 @@ class ScoutEngine(BaseEngine):
 
             # Parse LinkedIn HTML (basic extraction)
             raw_html = scrape_result.raw_html
-            
+
             # Basic company name extraction from HTML
             company_name = None
             if "<title>" in raw_html:
@@ -1614,9 +1608,9 @@ def get_scout_engine() -> ScoutEngine:
 # [x] enrich_linkedin_for_assignment method (Phase 24A+)
 # [x] _scrape_person_linkedin helper (Phase 24A+ - uses CamoufoxScraper)
 # [x] _scrape_company_linkedin helper (Phase 24A+ - uses CamoufoxScraper)
-# 
+#
 # FCO-002/FCO-003 DEPRECATION APPLIED (2026-02-05):
 # [x] Apollo integration removed
-# [x] Apify integration removed  
+# [x] Apify integration removed
 # [x] Siege Waterfall is now SSOT for enrichment
 # [x] CamoufoxScraper used for LinkedIn scraping

--- a/src/engines/smart_prompts.py
+++ b/src/engines/smart_prompts.py
@@ -545,10 +545,9 @@ async def build_full_pool_lead_context(
         AND la.status = 'active'
         LIMIT 1
     """)
-    assignment_result = await db.execute(
+    await db.execute(
         assignment_query, {"lead_pool_id": str(lead_pool_id)}
     )
-    assignment_row = assignment_result.fetchone()
 
     # For pool leads, social posts are stored on the assignment or linked lead
     # Check lead_social_posts by querying via any linked leads

--- a/src/engines/voice_agent_telnyx.py
+++ b/src/engines/voice_agent_telnyx.py
@@ -26,7 +26,6 @@ LATENCY TARGET: <200ms RTT (Sydney PoP co-location)
 ACCENT: Australian (Lee, Aussie Adventure Guide)
 """
 
-import asyncio
 import base64
 import json
 import logging
@@ -35,7 +34,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Callable, Optional
 from uuid import UUID, uuid4
 
 import httpx
@@ -121,19 +119,19 @@ class CallMetrics:
     """Metrics for a single call."""
     call_id: str
     start_time: datetime
-    end_time: Optional[datetime] = None
+    end_time: datetime | None = None
     duration_seconds: int = 0
-    
+
     # Latency tracking
     avg_stt_latency_ms: int = 0
     avg_llm_latency_ms: int = 0
     avg_tts_latency_ms: int = 0
     avg_total_latency_ms: int = 0
-    
+
     # Interaction counts
     turns: int = 0
     interruptions: int = 0
-    
+
     # Cost
     cost_aud: Decimal = Decimal("0.00")
 
@@ -142,22 +140,22 @@ class CallMetrics:
 class ConversationContext:
     """Conversation state and context."""
     call_id: str
-    lead_id: Optional[UUID] = None
-    
+    lead_id: UUID | None = None
+
     # Conversation history
     messages: list[dict] = field(default_factory=list)
-    
+
     # Current state
     state: CallState = CallState.IDLE
     current_utterance: str = ""
-    
+
     # Voice settings
     voice_id: str = AUSTRALIAN_VOICES[DEFAULT_VOICE]["voice_id"]
     voice_name: str = AUSTRALIAN_VOICES[DEFAULT_VOICE]["name"]
-    
+
     # Personality
     system_prompt: str = ""
-    
+
     # Metrics
     metrics: CallMetrics = field(default_factory=lambda: CallMetrics(call_id=""))
 
@@ -242,34 +240,34 @@ class VoiceAgentTelnyxEngine(BaseEngine):
     - Groq: LLM inference (<150ms)
     - Deepgram: STT (<100ms)
     """
-    
+
     def __init__(
         self,
-        telnyx_api_key: Optional[str] = None,
-        elevenlabs_api_key: Optional[str] = None,
-        groq_api_key: Optional[str] = None,
+        telnyx_api_key: str | None = None,
+        elevenlabs_api_key: str | None = None,
+        groq_api_key: str | None = None,
     ):
         """Initialize with API keys."""
         self._telnyx_key = telnyx_api_key or os.getenv("TELNYX_API_KEY")
         self._elevenlabs_key = elevenlabs_api_key or os.getenv("ELEVENLABS_API_KEY")
         self._groq_key = groq_api_key or os.getenv("GROQ_API_KEY")
-        
+
         # Initialize clients
         telnyx.api_key = self._telnyx_key
         self._elevenlabs = ElevenLabs(api_key=self._elevenlabs_key)
         self._groq = Groq(api_key=self._groq_key)
-        
+
         # Active calls
         self._active_calls: dict[str, ConversationContext] = {}
-    
+
     @property
     def name(self) -> str:
         return "voice_agent_telnyx"
-    
+
     # ============================================
     # CALL INITIATION
     # ============================================
-    
+
     async def initiate_call(
         self,
         to_number: str,
@@ -302,7 +300,7 @@ class VoiceAgentTelnyxEngine(BaseEngine):
         try:
             # Generate call ID
             call_id = str(uuid4())
-            
+
             # Build personality prompt
             system_prompt = AUSSIE_PERSONALITY_PROMPT.format(
                 company_name=company_name,
@@ -311,10 +309,10 @@ class VoiceAgentTelnyxEngine(BaseEngine):
                 lead_industry=lead_industry,
                 call_reason=call_reason,
             )
-            
+
             # Get voice config
             voice_config = AUSTRALIAN_VOICES.get(voice, AUSTRALIAN_VOICES[DEFAULT_VOICE])
-            
+
             # Create conversation context
             context = ConversationContext(
                 call_id=call_id,
@@ -325,10 +323,10 @@ class VoiceAgentTelnyxEngine(BaseEngine):
                 messages=[{"role": "system", "content": system_prompt}],
                 metrics=CallMetrics(call_id=call_id, start_time=datetime.utcnow()),
             )
-            
+
             # Store context
             self._active_calls[call_id] = context
-            
+
             # Initiate Telnyx call with streaming
             call = telnyx.Call.create(
                 connection_id=os.getenv("TELNYX_CONNECTION_ID"),
@@ -342,14 +340,14 @@ class VoiceAgentTelnyxEngine(BaseEngine):
                     json.dumps({"call_id": call_id, "lead_id": str(lead_id)}).encode()
                 ).decode(),
             )
-            
+
             context.state = CallState.RINGING
-            
+
             logger.info(
                 f"Initiated call {call_id} to {to_number} "
                 f"(voice: {voice_config['name']}, lead: {lead_id})"
             )
-            
+
             return EngineResult.ok(
                 data={
                     "call_id": call_id,
@@ -364,15 +362,15 @@ class VoiceAgentTelnyxEngine(BaseEngine):
                     "latency_target_ms": LATENCY_TARGETS["total_target"],
                 },
             )
-            
+
         except Exception as e:
             logger.exception(f"Failed to initiate call: {e}")
             return EngineResult.error(error=str(e))
-    
+
     # ============================================
     # WEBHOOK HANDLERS
     # ============================================
-    
+
     async def handle_webhook(
         self,
         call_id: str,
@@ -394,13 +392,13 @@ class VoiceAgentTelnyxEngine(BaseEngine):
         if not context:
             logger.warning(f"Received webhook for unknown call: {call_id}")
             return {"status": "ignored"}
-        
+
         if event_type == "call.answered":
             context.state = CallState.CONNECTED
             # Start with greeting
             greeting = await self._generate_greeting(context)
             await self._speak(context, greeting)
-            
+
         elif event_type == "call.hangup":
             context.state = CallState.ENDED
             context.metrics.end_time = datetime.utcnow()
@@ -410,23 +408,23 @@ class VoiceAgentTelnyxEngine(BaseEngine):
             # Calculate cost
             minutes = context.metrics.duration_seconds / 60
             context.metrics.cost_aud = COSTS_AUD["total_per_minute"] * Decimal(str(minutes))
-            
+
             logger.info(
                 f"Call {call_id} ended. Duration: {context.metrics.duration_seconds}s, "
                 f"Cost: ${context.metrics.cost_aud} AUD"
             )
-            
+
             # Cleanup
             del self._active_calls[call_id]
-        
+
         return {"status": "processed", "event": event_type}
-    
+
     async def handle_media_stream(
         self,
         call_id: str,
         audio_data: bytes,
         track: str,
-    ) -> Optional[bytes]:
+    ) -> bytes | None:
         """
         Handle real-time audio stream from Telnyx.
         
@@ -448,41 +446,41 @@ class VoiceAgentTelnyxEngine(BaseEngine):
         context = self._active_calls.get(call_id)
         if not context or track != "inbound":
             return None
-        
+
         # Track latency
         start_time = datetime.utcnow()
-        
+
         # 1. STT: Convert speech to text
         stt_start = datetime.utcnow()
         transcript = await self._speech_to_text(audio_data)
         stt_latency = (datetime.utcnow() - stt_start).total_seconds() * 1000
-        
+
         if not transcript or len(transcript.strip()) < 2:
             return None  # Silence or noise
-        
+
         logger.debug(f"[{call_id}] User: {transcript}")
-        
+
         # Check for barge-in (user interrupting)
         if context.state == CallState.SPEAKING:
             await self._handle_barge_in(context, transcript)
             return None
-        
+
         context.state = CallState.PROCESSING
         context.current_utterance = transcript
         context.messages.append({"role": "user", "content": transcript})
-        
+
         # 2. LLM: Generate response
         llm_start = datetime.utcnow()
         response = await self._generate_response(context)
         llm_latency = (datetime.utcnow() - llm_start).total_seconds() * 1000
-        
+
         context.messages.append({"role": "assistant", "content": response})
-        
+
         # 3. TTS: Convert response to speech
         tts_start = datetime.utcnow()
         audio = await self._text_to_speech(response, context.voice_id)
         tts_latency = (datetime.utcnow() - tts_start).total_seconds() * 1000
-        
+
         # Track metrics
         total_latency = (datetime.utcnow() - start_time).total_seconds() * 1000
         context.metrics.turns += 1
@@ -502,20 +500,20 @@ class VoiceAgentTelnyxEngine(BaseEngine):
             (context.metrics.avg_total_latency_ms * (context.metrics.turns - 1) + total_latency)
             / context.metrics.turns
         )
-        
+
         logger.info(
             f"[{call_id}] Turn {context.metrics.turns}: "
             f"STT={stt_latency:.0f}ms, LLM={llm_latency:.0f}ms, "
             f"TTS={tts_latency:.0f}ms, Total={total_latency:.0f}ms"
         )
-        
+
         context.state = CallState.SPEAKING
         return audio
-    
+
     # ============================================
     # BARGE-IN HANDLING
     # ============================================
-    
+
     async def _handle_barge_in(
         self,
         context: ConversationContext,
@@ -530,32 +528,32 @@ class VoiceAgentTelnyxEngine(BaseEngine):
         3. Process user's interruption
         """
         logger.info(f"[{context.call_id}] Barge-in detected: '{user_utterance[:50]}...'")
-        
+
         context.metrics.interruptions += 1
-        
+
         # Stop current audio playback via Telnyx
         try:
             # Send stop command to Telnyx media stream
             telnyx.Call.retrieve(context.call_id).stop_audio_playback()
         except Exception as e:
             logger.warning(f"Failed to stop audio playback: {e}")
-        
+
         # Transition to listening state
         context.state = CallState.LISTENING
-        
+
         # Log barge-in event
         barge_in = BargeInEvent(
             timestamp=datetime.utcnow(),
             interrupted_text=context.messages[-1].get("content", "") if context.messages else "",
             user_utterance=user_utterance,
         )
-        
+
         logger.debug(f"[{context.call_id}] Barge-in: interrupted at '{barge_in.interrupted_text[:30]}...'")
-    
+
     # ============================================
     # CORE FUNCTIONS
     # ============================================
-    
+
     async def _speech_to_text(self, audio_data: bytes) -> str:
         """
         Convert speech to text using Deepgram.
@@ -582,7 +580,7 @@ class VoiceAgentTelnyxEngine(BaseEngine):
             return result.get("results", {}).get("channels", [{}])[0].get(
                 "alternatives", [{}]
             )[0].get("transcript", "")
-    
+
     async def _generate_response(self, context: ConversationContext) -> str:
         """
         Generate response using Groq (Llama).
@@ -600,7 +598,7 @@ class VoiceAgentTelnyxEngine(BaseEngine):
         except Exception as e:
             logger.error(f"Groq error: {e}")
             return "Sorry, I didn't catch that. Could you say that again?"
-    
+
     async def _text_to_speech(self, text: str, voice_id: str) -> bytes:
         """
         Convert text to speech using ElevenLabs Flash v2.5.
@@ -618,16 +616,16 @@ class VoiceAgentTelnyxEngine(BaseEngine):
         except Exception as e:
             logger.error(f"ElevenLabs error: {e}")
             return b""
-    
+
     async def _speak(self, context: ConversationContext, text: str) -> None:
         """Speak text on the call."""
         context.state = CallState.SPEAKING
-        audio = await self._text_to_speech(text, context.voice_id)
-        
+        _audio = await self._text_to_speech(text, context.voice_id)
+
         # Send audio to Telnyx
         # This would go through the WebSocket stream
         logger.info(f"[{context.call_id}] Speaking: {text[:50]}...")
-    
+
     async def _generate_greeting(self, context: ConversationContext) -> str:
         """Generate opening greeting."""
         # Let LLM generate natural greeting based on context
@@ -635,18 +633,18 @@ class VoiceAgentTelnyxEngine(BaseEngine):
             "role": "user",
             "content": "[SYSTEM: Call connected. Generate your opening greeting.]"
         })
-        
+
         greeting = await self._generate_response(context)
-        
+
         # Remove the system message
         context.messages.pop()
-        
+
         return greeting
-    
+
     # ============================================
     # COST TRACKING
     # ============================================
-    
+
     def get_cost_comparison(self) -> dict:
         """Get cost comparison vs Vapi."""
         return {

--- a/src/engines/waterfall_verification_worker.py
+++ b/src/engines/waterfall_verification_worker.py
@@ -28,19 +28,18 @@ import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
-from datetime import datetime, date, timedelta
+from datetime import datetime, timedelta
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID, uuid4
 
 import httpx
 from fuzzywuzzy import fuzz
-from sqlalchemy import select, insert
+from sqlalchemy import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.engines.base import BaseEngine, EngineResult
-from src.models.lead_pool import LeadPool, EmailStatus
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +128,7 @@ class ABNRecord:
     state: str
     postcode: str
     gst_registered: bool
-    acn: Optional[str] = None
+    acn: str | None = None
 
 
 @dataclass
@@ -149,7 +148,7 @@ class ASICVerifyRecord:
     entity_type: str
     state: str
     postcode: str
-    directors: Optional[list[str]] = None  # Pending ASIC DSP approval
+    directors: list[str] | None = None  # Pending ASIC DSP approval
 
 
 @dataclass
@@ -157,14 +156,14 @@ class GMBRecord:
     """Record from Google Maps scraping."""
     google_place_id: str
     business_name: str
-    phone: Optional[str]
-    website: Optional[str]
+    phone: str | None
+    website: str | None
     address: str
     postcode: str
     state: str
     lat: float
     lng: float
-    rating: Optional[float]
+    rating: float | None
     review_count: int
     categories: list[str]
 
@@ -184,8 +183,8 @@ class ZeroBounceResult:
     email: str
     status: str  # valid, invalid, catch_all, unknown, spamtrap
     sub_status: str
-    did_you_mean: Optional[str]
-    activity_score: Optional[int]
+    did_you_mean: str | None
+    activity_score: int | None
 
 
 @dataclass
@@ -214,7 +213,7 @@ class LinkedInPost:
     num_likes: int
     num_comments: int
     hashtags: list[str] = field(default_factory=list)
-    topic: Optional[str] = None  # AI-inferred topic from content
+    topic: str | None = None  # AI-inferred topic from content
 
 
 @dataclass
@@ -241,53 +240,53 @@ class LineageStep:
     cost_aud: Decimal
     success: bool
     data_added: list[str] = field(default_factory=list)
-    error_message: Optional[str] = None
-    latency_ms: Optional[int] = None
-    raw_response: Optional[dict] = None
+    error_message: str | None = None
+    latency_ms: int | None = None
+    raw_response: dict | None = None
 
 
 @dataclass
 class WaterfallResult:
     """Complete result from waterfall verification."""
     lead_id: UUID
-    abn: Optional[str]
-    acn: Optional[str] = None  # T1.25: ASIC company number
-    asic_registered_name: Optional[str] = None  # T1.25: Clean registered name for fuzzy match
-    email: Optional[str] = None
-    phone: Optional[str] = None
-    website: Optional[str] = None
-    
+    abn: str | None
+    acn: str | None = None  # T1.25: ASIC company number
+    asic_registered_name: str | None = None  # T1.25: Clean registered name for fuzzy match
+    email: str | None = None
+    phone: str | None = None
+    website: str | None = None
+
     # Match quality
     abn_gmb_match_confidence: MatchConfidence = MatchConfidence.NO_MATCH
     abn_gmb_match_score: int = 0
-    
+
     # T-DM0: Decision Maker discovery (CEO Directive #040)
-    dm_name: Optional[str] = None
-    dm_title: Optional[str] = None
-    dm_linkedin_url: Optional[str] = None
+    dm_name: str | None = None
+    dm_title: str | None = None
+    dm_linkedin_url: str | None = None
     dm_candidates_found: int = 0
-    
+
     # T-DM2: LinkedIn Posts (CEO Directive #041)
     dm_linkedin_posts: list[LinkedInPost] = field(default_factory=list)
-    
+
     # T-DM3: X Posts (CEO Directive #041)
-    dm_x_handle: Optional[str] = None
+    dm_x_handle: str | None = None
     dm_x_posts: list[XPost] = field(default_factory=list)
-    
+
     # Verification
     verification_method: str  # single_source, dual_match, triple_check
     verification_sources: list[str]
     verification_consensus: bool
     email_confidence: int
-    
+
     # Costs
     total_cost_aud: Decimal
     lineage: list[LineageStep]
-    
+
     # ALS contribution
     source_count: int
     multi_source_bonus: int
-    
+
     # Status
     success: bool
     errors: list[str] = field(default_factory=list)
@@ -312,7 +311,7 @@ class WaterfallVerificationWorker(BaseEngine):
     - Full lineage logged to lead_lineage_log table
     - +15 ALS bonus for 3+ source verification
     """
-    
+
     def __init__(
         self,
         abn_client=None,
@@ -333,15 +332,15 @@ class WaterfallVerificationWorker(BaseEngine):
         self._gmb_scraper = gmb_scraper
         self._hunter_client = hunter_client
         self._zerobounce_client = zerobounce_client
-    
+
     @property
     def name(self) -> str:
         return "waterfall_verification"
-    
+
     # ============================================
     # MAIN VERIFICATION FLOW
     # ============================================
-    
+
     async def verify_lead(
         self,
         db: AsyncSession,
@@ -371,7 +370,7 @@ class WaterfallVerificationWorker(BaseEngine):
         errors: list[str] = []
         total_cost = Decimal("0.00")
         step_number = 0
-        
+
         # Initialize result
         result = WaterfallResult(
             lead_id=lead_id,
@@ -391,14 +390,14 @@ class WaterfallVerificationWorker(BaseEngine):
             multi_source_bonus=0,
             success=False,
         )
-        
+
         try:
             # ========== TIER 1: ABN SEED ==========
             step_number += 1
             start_time = datetime.utcnow()
-            
+
             abn_result = await self._tier1_abn_seed(company_name, postcode, state)
-            
+
             latency_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
             step = LineageStep(
                 step_number=step_number,
@@ -411,30 +410,30 @@ class WaterfallVerificationWorker(BaseEngine):
             )
             lineage.append(step)
             total_cost += step.cost_aud
-            
+
             if abn_result:
                 result.abn = abn_result.abn
                 result.verification_sources.append("abn")
             else:
                 errors.append("ABN seed: No match found for company name/postcode")
-            
+
             # ========== TIER 1.25: ASIC VERIFICATION (CEO Directive #039) ==========
             # Purpose: Get ASIC-registered business name for improved T2 fuzzy matching
-            asic_result: Optional[ASICVerifyRecord] = None
+            asic_result: ASICVerifyRecord | None = None
             gmb_search_name = company_name  # Default: use original company name
-            
+
             if abn_result and abn_result.acn:
                 step_number += 1
                 start_time = datetime.utcnow()
-                
+
                 asic_result = await self._tier1_25_asic_verify(
                     acn=abn_result.acn,
                     abn=abn_result.abn,
                 )
-                
+
                 latency_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
                 asic_success = asic_result is not None
-                
+
                 step = LineageStep(
                     step_number=step_number,
                     step_type="verification",
@@ -446,7 +445,7 @@ class WaterfallVerificationWorker(BaseEngine):
                 )
                 lineage.append(step)
                 total_cost += step.cost_aud
-                
+
                 if asic_result:
                     result.acn = asic_result.acn
                     result.asic_registered_name = asic_result.registered_name
@@ -458,28 +457,28 @@ class WaterfallVerificationWorker(BaseEngine):
                     )
                 else:
                     errors.append(f"T1.25: ASIC verify failed for ACN {abn_result.acn}")
-            
+
             # ========== TIER DM-0: LINKEDIN DECISION MAKER DISCOVERY (CEO Directive #040) ==========
             # Runs if we have a registered_name from T1.25 (or fallback to company_name)
             dm_search_name = gmb_search_name  # Use ASIC registered_name if available
-            
+
             step_number += 1
             start_time = datetime.utcnow()
-            
+
             dm_candidate = await self._tier_dm0_linkedin_discovery(
                 registered_name=dm_search_name,
                 state=state,
             )
-            
+
             latency_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
             dm0_success = dm_candidate is not None
-            
+
             # Calculate actual cost (SERP + profiles scraped)
             dm0_cost = DATAFORSEO_SERP_COST_AUD  # Always pay for SERP
             if dm0_success:
                 # Add Bright Data profile costs (estimated at 1 per successful result)
                 dm0_cost += BRIGHTDATA_PROFILE_COST_AUD
-            
+
             step = LineageStep(
                 step_number=step_number,
                 step_type="enrichment",
@@ -491,7 +490,7 @@ class WaterfallVerificationWorker(BaseEngine):
             )
             lineage.append(step)
             total_cost += dm0_cost
-            
+
             if dm_candidate:
                 result.dm_name = dm_candidate.dm_name
                 result.dm_title = dm_candidate.dm_title
@@ -504,23 +503,23 @@ class WaterfallVerificationWorker(BaseEngine):
                 )
             else:
                 errors.append(f"T-DM0: No decision maker found for '{dm_search_name}'")
-            
+
             # ========== TIER DM-2: LINKEDIN POSTS (CEO Directive #041) ==========
             # Only run for ALS ≥70 leads with a valid LinkedIn URL
             should_get_social = current_als_score >= 70 or force_full_waterfall
-            
+
             if should_get_social and result.dm_linkedin_url:
                 step_number += 1
                 start_time = datetime.utcnow()
-                
+
                 linkedin_posts = await self._tier_dm2_linkedin_posts(
                     dm_linkedin_url=result.dm_linkedin_url,
                     max_posts=5,
                 )
-                
+
                 latency_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
                 dm2_success = len(linkedin_posts) > 0
-                
+
                 step = LineageStep(
                     step_number=step_number,
                     step_type="enrichment",
@@ -532,7 +531,7 @@ class WaterfallVerificationWorker(BaseEngine):
                 )
                 lineage.append(step)
                 total_cost += step.cost_aud
-                
+
                 if linkedin_posts:
                     result.dm_linkedin_posts = linkedin_posts
                     result.verification_sources.append("dm2_linkedin_posts")
@@ -542,20 +541,20 @@ class WaterfallVerificationWorker(BaseEngine):
                     )
                 else:
                     errors.append(f"T-DM2: No LinkedIn posts found for '{result.dm_name}'")
-            
+
             # ========== TIER DM-3: X POSTS (CEO Directive #041) ==========
             # Only run for ALS ≥70 leads — discover X handle first
             if should_get_social:
                 step_number += 1
                 start_time = datetime.utcnow()
-                
+
                 # Discover X handle from website or SERP
                 x_handle = await self._discover_x_handle(
                     website=result.website,
                     dm_name=result.dm_name or "",
                     registered_name=gmb_search_name,
                 )
-                
+
                 x_posts = []
                 if x_handle:
                     result.dm_x_handle = x_handle
@@ -563,10 +562,10 @@ class WaterfallVerificationWorker(BaseEngine):
                         x_handle=x_handle,
                         max_posts=5,
                     )
-                
+
                 latency_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
                 dm3_success = len(x_posts) > 0
-                
+
                 step = LineageStep(
                     step_number=step_number,
                     step_type="enrichment",
@@ -578,7 +577,7 @@ class WaterfallVerificationWorker(BaseEngine):
                 )
                 lineage.append(step)
                 total_cost += step.cost_aud
-                
+
                 if x_posts:
                     result.dm_x_posts = x_posts
                     result.verification_sources.append("dm3_x_posts")
@@ -589,22 +588,22 @@ class WaterfallVerificationWorker(BaseEngine):
                     errors.append(f"T-DM3: X handle found ({x_handle}) but no posts retrieved")
                 else:
                     errors.append(f"T-DM3: No X handle found for '{result.dm_name}'")
-            
+
             # ========== TIER 2: GMB SCRAPER ==========
             step_number += 1
             start_time = datetime.utcnow()
-            
+
             # Use ASIC registered_name if available, otherwise original company_name
             gmb_result = await self._tier2_gmb_scraper(gmb_search_name, postcode, state)
-            
+
             latency_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
-            
+
             # Handle ABN ↔ GMB matching with error handling
             match_confidence = MatchConfidence.NO_MATCH
             match_score = 0
             gmb_success = False
             data_added = []
-            
+
             if gmb_result:
                 if abn_result:
                     # Both ABN and GMB found — attempt fuzzy match
@@ -612,7 +611,7 @@ class WaterfallVerificationWorker(BaseEngine):
                     match_confidence, match_score = self._match_abn_gmb(
                         abn_result, gmb_result, asic_result
                     )
-                    
+
                     if match_confidence != MatchConfidence.NO_MATCH:
                         # Match successful
                         gmb_success = True
@@ -647,7 +646,7 @@ class WaterfallVerificationWorker(BaseEngine):
                     errors.append("ABN not found — using GMB as primary source (unverified)")
             else:
                 errors.append("GMB scraper: No results for company/postcode")
-            
+
             step = LineageStep(
                 step_number=step_number,
                 step_type="enrichment",
@@ -660,50 +659,50 @@ class WaterfallVerificationWorker(BaseEngine):
             )
             lineage.append(step)
             total_cost += step.cost_aud
-            
+
             # ========== TIER 3: HUNTER.IO (Conditional) ==========
             # Only proceed if ALS >= 60 (Warm+) or forced
             should_verify_email = (
-                force_full_waterfall or 
+                force_full_waterfall or
                 current_als_score >= ALS_ESCALATION_THRESHOLD
             )
-            
+
             if should_verify_email and result.website:
                 step_number += 1
                 start_time = datetime.utcnow()
-                
+
                 domain = self._extract_domain(result.website)
                 hunter_result = await self._tier3_hunter_io(domain, company_name)
-                
+
                 latency_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
                 hunter_success = False
                 data_added = []
-                
+
                 if hunter_result:
                     result.email = hunter_result.email
                     result.email_confidence = hunter_result.confidence
                     result.verification_sources.append("hunter_io")
                     hunter_success = True
                     data_added = ["email"]
-                    
+
                     # ========== TIER 4: ZEROBOUNCE (Escalation) ==========
                     # Escalate if catch_all or low confidence
                     needs_escalation = (
                         hunter_result.status == "catch_all" or
                         hunter_result.confidence < HUNTER_CONFIDENCE_THRESHOLD
                     )
-                    
+
                     if needs_escalation:
                         step_number += 1
                         start_time = datetime.utcnow()
-                        
+
                         zb_result = await self._tier4_zerobounce(hunter_result.email)
-                        
+
                         latency_ms_zb = int(
                             (datetime.utcnow() - start_time).total_seconds() * 1000
                         )
                         zb_success = False
-                        
+
                         if zb_result:
                             if zb_result.status == "valid":
                                 result.email_confidence = 99
@@ -722,7 +721,7 @@ class WaterfallVerificationWorker(BaseEngine):
                                 )
                                 result.verification_sources.append("zerobounce")
                                 zb_success = True
-                        
+
                         step = LineageStep(
                             step_number=step_number,
                             step_type="verification",
@@ -737,7 +736,7 @@ class WaterfallVerificationWorker(BaseEngine):
                         total_cost += step.cost_aud
                 else:
                     errors.append(f"Hunter.io: No email found for domain {domain}")
-                
+
                 step = LineageStep(
                     step_number=step_number if not needs_escalation else step_number - 1,
                     step_type="verification",
@@ -754,13 +753,13 @@ class WaterfallVerificationWorker(BaseEngine):
                 else:
                     lineage.append(step)
                 total_cost += step.cost_aud
-            
+
             # ========== FINALIZE RESULT ==========
             result.source_count = len(result.verification_sources)
             result.total_cost_aud = total_cost
             result.lineage = lineage
             result.errors = errors
-            
+
             # Determine verification method
             if result.source_count >= 3:
                 result.verification_method = "triple_check"
@@ -774,13 +773,13 @@ class WaterfallVerificationWorker(BaseEngine):
             else:
                 result.verification_method = "single_source"
                 result.verification_consensus = False
-            
+
             # Overall success if we have at least email OR phone
             result.success = bool(result.email or result.phone)
-            
+
             # Log to database
             await self._log_lineage(db, result)
-            
+
             return EngineResult.ok(
                 data=result,
                 metadata={
@@ -789,7 +788,7 @@ class WaterfallVerificationWorker(BaseEngine):
                     "verification_method": result.verification_method,
                 },
             )
-            
+
         except Exception as e:
             logger.exception(f"Waterfall verification failed for lead {lead_id}")
             result.errors.append(f"Waterfall exception: {str(e)}")
@@ -799,16 +798,16 @@ class WaterfallVerificationWorker(BaseEngine):
                 error=str(e),
                 metadata={"partial_result": result},
             )
-    
+
     # ============================================
     # ALS CALCULATION
     # ============================================
-    
+
     def calculate_als_score(
         self,
         base_als_score: int,
         waterfall_result: WaterfallResult,
-        intent_signals: Optional[dict] = None,
+        intent_signals: dict | None = None,
     ) -> dict[str, Any]:
         """
         Calculate ALS with waterfall verification bonus.
@@ -841,15 +840,15 @@ class WaterfallVerificationWorker(BaseEngine):
             "sources_used": waterfall_result.verification_sources,
             "verification_method": waterfall_result.verification_method,
         }
-        
+
         # Multi-source verification bonus
         if waterfall_result.source_count >= 3:
             components["verification_bonus"] = MULTI_SOURCE_BONUS
-        
+
         # Intent signal bonus
         if intent_signals:
             intent_bonus = 0
-            
+
             # Ad volume signal: >50 ads running >60 days
             ad_volume = intent_signals.get("ad_volume", 0)
             ad_longevity = intent_signals.get("ad_longevity_days", 0)
@@ -857,17 +856,17 @@ class WaterfallVerificationWorker(BaseEngine):
                 intent_bonus += 10  # High-intent advertiser
             elif ad_volume >= 20:
                 intent_bonus += 5   # Active advertiser
-            
+
             # Hiring signal
             if intent_signals.get("is_hiring"):
                 intent_bonus += 3
-            
+
             # Funding signal
             if intent_signals.get("recent_funding"):
                 intent_bonus += 5
-            
+
             components["intent_bonus"] = min(intent_bonus, 15)  # Cap at 15
-        
+
         # Calculate final score (capped at 100)
         final_score = min(
             100,
@@ -875,21 +874,21 @@ class WaterfallVerificationWorker(BaseEngine):
             components["verification_bonus"] +
             components["intent_bonus"]
         )
-        
+
         components["final_score"] = final_score
-        
+
         return components
-    
+
     # ============================================
     # TIER IMPLEMENTATIONS
     # ============================================
-    
+
     async def _tier1_abn_seed(
         self,
         company_name: str,
         postcode: str,
         state: str,
-    ) -> Optional[ABNRecord]:
+    ) -> ABNRecord | None:
         """
         Tier 1: Look up company in ABN database.
         
@@ -898,7 +897,7 @@ class WaterfallVerificationWorker(BaseEngine):
         if self._abn_client is None:
             logger.warning("ABN client not configured — skipping Tier 1")
             return None
-        
+
         try:
             # Search by name + postcode + state
             results = await self._abn_client.search_by_name(
@@ -907,22 +906,22 @@ class WaterfallVerificationWorker(BaseEngine):
                 state=state,
                 active_only=True,
             )
-            
+
             if results and len(results) > 0:
                 # Return best match (API should return sorted by relevance)
                 return results[0]
-            
+
             return None
-            
+
         except Exception as e:
             logger.error(f"ABN lookup failed: {e}")
             return None
-    
+
     async def _tier1_25_asic_verify(
         self,
-        acn: Optional[str],
-        abn: Optional[str],
-    ) -> Optional[ASICVerifyRecord]:
+        acn: str | None,
+        abn: str | None,
+    ) -> ASICVerifyRecord | None:
         """
         Tier 1.25: ASIC Business Registry verification via ABR SearchByASIC.
         
@@ -942,25 +941,25 @@ class WaterfallVerificationWorker(BaseEngine):
         if self._abn_client is None:
             logger.warning("ABN client not configured — skipping T1.25 ASIC verify")
             return None
-        
+
         # Need ACN for ASIC lookup
         if not acn:
             logger.info("T1.25: No ACN available — skipping ASIC verify")
             return None
-        
+
         try:
             # Use ABR SearchByASIC to get ASIC-registered data
             result = await self._abn_client.search_by_acn(acn)
-            
+
             if not result:
                 logger.info(f"T1.25: No ASIC record found for ACN {acn}")
                 return None
-            
+
             # Extract registered business name (clean, official)
             # Priority: business_names (ASIC-registered) > legal_name
             business_names = result.get("business_names", [])
             legal_name = result.get("legal_name", "") or result.get("entity_name", "")
-            
+
             # Use first ASIC-registered business name if available
             # These are cleaner for GMB matching (e.g., "Efficient Media" vs "EFFICIENT MEDIA PTY LTD")
             if business_names and len(business_names) > 0:
@@ -968,9 +967,9 @@ class WaterfallVerificationWorker(BaseEngine):
             else:
                 # Fallback to legal name, cleaned
                 registered_name = self._clean_company_name(legal_name)
-            
+
             logger.info(f"T1.25: ASIC registered_name = '{registered_name}' for ACN {acn}")
-            
+
             return ASICVerifyRecord(
                 acn=acn,
                 registered_name=registered_name,
@@ -980,16 +979,16 @@ class WaterfallVerificationWorker(BaseEngine):
                 postcode=result.get("postcode", ""),
                 directors=None,  # Pending ASIC DSP approval - CEO Directive #039
             )
-            
+
         except Exception as e:
             logger.error(f"T1.25 ASIC verify failed for ACN {acn}: {e}")
             return None
-    
+
     async def _tier_dm0_linkedin_discovery(
         self,
         registered_name: str,
         state: str = "AU",
-    ) -> Optional[DMCandidate]:
+    ) -> DMCandidate | None:
         """
         Tier DM-0: LinkedIn Decision Maker Discovery.
         
@@ -1012,26 +1011,26 @@ class WaterfallVerificationWorker(BaseEngine):
         Cost: ~$0.0165 AUD (DataForSEO SERP $0.009 + up to 5 × Bright Data $0.0015)
         """
         import base64
-        
+
         # DataForSEO credentials
         dataforseo_login = os.getenv("DATAFORSEO_LOGIN")
         dataforseo_password = os.getenv("DATAFORSEO_PASSWORD")
         brightdata_api_key = os.getenv("BRIGHTDATA_API_KEY")
-        
+
         if not dataforseo_login or not dataforseo_password:
             logger.warning("DataForSEO credentials not set — skipping T-DM0")
             return None
-        
+
         if not brightdata_api_key:
             logger.warning("BRIGHTDATA_API_KEY not set — skipping T-DM0 profile scraping")
             return None
-        
+
         try:
             async with httpx.AsyncClient(timeout=60.0) as client:
                 # ========== STEP 1: DataForSEO SERP Query ==========
                 # Query: site:linkedin.com/in "{registered_name}" founder OR director OR CEO OR owner OR MD
                 search_query = f'site:linkedin.com/in "{registered_name}" founder OR director OR CEO OR owner OR MD'
-                
+
                 # DataForSEO location codes: 2036 = Australia
                 serp_payload = [{
                     "keyword": search_query,
@@ -1039,11 +1038,11 @@ class WaterfallVerificationWorker(BaseEngine):
                     "language_code": "en",
                     "depth": 10,
                 }]
-                
+
                 # Basic auth for DataForSEO
                 auth_str = f"{dataforseo_login}:{dataforseo_password}"
                 auth_bytes = base64.b64encode(auth_str.encode()).decode()
-                
+
                 serp_resp = await client.post(
                     "https://api.dataforseo.com/v3/serp/google/organic/live/advanced",
                     headers={
@@ -1054,18 +1053,18 @@ class WaterfallVerificationWorker(BaseEngine):
                 )
                 serp_resp.raise_for_status()
                 serp_data = serp_resp.json()
-                
+
                 # Extract items from SERP response
                 items = []
-                if (serp_data.get("tasks") and 
+                if (serp_data.get("tasks") and
                     serp_data["tasks"][0].get("result") and
                     serp_data["tasks"][0]["result"][0].get("items")):
                     items = serp_data["tasks"][0]["result"][0]["items"]
-                
+
                 if not items:
                     logger.info(f"T-DM0: No LinkedIn profiles found for '{registered_name}'")
                     return None
-                
+
                 # ========== STEP 2: Extract LinkedIn Profile URLs (max 5) ==========
                 linkedin_urls = []
                 for item in items[:10]:  # Check top 10 SERP results
@@ -1074,17 +1073,17 @@ class WaterfallVerificationWorker(BaseEngine):
                         linkedin_urls.append(url)
                     if len(linkedin_urls) >= 5:
                         break
-                
+
                 if not linkedin_urls:
                     logger.info(f"T-DM0: No linkedin.com/in/ URLs in SERP results for '{registered_name}'")
                     return None
-                
+
                 logger.info(f"T-DM0: Found {len(linkedin_urls)} LinkedIn profile URLs for '{registered_name}'")
-                
+
                 # ========== STEP 3: Bright Data LinkedIn Profile Scrape ==========
                 # Dataset: gd_l1viktl72bvl7bjuj0 (LinkedIn People)
                 profiles = []
-                
+
                 for profile_url in linkedin_urls:
                     try:
                         # Trigger scrape
@@ -1102,11 +1101,11 @@ class WaterfallVerificationWorker(BaseEngine):
                         )
                         trigger_resp.raise_for_status()
                         snapshot_id = trigger_resp.json().get("snapshot_id")
-                        
+
                         if not snapshot_id:
                             logger.warning(f"T-DM0: No snapshot_id for {profile_url}")
                             continue
-                        
+
                         # Poll for completion (max 2 minutes per profile)
                         profile_data = None
                         for _ in range(24):  # 24 × 5s = 120s
@@ -1130,30 +1129,30 @@ class WaterfallVerificationWorker(BaseEngine):
                             elif status_data.get("status") == "failed":
                                 logger.warning(f"T-DM0: Bright Data scrape failed for {profile_url}")
                                 break
-                        
+
                         if profile_data and "error" not in profile_data:
                             profiles.append({
                                 "url": profile_url,
                                 "data": profile_data,
                             })
-                    
+
                     except Exception as e:
                         logger.warning(f"T-DM0: Error scraping {profile_url}: {e}")
                         continue
-                
+
                 if not profiles:
                     logger.info(f"T-DM0: No valid profiles scraped for '{registered_name}'")
                     return None
-                
+
                 # ========== STEP 4: Local Title Filter ==========
                 candidates = []
-                
+
                 for profile in profiles:
                     data = profile["data"]
                     name = data.get("name", "") or data.get("full_name", "")
                     title = data.get("headline", "") or data.get("occupation", "") or ""
                     current_company = data.get("current_company_name", "") or ""
-                    
+
                     # Check for experience entries with current company
                     experiences = data.get("experience", []) or []
                     for exp in experiences:
@@ -1161,20 +1160,20 @@ class WaterfallVerificationWorker(BaseEngine):
                             current_company = exp.get("company_name", "") or current_company
                             title = exp.get("title", "") or title
                             break
-                    
+
                     # Calculate company match score
                     company_match_score = fuzz.token_set_ratio(
-                        registered_name.lower(), 
+                        registered_name.lower(),
                         current_company.lower()
                     )
-                    
+
                     # Calculate title score based on DM_TITLE_SCORES
                     title_score = 0
                     title_lower = title.lower()
                     for dm_title, score in DM_TITLE_SCORES.items():
                         if dm_title in title_lower:
                             title_score = max(title_score, score)
-                    
+
                     # Only consider if company match is reasonable (>60%) and has DM title
                     if company_match_score >= 60 and title_score > 0:
                         candidates.append(DMCandidate(
@@ -1184,30 +1183,30 @@ class WaterfallVerificationWorker(BaseEngine):
                             company_match_score=company_match_score,
                             title_score=title_score,
                         ))
-                
+
                 if not candidates:
                     logger.info(f"T-DM0: No DM candidates passed title filter for '{registered_name}'")
                     return None
-                
+
                 # Sort by title_score (desc), then company_match_score (desc)
                 candidates.sort(key=lambda c: (c.title_score, c.company_match_score), reverse=True)
-                
+
                 best_candidate = candidates[0]
                 logger.info(
                     f"T-DM0: Found DM candidate '{best_candidate.dm_name}' ({best_candidate.dm_title}) "
                     f"for '{registered_name}' — company_match={best_candidate.company_match_score}%, "
                     f"title_score={best_candidate.title_score}"
                 )
-                
+
                 return best_candidate
-        
+
         except httpx.HTTPStatusError as e:
             logger.error(f"T-DM0 HTTP error: {e.response.status_code} - {e.response.text[:200]}")
             return None
         except Exception as e:
             logger.error(f"T-DM0 failed for '{registered_name}': {e}")
             return None
-    
+
     async def _tier_dm2_linkedin_posts(
         self,
         dm_linkedin_url: str,
@@ -1231,15 +1230,15 @@ class WaterfallVerificationWorker(BaseEngine):
         Cost: ~$0.0015 AUD per request
         """
         brightdata_api_key = os.getenv("BRIGHTDATA_API_KEY")
-        
+
         if not brightdata_api_key:
             logger.warning("BRIGHTDATA_API_KEY not set — skipping T-DM2")
             return []
-        
+
         if not dm_linkedin_url:
             logger.info("T-DM2: No LinkedIn URL provided — skipping")
             return []
-        
+
         try:
             async with httpx.AsyncClient(timeout=120.0) as client:
                 # ========== Step 1: Trigger LinkedIn Posts collection ==========
@@ -1261,13 +1260,13 @@ class WaterfallVerificationWorker(BaseEngine):
                 )
                 trigger_resp.raise_for_status()
                 snapshot_id = trigger_resp.json().get("snapshot_id")
-                
+
                 if not snapshot_id:
                     logger.warning(f"T-DM2: No snapshot_id returned for {dm_linkedin_url}")
                     return []
-                
+
                 logger.info(f"T-DM2: Triggered LinkedIn Posts scrape: {snapshot_id}")
-                
+
                 # ========== Step 2: Poll for completion (max 2 minutes) ==========
                 for _ in range(24):  # 24 × 5s = 120s
                     await asyncio.sleep(5)
@@ -1276,7 +1275,7 @@ class WaterfallVerificationWorker(BaseEngine):
                         headers={"Authorization": f"Bearer {brightdata_api_key}"},
                     )
                     status_data = status_resp.json()
-                    
+
                     if status_data.get("status") == "ready":
                         break
                     elif status_data.get("status") == "failed":
@@ -1285,7 +1284,7 @@ class WaterfallVerificationWorker(BaseEngine):
                 else:
                     logger.warning(f"T-DM2: Timeout waiting for {dm_linkedin_url}")
                     return []
-                
+
                 # ========== Step 3: Download results ==========
                 data_resp = await client.get(
                     f"https://api.brightdata.com/datasets/v3/snapshot/{snapshot_id}",
@@ -1293,20 +1292,20 @@ class WaterfallVerificationWorker(BaseEngine):
                     headers={"Authorization": f"Bearer {brightdata_api_key}"},
                 )
                 results = data_resp.json()
-                
+
                 if not results:
                     logger.info(f"T-DM2: No posts found for {dm_linkedin_url}")
                     return []
-                
+
                 # ========== Step 4: Parse posts with 90-day local filter ==========
                 # CEO Directive #043: Date filter not supported in API, filter locally
                 cutoff_date = datetime.utcnow() - timedelta(days=90)
-                
+
                 posts = []
                 for post_data in results:
                     if "error" in post_data:
                         continue
-                    
+
                     # Parse and filter by date (90-day window)
                     date_str = post_data.get("date_posted", "")
                     if date_str:
@@ -1317,11 +1316,11 @@ class WaterfallVerificationWorker(BaseEngine):
                                 continue  # Skip posts older than 90 days
                         except (ValueError, TypeError):
                             pass  # Keep posts with unparseable dates
-                    
+
                     # Extract topic from hashtags or infer from content
                     hashtags = post_data.get("hashtags", []) or []
                     topic = hashtags[0] if hashtags else None
-                    
+
                     posts.append(LinkedInPost(
                         post_text=post_data.get("post_text", "") or post_data.get("title", ""),
                         date_posted=date_str,
@@ -1330,29 +1329,29 @@ class WaterfallVerificationWorker(BaseEngine):
                         hashtags=hashtags,
                         topic=topic,
                     ))
-                    
+
                     if len(posts) >= max_posts:
                         break
-                
+
                 logger.info(
                     f"T-DM2: Retrieved {len(posts)} LinkedIn posts within 90 days "
                     f"(filtered from {len(results)} total) for {dm_linkedin_url}"
                 )
                 return posts
-        
+
         except httpx.HTTPStatusError as e:
             logger.error(f"T-DM2 HTTP error: {e.response.status_code} - {e.response.text[:200]}")
             return []
         except Exception as e:
             logger.error(f"T-DM2 failed for '{dm_linkedin_url}': {e}")
             return []
-    
+
     async def _discover_x_handle(
         self,
-        website: Optional[str],
+        website: str | None,
         dm_name: str,
         registered_name: str,
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Discover X/Twitter handle via website scraping or SERP fallback.
         
@@ -1364,25 +1363,25 @@ class WaterfallVerificationWorker(BaseEngine):
             X handle (e.g., "@username") or None if not found
         """
         import re
-        
+
         # ========== Method 1: Scrape website for X/Twitter links ==========
         if website:
             try:
                 async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
                     resp = await client.get(website)
                     html = resp.text
-                    
+
                     # Look for X/Twitter profile links
                     patterns = [
                         r'https?://(?:www\.)?(?:twitter|x)\.com/([a-zA-Z0-9_]+)',
                         r'href=["\']https?://(?:www\.)?(?:twitter|x)\.com/([a-zA-Z0-9_]+)["\']',
                     ]
-                    
+
                     for pattern in patterns:
                         matches = re.findall(pattern, html, re.IGNORECASE)
                         # Filter out common non-profile paths
                         valid_handles = [
-                            m for m in matches 
+                            m for m in matches
                             if m.lower() not in ('share', 'intent', 'home', 'search', 'explore', 'i', 'hashtag')
                         ]
                         if valid_handles:
@@ -1391,32 +1390,32 @@ class WaterfallVerificationWorker(BaseEngine):
                             return f"@{handle}"
             except Exception as e:
                 logger.debug(f"T-DM3: Website scrape failed for {website}: {e}")
-        
+
         # ========== Method 2: SERP fallback ==========
         import base64
-        
+
         dataforseo_login = os.getenv("DATAFORSEO_LOGIN")
         dataforseo_password = os.getenv("DATAFORSEO_PASSWORD")
-        
+
         if not dataforseo_login or not dataforseo_password:
             logger.warning("DataForSEO credentials not set — skipping X handle SERP discovery")
             return None
-        
+
         try:
             async with httpx.AsyncClient(timeout=60.0) as client:
                 # Query: site:x.com "{dm_name}" "{registered_name}"
                 search_query = f'site:x.com "{dm_name}" "{registered_name}"'
-                
+
                 serp_payload = [{
                     "keyword": search_query,
                     "location_code": 2036,  # Australia
                     "language_code": "en",
                     "depth": 5,
                 }]
-                
+
                 auth_str = f"{dataforseo_login}:{dataforseo_password}"
                 auth_bytes = base64.b64encode(auth_str.encode()).decode()
-                
+
                 serp_resp = await client.post(
                     "https://api.dataforseo.com/v3/serp/google/organic/live/advanced",
                     headers={
@@ -1427,14 +1426,14 @@ class WaterfallVerificationWorker(BaseEngine):
                 )
                 serp_resp.raise_for_status()
                 serp_data = serp_resp.json()
-                
+
                 # Extract X profile URLs
                 items = []
-                if (serp_data.get("tasks") and 
+                if (serp_data.get("tasks") and
                     serp_data["tasks"][0].get("result") and
                     serp_data["tasks"][0]["result"][0].get("items")):
                     items = serp_data["tasks"][0]["result"][0]["items"]
-                
+
                 for item in items[:5]:
                     url = item.get("url", "")
                     # Match x.com/username or twitter.com/username
@@ -1444,14 +1443,14 @@ class WaterfallVerificationWorker(BaseEngine):
                         if handle.lower() not in ('share', 'intent', 'home', 'search', 'explore', 'i', 'hashtag'):
                             logger.info(f"T-DM3: Found X handle @{handle} via SERP for {dm_name}")
                             return f"@{handle}"
-                
+
                 logger.info(f"T-DM3: No X handle found for {dm_name} at {registered_name}")
                 return None
-        
+
         except Exception as e:
             logger.error(f"T-DM3 X handle SERP discovery failed: {e}")
             return None
-    
+
     async def _tier_dm3_x_posts(
         self,
         x_handle: str,
@@ -1475,19 +1474,19 @@ class WaterfallVerificationWorker(BaseEngine):
         Cost: ~$0.0015 AUD per request
         """
         brightdata_api_key = os.getenv("BRIGHTDATA_API_KEY")
-        
+
         if not brightdata_api_key:
             logger.warning("BRIGHTDATA_API_KEY not set — skipping T-DM3")
             return []
-        
+
         if not x_handle:
             logger.info("T-DM3: No X handle provided — skipping")
             return []
-        
+
         # Normalize handle (remove @ if present)
         handle = x_handle.lstrip("@")
         profile_url = f"https://x.com/{handle}"
-        
+
         try:
             async with httpx.AsyncClient(timeout=120.0) as client:
                 # ========== Step 1: Trigger X Posts collection ==========
@@ -1509,13 +1508,13 @@ class WaterfallVerificationWorker(BaseEngine):
                 )
                 trigger_resp.raise_for_status()
                 snapshot_id = trigger_resp.json().get("snapshot_id")
-                
+
                 if not snapshot_id:
                     logger.warning(f"T-DM3: No snapshot_id returned for {profile_url}")
                     return []
-                
+
                 logger.info(f"T-DM3: Triggered X Posts scrape: {snapshot_id}")
-                
+
                 # ========== Step 2: Poll for completion (max 2 minutes) ==========
                 for _ in range(24):  # 24 × 5s = 120s
                     await asyncio.sleep(5)
@@ -1524,7 +1523,7 @@ class WaterfallVerificationWorker(BaseEngine):
                         headers={"Authorization": f"Bearer {brightdata_api_key}"},
                     )
                     status_data = status_resp.json()
-                    
+
                     if status_data.get("status") == "ready":
                         break
                     elif status_data.get("status") == "failed":
@@ -1533,7 +1532,7 @@ class WaterfallVerificationWorker(BaseEngine):
                 else:
                     logger.warning(f"T-DM3: Timeout waiting for {profile_url}")
                     return []
-                
+
                 # ========== Step 3: Download results ==========
                 data_resp = await client.get(
                     f"https://api.brightdata.com/datasets/v3/snapshot/{snapshot_id}",
@@ -1541,20 +1540,20 @@ class WaterfallVerificationWorker(BaseEngine):
                     headers={"Authorization": f"Bearer {brightdata_api_key}"},
                 )
                 results = data_resp.json()
-                
+
                 if not results:
                     logger.info(f"T-DM3: No posts found for {profile_url}")
                     return []
-                
+
                 # ========== Step 4: Parse posts with 90-day local filter ==========
                 # CEO Directive #043: Date filter not supported in API, filter locally
                 cutoff_date = datetime.utcnow() - timedelta(days=90)
-                
+
                 posts = []
                 for post_data in results:
                     if "error" in post_data:
                         continue
-                    
+
                     # Parse and filter by date (90-day window)
                     date_str = post_data.get("date_posted", "")
                     if date_str:
@@ -1564,12 +1563,12 @@ class WaterfallVerificationWorker(BaseEngine):
                                 continue  # Skip posts older than 90 days
                         except (ValueError, TypeError):
                             pass  # Keep posts with unparseable dates
-                    
+
                     # Extract hashtags from description
                     import re
                     description = post_data.get("description", "") or ""
                     hashtags = re.findall(r'#(\w+)', description)
-                    
+
                     posts.append(XPost(
                         content=description,
                         date_posted=date_str,
@@ -1578,23 +1577,23 @@ class WaterfallVerificationWorker(BaseEngine):
                         views=post_data.get("views", 0) or 0,
                         hashtags=hashtags,
                     ))
-                    
+
                     if len(posts) >= max_posts:
                         break
-                
+
                 logger.info(
                     f"T-DM3: Retrieved {len(posts)} X posts within 90 days "
                     f"(filtered from {len(results)} total) for {profile_url}"
                 )
                 return posts
-        
+
         except httpx.HTTPStatusError as e:
             logger.error(f"T-DM3 HTTP error: {e.response.status_code} - {e.response.text[:200]}")
             return []
         except Exception as e:
             logger.error(f"T-DM3 failed for '{x_handle}': {e}")
             return []
-    
+
     def _clean_company_name(self, name: str) -> str:
         """
         Clean company name for better fuzzy matching.
@@ -1604,24 +1603,24 @@ class WaterfallVerificationWorker(BaseEngine):
         """
         if not name:
             return ""
-        
+
         import re
-        
+
         # Remove common Australian company suffixes
         suffixes_pattern = r'\s+(PTY\.?\s*LTD\.?|LIMITED|LTD\.?|PROPRIETARY|INC\.?|INCORPORATED|HOLDINGS?|GROUP|AUSTRALIA|AUST\.?|AU)\s*$'
         cleaned = re.sub(suffixes_pattern, '', name.upper(), flags=re.IGNORECASE)
-        
+
         # Normalize to title case
         cleaned = cleaned.strip().title()
-        
+
         return cleaned
-    
+
     async def _tier2_gmb_scraper(
         self,
         company_name: str,
         postcode: str,
         state: str,
-    ) -> Optional[GMBRecord]:
+    ) -> GMBRecord | None:
         """
         Tier 2: Scrape Google Maps for business info via Bright Data.
         
@@ -1633,7 +1632,7 @@ class WaterfallVerificationWorker(BaseEngine):
         if not api_key:
             logger.warning("BRIGHTDATA_API_KEY not set — skipping Tier 2")
             return None
-        
+
         # Map state code to city for better search results
         state_city_map = {
             "NSW": "Sydney", "VIC": "Melbourne", "QLD": "Brisbane",
@@ -1641,7 +1640,7 @@ class WaterfallVerificationWorker(BaseEngine):
             "ACT": "Canberra", "NT": "Darwin",
         }
         city = state_city_map.get(state, state)
-        
+
         try:
             async with httpx.AsyncClient(timeout=120.0) as client:
                 # Step 1: Trigger collection
@@ -1665,9 +1664,9 @@ class WaterfallVerificationWorker(BaseEngine):
                 if not snapshot_id:
                     logger.error("Bright Data trigger returned no snapshot_id")
                     return None
-                
+
                 logger.info(f"Bright Data T2 triggered: {snapshot_id}")
-                
+
                 # Step 2: Poll for completion (max 3 minutes)
                 for _ in range(18):  # 18 x 10s = 180s
                     await asyncio.sleep(10)
@@ -1681,7 +1680,7 @@ class WaterfallVerificationWorker(BaseEngine):
                 else:
                     logger.warning(f"Bright Data T2 timeout for {company_name}")
                     return None
-                
+
                 # Step 3: Fetch results
                 data_resp = await client.get(
                     f"https://api.brightdata.com/datasets/v3/snapshot/{snapshot_id}",
@@ -1689,15 +1688,15 @@ class WaterfallVerificationWorker(BaseEngine):
                     headers={"Authorization": f"Bearer {api_key}"},
                 )
                 results = data_resp.json()
-                
+
                 if not results or len(results) == 0:
                     logger.info(f"Bright Data T2 returned no results for {company_name}")
                     return None
-                
+
                 # Step 4: Find best match by fuzzy name similarity
                 best_match = None
                 best_score = 0
-                
+
                 for r in results:
                     if "error" in r:
                         continue
@@ -1706,11 +1705,11 @@ class WaterfallVerificationWorker(BaseEngine):
                     if score > best_score:
                         best_score = score
                         best_match = r
-                
+
                 if best_score < FUZZY_MATCH_THRESHOLD:
                     logger.info(f"Bright Data T2: best match score {best_score} below threshold for {company_name}")
                     return None
-                
+
                 # Step 5: Parse into GMBRecord
                 return GMBRecord(
                     google_place_id=best_match.get("place_id", ""),
@@ -1726,76 +1725,76 @@ class WaterfallVerificationWorker(BaseEngine):
                     review_count=best_match.get("reviews_count", 0) or 0,
                     categories=best_match.get("all_categories", []),
                 )
-                
+
         except httpx.HTTPStatusError as e:
             logger.error(f"Bright Data T2 HTTP error: {e.response.status_code} - {e.response.text[:200]}")
             return None
         except Exception as e:
             logger.error(f"Bright Data T2 failed: {e}")
             return None
-    
+
     def _extract_postcode(self, address: str) -> str:
         """Extract Australian postcode (4 digits) from address string."""
         import re
         match = re.search(r'\b(\d{4})\b', address)
         return match.group(1) if match else ""
-    
+
     async def _tier3_hunter_io(
         self,
         domain: str,
         company_name: str,
-    ) -> Optional[HunterResult]:
+    ) -> HunterResult | None:
         """
         Tier 3: Find and verify email via Hunter.io.
         """
         if self._hunter_client is None:
             logger.warning("Hunter.io client not configured — skipping Tier 3")
             return None
-        
+
         try:
             # Domain search for contacts
             result = await self._hunter_client.domain_search(
                 domain=domain,
                 company=company_name,
             )
-            
+
             if result and result.email:
                 return result
-            
+
             return None
-            
+
         except Exception as e:
             logger.error(f"Hunter.io failed: {e}")
             return None
-    
+
     async def _tier4_zerobounce(
         self,
         email: str,
-    ) -> Optional[ZeroBounceResult]:
+    ) -> ZeroBounceResult | None:
         """
         Tier 4: Premium verification via ZeroBounce.
         """
         if self._zerobounce_client is None:
             logger.warning("ZeroBounce client not configured — skipping Tier 4")
             return None
-        
+
         try:
             result = await self._zerobounce_client.validate(email)
             return result
-            
+
         except Exception as e:
             logger.error(f"ZeroBounce failed: {e}")
             return None
-    
+
     # ============================================
     # HELPER METHODS
     # ============================================
-    
+
     def _match_abn_gmb(
         self,
         abn: ABNRecord,
         gmb: GMBRecord,
-        asic: Optional[ASICVerifyRecord] = None,
+        asic: ASICVerifyRecord | None = None,
     ) -> tuple[MatchConfidence, int]:
         """
         Match ABN record to GMB record using fuzzy matching.
@@ -1819,29 +1818,29 @@ class WaterfallVerificationWorker(BaseEngine):
                     return MatchConfidence.NO_MATCH, 0
             except ValueError:
                 return MatchConfidence.NO_MATCH, 0
-        
+
         # Build list of names to check
         # CEO Directive #039: ASIC registered_name takes priority (cleaner, normalized)
         names_to_check = []
-        
+
         if asic and asic.registered_name:
             # Priority 1: ASIC registered name (clean, normalized)
             names_to_check.append(asic.registered_name)
             # Priority 2: All ASIC business names
             names_to_check.extend(asic.business_names or [])
-        
+
         # Priority 3: ABN legal name and business names (fallback)
         names_to_check.append(abn.legal_name)
         names_to_check.extend(abn.business_names)
-        
+
         # Also try cleaned version of legal name
         cleaned_legal = self._clean_company_name(abn.legal_name)
         if cleaned_legal and cleaned_legal not in names_to_check:
             names_to_check.append(cleaned_legal)
-        
+
         best_score = 0
         best_match_name = ""
-        
+
         for name in names_to_check:
             if not name:
                 continue
@@ -1852,13 +1851,13 @@ class WaterfallVerificationWorker(BaseEngine):
             if current_best > best_score:
                 best_score = current_best
                 best_match_name = name
-        
+
         # Log the match attempt for debugging
         logger.debug(
             f"ABN↔GMB match: best='{best_match_name}' vs GMB='{gmb.business_name}' "
             f"score={best_score}% (threshold={FUZZY_MATCH_THRESHOLD}%)"
         )
-        
+
         # Determine confidence level
         if best_score >= 95:
             return MatchConfidence.EXACT, best_score
@@ -1870,23 +1869,23 @@ class WaterfallVerificationWorker(BaseEngine):
             return MatchConfidence.LOW, best_score
         else:
             return MatchConfidence.NO_MATCH, best_score
-    
+
     def _extract_domain(self, url: str) -> str:
         """Extract domain from URL."""
         from urllib.parse import urlparse
-        
+
         if not url.startswith(("http://", "https://")):
             url = "https://" + url
-        
+
         parsed = urlparse(url)
         domain = parsed.netloc or parsed.path.split("/")[0]
-        
+
         # Remove www. prefix
         if domain.startswith("www."):
             domain = domain[4:]
-        
+
         return domain
-    
+
     async def _log_lineage(
         self,
         db: AsyncSession,
@@ -1911,12 +1910,12 @@ class WaterfallVerificationWorker(BaseEngine):
                     created_at=datetime.utcnow(),
                 )
                 await db.execute(stmt)
-            
+
             await db.commit()
             logger.info(
                 f"Logged {len(result.lineage)} lineage steps for lead {result.lead_id}"
             )
-            
+
         except Exception as e:
             logger.error(f"Failed to log lineage: {e}")
             await db.rollback()

--- a/src/enrichment/__init__.py
+++ b/src/enrichment/__init__.py
@@ -8,14 +8,13 @@ Created: 2026-02-16 (CEO Directive #023)
 """
 
 from .discovery_modes import (
-    DiscoveryMode,
-    CampaignConfig,
-    DiscoveryRecord,
     ABNFirstDiscovery,
+    CampaignConfig,
+    DiscoveryMode,
+    DiscoveryRecord,
     MapsFirstDiscovery,
     ParallelDiscovery,
 )
-
 from .waterfall_v2 import (
     LeadRecord,
     WaterfallV2,
@@ -24,12 +23,12 @@ from .waterfall_v2 import (
 __all__ = [
     # Discovery modes
     "DiscoveryMode",
-    "CampaignConfig", 
+    "CampaignConfig",
     "DiscoveryRecord",
     "ABNFirstDiscovery",
     "MapsFirstDiscovery",
     "ParallelDiscovery",
-    
+
     # Waterfall pipeline
     "LeadRecord",
     "WaterfallV2",

--- a/src/enrichment/discovery_modes.py
+++ b/src/enrichment/discovery_modes.py
@@ -26,7 +26,8 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, List, Dict, Optional
+from typing import Any
+
 from fuzzywuzzy import fuzz
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ logger = logging.getLogger(__name__)
 class DiscoveryMode(Enum):
     """Discovery modes for lead generation campaigns"""
     ABN_FIRST = "mode_a"      # Universal B2B - ABN API first
-    MAPS_FIRST = "mode_b"     # Local businesses with GMB - Google Maps first  
+    MAPS_FIRST = "mode_b"     # Local businesses with GMB - Google Maps first
     PARALLEL = "mode_c"       # Premium - both modes with deduplication
 
 
@@ -46,14 +47,14 @@ class CampaignConfig:
     industry: str
     location: str
     state: str = None
-    filters: Dict[str, Any] = field(default_factory=dict)
-    
+    filters: dict[str, Any] = field(default_factory=dict)
+
     # Discovery limits
     max_results: int = 1000
     abn_only_active: bool = True
     abn_only_gst: bool = True
     exclude_trusts: bool = True
-    
+
     # Quality gates
     min_confidence_score: float = 0.70
     fuzzy_match_threshold: int = 80
@@ -66,13 +67,13 @@ class DiscoveryRecord:
     business_name: str
     abn: str = None
     acn: str = None
-    
+
     # ABN Registry fields
     legal_name: str = None
     entity_type: str = None
     gst_registered: bool = False
     state: str = None
-    
+
     # Google Maps/GMB fields
     gmb_place_id: str = None
     phone: str = None
@@ -81,7 +82,7 @@ class DiscoveryRecord:
     rating: float = None
     reviews_count: int = None
     category: str = None
-    
+
     # Discovery metadata
     discovery_source: str = None  # "abn_api", "google_maps", "both"
     confidence_score: float = 0.0
@@ -90,14 +91,14 @@ class DiscoveryRecord:
 
 class ABNFirstDiscovery:
     """Mode A: Query ABN API first, then enrich with external data"""
-    
+
     def __init__(self, abn_client=None):
         """Initialize with ABN client dependency"""
         self.abn_client = abn_client
         if not abn_client:
             logger.warning("ABNFirstDiscovery: No ABN client provided - will fail at runtime")
-    
-    async def discover(self, config: CampaignConfig) -> List[DiscoveryRecord]:
+
+    async def discover(self, config: CampaignConfig) -> list[DiscoveryRecord]:
         """
         Discovery flow for Mode A:
         1. Build ABN search query from campaign config
@@ -106,27 +107,27 @@ class ABNFirstDiscovery:
         4. Return qualified ABN records for enrichment
         """
         logger.info(f"Starting ABN-first discovery for industry='{config.industry}', location='{config.location}'")
-        
+
         try:
             # Build search query for ABN API
             search_query = self._build_abn_search_query(config)
-            
+
             # Query ABN API
             abn_results = await self._query_abn_api(search_query, config)
-            
+
             # Apply hard filters
             filtered_results = self._apply_abn_filters(abn_results, config)
-            
+
             # Convert to unified format
             discovery_records = self._convert_abn_to_records(filtered_results)
-            
+
             logger.info(f"ABN-first discovery completed: {len(discovery_records)} qualified records")
             return discovery_records
-            
+
         except Exception as e:
             logger.error(f"ABN-first discovery failed: {str(e)}")
             return []
-    
+
     def _build_abn_search_query(self, config: CampaignConfig) -> dict:
         """Build ABN API search parameters"""
         query = {
@@ -135,54 +136,54 @@ class ABNFirstDiscovery:
             "state": config.state,
             "isCurrentIndicator": "Y" if config.abn_only_active else None,
         }
-        
+
         # Extract postcode from location if format is "City, State Postcode"
         if config.location and any(char.isdigit() for char in config.location):
             parts = config.location.split()
             if len(parts) > 0 and parts[-1].isdigit():
                 query["postcode"] = parts[-1]
-        
+
         return {k: v for k, v in query.items() if v is not None}
-    
-    async def _query_abn_api(self, query: dict, config: CampaignConfig) -> List[dict]:
+
+    async def _query_abn_api(self, query: dict, config: CampaignConfig) -> list[dict]:
         """Query ABN API with search parameters"""
         if not self.abn_client:
             raise ValueError("ABN client not configured")
-        
+
         # Call ABN API SearchByNameAdvanced2017
         # This would integrate with existing abn_client.py
         results = await self.abn_client.search_by_name_advanced(
             **query,
             max_results=config.max_results
         )
-        
+
         return results or []
-    
-    def _apply_abn_filters(self, results: List[dict], config: CampaignConfig) -> List[dict]:
+
+    def _apply_abn_filters(self, results: list[dict], config: CampaignConfig) -> list[dict]:
         """Apply hard filters to ABN results"""
         filtered = []
-        
+
         for record in results:
             # Filter out trusts if configured
             if config.exclude_trusts and record.get("entityType", "").upper() in ["TRUST"]:
                 continue
-            
+
             # Filter GST registration if configured
             if config.abn_only_gst and not record.get("gstRegistered", False):
                 continue
-            
+
             # Filter cancelled ABNs
             if record.get("abnStatus", "").upper() in ["CANCELLED", "INACTIVE"]:
                 continue
-            
+
             filtered.append(record)
-        
+
         return filtered
-    
-    def _convert_abn_to_records(self, abn_results: List[dict]) -> List[DiscoveryRecord]:
+
+    def _convert_abn_to_records(self, abn_results: list[dict]) -> list[DiscoveryRecord]:
         """Convert ABN API results to unified DiscoveryRecord format"""
         records = []
-        
+
         for result in abn_results:
             record = DiscoveryRecord(
                 business_name=result.get("businessName", "").strip(),
@@ -196,24 +197,24 @@ class ABNFirstDiscovery:
                 confidence_score=0.85,  # ABN API is high-confidence
                 discovered_at=result.get("timestamp") or "now"
             )
-            
+
             records.append(record)
-        
+
         return records
 
 
 class MapsFirstDiscovery:
     """Mode B: Query Google Maps first, then verify with ABN"""
-    
+
     def __init__(self, bright_data_client=None, abn_client=None):
         """Initialize with Bright Data and ABN clients"""
         self.bd = bright_data_client
         self.abn_client = abn_client
-        
+
         if not bright_data_client:
             logger.warning("MapsFirstDiscovery: No Bright Data client provided - will fail at runtime")
-    
-    async def discover(self, config: CampaignConfig) -> List[DiscoveryRecord]:
+
+    async def discover(self, config: CampaignConfig) -> list[DiscoveryRecord]:
         """
         Discovery flow for Mode B:
         1. Search Google Maps via SERP API (Bright Data)
@@ -221,29 +222,29 @@ class MapsFirstDiscovery:
         3. Return records with GMB data + ABN verification where possible
         """
         logger.info(f"Starting Maps-first discovery for industry='{config.industry}', location='{config.location}'")
-        
+
         try:
             # Search Google Maps
             gmb_results = await self._search_google_maps(config)
-            
+
             # Verify with ABN API
             verified_records = await self._verify_with_abn(gmb_results, config)
-            
+
             logger.info(f"Maps-first discovery completed: {len(verified_records)} records")
             return verified_records
-            
+
         except Exception as e:
             logger.error(f"Maps-first discovery failed: {str(e)}")
             return []
-    
-    async def _search_google_maps(self, config: CampaignConfig) -> List[dict]:
+
+    async def _search_google_maps(self, config: CampaignConfig) -> list[dict]:
         """Search Google Maps via Bright Data SERP API"""
         if not self.bd:
             raise ValueError("Bright Data client not configured")
-        
+
         # Build search query for Google Maps
         search_query = f"{config.industry} {config.location}"
-        
+
         # Use Bright Data Google Maps dataset
         # Dataset ID: gd_m8ebnr0q2qlklc02fz (from inventory)
         results = await self.bd.search_google_maps(
@@ -251,47 +252,47 @@ class MapsFirstDiscovery:
             location=config.location,
             max_results=config.max_results
         )
-        
+
         return results or []
-    
-    async def _verify_with_abn(self, gmb_results: List[dict], config: CampaignConfig) -> List[DiscoveryRecord]:
+
+    async def _verify_with_abn(self, gmb_results: list[dict], config: CampaignConfig) -> list[DiscoveryRecord]:
         """Verify GMB results with ABN API lookups"""
         verified_records = []
-        
+
         for gmb_result in gmb_results:
             business_name = gmb_result.get("name", "").strip()
-            
+
             if not business_name:
                 continue
-            
+
             # Attempt ABN lookup
             abn_match = await self._lookup_abn_by_name(business_name, config)
-            
+
             # Create record with GMB data + ABN verification
             record = self._create_verified_record(gmb_result, abn_match)
-            
+
             # Apply confidence scoring
             record.confidence_score = self._calculate_confidence(gmb_result, abn_match)
-            
+
             if record.confidence_score >= config.min_confidence_score:
                 verified_records.append(record)
-        
+
         return verified_records
-    
-    async def _lookup_abn_by_name(self, business_name: str, config: CampaignConfig) -> Optional[dict]:
+
+    async def _lookup_abn_by_name(self, business_name: str, config: CampaignConfig) -> dict | None:
         """Lookup ABN by business name"""
         if not self.abn_client:
             return None
-        
+
         try:
             search_params = {
                 "name": business_name,
                 "state": config.state,
                 "isCurrentIndicator": "Y"
             }
-            
+
             results = await self.abn_client.search_by_name_advanced(**search_params)
-            
+
             # Return best match based on name similarity
             if results:
                 for result in results:
@@ -301,14 +302,14 @@ class MapsFirstDiscovery:
                     )
                     if similarity >= config.fuzzy_match_threshold:
                         return result
-            
+
             return None
-            
+
         except Exception as e:
             logger.warning(f"ABN lookup failed for '{business_name}': {str(e)}")
             return None
-    
-    def _create_verified_record(self, gmb_result: dict, abn_match: Optional[dict]) -> DiscoveryRecord:
+
+    def _create_verified_record(self, gmb_result: dict, abn_match: dict | None) -> DiscoveryRecord:
         """Create unified record from GMB + ABN data"""
         record = DiscoveryRecord(
             business_name=gmb_result.get("name", "").strip(),
@@ -322,7 +323,7 @@ class MapsFirstDiscovery:
             discovery_source="google_maps",
             discovered_at="now"
         )
-        
+
         # Add ABN data if verified
         if abn_match:
             record.abn = abn_match.get("abn", "")
@@ -332,13 +333,13 @@ class MapsFirstDiscovery:
             record.gst_registered = abn_match.get("gstRegistered", False)
             record.state = abn_match.get("state", "")
             record.discovery_source = "both"
-        
+
         return record
-    
-    def _calculate_confidence(self, gmb_result: dict, abn_match: Optional[dict]) -> float:
+
+    def _calculate_confidence(self, gmb_result: dict, abn_match: dict | None) -> float:
         """Calculate confidence score for the record"""
         score = 0.0
-        
+
         # Base GMB confidence
         if gmb_result.get("name"):
             score += 0.3
@@ -348,19 +349,19 @@ class MapsFirstDiscovery:
             score += 0.2
         if gmb_result.get("address"):
             score += 0.1
-        
+
         # ABN verification bonus
         if abn_match:
             score += 0.3
             if abn_match.get("gstRegistered"):
                 score += 0.1
-        
+
         return min(score, 1.0)
 
 
 class ParallelDiscovery:
     """Mode C: Run both modes in parallel, deduplicate on ABN + fuzzy name match"""
-    
+
     def __init__(self, abn_client=None, bright_data_client=None):
         """Initialize with both discovery modes"""
         self.abn_discovery = ABNFirstDiscovery(abn_client=abn_client)
@@ -368,8 +369,8 @@ class ParallelDiscovery:
             bright_data_client=bright_data_client,
             abn_client=abn_client
         )
-    
-    async def discover(self, config: CampaignConfig) -> List[DiscoveryRecord]:
+
+    async def discover(self, config: CampaignConfig) -> list[DiscoveryRecord]:
         """
         Discovery flow for Mode C:
         1. Run both ABN-first and Maps-first in parallel
@@ -377,42 +378,42 @@ class ParallelDiscovery:
         3. Return merged records with highest confidence scores
         """
         logger.info(f"Starting parallel discovery for industry='{config.industry}', location='{config.location}'")
-        
+
         try:
             # Run both discovery modes in parallel
             abn_task = asyncio.create_task(self.abn_discovery.discover(config))
             maps_task = asyncio.create_task(self.maps_discovery.discover(config))
-            
+
             abn_results, maps_results = await asyncio.gather(abn_task, maps_task)
-            
+
             # Deduplicate and merge
             merged_records = self._deduplicate_and_merge(abn_results, maps_results, config)
-            
+
             logger.info(f"Parallel discovery completed: {len(merged_records)} deduplicated records")
             return merged_records
-            
+
         except Exception as e:
             logger.error(f"Parallel discovery failed: {str(e)}")
             return []
-    
+
     def _deduplicate_and_merge(
-        self, 
-        abn_results: List[DiscoveryRecord], 
-        maps_results: List[DiscoveryRecord],
+        self,
+        abn_results: list[DiscoveryRecord],
+        maps_results: list[DiscoveryRecord],
         config: CampaignConfig
-    ) -> List[DiscoveryRecord]:
+    ) -> list[DiscoveryRecord]:
         """Deduplicate records on ABN + fuzzy name matching"""
         merged = {}
-        
+
         # Process ABN results first (higher confidence for business data)
         for record in abn_results:
             key = self._generate_dedup_key(record, config)
             merged[key] = record
-        
+
         # Process Maps results, merging with ABN data where possible
         for record in maps_results:
             key = self._generate_dedup_key(record, config)
-            
+
             if key in merged:
                 # Merge GMB data into existing ABN record
                 existing = merged[key]
@@ -420,29 +421,29 @@ class ParallelDiscovery:
             else:
                 # Add new Maps-only record
                 merged[key] = record
-        
+
         return list(merged.values())
-    
+
     def _generate_dedup_key(self, record: DiscoveryRecord, config: CampaignConfig) -> str:
         """Generate deduplication key for record matching"""
         # Use ABN as primary key if available
         if record.abn and record.abn.strip():
             return f"abn_{record.abn.strip()}"
-        
+
         # Fall back to fuzzy business name matching
         clean_name = record.business_name.lower().strip()
         # Remove common business suffixes for better matching
         suffixes = ["pty ltd", "pty. ltd.", "proprietary limited", "limited", "ltd", "corp", "inc"]
         for suffix in suffixes:
             clean_name = clean_name.replace(suffix, "").strip()
-        
+
         return f"name_{clean_name}"
-    
+
     def _merge_records(self, abn_record: DiscoveryRecord, maps_record: DiscoveryRecord) -> DiscoveryRecord:
         """Merge ABN and Maps records, preferring non-empty values"""
         # Start with ABN record as base
         merged = abn_record
-        
+
         # Add GMB-specific fields from Maps record
         if not merged.phone and maps_record.phone:
             merged.phone = maps_record.phone
@@ -458,9 +459,9 @@ class ParallelDiscovery:
             merged.category = maps_record.category
         if maps_record.gmb_place_id:
             merged.gmb_place_id = maps_record.gmb_place_id
-        
+
         # Update metadata
         merged.discovery_source = "both"
         merged.confidence_score = max(abn_record.confidence_score, maps_record.confidence_score)
-        
+
         return merged

--- a/src/enrichment/waterfall_v2.py
+++ b/src/enrichment/waterfall_v2.py
@@ -34,20 +34,18 @@ Created: 2026-02-16 by subagent (CEO Directive #023)
 
 from __future__ import annotations
 
-import asyncio
-import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import List, Dict, Optional, Any
+from datetime import UTC, datetime
+
 import structlog
 
 from src.enrichment.discovery_modes import (
-    DiscoveryMode, 
-    CampaignConfig, 
-    DiscoveryRecord,
     ABNFirstDiscovery,
-    MapsFirstDiscovery, 
-    ParallelDiscovery
+    CampaignConfig,
+    DiscoveryMode,
+    DiscoveryRecord,
+    MapsFirstDiscovery,
+    ParallelDiscovery,
 )
 
 logger = structlog.get_logger()
@@ -56,19 +54,19 @@ logger = structlog.get_logger()
 @dataclass
 class LeadRecord:
     """Unified lead record through the waterfall pipeline"""
-    
+
     # Core identifiers
     id: str = None
     abn: str = None
     business_name: str = None
     legal_name: str = None
-    
+
     # ABN Registry fields (Tier 1)
     gst_registered: bool = False
     entity_type: str = None
     state: str = None
     acn: str = None
-    
+
     # GMB fields (Tier 1.5a)
     phone: str = None
     website: str = None
@@ -77,42 +75,42 @@ class LeadRecord:
     reviews_count: int = None
     category: str = None
     gmb_place_id: str = None
-    
+
     # LinkedIn Company fields (Tier 1.5b + 2)
     linkedin_company_url: str = None
     linkedin_data: dict = field(default_factory=dict)
-    employees: List[dict] = field(default_factory=list)
-    decision_makers: List[dict] = field(default_factory=list)
+    employees: list[dict] = field(default_factory=list)
+    decision_makers: list[dict] = field(default_factory=list)
     company_size: str = None
     industry: str = None
     founded: int = None
     headquarters: str = None
     specialties: str = None
-    
+
     # Contact enrichment fields (Tier 2.5 + 3)
     email: str = None
     email_confidence: float = None
     direct_mobile: str = None
     contact_source: str = None
-    
+
     # Kaspr Premium fields (Tier 5)
     kaspr_data: dict = field(default_factory=dict)
-    verified_contacts: List[dict] = field(default_factory=list)
-    
+    verified_contacts: list[dict] = field(default_factory=list)
+
     # Scoring and quality
     als_score: int = 0
     als_breakdown: dict = field(default_factory=dict)
     confidence_score: float = 0.0
-    
+
     # Tracking and metadata
-    enrichment_tiers_completed: List[str] = field(default_factory=list)
+    enrichment_tiers_completed: list[str] = field(default_factory=list)
     cost_aud: float = 0.0
     discovery_source: str = None
-    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
-    updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
-    
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
     # Error tracking
-    enrichment_errors: List[dict] = field(default_factory=list)
+    enrichment_errors: list[dict] = field(default_factory=list)
 
 
 class WaterfallV2:
@@ -127,25 +125,25 @@ class WaterfallV2:
     - PRE_ALS_GATE: Minimum score to continue past Tier 2 (cost control)
     - HOT_THRESHOLD: Minimum score for Tier 5 Kaspr enrichment (premium leads only)
     """
-    
+
     PRE_ALS_GATE = 30      # Minimum score to continue past Tier 2
     HOT_THRESHOLD = 85     # Minimum for Tier 5 (Kaspr)
-    
+
     # Cost constants (AUD)
     COSTS = {
         "serp_maps": 0.0015,
-        "serp_linkedin": 0.0015, 
+        "serp_linkedin": 0.0015,
         "linkedin_company": 0.0015,
         "linkedin_people": 0.0015,
         "hunter_email": 0.012,
         "kaspr_contact": 0.45
     }
-    
+
     def __init__(
-        self, 
+        self,
         bright_data_client=None,
-        abn_client=None, 
-        hunter_client=None, 
+        abn_client=None,
+        hunter_client=None,
         kaspr_client=None
     ):
         """Initialize waterfall with all integration clients"""
@@ -153,7 +151,7 @@ class WaterfallV2:
         self.abn_client = abn_client
         self.hunter = hunter_client
         self.kaspr = kaspr_client
-        
+
         # Initialize discovery engines
         self.abn_discovery = ABNFirstDiscovery(abn_client=abn_client)
         self.maps_discovery = MapsFirstDiscovery(
@@ -164,13 +162,13 @@ class WaterfallV2:
             abn_client=abn_client,
             bright_data_client=bright_data_client
         )
-    
+
     # PHASE 1: DISCOVERY
-    
-    async def run_discovery(self, config: CampaignConfig) -> List[LeadRecord]:
+
+    async def run_discovery(self, config: CampaignConfig) -> list[LeadRecord]:
         """PHASE 1: Run discovery mode based on campaign config"""
         logger.info(f"Phase 1: Starting discovery with mode={config.mode.value}")
-        
+
         try:
             # Select discovery engine based on mode
             if config.mode == DiscoveryMode.ABN_FIRST:
@@ -181,20 +179,20 @@ class WaterfallV2:
                 discovery_records = await self.parallel_discovery.discover(config)
             else:
                 raise ValueError(f"Unknown discovery mode: {config.mode}")
-            
+
             # Convert DiscoveryRecord to LeadRecord
             leads = []
             for record in discovery_records:
                 lead = self._convert_discovery_to_lead(record)
                 leads.append(lead)
-            
+
             logger.info(f"Phase 1 completed: {len(leads)} leads discovered")
             return leads
-            
+
         except Exception as e:
             logger.error(f"Phase 1 discovery failed: {str(e)}")
             return []
-    
+
     def _convert_discovery_to_lead(self, record: DiscoveryRecord) -> LeadRecord:
         """Convert DiscoveryRecord to LeadRecord for enrichment pipeline"""
         lead = LeadRecord(
@@ -215,33 +213,30 @@ class WaterfallV2:
             confidence_score=record.confidence_score,
             discovery_source=record.discovery_source
         )
-        
+
         # Set initial tiers as completed based on discovery source
         if record.discovery_source == "abn_api":
             lead.enrichment_tiers_completed = ["tier_1"]
-        elif record.discovery_source == "google_maps":
+        elif record.discovery_source == "google_maps" or record.discovery_source == "both":
             lead.enrichment_tiers_completed = ["tier_1", "tier_1_5a"]
             lead.cost_aud += self.COSTS["serp_maps"]
-        elif record.discovery_source == "both":
-            lead.enrichment_tiers_completed = ["tier_1", "tier_1_5a"]
-            lead.cost_aud += self.COSTS["serp_maps"]
-        
+
         return lead
-    
+
     # PHASE 2: ENRICHMENT TIERS
-    
+
     async def enrich_tier_1(self, lead: LeadRecord) -> LeadRecord:
         """Tier 1: ABN API - FREE - Always runs (if not from discovery)"""
         if "tier_1" in lead.enrichment_tiers_completed:
             logger.debug(f"Tier 1 already completed for {lead.id}")
             return lead
-        
+
         logger.debug(f"Tier 1: ABN enrichment for {lead.business_name}")
-        
+
         try:
             if not self.abn_client:
                 raise ValueError("ABN client not configured")
-            
+
             # Search ABN by business name if no ABN
             if not lead.abn and lead.business_name:
                 abn_results = await self.abn_client.search_by_name_advanced(
@@ -249,7 +244,7 @@ class WaterfallV2:
                     state=lead.state,
                     isCurrentIndicator="Y"
                 )
-                
+
                 if abn_results:
                     best_match = abn_results[0]  # Take first result for now
                     lead.abn = best_match.get("abn")
@@ -257,44 +252,44 @@ class WaterfallV2:
                     lead.gst_registered = best_match.get("gstRegistered", False)
                     lead.entity_type = best_match.get("entityType")
                     lead.state = best_match.get("state")
-            
+
             lead.enrichment_tiers_completed.append("tier_1")
             logger.debug(f"Tier 1 completed for {lead.id}")
-            
+
         except Exception as e:
-            error = {"tier": "tier_1", "error": str(e), "timestamp": datetime.now(timezone.utc).isoformat()}
+            error = {"tier": "tier_1", "error": str(e), "timestamp": datetime.now(UTC).isoformat()}
             lead.enrichment_errors.append(error)
             logger.warning(f"Tier 1 failed for {lead.id}: {str(e)}")
-        
+
         return lead
-    
+
     async def enrich_tier_1_5a(self, lead: LeadRecord) -> LeadRecord:
         """Tier 1.5a: SERP Google Maps - $0.0015 - If missing phone/website"""
         if "tier_1_5a" in lead.enrichment_tiers_completed:
             return lead
-        
+
         # Skip if we already have phone and website
         if lead.phone and lead.website:
             lead.enrichment_tiers_completed.append("tier_1_5a")
             return lead
-        
+
         logger.debug(f"Tier 1.5a: Google Maps enrichment for {lead.business_name}")
-        
+
         try:
             if not self.bd:
                 raise ValueError("Bright Data client not configured")
-            
+
             # Search Google Maps for business
             search_query = f"{lead.business_name} {lead.address or lead.state or ''}"
             gmb_results = await self.bd.search_google_maps(
                 query=search_query.strip(),
                 max_results=5
             )
-            
+
             if gmb_results:
                 # Take best match (first result for now)
                 gmb_data = gmb_results[0]
-                
+
                 # Fill missing fields
                 if not lead.phone:
                     lead.phone = gmb_data.get("phone")
@@ -310,37 +305,37 @@ class WaterfallV2:
                     lead.category = gmb_data.get("category")
                 if not lead.gmb_place_id:
                     lead.gmb_place_id = gmb_data.get("place_id")
-            
+
             lead.enrichment_tiers_completed.append("tier_1_5a")
             lead.cost_aud += self.COSTS["serp_maps"]
             logger.debug(f"Tier 1.5a completed for {lead.id}")
-            
+
         except Exception as e:
-            error = {"tier": "tier_1_5a", "error": str(e), "timestamp": datetime.now(timezone.utc).isoformat()}
+            error = {"tier": "tier_1_5a", "error": str(e), "timestamp": datetime.now(UTC).isoformat()}
             lead.enrichment_errors.append(error)
             logger.warning(f"Tier 1.5a failed for {lead.id}: {str(e)}")
-        
+
         return lead
-    
+
     async def enrich_tier_1_5b(self, lead: LeadRecord) -> LeadRecord:
         """Tier 1.5b: SERP Google LinkedIn Discovery - $0.0015 - Find LinkedIn URL"""
         if "tier_1_5b" in lead.enrichment_tiers_completed:
             return lead
-        
+
         logger.debug(f"Tier 1.5b: LinkedIn URL discovery for {lead.business_name}")
-        
+
         try:
             if not self.bd:
                 raise ValueError("Bright Data client not configured")
-            
+
             # Search LinkedIn company URL via SERP
             search_query = f'site:linkedin.com/company "{lead.business_name}" {lead.address or lead.state or ""}'
-            
+
             serp_results = await self.bd.search_google(
                 query=search_query.strip(),
                 max_results=10
             )
-            
+
             if serp_results:
                 # Find LinkedIn company URL in results
                 for result in serp_results:
@@ -348,92 +343,92 @@ class WaterfallV2:
                     if "linkedin.com/company/" in url and not url.endswith("/jobs"):
                         lead.linkedin_company_url = url
                         break
-            
+
             lead.enrichment_tiers_completed.append("tier_1_5b")
             lead.cost_aud += self.COSTS["serp_linkedin"]
             logger.debug(f"Tier 1.5b completed for {lead.id}")
-            
+
         except Exception as e:
-            error = {"tier": "tier_1_5b", "error": str(e), "timestamp": datetime.now(timezone.utc).isoformat()}
+            error = {"tier": "tier_1_5b", "error": str(e), "timestamp": datetime.now(UTC).isoformat()}
             lead.enrichment_errors.append(error)
             logger.warning(f"Tier 1.5b failed for {lead.id}: {str(e)}")
-        
+
         return lead
-    
+
     async def enrich_tier_2(self, lead: LeadRecord) -> LeadRecord:
         """Tier 2: LinkedIn Company Scraper - $0.0015 - If LinkedIn URL found"""
         if "tier_2" in lead.enrichment_tiers_completed:
             return lead
-        
+
         if not lead.linkedin_company_url:
             # Skip tier 2 if no LinkedIn URL found
             lead.enrichment_tiers_completed.append("tier_2")
             return lead
-        
+
         logger.debug(f"Tier 2: LinkedIn company scraping for {lead.business_name}")
-        
+
         try:
             if not self.bd:
                 raise ValueError("Bright Data client not configured")
-            
+
             # Scrape LinkedIn company page
             linkedin_data = await self.bd.scrape_linkedin_company(lead.linkedin_company_url)
-            
+
             if linkedin_data:
                 lead.linkedin_data = linkedin_data
-                
+
                 # Extract key fields
                 lead.company_size = linkedin_data.get("company_size")
                 lead.industry = linkedin_data.get("industries")
                 lead.founded = linkedin_data.get("founded")
                 lead.headquarters = linkedin_data.get("headquarters")
                 lead.specialties = linkedin_data.get("specialties")
-                
+
                 # Extract employee data for decision makers
                 employees = linkedin_data.get("employees", [])
                 if employees:
                     lead.employees = employees
                     # Filter for decision makers (C-level, VP, Director, Manager)
                     lead.decision_makers = self._extract_decision_makers(employees)
-            
+
             lead.enrichment_tiers_completed.append("tier_2")
             lead.cost_aud += self.COSTS["linkedin_company"]
             logger.debug(f"Tier 2 completed for {lead.id}")
-            
+
         except Exception as e:
-            error = {"tier": "tier_2", "error": str(e), "timestamp": datetime.now(timezone.utc).isoformat()}
+            error = {"tier": "tier_2", "error": str(e), "timestamp": datetime.now(UTC).isoformat()}
             lead.enrichment_errors.append(error)
             logger.warning(f"Tier 2 failed for {lead.id}: {str(e)}")
-        
+
         return lead
-    
-    def _extract_decision_makers(self, employees: List[dict]) -> List[dict]:
+
+    def _extract_decision_makers(self, employees: list[dict]) -> list[dict]:
         """Extract decision makers from employee list"""
         decision_makers = []
         decision_keywords = [
             "ceo", "cto", "cfo", "cmo", "coo", "chief", "president", "founder",
             "vp", "vice president", "director", "head of", "manager"
         ]
-        
+
         for employee in employees:
             title = employee.get("title", "").lower()
             if any(keyword in title for keyword in decision_keywords):
                 decision_makers.append(employee)
-        
+
         return decision_makers[:5]  # Limit to top 5
-    
+
     # PHASE 3: SCORING AND QUALITY GATES
-    
+
     def calculate_als(self, lead: LeadRecord) -> int:
         """Calculate Agency Lead Score (0-100)"""
         score_breakdown = {
             "company_fit": 0,      # 25 pts max
-            "authority": 0,        # 25 pts max  
+            "authority": 0,        # 25 pts max
             "timing": 0,          # 15 pts max
             "data_quality": 0,    # 20 pts max
             "engagement": 0       # 15 pts max
         }
-        
+
         # Company Fit (25 points)
         if lead.industry:
             score_breakdown["company_fit"] += 10
@@ -441,22 +436,22 @@ class WaterfallV2:
             score_breakdown["company_fit"] += 10  # Sweet spot for agencies
         if lead.specialties:
             score_breakdown["company_fit"] += 5
-        
+
         # Authority (25 points)
         if lead.decision_makers:
             score_breakdown["authority"] += min(len(lead.decision_makers) * 5, 15)
             # Bonus for C-level contacts
             c_level = sum(1 for dm in lead.decision_makers if any(
-                keyword in dm.get("title", "").lower() 
+                keyword in dm.get("title", "").lower()
                 for keyword in ["ceo", "cto", "cfo", "cmo", "chief", "founder"]
             ))
             score_breakdown["authority"] += min(c_level * 5, 10)
-        
+
         # Timing (15 points) - Based on recent activity signals
         if lead.linkedin_data.get("updates"):
             recent_updates = len(lead.linkedin_data["updates"])
             score_breakdown["timing"] += min(recent_updates * 2, 10)
-            
+
             # Hiring signal detection - bonus 5 points for active growth
             for update in lead.linkedin_data["updates"]:
                 update_text = (update.get("text") or "").lower()
@@ -464,16 +459,16 @@ class WaterfallV2:
                     score_breakdown["timing"] += 5  # Active hiring = growth signal
                     logger.debug("hiring_signal_detected", lead_id=lead.id)
                     break  # Only count once
-        
+
         if lead.founded and lead.founded >= datetime.now().year - 2:
             score_breakdown["timing"] += 5  # New companies often need services
-        
+
         # Data Quality (20 points) - Based on verified sources
         verified_sources = len(lead.enrichment_tiers_completed)
         score_breakdown["data_quality"] += min(verified_sources * 3, 15)
         if lead.email:
             score_breakdown["data_quality"] += 5
-        
+
         # Engagement Potential (15 points)
         if lead.website:
             score_breakdown["engagement"] += 5
@@ -483,38 +478,38 @@ class WaterfallV2:
             score_breakdown["engagement"] += 3
         if lead.reviews_count and lead.reviews_count >= 10:
             score_breakdown["engagement"] += 2
-        
+
         total_score = sum(score_breakdown.values())
         lead.als_breakdown = score_breakdown
-        
+
         logger.debug(f"ALS calculated for {lead.id}: {total_score} (breakdown: {score_breakdown})")
         return total_score
-    
+
     # PREMIUM ENRICHMENT TIERS (WITH GATES)
-    
+
     async def enrich_tier_2_5(self, lead: LeadRecord) -> LeadRecord:
         """Tier 2.5: LinkedIn People Profile - $0.0015 - Only if ALS >= 30"""
         if "tier_2_5" in lead.enrichment_tiers_completed:
             return lead
-        
+
         if lead.als_score < self.PRE_ALS_GATE:
             logger.debug(f"Tier 2.5 skipped for {lead.id} - ALS score {lead.als_score} below gate {self.PRE_ALS_GATE}")
             return lead
-        
+
         if not lead.decision_makers:
             # Skip if no decision makers found
             lead.enrichment_tiers_completed.append("tier_2_5")
             return lead
-        
+
         logger.debug(f"Tier 2.5: LinkedIn people profiles for {lead.business_name}")
-        
+
         try:
             if not self.bd:
                 raise ValueError("Bright Data client not configured")
-            
+
             # Enrich decision maker profiles
             enriched_decision_makers = []
-            
+
             for dm in lead.decision_makers[:3]:  # Limit to top 3 to control costs
                 profile_url = dm.get("link")
                 if profile_url:
@@ -522,47 +517,47 @@ class WaterfallV2:
                     if profile_data:
                         dm.update(profile_data)
                         enriched_decision_makers.append(dm)
-            
+
             if enriched_decision_makers:
                 lead.decision_makers = enriched_decision_makers
-            
+
             lead.enrichment_tiers_completed.append("tier_2_5")
             lead.cost_aud += self.COSTS["linkedin_people"]
             logger.debug(f"Tier 2.5 completed for {lead.id}")
-            
+
         except Exception as e:
-            error = {"tier": "tier_2_5", "error": str(e), "timestamp": datetime.now(timezone.utc).isoformat()}
+            error = {"tier": "tier_2_5", "error": str(e), "timestamp": datetime.now(UTC).isoformat()}
             lead.enrichment_errors.append(error)
             logger.warning(f"Tier 2.5 failed for {lead.id}: {str(e)}")
-        
+
         return lead
-    
+
     async def enrich_tier_3(self, lead: LeadRecord) -> LeadRecord:
         """Tier 3: Hunter.io Email - $0.012 - Only if ALS >= 30"""
         if "tier_3" in lead.enrichment_tiers_completed:
             return lead
-        
+
         if lead.als_score < self.PRE_ALS_GATE:
             logger.debug(f"Tier 3 skipped for {lead.id} - ALS score {lead.als_score} below gate {self.PRE_ALS_GATE}")
             return lead
-        
+
         if not lead.website:
             # Skip if no website for domain extraction
             lead.enrichment_tiers_completed.append("tier_3")
             return lead
-        
+
         logger.debug(f"Tier 3: Hunter.io email enrichment for {lead.business_name}")
-        
+
         try:
             if not self.hunter:
                 raise ValueError("Hunter.io client not configured")
-            
+
             # Extract domain from website
             domain = self._extract_domain(lead.website)
             if domain:
                 # Find email addresses for domain
                 email_results = await self.hunter.domain_search(domain)
-                
+
                 if email_results and email_results.get("emails"):
                     # Find best email (decision maker or generic contact)
                     best_email = self._select_best_email(email_results["emails"], lead.decision_makers)
@@ -570,94 +565,93 @@ class WaterfallV2:
                         lead.email = best_email.get("value")
                         lead.email_confidence = best_email.get("confidence", 0) / 100.0
                         lead.contact_source = "hunter"
-            
+
             lead.enrichment_tiers_completed.append("tier_3")
             lead.cost_aud += self.COSTS["hunter_email"]
             logger.debug(f"Tier 3 completed for {lead.id}")
-            
+
         except Exception as e:
-            error = {"tier": "tier_3", "error": str(e), "timestamp": datetime.now(timezone.utc).isoformat()}
+            error = {"tier": "tier_3", "error": str(e), "timestamp": datetime.now(UTC).isoformat()}
             lead.enrichment_errors.append(error)
             logger.warning(f"Tier 3 failed for {lead.id}: {str(e)}")
-        
+
         return lead
-    
-    def _extract_domain(self, website: str) -> Optional[str]:
+
+    def _extract_domain(self, website: str) -> str | None:
         """Extract domain from website URL"""
         if not website:
             return None
-        
+
         # Clean up URL
         domain = website.lower().strip()
         if domain.startswith("http://"):
             domain = domain[7:]
         elif domain.startswith("https://"):
             domain = domain[8:]
-        
+
         # Remove www prefix
         if domain.startswith("www."):
             domain = domain[4:]
-        
+
         # Remove path and parameters
         domain = domain.split("/")[0].split("?")[0]
-        
+
         return domain if "." in domain else None
-    
-    def _select_best_email(self, emails: List[dict], decision_makers: List[dict]) -> Optional[dict]:
+
+    def _select_best_email(self, emails: list[dict], decision_makers: list[dict]) -> dict | None:
         """Select best email from Hunter results"""
         if not emails:
             return None
-        
+
         # Sort by confidence score first
         emails_sorted = sorted(emails, key=lambda e: e.get("confidence", 0), reverse=True)
-        
+
         # If we have decision makers, try to match emails
         if decision_makers:
             dm_names = [dm.get("name", "").lower() for dm in decision_makers if dm.get("name")]
-            
+
             for email in emails_sorted:
-                email_address = email.get("value", "").lower()
                 first_name = email.get("first_name", "").lower()
                 last_name = email.get("last_name", "").lower()
-                
+
                 # Check if email matches any decision maker
                 full_name = f"{first_name} {last_name}".strip()
                 if any(name in full_name or full_name in name for name in dm_names if name):
                     return email
-        
+
         # Fall back to highest confidence email
         return emails_sorted[0]
-    
+
     async def enrich_tier_5(self, lead: LeadRecord) -> LeadRecord:
         """Tier 5: Kaspr Direct Contact - $0.45 - Only if ALS >= 85"""
         if "tier_5" in lead.enrichment_tiers_completed:
             return lead
-        
+
         if lead.als_score < self.HOT_THRESHOLD:
             logger.debug(f"Tier 5 skipped for {lead.id} - ALS score {lead.als_score} below hot threshold {self.HOT_THRESHOLD}")
             return lead
-        
+
         if not lead.decision_makers:
             # Skip if no decision makers to enrich
             lead.enrichment_tiers_completed.append("tier_5")
             return lead
-        
+
         logger.debug(f"Tier 5: Kaspr premium contact enrichment for {lead.business_name}")
-        
+
         try:
             if not self.kaspr:
                 raise ValueError("Kaspr client not configured")
-            
+
             # Enrich top decision makers with Kaspr
             verified_contacts = []
-            
-            for dm in lead.decision_makers[:2]:  # Limit to top 2 to control costs  
+
+            for dm in lead.decision_makers[:2]:  # Limit to top 2 to control costs
                 linkedin_url = dm.get("link")
                 if linkedin_url:
                     kaspr_data = await self.kaspr.enrich_identity(linkedin_url)
                     if kaspr_data:
                         verified_contacts.append(kaspr_data)
-                        
+
                         # Update lead with best contact info
                         if not lead.direct_mobile and kaspr_data.get("mobile"):
                             lead.direct_mobile = kaspr_data["mobile"]
@@ -665,96 +659,96 @@ class WaterfallV2:
                             lead.email = kaspr_data["email"]
                             lead.email_confidence = 0.95  # Kaspr is high confidence
                             lead.contact_source = "kaspr"
-            
+
             if verified_contacts:
                 lead.verified_contacts = verified_contacts
                 lead.kaspr_data = {
                     "contacts_enriched": len(verified_contacts),
-                    "enrichment_timestamp": datetime.now(timezone.utc).isoformat()
+                    "enrichment_timestamp": datetime.now(UTC).isoformat()
                 }
-            
+
             lead.enrichment_tiers_completed.append("tier_5")
             lead.cost_aud += self.COSTS["kaspr_contact"]
             logger.debug(f"Tier 5 completed for {lead.id}")
-            
+
         except Exception as e:
-            error = {"tier": "tier_5", "error": str(e), "timestamp": datetime.now(timezone.utc).isoformat()}
+            error = {"tier": "tier_5", "error": str(e), "timestamp": datetime.now(UTC).isoformat()}
             lead.enrichment_errors.append(error)
             logger.warning(f"Tier 5 failed for {lead.id}: {str(e)}")
-        
+
         return lead
-    
+
     # FULL PIPELINE ORCHESTRATION
-    
-    async def run_full_pipeline(self, config: CampaignConfig) -> List[LeadRecord]:
+
+    async def run_full_pipeline(self, config: CampaignConfig) -> list[LeadRecord]:
         """Execute complete Phase 1 → 2 → 3 pipeline"""
         logger.info(f"Starting full Waterfall v2 pipeline for {config.industry} in {config.location}")
-        
+
         try:
             # Phase 1: Discovery
             leads = await self.run_discovery(config)
             logger.info(f"Phase 1 completed: {len(leads)} leads discovered")
-            
+
             if not leads:
                 return []
-            
+
             enriched = []
-            
+
             for lead in leads:
                 logger.debug(f"Processing lead: {lead.business_name} ({lead.id})")
-                
+
                 # Phase 2: Core Enrichment (Always run)
                 lead = await self.enrich_tier_1(lead)
                 lead = await self.enrich_tier_1_5a(lead)
                 lead = await self.enrich_tier_1_5b(lead)
                 lead = await self.enrich_tier_2(lead)
-                
+
                 # Phase 3: Initial ALS Scoring
                 lead.als_score = self.calculate_als(lead)
                 logger.debug(f"Initial ALS score for {lead.id}: {lead.als_score}")
-                
+
                 # Quality Gate Check - Continue enrichment only if score >= PRE_ALS_GATE
                 if lead.als_score >= self.PRE_ALS_GATE:
                     logger.debug(f"Lead {lead.id} passed ALS gate ({lead.als_score} >= {self.PRE_ALS_GATE})")
-                    
+
                     # Phase 2 continued: Premium Enrichment
                     lead = await self.enrich_tier_2_5(lead)
                     lead = await self.enrich_tier_3(lead)
                     lead = await self.enrich_tier_5(lead)
-                    
+
                     # Phase 3: Final ALS Scoring
                     lead.als_score = self.calculate_als(lead)
                     logger.debug(f"Final ALS score for {lead.id}: {lead.als_score}")
                 else:
                     logger.debug(f"Lead {lead.id} did not pass ALS gate ({lead.als_score} < {self.PRE_ALS_GATE})")
-                
+
                 # Update final metadata
-                lead.updated_at = datetime.now(timezone.utc).isoformat()
+                lead.updated_at = datetime.now(UTC).isoformat()
                 enriched.append(lead)
-            
+
             # Pipeline summary
             total_cost = sum(lead.cost_aud for lead in enriched)
             high_quality_leads = len([lead for lead in enriched if lead.als_score >= self.HOT_THRESHOLD])
-            
+
             logger.info(
                 f"Waterfall v2 pipeline completed: {len(enriched)} leads processed, "
                 f"{high_quality_leads} high-quality leads (ALS >= {self.HOT_THRESHOLD}), "
                 f"Total cost: ${total_cost:.4f} AUD"
             )
-            
+
             return enriched
-            
+
         except Exception as e:
             logger.error(f"Full pipeline failed: {str(e)}")
             return []
-    
+
     # UTILITY METHODS
-    
-    def get_pipeline_stats(self, leads: List[LeadRecord]) -> dict:
+
+    def get_pipeline_stats(self, leads: list[LeadRecord]) -> dict:
         """Get pipeline statistics and performance metrics"""
         if not leads:
             return {}
-        
+
         stats = {
             "total_leads": len(leads),
             "total_cost_aud": sum(lead.cost_aud for lead in leads),
@@ -768,7 +762,7 @@ class WaterfallV2:
             "discovery_sources": {},
             "error_summary": {}
         }
-        
+
         # Enrichment tier completion rates
         all_tiers = ["tier_1", "tier_1_5a", "tier_1_5b", "tier_2", "tier_2_5", "tier_3", "tier_5"]
         for tier in all_tiers:
@@ -777,16 +771,16 @@ class WaterfallV2:
                 "completed": completed,
                 "rate": completed / len(leads) if leads else 0
             }
-        
+
         # Discovery source breakdown
         for lead in leads:
             source = lead.discovery_source or "unknown"
             stats["discovery_sources"][source] = stats["discovery_sources"].get(source, 0) + 1
-        
+
         # Error summary
         for lead in leads:
             for error in lead.enrichment_errors:
                 tier = error.get("tier", "unknown")
                 stats["error_summary"][tier] = stats["error_summary"].get(tier, 0) + 1
-        
+
         return stats

--- a/src/integrations/__init__.py
+++ b/src/integrations/__init__.py
@@ -17,17 +17,17 @@ LinkedIn enrichment now via Siege Waterfall → Kaspr pipeline.
 # Agency OS - Integrations Package
 
 from src.integrations.abn_client import ABNClient, get_abn_client
+from src.integrations.calendar_booking import router as calendar_booking_router
 from src.integrations.clicksend import ClickSendClient, get_clicksend_client
 from src.integrations.elevenlabs import ElevenLabsClient, get_elevenlabs_client
 from src.integrations.hunter import HunterClient, get_hunter_client
 from src.integrations.kaspr import KasprClient, get_kaspr_client
 from src.integrations.serper import SerperClient, get_serper_client
 from src.integrations.siege_waterfall import SiegeWaterfall, get_siege_waterfall
-from src.integrations.vapi import VapiClient, get_vapi_client
 
 # Billing & Booking
 from src.integrations.stripe_billing import router as stripe_billing_router
-from src.integrations.calendar_booking import router as calendar_booking_router
+from src.integrations.vapi import VapiClient, get_vapi_client
 
 __all__ = [
     "ABNClient",

--- a/src/integrations/abn_client.py
+++ b/src/integrations/abn_client.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -179,23 +179,23 @@ def validate_abn(abn: str) -> str:
     """
     # Remove spaces and non-digits
     cleaned = re.sub(r"\D", "", abn)
-    
+
     if len(cleaned) != 11:
         raise ABNValidationError(abn, "ABN must be 11 digits")
-    
+
     # ABN checksum validation
     # Weights: 10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19
     weights = [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
-    
+
     # Subtract 1 from first digit for checksum
     digits = [int(d) for d in cleaned]
     digits[0] -= 1
-    
-    checksum = sum(d * w for d, w in zip(digits, weights))
-    
+
+    checksum = sum(d * w for d, w in zip(digits, weights, strict=True))
+
     if checksum % 89 != 0:
         raise ABNValidationError(abn, "ABN checksum validation failed")
-    
+
     return cleaned
 
 
@@ -216,23 +216,23 @@ def validate_acn(acn: str) -> str:
     """
     # Remove spaces and non-digits
     cleaned = re.sub(r"\D", "", acn)
-    
+
     if len(cleaned) != 9:
         raise ABNValidationError(acn, "ACN must be 9 digits")
-    
+
     # ACN checksum validation
     # Weights: 8, 7, 6, 5, 4, 3, 2, 1 (for first 8 digits)
     weights = [8, 7, 6, 5, 4, 3, 2, 1]
-    
+
     digits = [int(d) for d in cleaned]
-    checksum = sum(d * w for d, w in zip(digits[:8], weights))
-    
+    checksum = sum(d * w for d, w in zip(digits[:8], weights, strict=True))
+
     remainder = checksum % 10
     check_digit = (10 - remainder) % 10
-    
+
     if check_digit != digits[8]:
         raise ABNValidationError(acn, "ACN checksum validation failed")
-    
+
     return cleaned
 
 
@@ -301,16 +301,16 @@ class ABNClient:
             guid: Authentication GUID (uses settings if not provided)
         """
         self.guid = guid or getattr(settings, "abn_lookup_guid", None) or ""
-        
+
         if not self.guid:
             logger.warning(
                 "[ABN] No GUID configured. API calls may fail. "
                 "Register for free at: https://abr.business.gov.au/Tools/WebServices"
             )
-        
+
         self._client: httpx.AsyncClient | None = None
         self._request_count = 0
-        
+
         # Check xmltodict is available
         if xmltodict is None:
             raise IntegrationError(
@@ -336,7 +336,7 @@ class ABNClient:
             await self._client.aclose()
             self._client = None
 
-    async def __aenter__(self) -> "ABNClient":
+    async def __aenter__(self) -> ABNClient:
         """Async context manager entry."""
         return self
 
@@ -369,41 +369,41 @@ class ABNClient:
             APIError: If HTTP request fails
         """
         client = await self._get_client()
-        
+
         # Add auth GUID to params
         params["authenticationGuid"] = self.guid
-        
+
         url = f"{ABN_LOOKUP_BASE_URL}/{method}"
-        
+
         try:
             self._request_count += 1
-            
+
             response = await client.get(url, params=params)
             response.raise_for_status()
-            
+
             # Parse XML response
             data = xmltodict.parse(response.text)
-            
+
             # Extract payload
             payload = data.get("ABRPayloadSearchResults", {})
             resp = payload.get("response", {})
-            
+
             # Check for exceptions
             if "exception" in resp:
                 exc = resp["exception"]
                 code = exc.get("exceptionCode", "UNKNOWN")
                 desc = exc.get("exceptionDescription", "Unknown error")
-                
+
                 # Log but don't capture expected errors in Sentry
                 if code == "SEARCH":
                     logger.debug(f"[ABN] Search returned no results: {desc}")
                 else:
                     logger.warning(f"[ABN] API error ({code}): {desc}")
-                
+
                 raise ABNLookupError(message=desc, code=code)
-            
+
             return payload
-            
+
         except httpx.HTTPStatusError as e:
             sentry_sdk.set_context(
                 "abn_request",
@@ -462,7 +462,7 @@ class ABNClient:
         """
         # Validate and clean ABN
         cleaned_abn = validate_abn(abn)
-        
+
         try:
             payload = await self._request(
                 "SearchByABNv202001",
@@ -471,15 +471,15 @@ class ABNClient:
                     "includeHistoricalDetails": "N",
                 },
             )
-            
+
             response = payload.get("response", {})
             record = response.get("businessEntity202001") or response.get("businessEntity201408") or response.get("businessEntity")
-            
+
             if not record:
                 raise ABNNotFoundError(cleaned_abn, "ABN")
-            
+
             return self._transform_business_entity(record)
-            
+
         except ABNLookupError as e:
             if "Search" in str(e.details.get("abr_error_code", "")):
                 raise ABNNotFoundError(cleaned_abn, "ABN")
@@ -528,10 +528,10 @@ class ABNClient:
                 message="Search name must be at least 3 characters",
                 field="name",
             )
-        
+
         # Build state filter params
-        state_params = {s: "N" for s in ["NSW", "SA", "ACT", "VIC", "WA", "NT", "QLD", "TAS"]}
-        
+        state_params = dict.fromkeys(["NSW", "SA", "ACT", "VIC", "WA", "NT", "QLD", "TAS"], "N")
+
         if state:
             # Normalize state code
             state_normalized = STATE_CODES.get(state.lower(), state.upper())
@@ -541,8 +541,8 @@ class ABNClient:
                 logger.warning(f"[ABN] Unknown state code: {state}")
         else:
             # If no state filter, search all states
-            state_params = {s: "Y" for s in state_params}
-        
+            state_params = dict.fromkeys(state_params, "Y")
+
         params = {
             "name": name,
             "postcode": postcode or "",
@@ -555,26 +555,26 @@ class ABNClient:
             "maxSearchResults": str(min(limit, 200)),
             **state_params,
         }
-        
+
         try:
             payload = await self._request(
                 "ABRSearchByNameAdvancedSimpleProtocol2017",
                 params,
             )
-            
+
             response = payload.get("response", {})
             search_results = response.get("searchResultsList", {})
-            
+
             if not search_results:
                 return []
-            
+
             # Handle single result vs list
             results = search_results.get("searchResultsRecord", [])
             if isinstance(results, dict):
                 results = [results]
-            
+
             return [self._transform_search_result(r) for r in results[:limit]]
-            
+
         except ABNLookupError as e:
             # No results is not an error
             if "Search" in str(e.details.get("abr_error_code", "")):
@@ -599,7 +599,7 @@ class ABNClient:
         """
         # Validate and clean ACN
         cleaned_acn = validate_acn(acn)
-        
+
         try:
             payload = await self._request(
                 "SearchByASICv201408",
@@ -608,15 +608,15 @@ class ABNClient:
                     "includeHistoricalDetails": "N",
                 },
             )
-            
+
             response = payload.get("response", {})
             record = response.get("businessEntity201408") or response.get("businessEntity")
-            
+
             if not record:
                 raise ABNNotFoundError(cleaned_acn, "ACN")
-            
+
             return self._transform_business_entity(record)
-            
+
         except ABNLookupError as e:
             if "Search" in str(e.details.get("abr_error_code", "")):
                 raise ABNNotFoundError(cleaned_acn, "ACN")
@@ -655,7 +655,7 @@ class ABNClient:
             })
         """
         results = []
-        
+
         # Postcode search
         if criteria.get("postcode"):
             postcode = str(criteria["postcode"])
@@ -664,21 +664,21 @@ class ABNClient:
                     message="Postcode must be 4 digits",
                     field="postcode",
                 )
-            
+
             try:
                 payload = await self._request(
                     "SearchByPostcode",
                     {"postcode": postcode},
                 )
-                
+
                 response = payload.get("response", {})
                 abn_list = response.get("abnList", {})
-                
+
                 if abn_list:
                     abns = abn_list.get("abn", [])
                     if isinstance(abns, str):
                         abns = [abns]
-                    
+
                     # Enrich first N ABNs with full details
                     enriched = []
                     for abn in abns[:limit]:
@@ -690,12 +690,12 @@ class ABNClient:
                         except (ABNNotFoundError, ABNLookupError) as e:
                             logger.debug(f"[ABN] Skipping {abn}: {e}")
                             continue
-                    
+
                     results.extend(enriched)
-                    
+
             except ABNLookupError:
                 pass  # No results for postcode
-        
+
         # Name search
         elif criteria.get("name"):
             name_results = await self.search_by_name(
@@ -705,12 +705,12 @@ class ABNClient:
                 limit=limit,
             )
             results.extend(name_results)
-        
+
         else:
             raise ValidationError(
                 message="Bulk search requires 'postcode' or 'name' in criteria",
             )
-        
+
         return results
 
     async def enrich_from_abn(self, abn: str) -> dict[str, Any]:
@@ -757,10 +757,10 @@ class ABNClient:
             # Multiple ABNs (historical) - get current
             current = next((a for a in abn_info if a.get("isCurrentIndicator") == "Y"), abn_info[0])
             abn_info = current
-        
+
         abn = abn_info.get("identifierValue", "")
         abn_status = abn_info.get("identifierStatus", "Unknown")
-        
+
         # Extract entity type
         entity_type_info = record.get("entityType", {})
         entity_type_code = entity_type_info.get("entityTypeCode", "")
@@ -768,27 +768,27 @@ class ABNClient:
             entity_type_code,
             entity_type_info.get("entityDescription", entity_type_code),
         )
-        
+
         # Extract GST status
         gst_info = record.get("goodsAndServicesTax", {})
         if isinstance(gst_info, list):
             gst_info = next((g for g in gst_info if g.get("effectiveTo") is None), gst_info[0] if gst_info else {})
-        
+
         gst_registered = gst_info.get("effectiveFrom") is not None
         gst_from = gst_info.get("effectiveFrom")
-        
+
         # Extract names
         business_name = ""
         trading_name = ""
         business_names = []
-        
+
         # Main name (for non-individuals)
         main_name = record.get("mainName", {})
         if isinstance(main_name, list):
             main_name = next((n for n in main_name if n.get("isCurrentIndicator") == "Y"), main_name[0] if main_name else {})
         if main_name:
             business_name = main_name.get("organisationName", "")
-        
+
         # Legal name (for individuals)
         legal_name = record.get("legalName", {})
         if isinstance(legal_name, list):
@@ -797,14 +797,14 @@ class ABNClient:
             given_name = legal_name.get("givenName", "")
             family_name = legal_name.get("familyName", "")
             business_name = f"{given_name} {family_name}".strip()
-        
+
         # Main trading name
         main_trading = record.get("mainTradingName", {})
         if isinstance(main_trading, list):
             main_trading = next((n for n in main_trading if n.get("isCurrentIndicator") == "Y"), main_trading[0] if main_trading else {})
         if main_trading:
             trading_name = main_trading.get("organisationName", "")
-        
+
         # Business names (ASIC registered since 2012)
         bn_list = record.get("businessName", [])
         if isinstance(bn_list, dict):
@@ -814,21 +814,21 @@ class ABNClient:
                 bn_name = bn.get("organisationName", "")
                 if bn_name:
                     business_names.append(bn_name)
-        
+
         # Extract address
         address_info = record.get("mainBusinessPhysicalAddress", {})
         if isinstance(address_info, list):
             address_info = next((a for a in address_info if a.get("isCurrentIndicator") == "Y"), address_info[0] if address_info else {})
-        
+
         state = address_info.get("stateCode", "")
         postcode = address_info.get("postcode", "")
-        
+
         # Extract ACN (for companies)
         acn = ""
         asic_number = record.get("ASICNumber", "")
         if asic_number:
             acn = asic_number
-        
+
         return {
             "found": True,
             "source": "abn_lookup",
@@ -855,19 +855,19 @@ class ABNClient:
             "gst_registered": gst_registered,
             "gst_from": gst_from,
             # Metadata
-            "retrieved_at": datetime.now(timezone.utc).isoformat(),
+            "retrieved_at": datetime.now(UTC).isoformat(),
         }
 
     def _transform_search_result(self, record: dict) -> dict[str, Any]:
         """Transform ABR search result to standard format."""
         abn = record.get("ABN", {}).get("identifierValue", "")
         abn_status = record.get("ABN", {}).get("identifierStatus", "")
-        
+
         # Get matched name
         name_info = record.get("mainName", {})
         name = name_info.get("organisationName", "")
         name_type = "main"
-        
+
         if not name:
             name_info = record.get("legalName", {})
             if name_info:
@@ -875,24 +875,24 @@ class ABNClient:
                 family = name_info.get("familyName", "")
                 name = f"{given} {family}".strip()
                 name_type = "legal"
-        
+
         if not name:
             name_info = record.get("businessName", {})
             name = name_info.get("organisationName", "")
             name_type = "business"
-        
+
         if not name:
             name_info = record.get("mainTradingName", {})
             name = name_info.get("organisationName", "")
             name_type = "trading"
-        
+
         # Address
         state = record.get("mainBusinessPhysicalAddress", {}).get("stateCode", "")
         postcode = record.get("mainBusinessPhysicalAddress", {}).get("postcode", "")
-        
+
         # Score
         score = int(record.get("score", 0))
-        
+
         return {
             "abn": format_abn(abn),
             "abn_raw": abn,

--- a/src/integrations/anthropic.py
+++ b/src/integrations/anthropic.py
@@ -46,7 +46,7 @@ class AnthropicClient:
             "cached": 0.465,
         },
     }
-    
+
     # Fallback pricing (Haiku rates)
     COST_PER_M_INPUT_TOKENS = 1.24
     COST_PER_M_OUTPUT_TOKENS = 6.20
@@ -82,8 +82,8 @@ class AnthropicClient:
             )
 
     async def _record_spend(
-        self, 
-        input_tokens: int, 
+        self,
+        input_tokens: int,
         output_tokens: int,
         cached_tokens: int = 0,
         model: str = "claude-3-5-haiku-20241022",
@@ -105,10 +105,10 @@ class AnthropicClient:
             "output": self.COST_PER_M_OUTPUT_TOKENS,
             "cached": self.COST_PER_M_CACHED_TOKENS,
         })
-        
+
         # Regular input tokens (minus cached)
         regular_input = max(0, input_tokens - cached_tokens)
-        
+
         cost = (
             (regular_input / 1_000_000) * pricing["input"] +
             (cached_tokens / 1_000_000) * pricing["cached"] +

--- a/src/integrations/bright_data_client.py
+++ b/src/integrations/bright_data_client.py
@@ -7,12 +7,13 @@ Supports Google/Maps searches via SERP API and LinkedIn scraping via Scrapers AP
 Note: All methods are async - use with await.
 """
 
-import httpx
 import asyncio
-import structlog
 import urllib.parse
-from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import structlog
 
 logger = structlog.get_logger()
 
@@ -39,11 +40,11 @@ class CostTracker:
     """Tracks API usage costs for the session"""
     serp_requests: int = 0
     scraper_records: int = 0
-    
+
     @property
     def total_aud(self) -> float:
         """Calculate total cost in AUD for this session"""
-        return (self.serp_requests * COSTS_AUD["serp_request"] + 
+        return (self.serp_requests * COSTS_AUD["serp_request"] +
                 self.scraper_records * COSTS_AUD["scraper_record"])
 
 
@@ -58,7 +59,7 @@ class BrightDataClient:
     
     All methods are async and should be called with await.
     """
-    
+
     def __init__(self, api_key: str, serp_zone: str = "serp_api1"):
         """
         Initialize the Bright Data client.
@@ -70,27 +71,27 @@ class BrightDataClient:
         self.api_key = api_key
         self.serp_zone = serp_zone
         self.costs = CostTracker()
-        self._client: Optional[httpx.AsyncClient] = None
-    
+        self._client: httpx.AsyncClient | None = None
+
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create async HTTP client."""
         if self._client is None or self._client.is_closed:
             self._client = httpx.AsyncClient(timeout=60.0, verify=False)
         return self._client
-    
+
     async def close(self):
         """Close the HTTP client."""
         if self._client and not self._client.is_closed:
             await self._client.aclose()
-    
+
     # SERP API Methods
-    
+
     async def search_google_maps(
-        self, 
-        query: str, 
+        self,
+        query: str,
         location: str,
         max_results: int = 20
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """
         Search Google Maps via SERP API.
         
@@ -106,18 +107,18 @@ class BrightDataClient:
         """
         encoded_query = urllib.parse.quote(f"{query} {location}")
         url = f"https://www.google.com/maps/search/{encoded_query}?brd_json=1"
-        
+
         result = await self._serp_request(url)
-        
+
         # Extract business results (limit to max_results)
         if isinstance(result, list):
             return result[:max_results]
         elif isinstance(result, dict) and "organic" in result:
             return result["organic"][:max_results]
-        
+
         return []
-    
-    async def search_google(self, query: str) -> Dict:
+
+    async def search_google(self, query: str) -> dict:
         """
         Search Google via SERP API.
         
@@ -131,16 +132,16 @@ class BrightDataClient:
         """
         encoded_query = urllib.parse.quote(query)
         url = f"https://www.google.com/search?q={encoded_query}&brd_json=1"
-        
+
         return await self._serp_request(url)
-    
+
     async def _serp_request(self, url: str, max_retries: int = 2) -> Any:
         """Execute SERP API request via proxy with retry and alerting."""
         proxy_url = f"http://brd-customer-hl_4af12f98-zone-{self.serp_zone}:{self.api_key}@brd.superproxy.io:33335"
-        
+
         client = await self._get_client()
         last_error = None
-        
+
         for attempt in range(max_retries + 1):
             try:
                 response = await client.get(
@@ -150,10 +151,10 @@ class BrightDataClient:
                 )
                 response.raise_for_status()
                 self.costs.serp_requests += 1
-                
+
                 logger.debug("serp_request_complete", url=url[:100], status=response.status_code)
                 return response.json()
-                
+
             except httpx.HTTPStatusError as e:
                 last_error = f"HTTP {e.response.status_code}"
                 logger.warning("serp_request_error", attempt=attempt, error=last_error)
@@ -163,10 +164,10 @@ class BrightDataClient:
             except Exception as e:
                 last_error = str(e)
                 logger.warning("serp_request_error", attempt=attempt, error=last_error)
-            
+
             if attempt < max_retries:
                 await asyncio.sleep(2 ** attempt)  # Exponential backoff
-        
+
         # All retries exhausted - fire alert
         await self._fire_bright_data_alert(last_error, max_retries + 1)
         raise BrightDataError(f"SERP request failed after {max_retries + 1} attempts: {last_error}")
@@ -176,7 +177,7 @@ class BrightDataClient:
         try:
             from src.integrations.supabase import get_db_session
             from src.services.alert_service import get_alert_service
-            
+
             async with get_db_session() as db:
                 alert_service = get_alert_service(db)
                 await alert_service.alert_bright_data_error(
@@ -186,10 +187,10 @@ class BrightDataClient:
                 )
         except Exception as e:
             logger.error("failed_to_fire_bright_data_alert", error=str(e))
-    
+
     # Scrapers API Methods
-    
-    async def scrape_linkedin_company(self, linkedin_url: str) -> Dict:
+
+    async def scrape_linkedin_company(self, linkedin_url: str) -> dict:
         """
         Scrape LinkedIn Company via Scrapers API.
         
@@ -206,8 +207,8 @@ class BrightDataClient:
             [{"url": linkedin_url}]
         )
         return results[0] if results else {}
-    
-    async def scrape_linkedin_profile(self, linkedin_url: str) -> Dict:
+
+    async def scrape_linkedin_profile(self, linkedin_url: str) -> dict:
         """
         Scrape LinkedIn People Profile via Scrapers API.
         
@@ -224,13 +225,13 @@ class BrightDataClient:
             [{"url": linkedin_url}]
         )
         return results[0] if results else {}
-    
+
     async def scrape_linkedin_jobs(
-        self, 
-        keyword: str, 
-        location: str, 
+        self,
+        keyword: str,
+        location: str,
         country: str = "AU"
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """
         Discover LinkedIn Jobs via keyword search.
         
@@ -249,33 +250,33 @@ class BrightDataClient:
             [{"keyword": keyword, "location": location, "country": country}],
             discover_by="keyword"
         )
-    
+
     async def _scraper_request(
-        self, 
-        dataset_id: str, 
-        inputs: List[Dict], 
+        self,
+        dataset_id: str,
+        inputs: list[dict],
         discover_by: str = None
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """Execute Scraper API: trigger → poll → download."""
         base_url = "https://api.brightdata.com/datasets/v3"
         headers = {
-            "Authorization": f"Bearer {self.api_key}", 
+            "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json"
         }
-        
+
         # Build trigger URL
         trigger_url = f"{base_url}/trigger?dataset_id={dataset_id}&include_errors=true"
         if discover_by:
             trigger_url += f"&type=discover_new&discover_by={discover_by}"
-        
+
         client = await self._get_client()
-        
+
         # Trigger
         try:
             response = await client.post(
-                trigger_url, 
-                headers=headers, 
-                json=inputs, 
+                trigger_url,
+                headers=headers,
+                json=inputs,
                 timeout=30.0
             )
             response.raise_for_status()
@@ -285,7 +286,7 @@ class BrightDataClient:
             raise BrightDataError(f"Scraper trigger failed: HTTP {e.response.status_code}")
         except httpx.RequestError as e:
             raise BrightDataError(f"Scraper trigger failed: {str(e)}")
-        
+
         # Poll until ready (max 5 minutes)
         for _ in range(60):
             try:
@@ -296,7 +297,7 @@ class BrightDataClient:
                 )
                 status_data = progress.json()
                 status = status_data.get("status")
-                
+
                 if status == "ready":
                     records = status_data.get("records", 0)
                     self.costs.scraper_records += records
@@ -304,14 +305,14 @@ class BrightDataClient:
                     break
                 elif status == "failed":
                     raise BrightDataError(f"Scraper job failed: {status_data}")
-                    
+
             except httpx.RequestError:
                 pass  # Retry on network errors
-            
+
             await asyncio.sleep(5)
         else:
             raise BrightDataError(f"Scraper timeout for snapshot {snapshot_id}")
-        
+
         # Download results
         try:
             data = await client.get(
@@ -325,14 +326,14 @@ class BrightDataClient:
             raise BrightDataError(f"Scraper download failed: HTTP {e.response.status_code}")
         except httpx.RequestError as e:
             raise BrightDataError(f"Scraper download failed: {str(e)}")
-    
+
     # Cost tracking methods
-    
+
     def get_total_cost(self) -> float:
         """Return total AUD spent this session."""
         return self.costs.total_aud
-    
-    def get_cost_breakdown(self) -> Dict[str, Any]:
+
+    def get_cost_breakdown(self) -> dict[str, Any]:
         """Return costs by method/tier."""
         return {
             "serp_requests": self.costs.serp_requests,

--- a/src/integrations/calendar_booking.py
+++ b/src/integrations/calendar_booking.py
@@ -13,19 +13,17 @@ Environment Variables:
 - CALENDLY_ORG_URI: Calendly organization URI for booking links
 """
 
-import os
-import hmac
 import hashlib
+import hmac
 import logging
-from datetime import datetime
-from typing import Optional, Dict, Any, Literal, TYPE_CHECKING
+import os
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
-import httpx
 
-from fastapi import APIRouter, Request, HTTPException, Header
-from pydantic import BaseModel, EmailStr
+from fastapi import APIRouter, Header, HTTPException, Request
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -89,22 +87,22 @@ async def _generate_calendly_link(
 ) -> str:
     """Generate a Calendly booking link with pre-filled info."""
     from urllib.parse import urlencode
-    
+
     # Build base URL
     base_url = f"https://calendly.com/{CALENDLY_ORG_URI}/{CALENDLY_EVENT_TYPE}"
-    
+
     # Add pre-fill parameters
     params = {
         "email": lead_email,
         "name": lead_name,
     }
-    
+
     if company_name:
         params["a1"] = company_name  # Custom question field for company
-    
+
     if client_id:
         params["utm_source"] = str(client_id)  # Track which agency client
-    
+
     return f"{base_url}?{urlencode(params)}"
 
 
@@ -116,21 +114,21 @@ async def _generate_cal_link(
 ) -> str:
     """Generate a Cal.com booking link with pre-filled info."""
     from urllib.parse import urlencode
-    
+
     # Cal.com uses different parameter format
     base_url = os.getenv("CAL_BOOKING_URL", "https://cal.com/demo")
-    
+
     params = {
         "email": lead_email,
         "name": lead_name,
     }
-    
+
     if company_name:
         params["company"] = company_name
-    
+
     if client_id:
         params["metadata[client_id]"] = str(client_id)
-    
+
     return f"{base_url}?{urlencode(params)}"
 
 
@@ -141,17 +139,17 @@ def _generate_fallback_link(
 ) -> str:
     """Generate a fallback static booking link."""
     from urllib.parse import urlencode
-    
+
     base_url = os.getenv("FALLBACK_BOOKING_URL", "https://calendly.com/agency-demo")
-    
+
     params = {
         "email": lead_email,
         "name": lead_name,
     }
-    
+
     if company_name:
         params["a1"] = company_name
-    
+
     return f"{base_url}?{urlencode(params)}"
 
 
@@ -186,26 +184,26 @@ async def send_booking_reply(
 
         # Determine reply channel from last activity
         last_channel = await _get_lead_last_channel(db, lead.id)
-        
+
         if last_channel == "email":
             # Send via email engine
             from src.engines.email import get_email_engine
             email_engine = get_email_engine()
-            
+
             result = await email_engine.send_email(
                 db=db,
                 lead_id=lead.id,
-                subject=f"Re: Let's Schedule a Call",
+                subject="Re: Let's Schedule a Call",
                 body=message,
                 from_domain=lead.assigned_email_resource,
             )
             return result.success
-            
+
         elif last_channel == "linkedin":
             # Send via LinkedIn engine
             from src.engines.linkedin import get_linkedin_engine
             linkedin_engine = get_linkedin_engine()
-            
+
             result = await linkedin_engine.send_message(
                 db=db,
                 lead_id=lead.id,
@@ -213,12 +211,12 @@ async def send_booking_reply(
                 account_id=lead.assigned_linkedin_seat,
             )
             return result.success
-            
+
         elif last_channel == "sms":
             # Send via SMS engine (shorter message)
             from src.engines.sms import get_sms_engine
             sms_engine = get_sms_engine()
-            
+
             short_message = f"Hi {first_name}! Here's my calendar: {booking_link}"
             result = await sms_engine.send_sms(
                 db=db,
@@ -227,7 +225,7 @@ async def send_booking_reply(
                 from_number=lead.assigned_phone_resource,
             )
             return result.success
-        
+
         else:
             logger.warning(f"Unknown channel for lead {lead.id}, cannot send booking reply")
             return False
@@ -276,7 +274,7 @@ async def handle_calendly_booking_confirmed(
     try:
         # Find lead by email
         from sqlalchemy import text
-        
+
         result = await db.execute(
             text("""
                 SELECT id, client_id, campaign_id, full_name, company
@@ -287,14 +285,14 @@ async def handle_calendly_booking_confirmed(
             {"email": event.attendee_email.lower()},
         )
         row = result.fetchone()
-        
+
         if not row:
             logger.warning(f"No lead found for booking email: {event.attendee_email}")
             return
 
         lead_id = row.id
         client_id = row.client_id
-        
+
         # Update lead status to CONVERTED
         await db.execute(
             text("""
@@ -364,13 +362,13 @@ class BookingEvent:
     booking_id: str
     event_name: str
     attendee_email: str
-    attendee_name: Optional[str]
+    attendee_name: str | None
     scheduled_time: datetime
     duration_minutes: int
-    meeting_url: Optional[str]
-    location: Optional[str]
-    notes: Optional[str]
-    raw_payload: Dict[str, Any]
+    meeting_url: str | None
+    location: str | None
+    notes: str | None
+    raw_payload: dict[str, Any]
 
 
 # =============================================================================
@@ -382,13 +380,13 @@ def verify_cal_signature(payload: bytes, signature: str) -> bool:
     if not CAL_WEBHOOK_SECRET:
         logger.warning("CAL_WEBHOOK_SECRET not set, skipping verification")
         return True
-    
+
     expected = hmac.new(
         CAL_WEBHOOK_SECRET.encode(),
         payload,
         hashlib.sha256
     ).hexdigest()
-    
+
     return hmac.compare_digest(expected, signature)
 
 
@@ -397,19 +395,19 @@ def verify_calendly_signature(payload: bytes, signature: str) -> bool:
     if not CALENDLY_WEBHOOK_SECRET:
         logger.warning("CALENDLY_WEBHOOK_SECRET not set, skipping verification")
         return True
-    
+
     # Calendly uses: t=timestamp,v1=signature format
     parts = dict(p.split("=") for p in signature.split(",") if "=" in p)
     sig = parts.get("v1", "")
     timestamp = parts.get("t", "")
-    
+
     signed_payload = f"{timestamp}.{payload.decode()}"
     expected = hmac.new(
         CALENDLY_WEBHOOK_SECRET.encode(),
         signed_payload.encode(),
         hashlib.sha256
     ).hexdigest()
-    
+
     return hmac.compare_digest(expected, sig)
 
 
@@ -417,21 +415,21 @@ def verify_calendly_signature(payload: bytes, signature: str) -> bool:
 # Payload Parsers
 # =============================================================================
 
-def parse_cal_webhook(payload: Dict[str, Any]) -> BookingEvent:
+def parse_cal_webhook(payload: dict[str, Any]) -> BookingEvent:
     """Parse Cal.com webhook payload into unified BookingEvent."""
     trigger = payload.get("triggerEvent", "")
     data = payload.get("payload", {})
-    
+
     # Map Cal.com triggers to our event types
     event_type_map = {
         "BOOKING_CREATED": "created",
         "BOOKING_CANCELLED": "cancelled",
         "BOOKING_RESCHEDULED": "rescheduled",
     }
-    
+
     attendees = data.get("attendees", [{}])
     attendee = attendees[0] if attendees else {}
-    
+
     return BookingEvent(
         provider=BookingProvider.CAL,
         event_type=event_type_map.get(trigger, "created"),
@@ -448,30 +446,30 @@ def parse_cal_webhook(payload: Dict[str, Any]) -> BookingEvent:
     )
 
 
-def parse_calendly_webhook(payload: Dict[str, Any]) -> BookingEvent:
+def parse_calendly_webhook(payload: dict[str, Any]) -> BookingEvent:
     """Parse Calendly webhook payload into unified BookingEvent."""
     event = payload.get("event", "")
     data = payload.get("payload", {})
-    
+
     # Map Calendly events
     event_type_map = {
         "invitee.created": "created",
         "invitee.canceled": "cancelled",
     }
-    
+
     invitee = data.get("invitee", {})
     scheduled = data.get("scheduled_event", {})
-    
+
     start_time = scheduled.get("start_time", "")
     end_time = scheduled.get("end_time", "")
-    
+
     # Calculate duration
     duration = 30
     if start_time and end_time:
         start = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
         end = datetime.fromisoformat(end_time.replace("Z", "+00:00"))
         duration = int((end - start).total_seconds() / 60)
-    
+
     return BookingEvent(
         provider=BookingProvider.CALENDLY,
         event_type=event_type_map.get(event, "created"),
@@ -495,19 +493,19 @@ def parse_calendly_webhook(payload: Dict[str, Any]) -> BookingEvent:
 async def handle_booking_created(event: BookingEvent) -> None:
     """Handle new demo booking - update pipeline stage and convert lead."""
     logger.info(f"Demo booked: {event.attendee_email} at {event.scheduled_time}")
-    
+
     try:
         supabase = get_supabase_client()
-        
+
         # Find lead by email
         lead_result = supabase.table("leads").select("id, client_id").eq(
             "email", event.attendee_email
         ).single().execute()
-        
+
         if lead_result.data:
             lead_id = lead_result.data["id"]
             client_id = lead_result.data.get("client_id")
-            
+
             # Directive 048: Update lead status to CONVERTED
             supabase.table("leads").update({
                 "status": "converted",
@@ -518,7 +516,7 @@ async def handle_booking_created(event: BookingEvent) -> None:
                     "meeting_url": event.meeting_url,
                 }
             }).eq("id", lead_id).execute()
-            
+
             # Update pipeline to demo_booked
             supabase.table("sales_pipeline").update({
                 "stage": "demo_booked",
@@ -526,7 +524,7 @@ async def handle_booking_created(event: BookingEvent) -> None:
                 "next_action_date": event.scheduled_time.isoformat(),
                 "notes": f"Meeting URL: {event.meeting_url or 'TBD'}"
             }).eq("lead_id", lead_id).execute()
-            
+
             # Directive 048: Trigger agency owner notification
             if client_id:
                 supabase.rpc("create_admin_notification", {
@@ -541,7 +539,7 @@ async def handle_booking_created(event: BookingEvent) -> None:
                         "scheduled_time": event.scheduled_time.isoformat(),
                     }
                 }).execute()
-            
+
             logger.info(f"Lead {lead_id} converted and pipeline updated")
         else:
             # Create lead if doesn't exist
@@ -551,7 +549,7 @@ async def handle_booking_created(event: BookingEvent) -> None:
                 "source": f"demo_booking_{event.provider.value}",
                 "status": "converted"  # Direct to converted since they booked
             }).execute()
-            
+
             if new_lead.data:
                 # Create pipeline entry
                 supabase.table("sales_pipeline").insert({
@@ -560,9 +558,9 @@ async def handle_booking_created(event: BookingEvent) -> None:
                     "next_action": f"Demo call: {event.event_name}",
                     "next_action_date": event.scheduled_time.isoformat()
                 }).execute()
-                
+
                 logger.info(f"Created new lead and pipeline for {event.attendee_email}")
-        
+
         # Store booking record
         supabase.table("demo_bookings").upsert({
             "booking_id": event.booking_id,
@@ -575,7 +573,7 @@ async def handle_booking_created(event: BookingEvent) -> None:
             "status": "scheduled",
             "raw_payload": event.raw_payload
         }, on_conflict="booking_id").execute()
-        
+
     except Exception as e:
         logger.error(f"Error handling booking created: {e}")
         raise
@@ -584,27 +582,27 @@ async def handle_booking_created(event: BookingEvent) -> None:
 async def handle_booking_cancelled(event: BookingEvent) -> None:
     """Handle cancelled booking - revert pipeline stage."""
     logger.info(f"Demo cancelled: {event.attendee_email}")
-    
+
     try:
         supabase = get_supabase_client()
-        
+
         # Update booking status
         supabase.table("demo_bookings").update({
             "status": "cancelled"
         }).eq("booking_id", event.booking_id).execute()
-        
+
         # Find lead and revert pipeline
         lead_result = supabase.table("leads").select("id").eq(
             "email", event.attendee_email
         ).single().execute()
-        
+
         if lead_result.data:
             supabase.table("sales_pipeline").update({
                 "stage": "contacted",  # Revert to contacted
                 "next_action": "Follow up on cancelled demo",
                 "notes": f"Demo cancelled at {datetime.utcnow().isoformat()}"
             }).eq("lead_id", lead_result.data["id"]).execute()
-            
+
     except Exception as e:
         logger.error(f"Error handling booking cancelled: {e}")
 
@@ -612,27 +610,27 @@ async def handle_booking_cancelled(event: BookingEvent) -> None:
 async def handle_booking_rescheduled(event: BookingEvent) -> None:
     """Handle rescheduled booking - update scheduled time."""
     logger.info(f"Demo rescheduled: {event.attendee_email} to {event.scheduled_time}")
-    
+
     try:
         supabase = get_supabase_client()
-        
+
         # Update booking
         supabase.table("demo_bookings").update({
             "scheduled_time": event.scheduled_time.isoformat(),
             "status": "rescheduled"
         }).eq("booking_id", event.booking_id).execute()
-        
+
         # Update pipeline next_action_date
         lead_result = supabase.table("leads").select("id").eq(
             "email", event.attendee_email
         ).single().execute()
-        
+
         if lead_result.data:
             supabase.table("sales_pipeline").update({
                 "next_action_date": event.scheduled_time.isoformat(),
                 "notes": f"Rescheduled to {event.scheduled_time}"
             }).eq("lead_id", lead_result.data["id"]).execute()
-            
+
     except Exception as e:
         logger.error(f"Error handling booking rescheduled: {e}")
 
@@ -648,23 +646,23 @@ async def cal_webhook(
 ):
     """Cal.com webhook endpoint."""
     payload = await request.body()
-    
+
     if x_cal_signature and not verify_cal_signature(payload, x_cal_signature):
         raise HTTPException(status_code=401, detail="Invalid signature")
-    
+
     data = await request.json()
     event = parse_cal_webhook(data)
-    
+
     handlers = {
         "created": handle_booking_created,
         "cancelled": handle_booking_cancelled,
         "rescheduled": handle_booking_rescheduled,
     }
-    
+
     handler = handlers.get(event.event_type)
     if handler:
         await handler(event)
-    
+
     return {"status": "ok"}
 
 
@@ -675,22 +673,22 @@ async def calendly_webhook(
 ):
     """Calendly webhook endpoint."""
     payload = await request.body()
-    
+
     if calendly_webhook_signature and not verify_calendly_signature(payload, calendly_webhook_signature):
         raise HTTPException(status_code=401, detail="Invalid signature")
-    
+
     data = await request.json()
     event = parse_calendly_webhook(data)
-    
+
     handlers = {
         "created": handle_booking_created,
         "cancelled": handle_booking_cancelled,
     }
-    
+
     handler = handlers.get(event.event_type)
     if handler:
         await handler(event)
-    
+
     return {"status": "ok"}
 
 

--- a/src/integrations/gmb_scraper.py
+++ b/src/integrations/gmb_scraper.py
@@ -47,6 +47,7 @@ DESCRIPTION: DIY GMB scraper replaces Apify dependency for Google Maps data
 # =============================================================================
 
 import asyncio
+import contextlib
 import json
 import logging
 import random
@@ -55,8 +56,8 @@ import sys
 from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Optional
-from urllib.parse import quote_plus, urljoin
+from typing import Any
+from urllib.parse import quote_plus
 
 import httpx
 from tenacity import (
@@ -71,17 +72,18 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 try:
     from tools.autonomous_browser import (
+        IdentityRotator,  # noqa: F401
         autonomous_fetch,
-        IdentityRotator,
-        create_stealth_context,
+        create_stealth_context,  # noqa: F401
     )
-    from tools.proxy_manager import get_proxy_list, get_manager as get_proxy_manager
+    from tools.proxy_manager import get_manager as get_proxy_manager  # noqa: F401
+    from tools.proxy_manager import get_proxy_list
     HAS_BROWSER = True
 except ImportError:
     HAS_BROWSER = False
 
 try:
-    from playwright.async_api import async_playwright
+    from playwright.async_api import async_playwright  # noqa: F401
     HAS_PLAYWRIGHT = True
 except ImportError:
     HAS_PLAYWRIGHT = False
@@ -138,30 +140,30 @@ class GMBResult:
     """Result from a GMB scrape operation."""
     found: bool = False
     source: str = "gmb_scraper"
-    
+
     # Core business data
-    name: Optional[str] = None
-    phone: Optional[str] = None
-    address: Optional[str] = None
-    website: Optional[str] = None
-    
+    name: str | None = None
+    phone: str | None = None
+    address: str | None = None
+    website: str | None = None
+
     # Rating & reviews
-    rating: Optional[float] = None
-    review_count: Optional[int] = None
-    
+    rating: float | None = None
+    review_count: int | None = None
+
     # Additional data
-    category: Optional[str] = None
-    place_id: Optional[str] = None
-    google_maps_url: Optional[str] = None
-    opening_hours: Optional[list] = None
-    
+    category: str | None = None
+    place_id: str | None = None
+    google_maps_url: str | None = None
+    opening_hours: list | None = None
+
     # Cost tracking
     cost_aud: Decimal = Decimal("0.00")
     requests_made: int = 0
-    
+
     # Error info
-    error: Optional[str] = None
-    
+    error: str | None = None
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary matching Apify output format."""
         return {
@@ -229,29 +231,29 @@ class GMBParser:
     Google Maps embeds business data in JavaScript arrays within the HTML.
     This parser extracts that data using regex and JSON parsing.
     """
-    
+
     # Patterns for extracting data from Google Maps HTML
     PHONE_PATTERNS = [
         r'"(\+?[\d\s\-\(\)]{10,20})"',  # Phone in quotes
         r'tel:(\+?[\d\-]+)',  # tel: links
         r'data-phone-number="([^"]+)"',  # data attributes
     ]
-    
+
     RATING_PATTERN = r'(\d+\.?\d*)\s*(?:stars?|out of 5)'
     REVIEW_COUNT_PATTERN = r'(\d+(?:,\d+)*)\s*(?:reviews?|Google reviews?)'
-    
+
     ADDRESS_PATTERNS = [
         r'data-address="([^"]+)"',
         r'"formatted_address"\s*:\s*"([^"]+)"',
     ]
-    
+
     WEBSITE_PATTERNS = [
         r'"website"\s*:\s*"([^"]+)"',
         r'href="(https?://(?!www\.google)[^"]+)"[^>]*>.*?(?:Website|Visit)',
     ]
-    
+
     PLACE_ID_PATTERN = r'data-pid="([^"]+)"|/maps/place/[^/]+/data=[^"]*!1s([^!]+)'
-    
+
     @classmethod
     def parse_business_data(cls, html: str, url: str = "") -> GMBResult:
         """
@@ -265,18 +267,18 @@ class GMBParser:
             GMBResult with extracted data
         """
         result = GMBResult(google_maps_url=url)
-        
+
         if not html or len(html) < 1000:
             result.error = "Empty or insufficient HTML content"
             return result
-        
+
         # Check for blocks
         html_lower = html.lower()
         for indicator in BLOCK_INDICATORS:
             if indicator in html_lower:
                 result.error = f"Blocked: {indicator} detected"
                 return result
-        
+
         # Try to extract structured data from script tags
         structured_data = cls._extract_structured_data(html)
         if structured_data:
@@ -284,17 +286,17 @@ class GMBParser:
             if result.name:
                 result.found = True
                 return result
-        
+
         # Fall back to regex parsing
         result = cls._parse_with_regex(html, result)
-        
+
         if result.name or result.phone or result.address:
             result.found = True
-        
+
         return result
-    
+
     @classmethod
-    def _extract_structured_data(cls, html: str) -> Optional[dict]:
+    def _extract_structured_data(cls, html: str) -> dict | None:
         """
         Extract structured JSON data from Google Maps script tags.
         
@@ -307,7 +309,7 @@ class GMBParser:
             r'window\.APP_OPTIONS\s*=\s*({.*?});',
             r'"localizedPrimaryCategory"\s*:\s*"([^"]+)"',
         ]
-        
+
         for pattern in patterns:
             match = re.search(pattern, html, re.DOTALL)
             if match:
@@ -316,7 +318,7 @@ class GMBParser:
                     return data
                 except json.JSONDecodeError:
                     continue
-        
+
         # Try to find LD+JSON structured data
         ld_json_pattern = r'<script[^>]*type="application/ld\+json"[^>]*>(.*?)</script>'
         for match in re.finditer(ld_json_pattern, html, re.DOTALL | re.IGNORECASE):
@@ -328,9 +330,9 @@ class GMBParser:
                     return data
             except json.JSONDecodeError:
                 continue
-        
+
         return None
-    
+
     @classmethod
     def _parse_structured_data(cls, data: dict, result: GMBResult) -> GMBResult:
         """Parse structured LD+JSON or similar data."""
@@ -338,7 +340,7 @@ class GMBParser:
             result.name = data.get("name")
             result.phone = data.get("telephone")
             result.website = data.get("url") or data.get("website")
-            
+
             # Address
             address_data = data.get("address", {})
             if isinstance(address_data, dict):
@@ -352,7 +354,7 @@ class GMBParser:
                 result.address = ", ".join(filter(None, parts))
             elif isinstance(address_data, str):
                 result.address = address_data
-            
+
             # Rating
             rating_data = data.get("aggregateRating", {})
             if isinstance(rating_data, dict):
@@ -361,21 +363,21 @@ class GMBParser:
                     result.review_count = int(rating_data.get("reviewCount", 0))
                 except (ValueError, TypeError):
                     pass
-            
+
             # Category
             result.category = data.get("@type") or data.get("category")
-            
+
             # Opening hours
             hours = data.get("openingHoursSpecification", [])
             if hours:
                 result.opening_hours = hours
-        
+
         return result
-    
+
     @classmethod
     def _parse_with_regex(cls, html: str, result: GMBResult) -> GMBResult:
         """Parse using regex patterns as fallback."""
-        
+
         # Extract name from title
         title_match = re.search(r'<title>([^<]+)</title>', html, re.IGNORECASE)
         if title_match:
@@ -383,7 +385,7 @@ class GMBParser:
             # Clean up title (remove " - Google Maps" suffix)
             title = re.sub(r'\s*[-–]\s*Google Maps.*$', '', title)
             result.name = title.strip()
-        
+
         # Extract phone
         for pattern in cls.PHONE_PATTERNS:
             match = re.search(pattern, html)
@@ -394,30 +396,26 @@ class GMBParser:
                 if len(phone) >= 10:
                     result.phone = phone
                     break
-        
+
         # Extract rating
         rating_match = re.search(cls.RATING_PATTERN, html, re.IGNORECASE)
         if rating_match:
-            try:
+            with contextlib.suppress(ValueError):
                 result.rating = float(rating_match.group(1))
-            except ValueError:
-                pass
-        
+
         # Extract review count
         review_match = re.search(cls.REVIEW_COUNT_PATTERN, html, re.IGNORECASE)
         if review_match:
-            try:
+            with contextlib.suppress(ValueError):
                 result.review_count = int(review_match.group(1).replace(",", ""))
-            except ValueError:
-                pass
-        
+
         # Extract address
         for pattern in cls.ADDRESS_PATTERNS:
             match = re.search(pattern, html)
             if match:
                 result.address = match.group(1)
                 break
-        
+
         # Extract website
         for pattern in cls.WEBSITE_PATTERNS:
             match = re.search(pattern, html, re.IGNORECASE)
@@ -427,19 +425,19 @@ class GMBParser:
                     website = "https://" + website
                 result.website = website
                 break
-        
+
         # Extract place ID
         place_match = re.search(cls.PLACE_ID_PATTERN, html)
         if place_match:
             result.place_id = place_match.group(1) or place_match.group(2)
-        
+
         # Extract category (look for aria-label patterns)
         category_match = re.search(r'aria-label="([^"]+)\s+category"', html, re.IGNORECASE)
         if category_match:
             result.category = category_match.group(1)
-        
+
         return result
-    
+
     @classmethod
     def extract_search_results(cls, html: str) -> list[dict]:
         """
@@ -448,31 +446,31 @@ class GMBParser:
         Returns list of basic business info from search page.
         """
         results = []
-        
+
         # Look for search result items
         # Google Maps search results contain data in specific patterns
         item_pattern = r'<a[^>]*href="([^"]*maps/place/[^"]+)"[^>]*>.*?</a>'
-        
+
         for match in re.finditer(item_pattern, html, re.DOTALL):
             url = match.group(1)
             if not url.startswith("http"):
                 url = "https://www.google.com" + url
-            
+
             # Extract place name from URL
             name_match = re.search(r'/maps/place/([^/]+)/', url)
             name = name_match.group(1).replace("+", " ") if name_match else None
-            
+
             # Extract place ID
             pid_match = re.search(r'!1s([^!]+)', url)
             place_id = pid_match.group(1) if pid_match else None
-            
+
             if name or place_id:
                 results.append({
                     "name": name,
                     "place_id": place_id,
                     "url": url,
                 })
-        
+
         return results
 
 
@@ -499,10 +497,10 @@ class GMBScraper:
         result = await scraper.search_business("Acme Corp", "Sydney, Australia")
         print(result)
     """
-    
+
     def __init__(
         self,
-        proxy_list: Optional[list[str]] = None,
+        proxy_list: list[str] | None = None,
         rate_limit_ms: int = MIN_REQUEST_DELAY_MS,
     ):
         """
@@ -518,7 +516,7 @@ class GMBScraper:
         self._last_request_time = 0
         self._request_count = 0
         self._total_cost = Decimal("0.00")
-        
+
         # Load proxies if not provided
         if not self._proxy_list and HAS_BROWSER:
             try:
@@ -526,42 +524,42 @@ class GMBScraper:
             except Exception as e:
                 logger.warning(f"Failed to load proxies: {e}")
                 self._proxy_list = []
-        
+
         # Identity rotator for stealth
         if HAS_BROWSER:
             self._rotator = IdentityRotator()
         else:
             self._rotator = None
-        
+
         logger.info(
             f"GMBScraper initialized with {len(self._proxy_list or [])} proxies"
         )
-    
+
     async def _rate_limit(self) -> None:
         """Apply rate limiting between requests."""
         import time
-        
+
         elapsed = (time.time() * 1000) - self._last_request_time
         delay_ms = random.randint(self._rate_limit_ms, MAX_REQUEST_DELAY_MS)
-        
+
         if elapsed < delay_ms:
             await asyncio.sleep((delay_ms - elapsed) / 1000)
-        
+
         self._last_request_time = time.time() * 1000
-    
+
     def _track_cost(self, requests: int = 1) -> Decimal:
         """Track cost for requests made."""
         cost = COST_PER_REQUEST_AUD * requests
         self._total_cost += cost
         self._request_count += requests
         return cost
-    
-    def _get_random_proxy(self) -> Optional[str]:
+
+    def _get_random_proxy(self) -> str | None:
         """Get a random proxy from the pool."""
         if not self._proxy_list:
             return None
         return random.choice(self._proxy_list)
-    
+
     async def search_business(
         self,
         name: str,
@@ -586,13 +584,13 @@ class GMBScraper:
             - category, place_id, google_maps_url, opening_hours
         """
         logger.info(f"Searching for business: {name} in {location}")
-        
+
         # Build search query
         query = f"{name} {location}"
         search_url = GOOGLE_MAPS_SEARCH_URL.format(query=quote_plus(query))
-        
+
         await self._rate_limit()
-        
+
         # Fetch search results
         try:
             html = await self._fetch_with_stealth(search_url)
@@ -610,12 +608,12 @@ class GMBScraper:
                 cost_aud=COST_PER_REQUEST_AUD,
                 requests_made=1,
             ).to_dict()
-        
+
         # Parse the page - Google Maps search often shows details directly
         result = GMBParser.parse_business_data(html, search_url)
         result.cost_aud = cost
         result.requests_made = 1
-        
+
         # If we got a match, try to get more details
         if result.found and result.place_id:
             await self._rate_limit()
@@ -630,9 +628,9 @@ class GMBScraper:
                     result.requests_made += details.get("requests_made", 0)
             except Exception as e:
                 logger.warning(f"Failed to get additional details: {e}")
-        
+
         return result.to_dict()
-    
+
     async def scrape_details(
         self,
         place_url: str,
@@ -647,9 +645,9 @@ class GMBScraper:
             dict with business data matching Apify output format
         """
         logger.info(f"Scraping details from: {place_url[:60]}...")
-        
+
         await self._rate_limit()
-        
+
         try:
             html = await self._fetch_with_stealth(place_url)
             cost = self._track_cost(1)
@@ -668,13 +666,13 @@ class GMBScraper:
                 cost_aud=COST_PER_REQUEST_AUD,
                 requests_made=1,
             ).to_dict()
-        
+
         result = GMBParser.parse_business_data(html, place_url)
         result.cost_aud = cost
         result.requests_made = 1
-        
+
         return result.to_dict()
-    
+
     async def batch_scrape(
         self,
         businesses: list[dict],
@@ -692,10 +690,10 @@ class GMBScraper:
             List of business data dicts
         """
         logger.info(f"Batch scraping {len(businesses)} businesses")
-        
+
         results = []
         semaphore = asyncio.Semaphore(max_concurrent)
-        
+
         async def scrape_one(biz: dict) -> dict:
             async with semaphore:
                 if "url" in biz:
@@ -705,14 +703,14 @@ class GMBScraper:
                         biz.get("name", ""),
                         biz.get("location", "Australia"),
                     )
-        
+
         # Process in batches
         tasks = [scrape_one(biz) for biz in businesses]
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        
+
         # Convert exceptions to error results
         final_results = []
-        for i, r in enumerate(results):
+        for _i, r in enumerate(results):
             if isinstance(r, Exception):
                 final_results.append(GMBResult(
                     error=str(r),
@@ -721,18 +719,18 @@ class GMBScraper:
                 ).to_dict())
             else:
                 final_results.append(r)
-        
+
         # Log summary
         success_count = sum(1 for r in final_results if r.get("found"))
         total_cost = sum(Decimal(str(r.get("cost_aud", 0))) for r in final_results)
-        
+
         logger.info(
             f"Batch complete: {success_count}/{len(businesses)} found, "
             f"cost: ${total_cost:.4f} AUD"
         )
-        
+
         return final_results
-    
+
     @retry(
         retry=retry_if_exception_type((httpx.TimeoutException, httpx.ProxyError)),
         stop=stop_after_attempt(MAX_RETRIES),
@@ -764,20 +762,20 @@ class GMBScraper:
                     use_cache=False,  # Don't cache GMB results
                     scroll=True,  # Load lazy content
                 )
-                
+
                 if result.get("success"):
                     return result.get("content", "")
-                
+
                 error = result.get("error", "Unknown error")
                 if any(ind in error.lower() for ind in BLOCK_INDICATORS):
                     raise BlockedError(error)
-                
+
                 logger.warning(f"Browser fetch failed: {error}")
             except BlockedError:
                 raise
             except Exception as e:
                 logger.warning(f"Browser fetch error: {e}")
-        
+
         # Fallback to httpx with proxy
         proxy = self._get_random_proxy()
         headers = {
@@ -789,30 +787,30 @@ class GMBScraper:
             "Connection": "keep-alive",
             "Upgrade-Insecure-Requests": "1",
         }
-        
+
         async with httpx.AsyncClient(
             proxy=proxy,
             timeout=30.0,
             follow_redirects=True,
         ) as client:
             response = await client.get(url, headers=headers)
-            
+
             # Check for blocks
             if response.status_code in (403, 429, 503):
                 raise BlockedError(f"HTTP {response.status_code}")
-            
+
             response.raise_for_status()
-            
+
             html = response.text
-            
+
             # Check content for block indicators
             html_lower = html.lower()
             for indicator in BLOCK_INDICATORS:
                 if indicator in html_lower:
                     raise BlockedError(f"Block indicator detected: {indicator}")
-            
+
             return html
-    
+
     def get_stats(self) -> dict[str, Any]:
         """Get scraper statistics."""
         return {
@@ -831,7 +829,7 @@ class GMBScraper:
 # SINGLETON FACTORY
 # ============================================
 
-_gmb_scraper: Optional[GMBScraper] = None
+_gmb_scraper: GMBScraper | None = None
 
 
 def get_gmb_scraper() -> GMBScraper:
@@ -889,33 +887,33 @@ async def batch_scrape_google_business(
 async def _cli_main():
     """CLI entry point."""
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="GMB Scraper CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
-    
+
     # Search command
     search_parser = subparsers.add_parser("search", help="Search for a business")
     search_parser.add_argument("name", help="Business name")
     search_parser.add_argument("--location", "-l", default="Australia", help="Location")
-    
+
     # Scrape command
     scrape_parser = subparsers.add_parser("scrape", help="Scrape a Maps URL")
     scrape_parser.add_argument("url", help="Google Maps URL")
-    
+
     # Stats command
-    stats_parser = subparsers.add_parser("stats", help="Show scraper stats")
-    
+    _stats_parser = subparsers.add_parser("stats", help="Show scraper stats")
+
     args = parser.parse_args()
-    
+
     if args.command == "search":
         result = await scrape_google_business(args.name, args.location)
         print(json.dumps(result, indent=2, default=str))
-    
+
     elif args.command == "scrape":
         scraper = get_gmb_scraper()
         result = await scraper.scrape_details(args.url)
         print(json.dumps(result, indent=2, default=str))
-    
+
     elif args.command == "stats":
         scraper = get_gmb_scraper()
         stats = scraper.get_stats()

--- a/src/integrations/heygen.py
+++ b/src/integrations/heygen.py
@@ -456,7 +456,7 @@ class HeyGenClient:
             # Create parent directories if needed
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            async with httpx.AsyncClient(timeout=300.0) as client:  # 5 min timeout for large videos
+            async with httpx.AsyncClient(timeout=300.0) as client:  # 5 min timeout for large videos  # noqa: SIM117
                 async with client.stream("GET", status.video_url) as response:
                     if response.status_code != 200:
                         raise IntegrationError(

--- a/src/integrations/hunter.py
+++ b/src/integrations/hunter.py
@@ -27,9 +27,10 @@ SIEGE CONTEXT:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -121,7 +122,7 @@ class Department(str, Enum):
 @dataclass
 class HunterEmail:
     """Single email result from Hunter."""
-    
+
     email: str
     email_type: EmailType | None = None
     confidence: int = 0
@@ -134,7 +135,7 @@ class HunterEmail:
     twitter: str | None = None
     phone_number: str | None = None
     sources: list[dict] = field(default_factory=list)
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -156,7 +157,7 @@ class HunterEmail:
 @dataclass
 class DomainSearchResult:
     """Result from domain search."""
-    
+
     domain: str
     disposable: bool = False
     webmail: bool = False
@@ -167,7 +168,7 @@ class DomainSearchResult:
     total_emails: int = 0
     cost_aud: float = 0.0
     source: str = "hunter"
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -187,7 +188,7 @@ class DomainSearchResult:
 @dataclass
 class EmailFinderResult:
     """Result from email finder."""
-    
+
     found: bool
     email: str | None = None
     score: int = 0
@@ -205,7 +206,7 @@ class EmailFinderResult:
     sources: list[dict] = field(default_factory=list)
     cost_aud: float = 0.0
     source: str = "hunter"
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -227,7 +228,7 @@ class EmailFinderResult:
 @dataclass
 class EmailVerificationResult:
     """Result from email verification."""
-    
+
     email: str
     status: VerificationStatus
     result: str
@@ -244,17 +245,17 @@ class EmailVerificationResult:
     sources: list[dict] = field(default_factory=list)
     cost_aud: float = 0.0
     source: str = "hunter"
-    
+
     @property
     def is_valid(self) -> bool:
         """Check if email is valid for outreach."""
         return self.status == VerificationStatus.VALID and self.score >= 70
-    
+
     @property
     def is_risky(self) -> bool:
         """Check if email is risky."""
         return self.disposable or self.accept_all or self.score < 50
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -281,7 +282,7 @@ class EmailVerificationResult:
 
 class HunterError(IntegrationError):
     """Hunter-specific integration error."""
-    
+
     def __init__(
         self,
         message: str,
@@ -292,7 +293,7 @@ class HunterError(IntegrationError):
 
 class HunterRateLimitError(HunterError):
     """Hunter rate limit exceeded (403)."""
-    
+
     def __init__(
         self,
         retry_after: int | None = None,
@@ -303,22 +304,23 @@ class HunterRateLimitError(HunterError):
             details["retry_after_seconds"] = retry_after
         super().__init__(message="Hunter rate limit exceeded", details=details)
         self.retry_after = retry_after
-        
+
         # Directive 048 Part F: Fire alert on rate limit
         asyncio.create_task(self._fire_rate_limit_alert(retry_after))
-    
+
     @staticmethod
     async def _fire_rate_limit_alert(retry_after: int | None) -> None:
         """Fire alert for Hunter rate limit hit."""
         try:
             from datetime import timedelta
+
             from src.integrations.supabase import get_db_session
             from src.services.alert_service import get_alert_service
-            
+
             reset_time = None
             if retry_after:
-                reset_time = datetime.now(timezone.utc) + timedelta(seconds=retry_after)
-            
+                reset_time = datetime.now(UTC) + timedelta(seconds=retry_after)
+
             async with get_db_session() as db:
                 alert_service = get_alert_service(db)
                 await alert_service.alert_hunter_rate_limit(
@@ -331,23 +333,23 @@ class HunterRateLimitError(HunterError):
 
 class HunterQuotaExceededError(HunterError):
     """Hunter usage quota exceeded (429)."""
-    
+
     def __init__(self, details: dict[str, Any] | None = None):
         super().__init__(
             message="Hunter usage quota exceeded - upgrade plan or wait for reset",
             details=details,
         )
-        
+
         # Directive 048 Part F: Fire alert on quota exceeded
         asyncio.create_task(self._fire_quota_alert())
-    
+
     @staticmethod
     async def _fire_quota_alert() -> None:
         """Fire alert for Hunter quota exceeded."""
         try:
             from src.integrations.supabase import get_db_session
             from src.services.alert_service import get_alert_service
-            
+
             async with get_db_session() as db:
                 alert_service = get_alert_service(db)
                 await alert_service.alert_hunter_rate_limit(
@@ -392,7 +394,7 @@ class HunterClient:
         cost_tracking_enabled: Whether to track costs (default True)
         total_cost_aud: Running total of API costs this session
     """
-    
+
     def __init__(
         self,
         api_key: str | None = None,
@@ -409,19 +411,19 @@ class HunterClient:
             IntegrationError: If no API key provided or found in settings
         """
         self.api_key = api_key or getattr(settings, "hunter_api_key", "")
-        
+
         if not self.api_key:
             raise IntegrationError(
                 service="hunter",
                 message="Hunter API key is required. Set HUNTER_API_KEY in environment.",
             )
-        
+
         self.cost_tracking_enabled = cost_tracking_enabled
         self.total_cost_aud: float = 0.0
         self._client: httpx.AsyncClient | None = None
         self._request_count: int = 0
         self._last_request_time: datetime | None = None
-    
+
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create HTTP client with authentication."""
         if self._client is None:
@@ -434,32 +436,32 @@ class HunterClient:
                 timeout=DEFAULT_TIMEOUT,
             )
         return self._client
-    
+
     async def close(self) -> None:
         """Close HTTP client and cleanup resources."""
         if self._client is not None:
             await self._client.aclose()
             self._client = None
-    
-    async def __aenter__(self) -> "HunterClient":
+
+    async def __aenter__(self) -> HunterClient:
         """Async context manager entry."""
         return self
-    
+
     async def __aexit__(self, *args) -> None:
         """Async context manager exit."""
         await self.close()
-    
+
     async def _rate_limit_delay(self) -> None:
         """Apply rate limiting delay between requests."""
         if self._last_request_time:
             elapsed = (
-                datetime.now(timezone.utc) - self._last_request_time
+                datetime.now(UTC) - self._last_request_time
             ).total_seconds()
             if elapsed < REQUEST_DELAY_SECONDS:
                 await asyncio.sleep(REQUEST_DELAY_SECONDS - elapsed)
-        
-        self._last_request_time = datetime.now(timezone.utc)
-    
+
+        self._last_request_time = datetime.now(UTC)
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),
@@ -490,14 +492,14 @@ class HunterClient:
             APIError: Other API errors
         """
         await self._rate_limit_delay()
-        
+
         client = await self._get_client()
         self._request_count += 1
-        
+
         # Always include api_key in params
         params = params or {}
         params["api_key"] = self.api_key
-        
+
         try:
             response = await client.request(
                 method=method,
@@ -505,25 +507,23 @@ class HunterClient:
                 params=params,
                 json=data if method != "GET" else None,
             )
-            
+
             # Handle specific status codes
             if response.status_code == 403:
                 raise HunterRateLimitError(retry_after=60)
-            
+
             if response.status_code == 429:
                 raise HunterQuotaExceededError()
-            
+
             response.raise_for_status()
             return response.json()
-            
+
         except httpx.HTTPStatusError as e:
             # Try to extract error details
             error_body = {}
-            try:
+            with contextlib.suppress(Exception):
                 error_body = e.response.json()
-            except Exception:
-                pass
-            
+
             sentry_sdk.set_context(
                 "hunter_request",
                 {
@@ -534,20 +534,20 @@ class HunterClient:
                 },
             )
             sentry_sdk.capture_exception(e)
-            
+
             # Extract error message from Hunter's error format
             error_msg = "Hunter API error"
             if "errors" in error_body and error_body["errors"]:
                 error_info = error_body["errors"][0]
                 error_msg = error_info.get("details", str(error_info))
-            
+
             raise APIError(
                 service="hunter",
                 status_code=e.response.status_code,
                 response=str(error_body),
                 message=f"{error_msg} ({e.response.status_code})",
             )
-        
+
         except httpx.RequestError as e:
             sentry_sdk.set_context(
                 "hunter_request",
@@ -557,22 +557,22 @@ class HunterClient:
                 },
             )
             sentry_sdk.capture_exception(e)
-            
+
             raise IntegrationError(
                 service="hunter",
                 message=f"Hunter request failed: {str(e)}",
             )
-    
+
     def _track_cost(self, cost: float) -> float:
         """Track API cost if enabled."""
         if self.cost_tracking_enabled:
             self.total_cost_aud += cost
         return cost
-    
+
     # ========================================
     # DOMAIN SEARCH
     # ========================================
-    
+
     async def domain_search(
         self,
         domain: str,
@@ -605,41 +605,41 @@ class HunterClient:
         """
         if not domain:
             raise ValidationError(message="Domain is required for domain search")
-        
+
         # Normalize domain
         domain = domain.lower().strip()
         if domain.startswith(("http://", "https://")):
             domain = domain.split("//")[1].split("/")[0]
-        
+
         logger.info(f"[Hunter] Domain search for: {domain}")
-        
+
         params = {
             "domain": domain,
             "limit": min(limit, 100),
             "offset": offset,
         }
-        
+
         if email_type:
             params["type"] = email_type.value
-        
+
         if seniority:
             params["seniority"] = ",".join(s.value for s in seniority)
-        
+
         if department:
             params["department"] = ",".join(d.value for d in department)
-        
+
         try:
             response = await self._request("GET", "/domain-search", params=params)
             data = response.get("data", {})
             meta = response.get("meta", {})
-            
+
             # Parse emails
             emails = []
             for email_data in data.get("emails", []):
                 emails.append(self._parse_email(email_data))
-            
+
             cost = self._track_cost(COST_DOMAIN_SEARCH_AUD)
-            
+
             return DomainSearchResult(
                 domain=data.get("domain", domain),
                 disposable=data.get("disposable", False),
@@ -651,7 +651,7 @@ class HunterClient:
                 total_emails=meta.get("results", len(emails)),
                 cost_aud=cost,
             )
-            
+
         except (HunterRateLimitError, HunterQuotaExceededError):
             raise
         except APIError:
@@ -659,11 +659,11 @@ class HunterClient:
         except Exception as e:
             logger.warning(f"[Hunter] Domain search failed for {domain}: {e}")
             return DomainSearchResult(domain=domain, cost_aud=0.0)
-    
+
     # ========================================
     # EMAIL FINDER
     # ========================================
-    
+
     async def email_finder(
         self,
         domain: str,
@@ -694,32 +694,32 @@ class HunterClient:
             raise ValidationError(message="Domain is required for email finder")
         if not first_name or not last_name:
             raise ValidationError(message="First and last name are required")
-        
+
         # Normalize
         domain = domain.lower().strip()
         if domain.startswith(("http://", "https://")):
             domain = domain.split("//")[1].split("/")[0]
-        
+
         logger.info(f"[Hunter] Email finder: {first_name} {last_name} @ {domain}")
-        
+
         params = {
             "domain": domain,
             "first_name": first_name.strip(),
             "last_name": last_name.strip(),
         }
-        
+
         if company:
             params["company"] = company.strip()
-        
+
         try:
             response = await self._request("GET", "/email-finder", params=params)
             data = response.get("data", {})
-            
+
             email = data.get("email")
             found = bool(email)
-            
+
             cost = self._track_cost(COST_EMAIL_FINDER_AUD) if found else 0.0
-            
+
             return EmailFinderResult(
                 found=found,
                 email=email,
@@ -738,7 +738,7 @@ class HunterClient:
                 sources=data.get("sources", []),
                 cost_aud=cost,
             )
-            
+
         except (HunterRateLimitError, HunterQuotaExceededError):
             raise
         except APIError:
@@ -751,11 +751,11 @@ class HunterClient:
                 first_name=first_name,
                 last_name=last_name,
             )
-    
+
     # ========================================
     # EMAIL VERIFICATION
     # ========================================
-    
+
     async def verify_email(self, email: str) -> EmailVerificationResult:
         """
         Verify email address deliverability.
@@ -775,11 +775,11 @@ class HunterClient:
         """
         if not email or "@" not in email:
             raise ValidationError(message="Valid email address is required")
-        
+
         email = email.lower().strip()
-        
+
         logger.info(f"[Hunter] Verifying email: {email}")
-        
+
         try:
             response = await self._request(
                 "GET",
@@ -787,16 +787,16 @@ class HunterClient:
                 params={"email": email},
             )
             data = response.get("data", {})
-            
+
             # Parse status
             status_str = data.get("status", "unknown").lower()
             try:
                 status = VerificationStatus(status_str)
             except ValueError:
                 status = VerificationStatus.UNKNOWN
-            
+
             cost = self._track_cost(COST_EMAIL_VERIFY_AUD)
-            
+
             return EmailVerificationResult(
                 email=data.get("email", email),
                 status=status,
@@ -814,7 +814,7 @@ class HunterClient:
                 sources=data.get("sources", []),
                 cost_aud=cost,
             )
-            
+
         except (HunterRateLimitError, HunterQuotaExceededError):
             raise
         except APIError:
@@ -828,11 +828,11 @@ class HunterClient:
                 score=0,
                 cost_aud=0.0,
             )
-    
+
     # ========================================
     # BATCH OPERATIONS
     # ========================================
-    
+
     async def batch_find_emails(
         self,
         prospects: list[dict[str, str]],
@@ -853,12 +853,12 @@ class HunterClient:
         """
         if not prospects:
             return []
-        
+
         logger.info(f"[Hunter] Batch email finder for {len(prospects)} prospects")
-        
+
         results: list[EmailFinderResult] = []
         semaphore = asyncio.Semaphore(max_concurrent)
-        
+
         async def find_with_semaphore(prospect: dict) -> EmailFinderResult:
             async with semaphore:
                 try:
@@ -878,30 +878,30 @@ class HunterClient:
                         first_name=prospect.get("first_name"),
                         last_name=prospect.get("last_name"),
                     )
-        
+
         try:
             for i, prospect in enumerate(prospects):
                 result = await find_with_semaphore(prospect)
                 results.append(result)
-                
+
                 if (i + 1) % 10 == 0:
                     logger.info(
                         f"[Hunter] Batch progress: {i + 1}/{len(prospects)} "
                         f"(Total cost: ${self.total_cost_aud:.2f} AUD)"
                     )
-                    
+
         except HunterQuotaExceededError:
             logger.error("[Hunter] Quota exceeded during batch - stopping")
             raise
-        
+
         successful = sum(1 for r in results if r.found)
         logger.info(
             f"[Hunter] Batch complete: {successful}/{len(prospects)} emails found "
             f"(Total cost: ${self.total_cost_aud:.2f} AUD)"
         )
-        
+
         return results
-    
+
     async def batch_verify_emails(
         self,
         emails: list[str],
@@ -921,12 +921,12 @@ class HunterClient:
         """
         if not emails:
             return []
-        
+
         logger.info(f"[Hunter] Batch verification for {len(emails)} emails")
-        
+
         results: list[EmailVerificationResult] = []
         semaphore = asyncio.Semaphore(max_concurrent)
-        
+
         async def verify_with_semaphore(email: str) -> EmailVerificationResult:
             async with semaphore:
                 try:
@@ -940,34 +940,34 @@ class HunterClient:
                         status=VerificationStatus.UNKNOWN,
                         result="error",
                     )
-        
+
         try:
             for i, email in enumerate(emails):
                 result = await verify_with_semaphore(email)
                 results.append(result)
-                
+
                 if (i + 1) % 20 == 0:
                     logger.info(
                         f"[Hunter] Verify progress: {i + 1}/{len(emails)} "
                         f"(Total cost: ${self.total_cost_aud:.2f} AUD)"
                     )
-                    
+
         except HunterQuotaExceededError:
             logger.error("[Hunter] Quota exceeded during batch verify - stopping")
             raise
-        
+
         valid_count = sum(1 for r in results if r.is_valid)
         logger.info(
             f"[Hunter] Batch verify complete: {valid_count}/{len(emails)} valid "
             f"(Total cost: ${self.total_cost_aud:.2f} AUD)"
         )
-        
+
         return results
-    
+
     # ========================================
     # HELPER METHODS
     # ========================================
-    
+
     def _parse_email(self, data: dict) -> HunterEmail:
         """Parse email data from API response."""
         email_type = None
@@ -976,7 +976,7 @@ class HunterClient:
             email_type = EmailType.PERSONAL
         elif type_str == "generic":
             email_type = EmailType.GENERIC
-        
+
         return HunterEmail(
             email=data.get("value", data.get("email", "")),
             email_type=email_type,
@@ -991,11 +991,11 @@ class HunterClient:
             phone_number=data.get("phone_number"),
             sources=data.get("sources", []),
         )
-    
+
     def get_session_cost(self) -> float:
         """Get total cost incurred this session in $AUD."""
         return self.total_cost_aud
-    
+
     def reset_cost_tracking(self) -> None:
         """Reset session cost tracking to zero."""
         self.total_cost_aud = 0.0

--- a/src/integrations/infraforge.py
+++ b/src/integrations/infraforge.py
@@ -5,6 +5,7 @@ Auth: Authorization header (plain key)
 """
 
 import httpx
+
 from src.config.settings import get_settings
 
 # Workspace IDs for InfraForge/Salesforge/WarmForge integration

--- a/src/integrations/kaspr.py
+++ b/src/integrations/kaspr.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -69,7 +69,7 @@ REQUEST_DELAY_SECONDS = 0.5  # Safety buffer
 @dataclass
 class KasprEnrichmentResult:
     """Result from Kaspr enrichment."""
-    
+
     found: bool
     mobile_number_verified: str | None = None
     mobile_confidence: int = 0  # 0-100 score
@@ -83,7 +83,7 @@ class KasprEnrichmentResult:
     cost_aud: float = 0.0
     source: str = "kaspr"
     raw_response: dict | None = None
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for storage/API response."""
         return {
@@ -109,7 +109,7 @@ class KasprEnrichmentResult:
 
 class KasprError(IntegrationError):
     """Kaspr-specific integration error."""
-    
+
     def __init__(
         self,
         message: str,
@@ -120,7 +120,7 @@ class KasprError(IntegrationError):
 
 class KasprRateLimitError(KasprError):
     """Kaspr rate limit exceeded."""
-    
+
     def __init__(
         self,
         retry_after: int | None = None,
@@ -135,7 +135,7 @@ class KasprRateLimitError(KasprError):
 
 class KasprCreditExhaustedError(KasprError):
     """Kaspr credits exhausted."""
-    
+
     def __init__(self, details: dict[str, Any] | None = None):
         super().__init__(
             message="Kaspr credits exhausted - plan limit reached",
@@ -170,7 +170,7 @@ class KasprClient:
         cost_tracking_enabled: Whether to track costs (default True)
         total_cost_aud: Running total of API costs this session
     """
-    
+
     def __init__(
         self,
         api_key: str | None = None,
@@ -187,19 +187,19 @@ class KasprClient:
             IntegrationError: If no API key provided or found in settings
         """
         self.api_key = api_key or getattr(settings, "kaspr_api_key", "")
-        
+
         if not self.api_key:
             raise IntegrationError(
                 service="kaspr",
                 message="Kaspr API key is required. Set KASPR_API_KEY in environment.",
             )
-        
+
         self.cost_tracking_enabled = cost_tracking_enabled
         self.total_cost_aud: float = 0.0
         self._client: httpx.AsyncClient | None = None
         self._request_count: int = 0
         self._last_request_time: datetime | None = None
-    
+
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create HTTP client with authentication."""
         if self._client is None:
@@ -212,32 +212,32 @@ class KasprClient:
                 timeout=DEFAULT_TIMEOUT,
             )
         return self._client
-    
+
     async def close(self) -> None:
         """Close HTTP client and cleanup resources."""
         if self._client is not None:
             await self._client.aclose()
             self._client = None
-    
-    async def __aenter__(self) -> "KasprClient":
+
+    async def __aenter__(self) -> KasprClient:
         """Async context manager entry."""
         return self
-    
+
     async def __aexit__(self, *args) -> None:
         """Async context manager exit."""
         await self.close()
-    
+
     async def _rate_limit_delay(self) -> None:
         """Apply rate limiting delay between requests."""
         if self._last_request_time:
             elapsed = (
-                datetime.now(timezone.utc) - self._last_request_time
+                datetime.now(UTC) - self._last_request_time
             ).total_seconds()
             if elapsed < REQUEST_DELAY_SECONDS:
                 await asyncio.sleep(REQUEST_DELAY_SECONDS - elapsed)
-        
-        self._last_request_time = datetime.now(timezone.utc)
-    
+
+        self._last_request_time = datetime.now(UTC)
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),
@@ -266,29 +266,29 @@ class KasprClient:
             APIError: Other API errors
         """
         await self._rate_limit_delay()
-        
+
         client = await self._get_client()
         self._request_count += 1
-        
+
         try:
             response = await client.request(
                 method=method,
                 url=endpoint,
                 json=data,
             )
-            
+
             # Handle specific status codes
             if response.status_code == 429:
                 retry_after = response.headers.get("Retry-After")
                 retry_seconds = int(retry_after) if retry_after else 60
                 raise KasprRateLimitError(retry_after=retry_seconds)
-            
+
             if response.status_code == 402:
                 raise KasprCreditExhaustedError()
-            
+
             response.raise_for_status()
             return response.json()
-            
+
         except httpx.HTTPStatusError as e:
             sentry_sdk.set_context(
                 "kaspr_request",
@@ -299,14 +299,14 @@ class KasprClient:
                 },
             )
             sentry_sdk.capture_exception(e)
-            
+
             raise APIError(
                 service="kaspr",
                 status_code=e.response.status_code,
                 response=e.response.text,
                 message=f"Kaspr API error: {e.response.status_code}",
             )
-        
+
         except httpx.RequestError as e:
             sentry_sdk.set_context(
                 "kaspr_request",
@@ -316,12 +316,12 @@ class KasprClient:
                 },
             )
             sentry_sdk.capture_exception(e)
-            
+
             raise IntegrationError(
                 service="kaspr",
                 message=f"Kaspr request failed: {str(e)}",
             )
-    
+
     def _extract_linkedin_public_id(self, linkedin_url: str) -> str | None:
         """
         Extract public LinkedIn ID from URL.
@@ -334,22 +334,22 @@ class KasprClient:
         """
         if not linkedin_url:
             return None
-        
+
         # Normalize URL
         url = linkedin_url.strip().rstrip("/")
-        
+
         # Handle various LinkedIn URL formats
         # https://www.linkedin.com/in/john-doe-12345
         # https://linkedin.com/in/john-doe-12345
         # linkedin.com/in/john-doe-12345
-        
+
         if "/in/" in url:
             parts = url.split("/in/")
             if len(parts) > 1:
                 return parts[1].split("/")[0].split("?")[0]
-        
+
         return None
-    
+
     async def enrich_mobile(
         self,
         linkedin_url: str,
@@ -374,15 +374,15 @@ class KasprClient:
             raise ValidationError(
                 message="LinkedIn URL is required for mobile enrichment",
             )
-        
+
         public_id = self._extract_linkedin_public_id(linkedin_url)
         if not public_id:
             raise ValidationError(
                 message=f"Could not extract LinkedIn ID from URL: {linkedin_url}",
             )
-        
+
         logger.info(f"[Kaspr] Enriching mobile for LinkedIn: {public_id}")
-        
+
         try:
             # Kaspr Person Search API
             # Reference: https://developers.kaspr.io/reference/person-search
@@ -393,13 +393,13 @@ class KasprClient:
                     "linkedInUrl": linkedin_url,
                 },
             )
-            
+
             return self._transform_response(response, linkedin_url)
-            
+
         except (KasprRateLimitError, KasprCreditExhaustedError):
             # Re-raise these specific errors
             raise
-        
+
         except Exception as e:
             logger.warning(f"[Kaspr] Enrichment failed for {public_id}: {e}")
             return KasprEnrichmentResult(
@@ -407,7 +407,7 @@ class KasprClient:
                 linkedin_url=linkedin_url,
                 source="kaspr",
             )
-    
+
     async def enrich_identity(
         self,
         linkedin_url: str | None = None,
@@ -436,11 +436,11 @@ class KasprClient:
         if linkedin_url:
             result = await self.enrich_mobile(linkedin_url)
             return result.to_dict()
-        
+
         # Fallback: Try name + company lookup
         if first_name and last_name and company:
             logger.info(f"[Kaspr] Trying name+company lookup: {first_name} {last_name} @ {company}")
-            
+
             try:
                 response = await self._request(
                     method="POST",
@@ -451,20 +451,20 @@ class KasprClient:
                         "companyName": company,
                     },
                 )
-                
+
                 result = self._transform_response(response, linkedin_url)
                 return result.to_dict()
-                
+
             except Exception as e:
                 logger.warning(f"[Kaspr] Name+company lookup failed: {e}")
-        
+
         # No valid lookup parameters
         return {
             "found": False,
             "source": "kaspr",
             "error": "No linkedin_url or name+company provided for lookup",
         }
-    
+
     async def batch_enrich(
         self,
         profiles: list[str],
@@ -485,12 +485,12 @@ class KasprClient:
         """
         if not profiles:
             return []
-        
+
         logger.info(f"[Kaspr] Batch enrichment for {len(profiles)} profiles")
-        
+
         results: list[KasprEnrichmentResult] = []
         semaphore = asyncio.Semaphore(max_concurrent)
-        
+
         async def enrich_with_semaphore(url: str) -> KasprEnrichmentResult:
             async with semaphore:
                 try:
@@ -505,33 +505,33 @@ class KasprClient:
                         linkedin_url=url,
                         source="kaspr",
                     )
-        
+
         try:
             # Process in batches with rate limiting
             for i, url in enumerate(profiles):
                 result = await enrich_with_semaphore(url)
                 results.append(result)
-                
+
                 # Log progress
                 if (i + 1) % 10 == 0:
                     logger.info(
                         f"[Kaspr] Batch progress: {i + 1}/{len(profiles)} "
                         f"(Total cost: ${self.total_cost_aud:.2f} AUD)"
                     )
-                    
+
         except KasprCreditExhaustedError:
             logger.error("[Kaspr] Credits exhausted during batch - stopping")
             raise
-        
+
         # Summary logging
         successful = sum(1 for r in results if r.found and r.mobile_number_verified)
         logger.info(
             f"[Kaspr] Batch complete: {successful}/{len(profiles)} mobiles found "
             f"(Total cost: ${self.total_cost_aud:.2f} AUD)"
         )
-        
+
         return results
-    
+
     def _transform_response(
         self,
         response: dict,
@@ -569,11 +569,11 @@ class KasprClient:
                 linkedin_url=linkedin_url,
                 source="kaspr",
             )
-        
+
         # Extract mobile number (prefer highest confidence)
         mobile_number = None
         mobile_confidence = 0
-        
+
         phones = response.get("phones") or []
         for phone in phones:
             phone_type = phone.get("type", "").lower()
@@ -582,13 +582,13 @@ class KasprClient:
                 if confidence > mobile_confidence:
                     mobile_number = phone.get("number")
                     mobile_confidence = confidence
-        
+
         # If no mobile, take first phone
         if not mobile_number and phones:
             first_phone = phones[0]
             mobile_number = first_phone.get("number")
             mobile_confidence = first_phone.get("confidence", 50)
-        
+
         # Extract email (prefer work email)
         email = None
         emails = response.get("emails") or []
@@ -597,26 +597,26 @@ class KasprClient:
             if email_type == "work":
                 email = email_data.get("email")
                 break
-        
+
         if not email and emails:
             email = emails[0].get("email")
-        
+
         # Build name
         first_name = response.get("firstName") or response.get("first_name")
         last_name = response.get("lastName") or response.get("last_name")
         full_name = None
         if first_name and last_name:
             full_name = f"{first_name} {last_name}"
-        
+
         # Determine if enrichment was successful
         found = bool(mobile_number or email)
-        
+
         # Track cost for successful enrichment
         cost = 0.0
         if found and self.cost_tracking_enabled:
             cost = COST_PER_ENRICHMENT_AUD
             self.total_cost_aud += cost
-        
+
         return KasprEnrichmentResult(
             found=found,
             mobile_number_verified=mobile_number,
@@ -632,7 +632,7 @@ class KasprClient:
             source="kaspr",
             raw_response=response if logger.isEnabledFor(logging.DEBUG) else None,
         )
-    
+
     def get_session_cost(self) -> float:
         """
         Get total cost incurred this session in $AUD.
@@ -641,7 +641,7 @@ class KasprClient:
             Total cost in AUD
         """
         return self.total_cost_aud
-    
+
     def reset_cost_tracking(self) -> None:
         """Reset session cost tracking to zero."""
         self.total_cost_aud = 0.0

--- a/src/integrations/siege_waterfall.py
+++ b/src/integrations/siege_waterfall.py
@@ -34,12 +34,13 @@ import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
 import httpx
 import sentry_sdk
+from fuzzywuzzy import fuzz
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -47,9 +48,6 @@ from tenacity import (
     wait_exponential,
 )
 
-from fuzzywuzzy import fuzz
-
-from src.config.settings import settings
 from src.exceptions import APIError, IntegrationError, ValidationError
 
 logger = logging.getLogger(__name__)
@@ -63,7 +61,7 @@ MEDIUM_CONFIDENCE_THRESHOLD = 80
 # These holding company patterns have low GMB match probability
 GENERIC_NAME_PATTERNS = (
     "holdings",
-    "enterprises", 
+    "enterprises",
     "investments",
     "trust",
     "group",
@@ -160,7 +158,7 @@ class TierResult:
     success: bool
     data: dict[str, Any] = field(default_factory=dict)
     cost_aud: float = 0.0
-    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
     error: str | None = None
     skipped: bool = False
     skip_reason: str | None = None
@@ -264,7 +262,7 @@ class GMBScraperAdapter:
     Method: discover_by=location
     Cost: ~$0.001/lead AUD
     """
-    
+
     DATASET_ID = "gd_m8ebnr0q2qlklc02fz"
     STATE_CITY_MAP = {
         "NSW": "Sydney", "VIC": "Melbourne", "QLD": "Brisbane",
@@ -274,7 +272,7 @@ class GMBScraperAdapter:
 
     def __init__(self):
         self._api_key = os.getenv("BRIGHTDATA_API_KEY")
-    
+
     def _is_available(self) -> bool:
         """Check if Bright Data API is configured."""
         return bool(self._api_key)
@@ -288,9 +286,9 @@ class GMBScraperAdapter:
         if not self._is_available():
             logger.warning("[GMB] BRIGHTDATA_API_KEY not set")
             return None
-        
+
         city = location or "Australia"
-        
+
         try:
             async with httpx.AsyncClient(timeout=120.0) as client:
                 # Trigger collection
@@ -313,7 +311,7 @@ class GMBScraperAdapter:
                 snapshot_id = resp.json().get("snapshot_id")
                 if not snapshot_id:
                     return None
-                
+
                 # Poll for completion
                 for _ in range(18):
                     await asyncio.sleep(10)
@@ -325,7 +323,7 @@ class GMBScraperAdapter:
                         break
                 else:
                     return None
-                
+
                 # Fetch results
                 data = await client.get(
                     f"https://api.brightdata.com/datasets/v3/snapshot/{snapshot_id}",
@@ -333,7 +331,7 @@ class GMBScraperAdapter:
                     headers={"Authorization": f"Bearer {self._api_key}"},
                 )
                 results = data.json()
-                
+
                 if results and len(results) > 0:
                     # Find best match
                     best = max(
@@ -343,7 +341,7 @@ class GMBScraperAdapter:
                     )
                     if best and fuzz.ratio(business_name.lower(), best.get("name", "").lower()) >= FUZZY_MATCH_THRESHOLD:
                         return {"found": True, **best}
-                
+
                 return None
         except Exception as e:
             logger.warning(f"[GMB] scrape_business failed: {e}")
@@ -359,10 +357,10 @@ class GMBScraperAdapter:
         if not self._is_available():
             logger.warning("[GMB] BRIGHTDATA_API_KEY not set")
             return {"found": False, "source": "gmb_unavailable"}
-        
+
         try:
             result = await self.scrape_business(business_name, location)
-            
+
             if result and result.get("found"):
                 return {
                     "found": True,
@@ -380,7 +378,7 @@ class GMBScraperAdapter:
                     "lng": result.get("lon"),
                     "cost_aud": 0.001,
                 }
-            
+
             return {"found": False, "source": "brightdata_gmb"}
         except Exception as e:
             logger.warning(f"[GMB] enrich_from_gmb failed: {e}")
@@ -401,7 +399,7 @@ class HunterClientAdapter:
 
     def __init__(self):
         self._client = None
-    
+
     def _get_client(self):
         """Lazy-load the real Hunter client."""
         if self._client is None:
@@ -424,7 +422,7 @@ class HunterClientAdapter:
                 "score": 0,
                 "source": "hunter_unavailable",
             }
-        
+
         try:
             result = await client.verify_email(email)
             return {
@@ -457,7 +455,7 @@ class HunterClientAdapter:
         if not client:
             logger.warning("[Hunter] Client not available")
             return {"found": False, "source": "hunter_unavailable"}
-        
+
         try:
             result = await client.email_finder(domain, first_name, last_name)
             return {
@@ -482,7 +480,7 @@ class HunterClientAdapter:
         if not client:
             logger.warning("[Hunter] Client not available")
             return []
-        
+
         try:
             result = await client.domain_search(domain, limit=limit)
             return [email.to_dict() for email in result.emails]
@@ -509,7 +507,7 @@ class ProxycurlClientAdapter:
     def __init__(self):
         self._client = None
         self._deprecated = True
-    
+
     def _get_client(self):
         """Proxycurl is deprecated - always returns None."""
         # Proxycurl shutdown July 2025. Do not attempt to import.
@@ -527,7 +525,7 @@ class ProxycurlClientAdapter:
         if not client:
             logger.warning("[Proxycurl] Client not available")
             return None
-        
+
         try:
             result = await client.enrich_profile(linkedin_url)
             if result.found:
@@ -547,11 +545,11 @@ class ProxycurlClientAdapter:
         if not client:
             logger.warning("[Proxycurl] Client not available")
             return None
-        
+
         if not linkedin_url:
             logger.warning("[Proxycurl] linkedin_url required for company profile")
             return None
-        
+
         try:
             result = await client.enrich_company(linkedin_url)
             if result.found:
@@ -571,10 +569,10 @@ class ProxycurlClientAdapter:
         if not client:
             logger.warning("[Proxycurl] Client not available")
             return {"found": False, "source": "proxycurl_unavailable"}
-        
+
         if not linkedin_url:
             return {"found": False, "source": "proxycurl", "error": "linkedin_url required"}
-        
+
         try:
             result = await client.enrich_profile(linkedin_url)
             data = result.to_dict()
@@ -593,14 +591,14 @@ ProxycurlClientStub = ProxycurlClientAdapter
 # Import real Kaspr client (Tier 5 - implemented)
 try:
     from src.integrations.kaspr import KasprClient, get_kaspr_client
-    
+
     KASPR_AVAILABLE = True
 except ImportError:
     KASPR_AVAILABLE = False
-    
+
     class KasprClient:  # type: ignore
         """Fallback stub if kaspr.py not available."""
-        
+
         async def enrich_identity(
             self,
             linkedin_url: str | None = None,
@@ -668,7 +666,7 @@ class SiegeWaterfall:
         self.gmb_scraper = gmb_scraper or GMBScraperAdapter()
         self.hunter_client = hunter_client or HunterClientAdapter()
         self.proxycurl_client = proxycurl_client or ProxycurlClientAdapter()
-        
+
         # Use real Kaspr client if available (Tier 5 - optional)
         # Kaspr requires KASPR_API_KEY; if missing, Tier 5 is simply unavailable
         if kaspr_client:
@@ -711,9 +709,9 @@ class SiegeWaterfall:
         Raises:
             ValidationError: If no usable lead data provided
         """
-        started_at = datetime.now(timezone.utc).isoformat()
+        started_at = datetime.now(UTC).isoformat()
         skip_tiers = skip_tiers or []
-        
+
         # Validate we have something to work with
         if not any([
             lead.get("email"),
@@ -727,15 +725,15 @@ class SiegeWaterfall:
                 message="Lead must have at least one of: email, abn, linkedin_url, "
                         "company_name, domain, or first_name + last_name",
             )
-        
+
         # Track results
         tier_results: list[TierResult] = []
         enriched_data: dict[str, Any] = dict(lead)  # Start with original
         total_cost_aud = 0.0
-        
+
         # Current ALS score (may be passed in or calculated)
         current_als = lead.get("als_score", 0)
-        
+
         # ===== TIER 1: ABN Bulk =====
         if EnrichmentTier.ABN not in skip_tiers:
             result = await self.tier1_abn(enriched_data)
@@ -750,7 +748,7 @@ class SiegeWaterfall:
                 skipped=True,
                 skip_reason="Tier skipped by request",
             ))
-        
+
         # ===== TIER 2: GMB/Ads Signals =====
         if EnrichmentTier.GMB not in skip_tiers:
             result = await self.tier2_gmb(enriched_data)
@@ -765,7 +763,7 @@ class SiegeWaterfall:
                 skipped=True,
                 skip_reason="Tier skipped by request",
             ))
-        
+
         # ===== TIER 3: Hunter.io =====
         if EnrichmentTier.HUNTER not in skip_tiers:
             result = await self.tier3_hunter(enriched_data)
@@ -780,7 +778,7 @@ class SiegeWaterfall:
                 skipped=True,
                 skip_reason="Tier skipped by request",
             ))
-        
+
         # ===== TIER 4: Proxycurl =====
         if EnrichmentTier.PROXYCURL not in skip_tiers:
             result = await self.tier4_proxycurl(enriched_data)
@@ -795,12 +793,12 @@ class SiegeWaterfall:
                 skipped=True,
                 skip_reason="Tier skipped by request",
             ))
-        
+
         # ===== TIER 5: Identity Gold (ALS >= 85 only) =====
         if EnrichmentTier.IDENTITY not in skip_tiers:
             # Recalculate ALS with current enrichment
             current_als = self._calculate_als(enriched_data)
-            
+
             if current_als >= 85 or force_tier5:
                 result = await self.tier5_identity(enriched_data, current_als, force=force_tier5)
                 tier_results.append(result)
@@ -821,12 +819,12 @@ class SiegeWaterfall:
                 skipped=True,
                 skip_reason="Tier skipped by request",
             ))
-        
+
         # ===== Calculate ALS Bonus =====
         sources_used = sum(1 for r in tier_results if r.success)
         als_bonus_applied = sources_used >= MIN_SOURCES_FOR_BONUS
         als_bonus_amount = ALS_MULTI_SOURCE_BONUS if als_bonus_applied else 0
-        
+
         # Apply bonus to enriched data
         if als_bonus_applied:
             final_als = self._calculate_als(enriched_data) + als_bonus_amount
@@ -836,7 +834,7 @@ class SiegeWaterfall:
                 f"[Siege] +{als_bonus_amount} ALS bonus applied "
                 f"({sources_used} sources)"
             )
-        
+
         # ===== Build Lineage =====
         enrichment_lineage = [
             {
@@ -850,22 +848,22 @@ class SiegeWaterfall:
             }
             for r in tier_results
         ]
-        
+
         # ===== Finalize =====
-        completed_at = datetime.now(timezone.utc).isoformat()
+        completed_at = datetime.now(UTC).isoformat()
         enriched_data["enrichment_cost_aud"] = total_cost_aud
         enriched_data["enrichment_sources"] = sources_used
         enriched_data["enrichment_completed_at"] = completed_at
-        
+
         # ===== CEO Directive #057: Enrichment Provenance =====
         # Determine best source URL for Spam Act "conspicuous publication" defence
         # Priority: LinkedIn > GMB > Company Website > Hunter domain
         enrichment_source_url = self._determine_source_url(enriched_data, tier_results)
         enrichment_captured_at = started_at  # When we captured the data
-        
+
         enriched_data["enrichment_source_url"] = enrichment_source_url
         enriched_data["enrichment_captured_at"] = enrichment_captured_at
-        
+
         return EnrichmentResult(
             lead_id=lead.get("id") or lead.get("lead_id"),
             original_data=lead,
@@ -902,13 +900,13 @@ class SiegeWaterfall:
         """
         tier = EnrichmentTier.ABN
         cost = TIER_COSTS_AUD[tier]
-        
+
         try:
             # Check if we have usable data
             abn = lead.get("abn")
             company_name = lead.get("company_name")
             state = lead.get("state") or lead.get("company_state")
-            
+
             if not abn and not company_name:
                 return TierResult(
                     tier=tier,
@@ -916,7 +914,7 @@ class SiegeWaterfall:
                     skipped=True,
                     skip_reason="No ABN or company_name available",
                 )
-            
+
             # Try ABN lookup first
             if abn:
                 result = await self.abn_client.lookup_abn(abn)
@@ -927,24 +925,24 @@ class SiegeWaterfall:
                     state=state,
                 )
                 result = results[0] if results else None
-            
+
             if not result:
                 return TierResult(
                     tier=tier,
                     success=False,
                     error="No ABN match found",
                 )
-            
+
             # Enrich from ABN data
             enriched = await self.abn_client.enrich_from_abn(
                 result.get("abn") or abn
             )
-            
+
             if enriched.get("found"):
                 # CEO Directive #057: ABN register is valid public source
                 abn_value = result.get("abn") or abn
                 source_url = f"https://abr.business.gov.au/ABN/View?abn={abn_value}" if abn_value else None
-                
+
                 await self._log_enrichment_operation(
                     tier=tier,
                     operation="abn_lookup",
@@ -972,7 +970,7 @@ class SiegeWaterfall:
                     success=False,
                     error="ABN enrichment returned no data",
                 )
-                
+
         except Exception as e:
             logger.warning(f"[Siege] Tier 1 ABN failed: {e}")
             sentry_sdk.capture_exception(e)
@@ -1036,7 +1034,7 @@ class SiegeWaterfall:
         """
         try:
             from src.integrations.supabase import get_supabase_client
-            
+
             supabase = get_supabase_client()
             log_entry = {
                 "abn": lead.get("abn"),
@@ -1092,14 +1090,14 @@ class SiegeWaterfall:
         tier = EnrichmentTier.GMB
         cost = TIER_COSTS_AUD[tier]
         start_time = time.time()
-        
+
         try:
             business_names = lead.get("business_names", [])
             trading_name = lead.get("trading_name")
             legal_name = lead.get("business_name") or lead.get("company_name")
             # CEO Directive #016: Bright Data LinkedIn company name (high priority)
             linkedin_company_name = lead.get("linkedin_company_name")
-            
+
             # CEO Directive #014 + #016: Generic name filter
             # Skip Tier 2 if no ASIC business names, no linkedin_company_name,
             # AND legal name is generic
@@ -1124,7 +1122,7 @@ class SiegeWaterfall:
                     skipped=True,
                     skip_reason=skip_reason,
                 )
-            
+
             # Build location string
             location_parts = []
             if lead.get("postcode"):
@@ -1134,41 +1132,39 @@ class SiegeWaterfall:
             state = lead.get("state") or lead.get("company_state")
             if state:
                 location_parts.append(state)
-            
+
             base_location = ", ".join(location_parts) if location_parts else ""
             domain = lead.get("domain") or lead.get("company_domain")
-            
+
             # Build waterfall search list with step tracking
             # Format: (name, step, location)
             waterfall_searches: list[tuple[str, str, str]] = []
-            
+
             # Step a: ASIC business names (highest priority for GMB matching)
             for bn in business_names:
                 if bn:
                     waterfall_searches.append((bn, "a", base_location or "Australia"))
-            
+
             # Step b: ABN trading_name (pre-2012 legacy)
             if trading_name:
                 waterfall_searches.append((trading_name, "b", base_location or "Australia"))
-            
+
             # Step c: Legal name stripped of suffixes
             if legal_name:
                 stripped_name = self._strip_legal_suffixes(legal_name)
-                if stripped_name and stripped_name != legal_name:
+                if stripped_name and stripped_name != legal_name or stripped_name:
                     waterfall_searches.append((stripped_name, "c", base_location or "Australia"))
-                elif stripped_name:
-                    waterfall_searches.append((stripped_name, "c", base_location or "Australia"))
-            
+
             # Step c.5: LinkedIn company name from Bright Data (CEO Directive #016)
             # Fallback after official govt data exhausted
             if linkedin_company_name:
                 waterfall_searches.append((linkedin_company_name, "c5", base_location or "Australia"))
-            
+
             # Step d: Location-pinned search (name + full location + "Australia")
             if legal_name and base_location:
                 location_pinned = f"{base_location}, Australia"
                 waterfall_searches.append((legal_name, "d", location_pinned))
-            
+
             if not waterfall_searches:
                 return TierResult(
                     tier=tier,
@@ -1176,35 +1172,35 @@ class SiegeWaterfall:
                     skipped=True,
                     skip_reason="No company_name or ABN business names available",
                 )
-            
+
             # Try each waterfall step until match found
             enriched = None
             matched_name = None
             matched_step = None
             names_tried = 0
-            
+
             for name, step, location in waterfall_searches:
                 names_tried += 1
                 step_start = time.time()
                 logger.debug(f"[Siege] Tier 2 GMB: Step {step} - Trying '{name}' in {location}")
-                
+
                 result = await self.gmb_scraper.enrich_from_gmb(
                     business_name=name,
                     domain=domain,
                     location=location,
                 )
-                
+
                 step_ms = int((time.time() - step_start) * 1000)
-                
+
                 if result.get("found"):
                     gmb_name = result.get("business_name", "")
                     match_score = max(
                         fuzz.ratio(name.lower(), gmb_name.lower()),
                         fuzz.token_set_ratio(name.lower(), gmb_name.lower()),
                     )
-                    
+
                     passed = match_score >= FUZZY_MATCH_THRESHOLD
-                    
+
                     # Log this attempt
                     await self._log_tier2_gmb_match(
                         lead=lead,
@@ -1218,7 +1214,7 @@ class SiegeWaterfall:
                         names_tried=names_tried,
                         processing_ms=step_ms,
                     )
-                    
+
                     if passed:
                         enriched = result
                         matched_name = name
@@ -1248,13 +1244,13 @@ class SiegeWaterfall:
                         names_tried=names_tried,
                         processing_ms=step_ms,
                     )
-            
+
             total_ms = int((time.time() - start_time) * 1000)
-            
+
             if enriched:
                 # CEO Directive #057: GMB URL is valid public source
                 gmb_source_url = enriched.get("google_maps_url")
-                
+
                 await self._log_enrichment_operation(
                     tier=tier,
                     operation="gmb_scrape",
@@ -1295,7 +1291,7 @@ class SiegeWaterfall:
                     success=False,
                     error=f"No GMB listing found (tried {names_tried} waterfall steps)",
                 )
-                
+
         except Exception as e:
             logger.warning(f"[Siege] Tier 2 GMB failed: {e}")
             sentry_sdk.capture_exception(e)
@@ -1334,21 +1330,21 @@ class SiegeWaterfall:
         """
         tier = EnrichmentTier.HUNTER
         cost = TIER_COSTS_AUD[tier]
-        
+
         try:
             email = lead.get("email")
             first_name = lead.get("first_name")
             last_name = lead.get("last_name")
             domain = lead.get("domain") or lead.get("company_domain")
-            
+
             # Verify existing email
             if email:
                 result = await self.hunter_client.verify_email(email)
-                
+
                 # CEO Directive #057: Construct source URL from domain
                 email_domain = email.split("@")[1] if "@" in email else None
                 hunter_source_url = f"https://{email_domain}" if email_domain else None
-                
+
                 await self._log_enrichment_operation(
                     tier=tier,
                     operation="verify_email",
@@ -1356,7 +1352,7 @@ class SiegeWaterfall:
                     success=True,
                     cost_aud=cost,
                 )
-                
+
                 return TierResult(
                     tier=tier,
                     success=True,
@@ -1369,7 +1365,7 @@ class SiegeWaterfall:
                     cost_aud=cost,
                     source_url=hunter_source_url,
                 )
-            
+
             # Try to find email by name + domain
             elif first_name and last_name and domain:
                 result = await self.hunter_client.find_email(
@@ -1377,11 +1373,11 @@ class SiegeWaterfall:
                     last_name=last_name,
                     domain=domain,
                 )
-                
+
                 if result.get("found"):
                     # CEO Directive #057: Domain website is the source
                     hunter_source_url = f"https://{domain}"
-                    
+
                     await self._log_enrichment_operation(
                         tier=tier,
                         operation="find_email",
@@ -1416,7 +1412,7 @@ class SiegeWaterfall:
                         error="Could not find email",
                         cost_aud=cost,  # Still charged for attempt
                     )
-            
+
             # NEW: Domain search for decision-maker discovery when only company is known
             elif domain:
                 # Use domain_search to find decision-makers at the company
@@ -1424,7 +1420,7 @@ class SiegeWaterfall:
                     domain=domain,
                     limit=5,  # Get top 5 contacts
                 )
-                
+
                 # Handle both DomainSearchResult object and list formats
                 if hasattr(search_result, "emails"):
                     # Real Hunter client returns DomainSearchResult
@@ -1434,7 +1430,7 @@ class SiegeWaterfall:
                     contacts = search_result
                 else:
                     contacts = []
-                
+
                 if contacts and len(contacts) > 0:
                     # Find the best decision-maker (executive/senior seniority)
                     decision_makers = []
@@ -1446,28 +1442,28 @@ class SiegeWaterfall:
                             contact_dict = contact
                         else:
                             continue
-                            
+
                         seniority = (contact_dict.get("seniority") or "").lower()
                         department = (contact_dict.get("department") or "").lower()
-                        
+
                         # Prioritize executives and senior roles in relevant departments
                         priority = 0
                         if seniority in ("executive", "senior"):
                             priority += 10
                         if department in ("executive", "management", "marketing", "sales"):
                             priority += 5
-                        
+
                         decision_makers.append((priority, contact_dict))
-                    
+
                     # Sort by priority and take the best match
                     decision_makers.sort(key=lambda x: x[0], reverse=True)
-                    
+
                     if decision_makers:
                         best_contact = decision_makers[0][1]
                         # CEO Directive #057: LinkedIn or domain website as source
                         contact_linkedin = best_contact.get("linkedin_url")
                         domain_source_url = contact_linkedin if contact_linkedin else f"https://{domain}"
-                        
+
                         await self._log_enrichment_operation(
                             tier=tier,
                             operation="domain_search",
@@ -1495,7 +1491,7 @@ class SiegeWaterfall:
                             cost_aud=0.15,  # Domain search costs more
                             source_url=domain_source_url,
                         )
-                
+
                 await self._log_enrichment_operation(
                     tier=tier,
                     operation="domain_search",
@@ -1510,7 +1506,7 @@ class SiegeWaterfall:
                     error="No contacts found for domain",
                     cost_aud=0.15,  # Still charged for domain search attempt
                 )
-            
+
             else:
                 return TierResult(
                     tier=tier,
@@ -1518,7 +1514,7 @@ class SiegeWaterfall:
                     skipped=True,
                     skip_reason="No email, name+domain, or domain available",
                 )
-                
+
         except Exception as e:
             logger.warning(f"[Siege] Tier 3 Hunter failed: {e}")
             sentry_sdk.capture_exception(e)
@@ -1544,13 +1540,13 @@ class SiegeWaterfall:
             TierResult with skipped=True
         """
         tier = EnrichmentTier.PROXYCURL
-        
+
         # Log deprecation notice
         logger.info(
             f"[Siege] Tier 4 pending — Unipile not activated. "
             f"LinkedIn enrichment skipped for lead: {lead.get('email', 'unknown')}"
         )
-        
+
         return TierResult(
             tier=tier,
             success=False,
@@ -1591,7 +1587,7 @@ class SiegeWaterfall:
         """
         tier = EnrichmentTier.IDENTITY
         cost = TIER_COSTS_AUD[tier]
-        
+
         # Guard: Only for high-ALS leads (unless forced)
         if als_score < 85 and not force:
             return TierResult(
@@ -1600,7 +1596,7 @@ class SiegeWaterfall:
                 skipped=True,
                 skip_reason=f"ALS {als_score} below 85 threshold",
             )
-        
+
         # Guard: Kaspr client must be available
         if self.kaspr_client is None:
             return TierResult(
@@ -1609,14 +1605,14 @@ class SiegeWaterfall:
                 skipped=True,
                 skip_reason="Kaspr client not configured (KASPR_API_KEY missing)",
             )
-        
+
         try:
             linkedin_url = lead.get("linkedin_url")
             email = lead.get("email")
             first_name = lead.get("first_name")
             last_name = lead.get("last_name")
             company = lead.get("company_name") or lead.get("company")
-            
+
             if not linkedin_url and not email:
                 return TierResult(
                     tier=tier,
@@ -1624,7 +1620,7 @@ class SiegeWaterfall:
                     skipped=True,
                     skip_reason="No linkedin_url or email for identity lookup",
                 )
-            
+
             enriched = await self.kaspr_client.enrich_identity(
                 linkedin_url=linkedin_url,
                 email=email,
@@ -1632,14 +1628,14 @@ class SiegeWaterfall:
                 last_name=last_name,
                 company=company,
             )
-            
+
             if enriched.get("found"):
                 logger.info(
                     f"[Siege] Tier 5 Identity Gold success for ALS={als_score} lead"
                 )
                 # CEO Directive #057: LinkedIn is the primary source for Kaspr
                 identity_source_url = linkedin_url or enriched.get("linkedin_url")
-                
+
                 await self._log_enrichment_operation(
                     tier=tier,
                     operation="identity_gold",
@@ -1671,7 +1667,7 @@ class SiegeWaterfall:
                     error="No identity data found",
                     cost_aud=cost,  # Still charged for lookup
                 )
-                
+
         except Exception as e:
             logger.warning(f"[Siege] Tier 5 Identity failed: {e}")
             sentry_sdk.capture_exception(e)
@@ -1721,9 +1717,9 @@ class SiegeWaterfall:
         try:
             # Lazy import to avoid circular dependencies
             from src.integrations.supabase import get_supabase_client
-            
+
             supabase = get_supabase_client()
-            
+
             log_entry = {
                 "operation_type": "enrichment",
                 "tier": tier.value,
@@ -1736,11 +1732,11 @@ class SiegeWaterfall:
                 "lead_domain": lead_data.get("domain") or lead_data.get("company_domain"),
                 "lead_company": lead_data.get("company_name"),
                 "metadata": metadata or {},
-                "created_at": datetime.now(timezone.utc).isoformat(),
+                "created_at": datetime.now(UTC).isoformat(),
             }
-            
+
             await supabase.table("audit_logs").insert(log_entry).execute()
-            
+
         except Exception as e:
             # Don't fail enrichment if logging fails
             logger.warning(f"[Siege] Audit log failed: {e}")
@@ -1776,24 +1772,24 @@ class SiegeWaterfall:
         linkedin_url = enriched_data.get("linkedin_url")
         if linkedin_url and "linkedin.com" in linkedin_url:
             return linkedin_url
-        
+
         # Check company LinkedIn URL
         company_linkedin_url = enriched_data.get("company_linkedin_url")
         if company_linkedin_url and "linkedin.com" in company_linkedin_url:
             return company_linkedin_url
-        
+
         # Check GMB/Google Maps URL from Tier 2
         for tier_result in tier_results:
             if tier_result.tier == EnrichmentTier.GMB and tier_result.success:
                 gmb_url = tier_result.data.get("google_maps_url")
                 if gmb_url:
                     return gmb_url
-        
+
         # Check company website URL (often has team/contact page)
         company_website = enriched_data.get("company_website")
         if company_website:
             return company_website
-        
+
         # Check domain (construct URL)
         company_domain = enriched_data.get("company_domain")
         if company_domain:
@@ -1801,7 +1797,7 @@ class SiegeWaterfall:
             if not company_domain.startswith(("http://", "https://")):
                 return f"https://{company_domain}"
             return company_domain
-        
+
         # Check ABN register URL from Tier 1
         for tier_result in tier_results:
             if tier_result.tier == EnrichmentTier.ABN and tier_result.success:
@@ -1809,12 +1805,12 @@ class SiegeWaterfall:
                 if abn:
                     # ABN lookup URL is a valid public record source
                     return f"https://abr.business.gov.au/ABN/View?abn={abn}"
-        
+
         # Check tier source URLs (fallback)
         for tier_result in tier_results:
             if tier_result.source_url:
                 return tier_result.source_url
-        
+
         return None
 
     def _merge_data(
@@ -1835,12 +1831,12 @@ class SiegeWaterfall:
             Merged dictionary
         """
         result = dict(base)
-        
+
         for key, value in new_data.items():
             # Skip meta keys
             if key in ("found", "source", "confidence"):
                 continue
-            
+
             # Only add if not already set
             if key not in result or result[key] is None:
                 result[key] = value
@@ -1850,7 +1846,7 @@ class SiegeWaterfall:
             # Merge dicts
             elif isinstance(value, dict) and isinstance(result[key], dict):
                 result[key] = {**result[key], **value}
-        
+
         return result
 
     def _calculate_als(self, lead: dict[str, Any]) -> int:
@@ -1867,7 +1863,7 @@ class SiegeWaterfall:
             ALS score (0-100)
         """
         score = 0
-        
+
         # Email (30 points max)
         if lead.get("email"):
             if lead.get("email_status") == "verified":
@@ -1876,29 +1872,29 @@ class SiegeWaterfall:
                 score += 25
             else:
                 score += 15
-        
+
         # Phone (20 points max)
         if lead.get("phone") or lead.get("mobile"):
             score += 20
-        
+
         # LinkedIn (15 points)
         if lead.get("linkedin_url"):
             score += 15
-        
+
         # Name (10 points)
         if lead.get("first_name") and lead.get("last_name"):
             score += 10
-        
+
         # Title/Role (10 points)
         if lead.get("title"):
             score += 10
-        
+
         # Company data (15 points max)
         if lead.get("company_name"):
             score += 10
         if lead.get("company_employee_count") or lead.get("company_industry"):
             score += 5
-        
+
         return min(score, 100)
 
 

--- a/src/integrations/stripe.py
+++ b/src/integrations/stripe.py
@@ -28,9 +28,10 @@ STRIPE CONTEXT:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from enum import Enum
 from typing import Any
@@ -39,13 +40,12 @@ from uuid import UUID
 import sentry_sdk
 from tenacity import (
     retry,
-    retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
 )
 
 from src.config.settings import settings
-from src.exceptions import APIError, IntegrationError, ValidationError
+from src.exceptions import IntegrationError
 
 logger = logging.getLogger(__name__)
 
@@ -118,11 +118,11 @@ class StripeCustomer:
     name: str | None = None
     metadata: dict[str, str] = field(default_factory=dict)
     created_at: datetime | None = None
-    
+
     # Agency OS specific
     client_id: UUID | None = None
     subscription_status: SubscriptionStatus | None = None
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -148,10 +148,10 @@ class StripeSubscription:
     trial_end: datetime | None = None
     cancel_at_period_end: bool = False
     canceled_at: datetime | None = None
-    
+
     # Pricing
     amount_aud: Decimal = Decimal("0.00")
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -180,7 +180,7 @@ class StripeInvoice:
     created_at: datetime | None = None
     paid_at: datetime | None = None
     invoice_pdf: str | None = None
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -196,7 +196,7 @@ class StripeInvoice:
         }
 
 
-@dataclass 
+@dataclass
 class WebhookEvent:
     """Parsed Stripe webhook event."""
     id: str
@@ -204,7 +204,7 @@ class WebhookEvent:
     data: dict[str, Any]
     created_at: datetime
     api_version: str | None = None
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -270,7 +270,7 @@ class StripeClient:
             tier=PricingTier.IGNITION,
         )
     """
-    
+
     def __init__(self, api_key: str | None = None, webhook_secret: str | None = None):
         """
         Initialize Stripe client.
@@ -282,10 +282,10 @@ class StripeClient:
         self._api_key = api_key or getattr(settings, "stripe_secret_key", None)
         self._webhook_secret = webhook_secret or getattr(settings, "stripe_webhook_secret", None)
         self._stripe = None
-        
+
         if not self._api_key:
             logger.warning("[Stripe] No API key configured - client will operate in stub mode")
-    
+
     def _get_stripe(self):
         """Lazy-load stripe module and configure API key."""
         if self._stripe is None:
@@ -300,16 +300,16 @@ class StripeClient:
                     message="stripe-python package not installed",
                 )
         return self._stripe
-    
+
     @property
     def is_configured(self) -> bool:
         """Check if Stripe is properly configured."""
         return bool(self._api_key)
-    
+
     # ============================================
     # CUSTOMER OPERATIONS
     # ============================================
-    
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),
@@ -344,14 +344,14 @@ class StripeClient:
                 name=name,
                 client_id=client_id,
             )
-        
+
         stripe = self._get_stripe()
-        
+
         try:
             customer_metadata = metadata or {}
             if client_id:
                 customer_metadata["agency_os_client_id"] = str(client_id)
-            
+
             # Run in executor to avoid blocking
             loop = asyncio.get_event_loop()
             customer = await loop.run_in_executor(
@@ -362,23 +362,23 @@ class StripeClient:
                     metadata=customer_metadata,
                 )
             )
-            
+
             logger.info(f"[Stripe] Created customer {customer.id} for {email}")
-            
+
             return StripeCustomer(
                 id=customer.id,
                 email=customer.email,
                 name=customer.name,
                 metadata=dict(customer.metadata),
-                created_at=datetime.fromtimestamp(customer.created, tz=timezone.utc),
+                created_at=datetime.fromtimestamp(customer.created, tz=UTC),
                 client_id=client_id,
             )
-            
+
         except Exception as e:
             logger.error(f"[Stripe] Failed to create customer: {e}")
             sentry_sdk.capture_exception(e)
             raise StripeError(f"Failed to create customer: {e}")
-    
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),
@@ -395,41 +395,39 @@ class StripeClient:
         """
         if not self.is_configured:
             return None
-        
+
         stripe = self._get_stripe()
-        
+
         try:
             loop = asyncio.get_event_loop()
             customer = await loop.run_in_executor(
                 None,
                 lambda: stripe.Customer.retrieve(customer_id)
             )
-            
+
             if customer.deleted:
                 return None
-            
+
             client_id = None
             if customer.metadata.get("agency_os_client_id"):
-                try:
+                with contextlib.suppress(ValueError):
                     client_id = UUID(customer.metadata["agency_os_client_id"])
-                except ValueError:
-                    pass
-            
+
             return StripeCustomer(
                 id=customer.id,
                 email=customer.email,
                 name=customer.name,
                 metadata=dict(customer.metadata),
-                created_at=datetime.fromtimestamp(customer.created, tz=timezone.utc),
+                created_at=datetime.fromtimestamp(customer.created, tz=UTC),
                 client_id=client_id,
             )
-            
+
         except stripe.error.InvalidRequestError:
             return None
         except Exception as e:
             logger.error(f"[Stripe] Failed to get customer {customer_id}: {e}")
             raise StripeError(f"Failed to retrieve customer: {e}")
-    
+
     async def update_customer(
         self,
         customer_id: str,
@@ -451,9 +449,9 @@ class StripeClient:
         """
         if not self.is_configured:
             raise StripeError("Stripe not configured")
-        
+
         stripe = self._get_stripe()
-        
+
         try:
             update_params = {}
             if email:
@@ -462,29 +460,29 @@ class StripeClient:
                 update_params["name"] = name
             if metadata:
                 update_params["metadata"] = metadata
-            
+
             loop = asyncio.get_event_loop()
             customer = await loop.run_in_executor(
                 None,
                 lambda: stripe.Customer.modify(customer_id, **update_params)
             )
-            
+
             return StripeCustomer(
                 id=customer.id,
                 email=customer.email,
                 name=customer.name,
                 metadata=dict(customer.metadata),
-                created_at=datetime.fromtimestamp(customer.created, tz=timezone.utc),
+                created_at=datetime.fromtimestamp(customer.created, tz=UTC),
             )
-            
+
         except Exception as e:
             logger.error(f"[Stripe] Failed to update customer {customer_id}: {e}")
             raise StripeError(f"Failed to update customer: {e}")
-    
+
     # ============================================
     # SUBSCRIPTION OPERATIONS
     # ============================================
-    
+
     async def create_subscription(
         self,
         customer_id: str,
@@ -507,7 +505,7 @@ class StripeClient:
         """
         if not self.is_configured:
             logger.warning("[Stripe] Operating in stub mode - returning mock subscription")
-            now = datetime.now(tz=timezone.utc)
+            now = datetime.now(tz=UTC)
             return StripeSubscription(
                 id=f"sub_stub_{customer_id}",
                 customer_id=customer_id,
@@ -517,9 +515,9 @@ class StripeClient:
                 current_period_end=now,
                 amount_aud=PRICING_IGNITION_AUD if tier == PricingTier.IGNITION else PRICING_GROWTH_AUD,
             )
-        
+
         stripe = self._get_stripe()
-        
+
         # Get price ID for tier
         price_id = PRICE_IDS.get(f"{tier.value}_monthly")
         if not price_id:
@@ -527,7 +525,7 @@ class StripeClient:
                 f"No price ID configured for tier: {tier.value}",
                 stripe_code="missing_price_id",
             )
-        
+
         try:
             loop = asyncio.get_event_loop()
             subscription = await loop.run_in_executor(
@@ -539,28 +537,28 @@ class StripeClient:
                     metadata={"tier": tier.value},
                 )
             )
-            
+
             logger.info(f"[Stripe] Created subscription {subscription.id} for {customer_id}")
-            
+
             amount = PRICING_IGNITION_AUD if tier == PricingTier.IGNITION else PRICING_GROWTH_AUD
-            
+
             return StripeSubscription(
                 id=subscription.id,
                 customer_id=customer_id,
                 status=SubscriptionStatus(subscription.status),
                 tier=tier,
                 current_period_start=datetime.fromtimestamp(
-                    subscription.current_period_start, tz=timezone.utc
+                    subscription.current_period_start, tz=UTC
                 ),
                 current_period_end=datetime.fromtimestamp(
-                    subscription.current_period_end, tz=timezone.utc
+                    subscription.current_period_end, tz=UTC
                 ),
-                trial_end=datetime.fromtimestamp(subscription.trial_end, tz=timezone.utc)
+                trial_end=datetime.fromtimestamp(subscription.trial_end, tz=UTC)
                 if subscription.trial_end else None,
                 cancel_at_period_end=subscription.cancel_at_period_end,
                 amount_aud=amount,
             )
-            
+
         except stripe.error.CardError as e:
             logger.error(f"[Stripe] Card error creating subscription: {e}")
             raise PaymentFailedError(str(e), stripe_code=e.code)
@@ -568,7 +566,7 @@ class StripeClient:
             logger.error(f"[Stripe] Failed to create subscription: {e}")
             sentry_sdk.capture_exception(e)
             raise SubscriptionError(f"Failed to create subscription: {e}")
-    
+
     async def get_subscription(self, subscription_id: str) -> StripeSubscription | None:
         """
         Retrieve a subscription.
@@ -581,44 +579,44 @@ class StripeClient:
         """
         if not self.is_configured:
             return None
-        
+
         stripe = self._get_stripe()
-        
+
         try:
             loop = asyncio.get_event_loop()
             subscription = await loop.run_in_executor(
                 None,
                 lambda: stripe.Subscription.retrieve(subscription_id)
             )
-            
+
             tier = PricingTier(subscription.metadata.get("tier", "ignition"))
             amount = PRICING_IGNITION_AUD if tier == PricingTier.IGNITION else PRICING_GROWTH_AUD
-            
+
             return StripeSubscription(
                 id=subscription.id,
                 customer_id=subscription.customer,
                 status=SubscriptionStatus(subscription.status),
                 tier=tier,
                 current_period_start=datetime.fromtimestamp(
-                    subscription.current_period_start, tz=timezone.utc
+                    subscription.current_period_start, tz=UTC
                 ),
                 current_period_end=datetime.fromtimestamp(
-                    subscription.current_period_end, tz=timezone.utc
+                    subscription.current_period_end, tz=UTC
                 ),
-                trial_end=datetime.fromtimestamp(subscription.trial_end, tz=timezone.utc)
+                trial_end=datetime.fromtimestamp(subscription.trial_end, tz=UTC)
                 if subscription.trial_end else None,
                 cancel_at_period_end=subscription.cancel_at_period_end,
-                canceled_at=datetime.fromtimestamp(subscription.canceled_at, tz=timezone.utc)
+                canceled_at=datetime.fromtimestamp(subscription.canceled_at, tz=UTC)
                 if subscription.canceled_at else None,
                 amount_aud=amount,
             )
-            
+
         except stripe.error.InvalidRequestError:
             return None
         except Exception as e:
             logger.error(f"[Stripe] Failed to get subscription {subscription_id}: {e}")
             raise StripeError(f"Failed to retrieve subscription: {e}")
-    
+
     async def cancel_subscription(
         self,
         subscription_id: str,
@@ -636,12 +634,12 @@ class StripeClient:
         """
         if not self.is_configured:
             raise StripeError("Stripe not configured")
-        
+
         stripe = self._get_stripe()
-        
+
         try:
             loop = asyncio.get_event_loop()
-            
+
             if at_period_end:
                 subscription = await loop.run_in_executor(
                     None,
@@ -655,35 +653,35 @@ class StripeClient:
                     None,
                     lambda: stripe.Subscription.cancel(subscription_id)
                 )
-            
+
             logger.info(f"[Stripe] Canceled subscription {subscription_id}")
-            
+
             tier = PricingTier(subscription.metadata.get("tier", "ignition"))
-            
+
             return StripeSubscription(
                 id=subscription.id,
                 customer_id=subscription.customer,
                 status=SubscriptionStatus(subscription.status),
                 tier=tier,
                 current_period_start=datetime.fromtimestamp(
-                    subscription.current_period_start, tz=timezone.utc
+                    subscription.current_period_start, tz=UTC
                 ),
                 current_period_end=datetime.fromtimestamp(
-                    subscription.current_period_end, tz=timezone.utc
+                    subscription.current_period_end, tz=UTC
                 ),
                 cancel_at_period_end=subscription.cancel_at_period_end,
-                canceled_at=datetime.fromtimestamp(subscription.canceled_at, tz=timezone.utc)
+                canceled_at=datetime.fromtimestamp(subscription.canceled_at, tz=UTC)
                 if subscription.canceled_at else None,
             )
-            
+
         except Exception as e:
             logger.error(f"[Stripe] Failed to cancel subscription {subscription_id}: {e}")
             raise SubscriptionError(f"Failed to cancel subscription: {e}")
-    
+
     # ============================================
     # INVOICE OPERATIONS
     # ============================================
-    
+
     async def get_invoices(
         self,
         customer_id: str,
@@ -701,16 +699,16 @@ class StripeClient:
         """
         if not self.is_configured:
             return []
-        
+
         stripe = self._get_stripe()
-        
+
         try:
             loop = asyncio.get_event_loop()
             invoices = await loop.run_in_executor(
                 None,
                 lambda: stripe.Invoice.list(customer=customer_id, limit=limit)
             )
-            
+
             result = []
             for inv in invoices.data:
                 result.append(StripeInvoice(
@@ -720,22 +718,22 @@ class StripeClient:
                     status=inv.status,
                     amount_due_aud=Decimal(str(inv.amount_due / 100)),
                     amount_paid_aud=Decimal(str(inv.amount_paid / 100)),
-                    created_at=datetime.fromtimestamp(inv.created, tz=timezone.utc),
-                    paid_at=datetime.fromtimestamp(inv.status_transitions.paid_at, tz=timezone.utc)
+                    created_at=datetime.fromtimestamp(inv.created, tz=UTC),
+                    paid_at=datetime.fromtimestamp(inv.status_transitions.paid_at, tz=UTC)
                     if inv.status_transitions.paid_at else None,
                     invoice_pdf=inv.invoice_pdf,
                 ))
-            
+
             return result
-            
+
         except Exception as e:
             logger.error(f"[Stripe] Failed to get invoices for {customer_id}: {e}")
             raise StripeError(f"Failed to retrieve invoices: {e}")
-    
+
     # ============================================
     # WEBHOOK HANDLING
     # ============================================
-    
+
     def verify_webhook(
         self,
         payload: bytes,
@@ -756,31 +754,31 @@ class StripeClient:
         """
         if not self._webhook_secret:
             raise WebhookVerificationError("Webhook secret not configured")
-        
+
         stripe = self._get_stripe()
-        
+
         try:
             event = stripe.Webhook.construct_event(
                 payload,
                 signature,
                 self._webhook_secret,
             )
-            
+
             return WebhookEvent(
                 id=event.id,
                 type=event.type,
                 data=dict(event.data.object),
-                created_at=datetime.fromtimestamp(event.created, tz=timezone.utc),
+                created_at=datetime.fromtimestamp(event.created, tz=UTC),
                 api_version=event.api_version,
             )
-            
+
         except stripe.error.SignatureVerificationError as e:
             logger.error(f"[Stripe] Webhook verification failed: {e}")
             raise WebhookVerificationError(str(e))
         except Exception as e:
             logger.error(f"[Stripe] Failed to parse webhook: {e}")
             raise WebhookVerificationError(f"Failed to parse webhook: {e}")
-    
+
     async def handle_webhook_event(self, event: WebhookEvent) -> dict[str, Any]:
         """
         Handle a verified webhook event.
@@ -794,7 +792,7 @@ class StripeClient:
             Handler result
         """
         logger.info(f"[Stripe] Handling webhook event: {event.type}")
-        
+
         handlers = {
             "customer.subscription.created": self._handle_subscription_created,
             "customer.subscription.updated": self._handle_subscription_updated,
@@ -802,48 +800,48 @@ class StripeClient:
             "invoice.paid": self._handle_invoice_paid,
             "invoice.payment_failed": self._handle_payment_failed,
         }
-        
+
         handler = handlers.get(event.type)
         if handler:
             return await handler(event)
-        
+
         logger.debug(f"[Stripe] No handler for event type: {event.type}")
         return {"status": "ignored", "event_type": event.type}
-    
+
     async def _handle_subscription_created(self, event: WebhookEvent) -> dict[str, Any]:
         """Handle subscription.created event."""
         # TODO: Update client record in database
         logger.info(f"[Stripe] Subscription created: {event.data.get('id')}")
         return {"status": "processed", "action": "subscription_created"}
-    
+
     async def _handle_subscription_updated(self, event: WebhookEvent) -> dict[str, Any]:
         """Handle subscription.updated event."""
         # TODO: Update client subscription status
         logger.info(f"[Stripe] Subscription updated: {event.data.get('id')}")
         return {"status": "processed", "action": "subscription_updated"}
-    
+
     async def _handle_subscription_deleted(self, event: WebhookEvent) -> dict[str, Any]:
         """Handle subscription.deleted event."""
         # TODO: Mark client as churned
         logger.info(f"[Stripe] Subscription deleted: {event.data.get('id')}")
         return {"status": "processed", "action": "subscription_deleted"}
-    
+
     async def _handle_invoice_paid(self, event: WebhookEvent) -> dict[str, Any]:
         """Handle invoice.paid event."""
         # TODO: Update payment record
         logger.info(f"[Stripe] Invoice paid: {event.data.get('id')}")
         return {"status": "processed", "action": "invoice_paid"}
-    
+
     async def _handle_payment_failed(self, event: WebhookEvent) -> dict[str, Any]:
         """Handle invoice.payment_failed event."""
         # TODO: Alert and retry handling
         logger.warning(f"[Stripe] Payment failed: {event.data.get('id')}")
         return {"status": "processed", "action": "payment_failed"}
-    
+
     # ============================================
     # CHECKOUT SESSION (For hosted checkout)
     # ============================================
-    
+
     async def create_checkout_session(
         self,
         customer_id: str,
@@ -870,13 +868,13 @@ class StripeClient:
         """
         if not self.is_configured:
             return f"{success_url}?session=stub_session"
-        
+
         stripe = self._get_stripe()
-        
+
         price_id = PRICE_IDS.get(f"{tier.value}_monthly")
         if not price_id:
             raise StripeError(f"No price ID configured for tier: {tier.value}")
-        
+
         try:
             loop = asyncio.get_event_loop()
             session = await loop.run_in_executor(
@@ -893,10 +891,10 @@ class StripeClient:
                     },
                 )
             )
-            
+
             logger.info(f"[Stripe] Created checkout session for {customer_id}")
             return session.url
-            
+
         except Exception as e:
             logger.error(f"[Stripe] Failed to create checkout session: {e}")
             raise StripeError(f"Failed to create checkout session: {e}")

--- a/src/integrations/stripe_billing.py
+++ b/src/integrations/stripe_billing.py
@@ -9,15 +9,15 @@ Environment Variables Required:
 - STRIPE_STANDARD_PRICE_ID: Price ID for standard plan
 """
 
-import os
 import logging
-from datetime import datetime
-from typing import Optional, Dict, Any, Literal
+import os
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
+from typing import Any
 
 import stripe
-from fastapi import APIRouter, Request, HTTPException, Header
+from fastapi import APIRouter, Header, HTTPException, Request
 from pydantic import BaseModel, EmailStr
 
 from src.integrations.supabase import get_supabase_client
@@ -40,10 +40,10 @@ class PlanType(str, Enum):
 @dataclass
 class SubscriptionResult:
     success: bool
-    customer_id: Optional[str] = None
-    subscription_id: Optional[str] = None
-    checkout_url: Optional[str] = None
-    error: Optional[str] = None
+    customer_id: str | None = None
+    subscription_id: str | None = None
+    checkout_url: str | None = None
+    error: str | None = None
 
 
 class CreateCheckoutRequest(BaseModel):
@@ -51,7 +51,7 @@ class CreateCheckoutRequest(BaseModel):
     plan_type: PlanType = PlanType.STANDARD
     success_url: str
     cancel_url: str
-    lead_id: Optional[str] = None
+    lead_id: str | None = None
 
 
 class CustomerPortalRequest(BaseModel):
@@ -65,8 +65,8 @@ class CustomerPortalRequest(BaseModel):
 
 async def create_customer(
     email: str,
-    name: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None
+    name: str | None = None,
+    metadata: dict[str, Any] | None = None
 ) -> stripe.Customer:
     """Create a Stripe customer."""
     try:
@@ -87,7 +87,7 @@ async def create_checkout_session(
     plan_type: PlanType,
     success_url: str,
     cancel_url: str,
-    lead_id: Optional[str] = None
+    lead_id: str | None = None
 ) -> SubscriptionResult:
     """
     Create a Stripe Checkout session for subscription.
@@ -98,13 +98,13 @@ async def create_checkout_session(
     try:
         # Determine price ID
         price_id = FOUNDING_PRICE_ID if plan_type == PlanType.FOUNDING else STANDARD_PRICE_ID
-        
+
         if not price_id:
             return SubscriptionResult(
                 success=False,
                 error=f"Price ID not configured for {plan_type.value} plan"
             )
-        
+
         # Check founding spots if requesting founding plan
         if plan_type == PlanType.FOUNDING:
             spots = await get_remaining_founding_spots()
@@ -113,7 +113,7 @@ async def create_checkout_session(
                     success=False,
                     error="All founding member spots have been claimed"
                 )
-        
+
         # Create checkout session
         session = stripe.checkout.Session.create(
             mode="subscription",
@@ -138,13 +138,13 @@ async def create_checkout_session(
             },
             allow_promotion_codes=True  # Allow coupon codes
         )
-        
+
         logger.info(f"Created checkout session: {session.id} for {email}")
         return SubscriptionResult(
             success=True,
             checkout_url=session.url
         )
-        
+
     except stripe.StripeError as e:
         logger.error(f"Stripe checkout error: {e}")
         return SubscriptionResult(success=False, error=str(e))
@@ -200,20 +200,20 @@ async def get_remaining_founding_spots() -> int:
 
 async def reserve_founding_spot(
     email: str,
-    company_name: Optional[str] = None,
-    lead_id: Optional[str] = None
-) -> Optional[int]:
+    company_name: str | None = None,
+    lead_id: str | None = None
+) -> int | None:
     """
     Reserve a founding member spot.
     Returns spot number if successful, None if spots full.
     """
     try:
         supabase = get_supabase_client()
-        
+
         # Get next available spot
         result = supabase.rpc("get_next_founding_spot").execute()
         spot_number = result.data
-        
+
         if not spot_number:
             # Add to waitlist instead
             supabase.table("founding_waitlist").insert({
@@ -222,7 +222,7 @@ async def reserve_founding_spot(
             }).execute()
             logger.info(f"Added {email} to founding waitlist")
             return None
-        
+
         # Reserve the spot
         supabase.table("founding_members").insert({
             "email": email,
@@ -231,10 +231,10 @@ async def reserve_founding_spot(
             "spot_number": spot_number,
             "status": "reserved"
         }).execute()
-        
+
         logger.info(f"Reserved founding spot #{spot_number} for {email}")
         return spot_number
-        
+
     except Exception as e:
         logger.error(f"Error reserving founding spot: {e}")
         return None
@@ -248,16 +248,16 @@ async def activate_founding_member(
     """Activate a reserved founding member after successful payment."""
     try:
         supabase = get_supabase_client()
-        
+
         result = supabase.table("founding_members").update({
             "status": "active",
             "stripe_customer_id": stripe_customer_id,
             "stripe_subscription_id": stripe_subscription_id,
             "activated_at": datetime.utcnow().isoformat()
         }).eq("email", email).execute()
-        
+
         return len(result.data) > 0
-        
+
     except Exception as e:
         logger.error(f"Error activating founding member: {e}")
         return False
@@ -267,18 +267,18 @@ async def activate_founding_member(
 # Webhook Handlers
 # =============================================================================
 
-async def handle_checkout_completed(session: Dict[str, Any]) -> None:
+async def handle_checkout_completed(session: dict[str, Any]) -> None:
     """Handle successful checkout completion."""
     customer_id = session.get("customer")
     subscription_id = session.get("subscription")
     customer_email = session.get("customer_email")
     metadata = session.get("metadata", {})
-    
+
     plan_type = metadata.get("plan_type", "standard")
     lead_id = metadata.get("lead_id")
-    
+
     logger.info(f"Checkout completed: {customer_email} - {plan_type} plan")
-    
+
     # Update sales pipeline if lead_id present
     if lead_id:
         try:
@@ -288,7 +288,7 @@ async def handle_checkout_completed(session: Dict[str, Any]) -> None:
             }).eq("lead_id", lead_id).execute()
         except Exception as e:
             logger.error(f"Failed to update pipeline: {e}")
-    
+
     # Activate founding member if applicable
     if plan_type == "founding" and customer_email:
         await activate_founding_member(
@@ -298,14 +298,13 @@ async def handle_checkout_completed(session: Dict[str, Any]) -> None:
         )
 
 
-async def handle_subscription_updated(subscription: Dict[str, Any]) -> None:
+async def handle_subscription_updated(subscription: dict[str, Any]) -> None:
     """Handle subscription updates (upgrades, downgrades, renewals)."""
     sub_id = subscription.get("id")
     status = subscription.get("status")
-    customer_id = subscription.get("customer")
-    
+
     logger.info(f"Subscription {sub_id} updated: status={status}")
-    
+
     # Update founding member status if churned
     if status in ("canceled", "unpaid"):
         try:
@@ -317,21 +316,21 @@ async def handle_subscription_updated(subscription: Dict[str, Any]) -> None:
             logger.error(f"Failed to update founding member status: {e}")
 
 
-async def handle_invoice_paid(invoice: Dict[str, Any]) -> None:
+async def handle_invoice_paid(invoice: dict[str, Any]) -> None:
     """Handle successful invoice payment."""
     customer_id = invoice.get("customer")
     amount_paid = invoice.get("amount_paid", 0) / 100  # Convert from cents
     currency = invoice.get("currency", "aud").upper()
-    
+
     logger.info(f"Invoice paid: {customer_id} - ${amount_paid} {currency}")
     # Could trigger internal notifications, update metrics, etc.
 
 
-async def handle_invoice_failed(invoice: Dict[str, Any]) -> None:
+async def handle_invoice_failed(invoice: dict[str, Any]) -> None:
     """Handle failed invoice payment."""
     customer_id = invoice.get("customer")
     attempt_count = invoice.get("attempt_count", 1)
-    
+
     logger.warning(f"Invoice failed: {customer_id} - attempt #{attempt_count}")
     # Could trigger dunning emails, Slack alerts, etc.
 
@@ -350,10 +349,10 @@ async def api_create_checkout(request: CreateCheckoutRequest):
         cancel_url=request.cancel_url,
         lead_id=request.lead_id
     )
-    
+
     if not result.success:
         raise HTTPException(status_code=400, detail=result.error)
-    
+
     return {"checkout_url": result.checkout_url}
 
 
@@ -377,7 +376,7 @@ async def api_founding_spots():
         supabase = get_supabase_client()
         result = supabase.table("founding_spots_status").select("*").single().execute()
         return result.data
-    except Exception as e:
+    except Exception:
         # Fallback if view doesn't exist yet
         spots = await get_remaining_founding_spots()
         return {
@@ -405,9 +404,9 @@ async def stripe_webhook(
     """
     if not WEBHOOK_SECRET:
         raise HTTPException(status_code=500, detail="Webhook secret not configured")
-    
+
     payload = await request.body()
-    
+
     try:
         event = stripe.Webhook.construct_event(
             payload, stripe_signature, WEBHOOK_SECRET
@@ -416,12 +415,12 @@ async def stripe_webhook(
         raise HTTPException(status_code=400, detail="Invalid payload")
     except stripe.SignatureVerificationError:
         raise HTTPException(status_code=400, detail="Invalid signature")
-    
+
     event_type = event["type"]
     data = event["data"]["object"]
-    
+
     logger.info(f"Stripe webhook received: {event_type}")
-    
+
     # Route to appropriate handler
     handlers = {
         "checkout.session.completed": handle_checkout_completed,
@@ -430,13 +429,13 @@ async def stripe_webhook(
         "invoice.paid": handle_invoice_paid,
         "invoice.payment_failed": handle_invoice_failed,
     }
-    
+
     handler = handlers.get(event_type)
     if handler:
         await handler(data)
     else:
         logger.debug(f"Unhandled webhook event type: {event_type}")
-    
+
     return {"status": "ok"}
 
 

--- a/src/integrations/twitter.py
+++ b/src/integrations/twitter.py
@@ -526,7 +526,7 @@ class TwitterClient:
                 "provider": "twitter",
             }
 
-        except Unauthorized as e:
+        except Unauthorized:
             raise APIError(
                 service="twitter",
                 status_code=401,

--- a/src/integrations/warmforge.py
+++ b/src/integrations/warmforge.py
@@ -9,6 +9,7 @@ Consumed by: warmup_monitor_flow
 """
 
 import httpx
+
 from src.config.settings import get_settings
 
 

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -24,7 +24,6 @@ from src.models.campaign_suggestion import (
 from src.models.client import Client
 from src.models.client_intelligence import ClientIntelligence
 from src.models.client_persona import PERSONA_ALLOCATIONS, ClientPersona
-from src.models.persona import PERSONA_TIER_ALLOCATIONS, Persona, PersonaStatus
 from src.models.conversion_patterns import ConversionPattern, ConversionPatternHistory
 from src.models.digest_log import DigestLog
 from src.models.icp_refinement_log import IcpRefinementLog
@@ -35,6 +34,7 @@ from src.models.linkedin_connection import LinkedInConnection, LinkedInConnectio
 from src.models.linkedin_credential import LinkedInCredential
 from src.models.linkedin_seat import LINKEDIN_WARMUP_SCHEDULE, LinkedInSeat, LinkedInSeatStatus
 from src.models.membership import Membership
+from src.models.persona import PERSONA_TIER_ALLOCATIONS, Persona, PersonaStatus
 from src.models.resource_pool import (
     HEALTH_DAILY_LIMITS,
     HEALTH_THRESHOLDS,

--- a/src/orchestration/flows/__init__.py
+++ b/src/orchestration/flows/__init__.py
@@ -21,7 +21,6 @@ from src.orchestration.flows.daily_digest_flow import (
     daily_digest_flow,
     send_client_digest_flow,
 )
-from src.orchestration.flows.warmup_monitor_flow import warmup_monitor_flow
 from src.orchestration.flows.enrichment_flow import daily_enrichment_flow
 from src.orchestration.flows.outreach_flow import hourly_outreach_flow as outreach_flow
 from src.orchestration.flows.pattern_backfill_flow import (
@@ -31,6 +30,10 @@ from src.orchestration.flows.pattern_backfill_flow import (
 from src.orchestration.flows.pattern_learning_flow import (
     single_client_pattern_learning_flow,
     weekly_pattern_learning_flow,
+)
+from src.orchestration.flows.persona_buffer_flow import (
+    get_buffer_status,
+    persona_buffer_flow,
 )
 from src.orchestration.flows.pool_assignment_flow import (
     jit_validate_outreach_batch_flow,
@@ -42,10 +45,7 @@ from src.orchestration.flows.stale_lead_refresh_flow import (
     daily_outreach_prep_flow,
     refresh_stale_leads_flow,
 )
-from src.orchestration.flows.persona_buffer_flow import (
-    persona_buffer_flow,
-    get_buffer_status,
-)
+from src.orchestration.flows.warmup_monitor_flow import warmup_monitor_flow
 
 __all__ = [
     # Core flows

--- a/src/orchestration/flows/batch_controller_flow.py
+++ b/src/orchestration/flows/batch_controller_flow.py
@@ -214,7 +214,7 @@ async def apply_gate_1_filter_task(
         if enrichment_data.get("country", "").lower() == "australia":
             abn = enrichment_data.get("abn")
             abn_verified = enrichment_data.get("abn_verified", False)
-            
+
             if not abn and not abn_verified:
                 await _soft_discard_lead(
                     db,
@@ -243,7 +243,7 @@ async def apply_gate_1_filter_task(
             {"lead_pool_id": lead_pool_id},
         )
         dup_row = dup_result.fetchone()
-        
+
         if dup_row and dup_row.dup_count > 0:
             await _soft_discard_lead(
                 db,
@@ -362,7 +362,7 @@ async def apply_gate_2_filter_task(
         # Check Hunter confidence
         enrichment_data = row.enrichment_data or {}
         hunter_confidence = enrichment_data.get("hunter_confidence", 100)
-        
+
         if hunter_confidence < 70:
             await _soft_discard_lead(
                 db,
@@ -494,11 +494,11 @@ async def trigger_replacement_discovery_task(
                 }
 
             icp_config = row.icp_config or {}
-            
+
             # Trigger GMB discovery via the discovery service
             # This would call the actual GMB scraper/discovery flow
             from src.integrations.gmb_scraper import trigger_gmb_discovery
-            
+
             discovery_result = await trigger_gmb_discovery(
                 search_queries=icp_config.get("search_queries", []),
                 locations=icp_config.get("countries", ["Australia"]),
@@ -877,7 +877,7 @@ async def apply_quality_gates_flow(
 
         # Gate 3 (never discards)
         g3_result = await apply_gate_3_filter_task(lead_pool_id=lead_pool_id)
-        
+
         if g3_result.get("action") == "demoted":
             results["gate_3_demoted"] += 1
 

--- a/src/orchestration/flows/infra_provisioning_flow.py
+++ b/src/orchestration/flows/infra_provisioning_flow.py
@@ -20,8 +20,7 @@ MARGIN IMPACT: Maintains 65.6% → 70.1% target achievable
 
 import logging
 from datetime import datetime
-from typing import Any
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from prefect import flow, task
 from prefect.task_runners import ConcurrentTaskRunner
@@ -74,11 +73,11 @@ async def check_domain_availability_task(
         List of available domains with pricing
     """
     client = get_infraforge_client()
-    
+
     try:
         # Generate alternatives
         alternatives = await client.generate_alternative_domains(base_name, count * 2)
-        
+
         available = []
         for domain in alternatives.get("domains", []):
             # Check availability
@@ -89,13 +88,13 @@ async def check_domain_availability_task(
                     "price_usd": availability.get("price", 14),
                     "price_aud": availability.get("price", 14) * 1.55,
                 })
-            
+
             if len(available) >= count:
                 break
-        
+
         logger.info(f"Found {len(available)} available domains for base: {base_name}")
         return available
-        
+
     except Exception as e:
         logger.error(f"Domain availability check failed: {e}")
         raise
@@ -117,21 +116,21 @@ async def purchase_domains_task(
         Purchase result with domain IDs
     """
     client = get_infraforge_client()
-    
+
     try:
         # Format for API
         domain_list = [{"domain": d["domain"]} for d in domains]
-        
+
         result = await client.buy_domains(domain_list)
-        
+
         # Calculate cost
         total_cost_aud = len(domains) * DOMAIN_COST_PER_YEAR_AUD
-        
+
         logger.info(
             f"Purchased {len(domains)} domains for client {client_id}. "
             f"Cost: ${total_cost_aud:.2f} AUD/year"
         )
-        
+
         return {
             "success": True,
             "domains_purchased": len(domains),
@@ -139,7 +138,7 @@ async def purchase_domains_task(
             "cost_aud_month": total_cost_aud / 12,
             "domain_ids": result.get("domainIds", []),
         }
-        
+
     except Exception as e:
         logger.error(f"Domain purchase failed: {e}")
         raise
@@ -167,7 +166,7 @@ async def create_mailboxes_task(
         Mailbox creation result
     """
     client = get_infraforge_client()
-    
+
     try:
         mailboxes = []
         for domain in domains:
@@ -175,24 +174,24 @@ async def create_mailboxes_task(
                 # Generate professional email prefixes
                 prefixes = ["outreach", "hello", "contact", "team", "sales"]
                 prefix = prefixes[i % len(prefixes)]
-                
+
                 mailboxes.append({
                     "email": f"{prefix}{i+1}@{domain}",
                     "firstName": "Agency",
                     "lastName": "Outreach",
                 })
-        
+
         result = await client.create_mailboxes(mailboxes)
-        
+
         # Calculate cost
         total_mailboxes = len(mailboxes)
         monthly_cost_aud = total_mailboxes * MAILFORGE_COST_PER_MAILBOX_AUD
-        
+
         logger.info(
             f"Created {total_mailboxes} mailboxes across {len(domains)} domains. "
             f"Cost: ${monthly_cost_aud:.2f} AUD/month"
         )
-        
+
         return {
             "success": True,
             "mailboxes_created": total_mailboxes,
@@ -200,7 +199,7 @@ async def create_mailboxes_task(
             "cost_aud_month": monthly_cost_aud,
             "mailbox_ids": result.get("mailboxIds", []),
         }
-        
+
     except Exception as e:
         logger.error(f"Mailbox creation failed: {e}")
         raise
@@ -228,25 +227,25 @@ async def export_to_warmup_task(
         Export result
     """
     client = get_infraforge_client()
-    
+
     try:
-        result = await client.export_to_salesforge(
+        await client.export_to_salesforge(
             from_workspace_id=from_workspace_id,
             to_workspace_id=to_salesforge_workspace_id,
             to_warmforge_workspace_id=to_warmforge_workspace_id,
             tag_name=tag_name,
             warmup_activated=True,  # Auto-start warmup
         )
-        
+
         logger.info(f"Exported mailboxes to Salesforge/WarmForge with tag: {tag_name}")
-        
+
         return {
             "success": True,
             "exported": True,
             "warmup_activated": True,
             "tag": tag_name,
         }
-        
+
     except Exception as e:
         logger.error(f"Export to warmup failed: {e}")
         raise
@@ -331,27 +330,27 @@ async def infra_provisioning_flow(
         Complete provisioning result with costs
     """
     logger.info(f"Starting infrastructure provisioning for client {client_id}")
-    
+
     start_time = datetime.utcnow()
-    
+
     # Step 1: Find available domains
     available_domains = await check_domain_availability_task(
         base_name=company_name,
         count=domain_count,
     )
-    
+
     if len(available_domains) < domain_count:
         logger.warning(
             f"Only {len(available_domains)} domains available, "
             f"requested {domain_count}"
         )
-    
+
     # Step 2: Purchase domains
     purchase_result = await purchase_domains_task(
         domains=available_domains[:domain_count],
         client_id=client_id,
     )
-    
+
     # Step 3: Create mailboxes
     domain_names = [d["domain"] for d in available_domains[:domain_count]]
     mailbox_result = await create_mailboxes_task(
@@ -359,13 +358,13 @@ async def infra_provisioning_flow(
         mailboxes_per_domain=mailboxes_per_domain,
         client_id=client_id,
     )
-    
+
     # Step 4: Export to warmup (if workspace IDs provided)
     export_result = {"success": False, "skipped": True}
     if salesforge_workspace_id and warmforge_workspace_id:
         infraforge_workspace = await get_infraforge_client().list_workspaces()
         workspace_id = infraforge_workspace.get("workspaces", [{}])[0].get("id")
-        
+
         if workspace_id:
             export_result = await export_to_warmup_task(
                 from_workspace_id=workspace_id,
@@ -373,7 +372,7 @@ async def infra_provisioning_flow(
                 to_warmforge_workspace_id=warmforge_workspace_id,
                 tag_name=f"client_{client_id}",
             )
-    
+
     # Step 5: Log costs
     await log_provisioning_cost_task(
         client_id=client_id,
@@ -382,15 +381,15 @@ async def infra_provisioning_flow(
         domain_cost_aud=purchase_result["cost_aud_month"],
         mailbox_cost_aud=mailbox_result["cost_aud_month"],
     )
-    
+
     # Calculate totals
     total_cost_month = (
-        purchase_result["cost_aud_month"] + 
+        purchase_result["cost_aud_month"] +
         mailbox_result["cost_aud_month"]
     )
-    
+
     duration = (datetime.utcnow() - start_time).total_seconds()
-    
+
     result = {
         "success": True,
         "client_id": str(client_id),
@@ -411,13 +410,13 @@ async def infra_provisioning_flow(
         "duration_seconds": duration,
         "automation_time_saved_hours": 15,  # vs manual Titan/Neo setup
     }
-    
+
     logger.info(
         f"Infrastructure provisioning complete for client {client_id}. "
         f"Cost: ${total_cost_month:.2f} AUD/month. "
         f"Duration: {duration:.1f}s (saved ~15 hours vs manual)"
     )
-    
+
     return result
 
 

--- a/src/orchestration/flows/marketing_automation_flow.py
+++ b/src/orchestration/flows/marketing_automation_flow.py
@@ -27,7 +27,6 @@ Orchestrates the daily "Build in Public" content generation:
 See: docs/marketing/MARKETING_LAUNCH_PLAN.md for templates
 """
 
-import asyncio
 import json
 import logging
 import os
@@ -35,13 +34,11 @@ import tempfile
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
-from uuid import UUID
 
 from prefect import flow, get_run_logger, task
 from prefect.runtime import flow_run
 
 from src.config.database import get_db_session
-from src.config.settings import settings
 from src.exceptions import IntegrationError
 
 logger = logging.getLogger(__name__)
@@ -223,17 +220,17 @@ async def get_marketing_metrics_task(metrics_date: date) -> dict[str, Any]:
     """
     log = get_run_logger()
 
-    async with get_db_session() as db:
+    async with get_db_session() as _db:
         # Query internal metrics - this would connect to your actual metrics tables
         # For now, returning structure that can be populated from actual data
-        
+
         # Calculate day number from launch date
         launch_date = date(2025, 1, 15)  # Configure actual launch date
         day_number = (metrics_date - launch_date).days + 1
 
         # Query email metrics for the date
         # In production, this queries the actual campaign_metrics and lead tables
-        metrics_query = """
+        _metrics_query = """
             SELECT 
                 COALESCE(SUM(emails_sent), 0) as emails_sent,
                 COALESCE(SUM(opens), 0) as opens,
@@ -244,16 +241,16 @@ async def get_marketing_metrics_task(metrics_date: date) -> dict[str, Any]:
             WHERE metric_date = :metric_date
             AND client_id = :internal_client_id
         """
-        
+
         # For now, return placeholder metrics
         # TODO: Replace with actual query execution when tables are ready
-        
+
         # Get customer count from customers table
         customers_count = 0  # Query actual customers table
-        
+
         # Calculate spots remaining
         spots_remaining = max(0, FOUNDING_SPOTS_TOTAL - customers_count)
-        
+
         metrics = {
             "emails_sent": 0,
             "opens": 0,
@@ -820,10 +817,10 @@ async def log_content_run_task(
     """
     log = get_run_logger()
 
-    async with get_db_session() as db:
+    async with get_db_session() as _db:
         # Log to a marketing_content_logs table if it exists
         # For now, just log to the logger
-        
+
         summary = {
             "flow_type": flow_type,
             "metric_date": metrics.get("metric_date"),
@@ -905,11 +902,11 @@ async def daily_content_flow(
     # 5. Generate video (unless skipped)
     video_result = None
     video_path = None
-    
+
     if not skip_video:
         video_id = await create_heygen_video_task(script, test_mode=test_mode)
         video_result = await wait_for_video_completion_task(video_id)
-        
+
         if video_result.get("video_url"):
             video_path = await download_video_task(video_id, video_result["video_url"])
     else:
@@ -917,14 +914,14 @@ async def daily_content_flow(
 
     # 6. Generate platform posts
     posts = await generate_platform_posts_task(
-        metrics, 
+        metrics,
         insight,
         video_url=video_result.get("video_url") if video_result else None,
     )
 
     # 7. Distribute content (unless skipped)
     distribution_results = {}
-    
+
     if not skip_distribution:
         # LinkedIn via Buffer
         distribution_results["linkedin"] = await schedule_linkedin_post_task(
@@ -1050,7 +1047,7 @@ async def milestone_content_flow(
 
     # Generate celebratory posts
     from src.integrations.anthropic import get_anthropic_client
-    
+
     client = get_anthropic_client()
 
     # Use AI to generate platform-specific milestone posts

--- a/src/orchestration/flows/outreach_flow.py
+++ b/src/orchestration/flows/outreach_flow.py
@@ -38,7 +38,7 @@ from uuid import UUID
 
 from prefect import flow, task
 from prefect.task_runners import ConcurrentTaskRunner
-from sqlalchemy import and_, select
+from sqlalchemy import and_, select, text
 
 from src.agents.sdk_agents import should_use_sdk_email
 from src.engines.allocator import get_allocator_engine
@@ -58,14 +58,11 @@ from src.models.base import (
 from src.models.campaign import Campaign
 from src.models.client import Client
 from src.models.lead import Lead
-from src.config.tiers import get_available_channels
 from src.services.content_qa_service import (
     validate_email_content,
     validate_linkedin_content,
     validate_sms_content,
 )
-
-from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +116,7 @@ async def check_campaign_quality_gate_task(campaign_id: str) -> dict[str, Any]:
 
         if not row or row.total_leads == 0:
             await _create_campaign_halt_notification(
-                db, campaign_id, "no_leads", 
+                db, campaign_id, "no_leads",
                 "Campaign has no leads in sequence", {}
             )
             return {
@@ -221,11 +218,11 @@ async def _create_campaign_halt_notification(
             {"campaign_id": campaign_id},
         )
         row = result.fetchone()
-        
+
         if row:
             import json
             from uuid import uuid4
-            
+
             notification_id = str(uuid4())
             await db.execute(
                 text("""
@@ -270,7 +267,7 @@ async def auto_assign_resources_task(lead_id: str, campaign_id: str) -> dict[str
         Dict with assigned resources
     """
     from src.config.tiers import CHANNEL_ACCESS_BY_ALS, get_als_tier
-    
+
     async with get_db_session() as db:
         # Get lead tier and client resources
         result = await db.execute(
@@ -309,7 +306,7 @@ async def auto_assign_resources_task(lead_id: str, campaign_id: str) -> dict[str
             """),
             {"client_id": str(client_id)},
         )
-        
+
         # Build resource map with best available resource per channel
         available_resources = {}
         for row in resources_result.fetchall():
@@ -353,7 +350,7 @@ async def auto_assign_resources_task(lead_id: str, campaign_id: str) -> dict[str
         if assigned:
             update_parts = []
             params = {"lead_id": lead_id}
-            
+
             if "email" in assigned:
                 update_parts.append("assigned_email_resource = :email_resource")
                 params["email_resource"] = assigned["email"]
@@ -399,7 +396,7 @@ async def trigger_additional_discovery_task(campaign_id: str) -> dict[str, Any]:
         Dict with discovery result
     """
     from src.orchestration.flows.batch_controller_flow import trigger_replacement_discovery_task
-    
+
     async with get_db_session() as db:
         # Get campaign client_id
         result = await db.execute(
@@ -407,17 +404,17 @@ async def trigger_additional_discovery_task(campaign_id: str) -> dict[str, Any]:
             {"campaign_id": campaign_id},
         )
         row = result.fetchone()
-        
+
         if not row:
             return {"campaign_id": campaign_id, "success": False, "error": "Campaign not found"}
-        
+
         # Trigger discovery for 50 additional leads
         discovery_result = await trigger_replacement_discovery_task(
             campaign_id=campaign_id,
             client_id=str(row.client_id),
             count_needed=50,
         )
-        
+
         return {
             "campaign_id": campaign_id,
             "success": discovery_result.get("success", False),
@@ -1095,7 +1092,7 @@ async def hourly_outreach_flow(batch_size: int = 50) -> dict[str, Any]:
     for campaign_id in all_campaign_ids:
         quality_result = await check_campaign_quality_gate_task(campaign_id)
         campaigns_checked[campaign_id] = quality_result
-        
+
         if not quality_result.get("passed"):
             logger.warning(
                 f"Campaign {campaign_id} failed quality gate: {quality_result.get('reason')} "
@@ -1125,7 +1122,7 @@ async def hourly_outreach_flow(batch_size: int = 50) -> dict[str, Any]:
     total_after_filter = sum(
         len(leads) for leads in leads_data["leads_by_channel"].values()
     )
-    
+
     if total_after_filter == 0:
         logger.info("No leads ready after quality gate filter")
         return {

--- a/src/orchestration/flows/persona_buffer_flow.py
+++ b/src/orchestration/flows/persona_buffer_flow.py
@@ -24,8 +24,8 @@ from sqlalchemy import func, select
 
 from src.config.database import get_db_session
 from src.models.resource_pool import ResourcePool, ResourceStatus, ResourceType
-from src.services.persona_service import generate_persona
 from src.services.domain_provisioning_service import provision_persona_with_domains
+from src.services.persona_service import generate_persona
 
 logger = logging.getLogger(__name__)
 

--- a/src/orchestration/tasks/enrichment_tasks.py
+++ b/src/orchestration/tasks/enrichment_tasks.py
@@ -17,6 +17,7 @@ RULES APPLIED:
   - Rule 14: Soft deletes only
 """
 
+import contextlib
 import logging
 from typing import Any
 from uuid import UUID
@@ -475,8 +476,8 @@ async def _pause_campaign_for_reconnect(
         {"campaign_id": str(campaign_id), "reason": reason}
     )
 
-    # Log to audit table if it exists
-    try:
+    # Log to audit table if it exists (audit table may not exist - that's fine)
+    with contextlib.suppress(Exception):
         await db.execute(
             text("""
                 INSERT INTO audit_log (
@@ -491,9 +492,6 @@ async def _pause_campaign_for_reconnect(
                 "details": f'{{"reason": "{reason}"}}',
             }
         )
-    except Exception:
-        # Audit table may not exist - that's fine
-        pass
 
     await db.commit()
     logger.warning(f"Paused campaign {campaign_id} for reconnect: {reason}")

--- a/src/services/alert_service.py
+++ b/src/services/alert_service.py
@@ -29,11 +29,11 @@ ALERT TYPES:
 8. Reply confidence <60% → human review queue (not alert)
 """
 
+import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 from uuid import UUID
-import json
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -237,7 +237,7 @@ class AlertService:
 
             # Send via Resend
             from src.integrations.resend import send_alert_email
-            
+
             await send_alert_email(
                 to_email=row.email,
                 to_name=row.first_name or "Agency Owner",
@@ -305,7 +305,7 @@ class AlertService:
         recovery_msg = ""
         if reset_time:
             recovery_msg = f" Estimated recovery: {reset_time.strftime('%Y-%m-%d %H:%M UTC')}"
-        
+
         return await self.create_alert(
             alert_type=AlertType.HUNTER_RATE_LIMIT,
             title="⚠️ Hunter Rate Limit Hit",

--- a/src/services/deliverability_service.py
+++ b/src/services/deliverability_service.py
@@ -23,11 +23,11 @@ REQUIREMENTS:
 3. Expose warmup status, daily send limit, health score per domain
 """
 
+import json
 import logging
 from datetime import datetime
 from typing import Any
 from uuid import UUID
-import json
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -109,7 +109,7 @@ class DeliverabilityService:
                 WHERE (:client_id IS NULL OR dws.client_id = :client_id)
                 ORDER BY dws.health_score ASC NULLS LAST
             """)
-            
+
             result = await self.session.execute(
                 query,
                 {"client_id": str(client_id) if client_id else None},
@@ -125,10 +125,10 @@ class DeliverabilityService:
             for row in rows:
                 total_domains += 1
                 health = row.health_score or 0
-                
+
                 if health >= WARMUP_HEALTH_THRESHOLD:
                     healthy_domains += 1
-                
+
                 if row.warmup_stage == "ramping":
                     warming_domains += 1
                 elif row.warmup_stage == "paused":
@@ -189,25 +189,25 @@ class DeliverabilityService:
         """
         try:
             from src.integrations.warmforge import get_warmforge_client
-            
+
             warmforge = get_warmforge_client()
-            
+
             # Get all accounts from Warmforge
             accounts = await warmforge.list_accounts()
-            
+
             updated = 0
             errors = []
 
             for account in accounts:
                 try:
                     domain = account.get("domain") or account.get("email", "").split("@")[-1]
-                    
+
                     if not domain:
                         continue
 
                     # Get detailed status
                     status = await warmforge.get_account_status(account.get("id"))
-                    
+
                     # Map warmup stage
                     warmup_stage = "stable"
                     if status.get("is_warming"):
@@ -300,7 +300,7 @@ class DeliverabilityService:
             List of alerts created
         """
         from src.services.alert_service import get_alert_service
-        
+
         alerts_created = []
 
         try:
@@ -328,7 +328,7 @@ class DeliverabilityService:
                     health_score=float(row.health_score) if row.health_score else 0,
                     threshold=WARMUP_HEALTH_THRESHOLD,
                 )
-                
+
                 if alert_id:
                     alerts_created.append({
                         "client_id": str(row.client_id),
@@ -360,7 +360,7 @@ class DeliverabilityService:
             Structured data feed for dashboard
         """
         report = await self.get_warmup_status_report(client_id)
-        
+
         # Transform for dashboard consumption
         return {
             "client_id": str(client_id),

--- a/src/services/domain_provisioning_service.py
+++ b/src/services/domain_provisioning_service.py
@@ -16,13 +16,12 @@ Handles:
 
 import logging
 from typing import Any
-from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.integrations.infraforge import get_infraforge_client, WORKSPACE_IDS
+from src.integrations.infraforge import WORKSPACE_IDS, get_infraforge_client
 from src.models.persona import Persona
-from src.models.resource_pool import ResourcePool, ResourceType, ResourceStatus
+from src.models.resource_pool import ResourceStatus, ResourceType
 from src.services.resource_assignment_service import add_resource_to_pool
 
 logger = logging.getLogger(__name__)

--- a/src/services/icp_filter_service.py
+++ b/src/services/icp_filter_service.py
@@ -241,14 +241,14 @@ class ICPFilterService:
     - Layer 2: Hard Exclude List check
     - Layer 3: Industry validation for ALS gating
     """
-    
+
     @staticmethod
     def normalize_text(text: str | None) -> str:
         """Normalize text for matching."""
         if not text:
             return ""
         return text.lower().strip()
-    
+
     @staticmethod
     def normalize_for_industry_match(text: str | None) -> str:
         """
@@ -262,7 +262,7 @@ class ICPFilterService:
         # Lowercase, strip, replace spaces with underscores
         normalized = text.lower().strip().replace(" ", "_").replace("&", "and")
         return normalized
-    
+
     @classmethod
     def check_category_whitelist(
         cls,
@@ -280,20 +280,20 @@ class ICPFilterService:
             Tuple of (passes_whitelist, matched_category)
         """
         all_cats = []
-        
+
         if gmb_category:
             all_cats.append(cls.normalize_text(gmb_category))
-        
+
         if categories:
             all_cats.extend([cls.normalize_text(c) for c in categories])
-        
+
         for cat in all_cats:
             for whitelist_term in ICP_CATEGORY_WHITELIST:
                 if whitelist_term in cat:
                     return True, cat
-        
+
         return False, None
-    
+
     @classmethod
     def check_category_blacklist(
         cls,
@@ -317,30 +317,30 @@ class ICPFilterService:
             Tuple of (is_blacklisted, matched_term)
         """
         all_text = []
-        
+
         if gmb_category:
             all_text.append(cls.normalize_text(gmb_category))
-        
+
         if categories:
             all_text.extend([cls.normalize_text(c) for c in categories])
-        
+
         # NOTE: company_name deliberately NOT included (Directive #046)
         # Property Marketing Agency should pass — their GMB category is "marketing agency"
-        
+
         if not all_text:
             # No categories to check = not blacklisted
             return False, None
-        
+
         combined = " ".join(all_text)
-        
+
         for blacklist_term in ICP_CATEGORY_BLACKLIST:
             # Use word boundary matching to avoid false positives
             pattern = r'\b' + re.escape(blacklist_term) + r'\b'
             if re.search(pattern, combined):
                 return True, blacklist_term
-        
+
         return False, None
-    
+
     @classmethod
     def check_industry_whitelist(
         cls,
@@ -362,25 +362,25 @@ class ICPFilterService:
             Tuple of (passes_whitelist, matched_industry)
         """
         industries = []
-        
+
         if industry:
             industries.append(cls.normalize_text(industry))
         if sub_industry:
             industries.append(cls.normalize_text(sub_industry))
-        
+
         # Build normalized whitelist for underscore matching
         normalized_whitelist = {cls.normalize_for_industry_match(t) for t in ICP_INDUSTRY_WHITELIST}
-        
+
         for ind in industries:
             # Direct match against whitelist
             if ind in ICP_INDUSTRY_WHITELIST:
                 return True, ind
-            
+
             # Normalized match (underscore format) — Directive #046
             normalized_ind = cls.normalize_for_industry_match(ind)
             if normalized_ind in normalized_whitelist:
                 return True, ind
-            
+
             # Partial match for flexibility
             for whitelist_term in ICP_INDUSTRY_WHITELIST:
                 if whitelist_term in ind or ind in whitelist_term:
@@ -389,9 +389,9 @@ class ICPFilterService:
                 norm_term = cls.normalize_for_industry_match(whitelist_term)
                 if norm_term in normalized_ind or normalized_ind in norm_term:
                     return True, ind
-        
+
         return False, None
-    
+
     @classmethod
     def check_industry_blacklist(
         cls,
@@ -409,18 +409,18 @@ class ICPFilterService:
             Tuple of (is_blacklisted, matched_industry)
         """
         industries = []
-        
+
         if industry:
             industries.append(cls.normalize_text(industry))
         if sub_industry:
             industries.append(cls.normalize_text(sub_industry))
-        
+
         for ind in industries:
             if ind in ICP_INDUSTRY_BLACKLIST:
                 return True, ind
-        
+
         return False, None
-    
+
     @classmethod
     def is_icp_qualified(
         cls,
@@ -446,30 +446,30 @@ class ICPFilterService:
             "layer_failed": None,
             "matched_term": None,
         }
-        
+
         # Extract fields
         company_name = lead_data.get("company_name")
         industry = lead_data.get("company_industry")
         sub_industry = lead_data.get("company_sub_industry")
-        
+
         # GMB categories from enrichment_data or direct field
         enrichment = lead_data.get("enrichment_data") or {}
         if isinstance(enrichment, str):
             import json
             try:
                 enrichment = json.loads(enrichment)
-            except:
+            except Exception:
                 enrichment = {}
-        
+
         categories = (
-            lead_data.get("categories") or 
+            lead_data.get("categories") or
             lead_data.get("all_categories") or
             enrichment.get("gmb_categories") or
             enrichment.get("categories") or
             []
         )
         gmb_category = lead_data.get("gmb_category") or enrichment.get("gmb_category")
-        
+
         # ========== Layer 2: Hard Exclude (check first) ==========
         # If blacklisted, reject immediately
         is_blacklisted, blacklist_term = cls.check_category_blacklist(
@@ -481,7 +481,7 @@ class ICPFilterService:
             details["matched_term"] = blacklist_term
             logger.info(f"ICP REJECT (Layer 2): {company_name} — {blacklist_term}")
             return False, details
-        
+
         is_industry_blacklisted, blacklist_industry = cls.check_industry_blacklist(
             industry, sub_industry
         )
@@ -491,7 +491,7 @@ class ICPFilterService:
             details["matched_term"] = blacklist_industry
             logger.info(f"ICP REJECT (Layer 2): {company_name} — industry: {blacklist_industry}")
             return False, details
-        
+
         # ========== Layer 1: Category Whitelist ==========
         passes_cat_whitelist, matched_cat = cls.check_category_whitelist(
             categories, gmb_category
@@ -502,7 +502,7 @@ class ICPFilterService:
             details["matched_term"] = matched_cat
             logger.info(f"ICP PASS (Layer 1): {company_name} — {matched_cat}")
             return True, details
-        
+
         # ========== Layer 3: Industry Whitelist ==========
         passes_ind_whitelist, matched_ind = cls.check_industry_whitelist(
             industry, sub_industry
@@ -513,13 +513,13 @@ class ICPFilterService:
             details["matched_term"] = matched_ind
             logger.info(f"ICP PASS (Layer 3): {company_name} — industry: {matched_ind}")
             return True, details
-        
+
         # ========== No match ==========
         details["reason"] = "No ICP match found"
         details["layer_failed"] = "no_whitelist_match"
         logger.info(f"ICP REJECT (no match): {company_name} — industry: {industry}")
         return False, details
-    
+
     @classmethod
     def calculate_industry_als_penalty(
         cls,
@@ -538,17 +538,17 @@ class ICPFilterService:
             Penalty points (0 = no penalty, 50+ = effectively disqualified)
         """
         industry = lead_data.get("company_industry")
-        
+
         # Blacklisted industry = max penalty
         is_blacklisted, _ = cls.check_industry_blacklist(industry)
         if is_blacklisted:
             return 60  # Ensures ALS < 50 even with perfect other scores
-        
+
         # Whitelisted industry = no penalty
         passes_whitelist, _ = cls.check_industry_whitelist(industry)
         if passes_whitelist:
             return 0
-        
+
         # Unknown industry = moderate penalty
         return 30
 

--- a/src/services/lead_pool_service.py
+++ b/src/services/lead_pool_service.py
@@ -51,7 +51,7 @@ class LeadPoolService:
         self.session = session
 
     async def create_or_update(
-        self, 
+        self,
         lead_data: dict[str, Any],
         skip_icp_check: bool = False,
     ) -> dict[str, Any]:
@@ -87,7 +87,7 @@ class LeadPoolService:
         if not skip_icp_check:
             icp_service = get_icp_filter_service()
             is_qualified, details = icp_service.is_icp_qualified(lead_data)
-            
+
             if not is_qualified:
                 company = lead_data.get("company_name", "Unknown")
                 reason = details.get("reason", "Failed ICP check")

--- a/src/services/persona_service.py
+++ b/src/services/persona_service.py
@@ -88,16 +88,16 @@ COMPANY_NAMES = [
 BIO_TEMPLATES = [
     "Passionate about helping businesses scale through strategic partnerships. "
     "{years}+ years of experience driving growth across diverse industries.",
-    
+
     "Dedicated to building lasting business relationships that deliver measurable results. "
     "Specializing in {specialty} with a track record of exceeding targets.",
-    
+
     "Results-driven professional focused on identifying and capturing growth opportunities. "
     "Known for a consultative approach that puts client success first.",
-    
+
     "Strategic thinker with expertise in {specialty}. "
     "Committed to understanding unique business challenges and delivering tailored solutions.",
-    
+
     "Experienced in driving revenue growth through relationship-based strategies. "
     "{years}+ years helping organizations achieve their full potential.",
 ]

--- a/src/services/spending_guard.py
+++ b/src/services/spending_guard.py
@@ -12,7 +12,6 @@ SAFEGUARDS:
 
 import logging
 from datetime import date
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +78,7 @@ def check_can_purchase(domain_count: int) -> bool:
         SpendingLimitExceeded: If any limit would be exceeded
     """
     _reset_if_new_day()
-    
+
     # Check per-call limit
     if domain_count > MAX_DOMAINS_PER_CALL:
         msg = (
@@ -88,7 +87,7 @@ def check_can_purchase(domain_count: int) -> bool:
         )
         logger.error(msg)
         raise SpendingLimitExceeded(msg)
-    
+
     # Check daily domain limit
     projected_domains = _daily_stats["domains_purchased"] + domain_count
     if projected_domains > MAX_DOMAINS_PER_DAY:
@@ -98,7 +97,7 @@ def check_can_purchase(domain_count: int) -> bool:
         )
         logger.error(msg)
         raise SpendingLimitExceeded(msg)
-    
+
     # Check daily spend limit
     projected_spend = domain_count * DOMAIN_COST_AUD
     if _daily_stats["spend_aud"] + projected_spend > MAX_SPEND_PER_DAY_AUD:
@@ -108,7 +107,7 @@ def check_can_purchase(domain_count: int) -> bool:
         )
         logger.error(msg)
         raise SpendingLimitExceeded(msg)
-    
+
     logger.info(
         f"Spending check passed: {domain_count} domains, "
         f"${projected_spend} (daily total will be: "
@@ -117,7 +116,7 @@ def check_can_purchase(domain_count: int) -> bool:
     return True
 
 
-def record_purchase(domain_count: int, spend_aud: Optional[float] = None) -> None:
+def record_purchase(domain_count: int, spend_aud: float | None = None) -> None:
     """
     Record a successful purchase against daily limits.
     
@@ -126,12 +125,12 @@ def record_purchase(domain_count: int, spend_aud: Optional[float] = None) -> Non
         spend_aud: Actual spend (defaults to domain_count * DOMAIN_COST_AUD)
     """
     _reset_if_new_day()
-    
+
     actual_spend = spend_aud if spend_aud is not None else (domain_count * DOMAIN_COST_AUD)
-    
+
     _daily_stats["domains_purchased"] += domain_count
     _daily_stats["spend_aud"] += actual_spend
-    
+
     logger.info(
         f"Recorded purchase: {domain_count} domains, ${actual_spend:.2f} "
         f"(daily totals: {_daily_stats['domains_purchased']} domains, "
@@ -156,7 +155,7 @@ def requires_approval(domain_count: int) -> bool:
 def queue_for_approval(
     domain_count: int,
     domains: list[str],
-    persona_id: Optional[str] = None,
+    persona_id: str | None = None,
     reason: str = "buffer_replenishment",
 ) -> str:
     """
@@ -166,9 +165,9 @@ def queue_for_approval(
         Approval request ID
     """
     import uuid
-    
+
     request_id = str(uuid.uuid4())[:8]
-    
+
     _pending_approvals.append({
         "request_id": request_id,
         "domain_count": domain_count,
@@ -177,12 +176,12 @@ def queue_for_approval(
         "reason": reason,
         "created_at": date.today().isoformat(),
     })
-    
+
     logger.warning(
         f"Large purchase queued for approval: {domain_count} domains "
         f"(request_id: {request_id})"
     )
-    
+
     return request_id
 
 
@@ -191,7 +190,7 @@ def get_pending_approvals() -> list[dict]:
     return _pending_approvals.copy()
 
 
-def approve_request(request_id: str) -> Optional[dict]:
+def approve_request(request_id: str) -> dict | None:
     """Approve a pending request, return the request details."""
     for i, req in enumerate(_pending_approvals):
         if req["request_id"] == request_id:

--- a/src/services/unipile_service.py
+++ b/src/services/unipile_service.py
@@ -15,11 +15,10 @@ Key Features:
 """
 
 import logging
-from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, select, text, update
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config.settings import settings
@@ -78,7 +77,7 @@ class UnipileAccountService:
 
         # Create pending record or update existing
         existing = await self.get_user_account(db, user_id)
-        
+
         if existing:
             # Update existing to pending
             await db.execute(
@@ -116,7 +115,7 @@ class UnipileAccountService:
                 "message": "Redirect user to auth_url to connect LinkedIn",
             }
 
-        except Exception as e:
+        except Exception:
             logger.exception(f"Failed to generate Unipile auth URL for user {user_id}")
             raise
 
@@ -483,9 +482,7 @@ class UnipileAccountService:
 
             # Map Unipile status to our status
             new_status = "OK"
-            if unipile_status == "CREDENTIALS":
-                new_status = "EXPIRED"
-            elif unipile_status == "DISCONNECTED":
+            if unipile_status == "CREDENTIALS" or unipile_status == "DISCONNECTED":
                 new_status = "EXPIRED"
             elif unipile_status == "ERROR":
                 new_status = "ERROR"

--- a/src/services/unsubscribe_token_service.py
+++ b/src/services/unsubscribe_token_service.py
@@ -95,7 +95,7 @@ class UnsubscribeTokenService:
         # Enforce minimum validity per Spam Act
         if validity_days < 30:
             validity_days = 30
-            logger.warning(f"Validity days increased to 30 (Spam Act requirement)")
+            logger.warning("Validity days increased to 30 (Spam Act requirement)")
 
         now = datetime.utcnow()
         expiry = now + timedelta(days=validity_days)


### PR DESCRIPTION
## Summary

Full codebase lint cleanup to unblock Railway CI pipeline.

### Stats
- **Files changed:** 49
- **Safe auto-fixes:** 1,844
- **Manual fixes:** 30
- **Remaining (cosmetic):** 387 whitespace in docstrings/SQL

---

## Safe Auto-Fixes (ruff --fix)

| Code | Count | Description |
|------|-------|-------------|
| W291/W293 | 1,900+ | Trailing whitespace |
| I001 | 25 | Import sorting |
| F401 | 45 | Unused imports |
| UP006/UP045 | 158 | Modern type annotations |
| UP017 | 38 | datetime.UTC alias |

---

## Manual Fixes (30)

### Critical
| File | Line | Code | Fix |
|------|------|------|-----|
| `closer.py` | 539 | F821 | Added `channel` parameter to `_handle_intent()` and updated caller |
| `icp_filter_service.py` | 461 | E722 | Replaced bare `except:` with `except Exception:` |

### Unused Variables (F841)
- `closer.py:813` — removed unused `question`
- `identity_escalation.py:376` — removed unused `start_time`
- `smart_prompts.py:551` — removed unused `assignment_row`
- `voice_agent_telnyx.py:623` — renamed `audio` → `_audio`
- `waterfall_v2.py:614` — removed unused `email_address`
- `stripe_billing.py:305` — removed unused `customer_id`
- `infra_provisioning_flow.py:232` — removed unused `result`
- `marketing_automation_flow.py:223,820` — renamed `db` → `_db`
- `marketing_automation_flow.py:233` — renamed `metrics_query` → `_metrics_query`
- `gmb_scraper.py:907` — renamed `stats_parser` → `_stats_parser`

### Loop Variables (B007)
- `scorer.py:539,2098` — renamed `canonical` → `_canonical`
- `gmb_scraper.py:716` — renamed `i` → `_i`

### Simplifications (SIM103/SIM110)
- `icp_scraper.py:303` — simplified to `return any(...)`
- `scout.py:657` — simplified return
- `identity_escalation.py:247` — simplified to `return any(...)`

### contextlib.suppress (SIM105)
- `gmb_scraper.py:402,410` — `contextlib.suppress(ValueError)`
- `hunter.py:523` — `contextlib.suppress(Exception)`
- `stripe.py:412` — `contextlib.suppress(ValueError)`
- `enrichment_tasks.py:479` — `contextlib.suppress(Exception)`

### Other
- `heygen.py:459` — added `# noqa: SIM117` (nested async with intentional)
- `abn_client.py:194,228` — added `strict=True` to zip()
- `gmb_scraper.py:76,78,79,85` — added `# noqa: F401` (imports for availability checks)

---

## Remaining (Acceptable)

387 W291/W293 errors in docstrings and multi-line SQL strings. These require `--unsafe-fixes` which is banned. CI may still flag them — this is acceptable per CEO directive.

---

## closer.py F821 Fix — Before/After

**Before:**
```python
async def _handle_intent(
    self, db: AsyncSession, lead: Lead, intent: IntentType,
    confidence: float, reply_analysis: dict[str, Any] | None = None,
) -> list[str]:
```

**After:**
```python
async def _handle_intent(
    self, db: AsyncSession, lead: Lead, intent: IntentType,
    confidence: float, channel: ChannelType,
    reply_analysis: dict[str, Any] | None = None,
) -> list[str]:
```

Root cause: `channel.value` was used at line 539 to build STOP reason string, but `channel` was never passed. Fixed by adding parameter and updating caller in `process_reply()`.

---

**Ready for CEO merge.**