### PR TITLE
[ELLIOT] fix: PR #613 follow-on — waterfall_verification_worker COSTS_USD rename

### DIFF
--- a/src/engines/waterfall_verification_worker.py
+++ b/src/engines/waterfall_verification_worker.py
@@ -76,8 +76,11 @@ class MatchConfidence(StrEnum):
     NO_MATCH = "no_match"  # Below threshold or no GMB result
 
 
-# Cost per operation in AUD (2026 pricing)
-COSTS_AUD = {
+# Vendor pricing in USD (Bright Data, Leadmagic, DataForSEO, ZeroBounce all
+# bill in USD per their public pricing pages). AUD conversion happens at
+# runtime via _cost_aud() using settings.aud_per_usd (LAW II SSOT). Do NOT
+# pre-multiply by 1.55 here — see _cost_aud() helper.
+COSTS_USD = {
     VerificationTier.ABN_SEED: Decimal("0.00"),  # Free (data.gov.au)
     VerificationTier.ASIC_VERIFY: Decimal("0.00"),  # Free (ABR SearchByASIC) - CEO Directive #039
     VerificationTier.GMB_SCRAPER: Decimal("0.0062"),  # GMB scraper (Bright Data)
@@ -93,6 +96,14 @@ COSTS_AUD = {
         "0.0030"
     ),  # Bright Data X Posts ($0.0015) + X handle discovery ($0.0015)
 }
+
+
+def _cost_aud(tier: "VerificationTier") -> Decimal:
+    """Return AUD-converted cost for a verification tier (LAW II)."""
+    from src.config.settings import settings
+
+    return COSTS_USD[tier] * Decimal(str(settings.aud_per_usd))
+
 
 # Bright Data Dataset IDs for T-DM2 and T-DM3
 BRIGHTDATA_LINKEDIN_POSTS_DATASET = "gd_lyy3tktm25m4avu764"
@@ -428,7 +439,7 @@ class WaterfallVerificationWorker(BaseEngine):
                 step_number=step_number,
                 step_type="source",
                 source_name=VerificationTier.ABN_SEED.value,
-                cost_aud=COSTS_AUD[VerificationTier.ABN_SEED],
+                cost_aud=_cost_aud(VerificationTier.ABN_SEED),
                 success=abn_result is not None,
                 data_added=["abn", "legal_name", "entity_type"] if abn_result else [],
                 latency_ms=latency_ms,
@@ -463,7 +474,7 @@ class WaterfallVerificationWorker(BaseEngine):
                     step_number=step_number,
                     step_type="verification",
                     source_name=VerificationTier.ASIC_VERIFY.value,
-                    cost_aud=COSTS_AUD[VerificationTier.ASIC_VERIFY],
+                    cost_aud=_cost_aud(VerificationTier.ASIC_VERIFY),
                     success=asic_success,
                     data_added=["registered_name", "acn"] if asic_success else [],
                     latency_ms=latency_ms,
@@ -549,7 +560,7 @@ class WaterfallVerificationWorker(BaseEngine):
                     step_number=step_number,
                     step_type="enrichment",
                     source_name=VerificationTier.DM2_LINKEDIN_POSTS.value,
-                    cost_aud=COSTS_AUD[VerificationTier.DM2_LINKEDIN_POSTS],
+                    cost_aud=_cost_aud(VerificationTier.DM2_LINKEDIN_POSTS),
                     success=dm2_success,
                     data_added=["dm_linkedin_posts"] if dm2_success else [],
                     latency_ms=latency_ms,
@@ -595,7 +606,7 @@ class WaterfallVerificationWorker(BaseEngine):
                     step_number=step_number,
                     step_type="enrichment",
                     source_name=VerificationTier.DM3_X_POSTS.value,
-                    cost_aud=COSTS_AUD[VerificationTier.DM3_X_POSTS],
+                    cost_aud=_cost_aud(VerificationTier.DM3_X_POSTS),
                     success=dm3_success,
                     data_added=["dm_x_handle", "dm_x_posts"]
                     if dm3_success
@@ -678,7 +689,7 @@ class WaterfallVerificationWorker(BaseEngine):
                 step_number=step_number,
                 step_type="enrichment",
                 source_name=VerificationTier.GMB_SCRAPER.value,
-                cost_aud=COSTS_AUD[VerificationTier.GMB_SCRAPER],
+                cost_aud=_cost_aud(VerificationTier.GMB_SCRAPER),
                 success=gmb_success,
                 data_added=data_added,
                 error_message=errors[-1] if not gmb_success else None,
@@ -747,7 +758,7 @@ class WaterfallVerificationWorker(BaseEngine):
                             step_number=step_number,
                             step_type="verification",
                             source_name=VerificationTier.ZEROBOUNCE.value,
-                            cost_aud=COSTS_AUD[VerificationTier.ZEROBOUNCE],
+                            cost_aud=_cost_aud(VerificationTier.ZEROBOUNCE),
                             success=zb_success,
                             data_added=["email_verified"] if zb_success else [],
                             error_message=errors[-1] if not zb_success else None,
@@ -762,7 +773,7 @@ class WaterfallVerificationWorker(BaseEngine):
                     step_number=step_number if not needs_escalation else step_number - 1,
                     step_type="verification",
                     source_name=VerificationTier.LEADMAGIC_EMAIL.value,
-                    cost_aud=COSTS_AUD[VerificationTier.LEADMAGIC_EMAIL],
+                    cost_aud=_cost_aud(VerificationTier.LEADMAGIC_EMAIL),
                     success=leadmagic_success,
                     data_added=data_added,
                     error_message=None if leadmagic_success else errors[-1],

--- a/tests/e2e/test_directive_041_integration.py
+++ b/tests/e2e/test_directive_041_integration.py
@@ -172,8 +172,11 @@ async def run_waterfall_on_lead(lead: dict) -> IntegrationTestResult:
     """
     from decimal import Decimal
 
-    # Cost constants from waterfall_verification_worker.py
-    COSTS_AUD = {
+    # Vendor pricing in USD (mirrors waterfall_verification_worker.py COSTS_USD).
+    # AUD conversion via settings.aud_per_usd at accumulation time (LAW II SSOT).
+    from src.config.settings import settings as _settings
+
+    COSTS_USD = {
         "abn_seed": Decimal("0.00"),
         "asic_verify": Decimal("0.00"),
         "gmb_scraper": Decimal("0.0062"),
@@ -184,6 +187,10 @@ async def run_waterfall_on_lead(lead: dict) -> IntegrationTestResult:
         "dm3_x_posts": Decimal("0.0030"),
     }
 
+    def _cost_aud(key: str) -> Decimal:
+        """Convert USD vendor cost to AUD via settings SSOT (LAW II)."""
+        return COSTS_USD[key] * Decimal(str(_settings.aud_per_usd))
+
     result = IntegrationTestResult(lead)
 
     try:
@@ -193,23 +200,23 @@ async def run_waterfall_on_lead(lead: dict) -> IntegrationTestResult:
 
         # Simulate T1: ABN Seed
         result.tiers_hit.append("T1_ABN_SEED")
-        result.total_cost_aud += COSTS_AUD["abn_seed"]
+        result.total_cost_aud += _cost_aud("abn_seed")
 
         # Simulate T1.25: ASIC Verify
         result.tiers_hit.append("T1.25_ASIC_VERIFY")
-        result.total_cost_aud += COSTS_AUD["asic_verify"]
+        result.total_cost_aud += _cost_aud("asic_verify")
 
         # Simulate T2: GMB Scraper
         result.tiers_hit.append("T2_GMB_SCRAPER")
-        result.total_cost_aud += COSTS_AUD["gmb_scraper"]
+        result.total_cost_aud += _cost_aud("gmb_scraper")
 
         # Simulate T3: Hunter.io
         result.tiers_hit.append("T3_HUNTER_IO")
-        result.total_cost_aud += COSTS_AUD["hunter_io"]
+        result.total_cost_aud += _cost_aud("hunter_io")
 
         # T-DM0: LinkedIn Discovery (always runs)
         result.tiers_hit.append("T_DM0_LINKEDIN_DISCOVERY")
-        result.total_cost_aud += COSTS_AUD["dm0_linkedin_discovery"]
+        result.total_cost_aud += _cost_aud("dm0_linkedin_discovery")
 
         # Check ALS threshold for social intelligence
         if lead["propensity_score"] >= 70:
@@ -222,7 +229,7 @@ async def run_waterfall_on_lead(lead: dict) -> IntegrationTestResult:
             # posts = await worker._tier_dm2_linkedin_posts(dm_linkedin_url)
             # For now, we mark it as hit and add cost
             result.tiers_hit.append("T_DM2_LINKEDIN_POSTS")
-            result.total_cost_aud += COSTS_AUD["dm2_linkedin_posts"]
+            result.total_cost_aud += _cost_aud("dm2_linkedin_posts")
 
             # T-DM3: X Posts
             logger.info(
@@ -233,7 +240,7 @@ async def run_waterfall_on_lead(lead: dict) -> IntegrationTestResult:
             # x_handle = await worker._discover_x_handle(website, dm_name, registered_name)
             # posts = await worker._tier_dm3_x_posts(x_handle)
             result.tiers_hit.append("T_DM3_X_POSTS")
-            result.total_cost_aud += COSTS_AUD["dm3_x_posts"]
+            result.total_cost_aud += _cost_aud("dm3_x_posts")
         else:
             # Below ALS threshold
             result.tiers_skipped.append("T_DM2_LINKEDIN_POSTS")


### PR DESCRIPTION
## Summary

Per Max directive 2026-05-08: fix `src/engines/waterfall_verification_worker.py:80` `COSTS_AUD` dict (USD values labeled AUD — same PR #613 bug pattern as BD + Leadmagic, separate definition). Found by Aiden in PR #622 review.

## Scope

| File | Change |
|---|---|
| `src/engines/waterfall_verification_worker.py` | Rename `COSTS_AUD` → `COSTS_USD`, add `_cost_aud(tier)` helper, update 7 ref sites |
| `tests/e2e/test_directive_041_integration.py` | Rename mirror dict to `COSTS_USD`, add local `_cost_aud` helper, update 7 accumulation sites |

2 files / +36 / -18.

## Refactor pattern (consistent with PR #613)

```python
# Vendor pricing in USD (Bright Data, Leadmagic, DataForSEO bill in USD).
# AUD conversion via settings.aud_per_usd (LAW II SSOT). Do NOT pre-multiply.
COSTS_USD = { VerificationTier.X: Decimal("0.0015"), ... }


def _cost_aud(tier: "VerificationTier") -> Decimal:
    from src.config.settings import settings
    return COSTS_USD[tier] * Decimal(str(settings.aud_per_usd))
```

7 ref sites updated: `cost_aud=COSTS_AUD[X]` → `cost_aud=_cost_aud(X)`.

## Test mirror update

`tests/e2e/test_directive_041_integration.py:176` had a LOCAL mirror dict (USD values labeled AUD). Same fix shape — renamed to `COSTS_USD`, added local helper that uses `settings.aud_per_usd`. Result: `total_cost_aud` accumulator now reflects real AUD (was USD-as-AUD).

## Verification

```
$ grep -rnE "from .*waterfall_verification_worker import COSTS_AUD" src/ tests/
(0 hits — clean)

$ pytest --collect-only -q | tail -1
3489/3493 tests collected (4 deselected) in 13.77s   ← baseline holds

$ ruff format src/engines/waterfall_verification_worker.py tests/e2e/test_directive_041_integration.py --check
2 files already formatted
```

## Out-of-scope

**Pre-existing dataclass import error at L281** (`WaterfallResult` has `non-default argument 'verification_method' follows default argument`). Verified on main with `git stash + checkout main` — same error. NOT introduced by this PR.

**Voice agent Telnyx (deferred per Max + Aiden alignment):** `src/engines/voice_agent_telnyx.py:92` has pre-multiplied AUD values using ad-hoc 1.5x rate. Different antipattern from USD-as-AUD bug — requires per-key vendor-pricing-page reconciliation. Separate PR.

**Pre-existing ruff format debt** in 7 other test files (not from PR #613 / #622 / #623). Separate cleanup PR.

## Test plan

- [x] Negative grep clean (no COSTS_AUD imports/references in production code or tests for waterfall_verification_worker)
- [x] Pytest collection unchanged (3489/3493)
- [x] Ruff format clean on modified files
- [x] Single-bot approval (lint-shape fix, non-architecture)
- [x] Aiden review per LAW XV-C governance — though this is non-arch, bundling with PR #613/#622 follow-on for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)