### PR TITLE
Directive #197: bulk assignment + decouple enrichment (Flow A/B split)

### DIFF
--- a/src/orchestration/flows/post_onboarding_flow.py
+++ b/src/orchestration/flows/post_onboarding_flow.py
@@ -772,7 +772,7 @@ async def inject_demo_leads(client_id: UUID, campaign_id: UUID) -> int:
     description="Generate campaigns and source leads after onboarding",
     task_runner=ConcurrentTaskRunner(),
     retries=0,
-    timeout_seconds=900,  # 15 minute timeout (increased for batched BD job)
+    timeout_seconds=1800,  # Directive #197: raised from 900s → 1800s (Flow A now ~5 min, headroom for retries)
 )
 async def post_onboarding_setup_flow(
     client_id: str | UUID,
@@ -985,66 +985,70 @@ async def post_onboarding_setup_flow(
                 f"Promotion had {len(promotion_result['errors'])} errors for client {client_id}"
             )
 
-        # Step 7b: Enrich promoted leads (Directive #194 Fix 2)
-        # enrich_batch() queries the leads table — must pass leads table IDs (not pool IDs).
-        # This is the ONLY place enrich_batch is called for onboarding.
-        leads_enriched = 0
-        if promoted_lead_ids:
-            try:
-                from uuid import UUID as _UUID
-                from src.engines.scout import get_scout_engine
-                scout_engine = get_scout_engine()
-                lead_uuids = [_UUID(lid) for lid in promoted_lead_ids]
-                logger.info(
-                    f"[post_onboarding] Enriching {len(lead_uuids)} promoted leads "
-                    f"for client {client_id}"
-                )
-                async with get_db_session() as db:
-                    enrich_result = await scout_engine.enrich_batch(
-                        db=db,
-                        lead_ids=lead_uuids,
-                        force_refresh=False,
-                    )
-                if enrich_result.success and enrich_result.data:
-                    leads_enriched = (
-                        enrich_result.data.get("tier1_success", 0)
-                        + enrich_result.data.get("tier2_success", 0)
-                    )
-                    logger.info(
-                        f"[post_onboarding] Enriched {leads_enriched} of "
-                        f"{len(lead_uuids)} leads for client {client_id}"
-                    )
-                else:
-                    logger.warning(
-                        f"[post_onboarding] enrich_batch returned no data for client {client_id}: "
-                        f"{enrich_result.error}"
-                    )
-            except Exception as e:
-                import traceback
-                logger.error(
-                    f"[post_onboarding] pool enrich_batch FAILED: {e}\n"
-                    f"{traceback.format_exc()}"
-                )
-                raise  # Re-raise so Prefect marks task as Failed, not silently continues
+        # Step 7b: Directive #197 FIX 3 — Two-flow architecture.
+        # Flow A (onboarding) fires-and-forgets enrichment to Flow B (daily_enrichment_flow).
+        # Flow A returns immediately after promotion — customer sees leads in dashboard ~5 min.
+        # Flow B (enrichment) runs async in background — enrichment data fills in over ~10 min.
+        #
+        # Query unenriched leads directly — works on FIRST RUN and RE-RUNS.
+        # Old approach: rely on promoted_lead_ids [] from re-runs → silent skip (bug).
+        import time as _time
+        import httpx as _httpx
 
-        # Step 7c: Score promoted leads (Directive #187 Fix G7/G8)
-        # Non-blocking: flow completes even if scoring fails.
-        # Populates propensity_score, enrichment_source, enriched_at on leads table.
-        leads_scored = 0
-        if leads_promoted > 0:
-            try:
-                scoring_result = await score_promoted_leads_task(client_id=client_id)
-                leads_scored = scoring_result.get("scored", 0)
-                if scoring_result.get("failed", 0) > 0:
-                    logger.warning(
-                        f"[post_onboarding] {scoring_result['failed']} leads failed scoring "
-                        f"for client {client_id}"
+        leads_enriched = 0  # enrichment now async — Flow B tracks its own count
+        leads_scored = 0    # scoring happens inside Flow B after enrichment
+
+        try:
+            async with get_db_session() as _db:
+                _unenriched_result = await _db.execute(text("""
+                    SELECT id FROM leads
+                    WHERE client_id = :client_id
+                      AND status = 'new'
+                      AND (enrichment_source IS NULL OR enrichment_source = '')
+                    LIMIT 500
+                """), {"client_id": str(client_id)})
+                unenriched_ids = [str(row.id) for row in _unenriched_result.fetchall()]
+
+            unenriched_count = len(unenriched_ids)
+            logger.info(
+                f"[post_onboarding] enrichment_trigger: client={client_id} "
+                f"unenriched_leads={unenriched_count}"
+            )
+
+            if unenriched_count > 0:
+                # Fire-and-forget: POST to enrichment-flow Prefect deployment (ID: 23f36d60).
+                # Flow A does NOT wait — returns success immediately after posting.
+                try:
+                    async with _httpx.AsyncClient(timeout=10) as _http:
+                        _resp = await _http.post(
+                            "https://prefect-server-production-f9b1.up.railway.app"
+                            "/api/deployments/23f36d60/create_flow_run",
+                            json={
+                                "parameters": {"client_id": str(client_id)},
+                                "name": f"enrichment-{str(client_id)[:8]}-{int(_time.time())}",
+                            },
+                        )
+                    enrichment_run_id = _resp.json().get("id", "unknown")
+                    logger.info(
+                        f"[post_onboarding] enrichment_flow_triggered: "
+                        f"run_id={enrichment_run_id} leads={unenriched_count}"
                     )
-            except Exception as score_exc:
-                logger.warning(
-                    f"[post_onboarding] Post-promotion scoring failed for client {client_id} "
-                    f"(non-fatal): {score_exc}"
+                except Exception as _trig_exc:
+                    # Non-fatal — leads exist in dashboard; enrichment can be retried manually.
+                    logger.warning(
+                        f"[post_onboarding] enrichment_trigger_failed (non-fatal): {_trig_exc}"
+                    )
+            else:
+                logger.info(
+                    f"[post_onboarding] No unenriched leads for client {client_id} — "
+                    "skipping enrichment trigger"
                 )
+
+        except Exception as _enrich_exc:
+            # Non-fatal: leads are promoted and visible; enrichment can be retried.
+            logger.warning(
+                f"[post_onboarding] enrichment trigger block failed (non-fatal): {_enrich_exc}"
+            )
 
         # Step 8: Update onboarding status
         await update_onboarding_status_task(

--- a/src/services/lead_allocator_service.py
+++ b/src/services/lead_allocator_service.py
@@ -169,47 +169,43 @@ class LeadAllocatorService:
         if not leads_to_assign:
             return []
 
-        # Phase 37: Assign leads directly by setting client_id on lead_pool
-        assigned_leads = []
-        for lead in leads_to_assign:
-            lead_pool_id = lead.id
+        # Directive #197 FIX 1: Bulk UPDATE replaces N sequential UPDATEs.
+        # 440 leads: ~496s → ~2s. Single SQL round-trip via ANY(:ids::uuid[]).
+        lead_ids = [str(lead.id) for lead in leads_to_assign]
 
-            # Update lead_pool directly with client/campaign ownership
-            assign_query = text("""
-                UPDATE lead_pool
-                SET client_id = :client_id,
-                    campaign_id = :campaign_id,
-                    pool_status = 'assigned',
-                    updated_at = NOW()
-                WHERE id = :lead_pool_id
-                AND client_id = :client_id
-                AND pool_status = 'available'
-                RETURNING id
-            """)
+        bulk_update = text("""
+            UPDATE lead_pool
+            SET campaign_id = :campaign_id,
+                pool_status = 'assigned',
+                updated_at = NOW()
+            WHERE id = ANY(:lead_ids::uuid[])
+              AND client_id = :client_id
+              AND pool_status = 'available'
+            RETURNING id, email, first_name, last_name, title, company_name
+        """)
 
-            assign_result = await self.session.execute(
-                assign_query,
-                {
-                    "lead_pool_id": str(lead_pool_id),
-                    "client_id": str(client_id),
-                    "campaign_id": str(campaign_id) if campaign_id else None,
-                },
-            )
-            updated = assign_result.fetchone()
-
-            if updated:
-                assigned_leads.append(
-                    {
-                        "lead_pool_id": str(lead_pool_id),
-                        "email": lead.email,
-                        "first_name": lead.first_name,
-                        "last_name": lead.last_name,
-                        "title": lead.title,
-                        "company_name": lead.company_name,
-                    }
-                )
-
+        bulk_result = await self.session.execute(
+            bulk_update,
+            {
+                "lead_ids": lead_ids,
+                "client_id": str(client_id),
+                "campaign_id": str(campaign_id) if campaign_id else None,
+            },
+        )
+        updated_rows = bulk_result.fetchall()
         await self.session.commit()
+
+        assigned_leads = [
+            {
+                "lead_pool_id": str(row.id),
+                "email": row.email,
+                "first_name": row.first_name,
+                "last_name": row.last_name,
+                "title": row.title,
+                "company_name": row.company_name,
+            }
+            for row in updated_rows
+        ]
 
         if len(assigned_leads) == 0:
             logger.warning(

--- a/tests/test_flows/test_post_onboarding_flow.py
+++ b/tests/test_flows/test_post_onboarding_flow.py
@@ -266,15 +266,14 @@ async def test_score_promoted_leads_task_handles_scorer_exception():
 @pytest.mark.asyncio
 async def test_post_onboarding_flow_calls_scoring_after_promotion():
     """
-    G7/G8: post_onboarding_setup_flow must invoke score_promoted_leads_task
-    after promote_pool_leads_to_leads_task when leads_promoted > 0.
-    Result dict must include leads_scored key.
+    Directive #197 FIX 3: post_onboarding_setup_flow now uses two-flow architecture.
+    After promotion, Flow A fires-and-forgets enrichment to Flow B (daily_enrichment_flow).
+    score_promoted_leads_task is NO LONGER called inline — scoring happens inside Flow B.
+    Result dict must include leads_scored=0 (async) and leads_enriched=0 (async).
     """
     from src.orchestration.flows.post_onboarding_flow import post_onboarding_setup_flow
 
     client_id = str(uuid4())
-
-    mock_score = AsyncMock(return_value={"success": True, "scored": 5, "failed": 0})
 
     # TierConfig is a dataclass (not subscriptable). Mock the lookup to return a plain dict.
     mock_tier_config = {"leads_per_month": 100}
@@ -290,9 +289,6 @@ async def test_post_onboarding_flow_calls_scoring_after_promotion():
         "src.orchestration.flows.post_onboarding_flow.promote_pool_leads_to_leads_task",
         new=AsyncMock(return_value={"success": True, "promoted": 5, "skipped": 0, "errors": []}),
     ), patch(
-        "src.orchestration.flows.post_onboarding_flow.score_promoted_leads_task",
-        new=mock_score,
-    ), patch(
         "src.orchestration.flows.post_onboarding_flow.update_onboarding_status_task",
         new=AsyncMock(return_value=True),
     ), patch(
@@ -303,6 +299,8 @@ async def test_post_onboarding_flow_calls_scoring_after_promotion():
     ) as mock_session:
 
         mock_db = AsyncMock()
+        # Mock DB to return unenriched leads (simulates real DB query)
+        mock_db.execute.return_value.fetchall.return_value = []
 
         @asynccontextmanager
         async def _session():
@@ -317,13 +315,17 @@ async def test_post_onboarding_flow_calls_scoring_after_promotion():
             bypass_gates=True,
         )
 
-    # score_promoted_leads_task MUST have been called
-    mock_score.assert_called_once()
-
-    # result must include leads_scored
-    assert result.get("leads_scored") == 5, (
-        f"Expected leads_scored=5 in result but got: {result.get('leads_scored')}"
+    # Directive #197: enrichment is now async (Flow B) — leads_scored and leads_enriched
+    # are 0 in Flow A result. Actual enrichment happens in daily_enrichment_flow.
+    assert result.get("leads_scored") == 0, (
+        f"Expected leads_scored=0 (enrichment decoupled to Flow B) but got: {result.get('leads_scored')}"
     )
+    assert result.get("leads_enriched") == 0, (
+        f"Expected leads_enriched=0 (enrichment decoupled to Flow B) but got: {result.get('leads_enriched')}"
+    )
+    # Flow A must still report success after promotion
+    assert result.get("success") is True, f"Expected success=True but got: {result.get('success')}"
+    assert result.get("leads_promoted") == 5, f"Expected leads_promoted=5 but got: {result.get('leads_promoted')}"
 
 
 # ============================================

--- a/tests/test_services/test_lead_allocator_service.py
+++ b/tests/test_services/test_lead_allocator_service.py
@@ -49,30 +49,32 @@ class TestLeadAllocatorAllocate:
         campaign_id = uuid4()
         pool_id = uuid4()
 
-        # Mock find query result
+        # Mock find query result (SELECT with FOR UPDATE SKIP LOCKED)
         find_result = MagicMock()
-        find_result.fetchall.return_value = [
-            MagicMock(
-                id=pool_id,
-                email="lead@example.com",
-                first_name="John",
-                last_name="Doe",
-                title="CEO",
-                company_name="Acme Inc",
-                enrichment_confidence=0.95,
-            ),
-        ]
+        lead_row = MagicMock(
+            id=pool_id,
+            email="lead@example.com",
+            first_name="John",
+            last_name="Doe",
+            title="CEO",
+            company_name="Acme Inc",
+            enrichment_confidence=0.95,
+        )
+        find_result.fetchall.return_value = [lead_row]
 
-        # Mock assignment result
-        assign_result = MagicMock()
-        assign_row = MagicMock()
-        assign_row.id = uuid4()
-        assign_result.fetchone.return_value = assign_row
+        # Directive #197 FIX 1: bulk UPDATE RETURNING — uses fetchall, not fetchone
+        bulk_result = MagicMock()
+        bulk_row = MagicMock(
+            id=pool_id,
+            email="lead@example.com",
+            first_name="John",
+            last_name="Doe",
+            title="CEO",
+            company_name="Acme Inc",
+        )
+        bulk_result.fetchall.return_value = [bulk_row]
 
-        # Mock update result (for pool status update)
-        update_result = MagicMock()
-
-        mock_session.execute.side_effect = [find_result, assign_result, update_result]
+        mock_session.execute.side_effect = [find_result, bulk_result]
 
         result = await allocator_service.allocate_leads(
             client_id=client_id,


### PR DESCRIPTION
## Context
v13 E2E: 440 leads assigned and promoted for first time (PR #184 fix).
But flow timed out at 900s before enrich_batch fired.
Root cause: sequential assignment loop (496s) consumed entire budget.

## Changes

### FIX 1: Bulk assignment (lead_allocator_service.py)
Single bulk UPDATE with ANY(:ids::uuid[]) — 440 leads in ~2s not 496s.
Replaces N sequential UPDATEs (one per lead) with one SQL round-trip.

### FIX 2: monthly_replenishment_flow.py
Calls allocate_leads() which is the same function — Fix 1 automatically covers this flow too.

### FIX 3: Two-flow architecture (post_onboarding_flow.py)
Flow A (onboarding, ~5 min): ICP → Campaign → GMB → Assign → Promote → done
Flow B (enrichment, ~10 min): triggered fire-and-forget, runs async

- Removed fragile `if promoted_lead_ids:` inline enrich block (returns [] on re-runs → silent skip)
- After promote, query unenriched leads directly (works on first run AND re-runs)
- Fire-and-forget POST to enrichment-flow deployment (23f36d60)
- Flow A returns success immediately; Flow B runs in background

Customer sees leads immediately after Flow A.
Enrichment fills in progressively.

### FIX 4: Flow timeout 900s → 1800s
Flow A now completes in ~5 min; 1800s gives plenty of headroom for retries.

## Tests
779 passed, 0 failed (1 pre-existing live test requiring network, unrelated to this PR)