### PR TITLE
feat(scoring): two-dimension prospect scorer + real ads detection — Directive #291

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -23,9 +23,9 @@ Revenue model for BU: API subscriptions, Salesforce/HubSpot marketplace, bulk an
 
 ## SECTION 2 — CURRENT STATE
 
-- Last directive issued: #290 (Orchestrator wiring + GMB + ads stub — COMPLETE)
-- Next directive: #291
-- Test baseline: 1088 passed, 0 failed, 28 skipped (+21 from #290)
+- Last directive issued: #291 (Two-dimension prospect scorer + real ads detection — COMPLETE)
+- Next directive: #292
+- Test baseline: 1120 passed, 0 failed, 28 skipped (+32 from #291)
 - Last merged PRs: #242–#253 (Sprints 1-5), #289+#290 pending merge
 - Spider.cloud: validated, API key in env SPIDER_API_KEY
 - Segment testing: ratified March 29 2026 — Segments 1+2 ready for live test
@@ -261,23 +261,46 @@ Sprint: Sprint 4 (Directive #287)
 
 ---
 
-### COMPOSITE AFFORDABILITY SCORING (Directive #288)
+### TWO-DIMENSION PROSPECT SCORING (Directive #291)
 
-`src/pipeline/affordability_scoring.py` — `AffordabilityScorer.score(enrichment)`.
+`src/pipeline/prospect_scorer.py` — `ProspectScorer` (replaces AffordabilityScorer in orchestrator).
+`AffordabilityScorer` (pipeline/affordability_scoring.py) left in place but disconnected from pipeline.
 
-Signal dimensions and point values (max 20):
+**Dimension 1: Affordability** — can they pay?
 
-| Signal | Source | Points |
-|--------|--------|--------|
-| Entity type | ABN | trust=3, company=2, partnership=1 |
-| GST registered | ABN | yes=1 |
-| Google Ads active | Ads Transparency | active+>5=3, active=2, none=0 |
-| Review count | DFS Maps GMB | 0–5=0, 6–20=1, 21–50=2, 51–100=3, 101+=4 |
-| Website sophistication | Spider scrape | professional CMS + tracking + booking + SSL + multi-page (max 5) |
-| Employee signals | Spider team page | 1–2=1, 3–5=2, 6+=3 |
-| Email maturity | DNS | PROFESSIONAL=1 |
+Hard gates (reject immediately): sole_trader, gst=False, unreachable (no website + no ABN).
 
-Band thresholds: **LOW (0–4, reject)** | **MEDIUM (5–8, pass)** | **HIGH (9–13, pass)** | **VERY_HIGH (14+, pass)**
+Soft signals: entity_type (trust/company/partner), GST, professional email, CMS, SSL, multi-page.
+
+Bands: **LOW (reject)** | **MEDIUM** | **HIGH** | **VERY_HIGH**. Gate passes at score ≥ 3.
+
+**Dimension 2: Intent** — will they buy?
+
+Free signals (from Spider HTML — zero extra cost):
+- website_no_analytics: has website but no GA4/GTM
+- ads_tag_no_conversion: AW- tag in HTML but no conversion tracking
+- meta_pixel: Facebook Pixel present
+- social_links, booking_no_analytics, stale_cms
+
+Band: **NOT_TRYING (skip paid enrichment)** | **DABBLING** | **TRYING** | **STRUGGLING**
+
+Full intent score (adds paid signals after free gate passes):
+- running_gads: DFS Ads Search confirms active Google Ads ($0.002/call)
+- gmb_established: GMB review count > 20
+
+**Evidence strings**: each signal generates a plain-English paired statement (effort + gap) for Haiku message generation. Example: "Running Google Ads but missing conversion tracking — wasting budget"
+
+**Pipeline gate flow** (Directive #291):
+```
+1. Free enrichment (Spider + DNS + ABN)
+2. GATE 1: Affordability → reject sole traders, no GST, unreachable
+3. GATE 2: Intent free → NOT_TRYING skips paid enrichment  
+4. Paid enrichment (gate passers only): DFS Ads Search + DFS Maps GMB
+5. Full intent score with paid signals
+6. DM identification
+7. Reachability check (LinkedIn or email)
+8. Build ProspectCard with evidence for Haiku
+```
 
 Hard gates: sole_trader → always reject | gst_registered=False → always reject | unreachable → always reject
 
@@ -481,7 +504,7 @@ Approval flow:
 |--------|------|------|--------|
 | ABN registry local JOIN | GST status (confirms $75k+ revenue), entity type, registration date | FREE | ✅ Live — 2,418,836 rows |
 | Website scrape (Spider.cloud) | Tech stack, CMS, tracking codes (GA4, GTM, Meta Pixel, Google Ads), contact info, JSON-LD address | FREE (direct HTTP) / $0.01/page (Spider.cloud) | ✅ Proven (10/10 Segment 2 test, Mar 2026) |
-| Google Ads Transparency Center | Binary: is business running Google Ads | FREE | ⚠️ STUB — `src/integrations/ads_transparency.py` returns None. No public API. Sprint 6: implement via Playwright or Bright Data Ads dataset. `is_running_ads` and `ads_count` always 0 until implemented. |
+| Google Ads Detection (two-tier) | Binary: is business running Google Ads | FREE (tag) + $0.002 (DFS) | ✅ LIVE — Directive #291. Tier 1: Spider AW-tag/Meta Pixel detection (free, 4/10 dental SMBs detected). Tier 2: DFS /ads_search/live/advanced (3/10 detected, complementary). Combined: 5/10 (50%) hit rate on dental SMBs. |
 | DNS + MX/SPF/DKIM check | Email maturity scoring (PROFESSIONAL/WEBMAIL/NONE), MX provider | FREE | ✅ Live — Segment 2 validated. DKIM excluded from scoring (0/10 AU SMBs have detectable DKIM). |
 | Phone carrier lookup | AU mobile carrier validation | FREE | Planned Sprint 5 |
 
@@ -593,7 +616,8 @@ v6 era (#271–#277): Layer 2 (discovery), Layer 3 (bulk filter), signal config 
 | Sprint 5 | #288 | Composite affordability scorer (7 signals, 4 bands) + streaming PipelineOrchestrator + ProspectCard | COMPLETE — PR #251 (pending merge) |
 | Sprint 5 | #289 | ABN multi-strategy matching waterfall (4 strategies, 8/10 live match rate) | COMPLETE — PR #252 |
 | Sprint 5 | #290 | Wire orchestrator: pull_batch + enrich methods, DFS Maps GMB, ads transparency stub | COMPLETE — PR #253 |
-| Sprint 6 | #291 | DM email waterfall (scrape→Leadmagic→ZeroBounce), mobile waterfall, reachability v7 | NEXT |
+| Sprint 6 | #291 | Two-dimension ProspectScorer (Affordability+Intent), DFS Ads Search, Spider ad tag detection, new orchestrator gates | COMPLETE — PR #254 |
+| Sprint 6 | #292 | DM email waterfall (scrape→Leadmagic→ZeroBounce), mobile waterfall, reachability v7 | NEXT |
 | Sprint 7 | #292–#293 | Message generation + outreach wiring: Haiku redesign with v7 signal inputs, scheduling engine, quota loop | Queued |
 | Sprint 8 | #294 | Multi-vertical: seed dental, recruitment, IT MSP signal configs + category codes | Queued |
 | Sprint 9 | #295 | Integration test + hardening: live pipeline test against 100 real domains, cost/quality audit | Queued |
@@ -620,6 +644,7 @@ v6 era (#271–#277): Layer 2 (discovery), Layer 3 (bulk filter), signal config 
 | #288 | Composite affordability scorer (AffordabilityScorer, 7 signals, 4 bands) + PipelineOrchestrator + ProspectCard | COMPLETE — PR #251 merged |
 | #289 | ABN multi-strategy matching: 4-strategy waterfall, domain/title/suburb/live-API, PTY LTD stripping, 8/10 live match rate | COMPLETE — PR #252 |
 | #290 | Orchestrator wiring: pull_batch + enrich methods, DFS Maps GMB (maps_search_gmb), ads transparency stub | COMPLETE — PR #253 |
+| #291 | Two-dimension ProspectScorer: score_affordability + score_intent_free + score_intent_full. DFS Ads Search ($0.002/call). Spider AW-tag/Meta Pixel detection (free). Gated orchestrator flow. | COMPLETE — PR #254 |
 
 ---
 

--- a/src/clients/dfs_labs_client.py
+++ b/src/clients/dfs_labs_client.py
@@ -93,6 +93,8 @@ class DFSLabsClient:
         self._cost_search_linkedin_people = Decimal("0")
         # SERP Google Maps GMB lookup (Directive #290)
         self._cost_maps_search_gmb = Decimal("0")
+        # Ads Search by domain (Directive #291)
+        self._cost_ads_search_by_domain = Decimal("0")
 
         # Cache for get_categories (free, rarely changes)
         self._categories_cache: list[dict] | None = None
@@ -133,6 +135,7 @@ class DFSLabsClient:
             + self._cost_bulk_domain_metrics
             + self._cost_search_linkedin_people
             + self._cost_maps_search_gmb
+            + self._cost_ads_search_by_domain
         )
         return float(total)
 
@@ -153,6 +156,7 @@ class DFSLabsClient:
             + self._cost_bulk_domain_metrics
             + self._cost_search_linkedin_people
             + self._cost_maps_search_gmb
+            + self._cost_ads_search_by_domain
         )
         return float(total_usd * AUD_RATE)
 
@@ -786,6 +790,68 @@ class DFSLabsClient:
             "gmb_address": item.get("address"),
             "gmb_phone": item.get("phone"),
             "gmb_found": True,
+        }
+
+    # ============================================
+    # ENDPOINT 9d: ads_search_by_domain  (Directive #291)
+    # ============================================
+
+    async def ads_search_by_domain(
+        self,
+        domain: str,
+        location_name: str = "Australia",
+    ) -> dict | None:
+        """
+        Check if a domain is running Google Ads via Ads Transparency endpoint.
+        Endpoint: /v3/serp/google/ads_search/live/advanced
+        Cost: $0.002/call.
+        Status 40102 = no ads found (not an error).
+        Returns dict with is_running_ads, ad_count, formats, first_shown, last_shown
+        or None on error.
+        """
+        try:
+            result = await self._post(
+                endpoint="/v3/serp/google/ads_search/live/advanced",
+                payload=[
+                    {
+                        "target": domain,
+                        "location_name": location_name,
+                        "language_name": "English",
+                    }
+                ],
+                cost_per_call=Decimal("0.002"),
+                cost_attr="_cost_ads_search_by_domain",
+            )
+        except Exception as exc:
+            logger.warning("ads_search_by_domain error for %s: %s", domain, exc)
+            return None
+
+        items = result.get("items") or []
+        if not items:
+            return {
+                "is_running_ads": False,
+                "ad_count": 0,
+                "formats": [],
+                "first_shown": None,
+                "last_shown": None,
+            }
+
+        dates = []
+        formats = set()
+        for item in items:
+            formats.add(item.get("format") or item.get("type") or "unknown")
+            for dk in ("first_shown", "date_from"):
+                if item.get(dk):
+                    dates.append(item[dk])
+        # last_shown from first item (highest rank)
+        last_shown = items[0].get("last_shown") or items[0].get("date_to")
+
+        return {
+            "is_running_ads": True,
+            "ad_count": len(items),
+            "formats": sorted(formats),
+            "first_shown": min(dates) if dates else None,
+            "last_shown": last_shown,
         }
 
     # ============================================

--- a/src/integrations/ads_transparency.py
+++ b/src/integrations/ads_transparency.py
@@ -1,22 +1,42 @@
 """
 Contract: src/integrations/ads_transparency.py
-Purpose: Google Ads Transparency Center check.
-Directive: #290
+Purpose: Google Ads activity check via DFS Ads Search endpoint.
+Layer: integration
+Directive: #291
 
-IMPLEMENTATION STATUS: STUB
-No public API exists. Stub returns None so pipeline degrades gracefully.
-TODO (Sprint 6): implement via Playwright or Bright Data Ads dataset.
+Replaces the stub from #290 with a real implementation using the DFS
+/v3/serp/google/ads_search/live/advanced endpoint (validated in spike:
+3/10 AU dental SMBs detected, $0.002/call, status 40102 = no ads).
+Cost: $0.002/domain.
 """
 from __future__ import annotations
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.clients.dfs_labs_client import DFSLabsClient
 
 logger = logging.getLogger(__name__)
 
 
-async def check_google_ads(domain: str) -> dict | None:
+async def check_google_ads(domain: str, dfs_client: "DFSLabsClient | None" = None) -> dict | None:
     """
-    Check if domain is running Google Ads. STUB — returns None always.
-    Returns dict with keys: is_running_ads, ads_count, last_seen — OR None.
+    Check if a domain is running Google Ads via DFS Ads Search.
+
+    Args:
+        domain: Business domain to check.
+        dfs_client: Optional DFSLabsClient instance. If None, returns None (graceful stub).
+
+    Returns:
+        dict with keys: is_running_ads (bool), ad_count (int), formats (list),
+        first_shown (str|None), last_shown (str|None)
+        OR None if dfs_client not available.
     """
-    logger.debug("check_google_ads: stub (domain=%s)", domain)
-    return None
+    if dfs_client is None:
+        logger.debug("check_google_ads: no dfs_client provided, skipping (domain=%s)", domain)
+        return None
+    try:
+        return await dfs_client.ads_search_by_domain(domain)
+    except Exception as exc:
+        logger.warning("check_google_ads failed for %s: %s", domain, exc)
+        return None

--- a/src/pipeline/free_enrichment.py
+++ b/src/pipeline/free_enrichment.py
@@ -27,6 +27,10 @@ BATCH_SIZE = 50
 DNS_TIMEOUT = 5
 SPIDER_MAX_CREDITS_PER_PAGE = 50
 
+AW_TAG_RE    = re.compile(r'AW-\d{4,12}', re.IGNORECASE)
+GADS_RMK_RE  = re.compile(r'googleads\.g\.doubleclick\.net|google_conversion_id', re.IGNORECASE)
+META_PIXEL_RE = re.compile(r'fbq\s*\(|connect\.facebook\.net[^"]*fbevents|_fbq\b', re.IGNORECASE)
+
 CMS_PATTERNS = {
     "wp-content/": "wordpress",
     "wp-includes/": "wordpress",
@@ -101,6 +105,24 @@ class FreeEnrichment:
         self._logger = logging.getLogger(__name__)
 
     # ── Helpers ──────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _detect_ad_tags(html: str) -> dict[str, bool]:
+        """Scan Spider-scraped HTML for advertising pixel/tag patterns.
+        Free signal: no extra API calls, uses already-scraped content.
+        Returns: has_google_ads_tag, has_meta_pixel, has_any_ad_tag
+        """
+        if not html:
+            return {"has_google_ads_tag": False, "has_meta_pixel": False, "has_any_ad_tag": False}
+        aw    = bool(AW_TAG_RE.search(html))
+        rmk   = bool(GADS_RMK_RE.search(html))
+        meta  = bool(META_PIXEL_RE.search(html))
+        gads  = aw or rmk
+        return {
+            "has_google_ads_tag": gads,
+            "has_meta_pixel": meta,
+            "has_any_ad_tag": gads or meta,
+        }
 
     def _abn_confidence(self, search_name: str, api_name: str) -> ABNMatchConfidence:
         """Compute name similarity between search term and ABN registry name."""
@@ -292,6 +314,7 @@ class FreeEnrichment:
                 "website_team_names": self._extract_team_urls(links),
                 "website_contact_emails": self._extract_emails(content, links),
                 "website_address": website_address,
+                **self._detect_ad_tags(content),
             }
         except Exception as exc:
             self._logger.warning("Spider error for %s: %s", domain, exc)

--- a/src/pipeline/pipeline_orchestrator.py
+++ b/src/pipeline/pipeline_orchestrator.py
@@ -3,15 +3,17 @@ Contract: src/pipeline/pipeline_orchestrator.py
 Purpose: Streaming pipeline that pulls domain batches until it reaches the
          target number of viable prospects with DMs.
 Layer: 2 - pipeline
-Imports: src.pipeline.affordability_scoring
+Imports: src.pipeline.prospect_scorer
 Consumers: orchestration layer
-Directive #288.
+Directive #291.
 """
 import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
 from typing import Optional, Any
+
+from src.pipeline.prospect_scorer import ProspectScorer, ProspectScore
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +23,13 @@ class PipelineStats:
     discovered: int = 0
     enriched: int = 0
     enrichment_failed: int = 0
-    gate_passed: int = 0
-    gate_failed: int = 0
+    affordability_rejected: int = 0
+    intent_rejected: int = 0
+    paid_enrichment_calls: int = 0
     dm_found: int = 0
-    dm_failed: int = 0
+    dm_not_found: int = 0
+    unreachable: int = 0
+    viable_prospects: int = 0
     total_cost_usd: float = 0.0
     elapsed_seconds: float = 0.0
 
@@ -35,9 +40,14 @@ class ProspectCard:
     company_name: str
     location: str
     services: list = field(default_factory=list)
-    gaps: list = field(default_factory=list)
+    evidence: list = field(default_factory=list)
     affordability_band: str = "UNKNOWN"
     affordability_score: int = 0
+    intent_band: str = "UNKNOWN"
+    intent_score: int = 0
+    is_running_ads: bool = False
+    gmb_review_count: int = 0
+    gmb_rating: Optional[float] = None
     dm_name: Optional[str] = None
     dm_title: Optional[str] = None
     dm_linkedin_url: Optional[str] = None
@@ -60,23 +70,27 @@ class PipelineOrchestrator:
     Args:
         discovery: has method pull_batch(category_code, location, limit, offset) -> list[dict]
         free_enrichment: has method enrich(domain) -> dict | None
-        affordability_scorer: AffordabilityScorer instance
+        prospect_scorer: ProspectScorer instance
         dm_identification: DMIdentification instance
+        gmb_client: optional, has maps_search_gmb()
+        ads_client: optional callable async (domain) -> dict|None
     """
 
     def __init__(
         self,
         discovery,
         free_enrichment,
-        affordability_scorer,
+        prospect_scorer,
         dm_identification,
         gmb_client=None,
+        ads_client=None,
     ):
         self._discovery = discovery
         self._enrichment = free_enrichment
-        self._scorer = affordability_scorer
+        self._scorer = prospect_scorer
         self._dm = dm_identification
         self._gmb_client = gmb_client
+        self._ads_client = ads_client   # callable: async (domain) -> dict|None
 
     async def run(
         self,
@@ -97,14 +111,10 @@ class PipelineOrchestrator:
         t0 = time.monotonic()
 
         while len(results) < target_count:
-            # --- Discovery ---
             try:
                 domains = await self._discovery.pull_batch(
-                    category_code=category_code,
-                    location=location,
-                    limit=batch_size,
-                    offset=offset,
-                )
+                    category_code=category_code, location=location,
+                    limit=batch_size, offset=offset)
             except Exception:
                 logger.exception("orchestrator_discovery_failed offset=%d", offset)
                 break
@@ -125,7 +135,7 @@ class PipelineOrchestrator:
                     stats.enrichment_failed += 1
                     continue
 
-                # --- Free enrichment ---
+                # Free enrichment
                 try:
                     enrichment = await self._enrichment.enrich(domain)
                 except Exception:
@@ -137,36 +147,52 @@ class PipelineOrchestrator:
                     continue
                 stats.enriched += 1
 
-                # --- Affordability gate ---
-                score = self._scorer.score(enrichment)
-                if not score.passed_gate:
-                    stats.gate_failed += 1
+                # GATE 1: Affordability
+                afford = self._scorer.score_affordability(enrichment)
+                if not afford.passed_gate:
+                    stats.affordability_rejected += 1
                     continue
-                stats.gate_passed += 1
 
-                # --- GMB reviews (optional, only for gate passers) ---
+                # GATE 2: Intent (free signals)
+                intent_free = self._scorer.score_intent_free(enrichment)
+                if not intent_free.passed_free_gate:
+                    stats.intent_rejected += 1
+                    continue
+
+                # Paid enrichment (gate passers only)
+                ads_data = None
+                gmb_data = None
+
+                if self._ads_client is not None:
+                    try:
+                        ads_data = await self._ads_client(domain)
+                        stats.paid_enrichment_calls += 1
+                        if ads_data:
+                            stats.total_cost_usd += 0.002
+                    except Exception:
+                        logger.exception("orchestrator_ads_failed domain=%s", domain)
+
                 if self._gmb_client is not None:
-                    company_name_for_gmb = (
+                    company_name = (
                         enrichment.get("company_name")
                         or enrichment.get("abn_entity_name")
                         or domain
                     )
                     suburb = (enrichment.get("website_address") or {}).get("suburb", "")
-                    gmb_query = f"{company_name_for_gmb} {suburb}".strip()
+                    gmb_query = f"{company_name} {suburb}".strip()
                     try:
                         gmb_data = await self._gmb_client.maps_search_gmb(
-                            business_name=gmb_query,
-                            location_name=location,
-                        )
+                            business_name=gmb_query, location_name=location)
+                        stats.paid_enrichment_calls += 1
                         if gmb_data:
-                            enrichment = {**enrichment, **gmb_data}
                             stats.total_cost_usd += 0.0035
-                            # Re-score with GMB data
-                            score = self._scorer.score(enrichment)
                     except Exception:
                         logger.exception("orchestrator_gmb_failed domain=%s", domain)
 
-                # --- DM identification ---
+                # Full intent score with paid data
+                intent = self._scorer.score_intent_full(enrichment, ads_data, gmb_data)
+
+                # DM identification
                 try:
                     company_name = (
                         enrichment.get("company_name")
@@ -174,43 +200,49 @@ class PipelineOrchestrator:
                         or domain
                     )
                     dm_result = await self._dm.identify(
-                        domain=domain,
-                        company_name=company_name,
-                        spider_data=enrichment,
-                        abn_data=enrichment,
-                    )
+                        domain=domain, company_name=company_name,
+                        spider_data=enrichment, abn_data=enrichment)
                 except Exception:
                     logger.exception("orchestrator_dm_failed domain=%s", domain)
                     dm_result = None
 
                 if not dm_result or not dm_result.name:
-                    stats.dm_failed += 1
+                    stats.dm_not_found += 1
                     continue
                 stats.dm_found += 1
 
-                # --- Build ProspectCard ---
+                # Reachability check
+                reachable = bool(dm_result.linkedin_url) or bool(
+                    enrichment.get("website_contact_emails"))
+                if not reachable:
+                    stats.unreachable += 1
+                    continue
+
+                # Build ProspectCard
                 card = ProspectCard(
                     domain=domain,
                     company_name=company_name,
-                    location=enrichment.get("website_address", {}).get("suburb", location),
+                    location=(enrichment.get("website_address") or {}).get("suburb", location),
                     services=enrichment.get("services") or [],
-                    gaps=score.gaps,
-                    affordability_band=score.band,
-                    affordability_score=score.raw_score,
+                    evidence=intent.evidence,
+                    affordability_band=afford.band,
+                    affordability_score=afford.raw_score,
+                    intent_band=intent.band,
+                    intent_score=intent.raw_score,
+                    is_running_ads=(ads_data or {}).get("is_running_ads", False),
+                    gmb_review_count=(gmb_data or {}).get("gmb_review_count", 0),
+                    gmb_rating=(gmb_data or {}).get("gmb_rating"),
                     dm_name=dm_result.name,
                     dm_title=dm_result.title,
                     dm_linkedin_url=dm_result.linkedin_url,
                     dm_confidence=dm_result.confidence,
                 )
                 results.append(card)
-                logger.info(
-                    "prospect_found domain=%s band=%s dm=%s",
-                    domain, score.band, dm_result.name,
-                )
+                stats.viable_prospects += 1
+                logger.info("prospect_found domain=%s afford=%s intent=%s dm=%s",
+                            domain, afford.band, intent.band, dm_result.name)
 
         stats.elapsed_seconds = time.monotonic() - t0
-        logger.info(
-            "orchestrator_complete prospects=%d discovered=%d elapsed=%.1fs",
-            len(results), stats.discovered, stats.elapsed_seconds,
-        )
+        logger.info("orchestrator_complete prospects=%d discovered=%d elapsed=%.1fs",
+                    len(results), stats.discovered, stats.elapsed_seconds)
         return PipelineResult(prospects=results, stats=stats)

--- a/src/pipeline/prospect_scorer.py
+++ b/src/pipeline/prospect_scorer.py
@@ -1,0 +1,338 @@
+"""
+Contract: src/pipeline/prospect_scorer.py
+Purpose: Two-dimension prospect scoring — Affordability (can they pay) +
+         Intent (will they buy). Replaces AffordabilityScorer as the primary
+         scorer in PipelineOrchestrator.
+Layer: pipeline
+Directive: #291
+
+PROPRIETARY: Signal weights are defined as constants only. Do not add
+inline comments explaining what scores mean. The algorithm is not for
+public disclosure.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+# ── Affordability constants ──────────────────────────────────────────────────
+_A_GATE_MIN = 3          # min score to pass affordability gate
+_A_BAND_MEDIUM = 3
+_A_BAND_HIGH = 6
+_A_BAND_VERY_HIGH = 9
+
+# Affordability signal weights
+_AW_ENTITY_TRUST    = 3
+_AW_ENTITY_COMPANY  = 2
+_AW_ENTITY_PARTNER  = 1
+_AW_GST             = 1
+_AW_PROF_EMAIL      = 1
+_AW_CMS             = 1
+_AW_SSL             = 1
+_AW_PAGES           = 1
+
+# ── Intent constants ─────────────────────────────────────────────────────────
+_I_GATE_FREE = "NOT_TRYING"   # band that skips paid enrichment
+_I_BAND_DABBLING    = 3
+_I_BAND_TRYING      = 5
+_I_BAND_STRUGGLING  = 8
+
+# Intent free-pass signal weights
+_IW_WEBSITE_NO_ANALYTICS   = 2
+_IW_ADS_TAG_NO_CONVERSION  = 3
+_IW_SOCIAL_LINKS           = 1
+_IW_BOOKING_NO_ANALYTICS   = 2
+_IW_STALE_CMS              = 1
+_IW_META_PIXEL             = 1
+
+# Intent paid-supplement signal weights
+_IW_RUNNING_GADS           = 2
+_IW_RUNNING_META_ADS       = 1
+_IW_GMB_LOW_RESPONSE       = 2
+_IW_GMB_ESTABLISHED        = 1
+
+
+@dataclass
+class AffordabilityResult:
+    raw_score: int
+    band: str          # LOW | MEDIUM | HIGH | VERY_HIGH
+    signals: dict
+    gaps: list
+    passed_gate: bool
+    reject_reason: str | None = None
+
+
+@dataclass
+class IntentResult:
+    raw_score: int
+    band: str          # NOT_TRYING | DABBLING | TRYING | STRUGGLING
+    signals: dict
+    evidence: list     # plain-English paired statements for Haiku
+    passed_free_gate: bool  # False if NOT_TRYING → skip paid enrichment
+
+
+@dataclass
+class ProspectScore:
+    affordability: AffordabilityResult
+    intent: IntentResult
+    is_running_ads: bool = False
+    gmb_review_count: int = 0
+    gmb_rating: float | None = None
+
+
+class ProspectScorer:
+    """
+    Two-dimension prospect scoring: Affordability + Intent.
+
+    Usage:
+        scorer = ProspectScorer()
+
+        # Gate 1 — affordability (hard gates: sole trader, no GST, unreachable)
+        afford = scorer.score_affordability(enrichment)
+        if not afford.passed_gate:
+            continue
+
+        # Gate 2 — intent free (free signals from Spider HTML)
+        intent_free = scorer.score_intent_free(enrichment)
+        if not intent_free.passed_free_gate:
+            continue   # skip paid enrichment
+
+        # After paid enrichment:
+        intent_full = scorer.score_intent_full(enrichment, ads_data, gmb_data)
+    """
+
+    def score_affordability(self, enrichment: dict) -> AffordabilityResult:
+        """
+        Score affordability from free enrichment signals.
+        Hard gates reject immediately (sole trader, no GST, unreachable).
+        """
+        signals: dict[str, int] = {}
+        gaps: list[str] = []
+
+        entity_type = (enrichment.get("entity_type") or "").lower()
+        gst = enrichment.get("gst_registered")
+        has_web = (
+            enrichment.get("website_cms") is not None
+            or enrichment.get("abn_matched")
+        )
+
+        # Hard gates
+        if "sole trader" in entity_type or "individual" in entity_type:
+            return AffordabilityResult(
+                raw_score=0, band="LOW", signals={"hard_gate": "sole_trader"},
+                gaps=["Business is a sole trader — not a viable agency prospect"],
+                passed_gate=False, reject_reason="sole_trader",
+            )
+
+        if gst is False:
+            return AffordabilityResult(
+                raw_score=0, band="LOW", signals={"hard_gate": "no_gst"},
+                gaps=["Not GST registered — revenue likely below $75k threshold"],
+                passed_gate=False, reject_reason="no_gst",
+            )
+
+        if not has_web:
+            return AffordabilityResult(
+                raw_score=0, band="LOW", signals={"hard_gate": "unreachable"},
+                gaps=["No website or ABN match — business not contactable"],
+                passed_gate=False, reject_reason="unreachable",
+            )
+
+        # Entity type
+        et = entity_type
+        if "trust" in et:
+            signals["entity_type"] = _AW_ENTITY_TRUST
+        elif "company" in et or "pty" in et or "ltd" in et:
+            signals["entity_type"] = _AW_ENTITY_COMPANY
+        elif "partner" in et:
+            signals["entity_type"] = _AW_ENTITY_PARTNER
+        else:
+            signals["entity_type"] = 0
+            gaps.append("Entity type unclear — cannot confirm business structure")
+
+        # GST
+        signals["gst_registered"] = _AW_GST if gst else 0
+
+        # Professional email
+        email_maturity = (enrichment.get("email_maturity") or enrichment.get("dns_email_maturity") or "").lower()
+        if email_maturity == "professional":
+            signals["professional_email"] = _AW_PROF_EMAIL
+        else:
+            signals["professional_email"] = 0
+            gaps.append("No professional email setup detected")
+
+        # Website investment
+        cms = (enrichment.get("website_cms") or "").lower()
+        professional_cms = ["wordpress", "squarespace", "shopify", "webflow", "wix",
+                            "custom", "react", "next", "nuxt", "gatsby"]
+        if any(c in cms for c in professional_cms):
+            signals["website_cms"] = _AW_CMS
+        else:
+            signals["website_cms"] = 0
+
+        if enrichment.get("website_cms"):  # if we scraped it, SSL likely present
+            signals["website_ssl"] = _AW_SSL
+        else:
+            signals["website_ssl"] = 0
+
+        pages = enrichment.get("website_page_links") or []
+        signals["website_pages"] = _AW_PAGES if (len(pages) > 1 or enrichment.get("website_cms")) else 0
+
+        raw = sum(signals.values())
+
+        if raw >= _A_BAND_VERY_HIGH:
+            band = "VERY_HIGH"
+        elif raw >= _A_BAND_HIGH:
+            band = "HIGH"
+        elif raw >= _A_BAND_MEDIUM:
+            band = "MEDIUM"
+        else:
+            band = "LOW"
+
+        return AffordabilityResult(
+            raw_score=raw,
+            band=band,
+            signals=signals,
+            gaps=gaps,
+            passed_gate=raw >= _A_GATE_MIN,
+        )
+
+    def score_intent_free(self, enrichment: dict) -> IntentResult:
+        """
+        Score intent from free Spider-scraped signals only.
+        NOT_TRYING band → skip paid enrichment.
+        """
+        signals: dict[str, int] = {}
+        evidence: list[str] = []
+
+        tracking = enrichment.get("website_tracking_codes") or []
+        tech     = enrichment.get("website_tech_stack") or []
+        cms      = (enrichment.get("website_cms") or "").lower()
+
+        tracking_lower = [t.lower() for t in tracking]
+        tech_lower     = [t.lower() for t in tech]
+
+        has_analytics = any(
+            k in t for t in tracking_lower + tech_lower
+            for k in ("ga4", "gtm", "google-analytics", "analytics", "hotjar", "clarity")
+        )
+        has_ads_tag     = enrichment.get("has_google_ads_tag") or False
+        has_meta_pixel  = enrichment.get("has_meta_pixel") or False
+        has_conversion  = any("aw-" in t or "conversion" in t for t in tracking_lower)
+        has_booking     = any(
+            b in cms or any(b in t for t in tech_lower + tracking_lower)
+            for b in ("calendly", "acuity", "mindbody", "timely", "bookeo",
+                      "appointy", "fresha", "shortcuts", "booking")
+        )
+        has_website = bool(enrichment.get("website_cms") or enrichment.get("title"))
+        has_social  = bool(enrichment.get("website_team_names"))  # proxy for social links
+
+        # Website with no analytics
+        if has_website and not has_analytics:
+            signals["website_no_analytics"] = _IW_WEBSITE_NO_ANALYTICS
+            evidence.append(
+                f"Has a {'professional ' + cms if cms else 'website'} but no analytics installed"
+            )
+
+        # Ads tag without conversion tracking
+        if has_ads_tag and not has_conversion:
+            signals["ads_tag_no_conversion"] = _IW_ADS_TAG_NO_CONVERSION
+            evidence.append(
+                "Running Google Ads but missing conversion tracking — wasting budget"
+            )
+        elif has_ads_tag and has_conversion:
+            signals["ads_tag_no_conversion"] = 0
+
+        # Meta Pixel present (marketing effort signal)
+        if has_meta_pixel:
+            signals["meta_pixel"] = _IW_META_PIXEL
+            evidence.append("Has Meta Pixel installed — running social media marketing")
+
+        # Social links (effort signal)
+        if has_social:
+            signals["social_links"] = _IW_SOCIAL_LINKS
+
+        # Booking system without analytics
+        if has_booking and not has_analytics:
+            signals["booking_no_analytics"] = _IW_BOOKING_NO_ANALYTICS
+            evidence.append(
+                "Has online booking but can't measure which channels drive bookings"
+            )
+
+        # Professional CMS with stale/thin content signal
+        if cms in ("wordpress", "squarespace", "webflow", "wix"):
+            signals["stale_cms"] = _IW_STALE_CMS
+
+        raw = sum(signals.values())
+
+        if raw >= _I_BAND_STRUGGLING:
+            band = "STRUGGLING"
+        elif raw >= _I_BAND_TRYING:
+            band = "TRYING"
+        elif raw >= _I_BAND_DABBLING:
+            band = "DABBLING"
+        else:
+            band = "NOT_TRYING"
+
+        return IntentResult(
+            raw_score=raw,
+            band=band,
+            signals=signals,
+            evidence=evidence,
+            passed_free_gate=(band != _I_GATE_FREE),
+        )
+
+    def score_intent_full(
+        self,
+        enrichment: dict,
+        ads_data: dict | None = None,
+        gmb_data: dict | None = None,
+    ) -> IntentResult:
+        """
+        Full intent score: free signals + paid enrichment (DFS Ads Search + GMB).
+        Call after score_intent_free passes.
+        """
+        # Start from free score
+        base = self.score_intent_free(enrichment)
+        signals = dict(base.signals)
+        evidence = list(base.evidence)
+
+        # Paid: Google Ads (from DFS Ads Search)
+        if ads_data:
+            if ads_data.get("is_running_ads"):
+                ad_count = ads_data.get("ad_count", 0)
+                signals["running_gads"] = _IW_RUNNING_GADS
+                evidence.append(
+                    f"Currently running {ad_count} Google Ads but no conversion tracking in place"
+                    if not enrichment.get("has_google_ads_tag")
+                    else f"Active on Google Ads with {ad_count} creatives"
+                )
+
+        # Paid: GMB reviews
+        if gmb_data:
+            review_count = gmb_data.get("gmb_review_count") or 0
+            if review_count > 20:
+                signals["gmb_established"] = _IW_GMB_ESTABLISHED
+                evidence.append(
+                    f"Has {review_count} Google reviews — established local presence"
+                )
+
+        raw = sum(signals.values())
+
+        if raw >= _I_BAND_STRUGGLING:
+            band = "STRUGGLING"
+        elif raw >= _I_BAND_TRYING:
+            band = "TRYING"
+        elif raw >= _I_BAND_DABBLING:
+            band = "DABBLING"
+        else:
+            band = "NOT_TRYING"
+
+        return IntentResult(
+            raw_score=raw,
+            band=band,
+            signals=signals,
+            evidence=evidence,
+            passed_free_gate=(band != _I_GATE_FREE),
+        )

--- a/tests/test_clients/test_dfs_ads_search.py
+++ b/tests/test_clients/test_dfs_ads_search.py
@@ -1,0 +1,46 @@
+"""Tests for DFSLabsClient.ads_search_by_domain — Directive #291."""
+import pytest
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+from src.clients.dfs_labs_client import DFSLabsClient
+
+
+def _c():
+    return DFSLabsClient(login="test", password="test")
+
+
+@pytest.mark.asyncio
+async def test_ads_found_returns_dict():
+    client = _c()
+    mock = {"items": [
+        {"type": "ads_search", "format": "text", "first_shown": "2025-01-01", "last_shown": "2026-03-29"},
+        {"type": "ads_search", "format": "video", "first_shown": "2024-06-01", "last_shown": "2026-03-28"},
+    ]}
+    with patch.object(client, "_post", new_callable=AsyncMock, return_value=mock):
+        r = await client.ads_search_by_domain("dental.com.au")
+    assert r["is_running_ads"] is True
+    assert r["ad_count"] == 2
+    assert "text" in r["formats"]
+
+
+@pytest.mark.asyncio
+async def test_no_items_returns_not_running():
+    client = _c()
+    with patch.object(client, "_post", new_callable=AsyncMock, return_value={"items": []}):
+        r = await client.ads_search_by_domain("unknown.com.au")
+    assert r["is_running_ads"] is False
+    assert r["ad_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_post_error_returns_none():
+    client = _c()
+    with patch.object(client, "_post", new_callable=AsyncMock, side_effect=Exception("network")):
+        r = await client.ads_search_by_domain("broken.com.au")
+    assert r is None
+
+
+def test_cost_attribute_initialised():
+    c = _c()
+    assert hasattr(c, "_cost_ads_search_by_domain")
+    assert c._cost_ads_search_by_domain == Decimal("0")

--- a/tests/test_integrations/test_ads_transparency_real.py
+++ b/tests/test_integrations/test_ads_transparency_real.py
@@ -1,0 +1,26 @@
+"""Tests for real ads_transparency (DFS-backed) — Directive #291."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from src.integrations.ads_transparency import check_google_ads
+
+
+@pytest.mark.asyncio
+async def test_no_client_returns_none():
+    assert await check_google_ads("dental.com.au", dfs_client=None) is None
+
+
+@pytest.mark.asyncio
+async def test_with_client_calls_ads_search():
+    client = MagicMock()
+    client.ads_search_by_domain = AsyncMock(return_value={"is_running_ads": True, "ad_count": 5})
+    result = await check_google_ads("dental.com.au", dfs_client=client)
+    assert result["is_running_ads"] is True
+    client.ads_search_by_domain.assert_called_once_with("dental.com.au")
+
+
+@pytest.mark.asyncio
+async def test_exception_returns_none():
+    client = MagicMock()
+    client.ads_search_by_domain = AsyncMock(side_effect=Exception("timeout"))
+    result = await check_google_ads("dental.com.au", dfs_client=client)
+    assert result is None

--- a/tests/test_pipeline/test_ad_tag_detection.py
+++ b/tests/test_pipeline/test_ad_tag_detection.py
@@ -1,0 +1,39 @@
+"""Tests for Spider HTML ad tag detection — Directive #291."""
+from src.pipeline.free_enrichment import FreeEnrichment
+
+
+def test_aw_tag_detected():
+    html = '<script>gtag("config","AW-974027818");</script>'
+    r = FreeEnrichment._detect_ad_tags(html)
+    assert r["has_google_ads_tag"] is True
+    assert r["has_any_ad_tag"] is True
+
+
+def test_remarketing_detected():
+    html = '<script src="https://googleads.g.doubleclick.net/pagead/viewthroughconversion/123/"></script>'
+    r = FreeEnrichment._detect_ad_tags(html)
+    assert r["has_google_ads_tag"] is True
+
+
+def test_meta_pixel_detected():
+    html = "fbq('init','1234567');"
+    r = FreeEnrichment._detect_ad_tags(html)
+    assert r["has_meta_pixel"] is True
+    assert r["has_any_ad_tag"] is True
+
+
+def test_meta_pixel_facebook_connect():
+    html = '<script src="https://connect.facebook.net/en_US/fbevents.js"></script>'
+    r = FreeEnrichment._detect_ad_tags(html)
+    assert r["has_meta_pixel"] is True
+
+
+def test_empty_html_returns_all_false():
+    r = FreeEnrichment._detect_ad_tags("")
+    assert r == {"has_google_ads_tag": False, "has_meta_pixel": False, "has_any_ad_tag": False}
+
+
+def test_no_tags_in_clean_html():
+    html = "<html><body><p>Hello world</p></body></html>"
+    r = FreeEnrichment._detect_ad_tags(html)
+    assert r["has_any_ad_tag"] is False

--- a/tests/test_pipeline/test_orchestrator_gates.py
+++ b/tests/test_pipeline/test_orchestrator_gates.py
@@ -1,0 +1,101 @@
+"""Tests for new gated PipelineOrchestrator flow — Directive #291."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, call
+from src.pipeline.pipeline_orchestrator import PipelineOrchestrator
+from src.pipeline.prospect_scorer import ProspectScorer
+
+
+def _afford_pass():
+    r = MagicMock(); r.passed_gate = True; r.band = "MEDIUM"; r.raw_score = 5; r.gaps = []
+    return r
+
+def _afford_fail():
+    r = MagicMock(); r.passed_gate = False; r.band = "LOW"; r.raw_score = 0; r.gaps = ["sole_trader"]
+    return r
+
+def _intent_pass():
+    r = MagicMock(); r.passed_free_gate = True; r.band = "TRYING"; r.raw_score = 5; r.evidence = ["Has website but no analytics"]
+    return r
+
+def _intent_fail():
+    r = MagicMock(); r.passed_free_gate = False; r.band = "NOT_TRYING"; r.raw_score = 0; r.evidence = []
+    return r
+
+def _make_orch(afford=None, intent_free=None, intent_full=None, dm=None):
+    disc = MagicMock(); disc.pull_batch = AsyncMock(side_effect=[[{"domain": "dental.com.au"}], []])
+    enr = MagicMock(); enr.enrich = AsyncMock(return_value={"domain":"dental.com.au","company_name":"Dental"})
+    scorer = MagicMock()
+    scorer.score_affordability = MagicMock(return_value=afford or _afford_pass())
+    scorer.score_intent_free = MagicMock(return_value=intent_free or _intent_pass())
+    scorer.score_intent_full = MagicMock(return_value=intent_full or _intent_pass())
+    dm_mock = MagicMock()
+    if dm is None:
+        dm_res = MagicMock(); dm_res.name = "Jane"; dm_res.title = "Owner"
+        dm_res.linkedin_url = "https://au.linkedin.com/in/jane"; dm_res.confidence = "HIGH"
+        dm_mock.identify = AsyncMock(return_value=dm_res)
+    else:
+        dm_mock.identify = AsyncMock(return_value=dm)
+    return PipelineOrchestrator(discovery=disc, free_enrichment=enr,
+                                prospect_scorer=scorer, dm_identification=dm_mock), scorer
+
+
+@pytest.mark.asyncio
+async def test_affordability_rejected_counted():
+    orch, scorer = _make_orch(afford=_afford_fail())
+    result = await orch.run("10514", target_count=5)
+    assert result.stats.affordability_rejected == 1
+    assert result.stats.intent_rejected == 0
+
+
+@pytest.mark.asyncio
+async def test_intent_not_trying_skips_paid_enrichment():
+    ads_client = AsyncMock()
+    orch, scorer = _make_orch(intent_free=_intent_fail())
+    orch._ads_client = ads_client
+    result = await orch.run("10514", target_count=5)
+    assert result.stats.intent_rejected == 1
+    ads_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_full_prospect_card_with_evidence():
+    orch, scorer = _make_orch()
+    result = await orch.run("10514", target_count=1, batch_size=1)
+    assert len(result.prospects) == 1
+    card = result.prospects[0]
+    assert card.dm_name == "Jane"
+    assert card.intent_band in ("NOT_TRYING", "DABBLING", "TRYING", "STRUGGLING", "UNKNOWN")
+
+
+@pytest.mark.asyncio
+async def test_dm_not_found_counted():
+    orch, _ = _make_orch(dm=None)
+    disc = MagicMock(); disc.pull_batch = AsyncMock(side_effect=[[{"domain":"x.com"}],[]])
+    enr = MagicMock(); enr.enrich = AsyncMock(return_value={"domain":"x.com","company_name":"X"})
+    scorer = MagicMock()
+    scorer.score_affordability = MagicMock(return_value=_afford_pass())
+    scorer.score_intent_free = MagicMock(return_value=_intent_pass())
+    scorer.score_intent_full = MagicMock(return_value=_intent_pass())
+    dm_mock = MagicMock(); dm_mock.identify = AsyncMock(return_value=None)
+    orch2 = PipelineOrchestrator(discovery=disc, free_enrichment=enr,
+                                 prospect_scorer=scorer, dm_identification=dm_mock)
+    result = await orch2.run("10514", target_count=5)
+    assert result.stats.dm_not_found == 1
+
+
+@pytest.mark.asyncio
+async def test_stops_at_target_count():
+    disc = MagicMock()
+    disc.pull_batch = AsyncMock(return_value=[{"domain": f"d{i}.com.au"} for i in range(20)])
+    enr = MagicMock(); enr.enrich = AsyncMock(return_value={"domain":"d.com.au","company_name":"D",
+                                                             "website_contact_emails":["a@b.com"]})
+    scorer = MagicMock()
+    scorer.score_affordability = MagicMock(return_value=_afford_pass())
+    scorer.score_intent_free = MagicMock(return_value=_intent_pass())
+    scorer.score_intent_full = MagicMock(return_value=_intent_pass())
+    dm_res = MagicMock(); dm_res.name = "Jane"; dm_res.title = ""; dm_res.linkedin_url = "https://li.com/in/j"; dm_res.confidence = "HIGH"
+    dm_mock = MagicMock(); dm_mock.identify = AsyncMock(return_value=dm_res)
+    orch = PipelineOrchestrator(discovery=disc, free_enrichment=enr,
+                                prospect_scorer=scorer, dm_identification=dm_mock)
+    result = await orch.run("10514", target_count=3, batch_size=20)
+    assert len(result.prospects) == 3

--- a/tests/test_pipeline/test_orchestrator_wiring.py
+++ b/tests/test_pipeline/test_orchestrator_wiring.py
@@ -1,15 +1,33 @@
-"""Tests for orchestrator wiring — Directive #290."""
+"""Tests for orchestrator wiring — updated for Directive #291."""
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from src.pipeline.pipeline_orchestrator import PipelineOrchestrator
 
 
+def _make_scorer(afford_pass=True):
+    scorer = MagicMock()
+    afford = MagicMock()
+    afford.passed_gate = afford_pass
+    afford.band = "MEDIUM" if afford_pass else "LOW"
+    afford.raw_score = 5 if afford_pass else 0
+    afford.gaps = []
+    scorer.score_affordability = MagicMock(return_value=afford)
+    intent = MagicMock()
+    intent.passed_free_gate = True
+    intent.band = "TRYING"
+    intent.raw_score = 5
+    intent.evidence = []
+    scorer.score_intent_free = MagicMock(return_value=intent)
+    scorer.score_intent_full = MagicMock(return_value=intent)
+    return scorer
+
+
 def _make_orch(**overrides):
     disc = MagicMock(); disc.pull_batch = AsyncMock(return_value=[])
     enr = MagicMock(); enr.enrich = AsyncMock(return_value=None)
-    scr = MagicMock()
+    scr = _make_scorer()
     dm = MagicMock(); dm.identify = AsyncMock(return_value=None)
-    kw = dict(discovery=disc, free_enrichment=enr, affordability_scorer=scr, dm_identification=dm)
+    kw = dict(discovery=disc, free_enrichment=enr, prospect_scorer=scr, dm_identification=dm)
     kw.update(overrides)
     return PipelineOrchestrator(**kw)
 
@@ -26,7 +44,7 @@ async def test_enrichment_failure_counted():
     disc = MagicMock(); disc.pull_batch = AsyncMock(side_effect=[[{"domain":"x.com"}], []])
     enr = MagicMock(); enr.enrich = AsyncMock(return_value=None)
     orch = PipelineOrchestrator(discovery=disc, free_enrichment=enr,
-                                affordability_scorer=MagicMock(), dm_identification=MagicMock())
+                                prospect_scorer=_make_scorer(), dm_identification=MagicMock())
     result = await orch.run("10514", target_count=5, batch_size=1)
     assert result.stats.enrichment_failed == 1
 
@@ -35,12 +53,11 @@ async def test_enrichment_failure_counted():
 async def test_gate_failure_counted():
     disc = MagicMock(); disc.pull_batch = AsyncMock(side_effect=[[{"domain":"x.com"}], []])
     enr = MagicMock(); enr.enrich = AsyncMock(return_value={"domain":"x.com","company_name":"X"})
-    score = MagicMock(); score.passed_gate = False; score.gaps = []; score.band = "LOW"; score.raw_score = 2
-    scr = MagicMock(); scr.score = MagicMock(return_value=score)
     orch = PipelineOrchestrator(discovery=disc, free_enrichment=enr,
-                                affordability_scorer=scr, dm_identification=MagicMock())
+                                prospect_scorer=_make_scorer(afford_pass=False),
+                                dm_identification=MagicMock())
     result = await orch.run("10514", target_count=5, batch_size=1)
-    assert result.stats.gate_failed == 1
+    assert result.stats.affordability_rejected == 1
 
 
 @pytest.mark.asyncio
@@ -48,13 +65,12 @@ async def test_full_prospect_card_built():
     disc = MagicMock(); disc.pull_batch = AsyncMock(side_effect=[[{"domain":"dental.com.au"}], []])
     enr = MagicMock(); enr.enrich = AsyncMock(return_value={
         "domain":"dental.com.au","company_name":"Dental","website_address":{"suburb":"Sydney"}})
-    score = MagicMock(); score.passed_gate = True; score.gaps = []; score.band = "MEDIUM"; score.raw_score = 6
-    scr = MagicMock(); scr.score = MagicMock(return_value=score)
+    scorer = _make_scorer()
     dm_r = MagicMock(); dm_r.name = "Jane"; dm_r.title = "Owner"
     dm_r.linkedin_url = "https://au.linkedin.com/in/jane"; dm_r.confidence = "HIGH"
     dm = MagicMock(); dm.identify = AsyncMock(return_value=dm_r)
     orch = PipelineOrchestrator(discovery=disc, free_enrichment=enr,
-                                affordability_scorer=scr, dm_identification=dm)
+                                prospect_scorer=scorer, dm_identification=dm)
     result = await orch.run("10514", target_count=1, batch_size=1)
     assert len(result.prospects) == 1
     assert result.prospects[0].dm_name == "Jane"
@@ -73,7 +89,7 @@ async def test_pull_batch_called_correct_args():
     disc = MagicMock(); disc.pull_batch = AsyncMock(return_value=[])
     enr = MagicMock(); enr.enrich = AsyncMock(return_value=None)
     orch = PipelineOrchestrator(discovery=disc, free_enrichment=enr,
-                                affordability_scorer=MagicMock(), dm_identification=MagicMock())
+                                prospect_scorer=_make_scorer(), dm_identification=MagicMock())
     await orch.run("10514", location="Australia", target_count=5, batch_size=10)
     disc.pull_batch.assert_called_once_with(
         category_code="10514", location="Australia", limit=10, offset=0)

--- a/tests/test_pipeline/test_pipeline_orchestrator.py
+++ b/tests/test_pipeline/test_pipeline_orchestrator.py
@@ -1,4 +1,4 @@
-"""Tests for PipelineOrchestrator — Directive #288."""
+"""Tests for PipelineOrchestrator — updated for Directive #291."""
 import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -31,20 +31,37 @@ def make_dm_result(name="Alice Owner"):
     return dm
 
 
-def make_score_result(passed=True, band="HIGH", score=10, gaps=None):
+def make_afford_result(passed=True, band="HIGH", score=10):
     result = MagicMock()
     result.passed_gate = passed
     result.band = band
     result.raw_score = score
-    result.gaps = gaps or []
+    result.gaps = []
     return result
+
+
+def make_intent_result(passed=True, band="TRYING", score=5):
+    result = MagicMock()
+    result.passed_free_gate = passed
+    result.band = band
+    result.raw_score = score
+    result.evidence = []
+    return result
+
+
+def make_scorer(afford_passed=True):
+    scorer = MagicMock()
+    scorer.score_affordability = MagicMock(return_value=make_afford_result(passed=afford_passed))
+    scorer.score_intent_free = MagicMock(return_value=make_intent_result())
+    scorer.score_intent_full = MagicMock(return_value=make_intent_result())
+    return scorer
 
 
 def make_orchestrator(discovery, free_enrichment, scorer, dm):
     return PipelineOrchestrator(
         discovery=discovery,
         free_enrichment=free_enrichment,
-        affordability_scorer=scorer,
+        prospect_scorer=scorer,
         dm_identification=dm,
     )
 
@@ -58,8 +75,7 @@ async def test_orchestrator_stops_at_target():
     free_enrichment = MagicMock()
     free_enrichment.enrich = AsyncMock(return_value=make_enrichment())
 
-    scorer = MagicMock()
-    scorer.score = MagicMock(return_value=make_score_result())
+    scorer = make_scorer()
 
     dm = MagicMock()
     dm.identify = AsyncMock(return_value=make_dm_result())
@@ -87,8 +103,7 @@ async def test_orchestrator_stops_on_category_exhausted():
     free_enrichment = MagicMock()
     free_enrichment.enrich = AsyncMock(return_value=make_enrichment())
 
-    scorer = MagicMock()
-    scorer.score = MagicMock(return_value=make_score_result())
+    scorer = make_scorer()
 
     dm = MagicMock()
     dm.identify = AsyncMock(return_value=make_dm_result())
@@ -104,9 +119,9 @@ async def test_orchestrator_tracks_stats():
     """
     5 domains:
       domain0 — enrich returns None → enrichment_failed
-      domain1 — gate_failed
-      domain2 — gate_failed
-      domain3 — dm_failed (dm.name is None)
+      domain1 — affordability gate fails
+      domain2 — affordability gate fails
+      domain3 — gate passed, dm.name is None → dm_not_found
       domain4 — success
     """
     domains = [{"domain": f"domain{i}.com"} for i in range(5)]
@@ -123,16 +138,18 @@ async def test_orchestrator_tracks_stats():
     free_enrichment = MagicMock()
     free_enrichment.enrich = enrich
 
-    score_responses = [
-        make_score_result(passed=False),
-        make_score_result(passed=False),
-        make_score_result(passed=True),
-        make_score_result(passed=True),
+    afford_responses = [
+        make_afford_result(passed=False),
+        make_afford_result(passed=False),
+        make_afford_result(passed=True),
+        make_afford_result(passed=True),
     ]
-    score_iter = iter(score_responses)
+    afford_iter = iter(afford_responses)
 
     scorer = MagicMock()
-    scorer.score = MagicMock(side_effect=lambda e: next(score_iter))
+    scorer.score_affordability = MagicMock(side_effect=lambda e: next(afford_iter))
+    scorer.score_intent_free = MagicMock(return_value=make_intent_result())
+    scorer.score_intent_full = MagicMock(return_value=make_intent_result())
 
     dm_responses = [make_dm_result(name=None), make_dm_result(name="Alice")]
     dm_iter = iter(dm_responses)
@@ -148,8 +165,8 @@ async def test_orchestrator_tracks_stats():
 
     assert result.stats.discovered == 5
     assert result.stats.enrichment_failed == 1
-    assert result.stats.gate_failed == 2
-    assert result.stats.dm_failed == 1
+    assert result.stats.affordability_rejected == 2
+    assert result.stats.dm_not_found == 1
     assert result.stats.dm_found == 1
 
 
@@ -164,8 +181,7 @@ async def test_prospect_card_fields():
     free_enrichment = MagicMock()
     free_enrichment.enrich = AsyncMock(return_value=enrichment)
 
-    scorer = MagicMock()
-    scorer.score = MagicMock(return_value=make_score_result(band="HIGH", score=11, gaps=["Not running Google Ads"]))
+    scorer = make_scorer()
 
     dm = MagicMock()
     dm.identify = AsyncMock(return_value=make_dm_result())
@@ -179,7 +195,7 @@ async def test_prospect_card_fields():
     assert card.domain == "example.com"
     assert isinstance(card.company_name, str) and card.company_name
     assert isinstance(card.location, str)
-    assert isinstance(card.gaps, list)
+    assert isinstance(card.evidence, list)
     assert isinstance(card.affordability_band, str)
     assert isinstance(card.affordability_score, int)
     assert isinstance(card.dm_name, str) and card.dm_name

--- a/tests/test_pipeline/test_prospect_scorer.py
+++ b/tests/test_pipeline/test_prospect_scorer.py
@@ -1,0 +1,125 @@
+"""Tests for ProspectScorer — Directive #291."""
+import pytest
+from src.pipeline.prospect_scorer import ProspectScorer, AffordabilityResult, IntentResult
+
+
+def _scorer():
+    return ProspectScorer()
+
+
+class TestAffordabilityGates:
+    def test_sole_trader_rejected(self):
+        s = _scorer()
+        r = s.score_affordability({"entity_type": "Individual/Sole Trader",
+                                   "gst_registered": True, "website_cms": "wordpress"})
+        assert r.passed_gate is False
+        assert r.reject_reason == "sole_trader"
+
+    def test_no_gst_rejected(self):
+        s = _scorer()
+        r = s.score_affordability({"entity_type": "Australian Private Company",
+                                   "gst_registered": False, "website_cms": "wordpress"})
+        assert r.passed_gate is False
+        assert r.reject_reason == "no_gst"
+
+    def test_unreachable_rejected(self):
+        s = _scorer()
+        r = s.score_affordability({"entity_type": "Australian Private Company",
+                                   "gst_registered": True, "website_cms": None,
+                                   "abn_matched": False})
+        assert r.passed_gate is False
+        assert r.reject_reason == "unreachable"
+
+    def test_company_gst_professional_email_good_website_passes(self):
+        s = _scorer()
+        r = s.score_affordability({
+            "entity_type": "Australian Private Company",
+            "gst_registered": True,
+            "website_cms": "wordpress",
+            "email_maturity": "professional",
+        })
+        assert r.passed_gate is True
+        assert r.band in ("MEDIUM", "HIGH", "VERY_HIGH")
+
+    def test_trust_higher_score_than_company(self):
+        s = _scorer()
+        r_trust = s.score_affordability({"entity_type": "Trust", "gst_registered": True,
+                                         "website_cms": "wordpress"})
+        r_co    = s.score_affordability({"entity_type": "Australian Private Company",
+                                         "gst_registered": True, "website_cms": "wordpress"})
+        assert r_trust.raw_score > r_co.raw_score
+
+
+class TestIntentFree:
+    def test_zero_signals_not_trying(self):
+        s = _scorer()
+        r = s.score_intent_free({})
+        assert r.band == "NOT_TRYING"
+        assert r.passed_free_gate is False
+
+    def test_website_no_analytics_gets_signal(self):
+        s = _scorer()
+        r = s.score_intent_free({
+            "website_cms": "wordpress",
+            "website_tracking_codes": [],
+        })
+        assert r.signals.get("website_no_analytics", 0) > 0
+        assert any("analytics" in e.lower() for e in r.evidence)
+
+    def test_ads_tag_no_conversion_high_signal(self):
+        s = _scorer()
+        r = s.score_intent_free({
+            "has_google_ads_tag": True,
+            "website_tracking_codes": [],
+        })
+        assert r.signals.get("ads_tag_no_conversion", 0) > 0
+        assert any("conversion" in e.lower() for e in r.evidence)
+
+    def test_meta_pixel_detected(self):
+        s = _scorer()
+        r = s.score_intent_free({"has_meta_pixel": True})
+        assert r.signals.get("meta_pixel", 0) > 0
+
+    def test_trying_band_passes_free_gate(self):
+        s = _scorer()
+        r = s.score_intent_free({
+            "website_cms": "wordpress",
+            "website_tracking_codes": [],
+            "has_google_ads_tag": True,
+        })
+        assert r.passed_free_gate is True
+        assert r.band in ("TRYING", "STRUGGLING", "DABBLING")
+
+    def test_evidence_pairs_effort_with_gap(self):
+        s = _scorer()
+        r = s.score_intent_free({
+            "website_cms": "wordpress",
+            "website_tracking_codes": [],
+            "has_google_ads_tag": True,
+        })
+        assert len(r.evidence) >= 1
+        for ev in r.evidence:
+            assert isinstance(ev, str) and len(ev) > 10
+
+
+class TestIntentFull:
+    def test_adds_gads_signal_when_running(self):
+        s = _scorer()
+        r = s.score_intent_full(
+            enrichment={"website_cms": "wordpress", "website_tracking_codes": []},
+            ads_data={"is_running_ads": True, "ad_count": 5},
+        )
+        assert r.signals.get("running_gads", 0) > 0
+
+    def test_no_ads_data_does_not_crash(self):
+        s = _scorer()
+        r = s.score_intent_full(enrichment={"website_cms": "wordpress"}, ads_data=None)
+        assert isinstance(r.raw_score, int)
+
+    def test_gmb_established_signal(self):
+        s = _scorer()
+        r = s.score_intent_full(
+            enrichment={},
+            gmb_data={"gmb_review_count": 25, "gmb_rating": 4.5},
+        )
+        assert r.signals.get("gmb_established", 0) > 0


### PR DESCRIPTION
## Directive #291 — Replace scoring with two-dimension model + real ads detection + correct pipeline placement

### What changed
| File | Change |
|---|---|
| `src/pipeline/prospect_scorer.py` | NEW — ProspectScorer: score_affordability, score_intent_free, score_intent_full |
| `src/pipeline/free_enrichment.py` | Add AW_TAG_RE/META_PIXEL_RE constants + _detect_ad_tags() wired into _scrape_website() |
| `src/clients/dfs_labs_client.py` | Add ads_search_by_domain() ENDPOINT 9d — /ads_search/live/advanced, $0.002/call |
| `src/integrations/ads_transparency.py` | Replace stub with real DFS-backed implementation |
| `src/pipeline/pipeline_orchestrator.py` | New gated flow: GATE 1 affordability → GATE 2 intent_free → paid enrichment → DM → reachability |

### Old scorers
ScorerEngine, Stage4Scorer, AffordabilityScorer: **left in place, untouched**. Disconnected from orchestrator only.

### Pipeline gate flow
1. Free enrichment (Spider + DNS + ABN)
2. **GATE 1: Affordability** — hard gates: sole_trader, no_gst, unreachable
3. **GATE 2: Intent free** — NOT_TRYING band skips paid enrichment
4. Paid enrichment (DFS Ads Search $0.002 + GMB $0.0035, gate passers only)
5. Full intent score with paid signals
6. DM identification
7. Reachability check (LinkedIn or email)

### Ads detection (spike-validated)
- Spider HTML tag check (free): 4/10 dental SMBs detected AW- or Meta Pixel
- DFS Ads Search ($0.002/call): 3/10 detected — different domains, complementary
- Combined: 5/10 (50%) of dental SMBs have active paid digital marketing

### Tests
```
1120 passed, 0 failed, 28 skipped (+32 from baseline 1088)
```

Resolves Directive #291. LAW XIV compliant.