### PR TITLE
[ELLIOT] feat(governance): Phase 4 — SessionEnd auto-enforcement + check_claim cleanup + tests

### DIFF
--- a/scripts/check_claim.py
+++ b/scripts/check_claim.py
@@ -22,8 +22,8 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -32,18 +32,6 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-
-def _send_tg_alert(message: str) -> None:
-    """Fire-and-forget TG alert via the tg shell helper."""
-    try:
-        subprocess.run(
-            ["tg", "-g", message],
-            check=False,
-            capture_output=True,
-            timeout=10,
-        )
-    except Exception:
-        pass  # Never block the gate on a notification failure
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -167,10 +155,17 @@ def main() -> int:
     reasons_str = "; ".join(result.reasons) if result.reasons else "policy denied (no reasons returned)"
     print(f"DENY: {reasons_str}", file=sys.stderr)
 
-    _send_tg_alert(
-        f"[GOVERNANCE] Gatekeeper DENY — directive={directive_id} "
-        f"callsign={callsign} reasons: {reasons_str}"
-    )
+    try:
+        from src.governance.tg_alert import alert_on_deny
+        claim_hash = hashlib.sha256(claim_text.encode()).hexdigest()[:16]
+        alert_on_deny(
+            callsign=callsign,
+            directive_id=directive_id,
+            reasons=result.reasons or [reasons_str],
+            claim_text_sha256_16=claim_hash,
+        )
+    except Exception:
+        pass  # Never block the gate on a notification failure
 
     return 1
 

--- a/scripts/session_end_hook.py
+++ b/scripts/session_end_hook.py
@@ -249,12 +249,13 @@ def main() -> int:
     memory_report = write_memory(summary)
 
     # ── Step 4: Gatekeeper soft-validation (observe-only, never blocks) ────────
+    # F3: only fire when a real DIRECTIVE_ID is set — skip for routine sessions
     gatekeeper_report = {"checked": False, "allow": None}
+    directive_id = os.environ.get("DIRECTIVE_ID", "")
     try:
         from src.governance.gatekeeper import check_completion_claim, opa_health
-        if opa_health():
+        if directive_id and opa_health():
             callsign = os.environ.get("CALLSIGN", "unknown")
-            directive_id = os.environ.get("DIRECTIVE_ID", "session-end-auto")
             result = check_completion_claim(
                 callsign=callsign,
                 directive_id=directive_id,

--- a/scripts/session_end_hook.py
+++ b/scripts/session_end_hook.py
@@ -248,11 +248,50 @@ def main() -> int:
     summary = _build_summary(hook_input, mirror_report)
     memory_report = write_memory(summary)
 
+    # ── Step 4: Gatekeeper soft-validation (observe-only, never blocks) ────────
+    gatekeeper_report = {"checked": False, "allow": None}
+    try:
+        from src.governance.gatekeeper import check_completion_claim, opa_health
+        if opa_health():
+            callsign = os.environ.get("CALLSIGN", "unknown")
+            directive_id = os.environ.get("DIRECTIVE_ID", "session-end-auto")
+            result = check_completion_claim(
+                callsign=callsign,
+                directive_id=directive_id,
+                claim_text=f"Session ended: {summary.get('reason', 'unknown')}",
+                evidence=f"$ session_end auto-check\nceo_memory={memory_report.get('ceo_memory_upserted')}, daily_log={memory_report.get('daily_log_written')}",
+                target_files=[],
+                store_writes=[sw for sw in [
+                    {"directive_id": directive_id, "store": "ceo_memory"} if memory_report.get("ceo_memory_upserted") else None,
+                    {"directive_id": directive_id, "store": "manual"} if mirror_report.get("mirror_invoked") else None,
+                ] if sw is not None],
+                frozen_paths=[],
+            )
+            gatekeeper_report["checked"] = True
+            gatekeeper_report["allow"] = result.allow
+            if not result.allow:
+                logger.warning("Gatekeeper DENY (observe-only): %s", result.reasons)
+                try:
+                    from src.governance.tg_alert import alert_on_deny
+                    import hashlib
+                    claim_hash = hashlib.sha256(f"session-end-{callsign}".encode()).hexdigest()[:16]
+                    alert_on_deny(
+                        callsign=callsign,
+                        directive_id=directive_id,
+                        reasons=result.reasons,
+                        claim_text_sha256_16=claim_hash,
+                    )
+                except Exception:
+                    pass
+    except Exception as exc:
+        logger.info("Gatekeeper check skipped (non-fatal): %s", exc)
+
     logger.info(
-        "Done. mirror_invoked=%s ceo_memory=%s daily_log=%s",
+        "Done. mirror_invoked=%s ceo_memory=%s daily_log=%s gatekeeper_allow=%s",
         mirror_report.get("mirror_invoked"),
         memory_report.get("ceo_memory_upserted"),
         memory_report.get("daily_log_written"),
+        gatekeeper_report.get("allow"),
     )
     # Always exit 0 so Claude Code never blocks SessionEnd on us.
     return 0

--- a/tests/scripts/test_check_claim.py
+++ b/tests/scripts/test_check_claim.py
@@ -1,0 +1,94 @@
+"""Tests for scripts/check_claim.py — CLI verification gate."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = str(_REPO_ROOT / "scripts" / "check_claim.py")
+
+# Common required flags used across tests
+_REQUIRED_FLAGS = [
+    "--callsign", "testcallsign",
+    "--directive-id", "TEST-001",
+    "--claim-text", "Test claim text",
+    "--evidence", "$ pytest -q\n3 passed",
+    "--target-files", "src/foo.py",
+    "--store-writes", '[{"directive_id":"TEST-001","store":"manual"}]',
+]
+
+
+def test_help_exits_zero():
+    result = subprocess.run(
+        [sys.executable, _SCRIPT, "--help"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"Expected exit 0, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+    assert "check_claim" in result.stdout.lower() or "gatekeeper" in result.stdout.lower()
+
+
+def test_missing_required_flags_exits_two():
+    result = subprocess.run(
+        [sys.executable, _SCRIPT],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2, f"Expected exit 2 (missing flags), got {result.returncode}\n{result.stderr}"
+
+
+def test_dry_run_exits_zero():
+    result = subprocess.run(
+        [sys.executable, _SCRIPT, "--dry-run"] + _REQUIRED_FLAGS,
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"Expected exit 0 on dry-run, got {result.returncode}\n{result.stderr}"
+    assert "DRY" in result.stdout.upper(), f"Expected 'DRY RUN' in stdout, got: {result.stdout!r}"
+
+
+def test_allow_path_exits_zero():
+    """mock check_completion_claim returning allow=True → exit 0."""
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+
+    import importlib
+    import scripts.check_claim as check_claim_mod
+
+    mock_result = SimpleNamespace(allow=True, reasons=[])
+
+    with patch("scripts.check_claim.sys.argv", ["check_claim.py"] + _REQUIRED_FLAGS):
+        with patch.dict("sys.modules", {
+            "src.governance.gatekeeper": MagicMock(
+                check_completion_claim=MagicMock(return_value=mock_result),
+            ),
+        }):
+            exit_code = check_claim_mod.main()
+
+    assert exit_code == 0, f"Expected exit 0 on ALLOW, got {exit_code}"
+
+
+def test_deny_path_exits_one():
+    """mock check_completion_claim returning allow=False with reasons → exit 1."""
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+
+    import scripts.check_claim as check_claim_mod
+
+    mock_result = SimpleNamespace(allow=False, reasons=["missing store write: ceo_memory"])
+
+    with patch("scripts.check_claim.sys.argv", ["check_claim.py"] + _REQUIRED_FLAGS):
+        with patch.dict("sys.modules", {
+            "src.governance.gatekeeper": MagicMock(
+                check_completion_claim=MagicMock(return_value=mock_result),
+            ),
+            "src.governance.tg_alert": MagicMock(
+                alert_on_deny=MagicMock(return_value=False),
+            ),
+        }):
+            exit_code = check_claim_mod.main()
+
+    assert exit_code == 1, f"Expected exit 1 on DENY, got {exit_code}"


### PR DESCRIPTION
## Summary
- **SessionEnd hook**: now calls `check_completion_claim()` after writing memory (observe-only, never blocks)
- **check_claim.py refactor**: replaced inline `tg -g` subprocess with `src.governance.tg_alert.alert_on_deny()` import
- **Tests**: 5 pytest cases for check_claim.py CLI (help, missing flags, dry-run, allow, deny)

## Phase 4 observe-mode behavior
On session end: Gatekeeper fires → if deny → logs warning + TG alert + governance_events row. Session ALWAYS ends (exit 0). No hard-blocking until confidence soak.

## Verification (R9)
```
$ python3 scripts/check_claim.py --help → exit 0
$ python3 -c "import ast; ast.parse(open('scripts/session_end_hook.py').read())" → syntax OK
$ pytest tests/scripts/test_check_claim.py -v → 5 passed in 0.38s
$ scripts/check_claim.py --dry-run ... → DRY RUN payload, exit 0
```

## Test plan
- [x] CLI --help exits 0
- [x] session_end_hook.py syntax valid
- [x] 5 pytest cases pass
- [x] --dry-run works

🤖 Generated with [Claude Code](https://claude.com/claude-code)