### PR TITLE
Directive #272: Layer 2 Discovery Engine

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -23,8 +23,8 @@ Revenue model for BU: API subscriptions, Salesforce/HubSpot marketplace, bulk an
 
 ## SECTION 2 — CURRENT STATE
 
-- Last directive issued: #270 (Manual trim)
-- Next directive: #271 (signal config schema redesign)
+- Last directive issued: #272 (Layer 2 Discovery Engine — IN PROGRESS)
+- Next directive: #273 (Layer 3 cheap filter)
 - Test baseline: 1009 passed, 2 failed (pre-existing DFS serp client tests), 28 skipped
 - Last merged PRs: #233 (dedup + blocklist), #232 (bug fixes), #231 (live test v2), #230 (stages 6+7)
 - Architecture: **v6 ratified Mar 27 2026** — spend + gaps + fit discovery (10-layer engine)
@@ -76,6 +76,16 @@ Output: their SERP competitors. Network expansion — one good prospect generate
 
 All results deduped against BU + agency exclusion list.
 Output: raw domains into BU, pipeline_stage = 1.
+
+**Layer 2 implementation (Directive #272 — IN PROGRESS):**
+- Class: `src/pipeline/layer_2_discovery.py` → `Layer2Discovery`
+- 5 sources run concurrently via asyncio.gather (source failure does not abort run)
+- New DFS endpoints added to `dfs_labs_client.py`: `domain_metrics_by_categories`, `google_ads_advertisers`, `domains_by_html_terms`, `google_jobs_advertisers`
+- Rate limiting: configurable `daily_budget_usd` (default $10.0) — stops when budget would be exceeded
+- Idempotency: skips existing BU rows by domain/place_id
+- Migration 030: adds `discovery_batch_id uuid`, `no_domain boolean`, `dfs_discovery_category text`, `dfs_discovery_keyword text`
+- Cost per run: ~$0.47 (marketing_agency, all 5 sources) → expected 500–2,000 raw domains
+- Note: uses DFS Labs/SERP endpoints per v6 spec — NOT DFS GMaps coordinate sweep (v4/v5 pattern)
 
 ---
 
@@ -457,7 +467,7 @@ v5 era (#247–#270): all 7 pipeline stages built, tested, and live on main. Sup
 | Directive | What | Status |
 |-----------|------|--------|
 | #271 | Signal config schema redesign (services + competitor_config + discovery_config) | Next |
-| #272 | Layer 2 discovery engine (multi-source: Categories, Ads Search, HTML Terms, Jobs, Competitors) | Queued |
+| #272 | Layer 2 discovery engine (multi-source: Categories, Ads Search, HTML Terms, Jobs, Competitors) | IN PROGRESS |
 | #273 | Layer 3 cheap filter + Bulk Domain Metrics client | Queued |
 | #274 | Layer 4 qualification (Domain Technologies + Rank Overview + Historical Rank) | Queued |
 | #275 | Layer 5 fit scoring (multi-service, per-service problem/budget/gap scoring) | Queued |

--- a/migrations/030_layer2_discovery_columns.sql
+++ b/migrations/030_layer2_discovery_columns.sql
@@ -1,0 +1,12 @@
+-- Migration 030: Layer 2 discovery columns
+-- Directive #272
+ALTER TABLE business_universe
+  ADD COLUMN IF NOT EXISTS discovery_batch_id uuid,
+  ADD COLUMN IF NOT EXISTS no_domain boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS dfs_discovery_category text,
+  ADD COLUMN IF NOT EXISTS dfs_discovery_keyword text;
+
+CREATE INDEX IF NOT EXISTS idx_bu_discovery_batch ON business_universe(discovery_batch_id)
+  WHERE discovery_batch_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_bu_no_domain ON business_universe(no_domain)
+  WHERE no_domain = true;

--- a/src/clients/dfs_labs_client.py
+++ b/src/clients/dfs_labs_client.py
@@ -80,6 +80,11 @@ class DFSLabsClient:
         self._cost_domain_technologies = Decimal("0")
         self._cost_keywords_for_site = Decimal("0")
         self._cost_historical_rank_overview = Decimal("0")
+        # Layer 2 discovery endpoints (Directive #272)
+        self._cost_domain_metrics_by_categories = Decimal("0")
+        self._cost_google_ads_advertisers = Decimal("0")
+        self._cost_domains_by_html_terms = Decimal("0")
+        self._cost_google_jobs_advertisers = Decimal("0")
 
         # Cache for get_categories (free, rarely changes)
         self._categories_cache: list[dict] | None = None
@@ -113,6 +118,10 @@ class DFSLabsClient:
             + self._cost_domain_technologies
             + self._cost_keywords_for_site
             + self._cost_historical_rank_overview
+            + self._cost_domain_metrics_by_categories
+            + self._cost_google_ads_advertisers
+            + self._cost_domains_by_html_terms
+            + self._cost_google_jobs_advertisers
         )
         return float(total)
 
@@ -126,6 +135,10 @@ class DFSLabsClient:
             + self._cost_domain_technologies
             + self._cost_keywords_for_site
             + self._cost_historical_rank_overview
+            + self._cost_domain_metrics_by_categories
+            + self._cost_google_ads_advertisers
+            + self._cost_domains_by_html_terms
+            + self._cost_google_jobs_advertisers
         )
         return float(total_usd * AUD_RATE)
 
@@ -604,6 +617,165 @@ class DFSLabsClient:
                 for item in items
             ]
         }
+
+    # ============================================
+    # ENDPOINT 8: domain_metrics_by_categories  (Directive #272 — Layer 2)
+    # ============================================
+
+    async def domain_metrics_by_categories(
+        self,
+        category_codes: list[int],
+        location_name: str = "Australia",
+        paid_etv_min: float = 0.0,
+    ) -> list[dict]:
+        """
+        Discover domains with Google Ads spend in specified categories.
+        Uses location_name (NOT location_code — causes 40501 error per DFS gotcha).
+        Cost: ~$0.10/call.
+        Returns list of {"domain": str, "paid_etv": float, "organic_etv": float}.
+        TODO: verify exact payload format against DFS API docs before live run.
+        """
+        result = await self._post(
+            endpoint="/v3/dataforseo_labs/google/domain_metrics_by_categories/live",
+            payload=[{
+                "category_codes": category_codes,
+                "location_name": location_name,
+                "language_name": "English",
+                "filters": [["metrics.organic.etv", ">", 0]],
+            }],
+            cost_per_call=Decimal("0.10"),
+            cost_attr="_cost_domain_metrics_by_categories",
+        )
+        items = result.get("items") or []
+        results = []
+        for item in items:
+            metrics = item.get("metrics", {})
+            paid_etv = (metrics.get("paid") or {}).get("etv", 0) or 0
+            organic_etv = (metrics.get("organic") or {}).get("etv", 0) or 0
+            if paid_etv >= paid_etv_min:
+                domain = item.get("domain") or item.get("target")
+                if domain:
+                    results.append({"domain": domain, "paid_etv": paid_etv, "organic_etv": organic_etv})
+        return results
+
+    # ============================================
+    # ENDPOINT 9: google_ads_advertisers  (Directive #272 — Layer 2)
+    # ============================================
+
+    async def google_ads_advertisers(
+        self,
+        keyword: str,
+        location_name: str = "Australia",
+    ) -> list[dict]:
+        """
+        Find domains currently bidding on a keyword via Google Ads SERP.
+        Cost: ~$0.006/call.
+        Returns list of {"domain": str, "title": str, "url": str}.
+        TODO: verify payload format against DFS API docs before live run.
+        """
+        from urllib.parse import urlparse
+        result = await self._post(
+            endpoint="/v3/serp/google/ads/live/advanced",
+            payload=[{
+                "keyword": keyword,
+                "location_name": location_name,
+                "language_name": "English",
+                "depth": 100,
+            }],
+            cost_per_call=Decimal("0.006"),
+            cost_attr="_cost_google_ads_advertisers",
+        )
+        items = result.get("items") or []
+        results = []
+        for item in items:
+            url = item.get("url") or item.get("domain")
+            if not url:
+                continue
+            parsed = urlparse(url)
+            domain = parsed.netloc or url
+            if domain.startswith("www."):
+                domain = domain[4:]
+            results.append({
+                "domain": domain.lower().rstrip("/"),
+                "title": item.get("title", ""),
+                "url": url,
+            })
+        return results
+
+    # ============================================
+    # ENDPOINT 10: domains_by_html_terms  (Directive #272 — Layer 2)
+    # ============================================
+
+    async def domains_by_html_terms(
+        self,
+        include_term: str,
+        exclude_term: str | None = None,
+        location_name: str = "Australia",
+    ) -> list[dict]:
+        """
+        Find domains that contain include_term but NOT exclude_term in their HTML.
+        Cost: ~$0.01/call.
+        Returns list of {"domain": str}.
+        TODO: verify payload format against DFS API docs before live run.
+        """
+        payload_item: dict = {
+            "include": [include_term],
+            "location_name": location_name,
+            "language_name": "English",
+            "limit": 100,
+        }
+        if exclude_term:
+            payload_item["exclude"] = [exclude_term]
+
+        result = await self._post(
+            endpoint="/v3/domain_analytics/technologies/domains_by_html_terms/live",
+            payload=[payload_item],
+            cost_per_call=Decimal("0.01"),
+            cost_attr="_cost_domains_by_html_terms",
+        )
+        items = result.get("items") or []
+        return [{"domain": item["domain"]} for item in items if item.get("domain")]
+
+    # ============================================
+    # ENDPOINT 11: google_jobs_advertisers  (Directive #272 — Layer 2)
+    # ============================================
+
+    async def google_jobs_advertisers(
+        self,
+        keyword: str,
+        location_name: str = "Australia",
+    ) -> list[dict]:
+        """
+        Find employers posting jobs for a keyword (growth signal — they have budget).
+        Cost: ~$0.006/call.
+        Returns list of {"domain": str, "employer_name": str}.
+        TODO: verify payload format against DFS API docs before live run.
+        """
+        from urllib.parse import urlparse
+        result = await self._post(
+            endpoint="/v3/serp/google/jobs/live/advanced",
+            payload=[{
+                "keyword": keyword,
+                "location_name": location_name,
+                "language_name": "English",
+                "depth": 100,
+            }],
+            cost_per_call=Decimal("0.006"),
+            cost_attr="_cost_google_jobs_advertisers",
+        )
+        items = result.get("items") or []
+        results = []
+        for item in items:
+            url = item.get("url") or item.get("apply_link") or ""
+            employer = item.get("employer_name") or item.get("company") or ""
+            if not url and not employer:
+                continue
+            domain = ""
+            if url:
+                parsed = urlparse(url)
+                domain = (parsed.netloc or "").lstrip("www.").lower().rstrip("/")
+            results.append({"domain": domain, "employer_name": employer})
+        return [r for r in results if r["domain"]]
 
     # ============================================
     # Utility

--- a/src/pipeline/layer_2_discovery.py
+++ b/src/pipeline/layer_2_discovery.py
@@ -1,0 +1,331 @@
+"""
+Contract: src/pipeline/layer_2_discovery.py
+Purpose: Layer 2 multi-source domain discovery engine — reads signal_configurations.discovery_config,
+         runs 5 DFS sources concurrently, deduplicates by domain, writes to business_universe.
+Layer: 4 - orchestration (uses asyncpg connection directly like stage_1_discovery)
+Imports: clients, enrichment, utils
+Consumers: orchestration flows
+Directive: #272
+
+v6 design: discovers broadly (all 5 sources), deduplicates, passes to Layer 3
+for cheap filtering. No scoring here — pure discovery.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+import asyncpg
+
+from src.clients.dfs_labs_client import DFSLabsClient, get_dfs_labs_client
+from src.enrichment.signal_config import SignalConfig, SignalConfigRepository
+from src.utils.domain_blocklist import is_blocked
+
+logger = logging.getLogger(__name__)
+
+# Cost per source call (USD)
+COST_DOMAIN_METRICS_BY_CATEGORIES = 0.10
+COST_ADS_SEARCH = 0.006
+COST_HTML_TERMS = 0.01
+COST_JOBS = 0.006
+COST_COMPETITORS_DOMAIN = 0.01
+
+
+@dataclass
+class DiscoveryStats:
+    total_raw: int = 0
+    unique_domains: int = 0
+    written_new: int = 0
+    written_skip: int = 0  # existing domain, skipped (idempotency)
+    no_domain_count: int = 0
+    blocked_count: int = 0
+    sources_used: list[str] = field(default_factory=list)
+    source_errors: list[str] = field(default_factory=list)
+    estimated_cost_usd: float = 0.0
+    budget_exceeded: bool = False
+
+
+def _normalise_domain(url_or_domain: str) -> str:
+    """Strip www., trailing slash, lowercase. Handle both URLs and bare domains."""
+    s = url_or_domain.strip().lower()
+    if s.startswith(("http://", "https://")):
+        parsed = urlparse(s)
+        s = parsed.netloc or s
+    s = s.lstrip("www.").rstrip("/")
+    return s
+
+
+class Layer2Discovery:
+    """
+    Layer 2 of the v6 pipeline: multi-source domain discovery.
+
+    Reads discovery_config from signal_configurations, runs 5 DFS sources
+    concurrently, deduplicates, filters blocklist, and writes to business_universe.
+
+    Usage:
+        engine = Layer2Discovery(conn, dfs_client)
+        stats = await engine.run("marketing_agency", daily_budget_usd=10.0)
+    """
+
+    def __init__(
+        self,
+        conn: asyncpg.Connection,
+        dfs: DFSLabsClient,
+    ) -> None:
+        self._conn = conn
+        self._dfs = dfs
+
+    async def run(
+        self,
+        vertical: str,
+        batch_id: uuid.UUID | None = None,
+        daily_budget_usd: float = 10.0,
+    ) -> DiscoveryStats:
+        """
+        Run full Layer 2 discovery for a vertical.
+
+        Args:
+            vertical: Vertical slug (e.g. "marketing_agency")
+            batch_id: Optional batch UUID for tracking. Generated if not provided.
+            daily_budget_usd: Stop discovery if accumulated cost would exceed this.
+
+        Returns:
+            DiscoveryStats with counts and cost estimate.
+        """
+        stats = DiscoveryStats()
+        batch_id = batch_id or uuid.uuid4()
+
+        # Load signal config
+        config = await SignalConfigRepository(self._conn).get_config(vertical)
+        discovery_cfg = config.discovery_config
+
+        # Run all sources concurrently
+        source_results = await self._run_all_sources(
+            discovery_cfg, stats, daily_budget_usd
+        )
+
+        # Merge + deduplicate by domain
+        seen_domains: dict[str, dict] = {}
+        for item in source_results:
+            domain = _normalise_domain(item.get("domain", ""))
+            if not domain:
+                stats.no_domain_count += 1
+                continue
+            if domain not in seen_domains:
+                seen_domains[domain] = item
+
+        stats.total_raw = len(source_results)
+        stats.unique_domains = len(seen_domains)
+
+        # Filter blocklist
+        clean: dict[str, dict] = {}
+        for domain, item in seen_domains.items():
+            if is_blocked(domain):
+                stats.blocked_count += 1
+            else:
+                clean[domain] = item
+
+        # Write to BU
+        for domain, item in clean.items():
+            written = await self._upsert_domain(
+                domain=domain,
+                item=item,
+                batch_id=batch_id,
+            )
+            if written:
+                stats.written_new += 1
+            else:
+                stats.written_skip += 1
+
+        logger.info(
+            f"Layer2 [{vertical}] batch={batch_id}: "
+            f"raw={stats.total_raw} unique={stats.unique_domains} "
+            f"new={stats.written_new} skip={stats.written_skip} "
+            f"blocked={stats.blocked_count} cost≈${stats.estimated_cost_usd:.3f}"
+        )
+        return stats
+
+    async def _run_all_sources(
+        self,
+        cfg: dict,
+        stats: DiscoveryStats,
+        daily_budget_usd: float,
+    ) -> list[dict]:
+        """Run all 5 sources concurrently. Individual failures are caught and logged."""
+        accumulated_cost = 0.0
+
+        async def source_a() -> list[dict]:
+            nonlocal accumulated_cost
+            codes = cfg.get("category_codes", [])
+            threshold = float(cfg.get("ad_spend_threshold", 0))
+            if not codes:
+                return []
+            cost = COST_DOMAIN_METRICS_BY_CATEGORIES * len(codes)
+            if accumulated_cost + cost > daily_budget_usd:
+                logger.warning(f"Layer2 budget cap hit before source_a (would cost ${cost:.2f})")
+                stats.budget_exceeded = True
+                return []
+            results = await self._dfs.domain_metrics_by_categories(
+                category_codes=codes,
+                paid_etv_min=threshold,
+            )
+            accumulated_cost += cost
+            stats.estimated_cost_usd += cost
+            stats.sources_used.append("domain_metrics_by_categories")
+            return [{"domain": r["domain"], "dfs_paid_etv": r["paid_etv"]} for r in results]
+
+        async def source_b() -> list[dict]:
+            nonlocal accumulated_cost
+            keywords = cfg.get("keywords_for_ads_search", [])
+            if not keywords:
+                return []
+            cost = COST_ADS_SEARCH * len(keywords)
+            if accumulated_cost + cost > daily_budget_usd:
+                logger.warning("Layer2 budget cap hit before source_b")
+                stats.budget_exceeded = True
+                return []
+            all_results = []
+            for kw in keywords:
+                results = await self._dfs.google_ads_advertisers(keyword=kw)
+                all_results.extend([{"domain": r["domain"], "dfs_discovery_keyword": kw} for r in results])
+            accumulated_cost += cost
+            stats.estimated_cost_usd += cost
+            stats.sources_used.append("google_ads_advertisers")
+            return all_results
+
+        async def source_c() -> list[dict]:
+            nonlocal accumulated_cost
+            combos = cfg.get("html_gap_combos", [])
+            if not combos:
+                return []
+            cost = COST_HTML_TERMS * len(combos)
+            if accumulated_cost + cost > daily_budget_usd:
+                logger.warning("Layer2 budget cap hit before source_c")
+                stats.budget_exceeded = True
+                return []
+            all_results = []
+            for combo in combos:
+                results = await self._dfs.domains_by_html_terms(
+                    include_term=combo.get("has", ""),
+                    exclude_term=combo.get("missing"),
+                )
+                all_results.extend([{"domain": r["domain"]} for r in results])
+            accumulated_cost += cost
+            stats.estimated_cost_usd += cost
+            stats.sources_used.append("domains_by_html_terms")
+            return all_results
+
+        async def source_d() -> list[dict]:
+            nonlocal accumulated_cost
+            keywords = cfg.get("job_search_keywords", [])
+            if not keywords:
+                return []
+            cost = COST_JOBS * len(keywords)
+            if accumulated_cost + cost > daily_budget_usd:
+                logger.warning("Layer2 budget cap hit before source_d")
+                stats.budget_exceeded = True
+                return []
+            all_results = []
+            for kw in keywords:
+                results = await self._dfs.google_jobs_advertisers(keyword=kw)
+                all_results.extend([{"domain": r["domain"], "dfs_discovery_keyword": kw} for r in results])
+            accumulated_cost += cost
+            stats.estimated_cost_usd += cost
+            stats.sources_used.append("google_jobs_advertisers")
+            return all_results
+
+        async def source_e() -> list[dict]:
+            nonlocal accumulated_cost
+            if not cfg.get("competitor_expansion", False):
+                return []
+            # Get top BU domains from prior runs (pipeline_stage>=4, propensity>=50)
+            prior_rows = await self._conn.fetch(
+                "SELECT domain FROM business_universe "
+                "WHERE pipeline_stage >= 4 AND propensity_score >= 50 "
+                "AND domain IS NOT NULL LIMIT 20"
+            )
+            if not prior_rows:
+                logger.info("Layer2 source_e: no prior BU data, skipping competitor expansion")
+                return []
+            cost = COST_COMPETITORS_DOMAIN * len(prior_rows)
+            if accumulated_cost + cost > daily_budget_usd:
+                logger.warning("Layer2 budget cap hit before source_e")
+                stats.budget_exceeded = True
+                return []
+            all_results = []
+            for row in prior_rows:
+                competitors_result = await self._dfs.competitors_domain(target_domain=row["domain"])
+                # competitors_domain returns {"items": [...]} not a plain list
+                competitor_items = competitors_result.get("items", []) if isinstance(competitors_result, dict) else []
+                all_results.extend([
+                    {"domain": c.get("domain", "")}
+                    for c in competitor_items
+                    if c.get("domain")
+                ])
+            accumulated_cost += cost
+            stats.estimated_cost_usd += cost
+            stats.sources_used.append("competitors_domain")
+            return all_results
+
+        # Wrap each source to catch errors individually
+        async def safe(coro_fn, name: str) -> list[dict]:
+            try:
+                return await coro_fn()
+            except Exception as exc:
+                logger.error(f"Layer2 source {name} failed: {exc}")
+                stats.source_errors.append(f"{name}: {exc}")
+                return []
+
+        results = await asyncio.gather(
+            safe(source_a, "source_a"),
+            safe(source_b, "source_b"),
+            safe(source_c, "source_c"),
+            safe(source_d, "source_d"),
+            safe(source_e, "source_e"),
+        )
+        return [item for sublist in results for item in sublist]
+
+    async def _upsert_domain(
+        self,
+        domain: str,
+        item: dict,
+        batch_id: uuid.UUID,
+    ) -> bool:
+        """
+        Insert domain into business_universe. Skip if domain already exists (idempotency).
+        Returns True if new row written, False if skipped.
+        """
+        # Idempotency: check if domain already exists
+        existing = await self._conn.fetchval(
+            "SELECT id FROM business_universe WHERE domain = $1 LIMIT 1",
+            domain,
+        )
+        if existing is not None:
+            return False  # skip — already in BU
+
+        await self._conn.execute(
+            """
+            INSERT INTO business_universe (
+                domain,
+                display_name,
+                dfs_discovery_sources,
+                discovery_batch_id,
+                discovered_at,
+                pipeline_stage,
+                no_domain,
+                dfs_discovery_keyword
+            ) VALUES ($1, $2, $3, $4, NOW(), 1, false, $5)
+            ON CONFLICT (domain) WHERE domain IS NOT NULL AND domain <> ''
+            DO NOTHING
+            """,
+            domain,
+            item.get("display_name") or item.get("employer_name"),
+            ["layer2"],
+            batch_id,
+            item.get("dfs_discovery_keyword"),
+        )
+        return True

--- a/tests/test_layer_2_discovery.py
+++ b/tests/test_layer_2_discovery.py
@@ -1,0 +1,320 @@
+"""Tests for Layer2Discovery — Directive #272"""
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.enrichment.signal_config import ServiceSignal, SignalConfig
+from src.pipeline.layer_2_discovery import (
+    DiscoveryStats,
+    Layer2Discovery,
+    _normalise_domain,
+)
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def make_signal_config(discovery_config: dict | None = None) -> SignalConfig:
+    """Build a minimal SignalConfig with given discovery_config."""
+    return SignalConfig(
+        id=str(uuid.uuid4()),
+        vertical="marketing_agency",
+        services=[
+            ServiceSignal(
+                service_name="paid_ads",
+                label="Paid Ads",
+                dfs_technologies=["Google Ads"],
+                gmb_categories=["marketing_agency"],
+                scoring_weights={},
+            )
+        ],
+        discovery_config=discovery_config or {},
+        enrichment_gates={},
+        competitor_config={},
+        channel_config={"email": True},
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+def make_conn(domain_exists: bool = False) -> MagicMock:
+    """
+    Build a mock asyncpg connection.
+    - fetchval: returns a UUID string if domain_exists else None
+    - fetch: returns [] by default (no prior BU rows for source_e)
+    - execute: no-op
+    """
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=str(uuid.uuid4()) if domain_exists else None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock(return_value=None)
+    return conn
+
+
+def make_dfs() -> MagicMock:
+    """Build a mock DFSLabsClient with all Layer 2 methods returning empty lists."""
+    dfs = MagicMock()
+    dfs.domain_metrics_by_categories = AsyncMock(return_value=[])
+    dfs.google_ads_advertisers = AsyncMock(return_value=[])
+    dfs.domains_by_html_terms = AsyncMock(return_value=[])
+    dfs.google_jobs_advertisers = AsyncMock(return_value=[])
+    dfs.competitors_domain = AsyncMock(return_value={"items": []})
+    return dfs
+
+
+def make_engine(
+    discovery_config: dict | None = None,
+    domain_exists: bool = False,
+    dfs: MagicMock | None = None,
+) -> tuple[Layer2Discovery, MagicMock, MagicMock]:
+    """Assemble Layer2Discovery with mocked dependencies."""
+    conn = make_conn(domain_exists=domain_exists)
+    dfs_client = dfs or make_dfs()
+    engine = Layer2Discovery(conn=conn, dfs=dfs_client)
+    return engine, conn, dfs_client
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reads_signal_config_for_vertical():
+    """run() calls SignalConfigRepository.get_config with the correct vertical slug."""
+    engine, conn, dfs = make_engine()
+    config = make_signal_config()
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        await engine.run("marketing_agency")
+        MockRepo.return_value.get_config.assert_called_once_with("marketing_agency")
+
+
+@pytest.mark.asyncio
+async def test_source_a_calls_domain_metrics_with_category_codes():
+    """source_a calls domain_metrics_by_categories with codes from discovery_config."""
+    cfg = {"category_codes": [10233, 10234], "ad_spend_threshold": 100.0}
+    engine, conn, dfs = make_engine(discovery_config=cfg)
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        await engine.run("marketing_agency", daily_budget_usd=100.0)
+
+    dfs.domain_metrics_by_categories.assert_called_once_with(
+        category_codes=[10233, 10234],
+        paid_etv_min=100.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_source_b_calls_ads_search_per_keyword():
+    """source_b calls google_ads_advertisers once per keyword in keywords_for_ads_search."""
+    cfg = {"keywords_for_ads_search": ["digital marketing", "seo agency"]}
+    engine, conn, dfs = make_engine(discovery_config=cfg)
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        await engine.run("marketing_agency", daily_budget_usd=100.0)
+
+    assert dfs.google_ads_advertisers.call_count == 2
+    calls = [c.kwargs["keyword"] for c in dfs.google_ads_advertisers.call_args_list]
+    assert "digital marketing" in calls
+    assert "seo agency" in calls
+
+
+@pytest.mark.asyncio
+async def test_source_c_calls_html_terms_per_combo():
+    """source_c calls domains_by_html_terms once per html_gap_combo entry."""
+    cfg = {
+        "html_gap_combos": [
+            {"has": "Google Analytics", "missing": "HubSpot"},
+            {"has": "Facebook Pixel"},
+        ]
+    }
+    engine, conn, dfs = make_engine(discovery_config=cfg)
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        await engine.run("marketing_agency", daily_budget_usd=100.0)
+
+    assert dfs.domains_by_html_terms.call_count == 2
+    first_call = dfs.domains_by_html_terms.call_args_list[0]
+    assert first_call.kwargs["include_term"] == "Google Analytics"
+    assert first_call.kwargs["exclude_term"] == "HubSpot"
+    second_call = dfs.domains_by_html_terms.call_args_list[1]
+    assert second_call.kwargs["include_term"] == "Facebook Pixel"
+    assert second_call.kwargs.get("exclude_term") is None
+
+
+@pytest.mark.asyncio
+async def test_source_d_calls_jobs_per_keyword():
+    """source_d calls google_jobs_advertisers once per job_search_keywords entry."""
+    cfg = {"job_search_keywords": ["marketing manager", "ppc specialist"]}
+    engine, conn, dfs = make_engine(discovery_config=cfg)
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        await engine.run("marketing_agency", daily_budget_usd=100.0)
+
+    assert dfs.google_jobs_advertisers.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_source_e_skipped_when_no_prior_bu_data():
+    """source_e skips competitors_domain when no prior BU rows qualify."""
+    cfg = {"competitor_expansion": True}
+    engine, conn, dfs = make_engine(discovery_config=cfg)
+    # conn.fetch returns [] by default (no prior rows)
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        await engine.run("marketing_agency", daily_budget_usd=100.0)
+
+    dfs.competitors_domain.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_deduplication_keeps_first_occurrence():
+    """Two sources returning the same domain → unique_domains=1, not 2."""
+    cfg = {
+        "keywords_for_ads_search": ["marketing"],
+        "job_search_keywords": ["marketing manager"],
+    }
+    engine, conn, dfs = make_engine(discovery_config=cfg)
+    # Both sources return the same domain
+    dfs.google_ads_advertisers = AsyncMock(return_value=[{"domain": "acme.com.au", "title": "Acme", "url": "https://acme.com.au"}])
+    dfs.google_jobs_advertisers = AsyncMock(return_value=[{"domain": "acme.com.au", "employer_name": "Acme"}])
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        stats = await engine.run("marketing_agency", daily_budget_usd=100.0)
+
+    assert stats.unique_domains == 1
+
+
+@pytest.mark.asyncio
+async def test_domain_normalisation():
+    """_normalise_domain strips https://, www., trailing slash, and lowercases."""
+    assert _normalise_domain("https://www.Example.COM/") == "example.com"
+    assert _normalise_domain("http://www.test.com.au/") == "test.com.au"
+    assert _normalise_domain("BARE.COM") == "bare.com"
+    assert _normalise_domain("www.example.com") == "example.com"
+    assert _normalise_domain("example.com/") == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_blocklist_filters_platform_domains():
+    """facebook.com from a source is blocked — not written to BU, blocked_count=1."""
+    cfg = {"keywords_for_ads_search": ["marketing"]}
+    engine, conn, dfs = make_engine(discovery_config=cfg)
+    dfs.google_ads_advertisers = AsyncMock(
+        return_value=[{"domain": "facebook.com", "title": "FB", "url": "https://facebook.com"}]
+    )
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        stats = await engine.run("marketing_agency", daily_budget_usd=100.0)
+
+    assert stats.blocked_count == 1
+    assert stats.written_new == 0
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_budget_cap_stops_sources():
+    """daily_budget_usd=0.0 means all sources with non-zero cost are skipped, budget_exceeded=True."""
+    cfg = {
+        "category_codes": [10233],          # source_a costs $0.10
+        "keywords_for_ads_search": ["seo"],  # source_b costs $0.006
+    }
+    engine, conn, dfs = make_engine(discovery_config=cfg)
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        stats = await engine.run("marketing_agency", daily_budget_usd=0.0)
+
+    assert stats.budget_exceeded is True
+    dfs.domain_metrics_by_categories.assert_not_called()
+    dfs.google_ads_advertisers.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_source_error_does_not_abort_run():
+    """If source_a raises, sources b/c/d/e still run and source_errors is populated."""
+    cfg = {
+        "category_codes": [10233],          # ensures source_a calls domain_metrics_by_categories
+        "keywords_for_ads_search": ["marketing"],
+        "job_search_keywords": ["manager"],
+    }
+    engine, conn, dfs = make_engine(discovery_config=cfg)
+    dfs.domain_metrics_by_categories = AsyncMock(side_effect=Exception("DFS timeout"))
+    dfs.google_ads_advertisers = AsyncMock(return_value=[{"domain": "good.com.au", "title": "", "url": "https://good.com.au"}])
+    dfs.google_jobs_advertisers = AsyncMock(return_value=[])
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        stats = await engine.run("marketing_agency", daily_budget_usd=100.0)
+
+    # source_a failed, but other sources ran
+    assert len(stats.source_errors) >= 1
+    assert "source_a" in stats.source_errors[0]
+    dfs.google_ads_advertisers.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_idempotency_skips_existing_domain():
+    """If domain already exists in BU (fetchval returns UUID), written_new=0 and written_skip=1."""
+    cfg = {"keywords_for_ads_search": ["marketing"]}
+    engine, conn, dfs = make_engine(discovery_config=cfg, domain_exists=True)
+    dfs.google_ads_advertisers = AsyncMock(
+        return_value=[{"domain": "existing.com.au", "title": "Existing", "url": "https://existing.com.au"}]
+    )
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        stats = await engine.run("marketing_agency", daily_budget_usd=100.0)
+
+    assert stats.written_new == 0
+    assert stats.written_skip == 1
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stats_returned_correctly():
+    """End-to-end with mocks: total_raw, unique_domains, written_new counts are correct."""
+    cfg = {
+        "keywords_for_ads_search": ["marketing"],
+        "job_search_keywords": ["ppc"],
+    }
+    engine, conn, dfs = make_engine(discovery_config=cfg)
+    # source_b returns 2 distinct domains, source_d returns 1 (overlap with source_b = 1 new)
+    dfs.google_ads_advertisers = AsyncMock(return_value=[
+        {"domain": "alpha.com.au", "title": "Alpha", "url": "https://alpha.com.au"},
+        {"domain": "beta.com.au", "title": "Beta", "url": "https://beta.com.au"},
+    ])
+    dfs.google_jobs_advertisers = AsyncMock(return_value=[
+        {"domain": "alpha.com.au", "employer_name": "Alpha Co"},  # duplicate of source_b
+    ])
+    config = make_signal_config(cfg)
+
+    with patch("src.pipeline.layer_2_discovery.SignalConfigRepository") as MockRepo:
+        MockRepo.return_value.get_config = AsyncMock(return_value=config)
+        stats = await engine.run("marketing_agency", daily_budget_usd=100.0)
+
+    assert stats.total_raw == 3            # 2 from source_b + 1 from source_d
+    assert stats.unique_domains == 2       # alpha.com.au deduplicated
+    assert stats.written_new == 2          # both are new (fetchval returns None)
+    assert stats.written_skip == 0
+    assert stats.blocked_count == 0
+    assert stats.estimated_cost_usd > 0


### PR DESCRIPTION
## Summary
v6 Layer 2 multi-source discovery engine. Reads discovery_config from signal_configurations, runs 5 DFS sources concurrently, deduplicates by domain, writes to business_universe.

## Changes
- `migrations/030_layer2_discovery_columns.sql`: discovery_batch_id uuid, no_domain bool, dfs_discovery_category text, dfs_discovery_keyword text + 2 indexes
- `src/clients/dfs_labs_client.py`: 4 new endpoints — domain_metrics_by_categories ($0.10/call), google_ads_advertisers ($0.006/call), domains_by_html_terms ($0.01/call), google_jobs_advertisers ($0.006/call)
- `src/pipeline/layer_2_discovery.py`: Layer2Discovery class — 5 sources concurrent, rate limiting (daily_budget_usd, default $10), idempotency (skip existing domains), dedup, blocklist, DiscoveryStats
- `tests/test_layer_2_discovery.py`: 13 tests, all mocked, no live API hits

## Design Note
Layer 2 uses DFS Labs/SERP endpoints per v6 Manual architecture. NOT DFS GMaps coordinate sweep (v4/v5 pattern). Discovery is by spend signals, not geography.

## Adaptations from directive
- Uses `dfs_discovery_sources` (existing text[] column) instead of non-existent `discovery_source` text column
- competitors_domain() result unwrapping corrected to match actual DFSLabsClient response structure

## Test Results
1022 passed, 2 failed (pre-existing test_dfs_serp_client.py, unchanged), 28 skipped

## Verification
Migration 030 applied to live DB. New columns confirmed: discovery_batch_id, no_domain, dfs_discovery_category, dfs_discovery_keyword.