### PR TITLE
[ELLIOT] fix(railway): correct service names to match Railway deployment

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -27,18 +27,26 @@ restartPolicyMaxRetries = 3
 
 # ── Service: API (FastAPI) ────────────────────────────────────────────────
 [[services]]
-name = "api"
+name = "agency-os"
 [services.deploy]
 startCommand = "uvicorn src.api.main:app --host 0.0.0.0 --port ${PORT:-8000}"
 [services.resources]
 # 2 GB ceiling. Guard warns at 1.6 GB, kills sub-agents at 1.9 GB.
 memoryMB = 2048
 
-# ── Service: Worker (Prefect / orchestration) ─────────────────────────────
+# ── Service: Prefect Server ───────────────────────────────────────────────
 [[services]]
-name = "worker"
+name = "prefect-server"
 [services.deploy]
-startCommand = "python -m src.workers.main"
+startCommand = "prefect server start --host 0.0.0.0 --port ${PORT:-4200}"
+[services.resources]
+memoryMB = 1024
+
+# ── Service: Prefect Worker ───────────────────────────────────────────────
+[[services]]
+name = "prefect-worker"
+[services.deploy]
+startCommand = "prefect worker start --pool default --type process"
 [services.resources]
 # 4 GB ceiling — workers spawn sub-agents that each need ~512 MB.
 memoryMB = 4096


### PR DESCRIPTION
## Summary
- Renamed `[[services]]` block `name = "api"` → `name = "agency-os"` to match Railway's actual service
- Replaced `name = "worker"` with two correct blocks: `name = "prefect-server"` and `name = "prefect-worker"`
- `prefect-server` startCommand: `prefect server start --host 0.0.0.0 --port ${PORT:-4200}`
- `prefect-worker` startCommand: `prefect worker start --pool default --type process`

## Root Cause
Railway applies `startCommand` overrides by matching the `name` field in `railway.toml` to the service name in the Railway dashboard. The old names (`api`, `worker`) did not match the actual deployed service names (`agency-os`, `prefect-server`, `prefect-worker`), so all three services fell back to the Dockerfile default — uvicorn.

## Test plan
- [ ] Verify Railway re-deploys all three services after merge
- [ ] Confirm `prefect-server` is running Prefect UI (not uvicorn) on its assigned port
- [ ] Confirm `prefect-worker` process is polling the default pool
- [ ] Confirm `agency-os` still serves the FastAPI health endpoint at `/api/v1/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)