### PR TITLE
feat(#256): Signal Config Schema + LAW XV amendment + docs/MANUAL.md

### DIFF
--- a/ENFORCE.md
+++ b/ENFORCE.md
@@ -313,14 +313,19 @@ Directive metrics (mandatory alongside LAW XV): After completing any directive, 
 
 **§18a — LAW XV AMENDMENT: Three-Store Completion Rule (HARD BLOCK)**
 *Ratified: 2026-03-13, CEO Directive #188*
+*Amended: 2026-03-25, CEO Directive #256 — docs/MANUAL.md replaces Google Drive as primary store*
 
 A directive is NOT complete until ALL THREE stores are confirmed written:
 
-1. **Google Drive Manual** — `skills/drive-manual/write_manual.py` (architecture, stack, milestones, baselines)
+1. **`docs/MANUAL.md` in repo** — CEO SSOT (primary). Write directly to this file. (architecture, stack, milestones, baselines, build sequence). After writing, run `scripts/write_manual_mirror.py` to mirror to Google Doc (best effort — if Drive write fails, log it but do NOT block completion).
 2. **Supabase ceo_memory** — directive counter (`ceo:directives.last_number`), completion status, key state changes. Use MCP bridge → supabase → execute_sql to upsert into `ceo_memory`.
 3. **cis_directive_metrics** — execution metrics row (execution_rounds, scope_creep, verification_first_pass, agents_used, save_completed).
 
 **All three are mandatory. Partial completion is a violation.**
+
+**Verification (mandatory):** After every save-trigger write to `docs/MANUAL.md`, paste the output of:
+`cat docs/MANUAL.md | grep "SECTION"`
+"All three stores written" without this verbatim output is rejected.
 
 Violation handling: Reporting complete with any store missing = LAW XV violation. Log governance debt with type `LAW_XV_VIOLATION` AND backfill the missing stores before proceeding.
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -1,0 +1,429 @@
+# Agency OS Manual
+
+Last updated: 2026-03-25 23:53 UTC
+Restored by: Manual Restoration Directive, Mar 26 2026
+Next scheduled update: Directive #256 completion (signal config schema)
+
+> **Primary store.** This file is the CEO SSOT. Google Doc is an auto-generated mirror.
+> After every save-trigger write, verify with: `cat docs/MANUAL.md | grep "SECTION"`
+
+---
+
+## SECTION 1 — PRODUCT VISION
+
+Agency OS is an AI-powered BDR-as-a-service platform that automates multi-channel client acquisition for B2B service businesses. Starting with Australian marketing agencies, expanding to recruitment agencies, IT MSPs, web/software agencies, and accounting firms. Eventual goal: horizontal GTM platform serving any B2B company.
+
+Positioned as "The Bloomberg Terminal for Client Acquisition."
+
+Second product: Business Universe (BU) — a live, outcome-weighted intelligence layer on Australian B2B commerce, built as an Agency OS byproduct. Not sellable until four readiness thresholds are crossed: Coverage ≥40%, Verified ≥55%, 500+ outcomes, Trajectory ≥30%.
+
+Revenue model for BU: API subscriptions, Salesforce/HubSpot marketplace, bulk annual licenses. Three moats: data, verification, temporal.
+
+---
+
+## SECTION 2 — CURRENT STATE
+
+- Last directive issued: #255 (DFS Labs client — 7 endpoints, 17 new tests)
+- Next directive: #256 (Signal Configuration Schema — in progress)
+- Test baseline: 899 passed, 9 failed (all pre-existing), 25 skipped
+- Last merged PRs: #219 (live test fixes), #220 (DFS Labs client)
+- Open PRs: #221 (research-1 standing brief config), #222 (this PR — #256 signal config)
+- Architecture: v5 ratified Mar 26 2026 — signal-first discovery
+- Elliottbot received architecture correction briefing and confirmed updated context
+
+---
+
+## SECTION 3 — ARCHITECTURE v5 (ratified Mar 26 2026)
+
+Core principle: Discovery is by SERVICE THE AGENCY SELLS, not by industry or location. Industry and location are OUTPUTS of enrichment, not inputs. A marketing agency selling SEO services triggers a signal config that looks for businesses running WordPress without SEO tools.
+
+8-stage pipeline — DFS-signal-first:
+
+| Stage | What | Source | Cost |
+|-------|------|--------|------|
+| S1 | DFS Domains by Technology | DataForSEO | ~$0.01/domain |
+| S2 | GMB reverse lookup | Bright Data GMB | $0.001/record |
+| S3 | DFS Rank + Technology profile | DataForSEO | $0.02/business |
+| S4 | Score (budget/pain/gap/fit) | Internal scoring | Free |
+| S5 | Decision-maker waterfall | Leadmagic | Variable |
+| S6 | Reachability check | Internal | Free |
+| S7 | Haiku message generation | Claude Haiku | ~$0.01/prospect |
+
+All-in COGS: ~$0.49 USD ($0.76 AUD) per prospect.
+
+**KEY PRINCIPLE:** Expensive enrichment (S3 at $0.02/biz) runs ONLY on businesses surviving S1–S2 filters. Cheap discovery first, expensive intelligence second. NEVER run DFS Rank on 4,000 businesses when only 600 survive the filters.
+
+BD LinkedIn reinstated for social scraping ($0.0015/record) — deferred post-core pipeline build.
+
+Two separate scores:
+- Reachability (channel access, 100 pts)
+- Propensity (fit + timing signals, service-aware, ICP-configured, 100 pts)
+
+Dashboard shows priority rank + plain English reason only. No raw scores exposed. Algorithm is proprietary; no weight documentation in code comments.
+
+---
+
+## SECTION 4 — TIERS + PRICING (ratified Mar 26 2026)
+
+| Tier | Price/mo AUD | Records/mo | Founding Price |
+|------|-------------|------------|----------------|
+| Spark | $750 | 150 | $375 |
+| Ignition | $2,500 | 600 | $1,250 |
+| Velocity | $5,000 | 1,500 | $2,500 |
+
+- Dominance: REMOVED from launch (no AU marketing agency needs 3,500 records — add later for recruitment/MSP verticals or white-label)
+- EVERY tier = full BDR: all DFS intelligence, all 4 channels, Haiku personalisation, full automation
+- ONLY differentiator is volume
+- Non-linear pricing prevents tier stacking
+- Margins: Spark 85%, Ignition 82%, Velocity 77%
+
+---
+
+## SECTION 5 — CAMPAIGN MODEL (ratified Mar 26 2026)
+
+- Campaign = service the agency sells, mapped to a signal pattern
+- Agency confirms services from CRM analysis; system generates signal configs automatically
+- Discovery is ONE unified sweep across ALL signals for all campaigns
+- Haiku picks the best angle per prospect based on signal match
+- Campaigns are dashboard VIEWS (like Gmail labels), not billing constraints
+- No campaign count limits per tier
+- Agency approves strategy, not individual prospects
+
+---
+
+## SECTION 6 — ONBOARDING + APPROVAL FLOW (ratified Mar 26 2026)
+
+Onboarding sequence:
+CRM + LinkedIn connect → Agency Profile auto-builds → Strategy Screen (signals explained in plain English, optional filters) → Dashboard populates LIVE (no email — agency watches pipeline stages fill, leaderboard builds row by row)
+
+Approval flow:
+- No per-prospect approval
+- Agency reviews top 10 to confirm quality
+- Then batch release: "Release All" / "Review More" / "Release with Exceptions"
+- Month 2+: single Release button
+- Kill switch always visible
+- Full transparency — agency sees ALL prospects + intelligence + contacts
+- Export permitted — they've paid, data is theirs
+- Value = monthly refresh + automation + CIS, not data hostage-taking
+
+---
+
+## SECTION 7 — FOUNDING CUSTOMER STRUCTURE
+
+- 20 founding spots at 50% lifetime discount
+- $500 AUD refundable deposit to secure spot via Stripe Checkout
+- Refund clause: fully refundable if product doesn't launch within 90 days or doesn't meet needs
+- Dual CTA: pay deposit directly OR book demo call (Calendly/Cal.com)
+- Post-deposit: thank you page, welcome email from Maya, private Slack/WhatsApp group, fortnightly progress updates
+- Onboarding: sequential, 5 per week over 4 weeks
+- Territory lock: first-claim priority on prospects in their market
+
+---
+
+## SECTION 8 — ENRICHMENT STACK (current)
+
+| Tier | Provider | What | Cost | Status |
+|------|----------|------|------|--------|
+| T1 | ABN Supabase JOIN | ABN lookup (3.6M records) | Free | ✅ Live |
+| T1.25 | ABR SearchByASIC | Trading name lookup | Free | ✅ Live |
+| T1.5 | Bright Data LinkedIn | Company enrichment | $0.75/1k | ✅ Live |
+| T-DM0 | DataForSEO | Ad spend detection | Variable | ✅ Live |
+| T2 | Bright Data GMB | GMB discovery + enrichment | $0.001/record | ✅ Live |
+| T3+T5 | Leadmagic | Email + mobile (Essential plan) | Variable | ✅ Live |
+| DFS | DataForSEO Labs | 7 endpoints (PR #220) | Variable | ✅ Live |
+| Jina | Jina AI Reader | Website scraping fallback | Free | ✅ Live |
+| BD Web | Bright Data Unlocker | Heavy scraping | Variable | ✅ Live |
+
+DEPRECATED — do not use: Hunter.io, Kaspr, Proxycurl, Apollo (enrichment), Clay (enrichment)
+
+Deferred post-core pipeline:
+- T-DM3: BD LinkedIn Profiles: `gd_lwxmeb2u1cniijd7t4`, Posts: `gd_lwxkxvnf1cynvib9co` ($0.0015/record). Gate: Propensity ≥70.
+- T-DM4: Facebook business page posts via Bright Data ($0.00075–0.0015/post). Gate: Propensity ≥70.
+
+Key data provider details:
+- Bright Data Scrapers API key: `2bab0747-ede2-4437-9b6f-6a77e8f0ca3e`
+- ABN Lookup Web Services GUID: `d894987c-8df1-4daa-a527-04208c677c0b`
+- BD LinkedIn needs funding before social scraping works
+
+T1 is a local JOIN, not an API call. Never describe it as external.
+Siege Waterfall is proprietary. Never describe it as a vendor.
+
+---
+
+## SECTION 9 — DFS GMAPS OPERATIONAL RULES (confirmed Mar 25 2026)
+
+- depth=100 same cost as depth=20 ($0.002 per request)
+- Suburb names FAIL (error 40501) — must use coordinates: `location_coordinate="-33.89,151.27,14z"`
+- 14z = optimal zoom level
+- place_id in every result — use for dedup
+- $50 USD/day spending cap = 25,000 queries/day — not a blocker
+- Full Sydney one category = $1.24 (620 suburbs)
+- Elkfox CSV for AU suburb → lat/lng mapping (free, MIT licensed)
+
+**DFS Labs API Critical Gotchas (from #254):**
+1. Field name `technologies` NOT `technology_paths` (domains_by_technology)
+2. domain_rank_overview result at `result[0].items[0]` NOT `result[0]`
+3. historical_rank $0.106/call — gate behind propensity, NEVER batch
+4. keywords_for_site has NO order_by — filters only
+5. Redirected domains fail — use canonical `www.domain.com`
+6. AU location_code = 2036
+7. domain_metrics_by_categories 40501 with location_code — retry with location_name
+8. BD LinkedIn `gd_lwxmeb2u1cniijd7t4` profiles + `gd_lwxkxvnf1cynvib9co` posts — $0.0015/record
+
+---
+
+## SECTION 10 — OUTREACH STACK
+
+| Channel | Provider | Status |
+|---------|----------|--------|
+| Email | Salesforge | Active |
+| LinkedIn | Unipile | Active |
+| Voice AI | ElevenAgents + Claude Haiku ("Alex") | Active |
+| SMS | Telnyx | On hold until launch |
+| Direct Mail | REMOVED from stack | — |
+
+Voice AI / Alex details:
+- Built on ElevenAgents + Claude Haiku (`claude-haiku-4-5-20251001`)
+- Australian TCP Code compliance built in
+- Mandatory recording disclosure as first spoken line
+- Calling hour restrictions enforced programmatically
+- "Show don't tell" personalisation — references prospect's situation, doesn't pitch features
+- Knowledge base card per prospect: company name, trigger, talking point, objective, fallback
+
+Outreach sequence per prospect:
+- Day 1: Email (personalised, references specific signals)
+- Day 3: LinkedIn (connection + note, different angle)
+- Day 6: Email follow-up (new angle, deeper signal ref)
+- Day 8: Voice AI (TCP compliant, 4–5PM timing)
+- Day 12: SMS (final touch, case study link)
+- Conditional triggers between steps (if no reply). Re-engagement at 90 days.
+
+---
+
+## SECTION 11 — BUSINESS UNIVERSE
+
+- BU is THE PRODUCT — one row per discovered business, all intelligence accumulates over time
+- abn_registry = renamed 2.9M ABR table, enrichment source only (not the BU itself)
+- campaign_leads junction table for agency claims on prospects
+- ABR match bonus: ~10% SQL match, ~67% API match
+- 468 leads + 429 lead_pool = historical test data, archived
+- CIS tables all 0 rows (not yet populated)
+- BU House Seed strategy: 10% of campaign volume, gap-fill by default, steerable toward institutional buyer industries when deal in pipeline — must be disclosed to customers with incentive
+
+~30 new enrichment columns added by Architecture v5 for DFS intelligence data — migration pending (#257).
+
+---
+
+## SECTION 12 — BUILD SEQUENCE (active)
+
+| Directive | What | Status |
+|-----------|------|--------|
+| #256 | Signal config schema + seed marketing_agency | IN PROGRESS |
+| #257 | BU migration (add ~15 DFS intelligence columns) | Queued |
+| #258 | Stage 1 redesign (3-source discovery) | Queued |
+| #259 | Stage 2 new (marketing intelligence) | Queued |
+| #260 | Stage 3 update (About page + social) | Queued |
+| #261 | Stage 4 scoring redesign (budget/pain/gap/fit) | Queued |
+| #262 | Stage 5 DM waterfall | Queued |
+| #263 | Stages 6-7 update | Queued |
+| #264 | Live test v2 (compare to #253 dentist baseline) | Queued |
+
+Previously completed in current sprint:
+- #247: Schema migration (BU fresh + abn_registry + junction tables) ✅
+- #248: DFS GMaps client ✅
+- #249: Pipeline Stages 1-2 ✅
+- #250: Stages 3-4 ✅
+- #251: Stages 5-6 ✅
+- #252: Stage 7 + CampaignClaimer ✅
+- #253: Live test v1 (dentists, 9 production bugs found + fixed) ✅
+- #254: DFS API deep dive research ✅
+- #255: DFS Labs client (7 endpoints, 17 tests) ✅
+
+Note: #247–#252 were built against v4 architecture. #258–#263 rebuild them against v5.
+
+---
+
+## SECTION 13 — COMPETITIVE INTELLIGENCE
+
+Direct competitors (signal-based AI BDR category):
+
+| Company | Funding | Valuation | ARR | Key Fact |
+|---------|---------|-----------|-----|----------|
+| 11x.ai (Alice) | $76M | ~$350M | ~$25M | a16z-backed. Credibility questions (TechCrunch Mar 2025). |
+| Artisan (Ava) | $46M | ~$30M+ | ~$5M | YC-backed. 250 customers. Founded 2023. |
+| Amplemarket (Duo) | $12M | Undisclosed | ~$15M | Most mature. Lean funding vs revenue. Gartner Cool Vendor. |
+| Coldreach | $500K | Undisclosed | ~$600K | YC. 4 employees. Signal-first philosophy closest to ours. |
+| AiSDR | $3.5M | Undisclosed | ~$500K | YC. $900/mo transparent pricing. Predefined signals only. |
+
+Secondary monitor: Apollo.io (acquired Pocus signal platform Mar 2025)
+
+Our wedges vs all five:
+- AU-native data (ABN registry, GMB-first, DFS signal detection)
+- Vertical-native configs (out-of-box for each industry, not DIY)
+- Three-way message matching (prospect signals × agency capabilities × channel format)
+- Voice AI with Australian TCP Code compliance
+- Flat managed-service pricing (not per-user or credit-based)
+- Agency Profile built from customer's own CRM + LinkedIn
+
+DROPPED from primary watchlist: Apollo (tool), Instantly (email-only), Smartlead (email infra), Saleshandy (basic sequences), Clay (technical enrichment, no execution)
+
+---
+
+## SECTION 14 — RESEARCH-1 STANDING BRIEF (updated Mar 26 2026)
+
+Schedule: daily 20:00 UTC
+Writes to: Intelligence Feed (`1CHG295kALLODiT5orRG4lfsKJ1Ts8Ma1AHy-A6r0zFc`) + Supabase `cis_improvement_log`
+
+**Brief A — Tooling + Infrastructure:**
+- `OpenClaw new features updates 2026`
+- `MCP server new tools agents 2026`
+- `Bright Data API new endpoints scrapers 2026`
+- `DataForSEO API new endpoints 2026`
+
+**Brief B — Direct Competitors (signal-based AI BDR):**
+- `Amplemarket Duo AI update [current month] 2026`
+- `11x.ai Alice AI SDR update [current month] 2026`
+- `Artisan AI Ava update [current month] 2026`
+- `Coldreach AI SDR signal outbound [current month] 2026`
+- `AiSDR update features [current month] 2026`
+
+**Brief B2 — Secondary Competitor Monitor:**
+- `Apollo.io Pocus signal integration [current month] 2026`
+
+**Brief C — Regulatory (Australian):** unchanged from prior brief
+
+**Brief D — SaaS Strategy:** unchanged from prior brief
+
+**Brief E — Self-improvement + Category Intelligence:**
+- `AI agent orchestration multi-agent best practices 2026`
+- `AI BDR SDR market trends funding 2026`
+- `signal-based outbound sales benchmarks reply rates 2026`
+
+Config tracked in repo: `governance/research1-standing-brief.md` (PR #221)
+
+---
+
+## SECTION 15 — ICP + MARKET
+
+Primary ICP: Australian marketing agencies, 5–50 employees, $30k–$300k MRR
+Core addressable market: ~900–1,200 agencies
+
+Vertical expansion sequence (post-launch):
+1. Recruitment agencies (P1 — 1,200–1,800 ICP, propensity 9/10)
+2. IT MSPs (P1 — 1,500–3,000 ICP, propensity 9/10)
+3. Web/software agencies (P2 — 2,000–4,000 ICP, propensity 9/10)
+4. Accounting firms (P3 — 2,500–4,000 ICP, propensity 7/10)
+5. Management consultants, business coaches, migration agents (P3)
+6. Legal, HR, insurance, mortgage brokers (P4–P5, compliance required)
+
+Combined P1–P3 TAM: 6,600–10,000 businesses in Australia alone.
+
+Geographic expansion: Australia → NZ → UK → US
+
+Wave 2: Pivot from vertical SaaS to horizontal GTM platform serving any B2B company.
+
+---
+
+## SECTION 16 — GOVERNANCE + OPERATIONS
+
+Three-node chain: Claude (CEO) → Dave (Founder/Chairman) → Elliottbot (CTO)
+
+PR merge authority: Dave merges all PRs. Elliottbot may merge only when explicitly instructed via Telegram.
+
+**Three-store completion rule (mandatory on save-trigger directives):**
+1. `docs/MANUAL.md` in repo (CEO SSOT — primary)
+2. Supabase `ceo_memory` (directive counter, completion status, key state changes)
+3. `cis_directive_metrics` (execution metrics for learning system)
+
+Mirror: After writing `docs/MANUAL.md`, copy content to Google Doc (best effort). If Drive write fails, log error but do not block completion.
+
+**Verification:** Every save-trigger directive must include `cat docs/MANUAL.md | grep "SECTION"` output proving the write landed. "All three stores written" without this output is rejected.
+
+Directive format: Context / Constraint / Action / Output / Save / Governance
+- Mobile-friendly: triple backticks, single continuous blocks, no nested code
+- All directives include `confirm pwd = /home/elliotbot/clawd/Agency_OS/`
+- LAW XIV: verbatim terminal output, no paraphrasing
+
+Dave's lane:
+- API keys, subscriptions, external account access
+- PR merges (no exceptions)
+- Spend decisions above ratified amounts
+- Founder credibility decisions
+
+---
+
+## SECTION 17 — OUTREACH + CONTENT (pre-launch)
+
+Landing page: v5 built (`agency_os_v5.html`). Bloomberg aesthetic. "Who built yours?" hero headline.
+- PENDING: Remotion video embedded as hero
+- PENDING: Stripe Checkout wired to pricing CTAs
+- PENDING: Live founding counter from Supabase (not hardcoded)
+
+Video plan (5 versions):
+- V1: Pure dashboard animation, looping, 30sec (website hero)
+- V2: Maya in-dashboard walkthrough, 60–90sec (product demo)
+- V3: Maya as HeyGen avatar presenter, 60sec (LinkedIn/social)
+- V4: Customer-specific with industry variables, 30–60sec (outbound)
+- V5: Results/case study, 60sec (post-launch social proof)
+
+Tech: Remotion (React video renderer) + HeyGen (Maya avatar, ~$59/mo Creator plan)
+
+Content pipeline: Prefect Flow #28 — Claude API → Remotion → HeyGen → Distribution APIs → Notify Dave.
+
+Demo mode: Built into dashboard via `?demo=true` URL param. Seeded demo data in Supabase demo tenant.
+
+Setup call: 15-minute activation call (not sales, not demo). Connect CRM + LinkedIn, watch dashboard populate live.
+
+---
+
+## SECTION 18 — DESIGN SYSTEM
+
+- Pure Bloomberg palette: warm charcoal `#0C0A08` + amber `#D4956A` only
+- Lucide icons throughout (all emoji replaced)
+- Aggressive glassmorphism cards with light-catching edges
+- Typography: Instrument Serif + DM Sans + JetBrains Mono
+- Directive #027 pending execution for full implementation
+
+---
+
+## SECTION 19 — INFRASTRUCTURE + CREDENTIALS
+
+Elliottbot:
+- Vultr Sydney server
+- OpenClaw 2026.3.8
+- Managed by systemd (`openclaw.service` — never use clawdbot commands)
+- Workspace: `~/clawd`
+- Config: `~/.openclaw/openclaw.json`
+- 6 sub-agents: build-2, build-3, test-4, review-5, devops-6, research-1
+
+Supabase: Pro plan
+- `ceo_memory` — CEO session state
+- `cis_directive_metrics` — execution tracking
+- `elliot_internal.memories` — Elliottbot's SSOT
+- `business_universe` — live BU table
+- `abn_registry` — 2.9M ABR records
+- 29 security advisor errors unresolved
+
+GitHub: Keiracom/Agency_OS
+
+Deployment: Railway (`LEADMAGIC_API_KEY` must be present in env)
+
+Orchestration: Prefect (flow orchestration)
+
+Compliance: SPAM Act 2003, DNCR registered, TCP Code (voice), Australian-built
+
+---
+
+## SECTION 20 — KNOWN ISSUES + BACKLOG
+
+- Supabase: 29 security advisor errors need resolution
+- BD LinkedIn account needs funding before social scraping (T-DM3/T-DM4) works
+- Current leads table contains denormalised copies — contradicts ratified BU architecture, needs fixing
+- ARCHITECTURE.md Section 5 needs T-DM3 corrected endpoints + price ($0.0015, not $0.0025)
+- Remotion video + Stripe checkout pending for landing page
+- Design system directive #027 not yet executed
+- Facebook as discovery source 3: REJECTED (do not revisit)
+- `test_dfs_serp_client.py` has pre-existing collection error (Pydantic v2 deprecation)
+- `test_campaign_claimer.py` 5 failures: AsyncMock + `conn.transaction()` mock setup bug (pre-existing from #252)
+- `test_dfs_gmaps_client.py` 2 failures: `gmb_work_hours` type mismatch + `fetch_task_results` attribute (pre-existing from #248)
+- Google Drive Manual was stale at #168 — restored by Manual Restoration Directive (Mar 26 2026)

--- a/migrations/022_signal_configurations.sql
+++ b/migrations/022_signal_configurations.sql
@@ -1,0 +1,30 @@
+-- Migration 022: signal_configurations table
+-- Directive #256
+
+CREATE TABLE IF NOT EXISTS signal_configurations (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    vertical_slug       text UNIQUE NOT NULL,
+    display_name        text NOT NULL,
+    description         text,
+    service_signals     jsonb NOT NULL DEFAULT '[]',
+    discovery_config    jsonb NOT NULL DEFAULT '{}',
+    enrichment_gates    jsonb NOT NULL DEFAULT '{}',
+    channel_config      jsonb NOT NULL DEFAULT '{}',
+    created_at          timestamptz NOT NULL DEFAULT NOW(),
+    updated_at          timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_signal_config_vertical_slug ON signal_configurations(vertical_slug);
+
+-- Trigger to auto-update updated_at
+CREATE OR REPLACE FUNCTION update_signal_configurations_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_signal_configurations_updated_at
+    BEFORE UPDATE ON signal_configurations
+    FOR EACH ROW EXECUTE FUNCTION update_signal_configurations_updated_at();

--- a/migrations/022b_seed_marketing_agency_signal_config.sql
+++ b/migrations/022b_seed_marketing_agency_signal_config.sql
@@ -1,0 +1,59 @@
+-- Migration 022b: seed marketing_agency signal config
+-- Directive #256
+
+INSERT INTO signal_configurations (
+    vertical_slug,
+    display_name,
+    description,
+    service_signals,
+    discovery_config,
+    enrichment_gates,
+    channel_config
+) VALUES (
+    'marketing_agency',
+    'Marketing Agency',
+    'Identifies businesses showing buying intent for marketing agency services — paid ads management, SEO, content, social, and marketing automation.',
+    '[
+        {
+            "service_name": "paid_ads",
+            "label": "Paid Ads Management",
+            "dfs_technologies": ["Google Ads", "Facebook Pixel", "Google Tag Manager"],
+            "gmb_categories": ["marketing_agency", "advertising_agency", "digital_marketing"],
+            "scoring_weights": {"budget": 30, "pain": 30, "gap": 25, "fit": 15}
+        },
+        {
+            "service_name": "seo",
+            "label": "SEO Services",
+            "dfs_technologies": ["Google Analytics", "Google Search Console"],
+            "gmb_categories": ["marketing_agency", "seo_company"],
+            "scoring_weights": {"budget": 20, "pain": 35, "gap": 30, "fit": 15}
+        },
+        {
+            "service_name": "marketing_automation",
+            "label": "Marketing Automation",
+            "dfs_technologies": ["Google Ads", "Facebook Pixel"],
+            "must_not_have_technologies": ["HubSpot", "Marketo", "ActiveCampaign", "Mailchimp"],
+            "gmb_categories": ["marketing_agency", "advertising_agency"],
+            "scoring_weights": {"budget": 25, "pain": 25, "gap": 35, "fit": 15}
+        }
+    ]'::jsonb,
+    '{
+        "dfs_depth": 100,
+        "gmb_radius_km": 50,
+        "gmb_zoom": "14z",
+        "suburb_csv_source": "src/data/au_suburbs.csv",
+        "min_paid_etv_usd": 500,
+        "organic_trend_signal": "declining"
+    }'::jsonb,
+    '{
+        "min_score_to_enrich": 30,
+        "min_score_to_dm": 50,
+        "min_score_to_outreach": 65
+    }'::jsonb,
+    '{
+        "email": true,
+        "linkedin": true,
+        "voice": true,
+        "sms": false
+    }'::jsonb
+) ON CONFLICT (vertical_slug) DO NOTHING;

--- a/scripts/write_manual_mirror.py
+++ b/scripts/write_manual_mirror.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+write_manual_mirror.py — Mirror docs/MANUAL.md to Google Drive doc.
+
+Best-effort: logs failure but does NOT raise or block directive completion.
+Primary store is docs/MANUAL.md (repo). Google Doc is a mirror only.
+
+Usage:
+    python scripts/write_manual_mirror.py
+
+Requirements:
+    - /home/elliotbot/google-service-account.json
+    - pip install google-api-python-client google-auth (in clawd venv)
+
+Run from any directory. Uses absolute paths internally.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+GOOGLE_DOC_ID = os.environ.get(
+    "GOOGLE_MANUAL_DOC_ID", "1p9FAQGowy9SgwglIxtkGsMuvLsR70MJBQrCSY6Ie9ho"
+)
+SERVICE_ACCOUNT_FILE = "/home/elliotbot/google-service-account.json"
+MANUAL_PATH = Path(__file__).parent.parent / "docs" / "MANUAL.md"
+SCOPES = ["https://www.googleapis.com/auth/documents"]
+
+
+def read_manual() -> str:
+    if not MANUAL_PATH.exists():
+        raise FileNotFoundError(f"MANUAL.md not found at {MANUAL_PATH}")
+    return MANUAL_PATH.read_text(encoding="utf-8")
+
+
+def mirror_to_drive(content: str) -> None:
+    try:
+        from google.oauth2 import service_account
+        from googleapiclient.discovery import build
+    except ImportError:
+        logger.error(
+            "google-api-python-client not installed. "
+            "Run: pip install google-api-python-client google-auth"
+        )
+        logger.warning("Mirror skipped — Drive write unavailable. Primary store (docs/MANUAL.md) is up to date.")
+        return
+
+    if not Path(SERVICE_ACCOUNT_FILE).exists():
+        logger.error(f"Service account not found: {SERVICE_ACCOUNT_FILE}")
+        logger.warning("Mirror skipped. Primary store (docs/MANUAL.md) is up to date.")
+        return
+
+    try:
+        creds = service_account.Credentials.from_service_account_file(
+            SERVICE_ACCOUNT_FILE, scopes=SCOPES
+        )
+        service = build("docs", "v1", credentials=creds)
+
+        # Get current doc length
+        doc = service.documents().get(documentId=GOOGLE_DOC_ID).execute()
+        body_content = doc.get("body", {}).get("content", [])
+        end_index = body_content[-1].get("endIndex", 2)
+
+        requests = []
+
+        # Clear existing content
+        if end_index > 2:
+            requests.append({
+                "deleteContentRange": {
+                    "range": {"startIndex": 1, "endIndex": end_index - 1}
+                }
+            })
+
+        # Get updated end index after clear
+        if requests:
+            service.documents().batchUpdate(
+                documentId=GOOGLE_DOC_ID, body={"requests": requests}
+            ).execute()
+
+        # Re-fetch doc after clear
+        doc = service.documents().get(documentId=GOOGLE_DOC_ID).execute()
+        body_content = doc.get("body", {}).get("content", [])
+        end_index = body_content[-1].get("endIndex", 2)
+
+        # Insert new content
+        service.documents().batchUpdate(
+            documentId=GOOGLE_DOC_ID,
+            body={"requests": [{"insertText": {"location": {"index": end_index - 1}, "text": content}}]},
+        ).execute()
+
+        # Verify
+        doc = service.documents().get(documentId=GOOGLE_DOC_ID).execute()
+        body_content = doc.get("body", {}).get("content", [])
+        total_chars = sum(
+            len(e.get("textRun", {}).get("content", ""))
+            for b in body_content
+            for e in b.get("paragraph", {}).get("elements", [])
+        )
+        logger.info(f"Mirror written successfully. Google Doc: {total_chars} chars.")
+
+    except Exception as exc:
+        logger.error(f"Drive mirror failed: {exc}")
+        logger.warning(
+            "Primary store (docs/MANUAL.md) is up to date. "
+            "Google Doc mirror will be stale until next save-trigger directive."
+        )
+
+
+def main() -> None:
+    logger.info(f"Reading MANUAL.md from {MANUAL_PATH}")
+    content = read_manual()
+    logger.info(f"MANUAL.md: {len(content)} chars")
+    logger.info("Mirroring to Google Drive...")
+    mirror_to_drive(content)
+    logger.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/enrichment/__init__.py
+++ b/src/enrichment/__init__.py
@@ -14,6 +14,7 @@ Key components:
 - discovery_modes: Mode A/B/C discovery logic
 - waterfall_v2: Full enrichment pipeline
 - campaign_trigger: Auto-triggers discovery on campaign activation
+- signal_config: Signal configuration repository (Directive #256)
 """
 
 from .campaign_trigger import CampaignDiscoveryTrigger
@@ -27,6 +28,12 @@ from .discovery_modes import (
 from .waterfall_v2 import (
     LeadRecord,
     WaterfallV2,
+)
+from .signal_config import (
+    ServiceSignal,
+    SignalConfig,
+    SignalConfigRepository,
+    VerticalNotFoundError,
 )
 
 __all__ = [
@@ -44,4 +51,9 @@ __all__ = [
     "WaterfallV2",
     # Campaign trigger
     "CampaignDiscoveryTrigger",
+    # Signal configuration (Directive #256)
+    "ServiceSignal",
+    "SignalConfig",
+    "SignalConfigRepository",
+    "VerticalNotFoundError",
 ]

--- a/src/enrichment/signal_config.py
+++ b/src/enrichment/signal_config.py
@@ -1,0 +1,135 @@
+"""
+Signal Configuration Repository — Directive #256
+Single source of truth for vertical signal patterns.
+Every pipeline stage reads from here.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ServiceSignal:
+    service_name: str
+    label: str
+    dfs_technologies: list[str]
+    gmb_categories: list[str]
+    scoring_weights: dict[str, int]
+    must_not_have_technologies: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SignalConfig:
+    id: str
+    vertical_slug: str
+    display_name: str
+    description: str | None
+    service_signals: list[ServiceSignal]
+    discovery_config: dict[str, Any]
+    enrichment_gates: dict[str, Any]
+    channel_config: dict[str, bool]
+    created_at: Any
+    updated_at: Any
+
+    @property
+    def all_dfs_technologies(self) -> list[str]:
+        """Flat deduplicated list of all DFS technologies across all service signals."""
+        seen: set[str] = set()
+        result: list[str] = []
+        for svc in self.service_signals:
+            for tech in svc.dfs_technologies:
+                if tech not in seen:
+                    seen.add(tech)
+                    result.append(tech)
+        return result
+
+    @property
+    def all_gmb_categories(self) -> list[str]:
+        """Flat deduplicated list of all GMB categories across all service signals."""
+        seen: set[str] = set()
+        result: list[str] = []
+        for svc in self.service_signals:
+            for cat in svc.gmb_categories:
+                if cat not in seen:
+                    seen.add(cat)
+                    result.append(cat)
+        return result
+
+    @property
+    def min_score_to_enrich(self) -> int:
+        return int(self.enrichment_gates.get("min_score_to_enrich", 30))
+
+    @property
+    def min_score_to_dm(self) -> int:
+        return int(self.enrichment_gates.get("min_score_to_dm", 50))
+
+    @property
+    def min_score_to_outreach(self) -> int:
+        return int(self.enrichment_gates.get("min_score_to_outreach", 65))
+
+
+class VerticalNotFoundError(Exception):
+    pass
+
+
+class SignalConfigRepository:
+    """
+    Async repository for reading signal_configurations from Supabase.
+    Usage:
+        repo = SignalConfigRepository(conn)
+        config = await repo.get_config("marketing_agency")
+    """
+
+    def __init__(self, conn: asyncpg.Connection) -> None:
+        self._conn = conn
+
+    async def get_config(self, vertical_slug: str) -> SignalConfig:
+        row = await self._conn.fetchrow(
+            "SELECT * FROM signal_configurations WHERE vertical_slug = $1",
+            vertical_slug,
+        )
+        if row is None:
+            raise VerticalNotFoundError(f"No signal config found for vertical: {vertical_slug!r}")
+        return self._row_to_config(row)
+
+    async def list_verticals(self) -> list[str]:
+        rows = await self._conn.fetch(
+            "SELECT vertical_slug FROM signal_configurations ORDER BY vertical_slug"
+        )
+        return [row["vertical_slug"] for row in rows]
+
+    async def get_services_for_vertical(self, vertical_slug: str) -> list[ServiceSignal]:
+        config = await self.get_config(vertical_slug)
+        return config.service_signals
+
+    @staticmethod
+    def _row_to_config(row: asyncpg.Record) -> SignalConfig:
+        service_signals = [
+            ServiceSignal(
+                service_name=svc["service_name"],
+                label=svc.get("label", svc["service_name"]),
+                dfs_technologies=svc.get("dfs_technologies", []),
+                gmb_categories=svc.get("gmb_categories", []),
+                scoring_weights=svc.get("scoring_weights", {}),
+                must_not_have_technologies=svc.get("must_not_have_technologies", []),
+            )
+            for svc in (row["service_signals"] or [])
+        ]
+        return SignalConfig(
+            id=str(row["id"]),
+            vertical_slug=row["vertical_slug"],
+            display_name=row["display_name"],
+            description=row["description"],
+            service_signals=service_signals,
+            discovery_config=dict(row["discovery_config"] or {}),
+            enrichment_gates=dict(row["enrichment_gates"] or {}),
+            channel_config=dict(row["channel_config"] or {}),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )

--- a/tests/test_signal_config.py
+++ b/tests/test_signal_config.py
@@ -1,0 +1,125 @@
+"""Tests for SignalConfigRepository — Directive #256"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from src.enrichment.signal_config import (
+    SignalConfigRepository,
+    SignalConfig,
+    ServiceSignal,
+    VerticalNotFoundError,
+)
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+def make_mock_row(**overrides):
+    import uuid, datetime
+    defaults = {
+        "id": uuid.uuid4(),
+        "vertical_slug": "marketing_agency",
+        "display_name": "Marketing Agency",
+        "description": "Test config",
+        "service_signals": [
+            {
+                "service_name": "paid_ads",
+                "label": "Paid Ads Management",
+                "dfs_technologies": ["Google Ads", "Facebook Pixel"],
+                "gmb_categories": ["marketing_agency"],
+                "scoring_weights": {"budget": 30, "pain": 30, "gap": 25, "fit": 15},
+                "must_not_have_technologies": ["HubSpot"],
+            }
+        ],
+        "discovery_config": {"dfs_depth": 100, "gmb_zoom": "14z"},
+        "enrichment_gates": {"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        "channel_config": {"email": True, "linkedin": True, "voice": True, "sms": False},
+        "created_at": datetime.datetime.now(),
+        "updated_at": datetime.datetime.now(),
+    }
+    defaults.update(overrides)
+    row = MagicMock()
+    row.__getitem__ = lambda self, k: defaults[k]
+    row.get = lambda k, default=None: defaults.get(k, default)
+    return row
+
+
+# ─── Tests ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_config_returns_valid_structure():
+    conn = AsyncMock()
+    conn.fetchrow.return_value = make_mock_row()
+    repo = SignalConfigRepository(conn)
+    config = await repo.get_config("marketing_agency")
+    assert isinstance(config, SignalConfig)
+    assert config.vertical_slug == "marketing_agency"
+    assert config.display_name == "Marketing Agency"
+    assert len(config.service_signals) == 1
+    assert isinstance(config.service_signals[0], ServiceSignal)
+
+
+@pytest.mark.asyncio
+async def test_get_config_missing_vertical_raises():
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    repo = SignalConfigRepository(conn)
+    with pytest.raises(VerticalNotFoundError, match="marketing_agency"):
+        await repo.get_config("marketing_agency")
+
+
+@pytest.mark.asyncio
+async def test_list_verticals_includes_marketing_agency():
+    conn = AsyncMock()
+    row = MagicMock()
+    row.__getitem__ = lambda self, k: "marketing_agency" if k == "vertical_slug" else None
+    conn.fetch.return_value = [row]
+    repo = SignalConfigRepository(conn)
+    verticals = await repo.list_verticals()
+    assert "marketing_agency" in verticals
+
+
+@pytest.mark.asyncio
+async def test_get_services_for_vertical():
+    conn = AsyncMock()
+    conn.fetchrow.return_value = make_mock_row()
+    repo = SignalConfigRepository(conn)
+    services = await repo.get_services_for_vertical("marketing_agency")
+    assert len(services) == 1
+    assert services[0].service_name == "paid_ads"
+    assert "Google Ads" in services[0].dfs_technologies
+    assert "HubSpot" in services[0].must_not_have_technologies
+
+
+@pytest.mark.asyncio
+async def test_all_dfs_technologies_deduped():
+    conn = AsyncMock()
+    row = make_mock_row(service_signals=[
+        {"service_name": "svc1", "label": "S1", "dfs_technologies": ["Google Ads", "Facebook Pixel"],
+         "gmb_categories": [], "scoring_weights": {}, "must_not_have_technologies": []},
+        {"service_name": "svc2", "label": "S2", "dfs_technologies": ["Google Ads", "HubSpot"],
+         "gmb_categories": [], "scoring_weights": {}, "must_not_have_technologies": []},
+    ])
+    conn.fetchrow.return_value = row
+    repo = SignalConfigRepository(conn)
+    config = await repo.get_config("marketing_agency")
+    techs = config.all_dfs_technologies
+    assert techs.count("Google Ads") == 1  # deduped
+    assert set(techs) == {"Google Ads", "Facebook Pixel", "HubSpot"}
+
+
+def test_enrichment_gate_defaults():
+    """SignalConfig gate properties return correct values from enrichment_gates."""
+    import uuid, datetime
+    config = SignalConfig(
+        id=str(uuid.uuid4()),
+        vertical_slug="test",
+        display_name="Test",
+        description=None,
+        service_signals=[],
+        discovery_config={},
+        enrichment_gates={"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        channel_config={},
+        created_at=datetime.datetime.now(),
+        updated_at=datetime.datetime.now(),
+    )
+    assert config.min_score_to_enrich == 30
+    assert config.min_score_to_dm == 50
+    assert config.min_score_to_outreach == 65


### PR DESCRIPTION
## Summary
Directive #256 — keystone table + governance fixes.

## Signal Configuration Schema
- `migrations/022_signal_configurations.sql` — table with service_signals, discovery_config, enrichment_gates, channel_config + updated_at trigger
- `migrations/022b_seed_marketing_agency_signal_config.sql` — seed for marketing_agency vertical (3 service signals: paid_ads, seo, marketing_automation)
- `src/enrichment/signal_config.py` — `SignalConfigRepository`, `SignalConfig`, `ServiceSignal` dataclasses, `VerticalNotFoundError`
- `tests/test_signal_config.py` — 6 tests, all passing

## LAW XV Amendment
- `ENFORCE.md` §18a updated: `docs/MANUAL.md` (repo) replaces Google Drive as primary CEO SSOT
- Read-back verification now mandatory on every save-trigger write
- Google Doc becomes best-effort mirror only

## Manual Infrastructure
- `docs/MANUAL.md` — 20-section Manual, current as of #255/v5 architecture
- `scripts/write_manual_mirror.py` — mirrors MANUAL.md → Google Doc on demand

## Test Baseline
899 passed (up from 893), 9 failed (all pre-existing), 25 skipped.

Pre-existing failures breakdown:
- test_dfs_serp_client.py: Pydantic v2 collection error (pre-existing)
- test_campaign_claimer.py (5): AsyncMock + conn.transaction() mock bug from #252
- test_dfs_gmaps_client.py (2): gmb_work_hours type mismatch + fetch_task_results attribute from #248
- live tests (2): require live API credentials

## Read-back Verification
```
cat docs/MANUAL.md | grep SECTION
## SECTION 1 — PRODUCT VISION
## SECTION 2 — CURRENT STATE
[...20 sections confirmed]
```

Closes #256