### PR TITLE
[ATLAS] P4 — Anthropic Batch API (300K output beta)

### DIFF
--- a/src/integrations/anthropic_batch.py
+++ b/src/integrations/anthropic_batch.py
@@ -1,0 +1,251 @@
+"""
+P4 — Anthropic Message Batches API integration (300K output beta).
+
+Wrapper around POST /v1/messages/batches and the related GET endpoints.
+Designed for bulk sub-agent work where the 50% pricing discount + the
+new 300K-output token ceiling make synchronous /messages calls
+economically + technically wrong.
+
+Public surface
+--------------
+    create_batch(messages, model, ...) -> str      # returns batch_id
+    poll_batch(batch_id) -> dict                   # raw status payload
+    get_results(batch_id) -> list[dict]            # per-request results
+    cancel_batch(batch_id) -> dict
+    wait_for_batch(batch_id, ...) -> dict          # convenience polling loop
+
+`messages` is a list[BatchRequest], where BatchRequest is either
+  - a list[ {"role": ..., "content": ...} ]   — convenience shape
+  - a {"custom_id": str, "params": {...}}     — full Anthropic shape
+
+The convenience shape is wrapped automatically:
+    custom_id = f"req-{i}"
+    params    = {"model": model, "max_tokens": 4096, "messages": [...]}
+
+Beta headers used (see Anthropic batch + 300K-output beta docs):
+  anthropic-beta: message-batches-2024-09-24,output-300k-2026-03-24
+
+Security
+  - No subprocess. No URL following from caller-supplied input.
+  - The only HTTP target is the constant ANTHROPIC_API_BASE.
+  - batch_id is matched against an allow-list regex before being
+    interpolated into a URL path.
+  - Caller-supplied `messages` are JSON-serialised by httpx; never
+    shell-quoted, never written to disk.
+  - Every error path raises a typed exception OR returns a
+    well-formed dict — the caller decides whether to retry.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Any
+
+import httpx
+
+from src.config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+ANTHROPIC_API_BASE = "https://api.anthropic.com/v1"
+ANTHROPIC_VERSION  = "2023-06-01"
+# Two beta headers, comma-separated, per Anthropic docs:
+#   message-batches-2024-09-24 — Batches API surface
+#   output-300k-2026-03-24     — 300K output-token ceiling (P4 ask)
+BATCH_BETA_HEADER = "message-batches-2024-09-24,output-300k-2026-03-24"
+
+DEFAULT_MAX_TOKENS = 4_096
+HTTP_TIMEOUT_S     = 30.0
+POLL_INTERVAL_S    = 5.0
+POLL_MAX_S         = 60 * 60 * 4   # 4 hour safety cap on wait_for_batch
+
+_BATCH_ID_RE = re.compile(r"^msgbatch_[A-Za-z0-9_-]{1,128}$")
+
+
+class AnthropicBatchError(RuntimeError):
+    """Typed exception so callers can distinguish batch failures from
+    generic httpx/JSON errors."""
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _api_key() -> str:
+    key = (getattr(settings, "anthropic_api_key", "") or "").strip()
+    if not key:
+        raise AnthropicBatchError("ANTHROPIC_API_KEY unset")
+    return key
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "x-api-key":         _api_key(),
+        "anthropic-version": ANTHROPIC_VERSION,
+        "anthropic-beta":    BATCH_BETA_HEADER,
+        "content-type":      "application/json",
+    }
+
+
+def _validate_batch_id(batch_id: str) -> str:
+    if not isinstance(batch_id, str) or not _BATCH_ID_RE.match(batch_id):
+        raise AnthropicBatchError(f"invalid batch_id: {batch_id!r}")
+    return batch_id
+
+
+def _normalise_requests(
+    messages: list[Any], model: str, max_tokens: int,
+) -> list[dict]:
+    """Accept either:
+      - list[ list[{"role":..., "content":...}] ]   convenience shape
+      - list[ {"custom_id": str, "params": {...}} ] full shape
+    Return the full Anthropic shape in both cases.
+    """
+    if not isinstance(messages, list) or not messages:
+        raise AnthropicBatchError("messages must be a non-empty list")
+
+    out: list[dict] = []
+    for i, item in enumerate(messages):
+        if isinstance(item, dict) and "params" in item and "custom_id" in item:
+            # Already in full shape — accept verbatim.
+            out.append(item)
+            continue
+        if isinstance(item, list):
+            out.append({
+                "custom_id": f"req-{i}",
+                "params": {
+                    "model":      model,
+                    "max_tokens": max_tokens,
+                    "messages":   item,
+                },
+            })
+            continue
+        raise AnthropicBatchError(
+            f"messages[{i}] must be a list of message dicts or a full request "
+            f"dict with custom_id+params; got {type(item).__name__}"
+        )
+    return out
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+def create_batch(
+    messages: list[Any],
+    model: str,
+    *,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    timeout: float = HTTP_TIMEOUT_S,
+) -> str:
+    """POST a new batch. Returns the batch_id."""
+    if not isinstance(model, str) or not model:
+        raise AnthropicBatchError("model must be a non-empty string")
+    requests_payload = _normalise_requests(messages, model, max_tokens)
+    body = {"requests": requests_payload}
+
+    with httpx.Client(timeout=timeout) as client:
+        resp = client.post(
+            f"{ANTHROPIC_API_BASE}/messages/batches",
+            json=body, headers=_headers(),
+        )
+    if resp.status_code >= 400:
+        raise AnthropicBatchError(
+            f"create_batch HTTP {resp.status_code}: {resp.text[:500]}"
+        )
+
+    data = resp.json()
+    batch_id = data.get("id")
+    if not isinstance(batch_id, str):
+        raise AnthropicBatchError(f"create_batch: missing 'id' in response: {data!r}")
+    logger.info(
+        "anthropic_batch.create batch_id=%s requests=%d model=%s",
+        batch_id, len(requests_payload), model,
+    )
+    return batch_id
+
+
+def poll_batch(batch_id: str, *, timeout: float = HTTP_TIMEOUT_S) -> dict:
+    """GET batch status. Returns the full payload (processing_status,
+    request_counts, etc.). Raises on HTTP/JSON failures."""
+    bid = _validate_batch_id(batch_id)
+    with httpx.Client(timeout=timeout) as client:
+        resp = client.get(
+            f"{ANTHROPIC_API_BASE}/messages/batches/{bid}",
+            headers=_headers(),
+        )
+    if resp.status_code >= 400:
+        raise AnthropicBatchError(
+            f"poll_batch HTTP {resp.status_code}: {resp.text[:500]}"
+        )
+    return resp.json()
+
+
+def get_results(batch_id: str, *, timeout: float = HTTP_TIMEOUT_S) -> list[dict]:
+    """GET batch results. Returns a list of per-request result dicts
+    (each has custom_id + result). Only valid AFTER the batch has
+    processing_status='ended'."""
+    bid = _validate_batch_id(batch_id)
+    with httpx.Client(timeout=timeout) as client:
+        resp = client.get(
+            f"{ANTHROPIC_API_BASE}/messages/batches/{bid}/results",
+            headers=_headers(),
+        )
+    if resp.status_code >= 400:
+        raise AnthropicBatchError(
+            f"get_results HTTP {resp.status_code}: {resp.text[:500]}"
+        )
+    # Anthropic returns JSONL — one result object per line.
+    out: list[dict] = []
+    for line in resp.text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            import json
+            out.append(json.loads(line))
+        except (ValueError, TypeError) as exc:
+            logger.warning("get_results: skip un-parseable line: %s", exc)
+    logger.info("anthropic_batch.results batch_id=%s n=%d", bid, len(out))
+    return out
+
+
+def cancel_batch(batch_id: str, *, timeout: float = HTTP_TIMEOUT_S) -> dict:
+    """POST cancel. Returns the updated batch payload."""
+    bid = _validate_batch_id(batch_id)
+    with httpx.Client(timeout=timeout) as client:
+        resp = client.post(
+            f"{ANTHROPIC_API_BASE}/messages/batches/{bid}/cancel",
+            headers=_headers(),
+        )
+    if resp.status_code >= 400:
+        raise AnthropicBatchError(
+            f"cancel_batch HTTP {resp.status_code}: {resp.text[:500]}"
+        )
+    return resp.json()
+
+
+def wait_for_batch(
+    batch_id: str,
+    *,
+    interval: float = POLL_INTERVAL_S,
+    max_wait_s: float = POLL_MAX_S,
+) -> dict:
+    """Convenience polling loop. Returns the final payload when
+    processing_status reaches a terminal state ('ended' / 'canceled' /
+    'expired'). Raises on timeout or HTTP failure."""
+    if interval <= 0:
+        raise AnthropicBatchError("interval must be > 0")
+    deadline = time.monotonic() + max_wait_s
+    terminal = {"ended", "canceled", "expired", "failed"}
+    while True:
+        payload = poll_batch(batch_id)
+        status = payload.get("processing_status")
+        if status in terminal:
+            logger.info(
+                "anthropic_batch.wait batch_id=%s terminal=%s counts=%s",
+                batch_id, status, payload.get("request_counts"),
+            )
+            return payload
+        if time.monotonic() > deadline:
+            raise AnthropicBatchError(
+                f"wait_for_batch timed out (>{max_wait_s}s) — last status={status!r}",
+            )
+        time.sleep(interval)

--- a/tests/integrations/test_anthropic_batch.py
+++ b/tests/integrations/test_anthropic_batch.py
@@ -1,0 +1,260 @@
+"""
+P4 — Tests for src/integrations/anthropic_batch.py.
+
+Pure mocks — never touches the real Anthropic API. Confirms:
+  - _normalise_requests handles convenience + full shapes
+  - _validate_batch_id rejects malformed ids
+  - create_batch posts the right body, returns the id, includes the
+    300K beta header
+  - poll_batch / get_results / cancel_batch hit the right URLs
+  - get_results parses JSONL line-per-result
+  - wait_for_batch loops until a terminal state, then returns
+  - Every error path raises AnthropicBatchError (not a generic exception)
+  - No subprocess invoked anywhere
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.integrations import anthropic_batch as ab
+
+# ─── _normalise_requests ───────────────────────────────────────────────────
+
+def test_normalise_convenience_shape():
+    out = ab._normalise_requests(
+        [[{"role": "user", "content": "hi"}]],
+        model="claude-haiku-4-5",
+        max_tokens=200,
+    )
+    assert out[0]["custom_id"] == "req-0"
+    assert out[0]["params"]["model"] == "claude-haiku-4-5"
+    assert out[0]["params"]["max_tokens"] == 200
+    assert out[0]["params"]["messages"][0]["content"] == "hi"
+
+
+def test_normalise_full_shape_passthrough():
+    full = {
+        "custom_id": "my-id-7",
+        "params": {"model": "x", "max_tokens": 1, "messages": []},
+    }
+    out = ab._normalise_requests([full], model="ignored", max_tokens=999)
+    assert out == [full]
+
+
+def test_normalise_rejects_empty_list():
+    with pytest.raises(ab.AnthropicBatchError):
+        ab._normalise_requests([], model="m", max_tokens=10)
+
+
+def test_normalise_rejects_bad_item_type():
+    with pytest.raises(ab.AnthropicBatchError):
+        ab._normalise_requests(["not a list or dict"], model="m", max_tokens=10)
+
+
+# ─── _validate_batch_id ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("good", [
+    "msgbatch_abc123",
+    "msgbatch_x-y_z",
+])
+def test_valid_batch_ids_pass(good):
+    assert ab._validate_batch_id(good) == good
+
+
+@pytest.mark.parametrize("bad", [
+    None, "", 123, "wrong_prefix_abc", "msgbatch_!!!", "msgbatch_" + "a" * 200,
+])
+def test_invalid_batch_ids_rejected(bad):
+    with pytest.raises(ab.AnthropicBatchError):
+        ab._validate_batch_id(bad)
+
+
+# ─── HTTP harness ──────────────────────────────────────────────────────────
+
+class _FakeClient:
+    """Context-manager fake httpx.Client that records calls + scripts responses."""
+
+    def __init__(self, scripted_responses):
+        self._scripted = list(scripted_responses)
+        self.calls = []
+
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+    def _next(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        if not self._scripted:
+            raise AssertionError(f"unexpected extra HTTP call {method} {url}")
+        return self._scripted.pop(0)
+
+    def post(self, url, **kw): return self._next("POST", url, **kw)
+    def get(self, url, **kw):  return self._next("GET", url, **kw)
+
+
+def _resp(status: int, json_data=None, text: str = "") -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.text = text or (str(json_data) if json_data is not None else "")
+    r.json = MagicMock(return_value=json_data or {})
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch):
+    monkeypatch.setattr(ab.settings, "anthropic_api_key", "test-key")
+
+
+# ─── create_batch ──────────────────────────────────────────────────────────
+
+def test_create_batch_returns_id_and_sends_beta_header(monkeypatch):
+    fake_client = _FakeClient([_resp(200, {"id": "msgbatch_abc"})])
+    monkeypatch.setattr(ab.httpx, "Client", lambda **_: fake_client)
+
+    out = ab.create_batch(
+        [[{"role": "user", "content": "hi"}]],
+        model="claude-haiku-4-5",
+    )
+    assert out == "msgbatch_abc"
+
+    method, url, kwargs = fake_client.calls[0]
+    assert method == "POST"
+    assert url == f"{ab.ANTHROPIC_API_BASE}/messages/batches"
+    assert "output-300k-2026-03-24" in kwargs["headers"]["anthropic-beta"]
+    assert "message-batches-2024-09-24" in kwargs["headers"]["anthropic-beta"]
+    assert kwargs["json"]["requests"][0]["params"]["model"] == "claude-haiku-4-5"
+
+
+def test_create_batch_raises_on_4xx(monkeypatch):
+    fake_client = _FakeClient([_resp(400, text="bad request")])
+    monkeypatch.setattr(ab.httpx, "Client", lambda **_: fake_client)
+    with pytest.raises(ab.AnthropicBatchError, match="HTTP 400"):
+        ab.create_batch([[{"role": "user", "content": "hi"}]], model="m")
+
+
+def test_create_batch_raises_when_response_missing_id(monkeypatch):
+    fake_client = _FakeClient([_resp(200, {"unexpected": "shape"})])
+    monkeypatch.setattr(ab.httpx, "Client", lambda **_: fake_client)
+    with pytest.raises(ab.AnthropicBatchError, match="missing 'id'"):
+        ab.create_batch([[{"role": "user", "content": "hi"}]], model="m")
+
+
+def test_create_batch_rejects_blank_model(monkeypatch):
+    with pytest.raises(ab.AnthropicBatchError):
+        ab.create_batch([[{"role": "user", "content": "x"}]], model="")
+
+
+# ─── poll_batch ────────────────────────────────────────────────────────────
+
+def test_poll_batch_returns_payload(monkeypatch):
+    fake_client = _FakeClient([_resp(200, {
+        "id": "msgbatch_abc", "processing_status": "in_progress",
+        "request_counts": {"processing": 5},
+    })])
+    monkeypatch.setattr(ab.httpx, "Client", lambda **_: fake_client)
+    out = ab.poll_batch("msgbatch_abc")
+    assert out["processing_status"] == "in_progress"
+    method, url, _ = fake_client.calls[0]
+    assert method == "GET"
+    assert url.endswith("/messages/batches/msgbatch_abc")
+
+
+def test_poll_batch_rejects_invalid_id():
+    with pytest.raises(ab.AnthropicBatchError):
+        ab.poll_batch("not-a-real-id")
+
+
+# ─── get_results — JSONL parsing ───────────────────────────────────────────
+
+def test_get_results_parses_jsonl(monkeypatch):
+    body = (
+        '{"custom_id":"req-0","result":{"type":"succeeded"}}\n'
+        '\n'
+        '{"custom_id":"req-1","result":{"type":"succeeded"}}\n'
+    )
+    fake_client = _FakeClient([_resp(200, text=body)])
+    monkeypatch.setattr(ab.httpx, "Client", lambda **_: fake_client)
+    out = ab.get_results("msgbatch_abc")
+    assert len(out) == 2
+    assert out[0]["custom_id"] == "req-0"
+    assert out[1]["custom_id"] == "req-1"
+
+
+def test_get_results_skips_garbage_lines(monkeypatch):
+    body = (
+        '{"custom_id":"req-0","result":{"type":"succeeded"}}\n'
+        'NOT-JSON\n'
+        '{"custom_id":"req-1","result":{"type":"succeeded"}}\n'
+    )
+    fake_client = _FakeClient([_resp(200, text=body)])
+    monkeypatch.setattr(ab.httpx, "Client", lambda **_: fake_client)
+    out = ab.get_results("msgbatch_abc")
+    assert len(out) == 2  # bad line skipped
+
+
+# ─── cancel_batch ──────────────────────────────────────────────────────────
+
+def test_cancel_batch_returns_payload(monkeypatch):
+    fake_client = _FakeClient([_resp(200, {"id": "msgbatch_abc", "processing_status": "canceling"})])
+    monkeypatch.setattr(ab.httpx, "Client", lambda **_: fake_client)
+    out = ab.cancel_batch("msgbatch_abc")
+    assert out["processing_status"] == "canceling"
+    method, url, _ = fake_client.calls[0]
+    assert method == "POST"
+    assert url.endswith("/cancel")
+
+
+# ─── wait_for_batch — polling loop ─────────────────────────────────────────
+
+def test_wait_for_batch_loops_until_terminal(monkeypatch):
+    """3 poll responses: in_progress → in_progress → ended."""
+    monkeypatch.setattr(ab.time, "sleep", lambda _s: None)  # no real sleep
+    payloads = [
+        {"processing_status": "in_progress"},
+        {"processing_status": "in_progress"},
+        {"processing_status": "ended", "request_counts": {"succeeded": 5}},
+    ]
+    fake_client = _FakeClient([_resp(200, p) for p in payloads])
+    monkeypatch.setattr(ab.httpx, "Client", lambda **_: fake_client)
+    out = ab.wait_for_batch("msgbatch_abc", interval=0.01, max_wait_s=10)
+    assert out["processing_status"] == "ended"
+    assert len(fake_client.calls) == 3
+
+
+def test_wait_for_batch_raises_on_timeout(monkeypatch):
+    monkeypatch.setattr(ab.time, "sleep", lambda _s: None)
+    # Always returns in_progress; loop must give up at deadline.
+    fake_client = _FakeClient([_resp(200, {"processing_status": "in_progress"})] * 50)
+    monkeypatch.setattr(ab.httpx, "Client", lambda **_: fake_client)
+    monkeypatch.setattr(ab.time, "monotonic", iter([0.0, 1.0, 5.0, 100.0]).__next__)
+    with pytest.raises(ab.AnthropicBatchError, match="timed out"):
+        ab.wait_for_batch("msgbatch_abc", interval=0.01, max_wait_s=2)
+
+
+def test_wait_for_batch_rejects_zero_interval():
+    with pytest.raises(ab.AnthropicBatchError):
+        ab.wait_for_batch("msgbatch_abc", interval=0, max_wait_s=10)
+
+
+# ─── missing API key ───────────────────────────────────────────────────────
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.setattr(ab.settings, "anthropic_api_key", "")
+    with pytest.raises(ab.AnthropicBatchError, match="API_KEY"):
+        ab.create_batch([[{"role": "user", "content": "hi"}]], model="m")
+
+
+# ─── security guards ──────────────────────────────────────────────────────
+
+@patch("subprocess.run")
+@patch("subprocess.check_call")
+@patch("subprocess.check_output")
+def test_no_subprocess_calls_in_module(check_output, check_call, run, monkeypatch):
+    """Defence-in-depth — no path through this module touches a subprocess."""
+    fake_client = _FakeClient([_resp(200, {"id": "msgbatch_x"})])
+    monkeypatch.setattr(ab.httpx, "Client", lambda **_: fake_client)
+    ab.create_batch([[{"role": "user", "content": "hi"}]], model="m")
+    run.assert_not_called()
+    check_call.assert_not_called()
+    check_output.assert_not_called()


### PR DESCRIPTION
## Summary
Wrapper around the Anthropic Message Batches API with the \`output-300k-2026-03-24\` beta header. 50% pricing discount + 300K output-token ceiling for cost-effective bulk sub-agent work.

## Public surface
| Function | Purpose |
|---|---|
| \`create_batch(messages, model, *, max_tokens, timeout)\` → \`batch_id\` | POST /v1/messages/batches |
| \`poll_batch(batch_id)\` → \`dict\` | GET status payload |
| \`get_results(batch_id)\` → \`list[dict]\` | GET + parse JSONL results |
| \`cancel_batch(batch_id)\` → \`dict\` | POST .../cancel |
| \`wait_for_batch(batch_id, *, interval, max_wait_s)\` → \`dict\` | Convenience polling loop, terminal-status aware |

\`messages\` accepts BOTH the convenience shape (auto-wrapped with \`custom_id="req-{i}"\`) and the full Anthropic shape (\`{custom_id, params}\` passthrough).

## Beta header
\`anthropic-beta: message-batches-2024-09-24,output-300k-2026-03-24\`

## Error model
All failure paths raise \`AnthropicBatchError\` (typed). \`wait_for_batch\` recognises the four terminal states (\`ended / canceled / expired / failed\`) and surfaces the final payload; on timeout it raises with the last-seen status.

## Security guards (per OpenClaw note carry-over)
- No subprocess
- Only HTTP target is the constant \`ANTHROPIC_API_BASE\` — no URL following from caller input
- \`batch_id\` matched against \`^msgbatch_[A-Za-z0-9_-]{1,128}$\` before any URL interpolation
- Messages JSON-serialised by httpx — never shell-quoted, never written to disk
- 30s HTTP timeout cap; 4h max-wait on \`wait_for_batch\` with monotonic-clock deadline

## Test plan
- [x] \`ruff check\` — clean
- [x] \`pytest tests/integrations/test_anthropic_batch.py\` — 26 passed in 2.75s
- [x] Zero live Anthropic calls (pure mocks)
- [x] Defence-in-depth: \`subprocess\` patched + asserted never invoked from \`create_batch\` end-to-end
- [ ] Operator: wire into bulk pipeline-stage callsites (sequence generation, voice-prompt synthesis) — out of scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)