### PR TITLE
Directive #205: fix ConversionPattern.valid_until datetime — naive UTC for tz-naive column mapping

### DIFF
--- a/src/engines/scorer.py
+++ b/src/engines/scorer.py
@@ -1127,7 +1127,7 @@ class ScorerEngine(BaseEngine):
             and_(
                 ConversionPattern.client_id == client_id,
                 ConversionPattern.pattern_type == "who",
-                ConversionPattern.valid_until > datetime.now(UTC),
+                ConversionPattern.valid_until > datetime.now(UTC).replace(tzinfo=None),  # asyncpg: naive UTC for mapped Mapped[datetime] column
             )
         )
         pattern_result = await db.execute(pattern_stmt)
@@ -1418,7 +1418,7 @@ class ScorerEngine(BaseEngine):
                 and_(
                     ConversionPattern.client_id == client_id,
                     ConversionPattern.pattern_type == "funnel",
-                    ConversionPattern.valid_until > datetime.now(UTC),
+                    ConversionPattern.valid_until > datetime.now(UTC).replace(tzinfo=None),  # asyncpg: naive UTC for mapped Mapped[datetime] column
                     # ConversionPattern uses TimestampMixin (not SoftDeleteMixin) — no deleted_at
                 )
             )


### PR DESCRIPTION
## Root cause
`ConversionPattern.valid_until` is mapped as `Mapped[datetime]` (no timezone), so the DB column is `TIMESTAMP WITHOUT TIME ZONE`. asyncpg rejects timezone-aware datetimes for tz-naive mapped columns, throwing `DataError: can't subtract offset-naive and offset-aware datetimes`.

This crashes `score_lead_task` in Flow B at lines 1130 and 1421 of `scorer.py`.

## Fix
`datetime.now(UTC).replace(tzinfo=None)` — same pattern as the `enriched_at` fix in PR #192. Both instances of `ConversionPattern.valid_until > datetime.now(UTC)` updated.

## Reproduction
v26 Flow B failed at 01:38:20Z with this exact error after PR #195 cleared the `deleted_at` blocker.

## Tests
765 passed, 4 skipped, 0 failed