### PR TITLE
feat(pipeline): httpx scraper + GMB fix + AU filter + parallel workers — Directive #295

### DIFF
--- a/src/clients/dfs_labs_client.py
+++ b/src/clients/dfs_labs_client.py
@@ -783,10 +783,22 @@ class DFSLabsClient:
         if not items:
             return None
         item = items[0]
+        # rating may be a scalar float or a dict like {"value": 4.2, "votes_count": 87}
+        rating_raw = item.get("rating")
+        rating_obj = rating_raw if isinstance(rating_raw, dict) else {}
+        gmb_rating = rating_obj.get("value") if rating_obj else (
+            float(rating_raw) if rating_raw is not None else None
+        )
+        gmb_review_count = (
+            item.get("rating_count")
+            or item.get("reviews_count")
+            or rating_obj.get("votes_count")
+            or 0
+        )
         return {
             "gmb_place_id": item.get("place_id"),
-            "gmb_rating": item.get("rating"),
-            "gmb_review_count": item.get("rating_count") or item.get("reviews_count") or 0,
+            "gmb_rating": gmb_rating,
+            "gmb_review_count": gmb_review_count,
             "gmb_address": item.get("address"),
             "gmb_phone": item.get("phone"),
             "gmb_found": True,

--- a/src/integrations/httpx_scraper.py
+++ b/src/integrations/httpx_scraper.py
@@ -1,0 +1,59 @@
+"""
+Contract: src/integrations/httpx_scraper.py
+Purpose: Lightweight raw-HTML website scraper using httpx (no JS rendering)
+Layer: 2 - integrations
+Imports: httpx only
+Consumers: src/pipeline/free_enrichment.py
+Directive: #295
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+class HttpxScraper:
+    """Raw-HTML scraper using httpx AsyncClient. No JS rendering."""
+
+    async def scrape(self, domain: str, timeout: float = 10.0) -> dict | None:
+        """
+        Fetch https://{domain} and return a result dict.
+
+        Returns:
+            dict with keys: status_code (int), html (str), title (str | None),
+            content_length (int)
+        Returns None on timeout, connection error, or non-200 status.
+        """
+        url = f"https://{domain}"
+        try:
+            async with httpx.AsyncClient(
+                follow_redirects=True,
+                headers={"User-Agent": _UA},
+                timeout=timeout,
+            ) as client:
+                resp = await client.get(url)
+        except (httpx.TimeoutException, httpx.ConnectError, httpx.RemoteProtocolError):
+            return None
+
+        if resp.status_code != 200:
+            return None
+
+        html = resp.text
+        title_match = _TITLE_RE.search(html)
+        title = title_match.group(1).strip() if title_match else None
+
+        return {
+            "status_code": resp.status_code,
+            "html": html,
+            "title": title,
+            "content_length": len(html),
+        }

--- a/src/pipeline/free_enrichment.py
+++ b/src/pipeline/free_enrichment.py
@@ -22,6 +22,8 @@ import asyncpg
 import dns.resolver
 import httpx
 
+from src.integrations.httpx_scraper import HttpxScraper
+
 SPIDER_API_URL = "https://api.spider.cloud/scrape"
 BATCH_SIZE = 50
 DNS_TIMEOUT = 5
@@ -133,6 +135,7 @@ class FreeEnrichment:
         self._conn = conn
         self._spider_key = os.environ.get("SPIDER_API_KEY", "")
         self._logger = logging.getLogger(__name__)
+        self._httpx = HttpxScraper()
 
     # ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -330,6 +333,25 @@ class FreeEnrichment:
                     }
         return None
 
+    def _is_au_domain(self, domain: str, html: str) -> bool:
+        """Return True if domain is likely Australian."""
+        # 1. .au TLD check (fast path)
+        if domain.endswith(".au"):
+            return True
+        # 2. Australian phone patterns in HTML
+        AU_PHONE_RE = re.compile(r"\b(0[2347]|0[45]\d|\+61)\d{8}\b")
+        if AU_PHONE_RE.search(html):
+            return True
+        # 3. Australian state abbreviations (as standalone words)
+        AU_STATE_RE = re.compile(r"\b(NSW|VIC|QLD|SA|WA|TAS|NT|ACT)\b")
+        if AU_STATE_RE.search(html):
+            return True
+        # 4. Australian postcode pattern (4-digit, 2000-9999 range)
+        AU_POSTCODE_RE = re.compile(r"\b[2-9]\d{3}\b")
+        if AU_POSTCODE_RE.search(html):
+            return True
+        return False
+
     async def run(self, limit: int = 500) -> dict:
         rows = await self._conn.fetch(
             "SELECT id, domain, state FROM business_universe "
@@ -420,12 +442,15 @@ class FreeEnrichment:
                 title.split("|")[0].split("-")[0].strip()[:60]
                 or domain.split(".")[0].replace("-", " ").title()
             )
+            html_content = spider_data.get("_raw_html", "")
+            is_au = self._is_au_domain(domain, html_content)
             return {
                 **spider_data,
                 **dns_data,
                 **abn_data,
                 "company_name": company_name,
                 "domain": domain,
+                "non_au": not is_au,
             }
         except Exception as exc:
             self._logger.warning("enrich_from_spider failed for %s: %s", domain, exc)
@@ -471,6 +496,25 @@ class FreeEnrichment:
         return False
 
     async def _scrape_website(self, domain: str) -> dict[str, Any]:
+        # ── Try httpx first (fast, free) ──────────────────────────────────────
+        httpx_result = await self._httpx.scrape(domain)
+        if httpx_result is not None and len(httpx_result["html"]) >= 1000:
+            content = httpx_result["html"]
+            website_address = self._extract_jsonld_address(content)
+            return {
+                "title": httpx_result["title"] or "",
+                "website_cms": self._extract_cms(content),
+                "website_tech_stack": self._extract_tech_stack(content),
+                "website_tracking_codes": self._extract_trackers(content),
+                "website_team_names": self._extract_team_urls([]),
+                "website_contact_emails": self._extract_emails(content, []),
+                "website_address": website_address,
+                "_raw_html": content,
+                "scraper_used": "httpx",
+                **self._detect_ad_tags(content),
+            }
+
+        # ── Fall back to Spider ────────────────────────────────────────────────
         payload = {
             "url": f"https://{domain}",
             "return_format": "raw",
@@ -494,7 +538,7 @@ class FreeEnrichment:
             if not data or not isinstance(data, list):
                 return {}
             item = data[0]
-            content: str = item.get("content") or ""
+            content = item.get("content") or ""
             links: list = item.get("links") or []
             metadata: dict = item.get("metadata") or {}
             if not content:
@@ -509,6 +553,8 @@ class FreeEnrichment:
                 "website_team_names": self._extract_team_urls(links),
                 "website_contact_emails": self._extract_emails(content, links),
                 "website_address": website_address,
+                "_raw_html": content,
+                "scraper_used": "spider",
                 **self._detect_ad_tags(content),
             }
         except Exception as exc:

--- a/src/pipeline/pipeline_orchestrator.py
+++ b/src/pipeline/pipeline_orchestrator.py
@@ -321,6 +321,10 @@ class PipelineOrchestrator:
                 # ── STAGE 4: Affordability gate (in-memory) ───────────────────
                 afford_passed: list[tuple[str, dict, Any]] = []
                 for domain, enrichment in enriched_pairs:
+                    # Non-AU filter: reject before scoring
+                    if enrichment.get("non_au"):
+                        stats.affordability_rejected += 1
+                        continue
                     try:
                         afford = self._scorer.score_affordability(enrichment)
                     except AttributeError:

--- a/src/pipeline/pipeline_orchestrator.py
+++ b/src/pipeline/pipeline_orchestrator.py
@@ -36,6 +36,12 @@ SEM_ABN    = 1     # asyncpg single-connection safety
 SEM_PAID   = 20    # DFS Ads Search + GMB concurrent
 SEM_DM     = 20    # DFS SERP LinkedIn concurrent
 
+# Global semaphore pool — shared across parallel workers (module-level singletons)
+GLOBAL_SEM_DFS    = asyncio.Semaphore(25)
+GLOBAL_SEM_SCRAPE = asyncio.Semaphore(50)
+GLOBAL_SEM_SONNET = asyncio.Semaphore(12)
+GLOBAL_SEM_HAIKU  = asyncio.Semaphore(15)
+
 
 @dataclass
 class PipelineStats:
@@ -471,4 +477,225 @@ class PipelineOrchestrator:
         stats.elapsed_seconds = time.monotonic() - t0
         logger.info("orchestrator_complete prospects=%d discovered=%d elapsed=%.1fs",
                     len(results), stats.discovered, stats.elapsed_seconds)
+        return PipelineResult(prospects=results, stats=stats)
+
+    # ── Parallel worker run ───────────────────────────────────────────────
+
+    async def run_parallel(
+        self,
+        category_codes: list[str],
+        location: str = "Australia",
+        target_count: int = 100,
+        num_workers: int = 4,
+        batch_size: int = 50,
+        exclude_domains: set | None = None,
+        on_prospect_found: Any = None,
+    ) -> PipelineResult:
+        """
+        Multi-worker parallel pipeline (Directive #295 Task E).
+
+        Spawns num_workers coroutines, each pulling batches from category_codes
+        in round-robin. Workers share a global semaphore pool and accumulate
+        results into a shared list protected by asyncio.Lock.
+
+        Args:
+            category_codes: DFS category codes to sweep (round-robin across workers).
+            location: Location string passed to discovery layer.
+            target_count: Stop once this many viable prospects are found.
+            num_workers: Number of concurrent worker coroutines.
+            batch_size: Domains per pull_batch call.
+            exclude_domains: Domains already claimed — skipped without processing.
+            on_prospect_found: Optional async callable(card: ProspectCard) called
+                               immediately when each prospect is found (for streaming).
+        """
+        t0 = time.monotonic()
+
+        # ── Shared state ─────────────────────────────────────────────────
+        results: list[ProspectCard] = []
+        results_lock = asyncio.Lock()
+        target_reached = asyncio.Event()
+
+        stats = PipelineStats()
+        stats_lock = asyncio.Lock()
+
+        seen_domains: set[str] = set(exclude_domains or [])
+        seen_lock = asyncio.Lock()
+
+        # Per-category offset counters (each worker advances its own category slot)
+        offsets: dict[str, int] = {code: 0 for code in category_codes}
+        offsets_lock = asyncio.Lock()
+
+        # Per-worker semaphores (each worker gets its own; global sems still apply)
+        sem_spider = asyncio.Semaphore(SEM_SPIDER)
+        sem_abn    = asyncio.Semaphore(SEM_ABN)
+        sem_paid   = asyncio.Semaphore(SEM_PAID)
+        sem_dm     = asyncio.Semaphore(SEM_DM)
+
+        # ── Worker coroutine ─────────────────────────────────────────────
+        async def _worker(worker_id: int) -> None:
+            cat_idx = worker_id  # each worker starts on a different category
+
+            while not target_reached.is_set():
+                # Round-robin category + advance offset
+                async with offsets_lock:
+                    cat_code = category_codes[cat_idx % len(category_codes)]
+                    offset = offsets[cat_code]
+                    offsets[cat_code] += batch_size
+                    cat_idx += 1
+
+                # STAGE 1: Discovery
+                try:
+                    async with GLOBAL_SEM_DFS:
+                        batch = await self._discovery.pull_batch(
+                            category_code=cat_code,
+                            location_name=location,
+                            limit=batch_size,
+                            offset=offset,
+                        )
+                except Exception as exc:
+                    logger.warning("worker_%d pull_batch error: %s", worker_id, exc)
+                    break
+
+                if not batch:
+                    break  # category exhausted for this worker
+
+                for domain_row in batch:
+                    if target_reached.is_set():
+                        return
+
+                    domain = domain_row.get("domain", "")
+                    if not domain:
+                        continue
+
+                    # Dedup across workers
+                    async with seen_lock:
+                        if domain in seen_domains:
+                            continue
+                        seen_domains.add(domain)
+
+                    async with stats_lock:
+                        stats.discovered += 1
+
+                    # STAGE 2: Scrape
+                    async with GLOBAL_SEM_SCRAPE:
+                        spider_data = await self._stage_spider(sem_spider, domain)
+
+                    # STAGE 3: Enrich (DNS + ABN)
+                    enrichment = await self._stage_enrich(sem_abn, domain, spider_data)
+                    if enrichment is None:
+                        async with stats_lock:
+                            stats.enrichment_failed += 1
+                        continue
+
+                    async with stats_lock:
+                        stats.enriched += 1
+
+                    # Non-AU filter (Task D)
+                    if enrichment.get("non_au"):
+                        async with stats_lock:
+                            stats.affordability_rejected += 1
+                        continue
+
+                    # GATE 1: Affordability
+                    afford = self._scorer.score_affordability(enrichment)
+                    if not afford.passed_gate:
+                        async with stats_lock:
+                            stats.affordability_rejected += 1
+                        continue
+
+                    # GATE 2: Intent free
+                    intent_free = self._scorer.score_intent_free(enrichment)
+                    if getattr(intent_free, "band", None) == "NOT_TRYING":
+                        async with stats_lock:
+                            stats.intent_rejected += 1
+                        continue
+
+                    # STAGE 6: Paid enrichment
+                    company_name = enrichment.get("company_name") or domain
+                    addr = enrichment.get("website_address") or {}
+                    suburb = (addr.get("suburb") or addr.get("city") or "") if isinstance(addr, dict) else ""
+
+                    async with GLOBAL_SEM_DFS:
+                        paid = await self._stage_paid(sem_paid, domain, company_name, suburb, location)
+
+                    async with stats_lock:
+                        stats.paid_enrichment_calls += 1
+
+                    ads_data = paid.get("ads_data")
+                    gmb_data = paid.get("gmb_data")
+                    if gmb_data:
+                        enrichment = {**enrichment, **gmb_data}
+
+                    # STAGE 7: Full intent score
+                    intent = self._scorer.score_intent_full(enrichment, ads_data, gmb_data)
+                    intent_band = getattr(intent, "band", "UNKNOWN")
+                    evidence = getattr(intent, "evidence", [])
+
+                    # STAGE 8: DM identification
+                    async with GLOBAL_SEM_DFS:
+                        dm = await self._stage_dm(sem_dm, domain, company_name, enrichment)
+
+                    if not dm or not getattr(dm, "name", None):
+                        async with stats_lock:
+                            stats.dm_not_found += 1
+                        continue
+
+                    async with stats_lock:
+                        stats.dm_found += 1
+
+                    # GATE: Reachability
+                    has_email = bool(enrichment.get("website_contact_emails"))
+                    has_linkedin = bool(getattr(dm, "linkedin_url", None))
+                    if not (has_email or has_linkedin):
+                        async with stats_lock:
+                            stats.unreachable += 1
+                        continue
+
+                    # Build ProspectCard
+                    card = ProspectCard(
+                        domain=domain,
+                        company_name=company_name,
+                        location=suburb,
+                        evidence=evidence,
+                        affordability_band=afford.band,
+                        affordability_score=afford.raw_score,
+                        intent_band=intent_band,
+                        intent_score=getattr(intent, "raw_score", 0),
+                        gmb_rating=enrichment.get("gmb_rating"),
+                        gmb_review_count=enrichment.get("gmb_review_count", 0),
+                        dm_name=dm.name,
+                        dm_title=getattr(dm, "title", None),
+                        dm_linkedin_url=getattr(dm, "linkedin_url", None),
+                        dm_confidence=getattr(dm, "confidence", None),
+                    )
+
+                    async with results_lock:
+                        if target_reached.is_set():
+                            return  # another worker just hit the target
+                        results.append(card)
+                        if on_prospect_found is not None:
+                            try:
+                                await on_prospect_found(card)
+                            except Exception:
+                                pass
+                        if len(results) >= target_count:
+                            target_reached.set()
+
+                    async with stats_lock:
+                        stats.viable_prospects += 1
+                        stats.category_stats[cat_code] = stats.category_stats.get(cat_code, 0) + 1
+                        logger.info(
+                            "parallel_prospect_found worker=%d domain=%s afford=%s intent=%s dm=%s",
+                            worker_id, domain, afford.band, intent_band, dm.name,
+                        )
+
+        # ── Launch workers ────────────────────────────────────────────────
+        workers = [_worker(i) for i in range(num_workers)]
+        await asyncio.gather(*workers, return_exceptions=True)
+
+        stats.elapsed_seconds = time.monotonic() - t0
+        logger.info(
+            "parallel_orchestrator_complete prospects=%d discovered=%d workers=%d elapsed=%.1fs",
+            len(results), stats.discovered, num_workers, stats.elapsed_seconds,
+        )
         return PipelineResult(prospects=results, stats=stats)

--- a/src/pipeline/prospect_scorer.py
+++ b/src/pipeline/prospect_scorer.py
@@ -311,7 +311,11 @@ class ProspectScorer:
 
         # Paid: GMB reviews
         if gmb_data:
-            review_count = gmb_data.get("gmb_review_count") or 0
+            _rc = gmb_data.get("gmb_review_count") or 0
+            try:
+                review_count = int(_rc)
+            except (TypeError, ValueError):
+                review_count = 0
             if review_count > 20:
                 signals["gmb_established"] = _IW_GMB_ESTABLISHED
                 evidence.append(

--- a/tests/test_clients/test_dfs_gmb_rating.py
+++ b/tests/test_clients/test_dfs_gmb_rating.py
@@ -1,0 +1,127 @@
+"""Tests for GMB rating parsing in DFSLabsClient.maps_search_gmb — Directive #295 Task C."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from decimal import Decimal
+
+
+def _make_dfs_result(item: dict) -> dict:
+    """Wrap an item in the DFS tasks/result envelope."""
+    return {
+        "tasks": [{
+            "status_code": 20000,
+            "result": [{"items": [item]}],
+        }]
+    }
+
+
+def _make_dfs_empty() -> dict:
+    return {"tasks": [{"status_code": 20000, "result": [{"items": []}]}]}
+
+
+async def _call_gmb(item_or_none):
+    """Helper: call maps_search_gmb with a mocked HTTP client."""
+    from src.clients.dfs_labs_client import DFSLabsClient
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    if item_or_none is None:
+        mock_response.json.return_value = _make_dfs_empty()
+    else:
+        mock_response.json.return_value = _make_dfs_result(item_or_none)
+    mock_response.raise_for_status = MagicMock()
+
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=mock_response)
+
+    with patch.object(DFSLabsClient, "_get_client", return_value=mock_http):
+        client = DFSLabsClient(login="test", password="test")
+        return await client.maps_search_gmb("Dentist Sydney", location_name="Sydney")
+
+
+@pytest.mark.asyncio
+async def test_gmb_rating_scalar():
+    """Rating is already a float scalar — should pass through."""
+    result = await _call_gmb({"place_id": "abc", "rating": 4.5, "rating_count": 42})
+    assert result["gmb_rating"] == 4.5
+    assert result["gmb_review_count"] == 42
+
+
+@pytest.mark.asyncio
+async def test_gmb_rating_dict_with_value():
+    """Rating is a dict {"value": 4.2, "votes_count": 87} — extract scalar."""
+    result = await _call_gmb({"place_id": "abc", "rating": {"value": 4.2, "votes_count": 87}})
+    assert result["gmb_rating"] == 4.2
+    assert result["gmb_review_count"] == 87
+
+
+@pytest.mark.asyncio
+async def test_gmb_rating_dict_with_rating_type():
+    """Rating dict has rating_type key — still extract value."""
+    result = await _call_gmb({
+        "place_id": "abc",
+        "rating": {"rating_type": "Max5", "value": 3.8, "votes_count": 15}
+    })
+    assert result["gmb_rating"] == 3.8
+    assert result["gmb_review_count"] == 15
+
+
+@pytest.mark.asyncio
+async def test_gmb_review_count_prefers_rating_count_over_votes():
+    """rating_count field takes priority over votes_count in rating dict."""
+    result = await _call_gmb({
+        "place_id": "abc",
+        "rating": {"value": 4.0, "votes_count": 10},
+        "rating_count": 55,
+    })
+    assert result["gmb_review_count"] == 55
+
+
+@pytest.mark.asyncio
+async def test_gmb_rating_none():
+    """No rating field — should return None rating, 0 count."""
+    result = await _call_gmb({"place_id": "abc"})
+    assert result["gmb_rating"] is None
+    assert result["gmb_review_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_gmb_empty_items():
+    """Empty items list — returns None."""
+    result = await _call_gmb(None)
+    assert result is None
+
+
+def test_prospect_scorer_gmb_review_count_int_cast():
+    """ProspectScorer.score_intent_full: review_count as string doesn't crash."""
+    from src.pipeline.prospect_scorer import ProspectScorer
+    scorer = ProspectScorer()
+    enrichment = {
+        "has_google_ads_tag": False,
+        "has_meta_pixel": False,
+        "website_cms": None,
+        "is_running_ads": False,
+        "ads_count": 0,
+        "website_tracking_codes": [],
+        "website_booking_system": False,
+        "website_team_names": [],
+        "website_social_links": [],
+    }
+    gmb_data = {"gmb_review_count": "25", "gmb_rating": "4.5"}
+    result = scorer.score_intent_full(enrichment, ads_data=None, gmb_data=gmb_data)
+    assert result.band in ("NOT_TRYING", "DABBLING", "TRYING", "STRUGGLING")
+
+
+def test_prospect_scorer_gmb_review_count_dict_doesnt_crash():
+    """ProspectScorer.score_intent_full: review_count as raw dict doesn't crash."""
+    from src.pipeline.prospect_scorer import ProspectScorer
+    scorer = ProspectScorer()
+    enrichment = {
+        "has_google_ads_tag": False, "has_meta_pixel": False,
+        "website_cms": None, "is_running_ads": False, "ads_count": 0,
+        "website_tracking_codes": [], "website_booking_system": False,
+        "website_team_names": [], "website_social_links": [],
+    }
+    # Simulates bug: raw dict passed through accidentally
+    gmb_data = {"gmb_review_count": {"value": 25}, "gmb_rating": 4.2}
+    result = scorer.score_intent_full(enrichment, ads_data=None, gmb_data=gmb_data)
+    assert result.band in ("NOT_TRYING", "DABBLING", "TRYING", "STRUGGLING")

--- a/tests/test_integrations/test_httpx_scraper.py
+++ b/tests/test_integrations/test_httpx_scraper.py
@@ -1,0 +1,89 @@
+"""Tests for HttpxScraper — Directive #295 Task B."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from src.integrations.httpx_scraper import HttpxScraper
+
+
+HTML_WITH_TITLE = "<html><head><title>Test Page</title></head><body>content</body></html>"
+
+
+@pytest.mark.asyncio
+async def test_scrape_returns_dict_on_200():
+    scraper = HttpxScraper()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = HTML_WITH_TITLE
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        mock_client_cls.return_value = mock_client
+
+        result = await scraper.scrape("example.com")
+
+    assert result is not None
+    assert result["status_code"] == 200
+    assert HTML_WITH_TITLE in result["html"]
+    assert result["content_length"] == len(HTML_WITH_TITLE)
+
+
+@pytest.mark.asyncio
+async def test_scrape_returns_none_on_timeout():
+    scraper = HttpxScraper()
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+        mock_client_cls.return_value = mock_client
+
+        result = await scraper.scrape("example.com")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_scrape_returns_none_on_non_200():
+    scraper = HttpxScraper()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    mock_resp.text = "Not Found"
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        mock_client_cls.return_value = mock_client
+
+        result = await scraper.scrape("example.com")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_scrape_extracts_title():
+    scraper = HttpxScraper()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = "<html><head><title>  My Dental Clinic  </title></head><body>hello</body></html>"
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        mock_client_cls.return_value = mock_client
+
+        result = await scraper.scrape("example.com")
+
+    assert result is not None
+    assert result["title"] == "My Dental Clinic"

--- a/tests/test_pipeline/test_country_filter.py
+++ b/tests/test_pipeline/test_country_filter.py
@@ -1,0 +1,112 @@
+"""Tests for AU country filter — Directive #295 Task D."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.pipeline.free_enrichment import FreeEnrichment
+from src.pipeline.pipeline_orchestrator import PipelineOrchestrator
+
+
+def make_fe() -> FreeEnrichment:
+    """Instantiate FreeEnrichment without a real DB connection."""
+    return FreeEnrichment.__new__(FreeEnrichment)
+
+
+# ── _is_au_domain tests ───────────────────────────────────────────────────────
+
+
+def test_au_domain_passes():
+    fe = make_fe()
+    assert fe._is_au_domain("dentist.com.au", "") is True
+
+
+def test_state_in_html_passes():
+    fe = make_fe()
+    html = "<p>We serve patients across NSW and beyond.</p>"
+    assert fe._is_au_domain("dentist.com", html) is True
+
+
+def test_phone_in_html_passes():
+    fe = make_fe()
+    # Australian landline: 02 9999 8888 — stripped of spaces = 0299998888
+    html = "<p>Call us on 0299998888 today</p>"
+    assert fe._is_au_domain("dentist.com", html) is True
+
+
+def test_foreign_domain_fails():
+    fe = make_fe()
+    # Turkish dental site with no AU indicators
+    html = "<html><head><title>Dentatur Diş Kliniği</title></head><body>İstanbul</body></html>"
+    assert fe._is_au_domain("dentatur.com", html) is False
+
+
+# ── non_au in orchestrator affordability gate ──────────────────────────────────
+
+
+def _make_orch_with_non_au(non_au: bool):
+    disc = MagicMock()
+    disc.pull_batch = AsyncMock(
+        side_effect=[[{"domain": "example.com"}], []]
+    )
+
+    fe = MagicMock()
+    fe.scrape_website = AsyncMock(return_value={"title": "Example", "_raw_html": ""})
+    fe.enrich_from_spider = AsyncMock(return_value={
+        "domain": "example.com",
+        "company_name": "Example Co",
+        "non_au": non_au,
+        "website_contact_emails": [],
+        "website_address": {},
+    })
+
+    scorer = MagicMock()
+    afford = MagicMock()
+    afford.passed_gate = True
+    afford.band = "MEDIUM"
+    afford.raw_score = 5
+    scorer.score_affordability = MagicMock(return_value=afford)
+
+    intent = MagicMock()
+    intent.band = "TRYING"
+    intent.raw_score = 5
+    intent.evidence = []
+    scorer.score_intent_free = MagicMock(return_value=intent)
+    scorer.score_intent_full = MagicMock(return_value=intent)
+
+    dm_id = MagicMock()
+    dm_result = MagicMock()
+    dm_result.name = "Jane Smith"
+    dm_result.title = "Owner"
+    dm_result.linkedin_url = "https://linkedin.com/in/jane"
+    dm_result.confidence = "HIGH"
+    dm_id.identify = AsyncMock(return_value=dm_result)
+
+    return PipelineOrchestrator(
+        discovery=disc,
+        free_enrichment=fe,
+        scorer=scorer,
+        dm_identification=dm_id,
+    ), scorer
+
+
+@pytest.mark.asyncio
+async def test_non_au_rejected_in_orchestrator():
+    """non_au=True domain is rejected and counted in affordability_rejected."""
+    orch, scorer = _make_orch_with_non_au(non_au=True)
+    result = await orch.run(category_codes="dental", location="Sydney", target_count=10)
+
+    assert result.stats.affordability_rejected == 1
+    assert result.stats.viable_prospects == 0
+    # score_affordability must NOT be called for non-AU domains
+    scorer.score_affordability.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_au_domain_not_rejected_in_orchestrator():
+    """non_au=False domain passes the AU filter and proceeds to scoring."""
+    orch, scorer = _make_orch_with_non_au(non_au=False)
+    result = await orch.run(category_codes="dental", location="Sydney", target_count=10)
+
+    # score_affordability is called (domain passed AU filter)
+    scorer.score_affordability.assert_called_once()

--- a/tests/test_pipeline/test_parallel_orchestrator.py
+++ b/tests/test_pipeline/test_parallel_orchestrator.py
@@ -1,0 +1,207 @@
+"""Tests for PipelineOrchestrator.run_parallel — Directive #295 Task E."""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from src.pipeline.pipeline_orchestrator import PipelineOrchestrator, GLOBAL_SEM_DFS, GLOBAL_SEM_SCRAPE
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _afford_pass():
+    r = MagicMock(); r.passed_gate = True; r.band = "HIGH"; r.raw_score = 9; r.gaps = []
+    return r
+
+def _intent_pass():
+    r = MagicMock(); r.passed_free_gate = True; r.band = "TRYING"; r.raw_score = 5; r.evidence = ["Has website, no analytics"]
+    return r
+
+def _intent_full():
+    r = MagicMock(); r.band = "TRYING"; r.raw_score = 6; r.evidence = ["Has website, no analytics"]
+    return r
+
+def _dm(name="Jane Owner"):
+    d = MagicMock(); d.name = name; d.title = "Owner"
+    d.linkedin_url = "https://au.linkedin.com/in/jane"; d.confidence = "HIGH"
+    return d
+
+def _enrichment(domain="x.com.au"):
+    return {
+        "domain": domain,
+        "company_name": "Test Co",
+        "entity_type": "Company",
+        "gst_registered": True,
+        "non_au": False,
+        "website_contact_emails": ["info@x.com.au"],
+        "website_address": {"suburb": "Sydney"},
+    }
+
+def _make_orch(domains_per_batch=5, target=3):
+    """Build a PipelineOrchestrator with all dependencies mocked."""
+    call_count = {"n": 0}
+
+    async def pull_batch(**kwargs):
+        call_count["n"] += 1
+        if call_count["n"] > 3:
+            return []
+        return [{"domain": f"d{call_count['n']}x{i}.com.au"} for i in range(domains_per_batch)]
+
+    discovery = MagicMock()
+    discovery.pull_batch = pull_batch
+
+    fe = MagicMock()
+    fe.scrape_website = AsyncMock(return_value={"title": "Test"})
+    fe.enrich_from_spider = AsyncMock(side_effect=lambda domain, spider_data: _enrichment(domain))
+
+    scorer = MagicMock()
+    scorer.score_affordability = MagicMock(return_value=_afford_pass())
+    scorer.score_intent_free = MagicMock(return_value=_intent_pass())
+    scorer.score_intent_full = MagicMock(return_value=_intent_full())
+
+    dm_id = MagicMock()
+    dm_id.identify = AsyncMock(return_value=_dm())
+
+    return PipelineOrchestrator(
+        discovery=discovery,
+        free_enrichment=fe,
+        scorer=scorer,
+        dm_identification=dm_id,
+    )
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_run_parallel_reaches_target():
+    """With ample domains, run_parallel stops at target_count."""
+    orch = _make_orch(domains_per_batch=10)
+    result = await orch.run_parallel(
+        category_codes=["10514"],
+        location="Australia",
+        target_count=3,
+        num_workers=2,
+        batch_size=10,
+    )
+    assert len(result.prospects) == 3
+    assert result.stats.viable_prospects == 3
+
+
+@pytest.mark.asyncio
+async def test_run_parallel_deduplicates_domains():
+    """Same domain appearing in multiple batches is processed only once."""
+    discovery = MagicMock()
+    call_n = {"n": 0}
+
+    async def pull_batch(**kwargs):
+        call_n["n"] += 1
+        if call_n["n"] == 1:
+            return [{"domain": "shared.com.au"}]
+        if call_n["n"] == 2:
+            return [{"domain": "shared.com.au"}]  # duplicate
+        return []
+
+    discovery.pull_batch = pull_batch
+
+    fe = MagicMock()
+    fe.scrape_website = AsyncMock(return_value={"title": "T"})
+    fe.enrich_from_spider = AsyncMock(return_value=_enrichment("shared.com.au"))
+
+    scorer = MagicMock()
+    scorer.score_affordability = MagicMock(return_value=_afford_pass())
+    scorer.score_intent_free = MagicMock(return_value=_intent_pass())
+    scorer.score_intent_full = MagicMock(return_value=_intent_full())
+
+    dm_id = MagicMock()
+    dm_id.identify = AsyncMock(return_value=_dm())
+
+    orch = PipelineOrchestrator(
+        discovery=discovery, free_enrichment=fe, scorer=scorer, dm_identification=dm_id,
+    )
+    result = await orch.run_parallel(
+        category_codes=["10514"], location="Australia",
+        target_count=10, num_workers=2, batch_size=1,
+    )
+    # shared.com.au should only be counted once
+    assert result.stats.discovered == 1
+
+
+@pytest.mark.asyncio
+async def test_run_parallel_stops_on_exhaustion():
+    """When all batches are empty, workers stop and result is returned."""
+    discovery = MagicMock()
+    discovery.pull_batch = AsyncMock(return_value=[])
+
+    fe = MagicMock()
+    fe.scrape_website = AsyncMock(return_value={})
+    fe.enrich_from_spider = AsyncMock(return_value=None)
+
+    scorer = MagicMock()
+    dm_id = MagicMock()
+
+    orch = PipelineOrchestrator(
+        discovery=discovery, free_enrichment=fe, scorer=scorer, dm_identification=dm_id,
+    )
+    result = await orch.run_parallel(
+        category_codes=["10514"], location="Australia",
+        target_count=100, num_workers=2, batch_size=10,
+    )
+    assert len(result.prospects) == 0
+    assert result.stats.discovered == 0
+
+
+@pytest.mark.asyncio
+async def test_run_parallel_non_au_rejected():
+    """Domains with non_au=True are counted in affordability_rejected."""
+    discovery = MagicMock()
+    discovery.pull_batch = AsyncMock(side_effect=[
+        [{"domain": "dentatur.com"}],
+        [],
+    ])
+
+    fe = MagicMock()
+    fe.scrape_website = AsyncMock(return_value={"title": "Turkish Dental"})
+    fe.enrich_from_spider = AsyncMock(return_value={
+        "domain": "dentatur.com",
+        "company_name": "Denta Tur",
+        "non_au": True,
+    })
+
+    scorer = MagicMock()
+    dm_id = MagicMock()
+
+    orch = PipelineOrchestrator(
+        discovery=discovery, free_enrichment=fe, scorer=scorer, dm_identification=dm_id,
+    )
+    result = await orch.run_parallel(
+        category_codes=["10514"], location="Australia",
+        target_count=10, num_workers=1, batch_size=5,
+    )
+    assert result.stats.affordability_rejected == 1
+    assert len(result.prospects) == 0
+
+
+@pytest.mark.asyncio
+async def test_run_parallel_on_prospect_found_callback():
+    """on_prospect_found callback is called for each prospect found."""
+    orch = _make_orch(domains_per_batch=5)
+    found = []
+
+    async def capture(card):
+        found.append(card.domain)
+
+    result = await orch.run_parallel(
+        category_codes=["10514"],
+        location="Australia",
+        target_count=2,
+        num_workers=1,
+        batch_size=5,
+        on_prospect_found=capture,
+    )
+    assert len(found) == 2
+    assert len(result.prospects) == 2
+
+
+@pytest.mark.asyncio
+async def test_global_semaphores_exist():
+    """Global semaphore pool is module-level and accessible."""
+    assert GLOBAL_SEM_DFS._value == 25
+    assert GLOBAL_SEM_SCRAPE._value == 50


### PR DESCRIPTION
## Directive #295

### Changes

**httpx primary scraper with Spider fallback**
- New `src/integrations/httpx_scraper.py` — `HttpxScraper.scrape()`: HTTPS-first, browser UA, returns `status_code/html/title/content_length`
- `free_enrichment.py`: try httpx first; fall back to Spider if result is `None` or HTML < 1000 chars
- Enrichment dict now includes `scraper_used: "httpx" | "spider"`

**GMB rating dict→scalar fix**
- `dfs_labs_client.py`: `gmb_rating` extracts scalar from dict `{value, votes_count}` or `{rating_type, value, votes_count}`
- `gmb_review_count` fallback chain: `rating_count → reviews_count → rating.votes_count`
- `prospect_scorer.py`: safe `int()` cast with `try/except` on `gmb_review_count` — prevents `TypeError` on dict/string input

**AU country filter at affordability gate**
- `free_enrichment.py`: `_is_au_domain(domain, html)` — fast path `.au` TLD, then AU phone patterns, state abbreviations (NSW/VIC/QLD etc), 4-digit postcode
- `non_au: True` injected into enrichment dict for non-AU domains
- `pipeline_orchestrator.py`: non-AU domains rejected at affordability gate (catches dentatur.com, uswatersystems.com)

**Parallel worker orchestrator with global semaphore pool**
- Module-level: `GLOBAL_SEM_DFS=25`, `GLOBAL_SEM_SCRAPE=50`, `GLOBAL_SEM_SONNET=12`, `GLOBAL_SEM_HAIKU=15`
- `PipelineOrchestrator.run_parallel()`: `num_workers` coroutines, round-robin categories, shared `asyncio.Lock` state, dedup via `seen_domains` set, `on_prospect_found` streaming callback, race-condition guard inside `results_lock`

### Tests
- **24 new tests, 1193 total passing, 0 failed, 5 skipped**
- `tests/test_integrations/test_httpx_scraper.py` — HttpxScraper (4 tests)
- `tests/test_pipeline/test_country_filter.py` — AU filter (5 tests)
- `tests/test_clients/test_dfs_gmb_rating.py` — GMB rating parsing (8 tests)
- `tests/test_pipeline/test_parallel_orchestrator.py` — parallel workers (6 tests) + semaphore check (1 test)

### Files changed
- `src/integrations/httpx_scraper.py` (new)
- `src/pipeline/free_enrichment.py`
- `src/pipeline/pipeline_orchestrator.py`
- `src/pipeline/prospect_scorer.py`
- `src/clients/dfs_labs_client.py`
- `tests/test_integrations/test_httpx_scraper.py` (new)
- `tests/test_pipeline/test_country_filter.py` (new)
- `tests/test_clients/test_dfs_gmb_rating.py` (new)
- `tests/test_pipeline/test_parallel_orchestrator.py` (new)