### PR TITLE
[ATLAS] TouchStore.apply() — wire reply mutations to Supabase

### DIFF
--- a/src/api/routes/outreach_webhooks.py
+++ b/src/api/routes/outreach_webhooks.py
@@ -21,18 +21,14 @@ hmac.compare_digest.
 """
 from __future__ import annotations
 
-import hashlib
-import hmac
 import logging
-import os
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from src.outreach.cadence.decision_tree import (
     CadenceDecisionTree,
-    TouchMutation,
-    apply_suppression,
+    TouchStore,
 )
 from src.outreach.reply_intent import classify_reply as llm_classify
 from src.pipeline.reply_router import classify_reply as keyword_classify
@@ -74,21 +70,35 @@ def _verify(secret_env: str, payload: bytes, signature: str | None) -> bool:
 # DB-facing shim — injectable for tests
 # ---------------------------------------------------------------------------
 
-class TouchStore:
-    """Interface the webhooks use to talk to scheduled_touches. Override in tests."""
+async def _default_db_conn() -> Any:
+    """Lazy asyncpg pool for the default TouchStore.
 
-    async def load_pending(self, lead_id: str) -> list[dict]:
-        return []
+    Returns None if the pool cannot be created (missing DSN / offline dev) —
+    TouchStore with db_conn=None falls back to the legacy-stub behaviour
+    (returns 0 applied), so the webhook still succeeds.
+    """
+    global _POOL
+    if _POOL is not None:
+        return _POOL
+    try:
+        import asyncpg  # local import keeps the route importable without asyncpg
 
-    async def apply(self, mutations: list[TouchMutation]) -> int:
-        return 0
+        from src.config.settings import settings
+        dsn = settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+        _POOL = await asyncpg.create_pool(dsn, min_size=1, max_size=5, statement_cache_size=0)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("outreach_webhooks: DB pool unavailable — %s", exc)
+        _POOL = None
+    return _POOL
 
 
-_default_store = TouchStore()
+_POOL: Any | None = None
 
 
-def get_touch_store() -> TouchStore:
-    return _default_store
+async def get_touch_store() -> TouchStore:
+    """FastAPI dependency — returns a TouchStore wired to the app's asyncpg pool."""
+    db = await _default_db_conn()
+    return TouchStore(db_conn=db)
 
 
 # ---------------------------------------------------------------------------
@@ -127,10 +137,14 @@ async def _process_reply(
     }
     mutations = CadenceDecisionTree().decide(intent, confidence, prospect_state, extracted)
 
-    # Execute suppression synchronously; other mutations go to the store.
+    # Propagate client_id + lead_id into mutation.extra so TouchStore inserts
+    # + suppression cascades have the tenancy/anchor they need.
     for m in mutations:
-        if m.action == "suppress":
-            apply_suppression(m)
+        m.extra.setdefault("client_id", client_id)
+        m.extra.setdefault("lead_id", lead_id)
+
+    # All mutations (including suppress write-through + cascade) go through
+    # TouchStore — no separate apply_suppression path here.
     applied = await store.apply(mutations)
 
     return {

--- a/src/outreach/cadence/decision_tree.py
+++ b/src/outreach/cadence/decision_tree.py
@@ -21,6 +21,7 @@ itself never calls the LLM — that's the webhook's job.
 """
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -274,3 +275,155 @@ def apply_suppression(mutation: TouchMutation) -> dict:
         channel=mutation.extra.get("channel", "all"),
         source=mutation.extra.get("source", "decision_tree"),
     )
+
+
+# ---------------------------------------------------------------------------
+# TouchStore — canonical DB-facing executor for TouchMutation lists.
+# Lives here (not in the webhook route) so Prefect flows + API handlers share
+# one implementation. Injectable db_conn so tests can mock the DB entirely.
+# ---------------------------------------------------------------------------
+
+class TouchStore:
+    """
+    Contract: src/outreach/cadence/decision_tree.py — TouchStore
+    Purpose:  Apply a list of TouchMutation to scheduled_touches + side-effects.
+    Layer:    services
+
+    Mutation → DB action map:
+        cancel     → UPDATE status='cancelled'
+        pause      → UPDATE status='paused'
+        reschedule → UPDATE scheduled_at=new_scheduled_at
+        insert     → INSERT status='pending'
+        suppress   → SuppressionManager.add_to_suppression + cancel all pending for lead
+        escalate   → log only (no DB write; queue TBD)
+        noop       → skipped
+
+    Backward compat: TouchStore() with no db_conn returns 0 applied (legacy stub).
+    """
+
+    def __init__(self, db_conn: Any | None = None) -> None:
+        self.db = db_conn
+
+    async def load_pending(self, lead_id: str) -> list[dict]:
+        if self.db is None:
+            return []
+        rows = await self.db.fetch(
+            """
+            SELECT id, channel, sequence_step, scheduled_at, status
+            FROM scheduled_touches
+            WHERE lead_id = $1 AND status IN ('pending', 'paused')
+            ORDER BY scheduled_at
+            """,
+            lead_id,
+        )
+        return [dict(r) for r in rows]
+
+    async def apply(self, mutations: list[TouchMutation]) -> int:
+        """Apply every mutation. Returns number of successfully-applied rows."""
+        if self.db is None:
+            return 0
+
+        applied = 0
+        for m in mutations:
+            try:
+                if await self._apply_one(m):
+                    applied += 1
+            except Exception as exc:
+                logger.exception("TouchStore.apply failed for %s: %s", m.action, exc)
+        return applied
+
+    async def _apply_one(self, m: TouchMutation) -> bool:
+        action = m.action
+        if action == "cancel":
+            return await self._status_update(m, "cancelled")
+        if action == "pause":
+            return await self._status_update(m, "paused")
+        if action == "reschedule":
+            return await self._reschedule(m)
+        if action == "insert":
+            return await self._insert(m)
+        if action == "suppress":
+            return await self._suppress(m)
+        if action == "escalate":
+            logger.info(
+                "TouchStore: escalate mutation — reason=%s extra=%s",
+                m.reason, m.extra,
+            )
+            return True
+        return False
+
+    # -- per-action helpers --------------------------------------------------
+
+    async def _status_update(self, m: TouchMutation, status: str) -> bool:
+        if not m.touch_id:
+            return False
+        await self.db.execute(
+            """
+            UPDATE scheduled_touches
+            SET status = $2,
+                skipped_reason = CASE WHEN $2 = 'paused' THEN $3 ELSE skipped_reason END,
+                failure_reason = CASE WHEN $2 = 'cancelled' THEN $3 ELSE failure_reason END,
+                updated_at = NOW()
+            WHERE id = $1
+            """,
+            m.touch_id, status, m.reason,
+        )
+        return True
+
+    async def _reschedule(self, m: TouchMutation) -> bool:
+        if not m.touch_id or not m.new_scheduled_at:
+            return False
+        await self.db.execute(
+            """
+            UPDATE scheduled_touches
+            SET scheduled_at = $2, updated_at = NOW()
+            WHERE id = $1
+            """,
+            m.touch_id, m.new_scheduled_at,
+        )
+        return True
+
+    async def _insert(self, m: TouchMutation) -> bool:
+        client_id = m.extra.get("client_id")
+        lead_id = m.extra.get("lead_id")
+        if not client_id or not lead_id or not m.channel:
+            logger.warning(
+                "TouchStore: insert missing client_id/lead_id/channel — extra=%s",
+                m.extra,
+            )
+            return False
+        scheduled_at = m.new_scheduled_at or datetime.now(UTC)
+        content = json.dumps(m.content or {})
+        prospect = json.dumps(m.extra.get("prospect") or {})
+        await self.db.execute(
+            """
+            INSERT INTO scheduled_touches (
+                client_id, lead_id, channel, sequence_step,
+                scheduled_at, status, content, prospect,
+                created_at, updated_at
+            ) VALUES (
+                $1, $2, $3, $4, $5, 'pending', $6::jsonb, $7::jsonb, NOW(), NOW()
+            )
+            """,
+            client_id, lead_id, m.channel,
+            m.sequence_step or 0, scheduled_at, content, prospect,
+        )
+        return True
+
+    async def _suppress(self, m: TouchMutation) -> bool:
+        # 1. Write-through to suppression list (best-effort, non-fatal).
+        result = apply_suppression(m)
+        # 2. Cascade: cancel every pending/paused touch for this lead.
+        lead_id = m.extra.get("lead_id")
+        if lead_id:
+            await self.db.execute(
+                """
+                UPDATE scheduled_touches
+                SET status = 'cancelled',
+                    failure_reason = 'suppressed',
+                    updated_at = NOW()
+                WHERE lead_id = $1 AND status IN ('pending', 'paused')
+                """,
+                lead_id,
+            )
+        return bool(result.get("success", True))

--- a/tests/api/test_outreach_webhooks.py
+++ b/tests/api/test_outreach_webhooks.py
@@ -103,8 +103,9 @@ def test_salesforge_fast_path_unsubscribe_applies_cancels_and_suppress(client, m
         "intent": "unsubscribe", "confidence": 0.95,
         "evidence_phrase": "unsubscribe", "extracted": {},
     })
-    with patch.object(outreach_webhooks, "apply_suppression") as apply_sup, \
-         patch.object(outreach_webhooks, "llm_classify", fake_llm):
+    # apply_suppression now lives inside TouchStore._suppress (decision_tree).
+    # The webhook no longer calls it directly — only store.apply() fires.
+    with patch.object(outreach_webhooks, "llm_classify", fake_llm):
         code, body = _post(
             client, "/webhooks/salesforge", "shh", "X-Salesforge-Signature",
             {"body": "please unsubscribe me, opt out, remove from list",
@@ -116,7 +117,6 @@ def test_salesforge_fast_path_unsubscribe_applies_cancels_and_suppress(client, m
     assert body["intent"] == "unsubscribe"
     assert body["mutations"] == 3  # two cancels + one suppress
     store.apply.assert_awaited_once()
-    apply_sup.assert_called_once()
 
 
 def test_fast_path_positive_hits_decision_tree(client, monkeypatch, store):

--- a/tests/outreach/cadence/test_touchstore.py
+++ b/tests/outreach/cadence/test_touchstore.py
@@ -1,0 +1,234 @@
+"""
+Tests for src/outreach/cadence/decision_tree.py — TouchStore executor.
+
+Zero paid API calls. Pure mocked asyncpg + stubbed SuppressionManager.
+
+Covers:
+- cancel                  → UPDATE status='cancelled'
+- pause                   → UPDATE status='paused'
+- reschedule              → UPDATE scheduled_at
+- insert                  → INSERT scheduled_touches
+- insert missing fields   → returns False, no INSERT fires
+- suppress                → add_to_suppression + cascade cancel all pending
+- escalate                → logged only, no DB write
+- noop                    → skipped
+- mixed list              → count matches successful applies
+- no-db fallback          → apply() returns 0 when db_conn=None (legacy stub)
+- per-mutation exception  → contained; successful ones still counted
+- load_pending            → SELECT with correct filter
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.outreach.cadence.decision_tree import TouchMutation, TouchStore
+
+
+def _db():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    db.fetch = AsyncMock(return_value=[])
+    return db
+
+
+# ---------- per-action coverage --------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cancel_updates_status_cancelled():
+    db = _db()
+    store = TouchStore(db_conn=db)
+    mutation = TouchMutation(action="cancel", touch_id="t1", reason="user rejected")
+    applied = await store.apply([mutation])
+    assert applied == 1
+    db.execute.assert_awaited_once()
+    sql, *args = db.execute.await_args.args
+    assert "UPDATE scheduled_touches" in sql
+    assert args[0] == "t1"
+    assert args[1] == "cancelled"
+    assert args[2] == "user rejected"
+
+
+@pytest.mark.asyncio
+async def test_pause_updates_status_paused():
+    db = _db()
+    store = TouchStore(db_conn=db)
+    applied = await store.apply(
+        [TouchMutation(action="pause", touch_id="t1", reason="question — 48h pause")],
+    )
+    assert applied == 1
+    sql, *args = db.execute.await_args.args
+    assert "UPDATE scheduled_touches" in sql
+    assert args[1] == "paused"
+
+
+@pytest.mark.asyncio
+async def test_reschedule_updates_scheduled_at():
+    db = _db()
+    store = TouchStore(db_conn=db)
+    when = datetime.now(UTC) + timedelta(days=5)
+    applied = await store.apply(
+        [TouchMutation(action="reschedule", touch_id="t1", new_scheduled_at=when)],
+    )
+    assert applied == 1
+    sql, *args = db.execute.await_args.args
+    assert "scheduled_at = $2" in sql
+    assert args[0] == "t1"
+    assert args[1] == when
+
+
+@pytest.mark.asyncio
+async def test_insert_writes_scheduled_touches_row():
+    db = _db()
+    store = TouchStore(db_conn=db)
+    mutation = TouchMutation(
+        action="insert",
+        channel="email",
+        sequence_step=2,
+        content={"subject": "Hi", "html_body": "<p>hey</p>"},
+        extra={
+            "client_id": "c1",
+            "lead_id": "l1",
+            "prospect": {"email": "amy@acme.com.au"},
+        },
+    )
+    applied = await store.apply([mutation])
+    assert applied == 1
+    sql, *args = db.execute.await_args.args
+    assert "INSERT INTO scheduled_touches" in sql
+    # client_id, lead_id, channel, sequence_step, scheduled_at, content, prospect
+    assert args[0] == "c1"
+    assert args[1] == "l1"
+    assert args[2] == "email"
+    assert args[3] == 2
+
+
+@pytest.mark.asyncio
+async def test_insert_skipped_when_client_or_lead_missing():
+    db = _db()
+    store = TouchStore(db_conn=db)
+    mutation = TouchMutation(
+        action="insert", channel="email",
+        extra={"lead_id": "l1"},  # no client_id
+    )
+    applied = await store.apply([mutation])
+    assert applied == 0
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_suppress_writes_suppression_and_cancels_pending():
+    db = _db()
+    store = TouchStore(db_conn=db)
+    mutation = TouchMutation(
+        action="suppress",
+        extra={
+            "lead_id": "l1",
+            "email": "amy@acme.com.au",
+            "suppression_reason": "unsubscribe",
+            "channel": "all",
+            "source": "decision_tree",
+        },
+    )
+    with patch(
+        "src.outreach.cadence.decision_tree.SuppressionManager.add_to_suppression",
+        return_value={"success": True, "email": "amy@acme.com.au"},
+    ) as mock_add:
+        applied = await store.apply([mutation])
+
+    assert applied == 1
+    mock_add.assert_called_once()
+    # Cascade UPDATE fires with lead_id filter
+    db.execute.assert_awaited_once()
+    sql, *args = db.execute.await_args.args
+    assert "status = 'cancelled'" in sql
+    assert "lead_id = $1" in sql
+    assert args[0] == "l1"
+
+
+@pytest.mark.asyncio
+async def test_escalate_logs_only_no_db_write():
+    db = _db()
+    store = TouchStore(db_conn=db)
+    applied = await store.apply(
+        [TouchMutation(action="escalate", reason="question", extra={"lead_id": "l1"})],
+    )
+    assert applied == 1
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_noop_is_skipped():
+    db = _db()
+    store = TouchStore(db_conn=db)
+    applied = await store.apply([TouchMutation(action="noop", reason="unclear")])
+    assert applied == 0
+    db.execute.assert_not_awaited()
+
+
+# ---------- aggregate behaviour --------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mixed_mutations_count_matches_applied():
+    db = _db()
+    store = TouchStore(db_conn=db)
+    when = datetime.now(UTC) + timedelta(days=3)
+    muts = [
+        TouchMutation(action="cancel", touch_id="t1"),
+        TouchMutation(action="pause", touch_id="t2"),
+        TouchMutation(action="reschedule", touch_id="t3", new_scheduled_at=when),
+        TouchMutation(action="escalate", extra={"lead_id": "l1"}),
+        TouchMutation(action="noop"),  # skipped
+    ]
+    applied = await store.apply(muts)
+    assert applied == 4
+    # 3 UPDATEs (cancel, pause, reschedule); escalate has no DB call; noop has no DB call
+    assert db.execute.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_no_db_fallback_returns_zero_applied():
+    store = TouchStore(db_conn=None)
+    applied = await store.apply(
+        [TouchMutation(action="cancel", touch_id="t1")],
+    )
+    assert applied == 0
+
+
+@pytest.mark.asyncio
+async def test_exception_in_one_mutation_does_not_block_others():
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[RuntimeError("boom"), None])
+    store = TouchStore(db_conn=db)
+    muts = [
+        TouchMutation(action="cancel", touch_id="t1"),
+        TouchMutation(action="cancel", touch_id="t2"),
+    ]
+    applied = await store.apply(muts)
+    assert applied == 1  # only the second succeeded
+    assert db.execute.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_load_pending_queries_only_pending_and_paused():
+    db = AsyncMock()
+    db.fetch = AsyncMock(return_value=[
+        {"id": "t1", "channel": "email", "sequence_step": 2,
+         "scheduled_at": datetime.now(UTC), "status": "pending"},
+    ])
+    store = TouchStore(db_conn=db)
+    rows = await store.load_pending("lead-1")
+    assert len(rows) == 1
+    sql, *args = db.fetch.await_args.args
+    assert "lead_id = $1" in sql
+    assert "status IN ('pending', 'paused')" in sql
+    assert args[0] == "lead-1"
+
+
+@pytest.mark.asyncio
+async def test_load_pending_empty_when_no_db():
+    store = TouchStore(db_conn=None)
+    rows = await store.load_pending("lead-1")
+    assert rows == []


### PR DESCRIPTION
## Summary
Unlocks end-to-end reply automation: the webhook decision tree already produced `TouchMutation` lists, but the executor was a stub that returned `0`. This PR replaces the stub with real writes against `scheduled_touches` + suppression-list cascade.

- **`TouchStore` relocated into `src/outreach/cadence/decision_tree.py`** (was in the webhook route file as a 10-line stub). Accepts an asyncpg-compatible `db_conn`; `None` falls back to the legacy zero-applied behaviour so the route stays importable without a DB.
- **Per-action SQL:**
  - `cancel` → UPDATE `status='cancelled'` + `failure_reason`
  - `pause` → UPDATE `status='paused'` + `skipped_reason`
  - `reschedule` → UPDATE `scheduled_at=$new_scheduled_at`
  - `insert` → INSERT `status='pending'` with `client_id / lead_id / channel / sequence_step / scheduled_at / content(jsonb) / prospect(jsonb)`
  - `suppress` → `SuppressionManager.add_to_suppression` write-through **plus** cascade UPDATE `status='cancelled'` on every pending/paused touch for that lead
  - `escalate` → log only (no DB write)
  - `noop` → skipped
- **Per-mutation exception containment**: a single failure does not abort the rest of the batch.
- **Webhook route** now imports `TouchStore` from `decision_tree`, wires `get_touch_store` to a lazy asyncpg pool, and propagates `client_id + lead_id` into every `mutation.extra` so inserts + cascades have the tenancy anchor.

## Test plan (zero paid API calls)
- [x] Rebased on current `origin/main`
- [x] `ruff check` — clean on all 4 touched files
- [x] `pytest` — **41 passed, 0 failed**
  - 13 new `test_touchstore.py` (every action, mixed list, no-db fallback, exception containment, load_pending)
  - 28 pre-existing `test_decision_tree` + `test_outreach_webhooks` (updated the old test that patched `apply_suppression` on the webhook module; that symbol is no longer imported there)
- [ ] Reviewer: verify no live DB call in the test suite — inspect `test_touchstore.py` for `AsyncMock` only
- [ ] Ops: `scheduled_touches` migration (`316_scheduled_touches.sql`) must be applied before this PR's writes run in any environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)