### PR TITLE
[ELLIOT] fix(memory): migration provenance keys (legacy_source + legacy_id)

### DIFF
--- a/scripts/migrate_memories.py
+++ b/scripts/migrate_memories.py
@@ -78,6 +78,10 @@ def _map_row(row: dict) -> dict:
         except json.JSONDecodeError:
             metadata = {"raw": metadata}
 
+    # Provenance keys for audit traceability (N1 from PR #488 review)
+    metadata["legacy_source"] = "elliot_internal.memories"
+    metadata["legacy_id"] = str(row.get("id", ""))
+
     return {
         "callsign": "elliot",
         "source_type": row.get("type") or "unknown",


### PR DESCRIPTION
## Summary
Adds typed_metadata['legacy_source'] + ['legacy_id'] to every migrated row so future audits can trace agent_memories rows back to their elliot_internal.memories origin.

Per Aiden review N1 on PR #488.

## Change
+4 lines in `_map_row()` — sets provenance before returning mapped dict.

## Verification
```
$ python3 scripts/migrate_memories.py --help → exits 0
$ syntax check → OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)