### PR TITLE
[ATLAS] feat: M10 — BU readiness threshold instrumentation

### DIFF
--- a/frontend/components/BUReadinessWidget.tsx
+++ b/frontend/components/BUReadinessWidget.tsx
@@ -1,0 +1,170 @@
+/**
+ * FILE: frontend/components/BUReadinessWidget.tsx
+ * PURPOSE: M10 — surface BU sellable thresholds (Coverage / Verified /
+ *          Outcomes / Trajectory) on the dashboard.
+ * PHASE:   M10 — BU readiness threshold instrumentation
+ *
+ * Polls /api/v1/bu/readiness on mount + every 60s. Each metric is shown
+ * with a progress bar against its threshold and a pass/fail badge:
+ *   - emerald: threshold met
+ *   - amber:   between 50% and 100% of threshold
+ *   - red:     below 50% of threshold
+ */
+
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { CheckCircle2, AlertTriangle, XCircle } from "lucide-react";
+import api from "@/lib/api";
+
+interface ReadinessMetric {
+  name: string;
+  value: number;
+  unit: "pct" | "count";
+  threshold: number;
+  pass: boolean;
+  detail: string;
+}
+
+interface ReadinessResponse {
+  metrics: ReadinessMetric[];
+  overall_pass: boolean;
+}
+
+const LABELS: Record<string, string> = {
+  coverage:   "Coverage",
+  verified:   "Verified contacts",
+  outcomes:   "Outcomes",
+  trajectory: "Trajectory",
+};
+
+function fmt(metric: ReadinessMetric): string {
+  if (metric.unit === "pct") return `${metric.value.toFixed(1)}%`;
+  return metric.value.toLocaleString();
+}
+
+function fmtThreshold(metric: ReadinessMetric): string {
+  if (metric.unit === "pct") return `≥ ${metric.threshold.toFixed(0)}%`;
+  return `≥ ${metric.threshold.toLocaleString()}`;
+}
+
+function ratio(metric: ReadinessMetric): number {
+  if (metric.threshold <= 0) return 0;
+  return Math.min(1, metric.value / metric.threshold);
+}
+
+function colorBand(metric: ReadinessMetric): {
+  bar: string; badge: string; text: string; icon: JSX.Element;
+} {
+  const r = ratio(metric);
+  if (metric.pass) {
+    return {
+      bar:   "bg-emerald-500",
+      badge: "bg-emerald-500/15 border-emerald-500/40 text-emerald-300",
+      text:  "text-emerald-300",
+      icon:  <CheckCircle2 className="w-3.5 h-3.5" />,
+    };
+  }
+  if (r >= 0.5) {
+    return {
+      bar:   "bg-amber-500",
+      badge: "bg-amber-500/15 border-amber-500/40 text-amber-300",
+      text:  "text-amber-300",
+      icon:  <AlertTriangle className="w-3.5 h-3.5" />,
+    };
+  }
+  return {
+    bar:   "bg-red-500",
+    badge: "bg-red-500/15 border-red-500/40 text-red-300",
+    text:  "text-red-300",
+    icon:  <XCircle className="w-3.5 h-3.5" />,
+  };
+}
+
+async function fetchReadiness(): Promise<ReadinessResponse | null> {
+  try {
+    return await api.get<ReadinessResponse>("/api/v1/bu/readiness");
+  } catch {
+    return null;
+  }
+}
+
+export function BUReadinessWidget() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["bu-readiness"],
+    queryFn: fetchReadiness,
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
+  });
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+      <header className="flex items-center justify-between mb-3">
+        <h3 className="font-mono text-[11px] uppercase tracking-widest text-gray-400">
+          BU readiness
+        </h3>
+        {data && (
+          <span
+            className={`inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-mono uppercase tracking-widest rounded border ${
+              data.overall_pass
+                ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-300"
+                : "bg-red-500/15 border-red-500/40 text-red-300"
+            }`}
+          >
+            {data.overall_pass ? (
+              <CheckCircle2 className="w-3 h-3" />
+            ) : (
+              <XCircle className="w-3 h-3" />
+            )}
+            {data.overall_pass ? "Sellable" : "Not yet"}
+          </span>
+        )}
+      </header>
+
+      {isLoading ? (
+        <div className="text-xs text-gray-500 italic py-3">Loading…</div>
+      ) : !data ? (
+        <div className="text-xs text-gray-500 italic py-3">
+          BU readiness endpoint unavailable.
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {data.metrics.map((m) => {
+            const { bar, badge, text, icon } = colorBand(m);
+            const pct = ratio(m) * 100;
+            return (
+              <li key={m.name}>
+                <div className="flex items-baseline justify-between mb-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-[10px] uppercase tracking-widest text-gray-400">
+                      {LABELS[m.name] ?? m.name}
+                    </span>
+                    <span
+                      className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-widest rounded border ${badge}`}
+                    >
+                      {icon}
+                      {m.pass ? "PASS" : "FAIL"}
+                    </span>
+                  </div>
+                  <div className="text-[11px] font-mono">
+                    <span className={text}>{fmt(m)}</span>
+                    <span className="text-gray-500 ml-1.5">
+                      {fmtThreshold(m)}
+                    </span>
+                  </div>
+                </div>
+                <div className="h-1.5 bg-gray-800 rounded-full overflow-hidden">
+                  <div
+                    className={`h-full ${bar} transition-all`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <div className="text-[10px] text-gray-500 mt-0.5">{m.detail}</div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/scripts/bu_readiness_check.py
+++ b/scripts/bu_readiness_check.py
@@ -1,11 +1,8 @@
 """
-M10 — BU readiness threshold instrumentation.
+M10 — BU readiness threshold instrumentation (CLI / cron entry-point).
 
-Measures the four sellable thresholds documented in the Manual:
-  - Coverage   ≥ 40% of TARGET_BU_SIZE (default 50,000 BU rows)
-  - Verified   ≥ 55% of dm_email rows have dm_email_verified=true
-  - Outcomes   ≥ 500 rows in cis_outreach_outcomes
-  - Trajectory ≥ 30% month-over-month BU growth rate
+Thin wrapper around src/services/bu_readiness.py so the script, the
+REST endpoint, and the dashboard widget all draw from one library.
 
 Usage:
     python3 scripts/bu_readiness_check.py            # human output
@@ -15,19 +12,13 @@ Exit codes:
     0  — all four thresholds met
     1  — at least one threshold failed
     3  — DB unavailable
-
-Designed to run as a daily cron AND on-demand. Same query path is reused
-by src/api/routes/bu_readiness.py so the dashboard widget and the cron
-report stay in sync.
 """
 from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import os
 import sys
-from dataclasses import asdict, dataclass
 
 SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
@@ -40,158 +31,12 @@ load_dotenv("/home/elliotbot/.config/agency-os/.env")
 import asyncpg  # noqa: E402
 
 from src.config.settings import settings  # noqa: E402
+from src.services.bu_readiness import (  # noqa: E402
+    gather_metrics,
+    render_human,
+    render_json,
+)
 
-# ── Thresholds (canonical Manual values) ───────────────────────────────────
-TARGET_BU_SIZE                = 50_000   # 100% coverage target
-COVERAGE_THRESHOLD_PCT        = 40.0
-VERIFIED_THRESHOLD_PCT        = 55.0
-OUTCOMES_THRESHOLD_COUNT      = 500
-TRAJECTORY_THRESHOLD_PCT      = 30.0
-TRAJECTORY_LOOKBACK_DAYS      = 30
-
-
-@dataclass
-class Metric:
-    name: str
-    value: float           # the measured value (% or count)
-    unit: str              # 'pct' | 'count'
-    threshold: float
-    pass_: bool            # alias for `pass` (Python keyword)
-    detail: str            # human-readable context
-
-    def to_dict(self) -> dict:
-        d = asdict(self)
-        d["pass"] = d.pop("pass_")
-        return d
-
-
-@dataclass
-class ReadinessReport:
-    metrics: list[Metric]
-    overall_pass: bool
-
-    def to_dict(self) -> dict:
-        return {
-            "metrics":      [m.to_dict() for m in self.metrics],
-            "overall_pass": self.overall_pass,
-        }
-
-
-# ── Query helpers ──────────────────────────────────────────────────────────
-
-async def measure_coverage(conn) -> Metric:
-    n = await conn.fetchval("SELECT COUNT(*) FROM business_universe")
-    pct = (n / TARGET_BU_SIZE) * 100 if TARGET_BU_SIZE > 0 else 0.0
-    return Metric(
-        name="coverage",
-        value=round(pct, 2),
-        unit="pct",
-        threshold=COVERAGE_THRESHOLD_PCT,
-        pass_=pct >= COVERAGE_THRESHOLD_PCT,
-        detail=f"{n:,} of {TARGET_BU_SIZE:,} BU rows",
-    )
-
-
-async def measure_verified(conn) -> Metric:
-    row = await conn.fetchrow(
-        """
-        SELECT
-          COUNT(*) FILTER (WHERE dm_email IS NOT NULL)               AS with_email,
-          COUNT(*) FILTER (WHERE dm_email_verified = TRUE)           AS verified
-        FROM business_universe
-        """,
-    )
-    with_email = int(row["with_email"] or 0)
-    verified   = int(row["verified"] or 0)
-    pct = (verified / with_email * 100) if with_email > 0 else 0.0
-    return Metric(
-        name="verified",
-        value=round(pct, 2),
-        unit="pct",
-        threshold=VERIFIED_THRESHOLD_PCT,
-        pass_=pct >= VERIFIED_THRESHOLD_PCT,
-        detail=f"{verified:,} of {with_email:,} dm_email rows verified",
-    )
-
-
-async def measure_outcomes(conn) -> Metric:
-    try:
-        n = await conn.fetchval("SELECT COUNT(*) FROM cis_outreach_outcomes")
-    except Exception:  # noqa: BLE001
-        n = 0
-    return Metric(
-        name="outcomes",
-        value=float(n),
-        unit="count",
-        threshold=OUTCOMES_THRESHOLD_COUNT,
-        pass_=n >= OUTCOMES_THRESHOLD_COUNT,
-        detail=f"{n:,} cis_outreach_outcomes rows",
-    )
-
-
-async def measure_trajectory(conn) -> Metric:
-    """Month-over-month BU growth rate.
-    Numerator   = rows created in the last LOOKBACK_DAYS.
-    Denominator = rows that existed BEFORE that lookback window.
-    """
-    row = await conn.fetchrow(
-        f"""
-        SELECT
-          COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '{TRAJECTORY_LOOKBACK_DAYS} days')
-                          AS new_rows,
-          COUNT(*) FILTER (WHERE created_at <  NOW() - INTERVAL '{TRAJECTORY_LOOKBACK_DAYS} days')
-                          AS pre_rows
-        FROM business_universe
-        """,
-    )
-    new_rows = int(row["new_rows"] or 0)
-    pre_rows = int(row["pre_rows"] or 0)
-    pct = (new_rows / pre_rows * 100) if pre_rows > 0 else 0.0
-    return Metric(
-        name="trajectory",
-        value=round(pct, 2),
-        unit="pct",
-        threshold=TRAJECTORY_THRESHOLD_PCT,
-        pass_=pct >= TRAJECTORY_THRESHOLD_PCT,
-        detail=f"{new_rows:,} new in last {TRAJECTORY_LOOKBACK_DAYS}d / {pre_rows:,} pre-window",
-    )
-
-
-async def gather_metrics(conn) -> ReadinessReport:
-    metrics = [
-        await measure_coverage(conn),
-        await measure_verified(conn),
-        await measure_outcomes(conn),
-        await measure_trajectory(conn),
-    ]
-    return ReadinessReport(
-        metrics=metrics,
-        overall_pass=all(m.pass_ for m in metrics),
-    )
-
-
-# ── Output ─────────────────────────────────────────────────────────────────
-
-def render_human(report: ReadinessReport) -> str:
-    lines = [
-        "=" * 64,
-        "BU Readiness Check",
-        "=" * 64,
-    ]
-    for m in report.metrics:
-        flag = "✓" if m.pass_ else "✗"
-        unit = "%" if m.unit == "pct" else ""
-        thr_unit = "%" if m.unit == "pct" else ""
-        lines.append(
-            f"  {flag} {m.name:<11} {m.value:>10.2f}{unit:<2} "
-            f"(threshold ≥ {m.threshold:.0f}{thr_unit})  {m.detail}"
-        )
-    lines.append("-" * 64)
-    lines.append(f"  Overall:    {'PASS' if report.overall_pass else 'FAIL'}")
-    return "\n".join(lines)
-
-
-# ── Entry-point ────────────────────────────────────────────────────────────
 
 async def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="BU readiness threshold check.")
@@ -210,11 +55,7 @@ async def main(argv: list[str] | None = None) -> int:
     finally:
         await conn.close()
 
-    if args.json:
-        print(json.dumps(report.to_dict(), indent=2))
-    else:
-        print(render_human(report))
-
+    print(render_json(report) if args.json else render_human(report))
     return 0 if report.overall_pass else 1
 
 

--- a/scripts/bu_readiness_check.py
+++ b/scripts/bu_readiness_check.py
@@ -1,0 +1,222 @@
+"""
+M10 — BU readiness threshold instrumentation.
+
+Measures the four sellable thresholds documented in the Manual:
+  - Coverage   ≥ 40% of TARGET_BU_SIZE (default 50,000 BU rows)
+  - Verified   ≥ 55% of dm_email rows have dm_email_verified=true
+  - Outcomes   ≥ 500 rows in cis_outreach_outcomes
+  - Trajectory ≥ 30% month-over-month BU growth rate
+
+Usage:
+    python3 scripts/bu_readiness_check.py            # human output
+    python3 scripts/bu_readiness_check.py --json     # machine-readable
+
+Exit codes:
+    0  — all four thresholds met
+    1  — at least one threshold failed
+    3  — DB unavailable
+
+Designed to run as a daily cron AND on-demand. Same query path is reused
+by src/api/routes/bu_readiness.py so the dashboard widget and the cron
+report stay in sync.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
+sys.path.insert(0, REPO_ROOT)
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv("/home/elliotbot/.config/agency-os/.env")
+
+import asyncpg  # noqa: E402
+
+from src.config.settings import settings  # noqa: E402
+
+# ── Thresholds (canonical Manual values) ───────────────────────────────────
+TARGET_BU_SIZE                = 50_000   # 100% coverage target
+COVERAGE_THRESHOLD_PCT        = 40.0
+VERIFIED_THRESHOLD_PCT        = 55.0
+OUTCOMES_THRESHOLD_COUNT      = 500
+TRAJECTORY_THRESHOLD_PCT      = 30.0
+TRAJECTORY_LOOKBACK_DAYS      = 30
+
+
+@dataclass
+class Metric:
+    name: str
+    value: float           # the measured value (% or count)
+    unit: str              # 'pct' | 'count'
+    threshold: float
+    pass_: bool            # alias for `pass` (Python keyword)
+    detail: str            # human-readable context
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["pass"] = d.pop("pass_")
+        return d
+
+
+@dataclass
+class ReadinessReport:
+    metrics: list[Metric]
+    overall_pass: bool
+
+    def to_dict(self) -> dict:
+        return {
+            "metrics":      [m.to_dict() for m in self.metrics],
+            "overall_pass": self.overall_pass,
+        }
+
+
+# ── Query helpers ──────────────────────────────────────────────────────────
+
+async def measure_coverage(conn) -> Metric:
+    n = await conn.fetchval("SELECT COUNT(*) FROM business_universe")
+    pct = (n / TARGET_BU_SIZE) * 100 if TARGET_BU_SIZE > 0 else 0.0
+    return Metric(
+        name="coverage",
+        value=round(pct, 2),
+        unit="pct",
+        threshold=COVERAGE_THRESHOLD_PCT,
+        pass_=pct >= COVERAGE_THRESHOLD_PCT,
+        detail=f"{n:,} of {TARGET_BU_SIZE:,} BU rows",
+    )
+
+
+async def measure_verified(conn) -> Metric:
+    row = await conn.fetchrow(
+        """
+        SELECT
+          COUNT(*) FILTER (WHERE dm_email IS NOT NULL)               AS with_email,
+          COUNT(*) FILTER (WHERE dm_email_verified = TRUE)           AS verified
+        FROM business_universe
+        """,
+    )
+    with_email = int(row["with_email"] or 0)
+    verified   = int(row["verified"] or 0)
+    pct = (verified / with_email * 100) if with_email > 0 else 0.0
+    return Metric(
+        name="verified",
+        value=round(pct, 2),
+        unit="pct",
+        threshold=VERIFIED_THRESHOLD_PCT,
+        pass_=pct >= VERIFIED_THRESHOLD_PCT,
+        detail=f"{verified:,} of {with_email:,} dm_email rows verified",
+    )
+
+
+async def measure_outcomes(conn) -> Metric:
+    try:
+        n = await conn.fetchval("SELECT COUNT(*) FROM cis_outreach_outcomes")
+    except Exception:  # noqa: BLE001
+        n = 0
+    return Metric(
+        name="outcomes",
+        value=float(n),
+        unit="count",
+        threshold=OUTCOMES_THRESHOLD_COUNT,
+        pass_=n >= OUTCOMES_THRESHOLD_COUNT,
+        detail=f"{n:,} cis_outreach_outcomes rows",
+    )
+
+
+async def measure_trajectory(conn) -> Metric:
+    """Month-over-month BU growth rate.
+    Numerator   = rows created in the last LOOKBACK_DAYS.
+    Denominator = rows that existed BEFORE that lookback window.
+    """
+    row = await conn.fetchrow(
+        f"""
+        SELECT
+          COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '{TRAJECTORY_LOOKBACK_DAYS} days')
+                          AS new_rows,
+          COUNT(*) FILTER (WHERE created_at <  NOW() - INTERVAL '{TRAJECTORY_LOOKBACK_DAYS} days')
+                          AS pre_rows
+        FROM business_universe
+        """,
+    )
+    new_rows = int(row["new_rows"] or 0)
+    pre_rows = int(row["pre_rows"] or 0)
+    pct = (new_rows / pre_rows * 100) if pre_rows > 0 else 0.0
+    return Metric(
+        name="trajectory",
+        value=round(pct, 2),
+        unit="pct",
+        threshold=TRAJECTORY_THRESHOLD_PCT,
+        pass_=pct >= TRAJECTORY_THRESHOLD_PCT,
+        detail=f"{new_rows:,} new in last {TRAJECTORY_LOOKBACK_DAYS}d / {pre_rows:,} pre-window",
+    )
+
+
+async def gather_metrics(conn) -> ReadinessReport:
+    metrics = [
+        await measure_coverage(conn),
+        await measure_verified(conn),
+        await measure_outcomes(conn),
+        await measure_trajectory(conn),
+    ]
+    return ReadinessReport(
+        metrics=metrics,
+        overall_pass=all(m.pass_ for m in metrics),
+    )
+
+
+# ── Output ─────────────────────────────────────────────────────────────────
+
+def render_human(report: ReadinessReport) -> str:
+    lines = [
+        "=" * 64,
+        "BU Readiness Check",
+        "=" * 64,
+    ]
+    for m in report.metrics:
+        flag = "✓" if m.pass_ else "✗"
+        unit = "%" if m.unit == "pct" else ""
+        thr_unit = "%" if m.unit == "pct" else ""
+        lines.append(
+            f"  {flag} {m.name:<11} {m.value:>10.2f}{unit:<2} "
+            f"(threshold ≥ {m.threshold:.0f}{thr_unit})  {m.detail}"
+        )
+    lines.append("-" * 64)
+    lines.append(f"  Overall:    {'PASS' if report.overall_pass else 'FAIL'}")
+    return "\n".join(lines)
+
+
+# ── Entry-point ────────────────────────────────────────────────────────────
+
+async def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="BU readiness threshold check.")
+    ap.add_argument("--json", action="store_true", help="Emit JSON instead of human output.")
+    args = ap.parse_args(argv)
+
+    try:
+        dsn = settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+        conn = await asyncpg.connect(dsn, statement_cache_size=0)
+    except Exception as exc:  # noqa: BLE001
+        print(f"DB unavailable: {exc}", file=sys.stderr)
+        return 3
+
+    try:
+        report = await gather_metrics(conn)
+    finally:
+        await conn.close()
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(render_human(report))
+
+    return 0 if report.overall_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -396,6 +396,7 @@ async def root() -> dict[str, Any]:
 # ============================================
 
 from src.api.routes.admin import router as admin_router
+from src.api.routes.bu_readiness import router as bu_readiness_router
 from src.api.routes.cycles import router as cycles_router
 from src.api.routes.dashboard import router as dashboard_router
 from src.api.routes.tiers import router as tiers_router
@@ -429,6 +430,7 @@ app.include_router(webhooks_outbound_router, prefix="/api/v1/webhooks-outbound")
 app.include_router(reports_router, prefix="/api/v1")
 app.include_router(admin_router, prefix="/api/v1")
 app.include_router(dashboard_router, prefix="/api/v1")
+app.include_router(bu_readiness_router, prefix="/api/v1")
 app.include_router(replies_router, prefix="/api/v1")
 app.include_router(meetings_router, prefix="/api/v1")
 # Phase 11: ICP Discovery / Onboarding

--- a/src/api/routes/bu_readiness.py
+++ b/src/api/routes/bu_readiness.py
@@ -17,8 +17,8 @@ import asyncpg
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
 
-from scripts.bu_readiness_check import gather_metrics  # type: ignore[import-not-found]
 from src.config.settings import settings
+from src.services.bu_readiness import gather_metrics
 
 logger = logging.getLogger(__name__)
 

--- a/src/api/routes/bu_readiness.py
+++ b/src/api/routes/bu_readiness.py
@@ -1,0 +1,76 @@
+"""
+FILE: src/api/routes/bu_readiness.py
+PURPOSE: M10 — expose the BU readiness threshold report as a REST endpoint.
+         Same query path as scripts/bu_readiness_check.py so the cron
+         + dashboard widget agree.
+PHASE:   M10 — BU readiness threshold instrumentation
+
+Public-by-design endpoint: returns ONLY the four aggregate threshold
+metrics (no PII, no per-row data). The frontend widget polls this on
+mount and renders progress bars + pass/fail badges.
+"""
+from __future__ import annotations
+
+import logging
+
+import asyncpg
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from scripts.bu_readiness_check import gather_metrics  # type: ignore[import-not-found]
+from src.config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/bu", tags=["bu-readiness"])
+
+
+class ReadinessMetric(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str
+    value: float
+    unit: str       # 'pct' | 'count'
+    threshold: float
+    # Serialized + accepted as 'pass' (Python keyword); attribute is pass_field.
+    pass_field: bool = Field(..., alias="pass")
+    detail: str
+
+
+class ReadinessResponse(BaseModel):
+    metrics: list[ReadinessMetric]
+    overall_pass: bool
+
+
+@router.get("/readiness", response_model=ReadinessResponse)
+async def bu_readiness() -> ReadinessResponse:
+    """Return the four BU sellable-threshold metrics (coverage / verified /
+    outcomes / trajectory) plus an overall pass flag.
+
+    Public by design — no PII surfaced, no client_id needed. Same query
+    path as scripts/bu_readiness_check.py so cron + dashboard agree."""
+    dsn = settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+    try:
+        conn = await asyncpg.connect(dsn, statement_cache_size=0)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("bu_readiness DB connect failed: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="DB unavailable",
+        ) from exc
+
+    try:
+        report = await gather_metrics(conn)
+    finally:
+        await conn.close()
+
+    return ReadinessResponse(
+        metrics=[
+            ReadinessMetric.model_validate({
+                "name": m.name, "value": m.value, "unit": m.unit,
+                "threshold": m.threshold, "pass": m.pass_, "detail": m.detail,
+            })
+            for m in report.metrics
+        ],
+        overall_pass=report.overall_pass,
+    )

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -46,6 +46,16 @@ class Settings(BaseSettings):
         description="Demo mode — disables real outreach sends + shows banner",
     )
 
+    # === BU readiness (M10) ===
+    # Total BU-row target representing 100% Coverage. The Coverage threshold
+    # in the Manual is "≥ 40% of TARGET_BU_SIZE", so changing this knob also
+    # changes the absolute pass bar. Override via TARGET_BU_SIZE env var.
+    TARGET_BU_SIZE: int = Field(
+        default=50_000,
+        validation_alias=AliasChoices("TARGET_BU_SIZE", "target_bu_size"),
+        description="100% BU coverage target — denominator of the Coverage metric",
+    )
+
     # === CORS ===
     ALLOWED_ORIGINS: list[str] = Field(
         default=["http://localhost:3000", "http://localhost:8000"],

--- a/src/services/bu_readiness.py
+++ b/src/services/bu_readiness.py
@@ -1,0 +1,197 @@
+"""
+M10 — BU readiness threshold calculations (shared lib).
+
+Single source of truth for the four sellable thresholds documented in
+the Manual:
+  - Coverage   ≥ 40% of settings.TARGET_BU_SIZE
+  - Verified   ≥ 55% of dm_email rows have dm_email_verified=true
+  - Outcomes   ≥ 500 rows in cis_outreach_outcomes
+  - Trajectory ≥ 30% standard month-over-month growth rate
+                 (rows created last 30d / rows created 30-60d ago)
+
+Consumers:
+  - scripts/bu_readiness_check.py  (cron + CLI)
+  - src/api/routes/bu_readiness.py (REST endpoint feeding the widget)
+
+Both call gather_metrics(conn) so the cron, the dashboard, and the
+REST response can never disagree on numbers.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+
+from src.config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+# ── Thresholds (canonical Manual values) ───────────────────────────────────
+COVERAGE_THRESHOLD_PCT        = 40.0
+VERIFIED_THRESHOLD_PCT        = 55.0
+OUTCOMES_THRESHOLD_COUNT      = 500
+TRAJECTORY_THRESHOLD_PCT      = 30.0
+TRAJECTORY_LOOKBACK_DAYS      = 30
+
+
+@dataclass
+class Metric:
+    name: str
+    value: float           # the measured value (% or count)
+    unit: str              # 'pct' | 'count'
+    threshold: float
+    pass_: bool            # alias for `pass` (Python keyword)
+    detail: str            # human-readable context
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["pass"] = d.pop("pass_")
+        return d
+
+
+@dataclass
+class ReadinessReport:
+    metrics: list[Metric]
+    overall_pass: bool
+
+    def to_dict(self) -> dict:
+        return {
+            "metrics":      [m.to_dict() for m in self.metrics],
+            "overall_pass": self.overall_pass,
+        }
+
+
+# ── Per-metric measurements ────────────────────────────────────────────────
+
+async def measure_coverage(conn) -> Metric:
+    target = max(1, int(getattr(settings, "TARGET_BU_SIZE", 50_000)))
+    n = await conn.fetchval("SELECT COUNT(*) FROM business_universe")
+    pct = (n / target) * 100
+    return Metric(
+        name="coverage",
+        value=round(pct, 2),
+        unit="pct",
+        threshold=COVERAGE_THRESHOLD_PCT,
+        pass_=pct >= COVERAGE_THRESHOLD_PCT,
+        detail=f"{n:,} of {target:,} BU rows",
+    )
+
+
+async def measure_verified(conn) -> Metric:
+    row = await conn.fetchrow(
+        """
+        SELECT
+          COUNT(*) FILTER (WHERE dm_email IS NOT NULL)               AS with_email,
+          COUNT(*) FILTER (WHERE dm_email_verified = TRUE)           AS verified
+        FROM business_universe
+        """,
+    )
+    with_email = int(row["with_email"] or 0)
+    verified   = int(row["verified"] or 0)
+    pct = (verified / with_email * 100) if with_email > 0 else 0.0
+    return Metric(
+        name="verified",
+        value=round(pct, 2),
+        unit="pct",
+        threshold=VERIFIED_THRESHOLD_PCT,
+        pass_=pct >= VERIFIED_THRESHOLD_PCT,
+        detail=f"{verified:,} of {with_email:,} dm_email rows verified",
+    )
+
+
+async def measure_outcomes(conn) -> Metric:
+    try:
+        n = await conn.fetchval("SELECT COUNT(*) FROM cis_outreach_outcomes")
+    except Exception as exc:  # noqa: BLE001
+        # M10-3 — surface the failure instead of silently zeroing.
+        logger.error(
+            "measure_outcomes: cis_outreach_outcomes query failed (%s) — reporting 0",
+            exc,
+        )
+        n = 0
+    return Metric(
+        name="outcomes",
+        value=float(n),
+        unit="count",
+        threshold=OUTCOMES_THRESHOLD_COUNT,
+        pass_=n >= OUTCOMES_THRESHOLD_COUNT,
+        detail=f"{n:,} cis_outreach_outcomes rows",
+    )
+
+
+async def measure_trajectory(conn) -> Metric:
+    """Standard month-over-month BU growth rate.
+
+    M10-4 — corrected from "last 30d / pre-30d" to the canonical MoM
+    definition: rows created in the last 30 days versus rows created in
+    the 30-60-day window. Both windows are equal length so the ratio is
+    comparable across time and not biased by historical accumulation.
+    """
+    days = TRAJECTORY_LOOKBACK_DAYS
+    row = await conn.fetchrow(
+        f"""
+        SELECT
+          COUNT(*) FILTER (
+            WHERE created_at >= NOW() - INTERVAL '{days} days'
+          ) AS new_rows,
+          COUNT(*) FILTER (
+            WHERE created_at >= NOW() - INTERVAL '{2 * days} days'
+              AND created_at <  NOW() - INTERVAL '{days} days'
+          ) AS prev_rows
+        FROM business_universe
+        """,
+    )
+    new_rows  = int(row["new_rows"] or 0)
+    prev_rows = int(row["prev_rows"] or 0)
+    pct = (new_rows / prev_rows * 100) if prev_rows > 0 else 0.0
+    return Metric(
+        name="trajectory",
+        value=round(pct, 2),
+        unit="pct",
+        threshold=TRAJECTORY_THRESHOLD_PCT,
+        pass_=pct >= TRAJECTORY_THRESHOLD_PCT,
+        detail=(
+            f"{new_rows:,} created last {days}d / "
+            f"{prev_rows:,} created {days}-{2 * days}d ago"
+        ),
+    )
+
+
+# ── Roll-up ────────────────────────────────────────────────────────────────
+
+async def gather_metrics(conn) -> ReadinessReport:
+    metrics = [
+        await measure_coverage(conn),
+        await measure_verified(conn),
+        await measure_outcomes(conn),
+        await measure_trajectory(conn),
+    ]
+    return ReadinessReport(
+        metrics=metrics,
+        overall_pass=all(m.pass_ for m in metrics),
+    )
+
+
+# ── Convenience: human render (used by the CLI) ────────────────────────────
+
+def render_human(report: ReadinessReport) -> str:
+    lines = [
+        "=" * 64,
+        "BU Readiness Check",
+        "=" * 64,
+    ]
+    for m in report.metrics:
+        flag = "✓" if m.pass_ else "✗"
+        unit = "%" if m.unit == "pct" else ""
+        thr_unit = "%" if m.unit == "pct" else ""
+        lines.append(
+            f"  {flag} {m.name:<11} {m.value:>10.2f}{unit:<2} "
+            f"(threshold ≥ {m.threshold:.0f}{thr_unit})  {m.detail}"
+        )
+    lines.append("-" * 64)
+    lines.append(f"  Overall:    {'PASS' if report.overall_pass else 'FAIL'}")
+    return "\n".join(lines)
+
+
+def render_json(report: ReadinessReport) -> str:
+    return json.dumps(report.to_dict(), indent=2)

--- a/tests/scripts/test_bu_readiness_check.py
+++ b/tests/scripts/test_bu_readiness_check.py
@@ -1,0 +1,170 @@
+"""
+M10 — Tests for scripts/bu_readiness_check.py.
+
+Pure mocks — no Supabase. Confirms the four metric calculators produce
+the right pass/fail verdict against the documented thresholds.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "bu_readiness_check.py"
+_spec = importlib.util.spec_from_file_location("bu_readiness_check", _SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+# Register BEFORE exec_module so dataclass field type resolution can find
+# the module via sys.modules during class body evaluation.
+sys.modules["bu_readiness_check"] = mod
+_spec.loader.exec_module(mod)
+
+
+def _conn(scalar_returns: list, fetchrow_returns: list):
+    """asyncpg conn stub — scalar/fetchrow each pop the next scripted value."""
+    sc = iter(scalar_returns)
+    fr = iter(fetchrow_returns)
+    c = MagicMock()
+    c.fetchval = AsyncMock(side_effect=lambda *_a, **_k: next(sc))
+    c.fetchrow = AsyncMock(side_effect=lambda *_a, **_k: next(fr))
+    return c
+
+
+# ─── coverage ──────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_coverage_passes_at_threshold():
+    # 40% of 50,000 = 20,000 — exactly at threshold should PASS (>=)
+    conn = _conn(scalar_returns=[20_000], fetchrow_returns=[])
+    m = await mod.measure_coverage(conn)
+    assert m.name == "coverage"
+    assert m.value == 40.0
+    assert m.pass_ is True
+
+
+@pytest.mark.asyncio
+async def test_coverage_fails_below_threshold():
+    conn = _conn(scalar_returns=[15_000], fetchrow_returns=[])
+    m = await mod.measure_coverage(conn)
+    assert m.value == 30.0
+    assert m.pass_ is False
+
+
+# ─── verified ──────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_verified_pct_calculation():
+    # 55 of 100 = 55% — at threshold, PASS
+    conn = _conn(scalar_returns=[],
+                 fetchrow_returns=[{"with_email": 100, "verified": 55}])
+    m = await mod.measure_verified(conn)
+    assert m.value == 55.0
+    assert m.pass_ is True
+
+
+@pytest.mark.asyncio
+async def test_verified_zero_email_is_zero_pct_not_div_zero():
+    conn = _conn(scalar_returns=[],
+                 fetchrow_returns=[{"with_email": 0, "verified": 0}])
+    m = await mod.measure_verified(conn)
+    assert m.value == 0.0
+    assert m.pass_ is False
+
+
+# ─── outcomes ──────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_outcomes_passes_at_500():
+    conn = _conn(scalar_returns=[500], fetchrow_returns=[])
+    m = await mod.measure_outcomes(conn)
+    assert m.value == 500.0
+    assert m.pass_ is True
+
+
+@pytest.mark.asyncio
+async def test_outcomes_handles_missing_table():
+    """If cis_outreach_outcomes doesn't exist (dev), report 0 and FAIL
+    rather than crash."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(side_effect=RuntimeError("relation missing"))
+    m = await mod.measure_outcomes(conn)
+    assert m.value == 0
+    assert m.pass_ is False
+
+
+# ─── trajectory ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_trajectory_pct():
+    # 30 new / 100 pre = 30% — at threshold, PASS
+    conn = _conn(scalar_returns=[],
+                 fetchrow_returns=[{"new_rows": 30, "pre_rows": 100}])
+    m = await mod.measure_trajectory(conn)
+    assert m.value == 30.0
+    assert m.pass_ is True
+
+
+@pytest.mark.asyncio
+async def test_trajectory_pre_zero_is_zero_pct_not_div_zero():
+    conn = _conn(scalar_returns=[],
+                 fetchrow_returns=[{"new_rows": 0, "pre_rows": 0}])
+    m = await mod.measure_trajectory(conn)
+    assert m.value == 0.0
+    assert m.pass_ is False
+
+
+# ─── render + roll-up ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_gather_metrics_overall_pass_requires_all_four():
+    """gather_metrics aggregates four measure_* calls. Overall pass only
+    when every metric passes."""
+    fetchval_returns = iter([20_000, 500])  # coverage, outcomes
+    fetchrow_returns = iter([
+        {"with_email": 100, "verified": 60},   # verified — PASS
+        {"new_rows": 30, "pre_rows": 100},     # trajectory — PASS (= threshold)
+    ])
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(side_effect=lambda *a, **k: next(fetchval_returns))
+    conn.fetchrow = AsyncMock(side_effect=lambda *a, **k: next(fetchrow_returns))
+
+    report = await mod.gather_metrics(conn)
+    assert report.overall_pass is True
+    assert len(report.metrics) == 4
+
+
+def test_render_human_includes_pass_fail_marker():
+    metrics = [
+        mod.Metric(name="coverage",   value=42, unit="pct",   threshold=40, pass_=True,  detail="d"),
+        mod.Metric(name="verified",   value=10, unit="pct",   threshold=55, pass_=False, detail="d"),
+        mod.Metric(name="outcomes",   value=100, unit="count", threshold=500, pass_=False, detail="d"),
+        mod.Metric(name="trajectory", value=33, unit="pct",   threshold=30, pass_=True,  detail="d"),
+    ]
+    report = mod.ReadinessReport(metrics=metrics, overall_pass=False)
+    out = mod.render_human(report)
+    assert "✓ coverage" in out
+    assert "✗ verified" in out
+    assert "FAIL" in out
+
+
+def test_metric_to_dict_renames_pass_field():
+    m = mod.Metric(name="x", value=1, unit="pct", threshold=1, pass_=True, detail="d")
+    d = m.to_dict()
+    assert "pass" in d
+    assert "pass_" not in d
+    assert d["pass"] is True
+
+
+def test_report_to_dict_serializes_to_json():
+    """JSON serialization of the report must succeed (used by --json)."""
+    metrics = [mod.Metric(name="x", value=1, unit="pct", threshold=1,
+                          pass_=True, detail="d")]
+    report = mod.ReadinessReport(metrics=metrics, overall_pass=True)
+    s = json.dumps(report.to_dict())
+    parsed = json.loads(s)
+    assert parsed["overall_pass"] is True
+    assert parsed["metrics"][0]["pass"] is True

--- a/tests/scripts/test_bu_readiness_check.py
+++ b/tests/scripts/test_bu_readiness_check.py
@@ -1,27 +1,18 @@
 """
-M10 — Tests for scripts/bu_readiness_check.py.
+M10 — Tests for the BU readiness threshold lib.
 
+Now imports the shared lib at src/services/bu_readiness.py (M10-1).
 Pure mocks — no Supabase. Confirms the four metric calculators produce
 the right pass/fail verdict against the documented thresholds.
 """
 from __future__ import annotations
 
-import importlib.util
 import json
-import sys
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "bu_readiness_check.py"
-_spec = importlib.util.spec_from_file_location("bu_readiness_check", _SCRIPT)
-mod = importlib.util.module_from_spec(_spec)
-assert _spec.loader is not None
-# Register BEFORE exec_module so dataclass field type resolution can find
-# the module via sys.modules during class body evaluation.
-sys.modules["bu_readiness_check"] = mod
-_spec.loader.exec_module(mod)
+from src.services import bu_readiness as mod
 
 
 def _conn(scalar_returns: list, fetchrow_returns: list):
@@ -54,11 +45,23 @@ async def test_coverage_fails_below_threshold():
     assert m.pass_ is False
 
 
+@pytest.mark.asyncio
+async def test_coverage_uses_settings_target_bu_size(monkeypatch):
+    """M10-2 — Coverage denominator must come from settings.TARGET_BU_SIZE."""
+    from src.config.settings import settings as _s
+    monkeypatch.setattr(_s, "TARGET_BU_SIZE", 10_000)
+    # 4,000 of 10,000 = 40% — passes
+    conn = _conn(scalar_returns=[4_000], fetchrow_returns=[])
+    m = await mod.measure_coverage(conn)
+    assert m.value == 40.0
+    assert m.pass_ is True
+    assert "10,000 BU rows" in m.detail
+
+
 # ─── verified ──────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_verified_pct_calculation():
-    # 55 of 100 = 55% — at threshold, PASS
     conn = _conn(scalar_returns=[],
                  fetchrow_returns=[{"with_email": 100, "verified": 55}])
     m = await mod.measure_verified(conn)
@@ -86,32 +89,39 @@ async def test_outcomes_passes_at_500():
 
 
 @pytest.mark.asyncio
-async def test_outcomes_handles_missing_table():
-    """If cis_outreach_outcomes doesn't exist (dev), report 0 and FAIL
-    rather than crash."""
+async def test_outcomes_logs_when_table_missing(caplog):
+    """M10-3 — DB error must be logged via logger.error, not silently
+    swallowed. measure_outcomes still returns 0/FAIL so the report is
+    well-formed."""
     conn = MagicMock()
     conn.fetchval = AsyncMock(side_effect=RuntimeError("relation missing"))
-    m = await mod.measure_outcomes(conn)
+    with caplog.at_level("ERROR", logger="src.services.bu_readiness"):
+        m = await mod.measure_outcomes(conn)
     assert m.value == 0
     assert m.pass_ is False
+    assert any("measure_outcomes" in r.message for r in caplog.records)
 
 
 # ─── trajectory ────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_trajectory_pct():
-    # 30 new / 100 pre = 30% — at threshold, PASS
+async def test_trajectory_uses_standard_mom_window():
+    """M10-4 — numerator = last 30d, denominator = 30-60d-ago window
+    (standard MoM), NOT total pre-window."""
     conn = _conn(scalar_returns=[],
-                 fetchrow_returns=[{"new_rows": 30, "pre_rows": 100}])
+                 fetchrow_returns=[{"new_rows": 30, "prev_rows": 100}])
     m = await mod.measure_trajectory(conn)
     assert m.value == 30.0
     assert m.pass_ is True
+    # The detail string should reference both windows clearly
+    assert "30d" in m.detail
+    assert "30-60d ago" in m.detail
 
 
 @pytest.mark.asyncio
 async def test_trajectory_pre_zero_is_zero_pct_not_div_zero():
     conn = _conn(scalar_returns=[],
-                 fetchrow_returns=[{"new_rows": 0, "pre_rows": 0}])
+                 fetchrow_returns=[{"new_rows": 0, "prev_rows": 0}])
     m = await mod.measure_trajectory(conn)
     assert m.value == 0.0
     assert m.pass_ is False
@@ -121,12 +131,10 @@ async def test_trajectory_pre_zero_is_zero_pct_not_div_zero():
 
 @pytest.mark.asyncio
 async def test_gather_metrics_overall_pass_requires_all_four():
-    """gather_metrics aggregates four measure_* calls. Overall pass only
-    when every metric passes."""
-    fetchval_returns = iter([20_000, 500])  # coverage, outcomes
+    fetchval_returns = iter([20_000, 500])
     fetchrow_returns = iter([
-        {"with_email": 100, "verified": 60},   # verified — PASS
-        {"new_rows": 30, "pre_rows": 100},     # trajectory — PASS (= threshold)
+        {"with_email": 100, "verified": 60},
+        {"new_rows": 30, "prev_rows": 100},
     ])
     conn = MagicMock()
     conn.fetchval = AsyncMock(side_effect=lambda *a, **k: next(fetchval_returns))
@@ -160,7 +168,6 @@ def test_metric_to_dict_renames_pass_field():
 
 
 def test_report_to_dict_serializes_to_json():
-    """JSON serialization of the report must succeed (used by --json)."""
     metrics = [mod.Metric(name="x", value=1, unit="pct", threshold=1,
                           pass_=True, detail="d")]
     report = mod.ReadinessReport(metrics=metrics, overall_pass=True)


### PR DESCRIPTION
## Summary
- `scripts/bu_readiness_check.py` — measures Coverage/Verified/Outcomes/Trajectory vs Manual thresholds
- `GET /api/v1/bu/readiness` endpoint — serves metrics to frontend
- `BUReadinessWidget.tsx` — progress bars + pass/fail badges (green/amber/red)
- Closes roadmap M10

## Test plan
- [x] Script outputs correct JSON with --json flag
- [x] Aiden peer review pending
- [ ] Frontend visual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)