### PR TITLE
[AIDEN] feat(admin): add Operations to admin sidebar nav

### DIFF
--- a/frontend/components/admin/AdminSidebar.tsx
+++ b/frontend/components/admin/AdminSidebar.tsx
@@ -66,6 +66,11 @@ const navItems: NavItem[] = [
     icon: Users,
   },
   {
+    title: "Operations",
+    href: "/admin/ops",
+    icon: BarChart3,
+  },
+  {
     title: "Activity",
     href: "/admin/activity",
     icon: Activity,


### PR DESCRIPTION
## Summary
Pending follow-up from PR #656 (Operations panel) — surfaces `/admin/ops` in the `AdminSidebar` so it's reachable from in-app nav, not just direct URL.

## Diff
Single nav-item insert in `frontend/components/admin/AdminSidebar.tsx` between Leads and Activity (logical placement: ops sits after client-facing entities + before activity feed). Reuses existing `BarChart3` icon already imported.

5 lines, 1 file.

## Verification
\`\`\`
$ pnpm tsc --noEmit  → exit 0
\`\`\`

## Test plan
- [x] TS strict-check clean
- [x] No new dependencies
- [x] Branched off latest main (post-#654 + #656 merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)