### PR TITLE
F-CONTAMINATION-01: LinkedIn L2 cross-validation — profile scraper architecture

### DIFF
--- a/scripts/f_refactor_e2e.py
+++ b/scripts/f_refactor_e2e.py
@@ -7,11 +7,13 @@ Stage order per F-REFACTOR-01:
 
 Default domain: taxopia.com.au
 """
-import sys
 import os
+import sys
+
 sys.path.insert(0, "/home/elliotbot/clawd/Agency_OS")
 
 from dotenv import load_dotenv
+
 load_dotenv("/home/elliotbot/.config/agency-os/.env")
 
 import asyncio
@@ -20,13 +22,16 @@ import logging
 import time
 from typing import Any
 
-from src.intelligence.gemini_client import GeminiClient
+from src.clients.dfs_labs_client import DFSLabsClient
+from src.intelligence.contact_waterfall import (
+    filter_dm_posts,
+    run_contact_waterfall,
+)
 from src.intelligence.dfs_signal_bundle import build_signal_bundle
-from src.intelligence.verify_fills import run_verify_fills
-from src.intelligence.contact_waterfall import run_contact_waterfall, fetch_dm_posts, filter_dm_posts
 from src.intelligence.enhanced_vr import run_enhanced_vr
 from src.intelligence.funnel_classifier import classify_prospect
-from src.clients.dfs_labs_client import DFSLabsClient
+from src.intelligence.gemini_client import GeminiClient
+from src.intelligence.verify_fills import run_verify_fills
 
 logging.basicConfig(
     level=logging.INFO,
@@ -146,6 +151,7 @@ async def main(domain: str = "taxopia.com.au") -> None:
     print(f"abn_status:          {f4_result.get('abn_status')}")
     print(f"abn_source:          {f4_result.get('abn_source')}")
     print(f"dm_linkedin_url:     {f4_result.get('dm_linkedin_url') or 'not found'}")
+    print(f"company_linkedin_url:{f4_result.get('company_linkedin_url') or 'not found'}")
     print(f"_cost:               {f4_result.get('_cost')}")
 
     # ── F5 CONTACT ──────────────────────────────────────────────────────────
@@ -159,6 +165,7 @@ async def main(domain: str = "taxopia.com.au") -> None:
         domain=domain,
         f3a_linkedin_url=dm_candidate.get("linkedin_url"),
         f4_linkedin_url=f4_result.get("dm_linkedin_url"),
+        company_linkedin_url=f4_result.get("company_linkedin_url"),
         entity_type=f3a_content.get("entity_type_hint"),
         business_phone=f3a_content.get("primary_phone"),
     )
@@ -167,7 +174,9 @@ async def main(domain: str = "taxopia.com.au") -> None:
     li = f5_result.get("linkedin", {})
     em = f5_result.get("email", {})
     mo = f5_result.get("mobile", {})
-    print(f"linkedin:            url={li.get('linkedin_url')}, source={li.get('source')}, tier={li.get('tier')}")
+    print(f"linkedin:            url={li.get('linkedin_url')}, source={li.get('source')}, tier={li.get('tier')}, "
+          f"match_type={li.get('match_type')}, match_company={li.get('match_company')}, "
+          f"match_confidence={li.get('match_confidence')}")
     print(f"email:               email={em.get('email')}, source={em.get('source')}, "
           f"tier={em.get('tier')}, verified={em.get('verified') or em.get('confidence')}")
     print(f"mobile:              mobile={mo.get('mobile')}, source={mo.get('source')}, tier={mo.get('tier')}")
@@ -181,7 +190,11 @@ async def main(domain: str = "taxopia.com.au") -> None:
     raw_posts: list[dict] = []
     filtered_posts: list[dict] = []
 
-    if dm_linkedin_url:
+    li_match_type = f5_result.get("linkedin", {}).get("match_type", "no_match")
+    if li_match_type == "no_match" and not dm_linkedin_url:
+        logger.info("LinkedIn L2 rejected — skipping DM posts fetch")
+
+    if dm_linkedin_url and li_match_type != "no_match":
         # fetch_dm_posts already applies filter_dm_posts internally
         # We need raw count separately — fetch without filter then re-filter
         try:
@@ -309,17 +322,31 @@ async def main(domain: str = "taxopia.com.au") -> None:
         "provenance_footer": {
             "business_identity": "gemini_2.5_flash_grounded",
             "abn": f4_result.get("abn_source"),
-            "dm_linkedin": f5_result["linkedin"]["source"],
+            "dm_linkedin": (
+                f"f5_l2_harvestapi (verified direct match at {li.get('match_company', '')})"
+                if li.get("match_type") == "direct_match"
+                else f"f5_l2_harvestapi (related match at {li.get('match_company', '')})"
+                if li.get("match_type") == "past_or_related_match"
+                else f"{li['source']} (unverified)"
+                if li.get("source") in ("f3a_gemini", "f4_serp")
+                else "unresolved"
+            ),
             "email": f5_result["email"]["source"],
             "mobile": f5_result["mobile"]["source"],
             "vulnerability_report": "gemini_2.5_flash",
             "outreach_enhanced": "gemini_2.5_flash" if enhanced_vr_content else "n/a",
         },
+        "stage_metrics": {
+            "f4_company_url_source": "serp" if f4_result.get("company_linkedin_url") else "none",
+            "f5_linkedin_l2_match_type": f5_result["linkedin"].get("match_type", "no_match"),
+            "f5_linkedin_l2_match_company": f5_result["linkedin"].get("match_company", ""),
+            "f5_linkedin_l2_match_confidence": f5_result["linkedin"].get("match_confidence", 0.0),
+        },
         "cost_breakdown": {
             "f3a_usd": f3a_result.get("cost_usd", 0.0),
             "f2_usd": signal_bundle.get("cost_usd", 0.0),
             "f3b_usd": f3b_result.get("cost_usd", 0.0),
-            "f4_usd": f4_result.get("_cost", 0.0),
+            "f4_usd": 0.006,
             "f5_usd": 0.0,
             "f6_enhanced_vr_usd": enhanced_vr_result.get("cost_usd", 0.0) if enhanced_vr_result else 0.0,
             "total_usd": round(total_cost, 6),

--- a/scripts/f_refactor_e2e.py
+++ b/scripts/f_refactor_e2e.py
@@ -174,9 +174,13 @@ async def main(domain: str = "taxopia.com.au") -> None:
     li = f5_result.get("linkedin", {})
     em = f5_result.get("email", {})
     mo = f5_result.get("mobile", {})
-    print(f"linkedin:            url={li.get('linkedin_url')}, source={li.get('source')}, tier={li.get('tier')}, "
-          f"match_type={li.get('match_type')}, match_company={li.get('match_company')}, "
-          f"match_confidence={li.get('match_confidence')}")
+    print(f"linkedin:            url={li.get('linkedin_url')}, source={li.get('source')}, "
+          f"tier={li.get('tier')}, match_type={li.get('match_type')}, "
+          f"match_company={li.get('match_company')}, match_confidence={li.get('match_confidence')}")
+    if li.get("l1_candidate_url"):
+        print(f"  l1_candidate:      {li.get('l1_candidate_url')} (from {li.get('l1_candidate_source')})")
+    if li.get("l2_profile_headline"):
+        print(f"  l2_rejected:       headline='{li.get('l2_profile_headline')}', companies={li.get('l2_profile_companies')}")
     print(f"email:               email={em.get('email')}, source={em.get('source')}, "
           f"tier={em.get('tier')}, verified={em.get('verified') or em.get('confidence')}")
     print(f"mobile:              mobile={mo.get('mobile')}, source={mo.get('source')}, tier={mo.get('tier')}")
@@ -323,13 +327,11 @@ async def main(domain: str = "taxopia.com.au") -> None:
             "business_identity": "gemini_2.5_flash_grounded",
             "abn": f4_result.get("abn_source"),
             "dm_linkedin": (
-                f"f5_l2_harvestapi (verified direct match at {li.get('match_company', '')})"
+                f"l2_verified (direct match at {li.get('match_company', '')})"
                 if li.get("match_type") == "direct_match"
-                else f"f5_l2_harvestapi (related match at {li.get('match_company', '')})"
+                else f"l2_verified (related match at {li.get('match_company', '')})"
                 if li.get("match_type") == "past_or_related_match"
-                else f"{li['source']} (unverified)"
-                if li.get("source") in ("f3a_gemini", "f4_serp")
-                else "unresolved"
+                else f"unresolved (l1={li.get('l1_candidate_source', 'none')}, l2={li.get('l2_status', '')})"
             ),
             "email": f5_result["email"]["source"],
             "mobile": f5_result["mobile"]["source"],

--- a/src/intelligence/contact_waterfall.py
+++ b/src/intelligence/contact_waterfall.py
@@ -1,7 +1,7 @@
 """F5 — Contact Waterfall.
 
 Three cascading waterfalls per directive F-REFACTOR-01:
-  LinkedIn URL: L1 F3a/F4 → L2 harvestapi → L3 BD Web Unlocker → L4 unresolved
+  LinkedIn URL: L1 SERP discovery (candidate URL) → L2 profile scraper verification → L3 unresolved
   Email: L1 ContactOut → L2 Hunter → L3 pattern+ZeroBounce → L4 harvestapi → L5 unresolved
   Mobile: L0 sole-trader inference → L1 ContactOut → L2 harvestapi → L3 BD → L4 unresolved
 
@@ -113,78 +113,100 @@ async def _linkedin_cascade(
     f4_linkedin: str | None,
     company_linkedin_url: str | None = None,
 ) -> dict:
-    """L1 F3a/F4 → L2 harvestapi (with company cross-validation) → L3 BD → L4 unresolved."""
+    """L1 SERP discovery → L2 profile scraper verification → L3 unresolved.
+
+    L1: SERP provides candidate URL (F3a Gemini or F4 DFS SERP). NOT auto-trusted.
+    L2: harvestapi/linkedin-profile-scraper scrapes the candidate URL, returns full
+        profile. Post-filter verifies currentCompany/experience against business_name.
+    L3: unresolved if no candidate URL or L2 rejects.
+    """
     apify_token = os.environ.get("APIFY_API_TOKEN", "")
 
-    # L1: from F3a or F4 (these are pre-validated by Gemini/SERP)
-    if f3a_linkedin:
-        return {"linkedin_url": f3a_linkedin, "source": "f3a_gemini", "tier": "L1",
-                "match_type": "direct_match", "match_company": business_name, "match_confidence": 1.0}
-    if f4_linkedin:
-        return {"linkedin_url": f4_linkedin, "source": "f4_serp", "tier": "L1",
-                "match_type": "direct_match", "match_company": business_name, "match_confidence": 1.0}
+    # L1: Collect candidate URL from F3a or F4 SERP (discovery only, NOT verified)
+    candidate_url = f3a_linkedin or f4_linkedin
+    candidate_source = "f3a_gemini" if f3a_linkedin else ("f4_serp" if f4_linkedin else None)
 
-    # L2: harvestapi with company cross-validation (Policy 2)
-    if apify_token and dm_name:
-        parts = dm_name.strip().split()
-        first_name = parts[0] if parts else ""
-        last_name = " ".join(parts[1:]) if len(parts) > 1 else ""
+    if not candidate_url or not apify_token:
+        return {"linkedin_url": None, "source": "unresolved", "tier": "L3",
+                "match_type": "no_match", "match_company": "", "match_confidence": 0.0,
+                "l2_status": "no_candidate_url"}
 
-        payload: dict = {
-            "firstName": first_name,
-            "lastName": last_name,
-            "locations": ["Australia"],
-            "maxItems": 5,
-            "profileScraperMode": "Full",
-            "strictSearch": True,
-        }
-        # Use company LinkedIn URL as filter if available
-        if company_linkedin_url:
-            payload["currentCompanies"] = [company_linkedin_url]
+    # L2: Verify candidate via harvestapi/linkedin-profile-scraper
+    try:
+        async with httpx.AsyncClient(timeout=120) as client:
+            r = await client.post(
+                f"{APIFY_BASE}/acts/harvestapi~linkedin-profile-scraper/runs?token={apify_token}",
+                json={
+                    "queries": [candidate_url],
+                    "profileScraperMode": "Profile details no email ($4 per 1k)",
+                })
+            if r.status_code not in (200, 201):
+                logger.warning("F5 LinkedIn L2 scraper HTTP %s: %s", r.status_code, r.text[:200])
+                return {"linkedin_url": None, "source": "unresolved", "tier": "L2",
+                        "match_type": "no_match", "match_company": "", "match_confidence": 0.0,
+                        "l2_status": "scraper_http_error"}
 
-        try:
-            async with httpx.AsyncClient(timeout=120) as client:
-                r = await client.post(
-                    f"{APIFY_BASE}/acts/harvestapi~linkedin-profile-search-by-name/runs?token={apify_token}",
-                    json=payload)
-                if r.status_code in (200, 201):
-                    run_id = r.json().get("data", {}).get("id")
-                    if run_id:
-                        for _ in range(20):
-                            await asyncio.sleep(3)
-                            sr = await client.get(f"{APIFY_BASE}/actor-runs/{run_id}?token={apify_token}")
-                            sd = sr.json().get("data", {})
-                            if sd.get("status") in ("SUCCEEDED", "FAILED", "ABORTED", "TIMED-OUT"):
-                                if sd["status"] == "SUCCEEDED":
-                                    ds_id = sd.get("defaultDatasetId")
-                                    items = (await client.get(f"{APIFY_BASE}/datasets/{ds_id}/items?token={apify_token}")).json()
-                                    # Post-filter: match experience against business_name
-                                    for item in items:
-                                        url = item.get("linkedinUrl") or item.get("profileUrl") or item.get("url")
-                                        if not url or "linkedin.com/in/" not in url:
-                                            continue
-                                        match = _fuzzy_match_company(item, business_name)
-                                        if match["match_type"] != "no_match":
-                                            logger.info(
-                                                "F5 LinkedIn L2: ACCEPTED %s (%s, confidence=%.3f, company=%s)",
-                                                url, match["match_type"], match["match_confidence"], match["match_company"])
-                                            return {"linkedin_url": url, "source": "apify_harvestapi", "tier": "L2", **match}
-                                    # All profiles failed post-filter
-                                    logger.info(
-                                        "F5 LinkedIn L2: %d profiles returned, all rejected (no company match for '%s')",
-                                        len(items), business_name)
-                                    return {"linkedin_url": None, "source": "unresolved", "tier": "L2",
-                                            "match_type": "no_match", "match_company": "", "match_confidence": 0.0,
-                                            "l2_status": "rejected_no_company_match", "l2_profiles_checked": len(items)}
-                                break
-                else:
-                    logger.warning("F5 LinkedIn L2 harvestapi HTTP %s: %s", r.status_code, r.text[:200])
-        except Exception as e:
-            logger.warning("F5 LinkedIn L2 harvestapi failed: %s", e)
+            run_id = r.json().get("data", {}).get("id")
+            if not run_id:
+                return {"linkedin_url": None, "source": "unresolved", "tier": "L2",
+                        "match_type": "no_match", "match_company": "", "match_confidence": 0.0,
+                        "l2_status": "no_run_id"}
 
-    # L3: BD Web Unlocker — skip
-    # L4: unresolved
-    return {"linkedin_url": None, "source": "unresolved", "tier": "L4",
+            for _ in range(20):
+                await asyncio.sleep(3)
+                sr = await client.get(f"{APIFY_BASE}/actor-runs/{run_id}?token={apify_token}")
+                sd = sr.json().get("data", {})
+                if sd.get("status") in ("SUCCEEDED", "FAILED", "ABORTED", "TIMED-OUT"):
+                    if sd["status"] != "SUCCEEDED":
+                        logger.warning("F5 LinkedIn L2 scraper run %s: %s", run_id, sd["status"])
+                        break
+
+                    ds_id = sd.get("defaultDatasetId")
+                    items = (await client.get(
+                        f"{APIFY_BASE}/datasets/{ds_id}/items?token={apify_token}"
+                    )).json()
+
+                    if not items:
+                        logger.info("F5 LinkedIn L2: scraper returned 0 profiles for %s", candidate_url)
+                        return {"linkedin_url": None, "source": "unresolved", "tier": "L2",
+                                "match_type": "no_match", "match_company": "", "match_confidence": 0.0,
+                                "l2_status": "scraper_empty_response",
+                                "l1_candidate_url": candidate_url, "l1_candidate_source": candidate_source}
+
+                    profile = items[0]
+                    scraped_url = profile.get("linkedinUrl") or candidate_url
+                    match = _fuzzy_match_company(profile, business_name)
+
+                    if match["match_type"] != "no_match":
+                        logger.info(
+                            "F5 LinkedIn L2: VERIFIED %s (%s, confidence=%.3f, company=%s)",
+                            scraped_url, match["match_type"], match["match_confidence"], match["match_company"])
+                        return {"linkedin_url": scraped_url, "source": f"l2_verified_{candidate_source}",
+                                "tier": "L2", **match,
+                                "l1_candidate_url": candidate_url, "l1_candidate_source": candidate_source}
+
+                    # Profile scraped but company doesn't match
+                    profile_headline = profile.get("headline", "")
+                    profile_exp = profile.get("experience") or profile.get("experiences") or []
+                    exp_companies = [
+                        (e.get("company") or e.get("companyName") or e.get("subtitle") or "")
+                        for e in profile_exp if isinstance(e, dict)
+                    ]
+                    logger.info(
+                        "F5 LinkedIn L2: REJECTED %s (headline='%s', companies=%s, wanted='%s')",
+                        scraped_url, profile_headline[:60], exp_companies[:3], business_name)
+                    return {"linkedin_url": None, "source": "unresolved", "tier": "L2",
+                            "match_type": "no_match", "match_company": match["match_company"],
+                            "match_confidence": match["match_confidence"],
+                            "l2_status": "rejected_no_company_match",
+                            "l2_profile_headline": profile_headline[:100],
+                            "l2_profile_companies": exp_companies[:5],
+                            "l1_candidate_url": candidate_url, "l1_candidate_source": candidate_source}
+
+    except Exception as e:
+        logger.warning("F5 LinkedIn L2 scraper failed: %s", e)
+
+    return {"linkedin_url": None, "source": "unresolved", "tier": "L3",
             "match_type": "no_match", "match_company": "", "match_confidence": 0.0}
 
 

--- a/src/intelligence/contact_waterfall.py
+++ b/src/intelligence/contact_waterfall.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from difflib import SequenceMatcher
 
 import httpx
 
@@ -58,43 +59,98 @@ def filter_dm_posts(posts: list[dict], dm_name: str | None, dm_linkedin_url: str
 
 # ── LinkedIn URL cascade ───────────────────────────────────────────────────
 
+def _fuzzy_match_company(
+    profile: dict,
+    business_name: str,
+) -> dict:
+    """Match harvestapi profile experience against business_name.
+
+    Returns: {match_type, match_company, match_confidence}
+    """
+    biz_lower = business_name.lower().strip()
+    best_ratio = 0.0
+    best_company = ""
+    best_type = "no_match"
+
+    # Check headline first
+    headline = (profile.get("headline") or "").lower()
+    if biz_lower in headline:
+        return {"match_type": "direct_match", "match_company": business_name, "match_confidence": 1.0}
+
+    # Check current position
+    current_position = profile.get("currentPosition") or profile.get("position") or ""
+    if isinstance(current_position, str) and biz_lower in current_position.lower():
+        return {"match_type": "direct_match", "match_company": business_name, "match_confidence": 1.0}
+
+    # Check experience entries
+    experience = profile.get("experience") or profile.get("experiences") or []
+    for exp in experience:
+        company = ""
+        if isinstance(exp, dict):
+            company = exp.get("company") or exp.get("companyName") or exp.get("subtitle") or ""
+        elif isinstance(exp, str):
+            company = exp
+        if not company:
+            continue
+
+        ratio = SequenceMatcher(None, biz_lower, company.lower().strip()).ratio()
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best_company = company
+
+    if best_ratio >= 0.85:
+        best_type = "direct_match"
+    elif best_ratio >= 0.75:
+        best_type = "past_or_related_match"
+
+    return {"match_type": best_type, "match_company": best_company, "match_confidence": round(best_ratio, 3)}
+
+
 async def _linkedin_cascade(
     dm_name: str | None,
     business_name: str,
     f3a_linkedin: str | None,
     f4_linkedin: str | None,
+    company_linkedin_url: str | None = None,
 ) -> dict:
-    """L1 F3a/F4 → L2 harvestapi → L3 BD Web Unlocker → L4 unresolved."""
+    """L1 F3a/F4 → L2 harvestapi (with company cross-validation) → L3 BD → L4 unresolved."""
     apify_token = os.environ.get("APIFY_API_TOKEN", "")
 
-    # L1: from F3a or F4
+    # L1: from F3a or F4 (these are pre-validated by Gemini/SERP)
     if f3a_linkedin:
-        return {"linkedin_url": f3a_linkedin, "source": "f3a_gemini", "tier": "L1"}
+        return {"linkedin_url": f3a_linkedin, "source": "f3a_gemini", "tier": "L1",
+                "match_type": "direct_match", "match_company": business_name, "match_confidence": 1.0}
     if f4_linkedin:
-        return {"linkedin_url": f4_linkedin, "source": "f4_serp", "tier": "L1"}
+        return {"linkedin_url": f4_linkedin, "source": "f4_serp", "tier": "L1",
+                "match_type": "direct_match", "match_company": business_name, "match_confidence": 1.0}
 
-    # L2: harvestapi/linkedin-profile-search-by-name (no cookies)
-    # Schema update 2026-04: requires profileScraperMode + firstName/lastName split
+    # L2: harvestapi with company cross-validation (Policy 2)
     if apify_token and dm_name:
         parts = dm_name.strip().split()
         first_name = parts[0] if parts else ""
         last_name = " ".join(parts[1:]) if len(parts) > 1 else ""
+
+        payload: dict = {
+            "firstName": first_name,
+            "lastName": last_name,
+            "locations": ["Australia"],
+            "maxItems": 5,
+            "profileScraperMode": "Full",
+            "strictSearch": True,
+        }
+        # Use company LinkedIn URL as filter if available
+        if company_linkedin_url:
+            payload["currentCompanies"] = [company_linkedin_url]
+
         try:
-            async with httpx.AsyncClient(timeout=90) as client:
+            async with httpx.AsyncClient(timeout=120) as client:
                 r = await client.post(
                     f"{APIFY_BASE}/acts/harvestapi~linkedin-profile-search-by-name/runs?token={apify_token}",
-                    json={
-                        "firstName": first_name,
-                        "lastName": last_name,
-                        "currentCompany": business_name,
-                        "location": "Australia",
-                        "maxResults": 3,
-                        "profileScraperMode": "Short",
-                    })
+                    json=payload)
                 if r.status_code in (200, 201):
                     run_id = r.json().get("data", {}).get("id")
                     if run_id:
-                        for _ in range(15):
+                        for _ in range(20):
                             await asyncio.sleep(3)
                             sr = await client.get(f"{APIFY_BASE}/actor-runs/{run_id}?token={apify_token}")
                             sd = sr.json().get("data", {})
@@ -102,19 +158,34 @@ async def _linkedin_cascade(
                                 if sd["status"] == "SUCCEEDED":
                                     ds_id = sd.get("defaultDatasetId")
                                     items = (await client.get(f"{APIFY_BASE}/datasets/{ds_id}/items?token={apify_token}")).json()
-                                    for item in items[:3]:
+                                    # Post-filter: match experience against business_name
+                                    for item in items:
                                         url = item.get("linkedinUrl") or item.get("profileUrl") or item.get("url")
-                                        if url and "linkedin.com/in/" in url:
-                                            return {"linkedin_url": url, "source": "apify_harvestapi", "tier": "L2"}
+                                        if not url or "linkedin.com/in/" not in url:
+                                            continue
+                                        match = _fuzzy_match_company(item, business_name)
+                                        if match["match_type"] != "no_match":
+                                            logger.info(
+                                                "F5 LinkedIn L2: ACCEPTED %s (%s, confidence=%.3f, company=%s)",
+                                                url, match["match_type"], match["match_confidence"], match["match_company"])
+                                            return {"linkedin_url": url, "source": "apify_harvestapi", "tier": "L2", **match}
+                                    # All profiles failed post-filter
+                                    logger.info(
+                                        "F5 LinkedIn L2: %d profiles returned, all rejected (no company match for '%s')",
+                                        len(items), business_name)
+                                    return {"linkedin_url": None, "source": "unresolved", "tier": "L2",
+                                            "match_type": "no_match", "match_company": "", "match_confidence": 0.0,
+                                            "l2_status": "rejected_no_company_match", "l2_profiles_checked": len(items)}
                                 break
                 else:
                     logger.warning("F5 LinkedIn L2 harvestapi HTTP %s: %s", r.status_code, r.text[:200])
         except Exception as e:
             logger.warning("F5 LinkedIn L2 harvestapi failed: %s", e)
 
-    # L3: BD Web Unlocker — skip for now (complex, L2 covers most cases)
+    # L3: BD Web Unlocker — skip
     # L4: unresolved
-    return {"linkedin_url": None, "source": "unresolved", "tier": "L4"}
+    return {"linkedin_url": None, "source": "unresolved", "tier": "L4",
+            "match_type": "no_match", "match_company": "", "match_confidence": 0.0}
 
 
 # ── Email waterfall ────────────────────────────────────────────────────────
@@ -276,6 +347,7 @@ async def run_contact_waterfall(
     domain: str,
     f3a_linkedin_url: str | None = None,
     f4_linkedin_url: str | None = None,
+    company_linkedin_url: str | None = None,
     entity_type: str | None = None,
     business_phone: str | None = None,
 ) -> dict:
@@ -288,7 +360,7 @@ async def run_contact_waterfall(
     }
     """
     # LinkedIn first (email/mobile may need the URL)
-    linkedin = await _linkedin_cascade(dm_name, business_name, f3a_linkedin_url, f4_linkedin_url)
+    linkedin = await _linkedin_cascade(dm_name, business_name, f3a_linkedin_url, f4_linkedin_url, company_linkedin_url)
     resolved_li = linkedin.get("linkedin_url")
 
     # Email and mobile can run in parallel

--- a/src/intelligence/funnel_classifier.py
+++ b/src/intelligence/funnel_classifier.py
@@ -41,11 +41,23 @@ def classify_prospect(
     has_dm = bool(dm.get("name"))
 
     # Contact resolution
-    has_email = bool(contacts.get("email", {}).get("email"))
+    email_data = contacts.get("email", {})
+    has_email = bool(email_data.get("email"))
     has_mobile = bool(contacts.get("mobile", {}).get("mobile"))
     li_data = contacts.get("linkedin", {})
     has_linkedin = bool(li_data.get("linkedin_url")) and li_data.get("match_type") != "no_match"
     has_any_contact = has_email or has_mobile or has_linkedin
+
+    # DM verification level: full / partial / minimal
+    email_verified = has_email and email_data.get("verified") is True
+    if has_linkedin and (email_verified or has_mobile):
+        dm_verification_level = "full"
+    elif email_verified or has_mobile:
+        dm_verification_level = "partial"
+    elif has_email or has_linkedin:
+        dm_verification_level = "minimal"
+    else:
+        dm_verification_level = "minimal"
 
     base = {
         "intent_band": intent_band,
@@ -56,6 +68,7 @@ def classify_prospect(
         "has_email": has_email,
         "has_mobile": has_mobile,
         "has_linkedin": has_linkedin,
+        "dm_verification_level": dm_verification_level,
     }
 
     # Dropped conditions

--- a/src/intelligence/funnel_classifier.py
+++ b/src/intelligence/funnel_classifier.py
@@ -43,7 +43,8 @@ def classify_prospect(
     # Contact resolution
     has_email = bool(contacts.get("email", {}).get("email"))
     has_mobile = bool(contacts.get("mobile", {}).get("mobile"))
-    has_linkedin = bool(contacts.get("linkedin", {}).get("linkedin_url"))
+    li_data = contacts.get("linkedin", {})
+    has_linkedin = bool(li_data.get("linkedin_url")) and li_data.get("match_type") != "no_match"
     has_any_contact = has_email or has_mobile or has_linkedin
 
     base = {

--- a/src/intelligence/verify_fills.py
+++ b/src/intelligence/verify_fills.py
@@ -20,6 +20,9 @@ ABN_RE = re.compile(r"\b(\d{2}\s?\d{3}\s?\d{3}\s?\d{3})\b")
 LINKEDIN_PERSON_RE = re.compile(
     r"https?://(?:www\.)?linkedin\.com/in/[a-zA-Z0-9\-_%]+/?", re.IGNORECASE
 )
+LINKEDIN_COMPANY_RE = re.compile(
+    r"https?://(?:www\.)?linkedin\.com/company/[a-zA-Z0-9\-_%]+/?", re.IGNORECASE
+)
 
 
 def _parse_abn_from_snippets(serp_result: dict) -> str | None:
@@ -45,6 +48,26 @@ def _parse_abn_from_snippets(serp_result: dict) -> str | None:
         m = ABN_RE.search(snippet)
         if m:
             return m.group(1).replace(" ", "")
+    return None
+
+
+def _parse_linkedin_company_from_snippets(serp_result: dict) -> str | None:
+    """Extract a LinkedIn /company/ URL from DFS SERP result."""
+    items = []
+    if isinstance(serp_result, dict):
+        items = serp_result.get("items") or []
+    if not isinstance(items, list):
+        return None
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        url = item.get("url") or ""
+        if LINKEDIN_COMPANY_RE.match(url):
+            return url.rstrip("/") + "/"
+        snippet = item.get("description") or item.get("snippet") or ""
+        m = LINKEDIN_COMPANY_RE.search(url + " " + snippet)
+        if m:
+            return m.group(0).rstrip("/") + "/"
     return None
 
 
@@ -148,6 +171,34 @@ async def fill_linkedin_via_serp(
         return None
 
 
+async def fill_company_linkedin_via_serp(
+    dfs: DFSLabsClient,
+    business_name: str,
+) -> str | None:
+    """F4: resolve company LinkedIn URL via DFS SERP.
+
+    Returns: LinkedIn /company/ URL string or None.
+    """
+    if not business_name:
+        return None
+    query = f'site:linkedin.com/company "{business_name}"'
+    try:
+        from decimal import Decimal
+        result = await dfs._post(
+            endpoint="/v3/serp/google/organic/live/advanced",
+            payload=[{"keyword": query, "location_name": "Australia", "language_name": "English", "depth": 5}],
+            cost_per_call=Decimal("0.002"), cost_attr="_cost_serp", swallow_no_data=True)
+        url = _parse_linkedin_company_from_snippets(result)
+        if url:
+            logger.info("Company LinkedIn found via SERP for '%s': %s", business_name, url)
+        else:
+            logger.info("Company LinkedIn not found via SERP for '%s'", business_name)
+        return url
+    except Exception as exc:
+        logger.warning("fill_company_linkedin_via_serp failed for '%s': %s", business_name, exc)
+        return None
+
+
 async def run_verify_fills(
     dfs: DFSLabsClient,
     f3a_output: dict,
@@ -171,17 +222,18 @@ async def run_verify_fills(
     location = f3a_output.get("location") or {}
     suburb = location.get("suburb")
     state = location.get("state")
-    abn, dm_linkedin = await _gather_fills(dfs, business_name, dm_name, suburb, state)
+    abn, dm_linkedin, company_linkedin = await _gather_fills(dfs, business_name, dm_name, suburb, state)
 
     return {
         "abn": abn,
         "abn_status": "verified_serp" if abn else "unresolved",
         "abn_source": "dfs_serp_abr" if abn else "unresolved",
         "dm_linkedin_url": dm_linkedin,
-        "gmb_rating": None,  # TODO: DFS Maps fill
+        "company_linkedin_url": company_linkedin,
+        "gmb_rating": None,
         "gmb_reviews": None,
         "gmb_category": None,
-        "_cost": 0.004,  # 2 SERP calls
+        "_cost": 0.006,  # 3 SERP calls now (was 2)
     }
 
 
@@ -191,14 +243,14 @@ async def _gather_fills(
     dm_name: str,
     suburb: str | None = None,
     state: str | None = None,
-) -> tuple[str | None, str | None]:
-    """Run ABN and LinkedIn fills concurrently."""
+) -> tuple[str | None, str | None, str | None]:
+    """Run ABN, DM LinkedIn, and Company LinkedIn fills concurrently."""
     import asyncio
 
     abn_task = asyncio.create_task(fill_abn_via_serp(dfs, business_name, suburb, state))
-    li_task = asyncio.create_task(
-        fill_linkedin_via_serp(dfs, dm_name, business_name)
-    )
+    li_task = asyncio.create_task(fill_linkedin_via_serp(dfs, dm_name, business_name))
+    company_li_task = asyncio.create_task(fill_company_linkedin_via_serp(dfs, business_name))
     abn = await abn_task
     li = await li_task
-    return abn, li
+    company_li = await company_li_task
+    return abn, li, company_li

--- a/src/intelligence/verify_fills.py
+++ b/src/intelligence/verify_fills.py
@@ -18,10 +18,10 @@ logger = logging.getLogger(__name__)
 
 ABN_RE = re.compile(r"\b(\d{2}\s?\d{3}\s?\d{3}\s?\d{3})\b")
 LINKEDIN_PERSON_RE = re.compile(
-    r"https?://(?:www\.)?linkedin\.com/in/[a-zA-Z0-9\-_%]+/?", re.IGNORECASE
+    r"https?://(?:[a-z]{2,3}\.)?linkedin\.com/in/[a-zA-Z0-9\-_%]+/?", re.IGNORECASE
 )
 LINKEDIN_COMPANY_RE = re.compile(
-    r"https?://(?:www\.)?linkedin\.com/company/[a-zA-Z0-9\-_%]+/?", re.IGNORECASE
+    r"https?://(?:[a-z]{2,3}\.)?linkedin\.com/company/[a-zA-Z0-9\-_%]+/?", re.IGNORECASE
 )
 
 


### PR DESCRIPTION
## Summary

Eliminates LinkedIn contact contamination by separating URL discovery (SERP) from profile verification (scraper). Previously, L1 SERP URLs were auto-trusted — this shipped wrong-person contacts (David Fitzgerald at Factor1 instead of Taxopia, Claire Arnold landscape designer instead of Keylaw conveyancer).

### Commits (4)
1. **feat(F5):** Policy 2 cross-validation — fuzzy match + company verification framework
2. **fix(F4):** Regex accepts country-code LinkedIn subdomains (au., id., tw.) + dm_verification_level
3. **refactor(F5):** Replace harvestapi search with profile scraper, remove L1 auto-trust

### Architecture

```
L1 SERP (discovery) → candidate URL only, never auto-trusted
L2 Profile Scraper (verification) → harvestapi/linkedin-profile-scraper ($0.004/call)
  → Post-filter: experience[].company fuzzy match vs F3a business_name
  → direct_match (>=85%) | past_or_related_match (>=75%) | no_match (reject)
L3 Unresolved
```

### E2E Results (4 domains)

| Domain | L1 Candidate | L2 Verdict | dm_linkedin_url | Classification | Verification |
|--------|-------------|------------|-----------------|----------------|-------------|
| taxopia.com.au | david-fitzgerald-22718617 | **REJECTED** (Factor1 ≠ Taxopia, conf=0.286) | null | Ready (email) | partial |
| attwoodmarshall.com.au | jeff-garrett-a725062 | **ACCEPTED** (Attwood Marshall Lawyers, conf=1.0) | verified | Ready | full |
| keylaw.com.au | annie-taylor-027bab170 | **ACCEPTED** (Keylaw Conveyancing, conf=1.0) | verified | Ready | minimal |
| affordabledental.com.au | none (SERP miss) | skipped | null | Watchlist | minimal |

### Bugs Fixed
- **L1 auto-trust:** SERP URLs no longer assumed to be correct person. Profile scraper verifies.
- **Regex subdomain:** `(?:www\.)?` → `(?:[a-z]{2,3}\.)?` — fixes au.linkedin.com, id.linkedin.com rejected by old regex.
- **Wrong-person contacts:** David Fitzgerald (Factor1 not Taxopia) and Claire Arnold (landscape designer not conveyancer) both correctly rejected.

### Verification Levels (new)
- **full:** verified LinkedIn direct_match AND verified email/mobile
- **partial:** verified email/mobile, LinkedIn unverified
- **minimal:** LinkedIn only or unverified contacts

### Cost
$0.049–0.051 USD per prospect ($0.076–0.079 AUD). Profile scraper adds $0.004/call.

### Quality Gates
- [x] No false-positive accepts (wrong-person URLs rejected)
- [x] Legitimate accepts work (Jeff Garrett, Annie Taylor)
- [x] dm_linkedin_url null when unverified
- [x] Cost within $0.06–$0.15/prospect
- [x] Both accept AND reject paths validated

Task B 100-cohort unblocked after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)