### PR TITLE
[AIDEN] tests: Prefect ephemeral-server conftest for orchestration/flows (Cat 1)

### DIFF
--- a/tests/orchestration/flows/conftest.py
+++ b/tests/orchestration/flows/conftest.py
@@ -1,0 +1,40 @@
+"""conftest.py — Prefect ephemeral server fixture for orchestration/flows tests.
+
+All tests under tests/orchestration/flows/ call Prefect @flow and @task
+decorated functions via .fn(), which triggers the Prefect task engine and
+requires a Prefect server. In CI there is no live server, so we spin up a
+temporary in-process SQLite-backed server for the test session.
+
+The fixture uses prefect.settings.temporary_settings to:
+  - Clear PREFECT_API_URL (overrides the Railway URL set in the environment)
+  - Enable PREFECT_SERVER_ALLOW_EPHEMERAL_MODE so Prefect auto-starts a
+    local in-process server
+
+Scope: session — one ephemeral server for the whole test session.
+"""
+from __future__ import annotations
+
+import pytest
+from prefect.settings import (
+    PREFECT_API_URL,
+    PREFECT_SERVER_ALLOW_EPHEMERAL_MODE,
+    temporary_settings,
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prefect_ephemeral_server():
+    """Start a temporary in-process Prefect server for the test session.
+
+    This is required because the flow tests call task.fn() / flow.fn() which
+    still triggers Prefect's AsyncClientContext, which attempts to connect to
+    PREFECT_API_URL. The Railway URL in the environment has no live server in
+    CI, so we redirect to an ephemeral local server instead.
+    """
+    with temporary_settings(
+        updates={
+            PREFECT_API_URL: None,
+            PREFECT_SERVER_ALLOW_EPHEMERAL_MODE: True,
+        }
+    ):
+        yield


### PR DESCRIPTION
## Summary

Per MAX directive — **Cat 1** of test triage. Resolves the 13-17 Prefect API test failures by spinning up an in-process ephemeral Prefect server for the orchestration/flows test session, instead of relying on a live Railway-hosted server.

Combined with Elliot's #529 (Cat 3 xfail + Cat 5 fixes + Restate stub), full suite is now **0 failed, 3151 passed, 28 skipped, 31 xfailed**. Down from 60 failed at session start.

## Approach

40-line session-scoped autouse fixture in `tests/orchestration/flows/conftest.py`:

```python
@pytest.fixture(scope="session", autouse=True)
def prefect_ephemeral_server():
    with temporary_settings(updates={
        PREFECT_API_URL: None,
        PREFECT_SERVER_ALLOW_EPHEMERAL_MODE: True,
    }):
        yield
```

Uses Prefect's own `temporary_settings` context to:
1. Clear the Railway `PREFECT_API_URL` from env
2. Enable `PREFECT_SERVER_ALLOW_EPHEMERAL_MODE` so Prefect auto-starts an in-process SQLite-backed server

Cleaner than mocking the client — no fragile patches on `get_client()` etc., no fixture-per-file duplication.

## Verification

```
$ pytest tests/orchestration/flows/ -v 2>&1 | tail -3
======================= 63 passed, 29 warnings in 29.11s =======================

$ pytest tests/ 2>&1 | tail -1
==== 3151 passed, 28 skipped, 31 xfailed, 191 warnings in 240.24s (0:04:00) ====
```

## Authorship note

The conftest file was pre-existing in the working tree as untracked content (from a prior session — possibly from earlier Prefect troubleshooting that wasn't committed). Build-2 verified the file's logic is correct against current `main + #529`, ran the full suite to confirm 63/63 pass, and staged it. No production code changes; this is purely test infrastructure that was sitting unstaged.

If anyone (Elliot, Dave, or a previous session of mine) recognizes the file as theirs — credit where due. The mechanical verification stands either way.

## Test plan

- [x] `pytest tests/orchestration/flows/` — 63/63 pass
- [x] Full suite — 0 failures (down from 17 post-#529)
- [x] No production code changes (`git diff main..HEAD -- src/` empty)
- [x] Ruff clean
- [ ] Peer review by Elliot

🤖 Generated with [Claude Code](https://claude.com/claude-code)