### PR TITLE
fix(discovery): add missing await on search_google_maps call (Bug #23)

### DIFF
--- a/src/enrichment/location_expander.py
+++ b/src/enrichment/location_expander.py
@@ -69,7 +69,7 @@ class LocationExpander:
     async def _expand_with_serp(self, city: str, state: str) -> list[str]:
         """Use Google SERP to find suburbs for unlisted city."""
         try:
-            results = self.bd.search_google(f"{city} {state} suburbs list")
+            results = await self.bd.search_google(f"{city} {state} suburbs list")
 
             # Parse suburbs from search results
             # This is heuristic - look for suburb names in snippets

--- a/src/enrichment/query_translator.py
+++ b/src/enrichment/query_translator.py
@@ -212,7 +212,7 @@ class QueryTranslator:
                     break
 
                 try:
-                    maps_results = self.bd.search_google_maps(
+                    maps_results = await self.bd.search_google_maps(
                         query=keyword, location=f"{suburb} {config.state}"
                     )
 


### PR DESCRIPTION
## Problem
`QueryTranslator.execute_maps_queries()` calls `self.bd.search_google_maps()` without `await` at line 215.

**Code before fix:**
```python
maps_results = self.bd.search_google_maps(
    query=keyword, location=f"{suburb} {config.state}"
)
```

**Issue:**
- `search_google_maps` is an `async def` method in `BrightDataClient`
- Without `await`, `maps_results` is a **coroutine object**, not a list
- `isinstance(maps_results, list)` returns `False`
- The loop `for record in maps_results if isinstance(maps_results, list) else []` becomes `for record in []`
- **Result:** Zero results processed, even when Bright Data API returns valid data

## Evidence from Test #18
```json
{
  "query_type": "maps_serp",
  "query_params": {"keyword": "marketing agency", "suburb": "Melbourne CBD"},
  "results_count": 0  // <-- Always 0 because coroutine not awaited
}
```

## Fix
```python
maps_results = await self.bd.search_google_maps(
    query=keyword, location=f"{suburb} {config.state}"
)
```

## Verification
```bash
grep -n "self.bd\." src/enrichment/query_translator.py
# Output: 215:                    maps_results = await self.bd.search_google_maps(
```

## Governance
- CEO Directive #111
- LAW V build-2
- LAW I-A cat-first verified