### PR TITLE
fix: add get_bright_data_client() factory function (Bug #17)

### DIFF
--- a/src/integrations/bright_data_client.py
+++ b/src/integrations/bright_data_client.py
@@ -8,6 +8,7 @@ Note: All methods are async - use with await.
 """
 
 import asyncio
+import os
 import urllib.parse
 from dataclasses import dataclass
 from typing import Any
@@ -332,3 +333,30 @@ class BrightDataClient:
             "scraper_cost_aud": self.costs.scraper_records * COSTS_AUD["scraper_record"],
             "total_aud": self.costs.total_aud,
         }
+
+
+# ============================================
+# FACTORY FUNCTION
+# ============================================
+
+# Module-level singleton
+_bright_data_client: BrightDataClient | None = None
+
+
+def get_bright_data_client() -> BrightDataClient:
+    """
+    Get or create BrightDataClient singleton instance.
+
+    Returns:
+        BrightDataClient instance
+
+    Raises:
+        ValueError: If BRIGHTDATA_API_KEY not configured
+    """
+    global _bright_data_client
+    if _bright_data_client is None:
+        api_key = os.getenv("BRIGHTDATA_API_KEY")
+        if not api_key:
+            raise ValueError("BRIGHTDATA_API_KEY not set")
+        _bright_data_client = BrightDataClient(api_key=api_key)
+    return _bright_data_client

--- a/src/orchestration/flows/campaign_flow.py
+++ b/src/orchestration/flows/campaign_flow.py
@@ -26,7 +26,7 @@ from sqlalchemy import and_, select, update
 
 from src.enrichment.campaign_trigger import CampaignDiscoveryTrigger
 from src.integrations.abn_client import get_abn_client
-from src.integrations.bright_data_client import BrightDataClient
+from src.integrations.bright_data_client import get_bright_data_client
 from src.integrations.leadmagic import get_leadmagic_client
 from src.integrations.supabase import get_db_session, get_supabase_client
 from src.models.base import CampaignStatus, LeadStatus, SubscriptionStatus
@@ -296,7 +296,7 @@ async def trigger_discovery_task(campaign_id: str) -> dict[str, Any]:
     # Initialize clients
     supabase_client = get_supabase_client()
     abn_client = get_abn_client()
-    bright_data_client = BrightDataClient()
+    bright_data_client = get_bright_data_client()
     leadmagic_client = get_leadmagic_client()
 
     # Create trigger instance


### PR DESCRIPTION
## Bug #17 Fix

**Problem:** `campaign_activation_flow` crashes with:
```
TypeError: BrightDataClient.__init__() missing 1 required positional argument: 'api_key'
```

**Root Cause:** `BrightDataClient()` was instantiated in `campaign_flow.py:299` without passing the required `api_key` argument. Unlike other clients, no factory function existed.

**Fix:**
1. Added `get_bright_data_client()` singleton factory to `bright_data_client.py`
2. Factory reads `BRIGHTDATA_API_KEY` from environment
3. Updated `campaign_flow.py` to use the factory function

**Pattern Consistency:**
- `get_abn_client()` ✓
- `get_leadmagic_client()` ✓
- `get_bright_data_client()` ✓ (new)

**Files Changed:**
- `src/integrations/bright_data_client.py` — factory function added
- `src/orchestration/flows/campaign_flow.py` — import and usage updated

---
Governance: CEO Directive #105