### PR TITLE
Directive #273: Fix pre-existing DFS SERP test failures

### DIFF
--- a/tests/test_dfs_serp_client.py
+++ b/tests/test_dfs_serp_client.py
@@ -25,14 +25,15 @@ def _make_client() -> DFSSerpClient:
     return DFSSerpClient(login="test_user", password="test_pass")
 
 
-def _task_post_response(task_id: str = "task-001") -> dict:
-    return {
-        "tasks": [{
-            "id": task_id,
-            "status_code": DFS_STATUS_SUCCESS,
-            "status_message": "Ok.",
-        }]
+def _task_post_response(task_id: str = "task-001", items: list[dict] | None = None) -> dict:
+    task: dict = {
+        "id": task_id,
+        "status_code": DFS_STATUS_SUCCESS,
+        "status_message": "Ok.",
     }
+    if items is not None:
+        task["result"] = [{"items": items}]
+    return {"tasks": [task]}
 
 
 def _task_get_response(task_id: str, items: list[dict]) -> dict:
@@ -87,7 +88,7 @@ async def test_find_dm_returns_mapped_fields():
         )
     ]
     mock_http = _mock_http_client(
-        _task_post_response(task_id),
+        _task_post_response(task_id, items),
         _task_get_response(task_id, items),
     )
     client._client = mock_http
@@ -140,7 +141,7 @@ async def test_dm_confidence_lower_at_position_5():
         )
     ]
     mock_http = _mock_http_client(
-        _task_post_response(task_id),
+        _task_post_response(task_id, items),
         _task_get_response(task_id, items),
     )
     client._client = mock_http


### PR DESCRIPTION
## Root Cause
Tests were written for the old task_post + task_get async pattern. The implementation was updated to use the live endpoint (single synchronous POST) but tests were not updated.

The mock put items in `_task_get_response` (set on `mock.get`), but `find_decision_maker` only ever calls `client.post`. GET was never called → items never reached → `_extract_dm([])` → `None` always.

## Fix
One change: `_task_post_response()` accepts optional `items` parameter and embeds them in `result`. Two failing tests updated to pass items to the POST mock. No production code changed.

## Tests
```
5 passed in 0.53s (targeted)
1024 passed, 0 failed, 28 skipped (full suite)
```