### PR TITLE
Fix: Bright Data GMB input validation — remove invalid location field

### DIFF
--- a/src/integrations/bright_data_client.py
+++ b/src/integrations/bright_data_client.py
@@ -387,7 +387,7 @@ class BrightDataClient:
         """
         results = await self._scraper_request(
             DATASET_IDS["gmb_business"],
-            [{"keyword": category, "country": "AU", "location": location}],
+            [{"keyword": category, "country": "AU"}],
             discover_by="location",
         )
 


### PR DESCRIPTION
## Bug
discover_gmb_by_category() was passing {keyword, country, location} to the Bright Data GMB dataset API. The API rejects the location field with validation_error. Exception was caught silently → records=[] → 0 leads from pool_population_flow.

## Fix
Remove location from the input body. keep discover_by=location as query param (correct usage per API spec).

## Evidence
```
{"error": "Invalid input provided", "code": "validation_error", "errors": [["location", "This input should not contain a location field"]]}
```

## Tests
≥755 passed, 0 failed