### PR TITLE
fix(enrichment): Bugs #24-27 - SERP parsing, method signatures, email gate

### DIFF
--- a/src/enrichment/campaign_trigger.py
+++ b/src/enrichment/campaign_trigger.py
@@ -240,10 +240,22 @@ class CampaignDiscoveryTrigger:
     async def _create_leads(self, campaign_id: str, leads: list) -> int:
         """Create leads in leads table."""
         created = 0
+        skipped = 0
         supabase = await get_async_supabase_service_client()
 
         for lead in leads:
             try:
+                # Gate: Skip leads without email (NOT NULL constraint)
+                # Unenriched leads without email have low value
+                if not lead.email:
+                    logger.info(
+                        "lead_skipped_no_email",
+                        business=lead.business_name,
+                        reason="email required but not discovered during enrichment"
+                    )
+                    skipped += 1
+                    continue
+
                 # Get campaign's client_id
                 campaign = await self._fetch_campaign(campaign_id)
                 client_id = campaign.get("client_id") if campaign else None
@@ -251,7 +263,11 @@ class CampaignDiscoveryTrigger:
                 lead_data = {
                     "campaign_id": campaign_id,
                     "client_id": client_id,
+                    "email": lead.email,
                     "company": lead.business_name,
+                    "phone": lead.phone,
+                    "website": lead.website,
+                    "linkedin_url": lead.linkedin_company_url,
                     "als_score": lead.als_score,
                     "als_components": lead.als_breakdown,
                     "cost_basis": lead.cost_aud,
@@ -262,6 +278,9 @@ class CampaignDiscoveryTrigger:
 
             except Exception as e:
                 logger.warning("create_lead_failed", error=str(e), business=lead.business_name)
+
+        if skipped > 0:
+            logger.info("leads_skipped_summary", skipped=skipped, reason="no_email")
 
         return created
 

--- a/src/enrichment/waterfall_v2.py
+++ b/src/enrichment/waterfall_v2.py
@@ -288,9 +288,12 @@ class WaterfallV2:
                 raise ValueError("Bright Data client not configured")
 
             # Search Google Maps for business
-            search_query = f"{lead.business_name} {lead.address or lead.state or ''}"
+            search_query = lead.business_name or ""
+            location = lead.address or lead.state or "Australia"
             gmb_results = await self.bd.search_google_maps(
-                query=search_query.strip(), max_results=5
+                query=search_query.strip(),
+                location=location.strip(),
+                max_results=5
             )
 
             if gmb_results:

--- a/src/integrations/bright_data_client.py
+++ b/src/integrations/bright_data_client.py
@@ -8,6 +8,7 @@ Note: All methods are async - use with await.
 """
 
 import asyncio
+import json
 import os
 import urllib.parse
 from dataclasses import dataclass
@@ -110,29 +111,49 @@ class BrightDataClient:
         result = await self._serp_request(url)
 
         # Extract business results (limit to max_results)
-        if isinstance(result, list):
+        # Response format: {"status_code": 200, "body": "{\"organic\": [...]}"}
+        if isinstance(result, dict) and "body" in result:
+            try:
+                body = json.loads(result["body"])
+                return body.get("organic", [])[:max_results]
+            except (json.JSONDecodeError, KeyError, TypeError):
+                return []
+        elif isinstance(result, list):
             return result[:max_results]
         elif isinstance(result, dict) and "organic" in result:
             return result["organic"][:max_results]
 
         return []
 
-    async def search_google(self, query: str) -> dict:
+    async def search_google(self, query: str, max_results: int = 10) -> list[dict]:
         """
         Search Google via SERP API.
 
         Args:
             query: Search query (e.g., 'site:linkedin.com/company "business name"')
+            max_results: Maximum results to return (default 10)
 
         Returns:
-            Search results with organic results list
+            List of organic search results
 
         Cost: $0.0015 AUD per request
         """
         encoded_query = urllib.parse.quote(query)
         url = f"https://www.google.com/search?q={encoded_query}&brd_json=1"
 
-        return await self._serp_request(url)
+        result = await self._serp_request(url)
+
+        # Parse response body (same format as Maps SERP)
+        if isinstance(result, dict) and "body" in result:
+            try:
+                body = json.loads(result["body"])
+                return body.get("organic", [])[:max_results]
+            except (json.JSONDecodeError, KeyError, TypeError):
+                return []
+        elif isinstance(result, dict) and "organic" in result:
+            return result["organic"][:max_results]
+
+        return []
 
     async def _serp_request(self, url: str, max_retries: int = 2) -> Any:
         """Execute SERP API request via Direct API with Bearer token auth."""


### PR DESCRIPTION
## CEO Directive #113

### Bug #24: Maps SERP Response Parsing
- **File:** `src/integrations/bright_data_client.py`
- **Issue:** Response `body` is a JSON string, code expected parsed dict
- **Fix:** Parse `result["body"]` as JSON before extracting `organic`

### Bug #25: search_google_maps Missing Location
- **File:** `src/enrichment/waterfall_v2.py`
- **Issue:** Tier 1.5a call missing required `location` argument
- **Fix:** Extract location from `lead.address` or `lead.state` or default to "Australia"

### Bug #26: search_google Unexpected max_results
- **File:** `src/integrations/bright_data_client.py`
- **Issue:** Caller passed `max_results` but method didn't accept it
- **Fix:** Added `max_results: int = 10` param to `search_google()`

### Bug #27: Email NOT NULL Constraint
- **File:** `src/enrichment/campaign_trigger.py`
- **Issue:** Lead insert failed due to email NOT NULL constraint
- **Fix:** Added gate to skip leads without email (log reason)

### Verified
- `grep -n search_google_maps waterfall_v2.py` confirms location passed
- `grep -n 'def search_google' bright_data_client.py` confirms signatures match
- `import json` added to bright_data_client.py