### PR TITLE
feat(pipeline): email discovery waterfall — Directive #299

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -23,9 +23,9 @@ Revenue model for BU: API subscriptions, Salesforce/HubSpot marketplace, bulk an
 
 ## SECTION 2 — CURRENT STATE
 
-- Last directive issued: #298 (multi-category service-first discovery — PR #260 open)
-- Test baseline: 1238 passed, 0 failed, 5 skipped
-- Last merged PRs: #247–#259 | Open: #260
+- Last directive issued: #299 (email discovery waterfall — PR #261 open)
+- Test baseline: 1254 passed, 0 failed, 5 skipped
+- Last merged PRs: #247–#260 | Open: #261
 - PR #254 (Directive #291 — ProspectScorer) pending merge
 - Architecture: **FINAL ratified Mar 30 2026** — service-signal discovery, two-dimension scoring, stage-parallel processing
 - **Pipeline test Run 1 (Mar 29):** 100 DMs from 200 domains, $3.51, 7.3 min
@@ -890,7 +890,8 @@ v6 era (#271–#277): Layer 2 (discovery), Layer 3 (bulk filter), signal config 
 | #295 | httpx primary scraper (Spider fallback), GMB rating dict→scalar fix, AU country filter, run_parallel() + global semaphore pool | COMPLETE — PR #257 |
 | #296 | Sonnet/Haiku intelligence layer: comprehend_website, classify_intent, analyse_reviews, judge_affordability, refine_evidence. Wired into run_parallel(). Prompt caching. | COMPLETE — PR #258 |
 | #297 | ABN matching audit: confirmed working on main (2.4M rows, live match verified). PR #249 abandoned (6k lines behind). 11 verification tests. | COMPLETE — PR #259 |
-| #298 | Multi-category service-first discovery: category_registry.py, MultiCategoryDiscovery, run_parallel(discover_all=True). 14 verticals, 20 codes. 13 tests. | PR #260 — pending merge |
+| #298 | Multi-category service-first discovery: category_registry.py, MultiCategoryDiscovery, run_parallel(discover_all=True). 14 verticals, 20 codes. 13 tests. | COMPLETE — PR #260 |
+| #299 | Email discovery waterfall: 4 layers (HTML/pattern/Leadmagic/Bright Data), GLOBAL_SEM_LEADMAGIC=10, ProspectCard email fields, Stage 9 wired. 16 tests. | PR #261 — pending merge |
 
 ---
 
@@ -1100,12 +1101,15 @@ URLs, review mentions, Brand SERP knowledge panel.
 Components: not yet built (Sprint 5)
 Status: BLOCKED — awaiting Segment 1+2 validation
 
-SEGMENT 4 — EMAIL DISCOVERY
-Get verified email. 4-tier waterfall: contact page
-scrape, pattern gen + SMTP verify, Leadmagic,
-FullEnrich/BetterContact. ZeroBounce verification.
-Components: partially built (Sprint 5)
-Status: BLOCKED — awaiting Segment 3 validation
+SEGMENT 4 — EMAIL DISCOVERY (Directive #299 — COMPLETE)
+4-layer waterfall wired into run_parallel Stage 9:
+- L1: Website HTML mailto:/regex (free, name-matched)
+- L2: Pattern generation + MX check (free)
+- L3: Leadmagic /email-finder ($0.015, SMTP-verified)
+- L4: Bright Data LinkedIn profile ($0.00075)
+Short-circuits on first hit. ProspectCard fields: dm_email, dm_email_verified, dm_email_source, dm_email_confidence, email_cost_usd.
+GLOBAL_SEM_LEADMAGIC = 10.
+Status: BUILT — src/pipeline/email_waterfall.py, PR #261
 
 SEGMENT 5 — PHONE DISCOVERY
 Get mobile/direct number. GMB phone carrier check,

--- a/src/pipeline/email_waterfall.py
+++ b/src/pipeline/email_waterfall.py
@@ -1,0 +1,356 @@
+"""
+Contract: src/pipeline/email_waterfall.py
+Purpose: 4-layer email discovery waterfall for pipeline v7.
+         Runs after DM identification. Finds and verifies deliverable email
+         addresses for decision makers before reachability scoring.
+Layer: 3 - pipeline
+Directive: #299
+
+Waterfall layers (short-circuit — returns on first verified hit):
+  Layer 1: Website HTML scrape (free) — mailto: links, email regex on cached HTML
+  Layer 2: Pattern generation (free) — first.last@, first@, flast@, firstl@
+            + MX record check to confirm domain accepts mail
+  Layer 3: Leadmagic email finder ($0.015 USD) — API lookup by name + domain
+  Layer 4: Bright Data LinkedIn enrichment ($0.00075 USD) — profile → email
+
+Semaphore: GLOBAL_SEM_LEADMAGIC (10 concurrent) added to global pool.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ── Lazy-imported clients (at module level for patchability) ─────────────────
+try:
+    from src.integrations.leadmagic import LeadmagicClient
+except ImportError:
+    LeadmagicClient = None  # type: ignore
+
+try:
+    from src.integrations.brightdata_client import BrightDataLinkedInClient
+except ImportError:
+    BrightDataLinkedInClient = None  # type: ignore
+
+# ── Global semaphore for Leadmagic API calls ──────────────────────────────────
+# Added to global pool alongside GLOBAL_SEM_SONNET / GLOBAL_SEM_HAIKU
+GLOBAL_SEM_LEADMAGIC = asyncio.Semaphore(10)
+
+# Email regex — matches standard email formats
+_EMAIL_RE = re.compile(
+    r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}",
+    re.IGNORECASE,
+)
+
+# Pattern templates: (format_name, template)
+# {f} = first name, {l} = last name, {fi} = first initial, {li} = last initial
+_PATTERN_TEMPLATES = [
+    ("first.last", "{f}.{l}"),
+    ("first", "{f}"),
+    ("flast", "{fi}{l}"),
+    ("firstl", "{f}{li}"),
+    ("last", "{l}"),
+]
+
+# Cost constants (USD)
+COST_LEADMAGIC = 0.015
+COST_BRIGHTDATA = 0.00075
+
+
+@dataclass
+class EmailResult:
+    """Result from email waterfall discovery."""
+    email: str | None
+    verified: bool
+    source: str  # "website" | "pattern" | "leadmagic" | "brightdata" | "none"
+    confidence: str  # "high" | "medium" | "low"
+    cost_usd: float
+
+    def to_dict(self) -> dict:
+        return {
+            "dm_email": self.email,
+            "dm_email_verified": self.verified,
+            "dm_email_source": self.source,
+            "dm_email_confidence": self.confidence,
+            "email_cost_usd": self.cost_usd,
+        }
+
+
+# ── Name parsing ──────────────────────────────────────────────────────────────
+
+def _parse_name(dm_name: str) -> tuple[str, str]:
+    """Split 'Michael Chen' → ('michael', 'chen'). Handles middle names."""
+    parts = dm_name.strip().split()
+    if not parts:
+        return "", ""
+    first = parts[0].lower()
+    last = parts[-1].lower() if len(parts) > 1 else ""
+    return first, last
+
+
+def _generate_patterns(first: str, last: str, domain: str) -> list[str]:
+    """Generate candidate email patterns from name + domain."""
+    if not first or not last or not domain:
+        return []
+    fi = first[0] if first else ""
+    li = last[0] if last else ""
+    candidates = []
+    for _, template in _PATTERN_TEMPLATES:
+        try:
+            local = template.format(f=first, l=last, fi=fi, li=li)
+            candidates.append(f"{local}@{domain}")
+        except KeyError:
+            pass
+    return candidates
+
+
+# ── Layer 1: Website HTML scrape ──────────────────────────────────────────────
+
+def _extract_emails_from_html(html: str, domain: str, dm_name: str) -> EmailResult | None:
+    """
+    Layer 1: Extract emails from cached website HTML.
+    Prefers emails that match the DM's name parts.
+    """
+    if not html:
+        return None
+
+    found = _EMAIL_RE.findall(html)
+    if not found:
+        return None
+
+    # Filter to emails on the same domain (or subdomain)
+    domain_clean = domain.lower().lstrip("www.")
+    domain_emails = [e for e in found if domain_clean in e.lower().split("@")[-1]]
+    all_emails = domain_emails or found[:5]  # fallback to any email if no domain match
+
+    if not all_emails:
+        return None
+
+    # Score by name match
+    first, last = _parse_name(dm_name)
+    name_parts = [p for p in [first, last] if len(p) >= 3]
+    best = None
+    best_score = -1
+
+    for email in all_emails:
+        local = email.split("@")[0].lower()
+        score = sum(1 for p in name_parts if p in local)
+        if score > best_score:
+            best_score = score
+            best = email
+
+    if best:
+        confidence = "high" if best_score >= 2 else ("medium" if best_score == 1 else "low")
+        return EmailResult(
+            email=best,
+            verified=False,  # not SMTP-verified, just found in HTML
+            source="website",
+            confidence=confidence,
+            cost_usd=0.0,
+        )
+    return None
+
+
+# ── Layer 2: Pattern generation + MX check ───────────────────────────────────
+
+async def _check_mx(domain: str) -> bool:
+    """Check if domain has MX records (accepts mail). Returns False on error."""
+    try:
+        import dns.resolver
+        resolver = dns.resolver.Resolver()
+        resolver.lifetime = 5.0
+        resolver.resolve(domain, "MX")
+        return True
+    except Exception:
+        return False
+
+
+async def _try_patterns(first: str, last: str, domain: str) -> EmailResult | None:
+    """
+    Layer 2: Generate patterns + confirm MX record exists.
+    Does NOT do SMTP probing — that's Layer 3's job.
+    Returns the most likely pattern with medium confidence if MX passes.
+    """
+    if not first or not last or not domain:
+        return None
+
+    has_mx = await _check_mx(domain)
+    if not has_mx:
+        return None
+
+    candidates = _generate_patterns(first, last, domain)
+    if not candidates:
+        return None
+
+    # Return first.last@domain as best guess (most common professional pattern)
+    best = candidates[0]
+    return EmailResult(
+        email=best,
+        verified=False,
+        source="pattern",
+        confidence="medium",
+        cost_usd=0.0,
+    )
+
+
+# ── Layer 3: Leadmagic email finder ──────────────────────────────────────────
+
+async def _leadmagic_lookup(
+    first: str,
+    last: str,
+    domain: str,
+    company_name: str | None = None,
+) -> EmailResult | None:
+    """
+    Layer 3: Leadmagic /email-finder — $0.015/call.
+    Returns verified email with confidence score.
+    """
+    if not first or not last or not domain:
+        return None
+
+    async with GLOBAL_SEM_LEADMAGIC:
+        try:
+            from src.config.settings import settings
+            if LeadmagicClient is None:
+                return None
+
+            async with LeadmagicClient(api_key=settings.leadmagic_api_key) as client:
+                result = await client.find_email(
+                    first_name=first.capitalize(),
+                    last_name=last.capitalize(),
+                    domain=domain,
+                    company=company_name,
+                )
+
+            if result.found and result.email:
+                confidence = (
+                    "high" if result.confidence >= 80
+                    else "medium" if result.confidence >= 50
+                    else "low"
+                )
+                return EmailResult(
+                    email=result.email,
+                    verified=True,  # Leadmagic verifies via SMTP
+                    source="leadmagic",
+                    confidence=confidence,
+                    cost_usd=COST_LEADMAGIC,
+                )
+        except Exception as exc:
+            logger.warning("email_waterfall layer3 leadmagic failed domain=%s: %s", domain, exc)
+    return None
+
+
+# ── Layer 4: Bright Data LinkedIn enrichment ─────────────────────────────────
+
+async def _brightdata_lookup(
+    dm_linkedin: str | None,
+    domain: str,
+    company_name: str | None = None,
+) -> EmailResult | None:
+    """
+    Layer 4: Bright Data LinkedIn profile → email ($0.00075/record).
+    Only runs if dm_linkedin URL is available.
+    """
+    if not dm_linkedin:
+        return None
+
+    try:
+        if BrightDataLinkedInClient is None:
+            return None
+
+        client = BrightDataLinkedInClient()
+        people = await client.lookup_company_people(
+            company_name=company_name or domain,
+            linkedin_url=dm_linkedin,
+        )
+
+        for person in people or []:
+            email = person.get("email") or person.get("email_address")
+            if email and "@" in email:
+                return EmailResult(
+                    email=email,
+                    verified=False,  # LinkedIn profile data, not SMTP-verified
+                    source="brightdata",
+                    confidence="medium",
+                    cost_usd=COST_BRIGHTDATA,
+                )
+    except Exception as exc:
+        logger.warning("email_waterfall layer4 brightdata failed domain=%s: %s", domain, exc)
+    return None
+
+
+# ── Main entry point ─────────────────────────────────────────────────────────
+
+async def discover_email(
+    domain: str,
+    dm_name: str,
+    dm_linkedin: str | None = None,
+    html: str | None = None,
+    company_name: str | None = None,
+    skip_layers: list[int] | None = None,
+) -> EmailResult:
+    """
+    4-layer email discovery waterfall.
+
+    Short-circuits on first verified/found email. Layers:
+      1: Website HTML (free)
+      2: Pattern generation + MX check (free)
+      3: Leadmagic finder ($0.015)
+      4: Bright Data LinkedIn ($0.00075)
+
+    Args:
+        domain: Business domain (e.g. "dentist.com.au")
+        dm_name: Decision maker full name (e.g. "Michael Chen")
+        dm_linkedin: LinkedIn URL if available from DM waterfall
+        html: Cached website HTML from scrape stage
+        company_name: Company name for API lookup context
+        skip_layers: List of layer numbers to skip (e.g. [3,4] to skip paid)
+
+    Returns:
+        EmailResult with email, verified flag, source, confidence, cost_usd.
+    """
+    skip = set(skip_layers or [])
+    first, last = _parse_name(dm_name)
+
+    # Layer 1: Website HTML
+    if 1 not in skip:
+        result = _extract_emails_from_html(html or "", domain, dm_name)
+        if result and result.email:
+            logger.info("email_waterfall L1 hit domain=%s email=%s", domain, result.email)
+            return result
+
+    # Layer 2: Pattern + MX
+    if 2 not in skip and first and last:
+        result = await _try_patterns(first, last, domain)
+        if result and result.email:
+            logger.info("email_waterfall L2 hit domain=%s email=%s", domain, result.email)
+            return result
+
+    # Layer 3: Leadmagic
+    if 3 not in skip and first and last:
+        result = await _leadmagic_lookup(first, last, domain, company_name)
+        if result and result.email:
+            logger.info("email_waterfall L3 hit domain=%s email=%s confidence=%s",
+                        domain, result.email, result.confidence)
+            return result
+
+    # Layer 4: Bright Data
+    if 4 not in skip:
+        result = await _brightdata_lookup(dm_linkedin, domain, company_name)
+        if result and result.email:
+            logger.info("email_waterfall L4 hit domain=%s email=%s", domain, result.email)
+            return result
+
+    # No email found
+    logger.debug("email_waterfall miss domain=%s", domain)
+    return EmailResult(
+        email=None,
+        verified=False,
+        source="none",
+        confidence="low",
+        cost_usd=0.0,
+    )

--- a/src/pipeline/pipeline_orchestrator.py
+++ b/src/pipeline/pipeline_orchestrator.py
@@ -30,6 +30,7 @@ from src.pipeline.prospect_scorer import ProspectScorer, ProspectScore
 from src.pipeline.intelligence import GLOBAL_SEM_SONNET, GLOBAL_SEM_HAIKU  # shared semaphores
 from src.pipeline import intelligence as _intel_module  # optional: used when self._intelligence is set
 from src.config.category_registry import get_discovery_categories, SERVICE_CATEGORY_MAP  # noqa: F401
+from src.pipeline.email_waterfall import discover_email, GLOBAL_SEM_LEADMAGIC  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +81,12 @@ class ProspectCard:
     dm_title: Optional[str] = None
     dm_linkedin_url: Optional[str] = None
     dm_confidence: Optional[str] = None
+    # Email waterfall fields (Directive #299)
+    dm_email: Optional[str] = None
+    dm_email_verified: bool = False
+    dm_email_source: Optional[str] = None
+    dm_email_confidence: Optional[str] = None
+    email_cost_usd: float = 0.0
 
 
 @dataclass
@@ -804,8 +811,17 @@ class PipelineOrchestrator:
                     async with stats_lock:
                         stats.dm_found += 1
 
-                    # GATE: Reachability
-                    has_email = bool(enrichment.get("website_contact_emails"))
+                    # ── STAGE 9: Email waterfall (after DM identification) ────
+                    email_result = await discover_email(
+                        domain=domain,
+                        dm_name=dm.name or "",
+                        dm_linkedin=getattr(dm, "linkedin_url", None),
+                        html=enrichment.get("html") or enrichment.get("_raw_html") or "",
+                        company_name=company_name,
+                    )
+
+                    # GATE: Reachability — email OR LinkedIn required
+                    has_email = bool(email_result.email) or bool(enrichment.get("website_contact_emails"))
                     has_linkedin = bool(getattr(dm, "linkedin_url", None))
                     if not (has_email or has_linkedin):
                         async with stats_lock:
@@ -828,6 +844,11 @@ class PipelineOrchestrator:
                         dm_title=getattr(dm, "title", None),
                         dm_linkedin_url=getattr(dm, "linkedin_url", None),
                         dm_confidence=getattr(dm, "confidence", None),
+                        dm_email=email_result.email,
+                        dm_email_verified=email_result.verified,
+                        dm_email_source=email_result.source,
+                        dm_email_confidence=email_result.confidence,
+                        email_cost_usd=email_result.cost_usd,
                     )
 
                     async with results_lock:

--- a/tests/test_email_waterfall.py
+++ b/tests/test_email_waterfall.py
@@ -1,0 +1,284 @@
+"""
+Tests for email discovery waterfall — Directive #299.
+Covers all 4 layers, short-circuit logic, name parsing, pattern generation,
+orchestrator wiring, and cost tracking.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+DENTAL_HTML = """
+<html><head><title>Pymble Dental</title></head><body>
+<a href="mailto:michael.chen@pymbledental.com.au">Email us</a>
+<p>Call 02 9144 1234 | Pymble NSW 2073</p>
+</body></html>
+"""
+
+NO_EMAIL_HTML = "<html><body><p>Welcome to our dental practice in Sydney.</p></body></html>"
+
+
+# ── Layer 1: Website HTML scrape ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_layer1_mailto_returns_email():
+    """Layer 1 extracts email from mailto: link in HTML."""
+    from src.pipeline.email_waterfall import discover_email
+    result = await discover_email(
+        domain="pymbledental.com.au",
+        dm_name="Michael Chen",
+        html=DENTAL_HTML,
+        skip_layers=[2, 3, 4],
+    )
+    assert result.email == "michael.chen@pymbledental.com.au"
+    assert result.source == "website"
+    assert result.cost_usd == 0.0
+
+
+@pytest.mark.asyncio
+async def test_layer1_name_match_gives_high_confidence():
+    """Email matching DM name parts gets high confidence."""
+    from src.pipeline.email_waterfall import discover_email
+    result = await discover_email(
+        domain="pymbledental.com.au",
+        dm_name="Michael Chen",
+        html=DENTAL_HTML,
+        skip_layers=[2, 3, 4],
+    )
+    assert result.confidence == "high"
+
+
+@pytest.mark.asyncio
+async def test_layer1_no_html_falls_through():
+    """Empty HTML skips Layer 1 and falls to Layer 2."""
+    from src.pipeline.email_waterfall import discover_email
+    with patch("src.pipeline.email_waterfall._check_mx", AsyncMock(return_value=True)):
+        result = await discover_email(
+            domain="dentist.com.au",
+            dm_name="Jane Smith",
+            html=None,
+            skip_layers=[3, 4],
+        )
+    # Should reach Layer 2 pattern
+    assert result.source in ("pattern", "none")
+
+
+# ── Layer 2: Pattern generation ───────────────────────────────────────────────
+
+def test_generate_patterns_produces_correct_emails():
+    """Pattern generator produces expected email formats."""
+    from src.pipeline.email_waterfall import _generate_patterns
+    patterns = _generate_patterns("michael", "chen", "dentist.com.au")
+    assert "michael.chen@dentist.com.au" in patterns
+    assert "michael@dentist.com.au" in patterns
+    assert "mchen@dentist.com.au" in patterns
+    assert "michaelc@dentist.com.au" in patterns
+
+
+def test_generate_patterns_empty_on_missing_name():
+    """Pattern generator returns empty list when name parts missing."""
+    from src.pipeline.email_waterfall import _generate_patterns
+    assert _generate_patterns("", "chen", "dentist.com.au") == []
+    assert _generate_patterns("michael", "", "dentist.com.au") == []
+    assert _generate_patterns("michael", "chen", "") == []
+
+
+@pytest.mark.asyncio
+async def test_layer2_mx_fail_skips_pattern():
+    """Layer 2 returns None when MX check fails."""
+    from src.pipeline.email_waterfall import _try_patterns
+    with patch("src.pipeline.email_waterfall._check_mx", AsyncMock(return_value=False)):
+        result = await _try_patterns("michael", "chen", "deadzone.invalid")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_layer2_mx_pass_returns_pattern():
+    """Layer 2 returns first.last@domain when MX passes."""
+    from src.pipeline.email_waterfall import _try_patterns
+    with patch("src.pipeline.email_waterfall._check_mx", AsyncMock(return_value=True)):
+        result = await _try_patterns("michael", "chen", "dentist.com.au")
+    assert result is not None
+    assert result.email == "michael.chen@dentist.com.au"
+    assert result.source == "pattern"
+    assert result.cost_usd == 0.0
+
+
+# ── Layer 3: Leadmagic ────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_layer3_leadmagic_verified_email():
+    """Layer 3 returns verified email from Leadmagic mock."""
+    from src.pipeline.email_waterfall import discover_email
+    mock_result = MagicMock()
+    mock_result.found = True
+    mock_result.email = "michael.chen@dentist.com.au"
+    mock_result.confidence = 90
+
+    mock_client = AsyncMock()
+    mock_client.find_email = AsyncMock(return_value=mock_result)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.pipeline.email_waterfall.LeadmagicClient", return_value=mock_client) as mock_cls:
+        # Make the class itself behave as async context manager
+        mock_cls.return_value = mock_client
+        result = await discover_email(
+            domain="dentist.com.au",
+            dm_name="Michael Chen",
+            html=NO_EMAIL_HTML,
+            skip_layers=[1, 2, 4],
+        )
+
+    assert result.source == "leadmagic"
+    assert result.verified is True
+    assert result.cost_usd == 0.015
+    assert result.confidence == "high"
+
+
+@pytest.mark.asyncio
+async def test_layer3_leadmagic_not_found_falls_through():
+    """Layer 3 miss falls through to Layer 4 (or returns none)."""
+    from src.pipeline.email_waterfall import discover_email
+    mock_result = MagicMock()
+    mock_result.found = False
+    mock_result.email = None
+
+    mock_client = AsyncMock()
+    mock_client.find_email = AsyncMock(return_value=mock_result)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.pipeline.email_waterfall.LeadmagicClient", return_value=mock_client):
+        result = await discover_email(
+            domain="dentist.com.au",
+            dm_name="Michael Chen",
+            html=NO_EMAIL_HTML,
+            skip_layers=[1, 2, 4],
+        )
+
+    assert result.email is None
+    assert result.source == "none"
+    assert result.cost_usd == 0.0
+
+
+# ── Layer 4: Bright Data ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_layer4_brightdata_returns_email_from_linkedin():
+    """Layer 4 extracts email from Bright Data LinkedIn profile."""
+    from src.pipeline.email_waterfall import _brightdata_lookup
+
+    mock_bd = MagicMock()
+    mock_bd.lookup_company_people = AsyncMock(return_value=[
+        {"name": "Michael Chen", "email": "m.chen@dentist.com.au", "title": "Owner"}
+    ])
+
+    with patch("src.pipeline.email_waterfall.BrightDataLinkedInClient", return_value=mock_bd):
+        result = await _brightdata_lookup(
+            dm_linkedin="https://au.linkedin.com/in/michael-chen",
+            domain="dentist.com.au",
+        )
+
+    assert result is not None
+    assert result.email == "m.chen@dentist.com.au"
+    assert result.source == "brightdata"
+    assert result.cost_usd == 0.00075
+
+
+@pytest.mark.asyncio
+async def test_layer4_skipped_without_linkedin():
+    """Layer 4 returns None when no LinkedIn URL provided."""
+    from src.pipeline.email_waterfall import _brightdata_lookup
+    result = await _brightdata_lookup(dm_linkedin=None, domain="dentist.com.au")
+    assert result is None
+
+
+# ── Short-circuit logic ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_short_circuit_on_layer1_hit():
+    """Layer 2/3/4 not called when Layer 1 finds email."""
+    from src.pipeline.email_waterfall import discover_email
+
+    with patch("src.pipeline.email_waterfall._check_mx", AsyncMock(side_effect=AssertionError("Layer 2 called"))) as mx, \
+         patch("src.pipeline.email_waterfall.LeadmagicClient", side_effect=AssertionError("Layer 3 called")):
+        result = await discover_email(
+            domain="pymbledental.com.au",
+            dm_name="Michael Chen",
+            html=DENTAL_HTML,
+        )
+
+    assert result.email == "michael.chen@pymbledental.com.au"
+    assert result.source == "website"
+
+
+# ── No result ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_all_layers_miss_returns_none_email():
+    """When all layers fail, returns EmailResult with email=None."""
+    from src.pipeline.email_waterfall import discover_email
+
+    with patch("src.pipeline.email_waterfall._check_mx", AsyncMock(return_value=False)), \
+         patch("src.pipeline.email_waterfall.LeadmagicClient", side_effect=Exception("API down")):
+        result = await discover_email(
+            domain="nowhere.com",
+            dm_name="Unknown Person",
+            html=None,
+            skip_layers=[4],
+        )
+
+    assert result.email is None
+    assert result.source == "none"
+    assert result.cost_usd == 0.0
+    assert result.verified is False
+
+
+# ── Cost tracking ─────────────────────────────────────────────────────────────
+
+def test_email_result_to_dict_has_required_keys():
+    """EmailResult.to_dict() produces all required prospect card keys."""
+    from src.pipeline.email_waterfall import EmailResult
+    r = EmailResult(
+        email="test@domain.com", verified=True,
+        source="leadmagic", confidence="high", cost_usd=0.015
+    )
+    d = r.to_dict()
+    assert "dm_email" in d
+    assert "dm_email_verified" in d
+    assert "dm_email_source" in d
+    assert "dm_email_confidence" in d
+    assert "email_cost_usd" in d
+    assert d["dm_email"] == "test@domain.com"
+    assert d["dm_email_verified"] is True
+    assert d["email_cost_usd"] == 0.015
+
+
+# ── Orchestrator wiring ───────────────────────────────────────────────────────
+
+def test_prospect_card_has_email_fields():
+    """ProspectCard has all email waterfall fields."""
+    from src.pipeline.pipeline_orchestrator import ProspectCard
+    card = ProspectCard(
+        domain="test.com.au",
+        company_name="Test Co",
+        location="Sydney",
+        dm_name="Jane Smith",
+        dm_email="jane@test.com.au",
+        dm_email_verified=True,
+        dm_email_source="leadmagic",
+        dm_email_confidence="high",
+        email_cost_usd=0.015,
+    )
+    assert card.dm_email == "jane@test.com.au"
+    assert card.dm_email_verified is True
+    assert card.dm_email_source == "leadmagic"
+    assert card.email_cost_usd == 0.015
+
+
+def test_global_sem_leadmagic_exported():
+    """GLOBAL_SEM_LEADMAGIC is importable from email_waterfall."""
+    from src.pipeline.email_waterfall import GLOBAL_SEM_LEADMAGIC
+    assert GLOBAL_SEM_LEADMAGIC._value == 10


### PR DESCRIPTION
## Directive #299 — Email Discovery Waterfall

### What this does
Wires email discovery into the v7 pipeline between DM identification and reachability scoring. Without this, Salesforge can't send — prospects have LinkedIn but no deliverable email address.

### Four layers (short-circuit on first hit)

| Layer | Method | Verified | Cost |
|-------|--------|----------|------|
| 1 | Website HTML — mailto: links + email regex | No (found in DOM) | Free |
| 2 | Pattern generation (first.last, first, flast, firstl) + MX record check | No (structural) | Free |
| 3 | Leadmagic /email-finder | Yes (SMTP probe) | $0.015 |
| 4 | Bright Data LinkedIn profile → email field | No (profile data) | $0.00075 |

### Files

**`src/pipeline/email_waterfall.py`** (NEW)
- `GLOBAL_SEM_LEADMAGIC = Semaphore(10)` — added to global semaphore pool
- `EmailResult` dataclass: email, verified, source, confidence, cost_usd, to_dict()
- `discover_email(domain, dm_name, dm_linkedin, html, company_name, skip_layers)` — main entry point
- All layers short-circuit: returns immediately on first confirmed email

**`src/pipeline/pipeline_orchestrator.py`**
- `ProspectCard` extended: dm_email, dm_email_verified, dm_email_source, dm_email_confidence, email_cost_usd
- `run_parallel._worker`: Stage 9 email waterfall runs after DM identification
- Reachability gate updated: `has_email = waterfall result OR website_contact_emails`

### Tests (16 in `tests/test_email_waterfall.py`)
All 4 layers, short-circuit logic, pattern generation, MX fail skip, Leadmagic mock, Bright Data mock, empty HTML fallthrough, all-miss returns None, EmailResult.to_dict(), ProspectCard fields, semaphore value.

### Baseline
**1254 passed, 0 failed, 5 skipped**