### PR TITLE
[AIDEN] feat(backup): offsite backup + DR runbook (Wave 1 #4)

### DIFF
--- a/.github/workflows/backup-offsite.yml
+++ b/.github/workflows/backup-offsite.yml
@@ -1,0 +1,47 @@
+name: Offsite DB Backup
+
+# Complements Supabase Pro's native 7-day PITR.
+# Written 2026-04-17 as Wave 1 item #4. Currently MANUAL-TRIGGER ONLY — Dave
+# enables the weekly schedule after: (1) configuring repo secrets, (2) one
+# successful manual run, (3) a restore-drill against the resulting dump.
+
+on:
+  workflow_dispatch:
+    inputs:
+      destination_override:
+        description: "Override BACKUP_DESTINATION for this run (optional)"
+        required: false
+        type: string
+  # schedule:
+  #   - cron: '0 17 * * 0'  # Weekly, Sunday 17:00 UTC = Monday 03:00 AEST
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pg_dump + cloud CLI
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y postgresql-client
+          # AWS CLI is preinstalled on ubuntu-latest; gsutil via gcloud-cli if needed;
+          # b2 via rclone as fallback
+          sudo apt-get install -y rclone || true
+
+      - name: Run backup
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+          BACKUP_DESTINATION: ${{ github.event.inputs.destination_override || secrets.BACKUP_DESTINATION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION || 'ap-southeast-2' }}
+        run: |
+          chmod +x scripts/backup_offsite.sh
+          bash scripts/backup_offsite.sh
+
+      - name: Report backup size
+        if: success()
+        run: echo "Backup completed successfully. Dest=${BACKUP_DESTINATION}"

--- a/docs/runbooks/disaster_recovery.md
+++ b/docs/runbooks/disaster_recovery.md
@@ -1,0 +1,115 @@
+# Disaster Recovery Runbook
+
+**Scope:** restoring the Agency OS Supabase database after data loss or project unavailability.
+
+**Owner:** Dave (CEO). Execute personally or direct a bot to assist.
+
+**Last reviewed:** 2026-04-17 (Wave 1 item #4). Re-validate with a drill every 30 days.
+
+---
+
+## Recovery paths (in order of preference)
+
+### Path 1 — Supabase native Point-in-Time Recovery (PITR)
+
+**Use when:** accidental DELETE/UPDATE, data corruption within the last 7 days, Supabase project still accessible.
+
+- Supabase Pro plan automatically retains daily backups + PITR for **7 days**.
+- Restore from the Supabase dashboard: Project Settings → Database → Backups → Restore.
+- **RTO:** ~30 minutes (Supabase creates a new project/branch with restored state).
+- **RPO:** up to ~24 hours, reduced by using PITR to pick a specific point in time.
+
+**Limits:** Only works while the Supabase project exists. Cannot recover from account suspension, project deletion, or billing lockout.
+
+### Path 2 — Offsite pg_dump restore
+
+**Use when:** Supabase project deleted/suspended, older than 7-day PITR window, Supabase-wide outage.
+
+- Backups produced by `scripts/backup_offsite.sh`, stored at `${BACKUP_DESTINATION}` (see env for current value).
+- Frequency: manual until Dave enables the weekly schedule in `.github/workflows/backup-offsite.yml`.
+- **RTO:** ~1–2 hours (fresh Supabase project + restore + re-wire env vars).
+- **RPO:** interval between scheduled runs (target: weekly once enabled).
+
+**Restore procedure:**
+
+```bash
+# 1. Download the most recent dump (adjust CLI for b2/gs destinations)
+aws s3 ls s3://YOUR-BUCKET/ --recursive | tail -5   # find latest
+aws s3 cp s3://YOUR-BUCKET/agency-os-backup-YYYYMMDDTHHMMSSZ.sql.gz ./restore.sql.gz
+
+# 2. Decompress
+gunzip restore.sql.gz
+
+# 3. Provision a new Supabase project and capture its postgres URL
+#    (Dashboard → New Project → Settings → Database → Connection string)
+export NEW_DB_URL="postgresql://postgres:...@db.NEW-PROJECT-REF.supabase.co:5432/postgres"
+
+# 4. Restore
+psql "${NEW_DB_URL}" < restore.sql
+
+# 5. Verify key row counts
+psql "${NEW_DB_URL}" -c "SELECT 'leads', COUNT(*) FROM leads
+                         UNION ALL SELECT 'clients', COUNT(*) FROM clients
+                         UNION ALL SELECT 'ceo_memory', COUNT(*) FROM ceo_memory
+                         UNION ALL SELECT 'cis_directive_metrics', COUNT(*) FROM cis_directive_metrics;"
+
+# 6. Update application env vars
+#    - ~/.config/agency-os/.env: SUPABASE_URL + SUPABASE_SERVICE_KEY
+#    - Railway environment variables (same)
+#    - Vercel environment variables (same)
+#    - GitHub Actions secrets if they reference the old project
+```
+
+### Path 3 — Reconstruct from git + Drive Manual
+
+**Use when:** catastrophic loss of both Supabase + all offsite backups.
+
+- Repo on GitHub contains every migration + schema. Re-run migrations on a fresh Supabase project:
+  ```bash
+  cd supabase && supabase db push  # or: manual psql < each migration file
+  ```
+- Drive Manual (`docs/MANUAL.md` mirrored to Google Drive) contains current state notes.
+- `ceo_memory` and `cis_directive_metrics` will be empty — manually re-seed from Manual + elliot_internal.memories if those Supabase memories survived.
+- **RTO:** days. **RPO:** effectively "everything operational is lost; only code + human memory remain."
+
+---
+
+## Pre-requisites (configure before a real incident)
+
+1. **Supabase DB connection string** — set `SUPABASE_DB_URL` in GitHub repo secrets AND in Dave's local `.env`.
+2. **Offsite destination** — choose and provision one:
+   - S3: create bucket, issue IAM user with `s3:PutObject` + `s3:GetObject` on that bucket only, set secrets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `BACKUP_DESTINATION=s3://bucket/agency-os/`.
+   - Backblaze B2: create bucket + application key; `rclone config` locally to create `b2-remote`; `BACKUP_DESTINATION=b2://bucket/agency-os/`.
+   - GCS: create bucket + service account JSON; `BACKUP_DESTINATION=gs://bucket/agency-os/`.
+3. **First manual run** — trigger the workflow manually (GitHub Actions → Offsite DB Backup → Run workflow). Confirm the dump arrives at the destination.
+4. **First restore drill** — see below. Do NOT enable the schedule until the drill completes.
+5. **Enable schedule** — uncomment the `schedule:` block in `.github/workflows/backup-offsite.yml` (weekly Sunday 17:00 UTC default).
+
+---
+
+## Monthly restore drill (target ~30 min each)
+
+1. Pick the most recent offsite backup.
+2. Provision a throwaway Supabase project ("agency-os-drill-YYYYMMDD").
+3. Execute the Path 2 restore procedure.
+4. Verify row counts match the source counts recorded at backup time.
+5. Record in `docs/runbooks/restore_drill_log.md`: date, backup used, RTO actual, any issues.
+6. Delete the throwaway project.
+
+**Purpose:** drills catch two classes of rot — (a) the backup script silently writing corrupted dumps, and (b) the restore procedure drifting out of sync with schema migrations. A backup you haven't restored is not a backup.
+
+---
+
+## What's NOT covered here
+
+- **Application credentials loss** — if the VPS or Railway account is lost, recover those from password manager. This runbook covers DB only.
+- **Supabase account recovery** — outside our control; Supabase support.
+- **GitHub loss** — GitHub is effectively an offsite backup of code. If GitHub itself is lost, pull from local clone.
+
+---
+
+## Governance
+
+- LAW XV-B: this runbook satisfies the Dave-visible DoD for Wave 1 item #4. A successful restore drill is the proof artifact.
+- LAW XVI: changes to this runbook go through PR review.
+- Revision history lives in git.

--- a/scripts/backup_offsite.sh
+++ b/scripts/backup_offsite.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# FILE: scripts/backup_offsite.sh
+# PURPOSE: Offsite backup of Supabase DB via pg_dump + upload to cloud storage.
+#          Complements Supabase Pro's native 7-day PITR; intended for recovery
+#          scenarios where the Supabase project itself is suspended/deleted.
+# AUTHOR: [AIDEN] — Wave 1 item #4 (offsite backup + recovery runbook)
+#
+# Env required:
+#   SUPABASE_DB_URL     — postgres connection string (from Supabase Settings → Database)
+#   BACKUP_DESTINATION  — one of: s3://bucket/path, b2://bucket/path, gs://bucket/path
+#
+# Optional env:
+#   BACKUP_KEEP_LOCAL=1 — don't delete the local dump after upload
+#   BACKUP_PREFIX        — filename prefix (default: agency-os-backup)
+#
+# Cloud creds (provide based on destination scheme):
+#   S3  → AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (or instance role)
+#   B2  → rclone remote "b2-remote" configured with application key
+#   GCS → GOOGLE_APPLICATION_CREDENTIALS path
+
+set -euo pipefail
+
+: "${SUPABASE_DB_URL:?SUPABASE_DB_URL is required}"
+: "${BACKUP_DESTINATION:?BACKUP_DESTINATION is required (s3://, b2://, or gs://)}"
+
+PREFIX="${BACKUP_PREFIX:-agency-os-backup}"
+TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+DUMP_FILE="/tmp/${PREFIX}-${TIMESTAMP}.sql.gz"
+
+echo "[backup] dumping Supabase DB → ${DUMP_FILE}"
+pg_dump "${SUPABASE_DB_URL}" --no-owner --no-acl --clean --if-exists | gzip > "${DUMP_FILE}"
+
+SIZE=$(du -h "${DUMP_FILE}" | cut -f1)
+echo "[backup] dump complete: ${SIZE}"
+
+echo "[backup] uploading to ${BACKUP_DESTINATION}"
+case "${BACKUP_DESTINATION}" in
+    s3://*)
+        aws s3 cp "${DUMP_FILE}" "${BACKUP_DESTINATION}/"
+        ;;
+    b2://*)
+        # Requires rclone remote "b2-remote:" preconfigured with B2 application key
+        rclone copy "${DUMP_FILE}" "${BACKUP_DESTINATION}"
+        ;;
+    gs://*)
+        gsutil cp "${DUMP_FILE}" "${BACKUP_DESTINATION}/"
+        ;;
+    *)
+        echo "[backup] ERROR: unsupported destination scheme: ${BACKUP_DESTINATION}" >&2
+        echo "[backup] supported: s3://, b2://, gs://" >&2
+        exit 2
+        ;;
+esac
+
+echo "[backup] uploaded OK"
+
+if [ "${BACKUP_KEEP_LOCAL:-0}" != "1" ]; then
+    rm -f "${DUMP_FILE}"
+    echo "[backup] local dump removed (set BACKUP_KEEP_LOCAL=1 to keep)"
+else
+    echo "[backup] local dump kept at ${DUMP_FILE}"
+fi
+
+echo "[backup] done"


### PR DESCRIPTION
## Summary

Wave 1 item #4. Offsite backup mechanism + disaster recovery runbook. Complements Supabase Pro's native 7-day PITR; covers scenarios PITR can't (project suspension/deletion, >7-day recovery, Supabase-wide outage).

## Added

**`scripts/backup_offsite.sh`** (2.3 KB) — pg_dump + gzip + upload via aws/rclone/gsutil. Destination-scheme driven (`s3://`, `b2://`, `gs://`). Fail-fast on unsupported schemes. Env-gated (`SUPABASE_DB_URL` + `BACKUP_DESTINATION` required).

**`.github/workflows/backup-offsite.yml`** (1.7 KB) — manual-trigger GitHub Action running the backup script. Weekly schedule is **commented out**; Dave enables it after a successful manual run + restore drill.

**`docs/runbooks/disaster_recovery.md`** (5.7 KB) — three recovery paths with RTO/RPO per path:
1. Supabase native PITR (7-day window, ~30 min RTO)
2. Offsite pg_dump restore (unlimited retention once enabled, ~1–2 hr RTO)
3. Git + Manual rebuild (catastrophic fallback, days RTO)
Plus: prereqs checklist, monthly restore drill procedure, governance.

## Explicitly NOT in this PR

- Actual cloud destination provisioning — Dave creates bucket + IAM/app key
- Repo secrets — Dave sets `SUPABASE_DB_URL`, `BACKUP_DESTINATION`, `AWS_*`
- Enabling the weekly cron — requires first successful manual run + one drill
- Running a real restore drill — scheduled after prereqs land

## Dave-visible DoD (per the wave plan)

Once prereqs complete + manual run fires:
1. Gzipped `.sql` dump appears at `BACKUP_DESTINATION`
2. Dave runs the Path 2 restore into a throwaway Supabase project
3. Row counts match source
4. Drill-report row added to `docs/runbooks/restore_drill_log.md` (new file on first drill)

## Test plan (what's testable WITHOUT cloud creds)

- [x] `bash -n scripts/backup_offsite.sh` — syntax clean
- [x] `yaml.safe_load(backup-offsite.yml)` — syntax clean
- [x] Destination-scheme dispatch logic reviewed (s3/b2/gs branches, explicit fail-fast on unknown)
- [ ] First manual-trigger run — Dave's step, post-merge

## Governance

- Branch targets `aiden/scaffold` per `IDENTITY.md` — does not merge to main.
- Wave 1 item #4 per Dave-approved plan.
- Elliot (CTO) reviews; Dave merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)