### PR TITLE
[ELLIOT] fix(lint): ruff format debt from PR #613 currency refactor

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -125,9 +125,7 @@ class Settings(BaseSettings):
     # stored in the vendor's billing currency (USD). This single SSOT converts
     # to AUD at runtime for LAW II compliance ("All financial outputs in $AUD").
     # Update this value when AUD/USD shifts materially.
-    aud_per_usd: float = Field(
-        default=1.55, description="AUD per USD exchange rate (LAW II SSOT)"
-    )
+    aud_per_usd: float = Field(default=1.55, description="AUD per USD exchange rate (LAW II SSOT)")
 
     # === API Keys ===
     anthropic_api_key: str = Field(default="", description="Anthropic/Claude API key")

--- a/src/integrations/dfs_serp_client.py
+++ b/src/integrations/dfs_serp_client.py
@@ -36,6 +36,7 @@ def _cost_per_serp_aud() -> Decimal:
 
     return COST_PER_SERP_USD * Decimal(str(settings.aud_per_usd))
 
+
 DFS_SERP_LOCATION_AU = 2036
 DFS_LINKEDIN_IN_PATTERN = "linkedin.com/in/"
 

--- a/src/integrations/leadmagic.py
+++ b/src/integrations/leadmagic.py
@@ -83,6 +83,7 @@ def _cost_aud(usd: float) -> float:
 
     return usd * settings.aud_per_usd
 
+
 # Rate limiting
 MAX_REQUESTS_PER_SECOND = 10
 REQUEST_DELAY_SECONDS = 1.0  # 1 second between requests

--- a/src/orchestration/flows/infra_provisioning_flow.py
+++ b/src/orchestration/flows/infra_provisioning_flow.py
@@ -58,6 +58,7 @@ def _domain_cost_per_year_aud() -> float:
 def _domain_cost_per_month_aud() -> float:
     return _domain_cost_per_year_aud() / 12
 
+
 # Default configuration
 DEFAULT_MAILBOXES_PER_DOMAIN = 2
 DEFAULT_DOMAINS_COUNT = 10


### PR DESCRIPTION
## Summary

PR #619 (Aiden Playwright scaffold) CI revealed Backend Lint (Ruff format) failing on main with 4 files needing reformat. These are the files from my PR #613 currency refactor — lint debt I left when pre-commit ruff hook didn't fire in my session.

## Root cause

`scripts/write_manual_mirror.py` flagged earlier today: `core.hooksPath = .git/hooks (not .githooks)`. The same hooksPath misconfiguration likely caused the ruff pre-commit hook to silently no-op when I committed PR #613.

## Fix

```
$ ruff format src/<4 files>
4 files reformatted
$ ruff format src/ --check
458 files already formatted
```

Pure formatting, no semantic change. Diff:
- `src/config/settings.py` — minor whitespace
- `src/integrations/dfs_serp_client.py` — minor whitespace
- `src/integrations/leadmagic.py` — minor whitespace
- `src/orchestration/flows/infra_provisioning_flow.py` — minor whitespace

4 files / +4 / -3.

## Why this exists

Aiden's PR #619 inherited the failure when his branch forked from main. Aiden's PR is innocent — failure is mine. This fix lands on main, then PR #619's Backend Lint check should pass on its next CI run (Aiden may need to push a no-op commit or rebase).

## Test plan

- [x] `ruff format src/ --check` returns "458 files already formatted"
- [x] No semantic changes (whitespace + import-order only)
- [x] Pytest baseline unaffected
- [x] Single-bot approval applies (lint fix, non-architecture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)