### PR TITLE
Fix: campaign suggestion fallback — removes single point of failure

### DIFF
--- a/src/orchestration/flows/post_onboarding_flow.py
+++ b/src/orchestration/flows/post_onboarding_flow.py
@@ -46,6 +46,22 @@ from src.integrations.supabase import get_db_session
 
 logger = logging.getLogger(__name__)
 
+# Fallback campaign used when AI suggestion fails (Anthropic unavailable/rate-limited/parse error).
+# Ensures downstream tasks (campaign creation, lead sourcing, enrichment) still run.
+FALLBACK_CAMPAIGN_SUGGESTIONS = [
+    {
+        "name": "Australian B2B Outreach",
+        "description": "Default campaign targeting Australian B2B decision-makers based on your ICP.",
+        "campaign_type": "ai_suggested",
+        "lead_allocation_pct": 100,
+        "target_industries": [],  # Will use client ICP industries
+        "target_titles": [],  # Will use client ICP titles
+        "target_locations": ["AU"],
+        "target_company_sizes": [],
+        "ai_reasoning": "Fallback campaign created when AI suggestion unavailable.",
+    }
+]
+
 
 # ============================================
 # TASKS
@@ -857,15 +873,13 @@ async def post_onboarding_setup_flow(
         suggestions_result = await generate_campaign_suggestions_task(client_id)
 
         if not suggestions_result["success"]:
-            logger.error(f"Post-onboarding failed at generate_campaign_suggestions_task")
-            return {
-                "success": False,
-                "client_id": str(client_id),
-                "error": suggestions_result.get("error", "Campaign suggestion failed"),
-                "failed_at": "generate_campaign_suggestions_task",
-            }
-
-        suggestions = suggestions_result["suggestions"]
+            logger.warning(
+                f"AI campaign suggestion failed for client {client_id}: "
+                f"{suggestions_result.get('error')}. Using fallback campaign."
+            )
+            suggestions = FALLBACK_CAMPAIGN_SUGGESTIONS
+        else:
+            suggestions = suggestions_result.get("suggestions", [])
         campaigns_created = []
 
         # Step 3: Create draft campaigns


### PR DESCRIPTION
## Problem
`generate_campaign_suggestions_task` calls Anthropic Claude. On any failure (API error, rate limit, parse error), the flow returned early with `success=False`, aborting ALL downstream tasks. Zero campaigns, zero leads, zero enrichment.

## Fix
When AI suggestions fail, log a warning and use a default fallback campaign ('Australian B2B Outreach') instead of returning early. Pipeline continues: creates 1 default draft campaign, sources leads, enriches, promotes to dashboard.

Added `FALLBACK_CAMPAIGN_SUGGESTIONS` constant at module level (line 51) with sensible defaults (target AU, 100% lead allocation, empty ICP fields that inherit from client ICP).

## Also
- **RAILWAY ANTHROPIC KEY**: GraphQL variables API returned 0 env vars — key is likely **absent** from Railway env. Dave should add ANTHROPIC_API_KEY manually via Railway dashboard (Settings → Variables) for the agency-os service. The fallback fix means the pipeline won't abort if the key is missing, but AI suggestions will be skipped.
- **pool_population_flow stub**: `search_and_populate_pool` in `scout.py` is truly stubbed (Apollo removed, CEO Directive #003). The Tier 1 lookalike block in `pool_population_flow.py` also returns stub results (0 leads added). Documented as gap — not fixed in this PR.
- **Tests**: 754 passed, 1 skipped (live test was flaky in full suite, passes in isolation — pre-existing issue unrelated to this change)