### PR TITLE
[ELLIOT] feat(coo): Phase B — group handler + group writer (ATLAS dispatch)

### DIFF
--- a/src/coo_bot/group_handler.py
+++ b/src/coo_bot/group_handler.py
@@ -1,0 +1,96 @@
+"""Max COO bot — Group message handler.
+
+Reads supergroup messages, maintains a rolling buffer of recent activity.
+Used by dm_handler to provide context when Dave asks 'what's happening?'
+
+Public API:
+    handle_group_message(update, context) — MessageHandler callback
+    get_recent_messages(limit=20) -> list[dict]
+"""
+from __future__ import annotations
+
+import logging
+from collections import deque
+from datetime import datetime, timezone
+from typing import Any
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+logger = logging.getLogger(__name__)
+
+# Group chat ID for the Agency OS supergroup
+_GROUP_CHAT_ID = -1003926592540
+
+# Rolling buffer — capped at 50 entries
+_MAX_BUFFER = 50
+_buffer: deque[dict[str, Any]] = deque(maxlen=_MAX_BUFFER)
+
+
+async def handle_group_message(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """MessageHandler callback for group chat messages.
+
+    Filters out own messages and enforcer alerts, stores the rest in the
+    rolling buffer for later retrieval via get_recent_messages().
+    """
+    if not update.message or not update.message.text:
+        return
+
+    # Only process messages from the configured group
+    if update.message.chat_id != _GROUP_CHAT_ID:
+        return
+
+    bot_id: int | None = None
+    try:
+        if context.bot:
+            bot_id = context.bot.id
+    except Exception:
+        pass
+
+    sender_id = update.message.from_user.id if update.message.from_user else None
+
+    # Skip own messages to avoid loops
+    if bot_id is not None and sender_id == bot_id:
+        logger.debug("group_handler: skipping own message")
+        return
+
+    text = update.message.text or ""
+
+    # Skip enforcer alerts
+    if text.startswith("[ENFORCER]"):
+        logger.debug("group_handler: skipping enforcer alert")
+        return
+
+    sender_name = "unknown"
+    if update.message.from_user:
+        u = update.message.from_user
+        sender_name = u.username or u.full_name or str(u.id)
+
+    ts = datetime.now(tz=timezone.utc).isoformat()
+    if update.message.date:
+        ts = update.message.date.astimezone(timezone.utc).isoformat()
+
+    entry: dict[str, Any] = {
+        "sender": sender_name,
+        "text": text,
+        "timestamp": ts,
+        "message_id": update.message.message_id,
+    }
+    _buffer.append(entry)
+    logger.debug("group_handler: buffered message from %s (buffer=%d)", sender_name, len(_buffer))
+
+
+def get_recent_messages(limit: int = 20) -> list[dict[str, Any]]:
+    """Return the most recent `limit` buffered group messages (newest last).
+
+    Args:
+        limit: Maximum number of messages to return (default 20, max 50).
+
+    Returns:
+        List of dicts with keys: sender, text, timestamp, message_id.
+    """
+    limit = min(limit, _MAX_BUFFER)
+    items = list(_buffer)
+    return items[-limit:]

--- a/src/coo_bot/group_writer.py
+++ b/src/coo_bot/group_writer.py
@@ -18,26 +18,35 @@ _GROUP_CHAT_ID = -1003926592540
 _PREFIX = "[MAX] "
 
 
-async def post_to_group(bot_token: str, text: str) -> bool:
+async def post_to_group(
+    bot_token: str,
+    text: str,
+    *,
+    dave_dm_id: int | None = None,
+) -> bool:
     """Post a message to the Agency OS supergroup with [MAX] prefix.
 
     Args:
         bot_token: Telegram bot token for Max.
         text: Message body (prefix will be prepended automatically).
+        dave_dm_id: Message ID of Dave's authorising DM (for audit trail).
 
     Returns:
         True on success, False on any failure (never raises).
     """
+    prefixed_text = f"{_PREFIX}{text}"
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
     payload = {
         "chat_id": _GROUP_CHAT_ID,
-        "text": f"{_PREFIX}{text}",
+        "text": prefixed_text,
     }
     try:
         async with httpx.AsyncClient(timeout=10) as client:
             response = await client.post(url, json=payload)
         if response.status_code == 200:
             logger.info("group_writer: posted to group OK")
+            # Audit trail — governance_events row per architecture spec
+            await _write_audit_event(prefixed_text, dave_dm_id)
             return True
         logger.error(
             "group_writer: sendMessage returned HTTP %d: %s",
@@ -48,3 +57,22 @@ async def post_to_group(bot_token: str, text: str) -> bool:
     except Exception as exc:
         logger.error("group_writer: post failed: %s", exc)
         return False
+
+
+async def _write_audit_event(text: str, dave_dm_id: int | None) -> None:
+    """Write a governance_events row for every Max group post. Best-effort."""
+    import os
+    try:
+        from src.governance._mcp_helpers import governance_event_emit
+        governance_event_emit(
+            callsign="max",
+            event_type="max_group_post",
+            event_data={
+                "text": text[:500],
+                "dave_authorized_via_dm_id": dave_dm_id,
+                "tier": int(os.environ.get("COO_APPROVAL_TIER", "0")),
+            },
+            tool_name="governance.coo_bot.group_writer",
+        )
+    except Exception as exc:
+        logger.warning("group_writer: audit event failed (non-blocking): %s", exc)

--- a/src/coo_bot/group_writer.py
+++ b/src/coo_bot/group_writer.py
@@ -1,0 +1,50 @@
+"""Max COO bot — Group writer.
+
+Posts to the Agency OS supergroup with [MAX] prefix.
+Called by dm_handler when Dave uses /post command.
+
+Public API:
+    post_to_group(bot_token: str, text: str) -> bool
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_GROUP_CHAT_ID = -1003926592540
+_PREFIX = "[MAX] "
+
+
+async def post_to_group(bot_token: str, text: str) -> bool:
+    """Post a message to the Agency OS supergroup with [MAX] prefix.
+
+    Args:
+        bot_token: Telegram bot token for Max.
+        text: Message body (prefix will be prepended automatically).
+
+    Returns:
+        True on success, False on any failure (never raises).
+    """
+    url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+    payload = {
+        "chat_id": _GROUP_CHAT_ID,
+        "text": f"{_PREFIX}{text}",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.post(url, json=payload)
+        if response.status_code == 200:
+            logger.info("group_writer: posted to group OK")
+            return True
+        logger.error(
+            "group_writer: sendMessage returned HTTP %d: %s",
+            response.status_code,
+            response.text[:200],
+        )
+        return False
+    except Exception as exc:
+        logger.error("group_writer: post failed: %s", exc)
+        return False

--- a/tests/coo_bot/test_group_handler.py
+++ b/tests/coo_bot/test_group_handler.py
@@ -1,0 +1,98 @@
+"""Tests for src/coo_bot/group_handler.py — group message buffer."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import src.coo_bot.group_handler as gh
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _make_update(
+    text: str,
+    sender_id: int = 12345,
+    sender_name: str = "testuser",
+    chat_id: int = -1003926592540,
+    message_id: int = 1,
+) -> MagicMock:
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.text = text
+    update.message.chat_id = chat_id
+    update.message.message_id = message_id
+    update.message.date = None
+    update.message.from_user = MagicMock()
+    update.message.from_user.id = sender_id
+    update.message.from_user.username = sender_name
+    update.message.from_user.full_name = sender_name
+    return update
+
+
+def _make_context(bot_id: int = 999) -> MagicMock:
+    ctx = MagicMock()
+    ctx.bot = MagicMock()
+    ctx.bot.id = bot_id
+    return ctx
+
+
+def setup_function():
+    """Clear buffer before each test."""
+    gh._buffer.clear()
+
+
+def test_skip_own_messages():
+    """Bot's own messages must not enter the buffer."""
+    bot_id = 999
+    update = _make_update("hello", sender_id=bot_id)
+    ctx = _make_context(bot_id=bot_id)
+    _run(gh.handle_group_message(update, ctx))
+    assert len(gh._buffer) == 0
+
+
+def test_skip_enforcer():
+    """Messages starting with [ENFORCER] must be silently dropped."""
+    update = _make_update("[ENFORCER] some alert", sender_id=111)
+    ctx = _make_context(bot_id=999)
+    _run(gh.handle_group_message(update, ctx))
+    assert len(gh._buffer) == 0
+
+
+def test_buffer_stores_message():
+    """Normal group message is stored with correct keys and values."""
+    update = _make_update("hi group", sender_id=111, sender_name="alice", message_id=42)
+    ctx = _make_context(bot_id=999)
+    _run(gh.handle_group_message(update, ctx))
+    assert len(gh._buffer) == 1
+    entry = gh._buffer[0]
+    assert entry["sender"] == "alice"
+    assert entry["text"] == "hi group"
+    assert entry["message_id"] == 42
+    assert "timestamp" in entry
+
+
+def test_buffer_limit_50():
+    """Buffer must never exceed 50 entries."""
+    ctx = _make_context(bot_id=999)
+    for i in range(60):
+        update = _make_update(f"msg {i}", sender_id=111, message_id=i)
+        _run(gh.handle_group_message(update, ctx))
+    assert len(gh._buffer) == 50
+
+
+def test_get_recent_messages_returns_latest():
+    """get_recent_messages(limit=N) returns the N most recent messages."""
+    ctx = _make_context(bot_id=999)
+    for i in range(10):
+        update = _make_update(f"msg {i}", sender_id=111, message_id=i)
+        _run(gh.handle_group_message(update, ctx))
+
+    recent = gh.get_recent_messages(limit=3)
+    assert len(recent) == 3
+    # Should be the last three (msg 7, 8, 9)
+    assert recent[-1]["text"] == "msg 9"
+    assert recent[0]["text"] == "msg 7"

--- a/tests/coo_bot/test_group_writer.py
+++ b/tests/coo_bot/test_group_writer.py
@@ -1,0 +1,80 @@
+"""Tests for src/coo_bot/group_writer.py — group post wrapper."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import httpx
+
+from src.coo_bot.group_writer import post_to_group, _PREFIX
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _mock_response(status_code: int) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = "ok" if status_code == 200 else "error"
+    return resp
+
+
+def test_post_success():
+    """When sendMessage returns 200, post_to_group returns True."""
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_mock_response(200))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.coo_bot.group_writer.httpx.AsyncClient", return_value=mock_client):
+        result = _run(post_to_group("fake-token", "Hello group"))
+
+    assert result is True
+
+
+def test_post_failure():
+    """When sendMessage returns non-200, post_to_group returns False."""
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_mock_response(400))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.coo_bot.group_writer.httpx.AsyncClient", return_value=mock_client):
+        result = _run(post_to_group("fake-token", "Hello group"))
+
+    assert result is False
+
+
+def test_prefix_added():
+    """[MAX] prefix is prepended to the message text sent to Telegram."""
+    sent_payload = {}
+
+    async def capture_post(url, json):
+        sent_payload.update(json)
+        return _mock_response(200)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=capture_post)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.coo_bot.group_writer.httpx.AsyncClient", return_value=mock_client):
+        _run(post_to_group("fake-token", "status update"))
+
+    assert sent_payload["text"].startswith(_PREFIX)
+    assert "status update" in sent_payload["text"]
+
+
+def test_post_exception_returns_false():
+    """Network exception is swallowed and returns False."""
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=httpx.ConnectError("timeout"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.coo_bot.group_writer.httpx.AsyncClient", return_value=mock_client):
+        result = _run(post_to_group("fake-token", "Hello"))
+
+    assert result is False


### PR DESCRIPTION
## Summary
Phase B components (ATLAS dispatch):
- `src/coo_bot/group_handler.py` — deque-based buffer (maxlen=50), skips own messages + enforcer alerts
- `src/coo_bot/group_writer.py` — async httpx post with [MAX] prefix, wrapped (never raises)
- 9 tests (5 handler + 4 writer)

## Verification
```
$ from src.coo_bot.group_handler import handle_group_message, get_recent_messages → OK
$ from src.coo_bot.group_writer import post_to_group → OK
$ pytest tests/coo_bot/test_group_handler.py tests/coo_bot/test_group_writer.py -v → 9 passed
```

## Companion
PR from ORION (Aiden): tier_framework.py + memory_retriever.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)