### PR TITLE
feat(pipeline): #305 — card quality: name waterfall, location waterfall, placeholder filter

### DIFF
--- a/src/pipeline/email_waterfall.py
+++ b/src/pipeline/email_waterfall.py
@@ -39,6 +39,84 @@ except ImportError:
 # Added to global pool alongside GLOBAL_SEM_SONNET / GLOBAL_SEM_HAIKU
 GLOBAL_SEM_LEADMAGIC = asyncio.Semaphore(10)
 
+# ── Placeholder email/phone blocklists (Directive #305) ──────────────────────
+
+PLACEHOLDER_EMAILS: frozenset[str] = frozenset({
+    "example@mail.com",
+    "you@mail.com",
+    "email@example.com",
+    "info@example.com",
+    "your@email.com",
+    "name@email.com",
+    "test@test.com",
+    "admin@example.com",
+    "yourname@email.com",
+    "user@example.com",
+    "email@yourdomain.com",
+    "you@yourdomain.com",
+    "hello@example.com",
+    "someone@example.com",
+    "address@example.com",
+    "noreply@example.com",
+})
+
+PLACEHOLDER_PHONES: frozenset[str] = frozenset({
+    "+1234567891",
+    "1234567890",
+    "0000000000",
+    "1111111111",
+    "2222222222",
+    "3333333333",
+    "4444444444",
+    "5555555555",
+    "6666666666",
+    "7777777777",
+    "8888888888",
+    "9999999999",
+    "0412345678",
+    "0400000000",
+    "0412000000",
+})
+
+_PLACEHOLDER_EMAIL_PATTERN = re.compile(
+    r"(example|yourname|placeholder|test|yourdomain|your-domain"
+    r"|your_email|youremail|noreply|no-reply)",
+    re.IGNORECASE,
+)
+
+_ALL_SAME_DIGIT_RE = re.compile(r"^(\d)\1{7,}$")  # 8+ same digits
+_SEQUENTIAL_PHONE_RE = re.compile(r"^(0?1234567|01234567|12345678|23456789|34567890)[\d]*$")
+
+
+def is_placeholder_email(email: str) -> bool:
+    """Return True if email is a known placeholder or matches placeholder patterns."""
+    if not email:
+        return False
+    email_lower = email.lower().strip()
+    if email_lower in PLACEHOLDER_EMAILS:
+        return True
+    local = email_lower.split("@")[0] if "@" in email_lower else email_lower
+    if _PLACEHOLDER_EMAIL_PATTERN.search(local):
+        return True
+    return False
+
+
+def is_placeholder_phone(phone: str) -> bool:
+    """Return True if phone is a known placeholder or sequential/all-same-digit."""
+    if not phone:
+        return False
+    digits_only = re.sub(r"[^\d]", "", phone)
+    if not digits_only:
+        return False
+    norm = re.sub(r"[\s\-\(\)\+]", "", phone)
+    if norm in PLACEHOLDER_PHONES or digits_only in {p.lstrip("+") for p in PLACEHOLDER_PHONES}:
+        return True
+    if _ALL_SAME_DIGIT_RE.match(digits_only):
+        return True
+    if _SEQUENTIAL_PHONE_RE.match(digits_only):
+        return True
+    return False
+
 # Email regex — matches standard email formats
 _EMAIL_RE = re.compile(
     r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}",
@@ -397,17 +475,23 @@ async def discover_email(
             name_parts = [p for p in [first, last] if len(p) >= 3]
             name_match = any(p in local for p in name_parts) if name_parts else False
             if name_match:
-                logger.info(
-                    "email_waterfall L0 contact_registry domain=%s email=%s (name match)",
-                    domain, email_val,
-                )
-                return EmailResult(
-                    email=email_val,
-                    verified=False,
-                    source="contact_registry",
-                    confidence="low",
-                    cost_usd=0.0,
-                )
+                if is_placeholder_email(email_val):
+                    logger.debug(
+                        "email_waterfall L0 placeholder rejected domain=%s email=%s",
+                        domain, email_val,
+                    )
+                else:
+                    logger.info(
+                        "email_waterfall L0 contact_registry domain=%s email=%s (name match)",
+                        domain, email_val,
+                    )
+                    return EmailResult(
+                        email=email_val,
+                        verified=False,
+                        source="contact_registry",
+                        confidence="low",
+                        cost_usd=0.0,
+                    )
             else:
                 logger.debug(
                     "email_waterfall L0 contact_registry domain=%s email=%s SKIPPED "
@@ -419,8 +503,15 @@ async def discover_email(
     if 1 not in skip:
         result = _extract_emails_from_html(html or "", clean_domain, dm_name)
         if result and result.email:
-            logger.info("email_waterfall L1 website domain=%s email=%s", domain, result.email)
-            return result
+            if is_placeholder_email(result.email):
+                logger.debug(
+                    "email_waterfall L1 placeholder rejected domain=%s email=%s",
+                    domain, result.email,
+                )
+                result = None  # fall through to next layer
+            else:
+                logger.info("email_waterfall L1 website domain=%s email=%s", domain, result.email)
+                return result
 
     # Layer 2: Leadmagic find_email (verified — Leadmagic finds real address)
     if 2 not in skip and first and last:

--- a/src/pipeline/free_enrichment.py
+++ b/src/pipeline/free_enrichment.py
@@ -318,6 +318,8 @@ class FreeEnrichment:
             "registration_date": row.get("registration_date"),
             "abn_confidence": confidence,
             "_abn_strategy": strategy,
+            "abn_trading_name": row.get("trading_name") or "",
+            "abn_legal_name": row.get("legal_name") or "",
         }
 
     def _compute_email_maturity(
@@ -853,6 +855,8 @@ class FreeEnrichment:
                     "registration_date": reg_date,
                     "abn_confidence": confidence,
                     "_abn_strategy": "live_api",
+                    "abn_trading_name": best.get("business_name") or "",
+                    "abn_legal_name": "",
                 }
                 r = _keep(candidate)
                 if r:

--- a/src/pipeline/pipeline_orchestrator.py
+++ b/src/pipeline/pipeline_orchestrator.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, Optional
@@ -33,6 +34,171 @@ from src.config.category_registry import get_discovery_categories, SERVICE_CATEG
 from src.pipeline.email_waterfall import discover_email, GLOBAL_SEM_LEADMAGIC  # noqa: F401
 
 logger = logging.getLogger(__name__)
+
+# ── Business name waterfall helpers (Directive #305) ─────────────────────────
+
+_ABN_ENTITY_SUFFIX_RE = re.compile(
+    r"\b(pty\.?\s*ltd\.?|pty\.?\s*limited|limited|ltd\.?|inc\.?|llc|"
+    r"proprietary|trustee\s+for|the\s+trustee|as\s+trustee)\b",
+    re.IGNORECASE,
+)
+
+
+def resolve_business_name(
+    domain: str,
+    enrichment: dict,
+    gmb_data: dict | None = None,
+) -> str:
+    """
+    Business name waterfall — returns the best available display name.
+
+    Priority:
+    1. ABN trading_name (if not just entity suffixes and not blank)
+    2. GMB business name from gmb_data
+    3. ABN legal_name (cleaned of entity suffixes)
+    4. Page title prefix (enrichment["company_name"])
+    5. Domain stem
+    """
+    def _is_valid(name: str) -> bool:
+        if not name or not name.strip():
+            return False
+        cleaned = _ABN_ENTITY_SUFFIX_RE.sub("", name).strip(" .,")
+        if not cleaned:
+            return False  # was only suffixes
+        if re.fullmatch(r"\d{9,11}", name.replace(" ", "")):
+            return False  # ABN number
+        if cleaned.lower() in ("com", "com.au", "net.au", "org.au", "au"):
+            return False
+        return True
+
+    candidates = [
+        enrichment.get("abn_trading_name", ""),
+        (gmb_data or {}).get("gmb_name", ""),
+        enrichment.get("abn_legal_name", ""),
+        enrichment.get("company_name", ""),  # title-derived
+    ]
+
+    for name in candidates:
+        if name and _is_valid(name.strip()):
+            return name.strip()[:80]
+
+    # Domain stem fallback
+    stem = domain[4:] if domain.startswith("www.") else domain
+    stem = stem.split(".")[0].replace("-", " ").replace("_", " ").title()
+    return stem or domain
+
+
+# ── Location waterfall helpers (Directive #305) ───────────────────────────────
+
+_AU_STATE_ABBR_RE = re.compile(
+    r"\b(NSW|VIC|QLD|WA|SA|TAS|ACT|NT)\b", re.IGNORECASE
+)
+
+_STATE_NAME_TO_ABBR: dict[str, str] = {
+    "new south wales": "NSW", "victoria": "VIC", "queensland": "QLD",
+    "western australia": "WA", "south australia": "SA", "tasmania": "TAS",
+    "australian capital territory": "ACT", "northern territory": "NT",
+}
+
+
+def _postcode_to_state(postcode: str) -> str:
+    """Map Australian postcode prefix to state abbreviation."""
+    try:
+        pc = int(postcode)
+        if 1000 <= pc <= 2999:
+            return "NSW"
+        if 3000 <= pc <= 3999:
+            return "VIC"
+        if 4000 <= pc <= 4999:
+            return "QLD"
+        if 5000 <= pc <= 5999:
+            return "SA"
+        if 6000 <= pc <= 6999:
+            return "WA"
+        if 7000 <= pc <= 7999:
+            return "TAS"
+        if 800 <= pc <= 999:
+            return "NT"
+        if 200 <= pc <= 299:
+            return "ACT"
+    except (ValueError, TypeError):
+        pass
+    return ""
+
+
+def resolve_location(
+    domain: str,
+    enrichment: dict,
+    gmb_data: dict | None = None,
+    default_location: str = "Australia",
+) -> tuple[str, str, str]:
+    """
+    Location waterfall — returns (suburb, state, display_string).
+
+    Priority:
+    1. GMB address — parse suburb + state from "123 Main St, Surry Hills NSW 2010"
+    2. website_address (JSON-LD) suburb + state
+    3. ABN state (from abn_state field if available)
+    4. State hint from enrichment
+    5. default_location passed from discovery
+    """
+    suburb = ""
+    state = ""
+
+    # Priority 1: GMB address
+    gmb_address = (
+        (gmb_data or {}).get("gmb_address")
+        or (gmb_data or {}).get("address")
+        or ""
+    )
+    if gmb_address:
+        state_match = _AU_STATE_ABBR_RE.search(gmb_address)
+        if state_match:
+            state = state_match.group(0).upper()
+            before_state = gmb_address[:state_match.start()].strip().rstrip(",").strip()
+            parts = [p.strip() for p in before_state.split(",") if p.strip()]
+            if parts:
+                suburb = parts[-1]
+
+    # Priority 2: JSON-LD address from website
+    if not suburb:
+        wa = enrichment.get("website_address") or {}
+        if isinstance(wa, dict):
+            suburb = wa.get("suburb") or wa.get("addressLocality") or wa.get("city") or ""
+            if not state:
+                state = wa.get("state") or wa.get("addressRegion") or ""
+                if state and len(state) > 3:
+                    state = _STATE_NAME_TO_ABBR.get(state.lower(), state)
+            if not state:
+                postcode = wa.get("postcode") or wa.get("postalCode") or ""
+                state = _postcode_to_state(str(postcode)) if postcode else ""
+
+    # Priority 3: ABN state
+    if not state:
+        abn_state = enrichment.get("abn_state") or ""
+        if abn_state:
+            state = _STATE_NAME_TO_ABBR.get(abn_state.lower(), abn_state)
+
+    # Priority 4: State hint from enrichment
+    if not state:
+        state_hint = enrichment.get("state_hint") or enrichment.get("state") or ""
+        if state_hint:
+            state = _STATE_NAME_TO_ABBR.get(state_hint.lower(), state_hint).upper()[:3]
+            if not _AU_STATE_ABBR_RE.match(state):
+                state = ""
+
+    # Build display string
+    if suburb and state:
+        display = f"{suburb}, {state}"
+    elif suburb:
+        display = suburb
+    elif state:
+        display = state
+    else:
+        display = default_location or "Australia"
+
+    return suburb, state, display
+
 
 # Semaphore limits — tuned for DFS 30-concurrent + Spider 15-concurrent limits
 SEM_SPIDER = 15    # Spider.cloud concurrent scrapes
@@ -89,6 +255,10 @@ class ProspectCard:
     dm_email_source: Optional[str] = None
     dm_email_confidence: Optional[str] = None
     email_cost_usd: float = 0.0
+    # Location fields (Directive #305 — supplements single "location" string)
+    location_suburb: str = ""
+    location_state: str = ""
+    location_display: str = ""  # "Surry Hills, NSW" or "NSW" or "Australia"
     # Intelligence endpoints (Directive #303)
     competitors_top3: list = field(default_factory=list)
     competitor_count: int = 0
@@ -530,11 +700,7 @@ class PipelineOrchestrator:
                         stats.unreachable += 1
                         continue
 
-                    company_name = (
-                        enrichment.get("company_name")
-                        or enrichment.get("abn_entity_name")
-                        or domain
-                    )
+                    company_name = resolve_business_name(domain, enrichment)
                     # Use intelligence layer results if available, else fall back to scorer
                     intel = intel_results.get(domain, {})
                     if intel.get("evidence_statements"):
@@ -546,10 +712,14 @@ class PipelineOrchestrator:
                         intent_band = getattr(intent_full, "band", "UNKNOWN") if intent_full else "UNKNOWN"
                         intent_score = getattr(intent_full, "raw_score", 0) if intent_full else 0
 
+                    _loc_suburb, _loc_state, _loc_display = resolve_location(domain, enrichment, default_location=location)
                     card = ProspectCard(
                         domain=domain,
                         company_name=company_name,
-                        location=(enrichment.get("website_address") or {}).get("suburb", location),
+                        location=_loc_display,
+                        location_suburb=_loc_suburb,
+                        location_state=_loc_state,
+                        location_display=_loc_display,
                         services=enrichment.get("services") or intel.get("services") or [],
                         evidence=evidence,
                         affordability_band=afford.band,
@@ -770,7 +940,7 @@ class PipelineOrchestrator:
 
                     intel = self._intelligence  # None if not wired
                     html = enrichment.get("html", "")
-                    company_name = enrichment.get("company_name") or domain
+                    company_name = resolve_business_name(domain, enrichment)
                     addr = enrichment.get("website_address") or {}
                     suburb = (addr.get("suburb") or addr.get("city") or "") if isinstance(addr, dict) else ""
 
@@ -875,10 +1045,16 @@ class PipelineOrchestrator:
                         continue
 
                     # Build ProspectCard
+                    # Re-resolve with GMB data now available (gmb_data merged into enrichment above)
+                    company_name = resolve_business_name(domain, enrichment, gmb_data)
+                    _loc_suburb, _loc_state, _loc_display = resolve_location(domain, enrichment, gmb_data, default_location=location)
                     card = ProspectCard(
                         domain=domain,
                         company_name=company_name,
-                        location=suburb,
+                        location=_loc_display,
+                        location_suburb=_loc_suburb,
+                        location_state=_loc_state,
+                        location_display=_loc_display,
                         evidence=evidence,
                         affordability_band=afford.band,
                         affordability_score=afford.raw_score,

--- a/tests/test_pipeline/test_card_quality.py
+++ b/tests/test_pipeline/test_card_quality.py
@@ -1,0 +1,116 @@
+"""
+Tests for card quality fixes — Directive #305:
+- Business name waterfall (resolve_business_name)
+- Location waterfall (resolve_location)
+- Placeholder filter (is_placeholder_email, is_placeholder_phone)
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.pipeline.pipeline_orchestrator import resolve_business_name, resolve_location
+from src.pipeline.email_waterfall import is_placeholder_email, is_placeholder_phone
+
+
+# ── resolve_business_name ─────────────────────────────────────────────────────
+
+def test_abn_trading_name_priority():
+    """ABN trading name wins over domain stem."""
+    enrichment = {
+        "abn_trading_name": "Dental1 Clinic Pty Ltd",
+        "abn_legal_name": "",
+        "company_name": "dental1",
+    }
+    result = resolve_business_name("dental1.com.au", enrichment)
+    assert result == "Dental1 Clinic Pty Ltd"
+
+
+def test_pty_ltd_alone_falls_through():
+    """ABN trading name = only entity suffix → falls through to GMB name."""
+    enrichment = {
+        "abn_trading_name": "Pty Ltd",
+        "abn_legal_name": "",
+        "company_name": "dental1",
+    }
+    gmb_data = {"gmb_name": "Bright Smile Dental"}
+    result = resolve_business_name("dental1.com.au", enrichment, gmb_data)
+    assert result == "Bright Smile Dental"
+
+
+def test_domain_stem_fallback():
+    """All candidates blank → domain stem."""
+    enrichment = {
+        "abn_trading_name": "",
+        "abn_legal_name": "",
+        "company_name": "",
+    }
+    result = resolve_business_name("bright-smile-dental.com.au", enrichment)
+    assert result == "Bright Smile Dental"
+
+
+def test_abn_legal_name_used_when_trading_empty():
+    """Falls through trading → GMB (None) → legal name."""
+    enrichment = {
+        "abn_trading_name": "",
+        "abn_legal_name": "Bright Smile Dental Pty Ltd",
+        "company_name": "fallback",
+    }
+    result = resolve_business_name("example.com.au", enrichment)
+    assert result == "Bright Smile Dental Pty Ltd"
+
+
+# ── resolve_location ──────────────────────────────────────────────────────────
+
+def test_gmb_address_suburb_state():
+    """GMB address parsed to suburb + state."""
+    gmb_data = {"gmb_address": "42 Main St, Parramatta NSW 2150"}
+    suburb, state, display = resolve_location("example.com.au", {}, gmb_data)
+    assert suburb == "Parramatta"
+    assert state == "NSW"
+    assert display == "Parramatta, NSW"
+
+
+def test_abn_postcode_resolves_to_state():
+    """Postcode 2000 → NSW when no suburb / GMB available."""
+    enrichment = {"website_address": {"postcode": "2000"}}
+    suburb, state, display = resolve_location("example.com.au", enrichment)
+    assert suburb == ""
+    assert state == "NSW"
+    assert display == "NSW"
+
+
+def test_australia_only_when_all_fail():
+    """No enrichment, no GMB → default 'Australia'."""
+    suburb, state, display = resolve_location("example.com.au", {})
+    assert suburb == ""
+    assert state == ""
+    assert display == "Australia"
+
+
+# ── is_placeholder_email ──────────────────────────────────────────────────────
+
+def test_placeholder_email_exact_match():
+    assert is_placeholder_email("example@mail.com") is True
+
+
+def test_placeholder_email_pattern():
+    assert is_placeholder_email("yourname@company.com") is True
+
+
+def test_real_email_passes():
+    assert is_placeholder_email("john.smith@dentist.com.au") is False
+
+
+# ── is_placeholder_phone ─────────────────────────────────────────────────────
+
+def test_placeholder_phone_all_same_digit():
+    assert is_placeholder_phone("0000000000") is True
+
+
+def test_placeholder_phone_sequential():
+    assert is_placeholder_phone("0412345678") is True
+
+
+def test_real_phone_passes():
+    assert is_placeholder_phone("0412 987 654") is False
+    assert is_placeholder_phone("+61 2 9123 4567") is False


### PR DESCRIPTION
Fixes three card quality bugs from integration test #300.

**Bug 1:** Business name = domain stem. Added `resolve_business_name()` waterfall: ABN trading_name → GMB name → ABN legal_name → title prefix → domain stem. Also adds `abn_trading_name` / `abn_legal_name` to all ABN result dicts in `free_enrichment.py`.

**Bug 2:** Location = "Australia" in 54% of cases. Added `resolve_location()` waterfall: GMB address → JSON-LD suburb/state → ABN postcode → state hint. Adds `location_suburb` / `location_state` / `location_display` fields to `ProspectCard` (backwards compat: `location` field set to display string).

**Bug 3:** Placeholder emails leaking (e.g. `example@mail.com`, `yourname@co.com`). Added `is_placeholder_email()` + `is_placeholder_phone()` with blocklist + pattern matching. Applied to Layers 0+1 in `discover_email()` (Layers 2/3 are trusted APIs, not filtered).

13 new tests in `tests/test_pipeline/test_card_quality.py`. Full suite: 1315 passed, 0 failed.