### PR TITLE
fix: add missing columns to clients table (Bug #11)

### DIFF
--- a/supabase/migrations/070_clients_missing_columns.sql
+++ b/supabase/migrations/070_clients_missing_columns.sql
@@ -1,0 +1,26 @@
+-- Migration: 070_clients_missing_columns.sql
+-- Bug #11: Add missing columns to clients table
+-- Full model audit per LAW I-A
+
+-- Emergency pause columns (Phase H, Item 43 - kill switch feature)
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS paused_at TIMESTAMPTZ NULL;
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS pause_reason TEXT NULL;
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS paused_by_user_id UUID NULL REFERENCES users(id);
+
+-- Digest preferences columns (Phase H, Item 44)
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS digest_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS digest_frequency TEXT NOT NULL DEFAULT 'daily';
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS digest_send_hour INTEGER NOT NULL DEFAULT 7;
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS digest_timezone TEXT NOT NULL DEFAULT 'Australia/Sydney';
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS digest_recipients JSONB NULL;
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS last_digest_sent_at TIMESTAMPTZ NULL;
+
+-- Founding member billing fields (Step 8/8)
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS deposit_paid BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS subscription_activated_at TIMESTAMPTZ NULL;
+
+-- Add index for pause queries (find all paused clients quickly)
+CREATE INDEX IF NOT EXISTS idx_clients_paused_at ON clients(paused_at) WHERE paused_at IS NOT NULL;
+
+-- Add index for digest scheduling queries
+CREATE INDEX IF NOT EXISTS idx_clients_digest_schedule ON clients(digest_enabled, digest_send_hour) WHERE digest_enabled = TRUE;


### PR DESCRIPTION
## Summary
Full model audit per LAW I-A found **11 missing columns** in the `clients` table.

## Missing Columns Added

### Emergency Pause (Kill Switch - Phase H, Item 43)
- `paused_at` - TIMESTAMPTZ NULL
- `pause_reason` - TEXT NULL
- `paused_by_user_id` - UUID NULL (FK to users)

### Digest Preferences (Phase H, Item 44)
- `digest_enabled` - BOOLEAN NOT NULL DEFAULT TRUE
- `digest_frequency` - TEXT NOT NULL DEFAULT 'daily'
- `digest_send_hour` - INTEGER NOT NULL DEFAULT 7
- `digest_timezone` - TEXT NOT NULL DEFAULT 'Australia/Sydney'
- `digest_recipients` - JSONB NULL
- `last_digest_sent_at` - TIMESTAMPTZ NULL

### Founding Member Billing (Step 8/8)
- `deposit_paid` - BOOLEAN NOT NULL DEFAULT FALSE
- `subscription_activated_at` - TIMESTAMPTZ NULL

## Indexes Added
- `idx_clients_paused_at` - Partial index for pause queries
- `idx_clients_digest_schedule` - Partial index for digest scheduling

## Notes
- Migration already applied to production DB
- E2E Test #6 should now pass
- Closes Bug #11

## Governance
- LAW I-A: Full model audit completed before migration
- PR only — Dave merges