### PR TITLE
[AIDEN] govern: Layer 6 SSOT drift-detection hook (fail-WARN)

### DIFF
--- a/docs/governance/SOP_ARCHITECTURE_SSOT.md
+++ b/docs/governance/SOP_ARCHITECTURE_SSOT.md
@@ -1,0 +1,82 @@
+# SOP: Architecture Source of Truth Discipline
+
+**Status:** ACTIVE
+**Effective:** 2026-05-07 (on merge of PR #606)
+**Authority:** CEO directive (2026-05-07)
+**Applies to:** All agents (Elliot, Aiden, clones)
+
+## 1. Canonical Sources
+
+Architecture state lives in exactly TWO places:
+- **ARCHITECTURE.md** — pipeline, vendors, tiers, deprecated items
+- **Drive Manual** (Doc ID: 1p9FAQGowy9SgwglIxtkGsMuvLsR70MJBQrCSY6Ie9ho) — CEO-facing mirror
+
+Everything else (CLAUDE.md, .claude/modules/, ceo_memory snapshots, training knowledge) is a POINTER or CACHE. Never quote architecture from a cache.
+
+## 2. Session Start (HARD BLOCK)
+
+Before any directive work:
+1. Read ARCHITECTURE.md fresh (cat, not from memory)
+2. Read dave_corrections table (`SELECT * FROM public.dave_corrections ORDER BY corrected_at DESC LIMIT 20`)
+3. If architecture was last validated >7 days ago, flag before proceeding
+
+Skipping this is a governance violation.
+
+## 3. Before Quoting Architecture
+
+Before stating pipeline stages, channels, vendors, or tier specs:
+1. Verify claim against ARCHITECTURE.md (read fresh, not cached)
+2. If ARCHITECTURE.md doesn't cover the claim, check Drive Manual
+3. If neither covers it, say 'unverified — not in SSOT' — do NOT fill from training data
+
+Never fill architecture gaps from training knowledge or stale module files.
+
+## 4. CLAUDE.md and Module Files
+
+CLAUDE.md contains:
+- Identity, governance, process, agent assignment
+- One-line POINTERS to ARCHITECTURE.md sections
+
+CLAUDE.md NEVER contains:
+- Pipeline stage descriptions
+- Vendor lists or comparisons
+- Channel enumerations
+- Enrichment tier specs
+
+.claude/modules/ files follow the same rule — pointers only, no state duplication.
+
+## 5. Deprecated Items
+
+ARCHITECTURE.md Section 3 is the canonical deprecated list. Items currently deprecated:
+- Direct mail (channel — removed permanently)
+- Lemlist (never adopted — Salesforge is canonical)
+- SmartLead (dropped from watchlist — Salesforge is canonical)
+- All items in Section 3 table
+
+Before proposing any vendor or channel, check Section 3 first.
+
+## 6. Sub-Agent Prompts
+
+When briefing sub-agents on architecture:
+- Reference 'see ARCHITECTURE.md Section X' — never paste pipeline prose
+- Do not include tier sequences, vendor names, or channel lists in prompt text
+- Sub-agents must read the source themselves
+
+## 7. Freshness Headers
+
+Every architecture doc carries a 'Last validated: YYYY-MM-DD' header. When you make substantive edits (add/remove/modify sections), update the date. Read-only verification doesn't bump the date.
+
+## 8. Drift Detection
+
+Layer 6 hook (`scripts/ssot_drift_check.sh`) fires on the **SessionStart:clear** hook event (scripts/ssot_drift_check.sh per PR #606) and:
+- Checks .claude/modules/ for size, pointer presence, forbidden patterns
+- Warns if divergence detected before any directive work proceeds
+
+Hook runs in fail-WARN mode (exit 0 always) — surfaces drift without blocking session start.
+
+## 9. Violations
+
+Quoting stale architecture as current = governance violation. Correct immediately:
+1. Retract the claim in group chat
+2. Post the correct information AS A POINTER (e.g. 'see ARCHITECTURE.md §X') — not as a paraphrase. Paraphrases in chat history can be re-extracted later as truth, recreating the original drift.
+3. Check whether the stale source still exists — if so, file PR to fix or archive it

--- a/docs/governance/SOP_ARCHITECTURE_SSOT.md
+++ b/docs/governance/SOP_ARCHITECTURE_SSOT.md
@@ -18,7 +18,7 @@ Everything else (CLAUDE.md, .claude/modules/, ceo_memory snapshots, training kno
 Before any directive work:
 1. Read ARCHITECTURE.md fresh (cat, not from memory)
 2. Read dave_corrections table (`SELECT * FROM public.dave_corrections ORDER BY corrected_at DESC LIMIT 20`)
-3. If architecture was last validated >7 days ago, flag before proceeding
+3. If architecture was last validated >7 days ago, flag to TG group (peer + Max) before proceeding
 
 Skipping this is a governance violation.
 

--- a/scripts/ssot_drift_check.sh
+++ b/scripts/ssot_drift_check.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# ssot_drift_check.sh — Layer 6 drift detector for SSOT-alignment.
+#
+# Purpose:
+#   Detect when .claude/modules/_enrichment_path.md or _dead_references.md
+#   drift from being bare pointers and start paraphrasing canonical state
+#   from ARCHITECTURE.md. The bare-pointer shape was ratified 2026-05-07
+#   (PR #603) after both bots auto-loaded stale prose ("T0 GMB → T1 ABN ...
+#   T5 Leadmagic Mobile" + Direct mail as channel) and quoted it as truth.
+#
+# Mode: fail-WARN on first deploy. Exits 0 always; emits warning text to
+#   stdout/stderr. Settings.json hook (SessionStart:clear) surfaces warning
+#   to the agent before first prompt.
+#
+# Usage:
+#   bash scripts/ssot_drift_check.sh
+#   # or via settings.json hook on SessionStart:clear
+#
+# Author: AIDEN (Layer 6 of 2026-05-07 SSOT-alignment fix)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENRICHMENT_PATH="${REPO_ROOT}/.claude/modules/_enrichment_path.md"
+DEAD_REFS_PATH="${REPO_ROOT}/.claude/modules/_dead_references.md"
+ARCHITECTURE_PATH="${REPO_ROOT}/ARCHITECTURE.md"
+
+WARNINGS=()
+
+emit_warning() {
+    WARNINGS+=("$1")
+}
+
+# ─── Check 1: _enrichment_path.md must be a bare pointer ────────────────────
+# A bare pointer is short, contains "ARCHITECTURE.md", and does NOT contain
+# pipeline tier names or flow descriptions.
+if [[ -f "${ENRICHMENT_PATH}" ]]; then
+    SIZE=$(wc -c < "${ENRICHMENT_PATH}")
+    if (( SIZE > 400 )); then
+        emit_warning "_enrichment_path.md is ${SIZE} bytes — bare pointer should be <400. Possible drift to paraphrase."
+    fi
+    if ! grep -q "ARCHITECTURE.md" "${ENRICHMENT_PATH}"; then
+        emit_warning "_enrichment_path.md missing ARCHITECTURE.md pointer — file may have been overwritten."
+    fi
+    # Patterns that should NEVER appear in a bare-pointer module (they belong in ARCHITECTURE.md only):
+    DRIFT_PATTERNS=(
+        "T0 GMB"
+        "T1 ABN"
+        "T1.5"
+        "T2.5"
+        "T3 Leadmagic"
+        "T5 Leadmagic"
+        "FLOW A"
+        "FLOW B"
+        "asyncio.gather"
+        "DataForSEO"
+    )
+    for pattern in "${DRIFT_PATTERNS[@]}"; do
+        if grep -qF "${pattern}" "${ENRICHMENT_PATH}"; then
+            emit_warning "_enrichment_path.md contains '${pattern}' — pipeline detail belongs in ARCHITECTURE.md only."
+        fi
+    done
+else
+    emit_warning "_enrichment_path.md missing at ${ENRICHMENT_PATH}"
+fi
+
+# ─── Check 2: _dead_references.md must be a bare pointer ────────────────────
+if [[ -f "${DEAD_REFS_PATH}" ]]; then
+    SIZE=$(wc -c < "${DEAD_REFS_PATH}")
+    if (( SIZE > 400 )); then
+        emit_warning "_dead_references.md is ${SIZE} bytes — bare pointer should be <400. Possible drift to deprecated-list paraphrase."
+    fi
+    if ! grep -q "ARCHITECTURE.md" "${DEAD_REFS_PATH}"; then
+        emit_warning "_dead_references.md missing ARCHITECTURE.md pointer — file may have been overwritten."
+    fi
+    # Patterns that belong in ARCHITECTURE.md §3 only:
+    DRIFT_VENDORS=(
+        "Proxycurl"
+        "Apollo (enrichment)"
+        "Direct mail"
+        "Kaspr"
+        "Hunter.io"
+        "ABNFirstDiscovery"
+        "Lemlist"
+        "SmartLead"
+    )
+    for vendor in "${DRIFT_VENDORS[@]}"; do
+        if grep -qF "${vendor}" "${DEAD_REFS_PATH}"; then
+            emit_warning "_dead_references.md contains '${vendor}' — deprecated-vendor list belongs in ARCHITECTURE.md §3 only."
+        fi
+    done
+else
+    emit_warning "_dead_references.md missing at ${DEAD_REFS_PATH}"
+fi
+
+# ─── Check 3: ARCHITECTURE.md must exist and have Last-validated header ────
+if [[ ! -f "${ARCHITECTURE_PATH}" ]]; then
+    emit_warning "ARCHITECTURE.md MISSING at ${ARCHITECTURE_PATH} — this is the canonical SSOT. STOP and report to Dave."
+elif ! grep -q "^# Last validated:" "${ARCHITECTURE_PATH}"; then
+    emit_warning "ARCHITECTURE.md missing 'Last validated' header — freshness gate not in place."
+fi
+
+# ─── Emit results ────────────────────────────────────────────────────────────
+if (( ${#WARNINGS[@]} > 0 )); then
+    echo "═══ SSOT DRIFT DETECTED (Layer 6 hook, fail-WARN) ═══" >&2
+    echo "" >&2
+    for w in "${WARNINGS[@]}"; do
+        echo "  ⚠ ${w}" >&2
+    done
+    echo "" >&2
+    echo "Action: cat ARCHITECTURE.md fresh (it is the canonical SSOT). Do NOT extract" >&2
+    echo "from .claude/modules/*.md as truth — those are pointers only by design." >&2
+    echo "If drift is real, open a governance PR to restore bare-pointer shape." >&2
+    echo "═══════════════════════════════════════════════════" >&2
+    exit 0  # WARN mode: do not block session
+fi
+
+echo "ssot_drift_check: clean (modules are bare pointers, ARCHITECTURE.md present)"
+exit 0


### PR DESCRIPTION
## Summary

Closes Layer 6 of the 2026-05-07 SSOT-alignment fix per Max directive. Adds a session-start drift detector that prevents recurrence of the failure mode where both bots auto-loaded stale prose from `.claude/modules/*.md` and quoted it as canonical truth.

## Background

Layer 1 (PR #603, merged) stripped pipeline/vendor prose from `.claude/modules/_enrichment_path.md` + `_dead_references.md`, replacing with bare pointers to ARCHITECTURE.md. Layer 5 (PR #604, dual-approved) archived stale docs + pruned poisoned ceo_memory keys.

But: nothing prevents the bare-pointer modules from drifting BACK to paraphrase over time. Layer 6 detects that drift on every session start and surfaces a warning to the agent before any work begins.

## What this PR adds

`scripts/ssot_drift_check.sh` — shell script with three checks:

**Check 1: `_enrichment_path.md` is a bare pointer**
- Size <400 bytes
- Contains `ARCHITECTURE.md` pointer
- Does NOT contain pipeline tier/flow patterns: `T0 GMB`, `T1 ABN`, `T1.5`, `T2.5`, `T3 Leadmagic`, `T5 Leadmagic`, `FLOW A`, `FLOW B`, `asyncio.gather`, `DataForSEO`

**Check 2: `_dead_references.md` is a bare pointer**
- Size <400 bytes
- Contains `ARCHITECTURE.md` pointer
- Does NOT contain deprecated-vendor names: `Proxycurl`, `Apollo (enrichment)`, `Direct mail`, `Kaspr`, `Hunter.io`, `ABNFirstDiscovery`, `Lemlist`, `SmartLead`

**Check 3: `ARCHITECTURE.md` exists with `Last validated` header**

## Mode: fail-WARN

Per Elliot's PR #603 review sharpening — first deploy is fail-WARN, not fail-BLOCK. Script always exits 0; warnings go to stderr. Hard-block too aggressive on first deploy.

## Verification

**Clean state (current main):**
```
$ bash scripts/ssot_drift_check.sh
ssot_drift_check: clean (modules are bare pointers, ARCHITECTURE.md present)
```

**Synthetic drift detection (test module with T0-T5 prose):**
```
═══ SSOT DRIFT DETECTED (Layer 6 hook, fail-WARN) ═══
  ⚠ _enrichment_path.md missing ARCHITECTURE.md pointer — file may have been overwritten.
  ⚠ _enrichment_path.md contains 'T0 GMB' — pipeline detail belongs in ARCHITECTURE.md only.
  ⚠ _enrichment_path.md contains 'T1 ABN' — pipeline detail belongs in ARCHITECTURE.md only.
  [...6 warnings total, exit 0 as designed]
```

Detection works on the patterns most likely to recur.

## Settings.json hook (NOT in this PR — Max-gated)

Per Max's Layer 6 plan, settings.json hook entry needs separate Max approval. Proposed entry for `~/.claude/settings.json`:

```json
{
  "hooks": {
    "SessionStart": [
      {
        "matcher": "clear",
        "hooks": [
          {
            "type": "command",
            "command": "bash $(git rev-parse --show-toplevel)/scripts/ssot_drift_check.sh"
          }
        ]
      }
    ]
  }
}
```

Once Max approves the hook config, drift detection runs on every `SessionStart:clear` (new session, after `/clear`, etc.).

## Test plan
- [x] Script exits 0 on clean state (no drift)
- [x] Script emits warnings + exits 0 on synthetic drift (fail-WARN, not fail-BLOCK)
- [x] Script handles missing files gracefully (warns instead of crashing)
- [x] Script is executable (`chmod +x`)
- [ ] Elliot peer-review per dual-approval rule
- [ ] Max approval on settings.json hook entry (separate change)

## Sequencing

This is the final layer of the 2026-05-07 SSOT-alignment fix:
- Layer 1 (#603) — strip stale prose ✅ merged
- Layer 5 (#604) — archive stale docs + memory ✅ dual-approved, awaiting merge
- Layer 6 (this PR) — drift detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)