### PR TITLE
feat: add stage_2_abn_gst to stage_parallelism.py

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -125,12 +125,15 @@ Core principle: Agency sells services. Prospects have problems. Industry is irre
 ### DISCOVERY
 
 **Single source:** DFS `domain_metrics_by_categories`
-- $0.10 per 100 domains ($0.001 amortised per domain)
-- On-demand batching: 100/batch, sequential per category
+- $0.10 per 100 domains ($0.012 amortised per domain after AU TLD filtering)
+- Categories run in parallel via `asyncio.gather`, DFS calls within category sequential
+- `GLOBAL_SEM_DFS=28` ceiling (peak observed: 10 for 10 categories)
+- Sampling: AU-TLD + ETV window filter FIRST, then take middle 10 of AU SMB pool (~30% position)
 - 22,592 AU dental domains confirmed, 31,445 AU plumbing — pool never exhausts
 - Monthly rotation across categories — refill loop at threshold=20, stops on target_reached
 - `claimed_by` exclusion applied at discovery — never returns already-claimed domains
 - 15 AU categories active across 14 verticals (dental, trades, legal, construction, hospitality, automotive, real estate, accounting, medical, fitness, hair & beauty, veterinary, HVAC, marketing)
+- **RATIFIED 2026-04-13:** 100 domains across 10 categories in 41.2s, $1.20. Ignition (60 cats) projected 4.1 min.
 
 ### Category ETV Windows (Calibrated #328.1, Apr 11 2026)
 
@@ -667,6 +670,9 @@ v6 era (#271–#277): Layer 2 (discovery), Layer 3 (bulk filter), signal config 
 | Phase 1 | P4 | Prefect flow for automated Stage 9→10 pipeline | COMPLETE — PR #308 merged |
 | Phase 1 | P5 | E2E automated live-fire: 25 BDMs, 97/100 dm_messages | COMPLETE — $1.56 USD |
 | Process | M-PROCESS-01 | Directive contract discipline ratified — see AGENTS.md. CTO must STOP and report when directive constraint is infeasible, not autonomously alter methodology. | RATIFIED 2026-04-13 |
+| Process | STYLE | Directive style: CEO specifies outcome + constraints + gates; CTO engineers fastest compliant path. | RATIFIED 2026-04-13 |
+| Stage 1 | S1 | Stage 1 ratified. 41.2s for 100 domains across 10 categories via parallel asyncio.gather. Middle-of-AU-SMB-pool sampling. Baseline locked for Stage 2 input. | RATIFIED 2026-04-13 |
+| Config | stage_2_abn_gst | stage_2_abn_gst added to stage_parallelism.py (50 concurrent, local JOIN). Audit flagged legacy key stage_2_scrape may be obsolete — preserved pending Pipeline E full ratification. | 2026-04-13 |
 
 ### Post-Test Build Queue (next priorities after provider resolution)
 

--- a/src/config/stage_parallelism.py
+++ b/src/config/stage_parallelism.py
@@ -39,13 +39,21 @@ STAGE_PARALLELISM: dict[str, StageConfig] = {
         "safety_margin": 0.67,
         "notes": "Sequential per category (1 call/category). 10 = max parallel categories. DFS ceiling 30 shared across all stages.",
     },
+    "stage_2_abn_gst": {
+        "stage_name": "Stage 2 — ABN + GST Enrichment (local Postgres JOIN)",
+        "concurrency": 50,
+        "provider": "asyncpg_local",
+        "provider_ceiling": 50,
+        "safety_margin": 1.0,
+        "notes": "Trigram fuzzy match against 2.4M ABN rows, CPU+DB bound, 50 concurrent stays under connection pool ceiling. Zero API cost.",
+    },
     "stage_2_scrape": {
-        "stage_name": "Stage 2 — Website Scrape (httpx + Spider)",
+        "stage_name": "Stage 2 — Website Scrape (httpx + Spider) [LEGACY — may be obsolete in Pipeline E]",
         "concurrency": 80,
         "provider": "httpx",
         "provider_ceiling": 100,
         "safety_margin": 0.80,
-        "notes": "httpx sem=80, Spider fallback sem=15. No external rate limit on httpx.",
+        "notes": "httpx sem=80, Spider fallback sem=15. No external rate limit on httpx. AUDIT: may be obsolete if Pipeline E renumbers stages.",
     },
     "stage_3_comprehension": {
         "stage_name": "Stage 3 — Website Comprehension (Sonnet)",


### PR DESCRIPTION
## Summary
- Added `stage_2_abn_gst` key (concurrency=50, local Postgres JOIN, zero API cost)
- Flagged `stage_2_scrape` as potentially obsolete in Pipeline E (preserved, not deleted)
- Manual Section 12 decision log updated

## Audit
11 keys → 12 keys. Only mismatch: `stage_2_scrape` has no Pipeline E stage mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)