### PR TITLE
Directive #198: State-of-art GMB capture + BU ABN matching + enrichment pipeline

### DIFF
--- a/src/engines/scout.py
+++ b/src/engines/scout.py
@@ -493,8 +493,11 @@ class ScoutEngine(BaseEngine):
                     "abn": getattr(lead, "abn", None),
                     "title": lead.title,
                     "city": getattr(lead, "city", None),
-                    "state": getattr(lead, "state", None),
+                    "state": getattr(lead, "company_state", None),  # Directive #198: fix key
                     "country": primary_country,
+                    "gmb_place_id": getattr(lead, "gmb_place_id", None),  # Directive #198: unlocks T2.5
+                    "gmb_rating": getattr(lead, "gmb_rating", None),
+                    "gmb_review_count": getattr(lead, "gmb_review_count", None),
                 }
 
                 # Run Siege Waterfall (skip Tier 5 unless already high ALS)

--- a/src/integrations/siege_waterfall.py
+++ b/src/integrations/siege_waterfall.py
@@ -774,6 +774,30 @@ class SiegeWaterfall:
                 skip_reason="Tier skipped by request",
             ))
 
+        # ===== TIER 2.5: GMB Reviews (Directive #198 — wired) =====
+        # Fires when gmb_place_id is available (populated by pool_population_flow).
+        # Low cost ($0.001), no ALS gate — runs unconditionally if place_id present.
+        if EnrichmentTier.GMB_REVIEWS not in skip_tiers:
+            try:
+                t25_result = await self.tier2_5_gmb_reviews(enriched_data)
+            except Exception as _e:
+                logger.warning(f"[enrich_lead] Tier 2.5 GMB Reviews raised unexpectedly: {_e}")
+                t25_result = TierResult(
+                    tier=EnrichmentTier.GMB_REVIEWS, success=False, error=str(_e)
+                )
+            tier_results.append(t25_result)
+            if t25_result.success:
+                enriched_data = self._merge_data(
+                    enriched_data, t25_result.data,
+                    source=t25_result.tier.value, conflicts=field_conflicts,
+                )
+                total_cost_aud += t25_result.cost_aud
+        else:
+            tier_results.append(TierResult(
+                tier=EnrichmentTier.GMB_REVIEWS, success=False, skipped=True,
+                skip_reason="Tier skipped by request",
+            ))
+
         # ===== LINKEDIN URL RESOLUTION =====
         # Directive #148: Resolve LinkedIn URL before T1.5
         if not enriched_data.get("company_linkedin_url") and not enriched_data.get(
@@ -2783,6 +2807,25 @@ class SiegeWaterfall:
             score += 10
         if lead.get("company_employee_count") or lead.get("company_industry"):
             score += 5
+
+        # Directive #198: GMB signals (free, from pool_population_flow)
+        gmb_rating = lead.get("gmb_rating")
+        gmb_reviews = lead.get("gmb_review_count")
+        if gmb_rating is not None and gmb_reviews is not None:
+            try:
+                rating_f = float(gmb_rating)
+                reviews_i = int(gmb_reviews)
+                # High reviews + low rating = reputation pain = buying signal
+                if rating_f < 3.5 and reviews_i > 20:
+                    score += 10
+                # High reviews + high rating = established, targetable business
+                elif rating_f > 4.0 and reviews_i > 50:
+                    score += 5
+            except (TypeError, ValueError):
+                pass
+        # Has domain = enrichable
+        if lead.get("domain"):
+            score += 3
 
         return min(score, 100)
 

--- a/src/models/lead.py
+++ b/src/models/lead.py
@@ -35,6 +35,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Integer,
+    Numeric,
     String,
     Text,
     UniqueConstraint,
@@ -216,6 +217,13 @@ class Lead(Base, UUIDMixin, TimestampMixin, SoftDeleteMixin):
     assigned_email_resource: Mapped[str | None] = mapped_column(Text, nullable=True)
     assigned_linkedin_seat: Mapped[str | None] = mapped_column(Text, nullable=True)
     assigned_phone_resource: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # === GMB Signals (Directive #198) ===
+    gmb_rating: Mapped[float | None] = mapped_column(Numeric(3, 1), nullable=True)
+    gmb_review_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    gmb_place_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    company_state: Mapped[str | None] = mapped_column(Text, nullable=True)
+    abn: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relationships
     client: Mapped["Client"] = relationship("Client", back_populates="leads")

--- a/src/models/lead_pool.py
+++ b/src/models/lead_pool.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Integer,
+    Numeric,
     String,
     Text,
 )
@@ -132,6 +133,14 @@ class LeadPool(Base, UUIDMixin, TimestampMixin):
     company_city: Mapped[str | None] = mapped_column(Text, nullable=True)
     company_state: Mapped[str | None] = mapped_column(Text, nullable=True)
     company_postal_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # ===== GMB DISCOVERY SIGNALS (Directive #198) =====
+    gmb_rating: Mapped[float | None] = mapped_column(Numeric(3, 1), nullable=True)
+    gmb_review_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    gmb_place_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    gmb_category: Mapped[str | None] = mapped_column(Text, nullable=True)
+    gmb_maps_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    abn: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Company Signals
     company_is_hiring: Mapped[bool | None] = mapped_column(Boolean, nullable=True)

--- a/src/orchestration/flows/pool_population_flow.py
+++ b/src/orchestration/flows/pool_population_flow.py
@@ -25,6 +25,7 @@ WATERFALL STRATEGY:
 
 import json
 import logging
+import re
 from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
@@ -508,16 +509,31 @@ async def populate_pool_from_icp_task(
             skipped += 1
             continue
 
-        phone = record.get("phone") or None
-        website = record.get("website") or ""
+        # Directive #198: Fix key names — GMB API uses phone_number + open_website
+        phone = record.get("phone_number") or record.get("phone") or None
+        website = record.get("open_website") or record.get("website") or ""
         domain = _extract_domain(website)
 
-        city = None
         address = record.get("address") or ""
+        # Parse city and state from AU address: "71 Macquarie St, Sydney NSW 2000, Australia"
+        city = None
+        state_code = None
         if address:
-            parts = [p.strip() for p in address.split(",") if p.strip()]
-            if len(parts) >= 2:
-                city = parts[-2]  # penultimate part is usually city
+            state_match = re.search(r"\b(NSW|VIC|QLD|SA|WA|TAS|NT|ACT)\b", address)
+            if state_match:
+                state_code = state_match.group(1)
+                before_state = address[: state_match.start()].strip().rstrip(",").strip()
+                city_parts = [p.strip() for p in before_state.split(",") if p.strip()]
+                city = city_parts[-1] if city_parts else None
+
+        # Directive #198: Capture all GMB signal fields
+        gmb_rating = record.get("rating") or None
+        gmb_review_count = (
+            record.get("reviews_count") if record.get("reviews_count") is not None else None
+        )
+        gmb_place_id = record.get("place_id") or None
+        gmb_category = record.get("category") or None
+        gmb_maps_url = record.get("url") or None
 
         # Dedup key: prefer domain, fall back to phone, then name
         dedup_key = domain or phone or company_name.lower()
@@ -530,9 +546,17 @@ async def populate_pool_from_icp_task(
             "client_id": str(client_id),
             "company_name": company_name,
             "company_domain": domain,
+            "company_website": website,
+            "company_state": state_code,
+            "company_country": record.get("country_code") or "AU",
             "phone": phone,
             "industry": industry,
             "city": city,
+            "gmb_rating": gmb_rating,
+            "gmb_review_count": gmb_review_count,
+            "gmb_place_id": gmb_place_id,
+            "gmb_category": gmb_category,
+            "gmb_maps_url": gmb_maps_url,
         })
 
     # Directive #194 Fix 1: TRUE bulk INSERT — single VALUES clause = 1 network call
@@ -545,20 +569,37 @@ async def populate_pool_from_icp_task(
         for i, row in enumerate(rows_to_insert):
             values_parts.append(
                 f"(gen_random_uuid(), :client_id_{i}, :company_name_{i}, :company_domain_{i}, "
-                f":phone_{i}, :industry_{i}, :city_{i}, 'available', 'gmb_discovery', 0, 'cold', NOW())"
+                f":company_website_{i}, :company_state_{i}, :company_country_{i}, "
+                f":phone_{i}, :industry_{i}, :city_{i}, "
+                f":gmb_rating_{i}, :gmb_review_count_{i}, :gmb_place_id_{i}, "
+                f":gmb_category_{i}, :gmb_maps_url_{i}, "
+                f"'available', 'gmb_discovery', 0, 'cold', NOW())"
             )
             params[f"client_id_{i}"] = row["client_id"]
             params[f"company_name_{i}"] = row["company_name"]
             params[f"company_domain_{i}"] = row["company_domain"]
+            params[f"company_website_{i}"] = row["company_website"]
+            params[f"company_state_{i}"] = row["company_state"]
+            params[f"company_country_{i}"] = row["company_country"]
             params[f"phone_{i}"] = row["phone"]
             params[f"industry_{i}"] = row["industry"]
             params[f"city_{i}"] = row["city"]
+            params[f"gmb_rating_{i}"] = row["gmb_rating"]
+            params[f"gmb_review_count_{i}"] = row["gmb_review_count"]
+            params[f"gmb_place_id_{i}"] = row["gmb_place_id"]
+            params[f"gmb_category_{i}"] = row["gmb_category"]
+            params[f"gmb_maps_url_{i}"] = row["gmb_maps_url"]
 
         async with get_db_session() as db:
             result = await db.execute(
                 text(
-                    "INSERT INTO lead_pool (id, client_id, company_name, company_domain, phone, "
-                    "company_industry, company_city, pool_status, enrichment_source, als_score, als_tier, created_at) "
+                    "INSERT INTO lead_pool ("
+                    "id, client_id, company_name, company_domain, "
+                    "company_website, company_state, company_country, "
+                    "phone, company_industry, company_city, "
+                    "gmb_rating, gmb_review_count, gmb_place_id, gmb_category, gmb_maps_url, "
+                    "pool_status, enrichment_source, als_score, als_tier, created_at"
+                    ") "
                     f"VALUES {', '.join(values_parts)} ON CONFLICT DO NOTHING RETURNING id"
                 ),
                 params,
@@ -567,6 +608,33 @@ async def populate_pool_from_icp_task(
             await db.commit()
         added = len(inserted_ids)
         skipped += len(rows_to_insert) - added  # rows that hit ON CONFLICT
+
+        # Directive #198 STEP 5: Match against business_universe by name+state for free ABN lookup
+        try:
+            async with get_db_session() as _db:
+                bu_result = await _db.execute(
+                    text("""
+                        UPDATE lead_pool lp
+                        SET abn = bu.abn,
+                            updated_at = NOW()
+                        FROM business_universe bu
+                        WHERE (
+                            LOWER(bu.trading_name) = LOWER(lp.company_name)
+                            OR LOWER(bu.legal_name) = LOWER(lp.company_name)
+                        )
+                        AND bu.state = lp.company_state
+                        AND bu.status = 'Active'
+                        AND lp.abn IS NULL
+                        AND lp.client_id = :client_id
+                        RETURNING lp.id
+                    """),
+                    {"client_id": str(client_id)},
+                )
+                await _db.commit()
+                matched = len(bu_result.fetchall())
+            logger.info(f"[pool_population] BU match: {matched}/{added} leads matched ABN")
+        except Exception as _bu_err:
+            logger.warning(f"[pool_population] BU match failed (non-blocking): {_bu_err}")
 
     logger.info(f"Tier 3 GMB discovery complete: {added} added, {skipped} skipped")
 

--- a/src/orchestration/flows/post_onboarding_flow.py
+++ b/src/orchestration/flows/post_onboarding_flow.py
@@ -461,6 +461,11 @@ async def promote_pool_leads_to_leads_task(
                 als_score,
                 als_tier,
                 status,
+                gmb_rating,
+                gmb_review_count,
+                gmb_place_id,
+                company_state,
+                abn,
                 created_at,
                 updated_at
             )
@@ -492,6 +497,11 @@ async def promote_pool_leads_to_leads_task(
                 0,
                 'cold',
                 'new',
+                lp.gmb_rating,
+                lp.gmb_review_count,
+                lp.gmb_place_id,
+                lp.company_state,
+                lp.abn,
                 NOW(),
                 NOW()
             FROM lead_pool lp


### PR DESCRIPTION
## CEO Directive #198 — Full pipeline overhaul

### Problem
17 E2E runs captured 4 of 32 GMB fields and threw away the rest.
Enrichment failed because domain was in the discarded data.
2.5M ABN records in business_universe sat unused.
T2.5 GMB Reviews was defined but never wired into enrich_lead.

### Changes

**PART 1 — GMB field capture** (`pool_population_flow.py`)
- `open_website` key fix (was `website` — always null → domain always null → enrichment 0%)
- `phone_number` key fix (was `phone`)
- Address parsing: regex extract city + state separately (was garbled)
- Captures: rating, review count, place_id, category, maps URL
- Also captures: company_state (AU state code), company_country, company_website

**PART 2 — business_universe ABN matching** (`pool_population_flow.py`)
- After GMB insert: UPDATE lead_pool JOIN business_universe by name+state
- Free local DB query — no API call
- Gives ABN to any lead whose name+state matches 2.5M BU records

**PART 3 — Promote carries all data** (`post_onboarding_flow.py`)
- gmb_rating, gmb_review_count, gmb_place_id, company_state, abn → leads table

**PART 4 — Enrichment uses new fields** (`scout.py` + `siege_waterfall.py`)
- scout.py passes state + gmb_place_id → unlocks T2.5 GMB Reviews
- Fixed `state` key to use `company_state` (Lead model attribute, was always None)
- **Wired T2.5 GMB Reviews** into enrich_lead (tier method existed, was never called)
- ABN pre-populated from BU match

**PART 5 — Free ALS signals** (`siege_waterfall.py`)
- GMB rating + review count fed into `_calculate_als`
- High review + low rating (<3.5, >20 reviews): +10 ALS (reputation pain = buying signal)
- High reviews + high rating (>4.0, >50 reviews): +5 ALS (established business)
- Has domain: +3 ALS

### Schema migrations
```sql
ALTER TABLE lead_pool ADD COLUMN gmb_rating numeric(3,1), gmb_review_count integer,
  gmb_place_id text, gmb_category text, gmb_maps_url text, abn text;
ALTER TABLE leads ADD COLUMN gmb_rating numeric(3,1), gmb_review_count integer,
  gmb_place_id text, company_state text, abn text;
CREATE INDEX idx_bu_legal_name_lower ON business_universe(lower(legal_name));
CREATE INDEX idx_bu_trading_name_lower ON business_universe(lower(trading_name));
```

### Tests
780 passed, 22 skipped, 0 failed