### PR TITLE
[ELLIOT] feat: Stage 10 writer/critic architecture — Anthropic writes, Gemini Flash critiques

### DIFF
--- a/src/orchestration/flows/stage_9_10_flow.py
+++ b/src/orchestration/flows/stage_9_10_flow.py
@@ -138,9 +138,11 @@ async def run_stage_10(
 ) -> dict:
     """Run Stage 10 message generation."""
     from src.integrations.anthropic import AnthropicClient
+    from src.intelligence.gemini_client import GeminiClient
     ai = AnthropicClient()
     signal_repo = SignalConfigRepository(pool)
-    gen = Stage10MessageGenerator(ai, signal_repo, pool)
+    gemini = GeminiClient(api_key=os.environ.get("GEMINI_API_KEY"))
+    gen = Stage10MessageGenerator(ai, signal_repo, pool, gemini_client=gemini)
     return await gen.run(vertical_slug, agency_profile, batch_size=len(bdm_ids))
 
 

--- a/src/pipeline/stage_10_critic.py
+++ b/src/pipeline/stage_10_critic.py
@@ -66,7 +66,7 @@ def _build_critic_prompt(
     subject: str | None,
     prospect_brief: str,
 ) -> str:
-    """Build the scoring prompt with the 5 criteria rubric."""
+    """Build the scoring prompt with the 6 criteria rubric."""
     lines = [
         f"Channel: {channel}",
     ]
@@ -204,8 +204,8 @@ async def critique_and_revise(
     for attempt in range(MAX_REVISIONS + 1):
         result = await critique_draft(gemini, channel, body, subject, prospect_brief)
 
-        # On critic failure (timeout/parse error) ship immediately
-        if result.get("needs_review") and result["score"] == 0 and attempt == 0:
+        # On critic failure (timeout/parse error) ship immediately — any attempt
+        if result.get("needs_review") and result["feedback"] in ("critic_timeout", "critic_parse_error"):
             return {
                 "body": body,
                 "subject": subject,

--- a/src/pipeline/stage_10_critic.py
+++ b/src/pipeline/stage_10_critic.py
@@ -16,10 +16,10 @@ CRITIC_PASS_THRESHOLD = 70
 MAX_REVISIONS = 2
 
 _CRITIC_SYSTEM_PROMPT = """You are a quality reviewer for B2B outreach messages targeting Australian SMBs.
-Score the draft on 5 criteria. Return ONLY valid JSON, no markdown."""
+Score the draft on 6 criteria. Return ONLY valid JSON, no markdown."""
 
 _CRITERIA_RUBRIC = """
-Score the message on these 5 criteria:
+Score the message on these 6 criteria:
 
 1. prospect_data (0-25): Does the message reference specific data about THIS prospect
    (tech stack, GMB rating, paid keywords, VR findings)? Generic messages score 0.
@@ -37,8 +37,12 @@ Score the message on these 5 criteria:
    Any fabricated statistics, made-up service offerings, or invented competitor
    references = 0 on this criterion.
 
-5. australian_voice (0-15): Natural, casual, peer-to-peer. Not American corporate
+5. australian_voice (0-10): Natural, casual, peer-to-peer. Not American corporate
    ("I hope this finds you well", "synergy", "leverage"). Not too informal either.
+
+6. hook_relevance (0-5): Does the opening hook connect to a specific signal from
+   the prospect brief (a real data point, not a generic observation)? If the hook
+   could apply to any business, score 0.
 
 Return ONLY this JSON structure, no markdown:
 {
@@ -48,9 +52,10 @@ Return ONLY this JSON structure, no markdown:
     "channel_format": <0-20>,
     "cta_quality": <0-20>,
     "no_hallucination": <0-20>,
-    "australian_voice": <0-15>
+    "australian_voice": <0-10>,
+    "hook_relevance": <0-5>
   },
-  "feedback": "<one sentence: the most important thing to fix>"
+  "feedback": "<quote the specific problematic line from the draft> — <reason it fails> — <suggested replacement>"
 }
 """
 
@@ -156,6 +161,11 @@ async def critique_draft(
     score = int(content.get("score", 0))
     feedback = content.get("feedback", "")
     criteria = content.get("criteria", {})
+
+    # HARD-FAIL: hallucinated claims detected — zero the entire score
+    if criteria.get("no_hallucination", 1) == 0:
+        feedback = f"HARD-FAIL: hallucinated claims detected — {feedback}"
+        score = 0
 
     return {
         "score": score,

--- a/src/pipeline/stage_10_critic.py
+++ b/src/pipeline/stage_10_critic.py
@@ -1,0 +1,249 @@
+"""Stage 10 Critic — Gemini Flash quality scoring for outreach drafts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any
+
+from src.intelligence.gemini_client import GeminiClient
+
+logger = logging.getLogger(__name__)
+
+CRITIC_PASS_THRESHOLD = 70
+MAX_REVISIONS = 2
+
+_CRITIC_SYSTEM_PROMPT = """You are a quality reviewer for B2B outreach messages targeting Australian SMBs.
+Score the draft on 5 criteria. Return ONLY valid JSON, no markdown."""
+
+_CRITERIA_RUBRIC = """
+Score the message on these 5 criteria:
+
+1. prospect_data (0-25): Does the message reference specific data about THIS prospect
+   (tech stack, GMB rating, paid keywords, VR findings)? Generic messages score 0.
+
+2. channel_format (0-20): Channel-appropriate format:
+   - email: 3 lines + subject line
+   - linkedin: under 300 chars, conversational
+   - sms: under 160 chars, clear value
+   - voice: natural cadence with question hooks
+
+3. cta_quality (0-20): Soft ask ("open to a chat?") scores high.
+   Hard sell ("buy now", "book a demo") scores 0. No CTA at all scores 5.
+
+4. no_hallucination (0-20): Message only cites data from the prospect brief.
+   Any fabricated statistics, made-up service offerings, or invented competitor
+   references = 0 on this criterion.
+
+5. australian_voice (0-15): Natural, casual, peer-to-peer. Not American corporate
+   ("I hope this finds you well", "synergy", "leverage"). Not too informal either.
+
+Return ONLY this JSON structure, no markdown:
+{
+  "score": <total 0-100>,
+  "criteria": {
+    "prospect_data": <0-25>,
+    "channel_format": <0-20>,
+    "cta_quality": <0-20>,
+    "no_hallucination": <0-20>,
+    "australian_voice": <0-15>
+  },
+  "feedback": "<one sentence: the most important thing to fix>"
+}
+"""
+
+
+def _build_critic_prompt(
+    channel: str,
+    body: str,
+    subject: str | None,
+    prospect_brief: str,
+) -> str:
+    """Build the scoring prompt with the 5 criteria rubric."""
+    lines = [
+        f"Channel: {channel}",
+    ]
+    if subject:
+        lines.append(f"Subject: {subject}")
+    lines += [
+        f"Message body:\n{body}",
+        "",
+        "Prospect brief (source of truth — only facts in here are valid to cite):",
+        prospect_brief,
+        "",
+        _CRITERIA_RUBRIC,
+    ]
+    return "\n".join(lines)
+
+
+async def critique_draft(
+    gemini: GeminiClient,
+    channel: str,
+    body: str,
+    subject: str | None,
+    prospect_brief: str,
+) -> dict[str, Any]:
+    """Score a draft message.
+
+    Returns:
+        {
+            "score": int,
+            "feedback": str,
+            "criteria": dict,
+            "pass": bool,
+        }
+    On timeout or error returns needs_review=True with critic_feedback="critic_timeout".
+    """
+    user_prompt = _build_critic_prompt(channel, body, subject, prospect_brief)
+
+    try:
+        result = await asyncio.wait_for(
+            gemini.comprehend(
+                system_prompt=_CRITIC_SYSTEM_PROMPT,
+                user_prompt=user_prompt,
+                enable_grounding=False,
+                enable_url_context=False,
+            ),
+            timeout=15.0,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("Critic timed out after 15s — shipping unreviewed")
+        return {
+            "score": 0,
+            "feedback": "critic_timeout",
+            "criteria": {},
+            "pass": False,
+            "needs_review": True,
+        }
+    except Exception as exc:
+        logger.warning("Critic error: %s — shipping unreviewed", exc)
+        return {
+            "score": 0,
+            "feedback": "critic_timeout",
+            "criteria": {},
+            "pass": False,
+            "needs_review": True,
+        }
+
+    content = result.get("content")
+
+    # content may come back as a dict (already parsed) or a string
+    if isinstance(content, str):
+        try:
+            content = json.loads(content)
+        except json.JSONDecodeError:
+            logger.warning("Critic returned unparseable JSON: %s", content[:200])
+            return {
+                "score": 0,
+                "feedback": "critic_parse_error",
+                "criteria": {},
+                "pass": False,
+                "needs_review": True,
+            }
+
+    if not isinstance(content, dict):
+        logger.warning("Critic returned unexpected type: %s", type(content))
+        return {
+            "score": 0,
+            "feedback": "critic_parse_error",
+            "criteria": {},
+            "pass": False,
+            "needs_review": True,
+        }
+
+    score = int(content.get("score", 0))
+    feedback = content.get("feedback", "")
+    criteria = content.get("criteria", {})
+
+    return {
+        "score": score,
+        "feedback": feedback,
+        "criteria": criteria,
+        "pass": score >= CRITIC_PASS_THRESHOLD,
+        "needs_review": False,
+    }
+
+
+async def critique_and_revise(
+    gemini: GeminiClient,
+    writer_fn,  # async callable(feedback: str) -> {"body": str, "subject": str | None}
+    channel: str,
+    prospect_brief: str,
+    initial_body: str,
+    initial_subject: str | None,
+) -> dict[str, Any]:
+    """Run the critic loop: score → revise if needed (max 2 retries) → return best draft.
+
+    Returns:
+        {
+            "body": str,
+            "subject": str | None,
+            "critic_score": int,
+            "critic_feedback": str,
+            "needs_review": bool,
+            "revision_count": int,
+        }
+    """
+    body = initial_body
+    subject = initial_subject
+    best: dict[str, Any] = {}
+    revision_count = 0
+
+    for attempt in range(MAX_REVISIONS + 1):
+        result = await critique_draft(gemini, channel, body, subject, prospect_brief)
+
+        # On critic failure (timeout/parse error) ship immediately
+        if result.get("needs_review") and result["score"] == 0 and attempt == 0:
+            return {
+                "body": body,
+                "subject": subject,
+                "critic_score": 0,
+                "critic_feedback": result["feedback"],
+                "needs_review": True,
+                "revision_count": 0,
+            }
+
+        # Track best scored draft
+        if not best or result["score"] > best.get("critic_score", -1):
+            best = {
+                "body": body,
+                "subject": subject,
+                "critic_score": result["score"],
+                "critic_feedback": result["feedback"],
+                "needs_review": result.get("needs_review", False),
+                "revision_count": revision_count,
+            }
+
+        if result["pass"]:
+            best["needs_review"] = False
+            return best
+
+        # Last attempt exhausted — ship best seen
+        if attempt == MAX_REVISIONS:
+            best["needs_review"] = True
+            return best
+
+        # Revise and try again
+        logger.info(
+            "Critic score %d < %d on attempt %d — requesting revision: %s",
+            result["score"],
+            CRITIC_PASS_THRESHOLD,
+            attempt + 1,
+            result["feedback"],
+        )
+        try:
+            revised = await writer_fn(result["feedback"])
+        except Exception as exc:
+            logger.warning("writer_fn failed on revision %d: %s", attempt + 1, exc)
+            best["needs_review"] = True
+            return best
+
+        body = revised.get("body", body)
+        subject = revised.get("subject", subject)
+        revision_count += 1
+
+    # Should not reach here
+    best["needs_review"] = True
+    return best

--- a/src/pipeline/stage_10_message_generator.py
+++ b/src/pipeline/stage_10_message_generator.py
@@ -19,6 +19,7 @@ from typing import Any
 import asyncpg
 
 from src.enrichment.signal_config import SignalConfigRepository
+from src.pipeline.stage_10_critic import critique_and_revise, CRITIC_PASS_THRESHOLD  # noqa: F401
 from src.utils.domain_blocklist import BLOCKED_DOMAINS
 
 logger = logging.getLogger(__name__)
@@ -94,10 +95,12 @@ class Stage10MessageGenerator:
         anthropic_client: Any,
         signal_repo: SignalConfigRepository,
         conn: asyncpg.Connection,
+        gemini_client: Any | None = None,
     ) -> None:
         self.ai = anthropic_client
         self.signal_repo = signal_repo
         self.conn = conn
+        self._gemini = gemini_client
         self._sonnet_sem = asyncio.Semaphore(SONNET_CONCURRENCY)
         self._haiku_sem = asyncio.Semaphore(HAIKU_CONCURRENCY)
         self._stats: dict[str, Any] = {
@@ -189,9 +192,47 @@ class Stage10MessageGenerator:
                 channel_messages.append(res)  # type: ignore[arg-type]
 
             if channel_messages:
-                await self._write_messages(
-                    business["id"], business["bdm_id"], channel_messages
-                )
+                if self._gemini is not None:
+                    # Critique and revise each channel message
+                    critic_results: dict[str, dict] = {}
+                    final_messages: list[tuple[str, str, str | None, dict[str, Any]]] = []
+                    for channel, body, subject, cost_info in channel_messages:
+                        async def _revise(
+                            feedback: str,
+                            ch: str = channel,
+                            biz: dict = business,
+                            pb: str = prospect_brief,
+                            ab: str = agency_brief,
+                        ) -> dict[str, Any]:
+                            revised_tuple = await self._generate_for_channel(
+                                ch, biz, pb,
+                                ab + "\n\nCRITIC FEEDBACK (fix this):\n" + feedback,
+                            )
+                            return {"body": revised_tuple[1], "subject": revised_tuple[2]}
+
+                        result = await critique_and_revise(
+                            gemini=self._gemini,
+                            writer_fn=_revise,
+                            channel=channel,
+                            prospect_brief=prospect_brief,
+                            initial_body=body,
+                            initial_subject=subject,
+                        )
+                        final_messages.append(
+                            (channel, result["body"], result["subject"], cost_info)
+                        )
+                        critic_results[channel] = {
+                            "score": result["critic_score"],
+                            "feedback": result["critic_feedback"],
+                            "needs_review": result["needs_review"],
+                        }
+                    await self._write_messages(
+                        business["id"], business["bdm_id"], final_messages, critic_results
+                    )
+                else:
+                    await self._write_messages(
+                        business["id"], business["bdm_id"], channel_messages
+                    )
                 messages_generated += len(channel_messages)
                 dms_processed += 1
 

--- a/src/pipeline/stage_10_message_generator.py
+++ b/src/pipeline/stage_10_message_generator.py
@@ -273,21 +273,38 @@ class Stage10MessageGenerator:
         bu_id: str,
         bdm_id: str,
         channel_messages: list[tuple[str, str, str | None, dict[str, Any]]],
+        critic_results: dict[str, dict] | None = None,
     ) -> None:
-        """Insert dm_messages rows and advance pipeline_stage to 10."""
+        """Insert dm_messages rows and advance pipeline_stage to 10.
+
+        Args:
+            bu_id: Business universe ID.
+            bdm_id: Business decision-maker ID.
+            channel_messages: List of (channel, body, subject, cost_info) tuples.
+            critic_results: Optional dict keyed by channel name containing
+                {"score": int, "feedback": str, "needs_review": bool}.
+                When None, critic columns default to NULL/FALSE.
+        """
         now = datetime.now(UTC)
         for channel, body, subject, cost_info in channel_messages:
             model_name = SONNET_MODEL if channel == "email" else HAIKU_MODEL
+            critic = (critic_results or {}).get(channel, {})
+            critic_score = critic.get("score")
+            critic_feedback = critic.get("feedback")
+            needs_review = critic.get("needs_review", False)
             await self.conn.execute(
                 """
                 INSERT INTO dm_messages
                     (business_universe_id, business_decision_makers_id, channel,
-                     subject, body, model, cost_usd, status, generated_at)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, 'draft', $8)
+                     subject, body, model, cost_usd, status, generated_at,
+                     critic_score, critic_feedback, needs_review)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, 'draft', $8,
+                        $9, $10, $11)
                 """,
                 bu_id, bdm_id, channel,
                 subject, body, model_name,
                 cost_info["cost_usd"], now,
+                critic_score, critic_feedback, needs_review,
             )
 
         await self.conn.execute(

--- a/supabase/migrations/20260421_dm_messages_critic_columns.sql
+++ b/supabase/migrations/20260421_dm_messages_critic_columns.sql
@@ -1,0 +1,4 @@
+-- Add critic columns to dm_messages for critic/writer architecture
+ALTER TABLE dm_messages ADD COLUMN IF NOT EXISTS critic_score INTEGER;
+ALTER TABLE dm_messages ADD COLUMN IF NOT EXISTS critic_feedback TEXT;
+ALTER TABLE dm_messages ADD COLUMN IF NOT EXISTS needs_review BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- **Writer:** Anthropic (Sonnet for email, Haiku for LinkedIn/SMS/voice) — unchanged
- **Critic:** New Gemini Flash quality scoring module (`src/pipeline/stage_10_critic.py`)
- **Loop:** Write → critique → revise (max 2 retries) → ship best draft
- **HARD-FAIL:** Hallucinated claims → score=0, no retry with same frame
- **Fallback:** Gemini timeout (>15s) → ship draft unreviewed with `needs_review=TRUE`
- **Migration:** 3 new columns on `dm_messages`: `critic_score`, `critic_feedback`, `needs_review`
- **Backward compat:** When `gemini_client=None`, critic is skipped entirely

### Critic rubric (6 fit-based criteria, total 100):
1. prospect_data (0-25): Uses specific prospect data, not generic
2. channel_format (0-20): Channel-appropriate format/length
3. cta_quality (0-20): Soft ask, not hard sell
4. no_hallucination (0-20): HARD-FAIL at 0 — only cite data from brief
5. australian_voice (0-10): AU casual, not American corporate
6. hook_relevance (0-5): Opening hooks to specific signal

### Files changed:
- `src/pipeline/stage_10_critic.py` — NEW: critic module
- `src/pipeline/stage_10_message_generator.py` — critic loop wired in run()
- `src/orchestration/flows/stage_9_10_flow.py` — GeminiClient passed to Stage10
- `supabase/migrations/20260421_dm_messages_critic_columns.sql` — 3 new columns

## Test plan
- [ ] Import check passes for both modules
- [ ] 91 tests pass (1 pre-existing failure: outreach_channels edge case)
- [ ] P5 Step 3: ≥1 card with critic_score populated
- [ ] Aiden peer-review: rubric is fit-based, retry cap is hard, feedback loop injects critic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>