### PR TITLE
[ELLIOT] chore: remove 13 stale TODO.md references

### DIFF
--- a/src/engines/deprecated/voice_vapi.py
+++ b/src/engines/deprecated/voice_vapi.py
@@ -1296,12 +1296,12 @@ def get_voice_engine() -> VoiceEngine:
 # [x] Phase 16: outcome, duration, touch_number tracked
 # [x] Phase 16: led_to_booking flag for converting touches
 # [x] Phase 17: Vapi + ElevenLabs stack (STT handled by Vapi)
-# [x] Voice retry: busy=2hr, no_answer=next business day (TODO.md #3)
+# [x] Voice retry: busy=2hr, no_answer=next business day
 # [x] Voice retry: MAX_RETRIES=3 enforced
 # [x] Voice retry: VoiceRetryService integration in process_call_webhook
-# [x] Business hours validation: 9-5 weekdays, skip 12-1 PM lunch (TODO.md #15)
+# [x] Business hours validation: 9-5 weekdays, skip 12-1 PM lunch
 # [x] Timezone-aware: uses lead.timezone or Australia/Sydney default
 # [x] get_next_business_hour() calculates next valid call time
-# [x] DNCR check: Australian numbers checked against Do Not Call Register (TODO.md #16)
+# [x] DNCR check: Australian numbers checked against Do Not Call Register
 # [x] DNCR cached: uses lead.dncr_checked/dncr_result to avoid redundant API calls
 # [x] DNCR rejection logging: _log_dncr_rejection() for audit trail

--- a/src/integrations/vapi.py
+++ b/src/integrations/vapi.py
@@ -570,7 +570,7 @@ def get_vapi_client() -> VapiClient:
 # [x] All functions have type hints
 # [x] All functions have docstrings
 # [x] Webhook parsing method included
-# [x] Recording deletion for 90-day retention compliance (TODO.md #14)
+# [x] Recording deletion for 90-day retention compliance
 # [x] Retry logic with tenacity (exponential backoff, 3 attempts)
 # [x] Retries on transient failures (network errors, timeouts)
 # [x] Failure logging before and after retries

--- a/src/orchestration/flows/credit_reset_flow.py
+++ b/src/orchestration/flows/credit_reset_flow.py
@@ -2,7 +2,7 @@
 FILE: src/orchestration/flows/credit_reset_flow.py
 PURPOSE: Monthly credit reset flow - resets client credits on billing date
 PHASE: P0 Critical Fix, Phase D Item 17 (trigger replenishment)
-TASK: TODO P0-001, Item 17
+TASK: P0-001 (completed)
 DEPENDENCIES:
   - src/integrations/supabase.py
   - src/models/client.py

--- a/src/orchestration/flows/monthly_replenishment_flow.py
+++ b/src/orchestration/flows/monthly_replenishment_flow.py
@@ -2,7 +2,7 @@
 FILE: src/orchestration/flows/monthly_replenishment_flow.py
 PURPOSE: Monthly lead replenishment flow - sources new leads after credit reset
 PHASE: Phase D - Item 17
-TASK: TODO Item 17 (P2: Implement monthly replenishment flow)
+TASK: P2 (completed)
 DEPENDENCIES:
   - src/orchestration/flows/pool_population_flow.py
   - src/orchestration/flows/credit_reset_flow.py (trigger)

--- a/src/orchestration/flows/recording_cleanup_flow.py
+++ b/src/orchestration/flows/recording_cleanup_flow.py
@@ -2,7 +2,7 @@
 FILE: src/orchestration/flows/recording_cleanup_flow.py
 PURPOSE: Daily cleanup of voice recordings older than 90 days
 PHASE: Voice Engine Compliance
-TASK: TODO.md #14
+TASK: #14 (completed)
 DEPENDENCIES:
   - src/services/recording_cleanup_service.py
   - src/integrations/supabase.py

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -56,10 +56,10 @@ Phase 22 additions (Content QA):
 Phase H additions (Client Transparency):
 - DigestService: Daily digest email generation and delivery (Item 44)
 
-Voice Retry additions (TODO.md #3):
+Voice Retry additions:
 - VoiceRetryService: Schedule voice call retries (busy=2hr, no_answer=next business day)
 
-Phone Provisioning additions (TODO.md #13):
+Phone Provisioning additions:
 - PhoneProvisioningService: Automated phone number provisioning via Twilio
 """
 
@@ -244,13 +244,13 @@ __all__ = [
     "validate_voice_script",
     # Phase H - Daily Digest
     "DigestService",
-    # Voice Retry (TODO.md #3)
+    # Voice Retry
     "VoiceRetryService",
     "get_voice_retry_service",
     "RETRY_DELAYS",
     "MAX_RETRIES",
     "RETRYABLE_OUTCOMES",
-    # Email Signature (TODO.md #20)
+    # Email Signature
     "generate_signature_text",
     "generate_signature_html",
     "get_display_name",
@@ -258,7 +258,7 @@ __all__ = [
     "get_signature_for_client",
     "get_display_name_for_persona",
     "append_signature_to_body",
-    # Phone Provisioning (TODO.md #13)
+    # Phone Provisioning
     "PhoneProvisioningService",
     "get_phone_provisioning_service",
     "get_voice_daily_limit",

--- a/src/services/phone_provisioning_service.py
+++ b/src/services/phone_provisioning_service.py
@@ -5,7 +5,7 @@ Layer: 3 - services
 Imports: models, integrations
 Consumers: orchestration flows, API routes, campaign creation
 Spec: docs/architecture/distribution/VOICE.md
-TODO.md: #13 (P3 Medium - Voice Engine)
+P3 (completed)
 
 Handles:
 - Search available Australian phone numbers from Twilio


### PR DESCRIPTION
## Summary
Audit of 68 TODO/FIXME/HACK markers in src/ — 13 stale references to completed TODO.md items removed.

## Audit results
| Category | Count | Action |
|----------|-------|--------|
| False positive (checklists, format strings) | 29 | Ignored |
| **Stale (completed work)** | **13** | **Removed in this PR** |
| Deferred (Dave-gated, external deps) | 18 | Left as-is |
| Trivial fix candidates | 6 | Separate follow-up |

## Files changed (7, comments only)
- `src/engines/deprecated/voice_vapi.py` — removed 3 completed checklist lines
- `src/orchestration/flows/credit_reset_flow.py` — TASK: TODO → completed
- `src/orchestration/flows/monthly_replenishment_flow.py` — TASK: TODO → completed
- `src/orchestration/flows/recording_cleanup_flow.py` — TASK: TODO.md → completed
- `src/services/__init__.py` — removed 5 TODO.md refs
- `src/services/phone_provisioning_service.py` — TODO.md → completed
- `src/integrations/vapi.py` — removed completed checklist line

## Verification
```
grep -rn 'TODO\.md' src/ --include='*.py' | grep -v __pycache__ | grep -v _TODO | grep -v 'No TODO'
(0 results — all stale refs removed)
ruff check → All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)