### PR TITLE
chore: add missing Python SDKs (upstash-redis, resend)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ asyncpg>=0.29.0
 
 # === Cache ===
 redis>=5.0.0
+upstash-redis>=1.6.0  # REST-based Redis client (Upstash serverless)
 
 # === HTTP Client ===
 httpx>=0.26.0
@@ -45,6 +46,7 @@ python-jose>=3.3.0
 stripe>=7.0.0
 
 # === Email ===
+resend>=2.23.0  # Resend email SDK
 # Salesforge uses REST API with httpx, no SDK needed
 
 # === SMS ===


### PR DESCRIPTION
## CEO Directive #092 - Track 1

### Changes
- Added `upstash-redis>=1.6.0` (REST-based Redis client for Upstash serverless)
- Added `resend>=2.23.0` (Email SDK)

### Already Present
- anthropic>=0.39.0
- redis>=5.0.0
- stripe>=7.0.0
- twilio>=8.10.0
- prefect>=3.0.0

### Installed Versions (confirmed working)
| Package | Version |
|---------|---------|
| anthropic | 0.84.0 |
| redis | 7.2.1 |
| upstash-redis | 1.6.0 |
| stripe | 14.4.0 |
| twilio | 9.10.2 |
| prefect | 3.6.19 |
| resend | 2.23.0 |

### Governance
LAW I-A compliant. PR only — Dave merges.