### PR TITLE
[ATLAS] P5 — Anthropic Rate Limits API integration

### DIFF
--- a/src/integrations/anthropic_rate_limit.py
+++ b/src/integrations/anthropic_rate_limit.py
@@ -1,0 +1,244 @@
+"""
+P5 — Anthropic Rate Limits API integration.
+
+Provides check_rate_limits(model, required_tokens) -> bool. Designed to
+be called BEFORE spawning a batch of sub-agent work so the orchestrator
+can decide whether to proceed, throttle, or defer.
+
+How it works
+------------
+The Anthropic API exposes its current rate-limit posture via response
+headers on every messages call:
+
+  anthropic-ratelimit-requests-remaining          (RPM headroom)
+  anthropic-ratelimit-tokens-remaining            (TPM headroom — total)
+  anthropic-ratelimit-input-tokens-remaining      (input TPM headroom)
+  anthropic-ratelimit-output-tokens-remaining     (output TPM headroom)
+  anthropic-ratelimit-requests-reset              (ISO8601 reset)
+  anthropic-ratelimit-tokens-reset                (ISO8601 reset)
+
+There is NO standalone "rate limits" endpoint, so we probe the cheapest
+available path — `/v1/messages/count_tokens` — which returns the same
+ratelimit headers without consuming real tokens. Result cached per-model
+for PROBE_TTL_SECONDS to avoid back-to-back probes.
+
+The function is intentionally conservative:
+  - No raises. Network / API errors return True (fail-open) so a
+    Rate-Limits-API outage cannot block legitimate work.
+  - No retries — this is a quick check, not a wait.
+  - Boolean answer + a structured log line. Caller (the batch
+    orchestrator) decides defer / proceed / split.
+
+Security: pure HTTP via httpx, API key from settings, no shell, no URL
+following from caller-supplied input.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+import httpx
+
+from src.config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+ANTHROPIC_API_BASE = "https://api.anthropic.com/v1"
+ANTHROPIC_VERSION  = "2023-06-01"
+PROBE_TTL_SECONDS  = 30
+PROBE_TIMEOUT_S    = 5.0
+
+# Headers we care about — names as documented by Anthropic.
+_HDR_REQ_REM    = "anthropic-ratelimit-requests-remaining"
+_HDR_TOK_REM    = "anthropic-ratelimit-tokens-remaining"
+_HDR_IN_REM     = "anthropic-ratelimit-input-tokens-remaining"
+_HDR_OUT_REM    = "anthropic-ratelimit-output-tokens-remaining"
+_HDR_REQ_RESET  = "anthropic-ratelimit-requests-reset"
+_HDR_TOK_RESET  = "anthropic-ratelimit-tokens-reset"
+
+
+@dataclass
+class RateLimitSnapshot:
+    """Cached headers from the most-recent probe per model."""
+    model:                str
+    requests_remaining:   int | None
+    tokens_remaining:     int | None
+    input_tokens_remaining:  int | None
+    output_tokens_remaining: int | None
+    requests_reset_iso:   str | None
+    tokens_reset_iso:     str | None
+    captured_at:          float
+
+    def headroom_for(self, required_tokens: int) -> tuple[bool, str]:
+        """Return (has_headroom, reason). Considers the most-restrictive
+        signal among the four *remaining* counters and the RPM check."""
+        # RPM: refuse when zero requests remain (we'd hit the wall).
+        if self.requests_remaining is not None and self.requests_remaining <= 0:
+            return False, f"requests_remaining={self.requests_remaining}"
+
+        # Token budgets — prefer the more specific headers when present.
+        if self.input_tokens_remaining is not None and self.input_tokens_remaining < required_tokens:
+            return False, (
+                f"input_tokens_remaining={self.input_tokens_remaining} "
+                f"< required={required_tokens}"
+            )
+        if self.output_tokens_remaining is not None and self.output_tokens_remaining < required_tokens:
+            return False, (
+                f"output_tokens_remaining={self.output_tokens_remaining} "
+                f"< required={required_tokens}"
+            )
+        # Total tokens fallback when per-direction headers absent.
+        if self.tokens_remaining is not None and self.tokens_remaining < required_tokens:
+            return False, (
+                f"tokens_remaining={self.tokens_remaining} "
+                f"< required={required_tokens}"
+            )
+        return True, "ok"
+
+
+# Per-process snapshot cache. Keyed by model.
+_SNAPSHOT_CACHE: dict[str, RateLimitSnapshot] = {}
+
+
+# ── Header parsing ─────────────────────────────────────────────────────────
+
+def _parse_int(v: str | None) -> int | None:
+    if v is None or v == "":
+        return None
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _snapshot_from_headers(model: str, headers) -> RateLimitSnapshot:
+    """headers — any mapping-like (httpx Headers, dict, etc.)."""
+    return RateLimitSnapshot(
+        model=model,
+        requests_remaining=_parse_int(headers.get(_HDR_REQ_REM)),
+        tokens_remaining=_parse_int(headers.get(_HDR_TOK_REM)),
+        input_tokens_remaining=_parse_int(headers.get(_HDR_IN_REM)),
+        output_tokens_remaining=_parse_int(headers.get(_HDR_OUT_REM)),
+        requests_reset_iso=headers.get(_HDR_REQ_RESET) or None,
+        tokens_reset_iso=headers.get(_HDR_TOK_RESET) or None,
+        captured_at=time.monotonic(),
+    )
+
+
+# ── Probe ──────────────────────────────────────────────────────────────────
+
+def _api_key() -> str | None:
+    key = getattr(settings, "anthropic_api_key", "") or ""
+    return key.strip() or None
+
+
+def _probe(model: str) -> RateLimitSnapshot | None:
+    """POST /v1/messages/count_tokens with a 1-token payload to fetch the
+    current rate-limit headers. Returns None on any HTTP failure (fail-open
+    is handled by the caller)."""
+    key = _api_key()
+    if not key:
+        logger.warning("anthropic_rate_limit: ANTHROPIC_API_KEY unset — cannot probe")
+        return None
+
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": "ok"}],
+    }
+    headers = {
+        "x-api-key":         key,
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type":      "application/json",
+    }
+
+    try:
+        with httpx.Client(timeout=PROBE_TIMEOUT_S) as client:
+            resp = client.post(
+                f"{ANTHROPIC_API_BASE}/messages/count_tokens",
+                json=payload, headers=headers,
+            )
+    except httpx.HTTPError as exc:
+        logger.warning("anthropic_rate_limit: probe HTTP error: %s", exc)
+        return None
+
+    # Anthropic returns the rate-limit headers regardless of the body's
+    # status code, but we still log non-2xx so debug surfaces are visible.
+    if resp.status_code >= 400:
+        logger.warning(
+            "anthropic_rate_limit: probe status=%s body[:200]=%r",
+            resp.status_code, resp.text[:200],
+        )
+
+    return _snapshot_from_headers(model, resp.headers)
+
+
+def _cached_snapshot(model: str) -> RateLimitSnapshot | None:
+    snap = _SNAPSHOT_CACHE.get(model)
+    if snap is None:
+        return None
+    if (time.monotonic() - snap.captured_at) > PROBE_TTL_SECONDS:
+        return None
+    return snap
+
+
+# ── Public surface ─────────────────────────────────────────────────────────
+
+def check_rate_limits(model: str, required_tokens: int) -> bool:
+    """Return True iff there is enough headroom on `model` for an
+    operation that will consume roughly `required_tokens`.
+
+    Cached per-model for PROBE_TTL_SECONDS (30s) so back-to-back checks
+    don't probe the API every time. On any probe failure (network,
+    missing API key, non-2xx) the function FAILS OPEN and returns True
+    so that an integration outage cannot block legitimate work — the
+    docstring on this function is the contract: a False answer means
+    "we have evidence of insufficient headroom"; a True answer means
+    "we have no evidence of insufficient headroom" (which includes
+    "we couldn't ask").
+
+    Side effect: emits a structured log line with the verdict and the
+    raw counters so the orchestrator's logs carry the evidence.
+    """
+    if not isinstance(model, str) or not model:
+        logger.warning("anthropic_rate_limit: invalid model arg %r — fail-open", model)
+        return True
+    if not isinstance(required_tokens, int) or required_tokens < 0:
+        logger.warning(
+            "anthropic_rate_limit: invalid required_tokens %r — fail-open",
+            required_tokens,
+        )
+        return True
+
+    snap = _cached_snapshot(model)
+    if snap is None:
+        snap = _probe(model)
+        if snap is None:
+            logger.info(
+                "anthropic_rate_limit: no probe data for model=%s required=%d — fail-open",
+                model, required_tokens,
+            )
+            return True
+        _SNAPSHOT_CACHE[model] = snap
+
+    ok, reason = snap.headroom_for(required_tokens)
+    log = logger.info if ok else logger.warning
+    log(
+        "anthropic_rate_limit: model=%s required=%d ok=%s reason=%s "
+        "rpm_rem=%s tpm_rem=%s in_rem=%s out_rem=%s",
+        model, required_tokens, ok, reason,
+        snap.requests_remaining, snap.tokens_remaining,
+        snap.input_tokens_remaining, snap.output_tokens_remaining,
+    )
+    return ok
+
+
+def reset_cache() -> None:
+    """Clear the per-process snapshot cache. Tests + ops use this to
+    force the next check_rate_limits() call to re-probe."""
+    _SNAPSHOT_CACHE.clear()
+
+
+def cached_snapshot(model: str) -> RateLimitSnapshot | None:
+    """Read-only accessor for ops / tests."""
+    return _cached_snapshot(model)

--- a/tests/integrations/test_anthropic_rate_limit.py
+++ b/tests/integrations/test_anthropic_rate_limit.py
@@ -1,0 +1,228 @@
+"""
+P5 — Tests for src/integrations/anthropic_rate_limit.py.
+
+Pure mocks — never touches the real Anthropic API. Confirms:
+  - _snapshot_from_headers parses each known counter
+  - RateLimitSnapshot.headroom_for picks the most-restrictive signal
+  - check_rate_limits caches per-model for PROBE_TTL_SECONDS
+  - check_rate_limits FAILS OPEN on probe failure (no key, HTTP error)
+  - check_rate_limits FAILS OPEN on invalid args
+  - reset_cache clears the snapshot store
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from src.integrations import anthropic_rate_limit as arl
+
+# ─── header parsing ────────────────────────────────────────────────────────
+
+def test_snapshot_from_headers_parses_known_counters():
+    headers = {
+        "anthropic-ratelimit-requests-remaining":       "42",
+        "anthropic-ratelimit-tokens-remaining":         "10000",
+        "anthropic-ratelimit-input-tokens-remaining":   "8000",
+        "anthropic-ratelimit-output-tokens-remaining":  "2000",
+        "anthropic-ratelimit-requests-reset":           "2026-04-26T10:00:00Z",
+        "anthropic-ratelimit-tokens-reset":             "2026-04-26T10:01:00Z",
+    }
+    snap = arl._snapshot_from_headers("claude-haiku-4-5", headers)
+    assert snap.model == "claude-haiku-4-5"
+    assert snap.requests_remaining == 42
+    assert snap.tokens_remaining == 10_000
+    assert snap.input_tokens_remaining == 8_000
+    assert snap.output_tokens_remaining == 2_000
+    assert snap.requests_reset_iso == "2026-04-26T10:00:00Z"
+
+
+def test_snapshot_handles_missing_or_empty_headers():
+    snap = arl._snapshot_from_headers("m", {})
+    assert snap.requests_remaining is None
+    assert snap.tokens_remaining is None
+    assert snap.input_tokens_remaining is None
+    assert snap.output_tokens_remaining is None
+
+
+def test_snapshot_handles_non_integer_strings():
+    snap = arl._snapshot_from_headers("m", {
+        "anthropic-ratelimit-tokens-remaining": "not-a-number",
+    })
+    assert snap.tokens_remaining is None
+
+
+# ─── headroom_for ──────────────────────────────────────────────────────────
+
+def _snap(**kw):
+    defaults = {
+        "model": "m",
+        "requests_remaining": 100,
+        "tokens_remaining": 100_000,
+        "input_tokens_remaining": 80_000,
+        "output_tokens_remaining": 20_000,
+        "requests_reset_iso": None,
+        "tokens_reset_iso": None,
+        "captured_at": 0.0,
+    }
+    defaults.update(kw)
+    return arl.RateLimitSnapshot(**defaults)
+
+
+def test_headroom_zero_requests_blocks():
+    ok, reason = _snap(requests_remaining=0).headroom_for(1_000)
+    assert ok is False
+    assert "requests_remaining" in reason
+
+
+def test_headroom_input_tokens_below_required_blocks():
+    ok, reason = _snap(input_tokens_remaining=500).headroom_for(1_000)
+    assert ok is False
+    assert "input_tokens_remaining" in reason
+
+
+def test_headroom_output_tokens_below_required_blocks():
+    ok, reason = _snap(output_tokens_remaining=500).headroom_for(1_000)
+    assert ok is False
+    assert "output_tokens_remaining" in reason
+
+
+def test_headroom_total_tokens_used_when_per_direction_absent():
+    ok, reason = _snap(
+        input_tokens_remaining=None, output_tokens_remaining=None,
+        tokens_remaining=500,
+    ).headroom_for(1_000)
+    assert ok is False
+    assert "tokens_remaining" in reason
+
+
+def test_headroom_passes_when_all_above_required():
+    ok, reason = _snap().headroom_for(1_000)
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_headroom_with_only_unknown_signals_passes():
+    """All counters None → no evidence of insufficient headroom → True."""
+    ok, _ = _snap(
+        requests_remaining=None, tokens_remaining=None,
+        input_tokens_remaining=None, output_tokens_remaining=None,
+    ).headroom_for(1_000)
+    assert ok is True
+
+
+# ─── check_rate_limits — caching + fail-open ───────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _reset_cache_between_tests():
+    arl.reset_cache()
+    yield
+    arl.reset_cache()
+
+
+def test_check_rate_limits_returns_true_when_no_api_key(monkeypatch):
+    monkeypatch.setattr(arl.settings, "anthropic_api_key", "")
+    assert arl.check_rate_limits("claude-haiku-4-5", 1_000) is True
+
+
+def test_check_rate_limits_returns_true_on_http_error(monkeypatch):
+    monkeypatch.setattr(arl.settings, "anthropic_api_key", "test-key")
+
+    class _BoomClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def post(self, *a, **k):
+            raise httpx.HTTPError("network down")
+
+    monkeypatch.setattr(arl.httpx, "Client", _BoomClient)
+    assert arl.check_rate_limits("claude-haiku-4-5", 1_000) is True
+
+
+def _fake_response(headers: dict, status: int = 200) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.text = "{}"
+    r.headers = headers
+    return r
+
+
+def _client_with(response):
+    class _Client:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def post(self, *a, **k): return response
+    return _Client
+
+
+def test_check_rate_limits_returns_false_when_below_required(monkeypatch):
+    monkeypatch.setattr(arl.settings, "anthropic_api_key", "test-key")
+    resp = _fake_response({
+        "anthropic-ratelimit-requests-remaining":      "100",
+        "anthropic-ratelimit-input-tokens-remaining":  "500",
+        "anthropic-ratelimit-output-tokens-remaining": "500",
+    })
+    monkeypatch.setattr(arl.httpx, "Client", _client_with(resp))
+    assert arl.check_rate_limits("m", 1_000) is False
+
+
+def test_check_rate_limits_returns_true_when_above_required(monkeypatch):
+    monkeypatch.setattr(arl.settings, "anthropic_api_key", "test-key")
+    resp = _fake_response({
+        "anthropic-ratelimit-requests-remaining":      "100",
+        "anthropic-ratelimit-input-tokens-remaining":  "9000",
+        "anthropic-ratelimit-output-tokens-remaining": "9000",
+    })
+    monkeypatch.setattr(arl.httpx, "Client", _client_with(resp))
+    assert arl.check_rate_limits("m", 1_000) is True
+
+
+def test_check_rate_limits_caches_per_model(monkeypatch):
+    """Second call within TTL should NOT probe the API again."""
+    monkeypatch.setattr(arl.settings, "anthropic_api_key", "test-key")
+    calls = {"n": 0}
+
+    class _CountingClient:
+        def __init__(self, *a, **k): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def post(self, *a, **k):
+            calls["n"] += 1
+            return _fake_response({
+                "anthropic-ratelimit-requests-remaining":     "10",
+                "anthropic-ratelimit-input-tokens-remaining": "5000",
+            })
+
+    monkeypatch.setattr(arl.httpx, "Client", _CountingClient)
+    arl.check_rate_limits("m", 1_000)
+    arl.check_rate_limits("m", 500)
+    assert calls["n"] == 1   # second call hit the cache
+    # cache is per-model — different model triggers a new probe
+    arl.check_rate_limits("other-model", 1_000)
+    assert calls["n"] == 2
+
+
+# ─── invalid args ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("bad_model", [None, "", 123, []])
+def test_invalid_model_fails_open(bad_model):
+    assert arl.check_rate_limits(bad_model, 1_000) is True
+
+
+@pytest.mark.parametrize("bad_required", [None, -1, "x", 1.5])
+def test_invalid_required_tokens_fails_open(bad_required):
+    assert arl.check_rate_limits("m", bad_required) is True
+
+
+# ─── reset_cache ───────────────────────────────────────────────────────────
+
+def test_reset_cache_clears_snapshots(monkeypatch):
+    monkeypatch.setattr(arl.settings, "anthropic_api_key", "test-key")
+    resp = _fake_response({"anthropic-ratelimit-requests-remaining": "100"})
+    monkeypatch.setattr(arl.httpx, "Client", _client_with(resp))
+    arl.check_rate_limits("m", 100)
+    assert arl.cached_snapshot("m") is not None
+    arl.reset_cache()
+    assert arl.cached_snapshot("m") is None


### PR DESCRIPTION
## Summary
\`check_rate_limits(model, required_tokens) -> bool\` for the orchestrator to call before spawning a batch. Probes \`/v1/messages/count_tokens\` (no real-token consumption) and reads the \`anthropic-ratelimit-*\` headers; cached per-model for 30s.

## Public surface
| Name | Purpose |
|---|---|
| \`check_rate_limits(model, required_tokens) -> bool\` | True iff there's enough headroom |
| \`reset_cache()\` | Drop the per-process snapshot store (ops + tests) |
| \`cached_snapshot(model)\` | Read-only accessor |

## Decision rule (most-restrictive signal wins)
- \`requests_remaining == 0\` → block
- \`input_tokens_remaining < required\` → block
- \`output_tokens_remaining < required\` → block
- \`tokens_remaining < required\` (used when per-direction headers absent) → block
- All counters None → True (no evidence to deny)

## Fail-open contract
Every error path returns True so a Rate-Limits-API outage cannot block legitimate work. Documented in the function docstring:
- \`False\` = we have evidence of insufficient headroom
- \`True\`  = we have no evidence of insufficient headroom (includes "we couldn't ask")

## Security
- No subprocess calls
- No URL following from caller input — only constant \`ANTHROPIC_API_BASE\`
- API key from \`settings.anthropic_api_key\`
- 5.0s timeout cap
- Invalid args fail-open

## Test plan
- [x] \`ruff check\` — clean
- [x] \`pytest tests/integrations/test_anthropic_rate_limit.py\` — 23 passed
- [x] No live Anthropic call during the test run (pure mocks)
- [ ] Reviewer: inspect the cache TTL (30s) — bump if batch orchestrator wants longer windows
- [ ] Operator: wire \`check_rate_limits()\` into batch dispatch points (pipeline orchestrator, sub-agent spawn) — out of scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)