### PR TITLE
[AIDEN] feat(email): cost_aud tracking on email_events + campaign_sends (Track 1 fix #2)

### DIFF
--- a/src/api/routes/email.py
+++ b/src/api/routes/email.py
@@ -42,6 +42,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, EmailStr, Field
 
+from src.config.email_costs import RESEND_COST_AUD_PER_EMAIL
 from src.integrations.resend_client import (
     ResendError,
     send_email,
@@ -210,8 +211,8 @@ def post_send(req: EmailSendRequest) -> EmailSendResponse:
     sql = (
         "INSERT INTO keiracom_admin.email_events "
         "(message_id, to_email, from_email, subject, status, "
-        " events, sent_at, last_event_at) "
-        "VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s) "
+        " events, sent_at, last_event_at, cost_aud) "
+        "VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s) "
         "ON CONFLICT (message_id) DO NOTHING"
     )
     initial_event = json.dumps(
@@ -233,6 +234,9 @@ def post_send(req: EmailSendRequest) -> EmailSendResponse:
                         initial_event,
                         now,
                         now,
+                        # LAW II: AUD cost per send. Resend Pro at ~$0.001 AUD/email.
+                        # Subscription cost is tracked separately in finance ledger.
+                        RESEND_COST_AUD_PER_EMAIL,
                     ),
                 )
             conn.commit()

--- a/src/config/email_costs.py
+++ b/src/config/email_costs.py
@@ -1,0 +1,61 @@
+"""src/config/email_costs.py — per-send AUD cost constants.
+
+Single source of truth for what each email-sending channel costs us in
+AUD. Used by `src/api/routes/email.py` (Resend route) and
+`src/engines/campaign_executor.py` (Resend dispatch) to populate the
+`cost_aud` columns added in migration 20260506_cost_aud_columns.sql.
+
+LAW II: all costs in AUD. USD-billed providers convert at 1.55× via the
+constants below.
+
+Update whenever provider pricing changes (and update the comment with
+the source URL + date so future readers can verify).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+# ── Resend ────────────────────────────────────────────────────────────────────
+# Resend Pro plan: $20 USD/mo for 50,000 emails = $0.0004 USD per email.
+# AUD: 0.0004 × 1.55 = 0.00062 AUD/email.
+# Reference: https://resend.com/pricing (snapshot 2026-05-06).
+# Rounded up to 0.0001 for safety / round-numbers; reconciliation against
+# the Resend invoice is the source of truth.
+RESEND_COST_AUD_PER_EMAIL: Decimal = Decimal("0.0010")
+
+# ── SmartLead ─────────────────────────────────────────────────────────────────
+# SmartLead Pro: $94 USD/mo flat-rate for API access. Per-send cost is
+# zero on the variable axis — the cost is the subscription, not per-email.
+# Stored as 0 here so accounting reflects the variable cost; subscription
+# fee is tracked separately in finance ledger.
+# Reference: skills/smartlead/SKILL.md (PR #578, dual-approved 2026-05-06).
+SMARTLEAD_COST_AUD_PER_EMAIL: Decimal = Decimal("0.0000")
+
+
+def cost_for_channel(channel: str) -> Decimal:
+    """Return per-send AUD cost for the given channel name.
+
+    Args:
+        channel: 'resend' or 'smartlead'. Case-insensitive.
+
+    Returns:
+        Decimal AUD cost. Decimal preserves precision through DB INSERT.
+
+    Raises:
+        ValueError on unknown channel — fail loud so we don't silently
+        zero out cost on a typo.
+    """
+    name = (channel or "").strip().lower()
+    if name == "resend":
+        return RESEND_COST_AUD_PER_EMAIL
+    if name == "smartlead":
+        return SMARTLEAD_COST_AUD_PER_EMAIL
+    raise ValueError(f"Unknown email channel: {channel!r} (expected 'resend' or 'smartlead')")
+
+
+__all__ = [
+    "RESEND_COST_AUD_PER_EMAIL",
+    "SMARTLEAD_COST_AUD_PER_EMAIL",
+    "cost_for_channel",
+]

--- a/src/engines/campaign_executor.py
+++ b/src/engines/campaign_executor.py
@@ -252,8 +252,17 @@ class CampaignExecutor:
         step: SequenceStep,
         message_id: str,
     ) -> None:
-        """Record a successful send in campaign_sends to prevent duplicates."""
+        """Record a successful send in campaign_sends to prevent duplicates.
+
+        LAW II: persists per-send AUD cost so run-level reporting can sum
+        cost_aud per (campaign_name, step_number) without joining external
+        billing data. Cost constant from src/config/email_costs.py.
+        """
         import asyncpg
+
+        # Local import — the cost constant lives in src/config/email_costs.py
+        # so it can be updated independently of the executor logic.
+        from src.config.email_costs import RESEND_COST_AUD_PER_EMAIL
 
         dsn = os.environ.get("DATABASE_URL_MIGRATIONS") or os.environ.get("DATABASE_URL", "")
         if dsn.startswith("postgresql+asyncpg://"):
@@ -263,14 +272,16 @@ class CampaignExecutor:
             try:
                 await conn.execute(
                     "INSERT INTO public.campaign_sends "
-                    "(prospect_id, dm_email, campaign_name, step_number, message_id, status) "
-                    "VALUES ($1::uuid, $2, $3, $4, $5, 'sent') "
+                    "(prospect_id, dm_email, campaign_name, step_number, "
+                    " message_id, status, cost_aud) "
+                    "VALUES ($1::uuid, $2, $3, $4, $5, 'sent', $6) "
                     "ON CONFLICT (campaign_name, step_number, dm_email) DO NOTHING",
                     prospect.id,
                     prospect.dm_email,
                     self.campaign_name,
                     step.step_number,
                     message_id,
+                    RESEND_COST_AUD_PER_EMAIL,
                 )
             finally:
                 await conn.close()

--- a/src/integrations/pipedrive_client.py
+++ b/src/integrations/pipedrive_client.py
@@ -138,7 +138,9 @@ def _request(
         if status == 429:
             if attempt < 3:
                 delay = backoff_delays[attempt]
-                LOGGER.warning("[pipedrive] 429 rate_limit, backoff %ds (attempt %d)", delay, attempt + 1)
+                LOGGER.warning(
+                    "[pipedrive] 429 rate_limit, backoff %ds (attempt %d)", delay, attempt + 1
+                )
                 time.sleep(delay)
                 last_exc = RuntimeError(f"[pipedrive] 429 rate limit after {attempt + 1} attempts")
                 continue

--- a/src/pipeline/austender_discovery.py
+++ b/src/pipeline/austender_discovery.py
@@ -243,10 +243,7 @@ async def run_ingest(
                 result.filtered_non_au += 1
                 continue
 
-            if (
-                event.contract_value_aud is None
-                or event.contract_value_aud < value_min_aud
-            ):
+            if event.contract_value_aud is None or event.contract_value_aud < value_min_aud:
                 result.filtered_low_value += 1
                 continue
 

--- a/supabase/migrations/20260506_cost_aud_columns.sql
+++ b/supabase/migrations/20260506_cost_aud_columns.sql
@@ -1,0 +1,24 @@
+-- FILE: supabase/migrations/20260506_cost_aud_columns.sql
+-- PURPOSE: Add per-row cost_aud tracking to email_events + campaign_sends.
+-- TASK: Track 1 audit Gap 3.3 — cost visibility was missing across all
+-- send paths. AUD-only per LAW II. DECIMAL(8,4) gives a $9,999.9999 per-row
+-- ceiling with sub-cent precision (Resend ~$0.0001 AUD per email; SmartLead
+-- subscription is flat-rate so per-row cost is bookkeeping only).
+
+-- 1. keiracom_admin.email_events — every Resend send writes one row here
+ALTER TABLE keiracom_admin.email_events
+    ADD COLUMN IF NOT EXISTS cost_aud DECIMAL(8, 4) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN keiracom_admin.email_events.cost_aud IS
+    'Per-send cost in AUD. Resend at ~$0.0001/send. Backfilled rows pre-2026-05-06 are 0.';
+
+-- 2. public.campaign_sends — every CampaignExecutor send writes one row here
+ALTER TABLE public.campaign_sends
+    ADD COLUMN IF NOT EXISTS cost_aud DECIMAL(8, 4) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.campaign_sends.cost_aud IS
+    'Per-send cost in AUD. Mirrors email_events.cost_aud for the same message.';
+
+-- 3. Lightweight aggregate index for run-level cost reporting
+-- (campaign_name, status) is a sensible partial index; omitted here to keep
+-- the migration cheap. Add later if reporting queries get slow.

--- a/tests/config/test_email_costs.py
+++ b/tests/config/test_email_costs.py
@@ -1,0 +1,57 @@
+"""tests/config/test_email_costs.py — unit tests for per-channel email cost config.
+
+Pure-function tests; no DB, no network.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from src.config.email_costs import (
+    RESEND_COST_AUD_PER_EMAIL,
+    SMARTLEAD_COST_AUD_PER_EMAIL,
+    cost_for_channel,
+)
+
+
+def test_resend_cost_is_decimal():
+    """Resend cost is a Decimal with cent precision (DB column is DECIMAL(8,4))."""
+    assert isinstance(RESEND_COST_AUD_PER_EMAIL, Decimal)
+    assert Decimal("0") < RESEND_COST_AUD_PER_EMAIL
+    # Sanity: should be sub-cent, well under $0.01 per send
+    assert Decimal("0.01") > RESEND_COST_AUD_PER_EMAIL
+
+
+def test_smartlead_cost_is_zero():
+    """SmartLead is flat-rate subscription — per-send variable cost is 0."""
+    assert Decimal("0") == SMARTLEAD_COST_AUD_PER_EMAIL
+
+
+def test_cost_for_channel_resend():
+    assert cost_for_channel("resend") == RESEND_COST_AUD_PER_EMAIL
+    assert cost_for_channel("Resend") == RESEND_COST_AUD_PER_EMAIL  # case-insensitive
+    assert cost_for_channel("  RESEND  ") == RESEND_COST_AUD_PER_EMAIL  # strip
+
+
+def test_cost_for_channel_smartlead():
+    assert cost_for_channel("smartlead") == SMARTLEAD_COST_AUD_PER_EMAIL
+    assert cost_for_channel("SmartLead") == SMARTLEAD_COST_AUD_PER_EMAIL
+
+
+def test_cost_for_channel_unknown_raises():
+    """Unknown channel raises ValueError — fail loud, don't silently zero."""
+    with pytest.raises(ValueError, match="Unknown email channel"):
+        cost_for_channel("salesforge")
+    with pytest.raises(ValueError, match="Unknown email channel"):
+        cost_for_channel("")
+    with pytest.raises(ValueError, match="Unknown email channel"):
+        cost_for_channel(None)  # type: ignore[arg-type]
+
+
+def test_cost_decimal_arithmetic_safe():
+    """Decimal preserves precision through arithmetic — no float drift."""
+    total = sum((RESEND_COST_AUD_PER_EMAIL for _ in range(1000)), Decimal("0"))
+    # 1000 × 0.0010 = 1.0000
+    assert total == Decimal("1.0000")


### PR DESCRIPTION
## Summary
- Closes Track 1 audit Gap 3.3 (**MAJOR** — no AUD cost visibility across send paths) by adding a `cost_aud DECIMAL(8,4)` column to both `keiracom_admin.email_events` and `public.campaign_sends` and populating it on every INSERT
- Centralises per-channel cost constants in a new `src/config/email_costs.py` module — single source of truth, easy to update on price changes, fails loud on unknown channels
- 6 new tests + 42 total tests still pass + ruff clean
- 6 files / +162 / -5

## Files changed
- `supabase/migrations/20260506_cost_aud_columns.sql` — new migration
- `src/config/email_costs.py` — new module (~50 lines)
- `tests/config/test_email_costs.py` — new (6 tests)
- `tests/config/__init__.py` — package marker
- `src/api/routes/email.py` — `/send` INSERT writes `cost_aud` (+3 lines)
- `src/engines/campaign_executor.py` — `_record_send` INSERT writes `cost_aud` (+12 lines)

## The migration
```sql
ALTER TABLE keiracom_admin.email_events
    ADD COLUMN IF NOT EXISTS cost_aud DECIMAL(8, 4) NOT NULL DEFAULT 0;
ALTER TABLE public.campaign_sends
    ADD COLUMN IF NOT EXISTS cost_aud DECIMAL(8, 4) NOT NULL DEFAULT 0;
```

`DECIMAL(8,4)` ceiling $9,999.9999 per-row, sub-cent precision. `IF NOT EXISTS` makes the migration idempotent. `DEFAULT 0` backfills existing rows so the NOT NULL doesn't reject them.

## Cost constants (`src/config/email_costs.py`)

| Channel | AUD/send | Source |
|---|---|---|
| Resend | `Decimal('0.0010')` | Pro plan $20 USD/mo / 50K emails ≈ $0.0004 USD × 1.55 ≈ $0.0006 AUD; rounded up to $0.001 for safety |
| SmartLead | `Decimal('0.0000')` | Flat-rate $94 USD/mo subscription — variable cost is 0; subscription tracked separately |

`cost_for_channel(name)` helper:
- Case-insensitive + whitespace-tolerant
- Raises `ValueError` on unknown channel (fail loud — no silent zeros on typos)

## Why Decimal not float
Float arithmetic drifts on small numbers — `1000 * 0.001` in float-land gives `0.99999...`, which would silently understate run cost. Decimal preserves exact precision through Python arithmetic AND through the `psycopg` / `asyncpg` DB INSERT (both bind Decimal directly to PG NUMERIC type without float conversion). Tested: `1000 × 0.0010 == Decimal('1.0000')` exactly.

## Wire-in points

### `src/api/routes/email.py` /send
```python
sql = (
    "INSERT INTO keiracom_admin.email_events "
    "(message_id, to_email, from_email, subject, status, "
    " events, sent_at, last_event_at, cost_aud) "
    "VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s) "
    "ON CONFLICT (message_id) DO NOTHING"
)
# ...
cur.execute(sql, (..., RESEND_COST_AUD_PER_EMAIL))
```

### `src/engines/campaign_executor.py` _record_send
```python
await conn.execute(
    "INSERT INTO public.campaign_sends "
    "(prospect_id, dm_email, campaign_name, step_number, "
    " message_id, status, cost_aud) "
    "VALUES ($1::uuid, $2, $3, $4, $5, 'sent', $6) "
    "ON CONFLICT (campaign_name, step_number, dm_email) DO NOTHING",
    ..., RESEND_COST_AUD_PER_EMAIL,
)
```

## Test coverage (6 new cases)
- Resend cost is Decimal, sub-cent
- SmartLead cost is exactly `Decimal('0')`
- `cost_for_channel` is case-insensitive + whitespace-tolerant
- Unknown channel raises `ValueError` (no silent zero)
- Decimal arithmetic preserves precision (1000 × 0.0010 == 1.0000 exactly)
- Resend cost passes the bounds check (>0 and <$0.01 per send)

## Regression check
Existing 36 tests in `test_email_routes.py` + `test_campaign_executor.py` all still pass — INSERT-shape change is backward compatible (extra column added at the end of the column list).

## Per LAW II / XII / XIII
- LAW II: AUD-only, Decimal preserves precision, USD billings convert at 1.55× via constants in `email_costs.py`
- LAW XII / XIII: no skill spec change needed — this is internal cost tracking, not an integration call pattern

## Coordination
- Track 1 fix #2 of MAX's 2026-05-06 directive (fix #1 was #591 — email.replied handler)
- Independent of the 11-PR queue currently dual-approved and awaiting merge
- Migration depends on `public.campaign_sends` table existing (created by migration `20260506_campaign_sends.sql` from PR #576, dual-approved + ready to merge). Merge order: #576 → this migration

## Audit gaps still deferred (future PRs / follow-up)
| Gap | Severity | Status |
|---|---|---|
| 3.1 SmartLead channel routing in CampaignExecutor | MAJOR | Intentional MVP scope (Resend-only for Client Zero) |
| 4.1 record-send-before-send timing window | MINOR | Needs Resend idempotency keys |
| 5.2 / 6.1 / 6.2 pipeline_stage progression | MINOR | Broader state-machine work; safe via dm_email_verified filter |
| 2.1 "there" subject leak | MINOR | Already filtered by `dm_name IS NOT NULL` |
| 5.3 legacy resend-signature audit | MINOR | Investigative, not a known bug |
| 2.2 hardcoded thresholds via campaign JSON | MINOR | Nice-to-have config flexibility |

🤖 Generated with [Claude Code](https://claude.com/claude-code)