### PR TITLE
[AIDEN] feat(observability): Phoenix export loop systemd unit + deploy README

### DIFF
--- a/infra/observability/README.md
+++ b/infra/observability/README.md
@@ -1,0 +1,59 @@
+# Phoenix Export Loop — systemd deploy
+
+Runs `scripts/phoenix_export_loop.py` as a systemd user service. Polls
+`public.governance_events` every 60s and ships new rows to the Phoenix
+Auditor on Railway as OTLP spans.
+
+## Install
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp infra/observability/agency-os-phoenix-export.service \
+   ~/.config/systemd/user/agency-os-phoenix-export.service
+mkdir -p /home/elliotbot/clawd/state
+systemctl --user daemon-reload
+systemctl --user enable --now agency-os-phoenix-export.service
+```
+
+## Verify
+
+```bash
+systemctl --user status agency-os-phoenix-export.service
+journalctl --user -u agency-os-phoenix-export.service -n 30
+cat /home/elliotbot/clawd/state/phoenix_watermark.txt
+```
+
+Expected log output (steady state):
+```
+[phoenix-export] INFO: Phoenix export loop started — interval=60s, batch_limit=500, watermark_path=/home/elliotbot/clawd/state/phoenix_watermark.txt
+[phoenix-export] INFO: cycle: fetched=N exported=N watermark_advanced=2026-05-01T...
+```
+
+## Verify spans land in Phoenix
+
+```bash
+curl -s "https://auditor-phoenix-production.up.railway.app/v1/projects/UHJvamVjdDoy/spans" \
+  | jq '.data | length'
+```
+
+Number should grow over time.
+
+## Tunables (override in unit file or .env)
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `PHOENIX_OTLP_ENDPOINT` | (none, must be set) | Phoenix OTLP HTTP traces endpoint |
+| `PHOENIX_PROJECT` | `agency-os-governance` | Phoenix project bucket for spans |
+| `PHOENIX_EXPORT_INTERVAL_S` | `60` | Poll cadence |
+| `PHOENIX_EXPORT_BATCH_LIMIT` | `500` | Max events per cycle |
+| `PHOENIX_WATERMARK_PATH` | `/home/elliotbot/clawd/state/phoenix_watermark.txt` | State file location |
+
+## Stop / disable
+
+```bash
+systemctl --user stop agency-os-phoenix-export.service
+systemctl --user disable agency-os-phoenix-export.service
+```
+
+The watermark file persists — disabling + re-enabling resumes from the
+last shipped event, no replay.

--- a/infra/observability/agency-os-phoenix-export.service
+++ b/infra/observability/agency-os-phoenix-export.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Agency OS Phoenix Export Loop — ships governance_events to Phoenix Auditor
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+ExecStart=/home/elliotbot/clawd/venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/phoenix_export_loop.py
+Restart=on-failure
+RestartSec=15
+StandardOutput=journal
+StandardError=journal
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+Environment=PYTHONUNBUFFERED=1
+Environment=PHOENIX_OTLP_ENDPOINT=https://auditor-phoenix-production.up.railway.app/v1/traces
+Environment=PHOENIX_PROJECT=agency-os-governance
+Environment=PHOENIX_EXPORT_INTERVAL_S=60
+Environment=PHOENIX_EXPORT_BATCH_LIMIT=500
+Environment=PHOENIX_WATERMARK_PATH=/home/elliotbot/clawd/state/phoenix_watermark.txt
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
Closes Phase 2 Auditor closeout: the export loop now runs continuously as a systemd user service, shipping `public.governance_events` to the Railway Phoenix instance every 60s. Last piece of the ingestion path.

`infra/observability/agency-os-phoenix-export.service`:
- Type=simple, restart-on-failure
- `WorkingDirectory=/home/elliotbot/clawd/Agency_OS` (canonical operational pull-of-main location)
- All Phoenix tunables baked in via `Environment=` (`PHOENIX_OTLP_ENDPOINT`, `PHOENIX_PROJECT`, `PHOENIX_EXPORT_INTERVAL_S`, `PHOENIX_EXPORT_BATCH_LIMIT`, `PHOENIX_WATERMARK_PATH`)
- `EnvironmentFile=/home/elliotbot/.config/agency-os/.env` for Supabase DSN

`infra/observability/README.md`: install / verify / stop steps, tunables table, Phoenix-side smoke command.

## Live verification
```
$ systemctl --user is-active agency-os-phoenix-export.service
active

$ journalctl --user -u agency-os-phoenix-export.service -n 5
[phoenix-export] INFO: Phoenix export loop started — interval=60s, batch_limit=500, watermark_path=/home/elliotbot/clawd/state/phoenix_watermark.txt
🔭 OpenTelemetry Tracing Details 🔭
|  Phoenix Project: agency-os-governance
|  Collector Endpoint: https://auditor-phoenix-production.up.railway.app/v1/traces
|  Transport: HTTP + protobuf
```

Service active, registered with Phoenix project `agency-os-governance`. Span flow will be observable via `curl https://auditor-phoenix-production.up.railway.app/v1/projects/UHJvamVjdDoy/spans | jq '.data | length'` over time.

## Operational note
Elliot worktree (`/home/elliotbot/clawd/Agency_OS`) was on stale main when the service first started — failed to find `scripts/phoenix_export_loop.py`. Pulled main to the worktree, restarted, service came up clean. Future operational services should presume Elliot worktree is the canonical pulled-up-to-date location.

## Test plan
- [x] `systemctl --user is-active` → active
- [x] Journal shows tracer registered + loop running
- [x] No regression — all merged Phase 2 code (#491, #494, #497) intact
- [ ] Span count growth observed over next ~10 min — will spot-check post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)