### PR TITLE
fix: increment cache-bust ARG (Bug #18)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 
 # Cache bust for pip install layer (increment to force reinstall)
 # Bug #16: Railway layer cache was serving stale deps missing fuzzywuzzy
-ARG PIP_CACHE_BUST=2026-02-26
+ARG PIP_CACHE_BUST=2026-02-26-v2
 
 # Install Python dependencies
 COPY requirements.txt .


### PR DESCRIPTION
## Bug #18 Fix

**Problem:** E2E Test #13 flow crashed with exit code 1, 0s runtime. Railway reused pre-PR#103 cache layer when PR #104 deployed because ARG value was static.

**Fix:** Increment cache-bust value to force layer rebuild.

```diff
- ARG PIP_CACHE_BUST=2026-02-26
+ ARG PIP_CACHE_BUST=2026-02-26-v2
```

---
Governance: CEO Directive #106