### PR TITLE
feat(dm): Bright Data LinkedIn DM lookup + DMIdentification pipeline — Directive #286

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -23,10 +23,10 @@ Revenue model for BU: API subscriptions, Salesforce/HubSpot marketplace, bulk an
 
 ## SECTION 2 — CURRENT STATE
 
-- Last directive issued: #285 (Free enrichment quality fixes — COMPLETE)
-- Next directive: #286
-- Test baseline: 1034 passed, 0 failed, 28 skipped (+18 from #285)
-- Last merged PRs: #242–#247 (Sprints 1-4), #248 (Directive #285 pending merge)
+- Last directive issued: #286 (DM Identification Layer — COMPLETE)
+- Next directive: #287
+- Test baseline: 1044 passed, 0 failed, 28 skipped (+10 from #286)
+- Last merged PRs: #242–#248 (Sprints 1-4), #249 (Directive #286 pending merge)
 - Spider.cloud: validated, API key in env SPIDER_API_KEY
 - Segment testing: ratified March 29 2026 — Segments 1+2 ready for live test
 - Architecture: **v7 ratified Mar 28 2026** — signal-first organic discovery, free intelligence sweep, proven with live AU data across 5 dental domains
@@ -506,8 +506,9 @@ v6 era (#271–#277): Layer 2 (discovery), Layer 3 (bulk filter), signal config 
 | Sprint 2 | #281–#282 | Free intelligence sweep: website scrape (Spider.cloud), DNS/MX/SPF/DKIM, ABN registry JOIN, free_enrichment.py | COMPLETE — PR #245 |
 | Sprint 3 | #283 | Paid enrichment: affordability gate + DFS bulk metrics + DFS Maps GMB, paid_enrichment.py | COMPLETE — PR #246 |
 | Sprint 4 | #284 | DFS date params fix + DiscoverySource enum (DOMAIN_CATEGORIES / MAPS_SERP stub) | COMPLETE — PR #247 merged |
-| Sprint 4 | #285 | Free enrichment quality: ABN confidence, JSON-LD address, email maturity collapse, silent exception fix | COMPLETE — PR #248 (pending merge) |
-| Sprint 4+ | #286+ | Segments 3-8 build (DM identification, email, phone, social, scoring, outreach) | ON HOLD — pending Segment 1+2 live test |
+| Sprint 4 | #285 | Free enrichment quality: ABN confidence, JSON-LD address, email maturity collapse, silent exception fix | COMPLETE — PR #248 merged |
+| Sprint 4 | #286 | DM Identification: BrightDataLinkedInClient + DMIdentification pipeline (4-tier fallback) | COMPLETE — PR #249 (pending merge) |
+| Sprint 4+ | #287+ | DM wiring into enrichment pipeline + Segment 4 live test | NEXT |
 | Sprint 5 | #286–#287 | DM discovery: email waterfall (scrape→Leadmagic→ZeroBounce), mobile waterfall, reachability v7 | Queued |
 | Sprint 6 | #288–#289 | Message generation + outreach wiring: Haiku redesign with v7 signal inputs, scheduling engine, quota loop | Queued |
 | Sprint 7 | #290 | Multi-vertical: seed dental, recruitment, IT MSP signal configs + category codes | Queued (parallel with 4–6) |

--- a/src/integrations/brightdata_client.py
+++ b/src/integrations/brightdata_client.py
@@ -1,0 +1,205 @@
+"""
+Contract: src/integrations/brightdata_client.py
+Purpose: LinkedIn DM lookup via Bright Data Scrapers API (new Scrapers API key)
+Layer: 2 - integrations
+Imports: models only
+Consumers: src/pipeline/dm_identification.py
+
+brightdata_client.py — LinkedIn DM lookup via Bright Data Scrapers API.
+Directive #286 | Cost: $0.00075/record ($0.75/1000)
+"""
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+BRIGHTDATA_SCRAPER_KEY = "2bab0747-ede2-4437-9b6f-6a77e8f0ca3e"
+DATASET_LINKEDIN_COMPANY = "gd_l1vikfnt1wgvvqz95w"
+COST_PER_RECORD_USD = 0.00075
+
+# DM title priority (lower index = higher priority)
+DM_TITLE_PRIORITY = [
+    "owner",
+    "founder",
+    "co-founder",
+    "director",
+    "principal",
+    "managing director",
+    "managing partner",
+    "managing",
+    "ceo",
+    "chief executive",
+    "proprietor",
+    "partner",
+    "president",
+    "general manager",
+]
+
+# Threshold: titles at index < HIGH_CONFIDENCE_THRESHOLD get HIGH confidence
+HIGH_CONFIDENCE_THRESHOLD = 6  # owner, founder, co-founder, director, principal, managing director
+
+
+class BrightDataLinkedInClient:
+    """Focused LinkedIn DM lookup client using new Scrapers API key."""
+
+    def __init__(self, api_key: str = BRIGHTDATA_SCRAPER_KEY):
+        self.api_key = api_key
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient()
+        return self._client
+
+    async def lookup_company_people(
+        self,
+        company_name: str,
+        domain: Optional[str] = None,
+        linkedin_url: Optional[str] = None,
+    ) -> list[dict]:
+        """
+        Returns list of dicts with keys: name, title, linkedin_url.
+        Caps at 20 records. Never raises on empty results.
+        """
+        if linkedin_url:
+            inputs = [{"url": linkedin_url}]
+            discover_by = None
+        else:
+            search_url = f"https://www.linkedin.com/search/results/companies/?keywords={company_name}"
+            inputs = [{"url": search_url}]
+            discover_by = "keyword"
+
+        try:
+            results = await self._scraper_request(
+                DATASET_LINKEDIN_COMPANY, inputs, discover_by=discover_by
+            )
+        except Exception:
+            logger.exception("brightdata_lookup_failed company=%s", company_name)
+            return []
+
+        # Extract employees/staff array from company result
+        people: list[dict] = []
+        for record in results:
+            employees = record.get("employees") or record.get("staff") or []
+            if isinstance(employees, list):
+                people.extend(employees)
+
+        # If no nested employees, treat top-level records as people
+        if not people:
+            people = results
+
+        people = people[:20]
+        cost = COST_PER_RECORD_USD * len(people)
+        logger.info(
+            "brightdata_lookup_complete company=%s records=%d cost_usd=%.4f",
+            company_name,
+            len(people),
+            cost,
+        )
+        return people
+
+    def pick_decision_maker(self, people: list[dict]) -> Optional[dict]:
+        """
+        Synchronous. Scores each person by DM_TITLE_PRIORITY.
+        Returns best match with confidence, or None if list is empty.
+        """
+        if not people:
+            return None
+
+        best_person = None
+        best_index = len(DM_TITLE_PRIORITY) + 1
+
+        for person in people:
+            title_raw = (person.get("title") or "").lower()
+            matched_index = len(DM_TITLE_PRIORITY)  # no match sentinel
+
+            for idx, keyword in enumerate(DM_TITLE_PRIORITY):
+                if keyword in title_raw:
+                    matched_index = idx
+                    break
+
+            if matched_index < best_index:
+                best_index = matched_index
+                best_person = person
+
+        if best_person is None:
+            # All had no title match — return first person with LOW confidence
+            best_person = people[0]
+            confidence = "LOW"
+        elif best_index < HIGH_CONFIDENCE_THRESHOLD:
+            confidence = "HIGH"
+        else:
+            confidence = "MEDIUM"
+
+        return {
+            "name": best_person.get("name"),
+            "title": best_person.get("title"),
+            "linkedin_url": best_person.get("linkedin_url") or best_person.get("url"),
+            "confidence": confidence,
+        }
+
+    async def _scraper_request(
+        self,
+        dataset_id: str,
+        inputs: list[dict],
+        discover_by: Optional[str] = None,
+    ) -> list[dict]:
+        """Trigger → poll → download pattern. 120s timeout (24 × 5s)."""
+        base_url = "https://api.brightdata.com/datasets/v3"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        trigger_url = f"{base_url}/trigger?dataset_id={dataset_id}&include_errors=true"
+        if discover_by:
+            trigger_url += f"&type=discover_new&discover_by={discover_by}"
+
+        client = await self._get_client()
+
+        # Trigger
+        response = await client.post(trigger_url, headers=headers, json=inputs, timeout=30.0)
+        if response.status_code >= 400:
+            body = response.text
+            raise ValueError(f"Bright Data API error: {response.status_code} {body}")
+        snapshot_id = response.json()["snapshot_id"]
+        logger.info("brightdata_triggered snapshot_id=%s dataset_id=%s", snapshot_id, dataset_id)
+
+        # Poll until ready (max 120s = 24 × 5s intervals)
+        for _ in range(24):
+            await asyncio.sleep(5)
+            try:
+                progress = await client.get(
+                    f"{base_url}/progress/{snapshot_id}", headers=headers, timeout=10.0
+                )
+                status_data = progress.json()
+                status = status_data.get("status")
+
+                if status == "ready":
+                    logger.info(
+                        "brightdata_ready snapshot_id=%s records=%s",
+                        snapshot_id,
+                        status_data.get("records", 0),
+                    )
+                    break
+                elif status == "failed":
+                    raise ValueError(f"Bright Data scraper job failed: {status_data}")
+            except httpx.RequestError:
+                pass  # retry on transient network errors
+
+        else:
+            raise TimeoutError("Bright Data scraper timed out")
+
+        # Download results
+        data = await client.get(
+            f"{base_url}/snapshot/{snapshot_id}?format=json",
+            headers=headers,
+            timeout=60.0,
+        )
+        data.raise_for_status()
+        return data.json()

--- a/src/pipeline/dm_identification.py
+++ b/src/pipeline/dm_identification.py
@@ -1,0 +1,156 @@
+"""
+Contract: src/pipeline/dm_identification.py
+Purpose: Decision maker identification pipeline — tiered lookup (LinkedIn → website → ABN)
+Layer: 4 - orchestration-adjacent pipeline
+Imports: integrations
+Consumers: enrichment_flow.py, lead_enrichment_flow.py
+
+dm_identification.py — Decision maker identification pipeline.
+Directive #286
+"""
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Words that indicate a business entity name, not a person name
+_BUSINESS_WORDS = {
+    "PLUMBING", "DENTAL", "SERVICES", "PTY", "LTD", "LIMITED", "TRUST",
+    "FAMILY", "AUSTRALIA", "MANAGEMENT", "GROUP", "HOLDINGS", "PARTNERS",
+    "CONSULTING", "SOLUTIONS", "SYSTEMS", "TECHNOLOGIES", "ENTERPRISES",
+    "INDUSTRIES", "TRADING", "INVESTMENTS", "PROPERTY", "PROPERTIES",
+    "CONSTRUCTION", "ENGINEERING", "MEDICAL", "HEALTH", "CARE",
+    "THE", "AND", "OF", "FOR",
+}
+
+
+@dataclass
+class DMResult:
+    name: Optional[str] = None
+    title: Optional[str] = None
+    source: str = "none"         # brightdata_linkedin | website_scrape | abn_entity
+    confidence: str = "none"     # HIGH | MEDIUM | LOW | none
+    linkedin_url: Optional[str] = None
+    tier_used: str = "none"      # T-DM1 | T-DM2 | T-DM3 | none (for CIS tracking)
+
+
+class DMIdentification:
+    def __init__(self, bd_client=None):
+        """bd_client: instance of BrightDataLinkedInClient (injected for testability)."""
+        self._bd = bd_client
+
+    async def identify(
+        self,
+        domain: str,
+        company_name: str,
+        linkedin_company_url: Optional[str] = None,
+        spider_data: Optional[dict] = None,
+        abn_data: Optional[dict] = None,
+    ) -> DMResult:
+        """
+        Identify the decision maker for a business using tiered fallback logic.
+
+        Returns DMResult with source and tier_used for CIS tracking.
+        """
+        spider_data = spider_data or {}
+        abn_data = abn_data or {}
+
+        # --- Step 1: Bright Data LinkedIn ---
+        if self._bd is not None:
+            linkedin_url = self._resolve_linkedin_url(spider_data, linkedin_company_url)
+            try:
+                people = await self._bd.lookup_company_people(
+                    company_name, domain=domain, linkedin_url=linkedin_url
+                )
+                dm = self._bd.pick_decision_maker(people)
+                if dm and dm.get("name"):
+                    logger.info(
+                        "dm_found source=brightdata_linkedin name=%s confidence=%s",
+                        dm["name"],
+                        dm["confidence"],
+                    )
+                    return DMResult(
+                        name=dm["name"],
+                        title=dm.get("title"),
+                        source="brightdata_linkedin",
+                        confidence=dm["confidence"],
+                        linkedin_url=dm.get("linkedin_url"),
+                        tier_used="T-DM1",
+                    )
+            except Exception:
+                logger.exception("dm_brightdata_failed domain=%s", domain)
+
+        # --- Step 2: Website scrape fallback ---
+        team_names: list[str] = spider_data.get("team_names") or []
+
+        # Also check title field for Dr. names
+        title_text = spider_data.get("title") or ""
+        dr_names = re.findall(r"\bDr\.?\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?", title_text)
+        all_names = team_names + dr_names
+
+        if all_names:
+            first_name = all_names[0]
+            logger.info("dm_found source=website_scrape name=%s", first_name)
+            return DMResult(
+                name=first_name,
+                title=None,
+                source="website_scrape",
+                confidence="MEDIUM",
+                tier_used="T-DM2",
+            )
+
+        # --- Step 3: ABN entity name fallback ---
+        entity_name = abn_data.get("entity_name") or ""
+        if entity_name:
+            candidate = self._extract_name_from_entity(entity_name)
+            if candidate:
+                logger.info("dm_found source=abn_entity name=%s", candidate)
+                return DMResult(
+                    name=candidate,
+                    title=None,
+                    source="abn_entity",
+                    confidence="LOW",
+                    tier_used="T-DM3",
+                )
+
+        # --- Step 4: No DM found ---
+        logger.info("dm_not_found domain=%s", domain)
+        return DMResult()
+
+    def _resolve_linkedin_url(
+        self,
+        spider_data: dict,
+        linkedin_company_url: Optional[str],
+    ) -> Optional[str]:
+        """Try to extract LinkedIn URL from spider_data socials, fallback to param."""
+        socials = spider_data.get("socials") or {}
+        if isinstance(socials, dict):
+            linkedin_slug = socials.get("linkedin")
+            if linkedin_slug:
+                # If it looks like a full URL, use it directly
+                if linkedin_slug.startswith("http"):
+                    return linkedin_slug
+                # Otherwise reconstruct from slug
+                slug = linkedin_slug.strip("/").split("/")[-1]
+                if slug:
+                    return f"https://www.linkedin.com/company/{slug}"
+        return linkedin_company_url
+
+    def _extract_name_from_entity(self, entity_name: str) -> Optional[str]:
+        """
+        Try to extract a person surname from an ABN entity name.
+        Returns title-cased word if found, else None.
+        """
+        words = entity_name.upper().split()
+        # Filter business words and short/non-alpha tokens
+        candidates = [
+            w for w in words
+            if w.isalpha()
+            and len(w) > 2
+            and w not in _BUSINESS_WORDS
+        ]
+        if candidates:
+            return candidates[0].title()
+        return None

--- a/tests/test_integrations/test_brightdata_client.py
+++ b/tests/test_integrations/test_brightdata_client.py
@@ -1,0 +1,123 @@
+"""Tests for src/integrations/brightdata_client.py — Directive #286"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.integrations.brightdata_client import BrightDataLinkedInClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_response(status_code: int, json_data):
+    """Create a mock httpx response."""
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data
+    mock.text = str(json_data)
+    mock.raise_for_status = MagicMock()
+    if status_code >= 400:
+        import httpx
+        mock.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=mock
+        )
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_people_list():
+    """Mock trigger→progress→download; assert 2 employees returned."""
+    client = BrightDataLinkedInClient(api_key="test-key")
+
+    trigger_resp = _make_mock_response(200, {"snapshot_id": "snap123"})
+    progress_resp = _make_mock_response(200, {"status": "ready", "records": 2})
+    download_resp = _make_mock_response(
+        200,
+        [
+            {
+                "company": "Acme",
+                "employees": [
+                    {"name": "Alice Smith", "title": "Owner"},
+                    {"name": "Bob Jones", "title": "Marketing Manager"},
+                ],
+            }
+        ],
+    )
+
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=trigger_resp)
+    mock_http.get = AsyncMock(side_effect=[progress_resp, download_resp])
+    mock_http.is_closed = False
+
+    with patch.object(client, "_get_client", return_value=mock_http):
+        people = await client.lookup_company_people(
+            "Acme Inc", domain="acme.com", linkedin_url="https://linkedin.com/company/acme"
+        )
+
+    assert len(people) == 2
+    assert people[0]["name"] == "Alice Smith"
+
+
+@pytest.mark.asyncio
+async def test_pick_dm_selects_owner_over_manager():
+    """Owner should beat Marketing Manager."""
+    client = BrightDataLinkedInClient(api_key="test-key")
+    people = [
+        {"name": "Bob", "title": "Marketing Manager"},
+        {"name": "Alice", "title": "Owner"},
+    ]
+    result = client.pick_decision_maker(people)
+    assert result is not None
+    assert result["name"] == "Alice"
+    assert result["confidence"] == "HIGH"
+
+
+@pytest.mark.asyncio
+async def test_pick_dm_priority_order():
+    """owner > founder > director > ceo."""
+    client = BrightDataLinkedInClient(api_key="test-key")
+    people = [
+        {"name": "Dave", "title": "CEO"},
+        {"name": "Carol", "title": "Director of Sales"},
+        {"name": "Bob", "title": "Founder"},
+        {"name": "Alice", "title": "Owner"},
+    ]
+    result = client.pick_decision_maker(people)
+    assert result is not None
+    assert result["name"] == "Alice"
+    assert result["confidence"] == "HIGH"
+
+    # Remove owner — founder should win (people[:3] = Dave/Carol/Bob, no Alice)
+    result2 = client.pick_decision_maker(people[:3])
+    assert result2["name"] == "Bob"
+
+    # Remove founder too — director should win (people[:2] = Dave/Carol)
+    result3 = client.pick_decision_maker(people[:2])
+    assert result3["name"] == "Carol"
+
+
+def test_pick_dm_empty_returns_none():
+    """Empty list returns None."""
+    client = BrightDataLinkedInClient(api_key="test-key")
+    assert client.pick_decision_maker([]) is None
+
+
+@pytest.mark.asyncio
+async def test_4xx_raises_valueerror():
+    """HTTP 401 from trigger should raise ValueError."""
+    client = BrightDataLinkedInClient(api_key="bad-key")
+
+    trigger_resp = _make_mock_response(401, {"error": "Unauthorized"})
+
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=trigger_resp)
+    mock_http.is_closed = False
+
+    with patch.object(client, "_get_client", return_value=mock_http):
+        with pytest.raises(ValueError, match="Bright Data API error: 401"):
+            await client._scraper_request("some_dataset", [{"url": "https://example.com"}])

--- a/tests/test_pipeline/test_dm_identification.py
+++ b/tests/test_pipeline/test_dm_identification.py
@@ -1,0 +1,116 @@
+"""Tests for src/pipeline/dm_identification.py — Directive #286"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.pipeline.dm_identification import DMIdentification, DMResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bd_client(people=None, dm=None):
+    """Return a mock BrightDataLinkedInClient."""
+    mock = MagicMock()
+    mock.lookup_company_people = AsyncMock(return_value=people or [])
+    mock.pick_decision_maker = MagicMock(return_value=dm)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identify_uses_linkedin_url_from_spider_data():
+    """spider_data with linkedin social → lookup uses reconstructed URL."""
+    dm_return = {"name": "Alice", "title": "Owner", "linkedin_url": None, "confidence": "HIGH"}
+    bd = _make_bd_client(people=[{"name": "Alice", "title": "Owner"}], dm=dm_return)
+
+    identifier = DMIdentification(bd_client=bd)
+    result = await identifier.identify(
+        domain="example.com",
+        company_name="Example Co",
+        spider_data={"socials": {"linkedin": "example-co"}},
+    )
+
+    called_kwargs = bd.lookup_company_people.call_args
+    assert "https://www.linkedin.com/company/example-co" in str(called_kwargs)
+    assert result.source == "brightdata_linkedin"
+    assert result.tier_used == "T-DM1"
+
+
+@pytest.mark.asyncio
+async def test_identify_falls_back_to_company_name_search():
+    """No linkedin in spider_data → lookup called with linkedin_url=None."""
+    dm_return = {"name": "Bob", "title": "CEO", "linkedin_url": None, "confidence": "MEDIUM"}
+    bd = _make_bd_client(people=[{"name": "Bob", "title": "CEO"}], dm=dm_return)
+
+    identifier = DMIdentification(bd_client=bd)
+    result = await identifier.identify(
+        domain="nolinkedin.com",
+        company_name="No LinkedIn Co",
+        spider_data={},
+    )
+
+    _, kwargs = bd.lookup_company_people.call_args
+    assert kwargs.get("linkedin_url") is None
+    assert result.name == "Bob"
+    assert result.source == "brightdata_linkedin"
+
+
+@pytest.mark.asyncio
+async def test_identify_falls_back_to_spider_names():
+    """bd returns empty → spider_data team_names used."""
+    bd = _make_bd_client(people=[], dm=None)
+
+    identifier = DMIdentification(bd_client=bd)
+    result = await identifier.identify(
+        domain="example.com",
+        company_name="Example Co",
+        spider_data={"team_names": ["Dr. Sarah Jones", "Tom Smith"]},
+    )
+
+    assert result.name == "Dr. Sarah Jones"
+    assert result.source == "website_scrape"
+    assert result.confidence == "MEDIUM"
+    assert result.tier_used == "T-DM2"
+
+
+@pytest.mark.asyncio
+async def test_identify_falls_back_to_abn():
+    """bd empty, no spider names, abn entity → extract name."""
+    bd = _make_bd_client(people=[], dm=None)
+
+    identifier = DMIdentification(bd_client=bd)
+    result = await identifier.identify(
+        domain="ferraridenial.com.au",
+        company_name="Ferrari Dental",
+        spider_data={},
+        abn_data={"entity_name": "FERRARI DENTAL PTY LTD"},
+    )
+
+    assert result.name == "Ferrari"
+    assert result.source == "abn_entity"
+    assert result.confidence == "LOW"
+    assert result.tier_used == "T-DM3"
+
+
+@pytest.mark.asyncio
+async def test_identify_returns_none_result_when_all_empty():
+    """All sources empty → DMResult with all defaults."""
+    bd = _make_bd_client(people=[], dm=None)
+
+    identifier = DMIdentification(bd_client=bd)
+    result = await identifier.identify(
+        domain="mystery.com",
+        company_name="Mystery Corp",
+        spider_data={},
+        abn_data={},
+    )
+
+    assert result.name is None
+    assert result.source == "none"
+    assert result.tier_used == "none"


### PR DESCRIPTION
## Directive #286 — Sprint 4: Decision Maker Identification Layer

### Context
Segment 3 live test returned 20% DM hit rate from free data alone (team page JS blocking, ABN names useless). This directive adds the primary paid DM source.

### New files

#### `src/integrations/brightdata_client.py`
New focused LinkedIn DM client using Scrapers API key `2bab0747...` (distinct from existing `bright_data_client.py`).

- `BrightDataLinkedInClient`
- `lookup_company_people(company_name, domain, linkedin_url)` — trigger→poll→download, cap 20 records
- `pick_decision_maker(people)` — DM_TITLE_PRIORITY scoring (owner > founder > co-founder > director > principal > managing > ceo > ...)
- `_scraper_request()` — 120s timeout; 4xx raises `ValueError`, timeout raises `TimeoutError`; never swallows errors
- Cost: $0.00075/record logged per call

#### `src/pipeline/dm_identification.py`
- `DMResult` dataclass: name, title, source, confidence, linkedin_url, tier_used
- `DMIdentification.identify()` — 4-tier fallback:
  - T-DM1: Bright Data LinkedIn (HIGH/MEDIUM confidence)
  - T-DM2: Spider team page names (MEDIUM)
  - T-DM3: ABN entity name extraction (LOW)
  - none: all sources exhausted
- `_resolve_linkedin_url()` — extracts LinkedIn company slug from spider social links
- `_extract_name_from_entity()` — strips biz words from ABN entity name

### Tests (+10 new)
- `tests/test_integrations/test_brightdata_client.py` — 5 tests
- `tests/test_pipeline/test_dm_identification.py` — 5 tests

### Pytest
```
1044 passed, 28 skipped, 60 warnings in 96.09s
```
(+10 from baseline 1034)

### Notes
- Does NOT modify `bright_data_client.py` (existing Datasets API client)
- `brightdata_client.py` (new) is injection-ready — `bd_client=None` skips paid lookup
- Integration into `free_enrichment.py` / `paid_enrichment.py` in follow-on directive

LAW V ✅ | LAW XIV ✅ | LAW XV ✅