### PR TITLE
[AIDEN] feat(A2 Phase 4 Tier A PR 2): wire 2 admin pages — campaigns + clients/[id]

### DIFF
--- a/frontend/app/admin/campaigns/page.tsx
+++ b/frontend/app/admin/campaigns/page.tsx
@@ -8,7 +8,9 @@
 "use client";
 
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Search, Filter } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -28,17 +30,50 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
-// Mock data
-const mockCampaigns = [
-  { id: "1", name: "Q4 Outreach", client: "LeadGen Pro", status: "active", leads: 450, sent: 380, replies: 23, replyRate: 6.1 },
-  { id: "2", name: "Tech Startups", client: "LeadGen Pro", status: "active", leads: 320, sent: 290, replies: 18, replyRate: 6.2 },
-  { id: "3", name: "Enterprise Push", client: "GrowthLab", status: "active", leads: 890, sent: 750, replies: 45, replyRate: 6.0 },
-  { id: "4", name: "SMB Nurture", client: "ScaleUp Co", status: "paused", leads: 680, sent: 680, replies: 52, replyRate: 7.6 },
-  { id: "5", name: "Holiday Campaign", client: "Marketing Plus", status: "active", leads: 245, sent: 180, replies: 12, replyRate: 6.7 },
-  { id: "6", name: "B2B Outreach", client: "Enterprise Co", status: "active", leads: 1200, sent: 890, replies: 67, replyRate: 7.5 },
-  { id: "7", name: "Startup Connect", client: "Enterprise Co", status: "completed", leads: 500, sent: 500, replies: 42, replyRate: 8.4 },
-  { id: "8", name: "Agency Leads", client: "TechVentures", status: "draft", leads: 0, sent: 0, replies: 0, replyRate: 0 },
-];
+// Phase 4 admin Tier A wiring (2026-05-10): replaces hardcoded mockCampaigns
+// with live `campaigns` + `clients` join. Activity-derived metrics
+// (leads / sent / replies / replyRate) currently render 0 — pre-revenue
+// (0 emails sent ever per audit). Real aggregation deferred to a follow-up
+// once outbound flows are wired (Stripe + Salesforge unblock).
+interface Campaign {
+  id: string;
+  name: string;
+  client: string;
+  status: string;
+  leads: number;
+  sent: number;
+  replies: number;
+  replyRate: number;
+}
+
+type CampaignRow = {
+  id: string;
+  name: string;
+  status: string | null;
+  clients: { name: string | null } | null;
+};
+
+async function fetchAdminCampaigns(): Promise<Campaign[]> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+  const { data, error } = await client
+    .from("campaigns")
+    .select("id, name, status, clients(name)")
+    .order("created_at", { ascending: false })
+    .limit(500);
+  if (error) throw error;
+  return ((data ?? []) as CampaignRow[]).map((row) => ({
+    id: row.id,
+    name: row.name,
+    client: row.clients?.name ?? "",
+    status: row.status ?? "draft",
+    leads: 0,
+    sent: 0,
+    replies: 0,
+    replyRate: 0,
+  }));
+}
 
 const statusColors = {
   active: "bg-amber/10 text-amber border-amber/20",
@@ -51,7 +86,13 @@ export default function AdminCampaignsPage() {
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
 
-  const filteredCampaigns = mockCampaigns.filter((campaign) => {
+  const { data: campaigns = [] } = useQuery({
+    queryKey: ["admin-campaigns"],
+    queryFn: fetchAdminCampaigns,
+    staleTime: 30 * 1000,
+  });
+
+  const filteredCampaigns = campaigns.filter((campaign) => {
     const matchesSearch =
       campaign.name.toLowerCase().includes(search.toLowerCase()) ||
       campaign.client.toLowerCase().includes(search.toLowerCase());

--- a/frontend/app/admin/clients/[id]/page.tsx
+++ b/frontend/app/admin/clients/[id]/page.tsx
@@ -8,8 +8,10 @@
 "use client";
 
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { createBrowserClient } from "@/lib/supabase";
 import {
   ArrowLeft,
   Eye,
@@ -37,42 +39,91 @@ import {
 } from "@/components/ui/table";
 import { ClientHealthIndicator } from "@/components/admin/ClientHealthIndicator";
 
-// Mock client data
-const mockClient = {
-  id: "1",
-  name: "LeadGen Pro",
-  tier: "velocity" as const,
-  mrr: 999,
-  status: "active" as const,
-  healthScore: 92,
-  creditsRemaining: 2500,
-  creditsTotal: 5000,
-  createdAt: new Date("2024-06-15"),
-  renewalDate: new Date("2025-01-15"),
-  lastActivity: new Date(Date.now() - 1000 * 60 * 5),
-  team: [
-    { id: "1", name: "John Smith", email: "john@leadgenpro.com", role: "owner" },
-    { id: "2", name: "Jane Doe", email: "jane@leadgenpro.com", role: "admin" },
-    { id: "3", name: "Bob Wilson", email: "bob@leadgenpro.com", role: "member" },
-  ],
-  campaigns: [
-    { id: "1", name: "Q4 Outreach", status: "active", leads: 450, sent: 380, replies: 23 },
-    { id: "2", name: "Tech Startups", status: "active", leads: 320, sent: 290, replies: 18 },
-    { id: "3", name: "Enterprise Push", status: "paused", leads: 890, sent: 750, replies: 45 },
-    { id: "4", name: "SMB Nurture", status: "completed", leads: 680, sent: 680, replies: 52 },
-  ],
-  recentActivity: [
-    { id: "1", action: "Email sent", details: "to john@acme.com", timestamp: new Date(Date.now() - 1000 * 60 * 5), channel: "email" },
-    { id: "2", action: "Lead enriched", details: "ALS: 82", timestamp: new Date(Date.now() - 1000 * 60 * 15), channel: null },
-    { id: "3", action: "Reply received", details: "from sarah@tech.co", timestamp: new Date(Date.now() - 1000 * 60 * 45), channel: "email" },
-    { id: "4", action: "LinkedIn sent", details: "connection request", timestamp: new Date(Date.now() - 1000 * 60 * 60), channel: "linkedin" },
-  ],
-  billing: [
-    { id: "1", date: new Date("2024-12-01"), amount: 999, status: "paid", invoice: "INV-2024-1201" },
-    { id: "2", date: new Date("2024-11-01"), amount: 999, status: "paid", invoice: "INV-2024-1101" },
-    { id: "3", date: new Date("2024-10-01"), amount: 999, status: "paid", invoice: "INV-2024-1001" },
-  ],
+// Phase 4 admin Tier A wiring (2026-05-10): replaces hardcoded mockClient
+// with live `clients` JOIN `memberships` JOIN `users` for the team list.
+// Nested arrays (campaigns / recentActivity / billing) default to empty —
+// pre-revenue (no campaigns sent, no Stripe, no activity yet). Each
+// section's wire-up is a separate follow-up once outbound flows + Stripe
+// are unblocked.
+type ClientDetail = {
+  id: string;
+  name: string;
+  tier: "ignition" | "velocity" | "spark";
+  mrr: number;
+  status: "active" | "trialing" | "past_due" | "paused" | "cancelled";
+  healthScore: number;
+  creditsRemaining: number;
+  creditsTotal: number;
+  createdAt: Date;
+  renewalDate: Date;
+  lastActivity: Date;
+  team: { id: string; name: string; email: string; role: string }[];
+  campaigns: { id: string; name: string; status: string; leads: number; sent: number; replies: number }[];
+  recentActivity: { id: string; action: string; details: string; timestamp: Date; channel: string | null }[];
+  billing: { id: string; date: Date; amount: number; status: string; invoice: string }[];
 };
+
+type ClientRow = {
+  id: string;
+  name: string;
+  tier: string | null;
+  subscription_status: string | null;
+  created_at: string;
+  updated_at: string;
+  memberships: Array<{
+    role: string | null;
+    deleted_at: string | null;
+    users: { id: string; email: string; full_name: string | null } | null;
+  }> | null;
+};
+
+async function fetchAdminClient(clientId: string): Promise<ClientDetail | null> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+  const { data, error } = await client
+    .from("clients")
+    .select(
+      "id, name, tier, subscription_status, created_at, updated_at, memberships(role, deleted_at, users(id, email, full_name))"
+    )
+    .eq("id", clientId)
+    .maybeSingle();
+  if (error || !data) return null;
+  const row = data as ClientRow;
+  const allowedTier: ClientDetail["tier"] = (["ignition", "velocity", "spark"].includes(row.tier ?? "")
+    ? (row.tier as ClientDetail["tier"])
+    : "ignition");
+  const allowedStatus: ClientDetail["status"] = (
+    ["active", "trialing", "past_due", "paused", "cancelled"].includes(row.subscription_status ?? "")
+      ? (row.subscription_status as ClientDetail["status"])
+      : "active"
+  );
+  const team = (row.memberships ?? [])
+    .filter((m) => m.deleted_at === null && m.users)
+    .map((m) => ({
+      id: m.users!.id,
+      name: m.users!.full_name ?? m.users!.email,
+      email: m.users!.email,
+      role: m.role ?? "member",
+    }));
+  return {
+    id: row.id,
+    name: row.name,
+    tier: allowedTier,
+    mrr: 0,
+    status: allowedStatus,
+    healthScore: 0,
+    creditsRemaining: 0,
+    creditsTotal: 0,
+    createdAt: new Date(row.created_at),
+    renewalDate: new Date(row.created_at),
+    lastActivity: new Date(row.updated_at),
+    team,
+    campaigns: [],
+    recentActivity: [],
+    billing: [],
+  };
+}
 
 const tierColors = {
   ignition: "bg-panel/10 text-amber border-default/20",
@@ -113,10 +164,38 @@ function formatTimeAgo(date: Date): string {
 
 export default function AdminClientDetailPage() {
   const params = useParams();
+  const clientId = (params?.id ?? "") as string;
   const [activeTab, setActiveTab] = useState("overview");
 
-  // In production, fetch client data based on params.id
-  const client = mockClient;
+  const { data: client, isLoading } = useQuery({
+    queryKey: ["admin-client", clientId],
+    queryFn: () => fetchAdminClient(clientId),
+    enabled: !!clientId,
+    staleTime: 30 * 1000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!client) {
+    return (
+      <div className="space-y-6">
+        <Link
+          href="/admin/clients"
+          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Clients
+        </Link>
+        <p className="text-sm text-muted-foreground">Client not found.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
PR 2 of Max's Tier A dispatch. Continues PR #663 pattern (`useQuery` + `createBrowserClient`). Object-shape mocks + nested arrays handled honestly with pre-revenue empty defaults documented inline.

## Pages wired
| Page | Backing | Pre-revenue notes |
|---|---|---|
| `/admin/campaigns` | `campaigns` JOIN `clients(name)` | Activity-derived metrics (leads/sent/replies/replyRate) default to 0 — 0 emails sent ever per audit. Aggregation deferred to follow-up. Filter UI preserved. |
| `/admin/clients/[id]` | `clients` JOIN `memberships` JOIN `users` for team list | Nested arrays (campaigns / recentActivity / billing) default empty. Adds proper 404 + loading branches. Each section wires-up post-Stripe + outbound unblock. |

## Defensive type narrowing
`tier` + `subscription_status` from Supabase rows narrowed to the allowed enum values (falls back to `"ignition"` / `"active"` if a row contains unexpected text). Protects existing badge color maps.

## Verification
\`\`\`
$ pnpm tsc --noEmit  → exit 0
\`\`\`

## Test plan
- [x] TS strict-check clean
- [x] 404 + loading branches added on clients/[id]
- [x] Filter UI preserved on campaigns
- [x] Branched off latest main (post-#662 + #663 merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)