### PR TITLE
[ELLIOT] feat(pipeline): post-discovery email verification via Leadmagic

### DIFF
--- a/src/integrations/leadmagic.py
+++ b/src/integrations/leadmagic.py
@@ -816,6 +816,48 @@ class LeadmagicClient:
             return CreditBalance()
 
     # ========================================
+    # EMAIL VERIFICATION
+    # ========================================
+
+    async def verify_email(self, email: str) -> dict:
+        """Verify an email address via Leadmagic email-validation endpoint.
+
+        Cost: 1 credit per 4 validations ($0.00375 AUD per email).
+
+        Returns:
+            dict with keys: email, status ('valid'|'invalid'|'risky'|'unknown'),
+            is_deliverable (bool), is_free_provider (bool).
+        """
+        if _is_mock_mode():
+            logger.info("[Leadmagic] MOCK MODE: verify_email %s → valid", email)
+            return {
+                "email": email,
+                "status": "valid",
+                "is_deliverable": True,
+                "is_free_provider": False,
+            }
+
+        if not email or "@" not in email:
+            return {"email": email, "status": "invalid", "is_deliverable": False}
+
+        try:
+            response = await self._request(
+                method="POST",
+                endpoint="/email-validation",
+                data={"email": email.strip().lower()},
+            )
+            status = (response.get("status") or "unknown").lower()
+            return {
+                "email": email,
+                "status": status,
+                "is_deliverable": status in ("valid", "risky"),
+                "is_free_provider": response.get("is_free_provider", False),
+            }
+        except Exception as exc:
+            logger.warning("[Leadmagic] verify_email failed for %s: %s", email, exc)
+            return {"email": email, "status": "unknown", "is_deliverable": False}
+
+    # ========================================
     # BATCH OPERATIONS
     # ========================================
 

--- a/src/orchestration/cohort_runner.py
+++ b/src/orchestration/cohort_runner.py
@@ -48,7 +48,7 @@ from src.intelligence.stage6_enrich import run_stage6_enrich
 from src.intelligence.stage9_social import run_stage9_social
 from src.intelligence.verify_fills import run_verify_fills
 from src.pipeline.contactout_enricher import enrich_dm_via_contactout
-from src.pipeline.email_waterfall import discover_email
+from src.pipeline.email_waterfall import discover_email, verify_discovered_email
 from src.pipeline.latency_tracker import LatencyTracker
 from src.pipeline.mobile_waterfall import run_mobile_waterfall
 from src.pipeline.suppression_manager import SuppressionManager
@@ -640,6 +640,15 @@ async def _run_stage8(
         )
     except Exception as exc:
         domain_data["errors"].append(f"stage8c_email: {exc}")
+
+    # 8c-verify: Post-discovery email verification via Leadmagic
+    # Only fires on unverified emails found by earlier waterfall layers.
+    # Cost: $0.00375 AUD per email (1 credit per 4 validations).
+    if email_result and email_result.email and not email_result.verified:
+        try:
+            email_result = await verify_discovered_email(email_result)
+        except Exception as exc:
+            domain_data["errors"].append(f"stage8c_verify: {exc}")
 
     # 8d: Mobile waterfall (uses contactout_result, no duplicate API call)
     # Pass brightdata_client (bd) and contact_data from Stage 3 identity (Fix D2.2-1)

--- a/src/pipeline/email_waterfall.py
+++ b/src/pipeline/email_waterfall.py
@@ -845,3 +845,46 @@ async def discover_email(
         confidence="low",
         cost_usd=0.0,
     )
+
+
+async def verify_discovered_email(email_result: EmailResult) -> EmailResult:
+    """Post-discovery verification pass via Leadmagic email-validation.
+
+    Called after discover_email() returns an unverified email. Verifies via
+    Leadmagic's email-validation endpoint ($0.00375 AUD per email — 1 credit
+    per 4 validations).
+
+    Only verifies if the email is unverified and non-null. Returns the same
+    EmailResult with verified flag updated.
+    """
+    if not email_result or not email_result.email or email_result.verified:
+        return email_result
+
+    try:
+        from src.config.settings import settings
+
+        if not settings.leadmagic_api_key:
+            logger.warning("verify_discovered_email: LEADMAGIC_API_KEY not set, skipping")
+            return email_result
+
+        async with LeadmagicClient(api_key=settings.leadmagic_api_key) as client:
+            result = await client.verify_email(email_result.email)
+
+        if result.get("is_deliverable"):
+            email_result.verified = True
+            email_result.cost_usd += 0.00375
+            logger.info(
+                "verify_discovered_email VERIFIED: %s (status=%s)",
+                email_result.email,
+                result.get("status"),
+            )
+        else:
+            logger.info(
+                "verify_discovered_email FAILED: %s (status=%s)",
+                email_result.email,
+                result.get("status"),
+            )
+    except Exception as exc:
+        logger.warning("verify_discovered_email error for %s: %s", email_result.email, exc)
+
+    return email_result

--- a/tests/test_email_verify_pass.py
+++ b/tests/test_email_verify_pass.py
@@ -1,0 +1,108 @@
+"""Tests for the post-discovery email verification pass."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.pipeline.email_waterfall import EmailResult, verify_discovered_email
+
+
+@pytest.mark.asyncio
+async def test_verify_sets_verified_true_on_deliverable():
+    """Leadmagic returns deliverable → verified=True."""
+    email_result = EmailResult(
+        email="test@dental.com.au",
+        verified=False,
+        source="pattern",
+        confidence="medium",
+        cost_usd=0.0,
+    )
+    mock_client = AsyncMock()
+    mock_client.verify_email = AsyncMock(
+        return_value={"email": "test@dental.com.au", "status": "valid", "is_deliverable": True}
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.pipeline.email_waterfall.LeadmagicClient", return_value=mock_client):
+        result = await verify_discovered_email(email_result)
+
+    assert result.verified is True
+    assert result.cost_usd == 0.00375
+
+
+@pytest.mark.asyncio
+async def test_verify_leaves_unverified_on_invalid():
+    """Leadmagic returns invalid → verified stays False."""
+    email_result = EmailResult(
+        email="bad@gone.com",
+        verified=False,
+        source="pattern",
+        confidence="medium",
+        cost_usd=0.0,
+    )
+    mock_client = AsyncMock()
+    mock_client.verify_email = AsyncMock(
+        return_value={"email": "bad@gone.com", "status": "invalid", "is_deliverable": False}
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.pipeline.email_waterfall.LeadmagicClient", return_value=mock_client):
+        result = await verify_discovered_email(email_result)
+
+    assert result.verified is False
+    assert result.cost_usd == 0.0
+
+
+@pytest.mark.asyncio
+async def test_verify_skips_already_verified():
+    """Already-verified emails are not re-verified."""
+    email_result = EmailResult(
+        email="verified@dental.com.au",
+        verified=True,
+        source="leadmagic",
+        confidence="high",
+        cost_usd=0.015,
+    )
+    result = await verify_discovered_email(email_result)
+    assert result.verified is True
+    assert result.cost_usd == 0.015  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_verify_skips_null_email():
+    """Null emails are returned as-is."""
+    email_result = EmailResult(
+        email=None,
+        verified=False,
+        source="none",
+        confidence="low",
+        cost_usd=0.0,
+    )
+    result = await verify_discovered_email(email_result)
+    assert result.verified is False
+
+
+@pytest.mark.asyncio
+async def test_verify_handles_api_error_gracefully():
+    """API errors don't crash — email stays unverified."""
+    email_result = EmailResult(
+        email="test@dental.com.au",
+        verified=False,
+        source="pattern",
+        confidence="medium",
+        cost_usd=0.0,
+    )
+    mock_client = AsyncMock()
+    mock_client.verify_email = AsyncMock(side_effect=RuntimeError("API down"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.pipeline.email_waterfall.LeadmagicClient", return_value=mock_client):
+        result = await verify_discovered_email(email_result)
+
+    assert result.verified is False
+    assert result.cost_usd == 0.0


### PR DESCRIPTION
## Summary
Closes F2.1 email verification gap (was 0.4%, 1/250 verified).

- `LeadmagicClient.verify_email()` — new method calling `/email-validation` endpoint
- `verify_discovered_email()` in `email_waterfall.py` — post-discovery verification
- Wired into `cohort_runner.py` after stage 8c email discovery
- Only verifies unverified hits (not misses), preserving cost shape
- Cost: $0.00375 AUD/email (1 credit per 4 validations) — +$0.94 per 250-email batch (+6.7%)

## Files changed
- `src/integrations/leadmagic.py` — `verify_email()` method + mock mode support
- `src/pipeline/email_waterfall.py` — `verify_discovered_email()` function
- `src/orchestration/cohort_runner.py` — wire after stage 8c
- `tests/test_email_verify_pass.py` — 5 tests (deliverable, invalid, already-verified, null, API error)

## Test plan
- [x] `pytest tests/test_email_verify_pass.py` — 5 passed
- [x] `ruff check` + `ruff format` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)