### PR TITLE
[ELLIOT] docs: sweep src/enrichment/ refs to src/pipeline/ (PR-C2 follow-up)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -77,8 +77,8 @@ Compare main failures vs feature branch to identify failures introduced by #144.
 ## FILES MODIFIED IN PR #131
 
 1. `src/integrations/bright_data_client.py` — GMB discovery methods
-2. `src/enrichment/discovery_modes.py` — GMBFirstDiscovery class
-3. `src/enrichment/query_translator.py` — GMB_FIRST mode
+2. `src/pipeline/discovery_modes.py` — GMBFirstDiscovery class
+3. `src/pipeline/query_translator.py` — GMB_FIRST mode
 4. `src/orchestration/flows/batch_controller_flow.py` — Wire GMB discovery
 5. `src/integrations/siege_waterfall.py` — Enrichment tiers + SIZE_GATE
 6. `src/engines/scorer.py` — Dual scoring system

--- a/docs/integrations/bright-data-inventory.md
+++ b/docs/integrations/bright-data-inventory.md
@@ -358,8 +358,8 @@ HOT_THRESHOLD = 85
 | File | Purpose |
 |------|---------|
 | `src/integrations/bright_data_client.py` | Unified SERP + Scrapers API client |
-| `src/enrichment/discovery_modes.py` | Mode A/B/C discovery logic |
-| `src/enrichment/waterfall_v2.py` | Full Phase 1→2→3 pipeline |
+| `src/pipeline/discovery_modes.py` | Mode A/B/C discovery logic |
+| `src/pipeline/waterfall_v2.py` | Full Phase 1→2→3 pipeline |
 
 ---
 

--- a/docs/pipeline-brief-for-claude.md
+++ b/docs/pipeline-brief-for-claude.md
@@ -87,10 +87,10 @@ Without a gate, we'd run Leadmagic email enrichment on all 2,520 leads that made
 **Codebase:** `/home/elliotbot/clawd`
 
 **Read these first:**
-- `src/enrichment/campaign_trigger.py` — active pipeline entry point
-- `src/enrichment/discovery_modes.py` — current MapsFirstDiscovery
-- `src/enrichment/query_translator.py` — discovery orchestration
-- `src/enrichment/waterfall_v2.py` — enrichment waterfall
+- `src/pipeline/campaign_trigger.py` — active pipeline entry point
+- `src/pipeline/discovery_modes.py` — current MapsFirstDiscovery
+- `src/pipeline/query_translator.py` — discovery orchestration
+- `src/pipeline/waterfall_v2.py` — enrichment waterfall
 - `src/integrations/bright_data_client.py` — BD SERP client
 - `src/integrations/leadmagic.py` — email/mobile enrichment
 - `src/integrations/abn_client.py` — ABN lookup
@@ -1580,9 +1580,9 @@ async def _enrich_lead(self, lead: LeadRecord) -> LeadRecord:
 
 ## FILES TO MODIFY
 
-6. `src/enrichment/discovery_modes.py` — Add `YPFirstDiscovery` class
-7. `src/enrichment/campaign_trigger.py` — Wire YP as T0, add gap scoring pre-step
-8. `src/enrichment/waterfall_v2.py` — Add stages 6-14 to the pipeline
+6. `src/pipeline/discovery_modes.py` — Add `YPFirstDiscovery` class
+7. `src/pipeline/campaign_trigger.py` — Wire YP as T0, add gap scoring pre-step
+8. `src/pipeline/waterfall_v2.py` — Add stages 6-14 to the pipeline
 
 ---
 


### PR DESCRIPTION
## Summary

PR-C2 (#597) moved 9 files from `src/enrichment/` into `src/pipeline/` and deleted the empty directory. Aiden updated docstring refs in dc98885e (commit-only); this PR completes the sweep across `HANDOFF.md` and `docs/`.

**11 references across 3 files** — all simple path swaps (`src/enrichment/X` → `src/pipeline/X`); all target files verified to exist at the new location on main.

## Files updated

- `HANDOFF.md` — 2 refs in PR #131 file list (`discovery_modes.py`, `query_translator.py`)
- `docs/pipeline-brief-for-claude.md` — 7 refs in "Read these first" + "FILES TO MODIFY" sections (`campaign_trigger.py`, `discovery_modes.py`, `query_translator.py`, `waterfall_v2.py`)
- `docs/integrations/bright-data-inventory.md` — 2 refs in file table (`discovery_modes.py`, `waterfall_v2.py`)

## Verification

```
$ rg 'src/enrichment|src\.enrichment' HANDOFF.md docs/
(no matches)
```

```
$ git ls-tree -r origin/main src/pipeline/ | grep -E "(campaign_trigger|waterfall_v2|discovery_modes|query_translator)"
src/pipeline/campaign_trigger.py
src/pipeline/discovery_modes.py
src/pipeline/query_translator.py
src/pipeline/waterfall_v2.py
```

## Test plan

- [x] Zero `src/enrichment/` refs remain in `HANDOFF.md` and `docs/`
- [x] All replacement paths exist in `src/pipeline/` on main
- [x] Diff is path-swap only — no semantic content changes
- [ ] Aiden review

🤖 Generated with [Claude Code](https://claude.com/claude-code)