### PR TITLE
[AIDEN] feat(A2 Phase 4 Tier A PR 1): wire 3 admin pages to live Supabase

### DIFF
--- a/frontend/app/admin/leads/page.tsx
+++ b/frontend/app/admin/leads/page.tsx
@@ -8,7 +8,9 @@
 "use client";
 
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -28,11 +30,10 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
-// Pre-revenue honesty: empty array beats fake names ("John Smith",
-// "Sarah Johnson", "Acme Corp", etc. that would show in admin/leads
-// post-login). Real wiring against the leads table is the Phase 4
-// admin Tier A batch (per docs/audits/aiden/admin_dashboard_mock_audit_2026-05-09.md).
-// Filters + stats logic below still works against an empty input.
+// Phase 4 admin Tier A wiring (2026-05-10): replaces the prior empty-array
+// honesty pass (PR #661) with live Supabase queries against `leads` table
+// joined with `clients` for cross-client display name. Filters + stats logic
+// below unchanged — operates on the fetched array.
 interface Lead {
   id: string;
   email: string;
@@ -44,7 +45,52 @@ interface Lead {
   status: "new" | "enriched" | "scored" | "in_sequence" | "converted" | "unsubscribed" | "bounced";
 }
 
-const mockLeads: Lead[] = [];
+type LeadRow = {
+  id: string;
+  email: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  company: string | null;
+  als_score: number | null;
+  als_tier: string | null;
+  status: string | null;
+  client_id: string | null;
+  clients: { name: string | null } | null;
+};
+
+const TIER_OF = (score: number | null): "hot" | "warm" | "cold" => {
+  if (score == null) return "cold";
+  if (score >= 70) return "hot";
+  if (score >= 40) return "warm";
+  return "cold";
+};
+
+const STATUS_OF = (raw: string | null): Lead["status"] => {
+  const allowed = ["new", "enriched", "scored", "in_sequence", "converted", "unsubscribed", "bounced"];
+  return (allowed.includes(raw ?? "") ? raw : "new") as Lead["status"];
+};
+
+async function fetchAdminLeads(): Promise<Lead[]> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+  const { data, error } = await client
+    .from("leads")
+    .select("id, email, first_name, last_name, company, als_score, als_tier, status, client_id, clients(name)")
+    .order("als_score", { ascending: false, nullsFirst: false })
+    .limit(500);
+  if (error) throw error;
+  return ((data ?? []) as LeadRow[]).map((row) => ({
+    id: row.id,
+    email: row.email ?? "",
+    name: [row.first_name, row.last_name].filter(Boolean).join(" ") || "Unknown",
+    company: row.company ?? "",
+    client: row.clients?.name ?? "",
+    als: row.als_score ?? 0,
+    tier: (["hot", "warm", "cold"].includes(row.als_tier ?? "") ? row.als_tier : TIER_OF(row.als_score)) as Lead["tier"],
+    status: STATUS_OF(row.status),
+  }));
+}
 
 const tierColors = {
   hot: "bg-amber-glow text-error border-amber/20",
@@ -67,7 +113,13 @@ export default function AdminLeadsPage() {
   const [tierFilter, setTierFilter] = useState("all");
   const [statusFilter, setStatusFilter] = useState("all");
 
-  const filteredLeads = mockLeads.filter((lead) => {
+  const { data: leads = [], isLoading } = useQuery({
+    queryKey: ["admin-leads"],
+    queryFn: fetchAdminLeads,
+    staleTime: 30 * 1000,
+  });
+
+  const filteredLeads = leads.filter((lead) => {
     const matchesSearch =
       lead.email.toLowerCase().includes(search.toLowerCase()) ||
       lead.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -79,9 +131,9 @@ export default function AdminLeadsPage() {
   });
 
   // ALS distribution
-  const hotLeads = mockLeads.filter((l) => l.als >= 70).length;
-  const warmLeads = mockLeads.filter((l) => l.als >= 40 && l.als < 70).length;
-  const coldLeads = mockLeads.filter((l) => l.als < 40).length;
+  const hotLeads = leads.filter((l) => l.als >= 70).length;
+  const warmLeads = leads.filter((l) => l.als >= 40 && l.als < 70).length;
+  const coldLeads = leads.filter((l) => l.als < 40).length;
 
   return (
     <div className="space-y-6">
@@ -100,7 +152,7 @@ export default function AdminLeadsPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{mockLeads.length.toLocaleString()}</div>
+            <div className="text-2xl font-bold">{isLoading ? "…" : leads.length.toLocaleString()}</div>
           </CardContent>
         </Card>
         <Card>

--- a/frontend/app/admin/replies/page.tsx
+++ b/frontend/app/admin/replies/page.tsx
@@ -8,8 +8,10 @@
 "use client";
 
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { Search, Mail, MessageSquare, Linkedin, ExternalLink } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -43,81 +45,60 @@ interface Reply {
   timestamp: Date;
 }
 
-// Mock data
-const mockReplies: Reply[] = [
-  {
-    id: "1",
-    client: "LeadGen Pro",
-    clientId: "cl1",
-    leadEmail: "john@acme.com",
-    leadId: "l1",
-    leadName: "John Smith",
-    channel: "email",
-    intent: "interested",
-    message: "Thanks for reaching out! I'd love to learn more about your services.",
-    timestamp: new Date(Date.now() - 1000 * 60 * 15),
-  },
-  {
-    id: "2",
-    client: "GrowthLab",
-    clientId: "cl2",
-    leadEmail: "sarah@tech.co",
-    leadId: "l2",
-    leadName: "Sarah Johnson",
-    channel: "email",
-    intent: "meeting_request",
-    message: "Can we schedule a call for next Tuesday?",
-    timestamp: new Date(Date.now() - 1000 * 60 * 45),
-  },
-  {
-    id: "3",
-    client: "ScaleUp Co",
-    clientId: "cl3",
-    leadEmail: "mike@startup.io",
-    leadId: "l3",
-    leadName: "Mike Wilson",
-    channel: "linkedin",
-    intent: "question",
-    message: "What are your pricing options for small teams?",
-    timestamp: new Date(Date.now() - 1000 * 60 * 90),
-  },
-  {
-    id: "4",
-    client: "Marketing Plus",
-    clientId: "cl4",
-    leadEmail: "lisa@enterprise.com",
-    leadId: "l4",
-    leadName: "Lisa Brown",
-    channel: "sms",
-    intent: "not_interested",
-    message: "Not interested at this time, thanks.",
-    timestamp: new Date(Date.now() - 1000 * 60 * 120),
-  },
-  {
-    id: "5",
-    client: "Enterprise Co",
-    clientId: "cl5",
-    leadEmail: "david@agency.com",
-    leadId: "l5",
-    leadName: "David Lee",
-    channel: "email",
-    intent: "out_of_office",
-    message: "I'm out of the office until January 5th.",
-    timestamp: new Date(Date.now() - 1000 * 60 * 180),
-  },
-  {
-    id: "6",
-    client: "LeadGen Pro",
-    clientId: "cl1",
-    leadEmail: "emma@corp.net",
-    leadId: "l6",
-    leadName: "Emma Davis",
-    channel: "email",
-    intent: "unsubscribe",
-    message: "Please remove me from your mailing list.",
-    timestamp: new Date(Date.now() - 1000 * 60 * 240),
-  },
-];
+// Phase 4 admin Tier A wiring (2026-05-10): replaces hardcoded mockReplies
+// with live activities query filtered to reply-shaped actions, joined with
+// leads + clients for sender + client display. Same action enum as
+// /api/replies route (PR #639).
+const REPLY_ACTIONS = ["reply.received", "reply_received", "received_reply"];
+
+type ActivityRow = {
+  id: string;
+  client_id: string | null;
+  lead_id: string | null;
+  channel: string | null;
+  intent: string | null;
+  content_preview: string | null;
+  created_at: string;
+  leads: {
+    email: string | null;
+    first_name: string | null;
+    last_name: string | null;
+  } | null;
+  clients: { name: string | null } | null;
+};
+
+const CHANNEL_OF = (raw: string | null): "email" | "sms" | "linkedin" => {
+  if (raw === "sms" || raw === "linkedin") return raw;
+  return "email";
+};
+
+async function fetchAdminReplies(): Promise<Reply[]> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+  const { data, error } = await client
+    .from("activities")
+    .select(
+      "id, client_id, lead_id, channel, intent, content_preview, created_at, leads(email, first_name, last_name), clients(name)"
+    )
+    .in("action", REPLY_ACTIONS)
+    .order("created_at", { ascending: false })
+    .limit(200);
+  if (error) throw error;
+  return ((data ?? []) as ActivityRow[]).map((row) => ({
+    id: row.id,
+    client: row.clients?.name ?? "",
+    clientId: row.client_id ?? "",
+    leadEmail: row.leads?.email ?? "",
+    leadId: row.lead_id ?? "",
+    leadName:
+      [row.leads?.first_name, row.leads?.last_name].filter(Boolean).join(" ") || "Unknown",
+    channel: CHANNEL_OF(row.channel),
+    intent: row.intent ?? "neutral",
+    message: row.content_preview ?? "",
+    timestamp: new Date(row.created_at),
+  }));
+}
 
 const intentColors: Record<string, string> = {
   interested: "bg-amber/10 text-amber border-amber/20",
@@ -155,9 +136,15 @@ export default function AdminRepliesPage() {
   const [clientFilter, setClientFilter] = useState("all");
   const [channelFilter, setChannelFilter] = useState("all");
 
-  const clients = Array.from(new Set(mockReplies.map((r) => r.client)));
+  const { data: replies = [], isLoading } = useQuery({
+    queryKey: ["admin-replies"],
+    queryFn: fetchAdminReplies,
+    staleTime: 30 * 1000,
+  });
 
-  const filteredReplies = mockReplies.filter((reply) => {
+  const clients = Array.from(new Set(replies.map((r) => r.client).filter(Boolean)));
+
+  const filteredReplies = replies.filter((reply) => {
     const matchesSearch =
       reply.leadEmail.toLowerCase().includes(search.toLowerCase()) ||
       reply.leadName.toLowerCase().includes(search.toLowerCase()) ||
@@ -169,9 +156,10 @@ export default function AdminRepliesPage() {
   });
 
   // Stats
-  const interestedCount = mockReplies.filter((r) => r.intent === "interested").length;
-  const meetingCount = mockReplies.filter((r) => r.intent === "meeting_request").length;
-  const questionCount = mockReplies.filter((r) => r.intent === "question").length;
+  const interestedCount = replies.filter((r) => r.intent === "interested").length;
+  const meetingCount = replies.filter((r) => r.intent === "meeting_request").length;
+  const questionCount = replies.filter((r) => r.intent === "question").length;
+  void isLoading; // surfaced via row count "0" pre-revenue; loading flag unused for stats
 
   return (
     <div className="space-y-6">
@@ -192,7 +180,7 @@ export default function AdminRepliesPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{mockReplies.length}</div>
+            <div className="text-2xl font-bold">{replies.length}</div>
           </CardContent>
         </Card>
         <Card>

--- a/frontend/app/admin/settings/users/page.tsx
+++ b/frontend/app/admin/settings/users/page.tsx
@@ -8,7 +8,9 @@
 "use client";
 
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Search, MoreHorizontal, Eye, UserX, Shield } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -48,75 +50,54 @@ interface User {
   isPlatformAdmin: boolean;
 }
 
-// Mock data
-const mockUsers: User[] = [
-  {
-    id: "1",
-    name: "Dave Williams",
-    email: "dave@agency.com",
-    clients: [],
-    lastActive: new Date(Date.now() - 1000 * 60 * 5),
-    status: "active",
-    isPlatformAdmin: true,
-  },
-  {
-    id: "2",
-    name: "John Smith",
-    email: "john@leadgenpro.com",
-    clients: [{ name: "LeadGen Pro", role: "owner" }],
-    lastActive: new Date(Date.now() - 1000 * 60 * 30),
-    status: "active",
-    isPlatformAdmin: false,
-  },
-  {
-    id: "3",
-    name: "Sarah Johnson",
-    email: "sarah@growthlab.co",
-    clients: [{ name: "GrowthLab", role: "owner" }],
-    lastActive: new Date(Date.now() - 1000 * 60 * 60 * 2),
-    status: "active",
-    isPlatformAdmin: false,
-  },
-  {
-    id: "4",
-    name: "Mike Wilson",
-    email: "mike@scaleup.io",
-    clients: [{ name: "ScaleUp Co", role: "admin" }],
-    lastActive: new Date(Date.now() - 1000 * 60 * 60 * 24),
-    status: "active",
-    isPlatformAdmin: false,
-  },
-  {
-    id: "5",
-    name: "Lisa Brown",
-    email: "lisa@enterprise.com",
-    clients: [
-      { name: "Enterprise Co", role: "owner" },
-      { name: "Marketing Plus", role: "admin" },
-    ],
-    lastActive: new Date(Date.now() - 1000 * 60 * 60 * 48),
-    status: "active",
-    isPlatformAdmin: false,
-  },
-  {
-    id: "6",
-    name: "Bob Chen",
-    email: "bob@leadgenpro.com",
-    clients: [{ name: "LeadGen Pro", role: "member" }],
-    lastActive: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7),
-    status: "inactive",
-    isPlatformAdmin: false,
-  },
-  {
-    id: "7",
-    name: "Alice Wong",
-    email: "alice@suspended.com",
-    clients: [{ name: "Suspended Co", role: "owner" }],
-    lastActive: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30),
-    status: "suspended",
-    isPlatformAdmin: false,
-  },
-];
+// Phase 4 admin Tier A wiring (2026-05-10): replaces hardcoded mockUsers
+// with live users + memberships + clients query. Status field synthesised
+// from updated_at recency (active <30d, inactive >30d) since the users
+// table doesn't track a separate status column today. Suspended state
+// would need a future schema column (deferred).
+type UserRow = {
+  id: string;
+  email: string;
+  full_name: string | null;
+  is_platform_admin: boolean;
+  updated_at: string;
+  memberships: Array<{
+    role: string | null;
+    deleted_at: string | null;
+    clients: { name: string | null } | null;
+  }> | null;
+};
+
+async function fetchAdminUsers(): Promise<User[]> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+  const { data, error } = await client
+    .from("users")
+    .select(
+      "id, email, full_name, is_platform_admin, updated_at, memberships(role, deleted_at, clients(name))"
+    )
+    .order("updated_at", { ascending: false })
+    .limit(500);
+  if (error) throw error;
+  const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+  return ((data ?? []) as UserRow[]).map((row) => {
+    const lastActive = new Date(row.updated_at);
+    const status: User["status"] = lastActive.getTime() > thirtyDaysAgo ? "active" : "inactive";
+    const clients = (row.memberships ?? [])
+      .filter((m) => m.deleted_at === null && m.clients?.name)
+      .map((m) => ({ name: m.clients?.name ?? "", role: m.role ?? "member" }));
+    return {
+      id: row.id,
+      name: row.full_name ?? row.email,
+      email: row.email,
+      clients,
+      lastActive,
+      status,
+      isPlatformAdmin: row.is_platform_admin,
+    };
+  });
+}
 
 const roleColors: Record<string, string> = {
   owner: "bg-amber/10 text-amber border-amber/20",
@@ -153,7 +134,13 @@ export default function AdminUsersPage() {
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
 
-  const filteredUsers = mockUsers.filter((user) => {
+  const { data: users = [] } = useQuery({
+    queryKey: ["admin-users"],
+    queryFn: fetchAdminUsers,
+    staleTime: 30 * 1000,
+  });
+
+  const filteredUsers = users.filter((user) => {
     const matchesSearch =
       user.name.toLowerCase().includes(search.toLowerCase()) ||
       user.email.toLowerCase().includes(search.toLowerCase());
@@ -161,8 +148,8 @@ export default function AdminUsersPage() {
     return matchesSearch && matchesStatus;
   });
 
-  const activeCount = mockUsers.filter((u) => u.status === "active").length;
-  const adminCount = mockUsers.filter((u) => u.isPlatformAdmin).length;
+  const activeCount = users.filter((u) => u.status === "active").length;
+  const adminCount = users.filter((u) => u.isPlatformAdmin).length;
 
   return (
     <div className="space-y-6">
@@ -183,7 +170,7 @@ export default function AdminUsersPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{mockUsers.length}</div>
+            <div className="text-2xl font-bold">{users.length}</div>
           </CardContent>
         </Card>
         <Card>
@@ -214,7 +201,7 @@ export default function AdminUsersPage() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-amber">
-              {mockUsers.filter((u) => u.status === "suspended").length}
+              {users.filter((u) => u.status === "suspended").length}
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
First batch of Phase 4 admin Tier A wiring (PR 1 of 2-3 per Max's dispatch). 3 array-shape mock-driven admin pages wired to live Supabase queries.

Pattern: keep `"use client"` + `useQuery` wrapping `createBrowserClient` direct query (matches `ActivityFeedFull.tsx` precedent). RLS scopes via `auth.uid()`; admin layout already gates to platform_admin only. Existing filter/search/stats logic preserved.

## Pages wired
| Page | Backing |
|---|---|
| `/admin/leads` | `leads` JOIN `clients`. Tier mapping (hot ≥ 70 / warm 40-69 / cold < 40) matches UI thresholds; uses `als_tier` column when present, falls back to computed from `als_score`. Replaces the empty-array honesty pass from PR #661. |
| `/admin/replies` | `activities` filtered to reply-shaped actions (`reply.received` / `reply_received` / `received_reply` — same enum as `/api/replies` in PR #639) JOIN `leads` JOIN `clients`. |
| `/admin/settings/users` | `users` JOIN `memberships` JOIN `clients`. Status synthesised from `updated_at` recency (active < 30d, inactive > 30d) since users table has no status column today. |

## Object-shape mocks deferred
`/admin/clients/[id]`, `/admin/costs`, `/admin/costs/channels`, `/admin/campaigns` — need richer treatment. Land in PR 2 + PR 3.

## Verification
\`\`\`
$ pnpm tsc --noEmit  → exit 0
\`\`\`

Pre-revenue reality: these pages render honest empty states (no clients, no leads, no replies yet). The empty filter result + 0/0/0 stat cards are correct.

## Test plan
- [x] TS strict-check clean
- [x] Filter UI + stats logic preserved against live data shape
- [x] Branched off latest main (post-#662 auto-pull synced worktree)
- [x] Negative-grep: no remaining `mockLeads`/`mockReplies`/`mockUsers` references in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)