### PR TITLE
Fix Flow B trigger + bulk promote + parallel enrichment tiers

### DIFF
--- a/src/integrations/siege_waterfall.py
+++ b/src/integrations/siege_waterfall.py
@@ -694,29 +694,85 @@ class SiegeWaterfall:
         # Current propensity score (may be passed in or calculated)
         lead.get("propensity_score", 0)
 
-        # ===== TIER 1: ABN Bulk =====
-        if EnrichmentTier.ABN not in skip_tiers:
-            try:
-                result = await self.tier1_abn(enriched_data)
-            except Exception as e:
-                # Directive #196: per-tier graceful degradation — tier failure must not crash enrichment
-                logger.warning(f"[enrich_lead] Tier 1 ABN raised unexpectedly: {e}")
-                result = TierResult(tier=EnrichmentTier.ABN, success=False, error=str(e))
-            tier_results.append(result)
-            if result.success:
-                enriched_data = self._merge_data(
-                    enriched_data, result.data, source=result.tier.value, conflicts=field_conflicts
-                )
-                total_cost_aud += result.cost_aud
-        else:
-            tier_results.append(
-                TierResult(
-                    tier=EnrichmentTier.ABN,
-                    success=False,
-                    skipped=True,
+        # ===== TIER 1 (ABN) + TIER 2 (GMB) — PARALLEL =====
+        # FIX 3 (Directive #185): T1 and T2 are independent — both use only original lead data.
+        # Fire them simultaneously; return_exceptions=True so a tier failure never kills the other.
+        # T1.5/SIZE-GATE/T3/T5 remain sequential: T1.5 needs T1 trading_name for LinkedIn URL
+        # resolution; T3/T5 have ALS gates that depend on merged T1+T1.5 results.
+
+        # Pre-compute GMB skip condition from original lead data (independent of T1)
+        has_gmb_from_t0 = any([
+            enriched_data.get("gmb_rating"),
+            enriched_data.get("gmb_review_count"),
+            enriched_data.get("gmb_category"),
+            enriched_data.get("gmb_address"),
+            enriched_data.get("gmb_phone"),
+            enriched_data.get("gmb_website"),
+            enriched_data.get("gmb_data"),
+        ])
+
+        async def _run_t1_abn() -> TierResult:
+            if EnrichmentTier.ABN in skip_tiers:
+                return TierResult(
+                    tier=EnrichmentTier.ABN, success=False, skipped=True,
                     skip_reason="Tier skipped by request",
                 )
+            try:
+                return await self.tier1_abn(enriched_data)
+            except Exception as _e:
+                # Directive #196: per-tier graceful degradation
+                logger.warning(f"[enrich_lead] Tier 1 ABN raised unexpectedly: {_e}")
+                return TierResult(tier=EnrichmentTier.ABN, success=False, error=str(_e))
+
+        async def _run_t2_gmb() -> "TierResult | None":
+            # Skip if T0 already has GMB data or tier is in skip list (avoid wasted API call)
+            if EnrichmentTier.GMB in skip_tiers or has_gmb_from_t0:
+                return None  # handled in post-processing below
+            try:
+                return await self.tier2_gmb(enriched_data)
+            except Exception as _e:
+                # Directive #196: per-tier graceful degradation
+                logger.warning(f"[enrich_lead] Tier 2 GMB raised unexpectedly: {_e}")
+                return TierResult(tier=EnrichmentTier.GMB, success=False, error=str(_e))
+
+        t1_result_raw, t2_result_raw = await asyncio.gather(
+            _run_t1_abn(), _run_t2_gmb(),
+            return_exceptions=True,
+        )
+
+        # Process T1 ABN result
+        if isinstance(t1_result_raw, Exception):
+            t1_result_raw = TierResult(tier=EnrichmentTier.ABN, success=False, error=str(t1_result_raw))
+        tier_results.append(t1_result_raw)
+        if t1_result_raw.success:
+            enriched_data = self._merge_data(
+                enriched_data, t1_result_raw.data, source=t1_result_raw.tier.value, conflicts=field_conflicts
             )
+            total_cost_aud += t1_result_raw.cost_aud
+
+        # Process T2 GMB result
+        if EnrichmentTier.GMB not in skip_tiers:
+            if has_gmb_from_t0:
+                tier_results.append(TierResult(
+                    tier=EnrichmentTier.GMB, success=True, skipped=True,
+                    skip_reason="T0 discovery already has GMB data (T0/T2 merge)",
+                ))
+                logger.info("[T2] Skipping GMB enrichment — T0 already has data")
+            else:
+                if isinstance(t2_result_raw, Exception):
+                    t2_result_raw = TierResult(tier=EnrichmentTier.GMB, success=False, error=str(t2_result_raw))
+                if t2_result_raw is not None:
+                    tier_results.append(t2_result_raw)
+                    if t2_result_raw.success:
+                        enriched_data = self._merge_data(
+                            enriched_data, t2_result_raw.data, source=t2_result_raw.tier.value, conflicts=field_conflicts
+                        )
+                        total_cost_aud += t2_result_raw.cost_aud
+        else:
+            tier_results.append(TierResult(
+                tier=EnrichmentTier.GMB, success=False, skipped=True,
+                skip_reason="Tier skipped by request",
+            ))
 
         # ===== LINKEDIN URL RESOLUTION =====
         # Directive #148: Resolve LinkedIn URL before T1.5
@@ -869,61 +925,6 @@ class SiegeWaterfall:
                     started_at=started_at,
                     completed_at=datetime.now(UTC).isoformat(),
                 )
-
-        # ===== TIER 2: GMB/Ads Signals =====
-        # CEO Directive: T0/T2 GMB Merge - Skip T2 if T0 discovery already has GMB data
-        # In Siege Waterfall v3, GMB-first discovery (T0) returns all GMB fields.
-        # T2 enrichment is redundant — saves $0.001/lead with zero data loss.
-        has_gmb_from_t0 = any(
-            [
-                enriched_data.get("gmb_rating"),
-                enriched_data.get("gmb_review_count"),
-                enriched_data.get("gmb_category"),
-                enriched_data.get("gmb_address"),
-                enriched_data.get("gmb_phone"),
-                enriched_data.get("gmb_website"),
-                enriched_data.get("gmb_data"),  # Alternative: nested GMB object from T0
-            ]
-        )
-
-        if EnrichmentTier.GMB not in skip_tiers:
-            if has_gmb_from_t0:
-                # T0 already provided GMB data — skip redundant T2 call
-                tier_results.append(
-                    TierResult(
-                        tier=EnrichmentTier.GMB,
-                        success=True,  # T0 already succeeded
-                        skipped=True,
-                        skip_reason="T0 discovery already has GMB data (T0/T2 merge)",
-                    )
-                )
-                logger.info("[T2] Skipping GMB enrichment — T0 already has data")
-            else:
-                # Fallback: T0 didn't provide GMB data (shouldn't happen in GMB-first mode)
-                try:
-                    result = await self.tier2_gmb(enriched_data)
-                except Exception as e:
-                    # Directive #196: per-tier graceful degradation
-                    logger.warning(f"[enrich_lead] Tier 2 GMB raised unexpectedly: {e}")
-                    result = TierResult(tier=EnrichmentTier.GMB, success=False, error=str(e))
-                tier_results.append(result)
-                if result.success:
-                    enriched_data = self._merge_data(
-                        enriched_data,
-                        result.data,
-                        source=result.tier.value,
-                        conflicts=field_conflicts,
-                    )
-                    total_cost_aud += result.cost_aud
-        else:
-            tier_results.append(
-                TierResult(
-                    tier=EnrichmentTier.GMB,
-                    success=False,
-                    skipped=True,
-                    skip_reason="Tier skipped by request",
-                )
-            )
 
         # ===== TIER 3: Leadmagic Email (ALS >= 35 only) =====
         if EnrichmentTier.LEADMAGIC_EMAIL not in skip_tiers:

--- a/src/orchestration/flows/post_onboarding_flow.py
+++ b/src/orchestration/flows/post_onboarding_flow.py
@@ -429,110 +429,84 @@ async def promote_pool_leads_to_leads_task(
 
         logger.info(f"Promoting {len(pool_leads)} pool leads to leads table for client {client_id}")
 
-        skipped = 0
-        for lead in pool_leads:
-            try:
-                insert_result = await db.execute(
-                    text("""
-                    INSERT INTO leads (
-                        id,
-                        client_id,
-                        campaign_id,
-                        email,
-                        first_name,
-                        last_name,
-                        title,
-                        phone,
-                        linkedin_url,
-                        seniority_level,
-                        personal_email,
-                        timezone,
-                        company,
-                        domain,
-                        organization_website,
-                        organization_linkedin_url,
-                        organization_industry,
-                        organization_employee_count,
-                        organization_country,
-                        organization_founded_year,
-                        organization_is_hiring,
-                        enrichment_source,
-                        enrichment_confidence,
-                        lead_pool_id,
-                        als_score,
-                        als_tier,
-                        status,
-                        created_at,
-                        updated_at
-                    ) VALUES (
-                        gen_random_uuid(),
-                        :client_id,
-                        :campaign_id,
-                        :email,
-                        :first_name,
-                        :last_name,
-                        :title,
-                        :phone,
-                        :linkedin_url,
-                        :seniority_level,
-                        :personal_email,
-                        :timezone,
-                        :company,
-                        :domain,
-                        :organization_website,
-                        :organization_linkedin_url,
-                        :organization_industry,
-                        :organization_employee_count,
-                        :organization_country,
-                        :organization_founded_year,
-                        :organization_is_hiring,
-                        :enrichment_source,
-                        :enrichment_confidence,
-                        :lead_pool_id,
-                        0,
-                        'cold',
-                        'new',
-                        NOW(),
-                        NOW()
-                    )
-                    ON CONFLICT ON CONSTRAINT unique_lead_per_client DO NOTHING
-                    RETURNING id
-                    """),
-                    {
-                        "client_id": str(lead.client_id),
-                        "campaign_id": str(lead.campaign_id),
-                        "email": lead.email,
-                        "first_name": lead.first_name,
-                        "last_name": lead.last_name,
-                        "title": lead.title,
-                        "phone": lead.phone,
-                        "linkedin_url": lead.linkedin_url,
-                        "seniority_level": lead.seniority,
-                        "personal_email": lead.personal_email,
-                        "timezone": lead.timezone,
-                        "company": lead.company_name,
-                        "domain": lead.company_domain,
-                        "organization_website": lead.company_website,
-                        "organization_linkedin_url": lead.company_linkedin_url,
-                        "organization_industry": lead.company_industry,
-                        "organization_employee_count": lead.company_employee_count,
-                        "organization_country": lead.company_country,
-                        "organization_founded_year": lead.company_founded_year,
-                        "organization_is_hiring": lead.company_is_hiring,
-                        "enrichment_source": lead.enrichment_source,
-                        "enrichment_confidence": lead.enrichment_confidence,
-                        "lead_pool_id": str(lead.id),
-                    },
-                )
-                new_id = insert_result.scalar()
-                if new_id:
-                    promoted += 1
-                    new_lead_ids.append(str(new_id))
-                else:
-                    skipped += 1  # ON CONFLICT DO NOTHING — already exists
-            except Exception as e:
-                logger.warning(f"Failed to promote pool lead {lead.id} ({lead.email}): {e}")
-                errors.append({"pool_lead_id": str(lead.id), "error": str(e)})
+        # FIX 2 (Directive #185): Single bulk INSERT SELECT instead of N sequential INSERTs.
+        # 374 leads × ~0.35s/insert = 130.8s → ~2s expected with bulk operation.
+        bulk_result = await db.execute(
+            text(f"""
+            INSERT INTO leads (
+                id,
+                client_id,
+                campaign_id,
+                email,
+                first_name,
+                last_name,
+                title,
+                phone,
+                linkedin_url,
+                seniority_level,
+                personal_email,
+                timezone,
+                company,
+                domain,
+                organization_website,
+                organization_linkedin_url,
+                organization_industry,
+                organization_employee_count,
+                organization_country,
+                organization_founded_year,
+                organization_is_hiring,
+                enrichment_source,
+                enrichment_confidence,
+                lead_pool_id,
+                als_score,
+                als_tier,
+                status,
+                created_at,
+                updated_at
+            )
+            SELECT
+                gen_random_uuid(),
+                lp.client_id,
+                lp.campaign_id,
+                lp.email,
+                lp.first_name,
+                lp.last_name,
+                lp.title,
+                lp.phone,
+                lp.linkedin_url,
+                lp.seniority,
+                lp.personal_email,
+                lp.timezone,
+                lp.company_name,
+                lp.company_domain,
+                lp.company_website,
+                lp.company_linkedin_url,
+                lp.company_industry,
+                lp.company_employee_count,
+                lp.company_country,
+                lp.company_founded_year,
+                lp.company_is_hiring,
+                lp.enrichment_source,
+                lp.enrichment_confidence,
+                lp.id,
+                0,
+                'cold',
+                'new',
+                NOW(),
+                NOW()
+            FROM lead_pool lp
+            WHERE lp.client_id = :client_id
+              AND lp.campaign_id IS NOT NULL
+              AND lp.pool_status NOT IN ('bounced', 'unsubscribed', 'invalid')
+              {email_filter}
+            ON CONFLICT ON CONSTRAINT unique_lead_per_client DO NOTHING
+            RETURNING id
+            """),
+            {"client_id": str(client_id)},
+        )
+        new_lead_ids = [str(row[0]) for row in bulk_result.fetchall()]
+        promoted = len(new_lead_ids)
+        skipped = len(pool_leads) - promoted  # ON CONFLICT DO NOTHING skips (duplicates)
 
         await db.commit()
 
@@ -1004,7 +978,7 @@ async def post_onboarding_setup_flow(
                     SELECT id FROM leads
                     WHERE client_id = :client_id
                       AND status = 'new'
-                      AND (enrichment_source IS NULL OR enrichment_source = '')
+                      AND enriched_at IS NULL
                     LIMIT 500
                 """), {"client_id": str(client_id)})
                 unenriched_ids = [str(row.id) for row in _unenriched_result.fetchall()]

--- a/tests/test_services/test_onboarding_pipeline.py
+++ b/tests/test_services/test_onboarding_pipeline.py
@@ -60,9 +60,11 @@ class TestPromotePoolLeadsToLeads:
         mock_select_result = MagicMock()
         mock_select_result.fetchall.return_value = [mock_pool_lead]
 
+        _new_lead_uuid = uuid4()
         mock_insert_result = MagicMock()
         mock_insert_result.rowcount = 1
-        mock_insert_result.scalar.return_value = uuid4()  # RETURNING id → promoted
+        # Bulk INSERT SELECT uses fetchall() to collect RETURNING id rows
+        mock_insert_result.fetchall.return_value = [(_new_lead_uuid,)]
 
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(side_effect=[mock_select_result, mock_insert_result])
@@ -122,10 +124,10 @@ class TestPromotePoolLeadsToLeads:
         mock_select_result = MagicMock()
         mock_select_result.fetchall.return_value = [mock_pool_lead]
 
-        # ON CONFLICT DO NOTHING → RETURNING id returns nothing → scalar() = None
+        # ON CONFLICT DO NOTHING → RETURNING id returns nothing → fetchall() = []
         mock_insert_result = MagicMock()
         mock_insert_result.rowcount = 0
-        mock_insert_result.scalar.return_value = None  # RETURNING id → no row → skipped
+        mock_insert_result.fetchall.return_value = []  # Bulk INSERT: no rows → skipped
 
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(side_effect=[mock_select_result, mock_insert_result])


### PR DESCRIPTION
## Fixes

### FIX 1: Flow B trigger (post_onboarding_flow.py)
`enrichment_source IS NULL` → `enriched_at IS NULL`

GMB leads have `enrichment_source='gmb_discovery'` (copied from lead_pool) — old query returned `unenriched_count=0` → enrichment trigger silently skipped. `enriched_at` is the correct signal: it is only set after siege waterfall enrichment completes.

### FIX 2: Bulk promote (post_onboarding_flow.py)
Single `INSERT INTO leads (...) SELECT ... FROM lead_pool` replaces N sequential `INSERT ... VALUES (...)` per-lead loop.

374 leads: ~130.8s → ~2s expected. Test mocks updated to use `fetchall()` instead of `scalar()` for `RETURNING id` rows.

### FIX 3: Parallel enrichment tiers (siege_waterfall.py)
`asyncio.gather()` runs T1 (ABN) and T2 (GMB) simultaneously — both tiers use only original lead data with no cross-dependencies.

`return_exceptions=True` in all gather calls — a tier failure never kills others.

T1.5/SIZE-GATE/T3/T5 remain sequential: T1.5 needs T1 ABN trading_name for LinkedIn URL resolution; T3/T5 have ALS gates that depend on merged T1+T1.5 results (parallelizing those would fire costly API calls on leads that fail the size gate or ALS thresholds).

## Tests
780 passed, 0 failed