### PR TITLE
fix(F5): Hunter field name + provider auth logging

### DIFF
--- a/src/intelligence/contact_waterfall.py
+++ b/src/intelligence/contact_waterfall.py
@@ -232,7 +232,9 @@ async def _email_waterfall(
                 r = await client.post(CONTACTOUT_ENRICH_URL,
                     headers={"authorization": "basic", "token": co_key},
                     json={"linkedin_url": linkedin_url})
-                if r.status_code == 200:
+                if r.status_code in (401, 403):
+                    logger.error("F5 Email L1 ContactOut AUTH/CREDIT FAILURE: HTTP %s — %s", r.status_code, r.text[:200])
+                elif r.status_code == 200:
                     profile = r.json().get("profile") or r.json().get("person") or r.json()
                     emails = profile.get("emails") or profile.get("work_emails") or []
                     if emails:
@@ -248,10 +250,12 @@ async def _email_waterfall(
             async with httpx.AsyncClient(timeout=15) as client:
                 r = await client.get(HUNTER_EMAIL_FINDER_URL,
                     params={"domain": domain, "first_name": first, "last_name": last, "api_key": hunter_key})
-                if r.status_code == 200:
+                if r.status_code in (401, 403):
+                    logger.error("F5 Email L2 Hunter AUTH FAILURE: HTTP %s — %s", r.status_code, r.text[:200])
+                elif r.status_code == 200:
                     data = r.json().get("data", {})
                     email = data.get("email")
-                    conf = data.get("confidence", 0)
+                    conf = data.get("score", 0) or data.get("confidence", 0)
                     if email and conf >= 70:
                         return {"email": email, "source": "hunter", "tier": "L2", "confidence": conf}
         except Exception as e:
@@ -305,7 +309,9 @@ async def _mobile_waterfall(
                 r = await client.post(CONTACTOUT_ENRICH_URL,
                     headers={"authorization": "basic", "token": co_key},
                     json={"linkedin_url": linkedin_url, "include": ["phone"]})
-                if r.status_code == 200:
+                if r.status_code in (401, 403):
+                    logger.error("F5 Mobile L1 ContactOut AUTH/CREDIT FAILURE: HTTP %s — %s", r.status_code, r.text[:200])
+                elif r.status_code == 200:
                     profile = r.json().get("profile") or r.json()
                     phones = profile.get("phones") or profile.get("phone_numbers") or []
                     for phone in phones:


### PR DESCRIPTION
## Summary

Two fixes from F-DIAGNOSIS-01 investigation on 100-cohort results.

### Fix 1 — Hunter email-finder field name (CRITICAL)
- **Bug:** Code reads `data.get("confidence", 0)` — Hunter returns `score` field
- **Impact:** `conf >= 70` never met → Hunter L2 NEVER fired for entire 100-cohort
- **Evidence:** 3/3 live re-tests returned valid emails (score 96-99) silently dropped
- **Fix:** `data.get("score", 0) or data.get("confidence", 0)`
- **Expected impact:** Email resolution 8% → 60-70%

### Fix 2 — Provider auth/credit failure logging
- **Bug:** ContactOut HTTP 403 (out of credits) silently swallowed — no log entry
- **Fix:** Add `logger.error()` for HTTP 401/403 on ContactOut (email L1 + mobile L1) and Hunter (email L2)
- **Pattern:** Any provider auth/credit failure now logged at ERROR level

### Not in this PR (deferred)
- L2 fuzzy threshold tuning (needs investigation)
- F3a DM retry (needs investigation)
- L2 empty profile problem (needs investigation)

## Test plan
- [ ] Re-run cohort after merge + ContactOut credit top-up
- [ ] Verify Hunter L2 fires and returns emails
- [ ] Verify ContactOut 403 appears in logs when credits exhausted

🤖 Generated with [Claude Code](https://claude.com/claude-code)