### PR TITLE
fix(discovery): cast lead_count to int + add waterfall error logging — Directive #135

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,33 +1,34 @@
-# HANDOFF.md — Session State (2026-02-26T08:59Z)
+# Session Handoff — 2026-02-27
 
-## Current State
-- **Next Directive:** #105
-- **Last PR:** #102 (SHA: 1fe58c7) - campaign flow trigger
-- **Test Client ID:** 87554553-e691-40c9-9307-eab684d20183
-- **Test Campaign ID:** d97208cb-65e9-4356-822f-36681c6fc441
+## Next Action
+Run E2E Test #31 after Railway redeploys. Both PRs just merged — wait 90 seconds.
 
-## Bug #16 Diagnosis (COMPLETE — DO NOT FIX WITHOUT DIRECTIVE)
+## PRs Merged This Session
+- PR #116: website→organization_website column fix
+- PR #117: T1.5b reads "link" not "url" key
+- PR #118: T2 populates lead.website from LinkedIn
+- PR #119: CLOSED (superseded by #120)
+- PR #120: Full v2.2 waterfall alignment (T1.25 built, tier reorder, trading_name fixes)
+- PR #121: T1.25 self.abn → self.abn_client fix
+- PR #122: DM discovery chain fix (T2 stores employees, T2.5 scrapes profiles, ALS authority scoring fixed)
 
-**Error:** `ModuleNotFoundError: No module named 'fuzzywuzzy'`
+## Test #31 Expected Results
+- T1.25 runs for ABN leads → trading names
+- T1.5b/T1.5a use trading names → 80%+ hit rate
+- T2.5 scrapes employee profiles → real DM titles
+- Authority score populated (was always 0)
+- ALS ceiling now 85+ (was 60)
+- Target: 40+ leads, avg ALS 55+
 
-**Import Chain:**
-```
-campaign_flow.py:27 → src.enrichment.campaign_trigger
-  → src/enrichment/__init__.py:20 → .discovery_modes
-    → src/enrichment/discovery_modes.py:31 → from fuzzywuzzy import fuzz
-      💥 CRASH (exit code 1, 0 runtime)
-```
+## Test #31 Campaign
+campaign_id: d97208cb-65e9-4356-822f-36681c6fc441
+client_id: 87554553-e691-40c9-9307-eab684d20183
 
-**Root Cause:** Railway Docker layer cache is serving a stale pip install layer. The dependency IS in requirements.txt (lines 69-70: fuzzywuzzy + python-Levenshtein), and IS in the deployed commit (1fe58c7). Railway's Docker build cache reused the pip install layer from before these deps were added.
+## Known State
+- LEADMAGIC_MOCK=true (emails are synthetic)
+- target_industries: ["marketing_agency"]
+- ALS gate: 20
+- All other mocks: MOCK_CRM, MOCK_UNIPILE = true
 
-**Fix Direction:** Force cache bust in Dockerfile.worker OR invalidate Railway build cache via dashboard.
-
-## Bugs Fixed (1-15)
-All resolved. See git history.
-
-## Milestone
-Flow triggered successfully on campaign activation → crashes on startup due to missing dependency (layer cache issue).
-
-## ceo_memory Synced
-- `ceo:session_2026-02-26` ✓
-- `ceo:directives` (last_number: 104) ✓
+## Next Directive Number
+#127

--- a/src/enrichment/campaign_trigger.py
+++ b/src/enrichment/campaign_trigger.py
@@ -106,12 +106,17 @@ class CampaignDiscoveryTrigger:
 
         # 6. Run waterfall enrichment on passed results
         enriched_leads = []
+        logger.info("waterfall_start", leads_to_process=len(passed_results[:config.lead_volume]))
         for result in passed_results[: config.lead_volume]:  # Limit to target volume
-            lead_record = self._convert_to_lead_record(result)
+            try:
+                lead_record = self._convert_to_lead_record(result)
 
-            # Run through waterfall tiers
-            lead_record = await self._enrich_lead(lead_record, config)
-            enriched_leads.append(lead_record)
+                # Run through waterfall tiers
+                lead_record = await self._enrich_lead(lead_record, config)
+                enriched_leads.append(lead_record)
+            except Exception as e:
+                logger.error("waterfall_lead_failed", business=result.business_name, error=str(e))
+                continue
 
         # 7. Create leads in database
         leads_created = await self._create_leads(campaign_id, enriched_leads)
@@ -155,7 +160,8 @@ class CampaignDiscoveryTrigger:
         state = icp.get("state") or self._infer_state(location)
 
         # Lead volume from campaign or default
-        lead_count = campaign.get("lead_count") or 100
+        # Cast to int to handle string "0" from DB (string "0" is truthy, int 0 is falsy)
+        lead_count = int(campaign.get("lead_count") or 0) or 100
 
         return CampaignConfig(
             campaign_id=campaign["id"],


### PR DESCRIPTION
## Root Cause

`campaign.get('lead_count')` returning string `'0'` was truthy, causing:
- `'0' or 100` = `'0'` (string) instead of `100` (int)
- `queries_estimated=2` instead of expected 5
- `passed_results[:'0']` potentially slicing incorrectly
- Only 1/40 leads processed through waterfall

## Fixes

1. **Line 158**: `int(campaign.get('lead_count') or 0) or 100`
   - Ensures string `'0'` → int `0` → `100` (default)

2. **Added `waterfall_start` log** with `leads_to_process` count

3. **Added try/except in waterfall loop** with error logging
   - Prevents silent failures
   - Logs `business_name` + error for debugging

## Governance

- LAW I-A diagnostic
- Build-2
- Directive #135

## Testing

Test #34 will run after merge to verify fix.