### PR TITLE
[AIDEN] feat(memory): typed memory layer v1 + /recall (Wave 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,3 +254,44 @@ Before context exhaustion or /reset:
 5. Report completion with directive number and PR links
 
 **Context thresholds:** 40% -> self-alert | 50% -> alert Dave | 60% -> execute session end protocol
+
+## Memory Layer (v1 typed, no embeddings)
+
+Agent memory is persisted to `public.agent_memories` via PostgREST. v1 is text + tag + source_type filtering only — no embeddings, no pgvector, no OpenAI.
+
+### Quick API
+
+```python
+from src.memory import store, retrieve, retrieve_by_tags, recall, Memory, VALID_SOURCE_TYPES
+
+# Write
+mem_id = store("aiden", "decision", "content", tags=["tag1"], typed_metadata={})
+
+# Read — any combination of filters
+mems = retrieve(types=["pattern", "decision"], tags=["tag1"], content_contains="topic", n=20)
+mems = retrieve_by_tags(["tag1", "tag2"], mode="any")  # or mode="all"
+
+# High-level recall grouped by source_type
+grouped = recall(topic="rate limiting")   # content + tag search
+grouped = recall()                        # recent high-value types
+```
+
+### Valid source_type values
+
+`pattern`, `decision`, `test_result`, `reasoning`, `skill`, `daily_log`, `dave_confirmed`, `verified_fact`, `research`
+
+### Rate limit
+
+Daily cap: `MEMORY_WRITE_CAP` env var (default 5000). File-backed at `/tmp/agent-memory-writes-YYYYMMDD.count`. Raises `RateLimitExceeded` at cap.
+
+### Telegram command
+
+`/recall` and `/recall <topic>` — calls `recall()`, formats output by source_type, replies inline or writes to `/tmp/recall-<uuid>.md` if too long.
+
+### Full contract
+
+`docs/memory_interface.md` — schema, operators, error table, v2 roadmap.
+
+### Schema
+
+Migration: `supabase/migrations/102_agent_memories.sql` — NOT yet applied to live Supabase. Dave applies post-merge.

--- a/docs/memory_interface.md
+++ b/docs/memory_interface.md
@@ -1,0 +1,168 @@
+# Memory Interface — v1 (typed, no embeddings)
+
+## Overview
+
+`src/memory` is the agent memory layer for multi-agent knowledge compounding.
+
+**v1 contract:** text + tag + source_type filtering via PostgREST. No embeddings, no pgvector, no OpenAI dependency. Embeddings are deferred to v2 when measured retrieval-miss evidence justifies the complexity cost.
+
+---
+
+## Module
+
+```
+src/memory/
+    __init__.py      — public re-exports
+    types.py         — Memory dataclass, VALID_SOURCE_TYPES, RateLimitExceeded
+    client.py        — lazy Supabase URL + headers from env
+    ratelimit.py     — daily write counter (file-backed, MEMORY_WRITE_CAP)
+    store.py         — write one memory row
+    retrieve.py      — filter-based read (type / callsign / tag / text / time)
+    recall.py        — high-level recall grouped by source_type (/recall Telegram)
+```
+
+---
+
+## Dataclass
+
+```python
+@dataclass(frozen=True)
+class Memory:
+    id: uuid.UUID
+    callsign: str
+    source_type: str
+    content: str
+    typed_metadata: dict
+    tags: list[str]
+    valid_from: datetime
+    valid_to: datetime | None
+    created_at: datetime
+```
+
+---
+
+## Valid source_type values
+
+```python
+VALID_SOURCE_TYPES = {
+    "pattern", "decision", "test_result", "reasoning", "skill",
+    "daily_log", "dave_confirmed", "verified_fact", "research",
+}
+```
+
+---
+
+## Public API
+
+### `store()`
+
+```python
+def store(
+    callsign: str,
+    source_type: str,
+    content: str,
+    typed_metadata: dict | None = None,
+    tags: list[str] | None = None,
+    valid_from: datetime | None = None,
+    valid_to: datetime | None = None,
+) -> uuid.UUID
+```
+
+Writes one memory row. Returns the inserted row UUID.
+
+Raises:
+- `ValueError` — source_type not in VALID_SOURCE_TYPES
+- `RateLimitExceeded` — daily cap hit (default 5000, env `MEMORY_WRITE_CAP`)
+- `RuntimeError` — Supabase HTTP error or connection failure
+
+### `retrieve()`
+
+```python
+def retrieve(
+    types: list[str] | None = None,
+    callsigns: list[str] | None = None,
+    tags: list[str] | None = None,
+    tag_mode: Literal["any", "all"] = "any",
+    since: datetime | None = None,
+    until: datetime | None = None,
+    content_contains: str | None = None,
+    n: int = 20,
+) -> list[Memory]
+```
+
+General PostgREST filter query. Ordered `created_at DESC`. Limit `n`.
+
+Filter operators used internally:
+- types: `source_type=in.(t1,t2)`
+- callsigns: `callsign=in.(c1,c2)`
+- tags any: `tags=ov.{t1,t2}`
+- tags all: `tags=cs.{t1,t2}`
+- text: `content=ilike.*term*`
+- time range: `created_at=gte.ISO` / `created_at=lte.ISO`
+
+### `retrieve_by_tags()`
+
+```python
+def retrieve_by_tags(
+    tags: list[str],
+    n: int = 20,
+    mode: Literal["any", "all"] = "any",
+) -> list[Memory]
+```
+
+Convenience wrapper — tags only.
+
+### `recall()`
+
+```python
+def recall(topic: str | None = None, n: int = 20) -> dict[str, list[Memory]]
+```
+
+High-level retrieval backing the `/recall` Telegram command. Returns memories grouped by `source_type`.
+
+- `topic` provided: queries `content_contains=topic` + `tags=[topic]`, deduplicates by id, groups by source_type.
+- `topic=None`: returns recent high-value memories (`pattern`, `decision`, `skill`, `dave_confirmed`), grouped by source_type.
+
+---
+
+## Rate limit
+
+File-backed daily counter: `/tmp/agent-memory-writes-YYYYMMDD.count`. Resets at UTC midnight. Cap: env `MEMORY_WRITE_CAP` (default 5000). Raises `RateLimitExceeded` when cap is reached.
+
+---
+
+## Errors
+
+| Exception | When |
+|-----------|------|
+| `ValueError` | `source_type` not in `VALID_SOURCE_TYPES` |
+| `RateLimitExceeded` | daily write cap hit |
+| `RuntimeError` | Supabase non-2xx or `httpx.HTTPError` |
+
+---
+
+## Schema (migration 102)
+
+Table: `public.agent_memories`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK, gen_random_uuid() |
+| callsign | text | agent identifier |
+| source_type | text | one of VALID_SOURCE_TYPES |
+| content | text | raw text content |
+| typed_metadata | jsonb | arbitrary structured metadata |
+| tags | text[] | GIN-indexed |
+| valid_from | timestamptz | DEFAULT now() |
+| valid_to | timestamptz | nullable — expiry |
+| created_at | timestamptz | DEFAULT now() |
+
+Migration file: `supabase/migrations/102_agent_memories.sql`
+
+**Do not apply to live Supabase** — Dave applies post-merge.
+
+---
+
+## v2 roadmap
+
+Add semantic search via embeddings when retrieval-miss evidence justifies. Candidate approach: `pgvector` extension + `embedding vector(1536)` column + `HNSW` index. The `store()` and `retrieve()` interfaces are designed to extend without breaking callers — `typed_metadata` can carry embedding metadata in a backward-compatible way. No timeline set; v1 ships first and we measure.

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,0 +1,20 @@
+"""
+Package: src/memory
+Purpose: Agent memory layer — text + tag + type filtered persistence.
+         v1: no embeddings, no pgvector, no OpenAI. PostgREST only.
+"""
+
+from .recall import recall
+from .retrieve import retrieve, retrieve_by_tags
+from .store import store
+from .types import VALID_SOURCE_TYPES, Memory, RateLimitExceeded
+
+__all__ = [
+    "store",
+    "retrieve",
+    "retrieve_by_tags",
+    "recall",
+    "Memory",
+    "VALID_SOURCE_TYPES",
+    "RateLimitExceeded",
+]

--- a/src/memory/client.py
+++ b/src/memory/client.py
@@ -1,0 +1,29 @@
+"""
+FILE: src/memory/client.py
+PURPOSE: Lazy Supabase HTTP client config for the memory layer.
+         No OpenAI — v1 is text+tag+type only.
+"""
+
+import os
+
+
+def _supabase_url() -> str:
+    url = os.environ.get("SUPABASE_URL", "")
+    if not url:
+        raise RuntimeError("SUPABASE_URL not set in environment")
+    return url.rstrip("/")
+
+
+def _supabase_headers() -> dict[str, str]:
+    key = os.environ.get("SUPABASE_SERVICE_KEY", "") or os.environ.get("SUPABASE_KEY", "")
+    if not key:
+        raise RuntimeError("SUPABASE_SERVICE_KEY (or SUPABASE_KEY) not set in environment")
+    return {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+    }
+
+
+MEMORIES_ENDPOINT = "/rest/v1/agent_memories"

--- a/src/memory/ratelimit.py
+++ b/src/memory/ratelimit.py
@@ -1,0 +1,53 @@
+"""
+FILE: src/memory/ratelimit.py
+PURPOSE: Daily (UTC) write counter for agent_memories.
+         File-backed at /tmp/agent-memory-writes-YYYYMMDD.count.
+         Env MEMORY_WRITE_CAP (default 5000).
+         check_and_increment() raises RateLimitExceeded if at cap.
+"""
+
+import os
+from datetime import datetime, timezone
+
+from .types import RateLimitExceeded
+
+_COUNT_DIR = "/tmp"
+_COUNT_PREFIX = "agent-memory-writes-"
+DEFAULT_CAP = 5000
+
+
+def _count_file() -> str:
+    date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
+    return os.path.join(_COUNT_DIR, f"{_COUNT_PREFIX}{date_str}.count")
+
+
+def _read_count(path: str) -> int:
+    try:
+        with open(path) as f:
+            return int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        return 0
+
+
+def _write_count(path: str, count: int) -> None:
+    with open(path, "w") as f:
+        f.write(str(count))
+
+
+def check_and_increment() -> int:
+    """Read current count; raise RateLimitExceeded if at cap; else increment and return new count."""
+    cap = int(os.environ.get("MEMORY_WRITE_CAP", DEFAULT_CAP))
+    path = _count_file()
+    current = _read_count(path)
+    if current >= cap:
+        raise RateLimitExceeded(
+            f"Daily memory write cap ({cap}) reached. Resets at UTC midnight."
+        )
+    new_count = current + 1
+    _write_count(path, new_count)
+    return new_count
+
+
+def current_count() -> int:
+    """Return today's write count without incrementing."""
+    return _read_count(_count_file())

--- a/src/memory/recall.py
+++ b/src/memory/recall.py
@@ -1,0 +1,41 @@
+"""
+FILE: src/memory/recall.py
+PURPOSE: High-level retrieval backing the /recall Telegram command.
+         v1 — text+tag content_contains + tag match, grouped by source_type.
+         v2 will layer semantic search when embeddings ship.
+"""
+
+from .retrieve import retrieve, retrieve_by_tags
+from .types import Memory
+
+_HIGH_VALUE_TYPES = ["pattern", "decision", "skill", "dave_confirmed"]
+
+
+def recall(topic: str | None = None, n: int = 20) -> dict[str, list[Memory]]:
+    """High-level retrieval backing the /recall Telegram command.
+
+    v1 behavior: if topic is a string, use it as content_contains + try-tag-match.
+    Combines results from both. Groups the output by source_type.
+
+    Returns: {source_type: [Memory, ...]} — empty types omitted.
+
+    v2 will layer semantic search on top when embeddings ship.
+    """
+    if topic is None:
+        memories = retrieve(types=_HIGH_VALUE_TYPES, n=n)
+    else:
+        by_content = retrieve(content_contains=topic, n=n)
+        by_tag = retrieve_by_tags([topic], n=n)
+
+        # Dedupe by id
+        seen: set = set()
+        memories = []
+        for m in by_content + by_tag:
+            if m.id not in seen:
+                seen.add(m.id)
+                memories.append(m)
+
+    grouped: dict[str, list[Memory]] = {}
+    for m in memories:
+        grouped.setdefault(m.source_type, []).append(m)
+    return grouped

--- a/src/memory/retrieve.py
+++ b/src/memory/retrieve.py
@@ -1,0 +1,120 @@
+"""
+FILE: src/memory/retrieve.py
+PURPOSE: Read memories from agent_memories via PostgREST filters.
+         v1 — text+tag+type filters only; no embeddings.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+import httpx
+
+from .client import MEMORIES_ENDPOINT, _supabase_headers, _supabase_url
+from .types import Memory
+
+
+def _parse_memory(row: dict) -> Memory:
+    def _dt(val: str | None) -> datetime | None:
+        if val is None:
+            return None
+        from datetime import timezone
+        from dateutil import parser as dateutil_parser
+        try:
+            dt = dateutil_parser.isoparse(val)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except Exception:
+            return None
+
+    valid_from_raw = row.get("valid_from")
+    created_at_raw = row.get("created_at")
+
+    from datetime import timezone
+    valid_from_dt = _dt(valid_from_raw)
+    if valid_from_dt is None:
+        valid_from_dt = datetime.now(timezone.utc)
+    created_at_dt = _dt(created_at_raw)
+    if created_at_dt is None:
+        created_at_dt = datetime.now(timezone.utc)
+
+    return Memory(
+        id=uuid.UUID(row["id"]),
+        callsign=row["callsign"],
+        source_type=row["source_type"],
+        content=row["content"],
+        typed_metadata=row.get("typed_metadata") or {},
+        tags=row.get("tags") or [],
+        valid_from=valid_from_dt,
+        valid_to=_dt(row.get("valid_to")),
+        created_at=created_at_dt,
+    )
+
+
+def retrieve(
+    types: list[str] | None = None,
+    callsigns: list[str] | None = None,
+    tags: list[str] | None = None,
+    tag_mode: Literal["any", "all"] = "any",
+    since: datetime | None = None,
+    until: datetime | None = None,
+    content_contains: str | None = None,
+    n: int = 20,
+) -> list[Memory]:
+    """General filter query. Combines any of: type IN (...), callsign IN (...),
+    tags overlap (any) or contain (all), created_at >= since, created_at <= until,
+    content ILIKE %X%. Orders by created_at DESC. Limit n."""
+
+    params: list[str] = []
+
+    if types:
+        type_csv = ",".join(types)
+        params.append(f"source_type=in.({type_csv})")
+
+    if callsigns:
+        cs_csv = ",".join(callsigns)
+        params.append(f"callsign=in.({cs_csv})")
+
+    if tags:
+        tag_csv = ",".join(tags)
+        if tag_mode == "all":
+            params.append(f"tags=cs.{{{tag_csv}}}")
+        else:
+            params.append(f"tags=ov.{{{tag_csv}}}")
+
+    if since is not None:
+        params.append(f"created_at=gte.{since.isoformat()}")
+
+    if until is not None:
+        params.append(f"created_at=lte.{until.isoformat()}")
+
+    if content_contains:
+        # Escape any % or _ in the search term to avoid accidental wildcards
+        safe = content_contains.replace("%", r"\%").replace("_", r"\_")
+        params.append(f"content=ilike.*{safe}*")
+
+    params.append("order=created_at.desc")
+    params.append(f"limit={n}")
+
+    qs = "&".join(params)
+    url = _supabase_url() + MEMORIES_ENDPOINT + (f"?{qs}" if qs else "")
+
+    try:
+        response = httpx.get(url, headers=_supabase_headers(), timeout=10)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Supabase returned {response.status_code}: {response.text}"
+            )
+        return [_parse_memory(row) for row in response.json()]
+    except httpx.HTTPError as exc:
+        raise RuntimeError(f"HTTP error retrieving memories: {exc}") from exc
+
+
+def retrieve_by_tags(
+    tags: list[str],
+    n: int = 20,
+    mode: Literal["any", "all"] = "any",
+) -> list[Memory]:
+    """Convenience: filter by tags only. mode 'any' uses ov., 'all' uses cs."""
+    return retrieve(tags=tags, tag_mode=mode, n=n)

--- a/src/memory/store.py
+++ b/src/memory/store.py
@@ -1,0 +1,70 @@
+"""
+FILE: src/memory/store.py
+PURPOSE: Write a memory row to agent_memories via PostgREST.
+         No embedding — v1 is text+tag+type only.
+"""
+
+import uuid
+from datetime import datetime
+
+import httpx
+
+from . import ratelimit
+from .client import MEMORIES_ENDPOINT, _supabase_headers, _supabase_url
+from .types import VALID_SOURCE_TYPES
+
+
+def store(
+    callsign: str,
+    source_type: str,
+    content: str,
+    typed_metadata: dict | None = None,
+    tags: list[str] | None = None,
+    valid_from: datetime | None = None,
+    valid_to: datetime | None = None,
+) -> uuid.UUID:
+    """Persist a memory row. Returns the UUID of the inserted row.
+
+    Raises:
+        ValueError: source_type not in VALID_SOURCE_TYPES.
+        RateLimitExceeded: daily write cap hit.
+        RuntimeError: Supabase HTTP error or connection failure.
+    """
+    if source_type not in VALID_SOURCE_TYPES:
+        raise ValueError(
+            f"Invalid source_type {source_type!r}. "
+            f"Must be one of: {sorted(VALID_SOURCE_TYPES)}"
+        )
+
+    ratelimit.check_and_increment()
+
+    payload: dict = {
+        "callsign": callsign,
+        "source_type": source_type,
+        "content": content,
+        "typed_metadata": typed_metadata or {},
+        "tags": tags or [],
+    }
+    # Only include valid_from/valid_to if explicitly provided;
+    # DB DEFAULT now() fires when omitted.
+    if valid_from is not None:
+        payload["valid_from"] = valid_from.isoformat()
+    if valid_to is not None:
+        payload["valid_to"] = valid_to.isoformat()
+
+    url = _supabase_url() + MEMORIES_ENDPOINT
+    headers = _supabase_headers()
+
+    try:
+        response = httpx.post(url, json=payload, headers=headers, timeout=10)
+        if response.status_code not in (200, 201):
+            raise RuntimeError(
+                f"Supabase returned {response.status_code}: {response.text}"
+            )
+        row = response.json()
+        # PostgREST returns a list when Prefer: return=representation
+        if isinstance(row, list):
+            row = row[0]
+        return uuid.UUID(row["id"])
+    except httpx.HTTPError as exc:
+        raise RuntimeError(f"HTTP error storing memory: {exc}") from exc

--- a/src/memory/types.py
+++ b/src/memory/types.py
@@ -1,0 +1,37 @@
+"""
+FILE: src/memory/types.py
+PURPOSE: Shared types for the agent memory layer (v1 — no embeddings).
+"""
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+VALID_SOURCE_TYPES: set[str] = {
+    "pattern",
+    "decision",
+    "test_result",
+    "reasoning",
+    "skill",
+    "daily_log",
+    "dave_confirmed",
+    "verified_fact",
+    "research",
+}
+
+
+@dataclass(frozen=True)
+class Memory:
+    id: uuid.UUID
+    callsign: str
+    source_type: str
+    content: str
+    typed_metadata: dict
+    tags: list[str]
+    valid_from: datetime
+    valid_to: datetime | None
+    created_at: datetime
+
+
+class RateLimitExceeded(Exception):
+    pass

--- a/src/telegram_bot/chat_bot.py
+++ b/src/telegram_bot/chat_bot.py
@@ -33,6 +33,7 @@ from telegram.ext import (
 )
 
 from src.telegram_bot.tag_handler import handle_tag, handle_tag_confirmation
+from src.telegram_bot.recall_handler import handle_recall
 
 # ---------------------------------------------------------------------------
 # Config
@@ -939,6 +940,7 @@ def main() -> None:
     app.add_handler(CommandHandler("relay", cmd_relay))
     app.add_handler(CommandHandler("help", cmd_help))
     app.add_handler(CommandHandler("tag", handle_tag))
+    app.add_handler(CommandHandler("recall", handle_recall))
 
     # Tag confirmation observer — must run BEFORE the main text fallback
     async def _tag_confirm_observer(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/src/telegram_bot/recall_handler.py
+++ b/src/telegram_bot/recall_handler.py
@@ -1,0 +1,72 @@
+"""
+FILE: src/telegram_bot/recall_handler.py
+PURPOSE: Telegram /recall command — surfaces agent memories grouped by source_type.
+CONSUMERS: src/telegram_bot/chat_bot.py (registers handle_recall)
+"""
+
+import logging
+import uuid
+from pathlib import Path
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+import src.memory as memory
+
+logger = logging.getLogger(__name__)
+
+_MAX_INLINE_CHARS = 3800  # Telegram message limit is ~4096; leave headroom
+_CONTENT_PREVIEW = 120
+
+
+def _format_memory_line(m: memory.Memory) -> str:
+    preview = m.content[:_CONTENT_PREVIEW].replace("\n", " ")
+    if len(m.content) > _CONTENT_PREVIEW:
+        preview += "..."
+    tag_str = f" [{', '.join(m.tags)}]" if m.tags else ""
+    return f"• {preview}{tag_str}"
+
+
+def _format_grouped(grouped: dict[str, list[memory.Memory]]) -> str:
+    if not grouped:
+        return "No memories found."
+    lines = []
+    for source_type, mems in sorted(grouped.items()):
+        lines.append(f"\n**{source_type.upper()}** ({len(mems)})")
+        for m in mems:
+            lines.append(_format_memory_line(m))
+    return "\n".join(lines).strip()
+
+
+async def handle_recall(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /recall [topic] command."""
+    if update.message is None:
+        return
+
+    args = context.args or []
+    topic = " ".join(args).strip() if args else None
+
+    try:
+        grouped = memory.recall(topic=topic)
+        body = _format_grouped(grouped)
+    except Exception as exc:
+        logger.exception("recall failed")
+        await update.message.reply_text(f"recall error: {exc}")
+        return
+
+    header = f"**/recall** {'`' + topic + '`' if topic else '(recent high-value)'}\n\n"
+    full_text = header + body
+
+    if len(full_text) <= _MAX_INLINE_CHARS:
+        await update.message.reply_text(full_text)
+    else:
+        # Write to temp file and send summary
+        tmp_path = Path(f"/tmp/recall-{uuid.uuid4()}.md")
+        tmp_path.write_text(full_text)
+        total = sum(len(v) for v in grouped.values())
+        summary = (
+            f"**/recall** returned {total} memories across {len(grouped)} type(s). "
+            f"Full output saved to:\n`{tmp_path}`"
+        )
+        await update.message.reply_text(summary)
+        logger.info(f"recall output written to {tmp_path}")

--- a/supabase/migrations/102_agent_memories.sql
+++ b/supabase/migrations/102_agent_memories.sql
@@ -1,0 +1,24 @@
+-- agent_memories: typed memory store for multi-agent knowledge compounding.
+-- No embeddings in v1 — text + tag + type filters via PostgREST. Embeddings
+-- deferred until measured retrieval-miss evidence justifies adding pgvector.
+
+CREATE TABLE IF NOT EXISTS public.agent_memories (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  callsign         text NOT NULL,
+  source_type      text NOT NULL,
+  content          text NOT NULL,
+  typed_metadata   jsonb NOT NULL DEFAULT '{}'::jsonb,
+  tags             text[] NOT NULL DEFAULT '{}',
+  valid_from       timestamptz NOT NULL DEFAULT now(),
+  valid_to         timestamptz,
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS agent_memories_callsign_idx    ON public.agent_memories (callsign);
+CREATE INDEX IF NOT EXISTS agent_memories_source_type_idx ON public.agent_memories (source_type);
+CREATE INDEX IF NOT EXISTS agent_memories_tags_idx        ON public.agent_memories USING GIN (tags);
+CREATE INDEX IF NOT EXISTS agent_memories_created_at_idx  ON public.agent_memories (created_at DESC);
+CREATE INDEX IF NOT EXISTS agent_memories_valid_from_idx  ON public.agent_memories (valid_from DESC);
+CREATE INDEX IF NOT EXISTS agent_memories_valid_to_idx    ON public.agent_memories (valid_to) WHERE valid_to IS NOT NULL;
+
+-- No SQL function needed — simple PostgREST filters cover v1.

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -1,0 +1,239 @@
+"""
+FILE: tests/memory/test_memory.py
+PURPOSE: Unit tests for the agent memory layer (v1 — no embeddings).
+         All external HTTP calls are mocked via unittest.mock.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_UUID = str(uuid.uuid4())
+FAKE_URL = "https://fake.supabase.co"
+FAKE_KEY = "fake-key"
+
+ENV_PATCH = {
+    "SUPABASE_URL": FAKE_URL,
+    "SUPABASE_SERVICE_KEY": FAKE_KEY,
+}
+
+
+def _fake_memory_row(**overrides) -> dict:
+    now = datetime.now(timezone.utc).isoformat()
+    base = {
+        "id": FAKE_UUID,
+        "callsign": "aiden",
+        "source_type": "pattern",
+        "content": "test content",
+        "typed_metadata": {},
+        "tags": ["test"],
+        "valid_from": now,
+        "valid_to": None,
+        "created_at": now,
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_response(status_code: int = 201, json_data=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data if json_data is not None else [_fake_memory_row()]
+    resp.text = "ok"
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# store() tests
+# ---------------------------------------------------------------------------
+
+class TestStore:
+
+    def test_store_validates_source_type(self):
+        """Invalid source_type raises ValueError before any HTTP call."""
+        from src.memory.store import store
+        with pytest.raises(ValueError, match="Invalid source_type"):
+            store("aiden", "not_a_valid_type", "content")
+
+    def test_store_calls_supabase_without_embedding(self):
+        """Payload sent to Supabase must NOT contain an embedding field."""
+        from src.memory.store import store
+
+        with patch.dict("os.environ", ENV_PATCH):
+            with patch("src.memory.ratelimit.check_and_increment", return_value=1):
+                with patch("httpx.post", return_value=_mock_response()) as mock_post:
+                    store("aiden", "pattern", "some content", tags=["t1"])
+
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs[1]["json"] if "json" in call_kwargs[1] else call_kwargs[0][1]
+        assert "embedding" not in payload, "embedding must not appear in v1 payload"
+        assert "vector" not in payload, "vector must not appear in v1 payload"
+
+    def test_store_returns_uuid(self):
+        """store() returns a uuid.UUID matching the inserted row id."""
+        from src.memory.store import store
+
+        with patch.dict("os.environ", ENV_PATCH):
+            with patch("src.memory.ratelimit.check_and_increment", return_value=1):
+                with patch("httpx.post", return_value=_mock_response(201, [_fake_memory_row(id=FAKE_UUID)])):
+                    result = store("aiden", "decision", "a decision")
+
+        assert isinstance(result, uuid.UUID)
+        assert str(result) == FAKE_UUID
+
+    def test_store_rate_limit(self):
+        """RateLimitExceeded propagates before any HTTP call."""
+        from src.memory.store import store
+        from src.memory.types import RateLimitExceeded
+
+        with patch("src.memory.ratelimit.check_and_increment", side_effect=RateLimitExceeded("cap")):
+            with pytest.raises(RateLimitExceeded):
+                store("aiden", "pattern", "content")
+
+    def test_store_wraps_httpx_errors(self):
+        """Non-2xx response from Supabase raises RuntimeError."""
+        from src.memory.store import store
+
+        with patch.dict("os.environ", ENV_PATCH):
+            with patch("src.memory.ratelimit.check_and_increment", return_value=1):
+                with patch("httpx.post", return_value=_mock_response(500, {})):
+                    with pytest.raises(RuntimeError, match="Supabase returned 500"):
+                        store("aiden", "research", "content")
+
+    def test_store_defaults_valid_from_if_none(self):
+        """When valid_from is None, the payload omits valid_from (DB DEFAULT fires)."""
+        from src.memory.store import store
+
+        with patch.dict("os.environ", ENV_PATCH):
+            with patch("src.memory.ratelimit.check_and_increment", return_value=1):
+                with patch("httpx.post", return_value=_mock_response()) as mock_post:
+                    store("aiden", "pattern", "content", valid_from=None)
+
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs[1]["json"] if "json" in call_kwargs[1] else call_kwargs[0][1]
+        assert "valid_from" not in payload, "valid_from must be omitted when None so DB DEFAULT fires"
+
+
+# ---------------------------------------------------------------------------
+# retrieve() tests
+# ---------------------------------------------------------------------------
+
+class TestRetrieve:
+
+    def _run_retrieve(self, **kwargs):
+        """Helper: patch env + httpx.get, run retrieve(), return (result, mock_get)."""
+        from src.memory.retrieve import retrieve
+
+        rows = [_fake_memory_row()]
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = rows
+
+        with patch.dict("os.environ", ENV_PATCH):
+            with patch("httpx.get", return_value=mock_resp) as mock_get:
+                result = retrieve(**kwargs)
+        return result, mock_get
+
+    def test_retrieve_by_type(self):
+        """types filter produces source_type=in.(...) in query string."""
+        result, mock_get = self._run_retrieve(types=["pattern", "decision"])
+        url = mock_get.call_args[0][0]
+        assert "source_type=in.(pattern,decision)" in url
+
+    def test_retrieve_by_callsign(self):
+        """callsigns filter produces callsign=in.(...) in query string."""
+        result, mock_get = self._run_retrieve(callsigns=["aiden", "elliot"])
+        url = mock_get.call_args[0][0]
+        assert "callsign=in.(aiden,elliot)" in url
+
+    def test_retrieve_by_tag_any(self):
+        """tag_mode='any' produces tags=ov.{...} operator in query string."""
+        result, mock_get = self._run_retrieve(tags=["memory", "test"], tag_mode="any")
+        url = mock_get.call_args[0][0]
+        assert "tags=ov.{memory,test}" in url
+
+    def test_retrieve_by_tag_all(self):
+        """tag_mode='all' produces tags=cs.{...} operator in query string."""
+        result, mock_get = self._run_retrieve(tags=["memory", "test"], tag_mode="all")
+        url = mock_get.call_args[0][0]
+        assert "tags=cs.{memory,test}" in url
+
+    def test_retrieve_content_contains(self):
+        """content_contains produces ilike filter with wildcards."""
+        result, mock_get = self._run_retrieve(content_contains="decision point")
+        url = mock_get.call_args[0][0]
+        assert "content=ilike.*decision" in url
+
+    def test_retrieve_time_range(self):
+        """since/until produce created_at gte/lte filters."""
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        until = datetime(2026, 4, 1, tzinfo=timezone.utc)
+        result, mock_get = self._run_retrieve(since=since, until=until)
+        url = mock_get.call_args[0][0]
+        assert "created_at=gte." in url
+        assert "created_at=lte." in url
+
+
+# ---------------------------------------------------------------------------
+# recall() tests
+# ---------------------------------------------------------------------------
+
+class TestRecall:
+
+    def _make_rows(self, types: list[str]) -> list[dict]:
+        rows = []
+        for st in types:
+            rows.append(_fake_memory_row(
+                id=str(uuid.uuid4()),
+                source_type=st,
+                content=f"Content about {st}",
+            ))
+        return rows
+
+    def test_recall_with_topic_groups_by_type(self):
+        """recall(topic=...) merges content + tag results and groups by source_type."""
+        from src.memory.recall import recall
+
+        mixed_rows = self._make_rows(["pattern", "decision", "research"])
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mixed_rows
+
+        with patch.dict("os.environ", ENV_PATCH):
+            with patch("httpx.get", return_value=mock_resp):
+                result = recall(topic="test topic")
+
+        assert isinstance(result, dict)
+        # Every key should be a valid source_type, every value a list
+        for key, val in result.items():
+            assert isinstance(key, str)
+            assert isinstance(val, list)
+            assert len(val) > 0
+
+    def test_recall_bare_returns_high_value_types(self):
+        """recall(topic=None) calls retrieve with high-value types only."""
+        from src.memory.recall import recall
+        from src.memory import retrieve as mem_retrieve
+
+        rows = self._make_rows(["pattern", "skill"])
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = rows
+
+        with patch.dict("os.environ", ENV_PATCH):
+            with patch("httpx.get", return_value=mock_resp) as mock_get:
+                result = recall(topic=None)
+
+        # Should only have called retrieve once (high-value path)
+        assert mock_get.call_count == 1
+        url = mock_get.call_args[0][0]
+        # High-value types should be in the query
+        assert "source_type=in." in url
+        for ht in ["pattern", "decision", "skill", "dave_confirmed"]:
+            assert ht in url


### PR DESCRIPTION
## Summary

Wave 2 workstream A. Typed memory layer — stores 9 kinds of memory rows (pattern / decision / test_result / reasoning / skill / daily_log / dave_confirmed / verified_fact / research) in a new `agent_memories` table. Text + tag + type filtering. **No embeddings in v1** — deferred to v2 after measured need.

**Pairs with Elliot's PR #354** (`/save` command + session hooks + CLAUDE.md consolidation). Each bot dual-approves the other per new governance rule.

## Architecture decision saved

Supabase `elliot_internal.memories` id `9c151cb1-5c94-4067-9388-80f6d599987e` — full ratified spec, source=aiden, co_author=elliot.

## Added (14 files, +916 lines)

- `supabase/migrations/102_agent_memories.sql` — table + 6 indexes (callsign, source_type, tags GIN, created_at, valid_from, valid_to)
- `src/memory/types.py` — `Memory` dataclass, `VALID_SOURCE_TYPES`, `RateLimitExceeded`
- `src/memory/client.py` — lazy Supabase URL + headers
- `src/memory/ratelimit.py` — daily UTC write counter, default 5000/day (env `MEMORY_WRITE_CAP`)
- `src/memory/store.py` — `store()` with validation + rate-limit + POST
- `src/memory/retrieve.py` — `retrieve()` + `retrieve_by_tags()` via PostgREST filter-builder
- `src/memory/recall.py` — `recall()` backing `/recall` command; groups by source_type
- `src/memory/__init__.py` — public re-exports
- `src/telegram_bot/recall_handler.py` — `/recall` handler; inline reply or `/tmp/recall-*.md` fallback
- `tests/memory/test_memory.py` — 14 cases, all green (0.23s)
- `docs/memory_interface.md` — v1 contract + v2 embeddings roadmap
- `CLAUDE.md` — `§Memory Layer` section

## Modified (minimal surface)

- `src/telegram_bot/chat_bot.py` — 2 lines added: import + register `CommandHandler("recall", ...)`

## Public API

```
store(callsign, source_type, content,
      typed_metadata=None, tags=None,
      valid_from=None, valid_to=None) -> uuid.UUID

retrieve(types=None, callsigns=None, tags=None, tag_mode='any',
         since=None, until=None, content_contains=None, n=20) -> list[Memory]

retrieve_by_tags(tags, n=20, mode='any') -> list[Memory]

recall(topic=None, n=20) -> dict[str, list[Memory]]   # grouped by type
```

## Test plan
- [x] `python3 -m py_compile` on all new `.py` — clean
- [x] `pytest tests/memory/` — 14/14 passed
- [x] `pytest tests/agent_coord/ tests/telegram_bot/ tests/test_three_store_save.py` — 31/31 passed (no regressions)
- [x] grep `embedding|pgvector|openai|OpenAI` in `src/memory/` — zero functional refs
- [ ] Live: Dave applies migration 102 post-merge
- [ ] Live: `/recall` in Telegram returns a structured brief

## Blockers
- **Not blocked by Anthropic credits** — `/recall` uses no LLM calls. `/save` (Elliot's workstream) IS blocked for extraction, but can ship in manual-input mode.

## Governance
- Wave 2 per Dave-approved plan 2026-04-17.
- Dual-approval required per today's new rule.
- Branch targets `aiden/scaffold` per `IDENTITY.md` — does not merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)