### PR TITLE
Directive #271: Signal config schema v6

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -1,8 +1,8 @@
 # Agency OS Manual
 
-Last updated: 2026-03-26 21:08 UTC
-Directive #270: Manual trim (34k → target <22k)
-Next scheduled update: Directive #271 completion (signal config schema redesign)
+Last updated: 2026-03-26 21:55 UTC
+Directive #271: Signal config schema v6 — migration 029 in progress
+Next scheduled update: Directive #271 completion (PR merge)
 
 > **Primary store.** This file is the CEO SSOT. Google Doc is an auto-generated mirror.
 > After every save-trigger write, verify with: `cat docs/MANUAL.md | grep "SECTION"`
@@ -291,7 +291,7 @@ competitor_config: jsonb:
   }
 ```
 
-Current schema (pre-#271): `service_signals` jsonb (instead of `services`), no `competitor_config` column. Redesign is Directive #271.
+Migration 029 (Directive #271): DROP old table → CREATE v6 schema (`vertical`, `services`, `discovery_config`, `enrichment_gates`, `competitor_config`, `channel_config`) → seed marketing_agency with 6 services (paid_ads, seo, social_media_marketing, web_design, marketing_automation, content_marketing). Python model updated (`src/enrichment/signal_config.py`). BUG-268-1 confirmed pre-fixed (stage_1_discovery.py already uses jsonb_array_elements_text). DFS v2 audit: PASS — all calls on /v3/.
 
 ---
 
@@ -632,8 +632,12 @@ Compliance: SPAM Act 2003, DNCR registered, TCP Code (voice), Australian-built
 - Remotion video + Stripe checkout pending for landing page
 - S7 prompt engineering needed (backlog — deferred post-#281)
 - S2 parallelisation needed (production speed — currently sequential)
-- signal_configurations schema needs redesign (#271)
-- BUG-268-1: S1 `unnest(jsonb)` fails — fix: `jsonb_array_elements_text()` + `jsonb_agg(DISTINCT elem)` pattern
+- BUG-268-1: CONFIRMED PRE-FIXED — stage_1_discovery.py already uses jsonb_array_elements_text() (no action needed)
 - BUG-268-2: BD GMB returning 401 on new-domain discovery requests — credentials issue in BD account (Dave to check dashboard)
+
+### Directive Log
+| Directive | What | Status |
+|-----------|------|--------|
+| #271 | Signal config schema v6 (migration 029 + model + 6-service seed) | IN PROGRESS — PR pending |
 
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -25,7 +25,7 @@ Revenue model for BU: API subscriptions, Salesforce/HubSpot marketplace, bulk an
 
 - Last directive issued: #270 (Manual trim)
 - Next directive: #271 (signal config schema redesign)
-- Test baseline: 992 passed, 2 failed (pre-existing DFS serp client tests), 28 skipped
+- Test baseline: 1009 passed, 2 failed (pre-existing DFS serp client tests), 28 skipped
 - Last merged PRs: #233 (dedup + blocklist), #232 (bug fixes), #231 (live test v2), #230 (stages 6+7)
 - Architecture: **v6 ratified Mar 27 2026** — spend + gaps + fit discovery (10-layer engine)
 - **All 7 pipeline stages S1-S7 built and on main (v5 era). v6 rebuild starts at #271 — see Section 12**
@@ -638,6 +638,6 @@ Compliance: SPAM Act 2003, DNCR registered, TCP Code (voice), Australian-built
 ### Directive Log
 | Directive | What | Status |
 |-----------|------|--------|
-| #271 | Signal config schema v6 (migration 029 + model + 6-service seed) | IN PROGRESS — PR pending |
+| #271 | Signal config schema v6 (migration 029 + model + 6-service seed) | COMPLETE — PR #235 open |
 
 

--- a/migrations/029_signal_configurations_v6.sql
+++ b/migrations/029_signal_configurations_v6.sql
@@ -1,0 +1,354 @@
+-- Migration 029: signal_configurations v6 schema redesign
+-- Directive #271
+--
+-- v5 used: vertical_slug text, service_signals jsonb (flat array), no competitor_config
+-- v6 uses: vertical varchar(100), services jsonb (nested with problem/budget/not_served signals),
+--          competitor_config jsonb
+--
+-- One test row (marketing_agency) exists, no FK dependencies. Safe to DROP and recreate.
+
+-- 1. Drop old table and trigger function
+DROP TABLE IF EXISTS signal_configurations CASCADE;
+DROP FUNCTION IF EXISTS update_signal_configurations_updated_at();
+
+-- 2. Create v6 table
+CREATE TABLE signal_configurations (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    vertical            varchar(100) UNIQUE NOT NULL,
+    services            jsonb NOT NULL DEFAULT '[]',
+    discovery_config    jsonb NOT NULL DEFAULT '{}',
+    enrichment_gates    jsonb NOT NULL DEFAULT '{}',
+    competitor_config   jsonb NOT NULL DEFAULT '{}',
+    channel_config      jsonb NOT NULL DEFAULT '{}',
+    created_at          timestamptz NOT NULL DEFAULT NOW(),
+    updated_at          timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_signal_config_vertical ON signal_configurations(vertical);
+
+-- 3. updated_at trigger
+CREATE OR REPLACE FUNCTION update_signal_configurations_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_signal_configurations_updated_at
+    BEFORE UPDATE ON signal_configurations
+    FOR EACH ROW EXECUTE FUNCTION update_signal_configurations_updated_at();
+
+-- 4. Seed marketing_agency with 6 services (v6 structure)
+INSERT INTO signal_configurations (
+    vertical,
+    services,
+    discovery_config,
+    enrichment_gates,
+    competitor_config,
+    channel_config
+) VALUES (
+    'marketing_agency',
+
+    '[
+        {
+            "service_key": "paid_ads",
+            "display_name": "Paid Ads Management",
+            "weight": 0.20,
+            "scoring_weights": {"budget": 30, "pain": 30, "gap": 25, "fit": 15},
+            "problem_signals": [
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "has paid spend but no conversion tracking pixel",
+                    "field": "dfs_paid_etv",
+                    "operator": "gt",
+                    "threshold": 200
+                },
+                {
+                    "source": "on_page_summary",
+                    "condition": "missing conversion tracking — ad spend going unmeasured",
+                    "field": "tech_stack",
+                    "operator": "missing",
+                    "threshold": ["gtag-conversion", "Google Tag Manager"]
+                }
+            ],
+            "budget_signals": [
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "active paid keyword spend indicates marketing budget",
+                    "field": "dfs_paid_etv",
+                    "operator": "gt",
+                    "threshold": 0
+                },
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "significant paid keyword volume confirms ad spend",
+                    "field": "dfs_paid_keywords",
+                    "operator": "gt",
+                    "threshold": 5
+                }
+            ],
+            "not_served_signals": [
+                {
+                    "source": "domain_technologies",
+                    "condition": "no PPC management or optimisation tool detected",
+                    "field": "tech_stack",
+                    "operator": "missing",
+                    "threshold": ["Google Ads", "Facebook Pixel", "Google Tag Manager", "WordStream", "Optmyzr", "AdEspresso"]
+                }
+            ]
+        },
+        {
+            "service_key": "seo",
+            "display_name": "SEO Services",
+            "weight": 0.20,
+            "scoring_weights": {"budget": 20, "pain": 35, "gap": 30, "fit": 15},
+            "problem_signals": [
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "organic ETV low vs paid spend — SEO underperforming",
+                    "field": "dfs_organic_etv",
+                    "operator": "lt",
+                    "threshold": 100
+                },
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "many keywords ranking 11-30 indicate low-hanging SEO wins",
+                    "field": "dfs_organic_pos_11_20",
+                    "operator": "gt",
+                    "threshold": 20
+                },
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "organic traffic declining month-over-month",
+                    "field": "dfs_organic_etv_trend",
+                    "operator": "lt",
+                    "threshold": -0.10
+                }
+            ],
+            "budget_signals": [
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "some organic presence indicates investment potential",
+                    "field": "dfs_organic_etv",
+                    "operator": "gt",
+                    "threshold": 10
+                }
+            ],
+            "not_served_signals": [
+                {
+                    "source": "domain_technologies",
+                    "condition": "no SEO platform or analytics tool detected",
+                    "field": "tech_stack",
+                    "operator": "missing",
+                    "threshold": ["Google Analytics", "Google Search Console", "Yoast SEO", "SEMrush", "Ahrefs", "Moz"]
+                }
+            ]
+        },
+        {
+            "service_key": "social_media_marketing",
+            "display_name": "Social Media Marketing",
+            "weight": 0.15,
+            "scoring_weights": {"budget": 20, "pain": 25, "gap": 35, "fit": 20},
+            "problem_signals": [
+                {
+                    "source": "domain_technologies",
+                    "condition": "no social proof widget or feed on site",
+                    "field": "tech_stack",
+                    "operator": "missing",
+                    "threshold": ["EmbedSocial", "Curator.io", "Smash Balloon", "Instagram Feed"]
+                },
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "low organic reach despite paid spend — social amplification missing",
+                    "field": "dfs_organic_etv",
+                    "operator": "lt",
+                    "threshold": 50
+                }
+            ],
+            "budget_signals": [
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "paid spend shows marketing budget exists",
+                    "field": "dfs_paid_etv",
+                    "operator": "gt",
+                    "threshold": 100
+                }
+            ],
+            "not_served_signals": [
+                {
+                    "source": "domain_technologies",
+                    "condition": "no social scheduling or management platform detected",
+                    "field": "tech_stack",
+                    "operator": "missing",
+                    "threshold": ["Facebook Pixel", "LinkedIn Insight Tag", "Hootsuite", "Buffer", "Sprout Social", "Later", "Twitter Pixel"]
+                }
+            ]
+        },
+        {
+            "service_key": "web_design",
+            "display_name": "Web Design & Development",
+            "weight": 0.20,
+            "scoring_weights": {"budget": 25, "pain": 35, "gap": 25, "fit": 15},
+            "problem_signals": [
+                {
+                    "source": "on_page_summary",
+                    "condition": "slow page speed or mobile UX issues detected",
+                    "field": "page_speed_score",
+                    "operator": "lt",
+                    "threshold": 60
+                },
+                {
+                    "source": "domain_technologies",
+                    "condition": "site uses outdated or DIY page builder",
+                    "field": "tech_stack",
+                    "operator": "contains",
+                    "threshold": "Wix"
+                }
+            ],
+            "budget_signals": [
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "organic or paid traffic indicates active business with budget",
+                    "field": "dfs_organic_etv",
+                    "operator": "gt",
+                    "threshold": 0
+                }
+            ],
+            "not_served_signals": [
+                {
+                    "source": "domain_technologies",
+                    "condition": "site uses DIY builder or legacy CMS lacking professional design",
+                    "field": "tech_stack",
+                    "operator": "missing",
+                    "threshold": ["WordPress", "Wix", "Squarespace", "Webflow", "React", "Next.js"]
+                }
+            ]
+        },
+        {
+            "service_key": "marketing_automation",
+            "display_name": "Marketing Automation",
+            "weight": 0.15,
+            "scoring_weights": {"budget": 25, "pain": 25, "gap": 35, "fit": 15},
+            "problem_signals": [
+                {
+                    "source": "domain_technologies",
+                    "condition": "has traffic but no lead capture or scheduling tool",
+                    "field": "tech_stack",
+                    "operator": "missing",
+                    "threshold": ["Typeform", "Calendly", "HubSpot Forms", "Gravity Forms"]
+                },
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "significant organic traffic with no automation stack — leads leaking",
+                    "field": "dfs_organic_etv",
+                    "operator": "gt",
+                    "threshold": 50
+                }
+            ],
+            "budget_signals": [
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "paid ad spend indicates budget available for automation",
+                    "field": "dfs_paid_etv",
+                    "operator": "gt",
+                    "threshold": 200
+                }
+            ],
+            "not_served_signals": [
+                {
+                    "source": "domain_technologies",
+                    "condition": "no CRM or marketing automation platform detected",
+                    "field": "tech_stack",
+                    "operator": "missing",
+                    "threshold": ["HubSpot", "Marketo", "ActiveCampaign", "Salesforce", "Mailchimp", "Klaviyo"]
+                }
+            ]
+        },
+        {
+            "service_key": "content_marketing",
+            "display_name": "Content Marketing",
+            "weight": 0.10,
+            "scoring_weights": {"budget": 15, "pain": 35, "gap": 30, "fit": 20},
+            "problem_signals": [
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "organic traffic declining month-over-month",
+                    "field": "dfs_organic_etv_trend",
+                    "operator": "lt",
+                    "threshold": -0.10
+                },
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "low organic keyword count indicates thin or absent content strategy",
+                    "field": "dfs_organic_keywords",
+                    "operator": "lt",
+                    "threshold": 50
+                }
+            ],
+            "budget_signals": [
+                {
+                    "source": "domain_rank_overview",
+                    "condition": "some organic presence indicates content investment potential",
+                    "field": "dfs_organic_etv",
+                    "operator": "gt",
+                    "threshold": 10
+                }
+            ],
+            "not_served_signals": [
+                {
+                    "source": "domain_technologies",
+                    "condition": "no content management or blogging platform detected",
+                    "field": "tech_stack",
+                    "operator": "missing",
+                    "threshold": ["WordPress", "Ghost", "Contentful", "HubSpot CMS", "Webflow CMS"]
+                }
+            ]
+        }
+    ]'::jsonb,
+
+    '{
+        "category_codes": [13418, 13420, 13421],
+        "ad_spend_threshold": 200,
+        "keywords_for_ads_search": [
+            "dentist Sydney",
+            "plumber Melbourne",
+            "accountant Brisbane",
+            "lawyer Perth",
+            "gym Adelaide"
+        ],
+        "html_gap_combos": [
+            {"has": "google-ads-pixel", "missing": "gtag-conversion"},
+            {"has": "wordpress", "missing": "yoast-seo"}
+        ],
+        "job_search_keywords": [
+            "marketing manager",
+            "digital marketing coordinator",
+            "SEO specialist"
+        ],
+        "competitor_expansion": true,
+        "max_competitors_per_prospect": 5
+    }'::jsonb,
+
+    '{
+        "min_score_to_qualify": 30,
+        "min_score_to_compete": 50,
+        "min_score_to_enrich": 30,
+        "min_score_to_dm": 50,
+        "min_score_to_outreach": 65
+    }'::jsonb,
+
+    '{
+        "max_competitors_per_prospect": 5,
+        "min_competitor_organic_etv": 100,
+        "store_top_n_for_messaging": 3,
+        "feed_back_to_discovery": true
+    }'::jsonb,
+
+    '{
+        "email": true,
+        "linkedin": true,
+        "voice": true,
+        "sms": false
+    }'::jsonb
+);

--- a/src/enrichment/signal_config.py
+++ b/src/enrichment/signal_config.py
@@ -1,7 +1,10 @@
 """
-Signal Configuration Repository — Directive #256
-Single source of truth for vertical signal patterns.
-Every pipeline stage reads from here.
+Contract: src/enrichment/signal_config.py
+Purpose: Signal configuration repository — v6 schema (services jsonb, competitor_config)
+Layer: 2 - integrations (reads DB only, no engine imports)
+Imports: asyncpg
+Consumers: engines, orchestration
+Directive: #271 (v6 redesign from #256)
 """
 from __future__ import annotations
 
@@ -16,33 +19,73 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ServiceSignal:
+    """
+    Per-service signal configuration.
+
+    Field order preserves v5 positional backward compat:
+      service_name, label, dfs_technologies, gmb_categories, scoring_weights,
+      must_not_have_technologies (all positional args used in existing tests)
+
+    v6 additions (keyword-only in practice): weight, problem_signals,
+      budget_signals, not_served_signals
+    """
+
     service_name: str
     label: str
-    dfs_technologies: list[str]
-    gmb_categories: list[str]
-    scoring_weights: dict[str, int]
+    # Backward-compat positional fields (stage_4_scoring.py reads these directly)
+    dfs_technologies: list[str] = field(default_factory=list)
+    gmb_categories: list[str] = field(default_factory=list)
+    scoring_weights: dict[str, int] = field(default_factory=dict)
     must_not_have_technologies: list[str] = field(default_factory=list)
+    # v6 new fields
+    weight: float = 1.0
+    problem_signals: list[dict] = field(default_factory=list)
+    budget_signals: list[dict] = field(default_factory=list)
+    not_served_signals: list[dict] = field(default_factory=list)
 
 
 @dataclass
 class SignalConfig:
+    """
+    v6: primary fields are `vertical` and `services`.
+    Backward-compat properties `vertical_slug` and `service_signals` are preserved
+    for all existing consumers.
+    """
+
     id: str
-    vertical_slug: str
-    display_name: str
-    description: str | None
-    service_signals: list[ServiceSignal]
+    vertical: str
+    services: list[ServiceSignal]
     discovery_config: dict[str, Any]
     enrichment_gates: dict[str, Any]
+    competitor_config: dict[str, Any]
     channel_config: dict[str, bool]
     created_at: Any
     updated_at: Any
 
+    # ── Backward-compat aliases ────────────────────────────────────────────────
+
+    @property
+    def vertical_slug(self) -> str:
+        """Backward compat: vertical_slug → vertical."""
+        return self.vertical
+
+    @property
+    def service_signals(self) -> list[ServiceSignal]:
+        """Backward compat: service_signals → services."""
+        return self.services
+
+    # ── Aggregate helpers ──────────────────────────────────────────────────────
+
     @property
     def all_dfs_technologies(self) -> list[str]:
-        """Flat deduplicated list of all DFS technologies across all service signals."""
+        """
+        Flat deduplicated list of DFS technology names for stage_1 discovery.
+        In v6 these are drawn from each service's dfs_technologies field
+        (which is populated from not_served_signals thresholds in _row_to_config).
+        """
         seen: set[str] = set()
         result: list[str] = []
-        for svc in self.service_signals:
+        for svc in self.services:
             for tech in svc.dfs_technologies:
                 if tech not in seen:
                     seen.add(tech)
@@ -51,15 +94,25 @@ class SignalConfig:
 
     @property
     def all_gmb_categories(self) -> list[str]:
-        """Flat deduplicated list of all GMB categories across all service signals."""
+        """Flat deduplicated list of GMB categories across all services."""
         seen: set[str] = set()
         result: list[str] = []
-        for svc in self.service_signals:
+        for svc in self.services:
             for cat in svc.gmb_categories:
                 if cat not in seen:
                     seen.add(cat)
                     result.append(cat)
         return result
+
+    # ── Enrichment gate properties ─────────────────────────────────────────────
+
+    @property
+    def min_score_to_qualify(self) -> int:
+        return int(self.enrichment_gates.get("min_score_to_qualify", 30))
+
+    @property
+    def min_score_to_compete(self) -> int:
+        return int(self.enrichment_gates.get("min_score_to_compete", 50))
 
     @property
     def min_score_to_enrich(self) -> int:
@@ -81,6 +134,9 @@ class VerticalNotFoundError(Exception):
 class SignalConfigRepository:
     """
     Async repository for reading signal_configurations from Supabase.
+    Supports both v5 (vertical_slug/service_signals columns) and
+    v6 (vertical/services columns) via graceful fallback in _row_to_config.
+
     Usage:
         repo = SignalConfigRepository(conn)
         config = await repo.get_config("marketing_agency")
@@ -89,47 +145,75 @@ class SignalConfigRepository:
     def __init__(self, conn: asyncpg.Connection) -> None:
         self._conn = conn
 
-    async def get_config(self, vertical_slug: str) -> SignalConfig:
+    async def get_config(self, vertical: str) -> SignalConfig:
         row = await self._conn.fetchrow(
-            "SELECT * FROM signal_configurations WHERE vertical_slug = $1",
-            vertical_slug,
+            "SELECT * FROM signal_configurations WHERE vertical = $1",
+            vertical,
         )
         if row is None:
-            raise VerticalNotFoundError(f"No signal config found for vertical: {vertical_slug!r}")
+            raise VerticalNotFoundError(f"No signal config found for vertical: {vertical!r}")
         return self._row_to_config(row)
 
     async def list_verticals(self) -> list[str]:
         rows = await self._conn.fetch(
-            "SELECT vertical_slug FROM signal_configurations ORDER BY vertical_slug"
+            "SELECT vertical FROM signal_configurations ORDER BY vertical"
         )
-        return [row["vertical_slug"] for row in rows]
+        return [row["vertical"] for row in rows]
 
-    async def get_services_for_vertical(self, vertical_slug: str) -> list[ServiceSignal]:
-        config = await self.get_config(vertical_slug)
-        return config.service_signals
+    async def get_services_for_vertical(self, vertical: str) -> list[ServiceSignal]:
+        config = await self.get_config(vertical)
+        return config.services
 
     @staticmethod
     def _row_to_config(row: asyncpg.Record) -> SignalConfig:
-        service_signals = [
-            ServiceSignal(
-                service_name=svc["service_name"],
-                label=svc.get("label", svc["service_name"]),
-                dfs_technologies=svc.get("dfs_technologies", []),
+        """
+        Map a DB row to SignalConfig.
+        Handles v6 columns (vertical, services) with fallback to v5 names
+        (vertical_slug, service_signals) for mock compatibility.
+        """
+        # v6 primary column names with v5 fallback
+        vertical = row.get("vertical") or row.get("vertical_slug") or ""
+
+        raw_services = row.get("services") or row.get("service_signals") or []
+
+        services = []
+        for svc in raw_services:
+            # v6 uses service_key/display_name; v5 used service_name/label
+            service_name = svc.get("service_key") or svc.get("service_name", "")
+            label = svc.get("display_name") or svc.get("label", service_name)
+
+            # dfs_technologies: use explicit field if present (v5 compat),
+            # otherwise derive from not_served_signals threshold lists
+            explicit_techs: list[str] = svc.get("dfs_technologies", [])
+            if not explicit_techs:
+                for sig in svc.get("not_served_signals", []):
+                    if sig.get("field") == "tech_stack" and sig.get("operator") == "missing":
+                        t = sig.get("threshold", [])
+                        if isinstance(t, list):
+                            explicit_techs = t
+                            break
+
+            services.append(ServiceSignal(
+                service_name=service_name,
+                label=label,
+                dfs_technologies=explicit_techs,
                 gmb_categories=svc.get("gmb_categories", []),
                 scoring_weights=svc.get("scoring_weights", {}),
                 must_not_have_technologies=svc.get("must_not_have_technologies", []),
-            )
-            for svc in (row["service_signals"] or [])
-        ]
+                weight=float(svc.get("weight", 1.0)),
+                problem_signals=svc.get("problem_signals", []),
+                budget_signals=svc.get("budget_signals", []),
+                not_served_signals=svc.get("not_served_signals", []),
+            ))
+
         return SignalConfig(
             id=str(row["id"]),
-            vertical_slug=row["vertical_slug"],
-            display_name=row["display_name"],
-            description=row["description"],
-            service_signals=service_signals,
-            discovery_config=dict(row["discovery_config"] or {}),
-            enrichment_gates=dict(row["enrichment_gates"] or {}),
-            channel_config=dict(row["channel_config"] or {}),
+            vertical=vertical,
+            services=services,
+            discovery_config=dict(row.get("discovery_config") or {}),
+            enrichment_gates=dict(row.get("enrichment_gates") or {}),
+            competitor_config=dict(row.get("competitor_config") or {}),
+            channel_config=dict(row.get("channel_config") or {}),
             created_at=row["created_at"],
             updated_at=row["updated_at"],
         )

--- a/tests/test_signal_config.py
+++ b/tests/test_signal_config.py
@@ -51,7 +51,7 @@ async def test_get_config_returns_valid_structure():
     config = await repo.get_config("marketing_agency")
     assert isinstance(config, SignalConfig)
     assert config.vertical_slug == "marketing_agency"
-    assert config.display_name == "Marketing Agency"
+    assert config.vertical == "marketing_agency"
     assert len(config.service_signals) == 1
     assert isinstance(config.service_signals[0], ServiceSignal)
 
@@ -69,7 +69,7 @@ async def test_get_config_missing_vertical_raises():
 async def test_list_verticals_includes_marketing_agency():
     conn = AsyncMock()
     row = MagicMock()
-    row.__getitem__ = lambda self, k: "marketing_agency" if k == "vertical_slug" else None
+    row.__getitem__ = lambda self, k: "marketing_agency" if k == "vertical" else None
     conn.fetch.return_value = [row]
     repo = SignalConfigRepository(conn)
     verticals = await repo.list_verticals()
@@ -110,12 +110,11 @@ def test_enrichment_gate_defaults():
     import uuid, datetime
     config = SignalConfig(
         id=str(uuid.uuid4()),
-        vertical_slug="test",
-        display_name="Test",
-        description=None,
-        service_signals=[],
+        vertical="test",
+        services=[],
         discovery_config={},
         enrichment_gates={"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        competitor_config={},
         channel_config={},
         created_at=datetime.datetime.now(),
         updated_at=datetime.datetime.now(),

--- a/tests/test_stage_1_discovery.py
+++ b/tests/test_stage_1_discovery.py
@@ -25,12 +25,11 @@ def make_signal_config(technologies: list[str] | None = None):
     ]
     return SignalConfig(
         id=str(uuid.uuid4()),
-        vertical_slug="marketing_agency",
-        display_name="Marketing Agency",
-        description="Test",
-        service_signals=services,
+        vertical="marketing_agency",
+        services=services,
         discovery_config={},
         enrichment_gates={"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        competitor_config={},
         channel_config={"email": True, "linkedin": True, "voice": True, "sms": False},
         created_at=datetime.now(),
         updated_at=datetime.now(),
@@ -153,8 +152,8 @@ async def test_deduplicates_technologies_across_services():
         ServiceSignal("svc2", "S2", ["Google Ads", "HubSpot"], [], {}),
     ]
     config = SignalConfig(
-        id=str(uuid.uuid4()), vertical_slug="test", display_name="T", description=None,
-        service_signals=services, discovery_config={}, enrichment_gates={}, channel_config={},
+        id=str(uuid.uuid4()), vertical="test",
+        services=services, discovery_config={}, enrichment_gates={}, competitor_config={}, channel_config={},
         created_at=datetime.now(), updated_at=datetime.now(),
     )
     techs = config.all_dfs_technologies

--- a/tests/test_stage_3_dfs_profile.py
+++ b/tests/test_stage_3_dfs_profile.py
@@ -22,12 +22,11 @@ def make_signal_config(technologies: list[str] = None):
     ]
     return SignalConfig(
         id=str(uuid.uuid4()),
-        vertical_slug="marketing_agency",
-        display_name="Marketing Agency",
-        description=None,
-        service_signals=services,
+        vertical="marketing_agency",
+        services=services,
         discovery_config={},
         enrichment_gates={},
+        competitor_config={},
         channel_config={},
         created_at=datetime.now(),
         updated_at=datetime.now(),

--- a/tests/test_stage_4_scoring.py
+++ b/tests/test_stage_4_scoring.py
@@ -23,12 +23,11 @@ def make_config(services=None):
     import uuid
     return SignalConfig(
         id=str(uuid.uuid4()),
-        vertical_slug="marketing_agency",
-        display_name="Marketing Agency",
-        description=None,
-        service_signals=services or [make_service()],
+        vertical="marketing_agency",
+        services=services or [make_service()],
         discovery_config={},
         enrichment_gates={"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        competitor_config={},
         channel_config={},
         created_at=datetime.now(),
         updated_at=datetime.now(),

--- a/tests/test_stage_5_dm_waterfall.py
+++ b/tests/test_stage_5_dm_waterfall.py
@@ -16,11 +16,11 @@ from src.enrichment.signal_config import SignalConfig, ServiceSignal
 def make_config():
     import uuid
     return SignalConfig(
-        id=str(uuid.uuid4()), vertical_slug="marketing_agency",
-        display_name="MktAgency", description=None,
-        service_signals=[ServiceSignal("paid_ads", "Paid Ads", ["Google Ads"], [], {})],
+        id=str(uuid.uuid4()), vertical="marketing_agency",
+        services=[ServiceSignal("paid_ads", "Paid Ads", ["Google Ads"], [], {})],
         discovery_config={},
         enrichment_gates={"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        competitor_config={},
         channel_config={},
         created_at=datetime.now(), updated_at=datetime.now(),
     )

--- a/tests/test_stage_6_reachability.py
+++ b/tests/test_stage_6_reachability.py
@@ -13,11 +13,11 @@ from src.enrichment.signal_config import SignalConfig, ServiceSignal
 def make_config(channel_config=None):
     import uuid
     return SignalConfig(
-        id=str(uuid.uuid4()), vertical_slug="marketing_agency",
-        display_name="MktAgency", description=None,
-        service_signals=[],
+        id=str(uuid.uuid4()), vertical="marketing_agency",
+        services=[],
         discovery_config={},
         enrichment_gates={"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        competitor_config={},
         channel_config=channel_config or {"email": True, "linkedin": True, "voice": True, "sms": False},
         created_at=datetime.now(), updated_at=datetime.now(),
     )

--- a/tests/test_stage_7_haiku.py
+++ b/tests/test_stage_7_haiku.py
@@ -20,11 +20,11 @@ AGENCY_PROFILE = {
 def make_config():
     import uuid
     return SignalConfig(
-        id=str(uuid.uuid4()), vertical_slug="marketing_agency",
-        display_name="MktAgency", description=None,
-        service_signals=[],
+        id=str(uuid.uuid4()), vertical="marketing_agency",
+        services=[],
         discovery_config={},
         enrichment_gates={"min_score_to_enrich": 30, "min_score_to_dm": 50, "min_score_to_outreach": 65},
+        competitor_config={},
         channel_config={"email": True, "linkedin": True, "voice": True, "sms": False},
         created_at=datetime.now(), updated_at=datetime.now(),
     )


### PR DESCRIPTION
## Summary
Migration 029: DROP and recreate signal_configurations with v6 schema.

## Changes
- `migrations/029_signal_configurations_v6.sql`: DROP old table (CASCADE), CREATE v6 schema (`vertical varchar(100)`, `services jsonb`, `competitor_config jsonb`), seed `marketing_agency` with 6 services (paid_ads, seo, social_media_marketing, web_design, marketing_automation, content_marketing) — each with problem/budget/not_served signals and DFS-backed thresholds
- `src/enrichment/signal_config.py`: Updated model to v6 — `vertical`/`services`/`competitor_config` as primary fields, backward-compat properties `vertical_slug` and `service_signals` preserved, `ServiceSignal` gains `weight` + `problem_signals`/`budget_signals`/`not_served_signals` fields, `_row_to_config` handles both v5/v6 column names, new `min_score_to_qualify`/`min_score_to_compete` gate properties
- `tests/`: Updated 7 test files to use v6 `SignalConfig` constructor kwargs; `ServiceSignal` positional compat preserved by maintaining old field order

## BUG-268-1
No unnest(jsonb) instances found in pipeline code. `stage_1_discovery.py` already uses `jsonb_array_elements_text()` — fixed in prior PR #233.

## DFS v2 Audit
PASS — all DFS calls use /v3/ endpoints. No blockers for #272.

## Test Results
2 failed (pre-existing test_dfs_serp_client.py failures, unrelated), 1009 passed, 28 skipped

## Verification
```
vertical=marketing_agency, service_count=6
```