### PR TITLE
[ELLIOT] feat(E1 R1): sdk_usage_log instrumentation for Anthropic calls

### DIFF
--- a/scripts/insert_system_pipeline_client.sql
+++ b/scripts/insert_system_pipeline_client.sql
@@ -1,0 +1,36 @@
+-- scripts/insert_system_pipeline_client.sql
+--
+-- E1 cost instrumentation prerequisite (per PHASE_1_KICKOFF 2026-05-08).
+--
+-- Inserts the SystemPipelineClient sentinel row that pipeline cost-logging
+-- (`src/pipeline/intelligence.py:_log_anthropic_call_to_sdk_usage`) writes
+-- against. Required because `sdk_usage_log.client_id` is NOT NULL with a
+-- FK constraint to `clients.id`, but pipeline runs against business_universe
+-- domains (pre-customer) — no natural client_id at AI call sites.
+--
+-- IDEMPOTENT: ON CONFLICT DO NOTHING. Safe to re-run.
+--
+-- CASCADE FOOTGUN: sdk_usage_log.client_id FK is ON DELETE CASCADE. If
+-- anyone DELETEs this row, every sdk_usage_log row referencing it goes
+-- too. Helper has a pre-write existence guard that refuses to write if
+-- this row is missing rather than 500 on FK violation. Operationally:
+-- never delete this row unless you're truncating sdk_usage_log first.
+--
+-- Run once before any pipeline AI call:
+--   psql $DATABASE_URL -f scripts/insert_system_pipeline_client.sql
+--
+-- Or via supabase MCP execute_sql tool with the body below.
+
+INSERT INTO public.clients (id, name, deposit_paid, created_at, updated_at)
+VALUES (
+    '00000000-0000-0000-0000-000000000001'::uuid,
+    'SystemPipelineClient (E1 sentinel)',
+    false,
+    NOW(),
+    NOW()
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Verify insert landed (or pre-existed):
+SELECT id, name, created_at FROM public.clients
+WHERE id = '00000000-0000-0000-0000-000000000001'::uuid;

--- a/src/pipeline/intelligence.py
+++ b/src/pipeline/intelligence.py
@@ -52,15 +52,25 @@ SYSTEM_PIPELINE_CLIENT_ID = UUID("00000000-0000-0000-0000-000000000001")
 # Per-token Anthropic pricing in USD per their public pricing page.
 # AUD conversion derived at runtime via settings.aud_per_usd (LAW II SSOT).
 # Source of truth (USD): https://www.anthropic.com/api/pricing as of 2026-05-08.
+#
+# Includes both DATED full IDs (the response model_id Anthropic returns) AND
+# UNDATED aliases (what callsites in this module pass as `model=` — see
+# _MODEL_SONNET / _MODEL_HAIKU below). Without the alias keys, the pricing
+# lookup misses every real call and the helper warn-and-skips silently —
+# captured by Aiden review on PR #630.
+_HAIKU_PRICE = {"input": 0.80 / 1_000_000, "output": 4.00 / 1_000_000}
+_SONNET_PRICE = {"input": 3.00 / 1_000_000, "output": 15.00 / 1_000_000}
 ANTHROPIC_PRICING_USD = {
     # Claude 3.5 Haiku (legacy): $0.80 / $4.00 per 1M tokens
-    "claude-3-5-haiku-20241022": {"input": 0.80 / 1_000_000, "output": 4.00 / 1_000_000},
-    # Claude Haiku 4.5: $0.80 / $4.00 per 1M tokens
-    "claude-haiku-4-5-20251001": {"input": 0.80 / 1_000_000, "output": 4.00 / 1_000_000},
+    "claude-3-5-haiku-20241022": _HAIKU_PRICE,
+    # Claude Haiku 4.5
+    "claude-haiku-4-5-20251001": _HAIKU_PRICE,
+    "claude-haiku-4-5": _HAIKU_PRICE,  # alias used by _MODEL_HAIKU
     # Claude Sonnet 4: $3.00 / $15.00 per 1M tokens
-    "claude-sonnet-4-20250514": {"input": 3.00 / 1_000_000, "output": 15.00 / 1_000_000},
-    # Claude Sonnet 4.6 (1M context): same per-token as Sonnet 4
-    "claude-sonnet-4-6": {"input": 3.00 / 1_000_000, "output": 15.00 / 1_000_000},
+    "claude-sonnet-4-20250514": _SONNET_PRICE,
+    # Claude Sonnet 4.5 / 4.6 (1M context)
+    "claude-sonnet-4-5": _SONNET_PRICE,  # alias used by _MODEL_SONNET
+    "claude-sonnet-4-6": _SONNET_PRICE,
 }
 
 

--- a/src/pipeline/intelligence.py
+++ b/src/pipeline/intelligence.py
@@ -26,10 +26,105 @@ import json
 import logging
 import os
 import re
+import time
+from uuid import UUID
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# E1 cost instrumentation — Phase 1 deliverable per Dave's PHASE_1_KICKOFF.
+# Round 1: log every Anthropic call to sdk_usage_log via best-effort writer.
+# Round 2 (deferred): per-vendor tracking (DataForSEO, Bright Data, Leadmagic,
+# ContactOut). Any dashboard surfacing aggregated "per-prospect cost" from
+# sdk_usage_log alone must label it AI-ONLY until R2 vendor tracking lands.
+# ────────────────────────────────────────────────────────────────────────────
+
+# Sentinel client row — must pre-exist in `public.clients` table. Run
+# scripts/insert_system_pipeline_client.sql once before pipeline runs.
+# CASCADE FOOTGUN: sdk_usage_log.client_id has ON DELETE CASCADE → if this
+# row is deleted, every sdk_usage_log row referencing it goes too. Helper
+# below has a pre-write guard that refuses writes if the row is missing.
+SYSTEM_PIPELINE_CLIENT_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+# Per-token Anthropic pricing in USD per their public pricing page.
+# AUD conversion derived at runtime via settings.aud_per_usd (LAW II SSOT).
+# Source of truth (USD): https://www.anthropic.com/api/pricing as of 2026-05-08.
+ANTHROPIC_PRICING_USD = {
+    # Claude 3.5 Haiku (legacy): $0.80 / $4.00 per 1M tokens
+    "claude-3-5-haiku-20241022": {"input": 0.80 / 1_000_000, "output": 4.00 / 1_000_000},
+    # Claude Haiku 4.5: $0.80 / $4.00 per 1M tokens
+    "claude-haiku-4-5-20251001": {"input": 0.80 / 1_000_000, "output": 4.00 / 1_000_000},
+    # Claude Sonnet 4: $3.00 / $15.00 per 1M tokens
+    "claude-sonnet-4-20250514": {"input": 3.00 / 1_000_000, "output": 15.00 / 1_000_000},
+    # Claude Sonnet 4.6 (1M context): same per-token as Sonnet 4
+    "claude-sonnet-4-6": {"input": 3.00 / 1_000_000, "output": 15.00 / 1_000_000},
+}
+
+
+async def _log_anthropic_call_to_sdk_usage(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    duration_ms: int,
+    *,
+    success: bool = True,
+    error_message: str | None = None,
+) -> None:
+    """Best-effort write of an Anthropic call to sdk_usage_log (E1 R1, AI-only).
+
+    Never raises. If sentinel row missing or DB write fails, logs a warning
+    and returns. Pipeline continues regardless.
+    """
+    try:
+        from sqlalchemy import text  # local import — avoid cold-path cost
+
+        from src.config.settings import settings
+        from src.integrations.supabase import get_db_session
+        from src.services.sdk_usage_service import log_sdk_usage
+
+        pricing = ANTHROPIC_PRICING_USD.get(model)
+        if not pricing:
+            logger.warning("E1: no pricing for model %s — sdk_usage_log write skipped", model)
+            return
+
+        cost_usd = pricing["input"] * input_tokens + pricing["output"] * output_tokens
+        cost_aud = cost_usd * settings.aud_per_usd
+
+        async with get_db_session() as db:
+            # Pre-write sentinel guard. ON DELETE CASCADE on the FK means
+            # if anyone DELETEs SYSTEM_PIPELINE_CLIENT_ID, every row here
+            # vanishes. Guard refuses to write rather than 500 on FK violation.
+            sentinel_check = await db.execute(
+                text("SELECT 1 FROM clients WHERE id = :id AND deleted_at IS NULL"),
+                {"id": SYSTEM_PIPELINE_CLIENT_ID},
+            )
+            if sentinel_check.scalar() is None:
+                logger.warning(
+                    "E1: SYSTEM_PIPELINE_CLIENT_ID %s missing from clients — "
+                    "run scripts/insert_system_pipeline_client.sql first. "
+                    "sdk_usage_log write skipped.",
+                    SYSTEM_PIPELINE_CLIENT_ID,
+                )
+                return
+
+            await log_sdk_usage(
+                db=db,
+                client_id=SYSTEM_PIPELINE_CLIENT_ID,
+                agent_type="pipeline_intelligence",
+                model_used=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_aud=cost_aud,
+                duration_ms=duration_ms,
+                success=success,
+                error_message=error_message,
+            )
+    except Exception as e:
+        logger.warning("E1: sdk_usage_log write failed (best-effort): %s", e)
+
 
 # ── Semaphores — defined here and re-exported; pipeline_orchestrator imports these ──
 # Defined in intelligence.py to avoid circular import with pipeline_orchestrator.
@@ -132,15 +227,39 @@ async def _call_anthropic(
         "system": system_blocks,
         "messages": [{"role": "user", "content": user_content}],
     }
-    async with httpx.AsyncClient(timeout=60.0) as client:
-        resp = await client.post(_ANTHROPIC_API, headers=headers, json=payload)
-        resp.raise_for_status()
-        data = resp.json()
+    started_at = time.time()
+    success = True
+    error_msg: str | None = None
+    in_tok = out_tok = 0
+    text = ""
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(_ANTHROPIC_API, headers=headers, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
 
-    text = data["content"][0]["text"] if data.get("content") else ""
-    usage = data.get("usage", {})
-    in_tok = usage.get("input_tokens", 0)
-    out_tok = usage.get("output_tokens", 0)
+        text = data["content"][0]["text"] if data.get("content") else ""
+        usage = data.get("usage", {})
+        in_tok = usage.get("input_tokens", 0)
+        out_tok = usage.get("output_tokens", 0)
+    except Exception as e:
+        success = False
+        error_msg = str(e)[:500]
+        raise
+    finally:
+        # E1: best-effort cost log. Never breaks the call.
+        duration_ms = int((time.time() - started_at) * 1000)
+        try:
+            await _log_anthropic_call_to_sdk_usage(
+                model=model,
+                input_tokens=in_tok,
+                output_tokens=out_tok,
+                duration_ms=duration_ms,
+                success=success,
+                error_message=error_msg,
+            )
+        except Exception:
+            pass
     return text, in_tok, out_tok
 
 

--- a/src/services/sdk_usage_service.py
+++ b/src/services/sdk_usage_service.py
@@ -85,7 +85,7 @@ async def log_sdk_usage(
             :id, :client_id, :lead_id, :campaign_id, :user_id,
             :agent_type, :model_used,
             :input_tokens, :output_tokens, :cached_tokens, :cost_aud,
-            :turns_used, :duration_ms, :tool_calls::jsonb,
+            :turns_used, :duration_ms, CAST(:tool_calls AS jsonb),
             :success, :error_message, :created_at
         )
     """)


### PR DESCRIPTION
## Summary

Per Dave's PHASE_1_KICKOFF E1 task. Round 1 wires sdk_usage_log writes at the Anthropic call chokepoint in `src/pipeline/intelligence.py:_call_anthropic`. Captures all Sonnet/Haiku pipeline usage. Round 2 (deferred) adds per-vendor tracking (DataForSEO/Bright Data/Leadmagic/ContactOut).

**Bonus side-fix:** discovered + patched a pre-existing SQL bug in `log_sdk_usage()` that explains why `sdk_usage_log = 0 rows` pre-PR. SQLAlchemy v2 doesn't accept `:param::type` cast syntax — replaced with `CAST(:param AS type)`. Without this fix, no E1 write would land regardless of caller wiring.

## End-to-end verification (executed against prod, row deleted post-test)

```
Inserted row id=70744278-f422-41a5-9ad6-4926eca0c6e0
  client_id=00000000-0000-0000-0000-000000000001 (sentinel)
  agent_type=pipeline_intelligence
  model_used=claude-haiku-4-5-20251001
  input_tokens=100, output_tokens=50
  cost_aud=0.000434
    (= 100*0.80/1M + 50*4.00/1M = 0.00028 USD × 1.55 = 0.000434 AUD ✓)
  success=true

Test row deleted: DELETE FROM sdk_usage_log WHERE id='70744278-...' RETURNING id;
```

## Diff

| File | Change |
|---|---|
| `src/pipeline/intelligence.py` | +98 / SYSTEM_PIPELINE_CLIENT_ID sentinel, ANTHROPIC_PRICING_USD, _log_anthropic_call_to_sdk_usage helper, _call_anthropic try/except/finally wrap |
| `src/services/sdk_usage_service.py` | +1/-1 / SQL fix `:tool_calls::jsonb` → `CAST(:tool_calls AS jsonb)` |
| `scripts/insert_system_pipeline_client.sql` | +36 NEW / idempotent sentinel row INSERT |

3 files, 165+ / 10-.

## Two flags baked into PR per Aiden's design-check concur

### 1. CASCADE FOOTGUN

`sdk_usage_log.client_id` has `ON DELETE CASCADE`. If anyone DELETEs the sentinel client, every sdk_usage_log row referencing it goes too. Mitigation:
- Helper has pre-write existence guard — `SELECT 1 FROM clients WHERE id=SYSTEM_PIPELINE_CLIENT_ID` → if missing, refuses to write + logs warning.
- Documented in helper docstring + SQL script comments.

### 2. AI-ONLY LABEL

Round 1 captures only Anthropic. Per Aiden review concur, any dashboard surfacing "per-prospect cost" from sdk_usage_log alone must label "AI-only" until R2 vendor tracking lands. Otherwise same trust problem as Max's `subscription_recurring` table (partial measurement reported as total). Documented in helper docstring + commit msg.

## Schema-design observation (Phase 2+ tech debt)

`sdk_usage_log.client_id NOT NULL + ON DELETE CASCADE` assumes every AI call has a paying client. False for pre-customer pipeline runs (business_universe top-up). Architecturally correct fix is migrate `client_id` to NULLABLE. Sentinel is bridge.

## LAW II compliance

Anthropic pricing follows USD-stored + AUD-derived pattern from PR #613/#622/#623 currency refactor:
- `ANTHROPIC_PRICING_USD = {"claude-haiku-4-5-20251001": {"input": 0.80 / 1_000_000, ...}}`
- `cost_aud = cost_usd * settings.aud_per_usd`

Does NOT pre-multiply. Does NOT use `src/integrations/anthropic.py`'s legacy `MODEL_PRICING` dict (that one is pre-multiplied 1.55, same antipattern as `voice_agent_telnyx.py` deferred per Max+Aiden alignment — separate cleanup PR).

## Operational requirement

`scripts/insert_system_pipeline_client.sql` must run once per environment before pipeline AI calls. Sentinel already present on Supabase prod (verified via INSERT during smoke test).

## Test plan

- [x] Pytest collection unchanged (3489/3493)
- [x] Ruff format clean on modified files
- [x] Imports verify (SYSTEM_PIPELINE_CLIENT_ID, ANTHROPIC_PRICING_USD, _log_anthropic_call_to_sdk_usage, _call_anthropic)
- [x] End-to-end smoke (row landed in sdk_usage_log, math verified, row deleted)
- [x] Sentinel guard activates correctly (verified via debug print "DEBUG sentinel exists: 1")
- [x] Single-bot approval per new governance (non-architecture, instrumentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)