### PR TITLE
[AIDEN] feat(clones): Rule 7 + learnings + round-trip test + HMAC signing + stale callback cleanup

### DIFF
--- a/scripts/cleanup_stale_callbacks.py
+++ b/scripts/cleanup_stale_callbacks.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""cleanup_stale_callbacks.py — delete failed callbacks older than N days.
+
+Addresses the C2 Prefect audit WARN finding (38 stale callbacks, oldest 18
+days) by running a bounded DELETE. Safe-mode default: dry-run prints the
+count that WOULD be deleted. Pass --execute to perform the delete.
+
+Usage:
+    python scripts/cleanup_stale_callbacks.py            # dry-run
+    python scripts/cleanup_stale_callbacks.py --execute  # actual delete
+    python scripts/cleanup_stale_callbacks.py --days 14  # custom age threshold
+
+Exit 0 on success (always prints count). Exit 2 on SQL error.
+
+Scope guards:
+- Only deletes rows where status = 'failed' (successful or pending rows left alone).
+- Minimum age threshold: 7 days default, --days N to adjust. Refuses 0 or negative.
+- Dry-run by default. Must pass --execute explicitly to mutate the table.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+
+def _load_env(env_path: str) -> None:
+    if not os.path.exists(env_path):
+        return
+    for line in Path(env_path).read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+async def run(days: int, execute: bool) -> int:
+    import asyncpg
+    db_url = os.environ.get("DATABASE_URL", "").replace("postgresql+asyncpg://", "postgresql://")
+    if not db_url:
+        print("ERROR: DATABASE_URL not set", file=sys.stderr)
+        return 2
+
+    conn = await asyncpg.connect(db_url, statement_cache_size=0)
+    try:
+        count_sql = (
+            "SELECT COUNT(*) FROM public.evo_flow_callbacks "
+            "WHERE status = 'failed' "
+            f"AND created_at < NOW() - INTERVAL '{days} days'"
+        )
+        stale_count = await conn.fetchval(count_sql)
+        print(f"stale_failed_callbacks_older_than_{days}d={stale_count}")
+
+        if not execute:
+            print("(dry-run — pass --execute to actually delete)")
+            return 0
+
+        del_sql = (
+            "DELETE FROM public.evo_flow_callbacks "
+            "WHERE status = 'failed' "
+            f"AND created_at < NOW() - INTERVAL '{days} days'"
+        )
+        result = await conn.execute(del_sql)
+        # asyncpg returns "DELETE N" string
+        deleted = int(result.split()[-1]) if result.startswith("DELETE") else -1
+        print(f"deleted={deleted}")
+        return 0
+    finally:
+        await conn.close()
+
+
+def main() -> int:
+    _load_env("/home/elliotbot/.config/agency-os/.env")
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--days", type=int, default=7)
+    parser.add_argument("--execute", action="store_true")
+    args = parser.parse_args()
+
+    if args.days <= 0:
+        print("ERROR: --days must be positive", file=sys.stderr)
+        return 2
+
+    return asyncio.run(run(args.days, args.execute))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sign_dispatch.py
+++ b/scripts/sign_dispatch.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Sign a dispatch payload and write it to a clone inbox.
+
+Helper for parent bots (or any authorised writer) to create HMAC-signed
+dispatch files that pass verification at the inbox relay-watcher.
+
+Usage:
+    python scripts/sign_dispatch.py --target atlas --type task_dispatch \\
+        --from elliot --brief "fix H1 persistence" \\
+        [--max-task-minutes 30] [--task-ref B4P2-T1]
+
+Requires INBOX_HMAC_SECRET in env (auto-loaded from ~/.config/agency-os/.env).
+
+Exit 0 on success, prints the written path. Exit 2 on missing secret or
+unknown target.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from security.inbox_hmac import sign  # noqa: E402
+
+
+VALID_TARGETS = {
+    "atlas": "/tmp/telegram-relay-atlas/inbox",
+    "orion": "/tmp/telegram-relay-orion/inbox",
+}
+
+
+def _load_env(env_path: str) -> None:
+    if not os.path.exists(env_path):
+        return
+    for line in Path(env_path).read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+def main() -> int:
+    _load_env("/home/elliotbot/.config/agency-os/.env")
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True, choices=list(VALID_TARGETS))
+    parser.add_argument("--type", default="task_dispatch")
+    parser.add_argument("--from", dest="sender", required=True)
+    parser.add_argument("--brief", required=True)
+    parser.add_argument("--max-task-minutes", type=int, default=30)
+    parser.add_argument("--task-ref", default=None)
+    args = parser.parse_args()
+
+    if not os.environ.get("INBOX_HMAC_SECRET"):
+        print("ERROR: INBOX_HMAC_SECRET not set in env (expected in ~/.config/agency-os/.env)", file=sys.stderr)
+        return 2
+
+    task_ref = args.task_ref or f"task_{int(time.time())}_{uuid.uuid4().hex[:6]}"
+    payload = {
+        "id": task_ref,
+        "type": args.type,
+        "from": args.sender,
+        "target": args.target,
+        "brief": args.brief,
+        "max_task_minutes": args.max_task_minutes,
+        "created_at": int(time.time()),
+    }
+    signed = sign(payload)
+
+    inbox = Path(VALID_TARGETS[args.target])
+    inbox.mkdir(parents=True, exist_ok=True)
+    out_path = inbox / f"{task_ref}.json"
+    out_path.write_text(json.dumps(signed))
+
+    print(str(out_path))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security utilities for Agency OS."""

--- a/src/security/inbox_hmac.py
+++ b/src/security/inbox_hmac.py
@@ -1,0 +1,106 @@
+"""HMAC sign/verify for clone inbox/outbox dispatch files.
+
+Closes the trust gap in `/tmp/telegram-relay-*/inbox/` and `outbox/`: the
+relay-watchers `tmux send-keys` any JSON they find. Without authentication,
+any process running as the `elliotbot` user can write a fake dispatch that
+gets injected into a parent or clone tmux. HMAC signing + verification makes
+tampered or unsigned files detectable.
+
+Threat model (Dave-ratified per B3 spec refinement #7):
+    This is TAMPER DETECTION against corrupted or accidentally-written files,
+    NOT authentication against a malicious insider with shell access. Anyone
+    who can read the shared secret from ~/.config/agency-os/.env can also
+    sign. Per-writer keys in Supabase Vault is the follow-up.
+
+Payload contract:
+    Dispatch files are JSON objects. Before HMAC, callers populate all task
+    fields. `sign(payload, secret)` adds an `hmac` key whose value is
+    HMAC-SHA256 over the canonical JSON of the payload (excluding `hmac`
+    itself). `verify(path, secret)` re-computes the HMAC from the file on
+    disk and returns True only if it matches the stored `hmac`.
+
+Canonical form (deterministic across writers + readers):
+    json.dumps(payload_without_hmac, sort_keys=True, separators=(",", ":"))
+
+Environment:
+    `INBOX_HMAC_SECRET` — shared secret, read from `~/.config/agency-os/.env`.
+    Treat as secret-equivalent to TELEGRAM_BOT_TOKEN. Not to be logged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_ENCODING = "utf-8"
+_HMAC_KEY = "hmac"
+
+
+def _canonical_bytes(payload: dict) -> bytes:
+    """Deterministic serialisation over everything except the `hmac` field."""
+    filtered = {k: v for k, v in payload.items() if k != _HMAC_KEY}
+    return json.dumps(filtered, sort_keys=True, separators=(",", ":")).encode(_ENCODING)
+
+
+def _compute(payload: dict, secret: str) -> str:
+    return hmac.new(secret.encode(_ENCODING), _canonical_bytes(payload), hashlib.sha256).hexdigest()
+
+
+def sign(payload: dict, secret: str | None = None) -> dict:
+    """Return the payload with an `hmac` field added.
+
+    The input payload is not mutated — a new dict is returned. If `secret`
+    is None, falls back to the `INBOX_HMAC_SECRET` env var. Raises
+    RuntimeError if no secret is available.
+    """
+    secret = secret or os.environ.get("INBOX_HMAC_SECRET")
+    if not secret:
+        raise RuntimeError("INBOX_HMAC_SECRET not set and no secret passed to sign()")
+    signed = dict(payload)
+    signed[_HMAC_KEY] = _compute(payload, secret)
+    return signed
+
+
+def verify(path: str | Path, secret: str | None = None) -> tuple[bool, str]:
+    """Read `path`, recompute HMAC, compare with stored value.
+
+    Returns (is_valid, reason). On mismatch, reason explains why — logs at
+    WARNING level. Callers should log + skip-inject on (False, _).
+    """
+    secret = secret or os.environ.get("INBOX_HMAC_SECRET")
+    if not secret:
+        return False, "INBOX_HMAC_SECRET not set"
+
+    p = Path(path)
+    try:
+        raw = p.read_text(encoding=_ENCODING)
+    except OSError as exc:
+        return False, f"read failed: {exc}"
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return False, f"not valid JSON: {exc}"
+
+    if not isinstance(payload, dict):
+        return False, "payload is not a JSON object"
+
+    stored = payload.get(_HMAC_KEY)
+    if not isinstance(stored, str):
+        return False, f"{_HMAC_KEY} field missing or not a string (unsigned file)"
+
+    expected = _compute(payload, secret)
+    if not hmac.compare_digest(stored, expected):
+        logger.warning("HMAC mismatch for %s — computed %s, stored %s", p, expected[:12], stored[:12])
+        return False, "HMAC mismatch (tampered or signed with different secret)"
+
+    return True, "ok"
+
+
+__all__ = ["sign", "verify"]


### PR DESCRIPTION
## Summary

Aiden-side of B4 Part 2 (clone architecture activation). Complements Elliot's 75e12316 (T3 digest + T1 auto-fix + probe 5/7 + enforcer iter-3).

4 commits:

- **520f51b0** — Enforcer Rule 7 (CLONE-DIRECT-GROUP-POST): flags any `[ATLAS]`/`[ORION]` callsign prefix in group chat as C3 violation.
- **53c77859** — `docs/clones/CLONE_LEARNINGS.template.md` (per-clone working journal template) + `scripts/round_trip_clone_test.py` (end-to-end smoke test, passed 10/10 for both ATLAS and ORION).
- **137e02ac** — `[DIRECT-BUILD:AIDEN]` HMAC signing: `src/security/inbox_hmac.py` (sign/verify with HMAC-SHA256 over canonical JSON, `hmac.compare_digest` for timing-attack safety) + `scripts/sign_dispatch.py` (CLI to produce signed dispatch files). Smoke test 3/3 PASS (signed-valid, tampered-invalid, unsigned-invalid).
- **e6077900** — `[DIRECT-BUILD:AIDEN]` `scripts/cleanup_stale_callbacks.py`: safe-mode dry-run DELETE for failed evo_flow_callbacks older than N days. Defaults to 7 days. Dry-run reports 30 stale rows. `--execute` is Dave-gated per ratified "big things" governance (irreversible actions).

## DIRECT-BUILD governance debt

Two items above tagged `[DIRECT-BUILD:AIDEN]` — ATLAS/ORION scaffolded but not yet activated (tmux + Claude Code launch pending from Dave), so built directly. Future identical work goes through clone dispatch once activated.

## Activation state (not in this PR)

- Worktrees ✓, outbox relay-watchers active ✓, inbox watchers enabled ✓ (Elliot's prior work)
- Clone tmux sessions + Claude Code processes — Dave's action
- HMAC verify hook in inbox watchers — one-line follow-up once clones live

## Test plan
- [x] `python scripts/round_trip_clone_test.py orion` → 10/10 PASS
- [x] `python scripts/round_trip_clone_test.py atlas` → 10/10 PASS
- [x] HMAC sign/verify smoke — valid signed, tampered, unsigned (3/3 correct)
- [x] `cleanup_stale_callbacks.py` dry-run — 30 rows reported, no mutation verified via independent SQL count
- [ ] Peer review by ELLIOT
- [ ] HMAC verify hook integrated into inbox watchers (follow-up after activation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)