### PR TITLE
[AIDEN] govern: strip stale architecture from CLAUDE.md modules, pointer-only

### DIFF
--- a/.claude/modules/_dead_references.md
+++ b/.claude/modules/_dead_references.md
@@ -1,9 +1,3 @@
 ## Dead References (Do Not Use)
 
-**Source of truth:** [ARCHITECTURE.md](../../ARCHITECTURE.md) §SECTION 3 (Deprecated Vendors).
-
-**DO NOT maintain the deprecated-vendors list in this file.** Read ARCHITECTURE.md §3 fresh every session.
-
-Duplicating the list creates drift — the previous table here missed entries ratified into ARCHITECTURE.md after this file's last update (e.g. Direct mail removed permanently as a channel; Lemlist + SmartLead never accepted into SSOT despite recommendation drafts).
-
-Any deprecation list previously living in this file was stale and removed (Layer 1 SSOT alignment, 2026-05-07).
+See [ARCHITECTURE.md](../../ARCHITECTURE.md) §SECTION 3. Read fresh every session. DO NOT maintain the deprecated-vendors list in this file.

--- a/.claude/modules/_dead_references.md
+++ b/.claude/modules/_dead_references.md
@@ -1,13 +1,9 @@
 ## Dead References (Do Not Use)
 
-| Dead | Replacement |
-|------|-------------|
-| Proxycurl | Bright Data LinkedIn Profile (gd_l1viktl72bvl7bjuj0) |
-| Apollo (enrichment) | Waterfall Tiers 1-5 |
-| Apify (GMB scraping) | Bright Data GMB Web Scraper (gd_m8ebnr0q2qlklc02fz). EXCEPTION: Apify harvestapi/linkedin-profile-scraper active in Pipeline F v2.1 for L2 LinkedIn verification. Apify facebook-posts-scraper active for Stage 9 social. |
-| SDK agents (enrichment/email/voice_kb) | Smart Prompts + sdk_brain.py |
-| MEMORY.md (new writes) | Supabase elliot_internal.memories |
-| HANDOFF.md (new writes) | Supabase elliot_internal.memories |
-| HunterIO (email verify) | Leadmagic ($0.015/email). EXCEPTION: Hunter email-finder active in Pipeline F v2.1 as L2 email fallback (score >= 70). |
-| Kaspr | Leadmagic mobile ($0.077) |
-| ABNFirstDiscovery | MapsFirstDiscovery (Waterfall v3) |
+**Source of truth:** [ARCHITECTURE.md](../../ARCHITECTURE.md) §SECTION 3 (Deprecated Vendors).
+
+**DO NOT maintain the deprecated-vendors list in this file.** Read ARCHITECTURE.md §3 fresh every session.
+
+Duplicating the list creates drift — the previous table here missed entries ratified into ARCHITECTURE.md after this file's last update (e.g. Direct mail removed permanently as a channel; Lemlist + SmartLead never accepted into SSOT despite recommendation drafts).
+
+Any deprecation list previously living in this file was stale and removed (Layer 1 SSOT alignment, 2026-05-07).

--- a/.claude/modules/_enrichment_path.md
+++ b/.claude/modules/_enrichment_path.md
@@ -1,9 +1,3 @@
 ## Active Enrichment Path
 
-**Source of truth:** [ARCHITECTURE.md](../../ARCHITECTURE.md) §SECTION 2 (System Architecture Overview) + §SECTION 5 (Enrichment Tiers Complete Spec).
-
-**DO NOT quote pipeline stages from this file.** Read ARCHITECTURE.md fresh every session.
-
-The canonical pipeline shape is FLOW A (sync discovery, target <6min) + FLOW B (async parallel enrichment via `asyncio.gather`, target <10min). T0 is DataForSEO `domain_metrics_by_categories`, NOT Bright Data GMB scrape (GMB is T2 backfill only). Live channels and vendors are listed in ARCHITECTURE.md §SECTION 4.
-
-Any pipeline prose previously living in this file was stale and removed (Layer 1 SSOT alignment, 2026-05-07).
+See [ARCHITECTURE.md](../../ARCHITECTURE.md) §SECTION 2 + §SECTION 5. Read fresh every session. DO NOT quote pipeline stages from this file.

--- a/.claude/modules/_enrichment_path.md
+++ b/.claude/modules/_enrichment_path.md
@@ -1,7 +1,9 @@
 ## Active Enrichment Path
 
-T0 GMB -> T1 ABN -> T1.5a SERP Maps -> T1.5b SERP LinkedIn -> T2 LinkedIn Company -> ALS gate (>=20) -> T2.5 LinkedIn People -> T3 Leadmagic Email -> T5 Leadmagic Mobile
+**Source of truth:** [ARCHITECTURE.md](../../ARCHITECTURE.md) §SECTION 2 (System Architecture Overview) + §SECTION 5 (Enrichment Tiers Complete Spec).
 
-**Decision-maker path:** T-DM0 DataForSEO ($0.0465) -> T-DM1 BD Profile ($0.0015) -> T-DM2/2b/3/4 (Propensity >=70)
+**DO NOT quote pipeline stages from this file.** Read ARCHITECTURE.md fresh every session.
 
-**ALS gates:** PRE_ALS_GATE = 20 | HOT_THRESHOLD = 85
+The canonical pipeline shape is FLOW A (sync discovery, target <6min) + FLOW B (async parallel enrichment via `asyncio.gather`, target <10min). T0 is DataForSEO `domain_metrics_by_categories`, NOT Bright Data GMB scrape (GMB is T2 backfill only). Live channels and vendors are listed in ARCHITECTURE.md §SECTION 4.
+
+Any pipeline prose previously living in this file was stale and removed (Layer 1 SSOT alignment, 2026-05-07).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,7 @@
 # ARCHITECTURE.md
 # Agency OS — Locked System Architecture
 # Ratified: March 17 2026 | Authority: CEO (Claude) | Amended: March 18 2026 | Directives #217, #218
+# Last validated: 2026-05-07 (Layer 1 SSOT alignment — Lemlist+SmartLead added to §3)
 # DO NOT MODIFY without an explicit CEO directive that
 # names this file and specifies the exact change.
 #
@@ -114,6 +115,8 @@ Report to CEO before continuing.
 | SERP API    | Search results      | DataForSEO             |
 | Direct mail | Outreach channel    | Removed permanently    |
 | ZeroBounce  | Email validation    | Parked — do not build  |
+| Lemlist     | Email outreach (proposed but never adopted) | Salesforge (Section 4 — wired and ready) |
+| SmartLead   | Email infra (dropped from primary watchlist) | Salesforge (Section 4 — wired and ready) |
 
 ---
 


### PR DESCRIPTION
## Summary

Layer 1 SSOT alignment per Max directive 2026-05-07. Strips stale pipeline/vendor prose from CLAUDE.md auto-loaded modules and replaces with single-line pointers to ARCHITECTURE.md.

## Root cause

Both Aiden and Elliot independently quoted "T0 GMB → T1 ABN → ... → T5 Leadmagic Mobile" as the active enrichment path AND included Direct mail as a channel in a strategic-framing post. Both wrong:

- Pipeline shape per ARCHITECTURE.md §SECTION 2 is FLOW A (sync discovery, T0 = DataForSEO `domain_metrics_by_categories`) + FLOW B (async parallel via `asyncio.gather`). NOT a strict T0→T1→T2→T3→T5 sequence.
- Direct mail is explicitly DEPRECATED per ARCHITECTURE.md §SECTION 3: "Direct mail | Outreach channel | Removed permanently".
- Email outreach vendor is Salesforge per ARCHITECTURE.md §SECTION 4 + Drive Manual line 512 ("Wired and ready"). The 6+ hour Lemlist-vs-SmartLead audit earlier in session was for a vendor slot already filled.

The error came from auto-loaded `.claude/modules/_enrichment_path.md` prose + auto-loaded `.claude/modules/_dead_references.md` table being incomplete. Auto-load wins extraction priority over read-on-demand canonical (ARCHITECTURE.md).

## Changes

### `.claude/modules/_enrichment_path.md`
Replace prose ("T0 GMB → ... → T5 Leadmagic Mobile") with pointer to ARCHITECTURE.md §SECTION 2 + §SECTION 5.

### `.claude/modules/_dead_references.md`
Replace deprecated-vendors table with pointer to ARCHITECTURE.md §SECTION 3. Stop maintaining the list in two places.

### `ARCHITECTURE.md` §SECTION 3
Add Lemlist + SmartLead as deprecated:

```
| Lemlist     | Email outreach (proposed but never adopted) | Salesforge (Section 4 — wired and ready) |
| SmartLead   | Email infra (dropped from primary watchlist) | Salesforge (Section 4 — wired and ready) |
```

### `ARCHITECTURE.md` header
Add `# Last validated: 2026-05-07 (Layer 1 SSOT alignment — Lemlist+SmartLead added to §3)` stamp.

## Memory pins (Layer 3, parallel — not in this PR)

Saved separately to `~/.claude/projects/-home-elliotbot-clawd-Agency-OS/memory/`:
- `feedback_architecture_read_fresh.md` — Read ARCHITECTURE.md fresh before quoting pipeline/channels/vendors
- `feedback_active_channels_canonical.md` — Email=Salesforge, Mail dead, Lemlist/SmartLead never propose

(Both already indexed in `MEMORY.md` by Elliot's parallel save; my duplicate-named files were removed to avoid clutter.)

## Test plan
- [x] `_enrichment_path.md` no longer contains pipeline tier names
- [x] `_dead_references.md` no longer contains vendor list (just pointer)
- [x] `ARCHITECTURE.md` §3 includes Lemlist + SmartLead rows
- [x] `ARCHITECTURE.md` header includes Last-validated stamp
- [ ] Elliot peer-review per dual-approval rule

## Sequencing

This PR is Layer 1 of Max's 2026-05-07 directive. Sequenced ahead of:
- Layer 2 (Elliot leads) — docs/ archival + ceo_memory pruning
- Layer 6 (Aiden after Layer 1 merges) — session-start drift detector hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)