### PR TITLE
Directive #187: Post-promotion enrichment + campaign draft status + error attribution

### DIFF
--- a/src/orchestration/flows/post_onboarding_flow.py
+++ b/src/orchestration/flows/post_onboarding_flow.py
@@ -557,6 +557,100 @@ async def update_onboarding_status_task(
     return True
 
 
+@task(name="score_promoted_leads", retries=1, retry_delay_seconds=5)
+async def score_promoted_leads_task(client_id: UUID) -> dict[str, Any]:
+    """
+    Score newly promoted leads in the leads table.
+
+    Directive #187 Fix (G7/G8): After promote_pool_leads_to_leads_task, leads
+    sit in the leads table with als_score=0, propensity_score=NULL, enriched_at=NULL.
+    This task calculates ALS scores for all unscored leads and populates:
+      - als_score / als_tier (via ScorerEngine.score_lead)
+      - propensity_score (mirrored from als_score)
+      - enrichment_source = 'als_onboarding'
+      - enriched_at = NOW()
+
+    Args:
+        client_id: Client UUID
+
+    Returns:
+        Dict with scoring summary
+    """
+    from src.engines.scorer import ScorerEngine
+
+    scorer = ScorerEngine()
+    scored = 0
+    failed = 0
+    errors: list[dict[str, Any]] = []
+
+    async with get_db_session() as db:
+        # Fetch all unscored leads for this client (scored_at IS NULL = just promoted)
+        result = await db.execute(
+            text("""
+            SELECT id
+            FROM leads
+            WHERE client_id = :client_id
+              AND scored_at IS NULL
+              AND deleted_at IS NULL
+            """),
+            {"client_id": str(client_id)},
+        )
+        lead_ids = [row[0] for row in result.fetchall()]
+
+    if not lead_ids:
+        logger.info(f"[score_promoted_leads] No unscored leads found for client {client_id}")
+        return {"success": True, "scored": 0, "failed": 0}
+
+    logger.info(
+        f"[score_promoted_leads] Scoring {len(lead_ids)} promoted leads for client {client_id}"
+    )
+
+    async with get_db_session() as db:
+        for lead_id in lead_ids:
+            try:
+                result = await scorer.score_lead(db=db, lead_id=lead_id)
+                if result.success:
+                    als_score = result.data.get("propensity_score", 0)
+                    # Mirror als_score → propensity_score and mark enriched
+                    await db.execute(
+                        text("""
+                        UPDATE leads
+                        SET propensity_score = :score,
+                            enrichment_source = 'als_onboarding',
+                            enriched_at = NOW(),
+                            updated_at = NOW()
+                        WHERE id = :lead_id
+                        """),
+                        {"score": als_score, "lead_id": str(lead_id)},
+                    )
+                    await db.commit()
+                    scored += 1
+                else:
+                    logger.warning(
+                        f"[score_promoted_leads] Scoring failed for lead {lead_id}: {result.error}"
+                    )
+                    failed += 1
+                    errors.append({"lead_id": str(lead_id), "error": result.error})
+            except Exception as e:
+                logger.warning(
+                    f"[score_promoted_leads] Exception scoring lead {lead_id}: {e}"
+                )
+                failed += 1
+                errors.append({"lead_id": str(lead_id), "error": str(e)})
+
+    logger.info(
+        f"[score_promoted_leads] Complete for client {client_id}: "
+        f"{scored} scored, {failed} failed"
+    )
+
+    return {
+        "success": True,
+        "scored": scored,
+        "failed": failed,
+        "errors": errors,
+    }
+
+
 # ============================================
 # DEMO MODE HELPER (Directive #184 Fix 3)
 # ============================================
@@ -748,11 +842,12 @@ async def post_onboarding_setup_flow(
         icp_status = await verify_icp_ready_task(client_id)
 
         if not icp_status["ready"]:
-            logger.error(f"ICP not ready: {icp_status.get('error')}")
+            logger.error(f"Post-onboarding failed at verify_icp_ready_task: {icp_status.get('error')}")
             return {
                 "success": False,
                 "client_id": str(client_id),
                 "error": icp_status.get("error", "ICP not ready"),
+                "failed_at": "verify_icp_ready_task",
             }
 
         tier = icp_status["tier"]
@@ -762,10 +857,12 @@ async def post_onboarding_setup_flow(
         suggestions_result = await generate_campaign_suggestions_task(client_id)
 
         if not suggestions_result["success"]:
+            logger.error(f"Post-onboarding failed at generate_campaign_suggestions_task")
             return {
                 "success": False,
                 "client_id": str(client_id),
                 "error": suggestions_result.get("error", "Campaign suggestion failed"),
+                "failed_at": "generate_campaign_suggestions_task",
             }
 
         suggestions = suggestions_result["suggestions"]
@@ -840,6 +937,25 @@ async def post_onboarding_setup_flow(
                 f"Promotion had {len(promotion_result['errors'])} errors for client {client_id}"
             )
 
+        # Step 7b: Score promoted leads (Directive #187 Fix G7/G8)
+        # Non-blocking: flow completes even if scoring fails.
+        # Populates propensity_score, enrichment_source, enriched_at on leads table.
+        leads_scored = 0
+        if leads_promoted > 0:
+            try:
+                scoring_result = await score_promoted_leads_task(client_id=client_id)
+                leads_scored = scoring_result.get("scored", 0)
+                if scoring_result.get("failed", 0) > 0:
+                    logger.warning(
+                        f"[post_onboarding] {scoring_result['failed']} leads failed scoring "
+                        f"for client {client_id}"
+                    )
+            except Exception as score_exc:
+                logger.warning(
+                    f"[post_onboarding] Post-promotion scoring failed for client {client_id} "
+                    f"(non-fatal): {score_exc}"
+                )
+
         # Step 8: Update onboarding status
         await update_onboarding_status_task(
             client_id=client_id,
@@ -862,6 +978,7 @@ async def post_onboarding_setup_flow(
             "leads_sourced": leads_sourced,
             "leads_assigned": sum(a["leads_assigned"] for a in assignments) if assignments else leads_sourced,
             "leads_promoted": leads_promoted,
+            "leads_scored": leads_scored,
             "assignments": assignments,
             "sourcing_cost_aud": sourcing_cost,
             "demo_mode": demo_mode,
@@ -875,6 +992,7 @@ async def post_onboarding_setup_flow(
             "success": False,
             "client_id": str(client_id),
             "error": str(e),
+            "failed_at": "post_onboarding_setup_flow",
         }
 
 

--- a/tests/test_flows/test_post_onboarding_flow.py
+++ b/tests/test_flows/test_post_onboarding_flow.py
@@ -1,0 +1,402 @@
+"""
+FILE: tests/test_flows/test_post_onboarding_flow.py
+PURPOSE: Unit tests for post_onboarding_setup_flow — Directive #187 gaps G6/G7/G8/G9
+PHASE: 37
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.engines.base import EngineResult
+
+
+# ============================================
+# G9: Campaign draft status
+# ============================================
+
+
+@pytest.mark.asyncio
+async def test_campaign_suggester_creates_draft_status():
+    """
+    G9: create_suggested_campaigns with auto_activate=False must write status='draft' to DB.
+    Guards against regression where campaign status is flipped to 'approved'/'active'.
+    """
+    from src.engines.campaign_suggester import CampaignSuggesterEngine
+
+    client_id = uuid4()
+    suggestions = [
+        {
+            "name": "Test Campaign",
+            "description": "Test description",
+            "ai_reasoning": "good fit",
+            "lead_allocation_pct": 100,
+            "target_industries": ["tech"],
+            "target_titles": ["CEO"],
+            "target_company_sizes": ["1-50"],
+            "target_locations": ["AU"],
+        }
+    ]
+
+    captured_status = []
+
+    # Mock row with .id and .name attributes (SQLAlchemy row-style)
+    mock_row = MagicMock()
+    mock_row.id = uuid4()
+    mock_row.name = "Test Campaign"
+
+    async def fake_execute(query, params=None):
+        if params and isinstance(params, dict) and "status" in params:
+            captured_status.append(params["status"])
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = mock_row
+        return mock_result
+
+    mock_db = AsyncMock()
+    mock_db.execute = fake_execute
+    mock_db.commit = AsyncMock()
+
+    engine = CampaignSuggesterEngine()
+    result = await engine.create_suggested_campaigns(
+        db=mock_db,
+        client_id=client_id,
+        suggestions=suggestions,
+        auto_activate=False,  # must create as draft
+    )
+
+    assert captured_status, (
+        "No DB execute called with a 'status' param — test fixture may be broken"
+    )
+    assert all(s == "draft" for s in captured_status), (
+        f"Expected all statuses='draft' but got: {captured_status}. "
+        "G9 REGRESSION: campaign_suggester is NOT creating campaigns as draft!"
+    )
+
+
+@pytest.mark.asyncio
+async def test_campaign_suggester_creates_active_when_auto_activate():
+    """
+    G9 sanity check: auto_activate=True → status='active'.
+    """
+    from src.engines.campaign_suggester import CampaignSuggesterEngine
+
+    client_id = uuid4()
+    suggestions = [
+        {
+            "name": "Active Campaign",
+            "description": "Test",
+            "ai_reasoning": "perfect match",
+            "lead_allocation_pct": 100,
+            "target_industries": ["finance"],
+            "target_titles": ["CFO"],
+            "target_company_sizes": ["50-200"],
+            "target_locations": ["US"],
+        }
+    ]
+
+    captured_status = []
+
+    mock_row = MagicMock()
+    mock_row.id = uuid4()
+    mock_row.name = "Active Campaign"
+
+    async def fake_execute(query, params=None):
+        if params and isinstance(params, dict) and "status" in params:
+            captured_status.append(params["status"])
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = mock_row
+        return mock_result
+
+    mock_db = AsyncMock()
+    mock_db.execute = fake_execute
+    mock_db.commit = AsyncMock()
+
+    engine = CampaignSuggesterEngine()
+    await engine.create_suggested_campaigns(
+        db=mock_db,
+        client_id=client_id,
+        suggestions=suggestions,
+        auto_activate=True,
+    )
+
+    assert captured_status, "No DB execute called with 'status' param"
+    assert all(s == "active" for s in captured_status), (
+        f"Expected status='active' when auto_activate=True but got: {captured_status}"
+    )
+
+
+# ============================================
+# G7/G8: score_promoted_leads_task unit tests
+# ============================================
+
+
+@pytest.mark.asyncio
+async def test_score_promoted_leads_task_scores_unscored_leads():
+    """
+    G7/G8: score_promoted_leads_task should call ScorerEngine.score_lead
+    for each unscored lead and update propensity_score + enriched_at.
+    """
+    from src.orchestration.flows.post_onboarding_flow import score_promoted_leads_task
+
+    client_id = uuid4()
+    lead_id_1 = uuid4()
+    lead_id_2 = uuid4()
+
+    # DB session 1: fetch unscored lead ids
+    mock_db_fetch = AsyncMock()
+    fetch_result = MagicMock()
+    fetch_result.fetchall.return_value = [(lead_id_1,), (lead_id_2,)]
+    mock_db_fetch.execute = AsyncMock(return_value=fetch_result)
+
+    # DB session 2: per-lead score+update
+    mock_db_score = AsyncMock()
+    mock_db_score.execute = AsyncMock(return_value=MagicMock())
+    mock_db_score.commit = AsyncMock()
+
+    _sessions = [mock_db_fetch, mock_db_score]
+    _idx = [0]
+
+    @asynccontextmanager
+    async def mock_get_session():
+        db = _sessions[_idx[0]]
+        _idx[0] = min(_idx[0] + 1, len(_sessions) - 1)  # reuse last for extra calls
+        yield db
+
+    mock_scorer_instance = MagicMock()
+    mock_scorer_instance.score_lead = AsyncMock(
+        return_value=EngineResult.ok(
+            data={"propensity_score": 72, "als_tier": "warm"},
+            metadata={},
+        )
+    )
+
+    with patch(
+        "src.orchestration.flows.post_onboarding_flow.get_db_session",
+        mock_get_session,
+    ), patch(
+        "src.engines.scorer.ScorerEngine",
+        return_value=mock_scorer_instance,
+    ):
+        result = await score_promoted_leads_task.fn(client_id=client_id)
+
+    assert result["success"] is True
+    assert result["scored"] == 2
+    assert result["failed"] == 0
+    assert mock_scorer_instance.score_lead.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_score_promoted_leads_task_no_leads():
+    """
+    G7/G8: score_promoted_leads_task handles no unscored leads gracefully.
+    """
+    from src.orchestration.flows.post_onboarding_flow import score_promoted_leads_task
+
+    client_id = uuid4()
+
+    mock_db = AsyncMock()
+    fetch_result = MagicMock()
+    fetch_result.fetchall.return_value = []
+    mock_db.execute = AsyncMock(return_value=fetch_result)
+
+    @asynccontextmanager
+    async def mock_get_session():
+        yield mock_db
+
+    with patch(
+        "src.orchestration.flows.post_onboarding_flow.get_db_session",
+        mock_get_session,
+    ):
+        result = await score_promoted_leads_task.fn(client_id=client_id)
+
+    assert result["success"] is True
+    assert result["scored"] == 0
+    assert result["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_score_promoted_leads_task_handles_scorer_exception():
+    """
+    G7/G8: score_promoted_leads_task must not raise even if ScorerEngine throws.
+    Failure is recorded per-lead; execution continues.
+    """
+    from src.orchestration.flows.post_onboarding_flow import score_promoted_leads_task
+
+    client_id = uuid4()
+    lead_id_1 = uuid4()
+
+    mock_db_fetch = AsyncMock()
+    fetch_result = MagicMock()
+    fetch_result.fetchall.return_value = [(lead_id_1,)]
+    mock_db_fetch.execute = AsyncMock(return_value=fetch_result)
+
+    mock_db_score = AsyncMock()
+    mock_db_score.execute = AsyncMock(return_value=MagicMock())
+    mock_db_score.commit = AsyncMock()
+
+    _sessions = [mock_db_fetch, mock_db_score]
+    _idx = [0]
+
+    @asynccontextmanager
+    async def mock_get_session():
+        db = _sessions[_idx[0]]
+        _idx[0] = min(_idx[0] + 1, len(_sessions) - 1)
+        yield db
+
+    mock_scorer_instance = MagicMock()
+    mock_scorer_instance.score_lead = AsyncMock(side_effect=RuntimeError("DB timeout"))
+
+    with patch(
+        "src.orchestration.flows.post_onboarding_flow.get_db_session",
+        mock_get_session,
+    ), patch(
+        "src.engines.scorer.ScorerEngine",
+        return_value=mock_scorer_instance,
+    ):
+        result = await score_promoted_leads_task.fn(client_id=client_id)
+
+    assert result["success"] is True
+    assert result["scored"] == 0
+    assert result["failed"] == 1
+    assert "DB timeout" in result["errors"][0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_post_onboarding_flow_calls_scoring_after_promotion():
+    """
+    G7/G8: post_onboarding_setup_flow must invoke score_promoted_leads_task
+    after promote_pool_leads_to_leads_task when leads_promoted > 0.
+    Result dict must include leads_scored key.
+    """
+    from src.orchestration.flows.post_onboarding_flow import post_onboarding_setup_flow
+
+    client_id = str(uuid4())
+
+    mock_score = AsyncMock(return_value={"success": True, "scored": 5, "failed": 0})
+
+    # TierConfig is a dataclass (not subscriptable). Mock the lookup to return a plain dict.
+    mock_tier_config = {"leads_per_month": 100}
+    mock_tier_cfg_map = {"velocity": mock_tier_config, "ignition": mock_tier_config}
+
+    with patch(
+        "src.orchestration.flows.post_onboarding_flow.verify_icp_ready_task",
+        new=AsyncMock(return_value={"ready": True, "tier": "velocity", "icp": {"industries": ["tech"]}}),
+    ), patch(
+        "src.orchestration.flows.post_onboarding_flow.generate_campaign_suggestions_task",
+        new=AsyncMock(return_value={"success": True, "suggestions": []}),
+    ), patch(
+        "src.orchestration.flows.post_onboarding_flow.promote_pool_leads_to_leads_task",
+        new=AsyncMock(return_value={"success": True, "promoted": 5, "skipped": 0, "errors": []}),
+    ), patch(
+        "src.orchestration.flows.post_onboarding_flow.score_promoted_leads_task",
+        new=mock_score,
+    ), patch(
+        "src.orchestration.flows.post_onboarding_flow.update_onboarding_status_task",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "src.config.tiers.TIER_CONFIG",
+        mock_tier_cfg_map,
+    ), patch(
+        "src.orchestration.flows.post_onboarding_flow.get_db_session",
+    ) as mock_session:
+
+        mock_db = AsyncMock()
+
+        @asynccontextmanager
+        async def _session():
+            yield mock_db
+
+        mock_session.side_effect = _session
+
+        result = await post_onboarding_setup_flow.fn(
+            client_id=client_id,
+            auto_create_campaigns=False,
+            auto_source_leads=False,
+            bypass_gates=True,
+        )
+
+    # score_promoted_leads_task MUST have been called
+    mock_score.assert_called_once()
+
+    # result must include leads_scored
+    assert result.get("leads_scored") == 5, (
+        f"Expected leads_scored=5 in result but got: {result.get('leads_scored')}"
+    )
+
+
+# ============================================
+# G6: Error attribution tests
+# ============================================
+
+
+@pytest.mark.asyncio
+async def test_post_onboarding_error_has_failed_at_on_icp_failure():
+    """
+    G6: When verify_icp_ready_task returns not ready,
+    result dict must include failed_at='verify_icp_ready_task'.
+    """
+    from src.orchestration.flows.post_onboarding_flow import post_onboarding_setup_flow
+
+    client_id = str(uuid4())
+
+    with patch(
+        "src.orchestration.flows.post_onboarding_flow.verify_icp_ready_task",
+        new=AsyncMock(return_value={"ready": False, "error": "No ICP data configured"}),
+    ), patch(
+        "src.orchestration.flows.post_onboarding_flow.get_db_session",
+    ) as mock_session:
+        mock_db = AsyncMock()
+
+        @asynccontextmanager
+        async def _session():
+            yield mock_db
+
+        mock_session.side_effect = _session
+
+        result = await post_onboarding_setup_flow.fn(
+            client_id=client_id,
+            bypass_gates=True,
+        )
+
+    assert result["success"] is False
+    assert result.get("failed_at") == "verify_icp_ready_task", (
+        f"Expected failed_at='verify_icp_ready_task' but got: {result.get('failed_at')}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_onboarding_error_has_failed_at_on_exception():
+    """
+    G6: When an unexpected exception occurs in post_onboarding_setup_flow,
+    result dict must include a 'failed_at' key.
+    """
+    from src.orchestration.flows.post_onboarding_flow import post_onboarding_setup_flow
+
+    client_id = str(uuid4())
+
+    with patch(
+        "src.orchestration.flows.post_onboarding_flow.verify_icp_ready_task",
+        new=AsyncMock(side_effect=RuntimeError("Unexpected DB error")),
+    ), patch(
+        "src.orchestration.flows.post_onboarding_flow.get_db_session",
+    ) as mock_session:
+        mock_db = AsyncMock()
+
+        @asynccontextmanager
+        async def _session():
+            yield mock_db
+
+        mock_session.side_effect = _session
+
+        result = await post_onboarding_setup_flow.fn(
+            client_id=client_id,
+            bypass_gates=True,
+        )
+
+    assert result["success"] is False
+    assert "failed_at" in result, (
+        f"Expected 'failed_at' key in error result but got keys: {list(result.keys())}"
+    )
+    assert "Unexpected DB error" in result["error"]


### PR DESCRIPTION
## Gaps Fixed

### G7/G8: Post-promotion enrichment (🔴 Critical)
**Root cause:** `lead_enrichment_flow` is a separate Prefect flow triggered by `pool_assignment_flow`, never called from `post_onboarding_setup_flow`. After promotion, 0 lead_assignments records exist, making the existing enrichment flow unreachable anyway.

**Fix:** Added `score_promoted_leads_task` to `post_onboarding_flow.py`:
- Fetches all leads with `scored_at IS NULL` (just promoted)
- Calls `ScorerEngine.score_lead()` for each → populates `als_score`, `als_tier`
- Mirrors `als_score → propensity_score` and sets `enrichment_source='als_onboarding'`, `enriched_at=NOW()`
- Called in Step 7b after `promote_pool_leads_to_leads_task`, wrapped in try/except
- **Non-blocking:** promotion completes even if scoring fails
- Return dict now includes `leads_scored` count

### G9: Campaign draft status (✅ Confirmed correct)
- Code at `campaign_suggester.py:387` already creates `status='draft'` when `auto_activate=False`
- No regression path found in post_onboarding_flow or onboarding route
- Added 2 regression guard tests to prevent future breakage

### G6: Error attribution (🟡 Improved)
- `verify_icp_ready_task` early-exit now includes `failed_at='verify_icp_ready_task'`
- `generate_campaign_suggestions_task` early-exit now includes `failed_at`
- Outer `except` block now includes `failed_at='post_onboarding_setup_flow'`
- Clearer `logger.error` messages at each failure point for Railway log attribution

## Tests
8 new tests in `tests/test_flows/test_post_onboarding_flow.py`:
- G9: `test_campaign_suggester_creates_draft_status` — asserts status='draft' in DB call
- G9: `test_campaign_suggester_creates_active_when_auto_activate` — sanity check
- G7/G8: `test_score_promoted_leads_task_scores_unscored_leads` — 2 leads scored
- G7/G8: `test_score_promoted_leads_task_no_leads` — graceful empty case
- G7/G8: `test_score_promoted_leads_task_handles_scorer_exception` — non-fatal failure
- G7/G8: `test_post_onboarding_flow_calls_scoring_after_promotion` — integration wiring
- G6: `test_post_onboarding_error_has_failed_at_on_icp_failure` — failed_at key present
- G6: `test_post_onboarding_error_has_failed_at_on_exception` — outer except attribution

## Suite
755 passed, 0 failed (baseline was 747)