### PR TITLE
[ELLIOT] fix(email): surface DB insert failure as 202+warning

### DIFF
--- a/src/api/routes/email.py
+++ b/src/api/routes/email.py
@@ -166,6 +166,8 @@ class EmailSendRequest(BaseModel):
 class EmailSendResponse(BaseModel):
     message_id: str
     status: str = "queued"
+    warning: str | None = None
+    detail: str | None = None
 
 
 class EmailStatusResponse(BaseModel):
@@ -239,6 +241,13 @@ def post_send(req: EmailSendRequest) -> EmailSendResponse:
     except Exception as exc:
         # Send already succeeded; log but don't fail the response.
         logger.error("[email/send] db insert failed message_id=%s: %s", message_id, exc)
+        return EmailSendResponse(
+            message_id=message_id,
+            status="queued",
+            warning="tracking_insert_failed",
+            detail="email sent via Resend but DB insert failed; "
+            "/status will return 404 for this message_id",
+        )
     return EmailSendResponse(message_id=message_id, status="queued")
 
 

--- a/tests/api/test_email_routes.py
+++ b/tests/api/test_email_routes.py
@@ -156,6 +156,29 @@ def test_unsubscribe_rejects_invalid_email(client):
     assert resp.status_code == 400
 
 
+def test_send_db_failure_returns_202_with_warning(client, monkeypatch):
+    """When Resend send succeeds but DB INSERT fails, return 202 with warning."""
+    monkeypatch.setattr(
+        email_route,
+        "send_email",
+        lambda **kw: {"id": "msg_db_fail"},
+    )
+    monkeypatch.setattr(
+        email_route,
+        "_connect",
+        lambda: (_ for _ in ()).throw(RuntimeError("db down")),
+    )
+    resp = client.post(
+        "/api/email/send",
+        json={"to": "x@y.com", "subject": "s", "body_text": "t"},
+    )
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["message_id"] == "msg_db_fail"
+    assert body["warning"] == "tracking_insert_failed"
+    assert "DB insert failed" in body["detail"]
+
+
 def test_send_rejects_no_body(client):
     resp = client.post(
         "/api/email/send",


### PR DESCRIPTION
Supersedes #558. Rebased onto current main. Same change: warning/detail fields on DB insert failure after successful Resend send.

pytest tests/api/test_email_routes.py — 21 passed. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)