### PR TITLE
[AIDEN] feat(admin/ops): 30s auto-refresh + last-refreshed indicator

### DIFF
--- a/frontend/app/admin/ops/AutoRefresh.tsx
+++ b/frontend/app/admin/ops/AutoRefresh.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+/**
+ * FILE: frontend/app/admin/ops/AutoRefresh.tsx
+ * PURPOSE: Client-side wrapper that calls router.refresh() every N seconds
+ *          so the server-component ops panel re-fetches its Supabase data
+ *          without a page reload. Phase 4 follow-up to PR #656 / Max's
+ *          dispatch ("ops panel auto-refresh + per-vendor cost cards").
+ */
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+interface AutoRefreshProps {
+  /** Polling interval in milliseconds. Default 30s. */
+  intervalMs?: number;
+}
+
+export function AutoRefresh({ intervalMs = 30_000 }: AutoRefreshProps) {
+  const router = useRouter();
+  useEffect(() => {
+    const id = setInterval(() => router.refresh(), intervalMs);
+    return () => clearInterval(id);
+  }, [router, intervalMs]);
+  return null;
+}

--- a/frontend/app/admin/ops/page.tsx
+++ b/frontend/app/admin/ops/page.tsx
@@ -23,9 +23,11 @@ import {
   Calendar,
   Database,
   DollarSign,
+  RefreshCw,
   TrendingDown,
   Zap,
 } from "lucide-react";
+import { AutoRefresh } from "./AutoRefresh";
 
 interface CostBreakdownRow {
   group: string;
@@ -149,21 +151,34 @@ function formatAUD(amount: number): string {
 export default async function OpsPanelPage() {
   const data = await fetchOpsData();
 
+  const renderedAt = new Date().toLocaleTimeString("en-AU", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Operations</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Real-time view of cost, pipeline activity, and conversion. All
-          data live from Supabase. Pre-revenue means honest zeros where
-          there&apos;s no traffic yet.
-        </p>
-        {data.errors && (
-          <p className="text-xs text-red-600 mt-2">
-            Some queries failed: {data.errors}
+      <AutoRefresh intervalMs={30_000} />
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Operations</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Real-time view of cost, pipeline activity, and conversion. All
+            data live from Supabase. Pre-revenue means honest zeros where
+            there&apos;s no traffic yet.
           </p>
-        )}
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground whitespace-nowrap">
+          <RefreshCw className="w-3 h-3" />
+          <span>Auto-refresh 30s · last {renderedAt}</span>
+        </div>
       </div>
+      {data.errors && (
+        <p className="text-xs text-red-600">
+          Some queries failed: {data.errors}
+        </p>
+      )}
 
       {/* Top KPIs */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">


### PR DESCRIPTION
## Summary
Per Max's dispatch ordering after Tier A wiring: ops panel auto-refresh.

## Changes
1. **`frontend/app/admin/ops/AutoRefresh.tsx` (NEW, 24 LOC)** — tiny client component calling `router.refresh()` every N ms (default 30s). Mounted as sibling in the ops page so the surrounding server-component data fetch (sdk_usage_log + vendor_usage_log + BU + meetings + activities) re-runs without a full page reload. Cleanup via `clearInterval` on unmount.

2. **Last-refreshed indicator in ops header** — server-render timestamp in top-right with refresh icon + \"Auto-refresh 30s · last HH:MM:SS\" label. At-a-glance freshness confidence.

## Per-vendor cost cards
**Already covered by PR #656.** The existing \"Vendor cost today (by vendor)\" table populates from `vendor_usage_log GROUP BY vendor`. When E1 R3 PR 2/3 client wiring lands and vendors fire, that table populates without further frontend work. No additional surface needed.

## Verification
\`\`\`
$ pnpm tsc --noEmit  → exit 0
\`\`\`

## Test plan
- [x] TS strict-check clean
- [x] Server-component data flow preserved (data fetch still in `OpsPanelPage` server function)
- [x] Auto-refresh ticks via `router.refresh()` not full page reload
- [x] Cleanup on unmount via `clearInterval`
- [x] Branched off latest main (post-#664 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)