### PR TITLE
[AIDEN] feat(slack-migration P1): slack_relay + DUAL_POST mirror

### DIFF
--- a/scripts/aiden_slack_mirror.py
+++ b/scripts/aiden_slack_mirror.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""aiden_slack_mirror.py — DUAL_POST dispatch for AIDEN-SLACK-MIGRATION-001.
+
+Watches Aiden's TG outbox dir (/tmp/telegram-relay-aiden/outbox/) and
+mirrors each outgoing message to Slack via slack_relay.py. This is the
+"DUAL_POST" half of the dispatch layer: TG outbox writes continue to
+fire normally (Elliot's TG relay watcher handles them); this service
+posts a parallel copy to Slack.
+
+Cutover plan (post-smoke, separate dispatch): switch to SLACK_ONLY by
+disabling Aiden's TG outbox watcher OR by setting SLACK_ONLY=true and
+making this service write a sentinel that the TG watcher respects.
+
+Env:
+    DUAL_POST            (default false) — if "true", this service runs
+                          the mirror. If false, exits 0 immediately
+                          (smoke gate).
+    SLACK_BOT_TOKEN      (required when DUAL_POST=true)
+    SLACK_DEFAULT_CHANNEL (optional, default #execution)
+
+Revert path: `systemctl --user stop aiden-slack-mirror.service` or unset
+DUAL_POST in EnvironmentFile and restart.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+CALLSIGN = "aiden"
+OUTBOX = Path(f"/tmp/telegram-relay-{CALLSIGN}/outbox")
+PROCESSED_MARKER_DIR = Path(f"/tmp/aiden-slack-mirror-processed")
+SLACK_RELAY = Path(__file__).resolve().parent / "slack_relay.py"
+
+DUAL_POST = os.environ.get("DUAL_POST", "false").lower() == "true"
+POLL_INTERVAL = float(os.environ.get("MIRROR_POLL_SECONDS", "2"))
+
+
+def already_processed(filename: str) -> bool:
+    return (PROCESSED_MARKER_DIR / filename).exists()
+
+
+def mark_processed(filename: str) -> None:
+    (PROCESSED_MARKER_DIR / filename).touch()
+
+
+def post_to_slack(text: str) -> bool:
+    """Invoke slack_relay.py with the message body. Returns True on success."""
+    try:
+        result = subprocess.run(
+            ["python3", str(SLACK_RELAY), "-g", text],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            print(f"slack_relay failed: {result.stderr.strip()}", file=sys.stderr, flush=True)
+            return False
+        return True
+    except subprocess.TimeoutExpired:
+        print("slack_relay timeout", file=sys.stderr, flush=True)
+        return False
+
+
+def process_outbox_file(path: Path) -> None:
+    """Read a single outbox JSON file and mirror its text to Slack."""
+    if already_processed(path.name):
+        return
+    try:
+        payload = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"skip {path.name}: {e}", file=sys.stderr, flush=True)
+        mark_processed(path.name)  # avoid retry loop on malformed files
+        return
+    text = payload.get("text") or ""
+    if not text:
+        mark_processed(path.name)
+        return
+    if post_to_slack(text):
+        mark_processed(path.name)
+        print(f"mirrored {path.name} -> Slack", flush=True)
+
+
+def main() -> int:
+    if not DUAL_POST:
+        print("DUAL_POST=false — mirror service no-op, exiting", flush=True)
+        return 0
+    PROCESSED_MARKER_DIR.mkdir(parents=True, exist_ok=True)
+    OUTBOX.mkdir(parents=True, exist_ok=True)
+    print(f"DUAL_POST=true — watching {OUTBOX} every {POLL_INTERVAL}s", flush=True)
+    # On boot, mark all CURRENT outbox files as processed (don't replay history).
+    for existing in OUTBOX.glob("*.json"):
+        mark_processed(existing.name)
+    while True:
+        for path in sorted(OUTBOX.glob("*.json")):
+            process_outbox_file(path)
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""slack_relay.py — Aiden-bot Slack relay (AIDEN-SLACK-MIGRATION-001).
+
+Mirrors the `tg` interface so callsites that switch from `tg -g "..."` to
+`slack_relay.py -g "..."` get the same call shape.
+
+Usage:
+    slack_relay.py "message"              → post to #execution (default)
+    slack_relay.py -g "message"           → post to #execution (group)
+    slack_relay.py -c <channel_id> "..."  → post to specific channel ID
+    echo "message" | slack_relay.py       → read from stdin
+
+Reads from env:
+    SLACK_BOT_TOKEN          (required) — xoxb-... bot token
+    SLACK_BOT_USERNAME       (optional) — default "Aiden"
+    SLACK_DEFAULT_CHANNEL    (optional) — default channel ID for -g
+                              (defaults to #execution = C0B3QB0K1GQ)
+    CALLSIGN                 (optional) — prefix tag, default "aiden"
+
+Per AIDEN-SLACK-MIGRATION-001 constraints:
+    - Uses chat:write.customize scope for username override
+    - Flat posting (no threads)
+    - Callsign tag preserved: "[AIDEN] message"
+
+Failures exit non-zero with raw Slack API error on stderr — non-fatal for
+callers, but visible.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+CALLSIGN = os.environ.get("CALLSIGN", "aiden")
+CALLSIGN_TAG = f"[{CALLSIGN.upper()}]"
+BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
+USERNAME = os.environ.get("SLACK_BOT_USERNAME", CALLSIGN.capitalize())
+
+# Channel IDs (verified 2026-05-11 per AIDEN-SLACK-MIGRATION-001 dispatch)
+CHANNELS = {
+    "execution": "C0B3QB0K1GQ",
+    "ceo": "C0B2PM3TV0B",
+    "alerts": "C0B2EJU53EK",
+    "completed_directives": "C0B2U15PSEA",
+}
+DEFAULT_CHANNEL = os.environ.get("SLACK_DEFAULT_CHANNEL", CHANNELS["execution"])
+
+
+def parse_args(argv: list[str]) -> tuple[str, str]:
+    """Return (channel_id, message)."""
+    channel = DEFAULT_CHANNEL
+    parts: list[str] = []
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a in ("-g", "--group"):
+            channel = CHANNELS["execution"]
+        elif a in ("-c", "--channel"):
+            i += 1
+            if i >= len(argv):
+                print("ERROR: -c requires a channel id", file=sys.stderr)
+                sys.exit(2)
+            # Accept either channel ID (C...) or named channel
+            arg = argv[i]
+            channel = CHANNELS.get(arg.lstrip("#"), arg)
+        elif a in ("-d", "--dm"):
+            print("ERROR: -d (DM) not supported in Slack relay yet", file=sys.stderr)
+            sys.exit(2)
+        else:
+            parts.append(a)
+        i += 1
+    message = " ".join(parts) if parts else sys.stdin.read().strip()
+    if not message:
+        print("ERROR: no message provided", file=sys.stderr)
+        sys.exit(2)
+    return channel, message
+
+
+def post(channel: str, text: str) -> dict:
+    """POST to Slack chat.postMessage. Returns parsed response."""
+    if not BOT_TOKEN:
+        print("ERROR: SLACK_BOT_TOKEN not set", file=sys.stderr)
+        sys.exit(2)
+    if not text.startswith(CALLSIGN_TAG):
+        text = f"{CALLSIGN_TAG} {text}"
+    body = json.dumps({"channel": channel, "text": text, "username": USERNAME}).encode("utf-8")
+    req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {BOT_TOKEN}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    except urllib.error.URLError as e:
+        print(f"ERROR: network failure: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> int:
+    channel, message = parse_args(sys.argv[1:])
+    result = post(channel, message)
+    if not result.get("ok"):
+        print(f"ERROR: Slack rejected: {result}", file=sys.stderr)
+        return 1
+    ts = result.get("ts", "")
+    ch = result.get("channel", channel)
+    print(f"→ {CALLSIGN_TAG} sent to Slack #{ch} (ts {ts})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

AIDEN-SLACK-MIGRATION-001 Phase 1 (additive — no cutover). Adds the Slack-side dispatch layer that mirrors my outbound TG messages to Slack. TG relay untouched.

- `scripts/slack_relay.py` — Slack equivalent of `tg`. Mirrors `-g/-c` arg shape, posts via `chat.postMessage` with `chat:write.customize` for username override `Aiden`. Channel ID map for execution / ceo / alerts / completed_directives. `[AIDEN]` callsign tag preserved.
- `scripts/aiden_slack_mirror.py` — polling watcher on `/tmp/telegram-relay-aiden/outbox/`. Gated on `DUAL_POST=true`. On boot marks existing outbox files as processed (no replay). Invokes `slack_relay.py` per new file.

## Smoke evidence (Rule 3 — verbatim)

`slack_relay.py` live post to `#execution`:
```
→ [AIDEN] sent to Slack #C0B3QB0K1GQ (ts 1778459538.265749)
```

`aiden_slack_mirror.py` end-to-end (DUAL_POST=true):
```
DUAL_POST=true — watching /tmp/telegram-relay-aiden/outbox every 2.0s
mirrored smoke_1778459683.json -> Slack
```

Processed marker confirmed: `/tmp/aiden-slack-mirror-processed/smoke_1778459683.json`.

`DUAL_POST=false` gate:
```
DUAL_POST=false — mirror service no-op, exiting
```

## Out-of-repo artefacts

`~/.config/systemd/user/aiden-slack-mirror.service` — user-service unit with `EnvironmentFile=/home/elliotbot/.config/agency-os/.env` and `Environment=DUAL_POST=true`. Enabled (symlinked into default.target.wants) but **NOT started** — awaiting Dave approval to begin the 24h dual-post smoke.

## Does NOT touch

- Elliot's `tg` relay
- `chat_bot` router
- Enforcer code (separate spec PR #672)
- Max's services
- Any callsite still using `tg -g`

## Revert

```
systemctl --user stop aiden-slack-mirror.service
systemctl --user disable aiden-slack-mirror.service
```

Or unset `DUAL_POST` in the unit and restart — the service self-noop's.

## Sequencing

Per Max's directive: this PR lands → 24h DUAL_POST smoke → cutover plan (SLACK_ONLY) → Elliot's ENFORCER-BUILD-001 (PR #672 spec) unblocks.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` syntax check both files
- [x] `slack_relay.py` live post to #execution returns `ok=true` with ts
- [x] `aiden_slack_mirror.py` consumes new outbox file, posts to Slack, marks processed
- [x] `DUAL_POST=false` exits with no-op log
- [x] `systemctl --user daemon-reload && enable` symlinks cleanly
- [ ] **Dave approval to start** `systemctl --user start aiden-slack-mirror.service` for 24h smoke
- [ ] Dual approval (Elliot + Aiden) before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)