### PR TITLE
[AIDEN] feat(landing): swap demo CTA host to app.agencyxos.ai

### DIFF
--- a/frontend/landing/index.html
+++ b/frontend/landing/index.html
@@ -1229,8 +1229,8 @@ footer .wordmark-lockup { font-size: 14px; }
       <a href="#founding" class="btn btn-solid">
         Reserve Founding Spot <span class="btn-arrow">→</span>
       </a>
-      <!-- Live demo: simulated onboarding → real seeded prospect cards. ?demo=true triggers middleware bypass + 24hr demo cookie. Swap host to app.agencyxos.ai once DNS propagates. -->
-      <a href="https://frontend-nine-rouge-37.vercel.app/onboarding/step-1?demo=true" class="btn btn-outline">
+      <!-- Live demo: simulated onboarding → real seeded prospect cards. ?demo=true triggers middleware bypass + 24hr demo cookie. -->
+      <a href="https://app.agencyxos.ai/onboarding/step-1?demo=true" class="btn btn-outline">
         Try the demo <span class="btn-arrow">→</span>
       </a>
       <!-- CTA_PLACEHOLDER: swap to Cal.com link when booking is live -->


### PR DESCRIPTION
Single-line URL swap. DNS propagated, CTA now points to on-brand app subdomain instead of vercel.app default placeholder.

Verified pre-commit:
`curl -I https://app.agencyxos.ai/onboarding/step-1?demo=true` → 200 + demo cookie.

Co-Authored-By: Claude Opus 4.7