### PR TITLE
[AIDEN] feat(listener): gate memory auto-injection behind LISTENER_AUTO_INJECT flag

### DIFF
--- a/src/telegram_bot/chat_bot.py
+++ b/src/telegram_bot/chat_bot.py
@@ -751,7 +751,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     # that causes "group" to match every group-chat commit)
     raw_text = update.message.text or ""
     memory_context = ""
-    if sender != Sender.SELF:
+    # LISTENER_AUTO_INJECT gates push-style injection. Default OFF — agents pull via MCP memory tool when needed.
+    if sender != Sender.SELF and os.getenv("LISTENER_AUTO_INJECT", "0") == "1":
         try:
             memories = await find_relevant_memories(raw_text)
             commits = await find_matching_commits(raw_text)
@@ -1105,15 +1106,16 @@ async def _outbox_watcher(app: Application) -> None:
                         peer_ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
                         peer_fname = f"{peer_ts}_{uuid.uuid4().hex[:8]}.json"
 
-                        # Enrich with memory context for the peer
+                        # Enrich with memory context for the peer (gated by LISTENER_AUTO_INJECT — default OFF).
                         outgoing_text = msg.get("text", "")
-                        try:
-                            peer_memories = await find_relevant_memories(outgoing_text)
-                            if peer_memories:
-                                mem_block = format_memory_context(peer_memories)
-                                outgoing_text = f"{mem_block}\n\n{outgoing_text}"
-                        except Exception:
-                            pass  # best-effort — cross-post still works without enrichment
+                        if os.getenv("LISTENER_AUTO_INJECT", "0") == "1":
+                            try:
+                                peer_memories = await find_relevant_memories(outgoing_text)
+                                if peer_memories:
+                                    mem_block = format_memory_context(peer_memories)
+                                    outgoing_text = f"{mem_block}\n\n{outgoing_text}"
+                            except Exception:
+                                pass  # best-effort — cross-post still works without enrichment
 
                         peer_payload = {
                             "id": peer_fname.replace(".json", ""),


### PR DESCRIPTION
## Summary
- Gates the auto-injection of `[MEMORY BRIEF]` / `[GIT CONTEXT]` / `[REPO CONTEXT]` blocks behind `LISTENER_AUTO_INJECT` env flag (default `0` = OFF).
- Two call sites gated, same flag:
  1. **Inbound listener** in `handle_message` (`src/telegram_bot/chat_bot.py` line ~754) — direct Telegram messages.
  2. **Cross-post enrichment** in `_outbox_watcher` (line ~1109) — outbound messages cross-posted to peer-bot inboxes (which arrive as noise on the receive side).
- Listener push → MCP memory pull. Agents call `recall_memory(query)` when they need context, instead of context being sprayed into every prompt.

## Why
Dave flagged: "I see a lot of noise in your prompt when goes through to your tmux. Most of it looks irrelevant to the context of the topic." Auto-injection on every message inflates each prompt by 500-1000 chars of mostly stale context. Useful ~10% of the time, noise ~90%.

## Approvals
- [PROPOSE:ELLIOT] / Max approved parallel build of Change 1 + Change 2.
- This PR = Change 2.
- Elliot building Change 1 (Stop hook auto-relay) in parallel.
- Dual-concur required before merge: Elliot peer-review + Max approval.

## Verification
- After deploy + service restart on `elliot-chat-bot`/`aiden-chat-bot`/`max-chat-bot`, send a `[TG-DAVE]` test message. Capture inbox JSON. Confirm `text` field has NO memory-context wrapping.
- Setting `LISTENER_AUTO_INJECT=1` in any worktree's `.env` restores old behavior — regression escape hatch.
- Existing memory writes (`auto_capture_message`, `daily_log`, `agent_memories`, `ceo_memory`) untouched. Pull-side via MCP unchanged.

## Test plan
- [ ] Elliot peer review.
- [ ] Max approval (Dave's proxy).
- [ ] Deploy verify: restart chat-bot services, send Dave message, confirm zero memory preamble in inbox JSON.
- [ ] Regression test: set `LISTENER_AUTO_INJECT=1` in test env, send message, confirm preamble returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)