### PR TITLE
[AIDEN] feat(observability): Auditor — Arize Phoenix self-hosted scaffold (Phase 2)

### DIFF
--- a/infra/phoenix/Dockerfile
+++ b/infra/phoenix/Dockerfile
@@ -1,0 +1,12 @@
+# Phase 2 — Auditor (Arize Phoenix self-hosted observability).
+# Phoenix UI: port 6006. OTLP ingest: 4317 (gRPC), 4318 (HTTP).
+# Persistent SQLite state at /tmp/phoenix to survive restarts (volume mount).
+
+FROM arizephoenix/phoenix:latest
+
+EXPOSE 6006 4317 4318
+
+ENV PHOENIX_PORT=6006
+ENV PHOENIX_GRPC_PORT=4317
+ENV PHOENIX_WORKING_DIR=/tmp/phoenix
+ENV PHOENIX_HOST=0.0.0.0

--- a/infra/phoenix/README.md
+++ b/infra/phoenix/README.md
@@ -1,0 +1,78 @@
+# Auditor — Arize Phoenix self-hosted observability
+
+Phase 2 roadmap component. Self-hosted Phoenix instance for governance-event
+traces and LLM-call observability. Complement to the COO bot — COO summarises
+plain-English; Phoenix shows the raw timeline + drill-down.
+
+## Why Phoenix
+
+- Self-hosted, $0 marginal (Railway compute only)
+- OTLP ingest (gRPC 4317, HTTP 4318) — same protocol used by OpenAI tracing
+- UI at :6006 — trace inspection, span timing, latency histograms
+- SQLite persistence (volume-mounted)
+
+## Ports
+
+| Port | Purpose |
+|------|---------|
+| 6006 | Web UI + REST API |
+| 4317 | OTLP gRPC ingest (Phoenix native + standard OTel SDKs) |
+| 4318 | OTLP HTTP ingest |
+
+## Deploying on Railway
+
+```bash
+railway up --service auditor-phoenix \
+  --dockerfile infra/phoenix/Dockerfile
+```
+
+Add a persistent volume mount at `/tmp/phoenix` so trace history survives
+restarts. The `railway.json` here points Railway at this Dockerfile +
+healthcheck on `/healthz`.
+
+Env vars:
+- `PHOENIX_PORT=6006` (UI)
+- `PHOENIX_GRPC_PORT=4317`
+- `PHOENIX_WORKING_DIR=/tmp/phoenix`
+- `PHOENIX_HOST=0.0.0.0` (Railway internal binding)
+
+## Smoke test (post-deploy)
+
+```bash
+curl "https://${PHOENIX_PUBLIC_HOST}/healthz"
+# Expected: HTTP 200, body {"status":"healthy"}
+```
+
+Open `https://${PHOENIX_PUBLIC_HOST}/` for the UI.
+
+## What's not in v1 (follow-up)
+
+- **Python adapter** — `src/observability/phoenix_client.py` to ingest
+  `public.governance_events` rows as Phoenix spans. Sketch:
+  ```python
+  from openinference.instrumentation import OpenInferenceTracer
+  tracer = OpenInferenceTracer(endpoint="http://auditor-phoenix.railway.internal:4317")
+  tracer.span("gatekeeper_decision", attributes={...}).end()
+  ```
+- **OpenAI auto-tracing** — `phoenix.otel.register(project_name="agency-os")`
+  in service entry points to capture every OpenAI call.
+- **CI dashboard** — daily auto-snapshot of Hit Rate / Gatekeeper allow-rate
+  / agent token spend.
+
+These are separate directives once Phoenix is verified live.
+
+## Cost estimate
+
+- Phoenix container: ~$5–10/month (small instance + 1GB SQLite volume)
+- No external API costs (self-hosted)
+
+Within the Railway spend Dave pre-approved 2026-05-01.
+
+## Status — 2026-05-01
+
+- [x] Dockerfile + railway.json (this PR)
+- [x] Deploy spec (this README)
+- [ ] Service deployed on Railway
+- [ ] Smoke test passing
+- [ ] Python adapter (`src/observability/phoenix_client.py`) — follow-up
+- [ ] OpenAI auto-tracing wired — follow-up

--- a/infra/phoenix/railway.json
+++ b/infra/phoenix/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "dockerfilePath": "infra/phoenix/Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "phoenix serve",
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## Summary
Phase 2 roadmap Auditor component. Self-hosted Arize Phoenix deploy spec — ports 6006 UI / 4317 OTLP gRPC / 4318 OTLP HTTP. Complement to the COO bot: COO summarises plain-English, Phoenix shows raw trace timeline + drill-down.

This PR ships the deploy spec only. The Python adapter (`src/observability/phoenix_client.py`) and OpenAI auto-tracing are a follow-up directive once Phoenix is verified live on Railway.

Files:
- `infra/phoenix/Dockerfile` — `FROM arizephoenix/phoenix:latest`
- `infra/phoenix/railway.json` — Railway build + deploy + healthcheck config
- `infra/phoenix/README.md` — deploy steps, smoke test, follow-up scope, cost estimate (~$5–10/mo, within Dave-approved Railway spend)

## Out of scope (follow-up)
- Actual Railway deploy
- `src/observability/phoenix_client.py` — ingest `public.governance_events` as Phoenix spans (sketch in README)
- OpenAI auto-tracing via `phoenix.otel.register(project_name="agency-os")`
- CI dashboard (daily Hit Rate / Gatekeeper allow-rate / token spend snapshot)

## Test plan
- [x] `git diff --cached --stat` → 3 new files, +103/-0
- [ ] Railway deploy + `curl /healthz` smoke test — separate follow-up directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)