### PR TITLE
[ELLIOT] chore: modernise datetime defaults — datetime.utcnow → _now_utc (tz-aware UTC)

### DIFF
--- a/src/models/sdk_usage_log.py
+++ b/src/models/sdk_usage_log.py
@@ -8,7 +8,7 @@ Consumers: sdk_brain, engines, api
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -22,6 +22,16 @@ from src.models.base import Base
 if TYPE_CHECKING:
     from src.models.client import Client
     from src.models.lead import Lead
+
+
+def _now_utc() -> datetime:
+    """Timezone-aware UTC default for SQLAlchemy DateTime columns.
+
+    Replaces the deprecated `datetime.utcnow` (no-tz) pattern. Module-level
+    function (not a lambda) so SQLAlchemy's signature-detection treats it as
+    a context-less callable.
+    """
+    return datetime.now(UTC)
 
 
 class SDKUsageLog(Base):
@@ -106,7 +116,7 @@ class SDKUsageLog(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        default=datetime.utcnow,
+        default=_now_utc,
     )
 
     # Soft delete

--- a/src/models/vendor_usage_log.py
+++ b/src/models/vendor_usage_log.py
@@ -8,7 +8,7 @@ Consumers: src/integrations/{dataforseo, leadmagic, contactout, brightdata}, ser
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -20,6 +20,16 @@ from src.models.base import Base
 
 if TYPE_CHECKING:
     pass
+
+
+def _now_utc() -> datetime:
+    """Timezone-aware UTC default for SQLAlchemy DateTime columns.
+
+    Replaces the deprecated `datetime.utcnow` (no-tz) pattern. Module-level
+    function so SQLAlchemy's signature-detection treats it as a context-less
+    callable.
+    """
+    return datetime.now(UTC)
 
 
 class VendorUsageLog(Base):
@@ -82,7 +92,7 @@ class VendorUsageLog(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        default=datetime.utcnow,
+        default=_now_utc,
     )
 
     deleted_at: Mapped[datetime | None] = mapped_column(


### PR DESCRIPTION
## Summary
Closes Aiden's deferred non-blocker #2 from PR #649 review. Both `SDKUsageLog` and `VendorUsageLog` had `default=datetime.utcnow` — Python 3.12+ deprecates `datetime.utcnow()` (no-tz). Replaces with a module-level `_now_utc()` helper returning `datetime.now(UTC)` — timezone-aware.

## Why module-level helper, not lambda
SQLAlchemy's `default=` callable signature-detection works cleanly with named functions. A bare `lambda: datetime.now(UTC)` *also* works in production but introspecting it via `__code__.co_argcount` gets noisy from the SQLAlchemy wrapper layer. The named helper is the canonical SQLAlchemy idiom and reads better in stack traces.

## Diff
2 files, 24 ins / 4 del — symmetric edit to both models:
- Add `from datetime import UTC, datetime`
- Add `def _now_utc() -> datetime: return datetime.now(UTC)` as module-level helper (with docstring noting deprecation reason)
- Swap `default=datetime.utcnow` → `default=_now_utc`

## Verification
```
$ ruff check src/models/sdk_usage_log.py src/models/vendor_usage_log.py
All checks passed!

$ python -c 'from src.models.sdk_usage_log import _now_utc as sdk_now; ...'
sdk _now_utc: 2026-05-09 21:19:30.250353+00:00 tz=UTC
ven _now_utc: 2026-05-09 21:19:30.250359+00:00 tz=UTC
Both timezone-aware UTC

SDKUsageLog default: <function _now_utc at 0x7df425009bc0>
VendorUsageLog default: <function _now_utc at 0x7df42323ba60>
```

## Behavior change
- `created_at` on new INSERTs is now timezone-aware (UTC).
- The DB column is already `TIMESTAMPTZ` (always UTC at rest), so this change only affects the in-memory Python value of a freshly-constructed but unsaved instance — anyone who reads `instance.created_at.tzinfo` now gets `UTC` instead of `None`.
- Removes the Python 3.12+ DeprecationWarning that fires every time the default runs.

## Closes
- Aiden non-blocker #2 from PR #649 review
- Cross-cuts both AI cost (`SDKUsageLog`) and vendor cost (`VendorUsageLog`) models — kept symmetric so the pattern doesn't drift again

## Test plan
- [x] `ruff check` clean
- [x] Both `_now_utc()` helpers verified to produce timezone-aware UTC
- [x] SQLAlchemy column default points at the named function (not a lambda) — verified via reflection
- [x] Branched off latest main (post-#654/#656 merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)