### PR TITLE
[AIDEN] docs(skills/smartlead): LAW XIII — warmup endpoints + MCP wire correction

### DIFF
--- a/skills/smartlead/SKILL.md
+++ b/skills/smartlead/SKILL.md
@@ -213,7 +213,7 @@ Confirmed via Smartlead docs and verified on the 2026-05-06 deep-dive:
 ## Governance
 
 - **LAW II:** all Smartlead costs logged in AUD (subscription is flat-rate so primarily a `$145 AUD/mo` line item, not per-call).
-- **LAW VI:** prefer this skill > MCP > exec. There is currently NO Smartlead MCP server, so all calls go through `src/integrations/smartlead_client.py` and that is wrapped by this skill.
+- **LAW VI (updated 2026-05-06):** prefer this skill > MCP > exec. **Smartlead MCP server now wired** (PR #579) — `mcp-bridge call smartlead <tool>` is the canonical operational dispatch path for the 75 endpoints / 116 tools NOT explicitly listed in this skill. Direct Python client (`src/integrations/smartlead_client.py`) is **deferred** unless evidence shows MCP is insufficient (saves ~500 lines per ELLIOT's audit). The skill stays canonical for the strategic-tool subset documented above; MCP handles the long tail.
 - **LAW XII / XIII:** see Integration Points above.
 - **CEO Directive (2026-05-06):** Smartlead is the canonical replacement for Salesforge. Salesforge integration code (if any survives) is dead-on-import — do not extend, do not reference.
 - **Pre-revenue reality (per memory `feedback_pre_revenue_reality`):** zero clients today. Subscription cost is real money out — confirm with Dave before activating Pro plan.
@@ -228,8 +228,8 @@ Confirmed via Smartlead docs and verified on the 2026-05-06 deep-dive:
 4. **List-campaigns endpoint** — not in current public docs; needed for UI / admin tooling.
 5. **AU deliverability** — run a 50-send Client Zero campaign through a Smartlead-managed AU SMTP and measure inbox-placement before any real volume. **No documented AU warmup partners** — confirmed gap.
 6. **SmartSenders programmatic seat purchase** — `auto-generate-mailboxes` and `bulk-create-accounts` API endpoints exist, but SmartSenders new-seat purchase from partners (Zapmail, InfraInbox, Mailreef) appears UI-driven. Confirm via partner support whether programmatic purchase is exposed.
-7. **Warmup config via API** — start/stop/daily-cap not documented as API endpoints. Confirm with Smartlead support; fall back to UI provisioning + API monitoring if not available.
-8. **Hidden API surface audit** — LeadMagic's GitHub Smartlead MCP server exposes 113 tools, broader than the public helpcenter docs. Audit the MCP server's schema against this skill spec; some "not documented" items above may exist.
+7. ✅ **Warmup config via API** — RESOLVED 2026-05-06 (corrected from prior "not documented" claim): endpoints DO exist per ELLIOT's MCP-server source audit — `PUT /email-accounts/{id}/warmup-settings` (configure), `GET /email-accounts/{id}/warmup-status` (read), `GET /email-accounts/{id}/health-metrics` (deliverability metrics). All three available programmatically.
+8. ✅ **Hidden API surface audit** — RESOLVED 2026-05-06: ELLIOT cloned LeadMagic's `smartlead-mcp-server` repo, verified **116 `registerTool()` calls backed by 75 unique API endpoints** (vs ~28 in this skill prior to update). LAW VI dispatch path: route operational tools via the MCP server (`mcp-bridge call smartlead <tool>`); skill remains the canonical contract. See Build Recommendation below.
 
 ---
 
@@ -273,7 +273,10 @@ Confirmed via Smartlead docs and verified on the 2026-05-06 deep-dive:
 | `verify-domain` (DNS) | ✅ | — |
 | Domain purchase via Namecheap integration | ✅ | — |
 | SmartSenders new-seat purchase from partners | ⚠️ partial | likely partner UI |
-| Warmup config (start/stop/daily-cap) | ❌ not documented | UI |
+| Warmup config — `PUT /email-accounts/{id}/warmup-settings` | ✅ | — |
+| Warmup status — `GET /email-accounts/{id}/warmup-status` | ✅ | — |
+| Warmup health metrics — `GET /email-accounts/{id}/health-metrics` | ✅ | — |
+| Routing tools NOT in this skill (≈47 more) | ✅ via `mcp-bridge call smartlead` | — |
 
 ---
 


### PR DESCRIPTION
## Summary
- Two LAW XIII corrections to `skills/smartlead/SKILL.md` based on the 2026-05-06 deep-dive findings
- 11 lines changed (+7/-4) across the Pending Verification list, the LAW VI governance line, and the Programmatic Provisioning Matrix
- No call-pattern changes — pure documentation currency

## Files changed
- `skills/smartlead/SKILL.md` (+7/-4)

## Why
LAW XIII: "Whenever a fix, pivot, or ratified decision changes how an external service is called, the corresponding skill file in `skills/` must be updated." After yesterday's deep-dive, two skill claims are now wrong:

### Correction 1 — Warmup endpoints DO exist
Pending Verification #7 said "Warmup config via API — start/stop/daily-cap not documented as API endpoints." ELLIOT's audit of the LeadMagic `smartlead-mcp-server` source proved three real endpoints exist:

- `PUT /email-accounts/{id}/warmup-settings` — configure warmup
- `GET /email-accounts/{id}/warmup-status` — read state
- `GET /email-accounts/{id}/health-metrics` — deliverability metrics

Pending Verification item flipped to ✅ RESOLVED. Programmatic Provisioning Matrix updated: the single "Warmup config — ❌ not documented" row split into three rows, all marked ✅ API.

### Correction 2 — Hidden API surface RESOLVED
Pending Verification #8 was "audit the MCP server schema." ELLIOT's audit confirmed **116 `registerTool()` calls backed by 75 unique API endpoints** vs the ~28 in our prior skill spec. Item flipped to ✅ RESOLVED with a pointer to the LAW VI dispatch path.

### Correction 3 — LAW VI section updated to post-#579 reality
The line previously read: *"There is currently NO Smartlead MCP server, so all calls go through `src/integrations/smartlead_client.py`..."* That's no longer true after PR #579 (Smartlead MCP bridge wire, dual-approved by ELLIOT). Replaced with:
- MCP server wired via PR #579, dispatch via `mcp-bridge call smartlead <tool>`
- Direct Python client **deferred** (saves ~500 lines per ELLIOT's audit) unless evidence shows MCP insufficient
- Skill stays canonical for the documented strategic-tool subset; MCP handles the long tail

## Programmatic Provisioning Matrix — before/after

**Before:**
```
| Warmup config (start/stop/daily-cap) | ❌ not documented | UI |
```

**After:**
```
| Warmup config — PUT /email-accounts/{id}/warmup-settings  | ✅ | — |
| Warmup status — GET /email-accounts/{id}/warmup-status    | ✅ | — |
| Warmup health metrics — GET /email-accounts/{id}/health-metrics | ✅ | — |
| Routing tools NOT in this skill (≈47 more) | ✅ via mcp-bridge call smartlead | — |
```

## What's UNCHANGED
- All endpoint signatures and call patterns
- All input parameter constraints / poka-yoke validation
- All error-handling semantics
- All other Caveats and Pending Verification items

## Coordination
- Depends on PR #579 (MCP bridge wire) merging — this PR's LAW VI prose references the bridge entry. If merge order matters, land #579 first; otherwise both are independent text edits and can land in any order.
- Pure doc currency, no test coverage required.

## Test plan
- [x] Markdown structure preserved
- [x] All claims sourced from the 2026-05-06 deep-dive (ELLIOT's MCP audit + the LeadMagic GitHub repo source)
- [x] No call-pattern changes — existing integrations unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)