### PR TITLE
feat(F2.1+F7): evo_flow_callbacks + agent_comms tables

### DIFF
--- a/supabase/migrations/20260413_f2_1_evo_flow_callbacks.sql
+++ b/supabase/migrations/20260413_f2_1_evo_flow_callbacks.sql
@@ -1,0 +1,22 @@
+-- F2.1: evo_flow_callbacks table
+-- Stores Prefect flow completion callbacks written by src/prefect_utils/callback_writer.py
+-- Polled by src/evo/callback_poller.py for Telegram alerts.
+
+CREATE TABLE IF NOT EXISTS public.evo_flow_callbacks (
+    id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    flow_name      TEXT        NOT NULL,
+    flow_run_id    TEXT,
+    deployment_id  TEXT,
+    status         TEXT        NOT NULL CHECK (status IN ('completed', 'failed', 'crashed')),
+    result_summary JSONB,
+    consumed_at    TIMESTAMPTZ,
+    consumed_by    TEXT,
+    created_at     TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_efc_flow_name   ON public.evo_flow_callbacks(flow_name);
+CREATE INDEX IF NOT EXISTS idx_efc_status      ON public.evo_flow_callbacks(status);
+CREATE INDEX IF NOT EXISTS idx_efc_consumed_at ON public.evo_flow_callbacks(consumed_at);
+
+COMMENT ON TABLE public.evo_flow_callbacks IS
+    'Prefect flow completion callbacks. Written by callback_writer.py, polled by callback_poller.py. F2.1.';

--- a/supabase/migrations/20260413_f7_agent_comms.sql
+++ b/supabase/migrations/20260413_f7_agent_comms.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS public.agent_comms (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    from_agent TEXT NOT NULL CHECK (from_agent IN ('ceo','cto','dave')),
+    to_agent TEXT NOT NULL CHECK (to_agent IN ('ceo','cto','dave')),
+    message_type TEXT NOT NULL CHECK (message_type IN ('directive','completion','question','status','approval_request','escalation','ratification')),
+    subject TEXT NOT NULL,
+    body TEXT NOT NULL,
+    references_directive TEXT,
+    phase TEXT,
+    requires_dave_approval BOOLEAN DEFAULT false,
+    dave_approved_at TIMESTAMPTZ,
+    dave_approved_by UUID,
+    budget_impact_usd NUMERIC(10,2),
+    created_at TIMESTAMPTZ DEFAULT now(),
+    read_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_comms_to_read ON agent_comms(to_agent, read_at);
+CREATE INDEX IF NOT EXISTS idx_agent_comms_approval ON agent_comms(requires_dave_approval, dave_approved_at);
+
+ALTER TABLE agent_comms ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY agent_comms_service_all ON agent_comms
+    FOR ALL TO service_role
+    USING (true) WITH CHECK (true);
+
+CREATE POLICY agent_comms_dave_read ON agent_comms
+    FOR SELECT TO authenticated
+    USING (from_agent = 'ceo' OR to_agent = 'dave');
+
+COMMENT ON TABLE agent_comms IS 'Inter-agent communication table. CEO/CTO write via service key. Dave reads via authenticated. Option A from #ROADMAP-MASTER.';


### PR DESCRIPTION
## Summary

- **F2.1** — `evo_flow_callbacks` table. Schema derived from `src/prefect_utils/callback_writer.py` (exact columns: `flow_name`, `flow_run_id`, `deployment_id`, `status` CHECK, `result_summary` JSONB, `consumed_at`/`consumed_by` for poller idempotency). Indexes on `flow_name`, `status`, `consumed_at`.
- **F7** — `agent_comms` table. Ratified schema from #ROADMAP-MASTER (Option A). CHECK constraints on `from_agent`, `to_agent`, `message_type`. RLS enabled: `service_role` full access, `authenticated` read for CEO→Dave messages.

## Test plan

- [ ] Apply both migrations against dev Supabase and confirm `\d evo_flow_callbacks` and `\d agent_comms` match expected schemas
- [ ] Run `src/prefect_utils/callback_writer.py` happy path — confirm INSERT succeeds (no 400/422)
- [ ] Run `src/evo/callback_poller.py` — confirm PATCH to `consumed_at` column resolves without error
- [ ] Confirm RLS policy blocks unauthenticated reads on `agent_comms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)