### PR TITLE
[ATLAS] P10 — REM Backfill one-shot memory migration

### DIFF
--- a/scripts/memory_rem_backfill.py
+++ b/scripts/memory_rem_backfill.py
@@ -1,0 +1,244 @@
+"""
+P10 — REM Backfill (one-shot historical memory consolidation).
+
+Companion to scripts/memory_consolidation.py (OC1 — Dreaming pattern).
+The Dreaming sweep is designed for the recent window (default 30d).
+This script handles the COLD STORE — every daily_log in
+elliot_internal.memories that's already older than --age-threshold-days
+(default 7) gets a one-time replay through the same five-factor scoring
++ promotion pipeline.
+
+Why a separate script?
+  - Dreaming is the ongoing nightly sweep — small windows, fast.
+  - REM Backfill is a one-shot migration over historical data.
+  - Same scoring lib (memory_consolidation) so the verdicts agree
+    with what the nightly Dreaming would have produced if it had been
+    running all along.
+  - OC1's WHERE-NOT-EXISTS idempotency guard means rerunning the
+    backfill never creates duplicate core_facts.
+
+Usage
+-----
+    python3 scripts/memory_rem_backfill.py                     # dry-run preview
+    python3 scripts/memory_rem_backfill.py --execute           # write
+    python3 scripts/memory_rem_backfill.py --age-threshold-days 14
+    python3 scripts/memory_rem_backfill.py --min-score 0.7
+    python3 scripts/memory_rem_backfill.py --max-rows 5000     # cap per run
+
+Exit codes: 0 OK · 3 DB unavailable.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
+sys.path.insert(0, REPO_ROOT)
+sys.path.insert(0, SCRIPTS_DIR)
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv("/home/elliotbot/.config/agency-os/.env")
+
+import asyncpg  # noqa: E402
+
+# Reuse the OC1 lib — same scoring, same idempotent INSERT.
+from memory_consolidation import (  # noqa: E402
+    Memory,
+    promote_to_core_fact,
+    score,
+)
+
+from src.config.settings import settings  # noqa: E402
+
+DEFAULT_AGE_THRESHOLD_DAYS = 7
+DEFAULT_MIN_SCORE          = 0.6
+DEFAULT_BATCH_SIZE         = 200
+DEFAULT_MAX_ROWS           = 0       # 0 = unbounded
+
+
+# ── DB I/O ────────────────────────────────────────────────────────────────
+
+async def fetch_old_daily_logs(
+    conn, *, age_threshold_days: int, max_rows: int,
+) -> list[Memory]:
+    """Pull every daily_log strictly OLDER than the age threshold,
+    newest-first within the cold window. max_rows == 0 → unbounded."""
+    cutoff = datetime.now(UTC) - timedelta(days=age_threshold_days)
+    if max_rows > 0:
+        rows = await conn.fetch(
+            """
+            SELECT id, content, content_hash, type, created_at, metadata
+            FROM elliot_internal.memories
+            WHERE deleted_at IS NULL
+              AND type = 'daily_log'
+              AND created_at < $1
+            ORDER BY created_at DESC
+            LIMIT $2
+            """,
+            cutoff, max_rows,
+        )
+    else:
+        rows = await conn.fetch(
+            """
+            SELECT id, content, content_hash, type, created_at, metadata
+            FROM elliot_internal.memories
+            WHERE deleted_at IS NULL
+              AND type = 'daily_log'
+              AND created_at < $1
+            ORDER BY created_at DESC
+            """,
+            cutoff,
+        )
+    return [
+        Memory(
+            id=str(r["id"]),
+            content=r["content"] or "",
+            content_hash=r["content_hash"],
+            type=r["type"],
+            created_at=r["created_at"],
+            metadata=r["metadata"] or {},
+        )
+        for r in rows
+    ]
+
+
+def _chunked(seq: list, size: int):
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
+
+
+# ── Pipeline ──────────────────────────────────────────────────────────────
+
+async def replay(
+    conn,
+    *,
+    age_threshold_days: int,
+    min_score: float,
+    batch_size: int,
+    max_rows: int,
+    dry_run: bool,
+) -> dict:
+    cold = await fetch_old_daily_logs(
+        conn,
+        age_threshold_days=age_threshold_days,
+        max_rows=max_rows,
+    )
+
+    promoted: list[Memory] = []
+    above_threshold_total = 0
+
+    for batch in _chunked(cold, batch_size):
+        # Score the batch in isolation so frequency / consolidation factors
+        # stay bounded and meaningful per-window.
+        score(batch)
+        for m in batch:
+            if m.composite >= min_score:
+                above_threshold_total += 1
+                # OC1 idempotency: WHERE NOT EXISTS keyed on
+                # metadata->>'consolidated_from' = m.id ensures a re-run
+                # is a no-op.
+                if await promote_to_core_fact(conn, m, dry_run=dry_run):
+                    promoted.append(m)
+
+    return {
+        "scanned":             len(cold),
+        "above_threshold":     above_threshold_total,
+        "promoted":            len(promoted),
+        "skipped_dup_guard":   above_threshold_total - len(promoted),
+        "age_threshold_days":  age_threshold_days,
+        "min_score":           min_score,
+        "batch_size":          batch_size,
+        "max_rows":            max_rows or "unbounded",
+        "top_promotions": [
+            {
+                "id":        m.id,
+                "composite": m.composite,
+                "created":   m.created_at.date().isoformat(),
+                "preview":   (m.content or "")[:120].replace("\n", " "),
+            }
+            for m in sorted(promoted, key=lambda x: x.composite, reverse=True)[:10]
+        ],
+    }
+
+
+# ── Render ────────────────────────────────────────────────────────────────
+
+def render_human(result: dict, *, dry_run: bool) -> str:
+    lines = [
+        "=" * 72,
+        f"REM Backfill — {'DRY-RUN' if dry_run else 'EXECUTE'}",
+        "=" * 72,
+        f"  age threshold     : > {result['age_threshold_days']} days old",
+        f"  min score         : {result['min_score']}",
+        f"  batch size        : {result['batch_size']}",
+        f"  max rows per run  : {result['max_rows']}",
+        "",
+        f"  scanned (cold daily_log):           {result['scanned']:,}",
+        f"  above promotion threshold:          {result['above_threshold']:,}",
+        f"  promoted (new core_fact rows):      {result['promoted']:,}",
+        f"  skipped by OC1 idempotency guard:   {result['skipped_dup_guard']:,}",
+    ]
+    if result["top_promotions"]:
+        lines.append("")
+        lines.append("  Top promotions:")
+        for p in result["top_promotions"]:
+            lines.append(
+                f"    {p['composite']:>5.3f}  {p['created']}  {p['id'][:8]}  {p['preview']}"
+            )
+    return "\n".join(lines)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+
+async def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="P10 REM Backfill — one-shot memory migration.")
+    ap.add_argument("--age-threshold-days", type=int, default=DEFAULT_AGE_THRESHOLD_DAYS,
+                    help="Only replay daily_logs strictly OLDER than this (default 7).")
+    ap.add_argument("--min-score", type=float, default=DEFAULT_MIN_SCORE,
+                    help="Composite-score threshold for promotion (default 0.6).")
+    ap.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE,
+                    help="Score window size (default 200).")
+    ap.add_argument("--max-rows", type=int, default=DEFAULT_MAX_ROWS,
+                    help="Cap rows pulled per run (default 0 = unbounded).")
+    ap.add_argument("--execute", action="store_true",
+                    help="Apply writes. Default is dry-run.")
+    args = ap.parse_args(argv)
+    dry_run = not args.execute
+
+    if args.age_threshold_days < 0:
+        print("--age-threshold-days must be >= 0", file=sys.stderr)
+        return 2
+    if args.batch_size <= 0:
+        print("--batch-size must be > 0", file=sys.stderr)
+        return 2
+
+    try:
+        dsn = settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+        conn = await asyncpg.connect(dsn, statement_cache_size=0)
+    except Exception as exc:  # noqa: BLE001
+        print(f"DB unavailable: {exc}", file=sys.stderr)
+        return 3
+
+    try:
+        result = await replay(
+            conn,
+            age_threshold_days=args.age_threshold_days,
+            min_score=args.min_score,
+            batch_size=args.batch_size,
+            max_rows=args.max_rows,
+            dry_run=dry_run,
+        )
+    finally:
+        await conn.close()
+
+    print(render_human(result, dry_run=dry_run))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/scripts/test_memory_rem_backfill.py
+++ b/tests/scripts/test_memory_rem_backfill.py
@@ -1,0 +1,227 @@
+"""
+P10 — Tests for scripts/memory_rem_backfill.py.
+
+Pure mocks — no real Supabase. Confirms:
+  - fetch_old_daily_logs query parameters (cutoff direction + bounded
+    vs unbounded LIMIT branch)
+  - _chunked yields full + partial windows
+  - replay() promotes only memories with composite >= min_score
+  - replay() obeys max_rows cap (via fetch limit) + batch_size
+  - replay() respects OC1 idempotency: when promote_to_core_fact returns
+    False (guard skipped), 'skipped_dup_guard' increments
+  - replay() in dry-run never invokes a real DB write through the
+    promote_to_core_fact stub
+  - render_human surfaces all four counts
+  - CLI rejects negative thresholds + zero batch size
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "memory_rem_backfill.py"
+_spec = importlib.util.spec_from_file_location("memory_rem_backfill", _SCRIPT)
+rem = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["memory_rem_backfill"] = rem
+_spec.loader.exec_module(rem)
+
+
+def _row(i: int, content: str = "filler entry"):
+    return {
+        "id":           f"00000000-0000-0000-0000-{i:012d}",
+        "content":      content,
+        "content_hash": f"hash-{i}",
+        "type":         "daily_log",
+        "created_at":   datetime(2026, 1, 1, tzinfo=UTC),
+        "metadata":     {},
+    }
+
+
+# ─── _chunked ──────────────────────────────────────────────────────────────
+
+def test_chunked_yields_full_and_partial_windows():
+    out = list(rem._chunked(list(range(7)), 3))
+    assert out == [[0, 1, 2], [3, 4, 5], [6]]
+
+
+def test_chunked_empty_list():
+    assert list(rem._chunked([], 5)) == []
+
+
+# ─── fetch_old_daily_logs ──────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_fetch_old_daily_logs_unbounded_branch():
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[_row(0), _row(1)])
+    out = await rem.fetch_old_daily_logs(
+        conn, age_threshold_days=7, max_rows=0,
+    )
+    assert len(out) == 2
+    sql = conn.fetch.await_args.args[0]
+    # Cold query uses < cutoff (older-than) — NOT >= cutoff
+    assert "created_at < $1" in sql
+    assert "LIMIT" not in sql  # unbounded branch
+
+
+@pytest.mark.asyncio
+async def test_fetch_old_daily_logs_bounded_branch():
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[_row(0)])
+    await rem.fetch_old_daily_logs(
+        conn, age_threshold_days=14, max_rows=500,
+    )
+    sql, *args = conn.fetch.await_args.args
+    assert "LIMIT $2" in sql
+    assert args[1] == 500
+
+
+# ─── replay() — scoring + promotion routing ────────────────────────────────
+
+@pytest.fixture
+def patch_score(monkeypatch):
+    """Score every memory at 0.7 by default; first arg of fetched list
+    flagged at composite 0.4 to test below-threshold skip."""
+    def _score(memories):
+        for i, m in enumerate(memories):
+            m.composite = 0.4 if i == 0 else 0.7
+            m.factors = {"r": 1.0}
+    monkeypatch.setattr(rem, "score", _score)
+    return _score
+
+
+@pytest.mark.asyncio
+async def test_replay_promotes_only_above_threshold(monkeypatch, patch_score):
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[_row(i) for i in range(3)])
+    promote = AsyncMock(return_value=True)
+    monkeypatch.setattr(rem, "promote_to_core_fact", promote)
+
+    result = await rem.replay(
+        conn, age_threshold_days=7, min_score=0.6,
+        batch_size=10, max_rows=0, dry_run=True,
+    )
+
+    assert result["scanned"] == 3
+    assert result["above_threshold"] == 2  # 0th below threshold
+    assert result["promoted"] == 2
+    assert result["skipped_dup_guard"] == 0
+    # promote called exactly twice (only above-threshold rows)
+    assert promote.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_replay_counts_idempotency_skip(monkeypatch, patch_score):
+    """When promote_to_core_fact returns False (OC1 WHERE NOT EXISTS
+    skipped the row), the count moves to skipped_dup_guard."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[_row(i) for i in range(3)])
+    # First above-threshold row inserts; second already exists in DB.
+    promote = AsyncMock(side_effect=[True, False])
+    monkeypatch.setattr(rem, "promote_to_core_fact", promote)
+
+    result = await rem.replay(
+        conn, age_threshold_days=7, min_score=0.6,
+        batch_size=10, max_rows=0, dry_run=False,
+    )
+    assert result["above_threshold"] == 2
+    assert result["promoted"] == 1
+    assert result["skipped_dup_guard"] == 1
+
+
+@pytest.mark.asyncio
+async def test_replay_chunks_into_batches(monkeypatch):
+    """batch_size=2 over 5 rows → 3 batches → 3 score() invocations."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[_row(i) for i in range(5)])
+    promote = AsyncMock(return_value=True)
+    monkeypatch.setattr(rem, "promote_to_core_fact", promote)
+
+    score_calls = {"n": 0}
+
+    def _score(batch):
+        score_calls["n"] += 1
+        for m in batch:
+            m.composite = 1.0  # everything passes
+
+    monkeypatch.setattr(rem, "score", _score)
+
+    result = await rem.replay(
+        conn, age_threshold_days=7, min_score=0.6,
+        batch_size=2, max_rows=0, dry_run=True,
+    )
+    assert score_calls["n"] == 3
+    assert result["scanned"] == 5
+    assert result["promoted"] == 5
+
+
+@pytest.mark.asyncio
+async def test_replay_dry_run_passes_flag_to_promote(monkeypatch, patch_score):
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[_row(0)])
+    captured = {"dry_run": None}
+
+    async def fake_promote(conn, m, *, dry_run):
+        captured["dry_run"] = dry_run
+        return True
+
+    monkeypatch.setattr(rem, "score", lambda batch: setattr(batch[0], "composite", 0.9))
+    monkeypatch.setattr(rem, "promote_to_core_fact", fake_promote)
+
+    await rem.replay(conn, age_threshold_days=7, min_score=0.6,
+                     batch_size=10, max_rows=0, dry_run=True)
+    assert captured["dry_run"] is True
+
+
+# ─── render_human ──────────────────────────────────────────────────────────
+
+def test_render_human_surfaces_all_counts():
+    result = {
+        "scanned": 100, "above_threshold": 40,
+        "promoted": 30, "skipped_dup_guard": 10,
+        "age_threshold_days": 7, "min_score": 0.6,
+        "batch_size": 200, "max_rows": "unbounded",
+        "top_promotions": [],
+    }
+    out = rem.render_human(result, dry_run=True)
+    assert "DRY-RUN" in out
+    assert "scanned (cold daily_log):           100" in out
+    assert "above promotion threshold:          40" in out
+    assert "promoted (new core_fact rows):      30" in out
+    assert "skipped by OC1 idempotency guard:   10" in out
+
+
+def test_render_human_lists_top_promotions():
+    result = {
+        "scanned": 1, "above_threshold": 1, "promoted": 1, "skipped_dup_guard": 0,
+        "age_threshold_days": 7, "min_score": 0.6,
+        "batch_size": 200, "max_rows": "unbounded",
+        "top_promotions": [
+            {"id": "abcdef12-...", "composite": 0.9,
+             "created": "2026-04-01", "preview": "Session ended..."},
+        ],
+    }
+    out = rem.render_human(result, dry_run=False)
+    assert "EXECUTE" in out
+    assert "0.900" in out
+    assert "Session ended..." in out
+
+
+# ─── CLI guards ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_cli_rejects_negative_age_threshold():
+    rc = await rem.main(["--age-threshold-days", "-1"])
+    assert rc == 2
+
+
+@pytest.mark.asyncio
+async def test_cli_rejects_zero_batch_size():
+    rc = await rem.main(["--batch-size", "0"])
+    assert rc == 2


### PR DESCRIPTION
## Summary
One-shot migration that replays every COLD \`daily_log\` (already older than \`--age-threshold-days\`, default 7) through the OC1 Dreaming pipeline (\`scripts/memory_consolidation.py\`). Same five-factor scoring; same idempotent INSERT guard, so re-runs are no-ops.

## Why a separate script
- **Dreaming** (OC1) — ongoing nightly sweep, recent window (default 30d).
- **REM Backfill** (P10) — one-shot historical replay, opposite query direction (\`created_at < cutoff\`).

Both share \`score()\` + \`promote_to_core_fact()\` so verdicts agree with what the nightly Dreaming would have produced if it had been running all along.

## CLI
\`\`\`
python3 scripts/memory_rem_backfill.py                     # dry-run preview
python3 scripts/memory_rem_backfill.py --execute           # write
python3 scripts/memory_rem_backfill.py --age-threshold-days 14
python3 scripts/memory_rem_backfill.py --min-score 0.7
python3 scripts/memory_rem_backfill.py --max-rows 5000     # cap per run
\`\`\`
Exit codes: 0 OK · 2 invalid args · 3 DB unavailable.

## Live dry-run (defaults, current Supabase)
\`\`\`
scanned (cold daily_log):           76
above promotion threshold:          44
promoted (new core_fact rows):      44
skipped by OC1 idempotency guard:   0
\`\`\`
Top promotions are real session-end summaries (multi-callsign marathons) — exactly the historical knowledge the backfill is supposed to surface.

## Test plan
- [x] \`ruff check\` — clean
- [x] \`pytest tests/scripts/test_memory_rem_backfill.py\` — 12 passed (chunking, fetch SQL direction, score routing, idempotency-skip count, dry-run flag flow, CLI guards)
- [x] Live dry-run produces sensible counts + top-promotion preview
- [ ] Operator: run \`--execute\` once at the operator's discretion; the OC1 guard makes it safely re-runnable

🤖 Generated with [Claude Code](https://claude.com/claude-code)