### PR TITLE
DASH-001: Full dashboard HTML mock (9 pages)

### DIFF
--- a/frontend/mocks/dashboard_full_mock.html
+++ b/frontend/mocks/dashboard_full_mock.html
@@ -1,0 +1,2608 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AgencyOS — Dashboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;1,700&family=DM+Sans:wght@300;400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* ─── DESIGN TOKENS ─────────────────────────────────────────────── */
+:root {
+  --cream: #F7F3EE;
+  --surface: #EDE8E0;
+  --ink: #0C0A08;
+  --ink-2: #2E2B26;
+  --ink-3: #7A756D;
+  --amber: #D4956A;
+  --amber-soft: rgba(212,149,106,0.12);
+  --copper: #C46A3E;
+  --tan: #C4A878;
+  --green: #6B8E5A;
+  --red: #B55A4C;
+  --rule: rgba(12,10,8,0.08);
+  --sidebar-w: 232px;
+  --topbar-h: 56px;
+}
+
+/* ─── RESET ─────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; background: var(--cream); color: var(--ink); }
+body { font-family: 'DM Sans', sans-serif; font-size: 14px; line-height: 1.5; display: flex; }
+a { color: inherit; text-decoration: none; }
+button { cursor: pointer; font-family: 'DM Sans', sans-serif; }
+input, select, textarea { font-family: 'DM Sans', sans-serif; }
+ul { list-style: none; }
+
+/* ─── SCROLLBAR ─────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 4px; height: 4px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--rule); border-radius: 2px; }
+
+/* ─── TYPOGRAPHY ─────────────────────────────────────────────────── */
+.playfair { font-family: 'Playfair Display', serif; font-weight: 700; }
+.mono { font-family: 'JetBrains Mono', monospace; }
+.eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); }
+
+/* ─── SIDEBAR ────────────────────────────────────────────────────── */
+#sidebar {
+  width: var(--sidebar-w);
+  min-width: var(--sidebar-w);
+  height: 100vh;
+  background: var(--ink);
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  left: 0; top: 0; bottom: 0;
+  z-index: 100;
+  overflow-y: auto;
+}
+
+.sidebar-logo {
+  padding: 24px 20px 20px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.sidebar-logo .logo-text {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 20px;
+  color: #fff;
+  letter-spacing: -0.02em;
+}
+.sidebar-logo .logo-text em {
+  color: var(--amber);
+  font-style: italic;
+}
+
+.sidebar-section {
+  padding: 16px 0 4px;
+}
+.sidebar-section-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.28);
+  padding: 0 20px 8px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 20px;
+  color: rgba(255,255,255,0.52);
+  font-size: 13.5px;
+  font-weight: 400;
+  cursor: pointer;
+  position: relative;
+  transition: color 0.15s, background 0.15s;
+  border-left: 2px solid transparent;
+  user-select: none;
+}
+.nav-item:hover { color: rgba(255,255,255,0.82); background: rgba(255,255,255,0.04); }
+.nav-item.active {
+  color: #fff;
+  background: var(--amber-soft);
+  border-left-color: var(--amber);
+  font-weight: 500;
+}
+.nav-icon { width: 16px; height: 16px; opacity: 0.7; flex-shrink: 0; }
+.nav-item.active .nav-icon { opacity: 1; }
+.nav-badge {
+  margin-left: auto;
+  background: var(--copper);
+  color: #fff;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 10px;
+  min-width: 20px;
+  text-align: center;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding: 16px 20px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.avatar-circle {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--amber);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Playfair Display', serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+.sidebar-user-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  line-height: 1.2;
+}
+.sidebar-user-sub {
+  font-size: 11px;
+  color: rgba(255,255,255,0.4);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ─── MAIN LAYOUT ────────────────────────────────────────────────── */
+#app {
+  margin-left: var(--sidebar-w);
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* ─── TOPBAR ─────────────────────────────────────────────────────── */
+#topbar {
+  height: var(--topbar-h);
+  background: var(--cream);
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+  padding: 0 40px;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  gap: 16px;
+}
+.breadcrumb {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--ink-3);
+}
+.breadcrumb .crumb-sep { color: var(--rule); }
+.breadcrumb .crumb-current { color: var(--ink-2); font-weight: 500; }
+
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.pulse-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+  color: var(--ink-3);
+  font-family: 'JetBrains Mono', monospace;
+}
+.pulse-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  animation: pulse 2s infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+.kill-btn {
+  background: transparent;
+  border: 1px solid var(--red);
+  color: var(--red);
+  font-size: 11px;
+  font-weight: 500;
+  font-family: 'JetBrains Mono', monospace;
+  padding: 5px 12px;
+  border-radius: 4px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: background 0.15s;
+}
+.kill-btn:hover { background: rgba(181,90,76,0.08); }
+
+/* ─── PAGE CONTENT ───────────────────────────────────────────────── */
+#page {
+  flex: 1;
+  overflow-y: auto;
+  padding: 36px 40px 60px;
+  max-width: 1480px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* ─── SHARED COMPONENTS ──────────────────────────────────────────── */
+.page-headline {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 36px;
+  color: var(--ink);
+  line-height: 1.18;
+  letter-spacing: -0.02em;
+  margin-bottom: 28px;
+}
+.page-headline em { color: var(--amber); font-style: italic; }
+
+.card {
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  padding: 22px 24px;
+}
+.card-sm { padding: 16px 18px; }
+
+.section-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: 14px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 0.04em;
+}
+.badge-amber { background: var(--amber-soft); color: var(--copper); }
+.badge-green { background: rgba(107,142,90,0.12); color: var(--green); }
+.badge-red { background: rgba(181,90,76,0.12); color: var(--red); }
+.badge-tan { background: rgba(196,168,120,0.15); color: #8A7350; }
+.badge-ink { background: rgba(12,10,8,0.06); color: var(--ink-2); }
+
+/* intent badge */
+.intent-struggling { background: rgba(181,90,76,0.10); color: var(--red); }
+.intent-trying { background: var(--amber-soft); color: var(--copper); }
+.intent-dabbling { background: rgba(12,10,8,0.06); color: var(--ink-3); }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 18px;
+  border-radius: 6px;
+  font-size: 13.5px;
+  font-weight: 500;
+  border: none;
+  transition: opacity 0.15s, background 0.15s;
+}
+.btn:hover { opacity: 0.85; }
+.btn-primary { background: var(--ink); color: #fff; }
+.btn-amber { background: var(--amber); color: #fff; }
+.btn-outline { background: transparent; border: 1px solid var(--rule); color: var(--ink-2); }
+.btn-ghost { background: transparent; color: var(--ink-3); }
+.btn:disabled { opacity: 0.38; cursor: not-allowed; }
+
+.divider { border: none; border-top: 1px solid var(--rule); margin: 20px 0; }
+
+/* heat dot */
+.heat-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.heat-hot { background: var(--copper); }
+.heat-warm { background: var(--amber); }
+.heat-cool { background: var(--tan); }
+
+/* score badge */
+.score-badge {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 500;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.score-hot { background: rgba(196,106,62,0.12); color: var(--copper); border: 1.5px solid var(--copper); }
+.score-warm { background: var(--amber-soft); color: var(--amber); border: 1.5px solid var(--amber); }
+.score-cool { background: rgba(196,168,120,0.12); color: var(--tan); border: 1.5px solid var(--tan); }
+.score-cold { background: rgba(12,10,8,0.06); color: var(--ink-3); border: 1.5px solid rgba(12,10,8,0.1); }
+
+/* progress bar */
+.progress-wrap { background: var(--rule); border-radius: 99px; overflow: hidden; }
+.progress-bar { height: 100%; border-radius: 99px; transition: width 0.6s ease; }
+
+/* grid helpers */
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+.grid-4 { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 16px; }
+
+/* ─── HOME PAGE ──────────────────────────────────────────────────── */
+.schedule-hero {
+  background: var(--ink);
+  border-radius: 12px;
+  padding: 28px 32px;
+  color: #fff;
+  margin-bottom: 28px;
+  display: flex;
+  align-items: flex-start;
+  gap: 40px;
+}
+.schedule-hero-left { flex: 1; }
+.schedule-campaign-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 22px;
+  font-weight: 700;
+  color: #fff;
+  margin-bottom: 4px;
+}
+.schedule-area {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: rgba(255,255,255,0.45);
+  margin-bottom: 20px;
+}
+.schedule-progress-track {
+  background: rgba(255,255,255,0.1);
+  border-radius: 99px;
+  height: 6px;
+  margin-bottom: 8px;
+}
+.schedule-progress-fill {
+  height: 6px;
+  border-radius: 99px;
+  background: var(--amber);
+}
+.schedule-days {
+  display: flex;
+  justify-content: space-between;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: rgba(255,255,255,0.35);
+}
+.schedule-stats {
+  display: flex;
+  gap: 32px;
+}
+.schedule-stat-val {
+  font-family: 'Playfair Display', serif;
+  font-size: 28px;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1;
+  margin-bottom: 4px;
+}
+.schedule-stat-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: rgba(255,255,255,0.4);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.metric-card { text-align: left; }
+.metric-val {
+  font-family: 'Playfair Display', serif;
+  font-size: 30px;
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1;
+  margin-bottom: 4px;
+}
+.metric-label { font-size: 12px; color: var(--ink-3); margin-bottom: 6px; }
+.metric-delta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.delta-up { color: var(--green); }
+.delta-down { color: var(--red); }
+
+.reply-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--rule);
+  cursor: pointer;
+  transition: background 0.1s;
+  margin: 0 -4px;
+  padding-left: 4px;
+  border-radius: 6px;
+}
+.reply-item:last-child { border-bottom: none; }
+.reply-item:hover { background: var(--surface); }
+.reply-meta { flex: 1; min-width: 0; }
+.reply-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 2px;
+}
+.reply-snippet {
+  font-size: 13px;
+  color: var(--ink-3);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.reply-biz { font-size: 11px; color: var(--ink-3); font-family: 'JetBrains Mono', monospace; margin-bottom: 3px; }
+.reply-time { font-size: 11px; color: var(--ink-3); white-space: nowrap; font-family: 'JetBrains Mono', monospace; }
+
+.meeting-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.meeting-item:last-child { border-bottom: none; }
+.meeting-date-pill {
+  background: var(--amber-soft);
+  color: var(--copper);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 4px 8px;
+  border-radius: 4px;
+  text-align: center;
+  min-width: 52px;
+  line-height: 1.4;
+}
+.meeting-name { font-size: 14px; font-weight: 500; color: var(--ink); }
+.meeting-biz { font-size: 12px; color: var(--ink-3); }
+
+.outreach-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+}
+.outreach-channel {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ink-2);
+  width: 72px;
+  flex-shrink: 0;
+}
+.outreach-bar-wrap { flex: 1; }
+.outreach-count {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ink-3);
+  white-space: nowrap;
+}
+
+.health-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.health-item:last-child { border-bottom: none; }
+.status-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.status-green { background: var(--green); }
+.status-amber { background: var(--amber); }
+.status-red { background: var(--red); }
+.health-name { flex: 1; font-size: 13px; color: var(--ink-2); }
+.health-status { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
+
+/* ─── PIPELINE ───────────────────────────────────────────────────── */
+.review-banner {
+  background: var(--amber-soft);
+  border: 1px solid rgba(212,149,106,0.3);
+  border-radius: 8px;
+  padding: 14px 18px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.review-banner-text { flex: 1; font-size: 13.5px; color: var(--ink-2); }
+.review-banner-text strong { color: var(--copper); }
+
+.filter-chips {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.chip {
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 12.5px;
+  font-weight: 500;
+  border: 1px solid var(--rule);
+  background: #fff;
+  color: var(--ink-3);
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: 'JetBrains Mono', monospace;
+}
+.chip:hover { border-color: var(--amber); color: var(--copper); }
+.chip.active { background: var(--ink); border-color: var(--ink); color: #fff; }
+
+/* pipeline row */
+.pipeline-row {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: box-shadow 0.15s, border-color 0.15s;
+  overflow: hidden;
+}
+.pipeline-row:hover { border-color: var(--amber); box-shadow: 0 2px 12px rgba(212,149,106,0.1); }
+
+.intent-bar {
+  width: 3px;
+  align-self: stretch;
+  flex-shrink: 0;
+}
+.intent-bar-struggling { background: var(--red); }
+.intent-bar-trying { background: var(--amber); }
+.intent-bar-dabbling { background: var(--tan); }
+
+.pipeline-rank {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--ink-3);
+  width: 36px;
+  text-align: center;
+  flex-shrink: 0;
+}
+.pipeline-main { flex: 1; padding: 14px 12px; min-width: 0; }
+.pipeline-biz-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 3px;
+}
+.pipeline-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.pipeline-suburb { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
+.pipeline-dm { font-size: 12.5px; color: var(--ink-3); width: 160px; flex-shrink: 0; padding: 14px 0; }
+.pipeline-channels { display: flex; gap: 6px; align-items: center; padding: 14px 16px; flex-shrink: 0; }
+.channel-dot {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  background: var(--surface);
+  color: var(--ink-3);
+  font-family: 'JetBrains Mono', monospace;
+}
+.pipeline-score-wrap { padding: 14px 16px; flex-shrink: 0; }
+.pipeline-caret {
+  padding: 14px 16px;
+  color: var(--ink-3);
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+/* ─── PIPELINE DETAIL ───────────────────────────────────────────── */
+.detail-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink-3);
+  font-size: 13px;
+  margin-bottom: 20px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.detail-back:hover { color: var(--ink); }
+
+.detail-nav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 28px;
+}
+.detail-nav-btn {
+  background: #fff;
+  border: 1px solid var(--rule);
+  color: var(--ink-2);
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 6px 14px;
+  border-radius: 5px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.detail-nav-btn:hover { border-color: var(--amber); }
+.detail-nav-sep { color: var(--ink-3); font-family: 'JetBrains Mono', monospace; font-size: 11px; }
+
+.detail-headline {
+  font-family: 'Playfair Display', serif;
+  font-size: 44px;
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin-bottom: 10px;
+}
+.detail-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+.detail-meta-item { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-3); }
+.detail-meta-dot { color: var(--rule); }
+.detail-actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 32px;
+}
+
+.score-card {
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  padding: 20px;
+  text-align: center;
+}
+.score-card-val {
+  font-family: 'Playfair Display', serif;
+  font-size: 36px;
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1;
+  margin-bottom: 4px;
+}
+.score-card-label { font-size: 12px; color: var(--ink-3); margin-bottom: 2px; }
+.score-card-sub { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); }
+
+.signal-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.signal-item:last-child { border-bottom: none; }
+.signal-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--amber); margin-top: 5px; flex-shrink: 0; }
+.signal-text { flex: 1; font-size: 13.5px; color: var(--ink-2); }
+.signal-time { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); white-space: nowrap; }
+
+.vuln-para {
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--ink-2);
+  font-style: italic;
+  padding: 18px;
+  background: var(--amber-soft);
+  border-radius: 8px;
+  border-left: 3px solid var(--amber);
+  margin-bottom: 20px;
+}
+
+.grade-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+.grade-cell {
+  background: var(--surface);
+  border-radius: 8px;
+  padding: 14px;
+  text-align: center;
+}
+.grade-letter {
+  font-family: 'Playfair Display', serif;
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 4px;
+  line-height: 1;
+}
+.grade-A { color: var(--green); }
+.grade-B { color: #5A8A74; }
+.grade-C { color: var(--amber); }
+.grade-D { color: var(--copper); }
+.grade-F { color: var(--red); }
+.grade-name { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.1em; }
+
+/* outreach tabs */
+.tab-bar {
+  display: flex;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 20px;
+}
+.tab-btn {
+  padding: 10px 18px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-3);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.tab-btn:hover { color: var(--ink); }
+.tab-btn.active { color: var(--amber); border-bottom-color: var(--amber); }
+.tab-content { display: none; }
+.tab-content.active { display: block; }
+
+.draft-content {
+  background: var(--surface);
+  border-radius: 8px;
+  padding: 18px;
+  font-size: 13.5px;
+  line-height: 1.7;
+  color: var(--ink-2);
+  white-space: pre-wrap;
+}
+.draft-label { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.1em; }
+
+/* DM card */
+.dm-card { margin-bottom: 16px; }
+.dm-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 2px;
+}
+.dm-title { font-size: 12px; color: var(--ink-3); margin-bottom: 14px; font-family: 'JetBrains Mono', monospace; }
+.dm-field { display: flex; align-items: center; gap: 8px; padding: 8px 0; border-bottom: 1px solid var(--rule); }
+.dm-field:last-child { border-bottom: none; }
+.dm-field-label { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); width: 56px; text-transform: uppercase; letter-spacing: 0.1em; flex-shrink: 0; }
+.dm-field-val { font-size: 13px; color: var(--ink-2); flex: 1; }
+.dm-verified { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--green); background: rgba(107,142,90,0.1); padding: 2px 7px; border-radius: 3px; }
+
+.timeline-item { display: flex; gap: 10px; padding: 10px 0; border-bottom: 1px solid var(--rule); }
+.timeline-item:last-child { border-bottom: none; }
+.timeline-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--amber); margin-top: 5px; flex-shrink: 0; }
+.timeline-text { font-size: 13px; color: var(--ink-2); }
+.timeline-time { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
+
+/* ─── CAMPAIGNS ──────────────────────────────────────────────────── */
+.campaign-card {
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  padding: 22px 24px;
+  margin-bottom: 14px;
+}
+.campaign-card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+.campaign-card-main { flex: 1; }
+.campaign-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 3px;
+}
+.campaign-area { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
+.campaign-metrics { display: flex; gap: 28px; margin-top: 16px; }
+.campaign-metric-val { font-family: 'Playfair Display', serif; font-size: 22px; font-weight: 700; color: var(--ink); margin-bottom: 1px; }
+.campaign-metric-label { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.08em; }
+
+/* modal */
+.modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(12,10,8,0.45);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 200;
+  opacity: 0; pointer-events: none;
+  transition: opacity 0.2s;
+}
+.modal-overlay.open { opacity: 1; pointer-events: all; }
+.modal {
+  background: #fff;
+  border-radius: 12px;
+  padding: 32px;
+  width: 100%;
+  max-width: 480px;
+  margin: 20px;
+  transform: translateY(12px);
+  transition: transform 0.2s;
+}
+.modal-overlay.open .modal { transform: translateY(0); }
+.modal-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 20px;
+}
+.form-field { margin-bottom: 18px; }
+.form-label { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 6px; }
+.form-select, .form-input {
+  width: 100%;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  padding: 9px 12px;
+  font-size: 14px;
+  color: var(--ink);
+  background: #fff;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.form-select:focus, .form-input:focus { border-color: var(--amber); }
+.radio-group { display: flex; gap: 12px; flex-wrap: wrap; }
+.radio-item { display: flex; align-items: center; gap: 6px; cursor: pointer; }
+.radio-item input[type="radio"] { accent-color: var(--amber); }
+.form-helper { font-size: 12px; color: var(--ink-3); margin-top: 5px; line-height: 1.5; }
+.modal-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 24px; }
+
+/* ─── INBOX ──────────────────────────────────────────────────────── */
+.inbox-layout { display: flex; gap: 0; height: calc(100vh - var(--topbar-h) - 80px); min-height: 500px; }
+.inbox-list {
+  width: 400px;
+  min-width: 400px;
+  border-right: 1px solid var(--rule);
+  overflow-y: auto;
+  background: #fff;
+  border-radius: 10px 0 0 10px;
+  border: 1px solid var(--rule);
+}
+.inbox-thread {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-left: none;
+  border-radius: 0 10px 10px 0;
+}
+.inbox-list-header { padding: 16px 18px; border-bottom: 1px solid var(--rule); }
+.inbox-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--rule);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.inbox-item:hover { background: var(--surface); }
+.inbox-item.active { background: var(--amber-soft); }
+.inbox-item-meta { flex: 1; min-width: 0; }
+.inbox-item-name { font-weight: 500; font-size: 14px; color: var(--ink); margin-bottom: 1px; }
+.inbox-item-biz { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); margin-bottom: 3px; }
+.inbox-item-snippet { font-size: 12.5px; color: var(--ink-3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.inbox-item-time { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); white-space: nowrap; }
+
+.thread-header {
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.thread-name { font-family: 'Playfair Display', serif; font-size: 18px; font-weight: 700; color: var(--ink); }
+.thread-biz { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
+.thread-body { flex: 1; overflow-y: auto; padding: 20px 24px; display: flex; flex-direction: column; gap: 14px; }
+.bubble { max-width: 75%; padding: 12px 16px; border-radius: 12px; line-height: 1.6; font-size: 13.5px; }
+.bubble-theirs { background: var(--ink); color: #fff; border-radius: 12px 12px 12px 2px; align-self: flex-start; }
+.bubble-ours { background: var(--surface); color: var(--ink-2); border-radius: 12px 12px 2px 12px; align-self: flex-end; }
+.bubble-time { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); margin-top: 4px; }
+.bubble-time-left { text-align: left; }
+.bubble-time-right { text-align: right; }
+.thread-actions {
+  padding: 14px 24px;
+  border-top: 1px solid var(--rule);
+  display: flex;
+  gap: 8px;
+}
+
+/* ─── SEQUENCES ──────────────────────────────────────────────────── */
+.channel-rate-card {
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  padding: 20px;
+}
+.channel-rate-name { font-size: 15px; font-weight: 500; color: var(--ink); margin-bottom: 4px; }
+.channel-rate-val {
+  font-family: 'Playfair Display', serif;
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 8px;
+}
+.channel-rate-detail { font-size: 12px; color: var(--ink-3); margin-bottom: 12px; }
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  margin-top: 16px;
+}
+.cal-header-cell {
+  text-align: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-3);
+  padding: 6px 0;
+  letter-spacing: 0.08em;
+}
+.cal-cell {
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 5px;
+  padding: 6px;
+  min-height: 68px;
+  position: relative;
+}
+.cal-date-num {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-3);
+  margin-bottom: 4px;
+}
+.cal-today { background: var(--amber-soft); border-color: var(--amber); }
+.cal-today .cal-date-num { color: var(--copper); font-weight: 500; }
+.cal-pill {
+  font-size: 9px;
+  font-family: 'JetBrains Mono', monospace;
+  padding: 2px 5px;
+  border-radius: 3px;
+  margin-bottom: 2px;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cal-email { background: rgba(107,142,90,0.15); color: var(--green); }
+.cal-linkedin { background: rgba(59,130,246,0.1); color: #3B82F6; }
+.cal-voice { background: var(--amber-soft); color: var(--copper); }
+.cal-sms { background: rgba(139,92,246,0.1); color: #8B5CF6; }
+
+.legend-row { display: flex; gap: 20px; flex-wrap: wrap; margin-top: 12px; }
+.legend-item { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--ink-3); }
+.legend-dot { width: 10px; height: 10px; border-radius: 2px; }
+
+/* ─── SIGNALS ────────────────────────────────────────────────────── */
+.signal-card {
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  padding: 22px 24px;
+}
+.signal-card-header { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+.signal-card-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--ink);
+  flex: 1;
+}
+.signal-toggle {
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  background: var(--green);
+  position: relative;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+.signal-toggle.off { background: var(--rule); }
+.signal-toggle::after {
+  content: '';
+  position: absolute;
+  width: 14px; height: 14px;
+  background: #fff;
+  border-radius: 50%;
+  top: 3px; left: 3px;
+  transition: left 0.15s;
+}
+.signal-toggle.off::after { left: 19px; }
+.signal-card-desc { font-size: 13px; color: var(--ink-3); line-height: 1.6; margin-bottom: 12px; }
+.signal-card-stat { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--copper); }
+
+/* ─── REPORTS ────────────────────────────────────────────────────── */
+.kpi-card {
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  padding: 22px;
+}
+.kpi-val {
+  font-family: 'Playfair Display', serif;
+  font-size: 34px;
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1;
+  margin-bottom: 4px;
+}
+.kpi-label { font-size: 12px; color: var(--ink-3); margin-bottom: 6px; }
+
+.funnel-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.funnel-row:last-child { border-bottom: none; }
+.funnel-label { font-size: 13px; color: var(--ink-2); width: 120px; flex-shrink: 0; }
+.funnel-bar-wrap { flex: 1; background: var(--rule); border-radius: 99px; height: 10px; overflow: hidden; }
+.funnel-bar { height: 10px; border-radius: 99px; background: var(--amber); }
+.funnel-pct { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-3); width: 48px; text-align: right; }
+.funnel-count { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-2); width: 52px; text-align: right; }
+
+.report-table { width: 100%; border-collapse: collapse; }
+.report-table th {
+  text-align: left;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--rule);
+}
+.report-table td { padding: 12px 12px; border-bottom: 1px solid var(--rule); font-size: 13.5px; color: var(--ink-2); }
+.report-table tr:last-child td { border-bottom: none; }
+.report-table tr:hover td { background: var(--surface); }
+
+/* ─── SETTINGS ───────────────────────────────────────────────────── */
+.settings-layout { display: flex; gap: 0; }
+.settings-nav {
+  width: 192px;
+  min-width: 192px;
+  padding: 0 0 20px;
+}
+.settings-nav-item {
+  padding: 9px 14px;
+  font-size: 13.5px;
+  color: var(--ink-3);
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.1s, color 0.1s;
+  font-weight: 400;
+  margin-bottom: 2px;
+}
+.settings-nav-item:hover { background: var(--surface); color: var(--ink); }
+.settings-nav-item.active { background: var(--amber-soft); color: var(--copper); font-weight: 500; }
+.settings-content { flex: 1; padding-left: 28px; }
+.settings-section { display: none; }
+.settings-section.active { display: block; }
+.settings-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.settings-row:last-child { border-bottom: none; }
+.settings-row-label { width: 180px; flex-shrink: 0; }
+.settings-row-key { font-size: 13.5px; font-weight: 500; color: var(--ink); margin-bottom: 2px; }
+.settings-row-sub { font-size: 12px; color: var(--ink-3); }
+.settings-row-val { flex: 1; font-size: 13.5px; color: var(--ink-2); }
+.settings-row-action { flex-shrink: 0; }
+
+.integration-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.integration-row:last-child { border-bottom: none; }
+.integration-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: var(--surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  flex-shrink: 0;
+}
+.integration-name { flex: 1; font-weight: 500; font-size: 14px; color: var(--ink); }
+.integration-desc { font-size: 12px; color: var(--ink-3); }
+.badge-connected { background: rgba(107,142,90,0.12); color: var(--green); }
+
+.danger-zone { border: 1px solid rgba(181,90,76,0.2); border-radius: 10px; padding: 24px; }
+.danger-zone-title { font-family: 'Playfair Display', serif; font-size: 18px; font-weight: 700; color: var(--red); margin-bottom: 16px; }
+.danger-row { display: flex; align-items: center; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--rule); }
+.danger-row:last-child { border-bottom: none; }
+.danger-row-info { flex: 1; }
+.danger-row-title { font-size: 14px; font-weight: 500; color: var(--ink); }
+.danger-row-sub { font-size: 12px; color: var(--ink-3); }
+.btn-danger { background: transparent; border: 1px solid var(--red); color: var(--red); font-size: 13px; padding: 7px 16px; border-radius: 5px; font-weight: 500; transition: background 0.15s; }
+.btn-danger:hover { background: rgba(181,90,76,0.08); }
+
+/* ─── MOBILE ─────────────────────────────────────────────────────── */
+#mobile-topbar {
+  display: none;
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: 52px;
+  background: var(--ink);
+  z-index: 120;
+  align-items: center;
+  padding: 0 16px;
+  gap: 12px;
+}
+.hamburger-btn {
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 20px;
+  line-height: 1;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+}
+.mobile-logo { font-family: 'Playfair Display', serif; font-size: 18px; color: #fff; }
+.mobile-logo em { color: var(--amber); font-style: italic; }
+
+#bottom-nav {
+  display: none;
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  height: 56px;
+  background: var(--ink);
+  border-top: 1px solid rgba(255,255,255,0.08);
+  z-index: 120;
+  align-items: stretch;
+}
+.bottom-nav-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  color: rgba(255,255,255,0.4);
+  font-size: 9px;
+  font-family: 'JetBrains Mono', monospace;
+  cursor: pointer;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: color 0.15s;
+}
+.bottom-nav-item.active { color: var(--amber); }
+.bottom-nav-icon { font-size: 16px; line-height: 1; }
+
+@media (max-width: 768px) {
+  #sidebar { transform: translateX(-100%); transition: transform 0.25s; }
+  #sidebar.mobile-open { transform: translateX(0); }
+  #mobile-topbar { display: flex; }
+  #bottom-nav { display: flex; }
+  #app { margin-left: 0; padding-top: 52px; padding-bottom: 56px; }
+  #topbar { display: none; }
+  #page { padding: 20px 16px 40px; }
+  .grid-4 { grid-template-columns: 1fr 1fr; }
+  .grid-3 { grid-template-columns: 1fr 1fr; }
+  .grid-2 { grid-template-columns: 1fr; }
+  .schedule-hero { flex-direction: column; gap: 20px; }
+  .schedule-stats { flex-wrap: wrap; gap: 16px; }
+  .detail-headline { font-size: 28px; }
+  .page-headline { font-size: 28px; }
+  .inbox-layout { flex-direction: column; height: auto; }
+  .inbox-list { width: 100%; min-width: unset; border-radius: 10px 10px 0 0; }
+  .inbox-thread { border-left: 1px solid var(--rule); border-radius: 0 0 10px 10px; }
+  .settings-layout { flex-direction: column; }
+  .settings-nav { width: 100%; display: flex; flex-wrap: wrap; gap: 6px; padding-bottom: 12px; border-bottom: 1px solid var(--rule); margin-bottom: 16px; }
+  .settings-content { padding-left: 0; }
+  .grade-grid { grid-template-columns: repeat(2, 1fr); }
+  .pipeline-dm { display: none; }
+  .pipeline-channels { display: none; }
+  .calendar-grid { gap: 2px; }
+  .cal-cell { min-height: 44px; }
+}
+
+/* ─── DETAIL TWO-COL LAYOUT ──────────────────────────────────────── */
+.detail-layout { display: grid; grid-template-columns: 1fr 320px; gap: 24px; }
+@media (max-width: 960px) { .detail-layout { grid-template-columns: 1fr; } }
+
+/* ─── SIDEBAR OVERLAY ────────────────────────────────────────────── */
+#sidebar-overlay {
+  display: none;
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 99;
+}
+#sidebar-overlay.show { display: block; }
+</style>
+</head>
+<body>
+
+<!-- ─── SIDEBAR ─── -->
+<nav id="sidebar">
+  <div class="sidebar-logo">
+    <div class="logo-text">Agency<em>OS</em></div>
+  </div>
+
+  <div class="sidebar-section">
+    <div class="sidebar-section-label">Workspace</div>
+    <div class="nav-item" data-route="#home" onclick="navigate('#home')">
+      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1L1 7v8h5v-5h4v5h5V7L8 1z"/></svg>
+      Dashboard
+    </div>
+    <div class="nav-item" data-route="#pipeline" onclick="navigate('#pipeline')">
+      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/><rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/></svg>
+      Pipeline
+      <span class="nav-badge">10</span>
+    </div>
+    <div class="nav-item" data-route="#inbox" onclick="navigate('#inbox')">
+      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M2 4a2 2 0 012-2h8a2 2 0 012 2v6a2 2 0 01-2 2H2.5L1 14V4z"/></svg>
+      Inbox
+      <span class="nav-badge">23</span>
+    </div>
+    <div class="nav-item" data-route="#campaigns" onclick="navigate('#campaigns')">
+      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M14 2L2 7l4 2 2 4 3-4 3 2z"/></svg>
+      Campaigns
+    </div>
+    <div class="nav-item" data-route="#sequences" onclick="navigate('#sequences')">
+      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><circle cx="3" cy="3" r="2"/><circle cx="3" cy="8" r="2"/><circle cx="3" cy="13" r="2"/><line x1="5" y1="3" x2="14" y2="3" stroke="currentColor" stroke-width="1.5"/><line x1="5" y1="8" x2="14" y2="8" stroke="currentColor" stroke-width="1.5"/><line x1="5" y1="13" x2="14" y2="13" stroke="currentColor" stroke-width="1.5"/></svg>
+      Sequences
+    </div>
+  </div>
+
+  <div class="sidebar-section">
+    <div class="sidebar-section-label">Intelligence</div>
+    <div class="nav-item" data-route="#signals" onclick="navigate('#signals')">
+      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1a1 1 0 00-1 1v2.5a1 1 0 002 0V2a1 1 0 00-1-1zm4.24 2.76a1 1 0 00-1.41 1.41A4 4 0 0112 8a4 4 0 01-1.17 2.83 1 1 0 001.41 1.41A6 6 0 0014 8a6 6 0 00-1.76-4.24zM3.76 3.76A6 6 0 002 8a6 6 0 001.76 4.24 1 1 0 001.41-1.41A4 4 0 014 8a4 4 0 011.17-2.83 1 1 0 00-1.41-1.41z"/></svg>
+      Signals
+    </div>
+    <div class="nav-item" data-route="#reports" onclick="navigate('#reports')">
+      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="10" width="3" height="5" rx="1"/><rect x="6" y="6" width="3" height="9" rx="1"/><rect x="11" y="3" width="3" height="12" rx="1"/></svg>
+      Reports
+    </div>
+  </div>
+
+  <div class="sidebar-section">
+    <div class="sidebar-section-label">Account</div>
+    <div class="nav-item" data-route="#settings" onclick="navigate('#settings')">
+      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 5a3 3 0 100 6A3 3 0 008 5zm0 1.5a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm6.5 1l-1.2-.4a5.5 5.5 0 00-.3-.7l.6-1.1-1.4-1.4-1.1.6a5.5 5.5 0 00-.7-.3L10 2.5H6l-.4 1.2a5.5 5.5 0 00-.7.3l-1.1-.6L2.4 4.8l.6 1.1a5.5 5.5 0 00-.3.7L1.5 7v2l1.2.4c.1.2.2.5.3.7l-.6 1.1 1.4 1.4 1.1-.6c.2.1.5.2.7.3L6 13.5h4l.4-1.2c.2-.1.5-.2.7-.3l1.1.6 1.4-1.4-.6-1.1c.1-.2.2-.5.3-.7l1.2-.4V7z"/></svg>
+      Settings
+    </div>
+  </div>
+
+  <div class="sidebar-footer">
+    <div class="avatar-circle">DS</div>
+    <div>
+      <div class="sidebar-user-name">David Stephens</div>
+      <div class="sidebar-user-sub">Ignition · Sydney</div>
+    </div>
+  </div>
+</nav>
+
+<div id="sidebar-overlay" onclick="closeMobileSidebar()"></div>
+
+<!-- ─── MOBILE TOPBAR ─── -->
+<div id="mobile-topbar">
+  <button class="hamburger-btn" onclick="toggleMobileSidebar()">☰</button>
+  <div class="mobile-logo">Agency<em>OS</em></div>
+  <div style="margin-left:auto;display:flex;align-items:center;gap:10px;">
+    <span class="pulse-dot"></span>
+    <button class="kill-btn" style="font-size:10px;padding:4px 10px;">Kill</button>
+  </div>
+</div>
+
+<!-- ─── MAIN APP ─── -->
+<div id="app">
+
+  <!-- TOPBAR -->
+  <div id="topbar">
+    <div class="breadcrumb" id="breadcrumb">
+      <span>AgencyOS</span>
+      <span class="crumb-sep">›</span>
+      <span class="crumb-current">Dashboard</span>
+    </div>
+    <div class="topbar-right">
+      <div class="pulse-row">
+        <div class="pulse-dot"></div>
+        <span>Day 14 of 30</span>
+      </div>
+      <button class="kill-btn" onclick="alert('Kill switch engaged — confirm?')">Kill Switch</button>
+    </div>
+  </div>
+
+  <!-- PAGE CONTENT -->
+  <div id="page"></div>
+
+</div>
+
+<!-- ─── BOTTOM NAV (mobile) ─── -->
+<div id="bottom-nav">
+  <div class="bottom-nav-item" onclick="navigate('#home')">
+    <div class="bottom-nav-icon">⌂</div>
+    <span>Home</span>
+  </div>
+  <div class="bottom-nav-item" onclick="navigate('#pipeline')">
+    <div class="bottom-nav-icon">⊞</div>
+    <span>Pipeline</span>
+  </div>
+  <div class="bottom-nav-item" onclick="navigate('#inbox')">
+    <div class="bottom-nav-icon">✉</div>
+    <span>Inbox</span>
+  </div>
+  <div class="bottom-nav-item" onclick="navigate('#campaigns')">
+    <div class="bottom-nav-icon">⊡</div>
+    <span>Campaigns</span>
+  </div>
+  <div class="bottom-nav-item" onclick="navigate('#signals')">
+    <div class="bottom-nav-icon">◉</div>
+    <span>Signals</span>
+  </div>
+</div>
+
+<!-- ─── CAMPAIGN MODAL ─── -->
+<div class="modal-overlay" id="campaignModal" onclick="closeModalOutside(event)">
+  <div class="modal">
+    <div class="modal-title">New Campaign</div>
+    <div class="form-field">
+      <div class="form-label">Service</div>
+      <select class="form-select">
+        <option>SEO Services</option>
+        <option>Google Ads Management</option>
+        <option>Web Design</option>
+        <option>Content Marketing</option>
+        <option>Social Media Management</option>
+        <option>Email Marketing</option>
+      </select>
+    </div>
+    <div class="form-field">
+      <div class="form-label">Service Area</div>
+      <div class="radio-group">
+        <label class="radio-item"><input type="radio" name="area" value="metro" checked> Metro</label>
+        <label class="radio-item"><input type="radio" name="area" value="state"> State</label>
+        <label class="radio-item"><input type="radio" name="area" value="national"> National</label>
+      </div>
+      <div class="form-helper">Metro targets businesses within 50km of a capital city CBD. State covers all businesses in a single state. National runs across all Australian states.</div>
+    </div>
+    <div class="form-field">
+      <div class="form-label">Target City</div>
+      <select class="form-select">
+        <option>Sydney</option>
+        <option>Melbourne</option>
+        <option>Brisbane</option>
+        <option>Perth</option>
+        <option>Adelaide</option>
+      </select>
+    </div>
+    <div class="modal-actions">
+      <button class="btn btn-outline" onclick="closeModal()">Cancel</button>
+      <button class="btn btn-amber">Launch Campaign</button>
+    </div>
+  </div>
+</div>
+
+<!-- ─── SCRIPT ─── -->
+<script>
+/* ═══════════════════════════════════════════════════════════════════
+   MOCK DATA
+═══════════════════════════════════════════════════════════════════ */
+const prospects = [
+  {
+    id: 'p1', name: 'Momentum Constructions', suburb: 'Brunswick', state: 'VIC',
+    industry: 'Construction', intent: 'struggling', score: 91, staff: '45',
+    est: '2008', revenue: '$8.2M', dm: { name: 'Marcus Chen', title: 'Managing Director',
+    email: 'm.chen@momentumconstructions.com.au', phone: '+61 412 XXX XXX', linkedin: 'Verified' },
+    signals: [
+      { text: 'Active Google Ads spend detected ($2,400/mo)', time: '2 days ago' },
+      { text: 'GMB rating dropped from 4.6 to 4.1 in 90 days (7 negative reviews)', time: '5 days ago' },
+      { text: 'Website last updated 2019 — no SSL, no mobile responsive', time: '1 week ago' },
+      { text: 'Competitor "BuildRight" running ads on their brand terms', time: '3 days ago' },
+    ],
+    affordability: 8, intentScore: 16, composite: 91,
+    vulnerability: 'Momentum Constructions is spending $2,400/month on Google Ads but their website converts poorly — no SSL certificate, not mobile responsive, and last updated in 2019. Their GMB rating has dropped from 4.6 to 4.1 with 7 negative reviews in 90 days. A competitor is actively bidding on their brand terms. They have budget and intent but are leaking value at every touchpoint.',
+    vulnGrades: { website: 'F', seo: 'D', reviews: 'D', ads: 'C', social: 'B', content: 'F' },
+  },
+  {
+    id: 'p2', name: 'Harbour Physiotherapy', suburb: 'Manly', state: 'NSW',
+    industry: 'Health', intent: 'struggling', score: 88, staff: '12',
+    est: '2015', revenue: '$1.8M', dm: { name: 'Sarah Walsh', title: 'Practice Owner',
+    email: 's.walsh@harbourphysio.com.au', phone: '+61 438 XXX XXX', linkedin: 'Verified' },
+    signals: [
+      { text: 'Google Ads paused after 6 months of continuous spend', time: '1 week ago' },
+      { text: '3 staff LinkedIn profiles updated to "Open to work"', time: '4 days ago' },
+      { text: 'Competitor opened 200m away with aggressive launch campaign', time: '2 weeks ago' },
+    ],
+    affordability: 6, intentScore: 15, composite: 88,
+    vulnerability: 'Harbour Physiotherapy paused their Google Ads after 6 months, suggesting budget pressure or poor ROI. Three staff have updated LinkedIn to "Open to work" which signals internal instability. A new competitor opened 200m away with an aggressive launch campaign — they need to defend their local market position urgently.',
+    vulnGrades: { website: 'C', seo: 'D', reviews: 'B', ads: 'F', social: 'D', content: 'D' },
+  },
+  {
+    id: 'p3', name: 'Cascade Dental Group', suburb: 'Paddington', state: 'QLD',
+    industry: 'Dental', intent: 'trying', score: 74, staff: '28',
+    est: '2012', revenue: '$4.1M', dm: { name: 'Dr James Liu', title: 'Principal Dentist',
+    email: 'j.liu@cascadedental.com.au', phone: '+61 402 XXX XXX', linkedin: 'Verified' },
+    signals: [
+      { text: 'Recently hired a marketing coordinator (LinkedIn post)', time: '1 week ago' },
+      { text: 'Website redesign detected — new template but thin content', time: '3 days ago' },
+      { text: 'Increased GMB post frequency from 0 to 3/week', time: '2 weeks ago' },
+    ],
+    affordability: 7, intentScore: 12, composite: 74,
+    vulnerability: 'Cascade Dental is actively trying — they hired a marketing coordinator and redesigned their website. But the new site has thin content and their GMB strategy is basic. They have intent and budget but lack expertise to execute effectively.',
+    vulnGrades: { website: 'C', seo: 'C', reviews: 'A', ads: 'D', social: 'C', content: 'D' },
+  },
+  {
+    id: 'p4', name: 'Coastal Veterinary', suburb: 'Byron Bay', state: 'NSW',
+    industry: 'Veterinary', intent: 'trying', score: 76, staff: '18',
+    est: '2010', revenue: '$2.9M', dm: { name: 'Dr Emma Russo', title: 'Head Veterinarian',
+    email: 'e.russo@coastalvet.com.au', phone: '+61 421 XXX XXX', linkedin: 'Verified' },
+    signals: [
+      { text: 'New Facebook ad campaign launched targeting pet owners', time: '5 days ago' },
+      { text: 'Blog section added to website but only 2 posts', time: '1 week ago' },
+      { text: 'Sponsoring local surf competition (community marketing)', time: '2 weeks ago' },
+    ],
+    affordability: 7, intentScore: 13, composite: 76,
+    vulnerability: 'Coastal Veterinary is investing in marketing but spreading thin — Facebook ads, blog content, and community sponsorship without a cohesive strategy. Their efforts show intent but lack the focus needed for ROI.',
+    vulnGrades: { website: 'B', seo: 'D', reviews: 'A', ads: 'C', social: 'B', content: 'D' },
+  },
+  {
+    id: 'p5', name: 'Riverside Accounting', suburb: 'North Sydney', state: 'NSW',
+    industry: 'Accounting', intent: 'dabbling', score: 52, staff: '8',
+    est: '2018', revenue: '$1.2M', dm: { name: 'Tom Bradley', title: 'Founder',
+    email: 't.bradley@riversideaccounting.com.au', phone: '+61 415 XXX XXX', linkedin: 'Verified' },
+    signals: [
+      { text: 'LinkedIn company page created but no posts', time: '3 weeks ago' },
+      { text: 'Google Business Profile claimed but incomplete', time: '2 weeks ago' },
+    ],
+    affordability: 5, intentScore: 8, composite: 52,
+    vulnerability: "Riverside Accounting is just starting their digital presence — LinkedIn page with no content, incomplete Google Business Profile. They know they need marketing but haven't committed resources yet.",
+    vulnGrades: { website: 'D', seo: 'F', reviews: 'C', ads: 'F', social: 'F', content: 'F' },
+  },
+];
+
+const replies = [
+  { id: 'r1', prospectId: 'p1', heat: 'hot', name: 'Marcus Chen', business: 'Momentum Constructions', snippet: "This is exactly what we need. Can we set up a call this week?", time: '2h ago', channel: 'email' },
+  { id: 'r2', prospectId: 'p2', heat: 'hot', name: 'Sarah Walsh', business: 'Harbour Physiotherapy', snippet: "Very interested. We've been struggling with our online presence.", time: '4h ago', channel: 'linkedin' },
+  { id: 'r3', prospectId: 'p3', heat: 'hot', name: 'Dr James Liu', business: 'Cascade Dental Group', snippet: "We just hired someone for this but would love a second opinion.", time: '1d ago', channel: 'email' },
+  { id: 'r4', prospectId: 'p4', heat: 'warm', name: 'Dr Emma Russo', business: 'Coastal Veterinary', snippet: "Interesting. Can you send more details about pricing?", time: '2d ago', channel: 'sms' },
+  { id: 'r5', prospectId: 'p5', heat: 'warm', name: 'Tom Bradley', business: 'Riverside Accounting', snippet: "Not sure if this is for us right now. Maybe next quarter?", time: '3d ago', channel: 'email' },
+  { id: 'r6', prospectId: 'p1', heat: 'cool', name: 'Reception', business: 'Momentum Constructions', snippet: "Marcus is away until Thursday. I'll pass this along.", time: '5d ago', channel: 'voice' },
+];
+
+const campaigns = [
+  { id: 'c1', name: 'SEO Services', area: 'Sydney Metro', status: 'active', day: 14, total: 30, contacted: 280, totalLeads: 600, replies: 23, meetings: 4 },
+  { id: 'c2', name: 'Google Ads Management', area: 'Melbourne Metro', status: 'active', day: 8, total: 30, contacted: 120, totalLeads: 600, replies: 9, meetings: 1 },
+  { id: 'c3', name: 'Web Design', area: 'Brisbane Metro', status: 'paused', day: 5, total: 30, contacted: 60, totalLeads: 600, replies: 4, meetings: 0 },
+  { id: 'c4', name: 'Content Marketing', area: 'National', status: 'draft', day: 0, total: 30, contacted: 0, totalLeads: 600, replies: 0, meetings: 0 },
+];
+
+/* ═══════════════════════════════════════════════════════════════════
+   ROUTING
+═══════════════════════════════════════════════════════════════════ */
+let activeInboxReply = 'r1';
+let activePipelineFilter = 'top10';
+let activeSettingsTab = 'account';
+let activeOutreachTab = 'email';
+
+const routes = {
+  '#home': renderHome,
+  '#pipeline': renderPipeline,
+  '#pipeline/p1': () => renderDetail('p1'),
+  '#pipeline/p2': () => renderDetail('p2'),
+  '#pipeline/p3': () => renderDetail('p3'),
+  '#pipeline/p4': () => renderDetail('p4'),
+  '#pipeline/p5': () => renderDetail('p5'),
+  '#campaigns': renderCampaigns,
+  '#inbox': renderInbox,
+  '#sequences': renderSequences,
+  '#signals': renderSignals,
+  '#reports': renderReports,
+  '#settings': renderSettings,
+};
+
+function navigate(hash) {
+  window.location.hash = hash;
+}
+
+function router() {
+  const hash = window.location.hash || '#home';
+  const render = routes[hash];
+  if (render) {
+    render();
+  } else if (hash.startsWith('#pipeline/')) {
+    const id = hash.split('/')[1];
+    renderDetail(id);
+  } else {
+    renderHome();
+  }
+  updateSidebarActive(hash);
+  updateBreadcrumb(hash);
+  updateBottomNav(hash);
+  window.scrollTo(0, 0);
+}
+
+function updateSidebarActive(hash) {
+  document.querySelectorAll('.nav-item').forEach(el => {
+    el.classList.remove('active');
+    const route = el.getAttribute('data-route');
+    if (route === hash || (hash.startsWith('#pipeline/') && route === '#pipeline')) {
+      el.classList.add('active');
+    }
+  });
+}
+
+function updateBreadcrumb(hash) {
+  const labels = {
+    '#home': 'Dashboard',
+    '#pipeline': 'Pipeline',
+    '#campaigns': 'Campaigns',
+    '#inbox': 'Inbox',
+    '#sequences': 'Sequences',
+    '#signals': 'Signals',
+    '#reports': 'Reports',
+    '#settings': 'Settings',
+  };
+  const crumb = document.getElementById('breadcrumb');
+  let current = labels[hash] || 'Pipeline';
+  if (hash.startsWith('#pipeline/')) {
+    const id = hash.split('/')[1];
+    const p = prospects.find(x => x.id === id);
+    crumb.innerHTML = `<span>AgencyOS</span><span class="crumb-sep">›</span><span onclick="navigate('#pipeline')" style="cursor:pointer;color:var(--ink-3)">Pipeline</span><span class="crumb-sep">›</span><span class="crumb-current">${p ? p.name : 'Detail'}</span>`;
+    return;
+  }
+  crumb.innerHTML = `<span>AgencyOS</span><span class="crumb-sep">›</span><span class="crumb-current">${current}</span>`;
+}
+
+function updateBottomNav(hash) {
+  const map = { '#home': 0, '#pipeline': 1, '#inbox': 2, '#campaigns': 3, '#signals': 4 };
+  const base = hash.startsWith('#pipeline/') ? '#pipeline' : hash;
+  document.querySelectorAll('.bottom-nav-item').forEach((el, i) => {
+    el.classList.toggle('active', map[base] === i);
+  });
+}
+
+window.addEventListener('hashchange', router);
+
+/* ═══════════════════════════════════════════════════════════════════
+   PAGE 1 — HOME
+═══════════════════════════════════════════════════════════════════ */
+function renderHome() {
+  const html = `
+    <h1 class="page-headline">Your acquisition engine,<br><em>running on schedule.</em></h1>
+
+    <!-- Schedule Hero -->
+    <div class="schedule-hero">
+      <div class="schedule-hero-left">
+        <div class="schedule-campaign-name">SEO Services — Sydney Metro</div>
+        <div class="schedule-area">Campaign C1 · Started 14 Apr 2026</div>
+        <div class="schedule-progress-track" style="margin-bottom:8px;">
+          <div class="schedule-progress-fill" style="width:${(14/30*100).toFixed(0)}%"></div>
+        </div>
+        <div class="schedule-days">
+          <span>Day 1</span>
+          <span>Day 14 of 30</span>
+          <span>Day 30</span>
+        </div>
+      </div>
+      <div class="schedule-stats">
+        <div>
+          <div class="schedule-stat-val">280</div>
+          <div class="schedule-stat-label">Contacted</div>
+        </div>
+        <div>
+          <div class="schedule-stat-val">23</div>
+          <div class="schedule-stat-label">Replies</div>
+        </div>
+        <div>
+          <div class="schedule-stat-val">4</div>
+          <div class="schedule-stat-label">Meetings</div>
+        </div>
+        <div>
+          <div class="schedule-stat-val">600</div>
+          <div class="schedule-stat-label">Total Leads</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Performance Metrics -->
+    <div class="section-label">Performance this campaign</div>
+    <div class="grid-4" style="margin-bottom:32px;">
+      <div class="card metric-card">
+        <div class="metric-label">Open Rate</div>
+        <div class="metric-val">47%</div>
+        <div class="metric-delta delta-up">↑ 3% vs prev campaign</div>
+      </div>
+      <div class="card metric-card">
+        <div class="metric-label">Reply Rate</div>
+        <div class="metric-val">8.2%</div>
+        <div class="metric-delta delta-up">↑ 1.1% vs prev campaign</div>
+      </div>
+      <div class="card metric-card">
+        <div class="metric-label">Meeting Rate</div>
+        <div class="metric-val">1.4%</div>
+        <div class="metric-delta" style="color:var(--ink-3);">— consistent</div>
+      </div>
+      <div class="card metric-card">
+        <div class="metric-label">Avg Reply Time</div>
+        <div class="metric-val">23h</div>
+        <div class="metric-delta delta-down" style="color:var(--green);">↓ 4h improvement</div>
+      </div>
+    </div>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:24px;margin-bottom:32px;" class="home-grid">
+      <!-- Hot Replies -->
+      <div class="card" style="grid-column:span 1;">
+        <div class="section-label">Hot replies</div>
+        ${replies.filter(r => r.heat === 'hot').slice(0,4).map(r => `
+          <div class="reply-item" onclick="navigate('#inbox')">
+            <div class="heat-dot heat-${r.heat}" style="margin-top:5px;"></div>
+            <div class="reply-meta">
+              <div class="reply-biz">${r.business}</div>
+              <div class="reply-name">${r.name}</div>
+              <div class="reply-snippet">"${r.snippet}"</div>
+            </div>
+            <div class="reply-time">${r.time}</div>
+          </div>
+        `).join('')}
+      </div>
+
+      <!-- Meetings Booked -->
+      <div class="card">
+        <div class="section-label">Meetings booked</div>
+        <div class="meeting-item">
+          <div class="meeting-date-pill">APR<br>14</div>
+          <div>
+            <div class="meeting-name">Marcus Chen</div>
+            <div class="meeting-biz">Momentum Constructions</div>
+          </div>
+        </div>
+        <div class="meeting-item">
+          <div class="meeting-date-pill">APR<br>15</div>
+          <div>
+            <div class="meeting-name">Sarah Walsh</div>
+            <div class="meeting-biz">Harbour Physiotherapy</div>
+          </div>
+        </div>
+        <div class="meeting-item">
+          <div class="meeting-date-pill">APR<br>17</div>
+          <div>
+            <div class="meeting-name">Dr James Liu</div>
+            <div class="meeting-biz">Cascade Dental Group</div>
+          </div>
+        </div>
+        <div class="meeting-item">
+          <div class="meeting-date-pill">APR<br>21</div>
+          <div>
+            <div class="meeting-name">Dr Emma Russo</div>
+            <div class="meeting-biz">Coastal Veterinary</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- System Health -->
+      <div class="card">
+        <div class="section-label">System health</div>
+        ${[
+          { name: 'Email Delivery', status: 'Operational', dot: 'green' },
+          { name: 'LinkedIn Queue', status: 'Operational', dot: 'green' },
+          { name: 'Voice AI', status: 'Operational', dot: 'green' },
+          { name: 'SMS Gateway', status: 'Degraded', dot: 'amber' },
+          { name: 'Data Enrichment', status: 'Operational', dot: 'green' },
+          { name: 'Prospect Pipeline', status: 'Operational', dot: 'green' },
+        ].map(h => `
+          <div class="health-item">
+            <div class="status-dot status-${h.dot}"></div>
+            <div class="health-name">${h.name}</div>
+            <div class="health-status">${h.status}</div>
+          </div>
+        `).join('')}
+      </div>
+    </div>
+
+    <!-- Today's Outreach -->
+    <div class="card">
+      <div class="section-label">Today's outreach — 43 of 105 completed</div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px 40px;">
+        ${[
+          { ch: 'Email', done: 18, total: 50, color: '#6B8E5A' },
+          { ch: 'LinkedIn', done: 12, total: 20, color: '#3B82F6' },
+          { ch: 'Voice AI', done: 5, total: 10, color: '#D4956A' },
+          { ch: 'SMS', done: 8, total: 25, color: '#8B5CF6' },
+        ].map(o => `
+          <div class="outreach-row">
+            <div class="outreach-channel">${o.ch}</div>
+            <div class="outreach-bar-wrap">
+              <div class="progress-wrap" style="height:6px;">
+                <div class="progress-bar" style="width:${(o.done/o.total*100).toFixed(0)}%;background:${o.color};"></div>
+              </div>
+            </div>
+            <div class="outreach-count">${o.done}/${o.total}</div>
+          </div>
+        `).join('')}
+      </div>
+    </div>
+  `;
+  document.getElementById('page').innerHTML = html;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PAGE 2 — PIPELINE
+═══════════════════════════════════════════════════════════════════ */
+function renderPipeline() {
+  const intentColor = { struggling: 'var(--red)', trying: 'var(--amber)', dabbling: 'var(--tan)' };
+  const scoreClass = s => s >= 85 ? 'score-hot' : s >= 60 ? 'score-warm' : s >= 35 ? 'score-cool' : 'score-cold';
+
+  const filtered = activePipelineFilter === 'struggling' ? prospects.filter(p => p.intent === 'struggling')
+    : activePipelineFilter === 'trying' ? prospects.filter(p => p.intent === 'trying')
+    : activePipelineFilter === 'dabbling' ? prospects.filter(p => p.intent === 'dabbling')
+    : prospects;
+
+  const html = `
+    <h1 class="page-headline">Your prospects,<br><em>ranked by intent.</em></h1>
+
+    <div class="review-banner">
+      <div class="review-banner-text">
+        You've reviewed <strong>3 of 10</strong> prospects. Release all 600 to outreach after quality check.
+      </div>
+      <button class="btn btn-amber" disabled style="opacity:0.45;font-size:13px;padding:7px 16px;">Release All 600</button>
+    </div>
+
+    <div class="filter-chips">
+      ${[
+        { key: 'top10', label: 'Top 10' },
+        { key: 'all', label: 'All 600' },
+        { key: 'struggling', label: 'Struggling' },
+        { key: 'trying', label: 'Trying' },
+        { key: 'dabbling', label: 'Dabbling' },
+      ].map(f => `
+        <div class="chip ${activePipelineFilter === f.key ? 'active' : ''}" onclick="setPipelineFilter('${f.key}')">${f.label}</div>
+      `).join('')}
+    </div>
+
+    ${filtered.map((p, i) => `
+      <div class="pipeline-row" onclick="navigate('#pipeline/${p.id}')">
+        <div class="intent-bar intent-bar-${p.intent}"></div>
+        <div class="pipeline-rank">${i+1}</div>
+        <div class="pipeline-main">
+          <div class="pipeline-biz-name">${p.name}</div>
+          <div class="pipeline-meta">
+            <span class="badge badge-ink badge ${p.intent === 'struggling' ? 'intent-struggling' : p.intent === 'trying' ? 'intent-trying' : 'intent-dabbling'}">${p.intent.charAt(0).toUpperCase()+p.intent.slice(1)}</span>
+            <span class="pipeline-suburb">${p.suburb}, ${p.state}</span>
+            <span class="pipeline-suburb">·</span>
+            <span class="pipeline-suburb">${p.industry}</span>
+          </div>
+        </div>
+        <div class="pipeline-dm" style="font-size:12.5px;color:var(--ink-3);">
+          <div style="font-weight:500;color:var(--ink-2);">${p.dm.name}</div>
+          <div style="font-size:11px;font-family:'JetBrains Mono',monospace;">${p.dm.title}</div>
+        </div>
+        <div class="pipeline-channels">
+          <div class="channel-dot" title="Email">✉</div>
+          <div class="channel-dot" title="LinkedIn">in</div>
+          <div class="channel-dot" title="Voice">☎</div>
+          <div class="channel-dot" title="SMS">📱</div>
+        </div>
+        <div class="pipeline-score-wrap">
+          <div class="score-badge ${scoreClass(p.score)}">${p.score}</div>
+        </div>
+        <div class="pipeline-caret">›</div>
+      </div>
+    `).join('')}
+  `;
+  document.getElementById('page').innerHTML = html;
+}
+
+function setPipelineFilter(key) {
+  activePipelineFilter = key;
+  renderPipeline();
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PAGE 3 — PIPELINE DETAIL
+═══════════════════════════════════════════════════════════════════ */
+function renderDetail(id) {
+  const p = prospects.find(x => x.id === id);
+  if (!p) { renderPipeline(); return; }
+  const idx = prospects.indexOf(p);
+  const prev = idx > 0 ? prospects[idx - 1] : null;
+  const next = idx < prospects.length - 1 ? prospects[idx + 1] : null;
+  const scoreClass = s => s >= 85 ? 'score-hot' : s >= 60 ? 'score-warm' : s >= 35 ? 'score-cool' : 'score-cold';
+
+  const draftEmail = `Subject: Your competitors are stealing your customers, Marcus
+
+Hi Marcus,
+
+I've been researching construction companies in Brunswick and noticed something that's costing Momentum Constructions new business every month.
+
+BuildRight are running Google Ads on your brand terms right now. When someone searches "Momentum Constructions," they're seeing your competitor's ad first.
+
+Combined with the 7 recent negative reviews on your GMB profile, potential customers who look you up are having a bad first impression — before they've even spoken to you.
+
+I specialise in fixing exactly this for construction businesses in Melbourne. I've helped 3 similar companies recover their local search dominance in under 90 days.
+
+Worth a 15-minute call this week?
+
+David Stephens
+Ignition Digital — Sydney`;
+
+  const draftLinkedin = `Hi Marcus, I noticed BuildRight are bidding on Momentum Constructions' brand terms in Google. Quick 15 minutes to show you how to reclaim that ground?`;
+
+  const draftSms = `Hi Marcus, David from Ignition. Noticed your GMB rating dropped recently + a competitor is running ads on your brand. Worth 15 mins? Happy to call whenever suits.`;
+
+  const draftVoice = `Opening: "Hi, is that Marcus? I'm David from Ignition Digital in Sydney. I've been doing some research on construction companies in Brunswick and I've found something that's costing Momentum Constructions new customers — do you have 2 minutes?"
+
+Pain point: "I can see that a competitor called BuildRight is running Google Ads on your brand name right now. So when potential customers search for you by name, they're seeing a competitor's ad first."
+
+CTA: "I've fixed this exact problem for 3 Melbourne construction companies this year. Could we book 15 minutes this week so I can show you what's happening and what we'd do to fix it?"`;
+
+  const gradeItems = [
+    { key: 'website', label: 'Website' },
+    { key: 'seo', label: 'SEO' },
+    { key: 'reviews', label: 'Reviews' },
+    { key: 'ads', label: 'Paid Ads' },
+    { key: 'social', label: 'Social' },
+    { key: 'content', label: 'Content' },
+  ];
+
+  const html = `
+    <div class="detail-back" onclick="navigate('#pipeline')">← Back to Pipeline</div>
+
+    <div class="detail-nav">
+      ${prev ? `<button class="detail-nav-btn" onclick="navigate('#pipeline/${prev.id}')">← ${prev.name}</button>` : ''}
+      <span class="detail-nav-sep" style="flex:1;text-align:center;font-size:12px;color:var(--ink-3);">${idx+1} of ${prospects.length}</span>
+      ${next ? `<button class="detail-nav-btn" onclick="navigate('#pipeline/${next.id}')">${next.name} →</button>` : ''}
+    </div>
+
+    <div class="detail-headline">${p.name}</div>
+    <div class="detail-meta-row">
+      <span class="detail-meta-item">${p.suburb}, ${p.state}</span>
+      <span class="detail-meta-dot">·</span>
+      <span class="detail-meta-item">${p.staff} staff</span>
+      <span class="detail-meta-dot">·</span>
+      <span class="detail-meta-item">Est. ${p.est}</span>
+      <span class="detail-meta-dot">·</span>
+      <span class="detail-meta-item">${p.revenue} revenue</span>
+    </div>
+    <div style="display:flex;gap:8px;margin-bottom:24px;flex-wrap:wrap;">
+      <span class="badge ${p.intent === 'struggling' ? 'intent-struggling' : p.intent === 'trying' ? 'intent-trying' : 'intent-dabbling'}">${p.intent.charAt(0).toUpperCase()+p.intent.slice(1)}</span>
+      <span class="badge badge-ink">CIS ${p.composite}</span>
+      <span class="badge badge-green">Active in pipeline</span>
+    </div>
+    <div class="detail-actions">
+      <button class="btn btn-outline">Skip</button>
+      <button class="btn btn-outline" style="color:var(--amber);border-color:var(--amber);">Flag</button>
+      <button class="btn btn-amber">Approve for Outreach</button>
+    </div>
+
+    <div class="detail-layout">
+      <!-- LEFT COLUMN -->
+      <div>
+        <!-- Score cards -->
+        <div class="grid-3" style="margin-bottom:24px;">
+          <div class="score-card">
+            <div class="score-card-val">${p.affordability}<span style="font-size:18px;color:var(--ink-3);">/10</span></div>
+            <div class="score-card-label">Affordability</div>
+            <div class="score-card-sub">Revenue signal</div>
+          </div>
+          <div class="score-card">
+            <div class="score-card-val">${p.intentScore}<span style="font-size:18px;color:var(--ink-3);">/18</span></div>
+            <div class="score-card-label">Intent Score</div>
+            <div class="score-card-sub">Buying signals</div>
+          </div>
+          <div class="score-card" style="border-color:var(--amber);">
+            <div class="score-card-val" style="color:var(--copper);">${p.composite}</div>
+            <div class="score-card-label">Composite CIS</div>
+            <div class="score-card-sub">Agency Lead Score</div>
+          </div>
+        </div>
+
+        <!-- Buying signals -->
+        <div class="card" style="margin-bottom:20px;">
+          <div class="section-label">Buying signals</div>
+          ${p.signals.map(s => `
+            <div class="signal-item">
+              <div class="signal-dot"></div>
+              <div class="signal-text">${s.text}</div>
+              <div class="signal-time">${s.time}</div>
+            </div>
+          `).join('')}
+        </div>
+
+        <!-- Vulnerability report -->
+        <div class="card" style="margin-bottom:20px;">
+          <div class="section-label">Vulnerability report</div>
+          <div class="vuln-para">${p.vulnerability}</div>
+          <div class="section-label" style="margin-bottom:12px;">Digital health scorecard</div>
+          <div class="grade-grid">
+            ${gradeItems.map(g => `
+              <div class="grade-cell">
+                <div class="grade-letter grade-${p.vulnGrades[g.key]}">${p.vulnGrades[g.key]}</div>
+                <div class="grade-name">${g.label}</div>
+              </div>
+            `).join('')}
+          </div>
+        </div>
+
+        <!-- Draft outreach -->
+        <div class="card">
+          <div class="section-label">Draft outreach</div>
+          <div class="tab-bar" id="outreachTabBar">
+            ${['email','linkedin','sms','voice'].map(t => `
+              <button class="tab-btn ${activeOutreachTab === t ? 'active' : ''}" onclick="switchOutreachTab('${t}')">${t.charAt(0).toUpperCase()+t.slice(1)}${t === 'voice' ? ' AI' : ''}</button>
+            `).join('')}
+          </div>
+          <div id="outreachTabEmail" class="tab-content ${activeOutreachTab === 'email' ? 'active' : ''}">
+            <div class="draft-label">Email draft</div>
+            <div class="draft-content">${draftEmail}</div>
+          </div>
+          <div id="outreachTabLinkedin" class="tab-content ${activeOutreachTab === 'linkedin' ? 'active' : ''}">
+            <div class="draft-label">LinkedIn message</div>
+            <div class="draft-content">${draftLinkedin}</div>
+          </div>
+          <div id="outreachTabSms" class="tab-content ${activeOutreachTab === 'sms' ? 'active' : ''}">
+            <div class="draft-label">SMS draft</div>
+            <div class="draft-content">${draftSms}</div>
+          </div>
+          <div id="outreachTabVoice" class="tab-content ${activeOutreachTab === 'voice' ? 'active' : ''}">
+            <div class="draft-label">Voice AI script</div>
+            <div class="draft-content">${draftVoice}</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- RIGHT COLUMN -->
+      <div>
+        <!-- DM card -->
+        <div class="card dm-card">
+          <div class="section-label">Decision-maker</div>
+          <div class="dm-name">${p.dm.name}</div>
+          <div class="dm-title">${p.dm.title}</div>
+          <div class="dm-field">
+            <div class="dm-field-label">Email</div>
+            <div class="dm-field-val" style="font-size:12px;word-break:break-all;">${p.dm.email}</div>
+            <span class="dm-verified">Verified</span>
+          </div>
+          <div class="dm-field">
+            <div class="dm-field-label">Phone</div>
+            <div class="dm-field-val">${p.dm.phone}</div>
+            <span class="dm-verified">Verified</span>
+          </div>
+          <div class="dm-field">
+            <div class="dm-field-label">LinkedIn</div>
+            <div class="dm-field-val">Profile found</div>
+            <span class="dm-verified">2 days ago</span>
+          </div>
+        </div>
+
+        <!-- Campaign card -->
+        <div class="card" style="margin-bottom:16px;">
+          <div class="section-label">Campaign assignment</div>
+          <div style="font-size:14px;font-weight:500;color:var(--ink);margin-bottom:4px;">SEO Services — Sydney Metro</div>
+          <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-3);margin-bottom:12px;">Campaign C1 · Day 14 of 30</div>
+          <div class="progress-wrap" style="height:5px;margin-bottom:6px;">
+            <div class="progress-bar" style="width:47%;background:var(--amber);"></div>
+          </div>
+          <div style="display:flex;justify-content:space-between;font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);">
+            <span>Day 1</span><span>Day 30</span>
+          </div>
+        </div>
+
+        <!-- Activity timeline -->
+        <div class="card">
+          <div class="section-label">Activity</div>
+          ${[
+            { text: 'Email opened (3x)', time: '2h ago' },
+            { text: 'LinkedIn profile viewed', time: '1d ago' },
+            { text: 'Initial email sent', time: '3d ago' },
+            { text: 'Prospect added to pipeline', time: '5d ago' },
+            { text: 'Enrichment completed', time: '5d ago' },
+          ].map(t => `
+            <div class="timeline-item">
+              <div class="timeline-dot"></div>
+              <div style="flex:1;">
+                <div class="timeline-text">${t.text}</div>
+              </div>
+              <div class="timeline-time">${t.time}</div>
+            </div>
+          `).join('')}
+        </div>
+      </div>
+    </div>
+  `;
+  document.getElementById('page').innerHTML = html;
+}
+
+function switchOutreachTab(tab) {
+  activeOutreachTab = tab;
+  document.querySelectorAll('.tab-btn').forEach(b => {
+    b.classList.toggle('active', b.textContent.toLowerCase().startsWith(tab));
+  });
+  ['email','linkedin','sms','voice'].forEach(t => {
+    const el = document.getElementById('outreachTab' + t.charAt(0).toUpperCase() + t.slice(1));
+    if (el) el.classList.toggle('active', t === tab);
+  });
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PAGE 4 — CAMPAIGNS
+═══════════════════════════════════════════════════════════════════ */
+function renderCampaigns() {
+  const statusBadge = s => s === 'active' ? 'badge-green' : s === 'paused' ? 'badge-amber' : 'badge-ink';
+  const html = `
+    <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:28px;flex-wrap:wrap;gap:12px;">
+      <h1 class="page-headline" style="margin-bottom:0;">Your campaigns,<br><em>running in parallel.</em></h1>
+      <button class="btn btn-amber" onclick="openModal()" style="margin-top:8px;">+ New Campaign</button>
+    </div>
+
+    ${campaigns.map(c => `
+      <div class="campaign-card">
+        <div class="campaign-card-header">
+          <div class="campaign-card-main">
+            <div style="display:flex;align-items:center;gap:10px;margin-bottom:4px;">
+              <span class="badge ${statusBadge(c.status)}">${c.status.charAt(0).toUpperCase()+c.status.slice(1)}</span>
+              ${c.status === 'active' ? `<span style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);">Day ${c.day} of ${c.total}</span>` : ''}
+            </div>
+            <div class="campaign-name">${c.name}</div>
+            <div class="campaign-area">${c.area}</div>
+          </div>
+          <div style="display:flex;gap:8px;flex-shrink:0;">
+            ${c.status === 'active' ? `<button class="btn btn-outline" style="font-size:12px;padding:6px 12px;">Pause</button>` : ''}
+            ${c.status === 'paused' ? `<button class="btn btn-amber" style="font-size:12px;padding:6px 12px;">Resume</button>` : ''}
+            ${c.status === 'draft' ? `<button class="btn btn-primary" style="font-size:12px;padding:6px 12px;">Launch</button>` : ''}
+            <button class="btn btn-ghost" style="font-size:12px;padding:6px 12px;">Edit</button>
+          </div>
+        </div>
+        ${c.status !== 'draft' ? `
+          <div class="progress-wrap" style="height:6px;margin-bottom:8px;">
+            <div class="progress-bar" style="width:${c.total > 0 ? (c.day/c.total*100).toFixed(0) : 0}%;background:${c.status === 'active' ? 'var(--amber)' : 'var(--tan)'};"></div>
+          </div>
+          <div style="display:flex;justify-content:space-between;font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);margin-bottom:16px;">
+            <span>Day 1</span><span>Day ${c.total}</span>
+          </div>
+        ` : `<div style="height:30px;display:flex;align-items:center;margin-bottom:8px;"><span style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-3);">Not yet launched — 600 prospects queued</span></div>`}
+        <div class="campaign-metrics">
+          <div>
+            <div class="campaign-metric-val">${c.contacted.toLocaleString()}</div>
+            <div class="campaign-metric-label">Contacted</div>
+          </div>
+          <div>
+            <div class="campaign-metric-val">${c.totalLeads.toLocaleString()}</div>
+            <div class="campaign-metric-label">Total Leads</div>
+          </div>
+          <div>
+            <div class="campaign-metric-val">${c.replies}</div>
+            <div class="campaign-metric-label">Replies</div>
+          </div>
+          <div>
+            <div class="campaign-metric-val">${c.meetings}</div>
+            <div class="campaign-metric-label">Meetings</div>
+          </div>
+          <div>
+            <div class="campaign-metric-val">${c.contacted > 0 ? (c.replies/c.contacted*100).toFixed(1) : '0.0'}%</div>
+            <div class="campaign-metric-label">Reply Rate</div>
+          </div>
+        </div>
+      </div>
+    `).join('')}
+  `;
+  document.getElementById('page').innerHTML = html;
+}
+
+function openModal() {
+  document.getElementById('campaignModal').classList.add('open');
+}
+function closeModal() {
+  document.getElementById('campaignModal').classList.remove('open');
+}
+function closeModalOutside(e) {
+  if (e.target.id === 'campaignModal') closeModal();
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PAGE 5 — INBOX
+═══════════════════════════════════════════════════════════════════ */
+function renderInbox() {
+  const channelIcon = ch => ({ email: '✉', linkedin: 'in', sms: '📱', voice: '☎' }[ch] || '·');
+  const activeReply = replies.find(r => r.id === activeInboxReply) || replies[0];
+  const p = prospects.find(x => x.id === activeReply.prospectId) || prospects[0];
+
+  const html = `
+    <h1 class="page-headline" style="margin-bottom:20px;">Inbox<br><em>replies &amp; conversations.</em></h1>
+    <div class="inbox-layout">
+      <!-- List -->
+      <div class="inbox-list">
+        <div class="inbox-list-header">
+          <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-3);">${replies.length} conversations · 3 unread</div>
+        </div>
+        ${replies.map(r => `
+          <div class="inbox-item ${r.id === activeInboxReply ? 'active' : ''}" onclick="setActiveReply('${r.id}')">
+            <div class="heat-dot heat-${r.heat}" style="margin-top:4px;"></div>
+            <div class="inbox-item-meta">
+              <div class="inbox-item-name">${r.name}</div>
+              <div class="inbox-item-biz">${r.business}</div>
+              <div class="inbox-item-snippet">${r.snippet}</div>
+            </div>
+            <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px;flex-shrink:0;">
+              <div class="inbox-item-time">${r.time}</div>
+              <div style="font-family:'JetBrains Mono',monospace;font-size:10px;background:var(--surface);padding:2px 5px;border-radius:3px;color:var(--ink-3);">${channelIcon(r.channel)}</div>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+
+      <!-- Thread -->
+      <div class="inbox-thread">
+        <div class="thread-header">
+          <div class="heat-dot heat-${activeReply.heat}"></div>
+          <div>
+            <div class="thread-name">${activeReply.name}</div>
+            <div class="thread-biz">${activeReply.business} · via ${activeReply.channel}</div>
+          </div>
+          <div style="margin-left:auto;display:flex;gap:8px;">
+            <button class="btn btn-outline" style="font-size:12px;padding:6px 12px;">View Prospect</button>
+            <button class="btn btn-amber" style="font-size:12px;padding:6px 12px;">Book Meeting</button>
+          </div>
+        </div>
+        <div class="thread-body">
+          <div>
+            <div class="bubble bubble-ours">
+              Hi ${activeReply.name.split(' ')[0]}, I've been analysing ${activeReply.business}'s digital presence and noticed a few things that are costing you customers. Worth a 15-minute call this week to walk through what we found?
+            </div>
+            <div class="bubble-time bubble-time-right">You · 3 days ago</div>
+          </div>
+          <div>
+            <div class="bubble bubble-theirs">${activeReply.snippet}</div>
+            <div class="bubble-time bubble-time-left">${activeReply.name} · ${activeReply.time}</div>
+          </div>
+          <div>
+            <div class="bubble bubble-ours">
+              Great — I'll send a calendar link. We'll cover exactly what we found and what the fix looks like. Should take no more than 15 minutes.
+            </div>
+            <div class="bubble-time bubble-time-right">You · 1h ago</div>
+          </div>
+        </div>
+        <div class="thread-actions">
+          <input type="text" placeholder="Reply to ${activeReply.name.split(' ')[0]}…" style="flex:1;border:1px solid var(--rule);border-radius:6px;padding:9px 12px;font-size:13.5px;outline:none;">
+          <button class="btn btn-amber">Send</button>
+        </div>
+      </div>
+    </div>
+  `;
+  document.getElementById('page').innerHTML = html;
+}
+
+function setActiveReply(id) {
+  activeInboxReply = id;
+  renderInbox();
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PAGE 6 — SEQUENCES
+═══════════════════════════════════════════════════════════════════ */
+function renderSequences() {
+  const days = Array.from({length: 35}, (_, i) => i + 1);
+  const today = 14;
+
+  const events = {
+    1: [{ type: 'email', label: 'Email 1' }],
+    3: [{ type: 'linkedin', label: 'LI connect' }],
+    5: [{ type: 'email', label: 'Email 2' }],
+    7: [{ type: 'voice', label: 'Voice AI' }],
+    10: [{ type: 'email', label: 'Email 3' }],
+    12: [{ type: 'sms', label: 'SMS' }],
+    14: [{ type: 'email', label: 'Email 4' }, { type: 'linkedin', label: 'LI msg' }],
+    17: [{ type: 'voice', label: 'Voice AI' }],
+    20: [{ type: 'email', label: 'Email 5' }],
+    23: [{ type: 'sms', label: 'SMS 2' }],
+    26: [{ type: 'email', label: 'Email 6' }],
+    30: [{ type: 'voice', label: 'Final call' }],
+  };
+
+  const html = `
+    <h1 class="page-headline" style="margin-bottom:28px;">Your sequences,<br><em>touch by touch.</em></h1>
+
+    <div class="grid-4" style="margin-bottom:32px;">
+      ${[
+        { ch: 'Email', rate: '47%', detail: '18/50 sent today', pct: 36, color: '#6B8E5A' },
+        { ch: 'LinkedIn', rate: '38%', detail: '12/20 sent today', pct: 60, color: '#3B82F6' },
+        { ch: 'Voice AI', rate: '22%', detail: '5/10 completed', pct: 50, color: '#D4956A' },
+        { ch: 'SMS', rate: '61%', detail: '8/25 sent today', pct: 32, color: '#8B5CF6' },
+      ].map(c => `
+        <div class="channel-rate-card">
+          <div class="eyebrow" style="margin-bottom:6px;">${c.ch}</div>
+          <div class="channel-rate-val">${c.rate}</div>
+          <div class="channel-rate-detail">${c.detail}</div>
+          <div class="progress-wrap" style="height:5px;">
+            <div class="progress-bar" style="width:${c.pct}%;background:${c.color};"></div>
+          </div>
+        </div>
+      `).join('')}
+    </div>
+
+    <div class="card">
+      <div class="section-label">30-day outreach calendar</div>
+      <div class="calendar-grid">
+        ${['MON','TUE','WED','THU','FRI','SAT','SUN'].map(d => `<div class="cal-header-cell">${d}</div>`).join('')}
+        ${days.map(d => {
+          const evs = events[d] || [];
+          const isToday = d === today;
+          return `
+            <div class="cal-cell ${isToday ? 'cal-today' : ''}">
+              <div class="cal-date-num">${d}</div>
+              ${evs.map(e => `<span class="cal-pill cal-${e.type}">${e.label}</span>`).join('')}
+            </div>
+          `;
+        }).join('')}
+      </div>
+      <div class="legend-row">
+        <div class="legend-item"><div class="legend-dot" style="background:rgba(107,142,90,0.4);"></div>Email</div>
+        <div class="legend-item"><div class="legend-dot" style="background:rgba(59,130,246,0.4);"></div>LinkedIn</div>
+        <div class="legend-item"><div class="legend-dot" style="background:var(--amber-soft);border:1px solid var(--amber);"></div>Voice AI</div>
+        <div class="legend-item"><div class="legend-dot" style="background:rgba(139,92,246,0.2);"></div>SMS</div>
+      </div>
+    </div>
+  `;
+  document.getElementById('page').innerHTML = html;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PAGE 7 — SIGNALS
+═══════════════════════════════════════════════════════════════════ */
+function renderSignals() {
+  const signalData = [
+    { cat: 'Competitive', name: 'Brand Term Bidding', desc: 'Detects when a competitor is running Google Ads on your prospect\'s brand keywords, creating urgency around paid search protection.', count: '14 triggered', trend: '+3 this week', on: true },
+    { cat: 'Review Health', name: 'GMB Rating Decline', desc: 'Flags businesses whose Google My Business rating has dropped by 0.3+ stars in the past 90 days, indicating reputation pressure.', count: '8 triggered', trend: '+1 this week', on: true },
+    { cat: 'Website', name: 'Outdated Website Signal', desc: 'Identifies websites not updated in 24+ months, missing SSL, or failing mobile responsiveness checks.', count: '31 triggered', trend: '+7 this week', on: true },
+    { cat: 'Ad Spend', name: 'Ad Pause Detected', desc: 'Catches businesses that have paused Google or Meta ad campaigns after a sustained spend period — often signals budget frustration.', count: '6 triggered', trend: '+2 this week', on: true },
+    { cat: 'Talent', name: 'Staff Churn Signal', desc: 'Monitors LinkedIn for multiple staff updating to "Open to work" at the same business — indicates internal instability.', count: '3 triggered', trend: 'steady', on: true },
+    { cat: 'Content', name: 'Thin Content Launch', desc: 'Detects businesses that recently launched a blog or content section but have fewer than 5 posts — shows intent without execution.', count: '11 triggered', trend: '+4 this week', on: false },
+  ];
+
+  const html = `
+    <h1 class="page-headline" style="margin-bottom:28px;">What the agent<br><em>watches for.</em></h1>
+    <div style="font-size:14px;color:var(--ink-3);margin-bottom:28px;max-width:600px;">
+      The intelligence engine monitors ${signalData.length} signal categories across every prospect. Enable or disable signals to tune your outreach criteria.
+    </div>
+    <div class="grid-2">
+      ${signalData.map(s => `
+        <div class="signal-card">
+          <div class="eyebrow" style="margin-bottom:8px;">${s.cat}</div>
+          <div class="signal-card-header">
+            <div class="signal-card-name">${s.name}</div>
+            <div class="signal-toggle ${s.on ? '' : 'off'}" onclick="this.classList.toggle('off')"></div>
+          </div>
+          <div class="signal-card-desc">${s.desc}</div>
+          <div class="signal-card-stat">${s.count} · ${s.trend}</div>
+        </div>
+      `).join('')}
+    </div>
+  `;
+  document.getElementById('page').innerHTML = html;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PAGE 8 — REPORTS
+═══════════════════════════════════════════════════════════════════ */
+function renderReports() {
+  const html = `
+    <h1 class="page-headline" style="margin-bottom:28px;">Campaign performance,<br><em>by the numbers.</em></h1>
+
+    <!-- KPIs -->
+    <div class="grid-4" style="margin-bottom:32px;">
+      ${[
+        { label: 'Total Contacted', val: '460', delta: '+120 this week', up: true },
+        { label: 'Total Replies', val: '36', delta: '7.8% reply rate', up: true },
+        { label: 'Meetings Booked', val: '5', delta: '1.1% meeting rate', up: null },
+        { label: 'Pipeline Value', val: '$47K', delta: 'Est. AUD', up: null },
+      ].map(k => `
+        <div class="kpi-card">
+          <div class="kpi-label">${k.label}</div>
+          <div class="kpi-val">${k.val}</div>
+          <div class="metric-delta ${k.up === true ? 'delta-up' : k.up === false ? 'delta-down' : ''}" style="${k.up === null ? 'color:var(--ink-3)' : ''}">${k.delta}</div>
+        </div>
+      `).join('')}
+    </div>
+
+    <div class="grid-2" style="margin-bottom:24px;">
+      <!-- Conversion Funnel -->
+      <div class="card">
+        <div class="section-label">Conversion funnel</div>
+        ${[
+          { label: 'Discovered', count: 2400, pct: 100 },
+          { label: 'Enriched', count: 1800, pct: 75 },
+          { label: 'Qualified (ALS≥20)', count: 940, pct: 39 },
+          { label: 'Released', count: 600, pct: 25 },
+          { label: 'Contacted', count: 460, pct: 19 },
+          { label: 'Replied', count: 36, pct: 1.5 },
+          { label: 'Meeting Booked', count: 5, pct: 0.2 },
+        ].map(f => `
+          <div class="funnel-row">
+            <div class="funnel-label">${f.label}</div>
+            <div class="funnel-bar-wrap">
+              <div class="funnel-bar" style="width:${f.pct}%;"></div>
+            </div>
+            <div class="funnel-pct">${f.pct}%</div>
+            <div class="funnel-count">${f.count.toLocaleString()}</div>
+          </div>
+        `).join('')}
+      </div>
+
+      <!-- Top Signals -->
+      <div class="card">
+        <div class="section-label">Top performing signals</div>
+        <table class="report-table">
+          <thead>
+            <tr>
+              <th>Signal</th>
+              <th>Triggered</th>
+              <th>Reply Rate</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${[
+              { name: 'Brand Term Bidding', count: 14, rate: '21.4%' },
+              { name: 'GMB Rating Decline', count: 8, rate: '18.8%' },
+              { name: 'Ad Pause Detected', count: 6, rate: '16.7%' },
+              { name: 'Outdated Website', count: 31, rate: '9.7%' },
+              { name: 'Staff Churn Signal', count: 3, rate: '33.3%' },
+            ].map(s => `
+              <tr>
+                <td>${s.name}</td>
+                <td><span class="mono" style="font-size:12px;">${s.count}</span></td>
+                <td><span class="badge badge-green" style="font-size:11px;">${s.rate}</span></td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Channel Performance -->
+    <div class="card">
+      <div class="section-label">Channel performance</div>
+      <table class="report-table">
+        <thead>
+          <tr>
+            <th>Channel</th>
+            <th>Sent</th>
+            <th>Open Rate</th>
+            <th>Reply Rate</th>
+            <th>Meetings</th>
+            <th>Cost/Reply (AUD)</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${[
+            { ch: 'Email', sent: 320, open: '47%', reply: '8.4%', meet: 3, cpr: '$2.10' },
+            { ch: 'LinkedIn', sent: 80, open: '—', reply: '11.3%', meet: 1, cpr: '$4.80' },
+            { ch: 'Voice AI', sent: 40, open: '—', reply: '5.0%', meet: 1, cpr: '$6.20' },
+            { ch: 'SMS', sent: 20, open: '—', reply: '15.0%', meet: 0, cpr: '$1.80' },
+          ].map(c => `
+            <tr>
+              <td><strong>${c.ch}</strong></td>
+              <td><span class="mono" style="font-size:12px;">${c.sent}</span></td>
+              <td>${c.open}</td>
+              <td><span class="badge badge-green" style="font-size:11px;">${c.reply}</span></td>
+              <td>${c.meet}</td>
+              <td><span class="mono" style="font-size:12px;color:var(--ink-3);">${c.cpr}</span></td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>
+    </div>
+  `;
+  document.getElementById('page').innerHTML = html;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PAGE 9 — SETTINGS
+═══════════════════════════════════════════════════════════════════ */
+function renderSettings() {
+  const tabs = ['account', 'integrations', 'team', 'billing', 'danger'];
+  const tabLabels = { account: 'Account', integrations: 'Integrations', team: 'Team', billing: 'Billing', danger: 'Danger Zone' };
+
+  const accountSection = `
+    <div class="section-label">Agency profile</div>
+    ${[
+      { key: 'Agency Name', sub: 'Displayed across all outreach', val: 'Ignition Digital' },
+      { key: 'Primary Service', sub: 'Used to qualify prospects', val: 'SEO Services, Google Ads, Web Design' },
+      { key: 'Target Areas', sub: 'Geographic targeting', val: 'Sydney, Melbourne, Brisbane' },
+      { key: 'Outreach Style', sub: 'Tone used in all drafts', val: 'Direct · Professional · Data-led' },
+    ].map(r => `
+      <div class="settings-row">
+        <div class="settings-row-label">
+          <div class="settings-row-key">${r.key}</div>
+          <div class="settings-row-sub">${r.sub}</div>
+        </div>
+        <div class="settings-row-val">${r.val}</div>
+        <div class="settings-row-action"><button class="btn btn-outline" style="font-size:12px;padding:5px 12px;">Edit</button></div>
+      </div>
+    `).join('')}
+  `;
+
+  const integrationsSection = `
+    <div class="section-label">Connected services</div>
+    ${[
+      { icon: '🔗', name: 'HubSpot CRM', desc: 'Sync prospects and deals', status: 'Connected' },
+      { icon: 'in', name: 'LinkedIn', desc: 'Automated connection requests and messages', status: 'Connected' },
+      { icon: '✉', name: 'Email Domains', desc: 'ignition.com.au · 3 mailboxes active', status: 'Connected' },
+      { icon: '☎', name: 'Voice AI', desc: 'Automated outbound calling', status: 'Connected' },
+      { icon: '📱', name: 'SMS Gateway', desc: 'Automated SMS outreach', status: 'Degraded' },
+      { icon: '📅', name: 'Calendar', desc: 'Google Calendar · Meeting booking', status: 'Connected' },
+    ].map(i => `
+      <div class="integration-row">
+        <div class="integration-icon">${i.icon}</div>
+        <div style="flex:1;">
+          <div class="integration-name">${i.name}</div>
+          <div class="integration-desc">${i.desc}</div>
+        </div>
+        <span class="badge ${i.status === 'Connected' ? 'badge-connected' : 'badge-amber'}">${i.status}</span>
+      </div>
+    `).join('')}
+  `;
+
+  const teamSection = `
+    <div class="section-label">Team members</div>
+    ${[
+      { name: 'David Stephens', role: 'Owner', email: 'david@ignition.com.au', avatar: 'DS' },
+      { name: 'Priya Nair', role: 'Account Manager', email: 'priya@ignition.com.au', avatar: 'PN' },
+    ].map(m => `
+      <div class="settings-row">
+        <div class="settings-row-label" style="display:flex;align-items:center;gap:10px;width:auto;margin-right:16px;">
+          <div class="avatar-circle" style="background:var(--ink-2);width:36px;height:36px;font-size:12px;">${m.avatar}</div>
+          <div>
+            <div class="settings-row-key">${m.name}</div>
+            <div class="settings-row-sub">${m.email}</div>
+          </div>
+        </div>
+        <div class="settings-row-val"><span class="badge badge-ink">${m.role}</span></div>
+        <div class="settings-row-action"><button class="btn btn-outline" style="font-size:12px;padding:5px 12px;">Edit</button></div>
+      </div>
+    `).join('')}
+    <div style="margin-top:16px;"><button class="btn btn-outline">+ Invite team member</button></div>
+  `;
+
+  const billingSection = `
+    <div class="section-label">Current plan</div>
+    <div class="card" style="margin-bottom:20px;">
+      <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;">
+        <div>
+          <div style="font-family:'Playfair Display',serif;font-size:22px;font-weight:700;color:var(--ink);">Growth Plan</div>
+          <div style="font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--ink-3);">$497 AUD / month · Renews 7 May 2026</div>
+        </div>
+        <span class="badge badge-green" style="margin-left:auto;">Active</span>
+      </div>
+      ${[
+        { feature: 'Prospects per month', val: '600' },
+        { feature: 'Campaigns', val: '4 active' },
+        { feature: 'Outreach channels', val: 'Email + LinkedIn + Voice + SMS' },
+        { feature: 'Seats', val: '3 users' },
+      ].map(f => `
+        <div style="display:flex;padding:8px 0;border-bottom:1px solid var(--rule);">
+          <div style="flex:1;font-size:13px;color:var(--ink-3);">${f.feature}</div>
+          <div style="font-family:'JetBrains Mono',monospace;font-size:13px;color:var(--ink-2);">${f.val}</div>
+        </div>
+      `).join('')}
+    </div>
+    <button class="btn btn-outline">Manage billing →</button>
+  `;
+
+  const dangerSection = `
+    <div class="danger-zone">
+      <div class="danger-zone-title">Danger Zone</div>
+      ${[
+        { title: 'Pause all campaigns', sub: 'Stop all active outreach immediately. Can be resumed.', btn: 'Pause All', red: false },
+        { title: 'Export all data', sub: 'Download all prospects, campaigns, and reply data as CSV.', btn: 'Export Data', red: false },
+        { title: 'Delete account', sub: 'Permanently delete your account and all data. This cannot be undone.', btn: 'Delete Account', red: true },
+      ].map(d => `
+        <div class="danger-row">
+          <div class="danger-row-info">
+            <div class="danger-row-title">${d.title}</div>
+            <div class="danger-row-sub">${d.sub}</div>
+          </div>
+          <button class="${d.red ? 'btn-danger' : 'btn btn-outline'}" style="${!d.red ? 'font-size:12px;padding:6px 12px;' : ''}">${d.btn}</button>
+        </div>
+      `).join('')}
+    </div>
+  `;
+
+  const sectionContent = {
+    account: accountSection,
+    integrations: integrationsSection,
+    team: teamSection,
+    billing: billingSection,
+    danger: dangerSection,
+  };
+
+  const html = `
+    <h1 class="page-headline" style="margin-bottom:28px;">Settings</h1>
+    <div class="settings-layout">
+      <div class="settings-nav">
+        ${tabs.map(t => `
+          <div class="settings-nav-item ${activeSettingsTab === t ? 'active' : ''}" onclick="switchSettingsTab('${t}')">${tabLabels[t]}</div>
+        `).join('')}
+      </div>
+      <div class="settings-content">
+        ${tabs.map(t => `
+          <div class="settings-section ${activeSettingsTab === t ? 'active' : ''}" id="stab-${t}">
+            ${sectionContent[t]}
+          </div>
+        `).join('')}
+      </div>
+    </div>
+  `;
+  document.getElementById('page').innerHTML = html;
+}
+
+function switchSettingsTab(tab) {
+  activeSettingsTab = tab;
+  document.querySelectorAll('.settings-nav-item').forEach((el, i) => {
+    const tabs = ['account', 'integrations', 'team', 'billing', 'danger'];
+    el.classList.toggle('active', tabs[i] === tab);
+  });
+  document.querySelectorAll('.settings-section').forEach(el => {
+    el.classList.toggle('active', el.id === 'stab-' + tab);
+  });
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   MOBILE SIDEBAR
+═══════════════════════════════════════════════════════════════════ */
+function toggleMobileSidebar() {
+  const sidebar = document.getElementById('sidebar');
+  const overlay = document.getElementById('sidebar-overlay');
+  sidebar.classList.toggle('mobile-open');
+  overlay.classList.toggle('show');
+}
+function closeMobileSidebar() {
+  document.getElementById('sidebar').classList.remove('mobile-open');
+  document.getElementById('sidebar-overlay').classList.remove('show');
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   INIT
+═══════════════════════════════════════════════════════════════════ */
+router();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Single self-contained HTML file for CEO design review. 2608 lines, 106KB.

**Pages:** Home, Pipeline, Pipeline Detail, Campaigns, Inbox, Sequences, Signals, Reports, Settings

**Features:**
- Hash-based routing between all 9 pages
- Locked design system (cream/amber/ink, Playfair/DM Sans/JetBrains Mono)
- 5 Australian mock businesses with full data
- Mobile responsive (hamburger + bottom nav below 768px)
- Interactive: modals, tab switching, filter chips, prev/next navigation
- No vendor names — all "Verified" badges

**Not production code** — prototype asset in `frontend/mocks/` for design review only.

## Test plan
- [x] File opens in browser
- [x] All 9 pages render via hash routes
- [x] Mobile responsive layout works
- [x] No external deps except Google Fonts CDN

🤖 Generated with [Claude Code](https://claude.com/claude-code)