### PR TITLE
fix(enrichment): Directive #115 - Credit discovery tiers in ALS calculation

### DIFF
--- a/src/enrichment/campaign_trigger.py
+++ b/src/enrichment/campaign_trigger.py
@@ -170,6 +170,23 @@ class CampaignDiscoveryTrigger:
         """Infer state from location name."""
         return self.location_expander.get_state_from_city(location)
 
+    def _get_discovery_tiers(self, source: str) -> list[str]:
+        """
+        Credit enrichment tiers based on discovery source.
+
+        Discovery sources already represent completed enrichment work:
+        - abn_api/abn_lookup: T1 ABN enrichment already done
+        - maps_serp/google_maps: T1 ABN + T1.5a Maps already done
+
+        This ensures ALS data_quality component correctly reflects
+        the enrichment work completed during discovery phase.
+        """
+        if source in ("abn_api", "abn_lookup"):
+            return ["tier_1"]
+        elif source in ("maps_serp", "google_maps", "both"):
+            return ["tier_1", "tier_1_5a"]
+        return []
+
     def _convert_to_lead_record(self, discovery_result) -> LeadRecord:
         """
         Convert DiscoveryResult to LeadRecord for waterfall.
@@ -225,8 +242,9 @@ class CampaignDiscoveryTrigger:
             category=category,
             gmb_place_id=raw.get("map_id") or raw.get("fid"),
 
-            # Initialize empty lists/dicts
-            enrichment_tiers_completed=[],
+            # Credit discovery tiers based on source
+            # This ensures ALS data_quality component reflects work already done
+            enrichment_tiers_completed=self._get_discovery_tiers(discovery_result.source),
         )
 
     async def _enrich_lead(self, lead: LeadRecord, config: CampaignConfig) -> LeadRecord:


### PR DESCRIPTION
## Problem

`_convert_to_lead_record` initialized `enrichment_tiers_completed=[]`, failing to credit discovery work already completed:
- ABN API discovery = T1 already done
- Maps SERP discovery = T1 + T1.5a already done

This caused ALS `data_quality` component to score 0 instead of 6-9 points, making it structurally impossible to pass the 35-point gate without LinkedIn data.

## Solution

Add `_get_discovery_tiers()` helper that credits tiers based on discovery source:
- `abn_api`/`abn_lookup` → `["tier_1"]` (+3 data_quality)
- `maps_serp`/`google_maps` → `["tier_1", "tier_1_5a"]` (+6 data_quality)

## Gate Position (Already Correct)

LAW I-A diagnosis confirmed current order is:
```
T1 → T1.5a → T1.5b → T2 (if URL) → ALS calc → GATE → T2.5 → T3 → T5
```
T2 was already before gate in deployed code (cf89a1f). No change needed there.

## ALS Impact (Boostable Scenario)

| Component | Before Fix | After Fix (T2 runs) |
|-----------|------------|---------------------|
| engagement | 15 | 15 |
| data_quality | 0 | 12 (4 tiers × 3, capped 15) |
| company_fit | 0 | 20 (industry + company_size) |
| **TOTAL** | **15** | **47** ✅ passes 35 gate |

## Governance

- **LAW I-A**: Diagnosis confirmed before fix
- **LAW V**: Build-2 (single file, surgical fix)
- **Directive**: #115
- **PR only**: Dave merges