### PR TITLE
[AIDEN] feat(tagging): /tag command for Dave-knowledge capture (Wave 1 #3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,60 @@ Script lives at `/home/elliotbot/clawd/Agency_OS/scripts/tg` (symlinked in `~/.l
 
 **Telegram bot-to-bot blind spot:** each bot's Telegram API receives every group message natively, but the tmux terminal only sees it if the cross-post fires. Hence `tg` over curl.
 
+## Dave Tagging — /tag Command
+
+Dave manually analyses rejected leads. `/tag` captures his reasoning into `lead_tags` so it's never lost.
+
+**What it does:** Dave sends `/tag <free text>`; Haiku (claude-haiku-4-5) parses the text into structured fields; bot confirms; Dave replies yes/no; on yes, a row is persisted to `public.lead_tags`.
+
+**Command syntax:**
+```
+/tag <free text>
+```
+**Example:**
+```
+/tag plumbermate.com.au dropped from stage 2 enterprise 200+ employees
+```
+
+**Stages** (`stage` field):
+```
+stage1_discovery | stage2_abn | stage3_comprehension | stage4_affordability
+stage5_scoring | stage6_seo | stage7_contact | stage8_email
+stage9_social | stage10_dm | stage11_card | manual
+```
+
+**Reason categories** (`reason_category` field):
+```
+enterprise | chain | franchise | wrong_industry | sole_trader | government
+not_au_based | duplicate | bad_data | not_a_business | already_customer
+not_reachable | other
+```
+
+**Append-only semantics:** Multiple rows per domain are allowed. Latest tag wins via `ORDER BY tagged_at DESC LIMIT 1`. Tag again any time to update reasoning — old rows are retained for audit.
+
+**Query examples:**
+```sql
+-- Latest tag per domain
+SELECT domain, reason_category, detail, tagged_at
+FROM lead_tags
+WHERE domain = 'plumbermate.com.au'
+ORDER BY tagged_at DESC LIMIT 1;
+
+-- All enterprise rejections
+SELECT domain, reason_category, detail FROM lead_tags
+WHERE reason_category = 'enterprise'
+ORDER BY tagged_at DESC;
+
+-- All tags from a stage
+SELECT domain, reason_category, detail FROM lead_tags
+WHERE stage = 'stage2_abn'
+ORDER BY tagged_at DESC;
+```
+
+**Retention:** Permanent — rows are never deleted.
+
+**Implementation:** `src/telegram_bot/tag_handler.py` (handler) + `src/pipeline/lead_tag_categories.py` (enums) + `supabase/migrations/101_lead_tags.sql` (schema).
+
 ## Directive + Validation Governance
 
 ### GOV-9 — Directive Scrutiny (MANDATORY)

--- a/src/pipeline/lead_tag_categories.py
+++ b/src/pipeline/lead_tag_categories.py
@@ -1,0 +1,46 @@
+"""
+FILE: src/pipeline/lead_tag_categories.py
+PURPOSE: Single source of truth for lead_tags stage and category enumerations.
+         Shared between tag_handler and any future query/reporting code.
+"""
+
+STAGE_CHOICES = [
+    "stage1_discovery",
+    "stage2_abn",
+    "stage3_comprehension",
+    "stage4_affordability",
+    "stage5_scoring",
+    "stage6_seo",
+    "stage7_contact",
+    "stage8_email",
+    "stage9_social",
+    "stage10_dm",
+    "stage11_card",
+    "manual",  # Dave catching it outside the pipeline
+]
+
+REASON_CATEGORIES = [
+    "enterprise",
+    "chain",
+    "franchise",
+    "wrong_industry",
+    "sole_trader",
+    "government",
+    "not_au_based",
+    "duplicate",
+    "bad_data",
+    "not_a_business",
+    "already_customer",
+    "not_reachable",
+    "other",
+]
+
+
+def is_valid_stage(s: str) -> bool:
+    """Return True if s is a recognised pipeline stage."""
+    return s in STAGE_CHOICES
+
+
+def is_valid_category(c: str) -> bool:
+    """Return True if c is a recognised reason category."""
+    return c in REASON_CATEGORIES

--- a/src/telegram_bot/chat_bot.py
+++ b/src/telegram_bot/chat_bot.py
@@ -24,6 +24,8 @@ from telegram.ext import (
     filters,
 )
 
+from src.telegram_bot.tag_handler import handle_tag, handle_tag_confirmation
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
@@ -928,11 +930,19 @@ def main() -> None:
     app.add_handler(CommandHandler("history", cmd_history))
     app.add_handler(CommandHandler("relay", cmd_relay))
     app.add_handler(CommandHandler("help", cmd_help))
+    app.add_handler(CommandHandler("tag", handle_tag))
+
+    # Tag confirmation observer — must run BEFORE the main text fallback
+    async def _tag_confirm_observer(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        consumed = await handle_tag_confirmation(update, context)
+        if not consumed:
+            await handle_message(update, context)
+
     # Media handlers before text fallback
     app.add_handler(MessageHandler(filters.PHOTO, handle_photo))
     app.add_handler(MessageHandler(filters.Document.ALL, handle_document))
-    # Text fallback last
-    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+    # Text fallback: tag confirmation intercept, then normal message handler
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, _tag_confirm_observer))
 
     app.run_polling(drop_pending_updates=True)
 

--- a/src/telegram_bot/tag_handler.py
+++ b/src/telegram_bot/tag_handler.py
@@ -1,0 +1,256 @@
+"""
+FILE: src/telegram_bot/tag_handler.py
+PURPOSE: Telegram /tag command handler — natural-language lead rejection tagging.
+         Dave sends /tag <free text>; Haiku parses to structured fields;
+         Dave confirms yes/no; on yes, a row is persisted to lead_tags.
+CONSUMERS: src/telegram_bot/chat_bot.py (registers handle_tag + handle_tag_confirmation)
+"""
+
+import asyncio
+import json
+import logging
+import os
+import traceback
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from src.pipeline.lead_tag_categories import (
+    REASON_CATEGORIES,
+    STAGE_CHOICES,
+    is_valid_category,
+    is_valid_stage,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+HAIKU_MODEL = "claude-haiku-4-5"
+TAG_TIMEOUT_SECONDS = 300  # 5 minutes
+
+# ---------------------------------------------------------------------------
+# In-memory pending tag store  {chat_id: PendingTag}
+# ---------------------------------------------------------------------------
+
+_pending_tags: dict[int, dict[str, Any]] = {}
+
+
+# ---------------------------------------------------------------------------
+# Helpers — imported lazily to avoid circular imports with chat_bot
+# ---------------------------------------------------------------------------
+
+def _get_bot_config() -> tuple[str, str, dict[str, str], str, int]:
+    """Return (SUPABASE_URL, SUPABASE_KEY, SUPABASE_HEADERS, CALLSIGN, DAVE_USER_ID).
+
+    Reads from environment so tests can patch os.environ without importing chat_bot.
+    """
+    supabase_url = os.environ.get("SUPABASE_URL", "")
+    supabase_key = os.environ.get("SUPABASE_SERVICE_KEY", "") or os.environ.get("SUPABASE_KEY", "")
+    headers = {
+        "apikey": supabase_key,
+        "Authorization": f"Bearer {supabase_key}",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+    }
+    callsign = os.environ.get("CALLSIGN", "elliot")
+    dave_user_id = int(os.environ.get("DAVE_USER_ID", "7267788033"))
+    return supabase_url, supabase_key, headers, callsign, dave_user_id
+
+
+def _classify_sender_local(update: Update) -> str:
+    """Lightweight sender check — returns 'dave' or the callsign."""
+    _, _, _, callsign, dave_user_id = _get_bot_config()
+    user = update.effective_user
+    if user and not user.is_bot and user.id == dave_user_id:
+        return "dave"
+    return callsign
+
+
+# ---------------------------------------------------------------------------
+# Haiku extraction
+# ---------------------------------------------------------------------------
+
+_EXTRACT_PROMPT = (
+    "Extract lead rejection tag fields from the user text. "
+    "Return ONLY valid JSON with these keys: "
+    "domain (string, required), stage (string, required), reason_category (string, required), "
+    "detail (string, required), criteria (object or null, optional). "
+    f"stage must be one of: {STAGE_CHOICES}. "
+    f"reason_category must be one of: {REASON_CATEGORIES}. "
+    "Map numeric stage references (e.g. 'stage 2') to their canonical name (e.g. 'stage2_abn'). "
+    "Return no other text — only the JSON object."
+)
+
+
+async def _haiku_extract(free_text: str) -> dict[str, Any]:
+    """Call Haiku to parse free_text into structured tag fields. Returns parsed dict."""
+    import anthropic  # local import — keeps module importable without anthropic installed in CI mocks
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    client = anthropic.AsyncAnthropic(api_key=api_key)
+
+    response = await client.messages.create(
+        model=HAIKU_MODEL,
+        max_tokens=300,
+        temperature=0,
+        system=_EXTRACT_PROMPT,
+        messages=[{"role": "user", "content": free_text}],
+    )
+    raw = response.content[0].text
+    return json.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# Timeout cleanup
+# ---------------------------------------------------------------------------
+
+async def _schedule_timeout(chat_id: int, message_id: int) -> None:
+    await asyncio.sleep(TAG_TIMEOUT_SECONDS)
+    pending = _pending_tags.get(chat_id)
+    if pending and pending.get("message_id") == message_id:
+        _pending_tags.pop(chat_id, None)
+        logger.info(f"[tag] Pending tag for chat={chat_id} timed out and cleared.")
+
+
+# ---------------------------------------------------------------------------
+# Public handler: /tag
+# ---------------------------------------------------------------------------
+
+async def handle_tag(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """CommandHandler callback for /tag <free text>."""
+    if not update.message or not update.effective_chat:
+        return
+
+    chat_id = update.effective_chat.id
+    message_id = update.message.message_id
+    free_text = " ".join(context.args) if context.args else ""
+
+    if not free_text.strip():
+        await update.message.reply_text(
+            "Usage: /tag <free text>\n"
+            "Example: /tag plumbermate.com.au dropped from stage 2 enterprise 200+ employees"
+        )
+        return
+
+    # Guard: one pending tag per chat at a time
+    if chat_id in _pending_tags:
+        await update.message.reply_text(
+            "Finish your previous tag first (reply yes/no)"
+        )
+        return
+
+    # Call Haiku
+    try:
+        parsed = await _haiku_extract(free_text)
+    except Exception as exc:
+        logger.error(f"[tag] Haiku extraction failed: {exc}")
+        await update.message.reply_text(f"Parse failed — {exc}. Tag not created.")
+        return
+
+    # Validate
+    stage = parsed.get("stage", "")
+    category = parsed.get("reason_category", "")
+    domain = parsed.get("domain", "")
+    detail = parsed.get("detail", "")
+    criteria = parsed.get("criteria")
+
+    errors: list[str] = []
+    if not domain:
+        errors.append("domain missing")
+    if not is_valid_stage(stage):
+        errors.append(f"invalid stage={stage!r}")
+    if not is_valid_category(category):
+        errors.append(f"invalid reason_category={category!r}")
+    if not detail:
+        errors.append("detail missing")
+
+    if errors:
+        await update.message.reply_text(
+            f"Parse error: {', '.join(errors)}.\n"
+            f"Raw parsed: domain={domain!r} stage={stage!r} category={category!r} detail={detail!r}"
+        )
+        return
+
+    # Store pending
+    tagged_by = _classify_sender_local(update)
+    _pending_tags[chat_id] = {
+        "domain": domain,
+        "stage": stage,
+        "reason_category": category,
+        "detail": detail,
+        "criteria": criteria,
+        "tagged_by": tagged_by,
+        "message_id": message_id,
+    }
+
+    # Schedule timeout cleanup
+    asyncio.create_task(_schedule_timeout(chat_id, message_id))
+
+    # Build confirmation
+    criteria_line = f"\ncriteria={json.dumps(criteria)}" if criteria else ""
+    confirm_text = (
+        f"Tag {domain} — stage={stage}, category={category}, detail={detail}"
+        f"{criteria_line}. Confirm? (reply yes/no)"
+    )
+    await update.message.reply_text(confirm_text)
+
+
+# ---------------------------------------------------------------------------
+# Public handler: yes/no confirmation
+# ---------------------------------------------------------------------------
+
+async def handle_tag_confirmation(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
+    """
+    MessageHandler observer. Returns True if the message was consumed (yes/no reply).
+    Returns False if no pending tag exists or message is not yes/no — caller passes through.
+    """
+    if not update.message or not update.effective_chat:
+        return False
+
+    chat_id = update.effective_chat.id
+    text = (update.message.text or "").strip().lower()
+
+    if chat_id not in _pending_tags:
+        return False
+
+    if text not in ("yes", "no"):
+        return False
+
+    pending = _pending_tags.pop(chat_id)
+
+    if text == "no":
+        await update.message.reply_text("Cancelled.")
+        return True
+
+    # Persist to Supabase
+    supabase_url, _, headers, _, _ = _get_bot_config()
+    payload: dict[str, Any] = {
+        "domain": pending["domain"],
+        "stage": pending["stage"],
+        "reason_category": pending["reason_category"],
+        "detail": pending["detail"],
+        "tagged_by": pending["tagged_by"],
+        "tagged_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if pending.get("criteria") is not None:
+        payload["criteria"] = pending["criteria"]
+
+    try:
+        url = f"{supabase_url}/rest/v1/lead_tags"
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, headers=headers, json=payload, timeout=10)
+        resp.raise_for_status()
+        await update.message.reply_text("✅ Tagged.")
+        logger.info(f"[tag] Persisted lead_tag for domain={pending['domain']}")
+    except Exception as exc:
+        logger.error(f"[tag] Supabase write failed: {traceback.format_exc()}")
+        short = str(exc)[:120]
+        await update.message.reply_text(f"Tag failed — {short}. Not saved.")
+
+    return True

--- a/supabase/migrations/101_lead_tags.sql
+++ b/supabase/migrations/101_lead_tags.sql
@@ -1,0 +1,20 @@
+-- Migration: 101_lead_tags.sql
+-- Purpose: Wave 1 Dave-knowledge capture — append-only lead rejection tags
+-- Append-only: multiple rows per domain allowed; latest wins via ORDER BY tagged_at DESC LIMIT 1
+
+CREATE TABLE IF NOT EXISTS public.lead_tags (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  domain           text NOT NULL,
+  business_name    text,                             -- snapshot at tag time
+  stage            text NOT NULL,                    -- stage1_discovery..stage11_card | manual
+  reason_category  text NOT NULL,                    -- enum enforced at app layer
+  detail           text NOT NULL,                    -- free-form
+  criteria         jsonb,                            -- optional structured (nullable)
+  tagged_at        timestamptz NOT NULL DEFAULT now(),
+  tagged_by        text NOT NULL DEFAULT 'dave'
+);
+
+CREATE INDEX IF NOT EXISTS lead_tags_domain_idx  ON public.lead_tags (domain);
+CREATE INDEX IF NOT EXISTS lead_tags_stage_idx   ON public.lead_tags (stage);
+CREATE INDEX IF NOT EXISTS lead_tags_reason_idx  ON public.lead_tags (reason_category);
+CREATE INDEX IF NOT EXISTS lead_tags_tagged_idx  ON public.lead_tags (tagged_at DESC);

--- a/tests/telegram_bot/test_tag_handler.py
+++ b/tests/telegram_bot/test_tag_handler.py
@@ -1,0 +1,408 @@
+"""
+FILE: tests/telegram_bot/test_tag_handler.py
+PURPOSE: Pytest suite for the /tag command handler (lead_tags Wave 1).
+"""
+
+import asyncio
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Ensure env is set before importing handler (mirrors conftest.py pattern)
+os.environ.setdefault("ENVIRONMENT", "development")
+os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
+os.environ.setdefault("SUPABASE_KEY", "test-key")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "test-service-key")
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-anthropic-key")
+os.environ.setdefault("CALLSIGN", "aiden")
+os.environ.setdefault("DAVE_USER_ID", "7267788033")
+
+from src.telegram_bot import tag_handler  # noqa: E402  (env must be set first)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_update(text: str, user_id: int = 7267788033, is_bot: bool = False, chat_id: int = 9999) -> MagicMock:
+    """Build a minimal mock Update that tag_handler inspects."""
+    user = MagicMock()
+    user.id = user_id
+    user.is_bot = is_bot
+    user.username = "dave" if not is_bot else "somebot"
+    user.first_name = "Dave" if not is_bot else "Bot"
+
+    chat = MagicMock()
+    chat.id = chat_id
+
+    message = MagicMock()
+    message.text = text
+    message.message_id = 42
+    message.reply_text = AsyncMock()
+
+    update = MagicMock()
+    update.effective_user = user
+    update.effective_chat = chat
+    update.message = message
+    return update
+
+
+def _make_context(args: list[str] | None = None) -> MagicMock:
+    ctx = MagicMock()
+    ctx.args = args or []
+    return ctx
+
+
+def _haiku_response(domain: str, stage: str, reason_category: str, detail: str, criteria=None) -> MagicMock:
+    """Build a mock anthropic messages.create response."""
+    payload = {"domain": domain, "stage": stage, "reason_category": reason_category, "detail": detail}
+    if criteria is not None:
+        payload["criteria"] = criteria
+
+    content_block = MagicMock()
+    content_block.text = json.dumps(payload)
+
+    response = MagicMock()
+    response.content = [content_block]
+    return response
+
+
+def _supabase_ok() -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=[{"id": "fake-uuid"}])
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def clear_pending():
+    """Clear pending tags before/after each test."""
+    tag_handler._pending_tags.clear()
+    yield
+    tag_handler._pending_tags.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_parses_daves_example():
+    """Haiku returns expected dict; bot replies with confirmation containing all fields."""
+    update = _make_update("plumbermate.com.au dropped from stage 2 enterprise 200+ employees")
+    ctx = _make_context(["plumbermate.com.au", "dropped", "from", "stage", "2", "enterprise", "200+", "employees"])
+
+    mock_response = _haiku_response(
+        domain="plumbermate.com.au",
+        stage="stage2_abn",
+        reason_category="enterprise",
+        detail="200+ employees",
+    )
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+        "domain": "plumbermate.com.au",
+        "stage": "stage2_abn",
+        "reason_category": "enterprise",
+        "detail": "200+ employees",
+    })):
+        await tag_handler.handle_tag(update, ctx)
+
+    update.message.reply_text.assert_called_once()
+    reply = update.message.reply_text.call_args[0][0]
+    assert "plumbermate.com.au" in reply
+    assert "stage2_abn" in reply
+    assert "enterprise" in reply
+    assert "200+ employees" in reply
+    assert "yes/no" in reply.lower()
+
+
+@pytest.mark.asyncio
+async def test_invalid_stage_from_llm():
+    """Bad stage from Haiku → error message, no row written."""
+    update = _make_update("example.com.au bad stage")
+    ctx = _make_context(["example.com.au", "bad", "stage"])
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+        "domain": "example.com.au",
+        "stage": "stage99_nonexistent",
+        "reason_category": "other",
+        "detail": "some detail",
+    })):
+        await tag_handler.handle_tag(update, ctx)
+
+    reply = update.message.reply_text.call_args[0][0]
+    assert "invalid stage" in reply.lower() or "stage99_nonexistent" in reply
+    assert update.effective_chat.id not in tag_handler._pending_tags
+
+
+@pytest.mark.asyncio
+async def test_invalid_category_from_llm():
+    """Bad reason_category from Haiku → error message, no row written."""
+    update = _make_update("example.com.au bad cat")
+    ctx = _make_context(["example.com.au", "bad", "cat"])
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+        "domain": "example.com.au",
+        "stage": "stage1_discovery",
+        "reason_category": "nonexistent_cat",
+        "detail": "some detail",
+    })):
+        await tag_handler.handle_tag(update, ctx)
+
+    reply = update.message.reply_text.call_args[0][0]
+    assert "invalid reason_category" in reply.lower() or "nonexistent_cat" in reply
+    assert update.effective_chat.id not in tag_handler._pending_tags
+
+
+@pytest.mark.asyncio
+async def test_yes_persists_row():
+    """yes reply → Supabase POST called with expected payload, reply says Tagged."""
+    chat_id = 1001
+    update_tag = _make_update("plumbermate.com.au enterprise", chat_id=chat_id)
+    ctx = _make_context(["plumbermate.com.au", "enterprise"])
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+        "domain": "plumbermate.com.au",
+        "stage": "stage2_abn",
+        "reason_category": "enterprise",
+        "detail": "200+ employees",
+    })):
+        await tag_handler.handle_tag(update_tag, ctx)
+
+    assert chat_id in tag_handler._pending_tags
+
+    update_yes = _make_update("yes", chat_id=chat_id)
+    ctx2 = _make_context()
+
+    mock_resp = _supabase_ok()
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client_cls.return_value = mock_client
+
+        consumed = await tag_handler.handle_tag_confirmation(update_yes, ctx2)
+
+    assert consumed is True
+    assert chat_id not in tag_handler._pending_tags
+    mock_client.post.assert_called_once()
+    call_kwargs = mock_client.post.call_args
+    payload = call_kwargs[1]["json"] if "json" in call_kwargs[1] else call_kwargs.kwargs.get("json", {})
+    assert payload["domain"] == "plumbermate.com.au"
+    assert payload["stage"] == "stage2_abn"
+    assert payload["reason_category"] == "enterprise"
+
+    reply = update_yes.message.reply_text.call_args[0][0]
+    assert "tagged" in reply.lower()
+
+
+@pytest.mark.asyncio
+async def test_no_cancels():
+    """no reply → no Supabase call, reply says Cancelled."""
+    chat_id = 1002
+    update_tag = _make_update("example.com.au sole trader", chat_id=chat_id)
+    ctx = _make_context(["example.com.au", "sole", "trader"])
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+        "domain": "example.com.au",
+        "stage": "stage1_discovery",
+        "reason_category": "sole_trader",
+        "detail": "sole trader operation",
+    })):
+        await tag_handler.handle_tag(update_tag, ctx)
+
+    update_no = _make_update("no", chat_id=chat_id)
+    ctx2 = _make_context()
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        consumed = await tag_handler.handle_tag_confirmation(update_no, ctx2)
+        mock_client_cls.assert_not_called()
+
+    assert consumed is True
+    assert chat_id not in tag_handler._pending_tags
+    reply = update_no.message.reply_text.call_args[0][0]
+    assert "cancelled" in reply.lower()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_tag_pending_rejected():
+    """Second /tag while one is pending → 'finish your previous tag first'."""
+    chat_id = 1003
+    update1 = _make_update("example.com.au chain", chat_id=chat_id)
+    ctx1 = _make_context(["example.com.au", "chain"])
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+        "domain": "example.com.au",
+        "stage": "stage1_discovery",
+        "reason_category": "chain",
+        "detail": "national chain",
+    })):
+        await tag_handler.handle_tag(update1, ctx1)
+
+    # Second /tag before confirming
+    update2 = _make_update("other.com.au franchise", chat_id=chat_id)
+    ctx2 = _make_context(["other.com.au", "franchise"])
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock()) as mock_extract:
+        await tag_handler.handle_tag(update2, ctx2)
+        mock_extract.assert_not_called()
+
+    reply = update2.message.reply_text.call_args[0][0]
+    assert "finish your previous tag" in reply.lower()
+
+
+@pytest.mark.asyncio
+async def test_timeout_clears_pending():
+    """After timeout elapses, pending tag is cleared silently."""
+    chat_id = 1004
+    update_tag = _make_update("example.com.au enterprise", chat_id=chat_id)
+    ctx = _make_context(["example.com.au", "enterprise"])
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+        "domain": "example.com.au",
+        "stage": "stage1_discovery",
+        "reason_category": "enterprise",
+        "detail": "big corp",
+    })), patch.object(tag_handler, "TAG_TIMEOUT_SECONDS", 0.05):
+        await tag_handler.handle_tag(update_tag, ctx)
+        assert chat_id in tag_handler._pending_tags
+        # Allow timeout coroutine to fire
+        await asyncio.sleep(0.15)
+
+    assert chat_id not in tag_handler._pending_tags
+
+
+@pytest.mark.asyncio
+async def test_orphan_domain_still_writes():
+    """Domain not in leads table → row still written to lead_tags (no FK)."""
+    chat_id = 1005
+    update_tag = _make_update("newdomain.com.au government", chat_id=chat_id)
+    ctx = _make_context(["newdomain.com.au", "government"])
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+        "domain": "newdomain.com.au",
+        "stage": "manual",
+        "reason_category": "government",
+        "detail": "local council",
+    })):
+        await tag_handler.handle_tag(update_tag, ctx)
+
+    update_yes = _make_update("yes", chat_id=chat_id)
+    ctx2 = _make_context()
+
+    mock_resp = _supabase_ok()
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client_cls.return_value = mock_client
+
+        consumed = await tag_handler.handle_tag_confirmation(update_yes, ctx2)
+
+    assert consumed is True
+    mock_client.post.assert_called_once()
+    payload = mock_client.post.call_args[1]["json"]
+    assert payload["domain"] == "newdomain.com.au"
+
+
+@pytest.mark.asyncio
+async def test_append_on_duplicate():
+    """Two /tag + yes for the same domain → two Supabase POST calls."""
+    chat_id = 1006
+
+    for i, detail in enumerate(["first tag", "second tag"]):
+        update_tag = _make_update(f"sameDomain.com.au {detail}", chat_id=chat_id)
+        ctx = _make_context([f"sameDomain.com.au", detail])
+
+        with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+            "domain": "sameDomain.com.au",
+            "stage": "stage1_discovery",
+            "reason_category": "duplicate",
+            "detail": detail,
+        })):
+            await tag_handler.handle_tag(update_tag, ctx)
+
+        update_yes = _make_update("yes", chat_id=chat_id)
+        ctx2 = _make_context()
+
+        mock_resp = _supabase_ok()
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            consumed = await tag_handler.handle_tag_confirmation(update_yes, ctx2)
+
+        assert consumed is True
+        # Both iterations should POST without error
+        mock_client.post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_tagged_by_defaults_dave():
+    """Sender classified as Dave → tagged_by = 'dave'."""
+    chat_id = 1007
+    update_tag = _make_update("example.com.au not_au_based", user_id=7267788033, is_bot=False, chat_id=chat_id)
+    ctx = _make_context(["example.com.au", "not_au_based"])
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+        "domain": "example.com.au",
+        "stage": "stage1_discovery",
+        "reason_category": "not_au_based",
+        "detail": "US company",
+    })):
+        await tag_handler.handle_tag(update_tag, ctx)
+
+    assert tag_handler._pending_tags[chat_id]["tagged_by"] == "dave"
+
+
+@pytest.mark.asyncio
+async def test_tagged_by_callsign_for_agent():
+    """Sender is a peer bot / unknown human → tagged_by = CALLSIGN."""
+    chat_id = 1008
+    # Non-Dave user_id
+    update_tag = _make_update("example.com.au bad_data", user_id=9999999, is_bot=False, chat_id=chat_id)
+    ctx = _make_context(["example.com.au", "bad_data"])
+
+    with patch("src.telegram_bot.tag_handler._haiku_extract", new=AsyncMock(return_value={
+        "domain": "example.com.au",
+        "stage": "stage1_discovery",
+        "reason_category": "bad_data",
+        "detail": "corrupted data",
+    })):
+        await tag_handler.handle_tag(update_tag, ctx)
+
+    callsign = os.environ.get("CALLSIGN", "elliot")
+    assert tag_handler._pending_tags[chat_id]["tagged_by"] == callsign
+
+
+@pytest.mark.asyncio
+async def test_non_yes_no_does_not_consume():
+    """A random text message when pending tag exists is not consumed (returns False)."""
+    chat_id = 1009
+    # Seed a pending tag manually
+    tag_handler._pending_tags[chat_id] = {
+        "domain": "test.com.au",
+        "stage": "manual",
+        "reason_category": "other",
+        "detail": "test",
+        "tagged_by": "dave",
+        "message_id": 1,
+    }
+
+    update = _make_update("hello there", chat_id=chat_id)
+    ctx = _make_context()
+    consumed = await tag_handler.handle_tag_confirmation(update, ctx)
+    assert consumed is False
+    # Pending should still be there
+    assert chat_id in tag_handler._pending_tags


### PR DESCRIPTION
## Summary

Wave 1 item #3. Natural-language Telegram `/tag` command lets Dave attach his drop-reason reasoning to leads. Haiku parses free text into structured fields; bot confirms back; on `yes` a row persists to new `lead_tags` table. Append-only — history preserved; latest wins via `ORDER BY tagged_at DESC`.

**Last Wave 1 item.**

## Interface

```
Dave:  /tag plumbermate.com.au dropped from stage 2 enterprise 200+ employees
Bot:   Tag plumbermate.com.au — stage=stage2_abn, category=enterprise,
       detail=200+ employees. Confirm? (reply yes/no)
Dave:  yes
Bot:   ✅ Tagged.
```

## Added

- `supabase/migrations/101_lead_tags.sql` — table (8 cols, 4 indexes, nullable criteria jsonb)
- `src/pipeline/lead_tag_categories.py` — 13 categories, 12 stages, validators (single source of truth)
- `src/telegram_bot/tag_handler.py` — full flow: Haiku extract → validate → pending state → confirm → write
- `tests/telegram_bot/test_tag_handler.py` — 12 pytest cases, all green (3.9s)

## Modified

- `src/telegram_bot/chat_bot.py` — minimal surface change: register `/tag` handler + inline `_tag_confirm_observer` closure intercepting yes/no before the main text handler
- `CLAUDE.md` — new `§Dave Tagging` section (~40 lines) under `§Group Chat Plumbing`

## Flag for Dave

**Haiku-per-tag API call (~$0.001/tag) is NOT queued for approval.** Rationale: Dave initiates each tag himself, so the API call is user-triggered. If you want the `/tag` command itself gated (bot queues pending tags for your approval before the Haiku call), tell us and we'll flip it. Default is permissive since Dave is the one typing the command.

## NOT in this PR (backlog)

- Dashboard visualisation of tags
- ML training on the tag dataset
- `/untag`, `/edit`, bulk CSV import (v2)

## Dave-visible DoD

1. You run migration 101 (`psql -f supabase/migrations/101_lead_tags.sql` against the project).
2. You type the example command → confirmation prompt → `yes` → row in `lead_tags`.
3. `SELECT domain, reason_category, detail, tagged_at FROM lead_tags ORDER BY tagged_at DESC LIMIT 10` returns your tags.

## Test plan
- [x] `python3 -m py_compile` on all 4 Python files — clean
- [x] `pytest tests/telegram_bot/` — 12/12 passed
- [x] `pytest tests/test_three_store_save.py tests/agent_coord/` — 19/19 still pass (no regression)
- [ ] Live test: Dave applies migration + runs sample command post-merge

## Governance
- Wave 1 item #3 per Dave-approved plan 2026-04-17.
- Branch targets `aiden/scaffold` per `IDENTITY.md` — does not merge to main.
- Elliot (CTO) reviews; Dave merges; Dave applies migration 101 post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)