### PR TITLE
fix(discovery): #304-FIX — dynamic available_history date

### DIFF
--- a/src/clients/dfs_labs_client.py
+++ b/src/clients/dfs_labs_client.py
@@ -106,6 +106,10 @@ class DFSLabsClient:
         # Cache for get_categories (free, rarely changes)
         self._categories_cache: list[dict] | None = None
 
+        # Cache for available_history date (free, changes monthly)
+        # Populated on first call to _get_latest_available_date().
+        self._available_history_date: str | None = None
+
     async def _get_client(self) -> httpx.AsyncClient:
         """Lazy-init httpx.AsyncClient with Basic Auth header."""
         if self._client is None or self._client.is_closed:
@@ -660,6 +664,47 @@ class DFSLabsClient:
         }
 
     # ============================================
+    # HELPER: available_history date  (Directive #304-FIX)
+    # ============================================
+
+    async def _get_latest_available_date(self) -> str:
+        """
+        Fetch the latest date available in DFS Labs history.
+
+        The domain_metrics_by_categories endpoint requires first_date and second_date
+        to be within the available history window. DFS updates this monthly; the
+        available_history endpoint returns the single latest valid date.
+
+        Cost: FREE (GET request, no task charge).
+        Result cached for the lifetime of this client instance — one call per session.
+
+        Returns:
+            ISO date string e.g. "2026-03-01", or today-35d as fallback if fetch fails.
+        """
+        if self._available_history_date is not None:
+            return self._available_history_date
+
+        try:
+            client = await self._get_client()
+            response = await client.get("/v3/dataforseo_labs/google/available_history")
+            response.raise_for_status()
+            data = response.json()
+            result_list = (data.get("tasks") or [{}])[0].get("result") or []
+            date_str = (result_list[0] if result_list else {}).get("date", "")
+            if date_str:
+                self._available_history_date = date_str
+                logger.info("DFS available_history: latest date = %s", date_str)
+                return date_str
+        except Exception as exc:
+            logger.warning("DFS available_history fetch failed: %s", exc)
+
+        # Fallback: 35 days ago (safely within last monthly snapshot)
+        fallback = (date.today() - timedelta(days=35)).strftime("%Y-%m-%d")
+        logger.warning("DFS available_history: using fallback date %s", fallback)
+        self._available_history_date = fallback
+        return fallback
+
+    # ============================================
     # ENDPOINT 8: domain_metrics_by_categories  (Directive #272 — Layer 2)
     # ============================================
 
@@ -685,14 +730,21 @@ class DFSLabsClient:
         Use discover_prospects() which paginates automatically.
 
         Args:
-            first_date: Start date YYYY-MM-DD (default: 6 months ago / today - 180 days).
-            second_date: End date YYYY-MM-DD (default: today).
+            first_date: Start date YYYY-MM-DD (default: latest available date - 180 days).
+                        Uses _get_latest_available_date() to stay within DFS history window.
+            second_date: End date YYYY-MM-DD (default: latest available date from DFS).
+                         Must not exceed the date returned by available_history endpoint.
+                         Bug fixed in Directive #304-FIX: was incorrectly defaulting to
+                         today, which exceeds the available window and causes 40501.
             limit: Items per API call (max 100, API default 100).
             offset: Pagination offset (0-indexed).
         """
-        today = date.today()
-        resolved_first_date = first_date or (today - timedelta(days=180)).strftime("%Y-%m-%d")
-        resolved_second_date = second_date or today.strftime("%Y-%m-%d")
+        # Fetch the latest date in DFS history (cached after first call).
+        # Both first_date and second_date must fall within available history.
+        latest_date = await self._get_latest_available_date()
+        latest_dt = date.fromisoformat(latest_date)
+        resolved_second_date = second_date or latest_date
+        resolved_first_date = first_date or (latest_dt - timedelta(days=180)).strftime("%Y-%m-%d")
 
         result = await self._post(
             endpoint="/v3/dataforseo_labs/google/domain_metrics_by_categories/live",

--- a/tests/test_clients/test_dfs_labs_client.py
+++ b/tests/test_clients/test_dfs_labs_client.py
@@ -138,3 +138,85 @@ async def test_domain_metrics_by_categories_custom_dates(client):
 
     assert item["first_date"] == custom_first
     assert item["second_date"] == custom_second
+
+
+# ============================================
+# Test 4: _get_latest_available_date — success
+# Directive #304-FIX
+# ============================================
+
+@pytest.mark.asyncio
+async def test_get_latest_available_date_uses_api(client):
+    """
+    When domain_metrics_by_categories is called with no explicit dates,
+    it calls _get_latest_available_date() and uses the returned date
+    as second_date (NOT today's date, which exceeds the DFS history window).
+    The result is cached so available_history is only called once per session.
+    """
+    available_date = "2026-03-01"
+
+    # Stub _get_latest_available_date so no real HTTP call is needed
+    with patch.object(
+        client,
+        "_get_latest_available_date",
+        new=AsyncMock(return_value=available_date),
+    ):
+        result_data = {"items": [], "total_count": 0}
+        mock_resp = make_mock_response(make_dfs_response(result_data))
+        mock_http_client = AsyncMock()
+        mock_http_client.post = AsyncMock(return_value=mock_resp)
+
+        with patch.object(client, "_get_client", return_value=mock_http_client):
+            await client.domain_metrics_by_categories(category_codes=[10514])
+
+    call_args = mock_http_client.post.call_args
+    payload_sent = call_args[1]["json"] if "json" in call_args[1] else call_args[0][1]
+    item = payload_sent[0]
+
+    # second_date must come from available_history, not today
+    assert item["second_date"] == available_date, (
+        f"second_date should be {available_date} from available_history, got {item['second_date']}"
+    )
+    # first_date must be ~180 days before the available_history date
+    d1 = date.fromisoformat(item["first_date"])
+    d2 = date.fromisoformat(available_date)
+    delta = (d2 - d1).days
+    assert 170 <= delta <= 190, (
+        f"first_date should be ~180 days before {available_date}, gap was {delta} days"
+    )
+
+
+# ============================================
+# Test 5: _get_latest_available_date — fallback on empty response
+# Directive #304-FIX
+# ============================================
+
+@pytest.mark.asyncio
+async def test_get_latest_available_date_fallback_on_empty(client):
+    """
+    If available_history returns an empty result list,
+    _get_latest_available_date() falls back to today minus 35 days.
+    No exception is raised; the fallback date is used for the API call.
+    """
+    from datetime import date, timedelta
+
+    # Mock GET available_history returning empty result
+    empty_hist_resp = make_mock_response(
+        {"tasks": [{"status_code": 20000, "status_message": "Ok.", "result": []}]}
+    )
+    metrics_resp = make_mock_response(make_dfs_response({"items": [], "total_count": 0}))
+
+    mock_http_client = AsyncMock()
+    mock_http_client.get = AsyncMock(return_value=empty_hist_resp)
+    mock_http_client.post = AsyncMock(return_value=metrics_resp)
+
+    with patch.object(client, "_get_client", return_value=mock_http_client):
+        # Clear any cached value
+        client._available_history_date = None
+        result = await client._get_latest_available_date()
+
+    expected_fallback = (date.today() - timedelta(days=35)).strftime("%Y-%m-%d")
+    assert result == expected_fallback, (
+        f"Fallback should be today-35d ({expected_fallback}), got {result}"
+    )
+    assert client._available_history_date == expected_fallback


### PR DESCRIPTION
## Problem
domain_metrics_by_categories was defaulting second_date to today (2026-04-03), but the DFS available_history endpoint returns 2026-03-01 as the latest available date. Any second_date beyond that causes 40501 Invalid Field. The sole discovery endpoint was broken for all new pipeline runs since April 1.

## Fix
- Added `_get_latest_available_date()` method that fetches `/v3/dataforseo_labs/google/available_history` (free GET, no cost)
- Result cached on `self._available_history_date` — one call per client session
- `domain_metrics_by_categories` now uses `await self._get_latest_available_date()` for both first_date and second_date defaults
- first_date = latest_available_date - 180 days (not today - 180 days)
- Fallback: today - 35 days if available_history fetch fails

## Tests
- test_get_latest_available_date_uses_api: verifies second_date uses available_history date, result cached
- test_get_latest_available_date_fallback_on_empty: verifies fallback to today-35d on empty response
- All 5 DFS client tests pass

## Live test
```
Available history date used: 2026-03-01
Results: 5 domains
  domain=pacificsmilesdental.com.au  organic_etv=384507.59
  domain=www.bupadental.com.au  organic_etv=348339.53
  domain=www.colgate.com  organic_etv=243507.93
```

## Baseline
1302 passed, 0 failed, 28 skipped (+2 tests)