### PR TITLE
feat(#264): Stage6 + Stage7 — reachability validation + Haiku message gen (pipeline v5 COMPLETE)

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -23,13 +23,12 @@ Revenue model for BU: API subscriptions, Salesforce/HubSpot marketplace, bulk an
 
 ## SECTION 2 — CURRENT STATE
 
-- Last directive issued: #255 (DFS Labs client — 7 endpoints, 17 new tests)
-- Next directive: #256 (Signal Configuration Schema — in progress)
-- Test baseline: 899 passed, 9 failed (all pre-existing), 25 skipped
+- Last directive issued: #264 (Stage 6 + Stage 7 — reachability validation + Haiku message gen)
+- Next directive: TBD
+- Test baseline: 987 passed, 2 failed (pre-existing DFS serp client tests), 28 skipped
 - Last merged PRs: #219 (live test fixes), #220 (DFS Labs client)
-- Open PRs: #221 (research-1 standing brief config), #222 (this PR — #256 signal config)
 - Architecture: v5 ratified Mar 26 2026 — signal-first discovery
-- Elliottbot received architecture correction briefing and confirmed updated context
+- **All 7 pipeline stages S1-S7 are built and tested as of March 26 2026**
 
 ---
 
@@ -60,6 +59,10 @@ All-in COGS: ~$0.49 USD ($0.76 AUD) per prospect.
 **S4 Implementation (built #262):** `src/pipeline/stage_4_scoring.py` — `Stage4Scorer` class. Scores per service signal; best match stored as `best_match_service` (S7 uses this to select outreach angle). Four dimensions: budget (digital spend signals), pain (reputation + gap signals), gap (service-specific tech gaps), fit (category + stack alignment). Reachability scored on confirmed channel access; recalculated after S5/S6. Gate: `min_score_to_enrich` from `signal_configurations` (default 30). All businesses progress to pipeline_stage=4 — low scorers filtered by `WHERE propensity_score < threshold` in downstream queries. New migration: `025_scoring_columns.sql` (score_reason, best_match_service, linkedin_company_url, scored_at).
 
 **S5 Implementation (built #263):** `src/pipeline/stage_5_dm_waterfall.py` — `Stage5DMWaterfall` class. Gate: `min_score_to_dm` (default 50) from `signal_configurations`. Waterfall order (cheapest first): `GMBContactExtractor` (free, BU data) → `WebsiteContactScraper` (free, Jina AI) → `LeadmagicPersonFinder` (paid, ~$0.015/email). Protocol-based: adding BD LinkedIn = adding one class to sources list. Stops at first valid result (name + contact method). Recalculates `reachability_score` after DM found. All rows progress to pipeline_stage=5; rows with no DM get `dm_source='none'` (S7 generates company-level outreach). New columns: `dm_phone`, `dm_found_at` (migration 026).
+
+**S6 Implementation (built #264):** `src/pipeline/stage_6_reachability.py` — `Stage6Reachability` class. Validates dm_email (format check), dm_phone (AU pattern), dm_linkedin_url (LinkedIn profile URL pattern), physical address. Determines `outreach_channels` (text[]) from validated channels filtered by `channel_config`. Recalculates `reachability_score` from confirmed channels. All rows progress to pipeline_stage=6. New columns: `outreach_channels TEXT[]`, `outreach_messages JSONB` (migration 027).
+
+**S7 Implementation (built #264):** `src/pipeline/stage_7_haiku.py` — `Stage7Haiku` class. Gate: `min_score_to_outreach=65`. Generates channel-specific messages (email: 3-line cold email <100 words; linkedin: <300 char connection note; voice: structured knowledge card JSON; sms: 1 sentence). Model: `claude-haiku-4-5-20251001`. Messages stored in `outreach_messages JSONB` on BU. All rows progress to pipeline_stage=7. No campaign dependency — operates directly on BU.
 
 **KEY PRINCIPLE:** Expensive enrichment (S3 at $0.02/biz) runs ONLY on businesses surviving S1–S2 filters. Cheap discovery first, expensive intelligence second. NEVER run DFS Rank on 4,000 businesses when only 600 survive the filters.
 
@@ -267,7 +270,7 @@ Meta:
 | #261 | Stage 3 DFS rank + technology profile (Stage3DFSProfile) | COMPLETE |
 | #262 | Stage 4 scoring redesign (budget/pain/gap/fit) | COMPLETE |
 | #263 | Stage 5 DM Waterfall (Stage5DMWaterfall) | COMPLETE |
-| #264 | Live test v2 (compare to #253 dentist baseline) | **next** |
+| #264 | Stage 6 Reachability + Stage 7 Haiku message gen | COMPLETE — ALL STAGES S1-S7 BUILT |
 
 Previously completed in current sprint:
 - #247: Schema migration (BU fresh + abn_registry + junction tables) ✅

--- a/migrations/027_outreach_columns.sql
+++ b/migrations/027_outreach_columns.sql
@@ -1,0 +1,6 @@
+-- Outreach channel + message storage — Stages 6 + 7
+-- Directive #264
+
+ALTER TABLE business_universe
+ADD COLUMN IF NOT EXISTS outreach_channels TEXT[],
+ADD COLUMN IF NOT EXISTS outreach_messages JSONB;

--- a/src/integrations/anthropic.py
+++ b/src/integrations/anthropic.py
@@ -40,6 +40,11 @@ class AnthropicClient:
             "output": 6.20,  # $4 USD × 1.55
             "cached": 0.124,  # 90% discount on cached
         },
+        "claude-haiku-4-5-20251001": {
+            "input": 1.24,  # $0.80 USD × 1.55
+            "output": 6.20,  # $4 USD × 1.55
+            "cached": 0.124,  # 90% discount on cached
+        },
         "claude-sonnet-4-20250514": {
             "input": 4.65,  # $3 USD × 1.55
             "output": 23.25,  # $15 USD × 1.55

--- a/src/pipeline/stage_6_reachability.py
+++ b/src/pipeline/stage_6_reachability.py
@@ -1,0 +1,153 @@
+"""
+Stage 6 Reachability Validation — Architecture v5
+Directive #264
+
+Validates contact channels for S5-completed businesses and determines
+which outreach channels are actually available.
+
+Reads pipeline_stage=5, writes pipeline_stage=6.
+Updates reachability_score and outreach_channels.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+import asyncpg
+
+from src.enrichment.signal_config import SignalConfigRepository
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_STAGE_S6 = 6
+
+_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
+_AU_PHONE_RE = re.compile(r"^(\+61|0)(4|2|3|7|8)\d[\d\s\-\.]{6,12}$")
+_LINKEDIN_PROFILE_RE = re.compile(r"^https?://(www\.)?linkedin\.com/in/[a-zA-Z0-9\-_%]+/?$")
+
+
+def validate_email(email: str | None) -> bool:
+    if not email:
+        return False
+    return bool(_EMAIL_RE.match(email.strip()))
+
+
+def validate_au_phone(phone: str | None) -> bool:
+    if not phone:
+        return False
+    return bool(_AU_PHONE_RE.match(phone.strip().replace(" ", "")))
+
+
+def validate_linkedin_url(url: str | None) -> bool:
+    if not url:
+        return False
+    return bool(_LINKEDIN_PROFILE_RE.match(url.strip()))
+
+
+def calculate_reachability(channels: list[str]) -> int:
+    """Reachability score from confirmed channels."""
+    score = 0
+    if "email" in channels:
+        score += 30
+    if "voice" in channels or "sms" in channels:
+        score += 25
+    if "linkedin" in channels:
+        score += 20
+    if "physical" in channels:
+        score += 15
+    if score > 0:
+        score += 10  # base: business is contactable at all
+    return min(score, 100)
+
+
+class Stage6Reachability:
+    """
+    Validate contact channels and finalise reachability for S5-completed businesses.
+
+    Usage:
+        stage = Stage6Reachability(signal_repo, conn)
+        result = await stage.run("marketing_agency", batch_size=100)
+    """
+
+    def __init__(
+        self,
+        signal_repo: SignalConfigRepository,
+        conn: asyncpg.Connection,
+    ) -> None:
+        self.signal_repo = signal_repo
+        self.conn = conn
+
+    async def run(
+        self,
+        vertical_slug: str,
+        batch_size: int = 100,
+    ) -> dict[str, Any]:
+        """
+        Validate channels for S5-completed businesses.
+        Returns {validated, channels_confirmed}
+        """
+        config = await self.signal_repo.get_config(vertical_slug)
+        channel_config = config.channel_config  # e.g. {"email": True, "linkedin": True, "voice": True, "sms": False}
+
+        rows = await self.conn.fetch(
+            """
+            SELECT id, dm_email, dm_phone, dm_linkedin_url,
+                   address, state, suburb, gmb_place_id
+            FROM business_universe
+            WHERE pipeline_stage = 5
+            ORDER BY pipeline_updated_at ASC
+            LIMIT $1
+            """,
+            batch_size,
+        )
+
+        validated = 0
+        channels_confirmed: dict[str, int] = {}
+
+        for row in rows:
+            channels = self._validate_channels(dict(row), channel_config)
+            reachability = calculate_reachability(channels)
+            now = datetime.now(timezone.utc)
+
+            await self.conn.execute(
+                """
+                UPDATE business_universe SET
+                    outreach_channels = $1,
+                    reachability_score = $2,
+                    pipeline_stage = $3,
+                    pipeline_updated_at = $4
+                WHERE id = $5
+                """,
+                channels,
+                reachability,
+                PIPELINE_STAGE_S6,
+                now,
+                row["id"],
+            )
+            validated += 1
+            for ch in channels:
+                channels_confirmed[ch] = channels_confirmed.get(ch, 0) + 1
+
+        return {"validated": validated, "channels_confirmed": channels_confirmed}
+
+    def _validate_channels(
+        self,
+        business: dict[str, Any],
+        channel_config: dict[str, bool],
+    ) -> list[str]:
+        """Determine which channels are both validated and enabled in config."""
+        confirmed = []
+        if channel_config.get("email") and validate_email(business.get("dm_email")):
+            confirmed.append("email")
+        if channel_config.get("linkedin") and validate_linkedin_url(business.get("dm_linkedin_url")):
+            confirmed.append("linkedin")
+        if channel_config.get("voice") and validate_au_phone(business.get("dm_phone")):
+            confirmed.append("voice")
+        if channel_config.get("sms") and validate_au_phone(business.get("dm_phone")):
+            confirmed.append("sms")
+        has_address = any([business.get("address"), business.get("state"), business.get("gmb_place_id")])
+        if has_address:
+            confirmed.append("physical")
+        return confirmed

--- a/src/pipeline/stage_7_haiku.py
+++ b/src/pipeline/stage_7_haiku.py
@@ -1,0 +1,237 @@
+"""
+Stage 7 Haiku Message Generation — Architecture v5
+Directive #264
+
+Generates personalised outreach messages for each confirmed channel
+using Claude Haiku. Messages reference specific prospect signals.
+No templates. No AI mentions. Human voice throughout.
+
+Model: claude-haiku-4-5-20251001
+Gate: propensity_score >= min_score_to_outreach (65)
+Stores messages in outreach_messages JSONB on BU.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import asyncpg
+
+from src.enrichment.signal_config import SignalConfigRepository
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_STAGE_S7 = 7
+HAIKU_MODEL = "claude-haiku-4-5-20251001"
+
+# Haiku 4.5 pricing (USD per token)
+HAIKU_INPUT_COST_PER_TOKEN = 0.0000008    # $0.80 per million input tokens
+HAIKU_OUTPUT_COST_PER_TOKEN = 0.000004    # $4.00 per million output tokens
+
+_CHANNEL_PROMPTS = {
+    "email": (
+        "Write a 3-line cold email. Line 1: one specific observation about their business (use the tech stack, "
+        "ad spend, or GMB data provided). Line 2: one question about their situation. Line 3: soft CTA — "
+        "ask if they're open to a quick chat, not to buy anything. Sign off with the agency founder's name. "
+        "Under 100 words. No 'I hope this email finds you well'. No mention of AI or automation. "
+        "Sound like a curious peer, not a salesperson."
+    ),
+    "linkedin": (
+        "Write a LinkedIn connection request note. Max 300 characters. Reference one shared context or "
+        "specific observation about their business. Do not pitch. Ask to connect. No mention of AI. "
+        "Sound like a genuine professional reaching out."
+    ),
+    "voice": (
+        "Write a structured voice call knowledge card as JSON with these fields: "
+        '{"trigger": "one-sentence reason for calling", "talking_point": "one specific business observation", '
+        '"objective": "book a 15-minute discovery call", "fallback": "offer to send a short email instead", '
+        '"company_name": "the business name"}. '
+        "This is a briefing card, not a script. Fill in real values from the prospect data."
+    ),
+    "sms": (
+        "Write a single SMS message. One sentence. Direct. Reference their business by name. "
+        "Offer a specific value observation, not a generic pitch. Max 160 characters. No mention of AI."
+    ),
+}
+
+_SYSTEM_PROMPT = """You are a senior business development consultant writing personalised outreach for a digital marketing agency.
+
+Rules:
+- Never use "I hope this email finds you well" or any equivalent
+- Never mention AI, automation, or that you used technology to find them
+- Reference exactly ONE specific signal from the prospect data
+- Match the agency's communication style described in the agency brief
+- Keep email under 100 words, LinkedIn note under 300 characters
+- Every message must pass: "Would I reply to this if I received it?"
+- Sound like a curious, intelligent human — not a salesperson
+- Do not fabricate specific numbers or claims not in the data provided"""
+
+
+class Stage7Haiku:
+    """
+    Haiku-powered personalised outreach message generator.
+
+    Usage:
+        stage = Stage7Haiku(anthropic_client, signal_repo, conn)
+        result = await stage.run("marketing_agency", agency_profile, batch_size=10)
+    """
+
+    def __init__(
+        self,
+        anthropic_client: Any,
+        signal_repo: SignalConfigRepository,
+        conn: asyncpg.Connection,
+    ) -> None:
+        self.ai = anthropic_client
+        self.signal_repo = signal_repo
+        self.conn = conn
+        self._total_input_tokens = 0
+        self._total_output_tokens = 0
+
+    @property
+    def total_cost_usd(self) -> float:
+        return (
+            self._total_input_tokens * HAIKU_INPUT_COST_PER_TOKEN
+            + self._total_output_tokens * HAIKU_OUTPUT_COST_PER_TOKEN
+        )
+
+    async def run(
+        self,
+        vertical_slug: str,
+        agency_profile: dict[str, Any],
+        batch_size: int = 10,
+    ) -> dict[str, Any]:
+        """
+        Generate personalised outreach messages for S6-completed businesses.
+        Gate: propensity_score >= min_score_to_outreach.
+        """
+        config = await self.signal_repo.get_config(vertical_slug)
+        outreach_gate = config.enrichment_gates.get("min_score_to_outreach", 65)
+
+        rows = await self.conn.fetch(
+            """
+            SELECT id, domain, display_name, gmb_category, state, suburb,
+                   dm_name, dm_title, best_match_service, score_reason,
+                   tech_stack, tech_gaps, dfs_paid_keywords, gmb_rating,
+                   gmb_review_count, outreach_channels
+            FROM business_universe
+            WHERE pipeline_stage = 6
+              AND propensity_score >= $1
+            ORDER BY propensity_score DESC
+            LIMIT $2
+            """,
+            outreach_gate,
+            batch_size,
+        )
+
+        messages_generated = 0
+
+        for row in rows:
+            business = dict(row)
+            channels = list(business.get("outreach_channels") or [])
+            if not channels:
+                continue
+
+            messages = await self._generate_messages(business, agency_profile, channels)
+            await self._write_messages(business["id"], messages)
+            messages_generated += len(messages)
+
+        return {
+            "messages_generated": messages_generated,
+            "cost_usd": self.total_cost_usd,
+            "cost_aud": round(self.total_cost_usd * 1.55, 4),
+        }
+
+    async def _generate_messages(
+        self,
+        business: dict[str, Any],
+        agency_profile: dict[str, Any],
+        channels: list[str],
+    ) -> dict[str, str]:
+        """Generate messages for each confirmed channel."""
+        prospect_brief = self._build_prospect_brief(business)
+        agency_brief = self._build_agency_brief(agency_profile)
+        messages: dict[str, str] = {}
+
+        for channel in channels:
+            if channel == "physical":
+                continue  # No message type for physical channel
+            prompt = _CHANNEL_PROMPTS.get(channel)
+            if not prompt:
+                continue
+
+            user_prompt = (
+                f"PROSPECT BRIEF:\n{prospect_brief}\n\n"
+                f"AGENCY BRIEF:\n{agency_brief}\n\n"
+                f"TASK:\n{prompt}"
+            )
+
+            try:
+                response = await self.ai.complete(
+                    prompt=user_prompt,
+                    system=_SYSTEM_PROMPT,
+                    model=HAIKU_MODEL,
+                    max_tokens=400,
+                    temperature=0.7,
+                )
+                content = response.get("content", "") if isinstance(response, dict) else str(response)
+                self._total_input_tokens += response.get("input_tokens", 0) if isinstance(response, dict) else 0
+                self._total_output_tokens += response.get("output_tokens", 0) if isinstance(response, dict) else 0
+                messages[channel] = content.strip()
+                await asyncio.sleep(0.5)  # Rate limiting
+            except Exception as e:
+                logger.warning(f"Haiku call failed for {business.get('domain')} channel={channel}: {e}")
+
+        return messages
+
+    def _build_prospect_brief(self, business: dict[str, Any]) -> str:
+        tech_stack = list(business.get("tech_stack") or [])[:5]
+        tech_gaps = list(business.get("tech_gaps") or [])[:3]
+        paid_kw = business.get("dfs_paid_keywords") or 0
+        location = ", ".join(filter(None, [business.get("suburb"), business.get("state")]))
+
+        lines = [
+            f"Business: {business.get('display_name') or business.get('domain')}",
+            f"Domain: {business.get('domain')}",
+            f"Category: {business.get('gmb_category') or 'Unknown'}",
+            f"Location: {location or 'Australia'}",
+            f"Decision maker: {business.get('dm_name') or 'Unknown'} ({business.get('dm_title') or 'Unknown title'})",
+            f"Best service match: {business.get('best_match_service') or 'Unknown'}",
+            f"Score reason: {business.get('score_reason') or 'N/A'}",
+            f"Tech stack (top 5): {', '.join(tech_stack) or 'Unknown'}",
+            f"Technology gaps: {', '.join(tech_gaps) or 'None detected'}",
+            f"Active paid keywords: {paid_kw}",
+            f"GMB rating: {business.get('gmb_rating') or 'N/A'} ({business.get('gmb_review_count') or 0} reviews)",
+        ]
+        return "\n".join(lines)
+
+    def _build_agency_brief(self, agency_profile: dict[str, Any]) -> str:
+        lines = [
+            f"Agency: {agency_profile.get('name', 'the agency')}",
+            f"Services: {', '.join(agency_profile.get('services', []))}",
+            f"Tone: {agency_profile.get('tone', 'professional, direct, results-focused')}",
+            f"Founder: {agency_profile.get('founder_name', 'the founder')}",
+        ]
+        if agency_profile.get("case_study"):
+            lines.append(f"Relevant case study: {agency_profile['case_study']}")
+        return "\n".join(lines)
+
+    async def _write_messages(self, row_id: str, messages: dict[str, str]) -> None:
+        """Store messages in outreach_messages JSONB and advance pipeline."""
+        now = datetime.now(timezone.utc)
+        await self.conn.execute(
+            """
+            UPDATE business_universe SET
+                outreach_messages = $1,
+                pipeline_stage = $2,
+                pipeline_updated_at = $3
+            WHERE id = $4
+            """,
+            json.dumps(messages),
+            PIPELINE_STAGE_S7,
+            now,
+            row_id,
+        )

--- a/tests/test_stage_6_reachability.py
+++ b/tests/test_stage_6_reachability.py
@@ -1,0 +1,130 @@
+"""Tests for Stage6Reachability — Directive #264"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime
+
+from src.pipeline.stage_6_reachability import (
+    Stage6Reachability, PIPELINE_STAGE_S6,
+    validate_email, validate_au_phone, validate_linkedin_url, calculate_reachability,
+)
+from src.enrichment.signal_config import SignalConfig, ServiceSignal
+
+
+def make_config(channel_config=None):
+    import uuid
+    return SignalConfig(
+        id=str(uuid.uuid4()), vertical_slug="marketing_agency",
+        display_name="MktAgency", description=None,
+        service_signals=[],
+        discovery_config={},
+        enrichment_gates={"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        channel_config=channel_config or {"email": True, "linkedin": True, "voice": True, "sms": False},
+        created_at=datetime.now(), updated_at=datetime.now(),
+    )
+
+
+def make_row(**overrides):
+    defaults = {
+        "id": "uuid-1",
+        "dm_email": "john@acme.com.au",
+        "dm_phone": "+61412345678",
+        "dm_linkedin_url": "https://linkedin.com/in/john-smith",
+        "address": "123 Main St",
+        "state": "VIC",
+        "suburb": "Melbourne",
+        "gmb_place_id": "ChIJ123",
+    }
+    defaults.update(overrides)
+    row = MagicMock()
+    row.__iter__ = lambda self: iter(defaults.items())
+    row.__getitem__ = lambda self, k: defaults[k]
+    row.get = lambda k, d=None: defaults.get(k, d)
+    row.keys = lambda: defaults.keys()
+    return row
+
+
+def make_conn(rows=None):
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[make_row()] if rows is None else rows)
+    conn.execute = AsyncMock(return_value=None)
+    return conn
+
+
+def make_stage(channel_config=None, rows=None):
+    signal_repo = MagicMock()
+    signal_repo.get_config = AsyncMock(return_value=make_config(channel_config))
+    conn = make_conn(rows)
+    stage = Stage6Reachability(signal_repo, conn)
+    return stage, conn
+
+
+# ─── Unit tests ──────────────────────────────────────────────────────────────
+
+def test_validates_email_format():
+    assert validate_email("john@acme.com.au") is True
+    assert validate_email("info@example.com") is True
+    assert validate_email("not-an-email") is False
+    assert validate_email(None) is False
+    assert validate_email("@nodomain") is False
+
+
+def test_validates_au_phone_format():
+    assert validate_au_phone("+61412345678") is True
+    assert validate_au_phone("0412345678") is True
+    assert validate_au_phone("0312345678") is True
+    assert validate_au_phone("1234567890") is False
+    assert validate_au_phone(None) is False
+
+
+def test_validates_linkedin_url():
+    assert validate_linkedin_url("https://linkedin.com/in/john-smith") is True
+    assert validate_linkedin_url("https://www.linkedin.com/in/jsmith123") is True
+    assert validate_linkedin_url("https://linkedin.com/company/acme") is False
+    assert validate_linkedin_url(None) is False
+    assert validate_linkedin_url("https://example.com") is False
+
+
+def test_calculates_final_reachability_score():
+    assert calculate_reachability(["email", "linkedin", "voice", "physical"]) == 100
+    assert calculate_reachability(["email"]) == 40  # 30 + 10 base
+    assert calculate_reachability([]) == 0
+
+
+@pytest.mark.asyncio
+async def test_determines_outreach_channels():
+    stage, conn = make_stage()
+    result = await stage.run("marketing_agency")
+    assert result["validated"] == 1
+    args = conn.execute.call_args[0]
+    channels = args[1]  # outreach_channels positional arg
+    assert "email" in channels
+    assert "linkedin" in channels
+    assert "voice" in channels
+
+
+@pytest.mark.asyncio
+async def test_respects_channel_config():
+    """SMS disabled in config → not in confirmed channels."""
+    stage, conn = make_stage(channel_config={"email": True, "linkedin": False, "voice": False, "sms": False})
+    result = await stage.run("marketing_agency")
+    args = conn.execute.call_args[0]
+    channels = args[1]
+    assert "linkedin" not in channels
+    assert "voice" not in channels
+    assert "email" in channels
+
+
+@pytest.mark.asyncio
+async def test_updates_pipeline_stage_to_6():
+    stage, conn = make_stage()
+    await stage.run("marketing_agency")
+    args = conn.execute.call_args[0]
+    assert PIPELINE_STAGE_S6 in args
+
+
+@pytest.mark.asyncio
+async def test_returns_channel_breakdown():
+    stage, conn = make_stage()
+    result = await stage.run("marketing_agency")
+    assert "channels_confirmed" in result
+    assert isinstance(result["channels_confirmed"], dict)

--- a/tests/test_stage_7_haiku.py
+++ b/tests/test_stage_7_haiku.py
@@ -1,0 +1,173 @@
+"""Tests for Stage7Haiku — Directive #264"""
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime
+
+from src.pipeline.stage_7_haiku import Stage7Haiku, PIPELINE_STAGE_S7, HAIKU_MODEL
+from src.enrichment.signal_config import SignalConfig, ServiceSignal
+
+
+AGENCY_PROFILE = {
+    "name": "Acme Digital Agency",
+    "services": ["SEO", "Paid Ads", "Marketing Automation"],
+    "tone": "professional, direct",
+    "founder_name": "Sarah",
+    "case_study": "Helped a plumber increase leads 3x in 90 days",
+}
+
+
+def make_config():
+    import uuid
+    return SignalConfig(
+        id=str(uuid.uuid4()), vertical_slug="marketing_agency",
+        display_name="MktAgency", description=None,
+        service_signals=[],
+        discovery_config={},
+        enrichment_gates={"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        channel_config={"email": True, "linkedin": True, "voice": True, "sms": False},
+        created_at=datetime.now(), updated_at=datetime.now(),
+    )
+
+
+def make_row(**overrides):
+    defaults = {
+        "id": "uuid-1", "domain": "acme-mktg.com.au",
+        "display_name": "Acme Marketing", "gmb_category": "Marketing Agency",
+        "state": "VIC", "suburb": "Melbourne",
+        "dm_name": "John Smith", "dm_title": "Director",
+        "best_match_service": "paid_ads",
+        "score_reason": "Best match: Paid Ads. Uses Google Ads but missing HubSpot. Active ad spend detected.",
+        "tech_stack": ["Google Ads", "WordPress", "Google Analytics"],
+        "tech_gaps": ["HubSpot", "Facebook Pixel"],
+        "dfs_paid_keywords": 12,
+        "gmb_rating": 3.8,
+        "gmb_review_count": 22,
+        "outreach_channels": ["email", "linkedin", "voice"],
+    }
+    defaults.update(overrides)
+    row = MagicMock()
+    row.__iter__ = lambda self: iter(defaults.items())
+    row.__getitem__ = lambda self, k: defaults[k]
+    row.get = lambda k, d=None: defaults.get(k, d)
+    row.keys = lambda: defaults.keys()
+    return row
+
+
+def make_ai_client(content="Test message response"):
+    client = MagicMock()
+    client.complete = AsyncMock(return_value={
+        "content": content,
+        "input_tokens": 200,
+        "output_tokens": 80,
+        "cost_aud": 0.001,
+    })
+    return client
+
+
+def make_conn(rows=None):
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[make_row()] if rows is None else rows)
+    conn.execute = AsyncMock(return_value=None)
+    return conn
+
+
+def make_stage(rows=None, ai_content="Test outreach message"):
+    ai = make_ai_client(ai_content)
+    signal_repo = MagicMock()
+    signal_repo.get_config = AsyncMock(return_value=make_config())
+    conn = make_conn(rows)
+    stage = Stage7Haiku(ai, signal_repo, conn)
+    return stage, ai, conn
+
+
+@pytest.mark.asyncio
+async def test_generates_email_message():
+    stage, ai, conn = make_stage()
+    stage.sources = None
+    result = await stage.run("marketing_agency", AGENCY_PROFILE)
+    assert result["messages_generated"] > 0
+    ai.complete.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_generates_linkedin_message():
+    stage, ai, conn = make_stage(rows=[make_row(outreach_channels=["linkedin"])])
+    result = await stage.run("marketing_agency", AGENCY_PROFILE)
+    assert result["messages_generated"] == 1
+    # Verify the right channel prompt was used
+    ai.complete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generates_voice_knowledge_card():
+    stage, ai, conn = make_stage(rows=[make_row(outreach_channels=["voice"])])
+    result = await stage.run("marketing_agency", AGENCY_PROFILE)
+    assert result["messages_generated"] == 1
+
+
+@pytest.mark.asyncio
+async def test_generates_sms_message():
+    stage, ai, conn = make_stage(rows=[make_row(outreach_channels=["sms"])])
+    result = await stage.run("marketing_agency", AGENCY_PROFILE)
+    assert result["messages_generated"] == 1
+
+
+@pytest.mark.asyncio
+async def test_references_specific_signal_in_message():
+    """Prospect brief includes score_reason and tech data for Haiku to reference."""
+    stage, ai, conn = make_stage()
+    await stage.run("marketing_agency", AGENCY_PROFILE)
+    call_kwargs = ai.complete.call_args
+    prompt = call_kwargs[1].get("prompt") or (call_kwargs[0][0] if call_kwargs[0] else "")
+    assert "Google Ads" in prompt or "paid_ads" in prompt or "score_reason" in prompt.lower() or "Score reason" in prompt
+
+
+@pytest.mark.asyncio
+async def test_uses_best_match_service():
+    """best_match_service from BU is included in prospect brief."""
+    stage, ai, conn = make_stage()
+    await stage.run("marketing_agency", AGENCY_PROFILE)
+    # Check that any call includes best_match_service context
+    all_calls_text = " ".join(
+        str(call[1].get("prompt") or (call[0][0] if call[0] else ""))
+        for call in ai.complete.call_args_list
+    )
+    assert "paid_ads" in all_calls_text
+
+
+@pytest.mark.asyncio
+async def test_respects_outreach_gate_threshold():
+    """Only pipeline_stage=6 rows with propensity >= 65 are processed."""
+    stage, ai, conn = make_stage()
+    await stage.run("marketing_agency", AGENCY_PROFILE)
+    fetch_sql = conn.fetch.call_args[0][0]
+    assert "propensity_score >= $1" in fetch_sql
+    assert conn.fetch.call_args[0][1] == 65
+
+
+@pytest.mark.asyncio
+async def test_skips_disabled_channels():
+    """Physical channel has no message type — no AI call made for it."""
+    stage, ai, conn = make_stage(rows=[make_row(outreach_channels=["physical"])])
+    result = await stage.run("marketing_agency", AGENCY_PROFILE)
+    assert result["messages_generated"] == 0
+    ai.complete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tracks_cost():
+    """Cost tracked from token counts."""
+    stage, ai, conn = make_stage(rows=[make_row(outreach_channels=["email"])])
+    result = await stage.run("marketing_agency", AGENCY_PROFILE)
+    assert result["cost_usd"] > 0
+    assert "cost_aud" in result
+
+
+@pytest.mark.asyncio
+async def test_updates_pipeline_stage_to_7():
+    """All processed rows advance to pipeline_stage=7."""
+    stage, ai, conn = make_stage()
+    await stage.run("marketing_agency", AGENCY_PROFILE)
+    args = conn.execute.call_args[0]
+    assert PIPELINE_STAGE_S7 in args


### PR DESCRIPTION
## Summary
Stages 6 and 7 complete the v5 pipeline. All 7 stages S1-S7 are now built and tested.

## Stage 6 — Reachability Validation
Channel validation for S5-completed businesses:
- email: format regex
- phone: AU phone pattern (+61/04/02/03/07/08)
- linkedin: LinkedIn profile URL pattern
- physical: address/state/gmb_place_id presence
Stores confirmed channels in `outreach_channels TEXT[]`. Respects `channel_config` (SMS disabled for marketing_agency).

## Stage 7 — Haiku Message Generation
- Gate: `propensity_score >= 65` (min_score_to_outreach)
- Model: `claude-haiku-4-5-20251001`
- Channel-specific prompts: email (<100 words), linkedin (<300 chars), voice (JSON knowledge card), sms (1 sentence)
- Stores messages in `outreach_messages JSONB` on BU
- **No campaign dependency** — v5-native, reads BU directly

## Old files untouched
`stage6_reachability.py` and `stage7_personalisation.py` left as reference (campaign-centric pre-v5 architecture).

## New Columns (migration 027)
- `outreach_channels TEXT[]`
- `outreach_messages JSONB`

## MODEL_PRICING updated
Added `claude-haiku-4-5-20251001` to `MODEL_PRICING` in `src/integrations/anthropic.py` (same rates as claude-3-5-haiku-20241022: $0.80/$4.00 USD per million tokens).

## Pipeline Complete
S1 → S2 → S3 → S4 → S5 → S6 → S7: discovery → GMB → DFS profile → scoring → DM waterfall → reachability → messages.

## Tests
18 new tests, 18 passed. Full suite: 987 passed, 2 failed (pre-existing DFS serp client tests, unrelated), 28 skipped.

Closes #264