### PR TITLE
[ELLIOT] chore(db): track unmanaged bu domain indexes in migration set

### DIFF
--- a/supabase/migrations/20260503_track_bu_domain_indexes.sql
+++ b/supabase/migrations/20260503_track_bu_domain_indexes.sql
@@ -1,0 +1,15 @@
+-- Track pre-existing business_universe domain indexes into migration set.
+-- These exist on live DB (created outside migrations) but were untracked,
+-- causing the DROP in 20260422_bu_stage_metrics.sql to reference an index
+-- that wasn't in the migration chain. Idempotent — IF NOT EXISTS.
+
+-- Primary btree index for JOIN lookups (e.g. conversion_feedback.py)
+CREATE INDEX IF NOT EXISTS idx_bu_domain
+    ON business_universe (domain);
+
+-- Unique partial index for ON CONFLICT upserts
+-- Predicate matches the standard upsert pattern used across enrichment flows:
+-- ON CONFLICT (domain) WHERE domain IS NOT NULL AND domain != '' DO UPDATE
+CREATE UNIQUE INDEX IF NOT EXISTS uq_bu_domain
+    ON business_universe (domain)
+    WHERE domain IS NOT NULL AND domain != '';


### PR DESCRIPTION
## Summary
`idx_bu_domain` and `uq_bu_domain` exist on live DB but were never tracked in migrations. This migration adds them with `IF NOT EXISTS` for idempotency.

## Background
- Live DB query confirmed both indexes exist
- `20260422_bu_stage_metrics.sql` DROPs `business_universe_domain_unique_idx` referencing `uq_bu_domain` as "pre-existing" — but it was never in the migration chain
- Multiple flows depend on these indexes: conversion_feedback.py JOIN, ON CONFLICT upserts across enrichment

## Migration
```sql
CREATE INDEX IF NOT EXISTS idx_bu_domain ON business_universe (domain);
CREATE UNIQUE INDEX IF NOT EXISTS uq_bu_domain ON business_universe (domain)
    WHERE domain IS NOT NULL AND domain != '';
```

Idempotent — safe to run on any environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)