### PR TITLE
[AIDEN] fix(A3 cluster 2): restore ScoutEngine.siege_waterfall — 15 errors → 16 passed

### DIFF
--- a/src/engines/scout.py
+++ b/src/engines/scout.py
@@ -124,20 +124,36 @@ class ScoutEngine(BaseEngine):
 
     def __init__(
         self,
+        siege_waterfall: Any = None,
         camoufox_scraper: CamoufoxScraper | None = None,
     ):
         """
         Initialize Scout engine with integration clients.
 
         Args:
+            siege_waterfall: Optional WaterfallV2 instance (lazy init if not provided).
+                Kept named `siege_waterfall` for backward compatibility — the
+                underlying impl is `src/pipeline/waterfall_v2.py` (renamed from
+                siege_waterfall.py in PR-A #593). Tests + body still reference
+                `self.siege_waterfall` to avoid a 10+ call-site rename.
             camoufox_scraper: Optional CamoufoxScraper for LinkedIn (lazy init if not provided)
         """
+        self._siege_waterfall = siege_waterfall
         self._camoufox = camoufox_scraper
         self.leadmagic = get_leadmagic_client()
 
     @property
     def name(self) -> str:
         return "scout"
+
+    @property
+    def siege_waterfall(self) -> Any:
+        """Get or create WaterfallV2 instance (lazy init)."""
+        if self._siege_waterfall is None:
+            from src.pipeline.waterfall_v2 import WaterfallV2
+
+            self._siege_waterfall = WaterfallV2()
+        return self._siege_waterfall
 
     @property
     def camoufox(self) -> CamoufoxScraper:


### PR DESCRIPTION
## Summary

Phase 1 task **A3 cluster 2** from `docs/audits/aiden/test_triage_2026-05-08.md` (PR #621). Scout engine had a structural bug since PR-A #593 reorg: code body references `self.siege_waterfall.enrich_lead(...)` at 10+ call sites but the `__init__` was reduced to only accept `camoufox_scraper=`.

## Root cause

PR-A #593 renamed `src/integrations/siege_waterfall.py` → `src/pipeline/waterfall_v2.py` and refactored ScoutEngine's constructor to drop the `siege_waterfall=` parameter. But the rename didn't follow through to the body — every `self.siege_waterfall.enrich_lead(...)` call site was left intact. Any runtime invocation of `enrich_lead()` would raise `AttributeError`.

Tests caught it as 15 collection errors:
```
TypeError: ScoutEngine.__init__() got an unexpected keyword argument 'siege_waterfall'
```

## Fix

Restore the `siege_waterfall` constructor parameter + lazy-init property (mirrors existing `camoufox_scraper` lazy pattern). The named alias is kept for backward compatibility to avoid a 10+ call-site rename:

```python
def __init__(
    self,
    siege_waterfall: Any = None,
    camoufox_scraper: CamoufoxScraper | None = None,
):
    self._siege_waterfall = siege_waterfall
    ...

@property
def siege_waterfall(self) -> Any:
    """Get or create WaterfallV2 instance (lazy init)."""
    if self._siege_waterfall is None:
        from src.pipeline.waterfall_v2 import WaterfallV2
        self._siege_waterfall = WaterfallV2()
    return self._siege_waterfall
```

## Verbatim post-fix

```
$ python3 -m pytest tests/test_engines/test_scout.py --tb=short --no-header
======================= 16 passed, 4 warnings in 13.03s ========================

$ python3 -m pytest --collect-only -q
3489/3493 tests collected (4 deselected) in 15.90s

$ ruff format src/engines/scout.py --check
1 file already formatted

$ ruff check src/engines/scout.py
All checks passed!
```

## Phase 1 A3 progress

- **15 of 16 collection errors** closed (Scout cluster — single root cause unblocked entire module)
- Remaining after merge: **28 failures + 1 error** (DNCR cluster 13 + Siege test rename 1 + Misc 4 + CIS 2 + Rescore 3 + Free enrichment 1 + Closer 1 + Campaign executor 1 + Directive 196 1 + 1 Siege error)
- Next cluster: DNCR client signature (13 fails, 1 root cause)

## Test plan

- [x] All 16 scout tests pass post-fix
- [x] Pytest collection baseline holds (3489/3493)
- [x] Ruff format + check clean
- [x] Branched fresh off main (no scope-mix per memory pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)