### PR TITLE
[ATLAS] feat(frontend): P3 items 2+1 — DAY N/30 cycle indicator + PauseAllButton consolidation

### DIFF
--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -16,7 +16,9 @@ import { redirect } from "next/navigation";
 import { getCurrentUser, getUserMemberships } from "@/lib/supabase-server";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { createServerClient } from "@/lib/supabase-server";
-import { KillSwitch } from "@/components/dashboard/KillSwitch";
+// KillSwitch consolidated into PauseAllButton (P3) — pause action now
+// lives in the topbar (Header + MobileTopbar) instead of as a fixed-
+// position floater. Import + render removed in this PR.
 import { DashboardNav } from "@/components/dashboard/DashboardNav";
 import { DemoModeBanner } from "@/components/dashboard/DemoModeBanner";
 
@@ -85,7 +87,6 @@ export default async function DashboardRootLayout({
     return (
       <DashboardLayout user={userData} client={clientDataForLayout}>
         <DemoModeBanner />
-        <KillSwitch />
         <div className="flex min-h-screen">
           <DashboardNav />
           <div className="flex-1 min-w-0 pt-14 md:pt-0">{children}</div>
@@ -166,7 +167,6 @@ export default async function DashboardRootLayout({
   return (
     <DashboardLayout user={userData} client={clientDataForLayout}>
       <DemoModeBanner />
-      <KillSwitch />
       <div className="flex min-h-screen">
         <DashboardNav />
         <div className="flex-1 min-w-0 pt-14 md:pt-0">{children}</div>

--- a/frontend/components/layout/cycle-indicator.tsx
+++ b/frontend/components/layout/cycle-indicator.tsx
@@ -1,0 +1,84 @@
+/**
+ * FILE: frontend/components/layout/cycle-indicator.tsx
+ * PURPOSE: "MAYA · DAY N/30" topbar indicator with pulsing amber dot.
+ * REFERENCE: dashboard-master-agency-desk.html line 782 —
+ *            <span class="tb-cycle"><span class="tb-dot"></span>
+ *              MAYA · DAY 14/30
+ *            </span>
+ * USAGE:    Desktop header right-cluster + mobile topbar.
+ *
+ * Day count is derived from the calendar day-of-month modulo 30 — a
+ * stand-in for a real `cycle_day` field on the metrics endpoint. When
+ * the backend exposes a real cycle origin, swap the calendar fallback
+ * for the live value (TODO(api) flagged below).
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+const CYCLE_LENGTH_DAYS = 30;
+
+function calendarCycleDay(): number {
+  // TODO(api): replace with metrics.cycle_day once the dashboard
+  // endpoint exposes it. Today = day-of-month, capped at 30.
+  const today = new Date();
+  const dayOfMonth = today.getDate();
+  return Math.min(CYCLE_LENGTH_DAYS, Math.max(1, dayOfMonth));
+}
+
+interface Props {
+  /** Optional override for tests / Storybook. */
+  day?: number;
+  /** Total cycle length. Defaults to 30. */
+  total?: number;
+  /** Compact mode (mobile topbar) — hides the "MAYA · " prefix. */
+  compact?: boolean;
+  className?: string;
+}
+
+export function CycleIndicator({
+  day, total = CYCLE_LENGTH_DAYS, compact = false, className,
+}: Props) {
+  // Hydration-safe: SSR renders a placeholder, client computes the
+  // real day after mount so React doesn't error on a Date mismatch.
+  const [resolvedDay, setResolvedDay] = useState<number | null>(day ?? null);
+  useEffect(() => {
+    if (day === undefined) setResolvedDay(calendarCycleDay());
+  }, [day]);
+
+  const labelDay = resolvedDay ?? "—";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-2 font-mono text-[11px] tracking-[0.06em] text-ink-3",
+        className,
+      )}
+      aria-label={`Maya cycle day ${labelDay} of ${total}`}
+      title={`Maya cycle · day ${labelDay} of ${total}`}
+    >
+      {/* Pulsing amber dot — matches /demo's .tb-dot */}
+      <span className="relative inline-flex w-[7px] h-[7px]">
+        <span
+          aria-hidden
+          className="absolute inset-0 rounded-full opacity-60 animate-ping"
+          style={{ backgroundColor: "var(--amber)" }}
+        />
+        <span
+          aria-hidden
+          className="relative inline-flex w-[7px] h-[7px] rounded-full"
+          style={{
+            backgroundColor: "var(--amber)",
+            boxShadow: "0 0 0 3px rgba(212,149,106,0.18)",
+          }}
+        />
+      </span>
+      <span className="whitespace-nowrap">
+        {compact ? "" : <span className="font-semibold">MAYA · </span>}
+        DAY {labelDay}/{total}
+      </span>
+    </span>
+  );
+}

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -27,7 +27,9 @@ import { useRouter } from "next/navigation";
 import { getInitials, getAvatarColor } from "@/lib/utils";
 import { CreditsBadge } from "./credits-badge";
 import { ThemeToggle } from "./theme-toggle";
-import { EmergencyPauseButton } from "@/components/dashboard/EmergencyPauseButton";
+// P3 — consolidated pause + cycle indicators
+import { PauseAllButton } from "./pause-all-button";
+import { CycleIndicator } from "./cycle-indicator";
 
 interface HeaderProps {
   title?: string;
@@ -122,16 +124,17 @@ export function Header({ title = "Dashboard", user, client, onOpenMenu }: Header
 
       {/* Right side */}
       <div className="flex items-center gap-3">
-        {/* Emergency Pause Button */}
-        {client?.id && (
-          <EmergencyPauseButton
-            clientId={client.id}
-            isPaused={isPaused}
-            pausedAt={client.pausedAt}
-            pauseReason={client.pauseReason}
-            onPauseChange={setIsPaused}
-          />
-        )}
+        {/* Cycle indicator — MAYA · DAY N/30 with pulsing amber dot */}
+        <CycleIndicator className="hidden lg:inline-flex" />
+
+        {/* Consolidated Pause-all (replaces EmergencyPauseButton) */}
+        <PauseAllButton
+          clientId={client?.id}
+          isPaused={isPaused}
+          pausedAt={client?.pausedAt}
+          pauseReason={client?.pauseReason}
+          onPauseChange={setIsPaused}
+        />
 
         {/* Theme toggle (sun ↔ moon) — A2 dark-mode dispatch */}
         <ThemeToggle />

--- a/frontend/components/layout/mobile-topbar.tsx
+++ b/frontend/components/layout/mobile-topbar.tsx
@@ -13,7 +13,9 @@
 
 import { useEffect, useState } from "react";
 import { Menu, Sun, Moon } from "lucide-react";
-import { EmergencyPauseButton } from "@/components/dashboard/EmergencyPauseButton";
+// P3 — consolidated pause + cycle indicator (replaces EmergencyPauseButton)
+import { PauseAllButton } from "./pause-all-button";
+import { CycleIndicator } from "./cycle-indicator";
 
 const THEME_KEY = "agencyos_theme";
 
@@ -62,7 +64,7 @@ export function MobileTopbar({ onOpenMenu, client }: Props) {
         WebkitBackdropFilter: "saturate(140%) blur(8px)",
       }}
     >
-      {/* Left: hamburger + logo */}
+      {/* Left: hamburger + logo + compact cycle pill */}
       <div className="flex items-center gap-2 min-w-0">
         <button
           type="button"
@@ -75,6 +77,8 @@ export function MobileTopbar({ onOpenMenu, client }: Props) {
         <div className="font-display font-bold text-[16px] tracking-[-0.01em] text-ink whitespace-nowrap">
           Agency<em className="text-amber" style={{ fontStyle: "italic" }}>OS</em>
         </div>
+        {/* Compact cycle indicator — DAY N/30 with pulsing dot, MAYA prefix dropped */}
+        <CycleIndicator compact className="hidden xs:inline-flex sm:inline-flex" />
       </div>
 
       {/* Right: theme toggle + compact pause */}
@@ -91,17 +95,14 @@ export function MobileTopbar({ onOpenMenu, client }: Props) {
             : <Sun  className="w-4 h-4" strokeWidth={1.6} />}
         </button>
 
-        {client?.id && (
-          <div className="scale-90 origin-right">
-            <EmergencyPauseButton
-              clientId={client.id}
-              isPaused={isPaused}
-              pausedAt={client.pausedAt}
-              pauseReason={client.pauseReason}
-              onPauseChange={setIsPaused}
-            />
-          </div>
-        )}
+        <PauseAllButton
+          clientId={client?.id}
+          isPaused={isPaused}
+          pausedAt={client?.pausedAt}
+          pauseReason={client?.pauseReason}
+          onPauseChange={setIsPaused}
+          compact
+        />
       </div>
     </header>
   );

--- a/frontend/components/layout/pause-all-button.tsx
+++ b/frontend/components/layout/pause-all-button.tsx
@@ -1,0 +1,204 @@
+/**
+ * FILE: frontend/components/layout/pause-all-button.tsx
+ * PURPOSE: Consolidated "Pause all" button for the topbar — replaces
+ *          KillSwitch.tsx + EmergencyPauseButton.tsx + (in-topbar use of)
+ *          PauseCycleButton.tsx with one component.
+ * REFERENCE: dashboard-master-agency-desk.html line 784 —
+ *            <button class="kill-btn">⏸ Pause all</button>
+ *
+ * Behaviour:
+ *   - Idle  → "⏸ Pause all" pill, hover amber
+ *   - Click → confirm dialog → POST /api/v1/clients/{id}/pause-all
+ *             via lib/api/campaigns.emergencyPauseAll (existing helper
+ *             that the old EmergencyPauseButton already used — kept
+ *             so backend semantics don't change)
+ *   - Paused state → "⏵ Resume" pill (amber accent)
+ *   - Mobile prop scales padding + hides the verb so it stays compact
+ *     in the 52px MobileTopbar
+ *
+ * Auth: relies on the auth cookie via `credentials: 'include'` inside
+ * the lib/api/campaigns helpers — no per-call auth wiring needed.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { Pause, Play } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { emergencyPauseAll, resumeAllOutreach } from "@/lib/api/campaigns";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  /** Tenant client ID — required to scope the pause-all call. When
+   *  undefined, the button renders disabled with a "no tenant" tooltip
+   *  so demo / pre-login views don't crash. */
+  clientId?: string;
+  /** Initial paused state from server. */
+  isPaused?: boolean;
+  /** Optional ISO timestamp for tooltip context when paused. */
+  pausedAt?: string | null;
+  /** Optional reason from the prior pause action. */
+  pauseReason?: string | null;
+  /** Compact variant for the 52px mobile topbar. */
+  compact?: boolean;
+  /** Callback after successful state change. */
+  onPauseChange?: (paused: boolean) => void;
+}
+
+export function PauseAllButton({
+  clientId,
+  isPaused = false,
+  pausedAt,
+  pauseReason,
+  compact = false,
+  onPauseChange,
+}: Props) {
+  const [paused, setPaused] = useState<boolean>(isPaused);
+  const [reason, setReason] = useState("");
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const { toast } = useToast();
+
+  const handleConfirmPause = async () => {
+    if (!clientId) return;
+    setBusy(true);
+    try {
+      await emergencyPauseAll(clientId, reason || "Pause all (operator)");
+      setPaused(true);
+      onPauseChange?.(true);
+      toast({
+        title: "All outreach paused",
+        description: "Maya will not send anything until you resume.",
+      });
+      setOpen(false);
+      setReason("");
+    } catch (err) {
+      toast({
+        title: "Pause failed",
+        description: err instanceof Error ? err.message : "Try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleResume = async () => {
+    if (!clientId) return;
+    setBusy(true);
+    try {
+      await resumeAllOutreach(clientId);
+      setPaused(false);
+      onPauseChange?.(false);
+      toast({
+        title: "Outreach resumed",
+        description: "Maya is back to work.",
+      });
+    } catch (err) {
+      toast({
+        title: "Resume failed",
+        description: err instanceof Error ? err.message : "Try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // ─── Resume pill (paused state) ─────────────────────────────────
+  if (paused) {
+    return (
+      <button
+        type="button"
+        disabled={busy || !clientId}
+        onClick={handleResume}
+        title={pauseReason ? `Paused${pausedAt ? ` at ${new Date(pausedAt).toLocaleString()}` : ""}: ${pauseReason}` : undefined}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-[6px]",
+          "font-mono uppercase font-semibold tracking-[0.08em]",
+          "bg-amber text-on-amber border border-amber",
+          "hover:opacity-90 disabled:opacity-50 transition-opacity",
+          compact ? "px-2.5 py-1 text-[10px]" : "px-3 py-1.5 text-[11px]",
+        )}
+      >
+        <Play className={compact ? "w-3 h-3" : "w-3.5 h-3.5"} />
+        {compact ? "" : "Resume"}
+      </button>
+    );
+  }
+
+  // ─── Pause pill (default state) ─────────────────────────────────
+  return (
+    <>
+      <button
+        type="button"
+        disabled={busy || !clientId}
+        onClick={() => setOpen(true)}
+        title={!clientId ? "No tenant context — sign in to pause." : undefined}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-[6px]",
+          "font-mono uppercase tracking-[0.08em]",
+          "bg-transparent text-ink-2 border border-rule",
+          "hover:text-red hover:border-red transition-colors",
+          "disabled:opacity-40 disabled:cursor-not-allowed",
+          compact ? "px-2.5 py-1 text-[10px]" : "px-3 py-1.5 text-[11px] font-semibold",
+        )}
+      >
+        <Pause className={compact ? "w-3 h-3" : "w-3.5 h-3.5"} />
+        {compact ? "" : "Pause all"}
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="font-display font-bold text-[20px] text-ink">
+              Pause <em className="text-amber" style={{ fontStyle: "italic" }}>all</em> outreach?
+            </DialogTitle>
+            <DialogDescription className="text-[13px] text-ink-2 leading-relaxed mt-1">
+              Maya will stop sending email, LinkedIn, voice, and SMS for
+              every campaign on this account until you resume. Existing
+              scheduled touches will not fire.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2 mt-2">
+            <Label htmlFor="pause-reason" className="font-mono text-[10px] tracking-[0.14em] uppercase text-ink-3">
+              Reason (optional)
+            </Label>
+            <Textarea
+              id="pause-reason"
+              placeholder="e.g. legal review, customer renegotiation, holiday freeze"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={3}
+            />
+          </div>
+
+          <DialogFooter className="gap-2 mt-2">
+            <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleConfirmPause}
+              disabled={busy}
+            >
+              {busy ? "Pausing…" : "Pause all"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Two related dashboard chrome items in one PR per dispatch.

## Audit findings (R7 done first)
Three pause components on main with three different scopes:

| Component | Scope | Endpoint |
|---|---|---|
| `KillSwitch.tsx` | Fixed-position global outreach toggle | `POST /api/v1/outreach/kill-switch` |
| `EmergencyPauseButton.tsx` | Per-client pause dialog | `emergencyPauseAll(clientId)` → `/api/v1/clients/{id}/pause-all` |
| `PauseCycleButton.tsx` | Per-cycle pause | `PATCH /api/v1/clients/{id}/cycles/{cycleId}/{pause\|resume}` |

`PauseCycleButton` lives in `DashboardNav` and addresses cycle-specific pause — **left untouched** because it's a different action surface than "pause all outreach". The consolidation merges the first two into one component.

## ITEM 2 — `CycleIndicator`
**`components/layout/cycle-indicator.tsx`** (NEW) — matches /demo's line 782:
```jsx
<span class="tb-cycle">
  <span class="tb-dot"></span>MAYA · DAY 14/30
</span>
```
- Pulsing amber dot (`animate-ping` + matching box-shadow ring per /demo's `--amber` rgba)
- Hydration-safe: SSR renders `—`, `useEffect` computes the live day after mount
- `compact` prop drops the `MAYA · ` prefix so the indicator fits the 52px MobileTopbar
- `TODO(api)`: day derived from calendar day-of-month until backend exposes a real `cycle_day` field

## ITEM 1 — `PauseAllButton`
**`components/layout/pause-all-button.tsx`** (NEW) — replaces `KillSwitch` + `EmergencyPauseButton` in the topbar.

| State | Visual |
|---|---|
| Idle | `⏸ Pause all` mono-uppercase pill, hover red |
| Paused | `⏵ Resume` amber-filled pill |

- Click → confirm dialog with optional reason textarea
- POSTs via existing `emergencyPauseAll(clientId, reason)` from `lib/api/campaigns` — **same backend endpoint as the prior `EmergencyPauseButton`, no behavioural change**
- `compact` prop scales padding + drops the verb so it fits the 52px mobile topbar

## Wire-up
| File | Change |
|---|---|
| `components/layout/header.tsx` | Imports `PauseAllButton` + `CycleIndicator`; replaces `<EmergencyPauseButton>` in right cluster; cycle indicator gated `hidden lg:inline-flex` to preserve tablet width budget |
| `components/layout/mobile-topbar.tsx` | Imports `PauseAllButton` + `CycleIndicator`; left cluster gets `<CycleIndicator compact />`; right cluster swaps `<EmergencyPauseButton>` → `<PauseAllButton compact />` |
| `app/dashboard/layout.tsx` | `<KillSwitch />` removed from both render paths (demo + auth). Fixed-position pause floater retired in favour of the topbar pause |

## Files NOT touched (intentional)
- `components/dashboard/KillSwitch.tsx` — left in place; no longer imported. Future cleanup can delete once we confirm no other surface uses it
- `components/dashboard/EmergencyPauseButton.tsx` — same rationale
- `components/dashboard/PauseCycleButton.tsx` — different action (per-cycle PATCH); used in `DashboardNav` for cycle-specific UX

## Test plan
- [x] `pnpm run build` — **exit 0**
- [x] No `ignoreBuildErrors` bypass
- [x] Backend pause endpoint unchanged (still `emergencyPauseAll` helper)
- [ ] Manual smoke after deploy:
      • Desktop header shows `MAYA · DAY N/30` pill on `lg+` viewports
      • Mobile topbar shows `DAY N/30` (compact, no MAYA prefix)
      • Click `⏸ Pause all` → dialog opens with reason textarea
      • Confirm → button flips to `⏵ Resume` amber pill, toast confirms
      • Click resume → flips back, toast confirms
      • Mobile compact button shows icons-only at 52px row height

🤖 Generated with [Claude Code](https://claude.com/claude-code)