### PR TITLE
[ELLIOT] feat(campaign): per-step send tracking — prevents duplicate sends

### DIFF
--- a/scripts/run_campaign.py
+++ b/scripts/run_campaign.py
@@ -45,6 +45,9 @@ async def main():
     parser.add_argument("--industry", help="Filter by industry (ILIKE match)")
     parser.add_argument("--min-confidence", type=int, default=70, help="Min dm_email_confidence")
     parser.add_argument("--from-address", help="Sender email address")
+    parser.add_argument(
+        "--campaign-name", help="Campaign name for send tracking (default: from JSON)"
+    )
     parser.add_argument("--live", action="store_true", help="Actually send (default: dry run)")
     args = parser.parse_args()
 
@@ -65,6 +68,7 @@ async def main():
         from_address=args.from_address,
         filter_industry=args.industry,
         min_confidence=args.min_confidence,
+        campaign_name=args.campaign_name,
     )
 
     results = await executor.run()

--- a/src/engines/campaign_executor.py
+++ b/src/engines/campaign_executor.py
@@ -88,6 +88,7 @@ class CampaignExecutor:
         from_address: str | None = None,
         filter_industry: str | None = None,
         min_confidence: int = 70,
+        campaign_name: str | None = None,
     ):
         self.step = step
         self.daily_limit = daily_limit
@@ -98,13 +99,17 @@ class CampaignExecutor:
         )
         self.filter_industry = filter_industry
         self.min_confidence = min_confidence
+        self.campaign_name = campaign_name or "default"
         self._results: list[SendResult] = []
 
         # Load sequence
         if sequence_steps:
             self.steps = [SequenceStep(**self._normalize_step(s)) for s in sequence_steps]
         elif sequence_path:
-            self.steps = self._load_sequence(sequence_path)
+            data = json.loads(Path(sequence_path).read_text())
+            if campaign_name is None and "campaign_name" in data:
+                self.campaign_name = data["campaign_name"]
+            self.steps = self._load_sequence_data(data)
         else:
             raise ValueError("Either sequence_path or sequence_steps required")
 
@@ -131,18 +136,17 @@ class CampaignExecutor:
         return {k: v for k, v in out.items() if k in valid}
 
     @staticmethod
-    def _load_sequence(path: str) -> list[SequenceStep]:
-        """Load sequence steps from a JSON file.
+    def _load_sequence_data(data: dict) -> list[SequenceStep]:
+        """Parse sequence steps from a pre-loaded dict.
 
         Accepts both schema variants:
         - {"steps": [...]} (CampaignExecutor native)
         - {"emails": [...]} (campaign_sender.py / Aiden's format)
         """
-        data = json.loads(Path(path).read_text())
         steps_data = data.get("steps") or data.get("emails") or data
         if isinstance(steps_data, list):
             return [SequenceStep(**CampaignExecutor._normalize_step(s)) for s in steps_data]
-        raise ValueError(f"Invalid sequence format in {path}")
+        raise ValueError("Invalid sequence format: expected 'steps' or 'emails' list")
 
     def _render_template(self, template: str, prospect: ProspectRecord) -> str:
         """Replace merge tags in a template string.
@@ -190,10 +194,11 @@ class CampaignExecutor:
         if dsn.startswith("postgresql+asyncpg://"):
             dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
 
-        params: list = [self.min_confidence, self.daily_limit]
+        # $1=min_confidence, $2=limit, $3=campaign_name, $4=step_number
+        params: list = [self.min_confidence, self.daily_limit, self.campaign_name, self.step]
         industry_clause = ""
         if self.filter_industry:
-            industry_clause = "AND gmb_category ILIKE $3"
+            industry_clause = "AND gmb_category ILIKE $5"
             params.append(f"%{self.filter_industry}%")
 
         sql = (
@@ -211,6 +216,11 @@ class CampaignExecutor:
             "  AND NOT EXISTS ("
             "    SELECT 1 FROM public.global_suppression gs "
             "    WHERE LOWER(gs.email) = LOWER(bu.dm_email)"
+            "  ) "
+            "  AND NOT EXISTS ("
+            "    SELECT 1 FROM public.campaign_sends cs "
+            "    WHERE cs.dm_email = bu.dm_email "
+            "    AND cs.campaign_name = $3 AND cs.step_number = $4"
             "  ) "
             f"  {industry_clause} "
             "ORDER BY COALESCE(dm_email_confidence, 0) DESC "
@@ -235,6 +245,41 @@ class CampaignExecutor:
             ]
         finally:
             await conn.close()
+
+    async def _record_send(
+        self,
+        prospect: ProspectRecord,
+        step: SequenceStep,
+        message_id: str,
+    ) -> None:
+        """Record a successful send in campaign_sends to prevent duplicates."""
+        import asyncpg
+
+        dsn = os.environ.get("DATABASE_URL_MIGRATIONS") or os.environ.get("DATABASE_URL", "")
+        if dsn.startswith("postgresql+asyncpg://"):
+            dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+        try:
+            conn = await asyncpg.connect(dsn)
+            try:
+                await conn.execute(
+                    "INSERT INTO public.campaign_sends "
+                    "(prospect_id, dm_email, campaign_name, step_number, message_id, status) "
+                    "VALUES ($1::uuid, $2, $3, $4, $5, 'sent') "
+                    "ON CONFLICT (campaign_name, step_number, dm_email) DO NOTHING",
+                    prospect.id,
+                    prospect.dm_email,
+                    self.campaign_name,
+                    step.step_number,
+                    message_id,
+                )
+            finally:
+                await conn.close()
+        except Exception as exc:
+            logger.error(
+                "[campaign] failed to record send: to=%s error=%s",
+                prospect.dm_email,
+                exc,
+            )
 
     async def _send_one(self, prospect: ProspectRecord, step: SequenceStep) -> SendResult:
         """Send one email to a prospect for a given sequence step."""
@@ -268,6 +313,7 @@ class CampaignExecutor:
                 prospect.dm_email,
                 message_id,
             )
+            await self._record_send(prospect, step, message_id)
             return SendResult(
                 prospect_id=prospect.id,
                 email=prospect.dm_email,

--- a/supabase/migrations/20260506_campaign_sends.sql
+++ b/supabase/migrations/20260506_campaign_sends.sql
@@ -1,0 +1,23 @@
+-- FILE: supabase/migrations/20260506_campaign_sends.sql
+-- PURPOSE: Track per-step campaign sends to prevent duplicate outreach
+-- TASK: Per-step send tracking for CampaignExecutor
+
+CREATE TABLE IF NOT EXISTS public.campaign_sends (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    prospect_id UUID NOT NULL,
+    dm_email TEXT NOT NULL,
+    campaign_name TEXT NOT NULL,
+    step_number INTEGER NOT NULL,
+    message_id TEXT,
+    status TEXT NOT NULL DEFAULT 'sent',
+    sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Unique constraint: one send per prospect per campaign per step
+    CONSTRAINT unique_campaign_step_prospect UNIQUE (campaign_name, step_number, dm_email)
+);
+
+CREATE INDEX idx_campaign_sends_lookup
+    ON public.campaign_sends (campaign_name, step_number, dm_email);
+
+CREATE INDEX idx_campaign_sends_prospect
+    ON public.campaign_sends (prospect_id);

--- a/tests/test_campaign_executor.py
+++ b/tests/test_campaign_executor.py
@@ -157,3 +157,30 @@ def test_compat_shim_aiden_json(tmp_path):
     assert len(executor.steps) == 1
     assert executor.steps[0].step_number == 1
     assert executor.steps[0].subject_template == "Test subject"
+    assert executor.campaign_name == "test"  # extracted from JSON
+
+
+def test_campaign_name_from_json(tmp_path):
+    """campaign_name is extracted from the sequence JSON when not provided."""
+    seq = {"campaign_name": "dental_intro_v1", "steps": SAMPLE_STEPS}
+    seq_file = tmp_path / "named.json"
+    seq_file.write_text(json.dumps(seq))
+    executor = CampaignExecutor(sequence_path=str(seq_file), step=1)
+    assert executor.campaign_name == "dental_intro_v1"
+
+
+def test_campaign_name_override(tmp_path):
+    """Explicit campaign_name overrides the JSON value."""
+    seq = {"campaign_name": "from_json", "steps": SAMPLE_STEPS}
+    seq_file = tmp_path / "override.json"
+    seq_file.write_text(json.dumps(seq))
+    executor = CampaignExecutor(
+        sequence_path=str(seq_file), step=1, campaign_name="explicit_override"
+    )
+    assert executor.campaign_name == "explicit_override"
+
+
+def test_campaign_name_default():
+    """campaign_name defaults to 'default' when not provided."""
+    executor = CampaignExecutor(sequence_steps=SAMPLE_STEPS, step=1)
+    assert executor.campaign_name == "default"


### PR DESCRIPTION
## Summary
Adds `campaign_sends` table and wires into CampaignExecutor to prevent duplicate sends on re-run.

- `_fetch_prospects` excludes already-sent prospects via `NOT EXISTS` on `campaign_sends`
- `_record_send` persists successful sends after each Resend call
- `campaign_name` auto-extracted from sequence JSON or passed via `--campaign-name`
- Unique constraint `(campaign_name, step_number, dm_email)` enforces at DB level
- Migration applied to prod

**This was the last blocker for `--live` usage.**

## Files changed
- `src/engines/campaign_executor.py` — `_record_send()`, `_fetch_prospects` exclusion, `campaign_name` param
- `scripts/run_campaign.py` — `--campaign-name` CLI flag
- `tests/test_campaign_executor.py` — 3 new tests (name from JSON, override, default)
- `supabase/migrations/20260506_campaign_sends.sql` — new table + indexes

## Test plan
- [x] `pytest tests/test_campaign_executor.py` — 13 passed
- [x] `ruff check` + `ruff format` — all passed
- [x] Migration applied to prod via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)