### PR TITLE
fix(enrichment): Directive #118 - Fix pipeline email generation bugs

### DIFF
--- a/src/enrichment/waterfall_v2.py
+++ b/src/enrichment/waterfall_v2.py
@@ -643,7 +643,7 @@ class WaterfallV2:
                     # Use company name as fallback for generic contact
                     result = await self.leadmagic.find_email(
                         first_name="info",
-                        last_name="",
+                        last_name="Contact",
                         domain=domain,
                         company=lead.business_name,
                     )

--- a/src/integrations/bright_data_client.py
+++ b/src/integrations/bright_data_client.py
@@ -143,15 +143,25 @@ class BrightDataClient:
 
         result = await self._serp_request(url)
 
-        # Parse response body (same format as Maps SERP)
+        # Parse response body - handle both "organic" and "results" keys
         if isinstance(result, dict) and "body" in result:
             try:
                 body = json.loads(result["body"])
-                return body.get("organic", [])[:max_results]
+                # Handle both formats from Bright Data SERP
+                if "organic" in body:
+                    return body["organic"][:max_results]
+                elif "results" in body:
+                    # Filter for organic type results
+                    organic = [r for r in body["results"] if r.get("type") == "organic"]
+                    return organic[:max_results]
+                return []
             except (json.JSONDecodeError, KeyError, TypeError):
                 return []
         elif isinstance(result, dict) and "organic" in result:
             return result["organic"][:max_results]
+        elif isinstance(result, dict) and "results" in result:
+            organic = [r for r in result["results"] if r.get("type") == "organic"]
+            return organic[:max_results]
 
         return []
 

--- a/src/integrations/leadmagic.py
+++ b/src/integrations/leadmagic.py
@@ -485,6 +485,34 @@ class LeadmagicClient:
             ValidationError: If required params missing
             LeadmagicError: If API call fails
         """
+        # MOCK MODE: Bypass validation and return synthetic email
+        if _is_mock_mode():
+            domain_clean = (domain or "").lower().strip()
+            if domain_clean.startswith(("http://", "https://")):
+                domain_clean = domain_clean.split("//")[1].split("/")[0]
+            fn = (first_name or "").lower().strip()
+            ln = (last_name or "").lower().strip()
+            if fn and ln:
+                mock_email = f"{fn}.{ln}@{domain_clean}"
+            else:
+                mock_email = f"info@{domain_clean}"
+            logger.info(f"[Leadmagic] MOCK MODE: Returning fake email {mock_email}")
+            return EmailFinderResult(
+                found=bool(domain_clean),
+                email=mock_email if domain_clean else None,
+                confidence=85,
+                status=EmailStatus.VALID,
+                first_name=(first_name or "").strip(),
+                last_name=(last_name or "").strip(),
+                domain=domain_clean,
+                company=company.strip() if company else None,
+                position=None,
+                linkedin_url=None,
+                cost_aud=0.0,
+                source="leadmagic-mock",
+            )
+
+        # Real mode validation
         if not domain:
             raise ValidationError(message="Domain is required for email finder")
         if not first_name or not last_name:
@@ -494,28 +522,6 @@ class LeadmagicClient:
         domain = domain.lower().strip()
         if domain.startswith(("http://", "https://")):
             domain = domain.split("//")[1].split("/")[0]
-
-        # MOCK MODE: Return realistic fake data without API call
-        if _is_mock_mode():
-            mock_email = f"{first_name.lower().strip()}.{last_name.lower().strip()}@{domain}"
-            mock_confidence = random.randint(85, 98)
-            logger.info(
-                f"[Leadmagic] MOCK MODE: Returning fake email for {first_name} {last_name} @ {domain}"
-            )
-            return EmailFinderResult(
-                found=True,
-                email=mock_email,
-                confidence=mock_confidence,
-                status=EmailStatus.VALID,
-                first_name=first_name.strip(),
-                last_name=last_name.strip(),
-                domain=domain,
-                company=company.strip() if company else None,
-                position=None,
-                linkedin_url=None,
-                cost_aud=0.0,  # No charge for mock
-                source="leadmagic-mock",
-            )
 
         logger.info(f"[Leadmagic] Email finder: {first_name} {last_name} @ {domain}")
 


### PR DESCRIPTION
## Problem

Pipeline produces 0 emails due to two bugs:

1. **T3 domain fallback** passes `last_name=""`
2. **Leadmagic validation** rejects empty last_name BEFORE mock check runs
3. **SERP parser** may miss results if Bright Data returns `results` key instead of `organic`

## Fixes

### Fix 1: Leadmagic Mock — Bypass Validation
```python
# BEFORE: Validation runs first, blocks empty names
if not first_name or not last_name:
    raise ValidationError(...)
if _is_mock_mode():
    ...

# AFTER: Mock check runs first, handles empty names
if _is_mock_mode():
    if fn and ln:
        mock_email = f"{fn}.{ln}@{domain}"
    else:
        mock_email = f"info@{domain}"
    return EmailFinderResult(...)
# Real mode validation continues below
```

### Fix 2: T3 Fallback — Replace Empty last_name
```python
# BEFORE
last_name=""

# AFTER
last_name="Contact"
```

### Fix 3: SERP Parser — Defensive Key Handling
```python
# Handle both formats from Bright Data
if "organic" in body:
    return body["organic"][:max_results]
elif "results" in body:
    organic = [r for r in body["results"] if r.get("type") == "organic"]
    return organic[:max_results]
```

## Expected Outcome

Leads with website domain should now get synthetic emails in mock mode:
- `info@capitaledgemedia.com.au` for Capital Edge Media
- Even without decision makers from T2

## Files Changed (3)
- `src/integrations/leadmagic.py` — Mock check before validation
- `src/enrichment/waterfall_v2.py` — T3 fallback last_name
- `src/integrations/bright_data_client.py` — SERP parser keys

## Governance
- **LAW I-A**: Current state confirmed before changes
- **LAW V**: Build-2 (3 files, +41/-25 lines)
- **Directive**: #118
- **PR only**: Dave merges