### PR TITLE
Fix allocate_leads UPDATE WHERE clause (client_id IS NULL → client_id = :client_id)

### DIFF
--- a/src/services/lead_allocator_service.py
+++ b/src/services/lead_allocator_service.py
@@ -182,7 +182,8 @@ class LeadAllocatorService:
                     pool_status = 'assigned',
                     updated_at = NOW()
                 WHERE id = :lead_pool_id
-                AND client_id IS NULL
+                AND client_id = :client_id
+                AND pool_status = 'available'
                 RETURNING id
             """)
 


### PR DESCRIPTION
## Bug
Phase 37 GMB leads are inserted with client_id pre-set.
UPDATE guard `AND client_id IS NULL` rejected all 445 records — 0 leads assigned across 12 E2E runs.

## Fix
```sql
-- Before
WHERE id = :lead_pool_id
AND client_id IS NULL

-- After  
WHERE id = :lead_pool_id
AND client_id = :client_id
AND pool_status = 'available'
```

## Tests
777 passed, 0 failed