### PR TITLE
[ELLIOT] fix(security): add missing sdk_usage_log RLS policies (memberships not client_memberships)

### DIFF
--- a/supabase/migrations/20260509_sdk_usage_log_rls_policies.sql
+++ b/supabase/migrations/20260509_sdk_usage_log_rls_policies.sql
@@ -1,0 +1,53 @@
+-- Migration: 20260509_sdk_usage_log_rls_policies.sql
+-- Purpose: Add the two RLS policies to sdk_usage_log that 018_sdk_usage_log.sql
+--          intended but never landed in prod. Discovered while building E1 R3
+--          (PR #649) — pg_policies showed sdk_usage_log has RLS enabled but
+--          ZERO policies, so authenticated PostgREST clients can read nothing
+--          (only the service_role bypass works).
+--
+--          Original 018 migration referenced `client_memberships` — a table
+--          that does not exist in prod schema. Canonical name is `memberships`
+--          (verified 2026-05-09: columns user_id, client_id, deleted_at all
+--          present). This migration uses the correct table name.
+--
+--          Idempotent: DROP IF EXISTS first so the migration is safe to re-run
+--          and survives any future divergence between dev and prod state.
+-- Created: 2026-05-09
+
+-- Pre-flight: ensure RLS is enabled (no-op if already on)
+ALTER TABLE sdk_usage_log ENABLE ROW LEVEL SECURITY;
+
+-- Drop any prior versions of these named policies before recreating, so the
+-- migration is idempotent even if a half-applied attempt left fragments behind.
+DROP POLICY IF EXISTS sdk_usage_platform_admin ON sdk_usage_log;
+DROP POLICY IF EXISTS sdk_usage_client_member ON sdk_usage_log;
+
+-- Platform admins see all SDK usage (full CRUD)
+CREATE POLICY sdk_usage_platform_admin ON sdk_usage_log
+    FOR ALL
+    TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM users u
+            WHERE u.id = auth.uid()
+            AND u.is_platform_admin = true
+        )
+    );
+
+-- Client members see their own client's SDK usage (read-only)
+CREATE POLICY sdk_usage_client_member ON sdk_usage_log
+    FOR SELECT
+    TO authenticated
+    USING (
+        EXISTS (
+            SELECT 1 FROM memberships m
+            WHERE m.user_id = auth.uid()
+            AND m.client_id = sdk_usage_log.client_id
+            AND m.deleted_at IS NULL
+        )
+    );
+
+COMMENT ON POLICY sdk_usage_platform_admin ON sdk_usage_log IS
+    'Platform admins (users.is_platform_admin = true) can do anything. Established 2026-05-09 — original 018_sdk_usage_log.sql policy never landed in prod.';
+COMMENT ON POLICY sdk_usage_client_member ON sdk_usage_log IS
+    'Client members (via memberships) can SELECT their own client rows. Established 2026-05-09 with correct memberships table reference (018 referenced non-existent client_memberships).';


### PR DESCRIPTION
## Summary
Per Max-approved follow-up to PR #649's schema-drift discovery. Re-scoped after prod inspection: the policies aren't broken-and-active — they were never installed at all.

```
$ SELECT relrowsecurity FROM pg_class WHERE relname='sdk_usage_log';
→ true            -- RLS is ON
$ SELECT * FROM pg_policies WHERE tablename='sdk_usage_log';
→ []              -- ZERO policies actually exist
```

`018_sdk_usage_log.sql` intended two policies but referenced `client_memberships` — a table that does not exist in prod (canonical name is `memberships`). The CREATE POLICY clauses never landed; authenticated PostgREST clients can read nothing from `sdk_usage_log`. Only `service_role` bypass works.

## What this PR does
- `ALTER TABLE sdk_usage_log ENABLE ROW LEVEL SECURITY` (no-op if already on — defensive)
- `DROP POLICY IF EXISTS` guards against any half-applied attempts
- Recreate `sdk_usage_platform_admin` (FOR ALL) and `sdk_usage_client_member` (FOR SELECT) using `memberships` (correct table)

## Net behavior change
- Client members can now SELECT their own client's `sdk_usage_log` rows
- Platform admins (`users.is_platform_admin = true`) can do everything
- `service_role` unaffected

## Verification — applied live
```
$ mcp__supabase__apply_migration → {"success":true}
$ SELECT policyname, qual FROM pg_policies WHERE tablename='sdk_usage_log';
sdk_usage_client_member  | (EXISTS ( SELECT 1 FROM memberships m WHERE ((m.user_id = auth.uid()) AND (m.client_id = sdk_usage_log.client_id) AND (m.deleted_at IS NULL))))
sdk_usage_platform_admin | (EXISTS ( SELECT 1 FROM users u WHERE ((u.id = auth.uid()) AND (u.is_platform_admin = true))))
```

## Out of scope (per Max's "isolated change" framing)
- `021_deep_research.sql` also references `client_memberships` in a JOIN, but the `deep_research` / `deep_research_runs` tables don't exist in prod either — that whole migration is dormant. Not worth chasing.
- `034_linkedin_timing.sql` references `client_memberships` only in COMMENTS as historical TODO; not active code.

## Test plan
- [x] Migration applies cleanly to live Supabase (verified via MCP)
- [x] Both policies present in `pg_policies` post-apply with `memberships` reference
- [x] Idempotent (DROP IF EXISTS + IF NOT EXISTS-style guards)
- [x] Branched off latest main (post-#649 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)