### PR TITLE
[AIDEN] feat(governance): Phase 3 — TG alert helper + DoD Gatekeeper invocation gate

### DIFF
--- a/DEFINITION_OF_DONE.md
+++ b/DEFINITION_OF_DONE.md
@@ -64,6 +64,21 @@ Not a summary. Not a tick. Verbatim output.
 [ ] C4. PR URL
     Paste full GitHub PR URL. No shortlinks.
 
+[ ] C5. Gatekeeper verdict obtained (GOV-PHASE3)
+    Command: scripts/check_claim.py --help to see flags.
+    Run check_claim.py with the directive's callsign,
+    directive_id, claim_text, evidence (raw verification
+    output with '$ ' prefix), target_files, and the four
+    store_writes (manual / ceo_memory / cis_directive_metrics
+    / drive_mirror — only those that apply to this directive).
+    Paste verbatim: verdict line + the governance_events row
+    inserted (callsign, event_type, directive_id, allow,
+    reasons).
+    Required: allow=true. If allow=false, address the
+    deny_reasons and re-run the gate before pasting any
+    completion claim. Deny verdict triggers a TG alert
+    automatically — do not suppress it.
+
 ---
 
 ## THREE-STORE COMPLETION

--- a/src/governance/tg_alert.py
+++ b/src/governance/tg_alert.py
@@ -1,0 +1,53 @@
+"""GOV-PHASE3 — TG alert helper for Gatekeeper deny verdicts.
+
+Wraps the `tg -g` relay CLI used by both bots. Used by scripts/check_claim.py
+to surface deny verdicts to the supergroup so peer + Dave see them in real
+time, not just buried in governance_events.
+
+Contract:
+    alert_on_deny(callsign, directive_id, reasons, claim_text_sha256_16) -> bool
+
+Returns True if relay write succeeded, False otherwise. Wrapped — never raises.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+_TG_BIN = "tg"
+_TIMEOUT_S = 5
+
+
+def alert_on_deny(
+    callsign: str,
+    directive_id: str,
+    reasons: Iterable[str],
+    claim_text_sha256_16: str,
+) -> bool:
+    """Post a Gatekeeper deny verdict to the TG supergroup via `tg -g`.
+
+    Returns True on subprocess exit 0, False on any failure.
+    """
+    if shutil.which(_TG_BIN) is None:
+        logger.warning("alert_on_deny: tg binary not on PATH; skipping")
+        return False
+
+    reason_lines = "\n".join(f"  - {r}" for r in reasons) or "  (no reasons reported)"
+    msg = (
+        f"[GATEKEEPER-DENY:{callsign}] directive={directive_id} "
+        f"claim_hash={claim_text_sha256_16}\n"
+        f"deny_reasons:\n{reason_lines}"
+    )
+    try:
+        result = subprocess.run(
+            [_TG_BIN, "-g", msg],
+            capture_output=True, text=True, timeout=_TIMEOUT_S, check=False,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("alert_on_deny: subprocess failed: %s", exc)
+        return False

--- a/tests/governance/test_tg_alert.py
+++ b/tests/governance/test_tg_alert.py
@@ -1,0 +1,65 @@
+"""GOV-PHASE3 — TG alert helper tests."""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+from src.governance.tg_alert import alert_on_deny
+
+
+def _ok_subproc() -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.stdout = ""
+    proc.stderr = ""
+    return proc
+
+
+def test_alert_returns_true_on_relay_success() -> None:
+    with patch("shutil.which", return_value="/usr/bin/tg"), \
+         patch("subprocess.run", return_value=_ok_subproc()) as run:
+        ok = alert_on_deny(
+            callsign="aiden",
+            directive_id="SYNTH-3",
+            reasons=["G1 fail", "G2 fail"],
+            claim_text_sha256_16="abc1234567890def",
+        )
+    assert ok is True
+    args, kwargs = run.call_args
+    cmd = args[0]
+    assert cmd[0] == "tg"
+    assert cmd[1] == "-g"
+    msg = cmd[2]
+    assert "[GATEKEEPER-DENY:aiden]" in msg
+    assert "directive=SYNTH-3" in msg
+    assert "claim_hash=abc1234567890def" in msg
+    assert "G1 fail" in msg and "G2 fail" in msg
+
+
+def test_alert_returns_false_when_tg_missing() -> None:
+    with patch("shutil.which", return_value=None):
+        ok = alert_on_deny(
+            callsign="aiden", directive_id="X", reasons=[],
+            claim_text_sha256_16="0" * 16,
+        )
+    assert ok is False
+
+
+def test_alert_returns_false_on_subprocess_error() -> None:
+    with patch("shutil.which", return_value="/usr/bin/tg"), \
+         patch("subprocess.run", side_effect=OSError("relay down")):
+        ok = alert_on_deny(
+            callsign="aiden", directive_id="X", reasons=["G3"],
+            claim_text_sha256_16="0" * 16,
+        )
+    assert ok is False
+
+
+def test_alert_handles_empty_reasons() -> None:
+    with patch("shutil.which", return_value="/usr/bin/tg"), \
+         patch("subprocess.run", return_value=_ok_subproc()) as run:
+        alert_on_deny(
+            callsign="aiden", directive_id="X", reasons=[],
+            claim_text_sha256_16="0" * 16,
+        )
+    msg = run.call_args[0][0][2]
+    assert "(no reasons reported)" in msg


### PR DESCRIPTION
## Summary
Phase 3 v1 (observe-only manual CLI) — Aiden side of the split.

- **`src/governance/tg_alert.py`** — `alert_on_deny()` helper used by `scripts/check_claim.py` (Elliot's side) to surface Gatekeeper deny verdicts to the supergroup. Shells out to the `tg -g` relay; wrapped, never raises.
- **`DEFINITION_OF_DONE.md`** — adds gate **C5** requiring agents to invoke `scripts/check_claim.py` before pasting any completion claim. Allow=true required; deny triggers automatic TG alert.

API contract for Elliot's CLI:
```python
from src.governance.tg_alert import alert_on_deny
alert_on_deny(callsign, directive_id, reasons, claim_text_sha256_16)  # bool
```

## Test plan
- [x] `pytest tests/governance/test_tg_alert.py -v` — 4/4 pass (happy path / missing-tg / subprocess error / empty reasons)
- [x] DEFINITION_OF_DONE.md edit confined to a single new gate item (no drift)
- [ ] Live wiring verified once Elliot's `check_claim.py` PR lands and imports `alert_on_deny`

## Companion PR
- Elliot: OPA systemd service + `scripts/check_claim.py` (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)