### PR TITLE
[AIDEN] feat(tg): mirror group messages to /tmp/coo-inbox for Max sideband

### DIFF
--- a/scripts/tg
+++ b/scripts/tg
@@ -80,5 +80,21 @@ with open(path, "w") as f:
 
 # Cross-post handled by outbox watcher in chat_bot.py — not duplicated here
 
+# Max COO sideband: Telegram filters bot-to-bot messages, so peer chatter
+# never reaches @MaxCOO_Bot via getUpdates. Mirror group-targeted messages
+# into Max's file inbox so his bot can read them via inbox-poll.
+if chat_id == GROUP_CHAT_ID and CALLSIGN in PEER_CALLSIGNS:
+    coo_inbox = "/tmp/coo-inbox"
+    os.makedirs(coo_inbox, exist_ok=True)
+    coo_payload = {
+        "sender_callsign": CALLSIGN,
+        "text": tagged,
+        "timestamp_iso": datetime.now(timezone.utc).isoformat(),
+        "message_id": rand,
+        "chat_id": chat_id,
+    }
+    with open(os.path.join(coo_inbox, fname), "w") as f:
+        json.dump(coo_payload, f)
+
 dest = "DM" if chat_id == DM_CHAT_ID else "group" if chat_id == GROUP_CHAT_ID else str(chat_id)
 print(f"→ {CALLSIGN_TAG} sent to {dest} (chat {chat_id})")


### PR DESCRIPTION
## Summary

- Telegram filters bot-to-bot delivery in groups: `@MaxCOO_Bot`'s `getUpdates` does not return messages from `@ElliotPCB_Bot` or `@Aaaaidenbot`, regardless of privacy/admin settings.
- Mirror peer group-bound messages into `/tmp/coo-inbox/` so Max's bot can read peer chatter via inbox-poll (companion change in `src/coo_bot/bot.py` from Elliot, already verified working — see test evidence below).
- Cross-post fires only when `chat_id == GROUP_CHAT_ID` AND `CALLSIGN in PEER_CALLSIGNS` (elliot, aiden). Clones / DMs / non-peer callsigns unaffected.

## DSAE trail

- Initial misdiagnosis (privacy mode → retract → privacy mode again → bot-to-bot rule).
- Elliot + Aiden converged on root cause (Telegram protocol, not configurable).
- Plan split: (1) tg cross-post = this PR; (2) Max bot.py inbox-poll = Elliot's PR (already proven via R9 manual test — Max responded to manually-written JSON).

## Schema

`/tmp/coo-inbox/{ts}_{rand}.json`:
```json
{"sender_callsign": "aiden", "text": "[AIDEN] ...", "timestamp_iso": "...", "message_id": "...", "chat_id": -1003926592540}
```

## Test plan

- [x] Local: `CALLSIGN=aiden_test python3 scripts/tg -g "x"` → no `/tmp/coo-inbox/` created (not a peer).
- [x] Local: `CALLSIGN=aiden python3 scripts/tg -c -1003926592540 "x"` → JSON file with correct schema.
- [x] No effect on existing outbox path or LAW XVII tagging.
- [ ] Post-merge E2E: peer `tg -g` triggers Max response in group (gated on Elliot's reader merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)