### PR TITLE
[ATLAS] H10 — add moved_to to inotifywait in relay watcher

### DIFF
--- a/src/telegram_bot/relay_watcher.sh
+++ b/src/telegram_bot/relay_watcher.sh
@@ -24,7 +24,9 @@ mkdir -p "$INBOX" "$PROCESSED"
 
 echo "[relay-watcher-${CALLSIGN}] Started. Watching $INBOX → tmux $TMUX_TARGET"
 
-inotifywait -m -q -e create "$INBOX" --format '%f' 2>/dev/null | while read fname; do
+# H10 — also watch -e moved_to so we don't drop dispatches the Write tool
+# delivers via atomic rename (which fires moved_to, not create).
+inotifywait -m -q -e create -e moved_to "$INBOX" --format '%f' 2>/dev/null | while read fname; do
     # Only process JSON metadata files
     [[ "$fname" != *.json ]] && continue
 


### PR DESCRIPTION
## Summary
One-line fix: the Telegram → tmux relay watcher only subscribed to inotify `create` events, so dispatches written via the Write tool (which delivers files via atomic rename → fires `moved_to`, not `create`) were silently dropped.

\`\`\`diff
- inotifywait -m -q -e create "\$INBOX" --format '%f' …
+ inotifywait -m -q -e create -e moved_to "\$INBOX" --format '%f' …
\`\`\`

## Files
- \`src/telegram_bot/relay_watcher.sh\` — the only watcher in the repo. The dispatch listed four scripts (\`atlas_inbox_watcher.sh\`, \`orion_inbox_watcher.sh\`, \`atlas_relay_watcher.sh\`, \`orion_relay_watcher.sh\`); none exist. The single canonical watcher is parametrised by callsign (\`\$1\` defaulting to \`elliot\`) and serves atlas/orion/elliot/scout from one implementation. Fix covers all callsigns.

## Test plan
- [x] \`bash -n src/telegram_bot/relay_watcher.sh\` — syntax OK
- [x] grep confirms \`-e create -e moved_to\` together on the inotifywait line
- [ ] Reviewer: restart relay watchers (\`systemctl --user restart atlas-relay-watcher orion-relay-watcher elliot-relay-watcher\` or equivalent) so the new flag takes effect
- [ ] Reviewer: drop a JSON dispatch into \`/tmp/telegram-relay-elliot/inbox/\` via Write (atomic rename) and confirm it relays to the tmux pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)