### PR TITLE
[ELLIOT] feat(memory): consolidation migration + session_end writer update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,16 +71,17 @@ Never call external services ad-hoc. No credential hunting.
 
 Session START query:
 ```sql
-SELECT type, LEFT(content, 200) as preview, created_at::date as date
-FROM elliot_internal.memories
-WHERE deleted_at IS NULL AND type IN ('daily_log', 'core_fact')
+SELECT source_type AS type, LEFT(content, 200) AS preview, created_at::date AS date
+FROM public.agent_memories
+WHERE callsign = 'elliot' AND state != 'archived'
+  AND source_type IN ('daily_log', 'core_fact')
 ORDER BY created_at DESC LIMIT 10;
 ```
 
 Session END — write daily_log before closing:
 ```sql
-INSERT INTO elliot_internal.memories (id, type, content, metadata, created_at)
-VALUES (gen_random_uuid(), 'daily_log', '<summary: what was done, PRs, decisions, blockers>', '{}'::jsonb, NOW());
+INSERT INTO public.agent_memories (id, callsign, source_type, content, typed_metadata, created_at, valid_from, state)
+VALUES (gen_random_uuid(), 'elliot', 'daily_log', '<summary: what was done, PRs, decisions, blockers>', '{}'::jsonb, NOW(), NOW(), 'confirmed');
 ```
 
 ## Governance Laws (Active)

--- a/scripts/migrate_memories.py
+++ b/scripts/migrate_memories.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Migrate elliot_internal.memories → public.agent_memories (unified SSOT).
+
+Usage:
+    python3 scripts/migrate_memories.py          # dry-run (safe, no writes)
+    python3 scripts/migrate_memories.py --execute  # actually write rows
+
+Field mapping:
+    type        → source_type
+    metadata    → typed_metadata
+    content     → content
+    created_at  → created_at + valid_from
+    <fixed>     → callsign='elliot', state='confirmed'
+
+Deduplication: skip rows whose content already exists in agent_memories
+(matched by content equality, not content_hash, since agent_memories has
+no content_hash column).
+
+Safety guarantees:
+    - Dry-run by default (--execute required to write)
+    - Never deletes from elliot_internal.memories (source kept as backup)
+    - Idempotent: re-running produces zero new inserts if all rows present
+    - Reports: total, skipped, migrated, errors
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[migrate-memories] %(levelname)s: %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENV_FILE = "/home/elliotbot/.config/agency-os/.env"
+
+
+# ── DSN resolution (same pattern as session_end_hook.py) ───────────────────
+
+def _supabase_dsn() -> str | None:
+    raw = (
+        os.environ.get("DATABASE_URL")
+        or os.environ.get("SUPABASE_DB_URL")
+        or ""
+    ).strip()
+    if raw:
+        return raw.replace("postgresql+asyncpg://", "postgresql://")
+    try:
+        sys.path.insert(0, str(REPO_ROOT))
+        from dotenv import load_dotenv
+        load_dotenv(ENV_FILE)
+        from src.config.settings import settings  # type: ignore[import-not-found]
+        return (settings.database_url or "").replace(
+            "postgresql+asyncpg://", "postgresql://"
+        ) or None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("DSN unavailable: %s", exc)
+        return None
+
+
+# ── field mapping ───────────────────────────────────────────────────────────
+
+def _map_row(row: dict) -> dict:
+    """Map one elliot_internal.memories row → agent_memories insert dict."""
+    metadata = row.get("metadata") or {}
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except json.JSONDecodeError:
+            metadata = {"raw": metadata}
+
+    return {
+        "callsign": "elliot",
+        "source_type": row.get("type") or "unknown",
+        "content": row.get("content") or "",
+        "typed_metadata": metadata,
+        "created_at": row.get("created_at"),
+        "valid_from": row.get("created_at"),
+        "state": "confirmed",
+    }
+
+
+# ── core migration logic ────────────────────────────────────────────────────
+
+async def _fetch_legacy(conn) -> list[dict]:
+    rows = await conn.fetch(
+        """
+        SELECT id, type, content, metadata, created_at
+        FROM elliot_internal.memories
+        WHERE deleted_at IS NULL
+        ORDER BY created_at ASC
+        """
+    )
+    return [dict(r) for r in rows]
+
+
+async def _fetch_existing_contents(conn) -> set[str]:
+    rows = await conn.fetch(
+        "SELECT content FROM public.agent_memories WHERE callsign = 'elliot'"
+    )
+    return {r["content"] for r in rows}
+
+
+async def _insert_row(conn, mapped: dict) -> None:
+    await conn.execute(
+        """
+        INSERT INTO public.agent_memories
+          (callsign, source_type, content, typed_metadata, created_at, valid_from, state)
+        VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
+        """,
+        mapped["callsign"],
+        mapped["source_type"],
+        mapped["content"],
+        json.dumps(mapped["typed_metadata"]),
+        mapped["created_at"],
+        mapped["valid_from"],
+        mapped["state"],
+    )
+
+
+async def _migrate(dsn: str, execute: bool) -> dict:
+    import asyncpg  # noqa: PLC0415
+
+    conn = await asyncpg.connect(dsn, statement_cache_size=0)
+    counts = {"total": 0, "skipped": 0, "migrated": 0, "errors": 0}
+    try:
+        legacy_rows = await _fetch_legacy(conn)
+        counts["total"] = len(legacy_rows)
+        logger.info("Fetched %d non-deleted rows from elliot_internal.memories", counts["total"])
+
+        existing = await _fetch_existing_contents(conn)
+        logger.info("Found %d existing elliot rows in agent_memories (dedup set)", len(existing))
+
+        for row in legacy_rows:
+            mapped = _map_row(row)
+            if mapped["content"] in existing:
+                counts["skipped"] += 1
+                continue
+
+            if not execute:
+                logger.debug("DRY-RUN: would insert source_type=%s created_at=%s",
+                             mapped["source_type"], mapped["created_at"])
+                counts["migrated"] += 1
+                continue
+
+            try:
+                await _insert_row(conn, mapped)
+                existing.add(mapped["content"])  # prevent in-batch dupes
+                counts["migrated"] += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Insert failed for row (type=%s): %s", mapped["source_type"], exc)
+                counts["errors"] += 1
+
+    finally:
+        await conn.close()
+
+    return counts
+
+
+# ── entry-point ─────────────────────────────────────────────────────────────
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Migrate elliot_internal.memories → public.agent_memories",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        default=False,
+        help="Actually write rows. Default is dry-run (no writes).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    mode = "EXECUTE" if args.execute else "DRY-RUN"
+    logger.info("Mode: %s", mode)
+
+    dsn = _supabase_dsn()
+    if not dsn:
+        logger.error("No DATABASE_URL found — cannot connect. Aborting.")
+        return 1
+
+    counts = asyncio.run(_migrate(dsn, execute=args.execute))
+
+    print(f"\n=== Migration report ({mode}) ===")
+    print(f"  Total legacy rows:  {counts['total']}")
+    print(f"  Already in target:  {counts['skipped']}")
+    print(f"  Migrated:           {counts['migrated']}")
+    print(f"  Errors:             {counts['errors']}")
+    if not args.execute:
+        print("\n  (DRY-RUN — re-run with --execute to apply)")
+
+    return 0 if counts["errors"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/session_end_hook.py
+++ b/scripts/session_end_hook.py
@@ -12,8 +12,8 @@ reason). Performs three best-effort steps:
      fresh content to the Drive doc.
   2. Writes a compact session-end summary into public.ceo_memory keyed
      `ceo:session_end_<YYYY-MM-DD>`.
-  3. Writes a daily_log row into elliot_internal.memories so the next
-     session's start-up query finds the trail.
+  3. Writes a daily_log row into public.agent_memories (unified SSOT) so
+     the next session's start-up query finds the trail.
 
 Non-blocking: every step is wrapped in try/except so a failure in one
 step does NOT prevent the next from running, and the hook ALWAYS exits
@@ -171,7 +171,7 @@ def _build_summary(hook_input: dict, mirror_report: dict) -> dict:
 
 
 def write_memory(summary: dict) -> dict:
-    """Write to ceo_memory + elliot_internal.memories. Returns counts."""
+    """Write to ceo_memory + public.agent_memories. Returns counts."""
     out = {"ceo_memory_upserted": False, "daily_log_written": False}
     dsn = _supabase_dsn()
     if not dsn:
@@ -204,13 +204,16 @@ def write_memory(summary: dict) -> dict:
                     f"MANUAL mirror: changed={summary['manual_mirror'].get('changed')}, "
                     f"invoked={summary['manual_mirror'].get('mirror_invoked')}."
                 )
+                callsign = os.environ.get("CALLSIGN", "elliot")
                 await conn.execute(
                     """
-                    INSERT INTO elliot_internal.memories
-                      (id, type, content, metadata, created_at)
-                    VALUES (gen_random_uuid(), 'daily_log', $1, $2::jsonb, NOW())
+                    INSERT INTO public.agent_memories
+                      (id, callsign, source_type, content, typed_metadata,
+                       created_at, valid_from, state)
+                    VALUES (gen_random_uuid(), $1, 'daily_log', $2, $3::jsonb,
+                            NOW(), NOW(), 'confirmed')
                     """,
-                    content, json.dumps(summary),
+                    callsign, content, json.dumps(summary),
                 )
                 out["daily_log_written"] = True
             finally:

--- a/tests/scripts/test_migrate_memories.py
+++ b/tests/scripts/test_migrate_memories.py
@@ -1,0 +1,149 @@
+"""
+Tests for scripts/migrate_memories.py.
+
+Pure mocks — no database connections. Verifies:
+  - dry-run makes no execute() calls
+  - deduplication skips rows whose content already exists
+  - field mapping: type→source_type, metadata→typed_metadata
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "migrate_memories.py"
+_spec = importlib.util.spec_from_file_location("migrate_memories", _SCRIPT)
+migrate = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["migrate_memories"] = migrate
+_spec.loader.exec_module(migrate)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+def _legacy_row(**kwargs) -> dict:
+    defaults = {
+        "id": "abc123",
+        "type": "daily_log",
+        "content": "Session ended ok.",
+        "metadata": {"key": "val"},
+        "created_at": None,
+    }
+    return {**defaults, **kwargs}
+
+
+# ── test_dry_run_no_writes ─────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_dry_run_no_writes():
+    """In dry-run mode _insert_row must never be called."""
+    rows = [_legacy_row(content="row one"), _legacy_row(content="row two")]
+
+    async def fake_fetch_legacy(_conn):
+        return rows
+
+    async def fake_fetch_existing(_conn):
+        return set()  # nothing pre-exists → would migrate both
+
+    insert_calls = []
+
+    async def fake_insert(_conn, mapped):
+        insert_calls.append(mapped)
+
+    with (
+        patch.object(migrate, "_fetch_legacy", fake_fetch_legacy),
+        patch.object(migrate, "_fetch_existing_contents", fake_fetch_existing),
+        patch.object(migrate, "_insert_row", fake_insert),
+        patch("asyncpg.connect", new_callable=AsyncMock) as mock_connect,
+    ):
+        fake_conn = AsyncMock()
+        mock_connect.return_value = fake_conn
+
+        counts = await migrate._migrate("postgresql://fake", execute=False)
+
+    # dry-run: migrated counter increments but insert never fires
+    assert insert_calls == [], "insert must NOT be called in dry-run"
+    assert counts["migrated"] == 2
+    assert counts["skipped"] == 0
+    assert counts["errors"] == 0
+
+
+# ── test_dedup_skips_existing ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_dedup_skips_existing():
+    """Rows whose content is already in agent_memories are skipped."""
+    existing_content = "Already in target table."
+    rows = [
+        _legacy_row(content=existing_content),
+        _legacy_row(content="Brand new row."),
+    ]
+
+    async def fake_fetch_legacy(_conn):
+        return rows
+
+    async def fake_fetch_existing(_conn):
+        return {existing_content}
+
+    insert_calls = []
+
+    async def fake_insert(_conn, mapped):
+        insert_calls.append(mapped["content"])
+
+    with (
+        patch.object(migrate, "_fetch_legacy", fake_fetch_legacy),
+        patch.object(migrate, "_fetch_existing_contents", fake_fetch_existing),
+        patch.object(migrate, "_insert_row", fake_insert),
+        patch("asyncpg.connect", new_callable=AsyncMock) as mock_connect,
+    ):
+        fake_conn = AsyncMock()
+        mock_connect.return_value = fake_conn
+
+        counts = await migrate._migrate("postgresql://fake", execute=True)
+
+    assert counts["skipped"] == 1, "pre-existing row must be skipped"
+    assert counts["migrated"] == 1, "new row must be migrated"
+    assert insert_calls == ["Brand new row."]
+
+
+# ── test_field_mapping ─────────────────────────────────────────────────────
+
+def test_field_mapping_type_to_source_type():
+    """_map_row must copy type → source_type."""
+    row = _legacy_row(type="core_fact")
+    mapped = migrate._map_row(row)
+    assert mapped["source_type"] == "core_fact"
+    assert "type" not in mapped
+
+
+def test_field_mapping_metadata_to_typed_metadata():
+    """_map_row must copy metadata → typed_metadata as dict."""
+    row = _legacy_row(metadata={"directive": 42})
+    mapped = migrate._map_row(row)
+    assert mapped["typed_metadata"] == {"directive": 42}
+    assert "metadata" not in mapped
+
+
+def test_field_mapping_string_metadata_parsed():
+    """_map_row must JSON-parse string metadata."""
+    row = _legacy_row(metadata='{"foo": "bar"}')
+    mapped = migrate._map_row(row)
+    assert mapped["typed_metadata"] == {"foo": "bar"}
+
+
+def test_field_mapping_callsign_fixed():
+    """callsign must always be 'elliot' for legacy rows."""
+    row = _legacy_row()
+    mapped = migrate._map_row(row)
+    assert mapped["callsign"] == "elliot"
+
+
+def test_field_mapping_state_confirmed():
+    """Migrated rows must land in 'confirmed' state."""
+    mapped = migrate._map_row(_legacy_row())
+    assert mapped["state"] == "confirmed"


### PR DESCRIPTION
## Summary
Memory consolidation: migrate elliot_internal.memories → public.agent_memories (unified SSOT).

- `scripts/migrate_memories.py` — dry-run by default, dedup by content, maps type→source_type
- `scripts/session_end_hook.py` — writer now INSERTs to public.agent_memories (not legacy table)
- `CLAUDE.md` — session START/END SQL references updated to agent_memories

## Important: migration NOT auto-run
Dave executes when ready: `python3 scripts/migrate_memories.py --execute`

## Verification (R9)
```
$ python3 scripts/migrate_memories.py --help → exits 0
$ ast.parse session_end_hook.py → syntax OK
$ pytest tests/scripts/test_migrate_memories.py -v → 7 passed in 0.19s
$ grep -c 'agent_memories' scripts/session_end_hook.py → 3
```

## Test plan
- [x] Migration script --help exits 0
- [x] session_end_hook.py syntax valid
- [x] 7 pytest cases pass (dry-run, dedup, field mapping)
- [x] CLAUDE.md references updated
- [ ] Production run: `python3 scripts/migrate_memories.py --execute` (Dave-triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)