### PR TITLE
fix(enrichment): T2 extracts website from LinkedIn data

### DIFF
--- a/src/enrichment/waterfall_v2.py
+++ b/src/enrichment/waterfall_v2.py
@@ -403,6 +403,10 @@ class WaterfallV2:
                 lead.headquarters = linkedin_data.get("headquarters")
                 lead.specialties = linkedin_data.get("specialties")
 
+                # Extract website from LinkedIn if not already set
+                if not lead.website:
+                    lead.website = linkedin_data.get("website")
+
                 # Extract employee data for decision makers
                 employees = linkedin_data.get("employees", [])
                 if employees:


### PR DESCRIPTION
## Directive #122

### Fix
T2 (LinkedIn company scraper) now populates `lead.website` from LinkedIn data when not already set.

### Root Cause
T3 early-exit condition:
```python
if not lead.website and not lead.decision_makers:
    return lead  # T3 skipped
```

T2 scraped LinkedIn which has website field but never wrote it to `lead.website`. This caused T3 to skip when leads lacked decision_makers.

### Change
```python
# After existing LinkedIn field extractions:
if not lead.website:
    lead.website = linkedin_data.get("website")
```

### Discovery Query Count (Separate Issue)
Test #28 showed 2 queries (1 ABN + 1 Maps) vs expected 4+.
- **Not a code regression** — git log shows no relevant changes
- **Root cause:** Campaign `target_industries: []` defaults to "general", which has no DB entry → Claude fallback returns 1 keyword
- **Fix:** Populate `target_industries` on test campaign OR add "general" industry keywords

**Governance:** LAW I-A. LAW V build-2. PR only — Dave merges.