### PR TITLE
[AIDEN] feat(observability): Phoenix export loop — periodic governance_events → spans

### DIFF
--- a/scripts/phoenix_export_loop.py
+++ b/scripts/phoenix_export_loop.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""GOV-PHASE2 Auditor — periodic governance_events → Phoenix span exporter.
+
+Watermark loop:
+  1. read last_export_timestamp from state file (or NOW()-1h on first run)
+  2. fetch governance_events rows where timestamp > last_export_timestamp
+  3. for each row, call src.observability.phoenix_client.export_event(tracer, row)
+  4. advance the watermark to MAX(timestamp) of fetched rows
+  5. sleep PHOENIX_EXPORT_INTERVAL_S seconds, repeat
+
+State file (default: /home/elliotbot/clawd/state/phoenix_watermark.txt) holds an
+ISO-8601 timestamp string. Failures (DB unreachable, OTLP unreachable) are
+logged and the loop continues — observability never crashes the service.
+
+Usage:
+    PYTHONPATH=. python3 scripts/phoenix_export_loop.py
+    PHOENIX_EXPORT_INTERVAL_S=30 python3 scripts/phoenix_export_loop.py  # tune
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[phoenix-export] %(levelname)s: %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+WATERMARK_PATH = Path(
+    os.environ.get(
+        "PHOENIX_WATERMARK_PATH",
+        "/home/elliotbot/clawd/state/phoenix_watermark.txt",
+    )
+)
+INTERVAL_S = int(os.environ.get("PHOENIX_EXPORT_INTERVAL_S", "60"))
+BATCH_LIMIT = int(os.environ.get("PHOENIX_EXPORT_BATCH_LIMIT", "500"))
+
+
+def read_watermark() -> datetime:
+    """Read the last-exported timestamp. Defaults to NOW()-1h on first run."""
+    try:
+        if WATERMARK_PATH.exists():
+            raw = WATERMARK_PATH.read_text(encoding="utf-8").strip()
+            if raw:
+                return datetime.fromisoformat(raw)
+    except (OSError, ValueError) as exc:
+        logger.warning("watermark read failed (%s) — defaulting to NOW()-1h", exc)
+    return datetime.now(UTC) - timedelta(hours=1)
+
+
+def write_watermark(ts: datetime) -> None:
+    """Persist the watermark. Best-effort — never raises."""
+    try:
+        WATERMARK_PATH.parent.mkdir(parents=True, exist_ok=True)
+        WATERMARK_PATH.write_text(ts.isoformat(), encoding="utf-8")
+    except OSError as exc:
+        logger.warning("watermark write failed: %s", exc)
+
+
+async def fetch_events(since: datetime, dsn: str, limit: int = BATCH_LIMIT) -> list[dict]:
+    """Fetch governance_events rows with timestamp > since. Returns [] on failure."""
+    try:
+        import asyncpg
+    except ImportError:
+        logger.error("asyncpg missing — install via requirements.txt")
+        return []
+    try:
+        conn = await asyncpg.connect(dsn, statement_cache_size=0)
+        try:
+            rows = await conn.fetch(
+                """
+                SELECT id, callsign, event_type, event_data, tool_name,
+                       file_path, directive_id, timestamp
+                FROM public.governance_events
+                WHERE timestamp > $1
+                ORDER BY timestamp ASC
+                LIMIT $2
+                """,
+                since,
+                limit,
+            )
+            return [dict(r) for r in rows]
+        finally:
+            await conn.close()
+    except Exception as exc:  # noqa: BLE001 - logged, not raised
+        logger.warning("fetch_events failed: %s", exc)
+        return []
+
+
+def _resolve_dsn() -> str | None:
+    raw = (
+        os.environ.get("DATABASE_URL")
+        or os.environ.get("SUPABASE_DB_URL")
+        or ""
+    ).strip()
+    if not raw:
+        return None
+    return raw.replace("postgresql+asyncpg://", "postgresql://")
+
+
+async def run_one_cycle(tracer) -> int:
+    """One iteration of the export loop. Returns the number of events exported."""
+    from src.observability.phoenix_client import export_event
+
+    dsn = _resolve_dsn()
+    if not dsn:
+        logger.warning("no DSN configured — skipping cycle")
+        return 0
+
+    since = read_watermark()
+    events = await fetch_events(since, dsn)
+    exported = 0
+    latest_ts = since
+    for ev in events:
+        if export_event(tracer, ev):
+            exported += 1
+        ts = ev.get("timestamp")
+        if isinstance(ts, datetime) and ts > latest_ts:
+            latest_ts = ts
+    if latest_ts > since:
+        write_watermark(latest_ts)
+    if events:
+        logger.info(
+            "cycle: fetched=%d exported=%d watermark_advanced=%s",
+            len(events), exported, latest_ts.isoformat(),
+        )
+    return exported
+
+
+async def main() -> int:
+    from src.observability.phoenix_client import init_tracer
+
+    tracer = init_tracer()
+    if tracer is None:
+        logger.error("Phoenix tracer unavailable — exiting (will retry on next service restart)")
+        return 1
+
+    logger.info(
+        "Phoenix export loop started — interval=%ds, batch_limit=%d, watermark_path=%s",
+        INTERVAL_S, BATCH_LIMIT, WATERMARK_PATH,
+    )
+    while True:
+        try:
+            await run_one_cycle(tracer)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("cycle error (continuing): %s", exc)
+        await asyncio.sleep(INTERVAL_S)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/observability/phoenix_client.py
+++ b/src/observability/phoenix_client.py
@@ -22,13 +22,16 @@ DEFAULT_PROJECT = os.environ.get("PHOENIX_PROJECT", "agency-os-governance")
 
 
 def init_tracer(project: str = DEFAULT_PROJECT, endpoint: str = DEFAULT_ENDPOINT):
-    """Register a Phoenix OTel tracer. Returns the tracer or None on failure.
+    """Register a Phoenix OTel tracer. Returns a tracer or None on failure.
 
-    Wrapped — observability never blocks the caller.
+    `phoenix.otel.register()` returns a TracerProvider — call `.get_tracer()` on
+    it to get the actual Tracer that has `start_as_current_span`. Wrapped —
+    observability never blocks the caller.
     """
     try:
         from phoenix.otel import register
-        return register(project_name=project, endpoint=endpoint)
+        provider = register(project_name=project, endpoint=endpoint)
+        return provider.get_tracer(__name__)
     except Exception as exc:  # pragma: no cover - import / network failure
         logger.warning("init_tracer failed (%s)", exc)
         return None

--- a/tests/observability/test_phoenix_client.py
+++ b/tests/observability/test_phoenix_client.py
@@ -67,3 +67,18 @@ def test_init_tracer_returns_none_when_phoenix_missing():
         with patch.dict("sys.modules", {"phoenix.otel": None}):
             tracer = phoenix_client.init_tracer()
             assert tracer is None
+
+
+def test_init_tracer_calls_get_tracer_on_provider():
+    """register() returns TracerProvider; init_tracer must call .get_tracer()
+    on it, not return the provider directly (which lacks
+    start_as_current_span)."""
+    fake_tracer = MagicMock()
+    fake_provider = MagicMock()
+    fake_provider.get_tracer.return_value = fake_tracer
+    fake_register = MagicMock(return_value=fake_provider)
+    with patch.dict("sys.modules", {"phoenix.otel": MagicMock(register=fake_register)}):
+        tracer = phoenix_client.init_tracer(project="p", endpoint="https://x/v1/traces")
+    fake_register.assert_called_once_with(project_name="p", endpoint="https://x/v1/traces")
+    fake_provider.get_tracer.assert_called_once()
+    assert tracer is fake_tracer

--- a/tests/scripts/test_phoenix_export_loop.py
+++ b/tests/scripts/test_phoenix_export_loop.py
@@ -1,0 +1,82 @@
+"""GOV-PHASE2 Auditor — phoenix_export_loop tests."""
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import scripts.phoenix_export_loop as loop
+
+
+@pytest.fixture
+def tmp_watermark(tmp_path, monkeypatch):
+    p = tmp_path / "phoenix_watermark.txt"
+    monkeypatch.setattr(loop, "WATERMARK_PATH", p)
+    return p
+
+
+def test_read_watermark_default_when_missing(tmp_watermark):
+    ts = loop.read_watermark()
+    delta = datetime.now(UTC) - ts
+    assert 3300 < delta.total_seconds() < 3700  # ~1h ago
+
+
+def test_read_watermark_round_trip(tmp_watermark):
+    sample = datetime(2026, 5, 1, 13, 0, 0, tzinfo=UTC)
+    loop.write_watermark(sample)
+    assert tmp_watermark.exists()
+    assert loop.read_watermark() == sample
+
+
+def test_read_watermark_handles_garbage(tmp_watermark):
+    tmp_watermark.write_text("not-a-timestamp", encoding="utf-8")
+    ts = loop.read_watermark()
+    assert (datetime.now(UTC) - ts).total_seconds() > 3000
+
+
+@pytest.mark.asyncio
+async def test_run_one_cycle_no_dsn(tmp_watermark, monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    tracer = MagicMock()
+    exported = await loop.run_one_cycle(tracer)
+    assert exported == 0
+
+
+@pytest.mark.asyncio
+async def test_run_one_cycle_exports_and_advances_watermark(tmp_watermark, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+    fake_events = [
+        {"event_type": "tool_call", "callsign": "aiden",
+         "timestamp": datetime(2026, 5, 1, 13, 0, 0, tzinfo=UTC),
+         "event_data": {}, "tool_name": "Bash", "file_path": "",
+         "directive_id": ""},
+        {"event_type": "tool_call", "callsign": "aiden",
+         "timestamp": datetime(2026, 5, 1, 13, 5, 0, tzinfo=UTC),
+         "event_data": {}, "tool_name": "Read", "file_path": "",
+         "directive_id": ""},
+    ]
+    tracer = MagicMock()
+    with patch.object(loop, "fetch_events", new=AsyncMock(return_value=fake_events)), \
+         patch("src.observability.phoenix_client.export_event", return_value=True) as mock_export:
+        exported = await loop.run_one_cycle(tracer)
+    assert exported == 2
+    assert mock_export.call_count == 2
+    assert loop.read_watermark() == datetime(2026, 5, 1, 13, 5, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_run_one_cycle_no_events_does_not_advance(tmp_watermark, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+    initial = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+    loop.write_watermark(initial)
+    with patch.object(loop, "fetch_events", new=AsyncMock(return_value=[])):
+        await loop.run_one_cycle(MagicMock())
+    assert loop.read_watermark() == initial


### PR DESCRIPTION
## Summary
Closes the Phase 2 Auditor ingestion path. PR #491 = scaffold, PR #494 = adapter, this PR = the orchestrator that periodically ships `public.governance_events` rows to Phoenix as OTLP spans.

`scripts/phoenix_export_loop.py` (161 lines):
- Watermark file at `/home/elliotbot/clawd/state/phoenix_watermark.txt` (override via `PHOENIX_WATERMARK_PATH` env)
- 60s cycle (override via `PHOENIX_EXPORT_INTERVAL_S`), batch limit 500 (override via `PHOENIX_EXPORT_BATCH_LIMIT`)
- `asyncpg.connect(dsn, statement_cache_size=0)` — pgbouncer compat (same pattern as session_end_hook + COO bot)
- All failures logged, loop continues — observability never crashes the service

`tests/scripts/test_phoenix_export_loop.py` (82 lines, 6 cases):
- default-watermark on missing file
- watermark round-trip
- garbage-handling fallback
- no-DSN cycle returns 0
- happy-path export + watermark advance
- empty cycle does not advance watermark

## Test plan
- [x] `pytest tests/scripts/test_phoenix_export_loop.py -v` → 6/6 pass
- [ ] Live smoke test against deployed Phoenix — separate follow-up directive (Phoenix Railway deploy is blocked on CLI auth; not in this PR's scope)

## Out of scope
- systemd unit — waits on Phoenix being live on Railway
- Live OTLP smoke test — same dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)