### PR TITLE
fix: include organic_count in DFS domain_metrics response

### DIFF
--- a/src/clients/dfs_labs_client.py
+++ b/src/clients/dfs_labs_client.py
@@ -784,6 +784,7 @@ class DFSLabsClient:
                             "domain": domain,
                             "paid_etv": paid_etv,
                             "organic_etv": organic_etv,
+                            "organic_count": item.get("organic_count") or 0,
                             "_total_count": total_count,  # propagate for pagination
                         }
                     )


### PR DESCRIPTION
## Summary
- One-line addition to `dfs_labs_client.py` `domain_metrics_by_categories()`
- DFS API returns `organic_count` (ranking keyword count) but client was stripping it
- Needed for #328.1 category ETV window calibration — `organic_count` is the SMB size proxy

## Test plan
- [x] 1346/28/0 baseline unchanged
- [x] No functional change to existing callers (new field additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)