### PR TITLE
fix: mock CRM column names + test auth UUID format

### DIFF
--- a/src/services/mock_crm_service.py
+++ b/src/services/mock_crm_service.py
@@ -102,8 +102,8 @@ class MockCRMService:
             lead_id = uuid4()
             await db.execute(
                 text("""
-                    INSERT INTO leads (id, client_id, first_name, last_name, email, company_name, job_title, status)
-                    VALUES (:id, :client_id, :first_name, :last_name, :email, :company_name, :job_title, 'qualified')
+                    INSERT INTO leads (id, client_id, first_name, last_name, email, company, title, status)
+                    VALUES (:id, :client_id, :first_name, :last_name, :email, :company, :title, 'qualified')
                 """),
                 {
                     "id": str(lead_id),
@@ -111,8 +111,8 @@ class MockCRMService:
                     "first_name": f"TestLead{len(lead_ids) + 1}",
                     "last_name": "MockData",
                     "email": f"testlead{len(lead_ids) + 1}@mocktest.example",
-                    "company_name": f"Test Company {len(lead_ids) + 1}",
-                    "job_title": "Decision Maker",
+                    "company": f"Test Company {len(lead_ids) + 1}",
+                    "title": "Decision Maker",
                 },
             )
             lead_ids.append(lead_id)

--- a/src/utils/test_auth.py
+++ b/src/utils/test_auth.py
@@ -68,7 +68,7 @@ def generate_test_token(
         "exp": expires_at,
         "iat": now,
         "iss": settings.supabase_url or "http://localhost:54321",
-        "sub": str(user_id) if user_id else f"test-user-{client_id}",
+        "sub": str(user_id) if user_id else str(client_id),
         "email": f"test@client-{client_id}.example",
         "role": "authenticated",
         # Custom claims for Agency OS


### PR DESCRIPTION
## CEO Directive #095 — Bugs 5 & 6

**LAW I-A enforced:** All schema columns verified via Supabase MCP query before code changes.

### BUG 5: mock_crm_service.py Wrong Column Names

**Root Cause:** leads INSERT used wrong column names that don't exist in schema.

**Verified Schema (via MCP query):**
```
leads table has: company, title (NOT company_name, job_title)
```

**Fix:**
- `company_name` → `company`
- `job_title` → `title`

Deals and meetings INSERTs verified correct — no changes needed.

### BUG 6: test_auth.py Invalid UUID in sub Claim

**Root Cause:** When no user_id provided, code used `f"test-user-{client_id}"` which creates an invalid UUID string like `test-user-550e8400-e29b-41d4-a716-446655440000`.

**Fix:** Use `str(client_id)` directly — client_id is already a valid UUID.

### Testing
Both changes are minimal and isolated to test infrastructure code.

---
**Governance:** LAW I-A. PR only — Dave merges.