### PR TITLE
[AIDEN] feat(governance): Restate Python service container + registration script (Track C1 closeout)

### DIFF
--- a/infra/restate/Dockerfile.service
+++ b/infra/restate/Dockerfile.service
@@ -1,0 +1,23 @@
+# Restate Python service container.
+# Hosts the `governance` VirtualObject (directive_start, directive_complete,
+# get_state) defined in src/governance/restate_service.py. Registers with
+# the Restate server (separate Railway service) via the Restate admin API
+# after deploy. Exposes ASGI on port 9070 (Restate SDK default).
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Minimal deps. The full Agency OS requirements.txt has heavy unrelated
+# packages — this service only needs restate-sdk + uvicorn.
+RUN pip install --no-cache-dir \
+      "restate-sdk>=0.17.0,<0.18.0" \
+      "uvicorn[standard]>=0.27"
+
+COPY src /app/src
+
+ENV PYTHONUNBUFFERED=1
+EXPOSE 9070
+
+CMD ["uvicorn", "src.governance.restate_service:asgi_app", \
+     "--host", "0.0.0.0", "--port", "9070", "--log-level", "info"]

--- a/scripts/register_restate_service.py
+++ b/scripts/register_restate_service.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Register the Python `governance` VirtualObject with the Restate server.
+
+Runs after the Python service container is healthy on Railway. POSTs the
+service URI to Restate's admin /deployments endpoint so Restate can route
+incoming directive_start/complete/get_state calls to our handlers.
+
+Usage:
+    RESTATE_ADMIN_URL=https://restate-server-production-60d4.up.railway.app:9070 \
+    PYTHON_SERVICE_URI=http://restate-py-service.railway.internal:9070 \
+    python3 scripts/register_restate_service.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import httpx
+
+ADMIN_URL = os.environ.get("RESTATE_ADMIN_URL", "http://localhost:9070")
+SERVICE_URI = os.environ.get(
+    "PYTHON_SERVICE_URI",
+    "http://restate-py-service.railway.internal:9070",
+)
+
+
+def register() -> int:
+    url = f"{ADMIN_URL.rstrip('/')}/deployments"
+    payload = {"uri": SERVICE_URI, "force": False}
+    print(f"POST {url} with {payload}", file=sys.stderr)
+    try:
+        resp = httpx.post(url, json=payload, timeout=30)
+    except httpx.HTTPError as exc:
+        print(f"register failed: {exc}", file=sys.stderr)
+        return 2
+    if resp.status_code >= 400:
+        print(f"non-2xx ({resp.status_code}): {resp.text}", file=sys.stderr)
+        return 1
+    print(resp.text)
+    return 0
+
+
+def list_services() -> int:
+    url = f"{ADMIN_URL.rstrip('/')}/services"
+    try:
+        resp = httpx.get(url, timeout=15)
+        print(resp.text)
+        return 0 if resp.status_code < 400 else 1
+    except httpx.HTTPError as exc:
+        print(f"list failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "list":
+        sys.exit(list_services())
+    sys.exit(register())


### PR DESCRIPTION
## Summary
Phase 1 Track C1 closeout: container artefact + registration tooling for the `governance` VirtualObject in `src/governance/restate_service.py`.

The Restate **server** has been live on Railway since session start (04:55Z, ATLAS deploy) with public URL `https://restate-server-production-60d4.up.railway.app` (8080 ingress). This PR adds the **second** piece: the Python service that hosts the handlers and registers them with the server.

`infra/restate/Dockerfile.service`:
- `FROM python:3.12-slim`, minimal pin (`restate-sdk>=0.17.0,<0.18.0` + `uvicorn[standard]`)
- `COPY src/` for the governance module
- `CMD uvicorn src.governance.restate_service:asgi_app --port 9070`
- **Distinct** from `infra/restate/Dockerfile` (the server image)

`scripts/register_restate_service.py`:
- POSTs to Restate admin `/deployments` so `governance.directive_start` etc. become reachable
- Env: `RESTATE_ADMIN_URL`, `PYTHON_SERVICE_URI`
- `list` subcommand shows registered services

## Out of scope (follow-up)
- Wire callers — no production code currently invokes `directive_start` etc. Separate directive after live verification.
- Local fallback systemd unit for the Python service.

## Live deploy state
- Railway service `restate-py-service` created via GraphQL (id `21710d9b-a4db-47fb-8ba7-d93d6181ed35`), `branch=main`, `repo=Keiracom/Agency_OS`.
- Build awaits `dockerfilePath` set via `serviceInstanceUpdate` (post-merge step) so the build picks up `infra/restate/Dockerfile.service`. Once the file is on `main`, configure the dockerfilePath, the service builds + deploys.
- Then run `register_restate_service.py` (one-shot) to wire handlers.

## Test plan
- [x] `git diff --cached --stat` → 2 files, +80/-0
- [ ] Post-merge: set `dockerfilePath=infra/restate/Dockerfile.service` on Railway service via GraphQL → verify build SUCCESS → register handlers → smoke-test `directive_start`
- [ ] Live verification (separate directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)