### PR TITLE
[AIDEN] fix(A3 cluster 6): siege fixture EnrichmentTier — 1 error → 0

### DIFF
--- a/tests/test_siege_enhancements.py
+++ b/tests/test_siege_enhancements.py
@@ -69,8 +69,8 @@ class TestAustralianLeadNoApolloFallback:
             },
             total_cost_aud=0.018,
             tier_results=[
-                MagicMock(tier=EnrichmentTier.ABN, success=True),
-                MagicMock(tier=EnrichmentTier.GMB, success=True),
+                MagicMock(tier=MagicMock(value="ABN"), success=True, skipped=False),
+                MagicMock(tier=MagicMock(value="GMB"), success=True, skipped=False),
             ],
         )
         return mock


### PR DESCRIPTION
## Summary
- Cluster 6 of A3 (Phase 1 test triage). Triage doc cluster 4.
- `EnrichmentTier` was deleted with `siege_waterfall.py` in 89272b2d (PR-A cleanup). Fixture still referenced it for `MagicMock(tier=EnrichmentTier.ABN)` causing `NameError` at collection time.
- Production `src/engines/scout.py` reads `tier_results[i].tier.value` and `.skipped`, so we mock the enum-like interface: `MagicMock(tier=MagicMock(value="ABN"), success=True, skipped=False)`.

## Drift note
Triage doc projected 3 fails + 1 error for this cluster. Max's prior fix (151c8e9a *restore ScoutEngine.siege_waterfall*) had already resolved the 3 fails — only the import-level reference remained. Net: 1 error → 0.

## Verification
```
$ ~/clawd/Agency_OS/.venv/bin/python -m pytest tests/test_siege_enhancements.py --tb=short
collected 9 items
tests/test_siege_enhancements.py .........                               [100%]
============================== 9 passed in 18.89s ==============================
```

Was: `8 passed, 1 error`.

## Test plan
- [x] All 9 tests pass locally
- [x] No source changes — test fixture only
- [x] Branched off latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)