### PR TITLE
[ELLIOT] feat: /update command + enforcer Rule 2+8 amendments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ On every new session, your FIRST action before any directive, query, or build wo
 2. Do not work from memory. Do not work from stale docs. Read the Manual before any directive.
 3. If the Manual is unreachable, alert Dave and STOP. Do not proceed from cached knowledge.
 4. **Telegram verification (HARD BLOCK):** Read the §Group Chat Plumbing section below. Verify `tg -g "test"` works. Your FIRST outbound message to Dave MUST go via `tg -g`, not terminal output. If `tg` fails, fix it before proceeding — Dave reads Telegram, not your terminal. All communication with Dave and peers happens via the Telegram group (chat_id `-1003926592540`), never terminal-only.
+5. **READ RECENT GROUP CHAT ON RESET (HARD BLOCK):** Pull the last ~30 messages or last 24 hours of the Telegram supergroup before acting on any directive. The Manual + ceo_memory capture ratified state but miss in-flight conversation — Dave approvals given in the last 10 minutes, peer corrections, dispatch announcements may NOT be in ceo_memory yet. Read from the listener log at `/tmp/telegram-relay-<callsign>/` or via Telegram getUpdates API. If the most recent messages reference a pending decision or approval, that state is ACTIVE — do NOT re-ask Dave for something visible in recent chat history.
+6. **CLONE AWARENESS (HARD BLOCK):** Check for active clone sessions (ATLAS, ORION, SCOUT) via `tmux list-sessions` and inbox/outbox watchers. Clones may have in-flight work dispatched before your reset. Read any pending outbox messages from clones before proceeding. You are not working alone — your clone assistant may already be executing directives.
 
 This overrides all other startup steps. The Manual is ground truth.
 

--- a/docs/clones/DEFERRED.md
+++ b/docs/clones/DEFERRED.md
@@ -35,6 +35,7 @@
 | 2.2.4 | Dispatcher wrapper over Salesforge/Unipile/ElevenAgents with webhook → outreach_events | **Deferred** | `PHASE-2.2-DISPATCHER-WRAPPER` ~6 hr. Largest ticket — central choke point, needs architect-0 sign-off |
 | 2.2.5 | Prefect flows (hourly pending-touches pipeline, daily warming/cycle/deliverability, weekly LinkedIn reset + mailbox stats, monthly cycle-close) | **Deferred** | `PHASE-2.2-PREFECT-FLOWS` ~5 hr |
 | 2.2.6 | Deliverability monitor — bounce >5% auto-pause, spam complaint >0.1% quarantine, LinkedIn 402/429 → 7-day cooldown | **Deferred** | `PHASE-2.2-DELIVERABILITY-MONITOR` ~4 hr |
+| 2.2.7 | Send pacer / anti-bot jitter — per-account inter-send delays: LinkedIn 2-8 min, email 30-90 sec, voice serialised 30-60 sec gap, SMS 2-5 sec. Prevents bot-flagging even when daily caps are respected. | **Deferred** | `PHASE-2.2-SEND-PACER` ~2 hr |
 
 ## Integration gaps
 

--- a/src/telegram_bot/chat_bot.py
+++ b/src/telegram_bot/chat_bot.py
@@ -518,6 +518,133 @@ async def cmd_history(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     )
 
 
+async def cmd_update(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Comprehensive session-resume handoff for a peer bot that just reset.
+    Protocol-first, state-second. Usage: /update <target_callsign>"""
+    if not await auth_check(update):
+        return
+
+    target = (context.args[0].lower() if context.args else
+              ("aiden" if CALLSIGN == "elliot" else "elliot"))
+    peer_clone = "ORION" if target == "aiden" else "ATLAS"
+    my_clone = "ATLAS" if CALLSIGN == "elliot" else "ORION"
+
+    # --- Data collection (comprehensive, Option B) ---
+    sections: list[str] = []
+
+    # 1. Protocol checklist (FIRST — restores behaviour before state)
+    sections.append(
+        f"[UPDATE:{CALLSIGN.upper()}→{target.upper()}] — session-resume handoff\n\n"
+        f"PROTOCOL CHECKLIST (reconstitute FIRST, before acting):\n"
+        f"1. You are {target.upper()}. Read ./IDENTITY.md + verify CALLSIGN env.\n"
+        f"2. TELEGRAM-ONLY: every response via `tg -g`. Dave reads Telegram, NOT terminal.\n"
+        f"3. Your peer is {CALLSIGN.upper()}. Prefix messages [{target.upper()}].\n"
+        f"4. Your clone is {peer_clone}. Dispatch via /tmp/telegram-relay-{peer_clone.lower()}/inbox/.\n"
+        f"5. Dispatch Coordination: [DISPATCH-PROPOSAL] + 20s peer [CONCUR] before inject (Rule 8).\n"
+        f"6. Read last 50 group messages before acting on any directive.\n"
+        f"7. ACKNOWLEDGE: reply via tg -g with [{target.upper()}] UPDATE-ACK."
+    )
+
+    # 2. ceo_memory state
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            keys = ["ceo:directives.last_number", "ceo:roadmap_master.active_phase",
+                    "ceo:session_end_" + datetime.now(timezone.utc).strftime("%Y-%m-%d")]
+            key_filter = ",".join(f'"{k}"' for k in keys)
+            r = await client.get(
+                f"{SUPABASE_URL}/rest/v1/ceo_memory?key=in.({key_filter})&select=key,value,updated_at",
+                headers=SUPABASE_HEADERS,
+            )
+            if r.status_code == 200 and r.json():
+                state_lines = ["CURRENT STATE (from ceo_memory):"]
+                for row in r.json():
+                    val = str(row.get("value", ""))[:200]
+                    state_lines.append(f"  {row['key']}: {val}")
+                sections.append("\n".join(state_lines))
+    except Exception as exc:
+        sections.append(f"ceo_memory: fetch failed ({exc})")
+
+    # 3. Open PRs
+    try:
+        pr_result = subprocess.run(
+            ["gh", "pr", "list", "--state", "open", "--json", "number,title",
+             "--jq", '.[] | "#\\(.number) \\(.title)"'],
+            capture_output=True, text=True, timeout=15, cwd=WORK_DIR,
+        )
+        pr_text = pr_result.stdout.strip() or "None"
+        sections.append(f"OPEN PRs:\n{pr_text}")
+    except Exception:
+        sections.append("OPEN PRs: fetch failed")
+
+    # 4. Recent commits
+    try:
+        log_result = subprocess.run(
+            ["git", "log", "--oneline", "-10"],
+            capture_output=True, text=True, timeout=10, cwd=WORK_DIR,
+        )
+        sections.append(f"RECENT COMMITS (last 10):\n{log_result.stdout.strip()}")
+    except Exception:
+        sections.append("RECENT COMMITS: fetch failed")
+
+    # 5. Clone status
+    try:
+        tmux_result = subprocess.run(
+            ["tmux", "list-sessions"],
+            capture_output=True, text=True, timeout=5,
+        )
+        sessions_text = tmux_result.stdout.strip() or "No tmux sessions"
+        sections.append(f"CLONE SESSIONS:\n{sessions_text}")
+    except Exception:
+        sections.append("CLONE SESSIONS: tmux query failed")
+
+    # 6. Pending dispatches
+    for clone_name in ["atlas", "orion", "scout"]:
+        inbox = f"/tmp/telegram-relay-{clone_name}/inbox"
+        try:
+            files = [f for f in os.listdir(inbox) if f.endswith(".json")] if os.path.isdir(inbox) else []
+            if files:
+                sections.append(f"PENDING DISPATCH ({clone_name}): {len(files)} file(s) — {', '.join(files[-3:])}")
+        except Exception:
+            pass
+
+    # 7. Last 5 group messages (from local chat log)
+    try:
+        log_path = f"/home/elliotbot/clawd/logs/telegram-group-{CALLSIGN}.log"
+        if os.path.exists(log_path):
+            with open(log_path) as f:
+                lines = f.readlines()[-5:]
+            if lines:
+                sections.append("LAST 5 GROUP MESSAGES:\n" + "".join(lines))
+    except Exception:
+        pass
+
+    # 8. Governance reminders
+    sections.append(
+        "ACTIVE GOVERNANCE:\n"
+        "  - Rule 2 (Step-0 exceptions: merges, rebases, acks)\n"
+        "  - Rule 8 (Dispatch coordination: proposal + 20s + concur)\n"
+        "  - Dual-concur on all PRs before Dave merges\n"
+        "  - Claim-before-touch on shared files\n"
+        "  - Be safe with deletions (file + line level)\n"
+        "  - Rebase on main before opening PR"
+    )
+
+    # 9. Next action
+    sections.append(
+        "IMMEDIATE NEXT ACTION: Read last 50 group messages, "
+        f"then reply via tg -g with [{target.upper()}] UPDATE-ACK — state + protocols synced."
+    )
+
+    msg = "\n\n".join(sections)
+
+    # Truncate to Telegram max (4096 chars) — split if needed
+    if len(msg) > 4000:
+        msg = msg[:3990] + "\n\n[TRUNCATED — read group chat for full context]"
+
+    await update.message.reply_text(msg)
+    logger.info(f"[/update] handoff compiled for {target} ({len(msg)} chars)")
+
+
 async def cmd_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not await auth_check(update):
         return
@@ -1169,6 +1296,7 @@ def main() -> None:
     app.add_handler(CommandHandler("history", cmd_history))
     app.add_handler(CommandHandler("relay", cmd_relay))
     app.add_handler(CommandHandler("save", cmd_save))
+    app.add_handler(CommandHandler("update", cmd_update))
     app.add_handler(CommandHandler("help", cmd_help))
     # Media handlers before text fallback
     app.add_handler(MessageHandler(filters.PHOTO, handle_photo))

--- a/src/telegram_bot/enforcer_bot.py
+++ b/src/telegram_bot/enforcer_bot.py
@@ -49,6 +49,10 @@ Rule 2 — STEP-0-BEFORE-EXECUTION: If the current message shows execution start
   (a) a Dave-directed Step 0 / RESTATE post, OR
   (b) a dual peer-Step-0 pair — BOTH `[FINAL CONCUR:ELLIOT]` AND `[FINAL CONCUR:AIDEN]` tags present in recent_messages on the same topic (dual-concur governance ratified 2026-04-22).
 Having EITHER signal = PASS. Missing BOTH = VIOLATION.
+EXCEPTIONS (always PASS, no Step 0 required):
+  (i)   PR merge on explicit CEO instruction (Dave posts "merge N" or "merge N + continue")
+  (ii)  Rebase performed as peer-review fix (continuation of original dispatch, not new directive)
+  (iii) Orchestrator tagging peer replies (acknowledgement, not execution)
 
 Rule 3 — COMPLETION-REQUIRES-VERIFICATION: If the current message claims task completion ("complete", "done", "all stores written", "4-store save complete"), check if verification evidence was posted (terminal output, SQL results, test output, commit hashes). Claim without evidence = VIOLATION.
 
@@ -57,6 +61,8 @@ Rule 4 — NO-UNREVIEWED-MAIN-PUSH: If the current message mentions pushing dire
 Rule 5 — SHARED-FILE-CLAIM: If the current message mentions editing memory_listener.py, chat_bot.py, store.py, listener_discernment.py, or any CLAUDE.md file, check if "[CLAIM:" was posted. Missing claim = VIOLATION.
 
 Rule 6 — SAVE-CLAIM-REQUIRES-PROOF: If the current message claims a save was completed ("state saved", "4-store save complete", "ceo_memory updated", "MANUAL updated", "Drive mirrored", "daily_log written", "stores written"), check that the message includes SPECIFIC EVIDENCE for EACH store claimed. Evidence means: commit hashes for MANUAL, SQL confirmation for ceo_memory, byte count or success message for Drive mirror, query result for daily_log. A bot saying "all stores written ✓" without showing the actual outputs for each store = VIOLATION. The claim must be backed by verifiable proof in recent messages, not just checkmarks.
+
+Rule 8 — DISPATCH-COORDINATION: If the current message shows a clone dispatch being injected (mentions "dispatched", "injected", "tmux paste", "ATLAS dispatched", "ORION dispatched", or dispatch JSON), check whether a [DISPATCH-PROPOSAL:<callsign>] was posted in recent_messages AND the peer posted [CONCUR] on that proposal BEFORE the dispatch. Dispatching without prior proposal + peer concur = VIOLATION. Exception: if only one bot is active (peer offline/reset), solo dispatch with proposal posted is sufficient.
 
 Rule 7 — CLONE-DIRECT-GROUP-POST: If the current message's bot/sender prefix is a CLONE callsign (ATLAS, ORION, or any `[<callsign>]` tag other than ELLIOT, AIDEN, DAVE, SCOUT, ENFORCER), flag as VIOLATION — clones are prohibited from posting to group per C3 Prime-Only Clone Channel. Clone output must go only to parent inbox via relay-watcher push. Parent surfaces clone artefacts to group via `[CONSUMED:<parent>] <path> + verbatim excerpt` post. Seeing a clone callsign in group means either (a) the clone violated C3 directly, or (b) a parent wrote under the wrong prefix — either way, flag.
 

--- a/tests/telegram_bot/test_cmd_update.py
+++ b/tests/telegram_bot/test_cmd_update.py
@@ -1,0 +1,105 @@
+"""Tests for /update command handler (src/telegram_bot/chat_bot.py::cmd_update)."""
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# Minimal import — cmd_update uses CALLSIGN, SUPABASE_URL, etc. from module scope.
+# We patch those at test level to avoid env dependency.
+
+
+@pytest.fixture
+def mock_update():
+    update = AsyncMock()
+    update.effective_chat.id = 7267788033
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+@pytest.fixture
+def mock_context_aiden():
+    ctx = MagicMock()
+    ctx.args = ["aiden"]
+    return ctx
+
+
+@pytest.fixture
+def mock_context_no_args():
+    ctx = MagicMock()
+    ctx.args = []
+    return ctx
+
+
+@patch.dict(os.environ, {"CALLSIGN": "elliot", "SUPABASE_URL": "https://test.supabase.co",
+                          "SUPABASE_SERVICE_KEY": "test-key", "TELEGRAM_TOKEN": "test"})
+class TestCmdUpdate:
+    """cmd_update handler tests."""
+
+    def _import_cmd_update(self):
+        """Import cmd_update with mocked env to avoid startup side-effects."""
+        # Patch telegram.ext before import to avoid bot init
+        import importlib
+        with patch("src.telegram_bot.chat_bot.auth_check", new_callable=AsyncMock, return_value=True):
+            from src.telegram_bot.chat_bot import cmd_update
+            return cmd_update
+
+    @pytest.mark.asyncio
+    async def test_target_defaults_to_peer(self, mock_update, mock_context_no_args):
+        """When no args, target defaults to the peer callsign."""
+        with patch("src.telegram_bot.chat_bot.auth_check", new_callable=AsyncMock, return_value=True), \
+             patch("src.telegram_bot.chat_bot.CALLSIGN", "elliot"), \
+             patch("src.telegram_bot.chat_bot.SUPABASE_URL", "https://test.supabase.co"), \
+             patch("src.telegram_bot.chat_bot.SUPABASE_HEADERS", {}), \
+             patch("src.telegram_bot.chat_bot.WORK_DIR", "/tmp"), \
+             patch("httpx.AsyncClient") as mock_client, \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+            client_instance = AsyncMock()
+            client_instance.get = AsyncMock(return_value=MagicMock(status_code=200, json=lambda: []))
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=client_instance)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            from src.telegram_bot.chat_bot import cmd_update
+            await cmd_update(mock_update, mock_context_no_args)
+
+            reply_text = mock_update.message.reply_text.call_args[0][0]
+            # Default peer for elliot is aiden
+            assert "→AIDEN" in reply_text
+            assert "TELEGRAM-ONLY" in reply_text
+
+    @pytest.mark.asyncio
+    async def test_protocol_first_in_output(self, mock_update, mock_context_aiden):
+        """Protocol checklist appears BEFORE state in the output."""
+        with patch("src.telegram_bot.chat_bot.auth_check", new_callable=AsyncMock, return_value=True), \
+             patch("src.telegram_bot.chat_bot.CALLSIGN", "elliot"), \
+             patch("src.telegram_bot.chat_bot.SUPABASE_URL", "https://test.supabase.co"), \
+             patch("src.telegram_bot.chat_bot.SUPABASE_HEADERS", {}), \
+             patch("src.telegram_bot.chat_bot.WORK_DIR", "/tmp"), \
+             patch("httpx.AsyncClient") as mock_client, \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="abc123 test commit", stderr="", returncode=0)
+            client_instance = AsyncMock()
+            client_instance.get = AsyncMock(return_value=MagicMock(status_code=200, json=lambda: []))
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=client_instance)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            from src.telegram_bot.chat_bot import cmd_update
+            await cmd_update(mock_update, mock_context_aiden)
+
+            reply_text = mock_update.message.reply_text.call_args[0][0]
+            protocol_pos = reply_text.find("PROTOCOL CHECKLIST")
+            state_pos = reply_text.find("CURRENT STATE")
+            # Protocol must come before state (-1 means not found, still valid if state missing)
+            assert protocol_pos >= 0, "Protocol checklist missing"
+            assert protocol_pos < state_pos or state_pos == -1
+
+    @pytest.mark.asyncio
+    async def test_auth_rejected(self, mock_update, mock_context_aiden):
+        """Unauthorized users get rejected."""
+        with patch("src.telegram_bot.chat_bot.auth_check", new_callable=AsyncMock, return_value=False):
+            from src.telegram_bot.chat_bot import cmd_update
+            await cmd_update(mock_update, mock_context_aiden)
+            # reply_text should NOT have been called (auth failed early)
+            mock_update.message.reply_text.assert_not_called()


### PR DESCRIPTION
## Summary
- /update command (Option B comprehensive) — protocol-first handoff for peer-bot session resume
- Enforcer Rule 2 amended: CEO merges, rebases, orchestrator acks exempt from Step 0
- Enforcer Rule 8 added: dispatch coordination enforcement (proposal + 20s concur)
- Dispatch Coordination Protocol added to shared governance
- Send pacer 2.2.7 added to deferred list
- 3 tests for cmd_update (target default, protocol-first ordering, auth rejection)

## Test plan
- [ ] `python3 -m pytest tests/telegram_bot/test_cmd_update.py -v`
- [ ] Restart telegram-chat-bot.service, type `/update aiden` in group, verify output
- [ ] Verify enforcer picks up Rule 2 exceptions + Rule 8 on restart

Generated with [Claude Code](https://claude.com/claude-code)