### PR TITLE
[ELLIOT] feat(E1 R2.1): per-model pricing dict for Gemini cost tracking

### DIFF
--- a/src/intelligence/gemini_retry.py
+++ b/src/intelligence/gemini_retry.py
@@ -21,8 +21,33 @@ GEMINI_MODEL = "gemini-2.5-flash"
 GEMINI_MODEL_DM = "gemini-3.1-pro-preview"
 GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta"
 
-INPUT_COST = 0.00000015  # per token
-OUTPUT_COST = 0.0000006  # per token
+# Per-token Gemini pricing in USD per Google's published rates as of 2026-05-08.
+# Source: https://ai.google.dev/gemini-api/docs/pricing
+# AUD conversion happens downstream in sdk_usage_log writers (LAW II SSOT).
+# Unknown models fall back to flash rates and emit a one-time warning.
+GEMINI_PRICING_USD: dict[str, dict[str, float]] = {
+    # Gemini 2.5 Flash: $0.15 / $0.60 per 1M tokens
+    "gemini-2.5-flash": {"input": 0.15 / 1_000_000, "output": 0.60 / 1_000_000},
+    # Gemini 3.1 Pro Preview: $1.25 / $10.00 per 1M tokens (used for DM-verify)
+    "gemini-3.1-pro-preview": {"input": 1.25 / 1_000_000, "output": 10.00 / 1_000_000},
+}
+_FALLBACK_PRICE = GEMINI_PRICING_USD["gemini-2.5-flash"]
+_warned_unknown_models: set[str] = set()
+
+
+def _price_for(model: str) -> dict[str, float]:
+    """Return per-token USD pricing for a Gemini model. Falls back to flash rates with a one-time warning."""
+    price = GEMINI_PRICING_USD.get(model)
+    if price is not None:
+        return price
+    if model not in _warned_unknown_models:
+        logger.warning(
+            "gemini_retry: no pricing for model %s — falling back to gemini-2.5-flash rates "
+            "(cost will be approximate; add to GEMINI_PRICING_USD)",
+            model,
+        )
+        _warned_unknown_models.add(model)
+    return _FALLBACK_PRICE
 
 
 async def gemini_call_with_retry(
@@ -111,7 +136,8 @@ async def gemini_call_with_retry(
             usage = data.get("usageMetadata", {})
             in_tok = usage.get("promptTokenCount", 0)
             out_tok = usage.get("candidatesTokenCount", 0)
-            cost = in_tok * INPUT_COST + out_tok * OUTPUT_COST
+            price = _price_for(effective_model)
+            cost = in_tok * price["input"] + out_tok * price["output"]
             total_in += in_tok
             total_out += out_tok
             total_cost += cost


### PR DESCRIPTION
## Summary
Closes the known follow-up flagged in PR #635: `gemini_retry.py` was applying flat `gemini-2.5-flash` rates ($0.15 / $0.60 per 1M tokens) to **every** Gemini call regardless of model. `gemini-3.1-pro-preview` (the DM-verify model) actually costs **$1.25 / $10.00 per 1M** — roughly **12× higher**. Every Pro DM call was being undercounted by an order of magnitude.

## Changes
| Before | After |
|---|---|
| `INPUT_COST = 0.00000015` (single rate) | `GEMINI_PRICING_USD[model]["input"]` lookup |
| `OUTPUT_COST = 0.0000006` (single rate) | `GEMINI_PRICING_USD[model]["output"]` lookup |
| (no fallback) | `_price_for(model)` warns once on unknown model, falls back to flash |
| `cost = in_tok * INPUT_COST + out_tok * OUTPUT_COST` | `price = _price_for(effective_model); cost = in_tok * price["input"] + out_tok * price["output"]` |

## Pricing (per Google's published rates 2026-05-08)
- **gemini-2.5-flash**: $0.15 / $0.60 per 1M tokens (unchanged from prior flat rate)
- **gemini-3.1-pro-preview**: $1.25 / $10.00 per 1M tokens (NEW)

Source: https://ai.google.dev/gemini-api/docs/pricing

## Verification
**Smoke test:**
```
flash: in=0.1500/M out=0.6000/M
pro:   in=1.2500/M out=10.0000/M
unknown model: falls back to flash rate (warned once)
pro 5000 in + 1000 out = $0.016250 USD (was $0.001350 at old flat rate)
```

The 12× delta on the example call shows the magnitude of the prior under-count for every Pro DM call.

**Lint:** `ruff check + format` — all clean.

**Backward compat:** confirmed via grep — `INPUT_COST` / `OUTPUT_COST` were internal-only, no external imports. Safe to replace.

**Downstream flow:** PR #635's `_log_gemini_call_to_sdk_usage` reads `cost_usd` from the gemini_retry result dict, so corrected costs flow into `sdk_usage_log` automatically without any further code changes.

## Test plan
- [x] Smoke test confirms both model rates + fallback path
- [x] `ruff check src/intelligence/gemini_retry.py` clean
- [x] `ruff format src/intelligence/gemini_retry.py --check` clean
- [x] No external callers of removed `INPUT_COST` / `OUTPUT_COST` (grep'd)
- [x] AUD conversion still happens downstream in sdk_usage_log writers (LAW II SSOT preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)