### PR TITLE
fix: use BD 'headline' field for job title in T2.5 (Directive #137)

### DIFF
--- a/src/enrichment/waterfall_v2.py
+++ b/src/enrichment/waterfall_v2.py
@@ -722,19 +722,26 @@ If truly unknown, return the legal name without the Pty Ltd suffix."""
                     profile_data = await self.bd.scrape_linkedin_profile(profile_url)
                     if profile_data:
                         # Extract key fields from profile
+                        # BD returns job title in 'headline' field, not 'title'
+                        job_title = (
+                            profile_data.get("headline")  # Primary: BD headline field
+                            or profile_data.get("title")  # Fallback: title field
+                        )
+                        
+                        # Fallback to position[0].title if still no title
+                        positions = profile_data.get("position", [])
+                        if not job_title and positions:
+                            job_title = positions[0].get("title")
+                        
                         profile_info = {
                             "first_name": profile_data.get("first_name"),
                             "last_name": profile_data.get("last_name"),
                             "name": profile_data.get("name"),
-                            "title": profile_data.get("title"),  # Real job title
+                            "title": job_title,  # Normalized job title
                             "link": profile_url,
                             "about": profile_data.get("about"),
-                            "position": profile_data.get("position", []),
+                            "position": positions,
                         }
-                        
-                        # Get current role from position if title not set
-                        if not profile_info["title"] and profile_info["position"]:
-                            profile_info["title"] = profile_info["position"][0].get("title")
                         
                         scraped_profiles.append(profile_info)
                         


### PR DESCRIPTION
## Summary
Directive #137 — Build-2 — LAW I-A compliant

Fixes title not populating from T2.5 LinkedIn profile scraping.

## Root Cause Analysis

**ISSUE 1 — Title not reaching lead**

Diagnostic queries showed:
- `decision_makers` column doesn't exist in leads table (not stored)
- T2.5 runs and populates `lead.decision_makers` in memory
- `_create_leads` correctly extracts from `dm.get('title')`
- BUT: `dm.get('title')` returns `None`

Prefect logs showed:
```
Tier 2.5: No DM found, using top profile for Marketing Agency Pro
Tier 2.5: No DM found, using top profile for Vic Marketing Club
```

**Root cause:** Bright Data LinkedIn People scraper returns job title in `headline` field, not `title`. T2.5 was looking for wrong field name.

## Fix (lines 722-744)

```python
# Before
profile_info = {
    ...
    "title": profile_data.get("title"),  # Wrong field!
    ...
}

# After  
job_title = (
    profile_data.get("headline")  # Primary: BD headline field
    or profile_data.get("title")  # Fallback: title field
)
if not job_title and positions:
    job_title = positions[0].get("title")
    
profile_info = {
    ...
    "title": job_title,  # Normalized job title
    ...
}
```

## ISSUE 2 — 40→18 Waterfall Drop

Diagnostic queries showed:
- All 40 `discovery_results` have `passed_filters=true`
- Campaign `lead_count=6` (not a code issue)
- Line 112 slices: `passed_results[:config.lead_volume]`

**This is a campaign config issue, not code.** CEO can increase `lead_count` on the campaign if more leads needed.

## Expected Impact

With this fix:
- T2.5 will populate `title` from BD `headline` field
- DM keyword matching will work (CEO, Director, etc.)
- Authority scoring will populate (was 0 for all leads)
- Hot lead threshold (ALS 85+) becomes achievable

## Governance
- LAW I-A: CEO SSOT checked
- LAW V: Build-2 (targeted fix only)
- PR only — Dave merges