### PR TITLE
[AIDEN] feat(pipeline): austender discovery + CLI (F2.2 connector slice 2)

### DIFF
--- a/scripts/ingest_austender.py
+++ b/scripts/ingest_austender.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Daily AusTender ingest — fetch supplier awards and write to BU.
+
+Defaults to dry-run (no DB writes) unless --live is passed. Live mode
+prompts for explicit "INGEST" confirmation before any writes.
+
+Usage:
+    # Yesterday's awards, dry run
+    python scripts/ingest_austender.py
+
+    # Yesterday's awards, live ingest
+    python scripts/ingest_austender.py --live
+
+    # 30-day backfill on first run
+    python scripts/ingest_austender.py --backfill-days 30 --live
+
+    # Specific date range
+    python scripts/ingest_austender.py --date-from 2026-04-01 --date-to 2026-04-07
+
+    # Lower value threshold for noise tuning
+    python scripts/ingest_austender.py --min-value 25000
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv("/home/elliotbot/.config/agency-os/.env")
+load_dotenv("/home/elliotbot/clawd/Agency_OS/config/.env")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def _parse_date(s: str) -> date:
+    return datetime.strptime(s, "%Y-%m-%d").date()
+
+
+async def _connect():
+    """Open an asyncpg connection from DATABASE_URL or DATABASE_URL_MIGRATIONS."""
+    import asyncpg
+
+    dsn = os.environ.get("DATABASE_URL_MIGRATIONS") or os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        sys.exit("ERROR: DATABASE_URL not configured (looked in env + .env file)")
+    if dsn.startswith("postgresql+asyncpg://"):
+        dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+    return await asyncpg.connect(dsn)
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--date-from", type=_parse_date, help="Inclusive lower bound (YYYY-MM-DD)")
+    ap.add_argument("--date-to", type=_parse_date, help="Inclusive upper bound (YYYY-MM-DD)")
+    ap.add_argument(
+        "--backfill-days",
+        type=int,
+        default=None,
+        help="Backfill last N days (overrides date-from/date-to). Use 30 for first-run seed.",
+    )
+    ap.add_argument(
+        "--min-value",
+        type=int,
+        default=50000,
+        help="Minimum AUD contract value (default 50000). Below 1000 rejected as noise.",
+    )
+    ap.add_argument(
+        "--live",
+        action="store_true",
+        help="Actually write to BU (default = dry run, no DB writes).",
+    )
+    args = ap.parse_args()
+
+    # Resolve date range
+    today = date.today()
+    if args.backfill_days is not None:
+        if args.backfill_days < 1 or args.backfill_days > 90:
+            sys.exit("ERROR: --backfill-days must be between 1 and 90")
+        date_from = today - timedelta(days=args.backfill_days)
+        date_to = today - timedelta(days=1)
+    elif args.date_from and args.date_to:
+        date_from = args.date_from
+        date_to = args.date_to
+    else:
+        # Default: yesterday only
+        date_from = today - timedelta(days=1)
+        date_to = today - timedelta(days=1)
+
+    if date_to >= today:
+        sys.exit(f"ERROR: date_to {date_to} must be < today {today}")
+    if date_to < date_from:
+        sys.exit(f"ERROR: date_to {date_to} before date_from {date_from}")
+
+    mode = "LIVE" if args.live else "DRY-RUN"
+    days = (date_to - date_from).days + 1
+
+    print(f"\n{'=' * 60}")
+    print(f"AusTender Ingest — {mode}")
+    print(f"{'=' * 60}")
+    print(f"  Date range:        {date_from} → {date_to}  ({days} day{'s' if days != 1 else ''})")
+    print(f"  Min value (AUD):   {args.min_value:,}")
+    print(f"  Output to BU:      {'YES (writes)' if args.live else 'NO (dry-run logging only)'}")
+    print(f"{'=' * 60}\n")
+
+    if args.live:
+        confirm = input(
+            "About to ingest into business_universe. Type INGEST to confirm: "
+        ).strip()
+        if confirm != "INGEST":
+            print("Aborted.")
+            return 1
+
+    from src.pipeline.austender_discovery import run_ingest
+
+    conn = await _connect() if args.live else None
+    try:
+        result = await run_ingest(
+            date_from=date_from,
+            date_to=date_to,
+            conn=conn,
+            value_min_aud=args.min_value,
+            dry_run=not args.live,
+        )
+    finally:
+        if conn is not None:
+            await conn.close()
+
+    print(f"\n{'=' * 60}")
+    print(f"Ingest Result — {mode}")
+    print(f"{'=' * 60}")
+    print(f"  Fetched (raw OCDS):      {result.fetched}")
+    print(f"  Parsed (typed events):   {result.parsed}")
+    print(f"  Filtered non-AU:         {result.filtered_non_au}")
+    print(f"  Filtered low-value:      {result.filtered_low_value}")
+    if args.live:
+        print(f"  Inserted (new BU rows):  {result.inserted}")
+        print(f"  Updated (existing rows): {result.updated}")
+    else:
+        eligible = result.parsed - result.filtered_non_au - result.filtered_low_value
+        print(f"  Would-write (eligible):  {eligible}")
+    print(f"  Errors:                  {result.errors}")
+    print(f"{'=' * 60}\n")
+
+    return 0 if result.errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/pipeline/austender_discovery.py
+++ b/src/pipeline/austender_discovery.py
@@ -1,0 +1,290 @@
+"""src/pipeline/austender_discovery.py — AusTender → business_universe writer.
+
+Bridges AwardEvent (from src/integrations/austender_client.py) into BU rows.
+For each AU supplier event:
+  - If an existing BU row matches by ABN → UPDATE signal_source / category_baselines
+  - Otherwise INSERT a new minimal row with discovery_source = 'austender_supplier',
+    pipeline_stage = 0 (feeds Stage 2+ on next pipeline run)
+
+Per LAW XII: callers go through skills/austender/SKILL.md (PR #583).
+Per LAW XIII: any change to call patterns updates the skill in the same PR.
+
+Skill spec: skills/austender/SKILL.md.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+from uuid import uuid4
+
+from src.integrations.austender_client import (
+    AusTenderClient,
+    AwardEvent,
+    date_range_chunks,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "IngestResult",
+    "ingest_award_event",
+    "run_ingest",
+]
+
+
+@dataclass
+class IngestResult:
+    """Summary of one AusTender ingest run."""
+
+    fetched: int = 0  # OCDS releases pulled from API
+    parsed: int = 0  # AwardEvents successfully parsed (None-returns excluded)
+    filtered_non_au: int = 0  # parsed but is_au_supplier()==False
+    filtered_low_value: int = 0  # AUD value below threshold
+    inserted: int = 0  # new BU rows
+    updated: int = 0  # existing BU rows (signal refresh)
+    errors: int = 0  # exceptions during write
+
+    def __str__(self) -> str:
+        return (
+            f"fetched={self.fetched} parsed={self.parsed} "
+            f"non_au_filtered={self.filtered_non_au} "
+            f"low_value_filtered={self.filtered_low_value} "
+            f"inserted={self.inserted} updated={self.updated} errors={self.errors}"
+        )
+
+
+_UPDATE_SQL = """
+    UPDATE public.business_universe
+    SET signal_source = 'austender_supplier',
+        signal_checked_at = NOW(),
+        last_signal_refresh = NOW(),
+        category_baselines = COALESCE(category_baselines, '{}'::jsonb) ||
+            jsonb_build_object('austender', $2::jsonb)
+    WHERE abn = $1
+    RETURNING id::text
+"""
+
+
+_INSERT_SQL = """
+    INSERT INTO public.business_universe (
+        id, abn, display_name, discovery_source, discovery_batch_id,
+        signal_source, signal_checked_at, last_signal_refresh,
+        pipeline_stage, category_baselines, created_at, updated_at
+    ) VALUES (
+        gen_random_uuid(), $1, $2, 'austender_supplier', $3,
+        'austender_supplier', NOW(), NOW(),
+        0, jsonb_build_object('austender', $4::jsonb), NOW(), NOW()
+    )
+    ON CONFLICT (abn) DO UPDATE SET
+        signal_source = 'austender_supplier',
+        signal_checked_at = NOW(),
+        last_signal_refresh = NOW(),
+        category_baselines = COALESCE(public.business_universe.category_baselines, '{}'::jsonb) ||
+            jsonb_build_object('austender', $4::jsonb)
+    RETURNING id::text, (xmax = 0) AS inserted
+"""
+
+
+def _build_jsonb_payload(event: AwardEvent) -> dict[str, Any]:
+    """Build the category_baselines.austender jsonb payload from an event."""
+    return {
+        "contract_id": event.contract_id,
+        "contract_value_aud": event.contract_value_aud,
+        "awarded_date": event.awarded_date,
+        "agency_name": event.agency_name,
+        "classification_id": event.classification_id,
+    }
+
+
+async def ingest_award_event(
+    event: AwardEvent,
+    conn,
+    discovery_batch_id: str,
+    *,
+    dry_run: bool = True,
+) -> tuple[str, bool] | None:
+    """Persist one AwardEvent to BU. Returns (bu_id, was_inserted) or None on skip.
+
+    Filters out non-AU suppliers and missing-ABN events upstream — caller is
+    responsible for that. This function assumes the event is AU-supplier valid.
+
+    Args:
+        event: parsed AwardEvent (must have supplier_abn).
+        conn: asyncpg connection.
+        discovery_batch_id: UUID for tracing the run that produced this row.
+        dry_run: when True, logs would-be SQL but does not execute.
+
+    Returns:
+        (bu_id, was_inserted) tuple where was_inserted=True means new row.
+        None on dry-run or invalid event.
+    """
+    if not event.supplier_abn or not event.is_au_supplier():
+        logger.debug("[austender] skipping non-AU/no-ABN event %s", event.contract_id)
+        return None
+
+    payload = _build_jsonb_payload(event)
+    payload_json = json.dumps(payload)
+
+    if dry_run:
+        logger.info(
+            "[austender] DRY-RUN would upsert abn=%s name=%s contract=%s value=%s",
+            event.supplier_abn,
+            event.supplier_name,
+            event.contract_id,
+            event.contract_value_aud,
+        )
+        return None
+
+    # Try UPDATE first (existing BU row); fall back to INSERT if no match.
+    updated_id = await conn.fetchval(_UPDATE_SQL, event.supplier_abn, payload_json)
+    if updated_id:
+        logger.info(
+            "[austender] updated bu=%s abn=%s contract=%s",
+            updated_id,
+            event.supplier_abn,
+            event.contract_id,
+        )
+        return (updated_id, False)
+
+    # No existing row — INSERT
+    row = await conn.fetchrow(
+        _INSERT_SQL,
+        event.supplier_abn,
+        event.supplier_name or "",
+        discovery_batch_id,
+        payload_json,
+    )
+    if row is None:
+        logger.error(
+            "[austender] INSERT returned nothing for abn=%s contract=%s",
+            event.supplier_abn,
+            event.contract_id,
+        )
+        return None
+    bu_id = row["id"]
+    inserted = bool(row["inserted"])
+    logger.info(
+        "[austender] %s bu=%s abn=%s contract=%s",
+        "inserted" if inserted else "updated_via_conflict",
+        bu_id,
+        event.supplier_abn,
+        event.contract_id,
+    )
+    return (bu_id, inserted)
+
+
+async def run_ingest(
+    date_from: date,
+    date_to: date,
+    conn,
+    *,
+    value_min_aud: int = 50000,
+    dry_run: bool = True,
+    client: AusTenderClient | None = None,
+) -> IngestResult:
+    """Top-level: fetch AusTender awards in a date range, parse, persist to BU.
+
+    Splits wide ranges into <=7-day chunks to avoid OCDS timeouts.
+
+    Args:
+        date_from / date_to: inclusive bounds.
+        conn: asyncpg connection.
+        value_min_aud: AUD value floor (default 50000 per skill spec).
+        dry_run: when True, no DB writes.
+        client: optional pre-built AusTenderClient (for tests).
+
+    Returns:
+        IngestResult with counts.
+    """
+    result = IngestResult()
+    discovery_batch_id = str(uuid4())
+    cli = client or AusTenderClient()
+
+    chunks = date_range_chunks(date_from, date_to, step_days=7)
+    logger.info(
+        "[austender] run_ingest from=%s to=%s chunks=%d batch_id=%s dry_run=%s",
+        date_from,
+        date_to,
+        len(chunks),
+        discovery_batch_id,
+        dry_run,
+    )
+
+    for chunk_from, chunk_to in chunks:
+        try:
+            releases = await cli.fetch_awards(
+                date_from=chunk_from,
+                date_to=chunk_to,
+                value_min_aud=value_min_aud,
+            )
+        except Exception as exc:
+            logger.error(
+                "[austender] fetch failed for chunk %s..%s: %s",
+                chunk_from,
+                chunk_to,
+                exc,
+            )
+            result.errors += 1
+            continue
+
+        result.fetched += len(releases)
+
+        for release in releases:
+            event = AwardEvent.from_ocds_release(release)
+            if event is None:
+                continue
+            result.parsed += 1
+
+            if not event.is_au_supplier():
+                result.filtered_non_au += 1
+                continue
+
+            if (
+                event.contract_value_aud is None
+                or event.contract_value_aud < value_min_aud
+            ):
+                result.filtered_low_value += 1
+                continue
+
+            try:
+                outcome = await ingest_award_event(
+                    event,
+                    conn,
+                    discovery_batch_id,
+                    dry_run=dry_run,
+                )
+            except Exception as exc:
+                logger.error(
+                    "[austender] write failed for contract=%s: %s",
+                    event.contract_id,
+                    exc,
+                )
+                result.errors += 1
+                continue
+
+            if outcome is None:
+                continue
+
+            _, was_inserted = outcome
+            if was_inserted:
+                result.inserted += 1
+            else:
+                result.updated += 1
+
+    logger.info("[austender] run_ingest complete: %s", result)
+    return result
+
+
+def yesterday_aest() -> date:
+    """Return yesterday's date in AEST (Australia/Sydney UTC+10/+11).
+
+    Approximation: uses UTC+10 (no DST). Off by 1d for ~half the year on
+    edge cases — acceptable for daily-cron 02:00 AEST scheduling. The
+    OCDS feed is timezone-naive at the date level anyway.
+    """
+    aest_now = datetime.now(timezone(timedelta(hours=10)))
+    return (aest_now - timedelta(days=1)).date()

--- a/tests/pipeline/test_austender_discovery.py
+++ b/tests/pipeline/test_austender_discovery.py
@@ -1,0 +1,329 @@
+"""tests/pipeline/test_austender_discovery.py — unit tests for AusTender → BU writer.
+
+Mocks asyncpg connection + AusTenderClient. No live DB / network.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.integrations.austender_client import AwardEvent
+from src.pipeline.austender_discovery import (
+    IngestResult,
+    _build_jsonb_payload,
+    ingest_award_event,
+    run_ingest,
+    yesterday_aest,
+)
+
+
+def _au_event(
+    *,
+    contract_id: str = "ocds-au-CN1",
+    abn: str = "33 051 775 556",
+    name: str = "Pymble Dental Pty Ltd",
+    value: int | None = 75000,
+) -> AwardEvent:
+    return AwardEvent(
+        contract_id=contract_id,
+        supplier_abn=abn,
+        supplier_name=name,
+        supplier_country="AU",
+        contract_value_aud=value,
+        awarded_date="2026-04-15",
+        agency_name="Department of Health",
+        classification_id="85101701",
+    )
+
+
+# ── _build_jsonb_payload ──────────────────────────────────────────────────────
+
+
+def test_build_jsonb_payload_extracts_all_fields():
+    event = _au_event()
+    payload = _build_jsonb_payload(event)
+    assert payload == {
+        "contract_id": "ocds-au-CN1",
+        "contract_value_aud": 75000,
+        "awarded_date": "2026-04-15",
+        "agency_name": "Department of Health",
+        "classification_id": "85101701",
+    }
+
+
+def test_build_jsonb_payload_handles_none_fields():
+    event = AwardEvent(
+        contract_id="ocds-au-CN2",
+        supplier_abn="33 051 775 556",
+        supplier_name=None,
+        supplier_country="AU",
+        contract_value_aud=None,
+        awarded_date=None,
+        agency_name=None,
+        classification_id=None,
+    )
+    payload = _build_jsonb_payload(event)
+    assert payload["contract_id"] == "ocds-au-CN2"
+    assert payload["contract_value_aud"] is None
+    assert payload["awarded_date"] is None
+
+
+# ── ingest_award_event ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ingest_dry_run_returns_none():
+    """Dry-run path makes no DB calls and returns None."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock()
+    conn.fetchrow = AsyncMock()
+
+    result = await ingest_award_event(_au_event(), conn, "batch-1", dry_run=True)
+    assert result is None
+    conn.fetchval.assert_not_called()
+    conn.fetchrow.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ingest_skips_non_au_supplier():
+    """Non-AU supplier event is filtered (returns None) without DB calls."""
+    event = AwardEvent(
+        contract_id="ocds-foreign-1",
+        supplier_abn=None,  # missing ABN → not AU
+        supplier_name="Foreign Vendor",
+        supplier_country="US",
+        contract_value_aud=100000,
+        awarded_date="2026-04-15",
+        agency_name="DoH",
+        classification_id=None,
+    )
+    conn = MagicMock()
+    conn.fetchval = AsyncMock()
+    conn.fetchrow = AsyncMock()
+
+    result = await ingest_award_event(event, conn, "batch-1", dry_run=False)
+    assert result is None
+    conn.fetchval.assert_not_called()
+    conn.fetchrow.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ingest_existing_row_takes_update_path():
+    """Existing BU row matched by ABN → UPDATE returns id; no INSERT."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="existing-bu-uuid")
+    conn.fetchrow = AsyncMock()
+
+    result = await ingest_award_event(_au_event(), conn, "batch-1", dry_run=False)
+    assert result == ("existing-bu-uuid", False)  # was_inserted=False
+    conn.fetchval.assert_awaited_once()
+    conn.fetchrow.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ingest_new_row_takes_insert_path():
+    """No existing row (UPDATE returns None) → INSERT path."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=None)  # UPDATE matched 0 rows
+    conn.fetchrow = AsyncMock(
+        return_value={"id": "new-bu-uuid", "inserted": True}
+    )
+
+    result = await ingest_award_event(_au_event(), conn, "batch-1", dry_run=False)
+    assert result == ("new-bu-uuid", True)
+    conn.fetchval.assert_awaited_once()
+    conn.fetchrow.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ingest_insert_returning_handles_conflict_path():
+    """INSERT ... ON CONFLICT DO UPDATE — xmax!=0 means conflict, was_inserted=False."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock(
+        return_value={"id": "conflict-bu-uuid", "inserted": False}
+    )
+
+    result = await ingest_award_event(_au_event(), conn, "batch-1", dry_run=False)
+    assert result == ("conflict-bu-uuid", False)
+
+
+# ── run_ingest ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_aggregates_counters():
+    """End-to-end: client returns 3 releases (1 AU/valid, 1 non-AU, 1 low-value) → counters reflect."""
+    # Build mock client returning 3 OCDS releases
+    valid_release = {
+        "ocid": "ocds-au-CN1",
+        "parties": [
+            {
+                "name": "Pymble Dental Pty Ltd",
+                "roles": ["supplier"],
+                "identifier": {"scheme": "AU-ABN", "id": "33051775556"},
+                "address": {"countryName": "AU"},
+            }
+        ],
+        "awards": [
+            {"value": {"amount": 75000, "currency": "AUD"}, "date": "2026-04-15"}
+        ],
+    }
+    non_au_release = {
+        "ocid": "ocds-foreign-1",
+        "parties": [
+            {
+                "name": "US Vendor",
+                "roles": ["supplier"],
+                "identifier": {"scheme": "AU-ABN", "id": "33051775556"},
+                "address": {"countryName": "United States"},
+            }
+        ],
+        "awards": [
+            {"value": {"amount": 100000, "currency": "AUD"}, "date": "2026-04-15"}
+        ],
+    }
+    low_value_release = {
+        "ocid": "ocds-au-CN2",
+        "parties": [
+            {
+                "name": "Tiny Co Pty Ltd",
+                "roles": ["supplier"],
+                "identifier": {"scheme": "AU-ABN", "id": "33051775556"},
+                "address": {"countryName": "AU"},
+            }
+        ],
+        "awards": [
+            {"value": {"amount": 10000, "currency": "AUD"}, "date": "2026-04-15"}
+        ],
+    }
+
+    mock_client = MagicMock()
+    mock_client.fetch_awards = AsyncMock(
+        return_value=[valid_release, non_au_release, low_value_release]
+    )
+
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="existing-uuid")
+    conn.fetchrow = AsyncMock()
+
+    result = await run_ingest(
+        date_from=date(2026, 4, 15),
+        date_to=date(2026, 4, 15),
+        conn=conn,
+        value_min_aud=50000,
+        dry_run=False,
+        client=mock_client,
+    )
+
+    assert result.fetched == 3
+    assert result.parsed == 3
+    assert result.filtered_non_au == 1
+    assert result.filtered_low_value == 1
+    assert result.updated == 1  # the valid one matched existing row
+    assert result.inserted == 0
+    assert result.errors == 0
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_handles_client_failure():
+    """Client raises → errors counter increments, no parse attempted."""
+    mock_client = MagicMock()
+    mock_client.fetch_awards = AsyncMock(side_effect=Exception("OCDS timeout"))
+
+    conn = MagicMock()
+    result = await run_ingest(
+        date_from=date(2026, 4, 15),
+        date_to=date(2026, 4, 15),
+        conn=conn,
+        dry_run=False,
+        client=mock_client,
+    )
+    assert result.errors == 1
+    assert result.fetched == 0
+    assert result.parsed == 0
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_chunks_wide_range():
+    """20-day range chunks into 3 weekly fetches."""
+    mock_client = MagicMock()
+    mock_client.fetch_awards = AsyncMock(return_value=[])
+
+    conn = MagicMock()
+    await run_ingest(
+        date_from=date(2026, 4, 1),
+        date_to=date(2026, 4, 20),
+        conn=conn,
+        dry_run=False,
+        client=mock_client,
+    )
+    # 1-7, 8-14, 15-20 → 3 chunks
+    assert mock_client.fetch_awards.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_dry_run_no_db_calls():
+    """Dry run path should not touch the DB connection."""
+    valid_release = {
+        "ocid": "ocds-au-CN1",
+        "parties": [
+            {
+                "name": "Pymble Dental",
+                "roles": ["supplier"],
+                "identifier": {"scheme": "AU-ABN", "id": "33051775556"},
+                "address": {"countryName": "AU"},
+            }
+        ],
+        "awards": [
+            {"value": {"amount": 75000, "currency": "AUD"}, "date": "2026-04-15"}
+        ],
+    }
+    mock_client = MagicMock()
+    mock_client.fetch_awards = AsyncMock(return_value=[valid_release])
+
+    conn = MagicMock()
+    conn.fetchval = AsyncMock()
+    conn.fetchrow = AsyncMock()
+
+    result = await run_ingest(
+        date_from=date(2026, 4, 15),
+        date_to=date(2026, 4, 15),
+        conn=conn,
+        dry_run=True,
+        client=mock_client,
+    )
+    # Counters reflect parse but not write
+    assert result.parsed == 1
+    assert result.inserted == 0
+    assert result.updated == 0
+    conn.fetchval.assert_not_called()
+    conn.fetchrow.assert_not_called()
+
+
+# ── yesterday_aest ────────────────────────────────────────────────────────────
+
+
+def test_yesterday_aest_returns_date():
+    """yesterday_aest is a date in the past, never today or future."""
+    y = yesterday_aest()
+    assert isinstance(y, date)
+    assert y < date.today() + __import__("datetime").timedelta(days=1)
+
+
+# ── IngestResult str ──────────────────────────────────────────────────────────
+
+
+def test_ingest_result_str_includes_all_counters():
+    r = IngestResult(fetched=10, parsed=8, filtered_non_au=2, filtered_low_value=1, inserted=3, updated=2, errors=0)
+    s = str(r)
+    assert "fetched=10" in s
+    assert "parsed=8" in s
+    assert "non_au_filtered=2" in s
+    assert "low_value_filtered=1" in s
+    assert "inserted=3" in s
+    assert "updated=2" in s
+    assert "errors=0" in s


### PR DESCRIPTION
## Summary
- Slice 2 of the AusTender connector — bridges `AwardEvent` (slice 1, #587) into `business_universe` via UPDATE-then-INSERT, plus the daily-cron CLI
- Three new files (~480 net lines) + 13-test suite
- AusTender now end-to-end ready: skill #583 → client #587 → discovery+CLI (this PR)

## Files changed
- `src/pipeline/austender_discovery.py` — new (~200 lines)
- `scripts/ingest_austender.py` — new (~120 lines)
- `tests/pipeline/test_austender_discovery.py` — new (13 tests)

## Discovery layer (`austender_discovery.py`)

### `ingest_award_event(event, conn, batch_id, dry_run)`
Atomic per-event write:
- **UPDATE first:** match by `abn`, set `signal_source = 'austender_supplier'`, `signal_checked_at = NOW()`, `last_signal_refresh = NOW()`, merge `category_baselines.austender` jsonb (preserves any existing keys).
- **INSERT on no-match:** new BU row with `discovery_source = signal_source = 'austender_supplier'`, `pipeline_stage = 0`, fresh UUID, `category_baselines.austender` jsonb populated.
- **ON CONFLICT (abn) DO UPDATE:** handles race condition between UPDATE returning empty and INSERT colliding with concurrent insert.

### `run_ingest(date_from, date_to, conn, ...)`
Top-level orchestrator:
- Splits wide ranges into ≤7d chunks via `date_range_chunks` (slice 1)
- Iterates: fetch → parse → filter (non-AU / low-value) → ingest
- Returns `IngestResult` with counters: fetched, parsed, filtered_non_au, filtered_low_value, inserted, updated, errors

### `yesterday_aest()` helper
Returns yesterday's date in AEST (UTC+10) for daily-cron defaults.

## CLI (`scripts/ingest_austender.py`)

```bash
# Yesterday's awards, dry-run (default)
python scripts/ingest_austender.py

# Yesterday's awards, live (prompts for 'INGEST' confirmation)
python scripts/ingest_austender.py --live

# 30-day backfill on first run
python scripts/ingest_austender.py --backfill-days 30 --live

# Specific date range
python scripts/ingest_austender.py --date-from 2026-04-01 --date-to 2026-04-07

# Lower value threshold for noise tuning
python scripts/ingest_austender.py --min-value 25000
```

Defaults are paranoid: dry-run unless `--live`, interactive `INGEST` confirm before any writes, `--backfill-days` capped 1–90.

## Schema mapping (zero migrations)
| Source field | BU column / jsonb |
|---|---|
| `event.supplier_abn` | `abn` (existing, canonicalised via #586) |
| `event.supplier_name` | `display_name` (INSERT only, never overwrite) |
| `event.contract_id` | `category_baselines.austender.contract_id` |
| `event.contract_value_aud` | `category_baselines.austender.contract_value_aud` |
| `event.awarded_date` | `category_baselines.austender.awarded_date` |
| `event.agency_name` | `category_baselines.austender.agency_name` |
| `event.classification_id` | `category_baselines.austender.classification_id` |
| Pipeline routing | `discovery_source = signal_source = 'austender_supplier'`, `pipeline_stage = 0`, `signal_checked_at = NOW()` |

All existing BU columns. **No migration in v1** ✅.

## Test coverage (13 cases)

- `_build_jsonb_payload`: extracts all fields, handles None gracefully (2)
- `ingest_award_event`: dry-run no-op, non-AU skip, UPDATE path, INSERT path, ON CONFLICT path (5)
- `run_ingest`: end-to-end aggregation (3 releases — 1 valid / 1 non-AU / 1 low-value), client-failure error counter, wide-range chunking (20d → 3 calls), dry-run no-DB (4)
- `yesterday_aest`: returns valid past date (1)
- `IngestResult.__str__`: format check (1)

## Verification
```
$ pytest tests/pipeline/test_austender_discovery.py -v
13 passed in 2.75s

$ ruff check src/pipeline/austender_discovery.py scripts/ingest_austender.py tests/pipeline/test_austender_discovery.py
All checks passed!
```

## Per LAW XII / XIII / II
- LAW XII: this module is the canonical writer for AusTender data. Direct INSERT/UPDATE on business_universe with austender_supplier source outside this module is forbidden.
- LAW XIII: any change to call patterns updates skills/austender/SKILL.md (#583).
- LAW II: AUD-only enforced at parser (slice 1) before reaching this module.

## Coordination
- **Branched off `aiden/austender-connector` (#587)** — depends on `AusTenderClient` + `AwardEvent` + `date_range_chunks` from slice 1.
- Rebases onto main once #587 + #586 land.
- AusTender connector now **end-to-end ready** pending merge: skill #583 → client #587 → discovery+CLI (this PR).
- ASIC + Seek connectors remain queued behind Dave actions (DSP email, Apify token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)