### PR TITLE
feat(campaigns): add targeting filters + ICP auto-populate (Step 5/8)

### DIFF
--- a/frontend/app/dashboard/campaigns/new/page.tsx
+++ b/frontend/app/dashboard/campaigns/new/page.tsx
@@ -3,12 +3,12 @@
 /**
  * FILE: frontend/app/dashboard/campaigns/new/page.tsx
  * PURPOSE: New Campaign Wizard - Multi-step form to create a campaign
- * SPRINT: Dashboard Sprint 3a - Campaign Management
+ * SPRINT: Dashboard Sprint 3a - Campaign Management + Step 5/8 Targeting Filters
  * SSOT: frontend/design/html-prototypes/campaign-new-v2.html
  * THEME: Bloomberg Terminal dark mode (charcoal #0C0A08, amber #D4956A)
  */
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { AppShell } from "@/components/layout/AppShell";
 import {
@@ -19,7 +19,11 @@ import {
   Eye,
   Heart,
   Clock,
+  Sparkles,
+  Wand2,
 } from "lucide-react";
+import { TargetingFilters, TargetingFiltersData } from "@/components/campaigns/TargetingFilters";
+import { useICPAutoPopulate } from "@/hooks/useICPAutoPopulate";
 
 // Wizard steps
 const STEPS = [
@@ -52,6 +56,27 @@ const GOALS = [
   },
 ];
 
+// Industry options
+const INDUSTRIES = [
+  "Technology", "SaaS", "Fintech", "Healthcare", "E-commerce",
+  "Manufacturing", "Professional Services", "Real Estate", "Education", "Media"
+];
+
+// Company size options
+const COMPANY_SIZES = [
+  { id: "1-10", label: "1-10 employees" },
+  { id: "11-50", label: "11-50 employees" },
+  { id: "51-200", label: "51-200 employees" },
+  { id: "201-500", label: "201-500 employees" },
+  { id: "500+", label: "500+ employees" },
+];
+
+// Location options
+const LOCATIONS = [
+  "Australia", "New Zealand", "Singapore", "United States", 
+  "United Kingdom", "Canada", "Germany", "Global"
+];
+
 export default function NewCampaignPage() {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
@@ -61,7 +86,34 @@ export default function NewCampaignPage() {
     startDate: "",
     endDate: "",
     ongoing: false,
+    // Step 2: Audience targeting
+    targetIndustries: [] as string[],
+    targetCompanySizes: [] as string[],
+    targetLocations: [] as string[],
+    targeting: {
+      alsTiers: ["Hot", "Warm"] as string[],
+      hiringOnly: false,
+      revenueMinAud: null as number | null,
+      revenueMaxAud: null as number | null,
+      fundingStages: [] as string[],
+    } as TargetingFiltersData,
+    // ICP tracking
+    icpPrefilled: false,
+    icpSourceProfileId: null as string | null,
   });
+  
+  // TODO: Replace with actual client ID from session/context
+  const clientId = "demo-client-id";
+  const { suggestion: icpSuggestion, loading: icpLoading, applyToForm } = useICPAutoPopulate(clientId);
+  const [icpApplied, setIcpApplied] = useState(false);
+
+  // Auto-apply ICP suggestion when available and not yet applied
+  useEffect(() => {
+    if (icpSuggestion && !icpApplied && currentStep === 2) {
+      applyToForm(setFormData);
+      setIcpApplied(true);
+    }
+  }, [icpSuggestion, icpApplied, currentStep, applyToForm]);
 
   const handleNext = () => {
     if (currentStep < STEPS.length) {
@@ -277,8 +329,187 @@ export default function NewCampaignPage() {
             </div>
           )}
 
-          {/* Steps 2-5: Coming Soon Placeholder */}
-          {currentStep > 1 && (
+          {/* Step 2: Audience Targeting */}
+          {currentStep === 2 && (
+            <div className="animate-fade-in">
+              <div className="p-6 border-b border-border-subtle">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h2 className="text-xl font-serif font-semibold text-text-primary">
+                      Target Audience
+                    </h2>
+                    <p className="text-sm text-text-muted mt-1">
+                      Define who you want to reach with this campaign
+                    </p>
+                  </div>
+                  {icpSuggestion && (
+                    <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-accent-primary/10 border border-accent-primary/30">
+                      <Wand2 className="w-4 h-4 text-accent-primary" />
+                      <span className="text-sm font-medium text-accent-primary">
+                        Pre-filled from your ICP
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="p-6 space-y-8">
+                {/* ICP Suggestion Banner */}
+                {icpSuggestion && formData.icpPrefilled && (
+                  <div className="p-4 rounded-xl bg-gradient-to-r from-accent-primary/10 to-accent-secondary/10 border border-accent-primary/20">
+                    <div className="flex items-start gap-3">
+                      <div className="w-10 h-10 rounded-lg bg-accent-primary/20 flex items-center justify-center shrink-0">
+                        <Sparkles className="w-5 h-5 text-accent-primary" />
+                      </div>
+                      <div>
+                        <h4 className="text-sm font-semibold text-text-primary">
+                          Suggested by Maya based on your ICP
+                        </h4>
+                        <p className="text-xs text-text-muted mt-1">
+                          We've pre-filled targeting based on your agency profile. 
+                          Feel free to adjust any settings below.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Target Industries */}
+                <div>
+                  <div className="flex items-center gap-2 mb-3">
+                    <label className="block text-sm font-medium text-text-primary">
+                      Target Industries
+                    </label>
+                    {icpSuggestion?.targetIndustries?.length > 0 && (
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-accent-primary/20 text-accent-primary">
+                        <Sparkles className="w-3 h-3" />
+                        Suggested
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {INDUSTRIES.map((industry) => {
+                      const isSelected = formData.targetIndustries.includes(industry);
+                      return (
+                        <button
+                          key={industry}
+                          onClick={() => {
+                            setFormData((prev) => ({
+                              ...prev,
+                              targetIndustries: isSelected
+                                ? prev.targetIndustries.filter((i) => i !== industry)
+                                : [...prev.targetIndustries, industry],
+                            }));
+                          }}
+                          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+                            isSelected
+                              ? "bg-accent-primary/20 text-accent-primary border border-accent-primary/50"
+                              : "bg-bg-surface text-text-secondary border border-border-default hover:border-border-strong"
+                          }`}
+                        >
+                          {industry}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Target Locations */}
+                <div>
+                  <div className="flex items-center gap-2 mb-3">
+                    <label className="block text-sm font-medium text-text-primary">
+                      Geographic Focus
+                    </label>
+                    {icpSuggestion?.targetLocations?.length > 0 && (
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-accent-primary/20 text-accent-primary">
+                        <Sparkles className="w-3 h-3" />
+                        Suggested
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {LOCATIONS.map((location) => {
+                      const isSelected = formData.targetLocations.includes(location);
+                      return (
+                        <button
+                          key={location}
+                          onClick={() => {
+                            setFormData((prev) => ({
+                              ...prev,
+                              targetLocations: isSelected
+                                ? prev.targetLocations.filter((l) => l !== location)
+                                : [...prev.targetLocations, location],
+                            }));
+                          }}
+                          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+                            isSelected
+                              ? "bg-blue-500/20 text-blue-400 border border-blue-500/50"
+                              : "bg-bg-surface text-text-secondary border border-border-default hover:border-border-strong"
+                          }`}
+                        >
+                          {location}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Company Size */}
+                <div>
+                  <div className="flex items-center gap-2 mb-3">
+                    <label className="block text-sm font-medium text-text-primary">
+                      Company Size
+                    </label>
+                    {icpSuggestion?.targetCompanySizes?.length > 0 && (
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-accent-primary/20 text-accent-primary">
+                        <Sparkles className="w-3 h-3" />
+                        Suggested
+                      </span>
+                    )}
+                  </div>
+                  <div className="grid grid-cols-5 gap-3">
+                    {COMPANY_SIZES.map((size) => {
+                      const isSelected = formData.targetCompanySizes.includes(size.id);
+                      return (
+                        <button
+                          key={size.id}
+                          onClick={() => {
+                            setFormData((prev) => ({
+                              ...prev,
+                              targetCompanySizes: isSelected
+                                ? prev.targetCompanySizes.filter((s) => s !== size.id)
+                                : [...prev.targetCompanySizes, size.id],
+                            }));
+                          }}
+                          className={`p-3 rounded-xl text-center transition-all ${
+                            isSelected
+                              ? "bg-green-500/20 text-green-400 border-2 border-green-500/50"
+                              : "bg-bg-surface text-text-secondary border-2 border-border-default hover:border-border-strong"
+                          }`}
+                        >
+                          <span className="text-sm font-medium">{size.label}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Advanced Targeting Filters (4 new filters) */}
+                <div className="pt-6 border-t border-border-subtle">
+                  <h3 className="text-lg font-serif font-semibold text-text-primary mb-4">
+                    Advanced Targeting
+                  </h3>
+                  <TargetingFilters
+                    value={formData.targeting}
+                    onChange={(targeting) => setFormData((prev) => ({ ...prev, targeting }))}
+                    icpSuggested={icpSuggestion?.targeting}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Steps 3-5: Coming Soon Placeholder */}
+          {currentStep > 2 && (
             <div className="animate-fade-in">
               <div className="p-6 border-b border-border-subtle">
                 <h2 className="text-xl font-serif font-semibold text-text-primary">

--- a/frontend/components/campaigns/TargetingFilters.tsx
+++ b/frontend/components/campaigns/TargetingFilters.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+/**
+ * FILE: frontend/components/campaigns/TargetingFilters.tsx
+ * PURPOSE: Campaign targeting filters - ALS tier, hiring, revenue, funding
+ * SPRINT: Step 5/8 - Campaign Targeting Filters + ICP Auto-Populate
+ * SSOT: campaign_targeting_gaps reference
+ */
+
+import { useState } from "react";
+import {
+  Flame,
+  ThermometerSun,
+  Snowflake,
+  IceCreamCone,
+  Briefcase,
+  DollarSign,
+  TrendingUp,
+  Sparkles,
+} from "lucide-react";
+
+// ALS Tier options
+const ALS_TIERS = [
+  { id: "Hot", icon: Flame, color: "text-red-500", bg: "bg-red-500/20" },
+  { id: "Warm", icon: ThermometerSun, color: "text-orange-400", bg: "bg-orange-400/20" },
+  { id: "Cool", icon: Snowflake, color: "text-blue-400", bg: "bg-blue-400/20" },
+  { id: "Cold", icon: IceCreamCone, color: "text-slate-400", bg: "bg-slate-400/20" },
+] as const;
+
+// Funding stage options
+const FUNDING_STAGES = [
+  { id: "Seed", label: "Seed" },
+  { id: "Series A", label: "Series A" },
+  { id: "Series B", label: "Series B" },
+  { id: "Series C+", label: "Series C+" },
+  { id: "Bootstrapped", label: "Bootstrapped" },
+  { id: "Unknown", label: "Unknown" },
+] as const;
+
+export interface TargetingFiltersData {
+  alsTiers: string[];
+  hiringOnly: boolean;
+  revenueMinAud: number | null;
+  revenueMaxAud: number | null;
+  fundingStages: string[];
+}
+
+interface TargetingFiltersProps {
+  value: TargetingFiltersData;
+  onChange: (value: TargetingFiltersData) => void;
+  icpSuggested?: {
+    alsTiers?: string[];
+    hiringOnly?: boolean;
+    revenueMinAud?: number | null;
+    revenueMaxAud?: number | null;
+    fundingStages?: string[];
+  } | null;
+}
+
+export function TargetingFilters({
+  value,
+  onChange,
+  icpSuggested,
+}: TargetingFiltersProps) {
+  const toggleAlsTier = (tier: string) => {
+    const newTiers = value.alsTiers.includes(tier)
+      ? value.alsTiers.filter((t) => t !== tier)
+      : [...value.alsTiers, tier];
+    onChange({ ...value, alsTiers: newTiers });
+  };
+
+  const toggleFundingStage = (stage: string) => {
+    const newStages = value.fundingStages.includes(stage)
+      ? value.fundingStages.filter((s) => s !== stage)
+      : [...value.fundingStages, stage];
+    onChange({ ...value, fundingStages: newStages });
+  };
+
+  const isSuggestedField = (field: keyof TargetingFiltersData) => {
+    if (!icpSuggested) return false;
+    return icpSuggested[field] !== undefined;
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* ALS Tier Filter */}
+      <div>
+        <div className="flex items-center gap-2 mb-3">
+          <label className="block text-sm font-medium text-text-primary">
+            Lead Quality (ALS Tier)
+          </label>
+          {isSuggestedField("alsTiers") && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-accent-primary/20 text-accent-primary">
+              <Sparkles className="w-3 h-3" />
+              Suggested by Maya
+            </span>
+          )}
+        </div>
+        <div className="grid grid-cols-4 gap-3">
+          {ALS_TIERS.map((tier) => {
+            const Icon = tier.icon;
+            const isSelected = value.alsTiers.includes(tier.id);
+            return (
+              <button
+                key={tier.id}
+                onClick={() => toggleAlsTier(tier.id)}
+                className={`flex flex-col items-center gap-2 p-4 rounded-xl border-2 transition-all ${
+                  isSelected
+                    ? `${tier.bg} border-current ${tier.color}`
+                    : "bg-bg-surface border-border-default hover:border-border-strong"
+                }`}
+              >
+                <Icon
+                  className={`w-6 h-6 ${isSelected ? tier.color : "text-text-muted"}`}
+                />
+                <span
+                  className={`text-sm font-medium ${
+                    isSelected ? tier.color : "text-text-secondary"
+                  }`}
+                >
+                  {tier.id}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-xs text-text-muted mt-2">
+          Hot = High intent | Warm = Good fit | Cool = Potential | Cold = Low priority
+        </p>
+      </div>
+
+      {/* Hiring Signal Filter */}
+      <div className="p-4 rounded-xl bg-bg-surface border border-border-default">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-lg bg-green-500/20 flex items-center justify-center">
+              <Briefcase className="w-5 h-5 text-green-500" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-text-primary">
+                  Only Companies Actively Hiring
+                </span>
+                {isSuggestedField("hiringOnly") && (
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-accent-primary/20 text-accent-primary">
+                    <Sparkles className="w-3 h-3" />
+                    Suggested
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-text-muted">
+                Filter to companies with active job postings (higher budget signal)
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => onChange({ ...value, hiringOnly: !value.hiringOnly })}
+            className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+              value.hiringOnly ? "bg-green-500" : "bg-border-strong"
+            }`}
+          >
+            <span
+              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
+                value.hiringOnly ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+      </div>
+
+      {/* Revenue Range Filter */}
+      <div>
+        <div className="flex items-center gap-2 mb-3">
+          <div className="w-8 h-8 rounded-lg bg-emerald-500/20 flex items-center justify-center">
+            <DollarSign className="w-4 h-4 text-emerald-500" />
+          </div>
+          <label className="block text-sm font-medium text-text-primary">
+            Company Revenue Range (AUD)
+          </label>
+          {isSuggestedField("revenueMinAud") && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-accent-primary/20 text-accent-primary">
+              <Sparkles className="w-3 h-3" />
+              Suggested by Maya
+            </span>
+          )}
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs text-text-muted mb-1.5">Minimum</label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted">
+                $
+              </span>
+              <input
+                type="number"
+                value={value.revenueMinAud ?? ""}
+                onChange={(e) =>
+                  onChange({
+                    ...value,
+                    revenueMinAud: e.target.value ? Number(e.target.value) : null,
+                  })
+                }
+                placeholder="0"
+                className="w-full pl-7 pr-4 py-2.5 rounded-lg text-sm bg-bg-surface border border-border-default text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary focus:ring-2 focus:ring-accent-primary/20 transition-all font-mono"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs text-text-muted mb-1.5">Maximum</label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted">
+                $
+              </span>
+              <input
+                type="number"
+                value={value.revenueMaxAud ?? ""}
+                onChange={(e) =>
+                  onChange({
+                    ...value,
+                    revenueMaxAud: e.target.value ? Number(e.target.value) : null,
+                  })
+                }
+                placeholder="No limit"
+                className="w-full pl-7 pr-4 py-2.5 rounded-lg text-sm bg-bg-surface border border-border-default text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-primary focus:ring-2 focus:ring-accent-primary/20 transition-all font-mono"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Funding Stage Filter */}
+      <div>
+        <div className="flex items-center gap-2 mb-3">
+          <div className="w-8 h-8 rounded-lg bg-purple-500/20 flex items-center justify-center">
+            <TrendingUp className="w-4 h-4 text-purple-500" />
+          </div>
+          <label className="block text-sm font-medium text-text-primary">
+            Funding Stage
+          </label>
+          {isSuggestedField("fundingStages") && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-accent-primary/20 text-accent-primary">
+              <Sparkles className="w-3 h-3" />
+              Suggested by Maya
+            </span>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {FUNDING_STAGES.map((stage) => {
+            const isSelected = value.fundingStages.includes(stage.id);
+            return (
+              <button
+                key={stage.id}
+                onClick={() => toggleFundingStage(stage.id)}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+                  isSelected
+                    ? "bg-purple-500/20 text-purple-400 border border-purple-500/50"
+                    : "bg-bg-surface text-text-secondary border border-border-default hover:border-border-strong"
+                }`}
+              >
+                {stage.label}
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-xs text-text-muted mt-2">
+          Select one or more funding stages, or leave empty for all
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default TargetingFilters;

--- a/frontend/hooks/useICPAutoPopulate.ts
+++ b/frontend/hooks/useICPAutoPopulate.ts
@@ -1,0 +1,192 @@
+"use client";
+
+/**
+ * FILE: frontend/hooks/useICPAutoPopulate.ts
+ * PURPOSE: Fetch agency_service_profile and map ICP to campaign filters
+ * SPRINT: Step 5/8 - Campaign Targeting Filters + ICP Auto-Populate
+ * SSOT: master_build_vision - "Maya suggests first campaign pre-filled from ICP"
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { TargetingFiltersData } from "@/components/campaigns/TargetingFilters";
+
+interface AgencyServiceProfile {
+  id: string;
+  client_id: string;
+  services: string[];
+  specialisations: string[];
+  target_industries: string[];
+  avg_deal_size_aud: number | null;
+  win_rate: number | null;
+  best_case_study: string | null;
+  top_clients: string[];
+  geographic_focus: string[];
+  confidence_score: number | null;
+}
+
+interface ICPSuggestion {
+  targetIndustries: string[];
+  targetLocations: string[];
+  targetCompanySizes: string[];
+  targeting: TargetingFiltersData;
+  profileId: string;
+  confidenceScore: number;
+}
+
+/**
+ * Maps avg_deal_size_aud to company size ranges
+ * Logic: Higher deal sizes suggest larger companies
+ */
+function mapDealSizeToCompanySizes(avgDealSize: number | null): string[] {
+  if (!avgDealSize) return ["1-10", "11-50", "51-200", "201-500", "500+"];
+  
+  if (avgDealSize < 10000) {
+    // Small deals → target startups and small businesses
+    return ["1-10", "11-50"];
+  } else if (avgDealSize < 50000) {
+    // Medium deals → target SMBs
+    return ["11-50", "51-200"];
+  } else if (avgDealSize < 200000) {
+    // Larger deals → target mid-market
+    return ["51-200", "201-500"];
+  } else {
+    // Enterprise deals → target large companies
+    return ["201-500", "500+"];
+  }
+}
+
+/**
+ * Maps deal size to revenue range assumptions
+ */
+function mapDealSizeToRevenue(avgDealSize: number | null): { min: number | null; max: number | null } {
+  if (!avgDealSize) return { min: null, max: null };
+  
+  // Assumption: Deal size is ~1-5% of annual budget
+  // Revenue assumption: ~10-20x the deal size for target company
+  const multiplier = 15;
+  const minRevenue = Math.round(avgDealSize * multiplier * 0.5);
+  const maxRevenue = Math.round(avgDealSize * multiplier * 3);
+  
+  return { min: minRevenue, max: maxRevenue };
+}
+
+/**
+ * Maps deal size to suggested ALS tiers
+ * Higher deal sizes → focus on better qualified leads
+ */
+function mapDealSizeToAlsTiers(avgDealSize: number | null): string[] {
+  if (!avgDealSize) return ["Hot", "Warm", "Cool", "Cold"];
+  
+  if (avgDealSize > 100000) {
+    // High-value deals → focus on best leads only
+    return ["Hot", "Warm"];
+  } else if (avgDealSize > 30000) {
+    // Medium deals → include cool leads
+    return ["Hot", "Warm", "Cool"];
+  } else {
+    // Lower deal sizes can handle higher volume
+    return ["Hot", "Warm", "Cool", "Cold"];
+  }
+}
+
+export function useICPAutoPopulate(clientId: string | null) {
+  const [suggestion, setSuggestion] = useState<ICPSuggestion | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchICP = useCallback(async () => {
+    if (!clientId) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/v1/clients/${clientId}/service-profile`);
+      
+      if (!response.ok) {
+        if (response.status === 404) {
+          // No ICP configured yet, that's OK
+          setSuggestion(null);
+          return;
+        }
+        throw new Error("Failed to fetch ICP profile");
+      }
+
+      const profile: AgencyServiceProfile = await response.json();
+      
+      // Map ICP to campaign targeting suggestion
+      const revenueRange = mapDealSizeToRevenue(profile.avg_deal_size_aud);
+      const alsTiers = mapDealSizeToAlsTiers(profile.avg_deal_size_aud);
+      const companySizes = mapDealSizeToCompanySizes(profile.avg_deal_size_aud);
+
+      const icpSuggestion: ICPSuggestion = {
+        targetIndustries: profile.target_industries || [],
+        targetLocations: profile.geographic_focus || [],
+        targetCompanySizes: companySizes,
+        targeting: {
+          alsTiers,
+          hiringOnly: false, // Default off, Maya doesn't know hiring preference
+          revenueMinAud: revenueRange.min,
+          revenueMaxAud: revenueRange.max,
+          fundingStages: [], // No ICP data for this, leave open
+        },
+        profileId: profile.id,
+        confidenceScore: profile.confidence_score || 0.5,
+      };
+
+      setSuggestion(icpSuggestion);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, [clientId]);
+
+  useEffect(() => {
+    fetchICP();
+  }, [fetchICP]);
+
+  const applyToForm = useCallback(
+    (
+      setFormData: (updater: (prev: any) => any) => void,
+      fields?: ("industries" | "locations" | "sizes" | "targeting")[]
+    ) => {
+      if (!suggestion) return;
+
+      const fieldsToApply = fields || ["industries", "locations", "sizes", "targeting"];
+
+      setFormData((prev: any) => {
+        const updates: any = { ...prev };
+
+        if (fieldsToApply.includes("industries") && suggestion.targetIndustries.length > 0) {
+          updates.targetIndustries = suggestion.targetIndustries;
+        }
+        if (fieldsToApply.includes("locations") && suggestion.targetLocations.length > 0) {
+          updates.targetLocations = suggestion.targetLocations;
+        }
+        if (fieldsToApply.includes("sizes") && suggestion.targetCompanySizes.length > 0) {
+          updates.targetCompanySizes = suggestion.targetCompanySizes;
+        }
+        if (fieldsToApply.includes("targeting")) {
+          updates.targeting = suggestion.targeting;
+        }
+
+        updates.icpPrefilled = true;
+        updates.icpSourceProfileId = suggestion.profileId;
+
+        return updates;
+      });
+    },
+    [suggestion]
+  );
+
+  return {
+    suggestion,
+    loading,
+    error,
+    applyToForm,
+    refetch: fetchICP,
+  };
+}
+
+export default useICPAutoPopulate;

--- a/supabase/migrations/065_campaign_channel_metrics.sql
+++ b/supabase/migrations/065_campaign_channel_metrics.sql
@@ -1,0 +1,40 @@
+-- Migration: 065_campaign_channel_metrics.sql
+-- Purpose: Add channel metrics JSONB and targeting filter columns for campaigns
+-- Sprint: Step 5/8 - Campaign Targeting Filters + ICP Auto-Populate
+
+-- Add channel_metrics JSONB to campaigns for per-channel performance tracking
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS channel_metrics JSONB DEFAULT '{}';
+-- Structure: {"email": {"sent": 0, "opened": 0, "clicked": 0}, "linkedin": {...}, "sms": {...}, "voice": {...}}
+
+-- Add targeting filter columns to campaigns (matches lead data fields)
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS target_als_tiers TEXT[] DEFAULT ARRAY['Hot', 'Warm', 'Cool', 'Cold'];
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS target_hiring_only BOOLEAN DEFAULT false;
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS target_revenue_min_aud NUMERIC DEFAULT NULL;
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS target_revenue_max_aud NUMERIC DEFAULT NULL;
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS target_funding_stages TEXT[] DEFAULT NULL;
+-- Options: Seed, Series A, Series B, Series C+, Bootstrapped, Unknown
+
+-- Add revenue and funding_stage columns to leads table (copy from lead_pool)
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS organization_revenue_aud NUMERIC DEFAULT NULL;
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS organization_funding_stage TEXT DEFAULT NULL;
+
+-- Add ICP-prefilled flag to track Maya suggestions
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS icp_prefilled BOOLEAN DEFAULT false;
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS icp_source_profile_id UUID REFERENCES agency_service_profile(id);
+
+-- Index for efficient filtering
+CREATE INDEX IF NOT EXISTS idx_leads_als_tier ON leads(als_tier);
+CREATE INDEX IF NOT EXISTS idx_leads_org_hiring ON leads(organization_is_hiring);
+CREATE INDEX IF NOT EXISTS idx_leads_org_revenue ON leads(organization_revenue_aud);
+CREATE INDEX IF NOT EXISTS idx_leads_funding_stage ON leads(organization_funding_stage);
+CREATE INDEX IF NOT EXISTS idx_campaigns_als_tiers ON campaigns USING GIN (target_als_tiers);
+CREATE INDEX IF NOT EXISTS idx_campaigns_funding_stages ON campaigns USING GIN (target_funding_stages);
+
+COMMENT ON COLUMN campaigns.channel_metrics IS 'Per-channel performance metrics: {channel: {sent, opened, clicked, replied, converted}}';
+COMMENT ON COLUMN campaigns.target_als_tiers IS 'Filter leads by ALS tier: Hot, Warm, Cool, Cold';
+COMMENT ON COLUMN campaigns.target_hiring_only IS 'Only include companies actively hiring';
+COMMENT ON COLUMN campaigns.target_revenue_min_aud IS 'Minimum company revenue in AUD';
+COMMENT ON COLUMN campaigns.target_revenue_max_aud IS 'Maximum company revenue in AUD';
+COMMENT ON COLUMN campaigns.target_funding_stages IS 'Filter by funding stage: Seed, Series A, Series B, Series C+, Bootstrapped, Unknown';
+COMMENT ON COLUMN campaigns.icp_prefilled IS 'Whether Maya auto-populated from ICP';
+COMMENT ON COLUMN campaigns.icp_source_profile_id IS 'Source agency_service_profile for ICP prefill';


### PR DESCRIPTION
## Summary
Step 5 of the 8-step build sprint. Adds four missing targeting filters to the campaign wizard and wires up ICP auto-populate from agency_service_profile.

## SSOT References
- **campaign_targeting_gaps**: Four filters missing from campaign UI
- **master_build_vision**: Maya suggests first campaign pre-filled from ICP

## Changes

### 1. TargetingFilters Component (4 filters)
- ALS Tier Filter: Multi-select (Hot/Warm/Cool/Cold)
- Hiring Signal Filter: Toggle switch
- Revenue Range Filter: Min/max AUD inputs
- Funding Stage Filter: Multi-select

### 2. ICP Auto-Populate Hook
- Fetches agency_service_profile
- Pre-fills industries, locations, sizes
- Shows 'Suggested by Maya' labels

### 3. Campaign Wizard Update
- Full Step 2 (Audience) implementation
- Integrated TargetingFilters component
- Maya suggestion banner

### 4. Migration 065 Applied
- channel_metrics JSONB
- target_als_tiers, target_hiring_only
- target_revenue_min/max_aud
- target_funding_stages
- icp_prefilled, icp_source_profile_id

## Files Modified
- frontend/app/dashboard/campaigns/new/page.tsx
- frontend/components/campaigns/TargetingFilters.tsx (new)
- frontend/hooks/useICPAutoPopulate.ts (new)
- supabase/migrations/065_campaign_channel_metrics.sql (new)