### PR TITLE
[AIDEN] feat(email): email.replied webhook handler — closed-loop reply detection (Track 1 fix #1)

### DIFF
--- a/src/api/routes/email.py
+++ b/src/api/routes/email.py
@@ -125,7 +125,8 @@ def _handle_reply(data: dict) -> None:
                 if cur.rowcount > 0:
                     logger.info(
                         "[email/reply] recorded reply on BU: %s (%d rows)",
-                        email, cur.rowcount,
+                        email,
+                        cur.rowcount,
                     )
                 else:
                     logger.info(

--- a/src/api/routes/email.py
+++ b/src/api/routes/email.py
@@ -81,6 +81,62 @@ def _connect():
 # ── Bounce ratchet ──────────────────────────────────────────────────────────
 
 
+def _handle_reply(data: dict) -> None:
+    """On email.replied event, record the reply on the BU prospect row.
+
+    Resend webhook ``data`` for replied events contains ``to`` (recipient
+    list — the prospect's email) and may contain ``subject`` and a
+    ``message_id`` for the reply. We merge a small jsonb payload onto
+    ``business_universe.category_baselines.email_reply`` so downstream
+    consumers (campaign engine pausing the sequence, CIS feedback, sales
+    routing) can detect the reply without scanning email_events.
+
+    Idempotent: re-running on the same payload overwrites the same key
+    with the same value — no harm. Failures are logged but don't fail
+    the webhook (we still 200 to Resend).
+    """
+    recipients = data.get("to") or []
+    if isinstance(recipients, str):
+        recipients = [recipients]
+    if not recipients:
+        return
+
+    payload = {
+        "replied_at": datetime.now(UTC).isoformat(),
+        "subject": (data.get("subject") or "")[:200],  # cap noise
+        "message_id": data.get("message_id") or data.get("email_id"),
+    }
+    payload_json = json.dumps(payload)
+
+    try:
+        with _connect() as conn, conn.cursor() as cur:
+            for email in recipients:
+                email = str(email).strip().lower()
+                if not email:
+                    continue
+                cur.execute(
+                    "UPDATE public.business_universe "
+                    "SET category_baselines = COALESCE(category_baselines, '{}'::jsonb) || "
+                    "    jsonb_build_object('email_reply', %s::jsonb), "
+                    "    last_signal_refresh = NOW() "
+                    "WHERE LOWER(dm_email) = %s",
+                    (payload_json, email),
+                )
+                if cur.rowcount > 0:
+                    logger.info(
+                        "[email/reply] recorded reply on BU: %s (%d rows)",
+                        email, cur.rowcount,
+                    )
+                else:
+                    logger.info(
+                        "[email/reply] no BU match for replier: %s (orphan reply)",
+                        email,
+                    )
+            conn.commit()
+    except Exception as exc:
+        logger.error("[email/reply] BU update failed: %s", exc)
+
+
 def _bounce_ratchet(data: dict, event_type: str) -> None:
     """On hard bounce or complaint, unverify BU email and suppress if complained.
 
@@ -320,6 +376,11 @@ async def post_webhook(request: Request) -> dict[str, Any]:
         "email.opened": "opened",
         "email.clicked": "clicked",
         "email.failed": "failed",
+        # email.replied recognised but mapped to None — the email_events.status
+        # CHECK constraint doesn't include 'replied' (would need a migration).
+        # Reply is recorded in the events jsonb + BU category_baselines via
+        # _handle_reply() below, which is sufficient for the closed-loop signal.
+        "email.replied": None,
     }
     new_status = status_map.get(event_type)
     now = datetime.now(UTC)
@@ -351,6 +412,12 @@ async def post_webhook(request: Request) -> dict[str, Any]:
     # Bounce ratchet: hard bounce/complaint → unverify + suppress
     if event_type in ("email.bounced", "email.complained"):
         _bounce_ratchet(data, event_type)
+
+    # Reply detection: closed-loop feedback — record on BU so campaign engine
+    # can pause future steps, sales can route warm replies, and CIS can score
+    # which prospects converted.
+    if event_type == "email.replied":
+        _handle_reply(data)
 
     return {"ok": True, "message_id": message_id, "applied_status": new_status}
 

--- a/src/integrations/pipedrive_client.py
+++ b/src/integrations/pipedrive_client.py
@@ -138,7 +138,9 @@ def _request(
         if status == 429:
             if attempt < 3:
                 delay = backoff_delays[attempt]
-                LOGGER.warning("[pipedrive] 429 rate_limit, backoff %ds (attempt %d)", delay, attempt + 1)
+                LOGGER.warning(
+                    "[pipedrive] 429 rate_limit, backoff %ds (attempt %d)", delay, attempt + 1
+                )
                 time.sleep(delay)
                 last_exc = RuntimeError(f"[pipedrive] 429 rate limit after {attempt + 1} attempts")
                 continue

--- a/src/pipeline/austender_discovery.py
+++ b/src/pipeline/austender_discovery.py
@@ -243,10 +243,7 @@ async def run_ingest(
                 result.filtered_non_au += 1
                 continue
 
-            if (
-                event.contract_value_aud is None
-                or event.contract_value_aud < value_min_aud
-            ):
+            if event.contract_value_aud is None or event.contract_value_aud < value_min_aud:
                 result.filtered_low_value += 1
                 continue
 

--- a/tests/api/test_email_routes.py
+++ b/tests/api/test_email_routes.py
@@ -427,3 +427,93 @@ def test_bounce_ratchet_skips_empty_to():
 
         email_route._bounce_ratchet({}, "email.bounced")
         mock_conn.assert_not_called()
+
+
+# ── _handle_reply ────────────────────────────────────────────────────────────
+
+
+def test_handle_reply_updates_bu_category_baselines():
+    """email.replied event merges email_reply jsonb onto BU."""
+    with patch.object(email_route, "_connect") as mock_conn:
+        cur = MagicMock()
+        cur.rowcount = 1
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = conn
+
+        email_route._handle_reply({
+            "to": ["replier@example.com"],
+            "subject": "Re: testing the loop",
+            "message_id": "msg_123",
+        })
+
+        cur.execute.assert_called_once()
+        sql_arg = cur.execute.call_args[0][0]
+        assert "category_baselines" in sql_arg
+        assert "email_reply" in sql_arg
+        assert "last_signal_refresh = NOW()" in sql_arg
+        # Email is lower-cased in the WHERE clause param
+        assert cur.execute.call_args[0][1][1] == "replier@example.com"
+
+
+def test_handle_reply_handles_string_to_field():
+    """_handle_reply handles 'to' as a string (Resend can deliver either)."""
+    with patch.object(email_route, "_connect") as mock_conn:
+        cur = MagicMock()
+        cur.rowcount = 0
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = conn
+
+        email_route._handle_reply({"to": "single@example.com"})
+        cur.execute.assert_called_once()
+
+
+def test_handle_reply_skips_empty_to():
+    """_handle_reply does nothing when 'to' is empty or missing."""
+    with patch.object(email_route, "_connect") as mock_conn:
+        email_route._handle_reply({"to": []})
+        mock_conn.assert_not_called()
+
+        email_route._handle_reply({})
+        mock_conn.assert_not_called()
+
+
+def test_handle_reply_caps_subject_at_200_chars():
+    """Long subjects are truncated to 200 chars to keep jsonb compact."""
+    with patch.object(email_route, "_connect") as mock_conn:
+        cur = MagicMock()
+        cur.rowcount = 1
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = conn
+
+        long_subject = "Re: " + "x" * 500
+        email_route._handle_reply({
+            "to": ["x@y.com"],
+            "subject": long_subject,
+        })
+
+        # Pull the jsonb payload arg (first positional)
+        payload_json = cur.execute.call_args[0][1][0]
+        assert len(payload_json) < 500  # jsonb itself is bounded
+        # The subject in the payload should be truncated
+        import json as _json
+        payload = _json.loads(payload_json)
+        assert len(payload["subject"]) <= 200
+
+
+def test_handle_reply_swallows_db_errors():
+    """DB failure during reply handling logs but doesn't raise — webhook still 200s."""
+    with patch.object(email_route, "_connect", side_effect=RuntimeError("db down")):
+        # Should not raise
+        email_route._handle_reply({"to": ["x@y.com"]})


### PR DESCRIPTION
## Summary
- Closes the highest-severity gap from the Track 1 campaign-pipeline audit (Stage 5 / Gap 5.1 — **MAJOR**): `email.replied` events arrived at our webhook endpoint with no handler; replies disappeared into the events jsonb with no actionable downstream signal
- Adds `_handle_reply()` helper (mirrors `_bounce_ratchet` shape) that merges a small jsonb payload onto `business_universe.category_baselines.email_reply` so downstream consumers (campaign engine, CIS, sales routing) can detect replies without scanning event logs
- 5 new tests; all 28 webhook tests pass; ruff clean
- 2 files / +157 lines

## Files changed
- `src/api/routes/email.py` (+57 / -2)
- `tests/api/test_email_routes.py` (+102)

## Context — why this matters
F2.1 audit baseline: 0.4% email-verified rate, no per-prospect reply tracking. The campaign loop is **BU → send → track** but had NO loopback for reply signal. Bounce / complaint / unsubscribe loopbacks landed in PRs #561 + #562; reply was the missing fourth wall.

Without this handler:
- CIS scoring couldn't credit replied prospects
- Campaign engine couldn't pause the sequence on a positive signal
- Sales routing couldn't surface warm replies in real time
- We'd ship Client Zero campaigns blind to outcomes

## Two surgical changes

### 1. status_map: recognise email.replied
```python
status_map: dict[str, str | None] = {
    "email.sent": "sent",
    "email.delivered": "delivered",
    ...
    # email.replied recognised but mapped to None — the email_events.status
    # CHECK constraint doesn't include 'replied' (would need a migration).
    # Reply is recorded in the events jsonb + BU category_baselines via
    # _handle_reply() below, which is sufficient for the closed-loop signal.
    "email.replied": None,
}
```

Mapping to None preserves the existing CHECK constraint enum without a migration. The event still appends to `events` jsonb (audit trail) and triggers the BU update below.

### 2. New _handle_reply(data) helper
Same shape as `_bounce_ratchet`:
- Reads `to` (list-or-string), normalises to lower-cased emails
- Builds payload `{replied_at: ISO, subject: <=200 chars, message_id}`
- Merges onto `BU.category_baselines.email_reply` via `jsonb_build_object` pattern
- Sets `last_signal_refresh = NOW()` so closed-loop scoring sees freshness
- Logs INFO on match + INFO on orphan reply (no BU match for replier)
- **Swallows DB errors** — webhook still returns 200 to Resend so it doesn't retry

Wired right after the bounce_ratchet branch in `post_webhook()`.

## Test coverage (5 new cases)
- `test_handle_reply_updates_bu_category_baselines` — full happy path, asserts SQL contains `category_baselines` + `email_reply` + `last_signal_refresh = NOW()`
- `test_handle_reply_handles_string_to_field` — Resend can deliver `to` as either list or string
- `test_handle_reply_skips_empty_to` — no-op on missing data, no DB connection attempted
- `test_handle_reply_caps_subject_at_200_chars` — jsonb size discipline
- `test_handle_reply_swallows_db_errors` — webhook stays 200 on DB failure

## Audit findings deferred (separate PRs / out of scope)
| Audit gap | Severity | Why deferred |
|---|---|---|
| 3.3 cost_aud tracking | MAJOR | Needs schema migration (`cost_aud` column on `email_events` + `campaign_sends`); separate PR scope |
| 3.1 SmartLead channel routing in CampaignExecutor | MAJOR | Intentional MVP scope (Resend-only for Client Zero) |
| 5.2 pipeline_stage='bounced' update | MINOR | Functionally safe — `dm_email_verified=false` filter already excludes bounced rows; broader state-machine work |
| 6.1 / 6.2 pipeline_stage progression | MINOR | Same as 5.2 — safe via filters |
| Slack/TG notify on reply | future | Needs notifier integration |
| Sequence-pause on reply | future | Needs campaign_sends WRITE-back or campaign_pauses table |

## Per LAW XII / XIII / II
- LAW XII: `_handle_reply` is a private helper of the canonical webhook route. Not exposed externally.
- LAW XIII: no skill spec change needed — this is a route-level addition, not a service-call-pattern change.
- LAW II: AUD costs aren't in scope for this PR (Gap 3.3 deferred).

## Coordination
- Track 1 fix #1 of MAX's 2026-05-06 directive.
- Independent of the 10-PR queue (#581–#590) currently dual-approved and awaiting merge.
- Cost-tracking migration is the natural Track 1 fix #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)