### PR TITLE
[ELLIOT] fix(governance): Phase 1.5 — session_end_hook ceo_memory column fix

### DIFF
--- a/scripts/session_end_hook.py
+++ b/scripts/session_end_hook.py
@@ -190,8 +190,8 @@ def write_memory(summary: dict) -> dict:
                 key = f"ceo:session_end_{datetime.now(UTC).date().isoformat()}_{os.environ.get('CALLSIGN', 'unknown')}"
                 await conn.execute(
                     """
-                    INSERT INTO ceo_memory (key, value, created_at, updated_at)
-                    VALUES ($1, $2::jsonb, NOW(), NOW())
+                    INSERT INTO ceo_memory (key, value, updated_at)
+                    VALUES ($1, $2::jsonb, NOW())
                     ON CONFLICT (key) DO UPDATE
                       SET value = EXCLUDED.value, updated_at = NOW()
                     """,


### PR DESCRIPTION
## Summary
- **Root cause:** `session_end_hook.py` referenced non-existent `created_at` column in `ceo_memory` table INSERT
- **Impact:** Every session end since Phase 1 deployed silently failed to persist state to ceo_memory + daily_log
- **Fix:** Removed `created_at` from INSERT — table schema is `(key, value, updated_at, version)`

## Verification (R9 raw evidence)
```
$ echo '<synthetic payload>' | CALLSIGN=elliot-synth python3 scripts/session_end_hook.py
[session-end-hook] INFO: SessionEnd fired — session_id=synth-te reason=synthetic-phase1.5
[session-end-hook] INFO: MANUAL.md unchanged since last mirror — no mirror trigger
[session-end-hook] INFO: Done. mirror_invoked=False ceo_memory=True daily_log=True

Supabase ceo_memory: key=ceo:session_end_2026-05-01_elliot-synth, updated_at=09:59:07Z ✅
Supabase daily_log: id=ac03bc48, content='Session ended (synthetic-phase1.5)...' ✅
```

## Test plan
- [x] Synthetic SessionEnd fires successfully
- [x] ceo_memory row confirmed in Supabase
- [x] daily_log row confirmed in Supabase
- [x] Stop hook verified working (no fix needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)