### PR TITLE
[AIDEN] fix(coo): P0 — memory_retriever async + opus_call timeout 30→90s

### DIFF
--- a/src/coo_bot/memory_retriever.py
+++ b/src/coo_bot/memory_retriever.py
@@ -81,20 +81,21 @@ def _supabase_ilike_search(query: str, limit: int) -> list[dict[str, Any]]:
         return []
 
 
-def get_relevant_memories(query: str, limit: int = 5) -> list[dict[str, Any]]:
+async def get_relevant_memories(query: str, limit: int = 5) -> list[dict[str, Any]]:
     """Load relevant agent_memories rows for `query`.
 
     Routes through memory_listener.recall_via_mem0 when MEMORY_RECALL_BACKEND
-    in ('mem0','hybrid'), otherwise direct Supabase ILIKE.
+    in ('mem0','hybrid'), otherwise direct Supabase ILIKE. Async because
+    callers run inside the bot's event loop — we must await recall_via_mem0
+    rather than spawn a nested asyncio.run() (which raises
+    'cannot be called from a running event loop').
     """
     backend = os.environ.get("MEMORY_RECALL_BACKEND", "supabase").lower()
     if backend in ("mem0", "hybrid"):
         try:
             from src.telegram_bot.memory_listener import recall_via_mem0
             callsign = os.environ.get("CALLSIGN", "aiden")
-            return asyncio.run(
-                recall_via_mem0(query, callsign=callsign, limit=limit)
-            )
+            return await recall_via_mem0(query, callsign=callsign, limit=limit)
         except Exception as exc:
             logger.warning(
                 "[memory_retriever] memory_listener path failed (%s); "
@@ -160,9 +161,13 @@ def _format_block(title: str, rows: list[dict[str, Any]]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def assemble_context(query: str) -> str:
-    """Build the combined context block injected into the Opus prompt."""
-    relevant = get_relevant_memories(query)
+async def assemble_context(query: str) -> str:
+    """Build the combined context block injected into the Opus prompt.
+
+    Async because get_relevant_memories is async (must await recall_via_mem0
+    inside the bot's running event loop).
+    """
+    relevant = await get_relevant_memories(query)
     high_value = get_high_value_memories()
     ceo_keys = get_ceo_memory_keys("ceo:")
     parts = [

--- a/src/coo_bot/opus_client.py
+++ b/src/coo_bot/opus_client.py
@@ -27,7 +27,10 @@ logger = logging.getLogger(__name__)
 
 _CLAUDE_BIN = shutil.which("claude") or "/home/elliotbot/.local/bin/claude"
 _DEFAULT_MODEL = "claude-opus-4-6"
-_DEFAULT_TIMEOUT = 30
+# Opus latency on Max plan is 5-15s base; with memory context payload + DM
+# response generation, observed >30s in production. Bumped to 90s — still
+# inside the LAW VII >60s async-pattern threshold the bot already uses.
+_DEFAULT_TIMEOUT = 90
 
 
 async def opus_call(

--- a/tests/coo_bot/test_memory_retriever.py
+++ b/tests/coo_bot/test_memory_retriever.py
@@ -39,12 +39,22 @@ def _build_mock_client(rows):
     return client
 
 
+def _run(coro):
+    """Run an async coro on a fresh event loop — avoids cross-test pollution."""
+    import asyncio
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
 def test_supabase_returns_rows():
     from src.coo_bot import memory_retriever as mr
 
     rows = [{"id": "1", "content": "hello world", "source_type": "research"}]
     with patch.object(mr, "_supabase_client", return_value=_build_mock_client(rows)):
-        out = mr.get_relevant_memories("hello", limit=5)
+        out = _run(mr.get_relevant_memories("hello", limit=5))
     assert out == rows
 
 
@@ -52,7 +62,7 @@ def test_empty_result_returns_empty_list():
     from src.coo_bot import memory_retriever as mr
 
     with patch.object(mr, "_supabase_client", return_value=_build_mock_client([])):
-        assert mr.get_relevant_memories("nothing-matches") == []
+        assert _run(mr.get_relevant_memories("nothing-matches")) == []
         assert mr.get_high_value_memories(callsign="aiden") == []
         assert mr.get_ceo_memory_keys("ceo:") == []
 
@@ -63,7 +73,7 @@ def test_exception_returns_empty_list():
     failing_client = MagicMock()
     failing_client.table.side_effect = RuntimeError("boom")
     with patch.object(mr, "_supabase_client", return_value=failing_client):
-        assert mr.get_relevant_memories("anything") == []
+        assert _run(mr.get_relevant_memories("anything")) == []
         assert mr.get_high_value_memories() == []
         assert mr.get_ceo_memory_keys("ceo:") == []
 
@@ -87,7 +97,7 @@ def test_hybrid_backend_uses_memory_listener_path(monkeypatch):
     with patch.dict(
         "sys.modules", {"src.telegram_bot.memory_listener": fake_module},
     ):
-        out = mr.get_relevant_memories("test query", limit=5)
+        out = _run(mr.get_relevant_memories("test query", limit=5))
     assert out == expected
 
 
@@ -111,5 +121,5 @@ def test_supabase_fallback_when_memory_listener_unavailable(monkeypatch):
             mr, "_supabase_client",
             return_value=_build_mock_client(fallback_rows),
         ):
-            out = mr.get_relevant_memories("query")
+            out = _run(mr.get_relevant_memories("query"))
     assert out == fallback_rows


### PR DESCRIPTION
## Summary
P0 fix for two production bugs caught from systemd journal of live Max bot. Dave's first DM returned the fallback "try again" message instead of a real Opus response.

**B1** — `memory_retriever.get_relevant_memories` called `asyncio.run(recall_via_mem0(...))` while running inside the bot's event loop (dm_handler is async). `RuntimeError: asyncio.run() cannot be called from a running event loop` + `RuntimeWarning: coroutine was never awaited`.
- Fix: make `get_relevant_memories` async, `await recall_via_mem0` directly.
- `assemble_context` becomes async too (its caller can `await` it). `dm_handler:117` already had `await`, so no upstream caller change needed.

**B2** — `opus_call._DEFAULT_TIMEOUT=30` too short for Opus + memory context. Live observed >30s. Bumped to 90s with inline rationale comment.

## Live evidence
```
21:29:53 WARNING: opus_call timed out after 30s
21:29:54 WARNING: memory_retriever path failed (asyncio.run() cannot be called from a running event loop)
21:29:54 sendMessage 200 OK   ← FALLBACK 'try again' message, not real reply
```

## Test plan
- [x] `pytest tests/coo_bot/ -q` → 43/43 pass
- [x] `test_memory_retriever` updated to await `get_relevant_memories` via fresh-event-loop `_run` helper (matches `test_opus_client` pattern)
- [ ] After merge: pull main into Elliot worktree, restart `agency-os-coo.service`, smoke test Dave → Max DM round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)