### PR TITLE
[ATLAS] feat(frontend): A2 dark mode + theme toggle

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -7,6 +7,15 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Honor users who opt out of motion at the OS level. Mirrors the
+   /demo prototype (frontend/landing/demo/index.html line 14). */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: .01ms !important;
+    transition-duration: .01ms !important;
+  }
+}
+
 @layer base {
   :root {
     /* =================================================

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -44,8 +44,24 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // A2 dark-mode anti-flash. Runs synchronously before any paint so
+  // the html element gets `.dark` set (or unset) before React renders
+  // — no flicker between server-default light and the user's saved
+  // preference. Mirrors the /demo prototype pattern.
+  const themeBootScript = `
+    try {
+      var t = localStorage.getItem('agencyos_theme');
+      if (t === 'dark' || (!t && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    } catch (e) {}
+  `;
+
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeBootScript }} />
+      </head>
       {/* Fonts loaded via @import in globals.css */}
       <body className={`${dmSans.variable} ${jetbrainsMono.variable} ${playfair.variable} font-sans bg-cream text-ink`}>
         <Providers>{children}</Providers>

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -26,6 +26,7 @@ import { createBrowserClient } from "@/lib/supabase";
 import { useRouter } from "next/navigation";
 import { getInitials, getAvatarColor } from "@/lib/utils";
 import { CreditsBadge } from "./credits-badge";
+import { ThemeToggle } from "./theme-toggle";
 import { EmergencyPauseButton } from "@/components/dashboard/EmergencyPauseButton";
 
 interface HeaderProps {
@@ -131,6 +132,9 @@ export function Header({ title = "Dashboard", user, client, onOpenMenu }: Header
             onPauseChange={setIsPaused}
           />
         )}
+
+        {/* Theme toggle (sun ↔ moon) — A2 dark-mode dispatch */}
+        <ThemeToggle />
 
         {/* Credits Badge */}
         <div className="hidden md:block">

--- a/frontend/components/layout/theme-toggle.tsx
+++ b/frontend/components/layout/theme-toggle.tsx
@@ -1,0 +1,75 @@
+/**
+ * FILE: frontend/components/layout/theme-toggle.tsx
+ * PURPOSE: Sun/moon theme toggle button — mirrors /demo's `.tb-theme`
+ *          pattern (frontend/landing/demo/index.html lines ~2333-2338).
+ *
+ * Behaviour:
+ *   - Click flips `html.dark` class on document.documentElement.
+ *   - Persists the choice in localStorage under `agencyos_theme`.
+ *   - Reads localStorage on mount so React state stays in sync with
+ *     whatever the inline pre-paint script (in app/layout.tsx) wrote
+ *     before hydration. No flash of wrong theme.
+ *
+ * The `.dark` class drives the html.dark CSS-var block in
+ * app/globals.css. Tailwind's darkMode: ["class"] config reads the
+ * same class for utility variants. Single source of truth.
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
+
+const STORAGE_KEY = "agencyos_theme";
+
+type Theme = "light" | "dark";
+
+function readTheme(): Theme {
+  if (typeof document === "undefined") return "light";
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+function applyTheme(next: Theme) {
+  if (typeof document === "undefined") return;
+  document.documentElement.classList.toggle("dark", next === "dark");
+  try {
+    localStorage.setItem(STORAGE_KEY, next);
+  } catch {
+    // localStorage may be blocked (Safari private mode); the class
+    // change still wins for the current session.
+  }
+}
+
+export function ThemeToggle({ className = "" }: { className?: string }) {
+  // Hydration-safe: start with `light` and reconcile in useEffect.
+  // The pre-paint script has already set the right class before this
+  // renders, so the reconciliation is a single state update with no
+  // visual flicker.
+  const [theme, setTheme] = useState<Theme>("light");
+  useEffect(() => { setTheme(readTheme()); }, []);
+
+  const next: Theme = theme === "dark" ? "light" : "dark";
+  const label = theme === "dark" ? "Switch to light theme" : "Switch to dark theme";
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={() => {
+        applyTheme(next);
+        setTheme(next);
+      }}
+      className={[
+        "tb-theme grid place-items-center w-8 h-8 rounded-full",
+        "border border-rule text-ink-3 hover:text-amber hover:border-amber",
+        "transition-colors",
+        className,
+      ].join(" ")}
+    >
+      {theme === "dark"
+        ? <Moon className="w-4 h-4" strokeWidth={1.6} />
+        : <Sun  className="w-4 h-4" strokeWidth={1.6} />}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
A2 dark-mode dispatch — wires the dark-theme inversion + sun/moon toggle button + anti-flash pre-paint script. Mirrors `/demo` prototype's `.tb-theme` pattern (`frontend/landing/demo/index.html` lines ~2333).

## What was already done in PR #441 (PR1)
The `html.dark` CSS-vars block in `frontend/app/globals.css` already matches the dispatch's spec **exactly**:

| Token | Light | Dark |
|---|---|---|
| `--cream` | `#F7F3EE` | `#0C0A08` |
| `--surface` | `#EDE8E0` | `#16130F` |
| `--ink` | `#0C0A08` | `#F5F2EC` |
| `--ink-2/3/4` | `#2E2B26` / `#7A756D` / `#B5B0A6` | `#C9C3B8` / `#807A6E` / `#4A443A` |
| `--rule` / `--rule-strong` | `rgba(12,10,8,0.08)` / `0.14` | `rgba(255,255,255,0.08)` / `0.14` |
| `--copper` | `#C46A3E` | `#E6A87D` |
| `--amber-soft` | `rgba(212,149,106,0.14)` | `rgba(212,149,106,0.18)` |
| `--panel-bg` | `#FFFFFF` | `#16130F` |

So step 1 was a no-op. Steps 2-6 (toggle, anti-flash, prefers-reduced-motion, build verify) are this PR.

## Files
| File | Change |
|---|---|
| `frontend/app/globals.css` | Added `@media (prefers-reduced-motion: reduce)` block at top — animation/transition durations clamped to `.01ms` for users who opt out of motion at the OS level |
| `frontend/components/layout/theme-toggle.tsx` | **NEW** — Sun/Moon button (lucide-react), `.tb-theme` class for compatibility with the prototype's click-handler script, hydration-safe state reconciliation in `useEffect`, persists to `localStorage['agencyos_theme']`, cream/amber styling |
| `frontend/app/layout.tsx` | Inline `<script>` in `<head>` runs before paint: reads `localStorage['agencyos_theme']` first, falls back to `prefers-color-scheme: dark` media query on first visit. Sets `html.dark` class synchronously so React renders the right theme on first paint |
| `frontend/components/layout/header.tsx` | Imports + renders `<ThemeToggle />` in the right-side cluster |

## Behaviour
1. **First visit** — script reads `prefers-color-scheme`. If OS is dark, `html.dark` is added before paint.
2. **Click toggle** — flips `html.dark`, writes `localStorage['agencyos_theme']` = `'dark' \| 'light'`.
3. **Subsequent visits** — script reads the explicit choice from localStorage, ignores OS preference.
4. **Reduced motion** — any user with `prefers-reduced-motion: reduce` gets `.01ms` animation/transition durations across the app.

## Test plan
- [x] `pnpm run build` — **exit 0**
- [x] No `ignoreBuildErrors` bypass
- [x] `<html suppressHydrationWarning>` already in place from prior PRs so React doesn't warn about the pre-paint class delta
- [ ] Manual smoke after deploy — toggle flips palette; localStorage persists across reloads; first visit honours OS dark preference; no flash of wrong theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)