### PR TITLE
[ATLAS] Dashboard nav sidebar + session-auth operator actions + mobile pass

### DIFF
--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -16,6 +16,7 @@ import { getCurrentUser, getUserMemberships } from "@/lib/supabase-server";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { createServerClient } from "@/lib/supabase-server";
 import { KillSwitch } from "@/components/dashboard/KillSwitch";
+import { DashboardNav } from "@/components/dashboard/DashboardNav";
 
 export default async function DashboardRootLayout({
   children,
@@ -94,7 +95,10 @@ export default async function DashboardRootLayout({
   return (
     <DashboardLayout user={userData} client={clientDataForLayout}>
       <KillSwitch />
-      {children}
+      <div className="flex min-h-screen">
+        <DashboardNav />
+        <div className="flex-1 min-w-0 pt-14 md:pt-0">{children}</div>
+      </div>
     </DashboardLayout>
   );
 }

--- a/frontend/components/dashboard/DashboardNav.tsx
+++ b/frontend/components/dashboard/DashboardNav.tsx
@@ -1,0 +1,126 @@
+/**
+ * FILE: frontend/components/dashboard/DashboardNav.tsx
+ * PURPOSE: Vertical sidebar nav for every /dashboard/* route
+ * PHASE: PHASE-2.1-FRONTEND-POLISH-HMAC (nav portion)
+ *
+ * Desktop: always-visible rail.
+ * Mobile  (< md): collapses behind a hamburger toggle; tap-outside closes.
+ * Active route indicated by left-border accent + tinted background.
+ * Approval link shows a live count badge (useApprovalQueue).
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Home, Users, Calendar, Activity, ShieldCheck, Menu, X,
+  type LucideIcon,
+} from "lucide-react";
+import { useApprovalQueue } from "@/lib/hooks/useApprovalQueue";
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+const ITEMS: NavItem[] = [
+  { href: "/dashboard",          label: "Home",     icon: Home },
+  { href: "/dashboard/pipeline", label: "Pipeline", icon: Users },
+  { href: "/dashboard/meetings", label: "Meetings", icon: Calendar },
+  { href: "/dashboard/activity", label: "Activity", icon: Activity },
+  { href: "/dashboard/approval", label: "Approval", icon: ShieldCheck },
+];
+
+function isActive(pathname: string, href: string): boolean {
+  if (href === "/dashboard") return pathname === "/dashboard";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function DashboardNav() {
+  const pathname = usePathname() ?? "";
+  const [open, setOpen] = useState(false);
+  const { touches } = useApprovalQueue();
+  const approvalCount = touches.length;
+
+  // Close the mobile drawer on route change.
+  useEffect(() => { setOpen(false); }, [pathname]);
+
+  // Close on Esc.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <>
+      {/* Mobile toggle (hidden on md+) */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label={open ? "Close nav" : "Open nav"}
+        className="md:hidden fixed top-3 left-3 z-40 p-2 rounded-md border border-gray-800 bg-gray-900/90 backdrop-blur text-gray-300 hover:text-amber-300 hover:border-amber-500/40"
+      >
+        {open ? <X className="w-4 h-4" /> : <Menu className="w-4 h-4" />}
+      </button>
+
+      {/* Mobile backdrop */}
+      {open && (
+        <div
+          className="md:hidden fixed inset-0 z-30 bg-black/60"
+          onClick={() => setOpen(false)}
+          aria-hidden
+        />
+      )}
+
+      <aside
+        aria-label="Dashboard navigation"
+        className={`fixed md:sticky md:top-0 md:left-0 top-0 left-0 z-30 md:z-10 h-screen w-56 flex-shrink-0
+          bg-gray-900 border-r border-gray-800
+          transition-transform duration-200 md:translate-x-0
+          ${open ? "translate-x-0" : "-translate-x-full md:translate-x-0"}`}
+      >
+        {/* Brand */}
+        <div className="px-4 py-4 border-b border-gray-800">
+          <div className="font-serif text-lg text-gray-100">Keira</div>
+          <div className="font-mono text-[10px] tracking-widest uppercase text-gray-500">
+            Agency desk
+          </div>
+        </div>
+
+        {/* Items */}
+        <nav className="px-2 py-3 space-y-1">
+          {ITEMS.map(({ href, label, icon: Icon }) => {
+            const active = isActive(pathname, href);
+            const showBadge = href === "/dashboard/approval" && approvalCount > 0;
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={`flex items-center gap-3 px-3 py-2 rounded-md text-sm border-l-2 transition ${
+                  active
+                    ? "bg-emerald-500/10 border-emerald-400 text-gray-100"
+                    : "border-transparent text-gray-400 hover:text-gray-100 hover:bg-gray-800/60"
+                }`}
+              >
+                <Icon className="w-4 h-4" strokeWidth={1.75} />
+                <span className="flex-1">{label}</span>
+                {showBadge && (
+                  <span className="text-[10px] font-mono font-bold px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-300 border border-amber-500/40">
+                    {approvalCount}
+                  </span>
+                )}
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* Footer spacer — leaves room for the KillSwitch fixed top-right */}
+        <div className="md:hidden h-14" aria-hidden />
+      </aside>
+    </>
+  );
+}

--- a/frontend/components/dashboard/KillSwitch.tsx
+++ b/frontend/components/dashboard/KillSwitch.tsx
@@ -29,7 +29,10 @@ interface KillState {
 
 async function fetchState(): Promise<KillState> {
   try {
-    const res = await fetch("/api/v1/outreach/kill-switch", { method: "GET" });
+    const res = await fetch("/api/v1/outreach/kill-switch", {
+      method: "GET",
+      credentials: "include",
+    });
     if (!res.ok) return { paused: false };
     return await res.json();
   } catch {
@@ -38,10 +41,12 @@ async function fetchState(): Promise<KillState> {
 }
 
 async function postToggle(next: boolean): Promise<KillState> {
+  // Session cookie authenticates the operator — no client-side HMAC.
   const res = await fetch("/api/v1/outreach/kill-switch", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ paused: next }),
+    credentials: "include",
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return await res.json().catch(() => ({ paused: next }));

--- a/frontend/lib/hooks/useApprovalQueue.ts
+++ b/frontend/lib/hooks/useApprovalQueue.ts
@@ -84,10 +84,14 @@ async function fetchPending(clientId: string): Promise<PendingTouch[]> {
 export type ApprovalAction = "approve" | "reject" | "defer";
 
 async function postAction(body: { touch_id: string; action: ApprovalAction }) {
+  // Operator identity is established by the session cookie / JWT set at login.
+  // No client-side HMAC — the dashboard is same-origin and the session cookie
+  // is the authoritative gate. Backend enforces RLS + session auth.
   const res = await fetch("/api/v1/outreach/approval", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    credentials: "include",
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- **DashboardNav** (new) — vertical sidebar wired into `/dashboard/layout.tsx`. 5 route links (Home, Pipeline, Meetings, Activity, Approval), active-route accent, live approval-count badge reading from `useApprovalQueue`. Desktop: sticky. Mobile: hamburger-toggled drawer with backdrop + Esc dismiss + auto-close on route change.
- **Operator actions use session auth only** — **HMAC client-side signer was removed mid-PR per CEO security correction**. Originally the brief asked for `NEXT_PUBLIC_OPERATOR_WEBHOOK_SECRET` + `X-Signature` headers; that's inherently readable by any browser client and weaker than session cookies. The dropped files/changes are documented in the commit message. All operator POSTs now pass `credentials: "include"` so the session cookie rides along. Backend RLS + session auth remain the authoritative gate.
- **Mobile pass** — all 5 dashboard routes reviewed. Existing code already uses `p-4 md:p-6`, responsive text sizes, stacking breakpoints, horizontal-scroll kanban, and full-screen < sm drawer. Only change needed was `pt-14 md:pt-0` on the layout main container so page headers don't sit under the mobile hamburger.

## Test plan
- [x] Rebased on current `origin/main` (e7159636 — post PR #394 merge)
- [x] `tsc --noEmit` clean on all new + modified files
- [x] Provider-leak grep clean
- [ ] Reviewer: browser check — sidebar renders on each `/dashboard/*` route, approval badge updates when queue changes, hamburger works on `< 768px`
- [ ] Reviewer: confirm the existing Sidebar component inside `DashboardLayout` wrapper is acceptable to keep (my new `DashboardNav` is additional, not a replacement — follow-up PR can retire whichever becomes redundant)

## Security note
The commit message has the full story on the HMAC removal. TL;DR: `NEXT_PUBLIC_*` env vars are readable by the browser, so they can't hold a real secret; the original dispatch intent is better served by session cookies + backend RLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)