### PR TITLE
[ELLIOT] fix(governance): Phase 2 — OPA Rego v1 syntax + deployment verified

### DIFF
--- a/infra/opa/policies/completion_claims.rego
+++ b/infra/opa/policies/completion_claims.rego
@@ -39,7 +39,7 @@ evidence_has_raw_output if {
 required_stores := {"manual", "ceo_memory", "cis_directive_metrics", "drive_mirror"}
 
 # Set of stores actually written for this directive.
-written_stores[s] {
+written_stores contains s if {
     some w in input.store_writes
     w.directive_id == input.directive_id
     s := w.store
@@ -59,7 +59,7 @@ store_writes_complete if {
 # everything under src/legacy/ recursively; "src/legacy/*" only
 # matches direct children. Authors should write registry entries
 # with the appropriate wildcard for the lock they want.
-frozen_hits[path] {
+frozen_hits contains path if {
     some path in input.target_files
     some pattern in input.frozen_paths
     glob.match(pattern, [], path)
@@ -79,18 +79,18 @@ allow if {
 
 # Human-readable failure reasons — surfaced by the Python client when
 # allow is false.
-deny_reasons[msg] {
+deny_reasons contains msg if {
     not evidence_has_raw_output
     msg := "evidence missing raw shell output (no '$ ' prefix detected)"
 }
 
-deny_reasons[msg] {
+deny_reasons contains msg if {
     not store_writes_complete
     missing := required_stores - written_stores
     msg := sprintf("store writes incomplete for %v: missing %v", [input.directive_id, missing])
 }
 
-deny_reasons[msg] {
+deny_reasons contains msg if {
     not no_frozen_targets
     msg := sprintf("target files include frozen paths: %v", [frozen_hits])
 }


### PR DESCRIPTION
## Summary
- Updated `completion_claims.rego` from Rego v0 → v1 syntax (OPA 1.4.2 requires `contains X if` for partial set rules)
- OPA binary installed at `~/.local/bin/opa` (v1.4.2, static linux_amd64)
- All three gates verified live: G1 (evidence), G2 (stores), G3 (frozen paths)

## Verification (R9 raw evidence)
```
$ opa check infra/opa/policies/completion_claims.rego
(no output = pass)

$ curl -s http://localhost:8181/health
{}

Allow path: allow=true, deny_reasons=[]
Deny path: allow=false, reasons=["evidence missing...", "store writes incomplete..."]

Python client: check_completion_claim() returns correct GatekeeperResult against live OPA
```

## Companion PR
- PR #479 (Aiden): Gatekeeper governance_events emit instrumentation

## Test plan
- [x] OPA syntax check passes
- [x] OPA server starts and /health returns 200
- [x] Allow path returns allow=true
- [x] Deny path returns allow=false with correct reasons
- [x] Python gatekeeper client works against live OPA
- [ ] Joint verification: governance_events row after both PRs merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)