### PR TITLE
[ATLAS] feat: dashboard rebuild PR2 — Cycle Progress + Performance Metrics + Hot Replies + System Health

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -40,6 +40,11 @@ import { TodayStrip } from "@/components/dashboard/TodayStrip";
 import { FunnelBar } from "@/components/dashboard/FunnelBar";
 import { AttentionCards } from "@/components/dashboard/AttentionCards";
 import { ProspectDrawer } from "@/components/dashboard/ProspectDrawer";
+// PR2 — dashboard rebuild core components (cream/amber palette, Playfair Display)
+import { CycleProgress } from "@/components/dashboard/CycleProgress";
+import { PerformanceMetrics } from "@/components/dashboard/PerformanceMetrics";
+import { HotReplies } from "@/components/dashboard/HotReplies";
+import { SystemHealth } from "@/components/dashboard/SystemHealth";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -92,6 +97,18 @@ export default function DashboardPage() {
         }}
       >
         <div className="relative z-10">
+          {/* PR2 — Cycle progress + performance + hot replies + health */}
+          <section className="mb-6 grid gap-5 lg:grid-cols-3">
+            <div className="lg:col-span-2 space-y-5">
+              <CycleProgress />
+              <PerformanceMetrics />
+              <SystemHealth />
+            </div>
+            <div className="lg:col-span-1">
+              <HotReplies />
+            </div>
+          </section>
+
           {/* v10 HOME SURFACES — BDR hero + today + funnel + attention */}
           <section className="mb-8 space-y-6">
             <HeroStrip />

--- a/frontend/components/dashboard/CycleProgress.tsx
+++ b/frontend/components/dashboard/CycleProgress.tsx
@@ -1,0 +1,125 @@
+/**
+ * FILE: frontend/components/dashboard/CycleProgress.tsx
+ * PURPOSE: "Day X of 30" cycle progress card — progress bar +
+ *          contacted / replies / meetings counts. PR2 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.bdr-hero` +
+ *            `MAYA · DAY 14/30` cycle indicator combined into one card.
+ */
+
+"use client";
+
+import { useDashboardV4 } from "@/hooks/use-dashboard-v4";
+
+const CYCLE_LENGTH_DAYS = 30;
+
+interface CycleProgressData {
+  currentDay: number;            // 1..30
+  contacted: number;
+  replies: number;
+  meetings: number;
+}
+
+/**
+ * Pull cycle data from useDashboardV4. The V4 hook does not yet return a
+ * cycle_day field — use the calendar day-of-month (1..30) modulo 30 as a
+ * stand-in until the backend exposes a real cycle origin.
+ *
+ * TODO(api): wire to a real cycle_day from `meetings_metrics_v4` once the
+ * backend tracks cycle start. Until then this is approximate.
+ */
+function useCycleProgress(): { data: CycleProgressData; loading: boolean } {
+  const { data, isLoading } = useDashboardV4();
+
+  // TODO(api): replace with metrics.cycle_day once backend exposes it.
+  const today = new Date();
+  const dayOfMonth = today.getDate();
+  const currentDay = Math.min(CYCLE_LENGTH_DAYS, Math.max(1, dayOfMonth));
+
+  const contacted = pickQuickStat(data?.quickStats ?? [], ["contacted", "prospects"]);
+  const replies   = pickQuickStat(data?.quickStats ?? [], ["replies", "reply"]);
+  const meetings  = data?.meetingsGoal?.current ?? 0;
+
+  return {
+    data: { currentDay, contacted, replies, meetings },
+    loading: isLoading,
+  };
+}
+
+function pickQuickStat(
+  stats: Array<{ label: string; value: string | number }>,
+  needles: string[],
+): number {
+  for (const s of stats) {
+    const lbl = (s.label || "").toLowerCase();
+    if (needles.some(n => lbl.includes(n))) {
+      const num = typeof s.value === "number" ? s.value : parseInt(String(s.value).replace(/[^\d]/g, ""), 10);
+      if (!Number.isNaN(num)) return num;
+    }
+  }
+  return 0;
+}
+
+export function CycleProgress() {
+  const { data: c, loading } = useCycleProgress();
+  const pct = Math.round((c.currentDay / CYCLE_LENGTH_DAYS) * 100);
+
+  return (
+    <section className="rounded-[10px] border border-rule bg-panel p-5 sm:p-6">
+      {/* Eyebrow + day label */}
+      <div className="flex items-baseline justify-between gap-4">
+        <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold">
+          Cycle Progress
+        </div>
+        <div className="font-mono text-[11px] text-ink-3 tracking-[0.06em]">
+          {loading ? "—" : `${CYCLE_LENGTH_DAYS - c.currentDay} days remaining`}
+        </div>
+      </div>
+
+      {/* Headline — Playfair with amber italic accent */}
+      <h2 className="font-display font-bold text-[28px] text-ink leading-[1.15] tracking-[-0.02em] mt-2">
+        Day <em className="text-amber not-italic" style={{ fontStyle: "italic" }}>{c.currentDay}</em>
+        <span className="text-ink-3"> of {CYCLE_LENGTH_DAYS}</span>
+      </h2>
+
+      {/* Progress bar */}
+      <div
+        className="mt-4 h-2 w-full rounded-full overflow-hidden"
+        style={{ backgroundColor: "rgba(12,10,8,0.06)" }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={CYCLE_LENGTH_DAYS}
+        aria-valuenow={c.currentDay}
+      >
+        <div
+          className="h-full transition-[width] duration-500 ease-out"
+          style={{
+            width: `${pct}%`,
+            background: "linear-gradient(90deg, var(--amber) 0%, var(--copper) 100%)",
+          }}
+        />
+      </div>
+
+      {/* Counts row — 3 cells */}
+      <div className="grid grid-cols-3 gap-4 mt-5 pt-5 border-t border-rule">
+        <CycleCell label="Contacted" value={c.contacted} loading={loading} />
+        <CycleCell label="Replies"    value={c.replies}    loading={loading} />
+        <CycleCell label="Meetings"   value={c.meetings}   loading={loading} />
+      </div>
+    </section>
+  );
+}
+
+function CycleCell({
+  label, value, loading,
+}: { label: string; value: number; loading: boolean }) {
+  return (
+    <div>
+      <div className="font-display font-bold text-[24px] text-ink leading-none">
+        {loading ? "—" : value.toLocaleString()}
+      </div>
+      <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-ink-3 mt-1.5">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/HotReplies.tsx
+++ b/frontend/components/dashboard/HotReplies.tsx
@@ -1,0 +1,122 @@
+/**
+ * FILE: frontend/components/dashboard/HotReplies.tsx
+ * PURPOSE: Recent prospect responses with amber heat dots — PR2 rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.attention-card.reply`
+ *            + warm-reply preview list patterns.
+ */
+
+"use client";
+
+import { useDashboardV4, type WarmReply } from "@/hooks/use-dashboard-v4";
+import Link from "next/link";
+
+/**
+ * Heat tier — drives how many amber dots render on the card. Until the
+ * backend exposes a per-reply heat score we infer it from preview length
+ * + name presence (longer, more personal previews → hotter).
+ *
+ * TODO(api): replace `inferHeat` with a real heat score from the warm
+ * replies endpoint once `lead_heat_score` is added to the response.
+ */
+function inferHeat(reply: WarmReply): 1 | 2 | 3 {
+  const len = (reply.preview || "").length;
+  if (len >= 140) return 3;
+  if (len >= 70)  return 2;
+  return 1;
+}
+
+export function HotReplies() {
+  const { data, isLoading } = useDashboardV4();
+  const replies = data?.warmReplies ?? [];
+
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-3">
+        <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold">
+          Hot Replies
+        </div>
+        <Link
+          href="/dashboard/replies"
+          className="font-mono text-[10px] tracking-[0.08em] uppercase text-copper hover:text-amber transition-colors"
+        >
+          View all →
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-[10px] border border-dashed border-rule bg-surface/50 px-5 py-4 text-[13px] text-ink-3">
+          Loading replies…
+        </div>
+      ) : replies.length === 0 ? (
+        <div className="rounded-[10px] border border-dashed border-rule bg-surface/50 px-5 py-4 text-[13px] text-ink-3">
+          <b className="text-ink">No hot replies yet</b> — new responses will surface here.
+        </div>
+      ) : (
+        <div className="grid gap-2.5">
+          {replies.slice(0, 5).map(reply => (
+            <HotReplyCard key={reply.id} reply={reply} heat={inferHeat(reply)} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function HotReplyCard({ reply, heat }: { reply: WarmReply; heat: 1 | 2 | 3 }) {
+  return (
+    <Link
+      href={`/dashboard/leads/${reply.leadId}`}
+      className="block rounded-[10px] border border-rule bg-panel hover:border-amber hover:shadow-[0_2px_10px_rgba(212,149,106,0.10)] transition-all px-4 py-3.5"
+    >
+      <div className="flex items-start gap-3">
+        {/* Avatar */}
+        <div
+          className="w-9 h-9 rounded-full grid place-items-center text-[12px] font-display font-bold shrink-0"
+          style={{ backgroundColor: "var(--amber)", color: "var(--on-amber)" }}
+        >
+          {reply.initials}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-[13px] text-ink font-medium truncate">
+              {reply.name}
+              {reply.company && (
+                <span className="text-ink-3 font-normal"> · {reply.company}</span>
+              )}
+            </div>
+
+            {/* Heat dots */}
+            <HeatDots heat={heat} />
+          </div>
+
+          <div className="text-[12.5px] text-ink-2 mt-1 line-clamp-2 leading-snug">
+            {reply.preview}
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function HeatDots({ heat }: { heat: 1 | 2 | 3 }) {
+  return (
+    <div
+      className="flex items-center gap-[3px] shrink-0"
+      title={`${heat === 3 ? "Very hot" : heat === 2 ? "Hot" : "Warm"} reply`}
+      aria-label={`${heat} of 3 heat dots`}
+    >
+      {[1, 2, 3].map(i => (
+        <span
+          key={i}
+          className="block w-[7px] h-[7px] rounded-full"
+          style={{
+            backgroundColor:
+              i <= heat ? "var(--amber)" : "rgba(12,10,8,0.10)",
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/PerformanceMetrics.tsx
+++ b/frontend/components/dashboard/PerformanceMetrics.tsx
@@ -1,0 +1,119 @@
+/**
+ * FILE: frontend/components/dashboard/PerformanceMetrics.tsx
+ * PURPOSE: 4-column performance grid — Open Rate / Reply Rate /
+ *          Meeting Rate / Avg Reply Time. PR2 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.sum-row` /
+ *            `.sum-card` / `.sum-val` / `.sum-label` styling.
+ */
+
+"use client";
+
+import { useDashboardV4 } from "@/hooks/use-dashboard-v4";
+
+interface MetricCard {
+  id: string;
+  value: string;            // formatted display value
+  unit?: string;             // amber suffix (em accent in prototype)
+  label: string;             // mono uppercase
+  delta?: string;            // small green/ink-3 line under the label
+  todo?: boolean;            // when true, source is mocked — flag in UI
+}
+
+export function PerformanceMetrics() {
+  const { data, isLoading } = useDashboardV4();
+
+  // TODO(api): the V4 metrics endpoint exposes show_rate + meetings_*,
+  // but does not yet return open_rate / reply_rate / avg_reply_time
+  // directly. When `meetings_metrics_v4` is extended these constants
+  // become real reads — until then we surface conservative placeholders
+  // for the prototype layout, marked with `todo: true` so the UI
+  // displays a small TODO badge.
+  const cards: MetricCard[] = [
+    {
+      id: "open",
+      value: "—",
+      unit: "%",
+      label: "Open Rate",
+      delta: "endpoint pending",
+      todo: true,
+    },
+    {
+      id: "reply",
+      value: "—",
+      unit: "%",
+      label: "Reply Rate",
+      delta: "endpoint pending",
+      todo: true,
+    },
+    {
+      id: "meeting",
+      value: data?.meetingsGoal?.target
+        ? `${Math.round(((data?.meetingsGoal?.current ?? 0) / data.meetingsGoal.target) * 100)}`
+        : "—",
+      unit: "%",
+      label: "Meeting Rate",
+      delta:
+        data?.meetingsGoal
+          ? `${data.meetingsGoal.current}/${data.meetingsGoal.target} this cycle`
+          : undefined,
+    },
+    {
+      id: "avg-reply",
+      value: "—",
+      unit: "h",
+      label: "Avg Reply Time",
+      delta: "endpoint pending",
+      todo: true,
+    },
+  ];
+
+  return (
+    <section>
+      <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold mb-3">
+        Performance
+      </div>
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3.5">
+        {cards.map(c => (
+          <SumCard key={c.id} card={c} loading={isLoading} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SumCard({ card, loading }: { card: MetricCard; loading: boolean }) {
+  return (
+    <div className="rounded-[10px] border border-rule bg-panel px-[18px] py-4 relative">
+      {card.todo && (
+        <span className="absolute top-2 right-2 font-mono text-[8px] tracking-[0.12em] uppercase text-amber/80 bg-amber-soft border border-amber/30 rounded px-1.5 py-[1px]">
+          TODO
+        </span>
+      )}
+
+      {/* Value — Playfair 28px with amber em accent for the unit */}
+      <div className="font-display font-bold text-[28px] leading-none text-ink">
+        {loading ? "—" : card.value}
+        {card.unit && (
+          <em
+            className="not-italic font-bold text-[18px] text-amber ml-0.5"
+            style={{ fontStyle: "normal" }}
+          >
+            {card.unit}
+          </em>
+        )}
+      </div>
+
+      {/* Label — JetBrains Mono uppercase */}
+      <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-ink-3 mt-1.5">
+        {card.label}
+      </div>
+
+      {/* Delta — small mono line beneath the label */}
+      {card.delta && (
+        <div className="font-mono text-[11px] text-green mt-1">
+          {card.delta}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/SystemHealth.tsx
+++ b/frontend/components/dashboard/SystemHealth.tsx
@@ -1,0 +1,136 @@
+/**
+ * FILE: frontend/components/dashboard/SystemHealth.tsx
+ * PURPOSE: 4 channel health pills — Email Delivery / LinkedIn Queue /
+ *          Voice AI / SMS Gateway. Green/amber/red status dots.
+ *          PR2 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.tb-cycle .tb-dot`
+ *            (pulsing dot) + `.pill` colour scheme.
+ */
+
+"use client";
+
+import { Mail, Linkedin, Phone, MessageSquare } from "lucide-react";
+
+type HealthStatus = "ok" | "warn" | "error";
+
+interface ChannelHealth {
+  id: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  status: HealthStatus;
+  detail: string;     // short subtitle, e.g. "98.2% delivered"
+}
+
+const STATUS_COLOR: Record<HealthStatus, { bg: string; ring: string; text: string }> = {
+  ok:    { bg: "var(--green)", ring: "rgba(107,142,90,0.35)", text: "var(--green)" },
+  warn:  { bg: "var(--amber)", ring: "rgba(212,149,106,0.35)", text: "var(--copper)" },
+  error: { bg: "var(--red)",   ring: "rgba(181,90,76,0.35)",   text: "var(--red)" },
+};
+
+/**
+ * TODO(api): SystemHealth is currently mock-only. The backend has the
+ * raw signals needed (`distribution.email`, LinkedIn queue depth, voice
+ * provider status, telnyx SMS gateway) but no aggregated /api/v1/system-
+ * health endpoint exists yet. Each card below carries a `todo` flag so a
+ * follow-up PR can wire `useSystemHealth()` without changing the layout.
+ */
+function useSystemHealthMock(): ChannelHealth[] {
+  return [
+    {
+      id: "email",
+      label: "Email Delivery",
+      icon: Mail,
+      status: "ok",
+      detail: "98.2% delivered · last 24h",
+    },
+    {
+      id: "linkedin",
+      label: "LinkedIn Queue",
+      icon: Linkedin,
+      status: "warn",
+      detail: "Weekend slowdown · 12 queued",
+    },
+    {
+      id: "voice",
+      label: "Voice AI",
+      icon: Phone,
+      status: "ok",
+      detail: "VAPI healthy · 0 failures",
+    },
+    {
+      id: "sms",
+      label: "SMS Gateway",
+      icon: MessageSquare,
+      status: "ok",
+      detail: "Telnyx · 100% uptime",
+    },
+  ];
+}
+
+export function SystemHealth() {
+  const channels = useSystemHealthMock();
+
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-3">
+        <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold">
+          System Health
+        </div>
+        <span className="font-mono text-[8px] tracking-[0.12em] uppercase text-amber/80 bg-amber-soft border border-amber/30 rounded px-1.5 py-[1px]">
+          TODO · MOCK
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {channels.map(channel => (
+          <HealthPill key={channel.id} channel={channel} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function HealthPill({ channel }: { channel: ChannelHealth }) {
+  const Icon = channel.icon;
+  const palette = STATUS_COLOR[channel.status];
+  const labelText = {
+    ok: "Operational",
+    warn: "Degraded",
+    error: "Outage",
+  }[channel.status];
+
+  return (
+    <div className="rounded-[10px] border border-rule bg-panel px-4 py-3.5 flex items-start gap-3">
+      <Icon className="w-4 h-4 mt-0.5 text-ink-3 shrink-0" strokeWidth={1.6} />
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          {/* Status dot */}
+          <span className="relative flex w-2 h-2">
+            {channel.status === "ok" && (
+              <span
+                className="absolute inline-flex h-full w-full rounded-full opacity-60 animate-ping"
+                style={{ backgroundColor: palette.bg }}
+              />
+            )}
+            <span
+              className="relative inline-flex w-2 h-2 rounded-full"
+              style={{ backgroundColor: palette.bg, boxShadow: `0 0 0 3px ${palette.ring}` }}
+            />
+          </span>
+
+          <span className="font-mono text-[10px] tracking-[0.1em] uppercase font-semibold" style={{ color: palette.text }}>
+            {labelText}
+          </span>
+        </div>
+
+        <div className="text-[13px] text-ink mt-1.5 font-medium truncate">
+          {channel.label}
+        </div>
+        <div className="text-[11.5px] text-ink-3 mt-0.5 truncate">
+          {channel.detail}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
PR 2 of 4 — four core information surfaces for the dashboard, all using the cream/amber palette + Playfair Display + JetBrains Mono typography wired in PR #441.

| Component | Source | Live data | TODO(api) |
|---|---|---|---|
| `CycleProgress` | `useDashboardV4` | quickStats counts, meetings goal | currentDay derived from calendar day-of-month — needs real `cycle_day` field |
| `PerformanceMetrics` | `useDashboardV4` | Meeting Rate (current/target × 100) | Open Rate / Reply Rate / Avg Reply Time pending `meetings_metrics_v4` extension — flagged with `TODO` badges |
| `HotReplies` | `useDashboardV4.warmReplies` | name, company, preview | heat dots inferred from preview length — needs `lead_heat_score` field |
| `SystemHealth` | mock | — | no aggregated `/api/v1/system-health` endpoint yet — section flagged `TODO · MOCK` at header |

## Acceptance criteria
1. **Cycle Progress** — "Day X of 30" Playfair headline with amber italic accent on the day number, linear-gradient amber→copper progress bar (aria-progressbar), 3-cell counts row (Contacted / Replies / Meetings).
2. **Performance Metrics** — responsive 4-column grid (2-up sm, 4-up lg). Playfair 28px values with amber `<em>` unit suffix. JetBrains Mono uppercase labels. Mono delta line.
3. **Hot Replies** — recent prospect responses with amber avatar circles, two-line previews, 1-3 amber heat dots. Empty + loading states both styled in cream/dashed border.
4. **System Health** — 4 channel pills (Email / LinkedIn / Voice / SMS) with green-pulse / amber / red status dots, mono uppercase status label + channel name + detail line.

## Files
- `frontend/components/dashboard/CycleProgress.tsx` — new
- `frontend/components/dashboard/PerformanceMetrics.tsx` — new
- `frontend/components/dashboard/HotReplies.tsx` — new
- `frontend/components/dashboard/SystemHealth.tsx` — new
- `frontend/app/dashboard/page.tsx` — integrates all four above the existing v10 surfaces (3-col grid, falls back to single column on mobile)

## Test plan
- [x] `tsc --noEmit` — 4 errors before, 4 errors after (pre-existing in `lib/__tests__/useLiveActivityFeed.test.ts`, unrelated to PR2)
- [x] Zero errors in any PR2 component file
- [ ] Manual browser smoke after merge — components render in cream/amber palette; live data flows through CycleProgress + PerformanceMetrics meeting rate + HotReplies; SystemHealth shows TODO·MOCK badge

## Follow-ups (not blocking PR2)
1. Backend: extend `meetings_metrics_v4` with `open_rate`, `reply_rate`, `avg_reply_time_hours`, `cycle_day`, `cycle_length_days` fields.
2. Backend: add `/api/v1/system-health` aggregator pulling `distribution.email`, LinkedIn queue depth, VAPI status, Telnyx SMS health.
3. Backend: extend warm-replies endpoint with `lead_heat_score`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)