### PR TITLE
fix(enrichment): Bug #29 - _convert_to_lead_record copies all Maps SERP fields

### DIFF
--- a/src/enrichment/campaign_trigger.py
+++ b/src/enrichment/campaign_trigger.py
@@ -171,10 +171,61 @@ class CampaignDiscoveryTrigger:
         return self.location_expander.get_state_from_city(location)
 
     def _convert_to_lead_record(self, discovery_result) -> LeadRecord:
-        """Convert DiscoveryResult to LeadRecord for waterfall."""
+        """
+        Convert DiscoveryResult to LeadRecord for waterfall.
+
+        Extracts all available fields from raw_data (Maps SERP or ABN API)
+        to maximize ALS score calculation accuracy before enrichment tiers run.
+        """
+        raw = discovery_result.raw_data or {}
+
+        # Extract category from Maps SERP (first category title)
+        category = None
+        if raw.get("category") and isinstance(raw["category"], list) and len(raw["category"]) > 0:
+            first_cat = raw["category"][0]
+            if isinstance(first_cat, dict):
+                category = first_cat.get("title")
+            elif isinstance(first_cat, str):
+                category = first_cat
+
+        # Extract reviews_count (Maps SERP uses reviews_cnt)
+        reviews_count = raw.get("reviews_cnt") or raw.get("reviews_count")
+        if reviews_count is not None:
+            try:
+                reviews_count = int(reviews_count)
+            except (ValueError, TypeError):
+                reviews_count = None
+
+        # Extract rating
+        rating = raw.get("rating")
+        if rating is not None:
+            try:
+                rating = float(rating)
+            except (ValueError, TypeError):
+                rating = None
+
         return LeadRecord(
+            # Core identifiers
             abn=discovery_result.abn,
-            business_name=discovery_result.business_name,
+            business_name=discovery_result.business_name or raw.get("title"),
+            legal_name=discovery_result.trading_name,
+            discovery_source=discovery_result.source,
+
+            # ABN Registry fields (from ABN API raw_data)
+            state=raw.get("state"),
+            gst_registered=raw.get("gst_registered", False),
+            entity_type=raw.get("entity_type"),
+
+            # GMB fields (from Maps SERP raw_data)
+            phone=raw.get("phone"),
+            website=raw.get("link") or raw.get("website"),
+            address=raw.get("address"),
+            rating=rating,
+            reviews_count=reviews_count,
+            category=category,
+            gmb_place_id=raw.get("map_id") or raw.get("fid"),
+
+            # Initialize empty lists/dicts
             enrichment_tiers_completed=[],
         )
 


### PR DESCRIPTION
## CEO Directive #114

### Bug #29: LeadRecord Conversion Loses Maps SERP Data

**File:** `src/enrichment/campaign_trigger.py`
**Function:** `_convert_to_lead_record()`

### Problem
Previous implementation only copied 2 fields:
```python
return LeadRecord(
    abn=discovery_result.abn,
    business_name=discovery_result.business_name,
    enrichment_tiers_completed=[],
)
```

This lost all rich data from Maps SERP raw_data:
- phone, website, address
- rating, reviews_count, category
- gmb_place_id, state

**Impact:** ALS scores calculated LOW → Tier 3 gate blocked → Leadmagic never called → 0 leads created

### Fix
Now extracts ALL relevant fields from `raw_data`:

| Source | Field | LeadRecord |
|--------|-------|------------|
| Direct | abn | abn |
| Direct | business_name | business_name |
| Direct | trading_name | legal_name |
| Direct | source | discovery_source |
| raw_data | phone | phone |
| raw_data | link/website | website |
| raw_data | address | address |
| raw_data | rating | rating |
| raw_data | reviews_cnt | reviews_count |
| raw_data | category[0].title | category |
| raw_data | map_id/fid | gmb_place_id |
| raw_data | state | state |
| raw_data | gst_registered | gst_registered |
| raw_data | entity_type | entity_type |

### Governance
- LAW V: build-2
- LAW I-A: Models inspected before fix
- PR only — Dave merges