### PR TITLE
Step 2/8: Campaign Status Enum — Add PENDING_APPROVAL + APPROVED

### DIFF
--- a/supabase/migrations/063_campaign_status_enum.sql
+++ b/supabase/migrations/063_campaign_status_enum.sql
@@ -1,0 +1,10 @@
+-- Migration: 063_campaign_status_enum.sql
+-- SSOT Key: campaign_approval_flow (ID: 9470bfb5-fedc-4f7b-a8cc-4b42d7ff96db)
+-- Purpose: Add PENDING_APPROVAL and APPROVED to campaign_status enum
+-- Status flow: DRAFT → PENDING_APPROVAL → APPROVED → ACTIVE
+
+-- Add new enum values (PostgreSQL allows adding values to existing enums)
+ALTER TYPE campaign_status ADD VALUE IF NOT EXISTS 'pending_approval' AFTER 'draft';
+ALTER TYPE campaign_status ADD VALUE IF NOT EXISTS 'approved' AFTER 'pending_approval';
+
+-- Result: draft, pending_approval, approved, active, paused, completed


### PR DESCRIPTION
## Build Sequence Step 2 of 8

### SSOT Reference
- **Key:** `campaign_approval_flow`
- **ID:** `9470bfb5-fedc-4f7b-a8cc-4b42d7ff96db`

### Changes
Adds two new values to `campaign_status` enum:
- `pending_approval` (after draft)
- `approved` (after pending_approval)

### Status Flow
```
DRAFT → PENDING_APPROVAL → APPROVED → ACTIVE → PAUSED/COMPLETED
```

### Enum Values (verified)
```
draft, pending_approval, approved, active, paused, completed
```

### Migration Status
✅ Applied to production Supabase

### Governance
- LAW I-A (SSOT queried first)
- LAW VIII (PR only)
- Migration only — no frontend, no endpoints