### PR TITLE
[ELLIOT] fix: PR #613 test regression — bright_data_client COSTS_USD rename

### DIFF
--- a/tests/integrations/test_bright_data_client.py
+++ b/tests/integrations/test_bright_data_client.py
@@ -37,14 +37,14 @@ class TestCosts:
     """Verify cost constants match the SSOT"""
 
     def test_serp_cost(self):
-        from integrations.bright_data_client import COSTS_AUD
+        from integrations.bright_data_client import COSTS_USD
 
-        assert COSTS_AUD["serp_request"] == 0.0015
+        assert COSTS_USD["serp_request"] == 0.0015
 
     def test_scraper_cost(self):
-        from integrations.bright_data_client import COSTS_AUD
+        from integrations.bright_data_client import COSTS_USD
 
-        assert COSTS_AUD["scraper_record"] == 0.0015
+        assert COSTS_USD["scraper_record"] == 0.0015
 
 
 class TestBrightDataClientInit:
@@ -91,7 +91,7 @@ class TestCostTracking:
         assert "total_aud" in breakdown
 
     def test_cost_calculation(self):
-        from integrations.bright_data_client import COSTS_AUD, BrightDataClient
+        from integrations.bright_data_client import BrightDataClient, _cost_aud
 
         client = BrightDataClient(api_key="test-key")
 
@@ -99,7 +99,8 @@ class TestCostTracking:
         client.costs.serp_requests = 10
         client.costs.scraper_records = 5
 
-        expected = (10 * COSTS_AUD["serp_request"]) + (5 * COSTS_AUD["scraper_record"])
+        # _cost_aud() converts USD → AUD via settings.aud_per_usd (LAW II SSOT).
+        expected = _cost_aud("serp_request", count=10) + _cost_aud("scraper_record", count=5)
         assert client.get_total_cost() == expected
 
 


### PR DESCRIPTION
## Summary

Per Max directive 2026-05-08 + Aiden's PR #621 Cluster 3 finding: 3 failures in `tests/integrations/test_bright_data_client.py` from PR #613 currency refactor that I missed.

## Root cause

PR #613's grep covered `src/` but not `tests/`. Test file imported `COSTS_AUD` which got renamed to `COSTS_USD`. Same "narrow grep misses adjacent structure" pattern as today's earlier session.

## Fix

| Line | Change |
|---|---|
| L40 | `import COSTS_AUD` → `import COSTS_USD` (rename) |
| L45 | same |
| L94 | `import COSTS_AUD, BrightDataClient` → `import BrightDataClient, _cost_aud` (use helper) |
| L102 | `(10 * COSTS_AUD["serp_request"]) + (5 * COSTS_AUD["scraper_record"])` → `_cost_aud("serp_request", count=10) + _cost_aud("scraper_record", count=5)` |

L102 needs the helper, not just rename — `client.get_total_cost()` post-PR-613 returns AUD via `_cost_aud()` (USD × settings.aud_per_usd). Pure rename would assert USD-on-LHS vs AUD-on-RHS and still fail.

## Verification

```
$ pytest tests/integrations/test_bright_data_client.py -k "serp_cost or scraper_cost or cost_calculation"
3 passed, 15 deselected in 0.79s

$ grep -rnE "from integrations.bright_data_client import COSTS_AUD" tests/
(0 hits — clean)
```

## Diff

1 file, +7, -6.

## Out-of-scope nit

`ruff format src/ tests/ --check` flags 7 OTHER pre-existing test files needing reformat (not from PR #613, not from this fix). Separate cleanup PR can address.

## Test plan

- [x] 3 affected tests pass
- [x] Negative grep clean on `tests/` for old COSTS_AUD import
- [x] Single-bot approval (lint fix, non-architecture)
- [x] Branch off latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)