### PR TITLE
feat(flows): Deploy crm-sync-flow with 4-hour schedule

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -250,12 +250,12 @@ deployments:
   # CRM SYNC FLOWS (Item 20)
   # ============================================
 
-  # CRM sync flow (6-hourly safety net for missed webhooks)
+  # CRM sync flow (4-hourly safety net for missed webhooks)
   - name: crm-sync-flow
     version: 1.0.0
-    paused: true  # Safety net - enable when CRMs configured
+    paused: false  # Active - polls CRMs every 4 hours
     tags: [crm, sync, safety-net, blind-conversions]
-    description: "CRM sync every 6 hours - safety net for missed webhooks (blind conversions)"
+    description: "CRM sync every 4 hours - safety net for missed webhooks (blind conversions)"
     entrypoint: src/orchestration/flows/crm_sync_flow.py:crm_sync_flow
     work_pool:
       name: agency-os-pool
@@ -263,9 +263,9 @@ deployments:
     parameters:
       since_hours: 24
     schedules:
-      - interval: 21600
+      - interval: 14400  # 4 hours in seconds
         timezone: Australia/Sydney
-        active: false
+        active: true
 
   # ============================================
   # INTELLIGENCE FLOWS

--- a/src/orchestration/flows/crm_sync_flow.py
+++ b/src/orchestration/flows/crm_sync_flow.py
@@ -840,3 +840,4 @@ async def crm_sync_flow(
 # [x] Session passed as argument (Rule 11)
 # [x] Error handling with graceful degradation
 # [x] Summary statistics returned
+# [x] Deployment via prefect.yaml (4-hour schedule)


### PR DESCRIPTION
## Summary
Deploy crm_sync_flow to Prefect with a 4-hour schedule for polling CRMs for missed webhook events (blind conversions).

## Changes
- **prefect.yaml**: Updated crm-sync-flow deployment:
  - Changed interval from 6h to 4h (14400 seconds)
  - Set `paused: false` to enable the deployment
  - Set schedule `active: true` to enable the schedule
  
- **crm_sync_flow.py**: Added deployment verification to checklist

## Verification
```
$ prefect deployment inspect 'crm-sync-flow/crm-sync-flow'
{
    'name': 'crm-sync-flow',
    'paused': False,
    'schedules': [{'interval': 14400.0, 'active': True, 'timezone': 'Australia/Sydney'}],
    ...
}
```

## Task
CRM-SYNC-001