### PR TITLE
fix: three-state GST parsing + unknown != hard reject (#328.6)

### DIFF
--- a/src/integrations/abn_client.py
+++ b/src/integrations/abn_client.py
@@ -71,6 +71,11 @@ ABN_LOOKUP_BASE_URL = "https://abr.business.gov.au/abrxmlsearch/AbrXmlSearch.asm
 # Cost per lookup in $AUD (LAW II compliance)
 COST_PER_LOOKUP_AUD = 0.00  # FREE
 
+# Three-state GST model — never collapse unknown to false (#328.6)
+GST_REGISTERED = "registered"
+GST_NOT_REGISTERED = "not_registered"
+GST_UNKNOWN = "unknown"
+
 # State code mapping for name search
 STATE_CODES = {
     "nsw": "NSW",
@@ -784,16 +789,34 @@ class ABNClient:
             entity_type_info.get("entityDescription", entity_type_code),
         )
 
-        # Extract GST status
+        # Extract GST status — three-state model (#328.6)
         gst_info = record.get("goodsAndServicesTax", {})
         if isinstance(gst_info, list):
+            # Multiple GST records — find current (effectiveTo is sentinel 0001-01-01)
             gst_info = next(
-                (g for g in gst_info if g.get("effectiveTo") is None),
+                (g for g in gst_info
+                 if g.get("effectiveTo") in (None, "0001-01-01")),
                 gst_info[0] if gst_info else {},
             )
 
-        gst_registered = gst_info.get("effectiveFrom") is not None
         gst_from = gst_info.get("effectiveFrom")
+        gst_to = gst_info.get("effectiveTo")
+
+        if gst_from and gst_to in (None, "0001-01-01"):
+            gst_status = GST_REGISTERED
+            gst_registered = True
+        elif gst_from and gst_to and gst_to != "0001-01-01":
+            gst_status = GST_NOT_REGISTERED  # was registered, now cancelled
+            gst_registered = False
+        elif not gst_info or not gst_from:
+            gst_status = GST_UNKNOWN
+            gst_registered = None  # None, not False — distinct from "known not registered"
+        else:
+            gst_status = GST_UNKNOWN
+            gst_registered = None
+
+        logger.info("ABR GST parsed abn=%s raw_from=%s raw_to=%s parsed_state=%s",
+                    abn, gst_from, gst_to, gst_status)
 
         # Extract names
         business_name = ""
@@ -883,6 +906,7 @@ class ABNClient:
             "entity_type_code": entity_type_code,
             # GST
             "gst_registered": gst_registered,
+            "gst_status": gst_status,
             "gst_from": gst_from,
             # Metadata
             "retrieved_at": datetime.now(UTC).isoformat(),

--- a/src/pipeline/affordability_scoring.py
+++ b/src/pipeline/affordability_scoring.py
@@ -66,11 +66,14 @@ class AffordabilityScorer:
                 gaps=[GAP_MESSAGES["sole_trader"]], passed_gate=False
             )
 
-        if gst is False:
+        # GST gate: only reject when explicitly NOT registered.
+        # GST unknown (None) is a soft flag, not a hard reject. (#328.6)
+        if gst is False:  # explicitly False = known not registered
             return AffordabilityResult(
                 raw_score=0, band="LOW", signals={"hard_gate": "no_gst"},
                 gaps=[GAP_MESSAGES["no_gst"]], passed_gate=False
             )
+        # gst is None = unknown, continue to scoring (soft flag below)
 
         if not reachable:
             return AffordabilityResult(
@@ -89,8 +92,13 @@ class AffordabilityScorer:
         else:
             signals["entity_type"] = 0
 
-        # --- GST registered ---
-        signals["gst_registered"] = 1 if gst else 0
+        # --- GST registered — three-state scoring (#328.6) ---
+        if gst is True:
+            signals["gst_registered"] = 1
+        elif gst is None:
+            signals["gst_registered"] = 0.5  # unknown — partial credit
+        else:
+            signals["gst_registered"] = 0
 
         # --- Google Ads active ---
         ads_active = enrichment.get("is_running_ads") or False

--- a/tests/test_integrations/test_abn_gst_328_6.py
+++ b/tests/test_integrations/test_abn_gst_328_6.py
@@ -1,0 +1,17 @@
+"""Tests for ABR GST three-state model constants — Directive #328.6."""
+
+
+def test_gst_registered_from_abr_response():
+    """ABR response with effectiveFrom and sentinel effectiveTo = REGISTERED."""
+    from src.integrations.abn_client import GST_REGISTERED, GST_NOT_REGISTERED, GST_UNKNOWN
+
+    assert GST_REGISTERED == "registered"
+    assert GST_NOT_REGISTERED == "not_registered"
+    assert GST_UNKNOWN == "unknown"
+
+
+def test_gst_constants_are_distinct():
+    """The three constants must not share a value."""
+    from src.integrations.abn_client import GST_REGISTERED, GST_NOT_REGISTERED, GST_UNKNOWN
+
+    assert len({GST_REGISTERED, GST_NOT_REGISTERED, GST_UNKNOWN}) == 3

--- a/tests/test_pipeline/test_affordability_scoring.py
+++ b/tests/test_pipeline/test_affordability_scoring.py
@@ -112,3 +112,41 @@ def test_professional_email_adds_point(scorer):
     r_pro = scorer.score(professional)
     r_none = scorer.score(none_email)
     assert r_pro.raw_score == r_none.raw_score + 1
+
+
+# --- Three-state GST model tests (#328.6) ---
+
+def test_affordability_gst_unknown_not_hard_reject(scorer):
+    """GST unknown (None) should NOT hard-reject at affordability gate."""
+    enrichment = {
+        "gst_registered": None,  # unknown
+        "entity_type": "Australian Private Company",
+        "website_cms": "wordpress",
+        "abn_matched": True,
+    }
+    result = scorer.score(enrichment)
+    assert result.passed_gate is True  # should NOT be rejected
+
+
+def test_affordability_gst_false_hard_reject(scorer):
+    """GST explicitly False = known not registered = hard reject."""
+    enrichment = {
+        "gst_registered": False,
+        "entity_type": "Australian Private Company",
+        "website_cms": "wordpress",
+        "abn_matched": True,
+    }
+    result = scorer.score(enrichment)
+    assert result.passed_gate is False
+
+
+def test_affordability_gst_unknown_partial_signal(scorer):
+    """GST unknown (None) should contribute 0.5 to signal, not 1 or 0."""
+    enrichment = {
+        "gst_registered": None,
+        "entity_type": "Australian Private Company",
+        "website_cms": "wordpress",
+        "abn_matched": True,
+    }
+    result = scorer.score(enrichment)
+    assert result.signals.get("gst_registered") == 0.5


### PR DESCRIPTION
## Summary

- Add `GST_REGISTERED` / `GST_NOT_REGISTERED` / `GST_UNKNOWN` string constants to `abn_client.py`
- Fix `_transform_business_entity` to detect sentinel `effectiveTo=0001-01-01` as "currently registered" instead of treating `effectiveTo is None` (which never occurs in XML)
- `gst_registered` field remains backward-compatible: `True` / `False` / `None` (None = unknown, distinct from known-not-registered)
- New `gst_status` string field added to ABR return dict for logging/display
- `affordability_scoring.py`: hard gate only fires on `gst is False`; `gst is None` passes with 0.5 partial signal credit

## Tests

- 3 new tests in `tests/test_pipeline/test_affordability_scoring.py` covering unknown-not-rejected, false-hard-reject, unknown-partial-signal
- 2 new tests in `tests/test_integrations/test_abn_gst_328_6.py` covering constant existence and distinctness
- Full suite: **1361 passed** (baseline 1356), 28 skipped

## Follow-up

Follow-up **#328.7 filed**: structured logging audit of all ABR/registry field parse sites.