### PR TITLE
fix(#267): domain dedup + blocklist + S2 NULL filter + Jina test cleanup

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -61,7 +61,7 @@ All-in COGS: ~$0.49 USD ($0.76 AUD) per prospect.
 
 **S4 Implementation (built #262):** `src/pipeline/stage_4_scoring.py` — `Stage4Scorer` class. Scores per service signal; best match stored as `best_match_service` (S7 uses this to select outreach angle). Four dimensions: budget (digital spend signals), pain (reputation + gap signals), gap (service-specific tech gaps), fit (category + stack alignment). Reachability scored on confirmed channel access; recalculated after S5/S6. Gate: `min_score_to_enrich` from `signal_configurations` (default 30). All businesses progress to pipeline_stage=4 — low scorers filtered by `WHERE propensity_score < threshold` in downstream queries. New migration: `025_scoring_columns.sql` (score_reason, best_match_service, linkedin_company_url, scored_at).
 
-**S5 Implementation (built #263):** `src/pipeline/stage_5_dm_waterfall.py` — `Stage5DMWaterfall` class. Gate: `min_score_to_dm` (default 50) from `signal_configurations`. Waterfall order (cheapest first): `GMBContactExtractor` (free, BU data) → `WebsiteContactScraper` (free, Jina AI) → `LeadmagicPersonFinder` (paid, ~$0.015/email). Protocol-based: adding BD LinkedIn = adding one class to sources list. Stops at first valid result (name + contact method). Recalculates `reachability_score` after DM found. All rows progress to pipeline_stage=5; rows with no DM get `dm_source='none'` (S7 generates company-level outreach). New columns: `dm_phone`, `dm_found_at` (migration 026).
+**S5 Implementation (built #263, updated #267):** `src/pipeline/stage_5_dm_waterfall.py` — `Stage5DMWaterfall` class. Gate: `min_score_to_dm` (default 50) from `signal_configurations`. Waterfall: GMBContactExtractor (free) → LeadmagicPersonFinder (paid). WebsiteContactScraper/Jina removed (#267). Protocol-based: adding BD LinkedIn = adding one class to sources list. Stops at first valid result (name + contact method). Recalculates `reachability_score` after DM found. All rows progress to pipeline_stage=5; rows with no DM get `dm_source='none'` (S7 generates company-level outreach). New columns: `dm_phone`, `dm_found_at` (migration 026).
 
 **S6 Implementation (built #264):** `src/pipeline/stage_6_reachability.py` — `Stage6Reachability` class. Validates dm_email (format check), dm_phone (AU pattern), dm_linkedin_url (LinkedIn profile URL pattern), physical address. Determines `outreach_channels` (text[]) from validated channels filtered by `channel_config`. Recalculates `reachability_score` from confirmed channels. All rows progress to pipeline_stage=6. New columns: `outreach_channels TEXT[]`, `outreach_messages JSONB` (migration 027).
 
@@ -147,8 +147,10 @@ Approval flow:
 | T2 | Bright Data GMB | GMB discovery + enrichment | $0.001/record | ✅ Live — dataset `gd_m8ebnr0q2qlklc02fz` (Google Maps full information), keyword discovery mode: `type=discover_new&discover_by=keyword` |
 | T3+T5 | Leadmagic | Email + mobile (Essential plan) | Variable | ✅ Live |
 | DFS | DataForSEO Labs | 7 endpoints (PR #220) | Variable | ✅ Live |
-| Jina | Jina AI Reader | Website scraping fallback | Free | ✅ Live |
+| Jina | Jina AI Reader | Website scraping fallback | Free | ~~Live~~ Removed from S5 (#267) |
 | BD Web | Bright Data Unlocker | Heavy scraping | Variable | ✅ Live |
+
+Domain blocklist (`src/utils/domain_blocklist.py`) filters platform/social/government domains before BU insert. Blocklist checked in S1 before any INSERT. Covers: social platforms (facebook.com, instagram.com, etc.), search/tech giants (google.com, etc.), website builders, hosting/infra, and *.gov.au subdomains. Directive #267.
 
 DEPRECATED — do not use: Hunter.io, Kaspr, Proxycurl, Apollo (enrichment), Clay (enrichment)
 
@@ -483,7 +485,11 @@ Compliance: SPAM Act 2003, DNCR registered, TCP Code (voice), Australian-built
 ~~**BUG-265-2** — S3 NULL domain guard~~ FIXED #266
 ~~**BUG-265-3** — S4 NULL signal scoring~~ FIXED #266
 ~~**BUG-266-1** — S5 EmailFinderResult type error~~ FIXED #266
-**S5 waterfall simplified:** Jina/WebsiteContactScraper removed. New order: GMBContactExtractor → LeadmagicPersonFinder.
-Stage5DMWaterfall._write_result passes the raw `EmailFinderResult` dataclass object instead of `email_result.email` string as query argument $3. Causes `asyncpg.exceptions.DataError: expected str, got EmailFinderResult`. Blocks all S5-S7 processing. Fix: extract `.email` attribute before passing to execute().
+~~**BUG-266-1 (DB)** — Duplicate domains in BU (non-atomic SELECT+INSERT)~~ FIXED #267 — migration 028: dedup + partial UNIQUE index; S1 ON CONFLICT upsert
+~~**BUG-266-2** — Platform/social/gov domains in BU (no blocklist)~~ FIXED #267 — domain_blocklist.py + S1 is_blocked() guard
+~~**BUG-266-3** — S2 BD 401 on NULL/empty domains~~ FIXED #267 — added AND domain IS NOT NULL AND domain <> '' to S2 SELECT
+~~**BUG-266-4** — Dead Jina test (test_falls_through_to_website_scraper)~~ FIXED #267 — test removed, test_waterfall_gmb_then_leadmagic_only added
+
+**S5 waterfall:** Jina/WebsiteContactScraper removed. Order: GMBContactExtractor → LeadmagicPersonFinder.
 
 **Live run stats (#266 final):** S2 advanced 30 rows, S3 profiled 26 (NULL domains skipped), S4 scored 23/26 above threshold, S5 found 7 DMs (GMB+Leadmagic, Jina removed), S6 validated 7 (email:3, voice:2, physical:7), S7 generated 4 messages at $0.0047. Pipeline working end-to-end. First real Haiku outreach messages produced. Total cost ~$1.30 across all runs.

--- a/migrations/028_unique_domain.sql
+++ b/migrations/028_unique_domain.sql
@@ -1,0 +1,21 @@
+-- Deduplicate business_universe by domain
+-- Keep row with highest pipeline_stage; ties broken by most recent updated_at
+-- Directive #267
+
+-- Step 1: Delete duplicates for real (non-empty) domains,
+-- keep the "best" row per domain (highest stage, most recent updated_at)
+DELETE FROM business_universe
+WHERE id NOT IN (
+    SELECT DISTINCT ON (domain) id
+    FROM business_universe
+    WHERE domain IS NOT NULL AND domain <> ''
+    ORDER BY domain, pipeline_stage DESC, pipeline_updated_at DESC NULLS LAST, created_at DESC
+)
+AND domain IS NOT NULL AND domain <> '';
+
+-- Step 2: Add partial UNIQUE index on domain
+-- (excludes NULL and empty strings; multiple blank-domain rows are kept until
+--  the BUG-266-2 blocklist fix prevents new ones from being inserted)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_bu_domain
+    ON business_universe(domain)
+    WHERE domain IS NOT NULL AND domain <> '';

--- a/src/pipeline/stage_1_discovery.py
+++ b/src/pipeline/stage_1_discovery.py
@@ -20,6 +20,7 @@ import asyncpg
 
 from src.clients.dfs_labs_client import DFSLabsClient
 from src.enrichment.signal_config import SignalConfig, SignalConfigRepository
+from src.utils.domain_blocklist import is_blocked
 
 logger = logging.getLogger(__name__)
 
@@ -148,55 +149,47 @@ class Stage1Discovery:
     ) -> bool:
         """
         Insert domain if new, append technology if exists.
-        Returns True if new row inserted, False if existing row updated.
+        Returns True if new row inserted, False if existing row updated or blocked.
+        Directive #267: checks domain blocklist before any DB operation;
+        uses INSERT ... ON CONFLICT for atomic upsert (no TOCTOU races).
         """
-        now = datetime.now(timezone.utc)
-        existing = await self.conn.fetchrow(
-            "SELECT id, dfs_technologies FROM business_universe WHERE domain = $1",
-            domain,
-        )
-
-        if existing is None:
-            # New domain — insert
-            await self.conn.execute(
-                """
-                INSERT INTO business_universe (
-                    display_name,
-                    domain,
-                    dfs_technologies,
-                    dfs_discovery_sources,
-                    dfs_technology_detected_at,
-                    pipeline_stage,
-                    pipeline_updated_at,
-                    discovered_at
-                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-                """,
-                item.get("title") or domain,   # display_name
-                domain,
-                [technology_name],              # dfs_technologies
-                [DISCOVERY_SOURCE],             # dfs_discovery_sources
-                now,
-                PIPELINE_STAGE_S1,
-                now,
-                now,
-            )
-            return True
-        else:
-            # Existing domain — append tech if not already present
-            existing_techs: list[str] = list(existing["dfs_technologies"] or [])
-            if technology_name not in existing_techs:
-                existing_techs.append(technology_name)
-                await self.conn.execute(
-                    """
-                    UPDATE business_universe
-                    SET dfs_technologies = $1,
-                        dfs_technology_detected_at = $2,
-                        pipeline_updated_at = $3
-                    WHERE domain = $4
-                    """,
-                    existing_techs,
-                    now,
-                    now,
-                    domain,
-                )
+        if is_blocked(domain):
+            logger.debug(f"S1: skipping blocked domain {domain!r}")
             return False
+
+        now = datetime.now(timezone.utc)
+
+        result = await self.conn.fetchrow(
+            """
+            INSERT INTO business_universe (
+                display_name,
+                domain,
+                dfs_technologies,
+                dfs_discovery_sources,
+                dfs_technology_detected_at,
+                pipeline_stage,
+                pipeline_updated_at,
+                discovered_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            ON CONFLICT (domain) DO UPDATE
+                SET dfs_technologies = (
+                        SELECT array(
+                            SELECT DISTINCT unnest(
+                                business_universe.dfs_technologies || EXCLUDED.dfs_technologies
+                            )
+                        )
+                    ),
+                    dfs_technology_detected_at = EXCLUDED.dfs_technology_detected_at,
+                    pipeline_updated_at = EXCLUDED.pipeline_updated_at
+            RETURNING (xmax = 0) AS inserted
+            """,
+            item.get("title") or domain,   # display_name
+            domain,
+            [technology_name],              # dfs_technologies
+            [DISCOVERY_SOURCE],             # dfs_discovery_sources
+            now,
+            PIPELINE_STAGE_S1,
+            now,
+            now,
+        )
+        return bool(result["inserted"]) if result else False

--- a/src/pipeline/stage_2_gmb_lookup.py
+++ b/src/pipeline/stage_2_gmb_lookup.py
@@ -56,6 +56,7 @@ class Stage2GMBLookup:
             SELECT id, domain, gmb_place_id
             FROM business_universe
             WHERE pipeline_stage = 1
+            AND domain IS NOT NULL AND domain <> ''
             ORDER BY discovered_at ASC
             LIMIT $1
             """,
@@ -124,6 +125,9 @@ class Stage2GMBLookup:
         Look up GMB for domain and update BU.
         Returns True if GMB found, False if not.
         """
+        if not domain:
+            logger.warning(f"S2: skipping row {row_id} — empty domain")
+            return False
         now = datetime.now(timezone.utc)
         business_name = extract_business_name(domain)
         logger.info(f"Stage 2: {domain} → searching '{business_name}'")

--- a/src/utils/domain_blocklist.py
+++ b/src/utils/domain_blocklist.py
@@ -1,0 +1,43 @@
+"""
+Domain blocklist for S1 discovery pipeline.
+Domains in this set are never inserted into business_universe.
+Directive #267
+"""
+from __future__ import annotations
+
+BLOCKED_DOMAINS: frozenset[str] = frozenset({
+    # Social platforms
+    "facebook.com", "instagram.com", "twitter.com", "x.com",
+    "tiktok.com", "pinterest.com", "snapchat.com", "reddit.com",
+    "youtube.com", "linkedin.com", "threads.net",
+    # Search / tech giants
+    "google.com", "google.com.au", "bing.com", "yahoo.com",
+    "apple.com", "microsoft.com", "amazon.com", "amazon.com.au",
+    # Website builders / platforms
+    "wordpress.com", "wix.com", "squarespace.com", "shopify.com",
+    "webflow.com", "weebly.com", "blogger.com",
+    # Hosting / infra
+    "godaddy.com", "cloudflare.com", "github.com", "gitlab.com",
+    "stackoverflow.com", "medium.com",
+    # Government / non-business
+    "gov.au", "nsw.gov.au", "vic.gov.au", "qld.gov.au",
+    "sa.gov.au", "wa.gov.au", "tas.gov.au", "act.gov.au",
+    "nt.gov.au", "health.gov.au",
+})
+
+
+def is_blocked(domain: str | None) -> bool:
+    """Return True if domain should be excluded from business_universe."""
+    if not domain:
+        return True
+    d = domain.lower().strip()
+    if not d:
+        return True
+    # Exact match
+    if d in BLOCKED_DOMAINS:
+        return True
+    # Subdomain of blocked domain (e.g. rfs.nsw.gov.au)
+    for blocked in BLOCKED_DOMAINS:
+        if d.endswith("." + blocked):
+            return True
+    return False

--- a/tests/test_domain_blocklist.py
+++ b/tests/test_domain_blocklist.py
@@ -1,0 +1,43 @@
+"""Tests for domain_blocklist utility. Directive #267"""
+from src.utils.domain_blocklist import is_blocked
+
+
+def test_blocks_facebook():
+    assert is_blocked("facebook.com") is True
+
+
+def test_blocks_subdomain_gov():
+    assert is_blocked("rfs.nsw.gov.au") is True
+
+
+def test_blocks_empty():
+    assert is_blocked("") is True
+    assert is_blocked(None) is True
+
+
+def test_allows_business_domain():
+    assert is_blocked("acme-dental.com.au") is False
+    assert is_blocked("sydneydentist.com.au") is False
+
+
+def test_blocks_google():
+    assert is_blocked("google.com") is True
+    assert is_blocked("google.com.au") is True
+
+
+def test_blocks_instagram():
+    assert is_blocked("instagram.com") is True
+
+
+def test_blocks_gov_au_subdomain():
+    assert is_blocked("health.nsw.gov.au") is True
+
+
+def test_allows_whitespace_stripped():
+    # domain with surrounding spaces should still be caught if blocked
+    assert is_blocked("  facebook.com  ") is True
+
+
+def test_blocks_case_insensitive():
+    assert is_blocked("Facebook.COM") is True
+    assert is_blocked("INSTAGRAM.COM") is True

--- a/tests/test_stage_1_discovery.py
+++ b/tests/test_stage_1_discovery.py
@@ -44,14 +44,18 @@ def make_dfs_response(domains: list[str], total_count: int | None = None):
 
 
 def make_conn(existing_domain: str | None = None):
-    """Build a mock asyncpg connection."""
+    """Build a mock asyncpg connection.
+
+    Directive #267: _upsert_domain now uses INSERT ... ON CONFLICT ... RETURNING (xmax=0) AS inserted
+    via conn.fetchrow (not conn.execute).
+    - existing_domain=None  → returns {"inserted": True}  (new row)
+    - existing_domain=<str> → returns {"inserted": False} (conflict/duplicate)
+    """
     conn = MagicMock()
-    if existing_domain:
-        row = MagicMock()
-        row.__getitem__ = lambda self, k: existing_domain if k == "domain" else ([] if k == "dfs_technologies" else None)
-        conn.fetchrow = AsyncMock(return_value=row)
-    else:
-        conn.fetchrow = AsyncMock(return_value=None)
+    row = MagicMock()
+    inserted_val = existing_domain is None  # True when no existing domain
+    row.__getitem__ = lambda self, k: inserted_val if k == "inserted" else None
+    conn.fetchrow = AsyncMock(return_value=row)
     conn.execute = AsyncMock(return_value=None)
     return conn
 
@@ -81,47 +85,39 @@ async def test_discovers_domains_from_signal_config():
     dfs.domains_by_technology.assert_called_once()
     assert result["discovered"] == 1
     assert result["duplicates_skipped"] == 0
-    conn.execute.assert_called_once()  # INSERT called
+    # Directive #267: upsert uses fetchrow (INSERT ... ON CONFLICT ... RETURNING)
+    conn.fetchrow.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_skips_existing_domains():
-    """Existing domain (same tech) → duplicate counted, no INSERT."""
+    """Existing domain → duplicate counted (ON CONFLICT returns inserted=False)."""
     stage, dfs, repo, conn = make_stage(
         techs=["Google Ads"],
-        existing_domain="example.com.au",
+        existing_domain="example.com.au",  # triggers inserted=False mock
     )
-    # Make existing row return tech already present
-    row = MagicMock()
-    row.__getitem__ = lambda self, k: (["Google Ads"] if k == "dfs_technologies" else None)
-    conn.fetchrow = AsyncMock(return_value=row)
-
     result = await stage.run_batch("marketing_agency", ["Google Ads"])
     assert result["discovered"] == 0
     assert result["duplicates_skipped"] == 1
-    # execute should NOT be called (tech already present)
+    # Directive #267: execute should NOT be called (upsert goes via fetchrow)
     conn.execute.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_appends_new_tech_to_existing_domain():
-    """Existing domain but different tech → UPDATE called, not INSERT, returns False."""
+    """Existing domain but different tech → ON CONFLICT upsert, returns inserted=False."""
     stage, dfs, repo, conn = make_stage(
         techs=["Facebook Pixel"],
-        existing_domain="example.com.au",
+        existing_domain="example.com.au",  # triggers inserted=False mock
     )
-    row = MagicMock()
-    row.__getitem__ = lambda self, k: (["Google Ads"] if k == "dfs_technologies" else None)
-    conn.fetchrow = AsyncMock(return_value=row)
-
     result = await stage.run_batch("marketing_agency", ["Facebook Pixel"])
-    # Existing domain with new tech → counted as duplicate (not new row)
+    # Existing domain → counted as duplicate (not a new row)
     assert result["duplicates_skipped"] == 1
     assert result["discovered"] == 0
-    # But UPDATE should have been called to append the tech
-    conn.execute.assert_called_once()
-    update_sql = conn.execute.call_args[0][0]
-    assert "UPDATE" in update_sql
+    # Directive #267: ON CONFLICT merges tech via fetchrow (no separate execute)
+    conn.fetchrow.assert_called_once()
+    upsert_sql = conn.fetchrow.call_args[0][0]
+    assert "ON CONFLICT" in upsert_sql
 
 
 @pytest.mark.asyncio
@@ -191,9 +187,65 @@ async def test_sets_pipeline_stage_s1_discovered():
     """New domain INSERT uses PIPELINE_STAGE_S1 (integer 1)."""
     stage, dfs, repo, conn = make_stage()
     await stage.run_batch("marketing_agency", ["Google Ads"])
-    conn.execute.assert_called_once()
-    # Verify the pipeline_stage value passed is integer 1
-    call_args = conn.execute.call_args[0]
-    # args: sql, display_name, domain, [techs], [sources], detected_at, pipeline_stage, pipeline_updated_at, discovered_at
+    # Directive #267: upsert uses fetchrow (INSERT ... ON CONFLICT ... RETURNING)
+    conn.fetchrow.assert_called_once()
+    call_args = conn.fetchrow.call_args[0]
     assert PIPELINE_STAGE_S1 == 1
     assert 1 in call_args  # pipeline_stage=1 is in the positional args
+
+
+# ─── Directive #267 tests ────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_no_duplicate_domains_across_techs():
+    """ON CONFLICT upsert prevents duplicate rows when same domain appears in multiple techs."""
+    stage, dfs, repo, conn = make_stage()
+    # Both techs return the same domain → second call returns inserted=False
+    call_count = 0
+    async def side_effect(**kwargs):
+        return make_dfs_response(["shared.com.au"])
+    dfs.domains_by_technology = AsyncMock(side_effect=side_effect)
+
+    # First call → inserted=True, second → inserted=False (conflict)
+    inserted_values = [True, False]
+    call_idx = 0
+    original_fetchrow = conn.fetchrow
+
+    async def fetchrow_side_effect(*args, **kwargs):
+        nonlocal call_idx
+        row = MagicMock()
+        val = inserted_values[min(call_idx, len(inserted_values) - 1)]
+        row.__getitem__ = lambda self, k: val if k == "inserted" else None
+        call_idx += 1
+        return row
+
+    conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+
+    result = await stage.run_batch("marketing_agency", ["Google Ads", "Facebook Pixel"])
+    assert result["discovered"] == 1       # only first call counted as new
+    assert result["duplicates_skipped"] == 1  # second call was a conflict
+
+
+@pytest.mark.asyncio
+async def test_blocks_platform_domains():
+    """Platform/social domains are not inserted into BU (blocklist check)."""
+    stage, dfs, repo, conn = make_stage()
+    dfs.domains_by_technology = AsyncMock(
+        return_value=make_dfs_response(["facebook.com", "instagram.com", "google.com"])
+    )
+    result = await stage.run_batch("marketing_agency", ["Google Ads"])
+    assert result["discovered"] == 0
+    assert result["duplicates_skipped"] == 3  # all blocked → counted as skipped
+    conn.fetchrow.assert_not_called()  # DB never touched for blocked domains
+
+
+@pytest.mark.asyncio
+async def test_allows_legitimate_business_domains():
+    """Normal business domains pass the blocklist check and are inserted."""
+    stage, dfs, repo, conn = make_stage()
+    dfs.domains_by_technology = AsyncMock(
+        return_value=make_dfs_response(["acme-dental.com.au"])
+    )
+    result = await stage.run_batch("marketing_agency", ["Google Ads"])
+    assert result["discovered"] == 1
+    conn.fetchrow.assert_called_once()  # DB upsert called for legitimate domain

--- a/tests/test_stage_5_dm_waterfall.py
+++ b/tests/test_stage_5_dm_waterfall.py
@@ -87,20 +87,16 @@ async def test_finds_dm_from_gmb_first():
 
 
 @pytest.mark.asyncio
-async def test_falls_through_to_website_scraper():
-    """First source returns None → second source is tried."""
-    source_1 = MagicMock(source_name="gmb")
-    source_1.find = AsyncMock(return_value=None)
-    source_2 = MagicMock(source_name="website")
-    source_2.find = AsyncMock(return_value=DMResult(
-        name="Bob Director", email="bob@biz.com.au", source="website"
-    ))
-    stage, conn, _ = make_stage()
-    stage.sources = [source_1, source_2]
-    result = await stage.run("marketing_agency")
-    assert result["found"] == 1
-    source_1.find.assert_called_once()
-    source_2.find.assert_called_once()
+async def test_waterfall_gmb_then_leadmagic_only():
+    """Waterfall has exactly 2 sources: GMB then Leadmagic. No Jina/website."""
+    lm = MagicMock()
+    signal_repo = MagicMock()
+    conn = MagicMock()
+    stage = Stage5DMWaterfall(lm, signal_repo, conn)
+    source_names = [s.source_name for s in stage.sources]
+    assert "gmb" in source_names[0].lower() or "gmb" in type(stage.sources[0]).__name__.lower()
+    assert "leadmagic" in source_names[-1].lower() or "leadmagic" in type(stage.sources[-1]).__name__.lower()
+    assert not any("website" in n.lower() or "jina" in n.lower() for n in source_names)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Fixes

### BUG-266-1 — Duplicate domains
- migration 028: dedup existing rows (keep highest pipeline_stage), add partial UNIQUE index on domain
- S1 _upsert_domain: INSERT ... ON CONFLICT upsert (atomic, no TOCTOU)
- Verified: 4,964 real domains, all unique in production DB

### BUG-266-2 — Platform domains in BU
- src/utils/domain_blocklist.py: BLOCKED_DOMAINS set + is_blocked() helper
- S1: check is_blocked() before INSERT
- Handles: social, search, builders, infra, .gov.au subdomains

### BUG-266-3 — S2 BD 401 on NULL/empty domains
- Added AND domain IS NOT NULL AND domain <> '' to S2 SELECT
- Added early-return guard in _lookup_and_update for empty domain
- 593 empty-string rows and 46 NULL rows now skipped

### BUG-266-4 — Jina dead code test
- Removed test_falls_through_to_website_scraper (tests removed code path)
- Added test_waterfall_gmb_then_leadmagic_only

## Tests
- 31 new/updated tests pass in targeted suite
- 992 passed, 2 pre-existing failures (test_dfs_serp_client.py) in full suite

## Manual
- SECTION 3: S5 waterfall updated (WebsiteContactScraper/Jina removed #267)
- SECTION 8: Domain blocklist note added
- SECTION 20: BUG-266-1 through BUG-266-4 marked FIXED
- Google Drive mirror updated

Closes #267