### PR TITLE
fix: remove missing audit_log columns from scout.py (#214)

### DIFF
--- a/src/engines/scout.py
+++ b/src/engines/scout.py
@@ -652,15 +652,17 @@ class ScoutEngine(BaseEngine):
 
             log_entry = {
                 "engine": self.name,
-                "operation_type": "enrichment",
                 "operation": operation,
                 "lead_id": lead_id,
-                "lead_email": lead_email,
                 "domain": domain,
                 "success": success,
                 "cost_aud": cost_aud,
                 "error_message": error,
-                "metadata": metadata or {},
+                "metadata": {
+                    **(metadata or {}),
+                    "operation_type": "enrichment",
+                    "lead_email": lead_email,
+                },
                 "created_at": datetime.now(UTC).isoformat(),
             }
 


### PR DESCRIPTION
## Directive #214

### File changed (1)
- `src/engines/scout.py`

### Change
`_log_enrichment_audit` log_entry had `lead_email` and `operation_type` as top-level keys — neither exists in the `audit_logs` table schema. Both moved into the `metadata` jsonb field (same fix as PR #201 applied to `siege_waterfall.py`).

Eliminates `[Scout] Audit log failed: lead_email column not found` on every enriched lead.

### Tests
763 passed, 4 skipped, 0 failed