### PR TITLE
[ELLIOT] feat(campaign): consolidate sender — CampaignExecutor is canonical

### DIFF
--- a/scripts/campaign_sender.py
+++ b/scripts/campaign_sender.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""scripts/campaign_sender.py — render and (dry-run) send campaign emails.
+"""DEPRECATED — use scripts/run_campaign.py + src/engines/campaign_executor.py instead.
+
+This script is superseded by the CampaignExecutor engine which handles both
+schema formats, parameterized queries, dual tag namespaces, and quality gates.
+
+Original description:
+scripts/campaign_sender.py — render and (dry-run) send campaign emails.
 
 Reads a campaign sequence JSON, queries Supabase business_universe for
 matching prospects with verified emails, replaces merge tags, and either
@@ -14,6 +20,7 @@ Usage:
     python scripts/campaign_sender.py --step 2 --limit 5  # dry-run step 2
     python scripts/campaign_sender.py --live --limit 1    # send 1 real email
 """
+
 from __future__ import annotations
 
 import argparse
@@ -27,9 +34,7 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_ENV_FILE = Path("/home/elliotbot/clawd/Agency_OS/config/.env")
-DEFAULT_CAMPAIGN = Path(
-    "/home/elliotbot/clawd/Agency_OS-max/campaigns/dental_sequence_v1.json"
-)
+DEFAULT_CAMPAIGN = Path("/home/elliotbot/clawd/Agency_OS-max/campaigns/dental_sequence_v1.json")
 MCP_BRIDGE_DIR = Path("/home/elliotbot/clawd/skills/mcp-bridge")
 TAG_RE = re.compile(r"\{\{\s*(\w+)\s*\}\}")
 
@@ -46,17 +51,13 @@ def load_env(path: Path) -> None:
 
 
 def psycopg_dsn() -> str:
-    url = (
-        os.environ.get("DATABASE_URL")
-        or os.environ.get("DATABASE_URL_MIGRATIONS")
-        or ""
-    )
+    url = os.environ.get("DATABASE_URL") or os.environ.get("DATABASE_URL_MIGRATIONS") or ""
     if not url:
         sys.exit("ERROR: DATABASE_URL not configured (looked in env + .env file)")
     if url.startswith("postgresql+asyncpg://"):
-        url = "postgresql://" + url[len("postgresql+asyncpg://"):]
+        url = "postgresql://" + url[len("postgresql+asyncpg://") :]
     elif url.startswith("postgres+asyncpg://"):
-        url = "postgresql://" + url[len("postgres+asyncpg://"):]
+        url = "postgresql://" + url[len("postgres+asyncpg://") :]
     return url
 
 
@@ -129,7 +130,12 @@ def build_context(p: Prospect, sender_name: str) -> dict[str, str]:
 
 
 def send_via_mcp(
-    *, to: str, subject: str, html: str, text: str, sender: str,
+    *,
+    to: str,
+    subject: str,
+    html: str,
+    text: str,
+    sender: str,
 ) -> dict[str, Any]:
     payload = {
         "from_address": sender,
@@ -140,7 +146,11 @@ def send_via_mcp(
     }
     proc = subprocess.run(
         [
-            "node", "scripts/mcp-bridge.js", "call", "resend", "send_email",
+            "node",
+            "scripts/mcp-bridge.js",
+            "call",
+            "resend",
+            "send_email",
             json.dumps(payload),
         ],
         cwd=MCP_BRIDGE_DIR,
@@ -176,14 +186,18 @@ def main() -> int:
     )
     ap.add_argument("--min-confidence", type=int, default=70)
     ap.add_argument(
-        "--require-verified", action=argparse.BooleanOptionalAction, default=True,
+        "--require-verified",
+        action=argparse.BooleanOptionalAction,
+        default=True,
     )
     ap.add_argument(
-        "--vertical-match", default=None,
+        "--vertical-match",
+        default=None,
         help="Override gmb_category ILIKE pattern (default derived from campaign vertical)",
     )
     ap.add_argument(
-        "--live", action="store_true",
+        "--live",
+        action="store_true",
         help="Actually send via Resend (default = dry-run, no network call)",
     )
     args = ap.parse_args()
@@ -211,7 +225,9 @@ def main() -> int:
     print(f"campaign        : {campaign.get('campaign_name')}")
     print(f"step            : {args.step}/{len(steps)}  delay_days={template.get('delay_days')}")
     print(f"vertical pattern: {pattern}  (campaign vertical={campaign.get('vertical')})")
-    print(f"filters         : verified={args.require_verified}, min_confidence={args.min_confidence}")
+    print(
+        f"filters         : verified={args.require_verified}, min_confidence={args.min_confidence}"
+    )
     print(f"prospects found : {len(prospects)} (limit={args.limit})")
     print(f"from            : {args.from_address}")
     print()
@@ -224,9 +240,7 @@ def main() -> int:
         api_key = os.environ.get("RESEND_API_KEY", "")
         if not api_key:
             sys.exit("ERROR: --live set but RESEND_API_KEY missing")
-        confirm = input(
-            f"About to send {len(prospects)} REAL emails. Type 'SEND' to confirm: "
-        )
+        confirm = input(f"About to send {len(prospects)} REAL emails. Type 'SEND' to confirm: ")
         if confirm.strip() != "SEND":
             print("Aborted.")
             return 1

--- a/src/engines/campaign_executor.py
+++ b/src/engines/campaign_executor.py
@@ -26,6 +26,13 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _clean_display_name(name: str | None) -> str | None:
+    """Strip GMB scraper cruft from display_name (e.g. ' | Medical Marketing Agency Sydney')."""
+    if not name:
+        return name
+    return name.split(" | ")[0].strip()
+
+
 @dataclass
 class ProspectRecord:
     """A BU row eligible for outreach."""
@@ -34,8 +41,10 @@ class ProspectRecord:
     domain: str
     dm_email: str
     dm_name: str | None = None
-    company_name: str | None = None
-    industry: str | None = None
+    display_name: str | None = None
+    gmb_category: str | None = None
+    state: str | None = None
+    suburb: str | None = None
 
 
 @dataclass
@@ -93,34 +102,75 @@ class CampaignExecutor:
 
         # Load sequence
         if sequence_steps:
-            self.steps = [SequenceStep(**s) for s in sequence_steps]
+            self.steps = [SequenceStep(**self._normalize_step(s)) for s in sequence_steps]
         elif sequence_path:
             self.steps = self._load_sequence(sequence_path)
         else:
             raise ValueError("Either sequence_path or sequence_steps required")
 
     @staticmethod
+    def _normalize_step(raw: dict) -> dict:
+        """Normalize step dict to SequenceStep fields.
+
+        Handles both schemas:
+        - Ours: {"step_number": 1, "subject_template": "...", "body_template": "..."}
+        - Aiden's: {"step": 1, "subject": "...", "body_text": "...", "body_html": "..."}
+        """
+        out = dict(raw)
+        # step → step_number
+        if "step" in out and "step_number" not in out:
+            out["step_number"] = out.pop("step")
+        # subject → subject_template
+        if "subject" in out and "subject_template" not in out:
+            out["subject_template"] = out.pop("subject")
+        # body_text or body_html → body_template
+        if "body_template" not in out:
+            out["body_template"] = out.pop("body_text", None) or out.pop("body_html", "")
+        # Drop extra keys that SequenceStep doesn't accept
+        valid = {"step_number", "subject_template", "body_template", "delay_days", "channel"}
+        return {k: v for k, v in out.items() if k in valid}
+
+    @staticmethod
     def _load_sequence(path: str) -> list[SequenceStep]:
-        """Load sequence steps from a JSON file."""
+        """Load sequence steps from a JSON file.
+
+        Accepts both schema variants:
+        - {"steps": [...]} (CampaignExecutor native)
+        - {"emails": [...]} (campaign_sender.py / Aiden's format)
+        """
         data = json.loads(Path(path).read_text())
-        steps_data = data.get("steps") or data
+        steps_data = data.get("steps") or data.get("emails") or data
         if isinstance(steps_data, list):
-            return [SequenceStep(**s) for s in steps_data]
+            return [SequenceStep(**CampaignExecutor._normalize_step(s)) for s in steps_data]
         raise ValueError(f"Invalid sequence format in {path}")
 
     def _render_template(self, template: str, prospect: ProspectRecord) -> str:
-        """Replace merge tags in a template string."""
+        """Replace merge tags in a template string.
+
+        Supports both tag namespaces:
+        - Native: {{first_name}}, {{company_name}}, {{domain}}, {{industry}}
+        - Aiden's: {{dm_name}}, {{display_name}}, {{state}}, {{suburb}}, {{sender_name}}
+        """
         first_name = ""
         if prospect.dm_name:
             parts = prospect.dm_name.strip().split()
             first_name = parts[0] if parts else ""
 
         replacements = {
+            # Native namespace
             "{{first_name}}": first_name or "there",
-            "{{company_name}}": prospect.company_name or "your practice",
+            "{{company_name}}": prospect.display_name or "your practice",
             "{{domain}}": prospect.domain or "",
-            "{{industry}}": prospect.industry or "",
+            "{{industry}}": prospect.gmb_category or "",
             "{{email}}": prospect.dm_email or "",
+            # Aiden's namespace
+            "{{dm_name}}": first_name or "there",
+            "{{display_name}}": _clean_display_name(prospect.display_name) or "your practice",
+            "{{state}}": prospect.state or "Australia",
+            "{{suburb}}": prospect.suburb or "your area",
+            "{{sender_name}}": self.from_address.split("<")[0].strip()
+            if "<" in self.from_address
+            else self.from_address.split("@")[0],
         }
         result = template
         for tag, value in replacements.items():
@@ -128,41 +178,58 @@ class CampaignExecutor:
         return result
 
     async def _fetch_prospects(self) -> list[ProspectRecord]:
-        """Query BU for eligible prospects."""
+        """Query BU for eligible prospects.
+
+        Uses parameterized queries to prevent SQL injection.
+        Column names match actual BU schema: display_name, gmb_category,
+        state, suburb (NOT company_name/industry which don't exist).
+        """
         import asyncpg
 
         dsn = os.environ.get("DATABASE_URL_MIGRATIONS") or os.environ.get("DATABASE_URL", "")
         if dsn.startswith("postgresql+asyncpg://"):
             dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
 
-        where_clauses = [
-            "dm_email IS NOT NULL",
-            "dm_email_verified = true",
-            f"COALESCE(dm_email_confidence, 0) >= {self.min_confidence}",
-            "NOT EXISTS (SELECT 1 FROM public.global_suppression gs WHERE LOWER(gs.email) = LOWER(bu.dm_email))",
-        ]
+        params: list = [self.min_confidence, self.daily_limit]
+        industry_clause = ""
         if self.filter_industry:
-            where_clauses.append(f"industry ILIKE '%{self.filter_industry}%'")
+            industry_clause = "AND gmb_category ILIKE $3"
+            params.append(f"%{self.filter_industry}%")
 
         sql = (
-            "SELECT id::text, domain, dm_email, dm_name, company_name, industry "
+            "SELECT id::text, domain, dm_email, dm_name, display_name, "
+            "       gmb_category, state, suburb "
             "FROM public.business_universe bu "
-            f"WHERE {' AND '.join(where_clauses)} "
-            f"ORDER BY COALESCE(dm_email_confidence, 0) DESC "
-            f"LIMIT {self.daily_limit}"
+            "WHERE dm_email IS NOT NULL "
+            "  AND dm_name IS NOT NULL "
+            "  AND dm_email_verified = true "
+            "  AND COALESCE(dm_email_confidence, 0) >= $1 "
+            "  AND LOWER(SPLIT_PART(dm_email, '@', 1)) NOT IN ("
+            "    'hello','info','reception','admin','office',"
+            "    'contact','sales','enquiries','support','hi','team'"
+            "  ) "
+            "  AND NOT EXISTS ("
+            "    SELECT 1 FROM public.global_suppression gs "
+            "    WHERE LOWER(gs.email) = LOWER(bu.dm_email)"
+            "  ) "
+            f"  {industry_clause} "
+            "ORDER BY COALESCE(dm_email_confidence, 0) DESC "
+            "LIMIT $2"
         )
 
         conn = await asyncpg.connect(dsn)
         try:
-            rows = await conn.fetch(sql)
+            rows = await conn.fetch(sql, *params)
             return [
                 ProspectRecord(
                     id=r["id"],
                     domain=r["domain"] or "",
                     dm_email=r["dm_email"],
                     dm_name=r.get("dm_name"),
-                    company_name=r.get("company_name"),
-                    industry=r.get("industry"),
+                    display_name=r.get("display_name"),
+                    gmb_category=r.get("gmb_category"),
+                    state=r.get("state"),
+                    suburb=r.get("suburb"),
                 )
                 for r in rows
             ]

--- a/tests/test_campaign_executor.py
+++ b/tests/test_campaign_executor.py
@@ -36,8 +36,10 @@ def _prospect(email="test@dental.com.au", name="Jane Smith", company="Smile Dent
         domain="dental.com.au",
         dm_email=email,
         dm_name=name,
-        company_name=company,
-        industry="dental",
+        display_name=company,
+        gmb_category="dental",
+        state="NSW",
+        suburb="Pymble",
     )
 
 
@@ -48,9 +50,19 @@ def test_render_template_replaces_tags():
     assert result == "Hi Jane at Smile Dental"
 
 
+def test_render_template_aiden_tags():
+    executor = CampaignExecutor(sequence_steps=SAMPLE_STEPS, step=1)
+    prospect = _prospect()
+    result = executor._render_template(
+        "Hi {{dm_name}} at {{display_name}} in {{suburb}}, {{state}}", prospect
+    )
+    assert result == "Hi Jane at Smile Dental in Pymble, NSW"
+
+
 def test_render_template_fallbacks_when_name_missing():
     executor = CampaignExecutor(sequence_steps=SAMPLE_STEPS, step=1)
     prospect = _prospect(name=None, company=None)
+    # company=None sets display_name=None in _prospect helper
     result = executor._render_template("Hi {{first_name}} at {{company_name}}", prospect)
     assert result == "Hi there at your practice"
 
@@ -106,3 +118,42 @@ def test_load_sequence_from_json(tmp_path):
     executor = CampaignExecutor(sequence_path=str(seq_file), step=1)
     assert len(executor.steps) == 2
     assert executor.steps[0].subject_template == SAMPLE_STEPS[0]["subject_template"]
+
+
+def test_compat_shim_aiden_schema():
+    """Aiden's schema uses 'emails' with 'step'/'subject'/'body_text' keys."""
+    aiden_steps = [
+        {
+            "step": 1,
+            "delay_days": 0,
+            "subject": "20 mins on AU agency tooling, {{dm_name}}?",
+            "body_text": "Hi {{dm_name}}, this is a test.",
+            "body_html": "<p>Hi {{dm_name}}</p>",
+        },
+    ]
+    executor = CampaignExecutor(sequence_steps=aiden_steps, step=1)
+    assert len(executor.steps) == 1
+    assert executor.steps[0].step_number == 1
+    assert executor.steps[0].subject_template == "20 mins on AU agency tooling, {{dm_name}}?"
+    assert executor.steps[0].body_template == "Hi {{dm_name}}, this is a test."
+
+
+def test_compat_shim_aiden_json(tmp_path):
+    """Load Aiden's 'emails' format from JSON."""
+    aiden_seq = {
+        "campaign_name": "test",
+        "emails": [
+            {
+                "step": 1,
+                "delay_days": 0,
+                "subject": "Test subject",
+                "body_text": "Test body",
+            },
+        ],
+    }
+    seq_file = tmp_path / "aiden_seq.json"
+    seq_file.write_text(json.dumps(aiden_seq))
+    executor = CampaignExecutor(sequence_path=str(seq_file), step=1)
+    assert len(executor.steps) == 1
+    assert executor.steps[0].step_number == 1
+    assert executor.steps[0].subject_template == "Test subject"


### PR DESCRIPTION
## Summary
Consolidates overlapping campaign sender implementations per Max's directive.

- `CampaignExecutor` (`src/engines/campaign_executor.py`) is the canonical sender
- `scripts/campaign_sender.py` marked DEPRECATED with redirect
- All quality gates from #572 pulled into executor (generic-inbox blacklist, dm_name NOT NULL, display_name cleaning)
- All #564 review fixes included (correct schema, dual tag namespaces, parameterized SQL)

Supersedes PRs #560, #564, #572 scope.

## Test plan
- [x] `pytest tests/test_campaign_executor.py` — 10 passed
- [x] `ruff check` + `ruff format` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)