### PR TITLE
feat: OpenAI cost tracking at all 6 call sites (F4-PART2-SETUP)

### DIFF
--- a/scripts/openai_cost_rollup.py
+++ b/scripts/openai_cost_rollup.py
@@ -1,0 +1,103 @@
+"""
+openai_cost_rollup.py — daily OpenAI cost summary from the JSONL cost log.
+
+Reads last 24h of /home/elliotbot/clawd/logs/openai-cost.jsonl,
+computes totals by use_case and callsign, writes a daily summary line to
+/home/elliotbot/clawd/logs/openai-cost-daily.jsonl, and sends a Telegram
+summary to the group.
+
+Intended to run via systemd timer at 23:55 AEST (13:55 UTC).
+"""
+import json
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+COST_LOG = Path("/home/elliotbot/clawd/logs/openai-cost.jsonl")
+DAILY_LOG = Path("/home/elliotbot/clawd/logs/openai-cost-daily.jsonl")
+
+
+def load_last_24h(log_path: Path) -> list[dict]:
+    """Read all JSONL lines from the last 24 hours."""
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+    entries = []
+    if not log_path.exists():
+        return entries
+    with open(log_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                ts = datetime.fromisoformat(entry["ts"])
+                if ts >= cutoff:
+                    entries.append(entry)
+            except Exception:
+                continue
+    return entries
+
+
+def compute_summary(entries: list[dict]) -> dict:
+    """Compute cost totals by use_case and callsign."""
+    total = 0.0
+    by_use_case: dict[str, float] = defaultdict(float)
+    by_callsign: dict[str, float] = defaultdict(float)
+    call_counts: dict[str, int] = defaultdict(int)
+
+    for e in entries:
+        cost = e.get("estimated_cost_usd", 0.0)
+        use_case = e.get("use_case", "unknown")
+        callsign = e.get("callsign", "unknown")
+        total += cost
+        by_use_case[use_case] += cost
+        by_callsign[callsign] += cost
+        call_counts[use_case] += 1
+
+    return {
+        "date": datetime.now(timezone.utc).date().isoformat(),
+        "total_usd": round(total, 6),
+        "by_use_case": {k: round(v, 6) for k, v in by_use_case.items()},
+        "by_callsign": {k: round(v, 6) for k, v in by_callsign.items()},
+        "call_counts": dict(call_counts),
+        "total_calls": len(entries),
+    }
+
+
+def write_daily_summary(summary: dict) -> None:
+    """Append summary to daily JSONL log."""
+    with open(DAILY_LOG, "a") as f:
+        f.write(json.dumps(summary) + "\n")
+
+
+def send_telegram(summary: dict) -> None:
+    """Send daily summary to Telegram group."""
+    total = summary["total_usd"]
+    by_uc = summary.get("by_use_case", {})
+    embed_cost = by_uc.get("embedding", 0) + by_uc.get("store_embedding", 0) + by_uc.get("backfill_embedding", 0)
+    disc_cost = by_uc.get("discernment", 0)
+    save_cost = by_uc.get("save_extraction", 0)
+    qe_cost = by_uc.get("query_expansion", 0)
+    calls = summary.get("total_calls", 0)
+    msg = (
+        f"[ELLIOT] Daily OpenAI cost: ${total:.4f} USD — "
+        f"embeddings ${embed_cost:.4f} | discernment ${disc_cost:.4f} | "
+        f"save ${save_cost:.4f} | query-expansion ${qe_cost:.4f} "
+        f"({calls} calls)"
+    )
+    subprocess.run(["tg", "-g", msg], check=False)
+
+
+def main() -> None:
+    entries = load_last_24h(COST_LOG)
+    summary = compute_summary(entries)
+    write_daily_summary(summary)
+    send_telegram(summary)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/openai_cost_weekly.py
+++ b/scripts/openai_cost_weekly.py
@@ -1,0 +1,135 @@
+"""
+openai_cost_weekly.py — weekly OpenAI cost summary from daily rollup JSONL.
+
+Reads last 7 days of /home/elliotbot/clawd/logs/openai-cost-daily.jsonl,
+computes 7-day totals, writes to Supabase ceo_memory key
+'ceo:openai_weekly_cost', and sends Telegram summary to group.
+
+Intended to run via systemd timer on Fridays at 18:00 AEST (08:00 UTC).
+"""
+import json
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import requests
+from dotenv import dotenv_values
+
+DAILY_LOG = Path("/home/elliotbot/clawd/logs/openai-cost-daily.jsonl")
+ENV_PATH = "/home/elliotbot/.config/agency-os/.env"
+
+
+def load_env() -> tuple[str, str]:
+    env = dotenv_values(ENV_PATH)
+    url = env.get("SUPABASE_URL", "").rstrip("/")
+    key = env.get("SUPABASE_SERVICE_KEY", "") or env.get("SUPABASE_KEY", "")
+    if not url or not key:
+        print("ERROR: SUPABASE_URL or SUPABASE_SERVICE_KEY missing from env.")
+        sys.exit(1)
+    return url, key
+
+
+def load_last_7_days(log_path: Path) -> list[dict]:
+    """Read daily summary lines from the last 7 days."""
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=7)).date().isoformat()
+    entries = []
+    if not log_path.exists():
+        return entries
+    with open(log_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                if entry.get("date", "") >= cutoff:
+                    entries.append(entry)
+            except Exception:
+                continue
+    return entries
+
+
+def compute_weekly(entries: list[dict]) -> dict:
+    """Aggregate 7-day totals from daily summaries."""
+    total = 0.0
+    by_use_case: dict[str, float] = defaultdict(float)
+    by_callsign: dict[str, float] = defaultdict(float)
+    total_calls = 0
+
+    for e in entries:
+        total += e.get("total_usd", 0.0)
+        total_calls += e.get("total_calls", 0)
+        for k, v in e.get("by_use_case", {}).items():
+            by_use_case[k] += v
+        for k, v in e.get("by_callsign", {}).items():
+            by_callsign[k] += v
+
+    return {
+        "week_ending": datetime.now(timezone.utc).date().isoformat(),
+        "total_usd": round(total, 6),
+        "by_use_case": {k: round(v, 6) for k, v in by_use_case.items()},
+        "by_callsign": {k: round(v, 6) for k, v in by_callsign.items()},
+        "total_calls": total_calls,
+        "days_covered": len(entries),
+    }
+
+
+def write_to_ceo_memory(supabase_url: str, supabase_key: str, summary: dict) -> None:
+    """Upsert weekly cost summary to ceo_memory."""
+    headers = {
+        "apikey": supabase_key,
+        "Authorization": f"Bearer {supabase_key}",
+        "Content-Type": "application/json",
+        "Prefer": "resolution=merge-duplicates",
+    }
+    payload = {
+        "key": "ceo:openai_weekly_cost",
+        "value": json.dumps(summary),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    resp = requests.post(
+        f"{supabase_url}/rest/v1/ceo_memory",
+        headers=headers,
+        json=payload,
+        timeout=10,
+    )
+    if resp.status_code not in (200, 201):
+        print(f"WARNING: ceo_memory write failed ({resp.status_code}): {resp.text[:200]}")
+    else:
+        print("ceo_memory updated: ceo:openai_weekly_cost")
+
+
+def send_telegram(summary: dict) -> None:
+    """Send weekly summary to Telegram group."""
+    total = summary["total_usd"]
+    total_aud = round(total * 1.55, 4)
+    by_uc = summary.get("by_use_case", {})
+    embed_cost = by_uc.get("embedding", 0) + by_uc.get("store_embedding", 0) + by_uc.get("backfill_embedding", 0)
+    disc_cost = by_uc.get("discernment", 0)
+    save_cost = by_uc.get("save_extraction", 0)
+    qe_cost = by_uc.get("query_expansion", 0)
+    calls = summary.get("total_calls", 0)
+    days = summary.get("days_covered", 0)
+    msg = (
+        f"[ELLIOT] Weekly OpenAI cost ({days}d): ${total:.4f} USD (${total_aud:.4f} AUD) — "
+        f"embeddings ${embed_cost:.4f} | discernment ${disc_cost:.4f} | "
+        f"save ${save_cost:.4f} | query-expansion ${qe_cost:.4f} "
+        f"({calls} total calls)"
+    )
+    subprocess.run(["tg", "-g", msg], check=False)
+
+
+def main() -> None:
+    supabase_url, supabase_key = load_env()
+    entries = load_last_7_days(DAILY_LOG)
+    summary = compute_weekly(entries)
+    write_to_ceo_memory(supabase_url, supabase_key, summary)
+    send_telegram(summary)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/memory/organise.py
+++ b/src/memory/organise.py
@@ -74,7 +74,19 @@ def backfill_embeddings(limit: int = EMBED_BATCH_LIMIT) -> int:
                 timeout=10,
             )
             if emb_resp.status_code == 200:
-                embedding = emb_resp.json()["data"][0]["embedding"]
+                emb_data = emb_resp.json()
+                try:
+                    from src.telegram_bot.openai_cost_logger import log_openai_call
+                    usage = emb_data.get("usage", {})
+                    log_openai_call(
+                        callsign=os.environ.get("CALLSIGN", "unknown"),
+                        use_case="backfill_embedding",
+                        model="text-embedding-3-small",
+                        input_tokens=usage.get("total_tokens", 0),
+                    )
+                except Exception:
+                    pass
+                embedding = emb_data["data"][0]["embedding"]
                 httpx.patch(
                     f"{SUPABASE_URL}/rest/v1/agent_memories?id=eq.{row['id']}",
                     headers={**headers, "Prefer": "return=minimal"},

--- a/src/memory/store.py
+++ b/src/memory/store.py
@@ -41,7 +41,19 @@ def _generate_embedding(text: str) -> list[float] | None:
             timeout=10,
         )
         if resp.status_code == 200:
-            return resp.json()["data"][0]["embedding"]
+            emb_data = resp.json()
+            try:
+                from src.telegram_bot.openai_cost_logger import log_openai_call
+                usage = emb_data.get("usage", {})
+                log_openai_call(
+                    callsign=os.environ.get("CALLSIGN", "unknown"),
+                    use_case="store_embedding",
+                    model="text-embedding-3-small",
+                    input_tokens=usage.get("total_tokens", 0),
+                )
+            except Exception:
+                pass
+            return emb_data["data"][0]["embedding"]
     except Exception as exc:
         logger.warning(f"[store] embedding generation failed: {exc}")
     return None

--- a/src/telegram_bot/listener_discernment.py
+++ b/src/telegram_bot/listener_discernment.py
@@ -21,7 +21,7 @@ synthesised brief block.
 """
 import json
 import logging
-import os
+import os  # noqa: F401 — used in cost logging block
 import re
 from typing import Any
 
@@ -115,7 +115,20 @@ async def discern_and_summarise(
                     f"[discernment] OpenAI returned {resp.status_code}: {resp.text[:200]}"
                 )
                 return _empty_result("openai_http_error")
-            raw = resp.json()["choices"][0]["message"]["content"]
+            resp_json = resp.json()
+            raw = resp_json["choices"][0]["message"]["content"]
+            try:
+                from src.telegram_bot.openai_cost_logger import log_openai_call
+                usage = resp_json.get("usage", {})
+                log_openai_call(
+                    callsign=os.environ.get("CALLSIGN", "unknown"),
+                    use_case="discernment",
+                    model="gpt-4o-mini",
+                    input_tokens=usage.get("prompt_tokens", 0),
+                    output_tokens=usage.get("completion_tokens", 0),
+                )
+            except Exception:
+                pass
     except Exception as exc:
         logger.warning(f"[discernment] call failed: {exc}")
         return _empty_result("call_exception")

--- a/src/telegram_bot/memory_listener.py
+++ b/src/telegram_bot/memory_listener.py
@@ -74,6 +74,18 @@ async def _expand_query(query_text: str) -> list[str]:
                 content = data["choices"][0]["message"]["content"]
                 parsed = json.loads(content)
                 variations = parsed.get("variations", [])
+                try:
+                    from src.telegram_bot.openai_cost_logger import log_openai_call
+                    usage = data.get("usage", {})
+                    log_openai_call(
+                        callsign=os.environ.get("CALLSIGN", "unknown"),
+                        use_case="query_expansion",
+                        model="gpt-4o-mini",
+                        input_tokens=usage.get("prompt_tokens", 0),
+                        output_tokens=usage.get("completion_tokens", 0),
+                    )
+                except Exception:
+                    pass
                 if isinstance(variations, list) and variations:
                     return [query_text] + [v for v in variations if isinstance(v, str)][:3]
     except Exception as exc:
@@ -137,7 +149,19 @@ async def _embed_text(text: str) -> list[float] | None:
                 json={"model": "text-embedding-3-small", "input": text[:8000]},
             )
             if resp.status_code == 200:
-                return resp.json()["data"][0]["embedding"]
+                emb_data = resp.json()
+                try:
+                    from src.telegram_bot.openai_cost_logger import log_openai_call
+                    usage = emb_data.get("usage", {})
+                    log_openai_call(
+                        callsign=os.environ.get("CALLSIGN", "unknown"),
+                        use_case="embedding",
+                        model="text-embedding-3-small",
+                        input_tokens=usage.get("total_tokens", 0),
+                    )
+                except Exception:
+                    pass
+                return emb_data["data"][0]["embedding"]
     except Exception as exc:
         logger.warning(f"[memory-listener] embedding failed: {exc}")
     return None

--- a/src/telegram_bot/openai_cost_logger.py
+++ b/src/telegram_bot/openai_cost_logger.py
@@ -1,0 +1,47 @@
+"""
+OpenAI cost logger — append-only JSONL for all OpenAI API calls in the listener subsystem.
+F4-PART2-SETUP: 7 days of data collection before budget trigger ratification.
+"""
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+COST_LOG_PATH = "/home/elliotbot/clawd/logs/openai-cost.jsonl"
+
+# OpenAI pricing (USD) as of 2025-05 — update if pricing changes
+PRICING = {
+    "text-embedding-3-small": {"input": 0.02 / 1_000_000},  # $0.02/1M tokens
+    "gpt-4o-mini": {"input": 0.15 / 1_000_000, "output": 0.60 / 1_000_000},  # $0.15/$0.60 per 1M
+}
+
+
+def log_openai_call(
+    callsign: str,
+    use_case: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int = 0,
+) -> None:
+    """Append one cost event to the JSONL log. Best-effort, never raises."""
+    try:
+        pricing = PRICING.get(model, {})
+        cost_usd = (
+            input_tokens * pricing.get("input", 0)
+            + output_tokens * pricing.get("output", 0)
+        )
+        entry = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "callsign": callsign,
+            "use_case": use_case,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "estimated_cost_usd": round(cost_usd, 8),
+        }
+        with open(COST_LOG_PATH, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except Exception as exc:
+        logger.warning(f"[openai-cost] log write failed: {exc}")

--- a/src/telegram_bot/save_handler.py
+++ b/src/telegram_bot/save_handler.py
@@ -71,6 +71,17 @@ def extract_memory_fields(raw_text: str) -> dict:
         temperature=0,
         max_tokens=500,
     )
+    try:
+        from src.telegram_bot.openai_cost_logger import log_openai_call
+        log_openai_call(
+            callsign=os.getenv("CALLSIGN", "unknown"),
+            use_case="save_extraction",
+            model="gpt-4o-mini",
+            input_tokens=response.usage.prompt_tokens if response.usage else 0,
+            output_tokens=response.usage.completion_tokens if response.usage else 0,
+        )
+    except Exception:
+        pass
     return json.loads(response.choices[0].message.content)
 
 

--- a/tests/test_openai_cost_logger.py
+++ b/tests/test_openai_cost_logger.py
@@ -1,0 +1,123 @@
+"""
+Tests for openai_cost_logger.py — F4-PART2-SETUP.
+"""
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _make_logger(log_path: str):
+    """Import the module with COST_LOG_PATH patched to a temp path."""
+    import importlib
+    import src.telegram_bot.openai_cost_logger as mod
+    original = mod.COST_LOG_PATH
+    mod.COST_LOG_PATH = log_path
+    yield mod
+    mod.COST_LOG_PATH = original
+
+
+@pytest.fixture()
+def cost_logger(tmp_path):
+    """Yield the cost logger module with log path pointed at tmp_path."""
+    import src.telegram_bot.openai_cost_logger as mod
+    log_file = str(tmp_path / "openai-cost.jsonl")
+    original = mod.COST_LOG_PATH
+    mod.COST_LOG_PATH = log_file
+    yield mod, log_file
+    mod.COST_LOG_PATH = original
+
+
+def test_writes_valid_jsonl(cost_logger):
+    mod, log_file = cost_logger
+    mod.log_openai_call(
+        callsign="elliot",
+        use_case="query_expansion",
+        model="gpt-4o-mini",
+        input_tokens=100,
+        output_tokens=50,
+    )
+    lines = Path(log_file).read_text().strip().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["callsign"] == "elliot"
+    assert entry["use_case"] == "query_expansion"
+    assert entry["model"] == "gpt-4o-mini"
+    assert entry["input_tokens"] == 100
+    assert entry["output_tokens"] == 50
+    assert "ts" in entry
+    assert "estimated_cost_usd" in entry
+
+
+def test_cost_gpt4o_mini(cost_logger):
+    mod, log_file = cost_logger
+    mod.log_openai_call(
+        callsign="elliot",
+        use_case="discernment",
+        model="gpt-4o-mini",
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+    )
+    entry = json.loads(Path(log_file).read_text().strip())
+    # $0.15/1M input + $0.60/1M output = $0.75 total
+    assert abs(entry["estimated_cost_usd"] - 0.75) < 1e-6
+
+
+def test_cost_embedding(cost_logger):
+    mod, log_file = cost_logger
+    mod.log_openai_call(
+        callsign="aiden",
+        use_case="embedding",
+        model="text-embedding-3-small",
+        input_tokens=1_000_000,
+        output_tokens=0,
+    )
+    entry = json.loads(Path(log_file).read_text().strip())
+    # $0.02/1M tokens
+    assert abs(entry["estimated_cost_usd"] - 0.02) < 1e-6
+
+
+def test_unknown_model_zero_cost(cost_logger):
+    mod, log_file = cost_logger
+    mod.log_openai_call(
+        callsign="elliot",
+        use_case="test",
+        model="gpt-99-unknown",
+        input_tokens=1000,
+        output_tokens=500,
+    )
+    entry = json.loads(Path(log_file).read_text().strip())
+    assert entry["estimated_cost_usd"] == 0.0
+
+
+def test_multiple_entries_appended(cost_logger):
+    mod, log_file = cost_logger
+    for i in range(3):
+        mod.log_openai_call(
+            callsign="elliot",
+            use_case=f"use_case_{i}",
+            model="gpt-4o-mini",
+            input_tokens=10,
+            output_tokens=5,
+        )
+    lines = Path(log_file).read_text().strip().splitlines()
+    assert len(lines) == 3
+
+
+def test_does_not_raise_on_write_failure(tmp_path):
+    """log_openai_call must never raise even on an unwritable path."""
+    import src.telegram_bot.openai_cost_logger as mod
+    original = mod.COST_LOG_PATH
+    # Point to a non-existent directory — guaranteed write failure
+    mod.COST_LOG_PATH = "/nonexistent_dir/openai-cost.jsonl"
+    try:
+        # Must not raise
+        mod.log_openai_call(
+            callsign="elliot",
+            use_case="test",
+            model="gpt-4o-mini",
+            input_tokens=10,
+        )
+    finally:
+        mod.COST_LOG_PATH = original


### PR DESCRIPTION
## Summary
- **New module:** `src/telegram_bot/openai_cost_logger.py` — append-only JSONL logger with per-model pricing
- **6 call sites instrumented** (all best-effort, never blocks live code):
  1. `memory_listener.py` — query expansion (gpt-4o-mini)
  2. `memory_listener.py` — embeddings (text-embedding-3-small)
  3. `listener_discernment.py` — L2 discernment (gpt-4o-mini)
  4. `save_handler.py` — save extraction (gpt-4o-mini)
  5. `store.py` — write embeddings (text-embedding-3-small)
  6. `organise.py` — backfill embeddings (text-embedding-3-small)
- **Daily rollup** (`scripts/openai_cost_rollup.py`): reads last 24h, computes totals by use_case + callsign, writes daily summary JSONL, posts TG summary
- **Weekly rollup** (`scripts/openai_cost_weekly.py`): 7-day totals, writes to `ceo:openai_weekly_cost`, posts TG summary
- **Systemd timers** created (NOT enabled): daily at 23:55 AEST, weekly Friday 18:00 AEST
- **6 unit tests** all passing

Feeds into F4-PART2-RATIFY (2026-04-25) — 7 days of cost data to set budget trigger.

## Test plan
- [x] `pytest tests/test_openai_cost_logger.py -v` — 6/6 passed
- [ ] Verify JSONL entries appear after live listener interactions
- [ ] Enable systemd timers after merge + review
- [ ] After 7 days, use cost data for F4-PART2-RATIFY budget trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)