### PR TITLE
[ATLAS] feat(governance): LAW XVIII orchestration enforcement

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/elliotbot/clawd/venv/bin/python3 scripts/hooks/enforce_delegation.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit|NotebookEdit",
         "hooks": [
           {

--- a/docs/governance/CONSOLIDATED_RULES.md
+++ b/docs/governance/CONSOLIDATED_RULES.md
@@ -117,8 +117,17 @@ MCP bridge → exec (then write a skill). When a fix changes how an external ser
 corresponding skill file is updated in the same PR. Long-running tasks (>60s expected) use async
 patterns.
 
-**Triggers when:** A bot writes code in response, calls an external service, or takes on a task that
-could be delegated.
+**LAW XVIII — Write Delegation Enforcement (runtime gate).** Callsign bots
+(`elliot`, `aiden`, `max`, `atlas`, `orion`, `scout`) MUST NOT execute write tools (`Edit`, `Write`,
+`MultiEdit`, `NotebookEdit`) directly. Every mutation is delegated to a sub-agent. Runtime enforcement:
+PreToolUse hook `scripts/hooks/enforce_delegation.py` blocks write tools when `CALLSIGN ∈
+{elliot,aiden,max,atlas,orion,scout}` and `DAVE_OVERRIDE != 1`. **Escape hatch:** `DAVE_OVERRIDE=1`
+in the bot's environment passes the call through and appends an audit record to
+`logs/governance/dave_override.jsonl`. All blocks append to `logs/governance/law_xviii_blocks.jsonl`
+with timestamp, callsign, tool, and file path.
+
+**Triggers when:** A bot writes code in response, calls an external service, takes on a task that
+could be delegated, or — for callsign bots — invokes a write tool directly.
 
 **Satisfied by:**
 - Tasks requiring >50 lines are decomposed and delegated to a sub-agent.
@@ -126,13 +135,18 @@ could be delegated.
 - Skill file updated in same PR as any change to how an external service is called.
 - Async/gather patterns used for operations expected to exceed 60 seconds.
 - Agent plans, dispatches, verifies, and reports — does not become the keyboard.
+- Callsign bots delegate all write tools (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) to sub-agents;
+  direct invocation is blocked at PreToolUse by `enforce_delegation.py` unless `DAVE_OVERRIDE=1` is
+  set, in which case the call is allowed and audit-logged.
 
 **Violation:** Flag `ORCHESTRATE violation` if response contains >50 lines of code, or if an external
-API is called without a skill/ reference.
+API is called without a skill/ reference. Flag `ORCHESTRATE-XVIII violation` when a callsign bot's
+write tool is blocked (recorded in `law_xviii_blocks.jsonl`) or when `DAVE_OVERRIDE=1` is used without
+prior Dave authorisation in chat (recorded in `dave_override.jsonl` for review).
 
 **Absorbs:** LAW V (50-Line Protection), LAW VI (Skills-First Operations), LAW VII (Timeout Protection),
 LAW XI (Orchestrate), LAW XII (Skills-First Integration), LAW XIII (Skill Currency Enforcement),
-LAW XV-A (Skills Are Mandatory).
+LAW XV-A (Skills Are Mandatory), LAW XVIII (Write Delegation Enforcement).
 
 ---
 

--- a/docs/governance/HMAC_ENABLEMENT.md
+++ b/docs/governance/HMAC_ENABLEMENT.md
@@ -1,0 +1,179 @@
+# Inbox HMAC Enablement — 4-Step Rollout
+
+**Status:** design only. Current production state is **unsigned dispatch accepted**: the atlas/orion inbox-watcher services skip HMAC verification when `INBOX_HMAC_SECRET` is unset in their environment. This document records the steps to flip on signed-only dispatch without dropping in-flight work.
+
+**Approved by Dave:** 2026-05-07 (LAW XVIII directive).
+
+**Related files:**
+- `scripts/sign_dispatch.py` — already supports `--target {atlas,orion}` and HMAC signing.
+- `src/security/inbox_hmac.py` — `sign()` / `verify()` primitives.
+- `scripts/dispatch_to_atlas.sh` — currently writes unsigned JSON. Switches to `sign_dispatch.py` after Step 4.
+
+---
+
+## Step 1 — Generate the secret
+
+On the host running watchers (production), generate a 256-bit hex secret:
+
+```bash
+openssl rand -hex 32 > /tmp/inbox_hmac_secret.txt
+chmod 600 /tmp/inbox_hmac_secret.txt
+cat /tmp/inbox_hmac_secret.txt   # copy the value, then shred the file
+shred -u /tmp/inbox_hmac_secret.txt
+```
+
+Add to `~/.config/agency-os/.env` so `scripts/sign_dispatch.py` auto-loads it on every dispatch:
+
+```
+INBOX_HMAC_SECRET=<paste-the-hex>
+```
+
+`chmod 600 ~/.config/agency-os/.env` if not already restricted.
+
+---
+
+## Step 2 — Set the secret in watcher service env
+
+Each watcher unit (`atlas-inbox-watcher.service`, `orion-inbox-watcher.service`) must see `INBOX_HMAC_SECRET` at startup. Two equivalent options:
+
+### Option A — drop-in override (preferred)
+
+```bash
+sudo systemctl edit atlas-inbox-watcher.service
+```
+
+Add:
+```
+[Service]
+Environment="INBOX_HMAC_SECRET=<paste-the-hex>"
+```
+
+Repeat for `orion-inbox-watcher.service`. Then:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart atlas-inbox-watcher.service orion-inbox-watcher.service
+```
+
+### Option B — shared EnvironmentFile
+
+```bash
+echo "INBOX_HMAC_SECRET=<paste-the-hex>" | sudo tee /etc/agency-os/watcher.env
+sudo chmod 600 /etc/agency-os/watcher.env
+sudo chown root:root /etc/agency-os/watcher.env
+```
+
+In each unit:
+```
+[Service]
+EnvironmentFile=/etc/agency-os/watcher.env
+```
+
+Verify the secret reached the process:
+
+```bash
+sudo systemctl show atlas-inbox-watcher.service -p Environment | grep -c INBOX_HMAC_SECRET
+# expect: 1
+```
+
+---
+
+## Step 3 — Audit `sign_dispatch.py` callers
+
+`scripts/sign_dispatch.py` already takes `--target {atlas,orion}` (see line 53). The work in this step is to **audit every caller** so `--target` is set explicitly — never relying on a default — and so dispatch wrappers route to the right inbox.
+
+Callers to audit:
+
+- [ ] `scripts/dispatch_to_atlas.sh` — currently unsigned. After Step 4, switch the JSON-build block to:
+  ```bash
+  python3 scripts/sign_dispatch.py \
+      --target atlas \
+      --from "$FROM_CALLSIGN" \
+      --brief "$BRIEF" \
+      --task-ref "$TASK_REF" \
+      --max-task-minutes "$MAX_MINUTES"
+  ```
+- [ ] Any future `scripts/dispatch_to_orion.sh` — same pattern, `--target orion`.
+- [ ] Manual operator commands in `docs/runbooks/` and the Manual — grep for `sign_dispatch.py` and `--target`.
+- [ ] CI scripts (if any) that dispatch tasks.
+
+**Do not switch wrappers to signed-only until Step 4's dual-accept window is open** — otherwise existing unsigned dispatches in the inbox will be rejected.
+
+---
+
+## Step 4 — Flip-day rollout (dual-accept → signed-only)
+
+The watcher must accept **both** signed and unsigned dispatches for 24 hours so anything already queued completes without rejection. Then close the window.
+
+### T0 — enable dual-accept
+
+Add an env flag to each watcher unit (drop-in or `EnvironmentFile`):
+
+```
+[Service]
+Environment="INBOX_HMAC_DUAL_ACCEPT=1"
+```
+
+Watcher logic (in the inbox-poll loop):
+
+```python
+import os
+from src.security.inbox_hmac import verify
+
+dual_accept = os.environ.get("INBOX_HMAC_DUAL_ACCEPT") == "1"
+
+if "_signature" in payload:
+    if not verify(payload):
+        reject(payload, reason="bad_signature")
+        continue
+elif dual_accept:
+    log.warning("accepting unsigned dispatch during dual-accept window")
+else:
+    reject(payload, reason="missing_signature")
+    continue
+```
+
+Restart watchers:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart atlas-inbox-watcher.service orion-inbox-watcher.service
+journalctl -u atlas-inbox-watcher -f
+```
+
+Smoke test both paths:
+```bash
+# signed
+python3 scripts/sign_dispatch.py --target atlas --from elliot \
+    --brief "hmac smoke" --task-ref hmac_smoke_$(date +%s)
+
+# unsigned (legacy)
+python3 -c 'import json,time; print(json.dumps({"id":"u1","type":"task_dispatch","from":"elliot","target":"atlas","brief":"unsigned smoke","created_at":int(time.time())}))' \
+    > /tmp/telegram-relay-atlas/inbox/u1.json
+```
+
+Both should be processed; journalctl should record the unsigned one with the `accepting unsigned dispatch` warning.
+
+### T0 + 24h — flip to signed-only
+
+```bash
+sudo systemctl edit atlas-inbox-watcher.service
+# remove the INBOX_HMAC_DUAL_ACCEPT line
+sudo systemctl daemon-reload
+sudo systemctl restart atlas-inbox-watcher.service orion-inbox-watcher.service
+```
+
+Repeat for orion. Re-run the smoke pair: signed should pass, unsigned should be rejected with `missing_signature`.
+
+### Rollback
+
+If signed-only causes drops, set `INBOX_HMAC_DUAL_ACCEPT=1` again and restart. Diagnose (check `scripts/sign_dispatch.py` output for the rejected dispatch, confirm the secret matches between sender and watcher), then retry the flip.
+
+---
+
+## Audit checklist (post-flip)
+
+- [ ] `journalctl -u atlas-inbox-watcher --since "1h ago" | grep -ic "missing_signature\|bad_signature"` returns the expected reject count and zero unexpected ones.
+- [ ] `python3 scripts/sign_dispatch.py --target atlas --from elliot --brief "smoke" --task-ref hmac_smoke_$(date +%s)` exits 0; the file appears in the inbox; the watcher consumes it.
+- [ ] An unsigned write into the inbox is rejected with a clear reason in journalctl.
+- [ ] `~/.config/agency-os/.env` is `chmod 600`.
+- [ ] Watcher units' `Environment=` does not appear in any group-readable log or `git ls-files` output.

--- a/scripts/check_atlas_alive.sh
+++ b/scripts/check_atlas_alive.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# LAW XVIII preflight — verify ATLAS clone is alive before dispatch.
+# Exit 0 alive, 1 dead. Used by scripts/dispatch_to_atlas.sh.
+
+set -u
+
+ATLAS_INBOX="/tmp/telegram-relay-atlas/inbox"
+ATLAS_TMUX_SESSION="atlas"
+ATLAS_WATCHER_SERVICE="atlas-inbox-watcher"
+
+fail() {
+    echo "DEAD: $1" >&2
+    exit 1
+}
+
+# Check 1 — tmux session exists
+if ! tmux has-session -t "$ATLAS_TMUX_SESSION" 2>/dev/null; then
+    fail "tmux session '$ATLAS_TMUX_SESSION' not found"
+fi
+
+# Check 2 — inbox dir present and writable
+if [ ! -d "$ATLAS_INBOX" ]; then
+    fail "inbox dir $ATLAS_INBOX missing"
+fi
+if [ ! -w "$ATLAS_INBOX" ]; then
+    fail "inbox dir $ATLAS_INBOX not writable"
+fi
+
+# Check 3 — watcher service active (try user scope first, then system)
+if systemctl --user is-active --quiet "$ATLAS_WATCHER_SERVICE" 2>/dev/null; then
+    :
+elif systemctl is-active --quiet "$ATLAS_WATCHER_SERVICE" 2>/dev/null; then
+    :
+else
+    fail "service '$ATLAS_WATCHER_SERVICE' not active (checked --user and system)"
+fi
+
+echo "ALIVE"
+exit 0

--- a/scripts/dispatch_to_atlas.sh
+++ b/scripts/dispatch_to_atlas.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# LAW XVIII dispatch wrapper — preflight ATLAS, then drop unsigned
+# task_dispatch JSON in /tmp/telegram-relay-atlas/inbox/.
+#
+# Usage:
+#   scripts/dispatch_to_atlas.sh --brief "fix H1 persistence" \
+#       --task-ref B4P2-T1 [--max-minutes 30]
+#
+# Sender callsign comes from $CALLSIGN (defaults to 'elliot').
+# Currently writes UNSIGNED JSON — watcher accepts when INBOX_HMAC_SECRET
+# is unset in its env. After HMAC enablement (see docs/governance/
+# HMAC_ENABLEMENT.md) this wrapper switches to call sign_dispatch.py.
+#
+# Exits:
+#   0 — dispatched (path printed on stdout)
+#   1 — preflight failed (ATLAS dead) or write failed
+#   2 — bad arguments
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ATLAS_INBOX="/tmp/telegram-relay-atlas/inbox"
+FROM_CALLSIGN="${CALLSIGN:-elliot}"
+
+BRIEF=""
+TASK_REF=""
+MAX_MINUTES="30"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --brief) BRIEF="${2:-}"; shift 2 ;;
+        --task-ref) TASK_REF="${2:-}"; shift 2 ;;
+        --max-minutes) MAX_MINUTES="${2:-}"; shift 2 ;;
+        -h|--help)
+            echo "usage: $0 --brief <text> --task-ref <slug> [--max-minutes N]"
+            exit 0
+            ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$BRIEF" ] || [ -z "$TASK_REF" ]; then
+    echo "usage: $0 --brief <text> --task-ref <slug> [--max-minutes N]" >&2
+    exit 2
+fi
+
+# Preflight — abort on dead ATLAS
+"$SCRIPT_DIR/check_atlas_alive.sh" >/dev/null || {
+    echo "ABORT: ATLAS preflight failed (run scripts/check_atlas_alive.sh for detail)" >&2
+    exit 1
+}
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_FILE="$ATLAS_INBOX/${TASK_REF}_${TS}.json"
+
+# Build JSON via env vars (avoids shell-quoting hazards in BRIEF).
+BRIEF="$BRIEF" \
+TASK_REF="$TASK_REF" \
+MAX_MINUTES="$MAX_MINUTES" \
+FROM_CALLSIGN="$FROM_CALLSIGN" \
+python3 -c '
+import json, os, time
+payload = {
+    "id": os.environ["TASK_REF"],
+    "type": "task_dispatch",
+    "from": os.environ["FROM_CALLSIGN"],
+    "target": "atlas",
+    "brief": os.environ["BRIEF"],
+    "max_task_minutes": int(os.environ["MAX_MINUTES"]),
+    "task_ref": os.environ["TASK_REF"],
+    "created_at": int(time.time()),
+}
+print(json.dumps(payload))
+' > "$OUT_FILE"
+
+echo "$OUT_FILE"
+exit 0

--- a/scripts/hooks/enforce_delegation.py
+++ b/scripts/hooks/enforce_delegation.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""LAW XVIII orchestration enforcement — PreToolUse hook.
+
+Blocks Edit / Write / MultiEdit / NotebookEdit when the running session is a
+callsign bot (elliot, aiden, max, atlas, orion, scout) and DAVE_OVERRIDE is
+not set to '1'. Callsign bots must delegate write ops to sub-agents (Rule 4
+ORCHESTRATE).
+
+DAVE_OVERRIDE=1 lets the call through and appends an audit record to
+logs/governance/dave_override.jsonl. Blocks append to
+logs/governance/law_xviii_blocks.jsonl.
+
+Hook protocol: reads PreToolUse JSON on stdin, prints decision JSON on
+stdout, exits 0. Fail-open on any unexpected error so a hook bug cannot
+paralyse a session.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+CALLSIGN_BOTS = frozenset({"elliot", "aiden", "max", "atlas", "orion", "scout"})
+WRITE_TOOLS = frozenset({"Edit", "Write", "MultiEdit", "NotebookEdit"})
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOG_DIR = REPO_ROOT / "logs" / "governance"
+BLOCK_LOG = LOG_DIR / "law_xviii_blocks.jsonl"
+OVERRIDE_LOG = LOG_DIR / "dave_override.jsonl"
+BLOCK_REASON = "LAW_XVIII: callsign bots must delegate write ops to sub-agents"
+
+
+def _append_jsonl(path: Path, record: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass  # never let logging failure paralyse the hook
+
+
+def _read_stdin() -> dict:
+    try:
+        raw = sys.stdin.read()
+        return json.loads(raw) if raw else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _emit_block(reason: str) -> None:
+    print(json.dumps({"decision": "block", "reason": reason}))
+
+
+def main() -> int:
+    callsign = (os.environ.get("CALLSIGN") or "").strip().lower()
+    override = os.environ.get("DAVE_OVERRIDE", "").strip() == "1"
+
+    payload = _read_stdin()
+    tool_name = payload.get("tool_name") or ""
+    tool_input = payload.get("tool_input") or {}
+    file_path = (
+        tool_input.get("file_path")
+        or tool_input.get("notebook_path")
+        or ""
+    )
+
+    if tool_name not in WRITE_TOOLS:
+        return 0
+    if callsign not in CALLSIGN_BOTS:
+        return 0
+
+    record = {
+        "ts": int(time.time()),
+        "callsign": callsign,
+        "tool": tool_name,
+        "file_path": file_path,
+        "session_id": payload.get("session_id"),
+    }
+
+    if override:
+        _append_jsonl(OVERRIDE_LOG, {**record, "event": "dave_override_pass"})
+        return 0
+
+    _append_jsonl(BLOCK_LOG, {**record, "event": "law_xviii_block"})
+    _emit_block(BLOCK_REASON)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001 — fail-open
+        sys.exit(0)


### PR DESCRIPTION
## Summary

Implements LAW XVIII — runtime gate that prevents callsign bots (`elliot`, `aiden`, `max`, `atlas`, `orion`, `scout`) from invoking write tools (`Edit` / `Write` / `MultiEdit` / `NotebookEdit`) directly. All mutations must be delegated to sub-agents. `DAVE_OVERRIDE=1` is the audit-logged escape hatch.

Absorbed into **Rule 4 ORCHESTRATE** (per Dave's three confirmed decisions: absorb into Rule 4, block write sub-agents, audit-logged DAVE_OVERRIDE).

## What lands in this PR

| File | Purpose |
| --- | --- |
| `scripts/hooks/enforce_delegation.py` | PreToolUse hook. Reads JSON on stdin, emits `{"decision": "block", "reason": ...}` on stdout when blocking. Block records → `logs/governance/law_xviii_blocks.jsonl`; override records → `logs/governance/dave_override.jsonl`. Fail-open on any exception. |
| `scripts/check_atlas_alive.sh` | Preflight: tmux session present, inbox dir writable, watcher service active. Exit 0 alive / 1 dead. |
| `scripts/dispatch_to_atlas.sh` | Wrapper: preflight → drop unsigned `task_dispatch` JSON in `/tmp/telegram-relay-atlas/inbox/`. After HMAC enablement (see HMAC doc), this switches to call `sign_dispatch.py`. |
| `docs/governance/HMAC_ENABLEMENT.md` | 4-step rollout: secret gen → watcher env → sign_dispatch caller audit → dual-accept (24h) → signed-only flip. |
| `docs/governance/CONSOLIDATED_RULES.md` | Rule 4 absorbs LAW XVIII (paragraph + Satisfied-by + Violation lines + Absorbs list). |
| `.claude/settings.json` | Registers `enforce_delegation.py` as the **first** PreToolUse hook (matcher `Edit\|Write\|MultiEdit\|NotebookEdit`). |

## Hook test evidence (local)

```
TEST 1: ATLAS + Write, no override        → BLOCK + jsonl log     ✅
TEST 2: ATLAS + Edit + DAVE_OVERRIDE=1   → ALLOW + override log  ✅
TEST 3: no callsign + Write              → ALLOW                  ✅
TEST 4: ATLAS + Read (non-write)         → ALLOW                  ✅
TEST 5: ELLIOT + MultiEdit               → BLOCK + jsonl log     ✅
TEST 6: garbage stdin                    → ALLOW (fail-open)     ✅
```

Both `law_xviii_blocks.jsonl` and `dave_override.jsonl` were produced with correct timestamp / callsign / tool / file_path / session_id / event records, then cleaned before commit (the hook recreates them on first real fire).

## Test plan

- [ ] Aiden review (governance correctness, Rule 4 phrasing)
- [ ] Elliot review (hook semantics, audit-log shape, lockout-risk handling)
- [ ] CI pre-commit passes (commit already passed local pre-commit)
- [ ] After merge: spot-check that an ATLAS session attempting `Write` in a sub-agent-less context is blocked with the documented reason and a row appears in `logs/governance/law_xviii_blocks.jsonl`
- [ ] HMAC flip is **NOT** part of this PR — only the rollout doc. Step 4 stays unscheduled until Dave authorises the flip-day.

## Lockout-risk note

Once this lands and propagates to a worktree's `.claude/settings.json`, the bot in that worktree cannot Edit/Write directly. To fix governance docs or hook code itself, set `DAVE_OVERRIDE=1` in the bot's environment for the duration of the edit (audit-logged). Sub-agents are unaffected (no `CALLSIGN` env var).

## Approval / merge gate

Approved by Dave 2026-05-07. **Dual-concur required: Elliot + Aiden both review before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)