### PR TITLE
[ELLIOT] govern: Layer 7 SSOT cleanup — Siege Waterfall stale references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # ARCHITECTURE.md
 # Agency OS — Locked System Architecture
 # Ratified: March 17 2026 | Authority: CEO (Claude) | Amended: March 18 2026 | Directives #217, #218
-# Last validated: 2026-05-07 (Layer 1 SSOT alignment — Lemlist+SmartLead added to §3)
+# Last validated: 2026-05-07 (Layer 7 SSOT cleanup — Siege Waterfall path corrected to src/pipeline/waterfall_v2.py per PR-A #593 rename)
 # DO NOT MODIFY without an explicit CEO directive that
 # names this file and specifies the exact change.
 #
@@ -45,11 +45,16 @@ Siege Waterfall is the orchestration layer that:
 
 The vendors Siege Waterfall calls are in SECTION 4.
 The orchestration logic lives in:
-  src/integrations/siege_waterfall.py
+  src/pipeline/waterfall_v2.py
   src/engines/scout.py
 
 Siege Waterfall is never deprecated. It is our core IP.
 Vendors inside it are replaced. The orchestrator improves.
+
+(Implementation note: the waterfall logic was renamed from
+`src/integrations/siege_waterfall.py` to `src/pipeline/waterfall_v2.py`
+in PR-A #593 consolidation. "Siege Waterfall" remains the conceptual
+name for our proprietary orchestration; the file path moved.)
 
 ---
 

--- a/src/engines/icp_scraper.py
+++ b/src/engines/icp_scraper.py
@@ -14,7 +14,7 @@ DEPENDENCIES:
 - src/engines/base.py
 - src/engines/url_validator.py
 - src/integrations/camoufox_scraper.py
-- src/integrations/siege_waterfall.py
+- src/pipeline/waterfall_v2.py (renamed from src/integrations/siege_waterfall.py PR-A #593)
 - src/integrations/gmb_scraper.py
 - src/exceptions.py
 
@@ -60,11 +60,8 @@ from src.integrations.camoufox_scraper import (
     is_camoufox_available,
 )
 
-# from src.integrations.siege_waterfall import (
-#     EnrichmentTier,
-#     SiegeWaterfall,
-#     get_siege_waterfall,
-# )
+# Note: src/integrations/siege_waterfall.py was deleted in PR-A #593;
+# enrichment now flows through src/pipeline/waterfall_v2.py.
 
 # Portfolio page paths to fetch directly (ICP-FIX-008)
 PORTFOLIO_PATHS = [
@@ -176,7 +173,6 @@ class ICPScraperEngine(BaseEngine):
         anthropic_client: AnthropicClient | None = None,
         url_validator: URLValidator | None = None,
         camoufox_scraper: CamoufoxScraper | None = None,
-        siege_waterfall: object | None = None,  # was SiegeWaterfall (removed PR-A)
     ):
         """
         Initialize with optional client overrides for testing.
@@ -185,12 +181,10 @@ class ICPScraperEngine(BaseEngine):
             anthropic_client: Optional Anthropic client override
             url_validator: Optional URL validator override
             camoufox_scraper: Optional Camoufox scraper override
-            siege_waterfall: Optional SiegeWaterfall override
         """
         self._anthropic = anthropic_client
         self._url_validator = url_validator
         self._camoufox = camoufox_scraper
-        self._siege_waterfall = siege_waterfall
 
     @property
     def name(self) -> str:
@@ -224,13 +218,6 @@ class ICPScraperEngine(BaseEngine):
         from src.config.settings import settings
 
         return settings.camoufox_enabled and is_camoufox_available()
-
-    @property
-    def siege_waterfall(self):  # was SiegeWaterfall (removed PR-A)
-        """Get Siege Waterfall for AU business enrichment."""
-        if self._siege_waterfall is None:
-            raise NotImplementedError("dead path: removed in PR-A #593")
-        return self._siege_waterfall
 
     def _extract_domain(self, url: str) -> str:
         """Extract domain from URL."""

--- a/src/engines/scout.py
+++ b/src/engines/scout.py
@@ -13,7 +13,7 @@ DEPENDENCIES:
   - src/engines/base.py
   - src/integrations/redis.py
   - src/integrations/camoufox_scraper.py (LinkedIn scraping)
-  - src/integrations/siege_waterfall.py (SSOT for AU enrichment)
+  - src/pipeline/waterfall_v2.py (SSOT for AU enrichment — renamed from siege_waterfall.py PR-A #593)
   - src/models/lead.py
 RULES APPLIED:
   - Rule 1: Follow blueprint exactly
@@ -26,7 +26,7 @@ PHASE 24A CHANGES:
   - Added enrich_to_pool method for pool-first enrichment
   - Added search_and_populate_pool for bulk pool population
   - Modified enrich_lead to optionally write to pool
-  - Enrichment SSOT: siege_waterfall.py
+  - Enrichment SSOT: waterfall_v2.py (renamed from siege_waterfall.py PR-A #593)
 
 PHASE 24F CHANGES:
   - Added filter_suppressed_leads method for client-specific filtering
@@ -124,17 +124,14 @@ class ScoutEngine(BaseEngine):
 
     def __init__(
         self,
-        siege_waterfall: object | None = None,  # was SiegeWaterfall (removed PR-A)
         camoufox_scraper: CamoufoxScraper | None = None,
     ):
         """
         Initialize Scout engine with integration clients.
 
         Args:
-            siege_waterfall: Optional SiegeWaterfall (uses singleton if not provided)
             camoufox_scraper: Optional CamoufoxScraper for LinkedIn (lazy init if not provided)
         """
-        self._siege_waterfall = siege_waterfall
         self._camoufox = camoufox_scraper
         self.leadmagic = get_leadmagic_client()
 
@@ -148,12 +145,6 @@ class ScoutEngine(BaseEngine):
         if self._camoufox is None:
             self._camoufox = CamoufoxScraper()
         return self._camoufox
-
-    @property
-    def siege_waterfall(self):  # was SiegeWaterfall (removed PR-A)
-        if self._siege_waterfall is None:
-            raise NotImplementedError("dead path: removed in PR-A #593")
-        return self._siege_waterfall
 
     async def enrich_lead(
         self,
@@ -671,7 +662,7 @@ class ScoutEngine(BaseEngine):
         Write enriched signals back to business_universe.
         Directive #215: LinkedIn, DataForSEO, and confidence score write-backs.
         Directive #217: Opportunity score write-back.
-        Architectural note: siege_waterfall.py is a pure data layer (no db access).
+        Architectural note: waterfall_v2.py is a pure data layer (no db access; renamed from siege_waterfall.py PR-A #593).
         All BU write-backs are performed here in scout.py where the db session lives.
         """
         if not domain:

--- a/src/integrations/__init__.py
+++ b/src/integrations/__init__.py
@@ -37,8 +37,7 @@ __all__ = [
     "get_elevenlabs_client",
     "LeadmagicClient",
     "get_leadmagic_client",
-    "SiegeWaterfall",
-    "get_siege_waterfall",
+    # SiegeWaterfall + get_siege_waterfall removed PR-A #593 (file deleted, replaced by src/pipeline/waterfall_v2.py)
     # Routers for FastAPI
     "calendar_booking_router",
 ]

--- a/src/orchestration/flows/pool_population_flow.py
+++ b/src/orchestration/flows/pool_population_flow.py
@@ -6,7 +6,7 @@ TASK: POOL-012 (Gap fix - pool population trigger)
 DEPENDENCIES:
   - src/engines/scout.py
   - src/integrations/supabase.py
-  - src/integrations/siege_waterfall.py (SSOT for enrichment)
+  - src/pipeline/waterfall_v2.py (SSOT for enrichment — renamed from siege_waterfall.py PR-A #593)
 RULES APPLIED:
   - Rule 1: Follow blueprint exactly
   - Rule 11: Session passed as argument
@@ -15,7 +15,7 @@ RULES APPLIED:
 
 ENRICHMENT STRATEGY:
   All enrichment now flows through Siege Waterfall (5-tier Australian B2B pipeline).
-  See src/integrations/siege_waterfall.py for tier details.
+  See src/pipeline/waterfall_v2.py for tier details.
 
 WATERFALL STRATEGY:
   Tier 1: Search by INDUSTRY from portfolio, EXCLUDE portfolio domains (lookalikes)
@@ -1129,4 +1129,4 @@ async def pool_population_batch_flow(
 #     - All tiers apply get_who_refined_criteria() before search
 #     - Refines titles, industries, and company size based on conversion patterns
 #     - Transparent logging of refinement application
-# [x] SIEGE WATERFALL: All enrichment flows through siege_waterfall.py (SSOT)
+# [x] SIEGE WATERFALL: All enrichment flows through waterfall_v2.py (SSOT — renamed from siege_waterfall.py PR-A #593)

--- a/src/orchestration/tasks/enrichment_tasks.py
+++ b/src/orchestration/tasks/enrichment_tasks.py
@@ -62,7 +62,7 @@ async def enrich_lead_task(
         Enrichment result with:
             - success: bool
             - lead_id: UUID
-            - enrichment_source: str (cache, siege_waterfall, camoufox)
+            - enrichment_source: str (cache, siege_waterfall, camoufox) — note: "siege_waterfall" string literal preserved for downstream telemetry compatibility despite file rename to waterfall_v2.py
             - confidence: float
             - fields_enriched: list[str]
 


### PR DESCRIPTION
## Summary

Layer 7 of the 2026-05-07 SSOT-alignment governance work. PR-A #593 deleted `src/integrations/siege_waterfall.py` but ARCHITECTURE.md and 5+ source files still referenced it as live. Two NotImplementedError dead-property accessors would have raised on any caller. This PR cleans up the stale references.

Same failure mode Dave called out earlier in the 2026-05-07 SSOT session — stale architecture references that auto-extract as truth.

## Changes

**ARCHITECTURE.md** — §1 file pointer corrected (`src/integrations/siege_waterfall.py` → `src/pipeline/waterfall_v2.py`), implementation note added, Last-validated header updated to 2026-05-07 Layer 7.

**`src/engines/scout.py`** — removed dead `siege_waterfall` @property (was raising `NotImplementedError`) + constructor parameter + private attribute. No callers found via grep — pure vestigial code.

**`src/engines/icp_scraper.py`** — same dead-property + parameter + attribute removal. Commented-out `from src.integrations.siege_waterfall import` block replaced with one-line note.

**`src/integrations/__init__.py`** — removed dead exports `SiegeWaterfall` + `get_siege_waterfall` from `__all__` (would have raised `ImportError` since neither symbol exists post-PR-A #593).

**`src/orchestration/flows/pool_population_flow.py`** — file-pointer references updated. **Preserved** `"enrichment_source": "siege_waterfall"` string literals at lines 1030/1099 (telemetry values written to DB, not file references — changing would break downstream queries/dashboards).

**`src/orchestration/tasks/enrichment_tasks.py`** — clarifying note added on `enrichment_source` field that "siege_waterfall" string literal is preserved for downstream telemetry compatibility despite file rename.

## Not in scope

- `jina.py` decision (ARCHITECTURE.md §5 lists "Jina AI Reader" as scraper Tier 2 but no `src/integrations/jina.py` exists — presumably called inline via `httpx_scraper.py`). Separate doc/code-decision PR.
- Layer 6.5 drift-hook extension (bash extension to grep ARCHITECTURE.md for missing file paths) — backlog.
- Other dead exports in `__init__.py` (`SerperClient` + `get_serper_client` in `__all__` without import) — separate cleanup, not Siege-related.

## Verification gates

```
$ grep -rn "SiegeWaterfall|get_siege_waterfall|_siege_waterfall" src/
Only result: __init__.py:40 cleanup-history note ✓

$ grep -c "NotImplementedError" src/engines/scout.py src/engines/icp_scraper.py
Both: 0 ✓

$ ruff check src/
All checks passed!

$ bash scripts/ssot_drift_check.sh
ssot_drift_check: clean (modules are bare pointers, ARCHITECTURE.md present)

$ pytest --collect-only tests/
3480/3484 tests collected (4 deselected, 0 errors)
```

## Test plan

- [ ] Aiden review (dual-approval per repo convention)
- [x] Local ruff check clean
- [x] Local drift hook clean
- [x] Local pytest collection clean (no new errors)
- [x] No stub/dead refs introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)