### PR TITLE
[ELLIOT] feat(E1 R3 PR 3/3): vendor_budget_alert.py + systemd unit pair

### DIFF
--- a/infra/alerts/agency-os-alert-vendor-budget.service
+++ b/infra/alerts/agency-os-alert-vendor-budget.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Agency OS — daily vendor cost budget threshold alert (80%/100% of VENDOR_BUDGET_DAILY_AUD)
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python /home/elliotbot/clawd/Agency_OS/scripts/alerts/vendor_budget_alert.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env

--- a/infra/alerts/agency-os-alert-vendor-budget.timer
+++ b/infra/alerts/agency-os-alert-vendor-budget.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run vendor budget threshold alert hourly on the hour
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/alerts/vendor_budget_alert.py
+++ b/scripts/alerts/vendor_budget_alert.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Fires when today's vendor_usage_log cost crosses 80% (warn) / 100% (exceeded) of VENDOR_BUDGET_DAILY_AUD."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import asyncpg
+
+BUDGET = float(os.environ.get("VENDOR_BUDGET_DAILY_AUD", "30"))
+
+
+async def main() -> int:
+    dsn = os.environ.get("DATABASE_URL", "").replace("postgresql+asyncpg://", "postgresql://")
+    if not dsn:
+        print("ERROR: DATABASE_URL not set", file=sys.stderr)
+        return 1
+    conn = await asyncpg.connect(dsn, statement_cache_size=0)
+    try:
+        spent = await conn.fetchval(
+            """SELECT COALESCE(SUM(cost_aud), 0) FROM vendor_usage_log
+               WHERE created_at::date = CURRENT_DATE""",
+        )
+    finally:
+        await conn.close()
+    spent = float(spent or 0)
+    pct = (spent / BUDGET * 100) if BUDGET > 0 else 0.0
+    if spent >= BUDGET:
+        emoji, label = "🚨", "EXCEEDED"
+    elif pct >= 80:
+        emoji, label = "⚠️", "warning"
+    else:
+        print(f"OK: ${spent:.2f}/${BUDGET:.2f} AUD ({pct:.0f}%)")
+        return 0
+    msg = f"[ELLIOT] {emoji} vendor budget {label}: ${spent:.2f}/${BUDGET:.2f} AUD ({pct:.0f}% of daily cap)"
+    proc = await asyncio.create_subprocess_exec("tg", "-g", msg)
+    await proc.wait()
+    print(msg)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Summary
Completes the alert side of E1 R3. Independent of the DataForSEO 402 top-up-or-swap decision (this script only reads `vendor_usage_log`; doesn't write).

Mirrors `scripts/alerts/budget_threshold_alert.py` exactly — just swaps the table to `vendor_usage_log` and the env var to `VENDOR_BUDGET_DAILY_AUD` (default \$30, conservative pre-revenue).

## Files
| File | Lines | Purpose |
|---|---|---|
| `scripts/alerts/vendor_budget_alert.py` | 45 | Sums `vendor_usage_log.cost_aud WHERE created_at::date = CURRENT_DATE`; fires 🚨 EXCEEDED at ≥100% / ⚠️ warning at ≥80% / silent OK otherwise |
| `infra/alerts/agency-os-alert-vendor-budget.service` | 8 | systemd user-service, `.venv/bin/python` ExecStart |
| `infra/alerts/agency-os-alert-vendor-budget.timer` | 9 | `OnCalendar=hourly`, `Persistent=true` (matches budget_threshold pattern) |

`infra/alerts/install.sh` already uses `agency-os-alert-*` glob, so future install runs pick this up automatically — no install.sh edit needed.

## Verification (live)
```
$ systemd-analyze --user verify infra/alerts/agency-os-alert-vendor-budget.{service,timer}
exit 0  (no warnings)

$ ruff check + format --check  → All checks passed!

$ python scripts/alerts/vendor_budget_alert.py
OK: $0.00/$30.00 AUD (0%)                           # quiet path, default budget

$ VENDOR_BUDGET_DAILY_AUD=5 python scripts/alerts/vendor_budget_alert.py
→ [ELLIOT] sent to group (chat -1003926592540)
[ELLIOT] 🚨 vendor budget EXCEEDED: $5.50/$5.00 AUD (110% of daily cap)

$ VENDOR_BUDGET_DAILY_AUD=6.40 python scripts/alerts/vendor_budget_alert.py
→ [ELLIOT] sent to group (chat -1003926592540)
[ELLIOT] ⚠️ vendor budget warning: $5.50/$6.40 AUD (86% of daily cap)
```
Test rows inserted via SENTINEL `client_id` (`00000000-0000-0000-0000-000000000001`) then deleted; final `vendor_usage_log` count = 0.

## Operational
Timer installed locally + enabled (matches earlier E2.1 dispatch pattern):
```
$ systemctl --user list-timers agency-os-alert-vendor-budget.timer
NEXT                         LEFT  ACTIVATES
Sat 2026-05-09 22:00:00 UTC  45min agency-os-alert-vendor-budget.service
```

## Closes
E1 R3 alert track. The remaining E1 R3 piece is PR 2/3 (vendor client wiring — DataForSEO / Leadmagic / ContactOut / Bright Data integration helpers calling `log_vendor_usage`). That's gated on the DFS top-up-or-swap decision so we don't wrap a vendor we may deprecate.

## Test plan
- [x] All 3 paths verified live (quiet OK, ⚠️ warning, 🚨 EXCEEDED) with temp test rows + cleanup
- [x] `systemd-analyze --user verify` clean on both unit files
- [x] `ruff check + format --check` clean
- [x] Branched off latest main (post-#655 tsbuildinfo rebase; force-pushed once to remove an accidental `frontend/tsconfig.tsbuildinfo` delta that belongs to #655 not this PR)
- [x] Timer installed + enabled locally; first scheduled fire at 22:00 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)