### PR TITLE
fix(enrichment): T1.5b use 'link' key from SERP results

### DIFF
--- a/src/enrichment/waterfall_v2.py
+++ b/src/enrichment/waterfall_v2.py
@@ -347,7 +347,7 @@ class WaterfallV2:
             if serp_results:
                 # Find LinkedIn company URL in results
                 for result in serp_results:
-                    url = result.get("url", "")
+                    url = result.get("link") or result.get("url", "")
                     if "linkedin.com/company/" in url and not url.endswith("/jobs"):
                         lead.linkedin_company_url = url
                         break


### PR DESCRIPTION
## Directive #121 (continued)

**Fix:** T1.5b key mismatch - BrightData SERP API returns LinkedIn URLs in `link` field, not `url`.

### Change
```python
# Before
url = result.get("url", "")

# After  
url = result.get("link") or result.get("url", "")
```

Now checks both keys for compatibility.

**Governance:** LAW I-A verified. LAW V build-2. PR only — Dave merges.