### PR TITLE
[ELLIOT] fix(governance): Phase 1 audit fixes F1-F3 — freeze project_id + Stop hook + router sys.path

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,18 @@
     "defaultMode": "bypassPermissions"
   },
   "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd /home/elliotbot/clawd/Agency_OS && PYTHONPATH=/home/elliotbot/clawd/Agency_OS /home/elliotbot/clawd/venv/bin/python3 scripts/governance_router.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "matcher": "*",

--- a/scripts/governance_router.py
+++ b/scripts/governance_router.py
@@ -10,6 +10,9 @@ The hook MUST never block the assistant — failures exit 0 silently.
 
 GOV-PHASE1-TRACK-B / B1.
 """
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from src.governance.router import main
 
 if __name__ == "__main__":

--- a/src/governance/freeze.py
+++ b/src/governance/freeze.py
@@ -33,7 +33,7 @@ MCP_TIMEOUT_S = 30
 
 def _mcp_execute_sql(sql: str) -> list[dict[str, Any]]:
     """Run SQL through the supabase MCP bridge, return rows as dicts."""
-    args_json = json.dumps({"query": sql})
+    args_json = json.dumps({"query": sql, "project_id": "jatzvazlbusedwsnqxzr"})
     proc = subprocess.run(
         ["node", MCP_BRIDGE_SCRIPT, "call", "supabase", "execute_sql", args_json],
         cwd=MCP_BRIDGE_DIR,


### PR DESCRIPTION
## Summary
- **F1**: freeze.py — added missing `project_id` parameter to MCP bridge calls. Without this, ALL freeze/unfreeze operations fail at runtime.
- **F2**: settings.json — added Stop hook entry for governance_router.py with PYTHONPATH. This is the missing wiring that prevented the Router from firing on assistant text.
- **F3**: governance_router.py — added sys.path.insert so `from src.governance.router import main` resolves when invoked as a Claude Code hook.

## Verification
- `python3 -m py_compile src/governance/freeze.py` → OK
- `python3 -m py_compile scripts/governance_router.py` → OK
- `python3 -c "import json; json.load(open('.claude/settings.json'))"` → valid JSON
- Commit: 2021aceb

## Audit context
Found during Phase 1 comprehensive audit. These 3 fixes are critical blockers — without them, Gatekeeper frozen-path checks fail, Router never fires, and the Stop hook script can't find its imports.

## Test plan
- [ ] Verify freeze_artifact() succeeds against live Supabase
- [ ] Verify Stop hook fires on session step (requires Claude Code restart)
- [ ] Verify governance_router.py classifies a Dave-addressed message correctly

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>