### PR TITLE
[ELLIOT] refactor: PR-A1 dead callsite cleanup (#593 follow-up)

### DIFF
--- a/src/agents/campaign_evolution/campaign_orchestrator_agent.py
+++ b/src/agents/campaign_evolution/campaign_orchestrator_agent.py
@@ -19,8 +19,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-# DEAD: from src.integrations.sdk_brain import SDKBrainResult, create_sdk_brain
-
 logger = logging.getLogger(__name__)
 
 
@@ -213,7 +211,7 @@ async def run_campaign_orchestrator(
     current_campaigns: list[dict[str, Any]],
     client_context: dict[str, Any],
     client_id: UUID | None = None,
-) -> SDKBrainResult:  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+) -> Any:  # was SDKBrainResult (removed PR-A)
     """
     Orchestrate analyzer outputs into campaign suggestions.
 
@@ -311,39 +309,8 @@ async def run_campaign_orchestrator(
         "Remember: ALL suggestions require client approval - never auto-apply."
     )
 
-    user_prompt = "".join(prompt_parts)
-
     # Create brain and run
-    brain = create_sdk_brain("campaign_evolution_orchestrator")  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    result = await brain.run(
-        prompt=user_prompt,
-        tools=[],
-        output_schema=CampaignSuggestionOutput,
-        system=ORCHESTRATOR_SYSTEM_PROMPT,
-    )
-
-    # Post-process: Filter suggestions below confidence threshold
-    if result.success and result.data:
-        filtered_suggestions = []
-        for suggestion in result.data.suggestions:
-            threshold = CONFIDENCE_THRESHOLDS.get(suggestion.suggestion_type, 0.7)
-            if suggestion.confidence >= threshold:
-                filtered_suggestions.append(suggestion)
-            else:
-                logger.info(
-                    f"Filtered suggestion '{suggestion.title}' - "
-                    f"confidence {suggestion.confidence} < threshold {threshold}"
-                )
-        result.data.suggestions = filtered_suggestions
-
-    logger.info(
-        f"Orchestrator complete: {len(result.data.suggestions) if result.success else 0} suggestions, "
-        f"confidence={result.data.overall_confidence if result.success else 'N/A'}, "
-        f"cost=${result.cost_aud:.4f}"
-    )
-
-    return result
+    raise NotImplementedError("dead path: sdk_brain removed in PR-A #593")
 
 
 # ============================================

--- a/src/agents/campaign_evolution/how_analyzer_agent.py
+++ b/src/agents/campaign_evolution/how_analyzer_agent.py
@@ -16,8 +16,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-# DEAD: from src.integrations.sdk_brain import SDKBrainResult, create_sdk_brain
-
 logger = logging.getLogger(__name__)
 
 
@@ -190,7 +188,7 @@ async def run_how_analyzer(
     current_strategy: dict[str, Any],
     campaign_metrics: dict[str, Any] | None = None,
     client_id: UUID | None = None,
-) -> SDKBrainResult:  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+) -> Any:  # was SDKBrainResult (removed PR-A)
     """
     Run HOW pattern analysis to generate channel suggestions.
 
@@ -248,24 +246,8 @@ async def run_how_analyzer(
         "Define tier-specific channel strategies."
     )
 
-    user_prompt = "".join(prompt_parts)
-
     # Create brain and run
-    brain = create_sdk_brain("campaign_evolution_how")  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    result = await brain.run(
-        prompt=user_prompt,
-        tools=[],  # No tools needed - analyzing provided data
-        output_schema=HOWAnalysis,
-        system=HOW_ANALYZER_SYSTEM_PROMPT,
-    )
-
-    logger.info(
-        f"HOW analyzer complete: confidence={result.data.confidence if result.success else 'N/A'}, "
-        f"cost=${result.cost_aud:.4f}"
-    )
-
-    return result
+    raise NotImplementedError("dead path: sdk_brain removed in PR-A #593")
 
 
 # ============================================

--- a/src/agents/campaign_evolution/what_analyzer_agent.py
+++ b/src/agents/campaign_evolution/what_analyzer_agent.py
@@ -16,8 +16,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-# DEAD: from src.integrations.sdk_brain import SDKBrainResult, create_sdk_brain
-
 logger = logging.getLogger(__name__)
 
 
@@ -188,7 +186,7 @@ async def run_what_analyzer(
     campaign_metrics: dict[str, Any] | None = None,
     business_context: dict[str, Any] | None = None,
     client_id: UUID | None = None,
-) -> SDKBrainResult:  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+) -> Any:  # was SDKBrainResult (removed PR-A)
     """
     Run WHAT pattern analysis to generate content suggestions.
 
@@ -249,24 +247,8 @@ async def run_what_analyzer(
         "Document winning patterns to amplify and losing patterns to avoid."
     )
 
-    user_prompt = "".join(prompt_parts)
-
     # Create brain and run
-    brain = create_sdk_brain("campaign_evolution_what")  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    result = await brain.run(
-        prompt=user_prompt,
-        tools=[],  # No tools needed - analyzing provided data
-        output_schema=WHATAnalysis,
-        system=WHAT_ANALYZER_SYSTEM_PROMPT,
-    )
-
-    logger.info(
-        f"WHAT analyzer complete: confidence={result.data.confidence if result.success else 'N/A'}, "
-        f"cost=${result.cost_aud:.4f}"
-    )
-
-    return result
+    raise NotImplementedError("dead path: sdk_brain removed in PR-A #593")
 
 
 # ============================================

--- a/src/agents/campaign_evolution/who_analyzer_agent.py
+++ b/src/agents/campaign_evolution/who_analyzer_agent.py
@@ -16,8 +16,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-# DEAD: from src.integrations.sdk_brain import SDKBrainResult, create_sdk_brain
-
 logger = logging.getLogger(__name__)
 
 
@@ -166,7 +164,7 @@ async def run_who_analyzer(
     campaign_metrics: dict[str, Any] | None = None,
     business_context: dict[str, Any] | None = None,
     client_id: UUID | None = None,
-) -> SDKBrainResult:  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+) -> Any:  # was SDKBrainResult (removed PR-A)
     """
     Run WHO pattern analysis to generate targeting suggestions.
 
@@ -222,24 +220,8 @@ async def run_who_analyzer(
         "Flag underperforming segments that should be deprioritized."
     )
 
-    user_prompt = "".join(prompt_parts)
-
     # Create brain and run
-    brain = create_sdk_brain("campaign_evolution_who")  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    result = await brain.run(
-        prompt=user_prompt,
-        tools=[],  # No tools needed - analyzing provided data
-        output_schema=WHOAnalysis,
-        system=WHO_ANALYZER_SYSTEM_PROMPT,
-    )
-
-    logger.info(
-        f"WHO analyzer complete: confidence={result.data.confidence if result.success else 'N/A'}, "
-        f"cost=${result.cost_aud:.4f}"
-    )
-
-    return result
+    raise NotImplementedError("dead path: sdk_brain removed in PR-A #593")
 
 
 # ============================================

--- a/src/agents/sdk_agents/icp_agent.py
+++ b/src/agents/sdk_agents/icp_agent.py
@@ -20,8 +20,6 @@ from pydantic import BaseModel, Field
 
 from src.agents.sdk_agents.sdk_tools import ICP_TOOLS
 
-# DEAD: from src.integrations.sdk_brain import SDKBrain, SDKBrainResult, create_sdk_brain
-
 logger = logging.getLogger(__name__)
 
 
@@ -195,20 +193,20 @@ class ICPAgent:
     - Self-review for quality
     """
 
-    def __init__(self, brain: SDKBrain | None = None):  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+    def __init__(self, brain: object | None = None):  # was SDKBrain (removed PR-A)
         """
         Initialize ICP Agent.
 
         Args:
             brain: Optional SDKBrain instance (creates one if not provided)
         """
-        self.brain = brain or create_sdk_brain("icp_extraction")  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+        raise NotImplementedError("dead path: sdk_brain removed in PR-A #593")
 
     async def extract(
         self,
         input_data: ICPInput,
         client_id: UUID | None = None,
-    ) -> SDKBrainResult:  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+    ):  # was SDKBrainResult (removed PR-A)
         """
         Extract ICP from input data using SDK Brain.
 
@@ -330,7 +328,7 @@ async def extract_icp(
     social_links: dict | None = None,
     existing_icp: dict | None = None,
     client_id: UUID | None = None,
-) -> SDKBrainResult:  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+):  # was SDKBrainResult (removed PR-A)
     """
     Convenience function to extract ICP.
 

--- a/src/agents/skills/industry_researcher.py
+++ b/src/agents/skills/industry_researcher.py
@@ -34,8 +34,6 @@ from pydantic import BaseModel, Field
 
 from src.agents.skills.base_skill import BaseSkill, SkillResult
 
-# DEAD: from src.integrations.serper import SerperClient, get_serper_client
-
 if TYPE_CHECKING:
     from src.integrations.anthropic import AnthropicClient
 
@@ -170,14 +168,14 @@ QUALITY CRITERIA:
 - Insights should be current (2024-2025 relevant)
 - Suggestions should be practical for cold outreach"""
 
-    def __init__(self, serper_client: SerperClient | None = None):  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+    def __init__(self, serper_client: object | None = None):  # was SerperClient (removed PR-A)
         """
         Initialize Industry Researcher skill.
 
         Args:
             serper_client: Optional Serper client (uses singleton if not provided)
         """
-        self._serper = serper_client or get_serper_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+        raise NotImplementedError("dead path: serper removed in PR-A #593")
 
     async def execute(
         self,

--- a/src/api/routes/webhooks.py
+++ b/src/api/routes/webhooks.py
@@ -41,9 +41,6 @@ from src.engines.closer import get_closer_engine
 # DEPRECATED: Vapi voice engine removed 2026-02-25. Voice stack: ElevenAgents + Twilio AU
 # from src.engines.voice import get_voice_engine
 from src.exceptions import WebhookError
-
-# DEAD: from src.integrations.postmark import get_postmark_client
-# DEAD: from src.integrations.twilio import get_twilio_client
 from src.integrations.unipile import get_unipile_client
 from src.models.activity import Activity
 from src.models.base import ChannelType
@@ -248,81 +245,7 @@ async def postmark_inbound_webhook(
     Returns:
         Success response
     """
-    # Get raw payload and signature
-    payload = await request.json()
-    signature = request.headers.get("X-Postmark-Signature")
-
-    # Verify signature (currently placeholder)
-    # NOTE: Implement custom verification in production
-    if settings.is_production and not verify_postmark_signature(await request.body(), signature):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid webhook signature",
-        )
-
-    try:
-        # Parse webhook payload
-        postmark = get_postmark_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-        parsed = postmark.parse_inbound_webhook(payload)
-
-        # Find lead by email
-        from_email = parsed["from_email"]
-        if not from_email:
-            return {"status": "ignored", "reason": "no_sender_email"}
-
-        lead = await find_lead_by_email(db, from_email)
-        if not lead:
-            return {"status": "ignored", "reason": "lead_not_found"}
-
-        # Check for duplicate processing
-        message_id = parsed["message_id"]
-        if message_id and await check_duplicate_activity(db, lead.id, message_id):
-            return {"status": "ignored", "reason": "already_processed"}
-
-        # Extract message content (prefer stripped text)
-        message = parsed["stripped_text"] or parsed["text_body"] or ""
-        if not message:
-            return {"status": "ignored", "reason": "empty_message"}
-
-        # Process reply via Closer engine
-        closer = get_closer_engine()
-        result = await closer.process_reply(
-            db=db,
-            lead_id=lead.id,
-            message=message,
-            channel=ChannelType.EMAIL,
-            provider_message_id=message_id,
-            in_reply_to=parsed["in_reply_to"],
-            metadata={
-                "from_name": parsed["from_name"],
-                "subject": parsed["subject"],
-                "to_email": parsed["to_email"],
-                "date": parsed["date"],
-                "has_attachments": len(parsed["attachments"]) > 0,
-            },
-        )
-
-        if not result.success:
-            raise WebhookError(
-                url="/webhooks/postmark/inbound",
-                message=f"Reply processing failed: {result.error}",
-            )
-
-        return {
-            "status": "processed",
-            "lead_id": str(lead.id),
-            "intent": result.data["intent"],
-            "confidence": result.data["confidence"],
-            "activity_id": result.data["activity_id"],
-        }
-
-    except Exception as e:
-        # Log error but return 200 to prevent Postmark retries
-        logger.exception("Postmark inbound webhook error: %s", e)
-        return {
-            "status": "error",
-            "error": str(e),
-        }
+    raise NotImplementedError("dead path: postmark removed in PR-A #593")
 
 
 @router.post("/postmark/bounce")
@@ -340,60 +263,7 @@ async def postmark_bounce_webhook(
     Returns:
         Success response
     """
-    payload = await request.json()
-
-    try:
-        # Parse bounce webhook
-        postmark = get_postmark_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-        parsed = postmark.parse_bounce_webhook(payload)
-
-        # Find lead by email
-        email = parsed["email"]
-        if not email:
-            return {"status": "ignored", "reason": "no_email"}
-
-        lead = await find_lead_by_email(db, email)
-        if not lead:
-            return {"status": "ignored", "reason": "lead_not_found"}
-
-        # Update lead status to bounced
-        from src.models.base import LeadStatus
-
-        lead.status = LeadStatus.BOUNCED
-        lead.bounce_count += 1
-
-        # Log bounce activity
-        activity = Activity(
-            client_id=lead.client_id,
-            campaign_id=lead.campaign_id,
-            lead_id=lead.id,
-            channel=ChannelType.EMAIL,
-            action="bounced",
-            provider_message_id=parsed["message_id"],
-            provider="postmark",
-            provider_status=parsed["bounce_type"],
-            metadata={
-                "bounce_type": parsed["bounce_type"],
-                "description": parsed["description"],
-                "details": parsed["details"],
-                "can_activate": parsed["can_activate"],
-            },
-        )
-        db.add(activity)
-
-        await db.commit()
-
-        return {
-            "status": "processed",
-            "lead_id": str(lead.id),
-            "bounce_type": parsed["bounce_type"],
-        }
-
-    except Exception as e:
-        return {
-            "status": "error",
-            "error": str(e),
-        }
+    raise NotImplementedError("dead path: postmark removed in PR-A #593")
 
 
 @router.post("/postmark/spam")
@@ -480,86 +350,7 @@ async def twilio_inbound_webhook(
     Returns:
         TwiML response (empty to acknowledge)
     """
-    # Get form data
-    form_data = await request.form()
-    params = dict(form_data)
-
-    # Get signature for verification
-    signature = request.headers.get("X-Twilio-Signature")
-
-    # Verify signature
-    # Construct full URL for signature verification
-    url = str(request.url)
-    if settings.is_production and not verify_twilio_signature(url, params, signature):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid Twilio signature",
-        )
-
-    try:
-        # Parse webhook payload
-        twilio = get_twilio_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-        parsed = twilio.parse_inbound_webhook(params)
-
-        # Find lead by phone number
-        from_number = parsed["from_number"]
-        if not from_number:
-            # Return empty TwiML to acknowledge
-            return {"status": "ignored", "reason": "no_phone_number"}
-
-        lead = await find_lead_by_phone(db, from_number)
-        if not lead:
-            return {"status": "ignored", "reason": "lead_not_found"}
-
-        # Check for duplicate processing
-        message_sid = parsed["message_sid"]
-        if message_sid and await check_duplicate_activity(db, lead.id, message_sid):
-            return {"status": "ignored", "reason": "already_processed"}
-
-        # Extract message content
-        message = parsed["body"]
-        if not message:
-            return {"status": "ignored", "reason": "empty_message"}
-
-        # Process reply via Closer engine
-        closer = get_closer_engine()
-        result = await closer.process_reply(
-            db=db,
-            lead_id=lead.id,
-            message=message,
-            channel=ChannelType.SMS,
-            provider_message_id=message_sid,
-            metadata={
-                "from_number": from_number,
-                "to_number": parsed["to_number"],
-                "from_city": parsed["from_city"],
-                "from_state": parsed["from_state"],
-                "from_country": parsed["from_country"],
-                "num_media": parsed["num_media"],
-            },
-        )
-
-        if not result.success:
-            raise WebhookError(
-                url="/webhooks/twilio/inbound",
-                message=f"Reply processing failed: {result.error}",
-            )
-
-        # Return empty TwiML response to acknowledge
-        # Twilio expects TwiML, but empty is fine
-        return {
-            "status": "processed",
-            "lead_id": str(lead.id),
-            "intent": result.data["intent"],
-            "confidence": result.data["confidence"],
-        }
-
-    except Exception as e:
-        # Return empty response to prevent Twilio retries
-        return {
-            "status": "error",
-            "error": str(e),
-        }
+    raise NotImplementedError("dead path: twilio removed in PR-A #593")
 
 
 @router.post("/twilio/status")
@@ -577,63 +368,7 @@ async def twilio_status_webhook(
     Returns:
         Success response
     """
-    # Get form data
-    form_data = await request.form()
-    params = dict(form_data)
-
-    try:
-        # Parse status webhook
-        twilio = get_twilio_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-        parsed = twilio.parse_status_webhook(params)
-
-        # Find existing activity by message SID
-        message_sid = parsed["message_sid"]
-        if not message_sid:
-            return {"status": "ignored", "reason": "no_message_sid"}
-
-        stmt = select(Activity).where(Activity.provider_message_id == message_sid)
-        result = await db.execute(stmt)
-        activity = result.scalar_one_or_none()
-
-        if not activity:
-            return {"status": "ignored", "reason": "activity_not_found"}
-
-        # Update activity with delivery status
-        message_status = parsed["message_status"]
-        activity.provider_status = message_status
-
-        # If delivered, create a new activity
-        if message_status == "delivered":
-            delivered_activity = Activity(
-                client_id=activity.client_id,
-                campaign_id=activity.campaign_id,
-                lead_id=activity.lead_id,
-                channel=ChannelType.SMS,
-                action="delivered",
-                provider_message_id=message_sid,
-                provider="twilio",
-                provider_status=message_status,
-            )
-            db.add(delivered_activity)
-
-        # If failed, log the error
-        if message_status in ("failed", "undelivered"):
-            activity.metadata["error_code"] = parsed.get("error_code")
-            activity.metadata["error_message"] = parsed.get("error_message")
-
-        await db.commit()
-
-        return {
-            "status": "processed",
-            "message_sid": message_sid,
-            "message_status": message_status,
-        }
-
-    except Exception as e:
-        return {
-            "status": "error",
-            "error": str(e),
-        }
+    raise NotImplementedError("dead path: twilio removed in PR-A #593")
 
 
 # ============================================

--- a/src/engines/closer.py
+++ b/src/engines/closer.py
@@ -36,8 +36,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.engines.base import BaseEngine, EngineResult
 from src.integrations.anthropic import AnthropicClient, get_anthropic_client
-
-# DEAD: from src.integrations.calendar_booking import generate_booking_link, send_booking_reply
 from src.models.activity import Activity
 from src.models.base import ChannelType, IntentType, LeadStatus
 from src.models.lead import Lead
@@ -471,21 +469,7 @@ class CloserEngine(BaseEngine):
             # Directive 048: Generate personalized booking link and send automated reply
             try:
                 # Generate personalized Calendly booking link
-                booking_link = await generate_booking_link(  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-                    lead_email=lead.email,
-                    lead_name=lead.full_name,
-                    company_name=lead.company,
-                    client_id=lead.client_id,
-                )
-
-                # Send automated reply with booking link
-                await send_booking_reply(  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-                    db=db,
-                    lead=lead,
-                    booking_link=booking_link,
-                )
-                actions.append("booking_link_generated")
-                actions.append("automated_reply_sent")
+                pass  # dead path: calendar_booking removed in PR-A #593
 
                 # CIS: Record ALS tier conversion when meeting is requested
                 try:

--- a/src/engines/email.py
+++ b/src/engines/email.py
@@ -92,7 +92,9 @@ class EmailEngine(OutreachEngine):
     - Warmforge mailbox compatibility
     """
 
-    def __init__(self, salesforge_client: object | None = None):  # was SalesforgeClient (removed PR-A)
+    def __init__(
+        self, salesforge_client: object | None = None
+    ):  # was SalesforgeClient (removed PR-A)
         """
         Initialize Email engine.
 

--- a/src/engines/email.py
+++ b/src/engines/email.py
@@ -60,7 +60,6 @@ from src.engines.content_utils import build_content_snapshot
 from src.exceptions import ResourceRateLimitError
 from src.integrations.redis import rate_limiter
 
-# DEAD: salesforge removed (invalid API key, replaced by Smartlead).
 # from src.integrations.salesforge import SalesforgeClient, get_salesforge_client
 from src.models.activity import Activity
 from src.models.base import ChannelType
@@ -93,7 +92,7 @@ class EmailEngine(OutreachEngine):
     - Warmforge mailbox compatibility
     """
 
-    def __init__(self, salesforge_client: SalesforgeClient | None = None):  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+    def __init__(self, salesforge_client: object | None = None):  # was SalesforgeClient (removed PR-A)
         """
         Initialize Email engine.
 
@@ -111,9 +110,9 @@ class EmailEngine(OutreachEngine):
         return ChannelType.EMAIL
 
     @property
-    def salesforge(self) -> SalesforgeClient:  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+    def salesforge(self):  # was SalesforgeClient (removed PR-A)
         if self._salesforge is None:
-            self._salesforge = get_salesforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+            raise NotImplementedError("dead path: removed in PR-A #593")
         return self._salesforge
 
     async def send(

--- a/src/engines/icp_scraper.py
+++ b/src/engines/icp_scraper.py
@@ -60,7 +60,6 @@ from src.integrations.camoufox_scraper import (
     is_camoufox_available,
 )
 
-# DEAD: siege_waterfall removed (replaced by current pipeline waterfall).
 # from src.integrations.siege_waterfall import (
 #     EnrichmentTier,
 #     SiegeWaterfall,
@@ -177,7 +176,7 @@ class ICPScraperEngine(BaseEngine):
         anthropic_client: AnthropicClient | None = None,
         url_validator: URLValidator | None = None,
         camoufox_scraper: CamoufoxScraper | None = None,
-        siege_waterfall: SiegeWaterfall | None = None,  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+        siege_waterfall: object | None = None,  # was SiegeWaterfall (removed PR-A)
     ):
         """
         Initialize with optional client overrides for testing.
@@ -227,10 +226,10 @@ class ICPScraperEngine(BaseEngine):
         return settings.camoufox_enabled and is_camoufox_available()
 
     @property
-    def siege_waterfall(self) -> SiegeWaterfall:  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+    def siege_waterfall(self):  # was SiegeWaterfall (removed PR-A)
         """Get Siege Waterfall for AU business enrichment."""
         if self._siege_waterfall is None:
-            self._siege_waterfall = get_siege_waterfall()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+            raise NotImplementedError("dead path: removed in PR-A #593")
         return self._siege_waterfall
 
     def _extract_domain(self, url: str) -> str:
@@ -855,8 +854,8 @@ Respond in JSON format only:
                 siege_result = await self.siege_waterfall.enrich_lead(
                     siege_data,
                     skip_tiers=[
-                        EnrichmentTier.LEADMAGIC_EMAIL,  # Skip email (no person data)  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-                        EnrichmentTier.IDENTITY,  # Skip mobile (no person data)  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+                        # EnrichmentTier removed (PR-A #593)
+                        # EnrichmentTier removed (PR-A #593)
                     ],
                 )
 

--- a/src/engines/scout.py
+++ b/src/engines/scout.py
@@ -64,8 +64,6 @@ from src.integrations.camoufox_scraper import CamoufoxScraper
 from src.integrations.dataforseo import get_dataforseo_client  # Directive #218: pre-gate DataForSEO
 from src.integrations.leadmagic import get_leadmagic_client
 from src.integrations.redis import enrichment_cache
-
-# DEAD: from src.integrations.siege_waterfall import EnrichmentTier, SiegeWaterfall, get_siege_waterfall
 from src.models.base import LeadStatus
 from src.models.lead import Lead
 from src.models.lead_social_post import LeadSocialPost
@@ -126,7 +124,7 @@ class ScoutEngine(BaseEngine):
 
     def __init__(
         self,
-        siege_waterfall: SiegeWaterfall | None = None,  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+        siege_waterfall: object | None = None,  # was SiegeWaterfall (removed PR-A)
         camoufox_scraper: CamoufoxScraper | None = None,
     ):
         """
@@ -152,9 +150,9 @@ class ScoutEngine(BaseEngine):
         return self._camoufox
 
     @property
-    def siege_waterfall(self) -> SiegeWaterfall:  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+    def siege_waterfall(self):  # was SiegeWaterfall (removed PR-A)
         if self._siege_waterfall is None:
-            self._siege_waterfall = get_siege_waterfall()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+            raise NotImplementedError("dead path: removed in PR-A #593")
         return self._siege_waterfall
 
     async def enrich_lead(
@@ -863,8 +861,8 @@ class ScoutEngine(BaseEngine):
                 siege_result = await self.siege_waterfall.enrich_lead(
                     lead_data,
                     skip_tiers=[
-                        EnrichmentTier.IDENTITY  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-                    ],  # Skip expensive Tier 5  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+                        # EnrichmentTier removed (PR-A #593)
+                    ],  # Skip expensive Tier 5 (EnrichmentTier removed PR-A)
                 )
 
                 # Directive #200: GMB leads already carry company-level data in
@@ -999,8 +997,8 @@ class ScoutEngine(BaseEngine):
             siege_result = await self.siege_waterfall.enrich_lead(
                 lead_data,
                 skip_tiers=[
-                    EnrichmentTier.IDENTITY  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-                ],  # Skip expensive Tier 5  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+                    # EnrichmentTier removed (PR-A #593)
+                ],  # Skip expensive Tier 5 (EnrichmentTier removed PR-A)
             )
 
             if siege_result.sources_used > 0:

--- a/src/integrations/__init__.py
+++ b/src/integrations/__init__.py
@@ -16,14 +16,10 @@ NOTE: T3 email and T5 mobile enrichment provided by Leadmagic.
 # Agency OS - Integrations Package
 
 from src.integrations.abn_client import ABNClient, get_abn_client
-
-# DEAD: from src.integrations.calendar_booking import router as calendar_booking_router
 from src.integrations.elevenagents_client import ElevenAgentsClient, get_elevenagents_client
 from src.integrations.elevenlabs import ElevenLabsClient, get_elevenlabs_client
 from src.integrations.leadmagic import LeadmagicClient, get_leadmagic_client
 
-# DEAD: from src.integrations.serper import SerperClient, get_serper_client
-# DEAD: from src.integrations.siege_waterfall import SiegeWaterfall, get_siege_waterfall
 # Billing & Booking (stripe_billing.py removed — canonical file is stripe.py)
 # The active billing router lives in src/api/routes/billing.py
 from src.integrations.vapi import VapiClient, get_vapi_client

--- a/src/orchestration/flows/cis_learning_flow.py
+++ b/src/orchestration/flows/cis_learning_flow.py
@@ -27,7 +27,6 @@ import os
 
 from prefect import flow, get_run_logger, task
 
-# DEAD: from src.integrations.sdk_brain import SiegeSDKIntelligence
 from src.integrations.supabase import get_db_session
 from src.prefect_utils.completion_hook import on_completion_hook
 from src.prefect_utils.hooks import on_failure_hook
@@ -91,8 +90,7 @@ async def analyze_with_claude(
     Calls SiegeSDKIntelligence.analyze_cis_outcomes() which uses
     Claude Sonnet 4 with a $2 AUD cost cap.
     """
-    sdk = SiegeSDKIntelligence()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-    return await sdk.analyze_cis_outcomes(outcomes, weights)
+    raise NotImplementedError("dead path: sdk_brain removed in PR-A #593")
 
 
 @task(name="cis-apply-deltas")

--- a/src/orchestration/flows/infra_provisioning_flow.py
+++ b/src/orchestration/flows/infra_provisioning_flow.py
@@ -25,7 +25,6 @@ from uuid import UUID
 from prefect import flow, task
 from prefect.task_runners import ConcurrentTaskRunner
 
-# DEAD: from src.integrations.infraforge import get_infraforge_client
 from src.integrations.supabase import get_db_session
 from src.prefect_utils.completion_hook import on_completion_hook
 from src.prefect_utils.hooks import on_failure_hook
@@ -75,34 +74,7 @@ async def check_domain_availability_task(
     Returns:
         List of available domains with pricing
     """
-    client = get_infraforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    try:
-        # Generate alternatives
-        alternatives = await client.generate_alternative_domains(base_name, count * 2)
-
-        available = []
-        for domain in alternatives.get("domains", []):
-            # Check availability
-            availability = await client.check_domain_availability(domain["name"])
-            if availability.get("available"):
-                available.append(
-                    {
-                        "domain": domain["name"],
-                        "price_usd": availability.get("price", 14),
-                        "price_aud": availability.get("price", 14) * 1.55,
-                    }
-                )
-
-            if len(available) >= count:
-                break
-
-        logger.info(f"Found {len(available)} available domains for base: {base_name}")
-        return available
-
-    except Exception as e:
-        logger.error(f"Domain availability check failed: {e}")
-        raise
+    raise NotImplementedError("dead path: infraforge removed in PR-A #593")
 
 
 @task(name="purchase_domains", retries=1)
@@ -120,33 +92,7 @@ async def purchase_domains_task(
     Returns:
         Purchase result with domain IDs
     """
-    client = get_infraforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    try:
-        # Format for API
-        domain_list = [{"domain": d["domain"]} for d in domains]
-
-        result = await client.buy_domains(domain_list)
-
-        # Calculate cost
-        total_cost_aud = len(domains) * DOMAIN_COST_PER_YEAR_AUD
-
-        logger.info(
-            f"Purchased {len(domains)} domains for client {client_id}. "
-            f"Cost: ${total_cost_aud:.2f} AUD/year"
-        )
-
-        return {
-            "success": True,
-            "domains_purchased": len(domains),
-            "cost_aud_year": total_cost_aud,
-            "cost_aud_month": total_cost_aud / 12,
-            "domain_ids": result.get("domainIds", []),
-        }
-
-    except Exception as e:
-        logger.error(f"Domain purchase failed: {e}")
-        raise
+    raise NotImplementedError("dead path: infraforge removed in PR-A #593")
 
 
 @task(name="create_mailboxes", retries=2, retry_delay_seconds=10)
@@ -170,46 +116,7 @@ async def create_mailboxes_task(
     Returns:
         Mailbox creation result
     """
-    client = get_infraforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    try:
-        mailboxes = []
-        for domain in domains:
-            for i in range(mailboxes_per_domain):
-                # Generate professional email prefixes
-                prefixes = ["outreach", "hello", "contact", "team", "sales"]
-                prefix = prefixes[i % len(prefixes)]
-
-                mailboxes.append(
-                    {
-                        "email": f"{prefix}{i + 1}@{domain}",
-                        "firstName": "Agency",
-                        "lastName": "Outreach",
-                    }
-                )
-
-        result = await client.create_mailboxes(mailboxes)
-
-        # Calculate cost
-        total_mailboxes = len(mailboxes)
-        monthly_cost_aud = total_mailboxes * MAILFORGE_COST_PER_MAILBOX_AUD
-
-        logger.info(
-            f"Created {total_mailboxes} mailboxes across {len(domains)} domains. "
-            f"Cost: ${monthly_cost_aud:.2f} AUD/month"
-        )
-
-        return {
-            "success": True,
-            "mailboxes_created": total_mailboxes,
-            "domains_used": len(domains),
-            "cost_aud_month": monthly_cost_aud,
-            "mailbox_ids": result.get("mailboxIds", []),
-        }
-
-    except Exception as e:
-        logger.error(f"Mailbox creation failed: {e}")
-        raise
+    raise NotImplementedError("dead path: infraforge removed in PR-A #593")
 
 
 @task(name="export_to_warmup", retries=2, retry_delay_seconds=5)
@@ -233,29 +140,7 @@ async def export_to_warmup_task(
     Returns:
         Export result
     """
-    client = get_infraforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    try:
-        await client.export_to_salesforge(
-            from_workspace_id=from_workspace_id,
-            to_workspace_id=to_salesforge_workspace_id,
-            to_warmforge_workspace_id=to_warmforge_workspace_id,
-            tag_name=tag_name,
-            warmup_activated=True,  # Auto-start warmup
-        )
-
-        logger.info(f"Exported mailboxes to Salesforge/WarmForge with tag: {tag_name}")
-
-        return {
-            "success": True,
-            "exported": True,
-            "warmup_activated": True,
-            "tag": tag_name,
-        }
-
-    except Exception as e:
-        logger.error(f"Export to warmup failed: {e}")
-        raise
+    raise NotImplementedError("dead path: infraforge removed in PR-A #593")
 
 
 @task(name="log_provisioning_cost")
@@ -366,19 +251,8 @@ async def infra_provisioning_flow(
         client_id=client_id,
     )
 
-    # Step 4: Export to warmup (if workspace IDs provided)
+    # Step 4: Export to warmup (dead path: infraforge removed in PR-A #593)
     export_result = {"success": False, "skipped": True}
-    if salesforge_workspace_id and warmforge_workspace_id:
-        infraforge_workspace = await get_infraforge_client().list_workspaces()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-        workspace_id = infraforge_workspace.get("workspaces", [{}])[0].get("id")
-
-        if workspace_id:
-            export_result = await export_to_warmup_task(
-                from_workspace_id=workspace_id,
-                to_salesforge_workspace_id=salesforge_workspace_id,
-                to_warmforge_workspace_id=warmforge_workspace_id,
-                tag_name=f"client_{client_id}",
-            )
 
     # Step 5: Log costs
     await log_provisioning_cost_task(

--- a/src/orchestration/flows/reply_recovery_flow.py
+++ b/src/orchestration/flows/reply_recovery_flow.py
@@ -27,11 +27,7 @@ from prefect import flow, task
 from sqlalchemy import and_, select
 
 from src.engines.closer import get_closer_engine
-
-# DEAD: from src.integrations.postmark import get_postmark_client
 from src.integrations.supabase import get_db_session
-
-# DEAD: from src.integrations.twilio import get_twilio_client
 from src.integrations.unipile import get_unipile_client
 from src.models.activity import Activity
 from src.models.base import ChannelType
@@ -60,55 +56,7 @@ async def poll_email_replies_task(since_hours: int = 6) -> dict[str, Any]:
     Returns:
         Dict with replies found
     """
-    postmark_client = get_postmark_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    try:
-        # Poll inbound messages from Postmark
-        since_time = datetime.now(UTC) - timedelta(hours=since_hours)
-
-        replies = await postmark_client.get_inbound_messages(
-            count=100,
-            offset=0,
-        )
-
-        # Filter to messages since cutoff time
-        recent_replies = []
-        for reply in replies:
-            received_at = reply.get("ReceivedAt")
-            if (
-                received_at
-                and datetime.fromisoformat(received_at.replace("Z", "+00:00")) > since_time
-            ):
-                recent_replies.append(
-                    {
-                        "message_id": reply.get("MessageID"),
-                        "from_email": reply.get("From"),
-                        "subject": reply.get("Subject"),
-                        "text_body": reply.get("TextBody"),
-                        "html_body": reply.get("HtmlBody"),
-                        "received_at": received_at,
-                        "in_reply_to": reply.get("Headers", [{}])[0].get("Value")
-                        if reply.get("Headers")
-                        else None,
-                    }
-                )
-
-        logger.info(f"Polled {len(recent_replies)} email replies from last {since_hours} hours")
-
-        return {
-            "channel": "email",
-            "replies_found": len(recent_replies),
-            "replies": recent_replies,
-        }
-
-    except Exception as e:
-        logger.error(f"Failed to poll email replies: {e}")
-        return {
-            "channel": "email",
-            "replies_found": 0,
-            "replies": [],
-            "error": str(e),
-        }
+    raise NotImplementedError("dead path: postmark removed in PR-A #593")
 
 
 @task(name="poll_sms_replies", retries=2, retry_delay_seconds=10)
@@ -124,45 +72,7 @@ async def poll_sms_replies_task(since_hours: int = 6) -> dict[str, Any]:
     Returns:
         Dict with replies found
     """
-    twilio_client = get_twilio_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    try:
-        # Poll inbound messages from Twilio
-        since_time = datetime.now(UTC) - timedelta(hours=since_hours)
-
-        replies = await twilio_client.get_inbound_messages(
-            date_sent_after=since_time,
-            limit=100,
-        )
-
-        recent_replies = []
-        for reply in replies:
-            recent_replies.append(
-                {
-                    "message_sid": reply.get("sid"),
-                    "from_phone": reply.get("from"),
-                    "to_phone": reply.get("to"),
-                    "body": reply.get("body"),
-                    "date_sent": reply.get("date_sent"),
-                }
-            )
-
-        logger.info(f"Polled {len(recent_replies)} SMS replies from last {since_hours} hours")
-
-        return {
-            "channel": "sms",
-            "replies_found": len(recent_replies),
-            "replies": recent_replies,
-        }
-
-    except Exception as e:
-        logger.error(f"Failed to poll SMS replies: {e}")
-        return {
-            "channel": "sms",
-            "replies_found": 0,
-            "replies": [],
-            "error": str(e),
-        }
+    raise NotImplementedError("dead path: twilio removed in PR-A #593")
 
 
 @task(name="poll_linkedin_replies", retries=2, retry_delay_seconds=10)

--- a/src/orchestration/flows/warmup_monitor_flow.py
+++ b/src/orchestration/flows/warmup_monitor_flow.py
@@ -19,8 +19,6 @@ from prefect.runtime import flow_run
 from sqlalchemy import select
 
 from src.config.database import get_db_session
-
-# DEAD: from src.integrations.warmforge import get_warmforge_client
 from src.models.resource_pool import ResourcePool, ResourceStatus, ResourceType
 from src.prefect_utils.completion_hook import on_completion_hook
 from src.prefect_utils.hooks import on_failure_hook
@@ -77,29 +75,7 @@ async def check_warmforge_status_task(domain: str) -> dict:
     Returns:
         Dict with warm, heat_score, mailbox_count, warmed_count
     """
-    log = get_run_logger()
-
-    try:
-        client = get_warmforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-        status = await client.get_domain_warmup_status(domain)
-
-        log.info(
-            f"WarmForge status for {domain}: "
-            f"warm={status['warm']}, heat_score={status['heat_score']}, "
-            f"mailboxes={status['warmed_count']}/{status['mailbox_count']}"
-        )
-
-        return status
-
-    except Exception as e:
-        log.error(f"Failed to check WarmForge for {domain}: {e}")
-        return {
-            "warm": False,
-            "heat_score": 0,
-            "mailbox_count": 0,
-            "warmed_count": 0,
-            "error": str(e),
-        }
+    raise NotImplementedError("dead path: warmforge removed in PR-A #593")
 
 
 @task(name="update_domain_status", retries=2, retry_delay_seconds=5)

--- a/src/orchestration/tasks/reply_tasks.py
+++ b/src/orchestration/tasks/reply_tasks.py
@@ -19,20 +19,16 @@ RULES APPLIED:
 """
 
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
 from prefect import task
-from sqlalchemy import and_, desc, select
+from sqlalchemy import and_, select
 
 from src.engines.closer import CloserEngine
 from src.exceptions import ValidationError
-
-# DEAD: from src.integrations.postmark import get_postmark_client
 from src.integrations.supabase import get_db_session
-
-# DEAD: from src.integrations.twilio import get_twilio_client
 from src.models.base import ChannelType
 from src.models.lead import Lead
 
@@ -222,86 +218,7 @@ async def poll_email_replies_task(
             - failed: int
             - replies: list[dict]
     """
-    if since is None:
-        since = datetime.now(UTC) - timedelta(hours=1)
-
-    logger.info(f"Polling Postmark for email replies since {since}")
-
-    postmark = get_postmark_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    try:
-        # Fetch inbound messages
-        messages = await postmark.get_inbound_messages(
-            count=limit,
-            offset=0,
-        )
-
-        processed = 0
-        failed = 0
-        replies = []
-
-        async with get_db_session() as db:
-            for msg in messages:
-                try:
-                    # Parse message
-                    from_email = msg.get("From", "")
-                    message_content = msg.get("TextBody") or msg.get("HtmlBody", "")
-                    in_reply_to = msg.get("Headers", {}).get("In-Reply-To")
-                    message_id = msg.get("MessageID")
-
-                    # Find lead by email
-                    stmt = (
-                        select(Lead)
-                        .where(
-                            and_(
-                                Lead.email == from_email,
-                                Lead.deleted_at.is_(None),
-                            )
-                        )
-                        .order_by(desc(Lead.created_at))
-                    )
-                    result = await db.execute(stmt)
-                    lead = result.scalar_one_or_none()
-
-                    if not lead:
-                        logger.warning(f"No lead found for email {from_email}")
-                        continue
-
-                    # Process reply
-                    await process_reply_task(
-                        lead_id=lead.id,
-                        message=message_content,
-                        channel=ChannelType.EMAIL,
-                        provider_message_id=message_id,
-                        in_reply_to=in_reply_to,
-                        metadata={"from_polling": True},
-                    )
-
-                    replies.append(
-                        {
-                            "lead_id": str(lead.id),
-                            "from_email": from_email,
-                            "message_id": message_id,
-                        }
-                    )
-                    processed += 1
-
-                except Exception as e:
-                    logger.error(f"Failed to process email reply: {e}")
-                    failed += 1
-
-        logger.info(f"Email polling complete. Processed: {processed}, Failed: {failed}")
-
-        return {
-            "total": len(messages),
-            "processed": processed,
-            "failed": failed,
-            "replies": replies,
-        }
-
-    except Exception as e:
-        logger.error(f"Email polling failed: {e}")
-        raise
+    raise NotImplementedError("dead path: postmark removed in PR-A #593")
 
 
 @task(
@@ -331,83 +248,7 @@ async def poll_sms_replies_task(
             - failed: int
             - replies: list[dict]
     """
-    if since is None:
-        since = datetime.now(UTC) - timedelta(hours=1)
-
-    logger.info(f"Polling Twilio for SMS replies since {since}")
-
-    twilio = get_twilio_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    try:
-        # Fetch messages
-        messages = await twilio.get_messages(
-            date_sent_after=since,
-            limit=limit,
-        )
-
-        processed = 0
-        failed = 0
-        replies = []
-
-        async with get_db_session() as db:
-            for msg in messages:
-                try:
-                    from_number = msg.get("from")
-                    message_content = msg.get("body", "")
-                    message_sid = msg.get("sid")
-
-                    # Find lead by phone
-                    stmt = (
-                        select(Lead)
-                        .where(
-                            and_(
-                                Lead.phone == from_number,
-                                Lead.deleted_at.is_(None),
-                            )
-                        )
-                        .order_by(desc(Lead.created_at))
-                    )
-                    result = await db.execute(stmt)
-                    lead = result.scalar_one_or_none()
-
-                    if not lead:
-                        logger.warning(f"No lead found for phone {from_number}")
-                        continue
-
-                    # Process reply
-                    await process_reply_task(
-                        lead_id=lead.id,
-                        message=message_content,
-                        channel=ChannelType.SMS,
-                        provider_message_id=message_sid,
-                        metadata={"from_polling": True},
-                    )
-
-                    replies.append(
-                        {
-                            "lead_id": str(lead.id),
-                            "from_number": from_number,
-                            "message_sid": message_sid,
-                        }
-                    )
-                    processed += 1
-
-                except Exception as e:
-                    logger.error(f"Failed to process SMS reply: {e}")
-                    failed += 1
-
-        logger.info(f"SMS polling complete. Processed: {processed}, Failed: {failed}")
-
-        return {
-            "total": len(messages),
-            "processed": processed,
-            "failed": failed,
-            "replies": replies,
-        }
-
-    except Exception as e:
-        logger.error(f"SMS polling failed: {e}")
-        raise
+    raise NotImplementedError("dead path: twilio removed in PR-A #593")
 
 
 # NOTE: poll_linkedin_replies_task removed - HeyReach deprecated, use Unipile instead

--- a/src/services/domain_provisioning_service.py
+++ b/src/services/domain_provisioning_service.py
@@ -19,7 +19,6 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-# DEAD: from src.integrations.infraforge import WORKSPACE_IDS, get_infraforge_client
 from src.models.persona import Persona
 from src.models.resource_pool import ResourceStatus, ResourceType
 from src.services.resource_assignment_service import add_resource_to_pool
@@ -30,10 +29,7 @@ logger = logging.getLogger(__name__)
 # ============================================
 # WORKSPACE IDS
 # ============================================
-
-INFRAFORGE_WORKSPACE = WORKSPACE_IDS["infraforge"]  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-SALESFORGE_WORKSPACE = WORKSPACE_IDS["salesforge"]  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-WARMFORGE_WORKSPACE = WORKSPACE_IDS["warmforge"]  # noqa: F821 (PR-A dead-import; clean in PR-A1)
+# Removed: INFRAFORGE/SALESFORGE/WARMFORGE workspace constants — dead imports cleaned in PR-A #593.
 
 
 # ============================================
@@ -119,28 +115,7 @@ async def check_domain_availability(domains: list[str]) -> list[str]:
     Returns:
         List of available domain names
     """
-    client = get_infraforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-    available: list[str] = []
-
-    try:
-        results = await client.check_domain_availability(domains)
-
-        for result in results:
-            domain = result.get("domain", "")
-            is_available = result.get("available", False)
-
-            if is_available:
-                available.append(domain)
-                logger.debug(f"Domain available: {domain}")
-            else:
-                logger.debug(f"Domain unavailable: {domain}")
-
-    except Exception as e:
-        logger.error(f"Error checking domain availability: {e}")
-        # Return empty list on error - caller should handle
-
-    logger.info(f"Availability check: {len(available)}/{len(domains)} domains available")
-    return available
+    raise NotImplementedError("dead path: infraforge removed in PR-A #593")
 
 
 # ============================================
@@ -165,18 +140,7 @@ async def purchase_domains(domains: list[str]) -> list[dict[str, Any]]:
         logger.warning("No domains to purchase")
         return []
 
-    client = get_infraforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-    results = await client.purchase_domains_bulk(domains)
-
-    successful = [r for r in results if r.get("status") != "failed"]
-    failed = [r for r in results if r.get("status") == "failed"]
-
-    if failed:
-        for f in failed:
-            logger.warning(f"Failed to purchase domain {f.get('domain')}: {f.get('error')}")
-
-    logger.info(f"Purchased {len(successful)}/{len(domains)} domains")
-    return successful
+    raise NotImplementedError("dead path: infraforge removed in PR-A #593")
 
 
 # ============================================
@@ -202,38 +166,7 @@ async def create_mailboxes_for_persona(
     Returns:
         List of created mailbox details
     """
-    client = get_infraforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-    mailboxes: list[dict[str, Any]] = []
-
-    # Mailbox configurations
-    mailbox_configs = [
-        {
-            "prefix": persona.first_name.lower(),
-            "display_name": persona.full_name,
-        },
-        {
-            "prefix": f"{persona.first_name[0].lower()}.{persona.last_name.lower()}",
-            "display_name": persona.display_name,
-        },
-    ]
-
-    for config in mailbox_configs:
-        try:
-            result = await client.create_mailbox(
-                domain=domain,
-                email_prefix=config["prefix"],
-                display_name=config["display_name"],
-                first_name=persona.first_name,
-                last_name=persona.last_name,
-            )
-            mailboxes.append(result)
-            logger.info(f"Created mailbox: {result.get('email')}")
-
-        except Exception as e:
-            logger.error(f"Failed to create mailbox {config['prefix']}@{domain}: {e}")
-            # Continue with other mailboxes
-
-    return mailboxes
+    raise NotImplementedError("dead path: infraforge removed in PR-A #593")
 
 
 # ============================================
@@ -262,24 +195,7 @@ async def export_to_salesforge_and_warmup(
         logger.warning("No domains to export")
         return False
 
-    client = get_infraforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-
-    try:
-        result = await client.export_to_salesforge(
-            domains=domains,
-            warmup_activated=True,
-        )
-
-        exported_count = result.get("exported_count", 0)
-        logger.info(
-            f"Exported {exported_count} mailboxes to Salesforge (tag: {tag_name}, warmup: enabled)"
-        )
-
-        return result.get("success", False)
-
-    except Exception as e:
-        logger.error(f"Export to Salesforge failed: {e}")
-        return False
+    raise NotImplementedError("dead path: infraforge removed in PR-A #593")
 
 
 # ============================================
@@ -453,33 +369,7 @@ async def get_warmup_status_for_domains(domains: list[str]) -> list[dict[str, An
     Returns:
         List of warmup status dicts per domain/mailbox
     """
-    client = get_infraforge_client()  # noqa: F821 (PR-A dead-import; clean in PR-A1)
-    statuses: list[dict[str, Any]] = []
-
-    for domain in domains:
-        try:
-            # Get mailboxes for domain
-            mailboxes = await client.get_mailboxes(domain=domain)
-
-            for mailbox in mailboxes:
-                email = mailbox.get("email", "")
-                if not email:
-                    continue
-
-                status = await client.get_warmup_status(email)
-                statuses.append(status)
-
-        except Exception as e:
-            logger.warning(f"Failed to get warmup status for {domain}: {e}")
-            statuses.append(
-                {
-                    "domain": domain,
-                    "status": "error",
-                    "error": str(e),
-                }
-            )
-
-    return statuses
+    raise NotImplementedError("dead path: infraforge removed in PR-A #593")
 
 
 async def provision_domain_only(


### PR DESCRIPTION
## Summary
- Replaces every `noqa: F821` annotation Aiden left after PR-A (#593) with a `raise NotImplementedError(...)` at the dead callsite.
- Removes unreachable code that lived below the dead calls and would have NameError'd on first execution (cis_learning_flow's `sdk.analyze_cis_outcomes`, infra_provisioning's `client.*`, postmark/twilio webhooks, etc.).
- Trims now-unused imports in `src/orchestration/tasks/reply_tasks.py`.

Touches the deleted-integration call paths: gohighlevel, heyreach, twitter, twilio, postmark, warmforge, infraforge, salesforge_client, sdk_brain, serper, siege_waterfall, calendar_booking.

## Verification
```
$ ruff check src/ --select F821
All checks passed!
$ ruff check src/
All checks passed!
$ grep -rln "noqa.*F821" --include="*.py"
(no output)
```

## Out of scope (pre-existing on main, not introduced here)
- `src.orchestration.tasks.enrichment_tasks` imports `EnrichmentError` which doesn't exist in `src/exceptions.py`.
- `src.orchestration.flows.infra_provisioning_flow` `@flow(tags=...)` kwarg incompatible with installed Prefect version.

## Test plan
- [x] `ruff check src/` passes (zero F821, zero F841, zero F401 in touched files)
- [x] `grep -r "noqa.*F821" --include="*.py"` returns nothing
- [x] Importability of touched modules verified (failures isolated to pre-existing unrelated bugs)
- [ ] Aiden review per dual-approval rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)