### PR TITLE
[ELLIOT] test(E1 R3 follow-up): add 2 tests for get_client_vendor_spend per Aiden #649 review

### DIFF
--- a/tests/test_services/test_vendor_usage_service.py
+++ b/tests/test_services/test_vendor_usage_service.py
@@ -7,7 +7,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from src.services.vendor_usage_service import log_vendor_usage
+from src.services.vendor_usage_service import get_client_vendor_spend, log_vendor_usage
 
 SENTINEL = UUID("00000000-0000-0000-0000-000000000001")
 
@@ -99,3 +99,55 @@ async def test_log_vendor_usage_returns_unique_ids(mock_session):
         db=mock_session, client_id=SENTINEL, vendor="brightdata", endpoint="gmb_lookup"
     )
     assert id1 != id2
+
+
+def _row(vendor: str, call_count: int, total_cost: float, total_units: int, avg: float):
+    """Build an asyncpg-Row-like mock for fetchall()."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        vendor=vendor,
+        call_count=call_count,
+        total_cost=total_cost,
+        total_units=total_units,
+        avg_cost_per_call=avg,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_client_vendor_spend_aggregates_by_vendor(mock_session):
+    """Aggregates per-vendor counts/cost/units; total_cost_aud = sum across vendors."""
+    fake_rows = [
+        _row("dataforseo", call_count=120, total_cost=2.40, total_units=120, avg=0.02),
+        _row("leadmagic", call_count=45, total_cost=0.90, total_units=45, avg=0.02),
+        _row("contactout", call_count=10, total_cost=0.30, total_units=20, avg=0.03),
+    ]
+    fetch_result = AsyncMock()
+    fetch_result.fetchall = lambda: fake_rows  # sync method on the result object
+    mock_session.execute = AsyncMock(return_value=fetch_result)
+
+    summary = await get_client_vendor_spend(mock_session, client_id=SENTINEL, days=30)
+
+    assert summary["client_id"] == str(SENTINEL)
+    assert summary["period_days"] == 30
+    assert summary["total_calls"] == 175
+    assert abs(summary["total_cost_aud"] - 3.60) < 1e-6
+    assert set(summary["breakdown"]) == {"dataforseo", "leadmagic", "contactout"}
+    assert summary["breakdown"]["dataforseo"]["call_count"] == 120
+    assert summary["breakdown"]["dataforseo"]["total_units"] == 120
+    assert summary["breakdown"]["dataforseo"]["avg_cost_per_call"] == 0.02
+
+
+@pytest.mark.asyncio
+async def test_get_client_vendor_spend_empty(mock_session):
+    """No rows → zero totals + empty breakdown, never raises."""
+    fetch_result = AsyncMock()
+    fetch_result.fetchall = lambda: []
+    mock_session.execute = AsyncMock(return_value=fetch_result)
+
+    summary = await get_client_vendor_spend(mock_session, client_id=SENTINEL, days=7)
+
+    assert summary["total_calls"] == 0
+    assert summary["total_cost_aud"] == 0.0
+    assert summary["breakdown"] == {}
+    assert summary["period_days"] == 7


### PR DESCRIPTION
## Summary
Closes Aiden's non-blocker #3 from PR #649 review (`get_client_vendor_spend untested`). Push timing meant this commit landed after Max merged #649 — orphaned on the now-deleted branch. Cherry-picked onto a fresh branch off post-#649 main as a tiny follow-up.

## Tests added
- `test_get_client_vendor_spend_aggregates_by_vendor` — 3-vendor mixed result aggregates correctly: `call_count` sum, `total_cost_aud` sum to 6 decimals, `breakdown` per-vendor with correct `call_count`, `total_units`, `avg_cost_per_call`.
- `test_get_client_vendor_spend_empty` — zero rows returns zero totals + empty breakdown without raising.

Mock pattern uses `SimpleNamespace` to mimic asyncpg-Row attribute access. `fetchall` is sync (matches the real result.fetchall API).

## Verification
```
$ pytest tests/test_services/test_vendor_usage_service.py -q
......                                                                   [100%]
6 passed in 0.96s
$ ruff check + format --check  → clean
```

## Aiden's other 2 non-blockers — explicitly deferred (documented in #649 commit body):
- **Sentinel pre-check symmetry vs E1 R1** — belongs in PR 2/3 integration helpers (parallel to E1 R1's `_log_anthropic_call_to_sdk_usage` wrapper), NOT in the raw `log_vendor_usage` service. Service stays as the building block; integration-side wrappers add the fail-open guard.
- **datetime.utcnow modernisation** — pre-existing pattern across both `SDKUsageLog` + `VendorUsageLog` models. Modernise as one consistency PR touching both, not asymmetrically here.

## Test plan
- [x] All 6 vendor_usage_service tests pass (4 pre-existing + 2 new)
- [x] `ruff check + format --check` clean
- [x] Branched off latest main (b3010b05, post-#649 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)