### PR TITLE
[ELLIOT] feat(E2.1): systemd user-timer units for the 4 alert scripts

### DIFF
--- a/infra/alerts/agency-os-alert-budget-threshold.service
+++ b/infra/alerts/agency-os-alert-budget-threshold.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Agency OS — daily SDK cost budget threshold alert (80%/100% of BUDGET_DAILY_AUD)
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python /home/elliotbot/clawd/Agency_OS/scripts/alerts/budget_threshold_alert.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env

--- a/infra/alerts/agency-os-alert-budget-threshold.timer
+++ b/infra/alerts/agency-os-alert-budget-threshold.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run budget threshold alert hourly on the hour
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/alerts/agency-os-alert-daily-digest.service
+++ b/infra/alerts/agency-os-alert-daily-digest.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Agency OS — last-24h activity digest to Telegram group
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python /home/elliotbot/clawd/Agency_OS/scripts/alerts/daily_digest.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env

--- a/infra/alerts/agency-os-alert-daily-digest.timer
+++ b/infra/alerts/agency-os-alert-daily-digest.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run daily digest at 23:55 AEST (13:55 UTC)
+
+[Timer]
+OnCalendar=*-*-* 13:55:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/alerts/agency-os-alert-lead-quality.service
+++ b/infra/alerts/agency-os-alert-lead-quality.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Agency OS — lead quality anomaly alert (24h propensity pass-rate vs 7d baseline)
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python /home/elliotbot/clawd/Agency_OS/scripts/alerts/lead_quality_anomaly.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env

--- a/infra/alerts/agency-os-alert-lead-quality.timer
+++ b/infra/alerts/agency-os-alert-lead-quality.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run lead quality anomaly alert every 6 hours
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=6h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/alerts/agency-os-alert-pipeline-failure.service
+++ b/infra/alerts/agency-os-alert-pipeline-failure.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Agency OS — pipeline failure alert (permanent_* spikes in business_universe)
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python /home/elliotbot/clawd/Agency_OS/scripts/alerts/pipeline_failure_alert.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env

--- a/infra/alerts/agency-os-alert-pipeline-failure.timer
+++ b/infra/alerts/agency-os-alert-pipeline-failure.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run pipeline failure alert every 15 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=15min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/alerts/install.sh
+++ b/infra/alerts/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# install.sh — copy Agency OS alert systemd units to ~/.config/systemd/user/.
+#
+# Idempotent. Does NOT enable/start timers — that is left as a manual ops
+# step so the operator chooses when alerts go live:
+#
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now \
+#       agency-os-alert-pipeline-failure.timer \
+#       agency-os-alert-daily-digest.timer \
+#       agency-os-alert-budget-threshold.timer \
+#       agency-os-alert-lead-quality.timer
+#
+# To uninstall: systemctl --user disable --now <each timer>; rm the files;
+# systemctl --user daemon-reload.
+
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+
+mkdir -p "$DEST_DIR"
+
+for unit in "$SRC_DIR"/agency-os-alert-*.service "$SRC_DIR"/agency-os-alert-*.timer; do
+    install -m 0644 "$unit" "$DEST_DIR/"
+    echo "installed: $(basename "$unit")"
+done
+
+echo
+echo "8 unit files copied to $DEST_DIR"
+echo "Next: systemctl --user daemon-reload && systemctl --user enable --now <timers>"


### PR DESCRIPTION
## Summary
Wires the 4 alert scripts shipped in #631 into a schedule. New directory `infra/alerts/` containing 4 service + 4 timer unit files plus an idempotent `install.sh`. Mirrors the existing `~/.config/systemd/user/openai-cost-daily.{service,timer}` pattern (user-units, no root).

## Schedule (all UTC)
| Alert | OnCalendar / OnUnitActiveSec |
|---|---|
| `pipeline_failure` | every 15 min (after 2-min boot delay) |
| `daily_digest` | `*-*-* 13:55:00 UTC` (= 23:55 AEST) |
| `budget_threshold` | `hourly` (at :00) |
| `lead_quality` | every 6 hours (after 10-min boot delay) |

Defaults posted to TG before commit; no peer pushback received.

## Operational note (deliberate)
`install.sh` copies the 8 unit files but does **not** enable/start timers. Operator decides when alerts go live:

```bash
bash infra/alerts/install.sh
systemctl --user daemon-reload
systemctl --user enable --now \
    agency-os-alert-pipeline-failure.timer \
    agency-os-alert-daily-digest.timer \
    agency-os-alert-budget-threshold.timer \
    agency-os-alert-lead-quality.timer
```

This preserves human control of the rollout (e.g., enable digest first, observe a day, then enable the others).

`ExecStart` uses `.venv/bin/python` (not `/usr/bin/python3`) because the alert scripts import `asyncpg`, which is a project-venv dependency. Verified `.venv/bin/python -c 'import asyncpg'` succeeds.

## Verification
**systemd-analyze on all 8 units:**
```
$ systemd-analyze --user verify infra/alerts/*.service infra/alerts/*.timer
$ echo $?
0
```
No warnings, no errors.

**Calendar expressions parse correctly:**
```
$ systemd-analyze calendar "*-*-* 13:55:00 UTC"
Normalized form: *-*-* 13:55:00 UTC
    Next elapse: Sat 2026-05-09 13:55:00 UTC
       From now: 14h left

$ systemd-analyze calendar "hourly"
Normalized form: *-*-* *:00:00
    Next elapse: Sat 2026-05-09 00:00:00 UTC
```

**Install script:**
- `bash -n install.sh` — clean syntax
- Tested with `XDG_CONFIG_HOME=$(mktemp -d) bash install.sh` — 8 units copied
- Re-run on same dir succeeds (idempotent)

## Test plan
- [x] All 8 unit files validate via `systemd-analyze --user verify`
- [x] Both OnCalendar expressions parse to expected next-fire times
- [x] `install.sh` syntax + idempotency checked
- [x] `.venv/bin/python` confirmed has asyncpg
- [x] No source/code changes — infrastructure only

## Out of scope (deliberate)
- Enabling/starting timers on this box (manual ops step)
- Cron alternative (systemd is the project convention per existing openai-cost-daily setup)
- Per-environment schedule overrides (post-MVP, current defaults are pre-revenue conservative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)