### PR TITLE
[ATLAS] feat(dashboard): Phase 2.1 — wire real BU data

### DIFF
--- a/frontend/hooks/use-dashboard-v4.ts
+++ b/frontend/hooks/use-dashboard-v4.ts
@@ -89,6 +89,10 @@ export interface DashboardV4Data {
   weekAhead: UpcomingMeeting[];
   insight: InsightData;
   warmReplies: WarmReply[];
+  // Phase-2.1 — wired to live business_universe data.
+  buStats: BUStats | null;
+  funnel: FunnelStage[];
+  activity: BUActivityEvent[];
 }
 
 // Backend response types
@@ -197,15 +201,59 @@ function formatMeetingDate(dateString: string | null): { dayLabel: string; dayNu
 }
 
 /**
- * Fetch hot leads (high ALS score with buying signals)
+ * Phase-2.1 — BU-direct shape returned by /api/v1/dashboard/bu-hot-leads.
+ */
+interface BUHotLeadResponse {
+  id: string;
+  domain: string;
+  company: string;
+  dm_name: string | null;
+  dm_title: string | null;
+  propensity_score: number;
+  pipeline_stage: number;
+  has_email: boolean;
+  has_mobile: boolean;
+}
+
+/**
+ * Fetch hot leads — Phase 2.1 wires this directly to business_universe via
+ * /api/v1/dashboard/bu-hot-leads (pipeline_stage >= 6 AND propensity > 70).
+ * Falls back to the legacy /api/v1/leads tier=hot endpoint if BU has no
+ * matching rows yet (e.g. dev DB where the pipeline hasn't run).
  */
 async function fetchHotLeads(clientId: string): Promise<HotProspect[]> {
+  // Primary: BU-direct
   try {
-    // Get hot tier leads sorted by score
+    const bu = await api.get<{ items: BUHotLeadResponse[] }>(
+      `/api/v1/dashboard/bu-hot-leads?limit=5&min_score=70&min_stage=6`,
+    );
+    if (bu.items.length > 0) {
+      return bu.items.map((row): HotProspect => {
+        const name = row.dm_name || row.company || row.domain || "Unknown";
+        const signals: string[] = [];
+        if (row.has_email) signals.push("Email verified");
+        if (row.has_mobile) signals.push("Mobile verified");
+        return {
+          id: row.id,
+          initials: getInitials(name),
+          name,
+          company: row.company,
+          title: row.dm_title || `Stage ${row.pipeline_stage}`,
+          signal: signals[0] || `Propensity ${row.propensity_score}`,
+          score: row.propensity_score,
+          isVeryHot: row.propensity_score >= 90,
+        };
+      });
+    }
+  } catch (error) {
+    console.warn("[fetchHotLeads] BU-direct failed, falling back to leads endpoint:", error);
+  }
+
+  // Fallback: legacy lead_pool tier=hot
+  try {
     const response = await api.get<{ items: HotLeadResponse[] }>(
       `/api/v1/leads?client_id=${clientId}&tier=hot&page_size=5&sort_by=propensity_score&sort_order=desc`
     );
-    
     return response.items.map((lead): HotProspect => {
       const name = [lead.first_name, lead.last_name].filter(Boolean).join(" ") || "Unknown";
       return {
@@ -221,6 +269,72 @@ async function fetchHotLeads(clientId: string): Promise<HotProspect[]> {
     });
   } catch (error) {
     console.error("[fetchHotLeads] Error:", error);
+    return [];
+  }
+}
+
+/**
+ * Phase-2.1 — BU stats strip (total businesses, with-email, with-mobile,
+ * total BDMs, enriched in last 24h).
+ */
+export interface BUStats {
+  total_businesses: number;
+  businesses_with_email: number;
+  businesses_with_mobile: number;
+  total_bdms: number;
+  enriched_last_24h: number;
+}
+
+async function fetchBUStats(): Promise<BUStats | null> {
+  try {
+    return await api.get<BUStats>(`/api/v1/dashboard/bu-stats`);
+  } catch (error) {
+    console.error("[fetchBUStats] Error:", error);
+    return null;
+  }
+}
+
+/**
+ * Phase-2.1 — Funnel distribution across pipeline_stage 1..11.
+ */
+export interface FunnelStage {
+  stage: number;
+  label: string;
+  count: number;
+}
+
+async function fetchBUFunnel(): Promise<FunnelStage[]> {
+  try {
+    const r = await api.get<{ stages: FunnelStage[]; total: number }>(
+      `/api/v1/dashboard/bu-funnel`,
+    );
+    return r.stages;
+  } catch (error) {
+    console.error("[fetchBUFunnel] Error:", error);
+    return [];
+  }
+}
+
+/**
+ * Phase-2.1 — Recent activity (enrichment + outreach).
+ */
+export interface BUActivityEvent {
+  id: string;
+  timestamp: string;
+  kind: "enrichment" | "outreach";
+  domain: string | null;
+  detail: string;
+  cost_usd: number | null;
+}
+
+async function fetchBUActivity(limit = 20): Promise<BUActivityEvent[]> {
+  try {
+    const r = await api.get<{ items: BUActivityEvent[] }>(
+      `/api/v1/dashboard/bu-activity?limit=${limit}`,
+    );
+    return r.items;
+  } catch (error) {
+    console.error("[fetchBUActivity] Error:", error);
     return [];
   }
 }
@@ -461,12 +575,18 @@ export function useDashboardV4() {
     queryFn: async (): Promise<DashboardV4Data> => {
       if (!clientId) throw new Error("No client ID");
 
-      // Fetch all data in parallel
-      const [metrics, hotLeads, meetings, warmReplies] = await Promise.all([
+      // Fetch all data in parallel — Phase-2.1 adds 3 BU-direct calls.
+      const [
+        metrics, hotLeads, meetings, warmReplies,
+        buStats, funnel, activity,
+      ] = await Promise.all([
         fetchDashboardV4Metrics(clientId),
         fetchHotLeads(clientId),
         fetchUpcomingMeetings(clientId),
         fetchWarmReplies(clientId),
+        fetchBUStats(),
+        fetchBUFunnel(),
+        fetchBUActivity(20),
       ]);
 
       // Calculate derived values
@@ -518,6 +638,10 @@ export function useDashboardV4() {
         weekAhead: meetings,
         insight: buildInsight(metrics),
         warmReplies,
+        // Phase-2.1 — live BU data.
+        buStats,
+        funnel,
+        activity,
       };
     },
     enabled: !!clientId,
@@ -551,5 +675,43 @@ export function useWarmReplies(limit = 5) {
     queryFn: () => fetchWarmReplies(clientId!),
     enabled: !!clientId,
     staleTime: 30 * 1000,
+  });
+}
+
+// ─── Phase-2.1 standalone hooks ────────────────────────────────────────────
+
+/** BU stats strip — total businesses, with-email, with-mobile, BDM, 24h. */
+export function useBUStats() {
+  const { clientId } = useClient();
+  return useQuery({
+    queryKey: ["bu-stats", clientId],
+    queryFn: () => fetchBUStats(),
+    enabled: !!clientId,
+    staleTime: 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
+  });
+}
+
+/** Funnel — pipeline_stage distribution across business_universe. */
+export function useBUFunnel() {
+  const { clientId } = useClient();
+  return useQuery({
+    queryKey: ["bu-funnel", clientId],
+    queryFn: () => fetchBUFunnel(),
+    enabled: !!clientId,
+    staleTime: 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
+  });
+}
+
+/** Recent activity — enrichment + outreach events merged & sorted. */
+export function useBUActivity(limit = 20) {
+  const { clientId } = useClient();
+  return useQuery({
+    queryKey: ["bu-activity", clientId, limit],
+    queryFn: () => fetchBUActivity(limit),
+    enabled: !!clientId,
+    staleTime: 30 * 1000,
+    refetchInterval: 60 * 1000,
   });
 }

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -397,6 +397,7 @@ async def root() -> dict[str, Any]:
 
 from src.api.routes.admin import router as admin_router
 from src.api.routes.cycles import router as cycles_router
+from src.api.routes.dashboard import router as dashboard_router
 from src.api.routes.tiers import router as tiers_router
 from src.api.routes.billing import router as billing_router
 from src.api.routes.campaign_generation import router as campaign_generation_router
@@ -427,6 +428,7 @@ app.include_router(webhooks_router, prefix="/api/v1/webhooks")
 app.include_router(webhooks_outbound_router, prefix="/api/v1/webhooks-outbound")
 app.include_router(reports_router, prefix="/api/v1")
 app.include_router(admin_router, prefix="/api/v1")
+app.include_router(dashboard_router, prefix="/api/v1")
 app.include_router(replies_router, prefix="/api/v1")
 app.include_router(meetings_router, prefix="/api/v1")
 # Phase 11: ICP Discovery / Onboarding

--- a/src/api/routes/dashboard.py
+++ b/src/api/routes/dashboard.py
@@ -7,11 +7,13 @@ PHASE:   PHASE-2.1-DASHBOARD-WIRING
 Reads directly from public.business_universe + public.cis_outreach_outcomes
 via raw SQL, scoped to the calling client's id (RLS-friendly). Pure read-only.
 
-Master Agency Desk v10 prototype was hard-coded; these endpoints replace
-that mock layer with live counts.
+Multi-tenant filtering: business_universe is shared inventory — every
+BU-touching endpoint joins through campaign_leads (which carries
+client_id) so a client only ever sees BU rows they have claimed.
 """
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -25,6 +27,8 @@ from src.api.dependencies import (
     get_current_client,
     get_db_session,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
@@ -84,15 +88,16 @@ class ActivityResponse(BaseModel):
 
 # Stage label map — ordered for UI funnel rendering.
 _STAGE_LABELS: dict[int, str] = {
-    1: "Discovered",
-    2: "SERP-verified",
-    3: "Identity-confirmed",
-    4: "Signal-bundled",
-    5: "Composite-scored",
-    6: "Historically-ranked",
-    7: "F3B-analysed",
-    8: "Contact-enriched",
-    9: "LinkedIn-confirmed",
+    0:  "Queued",
+    1:  "Discovered",
+    2:  "SERP-verified",
+    3:  "Identity-confirmed",
+    4:  "Signal-bundled",
+    5:  "Composite-scored",
+    6:  "Historically-ranked",
+    7:  "F3B-analysed",
+    8:  "Contact-enriched",
+    9:  "LinkedIn-confirmed",
     10: "VR-scored",
     11: "Card-ready",
 }
@@ -111,22 +116,48 @@ async def bu_hot_leads(
     db: AsyncSession = Depends(get_db_session),
 ) -> BUHotLeadsResponse:
     """Hot leads from business_universe — pipeline_stage >= min_stage AND
-    propensity_score > min_score, ordered by score desc."""
-    rows = (await db.execute(
+    propensity_score >= min_score, ordered by score desc.
+    Multi-tenant via JOIN on campaign_leads.client_id."""
+    page = (await db.execute(
         text("""
-            SELECT id, domain, display_name, dm_name, dm_title,
-                   COALESCE(propensity_score, 0) AS propensity_score,
-                   COALESCE(pipeline_stage, 0)   AS pipeline_stage,
-                   (dm_email IS NOT NULL)        AS has_email,
-                   ((dm_mobile IS NOT NULL) OR (dm_phone IS NOT NULL)) AS has_mobile
-            FROM business_universe
-            WHERE pipeline_stage >= :min_stage
-              AND COALESCE(propensity_score, 0) > :min_score
-            ORDER BY propensity_score DESC NULLS LAST
+            SELECT bu.id, bu.domain, bu.display_name, bu.dm_name, bu.dm_title,
+                   COALESCE(bu.propensity_score, 0) AS propensity_score,
+                   COALESCE(bu.pipeline_stage, 0)   AS pipeline_stage,
+                   (bu.dm_email IS NOT NULL)        AS has_email,
+                   ((bu.dm_mobile IS NOT NULL) OR (bu.dm_phone IS NOT NULL)) AS has_mobile
+            FROM business_universe bu
+            JOIN campaign_leads cl ON cl.business_universe_id = bu.id
+            WHERE cl.client_id = :client_id
+              AND bu.pipeline_stage >= :min_stage
+              AND COALESCE(bu.propensity_score, 0) >= :min_score
+            GROUP BY bu.id
+            ORDER BY MAX(COALESCE(bu.propensity_score, 0)) DESC
             LIMIT :limit
         """),
-        {"min_stage": min_stage, "min_score": min_score, "limit": limit},
+        {
+            "client_id": ctx.client_id,
+            "min_stage": min_stage,
+            "min_score": min_score,
+            "limit":     limit,
+        },
     )).mappings().all()
+
+    # Distinct count of qualifying BU rows for this client (not page size).
+    total = (await db.execute(
+        text("""
+            SELECT COUNT(DISTINCT bu.id) AS n
+            FROM business_universe bu
+            JOIN campaign_leads cl ON cl.business_universe_id = bu.id
+            WHERE cl.client_id = :client_id
+              AND bu.pipeline_stage >= :min_stage
+              AND COALESCE(bu.propensity_score, 0) >= :min_score
+        """),
+        {
+            "client_id": ctx.client_id,
+            "min_stage": min_stage,
+            "min_score": min_score,
+        },
+    )).scalar_one_or_none() or 0
 
     items = [
         BUHotLead(
@@ -140,9 +171,9 @@ async def bu_hot_leads(
             has_email=bool(r["has_email"]),
             has_mobile=bool(r["has_mobile"]),
         )
-        for r in rows
+        for r in page
     ]
-    return BUHotLeadsResponse(items=items, total=len(items))
+    return BUHotLeadsResponse(items=items, total=int(total))
 
 
 @router.get("/bu-stats", response_model=BUStats)
@@ -151,23 +182,38 @@ async def bu_stats(
     db: AsyncSession = Depends(get_db_session),
 ) -> BUStats:
     """Top-of-dashboard stats strip — total BU rows, with-email count,
-    with-mobile count, total BDMs, enriched-in-last-24h count."""
+    with-mobile count, total BDMs, enriched-in-last-24h count.
+    All BU counts JOIN campaign_leads.client_id; BDM count joins via
+    business_universe_id → campaign_leads."""
     cutoff = datetime.now(UTC) - timedelta(hours=24)
     row = (await db.execute(
         text("""
             SELECT
-                COUNT(*)                                              AS total_businesses,
-                COUNT(*) FILTER (WHERE dm_email IS NOT NULL)          AS with_email,
-                COUNT(*) FILTER (WHERE dm_mobile IS NOT NULL
-                                 OR dm_phone IS NOT NULL)             AS with_mobile,
-                COUNT(*) FILTER (WHERE last_enriched_at >= :cutoff)   AS enriched_24h
-            FROM business_universe
+              COUNT(DISTINCT bu.id) AS total_businesses,
+              COUNT(DISTINCT bu.id) FILTER (WHERE bu.dm_email IS NOT NULL)
+                                             AS with_email,
+              COUNT(DISTINCT bu.id) FILTER (WHERE bu.dm_mobile IS NOT NULL
+                                             OR bu.dm_phone IS NOT NULL)
+                                             AS with_mobile,
+              COUNT(DISTINCT bu.id) FILTER (WHERE bu.last_enriched_at >= :cutoff)
+                                             AS enriched_24h
+            FROM business_universe bu
+            JOIN campaign_leads cl ON cl.business_universe_id = bu.id
+            WHERE cl.client_id = :client_id
         """),
-        {"cutoff": cutoff},
+        {"client_id": ctx.client_id, "cutoff": cutoff},
     )).mappings().first()
 
     bdm_total = (await db.execute(
-        text("SELECT COUNT(*) AS n FROM business_decision_makers WHERE is_current = TRUE"),
+        text("""
+            SELECT COUNT(DISTINCT bdm.id) AS n
+            FROM business_decision_makers bdm
+            JOIN campaign_leads cl
+              ON cl.business_universe_id = bdm.business_universe_id
+            WHERE cl.client_id = :client_id
+              AND bdm.is_current = TRUE
+        """),
+        {"client_id": ctx.client_id},
     )).scalar_one_or_none() or 0
 
     return BUStats(
@@ -185,13 +231,18 @@ async def bu_funnel(
     db: AsyncSession = Depends(get_db_session),
 ) -> FunnelResponse:
     """Pipeline-stage distribution across business_universe.
-    Returns one row per stage 1..11 with the stage label and live count."""
+    Returns one row per stage 0..11 with the stage label and live count.
+    Multi-tenant via JOIN on campaign_leads.client_id."""
     rows = (await db.execute(
         text("""
-            SELECT COALESCE(pipeline_stage, 0) AS stage, COUNT(*) AS n
-            FROM business_universe
-            GROUP BY pipeline_stage
+            SELECT COALESCE(bu.pipeline_stage, 0) AS stage,
+                   COUNT(DISTINCT bu.id)          AS n
+            FROM business_universe bu
+            JOIN campaign_leads cl ON cl.business_universe_id = bu.id
+            WHERE cl.client_id = :client_id
+            GROUP BY bu.pipeline_stage
         """),
+        {"client_id": ctx.client_id},
     )).mappings().all()
     counts: dict[int, int] = {int(r["stage"]): int(r["n"]) for r in rows}
 
@@ -210,32 +261,43 @@ async def bu_activity(
 ) -> ActivityResponse:
     """Combined recent activity — most-recent enrichment events from BU
     plus most-recent outreach events from cis_outreach_outcomes, merged
-    and ordered by timestamp desc."""
+    and ordered by timestamp desc.
+    Both sources scoped to ctx.client_id."""
     enrich_rows = (await db.execute(
         text("""
-            SELECT id, domain, display_name, last_enriched_at,
-                   pipeline_stage, enrichment_cost_usd
-            FROM business_universe
-            WHERE last_enriched_at IS NOT NULL
-            ORDER BY last_enriched_at DESC
+            SELECT bu.id, bu.domain, bu.display_name, bu.last_enriched_at,
+                   bu.pipeline_stage, bu.enrichment_cost_usd
+            FROM business_universe bu
+            JOIN campaign_leads cl ON cl.business_universe_id = bu.id
+            WHERE cl.client_id = :client_id
+              AND bu.last_enriched_at IS NOT NULL
+            GROUP BY bu.id
+            ORDER BY MAX(bu.last_enriched_at) DESC
             LIMIT :limit
         """),
-        {"limit": limit},
+        {"client_id": ctx.client_id, "limit": limit},
     )).mappings().all()
 
     outreach_rows: list[Any] = []
     try:
         outreach_rows = (await db.execute(
             text("""
-                SELECT id, channel, sent_at, final_outcome
-                FROM cis_outreach_outcomes
-                WHERE client_id = :cid
-                ORDER BY sent_at DESC
+                SELECT o.id, o.channel, o.sent_at, o.final_outcome,
+                       bu.domain
+                FROM cis_outreach_outcomes o
+                LEFT JOIN leads l    ON l.id  = o.lead_id
+                LEFT JOIN business_universe bu
+                       ON bu.id = l.business_universe_id
+                WHERE o.client_id = :client_id
+                ORDER BY o.sent_at DESC
                 LIMIT :limit
             """),
-            {"cid": ctx.client_id, "limit": limit},
+            {"client_id": ctx.client_id, "limit": limit},
         )).mappings().all()
-    except Exception:  # noqa: BLE001 — outreach table may not exist in dev
+    except Exception as exc:  # noqa: BLE001 — table may not exist in dev
+        logger.error(
+            "bu_activity: outreach query failed (table missing in dev?): %s", exc,
+        )
         outreach_rows = []
 
     items: list[ActivityEvent] = []
@@ -253,7 +315,7 @@ async def bu_activity(
             id=f"out-{r['id']}",
             timestamp=(r["sent_at"] or datetime.now(UTC)).isoformat(),
             kind="outreach",
-            domain=None,
+            domain=r.get("domain"),
             detail=f"{r['channel']} sent — outcome={r['final_outcome'] or 'pending'}",
             cost_usd=None,
         ))

--- a/src/api/routes/dashboard.py
+++ b/src/api/routes/dashboard.py
@@ -1,0 +1,262 @@
+"""
+FILE: src/api/routes/dashboard.py
+PURPOSE: Phase-2.1 Dashboard endpoints — BU-direct hot leads, stats strip,
+         funnel distribution, activity feed.
+PHASE:   PHASE-2.1-DASHBOARD-WIRING
+
+Reads directly from public.business_universe + public.cis_outreach_outcomes
+via raw SQL, scoped to the calling client's id (RLS-friendly). Pure read-only.
+
+Master Agency Desk v10 prototype was hard-coded; these endpoints replace
+that mock layer with live counts.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.dependencies import (
+    ClientContext,
+    get_current_client,
+    get_db_session,
+)
+
+router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Schemas
+# ─────────────────────────────────────────────────────────────────────────────
+
+class BUHotLead(BaseModel):
+    id: str
+    domain: str
+    company: str
+    dm_name: str | None = None
+    dm_title: str | None = None
+    propensity_score: int = Field(default=0)
+    pipeline_stage: int = Field(default=0)
+    has_email: bool = False
+    has_mobile: bool = False
+
+
+class BUHotLeadsResponse(BaseModel):
+    items: list[BUHotLead]
+    total: int
+
+
+class BUStats(BaseModel):
+    total_businesses: int
+    businesses_with_email: int
+    businesses_with_mobile: int
+    total_bdms: int
+    enriched_last_24h: int
+
+
+class FunnelStage(BaseModel):
+    stage: int
+    label: str
+    count: int
+
+
+class FunnelResponse(BaseModel):
+    stages: list[FunnelStage]
+    total: int
+
+
+class ActivityEvent(BaseModel):
+    id: str
+    timestamp: str
+    kind: str  # 'enrichment' | 'outreach'
+    domain: str | None = None
+    detail: str
+    cost_usd: float | None = None
+
+
+class ActivityResponse(BaseModel):
+    items: list[ActivityEvent]
+
+
+# Stage label map — ordered for UI funnel rendering.
+_STAGE_LABELS: dict[int, str] = {
+    1: "Discovered",
+    2: "SERP-verified",
+    3: "Identity-confirmed",
+    4: "Signal-bundled",
+    5: "Composite-scored",
+    6: "Historically-ranked",
+    7: "F3B-analysed",
+    8: "Contact-enriched",
+    9: "LinkedIn-confirmed",
+    10: "VR-scored",
+    11: "Card-ready",
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoints
+# ─────────────────────────────────────────────────────────────────────────────
+
+@router.get("/bu-hot-leads", response_model=BUHotLeadsResponse)
+async def bu_hot_leads(
+    limit: int = Query(default=10, ge=1, le=50),
+    min_score: int = Query(default=70, ge=0, le=100),
+    min_stage: int = Query(default=6, ge=1, le=11),
+    ctx: ClientContext = Depends(get_current_client),
+    db: AsyncSession = Depends(get_db_session),
+) -> BUHotLeadsResponse:
+    """Hot leads from business_universe — pipeline_stage >= min_stage AND
+    propensity_score > min_score, ordered by score desc."""
+    rows = (await db.execute(
+        text("""
+            SELECT id, domain, display_name, dm_name, dm_title,
+                   COALESCE(propensity_score, 0) AS propensity_score,
+                   COALESCE(pipeline_stage, 0)   AS pipeline_stage,
+                   (dm_email IS NOT NULL)        AS has_email,
+                   ((dm_mobile IS NOT NULL) OR (dm_phone IS NOT NULL)) AS has_mobile
+            FROM business_universe
+            WHERE pipeline_stage >= :min_stage
+              AND COALESCE(propensity_score, 0) > :min_score
+            ORDER BY propensity_score DESC NULLS LAST
+            LIMIT :limit
+        """),
+        {"min_stage": min_stage, "min_score": min_score, "limit": limit},
+    )).mappings().all()
+
+    items = [
+        BUHotLead(
+            id=str(r["id"]),
+            domain=r["domain"] or "",
+            company=r["display_name"] or r["domain"] or "Unknown",
+            dm_name=r["dm_name"],
+            dm_title=r["dm_title"],
+            propensity_score=int(r["propensity_score"] or 0),
+            pipeline_stage=int(r["pipeline_stage"] or 0),
+            has_email=bool(r["has_email"]),
+            has_mobile=bool(r["has_mobile"]),
+        )
+        for r in rows
+    ]
+    return BUHotLeadsResponse(items=items, total=len(items))
+
+
+@router.get("/bu-stats", response_model=BUStats)
+async def bu_stats(
+    ctx: ClientContext = Depends(get_current_client),
+    db: AsyncSession = Depends(get_db_session),
+) -> BUStats:
+    """Top-of-dashboard stats strip — total BU rows, with-email count,
+    with-mobile count, total BDMs, enriched-in-last-24h count."""
+    cutoff = datetime.now(UTC) - timedelta(hours=24)
+    row = (await db.execute(
+        text("""
+            SELECT
+                COUNT(*)                                              AS total_businesses,
+                COUNT(*) FILTER (WHERE dm_email IS NOT NULL)          AS with_email,
+                COUNT(*) FILTER (WHERE dm_mobile IS NOT NULL
+                                 OR dm_phone IS NOT NULL)             AS with_mobile,
+                COUNT(*) FILTER (WHERE last_enriched_at >= :cutoff)   AS enriched_24h
+            FROM business_universe
+        """),
+        {"cutoff": cutoff},
+    )).mappings().first()
+
+    bdm_total = (await db.execute(
+        text("SELECT COUNT(*) AS n FROM business_decision_makers WHERE is_current = TRUE"),
+    )).scalar_one_or_none() or 0
+
+    return BUStats(
+        total_businesses=int((row or {}).get("total_businesses", 0)),
+        businesses_with_email=int((row or {}).get("with_email", 0)),
+        businesses_with_mobile=int((row or {}).get("with_mobile", 0)),
+        total_bdms=int(bdm_total),
+        enriched_last_24h=int((row or {}).get("enriched_24h", 0)),
+    )
+
+
+@router.get("/bu-funnel", response_model=FunnelResponse)
+async def bu_funnel(
+    ctx: ClientContext = Depends(get_current_client),
+    db: AsyncSession = Depends(get_db_session),
+) -> FunnelResponse:
+    """Pipeline-stage distribution across business_universe.
+    Returns one row per stage 1..11 with the stage label and live count."""
+    rows = (await db.execute(
+        text("""
+            SELECT COALESCE(pipeline_stage, 0) AS stage, COUNT(*) AS n
+            FROM business_universe
+            GROUP BY pipeline_stage
+        """),
+    )).mappings().all()
+    counts: dict[int, int] = {int(r["stage"]): int(r["n"]) for r in rows}
+
+    stages = [
+        FunnelStage(stage=s, label=_STAGE_LABELS[s], count=counts.get(s, 0))
+        for s in sorted(_STAGE_LABELS.keys())
+    ]
+    return FunnelResponse(stages=stages, total=sum(c.count for c in stages))
+
+
+@router.get("/bu-activity", response_model=ActivityResponse)
+async def bu_activity(
+    limit: int = Query(default=20, ge=1, le=100),
+    ctx: ClientContext = Depends(get_current_client),
+    db: AsyncSession = Depends(get_db_session),
+) -> ActivityResponse:
+    """Combined recent activity — most-recent enrichment events from BU
+    plus most-recent outreach events from cis_outreach_outcomes, merged
+    and ordered by timestamp desc."""
+    enrich_rows = (await db.execute(
+        text("""
+            SELECT id, domain, display_name, last_enriched_at,
+                   pipeline_stage, enrichment_cost_usd
+            FROM business_universe
+            WHERE last_enriched_at IS NOT NULL
+            ORDER BY last_enriched_at DESC
+            LIMIT :limit
+        """),
+        {"limit": limit},
+    )).mappings().all()
+
+    outreach_rows: list[Any] = []
+    try:
+        outreach_rows = (await db.execute(
+            text("""
+                SELECT id, channel, sent_at, final_outcome
+                FROM cis_outreach_outcomes
+                WHERE client_id = :cid
+                ORDER BY sent_at DESC
+                LIMIT :limit
+            """),
+            {"cid": ctx.client_id, "limit": limit},
+        )).mappings().all()
+    except Exception:  # noqa: BLE001 — outreach table may not exist in dev
+        outreach_rows = []
+
+    items: list[ActivityEvent] = []
+    for r in enrich_rows:
+        items.append(ActivityEvent(
+            id=f"enr-{r['id']}",
+            timestamp=(r["last_enriched_at"] or datetime.now(UTC)).isoformat(),
+            kind="enrichment",
+            domain=r["domain"],
+            detail=f"{r['display_name'] or r['domain']} → stage {r['pipeline_stage'] or 0}",
+            cost_usd=float(r["enrichment_cost_usd"]) if r["enrichment_cost_usd"] is not None else None,
+        ))
+    for r in outreach_rows:
+        items.append(ActivityEvent(
+            id=f"out-{r['id']}",
+            timestamp=(r["sent_at"] or datetime.now(UTC)).isoformat(),
+            kind="outreach",
+            domain=None,
+            detail=f"{r['channel']} sent — outcome={r['final_outcome'] or 'pending'}",
+            cost_usd=None,
+        ))
+
+    items.sort(key=lambda e: e.timestamp, reverse=True)
+    return ActivityResponse(items=items[:limit])

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -1,0 +1,224 @@
+"""
+Happy-path smoke tests for src/api/routes/dashboard.py.
+
+Mocks the AsyncSession + ClientContext deps so we can exercise the route
+wiring + response shape WITHOUT hitting Supabase. Each test confirms:
+  - 200 response
+  - response_model shape parses
+  - SQL passes ctx.client_id (multi-tenant filter is wired)
+
+Zero paid API calls, zero real DB.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.dependencies import get_current_client, get_db_session
+from src.api.routes.dashboard import router
+
+CLIENT_ID = uuid4()
+
+
+def _client_ctx() -> SimpleNamespace:
+    """Stand-in ClientContext — only client_id is touched by the routes."""
+    return SimpleNamespace(client_id=CLIENT_ID)
+
+
+def _result_with_rows(mappings_rows: list[dict]) -> MagicMock:
+    """Build a SQLAlchemy-style Result whose .mappings().all() returns rows."""
+    res = MagicMock()
+    res.mappings.return_value.all.return_value = mappings_rows
+    res.mappings.return_value.first.return_value = mappings_rows[0] if mappings_rows else {}
+    res.scalar_one_or_none.return_value = (
+        mappings_rows[0]["n"] if mappings_rows and "n" in mappings_rows[0] else 0
+    )
+    return res
+
+
+def _make_app(execute_side_effect):
+    """FastAPI app with overridden dependencies + scripted db.execute outputs."""
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=execute_side_effect)
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_client] = _client_ctx
+    app.dependency_overrides[get_db_session] = lambda: db
+    return app, db
+
+
+# ─── /bu-hot-leads ──────────────────────────────────────────────────────────
+
+def test_bu_hot_leads_happy_path():
+    page_rows = [
+        {
+            "id": uuid4(), "domain": "acme.com.au", "display_name": "Acme",
+            "dm_name": "Amy Boss", "dm_title": "CEO",
+            "propensity_score": 88, "pipeline_stage": 7,
+            "has_email": True, "has_mobile": False,
+        },
+    ]
+    total_row = [{"n": 42}]
+    execute_returns = iter([
+        _result_with_rows(page_rows),
+        _result_with_rows(total_row),
+    ])
+
+    async def side_effect(_sql, _params=None):
+        return next(execute_returns)
+
+    app, db = _make_app(side_effect)
+    res = TestClient(app).get("/dashboard/bu-hot-leads")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 42
+    assert body["items"][0]["company"] == "Acme"
+    assert body["items"][0]["has_email"] is True
+
+    # Multi-tenant gate: every SQL call passed ctx.client_id.
+    for call in db.execute.await_args_list:
+        params = call.args[1] if len(call.args) > 1 else {}
+        assert params.get("client_id") == CLIENT_ID, "missing client_id in params"
+
+
+# ─── /bu-stats ──────────────────────────────────────────────────────────────
+
+def test_bu_stats_happy_path():
+    stats_row = [{
+        "total_businesses": 100,
+        "with_email": 60,
+        "with_mobile": 25,
+        "enriched_24h": 12,
+    }]
+    bdm_row = [{"n": 73}]
+    execute_returns = iter([
+        _result_with_rows(stats_row),
+        _result_with_rows(bdm_row),
+    ])
+
+    async def side_effect(_sql, _params=None):
+        return next(execute_returns)
+
+    app, db = _make_app(side_effect)
+    res = TestClient(app).get("/dashboard/bu-stats")
+    assert res.status_code == 200
+    body = res.json()
+    assert body == {
+        "total_businesses":      100,
+        "businesses_with_email": 60,
+        "businesses_with_mobile": 25,
+        "total_bdms":            73,
+        "enriched_last_24h":     12,
+    }
+    for call in db.execute.await_args_list:
+        params = call.args[1] if len(call.args) > 1 else {}
+        assert params.get("client_id") == CLIENT_ID
+
+
+# ─── /bu-funnel ─────────────────────────────────────────────────────────────
+
+def test_bu_funnel_returns_all_12_stages():
+    funnel_row = [
+        {"stage": 1, "n": 50},
+        {"stage": 6, "n": 12},
+        {"stage": 11, "n": 4},
+    ]
+    execute_returns = iter([_result_with_rows(funnel_row)])
+
+    async def side_effect(_sql, _params=None):
+        return next(execute_returns)
+
+    app, db = _make_app(side_effect)
+    res = TestClient(app).get("/dashboard/bu-funnel")
+    assert res.status_code == 200
+    body = res.json()
+    # 12 stages (0..11) — quality fix A added stage 0 'Queued'.
+    assert len(body["stages"]) == 12
+    by_stage = {s["stage"]: s for s in body["stages"]}
+    assert by_stage[0]["label"] == "Queued"
+    assert by_stage[1]["count"] == 50
+    assert by_stage[6]["count"] == 12
+    assert by_stage[11]["count"] == 4
+    assert body["total"] == 66
+
+    params = db.execute.await_args.args[1]
+    assert params.get("client_id") == CLIENT_ID
+
+
+# ─── /bu-activity ───────────────────────────────────────────────────────────
+
+def test_bu_activity_merges_enrichment_and_outreach():
+    enrich_rows = [
+        {
+            "id": uuid4(), "domain": "acme.com.au", "display_name": "Acme",
+            "last_enriched_at": datetime(2026, 4, 25, 12, 0, tzinfo=UTC),
+            "pipeline_stage": 7, "enrichment_cost_usd": 0.18,
+        },
+    ]
+    outreach_rows = [
+        {
+            "id": uuid4(), "channel": "email",
+            "sent_at": datetime(2026, 4, 25, 13, 0, tzinfo=UTC),
+            "final_outcome": "delivered",
+            "domain": "beta.com.au",  # quality fix D: domain joined in
+        },
+    ]
+    execute_returns = iter([
+        _result_with_rows(enrich_rows),
+        _result_with_rows(outreach_rows),
+    ])
+
+    async def side_effect(_sql, _params=None):
+        return next(execute_returns)
+
+    app, db = _make_app(side_effect)
+    res = TestClient(app).get("/dashboard/bu-activity?limit=10")
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["items"]) == 2
+    # Outreach is later → first after desc sort.
+    assert body["items"][0]["kind"] == "outreach"
+    assert body["items"][0]["domain"] == "beta.com.au"  # quality fix D
+    assert body["items"][1]["kind"] == "enrichment"
+    assert body["items"][1]["domain"] == "acme.com.au"
+
+    for call in db.execute.await_args_list:
+        params = call.args[1] if len(call.args) > 1 else {}
+        assert params.get("client_id") == CLIENT_ID
+
+
+def test_bu_activity_handles_outreach_table_missing():
+    """When cis_outreach_outcomes raises (e.g. dev DB), endpoint still
+    returns enrichment rows — quality fix C ensures the error is logged."""
+    enrich_rows = [
+        {
+            "id": uuid4(), "domain": "acme.com.au", "display_name": "Acme",
+            "last_enriched_at": datetime(2026, 4, 25, tzinfo=UTC),
+            "pipeline_stage": 5, "enrichment_cost_usd": None,
+        },
+    ]
+
+    @pytest.fixture()
+    def _unused():  # noqa: ARG001
+        ...
+
+    call_count = {"i": 0}
+
+    async def side_effect(_sql, _params=None):
+        call_count["i"] += 1
+        if call_count["i"] == 1:
+            return _result_with_rows(enrich_rows)
+        raise RuntimeError("relation cis_outreach_outcomes does not exist")
+
+    app, _db = _make_app(side_effect)
+    res = TestClient(app).get("/dashboard/bu-activity")
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["items"]) == 1
+    assert body["items"][0]["kind"] == "enrichment"

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -222,3 +222,147 @@ def test_bu_activity_handles_outreach_table_missing():
     body = res.json()
     assert len(body["items"]) == 1
     assert body["items"][0]["kind"] == "enrichment"
+
+
+# ─── Cross-tenant negative test ─────────────────────────────────────────────
+#
+# Per-client BU "tables" — each row is owned by exactly one client. The mock
+# db.execute filters by params["client_id"] before returning rows, mirroring
+# the JOIN cl.client_id = :client_id behaviour the real SQL relies on.
+
+CLIENT_A = uuid4()
+CLIENT_B = uuid4()
+
+_BU_BY_CLIENT: dict = {
+    CLIENT_A: [
+        {  # Acme — owned by client A
+            "id": uuid4(), "domain": "acme-clienta.com.au", "display_name": "Acme A",
+            "dm_name": "Amy A", "dm_title": "CEO A",
+            "propensity_score": 95, "pipeline_stage": 8,
+            "has_email": True, "has_mobile": True,
+            "last_enriched_at": datetime(2026, 4, 25, 10, 0, tzinfo=UTC),
+            "enrichment_cost_usd": 0.22,
+        },
+    ],
+    CLIENT_B: [
+        {  # Beta — owned by client B
+            "id": uuid4(), "domain": "beta-clientb.com.au", "display_name": "Beta B",
+            "dm_name": "Bob B", "dm_title": "Founder B",
+            "propensity_score": 80, "pipeline_stage": 7,
+            "has_email": True, "has_mobile": False,
+            "last_enriched_at": datetime(2026, 4, 25, 11, 0, tzinfo=UTC),
+            "enrichment_cost_usd": 0.18,
+        },
+    ],
+}
+
+
+def _tenant_filtered_execute_factory(endpoint: str):
+    """Return an execute side-effect closure that simulates the per-client
+    BU rowstore + answers each route's specific result-shape contract."""
+    call_idx = {"i": 0}
+
+    async def side_effect(_sql, params=None):
+        params = params or {}
+        cid = params.get("client_id")
+        rows = list(_BU_BY_CLIENT.get(cid, []))
+        call_idx["i"] += 1
+
+        if endpoint == "bu-hot-leads":
+            # Call 1 = page rows (filtered by stage/score), Call 2 = total
+            if call_idx["i"] == 1:
+                ms, sc = params["min_stage"], params["min_score"]
+                page = [r for r in rows
+                        if r["pipeline_stage"] >= ms and r["propensity_score"] >= sc]
+                return _result_with_rows(page)
+            return _result_with_rows([{"n": len(rows)}])
+
+        if endpoint == "bu-stats":
+            # Call 1 = aggregate row, Call 2 = BDM count
+            if call_idx["i"] == 1:
+                return _result_with_rows([{
+                    "total_businesses": len(rows),
+                    "with_email":       sum(1 for r in rows if r["has_email"]),
+                    "with_mobile":      sum(1 for r in rows if r["has_mobile"]),
+                    "enriched_24h":     len(rows),
+                }])
+            return _result_with_rows([{"n": len(rows)}])
+
+        if endpoint == "bu-funnel":
+            stage_counts: dict[int, int] = {}
+            for r in rows:
+                stage_counts[r["pipeline_stage"]] = stage_counts.get(r["pipeline_stage"], 0) + 1
+            return _result_with_rows(
+                [{"stage": s, "n": n} for s, n in stage_counts.items()],
+            )
+
+        if endpoint == "bu-activity":
+            # Call 1 = enrichment rows, Call 2 = outreach (none for either)
+            if call_idx["i"] == 1:
+                return _result_with_rows(rows)
+            return _result_with_rows([])
+
+        return _result_with_rows([])
+
+    return side_effect
+
+
+@pytest.mark.parametrize("endpoint,client_a_marker", [
+    ("bu-hot-leads", "acme-clienta.com.au"),
+    ("bu-stats",     None),  # stats are aggregate; check via row count vs A's data
+    ("bu-funnel",    None),  # ditto — funnel is aggregate
+    ("bu-activity",  "acme-clienta.com.au"),
+])
+def test_bu_endpoints_do_not_leak_other_client_data(endpoint, client_a_marker):
+    """Request each BU endpoint as CLIENT_B and confirm CLIENT_A's data
+    never appears. Aggregate endpoints (stats, funnel) are checked by
+    asserting B's totals match B's row count, not A's row count."""
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_client] = (
+        lambda: SimpleNamespace(client_id=CLIENT_B)
+    )
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=_tenant_filtered_execute_factory(endpoint))
+    app.dependency_overrides[get_db_session] = lambda: db
+
+    res = TestClient(app).get(f"/dashboard/{endpoint}")
+    assert res.status_code == 200
+    body = res.json()
+
+    # ── Multi-tenant gate — every SQL call passed CLIENT_B's id, never A's
+    for call in db.execute.await_args_list:
+        params = call.args[1] if len(call.args) > 1 else {}
+        assert params.get("client_id") == CLIENT_B
+        assert params.get("client_id") != CLIENT_A
+
+    # ── Body inspection — CLIENT_A markers never appear
+    body_str = repr(body)
+    for a_row in _BU_BY_CLIENT[CLIENT_A]:
+        assert str(a_row["id"]) not in body_str, f"CLIENT_A id leaked into {endpoint}"
+        assert a_row["domain"] not in body_str, f"CLIENT_A domain leaked into {endpoint}"
+        assert a_row["display_name"] not in body_str, f"CLIENT_A name leaked into {endpoint}"
+        if a_row.get("dm_name"):
+            assert a_row["dm_name"] not in body_str, f"CLIENT_A DM leaked into {endpoint}"
+
+    # ── Endpoint-specific positive assertions: B's row IS present
+    b_row = _BU_BY_CLIENT[CLIENT_B][0]
+    if endpoint == "bu-hot-leads":
+        assert any(it["domain"] == b_row["domain"] for it in body["items"])
+        assert body["total"] == 1  # only B has 1 row
+    elif endpoint == "bu-stats":
+        # Aggregate counts reflect B's single row only (not A's row).
+        assert body["total_businesses"] == 1
+        assert body["businesses_with_email"] == 1
+        assert body["businesses_with_mobile"] == 0   # B's row has has_mobile=False
+        assert body["total_bdms"] == 1
+    elif endpoint == "bu-funnel":
+        # Funnel sees only B's stage-7 row.
+        by_stage = {s["stage"]: s for s in body["stages"]}
+        assert by_stage[7]["count"] == 1
+        assert by_stage[8]["count"] == 0  # A's stage-8 row not visible
+        assert body["total"] == 1
+    elif endpoint == "bu-activity":
+        domains = [it.get("domain") for it in body["items"]]
+        assert b_row["domain"] in domains


### PR DESCRIPTION
## Summary
- Wire Master Agency Desk v10 dashboard to real BU data
- Replace mock data with live Supabase queries
- Real business counts, email/mobile/BDM stats from business_universe

## Test plan
- [x] ATLAS clone built and pushed
- [x] Both agents reviewed branch
- [ ] Frontend visual verification (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)