### PR TITLE
[ATLAS] Step 1 cleanup — P11 sidecar wire-up + demo auth + smoke baseline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ FROM dependencies AS production
 # Copy application code
 COPY src/ ./src/
 COPY config/ ./config/
+COPY scripts/cgroup_memory_guard.py ./scripts/cgroup_memory_guard.py
+COPY scripts/entrypoint.sh ./scripts/entrypoint.sh
+RUN chmod +x ./scripts/entrypoint.sh
 
 # Create non-root user for security
 RUN adduser --disabled-password --gecos '' appuser && \
@@ -70,9 +73,10 @@ ENV AGENT_MEMORY_WARN_PCT=80 \
     AGENT_MEMORY_KILL_PCT=95 \
     AGENT_MEMORY_PID_DIR=/tmp/agency_os/agents
 
-# Default command (API service)
-# Uses shell form to expand $PORT env var (Railway sets this dynamically)
-CMD uvicorn src.api.main:app --host 0.0.0.0 --port ${PORT:-8000}
+# P11 — entrypoint launches the cgroup memory guard as a background
+# sidecar, then exec's uvicorn so signals propagate cleanly.
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]
+CMD ["sh", "-c", "uvicorn src.api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
 
 # === Camoufox Stage (Optional - Tier 3 Scraper) ===
 # Use this target for Cloudflare bypass capability
@@ -97,6 +101,9 @@ RUN pip install camoufox[geoip] && \
 # Copy application code
 COPY src/ ./src/
 COPY config/ ./config/
+COPY scripts/cgroup_memory_guard.py ./scripts/cgroup_memory_guard.py
+COPY scripts/entrypoint.sh ./scripts/entrypoint.sh
+RUN chmod +x ./scripts/entrypoint.sh
 
 # Create non-root user
 RUN adduser --disabled-password --gecos '' appuser && \
@@ -111,7 +118,8 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:${PORT:-8000}/api/v1/health || exit 1
 
 EXPOSE 8000
-CMD uvicorn src.api.main:app --host 0.0.0.0 --port ${PORT:-8000}
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]
+CMD ["sh", "-c", "uvicorn src.api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
 
 # === VERIFICATION CHECKLIST ===
 # [x] Contract comment at top

--- a/docs/SMOKE_TEST_2026-04-26.md
+++ b/docs/SMOKE_TEST_2026-04-26.md
@@ -1,0 +1,54 @@
+# Smoke Test — main branch — 2026-04-26 (Step 1 cleanup)
+
+Run after merging P1 governance hooks, OC1 memory consolidation, P4
+batch API, P5 rate limits, P9 context fork, P10 REM backfill, P6
+sandbox isolation (+ wire-up), P11 cgroup memory + sidecar, and demo
+auth seeding.
+
+## Command
+
+```
+pytest --tb=short -q --ignore=tests/test_dncr_client.py
+```
+
+`tests/test_dncr_client.py` collects cleanly in isolation but errors
+during full-suite collection (pre-existing import-order side-effect on
+main; not introduced by this branch). Running it standalone passes
+both of its 2 tests.
+
+## Results
+
+| Bucket   | Count |
+|----------|------:|
+| **passed**   | **2,880** |
+| **failed**   | **53**    |
+| skipped  | 28    |
+| warnings | 141   |
+| wall     | 3 min 19 s |
+
+`tests/scripts/` + `tests/config/` (the namespace touched by Step 1):
+**264 passed, 0 failed in 2.38 s.**
+
+## Failing groups (all pre-existing on main — none touched by this branch)
+
+| Group | Files | Failures |
+|-------|-------|---------:|
+| Pipeline orchestrator wiring | `tests/test_pipeline/test_orchestrator_*` | 8 |
+| Pipeline parallel orchestrator | `tests/test_pipeline/test_parallel_orchestrator.py` | 3 |
+| Pipeline pipeline_orchestrator | `tests/test_pipeline/test_pipeline_orchestrator.py` | 4 |
+| Pipeline stage_parallel | `tests/test_pipeline/test_stage_parallel.py` | 7 |
+| Stage 9/10 flow | `tests/test_stage_9_10_flow.py` | 4 |
+| Card streaming | `tests/unit/test_card_streaming.py` | 3 |
+| Other (orchestrator gates etc.) | misc | 24 |
+
+These failures pre-date the Step 1 cleanup branch (`P11 sidecar`,
+`demo auth user`). The branch does not modify
+`src/pipeline/orchestrator*`, `src/flows/stage_9_10_flow.py`, or any
+card-streaming module.
+
+## Verdict
+
+GREEN for the surface this branch touches (264/264 in the affected
+namespace). The 53 pipeline/stage failures are existing main-branch
+debt that should be triaged separately — flagging in next session
+end report.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# P11 — container entrypoint with cgroup memory guard sidecar.
+#
+# Launches scripts/cgroup_memory_guard.py in the background so it
+# polls the container's cgroup memory accounting (warns at
+# $AGENT_MEMORY_WARN_PCT, kills sub-agent PIDs at
+# $AGENT_MEMORY_KILL_PCT). Then exec's the primary command (uvicorn
+# in API service, prefect worker etc.) as PID 1's foreground child so
+# signals from the runtime still reach it cleanly.
+#
+# Disable the guard with AGENT_MEMORY_GUARD_DISABLED=1 (e.g. local
+# dev where /sys/fs/cgroup is not mounted in a useful way).
+set -eu
+
+GUARD="${AGENT_MEMORY_GUARD_DISABLED:-0}"
+PID_DIR="${AGENT_MEMORY_PID_DIR:-/tmp/agency_os/agents}"
+WARN_PCT="${AGENT_MEMORY_WARN_PCT:-80}"
+KILL_PCT="${AGENT_MEMORY_KILL_PCT:-95}"
+INTERVAL="${AGENT_MEMORY_INTERVAL:-10}"
+
+mkdir -p "${PID_DIR}" 2>/dev/null || true
+
+if [ "${GUARD}" != "1" ]; then
+  python3 /app/scripts/cgroup_memory_guard.py \
+      --pid-dir "${PID_DIR}" \
+      --warn-pct "${WARN_PCT}" \
+      --kill-pct "${KILL_PCT}" \
+      --interval "${INTERVAL}" &
+  GUARD_PID=$!
+  # Reap the guard if the primary process exits, so the container can
+  # cycle cleanly under Railway's restart policy.
+  trap 'kill ${GUARD_PID} 2>/dev/null || true' INT TERM EXIT
+fi
+
+# exec replaces the shell so signals reach the primary process.
+exec "$@"

--- a/scripts/seed_demo_tenant.py
+++ b/scripts/seed_demo_tenant.py
@@ -30,9 +30,12 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import os
 import re
 import sys
+import urllib.error
+import urllib.request
 
 SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
@@ -51,6 +54,9 @@ DEMO_TIER = "spark"
 TARGET_PROSPECTS = 20
 MIN_STAGE = 6
 MIN_PROPENSITY = 60
+
+DEMO_AUTH_EMAIL = "demo@keiracom.com"
+DEMO_AUTH_PASSWORD_DEFAULT = "demo-investor-2026"
 
 # Placeholder / non-deliverable email locals — treat the address as missing.
 PLACEHOLDER_LOCALS = frozenset({
@@ -90,6 +96,129 @@ async def ensure_demo_client(conn) -> str:
     )
     print(f"demo client created — id={new_id}")
     return str(new_id)
+
+
+def ensure_demo_auth_user(
+    *,
+    supabase_url: str,
+    service_key: str,
+    email: str = DEMO_AUTH_EMAIL,
+    password: str | None = None,
+    dry_run: bool = False,
+) -> dict | None:
+    """Create or fetch the demo Supabase auth user via the GoTrue admin API.
+
+    Idempotent: if a user with the given email already exists, return it
+    unchanged. Returns the auth-user dict (id, email…) on success, or
+    None when credentials are missing / dry-run.
+
+    Uses urllib so the script gains no new third-party dependency. The
+    service key is required — the anon key cannot create users.
+    """
+    if dry_run:
+        print(f"  DRY-RUN — would ensure auth user {email}")
+        return None
+    if not supabase_url or not service_key:
+        print(
+            "  WARNING — SUPABASE_URL or SUPABASE_SERVICE_KEY missing; "
+            "skipping auth-user creation",
+            file=sys.stderr,
+        )
+        return None
+
+    pw = password or os.environ.get("DEMO_PASSWORD") or DEMO_AUTH_PASSWORD_DEFAULT
+    base = supabase_url.rstrip("/")
+    headers = {
+        "apikey":         service_key,
+        "Authorization": f"Bearer {service_key}",
+        "Content-Type":  "application/json",
+    }
+
+    # 1) Idempotent lookup — does the user already exist?
+    list_url = f"{base}/auth/v1/admin/users?email={email}"
+    req = urllib.request.Request(list_url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            payload = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        print(f"  WARNING — auth user lookup failed: {exc}", file=sys.stderr)
+        payload = {}
+    except (urllib.error.URLError, OSError) as exc:
+        print(f"  WARNING — auth API unreachable: {exc}", file=sys.stderr)
+        return None
+
+    users = payload.get("users") if isinstance(payload, dict) else None
+    if isinstance(users, list):
+        for u in users:
+            if isinstance(u, dict) and (u.get("email") or "").lower() == email.lower():
+                print(f"  demo auth user exists — id={u.get('id')}")
+                return u
+
+    # 2) Create.
+    create_url = f"{base}/auth/v1/admin/users"
+    body = json.dumps({
+        "email":         email,
+        "password":      pw,
+        "email_confirm": True,
+        "user_metadata": {
+            "role":     "demo",
+            "label":    "Demo Investor",
+            "seeded_by": "scripts/seed_demo_tenant.py",
+        },
+    }).encode()
+    req = urllib.request.Request(create_url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            user = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        msg = exc.read().decode("utf-8", errors="replace") if exc.fp else str(exc)
+        print(f"  ERROR — auth user create failed: {exc.code} {msg}", file=sys.stderr)
+        return None
+    except (urllib.error.URLError, OSError) as exc:
+        print(f"  ERROR — auth API unreachable on create: {exc}", file=sys.stderr)
+        return None
+
+    print(f"  demo auth user created — id={user.get('id')}")
+    return user
+
+
+async def link_auth_user_to_client(
+    conn, *, auth_user_id: str | None, client_id: str, dry_run: bool,
+) -> bool:
+    """Best-effort link in client_users (if the table exists). Idempotent.
+
+    The exact membership table varies between deploys (client_users /
+    client_members / clients_users). We probe information_schema and
+    insert only if a compatible table is present, so this works on
+    any deploy without crashing fresh ones.
+    """
+    if dry_run or not auth_user_id:
+        return False
+    table = await conn.fetchval(
+        """
+        SELECT table_name FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name IN ('client_users', 'client_members', 'clients_users')
+        ORDER BY table_name LIMIT 1
+        """,
+    )
+    if not table:
+        print("  (no client membership table found — skipping link)")
+        return False
+    try:
+        await conn.execute(
+            f"""
+            INSERT INTO {table} (id, client_id, user_id, role, created_at, updated_at)
+            VALUES (gen_random_uuid(), $1, $2, 'admin', NOW(), NOW())
+            ON CONFLICT DO NOTHING
+            """,
+            client_id, auth_user_id,
+        )
+        print(f"  linked auth user {auth_user_id[:8]}… → client via {table}")
+        return True
+    except asyncpg.PostgresError as exc:
+        print(f"  WARNING — membership insert failed: {exc}", file=sys.stderr)
+        return False
 
 
 async def select_prospects(conn) -> list[dict]:
@@ -192,6 +321,22 @@ async def main():
 
     try:
         client_id = await ensure_demo_client(conn) if not dry_run else "DRY-RUN-CLIENT"
+
+        print("\nensuring demo Supabase auth user "
+              f"(email={DEMO_AUTH_EMAIL})…")
+        auth_user = ensure_demo_auth_user(
+            supabase_url=settings.supabase_url,
+            service_key=settings.supabase_service_key,
+            dry_run=dry_run,
+        )
+        if not dry_run and auth_user:
+            await link_auth_user_to_client(
+                conn,
+                auth_user_id=str(auth_user.get("id") or ""),
+                client_id=client_id,
+                dry_run=False,
+            )
+
         print(f"\nselecting top {TARGET_PROSPECTS} BU prospects "
               f"(stage >= {MIN_STAGE}, propensity > {MIN_PROPENSITY}, real email)…")
         prospects = await select_prospects(conn)

--- a/tests/scripts/test_seed_demo_tenant.py
+++ b/tests/scripts/test_seed_demo_tenant.py
@@ -153,3 +153,140 @@ async def test_link_prospects_skips_on_conflict_silently():
     prospects = [_make_prospect(dom=f"x{i}.com.au") for i in range(3)]
     n = await seed.link_prospects(conn, "client-uuid", prospects, dry_run=False)
     assert n == 2
+
+
+# ─── ensure_demo_auth_user (TASK B) ─────────────────────────────────────────
+
+class _FakeResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        return False
+    def read(self):
+        return self._body
+
+
+def test_ensure_demo_auth_user_dry_run_returns_none():
+    out = seed.ensure_demo_auth_user(
+        supabase_url="https://x.supabase.co", service_key="srv", dry_run=True,
+    )
+    assert out is None
+
+
+def test_ensure_demo_auth_user_no_credentials_skips():
+    out = seed.ensure_demo_auth_user(
+        supabase_url="", service_key="", dry_run=False,
+    )
+    assert out is None
+
+
+def test_ensure_demo_auth_user_idempotent_existing(monkeypatch):
+    payload = b'{"users":[{"id":"abc","email":"demo@keiracom.com"}]}'
+
+    def fake_urlopen(req, timeout=10):
+        # GET on the lookup endpoint — return the existing user
+        assert req.get_method() == "GET"
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr(seed.urllib.request, "urlopen", fake_urlopen)
+    out = seed.ensure_demo_auth_user(
+        supabase_url="https://x.supabase.co",
+        service_key="srv-key",
+        dry_run=False,
+    )
+    assert out and out["id"] == "abc"
+
+
+def test_ensure_demo_auth_user_creates_when_absent(monkeypatch):
+    calls = []
+
+    def fake_urlopen(req, timeout=10):
+        calls.append(req.get_method())
+        if req.get_method() == "GET":
+            return _FakeResponse(b'{"users":[]}')
+        # POST → return a freshly-created user
+        body = req.data or b""
+        assert b"demo@keiracom.com" in body
+        return _FakeResponse(b'{"id":"new-uuid","email":"demo@keiracom.com"}')
+
+    monkeypatch.setattr(seed.urllib.request, "urlopen", fake_urlopen)
+    out = seed.ensure_demo_auth_user(
+        supabase_url="https://x.supabase.co",
+        service_key="srv-key",
+        password="custom-pw",
+        dry_run=False,
+    )
+    assert calls == ["GET", "POST"]
+    assert out and out["id"] == "new-uuid"
+
+
+def test_ensure_demo_auth_user_uses_env_password(monkeypatch):
+    seen_body = {}
+
+    def fake_urlopen(req, timeout=10):
+        if req.get_method() == "GET":
+            return _FakeResponse(b'{"users":[]}')
+        seen_body["data"] = req.data
+        return _FakeResponse(b'{"id":"u","email":"demo@keiracom.com"}')
+
+    monkeypatch.setattr(seed.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setenv("DEMO_PASSWORD", "env-injected-pw")
+    seed.ensure_demo_auth_user(
+        supabase_url="https://x.supabase.co",
+        service_key="srv",
+        dry_run=False,
+    )
+    assert b"env-injected-pw" in seen_body["data"]
+
+
+def test_ensure_demo_auth_user_handles_network_error(monkeypatch):
+    def boom(req, timeout=10):
+        import urllib.error
+        raise urllib.error.URLError("connection refused")
+    monkeypatch.setattr(seed.urllib.request, "urlopen", boom)
+    out = seed.ensure_demo_auth_user(
+        supabase_url="https://x.supabase.co",
+        service_key="srv",
+        dry_run=False,
+    )
+    assert out is None
+
+
+# ─── link_auth_user_to_client (TASK B) ──────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_link_auth_user_dry_run_noops():
+    conn = MagicMock()
+    conn.fetchval = AsyncMock()
+    conn.execute = AsyncMock()
+    out = await seed.link_auth_user_to_client(
+        conn, auth_user_id="u", client_id="c", dry_run=True,
+    )
+    assert out is False
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_link_auth_user_skips_when_no_membership_table():
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.execute = AsyncMock()
+    out = await seed.link_auth_user_to_client(
+        conn, auth_user_id="u", client_id="c", dry_run=False,
+    )
+    assert out is False
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_link_auth_user_inserts_when_table_present():
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="client_users")
+    conn.execute = AsyncMock(return_value="INSERT 0 1")
+    out = await seed.link_auth_user_to_client(
+        conn, auth_user_id="u", client_id="c", dry_run=False,
+    )
+    assert out is True
+    conn.execute.assert_awaited_once()


### PR DESCRIPTION
## Summary
Three independent commits closing the Step 1 punch-list:

1. **`87c31ec3`** — **P11 sidecar wire-up**: new `scripts/entrypoint.sh` is now the container ENTRYPOINT for both production and with-camoufox stages. Launches `cgroup_memory_guard.py` in the background, traps TERM/INT/EXIT to reap it, then `exec`s uvicorn so PID-1 signals propagate cleanly. Disable with `AGENT_MEMORY_GUARD_DISABLED=1`.
2. **`4fc8134f`** — **Demo auth user**: `scripts/seed_demo_tenant.py` now also creates the Supabase auth user `demo@keiracom.com` via the GoTrue admin API (urllib only, no new deps). Idempotent. Password from `DEMO_PASSWORD` env or default `demo-investor-2026`. Best-effort link to a `client_users` / `client_members` / `clients_users` table if one exists.
3. **`43a9efa1`** — **Smoke baseline** of main after Step 1: 2880 passed / 53 failed / 28 skipped (3:19). Step 1 surface (`tests/scripts/` + `tests/config/`) fully GREEN at 264/264 in 2.38 s. Failures are pre-existing pipeline / orchestrator / stage_9_10_flow / card_streaming debt — full breakdown in `docs/SMOKE_TEST_2026-04-26.md`.

## Test plan
- [x] `ruff check` — clean on all touched files
- [x] `pytest tests/scripts/ tests/config/` — 264 passed in 2.38 s
- [x] `pytest --tb=short -q --ignore=tests/test_dncr_client.py` — 2880/2933 (53 pre-existing failures documented)
- [x] `bash -n scripts/entrypoint.sh` — shell syntax valid
- [x] `ensure_demo_auth_user` smoke: idempotent existing-user / fresh-create / env-password / network-error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)