### PR TITLE
[AIDEN] feat(campaign_sender): three quality gates before any cold outbound

### DIFF
--- a/scripts/campaign_sender.py
+++ b/scripts/campaign_sender.py
@@ -85,7 +85,16 @@ def fetch_prospects(
     require_verified: bool,
     min_confidence: int,
 ) -> list[Prospect]:
-    """Fetch BU prospects matching vertical, with email + suppression filters."""
+    """Fetch BU prospects matching vertical, with email + suppression + quality filters.
+
+    Quality gates (always on; cold outbound to generic inboxes or unknown DMs
+    burns domain reputation and produces no replies):
+      - Excludes generic inboxes (hello@, info@, reception@, admin@, office@,
+        contact@, sales@, enquiries@, support@, hi@, team@). These rarely reach
+        a decision-maker.
+      - Excludes prospects with NULL dm_name. No first name = no salvageable
+        cold subject line.
+    """
     sql = """
         SELECT bu.id::text, bu.dm_email, bu.dm_name, bu.display_name,
                bu.state, bu.suburb, bu.gmb_category, bu.dm_email_confidence
@@ -94,6 +103,11 @@ def fetch_prospects(
           ON LOWER(gs.email) = LOWER(bu.dm_email)
         WHERE bu.dm_email IS NOT NULL
           AND gs.email IS NULL
+          AND bu.dm_name IS NOT NULL
+          AND LOWER(SPLIT_PART(bu.dm_email, '@', 1)) NOT IN (
+              'hello', 'info', 'reception', 'admin', 'office',
+              'contact', 'sales', 'enquiries', 'support', 'hi', 'team'
+          )
           AND bu.gmb_category ILIKE %s
           AND (NOT %s OR bu.dm_email_verified = TRUE)
           AND COALESCE(bu.dm_email_confidence, 0) >= %s
@@ -118,10 +132,24 @@ def render(template: str, ctx: dict[str, str]) -> str:
     return TAG_RE.sub(lambda m: ctx.get(m.group(1), m.group(0)), template)
 
 
+def clean_display_name(raw: str | None) -> str:
+    """Strip GMB scraper artefacts from display_name before merge-tag substitution.
+
+    GMB titles often carry listing-type suffixes after a pipe ('Foo Agency |
+    Marketing Agency Sydney') that read like junk in a cold-email body. Take
+    the part before the first '|' and trim. Returns 'your practice' when
+    nothing usable remains.
+    """
+    if not raw:
+        return "your practice"
+    head = raw.split("|", 1)[0].strip()
+    return head or "your practice"
+
+
 def build_context(p: Prospect, sender_name: str) -> dict[str, str]:
     return {
         "dm_name": first_name(p.dm_name),
-        "display_name": p.display_name or "your practice",
+        "display_name": clean_display_name(p.display_name),
         "state": p.state or "Australia",
         "suburb": p.suburb or "your area",
         "sender_name": sender_name,


### PR DESCRIPTION
## Summary
- Three always-on data-quality filters added to `scripts/campaign_sender.py` after dry-run on real agency BU rows surfaced ~40% broken cold-outbound copy
- Branched off `aiden/campaign-sender` (PR #560); depends on #560 or rebases against main on merge
- Parallel work: ELLIOT added equivalent gates to `src/engines/campaign_executor.py` in PR #564 (commit d16d574e). Two scripts, same logic, both useful until they consolidate.

## Files changed
- `scripts/campaign_sender.py` (+30/-2)

## Why
Dry-run of `agency_owner_discovery_v2.json` against the BU agency rows (5 prospects, all `dm_email_verified` + `confidence=100`) revealed:
- **1 of 5** — generic inbox (`hello@halcyonagency.com.au`) with `dm_name=NULL`. Subject rendered as *"How are you handling your own outbound, there?"* — visibly broken on receipt.
- **1 of 5** — `display_name = "Online Marketing For Doctors | Medical Marketing Agency Sydney"`. Body rendered "Specifically curious about three things for Online Marketing For Doctors | Medical Marketing Agency Sydney:" — junk-drawer suffix from GMB scraper leaking into copy.

Three of five were clean (Dan @ Axis Social, Brendon @ Social X, Sharon @ Taurus). Even a 60% clean rate is too low for cold outbound on a domain we've spent two weeks warming.

## The gates

**1. Generic-inbox blacklist** — extends the `fetch_prospects` SQL:
```sql
AND LOWER(SPLIT_PART(bu.dm_email, '@', 1)) NOT IN (
    'hello', 'info', 'reception', 'admin', 'office',
    'contact', 'sales', 'enquiries', 'support', 'hi', 'team'
)
```
These local-parts almost never reach a decision-maker. Sending to them only generates bounces and risks complaints.

**2. NULL dm_name filter** — extends the same SQL:
```sql
AND bu.dm_name IS NOT NULL
```
The `first_name()` "there" fallback is fine for body greetings but unsalvageable in subject lines like *"Comparing notes, there?"*.

**3. Display-name cleaning at render time** — new `clean_display_name()` helper:
```python
def clean_display_name(raw: str | None) -> str:
    if not raw: return "your practice"
    head = raw.split("|", 1)[0].strip()
    return head or "your practice"
```
Operator-facing logs keep the raw `display_name` (so scraper-quality issues stay visible to humans); only the merge-tag substitution sees the cleaned version.

## Verification (local)
```
$ python3 scripts/campaign_sender.py --campaign agency_owner_discovery_v2.json \
    --step 1 --limit 5 --vertical-match agen --no-require-verified --min-confidence 0
```
**Before:** 2 of 5 broken (subject leak, body cruft).
**After:** 5 of 5 render cleanly. Generic inbox filtered out, scraper artefacts stripped from copy.

```
$ ruff check scripts/campaign_sender.py
All checks passed!
```

## No new CLI flags
Gates are always on. Cold outbound to a generic inbox or unknown DM is unambiguously bad signal regardless of operator intent. Operator can still bypass `--no-require-verified` for trial runs; generic-inbox + NULL-name remain hard filters.

## Coordination with PR #564
ELLIOT just shipped equivalent gates inside `CampaignExecutor` (commit d16d574e). Same logic, two scripts. Both are useful until we consolidate (which is its own future PR — your call on which script becomes the keeper).

## Test plan
- [x] Dry-run before: 2 of 5 broken
- [x] Dry-run after: 5 of 5 clean
- [x] Generic-inbox prospect filtered out, replaced by next-eligible
- [x] Ruff passes
- [ ] No new unit tests added — this is SQL+template-level. Coverage would require either schema-fixture tests or a future EXPLAIN-against-real-schema gate (per Dave's lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)