### PR TITLE
fix(enrichment): use service role client for Prefect worker RLS bypass (Bug #21)

### DIFF
--- a/src/enrichment/campaign_trigger.py
+++ b/src/enrichment/campaign_trigger.py
@@ -14,7 +14,7 @@ from src.enrichment.query_translator import CampaignConfig, QueryTranslator
 from src.enrichment.waterfall_v2 import LeadRecord, WaterfallV2
 from src.integrations.abn_client import ABNClient
 from src.integrations.bright_data_client import BrightDataClient
-from src.integrations.supabase import get_async_supabase_client
+from src.integrations.supabase import get_async_supabase_service_client
 
 logger = structlog.get_logger()
 
@@ -130,7 +130,7 @@ class CampaignDiscoveryTrigger:
     async def _fetch_campaign(self, campaign_id: str) -> dict | None:
         """Fetch campaign from database."""
         try:
-            supabase = await get_async_supabase_client()
+            supabase = await get_async_supabase_service_client()
             result = (
                 await supabase.table("campaigns")
                 .select("*")
@@ -231,7 +231,7 @@ class CampaignDiscoveryTrigger:
                 )
 
             # Batch insert
-            supabase = await get_async_supabase_client()
+            supabase = await get_async_supabase_service_client()
             await supabase.table("discovery_results").insert(records).execute()
 
         except Exception as e:
@@ -240,7 +240,7 @@ class CampaignDiscoveryTrigger:
     async def _create_leads(self, campaign_id: str, leads: list) -> int:
         """Create leads in leads table."""
         created = 0
-        supabase = await get_async_supabase_client()
+        supabase = await get_async_supabase_service_client()
 
         for lead in leads:
             try:
@@ -268,7 +268,7 @@ class CampaignDiscoveryTrigger:
     async def _update_campaign_stats(self, campaign_id: str, leads_created: int):
         """Update campaign with lead count."""
         try:
-            supabase = await get_async_supabase_client()
+            supabase = await get_async_supabase_service_client()
             await (
                 supabase.table("campaigns")
                 .update({"lead_count": leads_created})

--- a/src/enrichment/keyword_expander.py
+++ b/src/enrichment/keyword_expander.py
@@ -10,7 +10,7 @@ import os
 import anthropic
 import structlog
 
-from src.integrations.supabase import get_async_supabase_client
+from src.integrations.supabase import get_async_supabase_service_client
 
 logger = structlog.get_logger()
 
@@ -51,7 +51,7 @@ Example: ["keyword1", "keyword2", "keyword3"]"""
     async def _lookup_db(self, industry_slug: str) -> list[str] | None:
         """Lookup keywords from industry_keywords table."""
         try:
-            supabase = await get_async_supabase_client()
+            supabase = await get_async_supabase_service_client()
             result = (
                 await supabase.table("industry_keywords")
                 .select("keywords")
@@ -107,7 +107,7 @@ Example: ["keyword1", "keyword2", "keyword3"]"""
     async def get_maps_categories(self, industry_slug: str) -> list[str]:
         """Get Google Maps category terms for an industry."""
         try:
-            supabase = await get_async_supabase_client()
+            supabase = await get_async_supabase_service_client()
             result = (
                 await supabase.table("industry_keywords")
                 .select("maps_categories")

--- a/src/enrichment/location_expander.py
+++ b/src/enrichment/location_expander.py
@@ -7,7 +7,7 @@ Uses curated lookup table with SERP fallback for unknown cities.
 
 import structlog
 
-from src.integrations.supabase import get_async_supabase_client
+from src.integrations.supabase import get_async_supabase_service_client
 
 logger = structlog.get_logger()
 
@@ -50,7 +50,7 @@ class LocationExpander:
     async def _lookup_db(self, city: str, state: str) -> list[str]:
         """Lookup suburbs from location_suburbs table."""
         try:
-            supabase = await get_async_supabase_client()
+            supabase = await get_async_supabase_service_client()
             result = (
                 await supabase.table("location_suburbs")
                 .select("suburb")


### PR DESCRIPTION
## Problem
- Discovery trigger logs `campaign_not_found` for campaign `d97208cb-65e9-4356-822f-36681c6fc441` despite it existing
- Error: `PGRST116` — query returns 0 rows
- Root cause: `_fetch_campaign()` uses anon key client via `get_async_supabase_client()`
- RLS policy on campaigns requires `auth.uid()` which is NULL in Prefect worker context

## Fix
- Swap `get_async_supabase_client()` → `get_async_supabase_service_client()`
- Service role client bypasses RLS, allowing backend operations without user context

## Files Fixed (3 files, 7 occurrences)
| File | Occurrences |
|------|-------------|
| `src/enrichment/campaign_trigger.py` | 4 (import + 3 usages) |
| `src/enrichment/location_expander.py` | 2 (import + 1 usage) |
| `src/enrichment/keyword_expander.py` | 3 (import + 2 usages) |

## Verification
```bash
grep -rn 'get_async_supabase_client' src/enrichment/ src/orchestration/flows/
# Expected: 0 results ✅
```

## Governance
- CEO Directive #109
- LAW V build-2
- LAW I-A cat-first verified