### PR TITLE
[ATLAS] feat: M11 — write_manual_mirror staleness check + auto-update

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# M11 — auto-mirror docs/MANUAL.md to Google Drive when the just-made
+# commit touched it.
+#
+# Install (per clone):
+#     git config core.hooksPath .githooks
+#
+# Behaviour:
+#   - If the most recent commit changed docs/MANUAL.md, run
+#     scripts/write_manual_mirror.py in the background.
+#   - Failures are logged to /tmp but never block the commit.
+#   - Exits 0 immediately so commit performance is unaffected.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LOG="/tmp/manual_mirror_post_commit.log"
+
+# Diff just-completed commit; if MANUAL.md is in the file list, kick mirror.
+if git diff-tree --no-commit-id --name-only -r HEAD | grep -qx "docs/MANUAL.md"; then
+    echo "[$(date -Iseconds)] post-commit: MANUAL.md touched — kicking mirror" >> "$LOG"
+    (
+        cd "$REPO_ROOT"
+        python3 scripts/write_manual_mirror.py >> "$LOG" 2>&1 || \
+            echo "[$(date -Iseconds)] mirror exited non-zero (best-effort, non-blocking)" >> "$LOG"
+    ) &
+fi
+
+exit 0

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -16,12 +16,19 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 LOG="/tmp/manual_mirror_post_commit.log"
 
+# M11-3 — pin the venv interpreter so the hook works regardless of the
+# user's PATH or active virtualenv state when `git commit` runs.
+VENV_PY="/home/elliotbot/clawd/venv/bin/python3"
+if [[ ! -x "$VENV_PY" ]]; then
+    VENV_PY="$(command -v python3 || true)"
+fi
+
 # Diff just-completed commit; if MANUAL.md is in the file list, kick mirror.
 if git diff-tree --no-commit-id --name-only -r HEAD | grep -qx "docs/MANUAL.md"; then
-    echo "[$(date -Iseconds)] post-commit: MANUAL.md touched — kicking mirror" >> "$LOG"
+    echo "[$(date -Iseconds)] post-commit: MANUAL.md touched — kicking mirror ($VENV_PY)" >> "$LOG"
     (
         cd "$REPO_ROOT"
-        python3 scripts/write_manual_mirror.py >> "$LOG" 2>&1 || \
+        "$VENV_PY" scripts/write_manual_mirror.py >> "$LOG" 2>&1 || \
             echo "[$(date -Iseconds)] mirror exited non-zero (best-effort, non-blocking)" >> "$LOG"
     ) &
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ screenshot-to-code/
 # AIDEN-SCAFFOLD: per-callsign env files (never commit)
 .env.aiden
 .env.elliot
+
+# M11 — write_manual_mirror staleness state (per-clone, never commit)
+scripts/.manual_mirror_state

--- a/.gitignore
+++ b/.gitignore
@@ -132,5 +132,7 @@ screenshot-to-code/
 .env.aiden
 .env.elliot
 
-# M11 — write_manual_mirror staleness state (per-clone, never commit)
+# M11 — write_manual_mirror staleness state. Active path is now
+# ~/.config/agency-os/.manual_mirror_state (M11-2 — shared across clones).
+# This entry remains so any pre-fix per-worktree file gets ignored too.
 scripts/.manual_mirror_state

--- a/scripts/write_manual_mirror.py
+++ b/scripts/write_manual_mirror.py
@@ -44,8 +44,18 @@ GOOGLE_DOC_ID = os.environ.get(
 )
 SERVICE_ACCOUNT_FILE = "/home/elliotbot/google-service-account.json"
 MANUAL_PATH = Path(__file__).parent.parent / "docs" / "MANUAL.md"
-STATE_PATH = Path(__file__).parent / ".manual_mirror_state"
+
+# M11-2 — state file lives in the shared agency-os config dir, not in any
+# single worktree. All clones (atlas/elliot/main + future) share one source
+# of truth for "when was MANUAL.md last mirrored". Falls back to the legacy
+# per-worktree location during transition for callers who haven't migrated.
+_SHARED_STATE_DIR = Path.home() / ".config" / "agency-os"
+STATE_PATH = _SHARED_STATE_DIR / ".manual_mirror_state"
+_LEGACY_STATE_PATH = Path(__file__).parent / ".manual_mirror_state"
+
 SCOPES = ["https://www.googleapis.com/auth/documents"]
+HOOKS_PATH = ".githooks"
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 # ─── fingerprinting ────────────────────────────────────────────────────────
@@ -87,15 +97,29 @@ def fingerprint(path: Path) -> dict:
 
 
 def load_state() -> dict:
-    if not STATE_PATH.exists():
-        return {}
-    try:
-        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return {}
+    """Load state from the shared config dir. One-shot migrate from the
+    legacy per-worktree path if the shared file is missing but the
+    legacy file exists (so the first run after this fix doesn't re-mirror
+    unnecessarily)."""
+    if STATE_PATH.exists():
+        try:
+            return json.loads(STATE_PATH.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+    if _LEGACY_STATE_PATH.exists():
+        try:
+            data = json.loads(_LEGACY_STATE_PATH.read_text(encoding="utf-8"))
+            logger.info("M11-2 — migrating legacy state %s → %s",
+                        _LEGACY_STATE_PATH, STATE_PATH)
+            save_state(data)
+            return data
+        except (json.JSONDecodeError, OSError):
+            return {}
+    return {}
 
 
 def save_state(state: dict) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
     STATE_PATH.write_text(json.dumps(state, indent=2), encoding="utf-8")
 
 
@@ -105,6 +129,68 @@ def is_unchanged(current: dict, last: dict) -> bool:
     if "git_blob" in current and "git_blob" in last:
         return current["git_blob"] == last["git_blob"]
     return current.get("sha256") == last.get("sha256")
+
+
+# ─── M11-1 — hook installation ─────────────────────────────────────────────
+
+def _current_hooks_path() -> str | None:
+    """Return the value of `git config core.hooksPath` for REPO_ROOT,
+    or None if unset / git unavailable."""
+    try:
+        out = subprocess.check_output(
+            ["git", "config", "--get", "core.hooksPath"],
+            cwd=str(REPO_ROOT), stderr=subprocess.DEVNULL,
+        )
+        return out.decode().strip() or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def install_hook() -> int:
+    """Run `git config core.hooksPath .githooks` for REPO_ROOT. Verifies
+    that the post-commit hook exists + is executable. Returns 0 on
+    success, non-zero otherwise."""
+    hook = REPO_ROOT / HOOKS_PATH / "post-commit"
+    if not hook.exists():
+        logger.error("post-commit hook missing at %s", hook)
+        return 4
+    if not os.access(str(hook), os.X_OK):
+        logger.warning("post-commit hook not executable — fixing chmod +x")
+        try:
+            hook.chmod(hook.stat().st_mode | 0o111)
+        except OSError as exc:
+            logger.error("chmod failed: %s", exc)
+            return 4
+    try:
+        subprocess.check_call(
+            ["git", "config", "core.hooksPath", HOOKS_PATH],
+            cwd=str(REPO_ROOT),
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        logger.error("git config failed: %s", exc)
+        return 4
+    logger.info("post-commit hook installed — core.hooksPath=%s", HOOKS_PATH)
+    logger.info("Future MANUAL.md commits will auto-mirror to Drive.")
+    return 0
+
+
+def warn_if_hook_not_installed() -> None:
+    """Emit a single non-fatal warning when core.hooksPath is not
+    pointing at .githooks — most commits will then bypass the auto-mirror."""
+    current = _current_hooks_path()
+    if current == HOOKS_PATH:
+        return
+    if current is None:
+        logger.warning(
+            "post-commit hook not installed — run `python scripts/write_manual_mirror.py "
+            "--install` (or `git config core.hooksPath .githooks`) so MANUAL.md commits "
+            "auto-mirror.",
+        )
+    else:
+        logger.warning(
+            "core.hooksPath = %s (not .githooks). The M11 auto-mirror hook will "
+            "NOT fire on commits. Run --install to switch.", current,
+        )
 
 
 # ─── mirror impl ───────────────────────────────────────────────────────────
@@ -192,7 +278,18 @@ def main(argv: list[str] | None = None) -> int:
         "--check", action="store_true",
         help="Print staleness verdict and exit. No Drive write.",
     )
+    ap.add_argument(
+        "--install", action="store_true",
+        help="Install the post-commit hook (git config core.hooksPath .githooks) and exit.",
+    )
     args = ap.parse_args(argv)
+
+    # M11-1 — handle install first; it doesn't need MANUAL.md.
+    if args.install:
+        return install_hook()
+
+    # M11-1 — startup advisory if the hook isn't wired (non-fatal).
+    warn_if_hook_not_installed()
 
     if not MANUAL_PATH.exists():
         logger.error(f"MANUAL.md not found at {MANUAL_PATH}")

--- a/scripts/write_manual_mirror.py
+++ b/scripts/write_manual_mirror.py
@@ -2,22 +2,37 @@
 """
 write_manual_mirror.py — Mirror docs/MANUAL.md to Google Drive doc.
 
-Best-effort: logs failure but does NOT raise or block directive completion.
-Primary store is docs/MANUAL.md (repo). Google Doc is a mirror only.
+Best-effort: logs Drive failures but does NOT raise or block directive
+completion. Primary store is docs/MANUAL.md (repo). Google Doc is a mirror.
+
+M11 — staleness check:
+    Before mirroring, the script compares the current MANUAL.md fingerprint
+    (git blob hash, falling back to mtime + size) against the value stored
+    in scripts/.manual_mirror_state. If they match the script EXITS with
+    code 2 — the four-store-save check then surfaces the staleness as a
+    failure rather than silently re-mirroring identical content.
+
+    Use --force to mirror anyway (e.g. after a Drive doc was manually
+    truncated or when re-syncing a known-good copy).
 
 Usage:
-    python scripts/write_manual_mirror.py
+    python scripts/write_manual_mirror.py            # checks staleness
+    python scripts/write_manual_mirror.py --force    # bypass staleness check
+    python scripts/write_manual_mirror.py --check    # check only; no Drive write
 
-Requirements:
-    - /home/elliotbot/google-service-account.json
-    - pip install google-api-python-client google-auth (in clawd venv)
-
-Run from any directory. Uses absolute paths internally.
+Exit codes:
+    0  — mirrored successfully (or Drive failure logged best-effort)
+    2  — refused: MANUAL.md unchanged since last mirror; pass --force to override
+    3  — MANUAL.md missing
 """
 from __future__ import annotations
 
+import argparse
+import hashlib
+import json
 import logging
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -29,8 +44,70 @@ GOOGLE_DOC_ID = os.environ.get(
 )
 SERVICE_ACCOUNT_FILE = "/home/elliotbot/google-service-account.json"
 MANUAL_PATH = Path(__file__).parent.parent / "docs" / "MANUAL.md"
+STATE_PATH = Path(__file__).parent / ".manual_mirror_state"
 SCOPES = ["https://www.googleapis.com/auth/documents"]
 
+
+# ─── fingerprinting ────────────────────────────────────────────────────────
+
+def _git_blob_hash(path: Path) -> str | None:
+    """Return the git blob hash of `path`. None if not in a git repo."""
+    try:
+        out = subprocess.check_output(
+            ["git", "hash-object", str(path)],
+            cwd=str(path.parent), stderr=subprocess.DEVNULL,
+        )
+        return out.decode().strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _content_hash(path: Path) -> str:
+    """sha256 of file bytes — fallback when git is unavailable."""
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def fingerprint(path: Path) -> dict:
+    """Return a stable fingerprint dict for the file. Prefers git blob
+    hash so the check is robust against mtime touches that don't change
+    content; falls back to content sha256 + mtime + size."""
+    stat = path.stat()
+    fp: dict = {
+        "path":   str(path),
+        "size":   stat.st_size,
+        "mtime":  stat.st_mtime_ns,
+        "sha256": _content_hash(path),
+    }
+    blob = _git_blob_hash(path)
+    if blob:
+        fp["git_blob"] = blob
+    return fp
+
+
+def load_state() -> dict:
+    if not STATE_PATH.exists():
+        return {}
+    try:
+        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def save_state(state: dict) -> None:
+    STATE_PATH.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
+def is_unchanged(current: dict, last: dict) -> bool:
+    """Equal when the most-stable available identifier matches.
+    Prefers git blob hash; falls back to sha256."""
+    if "git_blob" in current and "git_blob" in last:
+        return current["git_blob"] == last["git_blob"]
+    return current.get("sha256") == last.get("sha256")
+
+
+# ─── mirror impl ───────────────────────────────────────────────────────────
 
 def read_manual() -> str:
     if not MANUAL_PATH.exists():
@@ -61,39 +138,31 @@ def mirror_to_drive(content: str) -> None:
         )
         service = build("docs", "v1", credentials=creds)
 
-        # Get current doc length
         doc = service.documents().get(documentId=GOOGLE_DOC_ID).execute()
         body_content = doc.get("body", {}).get("content", [])
         end_index = body_content[-1].get("endIndex", 2)
 
         requests = []
-
-        # Clear existing content
         if end_index > 2:
             requests.append({
                 "deleteContentRange": {
                     "range": {"startIndex": 1, "endIndex": end_index - 1}
                 }
             })
-
-        # Get updated end index after clear
         if requests:
             service.documents().batchUpdate(
                 documentId=GOOGLE_DOC_ID, body={"requests": requests}
             ).execute()
 
-        # Re-fetch doc after clear
         doc = service.documents().get(documentId=GOOGLE_DOC_ID).execute()
         body_content = doc.get("body", {}).get("content", [])
         end_index = body_content[-1].get("endIndex", 2)
 
-        # Insert new content
         service.documents().batchUpdate(
             documentId=GOOGLE_DOC_ID,
             body={"requests": [{"insertText": {"location": {"index": end_index - 1}, "text": content}}]},
         ).execute()
 
-        # Verify
         doc = service.documents().get(documentId=GOOGLE_DOC_ID).execute()
         body_content = doc.get("body", {}).get("content", [])
         total_chars = sum(
@@ -111,14 +180,71 @@ def mirror_to_drive(content: str) -> None:
         )
 
 
-def main() -> None:
+# ─── entrypoint ────────────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Mirror docs/MANUAL.md to Google Drive.")
+    ap.add_argument(
+        "--force", action="store_true",
+        help="Mirror even if MANUAL.md hasn't changed since last mirror.",
+    )
+    ap.add_argument(
+        "--check", action="store_true",
+        help="Print staleness verdict and exit. No Drive write.",
+    )
+    args = ap.parse_args(argv)
+
+    if not MANUAL_PATH.exists():
+        logger.error(f"MANUAL.md not found at {MANUAL_PATH}")
+        return 3
+
+    current_fp = fingerprint(MANUAL_PATH)
+    state = load_state()
+    last_fp = state.get("last_fingerprint", {})
+
+    unchanged = bool(last_fp) and is_unchanged(current_fp, last_fp)
+
+    if args.check:
+        if unchanged:
+            logger.warning(
+                "MANUAL.md UNCHANGED since last mirror "
+                "(git_blob=%s sha=%s) — staleness check would refuse mirror.",
+                current_fp.get("git_blob", "n/a"), current_fp["sha256"][:12],
+            )
+            return 2
+        logger.info("MANUAL.md CHANGED since last mirror — mirror would proceed.")
+        return 0
+
+    if unchanged and not args.force:
+        logger.error(
+            "MANUAL.md unchanged since last mirror "
+            "(git_blob=%s, sha=%s). Refusing to re-mirror identical content. "
+            "Pass --force to override (e.g. recovering from a manual Drive edit).",
+            current_fp.get("git_blob", "n/a"), current_fp["sha256"][:12],
+        )
+        return 2
+
+    if args.force and unchanged:
+        logger.warning("--force: re-mirroring even though MANUAL.md is unchanged.")
+
     logger.info(f"Reading MANUAL.md from {MANUAL_PATH}")
     content = read_manual()
     logger.info(f"MANUAL.md: {len(content)} chars")
     logger.info("Mirroring to Google Drive...")
     mirror_to_drive(content)
+
+    # Persist the new fingerprint regardless of Drive success — Drive failures
+    # are best-effort and we don't want a stuck DRIVE outage to permanently
+    # block the staleness check.
+    state["last_fingerprint"] = current_fp
+    state["last_mirrored_at"] = (
+        subprocess.check_output(["date", "-Iseconds"]).decode().strip()
+    )
+    save_state(state)
+    logger.info(f"State persisted to {STATE_PATH}")
     logger.info("Done.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/scripts/test_write_manual_mirror.py
+++ b/tests/scripts/test_write_manual_mirror.py
@@ -1,0 +1,165 @@
+"""
+M11 — Tests for scripts/write_manual_mirror.py staleness check.
+
+Covers:
+  - fingerprint() captures sha256 + size + mtime; git_blob present in git repo
+  - is_unchanged() returns True only when the stable identifier matches
+  - load_state / save_state roundtrip
+  - main() exits 2 when MANUAL.md unchanged since last mirror
+  - main() exits 0 when MANUAL.md changed (Drive write mocked)
+  - main() with --force exits 0 even when unchanged
+  - main() with --check exits 2 when stale, 0 when fresh, no Drive write
+  - main() exits 3 when MANUAL.md missing
+  - state file is updated after a successful mirror
+
+Pure file/process I/O — no Drive calls (mirror_to_drive monkeypatched).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "write_manual_mirror.py"
+_spec = importlib.util.spec_from_file_location("write_manual_mirror", _SCRIPT)
+mirror = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(mirror)
+
+
+@pytest.fixture()
+def tmp_manual(tmp_path, monkeypatch):
+    """Redirect MANUAL_PATH + STATE_PATH to a temp dir for isolation."""
+    manual = tmp_path / "MANUAL.md"
+    state = tmp_path / ".manual_mirror_state"
+    manual.write_text("# initial\n\nfirst version of the manual.\n")
+    monkeypatch.setattr(mirror, "MANUAL_PATH", manual)
+    monkeypatch.setattr(mirror, "STATE_PATH", state)
+    return manual, state
+
+
+# ─── fingerprint ───────────────────────────────────────────────────────────
+
+def test_fingerprint_includes_sha_and_size(tmp_manual):
+    manual, _ = tmp_manual
+    fp = mirror.fingerprint(manual)
+    assert "sha256" in fp
+    assert "size" in fp
+    assert fp["size"] == manual.stat().st_size
+
+
+def test_is_unchanged_matches_on_sha_only_when_no_git_blob():
+    a = {"sha256": "abc", "size": 10}
+    b = {"sha256": "abc", "size": 10}
+    c = {"sha256": "xyz", "size": 10}
+    assert mirror.is_unchanged(a, b) is True
+    assert mirror.is_unchanged(a, c) is False
+
+
+def test_is_unchanged_prefers_git_blob_when_present():
+    a = {"sha256": "abc", "git_blob": "deadbeef"}
+    b = {"sha256": "different", "git_blob": "deadbeef"}
+    # sha256 differs (impossible in real life but tests preference) — git_blob wins
+    assert mirror.is_unchanged(a, b) is True
+
+
+# ─── state roundtrip ───────────────────────────────────────────────────────
+
+def test_load_state_returns_empty_when_missing(tmp_manual):
+    _, state = tmp_manual
+    assert not state.exists()
+    assert mirror.load_state() == {}
+
+
+def test_save_then_load_state_roundtrip(tmp_manual):
+    _, state = tmp_manual
+    payload = {"last_fingerprint": {"sha256": "abc"}, "last_mirrored_at": "2026-04-25T12:00:00+00:00"}
+    mirror.save_state(payload)
+    assert state.exists()
+    assert mirror.load_state() == payload
+
+
+# ─── main() flows ──────────────────────────────────────────────────────────
+
+def test_main_exits_3_when_manual_missing(tmp_manual, caplog):
+    manual, _ = tmp_manual
+    manual.unlink()
+    code = mirror.main([])
+    assert code == 3
+
+
+def test_main_first_run_succeeds_and_writes_state(tmp_manual, caplog):
+    _, state = tmp_manual
+    with patch.object(mirror, "mirror_to_drive") as m:
+        code = mirror.main([])
+    assert code == 0
+    m.assert_called_once()
+    saved = json.loads(state.read_text())
+    assert "last_fingerprint" in saved
+    assert "sha256" in saved["last_fingerprint"]
+
+
+def test_main_refuses_when_unchanged(tmp_manual, caplog):
+    _, state = tmp_manual
+    # First mirror
+    with patch.object(mirror, "mirror_to_drive"):
+        assert mirror.main([]) == 0
+    # Second run with no changes — must refuse
+    with patch.object(mirror, "mirror_to_drive") as m:
+        code = mirror.main([])
+    assert code == 2
+    m.assert_not_called()
+
+
+def test_main_force_overrides_staleness_check(tmp_manual):
+    # Seed state so the next plain run would be unchanged
+    with patch.object(mirror, "mirror_to_drive"):
+        mirror.main([])
+    # --force must mirror even though nothing changed
+    with patch.object(mirror, "mirror_to_drive") as m:
+        code = mirror.main(["--force"])
+    assert code == 0
+    m.assert_called_once()
+
+
+def test_main_proceeds_when_manual_changes(tmp_manual):
+    manual, _ = tmp_manual
+    with patch.object(mirror, "mirror_to_drive"):
+        mirror.main([])
+    # Edit the file
+    manual.write_text(manual.read_text() + "\n\n## NEW SECTION\n")
+    with patch.object(mirror, "mirror_to_drive") as m:
+        code = mirror.main([])
+    assert code == 0
+    m.assert_called_once()
+
+
+def test_main_check_mode_prints_verdict_no_drive_write(tmp_manual):
+    """--check exits 0 when fresh, 2 when stale, never calls mirror."""
+    # Fresh first run — no state yet, treated as 'changed'
+    with patch.object(mirror, "mirror_to_drive") as m:
+        assert mirror.main(["--check"]) == 0
+    m.assert_not_called()
+    # Persist a state matching current content
+    with patch.object(mirror, "mirror_to_drive"):
+        mirror.main([])
+    # Now --check should report stale
+    with patch.object(mirror, "mirror_to_drive") as m2:
+        assert mirror.main(["--check"]) == 2
+    m2.assert_not_called()
+
+
+# ─── post-commit hook smoke ────────────────────────────────────────────────
+
+def test_post_commit_hook_exists_and_executable():
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    hook = repo_root / ".githooks" / "post-commit"
+    assert hook.exists(), "post-commit hook missing"
+    assert os.access(str(hook), os.X_OK), "post-commit hook not executable"
+    body = hook.read_text()
+    assert "docs/MANUAL.md" in body
+    assert "write_manual_mirror.py" in body

--- a/tests/scripts/test_write_manual_mirror.py
+++ b/tests/scripts/test_write_manual_mirror.py
@@ -163,3 +163,92 @@ def test_post_commit_hook_exists_and_executable():
     body = hook.read_text()
     assert "docs/MANUAL.md" in body
     assert "write_manual_mirror.py" in body
+
+
+# ─── M11-3 — hook uses pinned venv python ──────────────────────────────────
+
+def test_post_commit_hook_uses_venv_python():
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    body = (repo_root / ".githooks" / "post-commit").read_text()
+    assert "/home/elliotbot/clawd/venv/bin/python3" in body, (
+        "hook must pin venv interpreter (M11-3)"
+    )
+
+
+# ─── M11-2 — shared state path ─────────────────────────────────────────────
+
+def test_state_path_lives_under_shared_config_dir():
+    """Default STATE_PATH must point at ~/.config/agency-os, not in scripts/."""
+    expected = Path.home() / ".config" / "agency-os" / ".manual_mirror_state"
+    assert expected == mirror.STATE_PATH
+
+
+def test_load_state_migrates_legacy_path(tmp_path, monkeypatch):
+    """When the shared file is missing but the legacy per-worktree file
+    exists, load_state() copies it forward."""
+    shared = tmp_path / "shared" / ".manual_mirror_state"
+    legacy = tmp_path / "legacy" / ".manual_mirror_state"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text(json.dumps({"last_fingerprint": {"sha256": "legacy-sha"}}))
+    monkeypatch.setattr(mirror, "STATE_PATH", shared)
+    monkeypatch.setattr(mirror, "_LEGACY_STATE_PATH", legacy)
+
+    loaded = mirror.load_state()
+    assert loaded["last_fingerprint"]["sha256"] == "legacy-sha"
+    assert shared.exists()  # migrated forward
+    assert json.loads(shared.read_text())["last_fingerprint"]["sha256"] == "legacy-sha"
+
+
+# ─── M11-1 — hook installation + warning ───────────────────────────────────
+
+def test_install_runs_git_config(monkeypatch):
+    """--install must call `git config core.hooksPath .githooks` and
+    return 0 when the hook file is present + executable."""
+    calls: list[list[str]] = []
+
+    def fake_check_call(args, cwd=None, **_):
+        calls.append(args)
+        return 0
+
+    monkeypatch.setattr("subprocess.check_call", fake_check_call)
+    code = mirror.main(["--install"])
+    assert code == 0
+    assert any(a[:3] == ["git", "config", "core.hooksPath"] for a in calls)
+
+
+def test_install_returns_4_when_hook_missing(monkeypatch, tmp_path):
+    """install_hook should fail loudly if .githooks/post-commit is gone."""
+    monkeypatch.setattr(mirror, "REPO_ROOT", tmp_path)  # no .githooks dir
+    code = mirror.install_hook()
+    assert code == 4
+
+
+def test_warn_when_hook_not_installed(monkeypatch, caplog, tmp_manual):
+    """When core.hooksPath is unset, main() emits a single warning then
+    proceeds (non-fatal)."""
+    monkeypatch.setattr(mirror, "_current_hooks_path", lambda: None)
+    with caplog.at_level("WARNING"), patch.object(mirror, "mirror_to_drive"):
+        mirror.main([])
+    assert any(
+        "post-commit hook not installed" in r.message for r in caplog.records
+    )
+
+
+def test_no_warn_when_hook_correctly_installed(monkeypatch, caplog, tmp_manual):
+    """When core.hooksPath == .githooks, no install warning is emitted."""
+    monkeypatch.setattr(mirror, "_current_hooks_path", lambda: ".githooks")
+    with caplog.at_level("WARNING"), patch.object(mirror, "mirror_to_drive"):
+        mirror.main([])
+    for r in caplog.records:
+        assert "post-commit hook not installed" not in r.message
+        assert "core.hooksPath = " not in r.message
+
+
+def test_warn_when_hook_path_points_elsewhere(monkeypatch, caplog, tmp_manual):
+    """A non-.githooks setting should produce the 'not .githooks' warning."""
+    monkeypatch.setattr(mirror, "_current_hooks_path", lambda: ".husky")
+    with caplog.at_level("WARNING"), patch.object(mirror, "mirror_to_drive"):
+        mirror.main([])
+    assert any(
+        ".husky" in r.message and ".githooks" in r.message for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- Staleness check: compares MANUAL.md git hash against last-mirrored hash
- Exits non-zero when MANUAL.md unchanged since last mirror (catches stale four-store saves)
- `--force` flag overrides the check for intentional re-mirrors
- State file `.manual_mirror_state` tracks last-mirrored commit hash
- Closes roadmap M11, addresses the stale-mirror incident from this session

## Test plan
- [x] Mirror refuses when MANUAL.md unchanged
- [x] `--force` overrides check
- [x] State file updated after successful mirror
- [x] Aiden peer review pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)