### PR TITLE
[ELLIOT] feat(E1 R3): vendor_usage_log migration + model + service + tests (PR 1/3)

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -48,6 +48,7 @@ from src.models.resource_pool import (
 from src.models.sdk_usage_log import SDKUsageLog
 from src.models.url_validation import URLValidationResult
 from src.models.user import User
+from src.models.vendor_usage_log import VendorUsageLog
 from src.models.voice_call import VoiceCall, VoiceCallContext, VoiceCallOutcome
 
 __all__ = [
@@ -83,6 +84,8 @@ __all__ = [
     "LinkedInCredential",
     # SDK Brain
     "SDKUsageLog",
+    # Vendor cost tracking (E1 R3)
+    "VendorUsageLog",
     # Client Intelligence
     "ClientIntelligence",
     # Resource Pool

--- a/src/models/vendor_usage_log.py
+++ b/src/models/vendor_usage_log.py
@@ -1,0 +1,94 @@
+"""
+Contract: src/models/vendor_usage_log.py
+Purpose: SQLAlchemy model for non-token vendor usage tracking (E1 R3)
+Layer: 1 - models
+Imports: exceptions ONLY
+Consumers: src/integrations/{dataforseo, leadmagic, contactout, brightdata}, services
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
+
+if TYPE_CHECKING:
+    pass
+
+
+class VendorUsageLog(Base):
+    """E1 R3: per-call cost ledger for non-token vendors.
+
+    Mirrors SDKUsageLog shape but with vendor-shaped fields. New vendor =
+    data, not migration: just write a new ``vendor`` string. Pairs with the
+    spike doc at docs/audits/elliot/e1_r3_vendor_cost_spike_2026-05-09.md.
+    """
+
+    __tablename__ = "vendor_usage_log"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True)
+
+    client_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("clients.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    lead_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("leads.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    vendor: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        index=True,
+        comment="Vendor identifier: dataforseo, leadmagic, contactout, brightdata",
+    )
+    endpoint: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+        comment="Vendor endpoint or operation name",
+    )
+
+    units: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    units_unit: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        default="api_calls",
+        comment="Unit type: records | credits | api_calls",
+    )
+
+    cost_aud: Mapped[float] = mapped_column(
+        Numeric(10, 6),
+        nullable=False,
+        default=0,
+        comment="Total cost in AUD (USD × settings.aud_per_usd at write time)",
+    )
+
+    duration_ms: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    success: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=datetime.utcnow,
+    )
+
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    def __repr__(self) -> str:
+        return f"<VendorUsageLog {self.vendor}/{self.endpoint} ${self.cost_aud:.4f}>"

--- a/src/services/vendor_usage_service.py
+++ b/src/services/vendor_usage_service.py
@@ -1,0 +1,152 @@
+"""
+Contract: src/services/vendor_usage_service.py
+Purpose: Log non-token vendor API usage to database for cost tracking
+Layer: 3 - services
+Imports: sqlalchemy
+Consumers: src/integrations/{dataforseo, leadmagic, contactout, brightdata} clients
+
+Mirror of sdk_usage_service for the vendor side. Persists per-call records
+to vendor_usage_log. Called after each non-token vendor API hit (DataForSEO
+SERP, Leadmagic email find, ContactOut record, Bright Data GMB lookup, etc.).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+async def log_vendor_usage(
+    db: AsyncSession,
+    *,
+    client_id: UUID,
+    vendor: str,
+    endpoint: str,
+    cost_aud: float = 0.0,
+    units: int = 1,
+    units_unit: str = "api_calls",
+    duration_ms: int = 0,
+    success: bool = True,
+    error_message: str | None = None,
+    lead_id: UUID | None = None,
+) -> UUID:
+    """Log a non-token vendor API call to vendor_usage_log.
+
+    Args:
+        db: Database session
+        client_id: Client ID (use SYSTEM_PIPELINE_CLIENT_ID sentinel for pipeline runs)
+        vendor: Vendor identifier — "dataforseo" | "leadmagic" | "contactout" | "brightdata"
+        endpoint: Vendor endpoint or operation name (e.g. "domain_rank_overview")
+        cost_aud: Total cost in Australian dollars (USD × settings.aud_per_usd at write time)
+        units: Volume of work charged for (records / credits / api_calls)
+        units_unit: Unit type — "records" | "credits" | "api_calls"
+        duration_ms: Wall-clock duration of the call
+        success: Whether the call succeeded
+        error_message: Error message if failed
+        lead_id: Optional lead ID context
+
+    Returns:
+        UUID of the created log entry
+    """
+    log_id = uuid4()
+
+    query = text("""
+        INSERT INTO vendor_usage_log (
+            id, client_id, lead_id,
+            vendor, endpoint,
+            units, units_unit, cost_aud, duration_ms,
+            success, error_message, created_at
+        ) VALUES (
+            :id, :client_id, :lead_id,
+            :vendor, :endpoint,
+            :units, :units_unit, :cost_aud, :duration_ms,
+            :success, :error_message, :created_at
+        )
+    """)
+
+    await db.execute(
+        query,
+        {
+            "id": str(log_id),
+            "client_id": str(client_id),
+            "lead_id": str(lead_id) if lead_id else None,
+            "vendor": vendor,
+            "endpoint": endpoint,
+            "units": units,
+            "units_unit": units_unit,
+            "cost_aud": cost_aud,
+            "duration_ms": duration_ms,
+            "success": success,
+            "error_message": error_message,
+            "created_at": datetime.now(UTC),
+        },
+    )
+
+    await db.commit()
+
+    logger.info(
+        f"Logged vendor usage: {vendor}/{endpoint} ${cost_aud:.4f} AUD",
+        extra={
+            "log_id": str(log_id),
+            "client_id": str(client_id),
+            "vendor": vendor,
+            "endpoint": endpoint,
+            "cost_aud": cost_aud,
+            "success": success,
+        },
+    )
+
+    return log_id
+
+
+async def get_client_vendor_spend(
+    db: AsyncSession,
+    client_id: UUID,
+    days: int = 30,
+) -> dict[str, Any]:
+    """Vendor spend summary for a client over the last N days, grouped by vendor."""
+    query = text("""
+        SELECT
+            vendor,
+            COUNT(*) AS call_count,
+            SUM(cost_aud) AS total_cost,
+            SUM(units) AS total_units,
+            AVG(cost_aud) AS avg_cost_per_call
+        FROM vendor_usage_log
+        WHERE client_id = :client_id
+          AND created_at >= NOW() - (CAST(:days AS int) * INTERVAL '1 day')
+          AND deleted_at IS NULL
+        GROUP BY vendor
+        ORDER BY total_cost DESC
+    """)
+
+    result = await db.execute(query, {"client_id": str(client_id), "days": days})
+    rows = result.fetchall()
+
+    breakdown: dict[str, dict[str, Any]] = {}
+    total_cost = 0.0
+    total_calls = 0
+    for row in rows:
+        breakdown[row.vendor] = {
+            "call_count": row.call_count,
+            "total_cost": float(row.total_cost or 0),
+            "total_units": int(row.total_units or 0),
+            "avg_cost_per_call": float(row.avg_cost_per_call or 0),
+        }
+        total_cost += float(row.total_cost or 0)
+        total_calls += row.call_count
+
+    return {
+        "client_id": str(client_id),
+        "period_days": days,
+        "total_cost_aud": total_cost,
+        "total_calls": total_calls,
+        "breakdown": breakdown,
+    }

--- a/supabase/migrations/20260509_vendor_usage_log.sql
+++ b/supabase/migrations/20260509_vendor_usage_log.sql
@@ -1,0 +1,105 @@
+-- Migration: 20260509_vendor_usage_log.sql
+-- Purpose: E1 R3 — per-call cost ledger for non-token vendors (DataForSEO,
+--          Bright Data, Leadmagic, ContactOut, …). Parallel to sdk_usage_log,
+--          which only covers token-shaped AI vendors. See spike doc:
+--          docs/audits/elliot/e1_r3_vendor_cost_spike_2026-05-09.md
+-- Created: 2026-05-09
+-- Decision: Option B per Max group concurrence 2026-05-09
+
+CREATE TABLE IF NOT EXISTS vendor_usage_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Context (mirrors sdk_usage_log: SYSTEM_PIPELINE_CLIENT_ID sentinel for pipeline runs)
+    client_id UUID NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+    lead_id UUID REFERENCES leads(id) ON DELETE SET NULL,
+
+    -- Vendor identity (vendor-agnostic — new vendor is data, not migration)
+    vendor TEXT NOT NULL,            -- "dataforseo" | "leadmagic" | "contactout" | "brightdata"
+    endpoint TEXT NOT NULL,          -- "domain_rank_overview" | "find_email" | "phone_lookup" | "gmb_lookup"
+
+    -- Volume (vendor-specific unit type — freetext now, can tighten to enum later)
+    units INT NOT NULL DEFAULT 1,
+    units_unit TEXT NOT NULL DEFAULT 'api_calls',  -- "records" | "credits" | "api_calls"
+
+    -- Cost tracking (AUD via settings.aud_per_usd at write time, LAW II SSOT)
+    cost_aud DECIMAL(10, 6) NOT NULL DEFAULT 0,
+
+    -- Execution metrics
+    duration_ms INT NOT NULL DEFAULT 0,
+
+    -- Status
+    success BOOLEAN NOT NULL DEFAULT true,
+    error_message TEXT,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Soft delete
+    deleted_at TIMESTAMPTZ
+);
+
+-- Indexes for common queries (mirror sdk_usage_log shape)
+CREATE INDEX IF NOT EXISTS idx_vendor_usage_client ON vendor_usage_log(client_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_vendor_usage_lead ON vendor_usage_log(lead_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_vendor_usage_vendor ON vendor_usage_log(vendor) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_vendor_usage_endpoint ON vendor_usage_log(vendor, endpoint) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_vendor_usage_created ON vendor_usage_log(created_at) WHERE deleted_at IS NULL;
+-- (Date-bucket index intentionally omitted: DATE(timestamptz) is not IMMUTABLE,
+--  so it cannot back a btree index. The created_at btree above + WHERE
+--  deleted_at IS NULL suffices for daily-spend range scans, which the
+--  vendor_daily_spend view uses.)
+
+-- Daily spend tracking view (mirrors sdk_daily_spend shape)
+CREATE OR REPLACE VIEW vendor_daily_spend AS
+SELECT
+    client_id,
+    DATE(created_at) AS spend_date,
+    vendor,
+    endpoint,
+    COUNT(*) AS call_count,
+    SUM(units) AS total_units,
+    SUM(cost_aud) AS total_cost_aud,
+    AVG(duration_ms) AS avg_duration_ms,
+    COUNT(*) FILTER (WHERE success = true) AS success_count,
+    COUNT(*) FILTER (WHERE success = false) AS failure_count
+FROM vendor_usage_log
+WHERE deleted_at IS NULL
+GROUP BY client_id, DATE(created_at), vendor, endpoint;
+
+-- RLS (mirrors sdk_usage_log policies)
+ALTER TABLE vendor_usage_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY vendor_usage_platform_admin ON vendor_usage_log
+    FOR ALL
+    TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM users u
+            WHERE u.id = auth.uid()
+            AND u.is_platform_admin = true
+        )
+    );
+
+-- NOTE: Pre-existing migrations (018_sdk_usage_log.sql, etc.) reference a
+-- table named `client_memberships` that does not exist in prod schema. The
+-- canonical table is `memberships` (verified via information_schema query
+-- 2026-05-09: columns user_id, client_id, deleted_at all present). This
+-- migration uses the correct table name. Older policies should be patched
+-- in a follow-up PR — out of scope for E1 R3.
+CREATE POLICY vendor_usage_client_member ON vendor_usage_log
+    FOR SELECT
+    TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM memberships m
+            WHERE m.user_id = auth.uid()
+            AND m.client_id = vendor_usage_log.client_id
+            AND m.deleted_at IS NULL
+        )
+    );
+
+COMMENT ON TABLE vendor_usage_log IS 'E1 R3: per-call cost ledger for non-token vendors (DFS, Leadmagic, ContactOut, Bright Data). Parallel to sdk_usage_log.';
+COMMENT ON COLUMN vendor_usage_log.vendor IS 'Vendor identifier: dataforseo, leadmagic, contactout, brightdata';
+COMMENT ON COLUMN vendor_usage_log.endpoint IS 'Vendor endpoint or operation name (e.g. domain_rank_overview, find_email)';
+COMMENT ON COLUMN vendor_usage_log.units IS 'Volume of work charged for (records, credits, or api_calls per units_unit)';
+COMMENT ON COLUMN vendor_usage_log.cost_aud IS 'Total cost in Australian dollars (USD × settings.aud_per_usd at write time)';

--- a/tests/test_services/test_vendor_usage_service.py
+++ b/tests/test_services/test_vendor_usage_service.py
@@ -1,0 +1,101 @@
+"""Tests for vendor_usage_service (E1 R3)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.services.vendor_usage_service import log_vendor_usage
+
+SENTINEL = UUID("00000000-0000-0000-0000-000000000001")
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_log_vendor_usage_writes_required_fields(mock_session):
+    """Happy path: writes a row with all required fields and commits."""
+    log_id = await log_vendor_usage(
+        db=mock_session,
+        client_id=SENTINEL,
+        vendor="dataforseo",
+        endpoint="domain_rank_overview",
+        cost_aud=0.0155,
+        units=1,
+        duration_ms=850,
+        success=True,
+    )
+
+    assert isinstance(log_id, UUID)
+    mock_session.execute.assert_awaited_once()
+    mock_session.commit.assert_awaited_once()
+
+    bind_params = mock_session.execute.await_args.args[1]
+    assert bind_params["client_id"] == str(SENTINEL)
+    assert bind_params["vendor"] == "dataforseo"
+    assert bind_params["endpoint"] == "domain_rank_overview"
+    assert bind_params["cost_aud"] == 0.0155
+    assert bind_params["units"] == 1
+    assert bind_params["units_unit"] == "api_calls"  # default
+    assert bind_params["duration_ms"] == 850
+    assert bind_params["success"] is True
+    assert bind_params["lead_id"] is None
+    assert bind_params["error_message"] is None
+
+
+@pytest.mark.asyncio
+async def test_log_vendor_usage_success_false_with_error_message(mock_session):
+    """Failure path: success=False + error_message persisted verbatim."""
+    await log_vendor_usage(
+        db=mock_session,
+        client_id=SENTINEL,
+        vendor="leadmagic",
+        endpoint="find_email",
+        cost_aud=0.0,
+        success=False,
+        error_message="HTTP 402 Payment Required",
+    )
+
+    bind_params = mock_session.execute.await_args.args[1]
+    assert bind_params["success"] is False
+    assert bind_params["error_message"] == "HTTP 402 Payment Required"
+    assert bind_params["cost_aud"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_log_vendor_usage_lead_id_serialised(mock_session):
+    """When lead_id provided, it's stringified for the bind."""
+    lead_id = uuid4()
+    await log_vendor_usage(
+        db=mock_session,
+        client_id=SENTINEL,
+        vendor="contactout",
+        endpoint="phone_lookup",
+        lead_id=lead_id,
+        units=1,
+        units_unit="credits",
+    )
+
+    bind_params = mock_session.execute.await_args.args[1]
+    assert bind_params["lead_id"] == str(lead_id)
+    assert bind_params["units_unit"] == "credits"
+
+
+@pytest.mark.asyncio
+async def test_log_vendor_usage_returns_unique_ids(mock_session):
+    """Each invocation returns a fresh UUID."""
+    id1 = await log_vendor_usage(
+        db=mock_session, client_id=SENTINEL, vendor="brightdata", endpoint="gmb_lookup"
+    )
+    id2 = await log_vendor_usage(
+        db=mock_session, client_id=SENTINEL, vendor="brightdata", endpoint="gmb_lookup"
+    )
+    assert id1 != id2


### PR DESCRIPTION
## Summary
First PR of the E1 R3 build sequence per Max group concurrence on Decision 1 (Option B: new vendor_usage_log table) + Decision 3 (schema-first ordering, client wiring deferred until DFS top-up-or-swap decision lands).

## What's in
| File | Purpose |
|---|---|
| `supabase/migrations/20260509_vendor_usage_log.sql` | Table + 5 indexes + `vendor_daily_spend` view + RLS (memberships, NOT client_memberships) + comments |
| `src/models/vendor_usage_log.py` | SQLAlchemy 2.0 model — vendor + endpoint + units + units_unit + cost_aud, mirrors SDKUsageLog shape |
| `src/services/vendor_usage_service.py` | `log_vendor_usage()` writer + `get_client_vendor_spend()` summary; mirrors sdk_usage_service.py |
| `src/models/__init__.py` | Register VendorUsageLog export |
| `tests/test_services/test_vendor_usage_service.py` | 4 happy/failure/lead-id/unique-id tests, all green |

## Two schema gotchas surfaced + fixed during apply
1. **`DATE(timestamptz)` index rejected** — `ERROR: 42P17: functions in index expression must be marked IMMUTABLE`. Dropped the date-bucket index; the `created_at` btree + `WHERE deleted_at IS NULL` covers daily-spend range scans (which `vendor_daily_spend` view uses).
2. **`client_memberships` does not exist in prod** — the table referenced by 018_sdk_usage_log.sql's RLS policy is missing. Canonical table is `memberships` (verified via `information_schema.columns`: has `user_id`, `client_id`, `deleted_at`). Used `memberships`. Pre-existing policies on other tables effectively allow nothing — out of scope, worth a follow-up patch.

## Verification
**Migration applied to prod (jatzvazlbusedwsnqxzr) via `mcp__supabase__apply_migration`:**
```
{"success":true}
```

**Live INSERT round-trip via the actual service path (not raw SQL):**
```
INSERTED log_id=35c4f8bc-1b45-4e33-a729-e34efed97f5d
{'id': UUID('35c4f8bc-1b45-4e33-a729-e34efed97f5d'), 'vendor': 'dataforseo',
 'endpoint': 'domain_rank_overview', 'units': 1, 'units_unit': 'api_calls',
 'cost_aud': Decimal('0.015500'), 'duration_ms': 850, 'success': True,
 'created_at': datetime.datetime(2026, 5, 9, 20, 46, 20, 968501, ...)}
BEFORE=0  DELETED=1  AFTER=0
```

**Tests:**
```
$ pytest tests/test_services/test_vendor_usage_service.py -v
test_log_vendor_usage_writes_required_fields PASSED
test_log_vendor_usage_success_false_with_error_message PASSED
test_log_vendor_usage_lead_id_serialised PASSED
test_log_vendor_usage_returns_unique_ids PASSED
4 passed in 1.05s
```

**Lint:** `ruff check + format --check` → All checks passed!

## Out of scope (per spike sequencing — PRs 2/3 and 3/3)
- DataForSEO / Leadmagic / ContactOut / Bright Data client edits (PR 2/3 — gated on Dave's DFS decision so we don't wrap a vendor we may deprecate)
- `vendor_budget_alert.py` mirroring budget_threshold_alert.py shape (PR 3/3)
- DFS-402 wallet action itself (Dave operational decision)

## Test plan
- [x] Migration applies cleanly to live Supabase (verified via MCP)
- [x] Live INSERT through service + cleanup verified end-to-end
- [x] 4 service tests cover happy + failure + optional-lead-id + unique-id paths
- [x] `ruff check + format --check` clean
- [x] Branched off latest main (post-#642 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)