### PR TITLE
[ATLAS] feat: dashboard rebuild PR4 — mock unwiring + demo polish + agencyxos.ai/demo update

### DIFF
--- a/docs/DEMO_DRY_RUN_2026-04-28.md
+++ b/docs/DEMO_DRY_RUN_2026-04-28.md
@@ -1,0 +1,141 @@
+# Demo dry-run runbook — Dashboard rebuild PR4 (2026-04-28)
+
+Operator runbook for verifying the Dashboard rebuild end-to-end after PRs
+#441 (palette/sidebar), #442 (core components), #443 (pipeline view), and
+#444 (this PR — mock unwiring + demo polish).
+
+**Operator note:** the dry-run touches `clients`, `campaigns`, and
+`campaign_leads` rows. Clone Atlas does not have direct DB credentials in
+the Claude Code runtime; this script must be invoked from the operator's
+shell where `DATABASE_URL` / `SUPABASE_DB_URL` and the Supabase service
+key are loaded.
+
+## 1. Seed the demo tenant
+
+```bash
+cd /home/elliotbot/clawd/Agency_OS
+
+# Confirm dry-run output looks sane first.
+python3 scripts/seed_demo_tenant.py
+# Expected:
+#   demo client exists / created — id=…
+#   ensuring demo Supabase auth user (email=demo@keiracom.com)…
+#   selecting top 7 BU prospects (stage >= 6, propensity > 60, real email)…
+#   selected: 7 prospects   (or shortfall error if pool < 7)
+
+# Apply writes.
+python3 scripts/seed_demo_tenant.py --execute
+# Expected tail:
+#   demo campaign exists / created — id=…
+#   linked: 7 new campaign_leads rows
+#   demo_client_id: …
+#   demo_campaign_id: …
+```
+
+If `--execute` exits with `ERROR — only N of 7 target prospects passed all
+filters`, the BU pool is short of the curated tier. Triggers:
+
+- Run more enrichment to grow the candidate pool (Stage 9/10 funnel).
+- Or temporarily lower `MIN_PROPENSITY` in `scripts/seed_demo_tenant.py`
+  for a non-production demo (revert after capture).
+
+## 2. Confirm the auth path
+
+```bash
+# Auth user creation is idempotent. Re-running --execute is safe.
+# Verify the user exists via the Supabase admin API:
+curl -s "$SUPABASE_URL/auth/v1/admin/users?email=demo@keiracom.com" \
+  -H "apikey: $SUPABASE_SERVICE_KEY" \
+  -H "Authorization: Bearer $SUPABASE_SERVICE_KEY" | jq '.users[0].id'
+```
+
+Sign in at the dashboard route with:
+
+- email: `demo@keiracom.com`
+- password: `${DEMO_PASSWORD:-demo-investor-2026}`
+
+## 3. Pipeline View verification (PR3 + PR4)
+
+After signing in, open `/dashboard/pipeline`:
+
+- [ ] **Header** uses Playfair Display ("Pipeline, _ranked_") with amber
+      italic accent (PR1 palette)
+- [ ] **State tabs** render Review / Outreach / Complete; default mode is
+      Outreach showing live counts pulled from `usePipelineData`
+- [ ] **Filter chips**: All / Top 10 / Top 50 / Struggling / Trying /
+      Dabbling — counts add up to total
+- [ ] **List view** shows the 7 demo prospects ranked by score, each with
+      a left intent bar (red=struggling / amber=trying / tan=dabbling)
+- [ ] Active filter chip is amber-filled with on-amber text
+- [ ] Click any row → ProspectDrawer slides in (existing behaviour
+      preserved)
+- [ ] Toggle to `kanban` and `table` views — both still render
+
+## 4. Prospect Detail card (PR3)
+
+If the demo data has at least one prospect with grades, click that row to
+open the drawer. The new `ProspectDetailCard` component is available for
+embedding in any page; verify the grade strip + signal timeline render
+correctly when sample data is supplied:
+
+```tsx
+import { ProspectDetailCard } from "@/components/dashboard/ProspectDetailCard";
+
+<ProspectDetailCard prospect={{
+  id: "demo-1",
+  name: "Dr Sample",
+  company: "Demo Dental Clinic",
+  vulnerability: "No paid acquisition; weak SEO; reviews stale.",
+  grades: { website: "C", seo: "D", reviews: "F", ads: "F", social: "C", content: "B" },
+  signals: [
+    { id: "s1", kind: "email_sent", at: new Date().toISOString(), headline: "Email · Sent — opening hook" },
+    { id: "s2", kind: "email_replied", at: new Date(Date.now() - 3600_000).toISOString(),
+      headline: "Email · Replied", quote: "Very interested. We've been struggling with our online presence." },
+  ],
+  meeting: { scheduledAt: new Date(Date.now() + 2 * 86400_000).toISOString(), withName: "Dr Sample", durationMin: 30 },
+}} />
+```
+
+- [ ] A-F grade strip renders 6 colour-coded chips
+- [ ] Signal timeline shows mono date stamps + amber-bordered Playfair
+      italic quote blocks
+- [ ] Meeting block shows a green-bordered countdown ("in 2d Xh")
+
+## 5. Demo Mode banner (PR4)
+
+Set `IS_DEMO_MODE=true` (or seed the demo cookie) and reload `/dashboard`:
+
+- [ ] Banner sits at top with deep-ink background + amber `Demo Mode`
+      label + amber `Start Free Trial →` button
+- [ ] Dismiss button (×) clears the banner for the session
+- [ ] Banner palette matches the rest of the dashboard (no orange-gradient
+      legacy)
+
+## 6. Mock unwiring (PR4)
+
+On `/dashboard`:
+
+- [ ] Channel Orchestration slot shows a `TODO · MOCK` panel naming
+      `GET /api/v1/dashboard/touches?breakdown=channel`
+- [ ] Smart Calling slot shows a `TODO · MOCK` panel naming the voice
+      stats + recent calls endpoints
+- [ ] What's Working pane has the real `insight.detail` (when present)
+      and a `TODO · MOCK` sub-panel for the segment analytics endpoints
+- [ ] No fabricated numbers render in any of these slots
+
+## 7. agencyxos.ai/demo (Vercel marketing project)
+
+The static demo at `/demo` served from `frontend/landing/` is now the v10
+prototype `dashboard-master-agency-desk.html`. After the next Vercel
+deploy of the `frontend/landing/` project:
+
+- [ ] `https://agencyxos.ai/demo` serves the cream/amber Agency Desk
+      prototype (md5 matches `dashboard-master-agency-desk.html`)
+- [ ] Brand mark renders Playfair Display with amber italic `OS`
+- [ ] Sidebar is 232px dark with amber active borders
+
+## Sign-off
+
+When every checkbox is ticked, paste the Vercel deploy URL + a
+screenshot of `/dashboard` + `/dashboard/pipeline` into the dashboard
+rebuild thread.

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -40,6 +40,11 @@ import { TodayStrip } from "@/components/dashboard/TodayStrip";
 import { FunnelBar } from "@/components/dashboard/FunnelBar";
 import { AttentionCards } from "@/components/dashboard/AttentionCards";
 import { ProspectDrawer } from "@/components/dashboard/ProspectDrawer";
+// PR2 — dashboard rebuild core components (cream/amber palette, Playfair Display)
+import { CycleProgress } from "@/components/dashboard/CycleProgress";
+import { PerformanceMetrics } from "@/components/dashboard/PerformanceMetrics";
+import { HotReplies } from "@/components/dashboard/HotReplies";
+import { SystemHealth } from "@/components/dashboard/SystemHealth";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -92,6 +97,18 @@ export default function DashboardPage() {
         }}
       >
         <div className="relative z-10">
+          {/* PR2 — Cycle progress + performance + hot replies + health */}
+          <section className="mb-6 grid gap-5 lg:grid-cols-3">
+            <div className="lg:col-span-2 space-y-5">
+              <CycleProgress />
+              <PerformanceMetrics />
+              <SystemHealth />
+            </div>
+            <div className="lg:col-span-1">
+              <HotReplies />
+            </div>
+          </section>
+
           {/* v10 HOME SURFACES — BDR hero + today + funnel + attention */}
           <section className="mb-8 space-y-6">
             <HeroStrip />

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -26,12 +26,9 @@ import {
   TrendingUp,
   ArrowUpRight,
 } from "lucide-react";
-// TODO: wire channel-orchestration when API exposes per-channel touch counts
-import { mockChannelOrchestration } from "@/data/mock-dashboard";
-// TODO: wire smart-calling when voice AI call data API is available
-import { mockVoiceStats, mockRecentCalls } from "@/data/mock-dashboard";
-// TODO: wire what's-working insights (who-converts + best-channel-mix) when segment analytics API is available
-import { mockInsights } from "@/data/mock-dashboard";
+// PR4 — mock-data imports removed. The Channel Orchestration / Smart
+// Calling / What's Working slots now render a `TodoMockPanel` until
+// their endpoints exist. See ./TodoMockPanel.tsx + the JSX below.
 import { useLiveActivityFeed } from "@/lib/useLiveActivityFeed";
 import { providerLabel } from "@/lib/provider-labels";
 import { useDashboardV4 } from "@/hooks/use-dashboard-v4";
@@ -45,6 +42,8 @@ import { CycleProgress } from "@/components/dashboard/CycleProgress";
 import { PerformanceMetrics } from "@/components/dashboard/PerformanceMetrics";
 import { HotReplies } from "@/components/dashboard/HotReplies";
 import { SystemHealth } from "@/components/dashboard/SystemHealth";
+// PR4 — placeholder for slots whose backend endpoints don't exist yet
+import { TodoMockPanel } from "@/components/dashboard/TodoMockPanel";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -201,15 +200,17 @@ export default function DashboardPage() {
                 ))}
               </div>
 
-              {/* Channel Stats */}
-              <div className="grid grid-cols-5 gap-2">
-                {mockChannelOrchestration.channels.map((channel) => (
-                  <div key={channel.id} className="text-center p-3 bg-bg-elevated rounded-lg">
-                    <div className="text-lg font-bold font-mono text-text-primary">{channel.value}</div>
-                    <div className="text-[10px] text-text-muted uppercase mt-1 font-mono">{channel.label}</div>
-                  </div>
-                ))}
-              </div>
+              {/* Channel Stats — PR4: was mockChannelOrchestration */}
+              <TodoMockPanel
+                icon={<Zap className="w-4 h-4" strokeWidth={1.6} />}
+                eyebrow="Channel orchestration"
+                title="Per-channel touch counts not yet wired"
+                description="The hero ring above renders a fixed sample. Per-channel touch counts will populate when the metrics endpoint exposes a touches-by-channel breakdown."
+                endpointsNeeded={[
+                  "GET /api/v1/dashboard/touches?breakdown=channel",
+                  "fields: email_count, linkedin_count, sms_count, voice_count, mail_count",
+                ]}
+              />
             </GlassCard>
           </div>
 
@@ -285,73 +286,20 @@ export default function DashboardPage() {
               </div>
             </GlassCard>
 
-            {/* Smart Calling — TODO: wire smart-calling when voice AI call data API is available */}
-            <GlassCard className="p-0 overflow-hidden">
-              <div className="px-6 py-5 border-b border-border-subtle flex items-center justify-between">
-                <div className="flex items-center gap-2.5 text-sm font-semibold text-text-primary">
-                  <PhoneCall className="w-5 h-5 text-amber" strokeWidth={1.5} />
-                  Smart Calling
-                </div>
-                <div className="flex items-center gap-1.5 px-2.5 py-1 bg-amber-glow border border-amber/30 rounded-full text-xs font-mono font-medium text-amber">
-                  <div className="w-2 h-2 bg-amber rounded-full animate-pulse" />
-                  Active
-                </div>
-              </div>
-              <div className="p-6">
-                {/* Voice Stats */}
-                <div className="grid grid-cols-4 gap-3 mb-5">
-                  <div className="text-center p-4 bg-bg-elevated rounded-lg">
-                    <div className="text-2xl font-bold font-mono text-text-primary">{mockVoiceStats.calls}</div>
-                    <div className="text-[11px] text-text-muted mt-1 font-mono">Calls</div>
-                  </div>
-                  <div className="text-center p-4 bg-bg-elevated rounded-lg">
-                    <div className="text-2xl font-bold font-mono text-text-primary">{mockVoiceStats.connected}</div>
-                    <div className="text-[11px] text-text-muted mt-1 font-mono">Connect</div>
-                  </div>
-                  <div className="text-center p-4 bg-bg-elevated rounded-lg">
-                    <div className="text-2xl font-bold font-mono text-text-primary">{mockVoiceStats.booked}</div>
-                    <div className="text-[11px] text-text-muted mt-1 font-mono">Booked</div>
-                  </div>
-                  <div className="text-center p-4 bg-bg-elevated rounded-lg">
-                    <div className="text-2xl font-bold font-mono text-text-primary">{mockVoiceStats.rate}</div>
-                    <div className="text-[11px] text-text-muted mt-1 font-mono">Rate</div>
-                  </div>
-                </div>
+            {/* Smart Calling — PR4: was mockVoiceStats + mockRecentCalls */}
+            <TodoMockPanel
+              icon={<PhoneCall className="w-4 h-4" strokeWidth={1.6} />}
+              eyebrow="Smart calling"
+              title="Voice AI call data endpoint pending"
+              description="The voice channel runs through VAPI today, but no aggregated calls/connect/booked/rate endpoint exists yet. Recent calls + listen/transcript controls will land when this hook is added."
+              endpointsNeeded={[
+                "GET /api/v1/voice/stats?range=30d",
+                "GET /api/v1/voice/recent?limit=10",
+                "fields: calls, connected, booked, connect_rate, recent[{ name, outcome, summary, duration_s, recording_url, transcript_url }]",
+              ]}
+            />
 
-                {/* Recent Calls */}
-                {mockRecentCalls.map((call) => (
-                  <div key={call.id} className="flex items-start gap-3 py-3.5 border-b border-border-subtle last:border-0">
-                    <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${
-                      call.outcome === 'BOOKED' ? 'bg-amber-glow text-amber' : 'bg-bg-elevated text-text-secondary'
-                    }`}>
-                      {call.outcome === 'BOOKED' ? <CheckCircle2 className="w-4 h-4" /> : <Clock className="w-4 h-4" />}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm">
-                        <span className="font-semibold text-text-primary">{call.name}</span>
-                        <span className={`ml-2 text-xs font-mono font-medium ${
-                          call.outcome === 'BOOKED' ? 'text-amber' : 'text-text-secondary'
-                        }`}>
-                          {call.outcome}
-                        </span>
-                      </div>
-                      <div className="text-sm text-text-secondary mt-1">{call.summary}</div>
-                      <div className="flex gap-4 mt-2">
-                        <button className="text-xs text-amber flex items-center gap-1 hover:underline">
-                          <Play className="w-3 h-3" /> Listen
-                        </button>
-                        <button className="text-xs text-amber flex items-center gap-1 hover:underline">
-                          <FileText className="w-3 h-3" /> Transcript
-                        </button>
-                      </div>
-                    </div>
-                    <div className="text-sm text-text-muted font-mono">{call.duration}</div>
-                  </div>
-                ))}
-              </div>
-            </GlassCard>
-
-            {/* What's Working — TODO: wire who-converts + best-channel-mix when segment analytics API is available */}
+            {/* What's Working — PR4: insight is live, who-converts/channel-mix are mocks */}
             <GlassCard className="p-0 overflow-hidden">
               <div className="px-6 py-5 border-b border-border-subtle flex items-center justify-between">
                 <div className="flex items-center gap-2.5 text-sm font-semibold text-text-primary">
@@ -360,43 +308,31 @@ export default function DashboardPage() {
                 </div>
                 <span className="text-xs text-text-muted font-mono">Updated 2h ago</span>
               </div>
-              <div className="p-6">
-                {/* Insights Grid */}
-                <div className="grid grid-cols-2 gap-4 mb-5">
-                  <div className="bg-bg-elevated rounded-lg p-4">
-                    <div className="text-[11px] font-mono font-semibold uppercase tracking-wider text-text-muted mb-3">
-                      Who Converts
-                    </div>
-                    {mockInsights.whoConverts.map((item: { label: string; value: string }, i: number) => (
-                      <div key={i} className="flex justify-between items-center py-2">
-                        <span className="text-sm text-text-secondary">{item.label}</span>
-                        <span className="text-sm font-semibold font-mono text-amber">{item.value}</span>
-                      </div>
-                    ))}
-                  </div>
-                  <div className="bg-bg-elevated rounded-lg p-4">
-                    <div className="text-[11px] font-mono font-semibold uppercase tracking-wider text-text-muted mb-3">
-                      Best Channel Mix
-                    </div>
-                    {mockInsights.bestChannelMix.map((item: { label: string; value: string }, i: number) => (
-                      <div key={i} className="flex justify-between items-center py-2">
-                        <span className="text-sm text-text-secondary">{item.label}</span>
-                        <span className="text-sm font-semibold font-mono text-amber">{item.value}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+              <div className="p-6 space-y-5">
+                {/* Who-converts + channel-mix sub-panels — endpoints pending */}
+                <TodoMockPanel
+                  icon={<Lightbulb className="w-4 h-4" strokeWidth={1.6} />}
+                  eyebrow="Segment analytics"
+                  title="Who Converts + Best Channel Mix breakdowns pending"
+                  description="The segment analytics view requires a who-converts aggregation (industry / size buckets ranked by reply→meeting conversion) and a best-channel-mix aggregation (per-channel reply + meeting yield)."
+                  endpointsNeeded={[
+                    "GET /api/v1/insights/who-converts",
+                    "GET /api/v1/insights/channel-mix",
+                  ]}
+                />
 
-                {/* Discovery Banner — wired to useDashboardV4 insight */}
-                <div className="p-4 rounded-lg bg-amber-glow border border-amber/30">
-                  <div className="flex items-center gap-1.5 text-[11px] font-mono font-semibold uppercase tracking-wider text-amber mb-2">
-                    <Flame className="w-4 h-4" strokeWidth={1.5} />
-                    This Week's Discovery
+                {/* Discovery Banner — already wired to useDashboardV4 insight */}
+                {dashboardData?.insight.detail && (
+                  <div className="p-4 rounded-lg bg-amber-glow border border-amber/30">
+                    <div className="flex items-center gap-1.5 text-[11px] font-mono font-semibold uppercase tracking-wider text-amber mb-2">
+                      <Flame className="w-4 h-4" strokeWidth={1.5} />
+                      This Week's Discovery
+                    </div>
+                    <div className="text-sm text-text-primary leading-relaxed">
+                      {dashboardData.insight.detail}
+                    </div>
                   </div>
-                  <div className="text-sm text-text-primary leading-relaxed">
-                    {dashboardData?.insight.detail ?? mockInsights.discovery}
-                  </div>
-                </div>
+                )}
               </div>
             </GlassCard>
           </div>

--- a/frontend/app/dashboard/pipeline/page.tsx
+++ b/frontend/app/dashboard/pipeline/page.tsx
@@ -2,77 +2,208 @@
 
 /**
  * FILE: frontend/app/dashboard/pipeline/page.tsx
- * PURPOSE: Pipeline route — Kanban ↔ Table toggle over live Supabase prospect data
- * PHASE: PHASE-2.1-PIPELINE-MEETINGS
- *
- * Replaces the SSE stream view (preserved in git history at prior commits).
- * Uses usePipelineData for counts + prospect list.
+ * PURPOSE: Pipeline route — PR3 dashboard rebuild.
+ *          State-machine tabs (Review / Outreach / Complete) +
+ *          intent-bar prospect rows + filter chips.
+ *          Kanban / Table views preserved as alt views.
  */
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { AppShell } from "@/components/layout/AppShell";
 import { PipelineKanban } from "@/components/dashboard/PipelineKanban";
 import { PipelineTable } from "@/components/dashboard/PipelineTable";
 import { ProspectDrawer } from "@/components/dashboard/ProspectDrawer";
+import { PipelineRow, inferIntent } from "@/components/dashboard/PipelineRow";
+import {
+  PipelineFilters,
+  type PipelineFilterKey,
+} from "@/components/dashboard/PipelineFilters";
+import {
+  PipelineStateTabs,
+  type PipelineMode,
+} from "@/components/dashboard/PipelineStateTabs";
 import { usePipelineData } from "@/lib/hooks/usePipelineData";
 
-type View = "kanban" | "table";
+type View = "list" | "kanban" | "table";
 
 export default function PipelinePage() {
-  const [view, setView] = useState<View>("kanban");
+  const [view, setView] = useState<View>("list");
   const [activeLead, setActiveLead] = useState<string | null>(null);
+  const [filter, setFilter] = useState<PipelineFilterKey>("all");
+  const [mode, setMode] = useState<PipelineMode>("outreach");
   const { prospects, counts, isLoading } = usePipelineData();
 
+  // ─── Derived counts for filter chips + state tabs ───
+  const intentCounts = useMemo(() => {
+    let struggling = 0, trying = 0, dabbling = 0;
+    for (const p of prospects) {
+      const tier = inferIntent(p.score);
+      if (tier === "struggling") struggling++;
+      else if (tier === "trying") trying++;
+      else dabbling++;
+    }
+    return { struggling, trying, dabbling };
+  }, [prospects]);
+
+  // Filter + rank
+  const ranked = useMemo(() => {
+    const sorted = [...prospects].sort(
+      (a, b) => (b.score ?? 0) - (a.score ?? 0),
+    );
+    let filtered = sorted;
+    if (filter === "top10")      filtered = sorted.slice(0, 10);
+    else if (filter === "top50") filtered = sorted.slice(0, 50);
+    else if (filter === "struggling")
+      filtered = sorted.filter(p => inferIntent(p.score) === "struggling");
+    else if (filter === "trying")
+      filtered = sorted.filter(p => inferIntent(p.score) === "trying");
+    else if (filter === "dabbling")
+      filtered = sorted.filter(p => inferIntent(p.score) === "dabbling");
+    return filtered;
+  }, [prospects, filter]);
+
+  // State-tab metric inputs (live where possible)
   const total = prospects.length;
+  const reviewed = counts.discovered ? total - counts.discovered : total; // TODO(api): real reviewed count
+  const contactedCount = (counts.contacted ?? 0) + (counts.replied ?? 0) + (counts.meeting ?? 0) + (counts.converted ?? 0);
+  const repliedCount   = (counts.replied ?? 0)  + (counts.meeting ?? 0)  + (counts.converted ?? 0);
+  const meetingsCount  = (counts.meeting ?? 0)  + (counts.converted ?? 0);
 
   return (
     <AppShell pageTitle="Pipeline">
-      <div className="min-h-screen bg-gray-950 text-gray-100 p-4 md:p-6">
-        <header className="flex items-start md:items-center justify-between flex-col md:flex-row gap-3 mb-4">
+      <div className="px-4 md:px-6 py-6 space-y-6">
+        {/* Header */}
+        <header className="flex items-start md:items-center justify-between flex-col md:flex-row gap-3">
           <div>
-            <h1 className="font-serif text-2xl md:text-3xl text-gray-100">
-              Pipeline
+            <h1 className="font-display font-bold text-[28px] text-ink leading-tight tracking-[-0.02em]">
+              Pipeline,{" "}
+              <em className="text-amber" style={{ fontStyle: "italic" }}>
+                ranked
+              </em>
             </h1>
-            <p className="text-sm text-gray-400">
-              {total} {total === 1 ? "prospect" : "prospects"} across six stages
+            <p className="text-[13px] text-ink-3 mt-1">
+              {total} {total === 1 ? "prospect" : "prospects"} across the cycle ·
+              click any row for the briefing card.
             </p>
           </div>
-          <div className="inline-flex rounded-lg border border-gray-800 bg-gray-900 p-0.5">
-            {(["kanban", "table"] as View[]).map((v) => (
-              <button
-                key={v}
-                onClick={() => setView(v)}
-                className={`px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md ${
-                  view === v
-                    ? "bg-amber-500/10 text-amber-300 border border-amber-500/40"
-                    : "text-gray-400 hover:text-gray-200"
-                }`}
-              >
-                {v}
-              </button>
-            ))}
+
+          {/* View toggle */}
+          <div className="inline-flex p-[2px] rounded-md bg-surface">
+            {(["list", "kanban", "table"] as View[]).map(v => {
+              const isActive = v === view;
+              return (
+                <button
+                  key={v}
+                  onClick={() => setView(v)}
+                  className={[
+                    "px-3.5 py-1.5 font-mono text-[11px] tracking-[0.06em] rounded-[4px] uppercase transition-colors",
+                    isActive
+                      ? "bg-ink text-white font-semibold"
+                      : "text-ink-3 hover:text-ink",
+                  ].join(" ")}
+                >
+                  {v}
+                </button>
+              );
+            })}
           </div>
         </header>
 
-        {view === "kanban" ? (
+        {/* State-machine tabs */}
+        <PipelineStateTabs
+          mode={mode}
+          onChange={setMode}
+          {...(mode === "review"
+            ? {
+                mode: "review" as const,
+                total,
+                reviewed,
+                onReleaseAll: () => {/* TODO(api): wire batch-release endpoint */},
+              }
+            : mode === "outreach"
+            ? {
+                mode: "outreach" as const,
+                contacted: contactedCount,
+                replied:   repliedCount,
+                meetingsBooked: meetingsCount,
+              }
+            : {
+                mode: "complete" as const,
+                cycleNumber: 1, // TODO(api): real cycle number from metrics
+                contacted: contactedCount,
+                replied:   repliedCount,
+                meetingsBooked: meetingsCount,
+                nextCycleAt: null, // TODO(api): real next-cycle ISO timestamp
+              })}
+        />
+
+        {/* Filter chips */}
+        <PipelineFilters
+          active={filter}
+          onChange={setFilter}
+          options={[
+            { key: "all",        label: "All",        count: total },
+            { key: "top10",      label: "Top 10",     count: Math.min(10, total) },
+            { key: "top50",      label: "Top 50",     count: Math.min(50, total) },
+            { key: "struggling", label: "Struggling", count: intentCounts.struggling },
+            { key: "trying",     label: "Trying",     count: intentCounts.trying },
+            { key: "dabbling",   label: "Dabbling",   count: intentCounts.dabbling },
+          ]}
+        />
+
+        {/* Body — list / kanban / table */}
+        {view === "list" && (
+          <div className="space-y-2">
+            {isLoading ? (
+              <div className="rounded-[10px] border border-dashed border-rule bg-surface/50 px-5 py-6 text-[13px] text-ink-3">
+                Loading prospects…
+              </div>
+            ) : ranked.length === 0 ? (
+              <div className="rounded-[10px] border border-dashed border-rule bg-surface/50 px-5 py-6 text-[13px] text-ink-3">
+                No prospects match this filter yet.
+              </div>
+            ) : (
+              ranked.map((p, i) => (
+                <PipelineRow
+                  key={p.id}
+                  rank={i + 1}
+                  prospect={p}
+                  onClick={(id) => setActiveLead(id)}
+                />
+              ))
+            )}
+          </div>
+        )}
+
+        {view === "kanban" && (
           <PipelineKanban
-            prospects={prospects}
+            prospects={ranked}
             counts={counts}
-            onOpen={(id) => setActiveLead(id)}
-            isLoading={isLoading}
-          />
-        ) : (
-          <PipelineTable
-            prospects={prospects}
             onOpen={(id) => setActiveLead(id)}
             isLoading={isLoading}
           />
         )}
 
-        <nav className="mt-6 text-xs text-gray-500 font-mono flex gap-3">
-          <Link href="/dashboard" className="hover:text-gray-300">← Home</Link>
-          <Link href="/dashboard/meetings" className="hover:text-gray-300">Meetings →</Link>
+        {view === "table" && (
+          <PipelineTable
+            prospects={ranked}
+            onOpen={(id) => setActiveLead(id)}
+            isLoading={isLoading}
+          />
+        )}
+
+        {/* Footer nav */}
+        <nav className="text-[11px] font-mono text-ink-3 flex gap-3 pt-4 border-t border-rule">
+          <Link href="/dashboard" className="hover:text-copper transition-colors">
+            ← Home
+          </Link>
+          <Link
+            href="/dashboard/meetings"
+            className="hover:text-copper transition-colors"
+          >
+            Meetings →
+          </Link>
         </nav>
       </div>
 

--- a/frontend/components/dashboard/CycleProgress.tsx
+++ b/frontend/components/dashboard/CycleProgress.tsx
@@ -1,0 +1,125 @@
+/**
+ * FILE: frontend/components/dashboard/CycleProgress.tsx
+ * PURPOSE: "Day X of 30" cycle progress card — progress bar +
+ *          contacted / replies / meetings counts. PR2 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.bdr-hero` +
+ *            `MAYA · DAY 14/30` cycle indicator combined into one card.
+ */
+
+"use client";
+
+import { useDashboardV4 } from "@/hooks/use-dashboard-v4";
+
+const CYCLE_LENGTH_DAYS = 30;
+
+interface CycleProgressData {
+  currentDay: number;            // 1..30
+  contacted: number;
+  replies: number;
+  meetings: number;
+}
+
+/**
+ * Pull cycle data from useDashboardV4. The V4 hook does not yet return a
+ * cycle_day field — use the calendar day-of-month (1..30) modulo 30 as a
+ * stand-in until the backend exposes a real cycle origin.
+ *
+ * TODO(api): wire to a real cycle_day from `meetings_metrics_v4` once the
+ * backend tracks cycle start. Until then this is approximate.
+ */
+function useCycleProgress(): { data: CycleProgressData; loading: boolean } {
+  const { data, isLoading } = useDashboardV4();
+
+  // TODO(api): replace with metrics.cycle_day once backend exposes it.
+  const today = new Date();
+  const dayOfMonth = today.getDate();
+  const currentDay = Math.min(CYCLE_LENGTH_DAYS, Math.max(1, dayOfMonth));
+
+  const contacted = pickQuickStat(data?.quickStats ?? [], ["contacted", "prospects"]);
+  const replies   = pickQuickStat(data?.quickStats ?? [], ["replies", "reply"]);
+  const meetings  = data?.meetingsGoal?.current ?? 0;
+
+  return {
+    data: { currentDay, contacted, replies, meetings },
+    loading: isLoading,
+  };
+}
+
+function pickQuickStat(
+  stats: Array<{ label: string; value: string | number }>,
+  needles: string[],
+): number {
+  for (const s of stats) {
+    const lbl = (s.label || "").toLowerCase();
+    if (needles.some(n => lbl.includes(n))) {
+      const num = typeof s.value === "number" ? s.value : parseInt(String(s.value).replace(/[^\d]/g, ""), 10);
+      if (!Number.isNaN(num)) return num;
+    }
+  }
+  return 0;
+}
+
+export function CycleProgress() {
+  const { data: c, loading } = useCycleProgress();
+  const pct = Math.round((c.currentDay / CYCLE_LENGTH_DAYS) * 100);
+
+  return (
+    <section className="rounded-[10px] border border-rule bg-panel p-5 sm:p-6">
+      {/* Eyebrow + day label */}
+      <div className="flex items-baseline justify-between gap-4">
+        <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold">
+          Cycle Progress
+        </div>
+        <div className="font-mono text-[11px] text-ink-3 tracking-[0.06em]">
+          {loading ? "—" : `${CYCLE_LENGTH_DAYS - c.currentDay} days remaining`}
+        </div>
+      </div>
+
+      {/* Headline — Playfair with amber italic accent */}
+      <h2 className="font-display font-bold text-[28px] text-ink leading-[1.15] tracking-[-0.02em] mt-2">
+        Day <em className="text-amber not-italic" style={{ fontStyle: "italic" }}>{c.currentDay}</em>
+        <span className="text-ink-3"> of {CYCLE_LENGTH_DAYS}</span>
+      </h2>
+
+      {/* Progress bar */}
+      <div
+        className="mt-4 h-2 w-full rounded-full overflow-hidden"
+        style={{ backgroundColor: "rgba(12,10,8,0.06)" }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={CYCLE_LENGTH_DAYS}
+        aria-valuenow={c.currentDay}
+      >
+        <div
+          className="h-full transition-[width] duration-500 ease-out"
+          style={{
+            width: `${pct}%`,
+            background: "linear-gradient(90deg, var(--amber) 0%, var(--copper) 100%)",
+          }}
+        />
+      </div>
+
+      {/* Counts row — 3 cells */}
+      <div className="grid grid-cols-3 gap-4 mt-5 pt-5 border-t border-rule">
+        <CycleCell label="Contacted" value={c.contacted} loading={loading} />
+        <CycleCell label="Replies"    value={c.replies}    loading={loading} />
+        <CycleCell label="Meetings"   value={c.meetings}   loading={loading} />
+      </div>
+    </section>
+  );
+}
+
+function CycleCell({
+  label, value, loading,
+}: { label: string; value: number; loading: boolean }) {
+  return (
+    <div>
+      <div className="font-display font-bold text-[24px] text-ink leading-none">
+        {loading ? "—" : value.toLocaleString()}
+      </div>
+      <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-ink-3 mt-1.5">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/HotReplies.tsx
+++ b/frontend/components/dashboard/HotReplies.tsx
@@ -1,0 +1,122 @@
+/**
+ * FILE: frontend/components/dashboard/HotReplies.tsx
+ * PURPOSE: Recent prospect responses with amber heat dots — PR2 rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.attention-card.reply`
+ *            + warm-reply preview list patterns.
+ */
+
+"use client";
+
+import { useDashboardV4, type WarmReply } from "@/hooks/use-dashboard-v4";
+import Link from "next/link";
+
+/**
+ * Heat tier — drives how many amber dots render on the card. Until the
+ * backend exposes a per-reply heat score we infer it from preview length
+ * + name presence (longer, more personal previews → hotter).
+ *
+ * TODO(api): replace `inferHeat` with a real heat score from the warm
+ * replies endpoint once `lead_heat_score` is added to the response.
+ */
+function inferHeat(reply: WarmReply): 1 | 2 | 3 {
+  const len = (reply.preview || "").length;
+  if (len >= 140) return 3;
+  if (len >= 70)  return 2;
+  return 1;
+}
+
+export function HotReplies() {
+  const { data, isLoading } = useDashboardV4();
+  const replies = data?.warmReplies ?? [];
+
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-3">
+        <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold">
+          Hot Replies
+        </div>
+        <Link
+          href="/dashboard/replies"
+          className="font-mono text-[10px] tracking-[0.08em] uppercase text-copper hover:text-amber transition-colors"
+        >
+          View all →
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-[10px] border border-dashed border-rule bg-surface/50 px-5 py-4 text-[13px] text-ink-3">
+          Loading replies…
+        </div>
+      ) : replies.length === 0 ? (
+        <div className="rounded-[10px] border border-dashed border-rule bg-surface/50 px-5 py-4 text-[13px] text-ink-3">
+          <b className="text-ink">No hot replies yet</b> — new responses will surface here.
+        </div>
+      ) : (
+        <div className="grid gap-2.5">
+          {replies.slice(0, 5).map(reply => (
+            <HotReplyCard key={reply.id} reply={reply} heat={inferHeat(reply)} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function HotReplyCard({ reply, heat }: { reply: WarmReply; heat: 1 | 2 | 3 }) {
+  return (
+    <Link
+      href={`/dashboard/leads/${reply.leadId}`}
+      className="block rounded-[10px] border border-rule bg-panel hover:border-amber hover:shadow-[0_2px_10px_rgba(212,149,106,0.10)] transition-all px-4 py-3.5"
+    >
+      <div className="flex items-start gap-3">
+        {/* Avatar */}
+        <div
+          className="w-9 h-9 rounded-full grid place-items-center text-[12px] font-display font-bold shrink-0"
+          style={{ backgroundColor: "var(--amber)", color: "var(--on-amber)" }}
+        >
+          {reply.initials}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-[13px] text-ink font-medium truncate">
+              {reply.name}
+              {reply.company && (
+                <span className="text-ink-3 font-normal"> · {reply.company}</span>
+              )}
+            </div>
+
+            {/* Heat dots */}
+            <HeatDots heat={heat} />
+          </div>
+
+          <div className="text-[12.5px] text-ink-2 mt-1 line-clamp-2 leading-snug">
+            {reply.preview}
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function HeatDots({ heat }: { heat: 1 | 2 | 3 }) {
+  return (
+    <div
+      className="flex items-center gap-[3px] shrink-0"
+      title={`${heat === 3 ? "Very hot" : heat === 2 ? "Hot" : "Warm"} reply`}
+      aria-label={`${heat} of 3 heat dots`}
+    >
+      {[1, 2, 3].map(i => (
+        <span
+          key={i}
+          className="block w-[7px] h-[7px] rounded-full"
+          style={{
+            backgroundColor:
+              i <= heat ? "var(--amber)" : "rgba(12,10,8,0.10)",
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/PerformanceMetrics.tsx
+++ b/frontend/components/dashboard/PerformanceMetrics.tsx
@@ -1,0 +1,119 @@
+/**
+ * FILE: frontend/components/dashboard/PerformanceMetrics.tsx
+ * PURPOSE: 4-column performance grid — Open Rate / Reply Rate /
+ *          Meeting Rate / Avg Reply Time. PR2 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.sum-row` /
+ *            `.sum-card` / `.sum-val` / `.sum-label` styling.
+ */
+
+"use client";
+
+import { useDashboardV4 } from "@/hooks/use-dashboard-v4";
+
+interface MetricCard {
+  id: string;
+  value: string;            // formatted display value
+  unit?: string;             // amber suffix (em accent in prototype)
+  label: string;             // mono uppercase
+  delta?: string;            // small green/ink-3 line under the label
+  todo?: boolean;            // when true, source is mocked — flag in UI
+}
+
+export function PerformanceMetrics() {
+  const { data, isLoading } = useDashboardV4();
+
+  // TODO(api): the V4 metrics endpoint exposes show_rate + meetings_*,
+  // but does not yet return open_rate / reply_rate / avg_reply_time
+  // directly. When `meetings_metrics_v4` is extended these constants
+  // become real reads — until then we surface conservative placeholders
+  // for the prototype layout, marked with `todo: true` so the UI
+  // displays a small TODO badge.
+  const cards: MetricCard[] = [
+    {
+      id: "open",
+      value: "—",
+      unit: "%",
+      label: "Open Rate",
+      delta: "endpoint pending",
+      todo: true,
+    },
+    {
+      id: "reply",
+      value: "—",
+      unit: "%",
+      label: "Reply Rate",
+      delta: "endpoint pending",
+      todo: true,
+    },
+    {
+      id: "meeting",
+      value: data?.meetingsGoal?.target
+        ? `${Math.round(((data?.meetingsGoal?.current ?? 0) / data.meetingsGoal.target) * 100)}`
+        : "—",
+      unit: "%",
+      label: "Meeting Rate",
+      delta:
+        data?.meetingsGoal
+          ? `${data.meetingsGoal.current}/${data.meetingsGoal.target} this cycle`
+          : undefined,
+    },
+    {
+      id: "avg-reply",
+      value: "—",
+      unit: "h",
+      label: "Avg Reply Time",
+      delta: "endpoint pending",
+      todo: true,
+    },
+  ];
+
+  return (
+    <section>
+      <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold mb-3">
+        Performance
+      </div>
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3.5">
+        {cards.map(c => (
+          <SumCard key={c.id} card={c} loading={isLoading} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SumCard({ card, loading }: { card: MetricCard; loading: boolean }) {
+  return (
+    <div className="rounded-[10px] border border-rule bg-panel px-[18px] py-4 relative">
+      {card.todo && (
+        <span className="absolute top-2 right-2 font-mono text-[8px] tracking-[0.12em] uppercase text-amber/80 bg-amber-soft border border-amber/30 rounded px-1.5 py-[1px]">
+          TODO
+        </span>
+      )}
+
+      {/* Value — Playfair 28px with amber em accent for the unit */}
+      <div className="font-display font-bold text-[28px] leading-none text-ink">
+        {loading ? "—" : card.value}
+        {card.unit && (
+          <em
+            className="not-italic font-bold text-[18px] text-amber ml-0.5"
+            style={{ fontStyle: "normal" }}
+          >
+            {card.unit}
+          </em>
+        )}
+      </div>
+
+      {/* Label — JetBrains Mono uppercase */}
+      <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-ink-3 mt-1.5">
+        {card.label}
+      </div>
+
+      {/* Delta — small mono line beneath the label */}
+      {card.delta && (
+        <div className="font-mono text-[11px] text-green mt-1">
+          {card.delta}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/PipelineFilters.tsx
+++ b/frontend/components/dashboard/PipelineFilters.tsx
@@ -1,0 +1,64 @@
+/**
+ * FILE: frontend/components/dashboard/PipelineFilters.tsx
+ * PURPOSE: Filter chip row — Top 10 / Top 50 / Struggling / Trying /
+ *          Dabbling. PR3 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.chip` /
+ *            `.chip.active` / `.chip-count` styling.
+ */
+
+"use client";
+
+export type PipelineFilterKey =
+  | "all"
+  | "top10"
+  | "top50"
+  | "struggling"
+  | "trying"
+  | "dabbling";
+
+export interface PipelineFilterOption {
+  key: PipelineFilterKey;
+  label: string;
+  count: number;
+}
+
+interface Props {
+  options: PipelineFilterOption[];
+  active: PipelineFilterKey;
+  onChange: (key: PipelineFilterKey) => void;
+}
+
+export function PipelineFilters({ options, active, onChange }: Props) {
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {options.map(opt => {
+        const isActive = opt.key === active;
+        return (
+          <button
+            key={opt.key}
+            type="button"
+            onClick={() => onChange(opt.key)}
+            className={[
+              "px-3.5 py-1.5 rounded-full font-mono text-[11px] tracking-[0.06em] border transition-colors",
+              isActive
+                ? "bg-amber border-amber font-semibold"
+                : "bg-panel border-rule text-ink-3 hover:text-copper hover:border-amber",
+            ].join(" ")}
+            style={isActive ? { color: "var(--on-amber)" } : undefined}
+          >
+            {opt.label}
+            <span
+              className={[
+                "ml-1.5 font-bold",
+                isActive ? "" : "text-copper",
+              ].join(" ")}
+              style={isActive ? { color: "var(--on-amber)" } : undefined}
+            >
+              {opt.count}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/PipelineRow.tsx
+++ b/frontend/components/dashboard/PipelineRow.tsx
@@ -1,0 +1,148 @@
+/**
+ * FILE: frontend/components/dashboard/PipelineRow.tsx
+ * PURPOSE: Single pipeline row — left intent bar, rank, business name,
+ *          DM info, status badge. PR3 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.k-card`,
+ *            `.col-*` left-border colours, `.pipe-table` row styling.
+ */
+
+"use client";
+
+import type { PipelineProspect, PipelineStage } from "@/lib/hooks/usePipelineData";
+
+export type IntentTier = "struggling" | "trying" | "dabbling";
+
+const INTENT_COLOR: Record<IntentTier, string> = {
+  struggling: "var(--red)",     // immediate pain → highest urgency
+  trying:     "var(--amber)",   // active but underperforming
+  dabbling:   "#C9A88C",        // soft tan — light/exploratory
+};
+
+const STATUS_LABEL: Record<PipelineStage, { label: string; bg: string; fg: string }> = {
+  discovered: { label: "Discovered",     bg: "rgba(12,10,8,0.06)",    fg: "var(--ink-3)" },
+  enriched:   { label: "Enriched",       bg: "rgba(74,111,165,0.10)", fg: "var(--blue)" },
+  contacted:  { label: "Contacted",      bg: "rgba(74,111,165,0.14)", fg: "var(--blue)" },
+  replied:    { label: "Replied",        bg: "var(--amber-soft)",     fg: "var(--copper)" },
+  meeting:    { label: "Meeting Booked", bg: "rgba(107,142,90,0.16)", fg: "var(--green)" },
+  converted:  { label: "Won",            bg: "rgba(107,142,90,0.16)", fg: "var(--green)" },
+};
+
+/**
+ * Map a propensity score into the prototype's intent tier.
+ * TODO(api): replace with a server-side `intent_tier` once the BU
+ * detector exposes it directly. Today we infer from `score`.
+ */
+export function inferIntent(score: number | null | undefined): IntentTier {
+  if (score == null) return "dabbling";
+  if (score >= 70) return "struggling";   // hot — most pain
+  if (score >= 45) return "trying";        // mid
+  return "dabbling";
+}
+
+interface Props {
+  rank: number;
+  prospect: PipelineProspect & { suppressed?: boolean };
+  onClick?: (id: string) => void;
+}
+
+export function PipelineRow({ rank, prospect, onClick }: Props) {
+  const intent = inferIntent(prospect.score);
+  const status = prospect.suppressed
+    ? { label: "Suppressed", bg: "rgba(181,90,76,0.10)", fg: "var(--red)" }
+    : STATUS_LABEL[prospect.stage];
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onClick?.(prospect.id)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick?.(prospect.id);
+        }
+      }}
+      className="group grid items-center gap-4 rounded-[8px] border border-rule bg-panel hover:border-amber hover:shadow-[0_2px_10px_rgba(212,149,106,0.08)] transition-all px-4 py-3 cursor-pointer"
+      style={{
+        gridTemplateColumns: "4px 36px 1fr auto auto",
+        borderLeft: `4px solid ${INTENT_COLOR[intent]}`,
+        paddingLeft: 0,
+      }}
+    >
+      {/* Spacer for the inset border */}
+      <span aria-hidden className="block h-full" />
+
+      {/* Rank */}
+      <div className="font-mono text-[12px] tracking-[0.06em] text-ink-3 text-right">
+        {String(rank).padStart(2, "0")}
+      </div>
+
+      {/* Name + DM */}
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-display font-bold text-[15px] text-ink truncate">
+            {prospect.company || prospect.name}
+          </span>
+          {prospect.vrGrade && <Badge text={prospect.vrGrade} />}
+          {intent === "struggling" && (
+            <Badge text="HOT" tone="hot" title="High propensity — most pain signals" />
+          )}
+        </div>
+        <div className="font-mono text-[11px] text-ink-3 mt-0.5 truncate">
+          {prospect.name || "—"}
+          {prospect.lastChannel && (
+            <span className="text-ink-3"> · last via {prospect.lastChannel}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Score */}
+      <div className="font-mono text-[13px] font-semibold text-copper tabular-nums px-2 hidden sm:block">
+        {prospect.score ?? "—"}
+      </div>
+
+      {/* Status badge */}
+      <span
+        className="font-mono text-[10px] tracking-[0.1em] uppercase font-semibold px-2.5 py-[3px] rounded-full whitespace-nowrap"
+        style={{ backgroundColor: status.bg, color: status.fg }}
+      >
+        {status.label}
+      </span>
+    </div>
+  );
+}
+
+function Badge({
+  text, tone = "neutral", title,
+}: { text: string; tone?: "neutral" | "hot"; title?: string }) {
+  if (tone === "hot") {
+    return (
+      <span
+        title={title}
+        className="font-mono text-[9px] tracking-[0.14em] uppercase font-bold px-1.5 py-[1px] rounded"
+        style={{
+          color: "var(--red)",
+          backgroundColor: "rgba(181,90,76,0.10)",
+          border: "1px solid rgba(181,90,76,0.30)",
+        }}
+      >
+        {text}
+      </span>
+    );
+  }
+  return (
+    <span
+      className="font-display font-bold text-[10px] grid place-items-center w-5 h-5 rounded-[4px] text-white"
+      style={{
+        backgroundColor:
+          text === "A" || text === "B" ? "var(--green)" :
+          text === "C" ? "var(--amber)" :
+          text === "D" ? "var(--copper)" :
+          "var(--red)",
+        color: text === "C" ? "var(--on-amber)" : "white",
+      }}
+    >
+      {text}
+    </span>
+  );
+}

--- a/frontend/components/dashboard/PipelineStateTabs.tsx
+++ b/frontend/components/dashboard/PipelineStateTabs.tsx
@@ -1,0 +1,228 @@
+/**
+ * FILE: frontend/components/dashboard/PipelineStateTabs.tsx
+ * PURPOSE: Pipeline state-machine tab row — Review / Outreach /
+ *          Complete modes with mode-specific summaries (review counter,
+ *          outreach breakdown, completion countdown). PR3 dashboard rebuild.
+ *
+ * The three modes mirror the prototype's three pipeline phases:
+ *   Review  — operator gates which prospects to release
+ *   Outreach — Maya is actively running sequences
+ *   Complete — cycle finished, results posted, next cycle countdown
+ */
+
+"use client";
+
+import { useMemo } from "react";
+
+export type PipelineMode = "review" | "outreach" | "complete";
+
+interface ReviewProps {
+  mode: "review";
+  total: number;
+  reviewed: number;
+  onReleaseAll?: () => void;
+  releasing?: boolean;
+}
+
+interface OutreachProps {
+  mode: "outreach";
+  contacted: number;
+  replied: number;
+  meetingsBooked: number;
+}
+
+interface CompleteProps {
+  mode: "complete";
+  cycleNumber: number;
+  contacted: number;
+  replied: number;
+  meetingsBooked: number;
+  /** ISO timestamp at which the next cycle begins. */
+  nextCycleAt?: string | null;
+}
+
+type Props = ReviewProps | OutreachProps | CompleteProps;
+
+interface TabsProps {
+  mode: PipelineMode;
+  onChange: (mode: PipelineMode) => void;
+}
+
+/** Tab-row + content. Caller picks the visible mode and supplies data. */
+export function PipelineStateTabs(props: Props & TabsProps) {
+  return (
+    <section>
+      <TabRow active={props.mode} onChange={props.onChange} />
+
+      <div className="mt-4 rounded-[10px] border border-rule bg-panel p-5">
+        {props.mode === "review" && <ReviewBody {...props} />}
+        {props.mode === "outreach" && <OutreachBody {...props} />}
+        {props.mode === "complete" && <CompleteBody {...props} />}
+      </div>
+    </section>
+  );
+}
+
+function TabRow({
+  active, onChange,
+}: { active: PipelineMode; onChange: (m: PipelineMode) => void }) {
+  const tabs: Array<{ key: PipelineMode; label: string }> = [
+    { key: "review",   label: "Review" },
+    { key: "outreach", label: "Outreach" },
+    { key: "complete", label: "Complete" },
+  ];
+  return (
+    <div className="inline-flex p-[2px] rounded-md bg-surface">
+      {tabs.map(t => {
+        const isActive = t.key === active;
+        return (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => onChange(t.key)}
+            className={[
+              "px-3.5 py-1.5 font-mono text-[11px] tracking-[0.06em] rounded-[4px] uppercase transition-colors",
+              isActive
+                ? "bg-ink text-white font-semibold"
+                : "text-ink-3 hover:text-ink",
+            ].join(" ")}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Review mode ──────────────────────────────────────────────────────────
+
+function ReviewBody({ total, reviewed, onReleaseAll, releasing }: ReviewProps) {
+  const pct = total > 0 ? Math.round((reviewed / total) * 100) : 0;
+  const remaining = Math.max(0, total - reviewed);
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+        <h3 className="font-display font-bold text-[22px] text-ink leading-tight">
+          You have reviewed{" "}
+          <em className="text-amber" style={{ fontStyle: "italic" }}>
+            {reviewed}
+          </em>{" "}
+          <span className="text-ink-3">of {total}</span>
+        </h3>
+        <button
+          type="button"
+          onClick={onReleaseAll}
+          disabled={releasing || remaining === 0}
+          className="px-4 py-2 rounded-[6px] font-mono text-[11px] tracking-[0.08em] uppercase font-semibold transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+          style={{ backgroundColor: "var(--ink)", color: "white" }}
+        >
+          {releasing ? "Releasing…" : `Release All (${remaining})`}
+        </button>
+      </div>
+
+      <div
+        className="mt-3 h-1.5 w-full rounded-full overflow-hidden"
+        style={{ backgroundColor: "rgba(12,10,8,0.06)" }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-valuenow={reviewed}
+      >
+        <div
+          className="h-full transition-[width] duration-300"
+          style={{
+            width: `${pct}%`,
+            backgroundColor: "var(--amber)",
+          }}
+        />
+      </div>
+
+      <p className="mt-3 text-[13px] text-ink-2 leading-relaxed">
+        Each prospect waits in review until you release it — then Maya begins
+        outreach. No content sent yet.
+      </p>
+    </div>
+  );
+}
+
+// ─── Outreach mode ────────────────────────────────────────────────────────
+
+function OutreachBody({ contacted, replied, meetingsBooked }: OutreachProps) {
+  return (
+    <div>
+      <h3 className="font-display font-bold text-[22px] text-ink leading-tight">
+        Maya is <em className="text-amber" style={{ fontStyle: "italic" }}>working</em>
+      </h3>
+      <p className="text-[13px] text-ink-3 mt-1">
+        Sequences in flight. Numbers refresh every 5 minutes.
+      </p>
+
+      <div className="grid grid-cols-3 gap-4 mt-4 pt-4 border-t border-rule">
+        <Metric label="Contacted" value={contacted} />
+        <Metric label="Replied" value={replied} />
+        <Metric label="Booked" value={meetingsBooked} />
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <div className="font-display font-bold text-[24px] text-ink leading-none">
+        {value.toLocaleString()}
+      </div>
+      <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-ink-3 mt-1.5">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+// ─── Complete mode ────────────────────────────────────────────────────────
+
+function CompleteBody({
+  cycleNumber, contacted, replied, meetingsBooked, nextCycleAt,
+}: CompleteProps) {
+  const countdown = useNextCycleCountdown(nextCycleAt);
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+        <h3 className="font-display font-bold text-[22px] text-ink leading-tight">
+          Cycle <em className="text-amber" style={{ fontStyle: "italic" }}>{cycleNumber}</em>{" "}
+          <span className="text-ink-3">complete</span>
+        </h3>
+
+        {countdown && (
+          <div className="font-mono text-[11px] text-ink-3 tracking-[0.06em]">
+            Next cycle in <span className="text-copper font-semibold">{countdown}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 mt-4 pt-4 border-t border-rule">
+        <Metric label="Contacted" value={contacted} />
+        <Metric label="Replied" value={replied} />
+        <Metric label="Booked" value={meetingsBooked} />
+      </div>
+    </div>
+  );
+}
+
+function useNextCycleCountdown(nextCycleAt: string | null | undefined): string | null {
+  return useMemo(() => {
+    if (!nextCycleAt) return null;
+    const ts = Date.parse(nextCycleAt);
+    if (Number.isNaN(ts)) return null;
+    const diffMs = ts - Date.now();
+    if (diffMs <= 0) return "now";
+    const days = Math.floor(diffMs / (24 * 3600 * 1000));
+    const hours = Math.floor((diffMs % (24 * 3600 * 1000)) / (3600 * 1000));
+    if (days > 0) return `${days}d ${hours}h`;
+    const mins = Math.floor((diffMs % (3600 * 1000)) / 60000);
+    return `${hours}h ${mins}m`;
+  }, [nextCycleAt]);
+}

--- a/frontend/components/dashboard/ProspectDetailCard.tsx
+++ b/frontend/components/dashboard/ProspectDetailCard.tsx
@@ -1,0 +1,318 @@
+/**
+ * FILE: frontend/components/dashboard/ProspectDetailCard.tsx
+ * PURPOSE: Inline prospect briefing card — vulnerability text, A-F grade
+ *          strip (website / SEO / reviews / ads / social / content),
+ *          signal timeline (email/LinkedIn/voice/replies with quotes),
+ *          meeting info with booking countdown. PR3 dashboard rebuild.
+ *
+ * REFERENCE: dashboard-master-agency-desk.html — `.bf-section`,
+ *            `.vr-strip` / `.vr-letter`, `.event-card` / `.event-quote`,
+ *            drawer body builder at line ~1300.
+ *
+ * The existing ProspectDrawer renders inside a slide-over panel. This
+ * card is the inline equivalent for embedding directly in a page or
+ * within the drawer body — both surfaces share styling (per prototype's
+ * comment: "from drawer + briefing page so both surfaces stay
+ * consistent").
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import {
+  Mail, Linkedin, Phone, MessageSquare, MessageSquareReply, Calendar,
+} from "lucide-react";
+
+export type Grade = "A" | "B" | "C" | "D" | "F";
+
+export interface ProspectGrades {
+  website?: Grade;
+  seo?:     Grade;
+  reviews?: Grade;
+  ads?:     Grade;
+  social?:  Grade;
+  content?: Grade;
+}
+
+export type SignalKind =
+  | "email_sent" | "email_opened" | "email_replied"
+  | "linkedin_view" | "linkedin_invite" | "linkedin_message"
+  | "voice_call" | "voice_voicemail"
+  | "sms_sent" | "sms_replied"
+  | "meeting_booked";
+
+export interface ProspectSignal {
+  id: string;
+  kind: SignalKind;
+  at: string;          // ISO timestamp
+  headline: string;    // "Email opened — subject 'Quick question…'"
+  quote?: string;      // optional reply quote rendered as Playfair italic
+}
+
+export interface ProspectMeeting {
+  scheduledAt: string;   // ISO
+  durationMin?: number;
+  withName?: string;
+  joinUrl?: string;
+}
+
+export interface ProspectDetail {
+  id: string;
+  name: string;
+  company: string;
+  vulnerability?: string;
+  grades?: ProspectGrades;
+  signals?: ProspectSignal[];
+  meeting?: ProspectMeeting | null;
+}
+
+export function ProspectDetailCard({ prospect }: { prospect: ProspectDetail }) {
+  return (
+    <article className="rounded-[10px] border border-rule bg-panel p-5 sm:p-6 space-y-6">
+      <Header prospect={prospect} />
+
+      {prospect.vulnerability && (
+        <Section label="Vulnerability analysis">
+          <p className="text-[13px] text-ink-2 leading-relaxed">
+            {prospect.vulnerability}
+          </p>
+          {prospect.grades && <GradeStrip grades={prospect.grades} />}
+        </Section>
+      )}
+
+      {prospect.meeting && (
+        <Section label="Meeting">
+          <MeetingBlock meeting={prospect.meeting} />
+        </Section>
+      )}
+
+      {prospect.signals && prospect.signals.length > 0 && (
+        <Section label={`Signal timeline · ${prospect.signals.length} events`}>
+          <Timeline signals={prospect.signals} />
+        </Section>
+      )}
+    </article>
+  );
+}
+
+// ─── Header ────────────────────────────────────────────────────────────────
+
+function Header({ prospect }: { prospect: ProspectDetail }) {
+  return (
+    <div>
+      <h2 className="font-display font-bold text-[24px] text-ink leading-tight">
+        {prospect.company || prospect.name}
+      </h2>
+      {prospect.company && prospect.name && (
+        <div className="font-mono text-[11px] tracking-[0.06em] text-ink-3 mt-1">
+          {prospect.name}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Section wrapper — matches .bf-section h4 ──────────────────────────────
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h4
+        className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold pb-2 mb-3 border-b border-rule"
+      >
+        {label}
+      </h4>
+      {children}
+    </section>
+  );
+}
+
+// ─── A-F grade strip — matches .vr-strip / .vr-letter ──────────────────────
+
+const GRADE_BG: Record<Grade, { bg: string; fg: string }> = {
+  A: { bg: "var(--green)",  fg: "white" },
+  B: { bg: "var(--green)",  fg: "white" },
+  C: { bg: "var(--amber)",  fg: "var(--on-amber)" },
+  D: { bg: "var(--copper)", fg: "white" },
+  F: { bg: "var(--red)",    fg: "white" },
+};
+
+function GradeStrip({ grades }: { grades: ProspectGrades }) {
+  const order: Array<keyof ProspectGrades> = [
+    "website", "seo", "reviews", "ads", "social", "content",
+  ];
+  return (
+    <div className="flex flex-wrap gap-3 mt-4">
+      {order.map(k => {
+        const g = grades[k];
+        if (!g) return null;
+        const palette = GRADE_BG[g];
+        return (
+          <div key={k} className="flex flex-col items-center gap-1.5">
+            <div
+              className="w-[34px] h-[34px] rounded-[6px] grid place-items-center font-display font-bold text-[15px]"
+              style={{ backgroundColor: palette.bg, color: palette.fg }}
+            >
+              {g}
+            </div>
+            <span className="font-mono text-[10px] tracking-[0.06em] text-ink-3 capitalize">
+              {k}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Timeline — matches .event-card / .event-quote ─────────────────────────
+
+const SIGNAL_ICON: Record<SignalKind, {
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  bg: string;
+  color: string;
+  type: string;
+}> = {
+  email_sent:      { icon: Mail,               bg: "rgba(12,10,8,0.05)",     color: "var(--ink-3)", type: "Email · Sent" },
+  email_opened:    { icon: Mail,               bg: "var(--amber-soft)",      color: "var(--copper)", type: "Email · Opened" },
+  email_replied:   { icon: MessageSquareReply, bg: "rgba(107,142,90,0.16)",  color: "var(--green)", type: "Email · Replied" },
+  linkedin_view:   { icon: Linkedin,           bg: "rgba(74,111,165,0.14)",  color: "var(--blue)",  type: "LinkedIn · Profile view" },
+  linkedin_invite: { icon: Linkedin,           bg: "rgba(74,111,165,0.14)",  color: "var(--blue)",  type: "LinkedIn · Invite sent" },
+  linkedin_message:{ icon: Linkedin,           bg: "rgba(74,111,165,0.14)",  color: "var(--blue)",  type: "LinkedIn · Message" },
+  voice_call:      { icon: Phone,              bg: "rgba(196,106,62,0.14)",  color: "var(--copper)", type: "Voice · Call" },
+  voice_voicemail: { icon: Phone,              bg: "rgba(196,106,62,0.14)",  color: "var(--copper)", type: "Voice · Voicemail" },
+  sms_sent:        { icon: MessageSquare,      bg: "rgba(12,10,8,0.05)",     color: "var(--ink-3)", type: "SMS · Sent" },
+  sms_replied:     { icon: MessageSquareReply, bg: "rgba(107,142,90,0.16)",  color: "var(--green)", type: "SMS · Replied" },
+  meeting_booked:  { icon: Calendar,           bg: "rgba(74,111,165,0.14)",  color: "var(--blue)",  type: "Meeting · Booked" },
+};
+
+function Timeline({ signals }: { signals: ProspectSignal[] }) {
+  // Newest first
+  const sorted = [...signals].sort(
+    (a, b) => Date.parse(b.at) - Date.parse(a.at),
+  );
+  return (
+    <ol className="space-y-2.5">
+      {sorted.map(s => (
+        <SignalRow key={s.id} signal={s} />
+      ))}
+    </ol>
+  );
+}
+
+function SignalRow({ signal }: { signal: ProspectSignal }) {
+  const def = SIGNAL_ICON[signal.kind];
+  const Icon = def.icon;
+  const time = new Date(signal.at);
+  return (
+    <li className="grid gap-3 rounded-[10px] border border-rule bg-panel px-4 py-3.5"
+        style={{ gridTemplateColumns: "60px 38px 1fr" }}>
+      <div className="font-mono text-[10.5px] text-ink-3 pt-1 whitespace-nowrap">
+        {time.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+        <div className="opacity-70">
+          {time.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
+        </div>
+      </div>
+
+      <div
+        className="w-[38px] h-[38px] rounded-[10px] grid place-items-center"
+        style={{ backgroundColor: def.bg, color: def.color }}
+      >
+        <Icon className="w-4 h-4" strokeWidth={1.6} />
+      </div>
+
+      <div className="min-w-0">
+        <div className="font-mono text-[9.5px] tracking-[0.16em] uppercase font-semibold"
+             style={{ color: "var(--copper)" }}>
+          {def.type}
+        </div>
+        <div className="text-[14px] text-ink mt-0.5 leading-snug">
+          {signal.headline}
+        </div>
+        {signal.quote && (
+          <blockquote
+            className="mt-2 font-display italic text-[14px] text-ink-2 leading-snug py-2 px-3 rounded-[0_6px_6px_0]"
+            style={{
+              backgroundColor: "var(--surface)",
+              borderLeft: "3px solid var(--amber)",
+            }}
+          >
+            “{signal.quote}”
+          </blockquote>
+        )}
+      </div>
+    </li>
+  );
+}
+
+// ─── Meeting block — booking countdown ────────────────────────────────────
+
+function MeetingBlock({ meeting }: { meeting: ProspectMeeting }) {
+  const countdown = useMemo(() => {
+    const ts = Date.parse(meeting.scheduledAt);
+    if (Number.isNaN(ts)) return null;
+    const diffMs = ts - Date.now();
+    if (diffMs <= 0) return "in progress";
+    const days  = Math.floor(diffMs / (24 * 3600 * 1000));
+    const hours = Math.floor((diffMs % (24 * 3600 * 1000)) / (3600 * 1000));
+    const mins  = Math.floor((diffMs % (3600 * 1000)) / 60000);
+    if (days > 0) return `in ${days}d ${hours}h`;
+    if (hours > 0) return `in ${hours}h ${mins}m`;
+    return `in ${mins}m`;
+  }, [meeting.scheduledAt]);
+
+  const dt = new Date(meeting.scheduledAt);
+  const dateLabel = dt.toLocaleDateString(undefined, {
+    weekday: "long", month: "short", day: "numeric",
+  });
+  const timeLabel = dt.toLocaleTimeString(undefined, {
+    hour: "2-digit", minute: "2-digit",
+  });
+
+  return (
+    <div
+      className="rounded-[8px] p-4"
+      style={{
+        backgroundColor: "rgba(107,142,90,0.10)",
+        borderLeft: "3px solid var(--green)",
+      }}
+    >
+      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+        <div>
+          <div className="font-display font-bold text-[16px] text-ink">
+            {dateLabel}
+            <span className="text-ink-3"> · </span>
+            <span className="font-mono text-[14px]">{timeLabel}</span>
+          </div>
+          {meeting.withName && (
+            <div className="text-[12.5px] text-ink-2 mt-0.5">
+              with {meeting.withName}
+              {meeting.durationMin ? ` · ${meeting.durationMin} min` : ""}
+            </div>
+          )}
+        </div>
+
+        {countdown && (
+          <span
+            className="font-mono text-[11px] tracking-[0.08em] uppercase font-semibold"
+            style={{ color: "var(--green)" }}
+          >
+            {countdown}
+          </span>
+        )}
+      </div>
+
+      {meeting.joinUrl && (
+        <a
+          href={meeting.joinUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block mt-3 font-mono text-[10px] tracking-[0.08em] uppercase font-semibold px-3 py-1.5 rounded-[4px]"
+          style={{ backgroundColor: "var(--ink)", color: "white" }}
+        >
+          Join meeting →
+        </a>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/SystemHealth.tsx
+++ b/frontend/components/dashboard/SystemHealth.tsx
@@ -1,0 +1,136 @@
+/**
+ * FILE: frontend/components/dashboard/SystemHealth.tsx
+ * PURPOSE: 4 channel health pills — Email Delivery / LinkedIn Queue /
+ *          Voice AI / SMS Gateway. Green/amber/red status dots.
+ *          PR2 dashboard rebuild.
+ * REFERENCE: dashboard-master-agency-desk.html — `.tb-cycle .tb-dot`
+ *            (pulsing dot) + `.pill` colour scheme.
+ */
+
+"use client";
+
+import { Mail, Linkedin, Phone, MessageSquare } from "lucide-react";
+
+type HealthStatus = "ok" | "warn" | "error";
+
+interface ChannelHealth {
+  id: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  status: HealthStatus;
+  detail: string;     // short subtitle, e.g. "98.2% delivered"
+}
+
+const STATUS_COLOR: Record<HealthStatus, { bg: string; ring: string; text: string }> = {
+  ok:    { bg: "var(--green)", ring: "rgba(107,142,90,0.35)", text: "var(--green)" },
+  warn:  { bg: "var(--amber)", ring: "rgba(212,149,106,0.35)", text: "var(--copper)" },
+  error: { bg: "var(--red)",   ring: "rgba(181,90,76,0.35)",   text: "var(--red)" },
+};
+
+/**
+ * TODO(api): SystemHealth is currently mock-only. The backend has the
+ * raw signals needed (`distribution.email`, LinkedIn queue depth, voice
+ * provider status, telnyx SMS gateway) but no aggregated /api/v1/system-
+ * health endpoint exists yet. Each card below carries a `todo` flag so a
+ * follow-up PR can wire `useSystemHealth()` without changing the layout.
+ */
+function useSystemHealthMock(): ChannelHealth[] {
+  return [
+    {
+      id: "email",
+      label: "Email Delivery",
+      icon: Mail,
+      status: "ok",
+      detail: "98.2% delivered · last 24h",
+    },
+    {
+      id: "linkedin",
+      label: "LinkedIn Queue",
+      icon: Linkedin,
+      status: "warn",
+      detail: "Weekend slowdown · 12 queued",
+    },
+    {
+      id: "voice",
+      label: "Voice AI",
+      icon: Phone,
+      status: "ok",
+      detail: "VAPI healthy · 0 failures",
+    },
+    {
+      id: "sms",
+      label: "SMS Gateway",
+      icon: MessageSquare,
+      status: "ok",
+      detail: "Telnyx · 100% uptime",
+    },
+  ];
+}
+
+export function SystemHealth() {
+  const channels = useSystemHealthMock();
+
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-3">
+        <div className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3 font-semibold">
+          System Health
+        </div>
+        <span className="font-mono text-[8px] tracking-[0.12em] uppercase text-amber/80 bg-amber-soft border border-amber/30 rounded px-1.5 py-[1px]">
+          TODO · MOCK
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {channels.map(channel => (
+          <HealthPill key={channel.id} channel={channel} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function HealthPill({ channel }: { channel: ChannelHealth }) {
+  const Icon = channel.icon;
+  const palette = STATUS_COLOR[channel.status];
+  const labelText = {
+    ok: "Operational",
+    warn: "Degraded",
+    error: "Outage",
+  }[channel.status];
+
+  return (
+    <div className="rounded-[10px] border border-rule bg-panel px-4 py-3.5 flex items-start gap-3">
+      <Icon className="w-4 h-4 mt-0.5 text-ink-3 shrink-0" strokeWidth={1.6} />
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          {/* Status dot */}
+          <span className="relative flex w-2 h-2">
+            {channel.status === "ok" && (
+              <span
+                className="absolute inline-flex h-full w-full rounded-full opacity-60 animate-ping"
+                style={{ backgroundColor: palette.bg }}
+              />
+            )}
+            <span
+              className="relative inline-flex w-2 h-2 rounded-full"
+              style={{ backgroundColor: palette.bg, boxShadow: `0 0 0 3px ${palette.ring}` }}
+            />
+          </span>
+
+          <span className="font-mono text-[10px] tracking-[0.1em] uppercase font-semibold" style={{ color: palette.text }}>
+            {labelText}
+          </span>
+        </div>
+
+        <div className="text-[13px] text-ink mt-1.5 font-medium truncate">
+          {channel.label}
+        </div>
+        <div className="text-[11.5px] text-ink-3 mt-0.5 truncate">
+          {channel.detail}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/TodoMockPanel.tsx
+++ b/frontend/components/dashboard/TodoMockPanel.tsx
@@ -1,0 +1,67 @@
+/**
+ * FILE: frontend/components/dashboard/TodoMockPanel.tsx
+ * PURPOSE: Cream/amber placeholder panel that occupies the same slot as
+ *          a not-yet-wired feature. Replaces the silent mock-data cards
+ *          (Channel Orchestration / Smart Calling / What's Working)
+ *          that previously rendered fabricated numbers without a TODO
+ *          marker. PR4 dashboard rebuild.
+ *
+ * Each panel:
+ *   - Shows a TODO · MOCK pill so demo viewers + CEO can tell at a
+ *     glance that the surface is unwired
+ *   - Names the missing endpoint(s) so a future PR can grep for it
+ *   - Carries an optional eyebrow + icon to keep the slot visually
+ *     coherent with the rest of the dashboard chrome
+ */
+
+"use client";
+
+import type { ReactNode } from "react";
+
+interface Props {
+  icon?: ReactNode;
+  eyebrow: string;          // small mono uppercase eyebrow
+  title: string;             // Playfair-style headline
+  description: string;       // body copy
+  endpointsNeeded: string[]; // bullet list of pending endpoints
+}
+
+export function TodoMockPanel({
+  icon, eyebrow, title, description, endpointsNeeded,
+}: Props) {
+  return (
+    <div className="rounded-[10px] border border-dashed border-amber/40 bg-amber-soft px-5 py-5">
+      <div className="flex items-center gap-2.5 mb-2">
+        {icon && (
+          <span className="text-amber" aria-hidden>
+            {icon}
+          </span>
+        )}
+        <span className="font-mono text-[10px] tracking-[0.14em] uppercase font-semibold text-copper">
+          {eyebrow}
+        </span>
+        <span className="ml-auto font-mono text-[8px] tracking-[0.14em] uppercase text-amber bg-amber-soft border border-amber/40 rounded px-1.5 py-[1px]">
+          TODO · MOCK
+        </span>
+      </div>
+
+      <div className="font-display font-bold text-[18px] text-ink leading-snug">
+        {title}
+      </div>
+      <p className="text-[13px] text-ink-2 mt-1.5 leading-relaxed">
+        {description}
+      </p>
+
+      <ul className="mt-3 space-y-1">
+        {endpointsNeeded.map(ep => (
+          <li
+            key={ep}
+            className="font-mono text-[11px] text-ink-3 leading-tight"
+          >
+            <span className="text-copper">→</span> {ep}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/components/demo/DemoBanner.tsx
+++ b/frontend/components/demo/DemoBanner.tsx
@@ -18,29 +18,49 @@ export function DemoBanner() {
     return null;
   }
 
+  // PR4 — palette aligned with the cream/amber theme. Uses the
+  // brand-bar (deep ink) so the banner sits visually with the new
+  // 232px sidebar instead of the old gradient orange.
   return (
-    <div 
-      className="fixed top-0 left-0 right-0 z-[100] bg-gradient-to-r from-amber-600 to-orange-500 text-white px-4 py-2"
+    <div
+      className="fixed top-0 left-0 right-0 z-[100] px-4 py-2"
+      style={{
+        backgroundColor: "var(--brand-bar)",
+        borderBottom: "1px solid rgba(255,255,255,0.08)",
+        color: "white",
+      }}
     >
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <Sparkles className="w-4 h-4 animate-pulse" />
+          <Sparkles
+            className="w-4 h-4 animate-pulse"
+            style={{ color: "var(--amber)" }}
+          />
           <span className="text-sm font-medium">
-            <strong>Demo Mode</strong> — You&apos;re exploring Horizon Digital&apos;s Agency OS dashboard with sample data.
+            <strong className="font-mono uppercase tracking-[0.12em] text-[11px] mr-2" style={{ color: "var(--amber)" }}>
+              Demo Mode
+            </strong>
+            <span className="text-white/80">
+              You&apos;re exploring Agency<em className="not-italic" style={{ color: "var(--amber)", fontStyle: "italic" }}>OS</em> with sample data.
+            </span>
           </span>
         </div>
         <div className="flex items-center gap-3">
-          <a 
-            href="https://agency-os.com/signup" 
+          <a
+            href="https://agency-os.com/signup"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-xs font-semibold bg-white/20 hover:bg-white/30 px-3 py-1.5 rounded-full transition-colors"
+            className="text-xs font-mono font-semibold uppercase tracking-[0.08em] px-3 py-1.5 rounded-[4px] transition-colors"
+            style={{
+              backgroundColor: "var(--amber)",
+              color: "var(--on-amber)",
+            }}
           >
             Start Free Trial →
           </a>
-          <button 
+          <button
             onClick={() => setDismissed(true)}
-            className="p-1 hover:bg-white/20 rounded transition-colors"
+            className="p-1 rounded transition-colors text-white/60 hover:text-white hover:bg-white/10"
             aria-label="Dismiss banner"
           >
             <X className="w-4 h-4" />

--- a/frontend/landing/demo/index.html
+++ b/frontend/landing/demo/index.html
@@ -3,2358 +3,2342 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>AgencyOS — Dashboard</title>
+<title>AgencyOS — The Agency Desk</title>
+<script>
+  try { if (localStorage.getItem('agencyos_theme') === 'dark') document.documentElement.classList.add('dark'); } catch (e) {}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;1,700&family=DM+Sans:wght@300;400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;1,700&family=DM+Sans:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <style>
-@media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-}
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; } }
 
+/* ========== TOKENS ========== */
 :root {
   --cream: #F7F3EE;
   --surface: #EDE8E0;
   --ink: #0C0A08;
   --ink-2: #2E2B26;
   --ink-3: #7A756D;
+  --ink-4: #B5B0A6;
   --amber: #D4956A;
-  --amber-soft: rgba(212,149,106,0.12);
+  --amber-soft: rgba(212,149,106,0.14);
+  --amber-glow: rgba(212,149,106,0.08);
   --copper: #C46A3E;
-  --tan: #C4A878;
   --green: #6B8E5A;
   --red: #B55A4C;
+  --blue: #4A6FA5;
   --rule: rgba(12,10,8,0.08);
+  --rule-strong: rgba(12,10,8,0.14);
+  --brand-bar: #0C0A08;
+  --on-amber: #1a1207;
+  --panel-bg: #FFFFFF;
   --sidebar-w: 232px;
-  --topbar-h: 56px;
+  --topbar-h: 52px;
+  --bottomnav-h: 60px;
 }
+html.dark {
+  --cream: #0C0A08;
+  --surface: #16130F;
+  --ink: #F5F2EC;
+  --ink-2: #C9C3B8;
+  --ink-3: #807A6E;
+  --ink-4: #4A443A;
+  --rule: rgba(255,255,255,0.08);
+  --rule-strong: rgba(255,255,255,0.14);
+  --copper: #E6A87D;
+  --amber-soft: rgba(212,149,106,0.18);
+  --panel-bg: #16130F;
+}
+
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-html, body { height: 100%; background: var(--cream); color: var(--ink); }
-body { font-family: 'DM Sans', sans-serif; font-size: 14px; line-height: 1.5; display: flex; }
-a { color: inherit; text-decoration: none; }
-button { cursor: pointer; font-family: 'DM Sans', sans-serif; }
-input, select, textarea { font-family: 'DM Sans', sans-serif; }
-ul { list-style: none; }
-::-webkit-scrollbar { width: 4px; height: 4px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--rule); border-radius: 2px; }
-.playfair { font-family: 'Playfair Display', serif; font-weight: 700; }
+html, body { height: 100%; background: var(--cream); color: var(--ink); overflow-x: hidden; }
+body { font-family: 'DM Sans', system-ui, sans-serif; font-size: 14px; line-height: 1.5; max-width: 100vw; display: flex; flex-direction: column; }
+button { cursor: pointer; font: inherit; color: inherit; background: none; border: 0; }
+input, select, textarea { font: inherit; color: inherit; }
+ul { list-style: none; padding-left: 18px; }
 .mono { font-family: 'JetBrains Mono', monospace; }
-.eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); }
+.eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-3); }
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-thumb { background: var(--rule-strong); border-radius: 3px; }
+img, svg { max-width: 100%; }
+
+/* ========== TOPBAR ========== */
+#topbar {
+  position: sticky; top: 0; z-index: 50;
+  height: var(--topbar-h);
+  background: var(--brand-bar);
+  color: #F5F2EC;
+  display: flex; align-items: center;
+  padding: 0 16px;
+  gap: 14px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  flex-shrink: 0;
+}
+.brand { font-family: 'Playfair Display', serif; font-size: 18px; font-weight: 700; letter-spacing: -0.01em; }
+.brand em { color: var(--amber); font-style: italic; }
+.brand-tag { font-family: 'JetBrains Mono', monospace; font-size: 9px; letter-spacing: 0.14em; color: rgba(255,255,255,0.42); padding: 2px 7px; border: 1px solid rgba(255,255,255,0.14); border-radius: 3px; }
+.tb-spacer { flex: 1; }
+.tb-cycle { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: rgba(255,255,255,0.62); display: flex; align-items: center; gap: 6px; }
+.tb-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--green); animation: pulse 2s infinite; }
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+.tb-theme { width: 30px; height: 30px; border-radius: 50%; display: grid; place-items: center; font-size: 13px; color: rgba(255,255,255,0.7); border: 1px solid rgba(255,255,255,0.14); }
+.tb-theme:hover { color: var(--amber); border-color: var(--amber); }
+.tb-theme .t-sun { display: inline; } .tb-theme .t-moon { display: none; }
+html.dark .tb-theme .t-sun { display: none; } html.dark .tb-theme .t-moon { display: inline; }
+.kill-btn { background: transparent; color: rgba(255,255,255,0.85); border: 1px solid rgba(255,255,255,0.2); font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.08em; padding: 5px 12px; border-radius: 4px; text-transform: uppercase; }
+.kill-btn:hover { background: var(--red); color: #fff; border-color: var(--red); }
+.hamburger-btn { display: none; color: #fff; font-size: 22px; padding: 4px 8px; }
+
+/* ========== LAYOUT ========== */
+#shell { flex: 1; display: grid; grid-template-columns: var(--sidebar-w) 1fr; min-height: 0; min-width: 0; }
+
+/* Sidebar */
 #sidebar {
-  width: var(--sidebar-w); min-width: var(--sidebar-w); height: 100vh;
-  background: var(--ink); display: flex; flex-direction: column;
-  position: fixed; left: 0; top: 0; bottom: 0; z-index: 100; overflow-y: auto;
+  background: var(--brand-bar); color: #F5F2EC;
+  display: flex; flex-direction: column;
+  border-right: 1px solid rgba(255,255,255,0.06);
+  overflow-y: auto;
+  transition: transform .25s ease;
 }
-.sidebar-logo { padding: 24px 20px 20px; border-bottom: 1px solid rgba(255,255,255,0.06); }
-.sidebar-logo .logo-text { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 20px; color: #fff; letter-spacing: -0.02em; }
-.sidebar-logo .logo-text em { color: var(--amber); font-style: italic; }
-.sidebar-section { padding: 16px 0 4px; }
-.sidebar-section-label { font-family: 'JetBrains Mono', monospace; font-size: 9px; font-weight: 500; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(255,255,255,0.28); padding: 0 20px 8px; }
-.nav-item { display: flex; align-items: center; gap: 10px; padding: 9px 20px; color: rgba(255,255,255,0.52); font-size: 13.5px; font-weight: 400; cursor: pointer; position: relative; transition: color 0.15s, background 0.15s; border-left: 2px solid transparent; user-select: none; }
-.nav-item:hover { color: rgba(255,255,255,0.82); background: rgba(255,255,255,0.04); }
-.nav-item.active { color: #fff; background: var(--amber-soft); border-left-color: var(--amber); font-weight: 500; }
-.nav-icon { width: 16px; height: 16px; opacity: 0.7; flex-shrink: 0; }
-.nav-item.active .nav-icon { opacity: 1; }
-.nav-badge { margin-left: auto; background: var(--copper); color: #fff; font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500; padding: 1px 6px; border-radius: 10px; min-width: 20px; text-align: center; }
-.sidebar-footer { margin-top: auto; padding: 16px 20px; border-top: 1px solid rgba(255,255,255,0.06); display: flex; align-items: center; gap: 10px; }
-.avatar-circle { width: 32px; height: 32px; border-radius: 50%; background: var(--amber); display: flex; align-items: center; justify-content: center; font-family: 'Playfair Display', serif; font-size: 13px; font-weight: 700; color: #fff; flex-shrink: 0; }
-.sidebar-user-name { font-size: 13px; font-weight: 500; color: #fff; line-height: 1.2; }
-.sidebar-user-sub { font-size: 11px; color: rgba(255,255,255,0.4); font-family: 'JetBrains Mono', monospace; }
-#app { margin-left: var(--sidebar-w); flex: 1; display: flex; flex-direction: column; min-height: 100vh; }
-#topbar { height: var(--topbar-h); background: var(--cream); border-bottom: 1px solid var(--rule); display: flex; align-items: center; padding: 0 40px; position: sticky; top: 0; z-index: 50; gap: 16px; }
-.breadcrumb { flex: 1; display: flex; align-items: center; gap: 6px; font-size: 13px; color: var(--ink-3); }
-.breadcrumb .crumb-sep { color: var(--rule); }
-.breadcrumb .crumb-current { color: var(--ink-2); font-weight: 500; }
-.topbar-right { display: flex; align-items: center; gap: 16px; }
-.pulse-row { display: flex; align-items: center; gap: 7px; font-size: 12.5px; color: var(--ink-3); font-family: 'JetBrains Mono', monospace; }
-.pulse-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--green); animation: pulse 2s infinite; }
-@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-.kill-btn { background: transparent; border: 1px solid var(--red); color: var(--red); font-size: 11px; font-weight: 500; font-family: 'JetBrains Mono', monospace; padding: 5px 12px; border-radius: 4px; letter-spacing: 0.06em; text-transform: uppercase; transition: background 0.15s; }
-.kill-btn:hover { background: rgba(181,90,76,0.08); }
-#page { flex: 1; overflow-y: auto; padding: 36px 40px 60px; max-width: 1480px; width: 100%; margin: 0 auto; }
-.page-headline { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 36px; color: var(--ink); line-height: 1.18; letter-spacing: -0.02em; margin-bottom: 28px; }
-.page-headline em { color: var(--amber); font-style: italic; }
-.card { background: #fff; border: 1px solid var(--rule); border-radius: 10px; padding: 22px 24px; }
-.card-sm { padding: 16px 18px; }
-.section-label { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); margin-bottom: 14px; }
-.badge { display: inline-flex; align-items: center; padding: 3px 9px; border-radius: 20px; font-size: 11px; font-weight: 500; font-family: 'JetBrains Mono', monospace; letter-spacing: 0.04em; }
-.badge-amber { background: var(--amber-soft); color: var(--copper); }
-.badge-green { background: rgba(107,142,90,0.12); color: var(--green); }
-.badge-red { background: rgba(181,90,76,0.12); color: var(--red); }
-.badge-tan { background: rgba(196,168,120,0.15); color: #8A7350; }
-.badge-ink { background: rgba(12,10,8,0.06); color: var(--ink-2); }
-.badge-muted-red { background: rgba(181,90,76,0.08); color: rgba(181,90,76,0.6); }
-.intent-struggling { background: rgba(181,90,76,0.10); color: var(--red); }
-.intent-trying { background: var(--amber-soft); color: var(--copper); }
-.intent-dabbling { background: rgba(12,10,8,0.06); color: var(--ink-3); }
-.btn { display: inline-flex; align-items: center; gap: 6px; padding: 9px 18px; border-radius: 6px; font-size: 13.5px; font-weight: 500; border: none; transition: opacity 0.15s, background 0.15s; }
-.btn:hover { opacity: 0.85; }
+.sb-section { padding: 16px 0 4px; }
+.sb-label { font-family: 'JetBrains Mono', monospace; font-size: 9px; letter-spacing: 0.14em; color: rgba(255,255,255,0.32); text-transform: uppercase; padding: 0 20px 8px; }
+.sb-item { display: flex; align-items: center; gap: 12px; padding: 9px 20px; font-size: 13px; color: rgba(255,255,255,0.72); cursor: pointer; border-left: 2px solid transparent; transition: color .12s, background .12s, border-color .12s; }
+.sb-item:hover { color: #fff; background: rgba(255,255,255,0.03); }
+.sb-item.active { color: #fff; background: var(--amber-soft); border-left-color: var(--amber); font-weight: 500; }
+.sb-icon { width: 16px; height: 16px; flex-shrink: 0; opacity: 0.75; }
+.sb-item.active .sb-icon { opacity: 1; color: var(--amber); }
+.sb-badge { margin-left: auto; font-family: 'JetBrains Mono', monospace; font-size: 10px; background: var(--amber); color: var(--on-amber); padding: 1px 6px; border-radius: 10px; min-width: 20px; text-align: center; font-weight: 600; }
+.sb-foot { margin-top: auto; padding: 16px 20px; border-top: 1px solid rgba(255,255,255,0.06); display: flex; align-items: center; gap: 10px; }
+.avatar { width: 30px; height: 30px; border-radius: 50%; background: var(--amber); color: var(--on-amber); display: grid; place-items: center; font-family: 'Playfair Display', serif; font-weight: 700; font-size: 12px; flex-shrink: 0; }
+.sb-foot-n { font-size: 13px; color: #fff; }
+.sb-foot-r { font-size: 10.5px; color: rgba(255,255,255,0.42); font-family: 'JetBrains Mono', monospace; letter-spacing: 0.06em; }
+.sb-logo { padding: 22px 20px 18px; border-bottom: 1px solid rgba(255,255,255,0.06); }
+.sb-logo .lt { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 20px; letter-spacing: -0.02em; }
+.sb-logo .lt em { color: var(--amber); font-style: italic; }
+.sb-logo .ls { font-family: 'JetBrains Mono', monospace; font-size: 9px; letter-spacing: 0.14em; color: rgba(255,255,255,0.32); margin-top: 3px; text-transform: uppercase; }
+
+/* Main */
+#main { padding: 24px 32px 80px; min-width: 0; overflow-y: auto; max-width: 1280px; width: 100%; margin: 0 auto; }
+
+/* Page common */
+.page-h { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 30px; color: var(--ink); letter-spacing: -0.02em; line-height: 1.2; margin-bottom: 6px; }
+.page-h em { color: var(--amber); font-style: italic; }
+.page-sub { font-size: 13px; color: var(--ink-3); margin-bottom: 22px; max-width: 820px; }
+.section-label { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-3); font-weight: 600; margin: 24px 0 12px; }
+.card { background: var(--panel-bg); border: 1px solid var(--rule); border-radius: 10px; padding: 18px 20px; max-width: 100%; min-width: 0; overflow-x: auto; }
+
+/* Pills + chips */
+.pill { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500; letter-spacing: 0.1em; padding: 3px 8px; border-radius: 12px; display: inline-block; text-transform: uppercase; }
+.pill.green { background: rgba(107,142,90,0.16); color: var(--green); }
+.pill.amber { background: var(--amber-soft); color: var(--copper); }
+.pill.gray { background: rgba(12,10,8,0.06); color: var(--ink-3); }
+.pill.red { background: rgba(181,90,76,0.14); color: var(--red); }
+html.dark .pill.gray { background: rgba(255,255,255,0.06); }
+.chip { padding: 6px 14px; border-radius: 20px; font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.06em; color: var(--ink-3); background: var(--panel-bg); border: 1px solid var(--rule); cursor: pointer; transition: all .12s; }
+.chip:hover { color: var(--copper); border-color: var(--amber); }
+.chip.active { background: var(--amber); color: var(--on-amber); border-color: var(--amber); font-weight: 600; }
+.chip-count { display: inline-block; margin-left: 5px; font-weight: 700; color: var(--copper); }
+.chip.active .chip-count { color: var(--on-amber); }
+
+/* VR grade chip */
+.vr { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border-radius: 6px; color: #fff; font-family: 'Playfair Display', serif; font-weight: 700; font-size: 14px; flex-shrink: 0; }
+.vr[data-g="A"], .vr[data-g="B"] { background: var(--green); }
+.vr[data-g="C"] { background: var(--amber); color: var(--on-amber); }
+.vr[data-g="D"] { background: var(--copper); }
+.vr[data-g="F"] { background: var(--red); }
+
+/* Buttons */
+.btn { padding: 8px 16px; border-radius: 6px; font-size: 13px; font-weight: 500; transition: filter .12s; }
 .btn-primary { background: var(--ink); color: #fff; }
-.btn-amber { background: var(--amber); color: #fff; }
+html.dark .btn-primary { background: var(--amber); color: var(--on-amber); }
+.btn-amber { background: var(--amber); color: var(--on-amber); }
 .btn-outline { background: transparent; border: 1px solid var(--rule); color: var(--ink-2); }
-.btn-ghost { background: transparent; color: var(--ink-3); }
-.btn:disabled { opacity: 0.38; cursor: not-allowed; }
-.divider { border: none; border-top: 1px solid var(--rule); margin: 20px 0; }
-.heat-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-.heat-hot { background: var(--copper); }
-.heat-warm { background: var(--amber); }
-.heat-cool { background: var(--tan); }
-.score-badge { width: 42px; height: 42px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: 'JetBrains Mono', monospace; font-weight: 500; font-size: 14px; flex-shrink: 0; }
-.score-hot { background: rgba(196,106,62,0.12); color: var(--copper); border: 1.5px solid var(--copper); }
-.score-warm { background: var(--amber-soft); color: var(--amber); border: 1.5px solid var(--amber); }
-.score-cool { background: rgba(196,168,120,0.12); color: var(--tan); border: 1.5px solid var(--tan); }
-.score-cold { background: rgba(12,10,8,0.06); color: var(--ink-3); border: 1.5px solid rgba(12,10,8,0.1); }
-.progress-wrap { background: var(--rule); border-radius: 99px; overflow: hidden; }
-.progress-bar { height: 100%; border-radius: 99px; transition: width 0.6s ease; }
-.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-.grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
-.grid-4 { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 16px; }
-.schedule-hero { background: var(--ink); border-radius: 12px; padding: 28px 32px; color: #fff; margin-bottom: 28px; display: flex; align-items: flex-start; gap: 40px; }
-.schedule-hero-left { flex: 1; }
-.schedule-campaign-name { font-family: 'Playfair Display', serif; font-size: 22px; font-weight: 700; color: #fff; margin-bottom: 4px; }
-.schedule-area { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: rgba(255,255,255,0.45); margin-bottom: 20px; }
-.schedule-progress-track { background: rgba(255,255,255,0.1); border-radius: 99px; height: 6px; margin-bottom: 8px; }
-.schedule-progress-fill { height: 6px; border-radius: 99px; background: var(--amber); }
-.schedule-days { display: flex; justify-content: space-between; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: rgba(255,255,255,0.35); }
-.schedule-stats { display: flex; gap: 32px; }
-.schedule-stat-val { font-family: 'Playfair Display', serif; font-size: 28px; font-weight: 700; color: #fff; line-height: 1; margin-bottom: 4px; }
-.schedule-stat-label { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: rgba(255,255,255,0.4); letter-spacing: 0.1em; text-transform: uppercase; }
-.metric-card { text-align: left; }
-.metric-val { font-family: 'Playfair Display', serif; font-size: 30px; font-weight: 700; color: var(--ink); line-height: 1; margin-bottom: 4px; }
-.metric-label { font-size: 12px; color: var(--ink-3); margin-bottom: 6px; }
-.metric-delta { font-family: 'JetBrains Mono', monospace; font-size: 11px; display: inline-flex; align-items: center; gap: 3px; }
-.delta-up { color: var(--green); }
-.delta-down { color: var(--red); }
-.reply-item { display: flex; align-items: flex-start; gap: 12px; padding: 14px 0; border-bottom: 1px solid var(--rule); cursor: pointer; transition: background 0.1s; margin: 0 -4px; padding-left: 4px; border-radius: 6px; }
-.reply-item:last-child { border-bottom: none; }
-.reply-item:hover { background: var(--surface); }
-.reply-meta { flex: 1; min-width: 0; }
-.reply-name { font-family: 'Playfair Display', serif; font-size: 15px; font-weight: 700; color: var(--ink); margin-bottom: 2px; }
-.reply-snippet { font-size: 13px; color: var(--ink-3); font-style: italic; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.reply-biz { font-size: 11px; color: var(--ink-3); font-family: 'JetBrains Mono', monospace; margin-bottom: 3px; }
-.reply-time { font-size: 11px; color: var(--ink-3); white-space: nowrap; font-family: 'JetBrains Mono', monospace; }
-.meeting-item { display: flex; align-items: center; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--rule); }
-.meeting-item:last-child { border-bottom: none; }
-.meeting-date-pill { background: var(--amber-soft); color: var(--copper); font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500; padding: 4px 8px; border-radius: 4px; text-align: center; min-width: 52px; line-height: 1.4; }
-.meeting-name { font-size: 14px; font-weight: 500; color: var(--ink); }
-.meeting-biz { font-size: 12px; color: var(--ink-3); }
-.outreach-row { display: flex; align-items: center; gap: 12px; padding: 8px 0; }
-.outreach-channel { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-2); width: 72px; flex-shrink: 0; }
-.outreach-bar-wrap { flex: 1; }
-.outreach-count { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); white-space: nowrap; }
-.health-item { display: flex; align-items: center; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--rule); }
-.health-item:last-child { border-bottom: none; }
-.status-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-.status-green { background: var(--green); }
-.status-amber { background: var(--amber); }
-.status-red { background: var(--red); }
-.health-name { flex: 1; font-size: 13px; color: var(--ink-2); }
-.health-status { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
-.review-banner { background: var(--amber-soft); border: 1px solid rgba(212,149,106,0.3); border-radius: 8px; padding: 14px 18px; display: flex; align-items: center; gap: 16px; margin-bottom: 20px; }
-.review-banner-text { flex: 1; font-size: 13.5px; color: var(--ink-2); }
-.review-banner-text strong { color: var(--copper); }
-.status-strip { background: var(--surface); border: 1px solid var(--rule); border-radius: 8px; padding: 12px 18px; display: flex; align-items: center; gap: 16px; margin-bottom: 20px; font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-3); flex-wrap: wrap; }
-.filter-chips { display: flex; gap: 8px; margin-bottom: 20px; flex-wrap: wrap; }
-.chip { padding: 6px 14px; border-radius: 20px; font-size: 12.5px; font-weight: 500; border: 1px solid var(--rule); background: #fff; color: var(--ink-3); cursor: pointer; transition: all 0.15s; font-family: 'JetBrains Mono', monospace; }
-.chip:hover { border-color: var(--amber); color: var(--copper); }
-.chip.active { background: var(--amber-soft); border-color: var(--amber); color: var(--copper); }
-.pipeline-row { display: flex; align-items: center; gap: 0; background: #fff; border: 1px solid var(--rule); border-radius: 8px; margin-bottom: 8px; cursor: pointer; transition: box-shadow 0.15s, border-color 0.15s; overflow: hidden; position: relative; }
-.pipeline-row:hover { border-color: var(--amber); box-shadow: 0 2px 12px rgba(212,149,106,0.1); }
-.pipeline-row.visited { border-left: 3px solid rgba(212,149,106,0.35); }
-.intent-bar { width: 3px; align-self: stretch; flex-shrink: 0; }
-.intent-bar-struggling { background: var(--red); }
-.intent-bar-trying { background: var(--amber); }
-.intent-bar-dabbling { background: var(--tan); }
-.pipeline-rank { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-3); width: 36px; text-align: center; flex-shrink: 0; }
-.pipeline-main { flex: 1; padding: 14px 12px; min-width: 0; }
-.pipeline-biz-name { font-family: 'Playfair Display', serif; font-size: 16px; font-weight: 700; color: var(--ink); margin-bottom: 3px; }
-.pipeline-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.pipeline-suburb { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
-.pipeline-dm { font-size: 12.5px; color: var(--ink-3); width: 160px; flex-shrink: 0; padding: 14px 0; }
-.pipeline-channels { display: flex; gap: 6px; align-items: center; padding: 14px 16px; flex-shrink: 0; }
-.channel-dot { width: 26px; height: 26px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 11px; background: var(--surface); color: var(--ink-3); font-family: 'JetBrains Mono', monospace; }
-.pipeline-score-wrap { padding: 14px 16px; flex-shrink: 0; }
-.pipeline-status-wrap { padding: 14px 16px; flex-shrink: 0; }
-.pipeline-caret { padding: 14px 16px; color: var(--ink-3); font-size: 16px; flex-shrink: 0; }
-.status-badge-row { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500; padding: 3px 8px; border-radius: 3px; letter-spacing: 0.04em; white-space: nowrap; }
-.status-not-started { background: rgba(12,10,8,0.06); color: var(--ink-3); }
-.status-contacted { background: rgba(12,10,8,0.08); color: var(--ink-2); }
-.status-replied { background: var(--amber-soft); color: var(--copper); }
-.status-meeting-booked { background: rgba(196,106,62,0.12); color: var(--copper); }
-.status-suppressed { background: rgba(181,90,76,0.08); color: rgba(181,90,76,0.6); }
-.pagination-bar { display: flex; align-items: center; gap: 12px; padding: 16px 0; justify-content: center; font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-3); }
-.pagination-btn { background: #fff; border: 1px solid var(--rule); color: var(--ink-2); font-size: 12px; padding: 5px 12px; border-radius: 4px; font-family: 'JetBrains Mono', monospace; cursor: pointer; transition: border-color 0.15s; }
-.pagination-btn:hover:not(:disabled) { border-color: var(--amber); color: var(--copper); }
-.pagination-btn:disabled { opacity: 0.38; cursor: not-allowed; }
-.page-size-select { border: 1px solid var(--rule); background: #fff; color: var(--ink-2); font-size: 12px; padding: 5px 8px; border-radius: 4px; font-family: 'JetBrains Mono', monospace; cursor: pointer; }
-.detail-back { display: inline-flex; align-items: center; gap: 6px; color: var(--ink-3); font-size: 13px; margin-bottom: 20px; cursor: pointer; transition: color 0.15s; }
-.detail-back:hover { color: var(--ink); }
-.detail-nav { display: flex; align-items: center; gap: 10px; margin-bottom: 28px; }
-.detail-nav-btn { background: #fff; border: 1px solid var(--rule); color: var(--ink-2); font-size: 12.5px; font-weight: 500; padding: 6px 14px; border-radius: 5px; display: inline-flex; align-items: center; gap: 5px; cursor: pointer; transition: border-color 0.15s; }
-.detail-nav-btn:hover { border-color: var(--amber); }
-.detail-nav-sep { color: var(--ink-3); font-family: 'JetBrains Mono', monospace; font-size: 11px; }
-.detail-headline { font-family: 'Playfair Display', serif; font-size: 44px; font-weight: 700; color: var(--ink); line-height: 1.1; letter-spacing: -0.02em; margin-bottom: 10px; }
-.detail-meta-row { display: flex; align-items: center; gap: 16px; margin-bottom: 16px; flex-wrap: wrap; }
-.detail-meta-item { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-3); }
-.detail-meta-dot { color: var(--rule); }
-.detail-actions { display: flex; gap: 8px; margin-bottom: 32px; flex-wrap: wrap; }
-.score-card { background: #fff; border: 1px solid var(--rule); border-radius: 10px; padding: 20px; text-align: center; }
-.score-card-val { font-family: 'Playfair Display', serif; font-size: 36px; font-weight: 700; color: var(--ink); line-height: 1; margin-bottom: 4px; }
-.score-card-label { font-size: 12px; color: var(--ink-3); margin-bottom: 2px; }
-.score-card-sub { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); }
-.signal-item { display: flex; align-items: flex-start; gap: 10px; padding: 12px 0; border-bottom: 1px solid var(--rule); }
-.signal-item:last-child { border-bottom: none; }
-.signal-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--amber); margin-top: 5px; flex-shrink: 0; }
-.signal-text { flex: 1; font-size: 13.5px; color: var(--ink-2); }
-.signal-time { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); white-space: nowrap; }
-.vuln-para { font-size: 14px; line-height: 1.7; color: var(--ink-2); padding: 18px; background: var(--amber-soft); border-left: 3px solid var(--amber); margin-bottom: 20px; }
-.grade-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
-.grade-cell { background: var(--surface); border-radius: 8px; padding: 14px; text-align: center; }
-.grade-letter { font-family: 'Playfair Display', serif; font-size: 28px; font-weight: 700; margin-bottom: 4px; line-height: 1; }
-.grade-A { color: var(--green); }
-.grade-B { color: #5A8A74; }
-.grade-C { color: var(--amber); }
-.grade-D { color: var(--copper); }
-.grade-F { color: var(--red); }
-.grade-name { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.1em; }
-.tab-bar { display: flex; border-bottom: 1px solid var(--rule); margin-bottom: 20px; }
-.tab-btn { padding: 10px 18px; font-size: 13px; font-weight: 500; color: var(--ink-3); background: transparent; border: none; border-bottom: 2px solid transparent; margin-bottom: -1px; cursor: pointer; transition: color 0.15s; }
-.tab-btn:hover { color: var(--ink); }
-.tab-btn.active { color: var(--amber); border-bottom-color: var(--amber); }
-.tab-content { display: none; }
-.tab-content.active { display: block; }
-.draft-content { background: var(--surface); border-radius: 8px; padding: 18px; font-size: 13.5px; line-height: 1.7; color: var(--ink-2); white-space: pre-wrap; }
-.draft-label { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.1em; }
-.dm-card { margin-bottom: 16px; }
-.dm-name { font-family: 'Playfair Display', serif; font-size: 18px; font-weight: 700; color: var(--ink); margin-bottom: 2px; }
-.dm-title { font-size: 12px; color: var(--ink-3); margin-bottom: 14px; font-family: 'JetBrains Mono', monospace; }
-.dm-field { display: flex; align-items: center; gap: 8px; padding: 8px 0; border-bottom: 1px solid var(--rule); }
-.dm-field:last-child { border-bottom: none; }
-.dm-field-label { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); width: 56px; text-transform: uppercase; letter-spacing: 0.1em; flex-shrink: 0; }
-.dm-field-val { font-size: 13px; color: var(--ink-2); flex: 1; }
-.dm-verified { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--green); background: rgba(107,142,90,0.1); padding: 2px 7px; border-radius: 3px; }
-.timeline-item { display: flex; gap: 10px; padding: 10px 0; border-bottom: 1px solid var(--rule); }
-.timeline-item:last-child { border-bottom: none; }
-.timeline-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--amber); margin-top: 5px; flex-shrink: 0; }
-.timeline-text { font-size: 13px; color: var(--ink-2); }
-.timeline-time { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
-.outreach-timeline { position: relative; padding-left: 24px; }
-.outreach-timeline::before { content: ''; position: absolute; left: 7px; top: 8px; bottom: 8px; width: 2px; background: var(--amber); opacity: 0.3; }
-.ot-item { position: relative; margin-bottom: 16px; }
-.ot-dot { position: absolute; left: -20px; top: 4px; width: 10px; height: 10px; border-radius: 50%; background: var(--amber); border: 2px solid #fff; }
-.ot-dot-reply { background: var(--copper); }
-.ot-dot-system { background: var(--ink-3); }
-.ot-dot-fail { background: var(--red); }
-.ot-dot-meeting { background: var(--green); }
-.ot-time { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); margin-bottom: 2px; }
-.ot-label { font-size: 13px; color: var(--ink-2); line-height: 1.4; }
-.ot-content { background: var(--amber-soft); border-radius: 6px; padding: 10px 12px; margin-top: 6px; font-size: 12.5px; color: var(--ink-2); font-style: italic; line-height: 1.5; }
-.campaign-card { background: #fff; border: 1px solid var(--rule); border-radius: 10px; padding: 22px 24px; margin-bottom: 14px; }
-.campaign-card-header { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 16px; }
-.campaign-card-main { flex: 1; }
-.campaign-name { font-family: 'Playfair Display', serif; font-size: 20px; font-weight: 700; color: var(--ink); margin-bottom: 3px; }
-.campaign-area { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
-.campaign-metrics { display: flex; gap: 28px; margin-top: 16px; }
-.campaign-metric-val { font-family: 'Playfair Display', serif; font-size: 22px; font-weight: 700; color: var(--ink); margin-bottom: 1px; }
-.campaign-metric-label { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.08em; }
-.modal-overlay { position: fixed; inset: 0; background: rgba(12,10,8,0.45); display: flex; align-items: center; justify-content: center; z-index: 200; opacity: 0; pointer-events: none; transition: opacity 0.2s; }
-.modal-overlay.open { opacity: 1; pointer-events: all; }
-.modal { background: #fff; border-radius: 12px; padding: 32px; width: 100%; max-width: 480px; margin: 20px; transform: translateY(12px); transition: transform 0.2s; }
-.modal-overlay.open .modal { transform: translateY(0); }
-.modal-title { font-family: 'Playfair Display', serif; font-size: 22px; font-weight: 700; color: var(--ink); margin-bottom: 20px; }
-.modal-body { font-size: 14px; color: var(--ink-2); line-height: 1.6; margin-bottom: 24px; }
-.form-field { margin-bottom: 18px; }
-.form-label { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 6px; }
-.form-select, .form-input { width: 100%; border: 1px solid var(--rule); border-radius: 6px; padding: 9px 12px; font-size: 14px; color: var(--ink); background: #fff; outline: none; transition: border-color 0.15s; }
-.form-select:focus, .form-input:focus { border-color: var(--amber); }
-.form-textarea { width: 100%; border: 1px solid var(--rule); border-radius: 6px; padding: 9px 12px; font-size: 13.5px; color: var(--ink); background: #fff; outline: none; transition: border-color 0.15s; resize: vertical; min-height: 80px; line-height: 1.5; }
-.form-textarea:focus { border-color: var(--amber); }
-.radio-group { display: flex; gap: 12px; flex-wrap: wrap; }
-.radio-item { display: flex; align-items: center; gap: 6px; cursor: pointer; }
-.radio-item input[type="radio"] { accent-color: var(--amber); }
-.form-helper { font-size: 12px; color: var(--ink-3); margin-top: 5px; line-height: 1.5; }
-.modal-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 24px; }
-.inbox-layout { display: flex; gap: 0; height: calc(100vh - var(--topbar-h) - 80px); min-height: 500px; }
-.inbox-list { width: 400px; min-width: 400px; border-right: 1px solid var(--rule); overflow-y: auto; background: #fff; border-radius: 10px 0 0 10px; border: 1px solid var(--rule); }
-.inbox-thread { flex: 1; display: flex; flex-direction: column; background: #fff; border: 1px solid var(--rule); border-left: none; border-radius: 0 10px 10px 0; }
-.inbox-list-header { padding: 16px 18px; border-bottom: 1px solid var(--rule); }
-.inbox-item { display: flex; align-items: flex-start; gap: 10px; padding: 14px 18px; border-bottom: 1px solid var(--rule); cursor: pointer; transition: background 0.1s; }
-.inbox-item:hover { background: var(--surface); }
-.inbox-item.active { background: var(--amber-soft); }
-.inbox-item-meta { flex: 1; min-width: 0; }
-.inbox-item-name { font-weight: 500; font-size: 14px; color: var(--ink); margin-bottom: 1px; }
-.inbox-item-biz { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); margin-bottom: 3px; }
-.inbox-item-snippet { font-size: 12.5px; color: var(--ink-3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.inbox-item-time { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); white-space: nowrap; }
-.thread-header { padding: 18px 24px; border-bottom: 1px solid var(--rule); display: flex; align-items: center; gap: 12px; }
-.thread-name { font-family: 'Playfair Display', serif; font-size: 18px; font-weight: 700; color: var(--ink); }
-.thread-biz { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
-.thread-body { flex: 1; overflow-y: auto; padding: 20px 24px; display: flex; flex-direction: column; gap: 14px; }
-.bubble { max-width: 75%; padding: 12px 16px; border-radius: 12px; line-height: 1.6; font-size: 13.5px; }
-.bubble-theirs { background: var(--ink); color: #fff; border-radius: 12px 12px 12px 2px; align-self: flex-start; }
-.bubble-ours { background: var(--surface); color: var(--ink-2); border-radius: 12px 12px 2px 12px; align-self: flex-end; }
-.bubble-time { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); margin-top: 4px; }
-.bubble-time-left { text-align: left; }
-.bubble-time-right { text-align: right; }
-.thread-actions { padding: 14px 24px; border-top: 1px solid var(--rule); display: flex; gap: 8px; }
-.channel-rate-card { background: #fff; border: 1px solid var(--rule); border-radius: 10px; padding: 20px; }
-.channel-rate-name { font-size: 15px; font-weight: 500; color: var(--ink); margin-bottom: 4px; }
-.channel-rate-val { font-family: 'Playfair Display', serif; font-size: 28px; font-weight: 700; color: var(--ink); margin-bottom: 8px; }
-.channel-rate-detail { font-size: 12px; color: var(--ink-3); margin-bottom: 12px; }
-.calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; margin-top: 16px; }
-.cal-header-cell { text-align: center; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); padding: 6px 0; letter-spacing: 0.08em; }
-.cal-cell { background: #fff; border: 1px solid var(--rule); border-radius: 5px; padding: 6px; min-height: 68px; position: relative; }
-.cal-date-num { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); margin-bottom: 4px; }
-.cal-today { background: var(--amber-soft); border-color: var(--amber); }
-.cal-today .cal-date-num { color: var(--copper); font-weight: 500; }
-.cal-pill { font-size: 9px; font-family: 'JetBrains Mono', monospace; padding: 2px 5px; border-radius: 3px; margin-bottom: 2px; display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.cal-email { background: rgba(107,142,90,0.15); color: var(--green); }
-.cal-linkedin { background: rgba(59,130,246,0.1); color: #3B82F6; }
-.cal-voice { background: var(--amber-soft); color: var(--copper); }
-.cal-sms { background: rgba(139,92,246,0.1); color: #8B5CF6; }
-.legend-row { display: flex; gap: 20px; flex-wrap: wrap; margin-top: 12px; }
-.legend-item { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--ink-3); }
-.legend-dot { width: 10px; height: 10px; border-radius: 2px; }
-.signal-card { background: #fff; border: 1px solid var(--rule); border-radius: 10px; padding: 22px 24px; }
-.signal-card-header { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
-.signal-card-name { font-family: 'Playfair Display', serif; font-size: 17px; font-weight: 700; color: var(--ink); flex: 1; }
-.signal-toggle { width: 36px; height: 20px; border-radius: 10px; background: var(--green); position: relative; cursor: pointer; flex-shrink: 0; transition: background 0.15s; }
-.signal-toggle.off { background: var(--rule); }
-.signal-toggle::after { content: ''; position: absolute; width: 14px; height: 14px; background: #fff; border-radius: 50%; top: 3px; left: 3px; transition: left 0.15s; }
-.signal-toggle.off::after { left: 19px; }
-.signal-card-desc { font-size: 13px; color: var(--ink-3); line-height: 1.6; margin-bottom: 12px; }
-.signal-card-stat { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--copper); }
-.kpi-card { background: #fff; border: 1px solid var(--rule); border-radius: 10px; padding: 22px; }
-.kpi-val { font-family: 'Playfair Display', serif; font-size: 34px; font-weight: 700; color: var(--ink); line-height: 1; margin-bottom: 4px; }
-.kpi-label { font-size: 12px; color: var(--ink-3); margin-bottom: 6px; }
-.funnel-row { display: flex; align-items: center; gap: 12px; padding: 10px 0; border-bottom: 1px solid var(--rule); }
-.funnel-row:last-child { border-bottom: none; }
-.funnel-label { font-size: 13px; color: var(--ink-2); width: 120px; flex-shrink: 0; }
-.funnel-bar-wrap { flex: 1; background: var(--rule); border-radius: 99px; height: 10px; overflow: hidden; }
-.funnel-bar { height: 10px; border-radius: 99px; background: var(--amber); }
-.funnel-pct { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-3); width: 48px; text-align: right; }
-.funnel-count { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-2); width: 52px; text-align: right; }
-.report-table { width: 100%; border-collapse: collapse; }
-.report-table th { text-align: left; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.1em; padding: 8px 12px; border-bottom: 1px solid var(--rule); }
-.report-table td { padding: 12px 12px; border-bottom: 1px solid var(--rule); font-size: 13.5px; color: var(--ink-2); }
-.report-table tr:last-child td { border-bottom: none; }
-.report-table tr:hover td { background: var(--surface); }
-.settings-layout { display: flex; gap: 0; }
-.settings-nav { width: 192px; min-width: 192px; padding: 0 0 20px; }
-.settings-nav-item { padding: 9px 14px; font-size: 13.5px; color: var(--ink-3); cursor: pointer; border-radius: 6px; transition: background 0.1s, color 0.1s; font-weight: 400; margin-bottom: 2px; }
-.settings-nav-item:hover { background: var(--surface); color: var(--ink); }
-.settings-nav-item.active { background: var(--amber-soft); color: var(--copper); font-weight: 500; }
-.settings-content { flex: 1; padding-left: 28px; }
-.settings-section { display: none; }
-.settings-section.active { display: block; }
-.settings-row { display: flex; align-items: flex-start; gap: 12px; padding: 18px 0; border-bottom: 1px solid var(--rule); }
-.settings-row:last-child { border-bottom: none; }
-.settings-row-label { width: 180px; flex-shrink: 0; }
-.settings-row-key { font-size: 13.5px; font-weight: 500; color: var(--ink); margin-bottom: 2px; }
-.settings-row-sub { font-size: 12px; color: var(--ink-3); }
-.settings-row-val { flex: 1; font-size: 13.5px; color: var(--ink-2); }
-.settings-row-action { flex-shrink: 0; }
-.integration-row { display: flex; align-items: center; gap: 14px; padding: 16px 0; border-bottom: 1px solid var(--rule); }
-.integration-row:last-child { border-bottom: none; }
-.integration-icon-text { width: 36px; height: 36px; border-radius: 8px; background: var(--surface); display: flex; align-items: center; justify-content: center; font-size: 10px; font-family: 'JetBrains Mono', monospace; font-weight: 500; color: var(--ink-3); flex-shrink: 0; }
-.integration-name { flex: 1; font-weight: 500; font-size: 14px; color: var(--ink); }
-.integration-desc { font-size: 12px; color: var(--ink-3); }
-.badge-connected { background: rgba(107,142,90,0.12); color: var(--green); }
-.danger-zone { border: 1px solid rgba(181,90,76,0.2); border-radius: 10px; padding: 24px; }
-.danger-zone-title { font-family: 'Playfair Display', serif; font-size: 18px; font-weight: 700; color: var(--red); margin-bottom: 16px; }
-.danger-row { display: flex; align-items: center; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--rule); }
-.danger-row:last-child { border-bottom: none; }
-.danger-row-info { flex: 1; }
-.danger-row-title { font-size: 14px; font-weight: 500; color: var(--ink); }
-.danger-row-sub { font-size: 12px; color: var(--ink-3); }
-.btn-danger { background: transparent; border: 1px solid var(--red); color: var(--red); font-size: 13px; padding: 7px 16px; border-radius: 5px; font-weight: 500; transition: background 0.15s; cursor: pointer; }
-.btn-danger:hover { background: rgba(181,90,76,0.08); }
-.briefing-meeting-header { background: var(--ink); color: #fff; border-radius: 10px; padding: 24px 28px; margin-bottom: 24px; display: flex; align-items: center; gap: 24px; flex-wrap: wrap; }
-.briefing-countdown { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: rgba(255,255,255,0.5); }
-.briefing-section { margin-bottom: 28px; }
-.briefing-section-title { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 500; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-3); margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--rule); }
-.briefing-ai-summary { font-family: 'Playfair Display', serif; font-style: italic; font-size: 15px; color: var(--ink-2); line-height: 1.7; padding: 16px; background: var(--amber-soft); border-left: 3px solid var(--amber); }
-.reply-quote { background: var(--amber-soft); border-left: 3px solid var(--amber); padding: 14px 18px; font-size: 14px; color: var(--ink-2); font-style: italic; line-height: 1.6; margin: 12px 0; }
-.talking-point { padding: 10px 0; border-bottom: 1px solid var(--rule); font-size: 13.5px; color: var(--ink-2); }
-.talking-point:last-child { border-bottom: none; }
-.talking-point strong { color: var(--ink); }
-.case-study-card { background: var(--surface); border-radius: 8px; padding: 16px; }
-.case-study-name { font-family: 'Playfair Display', serif; font-size: 15px; font-weight: 700; color: var(--ink); margin-bottom: 4px; }
-.dev-controls { position: fixed; bottom: 20px; right: 20px; display: flex; gap: 6px; z-index: 300; background: rgba(12,10,8,0.85); border-radius: 8px; padding: 8px 10px; }
-.dev-btn { background: transparent; border: 1px solid rgba(255,255,255,0.2); color: rgba(255,255,255,0.6); font-family: 'JetBrains Mono', monospace; font-size: 10px; padding: 4px 10px; border-radius: 4px; cursor: pointer; transition: all 0.15s; letter-spacing: 0.06em; }
-.dev-btn:hover { border-color: var(--amber); color: var(--amber); }
-.dev-btn.active { border-color: var(--amber); color: var(--amber); background: var(--amber-soft); }
-.dev-label { font-family: 'JetBrains Mono', monospace; font-size: 9px; color: rgba(255,255,255,0.3); display: flex; align-items: center; padding-right: 6px; letter-spacing: 0.1em; text-transform: uppercase; }
-#mobile-topbar { display: none; position: fixed; top: 0; left: 0; right: 0; height: 52px; background: var(--ink); z-index: 120; align-items: center; padding: 0 16px; gap: 12px; }
-.hamburger-btn { background: transparent; border: none; color: #fff; font-size: 20px; line-height: 1; padding: 4px; display: flex; align-items: center; }
-.mobile-logo { font-family: 'Playfair Display', serif; font-size: 18px; color: #fff; }
-.mobile-logo em { color: var(--amber); font-style: italic; }
-#bottom-nav { display: none; position: fixed; bottom: 0; left: 0; right: 0; height: 56px; background: var(--ink); border-top: 1px solid rgba(255,255,255,0.08); z-index: 120; align-items: stretch; }
-.bottom-nav-item { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px; color: rgba(255,255,255,0.4); font-size: 9px; font-family: 'JetBrains Mono', monospace; cursor: pointer; letter-spacing: 0.06em; text-transform: uppercase; transition: color 0.15s; }
-.bottom-nav-item.active { color: var(--amber); }
-.bottom-nav-icon { font-size: 16px; line-height: 1; }
-@media (max-width: 768px) {
-  #sidebar { transform: translateX(-100%); transition: transform 0.25s; }
-  #sidebar.mobile-open { transform: translateX(0); }
-  #mobile-topbar { display: flex; }
-  #bottom-nav { display: flex; }
-  #app { margin-left: 0; padding-top: 52px; padding-bottom: 56px; }
-  #topbar { display: none; }
-  #page { padding: 20px 16px 40px; }
-  .grid-4 { grid-template-columns: 1fr 1fr; }
-  .grid-3 { grid-template-columns: 1fr 1fr; }
-  .grid-2 { grid-template-columns: 1fr; }
-  .schedule-hero { flex-direction: column; gap: 20px; }
-  .schedule-stats { flex-wrap: wrap; gap: 16px; }
-  .detail-headline { font-size: 28px; }
-  .page-headline { font-size: 28px; }
-  .inbox-layout { flex-direction: column; height: auto; }
-  .inbox-list { width: 100%; min-width: unset; border-radius: 10px 10px 0 0; }
-  .inbox-thread { border-left: 1px solid var(--rule); border-radius: 0 0 10px 10px; }
-  .settings-layout { flex-direction: column; }
-  .settings-nav { width: 100%; display: flex; flex-wrap: wrap; gap: 6px; padding-bottom: 12px; border-bottom: 1px solid var(--rule); margin-bottom: 16px; }
-  .settings-content { padding-left: 0; }
-  .grade-grid { grid-template-columns: repeat(2, 1fr); }
-  .pipeline-dm { display: none; }
-  .pipeline-channels { display: none; }
-  .calendar-grid { gap: 2px; }
-  .cal-cell { min-height: 44px; }
-  .dev-controls { bottom: 70px; }
+.btn-outline:hover { border-color: var(--amber); color: var(--copper); }
+.btn:active { filter: brightness(0.92); }
+
+/* ========== HOME — BDR HERO ========== */
+.bdr-hero { background: var(--ink); color: #fff; border-radius: 12px; padding: 24px 28px; margin-bottom: 22px; display: grid; grid-template-columns: 60px 1fr; gap: 20px; align-items: center; }
+.bdr-avatar { width: 60px; height: 60px; border-radius: 50%; background: linear-gradient(135deg, var(--amber), #a87044); display: grid; place-items: center; font-family: 'Playfair Display', serif; font-weight: 700; font-size: 24px; color: var(--on-amber); }
+.bdr-hero .h-eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.16em; color: rgba(255,255,255,0.45); text-transform: uppercase; margin-bottom: 6px; }
+.bdr-hero .h-line { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 22px; line-height: 1.3; letter-spacing: -0.01em; }
+.bdr-hero .h-line em { color: var(--amber); font-style: italic; }
+
+/* Summary stats row */
+.sum-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 26px; }
+.sum-card { background: var(--panel-bg); border: 1px solid var(--rule); border-radius: 10px; padding: 16px 18px; }
+.sum-val { font-family: 'Playfair Display', serif; font-size: 28px; font-weight: 700; color: var(--ink); line-height: 1; }
+.sum-val em { font-style: normal; color: var(--amber); font-size: 18px; }
+.sum-label { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.12em; color: var(--ink-3); text-transform: uppercase; margin-top: 6px; }
+.sum-delta { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--green); margin-top: 4px; }
+
+/* Today strip */
+.today-strip-head { display: flex; justify-content: space-between; align-items: baseline; margin: 8px 0 12px; }
+.today-strip-head .h { font-family: 'Playfair Display', serif; font-size: 18px; font-weight: 700; color: var(--ink); }
+.today-strip-head .h em { color: var(--amber); font-style: italic; }
+.today-strip-head .meta { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
+.today-strip { display: flex; gap: 12px; overflow-x: auto; padding-bottom: 8px; margin: 0 -4px 24px; padding-left: 4px; padding-right: 4px; scroll-snap-type: x mandatory; }
+.today-card { flex: 0 0 280px; background: var(--panel-bg); border: 1px solid var(--rule); border-radius: 10px; padding: 14px 16px; cursor: pointer; transition: border-color .12s, box-shadow .12s; scroll-snap-align: start; }
+.today-card:hover { border-color: var(--amber); box-shadow: 0 2px 10px rgba(212,149,106,0.1); }
+.today-card .tc-time { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--copper); font-weight: 600; letter-spacing: 0.06em; }
+.today-card .tc-name { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 16px; color: var(--ink); margin-top: 4px; line-height: 1.3; }
+.today-card .tc-dm { font-size: 12.5px; color: var(--ink-2); margin-top: 2px; }
+.today-card .tc-foot { display: flex; justify-content: space-between; align-items: center; margin-top: 12px; padding-top: 10px; border-top: 1px dashed var(--rule); }
+.today-card .tc-foot .vr { width: 24px; height: 24px; font-size: 12px; }
+.today-card .tc-link { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.08em; color: var(--copper); text-transform: uppercase; }
+.today-empty { background: var(--surface); border: 1px dashed var(--rule); border-radius: 10px; padding: 18px 22px; font-size: 13px; color: var(--ink-2); margin-bottom: 24px; }
+.today-empty b { color: var(--ink); }
+html.dark .today-empty { background: rgba(255,255,255,0.03); }
+
+/* Maya working strip */
+.maya-strip { background: var(--amber-soft); border: 1px solid var(--amber-glow); border-left: 3px solid var(--amber); border-radius: 8px; padding: 14px 18px; margin-bottom: 20px; cursor: pointer; transition: background .12s; }
+.maya-strip:hover { background: rgba(212,149,106,0.18); }
+.maya-strip-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.maya-strip-line { font-size: 13px; color: var(--ink); }
+.maya-strip-line b { color: var(--copper); }
+.maya-strip-chev { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--copper); letter-spacing: 0.08em; }
+.maya-strip-detail { display: none; margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--amber-glow); font-size: 12.5px; color: var(--ink-2); line-height: 1.6; }
+.maya-strip.open .maya-strip-detail { display: block; }
+.maya-strip-list { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-top: 8px; }
+.maya-action { background: var(--panel-bg); border-radius: 6px; padding: 10px 12px; }
+.maya-action .ma-cnt { font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 700; color: var(--copper); }
+.maya-action .ma-l { font-size: 11.5px; color: var(--ink-2); margin-top: 2px; }
+
+/* Funnel bar */
+.funnel-bar { display: flex; align-items: stretch; height: 36px; border-radius: 6px; overflow: hidden; border: 1px solid var(--rule); margin-bottom: 6px; }
+.funnel-seg { padding: 0 14px; display: flex; flex-direction: column; justify-content: center; min-width: 0; border-right: 1px solid rgba(255,255,255,0.18); color: #fff; font-family: 'JetBrains Mono', monospace; overflow: hidden; }
+.funnel-seg:last-child { border-right: 0; }
+.funnel-seg .fs-n { font-size: 13px; font-weight: 700; line-height: 1; white-space: nowrap; }
+.funnel-seg .fs-l { font-size: 9px; letter-spacing: 0.1em; opacity: 0.85; margin-top: 2px; white-space: nowrap; }
+.fs-discovered { background: var(--ink-3); }
+.fs-contacted { background: var(--blue); }
+.fs-replied { background: var(--amber); color: var(--on-amber); }
+.fs-meeting { background: var(--green); }
+.fs-won { background: var(--copper); }
+.funnel-meta { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); margin-top: 6px; letter-spacing: 0.04em; }
+
+/* Attention */
+.attention-card { background: var(--amber-soft); border: 1px solid var(--amber); border-left: 3px solid var(--amber); border-radius: 10px; padding: 14px 16px; margin-bottom: 10px; display: grid; grid-template-columns: 28px 1fr auto; gap: 12px; align-items: center; cursor: pointer; transition: background .12s; }
+.attention-card:hover { background: rgba(212,149,106,0.2); }
+.attention-card.meeting { background: rgba(107,142,90,0.10); border-color: var(--green); border-left-color: var(--green); }
+.attention-card.reply { background: rgba(107,142,90,0.08); border-color: var(--green); border-left-color: var(--green); }
+.attention-card.reply:hover { background: rgba(107,142,90,0.16); }
+.attention-card.reply .att-ic { background: var(--green); color: #fff; }
+.attention-card.downgrade { background: rgba(181,90,76,0.08); border-color: var(--red); border-left-color: var(--red); }
+.attention-card.downgrade:hover { background: rgba(181,90,76,0.14); }
+.attention-card.downgrade .att-ic { background: var(--red); color: #fff; }
+.att-ic { width: 28px; height: 28px; border-radius: 7px; background: var(--amber); color: var(--on-amber); display: grid; place-items: center; font-size: 14px; font-weight: 700; }
+.attention-card.meeting .att-ic { background: var(--green); color: #fff; }
+.att-text { font-size: 13px; color: var(--ink-2); line-height: 1.5; }
+.att-text b { color: var(--ink); font-weight: 600; }
+.att-cta { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.08em; color: var(--copper); text-transform: uppercase; padding: 6px 10px; border: 1px solid var(--copper); border-radius: 4px; white-space: nowrap; }
+
+/* Quality spot-check section removed in v4 (Fix 3). Pipeline F Stage 10
+   critic loop handles message QA automatically; showing spot-check on
+   the dashboard is redundant. */
+
+/* ========== PIPELINE ========== */
+.pipe-controls { display: flex; align-items: center; gap: 14px; margin-bottom: 18px; flex-wrap: wrap; }
+.view-toggle { display: flex; background: var(--surface); border-radius: 6px; padding: 2px; }
+html.dark .view-toggle { background: rgba(255,255,255,0.04); }
+.vt-btn { padding: 6px 14px; font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.06em; color: var(--ink-3); border-radius: 4px; }
+.vt-btn.active { background: var(--ink); color: #fff; font-weight: 600; }
+html.dark .vt-btn.active { background: var(--amber); color: var(--on-amber); }
+.filter-chips { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* Board */
+.board {
+  display: grid; grid-template-columns: repeat(5, minmax(260px, 1fr));
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 14px;
+  scroll-snap-type: x mandatory;
+  margin-left: -4px; margin-right: -4px; padding-left: 4px; padding-right: 4px;
 }
-.detail-layout { display: grid; grid-template-columns: 1fr 320px; gap: 24px; }
-@media (max-width: 960px) { .detail-layout { grid-template-columns: 1fr; } }
+.col { min-width: 0; background: var(--surface); border: 1px solid var(--rule); border-radius: 10px; display: flex; flex-direction: column; max-height: calc(100vh - 240px); scroll-snap-align: start; }
+html.dark .col { background: rgba(255,255,255,0.02); }
+.col-head { padding: 12px 14px; border-bottom: 1px solid var(--rule); display: flex; align-items: center; justify-content: space-between; gap: 10px; background: var(--panel-bg); border-radius: 10px 10px 0 0; position: relative; flex-shrink: 0; }
+.col-head::before { content: ''; position: absolute; top: 0; left: 10px; right: 10px; height: 3px; border-radius: 0 0 3px 3px; }
+.col-discovered .col-head::before { background: var(--ink-3); }
+.col-contacted .col-head::before { background: var(--blue); }
+.col-replied .col-head::before { background: var(--amber); }
+.col-meeting .col-head::before { background: var(--green); }
+.col-wonlost .col-head::before { background: linear-gradient(90deg, var(--green) 50%, var(--red) 50%); }
+.col-name { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-2); font-weight: 600; }
+.col-count { display: inline-flex; gap: 6px; font-family: 'JetBrains Mono', monospace; font-size: 10px; }
+.col-count .cn { background: var(--ink); color: #fff; padding: 1px 7px; border-radius: 10px; font-weight: 600; }
+.col-count .cp { color: var(--ink-3); }
+html.dark .col-count .cn { background: var(--amber); color: var(--on-amber); }
+.col-body { padding: 10px; display: flex; flex-direction: column; gap: 10px; overflow-y: auto; min-height: 80px; }
+.col-body-split { padding: 0; }
+.split-section { padding: 10px 10px 6px; display: flex; flex-direction: column; gap: 8px; }
+.split-label { font-family: 'JetBrains Mono', monospace; font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; padding: 6px 0 2px; }
+.split-label.won { color: var(--green); }
+.split-label.lost { color: var(--red); }
+
+.k-card { background: var(--panel-bg); border: 1px solid var(--rule); border-left: 3px solid var(--rule); border-radius: 6px; padding: 16px 20px; cursor: pointer; transition: border-color .12s, box-shadow .12s, transform .08s; line-height: 1.6; }
+.k-card:hover { border-color: var(--amber); box-shadow: 0 2px 10px rgba(212,149,106,0.1); transform: translateY(-1px); }
+.col-discovered .k-card { border-left-color: var(--ink-3); }
+.col-contacted .k-card { border-left-color: var(--blue); }
+.col-replied .k-card { border-left-color: var(--amber); }
+.col-meeting .k-card { border-left-color: var(--green); }
+.col-wonlost .split-section.won .k-card { border-left-color: var(--green); }
+.col-wonlost .split-section.lost .k-card { border-left-color: var(--red); }
+.k-name { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 14px; color: var(--ink); line-height: 1.3; }
+.k-dm { font-size: 12px; color: var(--ink-2); margin-top: 2px; }
+.k-dm-title { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); margin-top: 1px; }
+.k-meta { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; color: var(--ink-3); margin-top: 4px; letter-spacing: 0.03em; }
+.k-foot { display: flex; justify-content: space-between; align-items: center; margin-top: 10px; padding-top: 8px; border-top: 1px dashed var(--rule); gap: 6px; flex-wrap: wrap; }
+.k-left { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.k-left .vr { width: 24px; height: 24px; font-size: 12px; border-radius: 5px; }
+.k-score { font-family: 'JetBrains Mono', monospace; font-size: 14px; font-weight: 600; color: var(--copper); }
+.k-time { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); white-space: nowrap; }
+.col-empty { color: var(--ink-3); font-size: 11.5px; font-style: italic; padding: 16px 10px; text-align: center; }
+
+/* Pipeline table */
+.pipe-table { width: 100%; border-collapse: collapse; background: var(--panel-bg); border: 1px solid var(--rule); border-radius: 10px; overflow: hidden; font-size: 13px; }
+.pipe-table thead th { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); text-align: left; padding: 14px 18px; background: var(--surface); border-bottom: 1px solid var(--rule); cursor: pointer; }
+html.dark .pipe-table thead th { background: rgba(255,255,255,0.02); }
+.pipe-table thead th:hover { color: var(--amber); }
+.pipe-table tbody tr { border-bottom: 1px solid var(--rule); cursor: pointer; transition: background .12s; }
+.pipe-table tbody tr:hover { background: var(--amber-glow); }
+.pipe-table td { padding: 16px 18px; color: var(--ink-2); line-height: 1.6; }
+.pipe-table td.name-col { color: var(--ink); font-weight: 600; font-family: 'Playfair Display', serif; font-size: 14px; }
+.pipe-table td.score-col { font-family: 'JetBrains Mono', monospace; color: var(--copper); font-weight: 600; text-align: right; }
+.pipe-table td.dm-title { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); }
+.pipe-table td.mono { font-family: 'JetBrains Mono', monospace; font-size: 11.5px; color: var(--ink-3); }
+
+/* ========== FEED ========== */
+.feed-day { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.18em; color: var(--ink-3); text-transform: uppercase; padding: 22px 4px 10px; }
+.feed-day:first-child { padding-top: 6px; }
+.event-card { background: var(--panel-bg); border: 1px solid var(--rule); border-radius: 10px; margin-bottom: 10px; overflow: hidden; transition: border-color .12s, box-shadow .12s; }
+.event-card.expandable { cursor: pointer; }
+.event-card.expandable:hover { border-color: var(--amber); box-shadow: 0 1px 12px rgba(212,149,106,0.08); }
+.event-card.expanded { border-color: var(--amber); }
+.event-row { display: grid; grid-template-columns: 56px 38px 1fr auto; gap: 12px; padding: 14px 16px; align-items: flex-start; }
+.event-time { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; color: var(--ink-3); padding-top: 6px; white-space: nowrap; }
+.event-ico { width: 38px; height: 38px; border-radius: 10px; display: grid; place-items: center; font-size: 16px; flex-shrink: 0; }
+.event-ico.reply { background: rgba(107,142,90,0.16); color: var(--green); }
+.event-ico.meeting { background: rgba(74,111,165,0.14); color: var(--blue); }
+.event-ico.signal { background: var(--amber-soft); color: var(--copper); }
+.event-ico.outreach { background: rgba(12,10,8,0.05); color: var(--ink-3); }
+.event-ico.voice { background: rgba(196,106,62,0.14); color: var(--copper); }
+.event-ico.linkedin { background: rgba(74,111,165,0.14); color: var(--blue); }
+html.dark .event-ico.outreach { background: rgba(255,255,255,0.06); color: var(--ink-2); }
+.event-body { min-width: 0; }
+.event-type { font-family: 'JetBrains Mono', monospace; font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--copper); font-weight: 600; margin-bottom: 4px; }
+.event-headline { font-size: 14px; color: var(--ink); line-height: 1.45; font-weight: 500; }
+.event-headline .biz { color: var(--ink); font-weight: 700; cursor: pointer; border-bottom: 1px dotted var(--ink-3); }
+.event-headline .biz:hover { color: var(--copper); border-color: var(--copper); }
+.event-quote { font-family: 'Playfair Display', serif; font-style: italic; font-size: 14px; color: var(--ink-2); line-height: 1.55; margin-top: 6px; padding: 8px 12px; background: var(--surface); border-left: 3px solid var(--amber); border-radius: 0 6px 6px 0; }
+html.dark .event-quote { background: rgba(255,255,255,0.04); }
+.event-meta { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; color: var(--ink-3); margin-top: 5px; }
+.event-side { display: flex; align-items: center; gap: 6px; padding-top: 4px; }
+.event-side .vr { width: 28px; height: 28px; font-size: 14px; border-radius: 6px; }
+.event-chev { color: var(--ink-3); font-size: 14px; transition: transform .15s, color .15s; }
+.event-card.expanded .event-chev { transform: rotate(90deg); color: var(--amber); }
+.event-expand { display: none; padding: 0 16px 14px 110px; border-top: 1px dashed var(--rule); font-size: 13px; color: var(--ink-2); line-height: 1.55; }
+.event-card.expanded .event-expand { display: block; padding-top: 12px; }
+.event-expand h5 { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; color: var(--ink-3); text-transform: uppercase; margin: 12px 0 6px; font-weight: 600; }
+.event-expand h5:first-child { margin-top: 0; }
+.event-expand .actions { display: flex; gap: 8px; margin-top: 10px; }
+
+/* ========== MEETINGS — Calendar ========== */
+.cal-grid { display: grid; grid-template-columns: 56px repeat(5, 1fr); border: 1px solid var(--rule); border-radius: 10px; overflow: hidden; background: var(--panel-bg); margin-bottom: 24px; }
+.cal-corner { background: var(--surface); border-bottom: 1px solid var(--rule); }
+html.dark .cal-corner { background: rgba(255,255,255,0.02); }
+.cal-day-head { background: var(--surface); border-bottom: 1px solid var(--rule); border-left: 1px solid var(--rule); padding: 10px 12px; text-align: center; font-family: 'JetBrains Mono', monospace; }
+html.dark .cal-day-head { background: rgba(255,255,255,0.02); }
+.cal-day-head .ddow { font-size: 10px; letter-spacing: 0.16em; color: var(--ink-3); text-transform: uppercase; }
+.cal-day-head .dnum { font-family: 'Playfair Display', serif; font-size: 22px; font-weight: 700; color: var(--ink); margin-top: 2px; }
+.cal-day-head.today { background: var(--amber-soft); border-bottom: 2px solid var(--amber); position: relative; }
+.cal-day-head.today .ddow { color: var(--copper); font-weight: 700; }
+.cal-day-head.today::after { content: 'TODAY'; position: absolute; top: 4px; right: 6px; font-family: 'JetBrains Mono', monospace; font-size: 8px; letter-spacing: 0.16em; color: var(--copper); font-weight: 700; }
+.cal-time { border-bottom: 1px solid var(--rule); padding: 4px 8px 0; font-family: 'JetBrains Mono', monospace; font-size: 9.5px; color: var(--ink-3); text-align: right; height: 44px; }
+.cal-slot { border-bottom: 1px solid var(--rule); border-left: 1px solid var(--rule); height: 44px; position: relative; padding: 2px 4px; }
+.cal-slot.today-col { background: rgba(212,149,106,0.04); }
+.cal-event { position: absolute; left: 4px; right: 4px; background: var(--amber-soft); border: 1px solid var(--amber); border-left: 3px solid var(--amber); border-radius: 5px; padding: 5px 8px; cursor: pointer; z-index: 2; transition: box-shadow .12s, transform .08s; overflow: hidden; }
+.cal-event:hover { box-shadow: 0 2px 10px rgba(212,149,106,0.25); transform: translateY(-1px); }
+.cal-event.green { background: rgba(107,142,90,0.14); border-color: var(--green); border-left-color: var(--green); }
+.cal-event-time { font-family: 'JetBrains Mono', monospace; font-size: 9.5px; color: var(--copper); font-weight: 600; line-height: 1.1; }
+.cal-event.green .cal-event-time { color: var(--green); }
+.cal-event-name { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 12px; color: var(--ink); margin-top: 1px; line-height: 1.25; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cal-event-vr { position: absolute; top: 4px; right: 4px; width: 18px; height: 18px; border-radius: 4px; display: grid; place-items: center; color: #fff; font-family: 'Playfair Display', serif; font-weight: 700; font-size: 11px; }
+.cal-event-vr[data-g="A"], .cal-event-vr[data-g="B"] { background: var(--green); }
+.cal-event-vr[data-g="C"] { background: var(--amber); color: var(--on-amber); }
+.cal-event-vr[data-g="D"] { background: var(--copper); }
+.cal-event-vr[data-g="F"] { background: var(--red); }
+
+/* Meetings — day view (mobile) */
+.day-view { display: none; }
+.day-view-card { background: var(--panel-bg); border: 1px solid var(--rule); border-radius: 10px; margin-bottom: 22px; overflow: hidden; }
+.day-view-head { padding: 14px 16px; border-bottom: 1px solid var(--rule); background: var(--amber-soft); }
+.day-view-head .h-day { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.16em; color: var(--copper); text-transform: uppercase; font-weight: 700; }
+.day-view-head .h-date { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 22px; color: var(--ink); margin-top: 2px; }
+.day-view-body { padding: 12px 14px; }
+.day-meet { padding: 12px 14px; border: 1px solid var(--rule); border-left: 3px solid var(--amber); border-radius: 6px; margin-bottom: 8px; cursor: pointer; }
+.day-meet:hover { box-shadow: 0 1px 8px rgba(212,149,106,0.08); }
+.day-meet .dm-time { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--copper); font-weight: 600; }
+.day-meet .dm-name { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 14px; color: var(--ink); margin-top: 2px; }
+.day-meet .dm-dm { font-size: 12px; color: var(--ink-2); margin-top: 1px; }
+
+.upcoming-row { display: grid; grid-template-columns: 30px 1fr auto; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--rule); align-items: center; cursor: pointer; }
+.upcoming-row:last-child { border-bottom: 0; }
+.upcoming-row:hover { background: var(--amber-glow); }
+.upcoming-row .ur-vr { width: 30px; height: 30px; font-size: 14px; border-radius: 6px; }
+.upcoming-row .ur-main .ur-n { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 14px; color: var(--ink); }
+.upcoming-row .ur-main .ur-s { font-size: 11.5px; color: var(--ink-3); margin-top: 1px; }
+.upcoming-row .ur-when { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-2); text-align: right; }
+.upcoming-row .ur-when .cd { color: var(--copper); margin-top: 2px; font-size: 10.5px; }
+
+/* Briefing PAGE (meetings only) */
+.bp-back { display: inline-flex; align-items: center; gap: 6px; font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); padding: 6px 10px; border-radius: 4px; margin-bottom: 14px; cursor: pointer; }
+.bp-back:hover { color: var(--copper); background: var(--amber-glow); }
+.bp-header { background: var(--ink); color: #fff; border-radius: 12px; padding: 24px 28px; margin-bottom: 18px; display: flex; align-items: center; gap: 22px; flex-wrap: wrap; }
+.bp-header .bp-eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; color: rgba(255,255,255,0.45); text-transform: uppercase; }
+.bp-header .bp-when { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 22px; margin-top: 4px; line-height: 1.2; }
+.bp-header .bp-cd { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--amber); margin-top: 4px; }
+.bp-header .bp-spacer { flex: 1; }
+.bp-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.bp-actions .btn { padding: 9px 16px; font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.08em; font-weight: 700; text-transform: uppercase; border-radius: 6px; }
+.bp-actions .btn-amber { background: var(--amber); color: var(--on-amber); }
+.bp-actions .btn-ghost { background: rgba(255,255,255,0.1); color: #fff; }
+.bp-actions .btn-ghost:hover { background: rgba(255,255,255,0.2); }
+.bp-pdf-btn .lbl-pdf { display: none; }
+.pma-row { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 20px; }
+.pma-btn { padding: 10px 16px; border-radius: 6px; font-size: 12.5px; font-weight: 600; color: #fff; font-family: 'JetBrains Mono', monospace; letter-spacing: 0.06em; text-transform: uppercase; }
+.pma-won { background: var(--green); }
+.pma-follow { background: var(--amber); color: var(--on-amber); }
+.pma-noshow { background: var(--red); }
+.pma-resched { background: transparent; color: var(--ink-2); border: 1px solid var(--rule); }
+
+/* ========== PROGRESS ========== */
+.kpi-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 22px; }
+.kpi-cell { background: var(--panel-bg); border: 1px solid var(--rule); border-radius: 10px; padding: 14px 16px; }
+.kpi-val { font-family: 'Playfair Display', serif; font-size: 28px; font-weight: 700; color: var(--ink); line-height: 1; }
+.kpi-val small { font-size: 14px; color: var(--ink-3); }
+.kpi-l { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.12em; color: var(--ink-3); text-transform: uppercase; margin-top: 6px; }
+.kpi-note { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; color: var(--ink-3); margin-top: 4px; font-style: italic; }
+.fr-row { display: flex; align-items: center; gap: 12px; padding: 6px 0; font-size: 13px; }
+.fr-row .l { width: 110px; color: var(--ink-2); font-family: 'JetBrains Mono', monospace; font-size: 11px; flex-shrink: 0; }
+.fr-row .b { flex: 1; height: 22px; background: rgba(12,10,8,0.04); border-radius: 4px; overflow: hidden; }
+html.dark .fr-row .b { background: rgba(255,255,255,0.04); }
+.fr-row .bf { height: 100%; background: linear-gradient(90deg, var(--amber), #a87044); display: flex; align-items: center; padding: 0 10px; color: var(--on-amber); font-family: 'JetBrains Mono', monospace; font-weight: 700; font-size: 11px; }
+.fr-row .pc { min-width: 50px; text-align: right; color: var(--copper); font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 600; }
+.roi-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+.roi-cell { background: var(--surface); border-radius: 10px; padding: 14px 16px; }
+html.dark .roi-cell { background: rgba(255,255,255,0.04); }
+.roi-val { font-family: 'Playfair Display', serif; font-size: 26px; font-weight: 700; color: var(--copper); line-height: 1; }
+.roi-l { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-3); margin-top: 6px; }
+
+/* ========== SETTINGS ========== */
+.set-row { display: grid; grid-template-columns: 200px 1fr; gap: 14px; padding: 14px 0; border-bottom: 1px solid var(--rule); align-items: center; }
+.set-row:last-child { border-bottom: 0; }
+.set-key { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); letter-spacing: 0.06em; }
+.set-val input, .set-val select, .set-val textarea { background: var(--cream); border: 1px solid var(--rule); border-radius: 6px; padding: 9px 12px; font-size: 13px; color: var(--ink); width: 100%; max-width: 380px; }
+html.dark .set-val input, html.dark .set-val select, html.dark .set-val textarea { background: rgba(255,255,255,0.04); }
+.set-val textarea { min-height: 70px; resize: vertical; }
+
+/* ========== GLOBAL RIGHT DRAWER ========== */
+.drawer-backdrop { position: fixed; inset: 0; background: rgba(12,10,8,0.55); backdrop-filter: blur(2px); z-index: 150; display: none; }
+.drawer-backdrop.on { display: block; }
+.drawer { position: fixed; right: 0; top: 0; bottom: 0; width: min(640px, 100%); background: var(--cream); border-left: 1px solid var(--rule); z-index: 160; transform: translateX(100%); transition: transform .3s cubic-bezier(.2,.7,.3,1); overflow-y: auto; }
+.drawer.on { transform: translateX(0); }
+.drawer-head { position: sticky; top: 0; z-index: 3; background: var(--cream); padding: 18px 22px; border-bottom: 1px solid var(--rule); display: flex; justify-content: space-between; align-items: flex-start; gap: 14px; }
+.drawer-close { width: 44px; height: 44px; font-size: 24px; color: var(--ink-3); display: grid; place-items: center; border-radius: 8px; }
+.drawer-close:hover { color: var(--copper); background: var(--amber-glow); }
+.dh-name { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 22px; color: var(--ink); margin-top: 3px; }
+.dh-sub { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); margin-top: 2px; }
+.drawer-body { padding: 18px 22px 40px; }
+.bf-section { margin-bottom: 20px; }
+.bf-section h4 { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-3); margin-bottom: 10px; padding-bottom: 6px; border-bottom: 1px solid var(--rule); font-weight: 600; }
+.bf-ai { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--copper); letter-spacing: 0.12em; text-transform: uppercase; margin: -6px 0 14px; }
+.bf-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; padding: 14px; background: var(--surface); border-radius: 8px; }
+.bf-meta .bf-kv { padding: 6px 0; }
+html.dark .bf-meta { background: rgba(255,255,255,0.04); }
+.bf-kv { display: flex; justify-content: space-between; padding: 4px 0; font-size: 12px; }
+.bf-kv .k { color: var(--ink-3); }
+.bf-kv .v { color: var(--ink); font-weight: 500; font-family: 'JetBrains Mono', monospace; }
+.bf-hook { font-family: 'Playfair Display', serif; font-style: italic; font-size: 15px; color: var(--ink-2); line-height: 1.7; padding: 14px 16px; background: var(--surface); border-left: 3px solid var(--amber); border-radius: 0 6px 6px 0; }
+html.dark .bf-hook { background: rgba(255,255,255,0.04); }
+.bf-list li { margin-bottom: 8px; font-size: 13px; color: var(--ink-2); line-height: 1.55; }
+.bf-obj { padding: 12px 14px; background: var(--surface); border-radius: 8px; margin-bottom: 10px; }
+html.dark .bf-obj { background: rgba(255,255,255,0.04); }
+.bf-obj .obj-q { font-size: 13px; font-weight: 600; color: var(--ink); margin-bottom: 6px; }
+.bf-obj .obj-a { font-size: 12.5px; color: var(--ink-2); line-height: 1.55; }
+.vr-strip { display: flex; gap: 6px; margin-top: 6px; flex-wrap: wrap; }
+.vr-cw { display: flex; flex-direction: column; align-items: center; gap: 3px; }
+.vr-letter { width: 26px; height: 26px; border-radius: 5px; display: grid; place-items: center; color: #fff; font-family: 'Playfair Display', serif; font-weight: 700; font-size: 13px; }
+.vr-letter[data-g="A"], .vr-letter[data-g="B"] { background: var(--green); }
+.vr-letter[data-g="C"] { background: var(--amber); color: var(--on-amber); }
+.vr-letter[data-g="D"] { background: var(--copper); }
+.vr-letter[data-g="F"] { background: var(--red); }
+.vr-name { font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--ink-3); letter-spacing: 0.04em; text-transform: uppercase; }
+
+/* ========== MOBILE-TOPBAR + BOTTOM-NAV ========== */
+#mobile-topbar { display: none; position: fixed; top: 0; left: 0; right: 0; height: 52px; background: var(--brand-bar); color: #fff; z-index: 130; align-items: center; padding: 0 14px; gap: 12px; }
+.mobile-logo { font-family: 'Playfair Display', serif; font-size: 17px; }
+.mobile-logo em { color: var(--amber); font-style: italic; }
+#bottomnav { display: none; position: fixed; bottom: 0; left: 0; right: 0; height: var(--bottomnav-h); background: var(--brand-bar); border-top: 1px solid rgba(255,255,255,0.06); z-index: 100; }
+.bn-item { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px; color: rgba(255,255,255,0.55); font-size: 10.5px; font-family: 'JetBrains Mono', monospace; letter-spacing: 0.06em; cursor: pointer; }
+.bn-item .bn-ico { font-size: 17px; }
+.bn-item.active { color: var(--amber); }
 #sidebar-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; }
 #sidebar-overlay.show { display: block; }
-@media print {
-  #sidebar, #topbar, #bottom-nav, #mobile-topbar, .dev-controls, .detail-back, .detail-nav, .detail-actions { display: none !important; }
-  #app { margin-left: 0; }
-  #page { padding: 20px; }
-  .briefing-meeting-header { background: var(--ink) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+
+/* ========== SNAPSHOT 2-row layout (v4: bigger + spacious) ========== */
+.snap-card { padding: 24px !important; }
+.snap-head { display: flex; align-items: center; gap: 20px; flex-wrap: wrap; padding-bottom: 20px; border-bottom: 1px dashed var(--rule); }
+.snap-head .snap-vr { width: 52px; height: 52px; font-size: 22px; flex-shrink: 0; }
+.snap-head .snap-name { font-family: 'Playfair Display', serif; font-size: 24px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+.snap-head .snap-dm { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--ink-3); margin-top: 6px; letter-spacing: 0.04em; line-height: 1.5; }
+.snap-row { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; padding-top: 20px; }
+.snap-row + .snap-row { padding-top: 20px; border-top: 1px dashed var(--rule); margin-top: 20px; }
+.snap-row .snap-eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.16em; color: var(--ink-3); text-transform: uppercase; flex-basis: 100%; margin-bottom: -4px; font-weight: 600; }
+.snap-item { display: inline-flex; align-items: center; gap: 8px; font-size: 13px; color: var(--ink-2); margin-bottom: 8px; line-height: 1.5; }
+.snap-item .il { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--ink-3); letter-spacing: 0.06em; text-transform: uppercase; }
+.snap-item .iv { font-weight: 500; color: var(--ink); }
+.snap-sep { color: var(--ink-4); font-family: 'JetBrains Mono', monospace; font-size: 12px; }
+.snap-chip { display: inline-flex; align-items: center; gap: 6px; padding: 5px 11px; border-radius: 16px; background: var(--surface); font-size: 12px; color: var(--ink-2); border: 1px solid var(--rule); }
+html.dark .snap-chip { background: rgba(255,255,255,0.04); }
+.snap-chip b { color: var(--ink); font-weight: 600; }
+.snap-chip .sc-grade { width: 18px; height: 18px; border-radius: 4px; display: grid; place-items: center; color: #fff; font-family: 'Playfair Display', serif; font-weight: 700; font-size: 11px; }
+.snap-chip .sc-grade[data-g="A"], .snap-chip .sc-grade[data-g="B"] { background: var(--green); }
+.snap-chip .sc-grade[data-g="C"] { background: var(--amber); color: var(--on-amber); }
+.snap-chip .sc-grade[data-g="D"] { background: var(--copper); }
+.snap-chip .sc-grade[data-g="F"] { background: var(--red); }
+.snap-chip.score b { color: var(--copper); font-family: 'JetBrains Mono', monospace; }
+
+/* ========== SCHEDULE CARD (drawer section — v6) ========== */
+.sched-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; cursor: pointer; user-select: none; }
+.sched-head:hover .sched-chev { color: var(--copper); }
+.sched-head .sched-title { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-3); font-weight: 600; }
+.sched-head .sched-title .sched-sub { color: var(--ink-4); font-weight: 500; margin-left: 6px; letter-spacing: 0.08em; }
+.sched-chev { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-3); font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; transition: color .15s; }
+.sched-head:hover .sched-chev { color: var(--copper); }
+.sched-wrap[data-open="true"] .sched-chev { color: var(--copper); }
+/* v7: use display toggle (bulletproof across browsers) + opacity fade.
+   The previous max-height:0 → 640px transition was unreliable in some
+   layout contexts (flex parent, nested margins). */
+.sched-body { display: none; opacity: 0; transition: opacity .2s ease; }
+.sched-wrap[data-open="true"] .sched-body { display: block; opacity: 1; }
+.sched-inner { padding-top: 14px; border-top: 1px solid var(--rule); margin-top: 12px; }
+.sched-state { font-size: 13px; color: var(--ink-2); padding: 10px 14px; border-radius: 8px; background: var(--surface); line-height: 1.55; display: flex; gap: 10px; align-items: flex-start; }
+html.dark .sched-state { background: rgba(255,255,255,0.04); }
+.sched-state.complete { border-left: 3px solid var(--green); color: var(--ink); }
+.sched-state.paused { border-left: 3px solid var(--amber); color: var(--ink); }
+.sched-state.none { border-left: 3px solid var(--ink-3); color: var(--ink-2); font-style: italic; }
+.sched-state .sched-state-ic { font-size: 15px; flex-shrink: 0; }
+.sched-row { display: grid; grid-template-columns: 12px 82px 1fr; gap: 10px; align-items: center; padding: 10px 0; border-bottom: 1px dashed var(--rule); }
+.sched-row:last-of-type { border-bottom: 0; }
+.sched-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+.sched-dot.email { background: #6B8E5A; }
+.sched-dot.linkedin { background: #3B82F6; }
+.sched-dot.voice { background: #D4956A; }
+.sched-dot.sms { background: #8B5CF6; }
+.sched-date { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--ink-2); font-weight: 500; letter-spacing: 0.04em; }
+.sched-detail { min-width: 0; }
+.sched-ch { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; font-weight: 600; }
+.sched-ch.email { color: #5a7d4b; }
+.sched-ch.linkedin { color: #3262a0; }
+.sched-ch.voice { color: var(--copper); }
+.sched-ch.sms { color: #7256a0; }
+html.dark .sched-ch.email { color: #94b985; }
+html.dark .sched-ch.linkedin { color: #8ab4e8; }
+html.dark .sched-ch.sms { color: #b99bd4; }
+.sched-template { font-size: 12.5px; color: var(--ink); margin-top: 2px; line-height: 1.4; }
+.sched-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule); }
+.sched-actions button { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.06em; padding: 7px 12px; border-radius: 5px; background: transparent; border: 1px solid var(--rule); color: var(--ink-2); text-transform: uppercase; }
+.sched-actions button:hover { border-color: var(--amber); color: var(--copper); background: var(--amber-glow); }
+.sched-actions button.pause:hover { border-color: var(--red); color: var(--red); background: rgba(181,90,76,0.08); }
+
+/* ========== VR POPOVER ========== */
+/* v4 Fix 2: ALL .vr-letter are clickable everywhere — Pipeline, Table,
+   Feed, drawer, briefing. Gating from v3 reverted. */
+.vr-letter { cursor: pointer; transition: box-shadow .12s, transform .08s; }
+.vr-letter:hover { box-shadow: 0 0 0 3px var(--amber-soft); transform: scale(1.06); }
+/* Legacy .clickable kept for back-compat; identical behaviour. */
+.vr-letter.clickable { cursor: pointer; transition: box-shadow .12s, transform .08s; }
+.vr-letter.clickable:hover { box-shadow: 0 0 0 3px var(--amber-soft); transform: scale(1.06); }
+.vr-popover {
+  width: 340px;
+  background: #FFF8F0;       /* solid warm cream — opaque (Fix 1) */
+  border: 1px solid var(--copper);
+  border-radius: 10px;
+  padding: 16px 18px 18px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.15), 0 1px 3px rgba(0,0,0,0.08);
+  z-index: 220;              /* above drawer (160) + modal (200) */
+  font-size: 13px;
+  color: var(--ink);
+  line-height: 1.55;
+  position: absolute;
+}
+html.dark .vr-popover { background: #1F1B16; color: var(--ink); border-color: var(--copper); box-shadow: 0 4px 20px rgba(0,0,0,0.5), 0 1px 3px rgba(0,0,0,0.3); }
+.vr-pop-head { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; padding-right: 22px; }
+.vr-pop-head .vr-letter { width: 34px; height: 34px; font-size: 17px; cursor: default; }
+.vr-pop-head .vr-letter:hover { box-shadow: none; transform: none; }
+.vr-pop-key { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--copper); font-weight: 700; }
+.vr-pop-section { margin-top: 10px; }
+.vr-pop-section h6 { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase; color: var(--copper); margin-bottom: 4px; }
+.vr-pop-section p { font-size: 12.5px; color: var(--ink-2); line-height: 1.55; margin: 0; }
+.vr-pop-close { position: absolute; top: 6px; right: 8px; width: 28px; height: 28px; font-size: 18px; color: var(--ink-3); display: grid; place-items: center; border-radius: 6px; }
+.vr-pop-close:hover { color: var(--copper); background: rgba(196,106,62,0.1); }
+
+/* ========== COMMUNICATION TIMELINE ========== */
+.ct-wrap { position: relative; padding-left: 26px; }
+.ct-wrap::before { content: ''; position: absolute; left: 9px; top: 6px; bottom: 6px; width: 2px; background: linear-gradient(180deg, var(--amber), var(--rule)); border-radius: 2px; }
+.ct-row { position: relative; padding: 10px 0 10px 14px; }
+.ct-row::before {
+  content: ''; position: absolute; left: -22px; top: 14px;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--ink-3); border: 2px solid var(--cream); box-shadow: 0 0 0 1px var(--rule);
+}
+.ct-row.email::before { background: var(--blue); }
+.ct-row.linkedin::before { background: var(--blue); }
+.ct-row.voice::before { background: var(--copper); }
+.ct-row.sms::before { background: var(--ink-2); }
+.ct-row.reply::before { background: var(--amber); box-shadow: 0 0 0 4px var(--amber-glow); }
+.ct-row.meeting::before { background: var(--green); box-shadow: 0 0 0 4px rgba(107,142,90,0.18); width: 14px; height: 14px; left: -23px; }
+.ct-row .ct-time { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; color: var(--ink-3); letter-spacing: 0.04em; }
+.ct-row .ct-head { display: flex; align-items: center; gap: 8px; margin-top: 2px; }
+.ct-row .ct-ch { font-family: 'JetBrains Mono', monospace; font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; padding: 2px 6px; border-radius: 4px; font-weight: 600; }
+.ct-row .ct-ch.email { background: rgba(74,111,165,0.12); color: var(--blue); }
+.ct-row .ct-ch.linkedin { background: rgba(74,111,165,0.12); color: var(--blue); }
+.ct-row .ct-ch.voice { background: rgba(196,106,62,0.14); color: var(--copper); }
+.ct-row .ct-ch.sms { background: rgba(12,10,8,0.06); color: var(--ink-2); }
+.ct-row .ct-ch.reply { background: var(--amber-soft); color: var(--copper); }
+.ct-row .ct-ch.meeting { background: rgba(107,142,90,0.16); color: var(--green); }
+.ct-row .ct-label { font-size: 13px; font-weight: 600; color: var(--ink); }
+.ct-row .ct-detail { font-size: 12.5px; color: var(--ink-2); margin-top: 4px; line-height: 1.5; }
+.ct-row.reply .ct-detail { font-family: 'Playfair Display', serif; font-style: italic; padding: 8px 12px; background: var(--surface); border-left: 3px solid var(--amber); border-radius: 0 6px 6px 0; }
+html.dark .ct-row.reply .ct-detail { background: rgba(255,255,255,0.04); }
+.ct-row.meeting .ct-label { color: var(--green); }
+/* v8 Fix 2: clickable timeline rows + inline expand */
+.ct-row { cursor: pointer; border-radius: 6px; transition: background .12s; }
+.ct-row:hover { background: var(--amber-glow); }
+.ct-row .ct-chev { display: inline-block; margin-left: 8px; font-family: 'JetBrains Mono', monospace; font-size: 9.5px; color: var(--ink-3); letter-spacing: 0.06em; opacity: 0.6; transition: opacity .12s, transform .12s; }
+.ct-row:hover .ct-chev { opacity: 1; color: var(--copper); }
+.ct-row.open .ct-chev { color: var(--copper); opacity: 1; }
+.ct-expand { display: none; margin-top: 10px; padding: 12px 14px; background: var(--surface); border-radius: 6px; font-size: 12.5px; color: var(--ink-2); line-height: 1.6; }
+html.dark .ct-expand { background: rgba(255,255,255,0.04); }
+.ct-row.open .ct-expand { display: block; }
+.ct-expand h6 { font-family: 'JetBrains Mono', monospace; font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--copper); margin: 10px 0 4px; font-weight: 600; }
+.ct-expand h6:first-child { margin-top: 0; }
+.ct-expand p { margin: 0 0 4px; font-size: 12.5px; color: var(--ink); line-height: 1.55; }
+.ct-expand p:last-child { margin-bottom: 0; }
+/* v9: empty state for Discovered prospects with no outreach yet */
+.ct-empty { padding: 14px 16px; background: var(--surface); border: 1px dashed var(--rule); border-radius: 8px; font-size: 13px; color: var(--ink-3); font-style: italic; line-height: 1.55; }
+html.dark .ct-empty { background: rgba(255,255,255,0.03); }
+/* v10: unified-timeline state variants — completed (default solid dot,
+   per-channel colour) / scheduled (hollow amber) / paused (amber ⏸) /
+   skipped (gray strikethrough). */
+.ct-row .ct-state-ic { display: inline-block; width: 14px; text-align: center; font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-3); margin-right: 2px; flex-shrink: 0; }
+.ct-row.state-completed .ct-state-ic { color: var(--green); }
+.ct-row.state-completed.email .ct-state-ic { color: var(--blue); }
+.ct-row.state-completed.linkedin .ct-state-ic { color: var(--blue); }
+.ct-row.state-completed.voice .ct-state-ic { color: var(--copper); }
+.ct-row.state-completed.sms .ct-state-ic { color: #8B6CA0; }
+.ct-row.state-completed.reply .ct-state-ic { color: var(--amber); }
+.ct-row.state-completed.meeting .ct-state-ic { color: var(--green); }
+.ct-row.state-scheduled::before { background: transparent !important; border: 2px solid var(--amber); width: 12px; height: 12px; box-sizing: border-box; }
+.ct-row.state-scheduled .ct-state-ic { color: var(--amber); }
+.ct-row.state-scheduled .ct-label { color: var(--ink-2); font-weight: 500; }
+.ct-row.state-paused::before { background: var(--amber) !important; box-shadow: 0 0 0 4px rgba(212,149,106,0.18); }
+.ct-row.state-paused .ct-state-ic { color: var(--amber); }
+.ct-row.state-paused .ct-label { color: var(--ink-3); }
+.ct-row.state-paused .ct-detail { color: var(--copper); font-style: italic; }
+.ct-row.state-skipped::before { background: var(--ink-3) !important; }
+.ct-row.state-skipped .ct-state-ic { color: var(--ink-3); }
+.ct-row.state-skipped .ct-label, .ct-row.state-skipped .ct-detail { text-decoration: line-through; color: var(--ink-3); }
+.ct-cadence-msg { margin-top: 14px; padding: 12px 14px; border-radius: 8px; font-size: 13px; display: flex; gap: 10px; align-items: center; line-height: 1.55; }
+.ct-cadence-msg .cm-ic { font-size: 16px; flex-shrink: 0; }
+.ct-cadence-msg.complete { background: rgba(107,142,90,0.12); border-left: 3px solid var(--green); color: var(--ink); }
+.ct-cadence-msg.paused { background: var(--amber-soft); border-left: 3px solid var(--amber); color: var(--ink); }
+.ct-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule); }
+.ct-actions button { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.06em; padding: 7px 12px; border-radius: 5px; background: transparent; border: 1px solid var(--rule); color: var(--ink-2); text-transform: uppercase; cursor: pointer; }
+.ct-actions button:hover { border-color: var(--amber); color: var(--copper); background: var(--amber-glow); }
+.ct-actions button.pause:hover { border-color: var(--red); color: var(--red); background: rgba(181,90,76,0.08); }
+
+/* ========== AUTOPILOT (Settings) ========== */
+.autopilot-opt { display: flex; align-items: flex-start; gap: 12px; padding: 12px 14px; border: 1px solid var(--rule); border-radius: 8px; margin-bottom: 8px; cursor: pointer; transition: border-color .12s, background .12s; }
+.autopilot-opt:hover { border-color: var(--amber); }
+.autopilot-opt input[type="radio"] { margin-top: 4px; accent-color: var(--amber); }
+.autopilot-opt.selected { border-color: var(--amber); background: var(--amber-soft); }
+.autopilot-opt.coming { opacity: 0.65; cursor: default; }
+.autopilot-opt.coming:hover { border-color: var(--rule); }
+.ao-name { font-size: 14px; font-weight: 600; color: var(--ink); }
+.ao-name .ao-soon { font-family: 'JetBrains Mono', monospace; font-size: 9.5px; letter-spacing: 0.14em; color: var(--ink-3); text-transform: uppercase; padding: 2px 7px; border: 1px solid var(--rule); border-radius: 10px; margin-left: 8px; font-weight: 500; }
+.ao-desc { font-size: 12.5px; color: var(--ink-2); margin-top: 3px; line-height: 1.5; }
+
+/* ========== KANBAN DnD ========== */
+.k-card[draggable="true"] { cursor: grab; }
+.k-card.dragging { opacity: 0.45; cursor: grabbing; }
+.col.drag-over .col-body { background: var(--amber-glow); }
+.col-body { transition: background .12s; }
+
+/* ========== DnD reason modal ========== */
+.modal-bd { position: fixed; inset: 0; background: rgba(12,10,8,0.55); backdrop-filter: blur(2px); z-index: 200; display: none; }
+.modal-bd.on { display: grid; place-items: center; padding: 16px; }
+.modal {
+  width: min(440px, 100%);
+  background: var(--cream);
+  border: 1px solid var(--rule);
+  border-radius: 12px;
+  padding: 22px 24px;
+  box-shadow: 0 16px 48px rgba(12,10,8,0.3);
+}
+.modal h3 { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 19px; color: var(--ink); margin-bottom: 6px; }
+.modal .ms { font-size: 12.5px; color: var(--ink-3); margin-bottom: 16px; line-height: 1.5; }
+.modal .ms b { color: var(--ink); }
+.modal .reason-opt { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border: 1px solid var(--rule); border-radius: 6px; margin-bottom: 6px; cursor: pointer; }
+.modal .reason-opt:hover { border-color: var(--amber); }
+.modal .reason-opt input[type="radio"] { accent-color: var(--amber); }
+.modal .reason-opt label { font-size: 13px; color: var(--ink); cursor: pointer; flex: 1; }
+.modal textarea { width: 100%; background: var(--panel-bg); border: 1px solid var(--rule); border-radius: 6px; padding: 9px 11px; font-size: 12.5px; color: var(--ink); margin-top: 10px; min-height: 60px; resize: vertical; }
+html.dark .modal textarea { background: rgba(255,255,255,0.04); }
+.modal .ma { display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px; }
+
+/* ========== MEDIA QUERIES ========== */
+@media (max-width: 960px) {
+  .sum-row, .kpi-row { grid-template-columns: repeat(2, 1fr); }
+  .maya-strip-list { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 768px) {
+  #shell { grid-template-columns: 1fr; }
+  #sidebar { position: fixed; top: 0; left: 0; bottom: 0; width: 240px; z-index: 140; transform: translateX(-100%); }
+  #sidebar.mobile-open { transform: translateX(0); }
+  #topbar { display: none; }
+  #mobile-topbar { display: flex; }
+  #bottomnav { display: flex; }
+  .hamburger-btn { display: inline-block; }
+  body { padding-top: 52px; padding-bottom: var(--bottomnav-h); }
+  #main { padding: 18px 14px 24px; max-width: 100%; }
+  .page-h { font-size: 24px; }
+  .bdr-hero { grid-template-columns: 1fr; padding: 18px 18px; gap: 14px; }
+  .bdr-hero .h-line { font-size: 18px; }
+  .bdr-avatar { width: 50px; height: 50px; font-size: 22px; }
+  .sum-row { grid-template-columns: repeat(2, 1fr); gap: 10px; }
+  .sum-card { padding: 12px 14px; }
+  .sum-val { font-size: 22px; }
+  .today-card { flex: 0 0 240px; }
+  .maya-strip-list { grid-template-columns: 1fr; }
+  .board { grid-template-columns: repeat(5, 86vw); gap: 10px; }
+  .col { max-height: none; min-height: 280px; }
+  /* Kanban card mobile layout (v5 Fix 1) — everything stacks vertically,
+     no horizontal cramming */
+  .k-card { padding: 16px 18px; min-width: 0; }
+  .k-name { font-size: 16px; line-height: 1.35; }
+  .k-dm { font-size: 12px; margin-top: 4px; }
+  .k-dm-title { font-size: 11px; margin-top: 2px; }
+  .k-meta { font-size: 11px; margin-top: 6px; }
+  .k-foot { margin-top: 14px; padding-top: 12px; gap: 10px; }
+  .k-time { flex: 1 1 100%; margin-top: 4px; font-size: 10.5px; }
+  /* Table → card-list on mobile (v5 Fix 2) */
+  .pipe-table, .pipe-table tbody { display: block; width: 100%; border: 0; border-radius: 0; }
+  .pipe-table thead { display: none; }
+  .pipe-table tr { display: block; background: var(--panel-bg); border: 1px solid var(--rule); border-radius: 10px; margin-bottom: 10px; padding: 16px 18px; }
+  .pipe-table tr:hover { background: var(--panel-bg); border-color: var(--amber); }
+  .pipe-table td { display: block; padding: 3px 0; border: 0; text-align: left; line-height: 1.55; }
+  .pipe-table td.name-col { font-size: 17px; font-weight: 700; font-family: 'Playfair Display', serif; color: var(--ink); padding-bottom: 4px; }
+  .pipe-table td.mono { font-size: 11px; color: var(--ink-3); font-family: 'JetBrains Mono', monospace; }
+  .pipe-table td.dm-title { font-size: 11.5px; color: var(--ink-3); font-family: 'JetBrains Mono', monospace; padding-bottom: 6px; }
+  /* Score + VR + Status sit together on one footer row */
+  .pipe-table td.score-col { display: inline-block; margin-right: 14px; font-size: 15px; text-align: left; padding-top: 8px; }
+  .pipe-table td:nth-child(6) { display: inline-block; margin-right: 14px; padding-top: 8px; }
+  .pipe-table td:nth-child(7) { display: inline-block; padding-top: 8px; }
+  .pipe-table td:nth-child(8) { font-size: 10.5px; color: var(--ink-3); margin-top: 6px; font-family: 'JetBrains Mono', monospace; }
+  /* Drawer full-width on mobile */
+  .drawer { width: 100vw; border-left: 0; }
+  .drawer-head { padding: 16px 18px; }
+  .drawer-body { padding: 16px 18px 40px; }
+  .cal-grid { display: none; }
+  .day-view { display: block; }
+  .bp-header { padding: 18px 20px; gap: 14px; }
+  .bp-pdf-btn .lbl-print { display: none; }
+  .bp-pdf-btn .lbl-pdf { display: inline; }
+  .set-row { grid-template-columns: 1fr; gap: 6px; padding: 12px 0; }
+}
+@media (max-width: 600px) {
+  .funnel-seg .fs-n { font-size: 11px; }
+  .funnel-seg .fs-l { font-size: 8px; }
+  .event-time { display: none; }
+  .event-row { grid-template-columns: 38px 1fr auto; }
+  .event-expand { padding-left: 16px; }
+  /* Drawer bf-meta mobile stacking (v5 amendment) — label-over-value
+     pattern, single column, 12px gap between rows. */
+  .bf-meta { grid-template-columns: 1fr; gap: 12px; padding: 12px; }
+  .bf-meta .bf-kv { display: flex; flex-direction: column; gap: 2px; padding: 0; }
+  .bf-meta .bf-kv .k { font-family: 'JetBrains Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--ink-3); font-weight: 600; }
+  .bf-meta .bf-kv .v { font-size: 13.5px; color: var(--ink); font-family: 'DM Sans', sans-serif; font-weight: 500; }
 }
 </style>
 </head>
 <body>
 
-<nav id="sidebar">
-  <div class="sidebar-logo">
-    <div class="logo-text">Agency<em>OS</em></div>
-  </div>
-  <div class="sidebar-section">
-    <div class="sidebar-section-label">Workspace</div>
-    <div class="nav-item" data-route="#home" onclick="navigate('#home')">
-      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1L1 7v8h5v-5h4v5h5V7L8 1z"/></svg>
-      Dashboard
-    </div>
-    <div class="nav-item" data-route="#pipeline" onclick="navigate('#pipeline')">
-      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/><rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/></svg>
-      Pipeline
-      <span class="nav-badge">50</span>
-    </div>
-    <div class="nav-item" data-route="#inbox" onclick="navigate('#inbox')">
-      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M2 4a2 2 0 012-2h8a2 2 0 012 2v6a2 2 0 01-2 2H2.5L1 14V4z"/></svg>
-      Inbox
-      <span class="nav-badge">23</span>
-    </div>
-    <div class="nav-item" data-route="#cycles" onclick="navigate('#cycles')">
-      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M14 2L2 7l4 2 2 4 3-4 3 2z"/></svg>
-      Cycles
-    </div>
-    <div class="nav-item" data-route="#sequences" onclick="navigate('#sequences')">
-      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><circle cx="3" cy="3" r="2"/><circle cx="3" cy="8" r="2"/><circle cx="3" cy="13" r="2"/><line x1="5" y1="3" x2="14" y2="3" stroke="currentColor" stroke-width="1.5"/><line x1="5" y1="8" x2="14" y2="8" stroke="currentColor" stroke-width="1.5"/><line x1="5" y1="13" x2="14" y2="13" stroke="currentColor" stroke-width="1.5"/></svg>
-      Sequences
-    </div>
-  </div>
-  <div class="sidebar-section">
-    <div class="sidebar-section-label">Intelligence</div>
-    <div class="nav-item" data-route="#signals" onclick="navigate('#signals')">
-      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1a1 1 0 00-1 1v2.5a1 1 0 002 0V2a1 1 0 00-1-1zm4.24 2.76a1 1 0 00-1.41 1.41A4 4 0 0112 8a4 4 0 01-1.17 2.83 1 1 0 001.41 1.41A6 6 0 0014 8a6 6 0 00-1.76-4.24zM3.76 3.76A6 6 0 002 8a6 6 0 001.76 4.24 1 1 0 001.41-1.41A4 4 0 014 8a4 4 0 011.17-2.83 1 1 0 00-1.41-1.41z"/></svg>
-      Signals
-    </div>
-    <div class="nav-item" data-route="#reports" onclick="navigate('#reports')">
-      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="10" width="3" height="5" rx="1"/><rect x="6" y="6" width="3" height="9" rx="1"/><rect x="11" y="3" width="3" height="12" rx="1"/></svg>
-      Reports
-    </div>
-  </div>
-  <div class="sidebar-section">
-    <div class="sidebar-section-label">Account</div>
-    <div class="nav-item" data-route="#settings" onclick="navigate('#settings')">
-      <svg class="nav-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 5a3 3 0 100 6A3 3 0 008 5zm0 1.5a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm6.5 1l-1.2-.4a5.5 5.5 0 00-.3-.7l.6-1.1-1.4-1.4-1.1.6a5.5 5.5 0 00-.7-.3L10 2.5H6l-.4 1.2a5.5 5.5 0 00-.7.3l-1.1-.6L2.4 4.8l.6 1.1a5.5 5.5 0 00-.3.7L1.5 7v2l1.2.4c.1.2.2.5.3.7l-.6 1.1 1.4 1.4 1.1-.6c.2.1.5.2.7.3L6 13.5h4l.4-1.2c.2-.1.5-.2.7-.3l1.1.6 1.4-1.4-.6-1.1c.1-.2.2-.5.3-.7l1.2-.4V7z"/></svg>
-      Settings
-    </div>
-  </div>
-  <div class="sidebar-footer">
-    <div class="avatar-circle">DS</div>
-    <div>
-      <div class="sidebar-user-name">David Stephens</div>
-      <div class="sidebar-user-sub">Ignition · Sydney</div>
-    </div>
-  </div>
-</nav>
-
-<div id="sidebar-overlay" onclick="closeMobileSidebar()"></div>
+<header id="topbar">
+  <span class="brand">Agency<em>OS</em></span>
+  <span class="brand-tag">MASTER · THE AGENCY DESK</span>
+  <span class="tb-spacer"></span>
+  <span class="tb-cycle"><span class="tb-dot"></span>MAYA · DAY 14/30</span>
+  <button class="tb-theme" aria-label="Toggle theme"><span class="t-sun">☀</span><span class="t-moon">🌙</span></button>
+  <button class="kill-btn" onclick="alert('Pause all outreach — confirm?')">⏸ Pause all</button>
+</header>
 
 <div id="mobile-topbar">
   <button class="hamburger-btn" onclick="toggleMobileSidebar()">&#9776;</button>
-  <div class="mobile-logo">Agency<em>OS</em></div>
-  <div style="margin-left:auto;display:flex;align-items:center;gap:10px;">
-    <span class="pulse-dot"></span>
-    <button class="kill-btn" style="font-size:10px;padding:4px 10px;" onclick="alert('Pause all outreach — confirm?')">Pause all</button>
-  </div>
+  <span class="mobile-logo">Agency<em>OS</em></span>
+  <span class="tb-spacer"></span>
+  <button class="tb-theme" aria-label="Toggle theme"><span class="t-sun">☀</span><span class="t-moon">🌙</span></button>
+  <button class="kill-btn" style="font-size:10px;padding:4px 10px;" onclick="alert('Pause all outreach — confirm?')">Pause all</button>
 </div>
 
-<div id="app">
-  <div id="topbar">
-    <div class="breadcrumb" id="breadcrumb">
-      <span>AgencyOS</span>
-      <span class="crumb-sep">›</span>
-      <span class="crumb-current">Dashboard</span>
+<div id="sidebar-overlay" onclick="toggleMobileSidebar()"></div>
+
+<div id="shell">
+  <aside id="sidebar">
+    <div class="sb-logo">
+      <div class="lt">Agency<em>OS</em></div>
+      <div class="ls">The Agency Desk</div>
     </div>
-    <div class="topbar-right">
-      <div class="pulse-row">
-        <div class="pulse-dot"></div>
-        <span>Day 14 of 30</span>
+    <div class="sb-section">
+      <div class="sb-label">Workspace</div>
+      <div class="sb-item active" data-v="home" onclick="showView('home')">
+        <svg class="sb-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1L1 7v8h5v-5h4v5h5V7L8 1z"/></svg> Home
       </div>
-      <button class="kill-btn" onclick="alert('Pause all outreach — confirm?')">Pause all</button>
-    </div>
-  </div>
-  <div id="page"></div>
-</div>
-
-<div id="bottom-nav">
-  <div class="bottom-nav-item" onclick="navigate('#home')">
-    <div class="bottom-nav-icon">&#8962;</div>
-    <span>Home</span>
-  </div>
-  <div class="bottom-nav-item" onclick="navigate('#pipeline')">
-    <div class="bottom-nav-icon">&#10764;</div>
-    <span>Pipeline</span>
-  </div>
-  <div class="bottom-nav-item" onclick="navigate('#inbox')">
-    <div class="bottom-nav-icon">&#9993;</div>
-    <span>Inbox</span>
-  </div>
-  <div class="bottom-nav-item" onclick="navigate('#cycles')">
-    <div class="bottom-nav-icon">&#9711;</div>
-    <span>Cycles</span>
-  </div>
-  <div class="bottom-nav-item" onclick="navigate('#signals')">
-    <div class="bottom-nav-icon">&#9685;</div>
-    <span>Signals</span>
-  </div>
-</div>
-
-<!-- Modals -->
-<div class="modal-overlay" id="configModal" onclick="closeModalOutside(event,'configModal')">
-  <div class="modal">
-    <div class="modal-title">Configure Cycle</div>
-    <div class="form-field">
-      <div class="form-label">Services</div>
-      <div style="display:flex;flex-direction:column;gap:8px;margin-top:4px;">
-        <label style="display:flex;align-items:center;gap:8px;font-size:13.5px;cursor:pointer;"><input type="checkbox" checked style="accent-color:var(--amber)"> SEO Services</label>
-        <label style="display:flex;align-items:center;gap:8px;font-size:13.5px;cursor:pointer;"><input type="checkbox" checked style="accent-color:var(--amber)"> Google Ads Management</label>
-        <label style="display:flex;align-items:center;gap:8px;font-size:13.5px;cursor:pointer;"><input type="checkbox" checked style="accent-color:var(--amber)"> Web Design &amp; Development</label>
-        <label style="display:flex;align-items:center;gap:8px;font-size:13.5px;cursor:pointer;"><input type="checkbox" checked style="accent-color:var(--amber)"> Content Marketing</label>
-        <label style="display:flex;align-items:center;gap:8px;font-size:13.5px;cursor:pointer;"><input type="checkbox" checked style="accent-color:var(--amber)"> Social Media Management</label>
-        <label style="display:flex;align-items:center;gap:8px;font-size:13.5px;cursor:pointer;"><input type="checkbox" checked style="accent-color:var(--amber)"> Email Marketing</label>
+      <div class="sb-item" data-v="pipeline" onclick="showView('pipeline')">
+        <svg class="sb-icon" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="2" width="3" height="12" rx="1"/><rect x="6" y="2" width="3" height="8" rx="1"/><rect x="11" y="2" width="3" height="10" rx="1"/></svg> Pipeline
+        <span class="sb-badge">13</span>
+      </div>
+      <div class="sb-item" data-v="feed" onclick="showView('feed')">
+        <svg class="sb-icon" viewBox="0 0 16 16" fill="currentColor"><circle cx="3" cy="3" r="1.5"/><rect x="6" y="2.2" width="9" height="1.6" rx="0.5"/><circle cx="3" cy="8" r="1.5"/><rect x="6" y="7.2" width="9" height="1.6" rx="0.5"/><circle cx="3" cy="13" r="1.5"/><rect x="6" y="12.2" width="9" height="1.6" rx="0.5"/></svg> Feed
+        <span class="sb-badge">24</span>
+      </div>
+      <div class="sb-item" data-v="meetings" onclick="showView('meetings')">
+        <svg class="sb-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4"><rect x="2" y="3" width="12" height="11" rx="1.5"/><line x1="2" y1="6" x2="14" y2="6"/><line x1="5" y1="1.5" x2="5" y2="4" stroke-linecap="round"/><line x1="11" y1="1.5" x2="11" y2="4" stroke-linecap="round"/></svg> Meetings
+        <span class="sb-badge">4</span>
       </div>
     </div>
-    <div class="form-field">
-      <div class="form-label">Geographic Scope</div>
-      <div class="radio-group">
-        <label class="radio-item"><input type="radio" name="area" value="metro" checked> Metro</label>
-        <label class="radio-item"><input type="radio" name="area" value="state"> State</label>
-        <label class="radio-item"><input type="radio" name="area" value="national"> National</label>
+    <div class="sb-section">
+      <div class="sb-label">Report</div>
+      <div class="sb-item" data-v="progress" onclick="showView('progress')">
+        <svg class="sb-icon" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="10" width="3" height="5" rx="1"/><rect x="6" y="6" width="3" height="9" rx="1"/><rect x="11" y="3" width="3" height="12" rx="1"/></svg> Progress
       </div>
     </div>
-    <div class="modal-actions">
-      <button class="btn btn-outline" onclick="closeModal('configModal')">Cancel</button>
-      <button class="btn btn-amber" onclick="closeModal('configModal')">Save Settings</button>
+    <div class="sb-section">
+      <div class="sb-label">Account</div>
+      <div class="sb-item" data-v="settings" onclick="showView('settings')">
+        <svg class="sb-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 5a3 3 0 100 6 3 3 0 000-6zm6.5 2l-1.2-.4a5 5 0 00-.3-.7l.6-1.1-1.4-1.4-1.1.6a5 5 0 00-.7-.3L10 2.5H6l-.4 1.2a5 5 0 00-.7.3l-1.1-.6L2.4 4.8l.6 1.1a5 5 0 00-.3.7L1.5 7v2l1.2.4c.1.2.2.5.3.7l-.6 1.1 1.4 1.4 1.1-.6c.2.1.5.2.7.3L6 13.5h4l.4-1.2c.2-.1.5-.2.7-.3l1.1.6 1.4-1.4-.6-1.1c.1-.2.2-.5.3-.7l1.2-.4V7z"/></svg> Settings
+      </div>
     </div>
-  </div>
+    <div class="sb-foot">
+      <div class="avatar">DS</div>
+      <div>
+        <div class="sb-foot-n">Dave Stephens</div>
+        <div class="sb-foot-r">Operator</div>
+      </div>
+    </div>
+  </aside>
+
+  <main id="main"></main>
 </div>
 
-<div class="modal-overlay" id="releaseConfirmModal" onclick="closeModalOutside(event,'releaseConfirmModal')">
-  <div class="modal">
-    <div class="modal-title">Release without a full review?</div>
-    <div class="modal-body">
-      We recommend reviewing at least 10 prospects before releasing to outreach. This ensures you're comfortable with the quality and tone before your first messages go out.<br><br>
-      You've reviewed <strong id="reviewedCountInModal">0</strong> so far. Releasing now means the system will contact all 600 prospects with current draft messaging.
-    </div>
-    <div class="modal-actions">
-      <button class="btn btn-outline" onclick="closeModal('releaseConfirmModal')">Keep reviewing</button>
-      <button class="btn btn-amber" onclick="confirmRelease()">Release anyway</button>
-    </div>
-  </div>
-</div>
+<nav id="bottomnav">
+  <div class="bn-item active" data-v="home" onclick="showView('home')"><div class="bn-ico">⌂</div><span>Home</span></div>
+  <div class="bn-item" data-v="pipeline" onclick="showView('pipeline')"><div class="bn-ico">▤</div><span>Pipeline</span></div>
+  <div class="bn-item" data-v="meetings" onclick="showView('meetings')"><div class="bn-ico">◫</div><span>Meetings</span></div>
+  <div class="bn-item" data-v="feed" onclick="showView('feed')"><div class="bn-ico">≡</div><span>Feed</span></div>
+</nav>
 
-<div class="modal-overlay" id="noteModal" onclick="closeModalOutside(event,'noteModal')">
-  <div class="modal">
-    <div class="modal-title">Add note</div>
-    <div class="form-field">
-      <div class="form-label">Note for <span id="noteProspectName"></span></div>
-      <textarea class="form-textarea" id="noteTextarea" placeholder="Add a note about this prospect..." style="min-height:120px;"></textarea>
-    </div>
-    <div class="modal-actions">
-      <button class="btn btn-outline" onclick="closeModal('noteModal')">Cancel</button>
-      <button class="btn btn-amber" onclick="saveNote()">Save note</button>
-    </div>
-  </div>
-</div>
+<!-- DnD reason modal -->
+<div class="modal-bd" id="dndModal" onclick="if(event.target===this)closeDnDModal()"></div>
 
-<!-- Dev controls -->
-<div class="dev-controls">
-  <div class="dev-label">Cycle state</div>
-  <button class="dev-btn" id="devBtnReview" onclick="setCycleState('review')">Review</button>
-  <button class="dev-btn" id="devBtnOutreach" onclick="setCycleState('outreach')">Outreach</button>
-  <button class="dev-btn" id="devBtnComplete" onclick="setCycleState('complete')">Complete</button>
-</div>
+<!-- Global right drawer -->
+<div class="drawer-backdrop" id="drawerBackdrop" onclick="closeDrawer()"></div>
+<aside class="drawer" id="drawer">
+  <div class="drawer-head">
+    <div>
+      <div class="eyebrow">Briefing</div>
+      <div class="dh-name" id="dhName">—</div>
+      <div class="dh-sub" id="dhSub">—</div>
+    </div>
+    <button class="drawer-close" onclick="closeDrawer()" aria-label="Close">×</button>
+  </div>
+  <div class="drawer-body" id="drawerBody"></div>
+</aside>
 
 <script>
-/* ═══════════════════════════════════════════════════════════════════
-   MOCK DATA — 10 HERO PROSPECTS
-═══════════════════════════════════════════════════════════════════ */
-const heroProspects = [
+/* ================================================================
+   PROSPECT DATA — honest-data shape
+   (no revenue, no dm.style, no dm.linkedinActivity)
+================================================================ */
+const prospects = [
   {
-    id: 'p1', name: 'Momentum Constructions', suburb: 'Brunswick', state: 'VIC',
-    industry: 'Construction', intent: 'struggling', score: 91, staff: '28',
-    est: '2008', revenue: '$8.2M',
-    dm: { name: 'James Whitford', title: 'Founder & MD', email: 'j.whitford@momentumconstructions.com.au', phone: '+61 412 XXX XXX', linkedin: 'Verified', tenure: '16 years', prevRoles: 'Site Manager at Lendlease (2001–2008)', style: 'Direct and numbers-focused. Responds well to ROI data. Dislikes jargon.', linkedinActivity: 'Posts about project wins 2x/month. Engages with industry news.' },
-    signals: [
-      { text: 'Active Google Ads spend detected ($2,400/mo)', time: '2 days ago' },
-      { text: 'GMB rating dropped from 4.6 to 4.1 in 90 days', time: '5 days ago' },
-      { text: 'Website last updated 2019 — no SSL, not mobile responsive', time: '1 week ago' },
-      { text: 'Competitor bidding on their brand terms', time: '3 days ago' },
-    ],
-    affordability: 8, intentScore: 16, composite: 91,
-    vulnerability: 'Momentum Constructions is spending $2,400/month on Google Ads but their website converts poorly — no SSL, not mobile responsive, last updated 2019. GMB rating dropped from 4.6 to 4.1 with negative reviews in 90 days. A competitor is bidding on their brand terms. Budget and intent present but leaking value at every touchpoint.',
-    vulnGrades: { website: 'F', seo: 'D', reviews: 'D', ads: 'C', social: 'B', content: 'F' },
-    aiSummary: 'Momentum Constructions is a 28-person construction firm in Brunswick spending $2,400/month on paid ads without the digital infrastructure to convert that traffic. Their declining GMB rating and outdated website create urgency — a competitor has already moved in on their brand terms.',
-    timeline: [
-      { type: 'email_sent', label: 'Email 1 sent', time: 'Day 1 · 9:02am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 1 opened (3x)', time: 'Day 1 · 11:34am', dotClass: '' },
-      { type: 'linkedin_sent', label: 'LinkedIn connection request sent', time: 'Day 3 · 9:05am', dotClass: '' },
-      { type: 'linkedin_accepted', label: 'LinkedIn connection accepted', time: 'Day 3 · 2:17pm', dotClass: '' },
-      { type: 'email_sent', label: 'Email 2 sent', time: 'Day 5 · 9:01am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 2 opened (1x)', time: 'Day 5 · 4:52pm', dotClass: '' },
-      { type: 'voice_sent', label: 'Voice AI call placed', time: 'Day 7 · 10:00am', dotClass: '' },
-      { type: 'voice_voicemail', label: 'Voicemail left', time: 'Day 7 · 10:01am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 3 sent', time: 'Day 10 · 9:03am', dotClass: '' },
-      { type: 'email_replied', label: 'Reply received: "This is exactly what we need. Can we set up a call this week?"', time: 'Day 10 · 3:41pm', dotClass: 'ot-dot-reply' },
-      { type: 'meeting_booked', label: 'Meeting booked — 14 April 2026, 10:00am', time: 'Day 10 · 4:05pm', dotClass: 'ot-dot-meeting' },
-    ],
-    triggerSignal: 'GMB rating dropped 0.5 stars + competitor bidding on brand terms',
-    triggerMessage: 'Email 3 — Subject: "Your competitors are stealing your brand traffic, James"',
-    prospectReply: '"This is exactly what we need. Can we set up a call this week?"',
-    sentiment: 'High intent — immediate action requested',
-    timeToMeeting: '37 minutes from reply to booking',
-    meeting: { date: 'Monday 14 April 2026', time: '10:00am AEST', platform: 'Zoom', countdown: 'In 7 days' },
-    competitors: ['Lendlease Digital', 'Built Digital', 'Construct Media'],
-    recommendedAngle: 'Lead with the GMB decline data and the brand term bidding. Show the revenue impact. Propose a 90-day recovery plan starting with site rebuild + GMB management.',
-    pricingRange: '$2,800–$4,200/month AUD',
-    openingHook: '"James, your competitor is currently spending $800/month bidding on the exact phrase people search when looking for Momentum Constructions. I can show you that in the first 2 minutes."',
-    discoveryQuestions: ['What does a qualified lead look like for you?', 'How are you currently tracking ROI on your Google Ads spend?', 'What happened with the GMB reviews — did you notice the drop?'],
-    objections: [{ obj: '"We already have someone handling this."', response: 'Great — let me show you what they\'re missing on the technical side. This isn\'t about effort, it\'s about infrastructure.' }, { obj: '"Not in the budget right now."', response: 'You\'re already spending $2,400/month on ads. We\'re talking about making that spend work properly.' }],
-    closeOptions: ['90-day pilot at $2,800/month — website + GMB + ad landing pages', 'Full-service retainer at $4,200/month including content and ongoing optimisation'],
+    id:'p1', name:'Momentum Constructions', suburb:'Brunswick', state:'VIC',
+    industry:'Construction', score:91, staff:'28', est:'2008',
+    domain:'momentumconstructions.com.au', gmb_category:'General contractor',
+    abn_status:'active', abn_age_years:18,
+    dfs_organic_etv:180, dfs_organic_keywords:42, backlinks_count:67, domain_rank:28,
+    dm:{ name:'James Whitford', title:'Founder & MD', tenure:'16 years' },
+    vulnerability:'Google Ads spend detected but website converts poorly. GMB rating dropped 4.6→4.1 in 90 days. Competitor bidding on brand terms.',
+    vulnGrades:{ website:'F', seo:'D', reviews:'D', ads:'C', social:'B', content:'F' },
+    status:'Meeting Booked',
+    meeting:{ day:'Wed', date:'Wed 23 Apr', time:'4:00pm', startHour:16, durationHrs:1, countdown:'Today 4pm', platform:'Zoom', isToday:true },
+    lastAction:'Meeting booked · 37m ago',
+    openingHook:'"James, your competitor is bidding on the exact phrase people search when looking for Momentum Constructions. I can show you in 2 minutes."',
+    discoveryQuestions:['What does a qualified lead look like for you?','How are you tracking ROI on your Google Ads spend?','What happened with the GMB reviews — did you notice the drop?'],
+    objections:[{obj:'"We already have someone handling this."',response:'Let me show you what they\'re missing on the technical side.'}],
+    closeOptions:['90-day pilot at $2,800/month','Full retainer at $4,200/month'],
+    pricingRange:'$2,800–$4,200/month AUD',
+    competitors:['Brunswick Build Co','North Melbourne Construct','Carlton Trades'],
+    critic:{ email:82, linkedin:71, voice:88, sms:64 },
   },
   {
-    id: 'p2', name: 'Harbour Physiotherapy', suburb: 'Manly', state: 'NSW',
-    industry: 'Health', intent: 'struggling', score: 88, staff: '11',
-    est: '2015', revenue: '$1.8M',
-    dm: { name: 'Sarah Kemp', title: 'Clinical Director & Owner', email: 's.kemp@harbourphysio.com.au', phone: '+61 438 XXX XXX', linkedin: 'Verified', tenure: '9 years', prevRoles: 'Senior Physio at Prince of Wales Hospital (2010–2015)', style: 'Evidence-based thinker. Appreciates data. Skeptical of marketing claims.', linkedinActivity: 'Shares clinical research articles. Occasional posts about the practice.' },
-    signals: [
-      { text: 'Google Ads paused after 6 months continuous spend', time: '1 week ago' },
-      { text: '3 staff LinkedIn profiles updated to "Open to work"', time: '4 days ago' },
-      { text: 'Competitor opened 200m away with aggressive launch', time: '2 weeks ago' },
-    ],
-    affordability: 6, intentScore: 15, composite: 88,
-    vulnerability: 'Harbour Physiotherapy paused Google Ads after 6 months — budget pressure or poor ROI. Three staff updated LinkedIn to "Open to work" signalling instability. New competitor 200m away with aggressive launch. Need to defend local market urgently.',
-    vulnGrades: { website: 'C', seo: 'D', reviews: 'B', ads: 'F', social: 'D', content: 'D' },
-    aiSummary: 'Harbour Physiotherapy faces a classic squeeze: a new competitor 200m away has launched with aggressive digital presence while Harbour has pulled back from paid ads due to cost concerns. Staff instability signals internal pressure. The window to defend their local dominance is narrow.',
-    timeline: [
-      { type: 'email_sent', label: 'Email 1 sent', time: 'Day 1 · 8:58am', dotClass: '' },
-      { type: 'email_delivered', label: 'Email 1 delivered', time: 'Day 1 · 8:59am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 1 opened (2x)', time: 'Day 1 · 12:05pm', dotClass: '' },
-      { type: 'linkedin_sent', label: 'LinkedIn connection request sent', time: 'Day 3 · 9:00am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 2 sent', time: 'Day 5 · 9:02am', dotClass: '' },
-      { type: 'email_clicked', label: 'Email 2 link clicked', time: 'Day 5 · 2:33pm', dotClass: '' },
-      { type: 'email_sent', label: 'Email 3 sent', time: 'Day 10 · 9:00am', dotClass: '' },
-      { type: 'email_replied', label: 'Reply: "Very interested. We\'ve been struggling with our online presence."', time: 'Day 10 · 5:12pm', dotClass: 'ot-dot-reply' },
-      { type: 'meeting_booked', label: 'Meeting booked — 15 April 2026, 2:00pm', time: 'Day 11 · 9:30am', dotClass: 'ot-dot-meeting' },
-    ],
-    triggerSignal: 'Competitor launch 200m away + Google Ads paused',
-    triggerMessage: 'Email 3 — Subject: "The new physio on Sydney Road is ranking above you, Sarah"',
-    prospectReply: '"Very interested. We\'ve been struggling with our online presence."',
-    sentiment: 'Acknowledged pain point — warm to conversation',
-    timeToMeeting: '16 hours from reply to booking',
-    meeting: { date: 'Tuesday 15 April 2026', time: '2:00pm AEST', platform: 'Zoom', countdown: 'In 8 days' },
-    competitors: ['Manly Allied Health', 'Sydney Road Physio', 'Northern Beaches Physiotherapy'],
-    recommendedAngle: 'Lead with local competitive threat data. Show their organic ranking vs the new competitor. Propose a local SEO + GMB strategy to defend the territory.',
-    pricingRange: '$1,800–$2,800/month AUD',
-    openingHook: '"Sarah, the new practice that opened on Sydney Road 3 months ago is now outranking Harbour Physiotherapy for 14 of your top search terms. I can show you that in the first 60 seconds."',
-    discoveryQuestions: ['Why did you pause Google Ads — was it the cost or the results?', 'Have you seen patient numbers affected by the new competitor?', 'What does your current patient acquisition look like — mostly referrals?'],
-    objections: [{ obj: '"We can\'t afford it right now."', response: 'Every month you don\'t act is another month the competitor gains ground. What\'s the value of one new patient per week?' }],
-    closeOptions: ['Local defence package at $1,800/month — SEO + GMB + review management', 'Full digital at $2,800/month adding content and ads'],
+    id:'p2', name:'Harbour Physiotherapy', suburb:'Manly', state:'NSW',
+    industry:'Health', score:88, staff:'11', est:'2015',
+    domain:'harbourphysio.com.au', gmb_category:'Physiotherapist',
+    abn_status:'active', abn_age_years:11,
+    dfs_organic_etv:210, dfs_organic_keywords:58, backlinks_count:41, domain_rank:22,
+    dm:{ name:'Sarah Kemp', title:'Clinical Director & Owner', tenure:'9 years' },
+    vulnerability:'Paused Google Ads after 6 months. Competitor 200m away launched aggressively. Defensive opportunity.',
+    vulnGrades:{ website:'C', seo:'D', reviews:'B', ads:'F', social:'D', content:'D' },
+    status:'Meeting Booked',
+    meeting:{ day:'Wed', date:'Wed 23 Apr', time:'2:00pm', startHour:14, durationHrs:1, countdown:'Today 2pm', platform:'Zoom', isToday:true },
+    lastAction:'Meeting booked · 1d ago',
+    openingHook:'"Sarah, the new practice on Sydney Road is now outranking Harbour Physio for 14 of your top search terms."',
+    discoveryQuestions:['Why did you pause Google Ads — was it the cost or the results?','Have you seen patient numbers affected?','What does your current patient acquisition look like — mostly referrals?'],
+    objections:[{obj:'"We can\'t afford it right now."',response:'Every month you don\'t act the competitor gains ground.'}],
+    closeOptions:['Local defence at $1,800/month','Full digital at $2,800/month'],
+    pricingRange:'$1,800–$2,800/month AUD',
+    competitors:['Sydney Road Physio','Manly Allied Health','Northern Beaches Sports Med'],
+    critic:{ email:79, linkedin:81, voice:72, sms:68 },
   },
   {
-    id: 'p3', name: 'Cascade Dental Group', suburb: 'Paddington', state: 'NSW',
-    industry: 'Dental', intent: 'trying', score: 74, staff: '14',
-    est: '2012', revenue: '$4.1M',
-    dm: { name: 'Dr Priya Narayan', title: 'Principal Dentist & Owner', email: 'p.narayan@cascadedental.com.au', phone: '+61 402 XXX XXX', linkedin: 'Verified', tenure: '12 years', prevRoles: 'Associate Dentist at Smile Sydney (2008–2012)', style: 'Analytical. Values credentials and case studies from similar practices.', linkedinActivity: 'Active — posts about dental health awareness 3x/month.' },
-    signals: [
-      { text: 'Recently hired a marketing coordinator', time: '1 week ago' },
-      { text: 'Website redesign detected — new template but thin content', time: '3 days ago' },
-      { text: 'Increased GMB post frequency from 0 to 3/week', time: '2 weeks ago' },
-    ],
-    affordability: 7, intentScore: 12, composite: 74,
-    vulnerability: 'Cascade Dental is actively trying — hired a marketing coordinator and redesigned their website. But new site has thin content and GMB strategy is basic. Intent and budget present but lack expertise.',
-    vulnGrades: { website: 'C', seo: 'C', reviews: 'A', ads: 'D', social: 'C', content: 'D' },
-    aiSummary: 'Cascade Dental has the intent and is making moves — new hire, new website, increased GMB activity. The gap is expertise: they\'re investing without a strategic framework. The new marketing coordinator is likely overwhelmed and will welcome specialist support.',
-    timeline: [
-      { type: 'email_sent', label: 'Email 1 sent', time: 'Day 1 · 9:00am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 1 opened (4x)', time: 'Day 2 · 9:22am', dotClass: '' },
-      { type: 'linkedin_sent', label: 'LinkedIn connection request sent', time: 'Day 3 · 9:00am', dotClass: '' },
-      { type: 'linkedin_accepted', label: 'LinkedIn connection accepted', time: 'Day 4 · 11:40am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 2 sent', time: 'Day 5 · 9:00am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 3 sent', time: 'Day 10 · 9:00am', dotClass: '' },
-      { type: 'email_replied', label: 'Reply: "We just hired someone for this but would love a second opinion."', time: 'Day 10 · 1:18pm', dotClass: 'ot-dot-reply' },
-      { type: 'meeting_booked', label: 'Meeting booked — 17 April 2026, 11:00am', time: 'Day 10 · 3:00pm', dotClass: 'ot-dot-meeting' },
-    ],
-    triggerSignal: 'New marketing hire + website rebuild detected',
-    triggerMessage: 'Email 3 — Subject: "Your new website has one gap that\'ll cost you patients, Priya"',
-    prospectReply: '"We just hired someone for this but would love a second opinion."',
-    sentiment: 'Open but cautious — existing internal effort acknowledged',
-    timeToMeeting: '1 hour 42 minutes from reply to booking',
-    meeting: { date: 'Thursday 17 April 2026', time: '11:00am AEST', platform: 'Zoom', countdown: 'In 10 days' },
-    competitors: ['Paddington Dental', 'Oxford Street Smile Clinic', 'Bondi Dental'],
-    recommendedAngle: 'Position as expert support for their new coordinator, not replacement. Show the SEO gap in the new website. Dental-specific case studies.',
-    pricingRange: '$2,200–$3,400/month AUD',
-    openingHook: '"Priya, your new website looks great — but there\'s a technical SEO issue that means Google can\'t properly index 60% of your treatment pages. I can show you exactly what I mean."',
-    discoveryQuestions: ['What role do you see the new coordinator playing vs an agency?', 'What\'s the most important service you want more patients for?', 'Are you tracking where your current new patients come from?'],
-    objections: [{ obj: '"We have someone in-house now."', response: 'We work alongside in-house teams constantly. We handle the technical and strategic layer; they handle execution.' }],
-    closeOptions: ['Strategy and technical layer at $2,200/month alongside their coordinator', 'Full-service at $3,400/month if coordinator focus shifts to patient comms'],
+    id:'p3', name:'Cascade Dental Group', suburb:'Paddington', state:'NSW',
+    industry:'Dental', score:74, staff:'14', est:'2012',
+    domain:'cascadedental.com.au', gmb_category:'Dental clinic',
+    abn_status:'active', abn_age_years:14,
+    dfs_organic_etv:340, dfs_organic_keywords:89, backlinks_count:73, domain_rank:31,
+    dm:{ name:'Dr Priya Narayan', title:'Principal Dentist & Owner', tenure:'12 years' },
+    vulnerability:'Hired marketing coordinator, redesigned website. New site has thin content; GMB strategy is basic.',
+    vulnGrades:{ website:'C', seo:'C', reviews:'A', ads:'D', social:'C', content:'D' },
+    status:'Meeting Booked',
+    meeting:{ day:'Wed', date:'Wed 23 Apr', time:'10:00am', startHour:10, durationHrs:1, countdown:'Today 10am', platform:'Zoom', isToday:true },
+    lastAction:'Meeting booked · 2d ago',
+    openingHook:'"Priya, your new website looks great — but a technical SEO issue means Google can\'t index 60% of your treatment pages."',
+    discoveryQuestions:['What role do you see the new coordinator playing vs an agency?','What\'s the most important service you want more patients for?','Are you tracking where your current new patients come from?'],
+    objections:[{obj:'"We have someone in-house now."',response:'We work alongside in-house teams. Technical and strategic layer.'}],
+    closeOptions:['Strategy layer $2,200/month','Full-service $3,400/month'],
+    pricingRange:'$2,200–$3,400/month AUD',
+    competitors:['Paddington Smiles','Oxford St Dental','Bondi Junction Orthodontics'],
+    critic:{ email:85, linkedin:77, voice:74, sms:70 },
   },
   {
-    id: 'p4', name: 'Coastal Veterinary', suburb: 'Byron Bay', state: 'NSW',
-    industry: 'Veterinary', intent: 'trying', score: 76, staff: '16',
-    est: '2010', revenue: '$2.9M',
-    dm: { name: 'Dr Rebecca Ashford', title: 'Practice Owner', email: 'r.ashford@coastalvet.com.au', phone: '+61 421 XXX XXX', linkedin: 'Verified', tenure: '14 years', prevRoles: 'Veterinarian at RSPCA NSW (2006–2010)', style: 'Community-oriented. Warm communicator. Values relationship over hard sell.', linkedinActivity: 'Posts about animal welfare and local events occasionally.' },
-    signals: [
-      { text: 'New Facebook ad campaign targeting pet owners', time: '5 days ago' },
-      { text: 'Blog section added but only 2 posts', time: '1 week ago' },
-      { text: 'Sponsoring local surf competition', time: '2 weeks ago' },
-    ],
-    affordability: 7, intentScore: 13, composite: 76,
-    vulnerability: 'Coastal Veterinary investing in marketing but spreading thin — Facebook ads, blog, community sponsorship without cohesive strategy. Efforts show intent but lack focus for ROI.',
-    vulnGrades: { website: 'B', seo: 'D', reviews: 'A', ads: 'C', social: 'B', content: 'D' },
-    aiSummary: 'Coastal Veterinary is a well-regarded Byron Bay practice with genuine community presence. They\'re investing in marketing but without a connecting strategy — Facebook ads, a nascent blog, and local sponsorship are uncoordinated. A cohesive local digital strategy would amplify what\'s already working.',
-    timeline: [
-      { type: 'email_sent', label: 'Email 1 sent', time: 'Day 1 · 9:00am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 1 opened (1x)', time: 'Day 3 · 8:45am', dotClass: '' },
-      { type: 'sms_sent', label: 'SMS sent', time: 'Day 7 · 10:00am', dotClass: '' },
-      { type: 'sms_delivered', label: 'SMS delivered', time: 'Day 7 · 10:01am', dotClass: '' },
-      { type: 'sms_replied', label: 'SMS reply: "Interesting. Can you send more details about pricing?"', time: 'Day 7 · 2:33pm', dotClass: 'ot-dot-reply' },
-      { type: 'meeting_booked', label: 'Meeting booked — 21 April 2026, 9:30am', time: 'Day 8 · 10:00am', dotClass: 'ot-dot-meeting' },
-    ],
-    triggerSignal: 'Facebook ad activity + blog launch detected',
-    triggerMessage: 'SMS — "Hi Rebecca, David from Ignition. Your new Facebook ads are reaching pet owners but not converting. Worth 15 minutes?"',
-    prospectReply: '"Interesting. Can you send more details about pricing?"',
-    sentiment: 'Price-sensitive but interested — needs specifics before committing',
-    timeToMeeting: '20 hours from reply to booking',
-    meeting: { date: 'Monday 21 April 2026', time: '9:30am AEST', platform: 'Zoom', countdown: 'In 14 days' },
-    competitors: ['Bangalow Veterinary Hospital', 'Byron Vet Centre'],
-    recommendedAngle: 'Connect their community investment to digital strategy. Show how sponsorship + GMB + content creates a flywheel. Warm approach — lead with what they\'re already doing well.',
-    pricingRange: '$1,600–$2,400/month AUD',
-    openingHook: '"Rebecca, I can see you\'ve already done the hard part — you have community trust and good reviews. We just need to make sure that when someone in Byron searches for a vet at 11pm, Coastal comes up first."',
-    discoveryQuestions: ['How are new clients finding you at the moment?', 'What does the Facebook ad spend look like — is it producing bookings?', 'Is the blog something you want to grow or was it experimental?'],
-    objections: [{ obj: '"Can you send pricing first?"', response: 'I can send a range — but the right package depends on your goals. Two questions first...' }],
-    closeOptions: ['Local presence package at $1,600/month — GMB + content + Facebook', 'Full digital at $2,400/month adding SEO and ad management'],
+    id:'p4', name:'Coastal Veterinary', suburb:'Byron Bay', state:'NSW',
+    industry:'Veterinary', score:76, staff:'16', est:'2010',
+    domain:'coastalvet.com.au', gmb_category:'Veterinarian',
+    abn_status:'active', abn_age_years:9,
+    dfs_organic_etv:155, dfs_organic_keywords:46, backlinks_count:38, domain_rank:19,
+    dm:{ name:'Dr Rebecca Ashford', title:'Practice Owner', tenure:'14 years' },
+    vulnerability:'Investing in marketing but spreading thin — Facebook ads, blog, community sponsorship without cohesive strategy.',
+    vulnGrades:{ website:'B', seo:'D', reviews:'A', ads:'C', social:'B', content:'D' },
+    status:'Meeting Booked',
+    meeting:{ day:'Mon', date:'Mon 21 Apr', time:'9:30am', startHour:9, durationHrs:1, countdown:'Completed (logged)', platform:'Zoom', isToday:false, isPast:true },
+    lastAction:'Meeting completed · 2d ago',
+    openingHook:'"Rebecca, you\'ve done the hard part — community trust and good reviews."',
+    discoveryQuestions:['How are new clients finding you at the moment?','Is the Facebook spend producing bookings?','Is the blog something you want to grow?'],
+    objections:[{obj:'"Can you send pricing first?"',response:'I can send a range — the right package depends on your goals.'}],
+    closeOptions:['Local presence $1,600/month','Full digital $2,400/month'],
+    pricingRange:'$1,600–$2,400/month AUD',
+    competitors:['Byron Vet Centre','Bangalow Veterinary'],
+    critic:{ email:76, linkedin:69, voice:82, sms:74 },
   },
   {
-    id: 'p5', name: 'Southbank Legal Advisory', suburb: 'Southbank', state: 'VIC',
-    industry: 'Legal', intent: 'trying', score: 71, staff: '18',
-    est: '2014', revenue: '$3.6M',
-    dm: { name: 'Andrew Volkov', title: 'Managing Partner', email: 'a.volkov@southbanklegal.com.au', phone: '+61 403 XXX XXX', linkedin: 'Verified', tenure: '10 years', prevRoles: 'Senior Associate at Herbert Smith Freehills (2008–2014)', style: 'Precise and logic-driven. Responds to structured arguments. Dislikes vagueness.', linkedinActivity: 'Active — thought leadership articles and firm news 4x/month.' },
-    signals: [
-      { text: 'Published 4 thought leadership articles in 30 days', time: '1 week ago' },
-      { text: 'Google Ads spend increased 40% month-on-month', time: '3 days ago' },
-      { text: 'New practice area page added (family law)', time: '2 weeks ago' },
-    ],
-    affordability: 7, intentScore: 11, composite: 71,
-    vulnerability: 'Southbank Legal is investing in content and ads but execution is unfocused — thought leadership articles lack SEO, new practice page has thin content, ad spend increasing without conversion tracking.',
-    vulnGrades: { website: 'C', seo: 'D', reviews: 'B', ads: 'C', social: 'C', content: 'C' },
-    aiSummary: 'Southbank Legal is a 10-year-old firm with clear growth ambition — adding practice areas, publishing content, increasing ad spend. The problem is execution quality: their content lacks SEO, their new family law page won\'t rank, and their ad spend increase is blind.',
-    timeline: [
-      { type: 'email_sent', label: 'Email 1 sent', time: 'Day 1 · 9:00am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 1 opened (2x)', time: 'Day 2 · 8:11am', dotClass: '' },
-      { type: 'linkedin_sent', label: 'LinkedIn connection request sent', time: 'Day 3 · 9:00am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 2 sent', time: 'Day 5 · 9:00am', dotClass: '' },
-      { type: 'voice_sent', label: 'Voice AI call placed', time: 'Day 7 · 10:00am', dotClass: '' },
-      { type: 'voice_completed', label: 'Voice call connected — 2 min 14 sec conversation', time: 'Day 7 · 10:04am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 3 sent', time: 'Day 10 · 9:00am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 3 opened (3x)', time: 'Day 10 · 11:30am', dotClass: '' },
-    ],
-    triggerSignal: 'Ad spend increase + content output detected',
-    triggerMessage: 'Email 1 — Subject: "Your thought leadership content isn\'t ranking, Andrew — here\'s why"',
-    prospectReply: null,
-    sentiment: 'Engaged (opened 3x) but no reply yet',
-    timeToMeeting: 'Not yet booked',
-    meeting: null,
-    competitors: ['Holding Redlich', 'Macpherson Kelley', 'Lander & Rogers'],
-    recommendedAngle: 'Lead with the SEO audit of their content. Show exactly why their 4 articles aren\'t ranking. Legal-specific content strategy proposal.',
-    pricingRange: '$2,400–$3,800/month AUD',
-    openingHook: '"Andrew, you\'ve published 4 articles this month — I\'ve analysed all of them. Not one is ranking on page 1 for any commercial legal term. I can explain exactly why in under 3 minutes."',
-    discoveryQuestions: ['What\'s the primary driver for adding family law?', 'Who\'s writing the articles — internal or external?', 'Do you have visibility into what\'s driving your ad clicks?'],
-    objections: [{ obj: '"We manage this internally."', response: 'The volume of content is impressive. The gap is technical SEO — that\'s not about effort, it\'s about configuration.' }],
-    closeOptions: ['SEO-first at $2,400/month — technical + content optimisation', 'Full digital at $3,800/month including ad management and monthly reporting'],
+    id:'p5', name:'Southbank Legal Advisory', suburb:'Southbank', state:'VIC',
+    industry:'Legal', score:71, staff:'18', est:'2014',
+    domain:'southbanklegal.com.au', gmb_category:'Law firm',
+    abn_status:'active', abn_age_years:13,
+    dfs_organic_etv:420, dfs_organic_keywords:112, backlinks_count:94, domain_rank:34,
+    dm:{ name:'Andrew Volkov', title:'Managing Partner', tenure:'10 years' },
+    vulnerability:'Investing in content and ads but execution unfocused — thought leadership lacks SEO, ad spend increasing without conversion tracking.',
+    vulnGrades:{ website:'C', seo:'D', reviews:'B', ads:'C', social:'C', content:'C' },
+    status:'Replied', meeting:null, lastAction:'Reply received · 1d ago',
+    openingHook:'"Andrew, you\'ve published 4 articles this month — not one is ranking on page 1 for any commercial legal term."',
+    discoveryQuestions:['What\'s the primary driver for adding family law?','Who\'s writing the articles — internal or external?','Do you have visibility into what\'s driving your ad clicks?'],
+    objections:[{obj:'"We manage this internally."',response:'The gap is technical SEO — not effort, configuration.'}],
+    closeOptions:['SEO-first $2,400/month','Full digital $3,800/month'],
+    pricingRange:'$2,400–$3,800/month AUD',
+    competitors:['Holding Redlich','Macpherson Kelley','Lander & Rogers'],
+    critic:{ email:80, linkedin:73, voice:66, sms:62 },
   },
   {
-    id: 'p6', name: 'Riverside Accounting', suburb: 'North Sydney', state: 'NSW',
-    industry: 'Accounting', intent: 'dabbling', score: 52, staff: '9',
-    est: '2018', revenue: '$1.2M',
-    dm: { name: 'Michael Chen', title: 'Managing Partner', email: 'm.chen@riversideaccounting.com.au', phone: '+61 415 XXX XXX', linkedin: 'Verified', tenure: '6 years', prevRoles: 'Senior Accountant at Deloitte (2012–2018)', style: 'Analytical. Spreadsheet thinker. Needs to see the numbers before any commitment.', linkedinActivity: 'LinkedIn page exists but minimal personal activity.' },
-    signals: [
-      { text: 'LinkedIn company page created but no posts', time: '3 weeks ago' },
-      { text: 'Google Business Profile claimed but incomplete', time: '2 weeks ago' },
-    ],
-    affordability: 5, intentScore: 8, composite: 52,
-    vulnerability: "Riverside Accounting just starting digital presence — LinkedIn page with no content, incomplete Google Business Profile. Know they need marketing but haven't committed resources.",
-    vulnGrades: { website: 'D', seo: 'F', reviews: 'C', ads: 'F', social: 'F', content: 'F' },
-    aiSummary: 'Riverside Accounting is in the earliest stage of digital intent — they\'ve claimed their GMB and created a LinkedIn page but haven\'t acted further. Michael is analytical and will need to see a clear business case before committing.',
-    timeline: [
-      { type: 'email_sent', label: 'Email 1 sent', time: 'Day 1 · 9:00am', dotClass: '' },
-      { type: 'email_delivered', label: 'Email 1 delivered', time: 'Day 1 · 9:01am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 1 opened (1x)', time: 'Day 4 · 3:15pm', dotClass: '' },
-      { type: 'email_sent', label: 'Email 2 sent', time: 'Day 5 · 9:00am', dotClass: '' },
-      { type: 'email_replied', label: 'Reply: "Not sure if this is for us right now. Maybe next quarter?"', time: 'Day 6 · 9:44am', dotClass: 'ot-dot-reply' },
-    ],
-    triggerSignal: 'GMB claim + LinkedIn page creation',
-    triggerMessage: 'Email 2 — Subject: "Your incomplete Google profile is costing you referrals, Michael"',
-    prospectReply: '"Not sure if this is for us right now. Maybe next quarter?"',
-    sentiment: 'Soft objection — not a hard no, timing concern',
-    timeToMeeting: 'Not booked — nurture sequence',
-    meeting: null,
-    competitors: ['Carbon Group', 'NumberWorks Sydney', 'Chan & Naylor North Sydney'],
-    recommendedAngle: 'Low-commitment entry point. Lead with GMB completion (quick win). Show revenue per new client to justify cost.',
-    pricingRange: '$800–$1,400/month AUD',
-    openingHook: '"Michael, I\'m not going to pitch a big retainer. Let me spend 20 minutes showing you what fixing your Google profile alone would do for referrals."',
-    discoveryQuestions: ['What does a new client typically mean in annual revenue for the firm?', 'How do most of your clients find you currently?', 'What\'s making next quarter a better time than now?'],
-    objections: [{ obj: '"Maybe next quarter."', response: 'What changes next quarter? If it\'s budget, I have an entry-level option at $800/month that\'s designed for where you are now.' }],
-    closeOptions: ['Foundation package $800/month — GMB + basic SEO', 'Growth package $1,400/month adding content and review management'],
+    id:'p6', name:'Riverside Accounting', suburb:'North Sydney', state:'NSW',
+    industry:'Accounting', score:52, staff:'9', est:'2018',
+    domain:'riversideaccounting.com.au', gmb_category:'Accountant',
+    abn_status:'active', abn_age_years:21,
+    dfs_organic_etv:280, dfs_organic_keywords:67, backlinks_count:52, domain_rank:26,
+    dm:{ name:'Michael Chen', title:'Managing Partner', tenure:'6 years' },
+    vulnerability:'Just starting digital presence — LinkedIn page with no content, incomplete GMB.',
+    vulnGrades:{ website:'D', seo:'F', reviews:'C', ads:'F', social:'F', content:'F' },
+    status:'Replied', meeting:null, lastAction:'Soft reply (Q3) · 1d ago',
+    openingHook:'"Michael, I\'m not pitching a retainer. Let me spend 20 minutes on what fixing your Google profile alone would do for referrals."',
+    discoveryQuestions:['What does a new client typically mean in annual fee revenue for the firm?','How do most of your clients find you currently?','What\'s making next quarter a better time than now?'],
+    objections:[{obj:'"Maybe next quarter."',response:'What changes next quarter? If it\'s budget, I have an entry-level option.'}],
+    closeOptions:['Foundation $800/month','Growth $1,400/month'],
+    pricingRange:'$800–$1,400/month AUD',
+    competitors:['Carbon Group','Chan & Naylor North Sydney'],
+    critic:{ email:68, linkedin:62, voice:58, sms:55 },
   },
   {
-    id: 'p7', name: 'Parramatta Motor Group', suburb: 'Parramatta', state: 'NSW',
-    industry: 'Automotive', intent: 'dabbling', score: 47, staff: '34',
-    est: '2005', revenue: '$12.4M',
-    dm: { name: 'Wei Zhang', title: 'Dealer Principal', email: 'w.zhang@parramattamotors.com.au', phone: '+61 410 XXX XXX', linkedin: 'Verified', tenure: '19 years', prevRoles: 'Sales Manager at Parramatta Toyota (2001–2005)', style: 'Revenue-focused. Needs to see a clear return. Skeptical of digital — prefers traditional channels.', linkedinActivity: 'Inactive.' },
-    signals: [
-      { text: "Website hasn't been updated since 2020", time: '2 weeks ago' },
-      { text: 'Zero social media activity in 12 months', time: '1 month ago' },
-    ],
-    affordability: 8, intentScore: 5, composite: 47,
-    vulnerability: "Parramatta Motor Group has revenue and staff but zero digital marketing investment. Website from 2020, no social presence. High affordability but very low intent — classic 'don't know they need it' prospect.",
-    vulnGrades: { website: 'F', seo: 'F', reviews: 'B', ads: 'F', social: 'F', content: 'F' },
-    aiSummary: 'Parramatta Motor Group is a high-revenue dealership that has actively ignored digital for 5+ years. Wei is skeptical of digital marketing but the website and search presence are objectively weak. The play is ROI-first — show them what customers they\'re missing.',
-    timeline: [
-      { type: 'email_sent', label: 'Email 1 sent', time: 'Day 1 · 9:00am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 1 opened (1x)', time: 'Day 6 · 5:02pm', dotClass: '' },
-      { type: 'email_sent', label: 'Email 2 sent', time: 'Day 5 · 9:00am', dotClass: '' },
-      { type: 'voice_sent', label: 'Voice AI call placed', time: 'Day 7 · 10:00am', dotClass: '' },
-      { type: 'voice_voicemail', label: 'Voicemail left', time: 'Day 7 · 10:02am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 3 sent', time: 'Day 10 · 9:00am', dotClass: '' },
-      { type: 'system', label: 'Sequence completed — no reply', time: 'Day 14 · 9:00am', dotClass: 'ot-dot-system' },
-    ],
-    triggerSignal: 'Zero digital activity + high affordability score',
-    triggerMessage: 'Email 1 — Subject: "How many car buyers are you losing to Google every month, Wei?"',
-    prospectReply: null,
-    sentiment: 'No engagement — low-intent prospect',
-    timeToMeeting: 'Not booked',
-    meeting: null,
-    competitors: ['Parramatta Nissan', 'Westfield Honda', 'Motorpoint Parramatta'],
-    recommendedAngle: 'Revenue impact framing. Show the number of searches for their category in Parramatta. High-value but long cycle.',
-    pricingRange: '$3,200–$5,000/month AUD',
-    openingHook: '"Wei, there are 840 people searching for used cars in Parramatta every month. Parramatta Motor Group doesn\'t appear on the first page for any of them."',
-    discoveryQuestions: ['Where does most of your foot traffic come from today?', 'Have you ever tried digital advertising?', 'What would one extra car sale per week mean in margin?'],
-    objections: [{ obj: '"We do fine without digital."', response: 'You\'re doing well despite it — imagine doing well because of it.' }],
-    closeOptions: ['Visibility package $3,200/month — SEO + GMB + website', 'Full digital at $5,000/month including Google Ads'],
+    id:'p7', name:'Parramatta Motor Group', suburb:'Parramatta', state:'NSW',
+    industry:'Automotive', score:47, staff:'34', est:'2005',
+    domain:'parramattamotor.com.au', gmb_category:'Car dealer',
+    abn_status:'active', abn_age_years:27,
+    dfs_organic_etv:96, dfs_organic_keywords:29, backlinks_count:48, domain_rank:21,
+    dm:{ name:'Wei Zhang', title:'Dealer Principal', tenure:'19 years' },
+    vulnerability:'Zero digital marketing investment. Website from 2020, no social presence.',
+    vulnGrades:{ website:'F', seo:'F', reviews:'B', ads:'F', social:'F', content:'F' },
+    status:'Contacted', meeting:null, lastAction:'Voice AI voicemail · 2h ago',
+    openingHook:'"Wei, 840 people search for used cars in Parramatta monthly. Parramatta Motor doesn\'t appear on page 1 for any of them."',
+    discoveryQuestions:['Where does most of your foot traffic come from today?','Have you ever tried digital advertising?','What would one extra car sale per week mean in margin?'],
+    objections:[{obj:'"We do fine without digital."',response:'You\'re doing well despite it — imagine doing well because of it.'}],
+    closeOptions:['Visibility $3,200/month','Full digital $5,000/month'],
+    pricingRange:'$3,200–$5,000/month AUD',
+    competitors:['Parramatta Nissan','Westfield Honda'],
+    critic:{ email:72, linkedin:64, voice:70, sms:60 },
   },
   {
-    id: 'p8', name: 'Bondi Creative Studio', suburb: 'Bondi', state: 'NSW',
-    industry: 'Design', intent: 'trying', score: 68, staff: '8',
-    est: '2019', revenue: '$980K',
-    dm: { name: 'Aria Martinelli', title: 'Creative Director', email: 'a.martinelli@bondicreative.com.au', phone: '+61 422 XXX XXX', linkedin: 'Verified', tenure: '5 years', prevRoles: 'Senior Designer at Clemenger BBDO (2015–2019)', style: 'Creative-first. Responds to aesthetics and story. Dislikes corporate-speak.', linkedinActivity: 'Active — portfolio posts and design commentary weekly.' },
-    signals: [
-      { text: 'Portfolio website recently launched with case studies', time: '1 week ago' },
-      { text: 'Instagram following grew 300% in 3 months', time: '2 weeks ago' },
-      { text: 'Started running LinkedIn thought leadership', time: '3 weeks ago' },
-    ],
-    affordability: 4, intentScore: 11, composite: 68,
-    vulnerability: 'Bondi Creative understands marketing (they do it for clients) but struggles with their own pipeline. Strong social growth but no paid acquisition, thin SEO, no lead capture on portfolio site.',
-    vulnGrades: { website: 'B', seo: 'D', reviews: 'A', ads: 'F', social: 'A', content: 'B' },
-    aiSummary: 'Bondi Creative is the classic "cobbler\'s children" scenario — they produce excellent marketing for clients but their own digital acquisition is almost nonexistent beyond social. A referral-heavy agency with genuine creative talent needing a systematic new business channel.',
-    timeline: [
-      { type: 'email_sent', label: 'Email 1 sent', time: 'Day 1 · 9:00am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 1 opened (5x)', time: 'Day 1 · 10:48am', dotClass: '' },
-      { type: 'linkedin_sent', label: 'LinkedIn connection request sent', time: 'Day 3 · 9:00am', dotClass: '' },
-      { type: 'linkedin_accepted', label: 'LinkedIn connection accepted', time: 'Day 3 · 3:22pm', dotClass: '' },
-      { type: 'linkedin_messaged', label: 'LinkedIn message sent', time: 'Day 4 · 9:00am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 2 sent', time: 'Day 5 · 9:00am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 2 opened (2x)', time: 'Day 6 · 2:10pm', dotClass: '' },
-      { type: 'email_sent', label: 'Email 3 sent', time: 'Day 10 · 9:00am', dotClass: '' },
-    ],
-    triggerSignal: 'New portfolio site launch + Instagram growth',
-    triggerMessage: 'Email 1 — Subject: "Your work is excellent, Aria — but no one can find you on Google"',
-    prospectReply: null,
-    sentiment: 'Highly engaged (opened 5x) — no reply yet',
-    timeToMeeting: 'Not booked',
-    meeting: null,
-    competitors: ['Manual Sydney', 'Vert Design', 'Frost Collective'],
-    recommendedAngle: 'Peer-to-peer framing. Acknowledge their creative quality. Focus on new business channel, not design critique.',
-    pricingRange: '$1,200–$2,000/month AUD',
-    openingHook: '"Aria, I\'ve spent time on your portfolio — the work is genuinely excellent. The problem is that when a business in Sydney searches for a brand design studio, you don\'t appear anywhere in the top 20 results."',
-    discoveryQuestions: ['How do you win new clients today — mostly referrals?', 'Have you explored paid channels or is it purely organic?', 'What type of client are you trying to attract more of?'],
-    objections: [{ obj: '"We do marketing for others — we can do it ourselves."', response: 'Most of your competitors say the same. It\'s about bandwidth, not capability.' }],
-    closeOptions: ['New business channel at $1,200/month — SEO + lead capture', 'Full growth at $2,000/month adding content strategy'],
+    id:'p8', name:'Bondi Creative Studio', suburb:'Bondi', state:'NSW',
+    industry:'Design', score:68, staff:'8', est:'2019',
+    domain:'bondicreative.com.au', gmb_category:'Graphic designer',
+    abn_status:'active', abn_age_years:7,
+    dfs_organic_etv:140, dfs_organic_keywords:38, backlinks_count:82, domain_rank:29,
+    dm:{ name:'Aria Martinelli', title:'Creative Director', tenure:'5 years' },
+    vulnerability:'Strong social growth but no paid acquisition. Struggles with own pipeline.',
+    vulnGrades:{ website:'B', seo:'D', reviews:'A', ads:'F', social:'A', content:'B' },
+    status:'Contacted', meeting:null, lastAction:'LinkedIn accepted · 5h ago',
+    openingHook:'"Aria, your portfolio is excellent — but when someone searches for a Sydney brand design studio, you don\'t appear in the top 20."',
+    discoveryQuestions:['How do you win new clients today — mostly referrals?','Have you explored paid channels?','What type of client are you trying to attract more of?'],
+    objections:[{obj:'"We do marketing for others — we can do it ourselves."',response:'Most of your competitors say the same. It\'s about bandwidth, not capability.'}],
+    closeOptions:['New business channel $1,200/month','Full growth $2,000/month'],
+    pricingRange:'$1,200–$2,000/month AUD',
+    competitors:['Manual Sydney','Frost Collective'],
+    critic:{ email:83, linkedin:79, voice:68, sms:72 },
   },
   {
-    id: 'p9', name: 'Fitzroy Cafe Group', suburb: 'Fitzroy', state: 'VIC',
-    industry: 'Hospitality', intent: 'struggling', score: 84, staff: '22',
-    est: '2016', revenue: '$2.1M',
-    dm: { name: 'Tom Abernathy', title: 'Owner', email: 't.abernathy@fitzroycafe.com.au', phone: '+61 418 XXX XXX', linkedin: 'Verified', tenure: '8 years', prevRoles: 'Head Chef at Cumulus Inc (2012–2016)', style: 'Pragmatic. Busy. Responds to brevity. Dislikes anything that sounds like overhead.', linkedinActivity: 'Minimal.' },
-    signals: [
-      { text: 'Uber Eats commission complaints on social media', time: '3 days ago' },
-      { text: 'Staff hiring posts every 2 weeks (high turnover)', time: 'ongoing' },
-      { text: 'GMB photos last updated 18 months ago', time: '1 month ago' },
-      { text: 'Competitor cafe won "Best of Fitzroy" award', time: '1 week ago' },
-    ],
-    affordability: 6, intentScore: 14, composite: 84,
-    vulnerability: 'Fitzroy Cafe Group is bleeding margin to delivery platforms and struggling with staff retention. Stale GMB presence while a competitor won local awards. High urgency to build direct customer acquisition and reduce platform dependency.',
-    vulnGrades: { website: 'D', seo: 'F', reviews: 'C', ads: 'F', social: 'D', content: 'F' },
-    aiSummary: 'Fitzroy Cafe Group is caught in the delivery platform trap — high volume, thin margin, and growing frustration publicly visible. Tom is cash-conscious but the pain is real. The pitch is margin recovery: replace platform revenue with direct bookings.',
-    timeline: [
-      { type: 'email_sent', label: 'Email 1 sent', time: 'Day 1 · 9:00am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 1 opened (2x)', time: 'Day 2 · 7:33am', dotClass: '' },
-      { type: 'sms_sent', label: 'SMS sent', time: 'Day 5 · 10:00am', dotClass: '' },
-      { type: 'sms_delivered', label: 'SMS delivered', time: 'Day 5 · 10:01am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 2 sent', time: 'Day 5 · 9:00am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 3 sent', time: 'Day 10 · 9:00am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 3 opened (3x)', time: 'Day 10 · 6:15am', dotClass: '' },
-    ],
-    triggerSignal: 'Public Uber Eats complaints + competitor award win',
-    triggerMessage: 'Email 3 — Subject: "Sundays Fitzroy just won Best of Fitzroy. Here\'s how they did it, Tom."',
-    prospectReply: null,
-    sentiment: 'Engaged but no reply — follow-up needed',
-    timeToMeeting: 'Not booked',
-    meeting: null,
-    competitors: ['Sundays Fitzroy', 'Deadman Espresso', 'The Commoner'],
-    recommendedAngle: 'Margin recovery framing. Calculate how much Uber Eats is costing per month. Show what direct booking would look like.',
-    pricingRange: '$1,400–$2,200/month AUD',
-    openingHook: '"Tom, if you\'re paying Uber Eats 30% commission on $18,000/month in delivery, that\'s $5,400/month in platform fees. Our full package is $1,400/month and builds you a direct channel."',
-    discoveryQuestions: ['What percentage of revenue is delivery vs dine-in?', 'Have you tried promoting direct orders?', 'What did Sundays Fitzroy do differently that you\'ve noticed?'],
-    objections: [{ obj: '"I\'m too busy to deal with marketing."', response: 'That\'s exactly why you use us. It runs in the background. You do the coffee.' }],
-    closeOptions: ['Direct acquisition at $1,400/month — GMB + local SEO + Google Ads', 'Full platform at $2,200/month adding social and email marketing'],
+    id:'p9', name:'Fitzroy Cafe Group', suburb:'Fitzroy', state:'VIC',
+    industry:'Hospitality', score:84, staff:'22', est:'2016',
+    domain:'fitzroycafegroup.com.au', gmb_category:'Cafe',
+    abn_status:'active', abn_age_years:6,
+    dfs_organic_etv:78, dfs_organic_keywords:24, backlinks_count:31, domain_rank:17,
+    dm:{ name:'Tom Abernathy', title:'Owner', tenure:'8 years' },
+    vulnerability:'Margin pressure from delivery platforms. Stale GMB while competitor won local awards.',
+    vulnGrades:{ website:'D', seo:'F', reviews:'C', ads:'F', social:'D', content:'F' },
+    status:'Contacted', meeting:null, lastAction:'Email 3 sent · 8h ago',
+    openingHook:'"Tom, our full package is less than you pay in one week of delivery commission."',
+    discoveryQuestions:['What percentage of revenue is delivery vs dine-in?','Have you tried promoting direct orders?','What did Sundays Fitzroy do differently that you\'ve noticed?'],
+    objections:[{obj:'"I\'m too busy to deal with marketing."',response:'That\'s exactly why you use us. It runs in the background.'}],
+    closeOptions:['Direct acquisition $1,400/month','Full platform $2,200/month'],
+    pricingRange:'$1,400–$2,200/month AUD',
+    competitors:['Sundays Fitzroy','Deadman Espresso','The Commoner'],
+    critic:{ email:77, linkedin:68, voice:64, sms:54 },
   },
   {
-    id: 'p10', name: 'Gold Coast Mortgage Co', suburb: 'Surfers Paradise', state: 'QLD',
-    industry: 'Finance', intent: 'dabbling', score: 55, staff: '12',
-    est: '2017', revenue: '$1.8M',
-    dm: { name: 'Priya Sharma', title: 'Principal Broker', email: 'p.sharma@gcmortgage.com.au', phone: '+61 407 XXX XXX', linkedin: 'Verified', tenure: '7 years', prevRoles: 'Mortgage Broker at NAB (2013–2017)', style: 'Relationship-first. Referral network is core to her business. Open to new ideas.', linkedinActivity: 'Posts about property market commentary monthly.' },
-    signals: [
-      { text: 'Recently registered new ABN for financial planning arm', time: '2 weeks ago' },
-      { text: 'Sponsored local business networking event', time: '1 week ago' },
-    ],
-    affordability: 6, intentScore: 8, composite: 55,
-    vulnerability: 'Gold Coast Mortgage Co expanding into financial planning (new ABN) and doing community networking. Growth intent present but no digital strategy to capture it. Classic referral-dependent business ready for systematic acquisition.',
-    vulnGrades: { website: 'D', seo: 'F', reviews: 'B', ads: 'F', social: 'D', content: 'F' },
-    aiSummary: 'Gold Coast Mortgage Co is a referral-driven firm entering a growth phase — new ABN, new service line, community investment. Priya is relationship-oriented and the pitch should reflect that. The digital channel will feel like a natural extension of her networking.',
-    timeline: [
-      { type: 'email_sent', label: 'Email 1 sent', time: 'Day 1 · 9:00am', dotClass: '' },
-      { type: 'email_opened', label: 'Email 1 opened (1x)', time: 'Day 3 · 1:22pm', dotClass: '' },
-      { type: 'linkedin_sent', label: 'LinkedIn connection request sent', time: 'Day 3 · 9:00am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 2 sent', time: 'Day 5 · 9:00am', dotClass: '' },
-      { type: 'email_sent', label: 'Email 3 sent', time: 'Day 10 · 9:00am', dotClass: '' },
-    ],
-    triggerSignal: 'New ABN + networking sponsorship',
-    triggerMessage: 'Email 1 — Subject: "Your new financial planning arm needs a digital foundation, Priya"',
-    prospectReply: null,
-    sentiment: 'Opened once — low engagement so far',
-    timeToMeeting: 'Not booked',
-    meeting: null,
-    competitors: ['GC Home Loans', 'Aussie Surfers Paradise', 'Mortgage Choice GC'],
-    recommendedAngle: 'New venture framing. Digital as the infrastructure for the financial planning arm expansion.',
-    pricingRange: '$1,200–$2,000/month AUD',
-    openingHook: '"Priya, the financial planning ABN is a smart move. But right now when someone searches for financial planners in Surfers Paradise, there\'s no digital presence for that service at all."',
-    discoveryQuestions: ['How are you planning to get clients for the financial planning arm?', 'Is your referral network aware of the new service yet?', 'Have you set a target for new planning clients this year?'],
-    objections: [{ obj: '"We\'re still setting it up."', response: 'The best time to build a digital foundation is before you launch — so it\'s ready when you are.' }],
-    closeOptions: ['Foundation at $1,200/month for the new arm', 'Combined at $2,000/month covering both mortgage and planning'],
+    id:'p10', name:'Gold Coast Mortgage Co', suburb:'Surfers Paradise', state:'QLD',
+    industry:'Finance', score:55, staff:'12', est:'2017',
+    domain:'goldcoastmortgage.com.au', gmb_category:'Mortgage broker',
+    abn_status:'recent', abn_age_years:2,
+    dfs_organic_etv:195, dfs_organic_keywords:51, backlinks_count:44, domain_rank:23,
+    dm:{ name:'Priya Sharma', title:'Principal Broker', tenure:'7 years' },
+    vulnerability:'Expanding into financial planning (new ABN). Growth intent present but no digital strategy.',
+    vulnGrades:{ website:'D', seo:'F', reviews:'B', ads:'F', social:'D', content:'F' },
+    status:'Contacted', meeting:null, lastAction:'Email 2 sent · 1d ago',
+    openingHook:'"Priya, the financial planning ABN is a smart move. But there\'s no digital presence for that service at all."',
+    discoveryQuestions:['How are you planning to get clients for the financial planning arm?','Is your referral network aware of the new service yet?','Have you set a target for new planning clients this year?'],
+    objections:[{obj:'"We\'re still setting it up."',response:'The best time to build a digital foundation is before you launch.'}],
+    closeOptions:['Foundation $1,200/month','Combined $2,000/month'],
+    pricingRange:'$1,200–$2,000/month AUD',
+    competitors:['GC Home Loans','Mortgage Choice GC'],
+    critic:{ email:70, linkedin:65, voice:60, sms:58 },
+  },
+  /* 3 Discovered filler */
+  {
+    id:'d1', name:'Newtown Chiropractic', suburb:'Newtown', state:'NSW',
+    industry:'Health', score:72, staff:'8', est:'2013',
+    domain:'newtownchiro.com.au', gmb_category:'Chiropractor',
+    abn_status:'active', abn_age_years:12,
+    dfs_organic_etv:132, dfs_organic_keywords:34, backlinks_count:28, domain_rank:18,
+    dm:{ name:'Dr Natalie Osborne', title:'Principal Chiropractor', tenure:'11 years' },
+    vulnerability:'Recently moved premises. No GMB address update in 90 days. Organic presence thin.',
+    vulnGrades:{ website:'C', seo:'D', reviews:'B', ads:'F', social:'D', content:'C' },
+    status:'Discovered', meeting:null, lastAction:'GMB signal · 2h ago',
+    openingHook:'"Natalie, your new premises isn\'t showing on Google Maps yet — patients searching for you are getting the old address."',
+    discoveryQuestions:['When did you move?','How are patients finding the new location?','Any missed appointments attributed to the move?'],
+    objections:[{obj:'"We\'ll update it ourselves."',response:'Happy to do it free as part of a proper audit — takes 20 minutes.'}],
+    closeOptions:['Foundation $1,100/month','Local growth $1,800/month'],
+    pricingRange:'$1,100–$1,800/month AUD',
+    competitors:['Newtown Allied Health','Marrickville Chiropractic'],
+    critic:{ email:74, linkedin:70, voice:72, sms:66 },
+  },
+  {
+    id:'d2', name:'Barossa Cellars & Co', suburb:'Tanunda', state:'SA',
+    industry:'Retail', score:64, staff:'15', est:'2001',
+    domain:'barossacellars.com.au', gmb_category:'Wine store',
+    abn_status:'active', abn_age_years:25,
+    dfs_organic_etv:164, dfs_organic_keywords:48, backlinks_count:61, domain_rank:24,
+    dm:{ name:'Elizabeth Petrowski', title:'Owner', tenure:'24 years' },
+    vulnerability:'Direct-to-consumer website has no online ordering. Instagram active but no conversion path.',
+    vulnGrades:{ website:'D', seo:'C', reviews:'A', ads:'F', social:'B', content:'D' },
+    status:'Discovered', meeting:null, lastAction:'Discovery complete · 4h ago',
+    openingHook:'"Liz, 3,200 people per month are searching for Barossa wine online — and you don\'t sell anything via your site."',
+    discoveryQuestions:['Is DTC a growth goal?','What\'s the average order value at the cellar door?','Any constraints on interstate shipping?'],
+    objections:[{obj:'"Our wholesale is strong."',response:'Great — DTC is accretive, not replacement.'}],
+    closeOptions:['E-com foundation $1,600/month','Growth + Ads $2,400/month'],
+    pricingRange:'$1,600–$2,400/month AUD',
+    competitors:['Seppeltsfield Online','Peter Lehmann Direct'],
+    critic:{ email:76, linkedin:72, voice:68, sms:70 },
+  },
+  {
+    id:'d3', name:'Perth Childcare Collective', suburb:'Subiaco', state:'WA',
+    industry:'Education', score:59, staff:'42', est:'2007',
+    domain:'perthchildcare.com.au', gmb_category:'Child care agency',
+    abn_status:'active', abn_age_years:19,
+    dfs_organic_etv:108, dfs_organic_keywords:31, backlinks_count:19, domain_rank:15,
+    dm:{ name:'Rachel Holloway', title:'General Manager', tenure:'9 years' },
+    vulnerability:'Three centres, one outdated booking portal. Long waitlists but no waitlist management online.',
+    vulnGrades:{ website:'F', seo:'D', reviews:'C', ads:'F', social:'D', content:'F' },
+    status:'Discovered', meeting:null, lastAction:'New entry · 12m ago',
+    openingHook:'"Rachel, your waitlist is clearly working but the booking process loses families at step 3."',
+    discoveryQuestions:['How many waitlist families turn into enrolments?','What\'s the drop-off point in the form?','Any subsidy confusion you hear about repeatedly?'],
+    objections:[{obj:'"We\'re state-subsidised, budget is tight."',response:'We work with the sector. Start with what your enrolment-lift pays for.'}],
+    closeOptions:['Enrolment funnel $1,300/month','Full digital $2,100/month'],
+    pricingRange:'$1,300–$2,100/month AUD',
+    competitors:['Goodstart Subiaco','KU Children\'s Services'],
+    critic:{ email:67, linkedin:64, voice:62, sms:60 },
   },
 ];
 
-/* filler prospects */
-const firstNames = ['Nathan','Sophie','Marcus','Olivia','Liam','Emma','Jack','Charlotte','Ethan','Isabella','Noah','Mia','William','Ava','James','Grace','Benjamin','Chloe','Lucas','Zoe','Henry','Amelia','Alexander','Harper','Sebastian','Ella','Thomas','Lily','Michael','Hannah'];
-const lastNames = ['Morrison','Clarke','Nguyen','Williams','Johnson','Brown','Smith','Wilson','Taylor','Anderson','Thompson','White','Martin','Garcia','Davies','Evans','Lewis','Walker','Hall','Young'];
-const bizPrefixes = ['Momentum','Precision','Meridian','Apex','Bridge','North Star','Summit','Atlas','Keystone','Harbour','Ridgeline','Coastal','Pinnacle','Vantage','Sterling','Clearwater'];
-const bizSuffixes = ['Construction','Dental','Legal','Physio','Accounting','Plumbing','Electrical','Hospitality','Automotive','Retail','Landscaping','Architecture'];
-const suburbs = ['Newtown','Surry Hills','Glebe','Marrickville','Ultimo','Chippendale','Leichhardt','Rozelle','Balmain','Pyrmont','Darlinghurst','Redfern','Alexandria','Waterloo','Zetland','Erskineville','Annandale','Stanmore','Petersham','Enmore'];
-const states = ['NSW','VIC','QLD','NSW','NSW','VIC','NSW','QLD'];
-const intents = ['struggling','trying','dabbling'];
-const outreachStatuses = ['contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','contacted','replied','replied','replied','replied','replied','replied','replied','replied','suppressed','suppressed'];
-
-function seededRand(seed) {
-  let s = seed;
-  return function() { s = (s * 9301 + 49297) % 233280; return s / 233280; };
-}
-
-const fillerProspects = Array.from({length: 40}, (_, i) => {
-  const rng = seededRand(i * 1337 + 42);
-  const fn = firstNames[Math.floor(rng() * firstNames.length)];
-  const ln = lastNames[Math.floor(rng() * lastNames.length)];
-  const bpx = bizPrefixes[Math.floor(rng() * bizPrefixes.length)];
-  const bsx = bizSuffixes[Math.floor(rng() * bizSuffixes.length)];
-  const sub = suburbs[Math.floor(rng() * suburbs.length)];
-  const st = states[Math.floor(rng() * states.length)];
-  const score = Math.floor(rng() * 52) + 40;
-  const intentIdx = Math.floor(rng() * intents.length);
-  const outreachStatus = outreachStatuses[i] || 'contacted';
-  return {
-    id: 'pf' + (i + 1),
-    name: bpx + ' ' + bsx,
-    suburb: sub, state: st,
-    industry: bsx, intent: intents[intentIdx],
-    score, staff: String(Math.floor(rng() * 30) + 5),
-    est: String(2008 + Math.floor(rng() * 14)),
-    revenue: '$' + (Math.floor(rng() * 90) + 10) / 10 + 'M',
-    dm: { name: fn + ' ' + ln, title: 'Owner', email: fn.toLowerCase() + '@' + bpx.toLowerCase().replace(' ','') + bsx.toLowerCase() + '.com.au', phone: '+61 4XX XXX XXX', linkedin: 'Verified' },
-    signals: [{ text: 'Business signal detected', time: '1 week ago' }],
-    affordability: Math.floor(rng() * 6) + 3,
-    intentScore: Math.floor(rng() * 10) + 4,
-    composite: score,
-    vulnerability: 'Digital presence gaps detected. Priority outreach candidate.',
-    vulnGrades: { website: ['A','B','C','D','F'][Math.floor(rng()*5)], seo: ['C','D','F'][Math.floor(rng()*3)], reviews: ['A','B','C'][Math.floor(rng()*3)], ads: ['C','D','F'][Math.floor(rng()*3)], social: ['B','C','D','F'][Math.floor(rng()*4)], content: ['C','D','F'][Math.floor(rng()*3)] },
-    aiSummary: bpx + ' ' + bsx + ' is a local business with identifiable digital gaps and outreach potential.',
-    timeline: [],
-    triggerSignal: 'Digital gap detected',
-    triggerMessage: 'Initial outreach email',
-    prospectReply: null,
-    sentiment: 'Not yet contacted',
-    timeToMeeting: 'Not booked',
-    meeting: null,
-    competitors: [],
-    recommendedAngle: 'Standard digital presence improvement pitch.',
-    pricingRange: '$1,200–$2,400/month AUD',
-    openingHook: 'Standard opening.',
-    discoveryQuestions: [], objections: [], closeOptions: [],
-    outreachStatus,
-  };
-});
-
-const prospects = [...heroProspects, ...fillerProspects];
-
-const replies = [
-  { id: 'r1', prospectId: 'p1', heat: 'hot', name: 'James Whitford', business: 'Momentum Constructions', snippet: "This is exactly what we need. Can we set up a call this week?", time: '2h ago', channel: 'email' },
-  { id: 'r2', prospectId: 'p2', heat: 'hot', name: 'Sarah Kemp', business: 'Harbour Physiotherapy', snippet: "Very interested. We've been struggling with our online presence.", time: '4h ago', channel: 'linkedin' },
-  { id: 'r3', prospectId: 'p3', heat: 'hot', name: 'Dr Priya Narayan', business: 'Cascade Dental Group', snippet: "We just hired someone for this but would love a second opinion.", time: '1d ago', channel: 'email' },
-  { id: 'r4', prospectId: 'p4', heat: 'warm', name: 'Dr Rebecca Ashford', business: 'Coastal Veterinary', snippet: "Interesting. Can you send more details about pricing?", time: '2d ago', channel: 'sms' },
-  { id: 'r5', prospectId: 'p6', heat: 'warm', name: 'Michael Chen', business: 'Riverside Accounting', snippet: "Not sure if this is for us right now. Maybe next quarter?", time: '3d ago', channel: 'email' },
-  { id: 'r6', prospectId: 'p1', heat: 'cool', name: 'Reception', business: 'Momentum Constructions', snippet: "James is away until Thursday. I'll pass this along.", time: '5d ago', channel: 'voice' },
+const closed = [
+  { id:'w1', name:'Collaroy Dental Suite', dm:'Dr David Yao', grade:'A', score:92, outcome:'WON', time:'Cycle 2', amount:'$3,200/mo · signed' },
+  { id:'w2', name:'Leichhardt Plumbing', dm:'Frank Ciancio', grade:'B', score:84, outcome:'WON', time:'Cycle 2', amount:'$1,800/mo · signed' },
+  { id:'l1', name:'Mosman Wealth Advisors', dm:'Clara Hennessey', grade:'D', score:38, outcome:'LOST', time:'Cycle 2', amount:'No budget · Q3 retry' },
 ];
 
-/* ═══════════════════════════════════════════════════════════════════
-   STATE
-═══════════════════════════════════════════════════════════════════ */
-let activeInboxReply = 'r1';
-let activeSettingsTab = 'account';
-let activeOutreachTab = 'email';
-let activePipelineFilter = 'top10';
-let pipelinePage = 1;
-let pipelinePageSize = 20;
-let noteTargetId = null;
+/* Maya activity (today) */
+const MAYA_TODAY = [
+  { ic:'✉', t:'Sent Email 3 to <b>James Whitford</b> (Momentum)', at:'2m ago' },
+  { ic:'✓', t:'Booked meeting with <b>Sarah Kemp</b> (Harbour Physio) via reply', at:'14m ago' },
+  { ic:'in', t:'LinkedIn connect accepted by <b>Aria Martinelli</b> (Bondi Creative)', at:'1h ago' },
+  { ic:'✉', t:'SMS sent to <b>Dr Rebecca Ashford</b> (Coastal Vet)', at:'2h ago' },
+  { ic:'☎', t:'Voice AI scheduled for <b>Wei Zhang</b> (Parramatta Motor) tomorrow', at:'3h ago' },
+  { ic:'✉', t:'Email 3 sent to <b>Priya Sharma</b> (Gold Coast Mortgage)', at:'4h ago' },
+];
 
-function getCycleState() {
-  return localStorage.getItem('agencyos_cycle_state') || 'review';
+/* Needs your attention — SMART TRIGGERS (v4 Fix 4).
+   Exception-first, operator-action-required. Each derives from
+   a specific prospect state change, not generic system status. */
+const ATTENTION = [
+  {
+    type:'reply', ic:'💬', pid:'p2',
+    text:'<b>Harbour Physiotherapy</b> replied with positive sentiment — you haven\'t viewed their briefing yet.',
+    cta:'Open briefing →',
+  },
+  {
+    type:'meeting', ic:'⏱', pid:'p1',
+    text:'<b>Meeting with James Whitford in 2 hours</b> — briefing not opened.',
+    cta:'Open brief →',
+  },
+  {
+    type:'downgrade', ic:'⬇', pid:'p3',
+    text:'<b>Cascade Dental</b> went from Trying to Struggling — 3 new negative reviews detected.',
+    cta:'Review signal →',
+  },
+];
+
+/* QC_SAMPLE removed in v4 (Fix 3) — Stage 10 critic loop handles
+   message QA automatically; spot-check on dashboard is redundant. */
+
+/* Feed events */
+const events = [
+  { day:'TODAY', t:'12m ago', type:'reply', cat:'replies', pid:'p1', icon:'💬',
+    label:'REPLY · POSITIVE', headline:'<span class="biz" data-pid="p1">Momentum Constructions</span> replied — James Whitford',
+    quote:'"This is exactly what we need. Can we set up a call this week?"',
+    meta:'Maya queued meeting booking · briefing auto-generated' },
+  { day:'TODAY', t:'37m ago', type:'meeting', cat:'meetings', pid:'p1', icon:'📅',
+    label:'MEETING BOOKED', headline:'Meeting booked with <span class="biz" data-pid="p1">Momentum Constructions</span>',
+    meta:'Wed 23 Apr · 4:00pm · Zoom · today' },
+  { day:'TODAY', t:'1h ago', type:'signal', cat:'signals', pid:'p3', icon:'⚡',
+    label:'SIGNAL · HIRING', headline:'<span class="biz" data-pid="p3">Cascade Dental</span> hired marketing coordinator',
+    meta:'Strength 71 · LinkedIn job post · intent trigger ↑' },
+  { day:'TODAY', t:'2h ago', type:'voice', cat:'voice', pid:'p7', icon:'☎',
+    label:'VOICE AI · VOICEMAIL', headline:'Voice AI to <span class="biz" data-pid="p7">Parramatta Motor</span> — voicemail left',
+    meta:'Wei Zhang · 11sec · callback queued tomorrow 10:30am' },
+  { day:'TODAY', t:'3h ago', type:'outreach', cat:'outreach', pid:'p4', icon:'✉',
+    label:'EMAIL · SENT', headline:'Email 2 sent to <span class="biz" data-pid="p4">Coastal Veterinary</span>',
+    meta:'Subject: "Local search and your community presence"' },
+  { day:'TODAY', t:'4h ago', type:'signal', cat:'signals', pid:'p9', icon:'⚡',
+    label:'SIGNAL · SOCIAL', headline:'<span class="biz" data-pid="p9">Fitzroy Cafe Group</span> — public delivery-platform complaints',
+    meta:'Strength 81 · margin pressure visible' },
+  { day:'TODAY', t:'5h ago', type:'linkedin', cat:'outreach', pid:'p8', icon:'in',
+    label:'LINKEDIN · ACCEPTED', headline:'LinkedIn connect accepted — <span class="biz" data-pid="p8">Bondi Creative Studio</span>',
+    meta:'Aria Martinelli · message scheduled tomorrow 9am' },
+  { day:'TODAY', t:'6h ago', type:'reply', cat:'replies', pid:'p4', icon:'💬',
+    label:'REPLY · INTERESTED', headline:'<span class="biz" data-pid="p4">Coastal Veterinary</span> replied via SMS',
+    quote:'"Interesting. Can you send more details about pricing?"',
+    meta:'Maya sending pricing range + 2 discovery questions before full quote' },
+  { day:'YESTERDAY', t:'14:33', type:'meeting', cat:'meetings', pid:'p4', icon:'📅',
+    label:'MEETING BOOKED', headline:'Meeting booked with <span class="biz" data-pid="p4">Coastal Veterinary</span>',
+    meta:'Mon 21 Apr · 9:30am · completed' },
+  { day:'YESTERDAY', t:'13:00', type:'reply', cat:'replies', pid:'p3', icon:'💬',
+    label:'REPLY · CAUTIOUS', headline:'<span class="biz" data-pid="p3">Cascade Dental</span> replied — Dr Priya Narayan',
+    quote:'"We just hired someone for this but would love a second opinion."',
+    meta:'Maya sending case studies + complementary-role positioning' },
+  { day:'YESTERDAY', t:'11:42', type:'signal', cat:'signals', pid:'p2', icon:'⚡',
+    label:'SIGNAL · COMPETITOR', headline:'<span class="biz" data-pid="p2">Harbour Physiotherapy</span> — competitor 200m away launched',
+    meta:'Strength 92 · ad spend tripled in 14 days' },
+  { day:'YESTERDAY', t:'09:30', type:'meeting', cat:'meetings', pid:'p2', icon:'📅',
+    label:'MEETING BOOKED', headline:'Meeting booked with <span class="biz" data-pid="p2">Harbour Physiotherapy</span>',
+    meta:'Wed 23 Apr · 2:00pm · today' },
+  { day:'YESTERDAY', t:'08:00', type:'outreach', cat:'outreach', pid:'p10', icon:'✉',
+    label:'EMAIL · SENT', headline:'Email 3 sent to <span class="biz" data-pid="p10">Gold Coast Mortgage</span>',
+    meta:'Subject: "Your new financial planning arm needs a digital foundation"' },
+  { day:'EARLIER THIS WEEK', t:'Wed 11:30', type:'reply', cat:'replies', pid:'p2', icon:'💬',
+    label:'REPLY · INTERESTED', headline:'<span class="biz" data-pid="p2">Harbour Physiotherapy</span> replied — Sarah Kemp',
+    quote:'"Very interested. We\'ve been struggling with our online presence."',
+    meta:'Maya queued meeting booking · auto-confirmation sent' },
+  { day:'EARLIER THIS WEEK', t:'Wed 10:04', type:'voice', cat:'voice', pid:'p1', icon:'☎',
+    label:'VOICE AI · VOICEMAIL', headline:'Voice AI to <span class="biz" data-pid="p1">Momentum Constructions</span> — voicemail left',
+    meta:'James Whitford · 9sec · email follow-up sent' },
+  { day:'EARLIER THIS WEEK', t:'Tue 16:22', type:'reply', cat:'replies', pid:'p6', icon:'💬',
+    label:'REPLY · NOT NOW', headline:'<span class="biz" data-pid="p6">Riverside Accounting</span> replied — Michael Chen',
+    quote:'"Not sure if this is for us right now. Maybe next quarter?"',
+    meta:'Soft-objection · queued for Q3 nurture sequence' },
+  { day:'EARLIER THIS WEEK', t:'Tue 14:17', type:'signal', cat:'signals', pid:'p10', icon:'⚡',
+    label:'SIGNAL · ABN', headline:'<span class="biz" data-pid="p10">Gold Coast Mortgage Co</span> — registered new financial planning ABN',
+    meta:'Strength 67 · expansion signal · new service angle' },
+  { day:'EARLIER THIS WEEK', t:'Tue 09:00', type:'linkedin', cat:'outreach', pid:'p3', icon:'in',
+    label:'LINKEDIN · ACCEPTED', headline:'LinkedIn connect accepted — <span class="biz" data-pid="p3">Cascade Dental Group</span>',
+    meta:'Dr Priya Narayan · message will follow at email day 5' },
+  { day:'EARLIER THIS WEEK', t:'Mon 11:30', type:'reply', cat:'replies', pid:'p5', icon:'💬',
+    label:'REPLY · INTERESTED', headline:'<span class="biz" data-pid="p5">Southbank Legal Advisory</span> replied — Andrew Volkov',
+    quote:'"Interesting. Send me the audit — I\'ll read before we chat."',
+    meta:'Audit PDF queued for email 4 · supervisor review pending' },
+  { day:'EARLIER THIS WEEK', t:'Mon 09:00', type:'outreach', cat:'outreach', pid:'p5', icon:'✉',
+    label:'EMAIL · SENT', headline:'Email 1 sent to <span class="biz" data-pid="p5">Southbank Legal Advisory</span>',
+    meta:'Subject: "Your thought leadership content isn\'t ranking — here\'s why"' },
+  { day:'EARLIER THIS WEEK', t:'Mon 08:30', type:'signal', cat:'signals', pid:'p1', icon:'⚡',
+    label:'SIGNAL · REVIEWS', headline:'<span class="biz" data-pid="p1">Momentum Constructions</span> — GMB rating dropped 4.6→4.1 in 90 days',
+    meta:'Strength 76 · negative review velocity' },
+  { day:'EARLIER THIS WEEK', t:'Mon 08:00', type:'outreach', cat:'outreach', pid:'p9', icon:'✉',
+    label:'EMAIL · SENT', headline:'Email 1 sent to <span class="biz" data-pid="p9">Fitzroy Cafe Group</span>',
+    meta:'Subject: "Replace platform fees with direct bookings"' },
+  { day:'EARLIER THIS WEEK', t:'Mon 07:45', type:'voice', cat:'voice', pid:'p7', icon:'☎',
+    label:'VOICE AI · CALL ATTEMPTED', headline:'Voice AI to <span class="biz" data-pid="p7">Parramatta Motor Group</span> — no answer',
+    meta:'Wei Zhang · queued for retry' },
+  { day:'EARLIER THIS WEEK', t:'Mon 07:00', type:'signal', cat:'signals', pid:'p8', icon:'⚡',
+    label:'SIGNAL · SOCIAL', headline:'<span class="biz" data-pid="p8">Bondi Creative Studio</span> — Instagram following +300% in 3 months',
+    meta:'Strength 85 · momentum signal' },
+];
+
+/* ================================================================
+   HELPERS
+================================================================ */
+function overallVulnGrade(vg) {
+  if (!vg) return 'C';
+  const m={A:5,B:4,C:3,D:2,F:1}, i={5:'A',4:'B',3:'C',2:'D',1:'F'};
+  const v=Object.values(vg).map(x=>m[x]||3);
+  return i[Math.round(v.reduce((a,b)=>a+b,0)/v.length)]||'C';
 }
-function setCycleState(state) {
-  localStorage.setItem('agencyos_cycle_state', state);
-  updateDevControls();
-  const hash = window.location.hash || '#home';
-  if (hash === '#pipeline' || hash.startsWith('#pipeline/')) renderPipeline();
+function staffRange(s) {
+  const n=parseInt(s,10);
+  if(!n) return '—';
+  if(n<=10) return '1-10 employees';
+  if(n<=50) return '11-50 employees';
+  if(n<=200) return '51-200 employees';
+  return '200+ employees';
 }
-function updateDevControls() {
-  const state = getCycleState();
-  ['review','outreach','complete'].forEach(s => {
-    const el = document.getElementById('devBtn' + s.charAt(0).toUpperCase() + s.slice(1));
-    if (el) el.classList.toggle('active', state === s);
-  });
+function findP(id){ return prospects.find(p=>p.id===id); }
+function statusPill(s){
+  const c=s==='Meeting Booked'?'green':s==='Replied'?'amber':s==='Discovered'?'gray':'gray';
+  return `<span class="pill ${c}">${s}</span>`;
 }
 
-function getReviewedIds() {
-  try { return JSON.parse(localStorage.getItem('agencyos_reviewed_prospects') || '[]'); } catch(e) { return []; }
+/* Schedule — state-aware scheduled touchpoints for drawer (v6).
+   Default 5-touch sequence used for any Contacted prospect. */
+const DEFAULT_TOUCHES = [
+  { date:'Mon 28 Apr', channel:'Email',       chKey:'email',    template:'Competitor insight follow-up' },
+  { date:'Wed 30 Apr', channel:'LinkedIn DM', chKey:'linkedin', template:'Light-touch value share' },
+  { date:'Fri 2 May',  channel:'Voice AI',    chKey:'voice',    template:'Keira opener — pain-point hook' },
+  { date:'Tue 6 May',  channel:'Email',       chKey:'email',    template:'Social proof case study' },
+  { date:'Thu 8 May',  channel:'SMS',         chKey:'sms',      template:'Quick nudge — meeting CTA' },
+];
+function scheduleForProspect(p) {
+  /* Returns { state, items, message } — state is 'active' | 'complete' | 'paused' | 'none' */
+  if (!p) return { state:'none', items:[], message:'No prospect.' };
+  if (p.meeting) return { state:'complete', items:[], message:'Cadence complete — meeting booked' };
+  if (p.status === 'Replied') return { state:'paused', items:[], message:'Cadence paused — reply received' };
+  if (p.status === 'Discovered') return { state:'none', items:[], message:'Not yet in outreach — no touches scheduled' };
+  /* Contacted = render default 5-touch sequence */
+  return { state:'active', items: DEFAULT_TOUCHES, message:'' };
 }
-function markReviewed(id) {
-  const visited = getReviewedIds();
-  if (!visited.includes(id)) { visited.push(id); localStorage.setItem('agencyos_reviewed_prospects', JSON.stringify(visited)); }
+function toggleSched() {
+  const wrap = document.getElementById('schedWrap');
+  if (!wrap) return;
+  const next = wrap.dataset.open === 'true' ? 'false' : 'true';
+  wrap.setAttribute('data-open', next);
+  wrap.dataset.open = next;
+  /* v8 Fix 1: swap chev label text on toggle (triangle + phrase) */
+  const chev = document.getElementById('schedChev');
+  if (chev) chev.textContent = next === 'true' ? '▾ Collapse schedule' : '▸ Expand schedule';
 }
-function getReviewedCount() { return getReviewedIds().length; }
+/* Snapshot signal-row derivations — derive friendly summaries from vulnGrades */
+function gmbRating(g) { return ({A:'4.7',B:'4.2',C:'3.8',D:'3.3',F:'2.8'})[g] || '—'; }
+function adPresence(g) { return ({A:'Active · tracked',B:'Active',C:'Active · untracked',D:'Recently paused',F:'None detected'})[g] || '—'; }
+function intentBand(s) { return s>=80 ? 'Hot' : s>=60 ? 'Warm' : s>=40 ? 'Watching' : 'Cool'; }
 
-function getProspectNote(id) {
-  try { const n = JSON.parse(localStorage.getItem('agencyos_notes') || '{}'); return n[id] || ''; } catch(e) { return ''; }
+/* ================================================================
+   GLOBAL RIGHT DRAWER (briefing)
+================================================================ */
+function openDrawer(pid) {
+  const p = findP(pid); if (!p) return;
+  const vr = overallVulnGrade(p.vulnGrades);
+  document.getElementById('dhName').textContent = p.name;
+  document.getElementById('dhSub').textContent = `${p.dm.name} · ${p.dm.title} · ${p.suburb}, ${p.state}`;
+  const grades = ['website','seo','reviews','ads','social','content'];
+  document.getElementById('drawerBody').innerHTML = `
+    <div class="bf-section">
+      <h4>Business meta</h4>
+      <div class="bf-meta">
+        <div class="bf-kv"><span class="k">Domain</span><span class="v">${p.domain}</span></div>
+        <div class="bf-kv"><span class="k">GMB category</span><span class="v">${p.gmb_category}</span></div>
+        <div class="bf-kv"><span class="k">Employees</span><span class="v" title="Source: LinkedIn company page">${staffRange(p.staff)} (LinkedIn)</span></div>
+        <div class="bf-kv"><span class="k">Established</span><span class="v" title="Source: ABN registry">ABN registered ${p.est}</span></div>
+        <div class="bf-kv"><span class="k">DFS organic ETV</span><span class="v">$${p.dfs_organic_etv}/mo</span></div>
+        <div class="bf-kv"><span class="k">Domain rank</span><span class="v">${p.domain_rank}/100</span></div>
+        <div class="bf-kv"><span class="k">Backlinks</span><span class="v">${p.backlinks_count}</span></div>
+        <div class="bf-kv"><span class="k">Status</span><span class="v">${p.status}</span></div>
+      </div>
+    </div>
+
+    <div class="bf-section">
+      <h4>Vulnerability — overall grade ${vr}</h4>
+      <div style="font-size:13px;color:var(--ink-2);line-height:1.6;margin-bottom:12px;">${p.vulnerability}</div>
+      <div class="vr-strip">
+        ${grades.map(g => `<div class="vr-cw"><div class="vr-letter" data-g="${p.vulnGrades[g]}" onclick="showVRPopover('${p.id}','${g}',event)" title="Click for explanation">${p.vulnGrades[g]}</div><div class="vr-name">${g}</div></div>`).join('')}
+      </div>
+    </div>
+
+    <div class="bf-section">
+      <h4>Outreach timeline${(() => { const evs = unifiedTimeline(p); return evs.length ? ` <span style="font-family:'DM Sans',sans-serif;text-transform:none;letter-spacing:0;color:var(--ink-3);font-size:11px;font-weight:400;margin-left:6px;">${evs.length} events</span>` : ''; })()}</h4>
+      ${renderUnifiedTimeline(p, 'ctd')}
+    </div>
+
+    <div class="bf-section">
+      <h4>Recommended angle</h4>
+      <div class="bf-ai">✨ AI-generated briefing · verify before use</div>
+      <div class="bf-hook">${p.openingHook}</div>
+    </div>
+
+    <div class="bf-section">
+      <h4>Discovery questions</h4>
+      <ul class="bf-list">${p.discoveryQuestions.map(q => `<li>${q}</li>`).join('')}</ul>
+    </div>
+
+    <div class="bf-section">
+      <h4>Common objections</h4>
+      ${p.objections.map(o => `<div class="bf-obj"><div class="obj-q">${o.obj}</div><div class="obj-a">${o.response}</div></div>`).join('')}
+    </div>
+
+    <div class="bf-section">
+      <h4>Close options</h4>
+      <ul class="bf-list">${p.closeOptions.map(c => `<li>${c}</li>`).join('')}</ul>
+      <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);margin-top:10px;letter-spacing:0.1em;text-transform:uppercase;">Your service pricing — from your agency rate card</div>
+      <div style="font-family:'Playfair Display',serif;font-size:20px;font-weight:700;color:var(--ink);">${p.pricingRange}</div>
+    </div>
+
+    <div class="bf-section">
+      <h4>Also ranking for your keywords</h4>
+      <ul class="bf-list">${p.competitors.map(c => `<li>${c}</li>`).join('')}</ul>
+    </div>
+  `;
+  document.getElementById('drawerBackdrop').classList.add('on');
+  document.getElementById('drawer').classList.add('on');
 }
-function saveProspectNote(id, text) {
-  try { const n = JSON.parse(localStorage.getItem('agencyos_notes') || '{}'); n[id] = text; localStorage.setItem('agencyos_notes', JSON.stringify(n)); } catch(e) {}
+function closeDrawer() {
+  document.getElementById('drawerBackdrop').classList.remove('on');
+  document.getElementById('drawer').classList.remove('on');
 }
 
-/* ═══════════════════════════════════════════════════════════════════
-   ROUTING
-═══════════════════════════════════════════════════════════════════ */
-function navigate(hash) {
-  if (hash.startsWith('#pipeline/')) {
-    const id = hash.split('/')[1];
-    markReviewed(id);
+/* ================================================================
+   VR GRADE EXPLANATIONS — 3-section content (Data / Strengths /
+   Improvements). Clickable popover only on Meeting-Booked briefing
+   prep page (per dispatch v3).
+================================================================ */
+const VR_EXPLAIN = {
+  website: {
+    A: { data:'SSL active, mobile responsive, PageSpeed 82/100, structured data present.', strengths:'Fast load time, modern CMS, schema markup implemented, accessibility WCAG-AA.', improvements:'Minor: blog section could be more active. Conversion-rate test on hero CTA.' },
+    B: { data:'SSL active, mobile responsive, PageSpeed 64/100, partial schema.', strengths:'Solid technical foundation, decent UX, modern stack.', improvements:'Lighthouse score under 80, missing FAQ + service schema, image-weight optimisation.' },
+    C: { data:'SSL active, mobile responsive but slow on 3G, PageSpeed 48/100, no structured data.', strengths:'Functional, mobile-friendly, basic conversion paths.', improvements:'Page weight reduction, schema markup needed, hero CTA copy and conversion paths weak.' },
+    D: { data:'SSL active, partially mobile responsive, PageSpeed 32/100, outdated CMS, no schema.', strengths:'Domain has authority and history.', improvements:'Outdated CMS upgrade, mobile UX rebuild, slow load (>4s) needs caching + image strategy, schema markup missing.' },
+    F: { data:'No SSL, not mobile responsive, last updated 2019, no structured data, PageSpeed 23/100.', strengths:'Domain has history and some backlinks.', improvements:'Critical: SSL certificate needed, mobile responsive rebuild required, content refresh, schema markup missing.' },
+  },
+  seo: {
+    A: { data:'Top-3 rankings on 12 commercial keywords, 89 ranking total, clean technical SEO.', strengths:'Strong keyword footprint, healthy backlink profile, content depth.', improvements:'Continue topic cluster expansion. Internal-linking audit could lift mid-tier pages.' },
+    B: { data:'Page-1 rankings on 7 of 10 target keywords, 58 ranking total, 41 referring domains.', strengths:'Good page-1 share, healthy domain authority, on-page SEO solid.', improvements:'Push remaining 3 targets to page 1 with content depth + 2-3 quality backlinks each.' },
+    C: { data:'Page-1 rankings on 3 of 10 target keywords, 42 ranking total, 28 referring domains.', strengths:'Some commercial rankings, partial title-tag optimisation.', improvements:'Title tag rewrite for 7 service pages, meta description gaps, content depth on core pages.' },
+    D: { data:'Few first-page rankings (1-2), thin title tags, no meta descriptions, weak local SEO.', strengths:'Domain registered and indexed, some authority via backlinks.', improvements:'Title tag optimisation for 5 core service pages, meta descriptions, local SEO schema, content strategy for target keywords.' },
+    F: { data:'Zero first-page rankings for any target keyword, no title tag strategy, no meta descriptions, no local SEO.', strengths:'Domain registered and crawlable.', improvements:'Full SEO foundation needed — keyword strategy, title tags, meta descriptions, content plan, local schema, GMB optimisation.' },
+  },
+  reviews: {
+    A: { data:'4.7 stars, 124 reviews, fresh velocity (8 in last 30 days), all GMB Q&A answered.', strengths:'Excellent reputation, high volume, active response strategy, strong recent velocity.', improvements:'Maintain cadence. Consider video testimonials for top services.' },
+    B: { data:'4.2 stars, 47 reviews, 3 negative in last 90 days.', strengths:'Strong review volume, mostly positive sentiment, active GMB profile.', improvements:'Address 3 recent negative reviews, implement review response strategy, request cadence to lift average.' },
+    C: { data:'3.8 stars, 28 reviews, slow response to negatives, no review velocity.', strengths:'Above-3-star average, established review history.', improvements:'Active review response needed, review request automation, address themed complaints visible in 1-star reviews.' },
+    D: { data:'Below 3.5 stars OR fewer than 15 reviews OR no reviews in 90+ days.', strengths:'Has a GMB listing claimed.', improvements:'Critical reputation work — review response, customer outreach for fresh reviews, address recurring complaints, GMB Q&A activation.' },
+    F: { data:'No reviews OR negative trajectory OR multiple unanswered complaints.', strengths:'GMB listing exists (recoverable foundation).', improvements:'Review-recovery plan: respond to all negatives professionally, customer outreach for fresh reviews, complaint resolution programme, GMB completeness audit.' },
+  },
+  ads: {
+    A: { data:'Google Ads + Meta Ads spend detected, conversion tracking active, ROAS 4.2× visible.', strengths:'Active multi-channel paid spend, conversion tracking, healthy ROAS.', improvements:'Test new creative variants, expand into Performance Max for branded queries.' },
+    B: { data:'Google Ads spend detected, basic conversion tracking, no Meta presence.', strengths:'Active spend, basic tracking infrastructure in place.', improvements:'Conversion tracking event refinement, expand into Meta Ads for awareness, landing page CRO.' },
+    C: { data:'Google Ads spend detected (estimated moderate), no conversion tracking configured.', strengths:'Spending — willing to invest in growth.', improvements:'Critical: install conversion tracking immediately. Without it, spend efficiency cannot be measured. Add Google Analytics + GTM events.' },
+    D: { data:'Recently paused Google Ads after 6 months OR sporadic spend with no measurement.', strengths:'Has experimented with paid acquisition.', improvements:'Diagnose pause reason (cost vs. results). If results — full account audit + restart strategy. If cost — Performance Max + smart bidding to lift efficiency.' },
+    F: { data:'No paid spend detected. Competitors capturing the search demand.', strengths:'Untapped channel — clean slate for testing.', improvements:'Paid search foundation: keyword research, account structure, conversion tracking, landing pages, budget pacing.' },
+  },
+  social: {
+    A: { data:'Active LinkedIn + Instagram, 4+ posts/week, engagement rate 5.2%, follower growth 12% MoM.', strengths:'High-frequency posting, strong engagement, audience growth trend.', improvements:'Test short-form video. Consider expanding into TikTok for category awareness.' },
+    B: { data:'Active LinkedIn presence, posts 2x/month, modest engagement.', strengths:'Consistent presence, professional tone, moderate engagement.', improvements:'Increase posting cadence to weekly, expand into Instagram for visual storytelling, repurpose content across platforms.' },
+    C: { data:'Profiles exist, posts monthly or less, limited interaction.', strengths:'Profiles claimed and branded.', improvements:'Establish posting cadence (2x/month minimum), content calendar, engagement strategy with industry conversations.' },
+    D: { data:'Profiles exist but stale — last activity 60+ days ago.', strengths:'Profiles claimed (recoverable).', improvements:'Reactivation strategy: post weekly for 90 days to rebuild algorithm signals, profile refresh, engagement plan.' },
+    F: { data:'No social presence OR all profiles abandoned for 6+ months.', strengths:'No reputation to repair — clean start.', improvements:'Social foundation: claim handles, profile build-out (LinkedIn first for B2B), content calendar, posting cadence, engagement strategy.' },
+  },
+  content: {
+    A: { data:'Active blog (4+ posts/mo), 8 case studies, gated assets, content ranking on 14 long-tail terms.', strengths:'Strong content engine, case-study depth, ranking content.', improvements:'Topical authority play — pillar pages around 2-3 core services. Repurpose top posts into video.' },
+    B: { data:'Blog active (1-2 posts/mo), 3 case studies, partial content strategy.', strengths:'Consistent posting, some case-study proof, on-brand voice.', improvements:'Increase to weekly cadence, expand case studies to top services, add gated lead magnet for capture.' },
+    C: { data:'Sporadic blog activity, basic About page, 1-2 case studies.', strengths:'Foundation content present.', improvements:'Establish content calendar (2x/month minimum), case-study programme, service-page content depth.' },
+    D: { data:'Blog exists but rarely updated (last post >90 days), no case studies.', strengths:'Blog infrastructure ready.', improvements:'Content reactivation — editorial calendar, case-study collection programme, repurpose existing thought-leadership into rankable formats.' },
+    F: { data:'Blog section empty, no case studies, no content strategy.', strengths:'Service pages exist as foundation.', improvements:'Content foundation: blog launch, editorial calendar, case-study programme, gated assets, content-led SEO strategy.' },
+  },
+};
+function explainVR(p, key) {
+  const grade = (p.vulnGrades || {})[key] || 'C';
+  return (VR_EXPLAIN[key] || {})[grade] || { data:`Grade ${grade}.`, strengths:'—', improvements:'See vulnerability narrative for detail.' };
+}
+
+let activePopover = null;
+function showVRPopover(pid, key, evt) {
+  if (evt) { evt.stopPropagation(); }
+  closeVRPopover();
+  const p = findP(pid); if (!p) return;
+  const grade = (p.vulnGrades || {})[key] || 'C';
+  const ex = explainVR(p, key);
+  const tip = document.createElement('div');
+  tip.className = 'vr-popover';
+  tip.innerHTML = `
+    <button class="vr-pop-close" onclick="closeVRPopover()" aria-label="Close">×</button>
+    <div class="vr-pop-head">
+      <span class="vr-letter" data-g="${grade}">${grade}</span>
+      <span class="vr-pop-key">${key} · grade ${grade}</span>
+    </div>
+    <div class="vr-pop-section"><h6>Data — what we found</h6><p>${ex.data}</p></div>
+    <div class="vr-pop-section"><h6>Strengths</h6><p>${ex.strengths}</p></div>
+    <div class="vr-pop-section"><h6>Improvements</h6><p>${ex.improvements}</p></div>
+  `;
+  document.body.appendChild(tip);
+  activePopover = tip;
+  /* position below the clicked letter, clamped to viewport */
+  const target = evt && evt.target.closest('.vr-letter');
+  if (target) {
+    const rect = target.getBoundingClientRect();
+    tip.style.top = (rect.bottom + window.scrollY + 8) + 'px';
+    const left = rect.left + window.scrollX + (rect.width / 2) - 170;
+    tip.style.left = Math.max(8, Math.min(left, window.scrollX + window.innerWidth - 356)) + 'px';
   }
-  window.location.hash = hash;
+  setTimeout(() => document.addEventListener('click', vrPopoverOutside), 0);
+}
+function vrPopoverOutside(e) {
+  if (activePopover && !activePopover.contains(e.target)) closeVRPopover();
+}
+function closeVRPopover() {
+  if (activePopover) { activePopover.remove(); activePopover = null; }
+  document.removeEventListener('click', vrPopoverOutside);
 }
 
-function router() {
-  const hash = window.location.hash || '#home';
-  if (hash === '#home') renderHome();
-  else if (hash === '#pipeline') renderPipeline();
-  else if (hash.startsWith('#pipeline/')) { const id = hash.split('/')[1]; renderDetail(id); }
-  else if (hash === '#cycles') renderCycles();
-  else if (hash === '#inbox') renderInbox();
-  else if (hash === '#sequences') renderSequences();
-  else if (hash === '#signals') renderInsights();
-  else if (hash === '#reports') renderReports();
-  else if (hash === '#settings') renderSettings();
-  else renderHome();
-  updateSidebarActive(hash);
-  updateBreadcrumb(hash);
-  updateBottomNav(hash);
-  updateDevControls();
+/* ================================================================
+   COMMUNICATION TIMELINE — synthesised per prospect
+================================================================ */
+function synthTimeline(p) {
+  const events = [];
+  const reply = {
+    p1: '"This is exactly what we need. Can we set up a call this week?"',
+    p2: '"Very interested. We\'ve been struggling with our online presence."',
+    p3: '"We just hired someone for this but would love a second opinion."',
+    p4: '"Interesting. Can you send more details about pricing?"',
+    p5: '"Interesting. Send me the audit — I\'ll read before we chat."',
+    p6: '"Not sure if this is for us right now. Maybe next quarter?"',
+  }[p.id];
+  const subj = p.openingHook ? p.openingHook.match(/"([^"]+)"/)?.[1].slice(0, 70) || 'Vulnerability finding' : 'Outreach';
+  const fn = p.dm.name.split(' ')[1] || p.dm.name.split(' ')[0];
+  const body1 = `Hi ${fn}, ${p.vulnerability.split('.')[0].toLowerCase()}.\\nWorth 15 minutes this week to walk through what we\\'ve done for similar ${p.industry.toLowerCase()} businesses?`;
+  const body2 = `Hi ${fn} — following on from last week. Attaching a 1-pager from a ${p.industry} client we helped with a similar issue. Happy to jump on a short call.`;
+  const body3 = `Hi ${fn} — last touch from me for now. If the timing\\'s wrong, no stress — happy to check back in Q3. Otherwise reply with a 20-min window and I\\'ll send a calendar invite.`;
+  const liConnect = `Hi ${fn} — noticed ${p.vulnerability.split('.')[0].toLowerCase()}. I work with ${p.industry.toLowerCase()} businesses on exactly this. Open to connecting?`;
+
+  events.push({ ch:'email', t:'Day 1 · 09:02', label:'Email 1 sent', detail:`Subject: "${subj.split('.')[0]}…"`,
+    expand:`<h6>Subject</h6><p>${subj.split('.')[0]}…</p><h6>Body preview (first 2 lines)</h6><p>Hi ${fn}, ${p.vulnerability.split('.')[0].toLowerCase()}.<br>Worth 15 minutes this week to walk through what we've done for similar ${p.industry.toLowerCase()} businesses?</p><h6>Sent from</h6><p>dave@keiracom.com.au · via Maya</p>` });
+  events.push({ ch:'email', t:'Day 1 · 11:34', label:'Email 1 opened', detail:'opened 3×',
+    expand:`<h6>Open activity</h6><p>First open: Day 1 · 11:34am AEST<br>Second open: Day 1 · 2:17pm AEST<br>Third open: Day 2 · 8:09am AEST</p><h6>Engagement signal</h6><p>3× open + 2+ hour gap = warm read pattern. Indicator for prioritised follow-up.</p>` });
+  events.push({ ch:'linkedin', t:'Day 3 · 09:05', label:'LinkedIn connect sent', detail:'personalised note · 198 chars',
+    expand:`<h6>Connect note</h6><p>${liConnect}</p><h6>Delivery</h6><p>Sent via Unipile · DM's LinkedIn weekly cap: 847/1000 used</p>` });
+  if (['p3','p2','p5','p1','p6','p4'].includes(p.id)) events.push({ ch:'linkedin', t:'Day 3 · 14:17', label:'LinkedIn connect accepted', detail:'message sequence engaged',
+    expand:`<h6>Acceptance</h6><p>Accepted ${p.dm.name.split(' ')[0]}'s invite within 5 hours — high engagement signal.</p><h6>Next action</h6><p>Maya will send a value-share message on Day 5 after Email 2 lands, referencing the specific vulnerability noted in Email 1.</p>` });
+  events.push({ ch:'email', t:'Day 5 · 09:01', label:'Email 2 sent', detail:'follow-up · case study attached',
+    expand:`<h6>Subject</h6><p>Re: ${subj.split('.')[0]}… (quick follow-up)</p><h6>Body preview (first 2 lines)</h6><p>${body2.split('\\n')[0]}<br>${body2.split('\\n')[1] || ''}</p><h6>Attachment</h6><p>Case study: "${p.industry} win — 90-day outcome" (1 page PDF)</p>` });
+  if (p.status !== 'Discovered') events.push({ ch:'email', t:'Day 5 · 16:52', label:'Email 2 opened', detail:'opened 1×',
+    expand:`<h6>Open activity</h6><p>Single open: Day 5 · 4:52pm AEST</p><h6>Engagement signal</h6><p>1 open only. Attachment was not clicked. Softer signal than Email 1.</p>` });
+  if (['p1','p7','p9'].includes(p.id)) events.push({ ch:'voice', t:'Day 7 · 10:00', label:'Voice AI call placed', detail:'Maya · 11sec · voicemail left',
+    expand:`<h6>Outcome</h6><p>Voicemail left (11 seconds). Standard Keira opener — name-drops the specific pain point from Email 1.</p><h6>Voicemail transcript</h6><p style="font-style:italic;">"Hi ${fn}, this is Keira calling from Keiracom — just wanted to leave a quick note after my email earlier. If you get a chance to look, happy to have a quick chat this week. No pressure — have a great day."</p><h6>Follow-up</h6><p><a style="color:var(--copper);cursor:pointer;" onclick="event.stopPropagation();alert('Transcript download — prototype')">Transcript available →</a></p>` });
+  if (p.id === 'p4') events.push({ ch:'sms', t:'Day 7 · 10:00', label:'SMS sent', detail:'cross-channel touch',
+    expand:`<h6>SMS body</h6><p>Hi ${fn} — Dave from Keiracom. Sent you an email earlier re: ${p.name}. Quick 2-min read if you've got a sec. Cheers.</p><h6>Delivery status</h6><p>Delivered · Day 7 · 10:01am AEST · 160 chars</p>` });
+  events.push({ ch:'email', t:'Day 10 · 09:03', label:'Email 3 sent', detail:'breakup — last touch in sequence',
+    expand:`<h6>Subject</h6><p>One last thing, ${fn}?</p><h6>Body preview (first 2 lines)</h6><p>${body3.split('.')[0]}.<br>${body3.split('.')[1] || ''}.</p><h6>Tone</h6><p>Breakup / permission-based — designed to re-open the door without pressure.</p>` });
+  if (reply) {
+    events.push({ ch:'reply', t:'Day 10 · 15:41', label:'Reply received', detail:reply, isReply:true,
+      expand:`<h6>Full reply</h6><p style="font-style:italic;">${reply}</p><h6>Intent classification</h6><p>${p.status === 'Meeting Booked' ? 'Positive · meeting intent — auto-booking triggered' : 'Interested · awaiting operator direction'}</p><h6>Response time</h6><p>${reply ? 'From: ' + p.dm.email + '<br>Replied within: 6 hours 38 minutes' : '—'}</p>` });
+  }
+  if (p.meeting) {
+    events.push({ ch:'meeting', t:`Day 10 · 16:05`, label:`Meeting booked — ${p.meeting.date} ${p.meeting.time}`, detail:`via ${p.meeting.platform} · ${p.meeting.countdown}`, isCulm:true,
+      expand:`<h6>Meeting details</h6><p><b>${p.meeting.date} · ${p.meeting.time} AEST</b><br>Platform: ${p.meeting.platform}<br>Countdown: ${p.meeting.countdown}</p><h6>Attendees</h6><p>${p.dm.name} · ${p.dm.title} · ${p.name}<br>Dave Stephens · Founder · Keiracom Growth</p><h6>Pre-meeting brief</h6><p>Briefing auto-generated. Opening hook + discovery questions + objections ready in the briefing page.</p>` });
+  }
+  return events;
+}
+
+/* v8 Fix 2: per-row click-to-expand in Communication history */
+function toggleCT(rowId) {
+  const row = document.getElementById(rowId);
+  if (!row) return;
+  row.classList.toggle('open');
+}
+
+/* v10: unified Outreach timeline — merges past completed + future
+   scheduled + paused/skipped into one ordered array with per-event
+   .state. Replaces separate Schedule + Communication history. */
+function unifiedTimeline(p) {
+  /* DISCOVERED — only future, no past */
+  if (p.status === 'Discovered') {
+    return DEFAULT_TOUCHES.map(t => ({
+      state:'scheduled', ch:t.chKey, t:t.date,
+      label:`${t.channel} · ${t.template}`,
+      template:t.template,
+      detail:'Scheduled — outreach begins when cycle releases',
+      expand:`<h6>Template</h6><p>${t.template}</p><h6>Channel</h6><p>${t.channel}</p><h6>Scheduled for</h6><p>${t.date}</p><h6>Status</h6><p>No content sent yet — Maya begins outreach when this cycle releases. No fake content shown.</p>`,
+    }));
+  }
+
+  /* CONTACTED / REPLIED / MEETING-BOOKED — start with synthesised past */
+  let past = synthTimeline(p).map(e => ({ ...e, state:'completed' }));
+
+  /* CONTACTED — Email 3 + later are still scheduled (future) */
+  if (p.status === 'Contacted') {
+    const cutIdx = past.findIndex(e => e.label === 'Email 3 sent');
+    if (cutIdx !== -1) past = past.slice(0, cutIdx);
+    return [
+      ...past,
+      { state:'scheduled', ch:'email', t:'Day 10',
+        label:'Email 3 — Social proof case study', template:'Social proof case study',
+        detail:'Scheduled · breakup touch in 3 days',
+        expand:`<h6>Template</h6><p>Social proof case study</p><h6>Channel</h6><p>Email</p><h6>Scheduled for</h6><p>Day 10 of cycle</p><h6>Tone</h6><p>Permission-based "last from me for now" framing — designed to re-open the door without pressure.</p>` },
+      { state:'scheduled', ch:'sms', t:'Day 12',
+        label:'SMS · Quick nudge — meeting CTA', template:'Quick nudge — meeting CTA',
+        detail:'Scheduled · final cross-channel touch',
+        expand:`<h6>Template</h6><p>Quick nudge — meeting CTA</p><h6>Channel</h6><p>SMS</p><h6>Scheduled for</h6><p>Day 12 of cycle</p><h6>Trigger</h6><p>Sent only if Email 3 receives zero engagement.</p>` },
+    ];
+  }
+
+  /* REPLIED — past completed through reply, future remaining touches paused */
+  if (p.status === 'Replied') {
+    return [
+      ...past,
+      ...DEFAULT_TOUCHES.slice(2, 5).map(t => ({
+        state:'paused', ch:t.chKey, t:t.date,
+        label:`${t.channel} — ${t.template}`,
+        detail:'Paused — reply received Day 10',
+        expand:`<h6>Status</h6><p>Paused because prospect replied. Maya won't auto-send unless you explicitly resume cadence.</p><h6>Original template</h6><p>${t.template}</p><h6>Channel</h6><p>${t.channel}</p>`,
+      })),
+    ];
+  }
+
+  /* MEETING BOOKED — past complete, no future (cadence done) */
+  return past;
+}
+
+/* renderUnifiedTimeline — one place that builds the markup; called
+   from drawer + briefing page so both surfaces stay consistent. */
+function renderUnifiedTimeline(p, idPrefix) {
+  if (p.status === 'Discovered') {
+    /* render the scheduled list with empty-state message above */
+    const events = unifiedTimeline(p);
+    return `
+      <div class="ct-empty" style="margin-bottom:12px;">No outreach activity yet — Maya will begin when cycle releases.</div>
+      <div class="ct-wrap">
+        ${events.map((e, i) => unifiedRowHtml(e, i, p, idPrefix)).join('')}
+      </div>
+      <div class="ct-actions">
+        <button class="pause" onclick="event.stopPropagation();alert('Pause all scheduled touchpoints for ${p.name}')">Pause all</button>
+        <button onclick="event.stopPropagation();alert('Skip next scheduled touchpoint for ${p.name}')">Skip next</button>
+        <button onclick="event.stopPropagation();alert('Accelerate cadence for ${p.name} — compress next 5 touches into next 7 days')">Accelerate</button>
+      </div>
+    `;
+  }
+
+  const events = unifiedTimeline(p);
+  const hasScheduled = events.some(e => e.state === 'scheduled');
+  /* state-summary footer for completed cadences */
+  let footer = '';
+  if (p.meeting) {
+    footer = `<div class="ct-cadence-msg complete"><span class="cm-ic">✓</span> Cadence complete — meeting booked ${p.meeting.date} ${p.meeting.time}</div>`;
+  } else if (p.status === 'Replied' && !hasScheduled) {
+    footer = `<div class="ct-cadence-msg paused"><span class="cm-ic">⏸</span> Cadence paused — reply received Day 10</div>`;
+  } else if (p.status === 'Replied') {
+    footer = '';  /* paused rows already shown in timeline */
+  }
+
+  return `
+    <div class="ct-wrap">
+      ${events.map((e, i) => unifiedRowHtml(e, i, p, idPrefix)).join('')}
+    </div>
+    ${footer}
+    ${hasScheduled ? `
+      <div class="ct-actions">
+        <button class="pause" onclick="event.stopPropagation();alert('Pause all scheduled touchpoints for ${p.name}')">Pause all</button>
+        <button onclick="event.stopPropagation();alert('Skip next scheduled touchpoint for ${p.name}')">Skip next</button>
+        <button onclick="event.stopPropagation();alert('Accelerate cadence for ${p.name} — compress next 5 touches into next 7 days')">Accelerate</button>
+      </div>
+    ` : ''}
+  `;
+}
+
+function unifiedRowHtml(e, i, p, idPrefix) {
+  const rowId = `${idPrefix}-${p.id}-${i}`;
+  /* state icon for label area */
+  const stateIcon = e.state === 'scheduled' ? '○'
+                  : e.state === 'paused'    ? '⏸'
+                  : e.state === 'skipped'   ? '⊘'
+                  : '●';
+  return `
+    <div class="ct-row ${e.ch} state-${e.state}" id="${rowId}" onclick="toggleCT('${rowId}')">
+      <div class="ct-time">${e.t}</div>
+      <div class="ct-head">
+        <span class="ct-state-ic">${stateIcon}</span>
+        <span class="ct-ch ${e.ch}">${e.ch === 'meeting' ? 'meeting' : e.ch === 'reply' ? 'reply' : e.ch}</span>
+        <span class="ct-label">${e.label}</span>
+        <span class="ct-chev">▸ details</span>
+      </div>
+      <div class="ct-detail">${e.detail || ''}</div>
+      ${e.expand ? `<div class="ct-expand">${e.expand}</div>` : ''}
+    </div>
+  `;
+}
+
+/* ================================================================
+   HOME — The Desk
+================================================================ */
+function renderHome() {
+  const today = prospects.filter(p => p.meeting && p.meeting.isToday);
+  const totalActive = prospects.length;
+  const todayHtml = today.length === 0
+    ? `<div class="today-empty"><b>No meetings today</b> — Maya is working on ${totalActive} prospects in outreach.</div>`
+    : `<div class="today-strip">
+        ${today.map(p => {
+          const vr = overallVulnGrade(p.vulnGrades);
+          return `<div class="today-card" onclick="openBriefingPage('${p.id}')">
+            <div class="tc-time">${p.meeting.time} · ${p.meeting.platform}</div>
+            <div class="tc-name">${p.name}</div>
+            <div class="tc-dm">${p.dm.name} · ${p.dm.title}</div>
+            <div class="tc-foot"><span class="vr" data-g="${vr}">${vr}</span><span class="tc-link">Open briefing →</span></div>
+          </div>`;
+        }).join('')}
+      </div>`;
+
+  /* funnel totals */
+  const fc = {
+    discovered: prospects.length + closed.length,
+    contacted:  prospects.filter(p => p.status !== 'Discovered').length + closed.length,
+    replied:    prospects.filter(p => p.status === 'Replied' || p.status === 'Meeting Booked').length + closed.length,
+    meeting:    prospects.filter(p => p.status === 'Meeting Booked').length + closed.filter(c => c.outcome === 'WON').length,
+    won:        closed.filter(c => c.outcome === 'WON').length,
+  };
+
+  document.getElementById('main').innerHTML = `
+    <div class="bdr-hero">
+      <div class="bdr-avatar">M</div>
+      <div>
+        <div class="h-eyebrow">Your BDR report this week</div>
+        <div class="h-line">Maya found <em>31 replies</em> and booked <em>8 meetings</em> this week.</div>
+      </div>
+    </div>
+
+    <div class="sum-row">
+      <div class="sum-card"><div class="sum-val">247</div><div class="sum-label">Prospects Contacted</div><div class="sum-delta">+38 this week</div></div>
+      <div class="sum-card"><div class="sum-val">31</div><div class="sum-label">Replies Received</div><div class="sum-delta">+9 this week</div></div>
+      <div class="sum-card"><div class="sum-val">8<em>/10</em></div><div class="sum-label">Meetings Booked</div><div class="sum-delta">+3 this week</div></div>
+      <div class="sum-card"><div class="sum-val">3.2<em>%</em></div><div class="sum-label">Win Rate</div><div class="sum-delta">cycle to date</div></div>
+    </div>
+
+    <div class="today-strip-head"><div class="h">Your meetings <em>today</em></div><div class="meta">${today.length} ${today.length === 1 ? 'meeting' : 'meetings'} · cycle day 14/30</div></div>
+    ${todayHtml}
+
+    <div class="maya-strip" id="mayaStrip" onclick="document.getElementById('mayaStrip').classList.toggle('open')">
+      <div class="maya-strip-head">
+        <div class="maya-strip-line"><b>Maya is working in the background</b> · generating drafts for 12 prospects · critic loop on 3 · enriching 8</div>
+        <div class="maya-strip-chev">EXPAND ▾</div>
+      </div>
+      <div class="maya-strip-detail">
+        <div class="maya-strip-list">
+          <div class="maya-action"><div class="ma-cnt">12</div><div class="ma-l">drafts in flight (Email · LinkedIn · SMS · Voice)</div></div>
+          <div class="maya-action"><div class="ma-cnt">3</div><div class="ma-l">drafts in critic loop (rewriting based on score)</div></div>
+          <div class="maya-action"><div class="ma-cnt">8</div><div class="ma-l">prospects in Stage 9 enrichment (vulnerability scan)</div></div>
+        </div>
+        <div style="margin-top:10px;font-size:12px;color:var(--ink-3);">Recent today: ${MAYA_TODAY.slice(0,3).map(a => a.t).join(' · ')}</div>
+      </div>
+    </div>
+
+    <div class="section-label">Cycle funnel</div>
+    <div class="funnel-bar">
+      <div class="funnel-seg fs-discovered" style="flex:${fc.discovered};"><div class="fs-n">${fc.discovered}</div><div class="fs-l">Discovered</div></div>
+      <div class="funnel-seg fs-contacted" style="flex:${fc.contacted};"><div class="fs-n">${fc.contacted}</div><div class="fs-l">Contacted</div></div>
+      <div class="funnel-seg fs-replied" style="flex:${fc.replied};"><div class="fs-n">${fc.replied}</div><div class="fs-l">Replied</div></div>
+      <div class="funnel-seg fs-meeting" style="flex:${fc.meeting};"><div class="fs-n">${fc.meeting}</div><div class="fs-l">Meeting</div></div>
+      <div class="funnel-seg fs-won" style="flex:${fc.won};"><div class="fs-n">${fc.won}</div><div class="fs-l">Won</div></div>
+    </div>
+    <div class="funnel-meta">${fc.discovered} prospects · ${fc.contacted} contacted (${(fc.contacted/fc.discovered*100).toFixed(0)}%) · ${fc.replied} replied · ${fc.meeting} meetings · ${fc.won} won</div>
+
+    <div class="section-label">Needs your attention</div>
+    ${ATTENTION.map(a => `
+      <div class="attention-card ${a.type}" onclick="openDrawer('${a.pid}')">
+        <div class="att-ic">${a.ic}</div>
+        <div class="att-text">${a.text}</div>
+        <span class="att-cta">${a.cta}</span>
+      </div>
+    `).join('')}
+
+  `;
+}
+
+/* ================================================================
+   PIPELINE — Board + Table toggle
+================================================================ */
+let pipeView = 'board';
+let pipeFilter = 'all';
+
+function setPipeView(v) { pipeView = v; renderPipeline(); }
+function setPipeFilter(k) { pipeFilter = k; renderPipeline(); }
+
+const PIPE_FILTERS = [
+  { k:'all', l:'All' },
+  { k:'hot', l:'Hot (>80)' },
+  { k:'replied', l:'Replied' },
+  { k:'meeting', l:'Meeting Booked' },
+];
+
+function pipeFilterFn(p) {
+  if (pipeFilter === 'all') return true;
+  if (pipeFilter === 'hot') return p.score > 80;
+  if (pipeFilter === 'replied') return p.status === 'Replied';
+  if (pipeFilter === 'meeting') return p.status === 'Meeting Booked';
+  return true;
+}
+
+const PIPE_COLS = [
+  { key:'discovered', label:'Discovered', filter:p => p.status === 'Discovered' },
+  { key:'contacted',  label:'Contacted',  filter:p => p.status === 'Contacted' },
+  { key:'replied',    label:'Replied',    filter:p => p.status === 'Replied' },
+  { key:'meeting',    label:'Meeting Booked', filter:p => p.status === 'Meeting Booked' },
+  { key:'wonlost',    label:'Won / Lost', filter:() => false },
+];
+
+function renderPipeline() {
+  const counts = {};
+  PIPE_FILTERS.forEach(f => {
+    counts[f.k] = f.k === 'all' ? prospects.length : prospects.filter(pipeFilterFn).filter(() => true).length;
+  });
+  /* simpler: compute per filter */
+  const filterCounts = {
+    all: prospects.length,
+    hot: prospects.filter(p => p.score > 80).length,
+    replied: prospects.filter(p => p.status === 'Replied').length,
+    meeting: prospects.filter(p => p.status === 'Meeting Booked').length,
+  };
+
+  const filtered = prospects.filter(pipeFilterFn);
+  const total = prospects.length + closed.length;
+  const filterChipsHtml = PIPE_FILTERS.map(f =>
+    `<div class="chip ${pipeFilter===f.k?'active':''}" onclick="setPipeFilter('${f.k}')">${f.l}<span class="chip-count">${filterCounts[f.k]}</span></div>`
+  ).join('');
+
+  let mainHtml = '';
+  if (pipeView === 'board') {
+    mainHtml = `<div class="board">${PIPE_COLS.map(col => {
+      if (col.key === 'wonlost') {
+        const won = closed.filter(c => c.outcome === 'WON');
+        const lost = closed.filter(c => c.outcome === 'LOST');
+        const cnt = closed.length;
+        return `<div class="col col-${col.key}">
+          <div class="col-head"><span class="col-name">${col.label}</span><span class="col-count"><span class="cn">${cnt}</span><span class="cp">${(cnt/total*100).toFixed(0)}%</span></span></div>
+          <div class="col-body col-body-split">
+            <div class="split-section won">
+              <div class="split-label won">● Won · ${won.length}</div>
+              ${won.map(c => `<div class="k-card" onclick="alert('${c.name} — ${c.amount}')"><div class="k-name">${c.name}</div><div class="k-dm">${c.dm}</div><div class="k-foot"><div class="k-left"><span class="vr" data-g="${c.grade}">${c.grade}</span><span class="k-score">${c.score}</span></div><span class="k-time">${c.amount}</span></div></div>`).join('')}
+            </div>
+            <div class="split-section lost">
+              <div class="split-label lost">● Lost · ${lost.length}</div>
+              ${lost.length ? lost.map(c => `<div class="k-card" onclick="alert('${c.name} — ${c.amount}')"><div class="k-name">${c.name}</div><div class="k-dm">${c.dm}</div><div class="k-foot"><div class="k-left"><span class="vr" data-g="${c.grade}">${c.grade}</span><span class="k-score">${c.score}</span></div><span class="k-time">${c.amount}</span></div></div>`).join('') : '<div class="col-empty">No losses this cycle</div>'}
+            </div>
+          </div>
+        </div>`;
+      }
+      const list = filtered.filter(col.filter);
+      return `<div class="col col-${col.key}">
+        <div class="col-head"><span class="col-name">${col.label}</span><span class="col-count"><span class="cn">${list.length}</span><span class="cp">${(list.length/total*100).toFixed(0)}%</span></span></div>
+        <div class="col-body">
+          ${list.length ? list.map(p => {
+            const vr = overallVulnGrade(p.vulnGrades);
+            return `<div class="k-card" draggable="true" data-pid="${p.id}" data-col="${col.key}" onclick="openDrawer('${p.id}')" ondragstart="kanbanDragStart(event)" ondragend="kanbanDragEnd(event)">
+              <div class="k-name">${p.name}</div>
+              <div class="k-dm">${p.dm.name}</div>
+              <div class="k-dm-title">${p.dm.title}</div>
+              <div class="k-meta">${p.suburb}, ${p.state} · ${p.industry}</div>
+              <div class="k-foot">
+                <div class="k-left"><span class="vr" data-g="${vr}">${vr}</span><span class="k-score">${p.score}</span></div>
+                <span class="k-time">${p.lastAction || ''}</span>
+              </div>
+            </div>`;
+          }).join('') : '<div class="col-empty">Empty — awaiting prospects</div>'}
+        </div>
+      </div>`;
+    }).join('')}</div>`;
+  } else {
+    /* TABLE */
+    const rows = [...filtered].sort((a, b) => b.score - a.score);
+    mainHtml = `<table class="pipe-table">
+      <thead>
+        <tr>
+          <th>Domain</th><th>Business</th><th>DM</th><th>Title</th><th>Score</th><th>VR Grade</th><th>Status</th><th>Last Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows.map(p => {
+          const vr = overallVulnGrade(p.vulnGrades);
+          return `<tr onclick="openDrawer('${p.id}')">
+            <td class="mono">${p.domain}</td>
+            <td class="name-col">${p.name}</td>
+            <td>${p.dm.name}</td>
+            <td class="dm-title">${p.dm.title}</td>
+            <td class="score-col">${p.score}</td>
+            <td><span class="vr" data-g="${vr}" style="width:24px;height:24px;font-size:13px;">${vr}</span></td>
+            <td>${statusPill(p.status)}</td>
+            <td class="mono">${p.lastAction || '—'}</td>
+          </tr>`;
+        }).join('')}
+      </tbody>
+    </table>`;
+  }
+
+  document.getElementById('main').innerHTML = `
+    <h1 class="page-h">Pipeline,<br><em>${prospects.length} prospects active.</em></h1>
+    <p class="page-sub">Click any card or row to open the briefing drawer. Maya is moving these through.</p>
+    <div class="pipe-controls">
+      <div class="view-toggle">
+        <button class="vt-btn ${pipeView==='board'?'active':''}" onclick="setPipeView('board')">Board</button>
+        <button class="vt-btn ${pipeView==='table'?'active':''}" onclick="setPipeView('table')">Table</button>
+      </div>
+      <div class="filter-chips">${filterChipsHtml}</div>
+    </div>
+    ${mainHtml}
+  `;
+  /* wire DnD on columns (board view only) */
+  if (pipeView === 'board') {
+    document.querySelectorAll('.col').forEach(col => {
+      col.addEventListener('dragover', kanbanDragOver);
+      col.addEventListener('dragleave', kanbanDragLeave);
+      col.addEventListener('drop', kanbanDrop);
+    });
+  }
+}
+
+/* ================================================================
+   KANBAN DnD
+================================================================ */
+let dragPid = null, dragSourceCol = null;
+function kanbanDragStart(e) {
+  const card = e.target.closest('.k-card');
+  if (!card) return;
+  dragPid = card.dataset.pid;
+  dragSourceCol = card.dataset.col;
+  card.classList.add('dragging');
+  if (e.dataTransfer) { e.dataTransfer.effectAllowed = 'move'; try { e.dataTransfer.setData('text/plain', dragPid); } catch (_) {} }
+}
+function kanbanDragEnd(e) {
+  document.querySelectorAll('.k-card.dragging').forEach(c => c.classList.remove('dragging'));
+  document.querySelectorAll('.col.drag-over').forEach(c => c.classList.remove('drag-over'));
+}
+function kanbanDragOver(e) {
+  if (!dragPid) return;
+  e.preventDefault();
+  const col = e.currentTarget;
+  if (col.classList.contains('col-' + dragSourceCol)) return;
+  col.classList.add('drag-over');
+  if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+}
+function kanbanDragLeave(e) {
+  e.currentTarget.classList.remove('drag-over');
+}
+function kanbanDrop(e) {
+  e.preventDefault();
+  const col = e.currentTarget;
+  col.classList.remove('drag-over');
+  if (!dragPid) return;
+  const targetKey = col.classList.contains('col-discovered') ? 'discovered'
+                  : col.classList.contains('col-contacted') ? 'contacted'
+                  : col.classList.contains('col-replied') ? 'replied'
+                  : col.classList.contains('col-meeting') ? 'meeting'
+                  : col.classList.contains('col-wonlost') ? 'wonlost' : null;
+  if (!targetKey || targetKey === dragSourceCol) { dragPid = null; return; }
+  openDnDReasonModal(dragPid, dragSourceCol, targetKey);
+  dragPid = null; dragSourceCol = null;
+}
+
+const COL_LABEL = { discovered:'Discovered', contacted:'Contacted', replied:'Replied', meeting:'Meeting Booked', wonlost:'Won / Lost' };
+function openDnDReasonModal(pid, fromKey, toKey) {
+  const p = findP(pid); if (!p) return;
+  const m = document.getElementById('dndModal');
+  m.innerHTML = `
+    <div class="modal">
+      <h3>Move ${p.name}?</h3>
+      <div class="ms"><b>${p.name}</b> from <b>${COL_LABEL[fromKey]}</b> → <b>${COL_LABEL[toKey]}</b>. Why are you moving them?</div>
+      <label class="reason-opt"><input type="radio" name="dnd-reason" value="Stale"><label>Stale — no response in sequence</label></label>
+      <label class="reason-opt"><input type="radio" name="dnd-reason" value="Wrong fit"><label>Wrong fit — disqualify and remove</label></label>
+      <label class="reason-opt"><input type="radio" name="dnd-reason" value="Escalate"><label>Escalate — needs your direct attention</label></label>
+      <textarea placeholder="Free-text note (optional)…" id="dndNote"></textarea>
+      <div class="ma">
+        <button class="btn btn-outline" onclick="closeDnDModal()">Cancel</button>
+        <button class="btn btn-primary" onclick="confirmDnDMove('${pid}','${fromKey}','${toKey}')">OK</button>
+      </div>
+    </div>
+  `;
+  m.classList.add('on');
+}
+function closeDnDModal() { document.getElementById('dndModal').classList.remove('on'); }
+function confirmDnDMove(pid, fromKey, toKey) {
+  const reason = (document.querySelector('input[name="dnd-reason"]:checked') || {}).value || '(no reason selected)';
+  const note = (document.getElementById('dndNote') || {}).value || '';
+  const p = findP(pid);
+  alert(`${p ? p.name : pid} moved ${COL_LABEL[fromKey]} → ${COL_LABEL[toKey]}\nReason: ${reason}${note ? '\nNote: ' + note : ''}\n\n(prototype — no persistence)`);
+  closeDnDModal();
+}
+
+/* ================================================================
+   FEED
+================================================================ */
+let feedFilter = 'all';
+const FEED_FILTERS = [
+  { k:'all', l:'All' },
+  { k:'replies', l:'Replies' },
+  { k:'meetings', l:'Meetings' },
+  { k:'signals', l:'Signals' },
+  { k:'outreach', l:'Outreach' },
+  { k:'voice', l:'Voice' },
+];
+const expandedEvents = new Set();
+
+function setFeedFilter(k) { feedFilter = k; renderFeed(); }
+
+function feedCounts() {
+  const out = {};
+  FEED_FILTERS.forEach(f => out[f.k] = f.k==='all' ? events.length : events.filter(e=>e.cat===f.k).length);
+  return out;
+}
+
+function expandedHtml(e, p) {
+  if (e.type === 'reply') return `<h5>What Maya is doing next</h5><div>${e.meta || '—'}</div><h5>Briefing snapshot</h5><div>${p.vulnerability}</div><div class="actions"><button class="btn btn-amber" onclick="event.stopPropagation();openDrawer('${p.id}')">Open full briefing</button></div>`;
+  if (e.type === 'meeting') return `<h5>Briefing preview</h5><div class="bf-ai" style="margin:0 0 8px;">✨ AI-generated briefing · verify before use</div><div style="font-style:italic;color:var(--ink-2);margin-bottom:10px;">${p.openingHook}</div><div style="font-size:12.5px;color:var(--ink-3);">${p.vulnerability}</div><div class="actions"><button class="btn btn-primary" onclick="event.stopPropagation();openBriefingPage('${p.id}')">Open full briefing</button></div>`;
+  if (e.type === 'signal') return `<h5>What this signal means</h5><div>${p.vulnerability}</div><div class="actions"><button class="btn btn-amber" onclick="event.stopPropagation();openDrawer('${p.id}')">Open prospect detail</button></div>`;
+  return '';
+}
+
+function toggleEvent(id, ev) {
+  if (ev && ev.target.closest('.biz')) return;
+  if (ev && ev.target.closest('.btn')) return;
+  if (expandedEvents.has(id)) expandedEvents.delete(id); else expandedEvents.add(id);
+  renderFeed();
+}
+
+function renderFeed() {
+  const list = feedFilter === 'all' ? events : events.filter(e => e.cat === feedFilter);
+  const counts = feedCounts();
+  const chipsHtml = FEED_FILTERS.map(f =>
+    `<div class="chip ${feedFilter===f.k?'active':''}" onclick="setFeedFilter('${f.k}')">${f.l}<span class="chip-count">${counts[f.k]}</span></div>`
+  ).join('');
+
+  const html = [];
+  let lastDay = null;
+  list.forEach((e, i) => {
+    if (e.day !== lastDay) { html.push(`<div class="feed-day">${e.day}</div>`); lastDay = e.day; }
+    const p = findP(e.pid);
+    const vr = overallVulnGrade(p.vulnGrades);
+    const cardId = `evt-${i}`;
+    const isOpen = expandedEvents.has(cardId);
+    const expandable = ['reply','meeting','signal'].includes(e.type);
+    html.push(`
+      <div class="event-card ${expandable?'expandable':''} ${isOpen?'expanded':''}" id="${cardId}" ${expandable?`onclick="toggleEvent('${cardId}', event)"`:''}>
+        <div class="event-row">
+          <div class="event-time">${e.t}</div>
+          <div class="event-ico ${e.type}">${e.icon}</div>
+          <div class="event-body">
+            <div class="event-type">${e.label}</div>
+            <div class="event-headline">${e.headline}</div>
+            ${e.quote ? `<div class="event-quote">${e.quote}</div>` : ''}
+            ${e.meta ? `<div class="event-meta">${e.meta}</div>` : ''}
+          </div>
+          <div class="event-side">
+            <span class="vr" data-g="${vr}">${vr}</span>
+            ${expandable ? '<span class="event-chev">›</span>' : ''}
+          </div>
+        </div>
+        ${expandable ? `<div class="event-expand">${expandedHtml(e, p)}</div>` : ''}
+      </div>
+    `);
+  });
+
+  document.getElementById('main').innerHTML = `
+    <h1 class="page-h">Activity feed,<br><em>everything Maya is doing.</em></h1>
+    <p class="page-sub">Reverse-chronological. Tap any reply / meeting / signal card to expand. Tap any business name → briefing drawer.</p>
+    <div class="filter-chips" style="margin-bottom:18px;">${chipsHtml}</div>
+    ${html.join('')}
+  `;
+  document.querySelectorAll('.event-headline .biz').forEach(s => s.addEventListener('click', ev => { ev.stopPropagation(); openDrawer(s.dataset.pid); }));
+}
+
+/* ================================================================
+   MEETINGS — calendar + briefing PAGE
+================================================================ */
+const WEEK_DAYS = [
+  { dow:'MON', date:'21', isToday:false },
+  { dow:'TUE', date:'22', isToday:false },
+  { dow:'WED', date:'23', isToday:true },
+  { dow:'THU', date:'24', isToday:false },
+  { dow:'FRI', date:'25', isToday:false },
+];
+const HOUR_SLOTS = [8,9,10,11,12,13,14,15,16,17];
+
+function renderMeetings() {
+  const upcoming = prospects.filter(p => p.meeting).sort((a,b) => {
+    const ord = { Mon:1, Tue:2, Wed:3, Thu:4, Fri:5 };
+    return (ord[a.meeting.day] - ord[b.meeting.day]) || (a.meeting.startHour - b.meeting.startHour);
+  });
+  const today = upcoming.filter(p => p.meeting.isToday);
+
+  const grid = `<div class="cal-grid">
+    <div class="cal-corner"></div>
+    ${WEEK_DAYS.map(d => `<div class="cal-day-head ${d.isToday?'today':''}"><div class="ddow">${d.dow}</div><div class="dnum">${d.date}</div></div>`).join('')}
+    ${HOUR_SLOTS.map(hr => `
+      <div class="cal-time">${hr<12?hr+'am':hr===12?'12pm':(hr-12)+'pm'}</div>
+      ${WEEK_DAYS.map(d => {
+        const m = prospects.find(p => p.meeting && p.meeting.day === d.dow && p.meeting.startHour === hr);
+        let evHtml = '';
+        if (m) {
+          const vr = overallVulnGrade(m.vulnGrades);
+          const cls = m.meeting.isPast ? 'green' : '';
+          const h = (m.meeting.durationHrs || 1) * 44 - 6;
+          evHtml = `<div class="cal-event ${cls}" style="height:${h}px;" onclick="openBriefingPage('${m.id}')">
+            <span class="cal-event-vr" data-g="${vr}">${vr}</span>
+            <div class="cal-event-time">${m.meeting.time}</div>
+            <div class="cal-event-name">${m.name}</div>
+          </div>`;
+        }
+        return `<div class="cal-slot ${d.isToday?'today-col':''}">${evHtml}</div>`;
+      }).join('')}
+    `).join('')}
+  </div>`;
+
+  /* Mobile day view */
+  const dayView = `<div class="day-view">
+    <div class="day-view-card">
+      <div class="day-view-head">
+        <div class="h-day">TODAY · WEDNESDAY</div>
+        <div class="h-date">23 April</div>
+      </div>
+      <div class="day-view-body">
+        ${today.length ? today.map(p => `
+          <div class="day-meet" onclick="openBriefingPage('${p.id}')">
+            <div class="dm-time">${p.meeting.time} · ${p.meeting.platform} · ${p.meeting.countdown}</div>
+            <div class="dm-name">${p.name}</div>
+            <div class="dm-dm">${p.dm.name} · ${p.dm.title}</div>
+          </div>
+        `).join('') : '<div style="color:var(--ink-3);font-size:12px;font-style:italic;padding:14px 4px;">No meetings today</div>'}
+      </div>
+    </div>
+  </div>`;
+
+  document.getElementById('main').innerHTML = `
+    <h1 class="page-h">Your week,<br><em>${upcoming.length} ${upcoming.length === 1 ? 'meeting' : 'meetings'}.</em></h1>
+    <p class="page-sub">Click any calendar slot or row to open the full briefing page.</p>
+    ${grid}
+    ${dayView}
+    <div class="section-label">Upcoming this week</div>
+    ${upcoming.length === 0 ? '<div class="today-empty">No meetings booked yet — Maya is working on '+prospects.length+' prospects.</div>'
+      : upcoming.map(p => {
+        const vr = overallVulnGrade(p.vulnGrades);
+        return `<div class="upcoming-row" onclick="openBriefingPage('${p.id}')">
+          <span class="ur-vr vr" data-g="${vr}">${vr}</span>
+          <div class="ur-main">
+            <div class="ur-n">${p.dm.name} · ${p.name}</div>
+            <div class="ur-s">${p.dm.title} · ${p.suburb}, ${p.state}</div>
+          </div>
+          <div class="ur-when">${p.meeting.date} · ${p.meeting.time}<div class="cd">${p.meeting.countdown}</div></div>
+        </div>`;
+      }).join('')}
+  `;
+}
+
+/* Briefing PAGE (meetings only — replaces main) */
+function openBriefingPage(pid) {
+  const p = findP(pid); if (!p) return;
+  const vr = overallVulnGrade(p.vulnGrades);
+  const grades = ['website','seo','reviews','ads','social','content'];
+  const m = p.meeting;
+
+  document.getElementById('main').innerHTML = `
+    <div class="bp-back" onclick="showView('meetings')">← Back to calendar</div>
+
+    <div class="bp-header">
+      <div>
+        <div class="bp-eyebrow">${m ? (m.isPast ? 'Past meeting · log outcome' : (m.isToday ? "Today's meeting" : 'Upcoming meeting')) : 'Prospect briefing'}</div>
+        <div class="bp-when">${m ? `${m.date} · ${m.time}` : p.name}</div>
+        ${m ? `<div class="bp-cd">${m.countdown} · via ${m.platform}</div>` : ''}
+      </div>
+      <div class="bp-spacer"></div>
+      <div class="bp-actions">
+        ${m && !m.isPast ? `<button class="btn btn-amber" onclick="alert('Open ${m.platform} meeting link')">Join meeting</button>` : ''}
+        <button class="btn btn-ghost bp-pdf-btn" onclick="window.print()"><span class="lbl-print">Save PDF</span><span class="lbl-pdf">PDF</span></button>
+      </div>
+    </div>
+
+    ${m ? `
+      <div class="pma-row">
+        <button class="pma-btn pma-won" onclick="alert('Marked: Closed won')">Closed won</button>
+        <button class="pma-btn pma-follow" onclick="alert('Marked: Follow up')">Follow up</button>
+        <button class="pma-btn pma-noshow" onclick="alert('Marked: No show')">No show</button>
+        <button class="pma-btn pma-resched" onclick="alert('Marked: Reschedule')">Reschedule</button>
+      </div>
+    ` : ''}
+
+    <div class="card snap-card">
+      <h4 style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.14em;color:var(--ink-3);text-transform:uppercase;margin-bottom:16px;font-weight:600;">Prospect snapshot</h4>
+      <div class="snap-head">
+        <span class="vr snap-vr" data-g="${vr}">${vr}</span>
+        <div>
+          <div class="snap-name">${p.name}</div>
+          <div class="snap-dm">${p.dm.name} · ${p.dm.title} · ${p.dm.tenure}</div>
+        </div>
+      </div>
+      <div class="snap-row">
+        <span class="snap-eyebrow">Identity</span>
+        <span class="snap-item"><span class="iv mono" style="font-family:'JetBrains Mono',monospace;font-size:12px;">${p.domain}</span></span>
+        <span class="snap-sep">·</span>
+        <span class="snap-item"><span class="iv">${p.suburb}, ${p.state}</span></span>
+        <span class="snap-sep">·</span>
+        <span class="snap-item"><span class="iv">${p.industry}</span></span>
+        <span class="snap-sep">·</span>
+        <span class="snap-item" title="Source: ABN registry"><span class="il">ABN registered</span><span class="iv">${p.est}</span></span>
+      </div>
+      <div class="snap-row">
+        <span class="snap-eyebrow">Signals</span>
+        <span class="snap-chip"><span class="il" style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);letter-spacing:0.06em;text-transform:uppercase;">GMB rating</span><b>${gmbRating(p.vulnGrades.reviews)}★</b></span>
+        <span class="snap-chip"><span class="il" style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);letter-spacing:0.06em;text-transform:uppercase;">Website</span><span class="sc-grade" data-g="${p.vulnGrades.website}">${p.vulnGrades.website}</span></span>
+        <span class="snap-chip"><span class="il" style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);letter-spacing:0.06em;text-transform:uppercase;">Ad presence</span><b>${adPresence(p.vulnGrades.ads)}</b></span>
+        <span class="snap-chip"><span class="il" style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);letter-spacing:0.06em;text-transform:uppercase;">Intent</span><b>${intentBand(p.score)}</b></span>
+        <span class="snap-chip score"><span class="il" style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);letter-spacing:0.06em;text-transform:uppercase;">Propensity</span><b>${p.score}<span style="color:var(--ink-3);font-weight:400;">/100</span></b></span>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top:14px;">
+      <h4 style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.14em;color:var(--ink-3);text-transform:uppercase;margin-bottom:12px;font-weight:600;">Vulnerability — overall grade ${vr} <span style="font-family:'DM Sans',sans-serif;text-transform:none;letter-spacing:0;color:var(--ink-3);font-size:11px;font-weight:400;margin-left:8px;">click any letter for detail</span></h4>
+      <div style="font-size:13px;color:var(--ink-2);line-height:1.6;margin-bottom:12px;">${p.vulnerability}</div>
+      <div class="vr-strip">
+        ${grades.map(g => `<div class="vr-cw"><div class="vr-letter" data-g="${p.vulnGrades[g]}" onclick="showVRPopover('${p.id}','${g}',event)" title="Click for explanation">${p.vulnGrades[g]}</div><div class="vr-name">${g}</div></div>`).join('')}
+      </div>
+    </div>
+
+    <div class="card" style="margin-top:14px;">
+      <h4 style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.14em;color:var(--ink-3);text-transform:uppercase;margin-bottom:12px;font-weight:600;">Outreach timeline${(() => { const evs = unifiedTimeline(p); return evs.length ? ` <span style="font-family:'DM Sans',sans-serif;text-transform:none;letter-spacing:0;color:var(--ink-3);font-size:11px;font-weight:400;margin-left:6px;">${evs.length} events</span>` : ''; })()}</h4>
+      ${renderUnifiedTimeline(p, 'ctb')}
+    </div>
+
+    <div class="card" style="margin-top:14px;">
+      <h4 style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.14em;color:var(--ink-3);text-transform:uppercase;margin-bottom:12px;font-weight:600;">Recommended angle</h4>
+      <div class="bf-ai">✨ AI-generated briefing · verify before use</div>
+      <div class="bf-hook">${p.openingHook}</div>
+    </div>
+
+    <div class="card" style="margin-top:14px;">
+      <h4 style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.14em;color:var(--ink-3);text-transform:uppercase;margin-bottom:12px;font-weight:600;">Discovery questions</h4>
+      <ul class="bf-list">${p.discoveryQuestions.map(q => `<li>${q}</li>`).join('')}</ul>
+    </div>
+
+    <div class="card" style="margin-top:14px;">
+      <h4 style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.14em;color:var(--ink-3);text-transform:uppercase;margin-bottom:12px;font-weight:600;">Common objections</h4>
+      ${p.objections.map(o => `<div class="bf-obj"><div class="obj-q">${o.obj}</div><div class="obj-a">${o.response}</div></div>`).join('')}
+    </div>
+
+    <div class="card" style="margin-top:14px;">
+      <h4 style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.14em;color:var(--ink-3);text-transform:uppercase;margin-bottom:12px;font-weight:600;">Close options</h4>
+      <ul class="bf-list">${p.closeOptions.map(c => `<li>${c}</li>`).join('')}</ul>
+      <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);margin-top:10px;letter-spacing:0.1em;text-transform:uppercase;">Your service pricing — from your agency rate card</div>
+      <div style="font-family:'Playfair Display',serif;font-size:20px;font-weight:700;color:var(--ink);">${p.pricingRange}</div>
+    </div>
+
+    <div class="card" style="margin-top:14px;">
+      <h4 style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.14em;color:var(--ink-3);text-transform:uppercase;margin-bottom:12px;font-weight:600;">Also ranking for your keywords</h4>
+      <ul class="bf-list">${p.competitors.map(c => `<li>${c}</li>`).join('')}</ul>
+    </div>
+  `;
   window.scrollTo(0, 0);
 }
 
-function updateSidebarActive(hash) {
-  document.querySelectorAll('.nav-item').forEach(el => {
-    el.classList.remove('active');
-    const route = el.getAttribute('data-route');
-    if (route === hash || (hash.startsWith('#pipeline/') && route === '#pipeline')) el.classList.add('active');
-  });
-}
-
-function updateBreadcrumb(hash) {
-  const labels = { '#home': 'Dashboard', '#pipeline': 'Pipeline', '#cycles': 'Cycles', '#inbox': 'Inbox', '#sequences': 'Sequences', '#signals': 'Signals', '#reports': 'Reports', '#settings': 'Settings' };
-  const crumb = document.getElementById('breadcrumb');
-  if (hash.startsWith('#pipeline/')) {
-    const id = hash.split('/')[1];
-    const p = prospects.find(x => x.id === id);
-    crumb.innerHTML = `<span>AgencyOS</span><span class="crumb-sep">›</span><span onclick="navigate('#pipeline')" style="cursor:pointer;color:var(--ink-3)">Pipeline</span><span class="crumb-sep">›</span><span class="crumb-current">${p ? p.name : 'Detail'}</span>`;
-    return;
-  }
-  crumb.innerHTML = `<span>AgencyOS</span><span class="crumb-sep">›</span><span class="crumb-current">${labels[hash] || 'Dashboard'}</span>`;
-}
-
-function updateBottomNav(hash) {
-  const map = { '#home': 0, '#pipeline': 1, '#inbox': 2, '#cycles': 3, '#signals': 4 };
-  const base = hash.startsWith('#pipeline/') ? '#pipeline' : hash;
-  document.querySelectorAll('.bottom-nav-item').forEach((el, i) => { el.classList.toggle('active', map[base] === i); });
-}
-
-window.addEventListener('hashchange', router);
-
-/* ═══════════════════════════════════════════════════════════════════
-   MODAL HELPERS
-═══════════════════════════════════════════════════════════════════ */
-function openModal(id) { document.getElementById(id).classList.add('open'); }
-function closeModal(id) { document.getElementById(id).classList.remove('open'); }
-function closeModalOutside(e, id) { if (e.target.id === id) closeModal(id); }
-
-function openNoteModal(prospectId) {
-  noteTargetId = prospectId;
-  const p = prospects.find(x => x.id === prospectId);
-  document.getElementById('noteProspectName').textContent = p ? p.name : '';
-  document.getElementById('noteTextarea').value = getProspectNote(prospectId);
-  openModal('noteModal');
-}
-function saveNote() {
-  if (noteTargetId) saveProspectNote(noteTargetId, document.getElementById('noteTextarea').value);
-  closeModal('noteModal');
-}
-
-/* ═══════════════════════════════════════════════════════════════════
-   RELEASE LOGIC
-═══════════════════════════════════════════════════════════════════ */
-function handleRelease() {
-  const count = getReviewedCount();
-  if (count < 10) {
-    document.getElementById('reviewedCountInModal').textContent = count;
-    openModal('releaseConfirmModal');
-  } else {
-    confirmRelease();
-  }
-}
-function confirmRelease() {
-  closeModal('releaseConfirmModal');
-  setCycleState('outreach');
-  renderPipeline();
-}
-
-/* ═══════════════════════════════════════════════════════════════════
-   PAGE 1 — HOME
-═══════════════════════════════════════════════════════════════════ */
-function renderHome() {
-  const html = `
-    <h1 class="page-headline">Your acquisition engine,<br><em>running on schedule.</em></h1>
-    <div class="schedule-hero">
-      <div class="schedule-hero-left">
-        <div class="schedule-campaign-name">Cycle 3 · Day 14 of 30</div>
-        <div class="schedule-area">SEO Services — Sydney Metro · Started 1 May 2026</div>
-        <div class="schedule-progress-track" style="margin-bottom:8px;">
-          <div class="schedule-progress-fill" style="width:${(14/30*100).toFixed(0)}%"></div>
-        </div>
-        <div class="schedule-days"><span>Day 1</span><span>Day 14 of 30</span><span>Day 30</span></div>
-      </div>
-      <div class="schedule-stats">
-        <div><div class="schedule-stat-val">247</div><div class="schedule-stat-label">Contacted</div></div>
-        <div><div class="schedule-stat-val">31</div><div class="schedule-stat-label">Replies</div></div>
-        <div><div class="schedule-stat-val">8</div><div class="schedule-stat-label">Meetings</div></div>
-        <div><div class="schedule-stat-val">600</div><div class="schedule-stat-label">Total Records</div></div>
-      </div>
-    </div>
-    <div class="section-label">Performance this cycle</div>
-    <div class="grid-4" style="margin-bottom:32px;">
-      <div class="card metric-card"><div class="metric-label">Open Rate</div><div class="metric-val">47%</div><div class="metric-delta" style="color:var(--ink-3);font-family:'JetBrains Mono',monospace;font-size:11px;">AU B2B benchmark: 21%</div></div>
-      <div class="card metric-card"><div class="metric-label">Reply Rate</div><div class="metric-val">8.2%</div><div class="metric-delta" style="color:var(--ink-3);font-family:'JetBrains Mono',monospace;font-size:11px;">AU B2B benchmark: 3.1%</div></div>
-      <div class="card metric-card"><div class="metric-label">Meeting Rate</div><div class="metric-val">1.4%</div><div class="metric-delta" style="color:var(--ink-3);font-family:'JetBrains Mono',monospace;font-size:11px;">AU B2B benchmark: 0.8%</div></div>
-      <div class="card metric-card"><div class="metric-label">Avg Reply Time</div><div class="metric-val">23h</div><div class="metric-delta" style="color:var(--ink-3);font-family:'JetBrains Mono',monospace;font-size:11px;">from contacted to first reply</div></div>
-    </div>
-    <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:24px;margin-bottom:32px;" class="home-grid">
-      <div class="card" style="grid-column:span 1;">
-        <div class="section-label">Hot replies</div>
-        ${replies.filter(r => r.heat === 'hot').slice(0,4).map(r => `
-          <div class="reply-item" onclick="navigate('#inbox')">
-            <div class="heat-dot heat-${r.heat}" style="margin-top:5px;"></div>
-            <div class="reply-meta">
-              <div class="reply-biz">${r.business}</div>
-              <div class="reply-name">${r.name}</div>
-              <div class="reply-snippet">"${r.snippet}"</div>
-            </div>
-            <div class="reply-time">${r.time}</div>
-          </div>
-        `).join('')}
-      </div>
-      <div class="card">
-        <div class="section-label">Meetings booked</div>
-        <div class="meeting-item"><div class="meeting-date-pill">APR<br>14</div><div><div class="meeting-name">James Whitford</div><div class="meeting-biz">Momentum Constructions</div></div></div>
-        <div class="meeting-item"><div class="meeting-date-pill">APR<br>15</div><div><div class="meeting-name">Sarah Kemp</div><div class="meeting-biz">Harbour Physiotherapy</div></div></div>
-        <div class="meeting-item"><div class="meeting-date-pill">APR<br>17</div><div><div class="meeting-name">Dr Priya Narayan</div><div class="meeting-biz">Cascade Dental Group</div></div></div>
-        <div class="meeting-item"><div class="meeting-date-pill">APR<br>21</div><div><div class="meeting-name">Dr Rebecca Ashford</div><div class="meeting-biz">Coastal Veterinary</div></div></div>
-      </div>
-      <div class="card">
-        <div class="section-label">System health</div>
-        ${[
-          { name: 'Email Delivery', status: 'Operational', dot: 'green' },
-          { name: 'LinkedIn Queue', status: 'Operational', dot: 'green' },
-          { name: 'Voice AI', status: 'Operational', dot: 'green' },
-          { name: 'SMS Gateway', status: 'Degraded', dot: 'amber' },
-          { name: 'Data Enrichment', status: 'Operational', dot: 'green' },
-          { name: 'Prospect Pipeline', status: 'Operational', dot: 'green' },
-        ].map(h => `<div class="health-item"><div class="status-dot status-${h.dot}"></div><div class="health-name">${h.name}</div><div class="health-status">${h.status}</div></div>`).join('')}
-      </div>
-    </div>
-    <div class="card">
-      <div class="section-label">Today's outreach — 43 of 105 completed</div>
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px 40px;">
-        ${[
-          { ch: 'Email', done: 18, total: 50, color: '#6B8E5A' },
-          { ch: 'LinkedIn', done: 12, total: 20, color: '#3B82F6' },
-          { ch: 'Voice AI', done: 5, total: 10, color: '#D4956A' },
-          { ch: 'SMS', done: 8, total: 25, color: '#8B5CF6' },
-        ].map(o => `
-          <div class="outreach-row">
-            <div class="outreach-channel">${o.ch}</div>
-            <div class="outreach-bar-wrap"><div class="progress-wrap" style="height:6px;"><div class="progress-bar" style="width:${(o.done/o.total*100).toFixed(0)}%;background:${o.color};"></div></div></div>
-            <div class="outreach-count">${o.done}/${o.total}</div>
-          </div>
-        `).join('')}
-      </div>
-    </div>
-  `;
-  document.getElementById('page').innerHTML = html;
-}
-
-/* ═══════════════════════════════════════════════════════════════════
-   PAGE 2 — PIPELINE (THREE STATE)
-═══════════════════════════════════════════════════════════════════ */
-function scoreClass(s) { return s >= 85 ? 'score-hot' : s >= 60 ? 'score-warm' : s >= 35 ? 'score-cool' : 'score-cold'; }
-
-function getFilteredProspects() {
-  const state = getCycleState();
-  let pool = [...prospects];
-
-  if (state === 'review') {
-    const filterMap = {
-      top10: () => pool.slice(0, 10),
-      top50: () => pool.slice(0, 50),
-      all: () => pool,
-      struggling: () => pool.filter(p => p.intent === 'struggling'),
-      trying: () => pool.filter(p => p.intent === 'trying'),
-      dabbling: () => pool.filter(p => p.intent === 'dabbling'),
-    };
-    return (filterMap[activePipelineFilter] || filterMap.top10)();
-  } else {
-    const filterMap = {
-      all: () => pool,
-      in_outreach: () => pool.filter(p => (p.outreachStatus || 'not_started') !== 'not_started' && (p.outreachStatus || 'not_started') !== 'suppressed'),
-      replied: () => pool.filter(p => p.outreachStatus === 'replied'),
-      meeting_booked: () => pool.filter(p => p.outreachStatus === 'meeting_booked'),
-      suppressed: () => pool.filter(p => p.outreachStatus === 'suppressed'),
-      not_started: () => pool.filter(p => (p.outreachStatus || 'not_started') === 'not_started'),
-    };
-    return (filterMap[activePipelineFilter] || filterMap.all)();
-  }
-}
-
-function getOutreachStatus(p) {
-  if (p.outreachStatus) return p.outreachStatus;
-  if (p.id === 'p1' || p.id === 'p2' || p.id === 'p3' || p.id === 'p4') return 'meeting_booked';
-  if (p.id === 'p6') return 'replied';
-  if (['p5','p7','p8','p9','p10'].includes(p.id)) return 'contacted';
-  return 'not_started';
-}
-
-function statusBadgeHtml(status) {
-  const map = {
-    not_started: ['status-not-started','Not started'],
-    contacted: ['status-contacted','Contacted'],
-    replied: ['status-replied','Replied'],
-    meeting_booked: ['status-meeting-booked','Meeting booked'],
-    suppressed: ['status-suppressed','Suppressed'],
-  };
-  const [cls, label] = map[status] || map.not_started;
-  return `<span class="status-badge-row ${cls}">${label}</span>`;
-}
-
-function renderPipeline() {
-  const state = getCycleState();
-  const reviewedIds = getReviewedIds();
-  const filtered = getFilteredProspects();
-  const total = filtered.length;
-  const totalPages = Math.ceil(total / pipelinePageSize);
-  if (pipelinePage > totalPages) pipelinePage = 1;
-  const start = (pipelinePage - 1) * pipelinePageSize;
-  const pageItems = filtered.slice(start, start + pipelinePageSize);
-
-  let headerHtml = '';
-  let chipsHtml = '';
-
-  if (state === 'review') {
-    const reviewedCount = getReviewedCount();
-    headerHtml = `
-      <h1 class="page-headline">Your prospects,<br><em>ranked by intent.</em></h1>
-      <div class="review-banner">
-        <div class="review-banner-text">
-          You've reviewed <strong>${reviewedCount} of ${prospects.length}</strong>. We recommend at least 10 before your first release.
-        </div>
-        <button class="btn btn-amber" style="font-size:13px;padding:7px 16px;" onclick="handleRelease()">Release All 600</button>
-      </div>
-    `;
-    const reviewChips = [
-      {key:'top10',label:'Top 10'},{key:'top50',label:'Top 50'},{key:'all',label:'All'},{key:'struggling',label:'Struggling'},{key:'trying',label:'Trying'},{key:'dabbling',label:'Dabbling'},
-    ];
-    chipsHtml = `<div class="filter-chips">${reviewChips.map(f => `<div class="chip ${activePipelineFilter===f.key?'active':''}" onclick="setPipelineFilter('${f.key}')">${f.label}</div>`).join('')}</div>`;
-  } else if (state === 'outreach') {
-    headerHtml = `
-      <h1 class="page-headline">Cycle 3 —<br><em>in outreach.</em></h1>
-      <div class="status-strip">600 prospects in outreach &nbsp;·&nbsp; 247 contacted &nbsp;·&nbsp; 31 replied &nbsp;·&nbsp; 8 meetings booked</div>
-    `;
-    const outChips = [
-      {key:'all',label:'All'},{key:'in_outreach',label:'In outreach'},{key:'replied',label:'Replied'},{key:'meeting_booked',label:'Meeting booked'},{key:'suppressed',label:'Suppressed'},{key:'not_started',label:'Not started'},
-    ];
-    chipsHtml = `<div class="filter-chips">${outChips.map(f => `<div class="chip ${activePipelineFilter===f.key?'active':''}" onclick="setPipelineFilter('${f.key}')">${f.label}</div>`).join('')}</div>`;
-  } else {
-    headerHtml = `
-      <h1 class="page-headline">Cycle 3 —<br><em>14 meetings booked.</em></h1>
-      <div class="status-strip">Cycle complete &nbsp;·&nbsp; 14 meetings booked &nbsp;·&nbsp; 4 closes &nbsp;·&nbsp; Cycle 4 generates in 3 days</div>
-    `;
-    const outChips = [
-      {key:'all',label:'All'},{key:'in_outreach',label:'In outreach'},{key:'replied',label:'Replied'},{key:'meeting_booked',label:'Meeting booked'},{key:'suppressed',label:'Suppressed'},{key:'not_started',label:'Not started'},
-    ];
-    chipsHtml = `<div class="filter-chips">${outChips.map(f => `<div class="chip ${activePipelineFilter===f.key?'active':''}" onclick="setPipelineFilter('${f.key}')">${f.label}</div>`).join('')}</div>`;
-  }
-
-  const pageSizeHtml = `
-    <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;justify-content:space-between;">
-      <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-3);">${total} prospects</div>
-      <div style="display:flex;align-items:center;gap:6px;">
-        <span style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-3);">Show</span>
-        <select class="page-size-select" onchange="setPageSize(parseInt(this.value))">
-          ${[10,20,50,100].map(n => `<option value="${n}" ${pipelinePageSize===n?'selected':''}>${n}</option>`).join('')}
-        </select>
-        <span style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-3);">per page</span>
-      </div>
-    </div>
-  `;
-
-  const rowsHtml = pageItems.map((p, i) => {
-    const rank = start + i + 1;
-    const isVisited = reviewedIds.includes(p.id);
-    const pStatus = (state !== 'review') ? getOutreachStatus(p) : null;
-    return `
-      <div class="pipeline-row ${isVisited?'visited':''}" onclick="navigate('#pipeline/${p.id}')">
-        <div class="intent-bar intent-bar-${p.intent}"></div>
-        <div class="pipeline-rank">${rank}</div>
-        <div class="pipeline-main">
-          <div class="pipeline-biz-name">${p.name}</div>
-          <div class="pipeline-meta">
-            <span class="badge ${p.intent==='struggling'?'intent-struggling':p.intent==='trying'?'intent-trying':'intent-dabbling'}">${p.intent.charAt(0).toUpperCase()+p.intent.slice(1)}</span>
-            <span class="pipeline-suburb">${p.suburb}, ${p.state}</span>
-            <span class="pipeline-suburb">·</span>
-            <span class="pipeline-suburb">${p.industry}</span>
-          </div>
-        </div>
-        <div class="pipeline-dm">
-          <div style="font-weight:500;color:var(--ink-2);">${p.dm.name}</div>
-          <div style="font-size:11px;font-family:'JetBrains Mono',monospace;">${p.dm.title}</div>
-        </div>
-        ${state !== 'review' ? `<div class="pipeline-status-wrap">${statusBadgeHtml(pStatus)}</div>` : `
-        <div class="pipeline-channels">
-          <div class="channel-dot" title="Email" style="font-size:9px;">E</div>
-          <div class="channel-dot" title="LinkedIn" style="font-size:9px;">in</div>
-          <div class="channel-dot" title="Voice" style="font-size:9px;">VC</div>
-          <div class="channel-dot" title="SMS" style="font-size:9px;">S</div>
-        </div>`}
-        <div class="pipeline-score-wrap"><div class="score-badge ${scoreClass(p.score)}">${p.score}</div></div>
-        <div class="pipeline-caret">›</div>
-      </div>
-    `;
-  }).join('');
-
-  const paginationHtml = total > pipelinePageSize ? `
-    <div class="pagination-bar">
-      <button class="pagination-btn" onclick="setPipelinePage(${pipelinePage-1})" ${pipelinePage<=1?'disabled':''}>Prev</button>
-      <span>Page ${pipelinePage} of ${totalPages}</span>
-      <button class="pagination-btn" onclick="setPipelinePage(${pipelinePage+1})" ${pipelinePage>=totalPages?'disabled':''}>Next</button>
-    </div>
-  ` : '';
-
-  document.getElementById('page').innerHTML = headerHtml + chipsHtml + pageSizeHtml + rowsHtml + paginationHtml;
-}
-
-function setPipelineFilter(key) {
-  activePipelineFilter = key;
-  pipelinePage = 1;
-  renderPipeline();
-}
-function setPipelinePage(p) {
-  pipelinePage = p;
-  renderPipeline();
-  window.scrollTo(0,0);
-}
-function setPageSize(n) {
-  pipelinePageSize = n;
-  pipelinePage = 1;
-  renderPipeline();
-}
-
-/* ═══════════════════════════════════════════════════════════════════
-   PAGE 3 — PIPELINE DETAIL
-═══════════════════════════════════════════════════════════════════ */
-let activeDetailTab = 'overview';
-let activeTimelineFilter = 'all';
-
-function renderDetail(id) {
-  const p = prospects.find(x => x.id === id);
-  if (!p) { renderPipeline(); return; }
-  const state = getCycleState();
-  const idx = prospects.indexOf(p);
-  const prev = idx > 0 ? prospects[idx - 1] : null;
-  const next = idx < prospects.length - 1 ? prospects[idx + 1] : null;
-  const pStatus = getOutreachStatus(p);
-  const isMeetingBooked = pStatus === 'meeting_booked';
-  const isOutreachMode = (state === 'outreach' || state === 'complete');
-
-  const tabs = [];
-  if (isMeetingBooked && isOutreachMode) {
-    tabs.push({ key: 'briefing', label: 'Briefing' });
-    if (activeDetailTab === 'overview' && !tabs.find(t => t.key === activeDetailTab)) activeDetailTab = 'briefing';
-  }
-  tabs.push({ key: 'overview', label: 'Overview' });
-  if (isOutreachMode) tabs.push({ key: 'timeline', label: 'Timeline' });
-
-  if (!tabs.find(t => t.key === activeDetailTab)) activeDetailTab = tabs[0].key;
-
-  const firstName = p.dm.name.replace(/^Dr\s+/i,'').split(' ')[0];
-  const draftEmail = `Subject: Your competitors are stealing your customers, ${firstName}
-
-Hi ${firstName},
-
-I've been researching ${p.industry.toLowerCase()} businesses in ${p.suburb} and noticed something that's costing ${p.name} new business every month.
-
-${p.signals[0] ? p.signals[0].text : 'Your digital presence has gaps a competitor can exploit.'}
-
-I specialise in fixing exactly this for ${p.industry.toLowerCase()} businesses in ${p.state}. I've helped 3 similar businesses recover their local presence in under 90 days.
-
-Worth a 15-minute call this week?
-
-David Stephens
-Ignition Digital — Sydney`;
-
-  const draftLinkedin = `Hi ${firstName}, I noticed some signals that suggest ${p.name} could be getting more from their digital presence. Quick 15 minutes to walk through what we found?`;
-  const draftSms = `Hi ${firstName}, David from Ignition. ${p.signals[0] ? p.signals[0].text : 'Noticed some gaps in your digital presence.'} Worth 15 mins? Happy to call whenever suits.`;
-  const draftVoice = `Opening: "Hi, is that ${firstName}? I'm David from Ignition Digital in Sydney. I've been doing some research on ${p.industry.toLowerCase()} businesses in ${p.suburb} and I've found something that's costing ${p.name} new customers — do you have 2 minutes?"
-
-Pain point: "${p.signals[0] ? p.signals[0].text : 'Your digital presence has gaps that competitors can exploit.'}"
-
-CTA: "I've fixed this exact problem for 3 similar businesses this year. Could we book 15 minutes this week so I can show you what's happening and what we'd do to fix it?"`;
-
-  const gradeItems = [
-    {key:'website',label:'Website'},{key:'seo',label:'SEO'},{key:'reviews',label:'Reviews'},{key:'ads',label:'Paid Ads'},{key:'social',label:'Social'},{key:'content',label:'Content'},
+/* ================================================================
+   PROGRESS — Partner report
+================================================================ */
+function renderProgress() {
+  const funnel = [
+    { l:'Discovered', v:600, max:600 },
+    { l:'Contacted', v:247, max:600 },
+    { l:'Replied', v:31, max:600 },
+    { l:'Meetings', v:8, max:600 },
+    { l:'Won', v:3, max:600 },
   ];
+  document.getElementById('main').innerHTML = `
+    <h1 class="page-h">Cycle progress,<br><em>partner-ready report.</em></h1>
+    <p class="page-sub">Cycle 3 · day 14 of 30 · refreshed every 5 minutes. Raw metrics only — no unsourced benchmark comparisons.</p>
 
-  const note = getProspectNote(id);
-
-  function buildOverviewTab() {
-    return `
-      <div class="detail-layout">
-        <div>
-          <div class="grid-3" style="margin-bottom:24px;">
-            <div class="score-card"><div class="score-card-val">${p.affordability}<span style="font-size:18px;color:var(--ink-3);">/10</span></div><div class="score-card-label">Affordability</div><div class="score-card-sub">Revenue signal</div></div>
-            <div class="score-card"><div class="score-card-val">${p.intentScore}<span style="font-size:18px;color:var(--ink-3);">/18</span></div><div class="score-card-label">Intent Score</div><div class="score-card-sub">Buying signals</div></div>
-            <div class="score-card" style="border-color:var(--amber);"><div class="score-card-val" style="color:var(--copper);">${p.composite}</div><div class="score-card-label">Composite CIS</div><div class="score-card-sub">Agency Lead Score</div></div>
-          </div>
-          <div class="card" style="margin-bottom:20px;">
-            <div class="section-label">Buying signals</div>
-            ${p.signals.map(s => `<div class="signal-item"><div class="signal-dot"></div><div class="signal-text">${s.text}</div><div class="signal-time">${s.time}</div></div>`).join('')}
-          </div>
-          <div class="card" style="margin-bottom:20px;">
-            <div class="section-label">Vulnerability report</div>
-            <div class="vuln-para">${p.vulnerability}</div>
-            <div class="section-label" style="margin-bottom:12px;">Digital health scorecard</div>
-            <div class="grade-grid">
-              ${gradeItems.map(g => `<div class="grade-cell"><div class="grade-letter grade-${p.vulnGrades[g.key]}">${p.vulnGrades[g.key]}</div><div class="grade-name">${g.label}</div></div>`).join('')}
-            </div>
-          </div>
-          <div class="card" id="draftSection">
-            <div class="section-label">Draft outreach</div>
-            <div class="tab-bar" id="outreachTabBar">
-              ${['email','linkedin','sms','voice'].map(t => `<button class="tab-btn ${activeOutreachTab===t?'active':''}" onclick="switchOutreachTab('${t}')">${t.charAt(0).toUpperCase()+t.slice(1)}${t==='voice'?' AI':''}</button>`).join('')}
-            </div>
-            <div id="outreachTabEmail" class="tab-content ${activeOutreachTab==='email'?'active':''}"><div class="draft-label">Email draft</div><div class="draft-content">${draftEmail}</div></div>
-            <div id="outreachTabLinkedin" class="tab-content ${activeOutreachTab==='linkedin'?'active':''}"><div class="draft-label">LinkedIn message</div><div class="draft-content">${draftLinkedin}</div></div>
-            <div id="outreachTabSms" class="tab-content ${activeOutreachTab==='sms'?'active':''}"><div class="draft-label">SMS draft</div><div class="draft-content">${draftSms}</div></div>
-            <div id="outreachTabVoice" class="tab-content ${activeOutreachTab==='voice'?'active':''}"><div class="draft-label">Voice AI script</div><div class="draft-content">${draftVoice}</div></div>
-          </div>
-          ${note ? `<div class="card" style="margin-top:16px;"><div class="section-label">Notes</div><div style="font-size:13.5px;color:var(--ink-2);line-height:1.6;white-space:pre-wrap;">${note}</div></div>` : ''}
-        </div>
-        <div>
-          <div class="card dm-card">
-            <div class="section-label">Decision-maker</div>
-            <div class="dm-name">${p.dm.name}</div>
-            <div class="dm-title">${p.dm.title}</div>
-            <div class="dm-field"><div class="dm-field-label">Email</div><div class="dm-field-val" style="font-size:12px;word-break:break-all;">${p.dm.email}</div><span class="dm-verified">Verified</span></div>
-            <div class="dm-field"><div class="dm-field-label">Phone</div><div class="dm-field-val">${p.dm.phone}</div><span class="dm-verified">Verified</span></div>
-            <div class="dm-field"><div class="dm-field-label">LinkedIn</div><div class="dm-field-val">Profile found</div><span class="dm-verified">2 days ago</span></div>
-          </div>
-          <div class="card" style="margin-bottom:16px;">
-            <div class="section-label">Cycle</div>
-            <div style="font-size:14px;font-weight:500;color:var(--ink);margin-bottom:4px;">Cycle 3 · Day 14 of 30 · Released May 1</div>
-            <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-3);margin-bottom:12px;">SEO Services — Sydney Metro</div>
-            <div class="progress-wrap" style="height:5px;margin-bottom:6px;"><div class="progress-bar" style="width:47%;background:var(--amber);"></div></div>
-            <div style="display:flex;justify-content:space-between;font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);"><span>Day 1</span><span>Day 30</span></div>
-          </div>
-          <div class="card">
-            <div class="section-label">Activity</div>
-            ${[
-              {text:'Email opened (3x)',time:'2h ago'},{text:'LinkedIn profile viewed',time:'1d ago'},{text:'Initial email sent',time:'3d ago'},{text:'Prospect added to pipeline',time:'5d ago'},{text:'Enrichment completed',time:'5d ago'},
-            ].map(t => `<div class="timeline-item"><div class="timeline-dot"></div><div style="flex:1;"><div class="timeline-text">${t.text}</div></div><div class="timeline-time">${t.time}</div></div>`).join('')}
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
-  function buildTimelineTab() {
-    const timeline = p.timeline && p.timeline.length > 0 ? p.timeline : [
-      {type:'email_sent',label:'Email 1 sent',time:'Day 1 · 9:00am',dotClass:''},
-      {type:'email_opened',label:'Email 1 opened',time:'Day 2 · 11:00am',dotClass:''},
-      {type:'system',label:'In sequence',time:'Day 3',dotClass:'ot-dot-system'},
-    ];
-    const filterChips = [
-      {key:'all',label:'All'},{key:'replies',label:'Replies only'},{key:'system',label:'System'},{key:'failures',label:'Failures'},
-    ];
-    const filtered = timeline.filter(e => {
-      if (activeTimelineFilter === 'all') return true;
-      if (activeTimelineFilter === 'replies') return e.type && (e.type.includes('replied') || e.type.includes('reply'));
-      if (activeTimelineFilter === 'system') return e.dotClass === 'ot-dot-system';
-      if (activeTimelineFilter === 'failures') return e.type && (e.type.includes('bounce') || e.type.includes('fail') || e.type.includes('voicemail'));
-      return true;
-    });
-    return `
-      <div class="card">
-        <div class="section-label">Outreach timeline</div>
-        <div class="filter-chips" style="margin-bottom:16px;">
-          ${filterChips.map(f => `<div class="chip ${activeTimelineFilter===f.key?'active':''}" onclick="setTimelineFilter('${f.key}')">${f.label}</div>`).join('')}
-        </div>
-        <div class="outreach-timeline">
-          ${filtered.map(e => `
-            <div class="ot-item">
-              <div class="ot-dot ${e.dotClass || ''}"></div>
-              <div class="ot-time">${e.time}</div>
-              <div class="ot-label">${e.label}</div>
-              ${e.type && e.type.includes('replied') && e.label.includes('"') ? `<div class="ot-content">${e.label.match(/"([^"]+)"/)?.[1] || ''}</div>` : ''}
-            </div>
-          `).join('')}
-          ${filtered.length === 0 ? '<div style="color:var(--ink-3);font-size:13px;padding:12px 0;">No events match this filter.</div>' : ''}
-        </div>
-      </div>
-    `;
-  }
-
-  function buildBriefingTab() {
-    const m = p.meeting || { date: 'TBC', time: 'TBC', platform: 'Zoom', countdown: 'TBC' };
-    return `
-      <div>
-        <!-- 1. Meeting header -->
-        <div class="briefing-meeting-header" style="position:sticky;top:56px;z-index:40;">
-          <div style="flex:1;">
-            <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:rgba(255,255,255,0.4);text-transform:uppercase;letter-spacing:0.12em;margin-bottom:6px;">Upcoming meeting</div>
-            <div style="font-family:'Playfair Display',serif;font-size:20px;font-weight:700;color:#fff;margin-bottom:2px;">${m.date} · ${m.time}</div>
-            <div class="briefing-countdown">${m.countdown} · via ${m.platform}</div>
-          </div>
-          <div style="display:flex;gap:8px;">
-            <button class="btn" style="background:rgba(255,255,255,0.1);color:#fff;font-size:13px;padding:8px 16px;" onclick="window.print()">Print briefing</button>
-            <button class="btn btn-amber" style="font-size:13px;padding:8px 16px;">Join Zoom</button>
-          </div>
-        </div>
-
-        <!-- 2. Prospect snapshot -->
-        <div class="briefing-section">
-          <div class="briefing-section-title">Prospect snapshot</div>
-          <div class="card" style="margin-bottom:0;">
-            <div style="display:flex;align-items:flex-start;gap:20px;flex-wrap:wrap;">
-              <div style="flex:1;min-width:200px;">
-                <div style="font-family:'Playfair Display',serif;font-size:22px;font-weight:700;color:var(--ink);margin-bottom:4px;">${p.name}</div>
-                <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-3);margin-bottom:12px;">${p.suburb}, ${p.state} · ${p.industry} · Est. ${p.est} · ${p.staff} staff · ${p.revenue}</div>
-                <div class="briefing-ai-summary">${p.aiSummary || p.vulnerability}</div>
-              </div>
-              <div>
-                <div class="grade-grid" style="width:220px;">
-                  ${gradeItems.map(g => `<div class="grade-cell"><div class="grade-letter grade-${p.vulnGrades[g.key]}">${p.vulnGrades[g.key]}</div><div class="grade-name">${g.label}</div></div>`).join('')}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- 3. Decision maker profile -->
-        <div class="briefing-section">
-          <div class="briefing-section-title">Decision maker profile</div>
-          <div class="card">
-            <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
-              <div>
-                <div class="dm-name">${p.dm.name}</div>
-                <div class="dm-title">${p.dm.title}</div>
-                <div class="dm-field"><div class="dm-field-label">Tenure</div><div class="dm-field-val">${p.dm.tenure || 'Unknown'}</div></div>
-                <div class="dm-field"><div class="dm-field-label">Prev</div><div class="dm-field-val" style="font-size:12px;">${p.dm.prevRoles || 'Unknown'}</div></div>
-                <div class="dm-field"><div class="dm-field-label">LinkedIn</div><div class="dm-field-val">${p.dm.linkedinActivity || 'Unknown'}</div></div>
-              </div>
-              <div>
-                <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:8px;">Communication style</div>
-                <div style="font-size:13.5px;color:var(--ink-2);line-height:1.6;background:var(--surface);padding:14px;border-radius:6px;">${p.dm.style || 'No style data available.'}</div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- 4. Why they said yes -->
-        <div class="briefing-section">
-          <div class="briefing-section-title">Why they said yes</div>
-          <div class="card">
-            <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px;">
-              <div><div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:6px;">Triggering signal</div><div style="font-size:13.5px;color:var(--ink-2);">${p.triggerSignal || 'N/A'}</div></div>
-              <div><div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:6px;">Message that converted</div><div style="font-size:13.5px;color:var(--ink-2);">${p.triggerMessage || 'N/A'}</div></div>
-            </div>
-            ${p.prospectReply ? `<div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:8px;">Their exact reply</div><div class="reply-quote">"${p.prospectReply}"</div>` : ''}
-            <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:12px;">
-              <div><div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:4px;">Sentiment</div><div style="font-size:13px;color:var(--ink-2);">${p.sentiment || 'N/A'}</div></div>
-              <div><div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:4px;">Time to meeting</div><div style="font-size:13px;color:var(--ink-2);">${p.timeToMeeting || 'N/A'}</div></div>
-            </div>
-          </div>
-        </div>
-
-        <!-- 5. Full communication transcript -->
-        <div class="briefing-section">
-          <div class="briefing-section-title">Communication transcript</div>
-          <div class="card">
-            ${(p.timeline && p.timeline.length > 0 ? p.timeline : [{type:'email_sent',label:'No transcript available',time:'',dotClass:'ot-dot-system'}]).map(e => `
-              <div style="display:flex;gap:12px;padding:10px 0;border-bottom:1px solid var(--rule);">
-                <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);min-width:140px;flex-shrink:0;">${e.time}</div>
-                <div style="font-size:13px;color:var(--ink-2);">${e.label}</div>
-              </div>
-            `).join('')}
-          </div>
-        </div>
-
-        <!-- 6. Current state diagnosis -->
-        <div class="briefing-section">
-          <div class="briefing-section-title">Current state diagnosis</div>
-          <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
-            <div class="card">
-              <div class="section-label">Digital health</div>
-              <div class="vuln-para" style="font-size:13px;margin-bottom:0;">${p.vulnerability}</div>
-            </div>
-            <div class="card">
-              <div class="section-label">Competitor landscape</div>
-              ${(p.competitors && p.competitors.length > 0 ? p.competitors : ['No data']).map((c,i) => `
-                <div style="display:flex;align-items:center;gap:10px;padding:8px 0;border-bottom:1px solid var(--rule);">
-                  <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-3);width:20px;">${i+1}</div>
-                  <div style="font-size:13.5px;color:var(--ink-2);">${c}</div>
-                </div>
-              `).join('')}
-            </div>
-          </div>
-        </div>
-
-        <!-- 7. Recommended angle -->
-        <div class="briefing-section">
-          <div class="briefing-section-title">Recommended angle</div>
-          <div class="card">
-            <div style="margin-bottom:20px;">
-              <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:8px;">Opening hook</div>
-              <div style="font-size:14px;color:var(--ink-2);line-height:1.6;font-style:italic;background:var(--surface);padding:14px;border-radius:6px;">${p.openingHook || 'N/A'}</div>
-            </div>
-            <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:20px;">
-              <div>
-                <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:6px;">Core pitch</div>
-                <div style="font-size:13.5px;color:var(--ink-2);line-height:1.6;">${p.recommendedAngle || 'N/A'}</div>
-              </div>
-              <div>
-                <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:6px;">Pricing range</div>
-                <div style="font-family:'Playfair Display',serif;font-size:20px;font-weight:700;color:var(--ink);">${p.pricingRange || 'N/A'}</div>
-                <div style="font-size:12px;color:var(--ink-3);margin-top:4px;">AUD · dependent on scope</div>
-              </div>
-            </div>
-            <div class="section-label">Case studies (similar clients)</div>
-            <div class="grid-3">
-              ${[
-                {name:'Sydney Dental Co',result:'GMB rating 3.8→4.7 in 60 days',industry:'Dental'},
-                {name:'Lakeview Legal',result:'Organic leads +340% in 90 days',industry:'Legal'},
-                {name:'Metro Physio',result:'New patient enquiries +28/month',industry:'Health'},
-              ].map(cs => `<div class="case-study-card"><div class="eyebrow" style="margin-bottom:4px;">${cs.industry}</div><div class="case-study-name">${cs.name}</div><div style="font-size:12.5px;color:var(--green);font-family:'JetBrains Mono',monospace;margin-top:6px;">${cs.result}</div></div>`).join('')}
-            </div>
-          </div>
-        </div>
-
-        <!-- 8. Talking points -->
-        <div class="briefing-section">
-          <div class="briefing-section-title">Talking points</div>
-          <div class="card">
-            ${p.discoveryQuestions && p.discoveryQuestions.length > 0 ? `
-              <div style="margin-bottom:20px;">
-                <div class="section-label">Discovery questions</div>
-                ${p.discoveryQuestions.map((q,i) => `<div class="talking-point"><strong>${i+1}.</strong> ${q}</div>`).join('')}
-              </div>
-            ` : ''}
-            ${p.objections && p.objections.length > 0 ? `
-              <div style="margin-bottom:20px;">
-                <div class="section-label">Common objections</div>
-                ${p.objections.map(o => `<div class="talking-point"><strong>${o.obj}</strong><br><span style="color:var(--ink-3);font-size:13px;">→ ${o.response}</span></div>`).join('')}
-              </div>
-            ` : ''}
-            ${p.closeOptions && p.closeOptions.length > 0 ? `
-              <div>
-                <div class="section-label">Close options</div>
-                ${p.closeOptions.map((c,i) => `<div class="talking-point"><strong>Option ${i+1}:</strong> ${c}</div>`).join('')}
-              </div>
-            ` : ''}
-          </div>
-        </div>
-
-        <!-- 9. Post-meeting actions -->
-        <div class="briefing-section">
-          <div class="briefing-section-title">Post-meeting actions</div>
-          <div class="card">
-            <div style="margin-bottom:20px;">
-              <div class="section-label">Meeting outcome</div>
-              <div style="display:flex;gap:12px;flex-wrap:wrap;">
-                ${['Proposal sent','Follow-up booked','Not a fit','No show','Closed'].map(o => `<label style="display:flex;align-items:center;gap:6px;font-size:13.5px;cursor:pointer;"><input type="radio" name="outcome_${p.id}" style="accent-color:var(--amber);"> ${o}</label>`).join('')}
-              </div>
-            </div>
-            <div style="margin-bottom:20px;">
-              <div class="section-label">Follow-up email draft</div>
-              <textarea class="form-textarea" style="min-height:100px;">Hi ${firstName},
-
-Great speaking today. As discussed, I'll send through a proposal covering [key points from meeting].
-
-Looking forward to working together.
-
-David Stephens
-Ignition Digital</textarea>
-            </div>
-            <div>
-              <div class="section-label">Notes</div>
-              <textarea class="form-textarea" id="postMeetingNotes_${p.id}" style="min-height:80px;" placeholder="Notes from the meeting...">${getProspectNote(p.id)}</textarea>
-              <button class="btn btn-outline" style="margin-top:8px;font-size:12px;" onclick="savePostMeetingNote('${p.id}')">Save notes</button>
-            </div>
-            <div style="margin-top:20px;padding-top:16px;border-top:1px solid var(--rule);">
-              <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);margin-bottom:6px;">BRIEFING DELIVERY NOTE</div>
-              <div style="font-size:13px;color:var(--ink-2);">Briefing sent to your inbox the moment the meeting confirms. Not 1 hour before — immediately on booking.</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
-  const tabBarHtml = `
-    <div class="tab-bar" style="margin-bottom:24px;">
-      ${tabs.map(t => `<button class="tab-btn ${activeDetailTab===t.key?'active':''}" onclick="switchDetailTab('${t.key}','${id}')">${t.label}</button>`).join('')}
+    <div class="kpi-row">
+      <div class="kpi-cell"><div class="kpi-val">47<small>%</small></div><div class="kpi-l">Open Rate</div><div class="kpi-note">your data only</div></div>
+      <div class="kpi-cell"><div class="kpi-val">8.2<small>%</small></div><div class="kpi-l">Reply Rate</div><div class="kpi-note">your data only</div></div>
+      <div class="kpi-cell"><div class="kpi-val">1.4<small>%</small></div><div class="kpi-l">Meeting Rate</div><div class="kpi-note">your data only</div></div>
+      <div class="kpi-cell"><div class="kpi-val">23<small>h</small></div><div class="kpi-l">Avg Reply Time</div><div class="kpi-note">contacted → first reply</div></div>
     </div>
-  `;
 
-  let tabContentHtml = '';
-  if (activeDetailTab === 'overview') tabContentHtml = buildOverviewTab();
-  else if (activeDetailTab === 'timeline') tabContentHtml = buildTimelineTab();
-  else if (activeDetailTab === 'briefing') tabContentHtml = buildBriefingTab();
-
-  const actionButtons = [];
-  if (state === 'review') {
-    actionButtons.push(`<button class="btn btn-outline" onclick="suppressProspect('${id}')">Suppress</button>`);
-    actionButtons.push(`<button class="btn btn-outline" style="color:var(--amber);border-color:var(--amber);" onclick="scrollToDrafts()">Edit drafts</button>`);
-    actionButtons.push(`<button class="btn btn-outline" onclick="openNoteModal('${id}')">Add note</button>`);
-  } else {
-    actionButtons.push(`<button class="btn btn-outline" onclick="suppressProspect('${id}')">Suppress</button>`);
-    actionButtons.push(`<button class="btn btn-outline" onclick="openNoteModal('${id}')">Add note</button>`);
-  }
-
-  const statusBadgesHtml = state !== 'review' ? `<span class="badge badge-ink">${statusBadgeHtml(getOutreachStatus(p))}</span>` : `<span class="badge badge-green">Active in pipeline</span>`;
-
-  const html = `
-    <div class="detail-back" onclick="navigate('#pipeline')">← Back to Pipeline</div>
-    <div class="detail-nav">
-      ${prev ? `<button class="detail-nav-btn" onclick="navigate('#pipeline/${prev.id}')">← ${prev.name}</button>` : ''}
-      <span class="detail-nav-sep" style="flex:1;text-align:center;font-size:12px;color:var(--ink-3);">${idx+1} of ${prospects.length}</span>
-      ${next ? `<button class="detail-nav-btn" onclick="navigate('#pipeline/${next.id}')">${next.name} →</button>` : ''}
-    </div>
-    <div class="detail-headline">${p.name}</div>
-    <div class="detail-meta-row">
-      <span class="detail-meta-item">${p.suburb}, ${p.state}</span>
-      <span class="detail-meta-dot">·</span>
-      <span class="detail-meta-item">${p.staff} staff</span>
-      <span class="detail-meta-dot">·</span>
-      <span class="detail-meta-item">Est. ${p.est}</span>
-      <span class="detail-meta-dot">·</span>
-      <span class="detail-meta-item">${p.revenue} revenue</span>
-    </div>
-    <div style="display:flex;gap:8px;margin-bottom:24px;flex-wrap:wrap;">
-      <span class="badge ${p.intent==='struggling'?'intent-struggling':p.intent==='trying'?'intent-trying':'intent-dabbling'}">${p.intent.charAt(0).toUpperCase()+p.intent.slice(1)}</span>
-      <span class="badge badge-ink">CIS ${p.composite}</span>
-      ${statusBadgesHtml}
-    </div>
-    <div class="detail-actions">${actionButtons.join('')}</div>
-    ${tabs.length > 1 ? tabBarHtml : ''}
-    ${tabContentHtml}
-  `;
-  document.getElementById('page').innerHTML = html;
-}
-
-function switchDetailTab(tab, id) {
-  activeDetailTab = tab;
-  renderDetail(id);
-}
-function setTimelineFilter(f) {
-  activeTimelineFilter = f;
-  const hash = window.location.hash || '';
-  const id = hash.split('/')[1];
-  if (id) renderDetail(id);
-}
-function switchOutreachTab(tab) {
-  activeOutreachTab = tab;
-  document.querySelectorAll('#outreachTabBar .tab-btn').forEach(b => b.classList.toggle('active', b.textContent.toLowerCase().startsWith(tab)));
-  ['email','linkedin','sms','voice'].forEach(t => {
-    const el = document.getElementById('outreachTab' + t.charAt(0).toUpperCase() + t.slice(1));
-    if (el) el.classList.toggle('active', t === tab);
-  });
-}
-function suppressProspect(id) {
-  const p = prospects.find(x => x.id === id);
-  if (p) p.outreachStatus = 'suppressed';
-  navigate('#pipeline');
-}
-function scrollToDrafts() {
-  const el = document.getElementById('draftSection');
-  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-}
-function savePostMeetingNote(id) {
-  const el = document.getElementById('postMeetingNotes_' + id);
-  if (el) saveProspectNote(id, el.value);
-  const btn = el ? el.nextElementSibling : null;
-  if (btn) { btn.textContent = 'Saved'; setTimeout(() => { btn.textContent = 'Save notes'; }, 1500); }
-}
-
-/* ═══════════════════════════════════════════════════════════════════
-   PAGE 4 — CYCLES
-═══════════════════════════════════════════════════════════════════ */
-function renderCycles() {
-  const html = `
-    <div class="eyebrow" style="margin-bottom:8px;">Cycles · Previous cycles</div>
-    <h1 class="page-headline" style="margin-bottom:8px;">Your cycles,<br><em>one every 30 days.</em></h1>
-    <p style="font-size:14px;color:var(--ink-3);margin-bottom:32px;max-width:560px;">One cycle per subscription. 600 records per cycle. Automatic rollover. Configure everything in Settings.</p>
-    <div style="background:var(--ink-2);border-radius:12px;padding:28px 32px;margin-bottom:20px;color:#fff;">
-      <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:20px;flex-wrap:wrap;gap:12px;">
-        <div>
-          <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:rgba(255,255,255,0.4);letter-spacing:0.12em;text-transform:uppercase;margin-bottom:6px;">Current</div>
-          <div style="font-family:'Playfair Display',serif;font-size:22px;font-weight:700;color:#fff;margin-bottom:2px;">Cycle 3 · May 2026</div>
-          <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:rgba(255,255,255,0.45);">Day 14 of 30</div>
-        </div>
-        <button class="btn btn-outline" style="color:rgba(255,255,255,0.7);border-color:rgba(255,255,255,0.2);font-size:13px;" onclick="navigate('#pipeline')">View current cycle →</button>
-      </div>
-      <div style="background:rgba(255,255,255,0.1);border-radius:99px;height:6px;margin-bottom:8px;">
-        <div style="width:47%;height:6px;border-radius:99px;background:var(--amber);"></div>
-      </div>
-      <div style="display:flex;justify-content:space-between;font-family:'JetBrains Mono',monospace;font-size:10px;color:rgba(255,255,255,0.35);margin-bottom:24px;">
-        <span>Day 1</span><span>Day 14 of 30</span><span>Day 30</span>
-      </div>
-      <div style="display:flex;gap:32px;flex-wrap:wrap;">
-        <div><div style="font-family:'Playfair Display',serif;font-size:26px;font-weight:700;color:#fff;line-height:1;">247</div><div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:rgba(255,255,255,0.4);text-transform:uppercase;letter-spacing:0.1em;margin-top:4px;">Contacted</div></div>
-        <div><div style="font-family:'Playfair Display',serif;font-size:26px;font-weight:700;color:#fff;line-height:1;">31</div><div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:rgba(255,255,255,0.4);text-transform:uppercase;letter-spacing:0.1em;margin-top:4px;">Replies</div></div>
-        <div><div style="font-family:'Playfair Display',serif;font-size:26px;font-weight:700;color:#fff;line-height:1;">8</div><div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:rgba(255,255,255,0.4);text-transform:uppercase;letter-spacing:0.1em;margin-top:4px;">Meetings</div></div>
-      </div>
-    </div>
-    <div class="section-label" style="margin-bottom:12px;">Previous cycles</div>
-    ${[
-      { num: 2, month: 'April 2026', records: 600, contacted: 487, replies: 31, meetings: 7, closes: 2 },
-      { num: 1, month: 'March 2026', records: 600, contacted: 502, replies: 18, meetings: 3, closes: 1 },
-    ].map(c => `
-      <div class="campaign-card" style="margin-bottom:12px;">
-        <div class="campaign-card-header" style="margin-bottom:12px;">
-          <div class="campaign-card-main">
-            <div style="display:flex;align-items:center;gap:10px;margin-bottom:4px;">
-              <span class="badge badge-ink">Completed</span>
-            </div>
-            <div class="campaign-name">Cycle ${c.num}</div>
-            <div class="campaign-area">${c.month}</div>
-          </div>
-        </div>
-        <div class="campaign-metrics">
-          <div><div class="campaign-metric-val">${c.records.toLocaleString()}</div><div class="campaign-metric-label">Records</div></div>
-          <div><div class="campaign-metric-val">${c.contacted}</div><div class="campaign-metric-label">Contacted</div></div>
-          <div><div class="campaign-metric-val">${c.replies}</div><div class="campaign-metric-label">Replies</div></div>
-          <div><div class="campaign-metric-val">${c.meetings}</div><div class="campaign-metric-label">Meetings</div></div>
-          <div><div class="campaign-metric-val">${c.closes}</div><div class="campaign-metric-label">Closes</div></div>
-        </div>
-      </div>
-    `).join('')}
-  `;
-  document.getElementById('page').innerHTML = html;
-}
-
-/* ═══════════════════════════════════════════════════════════════════
-   PAGE 5 — INBOX
-═══════════════════════════════════════════════════════════════════ */
-function renderInbox() {
-  const channelLabel = ch => ({ email: 'E', linkedin: 'in', sms: 'S', voice: 'VC' }[ch] || '?');
-  const activeReply = replies.find(r => r.id === activeInboxReply) || replies[0];
-  const html = `
-    <h1 class="page-headline" style="margin-bottom:20px;">Inbox<br><em>replies &amp; conversations.</em></h1>
-    <div class="inbox-layout">
-      <div class="inbox-list">
-        <div class="inbox-list-header">
-          <div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-3);">${replies.length} conversations · 3 unread</div>
-        </div>
-        ${replies.map(r => `
-          <div class="inbox-item ${r.id === activeInboxReply ? 'active' : ''}" onclick="setActiveReply('${r.id}')">
-            <div class="heat-dot heat-${r.heat}" style="margin-top:4px;"></div>
-            <div class="inbox-item-meta">
-              <div class="inbox-item-name">${r.name}</div>
-              <div class="inbox-item-biz">${r.business}</div>
-              <div class="inbox-item-snippet">${r.snippet}</div>
-            </div>
-            <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px;flex-shrink:0;">
-              <div class="inbox-item-time">${r.time}</div>
-              <div style="font-family:'JetBrains Mono',monospace;font-size:10px;background:var(--surface);padding:2px 5px;border-radius:3px;color:var(--ink-3);">${channelLabel(r.channel)}</div>
-            </div>
-          </div>
-        `).join('')}
-      </div>
-      <div class="inbox-thread">
-        <div class="thread-header">
-          <div class="heat-dot heat-${activeReply.heat}"></div>
-          <div>
-            <div class="thread-name">${activeReply.name}</div>
-            <div class="thread-biz">${activeReply.business} · via ${activeReply.channel}</div>
-          </div>
-          <div style="margin-left:auto;display:flex;gap:8px;">
-            <button class="btn btn-outline" style="font-size:12px;padding:6px 12px;" onclick="navigate('#pipeline/${activeReply.prospectId}')">View Prospect</button>
-            <button class="btn btn-amber" style="font-size:12px;padding:6px 12px;">Book Meeting</button>
-          </div>
-        </div>
-        <div class="thread-body">
-          <div>
-            <div class="bubble bubble-ours">Hi ${activeReply.name.split(' ')[0]}, I've been analysing ${activeReply.business}'s digital presence and noticed a few things that are costing you customers. Worth a 15-minute call this week to walk through what we found?</div>
-            <div class="bubble-time bubble-time-right">You · 3 days ago</div>
-          </div>
-          <div>
-            <div class="bubble bubble-theirs">${activeReply.snippet}</div>
-            <div class="bubble-time bubble-time-left">${activeReply.name} · ${activeReply.time}</div>
-          </div>
-          <div>
-            <div class="bubble bubble-ours">Great — I'll send a calendar link. We'll cover exactly what we found and what the fix looks like. Should take no more than 15 minutes.</div>
-            <div class="bubble-time bubble-time-right">You · 1h ago</div>
-          </div>
-        </div>
-        <div class="thread-actions">
-          <input type="text" placeholder="Reply to ${activeReply.name.split(' ')[0]}…" style="flex:1;border:1px solid var(--rule);border-radius:6px;padding:9px 12px;font-size:13.5px;outline:none;">
-          <button class="btn btn-amber">Send</button>
-        </div>
-      </div>
-    </div>
-  `;
-  document.getElementById('page').innerHTML = html;
-}
-function setActiveReply(id) { activeInboxReply = id; renderInbox(); }
-
-/* ═══════════════════════════════════════════════════════════════════
-   PAGE 6 — SEQUENCES
-═══════════════════════════════════════════════════════════════════ */
-function renderSequences() {
-  const days = Array.from({length: 35}, (_, i) => i + 1);
-  const today = 14;
-  const events = { 1:[{type:'email',label:'Email 1'}],3:[{type:'linkedin',label:'LI connect'}],5:[{type:'email',label:'Email 2'}],7:[{type:'voice',label:'Voice AI'}],10:[{type:'email',label:'Email 3'}],12:[{type:'sms',label:'SMS'}],14:[{type:'email',label:'Email 4'},{type:'linkedin',label:'LI msg'}],17:[{type:'voice',label:'Voice AI'}],20:[{type:'email',label:'Email 5'}],23:[{type:'sms',label:'SMS 2'}],26:[{type:'email',label:'Email 6'}],30:[{type:'voice',label:'Final call'}] };
-  const html = `
-    <h1 class="page-headline" style="margin-bottom:28px;">Your sequences,<br><em>touch by touch.</em></h1>
-    <div class="grid-4" style="margin-bottom:32px;">
-      ${[
-        {ch:'Email',rate:'47%',detail:'18/50 sent today',pct:36,color:'#6B8E5A'},
-        {ch:'LinkedIn',rate:'38%',detail:'12/20 sent today',pct:60,color:'#3B82F6'},
-        {ch:'Voice AI',rate:'22%',detail:'5/10 completed',pct:50,color:'#D4956A'},
-        {ch:'SMS',rate:'61%',detail:'8/25 sent today',pct:32,color:'#8B5CF6'},
-      ].map(c => `
-        <div class="channel-rate-card">
-          <div class="eyebrow" style="margin-bottom:6px;">${c.ch}</div>
-          <div class="channel-rate-val">${c.rate}</div>
-          <div class="channel-rate-detail">${c.detail}</div>
-          <div class="progress-wrap" style="height:5px;"><div class="progress-bar" style="width:${c.pct}%;background:${c.color};"></div></div>
+    <div class="card">
+      <h4 style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.14em;color:var(--ink-3);text-transform:uppercase;margin-bottom:14px;font-weight:600;">Funnel</h4>
+      ${funnel.map(f => `
+        <div class="fr-row">
+          <div class="l">${f.l}</div>
+          <div class="b"><div class="bf" style="width:${Math.max(6, f.v/f.max*100)}%;">${f.v}</div></div>
+          <div class="pc">${(f.v/f.max*100).toFixed(f.v/f.max<0.05?1:0)}%</div>
         </div>
       `).join('')}
     </div>
-    <div class="card">
-      <div class="section-label">30-day outreach calendar</div>
-      <div class="calendar-grid">
-        ${['MON','TUE','WED','THU','FRI','SAT','SUN'].map(d => `<div class="cal-header-cell">${d}</div>`).join('')}
-        ${days.map(d => {
-          const evs = events[d] || [];
-          const isToday = d === today;
-          return `<div class="cal-cell ${isToday?'cal-today':''}"><div class="cal-date-num">${d}</div>${evs.map(e => `<span class="cal-pill cal-${e.type}">${e.label}</span>`).join('')}</div>`;
-        }).join('')}
+
+    <div class="card" style="margin-top:14px;">
+      <h4 style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.14em;color:var(--ink-3);text-transform:uppercase;margin-bottom:6px;font-weight:600;">Your subscription efficiency · AUD</h4>
+      <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--copper);letter-spacing:0.12em;text-transform:uppercase;margin-bottom:14px;">Based on your $2,500/month subscription</div>
+      <div class="roi-grid">
+        <div class="roi-cell"><div class="roi-val">$312</div><div class="roi-l">Cost / Meeting</div><div style="font-family:'JetBrains Mono',monospace;font-size:10.5px;color:var(--ink-3);margin-top:4px;">$2,500 ÷ 8 meetings</div></div>
+        <div class="roi-cell"><div class="roi-val">$81</div><div class="roi-l">Cost / Reply</div><div style="font-family:'JetBrains Mono',monospace;font-size:10.5px;color:var(--ink-3);margin-top:4px;">$2,500 ÷ 31 replies</div></div>
+        <div class="roi-cell"><div class="roi-val">$10</div><div class="roi-l">Cost / Contact</div><div style="font-family:'JetBrains Mono',monospace;font-size:10.5px;color:var(--ink-3);margin-top:4px;">$2,500 ÷ 247 contacts</div></div>
+        <div class="roi-cell"><div class="roi-val">3.0×</div><div class="roi-l">Pipeline ROI</div><div style="font-family:'JetBrains Mono',monospace;font-size:10.5px;color:var(--ink-3);margin-top:4px;">3 closed × $2,500 deal ÷ subscription</div></div>
       </div>
-      <div class="legend-row">
-        <div class="legend-item"><div class="legend-dot" style="background:rgba(107,142,90,0.4);"></div>Email</div>
-        <div class="legend-item"><div class="legend-dot" style="background:rgba(59,130,246,0.4);"></div>LinkedIn</div>
-        <div class="legend-item"><div class="legend-dot" style="background:var(--amber-soft);border:1px solid var(--amber);"></div>Voice AI</div>
-        <div class="legend-item"><div class="legend-dot" style="background:rgba(139,92,246,0.2);"></div>SMS</div>
-      </div>
+      <div style="margin-top:14px;font-size:12px;color:var(--ink-3);font-family:'JetBrains Mono',monospace;">Subscription $2,500/mo · Meetings 8 · Replies 31 · Contacts 247 · Closed 3 (avg deal $2,500)</div>
     </div>
+
+    <div style="text-align:center;margin-top:22px;"><button class="btn btn-primary" onclick="alert('Export PDF report for partners')">Export report</button></div>
   `;
-  document.getElementById('page').innerHTML = html;
 }
 
-/* ═══════════════════════════════════════════════════════════════════
-   PAGE 7 — SIGNALS
-═══════════════════════════════════════════════════════════════════ */
-function renderInsights() {
-  const signalPerformance = [
-    {name:'Active ad spend detected',category:'Timing',desc:'Google or Meta ad spend confirmed via transparency APIs and pixel detection.',detections:187,replyRate:'12.3%',meetingRate:'2.1%'},
-    {name:'Rapid hiring activity',category:'Growth',desc:'Multiple job postings or new hires detected on LinkedIn within 30 days.',detections:142,replyRate:'9.8%',meetingRate:'1.8%'},
-    {name:'GMB rating in decline',category:'Pain',desc:'Google Business rating dropped 0.3+ stars in 90 days with negative review velocity.',detections:98,replyRate:'17.4%',meetingRate:'3.2%'},
-    {name:'Outdated site or zero SEO',category:'Presence',desc:'Website technology stack older than 3 years, no SSL, or zero organic rankings.',detections:87,replyRate:'8.1%',meetingRate:'1.1%'},
-    {name:'Founder posts about pipeline',category:'Intent',desc:'Decision-maker posting about growth, leads, or marketing challenges on LinkedIn.',detections:54,replyRate:'22.1%',meetingRate:'4.7%'},
-    {name:'New ABN registration',category:'Velocity',desc:'Business registered within the last 12 months — early growth phase, actively building.',detections:32,replyRate:'6.2%',meetingRate:'0.9%'},
-  ];
-  const maxDetections = Math.max(...signalPerformance.map(s => s.detections));
-  const html = `
-    <div class="eyebrow" style="margin-bottom:12px;">Signal intelligence</div>
-    <h1 class="page-headline" style="margin-bottom:16px;">What the system sees<br><em>on your behalf.</em></h1>
-    <div style="font-size:14px;color:var(--ink-3);margin-bottom:36px;max-width:620px;">Every signal tracked across your 600 records this cycle. Ranked by what actually converts to meetings.</div>
-    <div class="grid-2" style="margin-bottom:40px;">
-      ${signalPerformance.map(s => `
-        <div class="card" style="padding:20px;">
-          <div style="font-family:'JetBrains Mono',monospace;font-size:10px;text-transform:uppercase;letter-spacing:1.2px;color:var(--ink-3);margin-bottom:6px;">${s.category}</div>
-          <div style="font-family:'Playfair Display',serif;font-size:18px;font-weight:700;color:var(--ink);margin-bottom:10px;">${s.name}</div>
-          <div style="font-size:14px;color:var(--ink-3);margin-bottom:16px;line-height:1.55;">${s.desc}</div>
-          <div style="display:flex;gap:24px;">
-            <div><div style="font-family:'JetBrains Mono',monospace;font-size:18px;font-weight:700;color:var(--ink);">${s.detections}</div><div style="font-size:11px;color:var(--ink-3);margin-top:2px;">detections</div></div>
-            <div><div style="font-family:'JetBrains Mono',monospace;font-size:18px;font-weight:700;color:var(--ink);">${s.replyRate}</div><div style="font-size:11px;color:var(--ink-3);margin-top:2px;">reply rate</div></div>
-            <div><div style="font-family:'JetBrains Mono',monospace;font-size:18px;font-weight:700;color:var(--amber);">${s.meetingRate}</div><div style="font-size:11px;color:var(--ink-3);margin-top:2px;">meeting rate</div></div>
-          </div>
-        </div>
-      `).join('')}
-    </div>
-    <div class="card" style="margin-bottom:32px;">
-      <div class="section-label" style="margin-bottom:4px;">Signal distribution this cycle</div>
-      <div style="font-size:13px;color:var(--ink-3);margin-bottom:20px;">Of your 600 prospects, which signal type is strongest?</div>
-      ${signalPerformance.map(s => `
-        <div style="display:flex;align-items:center;gap:12px;margin-bottom:14px;">
-          <div style="width:200px;font-size:13px;color:var(--ink-2);flex-shrink:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${s.name}</div>
-          <div style="flex:1;background:var(--surface);border-radius:2px;height:10px;overflow:hidden;">
-            <div style="width:${Math.round((s.detections/maxDetections)*100)}%;background:var(--amber);height:100%;border-radius:2px;"></div>
-          </div>
-          <div style="width:100px;display:flex;gap:8px;justify-content:flex-end;flex-shrink:0;">
-            <span style="font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--ink-2);">${s.detections}</span>
-            <span style="font-size:11px;color:var(--ink-3);">${s.replyRate}</span>
-          </div>
-        </div>
-      `).join('')}
-    </div>
-    <div class="card">
-      <div class="section-label" style="margin-bottom:16px;">Signal correlation with meetings</div>
-      <table class="report-table">
-        <thead><tr><th>Signal</th><th>Prospects</th><th>Meetings booked</th><th>Conversion rate</th></tr></thead>
-        <tbody>
-          ${[...signalPerformance].sort((a,b) => parseFloat(b.meetingRate)-parseFloat(a.meetingRate)).map(s => {
-            const meetings = Math.round(s.detections * parseFloat(s.meetingRate) / 100);
-            return `<tr><td>${s.name}</td><td><span class="mono" style="font-size:12px;">${s.detections}</span></td><td><span class="mono" style="font-size:12px;">${meetings}</span></td><td><span class="badge badge-green" style="font-size:11px;">${s.meetingRate}</span></td></tr>`;
-          }).join('')}
-        </tbody>
-      </table>
-    </div>
-  `;
-  document.getElementById('page').innerHTML = html;
-}
-
-/* ═══════════════════════════════════════════════════════════════════
-   PAGE 8 — REPORTS
-═══════════════════════════════════════════════════════════════════ */
-function renderReports() {
-  const systemSteps = [
-    {label:'Discovered',count:47832},{label:'Industry filter',count:8204},{label:'Affordability gate',count:3421},{label:'Intent filter',count:1188},{label:'Top 600 scored',count:600},
-  ];
-  const decisionSteps = [
-    {label:'Delivered to you',count:600},{label:'Released to outreach',count:600},{label:'Contacted',count:247},{label:'Opened',count:116},{label:'Replied',count:31},{label:'Meetings booked',count:8},
-  ];
-  const maxCount = systemSteps[0].count;
-  function funnelRow(step, prevCount, isSystem) {
-    const barWidth = Math.max(2, Math.round((step.count / maxCount) * 100));
-    const pctOfPrev = prevCount ? Math.round((step.count / prevCount) * 100) + '%' : '—';
-    const barColor = isSystem ? 'var(--amber)' : 'var(--ink-2)';
-    return `<div style="display:flex;align-items:center;gap:10px;margin-bottom:10px;">
-      <div style="width:160px;font-size:13px;color:var(--ink-2);flex-shrink:0;">${step.label}</div>
-      <div style="flex:1;background:var(--surface);border-radius:2px;height:10px;overflow:hidden;"><div style="width:${barWidth}%;background:${barColor};height:100%;border-radius:2px;"></div></div>
-      <div style="width:58px;text-align:right;font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--ink-2);flex-shrink:0;">${step.count.toLocaleString()}</div>
-      <div style="width:42px;text-align:right;font-size:11px;color:var(--ink-3);flex-shrink:0;">${pctOfPrev}</div>
-    </div>`;
-  }
-  const html = `
-    <h1 class="page-headline" style="margin-bottom:28px;">Cycle performance,<br><em>by the numbers.</em></h1>
-    <div class="grid-4" style="margin-bottom:32px;">
-      ${[
-        {label:'Total Contacted',val:'247',delta:'+80 this week',up:true},
-        {label:'Total Replies',val:'31',delta:'8.2% reply rate',up:true},
-        {label:'Meetings Booked',val:'8',delta:'1.4% meeting rate',up:null},
-        {label:'Pipeline Value',val:'$94K',delta:'Est. AUD',up:null},
-      ].map(k => `<div class="kpi-card"><div class="kpi-label">${k.label}</div><div class="kpi-val">${k.val}</div><div class="metric-delta ${k.up===true?'delta-up':k.up===false?'delta-down':''}" style="${k.up===null?'color:var(--ink-3)':''}">${k.delta}</div></div>`).join('')}
-    </div>
-    <div class="card" style="margin-bottom:24px;">
-      <div class="section-label" style="margin-bottom:4px;">Cycle 3 conversion funnel</div>
-      <div style="font-size:13px;color:var(--ink-3);margin-bottom:24px;">From 47,832 discovered to 8 meetings booked. This is what $2,500/mo buys you.</div>
-      <div style="font-family:'JetBrains Mono',monospace;font-size:10px;text-transform:uppercase;letter-spacing:1.2px;color:var(--amber);margin-bottom:14px;">System work</div>
-      ${systemSteps.map((step, i) => funnelRow(step, i > 0 ? systemSteps[i-1].count : null, true)).join('')}
-      <div style="display:flex;align-items:center;gap:12px;margin:20px 0;">
-        <div style="flex:1;height:1px;background:var(--rule);"></div>
-        <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ink-3);white-space:nowrap;">handoff — your cycle begins</div>
-        <div style="flex:1;height:1px;background:var(--rule);"></div>
-      </div>
-      <div style="font-family:'JetBrains Mono',monospace;font-size:10px;text-transform:uppercase;letter-spacing:1.2px;color:var(--ink-2);margin-bottom:14px;">Your decisions</div>
-      ${decisionSteps.map((step, i) => funnelRow(step, i > 0 ? decisionSteps[i-1].count : systemSteps[systemSteps.length-1].count, false)).join('')}
-    </div>
-    <div class="grid-2" style="margin-bottom:24px;">
-      <div class="card">
-        <div class="section-label">Top performing signals</div>
-        <table class="report-table">
-          <thead><tr><th>Signal</th><th>Triggered</th><th>Reply Rate</th></tr></thead>
-          <tbody>
-            ${[
-              {name:'Brand Term Bidding',count:14,rate:'21.4%'},
-              {name:'GMB Rating Decline',count:8,rate:'18.8%'},
-              {name:'Ad Pause Detected',count:6,rate:'16.7%'},
-              {name:'Outdated Website',count:31,rate:'9.7%'},
-              {name:'Staff Churn Signal',count:3,rate:'33.3%'},
-            ].map(s => `<tr><td>${s.name}</td><td><span class="mono" style="font-size:12px;">${s.count}</span></td><td><span class="badge badge-green" style="font-size:11px;">${s.rate}</span></td></tr>`).join('')}
-          </tbody>
-        </table>
-      </div>
-      <div class="card">
-        <div class="section-label">Channel performance</div>
-        <table class="report-table">
-          <thead><tr><th>Channel</th><th>Sent</th><th>Reply Rate</th><th>Meetings</th></tr></thead>
-          <tbody>
-            ${[
-              {ch:'Email',sent:180,reply:'8.4%',meet:2},
-              {ch:'LinkedIn',sent:60,reply:'11.3%',meet:1},
-              {ch:'Voice AI',sent:25,reply:'5.0%',meet:1},
-              {ch:'SMS',sent:15,reply:'15.0%',meet:0},
-            ].map(c => `<tr><td><strong>${c.ch}</strong></td><td><span class="mono" style="font-size:12px;">${c.sent}</span></td><td><span class="badge badge-green" style="font-size:11px;">${c.reply}</span></td><td>${c.meet}</td></tr>`).join('')}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  `;
-  document.getElementById('page').innerHTML = html;
-}
-
-/* ═══════════════════════════════════════════════════════════════════
-   PAGE 9 — SETTINGS
-═══════════════════════════════════════════════════════════════════ */
+/* ================================================================
+   SETTINGS
+================================================================ */
 function renderSettings() {
-  const tabs = ['account','integrations','team','billing','danger'];
-  const tabLabels = {account:'Account',integrations:'Integrations',team:'Team',billing:'Billing',danger:'Danger Zone'};
+  document.getElementById('main').innerHTML = `
+    <h1 class="page-h">Settings</h1>
+    <p class="page-sub">Configure Maya, your BDR agent.</p>
 
-  const integrationsSection = `
-    <div class="section-label">Connected services</div>
-    ${[
-      {abbr:'CRM', name:'HubSpot CRM',desc:'Sync prospects and deals',status:'Connected'},
-      {abbr:'LI', name:'LinkedIn',desc:'Automated connection requests and messages',status:'Connected'},
-      {abbr:'EMAIL', name:'Email Domains',desc:'ignition.com.au · 3 mailboxes active',status:'Connected'},
-      {abbr:'VOICE', name:'Voice AI',desc:'Automated outbound calling',status:'Connected'},
-      {abbr:'SMS', name:'SMS Gateway',desc:'Automated SMS outreach',status:'Degraded'},
-      {abbr:'CAL', name:'Calendar',desc:'Google Calendar · Meeting booking',status:'Connected'},
-    ].map(i => `
-      <div class="integration-row">
-        <div class="integration-icon-text">${i.abbr}</div>
-        <div style="flex:1;">
-          <div class="integration-name">${i.name}</div>
-          <div class="integration-desc">${i.desc}</div>
-        </div>
-        <span class="badge ${i.status==='Connected'?'badge-connected':'badge-amber'}">${i.status}</span>
-      </div>
-    `).join('')}
-  `;
-
-  const accountSection = `
-    <div style="margin-bottom:32px;">
-      <div style="font-family:'JetBrains Mono',monospace;font-size:10px;text-transform:uppercase;letter-spacing:1.2px;color:var(--ink-3);margin-bottom:8px;">Services you sell</div>
-      <div style="font-size:13px;color:var(--ink-3);margin-bottom:16px;">Extracted from your website and case studies during onboarding. Toggle off services you don't want prospects for.</div>
-      ${['SEO Services','Google Ads Management','Web Design & Development','Content Marketing','Social Media Management','Email Marketing'].map(s => `<label style="display:flex;align-items:center;gap:8px;padding:8px 0;cursor:pointer;"><input type="checkbox" checked style="accent-color:var(--amber);"> <span>${s}</span></label>`).join('')}
+    <div class="section-label" style="margin-top:0;">Agent</div>
+    <div class="card">
+      <div class="set-row"><div class="set-key">BDR name</div><div class="set-val"><input type="text" value="Maya"></div></div>
+      <div class="set-row"><div class="set-key">Agency name</div><div class="set-val"><input type="text" value="Keiracom Growth"></div></div>
+      <div class="set-row"><div class="set-key">Founder</div><div class="set-val"><input type="text" value="Dave Stephens · dave@keiracom.com.au"></div></div>
+      <div class="set-row"><div class="set-key">Quality-check cadence</div><div class="set-val"><select><option>3 random / day (current)</option><option>5 random / day</option><option>10 random / day</option><option>Review-all</option></select></div></div>
+      <div class="set-row"><div class="set-key">Needs-review threshold</div><div class="set-val"><select><option>Critic score &lt; 70 (current)</option><option>Critic score &lt; 80</option><option>Critic score &lt; 60</option></select></div></div>
+      <div class="set-row"><div class="set-key">Agency voice / tone</div><div class="set-val"><textarea>Direct. Australian. Evidence-led. No corporate fluff. Every message references a specific vulnerability on the prospect's site — never generic.</textarea></div></div>
     </div>
-    <div id="industriesSection" style="margin-bottom:32px;">
-      <div style="font-family:'JetBrains Mono',monospace;font-size:10px;text-transform:uppercase;letter-spacing:1.2px;color:var(--ink-3);margin-bottom:8px;">Industries you serve</div>
-      <div style="font-size:13px;color:var(--ink-3);margin-bottom:16px;">Default is all industries. Specialist agencies can narrow to their focus verticals.</div>
-      ${[
-        ['Health & Medical','dental, physio, GP, vet, specialist, aged care'],
-        ['Trades & Construction','builders, electricians, plumbers, HVAC'],
-        ['Professional Services','accounting, legal, consulting, HR'],
-        ['Hospitality','cafes, restaurants, venues, catering'],
-        ['Retail','bricks-and-mortar, e-commerce, specialty'],
-        ['Automotive','dealers, mechanics, panel beaters'],
-        ['Home & Lifestyle','interior design, landscaping, cleaning'],
-        ['Finance & Insurance','mortgage, insurance, financial planning'],
-      ].map(([name,sub]) => `<label style="display:flex;align-items:center;gap:8px;padding:8px 0;cursor:pointer;"><input type="checkbox" checked class="industry-cb" onchange="checkIndustryWarning()"> <span>${name}</span> <span style="font-size:11px;color:var(--ink-3);">(${sub})</span></label>`).join('')}
-      <div id="industryWarning" style="display:none;background:var(--amber-soft);border-left:3px solid var(--amber);padding:16px;margin:16px 0;font-size:13px;">
-        Health in Sydney Metro typically produces ~420 qualified records per cycle. Your Ignition tier is 600. Options:<br>
-        &rarr; Expand geography to NSW (~680 qualified)<br>
-        &rarr; Add Health + Wellness category (~590 qualified)<br>
-        &rarr; Accept 420 records this cycle (no tier change)
-      </div>
-    </div>
-    <div class="section-label">Agency profile</div>
-    ${[
-      {key:'Agency Name',sub:'Displayed across all outreach',val:'Ignition Digital'},
-      {key:'Primary Service',sub:'Used to qualify prospects',val:'SEO Services, Google Ads, Web Design'},
-      {key:'Target Areas',sub:'Geographic targeting',val:'Sydney, Melbourne, Brisbane'},
-      {key:'Outreach Style',sub:'Tone used in all drafts',val:'Direct · Professional · Data-led'},
-    ].map(r => `<div class="settings-row"><div class="settings-row-label"><div class="settings-row-key">${r.key}</div><div class="settings-row-sub">${r.sub}</div></div><div class="settings-row-val">${r.val}</div><div class="settings-row-action"><button class="btn btn-outline" style="font-size:12px;padding:5px 12px;">Edit</button></div></div>`).join('')}
-  `;
 
-  const teamSection = `
-    <div class="section-label">Team members</div>
-    ${[
-      {name:'David Stephens',role:'Owner',email:'david@ignition.com.au',avatar:'DS'},
-      {name:'Priya Nair',role:'Account Manager',email:'priya@ignition.com.au',avatar:'PN'},
-    ].map(m => `<div class="settings-row"><div class="settings-row-label" style="display:flex;align-items:center;gap:10px;width:auto;margin-right:16px;"><div class="avatar-circle" style="background:var(--ink-2);width:36px;height:36px;font-size:12px;">${m.avatar}</div><div><div class="settings-row-key">${m.name}</div><div class="settings-row-sub">${m.email}</div></div></div><div class="settings-row-val"><span class="badge badge-ink">${m.role}</span></div><div class="settings-row-action"><button class="btn btn-outline" style="font-size:12px;padding:5px 12px;">Edit</button></div></div>`).join('')}
-    <div style="margin-top:16px;"><button class="btn btn-outline">+ Invite team member</button></div>
-  `;
-
-  const billingSection = `
-    <div class="section-label">Current plan</div>
-    <div class="card" style="margin-bottom:20px;">
-      <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;">
+    <div class="section-label">Notification mode</div>
+    <p class="page-sub" style="margin-bottom:14px;">As you build trust with Maya, you can step back from daily dashboard checks and receive meeting alerts only.</p>
+    <div class="card">
+      <label class="autopilot-opt selected">
+        <input type="radio" name="notify" value="dashboard" checked>
         <div>
-          <div style="font-family:'Playfair Display',serif;font-size:22px;font-weight:700;color:var(--ink);">Growth Plan</div>
-          <div style="font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--ink-3);">$497 AUD / month · Renews 7 May 2026</div>
+          <div class="ao-name">Dashboard-first <span class="ao-soon" style="background:var(--amber-soft);color:var(--copper);border-color:var(--amber-dim);">Recommended for months 1-3</span></div>
+          <div class="ao-desc">Open the desk daily. Spot-check messages. Review every meeting brief. Build trust with Maya.</div>
         </div>
-        <span class="badge badge-green" style="margin-left:auto;">Active</span>
-      </div>
-      ${[
-        {feature:'Prospects per month',val:'600'},
-        {feature:'Campaigns',val:'4 active'},
-        {feature:'Outreach channels',val:'Email + LinkedIn + Voice + SMS'},
-        {feature:'Seats',val:'3 users'},
-      ].map(f => `<div style="display:flex;padding:8px 0;border-bottom:1px solid var(--rule);"><div style="flex:1;font-size:13px;color:var(--ink-3);">${f.feature}</div><div style="font-family:'JetBrains Mono',monospace;font-size:13px;color:var(--ink-2);">${f.val}</div></div>`).join('')}
+      </label>
+      <label class="autopilot-opt coming" onclick="event.preventDefault();">
+        <input type="radio" name="notify" value="alerts" disabled>
+        <div>
+          <div class="ao-name">Alerts-only <span class="ao-soon">coming soon</span></div>
+          <div class="ao-desc">Get pinged for booked meetings + flagged exceptions only. Maya runs hands-off in between.</div>
+        </div>
+      </label>
+      <label class="autopilot-opt coming" onclick="event.preventDefault();">
+        <input type="radio" name="notify" value="reports" disabled>
+        <div>
+          <div class="ao-name">Reports-only <span class="ao-soon">coming soon</span></div>
+          <div class="ao-desc">Weekly digest by email Mondays 7am AEST. No daily touchpoints. Pure background mode.</div>
+        </div>
+      </label>
     </div>
-    <button class="btn btn-outline">Manage billing →</button>
-  `;
 
-  const dangerSection = `
-    <div class="danger-zone">
-      <div class="danger-zone-title">Danger Zone</div>
-      ${[
-        {title:'Pause all campaigns',sub:'Stop all active outreach immediately. Can be resumed.',btn:'Pause All',red:false},
-        {title:'Export all data',sub:'Download all prospects, campaigns, and reply data as CSV.',btn:'Export Data',red:false},
-        {title:'Delete account',sub:'Permanently delete your account and all data. This cannot be undone.',btn:'Delete Account',red:true},
-      ].map(d => `<div class="danger-row"><div class="danger-row-info"><div class="danger-row-title">${d.title}</div><div class="danger-row-sub">${d.sub}</div></div><button class="${d.red?'btn-danger':'btn btn-outline'}" style="${!d.red?'font-size:12px;padding:6px 12px;':''}">${d.btn}</button></div>`).join('')}
-    </div>
+    <div style="margin-top:18px;text-align:right;"><button class="btn btn-primary">Save changes</button></div>
   `;
-
-  const sectionContent = {account:accountSection,integrations:integrationsSection,team:teamSection,billing:billingSection,danger:dangerSection};
-
-  const html = `
-    <h1 class="page-headline" style="margin-bottom:28px;">Settings</h1>
-    <div class="settings-layout">
-      <div class="settings-nav">
-        ${tabs.map(t => `<div class="settings-nav-item ${activeSettingsTab===t?'active':''}" onclick="switchSettingsTab('${t}')">${tabLabels[t]}</div>`).join('')}
-      </div>
-      <div class="settings-content">
-        ${tabs.map(t => `<div class="settings-section ${activeSettingsTab===t?'active':''}" id="stab-${t}">${sectionContent[t]}</div>`).join('')}
-      </div>
-    </div>
-  `;
-  document.getElementById('page').innerHTML = html;
+  /* visual select-state for the active radio */
+  document.querySelectorAll('.autopilot-opt input[type="radio"]').forEach(r => {
+    r.addEventListener('change', () => {
+      document.querySelectorAll('.autopilot-opt').forEach(o => o.classList.toggle('selected', o.querySelector('input[type="radio"]').checked));
+    });
+  });
 }
 
-function switchSettingsTab(tab) {
-  activeSettingsTab = tab;
-  document.querySelectorAll('.settings-nav-item').forEach((el,i) => { const tabs = ['account','integrations','team','billing','danger']; el.classList.toggle('active', tabs[i]===tab); });
-  document.querySelectorAll('.settings-section').forEach(el => { el.classList.toggle('active', el.id==='stab-'+tab); });
+/* ================================================================
+   ROUTER + theme + mobile sidebar
+================================================================ */
+function showView(v) {
+  document.querySelectorAll('.sb-item').forEach(n => n.classList.toggle('active', n.dataset.v === v));
+  document.querySelectorAll('.bn-item').forEach(b => b.classList.toggle('active', b.dataset.v === v));
+  if (v === 'home') renderHome();
+  else if (v === 'pipeline') renderPipeline();
+  else if (v === 'feed') renderFeed();
+  else if (v === 'meetings') renderMeetings();
+  else if (v === 'progress') renderProgress();
+  else if (v === 'settings') renderSettings();
+  closeDrawer();
+  if (window.matchMedia('(max-width: 768px)').matches) {
+    document.getElementById('sidebar').classList.remove('mobile-open');
+    document.getElementById('sidebar-overlay').classList.remove('show');
+  }
+  window.scrollTo(0, 0);
 }
-
-function checkIndustryWarning() {
-  const cbs = document.querySelectorAll('.industry-cb');
-  const allChecked = Array.from(cbs).every(cb => cb.checked);
-  const warning = document.getElementById('industryWarning');
-  if (warning) warning.style.display = allChecked ? 'none' : 'block';
-}
-
-/* ═══════════════════════════════════════════════════════════════════
-   MOBILE SIDEBAR
-═══════════════════════════════════════════════════════════════════ */
 function toggleMobileSidebar() {
   document.getElementById('sidebar').classList.toggle('mobile-open');
   document.getElementById('sidebar-overlay').classList.toggle('show');
 }
-function closeMobileSidebar() {
-  document.getElementById('sidebar').classList.remove('mobile-open');
-  document.getElementById('sidebar-overlay').classList.remove('show');
-}
 
-/* ═══════════════════════════════════════════════════════════════════
-   INIT
-═══════════════════════════════════════════════════════════════════ */
-router();
+document.addEventListener('click', e => {
+  if (e.target.closest('.tb-theme')) {
+    const next = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+    document.documentElement.classList.toggle('dark', next === 'dark');
+    localStorage.setItem('agencyos_theme', next);
+  }
+});
+
+renderHome();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Final PR in the dashboard rebuild chain (#441 → #442 → #443 → this). Strips every mock-data reference from `/dashboard`, repaletted the demo-mode banner, refreshed the static prototype served at `agencyxos.ai/demo`, and added an operator runbook for the demo seed dry-run.

## Acceptance criteria

### 1. Mock imports removed from `dashboard/page.tsx`
- ✅ `mockChannelOrchestration` → `TodoMockPanel` pointing at `GET /api/v1/dashboard/touches?breakdown=channel`
- ✅ `mockVoiceStats` + `mockRecentCalls` → `TodoMockPanel` pointing at `GET /api/v1/voice/stats` + `/api/v1/voice/recent`
- ✅ `mockInsights.whoConverts` + `mockInsights.bestChannelMix` → `TodoMockPanel` pointing at `/api/v1/insights/*`
- ✅ `mockInsights.discovery` fallback removed (insight banner now only renders when `dashboardData.insight.detail` is present)
- ✅ Zero remaining `mock*` references in the file (only commentary references survive)

### 2. Demo banner with new palette
`DemoBanner.tsx` repaletted from the orange-600→amber-500 gradient to the cream/amber theme: deep-ink `--brand-bar` background, amber `Demo Mode` eyebrow, amber→on-amber CTA. Brand mark uses Playfair italic `OS` accent so it sits visually with the sidebar logo from PR #441.

### 3. Demo dry-run runbook
`docs/DEMO_DRY_RUN_2026-04-28.md` documents the operator-side steps to:
- run `scripts/seed_demo_tenant.py --execute` (7 prospects + 1 demo campaign + 1 auth user)
- sign in as `demo@keiracom.com`
- verify Pipeline View, Prospect Detail card, Demo Banner, mock unwiring, and `/demo` static page

The dry-run itself can't be executed from the Atlas clone (no `DATABASE_URL` / `SUPABASE_SERVICE_KEY` in the Claude Code runtime). The runbook flags this and gives the operator a 7-checkbox sign-off pass.

### 4. agencyxos.ai/demo refreshed
`frontend/landing/demo/index.html` replaced with `dashboard-master-agency-desk.html` (v10, 2,344 lines). md5 hashes match — the Vercel project rooted at `frontend/landing/` will now serve the cream/amber Agency Desk prototype after its next deploy.

## Files
- `frontend/components/dashboard/TodoMockPanel.tsx` — **NEW**
- `frontend/app/dashboard/page.tsx` — mock imports stripped, three slots replaced
- `frontend/components/demo/DemoBanner.tsx` — palette aligned with cream/amber theme
- `frontend/landing/demo/index.html` — replaced with v10 prototype
- `docs/DEMO_DRY_RUN_2026-04-28.md` — **NEW** operator runbook

## Test plan
- [x] `tsc --noEmit` — 4 errors before, 4 errors after (pre-existing in `lib/__tests__/useLiveActivityFeed.test.ts`)
- [x] Zero errors in any PR4 file
- [x] `grep mockChannelOrchestration|mockVoiceStats|mockRecentCalls|mockInsights frontend/app/dashboard/page.tsx` — only comment references remain
- [x] `md5sum dashboard-master-agency-desk.html frontend/landing/demo/index.html` — match
- [ ] **Operator follow-up:** execute the runbook in `docs/DEMO_DRY_RUN_2026-04-28.md` against a deploy with credentials loaded; paste deploy URL + screenshots into thread

## Chain summary (4 PRs · #441 → #444)
| PR | Scope |
|---|---|
| #441 | Cream/amber palette, Playfair Display, 232px sidebar |
| #442 | Cycle Progress + Performance Metrics + Hot Replies + System Health |
| #443 | Pipeline View (intent rows, filters, state tabs) + Prospect Detail card |
| this | Mock unwiring + Demo Banner palette + agencyxos.ai/demo refresh + runbook |

🤖 Generated with [Claude Code](https://claude.com/claude-code)