### PR TITLE
[AIDEN] fix(A3 cluster 1): DNCR test imports — 13 fails → 13 passes

### DIFF
--- a/tests/integrations/test_dncr_client.py
+++ b/tests/integrations/test_dncr_client.py
@@ -6,16 +6,15 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
 
 import httpx
-import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
 
-from src.integrations.dncr import DNCRClient, DNCRResult
-
+from src.integrations.dncr import DNCRResult
+from src.integrations.dncr import SyncDNCRClient as DNCRClient
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -40,7 +39,7 @@ def _mock_response(
     return mock_client
 
 
-_BASE_TIME = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+_BASE_TIME = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
 
 
 def _fixed_now(t: datetime = _BASE_TIME):
@@ -60,7 +59,7 @@ class TestHappyPathRegistered:
         client = DNCRClient(api_key="test-key", http_client=mock_http, now_fn=_fixed_now())
         result = client.lookup("+61400000000")
         assert result.registered is True
-        assert result.registered_at == datetime(2025, 1, 1, tzinfo=timezone.utc)
+        assert result.registered_at == datetime(2025, 1, 1, tzinfo=UTC)
         assert result.status == "ok"
 
 


### PR DESCRIPTION
## Summary

Phase 1 task **A3 cluster 1** from `docs/audits/aiden/test_triage_2026-05-08.md` (PR #621). DNCR test failures had a single root cause.

## Root cause

`src/integrations/dncr.py` has TWO classes:

| Class | Line | Signature |
|---|---|---|
| `SyncDNCRClient` | 63 | `(api_key, base_url, timeout, cache_ttl_hours, http_client, now_fn)` ← matches tests |
| `DNCRClient` | 161 | `(api_key, api_url, account_id)` ← async production client |

Tests at `tests/integrations/test_dncr_client.py` were written against `SyncDNCRClient`'s signature (passes `http_client=` mock + `now_fn=` for time control + `cache_ttl_hours=`) but imported `DNCRClient`. Tests also use `.lookup(phone)` which only exists on `SyncDNCRClient`.

Result: 13 tests failed with `TypeError: DNCRClient.__init__() got an unexpected keyword argument 'http_client'`.

## Fix

Alias the import:

```python
-from src.integrations.dncr import DNCRClient, DNCRResult
+from src.integrations.dncr import DNCRResult
+from src.integrations.dncr import SyncDNCRClient as DNCRClient
```

Plus ruff F401 auto-fix on 7 unused imports in the same file (per Dave's "non-blockers are blockers" rule — caught by ruff while running pre-commit checks).

## Verbatim post-fix

```
$ python3 -m pytest tests/integrations/test_dncr_client.py
============================== 13 passed in 0.62s ==============================

$ python3 -m pytest --collect-only -q
3489/3493 tests collected (4 deselected) in 14.06s

$ ruff check tests/integrations/test_dncr_client.py
All checks passed!
```

## Phase 1 A3 progress

| Cluster | Count | Status |
|---|---|---|
| 2: Scout import (errors) | 15 | CLOSED in PR #628 |
| 1: DNCR signature (fails) | 13 | CLOSED in this PR |
| 3: BD test imports (fails) | 3 | CLOSED in PR #622 |
| 4: Siege references | 3 fails + 1 error | OPEN |
| 5: Misc one-offs | 4 | OPEN |
| 6: CIS prompts | 2 | OPEN |
| 7: Rescore engine | 3 | OPEN |

Total closed: **31** (15 errors + 13 fails + 3 fails). Remaining: **12 fails + 1 error** (down from 28 fails + 16 errors at the start of A3).

## Test plan

- [x] All 13 DNCR tests pass post-fix
- [x] Pytest collection baseline holds (3489/3493)
- [x] Ruff F401 cleanup applied + checks pass
- [x] Branched fresh off main (no scope-mix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)