### PR TITLE
fix(discovery): null guard for business_name in dedup — Directive #129

### DIFF
--- a/src/enrichment/discovery_modes.py
+++ b/src/enrichment/discovery_modes.py
@@ -417,11 +417,17 @@ class ParallelDiscovery:
 
         # Process ABN results first (higher confidence for business data)
         for record in abn_results:
+            # Skip records with no usable identity data
+            if not record.business_name and not record.abn:
+                continue
             key = self._generate_dedup_key(record, config)
             merged[key] = record
 
         # Process Maps results, merging with ABN data where possible
         for record in maps_results:
+            # Skip records with no usable identity data
+            if not record.business_name and not record.abn:
+                continue
             key = self._generate_dedup_key(record, config)
 
             if key in merged:
@@ -441,7 +447,7 @@ class ParallelDiscovery:
             return f"abn_{record.abn.strip()}"
 
         # Fall back to fuzzy business name matching
-        clean_name = record.business_name.lower().strip()
+        clean_name = (record.business_name or "").lower().strip()
         # Remove common business suffixes for better matching
         suffixes = ["pty ltd", "pty. ltd.", "proprietary limited", "limited", "ltd", "corp", "inc"]
         for suffix in suffixes:


### PR DESCRIPTION
## CEO Directive #129

### Problem
`discovery_modes.py:444` crashes with `NoneType.lower()` when `maps_serp` returns null `business_name`. This kills all 20 `abn_api` leads too — they hit the same dedup function.

### Root Cause
`maps_serp` returns 20 records with `business_name=null`. When these hit `_generate_dedup_key()`, the code crashes:
```python
clean_name = record.business_name.lower().strip()  # crashes on None
```

### Fix
**Part A** — Null guard in `_generate_dedup_key()`:
```python
clean_name = (record.business_name or "").lower().strip()
```

**Part B** — Skip records with no usable identity data before dedup:
```python
if not record.business_name and not record.abn:
    continue  # skip — no usable identity data
```

### Test #31 Blocked By This
- 0 T1.25 executions (abn_api leads crashed before reaching waterfall)
- 0 T2.5 executions (post-gate crash)
- Only 3 leads (from maps_serp fallback)
- All authority scores = 0

### Governance
LAW I-A. LAW V build-2. PR only — Dave merges.