### PR TITLE
Directive #207: fix scorer _persist_score — Python attr names not DB column names

### DIFF
--- a/src/engines/scorer.py
+++ b/src/engines/scorer.py
@@ -1731,13 +1731,15 @@ class ScorerEngine(BaseEngine):
             update(Lead)
             .where(Lead.id == lead.id)
             .values(
+                # Use Python attribute names (not DB column names) for ORM sync correctness.
+                # propensity_* attrs use name="als_*" in Lead model — must use attr name here.
                 als_score=score_data["propensity_score"],
-                als_tier=score_data["als_tier"],
-                als_data_quality=score_data["als_data_quality"],
-                als_authority=score_data["als_authority"],
-                als_company_fit=score_data["als_company_fit"],
-                als_timing=score_data["als_timing"],
-                als_risk=score_data["als_risk"],
+                propensity_tier=score_data["als_tier"],
+                propensity_data_quality=score_data["als_data_quality"],
+                propensity_authority=score_data["als_authority"],
+                propensity_company_fit=score_data["als_company_fit"],
+                propensity_timing=score_data["als_timing"],
+                propensity_risk=score_data["als_risk"],
                 # Phase 16: Store for learning
                 als_components=score_data.get("als_components"),
                 als_weights_used=score_data.get("als_weights_used"),


### PR DESCRIPTION
## Root cause
`scorer.py _persist_score` used DB column names (`als_tier`, `als_data_quality`, etc.) in `update().values()`. SQLAlchemy ORM requires Python attribute names for object sync-back. Lead model maps `propensity_*` attrs → `als_*` DB columns via `name=`.

Error: `InvalidRequestError: Attribute name not found, can't be synchronized back to objects: 'als_tier'`

## Fix
6 column names → Python attribute names:
- `als_tier` → `propensity_tier`
- `als_data_quality` → `propensity_data_quality`  
- `als_authority` → `propensity_authority`
- `als_company_fit` → `propensity_company_fit`
- `als_timing` → `propensity_timing`
- `als_risk` → `propensity_risk`

## Tests
765 passed, 4 skipped, 0 failed