### PR TITLE
[ORION] fix(integrations): AusTender connector — correct API URL + ISO 8601 + cursor pagination

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@
 testpaths = tests
 
 # Ignore directories that should not be collected
-addopts = --ignore=docs --ignore=scripts --ignore=screenshot-to-code --ignore=test_icp_extraction.py
+addopts = --ignore=docs --ignore=scripts --ignore=screenshot-to-code --ignore=test_icp_extraction.py -m "not live"
 
 # Asyncio mode
 asyncio_mode = auto
@@ -12,3 +12,4 @@ asyncio_default_fixture_loop_scope = function
 # Custom markers
 markers =
     integration: marks tests as integration tests
+    live: hits real external services — opt-in via `pytest -m live`

--- a/src/integrations/austender_client.py
+++ b/src/integrations/austender_client.py
@@ -56,11 +56,7 @@ def _to_iso_z(d: date) -> str:
     The live API rejects bare YYYY-MM-DD; it expects e.g.
     `2026-05-04T00:00:00Z` in the URL path.
     """
-    return (
-        datetime.combine(d, time.min, tzinfo=UTC)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return datetime.combine(d, time.min, tzinfo=UTC).isoformat().replace("+00:00", "Z")
 
 
 class AusTenderClient:
@@ -72,7 +68,9 @@ class AusTenderClient:
     """
 
     def __init__(
-        self, base_url: str = _BASE_URL, timeout: float = _REQUEST_TIMEOUT,
+        self,
+        base_url: str = _BASE_URL,
+        timeout: float = _REQUEST_TIMEOUT,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
@@ -104,8 +102,7 @@ class AusTenderClient:
         self._validate_range(date_from, date_to)
         if value_min_aud < 1000:
             raise ValueError(
-                f"value_min_aud must be >= 1000 AUD (got {value_min_aud}); "
-                "below is noise"
+                f"value_min_aud must be >= 1000 AUD (got {value_min_aud}); below is noise"
             )
 
         first_url = self._base_url + _PATH_TEMPLATE.format(
@@ -141,7 +138,8 @@ class AusTenderClient:
                 if not isinstance(releases, list):
                     logger.warning(
                         "[austender] unexpected releases shape on page %d: %s",
-                        pages, type(releases).__name__,
+                        pages,
+                        type(releases).__name__,
                     )
                     break
 
@@ -150,7 +148,8 @@ class AusTenderClient:
                     if not ocid or ocid in seen_ocids:
                         continue
                     if not _release_clears_value_threshold(
-                        release, value_min_aud,
+                        release,
+                        value_min_aud,
                     ):
                         continue
                     seen_ocids.add(ocid)
@@ -160,20 +159,21 @@ class AusTenderClient:
 
         if pages >= _MAX_PAGES:
             logger.warning(
-                "[austender] hit _MAX_PAGES=%d; cursor truncated", _MAX_PAGES,
+                "[austender] hit _MAX_PAGES=%d; cursor truncated",
+                _MAX_PAGES,
             )
         logger.info(
             "[austender] %d releases ≥ AUD %d across %d page(s)",
-            len(out), value_min_aud, pages,
+            len(out),
+            value_min_aud,
+            pages,
         )
         return out
 
     async def fetch_release_by_id(self, ocid: str) -> dict[str, Any] | None:
         """Fetch a single OCDS release by Open Contracting ID."""
         if not ocid or not isinstance(ocid, str):
-            raise ValueError(
-                f"ocid must be a non-empty string, got {ocid!r}"
-            )
+            raise ValueError(f"ocid must be a non-empty string, got {ocid!r}")
         url = f"{self._base_url}/release/{ocid}"
         logger.info("[austender] GET %s", url)
 
@@ -193,13 +193,9 @@ class AusTenderClient:
     @staticmethod
     def _validate_range(date_from: date, date_to: date) -> None:
         if not isinstance(date_from, date) or not isinstance(date_to, date):
-            raise ValueError(
-                "date_from and date_to must be datetime.date instances"
-            )
+            raise ValueError("date_from and date_to must be datetime.date instances")
         if date_to < date_from:
-            raise ValueError(
-                f"date_to {date_to} is before date_from {date_from}"
-            )
+            raise ValueError(f"date_to {date_to} is before date_from {date_from}")
         if date_to > date.today():
             raise ValueError(f"date_to {date_to} is in the future")
         # NOTE: the legacy 14-day cap was needed for the WAF-fronted
@@ -226,7 +222,8 @@ def _coerce_amount(raw: Any) -> float | None:
 
 
 def _release_clears_value_threshold(
-    release: dict[str, Any], value_min_aud: int,
+    release: dict[str, Any],
+    value_min_aud: int,
 ) -> bool:
     """True iff ANY contract on the release has currency=AUD and amount
     >= value_min_aud. Releases without an AUD amount are dropped."""
@@ -333,11 +330,9 @@ class AwardEvent:
         )
         buyer = next(
             (
-                p for p in parties
-                if any(
-                    r in (p.get("roles") or [])
-                    for r in ("procuringEntity", "buyer")
-                )
+                p
+                for p in parties
+                if any(r in (p.get("roles") or []) for r in ("procuringEntity", "buyer"))
             ),
             None,
         )
@@ -352,15 +347,9 @@ class AwardEvent:
         supplier_name = None
         if supplier:
             supplier_name = supplier.get("name")
-            country = (supplier.get("address") or {}).get(
-                "countryName"
-            ) or supplier.get("country")
+            country = (supplier.get("address") or {}).get("countryName") or supplier.get("country")
             country_norm = (country or "").strip().upper()
-            supplier_country = (
-                "AU"
-                if country_norm in ("AU", "AUSTRALIA", "AUS")
-                else country
-            )
+            supplier_country = "AU" if country_norm in ("AU", "AUSTRALIA", "AUS") else country
             # Try `identifier` first (spec-bare), then walk
             # `additionalIdentifiers` for the AU-ABN entry.
             id_candidates: list[dict[str, Any]] = []
@@ -369,9 +358,7 @@ class AwardEvent:
                 id_candidates.append(primary)
             extra = supplier.get("additionalIdentifiers") or []
             if isinstance(extra, list):
-                id_candidates.extend(
-                    e for e in extra if isinstance(e, dict)
-                )
+                id_candidates.extend(e for e in extra if isinstance(e, dict))
             for ident in id_candidates:
                 if ident.get("scheme") in ("AU-ABN", "ABN"):
                     supplier_abn = canonicalize_abn(ident.get("id"))
@@ -406,9 +393,7 @@ class AwardEvent:
             awarded_date_raw = contracts[0].get("dateSigned")
             items = contracts[0].get("items") or []
             if items:
-                classification_id = (items[0].get("classification") or {}).get(
-                    "id"
-                )
+                classification_id = (items[0].get("classification") or {}).get("id")
         if not awarded_date_raw:
             awards = release.get("awards") or []
             if awards:
@@ -416,18 +401,14 @@ class AwardEvent:
                 if classification_id is None:
                     items = awards[0].get("items") or []
                     if items:
-                        classification_id = (
-                            items[0].get("classification") or {}
-                        ).get("id")
+                        classification_id = (items[0].get("classification") or {}).get("id")
         if not awarded_date_raw:
             awarded_date_raw = release.get("date")
 
         awarded_date: str | None = None
         if awarded_date_raw:
             try:
-                parsed = datetime.fromisoformat(
-                    str(awarded_date_raw).replace("Z", "+00:00")
-                )
+                parsed = datetime.fromisoformat(str(awarded_date_raw).replace("Z", "+00:00"))
                 awarded_date = parsed.date().isoformat()
             except (ValueError, AttributeError):
                 awarded_date = str(awarded_date_raw)
@@ -445,7 +426,9 @@ class AwardEvent:
 
 
 def date_range_chunks(
-    start: date, end: date, step_days: int = 7,
+    start: date,
+    end: date,
+    step_days: int = 7,
 ) -> list[tuple[date, date]]:
     """Split a date range into chunks of <= step_days for paginated fetching.
 

--- a/src/integrations/austender_client.py
+++ b/src/integrations/austender_client.py
@@ -1,7 +1,7 @@
 """src/integrations/austender_client.py — AusTender OCDS API client.
 
 Fetches Australian Government procurement data via the public OCDS-compliant
-JSON API at tenders.gov.au. No authentication required — public open-
+JSON API at api.tenders.gov.au. No authentication required — public open-
 contracting data per AU Government policy.
 
 Per LAW XII (canonical interface): callers go through skills/austender/
@@ -9,13 +9,26 @@ SKILL.md. Direct HTTP calls to AusTender outside this module are forbidden.
 Per LAW XIII: any change to call patterns updates skills/austender/SKILL.md
 in the same PR.
 
+PR #587/#588 originally pointed at https://www.tenders.gov.au/Atm/Search/Ocds
+which is WAF-blocked at the egress layer. The live, public OCDS feed is at
+https://api.tenders.gov.au/ocds. This module:
+
+  - Hits /findByDates/contractPublished/{startISO}/{endISO} with full ISO
+    8601 UTC timestamps (e.g. 2026-05-04T00:00:00Z), not bare YYYY-MM-DD.
+  - Walks links.next cursor pagination (100 releases per page).
+  - Filters by value_min_aud client-side because the public API exposes no
+    `min` query param.
+  - Reads contract value from contracts[i].value.amount (string!) and the
+    buyer party role is `procuringEntity` (the legacy parser used `buyer`,
+    which never matched on the live feed).
+
 Skill spec: skills/austender/SKILL.md (PR #583).
 """
 
 from __future__ import annotations
 
 import logging
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from typing import Any
 
 import httpx
@@ -27,23 +40,40 @@ __all__ = [
     "AusTenderClient",
     "AwardEvent",
     "MIN_CONTRACT_VALUE_AUD",
+    "date_range_chunks",
 ]
 
-_BASE_URL = "https://www.tenders.gov.au/Atm/Search/Ocds"
+_BASE_URL = "https://api.tenders.gov.au/ocds"
+_PATH_TEMPLATE = "/findByDates/contractPublished/{start_iso}/{end_iso}"
 _REQUEST_TIMEOUT = 30.0
-_MAX_DATE_RANGE_DAYS = 14  # OCDS endpoints time out on wide ranges
+_MAX_PAGES = 200  # safety belt — 200 × 100 releases ≈ 20k contracts/window
 MIN_CONTRACT_VALUE_AUD = 50000  # Below this is panel-renewal noise.
+
+
+def _to_iso_z(d: date) -> str:
+    """Format `d` as a full ISO 8601 UTC timestamp ending in `Z`.
+
+    The live API rejects bare YYYY-MM-DD; it expects e.g.
+    `2026-05-04T00:00:00Z` in the URL path.
+    """
+    return (
+        datetime.combine(d, time.min, tzinfo=UTC)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 class AusTenderClient:
     """Lightweight client for the AusTender OCDS endpoints.
 
     Designed for daily-cron + ad-hoc backfill use. No auth, no rate-limit key —
-    public REST. Wrapper enforces date-range limits and value thresholds before
-    hitting the network.
+    public REST. Wrapper enforces date-range sanity + value thresholds before
+    hitting the network. Cursor pagination is automatic.
     """
 
-    def __init__(self, base_url: str = _BASE_URL, timeout: float = _REQUEST_TIMEOUT):
+    def __init__(
+        self, base_url: str = _BASE_URL, timeout: float = _REQUEST_TIMEOUT,
+    ) -> None:
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
 
@@ -53,62 +83,97 @@ class AusTenderClient:
         date_to: date,
         value_min_aud: int = MIN_CONTRACT_VALUE_AUD,
     ) -> list[dict[str, Any]]:
-        """Fetch award events between two dates (inclusive).
+        """Fetch OCDS releases with contractPublished in [date_from, date_to].
 
         Args:
             date_from: lower bound (inclusive). Reject if > today.
-            date_to: upper bound (inclusive). Reject if range > 14 days.
-            value_min_aud: minimum contract value AUD. Reject below 1000 (noise).
+            date_to: upper bound (inclusive). Must be >= date_from.
+            value_min_aud: minimum contract value AUD applied client-side.
+                Reject below 1000 (noise).
 
         Returns:
-            List of OCDS release dicts — raw, unparsed. Caller filters / parses.
+            List of OCDS release dicts (raw, unparsed). The caller invokes
+            AwardEvent.from_ocds_release() per element. Releases below
+            value_min_aud are dropped here so the consumer doesn't waste
+            cycles parsing them.
 
         Raises:
             ValueError on validation failure.
-            httpx.HTTPStatusError on non-2xx after retries.
+            httpx.HTTPStatusError on non-2xx (no retry — caller decides).
         """
         self._validate_range(date_from, date_to)
         if value_min_aud < 1000:
             raise ValueError(
-                f"value_min_aud must be >= 1000 AUD (got {value_min_aud}); below is noise"
+                f"value_min_aud must be >= 1000 AUD (got {value_min_aud}); "
+                "below is noise"
             )
 
-        params = {
-            "from": date_from.isoformat(),
-            "to": date_to.isoformat(),
-            "min": str(value_min_aud),
-        }
-        url = f"{self._base_url}/contracts.json"
-        logger.info("[austender] GET %s params=%s", url, params)
+        first_url = self._base_url + _PATH_TEMPLATE.format(
+            start_iso=_to_iso_z(date_from),
+            end_iso=_to_iso_z(date_to),
+        )
+        logger.info("[austender] GET %s", first_url)
 
+        out: list[dict[str, Any]] = []
+        seen_ocids: set[str] = set()
+        url: str | None = first_url
+        pages = 0
         async with httpx.AsyncClient(timeout=self._timeout) as client:
-            try:
-                response = await client.get(url, params=params)
-                response.raise_for_status()
-            except httpx.HTTPStatusError as exc:
-                logger.error(
-                    "[austender] %d %s for %s",
-                    exc.response.status_code,
-                    exc.response.reason_phrase,
-                    url,
-                )
-                raise
-            except httpx.RequestError as exc:
-                logger.error("[austender] request error %s: %s", url, exc)
-                raise
+            while url and pages < _MAX_PAGES:
+                pages += 1
+                try:
+                    response = await client.get(url)
+                    response.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    logger.error(
+                        "[austender] %d %s for %s",
+                        exc.response.status_code,
+                        exc.response.reason_phrase,
+                        url,
+                    )
+                    raise
+                except httpx.RequestError as exc:
+                    logger.error("[austender] request error %s: %s", url, exc)
+                    raise
 
-        data = response.json()
-        releases = data.get("releases") or data.get("contracts") or []
-        if not isinstance(releases, list):
-            logger.warning("[austender] unexpected response shape: %s", type(releases).__name__)
-            return []
-        logger.info("[austender] fetched %d releases", len(releases))
-        return releases
+                data = response.json()
+                releases = data.get("releases") or []
+                if not isinstance(releases, list):
+                    logger.warning(
+                        "[austender] unexpected releases shape on page %d: %s",
+                        pages, type(releases).__name__,
+                    )
+                    break
+
+                for release in releases:
+                    ocid = release.get("ocid") or release.get("id")
+                    if not ocid or ocid in seen_ocids:
+                        continue
+                    if not _release_clears_value_threshold(
+                        release, value_min_aud,
+                    ):
+                        continue
+                    seen_ocids.add(ocid)
+                    out.append(release)
+
+                url = (data.get("links") or {}).get("next")
+
+        if pages >= _MAX_PAGES:
+            logger.warning(
+                "[austender] hit _MAX_PAGES=%d; cursor truncated", _MAX_PAGES,
+            )
+        logger.info(
+            "[austender] %d releases ≥ AUD %d across %d page(s)",
+            len(out), value_min_aud, pages,
+        )
+        return out
 
     async def fetch_release_by_id(self, ocid: str) -> dict[str, Any] | None:
         """Fetch a single OCDS release by Open Contracting ID."""
         if not ocid or not isinstance(ocid, str):
-            raise ValueError(f"ocid must be a non-empty string, got {ocid!r}")
+            raise ValueError(
+                f"ocid must be a non-empty string, got {ocid!r}"
+            )
         url = f"{self._base_url}/release/{ocid}"
         logger.info("[austender] GET %s", url)
 
@@ -128,16 +193,61 @@ class AusTenderClient:
     @staticmethod
     def _validate_range(date_from: date, date_to: date) -> None:
         if not isinstance(date_from, date) or not isinstance(date_to, date):
-            raise ValueError("date_from and date_to must be datetime.date instances")
+            raise ValueError(
+                "date_from and date_to must be datetime.date instances"
+            )
         if date_to < date_from:
-            raise ValueError(f"date_to {date_to} is before date_from {date_from}")
+            raise ValueError(
+                f"date_to {date_to} is before date_from {date_from}"
+            )
         if date_to > date.today():
             raise ValueError(f"date_to {date_to} is in the future")
-        if (date_to - date_from).days > _MAX_DATE_RANGE_DAYS:
-            raise ValueError(
-                f"range too wide: {(date_to - date_from).days} days > "
-                f"{_MAX_DATE_RANGE_DAYS} (use multiple calls)"
-            )
+        # NOTE: the legacy 14-day cap was needed for the WAF-fronted
+        # /Atm/Search/Ocds endpoint which timed out. The api.tenders.gov.au
+        # feed paginates with `links.next`, so wide ranges work — we no
+        # longer enforce a hard upper bound here. date_range_chunks() is
+        # still exported for callers that want to slice for memory/log
+        # reasons, but it's no longer required for correctness.
+
+
+def _coerce_amount(raw: Any) -> float | None:
+    """Convert OCDS value.amount to float. The live feed returns it as a
+    string (e.g. '607987.88'); accept int/float too for forward-compat."""
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, str):
+        try:
+            return float(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _release_clears_value_threshold(
+    release: dict[str, Any], value_min_aud: int,
+) -> bool:
+    """True iff ANY contract on the release has currency=AUD and amount
+    >= value_min_aud. Releases without an AUD amount are dropped."""
+    contracts = release.get("contracts") or []
+    for c in contracts:
+        value = c.get("value") or {}
+        if value.get("currency") != "AUD":
+            continue
+        amount = _coerce_amount(value.get("amount"))
+        if amount is not None and amount >= value_min_aud:
+            return True
+    # Fall back to award.value when contract.value is absent (older releases).
+    awards = release.get("awards") or []
+    for a in awards:
+        value = a.get("value") or {}
+        if value.get("currency") != "AUD":
+            continue
+        amount = _coerce_amount(value.get("amount"))
+        if amount is not None and amount >= value_min_aud:
+            return True
+    return False
 
 
 # ── Parser ────────────────────────────────────────────────────────────────────
@@ -153,7 +263,7 @@ class AwardEvent:
         supplier_country (str | None): for filter; we only persist 'AU'
         contract_value_aud (int | None): cast to int AUD, None if non-AUD or missing
         awarded_date (str | None): ISO 8601 date string
-        agency_name (str | None): buyer party name
+        agency_name (str | None): buyer / procuringEntity party name
         classification_id (str | None): UNSPSC or AusTender category code
     """
 
@@ -179,7 +289,7 @@ class AwardEvent:
         awarded_date: str | None,
         agency_name: str | None,
         classification_id: str | None,
-    ):
+    ) -> None:
         self.contract_id = contract_id
         self.supplier_abn = supplier_abn
         self.supplier_name = supplier_name
@@ -200,6 +310,13 @@ class AwardEvent:
         Returns None if the release lacks required structural fields
         (contract_id, supplier party). Filtering on supplier ABN / country /
         currency happens at this layer; downstream gets a typed object or None.
+
+        Live-feed reality (api.tenders.gov.au, 2026-05):
+          - Buyer party role is `procuringEntity` (NOT `buyer` as the OCDS
+            spec suggests). Accept both for forward-compat.
+          - Award value lives at contracts[i].value, not awards[i].value.
+            Fall back to award.value if contract.value is absent.
+          - amount fields are strings ('607987.88'), not numbers.
         """
         from src.pipeline.abn_match import canonicalize_abn
 
@@ -207,57 +324,113 @@ class AwardEvent:
         if not contract_id:
             return None
 
-        # Find supplier and buyer parties
+        # Find supplier and buyer parties. Live feed uses 'procuringEntity'
+        # for the buyer; legacy data may also use 'buyer'.
         parties = release.get("parties") or []
         supplier = next(
             (p for p in parties if "supplier" in (p.get("roles") or [])),
             None,
         )
         buyer = next(
-            (p for p in parties if "buyer" in (p.get("roles") or [])),
+            (
+                p for p in parties
+                if any(
+                    r in (p.get("roles") or [])
+                    for r in ("procuringEntity", "buyer")
+                )
+            ),
             None,
         )
 
-        # Supplier ABN canonicalisation (silent drop on non-AU / missing)
+        # Supplier ABN canonicalisation (silent drop on non-AU / missing).
+        # Live feed reality (api.tenders.gov.au, 2026-05):
+        #   - ABN lives in `additionalIdentifiers` (an array), not the
+        #     spec-bare `identifier` field. Check both.
+        #   - countryName is uppercase 'AUSTRALIA', not the spec 'Australia'.
         supplier_abn = None
         supplier_country = None
         supplier_name = None
         if supplier:
             supplier_name = supplier.get("name")
-            country = (supplier.get("address") or {}).get("countryName") or supplier.get("country")
-            supplier_country = "AU" if country in ("AU", "Australia", "AUS") else country
-            identifier = supplier.get("identifier") or {}
-            if identifier.get("scheme") in ("AU-ABN", "ABN"):
-                supplier_abn = canonicalize_abn(identifier.get("id"))
+            country = (supplier.get("address") or {}).get(
+                "countryName"
+            ) or supplier.get("country")
+            country_norm = (country or "").strip().upper()
+            supplier_country = (
+                "AU"
+                if country_norm in ("AU", "AUSTRALIA", "AUS")
+                else country
+            )
+            # Try `identifier` first (spec-bare), then walk
+            # `additionalIdentifiers` for the AU-ABN entry.
+            id_candidates: list[dict[str, Any]] = []
+            primary = supplier.get("identifier")
+            if isinstance(primary, dict):
+                id_candidates.append(primary)
+            extra = supplier.get("additionalIdentifiers") or []
+            if isinstance(extra, list):
+                id_candidates.extend(
+                    e for e in extra if isinstance(e, dict)
+                )
+            for ident in id_candidates:
+                if ident.get("scheme") in ("AU-ABN", "ABN"):
+                    supplier_abn = canonicalize_abn(ident.get("id"))
+                    if supplier_abn:
+                        break
 
-        # Award value — AUD only (LAW II)
+        # Award value — AUD only (LAW II). Prefer contract.value (where the
+        # live feed actually puts it); fall back to award.value.
         contract_value_aud: int | None = None
-        awarded_date: str | None = None
-        awards = release.get("awards") or []
-        if awards:
-            first_award = awards[0]
-            value_obj = first_award.get("value") or {}
-            currency = value_obj.get("currency")
-            amount = value_obj.get("amount")
-            if currency == "AUD" and isinstance(amount, int | float):
-                contract_value_aud = int(amount)
-            awarded_date_raw = first_award.get("date") or release.get("date")
-            if awarded_date_raw:
-                # Normalise to YYYY-MM-DD
-                try:
-                    parsed = datetime.fromisoformat(awarded_date_raw.replace("Z", "+00:00"))
-                    awarded_date = parsed.date().isoformat()
-                except (ValueError, AttributeError):
-                    awarded_date = awarded_date_raw
+        contracts = release.get("contracts") or []
+        for c in contracts:
+            value_obj = c.get("value") or {}
+            if value_obj.get("currency") == "AUD":
+                amount = _coerce_amount(value_obj.get("amount"))
+                if amount is not None:
+                    contract_value_aud = int(amount)
+                    break
+        if contract_value_aud is None:
+            for a in release.get("awards") or []:
+                value_obj = a.get("value") or {}
+                if value_obj.get("currency") == "AUD":
+                    amount = _coerce_amount(value_obj.get("amount"))
+                    if amount is not None:
+                        contract_value_aud = int(amount)
+                        break
 
-            # Classification
-            items = first_award.get("items") or []
-            classification_id = None
+        # Award date + classification — prefer contract.dateSigned, fall
+        # back to award.date, then release.date.
+        awarded_date_raw: str | None = None
+        classification_id: str | None = None
+        if contracts:
+            awarded_date_raw = contracts[0].get("dateSigned")
+            items = contracts[0].get("items") or []
             if items:
-                cls_obj = items[0].get("classification") or {}
-                classification_id = cls_obj.get("id")
-        else:
-            classification_id = None
+                classification_id = (items[0].get("classification") or {}).get(
+                    "id"
+                )
+        if not awarded_date_raw:
+            awards = release.get("awards") or []
+            if awards:
+                awarded_date_raw = awards[0].get("date")
+                if classification_id is None:
+                    items = awards[0].get("items") or []
+                    if items:
+                        classification_id = (
+                            items[0].get("classification") or {}
+                        ).get("id")
+        if not awarded_date_raw:
+            awarded_date_raw = release.get("date")
+
+        awarded_date: str | None = None
+        if awarded_date_raw:
+            try:
+                parsed = datetime.fromisoformat(
+                    str(awarded_date_raw).replace("Z", "+00:00")
+                )
+                awarded_date = parsed.date().isoformat()
+            except (ValueError, AttributeError):
+                awarded_date = str(awarded_date_raw)
 
         return cls(
             contract_id=str(contract_id),
@@ -271,10 +444,14 @@ class AwardEvent:
         )
 
 
-def date_range_chunks(start: date, end: date, step_days: int = 7) -> list[tuple[date, date]]:
+def date_range_chunks(
+    start: date, end: date, step_days: int = 7,
+) -> list[tuple[date, date]]:
     """Split a date range into chunks of <= step_days for paginated fetching.
 
-    Used by the backfill flow to avoid OCDS timeouts on wide ranges.
+    No longer required for correctness on api.tenders.gov.au (cursor paging
+    handles wide ranges) — kept for callers that want bounded log output or
+    progress checkpoints during large backfills.
     """
     if end < start:
         return []

--- a/tests/integrations/test_austender_client.py
+++ b/tests/integrations/test_austender_client.py
@@ -141,12 +141,121 @@ def test_parser_handles_no_supplier_party():
 
 
 def test_parser_handles_missing_awards():
-    """No awards → contract_value_aud and awarded_date are None."""
+    """No awards AND no contracts → contract_value_aud is None.
+
+    awarded_date now falls back to release.date when neither
+    contracts.dateSigned nor awards.date is set — that's the most truthful
+    timestamp the live feed gives us, so we don't drop the row.
+    """
     release = _release_fixture(awards=[])
     event = AwardEvent.from_ocds_release(release)
     assert event is not None
     assert event.contract_value_aud is None
-    assert event.awarded_date is None
+    assert event.awarded_date == "2026-04-15"
+
+
+def test_parser_reads_value_from_contracts_first():
+    """When both contract.value and award.value exist, contract.value
+    wins — matches the live api.tenders.gov.au shape (PR #587/#588 fix)."""
+    release = _release_fixture(
+        contracts=[
+            {
+                "id": "CN-1",
+                "dateSigned": "2026-04-15T00:00:00Z",
+                "value": {"amount": "150000.50", "currency": "AUD"},
+            }
+        ],
+        awards=[
+            {
+                "date": "2026-04-15T00:00:00Z",
+                "value": {"amount": 75000, "currency": "AUD"},
+            }
+        ],
+    )
+    event = AwardEvent.from_ocds_release(release)
+    assert event is not None
+    assert event.contract_value_aud == 150000
+
+
+def test_parser_accepts_string_amounts():
+    """Live feed sends value.amount as a JSON string (e.g. '607987.88').
+    Parser must coerce — not crash on the type mismatch."""
+    release = _release_fixture(
+        contracts=[
+            {
+                "id": "CN-2",
+                "dateSigned": "2026-04-15T00:00:00Z",
+                "value": {"amount": "607987.88", "currency": "AUD"},
+            }
+        ],
+        awards=[],
+    )
+    event = AwardEvent.from_ocds_release(release)
+    assert event is not None
+    assert event.contract_value_aud == 607987
+
+
+def test_parser_reads_abn_from_additional_identifiers():
+    """Live feed puts the AU-ABN under `additionalIdentifiers` (array),
+    not the spec-bare `identifier` field. Parser must walk both."""
+    release = _release_fixture(
+        parties=[
+            {
+                "name": "Hamilton Company Australia",
+                "roles": ["supplier"],
+                "additionalIdentifiers": [
+                    {"id": "50674984886", "scheme": "AU-ABN"},
+                ],
+                "address": {"countryName": "AUSTRALIA"},
+            },
+            {"name": "Buyer", "roles": ["procuringEntity"]},
+        ],
+    )
+    event = AwardEvent.from_ocds_release(release)
+    assert event is not None
+    assert event.supplier_abn is not None
+    assert event.supplier_country == "AU"
+    assert event.is_au_supplier() is True
+
+
+def test_parser_normalises_uppercase_australia_country():
+    """countryName comes through as 'AUSTRALIA' on the live feed.
+    Match must be case-insensitive."""
+    release = _release_fixture(
+        parties=[
+            {
+                "name": "Acme",
+                "roles": ["supplier"],
+                "identifier": {"scheme": "AU-ABN", "id": "33051775556"},
+                "address": {"countryName": "AUSTRALIA"},
+            },
+        ],
+    )
+    event = AwardEvent.from_ocds_release(release)
+    assert event is not None
+    assert event.supplier_country == "AU"
+
+
+def test_parser_recognises_procuringEntity_role():
+    """Live feed uses role 'procuringEntity' (OCDS extension) instead of
+    the spec-bare 'buyer'. Parser must accept both for buyer-name lookup."""
+    release = _release_fixture(
+        parties=[
+            {
+                "name": "Acme Pty Ltd",
+                "roles": ["supplier"],
+                "identifier": {"scheme": "AU-ABN", "id": "33051775556"},
+                "address": {"countryName": "AU"},
+            },
+            {
+                "name": "Department of Defence",
+                "roles": ["procuringEntity"],
+            },
+        ],
+    )
+    event = AwardEvent.from_ocds_release(release)
+    assert event is not None
+    assert event.agency_name == "Department of Defence"
 
 
 def test_is_au_supplier_only_when_abn_and_country_match():
@@ -206,13 +315,25 @@ async def test_fetch_awards_rejects_inverted_range():
 
 
 @pytest.mark.asyncio
-async def test_fetch_awards_rejects_wide_range():
+async def test_fetch_awards_accepts_wide_range():
+    """The legacy WAF-fronted endpoint timed out on >14-day ranges, so the
+    client used to raise. api.tenders.gov.au paginates with links.next, so
+    wide ranges are now valid input — validation must NOT raise."""
     client = AusTenderClient()
-    with pytest.raises(ValueError, match="too wide"):
-        await client.fetch_awards(
+    # Don't actually hit the network here — patch httpx so this stays fast.
+    from unittest.mock import AsyncMock, patch
+    fake_response = AsyncMock()
+    fake_response.raise_for_status = lambda: None
+    fake_response.json = lambda: {"releases": [], "links": {}}
+    fake_client = AsyncMock()
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.get = AsyncMock(return_value=fake_response)
+    with patch("httpx.AsyncClient", return_value=fake_client):
+        result = await client.fetch_awards(
             date_from=date(2026, 1, 1),
-            date_to=date(2026, 5, 1),  # ~120 days
+            date_to=date(2026, 4, 30),  # ~120 days — old code would raise
         )
+    assert result == []
 
 
 @pytest.mark.asyncio
@@ -236,3 +357,39 @@ async def test_fetch_release_by_id_rejects_empty_ocid():
 def test_min_contract_value_constant():
     """Sanity: documented threshold matches research finding."""
     assert MIN_CONTRACT_VALUE_AUD == 50000
+
+
+# ── Live smoke (network) ─────────────────────────────────────────────────────
+# Process lesson from PR #587/#588: connector unit tests passed against the
+# WAF-blocked legacy URL because every HTTP call was mocked. Mocks pass
+# against any URL. We add at least one live smoke that hits the real
+# api.tenders.gov.au feed — guarded by `live` marker so default `pytest`
+# skips it; CI / manual verification runs `pytest -m live`.
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_fetch_awards_live_smoke_returns_releases():
+    """Hit api.tenders.gov.au for the last 7 closed days, ≥AUD 50k.
+
+    Asserts only that the call succeeds and returns ≥1 release — the
+    point is to catch URL/path/format breakage early. The number of
+    releases on any given week varies; the only zero-tolerance signal
+    is total breakage (URL change, WAF block, schema rename)."""
+    from datetime import timedelta
+
+    today = date.today()
+    awards = await AusTenderClient().fetch_awards(
+        date_from=today - timedelta(days=7),
+        date_to=today - timedelta(days=1),
+        value_min_aud=50_000,
+    )
+    assert isinstance(awards, list)
+    assert len(awards) > 0, (
+        "live AusTender feed returned 0 releases — "
+        "URL/path/format may have regressed"
+    )
+    # Spot-check the payload shape so we notice if OCDS schema drifts.
+    sample = awards[0]
+    assert "ocid" in sample or "id" in sample
+    assert "contracts" in sample or "awards" in sample


### PR DESCRIPTION
## Summary
Fixes the WAF-blocked AusTender connector landed in PR #587 / #588. References [AIDEN] research findings dispatched 2026-05-07.

The connector pointed at `https://www.tenders.gov.au/Atm/Search/Ocds` which is WAF-blocked at the egress layer (returned 403 in production). The live, public OCDS feed lives at `https://api.tenders.gov.au/ocds` with a different path shape, ISO 8601 timestamp format, and cursor-based pagination — none of which the legacy code handled.

## Five fixes in `src/integrations/austender_client.py`

| # | What | Before | After |
|---|------|--------|-------|
| 1 | Base URL | `www.tenders.gov.au/Atm/Search/Ocds` (WAF) | `api.tenders.gov.au/ocds` |
| 2 | Path | `/contracts.json?from=&to=&min=` (404) | `/findByDates/contractPublished/{startISO}/{endISO}` |
| 3 | Date format | `date.isoformat()` (`2026-05-04`) | `datetime.combine(d, time.min, tzinfo=UTC).isoformat().replace("+00:00","Z")` (`2026-05-04T00:00:00Z`) |
| 4 | `min` query param | sent as query; API ignored it | filter client-side post-paging |
| 5 | Pagination | single GET (lost everything past first 100) | walk `data["links"]["next"]` until exhausted (safety belt: `_MAX_PAGES=200`) |

Removed `_MAX_DATE_RANGE_DAYS=14` cap — cursor paging makes wide ranges safe. `date_range_chunks()` kept for callers that want bounded log output during large backfills.

## Bonus parser fixes uncovered by the dry-run gate

The original `AwardEvent.from_ocds_release()` had four assumptions that don't match the live feed. Without these, the dry-run hit `fetched=634, parsed=634, non_au_filtered=634, would-write=0` — every release was getting dropped at the AU-supplier filter.

- **Contract value lives at `contracts[i].value`, not `awards[i].value`.** Parser preferred awards-side; live data has it on contracts. Fix prefers contract.value, falls back to award.value.
- **`value.amount` is a JSON string** (`"607987.88"`), not a number. Coerce.
- **Buyer role is `procuringEntity`** on the live feed, not the OCDS-spec `buyer`. Accept both.
- **Supplier ABN lives under `additionalIdentifiers`** (array), not the spec-bare `identifier`. Walk both.
- **`countryName` is uppercase `AUSTRALIA`**. Case-insensitive match.

After these: dry-run shows `fetched=634, parsed=634, non_au_filtered=44, would-write=590, errors=0`.

## Process lesson encoded in the test commit

PR #587/#588 unit tests passed against the WAF-blocked URL because every HTTP call was mocked. **Mocks pass against any URL.** Going forward, connector test suites must include at least one live smoke marker. Added `@pytest.mark.live test_fetch_awards_live_smoke_returns_releases` — deselected from default `pytest` via `addopts -m "not live"`, opted in via `pytest -m live`.

## Verification gates (all green)

```
$ ruff check src/integrations/austender_client.py
All checks passed!

$ pytest tests/integrations/test_austender_client.py
26 passed, 1 deselected in 0.69s

$ python3 -c "import asyncio; from src.integrations.austender_client import AusTenderClient; from datetime import date, timedelta; today=date.today(); awards=asyncio.run(AusTenderClient().fetch_awards(today-timedelta(days=7), today-timedelta(days=1), value_min_aud=50000)); print(f'Got {len(awards)} awards')"
Got 634 awards

$ python3 scripts/ingest_austender.py --backfill-days 7
Ingest Result — DRY-RUN
  Fetched (raw OCDS):      634
  Parsed (typed events):   634
  Filtered non-AU:         44
  Filtered low-value:      0
  Would-write (eligible):  590
  Errors:                  0
```

## Test plan
- [x] ruff clean on `src/integrations/austender_client.py`
- [x] 26/26 unit tests pass (was 21; +5 covering the parser-shape fixes)
- [x] 1 live smoke (`pytest -m live`) — passes against real `api.tenders.gov.au`
- [x] Live `fetch_awards` returns 634 awards on a 7-day window ≥ AUD 50k
- [x] `scripts/ingest_austender.py --backfill-days 7` (dry-run): `errors=0`, `would-write=590`
- [ ] Aiden review before merge
- [ ] After merge: enable the `pytest -m live` job in CI so URL/path drift is caught early

🤖 Generated with [Claude Code](https://claude.com/claude-code)