### PR TITLE
feat(#259): Stage1Discovery — DFS signal-first discovery (pipeline v5)

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -51,6 +51,8 @@ Core principle: Discovery is by SERVICE THE AGENCY SELLS, not by industry or loc
 
 All-in COGS: ~$0.49 USD ($0.76 AUD) per prospect.
 
+**S1 Implementation (built #259):** `src/pipeline/stage_1_discovery.py` — `Stage1Discovery` class. Reads `signal_configurations` for vertical → extracts `all_dfs_technologies` → paginates `DFS.domains_by_technology()` per tech → deduplicates by domain → inserts/updates BU with `pipeline_stage=1`. Handles pagination (each page = $0.015). Delay configurable between techs (default 0.5s).
+
 **KEY PRINCIPLE:** Expensive enrichment (S3 at $0.02/biz) runs ONLY on businesses surviving S1–S2 filters. Cheap discovery first, expensive intelligence second. NEVER run DFS Rank on 4,000 businesses when only 600 survive the filters.
 
 BD LinkedIn reinstated for social scraping ($0.0015/record) — deferred post-core pipeline build.
@@ -252,8 +254,8 @@ Meta:
 | #256 | Signal config schema + seed marketing_agency | IN PROGRESS |
 | #257 | BU migration (add ~15 DFS intelligence columns) | Queued |
 | #258 | Stage 1 redesign (3-source discovery) | Queued |
-| #259 | Stage 2 new (marketing intelligence) | Queued |
-| #260 | Stage 3 update (About page + social) | Queued |
+| #259 | Stage 1 DFS signal-first discovery | COMPLETE |
+| #260 | Stage 2 new (marketing intelligence) | **next** |
 | #261 | Stage 4 scoring redesign (budget/pain/gap/fit) | Queued |
 | #262 | Stage 5 DM waterfall | Queued |
 | #263 | Stages 6-7 update | Queued |

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,0 +1,1 @@
+from src.pipeline.stage_1_discovery import Stage1Discovery

--- a/src/pipeline/stage_1_discovery.py
+++ b/src/pipeline/stage_1_discovery.py
@@ -1,0 +1,202 @@
+"""
+Stage 1 Discovery — DFS Signal-First
+Directive #259 — Architecture v5
+
+Discovers businesses by technology signals from signal_configurations.
+Reads signal config → extracts technology list → calls DFS domains_by_technology
+→ deduplicates by domain → inserts new rows to business_universe.
+
+Discovers ONLY. No enrichment, no scoring, no outreach.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+import asyncpg
+
+from src.clients.dfs_labs_client import DFSLabsClient
+from src.enrichment.signal_config import SignalConfig, SignalConfigRepository
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_STAGE_S1 = 1
+DISCOVERY_SOURCE = "dfs_domains_by_tech"
+DEFAULT_DELAY_BETWEEN_TECHS = 0.5  # seconds — rate limiting
+DEFAULT_MAX_DOMAINS_PER_TECH = 1000
+DEFAULT_PAGE_SIZE = 100  # DFS default, max per call
+
+
+class Stage1Discovery:
+    """
+    DFS signal-first discovery.
+
+    Usage:
+        stage = Stage1Discovery(dfs_client, signal_repo, conn)
+        result = await stage.run("marketing_agency")
+    """
+
+    def __init__(
+        self,
+        dfs_client: DFSLabsClient,
+        signal_repo: SignalConfigRepository,
+        conn: asyncpg.Connection,
+        delay_between_techs: float = DEFAULT_DELAY_BETWEEN_TECHS,
+    ) -> None:
+        self.dfs = dfs_client
+        self.signal_repo = signal_repo
+        self.conn = conn
+        self.delay = delay_between_techs
+
+    async def run(self, vertical_slug: str) -> dict[str, Any]:
+        """
+        Full discovery run for a vertical.
+        Returns: {discovered, duplicates_skipped, api_calls, cost_usd, technologies_searched}
+        """
+        config = await self.signal_repo.get_config(vertical_slug)
+        technologies = config.all_dfs_technologies
+        logger.info(
+            f"Stage 1: {vertical_slug} — {len(technologies)} technologies to search: {technologies}"
+        )
+        return await self.run_batch(
+            vertical_slug=vertical_slug,
+            technologies=technologies,
+            max_domains_per_tech=DEFAULT_MAX_DOMAINS_PER_TECH,
+        )
+
+    async def run_batch(
+        self,
+        vertical_slug: str,
+        technologies: list[str],
+        max_domains_per_tech: int = DEFAULT_MAX_DOMAINS_PER_TECH,
+    ) -> dict[str, Any]:
+        """
+        Discovery run for a specific technology list (supports partial runs and testing).
+        """
+        total_discovered = 0
+        total_duplicates = 0
+        total_api_calls = 0
+
+        for tech in technologies:
+            logger.info(f"Stage 1: searching '{tech}'")
+            discovered, dupes, calls = await self._discover_by_technology(
+                technology_name=tech,
+                max_domains=max_domains_per_tech,
+            )
+            total_discovered += discovered
+            total_duplicates += dupes
+            total_api_calls += calls
+            if self.delay > 0:
+                await asyncio.sleep(self.delay)
+
+        cost_usd = float(self.dfs.total_cost_usd)
+        result = {
+            "discovered": total_discovered,
+            "duplicates_skipped": total_duplicates,
+            "api_calls": total_api_calls,
+            "cost_usd": cost_usd,
+            "cost_aud": round(cost_usd * 1.55, 4),
+            "technologies_searched": len(technologies),
+        }
+        logger.info(f"Stage 1 complete: {result}")
+        return result
+
+    async def _discover_by_technology(
+        self, technology_name: str, max_domains: int
+    ) -> tuple[int, int, int]:
+        """Fetch all pages for one technology. Returns (discovered, dupes, api_calls)."""
+        discovered = 0
+        dupes = 0
+        api_calls = 0
+        offset = 0
+
+        while offset < max_domains:
+            limit = min(DEFAULT_PAGE_SIZE, max_domains - offset)
+            response = await self.dfs.domains_by_technology(
+                technology_name=technology_name,
+                limit=limit,
+                offset=offset,
+            )
+            api_calls += 1
+            items = response.get("items") or []
+            total_count = response.get("total_count", 0)
+
+            if not items:
+                break
+
+            for item in items:
+                domain = item.get("domain")
+                if not domain:
+                    continue
+                ok = await self._upsert_domain(domain, technology_name, item)
+                if ok:
+                    discovered += 1
+                else:
+                    dupes += 1
+
+            offset += len(items)
+            if offset >= total_count:
+                break
+
+        return discovered, dupes, api_calls
+
+    async def _upsert_domain(
+        self, domain: str, technology_name: str, item: dict
+    ) -> bool:
+        """
+        Insert domain if new, append technology if exists.
+        Returns True if new row inserted, False if existing row updated.
+        """
+        now = datetime.now(timezone.utc)
+        existing = await self.conn.fetchrow(
+            "SELECT id, dfs_technologies FROM business_universe WHERE domain = $1",
+            domain,
+        )
+
+        if existing is None:
+            # New domain — insert
+            await self.conn.execute(
+                """
+                INSERT INTO business_universe (
+                    display_name,
+                    domain,
+                    dfs_technologies,
+                    dfs_discovery_sources,
+                    dfs_technology_detected_at,
+                    pipeline_stage,
+                    pipeline_updated_at,
+                    discovered_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                """,
+                item.get("title") or domain,   # display_name
+                domain,
+                [technology_name],              # dfs_technologies
+                [DISCOVERY_SOURCE],             # dfs_discovery_sources
+                now,
+                PIPELINE_STAGE_S1,
+                now,
+                now,
+            )
+            return True
+        else:
+            # Existing domain — append tech if not already present
+            existing_techs: list[str] = list(existing["dfs_technologies"] or [])
+            if technology_name not in existing_techs:
+                existing_techs.append(technology_name)
+                await self.conn.execute(
+                    """
+                    UPDATE business_universe
+                    SET dfs_technologies = $1,
+                        dfs_technology_detected_at = $2,
+                        pipeline_updated_at = $3
+                    WHERE domain = $4
+                    """,
+                    existing_techs,
+                    now,
+                    now,
+                    domain,
+                )
+            return False

--- a/tests/test_stage_1_discovery.py
+++ b/tests/test_stage_1_discovery.py
@@ -1,0 +1,199 @@
+"""Tests for Stage1Discovery — Directive #259"""
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch, call
+from contextlib import asynccontextmanager
+
+from src.pipeline.stage_1_discovery import Stage1Discovery, PIPELINE_STAGE_S1, DISCOVERY_SOURCE
+from src.enrichment.signal_config import SignalConfig, ServiceSignal
+
+
+# ─── Fixtures ───────────────────────────────────────────────────────────────
+
+def make_signal_config(technologies: list[str] | None = None):
+    """Build a minimal SignalConfig with given technology list."""
+    import uuid
+    from datetime import datetime
+    services = [
+        ServiceSignal(
+            service_name="paid_ads",
+            label="Paid Ads",
+            dfs_technologies=technologies or ["Google Ads", "Facebook Pixel"],
+            gmb_categories=["marketing_agency"],
+            scoring_weights={"budget": 30, "pain": 30, "gap": 25, "fit": 15},
+        )
+    ]
+    return SignalConfig(
+        id=str(uuid.uuid4()),
+        vertical_slug="marketing_agency",
+        display_name="Marketing Agency",
+        description="Test",
+        service_signals=services,
+        discovery_config={},
+        enrichment_gates={"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        channel_config={"email": True, "linkedin": True, "voice": True, "sms": False},
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+def make_dfs_response(domains: list[str], total_count: int | None = None):
+    """Build a mock DFS domains_by_technology response."""
+    items = [{"domain": d, "title": f"Title {d}", "description": "", "technologies": {}} for d in domains]
+    return {"total_count": total_count or len(domains), "items": items}
+
+
+def make_conn(existing_domain: str | None = None):
+    """Build a mock asyncpg connection."""
+    conn = MagicMock()
+    if existing_domain:
+        row = MagicMock()
+        row.__getitem__ = lambda self, k: existing_domain if k == "domain" else ([] if k == "dfs_technologies" else None)
+        conn.fetchrow = AsyncMock(return_value=row)
+    else:
+        conn.fetchrow = AsyncMock(return_value=None)
+    conn.execute = AsyncMock(return_value=None)
+    return conn
+
+
+def make_stage(techs=None, existing_domain=None, dfs_items=None):
+    """Assemble a Stage1Discovery with mocked dependencies."""
+    dfs_client = MagicMock()
+    dfs_client.total_cost_usd = 0.015
+    dfs_client.domains_by_technology = AsyncMock(
+        return_value=make_dfs_response(dfs_items or ["example.com.au"])
+    )
+    signal_repo = MagicMock()
+    signal_repo.get_config = AsyncMock(return_value=make_signal_config(techs))
+    conn = make_conn(existing_domain)
+    stage = Stage1Discovery(dfs_client, signal_repo, conn, delay_between_techs=0)
+    return stage, dfs_client, signal_repo, conn
+
+
+# ─── Tests ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_discovers_domains_from_signal_config():
+    """run() loads config, iterates technologies, inserts new domains."""
+    stage, dfs, repo, conn = make_stage(techs=["Google Ads"])
+    result = await stage.run("marketing_agency")
+    repo.get_config.assert_called_once_with("marketing_agency")
+    dfs.domains_by_technology.assert_called_once()
+    assert result["discovered"] == 1
+    assert result["duplicates_skipped"] == 0
+    conn.execute.assert_called_once()  # INSERT called
+
+
+@pytest.mark.asyncio
+async def test_skips_existing_domains():
+    """Existing domain (same tech) → duplicate counted, no INSERT."""
+    stage, dfs, repo, conn = make_stage(
+        techs=["Google Ads"],
+        existing_domain="example.com.au",
+    )
+    # Make existing row return tech already present
+    row = MagicMock()
+    row.__getitem__ = lambda self, k: (["Google Ads"] if k == "dfs_technologies" else None)
+    conn.fetchrow = AsyncMock(return_value=row)
+
+    result = await stage.run_batch("marketing_agency", ["Google Ads"])
+    assert result["discovered"] == 0
+    assert result["duplicates_skipped"] == 1
+    # execute should NOT be called (tech already present)
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_appends_new_tech_to_existing_domain():
+    """Existing domain but different tech → UPDATE called, not INSERT, returns False."""
+    stage, dfs, repo, conn = make_stage(
+        techs=["Facebook Pixel"],
+        existing_domain="example.com.au",
+    )
+    row = MagicMock()
+    row.__getitem__ = lambda self, k: (["Google Ads"] if k == "dfs_technologies" else None)
+    conn.fetchrow = AsyncMock(return_value=row)
+
+    result = await stage.run_batch("marketing_agency", ["Facebook Pixel"])
+    # Existing domain with new tech → counted as duplicate (not new row)
+    assert result["duplicates_skipped"] == 1
+    assert result["discovered"] == 0
+    # But UPDATE should have been called to append the tech
+    conn.execute.assert_called_once()
+    update_sql = conn.execute.call_args[0][0]
+    assert "UPDATE" in update_sql
+
+
+@pytest.mark.asyncio
+async def test_handles_empty_dfs_response():
+    """Empty DFS response → no inserts, zero counts, no error."""
+    stage, dfs, repo, conn = make_stage()
+    dfs.domains_by_technology = AsyncMock(return_value={"total_count": 0, "items": []})
+    result = await stage.run_batch("marketing_agency", ["Google Ads"])
+    assert result["discovered"] == 0
+    assert result["duplicates_skipped"] == 0
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_respects_max_domains_per_tech_limit():
+    """max_domains_per_tech=1 should stop after 1 domain even if total_count is higher."""
+    stage, dfs, repo, conn = make_stage()
+    dfs.domains_by_technology = AsyncMock(
+        return_value={"total_count": 500, "items": [{"domain": "one.com.au", "title": "One", "description": "", "technologies": {}}]}
+    )
+    result = await stage.run_batch("marketing_agency", ["Google Ads"], max_domains_per_tech=1)
+    assert dfs.domains_by_technology.call_count == 1
+    assert result["discovered"] == 1
+
+
+@pytest.mark.asyncio
+async def test_deduplicates_technologies_across_services():
+    """all_dfs_technologies on config with 2 services sharing a tech deduplicates correctly."""
+    import uuid
+    from datetime import datetime
+    services = [
+        ServiceSignal("svc1", "S1", ["Google Ads", "Facebook Pixel"], [], {}),
+        ServiceSignal("svc2", "S2", ["Google Ads", "HubSpot"], [], {}),
+    ]
+    config = SignalConfig(
+        id=str(uuid.uuid4()), vertical_slug="test", display_name="T", description=None,
+        service_signals=services, discovery_config={}, enrichment_gates={}, channel_config={},
+        created_at=datetime.now(), updated_at=datetime.now(),
+    )
+    techs = config.all_dfs_technologies
+    assert techs.count("Google Ads") == 1  # deduped
+    assert set(techs) == {"Google Ads", "Facebook Pixel", "HubSpot"}
+
+
+@pytest.mark.asyncio
+async def test_returns_correct_counts():
+    """run_batch with 2 techs, 1 new domain each → discovered=2."""
+    stage, dfs, repo, conn = make_stage()
+    call_count = 0
+    domains = [["alpha.com.au"], ["beta.com.au"]]
+    async def side_effect(**kwargs):
+        nonlocal call_count
+        r = make_dfs_response(domains[call_count])
+        call_count += 1
+        return r
+    dfs.domains_by_technology = AsyncMock(side_effect=side_effect)
+
+    result = await stage.run_batch("marketing_agency", ["Google Ads", "Facebook Pixel"])
+    assert result["discovered"] == 2
+    assert result["duplicates_skipped"] == 0
+    assert result["technologies_searched"] == 2
+    assert result["api_calls"] == 2
+
+
+@pytest.mark.asyncio
+async def test_sets_pipeline_stage_s1_discovered():
+    """New domain INSERT uses PIPELINE_STAGE_S1 (integer 1)."""
+    stage, dfs, repo, conn = make_stage()
+    await stage.run_batch("marketing_agency", ["Google Ads"])
+    conn.execute.assert_called_once()
+    # Verify the pipeline_stage value passed is integer 1
+    call_args = conn.execute.call_args[0]
+    # args: sql, display_name, domain, [techs], [sources], detected_at, pipeline_stage, pipeline_updated_at, discovered_at
+    assert PIPELINE_STAGE_S1 == 1
+    assert 1 in call_args  # pipeline_stage=1 is in the positional args


### PR DESCRIPTION
## Summary
Rebuilds Stage 1 discovery against v5 architecture. Discovery is now by technology signal (what tools the business uses), not by GMB category/location.

## What It Does
1. Loads signal config for a vertical (e.g. marketing_agency)
2. Extracts all_dfs_technologies from all service signals
3. For each technology, paginates DFS domains_by_technology (AU, $0.015/call)
4. Deduplicates by domain against existing BU rows
5. Inserts new rows with pipeline_stage=1, dfs_technologies, dfs_discovery_sources
6. Appends new technologies to existing rows

## Files
- `src/pipeline/stage_1_discovery.py` — Stage1Discovery class
- `tests/test_stage_1_discovery.py` — 8 tests (all mocked)
- `docs/MANUAL.md` — Section 3 + 12 updated

## Old Stage 1
`src/pipeline/stage1_discovery.py` (GMB-based, #249) intentionally NOT removed — it may be needed for GMB reverse lookup (S2). Left in place.

## Test Baseline
Report vs 908 baseline.

Closes #259