### PR TITLE
[AIDEN] feat(A2 Phase 4 Tier A PR 3): wire 2 admin pages — costs + costs/channels

### DIFF
--- a/frontend/app/admin/costs/channels/page.tsx
+++ b/frontend/app/admin/costs/channels/page.tsx
@@ -7,7 +7,9 @@
 
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { createBrowserClient } from "@/lib/supabase";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -20,71 +22,106 @@ import {
 } from "@/components/ui/table";
 import { Mail, MessageSquare, Linkedin, Phone, Package } from "lucide-react";
 
-// Mock data
-const mockChannelCosts = {
-  total: 1599.69,
-  channels: [
-    {
-      name: "Email",
-      provider: "Resend",
-      icon: Mail,
-      color: "bg-panel",
-      sent: 18470,
-      cost: 456.23,
-      costPer: 0.025,
-      budget: 600,
-    },
-    {
-      name: "SMS",
-      provider: "Twilio",
-      icon: MessageSquare,
-      color: "bg-amber",
-      sent: 2340,
-      cost: 389.45,
-      costPer: 0.166,
-      budget: 500,
-    },
-    {
-      name: "LinkedIn",
-      provider: "HeyReach",
-      icon: Linkedin,
-      color: "bg-amber",
-      sent: 4560,
-      cost: 534.12,
-      costPer: 0.117,
-      budget: 700,
-    },
-    {
-      name: "Voice",
-      provider: "Synthflow",
-      icon: Phone,
-      color: "bg-amber",
-      sent: 156,
-      cost: 156.00,
-      costPer: 1.00,
-      budget: 300,
-    },
-    {
-      name: "Mail",
-      provider: "Lob",
-      icon: Package,
-      color: "bg-orange-500",
-      sent: 45,
-      cost: 63.89,
-      costPer: 1.42,
-      budget: 200,
-    },
-  ],
-  byClient: [
-    { client: "LeadGen Pro", email: 123.45, sms: 89.20, linkedin: 156.78, voice: 45.00, mail: 12.34 },
-    { client: "GrowthLab", email: 98.76, sms: 67.89, linkedin: 123.45, voice: 34.00, mail: 8.90 },
-    { client: "Enterprise Co", email: 87.65, sms: 78.90, linkedin: 89.12, voice: 28.00, mail: 15.67 },
-    { client: "ScaleUp Co", email: 65.43, sms: 45.67, linkedin: 67.89, voice: 22.00, mail: 9.87 },
-    { client: "Marketing Plus", email: 45.12, sms: 34.56, linkedin: 45.67, voice: 15.00, mail: 6.78 },
-  ],
+// Phase 4 admin Tier A wiring (2026-05-10): live aggregates from
+// vendor_usage_log GROUP BY vendor (channel mapping) + per client_id
+// for byClient breakdown. Pre-revenue: 0 vendors fired, all rows render
+// 0. Real fill on E1 R3 PR 2/3 client wiring landing.
+type ChannelRow = {
+  name: string;
+  provider: string;
+  icon: typeof Mail;
+  color: string;
+  sent: number;
+  cost: number;
+  costPer: number;
+  budget: number;
+};
+
+type ChannelCosts = {
+  total: number;
+  channels: ChannelRow[];
+  byClient: Array<{ client: string; email: number; sms: number; linkedin: number; voice: number; mail: number }>;
+};
+
+type VendorRow = { vendor: string | null; cost_aud: string | number; client_id: string | null };
+
+const CHANNEL_DEFS: Array<{ name: string; provider: string; icon: typeof Mail; color: string; budget: number }> = [
+  { name: "Email", provider: "Resend / Salesforge", icon: Mail, color: "bg-panel", budget: 600 },
+  { name: "SMS", provider: "Telnyx", icon: MessageSquare, color: "bg-amber", budget: 500 },
+  { name: "LinkedIn", provider: "Unipile", icon: Linkedin, color: "bg-amber", budget: 700 },
+  { name: "Voice", provider: "ElevenAgents", icon: Phone, color: "bg-amber", budget: 300 },
+  { name: "Mail", provider: "—", icon: Package, color: "bg-orange-500", budget: 200 },
+];
+
+function vendorToChannel(v: string): "email" | "sms" | "linkedin" | "voice" | "mail" {
+  const x = v.toLowerCase();
+  if (x.includes("salesforge") || x.includes("resend") || x.includes("postmark")) return "email";
+  if (x.includes("telnyx") || x.includes("twilio")) return "sms";
+  if (x.includes("unipile") || x.includes("heyreach") || x.includes("linkedin")) return "linkedin";
+  if (x.includes("vapi") || x.includes("voice") || x.includes("eleven")) return "voice";
+  if (x.includes("mail") || x.includes("postal")) return "mail";
+  return "email";
+}
+
+async function fetchChannelCosts(): Promise<ChannelCosts> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+  const monthStart = new Date(new Date().getFullYear(), new Date().getMonth(), 1).toISOString();
+
+  const { data: vendorRows } = await client
+    .from("vendor_usage_log")
+    .select("vendor, cost_aud, client_id")
+    .gte("created_at", monthStart);
+  const { data: clientRows } = await client.from("clients").select("id, name");
+
+  const clientNameById = new Map<string, string>();
+  for (const c of (clientRows ?? []) as Array<{ id: string; name: string }>) {
+    clientNameById.set(c.id, c.name);
+  }
+
+  const channelTotals: Record<string, number> = { email: 0, sms: 0, linkedin: 0, voice: 0, mail: 0 };
+  const byClientMap = new Map<string, { email: number; sms: number; linkedin: number; voice: number; mail: number }>();
+  let total = 0;
+
+  for (const row of (vendorRows ?? []) as VendorRow[]) {
+    const cost = typeof row.cost_aud === "string" ? Number(row.cost_aud) : row.cost_aud || 0;
+    const ch = vendorToChannel(row.vendor ?? "");
+    channelTotals[ch] += cost;
+    total += cost;
+    if (row.client_id) {
+      const cur = byClientMap.get(row.client_id) ?? { email: 0, sms: 0, linkedin: 0, voice: 0, mail: 0 };
+      cur[ch] += cost;
+      byClientMap.set(row.client_id, cur);
+    }
+  }
+
+  const channels: ChannelRow[] = CHANNEL_DEFS.map((def) => {
+    const key = vendorToChannel(def.name);
+    return { ...def, sent: 0, cost: channelTotals[key] ?? 0, costPer: 0 };
+  });
+
+  const byClient = Array.from(byClientMap.entries()).map(([clientId, breakdown]) => ({
+    client: clientNameById.get(clientId) ?? "Unknown",
+    ...breakdown,
+  }));
+
+  return { total, channels, byClient };
+}
+
+const EMPTY_CHANNEL_COSTS: ChannelCosts = {
+  total: 0,
+  channels: CHANNEL_DEFS.map((def) => ({ ...def, sent: 0, cost: 0, costPer: 0 })),
+  byClient: [],
 };
 
 export default function AdminChannelCostsPage() {
+  const { data: mockChannelCosts = EMPTY_CHANNEL_COSTS } = useQuery({
+    queryKey: ["admin-channel-costs"],
+    queryFn: fetchChannelCosts,
+    staleTime: 30 * 1000,
+  });
+
   return (
     <div className="space-y-6">
       {/* Header */}

--- a/frontend/app/admin/costs/page.tsx
+++ b/frontend/app/admin/costs/page.tsx
@@ -8,36 +8,142 @@
 "use client";
 
 import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Cpu, Send, ArrowRight, TrendingUp, TrendingDown } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
 
-// Mock data
-const mockCosts = {
-  totalMTD: 2847.52,
-  aiCosts: 1247.83,
-  channelCosts: 1599.69,
-  lastMonth: 2650.00,
-  projectedEOM: 3200.00,
+// Phase 4 admin Tier A wiring (2026-05-10): replaces hardcoded mockCosts
+// with live aggregates from sdk_usage_log (AI) + vendor_usage_log (channels).
+// Same source as /admin/ops cost cards (PR #656). MTD = month-to-date.
+// Per-AI-agent + per-channel breakdowns map agent_type prefixes + vendor IDs
+// to the existing UI category labels (content/reply/cmo for AI, channel
+// names for vendor). Last-month + projected-EOM derived from same tables.
+type CostsData = {
+  totalMTD: number;
+  aiCosts: number;
+  channelCosts: number;
+  lastMonth: number;
+  projectedEOM: number;
   byCategory: {
-    ai: {
-      content: 523,
-      reply: 412,
-      cmo: 312,
-    },
-    channels: {
-      email: 456,
-      sms: 389,
-      linkedin: 534,
-      voice: 156,
-      mail: 64,
-    },
+    ai: { content: number; reply: number; cmo: number };
+    channels: { email: number; sms: number; linkedin: number; voice: number; mail: number };
+  };
+};
+
+function startOfMonth(d: Date): string {
+  return new Date(d.getFullYear(), d.getMonth(), 1).toISOString();
+}
+
+function endOfPriorMonth(d: Date): string {
+  return new Date(d.getFullYear(), d.getMonth(), 0, 23, 59, 59).toISOString();
+}
+
+function startOfPriorMonth(d: Date): string {
+  return new Date(d.getFullYear(), d.getMonth() - 1, 1).toISOString();
+}
+
+async function fetchAdminCosts(): Promise<CostsData> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+  const now = new Date();
+  const monthStart = startOfMonth(now);
+  const priorStart = startOfPriorMonth(now);
+  const priorEnd = endOfPriorMonth(now);
+  const dayOfMonth = now.getDate();
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+
+  const [{ data: sdkMTD }, { data: vendorMTD }, { data: sdkPrior }, { data: vendorPrior }] = await Promise.all([
+    client
+      .from("sdk_usage_log")
+      .select("agent_type, cost_aud")
+      .gte("created_at", monthStart),
+    client
+      .from("vendor_usage_log")
+      .select("vendor, cost_aud")
+      .gte("created_at", monthStart),
+    client
+      .from("sdk_usage_log")
+      .select("cost_aud")
+      .gte("created_at", priorStart)
+      .lte("created_at", priorEnd),
+    client
+      .from("vendor_usage_log")
+      .select("cost_aud")
+      .gte("created_at", priorStart)
+      .lte("created_at", priorEnd),
+  ]);
+
+  const sumCost = (rows: Array<{ cost_aud: string | number }> | null) =>
+    (rows ?? []).reduce((s, r) => s + (typeof r.cost_aud === "string" ? Number(r.cost_aud) : r.cost_aud || 0), 0);
+
+  const aiCosts = sumCost(sdkMTD ?? []);
+  const channelCosts = sumCost(vendorMTD ?? []);
+  const totalMTD = aiCosts + channelCosts;
+  const lastMonth = sumCost(sdkPrior ?? []) + sumCost(vendorPrior ?? []);
+  const projectedEOM = dayOfMonth > 0 ? (totalMTD / dayOfMonth) * daysInMonth : totalMTD;
+
+  // AI breakdown by agent_type prefix
+  const aiBreakdown = { content: 0, reply: 0, cmo: 0 };
+  for (const row of (sdkMTD ?? []) as Array<{ agent_type: string | null; cost_aud: string | number }>) {
+    const cost = typeof row.cost_aud === "string" ? Number(row.cost_aud) : row.cost_aud || 0;
+    const at = row.agent_type ?? "";
+    if (at.includes("comprehend") || at.includes("analyse") || at.includes("identify")) aiBreakdown.content += cost;
+    else if (at.includes("reply") || at.includes("dm_verify")) aiBreakdown.reply += cost;
+    else if (at.includes("cmo") || at.includes("smart_prompt")) aiBreakdown.cmo += cost;
+    else aiBreakdown.content += cost; // default bucket
+  }
+
+  // Channel breakdown by vendor
+  const channelBreakdown = { email: 0, sms: 0, linkedin: 0, voice: 0, mail: 0 };
+  for (const row of (vendorMTD ?? []) as Array<{ vendor: string | null; cost_aud: string | number }>) {
+    const cost = typeof row.cost_aud === "string" ? Number(row.cost_aud) : row.cost_aud || 0;
+    const v = (row.vendor ?? "").toLowerCase();
+    if (v.includes("salesforge") || v.includes("resend") || v.includes("postmark")) channelBreakdown.email += cost;
+    else if (v.includes("telnyx") || v.includes("twilio")) channelBreakdown.sms += cost;
+    else if (v.includes("unipile") || v.includes("heyreach") || v.includes("linkedin")) channelBreakdown.linkedin += cost;
+    else if (v.includes("vapi") || v.includes("voice") || v.includes("eleven")) channelBreakdown.voice += cost;
+    else if (v.includes("mail") || v.includes("postal")) channelBreakdown.mail += cost;
+    else channelBreakdown.email += cost; // default bucket for enrichment vendors etc.
+  }
+
+  return {
+    totalMTD,
+    aiCosts,
+    channelCosts,
+    lastMonth,
+    projectedEOM,
+    byCategory: { ai: aiBreakdown, channels: channelBreakdown },
+  };
+}
+
+const EMPTY_COSTS: CostsData = {
+  totalMTD: 0,
+  aiCosts: 0,
+  channelCosts: 0,
+  lastMonth: 0,
+  projectedEOM: 0,
+  byCategory: {
+    ai: { content: 0, reply: 0, cmo: 0 },
+    channels: { email: 0, sms: 0, linkedin: 0, voice: 0, mail: 0 },
   },
 };
 
 export default function AdminCostsOverviewPage() {
-  const changePercent = ((mockCosts.totalMTD - mockCosts.lastMonth) / mockCosts.lastMonth) * 100;
-  const aiPercent = Math.round((mockCosts.aiCosts / mockCosts.totalMTD) * 100);
+  const { data: mockCosts = EMPTY_COSTS } = useQuery({
+    queryKey: ["admin-costs"],
+    queryFn: fetchAdminCosts,
+    staleTime: 30 * 1000,
+  });
+
+  const changePercent = mockCosts.lastMonth > 0
+    ? ((mockCosts.totalMTD - mockCosts.lastMonth) / mockCosts.lastMonth) * 100
+    : 0;
+  const aiPercent = mockCosts.totalMTD > 0
+    ? Math.round((mockCosts.aiCosts / mockCosts.totalMTD) * 100)
+    : 0;
   const channelPercent = 100 - aiPercent;
 
   return (


### PR DESCRIPTION
## Summary
PR 3 of Max's Tier A dispatch — **completes the 7-page Tier A wiring sequence**.

Both pages aggregate from `sdk_usage_log` + `vendor_usage_log` — same source as `/admin/ops` cost cards (PR #656). Object-shape mocks replaced with computed `CostsData` / `ChannelCosts` shapes.

## Pages wired
| Page | Backing |
|---|---|
| `/admin/costs` | MTD + last-month + projected-EOM from sdk_usage_log + vendor_usage_log. AI agent_type prefixes mapped to UI categories (comprehend/analyse/identify → content; reply/dm_verify → reply; cmo/smart_prompt → cmo). Channel vendor IDs mapped to channel names. Divide-by-zero guards for pre-revenue. |
| `/admin/costs/channels` | vendor_usage_log GROUP BY vendor + per-client_id (joined with clients for display name). 5 channel defs (Email/SMS/LinkedIn/Voice/Mail) with provider + budget. \"Sent\" counts default 0 — vendor_usage_log doesn't track per-channel send counts (deferred to activities-table follow-up). |

## Defensive empty defaults
`EMPTY_COSTS` + `EMPTY_CHANNEL_COSTS` render zeros + structure-preserving placeholders so existing UI templates work pre-revenue. No conditional rendering changes.

## Verification
\`\`\`
$ pnpm tsc --noEmit  → exit 0
\`\`\`

## Cumulative Tier A sequence
- PR #663 (merged): leads + replies + settings/users
- PR #665 (open): campaigns + clients/[id]
- This PR: costs + costs/channels

**Total: 7 of 7 Tier A pages wired across 3 PRs.**

## Test plan
- [x] TS strict-check clean
- [x] Existing UI templates unchanged (drop-in data-source swap)
- [x] Divide-by-zero + null-vendor guards added
- [x] Branched off latest main (post-#663 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)