### PR TITLE
fix: add client_id param to campaign_activation_flow (Bug #19)

### DIFF
--- a/src/orchestration/flows/campaign_flow.py
+++ b/src/orchestration/flows/campaign_flow.py
@@ -329,7 +329,10 @@ async def trigger_discovery_task(campaign_id: str) -> dict[str, Any]:
     description="Activate campaign with validation and enrichment trigger",
     log_prints=True,
 )
-async def campaign_activation_flow(campaign_id: str | UUID) -> dict[str, Any]:
+async def campaign_activation_flow(
+    campaign_id: str | UUID,
+    client_id: str | UUID | None = None,
+) -> dict[str, Any]:
     """
     Campaign activation flow.
 
@@ -343,6 +346,7 @@ async def campaign_activation_flow(campaign_id: str | UUID) -> dict[str, Any]:
 
     Args:
         campaign_id: Campaign UUID to activate (string or UUID)
+        client_id: Client UUID (optional, extracted from campaign if not provided)
 
     Returns:
         Dict with activation summary


### PR DESCRIPTION
## Bug #19 Fix

**Problem:** Flow crashes with SignatureMismatchError:
```
Function expects parameters ['campaign_id'] but was provided with parameters ['client_id', 'campaign_id']
```

**Root Cause:** API activation endpoint passes both `client_id` and `campaign_id` to the flow, but the flow signature only accepted `campaign_id`.

**Fix:** Add `client_id` as optional parameter with `None` default for backwards compatibility.

```python
async def campaign_activation_flow(
    campaign_id: str | UUID,
    client_id: str | UUID | None = None,  # NEW
) -> dict[str, Any]:
```

**Note:** The flow already extracts `client_id` from campaign data internally, so the param is not used in the body. It just prevents the signature mismatch crash.

---
Governance: CEO Directive #107