### PR TITLE
[ATLAS] fix: lower demo target to 7 (matches available high-quality pool)

### DIFF
--- a/scripts/seed_demo_tenant.py
+++ b/scripts/seed_demo_tenant.py
@@ -4,7 +4,7 @@ Seed the Demo tenant for investor-ready demos.
 What it does
 ------------
 1. Ensures a `clients` row named 'Demo Agency' exists (creates if missing).
-2. Selects up to 20 best BU prospects by:
+2. Selects up to TARGET_PROSPECTS best BU prospects by:
        pipeline_stage >= 6
        AND dm_email IS NOT NULL
        AND propensity_score > 60
@@ -15,7 +15,7 @@ What it does
 4. Inserts campaign_leads junction rows linking the Demo client to each
    selected BU id (status='claimed').
 
-If fewer than 20 prospects survive filtering it REPORTS the shortfall —
+If fewer than TARGET_PROSPECTS prospects survive filtering it REPORTS the shortfall —
 never pads with weaker prospects. The point of the demo is curated quality.
 
 Usage:
@@ -51,7 +51,9 @@ from src.config.settings import settings  # noqa: E402
 
 DEMO_CLIENT_NAME = "Demo Agency"
 DEMO_TIER = "spark"
-TARGET_PROSPECTS = 20
+# 7 high-quality dental clinics available at stage>=6 + propensity>60 + real email.
+# Increase when enrichment pipeline grows the pool.
+TARGET_PROSPECTS = 7
 MIN_STAGE = 6
 MIN_PROPENSITY = 60
 


### PR DESCRIPTION
## Summary
- `TARGET_PROSPECTS`: **20 → 7** in `scripts/seed_demo_tenant.py`
- Comment captures trigger to re-raise: when enrichment pipeline grows the pool, bump the constant
- Docstring lines that named the literal "20" updated to reference `TARGET_PROSPECTS` instead so they stay correct on future bumps

## Why
The seed currently aborts with `refusing to pad with weaker prospects` because the configured filters (`stage >= 6`, `propensity > 60`, real `dm_email`, non-suppressed) only yield 7 high-quality dental clinics today. Lowering the target unblocks the demo without compromising quality — same filters, same ordering, same shortfall guard.

## Test plan
- [x] `ruff check scripts/seed_demo_tenant.py` — clean
- [x] `pytest tests/scripts/test_seed_demo_tenant.py` — 26 passed in 0.68 s
- [x] Tests use `seed.TARGET_PROSPECTS` indirection (no hardcoded 20) — auto-adapt

🤖 Generated with [Claude Code](https://claude.com/claude-code)