### PR TITLE
[AIDEN] fix(relay): asyncio.wait_for timeout on outbox send

### DIFF
--- a/src/telegram_bot/chat_bot.py
+++ b/src/telegram_bot/chat_bot.py
@@ -106,6 +106,7 @@ running_processes: dict[int, asyncio.subprocess.Process] = {}
 RELAY_DIR = f"/tmp/telegram-relay-{CALLSIGN}"  # per-callsign isolation (LAW XVII)
 INBOX_DIR = f"{RELAY_DIR}/inbox"    # messages FROM Telegram TO tmux session
 OUTBOX_DIR = f"{RELAY_DIR}/outbox"  # messages FROM tmux session TO Telegram
+RELAY_SEND_TIMEOUT = 30  # seconds — guards against silent Telegram API stalls
 
 os.makedirs(INBOX_DIR, exist_ok=True)
 os.makedirs(OUTBOX_DIR, exist_ok=True)
@@ -1066,22 +1067,31 @@ async def _outbox_watcher(app: Application) -> None:
                             with open(tmp, "w") as tf:
                                 tf.write(text)
                             with open(tmp, "rb") as tf:
-                                await bot.send_document(chat_id=chat_id, document=tf, filename="message.md")
+                                await asyncio.wait_for(
+                                    bot.send_document(chat_id=chat_id, document=tf, filename="message.md"),
+                                    timeout=RELAY_SEND_TIMEOUT,
+                                )
                             os.unlink(tmp)
                         else:
                             for chunk in chunk_response(text):
-                                await bot.send_message(chat_id=chat_id, text=chunk)
+                                await asyncio.wait_for(
+                                    bot.send_message(chat_id=chat_id, text=chunk),
+                                    timeout=RELAY_SEND_TIMEOUT,
+                                )
 
                     elif msg.get("type") == "file":
                         file_path = msg.get("file_path", "")
                         caption = msg.get("caption", "")
                         if os.path.exists(file_path):
                             with open(file_path, "rb") as fh:
-                                await bot.send_document(
-                                    chat_id=chat_id,
-                                    document=fh,
-                                    filename=os.path.basename(file_path),
-                                    caption=caption[:1024] if caption else None,
+                                await asyncio.wait_for(
+                                    bot.send_document(
+                                        chat_id=chat_id,
+                                        document=fh,
+                                        filename=os.path.basename(file_path),
+                                        caption=caption[:1024] if caption else None,
+                                    ),
+                                    timeout=RELAY_SEND_TIMEOUT,
                                 )
 
                     os.unlink(fpath)


### PR DESCRIPTION
## Summary
- Wraps `bot.send_message` / `bot.send_document` calls in the outbox watcher (`src/telegram_bot/chat_bot.py::_outbox_watcher`) with `asyncio.wait_for(..., timeout=30s)`.
- Prevents the silent 1+ hour relay gap observed today (root-caused as a transient asyncio stall in the Telegram Bot API call).
- On timeout, the existing `except Exception` clause logs the error and moves the stuck file to `${RELAY_DIR}/errors/`, so the watcher loop continues instead of hanging.

## Approval
- [PROPOSE:ELLIOT] approved by Dave (TG group, 2026-05-02). Ranked 1 of 2.
- Dual approval required: Elliot to peer-review.

## Test plan
- [ ] Elliot peer review (10-line scope).
- [ ] Sanity: restart `aiden-chat-bot` service after merge; confirm outbox traffic still flows.
- [ ] Negative path: simulate stall by patching `bot.send_message` to `asyncio.sleep(60)` in a one-off test — confirm timeout fires at 30s and file lands in `errors/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)