### PR TITLE
[ATLAS] fix: migrate critical writes from REST to asyncpg (Supabase resilience)

### DIFF
--- a/scripts/session_end_hook.py
+++ b/scripts/session_end_hook.py
@@ -127,14 +127,32 @@ def maybe_mirror_manual() -> dict:
 # ── Steps 2 + 3: write to ceo_memory + daily_log ───────────────────────────
 
 def _supabase_dsn() -> str | None:
-    """Pull DATABASE_URL from the agency-os env file. Returns None when
-    the file is missing (e.g. in a sandbox)."""
+    """Resolve a postgres DSN for asyncpg.
+
+    Resolution order so the hook works equally well in dev shells, the
+    Claude Code SessionEnd runtime, and Railway deploys:
+      1. DATABASE_URL  (Railway / generic)
+      2. SUPABASE_DB_URL  (some deploy templates use this name)
+      3. ENV_FILE → src.config.settings.database_url  (local dev)
+
+    Strips the SQLAlchemy 'postgresql+asyncpg://' prefix because
+    asyncpg.connect rejects it.
+    """
+    raw = (
+        os.environ.get("DATABASE_URL")
+        or os.environ.get("SUPABASE_DB_URL")
+        or ""
+    ).strip()
+    if raw:
+        return raw.replace("postgresql+asyncpg://", "postgresql://")
     try:
         sys.path.insert(0, str(REPO_ROOT))
         from dotenv import load_dotenv
         load_dotenv(ENV_FILE)
         from src.config.settings import settings  # type: ignore[import-not-found]
-        return settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+        return (settings.database_url or "").replace(
+            "postgresql+asyncpg://", "postgresql://"
+        ) or None
     except Exception as exc:  # noqa: BLE001
         logger.warning("DSN unavailable (%s) — skipping memory writes", exc)
         return None

--- a/scripts/three_store_save.py
+++ b/scripts/three_store_save.py
@@ -15,6 +15,7 @@ Usage:
 """
 
 import argparse
+import asyncio
 import json
 import os
 import re
@@ -22,6 +23,35 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# DSN resolver — prefer DATABASE_URL, fall back to settings.database_url
+# ---------------------------------------------------------------------------
+
+def _resolve_dsn() -> str | None:
+    """Return a postgres DSN suitable for asyncpg, or None when unconfigured.
+
+    Prefers DATABASE_URL (Railway / generic), then SUPABASE_DB_URL, then
+    src.config.settings.database_url. Strips any 'postgresql+asyncpg://'
+    prefix because asyncpg.connect rejects the SQLAlchemy variant.
+    """
+    raw = (
+        os.environ.get("DATABASE_URL")
+        or os.environ.get("SUPABASE_DB_URL")
+        or ""
+    )
+    if not raw:
+        try:
+            sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+            from src.config.settings import settings  # type: ignore[import-not-found]
+            raw = settings.database_url or ""
+        except Exception:  # noqa: BLE001
+            raw = ""
+    raw = raw.strip()
+    if not raw:
+        return None
+    return raw.replace("postgresql+asyncpg://", "postgresql://")
 
 
 # ---------------------------------------------------------------------------
@@ -141,13 +171,12 @@ def save_manual(directive: str, pr_number: int, summary: str, section: int, dry_
 # ---------------------------------------------------------------------------
 
 def save_ceo_memory(directive: str, pr_number: int, summary: str, dry_run: bool, callsign: str = "elliot") -> bool:
-    supabase_url = os.environ.get("SUPABASE_URL", "").rstrip("/")
-    service_key = os.environ.get("SUPABASE_SERVICE_KEY", "")
+    """Upsert public.ceo_memory via asyncpg (no REST, no PostgREST).
 
-    if not supabase_url or not service_key:
-        print("[STORE 2/4] ceo_memory: FAILED — SUPABASE_URL or SUPABASE_SERVICE_KEY not set")
-        return False
-
+    statement_cache_size=0 so the connection works through Supabase's
+    pgbouncer transaction-mode pooler. Function stays sync — async
+    work is wrapped in asyncio.run so callers don't change.
+    """
     key = f"ceo:directive_{directive}_complete"
     value = {
         "directive": directive,
@@ -162,24 +191,32 @@ def save_ceo_memory(directive: str, pr_number: int, summary: str, dry_run: bool,
         print(f"  value={json.dumps(value)}")
         return True
 
-    import httpx
-    url = f"{supabase_url}/rest/v1/ceo_memory"
-    headers = {
-        "apikey": service_key,
-        "Authorization": f"Bearer {service_key}",
-        "Content-Type": "application/json",
-        "Prefer": "resolution=merge-duplicates",
-    }
-    body = {"key": key, "value": value, "updated_at": datetime.now(timezone.utc).isoformat()}
+    dsn = _resolve_dsn()
+    if not dsn:
+        print("[STORE 2/4] ceo_memory: FAILED — DATABASE_URL / SUPABASE_DB_URL not set")
+        return False
+
+    async def _upsert() -> None:
+        import asyncpg
+        conn = await asyncpg.connect(dsn, statement_cache_size=0)
+        try:
+            await conn.execute(
+                """
+                INSERT INTO ceo_memory (key, value, updated_at)
+                VALUES ($1, $2::jsonb, NOW())
+                ON CONFLICT (key) DO UPDATE
+                  SET value = EXCLUDED.value, updated_at = NOW()
+                """,
+                key, json.dumps(value),
+            )
+        finally:
+            await conn.close()
 
     try:
-        resp = httpx.post(url, headers=headers, json=body, timeout=15)
-        if resp.status_code in (200, 201):
-            print(f"[STORE 2/4] ceo_memory: OK — key={key!r}")
-            return True
-        print(f"[STORE 2/4] ceo_memory: FAILED — HTTP {resp.status_code}: {resp.text[:200]}")
-        return False
-    except Exception as exc:
+        asyncio.run(_upsert())
+        print(f"[STORE 2/4] ceo_memory: OK — key={key!r}")
+        return True
+    except Exception as exc:  # noqa: BLE001
         print(f"[STORE 2/4] ceo_memory: FAILED — {exc}")
         return False
 
@@ -189,13 +226,7 @@ def save_ceo_memory(directive: str, pr_number: int, summary: str, dry_run: bool,
 # ---------------------------------------------------------------------------
 
 def save_metrics(directive: str, pr_number: int, summary: str, dry_run: bool, callsign: str = "elliot") -> bool:
-    supabase_url = os.environ.get("SUPABASE_URL", "").rstrip("/")
-    service_key = os.environ.get("SUPABASE_SERVICE_KEY", "")
-
-    if not supabase_url or not service_key:
-        print("[STORE 3/4] cis_directive_metrics: FAILED — SUPABASE_URL or SUPABASE_SERVICE_KEY not set")
-        return False
-
+    """Insert into public.cis_directive_metrics via asyncpg (no REST)."""
     # Determine directive_id vs directive_ref
     if re.fullmatch(r"\d+", directive):
         directive_id = int(directive)
@@ -204,44 +235,60 @@ def save_metrics(directive: str, pr_number: int, summary: str, dry_run: bool, ca
         directive_id = 0
         directive_ref = directive
 
-    now_iso = datetime.now(timezone.utc).isoformat()
-    row = {
+    now = datetime.now(timezone.utc)
+    row_preview = {
         "directive_id": directive_id,
         "directive_ref": directive_ref,
-        "issued_date": now_iso,
-        "completed_date": now_iso,
+        "issued_date": now.isoformat(),
+        "completed_date": now.isoformat(),
         "execution_rounds": 1,
         "scope_creep": False,
         "verification_first_pass": True,
         "save_completed": True,
         "agents_used": ["build-2", "build-3"],
         "notes": summary,
-        "callsign": callsign,  # LAW XVII: tag row with callsign
-        "created_at": now_iso,
+        "callsign": callsign,
+        "created_at": now.isoformat(),
     }
 
     if dry_run:
-        print(f"[DRY-RUN][STORE 3/4] Would insert cis_directive_metrics row:")
-        print(f"  {json.dumps(row)}")
+        print("[DRY-RUN][STORE 3/4] Would insert cis_directive_metrics row:")
+        print(f"  {json.dumps(row_preview)}")
         return True
 
-    import httpx
-    url = f"{supabase_url}/rest/v1/cis_directive_metrics"
-    headers = {
-        "apikey": service_key,
-        "Authorization": f"Bearer {service_key}",
-        "Content-Type": "application/json",
-        "Prefer": "return=minimal",
-    }
+    dsn = _resolve_dsn()
+    if not dsn:
+        print("[STORE 3/4] cis_directive_metrics: FAILED — DATABASE_URL / SUPABASE_DB_URL not set")
+        return False
+
+    async def _insert() -> None:
+        import asyncpg
+        conn = await asyncpg.connect(dsn, statement_cache_size=0)
+        try:
+            await conn.execute(
+                """
+                INSERT INTO cis_directive_metrics (
+                  directive_id, directive_ref, issued_date, completed_date,
+                  execution_rounds, scope_creep, verification_first_pass,
+                  save_completed, agents_used, notes, callsign, created_at
+                ) VALUES (
+                  $1, $2, $3, $4,
+                  $5, $6, $7,
+                  $8, $9, $10, $11, $12
+                )
+                """,
+                directive_id, directive_ref, now, now,
+                1, False, True,
+                True, ["build-2", "build-3"], summary, callsign, now,
+            )
+        finally:
+            await conn.close()
 
     try:
-        resp = httpx.post(url, headers=headers, json=row, timeout=15)
-        if resp.status_code in (200, 201):
-            print(f"[STORE 3/4] cis_directive_metrics: OK — directive_ref={directive_ref!r}, directive_id={directive_id}")
-            return True
-        print(f"[STORE 3/4] cis_directive_metrics: FAILED — HTTP {resp.status_code}: {resp.text[:200]}")
-        return False
-    except Exception as exc:
+        asyncio.run(_insert())
+        print(f"[STORE 3/4] cis_directive_metrics: OK — directive_ref={directive_ref!r}, directive_id={directive_id}")
+        return True
+    except Exception as exc:  # noqa: BLE001
         print(f"[STORE 3/4] cis_directive_metrics: FAILED — {exc}")
         return False
 

--- a/tests/test_three_store_save.py
+++ b/tests/test_three_store_save.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import importlib.util
-import os
 from pathlib import Path
 
 import pytest
@@ -45,3 +44,140 @@ def test_manual_entry_tagged_aiden():
     """Aiden entries tagged [AIDEN]."""
     entry = tss.manual_entry("D2.2", 999, "aiden run", "aiden")
     assert "[AIDEN]" in entry
+
+
+# ─── asyncpg migration (REST → pgbouncer-friendly direct DB) ──────────────
+
+class _FakeConn:
+    """Minimal asyncpg-conn double — records every execute call."""
+    def __init__(self):
+        self.executed: list[tuple[str, tuple]] = []
+        self.closed = False
+    async def execute(self, sql, *args):
+        self.executed.append((sql, args))
+        return "INSERT 0 1"
+    async def close(self):
+        self.closed = True
+
+
+def _patch_asyncpg(monkeypatch, conn):
+    """Stub `import asyncpg; await asyncpg.connect(...)` inside save_*."""
+    import sys
+    import types
+    fake = types.SimpleNamespace()
+
+    async def _connect(dsn, **kw):
+        # Verify the pgbouncer-compat flag is set.
+        assert kw.get("statement_cache_size") == 0
+        assert dsn.startswith("postgresql://")
+        return conn
+
+    fake.connect = _connect
+    monkeypatch.setitem(sys.modules, "asyncpg", fake)
+
+
+def test_resolve_dsn_prefers_database_url(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@host/db")
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    assert tss._resolve_dsn() == "postgresql://u:p@host/db"
+
+
+def test_resolve_dsn_falls_back_to_supabase(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://x:y@h/d")
+    assert tss._resolve_dsn() == "postgresql://x:y@h/d"
+
+
+def test_resolve_dsn_strips_sqlalchemy_prefix(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@h/d")
+    assert tss._resolve_dsn() == "postgresql://u:p@h/d"
+
+
+def test_resolve_dsn_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    # Make settings.database_url empty too.
+    import sys
+    import types
+    fake_mod = types.ModuleType("src.config.settings")
+    fake_mod.settings = types.SimpleNamespace(database_url="")
+    monkeypatch.setitem(sys.modules, "src.config.settings", fake_mod)
+    assert tss._resolve_dsn() is None
+
+
+def test_save_ceo_memory_dry_run_no_db(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    # Dry-run path must not even resolve DSN.
+    assert tss.save_ceo_memory("D9", 999, "x", dry_run=True, callsign="atlas") is True
+
+
+def test_save_ceo_memory_no_dsn_returns_false(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    import sys
+    import types
+    fake_mod = types.ModuleType("src.config.settings")
+    fake_mod.settings = types.SimpleNamespace(database_url="")
+    monkeypatch.setitem(sys.modules, "src.config.settings", fake_mod)
+    assert tss.save_ceo_memory("D9", 999, "x", dry_run=False) is False
+
+
+def test_save_ceo_memory_executes_upsert_via_asyncpg(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/d")
+    conn = _FakeConn()
+    _patch_asyncpg(monkeypatch, conn)
+    assert tss.save_ceo_memory("D7", 707, "atlas summary", dry_run=False, callsign="atlas") is True
+    assert conn.closed
+    assert len(conn.executed) == 1
+    sql, args = conn.executed[0]
+    assert "INSERT INTO ceo_memory" in sql
+    assert "ON CONFLICT (key) DO UPDATE" in sql
+    assert args[0] == "ceo:directive_D7_complete"
+    # JSON value carries callsign + pr.
+    import json as _json
+    payload = _json.loads(args[1])
+    assert payload["pr"] == 707
+    assert payload["source"] == "atlas"
+
+
+def test_save_metrics_dry_run_no_db(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    assert tss.save_metrics("D9", 999, "x", dry_run=True) is True
+
+
+def test_save_metrics_executes_insert_via_asyncpg(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/d")
+    conn = _FakeConn()
+    _patch_asyncpg(monkeypatch, conn)
+    assert tss.save_metrics("D7", 707, "summary", dry_run=False, callsign="atlas") is True
+    assert conn.closed
+    sql, args = conn.executed[0]
+    assert "INSERT INTO cis_directive_metrics" in sql
+    # directive_id=0 / directive_ref="D7" because non-numeric label
+    assert args[0] == 0
+    assert args[1] == "D7"
+    assert args[10] == "atlas"   # callsign positional
+
+
+def test_save_metrics_numeric_directive_uses_directive_id(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/d")
+    conn = _FakeConn()
+    _patch_asyncpg(monkeypatch, conn)
+    tss.save_metrics("309", 707, "summary", dry_run=False)
+    _, args = conn.executed[0]
+    assert args[0] == 309
+    assert args[1] is None
+
+
+def test_save_ceo_memory_swallows_asyncpg_error(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/d")
+    import sys
+    import types
+    fake = types.SimpleNamespace()
+    async def boom(*a, **k):
+        raise RuntimeError("connection refused")
+    fake.connect = boom
+    monkeypatch.setitem(sys.modules, "asyncpg", fake)
+    assert tss.save_ceo_memory("D7", 707, "x", dry_run=False) is False


### PR DESCRIPTION
## Summary

Migrates the two critical-path directive-completion scripts from Supabase PostgREST (httpx POST `/rest/v1/...`) to direct asyncpg with `statement_cache_size=0` for pgbouncer transaction-mode pooler compat. Public function signatures unchanged — every existing caller works without modification.

### scripts/three_store_save.py
- New `_resolve_dsn()`: `DATABASE_URL` → `SUPABASE_DB_URL` → `settings.database_url`. Strips the SQLAlchemy `postgresql+asyncpg://` prefix that asyncpg.connect rejects.
- `save_ceo_memory()`: replaced httpx POST + `Prefer:resolution=merge-duplicates` with parameterised `INSERT … ON CONFLICT (key) DO UPDATE` via asyncpg. `asyncio.run` wrapper keeps the function sync.
- `save_metrics()`: replaced httpx POST with parameterised `INSERT INTO cis_directive_metrics`. directive_id / directive_ref split preserved.
- All error paths still return False + log; never raise.

### scripts/session_end_hook.py
- `write_memory()` ALREADY used asyncpg (line 155+); only the DSN resolver was settings-only. Updated `_supabase_dsn()` to honour `DATABASE_URL` → `SUPABASE_DB_URL` → settings fallback so the hook works in Railway / Claude-Code runtime where `DATABASE_URL` is canonical.

### Tests (+10)
`tests/test_three_store_save.py`: DSN resolution priority + sqlalchemy-prefix strip + None-when-unset; `save_ceo_memory` dry-run/no-DSN/upsert-SQL/payload/error-swallow; `save_metrics` dry-run/insert/numeric-vs-string directive.

ruff: 4 pre-existing UP017 nits in `three_store_save.py` (was 6 before, 4 after — net improvement).
pytest: **33 passed in 0.36s.**

---

## REST-write inventory (`grep -rn 'sb_post|sb_patch|postgrest|/rest/v1' src/ scripts/`)

61 lines / 60+ remaining sites. **Migrated in this PR: 2**. Remaining sites for follow-up sweeps:

### `scripts/` — 17 sites (10 files, excl. the 2 migrated)
- `backfill_supersedes_id.py` — agent_memories REST GET/POST/PATCH + `rpc/match_agent_memories`
- `fix_dead_refs_listener_seed_v1.py` — agent_memories REST PATCH + POST (seed-only, low blast radius)
- `gmb_pilot{2,2_resume,3,3_resume,4}.py` — pilot-only scripts; `rpc/execute_sql` + table POSTs (one-shot pilots; defer)
- `openai_cost_weekly.py` — ceo_memory REST POST (weekly cron — high value to migrate next)
- `seed_listener_knowledge_v1.py` — agent_memories REST POST (seed only)
- `session_end_check.py` / `session_start_load.py` — REST GET only (read-side, lower priority)

### `src/evo/` — `sb_post`/`sb_patch` helper layer (5 files)
- `supabase_client.py` defines the `sb_post`/`sb_patch`/`sb_get` helpers
- `auth_gate.py`, `consumer_helpers.py`, `agent_invoker.py`, `callback_poller.py` — all evo-task queue & callback paths
- **Recommendation:** rewrite `supabase_client.py` to wrap an asyncpg pool; downstream call sites stay unchanged.

### `src/memory/` — 8 sites (3 files)
- `client.py`, `organise.py`, `store.py` — agent_memories CRUD + `rpc/match_agent_memories` (vector-search RPC needs special handling — `pgvector` extension call from asyncpg)

### `src/pipeline/` — 5 sites (2 files)
- `compliance_handler.py` — suppression_list REST POST
- `suppression_manager.py` — suppression_list REST GET/POST/DELETE (4 sites)
  - **High-priority** for follow-up: this is on the live outreach path; pgbouncer disconnects here would silently drop suppression lookups.

### `src/telegram_bot/` — 8 sites (2 files)
- `chat_bot.py` — telegram_sessions CRUD (4) + ceo_memory REST GET (1)
- `memory_listener.py` — agent_memories CRUD + 2 RPC calls (hybrid_search, match)

### `src/prefect_utils/` — 1 site
- `callback_writer.py` — evo_flow_callbacks POST

### Suggested follow-up batches
1. **Outreach reliability:** `src/pipeline/suppression_manager.py` + `compliance_handler.py` (5 sites).
2. **EVO core:** rewrite `src/evo/supabase_client.py` against asyncpg pool (cascades to 4 callers).
3. **Memory subsystem:** `src/memory/{client,store,organise}.py` (8 sites; needs pgvector RPC plumbing).
4. **Telegram:** `chat_bot.py` + `memory_listener.py` (already in active rewrite — coordinate before touching).
5. **Cron + pilot scripts:** `openai_cost_weekly.py`, `backfill_supersedes_id.py`, `*pilot*.py` (low priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)