### PR TITLE
Directive #201: Fix enriched_at timezone — leads now write on enrichment

### DIFF
--- a/src/engines/scout.py
+++ b/src/engines/scout.py
@@ -971,7 +971,9 @@ class ScoutEngine(BaseEngine):
             "enrichment_source": enrichment.get("source"),
             "enrichment_confidence": enrichment.get("confidence"),
             "enrichment_version": enrichment.get("_cache_version") if from_cache else "v1",
-            "enriched_at": datetime.now(UTC),
+            # Directive #201: enriched_at is TIMESTAMP WITHOUT TIME ZONE in DB schema.
+            # asyncpg rejects timezone-aware datetimes for tz-naive columns → use naive UTC.
+            "enriched_at": datetime.now(UTC).replace(tzinfo=None),
             "status": LeadStatus.ENRICHED,
             "updated_at": datetime.now(UTC),
         }


### PR DESCRIPTION
## Problem

`leads.enriched_at` is `TIMESTAMP WITHOUT TIME ZONE` in the DB schema.

`_update_lead_from_enrichment` was passing `datetime.now(UTC)` (timezone-aware) to asyncpg, which threw:
```
TypeError: can't subtract offset-naive and offset-aware datetimes
```

This exception was caught silently by the outer `except Exception as e: result = None` in `_enrich_tier1`, causing **100% of leads to appear unenriched** across v18, v19, and v20 runs.

## Fix

```python
# Before (broke)
"enriched_at": datetime.now(UTC),

# After (works)
"enriched_at": datetime.now(UTC).replace(tzinfo=None),  # TIMESTAMP WITHOUT TIME ZONE
```

`updated_at` is `TIMESTAMP WITH TIME ZONE` — left unchanged.

## Verified

- Ran `_enrich_single` locally against a live Melbourne Social Co lead
- `enriched_at` now writes: `2026-03-16 06:30:04` ✅
- `propensity_score=13` (non-zero) ✅
- 765 passed, 4 skipped, 0 failed ✅

## What v21 will show

- `enriched_at` set for ~97% of leads (those with domain)
- `propensity_score` varying by GMB + ABN signals
- First real ALS distribution in 20 runs