### PR TITLE
[ELLIOT] feat(infra): auto-pull origin/main into both worktrees every 5min

### DIFF
--- a/infra/cron/agency-os-auto-pull-main.service
+++ b/infra/cron/agency-os-auto-pull-main.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Agency OS — auto-pull origin/main into Elliot + Aiden worktrees when on main + clean
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/env bash /home/elliotbot/clawd/Agency_OS/scripts/auto_pull_main.sh

--- a/infra/cron/agency-os-auto-pull-main.timer
+++ b/infra/cron/agency-os-auto-pull-main.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Agency OS main worktree auto-pull every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/auto_pull_main.sh
+++ b/scripts/auto_pull_main.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# auto_pull_main.sh — keep Elliot + Aiden worktrees' main branches in sync with origin/main.
+#
+# Runs every 5 minutes via the agency-os-auto-pull-main.timer systemd unit.
+# Behavior per worktree:
+#   - skip if path doesn't exist (operator removed it)
+#   - skip if not on main (feature-branch work in progress)
+#   - skip if working tree dirty (uncommitted changes — operator's intent)
+#   - skip if rebase / merge / cherry-pick in progress (operator mid-flight)
+#   - else: git fetch origin main + git merge --ff-only origin/main
+#
+# All output goes to systemd-journal (no TG spam unless the user adds it).
+# Failures are non-fatal — the next 5-min cycle retries.
+#
+# Why this exists: 2026-05-09 session had two stale-main rebase incidents
+# (PR #657 force-push, smoke test ran on pre-#637 code) because the worktree
+# wasn't kept in sync. This eliminates the failure class.
+
+set -uo pipefail
+
+WORKTREES=(
+    "/home/elliotbot/clawd/Agency_OS"
+    "/home/elliotbot/clawd/Agency_OS-aiden"
+)
+
+for wt in "${WORKTREES[@]}"; do
+    [ -d "$wt/.git" ] || [ -f "$wt/.git" ] || { echo "SKIP $wt: not a git worktree"; continue; }
+    branch=$(git -C "$wt" symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")
+    if [ "$branch" != "main" ]; then
+        echo "SKIP $wt: on $branch (only auto-pull when on main)"
+        continue
+    fi
+    if [ -n "$(git -C "$wt" status --porcelain)" ]; then
+        echo "SKIP $wt: working tree dirty"
+        continue
+    fi
+    git_dir=$(git -C "$wt" rev-parse --git-dir)
+    if [ -d "$git_dir/rebase-merge" ] || [ -d "$git_dir/rebase-apply" ] \
+       || [ -f "$git_dir/MERGE_HEAD" ] || [ -f "$git_dir/CHERRY_PICK_HEAD" ]; then
+        echo "SKIP $wt: rebase/merge/cherry-pick in progress"
+        continue
+    fi
+    if ! git -C "$wt" fetch --quiet origin main 2>&1; then
+        echo "FAIL $wt: fetch origin main failed"
+        continue
+    fi
+    before=$(git -C "$wt" rev-parse HEAD)
+    if git -C "$wt" merge --ff-only --quiet origin/main 2>&1; then
+        after=$(git -C "$wt" rev-parse HEAD)
+        if [ "$before" != "$after" ]; then
+            echo "PULLED $wt: $before → $after"
+        else
+            echo "OK $wt: already at $before"
+        fi
+    else
+        echo "FAIL $wt: ff-only merge refused (history diverged?)"
+    fi
+done


### PR DESCRIPTION
## Summary
Eliminates the stale-main correctness risk that hit twice in this session:
- PR #657 force-push needed because the smoke-test branch ran on pre-#637 code (per-model pricing not exercised first time)
- Aiden's Tier 2 PRs needed rebases for tsbuildinfo

Both incidents traced back to local worktrees being multiple commits behind `origin/main`. This adds a 5-minute systemd user-timer that fast-forward-merges `origin/main` into both Elliot's and Aiden's worktrees when safe.

## Behavior per worktree
| Condition | Action |
|---|---|
| Path missing | skip (operator removed it) |
| Not on `main` | skip (feature-branch work in progress) |
| Working tree dirty | skip (uncommitted changes — operator's intent) |
| Rebase / merge / cherry-pick in progress | skip (operator mid-flight) |
| Otherwise | `git fetch origin main` + `git merge --ff-only origin/main` |

All output → `systemd-journal`. No TG spam. Failures (e.g. fetch errors) are non-fatal — the next 5-min cycle retries.

## Verification — verbatim
```
$ bash scripts/auto_pull_main.sh
SKIP /home/elliotbot/clawd/Agency_OS: on elliot/auto-pull-main-cron (only auto-pull when on main)
PULLED /home/elliotbot/clawd/Agency_OS-aiden: 4a8be6f6... → 7c03daef...

$ systemd-analyze --user verify infra/cron/agency-os-auto-pull-main.{service,timer}
exit 0  (no warnings)

$ systemctl --user enable --now agency-os-auto-pull-main.timer
Created symlink ... timers.target.wants/agency-os-auto-pull-main.timer → ...

$ systemctl --user status agency-os-auto-pull-main.service
May 10 08:15:48 vultr env[1627194]: SKIP /home/elliotbot/clawd/Agency_OS:
  on elliot/auto-pull-main-cron (only auto-pull when on main)
```

The Aiden worktree was caught up from `4a8be6f6` → `7c03daef` on the first fire — that's the 4-commit-behind state I observed earlier when `git fetch origin main` reported main as behind. Aiden can branch off updated main on his next PR.

## Files
| File | Purpose |
|---|---|
| `scripts/auto_pull_main.sh` | bash script (~50 lines incl. comments). Per-worktree loop with all the skip-checks above. |
| `infra/cron/agency-os-auto-pull-main.service` | systemd user-service, oneshot |
| `infra/cron/agency-os-auto-pull-main.timer` | `OnBootSec=2min`, `OnUnitActiveSec=5min`, `Persistent=true` |

## Operational
Timer installed + enabled in `~/.config/systemd/user/` matching the existing `infra/alerts/*` pattern. Two commands run + documented in commit body — no `install.sh` needed for a single unit pair.

## Test plan
- [x] Bash syntax check (`bash -n`)
- [x] `systemd-analyze --user verify` clean on both unit files
- [x] Dry-run on the current state correctly skips Elliot worktree (feature branch) and pulls Aiden worktree (on main)
- [x] First-fire result visible in `systemctl --user status` — same skip behavior as the dry-run
- [x] Branched off latest `origin/main` (`7c03daef`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)