### PR TITLE
[AIDEN] govern: wire ssot_drift_check.sh on SessionStart:clear hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,16 @@
             "timeout": 15
           }
         ]
+      },
+      {
+        "matcher": "clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/ssot_drift_check.sh",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "Stop": [


### PR DESCRIPTION
## Summary

Activates Layer 6 drift-detection by adding the SessionStart hook entry to `.claude/settings.json`. Without this, the script committed in PR #606 never fires.

Per Max's directive: minimal change, hook config only.

## Change

Single addition to `.claude/settings.json` `hooks.SessionStart` array — a new entry with `matcher: "clear"`:

```json
{
  "matcher": "clear",
  "hooks": [
    {
      "type": "command",
      "command": "bash scripts/ssot_drift_check.sh",
      "timeout": 10
    }
  ]
}
```

## Design choices

- **Matcher: `"clear"`** — fires only on `/clear` events, not other SessionStart triggers (resume, compact). Per SOP §8 and PR #606 spec ("explicit > implicit").
- **Relative command path** (`bash scripts/ssot_drift_check.sh`) — matches existing pattern in this file (`recorder_hook.sh`, `inbox_check_hook.sh` both use relative paths from project root).
- **Timeout 10s** — script is local grep/wc only, typically completes in <1s. 10s is generous for slower disk.
- **Separate entry, not bundled** — kept the existing `matcher: "*"` block (which runs `context_compiler.py`) untouched. New `matcher: "clear"` block fires alongside on `/clear` events.

## Verification

- [x] JSON syntax valid (`python3 -c "import json; json.load(open(...))"` passes)
- [x] Diff stat: 1 file changed, 10 insertions, 0 deletions
- [ ] Elliot peer-review per dual-approval rule
- [ ] Max approval on settings.json change (his Layer 6 plan said he'd approve)
- [ ] E2E test (sequenced after merge): /clear in a fresh session, observe drift-check output; then synthetic drift test

## Sequencing

This is the activation step for the Layer 6 drift detector. Sequenced after PR #606 merge (which added the script). E2E test follows after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)