### PR TITLE
[ELLIOT] fix: GOV-8 — persist dropped domains to business_universe

### DIFF
--- a/src/orchestration/flows/pipeline_f_master_flow.py
+++ b/src/orchestration/flows/pipeline_f_master_flow.py
@@ -163,17 +163,61 @@ async def persist_stage8_to_db(pipeline: list[dict]) -> list[str]:
     pool = await asyncpg.create_pool(db_url, min_size=2, max_size=8, statement_cache_size=0)
     bdm_ids: list[str] = []
 
+    active_count = 0
+    dropped_count = 0
+
     try:
         async with pool.acquire() as conn:
             for d in pipeline:
+                domain = d["domain"]
+
                 if d.get("dropped_at"):
+                    # GOV-8: persist dropped domains for audit trail instead of silently skipping
+                    drop_reason = d.get("drop_reason", "unknown")
+                    dropped_stage = d.get("dropped_stage")
+
+                    # Derive display_name from whatever stage data exists
+                    identity = d.get("stage3") or {}
+                    display_name = (
+                        identity.get("business_name")
+                        or identity.get("company_name")
+                        or domain.split(".")[0].replace("-", " ").title()
+                    )
+
+                    # Negative stage convention: -N means dropped at stage N
+                    neg_stage = -abs(int(dropped_stage)) if dropped_stage is not None else None
+
+                    bu_id = await conn.fetchval(
+                        "SELECT id FROM business_universe WHERE domain = $1 LIMIT 1",
+                        domain,
+                    )
+                    if bu_id:
+                        await conn.execute(
+                            """UPDATE business_universe
+                               SET pipeline_stage = COALESCE($2, pipeline_stage),
+                                   pipeline_status = 'dropped',
+                                   filter_reason = $3,
+                                   dfs_discovery_category = COALESCE($4, dfs_discovery_category),
+                                   updated_at = NOW()
+                               WHERE id = $1""",
+                            bu_id, neg_stage, drop_reason, d.get("category") or None,
+                        )
+                    else:
+                        await conn.execute(
+                            """INSERT INTO business_universe
+                                   (domain, display_name, pipeline_stage, pipeline_status,
+                                    filter_reason, dfs_discovery_category)
+                               VALUES ($1, $2, $3, 'dropped', $4, $5)""",
+                            domain, display_name, neg_stage,
+                            drop_reason, d.get("category", ""),
+                        )
+                    dropped_count += 1
                     continue
 
                 identity = d.get("stage3") or {}
                 dm = identity.get("dm_candidate") or {}
                 scores = d.get("stage5") or {}
                 propensity = scores.get("composite_score", 0)
-                domain = d["domain"]
 
                 # Insert or find existing business_universe row
                 # No unique constraint on domain — check existence first
@@ -209,6 +253,7 @@ async def persist_stage8_to_db(pipeline: list[dict]) -> list[str]:
                 )
 
                 if not dm_name or not dm_linkedin:
+                    active_count += 1
                     continue
 
                 # Insert or find existing BDM row
@@ -229,11 +274,15 @@ async def persist_stage8_to_db(pipeline: list[dict]) -> list[str]:
                     )
                 if bdm_id:
                     bdm_ids.append(str(bdm_id))
+                active_count += 1
 
     finally:
         await pool.close()
 
-    logger.info("persist_stage8_to_db: wrote %d BDM rows", len(bdm_ids))
+    logger.info(
+        "persist_stage8_to_db: wrote %d active BDM rows, %d dropped domains logged",
+        len(bdm_ids), dropped_count,
+    )
     return bdm_ids
 
 

--- a/src/orchestration/flows/pipeline_f_master_flow.py
+++ b/src/orchestration/flows/pipeline_f_master_flow.py
@@ -185,7 +185,10 @@ async def persist_stage8_to_db(pipeline: list[dict]) -> list[str]:
                     )
 
                     # Negative stage convention: -N means dropped at stage N
-                    neg_stage = -abs(int(dropped_stage)) if dropped_stage is not None else None
+                    try:
+                        neg_stage = -abs(int(dropped_stage)) if dropped_stage is not None else None
+                    except (ValueError, TypeError):
+                        neg_stage = None
 
                     bu_id = await conn.fetchval(
                         "SELECT id FROM business_universe WHERE domain = $1 LIMIT 1",
@@ -209,7 +212,7 @@ async def persist_stage8_to_db(pipeline: list[dict]) -> list[str]:
                                     filter_reason, dfs_discovery_category)
                                VALUES ($1, $2, $3, 'dropped', $4, $5)""",
                             domain, display_name, neg_stage,
-                            drop_reason, d.get("category", ""),
+                            drop_reason, d.get("category") or None,
                         )
                     dropped_count += 1
                     continue


### PR DESCRIPTION
## Summary
- Dropped domains now persist to `business_universe` with `pipeline_status='dropped'`, `filter_reason`, and negative `pipeline_stage` (-N = dropped at stage N)
- Closes GOV-8 audit gap: previously dropped domains were silently skipped in `persist_stage8_to_db`
- No migration needed — `filter_reason TEXT` and `pipeline_status TEXT` already exist in schema

## Test plan
- [ ] 2132 tests pass, 6 pre-existing failures (campaign_flow, schema_f1)
- [ ] Zero regressions introduced
- [ ] Verify dropped domain appears in BU after pipeline run with drop_reason populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>