### PR TITLE
fix(discovery): DFS date params + DiscoverySource enum — Directive #284

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -23,15 +23,15 @@ Revenue model for BU: API subscriptions, Salesforce/HubSpot marketplace, bulk an
 
 ## SECTION 2 — CURRENT STATE
 
-- Last directive issued: #283 (Sprint 3: Paid Enrichment + Affordability Gate — COMPLETE)
-- Next directive: #284 (Segment 1+2 live test)
-- Test baseline: 1012 passed, 0 failed, 28 skipped (+10 from #283)
-- Last merged PRs: #242 (Sprint 1), #243 (schema), #244 (tests), #245 (Sprint 2), #246 (Sprint 3)
+- Last directive issued: #284 (DFS date params fix + dual discovery source — COMPLETE)
+- Next directive: #285 (Segment 1+2 live test)
+- Test baseline: 1016 passed, 0 failed, 28 skipped (+4 from #284)
+- Last merged PRs: #242 (Sprint 1), #243 (schema), #244 (tests), #245 (Sprint 2), #246 (Sprint 3), #247 (Directive #284 pending merge)
 - Spider.cloud: validated, API key in env SPIDER_API_KEY
 - Segment testing: ratified March 29 2026 — Segments 1+2 ready for live test
 - Architecture: **v7 ratified Mar 28 2026** — signal-first organic discovery, free intelligence sweep, proven with live AU data across 5 dental domains
 - **v6 pipeline SUPERSEDED. Layer 2 (5-source parallel) and Layer 3 (bulk filter) replaced. Layer 4 (DFS tech/rank/historical) replaced with free scrape stack.**
-- **Live testing confirmed: domain_metrics_by_categories returns 22,592 AU dental domains at $0.001/domain. Google Ads Transparency free scraper: 5/5 AU coverage. Website scraping direct HTTP: 5/5 coverage, full tech stack, FREE.**
+- **Live testing confirmed: domain_metrics_by_categories returns 24,231 AU dental / 31,445 AU plumbing domains at $0.0015/domain. Tail ($101–$500 ETV) = 90% real businesses in both categories. Plumbing top-200 = 0% local plumbers (gov/supplier pollution). Google Ads Transparency free scraper: 5/5 AU coverage. Website scraping direct HTTP: 5/5 coverage, full tech stack, FREE.**
 
 ---
 
@@ -60,7 +60,7 @@ Core principle: Signal-first organic discovery. Find businesses spending on Goog
 
 | Endpoint | Coverage | Cost | Signal |
 |----------|---------|------|--------|
-| DFS domain_metrics_by_categories | 22,592 AU dental domains returned | $0.001/domain | Organic ETV, keyword count, category confirmation |
+| DFS domain_metrics_by_categories | 24,231 AU dental / 31,445 AU plumbing domains | $0.0015/domain | Organic ETV, keyword count, category confirmation |
 | Google Ads Transparency Center | 5/5 AU coverage | FREE (Python scraper) | Binary: is business running Google Ads |
 | Website scraping (direct HTTP) | 5/5 AU coverage | FREE | Full tech stack, CMS, tracking codes, team names, contact info |
 | ABN verification (local JOIN) | 5/5 AU coverage | FREE | GST registration = $75k+ revenue confirmed |
@@ -89,10 +89,16 @@ Dedup against BU + blocklist. Insert new rows at pipeline_stage=1.
 
 **v7 change from v6:** 5-source parallel discovery REPLACED with single endpoint. Rationale: Google Jobs broken (40402), HTML Terms unreliable for AU, Competitors expansion better as an enrichment step. domain_metrics_by_categories alone returns 22,592 AU dental domains — more than sufficient.
 
-Cost: $0.001/domain
+Cost: $0.0015/domain (corrected Mar 2026 — was estimated $0.001)
 Sprint: Sprint 1
 
-**Status: BUILT (v7)** — single `domain_metrics_by_categories` call, sequential per category, AU domain filter, trajectory computation, Gate 1 applied post-insert. Directive #280, PR #242.
+**Dual discovery sources (Directive #284):**
+- `DiscoverySource.DOMAIN_CATEGORIES` — `domain_metrics_by_categories` (default). Professional categories (dental, medical): clean. Trades categories (plumbing, construction): top-200 polluted by gov/suppliers; tail ($101–$500 ETV) is 90% real businesses.
+- `DiscoverySource.MAPS_SERP` — DFS Maps SERP suburb sweep (stub only — Sprint 5). Required for trades categories where professional-to-aggregator ratio at top is 0%.
+
+**Bug fixed (Directive #284):** `first_date`/`second_date` were missing from the API payload — all calls returned 40501 silently. Fixed: defaults to 6-month window, caller can override. Error no longer swallowed.
+
+**Status: BUILT (v7)** — single `domain_metrics_by_categories` call, sequential per category, AU domain filter, trajectory computation, Gate 1 applied post-insert. Directive #280, PR #242. Date params fixed + DiscoverySource enum added: Directive #284, PR #247.
 
 ---
 
@@ -404,7 +410,7 @@ Approval flow:
 
 | Source | What | Cost | Status |
 |--------|------|------|--------|
-| DFS domain_metrics_by_categories | Domain discovery by AU industry category. Returns organic_etv, organic_keywords, category | $0.001/domain | ✅ Proven (22,592 AU dental domains) |
+| DFS domain_metrics_by_categories | Domain discovery by AU industry category. Returns organic_etv, organic_keywords, category | $0.0015/domain | ✅ Proven (24,231 AU dental / 31,445 AU plumbing domains, Mar 2026 spike) |
 | DFS SERP Google Maps | GMB: Place ID, category, rating, reviews, address, phone, hours | $0.0035/domain | ✅ Live — 4/5 AU GMB match proven |
 | DFS Competitors Domain | Top 5 SERP competitors per prospect | $0.01/call | ✅ Live |
 | DFS Brand SERP / Indexed Pages | Brand search presence, indexed page count | $0.005/call | Planned Sprint 3 |
@@ -493,7 +499,8 @@ v6 era (#271–#277): Layer 2 (discovery), Layer 3 (bulk filter), signal config 
 | Sprint 1 | #280 | Discovery engine: rebuild layer_2_discovery.py → single domain_metrics_by_categories call, remove 4 dead sources | COMPLETE — PR #242 |
 | Sprint 2 | #281–#282 | Free intelligence sweep: website scrape (Spider.cloud), DNS/MX/SPF/DKIM, ABN registry JOIN, free_enrichment.py | COMPLETE — PR #245 |
 | Sprint 3 | #283 | Paid enrichment: affordability gate + DFS bulk metrics + DFS Maps GMB, paid_enrichment.py | COMPLETE — PR #246 |
-| Sprint 4+ | #284+ | Segments 3-8 build (DM identification, email, phone, social, scoring, outreach) | ON HOLD — pending Segment 1+2 live test |
+| Sprint 4 | #284 | DFS date params fix + DiscoverySource enum (DOMAIN_CATEGORIES / MAPS_SERP stub) | COMPLETE — PR #247 (pending merge) |
+| Sprint 4+ | #285+ | Segments 3-8 build (DM identification, email, phone, social, scoring, outreach) | ON HOLD — pending Segment 1+2 live test |
 | Sprint 5 | #286–#287 | DM discovery: email waterfall (scrape→Leadmagic→ZeroBounce), mobile waterfall, reachability v7 | Queued |
 | Sprint 6 | #288–#289 | Message generation + outreach wiring: Haiku redesign with v7 signal inputs, scheduling engine, quota loop | Queued |
 | Sprint 7 | #290 | Multi-vertical: seed dental, recruitment, IT MSP signal configs + category codes | Queued (parallel with 4–6) |
@@ -512,6 +519,8 @@ v6 era (#271–#277): Layer 2 (discovery), Layer 3 (bulk filter), signal config 
 | #275 | asyncpg JSONB codec fix | COMPLETE — PR open (branch feat/275-asyncpg-jsonb-codec) |
 | #277 | Codebase audit (92 components, all sections) | COMPLETE — docs/v7-audit-results.md |
 | #278 | v7 architecture alignment (this directive) | COMPLETE |
+| #283 | Sprint 3: Paid enrichment + affordability gate | COMPLETE — PR #246 merged |
+| #284 | DFS date params fix (first_date/second_date) + DiscoverySource enum | COMPLETE — PR #247 (pending merge) |
 
 ---
 

--- a/src/clients/dfs_labs_client.py
+++ b/src/clients/dfs_labs_client.py
@@ -12,6 +12,7 @@ Wraps 7 DataForSEO endpoints for pipeline v4 discovery and intelligence.
 import base64
 import logging
 import time
+from datetime import date, timedelta
 from decimal import Decimal
 
 import httpx
@@ -159,6 +160,7 @@ class DFSLabsClient:
         payload: list,
         cost_per_call: Decimal,
         cost_attr: str,
+        swallow_no_data: bool = True,
     ) -> dict:
         """
         POST to a DataForSEO endpoint with retry, cost tracking, and error handling.
@@ -201,8 +203,13 @@ class DFSLabsClient:
         if dfs_status == DFS_STATUS_AUTH_FAILURE:
             raise DFSAuthError(f"DataForSEO authentication failed: {dfs_message}")
 
-        # No data — expected for small/unknown domains
+        # No data / invalid field (40501)
         if dfs_status == DFS_STATUS_NO_DATA:
+            if not swallow_no_data:
+                raise ValueError(
+                    f"DFS {endpoint}: 40501 Invalid Field — {dfs_message}. "
+                    "This is a programming error (bad payload), not a missing-data condition."
+                )
             logger.info(
                 f"DFS {endpoint}: 40501 no data (expected for unknown domains), "
                 f"elapsed={elapsed:.2f}s"
@@ -636,14 +643,23 @@ class DFSLabsClient:
         category_codes: list[int],
         location_name: str = "Australia",
         paid_etv_min: float = 0.0,
+        first_date: str | None = None,
+        second_date: str | None = None,
     ) -> list[dict]:
         """
         Discover domains with Google Ads spend in specified categories.
         Uses location_name (NOT location_code — causes 40501 error per DFS gotcha).
         Cost: ~$0.10/call.
         Returns list of {"domain": str, "paid_etv": float, "organic_etv": float}.
-        TODO: verify exact payload format against DFS API docs before live run.
+
+        Args:
+            first_date: Start date YYYY-MM-DD (default: 6 months ago / today - 180 days).
+            second_date: End date YYYY-MM-DD (default: today).
         """
+        today = date.today()
+        resolved_first_date = first_date or (today - timedelta(days=180)).strftime("%Y-%m-%d")
+        resolved_second_date = second_date or today.strftime("%Y-%m-%d")
+
         result = await self._post(
             endpoint="/v3/dataforseo_labs/google/domain_metrics_by_categories/live",
             payload=[
@@ -651,11 +667,14 @@ class DFSLabsClient:
                     "category_codes": category_codes,
                     "location_name": location_name,
                     "language_name": "English",
+                    "first_date": resolved_first_date,
+                    "second_date": resolved_second_date,
                     "filters": [["metrics.organic.etv", ">", 0]],
                 }
             ],
             cost_per_call=Decimal("0.10"),
             cost_attr="_cost_domain_metrics_by_categories",
+            swallow_no_data=False,
         )
         items = result.get("items") or []
         results = []

--- a/src/pipeline/layer_2_discovery.py
+++ b/src/pipeline/layer_2_discovery.py
@@ -16,6 +16,7 @@ import logging
 import uuid
 from dataclasses import dataclass, field
 from decimal import Decimal
+from enum import Enum
 from urllib.parse import urlparse
 
 import asyncpg
@@ -25,6 +26,12 @@ from src.enrichment.signal_config import SignalConfigRepository
 from src.utils.domain_blocklist import is_blocked
 
 logger = logging.getLogger(__name__)
+
+
+class DiscoverySource(str, Enum):
+    DOMAIN_CATEGORIES = "domain_categories"
+    MAPS_SERP = "maps_serp"
+
 
 # pipeline_stage value for Layer 2 discoveries (matches Stage 1 convention)
 PIPELINE_STAGE_DISCOVERED = 1
@@ -152,9 +159,11 @@ class Layer2Discovery:
         self,
         conn: asyncpg.Connection,
         dfs: DFSLabsClient,
+        source: DiscoverySource = DiscoverySource.DOMAIN_CATEGORIES,
     ) -> None:
         self._conn = conn
         self._dfs = dfs
+        self._source = source
 
     async def run(
         self,
@@ -176,6 +185,9 @@ class Layer2Discovery:
         Returns:
             DiscoveryStats with per-run counts and cost.
         """
+        if self._source == DiscoverySource.MAPS_SERP:
+            raise NotImplementedError("Maps SERP discovery not yet implemented — Sprint 5")
+
         run_id = batch_id or uuid.uuid4()
         stats = DiscoveryStats(run_id=run_id)
 

--- a/tests/test_clients/test_dfs_labs_client.py
+++ b/tests/test_clients/test_dfs_labs_client.py
@@ -1,0 +1,140 @@
+# FILE: tests/test_clients/test_dfs_labs_client.py
+# PURPOSE: Unit tests for DFSLabsClient date params + 40501 error handling — Directive #284
+
+"""
+Tests for domain_metrics_by_categories date parameters and error handling.
+All tests use mocks — NO live API calls.
+"""
+
+import re
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.clients.dfs_labs_client import DFSLabsClient
+
+
+# ============================================
+# Fixtures + helpers
+# ============================================
+
+
+@pytest.fixture
+def client():
+    return DFSLabsClient(login="test@example.com", password="test_password")
+
+
+def make_dfs_response(result_data, status_code: int = 20000, status_message: str = "Ok.") -> dict:
+    return {
+        "tasks": [
+            {
+                "status_code": status_code,
+                "status_message": status_message,
+                "result": [result_data] if result_data is not None else [],
+            }
+        ]
+    }
+
+
+def make_mock_response(json_data: dict, http_status: int = 200) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.status_code = http_status
+    mock_resp.json.return_value = json_data
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+# ============================================
+# Test 1: payload includes first_date and second_date
+# ============================================
+
+
+@pytest.mark.asyncio
+async def test_domain_metrics_by_categories_includes_dates(client):
+    """domain_metrics_by_categories must include first_date and second_date in the API payload."""
+    result_data = {"items": [], "total_count": 0}
+    mock_resp = make_mock_response(make_dfs_response(result_data))
+
+    mock_http_client = AsyncMock()
+    mock_http_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch.object(client, "_get_client", return_value=mock_http_client):
+        await client.domain_metrics_by_categories(category_codes=[10233])
+
+    call_args = mock_http_client.post.call_args
+    payload_sent = call_args[1]["json"] if "json" in call_args[1] else call_args[0][1]
+    item = payload_sent[0]
+
+    assert "first_date" in item, "first_date must be in the payload"
+    assert "second_date" in item, "second_date must be in the payload"
+
+    # Both must be YYYY-MM-DD format
+    assert _DATE_RE.match(item["first_date"]), f"first_date not YYYY-MM-DD: {item['first_date']}"
+    assert _DATE_RE.match(item["second_date"]), f"second_date not YYYY-MM-DD: {item['second_date']}"
+
+    # first_date must be ~180 days before second_date
+    d1 = date.fromisoformat(item["first_date"])
+    d2 = date.fromisoformat(item["second_date"])
+    delta = (d2 - d1).days
+    assert 170 <= delta <= 190, f"Expected ~180 day gap, got {delta}"
+
+
+# ============================================
+# Test 2: 40501 raises ValueError (not silent empty)
+# ============================================
+
+
+@pytest.mark.asyncio
+async def test_domain_metrics_by_categories_raises_on_40501(client):
+    """When DFS returns 40501, domain_metrics_by_categories must raise, not return empty list."""
+    invalid_field_response = make_dfs_response(
+        None,
+        status_code=40501,
+        status_message="Invalid Field: 'first_date' is required",
+    )
+    # result list is empty so make_dfs_response with None gives []
+    invalid_field_response["tasks"][0]["result"] = []
+
+    mock_resp = make_mock_response(invalid_field_response)
+    mock_http_client = AsyncMock()
+    mock_http_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch.object(client, "_get_client", return_value=mock_http_client):
+        with pytest.raises(ValueError, match="40501"):
+            await client.domain_metrics_by_categories(category_codes=[10233])
+
+
+# ============================================
+# Test 3: caller can override first_date and second_date
+# ============================================
+
+
+@pytest.mark.asyncio
+async def test_domain_metrics_by_categories_custom_dates(client):
+    """Caller-supplied first_date and second_date override the auto-computed defaults."""
+    result_data = {"items": [], "total_count": 0}
+    mock_resp = make_mock_response(make_dfs_response(result_data))
+
+    mock_http_client = AsyncMock()
+    mock_http_client.post = AsyncMock(return_value=mock_resp)
+
+    custom_first = "2024-01-01"
+    custom_second = "2024-06-30"
+
+    with patch.object(client, "_get_client", return_value=mock_http_client):
+        await client.domain_metrics_by_categories(
+            category_codes=[10233],
+            first_date=custom_first,
+            second_date=custom_second,
+        )
+
+    call_args = mock_http_client.post.call_args
+    payload_sent = call_args[1]["json"] if "json" in call_args[1] else call_args[0][1]
+    item = payload_sent[0]
+
+    assert item["first_date"] == custom_first
+    assert item["second_date"] == custom_second

--- a/tests/test_layer_2_discovery.py
+++ b/tests/test_layer_2_discovery.py
@@ -9,6 +9,7 @@ import pytest
 
 from src.enrichment.signal_config import ServiceSignal, SignalConfig
 from src.pipeline.layer_2_discovery import (
+    DiscoverySource,
     Layer2Discovery,
     _compute_trajectory,
     _normalise_domain,
@@ -382,3 +383,17 @@ async def test_idempotency_skips_existing_domain():
     for call_args in conn.execute.call_args_list:
         sql = call_args[0][0]
         assert "INSERT INTO business_universe" not in sql
+
+
+# ─── Test 12: DiscoverySource.MAPS_SERP raises NotImplementedError ─────────────
+
+
+@pytest.mark.asyncio
+async def test_maps_serp_raises_not_implemented():
+    """Layer2Discovery with source=MAPS_SERP must raise NotImplementedError on run()."""
+    conn = make_conn()
+    dfs = make_dfs()
+    engine = Layer2Discovery(conn=conn, dfs=dfs, source=DiscoverySource.MAPS_SERP)
+
+    with pytest.raises(NotImplementedError, match="Maps SERP"):
+        await engine.run("marketing_agency")


### PR DESCRIPTION
## Directive #284 — DFS client date params fix + dual discovery source architecture

### Problem
`domain_metrics_by_categories` was missing required `first_date` / `second_date` API parameters. All calls returned error `40501 "Invalid Field: 'first_date'"` — silently swallowed as empty results. Discovery was completely broken for this endpoint.

Found during Segment 1 live test spike (Mar 29 2026).

### Changes

#### `src/clients/dfs_labs_client.py`
- Added `first_date` and `second_date` optional params to `domain_metrics_by_categories`
- Defaults: `first_date = today - 180 days`, `second_date = today` (YYYY-MM-DD)
- Caller can override both dates
- 40501 errors no longer silently swallowed — raises `ValueError` with DFS status_message

#### `src/pipeline/layer_2_discovery.py`
- Added `DiscoverySource` enum: `DOMAIN_CATEGORIES` (default) | `MAPS_SERP`
- `Layer2Discovery` accepts `source: DiscoverySource` parameter
- `MAPS_SERP` raises `NotImplementedError("Maps SERP discovery not yet implemented — Sprint 5")`

#### `docs/MANUAL.md`
- Section 2: updated state + test baseline (1016/0/28)
- Section 3: Layer 2 dual discovery source docs + bug fix note + corrected DFS rate
- Section 8: DFS rate corrected /bin/bash.001 → /bin/bash.0015/domain
- Section 12: Sprint 4 row added, #284 in completed log

### Tests
- `+4 new tests` (payload includes dates, 40501 raises, caller override, MAPS_SERP NotImplementedError)
- **1016 passed, 0 failed, 28 skipped** (+4 from baseline 1012)

### Verbatim grep — first_date/second_date in fixed client
```
646:        first_date: str | None = None,
647:        second_date: str | None = None,
656:            first_date: Start date YYYY-MM-DD (default: 6 months ago / today - 180 days).
657:            second_date: End date YYYY-MM-DD (default: today).
660:        resolved_first_date = first_date or (today - timedelta(days=180)).strftime("%Y-%m-%d")
661:        resolved_second_date = second_date or today.strftime("%Y-%m-%d")
670:                    "first_date": resolved_first_date,
671:                    "second_date": resolved_second_date,
```

LAW V ✅ | LAW XIV ✅ | LAW XV ✅