### PR TITLE
fix(enrichment): T1.25 use abn_client not abn — Directive #125

### DIFF
--- a/src/enrichment/waterfall_v2.py
+++ b/src/enrichment/waterfall_v2.py
@@ -296,11 +296,11 @@ class WaterfallV2:
         logger.debug(f"Tier 1.25: ABR entity lookup for {lead.business_name} ({lead.abn})")
 
         try:
-            if not self.abn:
+            if not self.abn_client:
                 raise ValueError("ABN client not configured")
 
             # Lookup full entity details by ABN
-            entity_data = await self.abn.search_by_abn(lead.abn)
+            entity_data = await self.abn_client.search_by_abn(lead.abn)
 
             if entity_data and entity_data.get("found"):
                 # Set legal name (entity/company name)


### PR DESCRIPTION
## Bug
T1.25 referenced `self.abn` but client is stored as `self.abn_client`.

## Effect
- T1.25 crashed silently on every ABN lead
- `trading_name` never populated
- Downstream LinkedIn/GMB searches used keyword not trading name

## Fix
- Line 299: `self.abn` → `self.abn_client`
- Line 303: `self.abn.search_by_abn` → `self.abn_client.search_by_abn`

## Governance
- LAW I-A verified
- LAW V build-2
- Directive #125