### PR TITLE
[ATLAS] A3 — SessionEnd hook for auto four-store save

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,20 @@
   "permissions": {
     "defaultMode": "bypassPermissions"
   },
+  "hooks": {
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/elliotbot/clawd/venv/bin/python3 scripts/session_end_hook.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  },
   "mcpServers": {
     "supabase": {
       "command": "npx",

--- a/scripts/session_end_hook.py
+++ b/scripts/session_end_hook.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 from datetime import UTC, datetime
@@ -168,7 +169,7 @@ def write_memory(summary: dict) -> dict:
         async def _go():
             conn = await asyncpg.connect(dsn, statement_cache_size=0)
             try:
-                key = f"ceo:session_end_{datetime.now(UTC).date().isoformat()}"
+                key = f"ceo:session_end_{datetime.now(UTC).date().isoformat()}_{os.environ.get('CALLSIGN', 'unknown')}"
                 await conn.execute(
                     """
                     INSERT INTO ceo_memory (key, value, created_at, updated_at)

--- a/scripts/session_end_hook.py
+++ b/scripts/session_end_hook.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+A3 — SessionEnd hook: auto four-store save.
+
+Wired in .claude/settings.json under hooks.SessionEnd. Reads the hook
+input from stdin (JSON: session_id, transcript_path, cwd, hook_event_name,
+reason). Performs three best-effort steps:
+
+  1. If docs/MANUAL.md changed since the last successful mirror (state file
+     at ~/.config/agency-os/.manual_mirror_state), runs
+     `python3 scripts/write_manual_mirror.py --force` to push the
+     fresh content to the Drive doc.
+  2. Writes a compact session-end summary into public.ceo_memory keyed
+     `ceo:session_end_<YYYY-MM-DD>`.
+  3. Writes a daily_log row into elliot_internal.memories so the next
+     session's start-up query finds the trail.
+
+Non-blocking: every step is wrapped in try/except so a failure in one
+step does NOT prevent the next from running, and the hook ALWAYS exits
+0 (so Claude Code never blocks the SessionEnd transition on us).
+
+Logs go to stderr with the [session-end-hook] prefix so they show in
+the hook output without polluting Claude's stdout contract.
+
+Hook input contract (Claude Code SessionEnd, current docs):
+  {
+    "session_id": "<uuid>",
+    "transcript_path": "/path/to/.jsonl",
+    "cwd": "/abs/path",
+    "hook_event_name": "SessionEnd",
+    "reason": "exit|disconnect|...",
+  }
+
+We tolerate missing keys.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[session-end-hook] %(levelname)s: %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANUAL_PATH = REPO_ROOT / "docs" / "MANUAL.md"
+MIRROR_SCRIPT = REPO_ROOT / "scripts" / "write_manual_mirror.py"
+STATE_PATH = Path.home() / ".config" / "agency-os" / ".manual_mirror_state"
+ENV_FILE = "/home/elliotbot/.config/agency-os/.env"
+VENV_PY = "/home/elliotbot/clawd/venv/bin/python3"
+
+
+# ── Step 1: mirror MANUAL.md if it changed since last mirror ───────────────
+
+def _git_blob_hash(path: Path) -> str | None:
+    try:
+        out = subprocess.check_output(
+            ["git", "hash-object", str(path)],
+            cwd=str(REPO_ROOT), stderr=subprocess.DEVNULL,
+        )
+        return out.decode().strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _last_mirrored_blob() -> str | None:
+    try:
+        if not STATE_PATH.exists():
+            return None
+        data = json.loads(STATE_PATH.read_text(encoding="utf-8"))
+        return (data.get("last_fingerprint") or {}).get("git_blob")
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def maybe_mirror_manual() -> dict:
+    """Trigger the mirror script when the working-tree MANUAL.md differs
+    from the last mirrored fingerprint. Returns a small report."""
+    report = {"manual_present": False, "changed": None, "mirror_invoked": False, "exit_code": None}
+    if not MANUAL_PATH.exists():
+        logger.info("MANUAL.md not present at %s — skipping mirror step", MANUAL_PATH)
+        return report
+    report["manual_present"] = True
+
+    current = _git_blob_hash(MANUAL_PATH)
+    last    = _last_mirrored_blob()
+    changed = bool(current and current != last)
+    report["changed"] = changed
+
+    if not changed:
+        logger.info("MANUAL.md unchanged since last mirror — no mirror trigger")
+        return report
+
+    if not MIRROR_SCRIPT.exists():
+        logger.warning("mirror script missing at %s — skipping", MIRROR_SCRIPT)
+        return report
+
+    try:
+        result = subprocess.run(
+            [VENV_PY if Path(VENV_PY).exists() else "python3",
+             str(MIRROR_SCRIPT), "--force"],
+            cwd=str(REPO_ROOT),
+            capture_output=True, text=True, timeout=20,
+        )
+        report["mirror_invoked"] = True
+        report["exit_code"] = result.returncode
+        if result.returncode != 0:
+            logger.warning("mirror exited %d. stderr tail: %s",
+                           result.returncode, (result.stderr or "")[-200:])
+        else:
+            logger.info("mirror succeeded — Drive doc updated")
+    except subprocess.TimeoutExpired:
+        logger.warning("mirror timed out after 20s — best-effort skip")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("mirror invocation failed: %s", exc)
+    return report
+
+
+# ── Steps 2 + 3: write to ceo_memory + daily_log ───────────────────────────
+
+def _supabase_dsn() -> str | None:
+    """Pull DATABASE_URL from the agency-os env file. Returns None when
+    the file is missing (e.g. in a sandbox)."""
+    try:
+        sys.path.insert(0, str(REPO_ROOT))
+        from dotenv import load_dotenv
+        load_dotenv(ENV_FILE)
+        from src.config.settings import settings  # type: ignore[import-not-found]
+        return settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("DSN unavailable (%s) — skipping memory writes", exc)
+        return None
+
+
+def _build_summary(hook_input: dict, mirror_report: dict) -> dict:
+    return {
+        "session_id":     hook_input.get("session_id"),
+        "ended_at":       datetime.now(UTC).isoformat(),
+        "reason":         hook_input.get("reason", "unknown"),
+        "cwd":            hook_input.get("cwd"),
+        "transcript":     hook_input.get("transcript_path"),
+        "hook_event":     hook_input.get("hook_event_name", "SessionEnd"),
+        "manual_mirror":  mirror_report,
+    }
+
+
+def write_memory(summary: dict) -> dict:
+    """Write to ceo_memory + elliot_internal.memories. Returns counts."""
+    out = {"ceo_memory_upserted": False, "daily_log_written": False}
+    dsn = _supabase_dsn()
+    if not dsn:
+        return out
+
+    try:
+        # Use psycopg2 if asyncpg/asyncio inside a hook runtime is dicey;
+        # but asyncpg with asyncio.run is fine — keep one path.
+        import asyncio
+
+        import asyncpg
+
+        async def _go():
+            conn = await asyncpg.connect(dsn, statement_cache_size=0)
+            try:
+                key = f"ceo:session_end_{datetime.now(UTC).date().isoformat()}"
+                await conn.execute(
+                    """
+                    INSERT INTO ceo_memory (key, value, created_at, updated_at)
+                    VALUES ($1, $2::jsonb, NOW(), NOW())
+                    ON CONFLICT (key) DO UPDATE
+                      SET value = EXCLUDED.value, updated_at = NOW()
+                    """,
+                    key, json.dumps(summary),
+                )
+                out["ceo_memory_upserted"] = True
+
+                content = (
+                    f"Session ended ({summary.get('reason')}). "
+                    f"MANUAL mirror: changed={summary['manual_mirror'].get('changed')}, "
+                    f"invoked={summary['manual_mirror'].get('mirror_invoked')}."
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO elliot_internal.memories
+                      (id, type, content, metadata, created_at)
+                    VALUES (gen_random_uuid(), 'daily_log', $1, $2::jsonb, NOW())
+                    """,
+                    content, json.dumps(summary),
+                )
+                out["daily_log_written"] = True
+            finally:
+                await conn.close()
+
+        asyncio.run(_go())
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("memory writes failed (non-fatal): %s", exc)
+    return out
+
+
+# ── entry-point ────────────────────────────────────────────────────────────
+
+def read_hook_input() -> dict:
+    """Read JSON hook input from stdin. Returns {} on any failure."""
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return {}
+        return json.loads(raw)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("could not parse hook input from stdin: %s", exc)
+        return {}
+
+
+def main() -> int:
+    hook_input = read_hook_input()
+    logger.info(
+        "SessionEnd fired — session_id=%s reason=%s",
+        (hook_input.get("session_id") or "unknown")[:8],
+        hook_input.get("reason", "unknown"),
+    )
+
+    mirror_report = maybe_mirror_manual()
+    summary = _build_summary(hook_input, mirror_report)
+    memory_report = write_memory(summary)
+
+    logger.info(
+        "Done. mirror_invoked=%s ceo_memory=%s daily_log=%s",
+        mirror_report.get("mirror_invoked"),
+        memory_report.get("ceo_memory_upserted"),
+        memory_report.get("daily_log_written"),
+    )
+    # Always exit 0 so Claude Code never blocks SessionEnd on us.
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("unexpected hook failure (non-fatal): %s", exc)
+        sys.exit(0)

--- a/tests/scripts/test_session_end_hook.py
+++ b/tests/scripts/test_session_end_hook.py
@@ -1,0 +1,221 @@
+"""
+A3 — Tests for scripts/session_end_hook.py.
+
+Pure mocks — no Drive, no Supabase. Confirms:
+  - read_hook_input parses stdin JSON / tolerates garbage
+  - maybe_mirror_manual fires the mirror script ONLY when the working
+    MANUAL.md blob hash differs from the last-mirrored one
+  - maybe_mirror_manual short-circuits when MANUAL.md missing
+  - write_memory tolerates a missing DSN (no exception)
+  - main() always returns 0 (never blocks SessionEnd)
+  - main() handles unexpected exceptions in steps without raising
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "session_end_hook.py"
+_spec = importlib.util.spec_from_file_location("session_end_hook", _SCRIPT)
+hook = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["session_end_hook"] = hook
+_spec.loader.exec_module(hook)
+
+
+# ─── read_hook_input ───────────────────────────────────────────────────────
+
+def test_read_hook_input_parses_valid_json(monkeypatch):
+    payload = {"session_id": "abc", "reason": "exit"}
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
+    assert hook.read_hook_input() == payload
+
+
+def test_read_hook_input_returns_empty_on_garbage(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO("{not json"))
+    assert hook.read_hook_input() == {}
+
+
+def test_read_hook_input_returns_empty_on_blank(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    assert hook.read_hook_input() == {}
+
+
+# ─── maybe_mirror_manual ───────────────────────────────────────────────────
+
+def test_mirror_skipped_when_manual_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(hook, "MANUAL_PATH", tmp_path / "no-such-manual.md")
+    report = hook.maybe_mirror_manual()
+    assert report["manual_present"] is False
+    assert report["mirror_invoked"] is False
+
+
+def test_mirror_skipped_when_blob_unchanged(monkeypatch, tmp_path):
+    """current blob == last-mirrored blob → no subprocess call."""
+    manual = tmp_path / "MANUAL.md"
+    manual.write_text("hello")
+    monkeypatch.setattr(hook, "MANUAL_PATH", manual)
+    monkeypatch.setattr(hook, "_git_blob_hash", lambda _p: "deadbeef")
+    monkeypatch.setattr(hook, "_last_mirrored_blob", lambda: "deadbeef")
+    with patch.object(hook.subprocess, "run") as run:
+        report = hook.maybe_mirror_manual()
+    run.assert_not_called()
+    assert report["changed"] is False
+    assert report["mirror_invoked"] is False
+
+
+def test_mirror_fires_when_blob_changed(monkeypatch, tmp_path):
+    manual = tmp_path / "MANUAL.md"
+    manual.write_text("new content")
+    monkeypatch.setattr(hook, "MANUAL_PATH", manual)
+    monkeypatch.setattr(hook, "MIRROR_SCRIPT", manual)  # any path that exists
+    monkeypatch.setattr(hook, "_git_blob_hash", lambda _p: "newhash")
+    monkeypatch.setattr(hook, "_last_mirrored_blob", lambda: "oldhash")
+
+    fake_proc = MagicMock(returncode=0, stdout="", stderr="")
+    with patch.object(hook.subprocess, "run", return_value=fake_proc) as run:
+        report = hook.maybe_mirror_manual()
+
+    run.assert_called_once()
+    args = run.call_args.args[0]
+    assert "--force" in args
+    assert report["mirror_invoked"] is True
+    assert report["exit_code"] == 0
+
+
+def test_mirror_handles_subprocess_timeout(monkeypatch, tmp_path):
+    manual = tmp_path / "MANUAL.md"
+    manual.write_text("x")
+    monkeypatch.setattr(hook, "MANUAL_PATH", manual)
+    monkeypatch.setattr(hook, "MIRROR_SCRIPT", manual)
+    monkeypatch.setattr(hook, "_git_blob_hash", lambda _p: "a")
+    monkeypatch.setattr(hook, "_last_mirrored_blob", lambda: "b")
+
+    def boom(*_a, **_k):
+        raise hook.subprocess.TimeoutExpired(cmd="x", timeout=20)
+
+    with patch.object(hook.subprocess, "run", side_effect=boom):
+        report = hook.maybe_mirror_manual()
+    # Timeout did not crash; report records the attempt path
+    assert report["changed"] is True
+    assert report["mirror_invoked"] is False
+
+
+def test_mirror_skipped_when_script_missing(monkeypatch, tmp_path):
+    manual = tmp_path / "MANUAL.md"
+    manual.write_text("x")
+    monkeypatch.setattr(hook, "MANUAL_PATH", manual)
+    monkeypatch.setattr(hook, "MIRROR_SCRIPT", tmp_path / "no_such_mirror.py")
+    monkeypatch.setattr(hook, "_git_blob_hash", lambda _p: "a")
+    monkeypatch.setattr(hook, "_last_mirrored_blob", lambda: "b")
+    with patch.object(hook.subprocess, "run") as run:
+        report = hook.maybe_mirror_manual()
+    run.assert_not_called()
+    assert report["mirror_invoked"] is False
+
+
+# ─── _last_mirrored_blob ───────────────────────────────────────────────────
+
+def test_last_mirrored_blob_returns_none_when_state_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(hook, "STATE_PATH", tmp_path / "no-such-state")
+    assert hook._last_mirrored_blob() is None
+
+
+def test_last_mirrored_blob_returns_value_when_state_present(monkeypatch, tmp_path):
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"last_fingerprint": {"git_blob": "abc123"}}))
+    monkeypatch.setattr(hook, "STATE_PATH", state)
+    assert hook._last_mirrored_blob() == "abc123"
+
+
+def test_last_mirrored_blob_returns_none_on_garbage(monkeypatch, tmp_path):
+    state = tmp_path / "state.json"
+    state.write_text("not-json")
+    monkeypatch.setattr(hook, "STATE_PATH", state)
+    assert hook._last_mirrored_blob() is None
+
+
+# ─── write_memory ──────────────────────────────────────────────────────────
+
+def test_write_memory_returns_safely_when_no_dsn(monkeypatch):
+    monkeypatch.setattr(hook, "_supabase_dsn", lambda: None)
+    out = hook.write_memory({"session_id": "x", "manual_mirror": {}})
+    assert out == {"ceo_memory_upserted": False, "daily_log_written": False}
+
+
+def test_write_memory_handles_db_error(monkeypatch):
+    monkeypatch.setattr(hook, "_supabase_dsn", lambda: "postgresql://fake")
+    # Simulate asyncpg raising at connect time
+    fake_asyncpg = MagicMock()
+    fake_asyncpg.connect.side_effect = RuntimeError("network down")
+    monkeypatch.setitem(sys.modules, "asyncpg", fake_asyncpg)
+    out = hook.write_memory({"session_id": "x", "manual_mirror": {}})
+    assert out["ceo_memory_upserted"] is False
+    assert out["daily_log_written"] is False
+
+
+# ─── main() — always returns 0 ─────────────────────────────────────────────
+
+def test_main_returns_zero_on_happy_path(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO('{"session_id":"x","reason":"exit"}'))
+    monkeypatch.setattr(hook, "maybe_mirror_manual", lambda: {"mirror_invoked": False})
+    monkeypatch.setattr(hook, "write_memory", lambda _s: {
+        "ceo_memory_upserted": True, "daily_log_written": True,
+    })
+    assert hook.main() == 0
+
+
+def test_main_returns_zero_even_when_steps_raise(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO("{}"))
+
+    def boom():
+        raise RuntimeError("step exploded")
+
+    monkeypatch.setattr(hook, "maybe_mirror_manual", boom)
+    # main wraps in try/except at module level via __main__ guard,
+    # but main() itself must propagate; the entry-point catches it.
+    with pytest.raises(RuntimeError):
+        hook.main()
+
+
+def test_module_entrypoint_swallows_exceptions(monkeypatch):
+    """The __main__ guard must convert ANY hook failure into exit-0 so
+    Claude Code never blocks the SessionEnd transition."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("{}"))
+
+    def boom():
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(hook, "main", boom)
+    # Re-execute the __main__ block guard logic directly
+    with pytest.raises(SystemExit) as ei:
+        try:
+            sys.exit(hook.main())
+        except Exception:
+            sys.exit(0)
+    assert ei.value.code == 0
+
+
+# ─── settings.json wiring smoke ────────────────────────────────────────────
+
+def test_settings_json_contains_session_end_hook():
+    settings = json.loads(
+        (Path(__file__).resolve().parent.parent.parent / ".claude" / "settings.json").read_text()
+    )
+    assert "hooks" in settings
+    assert "SessionEnd" in settings["hooks"]
+    se = settings["hooks"]["SessionEnd"]
+    assert isinstance(se, list) and len(se) >= 1
+    # The first SessionEnd entry references our hook script
+    cmd_block = se[0]
+    assert "hooks" in cmd_block
+    assert any(
+        "session_end_hook.py" in h.get("command", "")
+        for h in cmd_block["hooks"]
+    ), "session_end_hook.py not registered in .claude/settings.json"


### PR DESCRIPTION
## Summary
Auto-triggers the four-store save when Claude Code closes a session — no more "did I remember to mirror MANUAL.md / write the daily_log" friction.

- **`.claude/settings.json`** — new `hooks.SessionEnd` block (matcher `*`, timeout 30s) pointing at \`/home/elliotbot/clawd/venv/bin/python3 scripts/session_end_hook.py\`.
- **`scripts/session_end_hook.py`** — reads hook stdin JSON; three best-effort steps (mirror if MANUAL.md changed → ceo_memory upsert → daily_log insert); always exits 0 so Claude Code never blocks the SessionEnd transition.
- **`tests/scripts/test_session_end_hook.py`** — 17 passing: stdin parse, state-file lookup, mirror trigger logic, write_memory safe-paths, main always exits 0, settings.json wiring smoke. Pure mocks.

## Mirror trigger logic
1. \`git hash-object docs/MANUAL.md\` (current blob)
2. Compare to \`~/.config/agency-os/.manual_mirror_state.last_fingerprint.git_blob\` (M11-2 shared state)
3. If different → \`python3 scripts/write_manual_mirror.py --force\` (20s timeout, venv interpreter)

## Memory writes
- Upsert \`ceo_memory\` key \`ceo:session_end_<YYYY-MM-DD>\` with full session summary JSON
- Insert \`daily_log\`-type row into \`elliot_internal.memories\`

## Test plan
- [x] \`ruff check\` — clean
- [x] \`pytest tests/scripts/test_session_end_hook.py\` — 17 passed
- [x] Live smoke (mocked stdin) — exit 0, mirror invoked when MANUAL.md differs, DSN load + DB writes attempted (best-effort path)
- [ ] Reviewer: confirm no \`src/pipeline/*\` or \`src/orchestration/flows/*\` modifications (out-of-scope per directive)
- [ ] Ops: hook fires on \`/exit\` in next session — observe \`[session-end-hook]\` lines in transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)