### PR TITLE
fix: resolve 3 issues from Test #34 (Directive #136)

### DIFF
--- a/src/enrichment/campaign_trigger.py
+++ b/src/enrichment/campaign_trigger.py
@@ -5,6 +5,8 @@ Automatically triggers discovery when a campaign becomes active.
 Wired to Supabase campaign status changes via webhook/function.
 """
 
+import traceback
+
 import structlog
 
 from src.enrichment.discovery_filters import DiscoveryFilters
@@ -115,7 +117,12 @@ class CampaignDiscoveryTrigger:
                 lead_record = await self._enrich_lead(lead_record, config)
                 enriched_leads.append(lead_record)
             except Exception as e:
-                logger.error("waterfall_lead_failed", business=result.business_name, error=str(e))
+                logger.error(
+                    "waterfall_lead_failed",
+                    business=result.business_name,
+                    error=str(e),
+                    traceback=traceback.format_exc(),
+                )
                 continue
 
         # 7. Create leads in database
@@ -403,14 +410,38 @@ class CampaignDiscoveryTrigger:
                 campaign = await self._fetch_campaign(campaign_id)
                 client_id = campaign.get("client_id") if campaign else None
 
+                # Extract decision maker fields from T2.5 enrichment
+                first_name = None
+                last_name = None
+                title = None
+                dm_linkedin_url = None
+
+                if lead.decision_makers:
+                    dm = lead.decision_makers[0]  # Use primary decision maker
+                    first_name = dm.get("first_name")
+                    last_name = dm.get("last_name")
+                    title = dm.get("title")
+                    dm_linkedin_url = dm.get("link")
+
+                    # Parse name from "name" field if first/last not available
+                    if not first_name and not last_name and dm.get("name"):
+                        name_parts = dm["name"].split()
+                        if len(name_parts) >= 1:
+                            first_name = name_parts[0]
+                        if len(name_parts) >= 2:
+                            last_name = " ".join(name_parts[1:])
+
                 lead_data = {
                     "campaign_id": campaign_id,
                     "client_id": client_id,
                     "email": lead.email,
                     "company": lead.business_name,
                     "phone": lead.phone,
+                    "first_name": first_name,
+                    "last_name": last_name,
+                    "title": title,
                     "organization_website": lead.website,
-                    "linkedin_url": lead.linkedin_company_url,
+                    "linkedin_url": dm_linkedin_url or lead.linkedin_company_url,
                     "als_score": lead.als_score,
                     "als_components": lead.als_breakdown,
                     "cost_basis": lead.cost_aud,

--- a/src/enrichment/waterfall_v2.py
+++ b/src/enrichment/waterfall_v2.py
@@ -541,6 +541,12 @@ If truly unknown, return the legal name without the Pty Ltd suffix."""
             if linkedin_data:
                 lead.linkedin_data = linkedin_data
 
+                # Update business_name from LinkedIn company name if available
+                # This fixes truncated names from Maps SERP (e.g., "MARKETING" -> "Bright Valley Marketing")
+                linkedin_name = linkedin_data.get("name")
+                if linkedin_name and len(linkedin_name) > len(lead.business_name or ""):
+                    lead.business_name = linkedin_name
+
                 # Extract key fields
                 lead.company_size = linkedin_data.get("company_size")
                 lead.industry = linkedin_data.get("industries")
@@ -588,7 +594,7 @@ If truly unknown, return the legal name without the Pty Ltd suffix."""
         ]
 
         for employee in employees:
-            title = employee.get("title", "").lower()
+            title = (employee.get("title") or "").lower()
             if any(keyword in title for keyword in decision_keywords):
                 decision_makers.append(employee)
 
@@ -617,7 +623,7 @@ If truly unknown, return the legal name without the Pty Ltd suffix."""
         # Authority (25 points) - Score based on best decision maker title
         if lead.decision_makers:
             for dm in lead.decision_makers[:1]:  # Score on best DM only
-                title = dm.get("title", "").lower()
+                title = (dm.get("title") or "").lower()
                 if any(k in title for k in ["ceo", "founder", "owner", "chief", "president", "managing director"]):
                     score_breakdown["authority"] = 25
                 elif any(k in title for k in ["vp", "vice president"]):


### PR DESCRIPTION
## Summary
Directive #136 — Build-2 — LAW I-A compliant

Fixes three issues identified in Test #34:
1. **NoneType.lower() crashes** (15 post_gate_enrichment_failed)
2. **DM titles not populating** (authority = 0 for all leads)
3. **Company names truncated** ('MARKETING' instead of full name)

## Changes

### Issue 1: NoneType.lower()
```python
# Before (line 591 & 620)
title = dm.get('title', '').lower()

# After
title = (dm.get('title') or '').lower()
```
The `.get('title', '')` pattern returns None if key exists with None value. Fixed with `(x or '')` pattern.

Also added traceback logging to waterfall_lead_failed handler for future debugging.

### Issue 2: DM titles not mapping to DB
```python
# _create_leads now extracts from decision_makers[0]:
first_name = dm.get('first_name')
last_name = dm.get('last_name')
title = dm.get('title')
dm_linkedin_url = dm.get('link')

# Also parses 'name' field if first/last not available
if not first_name and not last_name and dm.get('name'):
    name_parts = dm['name'].split()
    first_name = name_parts[0]
    last_name = ' '.join(name_parts[1:])
```

### Issue 3: Company names truncated
```python
# T2 now updates business_name from LinkedIn if longer
linkedin_name = linkedin_data.get('name')
if linkedin_name and len(linkedin_name) > len(lead.business_name or ''):
    lead.business_name = linkedin_name
```
Maps SERP results sometimes have truncated names. LinkedIn company name is authoritative.

## Test #34 Diagnostics Used
| Query | Result |
|-------|--------|
| post_gate_enrichment_failed | error: 'NoneType' object has no attribute 'lower' |
| tier_2_5_complete | 0 rows (no audit, but DM data exists) |
| tier_1_25_complete | 0 rows (expected - ABN-sourced only) |

## Governance
- LAW I-A: CEO SSOT checked before work
- LAW V: Build-2 (targeted fixes only)
- PR only — Dave merges