### PR TITLE
feat(pipeline): composite affordability scorer + streaming orchestrator — Directive #288

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -23,10 +23,10 @@ Revenue model for BU: API subscriptions, Salesforce/HubSpot marketplace, bulk an
 
 ## SECTION 2 — CURRENT STATE
 
-- Last directive issued: #287 (SERP-first DM waterfall + AU location filter — COMPLETE)
-- Next directive: #288
-- Test baseline: 1056 passed, 0 failed, 28 skipped (+12 from #287)
-- Last merged PRs: #242–#249 (Sprints 1-4), #250 (Directive #287 pending merge)
+- Last directive issued: #288 (Composite affordability scorer + streaming pipeline orchestrator — COMPLETE)
+- Next directive: #289
+- Test baseline: 1067 passed, 0 failed, 28 skipped (+11 from #288)
+- Last merged PRs: #242–#250 (Sprints 1-4), #251 (Directive #288 pending merge)
 - Spider.cloud: validated, API key in env SPIDER_API_KEY
 - Segment testing: ratified March 29 2026 — Segments 1+2 ready for live test
 - Architecture: **v7 ratified Mar 28 2026** — signal-first organic discovery, free intelligence sweep, proven with live AU data across 5 dental domains
@@ -253,10 +253,65 @@ Waterfall (return on first hit — ordered by hit rate, not cost):
 
 Orchestration: `src/pipeline/dm_identification.py` (`DMIdentification.identify()`)
 Returns: `DMResult(name, title, source, confidence, linkedin_url, tier_used)`
-Note: NOT yet wired into free_enrichment.py / paid_enrichment.py — Directive #288.
+Note: NOT yet wired into free_enrichment.py / paid_enrichment.py — Directive #289.
 
 Cost: $0.01/domain (T-DM1 SERP, 70% hit) → $0.00075/record (T-DM2 BD, fallback)
 Sprint: Sprint 4 (Directive #287)
+
+---
+
+### COMPOSITE AFFORDABILITY SCORING (Directive #288)
+
+`src/pipeline/affordability_scoring.py` — `AffordabilityScorer.score(enrichment)`.
+
+Signal dimensions and point values (max 20):
+
+| Signal | Source | Points |
+|--------|--------|--------|
+| Entity type | ABN | trust=3, company=2, partnership=1 |
+| GST registered | ABN | yes=1 |
+| Google Ads active | Ads Transparency | active+>5=3, active=2, none=0 |
+| Review count | DFS Maps GMB | 0–5=0, 6–20=1, 21–50=2, 51–100=3, 101+=4 |
+| Website sophistication | Spider scrape | professional CMS + tracking + booking + SSL + multi-page (max 5) |
+| Employee signals | Spider team page | 1–2=1, 3–5=2, 6+=3 |
+| Email maturity | DNS | PROFESSIONAL=1 |
+
+Band thresholds: **LOW (0–4, reject)** | **MEDIUM (5–8, pass)** | **HIGH (9–13, pass)** | **VERY_HIGH (14+, pass)**
+
+Hard gates: sole_trader → always reject | gst_registered=False → always reject | unreachable → always reject
+
+Returns `AffordabilityResult(raw_score, band, signals, gaps, passed_gate)`.
+
+`gaps` = plain-English list of zero-scoring signals (e.g. "Not running Google Ads", "Only 3 Google reviews"). **This is what Haiku uses for outreach angle generation.**
+
+---
+
+### STREAMING PIPELINE ORCHESTRATOR (Directive #288)
+
+`src/pipeline/pipeline_orchestrator.py` — `PipelineOrchestrator.run()`.
+
+Agency asks for 100 prospects. System delivers exactly 100. No prediction — keeps pulling until done.
+
+```
+results = []
+while len(results) < target_count:
+    domains = discovery.pull_batch(category_code, location, limit=batch_size, offset=offset)
+    if not domains: break  # category exhausted
+    for domain in domains:
+        enrichment = free_enrichment.enrich(domain)
+        score = scorer.score(enrichment)
+        if not score.passed_gate: continue
+        dm = dm_identification.identify(domain, ...)
+        if not dm.name: continue
+        results.append(ProspectCard(...))
+```
+
+`ProspectCard`: domain, company_name, location, services, **gaps** (from scorer), affordability_band, affordability_score, dm_name, dm_title, dm_linkedin_url, dm_confidence.
+
+`PipelineStats`: discovered / enriched / gate_passed / gate_failed / dm_found / dm_failed / total_cost_usd / elapsed_seconds.
+
+All dependencies injected (fully testable without DB).
+Sprint: Sprint 5 (Directive #288)
 
 ---
 
@@ -534,9 +589,10 @@ v6 era (#271–#277): Layer 2 (discovery), Layer 3 (bulk filter), signal config 
 | Sprint 4 | #285 | Free enrichment quality: ABN confidence, JSON-LD address, email maturity collapse, silent exception fix | COMPLETE — PR #248 merged |
 | Sprint 4 | #286 | DM Identification: BrightDataLinkedInClient + DMIdentification pipeline (4-tier fallback) | COMPLETE — PR #249 merged |
 | Sprint 4 | #287 | SERP-first DM waterfall: DFS SERP T-DM1 (70% hit), BD T-DM2, AU location filter | COMPLETE — PR #250 (pending merge) |
-| Sprint 5 | #288 | Wire DMIdentification into pipeline (free_enrichment.py / paid_enrichment.py) + Segment 4 live test | NEXT |
-| Sprint 5 | #289 | DM discovery: email waterfall (scrape→Leadmagic→ZeroBounce), mobile waterfall, reachability v7 | Queued |
-| Sprint 6 | #288–#289 | Message generation + outreach wiring: Haiku redesign with v7 signal inputs, scheduling engine, quota loop | Queued |
+| Sprint 5 | #288 | Composite affordability scorer (7 signals, 4 bands) + streaming PipelineOrchestrator + ProspectCard | COMPLETE — PR #251 (pending merge) |
+| Sprint 5 | #289 | Wire DMIdentification + orchestrator into pipeline (free_enrichment / paid_enrichment) + Segment 4 live test | NEXT |
+| Sprint 6 | #290 | DM email waterfall (scrape→Leadmagic→ZeroBounce), mobile waterfall, reachability v7 | Queued |
+| Sprint 7 | #291–#292 | Message generation + outreach wiring: Haiku redesign with v7 signal inputs, scheduling engine, quota loop | Queued |
 | Sprint 7 | #290 | Multi-vertical: seed dental, recruitment, IT MSP signal configs + category codes | Queued (parallel with 4–6) |
 | Sprint 8 | #291 | Integration test + hardening: live pipeline test against 100 real domains, cost/quality audit | Queued |
 | Sprint 9 | #292 | Founding customer prep: onboarding wizard, approval flow, territory locking, demo mode | Queued |
@@ -557,7 +613,8 @@ v6 era (#271–#277): Layer 2 (discovery), Layer 3 (bulk filter), signal config 
 | #284 | DFS date params fix (first_date/second_date) + DiscoverySource enum | COMPLETE — PR #247 merged |
 | #285 | Free enrichment quality: ABN confidence, JSON-LD address, EmailMaturity enum, silent exception fix | COMPLETE — PR #248 merged |
 | #286 | DM Identification: BrightDataLinkedInClient (brightdata_client.py) + DMIdentification pipeline (4-tier fallback T-DM1→T-DM3) | COMPLETE — PR #249 merged |
-| #287 | SERP-first DM waterfall: DFS SERP site:linkedin.com/in as T-DM1 (70% hit), BD as T-DM2, AU location filter | COMPLETE — PR #250 (pending merge) |
+| #287 | SERP-first DM waterfall: DFS SERP site:linkedin.com/in as T-DM1 (70% hit), BD as T-DM2, AU location filter | COMPLETE — PR #250 merged |
+| #288 | Composite affordability scorer (AffordabilityScorer, 7 signals, 4 bands) + PipelineOrchestrator + ProspectCard | COMPLETE — PR #251 (pending merge) |
 
 ---
 

--- a/src/pipeline/affordability_scoring.py
+++ b/src/pipeline/affordability_scoring.py
@@ -1,0 +1,210 @@
+"""
+Contract: src/pipeline/affordability_scoring.py
+Purpose: Composite affordability scorer — combines weak signals into a revenue band estimate.
+Layer: 2 - pipeline
+Imports: src.pipeline.free_enrichment (EmailMaturity enum)
+Consumers: src/pipeline/pipeline_orchestrator.py
+Directive #288.
+"""
+from dataclasses import dataclass, field
+from typing import Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Band thresholds
+# ---------------------------------------------------------------------------
+BAND_LOW       = (0,  4)   # reject
+BAND_MEDIUM    = (5,  8)   # pass — small but viable
+BAND_HIGH      = (9,  13)  # pass — strong prospect
+BAND_VERY_HIGH = (14, 20)  # pass — premium prospect
+
+# ---------------------------------------------------------------------------
+# Gap messages (for Haiku outreach context)
+# ---------------------------------------------------------------------------
+GAP_MESSAGES = {
+    "no_ads":       "Not running Google Ads",
+    "low_reviews":  "Only {count} Google reviews",  # format with actual count
+    "basic_cms":    "Basic website platform",
+    "no_tracking":  "No analytics installed",
+    "no_booking":   "No online booking system",
+    "webmail":      "Using Gmail/Outlook, not professional email",
+    "no_website":   "No website found",
+    "sole_trader":  "Sole trader — too small",
+    "no_gst":       "Not GST registered",
+}
+
+
+@dataclass
+class AffordabilityResult:
+    raw_score: int
+    band: str           # LOW | MEDIUM | HIGH | VERY_HIGH
+    signals: dict       # signal_name -> points awarded
+    gaps: list          # plain English gap strings for Haiku
+    passed_gate: bool
+
+
+class AffordabilityScorer:
+    """
+    Scores a domain on composite affordability using free enrichment signals.
+    Returns AffordabilityResult with band, score, signals dict, and gaps list.
+    """
+
+    def score(self, enrichment: dict) -> AffordabilityResult:
+        signals = {}
+        gaps = []
+
+        # --- Hard gates ---
+        entity_type = (enrichment.get("entity_type") or "").lower()
+        gst = enrichment.get("gst_registered")
+        reachable = enrichment.get("website_cms") is not None or enrichment.get("abn_matched")
+
+        if "sole trader" in entity_type or "individual" in entity_type:
+            return AffordabilityResult(
+                raw_score=0, band="LOW", signals={"hard_gate": "sole_trader"},
+                gaps=[GAP_MESSAGES["sole_trader"]], passed_gate=False
+            )
+
+        if gst is False:
+            return AffordabilityResult(
+                raw_score=0, band="LOW", signals={"hard_gate": "no_gst"},
+                gaps=[GAP_MESSAGES["no_gst"]], passed_gate=False
+            )
+
+        if not reachable:
+            return AffordabilityResult(
+                raw_score=0, band="LOW", signals={"hard_gate": "unreachable"},
+                gaps=[GAP_MESSAGES["no_website"]], passed_gate=False
+            )
+
+        # --- Entity type ---
+        et = (enrichment.get("entity_type") or "").lower()
+        if "trust" in et:
+            signals["entity_type"] = 3
+        elif "company" in et or "pty" in et or "ltd" in et:
+            signals["entity_type"] = 2
+        elif "partner" in et:
+            signals["entity_type"] = 1
+        else:
+            signals["entity_type"] = 0
+
+        # --- GST registered ---
+        signals["gst_registered"] = 1 if gst else 0
+
+        # --- Google Ads active ---
+        ads_active = enrichment.get("is_running_ads") or False
+        ads_count = enrichment.get("ads_count") or 0
+        if ads_active and ads_count > 5:
+            signals["google_ads"] = 3
+        elif ads_active:
+            signals["google_ads"] = 2
+        else:
+            signals["google_ads"] = 0
+            gaps.append(GAP_MESSAGES["no_ads"])
+
+        # --- Review count ---
+        review_count = enrichment.get("gmb_review_count") or 0
+        if review_count >= 101:
+            signals["review_count"] = 4
+        elif review_count >= 51:
+            signals["review_count"] = 3
+        elif review_count >= 21:
+            signals["review_count"] = 2
+        elif review_count >= 6:
+            signals["review_count"] = 1
+        else:
+            signals["review_count"] = 0
+            gaps.append(GAP_MESSAGES["low_reviews"].format(count=review_count))
+
+        # --- Website sophistication (max 5) ---
+        website_score = 0
+        cms = (enrichment.get("website_cms") or "").lower()
+        professional_cms = ["wordpress", "squarespace", "shopify", "webflow", "wix",
+                            "custom", "react", "next", "nuxt", "gatsby"]
+        if any(c in cms for c in professional_cms):
+            website_score += 1
+        else:
+            gaps.append(GAP_MESSAGES["basic_cms"])
+
+        tracking = enrichment.get("website_tracking_codes") or []
+        if tracking:
+            website_score += 1
+        else:
+            gaps.append(GAP_MESSAGES["no_tracking"])
+
+        # Booking system — look for booking signals in tech stack or tracking
+        tech = enrichment.get("website_tech_stack") or []
+        booking_signals = ["calendly", "acuity", "mindbody", "timely", "bookeo",
+                           "appointy", "fresha", "shortcuts", "booking"]
+        has_booking = any(
+            b in (enrichment.get("website_cms") or "").lower() or
+            any(b in t.lower() for t in tech) or
+            any(b in t.lower() for t in tracking)
+            for b in booking_signals
+        )
+        if has_booking:
+            website_score += 1
+        else:
+            gaps.append(GAP_MESSAGES["no_booking"])
+
+        # SSL — if we scraped it, it had SSL (spider follows https)
+        if enrichment.get("website_ssl") or enrichment.get("website_cms"):
+            website_score += 1
+
+        # Multiple pages
+        pages = enrichment.get("website_page_links") or []
+        if len(pages) > 1 or enrichment.get("website_cms"):
+            website_score += 1
+
+        signals["website"] = min(website_score, 5)
+
+        # --- Employee signals ---
+        team_names = enrichment.get("website_team_names") or []
+        n = len(team_names)
+        if n >= 6:
+            signals["employees"] = 3
+        elif n >= 3:
+            signals["employees"] = 2
+        elif n >= 1:
+            signals["employees"] = 1
+        else:
+            signals["employees"] = 0
+
+        # --- Email maturity ---
+        from src.pipeline.free_enrichment import EmailMaturity
+        em = enrichment.get("email_maturity")
+        if em == EmailMaturity.PROFESSIONAL or em == "PROFESSIONAL":
+            signals["email_maturity"] = 1
+        else:
+            signals["email_maturity"] = 0
+            if em == EmailMaturity.WEBMAIL or em == "WEBMAIL":
+                gaps.append(GAP_MESSAGES["webmail"])
+
+        # --- Total ---
+        raw_score = sum(signals.values())
+
+        # Band
+        if raw_score >= 14:
+            band = "VERY_HIGH"
+        elif raw_score >= 9:
+            band = "HIGH"
+        elif raw_score >= 5:
+            band = "MEDIUM"
+        else:
+            band = "LOW"
+
+        passed_gate = band != "LOW"
+
+        logger.info(
+            "affordability_scored domain_score=%d band=%s passed=%s",
+            raw_score, band, passed_gate,
+        )
+
+        return AffordabilityResult(
+            raw_score=raw_score,
+            band=band,
+            signals=signals,
+            gaps=gaps,
+            passed_gate=passed_gate,
+        )

--- a/src/pipeline/pipeline_orchestrator.py
+++ b/src/pipeline/pipeline_orchestrator.py
@@ -1,0 +1,192 @@
+"""
+Contract: src/pipeline/pipeline_orchestrator.py
+Purpose: Streaming pipeline that pulls domain batches until it reaches the
+         target number of viable prospects with DMs.
+Layer: 2 - pipeline
+Imports: src.pipeline.affordability_scoring
+Consumers: orchestration layer
+Directive #288.
+"""
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Optional, Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineStats:
+    discovered: int = 0
+    enriched: int = 0
+    enrichment_failed: int = 0
+    gate_passed: int = 0
+    gate_failed: int = 0
+    dm_found: int = 0
+    dm_failed: int = 0
+    total_cost_usd: float = 0.0
+    elapsed_seconds: float = 0.0
+
+
+@dataclass
+class ProspectCard:
+    domain: str
+    company_name: str
+    location: str
+    services: list = field(default_factory=list)
+    gaps: list = field(default_factory=list)
+    affordability_band: str = "UNKNOWN"
+    affordability_score: int = 0
+    dm_name: Optional[str] = None
+    dm_title: Optional[str] = None
+    dm_linkedin_url: Optional[str] = None
+    dm_confidence: Optional[str] = None
+
+
+@dataclass
+class PipelineResult:
+    prospects: list  # list[ProspectCard]
+    stats: PipelineStats
+
+
+class PipelineOrchestrator:
+    """
+    Streaming pipeline orchestrator.
+    Pulls domain batches until target_count viable prospects with DMs are found.
+
+    Injection-ready: all dependencies injected via __init__ for testability.
+
+    Args:
+        discovery: has method pull_batch(category_code, location, limit, offset) -> list[dict]
+        free_enrichment: has method enrich(domain) -> dict | None
+        affordability_scorer: AffordabilityScorer instance
+        dm_identification: DMIdentification instance
+    """
+
+    def __init__(
+        self,
+        discovery,
+        free_enrichment,
+        affordability_scorer,
+        dm_identification,
+    ):
+        self._discovery = discovery
+        self._enrichment = free_enrichment
+        self._scorer = affordability_scorer
+        self._dm = dm_identification
+
+    async def run(
+        self,
+        category_code: str,
+        location: str = "Australia",
+        target_count: int = 100,
+        batch_size: int = 50,
+    ) -> PipelineResult:
+        """
+        Pull domain batches until target_count prospects with DMs found.
+
+        Stops early if category is exhausted (pull_batch returns empty).
+        Tracks stats for cost/quality audit.
+        """
+        results: list[ProspectCard] = []
+        offset = 0
+        stats = PipelineStats()
+        t0 = time.monotonic()
+
+        while len(results) < target_count:
+            # --- Discovery ---
+            try:
+                domains = await self._discovery.pull_batch(
+                    category_code=category_code,
+                    location=location,
+                    limit=batch_size,
+                    offset=offset,
+                )
+            except Exception:
+                logger.exception("orchestrator_discovery_failed offset=%d", offset)
+                break
+
+            if not domains:
+                logger.info("orchestrator_category_exhausted at offset=%d", offset)
+                break
+
+            offset += batch_size
+            stats.discovered += len(domains)
+
+            for domain_data in domains:
+                if len(results) >= target_count:
+                    break
+
+                domain = domain_data if isinstance(domain_data, str) else domain_data.get("domain", "")
+                if not domain:
+                    stats.enrichment_failed += 1
+                    continue
+
+                # --- Free enrichment ---
+                try:
+                    enrichment = await self._enrichment.enrich(domain)
+                except Exception:
+                    logger.exception("orchestrator_enrich_failed domain=%s", domain)
+                    enrichment = None
+
+                if not enrichment:
+                    stats.enrichment_failed += 1
+                    continue
+                stats.enriched += 1
+
+                # --- Affordability gate ---
+                score = self._scorer.score(enrichment)
+                if not score.passed_gate:
+                    stats.gate_failed += 1
+                    continue
+                stats.gate_passed += 1
+
+                # --- DM identification ---
+                try:
+                    company_name = (
+                        enrichment.get("company_name")
+                        or enrichment.get("abn_entity_name")
+                        or domain
+                    )
+                    dm_result = await self._dm.identify(
+                        domain=domain,
+                        company_name=company_name,
+                        spider_data=enrichment,
+                        abn_data=enrichment,
+                    )
+                except Exception:
+                    logger.exception("orchestrator_dm_failed domain=%s", domain)
+                    dm_result = None
+
+                if not dm_result or not dm_result.name:
+                    stats.dm_failed += 1
+                    continue
+                stats.dm_found += 1
+
+                # --- Build ProspectCard ---
+                card = ProspectCard(
+                    domain=domain,
+                    company_name=company_name,
+                    location=enrichment.get("website_address", {}).get("suburb", location),
+                    services=enrichment.get("services") or [],
+                    gaps=score.gaps,
+                    affordability_band=score.band,
+                    affordability_score=score.raw_score,
+                    dm_name=dm_result.name,
+                    dm_title=dm_result.title,
+                    dm_linkedin_url=dm_result.linkedin_url,
+                    dm_confidence=dm_result.confidence,
+                )
+                results.append(card)
+                logger.info(
+                    "prospect_found domain=%s band=%s dm=%s",
+                    domain, score.band, dm_result.name,
+                )
+
+        stats.elapsed_seconds = time.monotonic() - t0
+        logger.info(
+            "orchestrator_complete prospects=%d discovered=%d elapsed=%.1fs",
+            len(results), stats.discovered, stats.elapsed_seconds,
+        )
+        return PipelineResult(prospects=results, stats=stats)

--- a/tests/test_pipeline/test_affordability_scoring.py
+++ b/tests/test_pipeline/test_affordability_scoring.py
@@ -1,0 +1,114 @@
+"""Tests for AffordabilityScorer — Directive #288."""
+import pytest
+from src.pipeline.affordability_scoring import AffordabilityScorer, AffordabilityResult
+
+
+@pytest.fixture
+def scorer():
+    return AffordabilityScorer()
+
+
+def test_sole_trader_always_rejected(scorer):
+    enrichment = {
+        "entity_type": "Individual/Sole Trader",
+        "gst_registered": True,
+        "website_cms": "wordpress",
+    }
+    result = scorer.score(enrichment)
+    assert result.passed_gate is False
+    assert "sole_trader" in str(result.signals)
+
+
+def test_gst_false_always_rejected(scorer):
+    enrichment = {
+        "entity_type": "Company",
+        "gst_registered": False,
+    }
+    result = scorer.score(enrichment)
+    assert result.passed_gate is False
+
+
+def test_high_band_scenario(scorer):
+    enrichment = {
+        "entity_type": "Company",
+        "gst_registered": True,
+        "is_running_ads": True,
+        "ads_count": 8,
+        "gmb_review_count": 55,
+        "website_cms": "wordpress",
+        "website_tracking_codes": ["ga4"],
+        "website_team_names": ["Alice Smith", "Bob Jones", "Carol White"],
+        "email_maturity": "PROFESSIONAL",
+        "abn_matched": True,
+    }
+    result = scorer.score(enrichment)
+    assert result.band in ("HIGH", "VERY_HIGH")
+    assert result.passed_gate is True
+
+
+def test_low_band_scenario(scorer):
+    enrichment = {
+        "entity_type": "Partnership",
+        "gst_registered": True,
+        "is_running_ads": False,
+        "gmb_review_count": 2,
+        "website_cms": None,
+        "website_tracking_codes": [],
+        "website_team_names": [],
+        "email_maturity": "NONE",
+        "abn_matched": True,  # reachable so not hard-gated
+    }
+    result = scorer.score(enrichment)
+    assert result.passed_gate is False
+    assert result.band == "LOW"
+
+
+def test_gaps_populated_from_zero_signals(scorer):
+    enrichment = {
+        "entity_type": "Company",
+        "gst_registered": True,
+        "is_running_ads": False,
+        "gmb_review_count": 3,
+        "website_cms": None,
+        "website_tracking_codes": [],
+        "email_maturity": "NONE",
+        "abn_matched": True,
+    }
+    result = scorer.score(enrichment)
+    assert "Not running Google Ads" in result.gaps
+    assert any("Google reviews" in g for g in result.gaps)
+
+
+def test_no_ads_gap_in_gaps(scorer):
+    enrichment = {
+        "entity_type": "Company",
+        "gst_registered": True,
+        "is_running_ads": False,
+        "gmb_review_count": 60,
+        "website_cms": "wordpress",
+        "website_tracking_codes": ["ga4", "gtm"],
+        "website_team_names": ["Alice", "Bob", "Carol", "Dave", "Eve", "Frank"],
+        "email_maturity": "PROFESSIONAL",
+        "abn_matched": True,
+    }
+    result = scorer.score(enrichment)
+    assert "Not running Google Ads" in result.gaps
+
+
+def test_professional_email_adds_point(scorer):
+    base = {
+        "entity_type": "Company",
+        "gst_registered": True,
+        "is_running_ads": False,
+        "gmb_review_count": 10,
+        "website_cms": "wordpress",
+        "website_tracking_codes": ["ga4"],
+        "website_team_names": ["Alice"],
+        "abn_matched": True,
+    }
+    professional = {**base, "email_maturity": "PROFESSIONAL"}
+    none_email = {**base, "email_maturity": "NONE"}
+
+    r_pro = scorer.score(professional)
+    r_none = scorer.score(none_email)
+    assert r_pro.raw_score == r_none.raw_score + 1

--- a/tests/test_pipeline/test_pipeline_orchestrator.py
+++ b/tests/test_pipeline/test_pipeline_orchestrator.py
@@ -1,0 +1,189 @@
+"""Tests for PipelineOrchestrator — Directive #288."""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from src.pipeline.pipeline_orchestrator import PipelineOrchestrator, ProspectCard, PipelineResult
+
+
+def make_enrichment():
+    return {
+        "entity_type": "Company",
+        "gst_registered": True,
+        "is_running_ads": True,
+        "ads_count": 8,
+        "gmb_review_count": 55,
+        "website_cms": "wordpress",
+        "website_tracking_codes": ["ga4"],
+        "website_team_names": ["Alice", "Bob", "Carol"],
+        "email_maturity": "PROFESSIONAL",
+        "abn_matched": True,
+        "company_name": "Test Co Pty Ltd",
+        "website_address": {"suburb": "Sydney"},
+    }
+
+
+def make_dm_result(name="Alice Owner"):
+    dm = MagicMock()
+    dm.name = name
+    dm.title = "Owner"
+    dm.linkedin_url = "https://linkedin.com/in/alice"
+    dm.confidence = "HIGH"
+    return dm
+
+
+def make_score_result(passed=True, band="HIGH", score=10, gaps=None):
+    result = MagicMock()
+    result.passed_gate = passed
+    result.band = band
+    result.raw_score = score
+    result.gaps = gaps or []
+    return result
+
+
+def make_orchestrator(discovery, free_enrichment, scorer, dm):
+    return PipelineOrchestrator(
+        discovery=discovery,
+        free_enrichment=free_enrichment,
+        affordability_scorer=scorer,
+        dm_identification=dm,
+    )
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_stops_at_target():
+    # 10 domains per batch, each passes all stages
+    discovery = MagicMock()
+    discovery.pull_batch = AsyncMock(return_value=[{"domain": f"domain{i}.com"} for i in range(10)])
+
+    free_enrichment = MagicMock()
+    free_enrichment.enrich = AsyncMock(return_value=make_enrichment())
+
+    scorer = MagicMock()
+    scorer.score = MagicMock(return_value=make_score_result())
+
+    dm = MagicMock()
+    dm.identify = AsyncMock(return_value=make_dm_result())
+
+    orch = make_orchestrator(discovery, free_enrichment, scorer, dm)
+    result = await orch.run("beauty_salon", target_count=5, batch_size=10)
+
+    assert len(result.prospects) == 5
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_stops_on_category_exhausted():
+    call_count = 0
+
+    async def pull_batch(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return [{"domain": f"domain{i}.com"} for i in range(3)]
+        return []
+
+    discovery = MagicMock()
+    discovery.pull_batch = pull_batch
+
+    free_enrichment = MagicMock()
+    free_enrichment.enrich = AsyncMock(return_value=make_enrichment())
+
+    scorer = MagicMock()
+    scorer.score = MagicMock(return_value=make_score_result())
+
+    dm = MagicMock()
+    dm.identify = AsyncMock(return_value=make_dm_result())
+
+    orch = make_orchestrator(discovery, free_enrichment, scorer, dm)
+    result = await orch.run("beauty_salon", target_count=100, batch_size=10)
+
+    assert len(result.prospects) == 3
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_tracks_stats():
+    """
+    5 domains:
+      domain0 — enrich returns None → enrichment_failed
+      domain1 — gate_failed
+      domain2 — gate_failed
+      domain3 — dm_failed (dm.name is None)
+      domain4 — success
+    """
+    domains = [{"domain": f"domain{i}.com"} for i in range(5)]
+
+    discovery = MagicMock()
+    discovery.pull_batch = AsyncMock(side_effect=[domains, []])
+
+    enrich_responses = [None, make_enrichment(), make_enrichment(), make_enrichment(), make_enrichment()]
+    enrich_iter = iter(enrich_responses)
+
+    async def enrich(domain):
+        return next(enrich_iter)
+
+    free_enrichment = MagicMock()
+    free_enrichment.enrich = enrich
+
+    score_responses = [
+        make_score_result(passed=False),
+        make_score_result(passed=False),
+        make_score_result(passed=True),
+        make_score_result(passed=True),
+    ]
+    score_iter = iter(score_responses)
+
+    scorer = MagicMock()
+    scorer.score = MagicMock(side_effect=lambda e: next(score_iter))
+
+    dm_responses = [make_dm_result(name=None), make_dm_result(name="Alice")]
+    dm_iter = iter(dm_responses)
+
+    async def identify(**kwargs):
+        return next(dm_iter)
+
+    dm = MagicMock()
+    dm.identify = identify
+
+    orch = make_orchestrator(discovery, free_enrichment, scorer, dm)
+    result = await orch.run("beauty_salon", target_count=10, batch_size=10)
+
+    assert result.stats.discovered == 5
+    assert result.stats.enrichment_failed == 1
+    assert result.stats.gate_failed == 2
+    assert result.stats.dm_failed == 1
+    assert result.stats.dm_found == 1
+
+
+@pytest.mark.asyncio
+async def test_prospect_card_fields():
+    domains = [{"domain": "example.com"}]
+
+    discovery = MagicMock()
+    discovery.pull_batch = AsyncMock(side_effect=[domains, []])
+
+    enrichment = make_enrichment()
+    free_enrichment = MagicMock()
+    free_enrichment.enrich = AsyncMock(return_value=enrichment)
+
+    scorer = MagicMock()
+    scorer.score = MagicMock(return_value=make_score_result(band="HIGH", score=11, gaps=["Not running Google Ads"]))
+
+    dm = MagicMock()
+    dm.identify = AsyncMock(return_value=make_dm_result())
+
+    orch = make_orchestrator(discovery, free_enrichment, scorer, dm)
+    result = await orch.run("beauty_salon", target_count=1, batch_size=10)
+
+    assert len(result.prospects) == 1
+    card = result.prospects[0]
+
+    assert card.domain == "example.com"
+    assert isinstance(card.company_name, str) and card.company_name
+    assert isinstance(card.location, str)
+    assert isinstance(card.gaps, list)
+    assert isinstance(card.affordability_band, str)
+    assert isinstance(card.affordability_score, int)
+    assert isinstance(card.dm_name, str) and card.dm_name
+    # dm_title, dm_linkedin_url, dm_confidence may be any value (including None)
+    assert hasattr(card, "dm_title")
+    assert hasattr(card, "dm_linkedin_url")
+    assert hasattr(card, "dm_confidence")


### PR DESCRIPTION
## Directive #288 — Composite affordability score + streaming pipeline orchestrator

### New files

#### `src/pipeline/affordability_scoring.py`
- `AffordabilityResult` dataclass: `raw_score`, `band`, `signals`, `gaps`, `passed_gate`
- `AffordabilityScorer.score(enrichment)` — 7 signal dimensions:
  - Entity type (0–3): trust=3, company=2, partnership=1
  - GST registered (0–1)
  - Google Ads active (0–3): active+>5ads=3, active=2, none=0
  - Review count (0–4): 0–5=0, 6–20=1, 21–50=2, 51–100=3, 101+=4
  - Website sophistication (0–5): professional CMS, tracking, booking, SSL, multiple pages
  - Employee signals (0–3): 1–2=1, 3–5=2, 6+=3
  - Email maturity (0–1): PROFESSIONAL=1
- Band thresholds: LOW (0–4 reject) | MEDIUM (5–8) | HIGH (9–13) | VERY_HIGH (14+)
- Hard gates: sole_trader → reject, gst_registered=False → reject, unreachable → reject
- `GAP_MESSAGES`: 6 plain-English gap strings for Haiku outreach context

#### `src/pipeline/pipeline_orchestrator.py`
- `PipelineStats` dataclass: discovered/enriched/gate_passed/gate_failed/dm_found/dm_failed/cost/elapsed
- `ProspectCard` dataclass: domain, company_name, location, services, gaps, affordability_band, affordability_score, dm_name, dm_title, dm_linkedin_url, dm_confidence
- `PipelineResult` dataclass: prospects + stats
- `PipelineOrchestrator.run(category_code, location, target_count, batch_size)`:
  - Pulls batches via `discovery.pull_batch()`
  - Per domain: enrich → affordability gate → DM identify → ProspectCard
  - Stops when `target_count` reached OR category exhausted
  - All dependencies injected (fully testable without DB)

### Tests (+11 new)
- `tests/test_pipeline/test_affordability_scoring.py` (7 tests)
- `tests/test_pipeline/test_pipeline_orchestrator.py` (4 tests)

### Pytest
```
1067 passed, 28 skipped, 60 warnings in 95.45s
```
(+11 from baseline 1056)

### Notes
- `DMIdentification` and enrichment dependencies fully injected — orchestrator is pure logic
- `is_running_ads` treated as False if absent from enrichment_data (stub field — Sprint 5)
- `gaps` field on ProspectCard is what Haiku uses for outreach angle generation (Directive #8)
- Not yet wired to DB/BU — pipeline_orchestrator uses protocol interfaces, not concrete classes

LAW V ✅ | LAW XIV ✅ | LAW XV ✅