### PR TITLE
[AIDEN] fix(coo): bump dm_handler opus_call timeout 30s -> 90s

### DIFF
--- a/src/coo_bot/dm_handler.py
+++ b/src/coo_bot/dm_handler.py
@@ -85,7 +85,7 @@ async def handle_dm(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     memory_context = await _load_context()
     user_msg = f"[Recent context]\n{memory_context}\n\n[Dave's message]\n{text}"
 
-    response = await opus_call(_COO_SYSTEM_PROMPT, user_msg, timeout=30)
+    response = await opus_call(_COO_SYSTEM_PROMPT, user_msg, timeout=90)
 
     if response:
         await update.message.reply_text(response)


### PR DESCRIPTION
## Summary
- PR #510 bumped `opus_client._DEFAULT_TIMEOUT` to 90s but `dm_handler.handle_dm` hardcodes `timeout=30` inline, overriding the default
- Live journal at 23:51:43Z shows `opus_call timed out after 30s` followed by fallback "try again" sent to Dave's DM
- 1-line change: `timeout=30` → `timeout=90`

## Test plan
- [x] `git diff` shows single-line change in dm_handler.py:88
- [ ] Merge + restart agency-os-coo.service
- [ ] Dave DMs Max → real Opus reply within 90s, no fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)