### PR TITLE
[AIDEN] fix: strike false 'X of 20 founding spots taken' from landing pages

### DIFF
--- a/frontend/components/generated/hero/components/agency-os-hero.tsx
+++ b/frontend/components/generated/hero/components/agency-os-hero.tsx
@@ -86,7 +86,7 @@ export default function AgencyOSHero() {
                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber opacity-75" />
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-amber" />
               </span>
-              <span className="text-sm text-ink/90 font-medium">Only 17 of 20 founding spots remaining</span>
+              <span className="text-sm text-ink/90 font-medium">20 founding spots available</span>
             </div>
 
             {/* Headline */}

--- a/frontend/components/landing/HeroSection.tsx
+++ b/frontend/components/landing/HeroSection.tsx
@@ -86,7 +86,7 @@ export default function AgencyOSHero() {
                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber opacity-75" />
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-amber" />
               </span>
-              <span className="text-sm text-ink/90 font-medium">Only 17 of 20 founding spots remaining</span>
+              <span className="text-sm text-ink/90 font-medium">20 founding spots available</span>
             </div>
 
             {/* Headline - Mint gradient */}

--- a/frontend/landing/index.html
+++ b/frontend/landing/index.html
@@ -1238,7 +1238,7 @@ footer .wordmark-lockup { font-size: 14px; }
         Book a call
       </a>
     </div>
-    <span class="hero-fine">3 of 20 founding spots taken · $500 refundable deposit</span>
+    <span class="hero-fine">20 founding spots · $500 refundable deposit</span>
   </div>
 
   <!-- Dashboard crop — actual product interface -->
@@ -1540,7 +1540,7 @@ footer .wordmark-lockup { font-size: 14px; }
     <!-- Spots remaining -->
     <div class="founding-foot r d2">
       <div class="spots-dots" id="spotDots"></div>
-      <div class="spots-caption-row"><b>3 of 20</b> founding spots reserved</div>
+      <div class="spots-caption-row"><b>20</b> founding spots available</div>
     </div>
   </div>
 </section>

--- a/landing-page-v2.html
+++ b/landing-page-v2.html
@@ -166,7 +166,7 @@
             <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
             <span class="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
           </span>
-          <span class="text-sm text-white/70">Only <span class="text-white font-semibold">17 of 20</span> founding spots remaining</span>
+          <span class="text-sm text-white/70"><span class="text-white font-semibold">20</span> founding spots available</span>
         </div>
       </div>
       

--- a/landing-page.html
+++ b/landing-page.html
@@ -110,7 +110,7 @@
       <div class="flex justify-center mb-8 fade-up">
         <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[#fef3c7] border border-[#fcd34d]/30">
           <span class="w-2 h-2 rounded-full bg-[#f59e0b] pulse-soft"></span>
-          <span class="text-xs font-medium text-[#92400e]">Only 17 of 20 founding spots remaining</span>
+          <span class="text-xs font-medium text-[#92400e]">20 founding spots available</span>
         </div>
       </div>
       

--- a/src/integrations/leadmagic.py
+++ b/src/integrations/leadmagic.py
@@ -91,13 +91,21 @@ def _is_production_environment() -> bool:
     below to refuse module load if mock mode is enabled in production —
     catastrophic-blast-radius-prevention (mock returns fake AU mobile numbers
     + fake emails to real campaigns).
+
+    Resolution order (explicit env beats path heuristic):
+    1. FASTAPI_ENV in {dev, development, test, staging} → False (explicit non-prod)
+    2. FASTAPI_ENV == production → True (explicit prod)
+    3. FASTAPI_ENV unset or unrecognised → worktree-path heuristic
     """
-    if os.getenv("FASTAPI_ENV", "").lower() == "production":
+    env = os.getenv("FASTAPI_ENV", "").lower()
+    if env in ("dev", "development", "test", "staging"):
+        return False
+    if env == "production":
         return True
-    # Heuristic: main worktree path indicates production code is loaded
-    # (Aiden/Atlas/Scout/Orion clone worktrees are dev-shaped)
-    abs_path = os.path.abspath(__file__)
-    return abs_path.startswith("/home/elliotbot/clawd/Agency_OS/")
+    # FASTAPI_ENV unset/unrecognised — fall back to worktree path heuristic.
+    # Main worktree path indicates production code is loaded
+    # (Aiden/Atlas/Scout/Orion clone worktrees are dev-shaped).
+    return os.path.abspath(__file__).startswith("/home/elliotbot/clawd/Agency_OS/")
 
 
 def _assert_mock_safe() -> None:

--- a/src/integrations/leadmagic.py
+++ b/src/integrations/leadmagic.py
@@ -84,6 +84,46 @@ def _is_mock_mode() -> bool:
     return os.getenv("LEADMAGIC_MOCK", "").lower() in ("true", "1", "yes")
 
 
+def _is_production_environment() -> bool:
+    """Detect production environment via env var or worktree path heuristic.
+
+    Returns True when running in production. Used by the mock-mode guardrail
+    below to refuse module load if mock mode is enabled in production —
+    catastrophic-blast-radius-prevention (mock returns fake AU mobile numbers
+    + fake emails to real campaigns).
+    """
+    if os.getenv("FASTAPI_ENV", "").lower() == "production":
+        return True
+    # Heuristic: main worktree path indicates production code is loaded
+    # (Aiden/Atlas/Scout/Orion clone worktrees are dev-shaped)
+    abs_path = os.path.abspath(__file__)
+    return abs_path.startswith("/home/elliotbot/clawd/Agency_OS/")
+
+
+def _assert_mock_safe() -> None:
+    """Refuse module load if LEADMAGIC_MOCK is enabled in production.
+
+    Mock mode returns realistic-but-fake AU mobile numbers + emails that
+    would be sent to real prospects in cohorts — catastrophic deliverability
+    + reputational damage if accidentally toggled in production.
+
+    Defensive guardrail: fails fast at import time, NOT at first call,
+    so misconfiguration is caught before any campaign starts.
+    """
+    if _is_mock_mode() and _is_production_environment():
+        raise RuntimeError(
+            "LEADMAGIC_MOCK is enabled in a production environment — "
+            "refusing module load. Mock mode returns fake AU mobile numbers "
+            "and emails which would be sent to real campaign prospects. "
+            "Either unset LEADMAGIC_MOCK or set FASTAPI_ENV to a non-production "
+            "value (and ensure you're not running from /home/elliotbot/clawd/Agency_OS/) "
+            "to proceed."
+        )
+
+
+_assert_mock_safe()
+
+
 # ============================================
 # ENUMS
 # ============================================

--- a/tests/integrations/test_leadmagic_mock_guardrail.py
+++ b/tests/integrations/test_leadmagic_mock_guardrail.py
@@ -63,21 +63,53 @@ def test_mock_safe_production_env_with_mock_on_raises():
             _assert_mock_safe()
 
 
-def test_mock_safe_production_via_worktree_path_heuristic():
-    """Production heuristic: main worktree path triggers production detection."""
+def test_explicit_dev_env_overrides_path_heuristic():
+    """FASTAPI_ENV=dev MUST short-circuit before worktree-path heuristic.
+
+    This is the bug Elliot caught in PR #610 review: original logic returned
+    True if path matched main worktree EVEN WHEN FASTAPI_ENV=dev was explicit.
+    Means a developer on main worktree setting FASTAPI_ENV=dev still got
+    RuntimeError at module load.
+
+    Fix: explicit dev/test/staging env values short-circuit to False before
+    path check fires.
+    """
     from src.integrations.leadmagic import _is_production_environment
 
-    # Heuristic check: when __file__ resolves to main worktree, production = True
-    # Direct unit test of the detection function
-    with patch.dict(os.environ, {"FASTAPI_ENV": "dev"}, clear=False):
-        # FASTAPI_ENV=dev shouldn't override worktree-path heuristic
-        # We can't easily fake __file__ in this test, so this asserts
-        # the function returns based on real path resolution
+    for dev_value in ("dev", "development", "test", "staging", "DEV", "Test"):
+        with patch.dict(os.environ, {"FASTAPI_ENV": dev_value}, clear=False):
+            assert _is_production_environment() is False, (
+                f"FASTAPI_ENV={dev_value} must override worktree-path heuristic"
+            )
+
+
+def test_explicit_production_env_returns_true_independent_of_path():
+    """FASTAPI_ENV=production returns True regardless of worktree path."""
+    from src.integrations.leadmagic import _is_production_environment
+
+    with patch.dict(os.environ, {"FASTAPI_ENV": "production"}, clear=False):
+        assert _is_production_environment() is True
+
+
+def test_unset_env_falls_back_to_path_heuristic():
+    """FASTAPI_ENV unset/empty falls back to worktree-path detection.
+
+    Aiden worktree path (/home/elliotbot/clawd/Agency_OS-aiden/) → not main
+    → returns False. Asserted directly without trying to fake __file__.
+    """
+    from src.integrations.leadmagic import _is_production_environment
+
+    # Clear FASTAPI_ENV to force fallback to path heuristic
+    env_without_fastapi = {k: v for k, v in os.environ.items() if k != "FASTAPI_ENV"}
+    with patch.dict(os.environ, env_without_fastapi, clear=True):
         result = _is_production_environment()
-        # Aiden worktree path → not production
-        assert result is False or "/clawd/Agency_OS/" in os.path.abspath(
-            "src/integrations/leadmagic.py"
-        )
+        # In Aiden worktree the test file path doesn't start with main worktree
+        # path → result must be False. In Elliot main worktree result would be True.
+        # Test asserts function correctly reflects the path it's loaded from.
+        import src.integrations.leadmagic as lm_mod
+
+        expected = os.path.abspath(lm_mod.__file__).startswith("/home/elliotbot/clawd/Agency_OS/")
+        assert result is expected
 
 
 def test_mock_safe_various_truthy_values_in_production():

--- a/tests/integrations/test_leadmagic_mock_guardrail.py
+++ b/tests/integrations/test_leadmagic_mock_guardrail.py
@@ -1,0 +1,107 @@
+"""Tests for the LEADMAGIC_MOCK production guardrail in src/integrations/leadmagic.py.
+
+The guardrail refuses module load if LEADMAGIC_MOCK is truthy AND
+the environment is detected as production. Catastrophic-blast-radius-
+prevention: mock mode returns fake AU mobile numbers and emails which
+would be sent to real campaign prospects.
+
+Tests cover:
+- Mock + production env → RuntimeError raised
+- Mock + dev env → no error
+- Production env without mock → no error
+- Dev env without mock → no error
+- Production heuristic via worktree path detection
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def test_mock_safe_dev_env_with_mock_off():
+    """Dev environment, mock OFF: no error, normal operation."""
+    from src.integrations.leadmagic import _assert_mock_safe, _is_mock_mode
+
+    with patch.dict(os.environ, {"LEADMAGIC_MOCK": "", "FASTAPI_ENV": "dev"}, clear=False):
+        assert _is_mock_mode() is False
+        _assert_mock_safe()  # Should not raise
+
+
+def test_mock_safe_dev_env_with_mock_on():
+    """Dev environment, mock ON: no error, mock allowed in dev."""
+    from src.integrations.leadmagic import _assert_mock_safe, _is_mock_mode
+
+    with patch.dict(os.environ, {"LEADMAGIC_MOCK": "true", "FASTAPI_ENV": "dev"}, clear=False):
+        assert _is_mock_mode() is True
+        # Should not raise — mock allowed in dev
+        _assert_mock_safe()
+
+
+def test_mock_safe_production_env_with_mock_off():
+    """Production env, mock OFF: no error, normal production operation."""
+    from src.integrations.leadmagic import _assert_mock_safe, _is_mock_mode
+
+    with patch.dict(os.environ, {"LEADMAGIC_MOCK": "", "FASTAPI_ENV": "production"}, clear=False):
+        assert _is_mock_mode() is False
+        _assert_mock_safe()  # Should not raise
+
+
+def test_mock_safe_production_env_with_mock_on_raises():
+    """Production env, mock ON: RuntimeError raised — refuses module load."""
+    from src.integrations.leadmagic import _assert_mock_safe, _is_mock_mode
+
+    with patch.dict(
+        os.environ, {"LEADMAGIC_MOCK": "true", "FASTAPI_ENV": "production"}, clear=False
+    ):
+        assert _is_mock_mode() is True
+        with pytest.raises(
+            RuntimeError, match="LEADMAGIC_MOCK is enabled in a production environment"
+        ):
+            _assert_mock_safe()
+
+
+def test_mock_safe_production_via_worktree_path_heuristic():
+    """Production heuristic: main worktree path triggers production detection."""
+    from src.integrations.leadmagic import _is_production_environment
+
+    # Heuristic check: when __file__ resolves to main worktree, production = True
+    # Direct unit test of the detection function
+    with patch.dict(os.environ, {"FASTAPI_ENV": "dev"}, clear=False):
+        # FASTAPI_ENV=dev shouldn't override worktree-path heuristic
+        # We can't easily fake __file__ in this test, so this asserts
+        # the function returns based on real path resolution
+        result = _is_production_environment()
+        # Aiden worktree path → not production
+        assert result is False or "/clawd/Agency_OS/" in os.path.abspath(
+            "src/integrations/leadmagic.py"
+        )
+
+
+def test_mock_safe_various_truthy_values_in_production():
+    """Mock-mode env var: 'true', '1', 'yes' all trigger guardrail in production."""
+    from src.integrations.leadmagic import _assert_mock_safe
+
+    for truthy in ("true", "TRUE", "1", "yes", "YES"):
+        with patch.dict(
+            os.environ,
+            {"LEADMAGIC_MOCK": truthy, "FASTAPI_ENV": "production"},
+            clear=False,
+        ):
+            with pytest.raises(RuntimeError):
+                _assert_mock_safe()
+
+
+def test_mock_safe_falsy_values_pass_through():
+    """Mock-mode env var: 'false', '0', '', 'no' do not trigger guardrail."""
+    from src.integrations.leadmagic import _assert_mock_safe
+
+    for falsy in ("false", "0", "", "no", "FALSE"):
+        with patch.dict(
+            os.environ,
+            {"LEADMAGIC_MOCK": falsy, "FASTAPI_ENV": "production"},
+            clear=False,
+        ):
+            _assert_mock_safe()  # Should not raise — mock is off


### PR DESCRIPTION
## Summary

Live `agencyxos.ai` was displaying **"3 of 20 founding spots taken · \$500 refundable deposit"** when zero spots have been taken (zero customers, zero waitlist entries, zero deposits per Max V1 trust verification 2026-05-08).

Per Dave's `DEFINITIVE_AUDIT_REPORT` immediate directive ("Landing page false claim correction — immediate, no phase gate") and Max's go-signal, strikes the hardcoded counter on all production surfaces in a single PR (LAW XV no-warn-only).

**This PR also includes the prior leadmagic-mock production guardrail commits** (PR #610 follow-on review-fix work that was on the same branch).

## Files corrected — false hardcoded counter

| File | Line | Old | New |
|---|---|---|---|
| `frontend/landing/index.html` | 1241, 1543 | `3 of 20 founding spots taken/reserved` | `20 founding spots available` |
| `landing-page.html` | 113 | `Only 17 of 20 founding spots remaining` | `20 founding spots available` |
| `landing-page-v2.html` | 169 | same | same |
| `frontend/components/landing/HeroSection.tsx` | 89 | same | same |
| `frontend/components/generated/hero/components/agency-os-hero.tsx` | 89 | same | same |

## Skipped — already-honest dynamic surfaces

- `frontend/components/marketing/founding-spots.tsx` — fetches `/api/v1/billing/founding-spots`
- `frontend/components/marketing/floating-founding-spots.tsx` — uses `useFoundingSpots` hook
- `frontend/app/page.tsx:679` — uses `spotsRemaining ?? "..."` from API
- `frontend/app/(marketing)/pricing/PricingClient.tsx` — references "20 founding spots" without false count
- `frontend/app/api/waitlist/route.ts` — references "20 founding spots" without false count

## Skipped — historical review doc

- `docs/marketing/landing-page-expert-panel.html` — internal review document of past panel state, not deployed (would be revisionist to edit)

## Verification

- `curl -L https://agencyxos.ai` (HTTP 200, 51,252 bytes) — confirmed live page serves the false claim before this PR
- `grep -rn "3 of 20|17 of 20|spots taken|spots reserved"` post-edit returns 0 hits in production code

## Test plan

- [ ] Vercel auto-deploys main after merge
- [ ] Live `agencyxos.ai` post-deploy: curl HTTP 200, body contains `20 founding spots available`, body does NOT contain `3 of 20` or `17 of 20`
- [ ] Dynamic founding-spots component still functions (fetches `/api/v1/billing/founding-spots` honestly — likely returns 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)