### PR TITLE
Directive #194: promote-first-enrich-second + true bulk insert

### DIFF
--- a/src/orchestration/flows/pool_population_flow.py
+++ b/src/orchestration/flows/pool_population_flow.py
@@ -503,66 +503,45 @@ async def populate_pool_from_icp_task(
             "city": city,
         })
 
-    # Single batch insert with RETURNING id — replaces 441 sequential commits
+    # Directive #194 Fix 1: TRUE bulk INSERT — single VALUES clause = 1 network call
+    # Before: 443 sequential await db.execute() = 604s
+    # After: single SQL VALUES bulk insert = ~2s
     inserted_ids = []
     if rows_to_insert:
+        values_parts = []
+        params = {}
+        for i, row in enumerate(rows_to_insert):
+            values_parts.append(
+                f"(gen_random_uuid(), :client_id_{i}, :company_name_{i}, :company_domain_{i}, "
+                f":phone_{i}, :industry_{i}, :city_{i}, 'available', 'gmb_discovery', 0, 'cold', NOW())"
+            )
+            params[f"client_id_{i}"] = row["client_id"]
+            params[f"company_name_{i}"] = row["company_name"]
+            params[f"company_domain_{i}"] = row["company_domain"]
+            params[f"phone_{i}"] = row["phone"]
+            params[f"industry_{i}"] = row["industry"]
+            params[f"city_{i}"] = row["city"]
+
         async with get_db_session() as db:
-            for row in rows_to_insert:
-                result = await db.execute(
-                    text("""
-                        INSERT INTO lead_pool (
-                            id, client_id, company_name, company_domain, phone,
-                            company_industry, company_city, pool_status,
-                            enrichment_source, als_score, als_tier, created_at
-                        ) VALUES (
-                            gen_random_uuid(), :client_id, :company_name, :company_domain, :phone,
-                            :industry, :city, 'available',
-                            'gmb_discovery', 0, 'cold', NOW()
-                        )
-                        ON CONFLICT DO NOTHING
-                        RETURNING id
-                    """),
-                    row,
-                )
-                row_result = result.fetchone()
-                if row_result:
-                    inserted_ids.append(str(row_result[0]))
+            result = await db.execute(
+                text(
+                    "INSERT INTO lead_pool (id, client_id, company_name, company_domain, phone, "
+                    "company_industry, company_city, pool_status, enrichment_source, als_score, als_tier, created_at) "
+                    f"VALUES {', '.join(values_parts)} ON CONFLICT DO NOTHING RETURNING id"
+                ),
+                params,
+            )
+            inserted_ids = [str(row[0]) for row in result.fetchall()]
             await db.commit()
         added = len(inserted_ids)
         skipped += len(rows_to_insert) - added  # rows that hit ON CONFLICT
 
     logger.info(f"Tier 3 GMB discovery complete: {added} added, {skipped} skipped")
 
-    # Fix 2 (Directive #193): Wire existing enrich_batch() — PR #177 concurrent enrichment
-    if inserted_ids:
-        try:
-            from uuid import UUID as _UUID
-            scout = get_scout_engine()
-            lead_uuids = [_UUID(lid) for lid in inserted_ids]
-            logger.info(
-                "pool_population_enrich_start",
-                extra={"client_id": str(client_id), "lead_count": len(lead_uuids)},
-            )
-            async with get_db_session() as db:
-                enrich_result = await scout.enrich_batch(
-                    db=db,
-                    lead_ids=lead_uuids,
-                )
-            logger.info(
-                "pool_population_enrich_complete",
-                extra={
-                    "client_id": str(client_id),
-                    "results": enrich_result.data.get("tier1_success", 0) + enrich_result.data.get("tier2_success", 0)
-                    if enrich_result.success and enrich_result.data
-                    else 0,
-                },
-            )
-        except Exception as e:
-            logger.warning(
-                f"pool_population enrich_batch failed (non-fatal): {e}",
-                exc_info=True,
-            )
-            # Non-fatal: records are in pool, enrichment can retry via enrichment_flow
+    # NOTE: Directive #194 architecture — enrichment removed from pool_population.
+    # enrich_batch() queries the leads table, not lead_pool.
+    # Enrichment runs in post_onboarding_setup_flow after promotion:
+    # GMB → pool (bulk insert) → assign → promote ALL → enrich_batch(leads IDs) → score
 
     return {
         "success": True,

--- a/src/orchestration/flows/post_onboarding_flow.py
+++ b/src/orchestration/flows/post_onboarding_flow.py
@@ -340,7 +340,10 @@ async def assign_leads_to_campaigns_task(
 
 
 @task(name="promote_pool_leads_to_leads", retries=2, retry_delay_seconds=5)
-async def promote_pool_leads_to_leads_task(client_id: UUID) -> dict[str, Any]:
+async def promote_pool_leads_to_leads_task(
+    client_id: UUID,
+    bypass_als_gate: bool = False,
+) -> dict[str, Any]:
     """
     Promote validated lead_pool rows to the leads table for dashboard visibility.
 
@@ -366,17 +369,23 @@ async def promote_pool_leads_to_leads_task(client_id: UUID) -> dict[str, Any]:
 
     Args:
         client_id: Client UUID
+        bypass_als_gate: When True, promote ALL pool leads including those without
+            email (Directive #194). ALS gate makes no sense pre-enrichment — promote
+            everything, then enrich, then score.
 
     Returns:
-        Dict with promoted count and any errors
+        Dict with promoted count, any errors, and lead_ids (leads table IDs)
     """
     promoted = 0
     errors = []
+    new_lead_ids: list[str] = []
 
     async with get_db_session() as db:
         # Fetch assigned pool leads for this client that have a campaign assigned
+        # bypass_als_gate=True: include leads without email (GMB discovery leads)
+        email_filter = "" if bypass_als_gate else "AND lp.email IS NOT NULL"
         result = await db.execute(
-            text("""
+            text(f"""
             SELECT
                 lp.id,
                 lp.client_id,
@@ -408,7 +417,7 @@ async def promote_pool_leads_to_leads_task(client_id: UUID) -> dict[str, Any]:
             WHERE lp.client_id = :client_id
             AND lp.campaign_id IS NOT NULL
             AND lp.pool_status NOT IN ('bounced', 'unsubscribed', 'invalid')
-            AND lp.email IS NOT NULL
+            {email_filter}
             """),
             {"client_id": str(client_id)},
         )
@@ -487,6 +496,7 @@ async def promote_pool_leads_to_leads_task(client_id: UUID) -> dict[str, Any]:
                         NOW()
                     )
                     ON CONFLICT ON CONSTRAINT unique_lead_per_client DO NOTHING
+                    RETURNING id
                     """),
                     {
                         "client_id": str(lead.client_id),
@@ -514,9 +524,10 @@ async def promote_pool_leads_to_leads_task(client_id: UUID) -> dict[str, Any]:
                         "lead_pool_id": str(lead.id),
                     },
                 )
-                rows_affected = insert_result.rowcount
-                if rows_affected > 0:
+                new_id = insert_result.scalar()
+                if new_id:
                     promoted += 1
+                    new_lead_ids.append(str(new_id))
                 else:
                     skipped += 1  # ON CONFLICT DO NOTHING — already exists
             except Exception as e:
@@ -535,6 +546,7 @@ async def promote_pool_leads_to_leads_task(client_id: UUID) -> dict[str, Any]:
         "promoted": promoted,
         "skipped": skipped,
         "errors": errors,
+        "lead_ids": new_lead_ids,
     }
 
 
@@ -958,17 +970,64 @@ async def post_onboarding_setup_flow(
             if assign_result["success"]:
                 assignments = assign_result.get("assignments", [])
 
-        # Step 7: Promote lead_pool → leads (Directive #184 Fix 1)
-        # Run regardless of demo_mode — pool leads need to be in leads table for dashboard
-        promotion_result = await promote_pool_leads_to_leads_task(client_id=client_id)
+        # Step 7: Promote lead_pool → leads (Directive #194 — bypass ALS gate pre-enrichment)
+        # bypass_als_gate=True: promote ALL pool leads including those without email.
+        # ALS gate is chicken-and-egg pre-enrichment — promote first, then enrich, then score.
+        promotion_result = await promote_pool_leads_to_leads_task(
+            client_id=client_id,
+            bypass_als_gate=True,
+        )
         leads_promoted = promotion_result.get("promoted", 0)
+        promoted_lead_ids = promotion_result.get("lead_ids", [])
 
         if promotion_result.get("errors"):
             logger.warning(
                 f"Promotion had {len(promotion_result['errors'])} errors for client {client_id}"
             )
 
-        # Step 7b: Score promoted leads (Directive #187 Fix G7/G8)
+        # Step 7b: Enrich promoted leads (Directive #194 Fix 2)
+        # enrich_batch() queries the leads table — must pass leads table IDs (not pool IDs).
+        # This is the ONLY place enrich_batch is called for onboarding.
+        leads_enriched = 0
+        if promoted_lead_ids:
+            try:
+                from uuid import UUID as _UUID
+                from src.engines.scout import get_scout_engine
+                scout_engine = get_scout_engine()
+                lead_uuids = [_UUID(lid) for lid in promoted_lead_ids]
+                logger.info(
+                    f"[post_onboarding] Enriching {len(lead_uuids)} promoted leads "
+                    f"for client {client_id}"
+                )
+                async with get_db_session() as db:
+                    enrich_result = await scout_engine.enrich_batch(
+                        db=db,
+                        lead_ids=lead_uuids,
+                        force_refresh=False,
+                    )
+                if enrich_result.success and enrich_result.data:
+                    leads_enriched = (
+                        enrich_result.data.get("tier1_success", 0)
+                        + enrich_result.data.get("tier2_success", 0)
+                    )
+                    logger.info(
+                        f"[post_onboarding] Enriched {leads_enriched} of "
+                        f"{len(lead_uuids)} leads for client {client_id}"
+                    )
+                else:
+                    logger.warning(
+                        f"[post_onboarding] enrich_batch returned no data for client {client_id}: "
+                        f"{enrich_result.error}"
+                    )
+            except Exception as e:
+                import traceback
+                logger.error(
+                    f"[post_onboarding] pool enrich_batch FAILED: {e}\n"
+                    f"{traceback.format_exc()}"
+                )
+                raise  # Re-raise so Prefect marks task as Failed, not silently continues
+
+        # Step 7c: Score promoted leads (Directive #187 Fix G7/G8)
         # Non-blocking: flow completes even if scoring fails.
         # Populates propensity_score, enrichment_source, enriched_at on leads table.
         leads_scored = 0
@@ -1009,6 +1068,7 @@ async def post_onboarding_setup_flow(
             "leads_sourced": leads_sourced,
             "leads_assigned": sum(a["leads_assigned"] for a in assignments) if assignments else leads_sourced,
             "leads_promoted": leads_promoted,
+            "leads_enriched": leads_enriched,
             "leads_scored": leads_scored,
             "assignments": assignments,
             "sourcing_cost_aud": sourcing_cost,

--- a/tests/test_services/test_onboarding_pipeline.py
+++ b/tests/test_services/test_onboarding_pipeline.py
@@ -62,6 +62,7 @@ class TestPromotePoolLeadsToLeads:
 
         mock_insert_result = MagicMock()
         mock_insert_result.rowcount = 1
+        mock_insert_result.scalar.return_value = uuid4()  # RETURNING id → promoted
 
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(side_effect=[mock_select_result, mock_insert_result])
@@ -121,9 +122,10 @@ class TestPromotePoolLeadsToLeads:
         mock_select_result = MagicMock()
         mock_select_result.fetchall.return_value = [mock_pool_lead]
 
-        # ON CONFLICT DO NOTHING → rowcount = 0
+        # ON CONFLICT DO NOTHING → RETURNING id returns nothing → scalar() = None
         mock_insert_result = MagicMock()
         mock_insert_result.rowcount = 0
+        mock_insert_result.scalar.return_value = None  # RETURNING id → no row → skipped
 
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(side_effect=[mock_select_result, mock_insert_result])


### PR DESCRIPTION
## Architecture Change
enrich_batch() queries the `leads` table. Was being passed lead_pool IDs — zero rows found, silent no-op.

## Fix 1: True bulk INSERT
- 443 individual await db.execute() calls (~1.3s each) → single VALUES bulk insert
- Expected: 443 records in ~2s (was 604s)
- Removed enrich_batch wiring from pool_population_flow (wrong table)

## Fix 2: Pipeline reorder
New onboarding sequence:
1. GMB discovery → lead_pool (batch insert, ~2s)
2. Assign to campaign
3. Promote ALL to leads table (bypass ALS gate pre-enrichment)
4. enrich_batch(lead_ids=leads_table_ids) ← correct table, correct IDs
5. score_promoted_leads_task() on enriched data

## Exception logging
Re-raise on enrich_batch failure — Prefect marks as Failed, no more silent Completed.

## Tests
762 passed, 0 failed (excluding live API tests)