### PR TITLE
[AIDEN] feat(landing): 'Try the demo' CTA in hero

### DIFF
--- a/frontend/landing/index.html
+++ b/frontend/landing/index.html
@@ -1229,6 +1229,10 @@ footer .wordmark-lockup { font-size: 14px; }
       <a href="#founding" class="btn btn-solid">
         Reserve Founding Spot <span class="btn-arrow">→</span>
       </a>
+      <!-- Live demo: simulated onboarding → real seeded prospect cards. ?demo=true triggers middleware bypass + 24hr demo cookie. Swap host to app.agencyxos.ai once DNS propagates. -->
+      <a href="https://frontend-nine-rouge-37.vercel.app/onboarding/step-1?demo=true" class="btn btn-outline">
+        Try the demo <span class="btn-arrow">→</span>
+      </a>
       <!-- CTA_PLACEHOLDER: swap to Cal.com link when booking is live -->
       <a href="mailto:hello@agencyxos.ai?subject=Agency%20OS%20demo%20call" class="btn btn-outline">
         Book a call


### PR DESCRIPTION
## Summary
- Add 'Try the demo' button to agencyxos.ai hero CTA group
- Links to `/onboarding/step-1?demo=true` on the frontend Vercel project
- Triggers existing middleware demo-bypass (Directive #028) — no app code changes

## Why
- Closes Option D demo roadmap. Investor visiting agencyxos.ai can now click straight into the live onboarding → dashboard flow.
- ?demo=true sets `agency_os_demo` cookie (24hr) which bypasses auth on /onboarding/* and /dashboard.

## Verification
Production smoke test via curl:
```
GET /onboarding/step-1?demo=true → HTTP/2 200 + Set-Cookie: agency_os_demo=true; Max-Age=86400
```
All 5 onboarding steps + dashboard return 200 with cookie persisted (verified by Elliot).

## Test plan
- [x] Curl verification of /onboarding/step-1?demo=true returns 200
- [ ] Manual browser walkthrough on production after deploy
- [ ] Dual-bot smoke test on agencyxos.ai post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)