### PR TITLE
[AIDEN] fix(import): sys.path for systemd runtime (#351 regression)

### DIFF
--- a/src/telegram_bot/chat_bot.py
+++ b/src/telegram_bot/chat_bot.py
@@ -13,6 +13,14 @@ import sys
 import uuid
 from datetime import datetime, timezone
 
+# Add repo root to sys.path so `from src.*` imports resolve when this script
+# is launched directly by systemd (sys.path[0] is src/telegram_bot/ by default,
+# which doesn't expose the `src` package). Tests work because pytest injects
+# rootdir; production didn't. Fixes #351 regression caught at service restart.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
 import httpx
 from dotenv import load_dotenv
 from telegram import Update


### PR DESCRIPTION
## Hotfix

aiden-telegram.service crash-looped after restart post-#351 merge with `ModuleNotFoundError: No module named 'src'`.

**Root cause:** chat_bot.py added `from src.telegram_bot.tag_handler import ...`. Works under pytest (conftest injects rootdir) but not at runtime. systemd runs the script with `sys.path[0] = src/telegram_bot/`, so the `src` package isn't visible.

**Fix:** inject repo root (computed from `__file__`) into `sys.path` at the top of chat_bot.py before the `from src.*` import. Keeps the `src.*` import style consistent with tag_handler.py + test suite.

## Verified

```
$ timeout 3 python3 src/telegram_bot/chat_bot.py
Terminated
exit=143  # SIGTERM from timeout, NOT an import error
```

Got past the import phase; was in the main loop when timeout killed it. Imports resolve.

## Peer-check miss (logged for Wave 1 retro)

Both Elliot and I approved #351 on pytest-green alone. Neither ran `python3 src/telegram_bot/chat_bot.py` directly. Tests pass because pytest sets rootdir; production doesn't. Adding "run-the-script-not-just-tests for any PR that modifies chat_bot.py imports" to the retro action items.

## Governance
- Urgent fix — my bot service offline until this lands
- Branch `a/hotfix-tag-import` targets `aiden/scaffold`
- Elliot reviews fast; Dave merges; I restart the service

🤖 Generated with [Claude Code](https://claude.com/claude-code)