### PR TITLE
feat(stage8): email scoring gate — CB Insights anti-pattern detection

### DIFF
--- a/src/pipeline/email_scoring_gate.py
+++ b/src/pipeline/email_scoring_gate.py
@@ -1,0 +1,313 @@
+"""
+Stage 8 Email Scoring Gate — CB Insights Anti-Pattern Detection
+Directive #339
+
+Pre-send scoring gate that evaluates outbound emails against the top failure
+patterns identified in CB Insights analysis of 147 cold emails (93.9% failure rate).
+
+GOV-12 compliant: runtime enforcement, not documentation-only.
+Callers receive a numeric score and flag list; blocking decision stays with the caller.
+
+Pass threshold: score >= 70
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+PASS_THRESHOLD = 70
+
+# Generic subject line phrases that signal low effort
+_GENERIC_SUBJECTS = frozenset([
+    "quick question",
+    "following up",
+    "touching base",
+    "just checking in",
+    "circling back",
+    "checking in",
+    "a quick note",
+])
+
+# Unmerged template token patterns — catches {name}, {{company}}, <FIRST_NAME>, [NAME], etc.
+_TEMPLATE_TOKEN_RE = re.compile(
+    r"(\{+\s*\w[\w\s]*\s*\}+)"           # {name} or {{company}}
+    r"|(<\s*[A-Z][A-Z_\s]{2,}\s*>)"      # <FIRST_NAME>
+    r"|(\[\s*[A-Z][A-Z_\s]{2,}\s*\])",   # [COMPANY_NAME]
+)
+
+# First-person pronouns
+_FIRST_PERSON_RE = re.compile(r"\b(I|we|our|my)\b", re.IGNORECASE)
+# Second-person pronouns
+_SECOND_PERSON_RE = re.compile(r"\b(you|your|you're|you've)\b", re.IGNORECASE)
+
+# Fake-threading prefixes
+_FAKE_THREAD_RE = re.compile(r"^\s*(re|fw|fwd)\s*:", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Subject-line checks
+# ---------------------------------------------------------------------------
+
+def _check_subject(subject: str, flags: list[dict], score: int) -> int:
+    stripped = subject.strip()
+
+    if len(stripped) < 5:
+        flags.append({
+            "pattern": "weak_subject",
+            "severity": "high",
+            "detail": "Subject line is empty or too short (< 5 chars).",
+        })
+        score -= 30
+        return score
+
+    if stripped.isupper() or len(re.findall(r"[!?]", stripped)) > 2:
+        flags.append({
+            "pattern": "spammy_subject",
+            "severity": "medium",
+            "detail": "Subject is all-caps or contains excessive punctuation (> 2 ! or ?).",
+        })
+        score -= 15
+
+    if _FAKE_THREAD_RE.match(stripped):
+        flags.append({
+            "pattern": "fake_threading",
+            "severity": "high",
+            "detail": "Subject starts with RE: or FW: suggesting a false thread.",
+        })
+        score -= 20
+
+    if stripped.lower() in _GENERIC_SUBJECTS:
+        flags.append({
+            "pattern": "generic_subject",
+            "severity": "low",
+            "detail": f"Subject '{stripped}' is a known low-effort phrase.",
+        })
+        score -= 10
+
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Body checks
+# ---------------------------------------------------------------------------
+
+def _check_body(
+    body: str,
+    recipient_company: str | None,
+    flags: list[dict],
+    score: int,
+) -> int:
+    if _TEMPLATE_TOKEN_RE.search(body):
+        flags.append({
+            "pattern": "mail_merge_failure",
+            "severity": "critical",
+            "detail": "Body contains unmerged template tokens (e.g. {name}, <FIRST_NAME>).",
+        })
+        score -= 25
+
+    body_lower = body.lower()
+    company_mentioned = (
+        recipient_company and recipient_company.lower() in body_lower
+    )
+    if not company_mentioned:
+        flags.append({
+            "pattern": "zero_buyer_knowledge",
+            "severity": "medium",
+            "detail": "Recipient company not mentioned — shows no buyer research.",
+        })
+        score -= 15
+
+    word_count = len(body.split())
+    if word_count > 300:
+        flags.append({
+            "pattern": "too_long",
+            "severity": "low",
+            "detail": f"Body is {word_count} words — cold emails should be under 300.",
+        })
+        score -= 10
+
+    score = _check_pronoun_balance(body, flags, score)
+    score = _check_cta(body, flags, score)
+
+    if "unsubscribe" in body_lower and "http" not in body_lower:
+        flags.append({
+            "pattern": "missing_unsubscribe_link",
+            "severity": "low",
+            "detail": "Mentions 'unsubscribe' but no URL present.",
+        })
+        score -= 5
+
+    return score
+
+
+def _check_pronoun_balance(body: str, flags: list[dict], score: int) -> int:
+    """Deduct if first-person pronouns dominate before any second-person usage."""
+    # Find position of first second-person pronoun
+    second_match = _SECOND_PERSON_RE.search(body)
+    if second_match:
+        prefix = body[: second_match.start()]
+    else:
+        prefix = body
+
+    first_count_before = len(_FIRST_PERSON_RE.findall(prefix))
+    if first_count_before > 3:
+        flags.append({
+            "pattern": "self_focused",
+            "severity": "medium",
+            "detail": (
+                f"First-person pronouns appear {first_count_before}x before any "
+                "second-person reference — email is seller-centric, not buyer-centric."
+            ),
+        })
+        score -= 15
+    return score
+
+
+def _check_cta(body: str, flags: list[dict], score: int) -> int:
+    """Deduct if the last two sentences contain no question mark."""
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", body.strip()) if s.strip()]
+    last_two = sentences[-2:] if len(sentences) >= 2 else sentences
+    if not any("?" in s for s in last_two):
+        flags.append({
+            "pattern": "no_call_to_action",
+            "severity": "medium",
+            "detail": "Last two sentences contain no question — no clear CTA.",
+        })
+        score -= 10
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Sequence checks
+# ---------------------------------------------------------------------------
+
+def _check_sequence(
+    sequence_position: int,
+    total_sequence_length: int,
+    flags: list[dict],
+    score: int,
+) -> int:
+    if total_sequence_length == 1:
+        flags.append({
+            "pattern": "insufficient_follow_up",
+            "severity": "medium",
+            "detail": "Sequence has only one touch — 80% of sales need 5+ follow-ups.",
+        })
+        score -= 10
+
+    if sequence_position > 5:
+        flags.append({
+            "pattern": "spam_fatigue_risk",
+            "severity": "low",
+            "detail": f"Touch #{sequence_position} — beyond touch 5 risks fatigue/spam reports.",
+        })
+        score -= 5
+
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Personalisation checks
+# ---------------------------------------------------------------------------
+
+def _check_personalisation(
+    body: str,
+    recipient_name: str | None,
+    recipient_company: str | None,
+    flags: list[dict],
+    score: int,
+) -> int:
+    body_lower = body.lower()
+
+    if recipient_name and recipient_name.lower() not in body_lower:
+        flags.append({
+            "pattern": "name_unused",
+            "severity": "low",
+            "detail": f"Recipient name '{recipient_name}' was available but not used in body.",
+        })
+        score -= 10
+
+    # Company already deducted in _check_body; skip double-penalising.
+    # This check only runs if company was NOT already flagged.
+    already_flagged = any(f["pattern"] == "zero_buyer_knowledge" for f in flags)
+    if recipient_company and not already_flagged:
+        if recipient_company.lower() not in body_lower:
+            flags.append({
+                "pattern": "company_unused",
+                "severity": "low",
+                "detail": f"Company '{recipient_company}' was available but not used in body.",
+            })
+            score -= 10
+
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def score_email(
+    subject: str,
+    body: str,
+    recipient_name: str | None = None,
+    recipient_company: str | None = None,
+    sequence_position: int = 1,
+    total_sequence_length: int = 1,
+) -> dict[str, Any]:
+    """Score an outbound email against CB Insights anti-patterns.
+
+    Args:
+        subject: Email subject line.
+        body: Plain-text email body.
+        recipient_name: Known first name of recipient (optional).
+        recipient_company: Known company name of recipient (optional).
+        sequence_position: Which touch in the outreach sequence (1-indexed).
+        total_sequence_length: Total planned touches in the sequence.
+
+    Returns:
+        {
+            "score": 0-100,
+            "pass": bool,        # True if score >= PASS_THRESHOLD (70)
+            "flags": [{"pattern": str, "severity": str, "detail": str}],
+            "recommendations": [str],
+        }
+    """
+    flags: list[dict] = []
+    score = 100
+
+    score = _check_subject(subject, flags, score)
+    score = _check_body(body, recipient_company, flags, score)
+    score = _check_sequence(sequence_position, total_sequence_length, flags, score)
+    score = _check_personalisation(body, recipient_name, recipient_company, flags, score)
+
+    score = max(0, score)
+
+    recommendations = _build_recommendations(flags)
+
+    return {
+        "score": score,
+        "pass": score >= PASS_THRESHOLD,
+        "flags": flags,
+        "recommendations": recommendations,
+    }
+
+
+def _build_recommendations(flags: list[dict]) -> list[str]:
+    _MAP = {
+        "weak_subject": "Write a specific subject line referencing the prospect's business or pain point.",
+        "spammy_subject": "Remove all-caps and reduce punctuation to 1 ! or ? maximum.",
+        "fake_threading": "Remove RE:/FW: prefix unless this is a genuine reply.",
+        "generic_subject": "Replace the generic phrase with something specific to this prospect.",
+        "mail_merge_failure": "All template tokens ({name}, <FIRST_NAME>, etc.) must be replaced before sending.",
+        "zero_buyer_knowledge": "Mention the recipient's company or industry by name to demonstrate research.",
+        "too_long": "Cut the email to under 300 words — shorter emails get higher reply rates.",
+        "self_focused": "Lead with a buyer-centric observation before introducing yourself.",
+        "no_call_to_action": "End with a clear question that asks for a specific next step.",
+        "missing_unsubscribe_link": "Add a real unsubscribe URL if referencing opt-out.",
+        "insufficient_follow_up": "Plan at least 5 touches — 80% of deals close after follow-up #5.",
+        "spam_fatigue_risk": "Consider retiring this contact or changing the channel after 5 touches.",
+        "name_unused": "Use the recipient's first name at least once to increase open-to-reply conversion.",
+        "company_unused": "Reference the recipient's company name to show you know who you're writing to.",
+    }
+    return [_MAP[f["pattern"]] for f in flags if f["pattern"] in _MAP]

--- a/tests/test_email_scoring_gate.py
+++ b/tests/test_email_scoring_gate.py
@@ -1,0 +1,438 @@
+"""
+Tests for email_scoring_gate — CB Insights anti-pattern detection.
+Directive #339
+"""
+
+import pytest
+
+from src.pipeline.email_scoring_gate import score_email, PASS_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+GOOD_SUBJECT = "Noticed you're running Google Ads without conversion tracking"
+GOOD_BODY = (
+    "Hi Sarah, your Google Ads account at Acme Plumbing caught my eye — "
+    "you're spending on broad match keywords but the site has no conversion pixel. "
+    "That usually means paying for clicks that never become jobs. "
+    "Would it be useful to do a 15-minute audit together this week?"
+)
+
+
+def _flag_patterns(result: dict) -> list[str]:
+    return [f["pattern"] for f in result["flags"]]
+
+
+# ---------------------------------------------------------------------------
+# Perfect email
+# ---------------------------------------------------------------------------
+
+class TestPerfectEmail:
+    def test_perfect_email_scores_100(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_name="Sarah",
+            recipient_company="Acme Plumbing",
+            sequence_position=1,
+            total_sequence_length=5,
+        )
+        assert result["score"] == 100
+        assert result["pass"] is True
+        assert result["flags"] == []
+        assert result["recommendations"] == []
+
+
+# ---------------------------------------------------------------------------
+# Subject line checks
+# ---------------------------------------------------------------------------
+
+class TestSubjectChecks:
+    def test_empty_subject_deducts_30(self):
+        # Pass recipient_company so zero_buyer_knowledge doesn't fire — isolating subject check
+        result = score_email(subject="", body=GOOD_BODY, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "weak_subject" in _flag_patterns(result)
+        assert result["score"] == 70  # 100 - 30
+
+    def test_short_subject_deducts_30(self):
+        result = score_email(subject="Hi", body=GOOD_BODY, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "weak_subject" in _flag_patterns(result)
+        assert result["score"] == 70
+
+    def test_all_caps_subject_deducts_15(self):
+        result = score_email(subject="BIG OPPORTUNITY FOR YOU", body=GOOD_BODY, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "spammy_subject" in _flag_patterns(result)
+        assert result["score"] == 85
+
+    def test_excessive_punctuation_deducts_15(self):
+        # Three exclamation marks — over the limit
+        result = score_email(subject="Hot deal available now!!!", body=GOOD_BODY, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "spammy_subject" in _flag_patterns(result)
+        assert result["score"] == 85
+
+    def test_two_punctuation_is_ok(self):
+        result = score_email(subject="Quick win for you!?", body=GOOD_BODY, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "spammy_subject" not in _flag_patterns(result)
+
+    def test_fake_re_threading_deducts_20(self):
+        result = score_email(subject="Re: our conversation", body=GOOD_BODY, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "fake_threading" in _flag_patterns(result)
+        assert result["score"] == 80
+
+    def test_fake_fw_threading_deducts_20(self):
+        result = score_email(subject="Fw: something important", body=GOOD_BODY, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "fake_threading" in _flag_patterns(result)
+
+    def test_generic_subject_deducts_10(self):
+        result = score_email(subject="Following up", body=GOOD_BODY, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "generic_subject" in _flag_patterns(result)
+        assert result["score"] == 90
+
+    def test_generic_subject_case_insensitive(self):
+        result = score_email(subject="QUICK QUESTION", body=GOOD_BODY, recipient_company="Acme Plumbing", total_sequence_length=5)
+        # all-caps triggers spammy_subject (-15); generic match on "quick question" also (-10)
+        assert "generic_subject" in _flag_patterns(result)
+        assert "spammy_subject" in _flag_patterns(result)
+
+
+# ---------------------------------------------------------------------------
+# Body checks
+# ---------------------------------------------------------------------------
+
+class TestBodyChecks:
+    def test_curly_template_token_deducts_25(self):
+        body = "Hi {first_name}, I wanted to reach out about " + GOOD_BODY[20:]
+        result = score_email(subject=GOOD_SUBJECT, body=body, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "mail_merge_failure" in _flag_patterns(result)
+        assert result["score"] <= 75  # 100 - 25
+
+    def test_double_curly_token(self):
+        body = "Hey {{name}}, " + GOOD_BODY[10:]
+        result = score_email(subject=GOOD_SUBJECT, body=body, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "mail_merge_failure" in _flag_patterns(result)
+
+    def test_angle_bracket_token(self):
+        body = "Dear <FIRST_NAME>, " + GOOD_BODY[10:]
+        result = score_email(subject=GOOD_SUBJECT, body=body, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "mail_merge_failure" in _flag_patterns(result)
+
+    def test_square_bracket_token(self):
+        body = "Hi [COMPANY_NAME] team, " + GOOD_BODY[10:]
+        result = score_email(subject=GOOD_SUBJECT, body=body, recipient_company="Acme Plumbing", total_sequence_length=5)
+        assert "mail_merge_failure" in _flag_patterns(result)
+
+    def test_no_company_mention_deducts_15(self):
+        generic_body = "Your business caught my eye and I think we can help. Would you be open to a chat?"
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=generic_body,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "zero_buyer_knowledge" in _flag_patterns(result)
+
+    def test_company_mention_clears_buyer_knowledge_flag(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "zero_buyer_knowledge" not in _flag_patterns(result)
+
+    def test_long_body_deducts_10(self):
+        long_body = (GOOD_BODY + " Also, ") * 20  # well over 300 words
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=long_body,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "too_long" in _flag_patterns(result)
+
+    def test_body_under_300_words_ok(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "too_long" not in _flag_patterns(result)
+
+    def test_no_cta_deducts_10(self):
+        no_cta = "Hi Sarah, your Acme Plumbing ads need work. I can help. Let me know."
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=no_cta,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "no_call_to_action" in _flag_patterns(result)
+
+    def test_question_in_last_sentence_clears_cta_flag(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "no_call_to_action" not in _flag_patterns(result)
+
+    def test_unsubscribe_without_link_deducts_5(self):
+        body = GOOD_BODY + " Reply 'unsubscribe' to opt out."
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=body,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "missing_unsubscribe_link" in _flag_patterns(result)
+
+    def test_unsubscribe_with_link_is_ok(self):
+        body = GOOD_BODY + " Unsubscribe: https://example.com/unsub"
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=body,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "missing_unsubscribe_link" not in _flag_patterns(result)
+
+
+# ---------------------------------------------------------------------------
+# Pronoun balance checks
+# ---------------------------------------------------------------------------
+
+class TestPronounBalance:
+    def test_self_focused_email_deducts_15(self):
+        self_focused = (
+            "I am reaching out because I think we can help. My company has worked "
+            "with lots of businesses like yours. I want to share our approach. "
+            "Would you be open to a call about Acme Plumbing?"
+        )
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=self_focused,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "self_focused" in _flag_patterns(result)
+
+    def test_buyer_centric_email_ok(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "self_focused" not in _flag_patterns(result)
+
+    def test_three_first_person_before_you_is_ok(self):
+        # Exactly 3 first-person before ANY second-person — should NOT trigger.
+        # Note: "your" also counts as second-person, so avoid it before the threshold.
+        body = (
+            "I run a digital agency. I work with plumbing businesses. I specialise in ads. "
+            "Would you be open to a quick audit of Acme Plumbing?"
+        )
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=body,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "self_focused" not in _flag_patterns(result)
+
+    def test_four_first_person_before_you_triggers(self):
+        # Four first-person pronouns before first second-person usage — triggers self_focused
+        body = (
+            "I run a digital agency. I work with plumbers. I built a tool for this. I find gaps. "
+            "Would you be open to a quick audit of Acme Plumbing?"
+        )
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=body,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "self_focused" in _flag_patterns(result)
+
+
+# ---------------------------------------------------------------------------
+# Sequence checks
+# ---------------------------------------------------------------------------
+
+class TestSequenceChecks:
+    def test_single_touch_deducts_10(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_company="Acme Plumbing",
+            sequence_position=1,
+            total_sequence_length=1,
+        )
+        assert "insufficient_follow_up" in _flag_patterns(result)
+        assert result["score"] == 90
+
+    def test_multi_touch_sequence_ok(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_company="Acme Plumbing",
+            sequence_position=2,
+            total_sequence_length=5,
+        )
+        assert "insufficient_follow_up" not in _flag_patterns(result)
+
+    def test_position_beyond_5_deducts_5(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_company="Acme Plumbing",
+            sequence_position=6,
+            total_sequence_length=8,
+        )
+        assert "spam_fatigue_risk" in _flag_patterns(result)
+        assert result["score"] == 95
+
+    def test_position_5_is_ok(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_company="Acme Plumbing",
+            sequence_position=5,
+            total_sequence_length=8,
+        )
+        assert "spam_fatigue_risk" not in _flag_patterns(result)
+
+
+# ---------------------------------------------------------------------------
+# Personalisation checks
+# ---------------------------------------------------------------------------
+
+class TestPersonalisationChecks:
+    def test_name_available_but_unused_deducts_10(self):
+        body = "Your business caught my eye at Acme Plumbing. Would you like a quick audit?"
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=body,
+            recipient_name="Sarah",
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "name_unused" in _flag_patterns(result)
+
+    def test_name_used_in_body_ok(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_name="Sarah",
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "name_unused" not in _flag_patterns(result)
+
+    def test_no_recipient_name_no_flag(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_name=None,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert "name_unused" not in _flag_patterns(result)
+
+    def test_company_unused_deducts_10_when_not_already_flagged(self):
+        # No company in body, company provided — should flag zero_buyer_knowledge (not company_unused)
+        body = "Your business caught my eye. Would you like a quick audit call?"
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=body,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        # zero_buyer_knowledge triggers first, company_unused should NOT double-penalise
+        assert "zero_buyer_knowledge" in _flag_patterns(result)
+        assert "company_unused" not in _flag_patterns(result)
+
+
+# ---------------------------------------------------------------------------
+# Multi-flag accumulation
+# ---------------------------------------------------------------------------
+
+class TestMultipleFlags:
+    def test_multiple_flags_accumulate(self):
+        """Mail merge failure + weak subject + single touch = -30 -25 -10 = 35."""
+        result = score_email(
+            subject="Hi",
+            body="Dear {name}, we want to help. Let me know.",
+            total_sequence_length=1,
+        )
+        patterns = _flag_patterns(result)
+        assert "weak_subject" in patterns
+        assert "mail_merge_failure" in patterns
+        assert "insufficient_follow_up" in patterns
+        # Score: 100 - 30 - 25 - 10 = 35, also no CTA (-10), no buyer knowledge (-15) = 10
+        assert result["score"] < PASS_THRESHOLD
+        assert result["pass"] is False
+
+    def test_score_floor_is_zero(self):
+        """Score never goes negative."""
+        result = score_email(
+            subject="",
+            body="I I I I {name} {{company}} <FIRST_NAME> [COMPANY_NAME].",
+            total_sequence_length=1,
+            sequence_position=7,
+        )
+        assert result["score"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# Pass / fail threshold
+# ---------------------------------------------------------------------------
+
+class TestPassFailThreshold:
+    def test_score_70_passes(self):
+        # Single touch only (-10) + generic subject (-10) + no CTA (-10) = 70
+        body = "Your business at Acme Plumbing caught my eye. I can help with your ads. Let me know."
+        result = score_email(
+            subject="Following up",
+            body=body,
+            recipient_company="Acme Plumbing",
+            total_sequence_length=1,
+        )
+        # Flags: generic_subject(-10), insufficient_follow_up(-10), no_cta(-10)
+        # Score should be 70 → pass
+        assert result["score"] == 70
+        assert result["pass"] is True
+
+    def test_score_69_fails(self):
+        # Ensure that a score below 70 is correctly marked as fail
+        result = score_email(
+            subject="Following up",
+            body="Your Acme Plumbing business caught my eye. I can help with your ads. Let me know.",
+            recipient_name="Sarah",
+            recipient_company="Acme Plumbing",
+            total_sequence_length=1,
+        )
+        # generic_subject(-10), insufficient_follow_up(-10), no_cta(-10), name_unused(-10) = 60
+        assert result["score"] == 60
+        assert result["pass"] is False
+
+    def test_pass_threshold_constant_is_70(self):
+        assert PASS_THRESHOLD == 70
+
+    def test_recommendations_present_on_fail(self):
+        result = score_email(subject="", body="Test.", total_sequence_length=1)
+        assert len(result["recommendations"]) > 0
+
+    def test_recommendations_empty_on_perfect(self):
+        result = score_email(
+            subject=GOOD_SUBJECT,
+            body=GOOD_BODY,
+            recipient_name="Sarah",
+            recipient_company="Acme Plumbing",
+            total_sequence_length=5,
+        )
+        assert result["recommendations"] == []


### PR DESCRIPTION
## Summary
- Adds `src/pipeline/email_scoring_gate.py` — pure regex/string scoring function, no ML, no external calls
- Scores emails 0-100 across 12 checks covering all 5 CB Insights failure categories (subject weakness, zero buyer knowledge, mail merge failures, insufficient follow-up, generic openers)
- Pass threshold 70; callers decide whether to block (GOV-12 compliant)
- Adds `tests/test_email_scoring_gate.py` — 41 tests, all passing

## Test plan
- [ ] `python3 -m pytest tests/test_email_scoring_gate.py -v` → 41 passed
- [ ] Perfect email scores 100, pass=True
- [ ] Each anti-pattern check deducts correct points in isolation
- [ ] Score floor is 0 (never negative)
- [ ] Pass threshold constant is 70

🤖 Generated with Claude Code (build-2)