### PR TITLE
[ELLIOT] refactor: LAW II currency SSOT — settings.aud_per_usd

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -120,6 +120,15 @@ class Settings(BaseSettings):
         default="http://localhost:4200/api", description="Prefect server API URL"
     )
 
+    # === LAW II — Currency Conversion (USD → AUD) ===
+    # Vendor pricing constants (Bright Data, Leadmagic, DataForSEO, etc.) are
+    # stored in the vendor's billing currency (USD). This single SSOT converts
+    # to AUD at runtime for LAW II compliance ("All financial outputs in $AUD").
+    # Update this value when AUD/USD shifts materially.
+    aud_per_usd: float = Field(
+        default=1.55, description="AUD per USD exchange rate (LAW II SSOT)"
+    )
+
     # === API Keys ===
     anthropic_api_key: str = Field(default="", description="Anthropic/Claude API key")
     anthropic_daily_spend_limit: float = Field(

--- a/src/governance/router.py
+++ b/src/governance/router.py
@@ -28,13 +28,14 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
 
+from src.config.settings import settings
 from src.telegram_bot.openai_cost_logger import COST_LOG_PATH, log_openai_call
 
 logger = logging.getLogger(__name__)
 
 Audience = Literal["dave", "peer", "system"]
 DEFAULT_MODEL = "gpt-4o-mini"
-_USD_TO_AUD = 1.55
+# AUD/USD conversion lives in settings.aud_per_usd (LAW II SSOT).
 _DEFAULT_DAILY_CAP_AUD = 5.00
 
 
@@ -64,7 +65,7 @@ def _daily_cost_usd_today() -> float:
 def _over_daily_cap() -> bool:
     """Return True if today's OpenAI spend (converted to AUD) exceeds ROUTER_DAILY_CAP_AUD."""
     cap_aud = float(os.environ.get("ROUTER_DAILY_CAP_AUD", _DEFAULT_DAILY_CAP_AUD))
-    spent_aud = _daily_cost_usd_today() * _USD_TO_AUD
+    spent_aud = _daily_cost_usd_today() * settings.aud_per_usd
     if spent_aud >= cap_aud:
         logger.warning(
             "router: daily cap reached ($%.4f AUD of $%.2f AUD limit); skipping OpenAI classifier",
@@ -186,7 +187,7 @@ def classify(
                 callsign=cs,
                 event_type="router_cost_cap_reached",
                 event_data={
-                    "spent_aud": round(_daily_cost_usd_today() * _USD_TO_AUD, 4),
+                    "spent_aud": round(_daily_cost_usd_today() * settings.aud_per_usd, 4),
                     "cap_aud": float(
                         os.environ.get("ROUTER_DAILY_CAP_AUD", _DEFAULT_DAILY_CAP_AUD)
                     ),

--- a/src/integrations/bright_data_client.py
+++ b/src/integrations/bright_data_client.py
@@ -31,10 +31,13 @@ DATASET_IDS = {
     "x_posts": "gd_lwdb4vjm1qvm96sbq2",  # X/Twitter posts dataset
 }
 
-COSTS_AUD = {
+# Vendor pricing in USD (Bright Data bills in USD per their public pricing page).
+# AUD conversion happens at runtime via _cost_aud() using settings.aud_per_usd
+# (LAW II SSOT). Do NOT pre-multiply by 1.55 here — see _cost_aud() helper.
+COSTS_USD = {
     "serp_request": 0.0015,
     "scraper_record": 0.0015,
-    # Siege Waterfall v3 costs (Directive #144)
+    # Pipeline F costs (Directive #144)
     "gmb_discovery": 0.001,  # T0 GMB-first discovery
     "gmb_reviews": 0.001,  # T2.5 GMB reviews
     "linkedin_company": 0.025,  # T1.5 LinkedIn company
@@ -42,6 +45,13 @@ COSTS_AUD = {
     "linkedin_posts": 0.0015,  # T-DM2 LinkedIn posts 90d
     "x_posts": 0.0025,  # T-DM3 X posts 90d
 }
+
+
+def _cost_aud(key: str, count: int = 1) -> float:
+    """Return AUD-converted cost for `count` calls of pricing key (LAW II)."""
+    from src.config.settings import settings
+
+    return COSTS_USD[key] * settings.aud_per_usd * count
 
 
 class BrightDataError(Exception):
@@ -59,10 +69,9 @@ class CostTracker:
 
     @property
     def total_aud(self) -> float:
-        """Calculate total cost in AUD for this session"""
-        return (
-            self.serp_requests * COSTS_AUD["serp_request"]
-            + self.scraper_records * COSTS_AUD["scraper_record"]
+        """Calculate total cost in AUD for this session (LAW II)."""
+        return _cost_aud("serp_request", count=self.serp_requests) + _cost_aud(
+            "scraper_record", count=self.scraper_records
         )
 
 
@@ -446,7 +455,7 @@ class BrightDataClient:
             category=category,
             location=location,
             records=records_returned,
-            cost_aud=records_returned * COSTS_AUD["gmb_discovery"],
+            cost_aud=_cost_aud("gmb_discovery", count=records_returned),
         )
 
         return results[:limit]
@@ -478,7 +487,7 @@ class BrightDataClient:
                 "gmb_reviews_complete",
                 place_id=place_id,
                 reviews_count=len(reviews),
-                cost_aud=COSTS_AUD["gmb_reviews"],
+                cost_aud=_cost_aud("gmb_reviews"),
             )
             return reviews
 
@@ -518,7 +527,7 @@ class BrightDataClient:
                 "linkedin_company_enriched",
                 url=linkedin_url,
                 has_posts=bool(result.get("updates", [])),
-                cost_aud=COSTS_AUD["linkedin_company"],
+                cost_aud=_cost_aud("linkedin_company"),
             )
             return result
 
@@ -593,7 +602,7 @@ class BrightDataClient:
             logger.info(
                 "linkedin_profile_enriched",
                 url=linkedin_url,
-                cost_aud=COSTS_AUD["linkedin_profile"],
+                cost_aud=_cost_aud("linkedin_profile"),
             )
             return result
 
@@ -647,7 +656,7 @@ class BrightDataClient:
                 "linkedin_posts_90d_complete",
                 url=linkedin_url,
                 posts_count=len(filtered_posts),
-                cost_aud=COSTS_AUD["linkedin_posts"],
+                cost_aud=_cost_aud("linkedin_posts"),
             )
             return filtered_posts
 
@@ -740,7 +749,7 @@ class BrightDataClient:
             first_name=first_name,
             last_name=last_name,
             title=title,
-            cost_aud=COSTS_AUD["linkedin_profile"],
+            cost_aud=_cost_aud("linkedin_profile"),
         )
 
         return {
@@ -797,7 +806,7 @@ class BrightDataClient:
                 "x_posts_90d_complete",
                 handle=handle,
                 posts_count=len(filtered_posts),
-                cost_aud=COSTS_AUD["x_posts"],
+                cost_aud=_cost_aud("x_posts"),
             )
             return filtered_posts
 
@@ -813,9 +822,9 @@ class BrightDataClient:
         """Return costs by method/tier."""
         return {
             "serp_requests": self.costs.serp_requests,
-            "serp_cost_aud": self.costs.serp_requests * COSTS_AUD["serp_request"],
+            "serp_cost_aud": _cost_aud("serp_request", count=self.costs.serp_requests),
             "scraper_records": self.costs.scraper_records,
-            "scraper_cost_aud": self.costs.scraper_records * COSTS_AUD["scraper_record"],
+            "scraper_cost_aud": _cost_aud("scraper_record", count=self.costs.scraper_records),
             "total_aud": self.costs.total_aud,
         }
 

--- a/src/integrations/dfs_serp_client.py
+++ b/src/integrations/dfs_serp_client.py
@@ -24,7 +24,17 @@ DFS_SERP_LIVE_ENDPOINT = "/serp/google/organic/live/advanced"
 DFS_STATUS_SUCCESS = 20000
 DFS_STATUS_AUTH_FAILURE = 40200
 
-COST_PER_SERP_AUD = Decimal("0.00930")  # $0.006 USD * 1.55 AUD/USD
+# Vendor pricing in USD (DataForSEO bills in USD per their public pricing page).
+# AUD conversion happens at runtime via _cost_per_serp_aud() using
+# settings.aud_per_usd (LAW II SSOT). Do NOT pre-multiply by 1.55 here.
+COST_PER_SERP_USD = Decimal("0.006")  # $0.006 USD per SERP query
+
+
+def _cost_per_serp_aud() -> Decimal:
+    """Return per-SERP cost in AUD using settings SSOT (LAW II)."""
+    from src.config.settings import settings
+
+    return COST_PER_SERP_USD * Decimal(str(settings.aud_per_usd))
 
 DFS_SERP_LOCATION_AU = 2036
 DFS_LINKEDIN_IN_PATTERN = "linkedin.com/in/"
@@ -75,7 +85,7 @@ class DFSSerpClient:
 
     @property
     def estimated_cost_aud(self) -> Decimal:
-        return self.queries_made * COST_PER_SERP_AUD
+        return Decimal(self.queries_made) * _cost_per_serp_aud()
 
     @retry(
         stop=stop_after_attempt(3),

--- a/src/integrations/leadmagic.py
+++ b/src/integrations/leadmagic.py
@@ -70,9 +70,18 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://api.leadmagic.io"
 DEFAULT_TIMEOUT = 30.0
 
-# Cost per operation in $AUD (LAW II compliance)
-COST_EMAIL_FINDER_AUD = 0.015  # T3 email enrichment
-COST_MOBILE_FINDER_AUD = 0.077  # T5 mobile enrichment
+# Vendor pricing in USD (Leadmagic bills in USD per their public pricing page).
+# AUD conversion happens at runtime via _cost_aud() using settings.aud_per_usd
+# (LAW II SSOT). Do NOT pre-multiply by 1.55 here.
+COST_EMAIL_FINDER_USD = 0.015  # T3 email enrichment
+COST_MOBILE_FINDER_USD = 0.077  # T5 mobile enrichment
+
+
+def _cost_aud(usd: float) -> float:
+    """Convert USD vendor cost to AUD using settings SSOT (LAW II)."""
+    from src.config.settings import settings
+
+    return usd * settings.aud_per_usd
 
 # Rate limiting
 MAX_REQUESTS_PER_SECOND = 10
@@ -599,7 +608,7 @@ class LeadmagicClient:
             except ValueError:
                 status = EmailStatus.UNKNOWN
 
-            cost = self._track_cost(COST_EMAIL_FINDER_AUD) if found else 0.0
+            cost = self._track_cost(_cost_aud(COST_EMAIL_FINDER_USD)) if found else 0.0
 
             return EmailFinderResult(
                 found=found,
@@ -718,7 +727,7 @@ class LeadmagicClient:
             if first_name and last_name:
                 full_name = f"{first_name} {last_name}"
 
-            cost = self._track_cost(COST_MOBILE_FINDER_AUD) if found else 0.0
+            cost = self._track_cost(_cost_aud(COST_MOBILE_FINDER_USD)) if found else 0.0
 
             return MobileFinderResult(
                 found=found,

--- a/src/orchestration/cohort_runner.py
+++ b/src/orchestration/cohort_runner.py
@@ -34,6 +34,7 @@ for _k, _v in env.items():
         os.environ.setdefault(_k, _v)
 
 from src.config.category_etv_windows import CATEGORY_ETV_WINDOWS, get_etv_window
+from src.config.settings import settings
 from src.integrations.bright_data_client import BrightDataClient
 from src.integrations.dfs_labs_client import DFSLabsClient
 from src.integrations.leadmagic import LeadmagicClient
@@ -927,7 +928,7 @@ def _build_summary(pipeline: list[dict], wall_s: float) -> dict:
         },
         "drop_reasons": dict(drop_reasons),
         "cost_usd": round(total_cost, 4),
-        "cost_aud": round(total_cost * 1.55, 4),
+        "cost_aud": round(total_cost * settings.aud_per_usd, 4),
         "cost_per_card": round(total_cost / cards, 4) if cards else None,
         "wall_clock_s": round(wall_s, 1),
         "per_stage_timing": per_stage_timing,

--- a/src/orchestration/flows/infra_provisioning_flow.py
+++ b/src/orchestration/flows/infra_provisioning_flow.py
@@ -36,10 +36,27 @@ logger = logging.getLogger(__name__)
 # CONSTANTS
 # ============================================
 
-# Cost constants (AUD)
-MAILFORGE_COST_PER_MAILBOX_AUD = 4.65  # $3 USD × 1.55
-DOMAIN_COST_PER_YEAR_AUD = 21.70  # $14 USD × 1.55
-DOMAIN_COST_PER_MONTH_AUD = DOMAIN_COST_PER_YEAR_AUD / 12  # ~$1.81
+# Vendor pricing in USD (Mailforge + domain registrars bill in USD per their
+# public pricing pages). AUD conversion derived via settings.aud_per_usd
+# (LAW II SSOT) — do NOT pre-multiply by 1.55 here.
+MAILFORGE_COST_PER_MAILBOX_USD = 3.0  # Mailforge mailbox subscription
+DOMAIN_COST_PER_YEAR_USD = 14.0  # Domain registrar yearly fee
+
+
+def _mailforge_cost_per_mailbox_aud() -> float:
+    from src.config.settings import settings
+
+    return MAILFORGE_COST_PER_MAILBOX_USD * settings.aud_per_usd
+
+
+def _domain_cost_per_year_aud() -> float:
+    from src.config.settings import settings
+
+    return DOMAIN_COST_PER_YEAR_USD * settings.aud_per_usd
+
+
+def _domain_cost_per_month_aud() -> float:
+    return _domain_cost_per_year_aud() / 12
 
 # Default configuration
 DEFAULT_MAILBOXES_PER_DOMAIN = 2

--- a/src/orchestration/flows/pipeline_f_master_flow.py
+++ b/src/orchestration/flows/pipeline_f_master_flow.py
@@ -31,6 +31,7 @@ import asyncpg
 from prefect import flow, task
 from prefect.cache_policies import NO_CACHE
 
+from src.config.settings import settings
 from src.prefect_utils.completion_hook import on_completion_hook
 from src.prefect_utils.hooks import on_failure_hook
 
@@ -58,7 +59,7 @@ _KEIRACOM_PROFILE = {
 }
 
 # ── Budget / gate constants ──────────────────────────────────────────────────
-_USD_TO_AUD = 1.55
+# AUD/USD conversion lives in settings.aud_per_usd (LAW II SSOT).
 _PASS_THRESHOLD = 70  # dm_messages quality gate (email_scoring_gate.PASS_THRESHOLD)
 
 
@@ -658,7 +659,7 @@ async def pipeline_f_master_flow(
         "enrichment_failed": result.stats.enrichment_failed,
         "affordability_rejected": result.stats.affordability_rejected,
         "cost_usd": round(result.stats.total_cost_usd, 4),
-        "cost_aud": round(result.stats.total_cost_usd * _USD_TO_AUD, 4),
+        "cost_aud": round(result.stats.total_cost_usd * settings.aud_per_usd, 4),
         "budget_cap_aud": effective_budget_aud,
         "elapsed_s": round(result.stats.elapsed_seconds, 1),
     }

--- a/src/orchestration/flows/stage_9_10_flow.py
+++ b/src/orchestration/flows/stage_9_10_flow.py
@@ -40,6 +40,7 @@ def _logger() -> logging.Logger:
     return logging.getLogger(__name__)
 
 
+from src.config.settings import settings
 from src.exceptions import AgencyProfileMissingError
 from src.pipeline.signal_config import SignalConfigRepository
 from src.pipeline.stage_9_vulnerability_enrichment import Stage9VulnerabilityEnrichment
@@ -221,7 +222,7 @@ async def stage_9_10_pipeline(
                     "stage_9_contactout_usd": round(s9_co_cost, 4),
                     "stage_10_messages_usd": round(s10_cost, 4),
                     "total_usd": round(total_est, 4),
-                    "total_aud": round(total_est * 1.55, 4),
+                    "total_aud": round(total_est * settings.aud_per_usd, 4),
                 },
                 "expected_writes": {
                     "business_universe.vulnerability_report": len(selected),
@@ -278,7 +279,7 @@ async def stage_9_10_pipeline(
             "stage_10": s10_result,
             "channel_counts": channel_counts,
             "total_cost_usd": round(total_cost, 6),
-            "total_cost_aud": round(total_cost * 1.55, 4),
+            "total_cost_aud": round(total_cost * settings.aud_per_usd, 4),
             "budget_cap_usd": budget_cap_usd,
         }
 

--- a/src/pipeline/stage_10_message_generator.py
+++ b/src/pipeline/stage_10_message_generator.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import asyncpg
 
+from src.config.settings import settings
 from src.pipeline.signal_config import SignalConfigRepository
 from src.pipeline.stage_10_critic import CRITIC_PASS_THRESHOLD, critique_and_revise  # noqa: F401
 from src.utils.domain_blocklist import BLOCKED_DOMAINS
@@ -261,7 +262,7 @@ class Stage10MessageGenerator:
             "dms_processed": dms_processed,
             "skipped_no_bdm": skipped_no_bdm,
             "cost_usd": round(self._stats["cost_usd"], 6),
-            "cost_aud": round(self._stats["cost_usd"] * 1.55, 4),
+            "cost_aud": round(self._stats["cost_usd"] * settings.aud_per_usd, 4),
             "cache_hit_rate": cache_hit_rate,
             "per_channel": self._stats["per_channel"],
         }

--- a/src/pipeline/stage_1_discovery.py
+++ b/src/pipeline/stage_1_discovery.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import asyncpg
 
+from src.config.settings import settings
 from src.integrations.dfs_labs_client import DFSLabsClient
 from src.pipeline.signal_config import SignalConfigRepository
 from src.utils.domain_blocklist import is_blocked
@@ -99,7 +100,7 @@ class Stage1Discovery:
             "duplicates_skipped": total_duplicates,
             "api_calls": total_api_calls,
             "cost_usd": cost_usd,
-            "cost_aud": round(cost_usd * 1.55, 4),
+            "cost_aud": round(cost_usd * settings.aud_per_usd, 4),
             "technologies_searched": len(technologies),
         }
         logger.info(f"Stage 1 complete: {result}")

--- a/src/pipeline/stage_3_dfs_profile.py
+++ b/src/pipeline/stage_3_dfs_profile.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import asyncpg
 
+from src.config.settings import settings
 from src.integrations.dfs_labs_client import DFSLabsClient
 from src.pipeline.signal_config import SignalConfigRepository
 
@@ -102,7 +103,7 @@ class Stage3DFSProfile:
             "profiled": profiled,
             "api_errors": errors,
             "cost_usd": cost_usd,
-            "cost_aud": round(cost_usd * 1.55, 4),
+            "cost_aud": round(cost_usd * settings.aud_per_usd, 4),
         }
         logger.info(f"Stage 3 complete: {result}")
         return result

--- a/src/pipeline/stage_7_haiku.py
+++ b/src/pipeline/stage_7_haiku.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import asyncpg
 
+from src.config.settings import settings
 from src.pipeline.signal_config import SignalConfigRepository
 
 logger = logging.getLogger(__name__)
@@ -156,7 +157,7 @@ class Stage7Haiku:
         return {
             "messages_generated": messages_generated,
             "cost_usd": self.total_cost_usd,
-            "cost_aud": round(self.total_cost_usd * 1.55, 4),
+            "cost_aud": round(self.total_cost_usd * settings.aud_per_usd, 4),
         }
 
     async def _generate_messages(

--- a/src/pipeline/stage_9_vulnerability_enrichment.py
+++ b/src/pipeline/stage_9_vulnerability_enrichment.py
@@ -21,6 +21,7 @@ from typing import Any
 import asyncpg
 import httpx
 
+from src.config.settings import settings
 from src.pipeline.intelligence import generate_vulnerability_report
 from src.utils.domain_blocklist import BLOCKED_DOMAINS
 
@@ -80,7 +81,7 @@ class Stage9VulnerabilityEnrichment:
             "cost_vr_usd": cost_vr,
             "cost_co_usd": cost_co,
             "cost_total_usd": total_usd,
-            "cost_total_aud": round(total_usd * 1.55, 4),
+            "cost_total_aud": round(total_usd * settings.aud_per_usd, 4),
         }
 
     async def _fetch_rows(self, conn, bdm_ids, batch_size):

--- a/tests/test_dfs_serp_client.py
+++ b/tests/test_dfs_serp_client.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src.integrations.dfs_serp_client import (
-    COST_PER_SERP_AUD,
+    _cost_per_serp_aud,
     DFS_STATUS_SUCCESS,
     DFSSerpClient,
 )
@@ -199,7 +199,7 @@ async def test_cost_tracking_increments():
         await client.find_decision_maker("Corp", "Sydney", "NSW")
 
     assert client.queries_made == 3, f"Expected 3 queries, got {client.queries_made}"
-    expected_cost = Decimal("3") * COST_PER_SERP_AUD
+    expected_cost = Decimal("3") * _cost_per_serp_aud()
     assert client.estimated_cost_aud == expected_cost, (
         f"Expected cost {expected_cost}, got {client.estimated_cost_aud}"
     )

--- a/tests/test_leadmagic_client.py
+++ b/tests/test_leadmagic_client.py
@@ -11,8 +11,9 @@ from src.integrations.leadmagic import (
     MobileFinderResult,
     EmailStatus,
     MobileStatus,
-    COST_EMAIL_FINDER_AUD,
-    COST_MOBILE_FINDER_AUD,
+    COST_EMAIL_FINDER_USD,
+    COST_MOBILE_FINDER_USD,
+    _cost_aud,
 )
 
 
@@ -175,8 +176,8 @@ async def test_cost_tracking(client):
         await client.find_email("Bob", "Jones", "example.com")
         await client.find_mobile("https://linkedin.com/in/test")
 
-    expected_min = 2 * COST_EMAIL_FINDER_AUD + COST_MOBILE_FINDER_AUD
+    expected_min = 2 * _cost_aud(COST_EMAIL_FINDER_USD) + _cost_aud(COST_MOBILE_FINDER_USD)
     assert client.total_cost_aud >= expected_min - 0.0001
     assert client.total_cost_aud == pytest.approx(
-        2 * COST_EMAIL_FINDER_AUD + COST_MOBILE_FINDER_AUD, abs=0.0001
+        2 * _cost_aud(COST_EMAIL_FINDER_USD) + _cost_aud(COST_MOBILE_FINDER_USD), abs=0.0001
     )


### PR DESCRIPTION
## Summary

Per Max-authorized PR 1 from dual-bot consolidation 2026-05-08. Pure refactor — vendor pricing constants now stored in vendor's billing currency (USD), AUD derived at runtime via single SSOT `settings.aud_per_usd`.

**Bug fixed:** ~55% understate on any AUD aggregation. 8 inline `* 1.55` sites + 4 pre-multiplied constants + 2 local `_USD_TO_AUD` constants previously stored USD values labeled AUD or duplicated the 1.55 exchange rate.

## Scope

14 production files + 2 test files. 109 insertions, 45 deletions.

| File | Change |
|---|---|
| `src/config/settings.py` | + `aud_per_usd: float = 1.55` (LAW II SSOT) |
| `src/integrations/bright_data_client.py` | `COSTS_AUD` → `COSTS_USD` + `_cost_aud()` helper |
| `src/integrations/leadmagic.py` | `COST_*_FINDER_AUD` → `_USD` + `_cost_aud()` helper |
| `src/integrations/dfs_serp_client.py` | `COST_PER_SERP_AUD` → `COST_PER_SERP_USD` + `_cost_per_serp_aud()` helper |
| `src/orchestration/flows/infra_provisioning_flow.py` | Mailforge + Domain constants → USD + helpers |
| `src/orchestration/flows/pipeline_f_master_flow.py` | Local `_USD_TO_AUD` → `settings.aud_per_usd` |
| `src/governance/router.py` | Local `_USD_TO_AUD` → `settings.aud_per_usd` |
| `src/orchestration/cohort_runner.py` | Inline `* 1.55` → `* settings.aud_per_usd` |
| `src/orchestration/flows/stage_9_10_flow.py` | 2× inline `* 1.55` (L224, L281) |
| `src/pipeline/stage_{1,3,7,9,10}*.py` | 5× inline `* 1.55` |
| `tests/test_dfs_serp_client.py` | Import `_cost_per_serp_aud` helper (expected value identical) |
| `tests/test_leadmagic_client.py` | Import `COST_*_FINDER_USD` + `_cost_aud` helper (expected value now correct AUD) |

## Refactor pattern (consistent across 4 integration files)

```python
# Vendor pricing in USD (vendor bills in USD per public pricing page).
COSTS_USD = {"key": 0.0015, ...}

def _cost_aud(key: str, count: int = 1) -> float:
    """Convert USD vendor cost to AUD using settings SSOT (LAW II)."""
    from src.config.settings import settings
    return COSTS_USD[key] * settings.aud_per_usd * count
```

Dataclass field names preserved (`cost_aud=...`) — 41 light consumer files don't change.

## Verification

```
$ pytest tests/ --collect-only -q | tail -1
3489/3493 tests collected (4 deselected) in 15.09s

$ pytest tests/test_dfs_serp_client.py tests/test_leadmagic_client.py
10 passed in 0.82s

$ grep -rnE '\* *1\.55|1\.55 *\*|= *1\.55|_USD_TO_AUD' src/ --include='*.py' \
    | grep -vE 'voice/system_prompt\.py|config/settings\.py|config/email_costs\.py'
(0 lines — clean)
```

Remaining informational text references (acceptable, by design):
- `src/config/settings.py:129` — canonical SSOT default
- `src/voice/system_prompt.py:45` — system prompt text instructing voice agent to convert USD to AUD verbally
- `src/config/email_costs.py:8` — module docstring comment

## LAW II compliance

Now structurally enforced:
- Single `settings.aud_per_usd` SSOT (was duplicated in 9+ places)
- Vendor prices stored in vendor's billing currency (clean reconciliation against vendor invoices)
- `cost_aud` fields are derived AUD, not stored USD-mislabeled-as-AUD

## Sequencing

Sequenced before PR 2 (cost instrumentation) so `sdk_usage_log` writes land with correct AUD values from row 1.

## Test plan

- [x] pytest collection baseline holds (3489/3493 = same as pre-PR)
- [x] Both affected test files pass (10/10)
- [x] Negative grep clean (0 hits in production code)
- [ ] Aiden review per 5-point checklist (negative grep, pytest collect, settings.AUD_PER_USD canonical, 3-heavy-consumer spot-check, BD/Leadmagic rename + helper present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)