### PR TITLE
fix: set accepted_at on test membership (Bug #14)

### DIFF
--- a/src/utils/test_auth.py
+++ b/src/utils/test_auth.py
@@ -77,13 +77,13 @@ async def _ensure_test_user_exists(client_id: UUID) -> UUID:
                 # Silently skip if user already exists
                 logger.debug(f"Test user insert skipped (may already exist): {e}")
 
-            # Create membership
+            # Create membership (with accepted_at so it's immediately usable)
             try:
                 await db.execute(
                     text("""
-                        INSERT INTO memberships (user_id, client_id, role, created_at, updated_at)
-                        VALUES (:user_id, :client_id, 'admin', NOW(), NOW())
-                        ON CONFLICT (user_id, client_id) DO NOTHING
+                        INSERT INTO memberships (user_id, client_id, role, accepted_at, created_at, updated_at)
+                        VALUES (:user_id, :client_id, 'admin', NOW(), NOW(), NOW())
+                        ON CONFLICT (user_id, client_id) DO UPDATE SET accepted_at = NOW(), updated_at = NOW()
                     """),
                     {
                         "user_id": str(user_id),


### PR DESCRIPTION
## Bug #14 Fix

**Problem:** E2E Test #9 failed with 'Membership invitation not yet accepted' because the test auth helper created memberships without setting `accepted_at`.

**Root Cause:** `_ensure_test_user_exists()` in `test_auth.py` was inserting memberships without the `accepted_at` field, and using `ON CONFLICT DO NOTHING` which meant existing rows also weren't updated.

**Fix:**
```sql
INSERT INTO memberships (user_id, client_id, role, accepted_at, created_at, updated_at)
VALUES (:user_id, :client_id, 'admin', NOW(), NOW(), NOW())
ON CONFLICT (user_id, client_id) DO UPDATE SET accepted_at = NOW(), updated_at = NOW()
```

**Schema verified** via LAW I-A before fix. Column `accepted_at` confirmed as `timestamp with time zone`.