### PR TITLE
[ATLAS] Phase 2.1 — Unified outreach timeline + VR popover

### DIFF
--- a/frontend/components/dashboard/OutreachTimeline.tsx
+++ b/frontend/components/dashboard/OutreachTimeline.tsx
@@ -1,0 +1,200 @@
+/**
+ * FILE: frontend/components/dashboard/OutreachTimeline.tsx
+ * PURPOSE: Vertical timeline — past (emerald) + NOW divider + future (amber) + state (blue)
+ * PHASE: PHASE-2.1-TIMELINE-VR-POPOVERS
+ *
+ * Used inside ProspectDrawer. Consumes TimelineEvent[] from useOutreachTimeline.
+ * Per-future-touch controls (Pause / Skip / Accelerate) POST to
+ * /api/v1/outreach/approval.
+ */
+
+"use client";
+
+import { useState } from "react";
+import {
+  Mail, Linkedin, Phone, MessageSquare, MessageCircle,
+  PauseCircle, SkipForward, FastForward, Flag,
+} from "lucide-react";
+import type { TimelineEvent } from "@/lib/hooks/useOutreachTimeline";
+import { canonicalChannel, providerLabel } from "@/lib/provider-labels";
+
+interface Props {
+  events: TimelineEvent[];
+  isLoading?: boolean;
+}
+
+function channelIcon(channel: string | null) {
+  const label = canonicalChannel(channel ?? "");
+  const Icon =
+    label === "Email"    ? Mail :
+    label === "LinkedIn" ? Linkedin :
+    label === "SMS"      ? MessageSquare :
+    label === "Voice AI" ? Phone :
+    MessageCircle;
+  return <Icon className="w-3.5 h-3.5" strokeWidth={1.75} />;
+}
+
+function fmt(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function OutreachTimeline({ events, isLoading }: Props) {
+  // Split at "now" to insert the NOW divider
+  const pastOrNow: TimelineEvent[] = [];
+  const future: TimelineEvent[] = [];
+  for (const e of events) {
+    if (e.isFuture) future.push(e);
+    else pastOrNow.push(e);
+  }
+
+  if (!events.length) {
+    return (
+      <div className="text-xs text-gray-500 italic">
+        {isLoading ? "Loading timeline…" : "No outreach activity yet."}
+      </div>
+    );
+  }
+
+  return (
+    <ol className="relative pl-5 border-l border-gray-800 space-y-3">
+      {pastOrNow.map((e) => <TimelineRow key={e.id} event={e} />)}
+      <NowDivider />
+      {future.map((e) => <TimelineRow key={e.id} event={e} />)}
+    </ol>
+  );
+}
+
+function NowDivider() {
+  return (
+    <li className="relative -ml-[9px] flex items-center gap-2 py-1">
+      <span className="w-[18px] h-[18px] rounded-full bg-gray-950 border-2 border-amber-400 flex items-center justify-center">
+        <span className="w-1.5 h-1.5 rounded-full bg-amber-400" />
+      </span>
+      <span className="font-mono text-[10px] uppercase tracking-widest text-amber-300">
+        Now
+      </span>
+      <span className="flex-1 h-px bg-amber-400/20" />
+    </li>
+  );
+}
+
+function TimelineRow({ event }: { event: TimelineEvent }) {
+  const [pending, setPending] = useState<string | null>(null);
+  const [done, setDone] = useState<string | null>(null);
+
+  const color = colorFor(event);
+  const timeColor =
+    event.type === "state" ? "text-sky-300" :
+    event.isFuture         ? "text-amber-300" :
+                             "text-emerald-300";
+
+  const runAction = async (action: "pause" | "skip" | "accelerate") => {
+    if (!event.touchId) return;
+    setPending(action);
+    try {
+      const res = await fetch("/api/v1/outreach/approval", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          touch_id: event.touchId,
+          action: action === "accelerate" ? "approve" :
+                  action === "skip"       ? "reject"  :
+                                            "defer",
+        }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setDone(action);
+    } catch (e) {
+      console.error("[OutreachTimeline] action failed", e);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <li className="relative">
+      {/* Dot on the rail */}
+      <span
+        className={`absolute -left-[21px] top-1 w-2.5 h-2.5 rounded-full border-2 bg-gray-950 ${color.dot}`}
+        aria-hidden
+      />
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className={`flex items-center gap-2 text-xs font-mono uppercase tracking-wider ${timeColor}`}>
+            {event.type === "state" ? <Flag className="w-3 h-3" /> : channelIcon(event.channel)}
+            <span>
+              {event.type === "state"
+                ? event.title
+                : canonicalChannel(event.channel ?? "")}
+            </span>
+            {event.sequenceStep && event.type !== "state" && (
+              <span className="text-gray-500"> · step {event.sequenceStep}</span>
+            )}
+          </div>
+          <div className="text-[11px] text-gray-500 font-mono mt-0.5">
+            {fmt(event.timestamp)}
+            {event.status ? <span> · {providerLabel(event.status)}</span> : null}
+          </div>
+          {event.content && (
+            <div className="text-xs text-gray-400 mt-1 line-clamp-2">
+              &ldquo;{providerLabel(event.content)}&rdquo;
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Per-future-touch controls */}
+      {event.type === "scheduled" && event.isFuture && event.touchId && (
+        <div className="flex gap-1.5 mt-1.5">
+          <CtlBtn
+            icon={<PauseCircle className="w-3 h-3" />}
+            label="Pause 24h"
+            onClick={() => runAction("pause")}
+            pending={pending === "pause"} done={done === "pause"}
+          />
+          <CtlBtn
+            icon={<SkipForward className="w-3 h-3" />}
+            label="Skip"
+            onClick={() => runAction("skip")}
+            pending={pending === "skip"} done={done === "skip"}
+          />
+          <CtlBtn
+            icon={<FastForward className="w-3 h-3" />}
+            label="Accelerate"
+            onClick={() => runAction("accelerate")}
+            pending={pending === "accelerate"} done={done === "accelerate"}
+          />
+        </div>
+      )}
+    </li>
+  );
+}
+
+function CtlBtn({
+  icon, label, onClick, pending, done,
+}: { icon: React.ReactNode; label: string; onClick: () => void; pending: boolean; done: boolean }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={pending}
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-gray-800 bg-gray-900 text-[10px] text-gray-400 hover:border-amber-500/40 hover:text-amber-300 disabled:opacity-40"
+    >
+      {icon}
+      <span>{pending ? "…" : done ? "✓" : label}</span>
+    </button>
+  );
+}
+
+function colorFor(e: TimelineEvent): { dot: string } {
+  if (e.type === "state")       return { dot: "border-sky-400" };
+  if (e.isFuture)               return { dot: "border-amber-400" };
+  if (e.type === "reply")       return { dot: "border-emerald-400" };
+  return { dot: "border-emerald-500" };
+}

--- a/frontend/components/dashboard/ProspectDrawer.tsx
+++ b/frontend/components/dashboard/ProspectDrawer.tsx
@@ -16,50 +16,22 @@
 
 import { useEffect, useState } from "react";
 import {
-  X, Mail, Linkedin, Phone, MessageSquare, ExternalLink,
+  X, Mail, Linkedin, Phone, ExternalLink,
   PauseCircle, SkipForward, Ban,
 } from "lucide-react";
-import {
-  useProspectDetail, type TouchEvent, type ScheduledTouch, type ReplyEvent,
-} from "@/lib/hooks/useProspectDetail";
-import { canonicalChannel, providerLabel } from "@/lib/provider-labels";
+import { useProspectDetail } from "@/lib/hooks/useProspectDetail";
+import { useOutreachTimeline } from "@/lib/hooks/useOutreachTimeline";
+import { OutreachTimeline } from "./OutreachTimeline";
+import { VRGradePopover } from "./VRGradePopover";
 
 interface Props {
   leadId: string | null;
   onClose: () => void;
 }
 
-const GRADE_COLOR: Record<string, string> = {
-  A: "bg-emerald-500/15 text-emerald-300 border-emerald-500/40",
-  B: "bg-amber-500/10 text-amber-300 border-amber-500/40",
-  C: "bg-amber-500/10 text-amber-300 border-amber-500/40",
-  D: "bg-red-500/10 text-red-300 border-red-500/40",
-  F: "bg-red-500/10 text-red-300 border-red-500/40",
-};
-
-function channelIcon(channel: string | null) {
-  const label = canonicalChannel(channel ?? "");
-  const Icon =
-    label === "Email"    ? Mail :
-    label === "LinkedIn" ? Linkedin :
-    label === "SMS"      ? MessageSquare :
-    label === "Voice AI" ? Phone :
-    Mail;
-  return <Icon className="w-3.5 h-3.5" strokeWidth={1.75} />;
-}
-
-function fmtDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}
-
 export function ProspectDrawer({ leadId, onClose }: Props) {
   const { prospect, isLoading } = useProspectDetail(leadId);
+  const timeline = useOutreachTimeline(prospect);
   const [actionState, setActionState] = useState<string | null>(null);
 
   // Escape closes drawer
@@ -113,9 +85,12 @@ export function ProspectDrawer({ leadId, onClose }: Props) {
           </div>
           <div className="flex items-center gap-2 shrink-0">
             {prospect?.vrGrade && (
-              <span className={`text-[11px] font-mono font-bold px-2 py-0.5 rounded border ${GRADE_COLOR[prospect.vrGrade] ?? ""}`}>
-                {prospect.vrGrade}
-              </span>
+              <VRGradePopover
+                grade={prospect.vrGrade}
+                score={prospect.score}
+                vr={prospect.vr}
+                evidence={buildEvidence(prospect)}
+              />
             )}
             <button
               onClick={onClose}
@@ -152,37 +127,9 @@ export function ProspectDrawer({ leadId, onClose }: Props) {
               <KV label="Location" value={prospect.enrichment.location} />
             </Section>
 
-            {/* Outreach timeline */}
+            {/* Unified outreach timeline */}
             <Section title="Outreach timeline">
-              {prospect.touches.length === 0 ? (
-                <Empty>No touches sent yet.</Empty>
-              ) : (
-                <ul className="space-y-2">
-                  {prospect.touches.map((t) => <TouchRow key={t.id} t={t} />)}
-                </ul>
-              )}
-            </Section>
-
-            {/* Scheduled */}
-            <Section title="Scheduled touches">
-              {prospect.scheduled.length === 0 ? (
-                <Empty>No upcoming touches.</Empty>
-              ) : (
-                <ul className="space-y-2">
-                  {prospect.scheduled.map((s) => <ScheduledRow key={s.id} s={s} />)}
-                </ul>
-              )}
-            </Section>
-
-            {/* Replies */}
-            <Section title="Reply history">
-              {prospect.replies.length === 0 ? (
-                <Empty>No replies received.</Empty>
-              ) : (
-                <ul className="space-y-2">
-                  {prospect.replies.map((r) => <ReplyRow key={r.id} r={r} />)}
-                </ul>
-              )}
+              <OutreachTimeline events={timeline} isLoading={isLoading} />
             </Section>
 
             {/* Quick actions */}
@@ -271,65 +218,17 @@ function ContactRow({
   );
 }
 
-function TouchRow({ t }: { t: TouchEvent }) {
-  return (
-    <li className="flex items-start gap-2 text-xs text-gray-300 py-1.5 border-b border-gray-800/60">
-      {channelIcon(t.channel)}
-      <div className="flex-1 min-w-0">
-        <div className="flex justify-between gap-2">
-          <span className="text-gray-200">
-            {canonicalChannel(t.channel)}
-            {t.sequenceStep ? <span className="text-gray-500"> · step {t.sequenceStep}</span> : null}
-          </span>
-          <span className="text-gray-500 font-mono">{fmtDate(t.sentAt)}</span>
-        </div>
-        <div className="text-[11px] text-gray-500 mt-0.5 truncate">
-          {t.status ? providerLabel(t.status) : "sent"}
-          {t.replied ? <span className="text-emerald-400 ml-2">· replied</span> : null}
-        </div>
-      </div>
-    </li>
-  );
-}
-
-function ScheduledRow({ s }: { s: ScheduledTouch }) {
-  return (
-    <li className="flex items-center gap-2 text-xs text-gray-300 py-1.5 border-b border-gray-800/60">
-      {channelIcon(s.channel)}
-      <span className="flex-1 text-gray-200">
-        {canonicalChannel(s.channel)}
-        {s.sequenceStep ? <span className="text-gray-500"> · step {s.sequenceStep}</span> : null}
-      </span>
-      <span className="text-gray-500 font-mono">{fmtDate(s.scheduledAt)}</span>
-      <span className={`text-[10px] font-mono uppercase tracking-wider px-1.5 py-0.5 rounded ${
-        s.status === "paused" ? "bg-amber-500/10 text-amber-300" : "bg-gray-800 text-gray-400"
-      }`}>
-        {s.status}
-      </span>
-    </li>
-  );
-}
-
-function ReplyRow({ r }: { r: ReplyEvent }) {
-  return (
-    <li className="text-xs py-1.5 border-b border-gray-800/60">
-      <div className="flex items-center gap-2 text-gray-300">
-        {channelIcon(r.channel)}
-        <span className="text-gray-200">{canonicalChannel(r.channel ?? "")}</span>
-        {r.intent && (
-          <span className="text-[10px] font-mono uppercase tracking-wider text-amber-300">
-            · {r.intent}
-          </span>
-        )}
-        <span className="ml-auto text-gray-500 font-mono">{fmtDate(r.receivedAt)}</span>
-      </div>
-      {r.preview && (
-        <div className="text-[11px] text-gray-400 mt-0.5 truncate italic">
-          &ldquo;{providerLabel(r.preview)}&rdquo;
-        </div>
-      )}
-    </li>
-  );
+function buildEvidence(p: {
+  enrichment: { industry: string | null; employeeCount: number | null; location: string | null };
+  touches: Array<{ replied: boolean }>;
+}): string[] {
+  const out: string[] = [];
+  if (p.enrichment.industry) out.push(`Industry: ${p.enrichment.industry}`);
+  if (p.enrichment.employeeCount) out.push(`Staff: ${p.enrichment.employeeCount}`);
+  if (p.enrichment.location) out.push(`Based in ${p.enrichment.location}`);
+  const replies = p.touches.filter((t) => t.replied).length;
+  if (replies > 0) out.push(`${replies} reply${replies > 1 ? "s" : ""} recorded`);
+  return out;
 }
 
 function ActionButton({

--- a/frontend/components/dashboard/VRGradePopover.tsx
+++ b/frontend/components/dashboard/VRGradePopover.tsx
@@ -1,0 +1,224 @@
+/**
+ * FILE: frontend/components/dashboard/VRGradePopover.tsx
+ * PURPOSE: Clickable VR grade badge + breakdown popover (sub-scores, strengths,
+ *          improvements, evidence).
+ * PHASE: PHASE-2.1-TIMELINE-VR-POPOVERS
+ *
+ * Renders nothing for breakdown details if all sub-scores are null — falls
+ * back to just the grade letter. Smart positioning based on viewport space.
+ */
+
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import type { VRBreakdown } from "@/lib/hooks/useProspectDetail";
+
+interface Props {
+  grade: string | null;
+  score: number | null;
+  vr: VRBreakdown;
+  /** Optional evidence bullets derived by caller from enrichment data. */
+  evidence?: string[];
+}
+
+const GRADE_COLOR: Record<string, string> = {
+  A: "bg-emerald-500/15 text-emerald-300 border-emerald-500/40",
+  B: "bg-amber-500/10 text-amber-300 border-amber-500/40",
+  C: "bg-amber-500/10 text-amber-300 border-amber-500/40",
+  D: "bg-red-500/10 text-red-300 border-red-500/40",
+  F: "bg-red-500/10 text-red-300 border-red-500/40",
+};
+
+export function VRGradePopover({ grade, score, vr, evidence = [] }: Props) {
+  const [open, setOpen] = useState(false);
+  const [placeAbove, setPlaceAbove] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click / Esc
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (
+        popRef.current?.contains(e.target as Node) ||
+        btnRef.current?.contains(e.target as Node)
+      ) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Smart positioning: if the button is in the bottom half of the viewport,
+  // render the popover above.
+  useLayoutEffect(() => {
+    if (!open || !btnRef.current) return;
+    const rect = btnRef.current.getBoundingClientRect();
+    setPlaceAbove(rect.bottom > window.innerHeight / 2);
+  }, [open]);
+
+  if (!grade) return <span className="text-gray-600">—</span>;
+
+  const hasSubScores =
+    vr.intent !== null || vr.affordability !== null ||
+    vr.authority !== null || vr.timing !== null;
+
+  return (
+    <div className="relative inline-block">
+      <button
+        ref={btnRef}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className={`inline-flex items-center gap-1 text-[11px] font-mono font-bold px-2 py-0.5 rounded border ${GRADE_COLOR[grade] ?? ""}`}
+      >
+        {grade}
+        <ChevronDown className={`w-3 h-3 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open && (
+        <div
+          ref={popRef}
+          className={`absolute right-0 z-50 w-72 bg-gray-950 border border-gray-700 rounded-lg shadow-xl p-3 ${
+            placeAbove ? "bottom-full mb-2" : "top-full mt-2"
+          }`}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between mb-3">
+            <div>
+              <div className="font-mono text-[10px] tracking-widest uppercase text-gray-500">
+                VR grade
+              </div>
+              <div className={`text-2xl font-bold ${GRADE_COLOR[grade]?.split(" ").find((c) => c.startsWith("text-")) ?? ""}`}>
+                {grade}
+              </div>
+            </div>
+            {score !== null && (
+              <div className="text-right">
+                <div className="font-mono text-[10px] tracking-widest uppercase text-gray-500">
+                  Score
+                </div>
+                <div className="text-xl font-mono text-gray-100">{score}</div>
+              </div>
+            )}
+          </div>
+
+          {/* Sub-scores */}
+          {hasSubScores ? (
+            <div className="space-y-1.5 mb-3">
+              <SubScoreBar label="Intent"        value={vr.intent} />
+              <SubScoreBar label="Affordability" value={vr.affordability} />
+              <SubScoreBar label="Authority"     value={vr.authority} />
+              <SubScoreBar label="Timing"        value={vr.timing} />
+            </div>
+          ) : (
+            <div className="text-[11px] text-gray-500 italic mb-3">
+              Sub-scores not yet computed for this prospect.
+            </div>
+          )}
+
+          {/* Strengths (A grades) / Improvements (D-F grades) */}
+          {hasSubScores && (grade === "A" ? (
+            <StrengthsList vr={vr} />
+          ) : (grade === "D" || grade === "F") ? (
+            <ImprovementsList vr={vr} />
+          ) : null)}
+
+          {/* Evidence */}
+          {evidence.length > 0 && (
+            <div className="mt-3 pt-3 border-t border-gray-800">
+              <div className="font-mono text-[10px] uppercase tracking-widest text-gray-500 mb-1">
+                Evidence
+              </div>
+              <ul className="text-[11px] text-gray-300 space-y-1">
+                {evidence.slice(0, 3).map((line, i) => (
+                  <li key={i} className="flex gap-1.5">
+                    <span className="text-gray-600">·</span>
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SubScoreBar({ label, value }: { label: string; value: number | null }) {
+  if (value === null) {
+    return (
+      <div className="flex justify-between items-center text-[11px]">
+        <span className="text-gray-500 font-mono uppercase tracking-wider">{label}</span>
+        <span className="text-gray-600">—</span>
+      </div>
+    );
+  }
+  const pct = Math.max(0, Math.min(100, value));
+  const barColor =
+    pct >= 75 ? "bg-emerald-500" :
+    pct >= 50 ? "bg-amber-500"   :
+                "bg-red-500";
+  return (
+    <div className="text-[11px]">
+      <div className="flex justify-between items-center mb-0.5">
+        <span className="text-gray-400 font-mono uppercase tracking-wider">{label}</span>
+        <span className="text-gray-200 font-mono">{pct}</span>
+      </div>
+      <div className="h-1.5 bg-gray-800 rounded-full overflow-hidden">
+        <div className={`h-full ${barColor}`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function rank(vr: VRBreakdown): Array<[string, number]> {
+  return (
+    [
+      ["Intent",        vr.intent],
+      ["Affordability", vr.affordability],
+      ["Authority",     vr.authority],
+      ["Timing",        vr.timing],
+    ].filter(([, v]) => v !== null) as Array<[string, number]>
+  );
+}
+
+function StrengthsList({ vr }: { vr: VRBreakdown }) {
+  const strong = rank(vr).filter(([, v]) => v >= 75);
+  if (strong.length === 0) return null;
+  return (
+    <div className="pt-2 border-t border-gray-800">
+      <div className="font-mono text-[10px] uppercase tracking-widest text-emerald-400 mb-1">
+        Strengths
+      </div>
+      <ul className="text-[11px] text-gray-300 space-y-0.5">
+        {strong.map(([name, v]) => (
+          <li key={name}>{name} is strong ({v})</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ImprovementsList({ vr }: { vr: VRBreakdown }) {
+  const weak = rank(vr).filter(([, v]) => v < 50);
+  if (weak.length === 0) return null;
+  return (
+    <div className="pt-2 border-t border-gray-800">
+      <div className="font-mono text-[10px] uppercase tracking-widest text-red-400 mb-1">
+        Improvements needed
+      </div>
+      <ul className="text-[11px] text-gray-300 space-y-0.5">
+        {weak.map(([name, v]) => (
+          <li key={name}>{name} is weak ({v})</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/lib/hooks/useOutreachTimeline.ts
+++ b/frontend/lib/hooks/useOutreachTimeline.ts
@@ -1,0 +1,135 @@
+/**
+ * FILE: frontend/lib/hooks/useOutreachTimeline.ts
+ * PURPOSE: Merge touches + scheduled + replies + state events into one sorted timeline
+ * PHASE: PHASE-2.1-TIMELINE-VR-POPOVERS
+ *
+ * Input: ProspectDetail from useProspectDetail (no extra network calls here —
+ * this hook is a pure transform).
+ *
+ * Output: TimelineEvent[] sorted chronologically ascending.
+ *
+ * Type key:
+ *   sent       — a completed outreach touch (past)
+ *   reply      — inbound reply from prospect (past)
+ *   scheduled  — pending/paused touch (future)
+ *   state      — cadence lifecycle event (past or future, e.g. "Sequence started",
+ *                "Paused due to OOO", "Suppressed")
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import type { ProspectDetail } from "@/lib/hooks/useProspectDetail";
+
+export type TimelineEventType = "sent" | "reply" | "scheduled" | "state";
+
+export interface TimelineEvent {
+  id: string;
+  type: TimelineEventType;
+  timestamp: string;
+  channel: string | null;
+  status: string | null;
+  content: string | null;
+  touchId: string | null;
+  sequenceStep: number | null;
+  isFuture: boolean;
+  title: string;
+}
+
+export function useOutreachTimeline(detail: ProspectDetail | null): TimelineEvent[] {
+  return useMemo(() => {
+    if (!detail) return [];
+    const now = Date.now();
+    const events: TimelineEvent[] = [];
+
+    // Past touches
+    for (const t of detail.touches) {
+      events.push({
+        id: `touch-${t.id}`,
+        type: "sent",
+        timestamp: t.sentAt,
+        channel: t.channel,
+        status: t.replied ? "replied" : (t.status ?? "sent"),
+        content: t.preview,
+        touchId: t.id,
+        sequenceStep: t.sequenceStep,
+        isFuture: false,
+        title: `Sent step ${t.sequenceStep ?? "?"}`,
+      });
+    }
+
+    // Replies
+    for (const r of detail.replies) {
+      events.push({
+        id: `reply-${r.id}`,
+        type: "reply",
+        timestamp: r.receivedAt,
+        channel: r.channel,
+        status: r.intent ?? "replied",
+        content: r.preview,
+        touchId: null,
+        sequenceStep: null,
+        isFuture: false,
+        title: r.intent ? `Reply — ${r.intent}` : "Reply received",
+      });
+    }
+
+    // Scheduled (future — unless scheduled_at is already past, in which case treat as due)
+    for (const s of detail.scheduled) {
+      const ts = s.scheduledAt ? new Date(s.scheduledAt).getTime() : NaN;
+      const isFuture = Number.isFinite(ts) ? ts > now : true;
+      events.push({
+        id: `sched-${s.id}`,
+        type: "scheduled",
+        timestamp: s.scheduledAt,
+        channel: s.channel,
+        status: s.status,
+        content: null,
+        touchId: s.id,
+        sequenceStep: s.sequenceStep,
+        isFuture,
+        title: `Scheduled step ${s.sequenceStep ?? "?"}`,
+      });
+    }
+
+    // Derived state markers
+    if (detail.touches.length > 0) {
+      const first = detail.touches[0];
+      events.push({
+        id: "state-start",
+        type: "state",
+        timestamp: first.sentAt,
+        channel: null,
+        status: "started",
+        content: null,
+        touchId: null,
+        sequenceStep: null,
+        isFuture: false,
+        title: "Sequence started",
+      });
+    }
+    const pausedScheduled = detail.scheduled.find((s) => s.status === "paused");
+    if (pausedScheduled) {
+      events.push({
+        id: "state-paused",
+        type: "state",
+        timestamp: pausedScheduled.scheduledAt,
+        channel: null,
+        status: "paused",
+        content: null,
+        touchId: null,
+        sequenceStep: null,
+        isFuture: true,
+        title: "Cadence paused",
+      });
+    }
+
+    events.sort((a, b) => {
+      const ta = a.timestamp ? new Date(a.timestamp).getTime() : 0;
+      const tb = b.timestamp ? new Date(b.timestamp).getTime() : 0;
+      return ta - tb;
+    });
+
+    return events;
+  }, [detail]);
+}

--- a/frontend/lib/hooks/useProspectDetail.ts
+++ b/frontend/lib/hooks/useProspectDetail.ts
@@ -57,12 +57,21 @@ export interface ReplyEvent {
   preview: string | null;
 }
 
+export interface VRBreakdown {
+  intent: number | null;
+  affordability: number | null;
+  authority: number | null;
+  timing: number | null;
+  vulnerabilityReport: Record<string, unknown> | null;
+}
+
 export interface ProspectDetail {
   leadId: string;
   name: string;
   company: string;
   vrGrade: string | null;
   score: number | null;
+  vr: VRBreakdown;
   contact: ProspectContact;
   enrichment: ProspectEnrichment;
   touches: TouchEvent[];
@@ -84,15 +93,33 @@ async function fetchDetail(leadId: string): Promise<ProspectDetail | null> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const client = sb as any;
 
-  const buRes = await client
-    .from("business_universe")
-    .select(
-      "id, display_name, dm_name, dm_title, dm_email, dm_phone, dm_mobile, dm_linkedin_url, " +
-      "abn, gmb_category, company_employee_count_exact, website, suburb, state, propensity_score",
-    )
-    .eq("id", leadId)
-    .maybeSingle();
-  const bu = buRes?.data as Record<string, unknown> | null;
+  // Column coverage: VR sub-scores (vr_intent_score etc.) may not exist in every
+  // deployment. Select them defensively and silently drop on error.
+  let bu: Record<string, unknown> | null = null;
+  try {
+    const full = await client
+      .from("business_universe")
+      .select(
+        "id, display_name, dm_name, dm_title, dm_email, dm_phone, dm_mobile, dm_linkedin_url, " +
+        "abn, gmb_category, company_employee_count_exact, website, suburb, state, " +
+        "propensity_score, vr_grade, vr_intent_score, vr_affordability_score, " +
+        "vr_authority_score, vr_timing_score, vulnerability_report",
+      )
+      .eq("id", leadId)
+      .maybeSingle();
+    bu = (full?.data as Record<string, unknown> | null) ?? null;
+    if (full?.error) throw full.error;
+  } catch {
+    const fallback = await client
+      .from("business_universe")
+      .select(
+        "id, display_name, dm_name, dm_title, dm_email, dm_phone, dm_mobile, dm_linkedin_url, " +
+        "abn, gmb_category, company_employee_count_exact, website, suburb, state, propensity_score",
+      )
+      .eq("id", leadId)
+      .maybeSingle();
+    bu = (fallback?.data as Record<string, unknown> | null) ?? null;
+  }
   if (!bu) return null;
 
   let touches: TouchEvent[] = [];
@@ -160,12 +187,26 @@ async function fetchDetail(leadId: string): Promise<ProspectDetail | null> {
   const emp = bu.company_employee_count_exact;
   const locParts = [bu.suburb as string | null, bu.state as string | null].filter(Boolean);
 
+  const vrGradeFromRow = (bu.vr_grade as string | null) ?? null;
+  const subNum = (k: string) =>
+    typeof bu[k] === "number" ? (bu[k] as number) : null;
+  const vulnReport = bu.vulnerability_report && typeof bu.vulnerability_report === "object"
+    ? (bu.vulnerability_report as Record<string, unknown>)
+    : null;
+
   return {
     leadId: String(bu.id),
     name: (bu.dm_name as string | null) ?? "Unknown",
     company: (bu.display_name as string | null) ?? "—",
-    vrGrade: gradeFromScore(score),
+    vrGrade: vrGradeFromRow ?? gradeFromScore(score),
     score,
+    vr: {
+      intent:        subNum("vr_intent_score"),
+      affordability: subNum("vr_affordability_score"),
+      authority:     subNum("vr_authority_score"),
+      timing:        subNum("vr_timing_score"),
+      vulnerabilityReport: vulnReport,
+    },
     contact: {
       email: (bu.dm_email as string | null) ?? null,
       phone: ((bu.dm_phone as string | null) ?? (bu.dm_mobile as string | null)) ?? null,


### PR DESCRIPTION
## Summary
- **OutreachTimeline** — vertical rail with coloured dots: past sent / reply = emerald, scheduled = amber, state marker = sky. `NOW` divider auto-inserted between last past event and first future event. Per-future-touch controls (Pause 24h / Skip / Accelerate) POST to `/api/v1/outreach/approval` as defer/reject/approve.
- **VRGradePopover** — clickable grade badge → popover with grade letter, overall score, 4 sub-score bars (Intent, Affordability, Authority, Timing) coloured by band, Strengths list (A grades), Improvements list (D/F grades), and up to 3 evidence bullets from enrichment. Smart vertical placement (opens upward when button is in bottom-half of viewport). Closes on outside click / Esc.
- **useOutreachTimeline** — pure transform merging ProspectDetail's touches + replies + scheduled into sorted `TimelineEvent[]`, plus derived state markers ("Sequence started", "Cadence paused" when any pending touch is `paused`).
- **ProspectDrawer** — grade badge now rendered by `VRGradePopover`. Three separate list sections (Outreach timeline, Scheduled, Reply history) collapsed into one `OutreachTimeline` section. Dead helpers removed.
- **useProspectDetail** — extended `ProspectDetail` with `VRBreakdown {intent, affordability, authority, timing, vulnerabilityReport}`. BU select tries the extended column set first and falls back silently if VR sub-score columns don't exist on this deployment.

## Test plan
- [x] Rebased on current `origin/main` (dafd87ef — post PR #390 merge)
- [x] `tsc --noEmit` clean on all 5 files (pre-existing unrelated errors in `lib/__tests__/useLiveActivityFeed.test.ts` remain)
- [x] Provider-leak grep: 0 matches
- [ ] Reviewer: browser — open drawer, click grade badge, confirm popover opens / closes / repositions
- [ ] Reviewer: browser — scroll future events, confirm Pause/Skip/Accelerate buttons fire and show "…" then "✓"
- [ ] Backend: `/api/v1/outreach/approval` still a stub — ensure approve/reject/defer action values are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)