### PR TITLE
fix(hotfix-01): Decimal serialization + pgbouncer pool compatibility

### DIFF
--- a/src/pipeline/stage_9_vulnerability_enrichment.py
+++ b/src/pipeline/stage_9_vulnerability_enrichment.py
@@ -33,8 +33,9 @@ _CO_COST_USD = 0.033
 
 
 class Stage9VulnerabilityEnrichment:
-    def __init__(self, conn: asyncpg.Connection) -> None:
+    def __init__(self, conn: asyncpg.Connection | asyncpg.Pool) -> None:
         self.conn = conn
+        self._is_pool = isinstance(conn, asyncpg.Pool)
         self._sem = asyncio.Semaphore(CONCURRENCY)
         self._co_key = os.environ.get("CONTACTOUT_API_KEY", "")
         self._stats: dict[str, Any] = {
@@ -52,40 +53,13 @@ class Stage9VulnerabilityEnrichment:
         bdm_ids: list[str] | None = None,
         batch_size: int = 25,
     ) -> dict[str, Any]:
-        if bdm_ids:
-            rows = await self.conn.fetch(
-                """
-                SELECT bdm.id AS bdm_id, bdm.name, bdm.title, bdm.linkedin_url,
-                       bu.id AS bu_id, bu.domain, bu.display_name, bu.gmb_category,
-                       bu.gmb_rating, bu.gmb_review_count, bu.tech_stack, bu.tech_gaps,
-                       bu.dfs_paid_keywords, bu.state, bu.suburb, bu.best_match_service,
-                       bu.score_reason
-                FROM business_decision_makers bdm
-                JOIN business_universe bu ON bu.id = bdm.business_universe_id
-                WHERE bdm.is_current = TRUE
-                  AND bdm.id = ANY($1)
-                ORDER BY bu.propensity_score DESC
-                """,
-                bdm_ids,
-            )
-        else:
-            rows = await self.conn.fetch(
-                """
-                SELECT bdm.id AS bdm_id, bdm.name, bdm.title, bdm.linkedin_url,
-                       bu.id AS bu_id, bu.domain, bu.display_name, bu.gmb_category,
-                       bu.gmb_rating, bu.gmb_review_count, bu.tech_stack, bu.tech_gaps,
-                       bu.dfs_paid_keywords, bu.state, bu.suburb, bu.best_match_service,
-                       bu.score_reason
-                FROM business_decision_makers bdm
-                JOIN business_universe bu ON bu.id = bdm.business_universe_id
-                WHERE bdm.is_current = TRUE
-                  AND bu.pipeline_stage < $1
-                ORDER BY bu.propensity_score DESC
-                LIMIT $2
-                """,
-                PIPELINE_STAGE_S9,
-                batch_size,
-            )
+        conn = await self._acquire()
+        try:
+            rows = await self._fetch_rows(conn, bdm_ids, batch_size)
+        finally:
+            await self._release(conn)
+        if not rows:
+            return {**self._stats, "processed": 0, "cost_total_usd": 0.0, "cost_total_aud": 0.0}
 
         tasks = [self._process_one(dict(row)) for row in rows]
         await asyncio.gather(*tasks, return_exceptions=True)
@@ -107,29 +81,84 @@ class Stage9VulnerabilityEnrichment:
             "cost_total_aud": round(total_usd * 1.55, 4),
         }
 
+    async def _fetch_rows(self, conn, bdm_ids, batch_size):
+        if bdm_ids:
+            return await conn.fetch(
+                """
+                SELECT bdm.id AS bdm_id, bdm.name, bdm.title, bdm.linkedin_url,
+                       bu.id AS bu_id, bu.domain, bu.display_name, bu.gmb_category,
+                       bu.gmb_rating, bu.gmb_review_count, bu.tech_stack, bu.tech_gaps,
+                       bu.dfs_paid_keywords, bu.state, bu.suburb, bu.best_match_service,
+                       bu.score_reason
+                FROM business_decision_makers bdm
+                JOIN business_universe bu ON bu.id = bdm.business_universe_id
+                WHERE bdm.is_current = TRUE
+                  AND bdm.id = ANY($1)
+                ORDER BY bu.propensity_score DESC
+                """,
+                bdm_ids,
+            )
+        else:
+            return await conn.fetch(
+                """
+                SELECT bdm.id AS bdm_id, bdm.name, bdm.title, bdm.linkedin_url,
+                       bu.id AS bu_id, bu.domain, bu.display_name, bu.gmb_category,
+                       bu.gmb_rating, bu.gmb_review_count, bu.tech_stack, bu.tech_gaps,
+                       bu.dfs_paid_keywords, bu.state, bu.suburb, bu.best_match_service,
+                       bu.score_reason
+                FROM business_decision_makers bdm
+                JOIN business_universe bu ON bu.id = bdm.business_universe_id
+                WHERE bdm.is_current = TRUE
+                  AND bu.pipeline_stage < $1
+                ORDER BY bu.propensity_score DESC
+                LIMIT $2
+                """,
+                PIPELINE_STAGE_S9,
+                batch_size,
+            )
+
+    async def _acquire(self):
+        """Acquire a connection — from pool or return single conn."""
+        if self._is_pool:
+            return await self.conn.acquire()
+        return self.conn
+
+    async def _release(self, conn):
+        """Release connection back to pool if pooled."""
+        if self._is_pool:
+            await self.conn.release(conn)
+
     async def _process_one(self, row: dict) -> None:
         async with self._sem:
             bu_data = {k: v for k, v in row.items() if not k.startswith("bdm_")}
             bu_data["bu_id"] = row["bu_id"]
 
+            # VR and ContactOut run in parallel — each acquires its own connection
             vr_task = self._generate_vr(bu_data)
             co_task = self._enrich_contactout(row["bdm_id"], row.get("linkedin_url"))
             await asyncio.gather(vr_task, co_task, return_exceptions=True)
 
-            await self.conn.execute(
-                "UPDATE business_universe SET pipeline_stage = $1, pipeline_updated_at = $2 WHERE id = $3",
-                PIPELINE_STAGE_S9,
-                datetime.now(UTC),
-                row["bu_id"],
-            )
+            conn = await self._acquire()
+            try:
+                await conn.execute(
+                    "UPDATE business_universe SET pipeline_stage = $1, pipeline_updated_at = $2 WHERE id = $3",
+                    PIPELINE_STAGE_S9,
+                    datetime.now(UTC),
+                    row["bu_id"],
+                )
+            finally:
+                await self._release(conn)
 
     async def _generate_vr(self, bu_data: dict) -> dict | None:
         domain = bu_data.get("domain") or ""
         company_name = bu_data.get("display_name") or domain
+        # Cast Decimal to float — Postgres returns numeric as Decimal
+        gmb_rating = bu_data.get("gmb_rating")
+        gmb_rating = float(gmb_rating) if gmb_rating is not None else None
 
         enrichment = {
-            "gmb_rating": bu_data.get("gmb_rating"),
-            "gmb_review_count": bu_data.get("gmb_review_count") or 0,
+            "gmb_rating": gmb_rating,
+            "gmb_review_count": int(bu_data.get("gmb_review_count") or 0),
             "gmb_found": True,
             "is_running_ads": (bu_data.get("dfs_paid_keywords") or 0) > 0,
             "ad_count": bu_data.get("dfs_paid_keywords") or 0,
@@ -154,12 +183,16 @@ class Stage9VulnerabilityEnrichment:
             report = await generate_vulnerability_report(
                 domain, company_name, enrichment, intelligence
             )
-            await self.conn.execute(
-                "UPDATE business_universe SET vulnerability_report = $1, pipeline_updated_at = $2 WHERE id = $3",
-                json.dumps(report),
-                datetime.now(UTC),
-                bu_data["bu_id"],
-            )
+            conn = await self._acquire()
+            try:
+                await conn.execute(
+                    "UPDATE business_universe SET vulnerability_report = $1, pipeline_updated_at = $2 WHERE id = $3",
+                    json.dumps(report),
+                    datetime.now(UTC),
+                    bu_data["bu_id"],
+                )
+            finally:
+                await self._release(conn)
             self._stats["vr_generated"] += 1
             self._stats["cost_vr_usd"] += _VR_COST_USD
             logger.info("VR generated domain=%s", domain)
@@ -201,34 +234,38 @@ class Stage9VulnerabilityEnrichment:
             about = profile.get("about") or profile.get("summary")
             connections_count = profile.get("connections_count") or profile.get("connections")
 
-            await self.conn.execute(
-                """
-                UPDATE business_decision_makers SET
-                    headline = $1,
-                    experience_json = $2,
-                    skills = $3,
-                    education = $4,
-                    seniority = $5,
-                    job_function = $6,
-                    about = $7,
-                    connections_count = $8,
-                    profile_source = 'contactout',
-                    profile_last_enriched_at = $9,
-                    raw_contactout_payload = $10
-                WHERE id = $11
-                """,
-                headline,
-                json.dumps(experience) if experience is not None else None,
-                list(skills) if skills is not None else None,
-                json.dumps(education) if education is not None else None,
-                seniority,
-                job_function,
-                about,
-                connections_count,
-                datetime.now(UTC),
-                json.dumps(data),
-                bdm_id,
-            )
+            conn = await self._acquire()
+            try:
+                await conn.execute(
+                    """
+                    UPDATE business_decision_makers SET
+                        headline = $1,
+                        experience_json = $2,
+                        skills = $3,
+                        education = $4,
+                        seniority = $5,
+                        job_function = $6,
+                        about = $7,
+                        connections_count = $8,
+                        profile_source = 'contactout',
+                        profile_last_enriched_at = $9,
+                        raw_contactout_payload = $10
+                    WHERE id = $11
+                    """,
+                    headline,
+                    json.dumps(experience) if experience is not None else None,
+                    list(skills) if skills is not None else None,
+                    json.dumps(education) if education is not None else None,
+                    seniority,
+                    job_function,
+                    about,
+                    connections_count,
+                    datetime.now(UTC),
+                    json.dumps(data),
+                    bdm_id,
+                )
+            finally:
+                await self._release(conn)
 
             self._stats["co_enriched"] += 1
             self._stats["cost_co_usd"] += _CO_COST_USD

--- a/tests/test_stage_9_vulnerability_enrichment.py
+++ b/tests/test_stage_9_vulnerability_enrichment.py
@@ -702,6 +702,49 @@ async def test_experience_json_serialized():
 
 
 @pytest.mark.asyncio
+async def test_decimal_gmb_rating_serialization():
+    """Decimal('4.9') from Postgres must not cause json.dumps failure in _generate_vr."""
+    from decimal import Decimal
+
+    stage, conn = make_stage()
+
+    with patch("src.pipeline.stage_9_vulnerability_enrichment.generate_vulnerability_report") as mock_vr:
+        mock_vr.return_value = make_vr_report()
+
+        bu_data = {
+            "bu_id": "bu-decimal",
+            "domain": "decimal.com.au",
+            "display_name": "Decimal Co",
+            "gmb_rating": Decimal("4.9"),
+            "gmb_review_count": 55,
+            "dfs_paid_keywords": 0,
+            "tech_stack": [],
+            "tech_gaps": [],
+        }
+
+        # Should not raise — Decimal cast to float before json.dumps
+        result = await stage._generate_vr(bu_data)
+        assert result is not None
+
+        # Verify the enrichment dict passed to generate_vulnerability_report has float
+        enrichment_arg = mock_vr.call_args[0][2]
+        assert isinstance(enrichment_arg["gmb_rating"], float)
+        assert enrichment_arg["gmb_rating"] == 4.9
+
+        # Verify json.dumps does not raise on the result
+        json.dumps(enrichment_arg)  # would raise TypeError if Decimal slipped through
+
+
+def test_pool_connection_accepted():
+    """Stage9VulnerabilityEnrichment must accept a mock pool object (asyncpg.Pool-like)."""
+    import asyncpg as _asyncpg
+    pool = MagicMock(spec=_asyncpg.Pool)
+    stage = Stage9VulnerabilityEnrichment(pool)
+    assert stage._is_pool is True
+    assert stage.conn is pool
+
+
+@pytest.mark.asyncio
 async def test_education_json_serialized():
     """Education list serialized as JSON in education"""
     stage, conn = make_stage()


### PR DESCRIPTION
## Summary
- Cast `gmb_rating` from `Decimal` to `float` before passing to `json.dumps` — Postgres returns numeric as Decimal which is not JSON serializable
- Cast `gmb_review_count` to `int` for same reason
- Accept `asyncpg.Pool` in addition to `asyncpg.Connection` — adds `_is_pool` flag plus `_acquire`/`_release` helpers so every DB operation acquires/releases its own connection, compatible with pgbouncer transaction mode
- Added two new tests: `test_decimal_gmb_rating_serialization` and `test_pool_connection_accepted`

## Test plan
- [ ] `python3 -m pytest tests/test_stage_9_vulnerability_enrichment.py -v` — 22 passed
- [ ] `python3 -m pytest -q --ignore=tests/test_api` — 1424 passed, 28 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)