### PR TITLE
[AIDEN] fix(settings): merge duplicate "Stop" hook keys (Change 1 was non-functional)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,18 +53,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "/home/elliotbot/clawd/venv/bin/python3 scripts/governance_router.py",
-            "timeout": 10
-          }
-        ]
-      }
     ]
   },
   "mcpServers": {


### PR DESCRIPTION
## Summary
- `.claude/settings.json` had two top-level `"Stop"` keys at the same JSON level (lines 6 and 57). JSON parsers silently take the LAST occurrence on duplicate keys.
- Result: `stop_relay_hook.sh` entry in the first "Stop" block was being discarded by Claude Code on load.
- **Change 1 (PR #515 / commit ce865169 / hotfix #517) has been NON-FUNCTIONAL** in both Elliot's and Aiden's environments since landing. Auto-relay never fired. Manual `tg -g` calls have been carrying every outbound this entire session.
- Max's worktree has a clean settings.json (single "Stop" key) — it's the only environment where the hook is properly wired.

## Evidence (raw)
```
$ git show origin/main:.claude/settings.json | grep -n '"Stop"'
6:    "Stop": [           ← contains stop_relay_hook (line 17)
57:    "Stop": [          ← contains only governance_router — WINS via parser

$ git show origin/main:.claude/settings.json | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)['hooks']['Stop'], indent=2))"
[ governance_router ONLY — stop_relay_hook entry from line 17 was discarded ]
```

## Fix
- Removed the duplicate `"Stop"` block (lines 57-68 — `governance_router` only, already present in the first block).
- Single remaining `"Stop"` key now correctly invokes BOTH `governance_router` AND `stop_relay_hook` under one matcher.

## Verification
```
$ python3 -c "import json; json.load(open('.claude/settings.json'))" → VALID
$ python3 -c "...['hooks']['Stop'][0]['hooks']" →
  {governance_router}, {stop_relay_hook}
$ grep -c '"Stop"' .claude/settings.json → 1 (single key)
```

## Approvals
- Elliot acknowledged authoring the duplicate and yielded the fix to Aiden.
- Dual-concur required before merge: Elliot peer-review + Max approval.

## Why this matters
Every session this hour where we thought "auto-relay is now mechanical" was wrong. The bug Dave called out hours ago ("relay keeps breaking") is half-fixed by Change 2 (memory noise gone) but Change 1's mechanical-enforcement promise was illusory. With this fix, the hook actually fires and `tg -g` becomes runtime-guaranteed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)