### PR TITLE
Directive #202: Fix score_lead_task — calculate_als → score_lead

### DIFF
--- a/src/orchestration/flows/enrichment_flow.py
+++ b/src/orchestration/flows/enrichment_flow.py
@@ -271,7 +271,8 @@ async def score_lead_task(lead_id: str) -> dict[str, Any]:
         lead_uuid = UUID(lead_id)
 
         # Calculate ALS score
-        result = await scorer_engine.calculate_als(db=db, lead_id=lead_uuid)
+        # Directive #202: ScorerEngine.calculate_als() never existed — correct method is score_lead()
+        result = await scorer_engine.score_lead(db=db, lead_id=lead_uuid)
 
         if result.success:
             propensity_score = result.data["propensity_score"]


### PR DESCRIPTION
## Problem

`score_lead_task` (enrichment_flow.py:274) calls `scorer_engine.calculate_als(db=db, lead_id=lead_uuid)`.

`ScorerEngine.calculate_als()` does not exist. `ScorerEngine.score_lead()` is the correct method.

This was a **dormant bug** — never triggered because enrichment never produced any `enriched_lead_ids` to score (v1–v20). First hit in v21 after PR #192 unblocked `enriched_at` writes:

```
Flow B crashed at 205s: AttributeError: 'ScorerEngine' object has no attribute 'calculate_als'
```

9 leads were enriched → dncr_batch_check ran → score_lead_task called → instant crash.

## Fix

```python
# Before
result = await scorer_engine.calculate_als(db=db, lead_id=lead_uuid)

# After
result = await scorer_engine.score_lead(db=db, lead_id=lead_uuid)
```

`score_lead` returns `EngineResult` with `data["propensity_score"]` and `data["als_tier"]` — exact shape the task already expects.

## Tests

765 passed, 4 skipped, 0 failed ✅