### PR TITLE
[ATLAS] feat(frontend): mobile-responsive dashboard sidebar

### DIFF
--- a/frontend/components/layout/dashboard-layout.tsx
+++ b/frontend/components/layout/dashboard-layout.tsx
@@ -3,9 +3,16 @@
  * PURPOSE: Main dashboard layout wrapper
  * PHASE: 8 (Frontend)
  * TASK: FE-004
- * UPDATED: Phase H Item 43 - Added pause status support
+ * UPDATED: 2026-04-30 — mobile-responsive shell. Sidebar now collapses
+ *          to an off-canvas drawer on <md viewports; Header gains a
+ *          hamburger button. State lifted here (now a client component)
+ *          so Sidebar + Header share open/close.
  */
 
+"use client";
+
+import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { Sidebar } from "./sidebar";
 import { Header } from "./header";
 
@@ -28,16 +35,37 @@ interface DashboardLayoutProps {
 }
 
 export function DashboardLayout({ children, user, client }: DashboardLayoutProps) {
-  // PR1 rebuild — fixed 232px dark sidebar + cream main area with
-  // 56px sticky cream-blur topbar. The sidebar is `position: fixed`,
-  // so the right column reserves space via `pl-sidebar` instead of
-  // wrapping in a flex grid (matches prototype #shell layout).
+  // Mobile drawer state. Defaults closed; opened by the Header
+  // hamburger; closed by the Sidebar X button, the backdrop, or any
+  // nav-link click. Always closed on route change.
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const pathname = usePathname();
+  useEffect(() => { setMobileOpen(false); }, [pathname]);
+
+  // Lock body scroll while the drawer is open on mobile so the user
+  // can't accidentally pan the underlying page through the backdrop.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    if (mobileOpen) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => { document.body.style.overflow = prev; };
+    }
+  }, [mobileOpen]);
+
   return (
     <div className="min-h-screen bg-cream text-ink">
-      <Sidebar />
-      <div className="pl-sidebar flex min-h-screen flex-col">
-        <Header user={user} client={client} />
-        <main className="flex-1 bg-cream px-8 py-6">
+      <Sidebar open={mobileOpen} onClose={() => setMobileOpen(false)} />
+
+      {/* Right column. On mobile the sidebar is off-canvas → no left
+          padding; on md+ it's fixed at 232px → reserve space. */}
+      <div className="md:pl-sidebar flex min-h-screen flex-col">
+        <Header
+          user={user}
+          client={client}
+          onOpenMenu={() => setMobileOpen(true)}
+        />
+        <main className="flex-1 bg-cream px-4 py-4 sm:px-6 md:px-8 md:py-6">
           <div className="mx-auto w-full max-w-[1280px]">{children}</div>
         </main>
       </div>

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -9,7 +9,7 @@
 "use client";
 
 import { useState } from "react";
-import { Bell, Search, LogOut, User, Settings } from "lucide-react";
+import { Bell, Search, LogOut, User, Settings, Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -43,9 +43,12 @@ interface HeaderProps {
     pausedAt?: string | null;
     pauseReason?: string | null;
   };
+  /** Mobile hamburger callback — wired by DashboardLayout to open the
+   *  off-canvas Sidebar drawer. Button is visible only on <md viewports. */
+  onOpenMenu?: () => void;
 }
 
-export function Header({ title = "Dashboard", user, client }: HeaderProps) {
+export function Header({ title = "Dashboard", user, client, onOpenMenu }: HeaderProps) {
   const router = useRouter();
   const supabase = createBrowserClient();
 
@@ -69,15 +72,24 @@ export function Header({ title = "Dashboard", user, client }: HeaderProps) {
         WebkitBackdropFilter: "saturate(140%) blur(8px)",
       }}
     >
-      {/* Left: Page title with LIVE badge */}
-      <div className="flex items-center gap-4">
-        <h1 className="font-display font-bold text-[20px] tracking-[-0.01em] text-ink">
+      {/* Left: hamburger (mobile only) + Page title with LIVE badge */}
+      <div className="flex items-center gap-3 md:gap-4">
+        <button
+          type="button"
+          onClick={onOpenMenu}
+          aria-label="Open navigation"
+          className="md:hidden -ml-2 p-2 rounded-md text-ink hover:bg-rule transition-colors"
+        >
+          <Menu className="w-5 h-5" />
+        </button>
+        <h1 className="font-display font-bold text-[18px] md:text-[20px] tracking-[-0.01em] text-ink truncate">
           {title}
         </h1>
 
-        {/* LIVE Status Badge — muted green on cream */}
+        {/* LIVE Status Badge — muted green on cream. Hidden on small
+            screens to save room for the title + hamburger. */}
         <div
-          className="flex items-center gap-2 rounded-full px-3 py-1"
+          className="hidden sm:flex items-center gap-2 rounded-full px-3 py-1"
           style={{ backgroundColor: "rgba(107,142,90,0.16)" }}
         >
           <span className="relative flex h-2 w-2">

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Radio,
   Inbox,
   Calendar,
+  X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -61,25 +62,62 @@ const navSections: NavSection[] = [
   },
 ];
 
-export function Sidebar() {
+interface SidebarProps {
+  /** Mobile drawer state — controlled by DashboardLayout. Desktop
+   *  sidebar always renders; mobile renders only when `open` is true. */
+  open?: boolean;
+  /** Mobile drawer dismiss callback (X button + backdrop tap + nav click). */
+  onClose?: () => void;
+}
+
+export function Sidebar({ open = false, onClose }: SidebarProps = {}) {
   const pathname = usePathname();
 
   return (
-    <aside
-      className="fixed left-0 top-0 bottom-0 w-sidebar bg-brand-bar text-white/80 flex flex-col z-50 overflow-y-auto"
-      style={{ borderRight: "1px solid rgba(255,255,255,0.06)" }}
-    >
+    <>
+      {/* Mobile backdrop — click to dismiss. Hidden on md+ where the
+          sidebar always renders. */}
+      <div
+        className={cn(
+          "fixed inset-0 z-40 bg-black/55 backdrop-blur-[2px] md:hidden transition-opacity",
+          open ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <aside
+        className={cn(
+          "fixed left-0 top-0 bottom-0 w-sidebar bg-brand-bar text-white/80 flex flex-col z-50 overflow-y-auto",
+          "transition-transform duration-300 ease-out",
+          // Mobile: off-canvas unless `open`. Desktop (md+): always visible.
+          open ? "translate-x-0" : "-translate-x-full md:translate-x-0",
+        )}
+        style={{ borderRight: "1px solid rgba(255,255,255,0.06)" }}
+        aria-label="Primary navigation"
+      >
       {/* Logo block — Playfair Display with amber italic accent */}
       <div
-        className="px-5 pt-[22px] pb-[18px]"
+        className="px-5 pt-[22px] pb-[18px] flex items-start justify-between"
         style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}
       >
-        <div className="font-display font-bold text-[20px] tracking-[-0.02em] text-white">
-          Agency<em className="text-amber not-italic-fallback" style={{ fontStyle: "italic" }}>OS</em>
+        <div>
+          <div className="font-display font-bold text-[20px] tracking-[-0.02em] text-white">
+            Agency<em className="text-amber not-italic-fallback" style={{ fontStyle: "italic" }}>OS</em>
+          </div>
+          <div className="font-mono text-[9px] tracking-[0.14em] uppercase text-white/30 mt-[3px]">
+            Agency Desk
+          </div>
         </div>
-        <div className="font-mono text-[9px] tracking-[0.14em] uppercase text-white/30 mt-[3px]">
-          Agency Desk
-        </div>
+        {/* Mobile-only close button */}
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close navigation"
+          className="md:hidden p-1.5 -mr-1 -mt-1 rounded text-white/60 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          <X className="w-5 h-5" />
+        </button>
       </div>
 
       {/* Nav sections */}
@@ -99,6 +137,7 @@ export function Sidebar() {
                 <Link
                   key={item.href}
                   href={item.href}
+                  onClick={onClose}
                   className={cn(
                     "flex items-center gap-3 px-5 py-[9px] text-[13px] transition-colors",
                     "border-l-2",
@@ -141,6 +180,7 @@ export function Sidebar() {
           </div>
         </div>
       </div>
-    </aside>
+      </aside>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
Currently the 232px fixed sidebar takes over half a mobile viewport and pushes content off-screen. This PR collapses the sidebar to an off-canvas drawer on `<md` breakpoints; the desktop layout (>=md) is byte-for-byte unchanged.

## Behaviour
| Viewport | Sidebar | Header hamburger | Right column |
|---|---|---|---|
| `<md` (mobile) | Off-canvas drawer; `translate-x-0` ↔ `-translate-x-full` 300ms transition; backdrop dim + blur, click → close | Visible | Full width (`pl-0`) |
| `>=md` (desktop) | Always visible 232px rail | Hidden | `md:pl-sidebar` (232px reservation) |

## Files
| File | Change |
|---|---|
| `components/layout/sidebar.tsx` | New `open` + `onClose` props; backdrop `<div>`; X close button (`md:hidden`); nav links call `onClose` so tapping closes the drawer |
| `components/layout/header.tsx` | New `onOpenMenu` prop; hamburger `<button>` (`md:hidden`) before title; title size scales `[18px] → [20px]`; LIVE badge `hidden sm:flex` |
| `components/layout/dashboard-layout.tsx` | Now `"use client"`; `useState` for drawer; `useEffect(pathname)` auto-closes on route change; body-scroll lock while open; `pl-sidebar → md:pl-sidebar`; `<main>` padding now responsive |

## Test plan
- [x] `pnpm run build` — **exit 0** (full route tree, dashboard-layout still server-renderable since the wrapper passes RSC `children` through)
- [x] `npx tsc --noEmit` — **exit 0**, zero output
- [x] No custom media queries — only Tailwind `md:` / `sm:` prefixes per dispatch
- [ ] Manual mobile smoke after deploy — hamburger opens drawer, X closes, backdrop tap closes, nav-link tap closes + navigates

🤖 Generated with [Claude Code](https://claude.com/claude-code)