### PR TITLE
feat(cis): CIS Learning Engine for propensity weight adjustment

### DIFF
--- a/migrations/cis_adjustment_log.sql
+++ b/migrations/cis_adjustment_log.sql
@@ -1,0 +1,25 @@
+-- CIS Learning Engine: Weight Adjustment Log
+-- Directive #147: Full audit trail for all weight changes
+
+CREATE TABLE IF NOT EXISTS cis_adjustment_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id UUID REFERENCES customers(id),
+    run_timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    signal_name TEXT NOT NULL,
+    weight_before INTEGER NOT NULL,
+    delta_applied INTEGER NOT NULL,
+    weight_after INTEGER NOT NULL,
+    confidence_score NUMERIC(3,2) NOT NULL,  -- 0.00 to 1.00
+    outcome_sample_size INTEGER NOT NULL,
+    skipped BOOLEAN NOT NULL DEFAULT FALSE,
+    skip_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for querying by customer and time
+CREATE INDEX idx_cis_adjustment_customer_time ON cis_adjustment_log(customer_id, run_timestamp DESC);
+
+-- Index for signal analysis
+CREATE INDEX idx_cis_adjustment_signal ON cis_adjustment_log(signal_name);
+
+COMMENT ON TABLE cis_adjustment_log IS 'Directive #147: Audit trail for CIS weight adjustments. Never destructive.';

--- a/migrations/outcomes_table.sql
+++ b/migrations/outcomes_table.sql
@@ -1,0 +1,73 @@
+-- CIS Learning Engine: Canonical Outcomes Table
+-- Directive #147: cis_outcome_schema_v3
+
+-- Outcome type enum
+DO $$ BEGIN
+    CREATE TYPE outcome_type AS ENUM (
+        'booked',
+        'replied_positive',
+        'replied_neutral', 
+        'replied_negative',
+        'unsubscribed',
+        'bounced',
+        'no_response'
+    );
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Channel converted enum
+DO $$ BEGIN
+    CREATE TYPE channel_converted_type AS ENUM (
+        'email',
+        'linkedin',
+        'sms',
+        'voice'
+    );
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Hook source enum
+DO $$ BEGIN
+    CREATE TYPE hook_source_type AS ENUM (
+        'dm_linkedin_posts',
+        'company_linkedin_posts',
+        'gmb_reviews',
+        'x_posts',
+        'none'
+    );
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS outcomes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id UUID REFERENCES customers(id),
+    lead_id UUID NOT NULL,
+    campaign_id UUID,
+    
+    -- Outcome classification
+    outcome_type outcome_type NOT NULL,
+    channel_converted channel_converted_type,
+    sequence_position INTEGER,
+    hook_source hook_source_type,
+    
+    -- Scores at time of send (for CIS learning)
+    reachability_at_send INTEGER,
+    propensity_at_send INTEGER,
+    
+    -- Active signals at time of send (for CIS learning)
+    signals_active JSONB,  -- {"hiring": true, "recent_funding": true, "dm_posts": 3, ...}
+    
+    -- Metadata
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for CIS analysis
+CREATE INDEX IF NOT EXISTS idx_outcomes_customer_created ON outcomes(customer_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_outcomes_type ON outcomes(outcome_type);
+CREATE INDEX IF NOT EXISTS idx_outcomes_signals ON outcomes USING GIN(signals_active);
+
+COMMENT ON TABLE outcomes IS 'Directive #147: Canonical outcomes table for CIS Learning Engine (schema v3)';

--- a/src/integrations/sdk_brain.py
+++ b/src/integrations/sdk_brain.py
@@ -1066,6 +1066,184 @@ Return ONLY the category name. Nothing else."""
             logger.warning(f"[SiegeSDK] Reply classification failed: {e}")
             return "negative_response"
 
+    # =========================================================================
+    # CIS LEARNING ENGINE (Directive #147)
+    # =========================================================================
+
+    async def analyze_cis_outcomes(
+        self,
+        outcomes: list[dict],
+        current_weights: dict,
+    ) -> dict:
+        """
+        Directive #147: CIS Learning Engine analysis.
+
+        Analyze outcome data to recommend propensity weight adjustments.
+        This is the core of the continuous improvement system — the moat.
+
+        Cost cap: $2 AUD per run.
+
+        Args:
+            outcomes: List of outcome records with signals_active
+            current_weights: Current weights from ceo:propensity_weights_v3
+
+        Returns:
+            {
+                "adjustments": {
+                    "signal_name": {"delta": int, "confidence": float, "reasoning": str}
+                },
+                "total_outcomes": int,
+                "meeting_booked_count": int,
+                "analysis_summary": str
+            }
+        """
+        # Segment outcomes by type
+        meeting_outcomes = [o for o in outcomes if o.get("outcome_type") == "booked"]
+        non_converting = [o for o in outcomes if o.get("outcome_type") in ("no_response", "bounced")]
+
+        prompt = f"""You are the CIS (Continuous Improvement System) analyst for Agency OS.
+
+TASK: Analyze outcome data to recommend propensity weight adjustments.
+
+CURRENT WEIGHTS:
+{json.dumps(current_weights, indent=2)}
+
+MEETING_BOOKED OUTCOMES ({len(meeting_outcomes)} total):
+{json.dumps([{"signals_active": o.get("signals_active"), "propensity_at_send": o.get("propensity_at_send")} for o in meeting_outcomes[:50]], indent=2)}
+
+NON-CONVERTING OUTCOMES (sample of {min(50, len(non_converting))}):
+{json.dumps([{"signals_active": o.get("signals_active"), "propensity_at_send": o.get("propensity_at_send")} for o in non_converting[:50]], indent=2)}
+
+ANALYSIS REQUIRED:
+1. Which signals in signals_active appeared frequently in MEETING_BOOKED outcomes?
+2. Which signals appeared frequently in non-converting leads?
+3. For each signal, recommend a weight adjustment (delta, not absolute).
+
+CONSTRAINTS:
+- Max delta: ±5 points per signal
+- Only recommend adjustments with confidence >= 0.7
+- If insufficient data for a signal, skip it
+- Preserve relative balance of weights
+
+RESPONSE FORMAT (JSON only):
+{{
+    "adjustments": {{
+        "signal_name": {{"delta": -3, "confidence": 0.85, "reasoning": "Appeared in 80% of non-converters"}}
+    }},
+    "analysis_summary": "Brief summary of patterns found"
+}}
+
+Respond with JSON only, no markdown."""
+
+        try:
+            # Call Claude Sonnet 4 with cost cap
+            response = await self._call_claude_with_cost_cap(
+                prompt=prompt,
+                model="claude-sonnet-4-20250514",
+                max_cost_usd=2.0,
+                max_tokens=2000,
+            )
+
+            result = json.loads(response)
+
+            # Add metadata
+            result["total_outcomes"] = len(outcomes)
+            result["meeting_booked_count"] = len(meeting_outcomes)
+
+            return result
+
+        except json.JSONDecodeError as e:
+            logger.error(f"[SiegeSDK] CIS analysis returned invalid JSON: {e}")
+            return {
+                "adjustments": {},
+                "total_outcomes": len(outcomes),
+                "meeting_booked_count": len(meeting_outcomes),
+                "analysis_summary": f"Analysis failed: invalid JSON response - {str(e)}",
+            }
+        except Exception as e:
+            logger.error(f"[SiegeSDK] CIS outcome analysis failed: {e}")
+            return {
+                "adjustments": {},
+                "total_outcomes": len(outcomes),
+                "meeting_booked_count": len(meeting_outcomes),
+                "analysis_summary": f"Analysis failed: {str(e)}",
+            }
+
+    async def _call_claude_with_cost_cap(
+        self,
+        prompt: str,
+        model: str = "claude-sonnet-4-20250514",
+        max_cost_usd: float = 2.0,
+        max_tokens: int = 2000,
+    ) -> str:
+        """
+        Call Claude with a cost cap.
+
+        Converts USD cost cap to AUD and enforces limits.
+
+        Args:
+            prompt: The prompt to send
+            model: Model to use
+            max_cost_usd: Maximum cost in USD
+            max_tokens: Maximum output tokens
+
+        Returns:
+            Response text content
+
+        Raises:
+            ValueError: If cost would exceed cap
+        """
+        # Convert USD to AUD (approx 1.55 conversion rate)
+        max_cost_aud = max_cost_usd * 1.55
+
+        # Check daily budget first
+        if self._spend_tracker:
+            remaining = await self._spend_tracker.get_remaining()
+            if remaining < max_cost_aud:
+                raise ValueError(f"Insufficient daily budget: ${remaining:.2f} AUD remaining")
+
+        # Create brain with cost limit
+        config = SDKBrainConfig(
+            model=model,
+            max_turns=1,
+            max_cost_aud=max_cost_aud,
+            timeout_seconds=120,
+        )
+
+        brain = SDKBrain(
+            config=config,
+            api_key=self._api_key,
+            spend_tracker=self._spend_tracker,
+        )
+
+        # Make the request
+        response = await brain.async_client.messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+
+        # Calculate and track cost
+        pricing = MODEL_PRICING.get(model, MODEL_PRICING["claude-sonnet-4-20250514"])
+        cost = (
+            (response.usage.input_tokens / 1_000_000) * pricing["input"]
+            + (response.usage.output_tokens / 1_000_000) * pricing["output"]
+        )
+
+        if self._spend_tracker:
+            await self._spend_tracker.add_spend(cost)
+
+        logger.info(
+            f"[SiegeSDK] CIS analysis cost: ${cost:.4f} AUD "
+            f"(in: {response.usage.input_tokens}, out: {response.usage.output_tokens})"
+        )
+
+        # Extract text content
+        if response.content and len(response.content) > 0:
+            return response.content[0].text
+
+        raise ValueError("Empty response from Claude")
+
 
 # Singleton instances
 _sdk_brain: SDKBrain | None = None

--- a/src/orchestration/deployments/__init__.py
+++ b/src/orchestration/deployments/__init__.py
@@ -1,0 +1,14 @@
+"""
+Prefect Deployments Package
+Contains deployment configurations for all flows.
+"""
+
+from src.orchestration.deployments.cis_learning_deployment import (
+    cis_weekly_deployment,
+    cis_manual_deployment,
+)
+
+__all__ = [
+    "cis_weekly_deployment",
+    "cis_manual_deployment",
+]

--- a/src/orchestration/deployments/cis_learning_deployment.py
+++ b/src/orchestration/deployments/cis_learning_deployment.py
@@ -1,0 +1,73 @@
+"""
+Prefect Deployment: CIS Learning Engine
+Directive #147: Weekly weight optimization
+
+Schedule: Every Sunday at 3:00 AM UTC
+- Runs after a full week of outcomes
+- Low-traffic time for minimal impact
+- Before Monday campaigns begin
+
+Manual trigger available via:
+    prefect deployment run 'cis-learning-engine/cis-weekly'
+"""
+
+from prefect.deployments import Deployment
+from prefect.server.schemas.schedules import CronSchedule
+
+from src.orchestration.flows.cis_learning_flow import cis_learning_flow
+
+
+# Weekly deployment - runs every Sunday at 3 AM UTC
+cis_weekly_deployment = Deployment.build_from_flow(
+    flow=cis_learning_flow,
+    name="cis-weekly",
+    version="1.0.0",
+    tags=["cis", "learning", "weekly", "directive-147"],
+    description=(
+        "Directive #147: CIS Learning Engine - Weekly weight adjustment. "
+        "Analyzes meeting outcomes and adjusts propensity weights for "
+        "continuous improvement. This is the moat."
+    ),
+    schedule=CronSchedule(
+        cron="0 3 * * 0",  # Every Sunday at 3:00 AM UTC
+        timezone="UTC",
+    ),
+    parameters={
+        "customer_id": None,  # Global weights
+        "run_type": "weekly",
+    },
+    work_queue_name="default",
+)
+
+
+# Manual/on-demand deployment - no schedule
+cis_manual_deployment = Deployment.build_from_flow(
+    flow=cis_learning_flow,
+    name="cis-manual",
+    version="1.0.0",
+    tags=["cis", "learning", "manual", "directive-147"],
+    description=(
+        "Directive #147: CIS Learning Engine - Manual trigger. "
+        "Use for testing or forced weight updates."
+    ),
+    schedule=None,  # No automatic schedule
+    parameters={
+        "customer_id": None,
+        "run_type": "manual",
+    },
+    work_queue_name="default",
+)
+
+
+if __name__ == "__main__":
+    # Deploy both configurations
+    cis_weekly_deployment.apply()
+    print("✓ Deployed: cis-learning-engine/cis-weekly (Sundays 3 AM UTC)")
+
+    cis_manual_deployment.apply()
+    print("✓ Deployed: cis-learning-engine/cis-manual (on-demand)")
+
+    print("\nDeployment commands:")
+    print("  Run weekly:  prefect deployment run 'cis-learning-engine/cis-weekly'")
+    print("  Run manual:  prefect deployment run 'cis-learning-engine/cis-manual'")
+    print("  With customer: prefect deployment run 'cis-learning-engine/cis-manual' -p customer_id=<uuid>")

--- a/src/orchestration/flows/__init__.py
+++ b/src/orchestration/flows/__init__.py
@@ -47,6 +47,7 @@ from src.orchestration.flows.stale_lead_refresh_flow import (
 )
 from src.orchestration.flows.voice_flow import voice_outreach_flow
 from src.orchestration.flows.warmup_monitor_flow import warmup_monitor_flow
+from src.orchestration.flows.cis_learning_flow import cis_learning_flow
 
 __all__ = [
     # Core flows
@@ -76,4 +77,6 @@ __all__ = [
     "get_buffer_status",
     # Voice Outreach
     "voice_outreach_flow",
+    # Directive #147: CIS Learning Engine
+    "cis_learning_flow",
 ]

--- a/src/orchestration/flows/cis_learning_flow.py
+++ b/src/orchestration/flows/cis_learning_flow.py
@@ -1,0 +1,417 @@
+"""
+CIS Learning Engine Flow
+Directive #147: Weekly weight adjustment based on outcomes
+
+ARCHITECTURE:
+1. Query outcomes since last run
+2. Threshold check (>= 20 MEETING_BOOKED)
+3. Claude analysis via sdk_brain
+4. Apply deltas with ±5 cap
+5. Log all changes to cis_adjustment_log
+
+PROPRIETARY: Weights never in code, only in ceo:propensity_weights_v3
+
+This is the moat. The CIS Learning Engine makes Agency OS smarter over time
+by analyzing what outreach patterns lead to booked meetings and adjusting
+propensity weights accordingly.
+
+Contract: src/orchestration/flows/cis_learning_flow.py
+Purpose: CIS Learning Engine weekly weight optimization
+Layer: 4 - orchestration
+Imports: services, integrations
+Consumers: Prefect scheduler
+"""
+
+from prefect import flow, task, get_run_logger
+from datetime import datetime
+import json
+
+from src.services.cis_outcome_service import (
+    get_outcomes_since_last_run,
+    count_meeting_booked_outcomes,
+    log_weight_adjustment,
+    get_propensity_weights,
+    save_propensity_weights,
+    log_cis_run_start,
+    log_cis_run_complete,
+)
+from src.integrations.sdk_brain import SiegeSDKIntelligence
+from src.integrations.supabase import get_db_session
+
+
+CEO_MEMORY_WEIGHTS_KEY = "ceo:propensity_weights_v3"
+MIN_OUTCOMES_THRESHOLD = 20
+MAX_DELTA_PER_RUN = 5
+
+
+@task(name="cis-query-outcomes")
+async def query_outcomes(customer_id: str | None = None) -> list[dict]:
+    """
+    Query outcomes for CIS analysis.
+
+    Fetches all outcomes since last CIS run with signals_active data.
+    """
+    async with get_db_session() as db:
+        return await get_outcomes_since_last_run(db, customer_id)
+
+
+@task(name="cis-check-threshold")
+async def check_threshold(customer_id: str | None = None) -> tuple[bool, int]:
+    """
+    Check if we have enough MEETING_BOOKED outcomes.
+
+    Requires >= 20 meeting_booked outcomes for statistical significance.
+    """
+    async with get_db_session() as db:
+        count = await count_meeting_booked_outcomes(db, customer_id)
+        return count >= MIN_OUTCOMES_THRESHOLD, count
+
+
+@task(name="cis-get-weights")
+async def get_current_weights() -> dict:
+    """
+    Fetch current weights from ceo_memory.
+
+    Weights are stored at ceo:propensity_weights_v3 in Supabase.
+    """
+    async with get_db_session() as db:
+        return await get_propensity_weights(db)
+
+
+@task(name="cis-claude-analysis")
+async def analyze_with_claude(
+    outcomes: list[dict],
+    weights: dict,
+) -> dict:
+    """
+    Run Claude analysis on outcomes.
+
+    Calls SiegeSDKIntelligence.analyze_cis_outcomes() which uses
+    Claude Sonnet 4 with a $2 AUD cost cap.
+    """
+    sdk = SiegeSDKIntelligence()
+    return await sdk.analyze_cis_outcomes(outcomes, weights)
+
+
+@task(name="cis-apply-deltas")
+async def apply_weight_deltas(
+    current_weights: dict,
+    adjustments: dict,
+    outcome_sample_size: int,
+    run_id: str,
+) -> dict:
+    """
+    Apply deltas to weights with ±5 cap.
+    Log all changes to cis_adjustment_log.
+
+    This task:
+    1. Iterates through proposed adjustments
+    2. Skips low confidence (<0.7) adjustments
+    3. Caps deltas at ±5 per signal
+    4. Logs every adjustment (applied or skipped) for audit
+    5. Returns updated weights dict
+    """
+    logger = get_run_logger()
+    updated_weights = json.loads(json.dumps(current_weights))  # Deep copy
+
+    async with get_db_session() as db:
+        for signal_name, adjustment in adjustments.items():
+            delta = adjustment.get("delta", 0)
+            confidence = adjustment.get("confidence", 0)
+            reasoning = adjustment.get("reasoning", "")
+
+            # Determine if this is a positive or negative signal
+            is_negative = signal_name in current_weights.get("negative", {})
+            weight_section = "negative" if is_negative else "weights"
+
+            # Get current weight
+            weight_before = current_weights.get(weight_section, {}).get(signal_name, 0)
+
+            # Skip low confidence adjustments
+            if confidence < 0.7:
+                await log_weight_adjustment(
+                    db=db,
+                    customer_id=None,  # Global weights
+                    signal_name=signal_name,
+                    weight_before=weight_before,
+                    delta_applied=0,
+                    weight_after=weight_before,
+                    confidence_score=confidence,
+                    outcome_sample_size=outcome_sample_size,
+                    skipped=True,
+                    skip_reason=f"Confidence {confidence:.2f} < 0.7 threshold",
+                    run_id=run_id,
+                )
+                logger.info(
+                    f"Skipped {signal_name}: confidence {confidence:.2f} < 0.7 "
+                    f"(reasoning: {reasoning})"
+                )
+                continue
+
+            # Cap delta at ±5
+            capped_delta = max(-MAX_DELTA_PER_RUN, min(MAX_DELTA_PER_RUN, delta))
+            if capped_delta != delta:
+                logger.info(
+                    f"Capped {signal_name} delta: {delta} → {capped_delta}"
+                )
+
+            # Calculate new weight
+            weight_after = weight_before + capped_delta
+
+            # Update weights dict
+            if weight_section not in updated_weights:
+                updated_weights[weight_section] = {}
+            updated_weights[weight_section][signal_name] = weight_after
+
+            # Log the adjustment
+            await log_weight_adjustment(
+                db=db,
+                customer_id=None,
+                signal_name=signal_name,
+                weight_before=weight_before,
+                delta_applied=capped_delta,
+                weight_after=weight_after,
+                confidence_score=confidence,
+                outcome_sample_size=outcome_sample_size,
+                skipped=False,
+                skip_reason=None,
+                run_id=run_id,
+            )
+
+            logger.info(
+                f"✓ Adjusted {signal_name}: {weight_before} + {capped_delta} = {weight_after} "
+                f"(confidence: {confidence:.2f}, reasoning: {reasoning})"
+            )
+
+    return updated_weights
+
+
+@task(name="cis-save-weights")
+async def save_updated_weights(weights: dict) -> bool:
+    """
+    Write updated weights back to ceo_memory.
+
+    Performs upsert to ceo:propensity_weights_v3 in Supabase.
+    """
+    async with get_db_session() as db:
+        result = await save_propensity_weights(db, weights)
+        return result.get("success", False)
+
+
+@task(name="cis-log-run-start")
+async def start_cis_run(
+    run_type: str = "weekly",
+    customer_id: str | None = None,
+) -> str:
+    """Log the start of a CIS run."""
+    async with get_db_session() as db:
+        return await log_cis_run_start(db, run_type, customer_id)
+
+
+@task(name="cis-log-run-complete")
+async def complete_cis_run(
+    run_id: str,
+    status: str,
+    outcomes_analyzed: int = 0,
+    adjustments_applied: int = 0,
+    summary: str = "",
+) -> bool:
+    """Log the completion of a CIS run."""
+    async with get_db_session() as db:
+        result = await log_cis_run_complete(
+            db, run_id, status, outcomes_analyzed, adjustments_applied, summary
+        )
+        return result.get("success", False)
+
+
+@flow(name="cis-learning-engine", log_prints=True)
+async def cis_learning_flow(
+    customer_id: str | None = None,
+    run_type: str = "weekly",
+):
+    """
+    CIS Learning Engine — Weekly weight adjustment.
+
+    Directive #147: Makes Agency OS smarter over time.
+    This is the moat.
+
+    The flow:
+    1. Checks threshold (need >= 20 MEETING_BOOKED outcomes)
+    2. Queries all outcomes since last run
+    3. Fetches current propensity weights from ceo_memory
+    4. Calls Claude Sonnet 4 to analyze patterns
+    5. Applies weight deltas (capped at ±5 per signal)
+    6. Saves updated weights back to ceo_memory
+    7. Logs everything to cis_adjustment_log for audit
+
+    Args:
+        customer_id: Optional customer filter (None = global weights)
+        run_type: Type of run (weekly, manual, triggered)
+
+    Returns:
+        Dict with status, outcomes_analyzed, adjustments_applied, summary
+    """
+    logger = get_run_logger()
+    logger.info("🧠 CIS Learning Engine starting...")
+    logger.info(f"   Run type: {run_type}")
+    logger.info(f"   Customer filter: {customer_id or 'global'}")
+
+    # Start run logging
+    run_id = await start_cis_run(run_type, customer_id)
+    logger.info(f"   Run ID: {run_id}")
+
+    # Step 1: Check threshold
+    has_enough, count = await check_threshold(customer_id)
+
+    if not has_enough:
+        logger.info(f"⏸️  CIS_PENDING — insufficient data ({count} < {MIN_OUTCOMES_THRESHOLD})")
+
+        await complete_cis_run(
+            run_id=run_id,
+            status="pending",
+            outcomes_analyzed=0,
+            adjustments_applied=0,
+            summary=f"Insufficient data: {count} meeting_booked outcomes (need {MIN_OUTCOMES_THRESHOLD})",
+        )
+
+        return {
+            "status": "pending",
+            "reason": "insufficient_data",
+            "count": count,
+            "threshold": MIN_OUTCOMES_THRESHOLD,
+            "run_id": run_id,
+        }
+
+    logger.info(f"✓ Threshold met: {count} MEETING_BOOKED outcomes")
+
+    # Step 2: Query outcomes
+    outcomes = await query_outcomes(customer_id)
+    logger.info(f"✓ Queried {len(outcomes)} total outcomes for analysis")
+
+    if not outcomes:
+        logger.warning("⚠️  No outcomes returned from query")
+        await complete_cis_run(
+            run_id=run_id,
+            status="failed",
+            summary="No outcomes returned from query",
+        )
+        return {
+            "status": "failed",
+            "reason": "no_outcomes",
+            "run_id": run_id,
+        }
+
+    # Step 3: Get current weights
+    current_weights = await get_current_weights()
+    logger.info(f"✓ Loaded current weights: {len(current_weights.get('weights', {}))} positive, "
+                f"{len(current_weights.get('negative', {}))} negative signals")
+
+    # Step 4: Claude analysis
+    logger.info("🔍 Running Claude analysis...")
+    try:
+        analysis = await analyze_with_claude(outcomes, current_weights)
+    except Exception as e:
+        logger.error(f"❌ Claude analysis failed: {e}")
+        await complete_cis_run(
+            run_id=run_id,
+            status="failed",
+            outcomes_analyzed=len(outcomes),
+            summary=f"Claude analysis failed: {str(e)}",
+        )
+        return {
+            "status": "failed",
+            "reason": "analysis_failed",
+            "error": str(e),
+            "run_id": run_id,
+        }
+
+    adjustments = analysis.get("adjustments", {})
+    summary = analysis.get("analysis_summary", "")
+
+    logger.info(f"✓ Analysis complete: {len(adjustments)} adjustments proposed")
+    logger.info(f"   Summary: {summary}")
+
+    # Step 5: Apply deltas
+    adjustments_applied = 0
+    if adjustments:
+        updated_weights = await apply_weight_deltas(
+            current_weights=current_weights,
+            adjustments=adjustments,
+            outcome_sample_size=len(outcomes),
+            run_id=run_id,
+        )
+
+        # Count applied adjustments (those that passed confidence threshold)
+        adjustments_applied = sum(
+            1 for adj in adjustments.values()
+            if adj.get("confidence", 0) >= 0.7
+        )
+
+        # Step 6: Save updated weights
+        if adjustments_applied > 0:
+            save_success = await save_updated_weights(updated_weights)
+            if save_success:
+                logger.info("✓ Weights updated in ceo_memory")
+            else:
+                logger.error("❌ Failed to save updated weights")
+                await complete_cis_run(
+                    run_id=run_id,
+                    status="failed",
+                    outcomes_analyzed=len(outcomes),
+                    adjustments_applied=adjustments_applied,
+                    summary=f"Failed to save weights. {summary}",
+                )
+                return {
+                    "status": "failed",
+                    "reason": "save_failed",
+                    "run_id": run_id,
+                }
+        else:
+            logger.info("ℹ️  No adjustments passed confidence threshold")
+    else:
+        logger.info("ℹ️  No adjustments proposed")
+
+    # Complete run logging
+    await complete_cis_run(
+        run_id=run_id,
+        status="complete",
+        outcomes_analyzed=len(outcomes),
+        adjustments_applied=adjustments_applied,
+        summary=summary,
+    )
+
+    logger.info("🎉 CIS Learning Engine complete!")
+    logger.info(f"   Outcomes analyzed: {len(outcomes)}")
+    logger.info(f"   Adjustments applied: {adjustments_applied}")
+
+    return {
+        "status": "complete",
+        "outcomes_analyzed": len(outcomes),
+        "meeting_booked_count": analysis.get("meeting_booked_count", count),
+        "adjustments_proposed": len(adjustments),
+        "adjustments_applied": adjustments_applied,
+        "summary": summary,
+        "run_id": run_id,
+    }
+
+
+# =========================================================================
+# MANUAL TRIGGER HELPER
+# =========================================================================
+
+
+async def run_cis_manually(customer_id: str | None = None):
+    """
+    Helper function to trigger CIS manually.
+
+    Usage:
+        import asyncio
+        from src.orchestration.flows.cis_learning_flow import run_cis_manually
+        asyncio.run(run_cis_manually())
+    """
+    return await cis_learning_flow(customer_id=customer_id, run_type="manual")
+
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(run_cis_manually())

--- a/src/services/cis_outcome_service.py
+++ b/src/services/cis_outcome_service.py
@@ -1,0 +1,485 @@
+"""
+Contract: src/services/cis_outcome_service.py
+Purpose: CIS Learning Engine outcome data access service
+Layer: 3 - services
+Imports: integrations
+Consumers: cis_learning_flow.py
+
+Directive #147: CIS Learning Engine data access layer.
+
+Provides data access functions for:
+- Querying outcomes since last CIS run
+- Counting meeting booked outcomes
+- Logging weight adjustments to cis_adjustment_log
+- Fetching/updating weights from ceo_memory
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.integrations.supabase import get_db_session
+
+logger = logging.getLogger(__name__)
+
+
+# =========================================================================
+# OUTCOME QUERIES
+# =========================================================================
+
+
+async def get_outcomes_since_last_run(
+    db: AsyncSession,
+    customer_id: str | None = None,
+    days_back: int = 7,
+) -> list[dict]:
+    """
+    Query outcomes for CIS analysis.
+
+    Fetches outcomes since the last CIS run or within days_back window.
+    Includes signals_active and propensity_at_send for each outcome.
+
+    Args:
+        db: Database session
+        customer_id: Optional customer filter (None = global)
+        days_back: Days to look back if no last run timestamp
+
+    Returns:
+        List of outcome dicts with signals_active, propensity_at_send, outcome_type
+    """
+    try:
+        # First, try to get last run timestamp from cis_run_log
+        last_run_query = text("""
+            SELECT MAX(completed_at) as last_run
+            FROM cis_run_log
+            WHERE status = 'complete'
+        """)
+        last_run_result = await db.execute(last_run_query)
+        last_run_row = last_run_result.fetchone()
+
+        if last_run_row and last_run_row.last_run:
+            since_date = last_run_row.last_run
+        else:
+            since_date = datetime.utcnow() - timedelta(days=days_back)
+
+        # Build the outcomes query
+        params: dict[str, Any] = {"since_date": since_date}
+
+        customer_filter = ""
+        if customer_id:
+            customer_filter = "AND o.client_id = :customer_id"
+            params["customer_id"] = customer_id
+
+        query = text(f"""
+            SELECT
+                o.id,
+                o.activity_id,
+                o.lead_id,
+                o.client_id,
+                o.channel,
+                o.als_score_at_send as propensity_at_send,
+                o.als_tier_at_send as tier_at_send,
+                o.final_outcome,
+                CASE
+                    WHEN o.meeting_booked_at IS NOT NULL THEN 'booked'
+                    WHEN o.replied_at IS NOT NULL THEN 'replied'
+                    WHEN o.opened_at IS NOT NULL THEN 'no_response'
+                    WHEN o.delivered_at IS NOT NULL THEN 'bounced'
+                    ELSE 'unknown'
+                END as outcome_type,
+                o.sent_at,
+                o.created_at,
+                -- Get signals_active from leads table
+                l.signals_active
+            FROM cis_outreach_outcomes o
+            LEFT JOIN leads l ON o.lead_id = l.id
+            WHERE o.sent_at >= :since_date
+            {customer_filter}
+            ORDER BY o.sent_at DESC
+            LIMIT 5000
+        """)
+
+        result = await db.execute(query, params)
+        rows = result.fetchall()
+
+        outcomes = []
+        for row in rows:
+            outcomes.append({
+                "id": str(row.id),
+                "activity_id": str(row.activity_id) if row.activity_id else None,
+                "lead_id": str(row.lead_id) if row.lead_id else None,
+                "client_id": str(row.client_id) if row.client_id else None,
+                "channel": row.channel,
+                "propensity_at_send": row.propensity_at_send,
+                "tier_at_send": row.tier_at_send,
+                "final_outcome": row.final_outcome,
+                "outcome_type": row.outcome_type,
+                "sent_at": row.sent_at.isoformat() if row.sent_at else None,
+                "signals_active": row.signals_active or [],
+            })
+
+        logger.info(f"CIS: Queried {len(outcomes)} outcomes since {since_date}")
+        return outcomes
+
+    except Exception as e:
+        logger.error(f"CIS: Failed to query outcomes: {e}")
+        return []
+
+
+async def count_meeting_booked_outcomes(
+    db: AsyncSession,
+    customer_id: str | None = None,
+    days_back: int = 7,
+) -> int:
+    """
+    Count MEETING_BOOKED outcomes for threshold check.
+
+    Args:
+        db: Database session
+        customer_id: Optional customer filter (None = global)
+        days_back: Days to look back
+
+    Returns:
+        Count of meeting_booked outcomes
+    """
+    try:
+        since_date = datetime.utcnow() - timedelta(days=days_back)
+        params: dict[str, Any] = {"since_date": since_date}
+
+        customer_filter = ""
+        if customer_id:
+            customer_filter = "AND client_id = :customer_id"
+            params["customer_id"] = customer_id
+
+        query = text(f"""
+            SELECT COUNT(*) as count
+            FROM cis_outreach_outcomes
+            WHERE meeting_booked_at IS NOT NULL
+            AND sent_at >= :since_date
+            {customer_filter}
+        """)
+
+        result = await db.execute(query, params)
+        row = result.fetchone()
+
+        count = row.count if row else 0
+        logger.info(f"CIS: Found {count} meeting_booked outcomes")
+        return count
+
+    except Exception as e:
+        logger.error(f"CIS: Failed to count meeting outcomes: {e}")
+        return 0
+
+
+# =========================================================================
+# WEIGHT ADJUSTMENT LOGGING
+# =========================================================================
+
+
+async def log_weight_adjustment(
+    db: AsyncSession,
+    customer_id: str | None,
+    signal_name: str,
+    weight_before: int,
+    delta_applied: int,
+    weight_after: int,
+    confidence_score: float,
+    outcome_sample_size: int,
+    skipped: bool = False,
+    skip_reason: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """
+    Log a weight adjustment to cis_adjustment_log.
+
+    Creates an audit trail of all CIS weight changes for compliance
+    and debugging.
+
+    Args:
+        db: Database session
+        customer_id: Customer ID (None = global weights)
+        signal_name: Name of the signal being adjusted
+        weight_before: Weight value before adjustment
+        delta_applied: Delta that was applied (0 if skipped)
+        weight_after: Weight value after adjustment
+        confidence_score: Claude's confidence score
+        outcome_sample_size: Number of outcomes analyzed
+        skipped: Whether adjustment was skipped
+        skip_reason: Reason for skipping (if applicable)
+        run_id: CIS run ID for grouping
+
+    Returns:
+        Dict with success status and log_id
+    """
+    try:
+        query = text("""
+            INSERT INTO cis_adjustment_log (
+                customer_id,
+                signal_name,
+                weight_before,
+                delta_applied,
+                weight_after,
+                confidence_score,
+                outcome_sample_size,
+                skipped,
+                skip_reason,
+                run_id,
+                created_at
+            ) VALUES (
+                :customer_id,
+                :signal_name,
+                :weight_before,
+                :delta_applied,
+                :weight_after,
+                :confidence_score,
+                :outcome_sample_size,
+                :skipped,
+                :skip_reason,
+                :run_id,
+                NOW()
+            )
+            RETURNING id
+        """)
+
+        result = await db.execute(query, {
+            "customer_id": customer_id,
+            "signal_name": signal_name,
+            "weight_before": weight_before,
+            "delta_applied": delta_applied,
+            "weight_after": weight_after,
+            "confidence_score": confidence_score,
+            "outcome_sample_size": outcome_sample_size,
+            "skipped": skipped,
+            "skip_reason": skip_reason,
+            "run_id": run_id,
+        })
+
+        row = result.fetchone()
+        await db.commit()
+
+        log_id = str(row.id) if row else None
+        action = "skipped" if skipped else "applied"
+        logger.info(
+            f"CIS: Logged adjustment for {signal_name}: "
+            f"{weight_before} → {weight_after} ({action})"
+        )
+
+        return {"success": True, "log_id": log_id}
+
+    except Exception as e:
+        logger.error(f"CIS: Failed to log weight adjustment: {e}")
+        return {"success": False, "error": str(e)}
+
+
+# =========================================================================
+# CEO MEMORY WEIGHT ACCESS
+# =========================================================================
+
+
+async def get_propensity_weights(db: AsyncSession) -> dict:
+    """
+    Fetch current propensity weights from ceo_memory.
+
+    Weights are stored at key 'ceo:propensity_weights_v3'.
+
+    Args:
+        db: Database session
+
+    Returns:
+        Weights dict with 'weights' and 'negative' sections
+    """
+    try:
+        query = text("""
+            SELECT value
+            FROM ceo_memory
+            WHERE key = 'ceo:propensity_weights_v3'
+        """)
+
+        result = await db.execute(query)
+        row = result.fetchone()
+
+        if row and row.value:
+            import json
+            weights = json.loads(row.value) if isinstance(row.value, str) else row.value
+            logger.info(f"CIS: Loaded propensity weights: {len(weights.get('weights', {}))} signals")
+            return weights
+
+        # Return default weights if not found
+        logger.warning("CIS: No weights found in ceo_memory, using defaults")
+        return {
+            "weights": {
+                "no_seo": 10,
+                "new_dm_6mo": 15,
+                "low_gmb_rating": 10,
+                "active_ad_spend": 15,
+                "growing_signals": 10,
+                "pain_point_post": 20,
+                "hiring_marketing": 10,
+                "outdated_website": 10,
+                "poor_digital_presence": 20,
+                "negative_marketing_review": 10,
+            },
+            "negative": {
+                "competitor": -25,
+                "enterprise_200plus": -15,
+                "large_internal_team": -20,
+                "recently_signed_agency": -15,
+            },
+        }
+
+    except Exception as e:
+        logger.error(f"CIS: Failed to get propensity weights: {e}")
+        return {"weights": {}, "negative": {}}
+
+
+async def save_propensity_weights(
+    db: AsyncSession,
+    weights: dict,
+) -> dict[str, Any]:
+    """
+    Save updated propensity weights to ceo_memory.
+
+    Performs an upsert to ceo:propensity_weights_v3.
+
+    Args:
+        db: Database session
+        weights: Updated weights dict
+
+    Returns:
+        Dict with success status
+    """
+    try:
+        import json
+
+        query = text("""
+            INSERT INTO ceo_memory (key, value, updated_at)
+            VALUES ('ceo:propensity_weights_v3', :value, NOW())
+            ON CONFLICT (key) DO UPDATE
+            SET value = :value, updated_at = NOW()
+            RETURNING key
+        """)
+
+        result = await db.execute(query, {
+            "value": json.dumps(weights),
+        })
+
+        await db.commit()
+
+        logger.info(f"CIS: Saved updated propensity weights")
+        return {"success": True}
+
+    except Exception as e:
+        logger.error(f"CIS: Failed to save propensity weights: {e}")
+        return {"success": False, "error": str(e)}
+
+
+# =========================================================================
+# CIS RUN LOGGING
+# =========================================================================
+
+
+async def log_cis_run_start(
+    db: AsyncSession,
+    run_type: str = "weekly",
+    customer_id: str | None = None,
+) -> str:
+    """
+    Log start of a CIS run.
+
+    Args:
+        db: Database session
+        run_type: Type of run (weekly, manual, etc.)
+        customer_id: Customer ID (None = global)
+
+    Returns:
+        Run ID
+    """
+    try:
+        query = text("""
+            INSERT INTO cis_run_log (
+                run_type,
+                customer_id,
+                status,
+                started_at,
+                created_at
+            ) VALUES (
+                :run_type,
+                :customer_id,
+                'running',
+                NOW(),
+                NOW()
+            )
+            RETURNING id
+        """)
+
+        result = await db.execute(query, {
+            "run_type": run_type,
+            "customer_id": customer_id,
+        })
+
+        row = result.fetchone()
+        await db.commit()
+
+        run_id = str(row.id) if row else None
+        logger.info(f"CIS: Started run {run_id} (type={run_type})")
+        return run_id
+
+    except Exception as e:
+        logger.error(f"CIS: Failed to log run start: {e}")
+        return ""
+
+
+async def log_cis_run_complete(
+    db: AsyncSession,
+    run_id: str,
+    status: str,
+    outcomes_analyzed: int = 0,
+    adjustments_applied: int = 0,
+    summary: str = "",
+) -> dict[str, Any]:
+    """
+    Log completion of a CIS run.
+
+    Args:
+        db: Database session
+        run_id: Run ID from log_cis_run_start
+        status: Final status (complete, pending, failed)
+        outcomes_analyzed: Number of outcomes analyzed
+        adjustments_applied: Number of adjustments applied
+        summary: Analysis summary
+
+    Returns:
+        Dict with success status
+    """
+    try:
+        query = text("""
+            UPDATE cis_run_log
+            SET
+                status = :status,
+                completed_at = NOW(),
+                outcomes_analyzed = :outcomes_analyzed,
+                adjustments_applied = :adjustments_applied,
+                summary = :summary
+            WHERE id = :run_id
+        """)
+
+        await db.execute(query, {
+            "run_id": run_id,
+            "status": status,
+            "outcomes_analyzed": outcomes_analyzed,
+            "adjustments_applied": adjustments_applied,
+            "summary": summary,
+        })
+
+        await db.commit()
+
+        logger.info(f"CIS: Completed run {run_id} (status={status})")
+        return {"success": True}
+
+    except Exception as e:
+        logger.error(f"CIS: Failed to log run completion: {e}")
+        return {"success": False, "error": str(e)}

--- a/supabase/migrations/076_cis_learning_engine.sql
+++ b/supabase/migrations/076_cis_learning_engine.sql
@@ -1,0 +1,122 @@
+-- ============================================================================
+-- Migration: 076_cis_learning_engine.sql
+-- Directive #147: CIS Learning Engine tables
+-- Purpose: Store weight adjustments and run logs for continuous improvement
+-- ============================================================================
+
+-- CIS Adjustment Log: Audit trail of all weight changes
+CREATE TABLE IF NOT EXISTS cis_adjustment_log (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    customer_id UUID REFERENCES customers(id) ON DELETE CASCADE,  -- NULL = global weights
+    signal_name TEXT NOT NULL,
+    weight_before INTEGER NOT NULL,
+    delta_applied INTEGER NOT NULL,
+    weight_after INTEGER NOT NULL,
+    confidence_score NUMERIC(4,3) NOT NULL,  -- 0.000 to 1.000
+    outcome_sample_size INTEGER NOT NULL,
+    skipped BOOLEAN DEFAULT FALSE,
+    skip_reason TEXT,
+    run_id UUID,  -- Links to cis_run_log
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- CIS Run Log: Track each CIS execution
+CREATE TABLE IF NOT EXISTS cis_run_log (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    run_type TEXT NOT NULL DEFAULT 'weekly',  -- weekly, manual, triggered
+    customer_id UUID REFERENCES customers(id) ON DELETE CASCADE,  -- NULL = global
+    status TEXT NOT NULL DEFAULT 'pending',  -- pending, running, complete, failed
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    outcomes_analyzed INTEGER DEFAULT 0,
+    adjustments_applied INTEGER DEFAULT 0,
+    summary TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Add foreign key from adjustment_log to run_log
+ALTER TABLE cis_adjustment_log
+    ADD CONSTRAINT fk_cis_adjustment_run
+    FOREIGN KEY (run_id) REFERENCES cis_run_log(id) ON DELETE SET NULL;
+
+-- Indexes for efficient queries
+CREATE INDEX IF NOT EXISTS idx_cis_adjustment_log_signal
+    ON cis_adjustment_log(signal_name);
+
+CREATE INDEX IF NOT EXISTS idx_cis_adjustment_log_created
+    ON cis_adjustment_log(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cis_adjustment_log_run
+    ON cis_adjustment_log(run_id);
+
+CREATE INDEX IF NOT EXISTS idx_cis_adjustment_log_customer
+    ON cis_adjustment_log(customer_id)
+    WHERE customer_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_cis_run_log_status
+    ON cis_run_log(status);
+
+CREATE INDEX IF NOT EXISTS idx_cis_run_log_completed
+    ON cis_run_log(completed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cis_run_log_customer
+    ON cis_run_log(customer_id)
+    WHERE customer_id IS NOT NULL;
+
+-- Add signals_active column to leads table if not exists
+-- This stores the active buyer signals for propensity calculation
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'leads' AND column_name = 'signals_active'
+    ) THEN
+        ALTER TABLE leads ADD COLUMN signals_active JSONB DEFAULT '[]'::JSONB;
+    END IF;
+END $$;
+
+-- Create index on signals_active for CIS queries
+CREATE INDEX IF NOT EXISTS idx_leads_signals_active
+    ON leads USING GIN (signals_active);
+
+-- Ensure ceo_memory table exists for propensity weights storage
+CREATE TABLE IF NOT EXISTS ceo_memory (
+    key TEXT PRIMARY KEY,
+    value JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Insert default propensity weights if not exists
+INSERT INTO ceo_memory (key, value)
+VALUES (
+    'ceo:propensity_weights_v3',
+    '{
+        "weights": {
+            "no_seo": 10,
+            "new_dm_6mo": 15,
+            "low_gmb_rating": 10,
+            "active_ad_spend": 15,
+            "growing_signals": 10,
+            "pain_point_post": 20,
+            "hiring_marketing": 10,
+            "outdated_website": 10,
+            "poor_digital_presence": 20,
+            "negative_marketing_review": 10
+        },
+        "negative": {
+            "competitor": -25,
+            "enterprise_200plus": -15,
+            "large_internal_team": -20,
+            "recently_signed_agency": -15
+        }
+    }'::JSONB
+)
+ON CONFLICT (key) DO NOTHING;
+
+-- Comments for documentation
+COMMENT ON TABLE cis_adjustment_log IS 'Directive #147: Audit trail of CIS weight adjustments';
+COMMENT ON TABLE cis_run_log IS 'Directive #147: CIS Learning Engine execution history';
+COMMENT ON COLUMN cis_adjustment_log.confidence_score IS 'Claude analysis confidence (0.0-1.0), adjustments < 0.7 are skipped';
+COMMENT ON COLUMN cis_adjustment_log.skip_reason IS 'Reason for skipping adjustment (low confidence, etc.)';
+COMMENT ON COLUMN cis_run_log.run_type IS 'weekly (scheduled), manual (on-demand), triggered (event-based)';


### PR DESCRIPTION
## Directive #147 — CIS Learning Engine

**The moat.** This is the learning loop that makes Agency OS smarter over time.

### Components

| File | Purpose |
|------|---------|
| `sdk_brain.py` | Claude Sonnet 4 analysis of outcome patterns |
| `cis_outcome_service.py` | Outcome queries + audit logging |
| `cis_learning_flow.py` | Weekly Prefect flow |
| `cis_learning_deployment.py` | Prefect deployment (Sundays 3 AM UTC) |
| `076_cis_learning_engine.sql` | Supabase migration |

### Architecture

1. **Trigger:** Weekly per active customer
2. **Threshold:** ≥20 MEETING_BOOKED outcomes required
3. **Analysis:** Claude identifies signal patterns in converters vs non-converters
4. **Constraints:**
   - Max ±5 points per signal per run
   - Confidence ≥0.7 required
   - $2 USD cost cap per analysis
5. **Audit:** Full trail in `cis_adjustment_log`

### Proprietary Protection

- Weights stored in `ceo:propensity_weights_v3` only
- **Never in code**
- **Never exposed via API**
- Agency sees priority_rank + plain-English reason only

### Governance

- LAW I-A: SSOT verified before build
- LAW V: data-1 + build-2 sub-agents
- LAW VI: MCP-first for Supabase

### Deployment

```bash
# Apply migration
supabase db push

# Deploy Prefect flow
python src/orchestration/deployments/cis_learning_deployment.py

# Manual trigger
prefect deployment run 'cis-learning-engine/cis-manual'
```

Dave merges.