### PR TITLE
refactor: agent_memories schema cleanup per F1 (SCHEMA-F1)

### DIFF
--- a/scripts/backfill_supersedes_id.py
+++ b/scripts/backfill_supersedes_id.py
@@ -94,7 +94,7 @@ def check_similarity_via_rpc(
     Use match_agent_memories RPC to get similarity score for a candidate.
     Returns float similarity or None if not found / error.
     """
-    rpc_url = supabase_url() + "/rest/v1/rpc/match_agent_memories_include_tentative"
+    rpc_url = supabase_url() + "/rest/v1/rpc/match_agent_memories"
     payload = {
         "query_embedding": embedding,
         "match_count": 10,

--- a/scripts/backfill_supersedes_id.py
+++ b/scripts/backfill_supersedes_id.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+SCHEMA-F1 Step 1 — One-time backfill of supersedes_id for 17 superseded rows.
+
+For each row WHERE state='superseded' AND supersedes_id IS NULL:
+  - Find best candidate superseder: same callsign + same source_type
+    + created_at > superseded_row.created_at + nearest in time
+  - Use match_agent_memories RPC to confirm content similarity > 0.85
+  - If match found: UPDATE supersedes_id = superseder.id
+                    + set typed_metadata.backfill_inferred = true
+  - If no match:    set typed_metadata.backfill_failed = true
+                    leave supersedes_id NULL
+
+DO NOT run without Dave's review. Reads env from /home/elliotbot/.config/agency-os/.env
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+import httpx
+
+
+def load_env() -> None:
+    env_file = "/home/elliotbot/.config/agency-os/.env"
+    if not os.path.exists(env_file):
+        print(f"ERROR: env file not found at {env_file}", file=sys.stderr)
+        sys.exit(1)
+    with open(env_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            val = val.strip().strip('"').strip("'")
+            os.environ.setdefault(key.strip(), val)
+
+
+def supabase_headers() -> dict:
+    key = os.environ["SUPABASE_SERVICE_KEY"]
+    return {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+
+
+def supabase_url() -> str:
+    return os.environ["SUPABASE_URL"]
+
+
+SIMILARITY_THRESHOLD = 0.85
+
+
+def fetch_superseded_nulls(client: httpx.Client) -> list[dict]:
+    """Fetch all superseded rows with supersedes_id IS NULL."""
+    url = (
+        supabase_url()
+        + "/rest/v1/agent_memories"
+        "?state=eq.superseded"
+        "&supersedes_id=is.null"
+        "&select=id,callsign,source_type,content,typed_metadata,created_at,embedding"
+    )
+    resp = client.get(url, headers=supabase_headers())
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_candidate_superseders(
+    client: httpx.Client, callsign: str, source_type: str, after_ts: str
+) -> list[dict]:
+    """Fetch rows with same callsign + source_type created after the superseded row."""
+    url = (
+        supabase_url()
+        + "/rest/v1/agent_memories"
+        f"?callsign=eq.{callsign}"
+        f"&source_type=eq.{source_type}"
+        f"&created_at=gt.{after_ts}"
+        "&state=neq.superseded"
+        "&select=id,created_at,embedding"
+        "&order=created_at.asc"
+        "&limit=10"
+    )
+    resp = client.get(url, headers=supabase_headers())
+    resp.raise_for_status()
+    return resp.json()
+
+
+def check_similarity_via_rpc(
+    client: httpx.Client, embedding: list[float], candidate_id: str
+) -> float | None:
+    """
+    Use match_agent_memories RPC to get similarity score for a candidate.
+    Returns float similarity or None if not found / error.
+    """
+    rpc_url = supabase_url() + "/rest/v1/rpc/match_agent_memories_include_tentative"
+    payload = {
+        "query_embedding": embedding,
+        "match_count": 10,
+        "match_threshold": 0.0,
+    }
+    resp = client.post(rpc_url, headers=supabase_headers(), json=payload)
+    if resp.status_code != 200:
+        return None
+    rows = resp.json() or []
+    for row in rows:
+        if row.get("id") == candidate_id:
+            return row.get("similarity")
+    return None
+
+
+def patch_row(
+    client: httpx.Client, row_id: str, patch_payload: dict
+) -> bool:
+    url = supabase_url() + f"/rest/v1/agent_memories?id=eq.{row_id}"
+    headers = {**supabase_headers(), "Prefer": "return=minimal"}
+    resp = client.patch(url, headers=headers, json=patch_payload)
+    return resp.status_code in (200, 204)
+
+
+def merge_typed_metadata(existing: dict | None, new_keys: dict) -> dict:
+    base = existing if isinstance(existing, dict) else {}
+    return {**base, **new_keys}
+
+
+def main() -> None:
+    load_env()
+
+    print("SCHEMA-F1 Step 1 — Backfill supersedes_id")
+    print("=" * 50)
+
+    matched = 0
+    failed = 0
+    skipped_no_embedding = 0
+
+    with httpx.Client(timeout=15) as client:
+        orphans = fetch_superseded_nulls(client)
+        print(f"Found {len(orphans)} superseded rows with supersedes_id=NULL\n")
+
+        for row in orphans:
+            row_id = row["id"]
+            callsign = row.get("callsign") or ""
+            source_type = row.get("source_type") or ""
+            created_at = row.get("created_at") or ""
+            embedding = row.get("embedding")
+            current_meta = row.get("typed_metadata") or {}
+
+            print(f"Processing {row_id} (callsign={callsign}, source_type={source_type})")
+
+            if not embedding:
+                print(f"  SKIP — no embedding, cannot compute similarity")
+                skipped_no_embedding += 1
+                continue
+
+            candidates = fetch_candidate_superseders(
+                client, callsign, source_type, created_at
+            )
+
+            if not candidates:
+                print(f"  NO CANDIDATES — marking backfill_failed")
+                meta = merge_typed_metadata(current_meta, {"backfill_failed": True})
+                patch_row(client, row_id, {"typed_metadata": meta})
+                failed += 1
+                continue
+
+            # Check similarity for each candidate (nearest in time = first)
+            best_id = None
+            best_similarity = 0.0
+            for cand in candidates:
+                cand_id = cand["id"]
+                sim = check_similarity_via_rpc(client, embedding, cand_id)
+                if sim is not None and sim > best_similarity:
+                    best_similarity = sim
+                    best_id = cand_id
+                if best_similarity >= SIMILARITY_THRESHOLD:
+                    break
+
+            if best_id and best_similarity >= SIMILARITY_THRESHOLD:
+                print(
+                    f"  MATCH found: superseder={best_id} similarity={best_similarity:.4f}"
+                )
+                meta = merge_typed_metadata(
+                    current_meta,
+                    {
+                        "backfill_inferred": True,
+                        "backfill_similarity": round(best_similarity, 4),
+                        "backfill_ts": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+                ok = patch_row(
+                    client,
+                    row_id,
+                    {"supersedes_id": best_id, "typed_metadata": meta},
+                )
+                if ok:
+                    print(f"  PATCHED OK")
+                    matched += 1
+                else:
+                    print(f"  PATCH FAILED — manual review needed")
+                    failed += 1
+            else:
+                print(
+                    f"  NO MATCH (best_similarity={best_similarity:.4f}) — marking backfill_failed"
+                )
+                meta = merge_typed_metadata(
+                    current_meta,
+                    {
+                        "backfill_failed": True,
+                        "backfill_best_similarity": round(best_similarity, 4),
+                        "backfill_ts": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+                patch_row(client, row_id, {"typed_metadata": meta})
+                failed += 1
+
+    print("\n" + "=" * 50)
+    print("SUMMARY")
+    print(f"  Matched + patched:   {matched}")
+    print(f"  No match (failed):   {failed}")
+    print(f"  Skipped (no embed):  {skipped_no_embedding}")
+    print(f"  Total processed:     {len(orphans)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/telegram_bot/memory_listener.py
+++ b/src/telegram_bot/memory_listener.py
@@ -471,8 +471,17 @@ async def _increment_access_counts(rows: list[dict], headers: dict) -> None:
                 current_state = row.get("state", "tentative")
                 if current_state == "tentative" and new_count >= PROMOTION_ACCESS_THRESHOLD:
                     payload["state"] = "confirmed"
+                    payload["promoted_from_id"] = row["id"]
+                    current_meta = row.get("typed_metadata") or {}
+                    payload["typed_metadata"] = {
+                        **current_meta,
+                        "promoted_at": __import__("datetime").datetime.now(
+                            __import__("datetime").timezone.utc
+                        ).isoformat(),
+                        "promoted_from_state": "tentative",
+                    }
                     logger.info(
-                        f"[memory-listener] promoting id={row['id']} tentative→confirmed "
+                        f"[memory-listener] PROMOTION FIRED id={row['id']} tentative→confirmed "
                         f"(access_count={new_count})"
                     )
                 try:

--- a/src/telegram_bot/memory_listener.py
+++ b/src/telegram_bot/memory_listener.py
@@ -475,9 +475,7 @@ async def _increment_access_counts(rows: list[dict], headers: dict) -> None:
                     current_meta = row.get("typed_metadata") or {}
                     payload["typed_metadata"] = {
                         **current_meta,
-                        "promoted_at": __import__("datetime").datetime.now(
-                            __import__("datetime").timezone.utc
-                        ).isoformat(),
+                        "promoted_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
                         "promoted_from_state": "tentative",
                     }
                     logger.info(

--- a/supabase/migrations/106_drop_dead_columns.sql
+++ b/supabase/migrations/106_drop_dead_columns.sql
@@ -1,0 +1,18 @@
+-- SCHEMA-F1 Step 3: Drop 5 dead columns from agent_memories.
+-- provenance: all 388 rows = {} (empty JSONB default). Zero code reads.
+-- signoff_status: all 388 rows = 'approved' (default). Zero code reads.
+-- category: all 388 rows = NULL. Zero code reads.
+-- business_score: all 388 rows = NULL. Zero code reads.
+-- learning_score: all 388 rows = NULL. Zero code reads.
+
+ALTER TABLE public.agent_memories DROP COLUMN IF EXISTS provenance;
+ALTER TABLE public.agent_memories DROP COLUMN IF EXISTS signoff_status;
+ALTER TABLE public.agent_memories DROP COLUMN IF EXISTS category;
+ALTER TABLE public.agent_memories DROP COLUMN IF EXISTS business_score;
+ALTER TABLE public.agent_memories DROP COLUMN IF EXISTS learning_score;
+
+-- SCHEMA-F1 Step 2: Document promoted_from_id semantics.
+COMMENT ON COLUMN public.agent_memories.promoted_from_id IS 'Self-reference indicates this row was promoted in-place from tentative to confirmed. Non-self FK reserved for future audit-row pattern.';
+
+-- SCHEMA-F1 Step 4: Defer contradicted_by_id — retain column, document intent.
+COMMENT ON COLUMN public.agent_memories.contradicted_by_id IS 'DEFERRED (SCHEMA-F1). Awaiting /contradict command or dave-correction flow design. Column retained — dropping has rollback cost.';

--- a/tests/test_schema_f1.py
+++ b/tests/test_schema_f1.py
@@ -1,0 +1,224 @@
+"""
+tests/test_schema_f1.py — Unit tests for SCHEMA-F1 promotion wiring.
+
+Covers:
+  1. Promotion sets promoted_from_id correctly (+ typed_metadata keys)
+  2. Below-threshold access does NOT set promoted_from_id
+  3. Already-confirmed row does NOT get promoted_from_id
+"""
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# PROMOTION_ACCESS_THRESHOLD is 3 — imported from module
+from src.telegram_bot.memory_listener import (
+    PROMOTION_ACCESS_THRESHOLD,
+    _increment_access_counts,
+)
+
+FAKE_URL = "https://fake.supabase.co"
+FAKE_KEY = "fake-service-key"
+
+HEADERS = {
+    "apikey": FAKE_KEY,
+    "Authorization": f"Bearer {FAKE_KEY}",
+    "Content-Type": "application/json",
+}
+
+
+def _make_row(
+    state: str = "tentative",
+    access_count: int = 0,
+    typed_metadata: dict | None = None,
+) -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "state": state,
+        "access_count": access_count,
+        "typed_metadata": typed_metadata or {},
+    }
+
+
+def _run(coro):
+    """Helper: run async coroutine in test."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestPromotionSetsPromotedFromId:
+    """
+    Test 1: access_count reaches PROMOTION_ACCESS_THRESHOLD (2 + 1 = 3).
+    Expect payload to include promoted_from_id = row['id'],
+    typed_metadata with promoted_at and promoted_from_state.
+    """
+
+    def test_payload_includes_promoted_from_id(self):
+        row = _make_row(state="tentative", access_count=PROMOTION_ACCESS_THRESHOLD - 1)
+        captured_payloads = []
+
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+
+        async def fake_patch(url, headers, json):
+            captured_payloads.append(json)
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.patch = fake_patch
+
+        env = {"SUPABASE_URL": FAKE_URL, "SUPABASE_SERVICE_KEY": FAKE_KEY}
+
+        with patch("src.telegram_bot.memory_listener.SUPABASE_URL", FAKE_URL), \
+             patch("src.telegram_bot.memory_listener.SUPABASE_KEY", FAKE_KEY), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+            _run(_increment_access_counts([row], HEADERS))
+
+        assert len(captured_payloads) == 1
+        payload = captured_payloads[0]
+
+        assert payload.get("state") == "confirmed", \
+            f"Expected state='confirmed', got {payload.get('state')!r}"
+        assert payload.get("promoted_from_id") == row["id"], \
+            f"Expected promoted_from_id={row['id']!r}, got {payload.get('promoted_from_id')!r}"
+
+        meta = payload.get("typed_metadata", {})
+        assert "promoted_at" in meta, \
+            f"Expected 'promoted_at' in typed_metadata, got keys: {list(meta.keys())}"
+        assert meta.get("promoted_from_state") == "tentative", \
+            f"Expected promoted_from_state='tentative', got {meta.get('promoted_from_state')!r}"
+
+    def test_promoted_at_is_iso_timestamp(self):
+        """promoted_at must be a parseable ISO 8601 string."""
+        row = _make_row(state="tentative", access_count=PROMOTION_ACCESS_THRESHOLD - 1)
+        captured_payloads = []
+
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+
+        async def fake_patch(url, headers, json):
+            captured_payloads.append(json)
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.patch = fake_patch
+
+        with patch("src.telegram_bot.memory_listener.SUPABASE_URL", FAKE_URL), \
+             patch("src.telegram_bot.memory_listener.SUPABASE_KEY", FAKE_KEY), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+            _run(_increment_access_counts([row], HEADERS))
+
+        meta = captured_payloads[0].get("typed_metadata", {})
+        promoted_at = meta.get("promoted_at", "")
+        # Must parse without exception
+        datetime.fromisoformat(promoted_at)
+
+    def test_existing_typed_metadata_preserved(self):
+        """Existing typed_metadata keys must be merged, not overwritten."""
+        existing_meta = {"some_existing_key": "some_value"}
+        row = _make_row(
+            state="tentative",
+            access_count=PROMOTION_ACCESS_THRESHOLD - 1,
+            typed_metadata=existing_meta,
+        )
+        captured_payloads = []
+
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+
+        async def fake_patch(url, headers, json):
+            captured_payloads.append(json)
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.patch = fake_patch
+
+        with patch("src.telegram_bot.memory_listener.SUPABASE_URL", FAKE_URL), \
+             patch("src.telegram_bot.memory_listener.SUPABASE_KEY", FAKE_KEY), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+            _run(_increment_access_counts([row], HEADERS))
+
+        meta = captured_payloads[0].get("typed_metadata", {})
+        assert meta.get("some_existing_key") == "some_value", \
+            "Existing typed_metadata keys must survive the merge"
+
+
+class TestBelowThresholdNoPromotion:
+    """
+    Test 2: access_count=0 → new_count=1, below threshold=3.
+    promoted_from_id must NOT appear in payload.
+    """
+
+    def test_below_threshold_no_promoted_from_id(self):
+        row = _make_row(state="tentative", access_count=0)
+        captured_payloads = []
+
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+
+        async def fake_patch(url, headers, json):
+            captured_payloads.append(json)
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.patch = fake_patch
+
+        with patch("src.telegram_bot.memory_listener.SUPABASE_URL", FAKE_URL), \
+             patch("src.telegram_bot.memory_listener.SUPABASE_KEY", FAKE_KEY), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+            _run(_increment_access_counts([row], HEADERS))
+
+        assert len(captured_payloads) == 1
+        payload = captured_payloads[0]
+
+        assert "promoted_from_id" not in payload, \
+            f"promoted_from_id should NOT be in payload below threshold, got {payload}"
+        assert payload.get("state") != "confirmed", \
+            "state should NOT be 'confirmed' below threshold"
+
+
+class TestAlreadyConfirmedNoPromotion:
+    """
+    Test 3: state='confirmed', access_count=5 → high count but already confirmed.
+    promoted_from_id must NOT appear in payload (no re-promotion).
+    """
+
+    def test_confirmed_row_no_promoted_from_id(self):
+        row = _make_row(state="confirmed", access_count=5)
+        captured_payloads = []
+
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+
+        async def fake_patch(url, headers, json):
+            captured_payloads.append(json)
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.patch = fake_patch
+
+        with patch("src.telegram_bot.memory_listener.SUPABASE_URL", FAKE_URL), \
+             patch("src.telegram_bot.memory_listener.SUPABASE_KEY", FAKE_KEY), \
+             patch("httpx.AsyncClient", return_value=mock_client):
+            _run(_increment_access_counts([row], HEADERS))
+
+        assert len(captured_payloads) == 1
+        payload = captured_payloads[0]
+
+        assert "promoted_from_id" not in payload, \
+            f"promoted_from_id should NOT be in payload for confirmed row, got {payload}"
+        # access_count should still increment
+        assert payload.get("access_count") == 6, \
+            f"access_count should increment to 6 regardless, got {payload.get('access_count')}"


### PR DESCRIPTION
## Summary
- **Step 1:** Backfill script for 17 superseded rows with `supersedes_id=NULL` (`scripts/backfill_supersedes_id.py` — not yet run, awaiting review)
- **Step 2:** Wire `promoted_from_id` on tentative→confirmed promotion (self-referencing FK + `typed_metadata.promoted_at` breadcrumb). PROMOTION FIRED log line added for frequency tracking.
- **Step 3:** Migration 106 drops 5 dead columns (`provenance`, `signoff_status`, `category`, `business_score`, `learning_score`)
- **Step 4:** `contradicted_by_id` deferred with SQL COMMENT documenting intent
- **Step 5:** 5 unit tests for promotion wiring (all passing)

Dave refinements applied:
- Backfill marks inferred successes with `backfill_inferred: true` (not just failures)
- SQL COMMENT on `promoted_from_id` explaining self-reference semantics
- `ceo:technical_debt.promoted_from_id_semantics` key written documenting FK asymmetry

## Test plan
- [x] `pytest tests/test_schema_f1.py -v` — 5/5 passed
- [ ] Backfill script review before execution
- [ ] Migration 106 applied via Supabase after merge
- [ ] Verify PROMOTION FIRED log line appears in listener telemetry on next live promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)