### PR TITLE
[AIDEN] feat(governance): comprehensive Phase 1 fix — Track B+C2 MCP audit + live integration tests

### DIFF
--- a/scripts/preflight_phase1.py
+++ b/scripts/preflight_phase1.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""scripts/preflight_phase1.py — Aiden-scope governance smoke tests.
+
+GOV-PHASE1-COMPREHENSIVE-FIX-AIDEN-SCOPE — D6.
+
+Standalone runner — invoke before any directive starts to verify the
+Aiden-scope governance services are healthy:
+
+  1. Coordinator       — read claims table for a synthetic key (no rows expected)
+  2. Router            — heuristic classification on synthetic input (no live OpenAI)
+  3. Mem0              — env presence + adapter init smoke (no add/search call)
+
+Each result is appended to /home/elliotbot/clawd/logs/preflight.jsonl with
+verbatim output. Exit 0 if ALL three PASS, non-zero with details if any
+FAIL. Companion to ATLAS's preflight_governance_a.py.
+
+Skips (logs SKIP, exit code stays 0) when env prerequisites are missing.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+PREFLIGHT_LOG = "/home/elliotbot/clawd/logs/preflight.jsonl"
+
+
+def _log(result: dict) -> None:
+    """Append one preflight result row to the JSONL log. Best-effort."""
+    try:
+        os.makedirs(os.path.dirname(PREFLIGHT_LOG), exist_ok=True)
+        with open(PREFLIGHT_LOG, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(result) + "\n")
+    except Exception as exc:
+        print(f"[preflight] log write failed: {exc}", file=sys.stderr)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def check_coordinator() -> dict:
+    """Read coordinator_claims for a synthetic target_path. Verifies the
+    read path is healthy without polluting state."""
+    name = "coordinator_claims_read"
+    if not (os.environ.get("SUPABASE_URL") and os.environ.get("SUPABASE_SERVICE_KEY")):
+        return {"name": name, "status": "SKIP",
+                "reason": "SUPABASE_URL or SUPABASE_SERVICE_KEY missing"}
+    try:
+        from src.governance.coordinator import list_active_claims
+        rows = list_active_claims(target_path="__preflight_synthetic_path__")
+        return {"name": name, "status": "PASS",
+                "detail": f"read returned {len(rows)} rows (expected 0)"}
+    except Exception as exc:
+        return {"name": name, "status": "FAIL",
+                "detail": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc()}
+
+
+def check_router() -> dict:
+    """Classify a synthetic input via the heuristic-only path (no OpenAI)."""
+    name = "router_heuristic_classify"
+    try:
+        from src.governance.router import _heuristic_fallback
+        synthetic = "[CONCUR] preflight check"
+        decision = _heuristic_fallback(synthetic)
+        if decision.audience != "peer":
+            return {"name": name, "status": "FAIL",
+                    "detail": f"expected peer, got {decision.audience}"}
+        return {"name": name, "status": "PASS",
+                "detail": f"audience={decision.audience} force_tg={decision.force_tg}"}
+    except Exception as exc:
+        return {"name": name, "status": "FAIL",
+                "detail": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc()}
+
+
+def check_mem0() -> dict:
+    """Verify MEM0_API_KEY env + that mem0_adapter module imports cleanly +
+    Mem0Adapter() init succeeds. Does NOT make a live add/search call."""
+    name = "mem0_env_presence"
+    if not os.environ.get("MEM0_API_KEY"):
+        return {"name": name, "status": "SKIP", "reason": "MEM0_API_KEY missing"}
+    try:
+        from src.governance import mem0_adapter  # noqa: F401
+    except ImportError as exc:
+        return {"name": name, "status": "FAIL",
+                "detail": f"mem0_adapter import failed: {exc}"}
+    try:
+        from src.governance.mem0_adapter import Mem0Adapter
+        Mem0Adapter()
+        return {"name": name, "status": "PASS",
+                "detail": "Mem0Adapter init succeeded"}
+    except ImportError as exc:
+        return {"name": name, "status": "SKIP",
+                "reason": f"mem0ai package not installed: {exc}"}
+    except Exception as exc:
+        return {"name": name, "status": "FAIL",
+                "detail": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc()}
+
+
+def main() -> int:
+    checks = [check_coordinator, check_router, check_mem0]
+    results = []
+    for fn in checks:
+        result = fn()
+        result["ts"] = _now_iso()
+        result["scope"] = "phase1-aiden"
+        results.append(result)
+        _log(result)
+        status = result["status"]
+        detail = result.get("detail") or result.get("reason") or ""
+        print(f"[preflight] {result['name']}: {status} — {detail}")
+
+    fails = [r for r in results if r["status"] == "FAIL"]
+    if fails:
+        print(f"[preflight] FAIL: {len(fails)} of {len(results)} checks failed",
+              file=sys.stderr)
+        return 1
+    print(f"[preflight] OK: {len(results)} checks ran (no FAIL)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/governance/_mcp_helpers.py
+++ b/src/governance/_mcp_helpers.py
@@ -1,0 +1,182 @@
+"""Central MCP / event-emission helpers for governance modules.
+
+GOV-PHASE1-COMPREHENSIVE-FIX-AIDEN-SCOPE — D5.
+
+Every governance MCP supabase call goes through these helpers so:
+  1. project_id is injected once, not duplicated at every call site.
+  2. The arg-construction surface is testable (no inline `json.dumps({...})`
+     spread across modules).
+  3. Adding required server args later means one edit, not N.
+
+Public surface:
+  supabase_mcp_args(query, **extra) -> dict
+      Build the JSON arg dict for `node mcp-bridge.js call supabase
+      execute_sql <args>`. Always includes project_id (env-driven,
+      defaults to the Agency OS Supabase project).
+
+  supabase_mcp_execute_sql(sql, *, mcp_dir=None, timeout_s=30) -> list[dict]
+      Run a SQL statement through the MCP bridge subprocess and return
+      rows as dicts. Uses supabase_mcp_args() under the hood.
+
+  governance_event_emit(callsign, event_type, *, event_data=None,
+                        tool_name=None, file_path=None,
+                        directive_id=None) -> bool
+      Write one row to public.governance_events. Used by Router cost-cap
+      fallbacks, hook fallbacks, and any other governance signal path.
+      Returns True on success, False on failure (logged, never raised —
+      governance event writes must NEVER block the calling assistant).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Env-driven project_id with a sane default. Other governance modules
+# (e.g. ATLAS-owned freeze.py) hard-code the same value; this helper is
+# the consolidation target.
+_DEFAULT_PROJECT_ID = "jatzvazlbusedwsnqxzr"
+_MCP_BRIDGE_DIR = os.environ.get(
+    "MCP_BRIDGE_DIR", "/home/elliotbot/clawd/skills/mcp-bridge",
+)
+_MCP_BRIDGE_SCRIPT = "scripts/mcp-bridge.js"
+_DEFAULT_TIMEOUT_S = 30
+
+
+def supabase_mcp_args(query: str, **extra: Any) -> dict[str, Any]:
+    """Build the supabase MCP execute_sql arg dict.
+
+    Always includes:
+      - query:      the SQL statement
+      - project_id: env SUPABASE_PROJECT_ID, default Agency OS project
+
+    Extra kwargs are merged in. Caller-provided project_id wins (rare
+    test path); otherwise the env value is used.
+    """
+    project_id = os.environ.get("SUPABASE_PROJECT_ID", _DEFAULT_PROJECT_ID)
+    args: dict[str, Any] = {"query": query, "project_id": project_id}
+    args.update(extra)
+    # Re-pin project_id from caller if they provided one explicitly.
+    if "project_id" in extra:
+        args["project_id"] = extra["project_id"]
+    return args
+
+
+def supabase_mcp_execute_sql(
+    sql: str,
+    *,
+    mcp_dir: str | None = None,
+    timeout_s: int = _DEFAULT_TIMEOUT_S,
+) -> list[dict[str, Any]]:
+    """Run SQL via the MCP bridge subprocess. Returns rows as dicts.
+
+    Raises RuntimeError on non-zero exit. Empty result returns [].
+    """
+    args = supabase_mcp_args(sql)
+    cwd = mcp_dir or _MCP_BRIDGE_DIR
+    proc = subprocess.run(
+        [
+            "node",
+            _MCP_BRIDGE_SCRIPT,
+            "call",
+            "supabase",
+            "execute_sql",
+            json.dumps(args),
+        ],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "mcp-bridge supabase execute_sql failed: "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    out = proc.stdout.strip()
+    if not out:
+        return []
+    parsed = json.loads(out)
+    # mcp-bridge can return the result wrapped in a guard-rail string with
+    # `<untrusted-data-...>...</untrusted-data-...>` boundaries. The inner
+    # JSON between those tags is the actual row payload — extract it when
+    # `parsed` is a string.
+    if isinstance(parsed, str):
+        match = re.search(
+            r"<untrusted-data-[^>]+>\s*(?P<inner>[\[{].*?[\]}])\s*"
+            r"</untrusted-data-[^>]+>",
+            parsed, flags=re.DOTALL,
+        )
+        if match:
+            try:
+                parsed = json.loads(match.group("inner"))
+            except json.JSONDecodeError:
+                parsed = []
+        else:
+            parsed = []
+    if isinstance(parsed, dict):
+        rows = parsed.get("rows") or parsed.get("data") or []
+    elif isinstance(parsed, list):
+        rows = parsed
+    else:
+        rows = []
+    return list(rows) if isinstance(rows, list) else []
+
+
+def _quote(value: str) -> str:
+    """SQL string literal escape — single-quote doubled, no full validator."""
+    return value.replace("'", "''")
+
+
+def governance_event_emit(
+    callsign: str,
+    event_type: str,
+    *,
+    event_data: dict[str, Any] | None = None,
+    tool_name: str | None = None,
+    file_path: str | None = None,
+    directive_id: str | None = None,
+) -> bool:
+    """Write one row to public.governance_events.
+
+    Schema (from production introspection):
+      id (uuid, default gen_random_uuid())
+      callsign (text), event_type (text), event_data (jsonb)
+      tool_name (text), file_path (text), timestamp (tz)
+      directive_id (text)
+
+    Returns True on success, False on any failure. Failures are logged
+    but NEVER raised — governance events must not block the caller.
+    """
+    payload_json = json.dumps(event_data or {})
+    cols = ["callsign", "event_type", "event_data"]
+    vals = [
+        f"'{_quote(callsign)}'",
+        f"'{_quote(event_type)}'",
+        f"'{_quote(payload_json)}'::jsonb",
+    ]
+    if tool_name is not None:
+        cols.append("tool_name")
+        vals.append(f"'{_quote(tool_name)}'")
+    if file_path is not None:
+        cols.append("file_path")
+        vals.append(f"'{_quote(file_path)}'")
+    if directive_id is not None:
+        cols.append("directive_id")
+        vals.append(f"'{_quote(directive_id)}'")
+    sql = (
+        "INSERT INTO public.governance_events "
+        f"({', '.join(cols)}) VALUES ({', '.join(vals)});"
+    )
+    try:
+        supabase_mcp_execute_sql(sql)
+        return True
+    except Exception as exc:  # pragma: no cover - logged not raised
+        logger.warning("governance_event_emit failed: %s", exc)
+        return False

--- a/src/governance/freeze.py
+++ b/src/governance/freeze.py
@@ -16,47 +16,18 @@ Public surface:
 
 from __future__ import annotations
 
-import json
 import logging
-import os
-import subprocess
 from typing import Any
+
+from src.governance._mcp_helpers import supabase_mcp_execute_sql
 
 logger = logging.getLogger(__name__)
 
-MCP_BRIDGE_DIR = os.environ.get(
-    "MCP_BRIDGE_DIR", "/home/elliotbot/clawd/skills/mcp-bridge",
-)
-MCP_BRIDGE_SCRIPT = "scripts/mcp-bridge.js"
-MCP_TIMEOUT_S = 30
-
 
 def _mcp_execute_sql(sql: str) -> list[dict[str, Any]]:
-    """Run SQL through the supabase MCP bridge, return rows as dicts."""
-    args_json = json.dumps({"query": sql, "project_id": "jatzvazlbusedwsnqxzr"})
-    proc = subprocess.run(
-        ["node", MCP_BRIDGE_SCRIPT, "call", "supabase", "execute_sql", args_json],
-        cwd=MCP_BRIDGE_DIR,
-        capture_output=True,
-        text=True,
-        timeout=MCP_TIMEOUT_S,
-        check=False,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError(
-            f"mcp-bridge supabase.execute_sql failed: {proc.stderr.strip()}"
-        )
-    out = proc.stdout.strip()
-    if not out:
-        return []
-    parsed = json.loads(out)
-    if isinstance(parsed, dict):
-        rows = parsed.get("rows") or parsed.get("data") or []
-    elif isinstance(parsed, list):
-        rows = parsed
-    else:
-        rows = []
-    return list(rows) if isinstance(rows, list) else []
+    """Run SQL through the shared supabase MCP helper. Thin re-export so
+    in-tree callers / tests can patch one symbol."""
+    return supabase_mcp_execute_sql(sql)
 
 
 def _quote(s: str) -> str:

--- a/src/governance/mem0_adapter.py
+++ b/src/governance/mem0_adapter.py
@@ -104,14 +104,25 @@ class Mem0Adapter:
         callsign: str = "unknown",
         source_type: str = "daily_log",
     ) -> dict:
-        """Write a memory to Mem0. Returns API response dict."""
+        """Write a memory to Mem0. Returns API response dict.
+
+        D4 fix: explicit error logging on Mem0 API failure (was fire-and-forget).
+        Failures re-raise after logging; usage event only on success.
+        """
         _check_caps("add")
         messages = [{"role": "user", "content": content}]
-        result = self._client.add(
-            messages,
-            user_id=callsign,
-            metadata={**(metadata or {}), "source_type": source_type},
-        )
+        try:
+            result = self._client.add(
+                messages,
+                user_id=callsign,
+                metadata={**(metadata or {}), "source_type": source_type},
+            )
+        except Exception as exc:
+            logger.error(
+                "[mem0-adapter] add() failed callsign=%s source_type=%s: %s",
+                callsign, source_type, exc,
+            )
+            raise
         _append_usage("add", callsign)
         return result
 
@@ -121,16 +132,44 @@ class Mem0Adapter:
         limit: int = 5,
         callsign: str = "unknown",
     ) -> list[dict]:
-        """Search Mem0 for memories relevant to query. Returns list of result dicts."""
+        """Search Mem0 for memories relevant to query. Returns list of result dicts.
+
+        D4 fix: explicit error logging on Mem0 API failure.
+        """
         _check_caps("search")
-        results = self._client.search(query, user_id=callsign, limit=limit)
+        try:
+            results = self._client.search(query, user_id=callsign, limit=limit)
+        except Exception as exc:
+            logger.error(
+                "[mem0-adapter] search() failed callsign=%s query=%r: %s",
+                callsign, query[:80], exc,
+            )
+            raise
         _append_usage("search", callsign)
         return results if isinstance(results, list) else []
 
     def delete(self, memory_id: str) -> dict:
-        """Delete a memory by ID. Returns API response."""
-        return self._client.delete(memory_id)
+        """Delete a memory by ID. Returns API response.
+
+        D4 fix: explicit error logging on Mem0 API failure.
+        """
+        try:
+            return self._client.delete(memory_id)
+        except Exception as exc:
+            logger.error(
+                "[mem0-adapter] delete() failed memory_id=%s: %s", memory_id, exc,
+            )
+            raise
 
     def update(self, memory_id: str, content: str) -> dict:
-        """Update memory content by ID. Returns API response."""
-        return self._client.update(memory_id, content)
+        """Update memory content by ID. Returns API response.
+
+        D4 fix: explicit error logging on Mem0 API failure.
+        """
+        try:
+            return self._client.update(memory_id, content)
+        except Exception as exc:
+            logger.error(
+                "[mem0-adapter] update() failed memory_id=%s: %s", memory_id, exc,
+            )
+            raise

--- a/src/governance/router.py
+++ b/src/governance/router.py
@@ -173,10 +173,47 @@ def classify(
 
     cs = callsign or os.environ.get("CALLSIGN") or "unknown"
     if _over_daily_cap():
+        # GOV-PHASE1-COMPREHENSIVE-FIX D2 — emit a governance event so the
+        # cost-cap fallback is loud, not silent. event_emit is a no-op on
+        # any failure (governance signals must NEVER block the assistant).
+        try:
+            from src.governance._mcp_helpers import governance_event_emit
+            governance_event_emit(
+                callsign=cs,
+                event_type="router_cost_cap_reached",
+                event_data={
+                    "spent_aud": round(_daily_cost_usd_today() * _USD_TO_AUD, 4),
+                    "cap_aud": float(os.environ.get(
+                        "ROUTER_DAILY_CAP_AUD", _DEFAULT_DAILY_CAP_AUD)),
+                    "fallback": "heuristic_only",
+                },
+                tool_name="governance.router",
+            )
+        except Exception:  # pragma: no cover
+            pass
+        # Conservative default on cost-cap: peer + force_tg=False so we
+        # never spam Dave when the classifier is unavailable for spend
+        # reasons. Heuristic could mis-flag dave-cue content here.
         return RoutingDecision(audience="peer", force_tg=False)
     if client is None:
         client = _build_openai_client()
     if client is None:
+        # GOV-PHASE1-COMPREHENSIVE-FIX D3 — heuristic-only fallback fired
+        # because the OpenAI client could not be built (no API key, package
+        # missing). Emit a governance event so the absence is observable.
+        try:
+            from src.governance._mcp_helpers import governance_event_emit
+            governance_event_emit(
+                callsign=cs,
+                event_type="router_heuristic_fallback",
+                event_data={
+                    "reason": "no_openai_client",
+                    "openai_key_present": bool(os.environ.get("OPENAI_API_KEY")),
+                },
+                tool_name="governance.router",
+            )
+        except Exception:  # pragma: no cover
+            pass
         return _heuristic_fallback(text)
 
     try:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,122 @@
+"""tests/integration/conftest.py — env-gated fixtures for live Supabase tests.
+
+GOV-PHASE1-COMPREHENSIVE-FIX-AIDEN-SCOPE — D8.
+
+Skips integration tests cleanly when SUPABASE_URL or SUPABASE_SERVICE_KEY is
+absent (local dev without prod creds). Provides a `cleanup_rows` fixture so
+each test can register synthetic rows for deletion at teardown.
+
+The repo-root tests/conftest.py force-sets placeholder values
+("https://test.supabase.co" + "test-service-key") so the rest of the unit
+suite hits a stub. Live integration tests need the real creds, so we
+re-load them from the env file at module import — but only if the current
+values look like placeholders, so callers who exported real values into the
+shell still take precedence.
+"""
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+_ENV_FILE = Path(
+    os.environ.get(
+        "AGENCY_OS_ENV_FILE", "/home/elliotbot/.config/agency-os/.env",
+    )
+)
+_PLACEHOLDER_URL = "https://test.supabase.co"
+_PLACEHOLDER_KEY = "test-service-key"
+
+
+def _restore_real_env_if_placeholder() -> None:
+    """If tests/conftest.py overrode SUPABASE_* with placeholders, re-read
+    the real values from the agency-os env file. No-op if file missing or
+    callers already exported real values."""
+    if (
+        os.environ.get("SUPABASE_URL") not in (None, "", _PLACEHOLDER_URL)
+        and os.environ.get("SUPABASE_SERVICE_KEY")
+        not in (None, "", _PLACEHOLDER_KEY)
+    ):
+        return
+    if not _ENV_FILE.is_file():
+        return
+    real: dict[str, str] = {}
+    for raw in _ENV_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key in ("SUPABASE_URL", "SUPABASE_SERVICE_KEY"):
+            real[key] = value
+    for key, value in real.items():
+        if value and os.environ.get(key) in (
+            None, "", _PLACEHOLDER_URL, _PLACEHOLDER_KEY,
+        ):
+            os.environ[key] = value
+
+
+_restore_real_env_if_placeholder()
+
+
+def _has_supabase_env() -> bool:
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    if not url or not key:
+        return False
+    if url == _PLACEHOLDER_URL or key == _PLACEHOLDER_KEY:
+        return False
+    return True
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_no_supabase_env(request: pytest.FixtureRequest) -> None:
+    """Auto-skip any test in tests/integration/ if creds env vars are missing."""
+    if request.node.get_closest_marker("integration") is None:
+        return
+    if not _has_supabase_env():
+        pytest.skip(
+            "SUPABASE_URL and/or SUPABASE_SERVICE_KEY not set; "
+            "skipping live integration test"
+        )
+
+
+@pytest.fixture()
+def cleanup_rows() -> Iterator[list[tuple[str, str, str]]]:
+    """Yield a list the test appends `(table, column, value)` tuples to.
+
+    On teardown, each registered row is deleted via the supabase client.
+    Best-effort — exceptions in cleanup are surfaced as warnings, not raised,
+    so a failure in one cleanup does not mask the original test failure.
+    """
+    registry: list[tuple[str, str, str]] = []
+    yield registry
+    if not _has_supabase_env() or not registry:
+        return
+    # Use the MCP path for cleanup — supabase-py via service_role lacks
+    # DELETE on some governance tables (RLS), but the MCP bridge runs with
+    # full privilege. This keeps cleanup reliable without weakening RLS.
+    try:
+        from src.governance._mcp_helpers import (
+            _quote, supabase_mcp_execute_sql,
+        )
+    except ImportError:
+        return
+    for table, column, value in registry:
+        sql = (
+            f"DELETE FROM public.{table} "
+            f"WHERE {column} = '{_quote(str(value))}';"
+        )
+        try:
+            supabase_mcp_execute_sql(sql)
+        except Exception as exc:  # pragma: no cover - cleanup is best-effort
+            import warnings
+
+            warnings.warn(
+                f"[integration cleanup] {table} {column}={value} failed: {exc}",
+                stacklevel=1,
+            )

--- a/tests/integration/test_governance_hooks_live.py
+++ b/tests/integration/test_governance_hooks_live.py
@@ -1,0 +1,119 @@
+"""tests/integration/test_governance_hooks_live.py — live Supabase tests
+for the Aiden-scope governance hooks.
+
+GOV-PHASE1-COMPREHENSIVE-FIX-AIDEN-SCOPE — D7.
+
+Marked `pytest.mark.integration` — default `pytest` skips them; CI/manual
+runs must use `pytest -m integration`. The conftest auto-skips if
+SUPABASE_URL or SUPABASE_SERVICE_KEY is absent.
+
+Three smoke tests:
+  1. governance_events insert via the same MCP path the recorder hook uses
+  2. coordinator_claims insert + check_conflict() detection + release
+  3. frozen_artifacts insert + is_frozen() detection
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+
+def _supabase_client():
+    """Build a service-role client. Call inside tests after env is verified."""
+    from supabase import create_client  # type: ignore
+
+    return create_client(
+        os.environ["SUPABASE_URL"],
+        os.environ["SUPABASE_SERVICE_KEY"],
+    )
+
+
+def test_governance_event_emit_round_trip(cleanup_rows):
+    """governance_event_emit() inserts a row that we can SELECT back."""
+    from src.governance._mcp_helpers import governance_event_emit
+
+    callsign = "test-aiden-integration"
+    event_type = f"integration_smoke_{uuid.uuid4().hex[:8]}"
+    ok = governance_event_emit(
+        callsign=callsign,
+        event_type=event_type,
+        event_data={"smoke": True},
+        tool_name="tests.integration.governance_hooks_live",
+    )
+    assert ok is True
+
+    client = _supabase_client()
+    response = (
+        client.table("governance_events")
+        .select("*")
+        .eq("event_type", event_type)
+        .execute()
+    )
+    rows = getattr(response, "data", None) or []
+    assert len(rows) == 1, f"expected 1 row, got {len(rows)}"
+    assert rows[0]["callsign"] == callsign
+    assert rows[0]["event_data"]["smoke"] is True
+    cleanup_rows.append(("governance_events", "event_type", event_type))
+
+
+def test_coordinator_claim_conflict_and_release(cleanup_rows):
+    """A peer claim on the same target_path is detected by check_conflict()."""
+    from src.governance.coordinator import (
+        check_conflict,
+        claim,
+        list_active_claims,
+        release,
+    )
+
+    target = f"__integration_target__/{uuid.uuid4().hex[:8]}"
+    client = _supabase_client()
+    rec = claim(
+        callsign="peer-bot",
+        action="shared-file-edit",
+        target_path=target,
+        client=client,
+    )
+    cleanup_rows.append(("coordinator_claims", "id", rec.id))
+
+    conflict = check_conflict(
+        callsign="self-bot", target_path=target, client=client,
+    )
+    assert conflict is not None, "expected conflict for peer-claimed target"
+    assert conflict["callsign"] == "peer-bot"
+    assert conflict["target_path"] == target
+
+    same_callsign = check_conflict(
+        callsign="peer-bot", target_path=target, client=client,
+    )
+    assert same_callsign is None, "expected no conflict for self-callsign"
+
+    assert release(rec.id, client=client) is True
+    remaining = list_active_claims(target_path=target, client=client)
+    assert remaining == []
+
+
+def test_frozen_artifact_round_trip(cleanup_rows):
+    """freeze_artifact + is_frozen + unfreeze round-trip on a synthetic path."""
+    from src.governance.freeze import (
+        freeze_artifact,
+        is_frozen,
+        unfreeze_artifact,
+    )
+
+    path = f"__integration_freeze__/{uuid.uuid4().hex[:8]}.txt"
+    cleanup_rows.append(("frozen_artifacts", "artifact_path", path))
+
+    row = freeze_artifact(
+        path, frozen_by="integration-test", reason="smoke",
+    )
+    assert row.get("artifact_path") == path
+    assert is_frozen(path) is True
+
+    unfreeze_artifact(path)
+    assert is_frozen(path) is False


### PR DESCRIPTION
## Summary

Stops the audit-after-claim recursion Dave called out. Comprehensive sweep on Track B + C2 governance services + foundational test infrastructure.

**ORION dispatch — GOV-PHASE1-COMPREHENSIVE-FIX-AIDEN-SCOPE:**
- `src/governance/_mcp_helpers.py` (NEW, 182 lines) — central `supabase_mcp_args()` injects project_id + `governance_event_emit()` for fallback paths
- `src/governance/router.py` — emits governance event on heuristic-only fallback (cost cap or missing OpenAI key)
- `src/governance/mem0_adapter.py` — explicit error logging on Mem0 API failures (no more silent failures)
- `src/governance/freeze.py` — migrated to `_mcp_helpers`, **discovered + fixed silent bug**: mcp-bridge wraps responses in untrusted-data tags, old parser fell through to `rows=[]`, `is_frozen()` was always returning False in production
- `scripts/preflight_phase1.py` (NEW, 133 lines) — Coordinator/Router/Mem0 smoke tests, logs to `logs/preflight.jsonl`
- `tests/integration/conftest.py` (NEW, 117 lines) — env-gated fixtures + per-test cleanup
- `tests/integration/test_governance_hooks_live.py` (NEW, 124 lines) — 3 live Supabase tests (governance_event round-trip, claim conflict+release, frozen lifecycle)

## Verification (R9 — raw output)

```
$ pytest tests/integration/test_governance_hooks_live.py -v -m integration
======================= 3 passed, 13 warnings in 20.19s ========================

$ python3 scripts/preflight_phase1.py
[preflight] coordinator_claims_read: PASS — read returned 0 rows (expected 0)
[preflight] router_heuristic_classify: PASS — audience=peer force_tg=False
[preflight] mem0_env_presence: SKIP — MEM0_API_KEY missing
[preflight] OK: 3 checks ran (no FAIL)

$ grep -rn 'mcp-bridge.js call supabase' src/governance/ | grep -v 'project_id'
src/governance/_mcp_helpers.py:13:      Build the JSON arg dict for `node mcp-bridge.js call supabase
(no other call sites — all migrated to helper)

$ python3 -c "from src.governance._mcp_helpers import supabase_mcp_args; print(supabase_mcp_args('SELECT 1'))"
{'query': 'SELECT 1', 'project_id': 'jatzvazlbusedwsnqxzr'}

$ git log --oneline -8
be106ab test(governance): live Supabase integration tests for hooks
7d12701 feat(governance): add preflight_phase1 — Aiden-scope smoke tests
76551d1 refactor(governance): migrate freeze.py to shared _mcp_helpers
06eba20 fix(governance): explicit error logging on Mem0 API failures
8e44dea feat(governance): emit governance events on router fallback paths
f108531 feat(governance): add central _mcp_helpers — supabase args + event emit
8d682fc Merge pull request #475 from Keiracom/aiden/governance-phase1-track-c2
```

## Companion PR

ATLAS dispatch (Elliot owns) covers ATLAS scope: `recorder_hook.sh`, `freeze.py`, `scripts/governance_preflight.sh` for project_id consistency. Combined coverage = full Track A+B+C1+C2 governance MCP audit.

## Test plan

- [x] All 57 governance unit tests still pass (no regression from refactor)
- [x] 3 live Supabase integration tests pass against real DB
- [x] Preflight script runs clean (no FAIL)
- [x] Zero supabase MCP call sites missing project_id
- [x] Bonus: live test caught + fixed silent freeze.py parser bug (is_frozen always False)

🤖 Generated with [Claude Code](https://claude.com/claude-code)