### PR TITLE
[AIDEN] verify_pr.sh: review-state check via latestReviews (Option A)

### DIFF
--- a/scripts/verify_pr.sh
+++ b/scripts/verify_pr.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 # Usage: verify_pr.sh <pr_number>
 # Outputs JSON: {"pr": <num>, "state": "...", "merged": bool, "merge_sha": "...",
-#                "ci_passing": bool, "failed_checks": [...], "pending_checks": [...]}
+#                "ci_passing": bool, "failed_checks": [...], "pending_checks": [...],
+#                "review_state": "APPROVED|CHANGES_REQUESTED|REVIEW_REQUIRED|unknown",
+#                "latest_reviews": [{"author": "...", "state": "..."}]}
 # Exit 0 on successful query, 2 on PR not found, 1 on gh error.
+#
+# review_state logic (uses GitHub's per-reviewer latest review — already de-duplicated):
+#   - Any CHANGES_REQUESTED among latest reviews → "CHANGES_REQUESTED"
+#   - At least one APPROVED and no CHANGES_REQUESTED → "APPROVED"
+#   - latestReviews empty or all COMMENTED → "REVIEW_REQUIRED"
+#   - gh fetch error → "unknown" (never silently defaults to APPROVED — anti-ghost-green)
 #
 # Gating checks (failures block merge): Backend Tests, MyPy, Frontend Checks, Dead Reference Guard
 # Non-blocking (pre-existing): Ruff/Backend Lint, SonarCloud, Vercel deployments — these are
@@ -60,6 +68,7 @@ if [[ $CHECKS_EXIT -ne 0 ]] && ! echo "$CHECKS_OUTPUT" | grep -q $'\t'; then
         --arg detail "$(echo "$CHECKS_OUTPUT" | head -c 200)" \
         '{pr: $pr, state: $state, merged: $merged, merge_sha: $merge_sha,
           ci_passing: null, ci_status: "unknown", failed_checks: [], pending_checks: [],
+          review_state: "unknown", latest_reviews: [],
           detail: $detail}'
     exit 1
 fi
@@ -93,6 +102,38 @@ else
     CI_PASSING=false
 fi
 
+# --- Fetch review state ---
+# Uses GitHub's latestReviews (per-reviewer latest — already de-duplicated by GitHub).
+# On error: review_state="unknown" — never silently defaults to APPROVED (anti-ghost-green).
+REVIEW_JSON=$(gh pr view "$PR_NUM" --json reviewDecision,latestReviews 2>&1)
+REVIEW_EXIT=$?
+
+if [[ $REVIEW_EXIT -ne 0 ]]; then
+    REVIEW_STATE="unknown"
+    LATEST_REVIEWS="[]"
+else
+    # Build latest_reviews array: [{"author": "login", "state": "APPROVED|..."}]
+    LATEST_REVIEWS=$(echo "$REVIEW_JSON" | jq '[
+        .latestReviews[]
+        | {"author": .author.login, "state": .state}
+    ]')
+
+    # Derive review_state from the latest review per reviewer
+    HAS_CHANGES=$(echo "$LATEST_REVIEWS" | jq 'map(select(.state == "CHANGES_REQUESTED")) | length > 0')
+    HAS_APPROVED=$(echo "$LATEST_REVIEWS" | jq 'map(select(.state == "APPROVED")) | length > 0')
+    REVIEWS_EMPTY=$(echo "$LATEST_REVIEWS" | jq 'length == 0')
+
+    if [[ "$REVIEWS_EMPTY" == "true" ]]; then
+        REVIEW_STATE="REVIEW_REQUIRED"
+    elif [[ "$HAS_CHANGES" == "true" ]]; then
+        REVIEW_STATE="CHANGES_REQUESTED"
+    elif [[ "$HAS_APPROVED" == "true" ]]; then
+        REVIEW_STATE="APPROVED"
+    else
+        REVIEW_STATE="REVIEW_REQUIRED"
+    fi
+fi
+
 # --- Compose output ---
 jq -n \
     --argjson pr "$PR_NUM" \
@@ -102,5 +143,8 @@ jq -n \
     --argjson ci_passing "$CI_PASSING" \
     --argjson failed_checks "$FAILED_CHECKS" \
     --argjson pending_checks "$PENDING_CHECKS" \
+    --arg review_state "$REVIEW_STATE" \
+    --argjson latest_reviews "$LATEST_REVIEWS" \
     '{pr: $pr, state: $state, merged: $merged, merge_sha: $merge_sha,
-      ci_passing: $ci_passing, failed_checks: $failed_checks, pending_checks: $pending_checks}'
+      ci_passing: $ci_passing, failed_checks: $failed_checks, pending_checks: $pending_checks,
+      review_state: $review_state, latest_reviews: $latest_reviews}'

--- a/scripts/verify_pr.sh
+++ b/scripts/verify_pr.sh
@@ -23,6 +23,10 @@ if [[ -z "$PR_NUM" ]]; then
     echo '{"error": "usage: verify_pr.sh <pr_number>"}' >&2
     exit 1
 fi
+if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+    echo '{"error": "PR number must be numeric"}' >&2
+    exit 1
+fi
 
 # --- Fetch PR state ---
 PR_JSON=$(gh pr view "$PR_NUM" --json state,mergedAt,mergeCommit 2>&1)

--- a/src/telegram_bot/enforcer_bot.py
+++ b/src/telegram_bot/enforcer_bot.py
@@ -198,9 +198,10 @@ BOT_INBOXES = [
 # Regex to detect PR number adjacent to a positive-claim keyword (either order).
 # Liberal on purpose — false positives are cheap (verification is mechanical and fast).
 # Matches both "#521 merged" and "521 passed" (bare number) and reverse-order "merged #521".
+# "approved" / "approved by both" included so review-state claims trigger mechanical check.
 PR_CLAIM_RE = re.compile(
-    r"#?(\d+).{0,80}?(merged|approved|complete|passed?|green|all\s+tests|ci\s+pass|ship)"
-    r"|(merged|approved|complete|passed?|green|all\s+tests|ci\s+pass).{0,80}?#?(\d+)",
+    r"#?(\d+).{0,80}?(merged|approved(?:\s+by\s+both)?|complete|passed?|green|all\s+tests|ci\s+pass|ship)"
+    r"|(merged|approved(?:\s+by\s+both)?|complete|passed?|green|all\s+tests|ci\s+pass).{0,80}?#?(\d+)",
     re.IGNORECASE,
 )
 
@@ -495,7 +496,7 @@ async def watch_max_outbox() -> None:
                         logger.warning("verify_pr.sh error for PR #%d: %s", pr_num, exc)
                         continue
 
-                    # Mechanical comparison — "approved" skipped (requires LLM semantics)
+                    # Mechanical comparison against verify_pr.sh output.
                     mismatch_reason = None
 
                     if claim_kw in ("merged", "complete", "ship") and not verify.get("merged"):
@@ -510,6 +511,12 @@ async def watch_max_outbox() -> None:
                         "ci pass",
                     ) and not verify.get("ci_passing"):
                         mismatch_reason = f"claimed '{claim_kw}' but ci_passing=false"
+                    elif re.match(r"approved", claim_kw, re.IGNORECASE):
+                        review_state = verify.get("review_state", "unknown")
+                        if review_state != "APPROVED":
+                            mismatch_reason = (
+                                f"claimed '{claim_kw}' but review_state={review_state}"
+                            )
 
                     if mismatch_reason:
                         failed = verify.get("failed_checks", [])
@@ -517,7 +524,8 @@ async def watch_max_outbox() -> None:
                         interjection = (
                             f"[ENFORCER] Rule 3 — COMPLETION-REQUIRES-VERIFICATION:\n"
                             f"MAX claimed PR #{pr_num} {mismatch_reason}. "
-                            f"state={verify.get('state')} ci_passing={verify.get('ci_passing')}. "
+                            f"state={verify.get('state')} ci_passing={verify.get('ci_passing')} "
+                            f"review_state={verify.get('review_state')}. "
                             f"Failed checks: {failed}. "
                             f"Source: {source_excerpt}"
                         )

--- a/tests/test_enforcer_max_outbox.py
+++ b/tests/test_enforcer_max_outbox.py
@@ -71,7 +71,9 @@ def _make_outbox_file(tmp_path, text: str) -> None:
 
 
 def _verify_json(merged: bool, ci_passing: bool, state: str = "MERGED",
-                 failed_checks: list | None = None) -> str:
+                 failed_checks: list | None = None,
+                 review_state: str = "APPROVED",
+                 latest_reviews: list | None = None) -> str:
     """Return JSON string as verify_pr.sh would output."""
     return json.dumps({
         "pr": 521,
@@ -81,6 +83,8 @@ def _verify_json(merged: bool, ci_passing: bool, state: str = "MERGED",
         "ci_passing": ci_passing,
         "failed_checks": failed_checks or [],
         "pending_checks": [],
+        "review_state": review_state,
+        "latest_reviews": latest_reviews if latest_reviews is not None else [],
     })
 
 
@@ -209,3 +213,94 @@ async def test_verify_pr_ci_unknown_no_ghost_green(tmp_path):
 def test_max_inbox_in_bot_inboxes():
     """MAX inbox must be present in BOT_INBOXES so interjections reach MAX."""
     assert "/tmp/telegram-relay-max/inbox" in BOT_INBOXES
+
+
+# ---------------------------------------------------------------------------
+# Review-state tests (verify_pr.sh review_state field)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_verify_pr_review_state_approved(tmp_path):
+    """review_state=APPROVED + claim says 'approved' → no interjection."""
+    _make_outbox_file(tmp_path, "PR #521 approved by both reviewers")
+
+    proc_mock = _async_proc_mock(_verify_json(
+        merged=True, ci_passing=True,
+        review_state="APPROVED",
+        latest_reviews=[
+            {"author": "elliotbot", "state": "APPROVED"},
+            {"author": "aidenbot", "state": "APPROVED"},
+        ],
+    ))
+
+    with patch("src.telegram_bot.enforcer_bot.MAX_OUTBOX", str(tmp_path)), \
+         patch("asyncio.create_subprocess_exec", proc_mock), \
+         patch("src.telegram_bot.enforcer_bot.send_interjection",
+               new_callable=AsyncMock) as mock_interject:
+
+        task = asyncio.create_task(watch_max_outbox())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        mock_interject.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_verify_pr_review_state_changes_requested(tmp_path):
+    """review_state=CHANGES_REQUESTED + claim says 'approved' → interjection fired."""
+    _make_outbox_file(tmp_path, "PR #521 approved")
+
+    proc_mock = _async_proc_mock(_verify_json(
+        merged=False, ci_passing=True, state="OPEN",
+        review_state="CHANGES_REQUESTED",
+        latest_reviews=[
+            {"author": "elliotbot", "state": "CHANGES_REQUESTED"},
+        ],
+    ))
+
+    with patch("src.telegram_bot.enforcer_bot.MAX_OUTBOX", str(tmp_path)), \
+         patch("asyncio.create_subprocess_exec", proc_mock), \
+         patch("src.telegram_bot.enforcer_bot.send_interjection",
+               new_callable=AsyncMock) as mock_interject:
+
+        task = asyncio.create_task(watch_max_outbox())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        mock_interject.assert_called_once()
+        call_text = mock_interject.call_args[0][0]
+        assert "CHANGES_REQUESTED" in call_text or "COMPLETION-REQUIRES-VERIFICATION" in call_text
+
+
+@pytest.mark.asyncio
+async def test_verify_pr_review_state_unknown(tmp_path):
+    """review_state=unknown + claim says 'approved' → must NOT ghost-green (interjection fired)."""
+    _make_outbox_file(tmp_path, "PR #521 approved")
+
+    proc_mock = _async_proc_mock(_verify_json(
+        merged=True, ci_passing=True,
+        review_state="unknown",
+        latest_reviews=[],
+    ))
+
+    with patch("src.telegram_bot.enforcer_bot.MAX_OUTBOX", str(tmp_path)), \
+         patch("asyncio.create_subprocess_exec", proc_mock), \
+         patch("src.telegram_bot.enforcer_bot.send_interjection",
+               new_callable=AsyncMock) as mock_interject:
+
+        task = asyncio.create_task(watch_max_outbox())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        # review_state=unknown must trigger interjection — never ghost-green
+        mock_interject.assert_called_once()
+        call_text = mock_interject.call_args[0][0]
+        # Must reference unknown state and not claim approval
+        assert "unknown" in call_text.lower() or "COMPLETION-REQUIRES-VERIFICATION" in call_text
+        assert "review_state=APPROVED" not in call_text

--- a/tests/test_enforcer_max_outbox.py
+++ b/tests/test_enforcer_max_outbox.py
@@ -304,3 +304,34 @@ async def test_verify_pr_review_state_unknown(tmp_path):
         # Must reference unknown state and not claim approval
         assert "unknown" in call_text.lower() or "COMPLETION-REQUIRES-VERIFICATION" in call_text
         assert "review_state=APPROVED" not in call_text
+
+
+@pytest.mark.asyncio
+async def test_verify_pr_review_state_commented_only(tmp_path):
+    """COMMENTED-only reviews (no APPROVED, no CHANGES_REQUESTED) → REVIEW_REQUIRED;
+    'approved' claim must trigger interjection."""
+    _make_outbox_file(tmp_path, "PR #521 approved")
+
+    proc_mock = _async_proc_mock(_verify_json(
+        merged=True, ci_passing=True,
+        review_state="REVIEW_REQUIRED",
+        latest_reviews=[
+            {"author": "elliotbot", "state": "COMMENTED"},
+        ],
+    ))
+
+    with patch("src.telegram_bot.enforcer_bot.MAX_OUTBOX", str(tmp_path)), \
+         patch("asyncio.create_subprocess_exec", proc_mock), \
+         patch("src.telegram_bot.enforcer_bot.send_interjection",
+               new_callable=AsyncMock) as mock_interject:
+
+        task = asyncio.create_task(watch_max_outbox())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        # COMMENTED-only must NOT count as APPROVED — claim "approved" → mismatch interjection
+        mock_interject.assert_called_once()
+        call_text = mock_interject.call_args[0][0]
+        assert "REVIEW_REQUIRED" in call_text or "COMPLETION-REQUIRES-VERIFICATION" in call_text


### PR DESCRIPTION
## Summary

Per MAX directive 2026-05-02 (Option A confirmed) — `verify_pr.sh` should report PR review state using **only the latest review per reviewer**, ignoring stale historical comments. Adds `review_state` + `latest_reviews` fields to the existing JSON output.

## Changes

`scripts/verify_pr.sh`:
- New `gh pr view --json reviewDecision,latestReviews` query
- Computes `review_state`:
  - any latest `CHANGES_REQUESTED` → `CHANGES_REQUESTED`
  - else any `APPROVED` with no `CHANGES_REQUESTED` → `APPROVED`
  - else `REVIEW_REQUIRED`
  - on `gh` error → `review_state: "unknown"` (no ghost-green)
- New fields added; existing fields unchanged (backward compatible)

`src/telegram_bot/enforcer_bot.py`:
- `watch_max_outbox` mismatch path extended for `"approved"` keyword: claim "approved" + `review_state != "APPROVED"` → Rule 3 interjection. `unknown` does NOT ghost-green (same anti-ghost-green principle as the CI check).

## Tests (3 new + existing)

```
tests/test_enforcer_max_outbox.py::test_verify_pr_review_state_approved PASSED
tests/test_enforcer_max_outbox.py::test_verify_pr_review_state_changes_requested PASSED
tests/test_enforcer_max_outbox.py::test_verify_pr_review_state_unknown PASSED
... 23 passed in 0.58s
```

## Verification on real PR

```
$ bash scripts/verify_pr.sh 522
{
  "pr": 522,
  "state": "MERGED", "merged": true, "merge_sha": "e25e306...",
  "ci_passing": true, "failed_checks": [], "pending_checks": [],
  "review_state": "REVIEW_REQUIRED",
  "latest_reviews": []
}
```

**Caveat:** PRs #519–#525 all report `review_state: "REVIEW_REQUIRED"` with `latest_reviews: []` because reviews in this repo are posted as **PR comments**, not formal GitHub reviews — both worktrees share the elliotbot GitHub account, which blocks `gh pr review`. The mechanical behaviour is correct (no formal reviews → REVIEW_REQUIRED) but the practical signal is limited until formal reviews resume. The check still catches the bug where MAX claims "approved" before reviewers have actually approved.

## Note on this PR's review

Per the same constraint above, my own approval and Elliot's approval will be in this PR's comments, not formal reviews. `verify_pr.sh` against #526 will report `REVIEW_REQUIRED` even after we both comment APPROVE. That's the correct mechanical state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)