### PR TITLE
[ELLIOT] feat(governance): Phase 3 — check_claim.py CLI + OPA systemd service

### DIFF
--- a/infra/opa/agency-os-opa.service
+++ b/infra/opa/agency-os-opa.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Agency OS OPA Policy Server
+After=network.target
+
+[Service]
+ExecStart=/home/elliotbot/.local/bin/opa run --server /home/elliotbot/clawd/Agency_OS/infra/opa/policies/ --addr :8181
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/scripts/check_claim.py
+++ b/scripts/check_claim.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""scripts/check_claim.py — CLI verification gate for gatekeeper completion claims.
+
+Calls check_completion_claim() from src.governance.gatekeeper against a live OPA
+instance. Used by agents before reporting directive completion.
+
+Usage (flags):
+    scripts/check_claim.py --callsign elliot --directive-id GOV-PHASE3 \\
+      --claim-text "Phase 3 complete" \\
+      --evidence "$ pytest -q\\n5 passed" \\
+      --target-files "src/foo.py,src/bar.py" \\
+      --store-writes '[{"directive_id":"GOV-PHASE3","store":"manual"},...]'
+
+Usage (stdin):
+    echo '{...}' | scripts/check_claim.py --stdin
+
+Exit codes:
+    0  — ALLOW (claim accepted)
+    1  — DENY  (claim rejected, reasons printed to stderr)
+    2  — usage / argument error
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo-root on sys.path so src.governance imports resolve regardless of cwd.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _send_tg_alert(message: str) -> None:
+    """Fire-and-forget TG alert via the tg shell helper."""
+    try:
+        subprocess.run(
+            ["tg", "-g", message],
+            check=False,
+            capture_output=True,
+            timeout=10,
+        )
+    except Exception:
+        pass  # Never block the gate on a notification failure
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="check_claim.py",
+        description=(
+            "Gatekeeper CLI — evaluates a completion claim against the OPA "
+            "policy.  Exits 0 on ALLOW, 1 on DENY."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read a JSON payload from stdin instead of using individual flags.",
+    )
+    p.add_argument("--callsign", help="Agent callsign (e.g. elliot, atlas).")
+    p.add_argument("--directive-id", dest="directive_id", help="Directive identifier.")
+    p.add_argument("--claim-text", dest="claim_text", help="What the agent claims to have done.")
+    p.add_argument("--evidence", help="Raw terminal output proving the claim.")
+    p.add_argument(
+        "--target-files",
+        dest="target_files",
+        help="Comma-separated list of files touched by this directive.",
+    )
+    p.add_argument(
+        "--store-writes",
+        dest="store_writes",
+        help='JSON array of {directive_id, store} objects covering the four-store write.',
+    )
+    p.add_argument(
+        "--frozen-paths",
+        dest="frozen_paths",
+        default="",
+        help="Comma-separated frozen paths (optional; defaults to live registry).",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the payload that would be sent to OPA without calling it.",
+    )
+    return p
+
+
+def _payload_from_args(args: argparse.Namespace) -> dict:
+    """Build the claim payload from CLI flags."""
+    missing = []
+    for field in ("callsign", "directive_id", "claim_text", "evidence", "target_files", "store_writes"):
+        if not getattr(args, field, None):
+            missing.append(f"--{field.replace('_', '-')}")
+    if missing:
+        print(f"error: missing required flags: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        store_writes = json.loads(args.store_writes)
+    except json.JSONDecodeError as exc:
+        print(f"error: --store-writes is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    target_files = [f.strip() for f in args.target_files.split(",") if f.strip()]
+    frozen_paths = (
+        [p.strip() for p in args.frozen_paths.split(",") if p.strip()]
+        if args.frozen_paths
+        else None
+    )
+
+    return {
+        "callsign": args.callsign,
+        "directive_id": args.directive_id,
+        "claim_text": args.claim_text,
+        "evidence": args.evidence,
+        "target_files": target_files,
+        "store_writes": store_writes,
+        "frozen_paths": frozen_paths,
+    }
+
+
+def _payload_from_stdin() -> dict:
+    """Read and parse a JSON payload from stdin."""
+    try:
+        return json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"error: stdin is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.stdin:
+        payload = _payload_from_stdin()
+    else:
+        payload = _payload_from_args(args)
+
+    if args.dry_run:
+        print("DRY-RUN — payload that would be sent to OPA:")
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    from src.governance.gatekeeper import check_completion_claim
+
+    frozen_paths = payload.pop("frozen_paths", None)
+
+    result = check_completion_claim(
+        frozen_paths=frozen_paths,
+        **payload,
+    )
+
+    claim_text = payload.get("claim_text", "")
+    directive_id = payload.get("directive_id", "")
+    callsign = payload.get("callsign", "")
+    truncated = claim_text[:80] + ("..." if len(claim_text) > 80 else "")
+
+    if result.allow:
+        print(f"ALLOW: {truncated}")
+        return 0
+
+    reasons_str = "; ".join(result.reasons) if result.reasons else "policy denied (no reasons returned)"
+    print(f"DENY: {reasons_str}", file=sys.stderr)
+
+    _send_tg_alert(
+        f"[GOVERNANCE] Gatekeeper DENY — directive={directive_id} "
+        f"callsign={callsign} reasons: {reasons_str}"
+    )
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- `scripts/check_claim.py` — CLI verification gate for completion claims
- `infra/opa/agency-os-opa.service` — systemd user service (auto-start, survives reboot)
- OPA installed at `~/.local/bin/opa` v1.4.2, runs on :8181

## Verification (R9 raw evidence)
```
$ python3 scripts/check_claim.py --help
usage: check_claim.py [-h] [--stdin] [--callsign CALLSIGN] ...

$ systemctl --user status agency-os-opa.service
Active: active (running) since Fri 2026-05-01 10:53:33 UTC

$ curl -s localhost:8181/health
{}

$ python3 scripts/check_claim.py --callsign test ... (all 4 stores)
ALLOW: test
EXIT: 0

$ python3 scripts/check_claim.py --callsign test ... (1 store, no evidence)
DENY: evidence missing raw shell output; store writes incomplete
EXIT: 1
```

## Companion PR
- PR #481 (Aiden): TG alert helper + DEFINITION_OF_DONE.md C5 gate

## Test plan
- [x] --help exits 0
- [x] OPA service active + enabled
- [x] Health check returns {}
- [x] Allow path exits 0
- [x] Deny path exits 1 with reasons
- [ ] Wire src.governance.tg_alert.alert_on_deny() after #481 merges (currently inline tg -g)

🤖 Generated with [Claude Code](https://claude.com/claude-code)