### PR TITLE
feat(P1.7): NULL-URL BDM cleanup + write-path guards + AU TLD enforcement

### DIFF
--- a/src/orchestration/flows/stage_9_10_flow.py
+++ b/src/orchestration/flows/stage_9_10_flow.py
@@ -65,6 +65,12 @@ WITH deduped AS (
       AND bdm.linkedin_url IS NOT NULL
       AND bdm.name IS NOT NULL AND bdm.name != 'Unknown'
       AND bu.pipeline_stage = 9
+      AND (bu.domain LIKE '%.com.au' OR bu.domain LIKE '%.net.au'
+           OR bu.domain LIKE '%.id.au' OR bu.domain LIKE '%.asn.au'
+           OR bu.domain LIKE '%.sydney' OR bu.domain LIKE '%.melbourne'
+           OR bu.domain LIKE '%.perth' OR bu.domain LIKE '%.brisbane')
+      AND bu.domain NOT LIKE '%.gov.au'
+      AND bu.domain NOT LIKE '%.gov'
     ORDER BY bdm.linkedin_url, bu.propensity_score DESC
 )
 SELECT bdm_id FROM deduped LIMIT $1

--- a/src/pipeline/stage_5_dm_waterfall.py
+++ b/src/pipeline/stage_5_dm_waterfall.py
@@ -345,6 +345,26 @@ class Stage5DMWaterfall:
 
         # Write DM to business_decision_makers (principle #2: canonical record shape)
         if dm and (dm.name or dm.linkedin_url):
+            # P1.7b: NULL-URL guard — skip INSERT unless at least one contact method present
+            if dm and not (dm.linkedin_url or dm.email):
+                logger.info("stage5_skip_no_contact domain=%s name=%s reason=no_linkedin_no_email",
+                            business.get("domain"), dm.name)
+                # Still advance pipeline stage but don't create non-actionable BDM
+                await self.conn.execute(
+                    """
+                    UPDATE business_universe SET
+                        reachability_score = $1,
+                        pipeline_stage = $2,
+                        pipeline_updated_at = $3
+                    WHERE id = $4
+                    """,
+                    reachability,
+                    PIPELINE_STAGE_S5,
+                    now,
+                    row_id,
+                )
+                return
+
             # P1.6a: dedup — skip INSERT if another is_current BDM already has this linkedin_url
             if dm.linkedin_url:
                 existing = await self.conn.fetchval(
@@ -374,6 +394,9 @@ class Stage5DMWaterfall:
 
             # P1.6d: name hygiene — strip emoji/non-letter leading/trailing chars
             clean_name = re.sub(r'^[^a-zA-Z]+|[^a-zA-Z.]+$', '', dm.name).strip() if dm.name else None
+            # P1.7d: title-case normalization — "sian mcconnell" → "Sian Mcconnell"
+            if clean_name:
+                clean_name = clean_name.title()
 
             # Mark any existing current DM as not-current first
             await self.conn.execute(

--- a/supabase/migrations/20260413_p1_7_bdm_null_url_cleanup.sql
+++ b/supabase/migrations/20260413_p1_7_bdm_null_url_cleanup.sql
@@ -1,0 +1,26 @@
+-- P1.7: Mark BDMs with NULL linkedin_url as not-current
+-- These are non-actionable placeholder rows from Stage 5
+BEGIN;
+
+UPDATE business_decision_makers
+SET is_current = FALSE, updated_at = NOW()
+WHERE is_current = TRUE
+  AND linkedin_url IS NULL;
+
+-- Also mark BDMs for blocked domains as not-current
+UPDATE business_decision_makers
+SET is_current = FALSE, updated_at = NOW()
+WHERE is_current = TRUE
+  AND business_universe_id IN (
+    SELECT id FROM business_universe
+    WHERE domain IN (
+      '1300smiles.com.au','bupadental.com.au','dentalcorp.com.au','dentalone.com.au',
+      'marchorthodontics.com.au','maven.dental','mavendental.com.au','mcdental.com.au',
+      'nationaldentalcare.com.au','nibdental.com.au','odontologie.com.au',
+      'pacificsmiles.com.au','primarydental.com.au','rsdentalgroup.com.au',
+      'smileclub.com.au','smilepath.com.au','smilesolutions.com.au','smileteam.com.au',
+      'stjohnhealth.com.au','totalortho.com.au'
+    )
+  );
+
+COMMIT;

--- a/tests/ci_guards/test_no_unknown_bdm_name.py
+++ b/tests/ci_guards/test_no_unknown_bdm_name.py
@@ -1,0 +1,11 @@
+"""CI guard: no is_current BDM should have name='Unknown'."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+def test_stage5_rejects_unknown_name():
+    """Stage 5 should not write BDMs with name='Unknown'."""
+    # This tests the write-path guard, not prod data
+    # Import DMResult and verify is_valid returns False for name="Unknown" with no contact
+    from src.pipeline.stage_5_dm_waterfall import DMResult
+    dm = DMResult(name="Unknown", source="test")
+    assert not dm.is_valid  # No contact method = not valid

--- a/tests/test_p1_7_bdm_cleanup.py
+++ b/tests/test_p1_7_bdm_cleanup.py
@@ -1,0 +1,125 @@
+"""
+P1.7: Tests for NULL-URL BDM write-path guard, name normalization,
+unknown name rejection, and AU TLD filter in flow SQL.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# 1. NULL-URL guard — no INSERT when both linkedin_url and email are absent
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_null_url_guard_skips_insert():
+    """dm with no linkedin_url and no email should not INSERT into BDM table."""
+    from src.pipeline.stage_5_dm_waterfall import Stage5DMWaterfall, DMResult
+
+    stage = Stage5DMWaterfall.__new__(Stage5DMWaterfall)
+    stage.conn = AsyncMock()
+    stage.conn.fetchval = AsyncMock(return_value=None)
+    stage.conn.execute = AsyncMock()
+
+    dm = DMResult(name="Jane Smith", source="test", linkedin_url=None, email=None)
+    business = {"id": "biz-001", "domain": "example.com.au"}
+
+    await stage._write_result("biz-001", dm, business)
+
+    # No UPDATE to business_decision_makers (only BU pipeline UPDATE should fire)
+    calls = [str(c) for c in stage.conn.execute.call_args_list]
+    # The INSERT SQL contains 'INSERT INTO business_decision_makers'
+    insert_calls = [c for c in calls if "INSERT INTO business_decision_makers" in c]
+    assert len(insert_calls) == 0, f"Expected no BDM INSERT but got: {insert_calls}"
+
+
+# ---------------------------------------------------------------------------
+# 2. NULL-URL guard allows INSERT when email is present
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_null_url_guard_allows_with_email():
+    """dm with email but no linkedin_url should proceed to INSERT."""
+    from src.pipeline.stage_5_dm_waterfall import Stage5DMWaterfall, DMResult
+
+    stage = Stage5DMWaterfall.__new__(Stage5DMWaterfall)
+    stage.conn = AsyncMock()
+    stage.conn.fetchval = AsyncMock(return_value=None)
+    stage.conn.execute = AsyncMock()
+
+    dm = DMResult(
+        name="Jane Smith", source="test", linkedin_url=None, email="jane@example.com.au"
+    )
+    business = {
+        "id": "biz-002", "domain": "example.com.au",
+        "dm_email": None, "dm_phone": None, "phone": None,
+        "address": None, "gmb_place_id": None,
+    }
+
+    await stage._write_result("biz-002", dm, business)
+
+    calls = [str(c) for c in stage.conn.execute.call_args_list]
+    insert_calls = [c for c in calls if "INSERT INTO business_decision_makers" in c]
+    assert len(insert_calls) == 1, f"Expected 1 BDM INSERT but got: {insert_calls}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Name title-case normalization — lowercase input
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_name_title_case_normalization():
+    """'sian mcconnell' must be stored as 'Sian Mcconnell'."""
+    from src.pipeline.stage_5_dm_waterfall import Stage5DMWaterfall, DMResult
+
+    stage = Stage5DMWaterfall.__new__(Stage5DMWaterfall)
+    stage.conn = AsyncMock()
+    stage.conn.fetchval = AsyncMock(return_value=None)
+
+    captured = {}
+
+    async def capture_execute(sql, *args):
+        if "INSERT INTO business_decision_makers" in sql:
+            captured["name"] = args[1]  # $2 = name
+
+    stage.conn.execute = capture_execute
+
+    dm = DMResult(
+        name="sian mcconnell", source="test",
+        email="sian@example.com.au", linkedin_url=None,
+    )
+    business = {
+        "id": "biz-003", "domain": "example.com.au",
+        "dm_email": None, "dm_phone": None, "phone": None,
+        "address": None, "gmb_place_id": None,
+    }
+
+    await stage._write_result("biz-003", dm, business)
+    assert captured.get("name") == "Sian Mcconnell", f"Got: {captured.get('name')}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Title-case preserves already-correct casing (Dr John)
+# ---------------------------------------------------------------------------
+def test_name_title_case_preserves_dr():
+    """title() on 'Dr John' gives 'Dr John' — no regression."""
+    name = "Dr John"
+    assert name.strip().title() == "Dr John"
+
+
+# ---------------------------------------------------------------------------
+# 5. DMResult with name='Unknown' and no contact is not valid
+# ---------------------------------------------------------------------------
+def test_unknown_name_dm_not_valid():
+    """DMResult(name='Unknown') without any contact method must not be valid."""
+    from src.pipeline.stage_5_dm_waterfall import DMResult
+
+    dm = DMResult(name="Unknown", source="test")
+    assert not dm.is_valid
+
+
+# ---------------------------------------------------------------------------
+# 6. _DEDUP_SQL contains AU TLD filter
+# ---------------------------------------------------------------------------
+def test_flow_sql_has_au_tld_filter():
+    """_DEDUP_SQL in stage_9_10_flow must contain .com.au filter clause."""
+    from src.orchestration.flows.stage_9_10_flow import _DEDUP_SQL
+
+    assert ".com.au" in _DEDUP_SQL, "_DEDUP_SQL missing AU TLD whitelist"
+    assert ".gov.au" in _DEDUP_SQL, "_DEDUP_SQL missing gov.au exclusion"


### PR DESCRIPTION
## Summary
- Migration marks NULL `linkedin_url` BDMs and 20 blocklist-domain BDMs as `is_current=FALSE`
- Write-path guard in Stage 5 skips INSERT unless `linkedin_url` OR `email` is present (logs and advances pipeline stage only)
- Title-case normalization applied to DM names at write path
- `_DEDUP_SQL` in stage_9_10_flow adds AU TLD whitelist (`.com.au`, `.net.au`, `.id.au`, `.asn.au`, `.sydney`, `.melbourne`, `.perth`, `.brisbane`) and excludes `.gov.au`/`.gov`
- 7 new tests (6 in `tests/test_p1_7_bdm_cleanup.py` + 1 CI guard)

## Test plan
- [x] `python3 -m pytest tests/test_p1_7_bdm_cleanup.py tests/ci_guards/test_no_unknown_bdm_name.py -v` — 7 passed
- [x] `python3 -m py_compile src/pipeline/stage_5_dm_waterfall.py` — OK
- [x] `python3 -m py_compile src/orchestration/flows/stage_9_10_flow.py` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)