### PR TITLE
[ATLAS] fix: demo seed — ensure_demo_campaign + full schema audit

### DIFF
--- a/scripts/seed_demo_tenant.py
+++ b/scripts/seed_demo_tenant.py
@@ -4,16 +4,18 @@ Seed the Demo tenant for investor-ready demos.
 What it does
 ------------
 1. Ensures a `clients` row named 'Demo Agency' exists (creates if missing).
-2. Selects up to TARGET_PROSPECTS best BU prospects by:
+2. Ensures a `campaigns` row named 'Demo Campaign' exists for that client
+   (creates if missing). REQUIRED — campaign_leads.campaign_id is NOT NULL.
+3. Selects up to TARGET_PROSPECTS best BU prospects by:
        pipeline_stage >= 6
        AND dm_email IS NOT NULL
        AND propensity_score > 60
    ordered by (propensity_score + COALESCE(reachability_score, 0)) DESC.
-3. Drops any row whose dm_email or domain is in the suppression list, OR
+4. Drops any row whose dm_email or domain is in the suppression list, OR
    whose dm_email is a placeholder (example@, test@, info@, admin@, etc.),
    OR whose display_name is NULL.
-4. Inserts campaign_leads junction rows linking the Demo client to each
-   selected BU id (status='claimed').
+5. Inserts campaign_leads junction rows linking the Demo client +
+   Demo campaign to each selected BU id (status='claimed').
 
 If fewer than TARGET_PROSPECTS prospects survive filtering it REPORTS the shortfall —
 never pads with weaker prospects. The point of the demo is curated quality.
@@ -50,6 +52,7 @@ import asyncpg  # noqa: E402
 from src.config.settings import settings  # noqa: E402
 
 DEMO_CLIENT_NAME = "Demo Agency"
+DEMO_CAMPAIGN_NAME = "Demo Campaign"
 # ignition is the entry tier — spark not in tier_type enum (TIERS-002 gap).
 # Demo runs at ignition until tier_type enum migration adds spark.
 DEMO_TIER = "ignition"
@@ -99,6 +102,39 @@ async def ensure_demo_client(conn) -> str:
         DEMO_CLIENT_NAME, DEMO_TIER,
     )
     print(f"demo client created — id={new_id}")
+    return str(new_id)
+
+
+async def ensure_demo_campaign(conn, client_id: str) -> str:
+    """Lookup-or-create the demo campaign for `client_id`. Returns its UUID.
+
+    Audited against the live `public.campaigns` schema (2026-04-26):
+    only `client_id` and `name` are NOT NULL without defaults — every
+    other column has a sensible default (status='draft', allocation_email
+    =100, campaign_type='custom', icp_config jsonb default, etc.) so we
+    do not need to enumerate them here. Idempotent on (client_id, name).
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT id FROM campaigns
+        WHERE client_id = $1 AND name = $2 AND deleted_at IS NULL
+        ORDER BY created_at DESC LIMIT 1
+        """,
+        client_id, DEMO_CAMPAIGN_NAME,
+    )
+    if row:
+        print(f"demo campaign exists — id={row['id']}")
+        return str(row["id"])
+
+    new_id = await conn.fetchval(
+        """
+        INSERT INTO campaigns (id, client_id, name, status, created_at, updated_at)
+        VALUES (gen_random_uuid(), $1, $2, 'active', NOW(), NOW())
+        RETURNING id
+        """,
+        client_id, DEMO_CAMPAIGN_NAME,
+    )
+    print(f"demo campaign created — id={new_id}")
     return str(new_id)
 
 
@@ -285,9 +321,21 @@ async def select_prospects(conn) -> list[dict]:
 
 async def link_prospects(
     conn, client_id: str, prospects: list[dict], *, dry_run: bool,
+    campaign_id: str | None = None,
 ) -> int:
-    """Insert (or skip-if-exists) one campaign_leads row per prospect."""
+    """Insert (or skip-if-exists) one campaign_leads row per prospect.
+
+    `campaign_id` is REQUIRED at the schema level (NOT NULL, no default
+    in public.campaign_leads). Kept as a keyword-only arg with a default
+    of None so older callers fail loud instead of silently writing rows
+    that get rejected at the DB.
+    """
     inserted = 0
+    if not dry_run and not campaign_id:
+        raise ValueError(
+            "campaign_id is required by public.campaign_leads (NOT NULL); "
+            "pass campaign_id from ensure_demo_campaign() into link_prospects()."
+        )
     for p in prospects:
         if dry_run:
             inserted += 1
@@ -295,13 +343,13 @@ async def link_prospects(
         result = await conn.fetchval(
             """
             INSERT INTO campaign_leads (
-                id, client_id, business_universe_id, status,
+                id, client_id, campaign_id, business_universe_id, status,
                 claimed_at, created_at, updated_at
-            ) VALUES (gen_random_uuid(), $1, $2, 'claimed', NOW(), NOW(), NOW())
+            ) VALUES (gen_random_uuid(), $1, $2, $3, 'claimed', NOW(), NOW(), NOW())
             ON CONFLICT DO NOTHING
             RETURNING id
             """,
-            client_id, p["id"],
+            client_id, campaign_id, p["id"],
         )
         if result:
             inserted += 1
@@ -325,6 +373,10 @@ async def main():
 
     try:
         client_id = await ensure_demo_client(conn) if not dry_run else "DRY-RUN-CLIENT"
+        campaign_id = (
+            await ensure_demo_campaign(conn, client_id)
+            if not dry_run else "DRY-RUN-CAMPAIGN"
+        )
 
         print("\nensuring demo Supabase auth user "
               f"(email={DEMO_AUTH_EMAIL})…")
@@ -373,9 +425,13 @@ async def main():
             print(f"\nDRY-RUN — would link {len(prospects)} BU rows to demo client")
             return
 
-        linked = await link_prospects(conn, client_id, prospects, dry_run=False)
+        linked = await link_prospects(
+            conn, client_id, prospects,
+            dry_run=False, campaign_id=campaign_id,
+        )
         print(f"\nlinked: {linked} new campaign_leads rows")
         print(f"demo_client_id: {client_id}")
+        print(f"demo_campaign_id: {campaign_id}")
     finally:
         await conn.close()
 

--- a/tests/scripts/test_seed_demo_tenant.py
+++ b/tests/scripts/test_seed_demo_tenant.py
@@ -130,9 +130,15 @@ async def test_link_prospects_writes_one_row_per_prospect():
     conn = MagicMock()
     conn.fetchval = AsyncMock(return_value=uuid4())
     prospects = [_make_prospect(dom=f"x{i}.com.au") for i in range(3)]
-    n = await seed.link_prospects(conn, "client-uuid", prospects, dry_run=False)
+    n = await seed.link_prospects(
+        conn, "client-uuid", prospects, dry_run=False, campaign_id="cmp-uuid",
+    )
     assert n == 3
     assert conn.fetchval.await_count == 3
+    # Confirm campaign_id is forwarded to the INSERT positionally.
+    first_args = conn.fetchval.await_args_list[0].args
+    assert first_args[1] == "client-uuid"
+    assert first_args[2] == "cmp-uuid"
 
 
 @pytest.mark.asyncio
@@ -151,8 +157,70 @@ async def test_link_prospects_skips_on_conflict_silently():
     conn = MagicMock()
     conn.fetchval = AsyncMock(side_effect=[uuid4(), None, uuid4()])
     prospects = [_make_prospect(dom=f"x{i}.com.au") for i in range(3)]
-    n = await seed.link_prospects(conn, "client-uuid", prospects, dry_run=False)
+    n = await seed.link_prospects(
+        conn, "client-uuid", prospects, dry_run=False, campaign_id="cmp-uuid",
+    )
     assert n == 2
+
+
+@pytest.mark.asyncio
+async def test_link_prospects_requires_campaign_id_when_executing():
+    """Schema audit gate: campaign_leads.campaign_id is NOT NULL — refuse
+    to issue an INSERT that would be rejected at the DB."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock()
+    prospects = [_make_prospect(dom="x.com.au")]
+    with pytest.raises(ValueError, match="campaign_id"):
+        await seed.link_prospects(conn, "client-uuid", prospects, dry_run=False)
+    conn.fetchval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_link_prospects_dry_run_allows_missing_campaign_id():
+    """Dry-run never touches the DB so missing campaign_id is tolerated."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock()
+    prospects = [_make_prospect(dom="x.com.au")]
+    n = await seed.link_prospects(conn, "client-uuid", prospects, dry_run=True)
+    assert n == 1
+    conn.fetchval.assert_not_awaited()
+
+
+# ─── ensure_demo_campaign (TASK A — schema-audited) ────────────────────────
+
+@pytest.mark.asyncio
+async def test_ensure_demo_campaign_returns_existing():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value={"id": "existing-cmp-uuid"})
+    conn.fetchval = AsyncMock()
+    out = await seed.ensure_demo_campaign(conn, "client-uuid")
+    assert out == "existing-cmp-uuid"
+    conn.fetchval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_demo_campaign_creates_when_absent():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetchval = AsyncMock(return_value="new-cmp-uuid")
+    out = await seed.ensure_demo_campaign(conn, "client-uuid")
+    assert out == "new-cmp-uuid"
+    sql, args = conn.fetchval.await_args.args[0], conn.fetchval.await_args.args[1:]
+    assert "INSERT INTO campaigns" in sql
+    assert args[0] == "client-uuid"
+    assert args[1] == seed.DEMO_CAMPAIGN_NAME
+
+
+@pytest.mark.asyncio
+async def test_ensure_demo_campaign_idempotent_lookup_by_name():
+    """Lookup query must match on (client_id, name) to prevent duplicates."""
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetchval = AsyncMock(return_value="x")
+    await seed.ensure_demo_campaign(conn, "client-uuid")
+    lookup_sql = conn.fetchrow.await_args.args[0]
+    assert "WHERE client_id = $1 AND name = $2" in lookup_sql
+    assert "deleted_at IS NULL" in lookup_sql
 
 
 # ─── ensure_demo_auth_user (TASK B) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the cascading-defects pattern (target=20→7, tier spark→ignition, now `campaign_id` NOT NULL) by auditing every INSERT in `seed_demo_tenant.py` against live `information_schema.columns` + `pg_enum` in one pass. No more one-at-a-time discovery.

### TASK A — `ensure_demo_campaign(conn, client_id) → str`
Lookup-or-create the demo campaign by `(client_id, name='Demo Campaign')`. Idempotent. Inserts only the columns NOT NULL without defaults (`client_id`, `name`) plus a `status='active'` override; every other `campaigns` column has a sensible default. `main()` now wires it after `ensure_demo_client` and threads `campaign_id` through `link_prospects`.

### TASK B — Schema audit findings (live snapshot 2026-04-26)

| Table | NOT NULL columns w/o default | INSERT covers? | Action |
|---|---|---|---|
| `clients` | `name` only (others have defaults) | ✓ | No change. `subscription_status='active'` valid in enum (`trialing/active/past_due/cancelled/paused`). `tier='ignition'` valid in `tier_type` enum (`ignition/velocity/dominance`). |
| `campaigns` | `client_id`, `name` | new INSERT in `ensure_demo_campaign` | Added — minimal INSERT with `status='active'` override |
| `campaign_leads` | `campaign_id`, `business_universe_id`, `client_id` | **❌ MISSING `campaign_id`** | **CRITICAL FIX**: threaded through, with runtime ValueError guard so regressions fail loud |
| `client_users` / `client_members` / `clients_users` | — | None exist in `public` | `link_auth_user_to_client` probe correctly no-ops; documented for follow-up (add membership table OR use `auth.users.user_metadata`) |

### Defence-in-depth
`link_prospects(..., campaign_id=None)` now raises `ValueError` if a real (non-dry-run) execute is attempted without `campaign_id`. Future regressions fail at the call site with a clear message instead of producing rejected DB inserts.

## Test plan
- [x] `ruff check` — clean
- [x] `pytest tests/scripts/test_seed_demo_tenant.py` — **31 passed in 0.82 s** (was 26; +5 new)
  - `link_prospects` forwards `campaign_id` positionally
  - `link_prospects` raises ValueError without `campaign_id` (real execute)
  - `link_prospects` dry-run tolerates missing `campaign_id`
  - `ensure_demo_campaign` returns existing / creates when absent
  - `ensure_demo_campaign` lookup matches `(client_id, name)` and excludes `deleted_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)