### PR TITLE
fix: AGENCY-PROFILE-TRUTH-AUDIT — remove fabricated data, require real agency profile

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -310,6 +310,14 @@ class APIError(IntegrationError):
         self.code = "API_ERROR"
 
 
+class AgencyProfileMissingError(IntegrationError):
+    """Raised when agency_profile is missing or incomplete for outreach generation."""
+
+    def __init__(self, message: str = "agency_profile is required for outreach generation"):
+        super().__init__("agency_profile", message)
+        self.code = "AGENCY_PROFILE_MISSING"
+
+
 class WebhookError(IntegrationError):
     """Webhook delivery failed."""
 

--- a/src/orchestration/flows/pipeline_f_master_flow.py
+++ b/src/orchestration/flows/pipeline_f_master_flow.py
@@ -35,6 +35,16 @@ async def _init_jsonb_codec(conn):
     )
 
 
+# ── Keiracom agency profile — ground truth, no fabricated claims ─────────────
+# Temporary until CRM/onboarding path reads from agency_service_profile table.
+# case_study intentionally omitted — Dave is pre-revenue, no clients yet.
+_KEIRACOM_PROFILE = {
+    "name": "Keiracom",
+    "services": ["SEO", "Google Ads", "Facebook Ads", "Website Development"],
+    "tone": "professional, direct, results-focused. Australian casual — not American corporate.",
+    "founder_name": "Dave",
+}
+
 # ── Budget / gate constants ──────────────────────────────────────────────────
 _USD_TO_AUD = 1.55
 _PASS_THRESHOLD = 70  # dm_messages quality gate (email_scoring_gate.PASS_THRESHOLD)
@@ -528,6 +538,7 @@ async def pipeline_f_master_flow(
                 bdm_ids=bdm_ids,
                 batch_size=len(bdm_ids),
                 budget_cap_usd=min(5.0, budget_cap_usd * 0.3),
+                agency_profile=_KEIRACOM_PROFILE,
                 dry_run=False,
             )
         except Exception as _s910_exc:

--- a/src/orchestration/flows/stage_9_10_flow.py
+++ b/src/orchestration/flows/stage_9_10_flow.py
@@ -56,17 +56,6 @@ async def _init_jsonb_codec(conn):
     )
 
 
-DEFAULT_AGENCY = {
-    "name": "Keiracom",
-    "services": ["SEO", "Google Ads", "Facebook Ads", "Website Development"],
-    "tone": "professional, direct, results-focused. Australian casual — not American corporate.",
-    "founder_name": "Dave",
-    "case_study": (
-        "Helped a Bondi dental practice increase new patient bookings by 40% in 3 months "
-        "through local SEO and Google Ads."
-    ),
-}
-
 _DEDUP_SQL = """
 WITH deduped AS (
     SELECT DISTINCT ON (bdm.linkedin_url)

--- a/src/orchestration/flows/stage_9_10_flow.py
+++ b/src/orchestration/flows/stage_9_10_flow.py
@@ -163,7 +163,7 @@ async def stage_9_10_pipeline(
     batch_size: int = 25,
     budget_cap_usd: float = 5.0,
     vertical_slug: str = "marketing_agency",
-    agency_profile: dict,
+    agency_profile: dict | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """

--- a/src/orchestration/flows/stage_9_10_flow.py
+++ b/src/orchestration/flows/stage_9_10_flow.py
@@ -42,6 +42,9 @@ from src.pipeline.stage_9_vulnerability_enrichment import Stage9VulnerabilityEnr
 from src.pipeline.stage_10_message_generator import Stage10MessageGenerator
 from src.enrichment.signal_config import SignalConfigRepository
 from src.prefect_utils.hooks import on_failure_hook
+from src.exceptions import AgencyProfileMissingError
+
+_REQUIRED_AGENCY_FIELDS = {"name", "services", "tone", "founder_name"}
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +134,7 @@ async def run_stage_10(
     ai = AnthropicClient()
     signal_repo = SignalConfigRepository(pool)
     gemini = GeminiClient(api_key=os.environ.get("GEMINI_API_KEY"))
-    gen = Stage10MessageGenerator(ai, signal_repo, pool, gemini_client=gemini)
+    gen = Stage10MessageGenerator(ai, signal_repo, pool, gemini_client=gemini, agency_profile=agency_profile)
     return await gen.run(vertical_slug, agency_profile, batch_size=len(bdm_ids))
 
 
@@ -160,7 +163,7 @@ async def stage_9_10_pipeline(
     batch_size: int = 25,
     budget_cap_usd: float = 5.0,
     vertical_slug: str = "marketing_agency",
-    agency_profile: dict | None = None,
+    agency_profile: dict,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """
@@ -172,9 +175,15 @@ async def stage_9_10_pipeline(
     batch_size:     Max BDMs to pull when auto-selecting (ignored when bdm_ids provided).
     budget_cap_usd: Hard spend ceiling for the run.
     vertical_slug:  Signal config vertical passed to Stage 10.
-    agency_profile: Agency context for message generation (defaults to Keiracom).
+    agency_profile: Agency context for message generation. Required — no default fallback.
     dry_run:        If True, select BDMs then stop — no enrichment or generation.
     """
+    if not agency_profile or not isinstance(agency_profile, dict):
+        raise AgencyProfileMissingError("agency_profile is required for outreach generation")
+    missing = _REQUIRED_AGENCY_FIELDS - set(agency_profile.keys())
+    if missing:
+        raise AgencyProfileMissingError(f"agency_profile missing required fields: {missing}")
+
     flow_logger = _logger()
 
     db_url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
@@ -249,8 +258,7 @@ async def stage_9_10_pipeline(
             )
 
         # 6. Stage 10
-        effective_agency = agency_profile or DEFAULT_AGENCY
-        s10_result = await run_stage_10(pool, selected, vertical_slug, effective_agency)
+        s10_result = await run_stage_10(pool, selected, vertical_slug, agency_profile)
         flow_logger.info("Stage 10 complete: %s", s10_result)
 
         # 7. Verify Stage 10

--- a/src/pipeline/stage_10_message_generator.py
+++ b/src/pipeline/stage_10_message_generator.py
@@ -96,11 +96,13 @@ class Stage10MessageGenerator:
         signal_repo: SignalConfigRepository,
         conn: asyncpg.Connection,
         gemini_client: Any | None = None,
+        agency_profile: dict[str, Any] | None = None,
     ) -> None:
         self.ai = anthropic_client
         self.signal_repo = signal_repo
         self.conn = conn
         self._gemini = gemini_client
+        self._agency_profile = agency_profile
         self._sonnet_sem = asyncio.Semaphore(SONNET_CONCURRENCY)
         self._haiku_sem = asyncio.Semaphore(HAIKU_CONCURRENCY)
         self._stats: dict[str, Any] = {

--- a/tests/fixtures/agency_profile_fixture.py
+++ b/tests/fixtures/agency_profile_fixture.py
@@ -1,0 +1,9 @@
+"""Test-only agency profile fixture. NEVER import from production code."""
+
+TEST_AGENCY_PROFILE = {
+    "name": "Test Agency",
+    "services": ["SEO", "Google Ads"],
+    "tone": "professional, direct. Australian casual.",
+    "founder_name": "Test Founder",
+    "case_study": "Test case study for unit tests only.",
+}


### PR DESCRIPTION
## Summary

- **T1:** Delete `DEFAULT_AGENCY` (contained fabricated Bondi dental case study) from `stage_9_10_flow.py`. Move to `tests/fixtures/agency_profile_fixture.py` as `TEST_AGENCY_PROFILE` with a clear "NEVER import from production code" docstring.
- **T2:** Add `AgencyProfileMissingError` to `src/exceptions.py`. Harden `stage_9_10_pipeline` with runtime validation — raises `AgencyProfileMissingError` if `agency_profile` is missing or missing required fields (`name`, `services`, `tone`, `founder_name`). Wire `agency_profile` into `Stage10MessageGenerator.__init__` as `self._agency_profile` for T4 critic integration. `_build_agency_brief` already omits `case_study` if None — no change needed.
- **T3:** Add `_KEIRACOM_PROFILE` to `pipeline_f_master_flow.py` — truthful, no fabricated case study. Pass to `stage_9_10_pipeline()`. Note: `agency_service_profile` Supabase table exists (migration 062) — CRM path is future work.

## Verification

- `grep -rn "DEFAULT_AGENCY" src/` → ZERO results
- `grep -rn "TEST_AGENCY_PROFILE" src/` → ZERO results
- `grep -rn "Bondi" src/` → ZERO results
- `python3 -c "from src.orchestration.flows.stage_9_10_flow import stage_9_10_pipeline; print('OK')"` → OK
- `pytest tests/ -x -q` → 1 pre-existing failure in `test_memory.py` (unrelated), 91 passed

## Test plan

- [ ] Confirm `grep -rn "DEFAULT_AGENCY" src/` returns zero
- [ ] Confirm `grep -rn "Bondi" src/` returns zero
- [ ] Confirm import of `stage_9_10_pipeline` succeeds
- [ ] Confirm calling `stage_9_10_pipeline()` without `agency_profile` raises `AgencyProfileMissingError`
- [ ] Confirm `_KEIRACOM_PROFILE` is wired in master flow call

🤖 Generated with [Claude Code](https://claude.com/claude-code)