### PR TITLE
[AIDEN] docs: file Aiden audit deliverables to docs/audits/aiden/

### DIFF
--- a/docs/audits/aiden/audit_discovery_2026-05-07.md
+++ b/docs/audits/aiden/audit_discovery_2026-05-07.md
@@ -1,0 +1,262 @@
+# audit_discovery_aiden.md
+
+**Submitted:** 2026-05-07
+**Author:** Aiden
+**Workspace:** /home/elliotbot/clawd/Agency_OS-aiden/
+**Branch:** aiden/scaffold (session branch, does not merge to main)
+
+---
+
+## 1. Role + ownership (one paragraph)
+
+Aiden is one of two AI engineering bots running parallel to Elliot under Max-COO and Dave-CEO. I take build directives, do code-level engineering work (PR authoring, refactors, cleanups, tests, audits), peer-review Elliot's PRs (dual-approval rule applies), and dispatch heavy or long-running work to my clone ORION. Recent ownership in this session: Layer 6 SSOT drift detector (PR #606), onboarding-flow spec PR #609 + amendments, leadmagic mock-mode production guardrail (PR #610), Layer 7 SSOT cleanup peer-review (PR #611), audit on voice/LinkedIn/frontend/ops scope. I do not own product/strategy decisions — those route via Dave through Max.
+
+---
+
+## 2. Single source of truth (SSOT) for my work
+
+| Surface | Location | Purpose |
+|---|---|---|
+| Operational architecture canon | `/home/elliotbot/clawd/Agency_OS-aiden/ARCHITECTURE.md` (also at top-level of repo) | Pipeline, vendors, tiers, deprecated items, scoring, validation rules, env vars, security, glossary, roadmap |
+| CEO-facing mirror | Google Doc ID `1p9FAQGowy9SgwglIxtkGsMuvLsR70MJBQrCSY6Ie9ho` (Drive Manual) | CEO-facing state mirror of architecture |
+| Process / governance | `docs/governance/SOP_ARCHITECTURE_SSOT.md` (ratified PR #606), `docs/governance/CONSOLIDATED_RULES.md` (7 rules ratified 2026-05-01) | SSOT discipline + consolidated rules |
+| Identity | `/home/elliotbot/clawd/Agency_OS-aiden/IDENTITY.md` | Callsign canonical (LAW XVII) |
+| Session memory (callsign-scoped) | `public.agent_memories` table in Supabase, filtered `WHERE callsign = 'aiden'` | Day-to-day session memory |
+| Long-term feedback memory | `/home/elliotbot/.claude/projects/-home-elliotbot-clawd-Agency-OS/memory/` (37 files indexed in `MEMORY.md`) | Cross-session feedback rules |
+| CEO state | `public.ceo_memory` table in Supabase | Dave-facing state, directive counter, blockers |
+| Specs (PR-merged) | `docs/specs/` (currently `onboarding_email_provisioning.md`) | Ratified design specifications |
+| Inbox/outbox relay | `/tmp/telegram-relay-aiden/inbox/` and `/outbox/` | Telegram cross-post + clone dispatch |
+
+---
+
+## 3. Tools, platforms, services I interact with daily
+
+| Tool | Purpose |
+|---|---|
+| `tg` CLI (group + DM modes) | Telegram cross-bot communication via group chat -1003926592540 |
+| Bash | Filesystem inspection, grep, find, ruff, pytest |
+| `git` + `gh` CLI | Branch/commit/push/PR operations on Keiracom/Agency_OS |
+| Read / Edit / Write tools | File-level editing in conversation |
+| Task tool (sub-agent dispatch) | research-1, build-2, build-3, test-4, review-5, devops-6, architect-0, Explore, Plan, general-purpose |
+| MCP bridge (`/home/elliotbot/clawd/skills/mcp-bridge/scripts/mcp-bridge.js`) | Wraps 13+ MCP servers: supabase, redis, prefect, railway, prospeo, dataforseo, vercel, salesforge, vapi, telnyx, unipile, resend, memory |
+| `mcp__keiradrive__keiradrive_search_doc` (loadable via ToolSearch) | Read CEO Drive Manual |
+| `WebFetch` (loadable via ToolSearch) | Verify vendor pricing pages, JS-rendered content |
+| Python 3 + pytest | Run tests, ruff format/check, manual verification |
+| Supabase via MCP | Query agent_memories, ceo_memory, business_universe, lead_pool etc. |
+| Clone dispatch (file-based) | Write JSON to `/tmp/telegram-relay-orion/inbox/` to dispatch ORION |
+
+---
+
+## 4. Reporting chain
+
+```
+Dave (CEO)
+  └─ Max (COO, Dave-proxy in TG group, Tier-0 authority)
+       ├─ Elliot (peer bot)
+       │    └─ ATLAS (Elliot's clone, /home/elliotbot/clawd/Agency_OS-atlas/)
+       └─ Aiden (this bot)
+            └─ ORION (Aiden's clone, /home/elliotbot/clawd/Agency_OS-orion/)
+```
+
+**Up:** Dave (via Max). **Sideways:** Elliot (peer, dual-approval reciprocal). **Down:** ORION (clone, dispatched via inbox JSON). **Sub-agents (transient):** Task-tool spawns (research-1, build-2, etc.) — dispatched per work item, not persistent.
+
+**Other clones in environment:** Scout (research clone for Elliot, `/home/elliotbot/clawd/Agency_OS-scout/`). Sometimes Atlas/Scout dispatched for parallel work.
+
+---
+
+## 5. Repository directory tree (top 2 levels)
+
+**Top-level (`/home/elliotbot/clawd/Agency_OS-aiden/`):**
+```
+agency-os-html/          agency-os-prototype/    agents/
+alembic/                 app-data/               builds/
+campaigns/               canvas/                 competitive/
+config/                  data/                   docs/
+frontend/                governance/             hooks/
+infra/                   landing-page-analysis/  maya-concepts/
+mcp-servers/             memory/                 migrations/
+projects/                prompts/                research/
+scripts/                 skills/                 SKILLS/
+src/                     .claude/                .git/
+tests/                   tasks/
+```
+
+**Top-level files of note:** `ARCHITECTURE.md`, `CLAUDE.md`, `IDENTITY.md`, `AGENTS.md`, `MEMORY.md`, `SECURITY.md`, plus many `*_REPORT.md`, `*_PLAN.md`, audit docs.
+
+**`src/` (2nd level) — backend Python:**
+```
+src/agent_coord/    src/agents/        src/api/         src/clients/
+src/clone_dispatch.py  src/config/    src/coo_bot/     src/data/
+src/detectors/      src/engines/       src/exceptions.py  src/integrations/
+src/intelligence/   src/middleware/    src/models/       src/observability/
+src/orchestration/  src/outreach/      src/pipeline/     src/services/
+src/skills/         src/sso/           src/telegram_bot/  src/utils/
+src/voice/          src/main.py
+```
+
+**`frontend/` (2nd level) — Next.js:**
+```
+frontend/app/        frontend/components/   frontend/contexts/
+frontend/data/       frontend/hooks/        frontend/landing/
+frontend/lib/        frontend/middleware.ts frontend/mocks/
+frontend/public/     frontend/scripts/      frontend/sentry.client.config.ts
+```
+
+**`docs/` (2nd level) — documentation:**
+```
+docs/advice/         docs/architecture/   docs/archive/        docs/audits/
+docs/clones/         docs/drafts/         docs/e2e/            docs/finance/
+docs/governance/     docs/integrations/   docs/landing-variants/
+docs/legal/          docs/manuals/        docs/marketing/      docs/ops/
+docs/phases/         docs/pitch/          docs/postmortems/    docs/progress/
+docs/research/       docs/roadmap/        docs/specs/          docs/strategy/
+docs/voice/          docs/MANUAL.md       docs/project_structure.md
+```
+
+---
+
+## 6. Governing files
+
+| File | Purpose |
+|---|---|
+| `/home/elliotbot/clawd/Agency_OS-aiden/ARCHITECTURE.md` | Locked system architecture (586 lines, 14 sections incl. Security/Glossary/Roadmap added in PR #608). Authority: CEO. Do not modify without explicit CEO directive. |
+| `/home/elliotbot/clawd/Agency_OS-aiden/CLAUDE.md` (43 lines, modular) | Project-config + auto-loaded module imports (`@.claude/modules/_*.md`) |
+| `/home/elliotbot/clawd/Agency_OS-aiden/IDENTITY.md` | Callsign source-of-truth (LAW XVII) |
+| `/home/elliotbot/clawd/Agency_OS-aiden/AGENTS.md` | Agent registry / role assignments |
+| `/home/elliotbot/clawd/Agency_OS-aiden/.claude/modules/` | 11 module files (process, laws, session start/end, governance rules) — pointer modules per Layer 1 SSOT alignment (PR #603) |
+| `/home/elliotbot/clawd/Agency_OS-aiden/docs/governance/CONSOLIDATED_RULES.md` | 7 ratified rules (2026-05-01) — VERIFY / COORDINATE / APPROVE / ORCHESTRATE / COMMUNICATE / GOVERN / BUSINESS |
+| `/home/elliotbot/clawd/Agency_OS-aiden/docs/governance/SOP_ARCHITECTURE_SSOT.md` | SOP for Architecture SSOT discipline (ACTIVE 2026-05-07, PR #606) |
+| `/home/elliotbot/clawd/Agency_OS-aiden/scripts/ssot_drift_check.sh` | Layer 6 drift detector (fires on `SessionStart:clear` per PR #607) |
+| `/home/elliotbot/clawd/Agency_OS-aiden/.claude/settings.json` | Hook configuration including ssot_drift_check.sh wiring |
+| `/home/elliotbot/clawd/Agency_OS-aiden/SECURITY.md` | Top-level security doc (existence verified, content not audited for this report) |
+| `/home/elliotbot/clawd/Agency_OS-aiden/docs/MANUAL.md` | Human-readable manual (in-repo mirror; canonical-source disambiguation vs Drive Manual is a queued Dave question) |
+| `/home/elliotbot/.claude/CLAUDE.md` (user-global, outside repo) | Elliottbot-as-CTO global identity instructions |
+| `/home/elliotbot/clawd/CLAUDE.md` (parent-dir, project-root) | Project-root CLAUDE.md (in-repo file at repo root) |
+
+---
+
+## 7. Test baseline
+
+```
+$ python3 -m pytest --collect-only -q
+3489/3493 tests collected (4 deselected) in 14.83s
+```
+
+- **Collected:** 3,489
+- **Deselected:** 4
+- **Total in test suite:** 3,493
+- **Failing:** unknown — running full suite past collection-only is multi-minute work; baseline collection success is the data point reported here
+
+**Test directory structure (top of `tests/`):**
+```
+tests/api/          tests/clones/         tests/coo_bot/       tests/dashboards/
+tests/e2e/          tests/engines/        tests/integrations/  tests/intelligence/
+tests/orchestration/ tests/outreach/      tests/pipeline/      tests/services/
+tests/test_integrations/ tests/voice/    tests/test_*.py (~100s of files)
+```
+
+Markers in pytest.ini: `live` (real API calls, deselected by default), `integration`, `e2e`. Default `pytest -m "not live"` pattern covers offline tests; `pytest -m live` opts into real-API smoke tests added in PR #602.
+
+---
+
+## 8. Databases
+
+**Supabase project:**
+- **Project ID:** `jatzvazlbusedwsnqxzr` (sole project per CLAUDE.md §Supabase)
+- **Region:** unknown — not exposed in CLAUDE.md or accessible env vars; would require direct Supabase dashboard access
+
+**Schemas + table counts:**
+
+### Schema: `elliot_internal` (4 tables)
+
+```
+api_keys_ledger      memories      prefect_logs      state
+```
+
+### Schema: `public` (141 tables)
+
+```
+_archive_lead_pool_mar25       _archive_leads_mar25            ab_test_variants
+ab_tests                       abn_registry                    activities
+activity_stats                 admin_notifications             agency_communication_profile
+agency_exclusion_list          agency_service_profile          agent_comms
+agent_memories                 api_rate_limits                 approval_queue
+audit_logs                     business_decision_makers        business_reviews
+business_universe              campaign_discovery_log          campaign_lead_messages
+campaign_leads                 campaign_resources              campaign_sends
+campaign_sequences             campaign_suggestion_history     campaign_suggestions
+campaigns                      ceo_memory                      ceo_memory_archive
+cis_adjustment_log             cis_agency_learnings            cis_agency_pool_config
+cis_agent_metrics              cis_als_tier_conversions        cis_ceo_corrections
+cis_channel_performance        cis_directive_metrics           cis_global_learning_pool
+cis_improvement_log            cis_message_patterns            cis_outreach_outcomes
+cis_reply_classifications      cis_run_log                     client_crm_configs
+client_customers               client_dashboard_flags          client_intelligence
+client_linkedin_credentials    client_personas                 client_portfolio
+client_projects                client_resources                client_suppression
+clients                        conversation_threads            conversion_pattern_history
+conversion_patterns            coordinator_claims              crm_push_log
+crm_sync_log                   deal_stage_history              deals
+demo_bookings                  digest_logs                     discarded_leads
+discovery_queries              discovery_results               dm_messages
+domain_suppression             domain_warmup_status            elliot_knowledge
+elliot_session_state           elliot_signoff_queue            elliot_status
+elliot_tasks                   email_events                    email_templates
+enrichment_diagnostic          enrichment_raw_responses        evo_auth_requests
+evo_flow_callbacks             evo_task_queue                  evo_task_results
+founding_members               founding_waitlist               frozen_artifacts
+global_suppression             gmb_pilot_results               gmb_vendor_test
+gmb_vendor_test_dfs            gmb_vendor_test_dfs_biz         gmb_vendor_test_dfs_v2
+governance_events              health_checks                   human_review_queue
+icp_extraction_jobs            icp_refinement_log              industry_keywords
+lead_agency_suppression        lead_assignments                lead_lineage_log
+lead_outreach_history          lead_permission_overrides       lead_pool
+lead_signal_changes            lead_social_posts               lead_tags
+leads                          linkedin_account_daily_state    linkedin_action_queue
+linkedin_connections           linkedin_seats                  location_suburbs
+meetings                       memberships                     outreach_telemetry
+personas                       platform_buyer_signals          platform_timing_signals
+replies                        resource_pool                   revenue_attribution
+sales_pipeline                 sales_pipeline_history          scheduled_touches
+scraper_health_log             sdk_usage_log                   signal_configurations
+suppression_list               telegram_sessions               thread_messages
+tier_registry                  trading_names                   unipile_accounts
+users                          voice_call_context              voice_calls
+waitlist                       webhook_configs                 webhook_deliveries
+```
+
+**Total: 145 tables across 2 schemas.**
+
+Note: 157 migrations exist in `alembic/versions/` per Max's audit. Schema may have additional schemas not queried (e.g., `auth.*` Supabase-managed).
+
+---
+
+## 9. External APIs and services
+
+Per `ARCHITECTURE.md` §SECTION 4 — LIVE VENDORS:
+
+| Vendor | Purpose | Active status | API key status |
+|---|---|---|---|
+| **DataForSEO** | T0 multi-category discovery, T-DM0 ad spend + DM signals | ACTIVE | env vars `DATAFORSEO_LOGIN` + `DATAFORSEO_PASSWORD` present in `~/.config/agency-os/.env` (not verified working in this audit) |
+| **Bright Data** | T2 GMB backfill (gd_m8ebnr0q2qlklc02fz), T1.5 LinkedIn Company, T-DM2 LinkedIn Profile, generic web scrape | ACTIVE | `BRIGHTDATA_API_KEY` present, verified working in PR #602 live-smoke (BD GMB + BD LinkedIn URL-input) |
+| **ABR (data.gov.au)** | ABN + trading name lookup | ACTIVE | `ABN_LOOKUP_GUID` present, verified working in PR #602 live-smoke |
+| **Leadmagic** | Email + mobile enrichment | ACTIVE | `LEADMAGIC_API_KEY` present, status unknown without re-verification |
+| **Jina AI Reader** | Web scrape (Tier 2 scraper waterfall) | ACTIVE | No API key required (free tier) |
+| **Anthropic API** | Claude Haiku/Sonnet/Opus | ACTIVE | `ANTHROPIC_API_KEY` present |
+| **Salesforge** | Email outreach | **BROKEN — API key returns 401** per Max audit; `salesforge` MCP server config in settings.json but `src/integrations/salesforge.py` does not exist |
+| **Unipile** | LinkedIn outreach (connections, DMs) | ACTIVE | env var present in `.env`, `src/integrations/unipile.py` 25.7KB substantive |
+| **ElevenAgents** | Voice AI persona (Alex) | ACTIVE | env vars `ELEVENLABS_API_KEY` + `ELEVENLABS_VOICE_ID` present, `src/integrations/elevenagents_client.py` 22.4KB substantive |
+| **Telnyx** | SMS outreach + voice PSTN | ACTIVE (code), UNTESTED LIVE | `src/integrations/telnyx_client.py` 17.7KB substantive; per Max audit "untested live" |
+
+**Other vendor env vars present in `.env` (per `grep -oE "^[A-Z_]+="`):**
+APIFY_API_TOKEN, APOLLO_API_KEY, BRAVE_API_KEY, CLICKSEND_API_KEY+USERNAME, CLOUDFLARE_ACCOUNT_ID+API_TOKEN+ZONE_AGENCYXOS+ZONE_KEIRACOM, CONTACTOUT_API_KEY, COO_BOT_TOKEN, CREDENTIAL_ENCRYPTION_KEY, CSB_API_KEY, DATABASE_URL+DATABASE_URL_MIGRATIONS, EXPO_TOKEN, GEMINI_API_KEY+GEMINI_API_KEY_BACKUP. Many of these reference vendors deprecated or pending — see ARCHITECTURE.md §3 DEPRECATED VENDORS for canonical deprecation list.
+
+**Vendor key status canonical reference:**
+`elliot_internal.api_keys_ledger` table exists per discovery in this audit but column schema not queried (column-name lookup failed in MCP shell escape during this audit). Per memory pin `api_key_lookup_sop`: query this table before assuming any key works.
+
+**Deprecated per ARCHITECTURE.md §3 (not active):**
+Clay, Hunter.io (except L2 fallback), Kaspr, Proxycurl, Apollo (deprecated for enrichment), Apify (deprecated for GMB; some narrow exceptions), Webshare, SERP API, Direct mail, ZeroBounce, Lemlist, SmartLead.
+
+---
+
+## End of report

--- a/docs/audits/aiden/audit_phase2_2026-05-07.md
+++ b/docs/audits/aiden/audit_phase2_2026-05-07.md
@@ -1,0 +1,211 @@
+# audit_phase2_aiden.md
+
+**Submitted:** 2026-05-07
+**Author:** Aiden
+**Tasks:** A1 (frontend shipping audit), A2 (PR #609 spec vs reality), A3 (deprecated code inventory)
+
+---
+
+## A1 — Frontend Shipping Audit
+
+Walking the frontend route-by-route. Status legend: WORKS (renders, functional logic visible) / PARTIAL (renders but stub-shaped or backend missing) / MISSING (route file does not exist or is hollow stub).
+
+### Auth + landing
+| Route | Lines | Status |
+|---|---|---|
+| `/(auth)/login` | 28 | PARTIAL (thin Supabase wrapper) |
+| `/(auth)/signup` | 182 | PARTIAL (form exists, Stripe wiring unverified) |
+| `/auth/callback` | exists | OAuth callback |
+| `/(marketing)/{about,how-it-works,pricing}` | exists | Marketing |
+| `/welcome` | exists | Post-signup |
+
+### Onboarding (10 pages, ~3000 lines — see A2 for spec gap)
+| Route | Lines | Status |
+|---|---|---|
+| `/onboarding` (root) | 12 | PARTIAL (redirect) |
+| `/onboarding/step-1` | 309 | WORKS |
+| `/onboarding/step-2` | 284 | WORKS |
+| `/onboarding/step-3` | 319 | WORKS |
+| `/onboarding/step-4` | 253 | WORKS |
+| `/onboarding/step-5` | 305 | WORKS |
+| `/onboarding/agency` | 613 | WORKS |
+| `/onboarding/service-area` | 268 | WORKS |
+| `/onboarding/crm` | 236 | WORKS |
+| `/onboarding/linkedin` | 250 | WORKS |
+
+### Dashboard (client-facing) — mixed substantial vs stub
+| Route | Lines | Status |
+|---|---|---|
+| `/dashboard` (root) | 45 | PARTIAL (landing tiles only) |
+| `/dashboard/activity` | 37 | PARTIAL (stub) |
+| `/dashboard/approval` | 39 | PARTIAL (stub) |
+| `/dashboard/archive` | 513 | WORKS |
+| `/dashboard/campaigns` | 474 | WORKS |
+| `/dashboard/campaigns/[id]` | 556 | WORKS |
+| `/dashboard/campaigns/approval` | 332 | WORKS |
+| `/dashboard/campaigns/new` | 575 | WORKS |
+| `/dashboard/elliot` | 119 | PARTIAL |
+| `/dashboard/inbox` | 13 | **MISSING** (stub) |
+| `/dashboard/inbox/[id]` | 155 | PARTIAL (detail only, no index) |
+| `/dashboard/leads` | 21 | **MISSING** (stub) |
+| `/dashboard/leads/[id]` | 22 | PARTIAL (stub) |
+| `/dashboard/meetings` | 159 | WORKS |
+| `/dashboard/pipeline` | 212 | WORKS |
+| `/dashboard/replies` | 12 | **MISSING** (stub) |
+| `/dashboard/reports` | 181 | WORKS |
+| `/dashboard/settings` | 373 | WORKS |
+| `/dashboard/settings/icp` | 486 | WORKS |
+| `/dashboard/settings/linkedin` | 235 | WORKS |
+| `/dashboard/settings/notifications` | 619 | WORKS |
+| `/dashboard/settings/profile` | 440 | WORKS |
+
+### Top-level (parallel to dashboard)
+| Route | Lines | Status |
+|---|---|---|
+| `/billing` | 59 | PARTIAL (Stripe price_ids=None per Max audit) |
+| `/campaigns` | 90 | PARTIAL (duplicate-shape of dashboard route?) |
+| `/leads` | 72 | PARTIAL (duplicate-shape of dashboard route?) |
+| `/leads/[id]` | 59 | PARTIAL |
+| `/replies` | 64 | PARTIAL (duplicate-shape of dashboard route?) |
+
+### Admin (internal, agency-staff facing) — heavily built
+20 admin routes, all 200-400 lines:
+- `/admin` (308), `/admin/activity` (283), `/admin/campaigns` (197), `/admin/clients` (294), `/admin/clients/[id]` (387), `/admin/compliance` (252), `/admin/compliance/bounces` (279), `/admin/compliance/suppression` (278), `/admin/costs` (211), `/admin/costs/ai` (254), `/admin/costs/channels` (224), `/admin/leads` (226), `/admin/replies` (351), `/admin/revenue` (314), `/admin/settings` (234), `/admin/settings/users` (348), `/admin/system` (346), `/admin/system/errors` (285), `/admin/system/queues` (282), `/admin/system/rate-limits` (243)
+
+All WORKS rating.
+
+### A1 summary
+- WORKS: ~32 routes (most onboarding, all admin, selected dashboard)
+- PARTIAL: ~13 routes (auth, marketing, billing, top-level duplicates, dashboard sub-pages)
+- MISSING (functional stubs): 4 critical client-facing routes — `dashboard/inbox`, `dashboard/leads`, `dashboard/replies`, `dashboard/activity`/`approval`
+
+**Critical Phase 1 gap:** unified inbox + replies + leads list — the surfaces a paying client uses to actually run their outreach — are stubs (12-21 lines each).
+
+**Asymmetry:** admin surface is disproportionately built (20 substantial routes) vs client dashboard (mix of substantial + stubs). Internal-tool-first build order.
+
+---
+
+## A2 — Onboarding Flow: PR #609 Spec vs Current Reality
+
+### What PR #609 spec mandates (`docs/specs/onboarding_email_provisioning.md`, 170 lines, Variant A locked)
+
+7 steps:
+1. Marketing site: "Send your first cold email within 24 hours"
+2. Signup form (<2 min): email, password, company name, ABN
+3. Email Setup Dashboard — domain provisioning (Primeforge mailbox)
+4. DNS verification — webhook-first SPF/DKIM/DMARC, polling fallback
+5. Mailbox provisioning — Primeforge pre-warmed (vendor-claimed, pending API verification)
+6. Self-test send to user's own email (gate before live prospect send)
+7. First campaign test post-gate
+
+Plus: free-trial 14d/45d/75d lifecycle, advanced settings toggle, transfer-on-churn.
+
+### What current frontend has
+
+10 pages, ~3,000 lines — agency-onboarding shape (CRM connect, LinkedIn account, service area, ICP, etc.)
+
+### Spec keyword search across current onboarding pages
+
+| Keyword | Files matching |
+|---|---|
+| `domain` | 0 |
+| `DNS` | 0 |
+| `SPF` | 0 |
+| `DKIM` | 0 |
+| `DMARC` | 0 |
+| `Primeforge` | 0 |
+| `mailbox provision` | 0 |
+| `self-test` | 0 |
+| `stripe` | 0 |
+
+**Zero overlap** between PR #609 email-provisioning spec and existing onboarding code.
+
+### Verdict
+
+The current 10-page onboarding flow is a DIFFERENT flow shape (agency profile collection) from the PR #609 email-provisioning spec. PR #609 was merged to `docs/specs/` but no parallel frontend work was done.
+
+If PR #609 ships as-specified, three options:
+- (a) Existing 10-page flow REPLACED by 7-step email-provisioning flow (loses ~3,000 lines of agency-config UX)
+- (b) PR #609 7-step ADDED as steps 6-12 of an extended onboarding (combined 17-step journey, very long)
+- (c) PR #609 spec REVISED to integrate domain/DNS/mailbox into existing 10-page flow
+
+This decision has not been made and is not currently in any task queue.
+
+---
+
+## A3 — Deprecated Code Inventory
+
+Counts per vendor per Dave's deprecation list. Search method: `grep -rli --include="*.py" "<vendor>" src/`. Case-insensitive.
+
+### Truly clean (0 references — fully removed)
+
+| Vendor | Count |
+|---|---|
+| Apollo | 0 |
+| Kaspr | 0 |
+| Proxycurl | 0 |
+| Webshare | 0 |
+| Lemlist | 0 |
+
+### References remaining
+
+#### Hunter — 4 files (within §3 EXCEPTION clause)
+- `src/orchestration/cohort_runner.py`
+- `src/pipeline/email_waterfall.py`
+- `src/intelligence/contact_waterfall.py`
+- `src/config/stage_parallelism.py`
+
+ARCHITECTURE.md §3 EXCEPTION: "Hunter email-finder active in Pipeline F v2.1 as L2 email fallback (score >= 70)." All 4 references appear consistent with the exception. Score-gate enforcement not directly verified.
+
+#### Apify — 2 files (within §3 EXCEPTION clause)
+- `src/intelligence/contact_waterfall.py`
+- `src/config/stage_parallelism.py`
+
+ARCHITECTURE.md §3 EXCEPTION: "Apify harvestapi/linkedin-profile-scraper active in Pipeline F v2.1 for L2 LinkedIn verification. Apify facebook-posts-scraper active for Stage 9 social." References appear consistent.
+
+#### Smartlead — 6 files (DEPRECATED, references NOT cleaned)
+- `src/integrations/smartlead_mcp.py`
+- `src/services/domain_pool_manager.py`
+- `src/services/email_events_service.py`
+- `src/api/routes/webhooks.py`
+- `src/config/email_costs.py`
+- `src/config/settings.py`
+
+Smartlead added to ARCHITECTURE.md §3 deprecated list in PR #603 (this session). 6 files still reference it. **Layer 7.X follow-up cleanup candidate** — same shape as Siege Waterfall PR #611 just-merged.
+
+#### Vapi — 15 files (AMBIGUOUS — needs Dave clarification)
+- `src/integrations/vapi.py` (21.8KB active)
+- `src/integrations/elevenlabs.py`, `src/integrations/__init__.py`
+- `src/engines/deprecated/voice_vapi.py` (already in deprecated/ subdir ✓)
+- `src/engines/voice_agent_telnyx.py`, `src/engines/sms.py`
+- `src/services/{phone_provisioning_service,voice_context_builder,voice_compliance_validator,recording_cleanup_service}.py`
+- `src/orchestration/tasks/outreach_tasks.py`
+- `src/orchestration/flows/{voice_flow,recording_cleanup_flow}.py`
+- `src/api/routes/webhooks.py`
+- `src/config/settings.py`
+
+Vapi is NOT listed in ARCHITECTURE.md §4 LIVE VENDORS (which lists ElevenAgents for Voice AI). One file is in `deprecated/`. The other 14 active references suggest:
+- (a) Vapi still in active use (not actually deprecated despite Dave's list), OR
+- (b) Genuinely deprecated and 14 files have stale references needing cleanup
+
+**Cannot determine from code-only audit. Needs Dave clarification.**
+
+### A3 totals
+
+| Vendor | Files | Verdict |
+|---|---|---|
+| Apollo | 0 | Clean |
+| Kaspr | 0 | Clean |
+| Proxycurl | 0 | Clean |
+| Webshare | 0 | Clean |
+| Lemlist | 0 | Clean |
+| Hunter | 4 | Consistent with §3 EXCEPTION |
+| Apify | 2 | Consistent with §3 EXCEPTION |
+| Smartlead | 6 | DEPRECATED — references not cleaned (Layer 7.X candidate) |
+| Vapi | 15 | AMBIGUOUS — needs Dave clarification on deprecation status |
+
+**Net cleanup work identified:** Smartlead (6 files), Vapi (potentially 14 files if confirmed deprecated). Total ~20 files of potential dead-reference cleanup.
+
+---
+
+## End of report

--- a/docs/audits/aiden/audit_verify_2026-05-08.md
+++ b/docs/audits/aiden/audit_verify_2026-05-08.md
@@ -1,0 +1,250 @@
+# audit_verify_aiden.md — V6 / V7 / V8 Trust Verification
+
+**To: Dave (CEO), via Max (COO)**
+**From: Aiden**
+**Compiled: 2026-05-07**
+**Method:** Primary-source verification only — raw terminal output, no interpretation, no estimates.
+
+---
+
+## ACKNOWLEDGEMENT OF PHASE 2 OVERSTATEMENT
+
+My Phase 2 audit said all 32 frontend routes WORK and all 20 admin routes WORK. That was a **file-existence claim, not a runs-with-real-data claim**. V6/V7/V8 below corrects the record against primary sources.
+
+**Single biggest correction:** of 20 admin pages, only **3** call backend APIs. The other 17 render hardcoded `mockXxx` const arrays inline — UI works, data is fake. My "WORKS" verdict was wrong by definition of working.
+
+---
+
+## V6 — Frontend deployed verification
+
+### Vercel deployment status (primary source: Vercel API via MCP)
+
+| Project | State | Domain | Framework | Region |
+|---|---|---|---|---|
+| frontend | READY (PROMOTED) | app.agencyxos.ai | Next.js | syd1 |
+| agencyxos-marketing | READY (PROMOTED) | agencyxos.ai | (none) | default |
+| admin-dashboard | READY (PROMOTED) | admin.agencyxos.ai | Next.js | default |
+
+Project IDs verified: prj_MJ5bRn9utnPHr21CnrIXOUEaBnt0 (frontend), prj_8HXmkBEefcksKAHks7RKTOYEDZtW (marketing), prj_DDWp9BLFSuDFlvP4zyPSgQJS6Flt (admin).
+
+### HTTP probes (raw curl, max-time 10s)
+
+```
+$ for url in https://app.agencyxos.ai https://agencyxos.ai https://admin.agencyxos.ai https://app.agencyxos.ai/signup https://app.agencyxos.ai/dashboard; do
+    code=$(curl -s -o /dev/null -w "%{http_code}" -L --max-time 10 "$url")
+    echo "$url -> HTTP $code"
+  done
+
+https://app.agencyxos.ai            -> HTTP 200
+https://agencyxos.ai                -> HTTP 200
+https://admin.agencyxos.ai          -> HTTP 200
+https://app.agencyxos.ai/signup     -> HTTP 200
+https://app.agencyxos.ai/dashboard  -> HTTP 200
+```
+
+### Auth gate verification
+
+```
+$ curl -sI -L --max-time 10 https://app.agencyxos.ai/dashboard | grep -E "HTTP|location:"
+HTTP/2 307
+location: /login?returnTo=%2Fdashboard
+HTTP/2 200
+```
+
+Unauthenticated `/dashboard` correctly redirects to `/login?returnTo=%2Fdashboard`. **Auth gate is enforced.**
+
+### Signup page rendering
+
+```
+$ curl -s -L --max-time 10 https://app.agencyxos.ai/signup | grep -oE '<title[^>]*>[^<]+</title>'
+<title>Agency OS - Automated Acquisition Engine</title>
+```
+
+The page **HTML responds 200 with title set**. However, the body contains:
+```
+<template data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"></template>
+```
+
+This means the form is rendered client-side via JS bundle. **Without a browser I cannot confirm the form inputs actually render or that submit succeeds.** I confirmed the JS chunk exists (`/_next/static/chunks/app/(auth)/signup/page-133bd6669795ea6f.js`) but I did not execute it.
+
+### Honest verdict
+
+| Check | Status | Evidence |
+|---|---|---|
+| Frontend deployed on Vercel | **VERIFIED** | 3 projects READY, syd1 region for app |
+| Public URLs respond 200 | **VERIFIED** | curl HTTP 200 on all 5 probed URLs |
+| Auth gate enforced | **VERIFIED** | /dashboard 307→/login when unauthed |
+| Signup page renders form | **UNVERIFIED — NO BROWSER** | HTML loads, form is CSR — I have no headless browser to confirm inputs render or submit succeeds |
+| Authed dashboard renders content | **UNVERIFIED — NO BROWSER + NO TEST ACCOUNT** | I do not have browser access AND I do not have a test login. Cannot prove the dashboard renders meaningful content rather than 500'ing post-auth |
+
+**You'll need to find another way for the two UNVERIFIED items** — a headless smoke test (Playwright) and a seeded test account would close them.
+
+---
+
+## V7 — Onboarding wiring (raw output)
+
+### Command 1: supabase imports in onboarding
+```
+$ grep -r "supabase" frontend/app/onboarding/ --include="*.tsx" --include="*.ts" -l
+(empty — 0 files)
+```
+
+**Onboarding pages do NOT import the Supabase client directly.** They write via backend API endpoints (correct pattern — frontend should not have service-role keys).
+
+### Command 2: fetch / api / mutation calls
+```
+$ grep -r "fetch\|api\|mutation" frontend/app/onboarding/ --include="*.tsx" --include="*.ts" -l
+frontend/app/onboarding/service-area/page.tsx
+frontend/app/onboarding/agency/page.tsx
+frontend/app/onboarding/crm/page.tsx
+frontend/app/onboarding/linkedin/page.tsx
+```
+
+### Endpoint detail (drill into the 4 wired pages)
+```
+--- crm/page.tsx ---
+25: const res = await fetch(`${API_BASE}/api/v1/crm/connect/hubspot`, { ... })
+
+--- agency/page.tsx ---
+78:  const res = await fetch(`${API_BASE}/api/v1/onboarding/status/${id}`, ...)
+86:  const res = await fetch(`${API_BASE}/api/v1/onboarding/result/${id}`, ...)
+137: const res = await fetch(`${API_BASE}/api/v1/onboarding/analyze`, ...)
+172: const res = await fetch(`${API_BASE}/api/v1/onboarding/confirm`, ...)
+
+--- service-area/page.tsx ---
+54: const res = await fetch(`${API_BASE}/api/v1/onboarding/confirm`, ...)
+74: void fetch(`${API_BASE}/api/v1/pipeline/trigger`, ...)
+
+--- linkedin/page.tsx ---
+25: const res = await fetch(`${API_BASE}/api/v1/linkedin/connect`, ...)
+```
+
+### V7 honest verdict
+
+| Question | Answer |
+|---|---|
+| Do onboarding pages call backends? | **YES — 4 pages call POST /api/v1/onboarding/{analyze,confirm,status,result} + /api/v1/{crm,linkedin}/connect + /api/v1/pipeline/trigger** |
+| Do they write to Supabase? | **NOT DIRECTLY — via FastAPI backend** (architecturally correct) |
+| Is the persistence loop verified end-to-end? | **UNVERIFIED — I confirmed the page issues a fetch, NOT that the backend handler exists, accepts the payload, and writes a row to Supabase.** Verifying that requires a backend smoke test against the analyze/confirm endpoints with a real signup account |
+
+**Caveat:** the spec I wrote in `docs/specs/onboarding_email_provisioning.md` (Variant A) describes a 7-step flow with **domain provisioning, DNS, mailbox, self-test send**. None of those steps exist in the 4 wired onboarding pages. Current onboarding is `agency → service-area → linkedin → crm`. The spec is design-stage; the live UI is a different (older) flow.
+
+---
+
+## V8 — Admin data sources (raw output)
+
+### Command (literal, as Dave specified)
+```
+$ grep -rn "mockData\|sampleData\|demoData\|seed\|placeholder\|TODO\|FIXME" frontend/app/admin/ --include="*.tsx" --include="*.ts" | head -30
+```
+
+Literal output: 23 hits — all matched on the substring `placeholder=` (the HTML attribute on `<Input>` and `<SelectValue>` components, e.g. `placeholder="Search leads..."`). These are **legitimate UI hints**, not mock data. Zero hits for `mockData`, `sampleData`, `demoData`, `seed`, `TODO`, or `FIXME`.
+
+### **BUT — Dave's grep missed the actual mock variables**
+
+The admin pages declare mock data with names like `mockCampaigns`, `mockReplies`, `mockUsers`, `mockSuppressionList` — none of which match `mockData|sampleData|demoData`. Broader grep:
+
+```
+$ grep -rnE "^const mock|// Mock data" frontend/app/admin/ --include="*.tsx" --include="*.ts"
+
+frontend/app/admin/campaigns/page.tsx:31:// Mock data
+frontend/app/admin/campaigns/page.tsx:32:const mockCampaigns = [
+frontend/app/admin/replies/page.tsx:46:// Mock data
+frontend/app/admin/replies/page.tsx:47:const mockReplies: Reply[] = [
+frontend/app/admin/leads/page.tsx:31:// Mock data
+frontend/app/admin/leads/page.tsx:32:const mockLeads = [
+frontend/app/admin/revenue/page.tsx:28:// Mock data
+frontend/app/admin/revenue/page.tsx:29:const mockRevenue = {
+frontend/app/admin/revenue/page.tsx:39:const mockTierBreakdown = [
+frontend/app/admin/revenue/page.tsx:45:const mockRecentTransactions = [
+frontend/app/admin/revenue/page.tsx:52:const mockUpcomingRenewals = [
+frontend/app/admin/revenue/page.tsx:58:const mockAtRisk = [
+frontend/app/admin/costs/page.tsx:15:// Mock data
+frontend/app/admin/costs/page.tsx:16:const mockCosts = {
+frontend/app/admin/costs/channels/page.tsx:23:// Mock data
+frontend/app/admin/costs/channels/page.tsx:24:const mockChannelCosts = {
+frontend/app/admin/system/page.tsx:31:// Mock data
+frontend/app/admin/system/page.tsx:32:const mockServices = [
+frontend/app/admin/system/page.tsx:40:const mockFlows = [
+frontend/app/admin/system/page.tsx:71:const mockErrors = [
+frontend/app/admin/system/page.tsx:92:const mockDbStats = {
+frontend/app/admin/system/page.tsx:103:const mockRateLimits = [
+frontend/app/admin/system/queues/page.tsx:48:// Mock data
+frontend/app/admin/system/queues/page.tsx:49:const mockFlows: Flow[] = [
+frontend/app/admin/system/queues/page.tsx:97:const mockQueueStats: QueueStats = {
+frontend/app/admin/system/rate-limits/page.tsx:43:// Mock data
+frontend/app/admin/system/rate-limits/page.tsx:44:const mockRateLimits: RateLimit[] = [
+frontend/app/admin/system/errors/page.tsx:42:// Mock data
+frontend/app/admin/system/errors/page.tsx:43:const mockErrors: ErrorEntry[] = [
+frontend/app/admin/compliance/page.tsx:23:// Mock data
+frontend/app/admin/compliance/page.tsx:24:const mockCompliance = {
+frontend/app/admin/compliance/bounces/page.tsx:48:// Mock data
+frontend/app/admin/compliance/bounces/page.tsx:49:const mockBounces: BounceEntry[] = [
+frontend/app/admin/compliance/suppression/page.tsx:42:// Mock data
+frontend/app/admin/compliance/suppression/page.tsx:43:const mockSuppressionList = [
+frontend/app/admin/clients/[id]/page.tsx:41:const mockClient = {
+frontend/app/admin/settings/users/page.tsx:51:// Mock data
+frontend/app/admin/settings/users/page.tsx:52:const mockUsers: User[] = [
+
+15 admin .tsx files contain top-level `const mock*` data declarations.
+```
+
+### Cross-check — admin pages that DO call backend
+```
+$ grep -rlE "fetch\(|useQuery|useSWR|/api/" frontend/app/admin/ --include="*.tsx" --include="*.ts"
+frontend/app/admin/page.tsx
+frontend/app/admin/activity/page.tsx
+frontend/app/admin/clients/page.tsx
+
+3 of 20 admin pages call backend APIs.
+```
+
+### V8 honest verdict
+
+| Page | Backend wiring | Data source |
+|---|---|---|
+| admin/ (overview)             | YES | live API |
+| admin/activity/                | YES | live API |
+| admin/clients/                 | YES | live API |
+| admin/clients/[id]/            | NO  | mockClient hardcoded |
+| admin/campaigns/               | NO  | mockCampaigns |
+| admin/replies/                 | NO  | mockReplies |
+| admin/leads/                   | NO  | mockLeads |
+| admin/revenue/                 | NO  | 5× mock arrays |
+| admin/costs/                   | NO  | mockCosts |
+| admin/costs/channels/          | NO  | mockChannelCosts |
+| admin/system/                  | NO  | 5× mock arrays |
+| admin/system/queues/           | NO  | mockFlows + mockQueueStats |
+| admin/system/rate-limits/      | NO  | mockRateLimits |
+| admin/system/errors/           | NO  | mockErrors |
+| admin/compliance/              | NO  | mockCompliance |
+| admin/compliance/bounces/      | NO  | mockBounces |
+| admin/compliance/suppression/  | NO  | mockSuppressionList |
+| admin/settings/users/          | NO  | mockUsers |
+| admin/settings/                | NO  | (no mock — static UI) |
+| admin/onboarding-progress/     | NO  | (no mock — static UI) |
+
+**3 of 20 admin pages are wired to real Supabase data via backend. 15 are rendering hardcoded mock arrays. 2 are static UI without data.**
+
+---
+
+## CORRECTIONS TO MY PHASE 2 AUDIT (audit_phase2_aiden.md)
+
+| Phase 2 claim | Reality after V6/V7/V8 |
+|---|---|
+| "32 frontend routes WORKS" | File-exists for 32. Auth gate works. Signup form rendering — UNVERIFIED (CSR, no browser). End-to-end signup flow — UNVERIFIED. |
+| "20 admin routes WORKS" | **3 of 20 actually fetch real data. 15 render mock const arrays.** WORKS verdict was a file-existence claim, not a renders-real-data claim. |
+| "10-page onboarding flow WORKS" | 4 of the live onboarding pages call backend endpoints. The 7-step Variant A spec (domain/DNS/mailbox/self-test) is design-stage, NOT in the live UI. |
+
+---
+
+## THE PRINCIPLE
+
+I conflated "file exists with reasonable code" with "feature works end-to-end". That's the same failure mode as the Supabase `subscription_recurring` table containing services nobody pays for — both are "self-reported by our own systems" rather than verified against the running outside world.
+
+For frontend going forward:
+- **Deployed status:** Vercel API + curl HTTP probe (this report)
+- **Renders real data:** grep `mock*` declarations + count `fetch(`/`useQuery` per page
+- **End-to-end:** headless browser (Playwright) + seeded test account — required to close UNVERIFIED items
+
+Any frontend route claim of WORKS in a future audit will require all three.


### PR DESCRIPTION
## Summary

Files three Aiden audit-round deliverables to `docs/audits/aiden/`. Symmetric with Elliot's PR #617 (`docs/audits/elliot/`).

Each file was originally compiled and submitted to Dave via Telegram on 2026-05-07/2026-05-08. This commit makes them durable in the repo.

## Files

| File | TG msg_id | Round |
|---|---|---|
| `audit_discovery_2026-05-07.md` | 11295 | Phase 1 — 9-section discovery audit |
| `audit_phase2_2026-05-07.md` | 11340 | Phase 2 — cross-reference findings (A1/A2/A3) |
| `audit_verify_2026-05-08.md` | 11372 | Trust verification — V6 frontend + V7 onboarding + V8 admin dashboard mock-data correction |

Naming convention matches Elliot's PR #617 (`audit_<round>_<YYYY-MM-DD>.md`).

## Test plan

- [x] No code changes — pure docs commit
- [x] Branched fresh off main (no scope-mix per memory pin)
- [x] Diff: 3 files / +723 / -0
- [ ] Reviewer confirms file paths + naming convention match Elliot's PR #617 pattern

Per Max directive 2026-05-08 ("D approved — file Aiden audit deliverables, same pattern as Elliot's C").

🤖 Generated with [Claude Code](https://claude.com/claude-code)