### PR TITLE
[ELLIOT] feat: scaffold scout agent-3 — wire bot plumbing

### DIFF
--- a/src/telegram_bot/chat_bot.py
+++ b/src/telegram_bot/chat_bot.py
@@ -57,10 +57,10 @@ CALLSIGN_TAG: str = f"[{CALLSIGN.upper()}]"
 
 # Sender classification for group chats (LAW XVII)
 BOT_USERNAME: str = ""  # populated at startup from getMe
-KNOWN_PEER_BOTS: set[str] = {"eeeeelllliiiioooottt_bot", "aaaaidenbot"}  # lowercase
+KNOWN_PEER_BOTS: set[str] = {"eeeeelllliiiioooottt_bot", "aaaaidenbot", "scoutbotstephensbot"}  # lowercase
 DAVE_USER_ID: int = 7267788033  # hardcoded CEO user_id — only this human gets Sender.DAVE
 # Peer cross-post: bot-to-bot visibility bypass (Telegram doesn't deliver bot-to-bot)
-_PEER_MAP = {"elliot": "aiden", "aiden": "elliot"}
+_PEER_MAP = {"elliot": "aiden", "aiden": "elliot", "scout": "elliot"}
 PEER_INBOX: str | None = f"/tmp/telegram-relay-{_PEER_MAP[CALLSIGN]}/inbox" if CALLSIGN in _PEER_MAP else None
 GROUP_CHAT_ID = -1003926592540
 
@@ -95,7 +95,7 @@ os.makedirs(INBOX_DIR, exist_ok=True)
 os.makedirs(OUTBOX_DIR, exist_ok=True)
 
 # Relay defaults ON only if tmux target exists (no tmux = use subprocess path)
-_TMUX_TARGETS = {"elliot": "elliottbot", "aiden": "aiden"}
+_TMUX_TARGETS = {"elliot": "elliottbot", "aiden": "aiden", "scout": "scout"}
 _tmux_session = _TMUX_TARGETS.get(CALLSIGN, f"{CALLSIGN}bot")
 _tmux_exists = os.system(f"tmux has-session -t {_tmux_session} 2>/dev/null") == 0
 relay_mode: dict[int, bool] = {cid: True for cid in ALLOWED_CHAT_IDS} if _tmux_exists else {}

--- a/src/telegram_bot/relay_watcher.sh
+++ b/src/telegram_bot/relay_watcher.sh
@@ -14,6 +14,8 @@ if [ "$CALLSIGN" = "elliot" ]; then
     TMUX_TARGET="elliottbot:0.0"
 elif [ "$CALLSIGN" = "aiden" ]; then
     TMUX_TARGET="aiden:0.0"
+elif [ "$CALLSIGN" = "scout" ]; then
+    TMUX_TARGET="scout:0.0"
 else
     TMUX_TARGET="${CALLSIGN}bot:0.0"
 fi


### PR DESCRIPTION
## Summary
- Add scout callsign to KNOWN_PEER_BOTS, _TMUX_TARGETS, _PEER_MAP in chat_bot.py
- Add scout tmux target mapping in relay_watcher.sh
- Scout cross-posts to elliot (matching aiden scaffold pattern)

## Test plan
- [ ] Verify scout tmux session resolves to CALLSIGN=scout via .bashrc
- [ ] Verify scout-telegram.service and scout-relay-watcher.service load correctly after Dave enables them
- [ ] Confirm scout bot messages appear in elliot inbox (cross-post path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)