### PR TITLE
[AIDEN] feat(memory): /recall TG command + conftest resilience (Track C2 / M2)

### DIFF
--- a/src/telegram_bot/chat_bot.py
+++ b/src/telegram_bot/chat_bot.py
@@ -36,6 +36,7 @@ from telegram.ext import (
 )
 
 from src.telegram_bot.save_handler import cmd_save
+from src.telegram_bot.recall_handler import cmd_recall
 from src.telegram_bot.memory_listener import find_relevant_memories, find_matching_commits, find_repo_mentions, format_memory_context, auto_capture_message
 
 # ---------------------------------------------------------------------------
@@ -1304,6 +1305,7 @@ def main() -> None:
     app.add_handler(CommandHandler("history", cmd_history))
     app.add_handler(CommandHandler("relay", cmd_relay))
     app.add_handler(CommandHandler("save", cmd_save))
+    app.add_handler(CommandHandler("recall", cmd_recall))
     app.add_handler(CommandHandler("update", cmd_update))
     app.add_handler(CommandHandler("help", cmd_help))
     # Media handlers before text fallback

--- a/src/telegram_bot/recall_handler.py
+++ b/src/telegram_bot/recall_handler.py
@@ -1,0 +1,57 @@
+"""GOV-PHASE2 Track C2 / M2 — /recall TG command handler.
+
+Surfaces the existing src.memory.recall.recall() function as a TG slash
+command. Output groups results by source_type with brief previews.
+
+Hybrid Mem0 retrieval is M3 territory and lives in
+src.telegram_bot.memory_listener.recall_via_mem0; this handler uses the
+canonical Supabase-backed recall() for now.
+"""
+from __future__ import annotations
+
+import logging
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from src.memory.recall import recall
+
+logger = logging.getLogger(__name__)
+
+_PREVIEW_LEN = 80
+_MAX_RESULTS_PER_TYPE = 3
+_DEFAULT_N = 20
+
+
+async def cmd_recall(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """/recall [topic] — surface high-value memories grouped by type."""
+    args: list[str] = context.args or []
+    topic = " ".join(args).strip() or None
+
+    try:
+        grouped = recall(topic=topic, n=_DEFAULT_N)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("[recall] retrieval failed: %s", exc)
+        await update.message.reply_text(f"Recall failed: {exc}")
+        return
+
+    if not grouped:
+        msg = "No memories found." if topic is None else f"No memories matching '{topic}'."
+        await update.message.reply_text(msg)
+        return
+
+    lines: list[str] = []
+    header = f"Recall: '{topic}'" if topic else "Recall: high-value memories"
+    lines.append(header)
+    for source_type in sorted(grouped):
+        memories = grouped[source_type][:_MAX_RESULTS_PER_TYPE]
+        lines.append(f"\n[{source_type}] ({len(grouped[source_type])} total)")
+        for m in memories:
+            preview = m.content[:_PREVIEW_LEN] + ("..." if len(m.content) > _PREVIEW_LEN else "")
+            lines.append(f"  - {preview}")
+
+    await update.message.reply_text("\n".join(lines))
+    logger.info(
+        "[recall] topic=%r returned %d types, %d total memories",
+        topic, len(grouped), sum(len(v) for v in grouped.values()),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,11 @@ def _cleanup_polluted_modules():
                 if "takes 0 positional arguments" in str(e):
                     # This IS the polluted lambda — delete it so fresh import happens
                     del sys.modules["src.memory.store"]
+            except ValueError:
+                # Real store validates source_type — 'test' is invalid, which
+                # confirms this is the production store, not the polluted lambda.
+                # No action needed.
+                pass
     yield
     # Cleanup after all tests (optional, for hygiene)
 

--- a/tests/telegram_bot/test_recall_handler.py
+++ b/tests/telegram_bot/test_recall_handler.py
@@ -1,0 +1,76 @@
+"""GOV-PHASE2 Track C2 / M2 — /recall TG command handler tests."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.memory.types import Memory
+from src.telegram_bot import recall_handler
+
+
+def _mk_memory(content: str, source_type: str) -> Memory:
+    return Memory(
+        id="00000000-0000-0000-0000-000000000000",
+        callsign="aiden",
+        source_type=source_type,
+        content=content,
+        typed_metadata={},
+        tags=[source_type],
+        valid_from="2026-05-01T00:00:00Z",
+        valid_to=None,
+        created_at="2026-05-01T00:00:00Z",
+    )
+
+
+def _mk_update_context(args: list[str]):
+    update = MagicMock()
+    update.message.reply_text = AsyncMock()
+    ctx = MagicMock()
+    ctx.args = args
+    return update, ctx
+
+
+@pytest.mark.asyncio
+async def test_recall_no_results_with_topic():
+    update, ctx = _mk_update_context(["nonexistent"])
+    with patch.object(recall_handler, "recall", return_value={}):
+        await recall_handler.cmd_recall(update, ctx)
+    update.message.reply_text.assert_called_once()
+    assert "nonexistent" in update.message.reply_text.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_recall_no_results_no_topic():
+    update, ctx = _mk_update_context([])
+    with patch.object(recall_handler, "recall", return_value={}):
+        await recall_handler.cmd_recall(update, ctx)
+    update.message.reply_text.assert_called_once()
+    assert "No memories found" in update.message.reply_text.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_recall_groups_and_truncates():
+    update, ctx = _mk_update_context(["test"])
+    grouped = {
+        "decision": [_mk_memory("decision content one", "decision")] * 5,
+        "pattern": [_mk_memory("pattern long " + "x" * 200, "pattern")],
+    }
+    with patch.object(recall_handler, "recall", return_value=grouped):
+        await recall_handler.cmd_recall(update, ctx)
+    msg = update.message.reply_text.call_args[0][0]
+    assert "Recall: 'test'" in msg
+    assert "[decision]" in msg and "(5 total)" in msg
+    assert "[pattern]" in msg and "(1 total)" in msg
+    # Truncation: only 3 per type, and content >80 chars gets ellipsis
+    assert msg.count("decision content one") == 3
+    assert "..." in msg
+
+
+@pytest.mark.asyncio
+async def test_recall_handles_exception():
+    update, ctx = _mk_update_context([])
+    with patch.object(recall_handler, "recall", side_effect=RuntimeError("db down")):
+        await recall_handler.cmd_recall(update, ctx)
+    update.message.reply_text.assert_called_once()
+    assert "Recall failed" in update.message.reply_text.call_args[0][0]


### PR DESCRIPTION
## Summary
Wires the existing `src.memory.recall.recall()` function as a Telegram slash command. Closes Mem0 audit gap **M2** per `ceo:mem0_decision_2026-05-01` — `/save` was already wired via `save_handler`, `/recall` had the backing function but no TG handler.

In-pass fix: `tests/conftest.py` `_cleanup_polluted_modules` fixture probes `store_module.store("aiden","test","test")` to detect pollution; real store raises `ValueError` on invalid source_type. Fixture now also catches `ValueError` as additional evidence the production store is in place. Was failing collection for any new test that imports `src.memory.store` at collect time (incl. this PR). Per GOV-10 Resolve-Now-Not-Later.

Hybrid Mem0 recall stays in `memory_listener.recall_via_mem0` (controlled by `MEMORY_RECALL_BACKEND` env, M1 territory — Elliot's PR #485).

## Test plan
- [x] `pytest tests/telegram_bot/test_recall_handler.py -v` → 4/4 pass (no-topic, with-topic, grouped+truncated, exception fallback)
- [x] `pytest tests/governance/test_gatekeeper_emit.py tests/governance/test_tg_alert.py -q` → 7/7 pass (no regression)
- [x] `git diff --cached --stat` → 4 files, +140/-0
- [ ] Live `/recall` in TG once merged + bot restarted

## Companion PR
- Elliot #485 (Track C2 / M1): mem0ai package install in venv + filters wrapper for SDK 2.0.1 + `MEMORY_RECALL_BACKEND=hybrid` in `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)