### PR TITLE
Directive B: Module fixes — Facebook SERP, scoring separation, structured VR

### DIFF
--- a/src/intelligence/comprehend_schema_f3b.py
+++ b/src/intelligence/comprehend_schema_f3b.py
@@ -1,10 +1,11 @@
-"""Stage 7 — ANALYSE: comprehension schema.
+"""Stage 7 — ANALYSE: vulnerability report + outreach drafts.
 
 Stage 7 ANALYSE fires WITHOUT grounding. Receives Stage 3 IDENTIFY output + DFS signal bundle.
-Generates scoring (affordability, intent, buyer_match), vulnerability analysis,
+Generates vulnerability report (structured, data-driven), intent band classification,
 and personalised outreach drafts.
 
-Scoring fields moved here from Stage 3 IDENTIFY in Pipeline F v2.
+Scoring is handled by Stage 5 prospect_scorer.py (deterministic formula).
+Stage 7 does NOT score — it writes narrative and outreach only.
 
 Sender fields MUST use {{agency_contact_name}} and {{agency_name}} placeholders.
 Do NOT hardcode any agency or contact names.
@@ -15,37 +16,42 @@ Pipeline F v2. Ratified: 2026-04-15.
 """
 from __future__ import annotations
 
-STAGE7_ANALYSE_PROMPT = """You are scoring and generating outreach materials for an Australian SMB prospect.
-You receive the prospect's identity data from Stage 3 IDENTIFY plus a DFS signal bundle with organic/paid metrics.
+STAGE7_ANALYSE_PROMPT = """You are a senior marketing analyst producing a vulnerability report and outreach drafts for an Australian SMB prospect. You receive identity data from Stage 3 IDENTIFY plus a DFS signal bundle with organic/paid/GMB/backlink/tech metrics.
 
-CRITICAL: Do NOT modify identity facts from Stage 3 IDENTIFY. Use them as-is.
+CRITICAL: Do NOT modify identity facts from Stage 3. Use them as-is.
 Sender fields MUST use {{agency_contact_name}} and {{agency_name}} placeholders — never hardcode names.
+Do NOT invent numbers. Only cite data present in the signal bundle. If a metric is missing, omit it.
 
 Return ONLY valid JSON:
 
 {
-  "affordability_score": 0,
-  "affordability_gate": "can_afford | cannot_afford",
   "intent_band_final": "DORMANT | DABBLING | TRYING | STRUGGLING | NOT_TRYING",
   "intent_evidence_final": [
     "evidence citing specific DFS numbers",
     "evidence citing specific DFS numbers",
     "evidence citing specific DFS numbers"
   ],
-  "buyer_match_score": 0,
   "vulnerability_report": {
-    "top_vulnerabilities": [
-      "specific gap 1 with quantified detail",
-      "specific gap 2 with quantified detail",
-      "specific gap 3 with quantified detail"
+    "summary": "2-3 sentence executive summary of their marketing position",
+    "strengths": [
+      "specific thing they do well, with data from the signal bundle"
     ],
-    "quantified_opportunities": [
-      "X keywords on page 2",
-      "Y competitors outranking on Z keyword"
+    "vulnerabilities": [
+      {
+        "area": "SEO | Paid Ads | Social | Reviews | Content | Technical",
+        "finding": "specific gap with quantified data from signals",
+        "impact": "what this costs them in plain English",
+        "recommendation": "what the agency should propose"
+      }
     ],
-    "what_marketing_agency_could_fix": "one paragraph — specific, actionable, referencing their actual gaps"
+    "gmb_health": {
+      "rating": 0,
+      "reviews": 0,
+      "assessment": "Strong | Moderate | Weak — with context"
+    },
+    "recommended_services": ["SEO", "Google Ads", "Social Media Management"],
+    "urgency": "high | medium | low — based on declining metrics or competitive pressure"
   },
-  "buyer_reasoning_summary": "one paragraph — best angle for outreach based on their specific situation",
   "draft_email": {
     "subject": "under 60 chars, specific to their business",
     "body": "3-5 sentences referencing a specific vulnerability, sounds human not AI, signs off as {{agency_contact_name}} from {{agency_name}}"
@@ -55,11 +61,10 @@ Return ONLY valid JSON:
 }
 
 Rules:
-- affordability_score: 0-10, based on business size, online presence, DFS traffic signals, and pricing signals.
-- affordability_gate: "can_afford" if score >= 5, else "cannot_afford".
 - intent_band_final: based on DFS organic signals, paid activity, and website quality. TRYING = active SEO effort. STRUGGLING = effort but poor results. DABBLING = minimal online presence. DORMANT = no activity. NOT_TRYING = deliberately offline.
-- buyer_match_score: 0-10, how well this prospect matches a B2B digital marketing agency ICP.
 - Reference SPECIFIC numbers from the DFS signal bundle (e.g. "you rank for 94 keywords in positions 4-10").
+- Strengths: acknowledge what the business does well FIRST. Builds trust.
+- Vulnerabilities: each must have area + finding + impact + recommendation. Quantify with actual signal data.
 - Sound like a direct, curious Australian professional — not an American corporate salesperson.
 - All monetary amounts in AUD.
-- Vulnerability statements must be quantified where DFS data supports it."""
+- Do NOT generate affordability_score, buyer_match_score, or any scoring fields. Scoring is handled separately."""

--- a/src/intelligence/serp_verify.py
+++ b/src/intelligence/serp_verify.py
@@ -1,9 +1,9 @@
 """Stage 2 — VERIFY: SERP-based candidate discovery.
 
-4 parallel DFS SERP calls per domain to gather candidate data before Gemini.
+5 parallel DFS SERP calls per domain to gather candidate data before Gemini.
 Gemini uses these as starting points, not restrictions.
 
-Pipeline F v2. Ratified: 2026-04-15.
+Pipeline F v2.1. Ratified: 2026-04-15.
 """
 from __future__ import annotations
 
@@ -21,6 +21,9 @@ logger = logging.getLogger(__name__)
 ABN_RE = re.compile(r"\b(\d{2}\s?\d{3}\s?\d{3}\s?\d{3})\b")
 LINKEDIN_COMPANY_RE = re.compile(
     r"https?://(?:[a-z]{2,3}\.)?linkedin\.com/company/[a-zA-Z0-9\-_%]+/?", re.IGNORECASE
+)
+FACEBOOK_PAGE_RE = re.compile(
+    r"https?://(?:www\.)?facebook\.com/[a-zA-Z0-9.\-_]+/?", re.IGNORECASE
 )
 
 
@@ -76,6 +79,18 @@ def _extract_company_linkedin(serp_result: dict) -> str | None:
     return None
 
 
+def _extract_facebook_url(serp_result: dict) -> str | None:
+    """Extract Facebook page URL from SERP results."""
+    items = serp_result.get("items") or []
+    for item in items[:3]:
+        if not isinstance(item, dict):
+            continue
+        url = item.get("url") or ""
+        if FACEBOOK_PAGE_RE.match(url) and "facebook.com/share" not in url:
+            return url.rstrip("/") + "/"
+    return None
+
+
 def _extract_dm_candidate(serp_result: dict) -> str | None:
     """Extract owner/director/founder name from SERP snippets."""
     items = serp_result.get("items") or []
@@ -97,7 +112,7 @@ async def run_serp_verify(
     dfs: "DFSLabsClient",  # noqa: UP037
     domain: str,
 ) -> dict:
-    """Run 4 SERP queries in parallel to gather candidate data for a domain.
+    """Run 5 SERP queries in parallel to gather candidate data for a domain.
 
     Returns:
         {
@@ -105,6 +120,7 @@ async def run_serp_verify(
             "serp_abn": str | None,
             "serp_company_linkedin": str | None,
             "serp_dm_candidate": str | None,
+            "serp_facebook_url": str | None,
             "_cost": float,
         }
     """
@@ -131,26 +147,32 @@ async def run_serp_verify(
             logger.warning("SERP query '%s' failed: %s", keyword[:40], exc)
             return {}
 
-    q_biz, q_abn, q_li, q_dm = await asyncio.gather(
-        _serp(f'"{clean_domain}"'),
+    # Extract business name first for Facebook query
+    q_biz = await _serp(f'"{clean_domain}"')
+    biz_name = _extract_business_name(q_biz)
+
+    q_abn, q_li, q_dm, q_fb = await asyncio.gather(
         _serp(f'"{clean_domain}" ABN'),
         _serp(f'"{clean_domain}" site:linkedin.com/company'),
         _serp(f'"{clean_domain}" owner OR director OR founder'),
+        _serp(f'"{biz_name}" site:facebook.com' if biz_name else f'"{clean_domain}" site:facebook.com'),
     )
 
     result = {
-        "serp_business_name": _extract_business_name(q_biz),
+        "serp_business_name": biz_name,
         "serp_abn": _extract_abn(q_abn),
         "serp_company_linkedin": _extract_company_linkedin(q_li),
         "serp_dm_candidate": _extract_dm_candidate(q_dm),
+        "serp_facebook_url": _extract_facebook_url(q_fb),
         "_cost": dfs.total_cost_usd - cost_before,
     }
     logger.info(
-        "Stage 2 VERIFY %s: biz=%s abn=%s li=%s dm=%s",
+        "Stage 2 VERIFY %s: biz=%s abn=%s li=%s dm=%s fb=%s",
         domain,
         result["serp_business_name"][:30] if result["serp_business_name"] else "null",
         result["serp_abn"] or "null",
         bool(result["serp_company_linkedin"]),
         result["serp_dm_candidate"] or "null",
+        bool(result["serp_facebook_url"]),
     )
     return result


### PR DESCRIPTION
## Summary

Three existing module fixes per Pipeline F v2.1 decisions.

### Task 1 — Scoring separation (Stage 7)
Removed affordability_score, affordability_gate, buyer_match_score from Stage 7 ANALYSE prompt. Stage 5 prospect_scorer.py is sole scorer. Stage 7 now generates only: intent_band_final, vulnerability_report (structured), outreach drafts.

### Task 2 — Facebook SERP (Stage 2)
Added 5th SERP query: "{business_name}" site:facebook.com. Business name query runs first to seed the Facebook query. Proven 3/3 in live test.

### Task 3 — Structured VR (Stage 7)
Replaced flat vulnerability list + hallucinated estimated_opportunity_value with structured output: summary, strengths (evidence-backed), vulnerabilities (area/finding/impact/recommendation), gmb_health, recommended_services, urgency. No invented numbers.

### Verification
- pytest: 1498 passed, 1 failed (pre-existing), 0 new failures
- Facebook test: hartsport→facebook.com/hartsportau/, unusualpetvets→TheUnusualPetVets/, beautopia→BeautopiaAustralia/

🤖 Generated with [Claude Code](https://claude.com/claude-code)