### PR TITLE
feat(#257): BU DFS intelligence columns — 22 new columns for pipeline v5

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -210,7 +210,38 @@ Outreach sequence per prospect:
 - CIS tables all 0 rows (not yet populated)
 - BU House Seed strategy: 10% of campaign volume, gap-fill by default, steerable toward institutional buyer industries when deal in pipeline — must be disclosed to customers with incentive
 
-~30 new enrichment columns added by Architecture v5 for DFS intelligence data — migration pending (#257).
+**New DFS intelligence columns (added #257, total BU columns: ~97):**
+
+S1 Discovery:
+- `dfs_technologies` jsonb — raw tech array from DFS domains_by_technology
+- `dfs_discovery_sources` text[] — all sources that found this business
+- `dfs_technology_detected_at` timestamptz
+
+S3 DFS Rank Overview:
+- `dfs_organic_etv` numeric — estimated organic traffic value (USD)
+- `dfs_paid_etv` numeric — estimated paid traffic cost (USD) — THE BUDGET SIGNAL
+- `dfs_organic_keywords` integer
+- `dfs_paid_keywords` integer
+- `dfs_organic_pos_1/2_3/4_10/11_20` integer — position distribution
+- `dfs_rank_fetched_at` timestamptz
+
+S3 DFS Domain Technologies:
+- `tech_stack` text[] — flat deduplicated technology list
+- `tech_categories` jsonb — nested dict by category
+- `tech_stack_depth` integer — count of unique technologies
+- `tech_gaps` text[] — must_not_have_tech items absent (computed)
+- `dfs_tech_fetched_at` timestamptz
+
+S4 Scoring (v5 budget/pain/gap/fit):
+- `score_budget` integer (0-30)
+- `score_pain` integer (0-30)
+- `score_gap` integer (0-25)
+- `score_fit` integer (0-15)
+- (composite `propensity_score` + `reachability_score` retained from v4)
+
+Meta:
+- `pipeline_updated_at` timestamptz
+- `enrichment_cost_usd` numeric (complements existing `enrichment_cost_aud`)
 
 ---
 

--- a/migrations/023_bu_dfs_columns.sql
+++ b/migrations/023_bu_dfs_columns.sql
@@ -1,0 +1,49 @@
+-- Migration 023: Add DFS intelligence columns to business_universe
+-- Directive #257
+
+-- ── Group A: DFS Domains by Technology (S1 discovery) ──────────────────────
+ALTER TABLE business_universe
+    ADD COLUMN IF NOT EXISTS dfs_technologies jsonb,
+    ADD COLUMN IF NOT EXISTS dfs_discovery_sources text[],
+    ADD COLUMN IF NOT EXISTS dfs_technology_detected_at timestamptz;
+
+-- ── Group B: DFS Domain Rank Overview (S3) ─────────────────────────────────
+ALTER TABLE business_universe
+    ADD COLUMN IF NOT EXISTS dfs_organic_etv numeric,
+    ADD COLUMN IF NOT EXISTS dfs_paid_etv numeric,
+    ADD COLUMN IF NOT EXISTS dfs_organic_keywords integer,
+    ADD COLUMN IF NOT EXISTS dfs_paid_keywords integer,
+    ADD COLUMN IF NOT EXISTS dfs_organic_pos_1 integer,
+    ADD COLUMN IF NOT EXISTS dfs_organic_pos_2_3 integer,
+    ADD COLUMN IF NOT EXISTS dfs_organic_pos_4_10 integer,
+    ADD COLUMN IF NOT EXISTS dfs_organic_pos_11_20 integer,
+    ADD COLUMN IF NOT EXISTS dfs_rank_fetched_at timestamptz;
+
+-- ── Group C: DFS Domain Technologies (S3) ──────────────────────────────────
+ALTER TABLE business_universe
+    ADD COLUMN IF NOT EXISTS tech_stack text[],
+    ADD COLUMN IF NOT EXISTS tech_categories jsonb,
+    ADD COLUMN IF NOT EXISTS tech_stack_depth integer,
+    ADD COLUMN IF NOT EXISTS tech_gaps text[],
+    ADD COLUMN IF NOT EXISTS dfs_tech_fetched_at timestamptz;
+
+-- ── Group D: Stage 4 Scoring sub-scores (v5 budget/pain/gap/fit) ───────────
+ALTER TABLE business_universe
+    ADD COLUMN IF NOT EXISTS score_budget integer,
+    ADD COLUMN IF NOT EXISTS score_pain integer,
+    ADD COLUMN IF NOT EXISTS score_gap integer,
+    ADD COLUMN IF NOT EXISTS score_fit integer;
+
+-- ── Group E: Pipeline + cost meta ──────────────────────────────────────────
+ALTER TABLE business_universe
+    ADD COLUMN IF NOT EXISTS pipeline_updated_at timestamptz,
+    ADD COLUMN IF NOT EXISTS enrichment_cost_usd numeric;
+
+-- ── Indexes ─────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_bu_dfs_paid_etv ON business_universe(dfs_paid_etv);
+CREATE INDEX IF NOT EXISTS idx_bu_dfs_organic_etv ON business_universe(dfs_organic_etv);
+CREATE INDEX IF NOT EXISTS idx_bu_tech_stack_depth ON business_universe(tech_stack_depth);
+CREATE INDEX IF NOT EXISTS idx_bu_score_budget ON business_universe(score_budget);
+CREATE INDEX IF NOT EXISTS idx_bu_score_pain ON business_universe(score_pain);
+CREATE INDEX IF NOT EXISTS idx_bu_score_gap ON business_universe(score_gap);
+CREATE INDEX IF NOT EXISTS idx_bu_score_fit ON business_universe(score_fit);


### PR DESCRIPTION
## Summary
Adds ~22 DFS intelligence columns to business_universe so pipeline stages S1-S7 have somewhere to write.

## New Columns
**Group A (S1 — DFS discovery):** dfs_technologies, dfs_discovery_sources, dfs_technology_detected_at
**Group B (S3 — DFS Rank Overview):** dfs_organic_etv, dfs_paid_etv, dfs_organic_keywords, dfs_paid_keywords, dfs_organic_pos_1/2_3/4_10/11_20, dfs_rank_fetched_at
**Group C (S3 — DFS Technologies):** tech_stack, tech_categories, tech_stack_depth, tech_gaps, dfs_tech_fetched_at
**Group D (S4 — Scoring):** score_budget, score_pain, score_gap, score_fit
**Group E (meta):** pipeline_updated_at, enrichment_cost_usd
**Indexes:** dfs_paid_etv, dfs_organic_etv, tech_stack_depth, all score_* columns

## Already Existed (NOT added)
All dm_* columns, pipeline_stage/status, propensity_score, reachability_score, all GMB columns

## Issues Found (not fixed)
- scout.py references old pre-#247 column names (dfs_organic_traffic etc.) — dead code, not wired to live path
- supabase/migrations/090_bu_enrichment.sql has conflicting old DFS names — historical, not applied
- MANUAL.md Section 11 said ~30 columns — actual is ~22 new

## LAW XV
docs/MANUAL.md Section 11 updated. read-back verified.

Closes #257