### PR TITLE
[ORION] feat(bu-closed-loop): S3 domain_data reconstruction + Stage 0->1 trigger fix

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -432,6 +432,29 @@ deployments:
     entrypoint: src/orchestration/flows/health_check_flow.py:health_check_flow
 
   # ============================================
+  # FREE ENRICHMENT FLOW (Directive: BU Closed-Loop S3 — Stage 0/1 trigger fix)
+  # ============================================
+  # Hourly safety-net: promotes stage-0/NULL BU rows to stage 1 then runs
+  # FreeEnrichment.run() over the backlog. ACTIVE (AUD 0 — local DNS /
+  # httpx / abn_registry; Spider fallback gated by SPIDER_API_KEY env var).
+  - name: free-enrichment-flow
+    version: "1.0.0"
+    paused: false  # ACTIVE — AUD 0 free-mode flow
+    tags: [bu-closed-loop, free-enrichment, stage-0-trigger, free-mode]
+    description: "BU Closed-Loop S3 — Stage 0/1 trigger fix. Hourly free-mode enrichment of stuck BU rows."
+    entrypoint: src/orchestration/flows/free_enrichment_flow.py:free_enrichment_flow
+    work_pool:
+      name: agency-os-pool
+      work_queue_name: agency-os-queue
+    parameters:
+      limit: 500
+      promote_stage_0: true
+    schedules:
+      - cron: "15 * * * *"
+        timezone: UTC
+        active: true
+
+  # ============================================
   # BU CLOSED-LOOP ENGINE (Directive: BU Closed-Loop S2)
   # ============================================
   # Daily backlog driver — re-enters stuck BU rows at their next stage in

--- a/src/orchestration/deployments/free_enrichment_deployment.py
+++ b/src/orchestration/deployments/free_enrichment_deployment.py
@@ -1,0 +1,38 @@
+"""Prefect Deployment: free-enrichment-flow (Stage 0/1 trigger fix).
+
+Directive: BU Closed-Loop Engine — Substep 3.
+Posture:   ACTIVE (paused=false). Stage 1 is AUD 0 — local DNS / httpx /
+           abn_registry. Spider fallback is gated by SPIDER_API_KEY env var.
+Schedule:  Hourly safety-net so newly-discovered BU rows enter the
+           enrichment cursor without manual intervention.
+"""
+from prefect.deployments import Deployment
+from prefect.server.schemas.schedules import CronSchedule
+
+from src.orchestration.flows.free_enrichment_flow import free_enrichment_flow
+
+free_enrichment_deployment = Deployment.build_from_flow(
+    flow=free_enrichment_flow,
+    name="free-enrichment-flow",
+    version="1.0.0",
+    tags=["bu-closed-loop", "free-enrichment", "stage-0-trigger", "free-mode"],
+    description=(
+        "BU Closed-Loop S3 free-enrichment flow. ACTIVE (AUD 0 — local DNS / "
+        "httpx / abn_registry). Hourly safety-net: promotes stage-0/NULL BU "
+        "rows to stage 1 then runs FreeEnrichment.run() over the backlog."
+    ),
+    schedule=CronSchedule(cron="15 * * * *", timezone="UTC"),
+    is_schedule_active=True,
+    parameters={
+        "limit": 500,
+        "promote_stage_0": True,
+    },
+    work_queue_name="default",
+)
+
+
+if __name__ == "__main__":
+    free_enrichment_deployment.apply()
+    print("Deployed: free-enrichment-flow/free-enrichment-flow (ACTIVE, hourly :15)")
+    print("Run via: prefect deployment run 'free-enrichment-flow/free-enrichment-flow'")
+    print("Override: -p limit=200 -p promote_stage_0=false")

--- a/src/orchestration/flows/bu_closed_loop_flow.py
+++ b/src/orchestration/flows/bu_closed_loop_flow.py
@@ -67,6 +67,15 @@ STAGE_ADVANCEMENT: dict[int, dict[str, Any]] = {
     # S3 — Stage 0 / 1 (post-discovery, pre-enrichment) advances via
     # free_enrichment. Pure local: DNS + httpx + abn_registry. AUD 0.
     0:  {"next_stage": 1,  "runner": "free_enrichment", "clients": [],         "is_free": True},
+    # S3-2 — Stage 1 -> 1 self-advancement is INTENTIONAL, not a bug.
+    # free_enrichment is the free-mode terminal stage (no paid path forward
+    # without human spend approval). Stamping stage_completed_at on each
+    # cycle is the cadence-backoff that prevents tight re-enrichment loops.
+    # Combined with S3-1's free_enrichment_completed_at short-circuit in
+    # _classify_row, the actual scrape only re-runs after the deliberate
+    # cadence (hot=14d / warm=60d / cold=180d) AND the row has not yet been
+    # enriched. Looks like an S2-1-class self-loop bug at first glance but
+    # is the correct semantics for the free-mode terminal.
     1:  {"next_stage": 1,  "runner": "free_enrichment", "clients": [],         "is_free": True},
     2:  {"next_stage": 3,  "runner": "_run_stage3",     "clients": ["gemini"], "is_free": True},
     3:  {"next_stage": 5,  "runner": "_run_stage5",     "clients": [],         "is_free": True},
@@ -118,6 +127,7 @@ async def fetch_backlog(
             SELECT id, domain, dfs_discovery_category AS category,
                    pipeline_stage, propensity_score,
                    stage_metrics, filter_reason,
+                   free_enrichment_completed_at,
                    COALESCE(
                        (SELECT MAX((value)::timestamptz)
                           FROM jsonb_each_text(stage_metrics -> 'stage_completed_at')),
@@ -129,7 +139,8 @@ async def fetch_backlog(
                AND domain IS NOT NULL
         )
         SELECT id, domain, category, pipeline_stage, propensity_score,
-               stage_metrics, filter_reason, latest_stage_at,
+               stage_metrics, filter_reason, free_enrichment_completed_at,
+               latest_stage_at,
                CASE
                    WHEN COALESCE(propensity_score, 0) >= 70 THEN 'hot'
                    WHEN COALESCE(propensity_score, 0) >= 50 THEN 'warm'
@@ -186,6 +197,17 @@ def _classify_row(
         return {
             "action": "skip",
             "reason": f"stuck:blocked_by_free_mode (would invoke {plan['runner']} requiring {plan['clients']})",
+        }
+    # S3-1 — pre-flight skip when the row has already been free-enriched.
+    # Without this gate, a stage-1 row that completed enrichment in a prior
+    # cycle would re-scrape on every closed-loop pass once the cadence
+    # threshold elapses. The cadence-backoff via stage_completed_at marker
+    # only mutes consecutive cycles, not the eventual re-scrape — this gate
+    # makes the no-op explicit and keeps the AUD 0 invariant tight.
+    if plan["runner"] == "free_enrichment" and row.get("free_enrichment_completed_at"):
+        return {
+            "action": "skip",
+            "reason": "stuck:already_free_enriched",
         }
     # S2-4 — pre-flight gate: refuse plans whose required clients are not
     # actually wired up. Today only Gemini is initialised in the flow body

--- a/src/orchestration/flows/bu_closed_loop_flow.py
+++ b/src/orchestration/flows/bu_closed_loop_flow.py
@@ -56,26 +56,30 @@ logger = logging.getLogger(__name__)
 # function consumes. Free-mode refuses any stage where a paid client is
 # required. Gemini is treated as free tier (per dispatch).
 #
-# pipeline_stage 0 / 1 → free_enrichment.run() (Stage 1 in dispatch lingo).
-# That path is OWNED by free_enrichment.py and NOT re-driven here — this flow
-# focuses on stages 2..11 cohort_runner advancement. Rows with stage<2 are
-# logged as `stuck:pre_enrichment_owned_by_free_enrichment`.
+# S3: pipeline_stage 0 (NULL coerced) and 1 advance via the
+# free_enrichment runner. Rows with stage 0 are first promoted to stage 1
+# inside advance_row's _invoke_runner branch, then enriched in the same
+# logical pass.
 _PAID_CLIENT_KEYS: set[str] = {"dfs", "bd", "lm"}
 _FREE_CLIENT_KEYS: set[str] = {"gemini"}
 
 STAGE_ADVANCEMENT: dict[int, dict[str, Any]] = {
-    2:  {"next_stage": 3,  "runner": "_run_stage3",  "clients": ["gemini"], "is_free": True},
-    3:  {"next_stage": 5,  "runner": "_run_stage5",  "clients": [],         "is_free": True},
+    # S3 — Stage 0 / 1 (post-discovery, pre-enrichment) advances via
+    # free_enrichment. Pure local: DNS + httpx + abn_registry. AUD 0.
+    0:  {"next_stage": 1,  "runner": "free_enrichment", "clients": [],         "is_free": True},
+    1:  {"next_stage": 1,  "runner": "free_enrichment", "clients": [],         "is_free": True},
+    2:  {"next_stage": 3,  "runner": "_run_stage3",     "clients": ["gemini"], "is_free": True},
+    3:  {"next_stage": 5,  "runner": "_run_stage5",     "clients": [],         "is_free": True},
     # 4 advances to 5 directly when the paid stage 4 is skipped — pure logic.
-    4:  {"next_stage": 5,  "runner": "_run_stage5",  "clients": [],         "is_free": True},
-    5:  {"next_stage": 7,  "runner": "_run_stage7",  "clients": ["gemini"], "is_free": True},
+    4:  {"next_stage": 5,  "runner": "_run_stage5",     "clients": [],         "is_free": True},
+    5:  {"next_stage": 7,  "runner": "_run_stage7",     "clients": ["gemini"], "is_free": True},
     # Stage 6 is DFS-paid and unreachable in free-mode; rows landing at 6
     # advance via _run_stage7 (Gemini, free) when free-mode is on.
-    6:  {"next_stage": 7,  "runner": "_run_stage7",  "clients": ["gemini"], "is_free": True},
-    7:  {"next_stage": 9,  "runner": "_run_stage9",  "clients": ["bd"],     "is_free": False},
-    8:  {"next_stage": 9,  "runner": "_run_stage9",  "clients": ["bd"],     "is_free": False},
-    9:  {"next_stage": 10, "runner": "_run_stage10", "clients": [],         "is_free": True},
-    10: {"next_stage": 11, "runner": "_run_stage11", "clients": [],         "is_free": True},
+    6:  {"next_stage": 7,  "runner": "_run_stage7",     "clients": ["gemini"], "is_free": True},
+    7:  {"next_stage": 9,  "runner": "_run_stage9",     "clients": ["bd"],     "is_free": False},
+    8:  {"next_stage": 9,  "runner": "_run_stage9",     "clients": ["bd"],     "is_free": False},
+    9:  {"next_stage": 10, "runner": "_run_stage10",    "clients": [],         "is_free": True},
+    10: {"next_stage": 11, "runner": "_run_stage11",    "clients": [],         "is_free": True},
 }
 
 
@@ -166,11 +170,10 @@ def _classify_row(
     advance_row.
     """
     current_stage = row["pipeline_stage"]
-    if current_stage is None or current_stage < 2:
-        return {
-            "action": "skip",
-            "reason": "stuck:pre_enrichment_owned_by_free_enrichment",
-        }
+    # S3 — stage 0 / NULL now route to free_enrichment via STAGE_ADVANCEMENT
+    # rather than being skipped as "owned by another flow". Treat NULL as 0.
+    if current_stage is None:
+        current_stage = 0
     if current_stage == 11:
         return {"action": "skip", "reason": "stuck:already_at_terminal_stage"}
     plan = STAGE_ADVANCEMENT.get(current_stage)
@@ -204,20 +207,187 @@ def _classify_row(
     }
 
 
-def _build_domain_data(row: dict[str, Any]) -> dict[str, Any]:
-    """Build the minimal domain_data dict cohort_runner._run_stageN expects.
+def _coerce_dict(value: Any) -> dict[str, Any]:
+    """Return a dict from value: passthrough dicts, parse JSON strings, else {}."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except (ValueError, json.JSONDecodeError):
+            return {}
+    return {}
 
-    NOTE: production-grade reconstruction (carrying stage3 / stage4 / stage5
-    intermediate dicts back from BU columns) is deferred to S3. This minimal
-    dict will trigger early-exit gates inside some _run_stageN functions when
-    prerequisites are missing — that is logged as `runner_early_exit` rather
-    than retried.
+
+def _stage4_from_columns(row: dict[str, Any]) -> dict[str, Any]:
+    """Fall-back reconstruction of the stage4 signal bundle from BU scalars
+    when stage_metrics->'stage4' is missing. _run_stage5 reads this dict via
+    `signal_bundle=...` so the keys must match build_signal_bundle output:
+    rank_overview / backlinks / etc."""
+    rank_overview: dict[str, Any] = {}
+    if row.get("dfs_organic_etv") is not None:
+        rank_overview["organic_etv"] = row["dfs_organic_etv"]
+    if row.get("dfs_organic_keywords") is not None:
+        rank_overview["organic_keywords"] = row["dfs_organic_keywords"]
+    if row.get("domain_rank") is not None:
+        rank_overview["rank"] = row["domain_rank"]
+
+    backlinks: dict[str, Any] = {}
+    if row.get("backlinks_count") is not None:
+        backlinks["backlinks_num"] = row["backlinks_count"]
+
+    bundle: dict[str, Any] = {}
+    if rank_overview:
+        bundle["rank_overview"] = rank_overview
+    if backlinks:
+        bundle["backlinks"] = backlinks
+    return bundle
+
+
+def _stage5_from_columns(row: dict[str, Any]) -> dict[str, Any]:
+    """Fall-back reconstruction of stage5 scores. _run_stage5 normally
+    populates this; on re-entry past stage 5 we want the existing scores
+    visible to stage7/10/11 even if stage_metrics->'stage5' is missing."""
+    scores: dict[str, Any] = {}
+    if row.get("propensity_score") is not None:
+        scores["composite_score"] = row["propensity_score"]
+        scores["is_viable_prospect"] = bool(row["propensity_score"])
+    for col_key, score_key in (
+        ("score_budget", "budget"),
+        ("score_pain", "pain"),
+        ("score_gap", "gap"),
+        ("score_fit", "fit"),
+    ):
+        if row.get(col_key) is not None:
+            scores[score_key] = row[col_key]
+    return scores
+
+
+def _stage3_from_columns(row: dict[str, Any]) -> dict[str, Any]:
+    """Fall-back reconstruction of stage3 identity. _run_stage5 / 7 read
+    business_name + dm_candidate from this dict."""
+    identity: dict[str, Any] = {}
+    name = row.get("trading_name") or row.get("abr_trading_name") or row.get("legal_name")
+    if name:
+        identity["business_name"] = str(name)
+    dm: dict[str, Any] = {}
+    if row.get("dm_phone"):
+        dm["phone"] = row["dm_phone"]
+    if row.get("linkedin_company_url"):
+        dm["linkedin_url"] = row["linkedin_company_url"]
+    if dm:
+        identity["dm_candidate"] = dm
+    if row.get("entity_type"):
+        identity["entity_type"] = row["entity_type"]
+    return identity
+
+
+def _build_domain_data(row: dict[str, Any]) -> dict[str, Any]:
+    """Production-grade reconstruction of the domain_data dict each
+    cohort_runner._run_stageN expects (S3 replacement of the minimal stub).
+
+    Strategy:
+      1. Read stage_metrics jsonb on BU — that JSONB carries stage2, stage3,
+         stage4, stage5 keys when persisted by _persist_stage4_to_bu and
+         pipeline_f_master_flow. High-fidelity path.
+      2. Fall back to BU column scalars for stage3 / stage4 / stage5 when
+         stage_metrics is empty (e.g., row enriched before stage_metrics
+         existed, or partial-state row). Keys match what each runner reads.
+      3. Carry the mutable scaffolding fields (errors, cost_usd, timings,
+         _latency_tracker) so runners do not crash on dict-missing keys.
+
+    Returns:
+        Dict with keys: domain, category, stage2, stage3, stage4, stage5,
+        stage6, stage7, stage8_verify, stage8_contacts, stage9, stage10,
+        stage11, errors, cost_usd, timings, dropped_at, drop_reason, _bu_id.
     """
+    # Late import — avoids a hard dep on cohort_runner at module-load time
+    # (so unit tests that don't exercise advance_row don't pay the cost).
+    from src.orchestration.cohort_runner import LatencyTracker
+
+    sm = _coerce_dict(row.get("stage_metrics"))
+
+    # Stage data — JSONB-preserved first, BU-column fallback second.
+    stage3 = _coerce_dict(sm.get("stage3")) or _stage3_from_columns(row)
+    stage4 = _coerce_dict(sm.get("stage4")) or _stage4_from_columns(row)
+    stage5 = _coerce_dict(sm.get("stage5")) or _stage5_from_columns(row)
+
     return {
         "domain": row["domain"],
         "category": row.get("category") or "",
+        "stage2": _coerce_dict(sm.get("stage2")),
+        "stage3": stage3,
+        "stage4": stage4,
+        "stage5": stage5,
+        "stage6": _coerce_dict(sm.get("stage6")),
+        "stage7": _coerce_dict(sm.get("stage7")),
+        "stage8_verify": _coerce_dict(sm.get("stage8_verify")),
+        "stage8_contacts": _coerce_dict(sm.get("stage8_contacts")),
+        "stage9": _coerce_dict(sm.get("stage9")),
+        "stage10": _coerce_dict(sm.get("stage10")),
+        "stage11": _coerce_dict(sm.get("stage11")),
+        # Mutable scaffolding the runners write into.
+        "errors": [],
+        "cost_usd": 0.0,
+        "timings": {},
+        "dropped_at": None,
+        "drop_reason": None,
+        "_latency_tracker": LatencyTracker(row["domain"]),
         "_bu_id": str(row["id"]),
     }
+
+
+async def _invoke_free_enrichment(domain_data: dict[str, Any]) -> dict[str, Any]:
+    """S3 — single-domain free_enrichment runner. Calls the existing
+    FreeEnrichment.enrich_from_spider() entrypoint (DNS + scrape + ABN
+    match) and folds the result back into domain_data.
+
+    AUD 0: local DNS, httpx scrape, local abn_registry lookups. Spider
+    fallback inside FreeEnrichment is gated by SPIDER_API_KEY env var.
+
+    The result populates domain_data with website_data + dns_data + abn_data
+    fields under stage2-equivalent keys so downstream stages see them. We do
+    NOT write to BU here — the per-row caller (advance_row) is the only DB
+    writer in the closed-loop flow.
+    """
+    from src.pipeline.free_enrichment import FreeEnrichment
+
+    engine = FreeEnrichment()
+    domain = domain_data["domain"]
+    try:
+        spider_data = await engine.scrape_website(domain)
+    except Exception as exc:
+        domain_data["errors"].append(f"free_enrichment_scrape: {exc}")
+        spider_data = {}
+    try:
+        result = await engine.enrich_from_spider(domain, spider_data or {}) or {}
+    except Exception as exc:
+        domain_data["errors"].append(f"free_enrichment: {exc}")
+        domain_data["dropped_at"] = "free_enrichment"
+        domain_data["drop_reason"] = f"free_enrichment_exception: {exc}"
+        return domain_data
+
+    # Fold enrichment result fields into domain_data so downstream stages
+    # see them. The keys mirror what _process_domain would have written
+    # to BU columns; we expose them on stage2 / stage3 surrogates.
+    domain_data["stage2"] = {
+        **(domain_data.get("stage2") or {}),
+        "website_cms": result.get("website_cms"),
+        "website_tech_stack": result.get("website_tech_stack"),
+        "website_contact_emails": result.get("website_contact_emails"),
+        "dns_mx_provider": result.get("dns_mx_provider"),
+        "dns_has_spf": result.get("dns_has_spf"),
+        "dns_has_dkim": result.get("dns_has_dkim"),
+        "non_au": result.get("non_au"),
+        "serp_abn": result.get("abn"),
+    }
+    if result.get("abn_matched") and result.get("company_name"):
+        existing_stage3 = domain_data.get("stage3") or {}
+        if not existing_stage3.get("business_name"):
+            existing_stage3["business_name"] = result["company_name"]
+            domain_data["stage3"] = existing_stage3
+    return domain_data
 
 
 async def _invoke_runner(
@@ -225,8 +395,11 @@ async def _invoke_runner(
     domain_data: dict[str, Any],
     clients: dict[str, Any],
 ) -> dict[str, Any]:
-    """Dispatch to cohort_runner._run_stageN by label. Imported lazily so
-    tests can patch the cohort_runner module surface."""
+    """Dispatch to cohort_runner._run_stageN by label, or the free_enrichment
+    pseudo-runner. Imported lazily so tests can patch module surfaces."""
+    if runner_label == "free_enrichment":
+        return await _invoke_free_enrichment(domain_data)
+
     from src.orchestration import cohort_runner as cr
 
     fn = getattr(cr, runner_label, None)

--- a/src/orchestration/flows/free_enrichment_flow.py
+++ b/src/orchestration/flows/free_enrichment_flow.py
@@ -1,0 +1,134 @@
+"""Free-mode enrichment flow — Stage 0/1 trigger fix.
+
+Directive: BU Closed-Loop Engine — Substep 3 (paired with bu_closed_loop_flow).
+Purpose:    Catch BU rows that pool_population inserts without setting
+            pipeline_stage (default = 0 / NULL) and run them through
+            FreeEnrichment.run(). 5,022 production rows are stuck at
+            pipeline_stage=0 because the existing FreeEnrichment cursor
+            requires pipeline_stage >= 1.
+
+Posture:    paused=false acceptable — Stage 1 is AUD 0 (local DNS, httpx
+            scraping, local abn_registry lookups, optional Spider fallback
+            which is gated off when SPIDER_API_KEY is unset).
+Schedule:   Hourly safety-net.
+
+Two-phase logic:
+  1. PROMOTE — UPDATE business_universe SET pipeline_stage = 1
+     WHERE pipeline_stage IS NULL OR pipeline_stage = 0
+       AND domain IS NOT NULL.
+     Brings stage-0 rows into the existing FreeEnrichment cursor's reach.
+  2. ENRICH — Invoke FreeEnrichment.run(limit) which uses the cursor
+     (pipeline_stage >= 1 AND free_enrichment_completed_at IS NULL ...)
+     and writes website_*, dns_*, abn_*, free_enrichment_completed_at,
+     and the stage_metrics.stage_completed_at.free_enrichment marker
+     introduced in BU Closed-Loop S1.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncpg
+from prefect import flow, task
+from prefect.cache_policies import NO_CACHE
+
+from src.prefect_utils.completion_hook import on_completion_hook
+from src.prefect_utils.hooks import on_failure_hook
+
+logger = logging.getLogger(__name__)
+
+
+async def _init_jsonb_codec(conn):
+    await conn.set_type_codec(
+        "jsonb",
+        encoder=json.dumps,
+        decoder=json.loads,
+        schema="pg_catalog",
+    )
+
+
+async def _open_pool() -> asyncpg.pool.Pool:
+    db_url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
+    return await asyncpg.create_pool(
+        db_url, min_size=2, max_size=4, statement_cache_size=0, init=_init_jsonb_codec,
+    )
+
+
+@task(name="free-enrichment-promote-stage-0", retries=1, cache_policy=NO_CACHE)
+async def promote_stage_0_rows(pool: asyncpg.pool.Pool) -> int:
+    """Promote BU rows whose pipeline_stage is NULL or 0 to pipeline_stage=1
+    so they enter the FreeEnrichment cursor on the next pass. Returns the
+    number of rows promoted."""
+    async with pool.acquire() as conn:
+        result = await conn.execute(
+            """UPDATE business_universe
+                  SET pipeline_stage = 1, updated_at = NOW()
+                WHERE (pipeline_stage IS NULL OR pipeline_stage = 0)
+                  AND domain IS NOT NULL"""
+        )
+    # asyncpg returns "UPDATE N"; pull the integer suffix.
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+@task(name="free-enrichment-run", retries=0, cache_policy=NO_CACHE)
+async def run_free_enrichment(limit: int) -> dict[str, Any]:
+    """Invoke FreeEnrichment.run(limit). Imported lazily so unit tests can
+    stub the module surface without paying its httpx / dns dependency cost."""
+    from src.pipeline.free_enrichment import FreeEnrichment
+
+    engine = FreeEnrichment()
+    return await engine.run(limit=limit)
+
+
+@flow(
+    name="free-enrichment-flow",
+    on_completion=[on_completion_hook],
+    on_failure=[on_failure_hook],
+)
+async def free_enrichment_flow(
+    limit: int = 500,
+    promote_stage_0: bool = True,
+) -> dict[str, Any]:
+    """Stage 0/1 trigger fix — promotes stage-0 BU rows then runs
+    FreeEnrichment over the resulting backlog.
+
+    Parameters
+    ----------
+    limit:           Max rows for FreeEnrichment.run() per invocation.
+    promote_stage_0: If True (default), bump pipeline_stage NULL/0 to 1
+                     before enrichment runs. Disable for read-only audits.
+    """
+    run_start = datetime.now(UTC).isoformat()
+    pool = await _open_pool()
+
+    summary: dict[str, Any] = {
+        "run_start_ts": run_start,
+        "limit": limit,
+        "promote_stage_0": promote_stage_0,
+        "promoted": 0,
+        "enrichment": {},
+    }
+
+    try:
+        if promote_stage_0:
+            promoted = await promote_stage_0_rows(pool)
+            summary["promoted"] = promoted
+            logger.info("free_enrichment_flow: promoted %d stage-0/NULL rows to stage 1",
+                        promoted)
+        else:
+            logger.info("free_enrichment_flow: promote_stage_0=False — skipping promote step")
+
+        enrichment_stats = await run_free_enrichment(limit)
+        summary["enrichment"] = enrichment_stats
+    finally:
+        await pool.close()
+
+    logger.info("free_enrichment_flow complete: %s",
+                json.dumps(summary, default=str))
+    return summary

--- a/tests/orchestration/flows/test_bu_closed_loop_flow.py
+++ b/tests/orchestration/flows/test_bu_closed_loop_flow.py
@@ -555,6 +555,68 @@ def test_s3_advance_row_invokes_free_enrichment_runner():
     fake_free.assert_awaited_once()
 
 
+def test_s3_1_classify_row_skips_already_free_enriched():
+    """S3-1 regression — stage 1 row whose free_enrichment_completed_at is
+    set must short-circuit with stuck:already_free_enriched BEFORE the
+    runner is invoked. Prevents redundant scrapes once bu_closed_loop_flow
+    eventually unpauses."""
+    from datetime import datetime as _dt
+    row = {
+        "pipeline_stage": 1,
+        "domain": "done.com.au",
+        "propensity_score": 80,
+        "free_enrichment_completed_at": _dt(2026, 1, 1),
+    }
+    out = flow_mod._classify_row(row, free_mode_only=True,
+                                 clients={"gemini": MagicMock()})
+    assert out["action"] == "skip"
+    assert out["reason"] == "stuck:already_free_enriched"
+
+
+def test_s3_1_classify_row_advances_when_free_enrichment_completed_at_is_null():
+    """Same row, free_enrichment_completed_at not set → must advance via
+    free_enrichment runner (the gate is opt-in)."""
+    row = {
+        "pipeline_stage": 1,
+        "domain": "fresh.com.au",
+        "propensity_score": 80,
+        "free_enrichment_completed_at": None,
+    }
+    out = flow_mod._classify_row(row, free_mode_only=True,
+                                 clients={"gemini": MagicMock()})
+    assert out["action"] == "advance"
+    assert out["runner"] == "free_enrichment"
+
+
+def test_s3_1_classify_row_does_not_short_circuit_non_free_enrichment_stages():
+    """The S3-1 gate must only trigger for the free_enrichment runner.
+    A stage-4 row with free_enrichment_completed_at set still advances
+    via _run_stage5 (not free_enrichment) — must not be falsely skipped."""
+    from datetime import datetime as _dt
+    row = {
+        "pipeline_stage": 4,
+        "domain": "downstream.com.au",
+        "propensity_score": 80,
+        "free_enrichment_completed_at": _dt(2026, 1, 1),
+    }
+    out = flow_mod._classify_row(row, free_mode_only=True,
+                                 clients={"gemini": MagicMock()})
+    assert out["action"] == "advance"
+    assert out["runner"] == "_run_stage5"
+
+
+def test_s3_1_fetch_backlog_sql_selects_free_enrichment_completed_at():
+    """fetch_backlog must SELECT the column so the row dict carries it
+    through to _classify_row's pre-flight gate."""
+    import inspect
+    src = inspect.getsource(flow_mod.fetch_backlog)
+    # Inside the stage_age CTE we now project the column.
+    assert "free_enrichment_completed_at" in src
+    # Outer SELECT also propagates it onto the result row.
+    # (Two appearances expected: once inside CTE, once in outer select.)
+    assert src.count("free_enrichment_completed_at") >= 2
+
+
 def test_s3_advance_row_records_free_enrichment_exception_as_runner_early_exit():
     """Free enrichment exception path: dropped_at set, attempt array gets
     an entry, pipeline_stage NOT advanced."""

--- a/tests/orchestration/flows/test_bu_closed_loop_flow.py
+++ b/tests/orchestration/flows/test_bu_closed_loop_flow.py
@@ -28,11 +28,19 @@ from src.orchestration.flows import bu_closed_loop_flow as flow_mod  # noqa: E40
 
 # ── _classify_row unit tests ────────────────────────────────────────────────
 
-def test_classify_row_pre_enrichment_skipped():
+def test_classify_row_pre_enrichment_advances_via_free_enrichment_s3():
+    """S3 — stage 0 / NULL no longer skipped. Routes to the free_enrichment
+    pseudo-runner so the closed-loop driver actually fires Stage 1."""
     row = {"pipeline_stage": 0, "domain": "x.com.au", "propensity_score": 80}
     out = flow_mod._classify_row(row, free_mode_only=True)
-    assert out["action"] == "skip"
-    assert "pre_enrichment" in out["reason"]
+    assert out["action"] == "advance"
+    assert out["runner"] == "free_enrichment"
+    assert out["next_stage"] == 1
+    # Stage NULL should be coerced to 0 and routed identically.
+    row_null = {"pipeline_stage": None, "domain": "y.com.au", "propensity_score": 80}
+    out_null = flow_mod._classify_row(row_null, free_mode_only=True)
+    assert out_null["action"] == "advance"
+    assert out_null["runner"] == "free_enrichment"
 
 
 def test_classify_row_terminal_stage_skipped():
@@ -211,8 +219,10 @@ def test_flow_advances_free_rows_and_blocks_paid_rows():
     assert summary["cadence_days"] == {"hot": 14, "warm": 60, "cold": 180}
 
 
-def test_flow_skips_pre_enrichment_rows():
-    """Rows with pipeline_stage < 2 are owned by free_enrichment, not this flow."""
+def test_flow_advances_pre_enrichment_rows_via_free_enrichment_s3():
+    """S3 — stage 1 row routes to free_enrichment runner and advances on
+    success. Free_enrichment is mocked at module surface so no real DNS /
+    httpx / abn_registry I/O happens."""
     rows = [{"id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
              "domain": "early.com.au", "category": "x",
              "pipeline_stage": 1, "propensity_score": 30,
@@ -222,15 +232,18 @@ def test_flow_skips_pre_enrichment_rows():
     execute_calls: list = []
     pool = _make_pool(execute_calls)
 
+    fake_invoke = AsyncMock(side_effect=lambda d: d)  # no-op; success path
+
     with patch.object(flow_mod, "_open_pool", AsyncMock(return_value=pool)), \
          patch.object(flow_mod.fetch_backlog, "fn", AsyncMock(return_value=rows)), \
+         patch.object(flow_mod, "_invoke_free_enrichment", fake_invoke), \
          patch("src.intelligence.gemini_client.GeminiClient",
                return_value=MagicMock()):
         summary = asyncio.run(flow_mod.bu_closed_loop_flow.fn(max_rows=10))
 
     assert summary["queried"] == 1
-    assert summary["advanced_per_stage"] == {}
-    assert any("pre_enrichment" in k for k in summary["stuck_per_reason"])
+    assert summary["advanced_per_stage"].get("stage_1_to_1") == 1
+    fake_invoke.assert_awaited_once()
 
 
 # ── S2-1 — runner_early_exit must NOT touch stage_completed_at ──────────────
@@ -417,3 +430,155 @@ def test_s2_4_flow_records_gemini_unavailable_when_init_fails():
     assert summary["queried"] == 1
     assert summary["advanced_per_stage"] == {}
     assert summary["stuck_per_reason"].get("stuck:gemini_client_unavailable") == 1
+
+
+# ── S3 — production-grade domain_data reconstruction ─────────────────────────
+
+def test_s3_build_domain_data_pulls_stages_from_stage_metrics_jsonb():
+    """High-fidelity path: stage_metrics jsonb carries stage2/3/4/5 from
+    prior _persist_stage4_to_bu / pipeline_f_master_flow writes. Reconstruction
+    must surface those dicts verbatim."""
+    row = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "domain": "rich.com.au",
+        "category": "dental",
+        "stage_metrics": {
+            "stage2": {"serp_abn": "12345678901"},
+            "stage3": {"business_name": "Rich Dental",
+                       "dm_candidate": {"name": "Dr X"}},
+            "stage4": {"rank_overview": {"organic_etv": 2500.0,
+                                          "organic_keywords": 120}},
+            "stage5": {"composite_score": 78, "is_viable_prospect": True},
+        },
+    }
+    dd = flow_mod._build_domain_data(row)
+    assert dd["domain"] == "rich.com.au"
+    assert dd["category"] == "dental"
+    assert dd["stage2"] == {"serp_abn": "12345678901"}
+    assert dd["stage3"]["business_name"] == "Rich Dental"
+    assert dd["stage4"]["rank_overview"]["organic_etv"] == 2500.0
+    assert dd["stage5"]["composite_score"] == 78
+    # Mutable scaffolding present for runners to write into.
+    assert dd["errors"] == []
+    assert dd["cost_usd"] == 0.0
+    assert dd["timings"] == {}
+    assert dd["dropped_at"] is None
+
+
+def test_s3_build_domain_data_falls_back_to_bu_columns_when_stage_metrics_empty():
+    """Fall-back path: stage_metrics empty (legacy row), reconstruction
+    uses BU column scalars to seed stage3 / stage4 / stage5."""
+    row = {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "domain": "legacy.com.au",
+        "category": "legal",
+        "stage_metrics": {},  # empty
+        "trading_name": "Legacy Legal",
+        "dm_phone": "+61400000000",
+        "linkedin_company_url": "https://linkedin.com/company/legacy",
+        "entity_type": "Company",
+        "dfs_organic_etv": 1500.0,
+        "dfs_organic_keywords": 80,
+        "domain_rank": 35,
+        "backlinks_count": 50,
+        "propensity_score": 65,
+        "score_budget": 18,
+        "score_pain": 16,
+        "score_gap": 17,
+        "score_fit": 14,
+    }
+    dd = flow_mod._build_domain_data(row)
+    # stage3 reconstruction.
+    assert dd["stage3"]["business_name"] == "Legacy Legal"
+    assert dd["stage3"]["dm_candidate"]["phone"] == "+61400000000"
+    assert dd["stage3"]["dm_candidate"]["linkedin_url"] == \
+        "https://linkedin.com/company/legacy"
+    assert dd["stage3"]["entity_type"] == "Company"
+    # stage4 reconstruction.
+    assert dd["stage4"]["rank_overview"]["organic_etv"] == 1500.0
+    assert dd["stage4"]["rank_overview"]["organic_keywords"] == 80
+    assert dd["stage4"]["rank_overview"]["rank"] == 35
+    assert dd["stage4"]["backlinks"]["backlinks_num"] == 50
+    # stage5 reconstruction.
+    assert dd["stage5"]["composite_score"] == 65
+    assert dd["stage5"]["budget"] == 18
+
+
+def test_s3_build_domain_data_handles_jsonb_stored_as_string():
+    """asyncpg fetch returns JSONB as dict only when the codec is registered.
+    Without it, JSONB arrives as a JSON string — reconstruction must coerce."""
+    row = {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "domain": "stringjson.com.au",
+        "category": "x",
+        "stage_metrics": '{"stage4": {"rank_overview": {"organic_etv": 999.0}}}',
+    }
+    dd = flow_mod._build_domain_data(row)
+    assert dd["stage4"]["rank_overview"]["organic_etv"] == 999.0
+
+
+# ── S3 — STAGE_ADVANCEMENT now covers stage 0 / 1 → free_enrichment ──────────
+
+def test_s3_stage_advancement_map_includes_stage_0_and_1():
+    assert 0 in flow_mod.STAGE_ADVANCEMENT
+    assert 1 in flow_mod.STAGE_ADVANCEMENT
+    assert flow_mod.STAGE_ADVANCEMENT[0]["runner"] == "free_enrichment"
+    assert flow_mod.STAGE_ADVANCEMENT[1]["runner"] == "free_enrichment"
+    assert flow_mod.STAGE_ADVANCEMENT[0]["is_free"] is True
+    assert flow_mod.STAGE_ADVANCEMENT[1]["is_free"] is True
+
+
+def test_s3_advance_row_invokes_free_enrichment_runner():
+    """advance_row dispatches the free_enrichment runner via the dedicated
+    pseudo-runner branch in _invoke_runner."""
+    execute_calls: list = []
+    pool = _make_pool(execute_calls)
+
+    row = {"id": "44444444-4444-4444-4444-444444444444",
+           "domain": "stage0.com.au", "category": "dental",
+           "pipeline_stage": 0,
+           "stage_metrics": {}}
+    plan = {"next_stage": 1, "runner": "free_enrichment",
+            "clients": [], "is_free": True}
+
+    fake_free = AsyncMock(side_effect=lambda d: d)  # success: no dropped_at
+
+    with patch.object(flow_mod, "_invoke_free_enrichment", fake_free):
+        result = asyncio.run(
+            flow_mod.advance_row.fn(pool, row, plan, clients={"gemini": None})
+        )
+
+    assert result["outcome"] == "advanced"
+    assert result["from_stage"] == 0
+    assert result["to_stage"] == 1
+    assert result["runner"] == "free_enrichment"
+    fake_free.assert_awaited_once()
+
+
+def test_s3_advance_row_records_free_enrichment_exception_as_runner_early_exit():
+    """Free enrichment exception path: dropped_at set, attempt array gets
+    an entry, pipeline_stage NOT advanced."""
+    execute_calls: list = []
+    pool = _make_pool(execute_calls)
+
+    row = {"id": "55555555-5555-5555-5555-555555555555",
+           "domain": "stage0fail.com.au", "category": "x",
+           "pipeline_stage": 0, "stage_metrics": {}}
+    plan = {"next_stage": 1, "runner": "free_enrichment",
+            "clients": [], "is_free": True}
+
+    async def _fail(d):
+        d["dropped_at"] = "free_enrichment"
+        d["drop_reason"] = "free_enrichment_exception: dns_timeout"
+        return d
+
+    with patch.object(flow_mod, "_invoke_free_enrichment", AsyncMock(side_effect=_fail)):
+        result = asyncio.run(
+            flow_mod.advance_row.fn(pool, row, plan, clients={"gemini": None})
+        )
+
+    assert result["outcome"] == "runner_early_exit"
+    assert "dns_timeout" in result["reason"]
+    sql = execute_calls[0][0]
+    assert "bu_closed_loop_attempts" in sql
+    assert "pipeline_stage" not in sql  # NOT advanced

--- a/tests/orchestration/flows/test_free_enrichment_flow.py
+++ b/tests/orchestration/flows/test_free_enrichment_flow.py
@@ -1,0 +1,115 @@
+"""Tests for src/orchestration/flows/free_enrichment_flow.py.
+
+Hermetic — mocks asyncpg pool + FreeEnrichment.run(). Verifies:
+  - promote_stage_0_rows issues an UPDATE that targets pipeline_stage IS NULL
+    OR pipeline_stage = 0 (and NO other rows).
+  - Returns the integer count parsed from the asyncpg "UPDATE N" status.
+  - free_enrichment_flow performs the two-phase sweep when promote_stage_0=True.
+  - free_enrichment_flow skips the promote step when promote_stage_0=False.
+  - Summary surfaces both promoted and enrichment stats.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+os.environ.setdefault("DATABASE_URL", "postgresql://stub:stub@stub:5432/stub")
+
+from src.orchestration.flows import free_enrichment_flow as fe_flow_mod  # noqa: E402
+
+
+def _make_pool(execute_return: str = "UPDATE 17") -> tuple[MagicMock, MagicMock]:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=execute_return)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=cm)
+    pool.close = AsyncMock(return_value=None)
+    return pool, conn
+
+
+# ── promote_stage_0_rows unit tests ─────────────────────────────────────────
+
+def test_promote_stage_0_rows_targets_null_and_zero_only():
+    pool, conn = _make_pool("UPDATE 42")
+    promoted = asyncio.run(fe_flow_mod.promote_stage_0_rows.fn(pool))
+
+    assert promoted == 42
+    sql = conn.execute.await_args.args[0]
+    # WHERE clause must specifically target NULL or 0.
+    assert "pipeline_stage IS NULL" in sql
+    assert "pipeline_stage = 0" in sql
+    # SET clause must promote to 1.
+    assert "SET pipeline_stage = 1" in sql
+    # Must NOT touch other stages.
+    assert "pipeline_stage = 2" not in sql
+    assert "pipeline_stage > 0" not in sql
+
+
+def test_promote_stage_0_rows_returns_zero_on_unparseable_update_response():
+    pool, conn = _make_pool("not-a-real-update-status")
+    promoted = asyncio.run(fe_flow_mod.promote_stage_0_rows.fn(pool))
+    assert promoted == 0
+
+
+# ── free_enrichment_flow end-to-end tests ───────────────────────────────────
+
+def test_flow_runs_two_phases_when_promote_enabled():
+    """promote_stage_0=True → both promote + enrich tasks run."""
+    pool, conn = _make_pool("UPDATE 100")
+    fake_enrich = AsyncMock(return_value={
+        "total": 100, "completed": 80, "abn_matched": 60,
+        "abn_unmatched": 20, "dns_skipped": 5, "spider_failed": 2, "errors": [],
+    })
+
+    with patch.object(fe_flow_mod, "_open_pool", AsyncMock(return_value=pool)), \
+         patch.object(fe_flow_mod.run_free_enrichment, "fn", fake_enrich):
+        summary = asyncio.run(fe_flow_mod.free_enrichment_flow.fn(
+            limit=100, promote_stage_0=True,
+        ))
+
+    assert summary["promoted"] == 100
+    assert summary["enrichment"]["total"] == 100
+    assert summary["enrichment"]["completed"] == 80
+    assert summary["promote_stage_0"] is True
+    assert summary["limit"] == 100
+    fake_enrich.assert_awaited_once_with(100)
+
+
+def test_flow_skips_promote_when_disabled():
+    """promote_stage_0=False → only enrich runs, promoted stays 0, no UPDATE issued."""
+    pool, conn = _make_pool("UPDATE 999")  # would be 999 if promote ran
+    fake_enrich = AsyncMock(return_value={"total": 0, "completed": 0,
+                                          "abn_matched": 0, "abn_unmatched": 0,
+                                          "dns_skipped": 0, "spider_failed": 0,
+                                          "errors": []})
+
+    with patch.object(fe_flow_mod, "_open_pool", AsyncMock(return_value=pool)), \
+         patch.object(fe_flow_mod.run_free_enrichment, "fn", fake_enrich):
+        summary = asyncio.run(fe_flow_mod.free_enrichment_flow.fn(
+            limit=50, promote_stage_0=False,
+        ))
+
+    assert summary["promoted"] == 0
+    assert summary["promote_stage_0"] is False
+    # Connection.execute should NOT have been called for promote.
+    conn.execute.assert_not_called()
+    fake_enrich.assert_awaited_once_with(50)
+
+
+def test_flow_summary_carries_run_start_and_limit():
+    pool, _ = _make_pool("UPDATE 0")
+    fake_enrich = AsyncMock(return_value={"total": 0})
+
+    with patch.object(fe_flow_mod, "_open_pool", AsyncMock(return_value=pool)), \
+         patch.object(fe_flow_mod.run_free_enrichment, "fn", fake_enrich):
+        summary = asyncio.run(fe_flow_mod.free_enrichment_flow.fn(limit=200))
+
+    assert "run_start_ts" in summary
+    assert summary["limit"] == 200


### PR DESCRIPTION
## Summary
BU Closed-Loop Engine — Substep 3. Two complementary fixes paired in one PR. **AUD 0 spend.**

(a) **Production-grade `domain_data` reconstruction** — replaces the S2 minimal stub so re-entries no longer mostly bounce as `runner_early_exit` on first attempt.
(b) **Stage 0→1 trigger fix** — addresses the 5,022 BU rows stuck at `pipeline_stage=0` because `pool_population_flow.py` inserts GMB rows without setting pipeline_stage and the existing `FreeEnrichment` cursor requires `pipeline_stage >= 1`.

## Files changed (`git diff --stat origin/main`)
```
 prefect.yaml                                       |  23 +++
 .../deployments/free_enrichment_deployment.py      |  38 ++++
 src/orchestration/flows/bu_closed_loop_flow.py     | 227 ++++++++++++++++++---
 src/orchestration/flows/free_enrichment_flow.py    | 134 ++++++++++++
 .../flows/test_bu_closed_loop_flow.py              | 179 +++++++++++++++-
 .../flows/test_free_enrichment_flow.py             | 115 +++++++++++
 6 files changed, 682 insertions(+), 34 deletions(-)
```

## (a) domain_data reconstruction strategy
1. **High-fidelity path** — read `stage_metrics` JSONB on BU. `_persist_stage4_to_bu` and `pipeline_f_master_flow` already write `stage2`/`stage3`/`stage4`/`stage5` keys there.
2. **Fall-back path** — when `stage_metrics` is empty (legacy row, partial state), reconstruct from BU column scalars:
   | Stage | BU columns used |
   |---|---|
   | stage3 | `trading_name` / `abr_trading_name` / `legal_name` + `dm_phone` + `linkedin_company_url` + `entity_type` |
   | stage4 | `dfs_organic_etv`, `dfs_organic_keywords`, `domain_rank`, `backlinks_count` |
   | stage5 | `propensity_score`, `score_budget`/`pain`/`gap`/`fit` |
3. **Defensive coercion** — handle JSONB-as-string (when codec isn't registered).
4. **Mutable scaffolding** — `errors`, `cost_usd`, `timings`, `_latency_tracker` so runners don't crash on missing keys.

## (b) Stage 0→1 root cause + fix
**Root cause** (audited):
- `pool_population_flow.py` line 738 INSERTs BU rows from GMB without setting `pipeline_stage`. Default is NULL/0.
- `src/pipeline/free_enrichment.py` cursor at line 460 requires `pipeline_stage >= 1`. Stage-0 rows are never enriched.
- bu_closed_loop_flow's S2 `_classify_row` skipped stage 0/1 with `stuck:pre_enrichment_owned_by_free_enrichment` — but the supposed owner never fired.

**Fix** (no `src/pipeline/*` edits — wraps existing `FreeEnrichment` class):
- **NEW** `src/orchestration/flows/free_enrichment_flow.py` — two-phase Prefect flow:
  1. PROMOTE: `UPDATE business_universe SET pipeline_stage=1 WHERE pipeline_stage IS NULL OR pipeline_stage=0`
  2. ENRICH: invoke `FreeEnrichment.run(limit)`
- **NEW** `src/orchestration/deployments/free_enrichment_deployment.py` — ACTIVE (`paused=false`), hourly cron `15 * * * *` UTC. AUD 0 (local DNS / httpx / abn_registry; Spider gated by `SPIDER_API_KEY`).
- **prefect.yaml** — `free-enrichment-flow` entry, `paused: false`, `schedules[0].active: true`.
- **bu_closed_loop_flow.STAGE_ADVANCEMENT** — `0 → 1` and `1 → 1` via new `free_enrichment` pseudo-runner; `_classify_row` coerces NULL stage to 0; `_invoke_runner` dispatches the pseudo-runner to `FreeEnrichment.scrape_website` + `enrich_from_spider` and folds results into `domain_data.stage2`/`stage3`.

## Test plan
- [x] `pytest tests/orchestration/flows/test_bu_closed_loop_flow.py tests/orchestration/flows/test_free_enrichment_flow.py` → **31/31 pass**
- [x] `pytest tests/orchestration/` → 84 passed, 1 pre-existing failure (`test_daily_decider_flow::test_aggregates_actions_across_clients` — same on `origin/main`, unrelated)
- [x] `py_compile` clean on all 6 changed files
- [x] AST: free_enrichment_deployment paused=false, is_schedule_active=True
- [x] AST: bu_closed_loop deployment still paused=true (S3 doesn't unpause it)

## Regression tests added
**bu_closed_loop_flow:**
- `test_classify_row_pre_enrichment_advances_via_free_enrichment_s3` (replaces obsolete S2 skip test)
- `test_flow_advances_pre_enrichment_rows_via_free_enrichment_s3` (replaces obsolete S2 skip test)
- `test_s3_build_domain_data_pulls_stages_from_stage_metrics_jsonb`
- `test_s3_build_domain_data_falls_back_to_bu_columns_when_stage_metrics_empty`
- `test_s3_build_domain_data_handles_jsonb_stored_as_string`
- `test_s3_stage_advancement_map_includes_stage_0_and_1`
- `test_s3_advance_row_invokes_free_enrichment_runner`
- `test_s3_advance_row_records_free_enrichment_exception_as_runner_early_exit`

**free_enrichment_flow** (NEW file, 6 tests):
- `test_promote_stage_0_rows_targets_null_and_zero_only`
- `test_promote_stage_0_rows_returns_zero_on_unparseable_update_response`
- `test_flow_runs_two_phases_when_promote_enabled`
- `test_flow_skips_promote_when_disabled`
- `test_flow_summary_carries_run_start_and_limit`

## Not modified
- `src/pipeline/*` (S1 frozen)
- `src/api/*` (ATLAS-owned)
- `src/engines/*`
- `bu_closed_loop_flow` itself stays `paused: true` — only `free_enrichment_flow` becomes ACTIVE under this directive

## Policy
**Dual-concur required**: parent AIDEN + peer ELLIOT must both approve. No self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
