### PR TITLE
[AIDEN] feat(coo): Phase C — bot.py wiring (Max COO proxy live)

### DIFF
--- a/src/coo_bot/bot.py
+++ b/src/coo_bot/bot.py
@@ -1,15 +1,19 @@
-"""COO Bot (Max) — Plain-English executive summaries for Dave.
+"""COO Bot (Max) — Dave's COO proxy for Agency OS.
 
-Phase 2 roadmap component. Observe-only v1: reads governance_events +
-ceo_memory, generates summaries, DMs Dave. Does NOT make decisions.
+Phase 2 build (Tier 0 starting authority). Reads supergroup + governance_events,
+DMs Dave summaries on hourly cadence + on-demand /status, accepts Dave's DMs
+as conversational + /post group-relay instructions.
+
+LLM: Claude Opus via `claude -p` subprocess on Dave's Max plan ($0/call).
 
 Environment:
-  COO_BOT_TOKEN         — Telegram bot token for @MaxCOO_Bot
-  OPENAI_API_KEY        — for summary generation
-  SUPABASE_URL + SUPABASE_SERVICE_KEY — for reading events
-  COO_DAVE_CHAT_ID      — Dave's chat ID for DM (default: 7267788033)
-  COO_DIGEST_INTERVAL_MINUTES — poll cadence (default: 60)
+  COO_BOT_TOKEN          — Telegram bot token for @MaxCOO_Bot
+  COO_DAVE_CHAT_ID       — Dave's chat ID for DM (default: 7267788033)
+  COO_DIGEST_INTERVAL_MINUTES — digest poll cadence (default: 60)
+  COO_APPROVAL_TIER      — 0..3, default 0 (tier-gated autonomy)
   DATABASE_URL or SUPABASE_DB_URL — asyncpg DSN
+  MEMORY_RECALL_BACKEND  — 'supabase' | 'mem0' | 'hybrid' for context retriever
+  OPENAI_API_KEY         — DEPRECATED for primary path; kept as legacy fallback
 """
 from __future__ import annotations
 
@@ -22,20 +26,26 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import asyncpg
-import openai
 from telegram import Bot, Update
 from telegram.error import TelegramError
-from telegram.ext import Application, CommandHandler, ContextTypes
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
 
 from src.coo_bot.config import COOConfig
+from src.coo_bot.dm_handler import handle_dm
+from src.coo_bot.group_handler import handle_group_message
+from src.coo_bot.opus_client import opus_call
+from src.coo_bot.persona import get_system_prompt
 
 logger = logging.getLogger(__name__)
 
-_SYSTEM_PROMPT = (
-    "You are Max, COO of Agency OS. "
-    "Summarize agent activity for Dave in 3-5 bullet points. "
-    "Be concise, flag anything unusual."
-)
+# Group chat ID for the Agency OS supergroup (used to filter MessageHandlers).
+_GROUP_CHAT_ID = -1003926592540
 
 
 # ---------------------------------------------------------------------------
@@ -44,37 +54,22 @@ _SYSTEM_PROMPT = (
 
 
 async def generate_summary(events: list[dict[str, Any]], window_hours: int = 1) -> str:
-    """Generate a plain-English digest of recent governance events via OpenAI.
+    """Generate a plain-English digest of recent governance events via Opus CLI.
 
-    Uses gpt-4o-mini to keep costs low. Returns an empty string on failure
-    so the caller can skip the DM gracefully.
+    Uses Claude Opus subprocess (Max plan, $0/call). Returns an empty string
+    on failure so the caller can skip the DM gracefully.
     """
-    cfg = COOConfig()
-    client = openai.AsyncOpenAI(api_key=cfg.openai_api_key)
-
     event_lines = "\n".join(
         f"- [{e.get('event_type', 'unknown')}] {e.get('event_data', {})} "
         f"(callsign={e.get('callsign', '?')}, ts={e.get('timestamp', '')})"
-        for e in events[:30]  # cap at 30 to stay under token budget
+        for e in events[:30]  # cap at 30 to stay under prompt budget
     )
     user_msg = (
-        f"Last {window_hours}h governance events ({len(events)} total):\n{event_lines}"
+        f"Last {window_hours}h governance events ({len(events)} total):\n"
+        f"{event_lines}\n\n"
+        "Summarize for Dave: 3-5 bullet points, flag anything unusual."
     )
-
-    try:
-        resp = await client.chat.completions.create(
-            model="gpt-4o-mini",
-            messages=[
-                {"role": "system", "content": _SYSTEM_PROMPT},
-                {"role": "user", "content": user_msg},
-            ],
-            max_tokens=300,
-            temperature=0.3,
-        )
-        return resp.choices[0].message.content or ""
-    except Exception as exc:
-        logger.error("OpenAI summary failed: %s", exc)
-        return ""
+    return await opus_call(get_system_prompt("dm"), user_msg, timeout=60)
 
 
 async def fetch_recent_events(
@@ -328,6 +323,22 @@ def main() -> None:
 
     app.add_handler(CommandHandler("status", cmd_status))
 
+    # Group reader — store messages from supergroup in rolling buffer.
+    app.add_handler(
+        MessageHandler(
+            filters.Chat(chat_id=_GROUP_CHAT_ID) & filters.TEXT,
+            handle_group_message,
+        )
+    )
+
+    # Dave's DM — bidirectional conversation + /post relay + STOP MAX kill.
+    app.add_handler(
+        MessageHandler(
+            filters.Chat(chat_id=cfg.dave_chat_id) & filters.TEXT,
+            handle_dm,
+        )
+    )
+
     interval_seconds = cfg.digest_interval_minutes * 60
     app.job_queue.run_repeating(
         _make_digest_job(cfg),
@@ -336,9 +347,9 @@ def main() -> None:
         name="digest",
     )
 
+    tier = int(os.environ.get("COO_APPROVAL_TIER", "0"))
     logger.info(
-        "COO bot starting — digest interval=%dm, dave_chat_id=%s",
-        cfg.digest_interval_minutes,
-        cfg.dave_chat_id,
+        "Max COO bot starting — digest interval=%dm, dave_chat_id=%s, tier=%d",
+        cfg.digest_interval_minutes, cfg.dave_chat_id, tier,
     )
     app.run_polling(drop_pending_updates=True)

--- a/tests/coo_bot/test_coo_bot.py
+++ b/tests/coo_bot/test_coo_bot.py
@@ -33,25 +33,14 @@ def _run(coro: Any) -> Any:
 
 
 def test_generate_summary_formats_correctly() -> None:
-    """OpenAI response content is returned as-is."""
+    """Opus call response is returned as-is (post-Phase-B migration)."""
     events = [_make_event("COST_CAP", "daily cap hit"), _make_event("GOV_DENY", "classifier blocked")]
 
-    fake_choice = MagicMock()
-    fake_choice.message.content = "- Cost cap hit\n- Classifier blocked"
-    fake_resp = MagicMock()
-    fake_resp.choices = [fake_choice]
-
-    with patch.dict(
-        "os.environ",
-        {"COO_BOT_TOKEN": "fake-token", "OPENAI_API_KEY": "fake-key"},
-    ):
-        with patch("src.coo_bot.bot.openai.AsyncOpenAI") as mock_openai_cls:
-            mock_client = MagicMock()
-            mock_client.chat = MagicMock()
-            mock_client.chat.completions = MagicMock()
-            mock_client.chat.completions.create = AsyncMock(return_value=fake_resp)
-            mock_openai_cls.return_value = mock_client
-
+    with patch.dict("os.environ", {"COO_BOT_TOKEN": "fake-token"}):
+        with patch(
+            "src.coo_bot.bot.opus_call",
+            AsyncMock(return_value="- Cost cap hit\n- Classifier blocked"),
+        ):
             from src.coo_bot.bot import generate_summary
 
             result = _run(generate_summary(events, window_hours=1))

--- a/tests/coo_bot/test_opus_client.py
+++ b/tests/coo_bot/test_opus_client.py
@@ -9,15 +9,13 @@ import pytest
 from src.coo_bot.opus_client import opus_call
 
 
-@pytest.fixture
-def event_loop():
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
-
-
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    """Run an async coro on a fresh event loop — avoids cross-test pollution."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def test_happy_path():


### PR DESCRIPTION
## Summary
**Final integration step.** All Phase B components (group_handler, group_writer, dm_handler, tier_framework, memory_retriever, persona, opus_client) are now wired into the running systemd service.

After this merge, Max becomes Dave's COO proxy in the supergroup at Tier 0:
- Reads supergroup → buffers + flag-to-DM logic
- Receives Dave's DM → conversational response with full context
- `/post <text>` from Dave → group post with `[MAX]` prefix + governance_events audit row
- `STOP MAX` DM keyword → forces Tier 0
- Hourly digest → now via Opus (was OpenAI gpt-4o-mini)

## Changes
- `src/coo_bot/bot.py`:
  - Drop `openai` import; route `generate_summary` through `opus_call` + `persona.get_system_prompt('dm')`.
  - Register MessageHandlers (group + DM) per architecture spec.
  - Log `COO_APPROVAL_TIER` on startup.
- `tests/coo_bot/test_coo_bot.py`: patch `opus_call` instead of `openai.AsyncOpenAI`.
- `tests/coo_bot/test_opus_client.py`: fresh event loop per `_run` call (cross-test pollution fix).

## Verification
- `pytest tests/coo_bot/ -q` → **43/43 pass**
- Live smoke: `opus_call("You are Max.", "Reply pong")` → `"pong"` (Max plan auth + Opus subprocess working)
- All Phase B modules import cleanly through `bot.py`

## What this completes
| Component | PR | Status |
|-----------|-----|--------|
| arch spec | #504 | ✅ merged |
| roadmap + opus_client + dm_handler | #505 | ✅ merged |
| group_handler + group_writer | #506 | ✅ merged |
| persona | #507 | ✅ merged |
| tier_framework + memory_retriever | #508 | ✅ merged |
| **bot.py wiring** | **#509** | **this PR** |

After merge: `systemctl --user restart agency-os-coo.service` to pick up the new wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)