### PR TITLE
[ATLAS] feat: dashboard rebuild PR1 — cream/amber palette + Playfair Display + 232px sidebar

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;1,700&family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&display=swap');
 
 /* Import design tokens - single source of truth */
 @import '../src/styles/design-tokens.css';
@@ -10,78 +10,131 @@
 @layer base {
   :root {
     /* =================================================
-       PURE BLOOMBERG DESIGN SYSTEM
-       Warm Charcoal + Amber ONLY
-       CEO Directive #027
+       AGENCY DESK — CREAM / AMBER LIGHT THEME
+       Dashboard rebuild PR1 (2026-04-28)
+       Reference: dashboard-master-agency-desk.html
        ================================================= */
-    
-    /* Background Layers */
-    --bg-void: #0C0A08;
-    --bg-base: #141210;
-    --bg-surface: #1C1A17;
-    --bg-elevated: #242220;
-    
-    /* Text */
-    --text-primary: #F5F0EB;
-    --text-secondary: #A39E96;
-    --text-muted: #6B6660;
-    
-    /* Accent — THE ONLY COLOR */
-    --amber: #D4956A;
+
+    /* Cream surface palette */
+    --cream:    #F7F3EE;
+    --surface:  #EDE8E0;
+    --panel-bg: #FFFFFF;
+
+    /* Ink scale (replaces the old dark text scale) */
+    --ink:   #0C0A08;
+    --ink-2: #2E2B26;
+    --ink-3: #7A756D;
+    --ink-4: #B5B0A6;
+
+    /* Brand bar (sidebar + topbar share this in dark accents) */
+    --brand-bar: #0C0A08;
+    --on-amber:  #1a1207;
+
+    /* Accent — amber stays the single accent */
+    --amber:       #D4956A;
     --amber-light: #E8B48A;
-    --amber-glow: rgba(212,149,106,0.12);
-    
-    /* Error (muted warm red — use sparingly) */
-    --error: #C0675A;
-    --error-glow: rgba(192,103,90,0.12);
-    
-    /* Borders */
-    --border-subtle: rgba(255,255,255,0.06);
-    --border-default: rgba(255,255,255,0.10);
-    --border-focus: rgba(255,255,255,0.20);
-    
-    /* Glassmorphism */
-    --glass-surface: rgba(255,255,255,0.04);
-    --glass-border: rgba(255,255,255,0.10);
-    --glass-border-top: rgba(255,255,255,0.15);
-    --glass-border-left: rgba(255,255,255,0.12);
-    
+    --amber-soft:  rgba(212,149,106,0.14);
+    --amber-glow:  rgba(212,149,106,0.08);
+    --copper:      #C46A3E;
+
+    /* Status (muted, used sparingly per prototype) */
+    --green: #6B8E5A;
+    --red:   #B55A4C;
+    --blue:  #4A6FA5;
+    --error: #B55A4C;
+    --error-glow: rgba(181,90,76,0.14);
+
+    /* Rules / borders */
+    --rule:        rgba(12,10,8,0.08);
+    --rule-strong: rgba(12,10,8,0.14);
+
+    /* Layout dimensions (PR1 — match prototype) */
+    --sidebar-w:  232px;
+    --topbar-h:   56px;
+    --bottomnav-h: 60px;
+
+    /* Background semantic aliases — mapped to cream/panel so legacy
+       components reading bg-bg-surface render on the new palette */
+    --bg-void:     var(--cream);
+    --bg-base:     var(--cream);
+    --bg-surface:  var(--panel-bg);
+    --bg-elevated: var(--panel-bg);
+
+    /* Text semantic aliases — mapped to ink scale */
+    --text-primary:   var(--ink);
+    --text-secondary: var(--ink-2);
+    --text-muted:     var(--ink-3);
+
+    /* Border aliases */
+    --border-subtle:  var(--rule);
+    --border-default: var(--rule);
+    --border-focus:   var(--rule-strong);
+
+    /* Glass — kept for legacy refs but blended for cream */
+    --glass-surface:    rgba(255,255,255,0.6);
+    --glass-border:     var(--rule);
+    --glass-border-top: var(--rule-strong);
+    --glass-border-left: var(--rule);
+
     /* Gradients */
     --gradient-amber: linear-gradient(135deg, #D4956A 0%, #E8B48A 100%);
-    
-    /* Fonts */
-    --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
-    --font-serif: 'Instrument Serif', Georgia, serif;
-    --font-mono: 'JetBrains Mono', monospace;
 
-    /* shadcn/ui compatibility layer */
-    --background: 20 12% 6%;
-    --foreground: 30 20% 95%;
-    --card: 20 12% 10%;
-    --card-foreground: 30 20% 95%;
-    --popover: 20 12% 8%;
-    --popover-foreground: 30 20% 95%;
-    --primary: 25 50% 62%;
-    --primary-foreground: 20 12% 6%;
-    --secondary: 20 8% 14%;
-    --secondary-foreground: 30 20% 95%;
-    --muted: 20 8% 14%;
-    --muted-foreground: 25 6% 40%;
+    /* Fonts */
+    --font-sans:    'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-serif:   'Playfair Display', Georgia, serif;
+    --font-display: 'Playfair Display', Georgia, serif;
+    --font-mono:    'JetBrains Mono', monospace;
+
+    /* shadcn/ui compatibility — cream/light HSL */
+    --background: 36 36% 95%;          /* cream */
+    --foreground: 24 13% 5%;           /* ink */
+    --card: 0 0% 100%;                 /* panel */
+    --card-foreground: 24 13% 5%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 24 13% 5%;
+    --primary: 25 50% 62%;             /* amber */
+    --primary-foreground: 24 13% 5%;
+    --secondary: 36 25% 90%;
+    --secondary-foreground: 24 13% 5%;
+    --muted: 36 25% 90%;
+    --muted-foreground: 30 6% 45%;
     --accent: 25 50% 62%;
-    --accent-foreground: 20 12% 6%;
-    --destructive: 8 55% 55%;
-    --destructive-foreground: 30 20% 95%;
-    --border: 0 0% 100% / 0.10;
-    --input: 0 0% 100% / 0.10;
+    --accent-foreground: 24 13% 5%;
+    --destructive: 8 40% 50%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 24 13% 5% / 0.08;
+    --input: 24 13% 5% / 0.10;
     --ring: 25 50% 62%;
-    --radius: 0.75rem;
-    
-    /* Chart colors (amber variations) */
+    --radius: 0.625rem;
+
+    /* Chart colours (amber variations) */
     --chart-1: 25 50% 62%;
     --chart-2: 25 50% 72%;
     --chart-3: 25 50% 52%;
     --chart-4: 25 50% 45%;
     --chart-5: 25 50% 38%;
+  }
+
+  html.dark {
+    /* Dark inversion (matches prototype html.dark block). Default theme
+       remains light; dark only kicks in if a user opts in via the
+       theme toggle. */
+    --cream:    #0C0A08;
+    --surface:  #16130F;
+    --panel-bg: #16130F;
+    --ink:      #F5F2EC;
+    --ink-2:    #C9C3B8;
+    --ink-3:    #807A6E;
+    --ink-4:    #4A443A;
+    --brand-bar: #0C0A08;
+    --rule:        rgba(255,255,255,0.08);
+    --rule-strong: rgba(255,255,255,0.14);
+    --amber-soft:  rgba(212,149,106,0.18);
+    --copper:      #E6A87D;
+    --bg-void:     var(--cream);
+    --bg-base:     var(--cream);
+    --bg-surface:  var(--panel-bg);
+    --bg-elevated: var(--panel-bg);
   }
 }
 
@@ -92,16 +145,34 @@
   
   body {
     @apply text-foreground;
-    background-color: var(--bg-void);
+    background-color: var(--cream);
     font-family: var(--font-sans);
     font-feature-settings: "rlig" 1, "calt" 1;
-    color: var(--text-primary);
+    color: var(--ink);
   }
-  
-  /* Typography */
+
+  /* Typography — Playfair Display headlines; ink colour via cascade */
   h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-serif);
-    color: var(--text-primary);
+    font-family: var(--font-display);
+    color: var(--ink);
+    letter-spacing: -0.01em;
+  }
+  /* Italic emphasis renders amber per prototype's `<em>` accent */
+  h1 em, h2 em, h3 em, h4 em, h5 em, h6 em,
+  .display em, .brand em {
+    color: var(--amber);
+    font-style: italic;
+    font-weight: 700;
+  }
+  /* Mono utility class — used for labels / numbers */
+  .mono { font-family: var(--font-mono); }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-3);
   }
   
   /* Data/numbers use mono */

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -6,19 +6,30 @@
  */
 
 import type { Metadata } from "next";
-import { DM_Sans, JetBrains_Mono } from "next/font/google";
+import { DM_Sans, JetBrains_Mono, Playfair_Display } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
 
-const dmSans = DM_Sans({ 
+const dmSans = DM_Sans({
   subsets: ["latin"],
   variable: "--font-dm-sans",
   display: "swap",
 });
 
-const jetbrainsMono = JetBrains_Mono({ 
+const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   variable: "--font-jetbrains",
+  display: "swap",
+});
+
+// PR1 dashboard rebuild — Playfair Display drives all serif headlines
+// (page titles, brand mark, sum-card values). Italic 700 is loaded so
+// the amber `<em>` accents in the prototype render correctly.
+const playfair = Playfair_Display({
+  subsets: ["latin"],
+  weight: ["700"],
+  style: ["normal", "italic"],
+  variable: "--font-playfair",
   display: "swap",
 });
 
@@ -36,7 +47,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       {/* Fonts loaded via @import in globals.css */}
-      <body className={`${dmSans.variable} ${jetbrainsMono.variable} font-sans`}>
+      <body className={`${dmSans.variable} ${jetbrainsMono.variable} ${playfair.variable} font-sans bg-cream text-ink`}>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/frontend/components/layout/dashboard-layout.tsx
+++ b/frontend/components/layout/dashboard-layout.tsx
@@ -28,13 +28,17 @@ interface DashboardLayoutProps {
 }
 
 export function DashboardLayout({ children, user, client }: DashboardLayoutProps) {
+  // PR1 rebuild — fixed 232px dark sidebar + cream main area with
+  // 56px sticky cream-blur topbar. The sidebar is `position: fixed`,
+  // so the right column reserves space via `pl-sidebar` instead of
+  // wrapping in a flex grid (matches prototype #shell layout).
   return (
-    <div className="flex h-screen overflow-hidden">
+    <div className="min-h-screen bg-cream text-ink">
       <Sidebar />
-      <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="pl-sidebar flex min-h-screen flex-col">
         <Header user={user} client={client} />
-        <main className="flex-1 overflow-y-auto bg-muted/30 p-6">
-          {children}
+        <main className="flex-1 bg-cream px-8 py-6">
+          <div className="mx-auto w-full max-w-[1280px]">{children}</div>
         </main>
       </div>
     </div>

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -60,28 +60,49 @@ export function Header({ title = "Dashboard", user, client }: HeaderProps) {
   const initials = getInitials(displayName);
 
   return (
-    <header className="flex h-16 items-center justify-between border-b border-border-subtle bg-bg-surface px-6">
+    <header
+      className="sticky top-0 z-40 flex h-topbar items-center justify-between border-b border-rule px-6"
+      style={{
+        // Cream + blur (matches prototype #topbar but on cream backdrop)
+        backgroundColor: "rgba(247, 243, 238, 0.85)",
+        backdropFilter: "saturate(140%) blur(8px)",
+        WebkitBackdropFilter: "saturate(140%) blur(8px)",
+      }}
+    >
       {/* Left: Page title with LIVE badge */}
       <div className="flex items-center gap-4">
-        <h1 className="text-xl font-semibold text-text-primary">{title}</h1>
-        
-        {/* LIVE Status Badge */}
-        <div className="flex items-center gap-2 rounded-full bg-status-success/10 px-3 py-1">
+        <h1 className="font-display font-bold text-[20px] tracking-[-0.01em] text-ink">
+          {title}
+        </h1>
+
+        {/* LIVE Status Badge — muted green on cream */}
+        <div
+          className="flex items-center gap-2 rounded-full px-3 py-1"
+          style={{ backgroundColor: "rgba(107,142,90,0.16)" }}
+        >
           <span className="relative flex h-2 w-2">
-            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-status-success opacity-75" />
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-status-success" />
+            <span
+              className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75"
+              style={{ backgroundColor: "var(--green)" }}
+            />
+            <span
+              className="relative inline-flex h-2 w-2 rounded-full"
+              style={{ backgroundColor: "var(--green)" }}
+            />
           </span>
-          <span className="text-xs font-medium text-status-success">LIVE</span>
+          <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-green">
+            Live
+          </span>
         </div>
       </div>
 
-      {/* Center: Search (placeholder for Sprint 1) */}
+      {/* Center: Search */}
       <div className="hidden flex-1 justify-center md:flex">
         <div className="relative w-full max-w-md">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-3" />
           <Input
-            placeholder="Search campaigns, leads..."
-            className="w-full border-border-subtle bg-bg-primary pl-9 text-text-primary placeholder:text-text-muted"
+            placeholder="Search campaigns, leads…"
+            className="w-full border-rule bg-panel pl-9 text-ink placeholder:text-ink-3"
           />
         </div>
       </div>

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -1,8 +1,8 @@
 /**
  * FILE: frontend/components/layout/sidebar.tsx
- * PURPOSE: Dashboard sidebar navigation - ported from HTML prototype
- * PHASE: 8 (Frontend)
- * TASK: FE-004
+ * PURPOSE: 232px dark sidebar with amber active borders + Playfair logo accent.
+ *          Ported from dashboard-master-agency-desk.html (PR1 rebuild).
+ * PHASE: 8 (Frontend) — Dashboard rebuild PR 1 of 4
  */
 
 "use client";
@@ -12,10 +12,13 @@ import { usePathname } from "next/navigation";
 import {
   LayoutDashboard,
   Users,
-  Zap,
-  MessageSquare,
+  Megaphone,
+  MessageSquareReply,
   BarChart3,
   Settings,
+  Radio,
+  Inbox,
+  Calendar,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -23,6 +26,7 @@ interface NavItem {
   title: string;
   href: string;
   icon: React.ComponentType<{ className?: string }>;
+  badge?: string;
 }
 
 interface NavSection {
@@ -32,23 +36,26 @@ interface NavSection {
 
 const navSections: NavSection[] = [
   {
-    title: "Main",
+    title: "Today",
     items: [
-      { title: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
-      { title: "Leads", href: "/dashboard/leads", icon: Users },
-      { title: "Campaigns", href: "/dashboard/campaigns", icon: Zap },
-      { title: "Replies", href: "/dashboard/replies", icon: MessageSquare },
+      { title: "Command Center", href: "/dashboard", icon: LayoutDashboard },
+      { title: "Live Pipeline",  href: "/dashboard/pipeline", icon: Radio },
+      { title: "Inbox",          href: "/dashboard/inbox", icon: Inbox },
+      { title: "Meetings",       href: "/dashboard/meetings", icon: Calendar },
     ],
   },
   {
-    title: "Analytics",
+    title: "Workflow",
     items: [
-      { title: "Reports", href: "/dashboard/reports", icon: BarChart3 },
+      { title: "Leads",     href: "/dashboard/leads", icon: Users },
+      { title: "Campaigns", href: "/dashboard/campaigns", icon: Megaphone },
+      { title: "Replies",   href: "/dashboard/replies", icon: MessageSquareReply },
     ],
   },
   {
-    title: "Settings",
+    title: "Insights",
     items: [
+      { title: "Reports",  href: "/dashboard/reports", icon: BarChart3 },
       { title: "Settings", href: "/dashboard/settings", icon: Settings },
     ],
   },
@@ -58,54 +65,82 @@ export function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <aside className="fixed left-0 top-0 bottom-0 w-60 bg-bg-surface border-r border-border-default py-5 z-50">
-      {/* Logo */}
-      <div className="flex items-center gap-3 px-5 mb-8">
-        <div className="w-9 h-9 rounded-[10px] bg-gradient-to-br from-accent-primary to-accent-primary-hover flex items-center justify-center">
-          <svg viewBox="0 0 24 24" fill="none" className="w-5 h-5">
-            <path
-              d="M5 12L10 17L19 8"
-              stroke="white"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+    <aside
+      className="fixed left-0 top-0 bottom-0 w-sidebar bg-brand-bar text-white/80 flex flex-col z-50 overflow-y-auto"
+      style={{ borderRight: "1px solid rgba(255,255,255,0.06)" }}
+    >
+      {/* Logo block — Playfair Display with amber italic accent */}
+      <div
+        className="px-5 pt-[22px] pb-[18px]"
+        style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}
+      >
+        <div className="font-display font-bold text-[20px] tracking-[-0.02em] text-white">
+          Agency<em className="text-amber not-italic-fallback" style={{ fontStyle: "italic" }}>OS</em>
         </div>
-        <span className="font-bold text-lg text-text-primary">Agency OS</span>
+        <div className="font-mono text-[9px] tracking-[0.14em] uppercase text-white/30 mt-[3px]">
+          Agency Desk
+        </div>
       </div>
 
-      {/* Navigation Sections */}
-      <nav className="space-y-6">
+      {/* Nav sections */}
+      <nav className="flex-1">
         {navSections.map((section) => (
-          <div key={section.title}>
-            <div className="px-5 text-[11px] font-semibold text-text-muted uppercase tracking-wide mb-2">
+          <div key={section.title} className="pt-4 pb-1">
+            <div className="font-mono text-[9px] tracking-[0.14em] uppercase text-white/30 px-5 pb-2">
               {section.title}
             </div>
             {section.items.map((item) => {
               const isActive =
                 pathname === item.href ||
                 (item.href !== "/dashboard" && pathname.startsWith(item.href + "/"));
-              
+              const Icon = item.icon;
+
               return (
                 <Link
                   key={item.href}
                   href={item.href}
                   className={cn(
-                    "flex items-center gap-3 px-5 py-3 text-sm font-medium transition-all duration-200",
+                    "flex items-center gap-3 px-5 py-[9px] text-[13px] transition-colors",
+                    "border-l-2",
                     isActive
-                      ? "bg-accent-primary/10 text-accent-primary-hover border-r-2 border-accent-primary"
-                      : "text-text-secondary hover:bg-bg-surface-hover hover:text-text-primary"
+                      ? "text-white bg-amber-soft border-amber font-medium"
+                      : "text-white/70 border-transparent hover:text-white hover:bg-white/[0.03]",
                   )}
                 >
-                  <item.icon className="w-5 h-5 shrink-0" />
+                  <Icon
+                    className={cn(
+                      "w-4 h-4 shrink-0",
+                      isActive ? "text-amber opacity-100" : "opacity-75",
+                    )}
+                  />
                   <span>{item.title}</span>
+                  {item.badge && (
+                    <span className="ml-auto font-mono text-[10px] bg-amber text-on-amber px-[6px] py-[1px] rounded-[10px] min-w-[20px] text-center font-semibold">
+                      {item.badge}
+                    </span>
+                  )}
                 </Link>
               );
             })}
           </div>
         ))}
       </nav>
+
+      {/* Footer — avatar block (matches prototype .sb-foot) */}
+      <div
+        className="mt-auto px-5 py-4 flex items-center gap-[10px]"
+        style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }}
+      >
+        <div className="w-[30px] h-[30px] rounded-full bg-amber text-on-amber grid place-items-center font-display font-bold text-[12px] shrink-0">
+          M
+        </div>
+        <div className="leading-tight">
+          <div className="text-[13px] text-white">Maya</div>
+          <div className="font-mono text-[10.5px] tracking-[0.06em] text-white/40">
+            BDR · ON
+          </div>
+        </div>
+      </div>
     </aside>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -18,31 +18,53 @@ module.exports = {
       }
     },
     extend: {
-      // Pure Bloomberg Dark Theme — Warm Charcoal + Amber ONLY
+      // Agency Desk — Cream/Amber Light Theme (PR1 rebuild)
       colors: {
-        // Background layers — reference CSS vars so data-theme switches them
-        'bg-void': 'var(--bg-void)',
-        'bg-base': 'var(--bg-base)',
-        'bg-surface': 'var(--bg-surface)',
+        // Cream surface palette
+        'cream':     'var(--cream)',
+        'surface':   'var(--surface)',
+        'panel':     'var(--panel-bg)',
+        'brand-bar': 'var(--brand-bar)',
+        'on-amber':  'var(--on-amber)',
+
+        // Ink scale
+        'ink':   'var(--ink)',
+        'ink-2': 'var(--ink-2)',
+        'ink-3': 'var(--ink-3)',
+        'ink-4': 'var(--ink-4)',
+
+        // Rules (cream-friendly subtle borders)
+        'rule':        'var(--rule)',
+        'rule-strong': 'var(--rule-strong)',
+
+        // Status (muted to fit cream backdrop)
+        'green':  'var(--green)',
+        'red':    'var(--red)',
+        'blue':   'var(--blue)',
+        'copper': 'var(--copper)',
+
+        // Legacy aliases — keep old class names working while we migrate
+        'bg-void':     'var(--bg-void)',
+        'bg-base':     'var(--bg-base)',
+        'bg-surface':  'var(--bg-surface)',
         'bg-elevated': 'var(--bg-elevated)',
 
-        // Borders — reference CSS vars
-        'border-subtle': 'var(--border-subtle)',
+        'border-subtle':  'var(--border-subtle)',
         'border-default': 'var(--border-default)',
-        'border-focus': 'var(--border-focus)',
+        'border-focus':   'var(--border-focus)',
 
-        // Text — reference CSS vars
-        'text-primary': 'var(--text-primary)',
+        'text-primary':   'var(--text-primary)',
         'text-secondary': 'var(--text-secondary)',
-        'text-muted': 'var(--text-muted)',
+        'text-muted':     'var(--text-muted)',
 
-        // Accent — reference CSS vars (amber unchanged between themes)
-        'amber': 'var(--amber)',
+        // Accent — amber unchanged between themes
+        'amber':       'var(--amber)',
         'amber-light': 'var(--amber-light)',
-        'amber-glow': 'var(--amber-glow)',
+        'amber-soft':  'var(--amber-soft)',
+        'amber-glow':  'var(--amber-glow)',
 
-        // Error state — reference CSS vars
-        'error': 'var(--error)',
+        // Error state
+        'error':      'var(--error)',
         'error-glow': 'var(--error-glow)',
         
         // Glass
@@ -95,9 +117,15 @@ module.exports = {
         }
       },
       fontFamily: {
-        sans: ['DM Sans', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
-        serif: ['Instrument Serif', 'Georgia', 'serif'],
-        mono: ['JetBrains Mono', 'monospace'],
+        sans:    ['DM Sans', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
+        serif:   ['Playfair Display', 'Georgia', 'serif'],
+        display: ['Playfair Display', 'Georgia', 'serif'],
+        mono:    ['JetBrains Mono', 'monospace'],
+      },
+      spacing: {
+        // Layout dimensions exposed as Tailwind utilities
+        'sidebar': 'var(--sidebar-w)',     // 232px
+        'topbar':  'var(--topbar-h)',      // 56px
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Summary
PR 1 of 4 — switches the dashboard chrome from the old Bloomberg-dark theme to the cream/amber light theme defined by `dashboard-master-agency-desk.html` (the prototype for agencyxos.ai/demo). Subsequent PRs migrate the page bodies, components, and remove the legacy `AppShell` 72px rail.

## Acceptance criteria — all met
1. **Tailwind CSS vars switched** — `--bg-void` → cream `#F7F3EE`, `--ink` `#0C0A08`, `--amber` `#D4956A`. Full ink/copper/rule scales + sidebar (232px) and topbar (56px) layout tokens. Legacy alias names kept so the rest of the app does not break this PR.
2. **Fonts wired** — Playfair Display (700 + italic) loaded via `next/font/google`, exposed as `--font-playfair`. DM Sans body, JetBrains Mono labels (`.mono`, `.eyebrow` classes). H1–H6 default to Playfair with `<em>` rendering amber italic per prototype.
3. **Sidebar rebuilt** — 232px dark `#0C0A08` bar with Playfair logo + amber italic "OS" accent, JetBrains Mono "Agency Desk" eyebrow, three nav sections (Today / Workflow / Insights). Active items: white text + amber-soft fill + 2px amber left border + amber icon. Maya footer block included.
4. **Top nav** — 56px sticky cream-blur backdrop (`rgba(247,243,238,0.85)` + `saturate(140%) blur(8px)`). Page title in Playfair 20px. LIVE pill switched to muted green on cream.
5. **Main content area** — cream background, 1280px centered, 24/32 padding (matches prototype `#main`).

## Files changed
- `frontend/app/globals.css` — palette swap + Playfair import + html.dark inversion + shadcn HSL remap
- `frontend/tailwind.config.js` — new utilities (`bg-cream`, `text-ink`, `border-rule`, `bg-brand-bar`, `bg-amber-soft`, `text-copper`) + `w-sidebar` / `h-topbar` / `pl-sidebar` spacing + `font-display` family
- `frontend/app/layout.tsx` — `Playfair_Display` next/font subset; `--font-playfair` variable on body
- `frontend/components/layout/sidebar.tsx` — full rewrite to 232px prototype spec
- `frontend/components/layout/header.tsx` — 56px sticky cream-blur + Playfair title + muted LIVE pill
- `frontend/components/layout/dashboard-layout.tsx` — `pl-sidebar` reservation + cream main + 1280px max width

## Out of scope (PR2/3/4)
- Page-level component rewrites (`/dashboard`, `/dashboard/leads`, etc.)
- Legacy `AppShell.tsx` 72px rail (used by non-dashboard routes; will be removed in a later PR)
- Maya AI bubble component
- `DashboardNav` (currently rendered alongside the new sidebar — to be deduplicated in PR2)

## Test plan
- [x] `tsc --noEmit` — 4 errors before, 4 errors after (all in `lib/__tests__/useLiveActivityFeed.test.ts`, unrelated regex parsing)
- [x] No errors in any PR1 target file
- [ ] Manual browser smoke after merge — sidebar/topbar render with cream/amber palette; Playfair headlines visible; amber italic accent on `Agency<em>OS</em>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)