### PR TITLE
Directive #203: fix calculate_als→score_lead, LinkedIn rstrip, als_score write, audit_logs migration

### DIFF
--- a/migrations/directive_203_audit_logs_lead_fields.sql
+++ b/migrations/directive_203_audit_logs_lead_fields.sql
@@ -1,0 +1,8 @@
+-- FILE: migrations/directive_203_audit_logs_lead_fields.sql
+-- PURPOSE: Add lead_company and domain columns to audit_logs
+-- DIRECTIVE: #203
+-- DATE: 2026-03-17
+
+ALTER TABLE audit_logs
+    ADD COLUMN IF NOT EXISTS lead_company TEXT,
+    ADD COLUMN IF NOT EXISTS domain TEXT;

--- a/src/api/routes/leads.py
+++ b/src/api/routes/leads.py
@@ -1021,7 +1021,7 @@ async def score_lead(
     scorer = get_scorer_engine()
 
     # Calculate propensity score
-    result = await scorer.calculate_als(db=db, lead_id=lead_id)
+    result = await scorer.score_lead(db=db, lead_id=lead_id)
 
     if not result.success:
         raise AgencyValidationError(

--- a/src/engines/scout.py
+++ b/src/engines/scout.py
@@ -305,7 +305,7 @@ class ScoutEngine(BaseEngine):
                 if bulk_urls:
                     bulk_results = await bd_client.scrape_linkedin_companies_bulk(bulk_urls)
                     for company in bulk_results:
-                        url = (
+                        url = str(
                             company.get("url") or company.get("linkedin_url") or ""
                         ).rstrip("/").lower()
                         if url:
@@ -1013,6 +1013,7 @@ class ScoutEngine(BaseEngine):
             als_score = self.siege_waterfall._calculate_als(enrichment)
             if als_score > 0:
                 update_data["propensity_score"] = als_score
+                update_data["als_score"] = als_score
                 update_data["propensity_tier"] = (
                     "hot" if als_score >= 85 else "warm" if als_score >= 50 else "cold"
                 )

--- a/src/models/lead.py
+++ b/src/models/lead.py
@@ -98,6 +98,7 @@ class Lead(Base, UUIDMixin, TimestampMixin, SoftDeleteMixin):
     # propensity_score: purchase likelihood (0-100)
     reachability_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
     propensity_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    als_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
     propensity_tier: Mapped[str | None] = mapped_column(String(20), nullable=True, name="als_tier")
     propensity_data_quality: Mapped[int | None] = mapped_column(
         Integer, nullable=True, name="als_data_quality"


### PR DESCRIPTION
## Changes

**4 fixes in one PR:**

### Fix 1 — `src/api/routes/leads.py:1024` (same bug as PR #193)
- `scorer.calculate_als()` → `scorer.score_lead()`
- Method never existed; only hit via the score API route (not enrichment flow)

### Fix 2 — `src/engines/scout.py:309` LinkedIn rstrip crash  
- BD LinkedIn bulk returns dicts; `company.get('url')` could be a dict  
- Wrap in `str()` before `.rstrip('/')` to prevent `AttributeError: 'dict' object has no attribute 'rstrip'`

### Fix 3 — `als_score` column never written
- `als_score` exists in DB but was missing from Lead model and `_update_lead_from_enrichment`  
- Added `als_score: Mapped[int | None]` to Lead model  
- Write `als_score` alongside `propensity_score` in `_update_lead_from_enrichment`

### Fix 4 — `audit_logs` missing `lead_company` + `domain` columns
- Migration file added: `migrations/directive_203_audit_logs_lead_fields.sql`  
- **Already applied to production** via direct DB execute

## Test baseline
765 passed, 4 skipped, 0 failed (live tests excluded — BD API calls)