### PR TITLE
Fix P0 (#185): verify_icp_ready_task column name bug

### DIFF
--- a/src/orchestration/flows/post_onboarding_flow.py
+++ b/src/orchestration/flows/post_onboarding_flow.py
@@ -68,7 +68,7 @@ async def verify_icp_ready_task(client_id: UUID) -> dict[str, Any]:
             text("""
             SELECT
                 c.id,
-                c.company_name,
+                c.name,
                 c.tier,
                 c.icp_industries,
                 c.icp_titles,
@@ -104,7 +104,7 @@ async def verify_icp_ready_task(client_id: UUID) -> dict[str, Any]:
     return {
         "ready": True,
         "client_id": str(client_id),
-        "company_name": row.company_name,
+        "company_name": row.name,
         "tier": str(row.tier) if row.tier else "ignition",
         "icp": {
             "industries": row.icp_industries or [],


### PR DESCRIPTION
## Root cause
verify_icp_ready_task raw SQL selects c.company_name. DB column is name. Every post_onboarding_setup_flow has been failing silently since day 1.

## Fix
c.company_name → c.name in raw SQL. Also fixed row.company_name → row.name in the return dict. Audited all other raw SQL in flow files.

## Impact
Unblocks: campaign creation, lead sourcing, enrichment, lead_pool → leads promotion.

## Tests
722 passed, 0 failed (live tests excluded as pre-existing external API dependency)