### PR TITLE
Directive #206: add scored_at, als_components, als_weights_used to Lead model

### DIFF
--- a/src/models/lead.py
+++ b/src/models/lead.py
@@ -32,6 +32,7 @@ from uuid import UUID
 from sqlalchemy import (
     Boolean,
     Date,
+    DateTime,
     Float,
     ForeignKey,
     Integer,
@@ -115,6 +116,12 @@ class Lead(Base, UUIDMixin, TimestampMixin, SoftDeleteMixin):
     propensity_risk: Mapped[int | None] = mapped_column(
         Integer, nullable=True, name="als_risk"
     )  # Max 15
+    # Phase 16: Conversion Intelligence learning columns
+    als_components: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    als_weights_used: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    scored_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # === Organization Data ===
     organization_industry: Mapped[str | None] = mapped_column(Text, nullable=True)


### PR DESCRIPTION
## Root cause
`scorer.py _persist_score` writes `scored_at`, `als_components`, `als_weights_used` via SQLAlchemy ORM update but these columns were missing from the Lead model → `CompileError: Unconsumed column names`.

DB columns exist (verified):
- `als_components → jsonb`
- `als_weights_used → jsonb`  
- `scored_at → timestamp with time zone`

## Fix
Added 3 `mapped_column` entries to Lead model. Added `DateTime` to SQLAlchemy imports.

## Reproduction
v27 Flow B crashed after enriching 11 leads — scoring wrote propensity_score via scout.py but score_lead_task then crashed trying to write scorer.py's full ALS breakdown.

## Tests
765 passed, 4 skipped, 0 failed