### PR TITLE
fix(ci): resolve ruff errors #059

### DIFF
--- a/src/api/routes/billing.py
+++ b/src/api/routes/billing.py
@@ -21,7 +21,7 @@ RULES APPLIED:
 
 import logging
 from datetime import datetime
-from typing import Annotated, Any
+from typing import Annotated
 from uuid import UUID
 
 import httpx
@@ -349,7 +349,7 @@ async def _send_welcome_email(email: str | None, agency_name: str) -> None:
                         </ol>
                         <p>Your $500 deposit will be credited against your first month's invoice.</p>
                         <p style="margin-top: 24px;">
-                            <a href="{settings.frontend_url}/onboarding" 
+                            <a href="{settings.frontend_url}/onboarding"
                                style="background: #1a1a2e; color: white; padding: 12px 24px; text-decoration: none; border-radius: 8px;">
                                 Continue Onboarding →
                             </a>

--- a/src/api/routes/campaigns.py
+++ b/src/api/routes/campaigns.py
@@ -34,6 +34,7 @@ from src.api.dependencies import (
     require_admin,
     require_member,
 )
+from src.api.routes.billing import activate_subscription_on_approval
 from src.exceptions import (
     ResourceDeletedError,
     ResourceNotFoundError,
@@ -44,9 +45,6 @@ from src.exceptions import (
 from src.models.base import CampaignStatus, ChannelType, PermissionMode
 from src.models.campaign import Campaign, CampaignResource, CampaignSequence
 from src.models.client import Client
-
-# Step 8/8: Import subscription activation helper
-from src.api.routes.billing import activate_subscription_on_approval
 
 router = APIRouter(tags=["campaigns"])
 


### PR DESCRIPTION
## CEO Directive #059 — CI Fix

### Changes
1. **billing.py:24** — Remove unused `typing.Any` import (F401)
2. **billing.py:352** — Remove trailing whitespace (W291)
3. **campaigns.py:30** — Sort import block per ruff I001

### Evidence

#### Ruff Output (zero errors):
```
$ ruff check src/
All checks passed!
```

#### Pytest Summary:
```
145 failed, 481 passed, 77 skipped, 48 errors in 248.05s
```
*Note: Test failures are pre-existing and NOT related to this PR.*

### LAW I-A Compliance
- ✅ Cat files before editing
- ✅ No optimistic completion — verified with ruff check