### PR TITLE
[AIDEN] feat(bu): gap #9 — raw ABN write + backfill script

### DIFF
--- a/scripts/backfill_abn_for_existing_rows.py
+++ b/scripts/backfill_abn_for_existing_rows.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""One-shot backfill — populate `business_universe.abn` for existing rows where
+`company_name` is set but `abn` is NULL.
+
+Per BU audit gap #9: 142 rows have `abn_matched=true` from seed-era imports
+but no `abn` value persisted. The matcher logic is correct (`_match_abn` in
+free_enrichment.py); this script re-runs the local matching path against
+existing rows so they get the raw ABN populated.
+
+Strategy:
+  1. Query rows with company_name populated and abn IS NULL
+  2. For each, call FreeEnrichment._local_abn_match(company_name, state, suburb)
+  3. If match found, UPDATE abn + gst_registered + entity_type + registration_date
+
+Usage:
+    python scripts/backfill_abn_for_existing_rows.py [--limit N] [--dry-run]
+
+Idempotent — running twice on same row = no-op (filtered by `abn IS NULL`).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+import asyncpg
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.pipeline.free_enrichment import FreeEnrichment  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger("backfill_abn")
+
+
+SELECT_SQL = """
+    SELECT id, domain, company_name, state, gmb_address
+      FROM business_universe
+     WHERE abn IS NULL
+       AND company_name IS NOT NULL
+       AND company_name != ''
+     ORDER BY id
+     LIMIT $1
+"""
+
+UPDATE_SQL = """
+    UPDATE business_universe
+       SET abn = $2,
+           gst_registered = COALESCE($3, gst_registered),
+           entity_type = COALESCE($4, entity_type),
+           registration_date = COALESCE($5, registration_date),
+           abn_matched = true,
+           updated_at = NOW()
+     WHERE id = $1
+"""
+
+
+async def backfill(limit: int, dry_run: bool) -> tuple[int, int]:
+    """Returns (rows_processed, rows_matched)."""
+    db_url = os.environ.get("DATABASE_URL", "").replace("postgresql+asyncpg://", "postgresql://")
+    if not db_url:
+        raise RuntimeError("DATABASE_URL not set")
+
+    conn = await asyncpg.connect(db_url, statement_cache_size=0)
+    try:
+        rows = await conn.fetch(SELECT_SQL, limit)
+        logger.info("Fetched %d candidate rows", len(rows))
+
+        fe = FreeEnrichment(conn)
+        matched = 0
+        for row in rows:
+            try:
+                # Build a minimal title for the local matcher to consume.
+                # _local_abn_match expects (search_title, state_hint, suburb)
+                suburb = None
+                if row["gmb_address"]:
+                    parts = row["gmb_address"].split(",")
+                    suburb = parts[-2].strip() if len(parts) >= 2 else None
+                result = await fe._local_abn_match(
+                    row["company_name"], state_hint=row["state"], suburb=suburb
+                )
+            except Exception as exc:
+                logger.warning("match failed id=%s domain=%s: %s", row["id"], row["domain"], exc)
+                continue
+
+            if not result or not result.get("abn"):
+                continue
+
+            matched += 1
+            if dry_run:
+                logger.info(
+                    "DRY-RUN id=%s domain=%s → abn=%s",
+                    row["id"],
+                    row["domain"],
+                    result.get("abn"),
+                )
+                continue
+
+            await conn.execute(
+                UPDATE_SQL,
+                row["id"],
+                result.get("abn"),
+                result.get("gst_registered"),
+                result.get("entity_type"),
+                result.get("registration_date"),
+            )
+
+        return len(rows), matched
+    finally:
+        await conn.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=10000)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    processed, matched = asyncio.run(backfill(args.limit, args.dry_run))
+    logger.info(
+        "Backfill complete: processed=%d matched=%d (dry_run=%s)", processed, matched, args.dry_run
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pipeline/free_enrichment.py
+++ b/src/pipeline/free_enrichment.py
@@ -385,6 +385,7 @@ class FreeEnrichment:
         confidence = self._abn_confidence(search_name, self._abn_clean_entity_name(api_name))
         return {
             "abn_matched": True,
+            "abn": row.get("abn"),
             "gst_registered": row["gst_registered"],
             "entity_type": row["entity_type"],
             "registration_date": row.get("registration_date"),
@@ -956,6 +957,7 @@ class FreeEnrichment:
                 gst, etype, reg_date = await self._local_abn_gst(abn_raw)
                 candidate = {
                     "abn_matched": True,
+                    "abn": abn_raw or None,
                     "gst_registered": gst,
                     "entity_type": etype,
                     "registration_date": reg_date,
@@ -999,6 +1001,7 @@ class FreeEnrichment:
                     entity_type                   = COALESCE($12, entity_type),
                     registration_date             = COALESCE($13, registration_date),
                     email_maturity                = $14,
+                    abn                           = COALESCE($15, abn),
                     free_enrichment_completed_at  = NOW(),
                     stage_metrics = jsonb_set(
                         COALESCE(stage_metrics, '{}'::jsonb),
@@ -1022,4 +1025,5 @@ class FreeEnrichment:
                 abn_data.get("entity_type"),
                 abn_data.get("registration_date"),
                 dns_data.get("email_maturity"),
+                abn_data.get("abn"),
             )

--- a/tests/test_gap9_abn_write.py
+++ b/tests/test_gap9_abn_write.py
@@ -1,0 +1,194 @@
+"""Tests for gap #9 — raw ABN value written to business_universe.abn column.
+
+Verifies three things:
+1. When _match_abn returns an ABN value, _write_results SQL includes abn=$15
+   with the correct value.
+2. When match fails (returns None for abn), SQL uses COALESCE so existing abn
+   is not clobbered.
+3. abn_matched boolean still fires — no regression on existing column writes.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, call, patch
+import json
+
+import pytest
+
+from src.pipeline.free_enrichment import FreeEnrichment
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def make_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock(return_value=None)
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    return conn
+
+
+def make_fe(conn: MagicMock | None = None) -> FreeEnrichment:
+    return FreeEnrichment(conn or make_conn())
+
+
+def _execute_sql(conn: MagicMock) -> str:
+    """Return the SQL string from the first conn.execute call."""
+    assert conn.execute.called, "conn.execute was never called"
+    return conn.execute.call_args[0][0]
+
+
+def _execute_args(conn: MagicMock) -> tuple:
+    """Return positional args passed to conn.execute (index 1 onward)."""
+    return conn.execute.call_args[0][1:]
+
+
+# ─── Test 1: ABN value written when match succeeds ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_results_includes_abn_value_on_match():
+    """When abn_data contains a raw ABN string, _write_results passes it as $15."""
+    conn = make_conn()
+    fe = make_fe(conn)
+
+    abn_data = {
+        "abn_matched": True,
+        "abn": "12 345 678 901",
+        "gst_registered": True,
+        "entity_type": "Company",
+        "registration_date": None,
+    }
+    website_data: dict = {
+        "website_cms": None,
+        "website_tech_stack": [],
+        "website_tracking_codes": [],
+        "website_team_names": [],
+        "website_contact_emails": [],
+    }
+    dns_data: dict = {
+        "dns_mx_provider": None,
+        "dns_has_spf": False,
+        "dns_has_dkim": False,
+        "email_maturity": None,
+    }
+
+    await fe._write_results("bu-001", website_data, dns_data, abn_data)
+
+    sql = _execute_sql(conn)
+    args = _execute_args(conn)
+
+    # SQL must reference the abn column with COALESCE
+    assert "abn" in sql
+    assert "COALESCE($15, abn)" in sql
+
+    # $15 positional arg (index 14 in args tuple — $1 is bu_id at index 0)
+    assert args[14] == "12 345 678 901"
+
+
+# ─── Test 2: No clobber when match fails ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_results_coalesce_guards_existing_abn_on_no_match():
+    """When abn_data has no ABN (None), COALESCE preserves the existing column value."""
+    conn = make_conn()
+    fe = make_fe(conn)
+
+    abn_data = {
+        "abn_matched": False,
+        # abn key absent — simulates no match
+    }
+    website_data: dict = {
+        "website_cms": None,
+        "website_tech_stack": [],
+        "website_tracking_codes": [],
+        "website_team_names": [],
+        "website_contact_emails": [],
+    }
+    dns_data: dict = {
+        "dns_mx_provider": None,
+        "dns_has_spf": False,
+        "dns_has_dkim": False,
+        "email_maturity": None,
+    }
+
+    await fe._write_results("bu-002", website_data, dns_data, abn_data)
+
+    sql = _execute_sql(conn)
+    args = _execute_args(conn)
+
+    # COALESCE pattern must be present so existing value is preserved
+    assert "COALESCE($15, abn)" in sql
+
+    # $15 must be None — COALESCE(None, abn) => existing abn untouched
+    assert args[14] is None
+
+
+# ─── Test 3: abn_matched boolean still written — no regression ───────────────
+
+
+@pytest.mark.asyncio
+async def test_write_results_still_sets_abn_matched_boolean():
+    """abn_matched=$10 still appears in SQL — no regression from adding abn=$15."""
+    conn = make_conn()
+    fe = make_fe(conn)
+
+    abn_data = {
+        "abn_matched": True,
+        "abn": "98 765 432 100",
+        "gst_registered": False,
+        "entity_type": "Sole Trader",
+        "registration_date": None,
+    }
+    website_data: dict = {
+        "website_cms": "shopify",
+        "website_tech_stack": ["react"],
+        "website_tracking_codes": [],
+        "website_team_names": [],
+        "website_contact_emails": ["info@example.com.au"],
+    }
+    dns_data: dict = {
+        "dns_mx_provider": "google",
+        "dns_has_spf": True,
+        "dns_has_dkim": True,
+        "email_maturity": "professional",
+    }
+
+    await fe._write_results("bu-003", website_data, dns_data, abn_data)
+
+    sql = _execute_sql(conn)
+    args = _execute_args(conn)
+
+    # abn_matched = $10 must still be present
+    assert "abn_matched" in sql
+    assert "$10" in sql
+    # Positional $10 = index 9 (0-based), after bu_id at index 0
+    assert args[9] is True
+
+    # abn at $15 also correct
+    assert args[14] == "98 765 432 100"
+
+
+# ─── Test 4: _abn_result_from_row now includes abn key ───────────────────────
+
+
+def test_abn_result_from_row_includes_abn_field():
+    """_abn_result_from_row populates 'abn' from the DB row."""
+    fe = make_fe()
+
+    row = MagicMock()
+    row.__getitem__ = lambda self, k: {"gst_registered": True, "entity_type": "Company"}[k]
+    row.get = lambda k, default=None: {
+        "abn": "11 111 111 111",
+        "trading_name": "Test Trading",
+        "legal_name": "Test Legal Pty Ltd",
+        "registration_date": None,
+    }.get(k, default)
+
+    result = fe._abn_result_from_row(row, "Test Legal", "domain_keywords")
+
+    assert "abn" in result
+    assert result["abn"] == "11 111 111 111"
+    assert result["abn_matched"] is True


### PR DESCRIPTION
## Summary

Per Dave directive — BU audit gap #9 (ABN match). Two complementary fixes:

1. **Write extension** — `_match_abn` returns the raw ABN string in its result dict; `_write_results` UPDATE persists it via `abn = COALESCE($15, abn)` (won't clobber manually-set values).
2. **One-shot backfill** — `scripts/backfill_abn_for_existing_rows.py` re-runs the local matcher against existing rows where `company_name` is populated but `abn IS NULL`. Idempotent, `--dry-run` flag, `--limit N` for staged rollout.

## Audit context

The matcher logic is correct (`_match_abn` 4-strategy waterfall, `abn_registry` has 2.4M rows). The 0.05% match rate cited in the directive is **operational** — `free_enrichment_flow` has never executed in production (0 rows have `free_enrichment_completed_at`). My recently-merged #537 unpauses `bu_closed_loop_flow` which should unblock execution.

This PR addresses two real code gaps that surfaced during the audit:
- The matcher wasn't writing the raw ABN value (only the boolean flag)
- No backfill mechanism existed for retroactively matching seed-era rows

## Files

- `src/pipeline/free_enrichment.py` — _match_abn result dict + _write_results SQL extension
- `scripts/backfill_abn_for_existing_rows.py` — NEW one-shot backfill
- `tests/test_gap9_abn_write.py` — NEW (4 tests)

## Tests

```
$ pytest tests/test_gap9_abn_write.py -v
4 passed in 3.13s
```

Coverage:
- ABN value present when match succeeds
- COALESCE preserves existing abn on match-fail
- `abn_matched` boolean still fires (no regression)
- Match-result dict shape verified

## Backfill usage

```bash
# Dry-run first to verify match rate
python scripts/backfill_abn_for_existing_rows.py --limit 100 --dry-run

# Then live writes once Dave/MAX confirms
python scripts/backfill_abn_for_existing_rows.py --limit 10000
```

## Test plan

- [x] 4/4 unit tests pass
- [x] py_compile clean on backfill script
- [x] ruff clean
- [ ] Peer review by Elliot
- [ ] Post-merge: dry-run backfill, verify match rate before live run

🤖 Generated with [Claude Code](https://claude.com/claude-code)