### PR TITLE
[ELLIOT] fix(p1): tg flag validation + coo-inbox cleanup

### DIFF
--- a/scripts/coo_inbox_cleanup.sh
+++ b/scripts/coo_inbox_cleanup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# coo_inbox_cleanup.sh — Remove coo-inbox files older than 7 days.
+# Run via cron: 0 3 * * * /home/elliotbot/clawd/Agency_OS/scripts/coo_inbox_cleanup.sh
+set -euo pipefail
+
+COO_INBOX="/tmp/coo-inbox"
+MAX_AGE_DAYS=7
+
+if [ ! -d "$COO_INBOX" ]; then
+    exit 0
+fi
+
+count=$(find "$COO_INBOX" -name "*.json" -mtime +${MAX_AGE_DAYS} -type f | wc -l)
+if [ "$count" -gt 0 ]; then
+    find "$COO_INBOX" -name "*.json" -mtime +${MAX_AGE_DAYS} -type f -delete
+    echo "[coo-cleanup] Removed $count files older than ${MAX_AGE_DAYS} days from $COO_INBOX"
+fi

--- a/scripts/tg
+++ b/scripts/tg
@@ -34,6 +34,8 @@ args = sys.argv[1:]
 chat_id = None
 message_parts = []
 
+VALID_FLAGS = {"-g", "--group", "-d", "--dm", "-c", "--chat"}
+
 i = 0
 while i < len(args):
     if args[i] in ("-g", "--group"):
@@ -43,6 +45,10 @@ while i < len(args):
     elif args[i] in ("-c", "--chat") and i + 1 < len(args):
         chat_id = int(args[i + 1])
         i += 1
+    elif args[i].startswith("-") and args[i] not in VALID_FLAGS:
+        print(f"Unknown flag: {args[i]}", file=sys.stderr)
+        print(f"Valid flags: -g (group), -d (DM), -c <chat_id>", file=sys.stderr)
+        sys.exit(1)
     else:
         message_parts.append(args[i])
     i += 1


### PR DESCRIPTION
## Summary
- `scripts/tg`: unknown flags now rejected with error + exit 1 (previously silently sent as message text)
- `scripts/coo_inbox_cleanup.sh`: deletes files older than 7 days from /tmp/coo-inbox. Cron: `0 3 * * *`

## Verification
```
$ tg --badflag "test"
Unknown flag: --badflag
Valid flags: -g (group), -d (DM), -c <chat_id>
EXIT: 1

$ bash scripts/coo_inbox_cleanup.sh
EXIT: 0  (no files >7d old yet)
```

## Test plan
- [ ] Aiden reviews
- [ ] Verify `tg -g "test"` still works (valid flag)
- [ ] Verify `tg --unknown "test"` rejects

🤖 Generated with [Claude Code](https://claude.com/claude-code)