### PR TITLE
feat(P1.6): BDM dedup + blocklist enforcement + name hygiene

### DIFF
--- a/src/pipeline/stage_10_message_generator.py
+++ b/src/pipeline/stage_10_message_generator.py
@@ -19,6 +19,7 @@ from typing import Any
 import asyncpg
 
 from src.enrichment.signal_config import SignalConfigRepository
+from src.utils.domain_blocklist import BLOCKED_DOMAINS
 
 logger = logging.getLogger(__name__)
 
@@ -139,11 +140,13 @@ class Stage10MessageGenerator:
                 ON bdm.business_universe_id = bu.id AND bdm.is_current = TRUE
             WHERE bu.pipeline_stage = 9
               AND bu.propensity_score >= $1
+              AND bu.domain NOT IN (SELECT unnest($3::text[]))
             ORDER BY bu.propensity_score DESC
             LIMIT $2
             """,
             outreach_gate,
             batch_size,
+            list(BLOCKED_DOMAINS),
         )
 
         messages_generated = 0

--- a/src/pipeline/stage_5_dm_waterfall.py
+++ b/src/pipeline/stage_5_dm_waterfall.py
@@ -345,6 +345,36 @@ class Stage5DMWaterfall:
 
         # Write DM to business_decision_makers (principle #2: canonical record shape)
         if dm and (dm.name or dm.linkedin_url):
+            # P1.6a: dedup — skip INSERT if another is_current BDM already has this linkedin_url
+            if dm.linkedin_url:
+                existing = await self.conn.fetchval(
+                    "SELECT id FROM business_decision_makers WHERE linkedin_url = $1 AND is_current = TRUE",
+                    dm.linkedin_url,
+                )
+                if existing:
+                    logger.info(
+                        "stage5_dedup_skip domain=%s linkedin_url=%s existing_bdm=%s",
+                        business.get("domain"), dm.linkedin_url, existing,
+                    )
+                    # Advance pipeline stage without creating a duplicate BDM
+                    await self.conn.execute(
+                        """
+                        UPDATE business_universe SET
+                            reachability_score = $1,
+                            pipeline_stage = $2,
+                            pipeline_updated_at = $3
+                        WHERE id = $4
+                        """,
+                        reachability,
+                        PIPELINE_STAGE_S5,
+                        now,
+                        row_id,
+                    )
+                    return
+
+            # P1.6d: name hygiene — strip emoji/non-letter leading/trailing chars
+            clean_name = re.sub(r'^[^a-zA-Z]+|[^a-zA-Z.]+$', '', dm.name).strip() if dm.name else None
+
             # Mark any existing current DM as not-current first
             await self.conn.execute(
                 """
@@ -364,7 +394,7 @@ class Stage5DMWaterfall:
                 ) VALUES ($1, $2, $3, $4, $5, $6, TRUE, $7, $7)
                 """,
                 row_id,
-                dm.name,
+                clean_name,
                 dm.title,
                 dm.linkedin_url,
                 dm.email,
@@ -372,7 +402,7 @@ class Stage5DMWaterfall:
                 now,
             )
             logger.info("stage5_dm_write domain=%s dm=%s → business_decision_makers",
-                        business.get("domain"), dm.name)
+                        business.get("domain"), clean_name)
 
         # Update BU pipeline state only (no dm_* fields)
         await self.conn.execute(

--- a/src/pipeline/stage_9_vulnerability_enrichment.py
+++ b/src/pipeline/stage_9_vulnerability_enrichment.py
@@ -21,6 +21,7 @@ import asyncpg
 import httpx
 
 from src.pipeline.intelligence import generate_vulnerability_report
+from src.utils.domain_blocklist import BLOCKED_DOMAINS
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +83,7 @@ class Stage9VulnerabilityEnrichment:
         }
 
     async def _fetch_rows(self, conn, bdm_ids, batch_size):
+        blocked = list(BLOCKED_DOMAINS)
         if bdm_ids:
             return await conn.fetch(
                 """
@@ -94,9 +96,11 @@ class Stage9VulnerabilityEnrichment:
                 JOIN business_universe bu ON bu.id = bdm.business_universe_id
                 WHERE bdm.is_current = TRUE
                   AND bdm.id = ANY($1)
+                  AND bu.domain NOT IN (SELECT unnest($2::text[]))
                 ORDER BY bu.propensity_score DESC
                 """,
                 bdm_ids,
+                blocked,
             )
         else:
             return await conn.fetch(
@@ -110,11 +114,13 @@ class Stage9VulnerabilityEnrichment:
                 JOIN business_universe bu ON bu.id = bdm.business_universe_id
                 WHERE bdm.is_current = TRUE
                   AND bu.pipeline_stage < $1
+                  AND bu.domain NOT IN (SELECT unnest($3::text[]))
                 ORDER BY bu.propensity_score DESC
                 LIMIT $2
                 """,
                 PIPELINE_STAGE_S9,
                 batch_size,
+                blocked,
             )
 
     async def _acquire(self):

--- a/supabase/migrations/20260413_p1_6_bdm_dedup_cleanup.sql
+++ b/supabase/migrations/20260413_p1_6_bdm_dedup_cleanup.sql
@@ -1,0 +1,19 @@
+-- P1.6: Mark duplicate BDMs as not-current, keeping highest propensity per linkedin_url
+BEGIN;
+
+WITH ranked AS (
+    SELECT bdm.id,
+           ROW_NUMBER() OVER (
+               PARTITION BY bdm.linkedin_url
+               ORDER BY bu.propensity_score DESC NULLS LAST, bdm.created_at ASC
+           ) AS rn
+    FROM business_decision_makers bdm
+    JOIN business_universe bu ON bu.id = bdm.business_universe_id
+    WHERE bdm.is_current = TRUE
+      AND bdm.linkedin_url IS NOT NULL
+)
+UPDATE business_decision_makers
+SET is_current = FALSE, updated_at = NOW()
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+COMMIT;

--- a/tests/ci_guards/test_no_duplicate_bdm_linkedin.py
+++ b/tests/ci_guards/test_no_duplicate_bdm_linkedin.py
@@ -1,0 +1,14 @@
+"""
+CI guard: Stage 5 dedup design contract.
+Verifies the dedup path (fetchval check + early return) is present in _write_result.
+"""
+import inspect
+
+
+def test_stage5_write_result_has_dedup_guard():
+    """_write_result must call fetchval to detect duplicate linkedin_url before INSERT."""
+    from src.pipeline.stage_5_dm_waterfall import Stage5DMWaterfall
+
+    source = inspect.getsource(Stage5DMWaterfall._write_result)
+    assert "fetchval" in source, "_write_result must use fetchval to check for duplicate linkedin_url"
+    assert "stage5_dedup_skip" in source, "_write_result must log stage5_dedup_skip on duplicate"

--- a/tests/test_p1_6_bdm_dedup.py
+++ b/tests/test_p1_6_bdm_dedup.py
@@ -1,0 +1,95 @@
+"""
+P1.6 BDM dedup + blocklist enforcement + name hygiene — CI tests.
+Tests: dedup skip, stage 9 blocklist, stage 10 blocklist, name hygiene (emoji + normal).
+"""
+from __future__ import annotations
+
+import re
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _apply_name_hygiene(name: str | None) -> str | None:
+    """Mirror of the hygiene logic in stage_5_dm_waterfall._write_result."""
+    return re.sub(r'^[^a-zA-Z]+|[^a-zA-Z.]+$', '', name).strip() if name else None
+
+
+# ── item (a): Stage 5 dedup ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_stage5_dedup_skips_existing_linkedin():
+    """Stage 5 must not INSERT a second BDM when linkedin_url already exists."""
+    from src.pipeline.stage_5_dm_waterfall import DMResult, Stage5DMWaterfall
+
+    conn = AsyncMock()
+    # fetchval returns an existing BDM id → duplicate detected
+    conn.fetchval = AsyncMock(return_value="existing-bdm-uuid")
+    conn.execute = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+
+    lm_client = MagicMock()
+    signal_repo = MagicMock()
+    config = MagicMock()
+    config.enrichment_gates = {"min_score_to_dm": 50}
+    signal_repo.get_config = AsyncMock(return_value=config)
+
+    stage = Stage5DMWaterfall(lm_client, signal_repo, conn)
+
+    dm = DMResult(name="Christian Oien", linkedin_url="https://linkedin.com/in/christian-oien", source="leadmagic")
+    business = {"id": "bu-1", "domain": "example.com.au", "propensity_score": 80}
+
+    await stage._write_result("bu-1", dm, business)
+
+    # fetchval must have been called to check for duplicate
+    conn.fetchval.assert_called_once()
+    call_args = conn.fetchval.call_args[0]
+    assert "linkedin_url" in call_args[0]  # the SQL contains linkedin_url
+    assert call_args[1] == "https://linkedin.com/in/christian-oien"
+
+    # No INSERT should have been issued
+    insert_calls = [
+        c for c in conn.execute.call_args_list
+        if "INSERT" in str(c)
+    ]
+    assert len(insert_calls) == 0, "INSERT must not be called for a duplicate linkedin_url"
+
+
+# ── item (b): Stage 9 blocklist ───────────────────────────────────────────────
+
+def test_stage9_blocklist_filter_in_query():
+    """Stage 9 batch SELECT must contain NOT IN blocklist filter."""
+    import inspect
+    import src.pipeline.stage_9_vulnerability_enrichment as s9_mod
+
+    source = inspect.getsource(s9_mod)
+    assert "NOT IN" in source, "Stage 9 source must contain NOT IN filter"
+    assert "BLOCKED_DOMAINS" in source, "Stage 9 must import and use BLOCKED_DOMAINS"
+
+
+# ── item (b): Stage 10 blocklist ──────────────────────────────────────────────
+
+def test_stage10_blocklist_filter_in_query():
+    """Stage 10 batch SELECT must contain NOT IN blocklist filter."""
+    import inspect
+    import src.pipeline.stage_10_message_generator as s10_mod
+
+    source = inspect.getsource(s10_mod)
+    assert "NOT IN" in source, "Stage 10 source must contain NOT IN filter"
+    assert "BLOCKED_DOMAINS" in source, "Stage 10 must import and use BLOCKED_DOMAINS"
+
+
+# ── item (d): Name hygiene ────────────────────────────────────────────────────
+
+def test_name_hygiene_strips_emoji():
+    """'📊 Louie Ramos' must become 'Louie Ramos'."""
+    result = _apply_name_hygiene("📊 Louie Ramos")
+    assert result == "Louie Ramos", f"Expected 'Louie Ramos', got {result!r}"
+
+
+def test_name_hygiene_preserves_normal():
+    """'Mark Gadeley' must remain 'Mark Gadeley' unchanged."""
+    result = _apply_name_hygiene("Mark Gadeley")
+    assert result == "Mark Gadeley", f"Expected 'Mark Gadeley', got {result!r}"

--- a/tests/test_stage_5_dm_waterfall.py
+++ b/tests/test_stage_5_dm_waterfall.py
@@ -43,10 +43,12 @@ def make_row(**overrides):
     return row
 
 
-def make_conn(rows=None):
+def make_conn(rows=None, existing_bdm_id=None):
     conn = MagicMock()
     conn.fetch = AsyncMock(return_value=[make_row()] if rows is None else rows)
     conn.execute = AsyncMock(return_value=None)
+    # fetchval used by P1.6a dedup check — default None (no duplicate)
+    conn.fetchval = AsyncMock(return_value=existing_bdm_id)
     return conn
 
 


### PR DESCRIPTION
## Summary
- **Stage 5 dedup (a):** `_write_result` now checks `fetchval` for existing `is_current=TRUE` BDM with same `linkedin_url` before INSERT. Duplicate skips INSERT, logs `stage5_dedup_skip`, still advances pipeline stage. Fixes 23-row Christian Oien contamination and Matt Pontey double.
- **Stage 9/10 blocklist (b):** Both batch SELECT queries now filter `bu.domain NOT IN (SELECT unnest($N::text[]))` using `BLOCKED_DOMAINS`. Fixes bupadental.com.au reaching pipeline.
- **BDM cleanup migration (c):** `supabase/migrations/20260413_p1_6_bdm_dedup_cleanup.sql` marks all duplicate `linkedin_url` rows `is_current=FALSE`, keeping highest-propensity per URL.
- **Name hygiene (d):** `clean_name = re.sub(r'^[^a-zA-Z]+|[^a-zA-Z.]+$', '', dm.name).strip()` at write path. Fixes '📊 Louie Ramos' → 'Louie Ramos'.
- **CI guard (e):** `tests/ci_guards/test_no_duplicate_bdm_linkedin.py` + `tests/test_p1_6_bdm_dedup.py` — 6 tests, all green.

## Test plan
- [x] `tests/test_p1_6_bdm_dedup.py` — 5 tests (dedup skip, stage 9 blocklist, stage 10 blocklist, emoji strip, normal name)
- [x] `tests/ci_guards/test_no_duplicate_bdm_linkedin.py` — design contract guard
- [x] `tests/test_stage_5_dm_waterfall.py` — all 11 existing tests still pass (fixed mock to add AsyncMock fetchval)
- [x] Full suite: 1426 passed (0 regressions introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)