### PR TITLE
fix(discovery): populate business_name from correct raw_data key — Directive #131

### DIFF
--- a/src/enrichment/query_translator.py
+++ b/src/enrichment/query_translator.py
@@ -184,7 +184,7 @@ class QueryTranslator:
                     results.append(
                         DiscoveryResult(
                             abn=record.get("abn"),
-                            business_name=record.get("entity_name") or record.get("name"),
+                            business_name=record.get("business_name") or record.get("entity_name") or record.get("name"),
                             trading_name=record.get("trading_name"),
                             source="abn_api",
                             raw_data=record,


### PR DESCRIPTION
## CEO Directive #131

### Problem
ABN API returns business name in `business_name` key, but `query_translator.py:186` was extracting from `entity_name` or `name` — neither of which exist in ABN API response.

**Evidence:**
```sql
raw_data->>'entity_name': null
raw_data->>'name': null
raw_data->>'business_name': 'Marketing Agency Pro'  -- ACTUAL DATA
```

Result: `discovery_results.business_name` column = NULL for all 20 ABN leads.

### Fix
Line 186 change:
```python
# Before:
business_name=record.get("entity_name") or record.get("name"),

# After:
business_name=record.get("business_name") or record.get("entity_name") or record.get("name"),
```

### This Unblocks
1. **Part B null guard** — Now correctly passes abn_api records (20 leads restored)
2. **Waterfall** — Receives leads with business_name populated
3. **.lower() crashes** — Resolved (business_name no longer None)
4. **T1.25** — Can run (leads have ABN + business_name)

### Expected Test #33 Outcome
- 20+ leads from abn_api entering waterfall
- T1.25 executing on ABN leads
- No post_gate_enrichment_failed crashes
- ALS ceiling ~85+ possible

### Governance
LAW I-A. LAW V build-2. PR only — Dave merges.