### PR TITLE
Directive #183: Onboarding ICP confirm + leads progress states

### DIFF
--- a/frontend/app/dashboard/leads/page.tsx
+++ b/frontend/app/dashboard/leads/page.tsx
@@ -6,9 +6,12 @@
  * SPRINT: Dashboard Sprint 2 - Step 6/8 Animated Lead Scoreboard
  * SSOT: lead_scoreboard_vision (ffd41389-645a-47c8-91d6-017b6cebe7ae)
  * THEME: Bloomberg Terminal dark mode (charcoal #0C0A08, amber #D4956A)
+ *
+ * DIRECTIVE #183 — Added onboarding progress states + auto-poll
  */
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import { motion, AnimatePresence, LayoutGroup } from "framer-motion";
 import Link from "next/link";
 import { AppShell } from "@/components/layout/AppShell";
@@ -27,15 +30,23 @@ import {
   Moon,
   Snowflake,
   ArrowUpDown,
+  Loader2,
+  CheckCircle2,
+  Sparkles,
 } from "lucide-react";
 
 // Tier filter type
 type TierFilter = "all" | "hot" | "warm" | "cool" | "cold";
 
+// Onboarding progress stages
+const ONBOARDING_STAGES = [
+  { label: "Discovering prospects in your market...", minSec: 0, maxSec: 30 },
+  { label: "Enriching company data...", minSec: 30, maxSec: 90 },
+  { label: "Scoring leads with AI...", minSec: 90, maxSec: 150 },
+];
+
 /**
  * Derive a 0–100 enrichment depth from available Lead fields.
- * - Basic fields (10 total) contribute up to 70 points.
- * - sdk_enrichment presence adds 30 points.
  */
 function getEnrichmentDepth(lead: Lead): number {
   const fields = [
@@ -60,18 +71,85 @@ function getEnrichmentDepth(lead: Lead): number {
 function getLeadTierFilter(lead: Lead): TierFilter {
   if (lead.propensity_tier === "dead") return "cold";
   if (lead.propensity_tier) return lead.propensity_tier as TierFilter;
-  // Fall back to score-based tier
   const score = lead.propensity_score ?? 0;
   return getALSTier(score) as TierFilter;
 }
 
 export default function LeadsScoreboardPage() {
+  const searchParams = useSearchParams();
+  const isOnboarding = searchParams.get("onboarding") === "true";
+
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTier, setSelectedTier] = useState<TierFilter>("all");
   const [sortAscending, setSortAscending] = useState(false);
 
+  // Onboarding progress state
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [pipelineReady, setPipelineReady] = useState(false);
+  const elapsedRef = useRef<NodeJS.Timeout | null>(null);
+  const pollRef = useRef<NodeJS.Timeout | null>(null);
+
   // Fetch real leads data
-  const { leads, total, isLoading, error } = useLeads({ page_size: 100 });
+  const { leads, total, isLoading, error, refresh } = useLeads({
+    page_size: 100,
+  });
+
+  // When onboarding mode: tick elapsed seconds + poll every 10s for leads
+  useEffect(() => {
+    if (!isOnboarding) return;
+
+    // Start elapsed timer
+    elapsedRef.current = setInterval(() => {
+      setElapsedSeconds((s) => s + 1);
+    }, 1000);
+
+    // Poll for leads every 10s
+    pollRef.current = setInterval(() => {
+      refresh();
+    }, 10_000);
+
+    return () => {
+      if (elapsedRef.current) clearInterval(elapsedRef.current);
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [isOnboarding, refresh]);
+
+  // When leads appear in onboarding mode, mark pipeline ready + stop timers
+  useEffect(() => {
+    if (isOnboarding && leads.length > 0 && !pipelineReady) {
+      setPipelineReady(true);
+      if (elapsedRef.current) clearInterval(elapsedRef.current);
+      if (pollRef.current) clearInterval(pollRef.current);
+    }
+  }, [isOnboarding, leads.length, pipelineReady]);
+
+  // Determine current onboarding stage
+  const currentStageIndex = useMemo(() => {
+    if (pipelineReady) return -1; // done
+    for (let i = ONBOARDING_STAGES.length - 1; i >= 0; i--) {
+      if (elapsedSeconds >= ONBOARDING_STAGES[i].minSec) return i;
+    }
+    return 0;
+  }, [elapsedSeconds, pipelineReady]);
+
+  // Progress percentage within current stage (for animated bar)
+  const stageProgress = useMemo(() => {
+    if (pipelineReady) return 100;
+    const stage = ONBOARDING_STAGES[currentStageIndex];
+    if (!stage) return 0;
+    const range = stage.maxSec - stage.minSec;
+    const within = elapsedSeconds - stage.minSec;
+    // Stage fills to 90% max (leaves room until real data arrives)
+    return Math.min(90, Math.round((within / range) * 100));
+  }, [elapsedSeconds, currentStageIndex, pipelineReady]);
+
+  // Overall progress (0-100) across all stages
+  const overallProgress = useMemo(() => {
+    if (pipelineReady) return 100;
+    const totalDuration =
+      ONBOARDING_STAGES[ONBOARDING_STAGES.length - 1].maxSec;
+    return Math.min(95, Math.round((elapsedSeconds / totalDuration) * 100));
+  }, [elapsedSeconds, pipelineReady]);
 
   // Calculate stats from real data
   const stats = useMemo(() => {
@@ -90,7 +168,6 @@ export default function LeadsScoreboardPage() {
                 leads.length
             )
           : 0,
-      // TODO: wire meetingsBooked per lead when available
       meetingsBooked: 0,
       hot: leads.filter((l) => getLeadTierFilter(l) === "hot").length,
       warm: leads.filter((l) => getLeadTierFilter(l) === "warm").length,
@@ -102,29 +179,25 @@ export default function LeadsScoreboardPage() {
   // Filter and sort leads
   const sortedLeads = useMemo(() => {
     const filtered = leads.filter((lead) => {
-      const name = [lead.first_name, lead.last_name]
-        .filter(Boolean)
-        .join(" ");
+      const name = [lead.first_name, lead.last_name].filter(Boolean).join(" ");
       const matchesSearch =
         name.toLowerCase().includes(searchQuery.toLowerCase()) ||
         (lead.company ?? "").toLowerCase().includes(searchQuery.toLowerCase()) ||
         lead.email.toLowerCase().includes(searchQuery.toLowerCase());
-
       const tier = getLeadTierFilter(lead);
       const matchesTier = selectedTier === "all" || tier === selectedTier;
-
       return matchesSearch && matchesTier;
     });
-
-    // Sort by ALS score (descending by default = leaderboard style)
     filtered.sort((a, b) => {
       const aScore = a.propensity_score ?? 0;
       const bScore = b.propensity_score ?? 0;
       return sortAscending ? aScore - bScore : bScore - aScore;
     });
-
     return filtered;
   }, [leads, searchQuery, selectedTier, sortAscending]);
+
+  // ── Show onboarding progress when ?onboarding=true and no leads yet ──
+  const showOnboardingProgress = isOnboarding && leads.length === 0 && !pipelineReady;
 
   return (
     <AppShell pageTitle="Lead Scoreboard">
@@ -138,7 +211,10 @@ export default function LeadsScoreboardPage() {
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 className="px-3 py-1 rounded-md font-mono text-sm font-semibold"
-                style={{ backgroundColor: "rgba(212, 149, 106, 0.15)", color: "#D4956A" }}
+                style={{
+                  backgroundColor: "rgba(212, 149, 106, 0.15)",
+                  color: "#D4956A",
+                }}
               >
                 LIVE
               </motion.span>
@@ -162,6 +238,162 @@ export default function LeadsScoreboardPage() {
             </button>
           </div>
         </div>
+
+        {/* ── ONBOARDING PROGRESS BANNER ── */}
+        <AnimatePresence>
+          {showOnboardingProgress && (
+            <motion.div
+              initial={{ opacity: 0, y: -12 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -12 }}
+              transition={{ duration: 0.4 }}
+              className="rounded-2xl p-6 space-y-5"
+              style={{
+                background:
+                  "linear-gradient(135deg, rgba(212, 149, 106, 0.08) 0%, rgba(16, 185, 129, 0.05) 100%)",
+                border: "1px solid rgba(212, 149, 106, 0.25)",
+              }}
+            >
+              {/* Top row */}
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div
+                    className="w-9 h-9 rounded-xl flex items-center justify-center"
+                    style={{
+                      backgroundColor: "rgba(212, 149, 106, 0.15)",
+                    }}
+                  >
+                    <Sparkles className="w-5 h-5 text-accent-primary" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold text-text-primary">
+                      Building your pipeline
+                    </p>
+                    <p className="text-xs text-text-muted">
+                      Maya is sourcing leads based on your ICP
+                    </p>
+                  </div>
+                </div>
+                <span className="font-mono text-sm text-accent-primary font-semibold">
+                  {overallProgress}%
+                </span>
+              </div>
+
+              {/* Overall progress bar */}
+              <div
+                className="w-full h-2 rounded-full overflow-hidden"
+                style={{ backgroundColor: "rgba(255,255,255,0.06)" }}
+              >
+                <motion.div
+                  className="h-full rounded-full"
+                  style={{
+                    background:
+                      "linear-gradient(90deg, #D4956A 0%, #10B981 100%)",
+                  }}
+                  initial={{ width: "5%" }}
+                  animate={{ width: `${overallProgress}%` }}
+                  transition={{ duration: 1, ease: "easeOut" }}
+                />
+              </div>
+
+              {/* Stage steps */}
+              <div className="space-y-3">
+                {ONBOARDING_STAGES.map((stage, i) => {
+                  const isDone = i < currentStageIndex;
+                  const isActive = i === currentStageIndex;
+                  return (
+                    <div key={i} className="flex items-center gap-3">
+                      <div
+                        className="w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0"
+                        style={{
+                          backgroundColor: isDone
+                            ? "rgba(16, 185, 129, 0.2)"
+                            : isActive
+                            ? "rgba(212, 149, 106, 0.2)"
+                            : "rgba(255,255,255,0.05)",
+                        }}
+                      >
+                        {isDone ? (
+                          <CheckCircle2 className="w-3.5 h-3.5 text-status-success" />
+                        ) : isActive ? (
+                          <motion.div
+                            animate={{ rotate: 360 }}
+                            transition={{
+                              repeat: Infinity,
+                              duration: 1,
+                              ease: "linear",
+                            }}
+                          >
+                            <Loader2 className="w-3.5 h-3.5 text-accent-primary" />
+                          </motion.div>
+                        ) : (
+                          <div className="w-2 h-2 rounded-full bg-text-muted" />
+                        )}
+                      </div>
+                      <span
+                        className="text-sm transition-colors duration-300"
+                        style={{
+                          color: isDone
+                            ? "#10B981"
+                            : isActive
+                            ? "#D4956A"
+                            : "#6B6560",
+                        }}
+                      >
+                        {stage.label}
+                      </span>
+                      {isActive && (
+                        <motion.span
+                          className="ml-auto text-xs text-text-muted font-mono"
+                          initial={{ opacity: 0 }}
+                          animate={{ opacity: 1 }}
+                        >
+                          {stageProgress}%
+                        </motion.span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+
+              <p className="text-xs text-text-muted text-center">
+                Auto-refreshing every 10 seconds · this usually takes 2–3 minutes
+              </p>
+            </motion.div>
+          )}
+
+          {/* Pipeline ready celebration */}
+          {isOnboarding && pipelineReady && leads.length > 0 && (
+            <motion.div
+              key="ready"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.5 }}
+              className="rounded-2xl p-5 flex items-center gap-4"
+              style={{
+                background:
+                  "linear-gradient(135deg, rgba(16, 185, 129, 0.1) 0%, rgba(16, 185, 129, 0.05) 100%)",
+                border: "1px solid rgba(16, 185, 129, 0.3)",
+              }}
+            >
+              <div
+                className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+                style={{ backgroundColor: "rgba(16, 185, 129, 0.15)" }}
+              >
+                <CheckCircle2 className="w-6 h-6 text-status-success" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-status-success">
+                  Your pipeline is ready!
+                </p>
+                <p className="text-xs text-text-muted mt-0.5">
+                  {leads.length} leads discovered and scored for you
+                </p>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         {/* Split-Flap Counter Bar */}
         <SplitFlapCounterBar
@@ -187,7 +419,7 @@ export default function LeadsScoreboardPage() {
               }}
             />
           </div>
-          
+
           {/* Sort Toggle */}
           <button
             onClick={() => setSortAscending(!sortAscending)}
@@ -198,17 +430,28 @@ export default function LeadsScoreboardPage() {
           </button>
 
           {/* Tier Filter Tabs */}
-          <div 
-            className="flex rounded-lg overflow-hidden" 
-            style={{ backgroundColor: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)" }}
+          <div
+            className="flex rounded-lg overflow-hidden"
+            style={{
+              backgroundColor: "rgba(255,255,255,0.03)",
+              border: "1px solid rgba(255,255,255,0.08)",
+            }}
           >
-            {([
-              { key: "all" as const, label: "All", icon: null, count: stats.total, color: undefined },
-              { key: "hot" as const, label: "Hot", icon: <Flame className="w-4 h-4" />, count: stats.hot, color: "#D4956A" },
-              { key: "warm" as const, label: "Warm", icon: <Zap className="w-4 h-4" />, count: stats.warm, color: "#EAB308" },
-              { key: "cool" as const, label: "Cool", icon: <Moon className="w-4 h-4" />, count: stats.cool, color: "#6B7280" },
-              { key: "cold" as const, label: "Cold", icon: <Snowflake className="w-4 h-4" />, count: stats.cold, color: "#374151" },
-            ]).map(({ key, label, icon, count, color }) => (
+            {(
+              [
+                { key: "all" as const, label: "All", icon: null, count: stats.total, color: undefined },
+                { key: "hot" as const, label: "Hot", icon: <Flame className="w-4 h-4" />, count: stats.hot, color: "#D4956A" },
+                { key: "warm" as const, label: "Warm", icon: <Zap className="w-4 h-4" />, count: stats.warm, color: "#EAB308" },
+                { key: "cool" as const, label: "Cool", icon: <Moon className="w-4 h-4" />, count: stats.cool, color: "#6B7280" },
+                { key: "cold" as const, label: "Cold", icon: <Snowflake className="w-4 h-4" />, count: stats.cold, color: "#374151" },
+              ] as Array<{
+                key: TierFilter;
+                label: string;
+                icon: React.ReactNode | null;
+                count: number;
+                color: string | undefined;
+              }>
+            ).map(({ key, label, icon, count, color }) => (
               <button
                 key={key}
                 onClick={() => setSelectedTier(key)}
@@ -221,8 +464,8 @@ export default function LeadsScoreboardPage() {
               >
                 {icon}
                 {label}
-                <span 
-                  className="text-xs font-mono px-1.5 py-0.5 rounded" 
+                <span
+                  className="text-xs font-mono px-1.5 py-0.5 rounded"
                   style={{ backgroundColor: "rgba(255,255,255,0.06)" }}
                 >
                   {count}
@@ -240,14 +483,22 @@ export default function LeadsScoreboardPage() {
           transition={{ duration: 0.5 }}
         >
           {/* Leaderboard Header */}
-          <div 
+          <div
             className="flex items-center gap-4 px-5 py-3 mb-4 rounded-xl"
             style={{ backgroundColor: "rgba(255,255,255,0.02)" }}
           >
-            <span className="w-8 text-xs font-semibold text-text-muted uppercase tracking-wider">#</span>
-            <span className="w-16 text-xs font-semibold text-text-muted uppercase tracking-wider">Score</span>
-            <span className="flex-1 text-xs font-semibold text-text-muted uppercase tracking-wider">Lead</span>
-            <span className="w-24 text-xs font-semibold text-text-muted uppercase tracking-wider">Enrichment</span>
+            <span className="w-8 text-xs font-semibold text-text-muted uppercase tracking-wider">
+              #
+            </span>
+            <span className="w-16 text-xs font-semibold text-text-muted uppercase tracking-wider">
+              Score
+            </span>
+            <span className="flex-1 text-xs font-semibold text-text-muted uppercase tracking-wider">
+              Lead
+            </span>
+            <span className="w-24 text-xs font-semibold text-text-muted uppercase tracking-wider">
+              Enrichment
+            </span>
             <span className="w-12"></span>
           </div>
 
@@ -280,9 +531,10 @@ export default function LeadsScoreboardPage() {
                 {sortedLeads.length > 0 ? (
                   <div className="space-y-2">
                     {sortedLeads.map((lead, index) => {
-                      const name = [lead.first_name, lead.last_name]
-                        .filter(Boolean)
-                        .join(" ") || lead.email;
+                      const name =
+                        [lead.first_name, lead.last_name]
+                          .filter(Boolean)
+                          .join(" ") || lead.email;
                       return (
                         <LeadScoreboardRow
                           key={lead.id}
@@ -299,14 +551,81 @@ export default function LeadsScoreboardPage() {
                       );
                     })}
                   </div>
-                ) : (
+                ) : !showOnboardingProgress ? (
                   <motion.div
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     className="text-center py-12"
                   >
-                    <p className="text-text-muted">No leads match your filters</p>
+                    <p className="text-text-muted">
+                      {searchQuery || selectedTier !== "all"
+                        ? "No leads match your filters"
+                        : "No leads yet"}
+                    </p>
                   </motion.div>
+                ) : (
+                  // Skeleton rows while onboarding is in progress
+                  <div className="space-y-3">
+                    {[...Array(5)].map((_, i) => (
+                      <motion.div
+                        key={i}
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: [0.3, 0.6, 0.3] }}
+                        transition={{
+                          repeat: Infinity,
+                          duration: 1.5,
+                          delay: i * 0.15,
+                        }}
+                        className="flex items-center gap-4 px-5 py-4 rounded-xl"
+                        style={{
+                          backgroundColor: "rgba(255,255,255,0.02)",
+                        }}
+                      >
+                        <div
+                          className="w-8 h-4 rounded"
+                          style={{
+                            backgroundColor: "rgba(255,255,255,0.06)",
+                          }}
+                        />
+                        <div
+                          className="w-16 h-4 rounded"
+                          style={{
+                            backgroundColor: "rgba(255,255,255,0.06)",
+                          }}
+                        />
+                        <div className="flex-1 flex items-center gap-3">
+                          <div
+                            className="w-8 h-8 rounded-full"
+                            style={{
+                              backgroundColor: "rgba(255,255,255,0.06)",
+                            }}
+                          />
+                          <div className="space-y-1.5">
+                            <div
+                              className="h-3 rounded"
+                              style={{
+                                width: `${100 + i * 30}px`,
+                                backgroundColor: "rgba(255,255,255,0.06)",
+                              }}
+                            />
+                            <div
+                              className="h-2.5 rounded"
+                              style={{
+                                width: `${70 + i * 20}px`,
+                                backgroundColor: "rgba(255,255,255,0.04)",
+                              }}
+                            />
+                          </div>
+                        </div>
+                        <div
+                          className="w-24 h-2 rounded-full"
+                          style={{
+                            backgroundColor: "rgba(255,255,255,0.06)",
+                          }}
+                        />
+                      </motion.div>
+                    ))}
+                  </div>
                 )}
               </AnimatePresence>
             </LayoutGroup>
@@ -316,12 +635,21 @@ export default function LeadsScoreboardPage() {
         {/* Footer Stats */}
         <div className="flex items-center justify-between text-sm text-text-muted">
           <p>
-            Showing <span className="font-mono font-medium text-text-secondary">{sortedLeads.length}</span> of{" "}
-            <span className="font-mono font-medium text-text-secondary">{stats.total}</span> leads
+            Showing{" "}
+            <span className="font-mono font-medium text-text-secondary">
+              {sortedLeads.length}
+            </span>{" "}
+            of{" "}
+            <span className="font-mono font-medium text-text-secondary">
+              {stats.total}
+            </span>{" "}
+            leads
           </p>
           <p className="flex items-center gap-2">
             <span className="w-2 h-2 rounded-full bg-status-success animate-pulse" />
-            Live updates enabled
+            {isOnboarding && !pipelineReady
+              ? "Sourcing in progress..."
+              : "Live updates enabled"}
           </p>
         </div>
       </div>

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -2,30 +2,77 @@
 
 /**
  * FILE: frontend/app/onboarding/page.tsx
- * PURPOSE: Agency onboarding flow - website URL + integrations
+ * PURPOSE: Agency onboarding flow - website URL + integrations + ICP review
  * SPRINT: Dashboard Sprint 1 - Onboarding Port
  * SSOT: frontend/design/html-prototypes/onboarding-v3.html
  * THEME: Bloomberg Terminal dark mode (charcoal #0C0A08, amber #D4956A)
- * 
+ *
  * ARCHITECTURE DECISION: LinkedIn and CRM connections are MANDATORY
  * - Cannot proceed to dashboard without both connections
  * - Clear messaging about why each connection is required
- * 
+ *
  * STEP 3/8: Wired to real backend APIs (no more setTimeout placeholders)
  * - HubSpot OAuth: GET /api/v1/crm/auth/hubspot
  * - LinkedIn OAuth: GET /api/v1/linkedin/connect
  * - ICP Extraction: POST /api/v1/onboarding/analyze
+ * - Job Status: GET /api/v1/onboarding/status/{job_id}
+ * - Job Result: GET /api/v1/onboarding/result/{job_id}
+ * - ICP Confirm: POST /api/v1/onboarding/confirm
  * - Gate Check: GET /api/v1/onboarding/gates
+ *
+ * DIRECTIVE #183 — Added ICP review/confirm step (step 3)
  */
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Check, Globe, Linkedin, ArrowRight, Sparkles, AlertCircle, RefreshCw } from "lucide-react";
+import {
+  Check,
+  Globe,
+  Linkedin,
+  ArrowRight,
+  Sparkles,
+  AlertCircle,
+  RefreshCw,
+  Edit2,
+  Target,
+  MapPin,
+  Users,
+  Briefcase,
+  CheckCircle2,
+  Loader2,
+} from "lucide-react";
 import { MayaOverlay } from "@/components/maya";
 
-type OnboardingStep = 'website' | 'integrations' | 'complete';
+type OnboardingStep = "website" | "integrations" | "icp_review" | "complete";
+type JobStatus = "pending" | "running" | "completed" | "failed";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
+interface ICPExtractionStatus {
+  job_id: string;
+  status: JobStatus;
+  current_step: string | null;
+  completed_steps: number;
+  total_steps: number;
+  progress_percent: number;
+  error_message: string | null;
+}
+
+interface ICPProfile {
+  company_name: string;
+  website_url: string;
+  company_description: string;
+  services_offered: string[];
+  value_proposition: string;
+  icp_industries: string[];
+  icp_company_sizes: string[];
+  icp_revenue_ranges: string[];
+  icp_locations: string[];
+  icp_titles: string[];
+  icp_pain_points: string[];
+  confidence: number;
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
+const POLL_INTERVAL_MS = 3000;
 
 export default function OnboardingPage() {
   const router = useRouter();
@@ -34,7 +81,7 @@ export default function OnboardingPage() {
   const [websiteValid, setWebsiteValid] = useState(false);
   const [hubspotConnected, setHubspotConnected] = useState(false);
   const [linkedinConnected, setLinkedinConnected] = useState(false);
-  const [currentStep, setCurrentStep] = useState<OnboardingStep>('website');
+  const [currentStep, setCurrentStep] = useState<OnboardingStep>("website");
   const [isLoading, setIsLoading] = useState(false);
   const [isHubspotLoading, setIsHubspotLoading] = useState(false);
   const [isLinkedinLoading, setIsLinkedinLoading] = useState(false);
@@ -42,19 +89,29 @@ export default function OnboardingPage() {
   const [mayaProgress, setMayaProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
+  // ICP review state
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [jobStatus, setJobStatus] = useState<ICPExtractionStatus | null>(null);
+  const [icpProfile, setIcpProfile] = useState<ICPProfile | null>(null);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [editMode, setEditMode] = useState(false);
+  const [editedProfile, setEditedProfile] = useState<Partial<ICPProfile>>({});
+  const pollRef = useRef<NodeJS.Timeout | null>(null);
+  const profileFetchedRef = useRef(false);
+
   // Handle OAuth callbacks from query params
   useEffect(() => {
-    const hubspotSuccess = searchParams.get('hubspot') === 'connected';
-    const linkedinSuccess = searchParams.get('linkedin') === 'connected';
-    const oauthError = searchParams.get('oauth_error');
+    const hubspotSuccess = searchParams.get("hubspot") === "connected";
+    const linkedinSuccess = searchParams.get("linkedin") === "connected";
+    const oauthError = searchParams.get("oauth_error");
 
     if (hubspotSuccess) {
       setHubspotConnected(true);
-      setCurrentStep('integrations');
+      setCurrentStep("integrations");
     }
     if (linkedinSuccess) {
       setLinkedinConnected(true);
-      setCurrentStep('integrations');
+      setCurrentStep("integrations");
     }
     if (oauthError) {
       setError(`OAuth failed: ${oauthError}`);
@@ -65,7 +122,9 @@ export default function OnboardingPage() {
   useEffect(() => {
     try {
       if (websiteUrl) {
-        new URL(websiteUrl.startsWith('http') ? websiteUrl : `https://${websiteUrl}`);
+        new URL(
+          websiteUrl.startsWith("http") ? websiteUrl : `https://${websiteUrl}`
+        );
         setWebsiteValid(true);
       } else {
         setWebsiteValid(false);
@@ -78,117 +137,166 @@ export default function OnboardingPage() {
   // Update Maya progress based on step
   useEffect(() => {
     const progressMap: Record<OnboardingStep, number> = {
-      'website': 33,
-      'integrations': 66,
-      'complete': 100,
+      website: 25,
+      integrations: 50,
+      icp_review: 75,
+      complete: 100,
     };
     setMayaProgress(progressMap[currentStep] || 0);
   }, [currentStep]);
 
-  // Progressive disclosure - advance to integrations when URL is valid
+  // Poll job status when in icp_review step
+  const fetchJobStatus = useCallback(async (id: string) => {
+    const res = await fetch(`${API_BASE}/api/v1/onboarding/status/${id}`, {
+      credentials: "include",
+    });
+    if (!res.ok) throw new Error(`Status fetch failed (${res.status})`);
+    return res.json() as Promise<ICPExtractionStatus>;
+  }, []);
+
+  const fetchJobResult = useCallback(async (id: string) => {
+    const res = await fetch(`${API_BASE}/api/v1/onboarding/result/${id}`, {
+      credentials: "include",
+    });
+    if (!res.ok) throw new Error(`Result fetch failed (${res.status})`);
+    return res.json() as Promise<ICPProfile>;
+  }, []);
+
+  useEffect(() => {
+    if (currentStep !== "icp_review" || !jobId) return;
+
+    const poll = async () => {
+      try {
+        const status = await fetchJobStatus(jobId);
+        setJobStatus(status);
+
+        if (status.status === "completed" && !profileFetchedRef.current) {
+          profileFetchedRef.current = true;
+          try {
+            const profile = await fetchJobResult(jobId);
+            setIcpProfile(profile);
+            setEditedProfile({});
+          } catch (err) {
+            console.error("Result fetch error:", err);
+          }
+          if (pollRef.current) {
+            clearInterval(pollRef.current);
+            pollRef.current = null;
+          }
+        } else if (status.status === "failed") {
+          setError(status.error_message ?? "ICP extraction failed");
+          if (pollRef.current) {
+            clearInterval(pollRef.current);
+            pollRef.current = null;
+          }
+        }
+      } catch (err) {
+        console.error("Poll error:", err);
+      }
+    };
+
+    profileFetchedRef.current = false;
+    poll();
+    pollRef.current = setInterval(poll, POLL_INTERVAL_MS);
+
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [currentStep, jobId, fetchJobStatus, fetchJobResult]);
+
   const handleWebsiteSubmit = () => {
-    if (websiteValid) {
-      setCurrentStep('integrations');
-    }
+    if (websiteValid) setCurrentStep("integrations");
   };
 
-  // HubSpot OAuth - calls POST /api/v1/crm/connect/hubspot
+  // HubSpot OAuth
   const handleHubspotConnect = useCallback(async () => {
     setError(null);
     setIsHubspotLoading(true);
-    
     try {
       const response = await fetch(`${API_BASE}/api/v1/crm/connect/hubspot`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
       });
-
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.detail || errorData.message || `HubSpot auth failed (${response.status})`);
+        throw new Error(
+          errorData.detail ||
+            errorData.message ||
+            `HubSpot auth failed (${response.status})`
+        );
       }
-
       const data = await response.json();
-      
       if (data.oauth_url) {
-        // Redirect to OAuth URL
         window.location.href = data.oauth_url;
       } else if (data.redirect_url || data.auth_url || data.url) {
-        // Fallback for other URL fields
-        const authUrl = data.redirect_url || data.auth_url || data.url;
-        window.location.href = authUrl;
+        window.location.href = data.redirect_url || data.auth_url || data.url;
       } else {
-        // Direct connection successful (no OAuth redirect needed)
         setHubspotConnected(true);
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to connect HubSpot';
-      setError(message);
-      console.error('HubSpot connect error:', err);
+      setError(err instanceof Error ? err.message : "Failed to connect HubSpot");
     } finally {
       setIsHubspotLoading(false);
     }
   }, []);
 
-  // LinkedIn OAuth - calls GET /api/v1/linkedin/connect
+  // LinkedIn OAuth
   const handleLinkedinConnect = useCallback(async () => {
     setError(null);
     setIsLinkedinLoading(true);
-    
     try {
       const response = await fetch(`${API_BASE}/api/v1/linkedin/connect`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
+        method: "GET",
+        credentials: "include",
       });
-
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.message || `LinkedIn auth failed (${response.status})`);
+        throw new Error(
+          errorData.message || `LinkedIn auth failed (${response.status})`
+        );
       }
-
       const data = await response.json();
-      
-      if (data.redirect_url || data.auth_url || data.url || data.hosted_auth_url) {
-        // Unipile returns hosted_auth_url for LinkedIn OAuth
-        const authUrl = data.hosted_auth_url || data.redirect_url || data.auth_url || data.url;
-        window.location.href = authUrl;
+      if (
+        data.redirect_url ||
+        data.auth_url ||
+        data.url ||
+        data.hosted_auth_url
+      ) {
+        window.location.href =
+          data.hosted_auth_url ||
+          data.redirect_url ||
+          data.auth_url ||
+          data.url;
       } else {
-        // Direct connection successful
         setLinkedinConnected(true);
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to connect LinkedIn';
-      setError(message);
-      console.error('LinkedIn connect error:', err);
+      setError(
+        err instanceof Error ? err.message : "Failed to connect LinkedIn"
+      );
     } finally {
       setIsLinkedinLoading(false);
     }
   }, []);
 
-  // Launch - calls POST /api/v1/onboarding/analyze for ICP extraction
+  // Launch → calls /analyze, transitions to icp_review
   const handleLaunch = useCallback(async () => {
     setError(null);
     setIsLoading(true);
-    setCurrentStep('complete');
-    
+
     try {
-      // Normalize website URL
-      const normalizedUrl = websiteUrl.startsWith('http') 
-        ? websiteUrl 
+      const normalizedUrl = websiteUrl.startsWith("http")
+        ? websiteUrl
         : `https://${websiteUrl}`;
 
       const response = await fetch(`${API_BASE}/api/v1/onboarding/analyze`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({
           website_url: normalizedUrl,
           crm_connected: hubspotConnected,
@@ -198,52 +306,87 @@ export default function OnboardingPage() {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.message || `Analysis failed (${response.status})`);
+        throw new Error(
+          errorData.message || `Analysis failed (${response.status})`
+        );
       }
 
       const data = await response.json();
 
-      // The response contains agency_service_profile and agency_communication_profile
-      // These are written to the backend's database by the analyze endpoint
-      // We can optionally store a reference in localStorage for the dashboard
-      if (data.agency_service_profile || data.agency_communication_profile) {
-        try {
-          localStorage.setItem('onboarding_profile', JSON.stringify({
-            service_profile: data.agency_service_profile,
-            communication_profile: data.agency_communication_profile,
-            completed_at: new Date().toISOString(),
-          }));
-        } catch {
-          // localStorage not available, continue anyway
-        }
+      // Store job_id and move to ICP review step
+      if (data.job_id) {
+        setJobId(data.job_id);
+        setCurrentStep("icp_review");
+      } else {
+        // Fallback if no job_id returned — go straight to dashboard
+        router.push("/dashboard?onboarding=true");
       }
-
-      // Success - redirect to dashboard
-      router.push("/dashboard?onboarding=true");
-      
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to analyze website';
-      setError(message);
-      setCurrentStep('integrations'); // Go back to allow retry
-      console.error('Launch/analyze error:', err);
+      setError(
+        err instanceof Error ? err.message : "Failed to analyze website"
+      );
     } finally {
       setIsLoading(false);
     }
   }, [websiteUrl, hubspotConnected, linkedinConnected, router]);
 
-  // MANDATORY GATES: Both LinkedIn AND CRM must be connected to proceed
-  // Architecture Decision: No bypass permitted
+  // Confirm ICP → calls /confirm, then redirects
+  const handleConfirmICP = useCallback(async () => {
+    if (!jobId) return;
+    setIsConfirming(true);
+    setError(null);
+
+    try {
+      // Build adjustments from edited fields if in edit mode
+      const adjustments =
+        editMode && Object.keys(editedProfile).length > 0
+          ? editedProfile
+          : undefined;
+
+      const response = await fetch(`${API_BASE}/api/v1/onboarding/confirm`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          job_id: jobId,
+          adjustments: adjustments ?? null,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          errorData.detail ||
+            errorData.message ||
+            `Confirm failed (${response.status})`
+        );
+      }
+
+      setCurrentStep("complete");
+      router.push("/dashboard?onboarding=true");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to confirm ICP");
+    } finally {
+      setIsConfirming(false);
+    }
+  }, [jobId, editMode, editedProfile, router]);
+
   const canLaunch = websiteValid && hubspotConnected && linkedinConnected;
 
-  // Dismiss error
-  const dismissError = () => setError(null);
+  const mergedProfile = icpProfile
+    ? { ...icpProfile, ...editedProfile }
+    : null;
+
+  const jobIsRunning =
+    jobStatus?.status === "pending" || jobStatus?.status === "running";
+  const jobIsCompleted = jobStatus?.status === "completed";
 
   return (
-    <div 
+    <div
       className="min-h-screen flex items-center justify-center px-4 py-8"
-      style={{ backgroundColor: '#0C0A08' }}
+      style={{ backgroundColor: "#0C0A08" }}
     >
-      <div className="w-full max-w-[480px]">
+      <div className="w-full max-w-[520px]">
         {/* Logo Section */}
         <div className="text-center mb-10">
           <div className="w-14 h-14 mx-auto mb-5 rounded-2xl gradient-premium flex items-center justify-center shadow-glow-md">
@@ -259,18 +402,18 @@ export default function OnboardingPage() {
 
         {/* Error Banner */}
         {error && (
-          <div 
+          <div
             className="mb-6 rounded-xl p-4 flex items-start gap-3"
             style={{
-              backgroundColor: 'rgba(239, 68, 68, 0.1)',
-              border: '1px solid rgba(239, 68, 68, 0.3)',
+              backgroundColor: "rgba(239, 68, 68, 0.1)",
+              border: "1px solid rgba(239, 68, 68, 0.3)",
             }}
           >
             <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
             <div className="flex-1">
               <p className="text-sm text-red-400">{error}</p>
-              <button 
-                onClick={dismissError}
+              <button
+                onClick={() => setError(null)}
                 className="text-xs text-red-300 hover:text-red-200 mt-1 underline"
               >
                 Dismiss
@@ -279,348 +422,723 @@ export default function OnboardingPage() {
           </div>
         )}
 
-        {/* Main Card - Glassmorphism */}
-        <div className="glass-surface rounded-2xl overflow-hidden">
-          {/* Card Header */}
-          <div className="p-6 border-b border-border-subtle">
-            <div className="flex items-center justify-center mb-4">
-              <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-xs font-semibold"
-                style={{ 
-                  background: 'linear-gradient(135deg, rgba(212, 149, 106, 0.15), rgba(224, 168, 125, 0.15))',
-                  border: '1px solid rgba(212, 149, 106, 0.3)',
-                  color: '#D4956A'
-                }}
-              >
-                <Sparkles className="w-3.5 h-3.5" />
-                Ignition Plan
-              </span>
-            </div>
-            <h2 className="text-xl font-serif text-text-primary text-center">
-              Let's get you set up
-            </h2>
-            <p className="text-text-secondary text-sm text-center mt-1">
-              Just 3 things and Maya will take it from here
-            </p>
-          </div>
-
-          {/* Card Body */}
-          <div className="p-6 space-y-6">
-            {/* Step 1: Website URL Input */}
-            <div className={`transition-all duration-300 ${currentStep !== 'website' && websiteValid ? 'opacity-60' : ''}`}>
-              <label className="block text-sm font-medium text-text-secondary mb-2">
-                Your Agency Website
-              </label>
-              <div className="relative">
-                <Globe className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-muted" />
-                <input
-                  type="url"
-                  value={websiteUrl}
-                  onChange={(e) => setWebsiteUrl(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleWebsiteSubmit()}
-                  placeholder="https://youragency.com.au"
-                  disabled={currentStep !== 'website'}
-                  className="w-full pl-12 pr-4 py-3.5 rounded-xl
-                    text-text-primary placeholder-text-muted text-[15px]
-                    transition-all duration-200
-                    disabled:opacity-60 disabled:cursor-not-allowed"
+        {/* ─── STEP 3: ICP REVIEW ─── */}
+        {currentStep === "icp_review" && (
+          <div className="glass-surface rounded-2xl overflow-hidden">
+            {/* Header */}
+            <div className="p-6 border-b border-border-subtle">
+              <div className="flex items-center justify-center mb-4">
+                <span
+                  className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-xs font-semibold"
                   style={{
-                    backgroundColor: 'rgba(255, 255, 255, 0.03)',
-                    border: '1px solid rgba(255, 255, 255, 0.08)',
-                  }}
-                  onFocus={(e) => e.target.style.borderColor = '#D4956A'}
-                  onBlur={(e) => e.target.style.borderColor = 'rgba(255, 255, 255, 0.08)'}
-                  autoFocus
-                />
-                {websiteValid && currentStep === 'website' && (
-                  <button
-                    onClick={handleWebsiteSubmit}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 px-3 py-1.5 rounded-lg
-                      text-xs font-medium gradient-premium text-text-primary"
-                  >
-                    Continue
-                  </button>
-                )}
-                {websiteValid && currentStep !== 'website' && (
-                  <Check className="absolute right-4 top-1/2 -translate-y-1/2 w-5 h-5 text-status-success" />
-                )}
-              </div>
-            </div>
-
-            {/* Auto-provision Notice */}
-            <div 
-              className={`rounded-xl p-4 transition-all duration-300 ${
-                currentStep === 'website' && !websiteValid ? 'opacity-50' : ''
-              }`}
-              style={{
-                backgroundColor: 'rgba(16, 185, 129, 0.08)',
-                border: '1px solid rgba(16, 185, 129, 0.2)',
-              }}
-            >
-              <div className="flex items-start gap-3">
-                <div className="w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5"
-                  style={{ backgroundColor: 'rgba(16, 185, 129, 0.2)' }}
-                >
-                  <Check className="w-3 h-3 text-status-success" />
-                </div>
-                <div>
-                  <p className="text-sm font-medium text-status-success">
-                    Email &amp; Phone auto-provisioned
-                  </p>
-                  <p className="text-xs text-text-muted mt-0.5">
-                    From pre-warmed pool for immediate deliverability
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            {/* Step 2: Integrations - Progressive disclosure */}
-            <div className={`step-reveal ${currentStep === 'integrations' || currentStep === 'complete' ? 'active' : ''}`}
-              style={{ 
-                opacity: currentStep === 'website' ? 0 : 1,
-                transform: currentStep === 'website' ? 'translateY(10px)' : 'translateY(0)',
-                transition: 'all 0.4s ease',
-                pointerEvents: currentStep === 'website' ? 'none' : 'auto'
-              }}
-            >
-              {/* Divider */}
-              <div className="relative my-2">
-                <div className="absolute inset-0 flex items-center">
-                  <div className="w-full border-t border-border-subtle" />
-                </div>
-                <div className="relative flex justify-center">
-                  <span className="px-4 text-xs text-text-muted uppercase tracking-wider"
-                    style={{ backgroundColor: '#0C0A08' }}
-                  >
-                    Connect Your Tools
-                  </span>
-                </div>
-              </div>
-
-              {/* Integration Buttons Grid */}
-              <div className="grid grid-cols-2 gap-3 mt-6">
-                {/* HubSpot CRM - REQUIRED */}
-                <div className="space-y-2">
-                  <button
-                    onClick={handleHubspotConnect}
-                    disabled={hubspotConnected || isHubspotLoading}
-                    className={`
-                      relative flex flex-col items-center justify-center p-5 rounded-xl w-full
-                      transition-all duration-200 glass-surface-hover
-                      ${hubspotConnected 
-                        ? 'border-status-success/30' 
-                        : 'hover:border-accent-primary/50'
-                      }
-                      disabled:cursor-not-allowed
-                    `}
-                    style={{
-                      backgroundColor: hubspotConnected 
-                        ? 'rgba(16, 185, 129, 0.05)' 
-                        : 'rgba(255, 255, 255, 0.03)',
-                      border: `1px solid ${hubspotConnected 
-                        ? 'rgba(16, 185, 129, 0.3)' 
-                        : 'rgba(255, 255, 255, 0.08)'
-                      }`,
-                    }}
-                  >
-                    {/* Required Badge */}
-                    <div className="absolute top-2 left-2 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wider"
-                      style={{
-                        backgroundColor: hubspotConnected ? 'rgba(16, 185, 129, 0.2)' : 'rgba(212, 149, 106, 0.2)',
-                        color: hubspotConnected ? '#10B981' : '#D4956A',
-                      }}
-                    >
-                      Required
-                    </div>
-                    
-                    {hubspotConnected ? (
-                      <div className="absolute top-2 right-2 w-5 h-5 bg-status-success rounded-full flex items-center justify-center">
-                        <Check className="w-3 h-3 text-text-primary" />
-                      </div>
-                    ) : null}
-                    
-                    {/* HubSpot Icon */}
-                    <div className="w-10 h-10 rounded-lg flex items-center justify-center mb-3"
-                      style={{ backgroundColor: 'rgba(255, 122, 89, 0.15)' }}
-                    >
-                      {isHubspotLoading ? (
-                        <div className="w-5 h-5 border-2 border-[#FF7A59] border-t-transparent rounded-full animate-spin" />
-                      ) : (
-                        <span className="text-[#FF7A59] font-bold text-sm">H</span>
-                      )}
-                    </div>
-                    <span className="text-sm font-medium text-text-primary">HubSpot CRM</span>
-                    <span className="text-[11px] text-text-muted mt-1">
-                      {hubspotConnected ? 'Connected ✓' : isHubspotLoading ? 'Connecting...' : 'Click to connect'}
-                    </span>
-                  </button>
-                  {/* CRM Gate Message */}
-                  {!hubspotConnected && (
-                    <p className="text-[10px] text-text-muted text-center px-2">
-                      Protects your existing clients from outreach and tracks booked meetings
-                    </p>
-                  )}
-                </div>
-
-                {/* LinkedIn - REQUIRED */}
-                <div className="space-y-2">
-                  <button
-                    onClick={handleLinkedinConnect}
-                    disabled={linkedinConnected || isLinkedinLoading}
-                    className={`
-                      relative flex flex-col items-center justify-center p-5 rounded-xl w-full
-                      transition-all duration-200 glass-surface-hover
-                      ${linkedinConnected 
-                        ? 'border-status-success/30' 
-                        : 'hover:border-accent-primary/50'
-                      }
-                      disabled:cursor-not-allowed
-                    `}
-                    style={{
-                      backgroundColor: linkedinConnected 
-                        ? 'rgba(16, 185, 129, 0.05)' 
-                        : 'rgba(255, 255, 255, 0.03)',
-                      border: `1px solid ${linkedinConnected 
-                        ? 'rgba(16, 185, 129, 0.3)' 
-                        : 'rgba(255, 255, 255, 0.08)'
-                      }`,
-                    }}
-                  >
-                    {/* Required Badge */}
-                    <div className="absolute top-2 left-2 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wider"
-                      style={{
-                        backgroundColor: linkedinConnected ? 'rgba(16, 185, 129, 0.2)' : 'rgba(212, 149, 106, 0.2)',
-                        color: linkedinConnected ? '#10B981' : '#D4956A',
-                      }}
-                    >
-                      Required
-                    </div>
-                    
-                    {linkedinConnected ? (
-                      <div className="absolute top-2 right-2 w-5 h-5 bg-status-success rounded-full flex items-center justify-center">
-                        <Check className="w-3 h-3 text-text-primary" />
-                      </div>
-                    ) : null}
-                    
-                    {/* LinkedIn Icon */}
-                    <div className="w-10 h-10 rounded-lg flex items-center justify-center mb-3"
-                      style={{ backgroundColor: 'rgba(10, 102, 194, 0.15)' }}
-                    >
-                      {isLinkedinLoading ? (
-                        <div className="w-5 h-5 border-2 border-[#0A66C2] border-t-transparent rounded-full animate-spin" />
-                      ) : (
-                        <Linkedin className="w-5 h-5 text-[#0A66C2]" />
-                      )}
-                    </div>
-                    <span className="text-sm font-medium text-text-primary">LinkedIn</span>
-                    <span className="text-[11px] text-text-muted mt-1">
-                      {linkedinConnected ? 'Connected ✓' : isLinkedinLoading ? 'Connecting...' : 'Click to connect'}
-                    </span>
-                  </button>
-                  {/* LinkedIn Gate Message */}
-                  {!linkedinConnected && (
-                    <p className="text-[10px] text-text-muted text-center px-2">
-                      Enables LinkedIn outreach and protects your network from outreach
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              {/* Gate Warning Banner - Shows when integrations are missing */}
-              {(currentStep === 'integrations' || currentStep === 'complete') && (!hubspotConnected || !linkedinConnected) && (
-                <div 
-                  className="mt-4 rounded-xl p-4 flex items-start gap-3"
-                  style={{
-                    backgroundColor: 'rgba(212, 149, 106, 0.1)',
-                    border: '1px solid rgba(212, 149, 106, 0.3)',
+                    background:
+                      "linear-gradient(135deg, rgba(212, 149, 106, 0.15), rgba(224, 168, 125, 0.15))",
+                    border: "1px solid rgba(212, 149, 106, 0.3)",
+                    color: "#D4956A",
                   }}
                 >
-                  <AlertCircle className="w-5 h-5 text-accent-primary flex-shrink-0 mt-0.5" />
-                  <div>
-                    <p className="text-sm font-medium text-accent-primary">
-                      Both connections required to continue
-                    </p>
-                    <p className="text-xs text-text-muted mt-1">
-                      Connect {!hubspotConnected && !linkedinConnected ? 'both HubSpot CRM and LinkedIn' : !hubspotConnected ? 'HubSpot CRM' : 'LinkedIn'} to launch your dashboard
-                    </p>
+                  <Target className="w-3.5 h-3.5" />
+                  Step 3 of 3 — Review Your ICP
+                </span>
+              </div>
+              <h2 className="text-xl font-serif text-text-primary text-center">
+                {jobIsRunning
+                  ? "Analyzing your agency..."
+                  : jobIsCompleted
+                  ? "Your Ideal Client Profile"
+                  : "Preparing results..."}
+              </h2>
+              <p className="text-text-secondary text-sm text-center mt-1">
+                {jobIsRunning
+                  ? `${jobStatus?.current_step ?? "Extracting ICP from your website"}...`
+                  : "Review what we found and confirm before launching"}
+              </p>
+            </div>
+
+            <div className="p-6">
+              {/* Running State */}
+              {jobIsRunning && (
+                <div className="space-y-5">
+                  <div className="flex items-center justify-center gap-3 py-4">
+                    <Loader2 className="w-6 h-6 text-accent-primary animate-spin" />
+                    <span className="text-sm text-text-secondary">
+                      {jobStatus?.current_step ?? "Analyzing your website"}
+                    </span>
+                  </div>
+                  {/* Progress bar */}
+                  <div
+                    className="w-full h-2 rounded-full overflow-hidden"
+                    style={{ backgroundColor: "rgba(255,255,255,0.06)" }}
+                  >
+                    <div
+                      className="h-full rounded-full transition-all duration-700"
+                      style={{
+                        width: `${jobStatus?.progress_percent ?? 10}%`,
+                        background:
+                          "linear-gradient(90deg, #D4956A 0%, #E0A87D 100%)",
+                      }}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    {[
+                      "Scraping website content",
+                      "Extracting industry signals",
+                      "Building ICP profile",
+                    ].map((step, i) => (
+                      <div key={i} className="flex items-center gap-3">
+                        <div
+                          className="w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0"
+                          style={{
+                            backgroundColor:
+                              (jobStatus?.completed_steps ?? 0) > i
+                                ? "rgba(16, 185, 129, 0.2)"
+                                : "rgba(255,255,255,0.05)",
+                          }}
+                        >
+                          {(jobStatus?.completed_steps ?? 0) > i ? (
+                            <CheckCircle2 className="w-3 h-3 text-status-success" />
+                          ) : (jobStatus?.completed_steps ?? 0) === i ? (
+                            <Loader2 className="w-3 h-3 text-accent-primary animate-spin" />
+                          ) : (
+                            <div className="w-1.5 h-1.5 rounded-full bg-text-muted" />
+                          )}
+                        </div>
+                        <span
+                          className="text-xs"
+                          style={{
+                            color:
+                              (jobStatus?.completed_steps ?? 0) > i
+                                ? "#10B981"
+                                : (jobStatus?.completed_steps ?? 0) === i
+                                ? "#D4956A"
+                                : "#6B6560",
+                          }}
+                        >
+                          {step}
+                        </span>
+                      </div>
+                    ))}
                   </div>
                 </div>
               )}
+
+              {/* Completed — show ICP */}
+              {jobIsCompleted && mergedProfile && (
+                <div className="space-y-5">
+                  {/* Edit toggle */}
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs text-text-muted">
+                      Confidence:{" "}
+                      <span className="text-accent-primary font-mono">
+                        {Math.round((mergedProfile.confidence ?? 0) * 100)}%
+                      </span>
+                    </p>
+                    <button
+                      onClick={() => setEditMode(!editMode)}
+                      className="flex items-center gap-1.5 text-xs text-text-secondary hover:text-text-primary transition-colors"
+                    >
+                      <Edit2 className="w-3 h-3" />
+                      {editMode ? "Done editing" : "Edit fields"}
+                    </button>
+                  </div>
+
+                  {/* ICP Grid */}
+                  <div className="space-y-4">
+                    {/* Industries */}
+                    <ICPField
+                      icon={<Briefcase className="w-4 h-4" />}
+                      label="Target Industries"
+                      values={mergedProfile.icp_industries ?? []}
+                      editMode={editMode}
+                      onEdit={(vals) =>
+                        setEditedProfile((p) => ({
+                          ...p,
+                          icp_industries: vals,
+                        }))
+                      }
+                    />
+                    {/* Locations */}
+                    <ICPField
+                      icon={<MapPin className="w-4 h-4" />}
+                      label="Target Geography"
+                      values={mergedProfile.icp_locations ?? []}
+                      editMode={editMode}
+                      onEdit={(vals) =>
+                        setEditedProfile((p) => ({
+                          ...p,
+                          icp_locations: vals,
+                        }))
+                      }
+                    />
+                    {/* Company sizes */}
+                    <ICPField
+                      icon={<Users className="w-4 h-4" />}
+                      label="Company Size"
+                      values={mergedProfile.icp_company_sizes ?? []}
+                      editMode={editMode}
+                      onEdit={(vals) =>
+                        setEditedProfile((p) => ({
+                          ...p,
+                          icp_company_sizes: vals,
+                        }))
+                      }
+                    />
+                    {/* Titles */}
+                    <ICPField
+                      icon={<Target className="w-4 h-4" />}
+                      label="Decision Maker Titles"
+                      values={mergedProfile.icp_titles ?? []}
+                      editMode={editMode}
+                      onEdit={(vals) =>
+                        setEditedProfile((p) => ({ ...p, icp_titles: vals }))
+                      }
+                    />
+                  </div>
+
+                  {/* Value prop */}
+                  {mergedProfile.value_proposition && (
+                    <div
+                      className="rounded-xl p-4"
+                      style={{
+                        backgroundColor: "rgba(212, 149, 106, 0.06)",
+                        border: "1px solid rgba(212, 149, 106, 0.2)",
+                      }}
+                    >
+                      <p className="text-xs font-medium text-accent-primary mb-1">
+                        Value Proposition
+                      </p>
+                      <p className="text-sm text-text-secondary">
+                        {mergedProfile.value_proposition}
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Confirm button */}
+                  <button
+                    onClick={handleConfirmICP}
+                    disabled={isConfirming}
+                    className="w-full py-4 rounded-xl text-[15px] font-semibold
+                      transition-all duration-200 flex items-center justify-center gap-2
+                      disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-glow-md"
+                    style={{
+                      background:
+                        "linear-gradient(135deg, #D4956A 0%, #E0A87D 100%)",
+                      color: "#0C0A08",
+                    }}
+                  >
+                    {isConfirming ? (
+                      <>
+                        <Loader2 className="w-5 h-5 animate-spin" />
+                        Launching your dashboard...
+                      </>
+                    ) : (
+                      <>
+                        Looks good — Launch Dashboard
+                        <ArrowRight className="w-5 h-5" />
+                      </>
+                    )}
+                  </button>
+
+                  <button
+                    onClick={() => setEditMode(true)}
+                    className="w-full py-2.5 rounded-xl text-sm font-medium text-text-muted hover:text-text-secondary transition-colors"
+                  >
+                    Something looks off? Edit above ↑
+                  </button>
+                </div>
+              )}
+
+              {/* No profile yet but completed (should not happen) */}
+              {jobIsCompleted && !mergedProfile && (
+                <div className="text-center py-8">
+                  <Loader2 className="w-6 h-6 animate-spin text-accent-primary mx-auto mb-3" />
+                  <p className="text-sm text-text-muted">Loading your ICP...</p>
+                </div>
+              )}
+
+              {/* Failed state */}
+              {jobStatus?.status === "failed" && (
+                <div className="text-center py-8 space-y-4">
+                  <p className="text-sm text-red-400">
+                    {jobStatus.error_message ?? "Extraction failed"}
+                  </p>
+                  <button
+                    onClick={() => {
+                      setCurrentStep("integrations");
+                      setJobId(null);
+                      setJobStatus(null);
+                    }}
+                    className="text-sm text-accent-primary hover:underline"
+                  >
+                    ← Back to try again
+                  </button>
+                </div>
+              )}
             </div>
 
-            {/* Launch Button */}
-            <button
-              onClick={handleLaunch}
-              disabled={!canLaunch || isLoading}
-              className="w-full py-4 rounded-xl text-[15px] font-semibold
-                transition-all duration-200 flex items-center justify-center gap-2
-                disabled:opacity-50 disabled:cursor-not-allowed
-                hover:shadow-glow-md"
-              style={{
-                background: canLaunch 
-                  ? 'linear-gradient(135deg, #D4956A 0%, #E0A87D 100%)'
-                  : 'rgba(255, 255, 255, 0.06)',
-                color: canLaunch ? '#0C0A08' : '#6B6560',
-              }}
-            >
-              {isLoading ? (
-                <>
-                  <div className="w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                  <span>Analyzing your agency...</span>
-                </>
-              ) : error && currentStep === 'integrations' ? (
-                <>
-                  <RefreshCw className="w-5 h-5" />
-                  Retry Launch
-                </>
-              ) : (
-                <>
-                  Launch Dashboard
-                  <ArrowRight className="w-5 h-5" />
-                </>
-              )}
-            </button>
+            {/* Footer */}
+            <div className="px-6 py-4 border-t border-border-subtle">
+              <p className="text-xs text-text-muted text-center">
+                Need help?{" "}
+                <a
+                  href="mailto:support@agency-os.com"
+                  className="text-accent-primary hover:underline"
+                >
+                  Contact support
+                </a>
+              </p>
+            </div>
           </div>
+        )}
 
-          {/* Card Footer */}
-          <div className="px-6 py-4 border-t border-border-subtle">
-            <p className="text-xs text-text-muted text-center">
-              Need help?{" "}
-              <a
-                href="mailto:support@agency-os.com"
-                className="text-accent-primary hover:underline"
+        {/* ─── STEPS 1 & 2: website + integrations ─── */}
+        {currentStep !== "icp_review" && currentStep !== "complete" && (
+          <div className="glass-surface rounded-2xl overflow-hidden">
+            {/* Card Header */}
+            <div className="p-6 border-b border-border-subtle">
+              <div className="flex items-center justify-center mb-4">
+                <span
+                  className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-xs font-semibold"
+                  style={{
+                    background:
+                      "linear-gradient(135deg, rgba(212, 149, 106, 0.15), rgba(224, 168, 125, 0.15))",
+                    border: "1px solid rgba(212, 149, 106, 0.3)",
+                    color: "#D4956A",
+                  }}
+                >
+                  <Sparkles className="w-3.5 h-3.5" />
+                  Ignition Plan
+                </span>
+              </div>
+              <h2 className="text-xl font-serif text-text-primary text-center">
+                Let&apos;s get you set up
+              </h2>
+              <p className="text-text-secondary text-sm text-center mt-1">
+                Just 3 things and Maya will take it from here
+              </p>
+            </div>
+
+            {/* Card Body */}
+            <div className="p-6 space-y-6">
+              {/* Step 1: Website URL */}
+              <div
+                className={`transition-all duration-300 ${
+                  currentStep !== "website" && websiteValid ? "opacity-60" : ""
+                }`}
               >
-                Contact support
-              </a>
-            </p>
-          </div>
-        </div>
+                <label className="block text-sm font-medium text-text-secondary mb-2">
+                  Your Agency Website
+                </label>
+                <div className="relative">
+                  <Globe className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-muted" />
+                  <input
+                    type="url"
+                    value={websiteUrl}
+                    onChange={(e) => setWebsiteUrl(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleWebsiteSubmit()}
+                    placeholder="https://youragency.com.au"
+                    disabled={currentStep !== "website"}
+                    className="w-full pl-12 pr-4 py-3.5 rounded-xl
+                      text-text-primary placeholder-text-muted text-[15px]
+                      transition-all duration-200
+                      disabled:opacity-60 disabled:cursor-not-allowed"
+                    style={{
+                      backgroundColor: "rgba(255, 255, 255, 0.03)",
+                      border: "1px solid rgba(255, 255, 255, 0.08)",
+                    }}
+                    onFocus={(e) =>
+                      (e.target.style.borderColor = "#D4956A")
+                    }
+                    onBlur={(e) =>
+                      (e.target.style.borderColor =
+                        "rgba(255, 255, 255, 0.08)")
+                    }
+                    autoFocus
+                  />
+                  {websiteValid && currentStep === "website" && (
+                    <button
+                      onClick={handleWebsiteSubmit}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 px-3 py-1.5 rounded-lg
+                        text-xs font-medium gradient-premium text-text-primary"
+                    >
+                      Continue
+                    </button>
+                  )}
+                  {websiteValid && currentStep !== "website" && (
+                    <Check className="absolute right-4 top-1/2 -translate-y-1/2 w-5 h-5 text-status-success" />
+                  )}
+                </div>
+              </div>
 
-        {/* Skeleton loader preview - shows what will load */}
-        {currentStep === 'complete' && (
-          <div className="mt-6 glass-surface rounded-xl p-4">
-            <p className="text-xs text-text-muted mb-3">
-              {isLoading ? 'Extracting ICP from your website...' : 'Preparing your dashboard...'}
-            </p>
-            <div className="space-y-3">
-              <div className="skeleton h-4 w-3/4" />
-              <div className="skeleton h-4 w-1/2" />
-              <div className="skeleton h-4 w-2/3" />
+              {/* Auto-provision Notice */}
+              <div
+                className={`rounded-xl p-4 transition-all duration-300 ${
+                  currentStep === "website" && !websiteValid ? "opacity-50" : ""
+                }`}
+                style={{
+                  backgroundColor: "rgba(16, 185, 129, 0.08)",
+                  border: "1px solid rgba(16, 185, 129, 0.2)",
+                }}
+              >
+                <div className="flex items-start gap-3">
+                  <div
+                    className="w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5"
+                    style={{ backgroundColor: "rgba(16, 185, 129, 0.2)" }}
+                  >
+                    <Check className="w-3 h-3 text-status-success" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-status-success">
+                      Email &amp; Phone auto-provisioned
+                    </p>
+                    <p className="text-xs text-text-muted mt-0.5">
+                      From pre-warmed pool for immediate deliverability
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Step 2: Integrations */}
+              <div
+                style={{
+                  opacity: currentStep === "website" ? 0 : 1,
+                  transform:
+                    currentStep === "website"
+                      ? "translateY(10px)"
+                      : "translateY(0)",
+                  transition: "all 0.4s ease",
+                  pointerEvents: currentStep === "website" ? "none" : "auto",
+                }}
+              >
+                <div className="relative my-2">
+                  <div className="absolute inset-0 flex items-center">
+                    <div className="w-full border-t border-border-subtle" />
+                  </div>
+                  <div className="relative flex justify-center">
+                    <span
+                      className="px-4 text-xs text-text-muted uppercase tracking-wider"
+                      style={{ backgroundColor: "#0C0A08" }}
+                    >
+                      Connect Your Tools
+                    </span>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3 mt-6">
+                  {/* HubSpot CRM */}
+                  <div className="space-y-2">
+                    <button
+                      onClick={handleHubspotConnect}
+                      disabled={hubspotConnected || isHubspotLoading}
+                      className={`
+                        relative flex flex-col items-center justify-center p-5 rounded-xl w-full
+                        transition-all duration-200 glass-surface-hover
+                        ${hubspotConnected ? "border-status-success/30" : "hover:border-accent-primary/50"}
+                        disabled:cursor-not-allowed
+                      `}
+                      style={{
+                        backgroundColor: hubspotConnected
+                          ? "rgba(16, 185, 129, 0.05)"
+                          : "rgba(255, 255, 255, 0.03)",
+                        border: `1px solid ${
+                          hubspotConnected
+                            ? "rgba(16, 185, 129, 0.3)"
+                            : "rgba(255, 255, 255, 0.08)"
+                        }`,
+                      }}
+                    >
+                      <div
+                        className="absolute top-2 left-2 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wider"
+                        style={{
+                          backgroundColor: hubspotConnected
+                            ? "rgba(16, 185, 129, 0.2)"
+                            : "rgba(212, 149, 106, 0.2)",
+                          color: hubspotConnected ? "#10B981" : "#D4956A",
+                        }}
+                      >
+                        Required
+                      </div>
+                      {hubspotConnected && (
+                        <div className="absolute top-2 right-2 w-5 h-5 bg-status-success rounded-full flex items-center justify-center">
+                          <Check className="w-3 h-3 text-text-primary" />
+                        </div>
+                      )}
+                      <div
+                        className="w-10 h-10 rounded-lg flex items-center justify-center mb-3"
+                        style={{ backgroundColor: "rgba(255, 122, 89, 0.15)" }}
+                      >
+                        {isHubspotLoading ? (
+                          <div className="w-5 h-5 border-2 border-[#FF7A59] border-t-transparent rounded-full animate-spin" />
+                        ) : (
+                          <span className="text-[#FF7A59] font-bold text-sm">
+                            H
+                          </span>
+                        )}
+                      </div>
+                      <span className="text-sm font-medium text-text-primary">
+                        HubSpot CRM
+                      </span>
+                      <span className="text-[11px] text-text-muted mt-1">
+                        {hubspotConnected
+                          ? "Connected ✓"
+                          : isHubspotLoading
+                          ? "Connecting..."
+                          : "Click to connect"}
+                      </span>
+                    </button>
+                    {!hubspotConnected && (
+                      <p className="text-[10px] text-text-muted text-center px-2">
+                        Protects your existing clients from outreach and tracks
+                        booked meetings
+                      </p>
+                    )}
+                  </div>
+
+                  {/* LinkedIn */}
+                  <div className="space-y-2">
+                    <button
+                      onClick={handleLinkedinConnect}
+                      disabled={linkedinConnected || isLinkedinLoading}
+                      className={`
+                        relative flex flex-col items-center justify-center p-5 rounded-xl w-full
+                        transition-all duration-200 glass-surface-hover
+                        ${linkedinConnected ? "border-status-success/30" : "hover:border-accent-primary/50"}
+                        disabled:cursor-not-allowed
+                      `}
+                      style={{
+                        backgroundColor: linkedinConnected
+                          ? "rgba(16, 185, 129, 0.05)"
+                          : "rgba(255, 255, 255, 0.03)",
+                        border: `1px solid ${
+                          linkedinConnected
+                            ? "rgba(16, 185, 129, 0.3)"
+                            : "rgba(255, 255, 255, 0.08)"
+                        }`,
+                      }}
+                    >
+                      <div
+                        className="absolute top-2 left-2 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wider"
+                        style={{
+                          backgroundColor: linkedinConnected
+                            ? "rgba(16, 185, 129, 0.2)"
+                            : "rgba(212, 149, 106, 0.2)",
+                          color: linkedinConnected ? "#10B981" : "#D4956A",
+                        }}
+                      >
+                        Required
+                      </div>
+                      {linkedinConnected && (
+                        <div className="absolute top-2 right-2 w-5 h-5 bg-status-success rounded-full flex items-center justify-center">
+                          <Check className="w-3 h-3 text-text-primary" />
+                        </div>
+                      )}
+                      <div
+                        className="w-10 h-10 rounded-lg flex items-center justify-center mb-3"
+                        style={{
+                          backgroundColor: "rgba(10, 102, 194, 0.15)",
+                        }}
+                      >
+                        {isLinkedinLoading ? (
+                          <div className="w-5 h-5 border-2 border-[#0A66C2] border-t-transparent rounded-full animate-spin" />
+                        ) : (
+                          <Linkedin className="w-5 h-5 text-[#0A66C2]" />
+                        )}
+                      </div>
+                      <span className="text-sm font-medium text-text-primary">
+                        LinkedIn
+                      </span>
+                      <span className="text-[11px] text-text-muted mt-1">
+                        {linkedinConnected
+                          ? "Connected ✓"
+                          : isLinkedinLoading
+                          ? "Connecting..."
+                          : "Click to connect"}
+                      </span>
+                    </button>
+                    {!linkedinConnected && (
+                      <p className="text-[10px] text-text-muted text-center px-2">
+                        Enables LinkedIn outreach and protects your network from
+                        outreach
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Gate Warning */}
+                {currentStep === "integrations" &&
+                  (!hubspotConnected || !linkedinConnected) && (
+                    <div
+                      className="mt-4 rounded-xl p-4 flex items-start gap-3"
+                      style={{
+                        backgroundColor: "rgba(212, 149, 106, 0.1)",
+                        border: "1px solid rgba(212, 149, 106, 0.3)",
+                      }}
+                    >
+                      <AlertCircle className="w-5 h-5 text-accent-primary flex-shrink-0 mt-0.5" />
+                      <div>
+                        <p className="text-sm font-medium text-accent-primary">
+                          Both connections required to continue
+                        </p>
+                        <p className="text-xs text-text-muted mt-1">
+                          Connect{" "}
+                          {!hubspotConnected && !linkedinConnected
+                            ? "both HubSpot CRM and LinkedIn"
+                            : !hubspotConnected
+                            ? "HubSpot CRM"
+                            : "LinkedIn"}{" "}
+                          to launch your dashboard
+                        </p>
+                      </div>
+                    </div>
+                  )}
+              </div>
+
+              {/* Launch Button */}
+              <button
+                onClick={handleLaunch}
+                disabled={!canLaunch || isLoading}
+                className="w-full py-4 rounded-xl text-[15px] font-semibold
+                  transition-all duration-200 flex items-center justify-center gap-2
+                  disabled:opacity-50 disabled:cursor-not-allowed
+                  hover:shadow-glow-md"
+                style={{
+                  background: canLaunch
+                    ? "linear-gradient(135deg, #D4956A 0%, #E0A87D 100%)"
+                    : "rgba(255, 255, 255, 0.06)",
+                  color: canLaunch ? "#0C0A08" : "#6B6560",
+                }}
+              >
+                {isLoading ? (
+                  <>
+                    <div className="w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                    <span>Analyzing your agency...</span>
+                  </>
+                ) : error ? (
+                  <>
+                    <RefreshCw className="w-5 h-5" />
+                    Retry Launch
+                  </>
+                ) : (
+                  <>
+                    Launch Dashboard
+                    <ArrowRight className="w-5 h-5" />
+                  </>
+                )}
+              </button>
+            </div>
+
+            <div className="px-6 py-4 border-t border-border-subtle">
+              <p className="text-xs text-text-muted text-center">
+                Need help?{" "}
+                <a
+                  href="mailto:support@agency-os.com"
+                  className="text-accent-primary hover:underline"
+                >
+                  Contact support
+                </a>
+              </p>
             </div>
           </div>
         )}
       </div>
 
-      {/* Maya Overlay - Sprint 4 */}
+      {/* Maya Overlay */}
       <MayaOverlay
         currentStep={currentStep}
         stepProgress={mayaProgress}
-        isTyping={isLoading || isHubspotLoading || isLinkedinLoading}
+        isTyping={isLoading || isHubspotLoading || isLinkedinLoading || jobIsRunning}
         isPulsing={true}
         isMinimised={isMayaMinimised}
         onMinimise={() => setIsMayaMinimised(true)}
         onMaximise={() => setIsMayaMinimised(false)}
         position="bottom-right"
       />
+    </div>
+  );
+}
+
+// ─── ICP Field Component ───────────────────────────────────────────────────
+
+interface ICPFieldProps {
+  icon: React.ReactNode;
+  label: string;
+  values: string[];
+  editMode: boolean;
+  onEdit: (values: string[]) => void;
+}
+
+function ICPField({ icon, label, values, editMode, onEdit }: ICPFieldProps) {
+  const [inputVal, setInputVal] = useState(values.join(", "));
+
+  // Sync when values change externally
+  useEffect(() => {
+    setInputVal(values.join(", "));
+  }, [values]);
+
+  const handleChange = (val: string) => {
+    setInputVal(val);
+    onEdit(
+      val
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    );
+  };
+
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{
+        backgroundColor: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.07)",
+      }}
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-text-muted">{icon}</span>
+        <span className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+          {label}
+        </span>
+      </div>
+      {editMode ? (
+        <input
+          type="text"
+          value={inputVal}
+          onChange={(e) => handleChange(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg text-sm text-text-primary bg-transparent"
+          style={{
+            backgroundColor: "rgba(255,255,255,0.05)",
+            border: "1px solid rgba(212, 149, 106, 0.4)",
+          }}
+          placeholder="Comma-separated values..."
+        />
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {values.length > 0 ? (
+            values.slice(0, 6).map((v, i) => (
+              <span
+                key={i}
+                className="px-2.5 py-1 rounded-full text-xs font-medium"
+                style={{
+                  backgroundColor: "rgba(212, 149, 106, 0.12)",
+                  color: "#D4956A",
+                  border: "1px solid rgba(212, 149, 106, 0.25)",
+                }}
+              >
+                {v}
+              </span>
+            ))
+          ) : (
+            <span className="text-xs text-text-muted italic">
+              Not detected
+            </span>
+          )}
+          {values.length > 6 && (
+            <span className="text-xs text-text-muted">
+              +{values.length - 6} more
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Phase 3 onboarding wiring — frontend only.

## Changes
- **Onboarding step 3 (ICP review)**: After analysis completes, show extracted ICP for user review. User confirms or edits, then calls /confirm endpoint before redirecting to dashboard.
- **Leads page progress states**: When redirected from onboarding (?onboarding=true) with no leads yet, show animated discovery → enrichment → scoring progress. Auto-polls every 10s until leads appear.

## What's NOT in this PR (Directive #184 — backend)
- Table routing fix (lead_pool → leads)
- Softening LinkedIn/CRM gates
- Demo mode flag

## Build
pnpm tsc --noEmit: 0 errors ✅