### PR TITLE
[AIDEN] feat(clones): Rule 7 enforcer + CLONE_LEARNINGS template + round-trip test

### DIFF
--- a/docs/clones/CLONE_LEARNINGS.template.md
+++ b/docs/clones/CLONE_LEARNINGS.template.md
@@ -1,0 +1,42 @@
+# CLONE_LEARNINGS.md — ORION working journal
+
+Per-clone working journal. Persists across `/clear` context resets between tasks.
+Complements `public.agent_memories` (tagged `callsign=orion`) for cross-clone
+pattern sharing.
+
+## Format
+
+One entry per learning. Newest at top. Each entry:
+
+```
+### <YYYY-MM-DD> — <one-line summary>
+**Task:** <task-ref>
+**Context:** <what you were doing>
+**Learning:** <the pattern — what to do / what to avoid>
+**Why:** <root cause or rationale — makes the rule judgment-friendly>
+```
+
+## When to write
+
+- After a task completes, if you encountered a non-obvious failure mode or
+  discovered a pattern that future clone tasks should respect.
+- After parent peer-correction, when the correction reveals a rule you didn't know.
+- After a stall you recovered from, documenting what caused it and how to avoid.
+
+## When NOT to write
+
+- Information already in `CLAUDE.md` or `~/.claude/CLAUDE.md` (don't duplicate).
+- Purely task-specific details the next task won't hit.
+- Facts derivable from git log, code, or the project docs.
+
+## Cross-clone sharing
+
+For patterns that would help ATLAS too, additionally write to
+`public.agent_memories` via MCP bridge tagged `callsign=orion, source_type=pattern`.
+Keep the one-liner summary here; the full pattern lives in memory.
+
+---
+
+## Entries
+
+<!-- Newest first. No entries yet. -->

--- a/scripts/round_trip_clone_test.py
+++ b/scripts/round_trip_clone_test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""round_trip_clone_test.py — end-to-end smoke test for clone dispatch flow.
+
+Verifies the C1→C6 clone communication protocol works end-to-end:
+ 1. Parent writes a trivial task brief to clone inbox.
+ 2. Relay-watcher picks up the brief and (in real use) injects into clone tmux.
+ 3. Clone writes result to outbox.
+ 4. Clone-to-parent relay-watcher picks up outbox and injects into parent tmux.
+
+This harness does NOT exercise the clone's Claude Code session itself — that
+requires a live clone ready to receive dispatch. It exercises the FILE-LEVEL
+plumbing: inbox write → relay-watcher detects → (clone would process) → outbox
+write → parent-side relay-watcher detects → tmux injection (tested via
+simulated outbox write).
+
+Usage:
+    python scripts/round_trip_clone_test.py atlas
+    python scripts/round_trip_clone_test.py orion
+
+Exit 0 on pass, non-zero on fail. Prints verbatim evidence per step.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+CLONE_CONFIG = {
+    "atlas": {
+        "parent": "elliot",
+        "worktree": "/home/elliotbot/clawd/Agency_OS-atlas",
+        "relay_dir": "/tmp/telegram-relay-atlas",
+        "systemd_unit": "atlas-relay-watcher.service",
+    },
+    "orion": {
+        "parent": "aiden",
+        "worktree": "/home/elliotbot/clawd/Agency_OS-orion",
+        "relay_dir": "/tmp/telegram-relay-orion",
+        "systemd_unit": "orion-relay-watcher.service",
+    },
+}
+
+
+def check(label: str, ok: bool, detail: str = "") -> None:
+    tag = "PASS" if ok else "FAIL"
+    print(f"  [{tag}] {label}{' — ' + detail if detail else ''}")
+    if not ok:
+        sys.exit(2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("clone", choices=list(CLONE_CONFIG))
+    args = parser.parse_args()
+    cfg = CLONE_CONFIG[args.clone]
+    clone = args.clone
+
+    print(f"=== round-trip test: {clone.upper()} (parent: {cfg['parent']}) ===")
+
+    # 1. Scaffold presence
+    worktree = Path(cfg["worktree"])
+    check("worktree exists", worktree.is_dir(), str(worktree))
+    check("IDENTITY.md present", (worktree / "IDENTITY.md").is_file())
+    check("CLONE_LEARNINGS.md present", (worktree / "CLONE_LEARNINGS.md").is_file())
+
+    relay = Path(cfg["relay_dir"])
+    for sub in ("inbox", "outbox", "processed"):
+        check(f"relay {sub} dir", (relay / sub).is_dir())
+
+    # 2. Systemd service active
+    result = subprocess.run(
+        ["systemctl", "--user", "is-active", cfg["systemd_unit"]],
+        capture_output=True, text=True,
+    )
+    check(
+        f"{cfg['systemd_unit']} active",
+        result.stdout.strip() == "active",
+        f"status={result.stdout.strip()}",
+    )
+
+    # 3. Inbox write — simulate parent dispatch
+    test_id = f"rt_{int(time.time())}_{uuid.uuid4().hex[:6]}"
+    inbox_file = relay / "inbox" / f"{test_id}.json"
+    inbox_file.write_text(json.dumps({
+        "id": test_id,
+        "type": "text",
+        "text": f"[ROUND-TRIP-TEST] Smoke probe for {clone}. No action required.",
+        "sender": "test-harness",
+    }))
+    check("inbox write", inbox_file.exists(), str(inbox_file))
+
+    # 4. Outbox write — simulate clone returning result
+    outbox_file = relay / "outbox" / f"{test_id}_result.txt"
+    outbox_file.write_text(f"[{clone.upper()}] round-trip test {test_id} ack")
+    check("outbox write", outbox_file.exists(), str(outbox_file))
+
+    # 5. Relay watcher processes outbox — give watcher time to move file
+    for _ in range(10):
+        time.sleep(0.5)
+        if not outbox_file.exists():
+            break
+    processed = relay / "processed" / outbox_file.name
+    check(
+        "relay-watcher moved outbox → processed",
+        processed.exists(),
+        f"{processed} (watcher picked up within 5s)",
+    )
+
+    # Cleanup test inbox artefact (outbox already moved by watcher)
+    try:
+        inbox_file.unlink()
+    except FileNotFoundError:
+        pass
+
+    print(f"=== {clone.upper()} round-trip: PASS ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/telegram_bot/enforcer_bot.py
+++ b/src/telegram_bot/enforcer_bot.py
@@ -41,7 +41,7 @@ RULES_PROMPT = """You are a governance enforcement bot for a multi-agent develop
 
 You monitor group chat messages between two AI agents (Elliot and Aiden) and their human manager (Dave).
 
-CHECK these 6 rules against the CURRENT MESSAGE in context of the RECENT MESSAGES:
+CHECK these 7 rules against the CURRENT MESSAGE in context of the RECENT MESSAGES:
 
 Rule 1 — CONCUR-BEFORE-SUMMARY: If the current message is a bot addressing Dave with a summary, recommendation, or decision (look for "Dave —", "Dave,", "your call", "here's the plan", "here's what"), check if the OTHER bot posted explicit concurrence ("concur", "concur confirmed", "CONCUR") in recent messages OR in GOVERNANCE_EVENTS (last_concur_elliot / last_concur_aiden) for the same topic. Missing concurrence = VIOLATION. NOTE: /stage0 gating is handled externally in code — evaluate Rule 1 on its merits and report if concurrence is missing.
 
@@ -54,6 +54,8 @@ Rule 4 — NO-UNREVIEWED-MAIN-PUSH: If the current message mentions pushing dire
 Rule 5 — SHARED-FILE-CLAIM: If the current message mentions editing memory_listener.py, chat_bot.py, store.py, listener_discernment.py, or any CLAUDE.md file, check if "[CLAIM:" was posted. Missing claim = VIOLATION.
 
 Rule 6 — SAVE-CLAIM-REQUIRES-PROOF: If the current message claims a save was completed ("state saved", "4-store save complete", "ceo_memory updated", "MANUAL updated", "Drive mirrored", "daily_log written", "stores written"), check that the message includes SPECIFIC EVIDENCE for EACH store claimed. Evidence means: commit hashes for MANUAL, SQL confirmation for ceo_memory, byte count or success message for Drive mirror, query result for daily_log. A bot saying "all stores written ✓" without showing the actual outputs for each store = VIOLATION. The claim must be backed by verifiable proof in recent messages, not just checkmarks.
+
+Rule 7 — CLONE-DIRECT-GROUP-POST: If the current message's bot/sender prefix is a CLONE callsign (ATLAS, ORION, or any `[<callsign>]` tag other than ELLIOT, AIDEN, DAVE, SCOUT, ENFORCER), flag as VIOLATION — clones are prohibited from posting to group per C3 Prime-Only Clone Channel. Clone output must go only to parent inbox via relay-watcher push. Parent surfaces clone artefacts to group via `[CONSUMED:<parent>] <path> + verbatim excerpt` post. Seeing a clone callsign in group means either (a) the clone violated C3 directly, or (b) a parent wrote under the wrong prefix — either way, flag.
 
 RESPOND WITH ONLY THIS JSON:
 {
@@ -83,6 +85,7 @@ TRIGGER_PATTERNS = [
     "memory_listener.py", "chat_bot.py", "store.py", "listener_discernment.py", "claude.md",
     "state saved", "ceo_memory updated", "manual updated", "drive mirror", "daily_log written",
     "stores written", "store save complete", "session closed",
+    "[atlas]", "[orion]",
 ]
 
 


### PR DESCRIPTION
## Summary

Aiden-side of the clone architecture directive. Complements Elliot's already-merged work on tier registry + C1 dispatch wrapper (commit bd6c573b).

- **Enforcer Rule 7 (CLONE-DIRECT-GROUP-POST)**: extends `RULES_PROMPT` in `src/telegram_bot/enforcer_bot.py` to flag any group-chat message posted under a clone callsign prefix (`[ATLAS]`, `[ORION]`, etc). Enforces C3 Prime-Only Clone Channel at the TG visibility layer. Scope-trimmed from my original 4-rule proposal — Rules 7/8/10 deferred to a follow-up enforcer architecture extension (public DISPATCH/CONSUMED tag tracking).
- **CLONE_LEARNINGS template**: `docs/clones/CLONE_LEARNINGS.template.md` — canonical per-clone working journal template. Each clone copies to its worktree on scaffold. Persists across `/clear` resets. Complements `public.agent_memories` (tagged `callsign=<clone>`) for cross-clone pattern sharing.
- **Round-trip test harness**: `scripts/round_trip_clone_test.py` — end-to-end smoke test verifying worktree + IDENTITY.md + CLONE_LEARNINGS.md + relay dirs + systemd service + inbox/outbox plumbing. Runs via `python scripts/round_trip_clone_test.py {atlas|orion}`. Exit 0 on pass.

## Clones scaffolded (infra, not in this PR)

- **ATLAS** (Elliot's): worktree at `/home/elliotbot/clawd/Agency_OS-atlas/`, branch `atlas/main`, systemd `atlas-relay-watcher.service` active
- **ORION** (Aiden's): worktree at `/home/elliotbot/clawd/Agency_OS-orion/`, branch `orion/main`, systemd `orion-relay-watcher.service` active

Clone worktree files (IDENTITY.md, CLONE_LEARNINGS.md) live on `atlas/main` and `orion/main` branches — these never merge to main per clone-branch-isolation convention (C6).

## Test plan
- [x] `python scripts/round_trip_clone_test.py orion` → 10/10 PASS
- [x] `python scripts/round_trip_clone_test.py atlas` → 10/10 PASS
- [x] `[ORION]` tag injects into aiden tmux via relay-watcher (C3 push confirmed)
- [x] `[ATLAS]` tag injects into elliottbot tmux via relay-watcher (C3 push confirmed)
- [x] Enforcer Rule 7 added; will catch any future [ATLAS]/[ORION] group-chat posts as violations
- [ ] Peer review by ELLIOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)