### PR TITLE
[ELLIOT] feat(coo): Max COO proxy — roadmap + Opus wrapper + DM handler

### DIFF
--- a/docs/roadmap/MAX_COO_ROADMAP.md
+++ b/docs/roadmap/MAX_COO_ROADMAP.md
@@ -1,0 +1,89 @@
+# Max COO Proxy — Build Roadmap
+Ratified: 2026-05-01. Dave directive: "Build now. Create roadmap and architecture specs."
+
+## Overview
+Max (@MaxCOO_Bot) becomes Dave's proxy in the Agency OS supergroup. Dave exits group, communicates through Max via DM only. Max reads group in real-time, relays to Dave, posts to group on Dave's behalf, and (at higher Tiers) interjects independently.
+
+## Phase A — Foundation (serial, ~2hr)
+
+### A1. Architecture Spec
+- File: docs/architecture/MAX_COO_ARCHITECTURE.md
+- Owner: Aiden (architect-0 dispatch)
+- Deliverable: component contracts, Tier model, CLI subprocess spec, file ownership map
+
+### A2. Opus CLI Subprocess Wrapper
+- File: src/coo_bot/opus_client.py (new)
+- Owner: Elliot
+- Deliverable: async wrapper around `claude -p` subprocess, timeout handling, error capture
+- Test: smoke test parallel calls, verify 5-15s response, no queue
+- Replaces: openai.AsyncOpenAI client in bot.py
+
+### A3. Group Message Handler
+- File: src/coo_bot/group_handler.py (new)
+- Owner: Aiden
+- Deliverable: reads supergroup messages via python-telegram-bot, updates working state buffer, decides flag-to-DM
+- Test: mock group messages, verify state buffer updates
+
+### A4. DM Bidirectional Handler
+- File: src/coo_bot/dm_handler.py (new)
+- Owner: Elliot
+- Deliverable: receives Dave DMs, loads memory context, calls Opus, responds. Receives /post commands, routes to group writer.
+- Test: mock DM conversation, verify context loading + response
+
+## Phase B — Parallel Components (clone dispatch, ~1hr)
+
+### B1. Tier Framework + Kill Switch
+- File: src/coo_bot/tier_framework.py (new)
+- Owner: ORION (Aiden's clone)
+- Deliverable: COO_APPROVAL_TIER env var (0/1/2/3), permission checks per action type, STOP MAX keyword detection
+- Test: unit tests for each tier gate
+
+### B2. Memory Retrieval Layer
+- File: src/coo_bot/memory_retriever.py (new)
+- Owner: ATLAS (Elliot's clone)
+- Deliverable: load relevant agent_memories for a query (semantic + tag filter), format as context for Opus prompt
+- Test: mock Supabase, verify context formatting
+
+### B3. Group Post Writer
+- File: src/coo_bot/group_writer.py (new)
+- Owner: Aiden
+- Deliverable: posts to group with [MAX] prefix when authorised by Tier check
+- Test: mock Telegram sendMessage, verify prefix + Tier gate
+
+### B4. Persona Prompt
+- File: src/coo_bot/persona.py (new)
+- Owner: Elliot
+- Deliverable: system prompt for Max's COO voice, loaded from Dave's historical post patterns
+- Test: prompt renders correctly with context injection
+
+## Phase C — Integration (sequential, ~1hr)
+
+### C1. Wire bot.py
+- Owner: Elliot (bot.py is his file)
+- Deliverable: register group_handler + dm_handler + group_writer in Application, wire Opus client
+- Test: full integration — mock group msg → DM arrives; mock Dave DM /post → group post fires
+
+### C2. Smoke Test
+- Owner: Both (joint verification)
+- Deliverable: real Telegram test — group message → Max DMs Dave; Dave DMs Max → Max posts to group
+- Gate: parallel subprocess calls work without blocking
+
+## Success Criteria
+1. Max reads group messages in real-time → DMs Dave summaries/flags
+2. Dave DMs Max instructions → Max posts to group with [MAX] prefix
+3. Tier 0: Max NEVER auto-posts to group without Dave's DM instruction
+4. STOP MAX keyword → Max drops to relay-only immediately
+5. Opus subprocess calls complete in <15s, parallel without blocking
+6. All components have pytest coverage
+
+## Timeline
+- Phase A: ~2hr (serial, foundation)
+- Phase B: ~1hr (parallel clone dispatch)
+- Phase C: ~1hr (integration + smoke)
+- Total: ~4hr wall-clock
+
+## Deferred (not in this build)
+- Tier 1+ auto-post categories
+- Event-driven flagging (replace time-based digest)
+- Dave-voice persona training from historical posts
+- Anthropic SDK migration (if subprocess bottlenecks)

--- a/src/coo_bot/dm_handler.py
+++ b/src/coo_bot/dm_handler.py
@@ -1,0 +1,137 @@
+"""Max COO bot — DM handler (Dave ↔ Max private channel).
+
+Handles bidirectional DM conversation with Dave:
+- Dave sends message → Max loads context (memories + recent group buffer) → responds via Opus
+- Dave sends /post <text> → Max posts to group via group_writer
+- Dave sends STOP MAX → Max drops to relay-only (Tier 0 emergency)
+
+Public API:
+    handle_dm(update, context) — registered as MessageHandler for Dave's DM chat
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from src.coo_bot.opus_client import opus_call
+from src.coo_bot.config import COOConfig
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+_COO_SYSTEM_PROMPT = (
+    "You are Max, COO of Agency OS. You are Dave's private strategic advisor. "
+    "You have access to the full history of agent activity via governance_events "
+    "and agent_memories. You watch the group chat in real-time. "
+    "Respond concisely and directly. Dave is the CEO — be useful, not verbose. "
+    "If Dave says '/post <text>' relay that text to the group (handled separately). "
+    "If Dave asks what's happening, summarise recent group activity. "
+    "If Dave asks for your opinion, give it honestly — you are his COO, not a yes-man."
+)
+
+
+async def handle_dm(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle a DM from Dave. Route to appropriate sub-handler."""
+    if not update.message or not update.message.text:
+        return
+
+    cfg = COOConfig()
+    text = update.message.text.strip()
+    chat_id = update.message.chat_id
+
+    # Only respond to Dave's DM
+    if chat_id != cfg.dave_chat_id:
+        return
+
+    # Kill switch
+    if text.upper() == "STOP MAX":
+        await update.message.reply_text(
+            "STOP MAX acknowledged. Dropping to relay-only. "
+            "No autonomous posts. DM me 'RESUME MAX' to restore."
+        )
+        # Write stop state (tier_framework will read this)
+        _write_stop_state(True)
+        logger.warning("STOP MAX triggered by Dave")
+        return
+
+    if text.upper() == "RESUME MAX":
+        _write_stop_state(False)
+        await update.message.reply_text("Resumed. Back to normal operation.")
+        logger.info("RESUME MAX triggered by Dave")
+        return
+
+    # /post command — relay to group
+    if text.startswith("/post "):
+        group_text = text[6:].strip()
+        if group_text:
+            # Import here to avoid circular — group_writer posts to group
+            try:
+                from src.coo_bot.group_writer import post_to_group
+                ok = await post_to_group(cfg.bot_token, group_text)
+                status = "Posted to group." if ok else "Failed to post."
+                await update.message.reply_text(status)
+            except Exception as exc:
+                await update.message.reply_text(f"Post failed: {exc}")
+        else:
+            await update.message.reply_text("Usage: /post <message to post to group>")
+        return
+
+    # Regular conversation — call Opus with context
+    memory_context = await _load_context()
+    user_msg = f"[Recent context]\n{memory_context}\n\n[Dave's message]\n{text}"
+
+    response = await opus_call(_COO_SYSTEM_PROMPT, user_msg, timeout=30)
+
+    if response:
+        await update.message.reply_text(response)
+    else:
+        await update.message.reply_text(
+            "I couldn't generate a response right now. Try again in a moment."
+        )
+
+
+async def _load_context() -> str:
+    """Load recent group messages + relevant memories as context for Opus call."""
+    lines = []
+    # Load from working state buffer (populated by group_handler)
+    try:
+        from src.coo_bot.group_handler import get_recent_messages
+        recent = get_recent_messages(limit=20)
+        if recent:
+            lines.append("Recent group messages:")
+            for msg in recent:
+                lines.append(f"  [{msg.get('sender', '?')}] {msg.get('text', '')[:150]}")
+    except ImportError:
+        lines.append("(group handler not loaded)")
+    except Exception as exc:
+        lines.append(f"(group context unavailable: {exc})")
+
+    # Load from agent_memories
+    try:
+        from src.coo_bot.memory_retriever import get_relevant_memories
+        memories = await get_relevant_memories(query="recent activity", limit=5)
+        if memories:
+            lines.append("\nRelevant memories:")
+            for m in memories:
+                lines.append(f"  [{m.get('source_type', '?')}] {m.get('content', '')[:100]}")
+    except ImportError:
+        pass
+    except Exception:
+        pass
+
+    return "\n".join(lines) if lines else "(no context available)"
+
+
+def _write_stop_state(stopped: bool) -> None:
+    """Write STOP MAX state to a file that tier_framework reads."""
+    import pathlib
+    state_file = pathlib.Path("/tmp/max-coo-stopped")
+    if stopped:
+        state_file.write_text("STOPPED")
+    else:
+        state_file.unlink(missing_ok=True)

--- a/src/coo_bot/opus_client.py
+++ b/src/coo_bot/opus_client.py
@@ -1,0 +1,71 @@
+"""Opus CLI subprocess wrapper for Max COO bot.
+
+Replaces the OpenAI AsyncOpenAI client with Claude Opus via the `claude`
+CLI (Max plan, $0/call). Each call spawns a short-lived subprocess:
+    claude -p "<prompt>" --model claude-opus-4-6
+
+The subprocess uses Dave's existing ~/.claude/credentials.json OAuth
+(Max plan authentication). No API key required.
+
+Public API:
+    result = await opus_call(system_prompt, user_message, timeout=30)
+    # result: str (response text) or "" on failure
+
+Design:
+- Async (asyncio.create_subprocess_exec) — non-blocking
+- Timeout protection (default 30s, configurable)
+- Never raises — returns "" on any failure (Max must never crash)
+- Logs failures for debugging
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+
+logger = logging.getLogger(__name__)
+
+_CLAUDE_BIN = shutil.which("claude") or "/home/elliotbot/.local/bin/claude"
+_DEFAULT_MODEL = "claude-opus-4-6"
+_DEFAULT_TIMEOUT = 30
+
+
+async def opus_call(
+    system_prompt: str,
+    user_message: str,
+    *,
+    model: str = _DEFAULT_MODEL,
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> str:
+    """Call Claude Opus via CLI subprocess. Returns response text or "" on failure.
+
+    Non-blocking (asyncio subprocess). Never raises.
+    """
+    prompt = f"{system_prompt}\n\n{user_message}"
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            _CLAUDE_BIN, "-p", prompt, "--model", model,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout
+        )
+        if proc.returncode != 0:
+            logger.warning(
+                "opus_call failed (rc=%s): %s",
+                proc.returncode, stderr.decode()[:200],
+            )
+            return ""
+        return stdout.decode().strip()
+    except asyncio.TimeoutError:
+        logger.warning("opus_call timed out after %ss", timeout)
+        if proc:
+            proc.kill()
+        return ""
+    except FileNotFoundError:
+        logger.error("claude binary not found at %s", _CLAUDE_BIN)
+        return ""
+    except Exception as exc:
+        logger.error("opus_call unexpected error: %s", exc)
+        return ""

--- a/tests/coo_bot/test_dm_handler.py
+++ b/tests/coo_bot/test_dm_handler.py
@@ -1,0 +1,94 @@
+"""Tests for src/coo_bot/dm_handler.py — DM bidirectional handler."""
+from __future__ import annotations
+
+import asyncio
+import pathlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.coo_bot.dm_handler import handle_dm, _write_stop_state
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _make_update(text: str, chat_id: int = 7267788033) -> MagicMock:
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.text = text
+    update.message.chat_id = chat_id
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+def test_non_dave_chat_id_rejected():
+    """Messages from non-Dave chat IDs are silently ignored."""
+    update = _make_update("hello", chat_id=99999)
+    _run(handle_dm(update, MagicMock()))
+    update.message.reply_text.assert_not_called()
+
+
+def test_stop_max_writes_state(tmp_path):
+    """STOP MAX writes the stop state file."""
+    with patch("src.coo_bot.dm_handler._write_stop_state") as mock_write:
+        update = _make_update("STOP MAX")
+        _run(handle_dm(update, MagicMock()))
+        mock_write.assert_called_once_with(True)
+        update.message.reply_text.assert_called_once()
+        assert "STOP MAX acknowledged" in update.message.reply_text.call_args[0][0]
+
+
+def test_resume_max_clears_state():
+    """RESUME MAX clears the stop state."""
+    with patch("src.coo_bot.dm_handler._write_stop_state") as mock_write:
+        update = _make_update("RESUME MAX")
+        _run(handle_dm(update, MagicMock()))
+        mock_write.assert_called_once_with(False)
+        assert "Resumed" in update.message.reply_text.call_args[0][0]
+
+
+def test_post_command_calls_group_writer():
+    """'/post hello world' delegates to group_writer."""
+    mock_post = AsyncMock(return_value=True)
+    with patch.dict("sys.modules", {"src.coo_bot.group_writer": MagicMock(post_to_group=mock_post)}):
+        update = _make_update("/post hello world")
+        _run(handle_dm(update, MagicMock()))
+        assert "Posted" in update.message.reply_text.call_args[0][0]
+
+
+def test_regular_text_calls_opus():
+    """Regular DM text calls opus_call and replies."""
+    with patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="Max response") as mock_opus, \
+         patch("src.coo_bot.dm_handler._load_context", new_callable=AsyncMock, return_value="context"):
+        update = _make_update("what's happening?")
+        _run(handle_dm(update, MagicMock()))
+        mock_opus.assert_called_once()
+        assert "Max response" in update.message.reply_text.call_args[0][0]
+
+
+def test_opus_failure_shows_fallback():
+    """When opus_call returns '', show fallback message."""
+    with patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="") as mock_opus, \
+         patch("src.coo_bot.dm_handler._load_context", new_callable=AsyncMock, return_value=""):
+        update = _make_update("tell me something")
+        _run(handle_dm(update, MagicMock()))
+        assert "couldn't generate" in update.message.reply_text.call_args[0][0]
+
+
+def test_write_stop_state_creates_file(tmp_path):
+    """_write_stop_state(True) creates the state file."""
+    state_file = tmp_path / "max-coo-stopped"
+    with patch("pathlib.Path", return_value=state_file):
+        _write_stop_state(True)
+    assert state_file.read_text() == "STOPPED"
+
+
+def test_write_stop_state_removes_file(tmp_path):
+    """_write_stop_state(False) removes the state file."""
+    state_file = tmp_path / "max-coo-stopped"
+    state_file.write_text("STOPPED")
+    with patch("pathlib.Path", return_value=state_file):
+        _write_stop_state(False)
+    assert not state_file.exists()

--- a/tests/coo_bot/test_opus_client.py
+++ b/tests/coo_bot/test_opus_client.py
@@ -1,0 +1,71 @@
+"""Tests for src/coo_bot/opus_client.py — Opus CLI subprocess wrapper."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from src.coo_bot.opus_client import opus_call
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_happy_path():
+    """opus_call returns stdout on success."""
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"response text", b""))
+    mock_proc.returncode = 0
+
+    with patch("src.coo_bot.opus_client.asyncio.create_subprocess_exec", return_value=mock_proc):
+        result = _run(opus_call("system", "user"))
+    assert result == "response text"
+
+
+def test_non_zero_exit_returns_empty():
+    """opus_call returns '' on non-zero exit code."""
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b"error msg"))
+    mock_proc.returncode = 1
+
+    with patch("src.coo_bot.opus_client.asyncio.create_subprocess_exec", return_value=mock_proc):
+        result = _run(opus_call("system", "user"))
+    assert result == ""
+
+
+def test_timeout_returns_empty():
+    """opus_call returns '' on timeout."""
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+    mock_proc.kill = MagicMock()
+
+    with patch("src.coo_bot.opus_client.asyncio.create_subprocess_exec", return_value=mock_proc):
+        result = _run(opus_call("system", "user", timeout=1))
+    assert result == ""
+
+
+def test_missing_binary_returns_empty():
+    """opus_call returns '' when claude binary not found."""
+    with patch("src.coo_bot.opus_client.asyncio.create_subprocess_exec", side_effect=FileNotFoundError()):
+        result = _run(opus_call("system", "user"))
+    assert result == ""
+
+
+def test_empty_stdout_returns_empty():
+    """opus_call returns '' on empty stdout."""
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"  \n  ", b""))
+    mock_proc.returncode = 0
+
+    with patch("src.coo_bot.opus_client.asyncio.create_subprocess_exec", return_value=mock_proc):
+        result = _run(opus_call("system", "user"))
+    assert result == ""


### PR DESCRIPTION
## Summary
Phase A of Max COO proxy build (per Dave's directive: "save specs then execute"):

- `docs/roadmap/MAX_COO_ROADMAP.md` — full build plan (89 lines, 4 phases)
- `src/coo_bot/opus_client.py` — async Claude Opus subprocess wrapper ($0/call via Max plan)
- `src/coo_bot/dm_handler.py` — bidirectional DM handler (Dave ↔ Max conversation + /post + STOP MAX)

## Companion PR
PR #504 (Aiden): architecture spec doc

## Next after merge
Clone dispatch: ATLAS → memory_retriever.py, ORION → tier_framework.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)