### PR TITLE
fix: audit and fix all INSERT bind parameters (Bug #10)

### DIFF
--- a/src/services/mock_crm_service.py
+++ b/src/services/mock_crm_service.py
@@ -353,6 +353,7 @@ class MockCRMService:
                 "showed_up": True,
                 "showed_up_confirmed_at": now - timedelta(days=3),
                 "meeting_outcome": "good",
+                "no_show_reason": None,
                 "meeting_notes": "MOCK_CRM: Great initial conversation, strong interest in solution",
             },
             # 1 Confirmed + No Show
@@ -380,6 +381,7 @@ class MockCRMService:
                 "showed_up": None,
                 "showed_up_confirmed_at": None,
                 "meeting_outcome": None,
+                "no_show_reason": None,
                 "meeting_notes": "MOCK_CRM: Pending confirmation, reminder scheduled",
             },
         ]


### PR DESCRIPTION
## CEO Directive #098 — Full Parameter Audit

### Problem
E2E Test #5 failed with missing `no_show_reason` bind parameter in meetings INSERT.

### Audit Results (All 4 INSERTs)

| Function | Table | SQL Params | Dict Keys | Status |
|----------|-------|------------|-----------|--------|
| `_ensure_test_leads()` | leads | 8 | 8 | ✅ Matched |
| `_seed_exclusion_list()` | agency_exclusion_list | 7 | 7 | ✅ Matched |
| `_seed_deals()` | deals | 12 | 12 | ✅ Matched |
| `_seed_meetings()` | meetings | 13 | 13* | 🔧 **Fixed** |

### Fixes Applied
- **Meeting 1** (confirmed/showed): Added `no_show_reason: None`
- **Meeting 3** (scheduled): Added `no_show_reason: None`

Meeting 2 (no-show) already had `no_show_reason` populated correctly.

### Verification
All 4 INSERT statements now have exact parameter count match:
- leads: 8 = 8 ✅
- agency_exclusion_list: 7 = 7 ✅
- deals: 12 = 12 ✅
- meetings: 13 = 13 ✅

Closes #10