### PR TITLE
[AIDEN] feat(admin): /admin/leads honesty — drop hardcoded mockLeads array

### DIFF
--- a/frontend/app/admin/leads/page.tsx
+++ b/frontend/app/admin/leads/page.tsx
@@ -28,17 +28,23 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
-// Mock data
-const mockLeads = [
-  { id: "1", email: "john@acme.com", name: "John Smith", company: "Acme Corp", client: "LeadGen Pro", als: 85, tier: "hot", status: "in_sequence" },
-  { id: "2", email: "sarah@tech.co", name: "Sarah Johnson", company: "TechCo", client: "GrowthLab", als: 72, tier: "warm", status: "enriched" },
-  { id: "3", email: "mike@startup.io", name: "Mike Wilson", company: "StartupIO", client: "ScaleUp Co", als: 91, tier: "hot", status: "converted" },
-  { id: "4", email: "lisa@enterprise.com", name: "Lisa Brown", company: "Enterprise Inc", client: "Enterprise Co", als: 45, tier: "cold", status: "new" },
-  { id: "5", email: "david@agency.com", name: "David Lee", company: "Agency XYZ", client: "Marketing Plus", als: 78, tier: "warm", status: "in_sequence" },
-  { id: "6", email: "emma@corp.net", name: "Emma Davis", company: "CorpNet", client: "LeadGen Pro", als: 88, tier: "hot", status: "in_sequence" },
-  { id: "7", email: "james@biz.com", name: "James Miller", company: "BizCom", client: "GrowthLab", als: 62, tier: "warm", status: "enriched" },
-  { id: "8", email: "anna@global.io", name: "Anna White", company: "GlobalIO", client: "Enterprise Co", als: 95, tier: "hot", status: "converted" },
-];
+// Pre-revenue honesty: empty array beats fake names ("John Smith",
+// "Sarah Johnson", "Acme Corp", etc. that would show in admin/leads
+// post-login). Real wiring against the leads table is the Phase 4
+// admin Tier A batch (per docs/audits/aiden/admin_dashboard_mock_audit_2026-05-09.md).
+// Filters + stats logic below still works against an empty input.
+interface Lead {
+  id: string;
+  email: string;
+  name: string;
+  company: string;
+  client: string;
+  als: number;
+  tier: "hot" | "warm" | "cold";
+  status: "new" | "enriched" | "scored" | "in_sequence" | "converted" | "unsubscribed" | "bounced";
+}
+
+const mockLeads: Lead[] = [];
 
 const tierColors = {
   hot: "bg-amber-glow text-error border-amber/20",


### PR DESCRIPTION
## Summary
Pre-revenue honesty pass on `/admin/leads`. Drops the hardcoded `mockLeads` array (8 entries with fake names: John Smith / Sarah Johnson / Acme Corp / TechCo / etc.) that platform admins would see post-login.

Same minimal pattern as NotificationsPanel honesty (PR #654): **typed empty array preserves the existing filter/render logic against zero input**. Search + tier filter + status filter all still work; stats render 0/0/0 honestly.

## Why minimal not full wiring
Real Supabase wiring is the Phase 4 admin Tier A batch (per `docs/audits/aiden/admin_dashboard_mock_audit_2026-05-09.md` — PR #658). Same shape as the other 6 Tier A pages; ships together when that batch lands. This PR just closes the immediate fake-data exposure.

## Diff
- `frontend/app/admin/leads/page.tsx` — `mockLeads` array (8 fake entries) → typed empty `Lead[]`. Added inline interface for type safety.
- 17 ins / 11 del across 1 file.

## Verification
\`\`\`
$ pnpm tsc --noEmit  → exit 0
\`\`\`
Existing useState filters + table render still work — empty array passes through cleanly.

## Test plan
- [x] TS strict-check clean
- [x] No new dependencies
- [x] Existing filter logic unchanged
- [x] Stats cards now show honest 0s instead of "8 leads"
- [x] Branched off latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)