### PR TITLE
Directive #177: Wire meeting/voice → CIS bridge

### DIFF
--- a/src/services/meeting_service.py
+++ b/src/services/meeting_service.py
@@ -204,6 +204,46 @@ class MeetingService:
             logger.error(f"CRM push failed for meeting {row.id}: {e}")
             meeting_data["crm_push_error"] = str(e)
 
+        # Directive #177: CIS bridge — wire meeting booking into CIS learning (non-blocking)
+        try:
+            from src.services.cis_outcome_service import process_conversion_timing
+            from src.services.cis_service import CISService
+
+            # Fetch lead propensity data for CIS tier conversion record
+            prop_result = await self.session.execute(
+                text("SELECT als_score, als_tier FROM leads WHERE id = :lead_id"),
+                {"lead_id": lead_id},
+            )
+            prop_row = prop_result.fetchone()
+
+            cis = CISService(self.session)
+
+            # 1. Mark the converting activity as meeting_booked in cis_outreach_outcomes
+            if converting_activity_id:
+                await cis.update_outreach_outcome(
+                    activity_id=converting_activity_id,
+                    event_type="meeting_booked",
+                )
+                # 2. Extract and record timing signals for this conversion
+                await process_conversion_timing(self.session, str(converting_activity_id))
+
+            # 3. Record propensity tier conversion for CIS learning
+            if prop_row and prop_row.als_score is not None:
+                await cis.record_propensity_conversion(
+                    lead_id=lead_id,
+                    client_id=client_id,
+                    propensity_score=prop_row.als_score,
+                    propensity_tier=prop_row.als_tier or "cold",
+                    channel_that_converted=converting_channel or "unknown",
+                    campaign_id=campaign_id,
+                    touches_before_conversion=touches_before,
+                    days_in_sequence=days_to_booking,
+                )
+
+            logger.info(f"CIS bridge: recorded meeting_booked for meeting {row.id}")
+        except Exception as e:
+            logger.warning(f"CIS bridge failed (non-blocking): {e}")
+
         return meeting_data
 
     async def create_blind_meeting(

--- a/src/services/voice_post_call_processor.py
+++ b/src/services/voice_post_call_processor.py
@@ -1169,6 +1169,54 @@ Return JSON classification only."""
             # Non-critical - log and continue
             logger.warning(f"Failed to write CIS feed: {e}")
 
+        # Directive #177: Wire voice call outcomes into cis_outreach_outcomes (non-blocking)
+        # voice_sync_tasks creates activity records with provider_message_id = voice_call.id
+        try:
+            from src.services.cis_service import CISService
+
+            # Map voice outcomes to CIS event types
+            _cis_event_map = {
+                CallOutcome.BOOKED: "meeting_booked",
+                CallOutcome.UNSUBSCRIBE: "unsubscribed",
+                CallOutcome.ANGRY: "complained",
+            }
+            cis_event = _cis_event_map.get(outcome)
+
+            if cis_event:
+                # Find the activity created by voice_sync_tasks for this call
+                act_result = await self.session.execute(
+                    text("""
+                        SELECT a.id
+                        FROM activities a
+                        JOIN voice_calls vc ON a.provider_message_id = vc.id::text
+                        WHERE vc.call_sid = :call_sid
+                          AND a.channel = 'voice'
+                        ORDER BY a.created_at DESC
+                        LIMIT 1
+                    """),
+                    {"call_sid": call_sid},
+                )
+                act_row = act_result.fetchone()
+
+                if act_row:
+                    cis = CISService(self.session)
+                    await cis.update_outreach_outcome(
+                        activity_id=act_row.id,
+                        event_type=cis_event,
+                    )
+                    logger.info(
+                        f"CIS voice bridge: recorded {cis_event} for call {call_sid} "
+                        f"(activity {act_row.id})"
+                    )
+                else:
+                    logger.debug(
+                        f"CIS voice bridge: no activity found yet for call {call_sid} "
+                        f"(voice_sync_tasks may not have run yet)"
+                    )
+        except Exception as e:
+            # CIS failure must NOT block voice operations
+            logger.warning(f"CIS voice bridge failed (non-blocking): {e}")
+
     # =========================================================================
     # HELPER METHODS
     # =========================================================================


### PR DESCRIPTION
## Summary
Closes the CIS feedback loop. Audit (Directive #176) confirmed all CIS infrastructure is built and deployed but receiving zero data because meeting_service.py never called CIS on booking confirmation.

## Changes
### meeting_service.py
- Added CIS bridge calls at meeting confirmation point (inside `create()`, after CRM push)
- `update_outreach_outcome(converting_activity_id, 'meeting_booked')`
- `record_propensity_conversion()` with lead propensity data (als_score, als_tier)
- `process_conversion_timing()` with timing signals
- All wrapped in try/except — CIS failure does NOT block meeting creation

### voice_post_call_processor.py
- Enhanced `_write_cis_feed()` to also update `cis_outreach_outcomes` for voice calls
- Maps BOOKED → `meeting_booked`, UNSUBSCRIBE → `unsubscribed`, ANGRY → `complained`
- Looks up voice activity via `activities.provider_message_id = voice_call.id` (synced by voice_sync_tasks)
- Same non-blocking pattern with try/except

## Impact
- CIS Learning Engine (runs Sunday 3AM UTC) will now have data
- After 20 meeting_booked outcomes: propensity weights begin adjusting
- Zero risk to meeting creation flow (all CIS calls non-blocking)

## Verification
- pytest: 719 passed, 22 skipped, 0 failed ✅
- Import checks: OK ✅
- grep confirms bridge calls in place ✅