### PR TITLE
feat(pipeline): Sonnet/Haiku intelligence layer — Directive #296

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -23,9 +23,9 @@ Revenue model for BU: API subscriptions, Salesforce/HubSpot marketplace, bulk an
 
 ## SECTION 2 — CURRENT STATE
 
-- Last directive issued: #295 (httpx scraper + GMB fix + AU filter + parallel workers — COMPLETE)
-- Test baseline: 1193 passed, 0 failed, 5 skipped
-- Last merged PRs: #247–#257
+- Last directive issued: #296 (Sonnet/Haiku intelligence layer — PR #258 open, pending merge)
+- Test baseline: 1214 passed, 0 failed, 5 skipped
+- Last merged PRs: #247–#257 | Open: #258
 - PR #254 (Directive #291 — ProspectScorer) pending merge
 - Architecture: **FINAL ratified Mar 30 2026** — service-signal discovery, two-dimension scoring, stage-parallel processing
 - **Pipeline test Run 1 (Mar 29):** 100 DMs from 200 domains, $3.51, 7.3 min
@@ -92,6 +92,41 @@ Applied in `free_enrichment.py` after scrape, before affordability scoring.
 5. None found → `non_au: True` → rejected at affordability gate
 
 Catches foreign domains that pass TLD check (e.g. `dentatur.com`, `uswatersystems.com`).
+
+### SONNET/HAIKU INTELLIGENCE LAYER (Directive #296)
+
+Replaces regex/rule-based analysis with LLM comprehension at five pipeline stages.
+
+**Five stages** (`src/pipeline/intelligence.py`):
+
+| Stage | Function | Model | Replaces | Cost/domain |
+|-------|----------|-------|----------|-------------|
+| 3b | `comprehend_website()` | Sonnet | Regex extraction | ~$0.010 |
+| 7 | `classify_intent()` | Sonnet | Point-counting scorer | ~$0.008 |
+| 7b | `analyse_reviews()` | Sonnet | No equivalent (new) | ~$0.005 |
+| 4 | `judge_affordability()` | Haiku | Rule-based gates | ~$0.001 |
+| 7c | `refine_evidence()` | Haiku | Hardcoded evidence strings | ~$0.002 |
+
+**Total: ~$0.026/domain. ~$16.50/100 DMs at 23% yield. Ignition margin >96%.**
+
+**Prompt caching design:** Static system prompt block (marked `cache_control: ephemeral`) always first; variable HTML/review content last. Anthropic prompt-caching-2024-07-31 beta header on every call.
+
+**Semaphores:** `GLOBAL_SEM_SONNET=12` and `GLOBAL_SEM_HAIKU=15` defined in `intelligence.py`, imported by `pipeline_orchestrator.py`. Prevents circular import.
+
+**Reliability:** httpx direct API (no SDK). JSON response with `try/except` fallback on every call — pipeline never crashes on LLM failure. Token usage logged per call for cost tracking.
+
+**Wiring in `run_parallel()` when `intelligence=` is passed:**
+```
+httpx scrape → comprehend_website (Sonnet)
+→ judge_affordability (Haiku) → affordability gate
+→ DFS ads + GMB → classify_intent (Sonnet)
+→ intent gate (NOT_TRYING rejected)
+→ analyse_reviews (Sonnet) → refine_evidence (Haiku)
+→ DM discovery → ProspectCard
+```
+Graceful fallback to rule-based scorer when `intelligence=None` (backwards compatible).
+
+---
 
 ### PARALLEL WORKER ORCHESTRATOR (Directive #295)
 
@@ -832,6 +867,7 @@ v6 era (#271–#277): Layer 2 (discovery), Layer 3 (bulk filter), signal config 
 | #293 | Stage-parallel orchestrator: 9-stage concurrent processing, SEM_SPIDER=15/SEM_ABN=1/SEM_PAID=20/SEM_DM=20 | COMPLETE — PR #255 |
 | #294 | Multi-category rotation: 15 AU categories, 5/month rotation, exclude_domains, category_stats | COMPLETE — PR #256 |
 | #295 | httpx primary scraper (Spider fallback), GMB rating dict→scalar fix, AU country filter, run_parallel() + global semaphore pool | COMPLETE — PR #257 |
+| #296 | Sonnet/Haiku intelligence layer: comprehend_website, classify_intent, analyse_reviews, judge_affordability, refine_evidence. Wired into run_parallel(). Prompt caching. | PR #258 — pending merge |
 
 ---
 

--- a/src/pipeline/intelligence.py
+++ b/src/pipeline/intelligence.py
@@ -1,0 +1,470 @@
+"""
+Contract: src/pipeline/intelligence.py
+Purpose: Hybrid Sonnet/Haiku intelligence layer — replaces regex/rule-based website
+         analysis and intent classification with LLM comprehension.
+Layer: 3 - pipeline (called after free enrichment, before scoring gates)
+Directive: #296
+
+Five async stages:
+  1. comprehend_website   — Sonnet, website HTML → structured signals
+  2. classify_intent      — Sonnet, signals + gmb + ads → band + evidence
+  3. analyse_reviews      — Sonnet, GMB reviews → sentiment + pain themes
+  4. judge_affordability  — Haiku, ABN + website → score + hard gate
+  5. refine_evidence      — Haiku, intent + reviews + website → final card copy
+
+All calls:
+  - Use GLOBAL_SEM_SONNET / GLOBAL_SEM_HAIKU from pipeline_orchestrator
+  - System prompt (static, cacheable) first; variable content last
+  - Return parsed JSON; on parse failure return safe fallback dict
+  - Log input/output token counts for cost tracking
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any
+
+import httpx
+
+from src.pipeline.pipeline_orchestrator import GLOBAL_SEM_SONNET, GLOBAL_SEM_HAIKU
+
+logger = logging.getLogger(__name__)
+
+# ── Model constants ───────────────────────────────────────────────────────────
+_MODEL_SONNET = "claude-sonnet-4-5"
+_MODEL_HAIKU  = "claude-haiku-4-5"
+_ANTHROPIC_API = "https://api.anthropic.com/v1/messages"
+_ANTHROPIC_VERSION = "2023-06-01"
+
+# Prompt caching beta header
+_CACHE_BETA = "prompt-caching-2024-07-31"
+
+# Max HTML chars sent to model — trim to avoid token blowout
+_HTML_MAX_CHARS = 12_000
+_REVIEW_MAX_CHARS = 6_000
+
+
+def _get_api_key() -> str:
+    """Resolve Anthropic API key from environment or settings."""
+    key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not key:
+        try:
+            from src.config.settings import settings
+            key = settings.anthropic_api_key
+        except Exception:
+            pass
+    return key
+
+
+def _trim_html(html: str) -> str:
+    """Strip script/style blocks and trim HTML to max chars."""
+    html = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    html = re.sub(r"<style[^>]*>.*?</style>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    html = re.sub(r"<[^>]+>", " ", html)
+    html = re.sub(r"\s+", " ", html).strip()
+    return html[:_HTML_MAX_CHARS]
+
+
+def _parse_json_response(text: str, fallback: dict) -> dict:
+    """Extract JSON from model response; return fallback on failure."""
+    # Try to find JSON block
+    match = re.search(r"\{[\s\S]*\}", text)
+    if match:
+        try:
+            return json.loads(match.group())
+        except json.JSONDecodeError:
+            pass
+    logger.warning("intelligence: failed to parse JSON response, using fallback")
+    return fallback
+
+
+async def _call_anthropic(
+    model: str,
+    system_blocks: list[dict],
+    user_content: str,
+    max_tokens: int = 1024,
+) -> tuple[str, int, int]:
+    """
+    POST to Anthropic Messages API.
+    Returns (response_text, input_tokens, output_tokens).
+    system_blocks: list of content blocks, first block marked cache_control for caching.
+    """
+    api_key = _get_api_key()
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": _ANTHROPIC_VERSION,
+        "anthropic-beta": _CACHE_BETA,
+        "content-type": "application/json",
+    }
+    payload = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "system": system_blocks,
+        "messages": [{"role": "user", "content": user_content}],
+    }
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(_ANTHROPIC_API, headers=headers, json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+
+    text = data["content"][0]["text"] if data.get("content") else ""
+    usage = data.get("usage", {})
+    in_tok  = usage.get("input_tokens", 0)
+    out_tok = usage.get("output_tokens", 0)
+    return text, in_tok, out_tok
+
+
+# ── Stage 1: Website comprehension (Sonnet) ───────────────────────────────────
+
+_WEBSITE_SYSTEM = """You are a business intelligence analyst specialising in Australian SMBs. \
+Analyse the website content provided and extract structured signals about the business.
+
+Return ONLY valid JSON with these exact keys:
+{
+  "services": ["list of services offered"],
+  "team_size_indicator": "solo|small(2-5)|medium(6-20)|large(20+)|unknown",
+  "technology_signals": {
+    "has_analytics": true/false,
+    "has_ads_tag": true/false,
+    "has_meta_pixel": true/false,
+    "has_booking_system": true/false,
+    "has_conversion_tracking": true/false,
+    "cms": "wordpress|wix|squarespace|webflow|shopify|custom|unknown",
+    "analytics_tools": ["list of analytics tools detected"]
+  },
+  "contact_methods": ["phone","email","contact_form","live_chat","booking"],
+  "content_freshness": "current|stale|no_content",
+  "business_maturity": "startup|growing|established|unknown",
+  "location_signals": ["list of AU states/cities mentioned"],
+  "pain_indicators": ["list of business problems the site hints at"]
+}"""
+
+_WEBSITE_SYSTEM_BLOCK = {
+    "type": "text",
+    "text": _WEBSITE_SYSTEM,
+    "cache_control": {"type": "ephemeral"},
+}
+
+
+async def comprehend_website(domain: str, html: str, url: str) -> dict:
+    """
+    Stage 1 — Sonnet. Extract structured business signals from website HTML.
+    Replaces regex-based extraction in free_enrichment.py.
+    """
+    fallback = {
+        "services": [], "team_size_indicator": "unknown",
+        "technology_signals": {
+            "has_analytics": False, "has_ads_tag": False, "has_meta_pixel": False,
+            "has_booking_system": False, "has_conversion_tracking": False,
+            "cms": "unknown", "analytics_tools": [],
+        },
+        "contact_methods": [], "content_freshness": "unknown",
+        "business_maturity": "unknown", "location_signals": [], "pain_indicators": [],
+    }
+    async with GLOBAL_SEM_SONNET:
+        try:
+            trimmed = _trim_html(html)
+            user_content = f"Domain: {domain}\nURL: {url}\n\nWebsite content:\n{trimmed}"
+            text, in_tok, out_tok = await _call_anthropic(
+                model=_MODEL_SONNET,
+                system_blocks=[_WEBSITE_SYSTEM_BLOCK],
+                user_content=user_content,
+                max_tokens=800,
+            )
+            logger.info("comprehend_website domain=%s tokens=%d/%d", domain, in_tok, out_tok)
+            return _parse_json_response(text, fallback)
+        except Exception as exc:
+            logger.warning("comprehend_website failed domain=%s: %s", domain, exc)
+            return fallback
+
+
+# ── Stage 2: Intent classification (Sonnet) ──────────────────────────────────
+
+_INTENT_SYSTEM = """You are a sales intelligence analyst for a digital marketing agency. \
+Your job is to classify an Australian SMB's digital marketing intent based on observable signals.
+
+Intent bands:
+- NOT_TRYING: No digital marketing activity. No website analytics, no ads, no online presence effort.
+- DABBLING: Some effort but inconsistent. Has a website but no tracking, or ran ads but stopped.
+- TRYING: Active digital marketing with clear gaps. Running ads without conversion tracking, \
+  has analytics but no optimisation, spending money without measuring results.
+- STRUGGLING: Heavy investment with obvious problems. High ad spend, poor landing pages, \
+  negative reviews, losing market share. Urgent need for help.
+
+Return ONLY valid JSON:
+{
+  "band": "NOT_TRYING|DABBLING|TRYING|STRUGGLING",
+  "score": 0-18,
+  "confidence": "HIGH|MEDIUM|LOW",
+  "evidence": [
+    {"effort": "what the business is doing", "gap": "what they're missing or doing wrong"}
+  ],
+  "primary_signal": "the single strongest signal that defines this classification",
+  "recommended_entry_point": "the most compelling opening for outreach"
+}"""
+
+_INTENT_SYSTEM_BLOCK = {
+    "type": "text",
+    "text": _INTENT_SYSTEM,
+    "cache_control": {"type": "ephemeral"},
+}
+
+
+async def classify_intent(
+    domain: str,
+    website_data: dict,
+    gmb_data: dict | None,
+    ads_data: dict | None,
+) -> dict:
+    """
+    Stage 2 — Sonnet. Classify digital marketing intent from aggregated signals.
+    Replaces point-counting in prospect_scorer.py score_intent_full().
+    """
+    fallback = {
+        "band": "NOT_TRYING", "score": 0, "confidence": "LOW",
+        "evidence": [], "primary_signal": "", "recommended_entry_point": "",
+    }
+    async with GLOBAL_SEM_SONNET:
+        try:
+            signals_summary = {
+                "website": website_data,
+                "gmb": {
+                    "review_count": (gmb_data or {}).get("gmb_review_count", 0),
+                    "rating": (gmb_data or {}).get("gmb_rating"),
+                    "found": (gmb_data or {}).get("gmb_found", False),
+                },
+                "ads": {
+                    "running": (ads_data or {}).get("is_running_ads", False),
+                    "ad_count": (ads_data or {}).get("ad_count", 0),
+                },
+            }
+            user_content = (
+                f"Domain: {domain}\n\n"
+                f"Signals:\n{json.dumps(signals_summary, indent=2)}"
+            )
+            text, in_tok, out_tok = await _call_anthropic(
+                model=_MODEL_SONNET,
+                system_blocks=[_INTENT_SYSTEM_BLOCK],
+                user_content=user_content,
+                max_tokens=600,
+            )
+            logger.info("classify_intent domain=%s tokens=%d/%d", domain, in_tok, out_tok)
+            return _parse_json_response(text, fallback)
+        except Exception as exc:
+            logger.warning("classify_intent failed domain=%s: %s", domain, exc)
+            return fallback
+
+
+# ── Stage 3: GMB review analysis (Sonnet) ────────────────────────────────────
+
+_REVIEWS_SYSTEM = """You are analysing Google My Business reviews for an Australian SMB. \
+Extract intelligence that would help a marketing agency understand the business's strengths, \
+weaknesses, and the owner's engagement style.
+
+Return ONLY valid JSON:
+{
+  "sentiment_trend": "improving|stable|declining|insufficient_data",
+  "average_rating": 0.0,
+  "pain_themes": ["list of recurring customer complaints or business problems"],
+  "strength_themes": ["list of recurring customer praises"],
+  "owner_responsiveness": "always|sometimes|rarely|never",
+  "owner_tone": "professional|friendly|defensive|absent",
+  "staff_mentions": ["staff names mentioned in reviews"],
+  "decision_maker_signals": ["signals about who runs the business"],
+  "marketing_opportunity": "one sentence on the strongest marketing angle based on reviews"
+}"""
+
+_REVIEWS_SYSTEM_BLOCK = {
+    "type": "text",
+    "text": _REVIEWS_SYSTEM,
+    "cache_control": {"type": "ephemeral"},
+}
+
+
+async def analyse_reviews(domain: str, reviews: list[dict]) -> dict:
+    """
+    Stage 3 — Sonnet. Read actual GMB review text to extract intelligence.
+    Only called when reviews are available from DFS GMB endpoint.
+    """
+    fallback = {
+        "sentiment_trend": "insufficient_data", "average_rating": 0.0,
+        "pain_themes": [], "strength_themes": [], "owner_responsiveness": "absent",
+        "owner_tone": "absent", "staff_mentions": [], "decision_maker_signals": [],
+        "marketing_opportunity": "",
+    }
+    if not reviews:
+        return fallback
+
+    async with GLOBAL_SEM_SONNET:
+        try:
+            # Trim reviews to stay within token budget
+            review_text = json.dumps(reviews, ensure_ascii=False)[:_REVIEW_MAX_CHARS]
+            user_content = f"Domain: {domain}\n\nReviews:\n{review_text}"
+            text, in_tok, out_tok = await _call_anthropic(
+                model=_MODEL_SONNET,
+                system_blocks=[_REVIEWS_SYSTEM_BLOCK],
+                user_content=user_content,
+                max_tokens=600,
+            )
+            logger.info("analyse_reviews domain=%s reviews=%d tokens=%d/%d",
+                        domain, len(reviews), in_tok, out_tok)
+            return _parse_json_response(text, fallback)
+        except Exception as exc:
+            logger.warning("analyse_reviews failed domain=%s: %s", domain, exc)
+            return fallback
+
+
+# ── Stage 4: Affordability judgment (Haiku) ──────────────────────────────────
+
+_AFFORD_SYSTEM = """You are assessing whether an Australian SMB can afford digital marketing services \
+(typically $1,500–$5,000 AUD/month). Use ABN registry data and website signals to judge financial capacity.
+
+Hard gates (return hard_gate=true if ANY apply):
+- Sole trader (individual, not a company/trust/partnership)
+- Not GST registered (turnover < $75K AUD)
+- No website AND no ABN found (unreachable)
+
+Score 0–10 based on: entity type, GST status, years trading, professional website, \
+email domain, CMS quality, team size signals.
+
+Return ONLY valid JSON:
+{
+  "score": 0-10,
+  "hard_gate": true/false,
+  "gate_reason": "sole_trader|no_gst|unreachable|none",
+  "band": "LOW|MEDIUM|HIGH|VERY_HIGH",
+  "judgment": "one sentence explaining the affordability assessment",
+  "confidence": "HIGH|MEDIUM|LOW"
+}"""
+
+_AFFORD_SYSTEM_BLOCK = {
+    "type": "text",
+    "text": _AFFORD_SYSTEM,
+    "cache_control": {"type": "ephemeral"},
+}
+
+
+async def judge_affordability(
+    domain: str,
+    abn_data: dict,
+    website_data: dict,
+) -> dict:
+    """
+    Stage 4 — Haiku. Assess whether SMB can afford agency services.
+    Complements ProspectScorer.score_affordability() with LLM judgment.
+    """
+    fallback = {
+        "score": 0, "hard_gate": False, "gate_reason": "none",
+        "band": "MEDIUM", "judgment": "", "confidence": "LOW",
+    }
+    async with GLOBAL_SEM_HAIKU:
+        try:
+            context = {
+                "domain": domain,
+                "abn": {
+                    "entity_type": abn_data.get("entity_type"),
+                    "gst_registered": abn_data.get("gst_registered"),
+                    "abn_matched": abn_data.get("abn_matched"),
+                    "entity_name": abn_data.get("entity_name"),
+                },
+                "website": {
+                    "cms": website_data.get("technology_signals", {}).get("cms"),
+                    "team_size": website_data.get("team_size_indicator"),
+                    "content_freshness": website_data.get("content_freshness"),
+                    "business_maturity": website_data.get("business_maturity"),
+                    "has_professional_email": "email" in (website_data.get("contact_methods") or []),
+                },
+            }
+            user_content = f"SMB profile:\n{json.dumps(context, indent=2)}"
+            text, in_tok, out_tok = await _call_anthropic(
+                model=_MODEL_HAIKU,
+                system_blocks=[_AFFORD_SYSTEM_BLOCK],
+                user_content=user_content,
+                max_tokens=300,
+            )
+            logger.info("judge_affordability domain=%s tokens=%d/%d", domain, in_tok, out_tok)
+            return _parse_json_response(text, fallback)
+        except Exception as exc:
+            logger.warning("judge_affordability failed domain=%s: %s", domain, exc)
+            return fallback
+
+
+# ── Stage 5: Evidence refinement (Haiku) ─────────────────────────────────────
+
+_EVIDENCE_SYSTEM = """You are writing prospect card copy for a digital marketing agency's CRM. \
+Given intent signals, review intelligence, and website analysis for an Australian SMB, \
+produce concise, specific, human-readable evidence statements.
+
+Rules:
+- Be specific (name the actual signal, not generic statements)
+- Use plain Australian business English
+- Each evidence statement = one observable fact + one implied opportunity
+- Headline signal = the single most compelling reason to reach out NOW
+- Recommended service = the most logical first service to offer
+- Outreach angle = the emotional hook for the first message (problem-aware, not solution-first)
+
+Return ONLY valid JSON:
+{
+  "evidence_statements": ["list of 2-5 specific evidence strings"],
+  "headline_signal": "single most compelling signal (one sentence)",
+  "recommended_service": "most logical first service to pitch",
+  "outreach_angle": "emotional hook for first outreach message"
+}"""
+
+_EVIDENCE_SYSTEM_BLOCK = {
+    "type": "text",
+    "text": _EVIDENCE_SYSTEM,
+    "cache_control": {"type": "ephemeral"},
+}
+
+
+async def refine_evidence(
+    domain: str,
+    intent_data: dict,
+    review_data: dict,
+    website_data: dict,
+) -> dict:
+    """
+    Stage 5 — Haiku. Produce final prospect card copy from aggregated intelligence.
+    Replaces hardcoded evidence strings in ProspectScorer.
+    """
+    fallback = {
+        "evidence_statements": [],
+        "headline_signal": "",
+        "recommended_service": "",
+        "outreach_angle": "",
+    }
+    async with GLOBAL_SEM_HAIKU:
+        try:
+            context = {
+                "domain": domain,
+                "intent_band": intent_data.get("band", "UNKNOWN"),
+                "intent_score": intent_data.get("score", 0),
+                "primary_signal": intent_data.get("primary_signal", ""),
+                "raw_evidence": intent_data.get("evidence", []),
+                "review_summary": {
+                    "sentiment_trend": review_data.get("sentiment_trend", "insufficient_data"),
+                    "pain_themes": review_data.get("pain_themes", []),
+                    "marketing_opportunity": review_data.get("marketing_opportunity", ""),
+                    "owner_responsiveness": review_data.get("owner_responsiveness", "absent"),
+                },
+                "website_summary": {
+                    "services": website_data.get("services", []),
+                    "pain_indicators": website_data.get("pain_indicators", []),
+                    "business_maturity": website_data.get("business_maturity", "unknown"),
+                },
+            }
+            user_content = f"Prospect intelligence:\n{json.dumps(context, indent=2)}"
+            text, in_tok, out_tok = await _call_anthropic(
+                model=_MODEL_HAIKU,
+                system_blocks=[_EVIDENCE_SYSTEM_BLOCK],
+                user_content=user_content,
+                max_tokens=400,
+            )
+            logger.info("refine_evidence domain=%s tokens=%d/%d", domain, in_tok, out_tok)
+            return _parse_json_response(text, fallback)
+        except Exception as exc:
+            logger.warning("refine_evidence failed domain=%s: %s", domain, exc)
+            return fallback

--- a/src/pipeline/intelligence.py
+++ b/src/pipeline/intelligence.py
@@ -20,6 +20,7 @@ All calls:
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -28,9 +29,12 @@ from typing import Any
 
 import httpx
 
-from src.pipeline.pipeline_orchestrator import GLOBAL_SEM_SONNET, GLOBAL_SEM_HAIKU
-
 logger = logging.getLogger(__name__)
+
+# ── Semaphores — defined here and re-exported; pipeline_orchestrator imports these ──
+# Defined in intelligence.py to avoid circular import with pipeline_orchestrator.
+GLOBAL_SEM_SONNET = asyncio.Semaphore(12)
+GLOBAL_SEM_HAIKU  = asyncio.Semaphore(15)
 
 # ── Model constants ───────────────────────────────────────────────────────────
 _MODEL_SONNET = "claude-sonnet-4-5"

--- a/src/pipeline/pipeline_orchestrator.py
+++ b/src/pipeline/pipeline_orchestrator.py
@@ -27,6 +27,8 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from src.pipeline.prospect_scorer import ProspectScorer, ProspectScore
+from src.pipeline.intelligence import GLOBAL_SEM_SONNET, GLOBAL_SEM_HAIKU  # shared semaphores
+from src.pipeline import intelligence as _intel_module  # optional: used when self._intelligence is set
 
 logger = logging.getLogger(__name__)
 
@@ -37,10 +39,9 @@ SEM_PAID   = 20    # DFS Ads Search + GMB concurrent
 SEM_DM     = 20    # DFS SERP LinkedIn concurrent
 
 # Global semaphore pool — shared across parallel workers (module-level singletons)
+# GLOBAL_SEM_SONNET and GLOBAL_SEM_HAIKU are defined in intelligence.py and imported above
 GLOBAL_SEM_DFS    = asyncio.Semaphore(25)
 GLOBAL_SEM_SCRAPE = asyncio.Semaphore(50)
-GLOBAL_SEM_SONNET = asyncio.Semaphore(12)
-GLOBAL_SEM_HAIKU  = asyncio.Semaphore(15)
 
 
 @dataclass
@@ -673,25 +674,40 @@ class PipelineOrchestrator:
                             stats.affordability_rejected += 1
                         continue
 
-                    # GATE 1: Affordability
-                    afford = self._scorer.score_affordability(enrichment)
-                    if not afford.passed_gate:
-                        async with stats_lock:
-                            stats.affordability_rejected += 1
-                        continue
-
-                    # GATE 2: Intent free
-                    intent_free = self._scorer.score_intent_free(enrichment)
-                    if getattr(intent_free, "band", None) == "NOT_TRYING":
-                        async with stats_lock:
-                            stats.intent_rejected += 1
-                        continue
-
-                    # STAGE 6: Paid enrichment
+                    intel = self._intelligence  # None if not wired
+                    html = enrichment.get("html", "")
                     company_name = enrichment.get("company_name") or domain
                     addr = enrichment.get("website_address") or {}
                     suburb = (addr.get("suburb") or addr.get("city") or "") if isinstance(addr, dict) else ""
 
+                    # ── STAGE 3b: Website comprehension (Sonnet, optional) ────
+                    website_data: dict = {}
+                    if intel is not None:
+                        website_data = await intel.comprehend_website(domain, html, f"https://{domain}")
+
+                    # ── GATE 1: Affordability ─────────────────────────────────
+                    if intel is not None:
+                        # Haiku affordability judgment replaces rule-based scorer
+                        afford_intel = await intel.judge_affordability(domain, enrichment, website_data)
+                        if afford_intel.get("hard_gate"):
+                            async with stats_lock:
+                                stats.affordability_rejected += 1
+                            continue
+                        # Build a duck-typed result compatible with ProspectCard fields
+                        class _AffordResult:
+                            band = afford_intel.get("band", "MEDIUM")
+                            raw_score = afford_intel.get("score", 5)
+                            passed_gate = not afford_intel.get("hard_gate", False)
+                            gaps: list = []
+                        afford = _AffordResult()
+                    else:
+                        afford = self._scorer.score_affordability(enrichment)
+                        if not afford.passed_gate:
+                            async with stats_lock:
+                                stats.affordability_rejected += 1
+                            continue
+
+                    # ── STAGE 6: Paid enrichment ──────────────────────────────
                     async with GLOBAL_SEM_DFS:
                         paid = await self._stage_paid(sem_paid, domain, company_name, suburb, location)
 
@@ -703,12 +719,39 @@ class PipelineOrchestrator:
                     if gmb_data:
                         enrichment = {**enrichment, **gmb_data}
 
-                    # STAGE 7: Full intent score
-                    intent = self._scorer.score_intent_full(enrichment, ads_data, gmb_data)
-                    intent_band = getattr(intent, "band", "UNKNOWN")
-                    evidence = getattr(intent, "evidence", [])
+                    # ── STAGE 7: Intent classification ────────────────────────
+                    if intel is not None:
+                        # Sonnet classify_intent replaces point-counting scorer
+                        intent_data = await intel.classify_intent(domain, website_data, gmb_data, ads_data)
+                        intent_band = intent_data.get("band", "NOT_TRYING")
+                        intent_score = intent_data.get("score", 0)
 
-                    # STAGE 8: DM identification
+                        # Intent gate: NOT_TRYING rejected
+                        if intent_band == "NOT_TRYING":
+                            async with stats_lock:
+                                stats.intent_rejected += 1
+                            continue
+
+                        # Sonnet analyse_reviews
+                        reviews = (gmb_data or {}).get("reviews") or []
+                        review_data = await intel.analyse_reviews(domain, reviews)
+
+                        # Haiku refine_evidence → final card copy
+                        refined = await intel.refine_evidence(domain, intent_data, review_data, website_data)
+                        evidence = refined.get("evidence_statements", [])
+                    else:
+                        # Fallback: rule-based scorer
+                        intent_free = self._scorer.score_intent_free(enrichment)
+                        if getattr(intent_free, "band", None) == "NOT_TRYING":
+                            async with stats_lock:
+                                stats.intent_rejected += 1
+                            continue
+                        intent = self._scorer.score_intent_full(enrichment, ads_data, gmb_data)
+                        intent_band = getattr(intent, "band", "UNKNOWN")
+                        intent_score = getattr(intent, "raw_score", 0)
+                        evidence = getattr(intent, "evidence", [])
+
+                    # ── STAGE 8: DM identification ────────────────────────────
                     async with GLOBAL_SEM_DFS:
                         dm = await self._stage_dm(sem_dm, domain, company_name, enrichment)
 
@@ -737,7 +780,7 @@ class PipelineOrchestrator:
                         affordability_band=afford.band,
                         affordability_score=afford.raw_score,
                         intent_band=intent_band,
-                        intent_score=getattr(intent, "raw_score", 0),
+                        intent_score=intent_score,
                         gmb_rating=enrichment.get("gmb_rating"),
                         gmb_review_count=enrichment.get("gmb_review_count", 0),
                         dm_name=dm.name,

--- a/src/pipeline/pipeline_orchestrator.py
+++ b/src/pipeline/pipeline_orchestrator.py
@@ -115,6 +115,7 @@ class PipelineOrchestrator:
         gmb_client=None,
         ads_client=None,
         prospect_scorer=None,
+        intelligence=None,
     ):
         self._discovery = discovery
         self._fe = free_enrichment
@@ -122,6 +123,7 @@ class PipelineOrchestrator:
         self._dm = dm_identification
         self._gmb_client = gmb_client
         self._ads_client = ads_client
+        self._intelligence = intelligence  # optional: IntelligenceLayer instance or module
 
     # ── Stage helpers ─────────────────────────────────────────────────────
 
@@ -198,6 +200,52 @@ class PipelineOrchestrator:
             except Exception:
                 logger.debug("stage_dm_failed domain=%s", domain)
                 return None
+
+    async def _stage_intelligence(
+        self,
+        domain: str,
+        html: str,
+        enrichment: dict,
+        ads_data: dict | None,
+        gmb_data: dict | None,
+    ) -> dict:
+        """
+        STAGE 7b: Run intelligence pipeline for one domain.
+        Calls comprehend_website → classify_intent → refine_evidence.
+        Returns merged intel dict with evidence_statements, intent_band, services, etc.
+        """
+        try:
+            intel = self._intelligence
+            url = f"https://{domain}"
+
+            # Comprehend website
+            website_data = await intel.comprehend_website(domain, html or "", url)
+
+            # Classify intent
+            intent_data = await intel.classify_intent(domain, website_data, gmb_data, ads_data)
+
+            # Analyse reviews if available
+            reviews = (gmb_data or {}).get("reviews") or []
+            review_data = await intel.analyse_reviews(domain, reviews)
+
+            # Refine evidence into final card copy
+            refined = await intel.refine_evidence(domain, intent_data, review_data, website_data)
+
+            return {
+                "website_data": website_data,
+                "intent_data": intent_data,
+                "review_data": review_data,
+                "evidence_statements": refined.get("evidence_statements", []),
+                "headline_signal": refined.get("headline_signal", ""),
+                "recommended_service": refined.get("recommended_service", ""),
+                "outreach_angle": refined.get("outreach_angle", ""),
+                "intent_band": intent_data.get("band"),
+                "intent_score": intent_data.get("score", 0),
+                "services": website_data.get("services", []),
+            }
+        except Exception as exc:
+            logger.warning("_stage_intelligence failed domain=%s: %s", domain, exc)
+            return {}
 
     # ── Main run ──────────────────────────────────────────────────────────
 
@@ -404,6 +452,28 @@ class PipelineOrchestrator:
                         intent_full = intent_free  # legacy fallback
                     dm_candidates.append((domain, enrichment, afford, intent_full, paid))
 
+                # ── STAGE 7b: Intelligence layer (optional, Sonnet/Haiku) ─────
+                # Runs comprehend_website → classify_intent → refine_evidence
+                # for each dm_candidate if intelligence module is wired.
+                intel_results: dict[str, dict] = {}
+                if self._intelligence is not None:
+                    intel_coros = []
+                    for domain, enrichment, afford, intent_full, paid in dm_candidates:
+                        spider_html = enrichment.get("html", "")
+                        ads_data = paid.get("ads_data")
+                        gmb_data = paid.get("gmb_data")
+                        intel_coros.append(
+                            self._stage_intelligence(domain, spider_html, enrichment, ads_data, gmb_data)
+                        )
+                    intel_raw = await asyncio.gather(*intel_coros, return_exceptions=True)
+                    for (domain, *_), intel in zip(dm_candidates, intel_raw):
+                        if isinstance(intel, Exception):
+                            logger.warning("intelligence failed domain=%s: %s", domain, intel)
+                            intel_results[domain] = {}
+                        else:
+                            intel_results[domain] = intel or {}
+                    logger.info("stage7b_intelligence_complete domains=%d", len(intel_results))
+
                 # ── STAGE 8: DM identification ALL concurrently ───────────────
                 dm_coros = []
                 for domain, enrichment, afford, intent_full, paid in dm_candidates:
@@ -444,15 +514,22 @@ class PipelineOrchestrator:
                         or enrichment.get("abn_entity_name")
                         or domain
                     )
-                    evidence = getattr(intent_full, "evidence", []) if intent_full else []
-                    intent_band = getattr(intent_full, "band", "UNKNOWN") if intent_full else "UNKNOWN"
-                    intent_score = getattr(intent_full, "raw_score", 0) if intent_full else 0
+                    # Use intelligence layer results if available, else fall back to scorer
+                    intel = intel_results.get(domain, {})
+                    if intel.get("evidence_statements"):
+                        evidence = intel["evidence_statements"]
+                        intent_band = intel.get("intent_band") or (getattr(intent_full, "band", "UNKNOWN") if intent_full else "UNKNOWN")
+                        intent_score = intel.get("intent_score") or (getattr(intent_full, "raw_score", 0) if intent_full else 0)
+                    else:
+                        evidence = getattr(intent_full, "evidence", []) if intent_full else []
+                        intent_band = getattr(intent_full, "band", "UNKNOWN") if intent_full else "UNKNOWN"
+                        intent_score = getattr(intent_full, "raw_score", 0) if intent_full else 0
 
                     card = ProspectCard(
                         domain=domain,
                         company_name=company_name,
                         location=(enrichment.get("website_address") or {}).get("suburb", location),
-                        services=enrichment.get("services") or [],
+                        services=enrichment.get("services") or intel.get("services") or [],
                         evidence=evidence,
                         affordability_band=afford.band,
                         affordability_score=afford.raw_score,

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -1,0 +1,284 @@
+"""Tests for src/pipeline/intelligence.py — Directive #296."""
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _mock_anthropic_response(payload: dict) -> MagicMock:
+    """Return a mock httpx response that mimics Anthropic API."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "content": [{"text": json.dumps(payload)}],
+        "usage": {"input_tokens": 100, "output_tokens": 50},
+    }
+    return mock_resp
+
+
+def _patch_httpx(payload: dict):
+    """Context manager: patch httpx.AsyncClient.post to return payload."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=_mock_anthropic_response(payload))
+    return patch("src.pipeline.intelligence.httpx.AsyncClient", return_value=mock_client)
+
+
+# ── comprehend_website ────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_comprehend_website_returns_structured_dict():
+    expected = {
+        "services": ["dental implants", "teeth whitening"],
+        "team_size_indicator": "small(2-5)",
+        "technology_signals": {
+            "has_analytics": False, "has_ads_tag": True, "has_meta_pixel": False,
+            "has_booking_system": True, "has_conversion_tracking": False,
+            "cms": "wordpress", "analytics_tools": [],
+        },
+        "contact_methods": ["phone", "email"],
+        "content_freshness": "current",
+        "business_maturity": "established",
+        "location_signals": ["Sydney", "NSW"],
+        "pain_indicators": ["no conversion tracking on ads"],
+    }
+    with _patch_httpx(expected):
+        from src.pipeline.intelligence import comprehend_website
+        result = await comprehend_website("dentist.com.au", "<html>test</html>", "https://dentist.com.au")
+    assert result["services"] == ["dental implants", "teeth whitening"]
+    assert result["technology_signals"]["has_ads_tag"] is True
+    assert result["location_signals"] == ["Sydney", "NSW"]
+
+
+@pytest.mark.asyncio
+async def test_comprehend_website_returns_fallback_on_api_error():
+    with patch("src.pipeline.intelligence.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=Exception("API down"))
+        mock_cls.return_value = mock_client
+        from src.pipeline.intelligence import comprehend_website
+        result = await comprehend_website("dentist.com.au", "<html>test</html>", "https://dentist.com.au")
+    assert result["services"] == []
+    assert result["team_size_indicator"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_comprehend_website_returns_fallback_on_bad_json():
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "content": [{"text": "not valid json at all!"}],
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+    with patch("src.pipeline.intelligence.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_cls.return_value = mock_client
+        from src.pipeline.intelligence import comprehend_website
+        result = await comprehend_website("dentist.com.au", "<html>test</html>", "https://dentist.com.au")
+    assert "services" in result  # fallback has services key
+
+
+# ── classify_intent ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_classify_intent_returns_band_and_evidence():
+    expected = {
+        "band": "TRYING",
+        "score": 7,
+        "confidence": "HIGH",
+        "evidence": [{"effort": "Running Google Ads", "gap": "No conversion tracking"}],
+        "primary_signal": "Active ads spend without measurement",
+        "recommended_entry_point": "We noticed your Google Ads are running without conversion tracking",
+    }
+    with _patch_httpx(expected):
+        from src.pipeline.intelligence import classify_intent
+        result = await classify_intent(
+            "dentist.com.au",
+            website_data={"technology_signals": {"has_ads_tag": True}},
+            gmb_data={"gmb_review_count": 45},
+            ads_data={"is_running_ads": True, "ad_count": 3},
+        )
+    assert result["band"] == "TRYING"
+    assert result["score"] == 7
+    assert len(result["evidence"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_classify_intent_fallback_on_error():
+    with patch("src.pipeline.intelligence.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=Exception("timeout"))
+        mock_cls.return_value = mock_client
+        from src.pipeline.intelligence import classify_intent
+        result = await classify_intent("dentist.com.au", {}, None, None)
+    assert result["band"] == "NOT_TRYING"
+    assert result["evidence"] == []
+
+
+# ── analyse_reviews ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_analyse_reviews_returns_sentiment():
+    expected = {
+        "sentiment_trend": "improving",
+        "average_rating": 4.5,
+        "pain_themes": ["long wait times"],
+        "strength_themes": ["friendly staff", "clean rooms"],
+        "owner_responsiveness": "always",
+        "owner_tone": "professional",
+        "staff_mentions": ["Dr. Smith"],
+        "decision_maker_signals": ["owner replies personally"],
+        "marketing_opportunity": "Highlight 5-star reviews in Google Ads",
+    }
+    reviews = [{"text": "Great service!", "rating": 5}]
+    with _patch_httpx(expected):
+        from src.pipeline.intelligence import analyse_reviews
+        result = await analyse_reviews("dentist.com.au", reviews)
+    assert result["sentiment_trend"] == "improving"
+    assert "Dr. Smith" in result["staff_mentions"]
+
+
+@pytest.mark.asyncio
+async def test_analyse_reviews_returns_fallback_for_empty_list():
+    from src.pipeline.intelligence import analyse_reviews
+    result = await analyse_reviews("dentist.com.au", [])
+    assert result["sentiment_trend"] == "insufficient_data"
+    assert result["pain_themes"] == []
+
+
+# ── judge_affordability ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_judge_affordability_passes_company():
+    expected = {
+        "score": 8,
+        "hard_gate": False,
+        "gate_reason": "none",
+        "band": "HIGH",
+        "judgment": "Established company, GST registered, professional website",
+        "confidence": "HIGH",
+    }
+    abn = {"entity_type": "Company", "gst_registered": True, "abn_matched": True}
+    website = {"technology_signals": {"cms": "wordpress"}, "team_size_indicator": "small(2-5)"}
+    with _patch_httpx(expected):
+        from src.pipeline.intelligence import judge_affordability
+        result = await judge_affordability("dentist.com.au", abn, website)
+    assert result["hard_gate"] is False
+    assert result["band"] == "HIGH"
+    assert result["score"] == 8
+
+
+@pytest.mark.asyncio
+async def test_judge_affordability_hard_gate_sole_trader():
+    expected = {
+        "score": 0,
+        "hard_gate": True,
+        "gate_reason": "sole_trader",
+        "band": "LOW",
+        "judgment": "Individual sole trader — below affordability threshold",
+        "confidence": "HIGH",
+    }
+    abn = {"entity_type": "Individual", "gst_registered": False}
+    with _patch_httpx(expected):
+        from src.pipeline.intelligence import judge_affordability
+        result = await judge_affordability("tradie.com.au", abn, {})
+    assert result["hard_gate"] is True
+    assert result["gate_reason"] == "sole_trader"
+
+
+# ── refine_evidence ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_refine_evidence_returns_card_copy():
+    expected = {
+        "evidence_statements": [
+            "Running Google Ads without conversion tracking — spending blind",
+            "WordPress site with no analytics — can't measure ROI",
+        ],
+        "headline_signal": "Active ad spend with zero measurement",
+        "recommended_service": "Google Ads audit + conversion tracking setup",
+        "outreach_angle": "You're spending money on ads but can't tell if they're working",
+    }
+    intent_data = {"band": "TRYING", "score": 7, "evidence": [], "primary_signal": "ads no tracking"}
+    with _patch_httpx(expected):
+        from src.pipeline.intelligence import refine_evidence
+        result = await refine_evidence("dentist.com.au", intent_data, {}, {})
+    assert len(result["evidence_statements"]) == 2
+    assert "headline_signal" in result
+    assert "outreach_angle" in result
+
+
+@pytest.mark.asyncio
+async def test_refine_evidence_fallback_on_error():
+    with patch("src.pipeline.intelligence.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=Exception("timeout"))
+        mock_cls.return_value = mock_client
+        from src.pipeline.intelligence import refine_evidence
+        result = await refine_evidence("dentist.com.au", {}, {}, {})
+    assert result["evidence_statements"] == []
+    assert result["headline_signal"] == ""
+
+
+# ── Orchestrator wiring ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_orchestrator_accepts_intelligence_kwarg():
+    """PipelineOrchestrator accepts intelligence= without error."""
+    from src.pipeline.pipeline_orchestrator import PipelineOrchestrator
+    intel_mock = MagicMock()
+    orch = PipelineOrchestrator(
+        discovery=MagicMock(),
+        free_enrichment=MagicMock(),
+        scorer=MagicMock(),
+        dm_identification=MagicMock(),
+        intelligence=intel_mock,
+    )
+    assert orch._intelligence is intel_mock
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_intelligence_none_by_default():
+    """intelligence= defaults to None — existing runs unaffected."""
+    from src.pipeline.pipeline_orchestrator import PipelineOrchestrator
+    orch = PipelineOrchestrator(
+        discovery=MagicMock(),
+        free_enrichment=MagicMock(),
+        scorer=MagicMock(),
+        dm_identification=MagicMock(),
+    )
+    assert orch._intelligence is None
+
+
+def test_intelligence_module_imports():
+    """All five functions importable from intelligence module."""
+    from src.pipeline.intelligence import (
+        comprehend_website,
+        classify_intent,
+        analyse_reviews,
+        judge_affordability,
+        refine_evidence,
+    )
+    assert callable(comprehend_website)
+    assert callable(classify_intent)
+    assert callable(analyse_reviews)
+    assert callable(judge_affordability)
+    assert callable(refine_evidence)
+
+
+def test_global_semaphores_used():
+    """Intelligence module imports GLOBAL_SEM_SONNET and GLOBAL_SEM_HAIKU."""
+    from src.pipeline.intelligence import GLOBAL_SEM_SONNET, GLOBAL_SEM_HAIKU
+    assert GLOBAL_SEM_SONNET._value == 12
+    assert GLOBAL_SEM_HAIKU._value == 15

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -282,3 +282,147 @@ def test_global_semaphores_used():
     from src.pipeline.intelligence import GLOBAL_SEM_SONNET, GLOBAL_SEM_HAIKU
     assert GLOBAL_SEM_SONNET._value == 12
     assert GLOBAL_SEM_HAIKU._value == 15
+
+
+# ── Semaphore acquisition test ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_comprehend_website_acquires_sonnet_semaphore():
+    """GLOBAL_SEM_SONNET is acquired and released on each comprehend_website call."""
+    import asyncio
+    from src.pipeline.intelligence import GLOBAL_SEM_SONNET
+
+    acquire_calls = []
+    release_calls = []
+
+    original_acquire = GLOBAL_SEM_SONNET.__class__.__aenter__
+    original_release = GLOBAL_SEM_SONNET.__class__.__aexit__
+
+    expected = {
+        "services": [], "team_size_indicator": "unknown",
+        "technology_signals": {
+            "has_analytics": False, "has_ads_tag": False, "has_meta_pixel": False,
+            "has_booking_system": False, "has_conversion_tracking": False,
+            "cms": "unknown", "analytics_tools": [],
+        },
+        "contact_methods": [], "content_freshness": "unknown",
+        "business_maturity": "unknown", "location_signals": [], "pain_indicators": [],
+    }
+
+    semaphore_acquired = []
+
+    async def patched_aenter(self):
+        semaphore_acquired.append(True)
+        return self
+
+    async def patched_aexit(self, *args):
+        semaphore_acquired.append(False)
+
+    with patch.object(GLOBAL_SEM_SONNET.__class__, "__aenter__", patched_aenter), \
+         patch.object(GLOBAL_SEM_SONNET.__class__, "__aexit__", patched_aexit), \
+         _patch_httpx(expected):
+        from src.pipeline.intelligence import comprehend_website
+        await comprehend_website("test.com.au", "<html>test</html>", "https://test.com.au")
+
+    # Semaphore was both acquired (True) and released (False)
+    assert True in semaphore_acquired
+    assert False in semaphore_acquired
+
+
+@pytest.mark.asyncio
+async def test_token_usage_logged(caplog):
+    """comprehend_website logs input/output token counts for cost tracking."""
+    import logging
+    expected = {
+        "services": ["plumbing"], "team_size_indicator": "small(2-5)",
+        "technology_signals": {
+            "has_analytics": True, "has_ads_tag": False, "has_meta_pixel": False,
+            "has_booking_system": False, "has_conversion_tracking": False,
+            "cms": "wordpress", "analytics_tools": ["ga4"],
+        },
+        "contact_methods": ["phone"],
+        "content_freshness": "current", "business_maturity": "established",
+        "location_signals": ["Melbourne", "VIC"], "pain_indicators": [],
+    }
+    with _patch_httpx(expected), caplog.at_level(logging.INFO, logger="src.pipeline.intelligence"):
+        from src.pipeline.intelligence import comprehend_website
+        await comprehend_website("plumber.com.au", "<html>plumbing</html>", "https://plumber.com.au")
+
+    # Log should contain domain and token counts (100 input, 50 output from mock)
+    assert any("plumber.com.au" in r.message and "100" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_run_parallel_with_intelligence_wired():
+    """run_parallel uses intelligence flow when self._intelligence is set."""
+    from src.pipeline.pipeline_orchestrator import PipelineOrchestrator
+
+    # Mock discovery: 2 domains then empty
+    disc = MagicMock()
+    disc.pull_batch = AsyncMock(side_effect=[
+        [{"domain": "dental.com.au"}, {"domain": "plumber.com.au"}],
+        [],
+    ])
+
+    # Mock free enrichment
+    fe = MagicMock()
+    fe.scrape_website = AsyncMock(return_value={"title": "Test", "html": "<html>Test</html>"})
+    fe.enrich_from_spider = AsyncMock(return_value={
+        "domain": "dental.com.au", "company_name": "Test Dental",
+        "entity_type": "Company", "gst_registered": True,
+        "non_au": False, "website_contact_emails": ["info@dental.com.au"],
+        "html": "<html>Test</html>",
+    })
+
+    # Mock intelligence module
+    intel = MagicMock()
+    intel.comprehend_website = AsyncMock(return_value={"services": ["dentistry"], "technology_signals": {"has_ads_tag": True}})
+    intel.judge_affordability = AsyncMock(return_value={"hard_gate": False, "band": "HIGH", "score": 8})
+    intel.classify_intent = AsyncMock(return_value={"band": "TRYING", "score": 6, "evidence": [{"effort": "Ads", "gap": "No tracking"}]})
+    intel.analyse_reviews = AsyncMock(return_value={"sentiment_trend": "stable", "pain_themes": []})
+    intel.refine_evidence = AsyncMock(return_value={
+        "evidence_statements": ["Running ads without conversion tracking"],
+        "headline_signal": "Active ad spend, no measurement",
+        "recommended_service": "Google Ads audit",
+        "outreach_angle": "You're spending blind",
+    })
+
+    # Mock DM
+    dm_id = MagicMock()
+    dm_result = MagicMock()
+    dm_result.name = "Dr. Jane Smith"
+    dm_result.title = "Principal Dentist"
+    dm_result.linkedin_url = "https://au.linkedin.com/in/janesmith"
+    dm_result.confidence = "HIGH"
+    dm_id.identify = AsyncMock(return_value=dm_result)
+
+    # Minimal scorer (fallback path, shouldn't be called with intel wired)
+    scorer = MagicMock()
+    scorer.score_affordability = MagicMock(side_effect=AssertionError("scorer should not be called with intel wired"))
+
+    orch = PipelineOrchestrator(
+        discovery=disc,
+        free_enrichment=fe,
+        scorer=scorer,
+        dm_identification=dm_id,
+        intelligence=intel,
+    )
+
+    result = await orch.run_parallel(
+        category_codes=["10514"],
+        location="Australia",
+        target_count=1,
+        num_workers=1,
+        batch_size=5,
+    )
+
+    assert len(result.prospects) >= 1
+    card = result.prospects[0]
+    assert card.evidence == ["Running ads without conversion tracking"]
+    assert card.intent_band == "TRYING"
+    assert card.dm_name == "Dr. Jane Smith"
+    # Verify intelligence functions were called
+    intel.comprehend_website.assert_called()
+    intel.judge_affordability.assert_called()
+    intel.classify_intent.assert_called()
+    intel.refine_evidence.assert_called()

--- a/tests/test_pipeline/test_orchestrator_parallel.py
+++ b/tests/test_pipeline/test_orchestrator_parallel.py
@@ -1,0 +1,181 @@
+"""Tests for PipelineOrchestrator.run_parallel() — Directive #295."""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.pipeline.pipeline_orchestrator import PipelineOrchestrator
+
+
+def _make_enrich(domain: str, non_au: bool = False) -> dict:
+    return {
+        "domain": domain,
+        "company_name": f"Co {domain}",
+        "non_au": non_au,
+        "website_contact_emails": [f"info@{domain}"],
+        "website_address": {"suburb": "Sydney"},
+    }
+
+
+def _afford_pass():
+    r = MagicMock()
+    r.passed_gate = True
+    r.band = "HIGH"
+    r.raw_score = 10
+    return r
+
+
+def _intent_pass():
+    r = MagicMock()
+    r.band = "TRYING"
+    r.raw_score = 5
+    r.evidence = []
+    return r
+
+
+def _make_dm(name: str = "Jane Owner") -> MagicMock:
+    dm = MagicMock()
+    dm.name = name
+    dm.title = "Owner"
+    dm.linkedin_url = "https://linkedin.com/in/jane"
+    dm.confidence = "HIGH"
+    return dm
+
+
+def _make_orch(domains_per_call: list[list[str]], enrich_non_au: bool = False):
+    """Build a PipelineOrchestrator with mocked dependencies."""
+    # Discovery side_effect: first call returns domains, subsequent calls return []
+    side_effects = []
+    for batch in domains_per_call:
+        side_effects.append([{"domain": d} for d in batch])
+    side_effects.append([])  # exhaustion sentinel
+
+    disc = MagicMock()
+    disc.pull_batch = AsyncMock(side_effect=side_effects)
+
+    enr = MagicMock()
+    enr.scrape_website = AsyncMock(return_value={})
+
+    async def _enrich_from_spider(domain, spider_data):
+        return _make_enrich(domain, non_au=enrich_non_au)
+
+    enr.enrich_from_spider = AsyncMock(side_effect=_enrich_from_spider)
+
+    scorer = MagicMock()
+    scorer.score_affordability = MagicMock(return_value=_afford_pass())
+    scorer.score_intent_free = MagicMock(return_value=_intent_pass())
+    scorer.score_intent_full = MagicMock(return_value=_intent_pass())
+
+    dm_module = MagicMock()
+    dm_module.identify = AsyncMock(return_value=_make_dm())
+
+    orch = PipelineOrchestrator(
+        discovery=disc,
+        free_enrichment=enr,
+        scorer=scorer,
+        dm_identification=dm_module,
+    )
+    return orch
+
+
+@pytest.mark.asyncio
+async def test_parallel_stops_at_target_count():
+    """run_parallel must stop once target_count prospects are found."""
+    # 10 domains across two batches — we only want 2
+    orch = _make_orch(
+        domains_per_call=[
+            [f"domain{i}.com.au" for i in range(5)],
+            [f"domain{i}.com.au" for i in range(5, 10)],
+        ]
+    )
+    result = await orch.run_parallel(
+        category_codes=["10514"],
+        location="Sydney",
+        target_count=2,
+        num_workers=1,
+        batch_size=5,
+    )
+    assert len(result.prospects) == 2
+    assert result.stats.viable_prospects == 2
+
+
+@pytest.mark.asyncio
+async def test_parallel_deduplicates_domains():
+    """Domains pulled by multiple workers must not be processed twice."""
+    # Two workers both discover the same domain list
+    same_domains = ["dup1.com.au", "dup2.com.au", "dup3.com.au"]
+
+    disc = MagicMock()
+    # Each category returns the same domains then []
+    call_count = {"n": 0}
+
+    async def pull_batch(**kwargs):
+        call_count["n"] += 1
+        # First call per category returns domains, second returns []
+        if call_count["n"] % 2 == 1:
+            return [{"domain": d} for d in same_domains]
+        return []
+
+    disc.pull_batch = AsyncMock(side_effect=pull_batch)
+
+    enr = MagicMock()
+    enr.scrape_website = AsyncMock(return_value={})
+    enr.enrich_from_spider = AsyncMock(
+        side_effect=lambda domain, spider_data: asyncio.coroutine(lambda: _make_enrich(domain))()
+    )
+
+    async def _enrich(domain, spider_data):
+        return _make_enrich(domain)
+
+    enr.enrich_from_spider = AsyncMock(side_effect=_enrich)
+
+    scorer = MagicMock()
+    scorer.score_affordability = MagicMock(return_value=_afford_pass())
+    scorer.score_intent_free = MagicMock(return_value=_intent_pass())
+    scorer.score_intent_full = MagicMock(return_value=_intent_pass())
+
+    dm_module = MagicMock()
+    dm_module.identify = AsyncMock(return_value=_make_dm())
+
+    orch = PipelineOrchestrator(
+        discovery=disc,
+        free_enrichment=enr,
+        scorer=scorer,
+        dm_identification=dm_module,
+    )
+
+    # Two workers, two categories — both would see the same domains
+    result = await orch.run_parallel(
+        category_codes=["10514", "20001"],
+        location="Sydney",
+        target_count=100,
+        num_workers=2,
+        batch_size=10,
+    )
+
+    # Domains should not appear twice in results
+    seen_domains = [p.domain for p in result.prospects]
+    assert len(seen_domains) == len(set(seen_domains)), "Duplicate domains in results"
+
+
+@pytest.mark.asyncio
+async def test_parallel_merges_stats():
+    """run_parallel must aggregate stats from all workers into a single PipelineStats."""
+    # 6 domains split across 2 categories → 2 workers
+    orch = _make_orch(
+        domains_per_call=[
+            ["a.com.au", "b.com.au", "c.com.au"],
+        ]
+    )
+    result = await orch.run_parallel(
+        category_codes=["cat1", "cat2"],
+        location="Melbourne",
+        target_count=10,
+        num_workers=2,
+        batch_size=10,
+    )
+    # Stats should be non-zero and reflect combined worker output
+    total = result.stats.enriched + result.stats.enrichment_failed + result.stats.affordability_rejected
+    assert result.stats.discovered >= 0
+    assert result.stats.elapsed_seconds >= 0
+    # viable_prospects must equal len(prospects)
+    assert result.stats.viable_prospects == len(result.prospects)


### PR DESCRIPTION
## Directive #296 — Hybrid Sonnet/Haiku Intelligence Layer

### What this does
Replaces regex/rule-based website analysis and point-counting intent classification with LLM comprehension at five pipeline stages.

### Five intelligence functions (`src/pipeline/intelligence.py` — NEW)

| Function | Model | Replaces | Cost |
|----------|-------|----------|------|
| `comprehend_website()` | Sonnet | Regex extraction in free_enrichment.py | ~$0.010 |
| `classify_intent()` | Sonnet | Point-counting in prospect_scorer.score_intent_full() | ~$0.008 |
| `analyse_reviews()` | Sonnet | No equivalent (new capability) | ~$0.005 |
| `judge_affordability()` | Haiku | Rule-based score_affordability() | ~$0.001 |
| `refine_evidence()` | Haiku | Hardcoded evidence strings in ProspectScorer | ~$0.002 |

**Total: ~$0.026/domain. $16.50/100 DMs at 23% yield. Ignition margin >96%.**

### Architecture
- **Prompt caching**: static system block marked `cache_control: ephemeral` first, variable HTML/data last
- **Semaphores**: `GLOBAL_SEM_SONNET=12`, `GLOBAL_SEM_HAIKU=15` — defined in `intelligence.py`, imported by orchestrator (no circular import)
- **httpx direct API** — no Anthropic SDK dependency
- **JSON response** with `try/except` fallback on every call — pipeline never crashes on LLM failure
- **Token logging** on every call for cost tracking

### Wiring in `run_parallel()` (Task C)
New flow when `intelligence=` is passed to `PipelineOrchestrator`:
```
httpx scrape → comprehend_website (Sonnet)
→ judge_affordability (Haiku) → gate
→ DFS ads + GMB → classify_intent (Sonnet) → intent gate (NOT_TRYING rejected)
→ analyse_reviews (Sonnet) → refine_evidence (Haiku)
→ DM discovery → done
```
Graceful fallback to rule-based scorer when `intelligence=None` (backwards compatible).

### Tests (18 in `tests/test_intelligence.py`)
All 5 functions tested: mock API responses, fallback on error, fallback on malformed JSON, semaphore acquire/release, token usage logging, run_parallel end-to-end with intelligence wired.

### Baseline
**1214 passed, 0 failed, 5 skipped**

### Files changed
- `src/pipeline/intelligence.py` (NEW)
- `src/pipeline/pipeline_orchestrator.py` (wiring + semaphore import)
- `tests/test_intelligence.py` (NEW, 18 tests)
- `tests/test_pipeline/test_orchestrator_parallel.py` (stale field fix)