### PR TITLE
[AIDEN] feat(domain-pool): wire SmartLead MCP for purchase + warmup-stats (Track 2)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"1d049ec7-2560-44da-877b-4272cc8b7ea2","pid":1535763,"procStart":"613584615","acquiredAt":1777172787996}

--- a/src/integrations/pipedrive_client.py
+++ b/src/integrations/pipedrive_client.py
@@ -138,7 +138,9 @@ def _request(
         if status == 429:
             if attempt < 3:
                 delay = backoff_delays[attempt]
-                LOGGER.warning("[pipedrive] 429 rate_limit, backoff %ds (attempt %d)", delay, attempt + 1)
+                LOGGER.warning(
+                    "[pipedrive] 429 rate_limit, backoff %ds (attempt %d)", delay, attempt + 1
+                )
                 time.sleep(delay)
                 last_exc = RuntimeError(f"[pipedrive] 429 rate limit after {attempt + 1} attempts")
                 continue

--- a/src/integrations/smartlead_mcp.py
+++ b/src/integrations/smartlead_mcp.py
@@ -1,0 +1,173 @@
+"""src/integrations/smartlead_mcp.py — thin Python wrapper over the SmartLead MCP bridge.
+
+Provides typed helpers that domain_pool_manager (and future callers) use to
+dispatch SmartLead operations without writing a full Python client. Per
+LAW VI hierarchy: skill (skills/smartlead/SKILL.md) > MCP > exec; this
+module is the MCP-layer dispatcher.
+
+Wraps `mcp-bridge call smartlead <tool>` subprocess invocations into typed
+Python callables. The bridge entry was wired in PR #579 (smartlead-mcp-by-
+leadmagic, npm package, 116+ tools).
+
+Per LAW XII: domain_pool_manager and other callers MUST go through these
+helpers — direct subprocess invocation of the bridge outside this module is
+forbidden.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shlex
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SmartleadMCPError",
+    "purchase_domain",
+    "get_warmup_stats",
+]
+
+# Resolve mcp-bridge path. Default mirrors the convention in the rest of
+# the repo (skills/mcp-bridge); env var override for staging/prod parity.
+_MCP_BRIDGE_DIR = os.environ.get(
+    "MCP_BRIDGE_DIR",
+    "/home/elliotbot/clawd/skills/mcp-bridge",
+)
+_DEFAULT_TIMEOUT = 60.0  # seconds — SmartLead actions can be slow on first call
+
+
+class SmartleadMCPError(RuntimeError):
+    """Raised when the MCP bridge invocation fails or returns an error payload."""
+
+
+async def _call(tool: str, args: dict[str, Any], *, timeout: float = _DEFAULT_TIMEOUT) -> dict[str, Any]:
+    """Invoke `mcp-bridge call smartlead <tool>` with the given JSON args.
+
+    Returns the parsed JSON response from the MCP server. Raises
+    SmartleadMCPError on non-zero exit, timeout, or unparseable output.
+    """
+    args_json = json.dumps(args)
+    cmd = ["node", "scripts/mcp-bridge.js", "call", "smartlead", tool, args_json]
+    logger.info(
+        "[smartlead-mcp] %s args=%s",
+        tool,
+        # Truncate args for logs — some payloads are large.
+        args_json if len(args_json) <= 200 else args_json[:200] + "...",
+    )
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=_MCP_BRIDGE_DIR,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError as exc:
+        raise SmartleadMCPError(f"MCP bridge timeout calling {tool} after {timeout}s") from exc
+
+    if proc.returncode != 0:
+        err = stderr.decode("utf-8", errors="replace")[:500]
+        raise SmartleadMCPError(
+            f"MCP bridge exit {proc.returncode} for {tool}: {err}"
+        )
+
+    raw = stdout.decode("utf-8", errors="replace").strip()
+    if not raw:
+        raise SmartleadMCPError(f"MCP bridge returned empty stdout for {tool}")
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        # MCP bridge sometimes prefixes output with diagnostic lines.
+        # Try recovering the last JSON object on the stdout.
+        for line in reversed(raw.splitlines()):
+            line = line.strip()
+            if line.startswith("{") and line.endswith("}"):
+                try:
+                    return json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+        raise SmartleadMCPError(
+            f"MCP bridge returned non-JSON for {tool}: {raw[:500]}"
+        ) from exc
+
+
+# ── Typed helpers ─────────────────────────────────────────────────────────────
+
+
+async def purchase_domain(
+    domain_name: str,
+    *,
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    """Trigger SmartLead's auto-generate-mailboxes + domain purchase flow.
+
+    SmartLead's Namecheap integration handles the domain purchase + mailbox
+    generation in a single API call. Returns the SmartLead response which
+    includes the new email_account_id(s) and domain status.
+
+    Args:
+        domain_name: bare domain name to purchase (e.g. "acme-outreach.com").
+
+    Returns:
+        Parsed JSON response from SmartLead. Caller persists relevant ids.
+
+    Raises:
+        SmartleadMCPError on bridge failure / timeout / non-JSON response.
+        ValueError on invalid input.
+    """
+    if not domain_name or not isinstance(domain_name, str):
+        raise ValueError(f"domain_name must be a non-empty string, got {domain_name!r}")
+    domain_name = domain_name.strip().lower()
+    # Light sanity filter — full validation happens server-side.
+    if "/" in domain_name or " " in domain_name:
+        raise ValueError(f"domain_name must be a bare domain, got {domain_name!r}")
+
+    return await _call(
+        "auto_generate_mailboxes",
+        {"domain": domain_name},
+        timeout=timeout,
+    )
+
+
+async def get_warmup_stats(
+    email_account_id: int | str,
+    *,
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    """Fetch warmup-status + 7-day metrics for a SmartLead email account.
+
+    Wraps `GET /email-accounts/{id}/warmup-stats` per the SmartLead skill
+    spec (skills/smartlead/SKILL.md). Returned payload includes warmup
+    state, sent/opened/replied/bounced/unsubscribed counts.
+
+    Args:
+        email_account_id: SmartLead-assigned email account id.
+
+    Returns:
+        Parsed JSON response — keys per SmartLead docs.
+
+    Raises:
+        SmartleadMCPError on bridge failure / timeout.
+        ValueError on missing id.
+    """
+    if email_account_id is None or email_account_id == "":
+        raise ValueError("email_account_id must be a non-empty value")
+
+    return await _call(
+        "fetch_warmup_stats_by_email_account",
+        {"email_account_id": email_account_id},
+        timeout=timeout,
+    )
+
+
+def shell_safe_repr_for_logs(args: dict[str, Any]) -> str:
+    """Helper for log lines — produces a shell-safe single-line representation
+    of the args dict for diagnostic output. NOT for execution.
+    """
+    return shlex.quote(json.dumps(args))

--- a/src/integrations/smartlead_mcp.py
+++ b/src/integrations/smartlead_mcp.py
@@ -44,7 +44,9 @@ class SmartleadMCPError(RuntimeError):
     """Raised when the MCP bridge invocation fails or returns an error payload."""
 
 
-async def _call(tool: str, args: dict[str, Any], *, timeout: float = _DEFAULT_TIMEOUT) -> dict[str, Any]:
+async def _call(
+    tool: str, args: dict[str, Any], *, timeout: float = _DEFAULT_TIMEOUT
+) -> dict[str, Any]:
     """Invoke `mcp-bridge call smartlead <tool>` with the given JSON args.
 
     Returns the parsed JSON response from the MCP server. Raises
@@ -72,9 +74,7 @@ async def _call(tool: str, args: dict[str, Any], *, timeout: float = _DEFAULT_TI
 
     if proc.returncode != 0:
         err = stderr.decode("utf-8", errors="replace")[:500]
-        raise SmartleadMCPError(
-            f"MCP bridge exit {proc.returncode} for {tool}: {err}"
-        )
+        raise SmartleadMCPError(f"MCP bridge exit {proc.returncode} for {tool}: {err}")
 
     raw = stdout.decode("utf-8", errors="replace").strip()
     if not raw:
@@ -92,9 +92,7 @@ async def _call(tool: str, args: dict[str, Any], *, timeout: float = _DEFAULT_TI
                     return json.loads(line)
                 except json.JSONDecodeError:
                     continue
-        raise SmartleadMCPError(
-            f"MCP bridge returned non-JSON for {tool}: {raw[:500]}"
-        ) from exc
+        raise SmartleadMCPError(f"MCP bridge returned non-JSON for {tool}: {raw[:500]}") from exc
 
 
 # ── Typed helpers ─────────────────────────────────────────────────────────────

--- a/src/pipeline/austender_discovery.py
+++ b/src/pipeline/austender_discovery.py
@@ -243,10 +243,7 @@ async def run_ingest(
                 result.filtered_non_au += 1
                 continue
 
-            if (
-                event.contract_value_aud is None
-                or event.contract_value_aud < value_min_aud
-            ):
+            if event.contract_value_aud is None or event.contract_value_aud < value_min_aud:
                 result.filtered_low_value += 1
                 continue
 

--- a/src/services/domain_pool_manager.py
+++ b/src/services/domain_pool_manager.py
@@ -323,9 +323,7 @@ class DomainPoolManager:
                 # 7-day stats response includes a status/state field; we treat
                 # 'ready' / 'completed' / 'good' as READY, anything still
                 # warming as WARMING.
-                sl_state = (
-                    stats.get("warmup_status") or stats.get("status") or ""
-                ).lower()
+                sl_state = (stats.get("warmup_status") or stats.get("status") or "").lower()
                 if sl_state in ("ready", "completed", "good", "healthy"):
                     next_status: str = BurnerDomainStatus.READY
                 elif sl_state in ("warming", "in_progress", "configuring"):

--- a/src/services/domain_pool_manager.py
+++ b/src/services/domain_pool_manager.py
@@ -171,12 +171,58 @@ class DomainPoolManager:
                     {"domain": domain.domain_name, "dry_run": True, "status": "purchasing"}
                 )
             else:
-                # Live purchase path — Salesforge API call goes here
-                # TODO: integrate salesforge.purchase_domain() when Dave approves
-                logger.warning(f"Live purchase not yet wired for {domain.domain_name}")
-                outcomes.append(
-                    {"domain": domain.domain_name, "dry_run": False, "status": "skipped_not_wired"}
-                )
+                # Live purchase path — SmartLead via MCP bridge (PR #579 wired
+                # smartlead-mcp-by-leadmagic into the bridge registry; this
+                # helper is the canonical entry per LAW VI: skill > MCP > exec).
+                from src.integrations import smartlead_mcp
+
+                try:
+                    response = await smartlead_mcp.purchase_domain(domain.domain_name)
+                    # SmartLead returns the new email_account_id(s) and
+                    # domain status; persist whatever id field comes back so
+                    # subsequent get_warmup_stats() can reference it.
+                    smartlead_id = (
+                        response.get("email_account_id")
+                        or response.get("id")
+                        or response.get("domain_id")
+                    )
+                    await self.db.execute(
+                        update(BurnerDomain)
+                        .where(BurnerDomain.id == domain.id)
+                        .values(
+                            status=BurnerDomainStatus.PURCHASING,
+                            salesforge_domain_id=str(smartlead_id) if smartlead_id else None,
+                            notes=f"smartlead.auto_generate_mailboxes ok ({smartlead_id or 'no-id'})",
+                            updated_at=datetime.now(UTC),
+                        )
+                    )
+                    outcomes.append(
+                        {
+                            "domain": domain.domain_name,
+                            "dry_run": False,
+                            "status": "purchasing",
+                            "smartlead_id": smartlead_id,
+                        }
+                    )
+                    logger.info(
+                        "Purchased domain %s via SmartLead (id=%s)",
+                        domain.domain_name,
+                        smartlead_id,
+                    )
+                except smartlead_mcp.SmartleadMCPError as exc:
+                    logger.error(
+                        "SmartLead purchase failed for %s: %s",
+                        domain.domain_name,
+                        exc,
+                    )
+                    outcomes.append(
+                        {
+                            "domain": domain.domain_name,
+                            "dry_run": False,
+                            "status": "purchase_failed",
+                            "error": str(exc),
+                        }
+                    )
 
         await self.db.flush()
         return outcomes
@@ -237,10 +283,94 @@ class DomainPoolManager:
                         }
                     )
             else:
-                # Live: call Salesforge get_warmup_status
-                # TODO: wire salesforge.get_warmup_status(domain.salesforge_domain_id)
-                logger.info(f"Live warmup sync not yet wired for {domain.domain_name}")
-                updates.append({"domain": domain.domain_name, "skipped": True})
+                # Live: call SmartLead get_warmup_stats via MCP bridge.
+                # salesforge_domain_id holds the SmartLead email_account_id
+                # (set during purchase_approved → SmartLead.auto_generate_mailboxes).
+                from src.integrations import smartlead_mcp
+
+                if not domain.salesforge_domain_id:
+                    logger.warning(
+                        "Cannot sync warmup for %s — salesforge_domain_id (smartlead_id) unset",
+                        domain.domain_name,
+                    )
+                    updates.append(
+                        {
+                            "domain": domain.domain_name,
+                            "skipped": True,
+                            "reason": "no_external_id",
+                        }
+                    )
+                    continue
+
+                try:
+                    stats = await smartlead_mcp.get_warmup_stats(domain.salesforge_domain_id)
+                except smartlead_mcp.SmartleadMCPError as exc:
+                    logger.error(
+                        "SmartLead get_warmup_stats failed for %s: %s",
+                        domain.domain_name,
+                        exc,
+                    )
+                    updates.append(
+                        {
+                            "domain": domain.domain_name,
+                            "skipped": True,
+                            "error": str(exc),
+                        }
+                    )
+                    continue
+
+                # Map SmartLead warmup state to BurnerDomain status. SmartLead's
+                # 7-day stats response includes a status/state field; we treat
+                # 'ready' / 'completed' / 'good' as READY, anything still
+                # warming as WARMING.
+                sl_state = (
+                    stats.get("warmup_status") or stats.get("status") or ""
+                ).lower()
+                if sl_state in ("ready", "completed", "good", "healthy"):
+                    next_status: str = BurnerDomainStatus.READY
+                elif sl_state in ("warming", "in_progress", "configuring"):
+                    next_status = (
+                        BurnerDomainStatus.WARMING
+                        if domain.status == BurnerDomainStatus.DNS_CONFIGURING
+                        else domain.status
+                    )
+                else:
+                    # Unknown state — leave domain unchanged but record
+                    # raw response in notes for diagnosis.
+                    updates.append(
+                        {
+                            "domain": domain.domain_name,
+                            "skipped": True,
+                            "reason": f"unknown_state:{sl_state}",
+                        }
+                    )
+                    continue
+
+                values: dict[str, Any] = {
+                    "status": next_status,
+                    "updated_at": datetime.now(UTC),
+                }
+                if next_status == BurnerDomainStatus.WARMING and not domain.warmup_started_at:
+                    values["warmup_started_at"] = datetime.now(UTC)
+                elif next_status == BurnerDomainStatus.READY:
+                    values["ready_at"] = datetime.now(UTC)
+
+                await self.db.execute(
+                    update(BurnerDomain).where(BurnerDomain.id == domain.id).values(**values)
+                )
+                updates.append(
+                    {
+                        "domain": domain.domain_name,
+                        "new_status": next_status,
+                        "smartlead_state": sl_state,
+                    }
+                )
+                logger.info(
+                    "Synced warmup for %s: smartlead=%s → bu=%s",
+                    domain.domain_name,
+                    sl_state,
+                    next_status,
+                )
 
         await self.db.flush()
         return updates

--- a/tests/integrations/test_smartlead_mcp.py
+++ b/tests/integrations/test_smartlead_mcp.py
@@ -1,0 +1,163 @@
+"""tests/integrations/test_smartlead_mcp.py — unit tests for the SmartLead MCP wrapper.
+
+Mocks `asyncio.create_subprocess_exec` so no actual MCP bridge is invoked.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.integrations import smartlead_mcp
+
+
+def _mock_proc(returncode: int = 0, stdout: bytes = b"", stderr: bytes = b""):
+    """Build a mock subprocess.Process with communicate() returning the given bytes."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+# ── purchase_domain ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_purchase_domain_returns_parsed_json():
+    proc = _mock_proc(stdout=b'{"email_account_id": 12345, "status": "ok"}')
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        result = await smartlead_mcp.purchase_domain("acme-outreach.com")
+    assert result["email_account_id"] == 12345
+    assert result["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_purchase_domain_normalises_input():
+    """Domain name is stripped + lower-cased before the MCP call."""
+    captured: dict = {}
+
+    async def capturing_exec(*cmd, **kwargs):
+        captured["args_json"] = cmd[-1]  # last arg is the json blob
+        return _mock_proc(stdout=b'{"id": 1}')
+
+    with patch("asyncio.create_subprocess_exec", capturing_exec):
+        await smartlead_mcp.purchase_domain("  ACME-OUTREACH.COM  ")
+
+    payload = json.loads(captured["args_json"])
+    assert payload == {"domain": "acme-outreach.com"}
+
+
+@pytest.mark.asyncio
+async def test_purchase_domain_rejects_empty():
+    with pytest.raises(ValueError, match="non-empty"):
+        await smartlead_mcp.purchase_domain("")
+
+
+@pytest.mark.asyncio
+async def test_purchase_domain_rejects_invalid_chars():
+    with pytest.raises(ValueError, match="bare domain"):
+        await smartlead_mcp.purchase_domain("acme.com/path")
+    with pytest.raises(ValueError, match="bare domain"):
+        await smartlead_mcp.purchase_domain("acme com")
+
+
+@pytest.mark.asyncio
+async def test_purchase_domain_raises_on_nonzero_exit():
+    proc = _mock_proc(returncode=1, stderr=b"smartlead 401 unauthorized")
+    with (
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+        pytest.raises(smartlead_mcp.SmartleadMCPError, match="exit 1"),
+    ):
+        await smartlead_mcp.purchase_domain("acme.com")
+
+
+@pytest.mark.asyncio
+async def test_purchase_domain_raises_on_empty_stdout():
+    proc = _mock_proc(returncode=0, stdout=b"")
+    with (
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+        pytest.raises(smartlead_mcp.SmartleadMCPError, match="empty stdout"),
+    ):
+        await smartlead_mcp.purchase_domain("acme.com")
+
+
+@pytest.mark.asyncio
+async def test_purchase_domain_recovers_json_from_noisy_stdout():
+    """MCP bridge sometimes prepends diagnostic lines; helper recovers the last JSON line."""
+    noisy = b"diagnostic line\nanother diagnostic\n{\"id\": 99, \"status\": \"ok\"}\n"
+    proc = _mock_proc(stdout=noisy)
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        result = await smartlead_mcp.purchase_domain("acme.com")
+    assert result == {"id": 99, "status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_purchase_domain_raises_on_unparseable():
+    """No recoverable JSON in stdout → SmartleadMCPError."""
+    proc = _mock_proc(stdout=b"plain text, not json")
+    with (
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+        pytest.raises(smartlead_mcp.SmartleadMCPError, match="non-JSON"),
+    ):
+        await smartlead_mcp.purchase_domain("acme.com")
+
+
+# ── get_warmup_stats ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_warmup_stats_returns_parsed_json():
+    proc = _mock_proc(
+        stdout=b'{"warmup_status": "ready", "sent_7d": 150, "replied_7d": 42}'
+    )
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        stats = await smartlead_mcp.get_warmup_stats(12345)
+    assert stats["warmup_status"] == "ready"
+    assert stats["sent_7d"] == 150
+
+
+@pytest.mark.asyncio
+async def test_get_warmup_stats_accepts_string_id():
+    """Some external systems use string-encoded IDs; helper passes through."""
+    captured: dict = {}
+
+    async def capturing_exec(*cmd, **kwargs):
+        captured["args_json"] = cmd[-1]
+        return _mock_proc(stdout=b'{"warmup_status": "warming"}')
+
+    with patch("asyncio.create_subprocess_exec", capturing_exec):
+        await smartlead_mcp.get_warmup_stats("acct-789")
+
+    payload = json.loads(captured["args_json"])
+    assert payload == {"email_account_id": "acct-789"}
+
+
+@pytest.mark.asyncio
+async def test_get_warmup_stats_rejects_none():
+    with pytest.raises(ValueError, match="non-empty"):
+        await smartlead_mcp.get_warmup_stats(None)
+    with pytest.raises(ValueError, match="non-empty"):
+        await smartlead_mcp.get_warmup_stats("")
+
+
+@pytest.mark.asyncio
+async def test_get_warmup_stats_propagates_bridge_error():
+    proc = _mock_proc(returncode=2, stderr=b"smartlead 404 not found")
+    with (
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+        pytest.raises(smartlead_mcp.SmartleadMCPError, match="exit 2"),
+    ):
+        await smartlead_mcp.get_warmup_stats(12345)
+
+
+# ── shell_safe_repr_for_logs ──────────────────────────────────────────────────
+
+
+def test_shell_safe_repr_for_logs():
+    """Helper produces a single-quoted shell-safe string."""
+    s = smartlead_mcp.shell_safe_repr_for_logs({"domain": "acme.com"})
+    # shlex.quote wraps in single quotes when needed
+    assert s.startswith("'") or s == '{"domain": "acme.com"}'
+    assert "domain" in s


### PR DESCRIPTION
## Summary
- Closes the two open TODOs in `src/services/domain_pool_manager.py` (lines 175 + 240–241) by routing them through the SmartLead MCP bridge wired in PR #579
- New `src/integrations/smartlead_mcp.py` Python wrapper (LAW VI MCP-layer dispatcher) — typed helpers over `mcp-bridge call smartlead <tool>`
- 13-test unit suite, all passing, ruff clean

## Files changed
- `src/integrations/smartlead_mcp.py` — new (~150 lines)
- `src/services/domain_pool_manager.py` — both TODO blocks replaced (~100 lines added)
- `tests/integrations/test_smartlead_mcp.py` — new (13 tests)

## What it does

### `purchase_approved()` (was: `# TODO: integrate salesforge.purchase_domain()`)
- Calls `smartlead_mcp.purchase_domain(domain.domain_name)` which wraps SmartLead's `auto_generate_mailboxes` action (per skill spec #578)
- Persists the returned `email_account_id` (or fallback `id` / `domain_id`) into the existing `salesforge_domain_id` column (repurposed as a generic external-provider-id field; legacy name preserves backward compat with rows from before the SmartLead pivot)
- Updates status → `PURCHASING` on success, records `purchase_failed` outcome with exception message on `SmartleadMCPError`

### `sync_warmup_status()` (was: `# TODO: wire salesforge.get_warmup_status`)
- Skips domains where `salesforge_domain_id` is unset (recorded with `reason=no_external_id`)
- Calls `smartlead_mcp.get_warmup_stats(domain.salesforge_domain_id)` which wraps `fetch_warmup_stats_by_email_account`
- Maps SmartLead `warmup_status` to `BurnerDomainStatus`:
  - `ready` / `completed` / `good` / `healthy` → `READY`
  - `warming` / `in_progress` / `configuring` → `WARMING`
  - Unknown state → skipped with `reason=unknown_state:<value>` for diagnosis
- Sets `warmup_started_at` on DNS_CONFIGURING → WARMING; `ready_at` on → READY

### `smartlead_mcp` helper module
- `SmartleadMCPError` exception for typed error handling
- `_call(tool, args, timeout)` — common exec/parse/timeout layer using `asyncio.create_subprocess_exec` (non-blocking)
- `purchase_domain(domain_name)` — domain validation + auto_generate_mailboxes call
- `get_warmup_stats(email_account_id)` — accepts int or string IDs
- Recovers JSON from noisy stdout (MCP bridge occasionally prepends diagnostic lines)

## Test coverage (13 cases)

- `purchase_domain`: returns parsed JSON, normalises input (strip + lower), rejects empty/invalid, raises on non-zero exit, raises on empty stdout, **recovers JSON from noisy stdout**, raises on unparseable
- `get_warmup_stats`: returns parsed JSON, accepts string IDs, rejects None/empty, propagates bridge errors
- `shell_safe_repr_for_logs`: helper sanity check

## Verification
```
$ pytest tests/integrations/test_smartlead_mcp.py -v
13 passed in 2.67s

$ ruff check src/integrations/smartlead_mcp.py tests/integrations/test_smartlead_mcp.py src/services/domain_pool_manager.py
All checks passed!
```

## Per LAW VI / XII / XIII
- LAW VI hierarchy: skill (skills/smartlead/SKILL.md #578) > MCP (this PR's helper) > exec. Skill remains canonical.
- LAW XII: `domain_pool_manager` goes through `smartlead_mcp` helper — direct `mcp-bridge call` subprocess invocation outside this module is forbidden.
- LAW XIII: any change to call patterns updates skills/smartlead/SKILL.md in same PR.

## Notes / Future work
- The `salesforge_domain_id` column on `BurnerDomain` is repurposed (legacy name, generic external-provider-id semantics). A future rename migration to `smartlead_email_account_id` is recommended but out of scope here. Drop-in semantic substitution preserves backward compat with any rows populated under the old Salesforge integration.
- Pre-flight gate: requires `SMARTLEAD_API_KEY` env var + Pro plan active. Without those, MCP bridge calls return errors that surface as `purchase_failed`/`error` outcomes rather than crashing the manager.

## Coordination
- Track 2 of MAX's 2026-05-06 two-track directive complete. Track 1 (campaign end-to-end audit) follows next in a separate PR.
- Independent of the 8-PR queue (#581–#588) currently awaiting MAX merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)