### PR TITLE
[ATLAS] Phase 2.1 — ProspectDrawer + Activity route

### DIFF
--- a/frontend/app/dashboard/activity/page.tsx
+++ b/frontend/app/dashboard/activity/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+/**
+ * FILE: frontend/app/dashboard/activity/page.tsx
+ * PURPOSE: Full-page activity timeline route
+ * PHASE: PHASE-2.1-PROSPECT-DRAWER-FEED
+ */
+
+import Link from "next/link";
+import { AppShell } from "@/components/layout/AppShell";
+import { ActivityFeedFull } from "@/components/dashboard/ActivityFeedFull";
+
+export default function ActivityPage() {
+  return (
+    <AppShell pageTitle="Activity">
+      <div className="min-h-screen bg-gray-950 text-gray-100 p-4 md:p-6">
+        <header className="mb-4">
+          <h1 className="font-serif text-2xl md:text-3xl text-gray-100">Activity</h1>
+          <p className="text-sm text-gray-400">
+            Live outreach events. Click any row to open the prospect drawer.
+          </p>
+        </header>
+
+        <ActivityFeedFull limit={150} />
+
+        <nav className="mt-6 text-xs text-gray-500 font-mono flex gap-3">
+          <Link href="/dashboard" className="hover:text-gray-300">← Home</Link>
+          <Link href="/dashboard/pipeline" className="hover:text-gray-300">Pipeline →</Link>
+          <Link href="/dashboard/meetings" className="hover:text-gray-300">Meetings →</Link>
+        </nav>
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/app/dashboard/meetings/page.tsx
+++ b/frontend/app/dashboard/meetings/page.tsx
@@ -11,16 +11,28 @@ import Link from "next/link";
 import { AppShell } from "@/components/layout/AppShell";
 import { MeetingsCalendar } from "@/components/dashboard/MeetingsCalendar";
 import { MeetingBriefing } from "@/components/dashboard/MeetingBriefing";
+import { ProspectDrawer } from "@/components/dashboard/ProspectDrawer";
 import { useMeetingsData, MeetingRow } from "@/lib/hooks/useMeetingsData";
+
+type Surface = "briefing" | "drawer";
 
 export default function MeetingsPage() {
   const { meetings, isLoading } = useMeetingsData();
-  const [activeId, setActiveId] = useState<string | null>(null);
+  const [activeMeetingId, setActiveMeetingId] = useState<string | null>(null);
+  const [activeLeadId, setActiveLeadId] = useState<string | null>(null);
+  const [surface, setSurface] = useState<Surface>("drawer");
 
   const active = useMemo<MeetingRow | null>(
-    () => meetings.find((m) => m.id === activeId) ?? null,
-    [meetings, activeId],
+    () => meetings.find((m) => m.id === activeMeetingId) ?? null,
+    [meetings, activeMeetingId],
   );
+
+  const openMeeting = (id: string) => {
+    const m = meetings.find((x) => x.id === id);
+    if (!m) return;
+    if (surface === "briefing") setActiveMeetingId(id);
+    else setActiveLeadId(m.leadId);
+  };
 
   const upcomingThisWeek = useMemo(() => {
     const now = Date.now();
@@ -42,14 +54,31 @@ export default function MeetingsPage() {
               {upcomingThisWeek.length === 1 ? "meeting" : "meetings"}.
             </em>
           </h1>
-          <p className="text-sm text-gray-400">
-            Click any slot to open the full briefing.
-          </p>
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-gray-400">
+              Click any slot to open the prospect drawer.
+            </p>
+            <div className="inline-flex rounded-lg border border-gray-800 bg-gray-900 p-0.5">
+              {(["drawer", "briefing"] as Surface[]).map((v) => (
+                <button
+                  key={v}
+                  onClick={() => setSurface(v)}
+                  className={`px-3 py-1 text-[10px] font-mono uppercase tracking-widest rounded-md ${
+                    surface === v
+                      ? "bg-amber-500/10 text-amber-300 border border-amber-500/40"
+                      : "text-gray-400 hover:text-gray-200"
+                  }`}
+                >
+                  {v}
+                </button>
+              ))}
+            </div>
+          </div>
         </header>
 
         <MeetingsCalendar
           meetings={meetings}
-          onOpen={(id) => setActiveId(id)}
+          onOpen={openMeeting}
           isLoading={isLoading}
         />
 
@@ -67,7 +96,7 @@ export default function MeetingsPage() {
               {upcomingThisWeek.map((m) => (
                 <li
                   key={m.id}
-                  onClick={() => setActiveId(m.id)}
+                  onClick={() => openMeeting(m.id)}
                   className="px-4 py-3 flex items-center gap-3 cursor-pointer hover:bg-gray-800/60"
                 >
                   {m.vrGrade && (
@@ -106,7 +135,8 @@ export default function MeetingsPage() {
         </nav>
       </div>
 
-      {active && <MeetingBriefing meeting={active} onClose={() => setActiveId(null)} />}
+      {active && <MeetingBriefing meeting={active} onClose={() => setActiveMeetingId(null)} />}
+      <ProspectDrawer leadId={activeLeadId} onClose={() => setActiveLeadId(null)} />
     </AppShell>
   );
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -39,7 +39,9 @@ import { HeroStrip } from "@/components/dashboard/HeroStrip";
 import { TodayStrip } from "@/components/dashboard/TodayStrip";
 import { FunnelBar } from "@/components/dashboard/FunnelBar";
 import { AttentionCards } from "@/components/dashboard/AttentionCards";
+import { ProspectDrawer } from "@/components/dashboard/ProspectDrawer";
 import Link from "next/link";
+import { useState } from "react";
 
 // Channel icon component
 const ChannelIcon = ({ type }: { type: string }) => {
@@ -57,6 +59,7 @@ export default function DashboardPage() {
   // Fetch real dashboard data (meetings goal, stats, hot prospects, week ahead, warm replies)
   const { data: dashboardData, isLoading: dashboardLoading } = useDashboardV4();
   const { activities: activityFeed, isLoading: activityLoading } = useLiveActivityFeed({ limit: 8 });
+  const [drawerLeadId, setDrawerLeadId] = useState<string | null>(null);
 
   const meetingsBooked = dashboardData?.meetingsGoal.current ?? 0;
   const meetingsTarget = dashboardData?.meetingsGoal.target ?? 10;
@@ -103,7 +106,7 @@ export default function DashboardPage() {
               <div className="text-[11px] font-mono uppercase tracking-[0.16em] text-gray-500 mb-3">
                 Needs your attention
               </div>
-              <AttentionCards />
+              <AttentionCards onLeadClick={(id) => setDrawerLeadId(id)} />
             </div>
           </section>
 
@@ -498,6 +501,7 @@ export default function DashboardPage() {
           </div>
         </div>
       </div>
+      <ProspectDrawer leadId={drawerLeadId} onClose={() => setDrawerLeadId(null)} />
     </AppShell>
   );
 }

--- a/frontend/app/dashboard/pipeline/page.tsx
+++ b/frontend/app/dashboard/pipeline/page.tsx
@@ -14,12 +14,14 @@ import Link from "next/link";
 import { AppShell } from "@/components/layout/AppShell";
 import { PipelineKanban } from "@/components/dashboard/PipelineKanban";
 import { PipelineTable } from "@/components/dashboard/PipelineTable";
+import { ProspectDrawer } from "@/components/dashboard/ProspectDrawer";
 import { usePipelineData } from "@/lib/hooks/usePipelineData";
 
 type View = "kanban" | "table";
 
 export default function PipelinePage() {
   const [view, setView] = useState<View>("kanban");
+  const [activeLead, setActiveLead] = useState<string | null>(null);
   const { prospects, counts, isLoading } = usePipelineData();
 
   const total = prospects.length;
@@ -57,13 +59,13 @@ export default function PipelinePage() {
           <PipelineKanban
             prospects={prospects}
             counts={counts}
-            onOpen={(id) => { window.location.href = `/dashboard/leads/${id}`; }}
+            onOpen={(id) => setActiveLead(id)}
             isLoading={isLoading}
           />
         ) : (
           <PipelineTable
             prospects={prospects}
-            onOpen={(id) => { window.location.href = `/dashboard/leads/${id}`; }}
+            onOpen={(id) => setActiveLead(id)}
             isLoading={isLoading}
           />
         )}
@@ -73,6 +75,8 @@ export default function PipelinePage() {
           <Link href="/dashboard/meetings" className="hover:text-gray-300">Meetings →</Link>
         </nav>
       </div>
+
+      <ProspectDrawer leadId={activeLead} onClose={() => setActiveLead(null)} />
     </AppShell>
   );
 }

--- a/frontend/components/dashboard/ActivityFeedFull.tsx
+++ b/frontend/components/dashboard/ActivityFeedFull.tsx
@@ -1,0 +1,177 @@
+/**
+ * FILE: frontend/components/dashboard/ActivityFeedFull.tsx
+ * PURPOSE: Full-page activity timeline. Click any row opens ProspectDrawer.
+ * PHASE: PHASE-2.1-PROSPECT-DRAWER-FEED
+ *
+ * NOTE: dispatch called this component `ActivityFeed.tsx` (NEW), but that
+ * name is already taken by a home widget re-exported from
+ * components/dashboard/index.ts. Renamed to ActivityFeedFull to avoid a
+ * breaking rename — the route wire-up imports this new file directly.
+ *
+ * Uses useLiveActivityFeed for realtime-ness but runs its own direct
+ * Supabase query alongside to resolve lead_id per event so click → drawer
+ * works. The realtime subscription invalidates queries that share a key
+ * prefix, which triggers the raw query refetch too.
+ */
+
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Mail, Linkedin, Phone, MessageSquare,
+  CircleCheck, CircleX, Circle, MessageCircle,
+} from "lucide-react";
+import { useClient } from "@/hooks/use-client";
+import { useLiveActivityFeed } from "@/lib/useLiveActivityFeed";
+import { createBrowserClient } from "@/lib/supabase";
+import { canonicalChannel } from "@/lib/provider-labels";
+import { ProspectDrawer } from "./ProspectDrawer";
+
+interface RawEvent {
+  id: string;
+  lead_id: string;
+  channel: string;
+  action: string;
+  sent_at: string;
+  leadName: string;
+  company: string;
+  status: string | null;
+}
+
+function channelIcon(channel: string) {
+  const label = canonicalChannel(channel ?? "");
+  const Icon =
+    label === "Email"    ? Mail :
+    label === "LinkedIn" ? Linkedin :
+    label === "SMS"      ? MessageSquare :
+    label === "Voice AI" ? Phone :
+    Mail;
+  return <Icon className="w-4 h-4 text-gray-400" strokeWidth={1.75} />;
+}
+
+function statusIcon(action: string, status: string | null) {
+  const a = action.toLowerCase();
+  const s = (status ?? "").toLowerCase();
+  if (a.includes("repl") || s.includes("repl")) return <MessageCircle className="w-3.5 h-3.5 text-emerald-400" />;
+  if (s.includes("bounc") || s === "failed") return <CircleX className="w-3.5 h-3.5 text-red-400" />;
+  if (s.includes("convert") || s === "sent") return <CircleCheck className="w-3.5 h-3.5 text-gray-400" />;
+  return <Circle className="w-3.5 h-3.5 text-gray-600" />;
+}
+
+async function fetchRawEvents(clientId: string, limit: number): Promise<RawEvent[]> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+
+  const { data: outcomes } = await client
+    .from("cis_outreach_outcomes")
+    .select("id, lead_id, channel, sent_at, final_outcome, replied_at")
+    .eq("client_id", clientId)
+    .order("sent_at", { ascending: false })
+    .limit(limit);
+
+  const rows = (outcomes ?? []) as Array<Record<string, unknown>>;
+  const leadIds = Array.from(new Set(rows.map((r) => String(r.lead_id)).filter(Boolean)));
+
+  const nameByLead = new Map<string, { name: string; company: string }>();
+  if (leadIds.length) {
+    const { data: bu } = await client
+      .from("business_universe")
+      .select("id, display_name, dm_name")
+      .in("id", leadIds);
+    for (const b of ((bu ?? []) as Array<Record<string, unknown>>)) {
+      nameByLead.set(String(b.id), {
+        name: (b.dm_name as string | null) ?? "Unknown",
+        company: (b.display_name as string | null) ?? "—",
+      });
+    }
+  }
+
+  return rows.map((r) => {
+    const id = String(r.id);
+    const leadId = String(r.lead_id);
+    const n = nameByLead.get(leadId) ?? { name: "Unknown", company: "—" };
+    return {
+      id,
+      lead_id: leadId,
+      channel: String(r.channel ?? ""),
+      action: r.replied_at ? "replied" : "sent",
+      sent_at: String(r.sent_at ?? ""),
+      leadName: n.name,
+      company: n.company,
+      status: (r.final_outcome as string | null) ?? null,
+    };
+  });
+}
+
+export function ActivityFeedFull({ limit = 100 }: { limit?: number }) {
+  const { clientId } = useClient();
+  const live = useLiveActivityFeed({ limit });
+  const [activeLead, setActiveLead] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["activity-raw", clientId, limit, live.status],
+    queryFn: () => fetchRawEvents(clientId!, limit),
+    enabled: !!clientId,
+    staleTime: 15_000,
+  });
+
+  const events = useMemo(() => data ?? [], [data]);
+
+  return (
+    <>
+      <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800">
+          <div className="font-mono text-[10px] tracking-widest uppercase text-gray-500">
+            Activity
+          </div>
+          <div className="text-[10px] font-mono text-gray-500">
+            {live.isLive ? (
+              <span className="inline-flex items-center gap-1 text-emerald-400">
+                <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+                LIVE
+              </span>
+            ) : live.status === "polling" ? (
+              "POLLING"
+            ) : (
+              "CONNECTING"
+            )}
+          </div>
+        </div>
+        {events.length === 0 ? (
+          <div className="px-4 py-10 text-center text-sm text-gray-500 italic">
+            {isLoading ? "Loading activity…" : "No activity yet."}
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-800">
+            {events.map((e) => (
+              <li
+                key={e.id}
+                onClick={() => setActiveLead(e.lead_id)}
+                className="px-4 py-3 flex items-center gap-3 hover:bg-gray-800/60 cursor-pointer"
+              >
+                <span className="shrink-0 text-gray-500 font-mono text-[10px] w-16">
+                  {new Date(e.sent_at).toLocaleTimeString([], {
+                    hour: "numeric", minute: "2-digit",
+                  })}
+                </span>
+                {channelIcon(e.channel)}
+                <span className="flex-1 min-w-0 text-sm text-gray-200 truncate">
+                  <span className="text-gray-100">{e.leadName}</span>
+                  <span className="text-gray-500"> · {e.company}</span>
+                </span>
+                <span className="shrink-0 inline-flex items-center gap-1.5 text-[11px] font-mono text-gray-400 uppercase tracking-wider">
+                  {statusIcon(e.action, e.status)}
+                  {e.action}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <ProspectDrawer leadId={activeLead} onClose={() => setActiveLead(null)} />
+    </>
+  );
+}

--- a/frontend/components/dashboard/AttentionCards.tsx
+++ b/frontend/components/dashboard/AttentionCards.tsx
@@ -34,7 +34,12 @@ const TYPE_STYLES: Record<AttentionType, { card: string; icon: string }> = {
   },
 };
 
-export function AttentionCards() {
+export interface AttentionCardsProps {
+  /** Optional — intercept leads-detail clicks and open a drawer instead of navigating. */
+  onLeadClick?: (leadId: string) => void;
+}
+
+export function AttentionCards({ onLeadClick }: AttentionCardsProps = {}) {
   const { items, isLoading, error } = useAttentionItems();
 
   if (isLoading) {
@@ -58,17 +63,35 @@ export function AttentionCards() {
   return (
     <div className="space-y-2.5">
       {items.map((item) => (
-        <AttentionRow key={item.id} item={item} />
+        <AttentionRow key={item.id} item={item} onLeadClick={onLeadClick} />
       ))}
     </div>
   );
 }
 
-function AttentionRow({ item }: { item: AttentionItem }) {
+function leadIdFromHref(href: string): string | null {
+  const m = /^\/dashboard\/leads\/([^/?#]+)/.exec(href);
+  return m ? m[1] : null;
+}
+
+function AttentionRow({
+  item, onLeadClick,
+}: { item: AttentionItem; onLeadClick?: (leadId: string) => void }) {
   const style = TYPE_STYLES[item.type];
+  const leadId = leadIdFromHref(item.href);
+  const interceptable = !!(onLeadClick && leadId);
+
+  const handleClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
+    if (interceptable) {
+      e.preventDefault();
+      onLeadClick!(leadId!);
+    }
+  };
+
   return (
     <Link
       href={item.href}
+      onClick={handleClick}
       className={`grid grid-cols-[28px_1fr_auto] gap-3 items-center rounded-lg border border-l-4 px-4 py-3.5 transition-colors hover:brightness-110 ${style.card}`}
     >
       <div

--- a/frontend/components/dashboard/ProspectDrawer.tsx
+++ b/frontend/components/dashboard/ProspectDrawer.tsx
@@ -1,0 +1,357 @@
+/**
+ * FILE: frontend/components/dashboard/ProspectDrawer.tsx
+ * PURPOSE: Right-slide drawer showing full prospect state (contact, enrichment, timeline, actions)
+ * PHASE: PHASE-2.1-PROSPECT-DRAWER-FEED
+ *
+ * Triggered by click on any prospect in Kanban/Table/Feed/Attention/Meetings.
+ * Close on backdrop click, X button, or Escape key.
+ * Desktop: 400px slide-from-right. Mobile: full-screen overlay.
+ *
+ * Quick actions (Pause/Skip/Suppress) POST to the webhook layer so the
+ * CadenceDecisionTree produces the mutations. Best-effort — UI shows
+ * optimistic feedback, errors surface inline.
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  X, Mail, Linkedin, Phone, MessageSquare, ExternalLink,
+  PauseCircle, SkipForward, Ban,
+} from "lucide-react";
+import {
+  useProspectDetail, type TouchEvent, type ScheduledTouch, type ReplyEvent,
+} from "@/lib/hooks/useProspectDetail";
+import { canonicalChannel, providerLabel } from "@/lib/provider-labels";
+
+interface Props {
+  leadId: string | null;
+  onClose: () => void;
+}
+
+const GRADE_COLOR: Record<string, string> = {
+  A: "bg-emerald-500/15 text-emerald-300 border-emerald-500/40",
+  B: "bg-amber-500/10 text-amber-300 border-amber-500/40",
+  C: "bg-amber-500/10 text-amber-300 border-amber-500/40",
+  D: "bg-red-500/10 text-red-300 border-red-500/40",
+  F: "bg-red-500/10 text-red-300 border-red-500/40",
+};
+
+function channelIcon(channel: string | null) {
+  const label = canonicalChannel(channel ?? "");
+  const Icon =
+    label === "Email"    ? Mail :
+    label === "LinkedIn" ? Linkedin :
+    label === "SMS"      ? MessageSquare :
+    label === "Voice AI" ? Phone :
+    Mail;
+  return <Icon className="w-3.5 h-3.5" strokeWidth={1.75} />;
+}
+
+function fmtDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function ProspectDrawer({ leadId, onClose }: Props) {
+  const { prospect, isLoading } = useProspectDetail(leadId);
+  const [actionState, setActionState] = useState<string | null>(null);
+
+  // Escape closes drawer
+  useEffect(() => {
+    if (!leadId) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [leadId, onClose]);
+
+  if (!leadId) return null;
+
+  const runAction = async (kind: "pause" | "skip" | "suppress") => {
+    if (!prospect) return;
+    setActionState(`${kind}:pending`);
+    try {
+      const res = await fetch("/api/outreach/action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ lead_id: prospect.leadId, action: kind }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setActionState(`${kind}:ok`);
+    } catch (e) {
+      console.error("[ProspectDrawer] action failed", e);
+      setActionState(`${kind}:error`);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/60"
+      onClick={onClose}
+      role="presentation"
+    >
+      <aside
+        onClick={(e) => e.stopPropagation()}
+        className="absolute right-0 top-0 h-full w-full sm:w-[420px] bg-gray-950 border-l border-gray-800 overflow-y-auto animate-in slide-in-from-right duration-200"
+        role="dialog"
+        aria-label="Prospect detail"
+      >
+        <header className="sticky top-0 bg-gray-950/95 backdrop-blur border-b border-gray-800 px-5 py-4 flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="font-mono text-[10px] tracking-widest uppercase text-gray-500">
+              Prospect
+            </div>
+            <h2 className="font-serif text-xl text-gray-100 truncate">
+              {prospect?.name ?? (isLoading ? "Loading…" : "—")}
+            </h2>
+            <div className="text-sm text-gray-400 truncate">{prospect?.company ?? ""}</div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {prospect?.vrGrade && (
+              <span className={`text-[11px] font-mono font-bold px-2 py-0.5 rounded border ${GRADE_COLOR[prospect.vrGrade] ?? ""}`}>
+                {prospect.vrGrade}
+              </span>
+            )}
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-gray-200 p-1"
+              aria-label="Close drawer"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </header>
+
+        {!prospect ? (
+          <div className="p-5 text-sm text-gray-500 italic">
+            {isLoading ? "Loading prospect…" : "Prospect not found."}
+          </div>
+        ) : (
+          <div className="p-5 space-y-6">
+            {/* Contact */}
+            <Section title="Contact">
+              <ContactRow icon={<Mail className="w-3.5 h-3.5" />} label="Email" value={prospect.contact.email} />
+              <ContactRow icon={<Phone className="w-3.5 h-3.5" />} label="Phone" value={prospect.contact.phone} />
+              <ContactRow
+                icon={<Linkedin className="w-3.5 h-3.5" />} label="LinkedIn"
+                value={prospect.contact.linkedinUrl} href={prospect.contact.linkedinUrl}
+              />
+            </Section>
+
+            {/* Enrichment */}
+            <Section title="Enrichment">
+              <KV label="ABN"      value={prospect.enrichment.abn} />
+              <KV label="Industry" value={prospect.enrichment.industry} />
+              <KV label="Staff"    value={prospect.enrichment.employeeCount?.toString() ?? null} />
+              <KV label="Website"  value={prospect.enrichment.website} href={prospect.enrichment.website} />
+              <KV label="Location" value={prospect.enrichment.location} />
+            </Section>
+
+            {/* Outreach timeline */}
+            <Section title="Outreach timeline">
+              {prospect.touches.length === 0 ? (
+                <Empty>No touches sent yet.</Empty>
+              ) : (
+                <ul className="space-y-2">
+                  {prospect.touches.map((t) => <TouchRow key={t.id} t={t} />)}
+                </ul>
+              )}
+            </Section>
+
+            {/* Scheduled */}
+            <Section title="Scheduled touches">
+              {prospect.scheduled.length === 0 ? (
+                <Empty>No upcoming touches.</Empty>
+              ) : (
+                <ul className="space-y-2">
+                  {prospect.scheduled.map((s) => <ScheduledRow key={s.id} s={s} />)}
+                </ul>
+              )}
+            </Section>
+
+            {/* Replies */}
+            <Section title="Reply history">
+              {prospect.replies.length === 0 ? (
+                <Empty>No replies received.</Empty>
+              ) : (
+                <ul className="space-y-2">
+                  {prospect.replies.map((r) => <ReplyRow key={r.id} r={r} />)}
+                </ul>
+              )}
+            </Section>
+
+            {/* Quick actions */}
+            <Section title="Quick actions">
+              <div className="grid grid-cols-3 gap-2">
+                <ActionButton
+                  icon={<PauseCircle className="w-4 h-4" />} label="Pause cadence"
+                  onClick={() => runAction("pause")}
+                  state={actionState?.startsWith("pause:") ? actionState : null}
+                />
+                <ActionButton
+                  icon={<SkipForward className="w-4 h-4" />} label="Skip next"
+                  onClick={() => runAction("skip")}
+                  state={actionState?.startsWith("skip:") ? actionState : null}
+                />
+                <ActionButton
+                  icon={<Ban className="w-4 h-4" />} label="Suppress"
+                  onClick={() => runAction("suppress")}
+                  state={actionState?.startsWith("suppress:") ? actionState : null}
+                  danger
+                />
+              </div>
+            </Section>
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}
+
+// ---------- helpers --------------------------------------------------------
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <div className="font-mono text-[10px] tracking-widest uppercase text-gray-500 mb-2">
+        {title}
+      </div>
+      <div className="space-y-1.5">{children}</div>
+    </section>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return <div className="text-xs text-gray-500 italic">{children}</div>;
+}
+
+function KV({ label, value, href }: { label: string; value: string | null; href?: string | null }) {
+  return (
+    <div className="flex justify-between gap-3 text-sm">
+      <span className="text-gray-500 font-mono text-[11px] uppercase">{label}</span>
+      {value ? (
+        href ? (
+          <a href={href} target="_blank" rel="noreferrer"
+             className="text-amber-300 hover:underline truncate max-w-[220px]">{value}</a>
+        ) : (
+          <span className="text-gray-200 truncate max-w-[220px]">{value}</span>
+        )
+      ) : (
+        <span className="text-gray-600">—</span>
+      )}
+    </div>
+  );
+}
+
+function ContactRow({
+  icon, label, value, href,
+}: { icon: React.ReactNode; label: string; value: string | null; href?: string | null }) {
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      <span className="text-gray-500">{icon}</span>
+      <span className="font-mono text-[10px] uppercase tracking-widest text-gray-500 w-16">{label}</span>
+      {value ? (
+        href ? (
+          <a href={href} target="_blank" rel="noreferrer"
+             className="text-amber-300 hover:underline truncate inline-flex items-center gap-1">
+            {value}<ExternalLink className="w-3 h-3" />
+          </a>
+        ) : (
+          <span className="text-gray-100 truncate">{value}</span>
+        )
+      ) : (
+        <span className="text-gray-600">—</span>
+      )}
+    </div>
+  );
+}
+
+function TouchRow({ t }: { t: TouchEvent }) {
+  return (
+    <li className="flex items-start gap-2 text-xs text-gray-300 py-1.5 border-b border-gray-800/60">
+      {channelIcon(t.channel)}
+      <div className="flex-1 min-w-0">
+        <div className="flex justify-between gap-2">
+          <span className="text-gray-200">
+            {canonicalChannel(t.channel)}
+            {t.sequenceStep ? <span className="text-gray-500"> · step {t.sequenceStep}</span> : null}
+          </span>
+          <span className="text-gray-500 font-mono">{fmtDate(t.sentAt)}</span>
+        </div>
+        <div className="text-[11px] text-gray-500 mt-0.5 truncate">
+          {t.status ? providerLabel(t.status) : "sent"}
+          {t.replied ? <span className="text-emerald-400 ml-2">· replied</span> : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function ScheduledRow({ s }: { s: ScheduledTouch }) {
+  return (
+    <li className="flex items-center gap-2 text-xs text-gray-300 py-1.5 border-b border-gray-800/60">
+      {channelIcon(s.channel)}
+      <span className="flex-1 text-gray-200">
+        {canonicalChannel(s.channel)}
+        {s.sequenceStep ? <span className="text-gray-500"> · step {s.sequenceStep}</span> : null}
+      </span>
+      <span className="text-gray-500 font-mono">{fmtDate(s.scheduledAt)}</span>
+      <span className={`text-[10px] font-mono uppercase tracking-wider px-1.5 py-0.5 rounded ${
+        s.status === "paused" ? "bg-amber-500/10 text-amber-300" : "bg-gray-800 text-gray-400"
+      }`}>
+        {s.status}
+      </span>
+    </li>
+  );
+}
+
+function ReplyRow({ r }: { r: ReplyEvent }) {
+  return (
+    <li className="text-xs py-1.5 border-b border-gray-800/60">
+      <div className="flex items-center gap-2 text-gray-300">
+        {channelIcon(r.channel)}
+        <span className="text-gray-200">{canonicalChannel(r.channel ?? "")}</span>
+        {r.intent && (
+          <span className="text-[10px] font-mono uppercase tracking-wider text-amber-300">
+            · {r.intent}
+          </span>
+        )}
+        <span className="ml-auto text-gray-500 font-mono">{fmtDate(r.receivedAt)}</span>
+      </div>
+      {r.preview && (
+        <div className="text-[11px] text-gray-400 mt-0.5 truncate italic">
+          &ldquo;{providerLabel(r.preview)}&rdquo;
+        </div>
+      )}
+    </li>
+  );
+}
+
+function ActionButton({
+  icon, label, onClick, state, danger,
+}: {
+  icon: React.ReactNode; label: string; onClick: () => void;
+  state: string | null; danger?: boolean;
+}) {
+  const pending = state?.endsWith(":pending");
+  const ok = state?.endsWith(":ok");
+  const err = state?.endsWith(":error");
+  const base = danger
+    ? "bg-red-500/10 border-red-500/40 text-red-300 hover:bg-red-500/20"
+    : "bg-gray-800 border-gray-700 text-gray-200 hover:border-amber-500/50";
+  return (
+    <button
+      onClick={onClick}
+      disabled={pending}
+      className={`border rounded-lg p-2 text-[11px] font-medium flex flex-col items-center gap-1 transition ${base} disabled:opacity-50`}
+    >
+      {icon}
+      <span>{pending ? "…" : ok ? "Done" : err ? "Retry" : label}</span>
+    </button>
+  );
+}

--- a/frontend/lib/hooks/useProspectDetail.ts
+++ b/frontend/lib/hooks/useProspectDetail.ts
@@ -1,0 +1,195 @@
+/**
+ * FILE: frontend/lib/hooks/useProspectDetail.ts
+ * PURPOSE: Full prospect state for the right-drawer — contact, enrichment, touches, replies
+ * PHASE: PHASE-2.1-PROSPECT-DRAWER-FEED
+ *
+ * Queries real Supabase tables. No mock data — returns nulls/empty arrays on any error.
+ *
+ * Sources:
+ *   business_universe       — identity + contact + enrichment snapshot
+ *   cis_outreach_outcomes   — touches sent with channel/sent_at/status
+ *   scheduled_touches       — pending upcoming touches
+ *   activities              — reply history (action='replied')
+ */
+
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { createBrowserClient } from "@/lib/supabase";
+
+export interface ProspectContact {
+  email: string | null;
+  phone: string | null;
+  linkedinUrl: string | null;
+}
+
+export interface ProspectEnrichment {
+  abn: string | null;
+  industry: string | null;
+  employeeCount: number | null;
+  website: string | null;
+  location: string | null;
+}
+
+export interface TouchEvent {
+  id: string;
+  channel: string;
+  sentAt: string;
+  status: string | null;
+  sequenceStep: number | null;
+  replied: boolean;
+  preview: string | null;
+}
+
+export interface ScheduledTouch {
+  id: string;
+  channel: string;
+  scheduledAt: string;
+  sequenceStep: number | null;
+  status: string;
+}
+
+export interface ReplyEvent {
+  id: string;
+  channel: string | null;
+  receivedAt: string;
+  intent: string | null;
+  preview: string | null;
+}
+
+export interface ProspectDetail {
+  leadId: string;
+  name: string;
+  company: string;
+  vrGrade: string | null;
+  score: number | null;
+  contact: ProspectContact;
+  enrichment: ProspectEnrichment;
+  touches: TouchEvent[];
+  scheduled: ScheduledTouch[];
+  replies: ReplyEvent[];
+}
+
+function gradeFromScore(score: number | null): string | null {
+  if (score === null || score === undefined) return null;
+  if (score >= 85) return "A";
+  if (score >= 70) return "B";
+  if (score >= 50) return "C";
+  if (score >= 30) return "D";
+  return "F";
+}
+
+async function fetchDetail(leadId: string): Promise<ProspectDetail | null> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+
+  const buRes = await client
+    .from("business_universe")
+    .select(
+      "id, display_name, dm_name, dm_title, dm_email, dm_phone, dm_mobile, dm_linkedin_url, " +
+      "abn, gmb_category, company_employee_count_exact, website, suburb, state, propensity_score",
+    )
+    .eq("id", leadId)
+    .maybeSingle();
+  const bu = buRes?.data as Record<string, unknown> | null;
+  if (!bu) return null;
+
+  let touches: TouchEvent[] = [];
+  try {
+    const { data } = await client
+      .from("cis_outreach_outcomes")
+      .select("id, channel, sent_at, final_outcome, sequence_step, replied_at, subject_hash")
+      .eq("lead_id", leadId)
+      .order("sent_at", { ascending: true })
+      .limit(50);
+    touches = ((data ?? []) as Array<Record<string, unknown>>).map((r) => ({
+      id: String(r.id),
+      channel: String(r.channel ?? ""),
+      sentAt: String(r.sent_at ?? ""),
+      status: (r.final_outcome as string | null) ?? null,
+      sequenceStep: (r.sequence_step as number | null) ?? null,
+      replied: !!r.replied_at,
+      preview: (r.subject_hash as string | null) ?? null,
+    }));
+  } catch (e) {
+    console.warn("[useProspectDetail] touches skipped", e);
+  }
+
+  let scheduled: ScheduledTouch[] = [];
+  try {
+    const { data } = await client
+      .from("scheduled_touches")
+      .select("id, channel, scheduled_at, sequence_step, status")
+      .eq("lead_id", leadId)
+      .in("status", ["pending", "paused"])
+      .order("scheduled_at", { ascending: true })
+      .limit(20);
+    scheduled = ((data ?? []) as Array<Record<string, unknown>>).map((r) => ({
+      id: String(r.id),
+      channel: String(r.channel ?? ""),
+      scheduledAt: String(r.scheduled_at ?? ""),
+      sequenceStep: (r.sequence_step as number | null) ?? null,
+      status: String(r.status ?? "pending"),
+    }));
+  } catch (e) {
+    console.warn("[useProspectDetail] scheduled skipped", e);
+  }
+
+  let replies: ReplyEvent[] = [];
+  try {
+    const { data } = await client
+      .from("activities")
+      .select("id, channel, created_at, intent, preview")
+      .eq("lead_id", leadId)
+      .eq("action", "replied")
+      .order("created_at", { ascending: false })
+      .limit(20);
+    replies = ((data ?? []) as Array<Record<string, unknown>>).map((r) => ({
+      id: String(r.id),
+      channel: (r.channel as string | null) ?? null,
+      receivedAt: String(r.created_at ?? ""),
+      intent: (r.intent as string | null) ?? null,
+      preview: (r.preview as string | null) ?? null,
+    }));
+  } catch (e) {
+    console.warn("[useProspectDetail] replies skipped", e);
+  }
+
+  const score = typeof bu.propensity_score === "number" ? (bu.propensity_score as number) : null;
+  const emp = bu.company_employee_count_exact;
+  const locParts = [bu.suburb as string | null, bu.state as string | null].filter(Boolean);
+
+  return {
+    leadId: String(bu.id),
+    name: (bu.dm_name as string | null) ?? "Unknown",
+    company: (bu.display_name as string | null) ?? "—",
+    vrGrade: gradeFromScore(score),
+    score,
+    contact: {
+      email: (bu.dm_email as string | null) ?? null,
+      phone: ((bu.dm_phone as string | null) ?? (bu.dm_mobile as string | null)) ?? null,
+      linkedinUrl: (bu.dm_linkedin_url as string | null) ?? null,
+    },
+    enrichment: {
+      abn: (bu.abn as string | null) ?? null,
+      industry: (bu.gmb_category as string | null) ?? null,
+      employeeCount: typeof emp === "number" ? emp : null,
+      website: (bu.website as string | null) ?? null,
+      location: locParts.length ? locParts.join(", ") : null,
+    },
+    touches,
+    scheduled,
+    replies,
+  };
+}
+
+export function useProspectDetail(leadId: string | null) {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["prospect-detail", leadId],
+    queryFn: () => fetchDetail(leadId!),
+    enabled: !!leadId,
+    staleTime: 30_000,
+  });
+  return { prospect: data ?? null, isLoading, error, refetch };
+}


### PR DESCRIPTION
## Summary
- **ProspectDrawer** — slide-from-right panel (420px desktop, full-screen mobile). Sections: VR-coloured grade badge, contact, enrichment (ABN, industry, staff, website, location), outreach timeline, scheduled touches, reply history, quick actions (Pause / Skip / Suppress POST to `/api/outreach/action`). Escape / backdrop / X all close.
- **useProspectDetail** — live Supabase loader joining `business_universe` + `cis_outreach_outcomes` + `scheduled_touches` + `activities`.
- **Activity route** — `/dashboard/activity` wraps `ActivityFeedFull`. Uses `useLiveActivityFeed` for realtime signal and runs its own direct query alongside to resolve `lead_id` per row so click → drawer works. **Named `ActivityFeedFull` (not `ActivityFeed` as in brief) to avoid clobbering the existing `components/dashboard/ActivityFeed.tsx` widget re-exported via `components/dashboard/index.ts`.** Flag in PR body.
- **Wires** — Home (`AttentionCards onLeadClick={setDrawerLeadId}`), Pipeline (Kanban + Table `onOpen`), Meetings (click opens drawer by default; briefing modal still available via a tiny toggle for meeting-specific context).
- **AttentionCards** gained an optional `onLeadClick` prop — intercepts Link clicks whose href matches `/dashboard/leads/{id}`; zero change when not supplied.

## Test plan
- [x] Rebased on current `origin/main` (f12b88af — post PR #386 merge)
- [x] `tsc --noEmit` clean on all 4 new + 4 modified files (pre-existing unrelated errors in `lib/__tests__/useLiveActivityFeed.test.ts` remain)
- [x] Provider-leak grep across all new files: 0 matches
- [ ] Reviewer: browser check — open drawer from Home attention cards, Pipeline Kanban card click, Pipeline table row, Meetings calendar tile, Activity feed row
- [ ] Ops: `POST /api/outreach/action` endpoint is referenced but not guaranteed to exist — if missing, Quick-action buttons will show "Retry" on click (UX degrades gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)