### PR TITLE
[AIDEN] chore(vercel): skip preview deploys for docs-only PRs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,7 @@
   "outputDirectory": "frontend/.next",
   "installCommand": "cd frontend && npm install",
   "devCommand": "cd frontend && npm run dev",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':(exclude)docs/**' ':(exclude)*.md' ':(exclude)**/*.md'",
   "regions": ["syd1"],
   "redirects": [],
   "cleanUrls": true,


### PR DESCRIPTION
## Summary
Per Max's operational dispatch (2026-05-09) — Vercel was rate-limiting on this session's high doc-PR cadence. PRs #641, #642, #643, #645, #646 all hit \"Deployment rate limited — retry in 24 hours\" warnings even though they were 100% docs.

Adds `ignoreCommand` to `vercel.json`. Vercel runs the command before each preview build:
- exit 0 → skip build
- exit 1 → run build

\`\`\`
git diff --quiet HEAD^ HEAD \\
  -- ':(exclude)docs/**' \\
     ':(exclude)*.md' \\
     ':(exclude)**/*.md'
\`\`\`

If the PR's diff against parent only touches `docs/**` or any `.md` file (top-level or nested), git diff finds no remaining changes, exits 0, Vercel skips. Code PRs (any `.ts` / `.tsx` / `.py` / `.json` change) still trigger preview builds because non-md files sit outside the exclusion list.

## Coverage
- `docs/**` — audit + spec + manual content
- `*.md` — top-level CLAUDE.md, README, IDENTITY.md, etc.
- `**/*.md` — nested READMEs (e.g. `infra/alerts/`)

## Reference
https://vercel.com/docs/projects/overview#ignored-build-step

## Test plan
- [x] Single-line addition to existing vercel.json — no other config touched
- [x] `git diff` syntax verified locally
- [x] Branched off latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)