### PR TITLE
[ELLIOT] fix(test): align mem0 search test with SDK 2.x filters API

### DIFF
--- a/tests/governance/test_mem0_adapter.py
+++ b/tests/governance/test_mem0_adapter.py
@@ -104,7 +104,7 @@ def test_search_queries_mem0_and_logs(log_path, monkeypatch):
     adapter = mod.Mem0Adapter()
     results = adapter.search("pipeline decision", limit=3, callsign="elliot")
 
-    mock_client.search.assert_called_once_with("pipeline decision", user_id="elliot", limit=3)
+    mock_client.search.assert_called_once_with("pipeline decision", filters={"user_id": "elliot"}, limit=3)
     assert isinstance(results, list)
     assert results[0]["memory"] == "test memory content"
 


### PR DESCRIPTION
## Summary
- Test expected Mem0 SDK 1.x signature: `search(query, user_id='elliot', limit=3)`
- Adapter correctly uses SDK 2.x: `search(query, filters={'user_id': 'elliot'}, limit=3)`
- Updated assertion to match actual call signature

## Root cause
Mem0 SDK 2.x changed `user_id` from a direct kwarg to `filters={'user_id': ...}`. The adapter was updated but the test wasn't.

## Verification
```
pytest tests/governance/test_mem0_adapter.py -v → 6/6 passed
Full suite: 61 pre-existing failures → 60 (this fixes 1, no regressions)
```

## Test plan
- [x] 6/6 mem0_adapter tests pass
- [x] No regressions (full suite confirms)
- [ ] Aiden peer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)