### PR TITLE
[ORION] feat(outreach): C1 budget cap — per-domain + per-customer admission gates

### DIFF
--- a/src/orchestration/flows/outreach_flow.py
+++ b/src/orchestration/flows/outreach_flow.py
@@ -77,16 +77,15 @@ logger = logging.getLogger(__name__)
 # control before any paid send, hard caps per-domain and per-customer,
 # structured skip rows (not silent drops) so CIS records the refusal.
 #
+# OB-5: Channel costs are inlined here as the canonical source for the
+# outreach gate. Future updates should align with src/config/settings.py
+# (sdk_daily_budget_aud_*) and the per-engine cost constants in
+# src/engines/voice_agent_telnyx.py (COSTS_AUD["total_per_minute"]).
 # AUD costs sourced from production engine constants:
 #   - Email (Resend):      $0.0006 AUD per send (Resend list price)
 #   - LinkedIn (Unipile):  $0.10   AUD per message
 #   - SMS (Telnyx):        $0.014  AUD per message
 #   - Voice (Telnyx 1min): $0.14   AUD per minute (see voice_agent_telnyx.py L23)
-#
-# Per-tier daily AUD ceilings track the SDK budget envelope from
-# src/config/settings.py (sdk_daily_budget_aud_*). These are hard ceilings
-# at the customer level — they include all paid surfaces, not just outreach.
-# Keeping outreach under these caps preserves head-room for SDK enrichment.
 CHANNEL_COST_AUD: dict[str, float] = {
     "email":    0.0006,
     "linkedin": 0.10,
@@ -94,9 +93,11 @@ CHANNEL_COST_AUD: dict[str, float] = {
     "voice":    0.14,
 }
 
-# Per-domain AUD cap — refuse-to-send when one domain has accumulated this
-# much spend in the rolling 24-hour window. Stops a single domain from
-# eating the customer's daily envelope on its own.
+# OB-4: Per-domain AUD cap — hardcoded at $5/day for launch. Roadmap polish:
+# this should become per-customer-tier configurable post-revenue (e.g., a
+# clients.outreach_domain_cap_aud column or a per-tier multiplier so
+# velocity customers can run multi-touch sequences against high-value
+# domains without artificially low ceilings).
 DEFAULT_DOMAIN_DAILY_AUD_CAP: float = 5.0
 
 # Per-customer per-tier daily AUD cap. Tracks src/config/settings.py SDK
@@ -110,10 +111,42 @@ TIER_DAILY_AUD_CAP: dict[str, float] = {
     "dominance": 100.0,
 }
 
+# OB-2: Module-level constant replaces the previous _today_window_sql() helper.
+# OB-6: Aligned to CURRENT_DATE (calendar-day in DB server timezone, UTC on
+# our infra) — matches the canonical daily-quota pattern used by
+# src/services/jit_validator.py:_check_rate_limits at line 431. Stripe has
+# NO daily rule (only monthly subscription anchor in current_period_start);
+# the cap resets at UTC midnight, consistent with the JIT rate limiter.
+_SPEND_WINDOW_SQL: str = "CURRENT_DATE"
 
-def _today_window_sql() -> str:
-    """ISO snippet — last 24 hours (rolling window matches Stripe day rule)."""
-    return "NOW() - INTERVAL '24 hours'"
+
+def _emit_snapshot_failure_alert(stage: str, exc: Exception) -> None:
+    """OB-1 — loud-but-non-blocking alert when the snapshot SQL silently
+    fails. Without this signal the in-memory gate cannot be trusted: a
+    cleared snapshot lets the flow front-load up to ~41,666 emails (at
+    $0.0006/send) before the in-memory delta hits the $25 spark cap.
+
+    logger.error tags the failure for log-scrape pickup. Best-effort
+    Telegram broadcast via src/prefect_utils/failure_alert.py — failure
+    of the alert itself is swallowed so the flow stays running.
+    """
+    logger.error(
+        "outreach_budget_snapshot_alert stage=%s exc_type=%s: %s "
+        "(in-memory gate untrusted — investigate prospect_telemetry / clients tables)",
+        stage, type(exc).__name__, exc,
+    )
+    try:
+        from src.prefect_utils.failure_alert import send_failure_alert
+        send_failure_alert(
+            flow_name="hourly_outreach",
+            flow_run_id=f"snapshot:{stage}",
+            error_message=f"snapshot_outreach_spend {stage} fetch failed: "
+                          f"{type(exc).__name__}: {exc}",
+            timestamp=datetime.now(UTC).isoformat(),
+        )
+    except Exception as alert_exc:
+        logger.error("outreach_budget_snapshot_alert: telegram emit failed: %s",
+                     alert_exc)
 
 
 @task(name="snapshot_outreach_spend", retries=1, retry_delay_seconds=2)
@@ -121,9 +154,9 @@ async def snapshot_outreach_spend_task(
     client_ids: list[str],
     domains: list[str],
 ) -> dict[str, dict[str, float]]:
-    """Pre-loop snapshot of last-24h outreach spend, grouped per-customer
-    and per-domain. The hourly_outreach_flow consults this snapshot before
-    each send to gate admission.
+    """Pre-loop snapshot of today's outreach spend (calendar-day-UTC),
+    grouped per-customer and per-domain. The hourly_outreach_flow consults
+    this snapshot before each send to gate admission.
 
     Returns:
         {
@@ -137,9 +170,12 @@ async def snapshot_outreach_spend_task(
         - prospect_telemetry (cost_aud column, JOIN leads for client/domain).
         - clients table (credits_remaining + tier).
 
-    All queries are best-effort: a Supabase outage degrades to "no spend
-    today" rather than blocking the flow. Defence-in-depth — the gate fires
-    again per-iteration on the in-memory delta.
+    Failure mode: queries are best-effort — a Supabase outage degrades to
+    "no spend today" rather than blocking the flow. Each failure path
+    emits a loud alert via _emit_snapshot_failure_alert (OB-1) so silent
+    front-loading of cap-bypassing sends is impossible without an audit
+    trail. Defence-in-depth: the per-iteration in-memory delta gate fires
+    independently.
     """
     snapshot: dict[str, dict[str, float]] = {
         "by_client": {cid: 0.0 for cid in client_ids},
@@ -151,8 +187,8 @@ async def snapshot_outreach_spend_task(
         return snapshot
 
     async with get_db_session() as db:
-        # Customer-level cost rollup (last 24h) — JOIN leads to attribute
-        # telemetry rows back to a client_id.
+        # Customer-level cost rollup (today, calendar-day-UTC) — JOIN leads
+        # to attribute telemetry rows back to a client_id.
         try:
             cost_by_client_q = text(f"""
                 SELECT l.client_id::text AS client_id,
@@ -161,7 +197,7 @@ async def snapshot_outreach_spend_task(
                   JOIN leads l ON l.id = t.prospect_id
                  WHERE l.client_id = ANY(:client_ids::uuid[])
                    AND t.event_type = 'touch'
-                   AND t.created_at >= {_today_window_sql()}
+                   AND t.created_at >= {_SPEND_WINDOW_SQL}
                  GROUP BY l.client_id
             """)
             result = await db.execute(
@@ -170,10 +206,9 @@ async def snapshot_outreach_spend_task(
             for row in result:
                 snapshot["by_client"][row.client_id] = float(row.spend_aud or 0.0)
         except Exception as exc:
-            logger.warning("snapshot_outreach_spend: by_client fetch failed (non-fatal): %s",
-                           exc)
+            _emit_snapshot_failure_alert("by_client", exc)
 
-        # Domain-level cost rollup (last 24h).
+        # Domain-level cost rollup (today, calendar-day-UTC).
         if any(d for d in domains):
             try:
                 cost_by_domain_q = text(f"""
@@ -183,7 +218,7 @@ async def snapshot_outreach_spend_task(
                       JOIN leads l ON l.id = t.prospect_id
                      WHERE l.domain = ANY(:domains::text[])
                        AND t.event_type = 'touch'
-                       AND t.created_at >= {_today_window_sql()}
+                       AND t.created_at >= {_SPEND_WINDOW_SQL}
                      GROUP BY l.domain
                 """)
                 result = await db.execute(
@@ -194,8 +229,7 @@ async def snapshot_outreach_spend_task(
                     if row.domain:
                         snapshot["by_domain"][row.domain] = float(row.spend_aud or 0.0)
             except Exception as exc:
-                logger.warning("snapshot_outreach_spend: by_domain fetch failed (non-fatal): %s",
-                               exc)
+                _emit_snapshot_failure_alert("by_domain", exc)
 
         # credits_remaining + tier per client.
         try:
@@ -212,8 +246,7 @@ async def snapshot_outreach_spend_task(
                 snapshot["by_client_credits"][row.id] = int(row.credits_remaining or 0)
                 snapshot["by_client_tier"][row.id] = (row.tier or "ignition").lower()
         except Exception as exc:
-            logger.warning("snapshot_outreach_spend: clients fetch failed (non-fatal): %s",
-                           exc)
+            _emit_snapshot_failure_alert("clients", exc)
 
     return snapshot
 
@@ -771,12 +804,18 @@ async def get_leads_ready_for_outreach_task(limit: int = 50) -> dict[str, Any]:
                 tier,
             ) = row
 
+            # OB-3: Client.tier is a TierType StrEnum mapped column with NOT NULL
+            # in src/models/client.py — the .value branch is the only one that
+            # fires in production. The "ignition" fallback covers the strictly
+            # unreachable None path (defensive against future ORM changes that
+            # could relax the constraint). No str() coercion needed.
+            tier_value = tier.value if tier is not None else "ignition"
             lead_data = {
                 "lead_id": str(lead_id),
                 "client_id": str(client_id),
                 "campaign_id": str(campaign_id),
                 "domain": domain or "",
-                "tier": tier.value if hasattr(tier, "value") else (str(tier) if tier else "ignition"),
+                "tier": tier_value,
                 "permission_mode": permission_mode.value if permission_mode else "co_pilot",
             }
 

--- a/src/orchestration/flows/outreach_flow.py
+++ b/src/orchestration/flows/outreach_flow.py
@@ -71,6 +71,253 @@ logger = logging.getLogger(__name__)
 
 
 # ============================================
+# BU-CLOSED-LOOP-C1 — OUTREACH SPEND CAP (gate-as-code, GOV-12)
+# ============================================
+# Replicates the CD Player budget pattern (commit 09a2f0c3): admission
+# control before any paid send, hard caps per-domain and per-customer,
+# structured skip rows (not silent drops) so CIS records the refusal.
+#
+# AUD costs sourced from production engine constants:
+#   - Email (Resend):      $0.0006 AUD per send (Resend list price)
+#   - LinkedIn (Unipile):  $0.10   AUD per message
+#   - SMS (Telnyx):        $0.014  AUD per message
+#   - Voice (Telnyx 1min): $0.14   AUD per minute (see voice_agent_telnyx.py L23)
+#
+# Per-tier daily AUD ceilings track the SDK budget envelope from
+# src/config/settings.py (sdk_daily_budget_aud_*). These are hard ceilings
+# at the customer level — they include all paid surfaces, not just outreach.
+# Keeping outreach under these caps preserves head-room for SDK enrichment.
+CHANNEL_COST_AUD: dict[str, float] = {
+    "email":    0.0006,
+    "linkedin": 0.10,
+    "sms":      0.014,
+    "voice":    0.14,
+}
+
+# Per-domain AUD cap — refuse-to-send when one domain has accumulated this
+# much spend in the rolling 24-hour window. Stops a single domain from
+# eating the customer's daily envelope on its own.
+DEFAULT_DOMAIN_DAILY_AUD_CAP: float = 5.0
+
+# Per-customer per-tier daily AUD cap. Tracks src/config/settings.py SDK
+# budgets (which already exist, ratified via Stripe pricing).
+TIER_DAILY_AUD_CAP: dict[str, float] = {
+    "spark":    25.0,
+    "ignition": 50.0,
+    "velocity": 100.0,
+    # dominance is deprecated per src/config/tiers.py — rows still tagged
+    # with it during migration get the velocity ceiling (safest available).
+    "dominance": 100.0,
+}
+
+
+def _today_window_sql() -> str:
+    """ISO snippet — last 24 hours (rolling window matches Stripe day rule)."""
+    return "NOW() - INTERVAL '24 hours'"
+
+
+@task(name="snapshot_outreach_spend", retries=1, retry_delay_seconds=2)
+async def snapshot_outreach_spend_task(
+    client_ids: list[str],
+    domains: list[str],
+) -> dict[str, dict[str, float]]:
+    """Pre-loop snapshot of last-24h outreach spend, grouped per-customer
+    and per-domain. The hourly_outreach_flow consults this snapshot before
+    each send to gate admission.
+
+    Returns:
+        {
+          "by_client":  {client_id: aud_spent_today},
+          "by_domain":  {domain:   aud_spent_today},
+          "by_client_credits": {client_id: credits_remaining},
+          "by_client_tier":    {client_id: tier_string},
+        }
+
+    Sources:
+        - prospect_telemetry (cost_aud column, JOIN leads for client/domain).
+        - clients table (credits_remaining + tier).
+
+    All queries are best-effort: a Supabase outage degrades to "no spend
+    today" rather than blocking the flow. Defence-in-depth — the gate fires
+    again per-iteration on the in-memory delta.
+    """
+    snapshot: dict[str, dict[str, float]] = {
+        "by_client": {cid: 0.0 for cid in client_ids},
+        "by_domain": {d: 0.0 for d in domains if d},
+        "by_client_credits": {},
+        "by_client_tier": {},
+    }
+    if not client_ids:
+        return snapshot
+
+    async with get_db_session() as db:
+        # Customer-level cost rollup (last 24h) — JOIN leads to attribute
+        # telemetry rows back to a client_id.
+        try:
+            cost_by_client_q = text(f"""
+                SELECT l.client_id::text AS client_id,
+                       COALESCE(SUM(t.cost_aud), 0.0)::float AS spend_aud
+                  FROM prospect_telemetry t
+                  JOIN leads l ON l.id = t.prospect_id
+                 WHERE l.client_id = ANY(:client_ids::uuid[])
+                   AND t.event_type = 'touch'
+                   AND t.created_at >= {_today_window_sql()}
+                 GROUP BY l.client_id
+            """)
+            result = await db.execute(
+                cost_by_client_q, {"client_ids": [str(c) for c in client_ids]}
+            )
+            for row in result:
+                snapshot["by_client"][row.client_id] = float(row.spend_aud or 0.0)
+        except Exception as exc:
+            logger.warning("snapshot_outreach_spend: by_client fetch failed (non-fatal): %s",
+                           exc)
+
+        # Domain-level cost rollup (last 24h).
+        if any(d for d in domains):
+            try:
+                cost_by_domain_q = text(f"""
+                    SELECT l.domain AS domain,
+                           COALESCE(SUM(t.cost_aud), 0.0)::float AS spend_aud
+                      FROM prospect_telemetry t
+                      JOIN leads l ON l.id = t.prospect_id
+                     WHERE l.domain = ANY(:domains::text[])
+                       AND t.event_type = 'touch'
+                       AND t.created_at >= {_today_window_sql()}
+                     GROUP BY l.domain
+                """)
+                result = await db.execute(
+                    cost_by_domain_q,
+                    {"domains": [d for d in domains if d]},
+                )
+                for row in result:
+                    if row.domain:
+                        snapshot["by_domain"][row.domain] = float(row.spend_aud or 0.0)
+            except Exception as exc:
+                logger.warning("snapshot_outreach_spend: by_domain fetch failed (non-fatal): %s",
+                               exc)
+
+        # credits_remaining + tier per client.
+        try:
+            client_q = text("""
+                SELECT id::text AS id, credits_remaining, tier::text AS tier
+                  FROM clients
+                 WHERE id = ANY(:client_ids::uuid[])
+                   AND deleted_at IS NULL
+            """)
+            result = await db.execute(
+                client_q, {"client_ids": [str(c) for c in client_ids]}
+            )
+            for row in result:
+                snapshot["by_client_credits"][row.id] = int(row.credits_remaining or 0)
+                snapshot["by_client_tier"][row.id] = (row.tier or "ignition").lower()
+        except Exception as exc:
+            logger.warning("snapshot_outreach_spend: clients fetch failed (non-fatal): %s",
+                           exc)
+
+    return snapshot
+
+
+def _check_budget_gate(
+    snapshot: dict[str, dict[str, float]],
+    lead_data: dict[str, Any],
+    channel: str,
+    domain_cap_aud: float = DEFAULT_DOMAIN_DAILY_AUD_CAP,
+) -> dict[str, Any] | None:
+    """Admission control. Returns a structured skip dict to refuse-to-send,
+    or None to proceed.
+
+    Mutates the snapshot in-place: when a send is admitted (returned None),
+    the caller is responsible for invoking _admit_send() to advance the
+    in-memory counters so subsequent iterations see the new spend.
+
+    Per GOV-12 — this is runtime conditional logic, not a comment block.
+    """
+    client_id = str(lead_data.get("client_id") or "")
+    domain = (lead_data.get("domain") or "").strip()
+    cost = CHANNEL_COST_AUD.get(channel, 0.0)
+
+    # Gate 1 — credits_remaining hard zero. Most decisive signal: customer
+    # has nothing left in the bank. Refuse all channels.
+    credits = snapshot.get("by_client_credits", {}).get(client_id)
+    if credits is not None and credits <= 0:
+        return {
+            "lead_id": lead_data.get("lead_id"),
+            "channel": channel,
+            "success": False,
+            "skipped": True,
+            "reason": "budget_cap_per_customer_exceeded",
+            "detail": "credits_remaining<=0",
+            "client_id": client_id,
+            "domain": domain or None,
+        }
+
+    # Gate 2 — per-customer daily AUD cap. Compare today's spend (snapshot)
+    # plus this send's cost against the tier ceiling.
+    tier = snapshot.get("by_client_tier", {}).get(client_id) or "ignition"
+    customer_cap = TIER_DAILY_AUD_CAP.get(tier, TIER_DAILY_AUD_CAP["ignition"])
+    customer_spent = snapshot.get("by_client", {}).get(client_id, 0.0)
+    if customer_spent + cost > customer_cap:
+        return {
+            "lead_id": lead_data.get("lead_id"),
+            "channel": channel,
+            "success": False,
+            "skipped": True,
+            "reason": "budget_cap_per_customer_exceeded",
+            "detail": (
+                f"tier={tier} cap_aud={customer_cap:.2f} "
+                f"spent_today_aud={customer_spent:.4f} "
+                f"+ this_send_aud={cost:.4f} > cap"
+            ),
+            "client_id": client_id,
+            "domain": domain or None,
+        }
+
+    # Gate 3 — per-domain daily AUD cap. Stops one domain dominating the
+    # customer's envelope.
+    if domain:
+        domain_spent = snapshot.get("by_domain", {}).get(domain, 0.0)
+        if domain_spent + cost > domain_cap_aud:
+            return {
+                "lead_id": lead_data.get("lead_id"),
+                "channel": channel,
+                "success": False,
+                "skipped": True,
+                "reason": "budget_cap_per_domain_exceeded",
+                "detail": (
+                    f"domain_cap_aud={domain_cap_aud:.2f} "
+                    f"spent_today_aud={domain_spent:.4f} "
+                    f"+ this_send_aud={cost:.4f} > cap"
+                ),
+                "client_id": client_id,
+                "domain": domain,
+            }
+
+    return None  # admit
+
+
+def _admit_send(
+    snapshot: dict[str, dict[str, float]],
+    lead_data: dict[str, Any],
+    channel: str,
+) -> None:
+    """Advance in-memory counters after a successful admission so the next
+    iteration's gate sees the updated spend. Mirrors the CD Player pattern's
+    shared cost counter — but here the snapshot dict IS the shared state."""
+    client_id = str(lead_data.get("client_id") or "")
+    domain = (lead_data.get("domain") or "").strip()
+    cost = CHANNEL_COST_AUD.get(channel, 0.0)
+    if client_id:
+        snapshot.setdefault("by_client", {})[client_id] = (
+            snapshot.get("by_client", {}).get(client_id, 0.0) + cost
+        )
+    if domain:
+        snapshot.setdefault("by_domain", {})[domain] = (
+            snapshot.get("by_domain", {}).get(domain, 0.0) + cost
+        )
+
+
+# ============================================
 # TASKS
 # ============================================
 
@@ -463,12 +710,14 @@ async def get_leads_ready_for_outreach_task(limit: int = 50) -> dict[str, Any]:
                 Lead.id,
                 Lead.client_id,
                 Lead.campaign_id,
+                Lead.domain,
                 Lead.assigned_email_resource,
                 Lead.assigned_linkedin_seat,
                 Lead.assigned_phone_resource,
                 Campaign.permission_mode,
                 Client.subscription_status,
                 Client.credits_remaining,
+                Client.tier,
             )
             .join(Client, Lead.client_id == Client.id)
             .join(Campaign, Lead.campaign_id == Campaign.id)
@@ -512,18 +761,22 @@ async def get_leads_ready_for_outreach_task(limit: int = 50) -> dict[str, Any]:
                 lead_id,
                 client_id,
                 campaign_id,
+                domain,
                 email_resource,
                 linkedin_seat,
                 phone_resource,
                 permission_mode,
                 subscription_status,
                 credits,
+                tier,
             ) = row
 
             lead_data = {
                 "lead_id": str(lead_id),
                 "client_id": str(client_id),
                 "campaign_id": str(campaign_id),
+                "domain": domain or "",
+                "tier": tier.value if hasattr(tier, "value") else (str(tier) if tier else "ignition"),
                 "permission_mode": permission_mode.value if permission_mode else "co_pilot",
             }
 
@@ -1239,8 +1492,37 @@ async def hourly_outreach_flow(batch_size: int = 50) -> dict[str, Any]:
         "sms": [],
     }
 
+    # ─── BU-CLOSED-LOOP-C1 — pre-loop spend snapshot ───────────────────────
+    # Admission control fires BEFORE any send. Snapshot loads the last-24h
+    # AUD spend per client + per domain, plus credits_remaining and tier.
+    # The in-memory snapshot dict doubles as the shared counter advanced
+    # by _admit_send() after each successful admission.
+    snapshot_client_ids = sorted({
+        lead_data["client_id"]
+        for channel_leads in leads_data["leads_by_channel"].values()
+        for lead_data in channel_leads
+    })
+    snapshot_domains = sorted({
+        (lead_data.get("domain") or "")
+        for channel_leads in leads_data["leads_by_channel"].values()
+        for lead_data in channel_leads
+        if lead_data.get("domain")
+    })
+    spend_snapshot = await snapshot_outreach_spend_task(
+        client_ids=snapshot_client_ids,
+        domains=snapshot_domains,
+    )
+
     # Process email outreach
     for lead_data in leads_data["leads_by_channel"]["email"]:
+        gate_skip = _check_budget_gate(spend_snapshot, lead_data, "email")
+        if gate_skip is not None:
+            logger.info(
+                "outreach_budget_gate refused: lead=%s channel=email reason=%s",
+                lead_data.get("lead_id"), gate_skip["reason"],
+            )
+            results["email"].append(gate_skip)
+            continue
         try:
             # JIT validation
             validation = await jit_validate_outreach_task(
@@ -1256,6 +1538,8 @@ async def hourly_outreach_flow(batch_size: int = 50) -> dict[str, Any]:
                 resource=lead_data["resource"],
                 permission_mode=validation["permission_mode"],
             )
+            if result.get("success"):
+                _admit_send(spend_snapshot, lead_data, "email")
             results["email"].append(result)
 
         except ValueError as e:
@@ -1271,6 +1555,14 @@ async def hourly_outreach_flow(batch_size: int = 50) -> dict[str, Any]:
 
     # Process LinkedIn outreach
     for lead_data in leads_data["leads_by_channel"]["linkedin"]:
+        gate_skip = _check_budget_gate(spend_snapshot, lead_data, "linkedin")
+        if gate_skip is not None:
+            logger.info(
+                "outreach_budget_gate refused: lead=%s channel=linkedin reason=%s",
+                lead_data.get("lead_id"), gate_skip["reason"],
+            )
+            results["linkedin"].append(gate_skip)
+            continue
         try:
             # JIT validation
             validation = await jit_validate_outreach_task(
@@ -1286,6 +1578,8 @@ async def hourly_outreach_flow(batch_size: int = 50) -> dict[str, Any]:
                 resource=lead_data["resource"],
                 permission_mode=validation["permission_mode"],
             )
+            if result.get("success"):
+                _admit_send(spend_snapshot, lead_data, "linkedin")
             results["linkedin"].append(result)
 
         except ValueError as e:
@@ -1301,6 +1595,14 @@ async def hourly_outreach_flow(batch_size: int = 50) -> dict[str, Any]:
 
     # Process SMS outreach
     for lead_data in leads_data["leads_by_channel"]["sms"]:
+        gate_skip = _check_budget_gate(spend_snapshot, lead_data, "sms")
+        if gate_skip is not None:
+            logger.info(
+                "outreach_budget_gate refused: lead=%s channel=sms reason=%s",
+                lead_data.get("lead_id"), gate_skip["reason"],
+            )
+            results["sms"].append(gate_skip)
+            continue
         try:
             # JIT validation
             validation = await jit_validate_outreach_task(
@@ -1316,6 +1618,8 @@ async def hourly_outreach_flow(batch_size: int = 50) -> dict[str, Any]:
                 resource=lead_data["resource"],
                 permission_mode=validation["permission_mode"],
             )
+            if result.get("success"):
+                _admit_send(spend_snapshot, lead_data, "sms")
             results["sms"].append(result)
 
         except ValueError as e:
@@ -1333,6 +1637,17 @@ async def hourly_outreach_flow(batch_size: int = 50) -> dict[str, Any]:
     emails_sent = sum(1 for r in results["email"] if r["success"])
     linkedin_sent = sum(1 for r in results["linkedin"] if r["success"])
     sms_sent = sum(1 for r in results["sms"] if r["success"])
+
+    # BU-CLOSED-LOOP-C1 — surface budget-cap skips so CIS / dashboards see
+    # them as a first-class outcome rather than a generic failure.
+    skipped_per_domain_cap = sum(
+        1 for ch in results.values() for r in ch
+        if r.get("reason") == "budget_cap_per_domain_exceeded"
+    )
+    skipped_per_customer_cap = sum(
+        1 for ch in results.values() for r in ch
+        if r.get("reason") == "budget_cap_per_customer_exceeded"
+    )
 
     # CIS: Update channel performance metrics per campaign
     try:
@@ -1392,6 +1707,8 @@ async def hourly_outreach_flow(batch_size: int = 50) -> dict[str, Any]:
         "linkedin_sent": linkedin_sent,
         "sms_sent": sms_sent,
         "total_sent": emails_sent + linkedin_sent + sms_sent,
+        "skipped_per_domain_cap": skipped_per_domain_cap,
+        "skipped_per_customer_cap": skipped_per_customer_cap,
         "results": results,
         "completed_at": datetime.now(UTC).isoformat(),
     }

--- a/tests/orchestration/flows/test_outreach_flow.py
+++ b/tests/orchestration/flows/test_outreach_flow.py
@@ -1,0 +1,235 @@
+"""Tests for src/orchestration/flows/outreach_flow.py budget gates.
+
+BU-CLOSED-LOOP-C1 — replicates the CD Player budget enforcement pattern.
+Hermetic — no live DB, no live channel adapters.
+
+Coverage:
+  - Domain at cap is skipped (refuse-to-send returns structured skip).
+  - Customer at cap is skipped (tier-based daily AUD ceiling).
+  - Customer with credits_remaining<=0 is skipped before any channel cost.
+  - Normal under-cap send proceeds + admit_send advances counters.
+  - Edge case: customer at exactly the cap before this send (this_send + spent
+    > cap → skip).
+  - Edge case: customer just under cap (this_send + spent <= cap → proceed).
+  - In-memory snapshot mutation via _admit_send is reflected in next gate call.
+  - Gate skip rows carry stable reason strings ('budget_cap_per_domain_exceeded',
+    'budget_cap_per_customer_exceeded') so CIS records the refusal.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+
+os.environ.setdefault("DATABASE_URL", "postgresql://stub:stub@stub:5432/stub")
+
+import importlib  # noqa: E402
+
+flow_mod = importlib.import_module("src.orchestration.flows.outreach_flow")
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+def _empty_snapshot(client_id: str = "client-1",
+                    domain: str = "example.com.au",
+                    tier: str = "ignition",
+                    credits: int = 1000,
+                    spent_client: float = 0.0,
+                    spent_domain: float = 0.0) -> dict[str, dict]:
+    return {
+        "by_client": {client_id: spent_client},
+        "by_domain": {domain: spent_domain},
+        "by_client_credits": {client_id: credits},
+        "by_client_tier": {client_id: tier},
+    }
+
+
+def _lead(channel_resource: str = "email-resource",
+          client_id: str = "client-1",
+          domain: str = "example.com.au",
+          lead_id: str = "lead-A") -> dict:
+    return {
+        "lead_id": lead_id,
+        "client_id": client_id,
+        "campaign_id": "camp-1",
+        "domain": domain,
+        "tier": "ignition",
+        "permission_mode": "autopilot",
+        "resource": channel_resource,
+    }
+
+
+# ── Gate behaviour — core matrix ────────────────────────────────────────────
+
+def test_gate_admits_normal_under_cap_send():
+    """Empty snapshot, sane caps → gate returns None (admit)."""
+    snap = _empty_snapshot()
+    out = flow_mod._check_budget_gate(snap, _lead(), "email")
+    assert out is None
+
+
+def test_gate_skips_domain_at_cap():
+    """Domain has already spent the cap today; one more send breaches."""
+    snap = _empty_snapshot(spent_domain=flow_mod.DEFAULT_DOMAIN_DAILY_AUD_CAP)
+    out = flow_mod._check_budget_gate(snap, _lead(), "linkedin")
+    assert out is not None
+    assert out["reason"] == "budget_cap_per_domain_exceeded"
+    assert out["success"] is False
+    assert out["skipped"] is True
+    assert out["channel"] == "linkedin"
+    assert out["domain"] == "example.com.au"
+    assert "domain_cap_aud" in out["detail"]
+
+
+def test_gate_skips_domain_exactly_at_cap_when_send_would_breach():
+    """Edge: spent == cap, this_send > 0, spent + this_send > cap → skip."""
+    snap = _empty_snapshot(spent_domain=flow_mod.DEFAULT_DOMAIN_DAILY_AUD_CAP)
+    # email costs 0.0006 AUD — pushes 5.0 + 0.0006 > 5.0 → must skip.
+    out = flow_mod._check_budget_gate(snap, _lead(), "email")
+    assert out is not None
+    assert out["reason"] == "budget_cap_per_domain_exceeded"
+
+
+def test_gate_admits_when_spent_just_under_cap():
+    """Edge: spent + this_send <= cap → admit. Use a value below the
+    domain cap minus the email cost to land cleanly under."""
+    snap = _empty_snapshot(spent_domain=flow_mod.DEFAULT_DOMAIN_DAILY_AUD_CAP
+                                         - flow_mod.CHANNEL_COST_AUD["email"]
+                                         - 0.001)
+    out = flow_mod._check_budget_gate(snap, _lead(), "email")
+    assert out is None
+
+
+def test_gate_skips_customer_at_tier_cap():
+    """Customer has spent the tier daily cap today (ignition = 50 AUD)."""
+    snap = _empty_snapshot(tier="ignition",
+                           spent_client=flow_mod.TIER_DAILY_AUD_CAP["ignition"])
+    out = flow_mod._check_budget_gate(snap, _lead(), "voice")
+    assert out is not None
+    assert out["reason"] == "budget_cap_per_customer_exceeded"
+    assert "tier=ignition" in out["detail"]
+    assert "cap_aud=50.00" in out["detail"]
+
+
+def test_gate_skips_customer_with_zero_credits_remaining():
+    """credits_remaining<=0 → blanket refuse all channels."""
+    snap = _empty_snapshot(credits=0)
+    out = flow_mod._check_budget_gate(snap, _lead(), "email")
+    assert out is not None
+    assert out["reason"] == "budget_cap_per_customer_exceeded"
+    assert out["detail"] == "credits_remaining<=0"
+
+
+def test_gate_uses_correct_per_tier_cap_for_spark():
+    """Spark tier has a 25 AUD daily ceiling (lower than ignition)."""
+    snap = _empty_snapshot(tier="spark",
+                           spent_client=flow_mod.TIER_DAILY_AUD_CAP["spark"])
+    out = flow_mod._check_budget_gate(snap, _lead(), "voice")
+    assert out is not None
+    assert out["reason"] == "budget_cap_per_customer_exceeded"
+    assert "tier=spark" in out["detail"]
+    assert "cap_aud=25.00" in out["detail"]
+
+
+def test_gate_uses_correct_per_tier_cap_for_velocity():
+    """Velocity tier has a 100 AUD daily ceiling (highest active)."""
+    snap = _empty_snapshot(tier="velocity",
+                           spent_client=99.99)
+    # voice cost is 0.14 → 99.99 + 0.14 > 100 → skip.
+    out = flow_mod._check_budget_gate(snap, _lead(), "voice")
+    assert out is not None
+    assert out["reason"] == "budget_cap_per_customer_exceeded"
+    assert "tier=velocity" in out["detail"]
+
+
+def test_gate_falls_back_to_ignition_cap_when_tier_unknown():
+    """Defensive: an unknown tier string falls back to ignition cap (50)."""
+    snap = _empty_snapshot(tier="bogus-tier",
+                           spent_client=flow_mod.TIER_DAILY_AUD_CAP["ignition"])
+    out = flow_mod._check_budget_gate(snap, _lead(), "voice")
+    assert out is not None
+    assert out["reason"] == "budget_cap_per_customer_exceeded"
+
+
+def test_gate_admits_when_no_domain_attached():
+    """If lead.domain is empty, the per-domain gate is skipped silently —
+    customer + credits gates still apply."""
+    snap = _empty_snapshot()
+    lead = _lead(domain="")
+    out = flow_mod._check_budget_gate(snap, lead, "email")
+    assert out is None
+
+
+# ── _admit_send behaviour ───────────────────────────────────────────────────
+
+def test_admit_send_advances_counters():
+    """After admit_send, the snapshot reflects the new spend and the next
+    gate call sees it. Mirrors the CD Player shared-counter pattern."""
+    snap = _empty_snapshot(spent_client=49.0, tier="ignition")  # 1 AUD headroom
+    lead = _lead()
+    # First send: voice = 0.14 → admitted, leaves 0.86 headroom.
+    assert flow_mod._check_budget_gate(snap, lead, "voice") is None
+    flow_mod._admit_send(snap, lead, "voice")
+    assert pytest.approx(snap["by_client"]["client-1"], abs=0.001) == 49.14
+    # Subsequent admit_send pushes total over 50 → next gate must refuse.
+    for _ in range(7):
+        flow_mod._admit_send(snap, lead, "voice")
+    refused = flow_mod._check_budget_gate(snap, lead, "voice")
+    assert refused is not None
+    assert refused["reason"] == "budget_cap_per_customer_exceeded"
+
+
+def test_admit_send_advances_domain_counter_too():
+    snap = _empty_snapshot()
+    lead = _lead()
+    flow_mod._admit_send(snap, lead, "linkedin")
+    assert pytest.approx(snap["by_domain"]["example.com.au"], abs=0.001) \
+        == flow_mod.CHANNEL_COST_AUD["linkedin"]
+
+
+def test_admit_send_no_op_when_lead_has_no_domain_or_client():
+    """Defensive: lead missing domain/client_id should not raise."""
+    snap = _empty_snapshot()
+    flow_mod._admit_send(snap, {"lead_id": "x"}, "email")
+    # Counters are unchanged.
+    assert snap["by_client"]["client-1"] == 0.0
+
+
+# ── Skip-row contract ───────────────────────────────────────────────────────
+
+def test_skip_row_carries_required_fields_for_cis():
+    """CIS consumers expect lead_id, channel, success=False, reason.
+    The structured skip dict from the gate must include all of these."""
+    snap = _empty_snapshot(credits=0)
+    skip = flow_mod._check_budget_gate(snap, _lead(), "email")
+    assert skip is not None
+    for required_key in ("lead_id", "channel", "success", "reason",
+                         "client_id", "skipped"):
+        assert required_key in skip
+    assert skip["success"] is False
+    assert skip["skipped"] is True
+    assert skip["lead_id"] == "lead-A"
+    assert skip["channel"] == "email"
+
+
+# ── Module-level cost / tier cap constants ──────────────────────────────────
+
+def test_channel_cost_aud_covers_all_required_channels():
+    """Every channel surfaced in the flow body must have a cost entry."""
+    for ch in ("email", "linkedin", "sms", "voice"):
+        assert ch in flow_mod.CHANNEL_COST_AUD
+        assert flow_mod.CHANNEL_COST_AUD[ch] > 0
+
+
+def test_tier_daily_aud_cap_covers_active_tiers():
+    """spark / ignition / velocity must be present; dominance kept for
+    DB-migration tolerance per src/config/tiers.py."""
+    for t in ("spark", "ignition", "velocity"):
+        assert t in flow_mod.TIER_DAILY_AUD_CAP
+        assert flow_mod.TIER_DAILY_AUD_CAP[t] > 0
+    # Ordering invariant: spark < ignition < velocity (cheaper plans cap lower).
+    assert (flow_mod.TIER_DAILY_AUD_CAP["spark"]
+            < flow_mod.TIER_DAILY_AUD_CAP["ignition"]
+            < flow_mod.TIER_DAILY_AUD_CAP["velocity"])

--- a/tests/orchestration/flows/test_outreach_flow.py
+++ b/tests/orchestration/flows/test_outreach_flow.py
@@ -223,6 +223,108 @@ def test_channel_cost_aud_covers_all_required_channels():
         assert flow_mod.CHANNEL_COST_AUD[ch] > 0
 
 
+# ── OB-1..OB-6 review-fix regressions ───────────────────────────────────────
+
+def test_ob1_snapshot_failure_emits_loud_alert(monkeypatch):
+    """OB-1: snapshot SQL silent-fail must call _emit_snapshot_failure_alert
+    (logger.error + best-effort Telegram broadcast) — never logger.warning."""
+    calls: list[tuple[str, str]] = []
+
+    def fake_emit(stage: str, exc: Exception) -> None:
+        calls.append((stage, type(exc).__name__))
+
+    monkeypatch.setattr(flow_mod, "_emit_snapshot_failure_alert", fake_emit)
+
+    # Stub get_db_session so every conn.execute raises — exercises all three
+    # try/except branches inside snapshot_outreach_spend_task.
+    import contextlib
+    from unittest.mock import AsyncMock, MagicMock
+
+    failing_db = MagicMock()
+    failing_db.execute = AsyncMock(side_effect=RuntimeError("supabase down"))
+
+    @contextlib.asynccontextmanager
+    async def fake_session():
+        yield failing_db
+
+    monkeypatch.setattr(flow_mod, "get_db_session", fake_session)
+
+    import asyncio
+    snap = asyncio.run(flow_mod.snapshot_outreach_spend_task.fn(
+        client_ids=["client-1"], domains=["example.com.au"],
+    ))
+
+    # All three failure branches fired the loud alert.
+    stages = sorted(stage for stage, _ in calls)
+    assert stages == ["by_client", "by_domain", "clients"]
+    # Every alert flagged the same RuntimeError.
+    assert all(exc_name == "RuntimeError" for _, exc_name in calls)
+    # Snapshot still returns a usable shape (defence-in-depth — gate runs anyway).
+    assert "by_client" in snap
+    assert "by_domain" in snap
+
+
+def test_ob2_spend_window_is_module_level_constant():
+    """OB-2: _today_window_sql() helper replaced by _SPEND_WINDOW_SQL constant."""
+    assert hasattr(flow_mod, "_SPEND_WINDOW_SQL")
+    assert isinstance(flow_mod._SPEND_WINDOW_SQL, str)
+    # The old function should be gone.
+    assert not hasattr(flow_mod, "_today_window_sql")
+
+
+def test_ob6_spend_window_uses_calendar_day_utc_not_rolling_24h():
+    """OB-6: window aligned to CURRENT_DATE (calendar-day-UTC) matching
+    src/services/jit_validator.py:431 daily-quota convention. NOT a
+    rolling 24h interval — Stripe has no daily rule, so prior comment was
+    misleading and SQL is now consistent with the existing JIT rate
+    limiter (cap resets at UTC midnight)."""
+    assert flow_mod._SPEND_WINDOW_SQL == "CURRENT_DATE"
+    # The snapshot SQL embeds the constant via f-string — verify the
+    # constant reference appears, not the resolved value (inspect.getsource
+    # returns source text with the {var} substitution in place).
+    import inspect
+    src = inspect.getsource(flow_mod.snapshot_outreach_spend_task)
+    assert "{_SPEND_WINDOW_SQL}" in src
+    # Old rolling-24h marker must be gone.
+    assert "INTERVAL '24 hours'" not in src
+    # Module-level docstring should not retain the misleading Stripe phrase.
+    mod_src = inspect.getsource(flow_mod)
+    assert "matches Stripe day rule" not in mod_src
+
+
+def test_ob3_tier_coercion_is_pinned_to_enum_value():
+    """OB-3: source code pins tier_value to tier.value with the only
+    fallback being None -> 'ignition'. The old hasattr() / str() fallback
+    chain is removed."""
+    import inspect
+    src = inspect.getsource(flow_mod.get_leads_ready_for_outreach_task)
+    assert "tier.value if tier is not None else \"ignition\"" in src
+    # The old defensive chain must be gone.
+    assert 'hasattr(tier, "value")' not in src
+
+
+def test_ob4_domain_cap_documented_as_roadmap_marker():
+    """OB-4: DEFAULT_DOMAIN_DAILY_AUD_CAP carries a roadmap-polish marker
+    noting the value should become per-customer-tier configurable
+    post-revenue. Comment-only verification."""
+    import inspect
+    src = inspect.getsource(flow_mod)
+    # The roadmap marker text must appear adjacent to the constant.
+    assert "per-customer-tier configurable post-revenue" in src
+    # Constant value remains 5.0.
+    assert flow_mod.DEFAULT_DOMAIN_DAILY_AUD_CAP == 5.0
+
+
+def test_ob5_channel_cost_aud_documents_canonical_source():
+    """OB-5: CHANNEL_COST_AUD comment block points to canonical settings
+    sources for future updates."""
+    import inspect
+    src = inspect.getsource(flow_mod)
+    # The OB-5 marker text must appear adjacent to the dict.
+    assert "src/config/settings.py" in src
+    assert "voice_agent_telnyx.py" in src
+
+
 def test_tier_daily_aud_cap_covers_active_tiers():
     """spark / ignition / velocity must be present; dominance kept for
     DB-migration tolerance per src/config/tiers.py."""

--- a/tests/test_flows/test_outreach_flow.py
+++ b/tests/test_flows/test_outreach_flow.py
@@ -17,6 +17,7 @@ from src.models.base import (
     LeadStatus,
     PermissionMode,
     SubscriptionStatus,
+    TierType,
 )
 from src.orchestration.flows.outreach_flow import (
     get_leads_ready_for_outreach_task,
@@ -89,7 +90,7 @@ async def test_get_leads_ready_for_outreach_success():
             PermissionMode.CO_PILOT,  # permission_mode
             SubscriptionStatus.ACTIVE,  # subscription_status
             1000,  # credits_remaining
-            "ignition",  # tier (BU-CLOSED-LOOP-C1: client.tier projected for per-tier daily AUD cap)
+            TierType.IGNITION,  # tier (BU-CLOSED-LOOP-C1: client.tier projected for per-tier daily AUD cap; OB-3 enum-pinned)
         ),
     ]
     mock_db.execute = AsyncMock(return_value=mock_result)

--- a/tests/test_flows/test_outreach_flow.py
+++ b/tests/test_flows/test_outreach_flow.py
@@ -82,12 +82,14 @@ async def test_get_leads_ready_for_outreach_success():
             uuid4(),  # lead_id
             uuid4(),  # client_id
             uuid4(),  # campaign_id
+            "example.com.au",  # domain (BU-CLOSED-LOOP-C1: lead.domain projected for budget gates)
             "domain.com",  # email_resource
             "seat123",  # linkedin_seat
             "+1234567890",  # phone_resource
             PermissionMode.CO_PILOT,  # permission_mode
             SubscriptionStatus.ACTIVE,  # subscription_status
             1000,  # credits_remaining
+            "ignition",  # tier (BU-CLOSED-LOOP-C1: client.tier projected for per-tier daily AUD cap)
         ),
     ]
     mock_db.execute = AsyncMock(return_value=mock_result)


### PR DESCRIPTION
## Summary
BU-CLOSED-LOOP-C1 — outreach spend cap. Replicates the CD Player budget enforcement pattern (commit `09a2f0c3`: per-stage cost gate + admission control + max_in_flight + budget hard cap) on the outreach surface. **Gate-as-code per GOV-12** — runtime conditionals, not comments.

Outreach is currently `paused: true` in `prefect.yaml` — **no live calls fire**. **AUD 0 spend** in this PR.

## Files changed (`git diff --stat origin/main`)
```
 src/orchestration/flows/outreach_flow.py        | 317 ++++++++++++++++++++++++
 tests/orchestration/flows/test_outreach_flow.py | 235 ++++++++++++++++++
 tests/test_flows/test_outreach_flow.py          |   2 +
 3 files changed, 554 insertions(+)
```

## What changes in `outreach_flow.py`
**New module-level constants:**
| Channel | Cost AUD | Source |
|---|---|---|
| email | $0.0006 | Resend list price |
| linkedin | $0.10 | Unipile message |
| sms | $0.014 | Telnyx SMS |
| voice | $0.14 | Telnyx 1-min (`voice_agent_telnyx.py` L23) |

| Tier | Daily AUD cap |
|---|---|
| spark | $25 |
| ignition | $50 |
| velocity | $100 |
| dominance | $100 (deprecated, kept for DB-migration tolerance) |

**Per-domain default daily cap: $5 AUD** — stops one domain dominating a customer's envelope.

**New tasks/helpers:**
- `snapshot_outreach_spend_task` — pre-loop snapshot of last-24h AUD spend per-customer (JOIN prospect_telemetry → leads → client_id) and per-domain. Also loads `credits_remaining` + `tier` per client. Best-effort: Supabase failure degrades to "no spend today"; per-iteration gate is the second line of defence.
- `_check_budget_gate(snapshot, lead_data, channel)` — returns a structured skip dict (`reason`, `detail`, `lead_id`, `channel`, ...) or None to admit. Three gates: (1) `credits_remaining<=0`; (2) customer tier-cap; (3) per-domain cap.
- `_admit_send` — advances the in-memory shared counter after each admission so subsequent iterations see the new spend (mirrors CD Player's shared cost counter).

**Wiring in `hourly_outreach_flow`:**
- `get_leads_ready_for_outreach_task` SELECT extended with `Lead.domain` and `Client.tier` so the gate has the data.
- Pre-loop snapshot fetched once.
- Each channel loop (email / linkedin / sms) calls `_check_budget_gate` BEFORE `send_*_task`. Skips append a structured row to `results[channel]` with stable reason `budget_cap_per_domain_exceeded` or `budget_cap_per_customer_exceeded` — CIS records the refusal as a first-class outcome.
- Successful sends call `_admit_send` to update the in-memory snapshot.
- Summary now carries `skipped_per_domain_cap` and `skipped_per_customer_cap` counters.

## Test plan
**16 new tests** in `tests/orchestration/flows/test_outreach_flow.py`:
- ✅ Gate admits normal under-cap send.
- ✅ Gate skips domain at cap.
- ✅ Gate skips domain exactly at cap (edge case — this_send breaches).
- ✅ Gate admits when spent just under cap.
- ✅ Gate skips customer at tier cap (ignition).
- ✅ Gate skips customer with `credits_remaining=0`.
- ✅ Gate uses correct per-tier cap (spark, velocity).
- ✅ Gate falls back to ignition cap on unknown tier.
- ✅ Gate admits when no domain attached.
- ✅ `_admit_send` advances customer counter (and refuses next iteration past cap).
- ✅ `_admit_send` advances domain counter.
- ✅ `_admit_send` no-op on missing keys.
- ✅ Skip row contract for CIS (lead_id, channel, success, reason, etc.).
- ✅ `CHANNEL_COST_AUD` covers all required channels with positive values.
- ✅ `TIER_DAILY_AUD_CAP` covers active tiers with spark < ignition < velocity.

**Pre-existing test update**: `tests/test_flows/test_outreach_flow.py::test_get_leads_ready_for_outreach_success` mock row tuple expanded from 9 → 11 columns (domain + tier added per the SELECT extension).

## Verification gates
- [x] `pytest tests/orchestration/flows/test_outreach_flow.py` → **16/16 pass**
- [x] `pytest tests/orchestration/` → 104 passed, 1 pre-existing failure (`test_daily_decider_flow::test_aggregates_actions_across_clients` — same on `origin/main`, unrelated)
- [x] `pytest -q --ignore=tests/test_dncr_client.py` (full repo) → 35 failed, 2566 passed, 28 skipped — **net failure delta vs main baseline = 0**
- [x] `py_compile` clean on changed files

## Pre-existing test debt (out of scope, documented)
- `tests/test_dncr_client.py` vs `tests/integrations/test_dncr_client.py` module-name collision (pre-existing on `origin/main`). Suite runs with `--ignore=tests/test_dncr_client.py` per dispatch's "do NOT skip; document" rule from S1.
- 35 pre-existing pipeline / card-streaming test failures on `origin/main`. Same count on this branch (delta = 0).

## Not modified
- `src/pipeline/*` / `src/api/*` / `src/engines/*`
- `prefect.yaml` (outreach-flow already `paused: true`; no schedule change)
- Schema (uses existing columns: `leads.domain`, `clients.tier`, `clients.credits_remaining`, `prospect_telemetry.cost_aud`)

## Policy
**Dual-concur required**: parent AIDEN + peer ELLIOT must both approve. No self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
