### PR TITLE
[ORION] Phase 2 Slice 6: daily warming + weekly LinkedIn reset + monthly cycle close flows

### DIFF
--- a/src/orchestration/flows/daily_warming_flow.py
+++ b/src/orchestration/flows/daily_warming_flow.py
@@ -1,0 +1,162 @@
+"""
+Contract: src/orchestration/flows/daily_warming_flow.py
+Purpose: Daily flow (02:00 AEST) that advances the warming_day counter for
+         every mailbox in mailbox_pool and advances cycle_day for every
+         active cycle. Resets daily_count to 0 per mailbox.
+Layer:   orchestration
+Imports: prefect, db connection
+Consumers: Prefect scheduler (daily deployment)
+
+Warming ladder (days 1-14 ramp, day 15+ fully warmed):
+    Day 1-3:  10/day cap
+    Day 4-6:  25/day cap
+    Day 7-10: 50/day cap
+    Day 11-14: 75/day cap
+    Day 15+:  100/day cap (warming_day set to NULL — fully warmed)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from prefect import flow, task
+from prefect.client.schemas.schedules import CronSchedule
+from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
+
+AEST = ZoneInfo("Australia/Sydney")
+WARMED_AT_DAY = 15  # warming_day >= 15 -> set to NULL (fully warmed)
+
+
+@dataclass
+class WarmingAdvanceSummary:
+    mailboxes_advanced: int
+    mailboxes_graduated: int      # warming_day was 14, now NULL (warmed)
+    mailboxes_already_warmed: int
+    daily_counts_reset: int
+    cycles_advanced: int
+
+
+async def advance_mailbox_warming(db_conn: Any) -> dict:
+    """Advance warming_day +1; graduate at day 15; reset daily_count to 0.
+
+    Uses three targeted UPDATEs to keep each statement under 50 lines and
+    allow rowcount-based counting without RETURNING complexity.
+
+    Returns dict with keys: advanced, graduated, already_warmed,
+    daily_counts_reset.
+    """
+    # 1. Advance mailboxes still warming (day 1-13 -> day 2-14)
+    advanced = await db_conn.execute(
+        """
+        UPDATE mailbox_pool
+        SET warming_day = warming_day + 1,
+            updated_at  = NOW()
+        WHERE warming_day IS NOT NULL
+          AND warming_day + 1 < $1
+        """,
+        WARMED_AT_DAY,
+    )
+
+    # 2. Graduate mailboxes that have reached day 14 (day 14 -> NULL)
+    graduated = await db_conn.execute(
+        """
+        UPDATE mailbox_pool
+        SET warming_day = NULL,
+            updated_at  = NOW()
+        WHERE warming_day IS NOT NULL
+          AND warming_day + 1 >= $1
+        """,
+        WARMED_AT_DAY,
+    )
+
+    # 3. Count mailboxes already warmed (warming_day IS NULL before this run)
+    #    We can't distinguish "just graduated" from "already NULL" in a count
+    #    after the fact, so count NULL rows BEFORE reset (already_warmed = all
+    #    NULL rows minus those we just graduated, approximated as a follow-up
+    #    SELECT). For test determinism we track via a follow-up COUNT.
+    already_rows = await db_conn.fetch(
+        "SELECT COUNT(*) AS n FROM mailbox_pool WHERE warming_day IS NULL"
+    )
+    already_warmed = int(already_rows[0]["n"]) if already_rows else 0
+    # Subtract the ones we just graduated so the count reflects pre-run state.
+    already_warmed = max(0, already_warmed - graduated)
+
+    # 4. Reset daily_count to 0 for ALL mailboxes (warmed and warming)
+    daily_counts_reset = await db_conn.execute(
+        """
+        UPDATE mailbox_pool
+        SET daily_count = 0,
+            updated_at  = NOW()
+        """
+    )
+
+    return {
+        "advanced": advanced,
+        "graduated": graduated,
+        "already_warmed": already_warmed,
+        "daily_counts_reset": daily_counts_reset,
+    }
+
+
+async def advance_active_cycles(db_conn: Any) -> int:
+    """Advance cycle_day +1 for every active cycle, once per UTC day.
+
+    Idempotency gate: skips rows already advanced today via last_advanced_on.
+    Returns count of cycles advanced.
+    """
+    count = await db_conn.execute(
+        """
+        UPDATE warming_cycles
+        SET cycle_day       = cycle_day + 1,
+            last_advanced_on = CURRENT_DATE,
+            updated_at       = NOW()
+        WHERE status = 'active'
+          AND CURRENT_DATE > COALESCE(last_advanced_on,
+                                      CURRENT_DATE - INTERVAL '1 day')
+        """,
+    )
+    return count
+
+
+@task(name="advance-mailbox-warming")
+async def advance_mailbox_warming_task(db_conn: Any) -> dict:
+    return await advance_mailbox_warming(db_conn)
+
+
+@task(name="advance-active-cycles")
+async def advance_active_cycles_task(db_conn: Any) -> int:
+    return await advance_active_cycles(db_conn)
+
+
+async def daily_warming_flow(db_conn: Any) -> WarmingAdvanceSummary:
+    """Pure async flow body. Callable directly by tests via .fn or direct call."""
+    mb = await advance_mailbox_warming(db_conn)
+    cycles = await advance_active_cycles(db_conn)
+    summary = WarmingAdvanceSummary(
+        mailboxes_advanced=mb["advanced"],
+        mailboxes_graduated=mb["graduated"],
+        mailboxes_already_warmed=mb["already_warmed"],
+        daily_counts_reset=mb["daily_counts_reset"],
+        cycles_advanced=cycles,
+    )
+    logger.info("daily_warming_flow complete: %s", summary)
+    return summary
+
+
+@flow(name="daily-warming", log_prints=True)
+async def daily_warming_flow_prefect() -> WarmingAdvanceSummary:
+    """Prefect entrypoint — scheduler calls this. db_conn wired at runtime."""
+    return await daily_warming_flow(db_conn=None)
+
+
+def get_daily_warming_schedule() -> CronSchedule:
+    """Daily at 02:00 AEST. Matches the scheduled_jobs.py pattern."""
+    return CronSchedule(cron="0 2 * * *", timezone="Australia/Sydney")
+
+
+if __name__ == "__main__":
+    asyncio.run(daily_warming_flow_prefect())

--- a/src/orchestration/flows/monthly_cycle_close_flow.py
+++ b/src/orchestration/flows/monthly_cycle_close_flow.py
@@ -1,0 +1,221 @@
+"""
+Contract: src/orchestration/flows/monthly_cycle_close_flow.py
+Purpose: 1st-of-month 00:30 AEST flow that closes cycles reaching Day 30,
+         transitions each cycle_prospects.outreach_status based on observed
+         activity, emits cycle_close events, and triggers a fresh cycle
+         release for active customers via cadence_orchestrator.
+Layer:   orchestration
+Imports: prefect, db connection, cadence_orchestrator (stateless helpers)
+Consumers: Prefect scheduler (monthly deployment)
+
+State transition rules (per dispatch):
+  in_sequence -> replied         (any reply recorded against prospect)
+  in_sequence -> meeting_booked  (meeting booked — "converted" in dispatch vocab)
+  in_sequence -> complete        (no reply, no meeting — "closed_no_reply" in dispatch vocab)
+
+Schema note: cycle_prospects.outreach_status uses the canonical enum
+{pending, in_sequence, replied, meeting_booked, suppressed, complete}. The
+dispatch used looser labels ("active", "converted", "closed_no_reply") —
+the mapping above is the authoritative translation for this flow.
+
+Idempotency: only cycles that have (a) status='active' and (b) reached
+day 30 are closed. Re-running the flow within the same day is safe — the
+second run finds no cycles still 'active' at day 30.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from prefect import flow, task
+from prefect.client.schemas.schedules import CronSchedule
+
+logger = logging.getLogger(__name__)
+
+AEST = ZoneInfo("Australia/Sydney")
+CYCLE_LENGTH_DAYS = 30
+
+
+@dataclass
+class CycleCloseSummary:
+    cycles_closed: int
+    transitions: dict[str, int] = field(default_factory=dict)   # outreach_status -> count
+    events_emitted: int = 0
+    next_cycles_released: int = 0
+
+
+async def find_cycles_to_close(db_conn: Any) -> list[dict]:
+    """Return active cycles that have reached day 30 (cycle_day_1_date + 30)."""
+    rows = await db_conn.fetch(
+        """
+        SELECT id, client_id, cycle_day_1_date, cycle_number
+        FROM cycles
+        WHERE status = 'active'
+          AND (CURRENT_DATE - cycle_day_1_date) >= $1
+        ORDER BY cycle_day_1_date
+        """,
+        CYCLE_LENGTH_DAYS,
+    )
+    return [dict(r) for r in rows]
+
+
+async def transition_cycle_prospects(db_conn: Any, cycle_id: str) -> dict[str, int]:
+    """Advance every cycle_prospects row for this cycle to its terminal state.
+
+    Priority when multiple signals exist:
+      meeting_booked > replied > complete
+    Rows already in suppressed | meeting_booked | replied | complete are left
+    untouched (idempotent).
+    """
+    counts = {"meeting_booked": 0, "replied": 0, "complete": 0}
+
+    # meeting_booked — highest priority
+    r = await db_conn.execute(
+        """
+        UPDATE cycle_prospects cp
+        SET outreach_status = 'meeting_booked', updated_at = NOW()
+        WHERE cp.cycle_id = $1
+          AND cp.outreach_status = 'in_sequence'
+          AND EXISTS (
+              SELECT 1 FROM dm_meetings m WHERE m.prospect_id = cp.prospect_id
+          )
+        """,
+        cycle_id,
+    )
+    counts["meeting_booked"] = _rowcount(r)
+
+    # replied — any reply row for prospect
+    r = await db_conn.execute(
+        """
+        UPDATE cycle_prospects cp
+        SET outreach_status = 'replied', updated_at = NOW()
+        WHERE cp.cycle_id = $1
+          AND cp.outreach_status = 'in_sequence'
+          AND EXISTS (
+              SELECT 1 FROM replies rp WHERE rp.prospect_id = cp.prospect_id
+          )
+        """,
+        cycle_id,
+    )
+    counts["replied"] = _rowcount(r)
+
+    # complete — everyone left still in_sequence
+    r = await db_conn.execute(
+        """
+        UPDATE cycle_prospects
+        SET outreach_status = 'complete', updated_at = NOW()
+        WHERE cycle_id = $1 AND outreach_status = 'in_sequence'
+        """,
+        cycle_id,
+    )
+    counts["complete"] = _rowcount(r)
+
+    return counts
+
+
+async def mark_cycle_closed(db_conn: Any, cycle_id: str) -> None:
+    await db_conn.execute(
+        """
+        UPDATE cycles
+        SET status = 'complete', completed_at = NOW(), updated_at = NOW()
+        WHERE id = $1 AND status = 'active'
+        """,
+        cycle_id,
+    )
+
+
+async def emit_cycle_close_event(db_conn: Any, cycle: dict, transitions: dict) -> None:
+    """Insert a cycle_close row into outreach_events (best-effort; swallow errors)."""
+    try:
+        await db_conn.execute(
+            """
+            INSERT INTO outreach_events (event_type, client_id, payload, created_at)
+            VALUES ('cycle_close', $1, $2::jsonb, NOW())
+            """,
+            cycle["client_id"],
+            {
+                "cycle_id": str(cycle["id"]),
+                "cycle_number": cycle["cycle_number"],
+                "transitions": transitions,
+            },
+        )
+    except Exception as exc:  # pragma: no cover — logged, not raised
+        logger.warning("cycle_close event emit failed for cycle=%s: %s", cycle["id"], exc)
+
+
+async def trigger_next_cycle_release(
+    db_conn: Any, client_id: str, new_cycle_trigger,
+) -> bool:
+    """Call the injected new_cycle_trigger(db_conn, client_id) to release a new
+    30-day cycle for active customers. Returns True on success."""
+    try:
+        await new_cycle_trigger(db_conn, client_id)
+        return True
+    except Exception as exc:  # pragma: no cover
+        logger.warning("next-cycle trigger failed for client=%s: %s", client_id, exc)
+        return False
+
+
+def _rowcount(result: Any) -> int:
+    if isinstance(result, int):
+        return result
+    if hasattr(result, "rowcount"):
+        return result.rowcount or 0
+    if isinstance(result, str) and " " in result:
+        parts = result.split()
+        if parts[-1].isdigit():
+            return int(parts[-1])
+    return 0
+
+
+@task(name="close-cycles")
+async def close_cycles_task(
+    db_conn: Any, new_cycle_trigger,
+) -> CycleCloseSummary:
+    summary = CycleCloseSummary(cycles_closed=0, transitions={
+        "meeting_booked": 0, "replied": 0, "complete": 0,
+    })
+    cycles = await find_cycles_to_close(db_conn)
+    for cycle in cycles:
+        transitions = await transition_cycle_prospects(db_conn, cycle["id"])
+        for k, v in transitions.items():
+            summary.transitions[k] = summary.transitions.get(k, 0) + v
+        await mark_cycle_closed(db_conn, cycle["id"])
+        await emit_cycle_close_event(db_conn, cycle, transitions)
+        summary.events_emitted += 1
+        if await trigger_next_cycle_release(db_conn, cycle["client_id"], new_cycle_trigger):
+            summary.next_cycles_released += 1
+        summary.cycles_closed += 1
+    return summary
+
+
+async def _default_new_cycle_trigger(db_conn: Any, client_id: str) -> None:
+    """Default next-cycle trigger — stubbed as a no-op INSERT into cycles.
+    In production this is overridden by the deployment to call
+    cadence_orchestrator's cycle-release helper with real sequence defaults."""
+    await db_conn.execute(
+        """
+        INSERT INTO cycles (client_id, cycle_number, target_prospects, cycle_day_1_date, status)
+        SELECT $1, COALESCE(MAX(cycle_number), 0) + 1, 0, CURRENT_DATE, 'active'
+        FROM cycles WHERE client_id = $1
+        """,
+        client_id,
+    )
+
+
+@flow(name="monthly-cycle-close", log_prints=True)
+async def monthly_cycle_close_flow(
+    db_conn: Any,
+    new_cycle_trigger=_default_new_cycle_trigger,
+) -> CycleCloseSummary:
+    summary = await close_cycles_task(db_conn, new_cycle_trigger)
+    logger.info("monthly_cycle_close_flow complete: %s", summary)
+    return summary
+
+
+def get_monthly_cycle_close_schedule() -> CronSchedule:
+    """1st of month 00:30 AEST."""
+    return CronSchedule(cron="30 0 1 * *", timezone="Australia/Sydney")

--- a/src/orchestration/flows/weekly_linkedin_reset_flow.py
+++ b/src/orchestration/flows/weekly_linkedin_reset_flow.py
@@ -1,0 +1,112 @@
+"""
+Contract: src/orchestration/flows/weekly_linkedin_reset_flow.py
+Purpose: Monday 00:00 AEST flow that resets LinkedIn weekly counters so each
+         new week starts with a fresh 100-connect + 350-message cap per
+         account. Idempotent: re-running during the same ISO-week is a no-op.
+Layer:   orchestration
+Imports: prefect, db connection
+Consumers: Prefect scheduler (weekly deployment — Monday)
+
+Works by deleting stale outreach_rate_state rows (channel='linkedin') whose
+window_start < this_week_monday_00_utc. The rate_limiter will re-initialise
+fresh rows on the next send against any account.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from prefect import flow, task
+from prefect.client.schemas.schedules import CronSchedule
+
+logger = logging.getLogger(__name__)
+
+AEST = ZoneInfo("Australia/Sydney")
+
+
+@dataclass
+class LinkedInResetSummary:
+    fired_on_monday: bool
+    rows_reset: int
+    accounts_affected: int
+    week_start: datetime
+
+
+def _current_week_monday(now_aest: datetime) -> datetime:
+    """Return Monday 00:00 AEST of the ISO-week containing now_aest."""
+    # weekday(): Monday=0 .. Sunday=6
+    monday = (now_aest - timedelta(days=now_aest.weekday())).replace(
+        hour=0, minute=0, second=0, microsecond=0,
+    )
+    return monday
+
+
+def _is_monday(now_aest: datetime) -> bool:
+    return now_aest.weekday() == 0
+
+
+async def reset_linkedin_weekly(db_conn: Any, now_aest: datetime) -> dict:
+    """Delete stale outreach_rate_state rows (linkedin channel) whose
+    window_start < this week's Monday 00:00 AEST (converted to UTC for
+    comparison).
+
+    Returns {"rows_reset": N, "accounts_affected": M}.
+
+    If now_aest is NOT a Monday, returns zeros and does NOT touch the table.
+    """
+    if not _is_monday(now_aest):
+        return {"rows_reset": 0, "accounts_affected": 0}
+
+    monday_aest = _current_week_monday(now_aest)
+    monday_utc = monday_aest.astimezone(timezone.utc)
+
+    # Count affected rows first (for idempotent reporting), then DELETE.
+    count_rows = await db_conn.fetch(
+        """
+        SELECT COUNT(*) AS rows_reset,
+               COUNT(DISTINCT account_id) AS accounts_affected
+        FROM outreach_rate_state
+        WHERE channel = 'linkedin' AND window_start < $1
+        """,
+        monday_utc,
+    )
+    # Delete them. Rate limiter re-creates fresh rows on next send.
+    await db_conn.execute(
+        """
+        DELETE FROM outreach_rate_state
+        WHERE channel = 'linkedin' AND window_start < $1
+        """,
+        monday_utc,
+    )
+    r = count_rows[0] if count_rows else {"rows_reset": 0, "accounts_affected": 0}
+    return {"rows_reset": r["rows_reset"], "accounts_affected": r["accounts_affected"]}
+
+
+@task(name="reset-linkedin-weekly")
+async def reset_linkedin_weekly_task(db_conn: Any, now_aest: datetime) -> dict:
+    return await reset_linkedin_weekly(db_conn, now_aest)
+
+
+@flow(name="weekly-linkedin-reset", log_prints=True)
+async def weekly_linkedin_reset_flow(
+    db_conn: Any,
+    now_fn=lambda: datetime.now(AEST),
+) -> LinkedInResetSummary:
+    now_aest = now_fn()
+    result = await reset_linkedin_weekly_task(db_conn, now_aest)
+    summary = LinkedInResetSummary(
+        fired_on_monday=_is_monday(now_aest),
+        rows_reset=result["rows_reset"],
+        accounts_affected=result["accounts_affected"],
+        week_start=_current_week_monday(now_aest),
+    )
+    logger.info("weekly_linkedin_reset_flow complete: %s", summary)
+    return summary
+
+
+def get_weekly_linkedin_reset_schedule() -> CronSchedule:
+    """Monday 00:00 AEST."""
+    return CronSchedule(cron="0 0 * * 1", timezone="Australia/Sydney")

--- a/tests/orchestration/flows/test_daily_warming_flow.py
+++ b/tests/orchestration/flows/test_daily_warming_flow.py
@@ -1,0 +1,146 @@
+"""Tests for daily_warming_flow — all run without a real DB or Prefect runtime."""
+from __future__ import annotations
+
+import logging
+import pytest
+
+from src.orchestration.flows.daily_warming_flow import (
+    WarmingAdvanceSummary,
+    advance_active_cycles,
+    advance_mailbox_warming,
+    daily_warming_flow,
+    get_daily_warming_schedule,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake DB connection
+# ---------------------------------------------------------------------------
+
+class FakeConn:
+    """Records all SQL calls; pops from rowcounts for execute(); returns
+    rows from fetch_rows for fetch()."""
+
+    def __init__(self, rowcounts: list[int], fetch_rows: list[list[dict]] | None = None):
+        self.calls: list[tuple] = []
+        self._rowcounts = list(rowcounts)
+        self._fetch_rows: list[list[dict]] = list(fetch_rows or [])
+
+    async def execute(self, sql: str, *args) -> int:
+        self.calls.append(("execute", sql, args))
+        return self._rowcounts.pop(0) if self._rowcounts else 0
+
+    async def fetch(self, sql: str, *args) -> list[dict]:
+        self.calls.append(("fetch", sql, args))
+        return self._fetch_rows.pop(0) if self._fetch_rows else []
+
+
+# ---------------------------------------------------------------------------
+# Case 1: advance_mailbox_warming returns correct counts
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_advance_mailbox_warming_counts():
+    """5 advanced, 1 graduated, fetch returns 4 NULL rows -> already_warmed=3,
+    9 daily_counts_reset."""
+    conn = FakeConn(
+        rowcounts=[5, 1, 9],
+        fetch_rows=[[{"n": 4}]],  # 4 NULL rows after graduation; minus 1 graduated = 3
+    )
+    result = await advance_mailbox_warming(conn)
+    assert result["advanced"] == 5
+    assert result["graduated"] == 1
+    assert result["already_warmed"] == 3
+    assert result["daily_counts_reset"] == 9
+
+
+# ---------------------------------------------------------------------------
+# Case 2: advance_active_cycles returns correct count
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_advance_active_cycles_count():
+    """Fake returns 3 -> function returns 3."""
+    conn = FakeConn(rowcounts=[3])
+    result = await advance_active_cycles(conn)
+    assert result == 3
+
+
+# ---------------------------------------------------------------------------
+# Case 3: daily_warming_flow composes WarmingAdvanceSummary correctly
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_daily_warming_flow_summary():
+    """End-to-end: flow calls both sub-functions and composes summary."""
+    conn = FakeConn(
+        rowcounts=[5, 1, 9, 3],
+        fetch_rows=[[{"n": 4}]],
+    )
+    summary = await daily_warming_flow(conn)
+    assert isinstance(summary, WarmingAdvanceSummary)
+    assert summary.mailboxes_advanced == 5
+    assert summary.mailboxes_graduated == 1
+    assert summary.mailboxes_already_warmed == 3
+    assert summary.daily_counts_reset == 9
+    assert summary.cycles_advanced == 3
+
+
+# ---------------------------------------------------------------------------
+# Case 4: Mailbox SQL contains warming_day ladder references
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mailbox_sql_contains_warming_ladder_keywords():
+    """The recorded SQL must reference warming_day and daily_count; the
+    WARMED_AT_DAY value (15) must appear either in SQL text or as a bind arg."""
+    conn = FakeConn(rowcounts=[0, 0, 0], fetch_rows=[[{"n": 0}]])
+    await advance_mailbox_warming(conn)
+
+    all_sql = " ".join(call[1] for call in conn.calls)
+    # Flatten all args tuples for arg presence check
+    all_args = [str(a) for call in conn.calls for a in call[2]]
+
+    assert "warming_day" in all_sql
+    assert "daily_count" in all_sql
+    # 15 may appear as literal in SQL or as a bind parameter
+    assert "15" in all_sql or "15" in all_args
+
+
+# ---------------------------------------------------------------------------
+# Case 5: Cycle advancement SQL is idempotent (contains CURRENT_DATE gate)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cycle_sql_is_idempotent():
+    """SQL must contain CURRENT_DATE or last_advanced_on guard."""
+    conn = FakeConn(rowcounts=[0])
+    await advance_active_cycles(conn)
+
+    assert conn.calls, "No SQL calls recorded"
+    sql = conn.calls[0][1]
+    assert "CURRENT_DATE" in sql or "last_advanced_on" in sql
+
+
+# ---------------------------------------------------------------------------
+# Case 6: get_daily_warming_schedule returns correct cron + timezone
+# ---------------------------------------------------------------------------
+
+def test_get_daily_warming_schedule():
+    from prefect.client.schemas.schedules import CronSchedule
+    sched = get_daily_warming_schedule()
+    assert isinstance(sched, CronSchedule)
+    assert sched.cron == "0 2 * * *"
+    assert "Sydney" in sched.timezone
+
+
+# ---------------------------------------------------------------------------
+# Case 7: Logging side-effect — INFO message emitted after successful run
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_daily_warming_flow_logs_info(caplog):
+    conn = FakeConn(rowcounts=[2, 0, 4, 1], fetch_rows=[[{"n": 0}]])
+    with caplog.at_level(logging.INFO, logger="src.orchestration.flows.daily_warming_flow"):
+        await daily_warming_flow(conn)
+    assert any("daily_warming_flow complete" in r.message for r in caplog.records)

--- a/tests/orchestration/flows/test_monthly_cycle_close_flow.py
+++ b/tests/orchestration/flows/test_monthly_cycle_close_flow.py
@@ -1,0 +1,215 @@
+"""
+Tests for src/orchestration/flows/monthly_cycle_close_flow.py.
+
+Covers: cycle-discovery filter, 3-tier state transition priority (meeting >
+replied > complete), idempotent close, event emission, next-cycle trigger
+fire, schedule cron/timezone. Uses an in-memory FakeConn to record all
+executed/fetched SQL without needing a real DB.
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+from src.orchestration.flows.monthly_cycle_close_flow import (
+    CYCLE_LENGTH_DAYS,
+    CycleCloseSummary,
+    close_cycles_task,
+    emit_cycle_close_event,
+    find_cycles_to_close,
+    get_monthly_cycle_close_schedule,
+    mark_cycle_closed,
+    monthly_cycle_close_flow,
+    transition_cycle_prospects,
+    trigger_next_cycle_release,
+)
+
+
+class FakeConn:
+    """Records every .execute / .fetch call. Returns programmable rowcounts
+    and fetch results in order."""
+
+    def __init__(
+        self,
+        fetch_returns: list[list[dict]] | None = None,
+        execute_rowcounts: list[int] | None = None,
+    ):
+        self.executed: list[tuple[str, tuple]] = []
+        self.fetched: list[tuple[str, tuple]] = []
+        self._fetch_returns = list(fetch_returns or [])
+        self._exec_rc = list(execute_rowcounts or [])
+
+    async def execute(self, sql: str, *args) -> int:
+        self.executed.append((sql, args))
+        return self._exec_rc.pop(0) if self._exec_rc else 0
+
+    async def fetch(self, sql: str, *args) -> list[dict]:
+        self.fetched.append((sql, args))
+        return self._fetch_returns.pop(0) if self._fetch_returns else []
+
+
+# -- find_cycles_to_close ---------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_find_cycles_filters_by_age_and_status():
+    rows = [
+        {"id": "c1", "client_id": "cl1", "cycle_day_1_date": date(2026, 3, 20), "cycle_number": 1},
+    ]
+    conn = FakeConn(fetch_returns=[rows])
+    out = await find_cycles_to_close(conn)
+    assert out == rows
+    sql, args = conn.fetched[0]
+    assert "status = 'active'" in sql
+    assert "CURRENT_DATE - cycle_day_1_date" in sql
+    assert args == (CYCLE_LENGTH_DAYS,)
+
+
+@pytest.mark.asyncio
+async def test_find_cycles_returns_empty_when_no_matches():
+    conn = FakeConn(fetch_returns=[[]])
+    assert await find_cycles_to_close(conn) == []
+
+
+# -- transition_cycle_prospects — priority + counts --------------------------
+
+@pytest.mark.asyncio
+async def test_transition_priority_meeting_beats_reply_beats_complete():
+    # meeting=2, replied=3, complete=5 — all three UPDATEs fire in order.
+    conn = FakeConn(execute_rowcounts=[2, 3, 5])
+    counts = await transition_cycle_prospects(conn, "cycle-1")
+    assert counts == {"meeting_booked": 2, "replied": 3, "complete": 5}
+    sqls = [s for (s, _) in conn.executed]
+    assert "meeting_booked" in sqls[0]
+    assert "replied" in sqls[1]
+    assert "complete" in sqls[2]
+
+
+@pytest.mark.asyncio
+async def test_transition_idempotent_when_all_already_terminal():
+    conn = FakeConn(execute_rowcounts=[0, 0, 0])
+    counts = await transition_cycle_prospects(conn, "cycle-1")
+    assert counts == {"meeting_booked": 0, "replied": 0, "complete": 0}
+
+
+# -- mark_cycle_closed ------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mark_cycle_closed_gates_on_active():
+    conn = FakeConn()
+    await mark_cycle_closed(conn, "cycle-1")
+    sql, args = conn.executed[0]
+    assert "status = 'complete'" in sql
+    assert "status = 'active'" in sql
+    assert args == ("cycle-1",)
+
+
+# -- emit_cycle_close_event -------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_emit_cycle_close_event_inserts_outreach_event():
+    conn = FakeConn()
+    cycle = {"id": "c1", "client_id": "cl1", "cycle_number": 7}
+    transitions = {"meeting_booked": 2, "replied": 3, "complete": 5}
+    await emit_cycle_close_event(conn, cycle, transitions)
+    sql, args = conn.executed[0]
+    assert "INSERT INTO outreach_events" in sql
+    assert "'cycle_close'" in sql
+    payload = args[1]
+    assert payload["cycle_id"] == "c1"
+    assert payload["cycle_number"] == 7
+    assert payload["transitions"] == transitions
+
+
+# -- trigger_next_cycle_release ---------------------------------------------
+
+@pytest.mark.asyncio
+async def test_trigger_next_cycle_release_calls_injected_fn():
+    calls = []
+
+    async def trigger(db, client_id):
+        calls.append((db, client_id))
+
+    conn = FakeConn()
+    ok = await trigger_next_cycle_release(conn, "cl1", trigger)
+    assert ok is True
+    assert calls == [(conn, "cl1")]
+
+
+@pytest.mark.asyncio
+async def test_trigger_next_cycle_release_swallows_error():
+    async def bad_trigger(db, client_id):
+        raise RuntimeError("boom")
+
+    conn = FakeConn()
+    ok = await trigger_next_cycle_release(conn, "cl1", bad_trigger)
+    assert ok is False
+
+
+# -- close_cycles_task composition ------------------------------------------
+
+@pytest.mark.asyncio
+async def test_close_cycles_task_end_to_end_two_cycles():
+    cycles = [
+        {"id": "c1", "client_id": "cl1", "cycle_day_1_date": date(2026, 3, 20), "cycle_number": 1},
+        {"id": "c2", "client_id": "cl2", "cycle_day_1_date": date(2026, 3, 22), "cycle_number": 2},
+    ]
+    # per cycle: 3 transition UPDATEs + 1 mark_cycle_closed + 1 event emit = 5 execs
+    # order of rowcounts: (meeting, replied, complete, mark, event) × 2
+    conn = FakeConn(
+        fetch_returns=[cycles],
+        execute_rowcounts=[2, 3, 5, 1, 1,  1, 2, 4, 1, 1],
+    )
+    calls = []
+
+    async def trigger(db, client_id):
+        calls.append(client_id)
+
+    summary = await close_cycles_task(conn, trigger)
+    assert summary.cycles_closed == 2
+    assert summary.transitions == {
+        "meeting_booked": 3, "replied": 5, "complete": 9,
+    }
+    assert summary.events_emitted == 2
+    assert summary.next_cycles_released == 2
+    assert calls == ["cl1", "cl2"]
+
+
+@pytest.mark.asyncio
+async def test_close_cycles_task_no_cycles_returns_zero_summary():
+    conn = FakeConn(fetch_returns=[[]])
+
+    async def trigger(db, client_id):
+        pass
+
+    summary = await close_cycles_task(conn, trigger)
+    assert summary.cycles_closed == 0
+    assert summary.events_emitted == 0
+    assert summary.next_cycles_released == 0
+
+
+# -- monthly_cycle_close_flow (via .fn) -------------------------------------
+
+@pytest.mark.asyncio
+async def test_flow_fn_composes_summary():
+    conn = FakeConn(fetch_returns=[[]])
+
+    async def trigger(db, client_id):
+        pass
+
+    summary = await monthly_cycle_close_flow.fn(conn, new_cycle_trigger=trigger)
+    assert isinstance(summary, CycleCloseSummary)
+    assert summary.cycles_closed == 0
+
+
+# -- schedule ---------------------------------------------------------------
+
+def test_get_schedule_cron_and_tz():
+    s = get_monthly_cycle_close_schedule()
+    assert s.cron == "30 0 1 * *"
+    assert str(s.timezone) == "Australia/Sydney"
+
+
+def test_cycle_length_constant_is_30():
+    assert CYCLE_LENGTH_DAYS == 30

--- a/tests/orchestration/flows/test_weekly_linkedin_reset_flow.py
+++ b/tests/orchestration/flows/test_weekly_linkedin_reset_flow.py
@@ -1,0 +1,186 @@
+"""Tests for weekly_linkedin_reset_flow.py — 9 cases."""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from prefect.client.schemas.schedules import CronSchedule
+
+from src.orchestration.flows.weekly_linkedin_reset_flow import (
+    AEST,
+    LinkedInResetSummary,
+    _current_week_monday,
+    _is_monday,
+    get_weekly_linkedin_reset_schedule,
+    reset_linkedin_weekly,
+    weekly_linkedin_reset_flow,
+)
+
+# ---------------------------------------------------------------------------
+# Fake DB
+# ---------------------------------------------------------------------------
+
+class FakeConn:
+    def __init__(self, count_row=None):
+        self.executed: list[tuple] = []
+        self.fetched: list[tuple] = []
+        self._count_row = count_row or {"rows_reset": 0, "accounts_affected": 0}
+
+    async def execute(self, sql: str, *args) -> int:
+        self.executed.append((sql, args))
+        return 0
+
+    async def fetch(self, sql: str, *args) -> list[dict]:
+        self.fetched.append((sql, args))
+        return [self._count_row]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MONDAY = datetime(2026, 4, 20, 9, 0, 0, tzinfo=AEST)       # Monday
+WEDNESDAY = datetime(2026, 4, 22, 12, 0, 0, tzinfo=AEST)   # Wednesday
+SUNDAY = datetime(2026, 4, 19, 23, 59, 0, tzinfo=AEST)     # Sunday
+TUESDAY = datetime(2026, 4, 21, 8, 0, 0, tzinfo=AEST)      # Tuesday
+
+
+# ---------------------------------------------------------------------------
+# Case 1: _is_monday
+# ---------------------------------------------------------------------------
+
+def test_is_monday_true():
+    assert _is_monday(MONDAY) is True
+
+
+def test_is_monday_false_sunday():
+    assert _is_monday(SUNDAY) is False
+
+
+def test_is_monday_false_tuesday():
+    assert _is_monday(TUESDAY) is False
+
+
+# ---------------------------------------------------------------------------
+# Case 2: _current_week_monday — Wed 2026-04-22 → Mon 2026-04-20 00:00 AEST
+# ---------------------------------------------------------------------------
+
+def test_current_week_monday_from_wednesday():
+    result = _current_week_monday(WEDNESDAY)
+    expected = datetime(2026, 4, 20, 0, 0, 0, tzinfo=AEST)
+    assert result == expected
+
+
+def test_current_week_monday_from_monday():
+    result = _current_week_monday(MONDAY)
+    expected = datetime(2026, 4, 20, 0, 0, 0, tzinfo=AEST)
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Case 3: reset_linkedin_weekly on Monday — fetch THEN execute (order check)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reset_on_monday_fetch_before_execute():
+    conn = FakeConn(count_row={"rows_reset": 5, "accounts_affected": 3})
+    result = await reset_linkedin_weekly(conn, MONDAY)
+
+    # Both fetch and execute must have been called
+    assert len(conn.fetched) == 1
+    assert len(conn.executed) == 1
+    # fetch comes first in the call sequence (tracked independently, but
+    # we verify both happened)
+    assert result["rows_reset"] == 5
+    assert result["accounts_affected"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Case 4: reset on non-Monday — zero returns, NO DB calls
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reset_on_wednesday_no_db_calls():
+    conn = FakeConn()
+    result = await reset_linkedin_weekly(conn, WEDNESDAY)
+
+    assert conn.executed == []
+    assert conn.fetched == []
+    assert result == {"rows_reset": 0, "accounts_affected": 0}
+
+
+# ---------------------------------------------------------------------------
+# Case 5: Idempotent — two calls on same Monday both return well-formed dicts
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_idempotent_same_monday():
+    conn = FakeConn(count_row={"rows_reset": 4, "accounts_affected": 2})
+    r1 = await reset_linkedin_weekly(conn, MONDAY)
+    # Second call: fake returns 0 rows (DELETE already cleared them)
+    conn._count_row = {"rows_reset": 0, "accounts_affected": 0}
+    r2 = await reset_linkedin_weekly(conn, MONDAY)
+
+    for r in (r1, r2):
+        assert "rows_reset" in r
+        assert "accounts_affected" in r
+    assert r2["rows_reset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Case 6: Returned dict reflects fetch count row values
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_result_reflects_count_row():
+    conn = FakeConn(count_row={"rows_reset": 12, "accounts_affected": 7})
+    result = await reset_linkedin_weekly(conn, MONDAY)
+    assert result["rows_reset"] == 12
+    assert result["accounts_affected"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Case 7: weekly_linkedin_reset_flow.fn composes LinkedInResetSummary on Monday
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_flow_fn_monday_summary():
+    conn = FakeConn(count_row={"rows_reset": 3, "accounts_affected": 2})
+    summary = await weekly_linkedin_reset_flow.fn(
+        db_conn=conn,
+        now_fn=lambda: MONDAY,
+    )
+    assert isinstance(summary, LinkedInResetSummary)
+    assert summary.fired_on_monday is True
+    assert summary.rows_reset == 3
+    assert summary.accounts_affected == 2
+    assert summary.week_start == datetime(2026, 4, 20, 0, 0, 0, tzinfo=AEST)
+
+
+# ---------------------------------------------------------------------------
+# Case 8: Non-Monday flow — fired_on_monday=False, zeros
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_flow_fn_non_monday_summary():
+    conn = FakeConn()
+    summary = await weekly_linkedin_reset_flow.fn(
+        db_conn=conn,
+        now_fn=lambda: WEDNESDAY,
+    )
+    assert isinstance(summary, LinkedInResetSummary)
+    assert summary.fired_on_monday is False
+    assert summary.rows_reset == 0
+    assert summary.accounts_affected == 0
+
+
+# ---------------------------------------------------------------------------
+# Case 9: get_weekly_linkedin_reset_schedule returns correct CronSchedule
+# ---------------------------------------------------------------------------
+
+def test_get_schedule_cron_and_tz():
+    schedule = get_weekly_linkedin_reset_schedule()
+    assert isinstance(schedule, CronSchedule)
+    assert schedule.cron == "0 0 * * 1"
+    assert schedule.timezone == "Australia/Sydney"


### PR DESCRIPTION
## Summary

Dispatch: **AIDEN → ORION**, `PHASE-2-SLICE-6 NARROWED` (2026-04-23, 90-min timebox). Elliot's counter-proposal scope: Prefect flows only. DNCR + alert wiring + dispatcher LinkedIn gate → slice 7.

Branched from fresh `origin/main` @ `77b87c1`. Pre-PR rebase gate verified at push — merge-base = main tip, no rebase needed.

## Tracks shipped

### Track A — daily_warming_flow.py
- `src/orchestration/flows/daily_warming_flow.py` (commit `50c4dde`)
- `@flow` scheduled daily 02:00 AEST. Advances `warming_day` +1 per mailbox (days 1–3 cap 10, 4–6 cap 25, 7–10 cap 50, 11–14 cap 75, ≥15 cap 100 + warming_day → NULL graduation). Resets `daily_count` to 0 on every mailbox.
- Advances cycle_day for active cycles; idempotency guard via CURRENT_DATE / last_advanced_on gate so re-running same day is a no-op.
- `get_daily_warming_schedule()` → `CronSchedule("0 2 * * *", Australia/Sydney)`.
- **7 tests pass.**

### Track B — weekly_linkedin_reset_flow.py
- `src/orchestration/flows/weekly_linkedin_reset_flow.py` (commit `50d335f`)
- `@flow` scheduled Monday 00:00 AEST. Deletes stale `outreach_rate_state` rows WHERE `channel='linkedin' AND window_start < this_week_monday_00_utc` — rate_limiter re-creates fresh rows on next send, cap = 100/week + 350/week message proxy.
- Guard: `_is_monday()` check gates all DB work; non-Monday invocations return zeros with **no DB calls** (defensive for manual re-runs).
- `get_weekly_linkedin_reset_schedule()` → `CronSchedule("0 0 * * 1", Australia/Sydney)`.
- **12 tests pass.**

### Track C — monthly_cycle_close_flow.py
- `src/orchestration/flows/monthly_cycle_close_flow.py` (commit `2dd0acd`)
- `@flow` scheduled 1st of month 00:30 AEST.
- State transition rules — priority ordered, idempotent:
  - `in_sequence` → `meeting_booked` (prospect has `dm_meetings` row) — dispatch vocab: "converted"
  - `in_sequence` → `replied` (prospect has `replies` row)
  - `in_sequence` → `complete` (no reply, no meeting) — dispatch vocab: "closed_no_reply"
  - Schema note: canonical enum is `{pending, in_sequence, replied, meeting_booked, suppressed, complete}`; the dispatch's loose labels are mapped in the module docstring.
- Per-cycle ops: find → transition_prospects (3 UPDATEs) → mark_cycle_closed → emit `outreach_events(event_type='cycle_close')` → `new_cycle_trigger(db_conn, client_id)` for fresh cycle release.
- `new_cycle_trigger` is injected — default stub inserts a new active cycle row; production deployment overrides with `cadence_orchestrator`'s full cycle-release helper.
- `get_monthly_cycle_close_schedule()` → `CronSchedule("30 0 1 * *", Australia/Sydney)`.
- **13 tests pass.**

## Tests

Full slice-6 regression:
```
pytest tests/orchestration/flows/test_daily_warming_flow.py tests/orchestration/flows/test_weekly_linkedin_reset_flow.py tests/orchestration/flows/test_monthly_cycle_close_flow.py -q
→ 32 passed
```

Tests drive flow internals directly via injected `db_conn` fakes (recording `.execute`/`.fetch` calls) and `flow.fn(...)` entrypoint — no Prefect runtime dependency, no real DB. The only noise is benign async-teardown warnings from Prefect's log handler; no test fails.

## Governance trace

- **Scope (C5):** 6 new files across `src/orchestration/flows/` + `tests/orchestration/flows/`. No changes to `scheduled_jobs.py` (schedule registration is a separate dispatch). No touches to ATLAS territory (Prospect Drawer, Feed route), `docs/MANUAL.md`, or `enforcer_bot.py`.
- **Branch (C6):** `orion/phase-2-slice-6`. No push to main.
- **Base verified:** `git merge-base HEAD origin/main = 77b87c1` at push time. Pre-PR rebase gate honoured.
- **Zero-deletion merge:** purely additive.
- **Parallelisation:** build-3 (A), build-2 (B), ORION (C) + orchestrator review of sub-agent output before push.

## Known follow-ups

- Schedule registration in `src/orchestration/schedules/scheduled_jobs.py` deferred — deployments can register via these flows' `get_*_schedule()` helpers when ready.
- `new_cycle_trigger` default in monthly-close is a stub INSERT; production-wire to `cadence_orchestrator`'s cycle-release helper is the slice-7+ dispatch.
- DNCR + operator alert + dispatcher LinkedIn gate — deferred to slice 7 per Elliot's counter-proposal.

## Test plan

- [ ] Aiden peer-review per-track diff
- [ ] Elliot `[FINAL CONCUR:elliot]` before merge (non-dispatching orchestrator)
- [ ] Apply schedules in scheduled_jobs.py (follow-up dispatch)
- [ ] Smoke on Supabase: dry-run `find_cycles_to_close` against real data to confirm SELECT semantics before enabling the @flow in prod

🤖 Dispatched to ORION build-clone via [Claude Code](https://claude.com/claude-code)