### PR TITLE
[AIDEN] feat(observability): Phoenix Python adapter — governance_events → OTLP spans

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,9 @@ restate-sdk>=0.17.0,<0.18.0  # 0.17 removed restate.server.app — top-level res
 # === Memory ===
 mem0ai>=2.0.0,<3.0.0  # Mem0 2.x — requires filters={} wrapper, not top-level user_id
 
+# === Observability — Phoenix Auditor (Phase 2) ===
+arize-phoenix-otel>=0.16.0,<1.0.0  # Phoenix OTLP tracer registration
+
 # === Testing ===
 pytest>=7.4.0
 pytest-asyncio>=0.21.0

--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -1,0 +1,7 @@
+"""Phase 2 — Auditor / observability layer.
+
+Wraps Arize Phoenix self-hosted observability. The Phoenix server itself
+is deployed on Railway (see infra/phoenix/). This package contains the
+Python ingestion side: convert governance_events rows into Phoenix spans
+via OTLP.
+"""

--- a/src/observability/phoenix_client.py
+++ b/src/observability/phoenix_client.py
@@ -1,0 +1,60 @@
+"""GOV-PHASE2 Auditor — Phoenix OTLP adapter.
+
+Converts public.governance_events rows into Phoenix spans via OTLP HTTP.
+Used by scripts/phoenix_export_loop.py to ship rows on a watermark loop.
+
+Env:
+    PHOENIX_OTLP_ENDPOINT  — default http://localhost:4318/v1/traces
+    PHOENIX_PROJECT        — default agency-os-governance
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENDPOINT = os.environ.get(
+    "PHOENIX_OTLP_ENDPOINT", "http://localhost:4318/v1/traces"
+)
+DEFAULT_PROJECT = os.environ.get("PHOENIX_PROJECT", "agency-os-governance")
+
+
+def init_tracer(project: str = DEFAULT_PROJECT, endpoint: str = DEFAULT_ENDPOINT):
+    """Register a Phoenix OTel tracer. Returns the tracer or None on failure.
+
+    Wrapped — observability never blocks the caller.
+    """
+    try:
+        from phoenix.otel import register
+        return register(project_name=project, endpoint=endpoint)
+    except Exception as exc:  # pragma: no cover - import / network failure
+        logger.warning("init_tracer failed (%s)", exc)
+        return None
+
+
+def export_event(tracer, event: dict[str, Any]) -> bool:
+    """Convert one governance_events row to a Phoenix span. Returns True on
+    success, False on any failure. Wrapped — never raises."""
+    if tracer is None:
+        return False
+    try:
+        span_name = str(event.get("event_type") or "governance_event")
+        with tracer.start_as_current_span(span_name) as span:
+            span.set_attribute("callsign", str(event.get("callsign") or ""))
+            span.set_attribute("tool_name", str(event.get("tool_name") or ""))
+            span.set_attribute("file_path", str(event.get("file_path") or ""))
+            span.set_attribute("directive_id", str(event.get("directive_id") or ""))
+            event_data = event.get("event_data") or {}
+            if isinstance(event_data, dict):
+                for k, v in event_data.items():
+                    span.set_attribute(f"event_data.{k}", str(v))
+            ts = event.get("timestamp")
+            if ts is not None:
+                span.set_attribute("source_timestamp", str(ts))
+        return True
+    except Exception as exc:  # pragma: no cover - export failure
+        logger.warning("export_event failed for event_type=%s: %s",
+                       event.get("event_type"), exc)
+        return False

--- a/tests/observability/test_phoenix_client.py
+++ b/tests/observability/test_phoenix_client.py
@@ -1,0 +1,69 @@
+"""GOV-PHASE2 Auditor — phoenix_client export tests."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from src.observability import phoenix_client
+
+
+def _mk_tracer() -> MagicMock:
+    """Build a tracer mock whose start_as_current_span returns a context-manager span."""
+    span = MagicMock()
+    span.set_attribute = MagicMock()
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=span)
+    cm.__exit__ = MagicMock(return_value=False)
+    tracer = MagicMock()
+    tracer.start_as_current_span.return_value = cm
+    return tracer, span
+
+
+def test_export_event_happy_path():
+    tracer, span = _mk_tracer()
+    event = {
+        "event_type": "tool_call",
+        "callsign": "aiden",
+        "tool_name": "Bash",
+        "file_path": "src/foo.py",
+        "directive_id": "TEST-1",
+        "event_data": {"hook": "recorder", "extra": 42},
+        "timestamp": "2026-05-01T13:00:00Z",
+    }
+    ok = phoenix_client.export_event(tracer, event)
+    assert ok is True
+    tracer.start_as_current_span.assert_called_once_with("tool_call")
+    attr_calls = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+    assert attr_calls["callsign"] == "aiden"
+    assert attr_calls["tool_name"] == "Bash"
+    assert attr_calls["directive_id"] == "TEST-1"
+    assert attr_calls["event_data.hook"] == "recorder"
+    assert attr_calls["event_data.extra"] == "42"
+    assert attr_calls["source_timestamp"] == "2026-05-01T13:00:00Z"
+
+
+def test_export_event_returns_false_when_tracer_none():
+    assert phoenix_client.export_event(None, {"event_type": "x"}) is False
+
+
+def test_export_event_handles_missing_fields():
+    tracer, span = _mk_tracer()
+    ok = phoenix_client.export_event(tracer, {"event_type": "minimal"})
+    assert ok is True
+    attr_calls = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+    assert attr_calls["callsign"] == ""
+    assert attr_calls["tool_name"] == ""
+    assert "source_timestamp" not in attr_calls
+
+
+def test_export_event_swallows_span_exception():
+    tracer = MagicMock()
+    tracer.start_as_current_span.side_effect = RuntimeError("OTLP down")
+    ok = phoenix_client.export_event(tracer, {"event_type": "x"})
+    assert ok is False
+
+
+def test_init_tracer_returns_none_when_phoenix_missing():
+    with patch("src.observability.phoenix_client.logger"):
+        with patch.dict("sys.modules", {"phoenix.otel": None}):
+            tracer = phoenix_client.init_tracer()
+            assert tracer is None


### PR DESCRIPTION
## Summary
Phase 2 Auditor follow-up to PR #491 (Phoenix scaffold). Wires the ingestion path: convert `public.governance_events` rows into Phoenix spans via OTLP HTTP. Companion to the deploy spec.

Files:
- `src/observability/__init__.py` — package marker + scope doc
- `src/observability/phoenix_client.py` — `init_tracer()` + `export_event()`. Both wrapped — observability never blocks the caller.
- `tests/observability/test_phoenix_client.py` — 5 cases: happy path, None tracer, missing fields, span exception swallow, missing `phoenix.otel`.
- `requirements.txt` — pin `arize-phoenix-otel>=0.16.0,<1.0.0` with inline rationale.

## Out of scope (follow-up)
- `scripts/phoenix_export_loop.py` — periodic loop with watermark on `public.governance_events.timestamp`. Waits on Phoenix being live on Railway to verify end-to-end.
- OpenAI auto-tracing via `phoenix.otel.register(...)` at service entry points.
- Trace grouping by `directive_id` (would group rows with same directive into a single trace tree, not a flat span list — schema design needed).

## Test plan
- [x] `pytest tests/observability/test_phoenix_client.py -v` → 5/5 pass
- [x] `git diff --cached --stat` → 5 files, +139/-0
- [ ] End-to-end smoke against deployed Phoenix — separate follow-up directive after Phoenix is on Railway

## Companion
- PR #491 (Aiden) — Phoenix scaffold (Dockerfile + Railway config + README), dual-approved, awaiting Dave merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)