### PR TITLE
[AIDEN] feat(pipeline): abn_match shared helper for F2.2 connectors

### DIFF
--- a/src/pipeline/abn_match.py
+++ b/src/pipeline/abn_match.py
@@ -1,0 +1,150 @@
+"""src/pipeline/abn_match.py — shared ABN utilities for F2.2 discovery integrations.
+
+Lightweight helpers used by AusTender, ASIC New Companies, and Seek connectors
+to canonicalise ABNs, clean entity names, and validate ABN checksums BEFORE
+writing to business_universe.
+
+Existing ABN-match logic in src/pipeline/free_enrichment.py
+(FreeEnrichmentService._abn_*) remains untouched — that module is tightly
+coupled to the cohort_runner enrichment flow and out of F2.2 scope. This
+module is for NEW connectors that need to validate + normalise an ABN
+inline before INSERT.
+
+Per LAW XII: F2.2 connectors (AusTender, ASIC, Seek) MUST go through these
+helpers — direct ABN handling outside this module is forbidden.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Public — F2.2 connectors import from here.
+__all__ = [
+    "canonicalize_abn",
+    "is_valid_abn",
+    "clean_entity_name",
+    "ABN_CANONICAL_FORMAT",
+]
+
+# Canonical "XX XXX XXX XXX" — 11 digits in 2-3-3-3 grouping with single-space
+# separators. ABR (Australian Business Register) presents ABNs in this shape;
+# we normalise to it for consistent BU storage and dedup.
+ABN_CANONICAL_FORMAT = "XX XXX XXX XXX"
+
+# ABR's documented ABN checksum weights (algorithm published at
+# https://abr.business.gov.au/Help/AbnFormat).
+_ABN_CHECKSUM_WEIGHTS = (10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19)
+
+# Suffix/prefix patterns that ABR (and ASIC) attach to entity names. Stripped
+# before similarity comparison to reduce false negatives ("ACME PTY LTD" vs
+# "ACME" should match).
+_RE_ENTITY_SUFFIXES = re.compile(
+    r"\s+(PTY\s+LTD|PTY\.?\s+LIMITED|PROPRIETARY\s+LIMITED|PROPRIETARY\s+LTD|"
+    r"LIMITED|LTD\.?|LLC|INC\.?|INCORPORATED|GMBH|TRUST|"
+    r"PARTNERSHIP|PARTNERS|CO\.?|COMPANY)\b\.?$",
+    re.IGNORECASE,
+)
+
+_RE_ENTITY_PREFIXES = re.compile(
+    r"^(THE\s+TRUSTEE\s+FOR\s+|THE\s+TRUSTEE\s+OF\s+|TRUSTEE\s+FOR\s+|"
+    r"AS\s+TRUSTEE\s+FOR\s+|ATF\s+|TRUSTEES?\s+OF\s+|"
+    r"THE\s+(LATE\s+)?ESTATE\s+OF\s+|ESTATE\s+OF\s+|"
+    r"THE\s+|MR\.?\s+|MRS\.?\s+|MS\.?\s+|MISS\s+|DR\.?\s+|PROF\.?\s+)",
+    re.IGNORECASE,
+)
+
+
+def canonicalize_abn(raw: str | None) -> str | None:
+    """Normalise an ABN to canonical "XX XXX XXX XXX" format.
+
+    Strips all non-digit characters, validates length (11 digits) and
+    ABN checksum per ABR spec. Returns None on any validation failure.
+
+    Args:
+        raw: ABN string in any format ("12345678901", "12 345 678 901",
+             "12-345-678-901", " 12.345.678.901 " etc.).
+
+    Returns:
+        Canonical "XX XXX XXX XXX" string on valid input. None otherwise.
+
+    Examples:
+        >>> canonicalize_abn("51 824 753 556")
+        '51 824 753 556'
+        >>> canonicalize_abn("51824753556")
+        '51 824 753 556'
+        >>> canonicalize_abn("not-an-abn")  # missing digits
+        >>> canonicalize_abn("12345678901")  # checksum fails
+    """
+    if not raw:
+        return None
+    digits = re.sub(r"\D", "", str(raw))
+    if len(digits) != 11:
+        return None
+    if not is_valid_abn(digits):
+        return None
+    # 2-3-3-3 grouping
+    return f"{digits[0:2]} {digits[2:5]} {digits[5:8]} {digits[8:11]}"
+
+
+def is_valid_abn(digits: str) -> bool:
+    """Validate an 11-digit ABN against the ABR checksum algorithm.
+
+    Per ABR: subtract 1 from the leading digit, multiply each of the 11
+    digits by the documented weights, sum the products, and verify the
+    sum modulo 89 is zero.
+
+    Args:
+        digits: 11-character digit-only string.
+
+    Returns:
+        True iff the ABN passes the ABR checksum.
+    """
+    if not digits or not digits.isdigit() or len(digits) != 11:
+        return False
+    int_digits = [int(d) for d in digits]
+    int_digits[0] -= 1  # ABR-spec adjustment to leading digit
+    weighted_sum = sum(d * w for d, w in zip(int_digits, _ABN_CHECKSUM_WEIGHTS, strict=True))
+    return weighted_sum % 89 == 0
+
+
+def clean_entity_name(name: str | None) -> str:
+    """Strip ABR/ASIC entity suffixes and trustee prefixes for comparison.
+
+    Used before fuzzy name-matching against ABR or BU `display_name` —
+    "DENTISTS @ PYMBLE PTY LIMITED" and "DENTISTS @ PYMBLE" should match
+    even though the legal-form suffix differs.
+
+    Args:
+        name: Raw entity name. None / empty returns "".
+
+    Returns:
+        Cleaned upper-cased name with surrounding whitespace stripped.
+
+    Examples:
+        >>> clean_entity_name("Dentists @ Pymble Pty Limited")
+        'DENTISTS @ PYMBLE'
+        >>> clean_entity_name("THE TRUSTEE FOR ACME TRUST")
+        'ACME'
+        >>> clean_entity_name("Acme Pty Ltd")
+        'ACME'
+        >>> clean_entity_name(None)
+        ''
+    """
+    if not name:
+        return ""
+    s = str(name).strip().upper()
+    # Strip prefixes first (greedy chain — "THE TRUSTEE FOR ..." may also
+    # have a "THE" prefix it strips at the front).
+    prev = None
+    while prev != s:
+        prev = s
+        s = _RE_ENTITY_PREFIXES.sub("", s).strip()
+    # Strip suffixes (also greedy — "X PTY LTD COMPANY" → "X").
+    prev = None
+    while prev != s:
+        prev = s
+        s = _RE_ENTITY_SUFFIXES.sub("", s).strip()
+        # Strip the trailing trust-suffix that some entities carry as the
+        # final word AFTER PTY LTD has been removed.
+        s = re.sub(r"\s+TRUST$", "", s).strip()
+    return s

--- a/tests/pipeline/test_abn_match.py
+++ b/tests/pipeline/test_abn_match.py
@@ -1,0 +1,166 @@
+"""tests/pipeline/test_abn_match.py — unit tests for the F2.2 shared ABN helpers.
+
+Covers canonicalize_abn (digit normalisation + checksum), is_valid_abn
+(ABR checksum algorithm), and clean_entity_name (suffix/prefix stripping
+for fuzzy comparison).
+
+All tests are pure-function — no DB, no network. Fast CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.pipeline.abn_match import (
+    ABN_CANONICAL_FORMAT,
+    canonicalize_abn,
+    clean_entity_name,
+    is_valid_abn,
+)
+
+# A real ABN that passes the ABR checksum (Telstra, public record).
+_VALID_ABN_DIGITS = "33051775556"
+_VALID_ABN_CANONICAL = "33 051 775 556"
+
+
+# ── canonicalize_abn ──────────────────────────────────────────────────────────
+
+
+def test_canonicalize_abn_passthrough_canonical():
+    assert canonicalize_abn(_VALID_ABN_CANONICAL) == _VALID_ABN_CANONICAL
+
+
+def test_canonicalize_abn_strips_separators():
+    assert canonicalize_abn("33-051-775-556") == _VALID_ABN_CANONICAL
+    assert canonicalize_abn("33.051.775.556") == _VALID_ABN_CANONICAL
+    assert canonicalize_abn("  33051775556  ") == _VALID_ABN_CANONICAL
+
+
+def test_canonicalize_abn_no_separators():
+    assert canonicalize_abn(_VALID_ABN_DIGITS) == _VALID_ABN_CANONICAL
+
+
+def test_canonicalize_abn_none_or_empty():
+    assert canonicalize_abn(None) is None
+    assert canonicalize_abn("") is None
+    assert canonicalize_abn("   ") is None
+
+
+def test_canonicalize_abn_wrong_length():
+    assert canonicalize_abn("123") is None
+    assert canonicalize_abn("123456789012") is None  # 12 digits
+
+
+def test_canonicalize_abn_non_digit_after_strip():
+    """Non-digit chars are stripped first; if remainder is wrong length OR
+    fails checksum, result is None either way."""
+    assert canonicalize_abn("not-an-abn-here") is None
+    # "ABN12345678901" → strip → "12345678901" (11 digits) → fails ABR checksum → None
+    assert canonicalize_abn("ABN12345678901") is None
+
+
+def test_canonicalize_abn_invalid_checksum():
+    """11 digits but failing the ABR checksum."""
+    # Trivial wrong: all zeros
+    assert canonicalize_abn("00000000000") is None
+    # Off-by-one of valid (last digit changed)
+    bad = _VALID_ABN_DIGITS[:-1] + "0"
+    if bad != _VALID_ABN_DIGITS:
+        assert canonicalize_abn(bad) is None
+
+
+def test_canonicalize_abn_canonical_format_constant():
+    """Sanity: the documented format constant matches the regex shape we produce."""
+    result = canonicalize_abn(_VALID_ABN_DIGITS)
+    assert result is not None
+    assert len(result) == len(ABN_CANONICAL_FORMAT)
+    assert result.count(" ") == ABN_CANONICAL_FORMAT.count(" ")
+
+
+# ── is_valid_abn ──────────────────────────────────────────────────────────────
+
+
+def test_is_valid_abn_passes_real_abn():
+    assert is_valid_abn(_VALID_ABN_DIGITS) is True
+
+
+def test_is_valid_abn_rejects_zero_padding():
+    assert is_valid_abn("00000000000") is False
+
+
+def test_is_valid_abn_rejects_short():
+    assert is_valid_abn("123") is False
+
+
+def test_is_valid_abn_rejects_non_digit():
+    assert is_valid_abn("abc12345678") is False
+    assert is_valid_abn("12 345 678 901") is False  # spaces not allowed in raw digits
+
+
+def test_is_valid_abn_empty_or_none():
+    assert is_valid_abn("") is False
+    # type: ignore[arg-type] — testing the None guard
+    assert is_valid_abn(None) is False  # type: ignore[arg-type]
+
+
+# ── clean_entity_name ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Acme Pty Ltd", "ACME"),
+        ("Acme PTY. LIMITED", "ACME"),
+        ("Acme Proprietary Limited", "ACME"),
+        ("Acme Limited", "ACME"),
+        ("Acme Ltd", "ACME"),
+        ("ACME LLC", "ACME"),
+        ("ACME, Inc.", "ACME,"),  # comma stays — not part of suffix pattern
+        ("Acme Incorporated", "ACME"),
+        ("Acme Co.", "ACME"),
+        ("Acme Company", "ACME"),
+    ],
+)
+def test_clean_entity_name_strips_suffixes(raw: str, expected: str):
+    assert clean_entity_name(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("THE TRUSTEE FOR ACME TRUST", "ACME"),
+        ("THE TRUSTEE OF ACME TRUST", "ACME"),
+        ("AS TRUSTEE FOR ACME TRUST", "ACME"),
+        ("ATF ACME TRUST", "ACME"),
+        ("THE Acme", "ACME"),
+        ("Mr Smith", "SMITH"),
+        ("Dr. Pymble Dental Pty Ltd", "PYMBLE DENTAL"),
+        ("ESTATE OF JOHN SMITH", "JOHN SMITH"),
+    ],
+)
+def test_clean_entity_name_strips_prefixes(raw: str, expected: str):
+    assert clean_entity_name(raw) == expected
+
+
+def test_clean_entity_name_combined_prefix_and_suffix():
+    """Strip both prefix and suffix in one call."""
+    assert clean_entity_name("THE TRUSTEE FOR PYMBLE DENTAL PTY LTD") == "PYMBLE DENTAL"
+
+
+def test_clean_entity_name_none_or_empty():
+    assert clean_entity_name(None) == ""
+    assert clean_entity_name("") == ""
+    assert clean_entity_name("   ") == ""
+
+
+def test_clean_entity_name_no_changes():
+    """A plain entity name with no recognised prefix/suffix is returned upper-cased."""
+    assert clean_entity_name("Pymble Dental") == "PYMBLE DENTAL"
+    assert clean_entity_name("acme") == "ACME"
+
+
+def test_clean_entity_name_handles_repeated_application():
+    """Repeated application is idempotent."""
+    once = clean_entity_name("Acme Pty Ltd")
+    twice = clean_entity_name(once)
+    assert once == twice


### PR DESCRIPTION
## Summary
- New module `src/pipeline/abn_match.py` (~150 lines) — F2.2-specific ABN canonicalisation + entity-name cleaning helpers
- 35-test unit suite at `tests/pipeline/test_abn_match.py`
- Existing ABN-match logic in `src/pipeline/free_enrichment.py` is **untouched** — that module is tightly coupled to cohort_runner enrichment flow, out of F2.2 scope. This new module is for connectors that need to validate + normalise an ABN inline before INSERT.
- Prerequisite for AusTender / ASIC / Seek connector PRs

## Files changed
- `src/pipeline/abn_match.py` — new (~150 lines)
- `tests/pipeline/test_abn_match.py` — new (35 tests)
- `tests/pipeline/__init__.py` — package marker

## Three public functions

### `canonicalize_abn(raw: str | None) -> str | None`
Strips all non-digit characters, validates 11-digit length and ABR checksum per spec. Returns canonical `'XX XXX XXX XXX'` format on valid input, `None` otherwise.

```python
canonicalize_abn("33 051 775 556")  # → '33 051 775 556'
canonicalize_abn("33051775556")     # → '33 051 775 556'
canonicalize_abn("33-051-775-556")  # → '33 051 775 556'
canonicalize_abn("not-an-abn")      # → None
canonicalize_abn("00000000000")     # → None (checksum fails)
```

### `is_valid_abn(digits: str) -> bool`
Pure function. Implements the documented ABR checksum algorithm: subtract 1 from leading digit, weighted sum mod 89.

### `clean_entity_name(name: str | None) -> str`
Strips ABR/ASIC entity suffixes (`PTY LTD`, `PROPRIETARY LIMITED`, `INC`, `TRUST` etc.) and trustee prefixes (`THE TRUSTEE FOR`, `ATF` etc.) for fuzzy comparison. Returns upper-cased cleaned name.

```python
clean_entity_name("Dentists @ Pymble Pty Limited") → "DENTISTS @ PYMBLE"
clean_entity_name("THE TRUSTEE FOR ACME TRUST")    → "ACME"
clean_entity_name("Dr. Pymble Dental Pty Ltd")     → "PYMBLE DENTAL"
```

## Why a NEW module instead of refactoring existing code

The existing ABN-match logic in `src/pipeline/free_enrichment.py` (`FreeEnrichmentService._abn_*`) is tightly coupled to the cohort_runner enrichment flow:
- `_abn_confidence` uses an enum (`ABNMatchConfidence`) defined elsewhere
- `_local_abn_match` requires a database connection + free-enrichment context
- `_abn_clean_entity_name` is a static method nested in the class

Refactoring those out into a shared helper would touch the live enrichment path — high-risk, no F2.2 benefit. F2.2 connectors only need lightweight stateless utilities: validate + canonicalise + clean. NEW module isolates that surface.

When the existing free_enrichment module is rewritten in a future cycle, the helpers there can switch to importing from `abn_match.py` — but that's a separate refactor, not blocking F2.2.

## Test coverage (35 cases)

- **`canonicalize_abn` — 8 cases:** passthrough, separator stripping (-, ., spaces), no-separators, None/empty, wrong length, non-digit input, invalid checksum, canonical-format constant sanity check
- **`is_valid_abn` — 5 cases:** real ABN passes, zero-padding rejected, short digits rejected, non-digit rejected, None/empty
- **`clean_entity_name` — 22 cases:** parametrised over 10 suffix patterns + 8 prefix patterns, combined prefix+suffix, None/empty, no-changes (idempotent upper-case), repeated-application idempotency

## Verification
```
$ pytest tests/pipeline/test_abn_match.py -v
35 passed in 2.93s

$ ruff check src/pipeline/abn_match.py tests/pipeline/test_abn_match.py
All checks passed!
```

## Per LAW XII
F2.2 connectors (AusTender #583, ASIC #584, Seek #585) MUST go through these helpers. Direct ABN handling outside this module is forbidden. Skill specs reference `src/pipeline/abn_match.py` as the canonical entry point.

## Coordination
- Refactor PR ships first as the prerequisite for the three connector PRs that follow
- Connector PRs (AusTender code, ASIC code, Seek code) will land sequentially after this lands
- No behaviour change to existing code. Safe to merge anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)