### PR TITLE
[ELLIOT] feat(coo): natural language intent classification — no more /post command

### DIFF
--- a/src/coo_bot/dm_handler.py
+++ b/src/coo_bot/dm_handler.py
@@ -1,8 +1,9 @@
 """Max COO bot — DM handler (Dave ↔ Max private channel).
 
 Handles bidirectional DM conversation with Dave:
-- Dave sends message → Max loads context (memories + recent group buffer) → responds via Opus
-- Dave sends /post <text> → Max posts to group via group_writer
+- Dave sends message → intent classifier (Opus) decides relay vs private
+- relay: posts to group via group_writer, confirms in DM
+- private: loads full context + responds via Opus
 - Dave sends STOP MAX → Max drops to relay-only (Tier 0 emergency)
 
 Public API:
@@ -29,7 +30,6 @@ _COO_SYSTEM_PROMPT = (
     "You have access to the full history of agent activity via governance_events "
     "and agent_memories. You watch the group chat in real-time. "
     "Respond concisely and directly. Dave is the CEO — be useful, not verbose. "
-    "If Dave says '/post <text>' relay that text to the group (handled separately). "
     "If Dave asks what's happening, summarise recent group activity. "
     "If Dave asks for your opinion, give it honestly — you are his COO, not a yes-man."
 )
@@ -65,27 +65,38 @@ async def handle_dm(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         logger.info("RESUME MAX triggered by Dave")
         return
 
-    # /post command — relay to group
-    if text.startswith("/post "):
-        group_text = text[6:].strip()
-        if group_text:
-            # Import here to avoid circular — group_writer posts to group
-            try:
-                from src.coo_bot.group_writer import post_to_group
-                ok = await post_to_group(cfg.bot_token, group_text)
-                status = "Posted to group." if ok else "Failed to post."
-                await update.message.reply_text(status)
-            except Exception as exc:
-                await update.message.reply_text(f"Post failed: {exc}")
-        else:
-            await update.message.reply_text("Usage: /post <message to post to group>")
+    # Classify intent: relay to group or private response
+    try:
+        from src.coo_bot.group_handler import get_recent_messages
+        recent_msgs = get_recent_messages(limit=10)
+    except Exception:
+        recent_msgs = []
+    recent_group = "\n".join(
+        f"[{m.get('sender', '?')}] {m.get('text', '')[:100]}" for m in recent_msgs
+    )
+
+    intent = await _classify_intent(text, recent_group)
+
+    if intent.get("intent") == "relay":
+        relay_text = intent.get("relay_text") or text
+        try:
+            from src.coo_bot.group_writer import post_to_group
+            ok = await post_to_group(
+                cfg.bot_token, relay_text, dave_dm_id=update.message.message_id
+            )
+            if ok:
+                await update.message.reply_text(f"Posted to group: {relay_text}")
+            else:
+                await update.message.reply_text("Failed to post to group.")
+        except Exception as exc:
+            await update.message.reply_text(f"Post failed: {exc}")
         return
 
-    # Regular conversation — call Opus with context
+    # Private response — load full context + call Opus
     memory_context = await _load_context()
     user_msg = f"[Recent context]\n{memory_context}\n\n[Dave's message]\n{text}"
 
-    response = await opus_call(_COO_SYSTEM_PROMPT, user_msg, timeout=30)
+    response = await opus_call(_COO_SYSTEM_PROMPT, user_msg, timeout=90)
 
     if response:
         await update.message.reply_text(response)
@@ -93,6 +104,35 @@ async def handle_dm(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(
             "I couldn't generate a response right now. Try again in a moment."
         )
+
+
+async def _classify_intent(text: str, recent_group: str) -> dict:
+    """Classify Dave's DM intent: 'relay' or 'private'.
+
+    Returns: {"intent": "relay"|"private", "relay_text": "..." or None}
+    """
+    import json
+    prompt = (
+        "You are Max's intent classifier. Dave DM'd you this message. "
+        "Based on the message content + recent group context, decide:\n"
+        "- 'relay': Dave wants this posted to the group (e.g. 'tell them X', "
+        "'approve that', 'merge it', direct instructions for agents)\n"
+        "- 'private': Dave wants a response from you in DM (questions, "
+        "'what do you think', 'summarise', opinions)\n\n"
+        "If relay: extract the exact text to post (clean it up for group "
+        "consumption but keep Dave's voice/intent).\n\n"
+        "Respond with ONLY valid JSON: {\"intent\": \"relay\"|\"private\", "
+        "\"relay_text\": \"text to post\" or null}\n\n"
+        f"Recent group context:\n{recent_group}\n\n"
+        f"Dave's DM: {text}"
+    )
+    raw = await opus_call(
+        "You are a JSON-only intent classifier.", prompt, timeout=30
+    )
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        return {"intent": "private", "relay_text": None}
 
 
 async def _load_context() -> str:

--- a/tests/coo_bot/test_dm_handler.py
+++ b/tests/coo_bot/test_dm_handler.py
@@ -49,18 +49,23 @@ def test_resume_max_clears_state():
         assert "Resumed" in update.message.reply_text.call_args[0][0]
 
 
-def test_post_command_calls_group_writer():
-    """'/post hello world' delegates to group_writer."""
+def test_relay_intent_calls_group_writer():
+    """When classifier returns relay intent, post_to_group is called and DM confirms."""
     mock_post = AsyncMock(return_value=True)
-    with patch.dict("sys.modules", {"src.coo_bot.group_writer": MagicMock(post_to_group=mock_post)}):
-        update = _make_update("/post hello world")
-        _run(handle_dm(update, MagicMock()))
+    relay_result = {"intent": "relay", "relay_text": "approve that PR"}
+    with patch("src.coo_bot.dm_handler._classify_intent", new_callable=AsyncMock, return_value=relay_result), \
+         patch("src.coo_bot.dm_handler._load_context", new_callable=AsyncMock, return_value="context"):
+        update = _make_update("tell them to approve that PR")
+        with patch.dict("sys.modules", {"src.coo_bot.group_writer": MagicMock(post_to_group=mock_post)}):
+            _run(handle_dm(update, MagicMock()))
         assert "Posted" in update.message.reply_text.call_args[0][0]
 
 
-def test_regular_text_calls_opus():
-    """Regular DM text calls opus_call and replies."""
-    with patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="Max response") as mock_opus, \
+def test_private_intent_calls_opus():
+    """When classifier returns private intent, opus_call is invoked for response."""
+    private_result = {"intent": "private", "relay_text": None}
+    with patch("src.coo_bot.dm_handler._classify_intent", new_callable=AsyncMock, return_value=private_result), \
+         patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="Max response") as mock_opus, \
          patch("src.coo_bot.dm_handler._load_context", new_callable=AsyncMock, return_value="context"):
         update = _make_update("what's happening?")
         _run(handle_dm(update, MagicMock()))
@@ -70,7 +75,9 @@ def test_regular_text_calls_opus():
 
 def test_opus_failure_shows_fallback():
     """When opus_call returns '', show fallback message."""
-    with patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="") as mock_opus, \
+    private_result = {"intent": "private", "relay_text": None}
+    with patch("src.coo_bot.dm_handler._classify_intent", new_callable=AsyncMock, return_value=private_result), \
+         patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="") as mock_opus, \
          patch("src.coo_bot.dm_handler._load_context", new_callable=AsyncMock, return_value=""):
         update = _make_update("tell me something")
         _run(handle_dm(update, MagicMock()))

--- a/tests/coo_bot/test_intent_classifier.py
+++ b/tests/coo_bot/test_intent_classifier.py
@@ -1,0 +1,85 @@
+"""Tests for _classify_intent in src/coo_bot/dm_handler.py."""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.coo_bot.dm_handler import _classify_intent, handle_dm
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _make_update(text: str, chat_id: int = 7267788033) -> MagicMock:
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.text = text
+    update.message.chat_id = chat_id
+    update.message.message_id = 42
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _classify_intent
+# ---------------------------------------------------------------------------
+
+def test_relay_intent_returned():
+    """When opus returns relay JSON, _classify_intent returns relay intent."""
+    relay_json = json.dumps({"intent": "relay", "relay_text": "approve that PR"})
+    with patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value=relay_json):
+        result = _run(_classify_intent("approve that PR", "recent context"))
+    assert result["intent"] == "relay"
+    assert result["relay_text"] == "approve that PR"
+
+
+def test_private_intent_returned():
+    """When opus returns private JSON, _classify_intent returns private intent."""
+    private_json = json.dumps({"intent": "private", "relay_text": None})
+    with patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value=private_json):
+        result = _run(_classify_intent("what do you think?", ""))
+    assert result["intent"] == "private"
+    assert result["relay_text"] is None
+
+
+def test_parse_failure_defaults_to_private():
+    """When opus returns garbage, _classify_intent defaults to private."""
+    with patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="not valid json"):
+        result = _run(_classify_intent("some message", ""))
+    assert result["intent"] == "private"
+    assert result["relay_text"] is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: handle_dm routes correctly based on intent
+# ---------------------------------------------------------------------------
+
+def test_handle_dm_relay_calls_post_to_group():
+    """handle_dm with relay intent calls post_to_group and confirms in DM."""
+    relay_result = {"intent": "relay", "relay_text": "merge it"}
+    mock_post = AsyncMock(return_value=True)
+    with patch("src.coo_bot.dm_handler._classify_intent", new_callable=AsyncMock, return_value=relay_result), \
+         patch("src.coo_bot.dm_handler._load_context", new_callable=AsyncMock, return_value="ctx"):
+        update = _make_update("tell them to merge it")
+        with patch.dict("sys.modules", {"src.coo_bot.group_writer": MagicMock(post_to_group=mock_post)}):
+            _run(handle_dm(update, MagicMock()))
+    reply_text = update.message.reply_text.call_args[0][0]
+    assert "Posted to group" in reply_text
+    assert "merge it" in reply_text
+
+
+def test_handle_dm_private_calls_opus_response():
+    """handle_dm with private intent calls opus for response, not post_to_group."""
+    private_result = {"intent": "private", "relay_text": None}
+    mock_post = AsyncMock(return_value=True)
+    with patch("src.coo_bot.dm_handler._classify_intent", new_callable=AsyncMock, return_value=private_result), \
+         patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="my opinion") as mock_opus, \
+         patch("src.coo_bot.dm_handler._load_context", new_callable=AsyncMock, return_value="ctx"):
+        update = _make_update("what do you think about the pipeline?")
+        _run(handle_dm(update, MagicMock()))
+    mock_opus.assert_called_once()
+    assert "my opinion" in update.message.reply_text.call_args[0][0]


### PR DESCRIPTION
## Summary
Replaces rigid /post command with Opus-powered intent classification. Max now understands natural DMs:
- "tell them to merge that" → relay to group
- "what do you think?" → private response

## Change
- Removed /post prefix parsing
- Added _classify_intent() — short Opus call (30s) that returns relay|private JSON
- Relay path: posts to group + confirms in DM
- Private path: loads context + generates full response (90s timeout)
- 48 tests pass (5 new + existing adapted)

## Verification
```
$ pytest tests/coo_bot/test_intent_classifier.py -v → 5 passed
$ pytest tests/coo_bot/ -q → 48 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)