### PR TITLE
[ELLIOT] feat: circuit breaker pattern for external API providers

### DIFF
--- a/src/integrations/brightdata_client.py
+++ b/src/integrations/brightdata_client.py
@@ -16,6 +16,8 @@ from typing import Optional
 
 import httpx
 
+from src.integrations.circuit_breaker import circuit_breaker
+
 logger = logging.getLogger(__name__)
 
 BRIGHTDATA_SCRAPER_KEY = "636a81d7-4f89-4fb5-904b-f1e195ec20d2"  # updated 2026-03-31 (Directive #300g+h)
@@ -144,6 +146,7 @@ class BrightDataLinkedInClient:
             "confidence": confidence,
         }
 
+    @circuit_breaker("brightdata", failure_threshold=5, recovery_timeout=60)
     async def _scraper_request(
         self,
         dataset_id: str,

--- a/src/integrations/circuit_breaker.py
+++ b/src/integrations/circuit_breaker.py
@@ -1,0 +1,246 @@
+"""
+FILE: src/integrations/circuit_breaker.py
+PURPOSE: Reusable failure-based circuit breaker for external API providers.
+         Three states: CLOSED (normal) -> OPEN (failing) -> HALF_OPEN (recovering).
+         NOT a spend limiter — that is handled by src/integrations/anthropic.py.
+PHASE: Integrations
+DEPENDENCIES: None (stdlib only)
+CONSUMERS: Any integration that wraps external HTTP calls.
+
+Usage (decorator):
+    @circuit_breaker("brightdata", failure_threshold=5, recovery_timeout=60)
+    async def my_api_call(...):
+        ...
+
+Usage (instance):
+    cb = get_circuit_breaker("leadmagic")
+    async with cb:
+        result = await api_call()
+"""
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import time
+from enum import Enum
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# State + Exception
+# ---------------------------------------------------------------------------
+
+
+class CircuitState(Enum):
+    CLOSED = "closed"        # Normal operation
+    OPEN = "open"            # Failing — reject all calls
+    HALF_OPEN = "half_open"  # Testing recovery — allow limited calls
+
+
+class CircuitOpenError(Exception):
+    """Raised when a circuit breaker is OPEN and the call is rejected."""
+
+    def __init__(self, provider: str, retry_after: float) -> None:
+        self.provider = provider
+        self.retry_after = retry_after
+        super().__init__(
+            f"Circuit OPEN for '{provider}'. Retry after {retry_after:.1f}s."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core circuit breaker class
+# ---------------------------------------------------------------------------
+
+
+class CircuitBreaker:
+    """
+    Async-safe three-state circuit breaker.
+
+    State transitions:
+        CLOSED  --[N failures]--> OPEN
+        OPEN    --[timeout expires]--> HALF_OPEN
+        HALF_OPEN --[success]--> CLOSED
+        HALF_OPEN --[failure]--> OPEN
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        failure_threshold: int = 5,
+        recovery_timeout_seconds: float = 60.0,
+        half_open_max_calls: int = 1,
+    ) -> None:
+        self.provider = provider
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout_seconds = recovery_timeout_seconds
+        self.half_open_max_calls = half_open_max_calls
+
+        self._state = CircuitState.CLOSED
+        self._failure_count = 0
+        self._opened_at: float | None = None
+        self._half_open_calls = 0
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # State helpers (all called under lock)
+    # ------------------------------------------------------------------
+
+    def _transition(self, new_state: CircuitState) -> None:
+        old = self._state
+        self._state = new_state
+        logger.warning(
+            "circuit_breaker state_transition provider=%s %s -> %s",
+            self.provider,
+            old.value,
+            new_state.value,
+        )
+        if new_state == CircuitState.OPEN:
+            self._opened_at = time.monotonic()
+            self._half_open_calls = 0
+        elif new_state == CircuitState.CLOSED:
+            self._failure_count = 0
+            self._opened_at = None
+            self._half_open_calls = 0
+
+    def _seconds_until_retry(self) -> float:
+        if self._opened_at is None:
+            return 0.0
+        elapsed = time.monotonic() - self._opened_at
+        return max(0.0, self.recovery_timeout_seconds - elapsed)
+
+    async def _check_state(self) -> None:
+        """
+        Evaluate current state; may auto-transition OPEN -> HALF_OPEN.
+        Raises CircuitOpenError if call must be rejected.
+        """
+        async with self._lock:
+            if self._state == CircuitState.OPEN:
+                remaining = self._seconds_until_retry()
+                if remaining > 0:
+                    raise CircuitOpenError(self.provider, remaining)
+                # Timeout expired — probe with a single call
+                self._transition(CircuitState.HALF_OPEN)
+
+            if self._state == CircuitState.HALF_OPEN:
+                if self._half_open_calls >= self.half_open_max_calls:
+                    # Another probe already in-flight — reject this one
+                    raise CircuitOpenError(self.provider, self.recovery_timeout_seconds)
+                self._half_open_calls += 1
+
+    async def _record_success(self) -> None:
+        async with self._lock:
+            if self._state == CircuitState.HALF_OPEN:
+                self._transition(CircuitState.CLOSED)
+            elif self._state == CircuitState.CLOSED:
+                # Reset failure count on success
+                self._failure_count = 0
+
+    async def _record_failure(self) -> None:
+        async with self._lock:
+            if self._state == CircuitState.HALF_OPEN:
+                self._transition(CircuitState.OPEN)
+            elif self._state == CircuitState.CLOSED:
+                self._failure_count += 1
+                if self._failure_count >= self.failure_threshold:
+                    self._transition(CircuitState.OPEN)
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> CircuitState:
+        return self._state
+
+    @property
+    def failure_count(self) -> int:
+        return self._failure_count
+
+    async def call(self, coro: Any) -> Any:
+        """
+        Execute an awaitable through the circuit breaker.
+
+        Usage:
+            result = await cb.call(some_coroutine(...))
+        """
+        await self._check_state()
+        try:
+            result = await coro
+            await self._record_success()
+            return result
+        except CircuitOpenError:
+            raise  # Don't count our own rejections as failures
+        except Exception:
+            await self._record_failure()
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Per-provider registry
+# ---------------------------------------------------------------------------
+
+_registry: dict[str, CircuitBreaker] = {}
+_registry_lock = asyncio.Lock()
+
+
+def get_circuit_breaker(
+    provider: str,
+    failure_threshold: int = 5,
+    recovery_timeout_seconds: float = 60.0,
+    half_open_max_calls: int = 1,
+) -> CircuitBreaker:
+    """
+    Return the existing CircuitBreaker for this provider, or create one.
+    Parameters are only applied on first creation — subsequent calls return
+    the same instance regardless of parameters passed.
+    """
+    if provider not in _registry:
+        _registry[provider] = CircuitBreaker(
+            provider=provider,
+            failure_threshold=failure_threshold,
+            recovery_timeout_seconds=recovery_timeout_seconds,
+            half_open_max_calls=half_open_max_calls,
+        )
+    return _registry[provider]
+
+
+def reset_circuit_breaker(provider: str) -> None:
+    """Remove a provider's circuit breaker from the registry (useful in tests)."""
+    _registry.pop(provider, None)
+
+
+# ---------------------------------------------------------------------------
+# Decorator
+# ---------------------------------------------------------------------------
+
+
+def circuit_breaker(
+    provider: str,
+    failure_threshold: int = 5,
+    recovery_timeout: float = 60.0,
+    half_open_max_calls: int = 1,
+) -> Callable:
+    """
+    Decorator that wraps an async function with a named circuit breaker.
+
+    Example:
+        @circuit_breaker("brightdata", failure_threshold=5, recovery_timeout=60)
+        async def call_bright_data(...):
+            ...
+    """
+    def decorator(fn: Callable) -> Callable:
+        @functools.wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            cb = get_circuit_breaker(
+                provider,
+                failure_threshold=failure_threshold,
+                recovery_timeout_seconds=recovery_timeout,
+                half_open_max_calls=half_open_max_calls,
+            )
+            return await cb.call(fn(*args, **kwargs))
+        return wrapper
+    return decorator

--- a/src/integrations/leadmagic.py
+++ b/src/integrations/leadmagic.py
@@ -57,6 +57,7 @@ from tenacity import (
 
 from src.config.settings import settings
 from src.exceptions import APIError, IntegrationError, ValidationError
+from src.integrations.circuit_breaker import circuit_breaker
 
 logger = logging.getLogger(__name__)
 
@@ -356,6 +357,7 @@ class LeadmagicClient:
 
         self._last_request_time = datetime.now(UTC)
 
+    @circuit_breaker("leadmagic", failure_threshold=5, recovery_timeout=60)
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,196 @@
+"""
+Tests for src/integrations/circuit_breaker.py
+
+Covers:
+  1. Circuit opens after N failures
+  2. Open circuit rejects calls (raises CircuitOpenError)
+  3. Circuit transitions to HALF_OPEN after recovery timeout
+  4. Circuit closes after successful half-open call
+  5. Circuit reopens after failed half-open call
+  6. Decorator works on async functions
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from src.integrations.circuit_breaker import (
+    CircuitBreaker,
+    CircuitOpenError,
+    CircuitState,
+    circuit_breaker,
+    get_circuit_breaker,
+    reset_circuit_breaker,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _fail():
+    raise ValueError("simulated failure")
+
+async def _ok():
+    return "ok"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def isolated_cb(request):
+    """Yield a fresh CircuitBreaker for each test; clean up registry after."""
+    provider = f"test_{request.node.name}"
+    cb = CircuitBreaker(
+        provider=provider,
+        failure_threshold=3,
+        recovery_timeout_seconds=0.2,   # short for tests
+        half_open_max_calls=1,
+    )
+    yield cb, provider
+    reset_circuit_breaker(provider)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — circuit opens after N failures
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_circuit_opens_after_n_failures(isolated_cb):
+    cb, _ = isolated_cb
+    assert cb.state == CircuitState.CLOSED
+
+    for _ in range(3):
+        with pytest.raises(ValueError):
+            await cb.call(_fail())
+
+    assert cb.state == CircuitState.OPEN
+    assert cb.failure_count >= 3
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — open circuit rejects calls
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_open_circuit_rejects_calls(isolated_cb):
+    cb, _ = isolated_cb
+
+    # Drive open
+    for _ in range(3):
+        with pytest.raises(ValueError):
+            await cb.call(_fail())
+
+    assert cb.state == CircuitState.OPEN
+
+    with pytest.raises(CircuitOpenError) as exc_info:
+        await cb.call(_ok())
+
+    assert "OPEN" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — OPEN -> HALF_OPEN after recovery timeout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_transitions_to_half_open_after_timeout(isolated_cb):
+    cb, _ = isolated_cb
+
+    for _ in range(3):
+        with pytest.raises(ValueError):
+            await cb.call(_fail())
+
+    assert cb.state == CircuitState.OPEN
+
+    # Wait for recovery timeout (0.2s in fixture)
+    await asyncio.sleep(0.25)
+
+    # Next call should be allowed (HALF_OPEN probe)
+    result = await cb.call(_ok())
+    assert result == "ok"
+    assert cb.state == CircuitState.CLOSED
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — circuit closes after successful half-open call
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_closes_after_successful_half_open(isolated_cb):
+    cb, _ = isolated_cb
+
+    for _ in range(3):
+        with pytest.raises(ValueError):
+            await cb.call(_fail())
+
+    await asyncio.sleep(0.25)  # let recovery timeout expire
+
+    # Probe succeeds -> should close
+    await cb.call(_ok())
+    assert cb.state == CircuitState.CLOSED
+    assert cb.failure_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — circuit reopens after failed half-open call
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reopens_after_failed_half_open(isolated_cb):
+    cb, _ = isolated_cb
+
+    for _ in range(3):
+        with pytest.raises(ValueError):
+            await cb.call(_fail())
+
+    await asyncio.sleep(0.25)  # recovery timeout expires -> HALF_OPEN probe allowed
+
+    # Probe fails -> should reopen
+    with pytest.raises(ValueError):
+        await cb.call(_fail())
+
+    assert cb.state == CircuitState.OPEN
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — decorator works on async functions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_decorator_wraps_async_function():
+    provider = "decorator_test"
+    reset_circuit_breaker(provider)
+
+    call_count = 0
+
+    @circuit_breaker(provider, failure_threshold=2, recovery_timeout=0.2)
+    async def guarded():
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("boom")
+
+    # Two failures should open the circuit
+    with pytest.raises(RuntimeError):
+        await guarded()
+    with pytest.raises(RuntimeError):
+        await guarded()
+
+    cb = get_circuit_breaker(provider)
+    assert cb.state == CircuitState.OPEN
+
+    # Third call is rejected by circuit, not the underlying function
+    # Use try/except so pytest doesn't GC an unawaited coroutine
+    try:
+        await guarded()
+        pytest.fail("Expected CircuitOpenError")
+    except CircuitOpenError:
+        pass
+
+    assert call_count == 2  # function body only ran twice, not three times
+
+    reset_circuit_breaker(provider)


### PR DESCRIPTION
## Summary
- New `src/integrations/circuit_breaker.py` — reusable CircuitBreaker class with CLOSED/OPEN/HALF_OPEN states, configurable thresholds, async-safe, per-provider instances
- Decorator pattern: `@circuit_breaker("provider", failure_threshold=5, recovery_timeout=60)`
- Wired into Bright Data (`_scraper_request`) and Leadmagic (`_request`) as proof of concept
- 6 tests covering: opens after N failures, rejects when open, half-open transition, close on success, reopen on failure, decorator on async functions

## Governance
- Wave 1 item #5 per Dave-approved plan
- Elliot builds, Aiden reviews, Dave merges
- Does NOT modify Anthropic's existing spend-based circuit breaker

## DoD (Dave-visible)
Simulate provider outage → circuit opens → calls rejected with CircuitOpenError → after recovery timeout, circuit tests one call → if success, resumes normal operation.

## Test plan
- [x] `pytest tests/test_circuit_breaker.py -v` — 6 passed
- [ ] Aiden review
- [ ] Dave merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)