### PR TITLE
[ELLIOT] fix(waterfall): correct skip_layers indices to match actual layer numbers

### DIFF
--- a/src/pipeline/email_waterfall.py
+++ b/src/pipeline/email_waterfall.py
@@ -653,7 +653,7 @@ async def discover_email(
         html: Cached website HTML from scrape stage
         company_name: Company name for API lookup context
         contact_data: Pre-scraped contact data dict (may contain company_email)
-        skip_layers: List of layer numbers to skip (e.g. [2,3] to skip paid)
+        skip_layers: List of layer numbers to skip (e.g. [3,5] to skip paid)
         contactout_result: Pre-fetched ContactOut enrichment dict (from
             enrich_dm_via_contactout). Caller fetches once and passes to both
             email and mobile waterfalls — no duplicate API calls.
@@ -804,7 +804,7 @@ async def discover_email(
     # Layer 3: Leadmagic find_email (verified — Leadmagic finds real address)
     # Website HTML layer REMOVED (D2.1B GOV-8) — Stage 3 Gemini already reads the
     # website and extracts dm_email + primary_email at zero additional cost.
-    if 2 not in skip and first and last:
+    if 3 not in skip and first and last:
         result = await _leadmagic_lookup(first, last, clean_domain, company_name)
         if result and result.email:
             return result
@@ -830,7 +830,7 @@ async def discover_email(
             )
 
     # Layer 5: Bright Data (unverified)
-    if 3 not in skip:
+    if 5 not in skip:
         result = await _brightdata_lookup(dm_linkedin, clean_domain, company_name)
         if result and result.email:
             return result

--- a/tests/test_email_waterfall.py
+++ b/tests/test_email_waterfall.py
@@ -3,10 +3,9 @@ Tests for email discovery waterfall — Directive #299.
 Covers all 4 layers, short-circuit logic, name parsing, pattern generation,
 orchestrator wiring, and cost tracking.
 """
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/tests/test_email_waterfall.py
+++ b/tests/test_email_waterfall.py
@@ -32,7 +32,7 @@ async def test_layer1_mailto_returns_email():
         domain="pymbledental.com.au",
         dm_name="Michael Chen",
         contact_data={"company_email": "michael.chen@pymbledental.com.au"},
-        skip_layers=[2, 3],
+        skip_layers=[3, 5],
     )
     assert result.email == "michael.chen@pymbledental.com.au"
     assert result.source == "contact_registry"
@@ -48,7 +48,7 @@ async def test_layer1_name_match_gives_high_confidence():
         domain="pymbledental.com.au",
         dm_name="Michael Chen",
         contact_data={"company_email": "michael.chen@pymbledental.com.au"},
-        skip_layers=[2, 3],
+        skip_layers=[3, 5],
     )
     # contact_registry source is unverified, confidence is low
     assert result.confidence == "low"
@@ -63,7 +63,7 @@ async def test_layer1_no_html_falls_through():
         domain="dentist.com.au",
         dm_name="Jane Smith",
         html=None,
-        skip_layers=[2, 3],
+        skip_layers=[3, 5],
     )
     assert result.source == "none"
 
@@ -141,7 +141,7 @@ async def test_layer2_leadmagic_verified_email():
             domain="dentist.com.au",
             dm_name="Michael Chen",
             html=NO_EMAIL_HTML,
-            skip_layers=[1, 3],
+            skip_layers=[1, 5],
         )
 
     assert result.source == "leadmagic"
@@ -169,7 +169,7 @@ async def test_layer2_leadmagic_not_found_falls_through():
             domain="dentist.com.au",
             dm_name="Michael Chen",
             html=NO_EMAIL_HTML,
-            skip_layers=[1, 3],
+            skip_layers=[1, 5],
         )
 
     assert result.email is None
@@ -378,7 +378,7 @@ async def test_contactout_beats_generic_inbox():
         dm_name="Michael Chen",
         html=GENERIC_HTML,
         contactout_result=contactout,
-        skip_layers=[2, 3],  # skip paid layers
+        skip_layers=[3, 5],  # skip paid layers
     )
 
     assert result.email == "michael.chen@dentist.com.au"
@@ -400,7 +400,7 @@ async def test_generic_inbox_falls_through_without_contactout():
         dm_name="Michael Chen",
         html=GENERIC_HTML,
         contactout_result=None,
-        skip_layers=[2, 3],  # skip paid layers
+        skip_layers=[3, 5],  # skip paid layers
     )
 
     # Generic inbox should fall through to generic fallback (not short-circuit)

--- a/tests/test_email_waterfall.py
+++ b/tests/test_email_waterfall.py
@@ -3,6 +3,7 @@ Tests for email discovery waterfall — Directive #299.
 Covers all 4 layers, short-circuit logic, name parsing, pattern generation,
 orchestrator wiring, and cost tracking.
 """
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_hunter_dm_verified_gate.py
+++ b/tests/test_hunter_dm_verified_gate.py
@@ -7,12 +7,10 @@ runtime conditional is enforced — not merely documented.
 
 from __future__ import annotations
 
-import asyncio
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -46,7 +44,7 @@ async def test_hunter_not_called_when_dm_not_verified():
 
         from src.pipeline.email_waterfall import discover_email
 
-        result = await discover_email(
+        await discover_email(
             domain="example.com",
             dm_name="John Doe",
             dm_verified=False,
@@ -71,7 +69,7 @@ async def test_hunter_called_when_dm_verified_and_name_present():
 
         from src.pipeline.email_waterfall import discover_email
 
-        result = await discover_email(
+        await discover_email(
             domain="example.com",
             dm_name="John Doe",
             dm_verified=True,
@@ -101,7 +99,7 @@ async def test_hunter_skipped_when_no_api_key():
 
         from src.pipeline.email_waterfall import discover_email
 
-        result = await discover_email(
+        await discover_email(
             domain="example.com",
             dm_name="John Doe",
             dm_verified=True,

--- a/tests/test_hunter_dm_verified_gate.py
+++ b/tests/test_hunter_dm_verified_gate.py
@@ -50,7 +50,7 @@ async def test_hunter_not_called_when_dm_not_verified():
             domain="example.com",
             dm_name="John Doe",
             dm_verified=False,
-            skip_layers=[1, 2, 3],  # skip paid layers, force Hunter path only
+            skip_layers=[0, 3, 5],  # skip ContactOut, Leadmagic, BrightData — isolate Hunter path
         )
 
     # Hunter GET must never have been called
@@ -75,8 +75,8 @@ async def test_hunter_called_when_dm_verified_and_name_present():
             domain="example.com",
             dm_name="John Doe",
             dm_verified=True,
-            # skip L0 contact_data, L1 contactout, L3 leadmagic so only Hunter runs
-            skip_layers=[2, 3],
+            # skip ContactOut, Leadmagic, BrightData so only Hunter runs
+            skip_layers=[0, 3, 5],
             contactout_result=None,
             contact_data=None,
         )
@@ -105,7 +105,7 @@ async def test_hunter_skipped_when_no_api_key():
             domain="example.com",
             dm_name="John Doe",
             dm_verified=True,
-            skip_layers=[2, 3],
+            skip_layers=[0, 3, 5],
             contactout_result=None,
             contact_data=None,
         )


### PR DESCRIPTION
Supersedes #556 (rebased onto current main).

Layer 3 (Leadmagic) guard checked `2 not in skip` and Layer 5 (BrightData) guard checked `3 not in skip` — both wrong. Fixed to match actual layer numbers. All test skip_layers updated.

pytest tests/test_email_waterfall.py tests/test_hunter_dm_verified_gate.py — 26 passed. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)