### PR TITLE
[ORION] Phase 2 Slice 9: DNCR wiring + BU lifecycle + nurture drip

### DIFF
--- a/alembic/versions/320_nurture_drip_state.sql
+++ b/alembic/versions/320_nurture_drip_state.sql
@@ -1,0 +1,17 @@
+-- Migration 320: nurture_drip_state table
+-- Idempotent — safe to re-run.
+
+CREATE TABLE IF NOT EXISTS nurture_drip_state (
+    prospect_id       UUID        PRIMARY KEY,
+    client_id         UUID        NOT NULL,
+    next_channel      TEXT        CHECK (next_channel IN ('email', 'linkedin')),
+    next_scheduled_at TIMESTAMPTZ,
+    touches_sent      INT         NOT NULL DEFAULT 0,
+    status            TEXT        NOT NULL DEFAULT 'active'
+                                  CHECK (status IN ('active', 'exhausted', 'paused')),
+    started_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS nurture_drip_state_client_status_idx
+    ON nurture_drip_state (client_id, status);

--- a/src/orchestration/flows/monthly_cycle_close_flow.py
+++ b/src/orchestration/flows/monthly_cycle_close_flow.py
@@ -171,9 +171,33 @@ def _rowcount(result: Any) -> int:
     return 0
 
 
+async def _enqueue_cold_prospects_for_nurture(
+    db_conn: Any, cycle: dict, transitions: dict, nurture_enqueue_fn,
+) -> None:
+    """Post-close hook: enqueue cold prospects (outreach_status=complete) into nurture drip.
+    Fetches the prospect_ids just transitioned to 'complete' then calls
+    nurture_enqueue_fn(prospect_id, client_id) for each one."""
+    if nurture_enqueue_fn is None or not transitions.get("complete"):
+        return
+    client_id = str(cycle["client_id"])
+    cycle_id = str(cycle["id"])
+    try:
+        rows = await db_conn.fetch(
+            """
+            SELECT prospect_id FROM cycle_prospects
+            WHERE cycle_id = $1 AND outreach_status = 'complete'
+            """,
+            cycle_id,
+        )
+        for row in rows:
+            nurture_enqueue_fn(str(row["prospect_id"]), client_id)
+    except Exception as exc:
+        logger.warning("nurture enqueue hook failed for cycle=%s: %s", cycle_id, exc)
+
+
 @task(name="close-cycles")
 async def close_cycles_task(
-    db_conn: Any, new_cycle_trigger,
+    db_conn: Any, new_cycle_trigger, nurture_enqueue_fn=None,
 ) -> CycleCloseSummary:
     summary = CycleCloseSummary(cycles_closed=0, transitions={
         "meeting_booked": 0, "replied": 0, "complete": 0,
@@ -186,6 +210,7 @@ async def close_cycles_task(
         await mark_cycle_closed(db_conn, cycle["id"])
         await emit_cycle_close_event(db_conn, cycle, transitions)
         summary.events_emitted += 1
+        await _enqueue_cold_prospects_for_nurture(db_conn, cycle, transitions, nurture_enqueue_fn)
         if await trigger_next_cycle_release(db_conn, cycle["client_id"], new_cycle_trigger):
             summary.next_cycles_released += 1
         summary.cycles_closed += 1
@@ -210,8 +235,10 @@ async def _default_new_cycle_trigger(db_conn: Any, client_id: str) -> None:
 async def monthly_cycle_close_flow(
     db_conn: Any,
     new_cycle_trigger=_default_new_cycle_trigger,
+    nurture_enqueue_fn=None,
 ) -> CycleCloseSummary:
-    summary = await close_cycles_task(db_conn, new_cycle_trigger)
+    summary = await close_cycles_task(db_conn, new_cycle_trigger,
+                                      nurture_enqueue_fn=nurture_enqueue_fn)
     logger.info("monthly_cycle_close_flow complete: %s", summary)
     return summary
 

--- a/src/outreach/cadence/daily_decider.py
+++ b/src/outreach/cadence/daily_decider.py
@@ -229,7 +229,17 @@ class DailyDecider:
 async def apply_actions(
     db_conn: Any, client_id: str, actions: list[DeciderAction],
 ) -> dict[str, int]:
-    """Write schedule_next + nurture actions to scheduled_touches. Never raises."""
+    """Write schedule_next + nurture actions to scheduled_touches. Never raises.
+
+    Also updates business_universe lifecycle columns alongside each touch
+    insert / suppression:
+      - schedule_next | nurture  -> outreach_status pending->active (idempotent),
+                                    last_outreach_at[channel] = scheduled_at,
+                                    signal_snapshot_at = NOW()
+      - suppress                 -> outreach_status = 'suppressed'
+    BU UPDATEs are best-effort — failures are logged but do not abort the
+    touch insert or bump the errors counter beyond the insert path.
+    """
     counts = {"scheduled": 0, "nurture": 0, "skipped": 0,
               "suppressed": 0, "escalated": 0, "errors": 0}
     for a in actions:
@@ -246,16 +256,61 @@ async def apply_actions(
                     a.scheduled_at,
                 )
                 counts["scheduled" if a.action == "schedule_next" else "nurture"] += 1
+                await _bu_mark_active(db_conn, a.lead_id, a.channel, a.scheduled_at)
             elif a.action == "skip":
                 counts["skipped"] += 1
             elif a.action == "suppress":
                 counts["suppressed"] += 1
+                await _bu_mark_suppressed(db_conn, a.lead_id)
             elif a.action == "escalate":
                 counts["escalated"] += 1
         except Exception as exc:
             counts["errors"] += 1
             logger.exception("apply_actions insert failed for lead=%s: %s", a.lead_id, exc)
     return counts
+
+
+async def _bu_mark_active(
+    db_conn: Any, lead_id: str, channel: str, scheduled_at: datetime,
+) -> None:
+    """Transition BU row to 'active' (from 'pending' only) and record last-touch
+    timestamp per channel. Idempotent: repeated calls for an already-active row
+    update last_outreach_at without regressing the enum."""
+    try:
+        await db_conn.execute(
+            """
+            UPDATE business_universe
+            SET outreach_status = CASE
+                    WHEN outreach_status = 'pending' THEN 'active'::bu_outreach_status
+                    ELSE outreach_status
+                END,
+                last_outreach_at = COALESCE(last_outreach_at, '{}'::jsonb)
+                    || jsonb_build_object($2::text, $3::timestamptz::text),
+                signal_snapshot_at = NOW(),
+                updated_at = NOW()
+            WHERE id = $1
+            """,
+            lead_id, channel, scheduled_at,
+        )
+    except Exception as exc:
+        logger.warning("bu_mark_active failed for lead=%s: %s", lead_id, exc)
+
+
+async def _bu_mark_suppressed(db_conn: Any, lead_id: str) -> None:
+    """Flip BU row to 'suppressed'. Terminal; does not regress from 'converted'."""
+    try:
+        await db_conn.execute(
+            """
+            UPDATE business_universe
+            SET outreach_status = 'suppressed'::bu_outreach_status,
+                signal_snapshot_at = NOW(),
+                updated_at = NOW()
+            WHERE id = $1 AND outreach_status != 'converted'
+            """,
+            lead_id,
+        )
+    except Exception as exc:
+        logger.warning("bu_mark_suppressed failed for lead=%s: %s", lead_id, exc)
 
 
 # ---------------------------------------------------------------------------

--- a/src/outreach/cadence/nurture_drip.py
+++ b/src/outreach/cadence/nurture_drip.py
@@ -1,0 +1,259 @@
+"""
+Contract: src/outreach/cadence/nurture_drip.py
+Purpose: Cold-prospect nurture drip — monthly 1-touch cadence alternating
+         Email and LinkedIn every 30 days, capped at 6 touches.
+Layer:   services (stateless once store is injected)
+Imports: stdlib
+Consumers: src/orchestration/flows/monthly_cycle_close_flow.py post-close hook
+
+Lifecycle:
+  - Cold prospect (cycle complete, no reply, not suppressed, not converted)
+    -> enqueue(prospect_id) schedules touch 1 (Email, T+30 days).
+  - Each successful send advances the count. Next touch scheduled at
+    T+30 from the prior send.
+  - At touch 6 the drip graduates — no further touches. Entry in the
+    nurture state row is marked 'exhausted'.
+
+State table (nurture_drip_state):
+  prospect_id UUID PK
+  client_id UUID
+  next_channel TEXT (email | linkedin)
+  next_scheduled_at TIMESTAMPTZ
+  touches_sent INT
+  status TEXT (active | exhausted | paused)
+  started_at TIMESTAMPTZ
+  updated_at TIMESTAMPTZ
+
+The drip itself does NOT dispatch touches — it writes rows into
+scheduled_touches just like daily_decider. The hourly cadence flow
+dispatches them as normal.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+NURTURE_INTERVAL_DAYS = 30
+NURTURE_MAX_TOUCHES = 6
+NURTURE_FIRST_TOUCH_OFFSET_DAYS = 30
+
+# Alternating pattern: even touches (1, 3, 5) email; odd (2, 4, 6) linkedin.
+# touches_sent 0 -> next is touch 1 -> email
+# touches_sent 1 -> next is touch 2 -> linkedin
+_CHANNEL_BY_TOUCH = ["email", "linkedin", "email", "linkedin", "email", "linkedin"]
+
+
+class NurtureStatus(str, Enum):
+    ACTIVE = "active"
+    EXHAUSTED = "exhausted"
+    PAUSED = "paused"
+
+
+@dataclass
+class NurtureState:
+    prospect_id: str
+    client_id: str
+    next_channel: str | None
+    next_scheduled_at: datetime | None
+    touches_sent: int
+    status: NurtureStatus
+    started_at: datetime
+    updated_at: datetime | None = None
+
+
+@dataclass
+class EnqueueResult:
+    prospect_id: str
+    status: NurtureStatus
+    action: str  # "enqueued" | "skipped" | "exhausted" | "already-active"
+    reason: str = ""
+    state: NurtureState | None = None
+
+
+def next_channel_for(touches_sent: int) -> str | None:
+    """Return 'email' or 'linkedin' based on zero-indexed position.
+    Returns None when touches_sent >= NURTURE_MAX_TOUCHES."""
+    if touches_sent >= NURTURE_MAX_TOUCHES:
+        return None
+    return _CHANNEL_BY_TOUCH[touches_sent]
+
+
+class NurtureDrip:
+    """Stateless drip scheduler. Store access via injected callables.
+
+    Required callables:
+      get_prospect_status(prospect_id)
+          -> {"outreach_status": str, "has_reply": bool, "has_meeting": bool}
+      get_state(prospect_id) -> NurtureState | None
+      upsert_state(state: NurtureState) -> None
+      insert_scheduled_touch(prospect_id, client_id, channel, scheduled_at,
+                             sequence_step=None) -> None
+      now_fn -> Callable[[], datetime]
+
+    NurtureDrip NEVER raises — all methods swallow exceptions and log them.
+    """
+
+    def __init__(
+        self,
+        get_prospect_status: Callable,
+        get_state: Callable,
+        upsert_state: Callable,
+        insert_scheduled_touch: Callable,
+        now_fn: Callable = lambda: datetime.now(timezone.utc),
+    ):
+        self._get_prospect_status = get_prospect_status
+        self._get_state = get_state
+        self._upsert_state = upsert_state
+        self._insert_scheduled_touch = insert_scheduled_touch
+        self._now_fn = now_fn
+
+    def is_eligible(self, prospect_id: str) -> tuple[bool, str]:
+        """Check cold-prospect eligibility. Returns (eligible, reason)."""
+        try:
+            info = self._get_prospect_status(prospect_id)
+        except Exception as exc:
+            logger.exception("nurture_drip.is_eligible: status lookup failed prospect=%s: %s",
+                             prospect_id, exc)
+            return False, "status_lookup_error"
+
+        status = info.get("outreach_status", "")
+
+        if status == "suppressed":
+            return False, "suppressed"
+        if status != "complete":
+            return False, f"not_cold (status={status})"
+        if info.get("has_reply"):
+            return False, "has_reply"
+        if info.get("has_meeting"):
+            return False, "has_meeting"
+
+        return True, ""
+
+    def enqueue(self, prospect_id: str, client_id: str) -> EnqueueResult:
+        """Enqueue a cold prospect into the drip. Idempotent."""
+        try:
+            eligible, reason = self.is_eligible(prospect_id)
+            if not eligible:
+                return EnqueueResult(
+                    prospect_id=prospect_id,
+                    status=NurtureStatus.PAUSED,
+                    action="skipped",
+                    reason=reason,
+                )
+
+            existing = self._get_state(prospect_id)
+            if existing is not None:
+                if existing.status == NurtureStatus.ACTIVE:
+                    return EnqueueResult(
+                        prospect_id=prospect_id,
+                        status=NurtureStatus.ACTIVE,
+                        action="already-active",
+                        state=existing,
+                    )
+                if existing.status == NurtureStatus.EXHAUSTED:
+                    return EnqueueResult(
+                        prospect_id=prospect_id,
+                        status=NurtureStatus.EXHAUSTED,
+                        action="exhausted",
+                        state=existing,
+                    )
+
+            now = self._now_fn()
+            first_touch_at = now + timedelta(days=NURTURE_FIRST_TOUCH_OFFSET_DAYS)
+            state = NurtureState(
+                prospect_id=prospect_id,
+                client_id=client_id,
+                next_channel="email",
+                next_scheduled_at=first_touch_at,
+                touches_sent=0,
+                status=NurtureStatus.ACTIVE,
+                started_at=now,
+                updated_at=now,
+            )
+            self._upsert_state(state)
+            self._insert_scheduled_touch(
+                prospect_id, client_id, "email", first_touch_at, sequence_step=100,
+            )
+            logger.info("nurture_drip.enqueue: prospect=%s enqueued touch-1 at %s",
+                        prospect_id, first_touch_at.isoformat())
+            return EnqueueResult(
+                prospect_id=prospect_id,
+                status=NurtureStatus.ACTIVE,
+                action="enqueued",
+                state=state,
+            )
+
+        except Exception as exc:
+            logger.exception("nurture_drip.enqueue: unexpected error prospect=%s: %s",
+                             prospect_id, exc)
+            return EnqueueResult(
+                prospect_id=prospect_id,
+                status=NurtureStatus.PAUSED,
+                action="skipped",
+                reason=f"internal_error: {exc}",
+            )
+
+    def record_send(self, prospect_id: str) -> EnqueueResult:
+        """Called after a drip touch dispatches. Advances touches_sent,
+        schedules the next touch if under cap, else marks exhausted."""
+        try:
+            state = self._get_state(prospect_id)
+            if state is None:
+                return EnqueueResult(
+                    prospect_id=prospect_id,
+                    status=NurtureStatus.PAUSED,
+                    action="skipped",
+                    reason="no drip state",
+                )
+
+            now = self._now_fn()
+            state.touches_sent += 1
+            state.updated_at = now
+
+            if state.touches_sent >= NURTURE_MAX_TOUCHES:
+                state.status = NurtureStatus.EXHAUSTED
+                state.next_scheduled_at = None
+                state.next_channel = None
+                self._upsert_state(state)
+                logger.info("nurture_drip.record_send: prospect=%s exhausted after %d touches",
+                            prospect_id, state.touches_sent)
+                return EnqueueResult(
+                    prospect_id=prospect_id,
+                    status=NurtureStatus.EXHAUSTED,
+                    action="exhausted",
+                    state=state,
+                )
+
+            next_ch = next_channel_for(state.touches_sent)
+            next_at = now + timedelta(days=NURTURE_INTERVAL_DAYS)
+            state.next_channel = next_ch
+            state.next_scheduled_at = next_at
+            self._upsert_state(state)
+            self._insert_scheduled_touch(
+                prospect_id, state.client_id, next_ch, next_at, sequence_step=100,
+            )
+            logger.info(
+                "nurture_drip.record_send: prospect=%s touch=%d next=%s at %s",
+                prospect_id, state.touches_sent, next_ch, next_at.isoformat(),
+            )
+            return EnqueueResult(
+                prospect_id=prospect_id,
+                status=NurtureStatus.ACTIVE,
+                action="enqueued",
+                state=state,
+            )
+
+        except Exception as exc:
+            logger.exception("nurture_drip.record_send: unexpected error prospect=%s: %s",
+                             prospect_id, exc)
+            return EnqueueResult(
+                prospect_id=prospect_id,
+                status=NurtureStatus.PAUSED,
+                action="skipped",
+                reason=f"internal_error: {exc}",
+            )

--- a/src/outreach/safety/compliance_guard.py
+++ b/src/outreach/safety/compliance_guard.py
@@ -13,12 +13,15 @@ blocks the send.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Callable
 from zoneinfo import ZoneInfo
 
 from src.outreach.safety.timing_engine import AU_PUBLIC_HOLIDAYS_2026, Channel
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_TZ = "Australia/Sydney"
 
@@ -42,6 +45,18 @@ def _default_dncr(phone: str) -> bool:  # noqa: ARG001
     return False
 
 
+def _resolve_dncr(lookup: Callable[[str], bool] | None) -> Callable[[str], bool]:
+    """Return the supplied lookup, or build the live adapter, falling back to no-op."""
+    if lookup is not None:
+        return lookup
+    try:
+        from src.outreach.safety.dncr_adapter import build_dncr_lookup as _build_dncr
+        return _build_dncr()
+    except Exception as exc:
+        logger.warning("DNCR adapter init failed, falling back to no-op: %s", exc)
+        return _default_dncr
+
+
 class ComplianceGuard:
     """
     Contract: src/outreach/safety/compliance_guard.py — ComplianceGuard
@@ -61,7 +76,7 @@ class ComplianceGuard:
         dncr_lookup: Callable[[str], bool] | None = None,
     ) -> None:
         self._suppression = suppression_lookup or _default_suppression
-        self._dncr = dncr_lookup or _default_dncr
+        self._dncr = _resolve_dncr(dncr_lookup)
 
     def check(
         self,

--- a/src/outreach/safety/dncr_adapter.py
+++ b/src/outreach/safety/dncr_adapter.py
@@ -1,0 +1,51 @@
+"""
+Contract: src/outreach/safety/dncr_adapter.py
+Purpose: Bridge DNCRClient (integration layer) to ComplianceGuard's
+         injectable dncr_lookup callable. Handles the three-state result
+         (registered=True/False/None) and applies the AU business-interest
+         rule for degraded API responses.
+Layer:   3 - engines
+Imports: stdlib + src.integrations.dncr_client
+Consumers: src/outreach/safety/compliance_guard.py (as dncr_lookup arg)
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from src.integrations.dncr_client import DNCRClient, DNCRResult
+
+logger = logging.getLogger(__name__)
+
+
+def build_dncr_lookup(
+    client: DNCRClient | None = None,
+    *,
+    log_degraded: bool = True,
+) -> Callable[[str], bool]:
+    """Return a callable(phone) -> bool suitable for ComplianceGuard.
+
+    Returns True only when registered=True. Degraded API results
+    (registered=None) return False with a warning log so the send is
+    ALLOWED under the AU business-interest B2B exemption. This matches
+    Dave's ratified policy: unknown state is a caution signal, not a block.
+
+    If client is None, constructs a default DNCRClient() (reads env vars).
+    """
+    dncr = client or DNCRClient()
+
+    def _lookup(phone: str) -> bool:
+        if not phone:
+            return False
+        result: DNCRResult = dncr.lookup(phone)
+        if result.registered is True:
+            return True
+        if result.registered is None and log_degraded:
+            logger.warning(
+                "DNCR degraded for %s (status=%s) — allowing send under "
+                "AU business-interest B2B exemption. Operator audit required.",
+                phone, result.status,
+            )
+        return False
+
+    return _lookup

--- a/tests/orchestration/flows/test_monthly_cycle_close_nurture.py
+++ b/tests/orchestration/flows/test_monthly_cycle_close_nurture.py
@@ -1,0 +1,138 @@
+"""
+Tests for nurture_enqueue_fn integration in close_cycles_task.
+
+Verifies the post-close hook is called correctly for prospects
+transitioning to 'complete', and is safely skipped when absent
+or when no 'complete' transitions occurred.
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+from src.orchestration.flows.monthly_cycle_close_flow import close_cycles_task
+
+
+class FakeConn:
+    """Minimal FakeConn — records executed/fetched SQL; returns programmable results."""
+
+    def __init__(
+        self,
+        fetch_returns: list[list[dict]] | None = None,
+        execute_rowcounts: list[int] | None = None,
+    ):
+        self.executed: list[tuple[str, tuple]] = []
+        self.fetched: list[tuple[str, tuple]] = []
+        self._fetch_returns = list(fetch_returns or [])
+        self._exec_rc = list(execute_rowcounts or [])
+
+    async def execute(self, sql: str, *args) -> int:
+        self.executed.append((sql, args))
+        return self._exec_rc.pop(0) if self._exec_rc else 0
+
+    async def fetch(self, sql: str, *args) -> list[dict]:
+        self.fetched.append((sql, args))
+        return self._fetch_returns.pop(0) if self._fetch_returns else []
+
+
+# ---------------------------------------------------------------------------
+# Helper builders
+# ---------------------------------------------------------------------------
+
+def one_cycle(cycle_id="c1", client_id="cl1") -> dict:
+    return {
+        "id": cycle_id,
+        "client_id": client_id,
+        "cycle_day_1_date": date(2026, 3, 1),
+        "cycle_number": 1,
+    }
+
+
+async def noop_trigger(db: Any, client_id: str) -> None:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Test 1: nurture_enqueue_fn called for each complete prospect
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nurture_enqueue_called_for_complete_prospects():
+    """One cycle with 3 prospects that transition to 'complete' — hook called 3 times."""
+    cycle = one_cycle()
+    # FakeConn fetch_returns order:
+    #   1st fetch = find_cycles_to_close -> [cycle]
+    #   2nd fetch = _enqueue_cold_prospects_for_nurture -> 3 prospect rows
+    prospect_rows = [
+        {"prospect_id": "p1"},
+        {"prospect_id": "p2"},
+        {"prospect_id": "p3"},
+    ]
+    conn = FakeConn(
+        fetch_returns=[[cycle], prospect_rows],
+        # transitions: meeting=0, replied=0, complete=3
+        # Then mark_cycle_closed + event emit = 2 more executes
+        execute_rowcounts=[0, 0, 3, 1, 1],
+    )
+
+    enqueue_calls: list[tuple[str, str]] = []
+
+    def nurture_fn(prospect_id: str, client_id: str) -> None:
+        enqueue_calls.append((prospect_id, client_id))
+
+    summary = await close_cycles_task(conn, noop_trigger, nurture_enqueue_fn=nurture_fn)
+
+    assert summary.cycles_closed == 1
+    assert summary.transitions["complete"] == 3
+    assert len(enqueue_calls) == 3
+    assert set(enqueue_calls) == {("p1", "cl1"), ("p2", "cl1"), ("p3", "cl1")}
+
+
+# ---------------------------------------------------------------------------
+# Test 2: nurture_enqueue_fn=None — no crash
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nurture_enqueue_fn_none_no_crash():
+    """nurture_enqueue_fn=None is the default — must not raise."""
+    cycle = one_cycle()
+    conn = FakeConn(
+        fetch_returns=[[cycle]],
+        execute_rowcounts=[0, 0, 3, 1, 1],
+    )
+
+    # Should complete cleanly without raising even though complete=3
+    summary = await close_cycles_task(conn, noop_trigger, nurture_enqueue_fn=None)
+    assert summary.cycles_closed == 1
+    # No fetch for prospect IDs was attempted (early return because fn is None)
+    # The only fetch is the initial find_cycles_to_close
+    assert len(conn.fetched) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 3: no 'complete' transitions — nurture_enqueue_fn NOT called
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nurture_enqueue_not_called_when_no_complete_transitions():
+    """All prospects replied or meeting_booked — complete=0, hook skipped."""
+    cycle = one_cycle()
+    conn = FakeConn(
+        fetch_returns=[[cycle]],
+        # meeting=2, replied=1, complete=0
+        execute_rowcounts=[2, 1, 0, 1, 1],
+    )
+
+    enqueue_calls: list[tuple] = []
+
+    def nurture_fn(prospect_id: str, client_id: str) -> None:
+        enqueue_calls.append((prospect_id, client_id))
+
+    summary = await close_cycles_task(conn, noop_trigger, nurture_enqueue_fn=nurture_fn)
+
+    assert summary.transitions["complete"] == 0
+    assert enqueue_calls == []
+    # No second fetch for prospect IDs was made
+    assert len(conn.fetched) == 1

--- a/tests/outreach/cadence/test_daily_decider.py
+++ b/tests/outreach/cadence/test_daily_decider.py
@@ -189,7 +189,9 @@ async def test_apply_actions_writes_scheduled_rows_and_counts():
     assert counts["skipped"] == 1
     assert counts["suppressed"] == 1
     assert counts["escalated"] == 1
-    assert db.execute.await_count == 2  # only schedule_next + nurture insert
+    # insert + bu_mark_active (schedule_next) + insert + bu_mark_active (nurture)
+    # + bu_mark_suppressed (suppress) = 5 execute calls
+    assert db.execute.await_count == 5
 
 
 @pytest.mark.asyncio

--- a/tests/outreach/cadence/test_daily_decider_bu_lifecycle.py
+++ b/tests/outreach/cadence/test_daily_decider_bu_lifecycle.py
@@ -1,0 +1,157 @@
+"""
+Tests for BU lifecycle column population in daily_decider.apply_actions.
+
+Covers the state transitions fired on scheduled_touches inserts + suppressions:
+  - schedule_next / nurture -> UPDATE business_universe SET outreach_status='active'
+    (from pending only) + last_outreach_at[channel] = scheduled_at +
+    signal_snapshot_at = NOW()
+  - suppress -> UPDATE business_universe SET outreach_status='suppressed'
+    (unless currently 'converted')
+  - BU UPDATE failures are swallowed (logged, not raised; errors counter
+    unaffected by BU-only failures).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.outreach.cadence.daily_decider import (
+    DeciderAction,
+    _bu_mark_active,
+    _bu_mark_suppressed,
+    apply_actions,
+)
+
+
+def _when() -> datetime:
+    return datetime.now(UTC) + timedelta(days=1)
+
+
+# -- _bu_mark_active --------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_bu_mark_active_fires_update_with_channel_timestamp():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    when = _when()
+    await _bu_mark_active(db, "lead-1", "email", when)
+    assert db.execute.await_count == 1
+    call_args = db.execute.await_args.args
+    sql = call_args[0]
+    rest = call_args[1:]
+    assert "business_universe" in sql
+    assert "outreach_status" in sql
+    assert "CASE" in sql  # idempotent pending->active gate
+    assert "last_outreach_at" in sql
+    assert "signal_snapshot_at" in sql
+    assert rest == ("lead-1", "email", when)
+
+
+@pytest.mark.asyncio
+async def test_bu_mark_active_swallows_db_errors():
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=RuntimeError("dead conn"))
+    # Should not raise
+    await _bu_mark_active(db, "lead-1", "email", _when())
+
+
+# -- _bu_mark_suppressed ----------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_bu_mark_suppressed_fires_update_gated_on_not_converted():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    await _bu_mark_suppressed(db, "lead-1")
+    assert db.execute.await_count == 1
+    call_args = db.execute.await_args.args
+    sql = call_args[0]
+    rest = call_args[1:]
+    assert "suppressed" in sql
+    assert "converted" in sql   # gate prevents regression from converted
+    assert rest == ("lead-1",)
+
+
+@pytest.mark.asyncio
+async def test_bu_mark_suppressed_swallows_db_errors():
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=RuntimeError("dead conn"))
+    await _bu_mark_suppressed(db, "lead-1")   # no raise
+
+
+# -- apply_actions composition --------------------------------------------
+
+@pytest.mark.asyncio
+async def test_schedule_next_fires_insert_and_bu_active():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    when = _when()
+    actions = [DeciderAction("lead-1", "schedule_next", "email", when, "", 1)]
+    counts = await apply_actions(db, "client-1", actions)
+    assert counts["scheduled"] == 1
+    assert counts["errors"] == 0
+    # 1 insert + 1 bu_mark_active = 2 executes
+    assert db.execute.await_count == 2
+    # Second call is the BU UPDATE
+    second_sql = db.execute.await_args_list[1].args[0]
+    assert "UPDATE business_universe" in second_sql
+
+
+@pytest.mark.asyncio
+async def test_nurture_fires_insert_and_bu_active():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    when = _when()
+    actions = [DeciderAction("lead-2", "nurture", "linkedin", when, "", None)]
+    counts = await apply_actions(db, "client-1", actions)
+    assert counts["nurture"] == 1
+    assert db.execute.await_count == 2
+    second_args = db.execute.await_args_list[1].args
+    assert "linkedin" in second_args  # channel passed to BU UPDATE
+
+
+@pytest.mark.asyncio
+async def test_suppress_fires_bu_suppressed():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    actions = [DeciderAction("lead-3", "suppress", None, None, "unsub", None)]
+    counts = await apply_actions(db, "client-1", actions)
+    assert counts["suppressed"] == 1
+    assert db.execute.await_count == 1  # only bu_mark_suppressed, no touch insert
+    sql = db.execute.await_args.args[0]
+    assert "suppressed" in sql
+
+
+@pytest.mark.asyncio
+async def test_skip_and_escalate_fire_no_bu_update():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    actions = [
+        DeciderAction("lead-4", "skip",     None, None, "too soon", None),
+        DeciderAction("lead-5", "escalate", None, None, "no chan",   None),
+    ]
+    counts = await apply_actions(db, "client-1", actions)
+    assert counts["skipped"] == 1
+    assert counts["escalated"] == 1
+    assert db.execute.await_count == 0  # no DB writes for pure-logging actions
+
+
+@pytest.mark.asyncio
+async def test_bu_update_failure_does_not_regress_success_counts():
+    # Insert succeeds; BU UPDATE fails. The scheduled counter still increments;
+    # errors counter remains 0 (BU is best-effort).
+    db = AsyncMock()
+    call_count = {"n": 0}
+
+    async def flaky_execute(*_args, **_kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return None           # scheduled_touches insert succeeds
+        raise RuntimeError("bu boom")
+
+    db.execute = AsyncMock(side_effect=flaky_execute)
+    actions = [DeciderAction("lead-1", "schedule_next", "email", _when(), "", 1)]
+    counts = await apply_actions(db, "client-1", actions)
+    assert counts["scheduled"] == 1
+    assert counts["errors"] == 0   # BU failure does not bump errors

--- a/tests/outreach/cadence/test_nurture_drip.py
+++ b/tests/outreach/cadence/test_nurture_drip.py
@@ -1,0 +1,320 @@
+"""
+Tests for src/outreach/cadence/nurture_drip.py
+
+In-memory fakes (dict-backed stores). now_fn frozen to a fixed datetime.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.outreach.cadence.nurture_drip import (
+    NURTURE_INTERVAL_DAYS,
+    NURTURE_MAX_TOUCHES,
+    NurtureDrip,
+    NurtureState,
+    NurtureStatus,
+    next_channel_for,
+)
+
+FIXED_NOW = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# In-memory fakes
+# ---------------------------------------------------------------------------
+
+class FakeStore:
+    def __init__(self, prospect_info: dict | None = None, initial_state: NurtureState | None = None):
+        self._prospects: dict[str, dict] = {}
+        if prospect_info:
+            self._prospects.update(prospect_info)
+        self._states: dict[str, NurtureState] = {}
+        if initial_state:
+            self._states[initial_state.prospect_id] = initial_state
+        self.upserted: list[NurtureState] = []
+        self.scheduled: list[tuple] = []
+
+    def get_prospect_status(self, prospect_id: str) -> dict:
+        return self._prospects.get(prospect_id, {})
+
+    def get_state(self, prospect_id: str) -> NurtureState | None:
+        return self._states.get(prospect_id)
+
+    def upsert_state(self, state: NurtureState) -> None:
+        self._states[state.prospect_id] = state
+        self.upserted.append(state)
+
+    def insert_scheduled_touch(self, prospect_id, client_id, channel, scheduled_at,
+                               sequence_step=None) -> None:
+        self.scheduled.append((prospect_id, client_id, channel, scheduled_at, sequence_step))
+
+    def build_drip(self) -> NurtureDrip:
+        return NurtureDrip(
+            get_prospect_status=self.get_prospect_status,
+            get_state=self.get_state,
+            upsert_state=self.upsert_state,
+            insert_scheduled_touch=self.insert_scheduled_touch,
+            now_fn=lambda: FIXED_NOW,
+        )
+
+
+def cold_prospect_info() -> dict:
+    return {
+        "outreach_status": "complete",
+        "has_reply": False,
+        "has_meeting": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. next_channel_for — alternating pattern
+# ---------------------------------------------------------------------------
+
+def test_next_channel_email_at_0():
+    assert next_channel_for(0) == "email"
+
+def test_next_channel_linkedin_at_1():
+    assert next_channel_for(1) == "linkedin"
+
+def test_next_channel_email_at_2():
+    assert next_channel_for(2) == "email"
+
+def test_next_channel_linkedin_at_3():
+    assert next_channel_for(3) == "linkedin"
+
+def test_next_channel_email_at_4():
+    assert next_channel_for(4) == "email"
+
+def test_next_channel_linkedin_at_5():
+    assert next_channel_for(5) == "linkedin"
+
+def test_next_channel_none_at_6():
+    assert next_channel_for(6) is None
+
+def test_next_channel_none_beyond_cap():
+    assert next_channel_for(10) is None
+
+
+# ---------------------------------------------------------------------------
+# 2-6. is_eligible
+# ---------------------------------------------------------------------------
+
+def test_is_eligible_cold_prospect_true():
+    store = FakeStore(prospect_info={"p1": cold_prospect_info()})
+    drip = store.build_drip()
+    eligible, reason = drip.is_eligible("p1")
+    assert eligible is True
+    assert reason == ""
+
+
+def test_is_eligible_rejects_non_complete_status():
+    store = FakeStore(prospect_info={"p1": {
+        "outreach_status": "in_sequence", "has_reply": False, "has_meeting": False,
+    }})
+    drip = store.build_drip()
+    eligible, reason = drip.is_eligible("p1")
+    assert eligible is False
+    assert "not_cold" in reason
+    assert "in_sequence" in reason
+
+
+def test_is_eligible_rejects_has_reply():
+    store = FakeStore(prospect_info={"p1": {
+        "outreach_status": "complete", "has_reply": True, "has_meeting": False,
+    }})
+    drip = store.build_drip()
+    eligible, reason = drip.is_eligible("p1")
+    assert eligible is False
+    assert reason == "has_reply"
+
+
+def test_is_eligible_rejects_has_meeting():
+    store = FakeStore(prospect_info={"p1": {
+        "outreach_status": "complete", "has_reply": False, "has_meeting": True,
+    }})
+    drip = store.build_drip()
+    eligible, reason = drip.is_eligible("p1")
+    assert eligible is False
+    assert reason == "has_meeting"
+
+
+def test_is_eligible_rejects_suppressed():
+    store = FakeStore(prospect_info={"p1": {
+        "outreach_status": "suppressed", "has_reply": False, "has_meeting": False,
+    }})
+    drip = store.build_drip()
+    eligible, reason = drip.is_eligible("p1")
+    assert eligible is False
+    assert reason == "suppressed"
+
+
+# ---------------------------------------------------------------------------
+# 7. enqueue happy path
+# ---------------------------------------------------------------------------
+
+def test_enqueue_cold_prospect_creates_active_state_and_schedules_touch():
+    store = FakeStore(prospect_info={"p1": cold_prospect_info()})
+    drip = store.build_drip()
+    result = drip.enqueue("p1", "cl1")
+
+    assert result.action == "enqueued"
+    assert result.status == NurtureStatus.ACTIVE
+    assert result.state is not None
+    assert result.state.touches_sent == 0
+    assert result.state.next_channel == "email"
+    expected_at = FIXED_NOW + timedelta(days=NURTURE_INTERVAL_DAYS)
+    assert result.state.next_scheduled_at == expected_at
+
+    # State was upserted
+    assert len(store.upserted) == 1
+    # Scheduled touch was inserted
+    assert len(store.scheduled) == 1
+    pid, cid, channel, sched_at, step = store.scheduled[0]
+    assert pid == "p1"
+    assert cid == "cl1"
+    assert channel == "email"
+    assert sched_at == expected_at
+    assert step == 100
+
+
+# ---------------------------------------------------------------------------
+# 8. enqueue idempotent — already-active
+# ---------------------------------------------------------------------------
+
+def test_enqueue_already_active_returns_already_active_no_duplicate():
+    existing = NurtureState(
+        prospect_id="p1", client_id="cl1", next_channel="linkedin",
+        next_scheduled_at=FIXED_NOW + timedelta(days=15),
+        touches_sent=1, status=NurtureStatus.ACTIVE,
+        started_at=FIXED_NOW,
+    )
+    store = FakeStore(prospect_info={"p1": cold_prospect_info()}, initial_state=existing)
+    drip = store.build_drip()
+    result = drip.enqueue("p1", "cl1")
+
+    assert result.action == "already-active"
+    assert result.status == NurtureStatus.ACTIVE
+    assert result.state is existing
+    # No new upserts or scheduled touches
+    assert len(store.upserted) == 0
+    assert len(store.scheduled) == 0
+
+
+# ---------------------------------------------------------------------------
+# 9. enqueue exhausted
+# ---------------------------------------------------------------------------
+
+def test_enqueue_exhausted_returns_exhausted_no_touch():
+    existing = NurtureState(
+        prospect_id="p1", client_id="cl1", next_channel=None,
+        next_scheduled_at=None, touches_sent=6,
+        status=NurtureStatus.EXHAUSTED, started_at=FIXED_NOW,
+    )
+    store = FakeStore(prospect_info={"p1": cold_prospect_info()}, initial_state=existing)
+    drip = store.build_drip()
+    result = drip.enqueue("p1", "cl1")
+
+    assert result.action == "exhausted"
+    assert result.status == NurtureStatus.EXHAUSTED
+    assert len(store.scheduled) == 0
+
+
+# ---------------------------------------------------------------------------
+# 10. enqueue ineligible (suppressed)
+# ---------------------------------------------------------------------------
+
+def test_enqueue_suppressed_returns_skipped():
+    store = FakeStore(prospect_info={"p1": {
+        "outreach_status": "suppressed", "has_reply": False, "has_meeting": False,
+    }})
+    drip = store.build_drip()
+    result = drip.enqueue("p1", "cl1")
+
+    assert result.action == "skipped"
+    assert result.reason == "suppressed"
+    assert len(store.scheduled) == 0
+
+
+# ---------------------------------------------------------------------------
+# 11. record_send advances 0->1 with next_channel='linkedin'
+# ---------------------------------------------------------------------------
+
+def test_record_send_advances_to_touch_1_linkedin():
+    state = NurtureState(
+        prospect_id="p1", client_id="cl1", next_channel="email",
+        next_scheduled_at=FIXED_NOW, touches_sent=0,
+        status=NurtureStatus.ACTIVE, started_at=FIXED_NOW,
+    )
+    store = FakeStore(initial_state=state)
+    drip = store.build_drip()
+    result = drip.record_send("p1")
+
+    assert result.action == "enqueued"
+    assert result.state.touches_sent == 1
+    assert result.state.next_channel == "linkedin"
+    assert result.state.next_scheduled_at == FIXED_NOW + timedelta(days=NURTURE_INTERVAL_DAYS)
+    # A new scheduled touch was inserted
+    assert len(store.scheduled) == 1
+    _, _, ch, _, _ = store.scheduled[0]
+    assert ch == "linkedin"
+
+
+# ---------------------------------------------------------------------------
+# 12. record_send alternates channels across 6 calls
+# ---------------------------------------------------------------------------
+
+def test_record_send_alternates_channels_across_6_calls():
+    state = NurtureState(
+        prospect_id="p1", client_id="cl1", next_channel="email",
+        next_scheduled_at=FIXED_NOW, touches_sent=0,
+        status=NurtureStatus.ACTIVE, started_at=FIXED_NOW,
+    )
+    store = FakeStore(initial_state=state)
+    drip = store.build_drip()
+
+    expected_sequence = ["linkedin", "email", "linkedin", "email", "linkedin"]
+    for i, expected_ch in enumerate(expected_sequence):
+        result = drip.record_send("p1")
+        assert result.action == "enqueued", f"call {i+1}: expected enqueued got {result.action}"
+        assert result.state.next_channel == expected_ch, (
+            f"call {i+1}: expected {expected_ch} got {result.state.next_channel}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 13. record_send at touch 5 -> touch 6 marks exhausted, no further insert
+# ---------------------------------------------------------------------------
+
+def test_record_send_at_touch_5_marks_exhausted():
+    state = NurtureState(
+        prospect_id="p1", client_id="cl1", next_channel="linkedin",
+        next_scheduled_at=FIXED_NOW, touches_sent=5,
+        status=NurtureStatus.ACTIVE, started_at=FIXED_NOW,
+    )
+    store = FakeStore(initial_state=state)
+    drip = store.build_drip()
+    result = drip.record_send("p1")
+
+    assert result.action == "exhausted"
+    assert result.status == NurtureStatus.EXHAUSTED
+    assert result.state.touches_sent == NURTURE_MAX_TOUCHES
+    assert result.state.next_channel is None
+    assert result.state.next_scheduled_at is None
+    # No scheduled touch inserted — drip is done
+    assert len(store.scheduled) == 0
+
+
+# ---------------------------------------------------------------------------
+# 14. record_send on missing state -> skipped / no drip state
+# ---------------------------------------------------------------------------
+
+def test_record_send_missing_state_returns_skipped():
+    store = FakeStore()  # no initial state
+    drip = store.build_drip()
+    result = drip.record_send("p1")
+
+    assert result.action == "skipped"
+    assert result.reason == "no drip state"
+    assert len(store.scheduled) == 0

--- a/tests/outreach/safety/test_dncr_adapter.py
+++ b/tests/outreach/safety/test_dncr_adapter.py
@@ -1,0 +1,154 @@
+"""
+Tests for src/outreach/safety/dncr_adapter.py
+
+Coverage:
+1. registered=True  -> adapter returns True
+2. registered=False -> adapter returns False
+3. registered=None (degraded) -> returns False + warning logged
+4. Empty phone ""   -> returns False, client.lookup NOT called
+5. None phone       -> returns False, client.lookup NOT called
+6. log_degraded=False + degraded -> returns False, NO warning logged
+7. Two calls with same phone produce consistent result (pass-through, no adapter cache)
+8. Log message contains phone + status for operator audit trail
+9. client=None path constructs a DNCRClient and returns a callable
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.integrations.dncr_client import DNCRResult
+from src.outreach.safety.dncr_adapter import build_dncr_lookup
+
+PHONE = "+61411111111"
+
+
+def _make_result(registered, status="ok"):
+    from datetime import datetime, timezone
+    return DNCRResult(
+        registered=registered,
+        registered_at=None,
+        last_checked=datetime.now(timezone.utc),
+        status=status,
+    )
+
+
+def _mock_client(registered, status="ok"):
+    client = MagicMock()
+    client.lookup.return_value = _make_result(registered, status)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — registered=True
+# ---------------------------------------------------------------------------
+
+def test_registered_true_returns_true():
+    client = _mock_client(True)
+    lookup = build_dncr_lookup(client)
+    assert lookup(PHONE) is True
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — registered=False
+# ---------------------------------------------------------------------------
+
+def test_registered_false_returns_false():
+    client = _mock_client(False)
+    lookup = build_dncr_lookup(client)
+    assert lookup(PHONE) is False
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — degraded (registered=None) -> False + warning log
+# ---------------------------------------------------------------------------
+
+def test_degraded_returns_false_and_logs_warning(caplog):
+    client = _mock_client(None, status="degraded:no_api_key")
+    lookup = build_dncr_lookup(client)
+    with caplog.at_level(logging.WARNING, logger="src.outreach.safety.dncr_adapter"):
+        result = lookup(PHONE)
+    assert result is False
+    assert any("degraded" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — empty phone -> False, client NOT called
+# ---------------------------------------------------------------------------
+
+def test_empty_phone_returns_false_without_lookup():
+    client = _mock_client(True)
+    lookup = build_dncr_lookup(client)
+    assert lookup("") is False
+    client.lookup.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — None phone -> False, client NOT called
+# ---------------------------------------------------------------------------
+
+def test_none_phone_returns_false_without_lookup():
+    client = _mock_client(True)
+    lookup = build_dncr_lookup(client)
+    assert lookup(None) is False  # type: ignore[arg-type]
+    client.lookup.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — log_degraded=False -> no warning logged
+# ---------------------------------------------------------------------------
+
+def test_degraded_no_log_when_disabled(caplog):
+    client = _mock_client(None, status="degraded:network")
+    lookup = build_dncr_lookup(client, log_degraded=False)
+    with caplog.at_level(logging.WARNING, logger="src.outreach.safety.dncr_adapter"):
+        result = lookup(PHONE)
+    assert result is False
+    assert not caplog.records
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — two calls with same phone -> consistent result (adapter is pass-through)
+# ---------------------------------------------------------------------------
+
+def test_two_calls_consistent():
+    client = _mock_client(True)
+    lookup = build_dncr_lookup(client)
+    assert lookup(PHONE) is True
+    assert lookup(PHONE) is True
+    assert client.lookup.call_count == 2  # adapter does NOT cache; DNCRClient caches internally
+
+
+# ---------------------------------------------------------------------------
+# Case 8 — log message contains phone + status
+# ---------------------------------------------------------------------------
+
+def test_degraded_log_contains_phone_and_status(caplog):
+    status = "degraded:rate_limited"
+    client = _mock_client(None, status=status)
+    lookup = build_dncr_lookup(client)
+    with caplog.at_level(logging.WARNING, logger="src.outreach.safety.dncr_adapter"):
+        lookup(PHONE)
+    assert caplog.records, "Expected at least one warning record"
+    msg = caplog.records[0].message
+    assert PHONE in msg
+    assert status in msg
+
+
+# ---------------------------------------------------------------------------
+# Case 9 — client=None path: constructs DNCRClient, returns callable
+# ---------------------------------------------------------------------------
+
+def test_no_client_arg_constructs_default():
+    """build_dncr_lookup() with no args should return a callable without raising."""
+    with patch("src.outreach.safety.dncr_adapter.DNCRClient") as MockClient:
+        mock_instance = MagicMock()
+        mock_instance.lookup.return_value = _make_result(False)
+        MockClient.return_value = mock_instance
+        lookup = build_dncr_lookup()
+    assert callable(lookup)
+    result = lookup(PHONE)
+    assert result is False
+    mock_instance.lookup.assert_called_once()


### PR DESCRIPTION
Dispatch: AIDEN -> ORION, PHASE-2-SLICE-9 (2026-04-23, 90min timebox). 3 tracks closing outreach-safety wiring. Zero ATLAS overlap.

Base: origin/main @ e715963. Pre-PR rebase gate verified at push.

## Tracks

**A — DNCR wiring** (commit 9265501): dncr_adapter.py build_dncr_lookup bridges DNCRClient to ComplianceGuard. Degraded state allows-with-warn per AU business-interest rule. 9 tests + full safety suite green.

**B — BU lifecycle in daily_decider** (commit 45b8517): apply_actions now fires _bu_mark_active (pending->active CASE, last_outreach_at jsonb per-channel, signal_snapshot_at) and _bu_mark_suppressed (gated on != converted). BU failures are best-effort — never abort touch insert. 9 new tests + 1 existing updated.

**C — nurture_drip.py + cycle-close hook** (commit 773bda1): NurtureDrip with is_eligible + enqueue + record_send (alternating email<->linkedin, 6-touch cap, never raises). Migration 320_nurture_drip_state.sql. monthly_cycle_close_flow gained 18 lines + nurture_enqueue_fn param. 21 + 3 tests.

## Tests

pytest tests/outreach/safety/ tests/outreach/cadence/ tests/orchestration/flows/ tests/integrations/test_dncr_client.py -q -> **246 passed**.

## Governance

Scope (C5): 9 new + 4 modified files; no frontend. Branch (C6): orion-only. Zero-deletion (additive + minimal refactor). Parallelisation: build-3 (A), build-2 (C), ORION (B).

## Follow-ups

- Reply classifier webhook -> BU replied (next dispatch)
- Booking webhook -> BU converted (next dispatch)
- daily_decider BU UPDATE assumes BU.id = lead_id; no-op-safe if mapping differs
- Apply migration 320 to Supabase jatzvazlbusedwsnqxzr
- Prefect deployment for monthly_cycle_close needs nurture_enqueue_fn wire