### PR TITLE
[ATLAS] feat(frontend): A5 mobile chrome — bottom nav + mobile topbar + table→card transform

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -206,6 +206,43 @@
 }
 
 /* =================================================
+   A5c — MOBILE TABLE → CARD TRANSFORM
+   Apply `.mobile-card-table` to a <table>; on <md viewports its
+   <thead> hides, each <tr> becomes a stacked card, and each <td>
+   stacks vertically with optional data-label callouts.
+   Reference: /demo lines 736-749 (.pipe-table mobile rules).
+   ================================================= */
+@media (max-width: 767px) {
+  .mobile-card-table { display: block; width: 100%; }
+  .mobile-card-table thead { display: none; }
+  .mobile-card-table tbody { display: block; }
+  .mobile-card-table tr {
+    display: block;
+    background: var(--panel-bg);
+    border: 1px solid var(--rule);
+    border-radius: 10px;
+    margin-bottom: 10px;
+    padding: 14px 16px;
+  }
+  .mobile-card-table td {
+    display: block;
+    padding: 4px 0;
+    border: 0 !important;
+    text-align: left !important;
+  }
+  /* Optional data-label hint shown before each cell on mobile */
+  .mobile-card-table td[data-label]::before {
+    content: attr(data-label) " · ";
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    margin-right: 6px;
+  }
+}
+
+/* =================================================
    TIER SYSTEM (Amber-based)
    ================================================= */
 .tier-hot {

--- a/frontend/components/dashboard/PipelineTable.tsx
+++ b/frontend/components/dashboard/PipelineTable.tsx
@@ -84,8 +84,8 @@ export function PipelineTable({ prospects, onOpen, isLoading }: Props) {
   }, [prospects, sortKey, dir]);
 
   return (
-    <div className="overflow-x-auto bg-gray-900 border border-gray-800 rounded-xl">
-      <table className="w-full text-sm">
+    <div className="md:overflow-x-auto md:bg-gray-900 md:border md:border-gray-800 md:rounded-xl">
+      <table className="w-full text-sm mobile-card-table">
         <thead className="border-b border-gray-800">
           <tr>
             <HeaderCell label="Prospect"   sortKey="name"         active={sortKey} dir={dir} onClick={handleSort} />

--- a/frontend/components/layout/bottom-nav.tsx
+++ b/frontend/components/layout/bottom-nav.tsx
@@ -1,0 +1,78 @@
+/**
+ * FILE: frontend/components/layout/bottom-nav.tsx
+ * PURPOSE: Fixed-bottom mobile navigation — 5 thumb-reach destinations.
+ *          Mobile-only (md:hidden); desktop uses the left sidebar.
+ * REFERENCE: dashboard-master-agency-desk.html — `.bottomnav` block at
+ *            lines ~845 and the `--bottomnav-h` (60px) layout token.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Home, BarChart3, Calendar, List, Settings as SettingsIcon,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+const ITEMS: NavItem[] = [
+  { href: "/dashboard",          label: "Home",     icon: Home },
+  { href: "/dashboard/pipeline", label: "Pipeline", icon: BarChart3 },
+  { href: "/dashboard/meetings", label: "Meetings", icon: Calendar },
+  { href: "/dashboard/activity", label: "Feed",     icon: List },
+  { href: "/dashboard/settings", label: "Settings", icon: SettingsIcon },
+];
+
+function isActive(pathname: string, href: string): boolean {
+  if (href === "/dashboard") return pathname === "/dashboard";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function BottomNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Mobile navigation"
+      className="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-panel border-t border-rule"
+      style={{ height: "var(--bottomnav-h)" }}
+    >
+      <ul className="grid grid-cols-5 h-full">
+        {ITEMS.map(item => {
+          const active = isActive(pathname, item.href);
+          const Icon = item.icon;
+          return (
+            <li key={item.href} className="relative">
+              <Link
+                href={item.href}
+                className={cn(
+                  "h-full flex flex-col items-center justify-center gap-0.5 transition-colors",
+                  active ? "text-amber" : "text-ink-3 hover:text-ink",
+                )}
+                aria-current={active ? "page" : undefined}
+              >
+                {active && (
+                  <span
+                    aria-hidden
+                    className="absolute top-0 left-1/2 -translate-x-1/2 w-8 h-[2px] rounded-b-[2px] bg-amber"
+                  />
+                )}
+                <Icon className="w-5 h-5" strokeWidth={active ? 2 : 1.6} />
+                <span className="font-mono text-[9px] tracking-[0.06em] uppercase">
+                  {item.label}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/components/layout/dashboard-layout.tsx
+++ b/frontend/components/layout/dashboard-layout.tsx
@@ -1,12 +1,13 @@
 /**
  * FILE: frontend/components/layout/dashboard-layout.tsx
- * PURPOSE: Main dashboard layout wrapper
- * PHASE: 8 (Frontend)
- * TASK: FE-004
- * UPDATED: 2026-04-30 — mobile-responsive shell. Sidebar now collapses
- *          to an off-canvas drawer on <md viewports; Header gains a
- *          hamburger button. State lifted here (now a client component)
- *          so Sidebar + Header share open/close.
+ * PURPOSE: Main dashboard layout wrapper.
+ * UPDATED:
+ *   2026-04-30 — mobile-responsive shell (#452): Sidebar drawer + Header
+ *                hamburger.
+ *   2026-04-30 — A5 mobile chrome (this PR): mobile topbar (52px,
+ *                replaces desktop Header on <md), bottom nav (60px,
+ *                fixed bottom md:hidden), content padding adjusts so
+ *                neither bar occludes the page.
  */
 
 "use client";
@@ -15,6 +16,8 @@ import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { Sidebar } from "./sidebar";
 import { Header } from "./header";
+import { MobileTopbar } from "./mobile-topbar";
+import { BottomNav } from "./bottom-nav";
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
@@ -28,16 +31,16 @@ interface DashboardLayoutProps {
     name: string;
     tier: string;
     creditsRemaining: number;
-    // Phase H, Item 43: Emergency pause status
     pausedAt?: string | null;
     pauseReason?: string | null;
   };
 }
 
 export function DashboardLayout({ children, user, client }: DashboardLayoutProps) {
-  // Mobile drawer state. Defaults closed; opened by the Header
-  // hamburger; closed by the Sidebar X button, the backdrop, or any
-  // nav-link click. Always closed on route change.
+  // Mobile drawer state. Defaults closed; opened by either the desktop
+  // Header hamburger or the MobileTopbar hamburger; closed by the
+  // Sidebar X button, the backdrop, or any nav-link click. Always
+  // closed on route change.
   const [mobileOpen, setMobileOpen] = useState(false);
   const pathname = usePathname();
   useEffect(() => { setMobileOpen(false); }, [pathname]);
@@ -57,9 +60,19 @@ export function DashboardLayout({ children, user, client }: DashboardLayoutProps
     <div className="min-h-screen bg-cream text-ink">
       <Sidebar open={mobileOpen} onClose={() => setMobileOpen(false)} />
 
-      {/* Right column. On mobile the sidebar is off-canvas → no left
-          padding; on md+ it's fixed at 232px → reserve space. */}
-      <div className="md:pl-sidebar flex min-h-screen flex-col">
+      {/* Mobile-only topbar — replaces the desktop Header on <md */}
+      <MobileTopbar
+        onOpenMenu={() => setMobileOpen(true)}
+        client={client?.id
+          ? { id: client.id, pausedAt: client.pausedAt, pauseReason: client.pauseReason }
+          : undefined}
+      />
+
+      {/* Right column. Mobile: no left pad (sidebar off-canvas), bottom
+          padding reserves space for the BottomNav (60px) so content
+          isn't hidden behind it. md+: 232px sidebar reservation, no
+          bottom nav, no extra bottom pad. */}
+      <div className="md:pl-sidebar flex min-h-screen flex-col pb-[var(--bottomnav-h)] md:pb-0">
         <Header
           user={user}
           client={client}
@@ -69,6 +82,9 @@ export function DashboardLayout({ children, user, client }: DashboardLayoutProps
           <div className="mx-auto w-full max-w-[1280px]">{children}</div>
         </main>
       </div>
+
+      {/* Mobile-only bottom navigation */}
+      <BottomNav />
     </div>
   );
 }

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -64,7 +64,7 @@ export function Header({ title = "Dashboard", user, client, onOpenMenu }: Header
 
   return (
     <header
-      className="sticky top-0 z-40 flex h-topbar items-center justify-between border-b border-rule px-6"
+      className="hidden md:flex sticky top-0 z-40 h-topbar items-center justify-between border-b border-rule px-6"
       style={{
         // Cream + blur (matches prototype #topbar but on cream backdrop)
         backgroundColor: "rgba(247, 243, 238, 0.85)",

--- a/frontend/components/layout/mobile-topbar.tsx
+++ b/frontend/components/layout/mobile-topbar.tsx
@@ -1,0 +1,108 @@
+/**
+ * FILE: frontend/components/layout/mobile-topbar.tsx
+ * PURPOSE: Compact 52px topbar for <md viewports. Replaces the desktop
+ *          Header on mobile.
+ *          Contains: hamburger (opens sidebar drawer) · AgencyOS brand
+ *          mark · theme toggle · compact pause button.
+ * REFERENCE: dashboard-master-agency-desk.html — `#mobile-topbar` block
+ *            lines ~787-793 and the `--topbar-h` token (52px on mobile,
+ *            56px desktop).
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { Menu, Sun, Moon } from "lucide-react";
+import { EmergencyPauseButton } from "@/components/dashboard/EmergencyPauseButton";
+
+const THEME_KEY = "agencyos_theme";
+
+interface Props {
+  onOpenMenu: () => void;
+  client?: {
+    id: string;
+    pausedAt?: string | null;
+    pauseReason?: string | null;
+  };
+}
+
+/**
+ * Self-contained theme toggle so this PR doesn't depend on the A2
+ * `theme-toggle.tsx` PR landing first. Mirrors the same localStorage
+ * key (`agencyos_theme`) so the two implementations stay compatible.
+ */
+function useThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setIsDark(document.documentElement.classList.contains("dark"));
+    }
+  }, []);
+  const toggle = () => {
+    if (typeof document === "undefined") return;
+    const next = !isDark;
+    document.documentElement.classList.toggle("dark", next);
+    try { localStorage.setItem(THEME_KEY, next ? "dark" : "light"); } catch {}
+    setIsDark(next);
+  };
+  return { isDark, toggle };
+}
+
+export function MobileTopbar({ onOpenMenu, client }: Props) {
+  const { isDark, toggle } = useThemeToggle();
+  const [isPaused, setIsPaused] = useState(!!client?.pausedAt);
+
+  return (
+    <header
+      className="md:hidden sticky top-0 z-40 flex items-center justify-between px-3 border-b border-rule"
+      style={{
+        height: "52px",
+        backgroundColor: "rgba(247, 243, 238, 0.85)",
+        backdropFilter: "saturate(140%) blur(8px)",
+        WebkitBackdropFilter: "saturate(140%) blur(8px)",
+      }}
+    >
+      {/* Left: hamburger + logo */}
+      <div className="flex items-center gap-2 min-w-0">
+        <button
+          type="button"
+          onClick={onOpenMenu}
+          aria-label="Open navigation"
+          className="-ml-1 p-2 rounded-md text-ink hover:bg-rule transition-colors"
+        >
+          <Menu className="w-5 h-5" />
+        </button>
+        <div className="font-display font-bold text-[16px] tracking-[-0.01em] text-ink whitespace-nowrap">
+          Agency<em className="text-amber" style={{ fontStyle: "italic" }}>OS</em>
+        </div>
+      </div>
+
+      {/* Right: theme toggle + compact pause */}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
+          title={isDark ? "Switch to light theme" : "Switch to dark theme"}
+          className="grid place-items-center w-8 h-8 rounded-full border border-rule text-ink-3 hover:text-amber hover:border-amber transition-colors"
+        >
+          {isDark
+            ? <Moon className="w-4 h-4" strokeWidth={1.6} />
+            : <Sun  className="w-4 h-4" strokeWidth={1.6} />}
+        </button>
+
+        {client?.id && (
+          <div className="scale-90 origin-right">
+            <EmergencyPauseButton
+              clientId={client.id}
+              isPaused={isPaused}
+              pausedAt={client.pausedAt}
+              pauseReason={client.pauseReason}
+              onPauseChange={setIsPaused}
+            />
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
Last Phase-1 mobile dispatch — three sub-deliverables shipped together because they all share the same `dashboard-layout.tsx` integration point. After this PR, a 375px viewport gets a thumb-reach BottomNav + compact MobileTopbar + card-stacked tables, while desktop renders byte-identical to the prior layout.

## A5a — BottomNav (NEW `components/layout/bottom-nav.tsx`)
| Property | Value |
|---|---|
| Visibility | `md:hidden` |
| Position | `fixed bottom-0 left-0 right-0` |
| Height | `var(--bottomnav-h)` (60px) |
| Items | Home / Pipeline / Meetings / Feed / Settings |
| Active | Amber underline indicator + amber icon/label |
| Icons | lucide-react: `Home`, `BarChart3`, `Calendar`, `List`, `Settings` |
| A11y | `aria-current="page"` on active |

## A5b — MobileTopbar (NEW `components/layout/mobile-topbar.tsx`)
- Sticky 52px topbar, `md:hidden`, cream-blur backdrop
- **Hamburger** → opens sidebar drawer (same state as desktop Header hamburger)
- **AgencyOS** brand mark (Playfair, amber italic OS accent)
- **Theme toggle** (sun/moon) — self-contained mini-component using the same `agencyos_theme` localStorage key as the A2 theme-toggle PR, so the two implementations stay compatible without import coupling
- **EmergencyPauseButton** — scaled to 90% so it fits the 52px row; only renders when `client.id` is provided

## A5c — Table → Card transform (`globals.css`)
New `@media (max-width: 767px)` block adds `.mobile-card-table` utility:
```css
.mobile-card-table thead { display: none; }
.mobile-card-table tr {
  display: block;
  background: var(--panel-bg);
  border: 1px solid var(--rule);
  border-radius: 10px;
  margin-bottom: 10px;
  padding: 14px 16px;
}
.mobile-card-table td[data-label]::before {
  content: attr(data-label) " · ";
  /* mono uppercase ink-3 callout */
}
```
Applied to `PipelineTable.tsx` — outer wrapper's `overflow-x-auto bg-gray-900 border border-gray-800 rounded-xl` classes also gated to `md:` so mobile gets a clean cream card stack with no horizontal scrollbar.

## Layout integration (`dashboard-layout.tsx`)
- `<MobileTopbar onOpenMenu=…>` rendered above the right column (md:hidden)
- Desktop `<Header>` switched to `hidden md:flex`
- `<BottomNav />` rendered at the end of the layout root (md:hidden)
- Right column gets `pb-[var(--bottomnav-h)] md:pb-0` so content isn't occluded by the 60px bottom bar on mobile
- Single `mobileOpen` drawer state still — both hamburgers fire the same callback

## Test plan
- [x] `pnpm run build` — **exit 0**
- [x] No `ignoreBuildErrors` bypass
- [ ] Manual smoke at 375px:
      • MobileTopbar visible, BottomNav visible, content sandwiched without occlusion
      • Either hamburger opens the sidebar drawer
      • Theme toggle flips `html.dark`
      • Pause button renders if a tenant client is loaded
      • PipelineTable rows stack as cards (no horizontal scroll)
- [ ] Manual smoke at 768px+:
      • Original desktop layout — sticky 56px Header, no BottomNav, no MobileTopbar
      • PipelineTable renders as a normal table with overflow-x-auto

🤖 Generated with [Claude Code](https://claude.com/claude-code)