### PR TITLE
Directive #196: pipeline resilience — retry + graceful degradation

### DIFF
--- a/migrations/directive_196_enrichment_status.sql
+++ b/migrations/directive_196_enrichment_status.sql
@@ -1,0 +1,31 @@
+-- Directive #196: Partial enrichment status tracking
+-- DO NOT RUN AUTOMATICALLY — apply manually via Dave or migration runner
+-- This adds a dedicated enrichment_status column to leads for faster querying.
+-- The metadata JSONB field is already being used for full tier tracking
+-- (see metadata->'enrichment_tracking'). This column is a queryable summary.
+
+-- Add enrichment_status column to leads table
+ALTER TABLE leads
+  ADD COLUMN IF NOT EXISTS enrichment_status TEXT
+    CHECK (enrichment_status IN ('fully_enriched', 'partially_enriched', 'discovery_only'))
+    DEFAULT 'discovery_only';
+
+-- Index for fast filtering by enrichment status
+CREATE INDEX IF NOT EXISTS idx_leads_enrichment_status ON leads (enrichment_status)
+  WHERE deleted_at IS NULL;
+
+-- Backfill: leads with enriched_at already set are fully_enriched
+UPDATE leads
+SET enrichment_status = 'fully_enriched'
+WHERE enriched_at IS NOT NULL
+  AND deleted_at IS NULL
+  AND enrichment_status = 'discovery_only';
+
+-- Backfill from existing metadata JSONB (for leads enriched via Directive #196 logic)
+UPDATE leads
+SET enrichment_status = (metadata->'enrichment_tracking'->>'status')::TEXT
+WHERE metadata->'enrichment_tracking'->>'status' IS NOT NULL
+  AND deleted_at IS NULL;
+
+-- Verify
+SELECT enrichment_status, COUNT(*) FROM leads WHERE deleted_at IS NULL GROUP BY enrichment_status;

--- a/src/engines/scout.py
+++ b/src/engines/scout.py
@@ -512,6 +512,20 @@ class ScoutEngine(BaseEngine):
                     result["source"] = f"siege_waterfall_{siege_result.sources_used}sources"
                     result["enrichment_cost_aud"] = siege_result.total_cost_aud
 
+                    # Directive #196: Partial enrichment tracking — tiers succeeded/failed
+                    tiers_attempted = [
+                        tr.tier.value for tr in siege_result.tier_results if not tr.skipped
+                    ]
+                    tiers_failed = [
+                        tr.tier.value
+                        for tr in siege_result.tier_results
+                        if not tr.success and not tr.skipped
+                    ]
+                    enrichment_status = "fully_enriched" if not tiers_failed else "partially_enriched"
+                    result["_enrichment_tier_results"] = tiers_attempted
+                    result["_enrichment_tiers_failed"] = tiers_failed
+                    result["_enrichment_status"] = enrichment_status
+
                     # Log successful SIEGE enrichment
                     await self._log_enrichment_audit(
                         operation="siege_waterfall",
@@ -942,6 +956,23 @@ class ScoutEngine(BaseEngine):
                     )
             except (ValueError, TypeError):
                 pass
+
+        # Directive #196: Partial enrichment status — write tier results to metadata JSONB
+        tiers_attempted = enrichment.get("_enrichment_tier_results")
+        tiers_failed = enrichment.get("_enrichment_tiers_failed")
+        enrichment_status = enrichment.get("_enrichment_status")
+        if tiers_attempted is not None:
+            partial_tracking = {
+                "tiers_attempted": tiers_attempted,
+                "tiers_failed": tiers_failed or [],
+                "status": enrichment_status or "discovery_only",
+            }
+            # Merge into existing metadata (don't overwrite other keys)
+            # Note: Lead.metadata DB column is mapped as Lead.lead_metadata to avoid
+            # name conflict with SQLAlchemy's declarative MetaData attribute.
+            existing_metadata = getattr(lead, "lead_metadata", None) or {}
+            merged_metadata = {**existing_metadata, "enrichment_tracking": partial_tracking}
+            update_data["lead_metadata"] = merged_metadata
 
         # Remove None values
         update_data = {k: v for k, v in update_data.items() if v is not None}

--- a/src/integrations/bright_data_client.py
+++ b/src/integrations/bright_data_client.py
@@ -308,7 +308,37 @@ class BrightDataClient:
     async def _scraper_request(
         self, dataset_id: str, inputs: list[dict], discover_by: str = None
     ) -> list[dict]:
-        """Execute Scraper API: trigger → poll → download."""
+        """Execute Scraper API: trigger → poll → download.
+
+        Directive #196: Retries once on snapshot timeout (transient BD issue).
+        Max 2 attempts total, 30s wait between attempts.
+        """
+        max_attempts = 2
+        retry_wait_seconds = 30
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                return await self._scraper_request_attempt(dataset_id, inputs, discover_by)
+            except BrightDataError as e:
+                if "timeout" in str(e).lower() and attempt < max_attempts:
+                    logger.warning(
+                        "bd_scraper_retry",
+                        attempt=attempt,
+                        dataset_id=dataset_id,
+                        error=str(e),
+                        retry_in_seconds=retry_wait_seconds,
+                    )
+                    await asyncio.sleep(retry_wait_seconds)
+                    continue
+                raise
+
+        # Should not be reached, but satisfy type checker
+        raise BrightDataError("_scraper_request: exhausted retries")  # pragma: no cover
+
+    async def _scraper_request_attempt(
+        self, dataset_id: str, inputs: list[dict], discover_by: str = None
+    ) -> list[dict]:
+        """Single attempt of Scraper API: trigger → poll → download."""
         base_url = "https://api.brightdata.com/datasets/v3"
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
 

--- a/src/integrations/siege_waterfall.py
+++ b/src/integrations/siege_waterfall.py
@@ -696,7 +696,12 @@ class SiegeWaterfall:
 
         # ===== TIER 1: ABN Bulk =====
         if EnrichmentTier.ABN not in skip_tiers:
-            result = await self.tier1_abn(enriched_data)
+            try:
+                result = await self.tier1_abn(enriched_data)
+            except Exception as e:
+                # Directive #196: per-tier graceful degradation — tier failure must not crash enrichment
+                logger.warning(f"[enrich_lead] Tier 1 ABN raised unexpectedly: {e}")
+                result = TierResult(tier=EnrichmentTier.ABN, success=False, error=str(e))
             tier_results.append(result)
             if result.success:
                 enriched_data = self._merge_data(
@@ -734,7 +739,12 @@ class SiegeWaterfall:
 
         # ===== TIER 1.5: BD LinkedIn Company =====
         if EnrichmentTier.LINKEDIN_COMPANY not in skip_tiers:
-            result = await self.tier1_5_linkedin_company(enriched_data, icp_passed=True)
+            try:
+                result = await self.tier1_5_linkedin_company(enriched_data, icp_passed=True)
+            except Exception as e:
+                # Directive #196: per-tier graceful degradation
+                logger.warning(f"[enrich_lead] Tier 1.5 LinkedIn raised unexpectedly: {e}")
+                result = TierResult(tier=EnrichmentTier.LINKEDIN_COMPANY, success=False, error=str(e))
             tier_results.append(result)
             if result.success:
                 enriched_data = self._merge_data(
@@ -890,7 +900,12 @@ class SiegeWaterfall:
                 logger.info("[T2] Skipping GMB enrichment — T0 already has data")
             else:
                 # Fallback: T0 didn't provide GMB data (shouldn't happen in GMB-first mode)
-                result = await self.tier2_gmb(enriched_data)
+                try:
+                    result = await self.tier2_gmb(enriched_data)
+                except Exception as e:
+                    # Directive #196: per-tier graceful degradation
+                    logger.warning(f"[enrich_lead] Tier 2 GMB raised unexpectedly: {e}")
+                    result = TierResult(tier=EnrichmentTier.GMB, success=False, error=str(e))
                 tier_results.append(result)
                 if result.success:
                     enriched_data = self._merge_data(
@@ -916,7 +931,12 @@ class SiegeWaterfall:
             current_als = self._calculate_als(enriched_data)
 
             if current_als >= 35:
-                result = await self.tier3_leadmagic_email(enriched_data)
+                try:
+                    result = await self.tier3_leadmagic_email(enriched_data)
+                except Exception as e:
+                    # Directive #196: per-tier graceful degradation
+                    logger.warning(f"[enrich_lead] Tier 3 Leadmagic email raised unexpectedly: {e}")
+                    result = TierResult(tier=EnrichmentTier.LEADMAGIC_EMAIL, success=False, error=str(e))
                 tier_results.append(result)
                 if result.success:
                     enriched_data = self._merge_data(
@@ -951,7 +971,12 @@ class SiegeWaterfall:
             current_als = self._calculate_als(enriched_data)
 
             if current_als >= 85 or force_tier5:
-                result = await self.tier5_identity(enriched_data, current_als, force=force_tier5)
+                try:
+                    result = await self.tier5_identity(enriched_data, current_als, force=force_tier5)
+                except Exception as e:
+                    # Directive #196: per-tier graceful degradation
+                    logger.warning(f"[enrich_lead] Tier 5 Identity raised unexpectedly: {e}")
+                    result = TierResult(tier=EnrichmentTier.IDENTITY, success=False, error=str(e))
                 tier_results.append(result)
                 if result.success:
                     enriched_data = self._merge_data(

--- a/src/orchestration/flows/pool_population_flow.py
+++ b/src/orchestration/flows/pool_population_flow.py
@@ -465,6 +465,38 @@ async def populate_pool_from_icp_task(
         logger.warning(f"GMB batch discovery failed: {e}")
         records = []
 
+    # Directive #196 FIX 5: GMB fallback — retry with single keyword if 0 records
+    if not records:
+        fallback_industry = industries[0] if industries else "marketing"
+        fallback_keyword = _map_industry_to_gmb_category(fallback_industry)
+        logger.warning(
+            f"GMB discovery returned 0 records, retrying with single keyword: {fallback_keyword!r}"
+        )
+        try:
+            records = await bd_client._scraper_request(
+                DATASET_IDS["gmb_business"],
+                [{"keyword": fallback_keyword, "country": "AU"}],
+                discover_by="location",
+            )
+            logger.info(f"GMB fallback query returned {len(records)} records")
+        except Exception as e:
+            logger.warning(f"GMB fallback discovery also failed: {e}")
+            records = []
+
+    if not records:
+        logger.warning(
+            f"GMB discovery returned 0 records after fallback for client={client_id}. "
+            "Returning graceful success — pipeline continues."
+        )
+        return {
+            "success": True,
+            "added": 0,
+            "skipped": 0,
+            "suppressed": 0,
+            "total": 0,
+            "fallback": "no_gmb_records",
+        }
+
     # Fix 1 (Directive #193): Collect all rows first, then single batch insert
     rows_to_insert = []
     for record in records:

--- a/tests/test_flows/test_directive_196_resilience.py
+++ b/tests/test_flows/test_directive_196_resilience.py
@@ -1,0 +1,182 @@
+"""
+FILE: tests/test_flows/test_directive_196_resilience.py
+PURPOSE: Tests for Directive #196 — Pipeline Resilience
+         - BD _scraper_request retry on timeout
+         - Pool population graceful return when GMB returns 0 records
+         - Per-tier graceful degradation in enrich_lead
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+# ============================================
+# FIX 5: test_pool_population_handles_empty_gmb
+# ============================================
+
+@pytest.mark.asyncio
+async def test_pool_population_handles_empty_gmb():
+    """
+    FIX 5: populate_pool_from_icp_task should return success with added=0 when
+    BD returns 0 records (even after the fallback retry), rather than crashing.
+    """
+    from src.orchestration.flows.pool_population_flow import populate_pool_from_icp_task
+
+    client_id = uuid4()
+    icp_criteria = {
+        "icp_industries": ["marketing"],
+        "icp_locations": ["Australia"],
+    }
+
+    # Mock BD client: both primary and fallback calls return empty list
+    mock_bd = AsyncMock()
+    mock_bd._scraper_request = AsyncMock(return_value=[])
+
+    with (
+        patch(
+            "src.integrations.bright_data_client.get_bright_data_client",
+            return_value=mock_bd,
+        ),
+    ):
+        result = await populate_pool_from_icp_task.fn(
+            client_id=client_id,
+            icp_criteria=icp_criteria,
+            limit=25,
+        )
+
+    assert result["success"] is True
+    assert result["added"] == 0
+    assert result.get("fallback") == "no_gmb_records"
+
+
+# ============================================
+# FIX 3: test_enrich_tier_failure_continues
+# ============================================
+
+@pytest.mark.asyncio
+async def test_enrich_tier_failure_continues():
+    """
+    FIX 3: When one enrichment tier raises an unexpected exception, subsequent tiers
+    must still run. Specifically: T1 ABN raising should NOT prevent T3 Leadmagic.
+    """
+    from src.integrations.siege_waterfall import EnrichmentTier, SiegeWaterfall, TierResult
+
+    waterfall = SiegeWaterfall()
+
+    # T1 ABN: raises an unexpected exception
+    async def boom_abn(lead):
+        raise RuntimeError("ABN service exploded")
+
+    # T1.5 LinkedIn: returns skipped (no URL)
+    async def skip_linkedin(lead, icp_passed=True):
+        return TierResult(
+            tier=EnrichmentTier.LINKEDIN_COMPANY,
+            success=False,
+            skipped=True,
+            skip_reason="No company LinkedIn URL available",
+        )
+
+    # T3 Leadmagic: returns success (verifies it ran despite T1 failure)
+    async def success_leadmagic(lead):
+        return TierResult(
+            tier=EnrichmentTier.LEADMAGIC_EMAIL,
+            success=True,
+            data={"email": "test@example.com"},
+            cost_aud=0.015,
+        )
+
+    # T2 GMB: returns skipped
+    async def skip_gmb(lead):
+        return TierResult(
+            tier=EnrichmentTier.GMB,
+            success=False,
+            skipped=True,
+            skip_reason="T0 discovery already has GMB data (T0/T2 merge)",
+        )
+
+    # T5: skipped
+    async def skip_t5(lead, als, force=False):
+        return TierResult(
+            tier=EnrichmentTier.IDENTITY,
+            success=False,
+            skipped=True,
+            skip_reason="ALS 40 < 85 threshold",
+        )
+
+    waterfall.tier1_abn = boom_abn
+    waterfall.tier1_5_linkedin_company = skip_linkedin
+    waterfall.tier2_gmb = skip_gmb
+    waterfall.tier3_leadmagic_email = success_leadmagic
+    waterfall.tier5_identity = skip_t5
+
+    # Also mock resolve_linkedin_url — tag linkedin_url_unknown=True so SIZE_GATE is bypassed
+    async def skip_resolve(lead):
+        return TierResult(
+            tier=EnrichmentTier.LINKEDIN_COMPANY,
+            success=False,
+            data={"linkedin_url_unknown": True},  # Bypass SIZE_GATE (Directive #148)
+            skip_reason="No company LinkedIn URL found via SERP",
+        )
+
+    waterfall.resolve_linkedin_url = skip_resolve
+
+    # Patch _calculate_als to return 40 (above T3 gate of 35, below T5 gate of 85)
+    with patch.object(waterfall, "_calculate_als", return_value=40):
+        result = await waterfall.enrich_lead(
+            {
+                "company_name": "Acme Corp",
+                "email": "owner@acme.com.au",
+                "domain": "acme.com.au",
+                "company_linkedin_url": None,
+            },
+            skip_tiers=[],
+        )
+
+    # T1 failed (exception swallowed) — should appear as failed tier
+    t1_results = [r for r in result.tier_results if r.tier == EnrichmentTier.ABN]
+    assert len(t1_results) == 1
+    assert t1_results[0].success is False
+    assert "ABN service exploded" in (t1_results[0].error or "")
+
+    # T3 Leadmagic should have succeeded (proving it ran despite T1 failure)
+    t3_results = [r for r in result.tier_results if r.tier == EnrichmentTier.LEADMAGIC_EMAIL]
+    assert len(t3_results) == 1, "Tier 3 should have run despite Tier 1 failure"
+    assert t3_results[0].success is True, "Tier 3 should have succeeded"
+
+    # At least 1 source used (T3)
+    assert result.sources_used >= 1
+
+
+# ============================================
+# FIX 1: test_scraper_request_retries_on_timeout
+# ============================================
+
+@pytest.mark.asyncio
+async def test_scraper_request_retries_on_timeout():
+    """
+    FIX 1: _scraper_request should retry once (with 30s wait) when the first
+    attempt times out, and succeed on the second attempt.
+    """
+    from src.integrations.bright_data_client import BrightDataClient, BrightDataError
+
+    call_count = 0
+
+    async def mock_attempt(dataset_id, inputs, discover_by=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise BrightDataError("Scraper timeout for snapshot snap-abc123")
+        return [{"name": "Test Biz"}]
+
+    client = BrightDataClient.__new__(BrightDataClient)
+    client._scraper_request_attempt = mock_attempt
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        result = await client._scraper_request("ds-123", [{"keyword": "plumber", "country": "AU"}])
+
+    assert call_count == 2, "Should have retried exactly once"
+    assert result == [{"name": "Test Biz"}]
+    # Verify 30s wait between attempts
+    mock_sleep.assert_called_once_with(30)


### PR DESCRIPTION
## Context
Run 10 of #185 failed due to transient BD snapshot timeout. Launch-critical fix.

## Changes

### BD retry (bright_data_client.py)
- `_scraper_request`: extracted to `_scraper_request_attempt` helper
- Outer retry loop: timeout → wait 30s → retry once (max 2 attempts)
- Logged: `bd_scraper_retry` event with attempt number + snapshot info

### Prefect retries (pool_population_flow.py)
- All pool_population external tasks already have `retries=2, retry_delay_seconds=10` ✅

### Per-tier graceful degradation (siege_waterfall.py)
- T1 ABN, T1.5 LinkedIn, T2 GMB, T3 Leadmagic, T5 Identity: each wrapped in `try/except`
- Exception in any tier → TierResult(success=False) logged, enrichment continues
- Lead always promoted with available data from successful tiers

### Partial enrichment tracking (scout.py + leads table)
- Siege Waterfall result: `_enrichment_tier_results`, `_enrichment_tiers_failed`, `_enrichment_status` added to enrichment dict
- `_update_lead_from_enrichment`: saves tracking to `leads.lead_metadata` JSONB as `enrichment_tracking`
- Status values: `fully_enriched` | `partially_enriched` | `discovery_only`
- Migration SQL (DO NOT RUN — Dave runs): `migrations/directive_196_enrichment_status.sql`

### GMB fallback (pool_population_flow.py)
- 0 records → retry with single keyword (fallback query)
- Still 0 → return `{success: True, added: 0, fallback: 'no_gmb_records'}` — pipeline continues

## Tests
779 passed, 0 failed (+ 3 new resilience tests):
- `test_pool_population_handles_empty_gmb` — BD returning [] → success with added=0
- `test_enrich_tier_failure_continues` — T1 raising exception → T3 still runs
- `test_scraper_request_retries_on_timeout` — timeout → 30s wait → retry once