### PR TITLE
fix: disable Sentry pydantic_ai integration (P0 - Railway crash)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -26,6 +26,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.pydantic_ai import PydanticAIIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 from sqlalchemy import text
@@ -60,6 +61,9 @@ if settings.sentry_dsn:
             StarletteIntegration(transaction_style="endpoint"),
             SqlalchemyIntegration(),
         ],
+        # Disable pydantic_ai integration - version mismatch causes startup crash
+        # See: AttributeError: type object 'ToolManager' has no attribute '_call_tool'
+        disabled_integrations=[PydanticAIIntegration],
         # Don't send PII by default
         send_default_pii=False,
         # Attach request data for debugging


### PR DESCRIPTION
## P0 — Restore Railway agency-os service

### Error
```
AttributeError: type object 'ToolManager' has no attribute '_call_tool'
```

### Root Cause
Sentry SDK auto-enables `PydanticAIIntegration` which expects `ToolManager._call_tool` to exist. Installed pydantic-ai version has different internals.

### Fix
Explicitly disable `PydanticAIIntegration` via `disabled_integrations` param.

```python
disabled_integrations=[PydanticAIIntegration],
```

### Impact
- Sentry still works for FastAPI, Starlette, SQLAlchemy
- Only pydantic_ai tracing disabled until versions aligned
- **Restores Railway agency-os service immediately**

### Governance
Keiracom/Agency_OS. PR only. Dave merges.