### PR TITLE
fix: remove early-return in _ensure_test_user_exists (Bug #14)

### DIFF
--- a/src/utils/test_auth.py
+++ b/src/utils/test_auth.py
@@ -45,22 +45,7 @@ async def _ensure_test_user_exists(client_id: UUID) -> UUID:
 
     try:
         async with get_db_session() as db:
-            # Check if membership already exists
-            result = await db.execute(
-                text("""
-                    SELECT user_id FROM memberships
-                    WHERE client_id = :client_id
-                    LIMIT 1
-                """),
-                {"client_id": str(client_id)},
-            )
-            existing = result.fetchone()
-
-            if existing:
-                logger.debug(f"Test membership already exists for client {client_id}")
-                return UUID(str(existing.user_id))
-
-            # Create test user in auth.users
+            # Create test user in auth.users (ON CONFLICT DO NOTHING if exists)
             try:
                 await db.execute(
                     text("""


### PR DESCRIPTION
## Bug #14 — Proper Fix

### Problem
The early-return membership check caused `ON CONFLICT DO UPDATE` to never fire.

```python
# Check if membership already exists
result = await db.execute(SELECT user_id FROM memberships...)
existing = result.fetchone()
if existing:
    return UUID(str(existing.user_id))  # ← EARLY RETURN (broken)
```

When a membership existed (with `accepted_at = NULL`), the function returned **before** reaching the INSERT that would trigger:
```sql
ON CONFLICT (user_id, client_id) DO UPDATE SET accepted_at = NOW()
```

### Fix
Removed the early-return check entirely. Now the function always executes the INSERT statements:
- **auth.users**: `ON CONFLICT DO NOTHING` (idempotent)  
- **memberships**: `ON CONFLICT DO UPDATE SET accepted_at = NOW()`

This ensures test users always get `accepted_at` populated, whether the record is new or existing.

### Testing
Data already fixed via direct SQL (Bug #14 resolution). Test #11 works. This PR prevents recurrence.

---
**Closes:** Bug #14
**Layer:** utils/test_auth