### PR TITLE
[ATLAS] fix: demo tier spark→ignition (enum alignment)

### DIFF
--- a/scripts/seed_demo_tenant.py
+++ b/scripts/seed_demo_tenant.py
@@ -50,7 +50,8 @@ import asyncpg  # noqa: E402
 from src.config.settings import settings  # noqa: E402
 
 DEMO_CLIENT_NAME = "Demo Agency"
-DEMO_TIER = "spark"
+# ignition is the entry tier — spark not in tier_type enum (TIERS-002 gap)
+DEMO_TIER = "ignition"
 TARGET_PROSPECTS = 20
 MIN_STAGE = 6
 MIN_PROPENSITY = 60


### PR DESCRIPTION
## Summary
- `DEMO_TIER`: **`spark` → `ignition`** in `scripts/seed_demo_tenant.py`
- Comment records the underlying gap: `spark` is not in the `public.tier_type` enum (TIERS-002)

## Why
Demo seed currently fails on `INSERT INTO clients (… tier …)` because `spark` is not a valid `tier_type` enum value. `ignition` is the canonical entry tier — switching to it unblocks the demo without needing a schema migration. A future enum cleanup pass can revisit whether `spark` should be added or renamed.

## Test plan
- [x] `ruff check scripts/seed_demo_tenant.py` — clean
- [x] `pytest tests/scripts/test_seed_demo_tenant.py` — 26 passed in 0.67 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)