### PR TITLE
[ELLIOT] feat(test): CD Player v1 test rewrite — orchestrator gates

### DIFF
--- a/tests/test_pipeline/test_orchestrator_gates.py
+++ b/tests/test_pipeline/test_orchestrator_gates.py
@@ -1,110 +1,344 @@
-"""Tests for new gated PipelineOrchestrator flow — Directive #291."""
+"""Tests for gated PipelineOrchestrator flow — CD Player v1 API.
+
+These tests patch the cohort_runner stage functions imported into
+pipeline_orchestrator so the real orchestrator logic runs but without
+live API calls. Stages return controlled domain_data dicts that trigger
+specific gate conditions.
+"""
 import pytest
-from unittest.mock import AsyncMock, MagicMock, call
-from src.pipeline.pipeline_orchestrator import PipelineOrchestrator
-from src.pipeline.prospect_scorer import ProspectScorer
+from unittest.mock import AsyncMock, MagicMock, patch
+from src.pipeline.pipeline_orchestrator import (
+    PipelineOrchestrator,
+    PipelineResult,
+    PipelineStats,
+    ProspectCard,
+)
 
 
-def _afford_pass():
-    r = MagicMock(); r.passed_gate = True; r.band = "MEDIUM"; r.raw_score = 5; r.gaps = []
-    return r
+# ── Shared stage mock helpers ─────────────────────────────────────────────────
 
-def _afford_fail():
-    r = MagicMock(); r.passed_gate = False; r.band = "LOW"; r.raw_score = 0; r.gaps = ["sole_trader"]
-    return r
-
-def _intent_pass():
-    r = MagicMock(); r.passed_free_gate = True; r.band = "TRYING"; r.raw_score = 5; r.evidence = ["Has website but no analytics"]
-    return r
-
-def _intent_fail():
-    r = MagicMock(); r.passed_free_gate = False; r.band = "NOT_TRYING"; r.raw_score = 0; r.evidence = []
-    return r
-
-def _make_orch(afford=None, intent_free=None, intent_full=None, dm=None):
-    disc = MagicMock(); disc.pull_batch = AsyncMock(side_effect=[[{"domain": "dental.com.au"}], []])
-    enr = MagicMock()
-    enr.scrape_website = AsyncMock(return_value={"title": "Dental"})
-    enr.enrich_from_spider = AsyncMock(return_value={"domain": "dental.com.au", "company_name": "Dental", "entity_type": "Company", "gst_registered": True})
-    scorer = MagicMock()
-    scorer.score_affordability = MagicMock(return_value=afford or _afford_pass())
-    scorer.score_intent_free = MagicMock(return_value=intent_free or _intent_pass())
-    scorer.score_intent_full = MagicMock(return_value=intent_full or _intent_pass())
-    dm_mock = MagicMock()
-    if dm is None:
-        dm_res = MagicMock(); dm_res.name = "Jane"; dm_res.title = "Owner"
-        dm_res.linkedin_url = "https://au.linkedin.com/in/jane"; dm_res.confidence = "HIGH"
-        dm_mock.identify = AsyncMock(return_value=dm_res)
-    else:
-        dm_mock.identify = AsyncMock(return_value=dm)
-    return PipelineOrchestrator(discovery=disc, free_enrichment=enr,
-                                prospect_scorer=scorer, dm_identification=dm_mock), scorer
+def _stage_pass(domain_data: dict) -> dict:
+    """Return domain_data unchanged (stage succeeded, no drop)."""
+    return domain_data
 
 
-@pytest.mark.xfail(reason="Legacy orchestrator API — CD Player v1 rewrite pending")
+async def _async_stage_pass(domain_data: dict, *args, **kwargs) -> dict:
+    return domain_data
+
+
+async def _stage2_mock(domain_data: dict, dfs) -> dict:
+    domain_data["stage2"] = {"serp_abn": "12345678901"}
+    domain_data["cost_usd"] += 0.01
+    return domain_data
+
+
+async def _stage3_pass(domain_data: dict, gemini) -> dict:
+    """Stage 3 that passes: returns a valid DM candidate."""
+    domain_data["stage3"] = {
+        "business_name": "Test Dental",
+        "is_enterprise_or_chain": False,
+        "dm_candidate": {
+            "name": "Jane Smith",
+            "role": "Owner",
+            "linkedin_url": "https://au.linkedin.com/in/janesmith",
+        },
+    }
+    return domain_data
+
+
+async def _stage3_no_dm(domain_data: dict, gemini) -> dict:
+    """Stage 3 that drops: no DM found (mirrors real cohort_runner gate)."""
+    domain_data["stage3"] = {
+        "business_name": "Test Co",
+        "is_enterprise_or_chain": False,
+        "dm_candidate": {},
+    }
+    domain_data["dropped_at"] = "stage3"
+    domain_data["drop_reason"] = "no_dm_found"
+    return domain_data
+
+
+async def _stage4_mock(domain_data: dict, dfs) -> dict:
+    domain_data["stage4"] = {
+        "rank_overview": {"organic_etv": 500, "rank": 50000},
+        "backlinks": {"backlinks_num": 120},
+    }
+    domain_data["cost_usd"] += 0.078
+    return domain_data
+
+
+async def _stage5_pass(domain_data: dict) -> dict:
+    """Stage 5 that passes the affordability gate (composite_score >= 30)."""
+    domain_data["stage5"] = {
+        "is_viable_prospect": True,
+        "composite_score": 55,
+        "affordability_band": "MEDIUM",
+        "affordability_score": 55,
+        "intent_band": "TRYING",
+        "intent_score": 55,
+    }
+    return domain_data
+
+
+async def _stage5_reject(domain_data: dict) -> dict:
+    """Stage 5 that fails the affordability gate (mirrors real cohort_runner gate)."""
+    domain_data["stage5"] = {
+        "is_viable_prospect": False,
+        "composite_score": 10,
+        "affordability_band": "LOW",
+        "affordability_score": 10,
+        "viability_reason": "sole_trader",
+    }
+    domain_data["dropped_at"] = "stage5"
+    domain_data["drop_reason"] = "viability: sole_trader"
+    return domain_data
+
+
+async def _stage6_mock(domain_data: dict, dfs) -> dict:
+    domain_data["stage6"] = {}
+    return domain_data
+
+
+async def _stage7_mock(domain_data: dict, gemini) -> dict:
+    domain_data["stage7"] = {"evidence": ["Has website", "No analytics"]}
+    return domain_data
+
+
+async def _stage8_mock(domain_data: dict, dfs, bd=None, lm=None) -> dict:
+    domain_data["stage8_verify"] = {}
+    domain_data["stage8_contacts"] = {
+        "email": {"email": "jane@testdental.com.au", "verified": True, "source": "leadmagic"},
+        "mobile": {},
+        "linkedin": {"linkedin_url": "https://au.linkedin.com/in/janesmith"},
+    }
+    domain_data["cost_usd"] += 0.015
+    return domain_data
+
+
+async def _stage9_mock(domain_data: dict, bd) -> dict:
+    domain_data["stage9"] = {}
+    return domain_data
+
+
+async def _stage10_mock(domain_data: dict) -> dict:
+    domain_data["stage10"] = {}
+    return domain_data
+
+
+async def _stage11_mock(domain_data: dict) -> dict:
+    stage3 = domain_data.get("stage3") or {}
+    dm = stage3.get("dm_candidate") or {}
+    stage5 = domain_data.get("stage5") or {}
+    domain_data["stage11"] = {
+        "company_name": stage3.get("business_name", "Test Co"),
+        "location": "Sydney NSW",
+        "location_suburb": "Sydney",
+        "location_state": "NSW",
+        "dm_name": dm.get("name"),
+        "dm_title": dm.get("role"),
+        "dm_linkedin_url": dm.get("linkedin_url"),
+        "dm_confidence": "HIGH",
+        "intent_band": stage5.get("intent_band", "TRYING"),
+        "services": ["dental"],
+        "evidence": ["Has website"],
+        "is_running_ads": False,
+        "gmb_review_count": 0,
+    }
+    return domain_data
+
+
+# ── Discovery mock factory ────────────────────────────────────────────────────
+
+def _make_discovery(domains: list[str]):
+    """Return a discovery mock whose pull_batch returns the domains once then empty."""
+    disc = MagicMock()
+    batch = [{"domain": d} for d in domains]
+    disc.pull_batch = AsyncMock(side_effect=[batch, []])
+    return disc
+
+
+# ── Patch context for all stage functions ────────────────────────────────────
+
+STAGE_PATCHES_PASS = {
+    "src.pipeline.pipeline_orchestrator._run_stage2": _stage2_mock,
+    "src.pipeline.pipeline_orchestrator._run_stage3": _stage3_pass,
+    "src.pipeline.pipeline_orchestrator._run_stage4": _stage4_mock,
+    "src.pipeline.pipeline_orchestrator._run_stage5": _stage5_pass,
+    "src.pipeline.pipeline_orchestrator._run_stage6": _stage6_mock,
+    "src.pipeline.pipeline_orchestrator._run_stage7": _stage7_mock,
+    "src.pipeline.pipeline_orchestrator._run_stage8": _stage8_mock,
+    "src.pipeline.pipeline_orchestrator._run_stage9": _stage9_mock,
+    "src.pipeline.pipeline_orchestrator._run_stage10": _stage10_mock,
+    "src.pipeline.pipeline_orchestrator._run_stage11": _stage11_mock,
+    "src.pipeline.pipeline_orchestrator._default_on_domain_complete": AsyncMock(return_value=None),
+}
+
+
+def _patch_stages(overrides: dict | None = None):
+    """Return a list of patch objects. overrides replaces specific stage mocks."""
+    patches = dict(STAGE_PATCHES_PASS)
+    if overrides:
+        patches.update(overrides)
+    return patches
+
+
+def _make_orch(discovery):
+    """Build an orchestrator with null clients (stages are fully mocked)."""
+    return PipelineOrchestrator(
+        dfs_client=MagicMock(),
+        gemini_client=MagicMock(),
+        bd_client=MagicMock(),
+        lm_client=MagicMock(),
+        discovery=discovery,
+        on_domain_complete=AsyncMock(return_value=None),
+    )
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
 @pytest.mark.asyncio
 async def test_affordability_rejected_counted():
-    orch, scorer = _make_orch(afford=_afford_fail())
-    result = await orch.run("10514", target_count=5)
+    """Stage 5 drop (score < gate) must increment stats.affordability_rejected."""
+    disc = _make_discovery(["dental.com.au"])
+    orch = _make_orch(disc)
+
+    stage_mocks = _patch_stages(overrides={
+        "src.pipeline.pipeline_orchestrator._run_stage5": _stage5_reject,
+    })
+    with (
+        patch("src.pipeline.pipeline_orchestrator._run_stage2", _stage2_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage3", _stage3_pass),
+        patch("src.pipeline.pipeline_orchestrator._run_stage4", _stage4_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage5", _stage5_reject),
+        patch("src.pipeline.pipeline_orchestrator._run_stage6", _stage6_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage7", _stage7_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage8", _stage8_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage9", _stage9_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage10", _stage10_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage11", _stage11_mock),
+    ):
+        result = await orch.run_streaming(
+            categories=["dental"], target_cards=5, budget_cap_aud=50.0, num_workers=1
+        )
+
     assert result.stats.affordability_rejected == 1
-    assert result.stats.intent_rejected == 0
+    assert result.stats.viable_prospects == 0
 
 
-@pytest.mark.xfail(reason="Legacy orchestrator API — CD Player v1 rewrite pending")
 @pytest.mark.asyncio
 async def test_intent_not_trying_skips_paid_enrichment():
-    ads_client = AsyncMock()
-    orch, scorer = _make_orch(intent_free=_intent_fail())
-    orch._ads_client = ads_client
-    result = await orch.run("10514", target_count=5)
-    assert result.stats.intent_rejected == 1
-    ads_client.assert_not_called()
+    """Stage 3 drop with no_dm_found must count as enrichment_failed (not a card).
+    Paid stages (8, 9) must not be called for that domain.
+    """
+    disc = _make_discovery(["dental.com.au"])
+    orch = _make_orch(disc)
+
+    stage8_spy = AsyncMock(side_effect=_stage8_mock)
+
+    with (
+        patch("src.pipeline.pipeline_orchestrator._run_stage2", _stage2_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage3", _stage3_no_dm),
+        patch("src.pipeline.pipeline_orchestrator._run_stage4", _stage4_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage5", _stage5_pass),
+        patch("src.pipeline.pipeline_orchestrator._run_stage6", _stage6_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage7", _stage7_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage8", stage8_spy),
+        patch("src.pipeline.pipeline_orchestrator._run_stage9", _stage9_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage10", _stage10_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage11", _stage11_mock),
+    ):
+        result = await orch.run_streaming(
+            categories=["dental"], target_cards=5, budget_cap_aud=50.0, num_workers=1
+        )
+
+    # Domain dropped at stage3 — no card produced, stage 8 never called
+    assert result.stats.viable_prospects == 0
+    assert result.stats.enrichment_failed == 1
+    stage8_spy.assert_not_called()
 
 
-@pytest.mark.xfail(reason="Legacy orchestrator API — CD Player v1 rewrite pending")
 @pytest.mark.asyncio
 async def test_full_prospect_card_with_evidence():
-    orch, scorer = _make_orch()
-    result = await orch.run("10514", target_count=1, batch_size=1)
+    """A domain that passes all gates must produce a ProspectCard with dm_name and intent_band."""
+    disc = _make_discovery(["dental.com.au"])
+    orch = _make_orch(disc)
+
+    with (
+        patch("src.pipeline.pipeline_orchestrator._run_stage2", _stage2_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage3", _stage3_pass),
+        patch("src.pipeline.pipeline_orchestrator._run_stage4", _stage4_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage5", _stage5_pass),
+        patch("src.pipeline.pipeline_orchestrator._run_stage6", _stage6_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage7", _stage7_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage8", _stage8_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage9", _stage9_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage10", _stage10_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage11", _stage11_mock),
+    ):
+        result = await orch.run_streaming(
+            categories=["dental"], target_cards=1, budget_cap_aud=50.0, num_workers=1
+        )
+
     assert len(result.prospects) == 1
     card = result.prospects[0]
-    assert card.dm_name == "Jane"
+    assert card.dm_name == "Jane Smith"
     assert card.intent_band in ("NOT_TRYING", "DABBLING", "TRYING", "STRUGGLING", "UNKNOWN")
 
 
-@pytest.mark.xfail(reason="Legacy orchestrator API — CD Player v1 rewrite pending")
 @pytest.mark.asyncio
 async def test_dm_not_found_counted():
-    disc = MagicMock(); disc.pull_batch = AsyncMock(side_effect=[[{"domain":"x.com"}],[]])
-    enr = MagicMock()
-    enr.scrape_website = AsyncMock(return_value={"title": "X"})
-    enr.enrich_from_spider = AsyncMock(return_value={"domain":"x.com","company_name":"X","entity_type":"Company","gst_registered":True})
-    scorer = MagicMock()
-    scorer.score_affordability = MagicMock(return_value=_afford_pass())
-    scorer.score_intent_free = MagicMock(return_value=_intent_pass())
-    scorer.score_intent_full = MagicMock(return_value=_intent_pass())
-    dm_mock = MagicMock(); dm_mock.identify = AsyncMock(return_value=None)
-    orch2 = PipelineOrchestrator(discovery=disc, free_enrichment=enr,
-                                 prospect_scorer=scorer, dm_identification=dm_mock)
-    result = await orch2.run("10514", target_count=5)
-    assert result.stats.dm_not_found == 1
+    """Stage 3 gate (no DM candidate) must drop the domain; no card produced."""
+    disc = _make_discovery(["x.com.au"])
+    orch = _make_orch(disc)
+
+    with (
+        patch("src.pipeline.pipeline_orchestrator._run_stage2", _stage2_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage3", _stage3_no_dm),
+        patch("src.pipeline.pipeline_orchestrator._run_stage4", _stage4_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage5", _stage5_pass),
+        patch("src.pipeline.pipeline_orchestrator._run_stage6", _stage6_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage7", _stage7_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage8", _stage8_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage9", _stage9_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage10", _stage10_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage11", _stage11_mock),
+    ):
+        result = await orch.run_streaming(
+            categories=["dental"], target_cards=5, budget_cap_aud=50.0, num_workers=1
+        )
+
+    # No card produced; enrichment_failed incremented for stage3 drop
+    assert result.stats.viable_prospects == 0
+    assert result.stats.enrichment_failed == 1
 
 
-@pytest.mark.xfail(reason="Legacy orchestrator API — CD Player v1 rewrite pending")
 @pytest.mark.asyncio
 async def test_stops_at_target_count():
+    """Pipeline must stop emitting cards once target_cards is reached."""
+    domains = [f"d{i}.com.au" for i in range(20)]
     disc = MagicMock()
-    disc.pull_batch = AsyncMock(return_value=[{"domain": f"d{i}.com.au"} for i in range(20)])
-    enr = MagicMock()
-    enr.scrape_website = AsyncMock(return_value={"title": "D"})
-    enr.enrich_from_spider = AsyncMock(return_value={"domain":"d.com.au","company_name":"D","entity_type":"Company","gst_registered":True,"website_contact_emails":["a@b.com"]})
-    scorer = MagicMock()
-    scorer.score_affordability = MagicMock(return_value=_afford_pass())
-    scorer.score_intent_free = MagicMock(return_value=_intent_pass())
-    scorer.score_intent_full = MagicMock(return_value=_intent_pass())
-    dm_res = MagicMock(); dm_res.name = "Jane"; dm_res.title = ""; dm_res.linkedin_url = "https://li.com/in/j"; dm_res.confidence = "HIGH"
-    dm_mock = MagicMock(); dm_mock.identify = AsyncMock(return_value=dm_res)
-    orch = PipelineOrchestrator(discovery=disc, free_enrichment=enr,
-                                prospect_scorer=scorer, dm_identification=dm_mock)
-    result = await orch.run("10514", target_count=3, batch_size=20)
+    disc.pull_batch = AsyncMock(return_value=[{"domain": d} for d in domains])
+    orch = _make_orch(disc)
+
+    with (
+        patch("src.pipeline.pipeline_orchestrator._run_stage2", _stage2_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage3", _stage3_pass),
+        patch("src.pipeline.pipeline_orchestrator._run_stage4", _stage4_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage5", _stage5_pass),
+        patch("src.pipeline.pipeline_orchestrator._run_stage6", _stage6_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage7", _stage7_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage8", _stage8_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage9", _stage9_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage10", _stage10_mock),
+        patch("src.pipeline.pipeline_orchestrator._run_stage11", _stage11_mock),
+    ):
+        result = await orch.run_streaming(
+            categories=["dental"],
+            target_cards=3,
+            budget_cap_aud=500.0,
+            num_workers=1,
+            batch_size=20,
+        )
+
     assert len(result.prospects) == 3

--- a/tests/test_pipeline/test_orchestrator_gates.py
+++ b/tests/test_pipeline/test_orchestrator_gates.py
@@ -5,17 +5,17 @@ pipeline_orchestrator so the real orchestrator logic runs but without
 live API calls. Stages return controlled domain_data dicts that trigger
 specific gate conditions.
 """
-import pytest
+
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from src.pipeline.pipeline_orchestrator import (
     PipelineOrchestrator,
-    PipelineResult,
-    PipelineStats,
-    ProspectCard,
 )
 
-
 # ── Shared stage mock helpers ─────────────────────────────────────────────────
+
 
 def _stage_pass(domain_data: dict) -> dict:
     """Return domain_data unchanged (stage succeeded, no drop)."""
@@ -149,6 +149,7 @@ async def _stage11_mock(domain_data: dict) -> dict:
 
 # ── Discovery mock factory ────────────────────────────────────────────────────
 
+
 def _make_discovery(domains: list[str]):
     """Return a discovery mock whose pull_batch returns the domains once then empty."""
     disc = MagicMock()
@@ -203,9 +204,11 @@ async def test_affordability_rejected_counted():
     disc = _make_discovery(["dental.com.au"])
     orch = _make_orch(disc)
 
-    stage_mocks = _patch_stages(overrides={
-        "src.pipeline.pipeline_orchestrator._run_stage5": _stage5_reject,
-    })
+    _patch_stages(
+        overrides={
+            "src.pipeline.pipeline_orchestrator._run_stage5": _stage5_reject,
+        }
+    )
     with (
         patch("src.pipeline.pipeline_orchestrator._run_stage2", _stage2_mock),
         patch("src.pipeline.pipeline_orchestrator._run_stage3", _stage3_pass),


### PR DESCRIPTION
## Summary
- Convert 5 xfailed orchestrator gate tests to real CD Player v1 mocked tests
- Patch cohort_runner stage functions at module level — real orchestrator logic runs
- External clients (dfs, gemini, bd, lm) mocked, not called

## Tests rewritten
| Test | Verifies |
|------|----------|
| test_affordability_rejected_counted | Stage 5 drop → stats.affordability_rejected |
| test_intent_not_trying_skips_paid_enrichment | Stage 3 drop → paid stages skipped |
| test_full_prospect_card_with_evidence | All gates pass → ProspectCard with dm_name |
| test_dm_not_found_counted | No DM candidate → stats.enrichment_failed |
| test_stops_at_target_count | Pipeline stops after target_cards reached |

## Verification
```
pytest tests/test_pipeline/test_orchestrator_gates.py -v → 5 passed
ruff check → clean
```

First file in CD Player v1 rewrite series (31 xfails → real tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)