### PR TITLE
[ELLIOT] feat: demo mode — hide TODO·MOCK badges in demo tenant

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -46,6 +46,8 @@ import { SystemHealth } from "@/components/dashboard/SystemHealth";
 import { TodoMockPanel } from "@/components/dashboard/TodoMockPanel";
 import Link from "next/link";
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import api from "@/lib/api";
 
 // Channel icon component
 const ChannelIcon = ({ type }: { type: string }) => {
@@ -64,6 +66,21 @@ export default function DashboardPage() {
   const { data: dashboardData, isLoading: dashboardLoading } = useDashboardV4();
   const { activities: activityFeed, isLoading: activityLoading } = useLiveActivityFeed({ limit: 8 });
   const [drawerLeadId, setDrawerLeadId] = useState<string | null>(null);
+
+  // Demo mode — hide TODO · MOCK badges for investor-facing demos
+  const { data: demoModeData } = useQuery({
+    queryKey: ["demo-mode"],
+    queryFn: async () => {
+      try {
+        return await api.get<{ is_demo_mode: boolean }>("/api/v1/dashboard/demo-mode");
+      } catch {
+        return { is_demo_mode: false };
+      }
+    },
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+  const isDemoMode = demoModeData?.is_demo_mode ?? false;
 
   const meetingsBooked = dashboardData?.meetingsGoal.current ?? 0;
   const meetingsTarget = dashboardData?.meetingsGoal.target ?? 10;
@@ -210,6 +227,7 @@ export default function DashboardPage() {
                   "GET /api/v1/dashboard/touches?breakdown=channel",
                   "fields: email_count, linkedin_count, sms_count, voice_count, mail_count",
                 ]}
+                hideBadge={isDemoMode}
               />
             </GlassCard>
           </div>
@@ -297,6 +315,7 @@ export default function DashboardPage() {
                 "GET /api/v1/voice/recent?limit=10",
                 "fields: calls, connected, booked, connect_rate, recent[{ name, outcome, summary, duration_s, recording_url, transcript_url }]",
               ]}
+              hideBadge={isDemoMode}
             />
 
             {/* What's Working — PR4: insight is live, who-converts/channel-mix are mocks */}
@@ -319,6 +338,7 @@ export default function DashboardPage() {
                     "GET /api/v1/insights/who-converts",
                     "GET /api/v1/insights/channel-mix",
                   ]}
+                  hideBadge={isDemoMode}
                 />
 
                 {/* Discovery Banner — already wired to useDashboardV4 insight */}

--- a/frontend/components/dashboard/TodoMockPanel.tsx
+++ b/frontend/components/dashboard/TodoMockPanel.tsx
@@ -8,10 +8,13 @@
  *
  * Each panel:
  *   - Shows a TODO · MOCK pill so demo viewers + CEO can tell at a
- *     glance that the surface is unwired
+ *     glance that the surface is unwired (hidden when hideBadge=true)
  *   - Names the missing endpoint(s) so a future PR can grep for it
  *   - Carries an optional eyebrow + icon to keep the slot visually
  *     coherent with the rest of the dashboard chrome
+ *
+ * hideBadge: pass true when IS_DEMO_MODE is active so investor demos
+ *   don't surface internal "TODO · MOCK" labels to external viewers.
  */
 
 "use client";
@@ -24,10 +27,11 @@ interface Props {
   title: string;             // Playfair-style headline
   description: string;       // body copy
   endpointsNeeded: string[]; // bullet list of pending endpoints
+  hideBadge?: boolean;       // when true, suppress the TODO · MOCK pill
 }
 
 export function TodoMockPanel({
-  icon, eyebrow, title, description, endpointsNeeded,
+  icon, eyebrow, title, description, endpointsNeeded, hideBadge = false,
 }: Props) {
   return (
     <div className="rounded-[10px] border border-dashed border-amber/40 bg-amber-soft px-5 py-5">
@@ -40,9 +44,11 @@ export function TodoMockPanel({
         <span className="font-mono text-[10px] tracking-[0.14em] uppercase font-semibold text-copper">
           {eyebrow}
         </span>
-        <span className="ml-auto font-mono text-[8px] tracking-[0.14em] uppercase text-amber bg-amber-soft border border-amber/40 rounded px-1.5 py-[1px]">
-          TODO · MOCK
-        </span>
+        {!hideBadge && (
+          <span className="ml-auto font-mono text-[8px] tracking-[0.14em] uppercase text-amber bg-amber-soft border border-amber/40 rounded px-1.5 py-[1px]">
+            TODO · MOCK
+          </span>
+        )}
       </div>
 
       <div className="font-display font-bold text-[18px] text-ink leading-snug">


### PR DESCRIPTION
## Summary
- TodoMockPanel.tsx: added `hideBadge` prop to suppress TODO·MOCK pill in demo mode
- dashboard/page.tsx: queries `/api/v1/dashboard/demo-mode` to derive `isDemoMode` flag, passes to all 3 TodoMockPanel instances
- Demo tenant already seeded with 7 Sydney dentist prospects (PR #440)

## Context
Investor demo readiness — when logged in as demo@keiracom.com, TODO·MOCK badges are hidden so investors see a clean dashboard.

## Test plan
- [ ] Login as demo@keiracom.com on /dashboard
- [ ] Verify 7 prospect cards visible in Pipeline View
- [ ] Verify TODO·MOCK badges NOT visible in demo mode
- [ ] Verify TODO·MOCK badges still visible for non-demo users

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>