### PR TITLE
[AIDEN] fix(A3 cluster 4): rescore test fixture — 3 fails → 0

### DIFF
--- a/tests/unit/test_rescore_engine.py
+++ b/tests/unit/test_rescore_engine.py
@@ -22,8 +22,7 @@ def _make_row(
     dfs_organic_etv: float = 600.0,
 ) -> MagicMock:
     """Build a mock asyncpg.Record."""
-    row = MagicMock()
-    row.__getitem__ = lambda self, key: {
+    data = {
         "id": bu_id,
         "filter_reason": filter_reason,
         "gmb_rating": gmb_rating,
@@ -32,10 +31,14 @@ def _make_row(
         "dfs_organic_etv": dfs_organic_etv,
         "backlinks_count": 0,
         "updated_at": None,
+        "scored_at": None,
         "domain": "example.com.au",
         "gmb_category": "Plumber",
         "pipeline_stage": -1,
-    }[key]
+    }
+    row = MagicMock()
+    row.__getitem__ = lambda self, key: data[key]
+    row.get = lambda key, default=None: data.get(key, default)
     return row
 
 


### PR DESCRIPTION
## Summary
- Cluster 4 of A3 (Phase 1 test triage). Triage doc cluster 7.
- `_make_row()` test fixture mocked `__getitem__` but not `.get()`. Source at `rescore_engine.py:193` calls `row.get("scored_at")` which returns `MagicMock()` instead of `None`, breaking `score_decay_factor`'s date arithmetic with `TypeError: '<' not supported between instances of 'MagicMock' and 'int'`.
- Fix wires `.get()` to the same data dict and adds `scored_at: None` key (decay returns 1.0 for None — preserves prior test semantics).

## Verification
```
$ ~/clawd/Agency_OS/.venv/bin/python -m pytest tests/unit/test_rescore_engine.py --tb=short
============================= test session starts ==============================
collected 4 items
tests/unit/test_rescore_engine.py ....                                   [100%]
============================== 4 passed in 0.59s ===============================
```

Was: `3 failed, 1 passed`.

## Test plan
- [x] All 4 tests pass locally
- [x] No source changes — test fixture only
- [x] Branched off latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)