### PR TITLE
[ELLIOT] feat(pipeline): stage-0 backfill script — drains 5,022 undiscovered BU rows

### DIFF
--- a/scripts/backfill_stage0.py
+++ b/scripts/backfill_stage0.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Backfill BU rows stuck at pipeline_stage=0 through the cohort runner.
+
+Selects domains from business_universe where pipeline_stage=0 (discovered
+but never enriched) and feeds them into the existing cohort_runner pipeline
+in configurable batch sizes.
+
+Usage:
+    # Dry run (default) — shows which domains would be processed
+    python scripts/backfill_stage0.py --batch 50
+
+    # Live run — actually processes domains through the pipeline
+    python scripts/backfill_stage0.py --batch 50 --live
+
+    # Offset for resumption after partial run
+    python scripts/backfill_stage0.py --batch 50 --offset 100 --live
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv("/home/elliotbot/.config/agency-os/.env")
+load_dotenv("/home/elliotbot/clawd/Agency_OS/config/.env")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+async def fetch_stage0_domains(batch_size: int, offset: int = 0) -> list[str]:
+    """Query BU for domains stuck at pipeline_stage=0."""
+    import asyncpg
+
+    dsn = os.environ.get("DATABASE_URL_MIGRATIONS") or os.environ.get("DATABASE_URL", "")
+    if dsn.startswith("postgresql+asyncpg://"):
+        dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        rows = await conn.fetch(
+            "SELECT domain FROM public.business_universe "
+            "WHERE pipeline_stage = 0 AND domain IS NOT NULL "
+            "ORDER BY created_at DESC "
+            "LIMIT $1 OFFSET $2",
+            batch_size,
+            offset,
+        )
+        return [r["domain"] for r in rows]
+    finally:
+        await conn.close()
+
+
+async def count_stage0() -> int:
+    """Count total BU rows at pipeline_stage=0."""
+    import asyncpg
+
+    dsn = os.environ.get("DATABASE_URL_MIGRATIONS") or os.environ.get("DATABASE_URL", "")
+    if dsn.startswith("postgresql+asyncpg://"):
+        dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        row = await conn.fetchrow(
+            "SELECT count(*) as cnt FROM public.business_universe WHERE pipeline_stage = 0"
+        )
+        return row["cnt"] if row else 0
+    finally:
+        await conn.close()
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Backfill stage-0 BU rows through pipeline")
+    parser.add_argument("--batch", type=int, default=50, help="Domains per batch (default 50)")
+    parser.add_argument("--offset", type=int, default=0, help="Skip first N rows (for resumption)")
+    parser.add_argument(
+        "--live", action="store_true", help="Actually run pipeline (default: dry run)"
+    )
+    parser.add_argument("--output", help="Output directory for results")
+    args = parser.parse_args()
+
+    total = await count_stage0()
+    logger.info("Stage-0 rows in BU: %d", total)
+
+    if total == 0:
+        print("No stage-0 rows to backfill.")
+        return
+
+    domains = await fetch_stage0_domains(args.batch, args.offset)
+    logger.info("Fetched %d domains (batch=%d, offset=%d)", len(domains), args.batch, args.offset)
+
+    if not domains:
+        print("No domains in this batch range.")
+        return
+
+    mode = "LIVE" if args.live else "DRY-RUN"
+    cost_estimate = len(domains) * 0.25
+    print(f"\n{'=' * 60}")
+    print(f"Stage-0 Backfill — {mode}")
+    print(f"{'=' * 60}")
+    print(f"  Total stage-0 rows:  {total}")
+    print(f"  This batch:          {len(domains)} domains")
+    print(f"  Offset:              {args.offset}")
+    print(f"  Est. cost:           ${cost_estimate:.2f} USD (${cost_estimate * 1.55:.2f} AUD)")
+    print(f"  Remaining after:     {total - args.offset - len(domains)}")
+    print(f"{'=' * 60}\n")
+
+    if not args.live:
+        print("Domains that would be processed:")
+        for i, d in enumerate(domains, 1):
+            print(f"  {i}. {d}")
+        print("\nDry run complete. Use --live to process.")
+        return
+
+    confirm = input(
+        f"About to process {len(domains)} domains (~${cost_estimate:.2f} USD). "
+        "Type BACKFILL to confirm: "
+    ).strip()
+    if confirm != "BACKFILL":
+        print("Aborted.")
+        return
+
+    from src.orchestration.cohort_runner import run_cohort
+
+    logger.info("Starting cohort run for %d domains...", len(domains))
+    try:
+        result = await run_cohort(
+            categories=[],
+            domains_per_category=0,
+            domains=domains,
+            output_dir=args.output,
+        )
+        summary = result.get("summary", {})
+        print(f"\n{'=' * 60}")
+        print("Backfill Complete")
+        print(f"{'=' * 60}")
+        print(f"  Processed:  {summary.get('total_processed', len(domains))}")
+        print(f"  Passed:     {summary.get('passed', 'N/A')}")
+        print(f"  Dropped:    {summary.get('dropped', 'N/A')}")
+        print(f"  Errors:     {summary.get('errors', 'N/A')}")
+        print(f"  Cost:       ${summary.get('total_cost_usd', 0):.2f} USD")
+        print(f"{'=' * 60}")
+    except Exception as exc:
+        logger.error("Backfill failed: %s", exc)
+        raise
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_backfill_stage0.py
+++ b/tests/test_backfill_stage0.py
@@ -1,0 +1,46 @@
+"""Tests for the stage-0 backfill script."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_fetch_stage0_domains_returns_list():
+    """fetch_stage0_domains returns a list of domain strings."""
+    from scripts.backfill_stage0 import fetch_stage0_domains
+
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(
+        return_value=[
+            {"domain": "dental1.com.au"},
+            {"domain": "dental2.com.au"},
+        ]
+    )
+    mock_conn.close = AsyncMock()
+
+    with patch("asyncpg.connect", return_value=mock_conn):
+        domains = await fetch_stage0_domains(batch_size=50, offset=0)
+
+    assert domains == ["dental1.com.au", "dental2.com.au"]
+    mock_conn.fetch.assert_called_once()
+    sql = mock_conn.fetch.call_args[0][0]
+    assert "pipeline_stage = 0" in sql
+    assert "LIMIT" in sql
+
+
+@pytest.mark.asyncio
+async def test_count_stage0_returns_int():
+    """count_stage0 returns the count of stage-0 rows."""
+    from scripts.backfill_stage0 import count_stage0
+
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value={"cnt": 5022})
+    mock_conn.close = AsyncMock()
+
+    with patch("asyncpg.connect", return_value=mock_conn):
+        count = await count_stage0()
+
+    assert count == 5022


### PR DESCRIPTION
## Summary
5,022 BU rows stuck at pipeline_stage=0 (discovered but never enriched). This script feeds them into cohort_runner in batches.

- Queries BU for pipeline_stage=0, ordered by created_at DESC
- Configurable batch size (default 50) and offset for resumption
- Dry-run default, --live requires interactive BACKFILL confirmation
- Cost estimate shown before confirmation
- Full drain: ~$1,265 USD ($1,960 AUD) across 101 runs at 50/batch

## Files
- `scripts/backfill_stage0.py` — CLI script
- `tests/test_backfill_stage0.py` — 2 tests

## Test plan
- [x] `pytest tests/test_backfill_stage0.py` — 2 passed
- [x] `ruff check` + `ruff format` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)