### PR TITLE
fix: register JSONB codec for asyncpg pools behind pgbouncer

### DIFF
--- a/src/orchestration/flows/pipeline_f_master_flow.py
+++ b/src/orchestration/flows/pipeline_f_master_flow.py
@@ -7,6 +7,7 @@ Posture: PARALLEL to existing flows — does NOT replace pool_population_flow,
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 import random
@@ -22,6 +23,17 @@ from src.prefect_utils.completion_hook import on_completion_hook
 from src.prefect_utils.hooks import on_failure_hook
 
 logger = logging.getLogger(__name__)
+
+
+async def _init_jsonb_codec(conn):
+    """Register JSONB codec for connections behind pgbouncer (statement_cache_size=0)."""
+    await conn.set_type_codec(
+        'jsonb',
+        encoder=json.dumps,
+        decoder=json.loads,
+        schema='pg_catalog',
+    )
+
 
 # ── Budget / gate constants ──────────────────────────────────────────────────
 _USD_TO_AUD = 1.55
@@ -160,7 +172,7 @@ async def persist_stage8_to_db(pipeline: list[dict]) -> list[str]:
     - business_decision_makers: business_universe_id, name, linkedin_url, is_current=True
     """
     db_url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
-    pool = await asyncpg.create_pool(db_url, min_size=2, max_size=8, statement_cache_size=0)
+    pool = await asyncpg.create_pool(db_url, min_size=2, max_size=8, statement_cache_size=0, init=_init_jsonb_codec)
     bdm_ids: list[str] = []
 
     active_count = 0
@@ -312,7 +324,7 @@ async def dm_messages_gate(run_start_ts: str, sample_size: int = 3) -> dict:
         run_start_dt = run_start_ts
 
     db_url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
-    pool = await asyncpg.create_pool(db_url, min_size=2, max_size=4, statement_cache_size=0)
+    pool = await asyncpg.create_pool(db_url, min_size=2, max_size=4, statement_cache_size=0, init=_init_jsonb_codec)
 
     try:
         async with pool.acquire() as conn:

--- a/src/orchestration/flows/stage_9_10_flow.py
+++ b/src/orchestration/flows/stage_9_10_flow.py
@@ -14,6 +14,7 @@ Alerting: Telegram on failure
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 from typing import Any
@@ -43,6 +44,17 @@ from src.enrichment.signal_config import SignalConfigRepository
 from src.prefect_utils.hooks import on_failure_hook
 
 logger = logging.getLogger(__name__)
+
+
+async def _init_jsonb_codec(conn):
+    """Register JSONB codec for connections behind pgbouncer (statement_cache_size=0)."""
+    await conn.set_type_codec(
+        'jsonb',
+        encoder=json.dumps,
+        decoder=json.loads,
+        schema='pg_catalog',
+    )
+
 
 DEFAULT_AGENCY = {
     "name": "Keiracom",
@@ -125,8 +137,8 @@ async def run_stage_10(
     agency_profile: dict,
 ) -> dict:
     """Run Stage 10 message generation."""
-    import anthropic as _anthropic
-    ai = _anthropic.AsyncAnthropic()
+    from src.integrations.anthropic import AnthropicClient
+    ai = AnthropicClient()
     signal_repo = SignalConfigRepository(pool)
     gen = Stage10MessageGenerator(ai, signal_repo, pool)
     return await gen.run(vertical_slug, agency_profile, batch_size=len(bdm_ids))
@@ -180,6 +192,7 @@ async def stage_9_10_pipeline(
         min_size=5,
         max_size=15,
         statement_cache_size=0,
+        init=_init_jsonb_codec,
     )
 
     try:


### PR DESCRIPTION
## Summary
- Root cause of Stage 9+10 `'str' object has no attribute 'get'` crashes: asyncpg with `statement_cache_size=0` (required for pgbouncer on Supabase) returns JSONB columns as raw strings, not decoded Python objects
- Add `_init_jsonb_codec()` helper in both flow files; wire as `init=` param on all three pools with `statement_cache_size=0`
- Fix `run_stage_10`: replace raw `anthropic.AsyncAnthropic()` with `AnthropicClient()` wrapper — Stage10MessageGenerator expects the `.complete()` method on our client

## Files changed
- `src/orchestration/flows/stage_9_10_flow.py` — JSONB codec + AnthropicClient fix
- `src/orchestration/flows/pipeline_f_master_flow.py` — JSONB codec on persist_stage8 pool + dm_messages_gate pool

## Test plan
- [x] Local JSONB decode verification: `type: <class 'list'>, first element type: <class 'dict'>` — PASS
- [x] Full pytest suite: 91 passed, 23 skipped (1 pre-existing flaky test in test_memory.py — fails on main too, unrelated)

🤖 Generated with Claude Code (build-2)