### PR TITLE
[AIDEN] fix(A3 cluster 7): misc test fails — 4 fails → 0

### DIFF
--- a/tests/orchestration/flows/conftest.py
+++ b/tests/orchestration/flows/conftest.py
@@ -9,33 +9,50 @@ The fixture uses prefect.settings.temporary_settings to:
   - Clear PREFECT_API_URL (overrides the Railway URL set in the environment)
   - Enable PREFECT_SERVER_ALLOW_EPHEMERAL_MODE so Prefect auto-starts a
     local in-process server
+  - Point PREFECT_HOME at a clean tmp dir so alembic migration state is
+    fresh (avoids "Can't locate revision …" when the user's ~/.prefect
+    db was created against a different Prefect version)
 
 Scope: session — one ephemeral server for the whole test session.
 """
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
+
 import pytest
 from prefect.settings import (
     PREFECT_API_URL,
+    PREFECT_HOME,
     PREFECT_SERVER_ALLOW_EPHEMERAL_MODE,
+    PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS,
     temporary_settings,
 )
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(autouse=True)
 def prefect_ephemeral_server():
-    """Start a temporary in-process Prefect server for the test session.
+    """Start a temporary in-process Prefect server per test.
 
-    This is required because the flow tests call task.fn() / flow.fn() which
-    still triggers Prefect's AsyncClientContext, which attempts to connect to
-    PREFECT_API_URL. The Railway URL in the environment has no live server in
-    CI, so we redirect to an ephemeral local server instead.
+    Per-function scope — each test that calls asyncio.run() creates a new
+    event loop, and Prefect's ephemeral server holds resources bound to a
+    specific loop. Reusing a stale ephemeral context across asyncio.run()
+    calls causes "Timed out while attempting to connect to ephemeral
+    Prefect API server" failures in subsequent tests.
+
+    Each test gets a fresh PREFECT_HOME tmp dir so the SQLite migration
+    state and the ephemeral server resolve cleanly. Startup timeout is
+    raised from the 20s default to 60s to absorb cold-start variance on
+    CI runners and on machines with a slow first SQLite migration pass.
     """
-    with temporary_settings(
-        updates={
-            PREFECT_API_URL: None,
-            PREFECT_SERVER_ALLOW_EPHEMERAL_MODE: True,
-        }
-    ):
-        yield
+    with tempfile.TemporaryDirectory(prefix="prefect-test-home-") as tmp_home:
+        with temporary_settings(
+            updates={
+                PREFECT_API_URL: None,
+                PREFECT_SERVER_ALLOW_EPHEMERAL_MODE: True,
+                PREFECT_HOME: Path(tmp_home),
+                PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS: 60,
+            }
+        ):
+            yield

--- a/tests/orchestration/flows/test_free_enrichment_flow.py
+++ b/tests/orchestration/flows/test_free_enrichment_flow.py
@@ -98,7 +98,7 @@ def test_flow_runs_two_phases_when_promote_enabled():
 
 
 def test_flow_skips_promote_when_disabled():
-    """promote_stage_0=False → only enrich runs, promoted stays 0, no UPDATE issued."""
+    """promote_stage_0=False → backfill runs (gap #11), promote does not."""
     pool, conn = _make_pool("UPDATE 999")  # would be 999 if promote ran
     fake_enrich = AsyncMock(
         return_value={
@@ -125,8 +125,12 @@ def test_flow_skips_promote_when_disabled():
 
     assert summary["promoted"] == 0
     assert summary["promote_stage_0"] is False
-    # Connection.execute should NOT have been called for promote.
-    conn.execute.assert_not_called()
+    # Backfill (gap #11) always runs; promote-stage-0 UPDATE must NOT run.
+    # Verify no execute call mentions "pipeline_stage" (the promote SQL signature).
+    promote_calls = [
+        call for call in conn.execute.await_args_list if "pipeline_stage" in str(call)
+    ]
+    assert promote_calls == [], "promote_stage_0_rows must not run when promote_stage_0=False"
     fake_enrich.assert_awaited_once_with(50)
 
 

--- a/tests/test_campaign_executor.py
+++ b/tests/test_campaign_executor.py
@@ -102,7 +102,7 @@ def test_sequence_step_not_found_raises():
     with pytest.raises(ValueError, match="Step 99 not found"):
         import asyncio
 
-        asyncio.get_event_loop().run_until_complete(executor.run())
+        asyncio.run(executor.run())
 
 
 def test_summary_empty_before_run():

--- a/tests/test_engines/test_closer.py
+++ b/tests/test_engines/test_closer.py
@@ -415,7 +415,14 @@ async def test_process_reply_success():
 
 @pytest.mark.asyncio
 async def test_handle_meeting_request_intent():
-    """Test handling of meeting request intent."""
+    """Test handling of meeting request intent.
+
+    calendar_booking integration was removed in PR-A #593 (closer.py:469
+    is now a `pass # dead path`). Booking-link generation actions
+    (booking_link_generated, automated_reply_sent) are no longer emitted.
+    Test now asserts only the surviving actions: awaiting_booking_confirmation
+    and the CIS conversion record path.
+    """
     engine = CloserEngine(anthropic_client=MockAnthropicClient("meeting_request", 0.95))
     mock_db = MockDB()
     lead = MockLead(status=LeadStatus.IN_SEQUENCE)
@@ -427,12 +434,6 @@ async def test_handle_meeting_request_intent():
         patches[1],
         patches[2],
         patches[3],
-        patch(
-            "src.engines.closer.generate_booking_link",
-            new_callable=AsyncMock,
-            return_value="https://calendly.com/test",
-        ),
-        patch("src.engines.closer.send_booking_reply", new_callable=AsyncMock),
         patch.object(engine, "_update_thread_outcome", new_callable=AsyncMock),
         patch.object(engine, "_flag_for_human_review", new_callable=AsyncMock),
         patch("src.services.cis_service.get_cis_service") as mock_cis,
@@ -452,8 +453,6 @@ async def test_handle_meeting_request_intent():
         assert result.success
         # Status stays IN_SEQUENCE until Calendly webhook confirms booking
         assert lead.status == LeadStatus.IN_SEQUENCE
-        assert "booking_link_generated" in result.data["actions"]
-        assert "automated_reply_sent" in result.data["actions"]
         assert "awaiting_booking_confirmation" in result.data["actions"]
 
 

--- a/tests/test_flows/test_directive_196_resilience.py
+++ b/tests/test_flows/test_directive_196_resilience.py
@@ -55,100 +55,11 @@ async def test_pool_population_handles_empty_gmb():
 # ============================================
 # FIX 3: test_enrich_tier_failure_continues
 # ============================================
-
-
-@pytest.mark.asyncio
-async def test_enrich_tier_failure_continues():
-    """
-    FIX 3: When one enrichment tier raises an unexpected exception, subsequent tiers
-    must still run. Specifically: T1 ABN raising should NOT prevent T3 Leadmagic.
-    """
-    from src.integrations.siege_waterfall import EnrichmentTier, SiegeWaterfall, TierResult
-
-    waterfall = SiegeWaterfall()
-
-    # T1 ABN: raises an unexpected exception
-    async def boom_abn(lead):
-        raise RuntimeError("ABN service exploded")
-
-    # T1.5 LinkedIn: returns skipped (no URL)
-    async def skip_linkedin(lead, icp_passed=True):
-        return TierResult(
-            tier=EnrichmentTier.LINKEDIN_COMPANY,
-            success=False,
-            skipped=True,
-            skip_reason="No company LinkedIn URL available",
-        )
-
-    # T3 Leadmagic: returns success (verifies it ran despite T1 failure)
-    async def success_leadmagic(lead):
-        return TierResult(
-            tier=EnrichmentTier.LEADMAGIC_EMAIL,
-            success=True,
-            data={"email": "test@example.com"},
-            cost_aud=0.015,
-        )
-
-    # T2 GMB: returns skipped
-    async def skip_gmb(lead):
-        return TierResult(
-            tier=EnrichmentTier.GMB,
-            success=False,
-            skipped=True,
-            skip_reason="T0 discovery already has GMB data (T0/T2 merge)",
-        )
-
-    # T5: skipped
-    async def skip_t5(lead, als, force=False):
-        return TierResult(
-            tier=EnrichmentTier.IDENTITY,
-            success=False,
-            skipped=True,
-            skip_reason="ALS 40 < 85 threshold",
-        )
-
-    waterfall.tier1_abn = boom_abn
-    waterfall.tier1_5_linkedin_company = skip_linkedin
-    waterfall.tier2_gmb = skip_gmb
-    waterfall.tier3_leadmagic_email = success_leadmagic
-    waterfall.tier5_identity = skip_t5
-
-    # Also mock resolve_linkedin_url — tag linkedin_url_unknown=True so SIZE_GATE is bypassed
-    async def skip_resolve(lead):
-        return TierResult(
-            tier=EnrichmentTier.LINKEDIN_COMPANY,
-            success=False,
-            data={"linkedin_url_unknown": True},  # Bypass SIZE_GATE (Directive #148)
-            skip_reason="No company LinkedIn URL found via SERP",
-        )
-
-    waterfall.resolve_linkedin_url = skip_resolve
-
-    # Patch _calculate_als to return 40 (above T3 gate of 35, below T5 gate of 85)
-    with patch.object(waterfall, "_calculate_als", return_value=40):
-        result = await waterfall.enrich_lead(
-            {
-                "company_name": "Acme Corp",
-                "email": "owner@acme.com.au",
-                "domain": "acme.com.au",
-                "company_linkedin_url": None,
-            },
-            skip_tiers=[],
-        )
-
-    # T1 failed (exception swallowed) — should appear as failed tier
-    t1_results = [r for r in result.tier_results if r.tier == EnrichmentTier.ABN]
-    assert len(t1_results) == 1
-    assert t1_results[0].success is False
-    assert "ABN service exploded" in (t1_results[0].error or "")
-
-    # T3 Leadmagic should have succeeded (proving it ran despite T1 failure)
-    t3_results = [r for r in result.tier_results if r.tier == EnrichmentTier.LEADMAGIC_EMAIL]
-    assert len(t3_results) == 1, "Tier 3 should have run despite Tier 1 failure"
-    assert t3_results[0].success is True, "Tier 3 should have succeeded"
-
-    # At least 1 source used (T3)
-    assert result.sources_used >= 1
+# REMOVED: src/integrations/siege_waterfall.py was deleted in 89272b2d
+# (PR-A cleanup, "replaced by current pipeline waterfall"). The
+# SiegeWaterfall class and its EnrichmentTier/TierResult types no longer
+# exist; the per-tier graceful-degradation guarantee this test asserted
+# now lives in src/pipeline/ and should be re-tested there if needed.
 
 
 # ============================================


### PR DESCRIPTION
## Summary
Cluster 7 of A3 (Phase 1 test triage). Triage doc cluster 5. Five separate fixes across four files. All test-only changes; no source modifications.

| # | File | Change | Reason |
|---|---|---|---|
| 1 | `test_engines/test_closer.py::test_handle_meeting_request_intent` | drop dead patches, assert only surviving action | calendar_booking removed in PR-A #593; closer.py:469 is `pass # dead path` |
| 2 | `test_flows/test_directive_196_resilience.py::test_enrich_tier_failure_continues` | remove test | imports `SiegeWaterfall` from deleted `src.integrations.siege_waterfall` (89272b2d) |
| 3 | `orchestration/flows/conftest.py` | function-scope, fresh PREFECT_HOME tmpdir, 60s startup timeout | session-scoped fixture broke between `asyncio.run()` calls; user's `~/.prefect/prefect.db` has stale alembic revision |
| 4 | `orchestration/flows/test_free_enrichment_flow.py::test_flow_skips_promote_when_disabled` | assert no `pipeline_stage` UPDATE (was: `assert_not_called`) | production now runs `backfill_domain_from_gmb` (gap #11) unconditionally before the promote gate |
| 5 | `test_campaign_executor.py::test_sequence_step_not_found_raises` | `asyncio.run()` (was: `asyncio.get_event_loop().run_until_complete`) | deprecated pattern broke after function-scoped Prefect fixture closed earlier loops |

## Drift note
Triage doc projected 4 cluster fails. Pytest run found 5 failures (extra `test_flow_runs_two_phases_when_promote_enabled`) — that one was the same Prefect ephemeral server timeout root cause as `test_flow_summary_carries_run_start_and_limit`, both fixed by the conftest change. `test_sequence_step_not_found_raises` (#5 above) was projected to fail but actually passed in isolation — the fixture-cleanup change exposed a pre-existing deprecated-loop bug.

## Verification
```
$ ~/clawd/Agency_OS/.venv/bin/python -m pytest tests/test_engines/test_closer.py::test_handle_meeting_request_intent \
    tests/test_flows/test_directive_196_resilience.py \
    tests/orchestration/flows/test_free_enrichment_flow.py \
    tests/test_campaign_executor.py --tb=line
======================= 21 passed, 20 warnings in 33.80s =======================
```

Stability: free_enrichment_flow ran 4× independently → 4× green (was flaky 1/3 before timeout bump).

## Test plan
- [x] All 21 tests pass locally
- [x] No source changes — test/test-fixture edits only
- [x] Branched off latest main
- [x] Stability re-runs (4×) for the previously flaky Prefect tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)