### PR TITLE
[AIDEN] feat(governance): instrument Gatekeeper verdicts to governance_events (Phase 2)

### DIFF
--- a/src/governance/gatekeeper.py
+++ b/src/governance/gatekeeper.py
@@ -26,6 +26,7 @@ unless the caller passes them explicitly (used for tests).
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from collections.abc import Iterable
@@ -38,6 +39,35 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_OPA_URL = os.environ.get("OPA_URL", "http://localhost:8181")
 DEFAULT_DECISION_PATH = "v1/data/agency/completion_claims"
+
+
+def _emit_verdict(
+    *,
+    callsign: str,
+    directive_id: str,
+    claim_text: str,
+    allow: bool,
+    reasons: list[str],
+    error: str | None = None,
+) -> None:
+    """Emit one governance_events row per Gatekeeper verdict (GOV-12)."""
+    try:
+        from src.governance._mcp_helpers import governance_event_emit
+        claim_hash = hashlib.sha256(claim_text.encode("utf-8")).hexdigest()[:16]
+        governance_event_emit(
+            callsign=callsign,
+            event_type="gatekeeper_decision",
+            event_data={
+                "allow": allow,
+                "reasons": reasons,
+                "claim_text_sha256_16": claim_hash,
+                "error": error,
+            },
+            tool_name="governance.gatekeeper",
+            directive_id=directive_id,
+        )
+    except Exception:  # pragma: no cover
+        pass
 
 
 @dataclass
@@ -97,14 +127,23 @@ def check_completion_claim(
         result = _post_decision(payload, opa_url=opa_url)
     except httpx.HTTPError as exc:
         logger.warning("Gatekeeper OPA request failed: %s", exc)
+        err_reasons = [f"opa request failed: {exc}"]
+        _emit_verdict(
+            callsign=callsign, directive_id=directive_id, claim_text=claim_text,
+            allow=False, reasons=err_reasons, error=str(exc),
+        )
         return GatekeeperResult(
             allow=False,
-            reasons=[f"opa request failed: {exc}"],
+            reasons=err_reasons,
             raw={"error": str(exc)},
         )
 
     allow = bool(result.get("allow", False))
     reasons = list(result.get("deny_reasons", []) or [])
+    _emit_verdict(
+        callsign=callsign, directive_id=directive_id, claim_text=claim_text,
+        allow=allow, reasons=reasons,
+    )
     return GatekeeperResult(allow=allow, reasons=reasons, raw=result)
 
 

--- a/tests/governance/test_gatekeeper_emit.py
+++ b/tests/governance/test_gatekeeper_emit.py
@@ -1,0 +1,56 @@
+"""GOV-PHASE2 — Gatekeeper verdict emit instrumentation tests."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from src.governance import gatekeeper
+
+
+@pytest.fixture
+def common_args() -> dict:
+    return {
+        "callsign": "aiden-test",
+        "directive_id": "GOV-PHASE2-TEST",
+        "claim_text": "synthetic completion claim",
+        "evidence": "$ pytest -q\nOK",
+        "target_files": ["src/foo.py"],
+        "store_writes": [],
+        "frozen_paths": [],
+    }
+
+
+def test_emit_on_allow_true(common_args: dict) -> None:
+    with patch.object(gatekeeper, "_post_decision",
+                      return_value={"allow": True, "deny_reasons": []}), \
+         patch("src.governance._mcp_helpers.governance_event_emit") as emit:
+        result = gatekeeper.check_completion_claim(**common_args)
+    assert result.allow is True
+    assert emit.call_count == 1
+    kwargs = emit.call_args.kwargs
+    assert kwargs["event_type"] == "gatekeeper_decision"
+    assert kwargs["event_data"]["allow"] is True
+    assert kwargs["directive_id"] == "GOV-PHASE2-TEST"
+
+
+def test_emit_on_deny(common_args: dict) -> None:
+    with patch.object(gatekeeper, "_post_decision",
+                      return_value={"allow": False, "deny_reasons": ["G2 fail"]}), \
+         patch("src.governance._mcp_helpers.governance_event_emit") as emit:
+        result = gatekeeper.check_completion_claim(**common_args)
+    assert result.allow is False
+    assert result.reasons == ["G2 fail"]
+    assert emit.call_args.kwargs["event_data"]["allow"] is False
+    assert emit.call_args.kwargs["event_data"]["reasons"] == ["G2 fail"]
+
+
+def test_emit_on_opa_error(common_args: dict) -> None:
+    with patch.object(gatekeeper, "_post_decision",
+                      side_effect=httpx.ConnectError("boom")), \
+         patch("src.governance._mcp_helpers.governance_event_emit") as emit:
+        result = gatekeeper.check_completion_claim(**common_args)
+    assert result.allow is False
+    assert emit.call_count == 1
+    assert emit.call_args.kwargs["event_data"]["error"] == "boom"


### PR DESCRIPTION
## Summary
Phase 2 / GOV-12 fix: `check_completion_claim()` now emits one `governance_events` row per verdict. Previously verdicts returned silently — gate-as-code violation since observability was missing.

- `_emit_verdict()` helper wraps `_mcp_helpers.governance_event_emit`
- Emits on all 3 return paths: `allow=True`, `allow=False`, OPA `httpx` error
- `event_type=gatekeeper_decision`; `event_data = {allow, reasons, claim_text_sha256_16, error}`
- Wrapped in `try/except` — governance signals must never block the caller (matches `router.py` D2/D3 pattern)

## Test plan
- [x] `pytest tests/governance/test_gatekeeper_emit.py -v` — 3/3 pass (allow / deny / opa-error all emit)
- [ ] Live OPA test — pending Elliot's OPA spin-up; will verify governance_events row lands with `event_type='gatekeeper_decision'` post-merge or in joint Phase 2 close
- [x] Dual-bot review (Elliot to inspect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)