### PR TITLE
[ELLIOT] fix(M3): founding-spots fallback 17 → 20 (no customers, no taken spots)

### DIFF
--- a/frontend/components/marketing/founding-spots.tsx
+++ b/frontend/components/marketing/founding-spots.tsx
@@ -33,12 +33,13 @@ export function FoundingSpots({
           const data = await response.json();
           setRemaining(data.spots_remaining);
         } else {
-          // Fallback if API not available
-          setRemaining(17);
+          // Fallback if API not available — must be truthful (zero customers,
+          // so all 20 spots are available). Was previously 17 (implying 3 taken).
+          setRemaining(20);
         }
       } catch {
-        // Fallback to static number if fetch fails
-        setRemaining(17);
+        // Fallback to static number if fetch fails — see note above.
+        setRemaining(20);
         setError(true);
       }
       setLoading(false);
@@ -130,10 +131,11 @@ export function useFoundingSpots() {
           setRemaining(data.spots_remaining);
           setTotalSpots(data.total_spots);
         } else {
-          setRemaining(17);
+          // Truthful fallback — zero customers, all 20 spots available.
+          setRemaining(20);
         }
       } catch {
-        setRemaining(17);
+        setRemaining(20);
       }
       setLoading(false);
     }


### PR DESCRIPTION
## Summary

Per Max's M3 directive 2026-05-08 + Dave's PHASE_1_KICKOFF #6: landing page false-claim cleanup. Components/marketing/founding-spots.tsx had 4 hardcoded fallbacks of `setRemaining(17)` (implying 3 taken), which is false — backend confirms 0 clients with `deposit_paid=true`, so spots_remaining = 20 - 0 = 20.

## Sites updated (4 in 1 file)

| Line | Before | After |
|---|---|---|
| L37 | `setRemaining(17)` (variant-render fallback) | `setRemaining(20)` |
| L41 | `setRemaining(17)` (variant-render exception) | `setRemaining(20)` |
| L133 | `setRemaining(17)` (useFoundingSpots hook fallback) | `setRemaining(20)` |
| L136 | `setRemaining(17)` (useFoundingSpots hook exception) | `setRemaining(20)` |

## Other 5 files Max flagged — verified honest already

- `HeroSection.tsx` + `agency-os-hero.tsx` — already "20 founding spots available" per PR #612 (verified clean today)
- `app/page.tsx` L679 — uses `${spotsRemaining ?? "..."}` interpolation, no hardcoded value (honest pass-through)
- `PricingClient.tsx` L247 + L298 — refers to "20 founding spots" total offer (truthful, NOT a "X taken" claim)
- `api/waitlist/route.ts` L126 — "one of 20 founding spots" (truthful total-offer language)

## Backend endpoint already correct

`src/api/routes/billing.py:472` returns `spots_remaining = total_spots - spots_taken` (20 - 0 = 20).

Verified Supabase state:
```sql
SELECT COUNT(*) FROM clients WHERE deposit_paid=true AND deleted_at IS NULL → 0
```

Net: only the React component fallback was lying.

## Diff

1 file, +8, -6 (4 value changes + 2 explanatory comments).

## Test plan

- [x] All 4 setRemaining(17) sites changed to setRemaining(20)
- [x] Negative grep across all 6 files Max flagged: 0 hits on "17 of 20|17 founding|setRemaining(17)"
- [x] Backend endpoint verified — returns 20 with current 0-customer state
- [x] Single-bot approval (credibility fix, non-architecture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)