### PR TITLE
[ATLAS] feat(frontend): B2.1 visual parity — pipeline kanban + table rebrand to /demo

### DIFF
--- a/docs/B2_VISUAL_PARITY_AUDIT.md
+++ b/docs/B2_VISUAL_PARITY_AUDIT.md
@@ -1,0 +1,97 @@
+# B2.1 visual parity — R7 audit log (2026-04-30)
+
+Audit performed before any code changes per dispatch.
+
+## Sub-task 1 — `/welcome` smoke test
+Verified — no changes needed.
+
+PR #461 (A7.1) restored the full 862-line founding-member welcome
+page from origin/main and migrated its local CSS-var redefinitions
+of `--cream / --ink / --amber / --rule` to read from `globals.css`,
+so the page now uses the same token system as the rest of the app
+and inverts under `html.dark`. Demo-cookie short-circuit also
+verified. Spot-check of class names (`hero-h1`, `confirm-badge`,
+`btn-primary`) confirms the prototype's structure intact.
+
+## Sub-task 2 — `/(auth)/login` + `/(auth)/signup` smoke test
+Verified — no changes needed.
+
+PR #460 (A6) repalleted both pages: cream rounded panel, Playfair
+"Welcome back" / "Create your account" headlines with amber italic
+emphasis, JetBrains Mono uppercase labels, cream-bg mono inputs
+with `focus:border-amber focus:ring-amber/40`, ink primary button,
+cream Google secondary, copper hover for sub-links. `(auth)/layout
+.tsx` carries the AgencyOS brand mark + "Try the demo →" footer.
+Auth logic (Supabase `signInWithPassword` / `signUp`) byte-
+identical to pre-A6.
+
+## Sub-task 3 — `/dashboard/pipeline` rebrand
+Gap found. Two components still on the dark Bloomberg theme:
+
+### `PipelineKanban.tsx`
+Was 6 columns (discovered/enriched/contacted/replied/meeting/
+converted) with `bg-gray-900 border-gray-800` panels and dark cards.
+**Migrated** to the prototype's 5-column structure (PIPE_COLS lines
+1735-1745):
+
+| Column | Stage(s) merged | Top accent (`.col-*-head::before`) |
+|---|---|---|
+| **New** | `discovered` + `enriched` | `var(--ink-3)` |
+| **Contacted** | `contacted` | `var(--blue)` |
+| **Replied** | `replied` | `var(--amber)` |
+| **Meeting** | `meeting` | `var(--green)` |
+| **Won** | `converted` | `var(--copper)` |
+
+Cards translated to /demo's `.k-card` pattern:
+- `bg-panel border border-rule` cream card
+- 3px left border in the column's accent colour
+- Playfair font-bold 14px name (Company name when present, falls
+  back to lead name)
+- DM-name body in `text-ink-2`
+- JetBrains Mono `text-[10.5px] text-ink-3` channel · date meta line
+- Foot row: VR grade chip + score in `text-copper`, separated from
+  body by a dashed `border-rule`
+- Hover: `border-amber` + `box-shadow` amber glow per prototype
+- Native HTML5 drag/drop preserved; first stage in a merged column
+  wins on drop (e.g. `discovered` for the New column)
+
+Column header gets the prototype's `top: 0; left/right: 10px;
+height: 3px` accent stripe. Counts shown as `<bg-ink white pill>` +
+`<text-ink-3 percentage>`. Empty column copy: "Empty — awaiting
+prospects".
+
+### `PipelineTable.tsx`
+Was `bg-gray-900` outer panel with `bg-gray-800` headers and
+`text-gray-300/400/500` body text. **Migrated** to:
+- `bg-panel border-rule rounded-[10px]` outer panel
+- `bg-surface border-rule` thead with mono uppercase ink-3 headers
+  and `hover:text-amber` sort indicator
+- `text-ink` row body with Playfair-bold prospect name, `text-ink-2`
+  company/stage, `font-mono text-[11px] text-ink-3` for channel /
+  dates
+- `bg-amber-soft` hover instead of dark grey
+- VR grade chip swapped to the prototype's colour-coded square (A/B
+  green, C amber+on-amber, D copper, F red) — same component pattern
+  as the Kanban cards
+- Each cell gets a `data-label` attr so the mobile-card-table CSS
+  utility from PR #458 displays "Prospect ·", "Stage ·" etc. as
+  cell prefixes when stacked on `<md`
+
+## Verification
+```
+pnpm run build → exit 0
+```
+
+## Files
+- `frontend/components/dashboard/PipelineKanban.tsx` — 6 → 5 columns, /demo `.k-card` pattern
+- `frontend/components/dashboard/PipelineTable.tsx` — cream/amber rebrand + data-label cells
+- `docs/B2_VISUAL_PARITY_AUDIT.md` — this file
+
+## Out of scope (not changed)
+- `app/dashboard/pipeline/page.tsx` — view toggle + filter chips +
+  state tabs already on /demo design from PR #443 + PR #466
+- `PipelineFilters.tsx` — already uses /demo's `.chip` pill pattern
+- `PipelineRow.tsx` (list view) — already on /demo design from PR #443
+- Drawer behaviour — `<ProspectDrawer>` opens on card click
+  (`onOpen(p.id)` → `setActiveLead(id)` → drawer renders), matching
+  the prototype's `openDrawer(pid)` pattern. No change needed

--- a/frontend/components/dashboard/PipelineKanban.tsx
+++ b/frontend/components/dashboard/PipelineKanban.tsx
@@ -1,15 +1,22 @@
 /**
  * FILE: frontend/components/dashboard/PipelineKanban.tsx
- * PURPOSE: Kanban board — 6 stage columns with HTML drag-drop + click-to-open
- * PHASE: PHASE-2.1-PIPELINE-MEETINGS
+ * PURPOSE: Kanban board — 5 stage columns matching /demo's
+ *          PIPE_COLS pattern (lines 1735-1745). Cream/amber palette
+ *          with the prototype's `.k-card` class translated to
+ *          Tailwind tokens.
+ *          B2.1 visual parity (2026-04-30) — was on the dark
+ *          Bloomberg theme; now matches /demo verbatim.
  *
- * Dark theme, Tailwind only. No external DnD library — native HTML5 DnD.
+ * Five columns: Discovered (=New) · Contacted · Replied · Meeting ·
+ * Won. Each column gets a top accent stripe in its stage colour
+ * (matches prototype's `.col-head::before` rule). Cards use the
+ * Playfair name + DM Sans body + JetBrains Mono meta pattern.
+ * Native HTML5 drag/drop preserved.
  */
 
 "use client";
 
 import { useState } from "react";
-import { Mail, Linkedin, Phone, MessageSquare } from "lucide-react";
 import {
   PipelineProspect,
   PipelineStage,
@@ -24,122 +31,196 @@ interface Props {
   isLoading?: boolean;
 }
 
-const COLUMNS: Array<{ key: PipelineStage; label: string }> = [
-  { key: "discovered", label: "Discovered" },
-  { key: "enriched",   label: "Enriched" },
-  { key: "contacted",  label: "Contacted" },
-  { key: "replied",    label: "Replied" },
-  { key: "meeting",    label: "Meeting" },
-  { key: "converted",  label: "Converted" },
+type ColumnKey = "discovered" | "contacted" | "replied" | "meeting" | "won";
+
+interface ColDef {
+  key: ColumnKey;
+  label: string;
+  /** Top accent stripe colour — matches /demo's `.col-*-head::before` */
+  accent: string;
+  /** Stages that map to this column */
+  stages: PipelineStage[];
+}
+
+const COLUMNS: ColDef[] = [
+  { key: "discovered", label: "New",       accent: "var(--ink-3)",  stages: ["discovered", "enriched"] },
+  { key: "contacted",  label: "Contacted", accent: "var(--blue)",   stages: ["contacted"] },
+  { key: "replied",    label: "Replied",   accent: "var(--amber)",  stages: ["replied"] },
+  { key: "meeting",    label: "Meeting",   accent: "var(--green)",  stages: ["meeting"] },
+  { key: "won",        label: "Won",       accent: "var(--copper)", stages: ["converted"] },
 ];
 
-function ChannelGlyph({ channel }: { channel: string | null }) {
-  const label = canonicalChannel(channel ?? "");
-  const Icon =
-    label === "Email"    ? Mail :
-    label === "LinkedIn" ? Linkedin :
-    label === "SMS"      ? MessageSquare :
-    label === "Voice AI" ? Phone :
-    Mail;
-  return (
-    <span
-      className="inline-flex items-center gap-1 text-[10px] text-gray-400 font-mono uppercase"
-      title={label}
-    >
-      <Icon className="w-3 h-3" strokeWidth={1.75} />
-      {label === "Voice AI" ? "Voice" : label}
-    </span>
-  );
+function colCount(
+  counts: Record<PipelineStage, number>,
+  col: ColDef,
+): number {
+  return col.stages.reduce((acc, s) => acc + (counts[s] ?? 0), 0);
 }
 
 function Card({
-  p,
-  onOpen,
-  onDragStart,
+  p, onOpen, onDragStart, accent,
 }: {
   p: PipelineProspect;
   onOpen: (id: string) => void;
   onDragStart: (e: React.DragEvent<HTMLDivElement>, id: string) => void;
+  accent: string;
 }) {
-  const sent = p.lastTouchAt ? new Date(p.lastTouchAt).toLocaleDateString() : "—";
+  const lastTouch = p.lastTouchAt
+    ? new Date(p.lastTouchAt).toLocaleDateString(undefined, {
+        month: "short", day: "numeric",
+      })
+    : null;
+  const channelLabel = p.lastChannel ? canonicalChannel(p.lastChannel) : null;
+
   return (
     <div
       draggable
       onDragStart={(e) => onDragStart(e, p.id)}
       onClick={() => onOpen(p.id)}
-      className="cursor-pointer bg-gray-800 border border-gray-700 rounded-lg p-3 hover:border-amber-500/50 hover:bg-gray-800/70 transition"
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen(p.id);
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      className="cursor-pointer bg-panel border border-rule rounded-[6px] px-4 py-3 hover:border-amber hover:shadow-[0_2px_10px_rgba(212,149,106,0.10)] transition-all leading-[1.4]"
+      style={{ borderLeft: `3px solid ${accent}` }}
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <div className="font-serif text-sm text-gray-100 truncate">{p.name}</div>
-          <div className="text-xs text-gray-400 truncate">{p.company}</div>
-        </div>
-        {p.vrGrade && (
-          <span className="shrink-0 text-[10px] font-mono font-bold px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-300 border border-amber-500/30">
-            {p.vrGrade}
-          </span>
-        )}
+      {/* Name — Playfair */}
+      <div className="font-display font-bold text-[14px] text-ink leading-[1.3] truncate">
+        {p.company || p.name}
       </div>
-      <div className="flex items-center justify-between mt-2">
-        <ChannelGlyph channel={p.lastChannel} />
-        <span className="text-[10px] text-gray-500 font-mono">{sent}</span>
+
+      {/* DM */}
+      {p.name && (
+        <div className="text-[12px] text-ink-2 mt-0.5 truncate">{p.name}</div>
+      )}
+
+      {/* Meta — channel · date */}
+      {(channelLabel || lastTouch) && (
+        <div className="font-mono text-[10.5px] text-ink-3 mt-1 tracking-[0.03em] truncate">
+          {channelLabel}
+          {channelLabel && lastTouch ? " · " : ""}
+          {lastTouch}
+        </div>
+      )}
+
+      {/* Foot — VR grade + score on left, no right slot for now */}
+      <div className="flex justify-between items-center mt-2.5 pt-2 border-t border-dashed border-rule gap-1.5 flex-wrap">
+        <div className="flex items-center gap-1.5 min-w-0">
+          {p.vrGrade && (
+            <span
+              className="font-display font-bold text-[12px] grid place-items-center w-6 h-6 rounded-[5px]"
+              style={{
+                backgroundColor:
+                  p.vrGrade === "A" || p.vrGrade === "B" ? "var(--green)" :
+                  p.vrGrade === "C" ? "var(--amber)" :
+                  p.vrGrade === "D" ? "var(--copper)" :
+                  "var(--red)",
+                color: p.vrGrade === "C" ? "var(--on-amber)" : "white",
+              }}
+            >
+              {p.vrGrade}
+            </span>
+          )}
+          {p.score != null && (
+            <span className="font-mono text-[14px] font-semibold text-copper tabular-nums">
+              {p.score}
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );
 }
 
-export function PipelineKanban({ prospects, counts, onOpen, onMove, isLoading }: Props) {
+export function PipelineKanban({
+  prospects, counts, onOpen, onMove, isLoading,
+}: Props) {
   const [dragId, setDragId] = useState<string | null>(null);
-  const [overCol, setOverCol] = useState<PipelineStage | null>(null);
+  const [overCol, setOverCol] = useState<ColumnKey | null>(null);
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>, id: string) => {
     setDragId(id);
     e.dataTransfer.effectAllowed = "move";
     e.dataTransfer.setData("text/plain", id);
   };
-  const handleDragOver = (e: React.DragEvent<HTMLDivElement>, col: PipelineStage) => {
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>, col: ColumnKey) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = "move";
     setOverCol(col);
   };
-  const handleDrop = (e: React.DragEvent<HTMLDivElement>, to: PipelineStage) => {
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, to: ColumnKey) => {
     e.preventDefault();
     const id = dragId || e.dataTransfer.getData("text/plain");
-    if (id && onMove) onMove(id, to);
+    if (id && onMove) {
+      // First stage in the merged column wins (e.g. "discovered" for New).
+      const target = COLUMNS.find(c => c.key === to);
+      if (target) onMove(id, target.stages[0]);
+    }
     setDragId(null);
     setOverCol(null);
   };
 
+  const total = prospects.length || 1;
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-6 gap-3 overflow-x-auto">
+    <div
+      className="grid gap-3 overflow-x-auto pb-3.5 -mx-1 px-1 snap-x"
+      style={{ gridTemplateColumns: "repeat(5, minmax(260px, 1fr))" }}
+    >
       {COLUMNS.map((col) => {
-        const list = prospects.filter((p) => p.stage === col.key);
+        const list = prospects.filter((p) => col.stages.includes(p.stage));
+        const count = colCount(counts, col);
+        const pct = Math.round((count / total) * 100);
         const active = overCol === col.key;
         return (
           <div
             key={col.key}
             onDragOver={(e) => handleDragOver(e, col.key)}
             onDrop={(e) => handleDrop(e, col.key)}
-            className={`bg-gray-900 border rounded-xl p-3 min-h-[320px] ${
-              active ? "border-amber-500/50 bg-amber-500/5" : "border-gray-800"
+            className={`min-w-0 bg-surface border border-rule rounded-[10px] flex flex-col snap-start ${
+              active ? "border-amber" : ""
             }`}
+            style={{ maxHeight: "calc(100vh - 240px)" }}
           >
-            <div className="flex items-center justify-between mb-3">
-              <span className="font-mono text-[10px] tracking-widest text-gray-400 uppercase">
+            {/* Column head with top accent stripe (matches .col-head::before) */}
+            <div
+              className="px-3.5 py-3 border-b border-rule flex items-center justify-between gap-2.5 bg-panel rounded-t-[10px] relative shrink-0"
+            >
+              <span
+                aria-hidden
+                className="absolute top-0 left-2.5 right-2.5 h-[3px] rounded-b-[3px]"
+                style={{ backgroundColor: col.accent }}
+              />
+              <span className="font-mono text-[10.5px] tracking-[0.14em] uppercase text-ink-2 font-semibold">
                 {col.label}
               </span>
-              <span className="font-mono text-[11px] text-gray-300">
-                {counts[col.key] ?? 0}
+              <span className="inline-flex gap-1.5 font-mono text-[10px] items-center">
+                <span className="bg-ink text-white px-[7px] py-[1px] rounded-[10px] font-semibold">
+                  {count}
+                </span>
+                <span className="text-ink-3">{pct}%</span>
               </span>
             </div>
-            <div className="space-y-2">
+
+            {/* Column body */}
+            <div className="p-2.5 flex flex-col gap-2.5 overflow-y-auto min-h-[80px] flex-1">
               {list.length === 0 ? (
-                <div className="text-[11px] text-gray-600 italic py-4 text-center">
-                  {isLoading ? "Loading…" : "No prospects"}
+                <div className="text-[11.5px] italic text-ink-3 text-center py-4 px-2.5">
+                  {isLoading ? "Loading…" : "Empty — awaiting prospects"}
                 </div>
               ) : (
                 list.map((p) => (
-                  <Card key={p.id} p={p} onOpen={onOpen} onDragStart={handleDragStart} />
+                  <Card
+                    key={p.id}
+                    p={p}
+                    onOpen={onOpen}
+                    onDragStart={handleDragStart}
+                    accent={col.accent}
+                  />
                 ))
               )}
             </div>

--- a/frontend/components/dashboard/PipelineTable.tsx
+++ b/frontend/components/dashboard/PipelineTable.tsx
@@ -60,7 +60,7 @@ function HeaderCell({
   return (
     <th
       onClick={() => onClick(sortKey)}
-      className="text-left px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-gray-400 cursor-pointer select-none hover:text-gray-200"
+      className="text-left px-[18px] py-3.5 font-mono text-[10px] uppercase tracking-[0.12em] text-ink-3 cursor-pointer select-none hover:text-amber bg-surface border-b border-rule font-semibold"
     >
       {label}{is ? (dir === "asc" ? " ↑" : " ↓") : ""}
     </th>
@@ -84,9 +84,9 @@ export function PipelineTable({ prospects, onOpen, isLoading }: Props) {
   }, [prospects, sortKey, dir]);
 
   return (
-    <div className="md:overflow-x-auto md:bg-gray-900 md:border md:border-gray-800 md:rounded-xl">
-      <table className="w-full text-sm mobile-card-table">
-        <thead className="border-b border-gray-800">
+    <div className="md:overflow-x-auto md:bg-panel md:border md:border-rule md:rounded-[10px]">
+      <table className="w-full text-[13px] mobile-card-table">
+        <thead>
           <tr>
             <HeaderCell label="Prospect"   sortKey="name"         active={sortKey} dir={dir} onClick={handleSort} />
             <HeaderCell label="Company"    sortKey="company"      active={sortKey} dir={dir} onClick={handleSort} />
@@ -100,7 +100,7 @@ export function PipelineTable({ prospects, onOpen, isLoading }: Props) {
         <tbody>
           {sorted.length === 0 ? (
             <tr>
-              <td colSpan={7} className="px-3 py-8 text-center text-gray-500 italic">
+              <td colSpan={7} className="px-[18px] py-8 text-center text-ink-3 italic">
                 {isLoading ? "Loading…" : "No prospects yet"}
               </td>
             </tr>
@@ -108,22 +108,35 @@ export function PipelineTable({ prospects, onOpen, isLoading }: Props) {
             <tr
               key={p.id}
               onClick={() => onOpen(p.id)}
-              className="border-b border-gray-800/60 hover:bg-gray-800/60 cursor-pointer"
+              data-label="Row"
+              className="border-b border-rule hover:bg-amber-soft cursor-pointer transition-colors"
             >
-              <td className="px-3 py-2 text-gray-100">{p.name}</td>
-              <td className="px-3 py-2 text-gray-300">{p.company}</td>
-              <td className="px-3 py-2 text-gray-300">{STAGE_LABEL[p.stage]}</td>
-              <td className="px-3 py-2 text-gray-400 font-mono text-xs">
+              <td data-label="Prospect"   className="px-[18px] py-4 font-display font-bold text-[14px] text-ink">
+                {p.name}
+              </td>
+              <td data-label="Company"    className="px-[18px] py-4 text-ink-2">{p.company}</td>
+              <td data-label="Stage"      className="px-[18px] py-4 text-ink-2">{STAGE_LABEL[p.stage]}</td>
+              <td data-label="Channel"    className="px-[18px] py-4 font-mono text-[11px] text-ink-3">
                 {p.lastChannel ? canonicalChannel(p.lastChannel) : "—"}
               </td>
-              <td className="px-3 py-2 text-gray-400 font-mono text-xs">{fmtDate(p.lastTouchAt)}</td>
-              <td className="px-3 py-2 text-gray-400 font-mono text-xs">{fmtDate(p.nextTouchAt)}</td>
-              <td className="px-3 py-2">
+              <td data-label="Last touch" className="px-[18px] py-4 font-mono text-[11px] text-ink-3">{fmtDate(p.lastTouchAt)}</td>
+              <td data-label="Next touch" className="px-[18px] py-4 font-mono text-[11px] text-ink-3">{fmtDate(p.nextTouchAt)}</td>
+              <td data-label="Grade"      className="px-[18px] py-4">
                 {p.vrGrade ? (
-                  <span className="text-[10px] font-mono font-bold px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-300 border border-amber-500/30">
+                  <span
+                    className="font-display font-bold text-[12px] grid place-items-center w-6 h-6 rounded-[5px]"
+                    style={{
+                      backgroundColor:
+                        p.vrGrade === "A" || p.vrGrade === "B" ? "var(--green)" :
+                        p.vrGrade === "C" ? "var(--amber)" :
+                        p.vrGrade === "D" ? "var(--copper)" :
+                        "var(--red)",
+                      color: p.vrGrade === "C" ? "var(--on-amber)" : "white",
+                    }}
+                  >
                     {p.vrGrade}
                   </span>
-                ) : "—"}
+                ) : <span className="text-ink-3">—</span>}
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
B2.1 visual parity dispatch. R7 audit done first per dispatch (full log: `docs/B2_VISUAL_PARITY_AUDIT.md`). Three sub-tasks audited, two passed verification, one needed code changes.

## Audit findings

| Sub-task | Status | Reason |
|---|---|---|
| `/welcome` | ✅ Verified, no changes | PR #461 (A7.1) already restored + migrated to global cream/amber tokens with dark-mode + demo-cookie support |
| `/(auth)/login` + `/(auth)/signup` | ✅ Verified, no changes | PR #460 (A6) already repalleted both with cream panel, Playfair italic amber emphasis, mono labels, demo-bypass footer |
| `/dashboard/pipeline` | ❌ Gap found | `PipelineKanban` + `PipelineTable` still on the dark Bloomberg theme |

## `/dashboard/pipeline` rebrand

### `PipelineKanban.tsx` — 6 columns → /demo's 5
| Column | Stage(s) merged | Top accent stripe |
|---|---|---|
| **New** | `discovered` + `enriched` | `var(--ink-3)` |
| **Contacted** | `contacted` | `var(--blue)` |
| **Replied** | `replied` | `var(--amber)` |
| **Meeting** | `meeting` | `var(--green)` |
| **Won** | `converted` | `var(--copper)` |

Cards translated to /demo's `.k-card` pattern:
- `bg-panel border-rule` cream card with 3px left border in column's accent colour
- Playfair-bold 14px name, DM-name body in `text-ink-2`
- Mono `[10.5px]` channel · date meta line
- Foot row: VR grade colour-coded chip (A/B green, C amber+on-amber, D copper, F red) + score in `text-copper`
- Hover: `border-amber` + amber-glow shadow per prototype
- Empty state: "Empty — awaiting prospects"
- Native HTML5 drag/drop preserved (first stage in merged column wins on drop)

Column header gets the prototype's `top:0; left/right:10px; height:3px` accent stripe via absolute span. Counts shown as `<bg-ink white pill>` + `<text-ink-3 %>`.

### `PipelineTable.tsx` — cream/amber rebrand
- Outer panel: `bg-panel border-rule rounded-[10px]`
- thead: `bg-surface` mono uppercase ink-3 + `hover:text-amber` sort indicator
- Body: Playfair-bold prospect name, ink-2 company/stage, mono `[11px]` ink-3 channel/dates
- Row hover: `bg-amber-soft` (was dark grey)
- VR grade chip — same colour-coded square as the kanban cards
- Each `<td>` carries `data-label="…"` so the **mobile-card-table** CSS utility from PR #458 displays "Prospect · / Stage ·" prefixes when stacked on `<md`

## Out of scope (already on /demo from prior PRs)
- View toggle (list / kanban / table) in `app/dashboard/pipeline/page.tsx` — already `bg-surface` cream
- `PipelineFilters.tsx` — already uses /demo's `.chip` pill pattern (#443, #466)
- `PipelineRow.tsx` (list view) — already on /demo design (#443)
- `<ProspectDrawer>` — opens on card click (`onOpen(p.id)` → `setActiveLead(id)` → drawer renders), matching the prototype's `openDrawer(pid)` pattern

## Test plan
- [x] `pnpm run build` — **exit 0**
- [x] No `ignoreBuildErrors` bypass
- [ ] Manual smoke after deploy:
      • Pipeline route shows 5 columns with correct accent stripes
      • Cards have Playfair name + colour-coded VR chip + amber hover
      • Table renders with cream chrome; mobile stacks rows as cards with `data-label` prefixes
      • Drawer still opens on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)