### PR TITLE
feat(#261): Stage3DFSProfile — DFS rank + technology profile (pipeline v5)

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -55,6 +55,8 @@ All-in COGS: ~$0.49 USD ($0.76 AUD) per prospect.
 
 **S2 Implementation (built #260):** `src/pipeline/stage_2_gmb_lookup.py` — `Stage2GMBLookup` class. Lookup strategy: domain → business name (via `src/utils/domain_parser.py`) → Bright Data GMB search (`src/clients/bright_data_gmb_client.py`). Writes gmb_place_id, category, rating, review_count, work_hours, address fields, address_source='gmb' to BU. Progresses all rows to pipeline_stage=2 regardless of GMB match. Cost: $0.001/record. New column: `address_source TEXT` (migration 024).
 
+**S3 Implementation (built #261):** `src/pipeline/stage_3_dfs_profile.py` — `Stage3DFSProfile` class. Calls `DFS.domain_rank_overview` + `DFS.domain_technologies` concurrently per domain. Field mapping: rank → dfs_organic_etv/keywords/pos_*, tech → tech_stack/categories/depth. Calculates tech_gaps (signal technologies NOT in domain's detected stack — key input for S4 gap scoring). pipeline_stage=3 on all processed rows. Cost: ~$0.03/business. Note: dfs_domain_rank and dfs_backlinks_count dropped (DFS rank endpoint does not return scalar rank; digital maturity signals = dfs_organic_etv + dfs_organic_keywords).
+
 **KEY PRINCIPLE:** Expensive enrichment (S3 at $0.02/biz) runs ONLY on businesses surviving S1–S2 filters. Cheap discovery first, expensive intelligence second. NEVER run DFS Rank on 4,000 businesses when only 600 survive the filters.
 
 BD LinkedIn reinstated for social scraping ($0.0015/record) — deferred post-core pipeline build.
@@ -258,8 +260,8 @@ Meta:
 | #258 | Stage 1 redesign (3-source discovery) | Queued |
 | #259 | Stage 1 DFS signal-first discovery | COMPLETE |
 | #260 | Stage 2 new (marketing intelligence) | COMPLETE |
-| #261 | Stage 4 scoring redesign (budget/pain/gap/fit) | **next** |
-| #262 | Stage 5 DM waterfall | Queued |
+| #261 | Stage 3 DFS rank + technology profile (Stage3DFSProfile) | COMPLETE |
+| #262 | Stage 4 scoring redesign (budget/pain/gap/fit) | **next** |
 | #263 | Stages 6-7 update | Queued |
 | #264 | Live test v2 (compare to #253 dentist baseline) | Queued |
 

--- a/src/pipeline/stage_3_dfs_profile.py
+++ b/src/pipeline/stage_3_dfs_profile.py
@@ -1,0 +1,194 @@
+"""
+Stage 3 DFS Rank + Technology Profile — Architecture v5
+Directive #261
+
+Takes S2-completed domains (pipeline_stage=2), pulls full digital
+profile via DFS Labs: domain rank/traffic signals + complete tech stack.
+
+Calculates tech_gaps: technologies from signal_config that the business
+does NOT have (gap score input for S4).
+
+Enriches ONLY. No scoring, no DM discovery, no outreach.
+Cost: ~$0.03/business (rank $0.01 + tech $0.01-0.02).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import asyncpg
+
+from src.clients.dfs_labs_client import DFSLabsClient
+from src.enrichment.signal_config import SignalConfigRepository
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_STAGE_S3 = 3
+COST_PER_DOMAIN_USD = 0.03  # rank ($0.01) + tech ($0.01-0.02)
+
+
+class Stage3DFSProfile:
+    """
+    DFS digital profile enrichment for S2-completed domains.
+
+    Usage:
+        stage = Stage3DFSProfile(dfs_client, signal_repo, conn)
+        result = await stage.run(vertical_slug="marketing_agency", batch_size=50)
+    """
+
+    def __init__(
+        self,
+        dfs_client: DFSLabsClient,
+        signal_repo: SignalConfigRepository,
+        conn: asyncpg.Connection,
+        delay: float = 0.2,
+    ) -> None:
+        self.dfs = dfs_client
+        self.signal_repo = signal_repo
+        self.conn = conn
+        self.delay = delay
+
+    async def run(
+        self,
+        vertical_slug: str,
+        batch_size: int = 50,
+    ) -> dict[str, Any]:
+        """
+        Profile all S2-completed domains for a vertical.
+        Returns {profiled, api_errors, cost_usd, cost_aud}
+        """
+        config = await self.signal_repo.get_config(vertical_slug)
+        signal_technologies = set(config.all_dfs_technologies)
+
+        rows = await self.conn.fetch(
+            """
+            SELECT id, domain
+            FROM business_universe
+            WHERE pipeline_stage = 2
+            ORDER BY pipeline_updated_at ASC
+            LIMIT $1
+            """,
+            batch_size,
+        )
+
+        profiled = 0
+        errors = 0
+
+        for row in rows:
+            try:
+                await self._profile_domain(
+                    row_id=row["id"],
+                    domain=row["domain"],
+                    signal_technologies=signal_technologies,
+                )
+                profiled += 1
+            except Exception as e:
+                logger.error(f"Stage 3 error for {row['domain']}: {e}")
+                errors += 1
+            if self.delay > 0:
+                await asyncio.sleep(self.delay)
+
+        cost_usd = float(self.dfs.total_cost_usd)
+        result = {
+            "profiled": profiled,
+            "api_errors": errors,
+            "cost_usd": cost_usd,
+            "cost_aud": round(cost_usd * 1.55, 4),
+        }
+        logger.info(f"Stage 3 complete: {result}")
+        return result
+
+    async def _profile_domain(
+        self,
+        row_id: str,
+        domain: str,
+        signal_technologies: set[str],
+    ) -> None:
+        """Pull rank + tech data for a single domain and update BU."""
+        now = datetime.now(timezone.utc)
+
+        # Call both endpoints concurrently
+        rank_data, tech_data = await asyncio.gather(
+            self.dfs.domain_rank_overview(domain),
+            self.dfs.domain_technologies(domain),
+            return_exceptions=True,
+        )
+
+        # Handle exceptions from gather
+        if isinstance(rank_data, Exception):
+            logger.warning(f"Rank overview failed for {domain}: {rank_data}")
+            rank_data = None
+        if isinstance(tech_data, Exception):
+            logger.warning(f"Technologies failed for {domain}: {tech_data}")
+            tech_data = None
+
+        # Build update dict — start with what we always set
+        update: dict[str, Any] = {
+            "pipeline_stage": PIPELINE_STAGE_S3,
+            "pipeline_updated_at": now,
+            "dfs_rank_fetched_at": now if rank_data is not None else None,
+            "dfs_tech_fetched_at": now if tech_data is not None else None,
+        }
+
+        # Rank fields (all nullable — small businesses may not rank)
+        if rank_data:
+            update.update({
+                "dfs_organic_etv":       rank_data.get("dfs_organic_etv"),
+                "dfs_paid_etv":          rank_data.get("dfs_paid_etv"),
+                "dfs_organic_keywords":  rank_data.get("dfs_organic_keywords"),
+                "dfs_paid_keywords":     rank_data.get("dfs_paid_keywords"),
+                "dfs_organic_pos_1":     rank_data.get("dfs_organic_pos_1"),
+                "dfs_organic_pos_2_3":   rank_data.get("dfs_organic_pos_2_3"),
+                "dfs_organic_pos_4_10":  rank_data.get("dfs_organic_pos_4_10"),
+                "dfs_organic_pos_11_20": rank_data.get("dfs_organic_pos_11_20"),
+            })
+
+        # Tech fields
+        if tech_data:
+            tech_stack: list[str] = tech_data.get("tech_stack") or []
+            update.update({
+                "tech_stack":       tech_stack,
+                "tech_categories":  tech_data.get("tech_categories"),
+                "tech_stack_depth": tech_data.get("tech_stack_depth") or len(tech_stack),
+                "tech_gaps":        self._calculate_tech_gaps(tech_stack, signal_technologies),
+            })
+
+        await self._write_update(row_id, update)
+
+    def _calculate_tech_gaps(
+        self,
+        detected_tech: list[str],
+        signal_technologies: set[str],
+    ) -> list[str]:
+        """
+        Technologies from signal_config that the business does NOT have.
+        These are the gaps S4 uses to score outreach angle quality.
+        """
+        detected_set = {t.lower() for t in detected_tech}
+        return [
+            tech
+            for tech in sorted(signal_technologies)
+            if tech.lower() not in detected_set
+        ]
+
+    async def _write_update(self, row_id: str, update: dict[str, Any]) -> None:
+        """Write all non-None fields to BU in a single UPDATE."""
+        # Build SET clause dynamically from non-None keys
+        # Always set pipeline_stage and pipeline_updated_at
+        always_set = {"pipeline_stage", "pipeline_updated_at"}
+        fields = {k: v for k, v in update.items() if v is not None or k in always_set}
+
+        if not fields:
+            return
+
+        cols = list(fields.keys())
+        vals = list(fields.values())
+        set_clause = ", ".join(f"{col} = ${i+1}" for i, col in enumerate(cols))
+        vals.append(row_id)
+
+        await self.conn.execute(
+            f"UPDATE business_universe SET {set_clause} WHERE id = ${len(vals)}",
+            *vals,
+        )

--- a/tests/test_stage_3_dfs_profile.py
+++ b/tests/test_stage_3_dfs_profile.py
@@ -1,0 +1,205 @@
+"""Tests for Stage3DFSProfile — Directive #261"""
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.pipeline.stage_3_dfs_profile import Stage3DFSProfile, PIPELINE_STAGE_S3
+from src.enrichment.signal_config import SignalConfig, ServiceSignal
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+def make_signal_config(technologies: list[str] = None):
+    import uuid
+    services = [
+        ServiceSignal(
+            service_name="paid_ads",
+            label="Paid Ads",
+            dfs_technologies=technologies or ["Google Ads", "Facebook Pixel", "HubSpot"],
+            gmb_categories=[],
+            scoring_weights={},
+        )
+    ]
+    return SignalConfig(
+        id=str(uuid.uuid4()),
+        vertical_slug="marketing_agency",
+        display_name="Marketing Agency",
+        description=None,
+        service_signals=services,
+        discovery_config={},
+        enrichment_gates={},
+        channel_config={},
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+MOCK_RANK_DATA = {
+    "dfs_organic_etv": 1250.50,
+    "dfs_paid_etv": 340.0,
+    "dfs_organic_keywords": 450,
+    "dfs_paid_keywords": 28,
+    "dfs_organic_pos_1": 5,
+    "dfs_organic_pos_2_3": 12,
+    "dfs_organic_pos_4_10": 45,
+    "dfs_organic_pos_11_20": 88,
+}
+
+MOCK_TECH_DATA = {
+    "tech_stack": ["Google Ads", "WordPress", "Google Analytics"],
+    "tech_categories": {"cms": {"wordpress": ["WordPress"]}, "analytics": {"google_analytics": ["Google Analytics"]}},
+    "tech_stack_depth": 3,
+}
+
+
+def make_dfs_client(rank_data=MOCK_RANK_DATA, tech_data=MOCK_TECH_DATA):
+    client = MagicMock()
+    client.total_cost_usd = 0.03
+    client.domain_rank_overview = AsyncMock(return_value=rank_data)
+    client.domain_technologies = AsyncMock(return_value=tech_data)
+    return client
+
+
+def make_row(domain="example.com.au", row_id="uuid-1"):
+    row = MagicMock()
+    row.__getitem__ = lambda self, k: {"id": row_id, "domain": domain}[k]
+    return row
+
+
+def make_conn(rows=None):
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=rows or [make_row()])
+    conn.execute = AsyncMock(return_value=None)
+    return conn
+
+
+def make_stage(rank_data=MOCK_RANK_DATA, tech_data=MOCK_TECH_DATA, rows=None, technologies=None):
+    dfs = make_dfs_client(rank_data, tech_data)
+    signal_repo = MagicMock()
+    signal_repo.get_config = AsyncMock(return_value=make_signal_config(technologies))
+    conn = make_conn(rows)
+    stage = Stage3DFSProfile(dfs, signal_repo, conn, delay=0)
+    return stage, dfs, signal_repo, conn
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_profiles_s2_domains_with_rank_and_tech():
+    """run() calls both DFS endpoints and writes all fields to BU."""
+    stage, dfs, repo, conn = make_stage()
+    result = await stage.run("marketing_agency")
+    assert result["profiled"] == 1
+    assert result["api_errors"] == 0
+    dfs.domain_rank_overview.assert_called_once()
+    dfs.domain_technologies.assert_called_once()
+    conn.execute.assert_called_once()
+    update_sql = conn.execute.call_args[0][0]
+    assert "dfs_organic_etv" in update_sql
+    assert "tech_stack" in update_sql
+
+
+@pytest.mark.asyncio
+async def test_calculates_tech_gaps_from_signal_config():
+    """tech_gaps = signal technologies NOT in detected tech_stack."""
+    # Signal wants: Google Ads, Facebook Pixel, HubSpot
+    # Domain has:   Google Ads, WordPress, Google Analytics
+    # Expected gaps: Facebook Pixel, HubSpot
+    stage, dfs, repo, conn = make_stage(
+        technologies=["Google Ads", "Facebook Pixel", "HubSpot"]
+    )
+    await stage.run("marketing_agency")
+    update_sql = conn.execute.call_args[0][0]
+    update_args = conn.execute.call_args[0]
+    # Find the tech_gaps value — it will be a list
+    gaps = None
+    for arg in update_args:
+        if isinstance(arg, list) and any(t in ["Facebook Pixel", "HubSpot"] for t in (arg or [])):
+            gaps = arg
+            break
+    assert gaps is not None
+    assert "Facebook Pixel" in gaps
+    assert "HubSpot" in gaps
+    assert "Google Ads" not in gaps  # domain already has it
+
+
+@pytest.mark.asyncio
+async def test_calculates_tech_stack_depth():
+    """tech_stack_depth = count of detected technologies."""
+    stage, _, _, conn = make_stage()
+    await stage.run("marketing_agency")
+    args = conn.execute.call_args[0]
+    # tech_stack_depth should be 3 (matching MOCK_TECH_DATA)
+    assert 3 in args
+
+
+@pytest.mark.asyncio
+async def test_handles_no_rank_data():
+    """If rank endpoint returns None, still progress to stage 3."""
+    stage, dfs, repo, conn = make_stage(rank_data=None)
+    result = await stage.run("marketing_agency")
+    assert result["profiled"] == 1
+    assert result["api_errors"] == 0
+    conn.execute.assert_called_once()
+    update_sql = conn.execute.call_args[0][0]
+    assert "pipeline_stage" in update_sql
+
+
+@pytest.mark.asyncio
+async def test_handles_no_tech_data():
+    """If tech endpoint returns None, still progress to stage 3."""
+    stage, dfs, repo, conn = make_stage(tech_data=None)
+    result = await stage.run("marketing_agency")
+    assert result["profiled"] == 1
+    conn.execute.assert_called_once()
+    update_sql = conn.execute.call_args[0][0]
+    assert "pipeline_stage" in update_sql
+    # tech_stack should NOT appear in update (no data)
+    assert "tech_stack" not in update_sql
+
+
+@pytest.mark.asyncio
+async def test_respects_batch_size():
+    """run() passes batch_size LIMIT to the DB query."""
+    stage, _, _, conn = make_stage()
+    await stage.run("marketing_agency", batch_size=10)
+    fetch_sql = conn.fetch.call_args[0][0]
+    assert "LIMIT" in fetch_sql
+    assert conn.fetch.call_args[0][1] == 10
+
+
+@pytest.mark.asyncio
+async def test_tracks_cost_accurately():
+    """result includes cost_usd from DFS client."""
+    stage, dfs, _, _ = make_stage()
+    dfs.total_cost_usd = 0.09  # 3 domains * $0.03
+    result = await stage.run("marketing_agency")
+    assert result["cost_usd"] == 0.09
+    assert result["cost_aud"] == round(0.09 * 1.55, 4)
+
+
+@pytest.mark.asyncio
+async def test_updates_pipeline_stage_to_3():
+    """pipeline_stage=3 is written after S3 processing."""
+    stage, _, _, conn = make_stage()
+    await stage.run("marketing_agency")
+    args = conn.execute.call_args[0]
+    assert PIPELINE_STAGE_S3 in args
+
+
+@pytest.mark.asyncio
+async def test_maps_dfs_fields_to_bu_columns_correctly():
+    """All rank fields from domain_rank_overview appear in the UPDATE."""
+    stage, _, _, conn = make_stage()
+    await stage.run("marketing_agency")
+    update_sql = conn.execute.call_args[0][0]
+    expected_cols = [
+        "dfs_organic_etv", "dfs_paid_etv", "dfs_organic_keywords",
+        "dfs_paid_keywords", "dfs_organic_pos_1", "dfs_organic_pos_2_3",
+        "dfs_organic_pos_4_10", "dfs_organic_pos_11_20",
+        "dfs_rank_fetched_at", "tech_stack", "tech_categories",
+        "tech_stack_depth", "tech_gaps", "dfs_tech_fetched_at",
+        "pipeline_stage", "pipeline_updated_at",
+    ]
+    for col in expected_cols:
+        assert col in update_sql, f"Expected column '{col}' in UPDATE but not found"


### PR DESCRIPTION
## Summary
Stage 3 of the v5 pipeline: turns S2-discovered domains into fully profiled businesses.

## What It Does
1. Queries BU for pipeline_stage=2 rows
2. Calls DFS domain_rank_overview + domain_technologies concurrently
3. Maps all rank/traffic/tech fields to BU columns
4. Computes tech_gaps: signal_config technologies the business does NOT have
5. Progresses all rows to pipeline_stage=3 (even if DFS returns no data)

## Key Design Decisions (Directive #261)
- dfs_domain_rank and dfs_backlinks_count: DROPPED — DFS rank endpoint returns traffic signals not scalar rank; S4 will use dfs_organic_etv + dfs_organic_keywords as digital maturity signals
- tech_gaps: computed from signal_config.all_dfs_technologies vs detected tech_stack (key S4 input)
- Cost: ~$0.03/business (rank + tech, worst case for www. fallback)

## Applied to Live DB
- migrations/022_signal_configurations.sql — signal_configurations table
- migrations/022b_seed_marketing_agency_signal_config.sql — marketing_agency seed
- Verified: SELECT COUNT(*) FROM signal_configurations → 1 row

## Files
- `src/pipeline/stage_3_dfs_profile.py` — Stage3DFSProfile class
- `tests/test_stage_3_dfs_profile.py` — 9 tests (all mocked)
- `docs/MANUAL.md` — Sections 3 + 12 updated

## Baseline
vs 938 baseline: 947 passed, same 2 pre-existing failures (test_dfs_serp_client), 28 skipped.

Closes #261