### PR TITLE
[AIDEN] chat_bot: multi-peer _PEER_MAP — Max receives from both agents

### DIFF
--- a/src/telegram_bot/chat_bot.py
+++ b/src/telegram_bot/chat_bot.py
@@ -88,10 +88,18 @@ KNOWN_PEER_BOTS: set[str] = {
 }  # lowercase
 DAVE_USER_ID: int = 7267788033  # hardcoded CEO user_id — only this human gets Sender.DAVE
 # Peer cross-post: bot-to-bot visibility bypass (Telegram doesn't deliver bot-to-bot)
-_PEER_MAP = {"elliot": "aiden", "aiden": "elliot", "scout": "elliot"}
-PEER_INBOX: str | None = (
-    f"/tmp/telegram-relay-{_PEER_MAP[CALLSIGN]}/inbox" if CALLSIGN in _PEER_MAP else None
-)
+_PEER_MAP: dict[str, list[str]] = {
+    "elliot": ["aiden", "max"],
+    "aiden": ["elliot", "max"],
+    "scout": ["elliot"],
+    "max": [],  # Max receives but doesn't cross-post
+}
+PEER_INBOXES: list[str] = [
+    f"/tmp/telegram-relay-{p}/inbox" for p in _PEER_MAP.get(CALLSIGN, [])
+]
+# Backward-compat shim — callers that still reference PEER_INBOX get the first peer.
+# Migrate callers to iterate PEER_INBOXES directly.
+PEER_INBOX: str | None = PEER_INBOXES[0] if PEER_INBOXES else None
 ENFORCER_INBOX = "/tmp/telegram-relay-enforcer/inbox"
 GROUP_CHAT_ID = -1003926592540
 
@@ -1198,13 +1206,11 @@ async def _outbox_watcher(app: Application) -> None:
                     os.unlink(fpath)
                     logger.info(f"[relay] outbox sent: {fname}")
 
-                    # Cross-post group messages to peer bot's inbox (Telegram bot-to-bot blind spot)
+                    # Cross-post group messages to all peer bot inboxes (Telegram bot-to-bot blind spot)
                     # Sender-side listener hook: enrich cross-post with memory context
                     # so the receiving peer gets context they'd miss (their listener doesn't fire on cross-posts)
-                    if chat_id == GROUP_CHAT_ID and PEER_INBOX and msg.get("type") == "text":
-                        os.makedirs(PEER_INBOX, exist_ok=True)
+                    if chat_id == GROUP_CHAT_ID and PEER_INBOXES and msg.get("type") == "text":
                         peer_ts = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
-                        peer_fname = f"{peer_ts}_{uuid.uuid4().hex[:8]}.json"
 
                         # Enrich with memory context for the peer (gated by LISTENER_AUTO_INJECT — default OFF).
                         outgoing_text = msg.get("text", "")
@@ -1217,17 +1223,20 @@ async def _outbox_watcher(app: Application) -> None:
                             except Exception:
                                 pass  # best-effort — cross-post still works without enrichment
 
-                        peer_payload = {
-                            "id": peer_fname.replace(".json", ""),
-                            "type": "text",
-                            "chat_id": chat_id,
-                            "text": f"[GROUP — from {CALLSIGN.upper()} (peer bot, NOT your boss Dave)]: {outgoing_text}",
-                            "sender": "peer",
-                            "timestamp": datetime.now(UTC).isoformat(),
-                        }
-                        with open(os.path.join(PEER_INBOX, peer_fname), "w") as pf:
-                            _json.dump(peer_payload, pf)
-                        logger.info(f"[relay] cross-posted to peer inbox: {peer_fname}")
+                        for peer_inbox in PEER_INBOXES:
+                            os.makedirs(peer_inbox, exist_ok=True)
+                            peer_fname = f"{peer_ts}_{uuid.uuid4().hex[:8]}.json"
+                            peer_payload = {
+                                "id": peer_fname.replace(".json", ""),
+                                "type": "text",
+                                "chat_id": chat_id,
+                                "text": f"[GROUP — from {CALLSIGN.upper()} (peer bot, NOT your boss Dave)]: {outgoing_text}",
+                                "sender": "peer",
+                                "timestamp": datetime.now(UTC).isoformat(),
+                            }
+                            with open(os.path.join(peer_inbox, peer_fname), "w") as pf:
+                                _json.dump(peer_payload, pf)
+                            logger.info(f"[relay] cross-posted to peer inbox: {peer_inbox}/{peer_fname}")
 
                     # Cross-post to enforcer inbox (governance enforcement daemon)
                     if chat_id == GROUP_CHAT_ID and msg.get("type") == "text":

--- a/tests/test_chat_bot_peer_map.py
+++ b/tests/test_chat_bot_peer_map.py
@@ -1,0 +1,65 @@
+"""Unit tests for _PEER_MAP multi-peer shape and PEER_INBOXES derivation.
+
+Tests cover: elliot, aiden, max, and unknown callsign perspectives.
+Uses importlib.reload after monkeypatching os.environ["CALLSIGN"] so each
+test sees the module-level constants recalculated for the target callsign.
+"""
+
+import importlib
+import os
+
+import pytest
+
+
+def _reload_with_callsign(monkeypatch, callsign: str):
+    """Set CALLSIGN env var and reload chat_bot, returning the fresh module."""
+    monkeypatch.setenv("CALLSIGN", callsign)
+    import src.telegram_bot.chat_bot as mod
+
+    importlib.reload(mod)
+    return mod
+
+
+def test_elliot_peer_inboxes(monkeypatch):
+    mod = _reload_with_callsign(monkeypatch, "elliot")
+    assert mod.PEER_INBOXES == [
+        "/tmp/telegram-relay-aiden/inbox",
+        "/tmp/telegram-relay-max/inbox",
+    ]
+
+
+def test_aiden_peer_inboxes(monkeypatch):
+    mod = _reload_with_callsign(monkeypatch, "aiden")
+    assert mod.PEER_INBOXES == [
+        "/tmp/telegram-relay-elliot/inbox",
+        "/tmp/telegram-relay-max/inbox",
+    ]
+
+
+def test_max_peer_inboxes_empty(monkeypatch):
+    """Max receives cross-posts but does not cross-post to others."""
+    mod = _reload_with_callsign(monkeypatch, "max")
+    assert mod.PEER_INBOXES == []
+    assert mod.PEER_INBOX is None
+
+
+def test_unknown_callsign_peer_inboxes_empty(monkeypatch):
+    """Undefined callsign must return empty list — no KeyError."""
+    mod = _reload_with_callsign(monkeypatch, "unknown_agent_xyz")
+    assert mod.PEER_INBOXES == []
+    assert mod.PEER_INBOX is None
+
+
+def test_backward_compat_shim_elliot(monkeypatch):
+    """PEER_INBOX shim points to first peer for callsigns that have peers."""
+    mod = _reload_with_callsign(monkeypatch, "elliot")
+    assert mod.PEER_INBOX == "/tmp/telegram-relay-aiden/inbox"
+
+
+def test_peer_map_shape(monkeypatch):
+    """_PEER_MAP values must all be lists, not strings."""
+    mod = _reload_with_callsign(monkeypatch, "elliot")
+    for callsign, peers in mod._PEER_MAP.items():
+        assert isinstance(peers, list), (
+            f"_PEER_MAP[{callsign!r}] is {type(peers).__name__}, expected list"
+        )


### PR DESCRIPTION
## Summary

Per MAX directive 2026-05-02 — *"Add Max to the peer cross-post map in chat_bot.py (_PEER_MAP) so Max receives group messages from both agents."*

The current `_PEER_MAP` is `dict[str, str]` (single peer per callsign), which can't satisfy the stated goal — there's no way to make Max receive from BOTH Elliot AND Aiden with a 1:1 map. Reshaped to `dict[str, list[str]]`.

## Changes

`src/telegram_bot/chat_bot.py`:
```python
_PEER_MAP: dict[str, list[str]] = {
    "elliot": ["aiden", "max"],
    "aiden":  ["elliot", "max"],
    "scout":  ["elliot"],
    "max":    [],          # receives but doesn't cross-post
}
PEER_INBOXES: list[str] = [
    f"/tmp/telegram-relay-{p}/inbox" for p in _PEER_MAP.get(CALLSIGN, [])
]
PEER_INBOX: str | None = PEER_INBOXES[0] if PEER_INBOXES else None  # backward-compat shim
```

Cross-post site (~L1212) now iterates `PEER_INBOXES`, writing a fresh filename per inbox with a shared timestamp for ordering determinism.

## Tests (6 new in `tests/test_chat_bot_peer_map.py`)

- `test_elliot_peer_inboxes` — `['/tmp/telegram-relay-aiden/inbox', '/tmp/telegram-relay-max/inbox']`
- `test_aiden_peer_inboxes` — `['/tmp/telegram-relay-elliot/inbox', '/tmp/telegram-relay-max/inbox']`
- `test_max_peer_inboxes_empty` — `[]`
- `test_unknown_callsign_peer_inboxes_empty` — `[]` (no KeyError)
- `test_backward_compat_shim_elliot` — `PEER_INBOX` shim points to first peer
- `test_peer_map_shape` — confirms `dict[str, list[str]]`

```
$ pytest tests/test_chat_bot_peer_map.py -v
6 passed
```

## Worktree drift note

`Agency_OS` / `Agency_OS-aiden` / `Agency_OS-orion` have divergent `chat_bot.py` copies (different MD5s as of 2026-05-02). This PR updates `Agency_OS-aiden`'s checkout. Other worktrees pick up via `git merge main` on next sync. If MAX wants forced parity across all 3 worktrees in this session, that's a separate operation — let me know.

## Backward compatibility

- `PEER_INBOX` (str|None) retained as alias for first peer — any existing caller still works.
- Callers should migrate to iterating `PEER_INBOXES`. Migration not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)