### PR TITLE
[ATLAS] feat: M8 — Prefect 3.x deployment migration

### DIFF
--- a/src/orchestration/deployments/__init__.py
+++ b/src/orchestration/deployments/__init__.py
@@ -1,14 +1,25 @@
 """
-Prefect Deployments Package
-Contains deployment configurations for all flows.
+Prefect Deployments Package — config dicts + serve() entry-points.
+
+M8 (2026-04-26): The legacy `Deployment.build_from_flow(...)` API was
+removed in Prefect 3.x. Each deployment file now exposes a config dict
+(consumed by tests) plus a `serve()` callable; the deployment object no
+longer exists at module-import time, so the legacy re-exports
+(cis_weekly_deployment / cis_manual_deployment) have been removed.
+
+Production deployments are configured in prefect.yaml. The .py files in
+this package are for ad-hoc / local-dev `flow.serve()` sessions — run
+each as `python -m src.orchestration.deployments.X` when needed.
 """
 
 from src.orchestration.deployments.cis_learning_deployment import (
-    cis_manual_deployment,
-    cis_weekly_deployment,
+    MANUAL_CONFIG as cis_manual_config,
+)
+from src.orchestration.deployments.cis_learning_deployment import (
+    WEEKLY_CONFIG as cis_weekly_config,
 )
 
 __all__ = [
-    "cis_weekly_deployment",
-    "cis_manual_deployment",
+    "cis_weekly_config",
+    "cis_manual_config",
 ]

--- a/src/orchestration/deployments/bu_closed_loop_deployment.py
+++ b/src/orchestration/deployments/bu_closed_loop_deployment.py
@@ -3,6 +3,14 @@
 Directive: BU Closed-Loop Engine — Substep 2 of 4.
 Posture:   PAUSED by default. Schedule: daily 04:00 UTC.
 
+M8 — migrated from Deployment.build_from_flow (removed in Prefect 3.x)
+to flow.serve() per Prefect 3 docs. The DEPLOYMENT_CONFIG dict is the
+single source of truth and is consumed both by the __main__ entry-point
+(when this file is run directly) and by tests that validate config shape.
+
+Production deployment is canonical via prefect.yaml's `bu-closed-loop-flow`
+entry — running this script is for ad-hoc / local-dev serve sessions.
+
 Unpause criteria (per repo pause-governance policy in prefect.yaml):
   - S3 (data-mapping) ratified — domain_data reconstruction from BU columns
     needs to be complete enough that _run_stageN early-exits drop below
@@ -10,36 +18,37 @@ Unpause criteria (per repo pause-governance policy in prefect.yaml):
   - Live-spend safety review confirmed AUD 0 budget enforcement holds when
     free_mode_only=True at scale.
 """
-from prefect.deployments import Deployment
-from prefect.server.schemas.schedules import CronSchedule
-
 from src.orchestration.flows.bu_closed_loop_flow import bu_closed_loop_flow
 
-bu_closed_loop_deployment = Deployment.build_from_flow(
-    flow=bu_closed_loop_flow,
-    name="bu-closed-loop-flow",
-    version="1.0.0",
-    tags=["bu-closed-loop", "backlog-driver", "free-mode", "paused"],
-    description=(
+DEPLOYMENT_CONFIG = {
+    "name":        "bu-closed-loop-flow",
+    "version":     "1.0.0",
+    "tags":        ["bu-closed-loop", "backlog-driver", "free-mode", "paused"],
+    "description": (
         "BU Closed-Loop S2 backlog driver. PAUSED by default. Daily 04:00 UTC "
         "scan of stuck BU rows; advances by one stage per row in free-mode "
         "(zero AUD spend) using age-tiered cadence."
     ),
-    schedule=CronSchedule(cron="0 4 * * *", timezone="UTC"),
-    is_schedule_active=False,  # Schedule INACTIVE until S3 ratifies
-    parameters={
-        "max_rows": 500,
-        "free_mode_only": True,
-        "cadence_hot_days": 14,
+    "cron":        "0 4 * * *",
+    "paused":      True,  # PAUSED until S3 ratifies (was is_schedule_active=False)
+    "parameters": {
+        "max_rows":          500,
+        "free_mode_only":    True,
+        "cadence_hot_days":  14,
         "cadence_warm_days": 60,
         "cadence_cold_days": 180,
     },
-    work_queue_name="default",
-)
+}
+
+
+def serve() -> None:
+    """Run the flow as a long-lived Prefect 3 server.
+    Replaces the legacy Deployment.build_from_flow.apply pattern pattern."""
+    bu_closed_loop_flow.serve(**DEPLOYMENT_CONFIG)
 
 
 if __name__ == "__main__":
-    bu_closed_loop_deployment.apply()
-    print("Deployed: bu-closed-loop-flow/bu-closed-loop-flow (PAUSED, 04:00 UTC daily)")
+    print("Serving: bu-closed-loop-flow (PAUSED, 04:00 UTC daily)")
     print("Run via: prefect deployment run 'bu-closed-loop-flow/bu-closed-loop-flow'")
     print("Override: -p max_rows=100 -p free_mode_only=true -p cadence_hot_days=7")
+    serve()

--- a/src/orchestration/deployments/cis_learning_deployment.py
+++ b/src/orchestration/deployments/cis_learning_deployment.py
@@ -9,66 +9,71 @@ Schedule: Every Sunday at 3:00 AM UTC
 
 Manual trigger available via:
     prefect deployment run 'cis-learning-engine/cis-weekly'
+
+M8 — migrated from Deployment.build_from_flow (removed in Prefect 3.x)
+to flow.serve() per Prefect 3 docs. The CONFIG dicts are the single
+source of truth and importable for tests; the __main__ block hands them
+to flow.serve() to start the deployment server.
 """
-
-from prefect.deployments import Deployment
-from prefect.server.schemas.schedules import CronSchedule
-
 from src.orchestration.flows.cis_learning_flow import cis_learning_flow
 
-# Weekly deployment - runs every Sunday at 3 AM UTC
-cis_weekly_deployment = Deployment.build_from_flow(
-    flow=cis_learning_flow,
-    name="cis-weekly",
-    version="1.0.0",
-    tags=["cis", "learning", "weekly", "directive-147"],
-    description=(
+# Weekly deployment — runs every Sunday at 3 AM UTC
+WEEKLY_CONFIG = {
+    "name":        "cis-weekly",
+    "version":     "1.0.0",
+    "tags":        ["cis", "learning", "weekly", "directive-147"],
+    "description": (
         "Directive #147: CIS Learning Engine - Weekly weight adjustment. "
         "Analyzes meeting outcomes and adjusts propensity weights for "
         "continuous improvement. This is the moat."
     ),
-    schedule=CronSchedule(
-        cron="0 3 * * 0",  # Every Sunday at 3:00 AM UTC
-        timezone="UTC",
-    ),
-    parameters={
+    "cron":        "0 3 * * 0",  # Every Sunday at 3:00 AM UTC
+    "parameters": {
         "customer_id": None,  # Global weights
-        "run_type": "weekly",
+        "run_type":    "weekly",
     },
-    work_queue_name="default",
-)
+}
 
 
-# Manual/on-demand deployment - no schedule
-cis_manual_deployment = Deployment.build_from_flow(
-    flow=cis_learning_flow,
-    name="cis-manual",
-    version="1.0.0",
-    tags=["cis", "learning", "manual", "directive-147"],
-    description=(
+# Manual / on-demand deployment — no schedule
+MANUAL_CONFIG = {
+    "name":        "cis-manual",
+    "version":     "1.0.0",
+    "tags":        ["cis", "learning", "manual", "directive-147"],
+    "description": (
         "Directive #147: CIS Learning Engine - Manual trigger. "
         "Use for testing or forced weight updates."
     ),
-    schedule=None,  # No automatic schedule
-    parameters={
+    # No 'cron' key — Prefect interprets absence as no schedule.
+    "parameters": {
         "customer_id": None,
-        "run_type": "manual",
+        "run_type":    "manual",
     },
-    work_queue_name="default",
-)
+}
+
+
+def serve_weekly() -> None:
+    """Long-running serve for the weekly deployment."""
+    cis_learning_flow.serve(**WEEKLY_CONFIG)
+
+
+def serve_manual() -> None:
+    """Long-running serve for the manual deployment."""
+    cis_learning_flow.serve(**MANUAL_CONFIG)
+
+
+def serve_both() -> None:
+    """Serve both weekly + manual under one process. Prefect 3 supports
+    multi-deployment serve via flow.serve.to_deployment + serve(...)."""
+    weekly = cis_learning_flow.to_deployment(**WEEKLY_CONFIG)
+    manual = cis_learning_flow.to_deployment(**MANUAL_CONFIG)
+    from prefect import serve as _serve
+    _serve(weekly, manual)
 
 
 if __name__ == "__main__":
-    # Deploy both configurations
-    cis_weekly_deployment.apply()
-    print("✓ Deployed: cis-learning-engine/cis-weekly (Sundays 3 AM UTC)")
-
-    cis_manual_deployment.apply()
-    print("✓ Deployed: cis-learning-engine/cis-manual (on-demand)")
-
-    print("\nDeployment commands:")
-    print("  Run weekly:  prefect deployment run 'cis-learning-engine/cis-weekly'")
-    print("  Run manual:  prefect deployment run 'cis-learning-engine/cis-manual'")
-    print(
-        "  With customer: prefect deployment run 'cis-learning-engine/cis-manual' -p customer_id=<uuid>"
-    )
+    print("Serving: cis-learning-engine/cis-weekly + cis-manual")
+    print("Run weekly:    prefect deployment run 'cis-learning-engine/cis-weekly'")
+    print("Run manual:    prefect deployment run 'cis-learning-engine/cis-manual'")
+    print("With customer: prefect deployment run 'cis-learning-engine/cis-manual' -p customer_id=<uuid>")
+    serve_both()

--- a/src/orchestration/deployments/free_enrichment_deployment.py
+++ b/src/orchestration/deployments/free_enrichment_deployment.py
@@ -5,34 +5,40 @@ Posture:   ACTIVE (paused=false). Stage 1 is AUD 0 — local DNS / httpx /
            abn_registry. Spider fallback is gated by SPIDER_API_KEY env var.
 Schedule:  Hourly safety-net so newly-discovered BU rows enter the
            enrichment cursor without manual intervention.
-"""
-from prefect.deployments import Deployment
-from prefect.server.schemas.schedules import CronSchedule
 
+M8 — migrated from Deployment.build_from_flow (removed in Prefect 3.x)
+to flow.serve(). Production deployment is canonical via prefect.yaml's
+`free-enrichment-flow` entry; running this script is for ad-hoc /
+local-dev serve sessions.
+"""
 from src.orchestration.flows.free_enrichment_flow import free_enrichment_flow
 
-free_enrichment_deployment = Deployment.build_from_flow(
-    flow=free_enrichment_flow,
-    name="free-enrichment-flow",
-    version="1.0.0",
-    tags=["bu-closed-loop", "free-enrichment", "stage-0-trigger", "free-mode"],
-    description=(
+DEPLOYMENT_CONFIG = {
+    "name":        "free-enrichment-flow",
+    "version":     "1.0.0",
+    "tags":        ["bu-closed-loop", "free-enrichment", "stage-0-trigger", "free-mode"],
+    "description": (
         "BU Closed-Loop S3 free-enrichment flow. ACTIVE (AUD 0 — local DNS / "
         "httpx / abn_registry). Hourly safety-net: promotes stage-0/NULL BU "
         "rows to stage 1 then runs FreeEnrichment.run() over the backlog."
     ),
-    schedule=CronSchedule(cron="15 * * * *", timezone="UTC"),
-    is_schedule_active=True,
-    parameters={
-        "limit": 500,
+    "cron":        "15 * * * *",
+    "paused":      False,  # ACTIVE — was is_schedule_active=True
+    "parameters": {
+        "limit":           500,
         "promote_stage_0": True,
     },
-    work_queue_name="default",
-)
+}
+
+
+def serve() -> None:
+    """Run the flow as a long-lived Prefect 3 server.
+    Replaces the legacy Deployment.build_from_flow.apply pattern pattern."""
+    free_enrichment_flow.serve(**DEPLOYMENT_CONFIG)
 
 
 if __name__ == "__main__":
-    free_enrichment_deployment.apply()
-    print("Deployed: free-enrichment-flow/free-enrichment-flow (ACTIVE, hourly :15)")
+    print("Serving: free-enrichment-flow (ACTIVE, hourly :15)")
     print("Run via: prefect deployment run 'free-enrichment-flow/free-enrichment-flow'")
     print("Override: -p limit=200 -p promote_stage_0=false")
+    serve()

--- a/src/orchestration/deployments/pipeline_f_deployment.py
+++ b/src/orchestration/deployments/pipeline_f_deployment.py
@@ -3,38 +3,44 @@ P4 Build — manual trigger for P5 validation, cron placeholder for production.
 
 T4 (2026-04-24): Deployment parameters now include tier / demo_mode / client_id
 so a single deployment can be triggered per-tier or per-client without redeploying.
-"""
-from prefect.deployments import Deployment
-from prefect.server.schemas.schedules import CronSchedule
 
+M8 (2026-04-26): Migrated from Deployment.build_from_flow (removed in
+Prefect 3.x) to flow.serve() per Prefect 3 docs. Production deployment is
+canonical via prefect.yaml's `pipeline-f-master-flow` entry; running this
+script is for ad-hoc / local-dev serve sessions.
+"""
 from src.orchestration.flows.pipeline_f_master_flow import pipeline_f_master_flow
 
-pipeline_f_deployment = Deployment.build_from_flow(
-    flow=pipeline_f_master_flow,
-    name="pipeline-f-p5",
-    version="1.1.0",
-    tags=["p4", "pipeline-f", "master-flow", "cd-player-v1"],
-    description=(
+DEPLOYMENT_CONFIG = {
+    "name":        "pipeline-f-p5",
+    "version":     "1.1.0",
+    "tags":        ["p4", "pipeline-f", "master-flow", "cd-player-v1"],
+    "description": (
         "P4 Build: Pipeline F master flow (CD Player v1). Manual trigger for P5 validation. "
         "Tier-aware runtime via {tier, demo_mode, client_id} parameters."
     ),
-    schedule=None,  # Manual trigger only for P5. Production cron TBD post-P5.
-    parameters={
+    # No 'cron' key — manual trigger only for P5. Production cron TBD post-P5.
+    "parameters": {
         # T4 params — tier-aware CD Player v1 wiring
-        "tier": "ignition",
-        "demo_mode": False,
-        "client_id": None,
+        "tier":           "ignition",
+        "demo_mode":      False,
+        "client_id":      None,
         # Legacy discovery + budget knobs
-        "categories": ["dental", "plumbing", "legal", "accounting", "fitness"],
-        "dry_run": False,
+        "categories":     ["dental", "plumbing", "legal", "accounting", "fitness"],
+        "dry_run":        False,
         "budget_cap_aud": None,  # None → let tier default win (see _tier_runtime)
     },
-    work_queue_name="default",
-)
+}
+
+
+def serve() -> None:
+    """Run the flow as a long-lived Prefect 3 server.
+    Replaces the legacy Deployment.build_from_flow.apply pattern pattern."""
+    pipeline_f_master_flow.serve(**DEPLOYMENT_CONFIG)
 
 
 if __name__ == "__main__":
-    pipeline_f_deployment.apply()
-    print("Deployed: pipeline-f-master-flow/pipeline-f-p5 (manual trigger, tier-aware)")
+    print("Serving: pipeline-f-master-flow/pipeline-f-p5 (manual trigger, tier-aware)")
     print("Run via: prefect deployment run 'pipeline-f-master-flow/pipeline-f-p5'")
     print("Override params: prefect deployment run '...' -p tier=spark -p demo_mode=true -p client_id=test")
+    serve()

--- a/tests/orchestration/test_deployments.py
+++ b/tests/orchestration/test_deployments.py
@@ -1,0 +1,106 @@
+"""
+M8 — smoke tests for the migrated Prefect 3.x deployment modules.
+
+Each test confirms:
+  - the module imports without raising (i.e. no leftover prefect.deployments
+    or prefect.server.schemas references)
+  - the DEPLOYMENT_CONFIG dict (or per-deployment CONFIG dicts) carries the
+    canonical fields flow.serve() / flow.deploy() will accept
+  - serve()-style callables exist and reference the live flow object
+
+No live Prefect server required — flow.serve() itself is NOT invoked.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+EXPECTED_KEYS_REQUIRED = {"name", "version", "tags", "description", "parameters"}
+
+
+@pytest.mark.parametrize("module_name", [
+    "src.orchestration.deployments.bu_closed_loop_deployment",
+    "src.orchestration.deployments.cis_learning_deployment",
+    "src.orchestration.deployments.free_enrichment_deployment",
+    "src.orchestration.deployments.pipeline_f_deployment",
+])
+def test_module_imports_cleanly(module_name):
+    """Importing the module must not raise (the old import was
+    `from prefect.deployments import Deployment` which is gone)."""
+    mod = importlib.import_module(module_name)
+    assert mod is not None
+
+
+def test_bu_closed_loop_config_shape():
+    from src.orchestration.deployments import bu_closed_loop_deployment as m
+    cfg = m.DEPLOYMENT_CONFIG
+    assert EXPECTED_KEYS_REQUIRED.issubset(cfg.keys())
+    assert cfg["name"] == "bu-closed-loop-flow"
+    assert cfg["cron"] == "0 4 * * *"
+    assert cfg["paused"] is True
+    assert callable(m.serve)
+
+
+def test_free_enrichment_config_shape():
+    from src.orchestration.deployments import free_enrichment_deployment as m
+    cfg = m.DEPLOYMENT_CONFIG
+    assert EXPECTED_KEYS_REQUIRED.issubset(cfg.keys())
+    assert cfg["name"] == "free-enrichment-flow"
+    assert cfg["cron"] == "15 * * * *"
+    assert cfg["paused"] is False
+    assert callable(m.serve)
+
+
+def test_pipeline_f_config_shape():
+    from src.orchestration.deployments import pipeline_f_deployment as m
+    cfg = m.DEPLOYMENT_CONFIG
+    assert EXPECTED_KEYS_REQUIRED.issubset(cfg.keys())
+    assert cfg["name"] == "pipeline-f-p5"
+    # No cron — manual-trigger only
+    assert "cron" not in cfg
+    assert callable(m.serve)
+
+
+def test_cis_learning_has_two_configs():
+    from src.orchestration.deployments import cis_learning_deployment as m
+    assert EXPECTED_KEYS_REQUIRED.issubset(m.WEEKLY_CONFIG.keys())
+    assert EXPECTED_KEYS_REQUIRED.issubset(m.MANUAL_CONFIG.keys())
+    assert m.WEEKLY_CONFIG["cron"] == "0 3 * * 0"
+    # Manual has no cron
+    assert "cron" not in m.MANUAL_CONFIG
+    assert callable(m.serve_weekly)
+    assert callable(m.serve_manual)
+    assert callable(m.serve_both)
+
+
+def test_no_legacy_imports_in_any_deployment_file():
+    """Sanity — no live call to the deprecated Prefect 3.x APIs.
+    Docstring mentions are allowed (the M8 migration note references the
+    old API by name); we forbid the actual import + call sites only."""
+    import inspect
+    forbidden_lines = (
+        "from prefect.deployments import Deployment",
+        "from prefect.server.schemas",
+        ".build_from_flow(",
+    )
+    for name in (
+        "src.orchestration.deployments.bu_closed_loop_deployment",
+        "src.orchestration.deployments.cis_learning_deployment",
+        "src.orchestration.deployments.free_enrichment_deployment",
+        "src.orchestration.deployments.pipeline_f_deployment",
+    ):
+        mod = importlib.import_module(name)
+        src = inspect.getsource(mod)
+        for token in forbidden_lines:
+            assert token not in src, f"{name} still references deprecated {token!r}"
+
+
+def test_init_exports_config_dicts_not_objects():
+    """The package __init__ used to re-export deployment objects which
+    no longer exist after migration. Confirm it now exports the configs."""
+    from src.orchestration import deployments
+    assert hasattr(deployments, "cis_weekly_config")
+    assert hasattr(deployments, "cis_manual_config")
+    assert deployments.cis_weekly_config["name"] == "cis-weekly"
+    assert deployments.cis_manual_config["name"] == "cis-manual"


### PR DESCRIPTION
## Summary
- Migrate all deployment files from deprecated `Deployment.build_from_flow()` to `flow.serve()` pattern
- Prefect 3.x compatible deployment wiring
- No flow logic changes — deployment plumbing only

## Test plan
- [x] All deployment files importable without error
- [x] Aiden peer review pending
- [ ] Prefect deployment inspect (requires live Prefect server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)