### PR TITLE
Directive #200: GMB passthrough enrichment — set enriched_at from company data

### DIFF
--- a/src/engines/scout.py
+++ b/src/engines/scout.py
@@ -509,13 +509,28 @@ class ScoutEngine(BaseEngine):
                     skip_tiers=[EnrichmentTier.IDENTITY],  # Skip expensive Tier 5
                 )
 
-                if siege_result.sources_used > 0:
+                # Directive #200: GMB leads already carry company-level data in
+                # enriched_data (domain, phone, gmb_rating, etc.) even when no new
+                # API tier fires (sources_used=0). Don't discard that data.
+                # Mark as company-level enriched if we have company identity.
+                _ed = siege_result.enriched_data
+                _has_company_data = bool(
+                    (_ed.get("company_name") or _ed.get("company"))
+                    and (_ed.get("domain") or _ed.get("phone") or _ed.get("gmb_place_id"))
+                )
+                if siege_result.sources_used > 0 or _has_company_data:
                     result = siege_result.enriched_data
                     result["found"] = True
-                    result["confidence"] = 0.75 + (
-                        siege_result.sources_used * 0.05
-                    )  # Higher confidence with more sources
-                    result["source"] = f"siege_waterfall_{siege_result.sources_used}sources"
+                    result["confidence"] = (
+                        0.75 + (siege_result.sources_used * 0.05)
+                        if siege_result.sources_used > 0
+                        else 0.70  # minimum threshold for company-level GMB data
+                    )
+                    result["source"] = (
+                        f"siege_waterfall_{siege_result.sources_used}sources"
+                        if siege_result.sources_used > 0
+                        else "gmb_passthrough"
+                    )
                     result["enrichment_cost_aud"] = siege_result.total_cost_aud
 
                     # Directive #196: Partial enrichment tracking — tiers succeeded/failed


### PR DESCRIPTION
## Root cause of 0 enrichment across v14–v19

`siege_result.sources_used = 0` when T1 ABN finds no match for a GMB lead name.
Even though `enriched_data` contains `domain + phone + gmb_rating + gmb_place_id`
captured during discovery (Directive #198), all of it was discarded.

## Fix
One conditional in `src/engines/scout.py` (~line 512):
```python
# Before
if siege_result.sources_used > 0:

# After
_has_company_data = bool((company_name or company) and (domain or phone or gmb_place_id))
if siege_result.sources_used > 0 or _has_company_data:
```
When `_has_company_data` is True: `found=True`, `confidence=0.70`, `source='gmb_passthrough'`.
`_validate_enrichment(company_level=True)` passes → `enriched_at` written → ALS scores computed.

## Expected ALS after this fix (no new API calls)
- phone (+20) + domain (+3) + GMB high-rating (+5) = **28 ALS**
- phone (+20) + domain (+3) + GMB reputation pain (+10) = **33 ALS**
- Scores will **vary** based on GMB signals already in the data

## Tests
778 passed, 0 failed (2 live integration tests are pre-existing failures unrelated to this change)