### PR TITLE
[ELLIOT] fix(security): add Svix replay-attack protection to webhook HMAC

### DIFF
--- a/src/api/routes/email.py
+++ b/src/api/routes/email.py
@@ -282,7 +282,9 @@ async def post_webhook(request: Request) -> dict[str, Any]:
     appends event to the row, updates `status` + `last_event_at`."""
     raw = await request.body()
     sig = request.headers.get("svix-signature") or request.headers.get("resend-signature")
-    if not verify_webhook_signature(raw, sig):
+    msg_id = request.headers.get("svix-id")
+    timestamp = request.headers.get("svix-timestamp")
+    if not verify_webhook_signature(raw, sig, msg_id=msg_id, timestamp=timestamp):
         raise HTTPException(status_code=401, detail="invalid signature")
     try:
         payload = json.loads(raw.decode("utf-8") or "{}")

--- a/src/integrations/resend_client.py
+++ b/src/integrations/resend_client.py
@@ -15,6 +15,7 @@ import hashlib
 import hmac
 import logging
 import os
+import time
 from typing import Any
 from urllib.parse import quote
 
@@ -99,36 +100,67 @@ def send_email(
     return result
 
 
-def verify_webhook_signature(raw_body: bytes, signature_header: str | None) -> bool:
-    """Verify Resend webhook HMAC-SHA256 — Svix base64 format.
+WEBHOOK_TOLERANCE_SECONDS = 300  # 5 minutes — Svix/Resend default
 
-    Resend uses Svix under the hood. Svix `v1` signatures are base64-encoded
-    HMAC-SHA256 of the raw body, formatted as `v1,<base64>` (or
-    space-separated when multiple keys are active). We accept the spec form
-    plus the bare-base64 fallback.
 
-    The signing secret comes from `RESEND_WEBHOOK_SECRET`. If unset, this
-    function returns False — the route handler converts that to 401.
+def verify_webhook_signature(
+    raw_body: bytes,
+    signature_header: str | None,
+    msg_id: str | None = None,
+    timestamp: str | None = None,
+) -> bool:
+    """Verify Resend webhook HMAC-SHA256 with replay protection — Svix spec.
+
+    Svix signs ``{msg_id}.{timestamp}.{body}`` (not raw body alone).
+    Timestamps outside a 5-minute tolerance window are rejected to prevent
+    replay attacks. All three Svix headers (svix-id, svix-timestamp,
+    svix-signature) are required — missing any header fails closed.
+
+    The signing secret comes from ``RESEND_WEBHOOK_SECRET``. Svix secrets
+    are prefixed ``whsec_``; the base64 payload after the prefix is the
+    actual HMAC key.
     """
-    if not signature_header:
+    if not signature_header or not msg_id or not timestamp:
         return False
     secret = os.environ.get("RESEND_WEBHOOK_SECRET", "")
     if not secret:
         logger.warning("[resend_client] RESEND_WEBHOOK_SECRET unset — rejecting webhook")
         return False
+
+    # Timestamp replay check
     try:
-        digest = hmac.new(
-            secret.encode("utf-8"),
-            raw_body,
-            hashlib.sha256,
-        ).digest()
+        ts = int(timestamp)
+    except (ValueError, TypeError):
+        logger.warning("[resend_client] invalid svix-timestamp: %s", timestamp)
+        return False
+    now = int(time.time())
+    if abs(now - ts) > WEBHOOK_TOLERANCE_SECONDS:
+        logger.warning(
+            "[resend_client] webhook timestamp outside tolerance: ts=%s now=%s",
+            ts,
+            now,
+        )
+        return False
+
+    # Svix signing payload: "{msg_id}.{timestamp}.{body}"
+    sign_payload = f"{msg_id}.{timestamp}.".encode() + raw_body
+
+    # Svix secrets are prefixed "whsec_" — decode the base64 key after prefix
+    key_material = secret.removeprefix("whsec_")
+    try:
+        key_bytes = base64.b64decode(key_material)
+    except Exception:
+        key_bytes = key_material.encode()
+
+    try:
+        digest = hmac.new(key_bytes, sign_payload, hashlib.sha256).digest()
         expected_b64 = base64.b64encode(digest).decode("ascii")
     except Exception as exc:
         logger.warning("[resend_client] HMAC compute failed: %s", exc)
         return False
-    # Svix can deliver multiple signatures separated by spaces, each shaped
-    # `v1,<base64>` (the `v1,` is the version prefix, followed by the
-    # base64 digest). Strip the prefix and constant-time-compare each.
+
+    # Svix delivers multiple signatures separated by spaces, each shaped
+    # ``v1,<base64>``. Strip the prefix and constant-time-compare each.
     candidates: list[str] = []
     for token in signature_header.replace("\t", " ").split():
         token = token.strip().rstrip(",")
@@ -137,6 +169,5 @@ def verify_webhook_signature(raw_body: bytes, signature_header: str | None) -> b
         if token.startswith("v1,"):
             candidates.append(token[len("v1,") :])
         else:
-            # Bare token (no version prefix) — accept verbatim.
             candidates.append(token)
     return any(hmac.compare_digest(expected_b64, c) for c in candidates)

--- a/tests/api/test_email_routes.py
+++ b/tests/api/test_email_routes.py
@@ -10,7 +10,8 @@ import base64
 import hashlib
 import hmac
 import json
-from unittest.mock import MagicMock
+import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -18,6 +19,30 @@ from fastapi.testclient import TestClient
 from src.api.main import app
 from src.api.routes import email as email_route
 from src.integrations import resend_client
+
+
+def _svix_sign(
+    body: bytes,
+    secret: str,
+    msg_id: str = "msg_test",
+    timestamp: int | None = None,
+) -> dict[str, str]:
+    """Build valid Svix headers for a webhook payload."""
+    ts = timestamp or int(time.time())
+    sign_payload = f"{msg_id}.{ts}.".encode() + body
+    key_material = secret.removeprefix("whsec_")
+    try:
+        key_bytes = base64.b64decode(key_material)
+    except Exception:
+        key_bytes = key_material.encode()
+    digest = hmac.new(key_bytes, sign_payload, hashlib.sha256).digest()
+    sig_b64 = base64.b64encode(digest).decode("ascii")
+    return {
+        "svix-id": msg_id,
+        "svix-timestamp": str(ts),
+        "svix-signature": f"v1,{sig_b64}",
+        "content-type": "application/json",
+    }
 
 
 @pytest.fixture()
@@ -179,10 +204,15 @@ def test_status_404_when_missing(client, monkeypatch):
 def test_webhook_rejects_bad_signature(client, monkeypatch):
     monkeypatch.setenv("RESEND_WEBHOOK_SECRET", "shh")
     body = b'{"type":"email.delivered","data":{"email_id":"x"}}'
+    ts = str(int(time.time()))
     resp = client.post(
         "/api/email/webhook",
         content=body,
-        headers={"svix-signature": "v1,deadbeef"},
+        headers={
+            "svix-id": "msg_bad",
+            "svix-timestamp": ts,
+            "svix-signature": "v1,deadbeef",
+        },
     )
     assert resp.status_code == 401
 
@@ -199,21 +229,12 @@ def test_webhook_accepts_valid_signature_and_updates_status(
             "data": {"email_id": "msg_test_123"},
         }
     ).encode("utf-8")
-    digest = hmac.new(b"shh", body, hashlib.sha256).digest()
-    sig_b64 = base64.b64encode(digest).decode("ascii")
-    resp = client.post(
-        "/api/email/webhook",
-        content=body,
-        headers={
-            "svix-signature": f"v1,{sig_b64}",
-            "content-type": "application/json",
-        },
-    )
+    headers = _svix_sign(body, "shh")
+    resp = client.post("/api/email/webhook", content=body, headers=headers)
     assert resp.status_code == 200, resp.text
     body_json = resp.json()
     assert body_json["ok"] is True
     assert body_json["applied_status"] == "delivered"
-    # DB UPDATE was attempted.
     args = mock_db.execute.call_args[0]
     assert "UPDATE keiracom_admin.email_events" in args[0]
 
@@ -221,12 +242,8 @@ def test_webhook_accepts_valid_signature_and_updates_status(
 def test_webhook_secret_unset_rejects_all(client, monkeypatch):
     monkeypatch.delenv("RESEND_WEBHOOK_SECRET", raising=False)
     body = b'{"type":"email.delivered","data":{"email_id":"x"}}'
-    sig = "v1," + hmac.new(b"any", body, hashlib.sha256).hexdigest()
-    resp = client.post(
-        "/api/email/webhook",
-        content=body,
-        headers={"svix-signature": sig},
-    )
+    headers = _svix_sign(body, "any")
+    resp = client.post("/api/email/webhook", content=body, headers=headers)
     assert resp.status_code == 401
 
 
@@ -238,13 +255,8 @@ def test_webhook_unknown_event_type_keeps_status(client, mock_db, monkeypatch):
             "data": {"email_id": "msg_test_123"},
         }
     ).encode("utf-8")
-    digest = hmac.new(b"shh", body, hashlib.sha256).digest()
-    sig_b64 = base64.b64encode(digest).decode("ascii")
-    resp = client.post(
-        "/api/email/webhook",
-        content=body,
-        headers={"svix-signature": f"v1,{sig_b64}"},
-    )
+    headers = _svix_sign(body, "shh")
+    resp = client.post("/api/email/webhook", content=body, headers=headers)
     assert resp.status_code == 200
     assert resp.json()["applied_status"] is None
 
@@ -263,23 +275,21 @@ def test_webhook_accepts_multiple_space_separated_signatures(
             "data": {"email_id": "msg_test_123"},
         }
     ).encode("utf-8")
-    good = base64.b64encode(hmac.new(b"current_secret", body, hashlib.sha256).digest()).decode(
-        "ascii"
-    )
-    bad = base64.b64encode(hmac.new(b"old_rotated_secret", body, hashlib.sha256).digest()).decode(
-        "ascii"
-    )
-    resp = client.post(
-        "/api/email/webhook",
-        content=body,
-        headers={"svix-signature": f"v1,{bad} v1,{good}"},
-    )
+    good_headers = _svix_sign(body, "current_secret")
+    bad_headers = _svix_sign(body, "old_rotated_secret")
+    combined = f"{bad_headers['svix-signature']} {good_headers['svix-signature']}"
+    headers = {
+        "svix-id": good_headers["svix-id"],
+        "svix-timestamp": good_headers["svix-timestamp"],
+        "svix-signature": combined,
+        "content-type": "application/json",
+    }
+    resp = client.post("/api/email/webhook", content=body, headers=headers)
     assert resp.status_code == 200, resp.text
 
 
 def test_webhook_rejects_hex_signature(client, monkeypatch):
-    """Hex digests must NOT be accepted — Svix is base64-only. Guards
-    against accidental regression to the old hex-accepting behaviour."""
+    """Hex digests must NOT be accepted — Svix is base64-only."""
     monkeypatch.setenv("RESEND_WEBHOOK_SECRET", "shh")
     body = json.dumps(
         {
@@ -287,11 +297,43 @@ def test_webhook_rejects_hex_signature(client, monkeypatch):
             "data": {"email_id": "msg_test_123"},
         }
     ).encode("utf-8")
+    ts = str(int(time.time()))
     sig_hex = hmac.new(b"shh", body, hashlib.sha256).hexdigest()
     resp = client.post(
         "/api/email/webhook",
         content=body,
-        headers={"svix-signature": f"v1,{sig_hex}"},
+        headers={
+            "svix-id": "msg_hex",
+            "svix-timestamp": ts,
+            "svix-signature": f"v1,{sig_hex}",
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_webhook_rejects_expired_timestamp(client, monkeypatch):
+    """Timestamps older than 5 minutes must be rejected (replay protection)."""
+    monkeypatch.setenv("RESEND_WEBHOOK_SECRET", "shh")
+    body = json.dumps(
+        {
+            "type": "email.delivered",
+            "data": {"email_id": "msg_test_123"},
+        }
+    ).encode("utf-8")
+    old_ts = int(time.time()) - 600  # 10 minutes ago
+    headers = _svix_sign(body, "shh", timestamp=old_ts)
+    resp = client.post("/api/email/webhook", content=body, headers=headers)
+    assert resp.status_code == 401
+
+
+def test_webhook_rejects_missing_svix_headers(client, monkeypatch):
+    """Missing svix-id or svix-timestamp headers must be rejected."""
+    monkeypatch.setenv("RESEND_WEBHOOK_SECRET", "shh")
+    body = b'{"type":"email.delivered","data":{"email_id":"x"}}'
+    resp = client.post(
+        "/api/email/webhook",
+        content=body,
+        headers={"svix-signature": "v1,anything"},
     )
     assert resp.status_code == 401
 


### PR DESCRIPTION
## Summary
Supersedes #557 (rebased onto current main post-merge of #560-565).

- Webhook HMAC validates full Svix signing payload (`msg_id.timestamp.body`)
- Timestamps outside 5-min tolerance rejected (replay protection)
- Missing `svix-id`/`svix-timestamp` headers fail closed
- Svix `whsec_` secret prefix handling
- All webhook tests use `_svix_sign()` helper; 2 new tests (replay + missing headers)

## Test plan
- [x] `pytest tests/api/test_email_routes.py` — 22 passed
- [x] `ruff check` + `ruff format` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)