### PR TITLE
[ORION] feat(bu-closed-loop): S1 instrumentation writes — filter_reason + stage_completed_at + abn_match sweep

### DIFF
--- a/scripts/abn_match_sweep.py
+++ b/scripts/abn_match_sweep.py
@@ -1,0 +1,255 @@
+"""
+ABN Match Sweep — back-fill abn / abn_matched / abn_status_code / abr_last_updated
+on business_universe rows that were never matched against the local abn_registry.
+
+DIRECTIVE: BU Closed-Loop Engine — Substep 1 of 4 (instrumentation writes).
+COST: AUD 0. Pure local SQL via asyncpg. Zero external API calls.
+SAFETY: Only updates rows where fuzzy-match confidence >= MIN_CONFIDENCE.
+
+Column mapping (dispatch named -> existing BU column, since the dispatch
+forbids new schema migrations):
+  dispatch.abn_status     -> business_universe.abn_status_code  (migration 086)
+  dispatch.abr_matched_at -> business_universe.abr_last_updated (migration 086)
+  dispatch.abn            -> business_universe.abn              (migration 086)
+  dispatch.abn_matched    -> business_universe.abn_matched      (migration 098)
+
+abn_registry shape (from src/pipeline/free_enrichment.py usage):
+  abn, legal_name, trading_name, gst_registered, entity_type,
+  registration_date, state.
+NOTE: abn_registry has no `suburb` column, so the dispatch's
+"display_name + suburb + state" fuzzy match is implemented as
+"display_name + state" with display_name resolved from the BU row's
+trading_name | abr_trading_name | legal_name | display_name fallback chain.
+
+Usage:
+    python scripts/abn_match_sweep.py --batch-size 200 --min-confidence 0.7
+    python scripts/abn_match_sweep.py --dry-run        # plan only, no writes
+    python scripts/abn_match_sweep.py --bu-ids <id>,<id>  # restrict to ids
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger("abn_match_sweep")
+
+DEFAULT_BATCH_SIZE = 200
+MIN_CONFIDENCE = 0.7  # pg_trgm similarity threshold
+
+
+def _resolve_db_url() -> str:
+    url = os.environ.get("DATABASE_URL", "")
+    if not url:
+        raise SystemExit(
+            "DATABASE_URL not set. Source the env file before running:\n"
+            "  source /home/elliotbot/.config/agency-os/.env"
+        )
+    # Normalise SQLAlchemy-style URL to asyncpg-friendly form.
+    return url.replace("postgresql+asyncpg://", "postgresql://")
+
+
+async def _select_unmatched_bus(
+    conn: asyncpg.Connection,
+    batch_size: int,
+    bu_ids: list[str] | None,
+) -> list[asyncpg.Record]:
+    """Pull BU rows where abn_matched IS NOT TRUE (covers FALSE and NULL)."""
+    if bu_ids:
+        return await conn.fetch(
+            """SELECT id, domain, state,
+                      legal_name, trading_name, abr_trading_name, display_name
+                 FROM business_universe
+                WHERE abn_matched IS NOT TRUE
+                  AND id = ANY($1::uuid[])
+                ORDER BY id
+                LIMIT $2""",
+            bu_ids, batch_size,
+        )
+    return await conn.fetch(
+        """SELECT id, domain, state,
+                  legal_name, trading_name, abr_trading_name, display_name
+             FROM business_universe
+            WHERE abn_matched IS NOT TRUE
+            ORDER BY id
+            LIMIT $1""",
+        batch_size,
+    )
+
+
+def _resolve_search_name(row: asyncpg.Record) -> str | None:
+    """Pick the best available human-readable name for fuzzy matching."""
+    for key in ("trading_name", "abr_trading_name", "legal_name", "display_name"):
+        v = row.get(key) if hasattr(row, "get") else row[key]
+        if v and str(v).strip():
+            return str(v).strip()
+    return None
+
+
+async def _fuzzy_match_one(
+    conn: asyncpg.Connection,
+    name: str,
+    state: str | None,
+    min_confidence: float,
+) -> dict[str, Any] | None:
+    """Return the best abn_registry match for `name` (optionally constrained
+    to `state`) when similarity >= min_confidence. None otherwise.
+
+    Uses pg_trgm similarity() on the greater of trading_name / legal_name
+    similarity. State is an optional exact-match tiebreaker.
+    """
+    sql = """
+        SELECT abn,
+               legal_name,
+               trading_name,
+               gst_registered,
+               entity_type,
+               registration_date,
+               state,
+               GREATEST(
+                   COALESCE(similarity(trading_name, $1), 0.0),
+                   COALESCE(similarity(legal_name,   $1), 0.0)
+               ) AS confidence
+          FROM abn_registry
+         WHERE (
+                 trading_name % $1
+              OR legal_name   % $1
+               )
+           AND ($2::text IS NULL OR state IS NULL OR UPPER(state) = UPPER($2))
+         ORDER BY confidence DESC
+         LIMIT 1
+    """
+    row = await conn.fetchrow(sql, name, state)
+    if row is None:
+        return None
+    confidence = float(row["confidence"] or 0.0)
+    if confidence < min_confidence:
+        return None
+    return {
+        "abn": row["abn"],
+        "legal_name": row["legal_name"],
+        "trading_name": row["trading_name"],
+        "entity_type": row["entity_type"],
+        "registration_date": row["registration_date"],
+        "state": row["state"],
+        "confidence": confidence,
+    }
+
+
+async def _apply_match(
+    conn: asyncpg.Connection,
+    bu_id: str,
+    match: dict[str, Any],
+) -> None:
+    """Write the match back to business_universe.
+
+    Maps dispatch field names to existing BU columns:
+      abn_status     -> abn_status_code   (text)
+      abr_matched_at -> abr_last_updated  (timestamptz)
+    """
+    # Derive an abn_status_code from entity-level signals. abn_registry does
+    # not carry a status column, so we infer 'active' for any matched row;
+    # downstream ABR refresh will overwrite with authoritative status.
+    abn_status_code = "active"
+    await conn.execute(
+        """UPDATE business_universe
+              SET abn               = COALESCE($2, abn),
+                  abn_matched       = TRUE,
+                  abn_status_code   = COALESCE(abn_status_code, $3),
+                  abr_last_updated  = NOW(),
+                  updated_at        = NOW()
+            WHERE id = $1""",
+        bu_id, match["abn"], abn_status_code,
+    )
+
+
+async def sweep(
+    db_url: str,
+    batch_size: int,
+    min_confidence: float,
+    dry_run: bool,
+    bu_ids: list[str] | None,
+) -> dict[str, int]:
+    stats = {"total": 0, "matched": 0, "skipped_no_name": 0, "skipped_low_conf": 0, "errors": 0}
+    pool = await asyncpg.create_pool(
+        db_url, min_size=1, max_size=4, statement_cache_size=0,
+    )
+    try:
+        async with pool.acquire() as conn:
+            rows = await _select_unmatched_bus(conn, batch_size, bu_ids)
+            stats["total"] = len(rows)
+            for row in rows:
+                bu_id = str(row["id"])
+                name = _resolve_search_name(row)
+                if not name:
+                    stats["skipped_no_name"] += 1
+                    print(f"SKIP no_name bu_id={bu_id} domain={row.get('domain')}")
+                    continue
+                state = row.get("state")
+                try:
+                    match = await _fuzzy_match_one(conn, name, state, min_confidence)
+                except Exception as exc:
+                    stats["errors"] += 1
+                    print(f"ERROR bu_id={bu_id} name={name!r}: {exc}")
+                    continue
+                if match is None:
+                    stats["skipped_low_conf"] += 1
+                    print(f"SKIP low_conf bu_id={bu_id} name={name!r} state={state}")
+                    continue
+                if dry_run:
+                    print(
+                        f"DRY-RUN match bu_id={bu_id} name={name!r} -> "
+                        f"abn={match['abn']} conf={match['confidence']:.3f}"
+                    )
+                else:
+                    try:
+                        await _apply_match(conn, bu_id, match)
+                        stats["matched"] += 1
+                        print(
+                            f"MATCH bu_id={bu_id} name={name!r} -> "
+                            f"abn={match['abn']} conf={match['confidence']:.3f}"
+                        )
+                    except Exception as exc:
+                        stats["errors"] += 1
+                        print(f"ERROR write bu_id={bu_id}: {exc}")
+    finally:
+        await pool.close()
+    return stats
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE,
+                   help=f"Rows per sweep (default {DEFAULT_BATCH_SIZE})")
+    p.add_argument("--min-confidence", type=float, default=MIN_CONFIDENCE,
+                   help=f"pg_trgm similarity threshold (default {MIN_CONFIDENCE})")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Plan only; do not write to BU")
+    p.add_argument("--bu-ids", default=None,
+                   help="Comma-separated UUIDs to restrict the sweep")
+    return p.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = _parse_args()
+    bu_ids = [s.strip() for s in args.bu_ids.split(",")] if args.bu_ids else None
+    db_url = _resolve_db_url()
+    stats = asyncio.run(sweep(
+        db_url=db_url,
+        batch_size=args.batch_size,
+        min_confidence=args.min_confidence,
+        dry_run=args.dry_run,
+        bu_ids=bu_ids,
+    ))
+    print(f"\nSWEEP SUMMARY: {stats}")
+    sys.exit(0 if stats["errors"] == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipeline/free_enrichment.py
+++ b/src/pipeline/free_enrichment.py
@@ -451,10 +451,20 @@ class FreeEnrichment:
 
     async def run(self, limit: int = 500) -> dict:
         async with self._acquire() as conn:
+            # Generalised cursor: catches rows that have never been processed
+            # (legacy NULL marker) AND rows whose JSONB stage_completed_at marker
+            # is missing AND rows previously aborted via free_enrichment_exception.
+            # This closes the gap where partial / errored rows were never retried.
             rows = await conn.fetch(
-                "SELECT id, domain, state FROM business_universe "
-                "WHERE pipeline_stage >= 1 AND free_enrichment_completed_at IS NULL "
-                "AND domain IS NOT NULL LIMIT $1",
+                """SELECT id, domain, state FROM business_universe
+                   WHERE pipeline_stage >= 1
+                     AND domain IS NOT NULL
+                     AND (
+                           free_enrichment_completed_at IS NULL
+                        OR (stage_metrics -> 'stage_completed_at' ->> 'free_enrichment') IS NULL
+                        OR filter_reason = 'free_enrichment_exception'
+                     )
+                   LIMIT $1""",
                 limit,
             )
         stats = {
@@ -567,6 +577,9 @@ class FreeEnrichment:
                 website_data = await self._scrape_website(domain)
             else:
                 stats["dns_skipped"] += 1
+                # Instrumentation: mark the dead-DNS skip path so the gap is visible.
+                # Not a hard drop — _write_results still runs below with empty website_data.
+                await self._write_filter_reason(bu_id, "free_enrichment_dns_unreachable")
             dns_data = self._enrich_dns(domain)
             suburb = (website_data.get("website_address") or {}).get("suburb")
             abn_data = await self._match_abn(
@@ -581,6 +594,25 @@ class FreeEnrichment:
         except Exception as exc:
             self._logger.error("FreeEnrichment error for %s: %s", domain, exc)
             stats["errors"].append({"domain": domain, "error": str(exc)})
+            # Instrumentation: record the exception so the generalised cursor
+            # picks the row up on the next sweep instead of leaving it stuck.
+            try:
+                await self._write_filter_reason(bu_id, "free_enrichment_exception")
+            except Exception as inner:
+                self._logger.warning(
+                    "FreeEnrichment: failed to write exception filter_reason for %s: %s",
+                    domain, inner,
+                )
+
+    async def _write_filter_reason(self, bu_id: str, reason: str) -> None:
+        """Write filter_reason to BU without touching pipeline_stage. Skip-marker only."""
+        async with self._acquire() as conn:
+            await conn.execute(
+                """UPDATE business_universe
+                   SET filter_reason = $2, updated_at = NOW()
+                   WHERE id = $1""",
+                bu_id, reason,
+            )
 
     def _dns_precheck(self, domain: str) -> bool:
         resolver = dns.resolver.Resolver()
@@ -959,7 +991,13 @@ class FreeEnrichment:
                     entity_type                   = COALESCE($12, entity_type),
                     registration_date             = COALESCE($13, registration_date),
                     email_maturity                = $14,
-                    free_enrichment_completed_at  = NOW()
+                    free_enrichment_completed_at  = NOW(),
+                    stage_metrics = jsonb_set(
+                        COALESCE(stage_metrics, '{}'::jsonb),
+                        '{stage_completed_at,free_enrichment}',
+                        to_jsonb(NOW()::text),
+                        true
+                    )
                 WHERE id = $1
                 """,
                 bu_id,

--- a/src/pipeline/layer_3_bulk_filter.py
+++ b/src/pipeline/layer_3_bulk_filter.py
@@ -135,7 +135,9 @@ class Layer3BulkFilter:
 
                 # Apply thresholds and update BU
                 for domain in batch:
-                    m = metrics_by_domain.get(domain, {})
+                    m = metrics_by_domain.get(domain)
+                    in_response = m is not None
+                    m = m or {}
                     organic_etv = m.get("organic_etv", 0.0)
                     paid_etv = m.get("paid_etv", 0.0)
                     backlinks = m.get("backlinks_count", 0)
@@ -160,6 +162,12 @@ class Layer3BulkFilter:
                                 dfs_paid_etv = COALESCE($3, dfs_paid_etv),
                                 backlinks_count = $4,
                                 domain_rank = $5,
+                                stage_metrics = jsonb_set(
+                                    COALESCE(stage_metrics, '{}'::jsonb),
+                                    '{stage_completed_at,layer_3_bulk_filter}',
+                                    to_jsonb(NOW()::text),
+                                    true
+                                ),
                                 updated_at = NOW()
                             WHERE id = $1
                             """,
@@ -171,6 +179,18 @@ class Layer3BulkFilter:
                         )
                         stats.passed += 1
                     else:
+                        # Specific drop reasons — covers every drop branch
+                        if not in_response:
+                            reason = "bulk_metrics_missing_from_response"
+                        else:
+                            failed = []
+                            if not (organic_etv > min_organic):
+                                failed.append("organic_etv")
+                            if not (paid_etv > min_paid):
+                                failed.append("paid_etv")
+                            if not (backlinks >= min_backlinks):
+                                failed.append("backlinks")
+                            reason = "bulk_metrics_below_threshold:" + "+".join(failed)
                         await self._conn.execute(
                             """
                             UPDATE business_universe SET
@@ -180,11 +200,17 @@ class Layer3BulkFilter:
                                 dfs_paid_etv = COALESCE($4, dfs_paid_etv),
                                 backlinks_count = $5,
                                 domain_rank = $6,
+                                stage_metrics = jsonb_set(
+                                    COALESCE(stage_metrics, '{}'::jsonb),
+                                    '{stage_completed_at,layer_3_bulk_filter}',
+                                    to_jsonb(NOW()::text),
+                                    true
+                                ),
                                 updated_at = NOW()
                             WHERE id = $1
                             """,
                             domain_id,
-                            "bulk_metrics_below_threshold",
+                            reason,
                             organic_etv if organic_etv > 0 else None,
                             paid_etv if paid_etv > 0 else None,
                             backlinks if backlinks > 0 else None,
@@ -195,6 +221,36 @@ class Layer3BulkFilter:
             except Exception as exc:
                 logger.error(f"Layer3: batch {stats.batches_called + 1} failed: {exc}")
                 stats.errors.append(str(exc))
+                # Mark each domain in the failed batch with a filter_reason so the
+                # gap is visible. Pipeline stage stays at 1 for retry — these are
+                # NOT drops, just instrumentation markers on the failed attempt.
+                exc_marker = f"bulk_metrics_batch_error:{type(exc).__name__}"
+                for domain in batch:
+                    domain_id = id_by_domain.get(domain)
+                    if not domain_id:
+                        continue
+                    try:
+                        await self._conn.execute(
+                            """
+                            UPDATE business_universe SET
+                                filter_reason = $2,
+                                stage_metrics = jsonb_set(
+                                    COALESCE(stage_metrics, '{}'::jsonb),
+                                    '{layer_3_last_error}',
+                                    to_jsonb($3::text),
+                                    true
+                                ),
+                                updated_at = NOW()
+                            WHERE id = $1
+                            """,
+                            domain_id,
+                            exc_marker,
+                            str(exc)[:500],
+                        )
+                    except Exception as mark_exc:
+                        logger.warning(
+                            f"Layer3: failed to write batch-error marker for {domain}: {mark_exc}"
+                        )
 
         logger.info(
             f"Layer3 [{vertical}]: processed={stats.total_processed} "

--- a/src/pipeline/paid_enrichment.py
+++ b/src/pipeline/paid_enrichment.py
@@ -43,12 +43,41 @@ def _state_coords(state: str | None) -> tuple[float, float]:
     return _DEFAULT_COORDS
 
 
+async def _suppression_cross_check(
+    conn: asyncpg.Connection,
+    bu_ids: list[str],
+) -> set[str]:
+    """Return the subset of BU ids whose website_contact_emails intersect the
+    public.suppression_list (any email match on channel ∈ {'all','email'}).
+
+    Pre-paid-spend SQL guard. Pure SQL — no live API calls. DNCR phone checks
+    live in Redis cache (src/integrations/dncr.py) and have no SQL surface, so
+    they are not joined here; that path is exercised at the live-call site.
+    """
+    if not bu_ids:
+        return set()
+    rows = await conn.fetch(
+        """SELECT DISTINCT bu.id
+             FROM business_universe bu,
+                  jsonb_array_elements_text(
+                      COALESCE(bu.website_contact_emails, '[]'::jsonb)
+                  ) AS contact_email
+             JOIN public.suppression_list s
+               ON LOWER(s.email) = LOWER(contact_email)
+            WHERE bu.id = ANY($1::uuid[])
+              AND s.channel IN ('all', 'email')""",
+        bu_ids,
+    )
+    return {str(r["id"]) for r in rows}
+
+
 async def affordability_gate(
     conn: asyncpg.Connection,
     limit: int = 1000,
 ) -> tuple[list[asyncpg.Record], list[asyncpg.Record]]:
     """
-    Query BU for domains ready for paid enrichment. Apply 4-gate filter.
+    Query BU for domains ready for paid enrichment. Apply 4-gate filter +
+    suppression cross-check.
     Returns (passing_rows, failing_rows).
     Failing rows have paid_enrichment_skipped_reason written to DB before returning.
     """
@@ -64,10 +93,20 @@ async def affordability_gate(
         limit,
     )
 
+    # Suppression cross-check BEFORE any paid-spend SQL. Skip-marker rows
+    # whose contact emails match the suppression list — they never enter the
+    # _check_gates loop and never reach DFS / GMB calls downstream.
+    suppressed_ids = await _suppression_cross_check(
+        conn, [str(r["id"]) for r in rows]
+    )
+
     passing: list[asyncpg.Record] = []
     failing: list[tuple[asyncpg.Record, str]] = []
 
     for row in rows:
+        if str(row["id"]) in suppressed_ids:
+            failing.append((row, "suppression_match"))
+            continue
         reason = _check_gates(row)
         if reason is None:
             passing.append(row)

--- a/tests/scripts/test_abn_match_sweep.py
+++ b/tests/scripts/test_abn_match_sweep.py
@@ -1,0 +1,222 @@
+"""Unit tests for scripts/abn_match_sweep.py.
+
+These tests mock asyncpg so the suite stays hermetic — no DB needed.
+Logic under test:
+  - _resolve_search_name() picks the best available name from the BU row.
+  - sweep() (via mocked pool) writes abn / abn_matched / abn_status_code
+    when match confidence >= threshold and dry_run=False.
+  - Low-confidence matches are skipped.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Load the script as a module under the name `abn_match_sweep` without
+# requiring scripts/ to be a package. spec_from_file_location keeps test
+# isolation from production import paths.
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "abn_match_sweep.py"
+_spec = importlib.util.spec_from_file_location("abn_match_sweep", _SCRIPT_PATH)
+abn_match_sweep = importlib.util.module_from_spec(_spec)
+sys.modules["abn_match_sweep"] = abn_match_sweep
+_spec.loader.exec_module(abn_match_sweep)
+
+
+# ── _resolve_search_name ────────────────────────────────────────────────────
+
+class _Row(dict):
+    """asyncpg.Record-like dict with .get() semantics used by the sweep code."""
+
+
+def test_resolve_search_name_prefers_trading_name():
+    row = _Row(trading_name="Pymble Dental",
+               abr_trading_name="Pymble Dental Pty Ltd",
+               legal_name="ABC PTY LTD",
+               display_name="abc.com.au")
+    assert abn_match_sweep._resolve_search_name(row) == "Pymble Dental"
+
+
+def test_resolve_search_name_falls_back_to_legal_name():
+    row = _Row(trading_name=None,
+               abr_trading_name="",
+               legal_name="ABC Pty Ltd",
+               display_name=None)
+    assert abn_match_sweep._resolve_search_name(row) == "ABC Pty Ltd"
+
+
+def test_resolve_search_name_returns_none_when_empty():
+    row = _Row(trading_name=None, abr_trading_name=None,
+               legal_name=None, display_name=None)
+    assert abn_match_sweep._resolve_search_name(row) is None
+
+
+# ── sweep() — happy path with mocked pool ──────────────────────────────────
+
+def _make_pool(rows: list[_Row], match_row: dict | None) -> MagicMock:
+    """Build a MagicMock asyncpg pool whose acquire() yields a conn whose
+    fetch() returns `rows` and fetchrow() returns the (row-shaped) match."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=rows)
+    if match_row is None:
+        conn.fetchrow = AsyncMock(return_value=None)
+    else:
+        # asyncpg.Record-like — supports __getitem__
+        rec = MagicMock()
+        rec.__getitem__.side_effect = lambda key: match_row[key]
+        conn.fetchrow = AsyncMock(return_value=rec)
+    conn.execute = AsyncMock(return_value="UPDATE 1")
+
+    pool_cm = MagicMock()
+    pool_cm.__aenter__ = AsyncMock(return_value=conn)
+    pool_cm.__aexit__ = AsyncMock(return_value=False)
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=pool_cm)
+    pool.close = AsyncMock(return_value=None)
+    return pool, conn
+
+
+def test_sweep_writes_match_when_confidence_above_threshold():
+    bu_id = "00000000-0000-0000-0000-000000000001"
+    rows = [_Row(id=bu_id, domain="example.com.au", state="NSW",
+                 legal_name="Example Pty Ltd", trading_name="Example Dental",
+                 abr_trading_name=None, display_name=None)]
+    match = {
+        "abn": "12345678901",
+        "legal_name": "Example Pty Ltd",
+        "trading_name": "Example Dental",
+        "entity_type": "Company",
+        "registration_date": None,
+        "state": "NSW",
+        "confidence": 0.92,
+    }
+    pool, conn = _make_pool(rows, match)
+
+    async def _fake_create_pool(*_a, **_kw):
+        return pool
+
+    with patch.object(abn_match_sweep.asyncpg, "create_pool", _fake_create_pool):
+        stats = asyncio.run(abn_match_sweep.sweep(
+            db_url="postgresql://stub",
+            batch_size=10,
+            min_confidence=0.7,
+            dry_run=False,
+            bu_ids=None,
+        ))
+
+    assert stats == {"total": 1, "matched": 1, "skipped_no_name": 0,
+                     "skipped_low_conf": 0, "errors": 0}
+    # _apply_match should have run an UPDATE on business_universe with the
+    # mapped columns (abn, abn_matched=TRUE, abn_status_code, abr_last_updated).
+    update_calls = [c for c in conn.execute.await_args_list
+                    if "UPDATE business_universe" in c.args[0]]
+    assert update_calls, "expected at least one BU UPDATE"
+    update_sql = update_calls[0].args[0]
+    assert "abn_matched       = TRUE" in update_sql
+    assert "abn_status_code" in update_sql
+    assert "abr_last_updated" in update_sql
+
+
+def test_sweep_skips_low_confidence_match():
+    bu_id = "00000000-0000-0000-0000-000000000002"
+    rows = [_Row(id=bu_id, domain="weak.com.au", state="VIC",
+                 legal_name=None, trading_name="Weak Match",
+                 abr_trading_name=None, display_name=None)]
+    match = {
+        "abn": "99999999999", "legal_name": "X", "trading_name": "Y",
+        "entity_type": None, "registration_date": None, "state": "VIC",
+        "confidence": 0.42,  # below threshold
+    }
+    pool, conn = _make_pool(rows, match)
+
+    async def _fake_create_pool(*_a, **_kw):
+        return pool
+
+    with patch.object(abn_match_sweep.asyncpg, "create_pool", _fake_create_pool):
+        stats = asyncio.run(abn_match_sweep.sweep(
+            db_url="postgresql://stub",
+            batch_size=10,
+            min_confidence=0.7,
+            dry_run=False,
+            bu_ids=None,
+        ))
+
+    assert stats["matched"] == 0
+    assert stats["skipped_low_conf"] == 1
+    # No UPDATE should have hit business_universe.
+    assert not any("UPDATE business_universe" in c.args[0]
+                   for c in conn.execute.await_args_list)
+
+
+def test_sweep_skips_row_with_no_resolvable_name():
+    rows = [_Row(id="00000000-0000-0000-0000-000000000003",
+                 domain="anon.com.au", state="QLD",
+                 legal_name=None, trading_name=None,
+                 abr_trading_name=None, display_name=None)]
+    pool, conn = _make_pool(rows, match_row=None)
+
+    async def _fake_create_pool(*_a, **_kw):
+        return pool
+
+    with patch.object(abn_match_sweep.asyncpg, "create_pool", _fake_create_pool):
+        stats = asyncio.run(abn_match_sweep.sweep(
+            db_url="postgresql://stub",
+            batch_size=10,
+            min_confidence=0.7,
+            dry_run=False,
+            bu_ids=None,
+        ))
+
+    assert stats == {"total": 1, "matched": 0, "skipped_no_name": 1,
+                     "skipped_low_conf": 0, "errors": 0}
+
+
+def test_sweep_dry_run_does_not_write():
+    bu_id = "00000000-0000-0000-0000-000000000004"
+    rows = [_Row(id=bu_id, domain="dry.com.au", state="NSW",
+                 legal_name=None, trading_name="Dry Run",
+                 abr_trading_name=None, display_name=None)]
+    match = {
+        "abn": "11111111111", "legal_name": "X", "trading_name": "Y",
+        "entity_type": None, "registration_date": None, "state": "NSW",
+        "confidence": 0.95,
+    }
+    pool, conn = _make_pool(rows, match)
+
+    async def _fake_create_pool(*_a, **_kw):
+        return pool
+
+    with patch.object(abn_match_sweep.asyncpg, "create_pool", _fake_create_pool):
+        stats = asyncio.run(abn_match_sweep.sweep(
+            db_url="postgresql://stub",
+            batch_size=10,
+            min_confidence=0.7,
+            dry_run=True,
+            bu_ids=None,
+        ))
+
+    # Total counted, but no match recorded and no UPDATE executed.
+    assert stats["total"] == 1
+    assert stats["matched"] == 0
+    assert not any("UPDATE business_universe" in c.args[0]
+                   for c in conn.execute.await_args_list)
+
+
+def test_resolve_db_url_normalises_sqlalchemy_form(monkeypatch):
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://user:pw@host:5432/db",
+    )
+    assert abn_match_sweep._resolve_db_url() == "postgresql://user:pw@host:5432/db"
+
+
+def test_resolve_db_url_raises_when_missing(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(SystemExit):
+        abn_match_sweep._resolve_db_url()

--- a/tests/test_paid_enrichment.py
+++ b/tests/test_paid_enrichment.py
@@ -64,7 +64,9 @@ async def test_affordability_gate_passes_gst_registered():
     """Row with abn_matched + gst_registered + Company entity passes all gates."""
     conn = make_conn()
     row = make_row(website_cms="wordpress", abn_matched=True, gst_registered=True, entity_type="Company")
-    conn.fetch = AsyncMock(return_value=[row])
+    # First fetch: BU candidate rows. Second fetch: suppression cross-check
+    # (added in BU Closed-Loop S1) — return [] = no suppression match.
+    conn.fetch = AsyncMock(side_effect=[[row], []])
 
     passing, failing = await affordability_gate(conn, 10)
 
@@ -82,7 +84,9 @@ async def test_affordability_gate_rejects_dead_site():
     conn = make_conn()
     row = make_row(website_cms=None, website_tech_stack=None, website_contact_emails=None,
                    abn_matched=True, gst_registered=True, entity_type="Company")
-    conn.fetch = AsyncMock(return_value=[row])
+    # First fetch: BU candidate rows. Second fetch: suppression cross-check
+    # (added in BU Closed-Loop S1) — return [] = no suppression match.
+    conn.fetch = AsyncMock(side_effect=[[row], []])
 
     passing, failing = await affordability_gate(conn, 10)
 
@@ -100,7 +104,9 @@ async def test_affordability_gate_rejects_sole_trader():
     conn = make_conn()
     row = make_row(website_cms="wordpress", abn_matched=True, gst_registered=True,
                    entity_type="Individual/Sole Trader")
-    conn.fetch = AsyncMock(return_value=[row])
+    # First fetch: BU candidate rows. Second fetch: suppression cross-check
+    # (added in BU Closed-Loop S1) — return [] = no suppression match.
+    conn.fetch = AsyncMock(side_effect=[[row], []])
 
     passing, failing = await affordability_gate(conn, 10)
 
@@ -116,7 +122,9 @@ async def test_affordability_gate_rejects_no_gst():
     """Row with gst_registered=False fails GATE 3."""
     conn = make_conn()
     row = make_row(website_cms="wordpress", abn_matched=True, gst_registered=False, entity_type="Company")
-    conn.fetch = AsyncMock(return_value=[row])
+    # First fetch: BU candidate rows. Second fetch: suppression cross-check
+    # (added in BU Closed-Loop S1) — return [] = no suppression match.
+    conn.fetch = AsyncMock(side_effect=[[row], []])
 
     passing, failing = await affordability_gate(conn, 10)
 
@@ -132,7 +140,9 @@ async def test_affordability_gate_passes_null_entity_type():
     """None entity_type should not be rejected — sole trader check is explicit match only."""
     conn = make_conn()
     row = make_row(website_cms="wordpress", abn_matched=True, gst_registered=True, entity_type=None)
-    conn.fetch = AsyncMock(return_value=[row])
+    # First fetch: BU candidate rows. Second fetch: suppression cross-check
+    # (added in BU Closed-Loop S1) — return [] = no suppression match.
+    conn.fetch = AsyncMock(side_effect=[[row], []])
 
     passing, failing = await affordability_gate(conn, 10)
 
@@ -241,7 +251,9 @@ async def test_skipped_domains_get_timestamp():
     """Rows failing the gate have paid_enrichment_skipped_reason + completed_at written."""
     conn = make_conn()
     row = make_row(website_cms=None, website_tech_stack=None, website_contact_emails=None)
-    conn.fetch = AsyncMock(return_value=[row])
+    # First fetch: BU candidate rows. Second fetch: suppression cross-check
+    # (added in BU Closed-Loop S1) — return [] = no suppression match.
+    conn.fetch = AsyncMock(side_effect=[[row], []])
 
     passing, failing = await affordability_gate(conn)
 

--- a/tests/test_pipeline/test_layer_3_bulk_filter_filter_reason.py
+++ b/tests/test_pipeline/test_layer_3_bulk_filter_filter_reason.py
@@ -1,0 +1,133 @@
+"""SQL spot-check fixtures for layer_3_bulk_filter filter_reason population.
+
+Verifies that every drop branch in Layer3BulkFilter.run() writes a *specific*
+filter_reason to business_universe (BU Closed-Loop S1 acceptance gate).
+
+We do NOT hit a real DB; we mock asyncpg.Connection and assert that the SQL
+UPDATE issued for each drop branch carries the expected filter_reason value.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.pipeline.layer_3_bulk_filter import Layer3BulkFilter
+
+
+def _make_conn(stage1_rows: list[dict]) -> MagicMock:
+    """Build a mock asyncpg conn for Layer3 happy-path/drop-path tests."""
+    conn = MagicMock()
+    # _run() executes UPDATE for no_domain advancement, then SELECT, then per-row UPDATEs.
+    conn.execute = AsyncMock(return_value="UPDATE 0")
+    conn.fetch = AsyncMock(return_value=stage1_rows)
+    return conn
+
+
+def _make_signal_config():
+    """Return a stand-in config object with default thresholds."""
+    cfg = MagicMock()
+    cfg.enrichment_gates = {}  # use defaults
+    return cfg
+
+
+def _patch_signal_repo(monkeypatch):
+    repo = MagicMock()
+    repo.get_config = AsyncMock(return_value=_make_signal_config())
+    monkeypatch.setattr(
+        "src.pipeline.layer_3_bulk_filter.SignalConfigRepository",
+        lambda conn: repo,
+    )
+
+
+def _captured_filter_reasons(conn: MagicMock) -> list[str]:
+    """Pull the filter_reason argument from every UPDATE call that wrote one."""
+    reasons: list[str] = []
+    for call in conn.execute.await_args_list:
+        sql = call.args[0] if call.args else ""
+        if "filter_reason" not in sql:
+            continue
+        if "pipeline_stage = -1" in sql or "pipeline_stage = 2" in sql:
+            # drop / pass branch — second positional arg is filter_reason
+            if len(call.args) >= 3:
+                reasons.append(call.args[2])
+        else:
+            # batch-error marker branch — second positional arg is reason
+            if len(call.args) >= 3:
+                reasons.append(call.args[2])
+    return reasons
+
+
+@pytest.mark.asyncio
+async def test_layer3_drop_below_threshold_writes_specific_filter_reason(monkeypatch):
+    """Threshold-fail drop branch writes a *specific* reason naming which
+    threshold(s) failed (not the old generic 'bulk_metrics_below_threshold')."""
+    bu_id = "11111111-1111-1111-1111-111111111111"
+    rows = [{"id": bu_id, "domain": "weak.com.au"}]
+    conn = _make_conn(rows)
+
+    dfs = MagicMock()
+    dfs.bulk_domain_metrics = AsyncMock(return_value=[
+        # Returned by DFS, but every metric is below threshold → drop.
+        {"domain": "weak.com.au", "organic_etv": 0.0,
+         "paid_etv": 0.0, "backlinks_count": 0, "domain_rank": 0},
+    ])
+
+    _patch_signal_repo(monkeypatch)
+    engine = Layer3BulkFilter(conn, dfs)
+    stats = await engine.run("dental")
+    assert stats.rejected == 1
+
+    reasons = _captured_filter_reasons(conn)
+    assert reasons, "expected at least one filter_reason write on drop"
+    matched = [r for r in reasons if r.startswith("bulk_metrics_below_threshold:")]
+    assert matched, f"expected specific below_threshold reason; got {reasons}"
+    # Specific axes must appear so analytics can group by failure type.
+    assert "organic_etv" in matched[0]
+    assert "paid_etv" in matched[0]
+    assert "backlinks" in matched[0]
+
+
+@pytest.mark.asyncio
+async def test_layer3_missing_from_response_uses_distinct_reason(monkeypatch):
+    """Domain absent from DFS bulk response → distinct reason, not the
+    generic threshold reason."""
+    bu_id = "22222222-2222-2222-2222-222222222222"
+    rows = [{"id": bu_id, "domain": "ghost.com.au"}]
+    conn = _make_conn(rows)
+
+    dfs = MagicMock()
+    dfs.bulk_domain_metrics = AsyncMock(return_value=[])  # ghost domain not returned
+
+    _patch_signal_repo(monkeypatch)
+    engine = Layer3BulkFilter(conn, dfs)
+    stats = await engine.run("dental")
+    assert stats.rejected == 1
+
+    reasons = _captured_filter_reasons(conn)
+    assert "bulk_metrics_missing_from_response" in reasons
+
+
+@pytest.mark.asyncio
+async def test_layer3_batch_error_writes_marker_filter_reason(monkeypatch):
+    """DFS bulk-call exception writes a batch-error marker on every domain in
+    the failed batch (pipeline_stage stays at 1 — these are not drops)."""
+    rows = [
+        {"id": "33333333-3333-3333-3333-333333333333", "domain": "a.com.au"},
+        {"id": "44444444-4444-4444-4444-444444444444", "domain": "b.com.au"},
+    ]
+    conn = _make_conn(rows)
+
+    dfs = MagicMock()
+    dfs.bulk_domain_metrics = AsyncMock(side_effect=RuntimeError("DFS down"))
+
+    _patch_signal_repo(monkeypatch)
+    engine = Layer3BulkFilter(conn, dfs)
+    stats = await engine.run("dental")
+    assert stats.errors  # batch error logged in stats
+
+    reasons = _captured_filter_reasons(conn)
+    matched = [r for r in reasons if r.startswith("bulk_metrics_batch_error:")]
+    assert len(matched) >= 2, f"expected batch-error marker per domain; got {reasons}"
+    assert "RuntimeError" in matched[0]


### PR DESCRIPTION
## Summary
BU Closed-Loop Engine — Substep 1 of 4 (instrumentation writes). AUD 0 spend, no new schema migrations. Closes the BIG instrumentation gap where `filter_reason` was populated on only 0.03% of dropped BU rows.

## Files changed (`git diff --stat origin/main`)
```
 scripts/abn_match_sweep.py                                       | 255 +++++++++++++++++++++
 src/pipeline/free_enrichment.py                                  |  46 +++-
 src/pipeline/layer_3_bulk_filter.py                              |  60 ++++-
 src/pipeline/paid_enrichment.py                                  |  41 +++-
 tests/scripts/__init__.py                                        |   0
 tests/scripts/test_abn_match_sweep.py                            | 222 ++++++++++++++++++
 tests/test_paid_enrichment.py                                    |  24 +-
 tests/test_pipeline/test_layer_3_bulk_filter_filter_reason.py    | 133 +++++++++++
 8 files changed, 768 insertions(+), 13 deletions(-)
```

(Body diff-stat corrected by parent reviewer 2026-04-25 — earlier body listed 196 files / 36,680 insertions, which was a stale stat from ORION's worktree before recent main merges. Actual scope is the 8 files above.)

## What changed
- **layer_3_bulk_filter.py** — every drop branch now writes a *specific* `filter_reason` (`bulk_metrics_below_threshold:<axes>`, `bulk_metrics_missing_from_response`, `bulk_metrics_batch_error:<exc_type>`). `stage_metrics.stage_completed_at.layer_3_bulk_filter` JSONB key written on every pass and reject.
- **free_enrichment.py** — generalised cursor catches rows missing the new `stage_metrics.stage_completed_at.free_enrichment` marker AND rows previously aborted with `free_enrichment_exception`. Writes the JSONB marker on success; writes `filter_reason` on DNS-fail skip and broad-catch errors.
- **paid_enrichment.py** — new `_suppression_cross_check()` JOIN against `public.suppression_list` (channel ∈ {'all','email'}) before any paid-spend SQL. Suppressed rows get `paid_enrichment_skipped_reason='suppression_match'`. DNCR phone checks live in Redis (no SQL surface) and are unchanged.
- **scripts/abn_match_sweep.py** (NEW) — one-shot asyncpg sweep, pg_trgm fuzzy match against `public.abn_registry` on trading_name/legal_name with state constraint. Updates BU.abn / abn_matched=TRUE / abn_status_code / abr_last_updated when similarity >= 0.7. `--dry-run` / `--bu-ids` / `--batch-size` / `--min-confidence` flags. Zero API calls.

## Column mapping (dispatch-named -> existing BU column)
The dispatch forbade new schema migrations, so:

| Dispatch | Existing BU column |
|---|---|
| `stage_completed_at` jsonb | sub-key inside existing `stage_metrics` jsonb |
| `abn_status` | `abn_status_code` (migration 086) |
| `abr_matched_at` | `abr_last_updated` (migration 086) |
| `abn` / `abn_matched` / `filter_reason` | direct (already exist) |

abn_registry has no `suburb` column — fuzzy match downgraded to (name + state) instead of dispatch's (name + suburb + state). Documented in `scripts/abn_match_sweep.py` header.

## Test plan
- [x] `pytest tests/test_paid_enrichment.py` → 16/16 pass (mock updated for new `conn.fetch` suppression cross-check)
- [x] `pytest tests/scripts/test_abn_match_sweep.py` → 9/9 pass
- [x] `pytest tests/test_pipeline/test_layer_3_bulk_filter_filter_reason.py` → 3/3 pass (SQL spot-check fixtures)
- [x] `pytest tests/test_free_enrichment.py tests/pipeline` → 18/18 pass
- [x] **Full `pytest -q --ignore=tests/test_dncr_client.py`**: 35 failed (identical to origin/main baseline), 2503 passed (+9 new), 28 skipped. Net failure delta vs main = **0**.

## Pre-existing test debt (out of S1 scope, documented)
- `tests/test_dncr_client.py` vs `tests/integrations/test_dncr_client.py` module-name collision blocks pytest collection. Suite was run with `--ignore=tests/test_dncr_client.py` per dispatch's "do NOT skip; document" rule. Cleanup belongs in a separate directive.
- 35 pre-existing pipeline / card-streaming test failures on `origin/main`. Net delta on this branch = 0.

## Reviews
- Parent AIDEN: code APPROVED 2026-04-25.
- Peer ELLIOT: code APPROVED 2026-04-25.
- Body diff-stat corrected by parent reviewer.

## Policy
**Dual-concur required**: parent AIDEN + peer ELLIOT must both approve before merge. No self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
