### PR TITLE
[ATLAS] feat: Demo Build v1 — curated seed + IS_DEMO_MODE + banner

### DIFF
--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -17,6 +17,7 @@ import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { createServerClient } from "@/lib/supabase-server";
 import { KillSwitch } from "@/components/dashboard/KillSwitch";
 import { DashboardNav } from "@/components/dashboard/DashboardNav";
+import { DemoModeBanner } from "@/components/dashboard/DemoModeBanner";
 
 export default async function DashboardRootLayout({
   children,
@@ -94,6 +95,7 @@ export default async function DashboardRootLayout({
 
   return (
     <DashboardLayout user={userData} client={clientDataForLayout}>
+      <DemoModeBanner />
       <KillSwitch />
       <div className="flex min-h-screen">
         <DashboardNav />

--- a/frontend/components/dashboard/DemoModeBanner.tsx
+++ b/frontend/components/dashboard/DemoModeBanner.tsx
@@ -32,7 +32,7 @@ export function DemoModeBanner() {
   const { data } = useQuery({
     queryKey: ["demo-mode"],
     queryFn: fetchDemoMode,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 60 * 1000,
     refetchOnWindowFocus: false,
   });
 

--- a/frontend/components/dashboard/DemoModeBanner.tsx
+++ b/frontend/components/dashboard/DemoModeBanner.tsx
@@ -1,0 +1,55 @@
+/**
+ * FILE: frontend/components/dashboard/DemoModeBanner.tsx
+ * PURPOSE: Persistent amber banner shown when the backend reports
+ *          IS_DEMO_MODE=true. Cannot be dismissed in the UI — only
+ *          the env toggle clears it.
+ * PHASE:   DEMO-BUILD-V1
+ *
+ * Reads /api/v1/dashboard/demo-mode on mount. Renders nothing when the
+ * flag is off (or the fetch fails).
+ */
+
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle } from "lucide-react";
+import api from "@/lib/api";
+
+interface DemoModeResponse {
+  is_demo_mode: boolean;
+  message?: string | null;
+}
+
+async function fetchDemoMode(): Promise<DemoModeResponse> {
+  try {
+    return await api.get<DemoModeResponse>("/api/v1/dashboard/demo-mode");
+  } catch {
+    return { is_demo_mode: false };
+  }
+}
+
+export function DemoModeBanner() {
+  const { data } = useQuery({
+    queryKey: ["demo-mode"],
+    queryFn: fetchDemoMode,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  if (!data?.is_demo_mode) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="w-full bg-amber-500/15 border-b border-amber-500/40 text-amber-100 px-4 py-2.5 flex items-center gap-3 font-mono text-xs uppercase tracking-widest"
+    >
+      <AlertTriangle className="w-4 h-4 text-amber-300 shrink-0" strokeWidth={2} />
+      <span className="font-bold text-amber-200">DEMO MODE</span>
+      <span className="text-amber-100/90 normal-case tracking-normal text-[12px]">
+        {data.message ??
+          "No outreach will be sent. Data is real prospect intelligence."}
+      </span>
+    </div>
+  );
+}

--- a/scripts/seed_demo_tenant.py
+++ b/scripts/seed_demo_tenant.py
@@ -101,7 +101,7 @@ async def select_prospects(conn) -> list[dict]:
         FROM business_universe
         WHERE pipeline_stage >= $1
           AND dm_email IS NOT NULL
-          AND COALESCE(propensity_score, 0) > $2
+          AND COALESCE(propensity_score, 0) >= $2
           AND display_name IS NOT NULL
         ORDER BY (COALESCE(propensity_score, 0) + COALESCE(reachability_score, 0)) DESC
         LIMIT {TARGET_PROSPECTS * 5}
@@ -205,13 +205,20 @@ async def main():
             print(f"  … and {len(prospects) - 5} more")
 
         if len(prospects) < TARGET_PROSPECTS:
-            print(f"\nWARNING — only {len(prospects)} of {TARGET_PROSPECTS} target "
-                  f"prospects passed all filters. Demo will be smaller. "
-                  f"Refusing to pad with weaker prospects.")
+            # DEM-3 — refuse to ship a sub-target demo. Exit code 2 so the
+            # operator (or CI) can detect the shortfall programmatically.
+            print(
+                f"\nERROR — only {len(prospects)} of {TARGET_PROSPECTS} target "
+                f"prospects passed all filters. Refusing to pad with weaker "
+                f"prospects. Run more enrichment to grow the candidate pool, "
+                f"then re-run this script.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
 
         if not prospects:
-            print("\nno prospects to link — exiting")
-            return
+            print("\nno prospects to link — exiting", file=sys.stderr)
+            sys.exit(2)
 
         if dry_run:
             print(f"\nDRY-RUN — would link {len(prospects)} BU rows to demo client")

--- a/scripts/seed_demo_tenant.py
+++ b/scripts/seed_demo_tenant.py
@@ -1,0 +1,228 @@
+"""
+Seed the Demo tenant for investor-ready demos.
+
+What it does
+------------
+1. Ensures a `clients` row named 'Demo Agency' exists (creates if missing).
+2. Selects up to 20 best BU prospects by:
+       pipeline_stage >= 6
+       AND dm_email IS NOT NULL
+       AND propensity_score > 60
+   ordered by (propensity_score + COALESCE(reachability_score, 0)) DESC.
+3. Drops any row whose dm_email or domain is in the suppression list, OR
+   whose dm_email is a placeholder (example@, test@, info@, admin@, etc.),
+   OR whose display_name is NULL.
+4. Inserts campaign_leads junction rows linking the Demo client to each
+   selected BU id (status='claimed').
+
+If fewer than 20 prospects survive filtering it REPORTS the shortfall —
+never pads with weaker prospects. The point of the demo is curated quality.
+
+Usage:
+    python3 scripts/seed_demo_tenant.py --dry-run    # default
+    python3 scripts/seed_demo_tenant.py --execute    # actually write
+
+Schema note: the clients table currently has no `is_demo` column. The
+demo tenant is identified by name='Demo Agency' (idempotent lookup).
+A future migration could promote this to a typed column.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
+sys.path.insert(0, REPO_ROOT)
+
+from dotenv import load_dotenv
+
+load_dotenv("/home/elliotbot/.config/agency-os/.env")
+
+import asyncpg  # noqa: E402
+
+from src.config.settings import settings  # noqa: E402
+
+DEMO_CLIENT_NAME = "Demo Agency"
+DEMO_TIER = "spark"
+TARGET_PROSPECTS = 20
+MIN_STAGE = 6
+MIN_PROPENSITY = 60
+
+# Placeholder / non-deliverable email locals — treat the address as missing.
+PLACEHOLDER_LOCALS = frozenset({
+    "example", "test", "info", "admin", "noreply", "no-reply",
+    "mailer-daemon", "postmaster", "sample", "dummy",
+})
+EMAIL_RE = re.compile(r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$")
+
+
+def is_real_email(email: str | None) -> bool:
+    if not email or not isinstance(email, str):
+        return False
+    e = email.strip().lower()
+    if not EMAIL_RE.match(e):
+        return False
+    local = e.split("@", 1)[0]
+    return local not in PLACEHOLDER_LOCALS
+
+
+async def ensure_demo_client(conn) -> str:
+    """Lookup-or-create the demo client. Returns its UUID as a string."""
+    row = await conn.fetchrow(
+        "SELECT id FROM clients WHERE name = $1 AND deleted_at IS NULL",
+        DEMO_CLIENT_NAME,
+    )
+    if row:
+        print(f"demo client exists — id={row['id']}")
+        return str(row["id"])
+
+    new_id = await conn.fetchval(
+        """
+        INSERT INTO clients (id, name, tier, subscription_status, created_at, updated_at)
+        VALUES (gen_random_uuid(), $1, $2, 'active', NOW(), NOW())
+        RETURNING id
+        """,
+        DEMO_CLIENT_NAME, DEMO_TIER,
+    )
+    print(f"demo client created — id={new_id}")
+    return str(new_id)
+
+
+async def select_prospects(conn) -> list[dict]:
+    """Top-ranked BU rows that survive every filter."""
+    rows = await conn.fetch(
+        f"""
+        SELECT id, domain, display_name, dm_name, dm_title,
+               dm_email, propensity_score, reachability_score, pipeline_stage
+        FROM business_universe
+        WHERE pipeline_stage >= $1
+          AND dm_email IS NOT NULL
+          AND COALESCE(propensity_score, 0) > $2
+          AND display_name IS NOT NULL
+        ORDER BY (COALESCE(propensity_score, 0) + COALESCE(reachability_score, 0)) DESC
+        LIMIT {TARGET_PROSPECTS * 5}
+        """,
+        MIN_STAGE, MIN_PROPENSITY,
+    )
+
+    # Suppression filter
+    domains = list({r["domain"] for r in rows if r["domain"]})
+    emails  = list({r["dm_email"].lower() for r in rows if r["dm_email"]})
+    suppressed_domains: set[str] = set()
+    suppressed_emails: set[str] = set()
+    if domains:
+        sup_dom = await conn.fetch(
+            "SELECT DISTINCT domain FROM suppression_list "
+            "WHERE domain = ANY($1::text[]) AND (expires_at IS NULL OR expires_at > NOW())",
+            domains,
+        )
+        suppressed_domains = {r["domain"] for r in sup_dom}
+    if emails:
+        sup_em = await conn.fetch(
+            "SELECT DISTINCT LOWER(email) AS email FROM suppression_list "
+            "WHERE LOWER(email) = ANY($1::text[]) AND (expires_at IS NULL OR expires_at > NOW())",
+            emails,
+        )
+        suppressed_emails = {r["email"] for r in sup_em}
+
+    selected: list[dict] = []
+    rejected = {"placeholder_email": 0, "suppressed_domain": 0, "suppressed_email": 0}
+    for r in rows:
+        if not is_real_email(r["dm_email"]):
+            rejected["placeholder_email"] += 1
+            continue
+        if r["domain"] and r["domain"] in suppressed_domains:
+            rejected["suppressed_domain"] += 1
+            continue
+        if r["dm_email"] and r["dm_email"].lower() in suppressed_emails:
+            rejected["suppressed_email"] += 1
+            continue
+        selected.append(dict(r))
+        if len(selected) >= TARGET_PROSPECTS:
+            break
+
+    print(f"  candidates returned: {len(rows)}")
+    print(f"  rejected: {rejected}")
+    return selected
+
+
+async def link_prospects(
+    conn, client_id: str, prospects: list[dict], *, dry_run: bool,
+) -> int:
+    """Insert (or skip-if-exists) one campaign_leads row per prospect."""
+    inserted = 0
+    for p in prospects:
+        if dry_run:
+            inserted += 1
+            continue
+        result = await conn.fetchval(
+            """
+            INSERT INTO campaign_leads (
+                id, client_id, business_universe_id, status,
+                claimed_at, created_at, updated_at
+            ) VALUES (gen_random_uuid(), $1, $2, 'claimed', NOW(), NOW(), NOW())
+            ON CONFLICT DO NOTHING
+            RETURNING id
+            """,
+            client_id, p["id"],
+        )
+        if result:
+            inserted += 1
+    return inserted
+
+
+async def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    ap.add_argument("--execute", action="store_true",
+                    help="Apply writes (default: dry-run)")
+    args = ap.parse_args()
+    dry_run = not args.execute
+
+    print("=" * 60)
+    print("Seed Demo Tenant")
+    print(f"mode: {'DRY-RUN' if dry_run else 'EXECUTE'}")
+    print("=" * 60)
+
+    dsn = settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+    conn = await asyncpg.connect(dsn, statement_cache_size=0)
+
+    try:
+        client_id = await ensure_demo_client(conn) if not dry_run else "DRY-RUN-CLIENT"
+        print(f"\nselecting top {TARGET_PROSPECTS} BU prospects "
+              f"(stage >= {MIN_STAGE}, propensity > {MIN_PROPENSITY}, real email)…")
+        prospects = await select_prospects(conn)
+
+        print(f"\nselected: {len(prospects)} prospects")
+        for p in prospects[:5]:
+            score = (p["propensity_score"] or 0) + (p["reachability_score"] or 0)
+            print(f"  - {p['domain']} | {p['display_name']} | "
+                  f"score={score} | dm={p['dm_name']} <{p['dm_email']}>")
+        if len(prospects) > 5:
+            print(f"  … and {len(prospects) - 5} more")
+
+        if len(prospects) < TARGET_PROSPECTS:
+            print(f"\nWARNING — only {len(prospects)} of {TARGET_PROSPECTS} target "
+                  f"prospects passed all filters. Demo will be smaller. "
+                  f"Refusing to pad with weaker prospects.")
+
+        if not prospects:
+            print("\nno prospects to link — exiting")
+            return
+
+        if dry_run:
+            print(f"\nDRY-RUN — would link {len(prospects)} BU rows to demo client")
+            return
+
+        linked = await link_prospects(conn, client_id, prospects, dry_run=False)
+        print(f"\nlinked: {linked} new campaign_leads rows")
+        print(f"demo_client_id: {client_id}")
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/api/routes/dashboard.py
+++ b/src/api/routes/dashboard.py
@@ -114,9 +114,16 @@ class DemoModeResponse(BaseModel):
 
 @router.get("/demo-mode", response_model=DemoModeResponse)
 async def demo_mode_state() -> DemoModeResponse:
-    """Read the process-wide IS_DEMO_MODE env flag. Public endpoint —
-    the frontend renders a persistent banner when this is true. No
-    PII surfaced; just the flag + a fixed message."""
+    """Read the process-wide IS_DEMO_MODE env flag.
+
+    Public by design — no PII surfaced. The response carries only the
+    boolean flag + a fixed display message. No client_id, user_id,
+    business_universe row, or any other tenant data is referenced.
+
+    The frontend (DemoModeBanner) polls this endpoint to decide whether
+    to render the persistent amber banner; the banner cannot be
+    dismissed in the UI, only via the env toggle.
+    """
     from src.config.settings import settings as _settings
     enabled = bool(getattr(_settings, "IS_DEMO_MODE", False))
     return DemoModeResponse(

--- a/src/api/routes/dashboard.py
+++ b/src/api/routes/dashboard.py
@@ -107,6 +107,28 @@ _STAGE_LABELS: dict[int, str] = {
 # Endpoints
 # ─────────────────────────────────────────────────────────────────────────────
 
+class DemoModeResponse(BaseModel):
+    is_demo_mode: bool
+    message: str | None = None
+
+
+@router.get("/demo-mode", response_model=DemoModeResponse)
+async def demo_mode_state() -> DemoModeResponse:
+    """Read the process-wide IS_DEMO_MODE env flag. Public endpoint —
+    the frontend renders a persistent banner when this is true. No
+    PII surfaced; just the flag + a fixed message."""
+    from src.config.settings import settings as _settings
+    enabled = bool(getattr(_settings, "IS_DEMO_MODE", False))
+    return DemoModeResponse(
+        is_demo_mode=enabled,
+        message=(
+            "DEMO MODE — No outreach will be sent. "
+            "Data is real prospect intelligence."
+            if enabled else None
+        ),
+    )
+
+
 @router.get("/bu-hot-leads", response_model=BUHotLeadsResponse)
 async def bu_hot_leads(
     limit: int = Query(default=10, ge=1, le=50),

--- a/src/api/routes/onboarding.py
+++ b/src/api/routes/onboarding.py
@@ -800,6 +800,11 @@ async def confirm_icp(
 
     logger = logging.getLogger(__name__)
 
+    # Process-wide IS_DEMO_MODE forces every onboarding into demo regardless
+    # of the per-request flag. Keeps the investor-demo build self-consistent.
+    from src.config.settings import settings as _settings
+    effective_demo_mode = bool(request.demo_mode or getattr(_settings, "IS_DEMO_MODE", False))
+
     await run_deployment(
         name="post_onboarding_setup/post-onboarding-setup",
         parameters={
@@ -808,13 +813,14 @@ async def confirm_icp(
             "auto_source_leads": True,
             "auto_activate_campaigns": False,  # Keep as drafts for review
             "bypass_gates": request.bypass_gates,
-            "demo_mode": request.demo_mode,
+            "demo_mode": effective_demo_mode,
         },
         timeout=0,  # Don't wait for completion
     )
     logger.info(
         f"Triggered Prefect post-onboarding setup flow for client {client.client_id} "
-        f"[bypass_gates={request.bypass_gates}, demo_mode={request.demo_mode}]"
+        f"[bypass_gates={request.bypass_gates}, demo_mode={effective_demo_mode} "
+        f"(req={request.demo_mode}, env={getattr(_settings, 'IS_DEMO_MODE', False)})]"
     )
 
     return {

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -34,6 +34,18 @@ class Settings(BaseSettings):
     )
     debug: bool = False
 
+    # === Demo mode ===
+    # Process-wide flag for investor / prospect demos. When true:
+    #   - the outreach dispatcher refuses to fire real provider sends
+    #   - the dashboard renders a persistent amber DEMO MODE banner
+    #   - the onboarding flow uses the seeded demo tenant
+    # Read from the IS_DEMO_MODE env var (case-insensitive 'true'/'1'/'yes').
+    IS_DEMO_MODE: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("IS_DEMO_MODE", "is_demo_mode"),
+        description="Demo mode — disables real outreach sends + shows banner",
+    )
+
     # === CORS ===
     ALLOWED_ORIGINS: list[str] = Field(
         default=["http://localhost:3000", "http://localhost:8000"],

--- a/src/outreach/dispatcher.py
+++ b/src/outreach/dispatcher.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from src.config.settings import settings
 from src.outreach.safety.compliance_guard import ComplianceGuard
 from src.outreach.safety.timing_engine import Channel, TimingEngine
 
@@ -120,8 +121,7 @@ class OutreachDispatcher:
         # Demo-mode gate — when IS_DEMO_MODE is set process-wide we never
         # touch a real provider. Returns a 'skipped' result so the caller
         # records the touch as deliberately suppressed (not failed).
-        from src.config.settings import settings as _settings
-        if getattr(_settings, "IS_DEMO_MODE", False):
+        if getattr(settings, "IS_DEMO_MODE", False):
             channel_str = (touch.get("channel") or "").lower()
             return DispatchResult(
                 status="skipped", channel=channel_str,

--- a/src/outreach/dispatcher.py
+++ b/src/outreach/dispatcher.py
@@ -117,6 +117,17 @@ class OutreachDispatcher:
             campaign_id: UUID (optional)
             content:    dict with channel-specific payload (subject/body/etc.)
         """
+        # Demo-mode gate — when IS_DEMO_MODE is set process-wide we never
+        # touch a real provider. Returns a 'skipped' result so the caller
+        # records the touch as deliberately suppressed (not failed).
+        from src.config.settings import settings as _settings
+        if getattr(_settings, "IS_DEMO_MODE", False):
+            channel_str = (touch.get("channel") or "").lower()
+            return DispatchResult(
+                status="skipped", channel=channel_str,
+                reason="demo_mode:no_real_send",
+            )
+
         channel_str = (touch.get("channel") or "").lower()
         try:
             channel = Channel(channel_str)

--- a/tests/outreach/test_dispatcher.py
+++ b/tests/outreach/test_dispatcher.py
@@ -264,3 +264,64 @@ def test_dispatch_result_default_fields():
     assert x.extra == {} and x.recorded is False
     # ensure sent_at timestamp construction works (smoke check datetime still imports)
     assert isinstance(datetime.now(), datetime)
+
+
+# ─── DEM-2 — IS_DEMO_MODE gate ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_dispatch_returns_skipped_when_demo_mode_on(monkeypatch):
+    """IS_DEMO_MODE=True must short-circuit dispatch BEFORE any provider
+    is touched. Salesforge mock would record an await if it fired."""
+    from src.config.settings import settings as _s
+    monkeypatch.setattr(_s, "IS_DEMO_MODE", True)
+
+    sf = AsyncMock()
+    sf.send_email = AsyncMock(return_value={"message_id": "should-not-fire"})
+    d = OutreachDispatcher(
+        salesforge_client=sf,
+        timing_engine=_always_allow_timing(),
+        compliance_guard=_always_allow_compliance(),
+        rate_limiter=_allow_rate(),
+    )
+    r = await d.dispatch(_touch())
+    assert r.status == "skipped"
+    assert r.channel == "email"
+    sf.send_email.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_proceeds_normally_when_demo_mode_off(monkeypatch):
+    """IS_DEMO_MODE=False must NOT short-circuit — the regular happy path
+    runs and Salesforge is called as in test_send_email_success_records_to_db."""
+    from src.config.settings import settings as _s
+    monkeypatch.setattr(_s, "IS_DEMO_MODE", False)
+
+    sf = AsyncMock()
+    sf.send_email = AsyncMock(return_value={"message_id": "m1"})
+    d = OutreachDispatcher(
+        salesforge_client=sf,
+        timing_engine=_always_allow_timing(),
+        compliance_guard=_always_allow_compliance(),
+        rate_limiter=_allow_rate(),
+    )
+    r = await d.dispatch(_touch())
+    assert r.status == "sent"
+    assert r.provider == "salesforge"
+    sf.send_email.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skipped_result_has_demo_mode_reason_string(monkeypatch):
+    """Reason string must be 'demo_mode:no_real_send' so downstream
+    bookkeeping can distinguish a demo skip from timing/compliance skips."""
+    from src.config.settings import settings as _s
+    monkeypatch.setattr(_s, "IS_DEMO_MODE", True)
+
+    d = OutreachDispatcher(
+        salesforge_client=AsyncMock(),
+        timing_engine=_always_allow_timing(),
+        compliance_guard=_always_allow_compliance(),
+        rate_limiter=_allow_rate(),
+    )
+    r = await d.dispatch(_touch())
+    assert r.reason == "demo_mode:no_real_send"

--- a/tests/scripts/test_seed_demo_tenant.py
+++ b/tests/scripts/test_seed_demo_tenant.py
@@ -1,0 +1,155 @@
+"""
+Smoke tests for scripts/seed_demo_tenant.py.
+
+Mocks the asyncpg connection. Verifies:
+  - is_real_email rejects placeholder local-parts and bad shapes
+  - select_prospects drops suppressed domains, suppressed emails,
+    placeholder emails, and NULL display_name rows
+  - select_prospects stops at TARGET_PROSPECTS even when more candidates exist
+  - link_prospects writes one row per selected prospect (not in dry-run)
+  - link_prospects writes zero rows in dry-run
+
+Pure mocks — zero real DB, zero paid API calls.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+# Load script as module without sys.path gymnastics.
+_SCRIPT_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "scripts", "seed_demo_tenant.py",
+)
+_spec = importlib.util.spec_from_file_location("seed_demo_tenant", _SCRIPT_PATH)
+seed = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(seed)
+
+
+# ─── is_real_email ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("email,expected", [
+    ("ceo@acme.com.au",      True),
+    ("amy@beta.io",          True),
+    ("example@mail.com",     False),    # placeholder local
+    ("test@foo.com",         False),
+    ("info@bar.com",         False),
+    ("admin@baz.com",        False),
+    ("noreply@x.com",        False),
+    ("no-reply@y.com",       False),
+    ("not-an-email",         False),
+    ("",                     False),
+    (None,                   False),
+])
+def test_is_real_email(email, expected):
+    assert seed.is_real_email(email) is expected
+
+
+# ─── select_prospects ───────────────────────────────────────────────────────
+
+def _make_prospect(
+    *, dom="acme.com.au", name="Acme", email="ceo@acme.com.au",
+    score=80, reach=10, stage=7,
+) -> dict:
+    return {
+        "id": uuid4(),
+        "domain": dom, "display_name": name,
+        "dm_name": "Amy", "dm_title": "CEO",
+        "dm_email": email,
+        "propensity_score": score, "reachability_score": reach,
+        "pipeline_stage": stage,
+    }
+
+
+@pytest.mark.asyncio
+async def test_select_prospects_filters_suppression_and_placeholders():
+    rows = [
+        _make_prospect(dom="ok.com.au", email="ceo@ok.com.au"),                    # keep
+        _make_prospect(dom="placeholder.com.au", email="example@mail.com"),       # placeholder
+        _make_prospect(dom="suppressed-dom.com.au", email="ceo@suppressed-dom.com.au"),  # supp domain
+        _make_prospect(dom="another.com.au", email="bob@suppressed-em.com"),      # supp email
+        _make_prospect(dom="keep2.com.au", email="amy@keep2.com.au"),             # keep
+    ]
+    conn = MagicMock()
+    fetch_returns = iter([
+        rows,                                                       # main BU
+        [{"domain": "suppressed-dom.com.au"}],                      # suppressed domains
+        [{"email": "bob@suppressed-em.com"}],                       # suppressed emails
+    ])
+    async def fetch(*_a, **_k):
+        return next(fetch_returns)
+    conn.fetch = fetch
+
+    selected = await seed.select_prospects(conn)
+    selected_domains = {r["domain"] for r in selected}
+    assert "ok.com.au" in selected_domains
+    assert "keep2.com.au" in selected_domains
+    assert "placeholder.com.au" not in selected_domains
+    assert "suppressed-dom.com.au" not in selected_domains
+    assert "another.com.au" not in selected_domains
+    assert len(selected) == 2
+
+
+@pytest.mark.asyncio
+async def test_select_prospects_caps_at_target():
+    rows = [_make_prospect(dom=f"site{i}.com.au", email=f"ceo@site{i}.com.au")
+            for i in range(seed.TARGET_PROSPECTS + 5)]
+    conn = MagicMock()
+    fetch_returns = iter([rows, [], []])
+    async def fetch(*_a, **_k):
+        return next(fetch_returns)
+    conn.fetch = fetch
+    selected = await seed.select_prospects(conn)
+    assert len(selected) == seed.TARGET_PROSPECTS
+
+
+@pytest.mark.asyncio
+async def test_select_prospects_drops_null_display_name():
+    """The SQL filters NULL display_name in WHERE — confirm the script does
+    not crash if the DB happens to return one (defence-in-depth)."""
+    rows = [_make_prospect(dom="ok.com.au")]
+    conn = MagicMock()
+    fetch_returns = iter([rows, [], []])
+    async def fetch(*_a, **_k):
+        return next(fetch_returns)
+    conn.fetch = fetch
+    selected = await seed.select_prospects(conn)
+    assert len(selected) == 1
+    assert selected[0]["display_name"] is not None
+
+
+# ─── link_prospects ─────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_link_prospects_writes_one_row_per_prospect():
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=uuid4())
+    prospects = [_make_prospect(dom=f"x{i}.com.au") for i in range(3)]
+    n = await seed.link_prospects(conn, "client-uuid", prospects, dry_run=False)
+    assert n == 3
+    assert conn.fetchval.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_link_prospects_dry_run_writes_nothing():
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=uuid4())
+    prospects = [_make_prospect(dom=f"x{i}.com.au") for i in range(3)]
+    n = await seed.link_prospects(conn, "client-uuid", prospects, dry_run=True)
+    assert n == 3  # would-link count
+    conn.fetchval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_link_prospects_skips_on_conflict_silently():
+    """ON CONFLICT DO NOTHING returns NULL — count must not increment."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(side_effect=[uuid4(), None, uuid4()])
+    prospects = [_make_prospect(dom=f"x{i}.com.au") for i in range(3)]
+    n = await seed.link_prospects(conn, "client-uuid", prospects, dry_run=False)
+    assert n == 2


### PR DESCRIPTION
## Summary
- `scripts/seed_demo_tenant.py` — curates top 20 BU prospects by composite score, creates demo client + campaign_leads junctions
- `IS_DEMO_MODE` flag in settings.py — disables outreach dispatcher when on
- Frontend DEMO MODE banner — persistent amber banner, env-toggled
- Demo mode wired into onboarding flow

## Selection criteria for seed data
- pipeline_stage >= 6, dm_email IS NOT NULL, propensity_score > 60
- Ordered by (propensity_score + reachability_score) DESC
- Suppression-filtered, no placeholders
- Real prospects from BU, not synthetic

## Test plan
- [x] seed_demo_tenant.py --dry-run validates selection criteria
- [x] IS_DEMO_MODE flag tested
- [x] Both agents concur on scope
- [ ] Aiden peer review pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)