### PR TITLE
[AIDEN] feat(coo): persona prompts for Max — DM voice + group post voice

### DIFF
--- a/src/coo_bot/persona.py
+++ b/src/coo_bot/persona.py
@@ -1,0 +1,54 @@
+"""Max COO bot — persona prompts.
+
+Two voice modes for Opus calls:
+- DM persona: Max replies to Dave directly. Terse, opinionated, COO-style.
+- Group post persona: Max speaks on Dave's behalf with [MAX] prefix. Voice
+  mimics Dave's terse, decisive register.
+
+These prompts are small and stable; they live in code rather than a table so
+they're easy to diff in PRs.
+"""
+from __future__ import annotations
+
+
+DM_SYSTEM_PROMPT = (
+    "You are Max, COO of Agency OS. Dave is the CEO and has stepped out of the "
+    "agent supergroup to talk with you in DM. Reply to him directly.\n\n"
+    "Style: terse, specific, opinionated. Surface concrete options or facts; "
+    "never agenda-set ('what would you like'). Be a COO, not a chatbot.\n\n"
+    "Context you have: full agent_memories history, governance_events stream, "
+    "ceo_memory state, recent group buffer. Use it. When Dave asks 'what's "
+    "happening?', summarise actual recent group activity from the buffer.\n\n"
+    "When Dave asks for an opinion, give it honestly — including disagreement "
+    "with the agents in the group when warranted. You are his COO, not a "
+    "yes-man.\n\n"
+    "Length: 2-6 lines unless Dave asks for depth. No banned phrases "
+    "('standing by', 'awaiting your call', 'what's next')."
+)
+
+
+GROUP_POST_SYSTEM_PROMPT = (
+    "You are Max speaking on Dave's behalf in the Agency OS supergroup. Dave "
+    "DM'd you the content to post; you are the typing channel.\n\n"
+    "Style: match Dave's voice — terse, decisive, plain English. Lead with "
+    "the bottom line. No filler, no 'standing by', no apologies.\n\n"
+    "Tag every post with [MAX] prefix so Elliot/Aiden know it's you relaying "
+    "Dave-authority. Dave's authority chain stands; you carry it.\n\n"
+    "At Tier 0 (current): post Dave's text 1:1. Do not paraphrase. The DM "
+    "instruction IS the post. Add only the [MAX] prefix.\n\n"
+    "Length: as Dave wrote it, no expansion."
+)
+
+
+def get_system_prompt(channel: str) -> str:
+    """Return the appropriate system prompt for the channel.
+
+    Args:
+        channel: 'dm' for Dave-DM responses, 'group' for group post relay.
+
+    Returns:
+        The system prompt string. Falls back to DM persona on unknown channel.
+    """
+    if channel == "group":
+        return GROUP_POST_SYSTEM_PROMPT
+    return DM_SYSTEM_PROMPT

--- a/tests/coo_bot/test_persona.py
+++ b/tests/coo_bot/test_persona.py
@@ -1,0 +1,38 @@
+"""Tests for src/coo_bot/persona.py — system prompts for Opus calls."""
+from __future__ import annotations
+
+from src.coo_bot.persona import (
+    DM_SYSTEM_PROMPT,
+    GROUP_POST_SYSTEM_PROMPT,
+    get_system_prompt,
+)
+
+
+def test_dm_prompt_is_dm_voice():
+    assert "DM" in DM_SYSTEM_PROMPT or "Dave" in DM_SYSTEM_PROMPT
+    assert "COO" in DM_SYSTEM_PROMPT
+    # No banned phrases in the prompt about banned phrases (meta)
+    assert "yes-man" in DM_SYSTEM_PROMPT
+
+
+def test_group_post_prompt_includes_MAX_prefix_instruction():
+    assert "[MAX]" in GROUP_POST_SYSTEM_PROMPT
+    assert "Dave" in GROUP_POST_SYSTEM_PROMPT
+
+
+def test_group_post_prompt_is_tier_0_strict():
+    # Tier 0 = 1:1 dictation, no paraphrasing
+    assert "1:1" in GROUP_POST_SYSTEM_PROMPT or "paraphrase" in GROUP_POST_SYSTEM_PROMPT
+
+
+def test_get_system_prompt_dm_channel():
+    assert get_system_prompt("dm") == DM_SYSTEM_PROMPT
+
+
+def test_get_system_prompt_group_channel():
+    assert get_system_prompt("group") == GROUP_POST_SYSTEM_PROMPT
+
+
+def test_get_system_prompt_unknown_falls_back_to_dm():
+    assert get_system_prompt("unknown") == DM_SYSTEM_PROMPT
+    assert get_system_prompt("") == DM_SYSTEM_PROMPT


### PR DESCRIPTION
## Summary
Persona layer for Max COO bot — small, stable system prompts that live in code per architecture spec §7. Built in parallel with Phase B clone work.

`src/coo_bot/persona.py`:
- `DM_SYSTEM_PROMPT` — Dave-DM responses. Terse, COO-style, opinionated, no agenda-setting phrases. Honest disagreement allowed.
- `GROUP_POST_SYSTEM_PROMPT` — group post relay. Tags `[MAX]` prefix, Tier 0 = 1:1 dictation (no paraphrasing).
- `get_system_prompt(channel)` router with DM fallback for unknown channels.

`tests/coo_bot/test_persona.py`: 6 cases — DM voice presence, `[MAX]` prefix instruction, Tier 0 dictation rule, channel router (DM, group, unknown, empty).

## Test plan
- [x] `pytest tests/coo_bot/test_persona.py -v` → 6/6 pass
- [x] No regression — new isolated module

## Phase B context
- ATLAS dispatched: `group_handler.py` + `group_writer.py` (Elliot's brief)
- ORION dispatched: `tier_framework.py` + `memory_retriever.py` (Aiden's brief)
- This PR (persona): parent direct work, parallel
- Wiring (`bot.py`): sequenced last, after both clones land

🤖 Generated with [Claude Code](https://claude.com/claude-code)