### PR TITLE
[AIDEN] feat(mcp-bridge): wire smartlead — LeadMagic MCP server (116+ tools)

### DIFF
--- a/skills/mcp-bridge/scripts/mcp-bridge.js
+++ b/skills/mcp-bridge/scripts/mcp-bridge.js
@@ -67,7 +67,12 @@ const MCP_SERVERS = {
     salesforge: {
         path: "/home/elliotbot/clawd/mcp-servers/salesforge-mcp/dist/index.js",
         env: { SALESFORGE_API_KEY: process.env.SALESFORGE_API_KEY || "" },
-        description: "Salesforge outreach - campaigns, sequences, leads",
+        description: "Salesforge outreach - DEAD (invalid API key as of 2026-05-06). Use smartlead instead.",
+    },
+    smartlead: {
+        npx: "smartlead-mcp-by-leadmagic",
+        env: { SMARTLEAD_API_KEY: process.env.SMARTLEAD_API_KEY || "" },
+        description: "Smartlead cold-outbound (LeadMagic MCP, 116+ tools across campaigns, leads, accounts, analytics, smart-delivery, smart-senders, webhooks, client mgmt). Pro plan required.",
     },
     vapi: {
         path: "/home/elliotbot/clawd/mcp-servers/vapi-mcp/dist/index.js",

--- a/skills/mcp-bridge/src/mcp-bridge.ts
+++ b/skills/mcp-bridge/src/mcp-bridge.ts
@@ -80,7 +80,12 @@ const MCP_SERVERS: Record<string, MCPServerConfig> = {
   salesforge: {
     path: "/home/elliotbot/clawd/mcp-servers/salesforge-mcp/dist/index.js",
     env: { SALESFORGE_API_KEY: process.env.SALESFORGE_API_KEY || "" },
-    description: "Salesforge outreach - campaigns, sequences, leads",
+    description: "Salesforge outreach - DEAD (invalid API key as of 2026-05-06). Use smartlead instead.",
+  },
+  smartlead: {
+    npx: "smartlead-mcp-by-leadmagic",
+    env: { SMARTLEAD_API_KEY: process.env.SMARTLEAD_API_KEY || "" },
+    description: "Smartlead cold-outbound (LeadMagic MCP, 116+ tools across campaigns, leads, accounts, analytics, smart-delivery, smart-senders, webhooks, client mgmt). Pro plan required.",
   },
   vapi: {
     path: "/home/elliotbot/clawd/mcp-servers/vapi-mcp/dist/index.js",


### PR DESCRIPTION
## Summary
- Adds `smartlead` server to the mcp-bridge registry per MAX's 2026-05-06 greenlight ("Go ahead on MCP bridge wire. Low risk prep work.")
- Wires the LeadMagic open-source MCP server (`smartlead-mcp-by-leadmagic` on npm) as a LAW VI fallback path
- Side-effect: marks `salesforge` registry entry as DEAD with redirect to `smartlead` (per Manual blocker table)
- 12 lines changed across two files (TS source + JS compiled output)

## Files changed
- `skills/mcp-bridge/src/mcp-bridge.ts` (+5 / -1)
- `skills/mcp-bridge/scripts/mcp-bridge.js` (+5 / -1)

## Why
Per the build-vs-buy decision ELLIOT and I dual-concurred on after the deep-dive (#578 / TG group):

- **Skill spec** (`skills/smartlead/SKILL.md`, merged via #563+#578) is the **canonical contract** — what callers can rely on.
- **MCP server** (this PR) is the **operational dispatcher** — same pattern as `prefect`, `railway`, `supabase`, `dataforseo`.
- **Direct Python client** (`src/integrations/smartlead_client.py`) **deferred** until evidence shows MCP is insufficient. Saves ~500 lines of code we'd otherwise duplicate.

ELLIOT's MCP audit verified the LeadMagic server is legitimate, production-quality, and exposes 116 `registerTool()` calls backed by 75 unique Smartlead API endpoints — vs ~28 endpoints in our skill spec.

## Configuration
```typescript
smartlead: {
  npx: "smartlead-mcp-by-leadmagic",
  env: { SMARTLEAD_API_KEY: process.env.SMARTLEAD_API_KEY || "" },
  description: "Smartlead cold-outbound (LeadMagic MCP, 116+ tools across campaigns, leads, accounts, analytics, smart-delivery, smart-senders, webhooks, client mgmt). Pro plan required.",
}
```

- **npm package:** [smartlead-mcp-by-leadmagic](https://www.npmjs.com/package/smartlead-mcp-by-leadmagic) (LeadMagic-published, MIT)
- **env required:** `SMARTLEAD_API_KEY` (Pro plan minimum **$145 AUD/mo** gates API access)
- **Pattern match:** identical shape to existing `supabase` / `redis` npx entries

## Tool surface unlocked

| Category | Tools | Purpose |
|---|---|---|
| Campaign Management | 14 | Create / pause / resume / clone / schedule |
| Lead Management | 17 | Import, categorise, response analysis, CRM sync |
| Email Accounts | 15 | SMTP setup, warmup, reputation building |
| Analytics | 18 | Real-time metrics, conversion funnels |
| Statistics | 18 | Campaign + warmup tracking |
| Smart Delivery | 11 | Spam testing, deliverability scoring (separate base URL) |
| Smart Senders | 12 | Domain health, sender rotation, mailbox provisioning |
| Webhooks | 9 | Event subscription CRUD |
| Client Management | 8 | Team + API key + workspace mgmt |

## Salesforge cleanup
The `salesforge` registry entry's description now reads:
> Salesforge outreach - DEAD (invalid API key as of 2026-05-06). Use smartlead instead.

The entry stays in the registry rather than getting removed — keeps any historical references resolvable + makes the dead-status visible to anyone who runs `mcp-bridge servers`. Hard removal can come in a follow-up if/when no callers reference it.

## Verification
```
$ cd /home/elliotbot/clawd/skills/mcp-bridge  # outer clone with node_modules
$ node scripts/mcp-bridge.js servers
# Available MCP Servers
## supabase ✓ (npm)
... (existing entries unchanged)
```
The worktree clone lacks `node_modules` (build artefact, not committed); runtime verification post-merge happens when Dave/Max sync the outer clone.

## Governance
- **LAW VI hierarchy preserved:** skills > MCP > exec. Smartlead skill stays canonical; MCP is dispatch.
- **LAW XII:** any future direct-call path for smartlead must still be wrapped by the skill.
- **LAW XIII:** skill update for warmup-endpoints-do-exist correction (per ELLIOT's MCP audit finding that my #578 "warmup config not documented as API" was wrong) queued as a separate follow-up after this lands.

## Test plan
- [x] Both files updated in lockstep (TS source + compiled JS — same edit shape)
- [x] Pattern matches existing `supabase` / `redis` npx entries — no schema deviation
- [x] Outer-clone bridge runs structurally (smoke test on existing entries)
- [ ] Live npx invocation: blocked until `SMARTLEAD_API_KEY` provisioned per MAX/Dave Pro-plan greenlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)