### PR TITLE
[AIDEN] feat(A2 Phase 4 Tier B PR 1): wire 3 compliance pages — schema unblock

### DIFF
--- a/frontend/app/admin/compliance/bounces/page.tsx
+++ b/frontend/app/admin/compliance/bounces/page.tsx
@@ -8,6 +8,8 @@
 "use client";
 
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { createBrowserClient } from "@/lib/supabase";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -45,23 +47,53 @@ interface ClientBounceRate {
   spamComplaints: number;
 }
 
-// Mock data
-const mockBounces: BounceEntry[] = [
-  { id: "1", email: "invalid@nowhere.com", client: "GrowthLab", type: "hard", reason: "Mailbox does not exist", timestamp: new Date(Date.now() - 1000 * 60 * 30) },
-  { id: "2", email: "full@mailbox.com", client: "LeadGen Pro", type: "soft", reason: "Mailbox full", timestamp: new Date(Date.now() - 1000 * 60 * 60) },
-  { id: "3", email: "spam@marked.com", client: "LeadGen Pro", type: "spam", reason: "Marked as spam by recipient", timestamp: new Date(Date.now() - 1000 * 60 * 90) },
-  { id: "4", email: "old@domain.net", client: "ScaleUp Co", type: "hard", reason: "Domain not found", timestamp: new Date(Date.now() - 1000 * 60 * 120) },
-  { id: "5", email: "temp@issue.com", client: "GrowthLab", type: "soft", reason: "Temporary delivery failure", timestamp: new Date(Date.now() - 1000 * 60 * 150) },
-  { id: "6", email: "blocked@company.com", client: "Enterprise Co", type: "hard", reason: "Recipient blocked sender", timestamp: new Date(Date.now() - 1000 * 60 * 180) },
-];
+// Phase 4 admin Tier B wiring (2026-05-10): live query against
+// `email_events` filtered to bounce/spam-shaped event_types, joined
+// with leads (for email) + clients (for client name).
+//
+// Pre-revenue: 0 emails sent → email_events likely empty → all stats
+// render 0 honestly. Per-client bounce rates aggregate is deferred —
+// requires sent-count from activities + bounce-count from email_events
+// in a single GROUP BY query, more involved than scope of this PR.
+// Empty array shows no rows, "0 clients at risk" stat is correct.
+type EventRow = {
+  id: string;
+  event_type: string;
+  event_at: string;
+  leads: { email: string | null } | null;
+  clients: { name: string | null } | null;
+};
 
-const mockClientRates: ClientBounceRate[] = [
-  { client: "GrowthLab", sent: 450, bounced: 32, bounceRate: 7.1, spamComplaints: 2 },
-  { client: "LeadGen Pro", sent: 890, bounced: 18, bounceRate: 2.0, spamComplaints: 3 },
-  { client: "ScaleUp Co", sent: 320, bounced: 5, bounceRate: 1.6, spamComplaints: 0 },
-  { client: "Enterprise Co", sent: 560, bounced: 8, bounceRate: 1.4, spamComplaints: 0 },
-  { client: "Marketing Plus", sent: 280, bounced: 3, bounceRate: 1.1, spamComplaints: 0 },
-];
+const BOUNCE_EVENT_TYPES = ["bounce", "hard_bounce", "soft_bounce", "complaint", "spam"];
+
+function eventTypeToBucket(et: string): "hard" | "soft" | "spam" {
+  if (et === "spam" || et === "complaint") return "spam";
+  if (et === "soft_bounce") return "soft";
+  return "hard"; // hard_bounce + generic "bounce" → hard
+}
+
+async function fetchBounces(): Promise<BounceEntry[]> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+  const { data, error } = await client
+    .from("email_events")
+    .select("id, event_type, event_at, leads(email), clients(name)")
+    .in("event_type", BOUNCE_EVENT_TYPES)
+    .order("event_at", { ascending: false })
+    .limit(200);
+  if (error) throw error;
+  return ((data ?? []) as EventRow[]).map((row) => ({
+    id: row.id,
+    email: row.leads?.email ?? "",
+    client: row.clients?.name ?? "",
+    type: eventTypeToBucket(row.event_type),
+    reason: row.event_type, // raw event_type as the reason for now
+    timestamp: new Date(row.event_at),
+  }));
+}
+
+const EMPTY_CLIENT_RATES: ClientBounceRate[] = [];
 
 const typeColors = {
   hard: "bg-amber-glow text-error border-amber/20",
@@ -79,6 +111,13 @@ function formatTimeAgo(date: Date): string {
 
 export default function AdminBouncesPage() {
   const [typeFilter, setTypeFilter] = useState("all");
+
+  const { data: mockBounces = [] } = useQuery({
+    queryKey: ["admin-bounces"],
+    queryFn: fetchBounces,
+    staleTime: 30 * 1000,
+  });
+  const mockClientRates = EMPTY_CLIENT_RATES;
 
   const filteredBounces = mockBounces.filter(
     (bounce) => typeFilter === "all" || bounce.type === typeFilter

--- a/frontend/app/admin/compliance/page.tsx
+++ b/frontend/app/admin/compliance/page.tsx
@@ -8,7 +8,9 @@
 "use client";
 
 import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { createBrowserClient } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -20,22 +22,77 @@ import {
   CheckCircle,
 } from "lucide-react";
 
-// Mock data
-const mockCompliance = {
-  suppressionCount: 1247,
-  bounceRate: 2.3,
-  spamComplaints: 5,
-  dncrBlocks: 23,
-  lastAudit: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7),
-  status: "healthy" as const,
-  recentIssues: [
-    { type: "bounce", count: 12, client: "GrowthLab" },
-    { type: "spam", count: 2, client: "LeadGen Pro" },
-    { type: "dncr", count: 5, client: "ScaleUp Co" },
-  ],
+// Phase 4 admin Tier B wiring (2026-05-10): aggregates from
+// `email_suppression` + `email_events` (last 30d). bounceRate needs a
+// sent-count denominator from activities — deferred (pre-revenue 0
+// sent). dncrBlocks = 0 (voice channel; 0 calls fired). lastAudit
+// defaults to epoch (UI shows "—").
+type ComplianceData = {
+  suppressionCount: number;
+  bounceRate: number;
+  spamComplaints: number;
+  dncrBlocks: number;
+  lastAudit: Date;
+  status: "healthy" | "issues";
+  recentIssues: Array<{ type: string; count: number; client: string }>;
+};
+
+async function fetchCompliance(): Promise<ComplianceData> {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+  const [{ count: suppressionCount }, { data: events }] = await Promise.all([
+    client.from("email_suppression").select("*", { count: "exact", head: true }).is("deleted_at", null),
+    client
+      .from("email_events")
+      .select("event_type, clients(name)")
+      .in("event_type", ["bounce", "hard_bounce", "soft_bounce", "spam", "complaint"])
+      .gte("event_at", new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()),
+  ]);
+  const eventRows = (events ?? []) as Array<{ event_type: string; clients: { name: string | null } | null }>;
+  const totalBounceish = eventRows.length;
+  const spamComplaints = eventRows.filter((r) => r.event_type === "spam" || r.event_type === "complaint").length;
+  const grouped = new Map<string, number>();
+  for (const r of eventRows) {
+    const bucket = r.event_type === "spam" || r.event_type === "complaint" ? "spam" : "bounce";
+    const c = r.clients?.name ?? "Unknown";
+    const key = `${bucket}::${c}`;
+    grouped.set(key, (grouped.get(key) ?? 0) + 1);
+  }
+  const recentIssues = Array.from(grouped.entries())
+    .map(([key, count]) => {
+      const [type, c] = key.split("::");
+      return { type, count, client: c };
+    })
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+  return {
+    suppressionCount: suppressionCount ?? 0,
+    bounceRate: 0,
+    spamComplaints,
+    dncrBlocks: 0,
+    lastAudit: new Date(0),
+    status: totalBounceish > 50 ? "issues" : "healthy",
+    recentIssues,
+  };
+}
+
+const EMPTY_COMPLIANCE: ComplianceData = {
+  suppressionCount: 0,
+  bounceRate: 0,
+  spamComplaints: 0,
+  dncrBlocks: 0,
+  lastAudit: new Date(0),
+  status: "healthy",
+  recentIssues: [],
 };
 
 export default function AdminCompliancePage() {
+  const { data: mockCompliance = EMPTY_COMPLIANCE } = useQuery({
+    queryKey: ["admin-compliance"],
+    queryFn: fetchCompliance,
+    staleTime: 30 * 1000,
+  });
   const bounceStatus = mockCompliance.bounceRate < 2 ? "good" : mockCompliance.bounceRate < 5 ? "warning" : "critical";
 
   return (

--- a/frontend/app/admin/compliance/suppression/page.tsx
+++ b/frontend/app/admin/compliance/suppression/page.tsx
@@ -8,7 +8,9 @@
 "use client";
 
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Search, Plus, Upload, Trash2 } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -39,14 +41,41 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 
-// Mock data
-const mockSuppressionList = [
-  { id: "1", email: "spam@badactor.com", reason: "spam", source: "system", addedBy: "System", addedAt: new Date(Date.now() - 1000 * 60 * 60 * 24) },
-  { id: "2", email: "john@unsubscribed.com", reason: "unsubscribe", source: "LeadGen Pro", addedBy: "User Request", addedAt: new Date(Date.now() - 1000 * 60 * 60 * 48) },
-  { id: "3", email: "bounced@invalid.net", reason: "bounce", source: "GrowthLab", addedBy: "System", addedAt: new Date(Date.now() - 1000 * 60 * 60 * 72) },
-  { id: "4", email: "competitor@rival.com", reason: "manual", source: "Admin", addedBy: "dave@agency.com", addedAt: new Date(Date.now() - 1000 * 60 * 60 * 96) },
-  { id: "5", email: "noreply@company.com", reason: "manual", source: "Admin", addedBy: "dave@agency.com", addedAt: new Date(Date.now() - 1000 * 60 * 60 * 120) },
-];
+// Phase 4 admin Tier B wiring (2026-05-10): live query against
+// `email_suppression` table from PR #664. Schema:
+// id, email, client_id, reason, source, notes, created_at, deleted_at.
+// Mock had `addedBy` field — schema has no per-row author column today,
+// so we display `source` in its place (good enough until a created_by
+// column is added in a follow-up).
+type SuppressionRow = {
+  id: string;
+  email: string;
+  reason: string;
+  source: string;
+  notes: string | null;
+  created_at: string;
+};
+
+async function fetchSuppressionList() {
+  const sb = createBrowserClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = sb as any;
+  const { data, error } = await client
+    .from("email_suppression")
+    .select("id, email, reason, source, notes, created_at")
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false })
+    .limit(500);
+  if (error) throw error;
+  return ((data ?? []) as SuppressionRow[]).map((row) => ({
+    id: row.id,
+    email: row.email,
+    reason: row.reason,
+    source: row.source,
+    addedBy: row.notes ?? row.source,
+    addedAt: new Date(row.created_at),
+  }));
+}
 
 const reasonColors = {
   spam: "bg-amber-glow text-error border-amber/20",
@@ -69,6 +98,12 @@ export default function AdminSuppressionPage() {
   const [newEmail, setNewEmail] = useState("");
   const [newReason, setNewReason] = useState("manual");
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  const { data: mockSuppressionList = [] } = useQuery({
+    queryKey: ["admin-suppression"],
+    queryFn: fetchSuppressionList,
+    staleTime: 30 * 1000,
+  });
 
   const filteredList = mockSuppressionList.filter((item) => {
     const matchesSearch = item.email.toLowerCase().includes(search.toLowerCase());


### PR DESCRIPTION
## Summary
First Tier B batch following Elliot's PR #664 schema migrations (`email_suppression` / `system_errors` / `rate_limits`). Continues `useQuery + createBrowserClient` pattern from Tier A.

## Pages wired
| Page | Backing |
|---|---|
| `/admin/compliance/suppression` | `email_suppression` table query, filtered `deleted_at IS NULL`. Schema → UI mapping: `addedBy = notes ?? source` (no `created_by` column yet). |
| `/admin/compliance/bounces` | `email_events` filtered to bounce-shaped `event_type`s (bounce/hard_bounce/soft_bounce/spam/complaint), joined with leads + clients. `mockClientRates` aggregate deferred (needs sent-count from activities — more involved query). |
| `/admin/compliance` | Aggregates suppression count + 30d bounce/spam totals + per-client+type rollup for `recentIssues`. `bounceRate` and `dncrBlocks` default to 0 with rationale. Status flips to \"issues\" when `totalBounceish > 50`. |

## Pre-revenue empty-state expectations
`email_events` likely 0 rows (0 emails sent ever), `email_suppression` 0 rows (no opt-outs yet). All KPI cards render honest 0s; `recentIssues` table renders empty.

## Verification
\`\`\`
$ pnpm tsc --noEmit  → exit 0
\`\`\`

## Tier B sequence progress
- This PR: `/admin/compliance` + `/compliance/bounces` + `/compliance/suppression` (3 of 5)
- Remaining: `/admin/system/errors` + `/admin/system/rate-limits` (next PR)

## Test plan
- [x] TS strict-check clean
- [x] Existing filter UI + Add dialog preserved on suppression
- [x] event_type → bucket mapping (spam|complaint → spam, soft_bounce → soft, else → hard) covers all 5 schema event types
- [x] Branched off latest main (post-#664 schema merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)