### PR TITLE
fix(enrichment): move Leadmagic error imports to module level — Directive #119

### DIFF
--- a/src/enrichment/campaign_trigger.py
+++ b/src/enrichment/campaign_trigger.py
@@ -300,11 +300,28 @@ class CampaignDiscoveryTrigger:
 
         # Gate check for further enrichment
         if gate_passed:
-            lead = await self.waterfall.enrich_tier_2_5(lead)
-            lead = await self.waterfall.enrich_tier_3(lead)
-            lead = await self.waterfall.enrich_tier_5(lead)
-            # Recalculate ALS after enrichment
-            lead.als_score = self.waterfall.calculate_als(lead)
+            try:
+                lead = await self.waterfall.enrich_tier_2_5(lead)
+                lead = await self.waterfall.enrich_tier_3(lead)
+                lead = await self.waterfall.enrich_tier_5(lead)
+                # Recalculate ALS after enrichment
+                lead.als_score = self.waterfall.calculate_als(lead)
+            except Exception as e:
+                logger.warning(
+                    "enrichment_post_gate_failed",
+                    business=lead.business_name,
+                    error=str(e),
+                )
+                await self._write_audit_log(
+                    supabase,
+                    campaign_id,
+                    "post_gate_enrichment_failed",
+                    {
+                        "business_name": lead.business_name,
+                        "error": str(e),
+                        "als_score": lead.als_score,
+                    },
+                )
 
         return lead
 

--- a/src/enrichment/waterfall_v2.py
+++ b/src/enrichment/waterfall_v2.py
@@ -51,6 +51,10 @@ from src.enrichment.discovery_modes import (
     MapsFirstDiscovery,
     ParallelDiscovery,
 )
+from src.integrations.leadmagic import (
+    LeadmagicCreditExhaustedError,
+    LeadmagicNoPlanError,
+)
 
 logger = structlog.get_logger()
 
@@ -601,12 +605,6 @@ class WaterfallV2:
                     "Leadmagic client not configured - required for T3 email enrichment"
                 )
 
-            # Import error types for explicit handling
-            from src.integrations.leadmagic import (
-                LeadmagicCreditExhaustedError,
-                LeadmagicNoPlanError,
-            )
-
             # Try to find email for best decision maker
             email_found = False
 
@@ -725,12 +723,6 @@ class WaterfallV2:
                 raise ValueError(
                     "Leadmagic client not configured - required for T5 mobile enrichment"
                 )
-
-            # Import error types for explicit handling
-            from src.integrations.leadmagic import (
-                LeadmagicCreditExhaustedError,
-                LeadmagicNoPlanError,
-            )
 
             # Enrich top decision makers with Leadmagic mobile finder
             verified_contacts = []


### PR DESCRIPTION
## Directive #119 — Fix T3 Silent Failure

### Root Cause
`LeadmagicCreditExhaustedError` and `LeadmagicNoPlanError` were imported **INSIDE** the try block in `enrich_tier_3` and `enrich_tier_5`. When `self.leadmagic` was None:

1. `ValueError` raised at line 600 (before imports)
2. Imports at lines 606-608 never execute
3. Python evaluates `except (LeadmagicCreditExhaustedError, ...)` at line 660
4. **`UnboundLocalError`** — names not in scope
5. Exception propagates uncaught, T3 crashes silently

### Fixes Applied

**Fix 1: waterfall_v2.py** — Move imports to module level
```python
from src.integrations.leadmagic import (
    LeadmagicCreditExhaustedError,
    LeadmagicNoPlanError,
)
```

**Fix 2: campaign_trigger.py** — Wrap gate_passed block in try/except
```python
if gate_passed:
    try:
        lead = await self.waterfall.enrich_tier_2_5(lead)
        lead = await self.waterfall.enrich_tier_3(lead)
        lead = await self.waterfall.enrich_tier_5(lead)
        lead.als_score = self.waterfall.calculate_als(lead)
    except Exception as e:
        logger.warning("enrichment_post_gate_failed", ...)
        await self._write_audit_log(...)
```

### Before/After

| Metric | Before | After |
|--------|--------|-------|
| T3 behavior | `UnboundLocalError` crash | Graceful error handling |
| Lead creation | Silent drop | Continues with errors logged |
| Audit trail | Goes cold after `als_calculated` | `post_gate_enrichment_failed` logged |

### Test Output (After Fix)
```
T3 completed
email=None
tiers=['tier_1', 'tier_1_5a', 'tier_2_5']
errors=[{'tier': 'tier_3', 'error': 'Leadmagic client not configured...'}]
```

### Governance
- **LAW I-A**: Read-before-write verified
- **LAW V**: Build-2 PR for Dave merge
- **Directive #119**