### PR TITLE
[AIDEN] feat(coo): Phase B — tier_framework + memory_retriever (ORION dispatch)

### DIFF
--- a/src/coo_bot/memory_retriever.py
+++ b/src/coo_bot/memory_retriever.py
@@ -1,0 +1,173 @@
+"""src/coo_bot/memory_retriever.py — context loader for the Max COO Opus prompt.
+
+MAX-COO-PHASE-B / Phase B File 2.
+
+Three retrievers + one assembler:
+
+  get_relevant_memories(query, limit=5)
+      ILIKE search on public.agent_memories. When MEMORY_RECALL_BACKEND in
+      ('mem0', 'hybrid'), delegates to memory_listener.recall_via_mem0 for
+      relationship-aware recall; otherwise direct Supabase query.
+
+  get_high_value_memories(callsign='aiden', limit=10)
+      Loads source_type IN (pattern, decision, dave_confirmed, verified_fact)
+      rows for the given callsign, newest first.
+
+  get_ceo_memory_keys(prefix)
+      Loads public.ceo_memory rows whose `key` starts with `prefix`.
+
+  assemble_context(query)
+      Combines all three above into a single formatted block ready for
+      Opus prompt injection.
+
+Every external call is wrapped in try/except — a memory miss must never
+block the COO bot from responding. Failures return [] / "" and log a
+warning.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_HIGH_VALUE_SOURCE_TYPES = (
+    "pattern",
+    "decision",
+    "dave_confirmed",
+    "verified_fact",
+)
+
+
+def _supabase_client():
+    """Build a service-role Supabase client. Returns None if env or pkg
+    missing — callers degrade to []."""
+    url = os.environ.get("SUPABASE_URL", "")
+    key = os.environ.get("SUPABASE_SERVICE_KEY", "") or os.environ.get(
+        "SUPABASE_KEY", "",
+    )
+    if not url or not key:
+        return None
+    try:
+        from supabase import create_client  # type: ignore
+    except ImportError:
+        logger.warning("[memory_retriever] supabase package not installed")
+        return None
+    try:
+        return create_client(url, key)
+    except Exception as exc:
+        logger.warning("[memory_retriever] supabase client init failed: %s", exc)
+        return None
+
+
+def _supabase_ilike_search(query: str, limit: int) -> list[dict[str, Any]]:
+    client = _supabase_client()
+    if client is None:
+        return []
+    try:
+        response = (
+            client.table("agent_memories")
+            .select("id,content,source_type,callsign,created_at")
+            .ilike("content", f"%{query}%")
+            .order("created_at", desc=True)
+            .limit(limit)
+            .execute()
+        )
+        return list(getattr(response, "data", None) or [])
+    except Exception as exc:
+        logger.warning("[memory_retriever] ilike search failed: %s", exc)
+        return []
+
+
+def get_relevant_memories(query: str, limit: int = 5) -> list[dict[str, Any]]:
+    """Load relevant agent_memories rows for `query`.
+
+    Routes through memory_listener.recall_via_mem0 when MEMORY_RECALL_BACKEND
+    in ('mem0','hybrid'), otherwise direct Supabase ILIKE.
+    """
+    backend = os.environ.get("MEMORY_RECALL_BACKEND", "supabase").lower()
+    if backend in ("mem0", "hybrid"):
+        try:
+            from src.telegram_bot.memory_listener import recall_via_mem0
+            callsign = os.environ.get("CALLSIGN", "aiden")
+            return asyncio.run(
+                recall_via_mem0(query, callsign=callsign, limit=limit)
+            )
+        except Exception as exc:
+            logger.warning(
+                "[memory_retriever] memory_listener path failed (%s); "
+                "falling back to supabase",
+                exc,
+            )
+    return _supabase_ilike_search(query, limit)
+
+
+def get_high_value_memories(
+    callsign: str = "aiden", limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Load high-signal agent_memories for `callsign`, newest first."""
+    client = _supabase_client()
+    if client is None:
+        return []
+    try:
+        response = (
+            client.table("agent_memories")
+            .select("id,content,source_type,callsign,created_at")
+            .eq("callsign", callsign)
+            .in_("source_type", list(_HIGH_VALUE_SOURCE_TYPES))
+            .order("created_at", desc=True)
+            .limit(limit)
+            .execute()
+        )
+        return list(getattr(response, "data", None) or [])
+    except Exception as exc:
+        logger.warning("[memory_retriever] high-value query failed: %s", exc)
+        return []
+
+
+def get_ceo_memory_keys(prefix: str) -> list[dict[str, Any]]:
+    """Load public.ceo_memory rows whose `key` starts with `prefix`."""
+    client = _supabase_client()
+    if client is None:
+        return []
+    try:
+        response = (
+            client.table("ceo_memory")
+            .select("key,value,updated_at")
+            .like("key", f"{prefix}%")
+            .order("updated_at", desc=True)
+            .execute()
+        )
+        return list(getattr(response, "data", None) or [])
+    except Exception as exc:
+        logger.warning("[memory_retriever] ceo_memory query failed: %s", exc)
+        return []
+
+
+def _format_block(title: str, rows: list[dict[str, Any]]) -> str:
+    if not rows:
+        return f"### {title}\n(none)\n"
+    lines = [f"### {title}"]
+    for row in rows:
+        # ceo_memory rows expose key/value; agent_memories rows expose content.
+        if "key" in row:
+            lines.append(f"- {row['key']}: {row.get('value', '')}")
+        else:
+            src = row.get("source_type", "")
+            lines.append(f"- [{src}] {row.get('content', '')}")
+    return "\n".join(lines) + "\n"
+
+
+def assemble_context(query: str) -> str:
+    """Build the combined context block injected into the Opus prompt."""
+    relevant = get_relevant_memories(query)
+    high_value = get_high_value_memories()
+    ceo_keys = get_ceo_memory_keys("ceo:")
+    parts = [
+        _format_block("Relevant Memories", relevant),
+        _format_block("High-Value Memories", high_value),
+        _format_block("CEO Memory", ceo_keys),
+    ]
+    return "\n".join(parts)

--- a/src/coo_bot/tier_framework.py
+++ b/src/coo_bot/tier_framework.py
@@ -1,0 +1,104 @@
+"""src/coo_bot/tier_framework.py — Max COO autonomy tier gate.
+
+MAX-COO-PHASE-B / Phase B File 1.
+
+Tiered approval framework that decides whether the COO bot may post a
+given action autonomously, based on:
+
+  1. COO_APPROVAL_TIER env var (0..3, default 0)
+  2. STOP MAX state file at /home/elliotbot/clawd/state/coo_tier_override
+     (when present, force-tier-zero regardless of env)
+
+Tier categories (per docs/architecture/MAX_COO_ARCHITECTURE.md):
+  Tier 0 — nothing autonomous (every action goes to Dave)
+  Tier 1 — pre-approved low-risk: governance flags, dispatch acks
+  Tier 2 — Tier 1 + routine ops: status reports, memory writes, log queries
+  Tier 3 — full proxy: anything Tier 2 plus directive issuance, peer dispatch
+
+GOV-12: each tier check is a runtime conditional, not a comment.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+STOP_OVERRIDE_PATH = Path(
+    os.environ.get(
+        "COO_TIER_OVERRIDE_PATH",
+        "/home/elliotbot/clawd/state/coo_tier_override",
+    )
+)
+
+TIER_1_ACTIONS: frozenset[str] = frozenset({
+    "governance_flag",
+    "dispatch_ack",
+})
+TIER_2_ACTIONS: frozenset[str] = frozenset({
+    "status_report",
+    "memory_write",
+    "log_query",
+})
+TIER_3_ACTIONS: frozenset[str] = frozenset({
+    "directive_issuance",
+    "peer_dispatch",
+})
+
+
+def force_tier_zero() -> bool:
+    """Return True iff the STOP MAX override file is present."""
+    return STOP_OVERRIDE_PATH.is_file()
+
+
+def write_stop_override(reason: str = "") -> None:
+    """Create the STOP MAX override file. Idempotent. Best-effort on parent
+    dir creation."""
+    try:
+        STOP_OVERRIDE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        STOP_OVERRIDE_PATH.write_text(reason or "stop", encoding="utf-8")
+    except OSError as exc:
+        logger.warning("[tier_framework] write_stop_override failed: %s", exc)
+
+
+def clear_stop_override() -> None:
+    """Remove the STOP MAX override file. No-op if absent."""
+    try:
+        STOP_OVERRIDE_PATH.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning("[tier_framework] clear_stop_override failed: %s", exc)
+
+
+def get_current_tier() -> int:
+    """Resolve effective tier: STOP override wins, else env COO_APPROVAL_TIER
+    (clamped to 0..3, non-int falls back to 0)."""
+    if force_tier_zero():
+        return 0
+    raw = os.environ.get("COO_APPROVAL_TIER", "0")
+    try:
+        tier = int(raw)
+    except (TypeError, ValueError):
+        return 0
+    if tier < 0:
+        return 0
+    if tier > 3:
+        return 3
+    return tier
+
+
+def can_post(action_type: str, current_tier: int | None = None) -> bool:
+    """Return True iff `action_type` is permitted at `current_tier`.
+
+    `current_tier` defaults to get_current_tier() when None. Unknown action
+    types are denied (closed-by-default)."""
+    tier = current_tier if current_tier is not None else get_current_tier()
+    if tier <= 0:
+        return False
+    if tier >= 1 and action_type in TIER_1_ACTIONS:
+        return True
+    if tier >= 2 and action_type in TIER_2_ACTIONS:
+        return True
+    if tier >= 3 and action_type in TIER_3_ACTIONS:
+        return True
+    return False

--- a/tests/coo_bot/test_memory_retriever.py
+++ b/tests/coo_bot/test_memory_retriever.py
@@ -1,0 +1,115 @@
+"""tests/coo_bot/test_memory_retriever.py — unit tests for COO memory loaders.
+
+MAX-COO-PHASE-B / Phase B File 2.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch):
+    """Default: supabase backend so retrievers hit _supabase_client path."""
+    monkeypatch.setenv("MEMORY_RECALL_BACKEND", "supabase")
+    monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "test-service-key")
+
+
+def _mock_response(rows):
+    """Build a fake supabase response object exposing `.data`."""
+    resp = MagicMock()
+    resp.data = rows
+    return resp
+
+
+def _build_mock_client(rows):
+    """Build a mock client whose chained query call returns `rows`."""
+    client = MagicMock()
+    chain = client.table.return_value
+    chain.select.return_value = chain
+    chain.ilike.return_value = chain
+    chain.eq.return_value = chain
+    chain.in_.return_value = chain
+    chain.like.return_value = chain
+    chain.order.return_value = chain
+    chain.limit.return_value = chain
+    chain.execute.return_value = _mock_response(rows)
+    return client
+
+
+def test_supabase_returns_rows():
+    from src.coo_bot import memory_retriever as mr
+
+    rows = [{"id": "1", "content": "hello world", "source_type": "research"}]
+    with patch.object(mr, "_supabase_client", return_value=_build_mock_client(rows)):
+        out = mr.get_relevant_memories("hello", limit=5)
+    assert out == rows
+
+
+def test_empty_result_returns_empty_list():
+    from src.coo_bot import memory_retriever as mr
+
+    with patch.object(mr, "_supabase_client", return_value=_build_mock_client([])):
+        assert mr.get_relevant_memories("nothing-matches") == []
+        assert mr.get_high_value_memories(callsign="aiden") == []
+        assert mr.get_ceo_memory_keys("ceo:") == []
+
+
+def test_exception_returns_empty_list():
+    from src.coo_bot import memory_retriever as mr
+
+    failing_client = MagicMock()
+    failing_client.table.side_effect = RuntimeError("boom")
+    with patch.object(mr, "_supabase_client", return_value=failing_client):
+        assert mr.get_relevant_memories("anything") == []
+        assert mr.get_high_value_memories() == []
+        assert mr.get_ceo_memory_keys("ceo:") == []
+
+
+def test_hybrid_backend_uses_memory_listener_path(monkeypatch):
+    from src.coo_bot import memory_retriever as mr
+
+    monkeypatch.setenv("MEMORY_RECALL_BACKEND", "hybrid")
+    monkeypatch.setenv("CALLSIGN", "orion")
+
+    expected = [{"content": "from-mem0", "source_type": "pattern"}]
+
+    async def _fake_recall(query, callsign, limit):
+        assert query == "test query"
+        assert callsign == "orion"
+        assert limit == 5
+        return expected
+
+    fake_module = MagicMock()
+    fake_module.recall_via_mem0 = _fake_recall
+    with patch.dict(
+        "sys.modules", {"src.telegram_bot.memory_listener": fake_module},
+    ):
+        out = mr.get_relevant_memories("test query", limit=5)
+    assert out == expected
+
+
+def test_supabase_fallback_when_memory_listener_unavailable(monkeypatch):
+    """When MEMORY_RECALL_BACKEND=hybrid but the import or recall call
+    raises, get_relevant_memories falls back to the supabase ilike path."""
+    from src.coo_bot import memory_retriever as mr
+
+    monkeypatch.setenv("MEMORY_RECALL_BACKEND", "hybrid")
+
+    fallback_rows = [{"id": "fb", "content": "fallback row"}]
+
+    async def _broken_recall(*args, **kwargs):
+        raise RuntimeError("mem0 unreachable")
+
+    fake_module = MagicMock()
+    fake_module.recall_via_mem0 = _broken_recall
+
+    with patch.dict("sys.modules", {"src.telegram_bot.memory_listener": fake_module}):
+        with patch.object(
+            mr, "_supabase_client",
+            return_value=_build_mock_client(fallback_rows),
+        ):
+            out = mr.get_relevant_memories("query")
+    assert out == fallback_rows

--- a/tests/coo_bot/test_tier_framework.py
+++ b/tests/coo_bot/test_tier_framework.py
@@ -1,0 +1,84 @@
+"""tests/coo_bot/test_tier_framework.py — unit tests for the COO tier gate.
+
+MAX-COO-PHASE-B / Phase B File 1.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def tier_module(tmp_path, monkeypatch):
+    """Re-import tier_framework with the override path pointing at tmp_path
+    so tests don't touch the real /home/elliotbot/clawd/state file."""
+    override = tmp_path / "coo_tier_override"
+    monkeypatch.setenv("COO_TIER_OVERRIDE_PATH", str(override))
+    monkeypatch.delenv("COO_APPROVAL_TIER", raising=False)
+    import importlib
+
+    import src.coo_bot.tier_framework as tf
+    importlib.reload(tf)
+    yield tf, override
+    # Reload again post-test so the module's global path doesn't leak.
+    importlib.reload(tf)
+
+
+def test_tier_zero_denies_all(tier_module):
+    tf, _ = tier_module
+    assert tf.can_post("governance_flag", 0) is False
+    assert tf.can_post("dispatch_ack", 0) is False
+    assert tf.can_post("status_report", 0) is False
+
+
+def test_tier_one_allows_pre_approved(tier_module):
+    tf, _ = tier_module
+    assert tf.can_post("governance_flag", 1) is True
+    assert tf.can_post("dispatch_ack", 1) is True
+
+
+def test_tier_one_denies_non_approved(tier_module):
+    tf, _ = tier_module
+    # routine ops are Tier 2, full proxy is Tier 3 — not allowed at Tier 1.
+    assert tf.can_post("status_report", 1) is False
+    assert tf.can_post("directive_issuance", 1) is False
+    # Unknown action types are closed-by-default at every tier.
+    assert tf.can_post("unknown_action", 3) is False
+
+
+def test_stop_max_overrides_higher_tier(tier_module, monkeypatch):
+    tf, override = tier_module
+    monkeypatch.setenv("COO_APPROVAL_TIER", "3")
+    tf.write_stop_override("test reason")
+    assert override.is_file()
+    assert tf.force_tier_zero() is True
+    assert tf.get_current_tier() == 0
+    # Even Tier 3 actions are denied while STOP MAX is active.
+    assert tf.can_post("directive_issuance") is False
+    assert tf.can_post("governance_flag") is False
+
+
+def test_stop_max_clear_restores_tier(tier_module, monkeypatch):
+    tf, override = tier_module
+    monkeypatch.setenv("COO_APPROVAL_TIER", "2")
+    tf.write_stop_override()
+    assert tf.get_current_tier() == 0
+    tf.clear_stop_override()
+    assert override.is_file() is False
+    assert tf.force_tier_zero() is False
+    assert tf.get_current_tier() == 2
+    assert tf.can_post("status_report") is True
+
+
+def test_env_var_read_returns_int(tier_module, monkeypatch):
+    tf, _ = tier_module
+    monkeypatch.setenv("COO_APPROVAL_TIER", "1")
+    assert tf.get_current_tier() == 1
+    monkeypatch.setenv("COO_APPROVAL_TIER", "3")
+    assert tf.get_current_tier() == 3
+    # Out-of-range clamps; non-int falls to 0.
+    monkeypatch.setenv("COO_APPROVAL_TIER", "9")
+    assert tf.get_current_tier() == 3
+    monkeypatch.setenv("COO_APPROVAL_TIER", "not-an-int")
+    assert tf.get_current_tier() == 0


### PR DESCRIPTION
## Summary
ORION clone dispatch — Phase B remaining components per Max COO architecture spec.

`src/coo_bot/tier_framework.py` (97 lines):
- `COO_APPROVAL_TIER` env var (0-3, default 0).
- `can_post(action_type, current_tier) -> bool` checks category whitelist per tier.
- Tier 0 = nothing autonomous. Tier 1 = pre-approved low-risk (gov flags, dispatch acks). Tier 2 = routine ops. Tier 3 = full proxy.
- STOP MAX state file at `/home/elliotbot/clawd/state/coo_tier_override` — when present, forces Tier 0.
- Closed-by-default semantics; `get_current_tier()` reads env + state file together.

`src/coo_bot/memory_retriever.py` (162 lines):
- `get_relevant_memories(query, limit=5)` — uses `recall_via_mem0` if `MEMORY_RECALL_BACKEND=hybrid`, falls back to direct Supabase ILIKE on `agent_memories`.
- `get_high_value_memories(callsign, limit=10)` — pulls pattern/decision/dave_confirmed/verified_fact rows.
- `get_ceo_memory_keys(prefix)` — ceo_memory key lookup.
- `assemble_context(query)` — combines all 3 into a single context block for Opus prompt injection.
- All external calls wrapped — memory miss never blocks COO.

## Test plan
- [x] `pytest tests/coo_bot/test_tier_framework.py tests/coo_bot/test_memory_retriever.py -v` → 11/11 pass (per ORION outbox)
- [x] Closed-by-default tier gate (Tier 0 denies all)
- [x] STOP MAX overrides higher tier
- [x] Hybrid backend routes through memory_listener; supabase fallback when memory_listener unavailable

## Phase B status
- ✅ ATLAS: group_handler + group_writer (PR #506 merged)
- ✅ ORION: tier_framework + memory_retriever (this PR)
- ✅ Persona: PR #507 merged
- Wiring next: `src/coo_bot/bot.py` integrates all components into Application + handlers (Aiden direct, sequenced last)

🤖 Generated with [Claude Code](https://claude.com/claude-code)