### PR TITLE
[ELLIOT] fix: F21-CRITICAL-3 — mobile wiring + agency_name test lock + Hunter gate test lock

### DIFF
--- a/src/orchestration/cohort_runner.py
+++ b/src/orchestration/cohort_runner.py
@@ -35,6 +35,7 @@ for _k, _v in env.items():
 from src.clients.dfs_labs_client import DFSLabsClient
 from src.config.category_etv_windows import CATEGORY_ETV_WINDOWS, get_etv_window
 from src.integrations.bright_data_client import BrightDataClient
+from src.integrations.leadmagic import LeadmagicClient
 from src.pipeline.contactout_enricher import enrich_dm_via_contactout
 from src.pipeline.email_waterfall import discover_email
 from src.pipeline.mobile_waterfall import run_mobile_waterfall
@@ -380,7 +381,7 @@ def _source_to_tier(source: str) -> str:
     }.get(source, f"UNKNOWN:{source}")
 
 
-async def _run_stage8(domain_data: dict, dfs: DFSLabsClient, bd: BrightDataClient | None = None) -> dict:
+async def _run_stage8(domain_data: dict, dfs: DFSLabsClient, bd: BrightDataClient | None = None, lm: LeadmagicClient | None = None) -> dict:
     """Stage 8 CONTACT — verify fills (8a) + unified contact waterfall (8b-d)."""
     _tracker(domain_data).start_stage("stage8")
     t0 = time.monotonic()
@@ -457,6 +458,7 @@ async def _run_stage8(domain_data: dict, dfs: DFSLabsClient, bd: BrightDataClien
             contact_data=contact_data_mobile or None,
             contactout_result=contactout_result,
             brightdata_client=bd,
+            leadmagic_client=lm,
         )
     except Exception as exc:
         domain_data["errors"].append(f"stage8d_mobile: {exc}")
@@ -688,6 +690,7 @@ async def run_cohort(
     )
     gemini = GeminiClient(api_key=env.get("GEMINI_API_KEY"))
     bd = BrightDataClient(api_key=env.get("BRIGHTDATA_API_KEY", ""))
+    lm = LeadmagicClient()
 
     # Pre-run cost estimate and hard cap
     # When --domains is used, domains_per_category=0 and categories=[], so use len(domains) directly
@@ -868,7 +871,7 @@ async def run_cohort(
 
     # Stage 8
     active8 = _active(pipeline)
-    updated8 = await run_parallel(active8, lambda d: _run_stage8(d, dfs, bd), concurrency=15, label="Stage 8 CONTACT")
+    updated8 = await run_parallel(active8, lambda d: _run_stage8(d, dfs, bd, lm), concurrency=15, label="Stage 8 CONTACT")
     _merge(pipeline, updated8)
     _tg_progress("Stage 8 CONTACT", pipeline, _total_cost())
     if _check_budget(pipeline, budget_hard_cap):

--- a/src/pipeline/pipeline_orchestrator.py
+++ b/src/pipeline/pipeline_orchestrator.py
@@ -336,6 +336,8 @@ class PipelineOrchestrator:
         prospect_scorer=None,
         intelligence=None,
         on_card=None,
+        leadmagic_client=None,  # ADD: for mobile waterfall L2
+        brightdata_client=None,  # ADD: for mobile waterfall L3
     ):
         self._discovery = discovery
         self._fe = free_enrichment
@@ -345,6 +347,8 @@ class PipelineOrchestrator:
         self._ads_client = ads_client
         self._intelligence = intelligence  # optional: IntelligenceLayer instance or module
         self._on_card = on_card  # optional: callable(ProspectCard) — fires as each card completes
+        self._leadmagic_client = leadmagic_client
+        self._brightdata_client = brightdata_client
 
     # ── Stage helpers ─────────────────────────────────────────────────────
 
@@ -1170,6 +1174,8 @@ class PipelineOrchestrator:
                         dm_linkedin_url=dm_linkedin_url,
                         contact_data=contact_data_for_mobile,
                         contactout_result=contactout_result,
+                        leadmagic_client=self._leadmagic_client,  # ADD
+                        brightdata_client=self._brightdata_client,  # ADD
                     )
 
                     # GATE: Reachability — email OR LinkedIn required

--- a/tests/test_hunter_dm_verified_gate.py
+++ b/tests/test_hunter_dm_verified_gate.py
@@ -1,0 +1,111 @@
+"""Lock test: Hunter L2 email-finder is gated on dm_verified=True (GOV-12).
+
+Rationale: email_waterfall.py line 565 gates Hunter on dm_verified to avoid
+confident email attribution on unconfirmed DMs. These tests verify the
+runtime conditional is enforced — not merely documented.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_hunter_response(email: str = "john.doe@example.com", score: int = 85) -> MagicMock:
+    """Return a mock httpx Response for a successful Hunter call."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"data": {"email": email, "score": score}}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hunter_not_called_when_dm_not_verified():
+    """When dm_verified=False, Hunter L2 must never be called."""
+    os.environ["HUNTER_API_KEY"] = "test-key-123"
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=_make_hunter_response())
+        mock_client_cls.return_value = mock_client
+
+        from src.pipeline.email_waterfall import discover_email
+
+        result = await discover_email(
+            domain="example.com",
+            dm_name="John Doe",
+            dm_verified=False,
+            skip_layers=[1, 2, 3],  # skip paid layers, force Hunter path only
+        )
+
+    # Hunter GET must never have been called
+    mock_client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hunter_called_when_dm_verified_and_name_present():
+    """When dm_verified=True and first/last/domain are present, Hunter L2 IS called."""
+    os.environ["HUNTER_API_KEY"] = "test-key-123"
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=_make_hunter_response())
+        mock_client_cls.return_value = mock_client
+
+        from src.pipeline.email_waterfall import discover_email
+
+        result = await discover_email(
+            domain="example.com",
+            dm_name="John Doe",
+            dm_verified=True,
+            # skip L0 contact_data, L1 contactout, L3 leadmagic so only Hunter runs
+            skip_layers=[2, 3],
+            contactout_result=None,
+            contact_data=None,
+        )
+
+    # Hunter GET must have been called exactly once
+    mock_client.get.assert_called_once()
+    call_kwargs = mock_client.get.call_args
+    assert "hunter.io" in call_kwargs[0][0]
+
+
+@pytest.mark.asyncio
+async def test_hunter_skipped_when_no_api_key():
+    """When HUNTER_API_KEY is absent, Hunter is skipped even with dm_verified=True."""
+    os.environ.pop("HUNTER_API_KEY", None)
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=_make_hunter_response())
+        mock_client_cls.return_value = mock_client
+
+        from src.pipeline.email_waterfall import discover_email
+
+        result = await discover_email(
+            domain="example.com",
+            dm_name="John Doe",
+            dm_verified=True,
+            skip_layers=[2, 3],
+            contactout_result=None,
+            contact_data=None,
+        )
+
+    mock_client.get.assert_not_called()

--- a/tests/test_stage10_agency_name.py
+++ b/tests/test_stage10_agency_name.py
@@ -1,0 +1,47 @@
+"""Lock test: Stage 10 enhanced_vr system prompt constants must NOT contain {{agency_name}} tokens.
+
+Rationale: F21-CRITICAL fix replaced {{agency_name}} with the literal "Agency OS"
+in the system prompts used for Gemini calls. These tests lock that fix so it
+cannot be silently reverted.
+
+Note: The module docstring at line 9 legitimately mentions {{agency_name}} as a
+negative example ("Do NOT use..."). Tests scope to prompt constants only.
+"""
+from __future__ import annotations
+
+import src.intelligence.enhanced_vr as _vr_mod
+
+
+def _prompt_constants() -> list[tuple[str, str]]:
+    """Return (name, value) for module-level string constants that are prompts."""
+    return [
+        (name, val)
+        for name, val in vars(_vr_mod).items()
+        if isinstance(val, str) and name.endswith("_PROMPT")
+    ]
+
+
+def test_no_agency_name_token_in_system_prompts():
+    """No *_PROMPT constant may contain {{agency_name}}."""
+    prompts = _prompt_constants()
+    assert prompts, "No *_PROMPT constants found in enhanced_vr — check naming"
+    for name, text in prompts:
+        assert "{{agency_name}}" not in text, (
+            f"Found unfilled {{{{agency_name}}}} token in {name} — revert detected"
+        )
+
+
+def test_agency_os_literal_present_in_prompts():
+    """The literal 'Agency OS' must appear in at least one *_PROMPT constant."""
+    combined = " ".join(text for _, text in _prompt_constants())
+    assert "Agency OS" in combined, (
+        "'Agency OS' not found in any *_PROMPT constant in enhanced_vr"
+    )
+
+
+def test_no_double_brace_tokens_in_system_prompts():
+    """No {{ ... }} placeholder tokens should appear in the system prompts."""
+    for name, text in _prompt_constants():
+        assert "{{" not in text, (
+            f"Unfilled template token found in {name}: ...{text[:80]}..."
+        )


### PR DESCRIPTION
## Summary
- **Fix 1 CODE:** Pass `leadmagic_client` + `brightdata_client` to `run_mobile_waterfall` in both `pipeline_orchestrator.py` and `cohort_runner.py`. Closes the mobile waterfall L2/L3 client pass-through gap identified in D2 audit CRITICAL #1.
- **Fix 2 TEST:** 3 tests locking `{{agency_name}}` resolution in Stage 10 output. Code fix was already on HEAD (PR #336, commit 10b08a18). This adds N>1 test coverage per directive.
- **Fix 3 TEST:** 3 tests locking Hunter `dm_verified` runtime gate (GOV-12). Code fix was already on HEAD (PR #336). This locks the conditional at `email_waterfall.py:565`.

## Felt-sufficiency applied
Pre-fix verification found 2 of 3 "CRITICAL unresolved" findings were already resolved by PR #336 (D2.2-CRITICAL). Only Fix 1 required new code. Fixes 2+3 are test-only coverage additions.

## Test plan
- [x] `pytest tests/test_stage10_agency_name.py` — 3 passed
- [x] `pytest tests/test_hunter_dm_verified_gate.py` — 3 passed
- [x] 6/6 new tests green, 2180 total collected

🤖 Generated with [Claude Code](https://claude.com/claude-code)