### PR TITLE
[AIDEN] perf(coo): apply Haiku/Opus tiering to dm_handler

### DIFF
--- a/src/coo_bot/dm_handler.py
+++ b/src/coo_bot/dm_handler.py
@@ -92,11 +92,28 @@ async def handle_dm(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             await update.message.reply_text(f"Post failed: {exc}")
         return
 
-    # Private response — load full context + call Opus
+    # Private response — Haiku tier for routine, Opus only for deep/tools.
+    # Mirrors group_handler latency strategy (commit 6823670e).
     memory_context = await _load_context()
     user_msg = f"[Recent context]\n{memory_context}\n\n[Dave's message]\n{text}"
 
-    response = await opus_call(_COO_SYSTEM_PROMPT, user_msg, timeout=90)
+    lowered = text.lower()
+    needs_tools = any(kw in lowered for kw in [
+        "read", "file", "check", "look at", "query", "show me",
+        "what's in", "cat ", "grep", "find", "database", "supabase",
+        "store", "manual", "claude.md", "architecture",
+    ])
+    needs_deep = needs_tools or any(kw in lowered for kw in [
+        "why", "diagnose", "explain", "analyse", "opinion", "think",
+        "strategy", "plan", "recommend",
+    ])
+    model = "claude-opus-4-6" if needs_deep else "claude-haiku-4-5"
+    timeout = 120 if needs_tools else (90 if needs_deep else 20)
+
+    response = await opus_call(
+        _COO_SYSTEM_PROMPT, user_msg,
+        timeout=timeout, model=model, with_tools=needs_tools,
+    )
 
     if response:
         await update.message.reply_text(response)

--- a/tests/coo_bot/test_dm_handler.py
+++ b/tests/coo_bot/test_dm_handler.py
@@ -84,6 +84,48 @@ def test_opus_failure_shows_fallback():
         assert "couldn't generate" in update.message.reply_text.call_args[0][0]
 
 
+def test_routine_dm_uses_haiku_short_timeout():
+    """Routine 'what's up?' DM routes to Haiku with 20s timeout (no deep/tools keywords)."""
+    private_result = {"intent": "private", "relay_text": None}
+    with patch("src.coo_bot.dm_handler._classify_intent", new_callable=AsyncMock, return_value=private_result), \
+         patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="ok") as mock_opus, \
+         patch("src.coo_bot.dm_handler._load_context", new_callable=AsyncMock, return_value=""):
+        update = _make_update("hey max status update")
+        _run(handle_dm(update, MagicMock()))
+        kwargs = mock_opus.call_args.kwargs
+        assert kwargs["model"] == "claude-haiku-4-5"
+        assert kwargs["timeout"] == 20
+        assert kwargs["with_tools"] is False
+
+
+def test_deep_dm_routes_to_opus():
+    """DM with deep keywords ('why', 'explain') routes to Opus, longer timeout."""
+    private_result = {"intent": "private", "relay_text": None}
+    with patch("src.coo_bot.dm_handler._classify_intent", new_callable=AsyncMock, return_value=private_result), \
+         patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="ok") as mock_opus, \
+         patch("src.coo_bot.dm_handler._load_context", new_callable=AsyncMock, return_value=""):
+        update = _make_update("why is the pipeline stalled, explain")
+        _run(handle_dm(update, MagicMock()))
+        kwargs = mock_opus.call_args.kwargs
+        assert kwargs["model"] == "claude-opus-4-6"
+        assert kwargs["timeout"] == 90
+        assert kwargs["with_tools"] is False
+
+
+def test_tools_dm_routes_to_opus_with_tools():
+    """DM with tools keywords ('check the file', 'query database') gets tool access + 120s timeout."""
+    private_result = {"intent": "private", "relay_text": None}
+    with patch("src.coo_bot.dm_handler._classify_intent", new_callable=AsyncMock, return_value=private_result), \
+         patch("src.coo_bot.dm_handler.opus_call", new_callable=AsyncMock, return_value="ok") as mock_opus, \
+         patch("src.coo_bot.dm_handler._load_context", new_callable=AsyncMock, return_value=""):
+        update = _make_update("check the manual for the deploy section")
+        _run(handle_dm(update, MagicMock()))
+        kwargs = mock_opus.call_args.kwargs
+        assert kwargs["model"] == "claude-opus-4-6"
+        assert kwargs["timeout"] == 120
+        assert kwargs["with_tools"] is True
+
+
 def test_write_stop_state_creates_file(tmp_path):
     """_write_stop_state(True) creates the state file."""
     state_file = tmp_path / "max-coo-stopped"


### PR DESCRIPTION
## Summary

Mirror group_handler latency strategy (commit 6823670e) on the DM path. Routine DMs to Max now route to Haiku (20s) instead of Opus (90s default). Deep/analytical keywords escalate to Opus. Tool keywords get read-only tool access with 120s.

Companion to the group-side fix — both directions of Max comms now tiered.

## Routing

| Trigger | Model | Timeout | Tools |
|---------|-------|---------|-------|
| `read`/`check`/`file`/`query`/`grep`/`database`/... | Opus | 120s | Yes |
| `why`/`explain`/`diagnose`/`strategy`/... | Opus | 90s | No |
| Everything else | Haiku | 20s | No |

## Tests

- 3 new (routine→Haiku, deep→Opus, tools→Opus+tools)
- 11/11 pass — no regression on existing 8 tests

## Expected impact

Dave's routine DMs to Max: 60-120s → 5-8s.

## Governance trail

[PROPOSE:aiden] approved by Dave ("Merge and continue"). Step 0 RESTATE posted. Built in parallel with Elliot's PR #511 merge — non-overlapping files. Awaiting [CONCUR:ELLIOT] before merge per dual-approval rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)