### PR TITLE
[ATLAS] feat: dashboard rebuild PR3 — Pipeline View + state tabs + Prospect Detail

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -40,6 +40,11 @@ import { TodayStrip } from "@/components/dashboard/TodayStrip";
 import { FunnelBar } from "@/components/dashboard/FunnelBar";
 import { AttentionCards } from "@/components/dashboard/AttentionCards";
 import { ProspectDrawer } from "@/components/dashboard/ProspectDrawer";
+// PR2 — dashboard rebuild core components (cream/amber palette, Playfair Display)
+import { CycleProgress } from "@/components/dashboard/CycleProgress";
+import { PerformanceMetrics } from "@/components/dashboard/PerformanceMetrics";
+import { HotReplies } from "@/components/dashboard/HotReplies";
+import { SystemHealth } from "@/components/dashboard/SystemHealth";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -92,6 +97,18 @@ export default function DashboardPage() {
         }}
       >
         <div className="relative z-10">
+          {/* PR2 — Cycle progress + performance + hot replies + health */}
+          <section className="mb-6 grid gap-5 lg:grid-cols-3">
+            <div className="lg:col-span-2 space-y-5">
+              <CycleProgress />
+              <PerformanceMetrics />
+              <SystemHealth />
+            </div>
+            <div className="lg:col-span-1">
+              <HotReplies />
+            </div>
+          </section>
+
           {/* v10 HOME SURFACES — BDR hero + today + funnel + attention */}
           <section className="mb-8 space-y-6">
             <HeroStrip />

--- a/frontend/app/dashboard/pipeline/page.tsx
+++ b/frontend/app/dashboard/pipeline/page.tsx
@@ -2,77 +2,208 @@
 
 /**
  * FILE: frontend/app/dashboard/pipeline/page.tsx
- * PURPOSE: Pipeline route — Kanban ↔ Table toggle over live Supabase prospect data
- * PHASE: PHASE-2.1-PIPELINE-MEETINGS
- *
- * Replaces the SSE stream view (preserved in git history at prior commits).
- * Uses usePipelineData for counts + prospect list.
+ * PURPOSE: Pipeline route — PR3 dashboard rebuild.
+ *          State-machine tabs (Review / Outreach / Complete) +
+ *          intent-bar prospect rows + filter chips.
+ *          Kanban / Table views preserved as alt views.
  */
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { AppShell } from "@/components/layout/AppShell";
 import { PipelineKanban } from "@/components/dashboard/PipelineKanban";
 import { PipelineTable } from "@/components/dashboard/PipelineTable";
 import { ProspectDrawer } from "@/components/dashboard/ProspectDrawer";
+import { PipelineRow, inferIntent } from "@/components/dashboard/PipelineRow";
+import {
+  PipelineFilters,
+  type PipelineFilterKey,
+} from "@/components/dashboard/PipelineFilters";
+import {
+  PipelineStateTabs,
+  type PipelineMode,
+} from "@/components/dashboard/PipelineStateTabs";
 import { usePipelineData } from "@/lib/hooks/usePipelineData";
 
-type View = "kanban" | "table";
+type View = "list" | "kanban" | "table";
 
 export default function PipelinePage() {
-  const [view, setView] = useState<View>("kanban");
+  const [view, setView] = useState<View>("list");
   const [activeLead, setActiveLead] = useState<string | null>(null);
+  const [filter, setFilter] = useState<PipelineFilterKey>("all");
+  const [mode, setMode] = useState<PipelineMode>("outreach");
   const { prospects, counts, isLoading } = usePipelineData();
 
+  // ─── Derived counts for filter chips + state tabs ───
+  const intentCounts = useMemo(() => {
+    let struggling = 0, trying = 0, dabbling = 0;
+    for (const p of prospects) {
+      const tier = inferIntent(p.score);
+      if (tier === "struggling") struggling++;
+      else if (tier === "trying") trying++;
+      else dabbling++;
+    }
+    return { struggling, trying, dabbling };
+  }, [prospects]);
+
+  // Filter + rank
+  const ranked = useMemo(() => {
+    const sorted = [...prospects].sort(
+      (a, b) => (b.score ?? 0) - (a.score ?? 0),
+    );
+    let filtered = sorted;
+    if (filter === "top10")      filtered = sorted.slice(0, 10);
+    else if (filter === "top50") filtered = sorted.slice(0, 50);
+    else if (filter === "struggling")
+      filtered = sorted.filter(p => inferIntent(p.score) === "struggling");
+    else if (filter === "trying")
+      filtered = sorted.filter(p => inferIntent(p.score) === "trying");
+    else if (filter === "dabbling")
+      filtered = sorted.filter(p => inferIntent(p.score) === "dabbling");
+    return filtered;
+  }, [prospects, filter]);
+
+  // State-tab metric inputs (live where possible)
   const total = prospects.length;
+  const reviewed = counts.discovered ? total - counts.discovered : total; // TODO(api): real reviewed count
+  const contactedCount = (counts.contacted ?? 0) + (counts.replied ?? 0) + (counts.meeting ?? 0) + (counts.converted ?? 0);
+  const repliedCount   = (counts.replied ?? 0)  + (counts.meeting ?? 0)  + (counts.converted ?? 0);
+  const meetingsCount  = (counts.meeting ?? 0)  + (counts.converted ?? 0);
 
   return (
     <AppShell pageTitle="Pipeline">
-      <div className="min-h-screen bg-gray-950 text-gray-100 p-4 md:p-6">
-        <header className="flex items-start md:items-center justify-between flex-col md:flex-row gap-3 mb-4">
+      <div className="px-4 md:px-6 py-6 space-y-6">
+        {/* Header */}
+        <header className="flex items-start md:items-center justify-between flex-col md:flex-row gap-3">
           <div>
-            <h1 className="font-serif text-2xl md:text-3xl text-gray-100">
-              Pipeline
+            <h1 className="font-display font-bold text-[28px] text-ink leading-tight tracking-[-0.02em]">
+              Pipeline,{" "}
+              <em className="text-amber" style={{ fontStyle: "italic" }}>
+                ranked
+              </em>
             </h1>
-            <p className="text-sm text-gray-400">
-              {total} {total === 1 ? "prospect" : "prospects"} across six stages
+            <p className="text-[13px] text-ink-3 mt-1">
+              {total} {total === 1 ? "prospect" : "prospects"} across the cycle ·
+              click any row for the briefing card.
             </p>
           </div>
-          <div className="inline-flex rounded-lg border border-gray-800 bg-gray-900 p-0.5">
-            {(["kanban", "table"] as View[]).map((v) => (
-              <button
-                key={v}
-                onClick={() => setView(v)}
-                className={`px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md ${
-                  view === v
-                    ? "bg-amber-500/10 text-amber-300 border border-amber-500/40"
-                    : "text-gray-400 hover:text-gray-200"
-                }`}
-              >
-                {v}
-              </button>
-            ))}
+
+          {/* View toggle */}
+          <div className="inline-flex p-[2px] rounded-md bg-surface">
+            {(["list", "kanban", "table"] as View[]).map(v => {
+              const isActive = v === view;
+              return (
+                <button
+                  key={v}
+                  onClick={() => setView(v)}
+                  className={[
+                    "px-3.5 py-1.5 font-mono text-[11px] tracking-[0.06em] rounded-[4px] uppercase transition-colors",
+                    isActive
+                      ? "bg-ink text-white font-semibold"
+                      : "text-ink-3 hover:text-ink",
+                  ].join(" ")}
+                >
+                  {v}
+                </button>
+              );
+            })}
           </div>
         </header>
 
-        {view === "kanban" ? (
+        {/* State-machine tabs */}
+        <PipelineStateTabs
+          mode={mode}
+          onChange={setMode}
+          {...(mode === "review"
+            ? {
+                mode: "review" as const,
+                total,
+                reviewed,
+                onReleaseAll: () => {/* TODO(api): wire batch-release endpoint */},
+              }
+            : mode === "outreach"
+            ? {
+                mode: "outreach" as const,
+                contacted: contactedCount,
+                replied:   repliedCount,
+                meetingsBooked: meetingsCount,
+              }
+            : {
+                mode: "complete" as const,
+                cycleNumber: 1, // TODO(api): real cycle number from metrics
+                contacted: contactedCount,
+                replied:   repliedCount,
+                meetingsBooked: meetingsCount,
+                nextCycleAt: null, // TODO(api): real next-cycle ISO timestamp
+              })}
+        />
+
+        {/* Filter chips */}
+        <PipelineFilters
+          active={filter}
+          onChange={setFilter}
+          options={[
+            { key: "all",        label: "All",        count: total },
+            { key: "top10",      label: "Top 10",     count: Math.min(10, total) },
+            { key: "top50",      label: "Top 50",     count: Math.min(50, total) },
+            { key: "struggling", label: "Struggling", count: intentCounts.struggling },
+            { key: "trying",     label: "Trying",     count: intentCounts.trying },
+            { key: "dabbling",   label: "Dabbling",   count: intentCounts.dabbling },
+          ]}
+        />
+
+        {/* Body — list / kanban / table */}
+        {view === "list" && (
+          <div className="space-y-2">
+            {isLoading ? (
+              <div className="rounded-[10px] border border-dashed border-rule bg-surface/50 px-5 py-6 text-[13px] text-ink-3">
+                Loading prospects…
+              </div>
+            ) : ranked.length === 0 ? (
+              <div className="rounded-[10px] border border-dashed border-rule bg-surface/50 px-5 py-6 text-[13px] text-ink-3">
+                No prospects match this filter yet.
+              </div>
+            ) : (
+              ranked.map((p, i) => (
+                <PipelineRow
+                  key={p.id}
+                  rank={i + 1}
+                  prospect={p}
+                  onClick={(id) => setActiveLead(id)}
+                />
+              ))
+            )}
+          </div>
+        )}
+
+        {view === "kanban" && (
           <PipelineKanban
-            prospects={prospects}
+            prospects={ranked}
             counts={counts}
-            onOpen={(id) => setActiveLead(id)}
-            isLoading={isLoading}
-          />
-        ) : (
-          <PipelineTable
-            prospects={prospects}
             onOpen={(id) => setActiveLead(id)}
             isLoading={isLoading}
           />
         )}
 
-        <nav className="mt-6 text-xs text-gray-500 font-mono flex gap-3">
-          <Link href="/dashboard" className="hover:text-gray-300">← Home</Link>
-          <Link href="/dashboard/meetings" className="hover:text-gray-300">Meetings →</Link>
+        {view === "table" && (
+          <PipelineTable
+            prospects={ranked}
+            onOpen={(id) => setActiveLead(id)}
+            isLoading={isLoading}
+          />
+        )}
+
+        {/* Footer nav */}
+        <nav className="text-[11px] font-mono text-ink-3 flex gap-3 pt-4 border-t border-rule">
+          <Link href="/dashboard" className="hover:text-copper transition-colors">
+            ← Home
+          </Link>
+          <Link
+            href="/dashboard/meetings"
+            className="hover:text-copper transition-colors"
+          >
+            Meetings →
+          </Link>
         </nav>
       </div>
 

--- a/frontend/components/dashboard/CycleProgress.tsx
+++ b/frontend/components/dashboard/CycleProgress.tsx
@@ -1,0 +1,125 @@
+/**
+ * FILE: frontend/components/dashboard/CycleProgress.tsx
+ * PURPOSE: "Day X of 30" cycle progress card — progress bar +
+ *          contacted / replies / meetings counts. PR2 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.bdr-hero` +
+ *            `MAYA · DAY 14/30` cycle indicator combined into one card.
+ */
+
+"use client";
+
+import { useDashboardV4 } from "@/hooks/use-dashboard-v4";
+
+const CYCLE_LENGTH_DAYS = 30;
+
+interface CycleProgressData {
+  currentDay: number;            // 1..30
+  contacted: number;
+  replies: number;
+  meetings: number;
+}
+
+/**
+ * Pull cycle data from useDashboardV4. The V4 hook does not yet return a
+ * cycle_day field — use the calendar day-of-month (1..30) modulo 30 as a
+ * stand-in until the backend exposes a real cycle origin.
+ *
+ * TODO(api): wire to a real cycle_day from `meetings_metrics_v4` once the
+ * backend tracks cycle start. Until then this is approximate.
+ */
+function useCycleProgress(): { data: CycleProgressData; loading: boolean } {
+  const { data, isLoading } = useDashboardV4();
+
+  // TODO(api): replace with metrics.cycle_day once backend exposes it.
+  const today = new Date();
+  const dayOfMonth = today.getDate();
+  const currentDay = Math.min(CYCLE_LENGTH_DAYS, Math.max(1, dayOfMonth));
+
+  const contacted = pickQuickStat(data?.quickStats ?? [], ["contacted", "prospects"]);
+  const replies   = pickQuickStat(data?.quickStats ?? [], ["replies", "reply"]);
+  const meetings  = data?.meetingsGoal?.current ?? 0;
+
+  return {
+    data: { currentDay, contacted, replies, meetings },
+    loading: isLoading,
+  };
+}
+
+function pickQuickStat(
+  stats: Array<{ label: string; value: string | number }>,
+  needles: string[],
+): number {
+  for (const s of stats) {
+    const lbl = (s.label || "").toLowerCase();
+    if (needles.some(n => lbl.includes(n))) {
+      const num = typeof s.value === "number" ? s.value : parseInt(String(s.value).replace(/[^\d]/g, ""), 10);
+      if (!Number.isNaN(num)) return num;
+    }
+  }
+  return 0;
+}
+
+export function CycleProgress() {
+  const { data: c, loading } = useCycleProgress();
+  const pct = Math.round((c.currentDay / CYCLE_LENGTH_DAYS) * 100);
+
+  return (
+    <section className="rounded-[10px] border border-rule bg-panel p-5 sm:p-6">
+      {/* Eyebrow + day label */}
+      <div className="flex items-baseline justify-between gap-4">
+        <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold">
+          Cycle Progress
+        </div>
+        <div className="font-mono text-[11px] text-ink-3 tracking-[0.06em]">
+          {loading ? "—" : `${CYCLE_LENGTH_DAYS - c.currentDay} days remaining`}
+        </div>
+      </div>
+
+      {/* Headline — Playfair with amber italic accent */}
+      <h2 className="font-display font-bold text-[28px] text-ink leading-[1.15] tracking-[-0.02em] mt-2">
+        Day <em className="text-amber not-italic" style={{ fontStyle: "italic" }}>{c.currentDay}</em>
+        <span className="text-ink-3"> of {CYCLE_LENGTH_DAYS}</span>
+      </h2>
+
+      {/* Progress bar */}
+      <div
+        className="mt-4 h-2 w-full rounded-full overflow-hidden"
+        style={{ backgroundColor: "rgba(12,10,8,0.06)" }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={CYCLE_LENGTH_DAYS}
+        aria-valuenow={c.currentDay}
+      >
+        <div
+          className="h-full transition-[width] duration-500 ease-out"
+          style={{
+            width: `${pct}%`,
+            background: "linear-gradient(90deg, var(--amber) 0%, var(--copper) 100%)",
+          }}
+        />
+      </div>
+
+      {/* Counts row — 3 cells */}
+      <div className="grid grid-cols-3 gap-4 mt-5 pt-5 border-t border-rule">
+        <CycleCell label="Contacted" value={c.contacted} loading={loading} />
+        <CycleCell label="Replies"    value={c.replies}    loading={loading} />
+        <CycleCell label="Meetings"   value={c.meetings}   loading={loading} />
+      </div>
+    </section>
+  );
+}
+
+function CycleCell({
+  label, value, loading,
+}: { label: string; value: number; loading: boolean }) {
+  return (
+    <div>
+      <div className="font-display font-bold text-[24px] text-ink leading-none">
+        {loading ? "—" : value.toLocaleString()}
+      </div>
+      <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-ink-3 mt-1.5">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/HotReplies.tsx
+++ b/frontend/components/dashboard/HotReplies.tsx
@@ -1,0 +1,122 @@
+/**
+ * FILE: frontend/components/dashboard/HotReplies.tsx
+ * PURPOSE: Recent prospect responses with amber heat dots — PR2 rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.attention-card.reply`
+ *            + warm-reply preview list patterns.
+ */
+
+"use client";
+
+import { useDashboardV4, type WarmReply } from "@/hooks/use-dashboard-v4";
+import Link from "next/link";
+
+/**
+ * Heat tier — drives how many amber dots render on the card. Until the
+ * backend exposes a per-reply heat score we infer it from preview length
+ * + name presence (longer, more personal previews → hotter).
+ *
+ * TODO(api): replace `inferHeat` with a real heat score from the warm
+ * replies endpoint once `lead_heat_score` is added to the response.
+ */
+function inferHeat(reply: WarmReply): 1 | 2 | 3 {
+  const len = (reply.preview || "").length;
+  if (len >= 140) return 3;
+  if (len >= 70)  return 2;
+  return 1;
+}
+
+export function HotReplies() {
+  const { data, isLoading } = useDashboardV4();
+  const replies = data?.warmReplies ?? [];
+
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-3">
+        <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold">
+          Hot Replies
+        </div>
+        <Link
+          href="/dashboard/replies"
+          className="font-mono text-[10px] tracking-[0.08em] uppercase text-copper hover:text-amber transition-colors"
+        >
+          View all →
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-[10px] border border-dashed border-rule bg-surface/50 px-5 py-4 text-[13px] text-ink-3">
+          Loading replies…
+        </div>
+      ) : replies.length === 0 ? (
+        <div className="rounded-[10px] border border-dashed border-rule bg-surface/50 px-5 py-4 text-[13px] text-ink-3">
+          <b className="text-ink">No hot replies yet</b> — new responses will surface here.
+        </div>
+      ) : (
+        <div className="grid gap-2.5">
+          {replies.slice(0, 5).map(reply => (
+            <HotReplyCard key={reply.id} reply={reply} heat={inferHeat(reply)} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function HotReplyCard({ reply, heat }: { reply: WarmReply; heat: 1 | 2 | 3 }) {
+  return (
+    <Link
+      href={`/dashboard/leads/${reply.leadId}`}
+      className="block rounded-[10px] border border-rule bg-panel hover:border-amber hover:shadow-[0_2px_10px_rgba(212,149,106,0.10)] transition-all px-4 py-3.5"
+    >
+      <div className="flex items-start gap-3">
+        {/* Avatar */}
+        <div
+          className="w-9 h-9 rounded-full grid place-items-center text-[12px] font-display font-bold shrink-0"
+          style={{ backgroundColor: "var(--amber)", color: "var(--on-amber)" }}
+        >
+          {reply.initials}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-[13px] text-ink font-medium truncate">
+              {reply.name}
+              {reply.company && (
+                <span className="text-ink-3 font-normal"> · {reply.company}</span>
+              )}
+            </div>
+
+            {/* Heat dots */}
+            <HeatDots heat={heat} />
+          </div>
+
+          <div className="text-[12.5px] text-ink-2 mt-1 line-clamp-2 leading-snug">
+            {reply.preview}
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function HeatDots({ heat }: { heat: 1 | 2 | 3 }) {
+  return (
+    <div
+      className="flex items-center gap-[3px] shrink-0"
+      title={`${heat === 3 ? "Very hot" : heat === 2 ? "Hot" : "Warm"} reply`}
+      aria-label={`${heat} of 3 heat dots`}
+    >
+      {[1, 2, 3].map(i => (
+        <span
+          key={i}
+          className="block w-[7px] h-[7px] rounded-full"
+          style={{
+            backgroundColor:
+              i <= heat ? "var(--amber)" : "rgba(12,10,8,0.10)",
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/PerformanceMetrics.tsx
+++ b/frontend/components/dashboard/PerformanceMetrics.tsx
@@ -1,0 +1,119 @@
+/**
+ * FILE: frontend/components/dashboard/PerformanceMetrics.tsx
+ * PURPOSE: 4-column performance grid — Open Rate / Reply Rate /
+ *          Meeting Rate / Avg Reply Time. PR2 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.sum-row` /
+ *            `.sum-card` / `.sum-val` / `.sum-label` styling.
+ */
+
+"use client";
+
+import { useDashboardV4 } from "@/hooks/use-dashboard-v4";
+
+interface MetricCard {
+  id: string;
+  value: string;            // formatted display value
+  unit?: string;             // amber suffix (em accent in prototype)
+  label: string;             // mono uppercase
+  delta?: string;            // small green/ink-3 line under the label
+  todo?: boolean;            // when true, source is mocked — flag in UI
+}
+
+export function PerformanceMetrics() {
+  const { data, isLoading } = useDashboardV4();
+
+  // TODO(api): the V4 metrics endpoint exposes show_rate + meetings_*,
+  // but does not yet return open_rate / reply_rate / avg_reply_time
+  // directly. When `meetings_metrics_v4` is extended these constants
+  // become real reads — until then we surface conservative placeholders
+  // for the prototype layout, marked with `todo: true` so the UI
+  // displays a small TODO badge.
+  const cards: MetricCard[] = [
+    {
+      id: "open",
+      value: "—",
+      unit: "%",
+      label: "Open Rate",
+      delta: "endpoint pending",
+      todo: true,
+    },
+    {
+      id: "reply",
+      value: "—",
+      unit: "%",
+      label: "Reply Rate",
+      delta: "endpoint pending",
+      todo: true,
+    },
+    {
+      id: "meeting",
+      value: data?.meetingsGoal?.target
+        ? `${Math.round(((data?.meetingsGoal?.current ?? 0) / data.meetingsGoal.target) * 100)}`
+        : "—",
+      unit: "%",
+      label: "Meeting Rate",
+      delta:
+        data?.meetingsGoal
+          ? `${data.meetingsGoal.current}/${data.meetingsGoal.target} this cycle`
+          : undefined,
+    },
+    {
+      id: "avg-reply",
+      value: "—",
+      unit: "h",
+      label: "Avg Reply Time",
+      delta: "endpoint pending",
+      todo: true,
+    },
+  ];
+
+  return (
+    <section>
+      <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold mb-3">
+        Performance
+      </div>
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3.5">
+        {cards.map(c => (
+          <SumCard key={c.id} card={c} loading={isLoading} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SumCard({ card, loading }: { card: MetricCard; loading: boolean }) {
+  return (
+    <div className="rounded-[10px] border border-rule bg-panel px-[18px] py-4 relative">
+      {card.todo && (
+        <span className="absolute top-2 right-2 font-mono text-[8px] tracking-[0.12em] uppercase text-amber/80 bg-amber-soft border border-amber/30 rounded px-1.5 py-[1px]">
+          TODO
+        </span>
+      )}
+
+      {/* Value — Playfair 28px with amber em accent for the unit */}
+      <div className="font-display font-bold text-[28px] leading-none text-ink">
+        {loading ? "—" : card.value}
+        {card.unit && (
+          <em
+            className="not-italic font-bold text-[18px] text-amber ml-0.5"
+            style={{ fontStyle: "normal" }}
+          >
+            {card.unit}
+          </em>
+        )}
+      </div>
+
+      {/* Label — JetBrains Mono uppercase */}
+      <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-ink-3 mt-1.5">
+        {card.label}
+      </div>
+
+      {/* Delta — small mono line beneath the label */}
+      {card.delta && (
+        <div className="font-mono text-[11px] text-green mt-1">
+          {card.delta}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/PipelineFilters.tsx
+++ b/frontend/components/dashboard/PipelineFilters.tsx
@@ -1,0 +1,64 @@
+/**
+ * FILE: frontend/components/dashboard/PipelineFilters.tsx
+ * PURPOSE: Filter chip row — Top 10 / Top 50 / Struggling / Trying /
+ *          Dabbling. PR3 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.chip` /
+ *            `.chip.active` / `.chip-count` styling.
+ */
+
+"use client";
+
+export type PipelineFilterKey =
+  | "all"
+  | "top10"
+  | "top50"
+  | "struggling"
+  | "trying"
+  | "dabbling";
+
+export interface PipelineFilterOption {
+  key: PipelineFilterKey;
+  label: string;
+  count: number;
+}
+
+interface Props {
+  options: PipelineFilterOption[];
+  active: PipelineFilterKey;
+  onChange: (key: PipelineFilterKey) => void;
+}
+
+export function PipelineFilters({ options, active, onChange }: Props) {
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {options.map(opt => {
+        const isActive = opt.key === active;
+        return (
+          <button
+            key={opt.key}
+            type="button"
+            onClick={() => onChange(opt.key)}
+            className={[
+              "px-3.5 py-1.5 rounded-full font-mono text-[11px] tracking-[0.06em] border transition-colors",
+              isActive
+                ? "bg-amber border-amber font-semibold"
+                : "bg-panel border-rule text-ink-3 hover:text-copper hover:border-amber",
+            ].join(" ")}
+            style={isActive ? { color: "var(--on-amber)" } : undefined}
+          >
+            {opt.label}
+            <span
+              className={[
+                "ml-1.5 font-bold",
+                isActive ? "" : "text-copper",
+              ].join(" ")}
+              style={isActive ? { color: "var(--on-amber)" } : undefined}
+            >
+              {opt.count}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/PipelineRow.tsx
+++ b/frontend/components/dashboard/PipelineRow.tsx
@@ -1,0 +1,148 @@
+/**
+ * FILE: frontend/components/dashboard/PipelineRow.tsx
+ * PURPOSE: Single pipeline row — left intent bar, rank, business name,
+ *          DM info, status badge. PR3 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.k-card`,
+ *            `.col-*` left-border colours, `.pipe-table` row styling.
+ */
+
+"use client";
+
+import type { PipelineProspect, PipelineStage } from "@/lib/hooks/usePipelineData";
+
+export type IntentTier = "struggling" | "trying" | "dabbling";
+
+const INTENT_COLOR: Record<IntentTier, string> = {
+  struggling: "var(--red)",     // immediate pain → highest urgency
+  trying:     "var(--amber)",   // active but underperforming
+  dabbling:   "#C9A88C",        // soft tan — light/exploratory
+};
+
+const STATUS_LABEL: Record<PipelineStage, { label: string; bg: string; fg: string }> = {
+  discovered: { label: "Discovered",     bg: "rgba(12,10,8,0.06)",    fg: "var(--ink-3)" },
+  enriched:   { label: "Enriched",       bg: "rgba(74,111,165,0.10)", fg: "var(--blue)" },
+  contacted:  { label: "Contacted",      bg: "rgba(74,111,165,0.14)", fg: "var(--blue)" },
+  replied:    { label: "Replied",        bg: "var(--amber-soft)",     fg: "var(--copper)" },
+  meeting:    { label: "Meeting Booked", bg: "rgba(107,142,90,0.16)", fg: "var(--green)" },
+  converted:  { label: "Won",            bg: "rgba(107,142,90,0.16)", fg: "var(--green)" },
+};
+
+/**
+ * Map a propensity score into the prototype's intent tier.
+ * TODO(api): replace with a server-side `intent_tier` once the BU
+ * detector exposes it directly. Today we infer from `score`.
+ */
+export function inferIntent(score: number | null | undefined): IntentTier {
+  if (score == null) return "dabbling";
+  if (score >= 70) return "struggling";   // hot — most pain
+  if (score >= 45) return "trying";        // mid
+  return "dabbling";
+}
+
+interface Props {
+  rank: number;
+  prospect: PipelineProspect & { suppressed?: boolean };
+  onClick?: (id: string) => void;
+}
+
+export function PipelineRow({ rank, prospect, onClick }: Props) {
+  const intent = inferIntent(prospect.score);
+  const status = prospect.suppressed
+    ? { label: "Suppressed", bg: "rgba(181,90,76,0.10)", fg: "var(--red)" }
+    : STATUS_LABEL[prospect.stage];
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onClick?.(prospect.id)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick?.(prospect.id);
+        }
+      }}
+      className="group grid items-center gap-4 rounded-[8px] border border-rule bg-panel hover:border-amber hover:shadow-[0_2px_10px_rgba(212,149,106,0.08)] transition-all px-4 py-3 cursor-pointer"
+      style={{
+        gridTemplateColumns: "4px 36px 1fr auto auto",
+        borderLeft: `4px solid ${INTENT_COLOR[intent]}`,
+        paddingLeft: 0,
+      }}
+    >
+      {/* Spacer for the inset border */}
+      <span aria-hidden className="block h-full" />
+
+      {/* Rank */}
+      <div className="font-mono text-[12px] tracking-[0.06em] text-ink-3 text-right">
+        {String(rank).padStart(2, "0")}
+      </div>
+
+      {/* Name + DM */}
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-display font-bold text-[15px] text-ink truncate">
+            {prospect.company || prospect.name}
+          </span>
+          {prospect.vrGrade && <Badge text={prospect.vrGrade} />}
+          {intent === "struggling" && (
+            <Badge text="HOT" tone="hot" title="High propensity — most pain signals" />
+          )}
+        </div>
+        <div className="font-mono text-[11px] text-ink-3 mt-0.5 truncate">
+          {prospect.name || "—"}
+          {prospect.lastChannel && (
+            <span className="text-ink-3"> · last via {prospect.lastChannel}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Score */}
+      <div className="font-mono text-[13px] font-semibold text-copper tabular-nums px-2 hidden sm:block">
+        {prospect.score ?? "—"}
+      </div>
+
+      {/* Status badge */}
+      <span
+        className="font-mono text-[10px] tracking-[0.1em] uppercase font-semibold px-2.5 py-[3px] rounded-full whitespace-nowrap"
+        style={{ backgroundColor: status.bg, color: status.fg }}
+      >
+        {status.label}
+      </span>
+    </div>
+  );
+}
+
+function Badge({
+  text, tone = "neutral", title,
+}: { text: string; tone?: "neutral" | "hot"; title?: string }) {
+  if (tone === "hot") {
+    return (
+      <span
+        title={title}
+        className="font-mono text-[9px] tracking-[0.14em] uppercase font-bold px-1.5 py-[1px] rounded"
+        style={{
+          color: "var(--red)",
+          backgroundColor: "rgba(181,90,76,0.10)",
+          border: "1px solid rgba(181,90,76,0.30)",
+        }}
+      >
+        {text}
+      </span>
+    );
+  }
+  return (
+    <span
+      className="font-display font-bold text-[10px] grid place-items-center w-5 h-5 rounded-[4px] text-white"
+      style={{
+        backgroundColor:
+          text === "A" || text === "B" ? "var(--green)" :
+          text === "C" ? "var(--amber)" :
+          text === "D" ? "var(--copper)" :
+          "var(--red)",
+        color: text === "C" ? "var(--on-amber)" : "white",
+      }}
+    >
+      {text}
+    </span>
+  );
+}

--- a/frontend/components/dashboard/PipelineStateTabs.tsx
+++ b/frontend/components/dashboard/PipelineStateTabs.tsx
@@ -1,0 +1,228 @@
+/**
+ * FILE: frontend/components/dashboard/PipelineStateTabs.tsx
+ * PURPOSE: Pipeline state-machine tab row — Review / Outreach /
+ *          Complete modes with mode-specific summaries (review counter,
+ *          outreach breakdown, completion countdown). PR3 dashboard rebuild.
+ *
+ * The three modes mirror the prototype's three pipeline phases:
+ *   Review  — operator gates which prospects to release
+ *   Outreach — Maya is actively running sequences
+ *   Complete — cycle finished, results posted, next cycle countdown
+ */
+
+"use client";
+
+import { useMemo } from "react";
+
+export type PipelineMode = "review" | "outreach" | "complete";
+
+interface ReviewProps {
+  mode: "review";
+  total: number;
+  reviewed: number;
+  onReleaseAll?: () => void;
+  releasing?: boolean;
+}
+
+interface OutreachProps {
+  mode: "outreach";
+  contacted: number;
+  replied: number;
+  meetingsBooked: number;
+}
+
+interface CompleteProps {
+  mode: "complete";
+  cycleNumber: number;
+  contacted: number;
+  replied: number;
+  meetingsBooked: number;
+  /** ISO timestamp at which the next cycle begins. */
+  nextCycleAt?: string | null;
+}
+
+type Props = ReviewProps | OutreachProps | CompleteProps;
+
+interface TabsProps {
+  mode: PipelineMode;
+  onChange: (mode: PipelineMode) => void;
+}
+
+/** Tab-row + content. Caller picks the visible mode and supplies data. */
+export function PipelineStateTabs(props: Props & TabsProps) {
+  return (
+    <section>
+      <TabRow active={props.mode} onChange={props.onChange} />
+
+      <div className="mt-4 rounded-[10px] border border-rule bg-panel p-5">
+        {props.mode === "review" && <ReviewBody {...props} />}
+        {props.mode === "outreach" && <OutreachBody {...props} />}
+        {props.mode === "complete" && <CompleteBody {...props} />}
+      </div>
+    </section>
+  );
+}
+
+function TabRow({
+  active, onChange,
+}: { active: PipelineMode; onChange: (m: PipelineMode) => void }) {
+  const tabs: Array<{ key: PipelineMode; label: string }> = [
+    { key: "review",   label: "Review" },
+    { key: "outreach", label: "Outreach" },
+    { key: "complete", label: "Complete" },
+  ];
+  return (
+    <div className="inline-flex p-[2px] rounded-md bg-surface">
+      {tabs.map(t => {
+        const isActive = t.key === active;
+        return (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => onChange(t.key)}
+            className={[
+              "px-3.5 py-1.5 font-mono text-[11px] tracking-[0.06em] rounded-[4px] uppercase transition-colors",
+              isActive
+                ? "bg-ink text-white font-semibold"
+                : "text-ink-3 hover:text-ink",
+            ].join(" ")}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Review mode ──────────────────────────────────────────────────────────
+
+function ReviewBody({ total, reviewed, onReleaseAll, releasing }: ReviewProps) {
+  const pct = total > 0 ? Math.round((reviewed / total) * 100) : 0;
+  const remaining = Math.max(0, total - reviewed);
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+        <h3 className="font-display font-bold text-[22px] text-ink leading-tight">
+          You have reviewed{" "}
+          <em className="text-amber" style={{ fontStyle: "italic" }}>
+            {reviewed}
+          </em>{" "}
+          <span className="text-ink-3">of {total}</span>
+        </h3>
+        <button
+          type="button"
+          onClick={onReleaseAll}
+          disabled={releasing || remaining === 0}
+          className="px-4 py-2 rounded-[6px] font-mono text-[11px] tracking-[0.08em] uppercase font-semibold transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+          style={{ backgroundColor: "var(--ink)", color: "white" }}
+        >
+          {releasing ? "Releasing…" : `Release All (${remaining})`}
+        </button>
+      </div>
+
+      <div
+        className="mt-3 h-1.5 w-full rounded-full overflow-hidden"
+        style={{ backgroundColor: "rgba(12,10,8,0.06)" }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-valuenow={reviewed}
+      >
+        <div
+          className="h-full transition-[width] duration-300"
+          style={{
+            width: `${pct}%`,
+            backgroundColor: "var(--amber)",
+          }}
+        />
+      </div>
+
+      <p className="mt-3 text-[13px] text-ink-2 leading-relaxed">
+        Each prospect waits in review until you release it — then Maya begins
+        outreach. No content sent yet.
+      </p>
+    </div>
+  );
+}
+
+// ─── Outreach mode ────────────────────────────────────────────────────────
+
+function OutreachBody({ contacted, replied, meetingsBooked }: OutreachProps) {
+  return (
+    <div>
+      <h3 className="font-display font-bold text-[22px] text-ink leading-tight">
+        Maya is <em className="text-amber" style={{ fontStyle: "italic" }}>working</em>
+      </h3>
+      <p className="text-[13px] text-ink-3 mt-1">
+        Sequences in flight. Numbers refresh every 5 minutes.
+      </p>
+
+      <div className="grid grid-cols-3 gap-4 mt-4 pt-4 border-t border-rule">
+        <Metric label="Contacted" value={contacted} />
+        <Metric label="Replied" value={replied} />
+        <Metric label="Booked" value={meetingsBooked} />
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <div className="font-display font-bold text-[24px] text-ink leading-none">
+        {value.toLocaleString()}
+      </div>
+      <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-ink-3 mt-1.5">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+// ─── Complete mode ────────────────────────────────────────────────────────
+
+function CompleteBody({
+  cycleNumber, contacted, replied, meetingsBooked, nextCycleAt,
+}: CompleteProps) {
+  const countdown = useNextCycleCountdown(nextCycleAt);
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+        <h3 className="font-display font-bold text-[22px] text-ink leading-tight">
+          Cycle <em className="text-amber" style={{ fontStyle: "italic" }}>{cycleNumber}</em>{" "}
+          <span className="text-ink-3">complete</span>
+        </h3>
+
+        {countdown && (
+          <div className="font-mono text-[11px] text-ink-3 tracking-[0.06em]">
+            Next cycle in <span className="text-copper font-semibold">{countdown}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 mt-4 pt-4 border-t border-rule">
+        <Metric label="Contacted" value={contacted} />
+        <Metric label="Replied" value={replied} />
+        <Metric label="Booked" value={meetingsBooked} />
+      </div>
+    </div>
+  );
+}
+
+function useNextCycleCountdown(nextCycleAt: string | null | undefined): string | null {
+  return useMemo(() => {
+    if (!nextCycleAt) return null;
+    const ts = Date.parse(nextCycleAt);
+    if (Number.isNaN(ts)) return null;
+    const diffMs = ts - Date.now();
+    if (diffMs <= 0) return "now";
+    const days = Math.floor(diffMs / (24 * 3600 * 1000));
+    const hours = Math.floor((diffMs % (24 * 3600 * 1000)) / (3600 * 1000));
+    if (days > 0) return `${days}d ${hours}h`;
+    const mins = Math.floor((diffMs % (3600 * 1000)) / 60000);
+    return `${hours}h ${mins}m`;
+  }, [nextCycleAt]);
+}

--- a/frontend/components/dashboard/ProspectDetailCard.tsx
+++ b/frontend/components/dashboard/ProspectDetailCard.tsx
@@ -1,0 +1,318 @@
+/**
+ * FILE: frontend/components/dashboard/ProspectDetailCard.tsx
+ * PURPOSE: Inline prospect briefing card — vulnerability text, A-F grade
+ *          strip (website / SEO / reviews / ads / social / content),
+ *          signal timeline (email/LinkedIn/voice/replies with quotes),
+ *          meeting info with booking countdown. PR3 dashboard rebuild.
+ *
+ * REFERENCE: dashboard-master-agency-desk.html — `.bf-section`,
+ *            `.vr-strip` / `.vr-letter`, `.event-card` / `.event-quote`,
+ *            drawer body builder at line ~1300.
+ *
+ * The existing ProspectDrawer renders inside a slide-over panel. This
+ * card is the inline equivalent for embedding directly in a page or
+ * within the drawer body — both surfaces share styling (per prototype's
+ * comment: "from drawer + briefing page so both surfaces stay
+ * consistent").
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import {
+  Mail, Linkedin, Phone, MessageSquare, MessageSquareReply, Calendar,
+} from "lucide-react";
+
+export type Grade = "A" | "B" | "C" | "D" | "F";
+
+export interface ProspectGrades {
+  website?: Grade;
+  seo?:     Grade;
+  reviews?: Grade;
+  ads?:     Grade;
+  social?:  Grade;
+  content?: Grade;
+}
+
+export type SignalKind =
+  | "email_sent" | "email_opened" | "email_replied"
+  | "linkedin_view" | "linkedin_invite" | "linkedin_message"
+  | "voice_call" | "voice_voicemail"
+  | "sms_sent" | "sms_replied"
+  | "meeting_booked";
+
+export interface ProspectSignal {
+  id: string;
+  kind: SignalKind;
+  at: string;          // ISO timestamp
+  headline: string;    // "Email opened — subject 'Quick question…'"
+  quote?: string;      // optional reply quote rendered as Playfair italic
+}
+
+export interface ProspectMeeting {
+  scheduledAt: string;   // ISO
+  durationMin?: number;
+  withName?: string;
+  joinUrl?: string;
+}
+
+export interface ProspectDetail {
+  id: string;
+  name: string;
+  company: string;
+  vulnerability?: string;
+  grades?: ProspectGrades;
+  signals?: ProspectSignal[];
+  meeting?: ProspectMeeting | null;
+}
+
+export function ProspectDetailCard({ prospect }: { prospect: ProspectDetail }) {
+  return (
+    <article className="rounded-[10px] border border-rule bg-panel p-5 sm:p-6 space-y-6">
+      <Header prospect={prospect} />
+
+      {prospect.vulnerability && (
+        <Section label="Vulnerability analysis">
+          <p className="text-[13px] text-ink-2 leading-relaxed">
+            {prospect.vulnerability}
+          </p>
+          {prospect.grades && <GradeStrip grades={prospect.grades} />}
+        </Section>
+      )}
+
+      {prospect.meeting && (
+        <Section label="Meeting">
+          <MeetingBlock meeting={prospect.meeting} />
+        </Section>
+      )}
+
+      {prospect.signals && prospect.signals.length > 0 && (
+        <Section label={`Signal timeline · ${prospect.signals.length} events`}>
+          <Timeline signals={prospect.signals} />
+        </Section>
+      )}
+    </article>
+  );
+}
+
+// ─── Header ────────────────────────────────────────────────────────────────
+
+function Header({ prospect }: { prospect: ProspectDetail }) {
+  return (
+    <div>
+      <h2 className="font-display font-bold text-[24px] text-ink leading-tight">
+        {prospect.company || prospect.name}
+      </h2>
+      {prospect.company && prospect.name && (
+        <div className="font-mono text-[11px] tracking-[0.06em] text-ink-3 mt-1">
+          {prospect.name}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Section wrapper — matches .bf-section h4 ──────────────────────────────
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h4
+        className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold pb-2 mb-3 border-b border-rule"
+      >
+        {label}
+      </h4>
+      {children}
+    </section>
+  );
+}
+
+// ─── A-F grade strip — matches .vr-strip / .vr-letter ──────────────────────
+
+const GRADE_BG: Record<Grade, { bg: string; fg: string }> = {
+  A: { bg: "var(--green)",  fg: "white" },
+  B: { bg: "var(--green)",  fg: "white" },
+  C: { bg: "var(--amber)",  fg: "var(--on-amber)" },
+  D: { bg: "var(--copper)", fg: "white" },
+  F: { bg: "var(--red)",    fg: "white" },
+};
+
+function GradeStrip({ grades }: { grades: ProspectGrades }) {
+  const order: Array<keyof ProspectGrades> = [
+    "website", "seo", "reviews", "ads", "social", "content",
+  ];
+  return (
+    <div className="flex flex-wrap gap-3 mt-4">
+      {order.map(k => {
+        const g = grades[k];
+        if (!g) return null;
+        const palette = GRADE_BG[g];
+        return (
+          <div key={k} className="flex flex-col items-center gap-1.5">
+            <div
+              className="w-[34px] h-[34px] rounded-[6px] grid place-items-center font-display font-bold text-[15px]"
+              style={{ backgroundColor: palette.bg, color: palette.fg }}
+            >
+              {g}
+            </div>
+            <span className="font-mono text-[10px] tracking-[0.06em] text-ink-3 capitalize">
+              {k}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Timeline — matches .event-card / .event-quote ─────────────────────────
+
+const SIGNAL_ICON: Record<SignalKind, {
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  bg: string;
+  color: string;
+  type: string;
+}> = {
+  email_sent:      { icon: Mail,               bg: "rgba(12,10,8,0.05)",     color: "var(--ink-3)", type: "Email · Sent" },
+  email_opened:    { icon: Mail,               bg: "var(--amber-soft)",      color: "var(--copper)", type: "Email · Opened" },
+  email_replied:   { icon: MessageSquareReply, bg: "rgba(107,142,90,0.16)",  color: "var(--green)", type: "Email · Replied" },
+  linkedin_view:   { icon: Linkedin,           bg: "rgba(74,111,165,0.14)",  color: "var(--blue)",  type: "LinkedIn · Profile view" },
+  linkedin_invite: { icon: Linkedin,           bg: "rgba(74,111,165,0.14)",  color: "var(--blue)",  type: "LinkedIn · Invite sent" },
+  linkedin_message:{ icon: Linkedin,           bg: "rgba(74,111,165,0.14)",  color: "var(--blue)",  type: "LinkedIn · Message" },
+  voice_call:      { icon: Phone,              bg: "rgba(196,106,62,0.14)",  color: "var(--copper)", type: "Voice · Call" },
+  voice_voicemail: { icon: Phone,              bg: "rgba(196,106,62,0.14)",  color: "var(--copper)", type: "Voice · Voicemail" },
+  sms_sent:        { icon: MessageSquare,      bg: "rgba(12,10,8,0.05)",     color: "var(--ink-3)", type: "SMS · Sent" },
+  sms_replied:     { icon: MessageSquareReply, bg: "rgba(107,142,90,0.16)",  color: "var(--green)", type: "SMS · Replied" },
+  meeting_booked:  { icon: Calendar,           bg: "rgba(74,111,165,0.14)",  color: "var(--blue)",  type: "Meeting · Booked" },
+};
+
+function Timeline({ signals }: { signals: ProspectSignal[] }) {
+  // Newest first
+  const sorted = [...signals].sort(
+    (a, b) => Date.parse(b.at) - Date.parse(a.at),
+  );
+  return (
+    <ol className="space-y-2.5">
+      {sorted.map(s => (
+        <SignalRow key={s.id} signal={s} />
+      ))}
+    </ol>
+  );
+}
+
+function SignalRow({ signal }: { signal: ProspectSignal }) {
+  const def = SIGNAL_ICON[signal.kind];
+  const Icon = def.icon;
+  const time = new Date(signal.at);
+  return (
+    <li className="grid gap-3 rounded-[10px] border border-rule bg-panel px-4 py-3.5"
+        style={{ gridTemplateColumns: "60px 38px 1fr" }}>
+      <div className="font-mono text-[10.5px] text-ink-3 pt-1 whitespace-nowrap">
+        {time.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+        <div className="opacity-70">
+          {time.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
+        </div>
+      </div>
+
+      <div
+        className="w-[38px] h-[38px] rounded-[10px] grid place-items-center"
+        style={{ backgroundColor: def.bg, color: def.color }}
+      >
+        <Icon className="w-4 h-4" strokeWidth={1.6} />
+      </div>
+
+      <div className="min-w-0">
+        <div className="font-mono text-[9.5px] tracking-[0.16em] uppercase font-semibold"
+             style={{ color: "var(--copper)" }}>
+          {def.type}
+        </div>
+        <div className="text-[14px] text-ink mt-0.5 leading-snug">
+          {signal.headline}
+        </div>
+        {signal.quote && (
+          <blockquote
+            className="mt-2 font-display italic text-[14px] text-ink-2 leading-snug py-2 px-3 rounded-[0_6px_6px_0]"
+            style={{
+              backgroundColor: "var(--surface)",
+              borderLeft: "3px solid var(--amber)",
+            }}
+          >
+            “{signal.quote}”
+          </blockquote>
+        )}
+      </div>
+    </li>
+  );
+}
+
+// ─── Meeting block — booking countdown ────────────────────────────────────
+
+function MeetingBlock({ meeting }: { meeting: ProspectMeeting }) {
+  const countdown = useMemo(() => {
+    const ts = Date.parse(meeting.scheduledAt);
+    if (Number.isNaN(ts)) return null;
+    const diffMs = ts - Date.now();
+    if (diffMs <= 0) return "in progress";
+    const days  = Math.floor(diffMs / (24 * 3600 * 1000));
+    const hours = Math.floor((diffMs % (24 * 3600 * 1000)) / (3600 * 1000));
+    const mins  = Math.floor((diffMs % (3600 * 1000)) / 60000);
+    if (days > 0) return `in ${days}d ${hours}h`;
+    if (hours > 0) return `in ${hours}h ${mins}m`;
+    return `in ${mins}m`;
+  }, [meeting.scheduledAt]);
+
+  const dt = new Date(meeting.scheduledAt);
+  const dateLabel = dt.toLocaleDateString(undefined, {
+    weekday: "long", month: "short", day: "numeric",
+  });
+  const timeLabel = dt.toLocaleTimeString(undefined, {
+    hour: "2-digit", minute: "2-digit",
+  });
+
+  return (
+    <div
+      className="rounded-[8px] p-4"
+      style={{
+        backgroundColor: "rgba(107,142,90,0.10)",
+        borderLeft: "3px solid var(--green)",
+      }}
+    >
+      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+        <div>
+          <div className="font-display font-bold text-[16px] text-ink">
+            {dateLabel}
+            <span className="text-ink-3"> · </span>
+            <span className="font-mono text-[14px]">{timeLabel}</span>
+          </div>
+          {meeting.withName && (
+            <div className="text-[12.5px] text-ink-2 mt-0.5">
+              with {meeting.withName}
+              {meeting.durationMin ? ` · ${meeting.durationMin} min` : ""}
+            </div>
+          )}
+        </div>
+
+        {countdown && (
+          <span
+            className="font-mono text-[11px] tracking-[0.08em] uppercase font-semibold"
+            style={{ color: "var(--green)" }}
+          >
+            {countdown}
+          </span>
+        )}
+      </div>
+
+      {meeting.joinUrl && (
+        <a
+          href={meeting.joinUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-3 font-mono text-[10px] tracking-[0.08em] uppercase font-semibold px-3 py-1.5 rounded-[4px]"
+          style={{ backgroundColor: "var(--ink)", color: "white" }}
+        >
+          Join meeting →
+        </a>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/SystemHealth.tsx
+++ b/frontend/components/dashboard/SystemHealth.tsx
@@ -1,0 +1,136 @@
+/**
+ * FILE: frontend/components/dashboard/SystemHealth.tsx
+ * PURPOSE: 4 channel health pills — Email Delivery / LinkedIn Queue /
+ *          Voice AI / SMS Gateway. Green/amber/red status dots.
+ *          PR2 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.tb-cycle .tb-dot`
+ *            (pulsing dot) + `.pill` colour scheme.
+ */
+
+"use client";
+
+import { Mail, Linkedin, Phone, MessageSquare } from "lucide-react";
+
+type HealthStatus = "ok" | "warn" | "error";
+
+interface ChannelHealth {
+  id: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  status: HealthStatus;
+  detail: string;     // short subtitle, e.g. "98.2% delivered"
+}
+
+const STATUS_COLOR: Record<HealthStatus, { bg: string; ring: string; text: string }> = {
+  ok:    { bg: "var(--green)", ring: "rgba(107,142,90,0.35)", text: "var(--green)" },
+  warn:  { bg: "var(--amber)", ring: "rgba(212,149,106,0.35)", text: "var(--copper)" },
+  error: { bg: "var(--red)",   ring: "rgba(181,90,76,0.35)",   text: "var(--red)" },
+};
+
+/**
+ * TODO(api): SystemHealth is currently mock-only. The backend has the
+ * raw signals needed (`distribution.email`, LinkedIn queue depth, voice
+ * provider status, telnyx SMS gateway) but no aggregated /api/v1/system-
+ * health endpoint exists yet. Each card below carries a `todo` flag so a
+ * follow-up PR can wire `useSystemHealth()` without changing the layout.
+ */
+function useSystemHealthMock(): ChannelHealth[] {
+  return [
+    {
+      id: "email",
+      label: "Email Delivery",
+      icon: Mail,
+      status: "ok",
+      detail: "98.2% delivered · last 24h",
+    },
+    {
+      id: "linkedin",
+      label: "LinkedIn Queue",
+      icon: Linkedin,
+      status: "warn",
+      detail: "Weekend slowdown · 12 queued",
+    },
+    {
+      id: "voice",
+      label: "Voice AI",
+      icon: Phone,
+      status: "ok",
+      detail: "VAPI healthy · 0 failures",
+    },
+    {
+      id: "sms",
+      label: "SMS Gateway",
+      icon: MessageSquare,
+      status: "ok",
+      detail: "Telnyx · 100% uptime",
+    },
+  ];
+}
+
+export function SystemHealth() {
+  const channels = useSystemHealthMock();
+
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-3">
+        <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold">
+          System Health
+        </div>
+        <span className="font-mono text-[8px] tracking-[0.12em] uppercase text-amber/80 bg-amber-soft border border-amber/30 rounded px-1.5 py-[1px]">
+          TODO · MOCK
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {channels.map(channel => (
+          <HealthPill key={channel.id} channel={channel} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function HealthPill({ channel }: { channel: ChannelHealth }) {
+  const Icon = channel.icon;
+  const palette = STATUS_COLOR[channel.status];
+  const labelText = {
+    ok: "Operational",
+    warn: "Degraded",
+    error: "Outage",
+  }[channel.status];
+
+  return (
+    <div className="rounded-[10px] border border-rule bg-panel px-4 py-3.5 flex items-start gap-3">
+      <Icon className="w-4 h-4 mt-0.5 text-ink-3 shrink-0" strokeWidth={1.6} />
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          {/* Status dot */}
+          <span className="relative flex w-2 h-2">
+            {channel.status === "ok" && (
+              <span
+                className="absolute inline-flex h-full w-full rounded-full opacity-60 animate-ping"
+                style={{ backgroundColor: palette.bg }}
+              />
+            )}
+            <span
+              className="relative inline-flex w-2 h-2 rounded-full"
+              style={{ backgroundColor: palette.bg, boxShadow: `0 0 0 3px ${palette.ring}` }}
+            />
+          </span>
+
+          <span className="font-mono text-[10px] tracking-[0.1em] uppercase font-semibold" style={{ color: palette.text }}>
+            {labelText}
+          </span>
+        </div>
+
+        <div className="text-[13px] text-ink mt-1.5 font-medium truncate">
+          {channel.label}
+        </div>
+        <div className="text-[11.5px] text-ink-3 mt-0.5 truncate">
+          {channel.detail}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
PR 3 of 4 — pipeline view (intent-bar rows, filter chips, state-machine tabs) + inline prospect briefing card. Cream/amber palette + Playfair Display headlines + JetBrains Mono labels carried over from PR #441 / #442.

## Acceptance criteria

### 1. Pipeline View — `PipelineRow.tsx`
- Left intent bar: **red (struggling) / amber (trying) / tan (dabbling)** — colour inferred from propensity score until backend exposes `intent_tier` directly
- Rank · Playfair company name · A-F vrGrade chip · HOT badge on struggling tier · DM/last-channel mono line · score · status badge
- Status badges: Discovered / Enriched / Contacted / Replied / Meeting Booked / Won / Suppressed (each with palette-correct background + foreground)
- Keyboard-activatable (Enter / Space)

### 2. Filter chips — `PipelineFilters.tsx`
Six options (All / Top 10 / Top 50 / Struggling / Trying / Dabbling) with prototype `.chip.active` styling (amber background + on-amber text + bold count).

### 3. Pipeline State Tabs — `PipelineStateTabs.tsx`
| Mode | Content |
|---|---|
| **Review** | "You have reviewed N of T" Playfair headline · amber progress bar · "Release All (remaining)" button |
| **Outreach** | "Maya is working" headline · 3-cell breakdown (contacted / replied / booked) |
| **Complete** | "Cycle N complete" · 3-cell breakdown · countdown to next cycle (computed from `nextCycleAt` ISO timestamp) |

### 4. Prospect Detail — `ProspectDetailCard.tsx`
Inline briefing card (drawer + page share styling per the prototype's `bf-section` pattern):
- Vulnerability analysis text + 6-cell A-F grade strip (website / SEO / reviews / ads / social / content) using prototype `.vr-letter` colours
- Signal timeline: 11 signal kinds (email/LinkedIn/voice/SMS/meeting) each with icon, mono date, mono uppercase type label, optional Playfair italic quote
- Meeting block with ISO-derived booking countdown (`in 2d 3h`), green accent border, optional Join URL button

## Pipeline route
- Three views toggled at the top: `list` (new) · `kanban` · `table`
- List view = ranked rows filtered by chip selection
- State tabs above the list, mode-specific content
- Filter chips below state tabs with live counts
- Existing kanban + table preserved (cream rebrand can come in PR4)

## Live data wiring (via `usePipelineData`)
- Total prospects, per-stage counts (contacted/replied/meeting/converted) → state-tab metrics + filter counts
- Intent tier inferred from `propensity_score` server-side already → mapped client-side via `inferIntent()`

## TODO(api) markers (not blocking)
- `cycle_number` / `cycle_length_days` / `next_cycle_at` on metrics endpoint
- Reviewed count + bulk Release All endpoint
- `intent_tier` directly on prospect rows
- Real signal-timeline endpoint feeding `ProspectDetailCard.signals`

## Test plan
- [x] `tsc --noEmit` — 4 errors before, 4 errors after (pre-existing in `lib/__tests__/useLiveActivityFeed.test.ts`)
- [x] Zero errors in any PR3 component
- [ ] Manual browser smoke after merge — list view shows intent-coloured rows; filter chips switch correctly; state-tab modes render their distinct content; prospect detail card shows grade strip + timeline correctly when wired with sample data

🤖 Generated with [Claude Code](https://claude.com/claude-code)