### PR TITLE
[ELLIOT] fix(tests): triage 3 pre-existing vitest failures (provider-labels x3 + useLiveActivityFeed)

### DIFF
--- a/frontend/lib/__tests__/useLiveActivityFeed.test.tsx
+++ b/frontend/lib/__tests__/useLiveActivityFeed.test.tsx
@@ -20,25 +20,34 @@ import { ReactNode } from "react";
 
 // Mocked Supabase channel factory. Each test swaps in a channel with
 // controllable .subscribe() and .on() behaviour.
-const mockChannel = () => {
-  let onSubscribe: ((s: string) => void) | null = null;
-  const handlers: Array<(payload: unknown) => void> = [];
+//
+// vi.hoisted wrapper: vi.mock factories are hoisted to the top of the file
+// before any other top-level code runs, so any helper they reference must
+// also live inside a hoisted block. Without this, the factory captures
+// `mockChannel` before its declaration is reached and fails at module-init
+// time with "Cannot access 'mockChannel' before initialization".
+const { mockChannel } = vi.hoisted(() => {
+  const mockChannel = () => {
+    let onSubscribe: ((s: string) => void) | null = null;
+    const handlers: Array<(payload: unknown) => void> = [];
 
-  const channel = {
-    on: vi.fn((_event: string, _cfg: unknown, handler: (p: unknown) => void) => {
-      handlers.push(handler);
-      return channel;
-    }),
-    subscribe: vi.fn((cb: (s: string) => void) => {
-      onSubscribe = cb;
-      return channel;
-    }),
-    // Test helpers (not part of real supabase-js API)
-    _fire: (status: string) => onSubscribe?.(status),
-    _receive: (payload: unknown) => handlers.forEach((h) => h(payload)),
+    const channel = {
+      on: vi.fn((_event: string, _cfg: unknown, handler: (p: unknown) => void) => {
+        handlers.push(handler);
+        return channel;
+      }),
+      subscribe: vi.fn((cb: (s: string) => void) => {
+        onSubscribe = cb;
+        return channel;
+      }),
+      // Test helpers (not part of real supabase-js API)
+      _fire: (status: string) => onSubscribe?.(status),
+      _receive: (payload: unknown) => handlers.forEach((h) => h(payload)),
+    };
+    return channel;
   };
-  return channel;
-};
+  return { mockChannel };
+});
 
 vi.mock("@/lib/supabase", () => {
   const channel = mockChannel();
@@ -78,9 +87,12 @@ const wrapper = ({ children }: { children: ReactNode }) => {
 describe("useLiveActivityFeed", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers();
   });
   afterEach(() => vi.useRealTimers());
+  // Note: vi.useFakeTimers() is scoped per-test (only the 10s-timeout test
+  // needs it). Globally enabling fake timers breaks testing-library's
+  // waitFor() — its retry interval ticks against the timer source, so a
+  // wall-clock waitFor inside a fake-timers test hangs until test timeout.
 
   it("subscribes to 4 realtime tables on mount (cis_outreach_outcomes + replies + dm_meetings + client_suppression)", async () => {
     const { result } = renderHook(() => useLiveActivityFeed({ limit: 8 }), {
@@ -123,6 +135,7 @@ describe("useLiveActivityFeed", () => {
   });
 
   it("falls back to polling if subscribe does not settle within 10s", async () => {
+    vi.useFakeTimers();
     const { result } = renderHook(() => useLiveActivityFeed(), { wrapper });
     // Do NOT fire any status — let timeout fire
     await act(async () => {

--- a/frontend/lib/provider-labels.ts
+++ b/frontend/lib/provider-labels.ts
@@ -29,6 +29,8 @@ const CANONICAL_REPLACEMENTS: ReadonlyArray<readonly [RegExp, string]> = [
   // Voice AI providers
   [/\bElevenAgents\b/gi, "Voice AI"],
   [/\bElevenLabs?\s+Agents?\b/gi, "Voice AI"],
+  // Bare "ElevenLabs" without "Agent(s)" — defensive against truncated copy.
+  [/\bElevenLabs?\b/gi, "Voice AI"],
 
   // Email sending providers
   [/\bSalesforge\b/gi, "Email"],
@@ -39,6 +41,11 @@ const CANONICAL_REPLACEMENTS: ReadonlyArray<readonly [RegExp, string]> = [
   [/\bProspeo\b/gi, "Contact finder"],
   [/\bLeadmagic\b/gi, "Contact finder"],
   [/\bBright\s*Data\b/gi, "Profile data"],
+  [/\bProxycurl\b/gi, "Profile data"],
+
+  // SEO data providers — DataForSEO bare mention (the \bDFS\b above only
+  // catches the abbreviation; full vendor name needs its own pattern).
+  [/\bDataForSEO\b/gi, "Organic"],
 ];
 
 /**


### PR DESCRIPTION
## Summary
Per Max group dispatch — 3 pre-existing vitest failures carried all week. All green now: **48/48 tests pass** across both files.

## Failure 1: provider-labels.test.ts × 3
Failing tests: `never leaks raw name <X> in its own output` for X in `{ElevenLabs, DataForSEO, Proxycurl}`.

Root cause: `CANONICAL_REPLACEMENTS` was missing patterns for these vendor strings.
- `\bElevenLabs?\s+Agents?\b` only catches "ElevenLabs Agent" — not bare "ElevenLabs"
- `\bDFS\b` doesn't match the full "DataForSEO" name
- "Proxycurl" absent entirely

Fix: 3 new regex patterns added to `CANONICAL_REPLACEMENTS`:
| Pattern | Replacement |
|---|---|
| `/\bElevenLabs?\b/gi` | `'Voice AI'` (catches bare; existing Agent-suffix pattern still works for compounds) |
| `/\bProxycurl\b/gi` | `'Profile data'` |
| `/\bDataForSEO\b/gi` | `'Organic'` |

## Failure 2: useLiveActivityFeed.test.tsx × all 4 tests (entire file failed)
Two structural issues:

1. **`vi.mock` factory referenced top-level `mockChannel` function.** `vi.mock` factories are hoisted to the top of the file before any other code runs — the factory captured `mockChannel` before its declaration was reached, crashing at module-init with `Cannot access mockChannel before initialization`. **Fix:** wrap `mockChannel` in `vi.hoisted({...})` so it lives in the same hoisted scope as the factory.

2. **`vi.useFakeTimers()` in `beforeEach` broke testing-library's `waitFor()`** in the 3 SUBSCRIBED/INSERT/CHANNEL_ERROR tests. `waitFor`'s retry interval ticks against the timer source — globally fake-timers means `waitFor` never retries, so each test hung 5s until vitest killed it. **Fix:** scope `vi.useFakeTimers()` into only the one test that needs it (10s-timeout fallback).

## Verification — verbatim
```
$ node_modules/.bin/vitest run lib/__tests__/provider-labels.test.ts
Test Files  1 passed (1)
     Tests  44 passed (44)

$ node_modules/.bin/vitest run lib/__tests__/useLiveActivityFeed.test.tsx
Test Files  1 passed (1)
     Tests  4 passed (4)

$ node_modules/.bin/vitest run lib/__tests__/{provider-labels,useLiveActivityFeed}.test.*
Test Files  2 passed (2)
     Tests  48 passed (48)
```

## Defensive future-proofing
Both root causes documented as inline comments in the test file (`vi.hoisted` rationale + scoped fake-timers note) so future tests adopting the same pattern don't re-trip these landmines.

## Test plan
- [x] All 3 previously-failing provider-labels tests pass
- [x] All 4 useLiveActivityFeed tests pass (was 0 — file didn't even load)
- [x] Combined: 48/48 green
- [x] Branched off latest main (post-#667 E2E harness merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)