### PR TITLE
feat(pipeline): #306 — Marketing Vulnerability Report

### DIFF
--- a/src/pipeline/intelligence.py
+++ b/src/pipeline/intelligence.py
@@ -525,3 +525,122 @@ async def refine_evidence(
         except Exception as exc:
             logger.warning("refine_evidence failed domain=%s: %s", domain, exc)
             return fallback
+
+
+# ── Stage 7c: Marketing Vulnerability Report (Sonnet) ─────────────────────────
+
+_VULN_SYSTEM = """You are a marketing analyst producing a Marketing Vulnerability Report for an Australian business.
+
+You receive raw data from multiple intelligence sources. Your job is to synthesise it into a structured assessment that a marketing agency can show the business owner to explain their marketing gaps.
+
+Rules:
+- Assign grades: A (excellent), B (good), C (average), D (poor), F (critical failure)
+- Use "Insufficient Data" grade when data for a section is missing or null
+- Every finding must reference specific numbers from the data provided
+- Do NOT fabricate numbers or make assumptions beyond the data
+- Competitive comparisons only where competitor data is actually present
+- Be direct and specific — no vague statements like "could be improved"
+
+Output ONLY valid JSON. No preamble, no explanation."""
+
+_VULN_SYSTEM_BLOCK = {
+    "type": "text",
+    "text": _VULN_SYSTEM,
+    "cache_control": {"type": "ephemeral"},
+}
+
+_VULN_FALLBACK = {
+    "overall_grade": "Insufficient Data",
+    "sections": {
+        "search_visibility": {"grade": "Insufficient Data", "findings": [], "data": {}},
+        "technical_seo": {"grade": "Insufficient Data", "findings": [], "data": {}},
+        "backlink_profile": {"grade": "Insufficient Data", "findings": [], "data": {}},
+        "paid_advertising": {"grade": "Insufficient Data", "findings": [], "data": {}},
+        "reputation": {"grade": "Insufficient Data", "findings": [], "data": {}},
+        "competitive_position": {"grade": "Insufficient Data", "findings": [], "competitors": []},
+    },
+    "priority_action": "",
+    "three_month_roadmap": [],
+}
+
+
+async def generate_vulnerability_report(
+    domain: str,
+    company_name: str,
+    enrichment: dict,
+    intelligence: dict,
+    competitors_data: dict | None = None,
+    backlinks_data: dict | None = None,
+    brand_serp_data: dict | None = None,
+    indexed_pages: int = 0,
+) -> dict:
+    """
+    Stage 7c — Sonnet. Synthesise all available intelligence into a structured
+    Marketing Vulnerability Report.
+
+    Cost: ~$0.02–0.03 per domain (Sonnet, cached system prompt, ~2K variable tokens).
+    Semaphore: GLOBAL_SEM_SONNET.
+    Prompt caching: static system prompt cached, variable data last.
+
+    Returns dict with sections: search_visibility, technical_seo, backlink_profile,
+    paid_advertising, reputation, competitive_position. Plus overall_grade,
+    priority_action, three_month_roadmap.
+    """
+    async with GLOBAL_SEM_SONNET:
+        try:
+            website_data = intelligence.get("website_data", {}) if intelligence else {}
+            intent_data = intelligence.get("intent_data", {}) if intelligence else {}
+
+            context_dict = {
+                "company_name": company_name,
+                "domain": domain,
+                "intent_band": intent_data.get("band", intelligence.get("intent_band", "UNKNOWN")) if intelligence else "UNKNOWN",
+                "intent_score": intent_data.get("score", intelligence.get("intent_score", 0)) if intelligence else 0,
+                "website": {
+                    "services": enrichment.get("services") or website_data.get("services", []),
+                    "cms": (website_data.get("technology_signals") or {}).get("cms", enrichment.get("cms", "unknown")),
+                    "has_analytics": (website_data.get("technology_signals") or {}).get("has_analytics", enrichment.get("has_analytics", False)),
+                    "has_ads_tag": (website_data.get("technology_signals") or {}).get("has_ads_tag", enrichment.get("has_ads_tag", False)),
+                    "has_booking_system": (website_data.get("technology_signals") or {}).get("has_booking_system", enrichment.get("has_booking_system", False)),
+                    "has_conversion_tracking": (website_data.get("technology_signals") or {}).get("has_conversion_tracking", enrichment.get("has_conversion_tracking", False)),
+                },
+                "ads": {
+                    "is_running_ads": enrichment.get("is_running_ads", False),
+                    "ad_count": enrichment.get("ad_count", 0),
+                    "google_ads_active": enrichment.get("google_ads_active", False),
+                },
+                "gmb": {
+                    "rating": enrichment.get("gmb_rating"),
+                    "review_count": enrichment.get("gmb_review_count", 0),
+                    "gmb_found": enrichment.get("gmb_found", False),
+                },
+                "competitors": (competitors_data or {}).get("top3", []),
+                "competitor_count": (competitors_data or {}).get("count", 0),
+                "backlinks": {
+                    "referring_domains": (backlinks_data or {}).get("referring_domains", 0),
+                    "domain_rank": (backlinks_data or {}).get("domain_rank", 0),
+                    "backlink_trend": (backlinks_data or {}).get("trend", "unknown"),
+                },
+                "brand_serp": {
+                    "brand_position": (brand_serp_data or {}).get("position"),
+                    "gmb_showing": (brand_serp_data or {}).get("gmb_showing", False),
+                    "competitors_bidding": (brand_serp_data or {}).get("competitors_bidding", False),
+                },
+                "indexed_pages": indexed_pages,
+            }
+
+            user_content = (
+                f"Business intelligence data:\n{json.dumps(context_dict, indent=2)}\n\n"
+                "Produce the Marketing Vulnerability Report JSON."
+            )
+            text, in_tok, out_tok = await _call_anthropic(
+                model=_MODEL_SONNET,
+                system_blocks=[_VULN_SYSTEM_BLOCK],
+                user_content=user_content,
+                max_tokens=1200,
+            )
+            logger.info("generate_vulnerability_report domain=%s tokens=%d/%d", domain, in_tok, out_tok)
+            return _parse_json_response(text, _VULN_FALLBACK)
+        except Exception as exc:
+            logger.warning("generate_vulnerability_report failed domain=%s: %s", domain, exc)
+            return _VULN_FALLBACK

--- a/src/pipeline/pipeline_orchestrator.py
+++ b/src/pipeline/pipeline_orchestrator.py
@@ -269,6 +269,8 @@ class ProspectCard:
     brand_gmb_showing: bool = False
     brand_competitors_bidding: bool = False
     indexed_pages: int = 0
+    # Vulnerability Report (Directive #306)
+    vulnerability_report: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -713,6 +715,36 @@ class PipelineOrchestrator:
                         intent_score = getattr(intent_full, "raw_score", 0) if intent_full else 0
 
                     _loc_suburb, _loc_state, _loc_display = resolve_location(domain, enrichment, default_location=location)
+
+                    # ── STAGE 7c: Vulnerability Report ───────────────────────────
+                    vuln_report: dict = {}
+                    if self._intelligence is not None:
+                        _comp_data = {
+                            "top3": (paid.get("ads_data") or {}).get("competitors_top3", []),
+                            "count": (paid.get("ads_data") or {}).get("competitor_count", 0),
+                        }
+                        _bl_data = {
+                            "referring_domains": enrichment.get("backlinks_referring_domains", 0),
+                            "domain_rank": enrichment.get("backlinks_domain_rank", 0),
+                            "trend": enrichment.get("backlinks_trend", "unknown"),
+                        }
+                        _brand_data = {
+                            "position": enrichment.get("brand_serp_position"),
+                            "gmb_showing": enrichment.get("brand_serp_gmb_showing", False),
+                            "competitors_bidding": enrichment.get("brand_serp_competitors_bidding", False),
+                        }
+                        _indexed = enrichment.get("indexed_pages_count", 0)
+                        vuln_report = await self._intelligence.generate_vulnerability_report(
+                            domain=domain,
+                            company_name=company_name,
+                            enrichment=enrichment,
+                            intelligence=intel,
+                            competitors_data=_comp_data,
+                            backlinks_data=_bl_data,
+                            brand_serp_data=_brand_data,
+                            indexed_pages=_indexed,
+                        )
+
                     card = ProspectCard(
                         domain=domain,
                         company_name=company_name,
@@ -733,6 +765,7 @@ class PipelineOrchestrator:
                         dm_title=dm.title,
                         dm_linkedin_url=dm.linkedin_url,
                         dm_confidence=dm.confidence,
+                        vulnerability_report=vuln_report,
                     )
                     results.append(card)
                     stats.viable_prospects += 1
@@ -1015,6 +1048,39 @@ class PipelineOrchestrator:
                         intent_score = getattr(intent, "raw_score", 0)
                         evidence = getattr(intent, "evidence", [])
 
+                    # ── STAGE 7c: Vulnerability Report ───────────────────────────
+                    vuln_report: dict = {}
+                    if intel is not None and hasattr(intel, "generate_vulnerability_report"):
+                        try:
+                            _comp_data = {
+                                "top3": paid.get("competitors_top3", []) if isinstance(paid, dict) else [],
+                                "count": paid.get("competitor_count", 0) if isinstance(paid, dict) else 0,
+                            }
+                            _bl_data = {
+                                "referring_domains": paid.get("backlinks_referring_domains", 0) if isinstance(paid, dict) else 0,
+                                "domain_rank": paid.get("backlinks_domain_rank", 0) if isinstance(paid, dict) else 0,
+                                "trend": paid.get("backlinks_trend", "unknown") if isinstance(paid, dict) else "unknown",
+                            }
+                            _brand_data = {
+                                "position": paid.get("brand_serp_position") if isinstance(paid, dict) else None,
+                                "gmb_showing": paid.get("brand_serp_gmb_showing", False) if isinstance(paid, dict) else False,
+                                "competitors_bidding": paid.get("brand_serp_competitors_bidding", False) if isinstance(paid, dict) else False,
+                            }
+                            _indexed = paid.get("indexed_pages_count", 0) if isinstance(paid, dict) else 0
+                            _intel_data = {"intent_band": intent_band, "intent_score": intent_score} if not isinstance(intent_data, dict) else intent_data
+                            vuln_report = await intel.generate_vulnerability_report(
+                                domain=domain,
+                                company_name=company_name,
+                                enrichment=enrichment,
+                                intelligence=_intel_data,
+                                competitors_data=_comp_data,
+                                backlinks_data=_bl_data,
+                                brand_serp_data=_brand_data,
+                                indexed_pages=_indexed,
+                            )
+                        except Exception as _vuln_exc:
+                            logger.warning("vulnerability_report failed domain=%s: %s", domain, _vuln_exc)
+
                     # ── STAGE 8: DM identification ────────────────────────────
                     async with GLOBAL_SEM_DFS:
                         dm = await self._stage_dm(sem_dm, domain, company_name, enrichment)
@@ -1071,6 +1137,7 @@ class PipelineOrchestrator:
                         dm_email_source=email_result.source,
                         dm_email_confidence=email_result.confidence,
                         email_cost_usd=email_result.cost_usd,
+                        vulnerability_report=vuln_report,
                     )
 
                     async with results_lock:

--- a/tests/test_intelligence_vuln_report.py
+++ b/tests/test_intelligence_vuln_report.py
@@ -1,0 +1,236 @@
+"""
+Tests for generate_vulnerability_report() — Directive #306.
+Tests the Stage 7c Sonnet synthesis function and ProspectCard field.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import fields
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import src.pipeline.intelligence as intel_module
+from src.pipeline.intelligence import (
+    _VULN_FALLBACK,
+    _VULN_SYSTEM_BLOCK,
+    generate_vulnerability_report,
+)
+from src.pipeline.pipeline_orchestrator import ProspectCard
+
+# ── Shared mock data ────────────────────────────────────────────────────────
+
+_FULL_MOCK_RESULT = {
+    "overall_grade": "D+",
+    "sections": {
+        "search_visibility": {
+            "grade": "D",
+            "findings": ["Brand ranks at position 8 — below the fold"],
+            "data": {"brand_position": 8},
+        },
+        "technical_seo": {
+            "grade": "C",
+            "findings": ["94 pages indexed — reasonable for site size"],
+            "data": {"indexed_pages": 94, "cms": "WordPress"},
+        },
+        "backlink_profile": {
+            "grade": "D",
+            "findings": ["Domain rank 18 — below average for this category"],
+            "data": {"domain_rank": 18, "trend": "declining"},
+        },
+        "paid_advertising": {
+            "grade": "F",
+            "findings": ["13 campaigns running but no conversion tracking installed"],
+            "data": {"campaigns": 13, "tracking": False},
+        },
+        "reputation": {
+            "grade": "B-",
+            "findings": ["4.2 stars from 265 reviews — strong social proof"],
+            "data": {"rating": 4.2, "reviews": 265},
+        },
+        "competitive_position": {
+            "grade": "D",
+            "findings": ["3 competitors outranking on brand SERP"],
+            "competitors": [{"domain": "rival.com.au", "dr": 34}],
+        },
+    },
+    "priority_action": "Install conversion tracking on all 13 Google Ads campaigns immediately.",
+    "three_month_roadmap": [
+        "Month 1: Fix conversion tracking and audit 13 campaigns for waste",
+        "Month 2: Build backlinks to push domain rank above 25",
+        "Month 3: Claim brand SERP position 1 via review response strategy",
+    ],
+}
+
+_MOCK_ENRICHMENT = {
+    "gmb_rating": 4.2,
+    "gmb_review_count": 265,
+    "is_running_ads": True,
+    "google_ads_active": True,
+}
+
+_MOCK_INTELLIGENCE = {
+    "intent_band": "ACTIVE_SPENDER",
+    "intent_score": 72,
+}
+
+
+# ── test_1: full data returns all 6 sections ─────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_1_full_data_returns_all_sections():
+    with patch.object(intel_module, "_call_anthropic", new=AsyncMock(
+        return_value=(json.dumps(_FULL_MOCK_RESULT), 800, 300)
+    )):
+        result = await generate_vulnerability_report(
+            domain="example.com.au",
+            company_name="Example Pty Ltd",
+            enrichment=_MOCK_ENRICHMENT,
+            intelligence=_MOCK_INTELLIGENCE,
+            competitors_data={"top3": [{"domain": "rival.com.au"}], "count": 3},
+            backlinks_data={"referring_domains": 45, "domain_rank": 18, "trend": "declining"},
+            brand_serp_data={"position": 8, "gmb_showing": True, "competitors_bidding": True},
+            indexed_pages=94,
+        )
+
+    assert "sections" in result
+    expected_sections = {
+        "search_visibility",
+        "technical_seo",
+        "backlink_profile",
+        "paid_advertising",
+        "reputation",
+        "competitive_position",
+    }
+    assert set(result["sections"].keys()) == expected_sections
+
+
+# ── test_2: missing competitors gives "Insufficient Data" grade ──────────────
+
+@pytest.mark.asyncio
+async def test_2_missing_competitors_gives_insufficient():
+    partial_result = dict(_FULL_MOCK_RESULT)
+    partial_result["sections"] = dict(_FULL_MOCK_RESULT["sections"])
+    partial_result["sections"]["competitive_position"] = {
+        "grade": "Insufficient Data",
+        "findings": [],
+        "competitors": [],
+    }
+    with patch.object(intel_module, "_call_anthropic", new=AsyncMock(
+        return_value=(json.dumps(partial_result), 700, 250)
+    )):
+        result = await generate_vulnerability_report(
+            domain="nocomp.com.au",
+            company_name="No Comp Co",
+            enrichment={},
+            intelligence={},
+            competitors_data=None,
+        )
+
+    assert result["sections"]["competitive_position"]["grade"] == "Insufficient Data"
+
+
+# ── test_3: missing ads data does not crash ───────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_3_missing_ads_gives_appropriate_grade():
+    no_ads_result = dict(_FULL_MOCK_RESULT)
+    no_ads_result["sections"] = dict(_FULL_MOCK_RESULT["sections"])
+    no_ads_result["sections"]["paid_advertising"] = {
+        "grade": "Insufficient Data",
+        "findings": ["No advertising data available"],
+        "data": {},
+    }
+    with patch.object(intel_module, "_call_anthropic", new=AsyncMock(
+        return_value=(json.dumps(no_ads_result), 600, 200)
+    )):
+        result = await generate_vulnerability_report(
+            domain="noads.com.au",
+            company_name="No Ads Ltd",
+            enrichment={"google_ads_active": False},
+            intelligence={},
+        )
+
+    assert "paid_advertising" in result["sections"]
+    assert result["sections"]["paid_advertising"]["grade"] is not None
+
+
+# ── test_4: result has all top-level required keys ────────────────────────────
+
+@pytest.mark.asyncio
+async def test_4_result_json_has_required_keys():
+    with patch.object(intel_module, "_call_anthropic", new=AsyncMock(
+        return_value=(json.dumps(_FULL_MOCK_RESULT), 800, 300)
+    )):
+        result = await generate_vulnerability_report(
+            domain="keys-check.com.au",
+            company_name="Keys Check Co",
+            enrichment=_MOCK_ENRICHMENT,
+            intelligence=_MOCK_INTELLIGENCE,
+        )
+
+    for key in ("overall_grade", "sections", "priority_action", "three_month_roadmap"):
+        assert key in result, f"Missing top-level key: {key}"
+
+
+# ── test_5: ProspectCard has vulnerability_report field ──────────────────────
+
+def test_5_vulnerability_report_on_prospect_card():
+    card = ProspectCard(domain="x.com.au", company_name="X", location="Sydney")
+    assert hasattr(card, "vulnerability_report")
+    assert isinstance(card.vulnerability_report, dict)
+
+
+# ── test_6: GLOBAL_SEM_SONNET semaphore is acquired ──────────────────────────
+
+@pytest.mark.asyncio
+async def test_6_sonnet_semaphore_acquired():
+    real_sem = asyncio.Semaphore(1)
+    acquired_events: list[bool] = []
+
+    original_acquire = real_sem.acquire
+
+    async def tracking_acquire():
+        acquired_events.append(True)
+        return await original_acquire()
+
+    real_sem.acquire = tracking_acquire  # type: ignore[method-assign]
+
+    with patch.object(intel_module, "GLOBAL_SEM_SONNET", real_sem):
+        with patch.object(intel_module, "_call_anthropic", new=AsyncMock(
+            return_value=(json.dumps(_FULL_MOCK_RESULT), 800, 300)
+        )):
+            await generate_vulnerability_report(
+                domain="sem-test.com.au",
+                company_name="Sem Test",
+                enrichment={},
+                intelligence={},
+            )
+
+    assert len(acquired_events) >= 1, "Semaphore was never acquired"
+
+
+# ── test_7: _VULN_SYSTEM_BLOCK has prompt caching header ─────────────────────
+
+def test_7_prompt_caching_block_present():
+    assert "cache_control" in _VULN_SYSTEM_BLOCK
+    assert _VULN_SYSTEM_BLOCK["cache_control"] == {"type": "ephemeral"}
+
+
+# ── test_8: API error returns fallback dict ───────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_8_api_error_returns_fallback():
+    with patch.object(intel_module, "_call_anthropic", new=AsyncMock(
+        side_effect=Exception("API error")
+    )):
+        result = await generate_vulnerability_report(
+            domain="error.com.au",
+            company_name="Error Co",
+            enrichment={},
+            intelligence={},
+        )
+
+    assert result["overall_grade"] == "Insufficient Data"
+    assert result == _VULN_FALLBACK


### PR DESCRIPTION
Adds `generate_vulnerability_report()` to `intelligence.py` as Stage 7c between intent classification and DM identification.

Sonnet reads all available intelligence (ads, GMB, competitors, backlinks, brand SERP, indexed pages, website comprehension) and produces a structured **6-section Marketing Vulnerability Report** with grades (A–F), specific findings referencing real numbers, and a 3-month roadmap.

## Changes

- **`src/pipeline/intelligence.py`** — `generate_vulnerability_report()` async function, `_VULN_SYSTEM` prompt, `_VULN_SYSTEM_BLOCK` (cached), `_VULN_FALLBACK`
- **`src/pipeline/pipeline_orchestrator.py`** — `vulnerability_report: dict` field on `ProspectCard`; Stage 7c wired in both `run()` and `run_parallel()` with try/except (non-blocking on failure)
- **`tests/test_intelligence_vuln_report.py`** — 8 new tests

## Cost

~$0.02–0.03/domain (Sonnet, prompt caching on static system prompt, ~2K variable tokens).

## Test results

8/8 new tests pass. Full suite: **1323 passed, 0 failed** (baseline was 1315).