### PR TITLE
[ELLIOT] feat: Prospeo email finder as Layer 2.5 in email waterfall

### DIFF
--- a/src/integrations/prospeo_client.py
+++ b/src/integrations/prospeo_client.py
@@ -5,6 +5,7 @@ Layer: 2 - integrations
 Imports: models only
 Consumers: email_waterfall.py
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/integrations/prospeo_client.py
+++ b/src/integrations/prospeo_client.py
@@ -1,0 +1,84 @@
+"""
+Contract: src/integrations/prospeo_client.py
+Purpose: Prospeo email finder and verifier client (Layer 2.5 in email waterfall)
+Layer: 2 - integrations
+Imports: models only
+Consumers: email_waterfall.py
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+PROSPEO_BASE = "https://api.prospeo.io"
+COST_FIND = 0.01  # USD per find_email call
+COST_VERIFY = 0.01  # USD per verify call
+
+
+@dataclass
+class ProspeoResult:
+    email: str | None
+    verified: bool
+    confidence: int
+    status: str  # "valid" | "risky" | "unknown" | "invalid"
+    cost_usd: float
+
+
+class ProspeoClient:
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+
+    async def find_email(self, full_name: str, domain: str) -> ProspeoResult | None:
+        """Find email for a person by name + domain."""
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                r = await client.post(
+                    f"{PROSPEO_BASE}/email-finder",
+                    json={"full_name": full_name, "domain": domain},
+                    headers={"X-KEY": self.api_key, "Content-Type": "application/json"},
+                )
+                if r.status_code != 200:
+                    logger.warning("prospeo find_email %d: %s", r.status_code, r.text[:200])
+                    return None
+                data = r.json().get("response", {})
+                email = data.get("email")
+                if not email:
+                    return None
+                return ProspeoResult(
+                    email=email,
+                    verified=data.get("email_status") == "valid",
+                    confidence=data.get("confidence", 0),
+                    status=data.get("email_status", "unknown"),
+                    cost_usd=COST_FIND,
+                )
+        except Exception as e:
+            logger.warning("prospeo find_email error: %s", e)
+            return None
+
+    async def verify_email(self, email: str) -> ProspeoResult | None:
+        """Verify an email address."""
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                r = await client.post(
+                    f"{PROSPEO_BASE}/email-verifier",
+                    json={"email": email},
+                    headers={"X-KEY": self.api_key, "Content-Type": "application/json"},
+                )
+                if r.status_code != 200:
+                    logger.warning("prospeo verify_email %d: %s", r.status_code, r.text[:200])
+                    return None
+                data = r.json().get("response", {})
+                return ProspeoResult(
+                    email=email,
+                    verified=data.get("email_status") == "valid",
+                    confidence=90 if data.get("email_status") == "valid" else 30,
+                    status=data.get("email_status", "unknown"),
+                    cost_usd=COST_VERIFY,
+                )
+        except Exception as e:
+            logger.warning("prospeo verify_email error: %s", e)
+            return None

--- a/src/pipeline/email_waterfall.py
+++ b/src/pipeline/email_waterfall.py
@@ -13,6 +13,7 @@ Waterfall layers (short-circuit — returns on first hit):
            stale = domain mismatch → falls through to Hunter
   Layer 2: Hunter email-finder (free, included in plan) — name + domain lookup
            Score >= 70 required. 2000 calls/mo.
+  Layer 2.5: Prospeo email-finder ($0.01 USD) — name + domain lookup, verified
   Layer 3: Leadmagic email finder ($0.015 USD) — API lookup by name + domain, verified
   Layer 4: ContactOut stale fallback — stale email accepted after Leadmagic miss
   Layer 5: Bright Data LinkedIn enrichment ($0.00075 USD) — profile → email, unverified
@@ -120,9 +121,15 @@ try:
 except ImportError:
     BrightDataLinkedInClient = None  # type: ignore
 
+try:
+    from src.integrations.prospeo_client import ProspeoClient
+except ImportError:
+    ProspeoClient = None  # type: ignore
+
 # ── Global semaphore for Leadmagic API calls ──────────────────────────────────
 # Added to global pool alongside GLOBAL_SEM_SONNET / GLOBAL_SEM_HAIKU
 GLOBAL_SEM_LEADMAGIC = asyncio.Semaphore(10)
+GLOBAL_SEM_PROSPEO = asyncio.Semaphore(10)
 
 # ── Placeholder email/phone blocklists (Directive #305) ──────────────────────
 
@@ -260,6 +267,7 @@ _PATTERN_TEMPLATES = [
 # Cost constants (USD)
 COST_LEADMAGIC = 0.015
 COST_BRIGHTDATA = 0.00075
+COST_PROSPEO = 0.01
 
 
 @dataclass
@@ -268,7 +276,7 @@ class EmailResult:
 
     email: str | None
     verified: bool
-    source: str  # "website" | "pattern" | "leadmagic" | "brightdata" | "none"
+    source: str  # "website" | "pattern" | "prospeo" | "leadmagic" | "brightdata" | "none"
     confidence: str  # "high" | "medium" | "low"
     cost_usd: float
 
@@ -476,6 +484,54 @@ async def _try_patterns(first: str, last: str, domain: str) -> EmailResult | Non
         confidence="medium",
         cost_usd=0.0,
     )
+
+
+# ── Layer 2.5: Prospeo email finder ──────────────────────────────────────────
+
+
+async def _prospeo_lookup(
+    first: str,
+    last: str,
+    domain: str,
+) -> EmailResult | None:
+    """
+    Layer 2.5: Prospeo /email-finder — $0.01/call.
+    Slots between Hunter (free) and Leadmagic (paid).
+    """
+    if not first or not last or not domain:
+        return None
+
+    async with GLOBAL_SEM_PROSPEO:
+
+        async def _do_prospeo_call():
+            from src.config.settings import settings
+
+            if ProspeoClient is None or not settings.prospeo_api_key:
+                return None
+            client = ProspeoClient(api_key=settings.prospeo_api_key)
+            return await client.find_email(
+                full_name=f"{first.capitalize()} {last.capitalize()}",
+                domain=domain,
+            )
+
+        result = await _with_retry(_do_prospeo_call, label="prospeo-email")
+
+        if result and result.email and result.status in ("valid", "risky"):
+            confidence = (
+                "high"
+                if result.confidence >= 80
+                else "medium"
+                if result.confidence >= 50
+                else "low"
+            )
+            return EmailResult(
+                email=result.email,
+                verified=result.verified,
+                source="prospeo",
+                confidence=confidence,
+                cost_usd=COST_PROSPEO,
+            )
+    return None
 
 
 # ── Layer 3: Leadmagic email finder ──────────────────────────────────────────
@@ -738,6 +794,12 @@ async def discover_email(
             dm_verified,
             domain,
         )
+
+    # Layer 2.5: Prospeo email finder ($0.01/call — slots between Hunter and Leadmagic)
+    if first and last and clean_domain:
+        result = await _prospeo_lookup(first, last, clean_domain)
+        if result and result.email:
+            return result
 
     # Layer 3: Leadmagic find_email (verified — Leadmagic finds real address)
     # Website HTML layer REMOVED (D2.1B GOV-8) — Stage 3 Gemini already reads the


### PR DESCRIPTION
## Summary
Adds Prospeo find_email + verify_email as Layer 2.5 in the email waterfall, between Hunter (L2, free) and Leadmagic (L3, $0.015). Replaces dead Reacher.

**New file:** `src/integrations/prospeo_client.py`
- ProspeoClient with find_email (POST /email-finder) and verify_email (POST /email-verifier)
- $0.01 USD per call
- Returns ProspeoResult dataclass

**Modified:** `src/pipeline/email_waterfall.py`
- Layer 2.5 inserted between Hunter and Leadmagic in discover_email flow
- Lazy import + GLOBAL_SEM_PROSPEO (10 concurrent) + cost constant
- Only "valid" and "risky" statuses proceed; "unknown"/"invalid" fall through to Leadmagic
- Uses settings.prospeo_api_key (already in settings.py line 173)

## Waterfall order (updated)
L0: Contact registry (free) → L1: ContactOut (free) → L2: Hunter (free) → **L2.5: Prospeo ($0.01)** → L3: Leadmagic ($0.015) → L4: ContactOut stale → L5: Bright Data ($0.00075)

## Verification
```
$ python3 -c "import ast; ast.parse(open('src/integrations/prospeo_client.py').read()); print('OK')"
prospeo_client.py OK
$ python3 -c "import ast; ast.parse(open('src/pipeline/email_waterfall.py').read()); print('OK')"
email_waterfall.py OK
```

## Test plan
- [ ] Aiden reviews waterfall insertion point
- [ ] Verify Prospeo API key is set in env
- [ ] Integration test with real name + domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)