### PR TITLE
[AIDEN] feat(agent_coord): bootstrap multi-agent coordination infra

### DIFF
--- a/scripts/review-sync.sh
+++ b/scripts/review-sync.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eu
+
+BRANCH="${1:?Usage: review-sync.sh <branch-name>}"
+REVIEW_WT="/home/elliotbot/clawd/Agency_OS-aiden-review"
+
+if [ ! -d "$REVIEW_WT" ]; then
+    echo "ERROR: Review worktree '$REVIEW_WT' does not exist."
+    echo "Create it first with:"
+    echo "  git worktree add /home/elliotbot/clawd/Agency_OS-aiden-review main"
+    exit 2
+fi
+
+git -C "$REVIEW_WT" fetch origin
+git -C "$REVIEW_WT" checkout "$BRANCH"
+
+echo ""
+echo "=== git status: $REVIEW_WT ==="
+git -C "$REVIEW_WT" status

--- a/src/agent_coord/__init__.py
+++ b/src/agent_coord/__init__.py
@@ -1,0 +1,24 @@
+"""
+agent_coord — primitives layer for multi-agent parallel work.
+
+Provides:
+- File-claim system (claims.py): prevent sub-agents stepping on each other's files.
+- Status broadcasting (status.py): each bot can see what the other's sub-agents are doing.
+- Cleanup CLI (cleanup.py): remove stale claims on startup.
+
+Public API:
+    from agent_coord import claim, release, is_claimed, scan_stale
+    from agent_coord import set_status, get_peer_status
+"""
+
+from .claims import claim, release, is_claimed, scan_stale
+from .status import set_status, get_peer_status
+
+__all__ = [
+    "claim",
+    "release",
+    "is_claimed",
+    "scan_stale",
+    "set_status",
+    "get_peer_status",
+]

--- a/src/agent_coord/claims.py
+++ b/src/agent_coord/claims.py
@@ -1,0 +1,187 @@
+"""
+File-claim system for multi-agent coordination.
+
+Claims are keyed by repo-relative path (SHA-256 hash, first 16 hex chars) so both
+worktrees (Agency_OS and Agency_OS-aiden) see the same claim for the same file.
+
+All claim files are stored under CLAIMS_DIR as JSON with atomic tmp+rename writes.
+"""
+
+import hashlib
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+
+CLAIMS_DIR = "/tmp/agent-claims"
+DEFAULT_TTL_SECONDS = 900  # 15 minutes
+
+os.makedirs(CLAIMS_DIR, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _path_to_key(repo_relative_path: str) -> str:
+    """Hash repo-relative path → first 16 hex chars."""
+    return hashlib.sha256(repo_relative_path.encode()).hexdigest()[:16]
+
+
+def _atomic_write(path: str, payload: dict) -> None:
+    """Write JSON to path.tmp.<uuid4> then rename into place."""
+    tmp_path = f"{path}.tmp.{uuid.uuid4().hex}"
+    with open(tmp_path, "w") as f:
+        json.dump(payload, f)
+    os.rename(tmp_path, path)
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_ts(ts_str: str) -> datetime:
+    """Parse ISO-8601 UTC string → aware datetime."""
+    dt = datetime.fromisoformat(ts_str)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _claim_path(repo_relative_path: str) -> str:
+    return os.path.join(CLAIMS_DIR, _path_to_key(repo_relative_path) + ".json")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def claim(
+    repo_relative_path: str,
+    callsign: str,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    branch: str | None = None,
+) -> bool:
+    """
+    Attempt to claim a file.
+
+    Returns True if the claim was acquired or refreshed (re-entrant for same callsign).
+    Returns False if the file is actively claimed by a different callsign.
+    """
+    claim_file = _claim_path(repo_relative_path)
+    now = _now_utc()
+
+    try:
+        with open(claim_file) as f:
+            existing = json.load(f)
+        holder = existing.get("callsign")
+        ts = _parse_ts(existing["timestamp_utc"])
+        elapsed = (now - ts).total_seconds()
+        existing_ttl = existing.get("ttl_seconds", DEFAULT_TTL_SECONDS)
+        expired = elapsed >= existing_ttl
+
+        if not expired and holder != callsign:
+            # Active claim held by someone else
+            return False
+        # Either expired or same callsign → fall through to overwrite/refresh
+    except FileNotFoundError:
+        pass  # No existing claim — proceed to write
+
+    payload = {
+        "path": repo_relative_path,
+        "callsign": callsign,
+        "timestamp_utc": now.isoformat(),
+        "ttl_seconds": ttl_seconds,
+        "branch": branch,
+    }
+    _atomic_write(claim_file, payload)
+    return True
+
+
+def release(repo_relative_path: str, callsign: str) -> bool:
+    """
+    Release a claim.
+
+    Returns True if the claim belonged to callsign and was removed.
+    Returns False if the file isn't claimed, or the holder is a different callsign.
+    """
+    claim_file = _claim_path(repo_relative_path)
+    try:
+        with open(claim_file) as f:
+            existing = json.load(f)
+    except FileNotFoundError:
+        return False
+
+    if existing.get("callsign") != callsign:
+        return False
+
+    try:
+        os.unlink(claim_file)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def is_claimed(repo_relative_path: str) -> dict | None:
+    """
+    Return the active claim dict (with added `seconds_remaining` key) or None.
+
+    Returns None if absent or expired.
+    """
+    claim_file = _claim_path(repo_relative_path)
+    try:
+        with open(claim_file) as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return None
+
+    now = _now_utc()
+    ts = _parse_ts(data["timestamp_utc"])
+    elapsed = (now - ts).total_seconds()
+    ttl = data.get("ttl_seconds", DEFAULT_TTL_SECONDS)
+
+    if elapsed >= ttl:
+        return None
+
+    result = dict(data)
+    result["seconds_remaining"] = ttl - elapsed
+    return result
+
+
+def scan_stale() -> list[dict]:
+    """
+    Return a list of dicts for every expired claim in CLAIMS_DIR.
+
+    Each dict: {path, callsign, timestamp_utc, elapsed_seconds}
+    """
+    stale = []
+    try:
+        entries = os.listdir(CLAIMS_DIR)
+    except FileNotFoundError:
+        return []
+
+    now = _now_utc()
+    for entry in entries:
+        if not entry.endswith(".json"):
+            continue
+        full = os.path.join(CLAIMS_DIR, entry)
+        try:
+            with open(full) as f:
+                data = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            continue
+
+        ts = _parse_ts(data["timestamp_utc"])
+        elapsed = (now - ts).total_seconds()
+        ttl = data.get("ttl_seconds", DEFAULT_TTL_SECONDS)
+
+        if elapsed >= ttl:
+            stale.append({
+                "path": data.get("path", ""),
+                "callsign": data.get("callsign", ""),
+                "timestamp_utc": data["timestamp_utc"],
+                "elapsed_seconds": elapsed,
+                "_claim_file": full,
+            })
+
+    return stale

--- a/src/agent_coord/cleanup.py
+++ b/src/agent_coord/cleanup.py
@@ -1,0 +1,34 @@
+"""
+CLI entrypoint for startup cleanup of stale agent claims.
+
+Usage:
+    python -m agent_coord.cleanup
+    python src/agent_coord/cleanup.py
+"""
+
+import os
+import sys
+
+from .claims import scan_stale
+
+
+def main() -> int:
+    """Remove all stale claims and print a summary. Returns 0 always."""
+    stale = scan_stale()
+    n = 0
+    for item in stale:
+        claim_file = item.get("_claim_file", "")
+        if claim_file and os.path.exists(claim_file):
+            try:
+                os.unlink(claim_file)
+                print(f"  Removed stale claim: {item['path']} (held by {item['callsign']})")
+                n += 1
+            except FileNotFoundError:
+                pass  # Already gone — race is fine
+
+    print(f"Cleared {n} stale claims")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agent_coord/status.py
+++ b/src/agent_coord/status.py
@@ -1,0 +1,64 @@
+"""
+Status-broadcasting for multi-agent coordination.
+
+Each callsign writes its active agent roster to STATUS_DIR/{callsign}.json.
+Peers read each other's status files to understand what's in-flight.
+"""
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+
+STATUS_DIR = "/tmp/agent-status"
+
+os.makedirs(STATUS_DIR, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _atomic_write(path: str, payload: dict) -> None:
+    """Write JSON to path.tmp.<uuid4> then rename into place."""
+    tmp_path = f"{path}.tmp.{uuid.uuid4().hex}"
+    with open(tmp_path, "w") as f:
+        json.dump(payload, f)
+    os.rename(tmp_path, path)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def set_status(callsign: str, active_agents: list[dict]) -> None:
+    """
+    Broadcast this callsign's active agent roster.
+
+    active_agents items must have keys: name, task, file, started_at.
+    Writes atomically to STATUS_DIR/{callsign}.json.
+    """
+    payload = {
+        "callsign": callsign,
+        "active_agents": active_agents,
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+    }
+    status_file = os.path.join(STATUS_DIR, f"{callsign}.json")
+    _atomic_write(status_file, payload)
+
+
+def get_peer_status(peer_callsign: str) -> dict | None:
+    """
+    Read a peer's status file.
+
+    Returns parsed dict or None if missing / unreadable / malformed JSON.
+    Does not raise on JSON decode error (peer may be mid-write).
+    """
+    status_file = os.path.join(STATUS_DIR, f"{peer_callsign}.json")
+    try:
+        with open(status_file) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError:
+        return None

--- a/tests/agent_coord/test_claims.py
+++ b/tests/agent_coord/test_claims.py
@@ -1,0 +1,107 @@
+"""Tests for agent_coord.claims."""
+
+import json
+import os
+import time
+
+import pytest
+
+import src.agent_coord.claims as claims_mod
+from src.agent_coord.claims import (
+    CLAIMS_DIR,
+    claim,
+    is_claimed,
+    release,
+    scan_stale,
+    _path_to_key,
+)
+
+
+@pytest.fixture(autouse=True)
+def redirect_claims_dir(tmp_path, monkeypatch):
+    """Redirect CLAIMS_DIR to a tmp directory for isolation."""
+    fake_dir = str(tmp_path / "claims")
+    os.makedirs(fake_dir, exist_ok=True)
+    monkeypatch.setattr(claims_mod, "CLAIMS_DIR", fake_dir)
+    yield fake_dir
+
+
+def test_claim_happy_path(redirect_claims_dir):
+    path = "src/some_module.py"
+    assert claim(path, "aiden") is True
+    result = is_claimed(path)
+    assert result is not None
+    assert result["callsign"] == "aiden"
+    assert result["path"] == path
+    assert result["seconds_remaining"] > 0
+    assert release(path, "aiden") is True
+    assert is_claimed(path) is None
+
+
+def test_claim_collision(redirect_claims_dir):
+    path = "src/shared.py"
+    assert claim(path, "aiden") is True
+    assert claim(path, "elliot") is False
+    # aiden still holds it
+    result = is_claimed(path)
+    assert result["callsign"] == "aiden"
+
+
+def test_claim_reentrant(redirect_claims_dir):
+    path = "src/reentered.py"
+    assert claim(path, "aiden", ttl_seconds=60) is True
+    first_ts = is_claimed(path)["timestamp_utc"]
+    time.sleep(0.05)
+    assert claim(path, "aiden", ttl_seconds=60) is True
+    second_ts = is_claimed(path)["timestamp_utc"]
+    # Timestamp must be refreshed (second >= first)
+    assert second_ts >= first_ts
+
+
+def test_claim_expired(redirect_claims_dir):
+    path = "src/expiring.py"
+    # Claim with TTL=0 so it expires immediately
+    assert claim(path, "aiden", ttl_seconds=0) is True
+    # is_claimed should see it as expired
+    assert is_claimed(path) is None
+    # Another agent can now claim it
+    assert claim(path, "elliot", ttl_seconds=60) is True
+    assert is_claimed(path)["callsign"] == "elliot"
+
+
+def test_release_wrong_callsign(redirect_claims_dir):
+    path = "src/protected.py"
+    assert claim(path, "aiden") is True
+    assert release(path, "elliot") is False
+    # Still claimed by aiden
+    assert is_claimed(path) is not None
+
+
+def test_release_nothing(redirect_claims_dir):
+    path = "src/never_claimed.py"
+    assert release(path, "aiden") is False
+
+
+def test_scan_stale_finds_expired(redirect_claims_dir):
+    path = "src/stale.py"
+    assert claim(path, "aiden", ttl_seconds=0) is True
+    stale = scan_stale()
+    assert len(stale) == 1
+    assert stale[0]["path"] == path
+    assert stale[0]["callsign"] == "aiden"
+    assert stale[0]["elapsed_seconds"] >= 0
+
+
+def test_scan_stale_skips_active(redirect_claims_dir):
+    path = "src/active.py"
+    assert claim(path, "aiden", ttl_seconds=900) is True
+    stale = scan_stale()
+    assert stale == []
+
+
+def test_atomic_write_no_partial_file(redirect_claims_dir):
+    path = "src/atomic.py"
+    assert claim(path, "aiden") is True
+    # No .tmp.* files should remain
+    tmp_files = [f for f in os.listdir(redirect_claims_dir) if ".tmp." in f]
+    assert tmp_files == []

--- a/tests/agent_coord/test_status.py
+++ b/tests/agent_coord/test_status.py
@@ -1,0 +1,63 @@
+"""Tests for agent_coord.status."""
+
+import json
+import os
+
+import pytest
+
+import src.agent_coord.status as status_mod
+from src.agent_coord.status import get_peer_status, set_status
+
+
+SAMPLE_AGENTS = [
+    {"name": "build-2", "task": "write claims.py", "file": "src/agent_coord/claims.py", "started_at": "2026-04-16T00:00:00+00:00"},
+]
+
+
+@pytest.fixture(autouse=True)
+def redirect_status_dir(tmp_path, monkeypatch):
+    """Redirect STATUS_DIR to a tmp directory for isolation."""
+    fake_dir = str(tmp_path / "status")
+    os.makedirs(fake_dir, exist_ok=True)
+    monkeypatch.setattr(status_mod, "STATUS_DIR", fake_dir)
+    yield fake_dir
+
+
+def test_set_and_get_status(redirect_status_dir):
+    set_status("aiden", SAMPLE_AGENTS)
+    result = get_peer_status("aiden")
+    assert result is not None
+    assert result["callsign"] == "aiden"
+    assert result["active_agents"] == SAMPLE_AGENTS
+    assert "last_updated" in result
+
+
+def test_get_missing_peer(redirect_status_dir):
+    result = get_peer_status("nobody")
+    assert result is None
+
+
+def test_atomic_write_no_partial(redirect_status_dir):
+    set_status("aiden", SAMPLE_AGENTS)
+    tmp_files = [f for f in os.listdir(redirect_status_dir) if ".tmp." in f]
+    assert tmp_files == []
+
+
+def test_set_overwrites(redirect_status_dir):
+    set_status("aiden", SAMPLE_AGENTS)
+    new_agents = [{"name": "test-4", "task": "run tests", "file": "tests/", "started_at": "2026-04-16T01:00:00+00:00"}]
+    set_status("aiden", new_agents)
+
+    result = get_peer_status("aiden")
+    assert result["active_agents"] == new_agents
+    # Ensure only one file exists
+    files = [f for f in os.listdir(redirect_status_dir) if f.endswith(".json")]
+    assert len(files) == 1
+
+
+def test_get_tolerates_malformed_json(redirect_status_dir):
+    bad_file = os.path.join(redirect_status_dir, "broken.json")
+    with open(bad_file, "w") as f:
+        f.write("{this is not valid json")
+    result = get_peer_status("broken")
+    assert result is None


### PR DESCRIPTION
## Summary

First primitives layer for parallel work between the Aiden and Elliot Claude sessions — the bootstrap Dave approved at 2026-04-17 ~02:00Z in the Agency OS supergroup ("Yes" → Elliot's Option 1: Aiden-builds-infra as the first real test of the operating model using the model itself).

## What's in

**`src/agent_coord/`** — new module
- `claims.py` — file-claim system. 15-min default TTL, re-entrant claims (same callsign refreshes), expired-claim takeover, atomic tmp+rename writes. Keys are `sha256(repo-relative path)[:16]` so both worktrees see the same claim for the same file. Public API: `claim()`, `release()`, `is_claimed()`, `scan_stale()`.
- `status.py` — per-callsign status broadcasting. `set_status(callsign, active_agents)` writes atomically to `/tmp/agent-status/{callsign}.json`; `get_peer_status()` tolerates mid-write / malformed JSON by returning None.
- `cleanup.py` — CLI entrypoint (`python -m agent_coord.cleanup`) for startup stale-claim cleanup. Run before dispatching sub-agents.
- `__init__.py` — re-exports the public API.

**`scripts/review-sync.sh`** — prepares `Agency_OS-aiden-review/` worktree for reviewing Elliot's branches. Errors cleanly if the worktree doesn't yet exist (creation is out-of-scope for this PR).

**`tests/agent_coord/`** — 14 pytest cases covering: happy-path claim/release, collision, re-entrant, TTL expiry, release-wrong-callsign, scan-stale, atomic-write no-partial-file, malformed-JSON tolerance. All green (0.27s).

## Governance

- Branch `a/agent-coord` targets `aiden/scaffold` per `IDENTITY.md` — does not merge to main.
- Commit + PR tagged `[AIDEN]` per LAW XVII.
- Dave pre-approved this build on 2026-04-17. Elliot (CTO) reviews; Dave merges.
- LAW XVI clean — no unrelated edits in this PR.

## Scope OUT (follow-ups)

- Creating the `Agency_OS-aiden-review/` worktree (devops).
- Integrating `cleanup` into `chat_bot.py` startup (separate PR).
- Wiring file-claim checks into the sub-agent dispatch path.
- Cross-worktree import strategy — to be decided when Elliot's workspace picks up these files. Likely candidates: editable install, symlink, or mirroring the module to his `src/`.

## Test plan
- [x] `python3 -m py_compile` — all 4 modules clean
- [x] `bash -n scripts/review-sync.sh` — clean; +x set
- [x] `pytest tests/agent_coord/` — 14/14 passed
- [x] `python -m agent_coord.cleanup` runs cleanly (PYTHONPATH=src)
- [ ] Live: claim + release cycle observed in `/tmp/agent-claims/` (to verify after Elliot's re-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)