### PR TITLE
[ATLAS] Realtime subscriptions + Vitest setup

### DIFF
--- a/frontend/lib/__tests__/provider-labels.test.ts
+++ b/frontend/lib/__tests__/provider-labels.test.ts
@@ -1,0 +1,109 @@
+/**
+ * FILE: frontend/lib/__tests__/provider-labels.test.ts
+ * PURPOSE: Verify the provider-leak scrub catches every known vendor name
+ *          and that canonicalChannel normalises channel strings correctly.
+ * PHASE: PHASE-2.1-REALTIME-VITEST — first real Vitest target
+ *
+ * Run: `npm test lib/__tests__/provider-labels.test.ts`
+ *
+ * ⚠ If you add a new vendor to CANONICAL_REPLACEMENTS in provider-labels.ts,
+ *   add a row to LEAK_PAIRS below so the invariant is enforced.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  canonicalChannel,
+  canonicalMetric,
+  providerLabel,
+} from "@/lib/provider-labels";
+
+/** [raw provider name] → [expected scrubbed substring the user should see] */
+const LEAK_PAIRS: Array<[string, string]> = [
+  ["Unipile",                 "LinkedIn"],
+  ["Sent via Unipile",        "Sent via LinkedIn"],
+  ["via Unipile",             "via LinkedIn"],
+  ["ElevenAgents",            "Voice AI"],
+  ["ElevenLabs Agent",        "Voice AI"],
+  ["Salesforge",              "Email"],
+  ["via Mailgun",             "via Email"],
+  ["via Resend",              "via Email"],
+  ["Prospeo",                 "Contact finder"],
+  ["Leadmagic",               "Contact finder"],
+  ["Bright Data",             "Profile data"],
+  ["BrightData",              "Profile data"],
+  ["DFS organic ETV",         "Organic traffic value"],
+  ["DFS keywords",            "Keyword positions"],
+  ["DFS",                     "Organic"],
+];
+
+const FORBIDDEN = [
+  "Unipile", "Salesforge", "ElevenAgents", "ElevenLabs",
+  "Mailgun", "Resend", "Prospeo", "Leadmagic", "Bright Data",
+  "BrightData", "DataForSEO", "Proxycurl",
+];
+
+describe("providerLabel", () => {
+  it("returns empty string unchanged", () => {
+    expect(providerLabel("")).toBe("");
+  });
+
+  it("passes through plain text without provider names unchanged", () => {
+    expect(providerLabel("Booked meeting for Tuesday")).toBe("Booked meeting for Tuesday");
+  });
+
+  it.each(LEAK_PAIRS)("scrubs %s → contains %s", (raw, expected) => {
+    const out = providerLabel(raw);
+    expect(out).toContain(expected);
+  });
+
+  it.each(FORBIDDEN)("never leaks raw name %s in its own output", (name) => {
+    const out = providerLabel(`Sent via ${name} at 3pm`);
+    // After scrub, the raw provider name must be gone (modulo the forbidden
+    // DFS substring which legitimately matches 'DFSNewbie' — not a concern
+    // for user-facing copy, but the regex already scrubs the standalone token).
+    expect(out).not.toContain(name);
+  });
+
+  it("scrubs multiple providers in the same string", () => {
+    const out = providerLabel("Prospeo then Unipile then Salesforge");
+    expect(out).not.toMatch(/Prospeo/);
+    expect(out).not.toMatch(/Unipile/);
+    expect(out).not.toMatch(/Salesforge/);
+    expect(out).toContain("Contact finder");
+    expect(out).toContain("LinkedIn");
+    expect(out).toContain("Email");
+  });
+});
+
+describe("canonicalChannel", () => {
+  const CHANNEL_MAP: Array<[string, string]> = [
+    ["unipile",      "LinkedIn"],
+    ["LinkedIn",     "LinkedIn"],
+    ["salesforge",   "Email"],
+    ["email",        "Email"],
+    ["mailgun",      "Email"],
+    ["resend",       "Email"],
+    ["elevenagents", "Voice AI"],
+    ["elevenlabs",   "Voice AI"],
+    ["voice",        "Voice AI"],
+    ["vapi",         "Voice AI"],
+    ["sms",          "SMS"],
+    ["telnyx",       "SMS"],
+  ];
+
+  it.each(CHANNEL_MAP)("canonicalises %s → %s", (input, expected) => {
+    expect(canonicalChannel(input)).toBe(expected);
+  });
+
+  it("handles empty / unknown gracefully", () => {
+    expect(canonicalChannel("")).not.toMatch(/undefined/);
+    // Unknown channels should not throw or return a provider name
+    const out = canonicalChannel("mystery");
+    for (const name of FORBIDDEN) expect(out).not.toContain(name);
+  });
+});
+
+describe("canonicalMetric", () => {
+  it("delegates to providerLabel under the hood (DFS metric scrubs correctly)", () => {
+    expect(canonicalMetric("DFS organic ETV")).toBe("Organic traffic value");
+  });
+});

--- a/frontend/lib/hooks/useDashboardStats.ts
+++ b/frontend/lib/hooks/useDashboardStats.ts
@@ -8,9 +8,10 @@
 
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useClient } from "@/hooks/use-client";
 import { createBrowserClient } from "@/lib/supabase";
+import { useRealtimeSubscription } from "@/lib/hooks/useRealtimeSubscription";
 
 export interface DashboardStats {
   prospectsContacted: number;
@@ -159,13 +160,36 @@ async function fetchStats(clientId: string): Promise<Omit<DashboardStats, "isLoa
 
 export function useDashboardStats(): DashboardStats {
   const { clientId } = useClient();
+  const qc = useQueryClient();
+  const queryKey = ["dashboard-stats-v10", clientId];
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ["dashboard-stats-v10", clientId],
+    queryKey,
     queryFn: () => fetchStats(clientId!),
     enabled: !!clientId,
     staleTime: 60_000,
+    // Longer backstop — realtime is primary refresh mechanism.
     refetchInterval: 300_000,
+  });
+
+  const invalidate = () => qc.invalidateQueries({ queryKey });
+
+  // Realtime: any new outcome or scheduled-touch state change refreshes stats.
+  useRealtimeSubscription({
+    table: "cis_outreach_outcomes",
+    filter: clientId ? `client_id=eq.${clientId}` : undefined,
+    enabled: !!clientId,
+    onInsert: invalidate,
+    onUpdate: invalidate,
+    onPoll:   invalidate,
+  });
+  useRealtimeSubscription({
+    table: "scheduled_touches",
+    filter: clientId ? `client_id=eq.${clientId}` : undefined,
+    enabled: !!clientId,
+    onInsert: invalidate,
+    onUpdate: invalidate,
+    onPoll:   invalidate,
   });
 
   return {

--- a/frontend/lib/hooks/usePipelineData.ts
+++ b/frontend/lib/hooks/usePipelineData.ts
@@ -13,9 +13,10 @@
 
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useClient } from "@/hooks/use-client";
 import { createBrowserClient } from "@/lib/supabase";
+import { useRealtimeSubscription } from "@/lib/hooks/useRealtimeSubscription";
 
 export type PipelineStage =
   | "discovered"
@@ -160,12 +161,34 @@ async function fetchPipeline(clientId: string): Promise<Omit<PipelineData, "isLo
 
 export function usePipelineData(): PipelineData {
   const { clientId } = useClient();
+  const qc = useQueryClient();
+  const queryKey = ["pipeline-v10", clientId];
+
   const { data, isLoading, error } = useQuery({
-    queryKey: ["pipeline-v10", clientId],
+    queryKey,
     queryFn: () => fetchPipeline(clientId!),
     enabled: !!clientId,
     staleTime: 30_000,
-    refetchInterval: 120_000,
+    // Long backstop — realtime drives refresh.
+    refetchInterval: 300_000,
+  });
+
+  const invalidate = () => qc.invalidateQueries({ queryKey });
+
+  useRealtimeSubscription({
+    table: "business_universe",
+    filter: clientId ? `client_id=eq.${clientId}` : undefined,
+    enabled: !!clientId,
+    onInsert: invalidate,
+    onUpdate: invalidate,
+    onPoll:   invalidate,
+  });
+  useRealtimeSubscription({
+    table: "cis_outreach_outcomes",
+    filter: clientId ? `client_id=eq.${clientId}` : undefined,
+    enabled: !!clientId,
+    onInsert: invalidate,
+    onPoll:   invalidate,
   });
   return {
     prospects: data?.prospects ?? [],

--- a/frontend/lib/hooks/useRealtimeSubscription.ts
+++ b/frontend/lib/hooks/useRealtimeSubscription.ts
@@ -1,0 +1,148 @@
+/**
+ * FILE: frontend/lib/hooks/useRealtimeSubscription.ts
+ * PURPOSE: Generic Supabase Realtime subscription with automatic polling fallback.
+ * PHASE: PHASE-2.1-REALTIME-VITEST
+ *
+ * Usage:
+ *   const { isRealtime, isPolling, lastEvent } = useRealtimeSubscription({
+ *     table: "cis_outreach_outcomes",
+ *     filter: `client_id=eq.${clientId}`,
+ *     onInsert: (row) => qc.invalidateQueries({ queryKey: [...] }),
+ *     onUpdate: (row) => ...,
+ *     onDelete: (row) => ...,
+ *   });
+ *
+ * Behaviour:
+ *   - Subscribes on mount. Unsubscribes on unmount.
+ *   - If SUBSCRIBED status is not reached within SUBSCRIBE_TIMEOUT_MS (5s)
+ *     or if the channel emits CHANNEL_ERROR / TIMED_OUT / CLOSED, flips to
+ *     polling mode: fires a tick every POLLING_INTERVAL_MS (30s) so callers
+ *     can refetch as though an event occurred.
+ *   - Automatic reconnect: the Supabase JS client handles transport-level
+ *     reconnects; this hook only flips to polling on hard failure.
+ */
+
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createClient } from "@/lib/supabase";
+
+export type RealtimeStatus = "connecting" | "live" | "polling" | "error";
+
+export interface UseRealtimeSubscriptionOptions {
+  /** Table to subscribe to (public schema). */
+  table: string;
+  /** Optional PostgREST-style filter string: `client_id=eq.<uuid>`. */
+  filter?: string;
+  /** Channel name — defaults to `rt:${table}:${filter}`. */
+  channelName?: string;
+  /** Skip subscription entirely (e.g. no clientId yet). */
+  enabled?: boolean;
+  /** Called for INSERT events. */
+  onInsert?: (row: Record<string, unknown>) => void;
+  /** Called for UPDATE events. */
+  onUpdate?: (row: Record<string, unknown>) => void;
+  /** Called for DELETE events. */
+  onDelete?: (row: Record<string, unknown>) => void;
+  /** Called every polling tick when in polling fallback. */
+  onPoll?: () => void;
+}
+
+export interface UseRealtimeSubscriptionResult {
+  status: RealtimeStatus;
+  isRealtime: boolean;
+  isPolling: boolean;
+  lastEvent: number | null;
+}
+
+const SUBSCRIBE_TIMEOUT_MS = 5_000;
+const POLLING_INTERVAL_MS = 30_000;
+
+export function useRealtimeSubscription(
+  options: UseRealtimeSubscriptionOptions,
+): UseRealtimeSubscriptionResult {
+  const { table, filter, channelName, enabled = true, onInsert, onUpdate, onDelete, onPoll } =
+    options;
+
+  const [status, setStatus] = useState<RealtimeStatus>(enabled ? "connecting" : "error");
+  const [lastEvent, setLastEvent] = useState<number | null>(null);
+
+  // Refs so we can re-read the latest callback from the interval / channel
+  // without re-subscribing on every render.
+  const cbRef = useRef({ onInsert, onUpdate, onDelete, onPoll });
+  cbRef.current = { onInsert, onUpdate, onDelete, onPoll };
+
+  useEffect(() => {
+    if (!enabled) {
+      setStatus("error");
+      return;
+    }
+
+    setStatus("connecting");
+    const supabase = createClient();
+    const name = channelName ?? `rt:${table}:${filter ?? "all"}`;
+    const channel = supabase.channel(name);
+
+    channel.on(
+      "postgres_changes",
+      { event: "*", schema: "public", table, ...(filter ? { filter } : {}) },
+      (payload: { eventType?: string; new?: unknown; old?: unknown }) => {
+        setLastEvent(Date.now());
+        const row = (payload.new ?? payload.old ?? {}) as Record<string, unknown>;
+        const ev = payload.eventType?.toUpperCase();
+        if (ev === "INSERT") cbRef.current.onInsert?.(row);
+        else if (ev === "UPDATE") cbRef.current.onUpdate?.(row);
+        else if (ev === "DELETE") cbRef.current.onDelete?.(row);
+      },
+    );
+
+    let settled = false;
+    let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+    let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+    const startPolling = () => {
+      if (pollTimer) return;
+      setStatus("polling");
+      pollTimer = setInterval(() => {
+        setLastEvent(Date.now());
+        cbRef.current.onPoll?.();
+      }, POLLING_INTERVAL_MS);
+    };
+
+    fallbackTimer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        startPolling();
+      }
+    }, SUBSCRIBE_TIMEOUT_MS);
+
+    channel.subscribe((subStatus: string) => {
+      if (subStatus === "SUBSCRIBED") {
+        settled = true;
+        if (fallbackTimer) clearTimeout(fallbackTimer);
+        setStatus("live");
+      } else if (
+        subStatus === "CHANNEL_ERROR" ||
+        subStatus === "TIMED_OUT" ||
+        subStatus === "CLOSED"
+      ) {
+        settled = true;
+        if (fallbackTimer) clearTimeout(fallbackTimer);
+        startPolling();
+      }
+    });
+
+    return () => {
+      if (fallbackTimer) clearTimeout(fallbackTimer);
+      if (pollTimer) clearInterval(pollTimer);
+      supabase.removeChannel(channel);
+    };
+  }, [enabled, table, filter, channelName]);
+
+  return {
+    status,
+    isRealtime: status === "live",
+    isPolling: status === "polling",
+    lastEvent,
+  };
+}

--- a/frontend/lib/useLiveActivityFeed.ts
+++ b/frontend/lib/useLiveActivityFeed.ts
@@ -5,6 +5,12 @@
  *          with 30s polling as automatic fallback on websocket failure.
  *
  * PHASE: PHASE-2.1-2.2 Slice 2 (Track 2.1-next — Realtime subscriptions)
+ * UPDATED: PHASE-2.1-REALTIME-VITEST — reviewed as part of the realtime
+ * upgrade sweep. This hook is already subscription-based with 30s polling
+ * as fallback, so no logic change was required. The generic
+ * `useRealtimeSubscription` hook introduced in the same sweep is the
+ * recommended implementation for *new* per-table subscriptions; this hook
+ * subscribes to four tables simultaneously and remains bespoke for now.
  *
  * Subscribes per-client-id to four tables:
  *   - cis_outreach_outcomes   (outreach events)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@arwes/react": "^1.0.0-next.25020502",
@@ -85,16 +87,22 @@
   },
   "devDependencies": {
     "@tanstack/react-query-devtools": "^5.91.3",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
     "@types/node": "^20.10.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/three": "^0.182.0",
+    "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.24",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.0.4",
+    "jsdom": "^25.0.1",
     "postcss": "^8.5.6",
     "postcss-import": "^16.1.1",
     "tailwindcss": "^3.4.19",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^2.1.8"
   }
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,28 @@
+/**
+ * FILE: frontend/vitest.config.ts
+ * PURPOSE: Vitest configuration — jsdom env, path aliases matching tsconfig.json
+ * PHASE: PHASE-2.1-REALTIME-VITEST
+ */
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@":            path.resolve(__dirname, "."),
+      "@/components": path.resolve(__dirname, "components"),
+      "@/lib":        path.resolve(__dirname, "lib"),
+      "@/hooks":      path.resolve(__dirname, "hooks"),
+      "@/types":      path.resolve(__dirname, "types"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["lib/**/__tests__/**/*.test.{ts,tsx}", "components/**/__tests__/**/*.test.{ts,tsx}"],
+    exclude: ["node_modules", ".next", "design/**"],
+    setupFiles: ["./vitest.setup.ts"],
+  },
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,6 @@
+/**
+ * FILE: frontend/vitest.setup.ts
+ * PURPOSE: Global test setup — matcher extensions, cleanup
+ * PHASE: PHASE-2.1-REALTIME-VITEST
+ */
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
### Deliverable 1 — Realtime
- **`useRealtimeSubscription`** (new) — generic, reusable hook. Subscribes to one public table with optional filter. Fires `onInsert` / `onUpdate` / `onDelete` callbacks. Falls back to 30s polling if `SUBSCRIBED` is not reached within 5s or on `CHANNEL_ERROR` / `TIMED_OUT` / `CLOSED`. Returns `{ status, isRealtime, isPolling, lastEvent }`.
- **`useDashboardStats`** — wired to `cis_outreach_outcomes` + `scheduled_touches`. React Query cache invalidated on every event.
- **`usePipelineData`** — wired to `business_universe` + `cis_outreach_outcomes`.
- **`useLiveActivityFeed`** — reviewed, already realtime with polling fallback. Header comment updated; no behaviour change.

### Deliverable 2 — Vitest
- `vitest.config.ts` with jsdom env + tsconfig-matching path aliases.
- `vitest.setup.ts` imports `@testing-library/jest-dom/vitest`.
- `frontend/lib/__tests__/provider-labels.test.ts` — first real test target. Parametrised leak-scrub matrix over every known vendor, `FORBIDDEN`-never-leaks invariant, `canonicalChannel` and `canonicalMetric` coverage.
- `package.json` adds `test` + `test:watch` scripts and devDependencies: `vitest`, `@vitejs/plugin-react`, `@testing-library/{dom,react,jest-dom}`, `jsdom`.

## Test plan
- [x] Rebased on current `origin/main` (325dbb78 — post PR #392 merge)
- [x] `tsc --noEmit` clean on all new + modified files
- [x] Provider-leak grep clean on all production files (test file intentionally names vendors as test inputs)
- [ ] **`npm install` failed locally** due to a **pre-existing** resolver error on `baseline-browser-mapping@^2.10.12` — **not** related to deps added here. Added deps use standard current versions and should install cleanly once the unrelated resolver issue is fixed. Once install succeeds, `npm test` runs the new provider-labels test suite.
- [ ] Reviewer: verify CI/preview environment can install and run `npm test` successfully after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)