### PR TITLE
feat(campaigns): add approval gate endpoints and Prefect guards (Step 4/8)

### DIFF
--- a/frontend/design/prototype/components/campaigns/CampaignAllocationManager.tsx
+++ b/frontend/design/prototype/components/campaigns/CampaignAllocationManager.tsx
@@ -10,7 +10,7 @@ import { PrioritySlider } from "./PrioritySlider";
 export interface CampaignWithPriority {
   id: string;
   name: string;
-  status: "active" | "paused" | "draft";
+  status: "active" | "paused" | "draft" | "pending_approval" | "approved";
   priority_pct: number;
   is_ai_suggested: boolean;
   meetings_this_month: number;
@@ -151,22 +151,26 @@ export function CampaignAllocationManager({
   };
 
   // Status badge component
-  const StatusBadge = ({ status }: { status: "active" | "paused" | "draft" }) => {
-    const styles = {
+  const StatusBadge = ({ status }: { status: "active" | "paused" | "draft" | "pending_approval" | "approved" }) => {
+    const styles: Record<string, string> = {
       active: "bg-[#DCFCE7] text-[#166534]",
       paused: "bg-[#FEF3C7] text-[#92400E]",
       draft: "bg-[#F1F5F9] text-[#64748B]",
+      pending_approval: "bg-[#FEF9C3] text-[#854D0E]",  // Yellow for pending
+      approved: "bg-[#FEF3C7] text-[#B45309]",          // Amber for approved
     };
 
-    const labels = {
+    const labels: Record<string, string> = {
       active: "Active",
       paused: "Paused",
       draft: "Draft",
+      pending_approval: "Pending Approval",
+      approved: "Approved",
     };
 
     return (
-      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${styles[status]}`}>
-        {labels[status]}
+      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${styles[status] || styles.draft}`}>
+        {labels[status] || status}
       </span>
     );
   };

--- a/frontend/design/prototype/components/campaigns/CampaignDetail.tsx
+++ b/frontend/design/prototype/components/campaigns/CampaignDetail.tsx
@@ -153,10 +153,16 @@ export function CampaignDetail() {
                     ? "bg-[#DCFCE7] text-[#166534]"
                     : campaign.status === "paused"
                     ? "bg-[#FEF3C7] text-[#92400E]"
+                    : campaign.status === "pending_approval"
+                    ? "bg-[#FEF9C3] text-[#854D0E]"
+                    : campaign.status === "approved"
+                    ? "bg-[#FEF3C7] text-[#B45309]"
                     : "bg-[#F1F5F9] text-[#64748B]"
                 }`}
               >
-                {campaign.status.charAt(0).toUpperCase() + campaign.status.slice(1)}
+                {campaign.status === "pending_approval" 
+                  ? "Pending Approval" 
+                  : campaign.status.charAt(0).toUpperCase() + campaign.status.slice(1)}
               </span>
             </div>
             <h1 className="text-2xl font-bold text-[#1E293B]">{campaign.name}</h1>
@@ -169,6 +175,24 @@ export function CampaignDetail() {
               <button className="flex items-center gap-2 px-4 py-2 bg-[#FEF3C7] hover:bg-[#FDE68A] text-[#92400E] text-sm font-medium rounded-lg transition-colors">
                 <Pause className="h-4 w-4" />
                 Pause Campaign
+              </button>
+            ) : campaign.status === "draft" ? (
+              <button className="flex items-center gap-2 px-4 py-2 bg-[#3B82F6] hover:bg-[#2563EB] text-text-primary text-sm font-medium rounded-lg transition-colors shadow-lg shadow-amber/25">
+                Submit for Approval
+              </button>
+            ) : campaign.status === "pending_approval" ? (
+              <>
+                <button className="flex items-center gap-2 px-4 py-2 bg-[#DCFCE7] hover:bg-[#BBF7D0] text-[#166534] text-sm font-medium rounded-lg transition-colors">
+                  Approve
+                </button>
+                <button className="flex items-center gap-2 px-4 py-2 bg-[#FEE2E2] hover:bg-[#FECACA] text-[#DC2626] text-sm font-medium rounded-lg transition-colors">
+                  Reject
+                </button>
+              </>
+            ) : campaign.status === "approved" ? (
+              <button className="flex items-center gap-2 px-4 py-2 bg-[#3B82F6] hover:bg-[#2563EB] text-text-primary text-sm font-medium rounded-lg transition-colors shadow-lg shadow-amber/25">
+                <Play className="h-4 w-4" />
+                Activate Campaign
               </button>
             ) : (
               <button className="flex items-center gap-2 px-4 py-2 bg-[#3B82F6] hover:bg-[#2563EB] text-text-primary text-sm font-medium rounded-lg transition-colors shadow-lg shadow-amber/25">

--- a/frontend/design/prototype/components/campaigns/CampaignList.tsx
+++ b/frontend/design/prototype/components/campaigns/CampaignList.tsx
@@ -8,7 +8,7 @@ import { CampaignAllocationManager, CampaignWithPriority } from "./CampaignAlloc
 /**
  * Status filter type
  */
-type StatusFilter = "all" | "active" | "paused" | "draft";
+type StatusFilter = "all" | "active" | "paused" | "draft" | "pending_approval" | "approved";
 
 /**
  * Demo campaign data for prototype
@@ -87,6 +87,8 @@ export function CampaignList() {
   const filterButtons: { value: StatusFilter; label: string }[] = [
     { value: "all", label: "All" },
     { value: "active", label: "Active" },
+    { value: "approved", label: "Approved" },
+    { value: "pending_approval", label: "Pending" },
     { value: "paused", label: "Paused" },
     { value: "draft", label: "Draft" },
   ];

--- a/src/api/routes/campaigns.py
+++ b/src/api/routes/campaigns.py
@@ -762,8 +762,11 @@ async def update_campaign_status(
     current_status = campaign.status
 
     # Validate transitions
+    # LAW: campaign_approval_flow - Approval gate required before activation
     valid_transitions = {
-        CampaignStatus.DRAFT: [CampaignStatus.ACTIVE],
+        CampaignStatus.DRAFT: [CampaignStatus.PENDING_APPROVAL],
+        CampaignStatus.PENDING_APPROVAL: [CampaignStatus.APPROVED, CampaignStatus.DRAFT],
+        CampaignStatus.APPROVED: [CampaignStatus.ACTIVE],
         CampaignStatus.ACTIVE: [CampaignStatus.PAUSED, CampaignStatus.COMPLETED],
         CampaignStatus.PAUSED: [CampaignStatus.ACTIVE, CampaignStatus.COMPLETED],
         CampaignStatus.COMPLETED: [],  # Terminal state
@@ -799,6 +802,9 @@ async def activate_campaign(
     """
     Activate a campaign (shortcut for status update).
 
+    LAW: campaign_approval_flow - Campaign must be APPROVED before activation.
+    Campaigns in PAUSED status can also be reactivated.
+
     Args:
         client_id: Client UUID
         campaign_id: Campaign UUID
@@ -810,9 +816,11 @@ async def activate_campaign(
     """
     campaign = await get_campaign_or_404(campaign_id, client_id, db)
 
-    if campaign.status not in [CampaignStatus.DRAFT, CampaignStatus.PAUSED]:
+    # LAW: campaign_approval_flow - Only APPROVED or PAUSED campaigns can be activated
+    if campaign.status not in [CampaignStatus.APPROVED, CampaignStatus.PAUSED]:
         raise AgencyValidationError(
-            f"Cannot activate campaign with status {campaign.status.value}",
+            f"Cannot activate campaign with status {campaign.status.value}. "
+            f"Campaign must be APPROVED or PAUSED to activate.",
             field="status",
         )
 
@@ -824,6 +832,188 @@ async def activate_campaign(
     response.reply_rate = campaign.reply_rate
     response.conversion_rate = campaign.conversion_rate
     return response
+
+
+# ============================================
+# Campaign Approval Gate (LAW: campaign_approval_flow)
+# ============================================
+
+
+class RejectionRequest(BaseModel):
+    """Request body for campaign rejection."""
+
+    rejection_reason: str = Field(..., min_length=1, max_length=1000, description="Reason for rejection")
+
+
+@router.post(
+    "/clients/{client_id}/campaigns/{campaign_id}/submit-for-approval",
+    response_model=CampaignResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def submit_campaign_for_approval(
+    client_id: UUID,
+    campaign_id: UUID,
+    ctx: Annotated[ClientContext, Depends(require_member)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> CampaignResponse:
+    """
+    Submit a campaign for approval (DRAFT → PENDING_APPROVAL).
+
+    LAW: campaign_approval_flow - Every campaign requires explicit agency sign-off.
+
+    Requirements:
+    - Campaign must be in DRAFT status
+    - Campaign must have at least 1 lead assigned
+
+    Args:
+        client_id: Client UUID
+        campaign_id: Campaign UUID
+        ctx: Client context (requires member role)
+        db: Database session
+
+    Returns:
+        Updated campaign with PENDING_APPROVAL status
+    """
+    campaign = await get_campaign_or_404(campaign_id, client_id, db)
+
+    # Validate current status
+    if campaign.status != CampaignStatus.DRAFT:
+        raise AgencyValidationError(
+            f"Cannot submit campaign for approval: current status is {campaign.status.value}. "
+            f"Only DRAFT campaigns can be submitted for approval.",
+            field="status",
+        )
+
+    # Check that campaign has at least 1 lead
+    lead_count_query = text("""
+        SELECT COUNT(*) as lead_count
+        FROM leads
+        WHERE campaign_id = :campaign_id
+        AND deleted_at IS NULL
+    """)
+    result = await db.execute(lead_count_query, {"campaign_id": campaign_id})
+    row = result.fetchone()
+    lead_count = row.lead_count if row else 0
+
+    if lead_count == 0:
+        raise AgencyValidationError(
+            "Cannot submit campaign for approval: campaign must have at least 1 lead assigned.",
+            field="leads",
+        )
+
+    # Update status
+    campaign.status = CampaignStatus.PENDING_APPROVAL
+    await db.flush()
+    await db.refresh(campaign)
+
+    logger.info(
+        f"Campaign {campaign_id} submitted for approval by user {ctx.user_id} "
+        f"(client: {client_id}, leads: {lead_count})"
+    )
+
+    return await enrich_campaign_response(campaign, db)
+
+
+@router.post(
+    "/clients/{client_id}/campaigns/{campaign_id}/approve",
+    response_model=CampaignResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def approve_campaign(
+    client_id: UUID,
+    campaign_id: UUID,
+    ctx: Annotated[ClientContext, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> CampaignResponse:
+    """
+    Approve a campaign (PENDING_APPROVAL → APPROVED).
+
+    LAW: campaign_approval_flow - Only works if status is PENDING_APPROVAL.
+
+    Args:
+        client_id: Client UUID
+        campaign_id: Campaign UUID
+        ctx: Client context (requires admin role for approval)
+        db: Database session
+
+    Returns:
+        Updated campaign with APPROVED status
+    """
+    campaign = await get_campaign_or_404(campaign_id, client_id, db)
+
+    # Validate current status
+    if campaign.status != CampaignStatus.PENDING_APPROVAL:
+        raise AgencyValidationError(
+            f"Cannot approve campaign: current status is {campaign.status.value}. "
+            f"Only PENDING_APPROVAL campaigns can be approved.",
+            field="status",
+        )
+
+    # Update status
+    campaign.status = CampaignStatus.APPROVED
+    await db.flush()
+    await db.refresh(campaign)
+
+    logger.info(
+        f"Campaign {campaign_id} APPROVED by admin {ctx.user_id} (client: {client_id})"
+    )
+
+    return await enrich_campaign_response(campaign, db)
+
+
+@router.post(
+    "/clients/{client_id}/campaigns/{campaign_id}/reject",
+    response_model=CampaignResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def reject_campaign(
+    client_id: UUID,
+    campaign_id: UUID,
+    request: RejectionRequest,
+    ctx: Annotated[ClientContext, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> CampaignResponse:
+    """
+    Reject a campaign (PENDING_APPROVAL → DRAFT).
+
+    LAW: campaign_approval_flow - Only works if status is PENDING_APPROVAL.
+    Campaign returns to DRAFT for revisions.
+
+    Args:
+        client_id: Client UUID
+        campaign_id: Campaign UUID
+        request: Rejection reason
+        ctx: Client context (requires admin role for rejection)
+        db: Database session
+
+    Returns:
+        Updated campaign with DRAFT status
+    """
+    campaign = await get_campaign_or_404(campaign_id, client_id, db)
+
+    # Validate current status
+    if campaign.status != CampaignStatus.PENDING_APPROVAL:
+        raise AgencyValidationError(
+            f"Cannot reject campaign: current status is {campaign.status.value}. "
+            f"Only PENDING_APPROVAL campaigns can be rejected.",
+            field="status",
+        )
+
+    # Update status back to DRAFT
+    campaign.status = CampaignStatus.DRAFT
+    # Store rejection reason (if campaign model has this field, otherwise log it)
+    if hasattr(campaign, "rejection_reason"):
+        campaign.rejection_reason = request.rejection_reason
+
+    await db.flush()
+    await db.refresh(campaign)
+
+    logger.info(
+        f"Campaign {campaign_id} REJECTED by admin {ctx.user_id} "
+        f"(client: {client_id}, reason: {request.rejection_reason})"
+    )
+
+    return await enrich_campaign_response(campaign, db)
 
 
 @router.post(

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -155,9 +155,15 @@ class PermissionMode(StrEnum):
 
 
 class CampaignStatus(StrEnum):
-    """Campaign lifecycle status."""
+    """Campaign lifecycle status.
+
+    Flow: DRAFT → PENDING_APPROVAL → APPROVED → ACTIVE → PAUSED/COMPLETED
+    LAW: campaign_approval_flow - Every campaign requires explicit agency sign-off.
+    """
 
     DRAFT = "draft"
+    PENDING_APPROVAL = "pending_approval"
+    APPROVED = "approved"
     ACTIVE = "active"
     PAUSED = "paused"
     COMPLETED = "completed"

--- a/src/orchestration/flows/outreach_flow.py
+++ b/src/orchestration/flows/outreach_flow.py
@@ -630,8 +630,15 @@ async def jit_validate_outreach_task(
         if not campaign:
             raise ValueError(f"Campaign {campaign_id} not found or deleted")
 
+        # Campaign approval guard (LAW: campaign_approval_flow)
+        # No outreach may execute unless campaign has gone through approval and is ACTIVE.
+        # Status flow: DRAFT → PENDING_APPROVAL → APPROVED → ACTIVE
         if campaign.status != CampaignStatus.ACTIVE:
-            raise ValueError(f"Campaign status is {campaign.status.value}")
+            logger.info(
+                f"Campaign {campaign_id} not approved for outreach (status={campaign.status.value}). "
+                f"Skipping outreach per campaign_approval_flow LAW."
+            )
+            raise ValueError(f"Campaign status is {campaign.status.value}, must be ACTIVE")
 
         # Phase H, Item 43: Campaign pause check
         if campaign.paused_at is not None:


### PR DESCRIPTION
## Summary
Implements campaign approval gate per LAW: campaign_approval_flow (ID: 9470bfb5-fedc-4f7b-a8cc-4b42d7ff96db)

## SSOT Reference
> Every campaign requires explicit agency sign-off before any outreach fires. Status flow: DRAFT → PENDING_APPROVAL → APPROVED → ACTIVE. No Prefect flow may execute outreach unless campaign status is APPROVED.

## Changes

### Backend (src/api/routes/campaigns.py)
- Add `PENDING_APPROVAL` and `APPROVED` to `CampaignStatus` enum
- Add `POST /api/v1/campaigns/{id}/submit-for-approval` - DRAFT → PENDING_APPROVAL
- Add `POST /api/v1/campaigns/{id}/approve` - PENDING_APPROVAL → APPROVED (admin only)
- Add `POST /api/v1/campaigns/{id}/reject` - PENDING_APPROVAL → DRAFT (admin only)
- Update valid status transitions to enforce approval flow
- Update `/activate` endpoint to require APPROVED status

### Prefect Guard (src/orchestration/flows/outreach_flow.py)
- Add explicit LAW comment in JIT validation
- Guard logs info message when campaign not approved

### Frontend (frontend/design/prototype/components/campaigns/)
- Add PENDING_APPROVAL (yellow) and APPROVED (amber) status badges
- Add approve/reject buttons when status is PENDING_APPROVAL
- Add submit for approval button when status is DRAFT
- Update status filter buttons

## Status Flow
```
DRAFT → PENDING_APPROVAL → APPROVED → ACTIVE → PAUSED/COMPLETED
```

## Testing
- [ ] Submit draft campaign for approval
- [ ] Approve pending campaign
- [ ] Reject pending campaign
- [ ] Verify outreach blocked for non-ACTIVE campaigns
