### PR TITLE
[AIDEN] feat(slack-migration P3.5): Slack inbound listener

### DIFF
--- a/scripts/aiden_slack_listener.py
+++ b/scripts/aiden_slack_listener.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""aiden_slack_listener.py — Slack inbound bridge for AIDEN callsign.
+
+Polls Slack `#execution` `conversations.history` every 20s, filters messages
+the AIDEN agent should see, writes them to /tmp/telegram-relay-aiden/inbox/
+in the JSON shape relay_watcher.sh expects so tmux injection still works.
+
+Filter logic (per AIDEN-SLACK-MIGRATION-001 step 3.5 directive):
+    - Skip messages whose text starts with `[AIDEN]` (self-loop guard;
+      shared bot_id means we can't distinguish self vs Elliot via bot_id)
+    - Keep messages matching callsign tokens: aiden, all, both, team
+      (case-insensitive, substring)
+    - Keep messages from non-bot users (Dave/Max-as-human posts)
+    - Keep messages tagged `[ELLIOT]`, `[MAX]`, `[ENFORCER]`, `[DAVE]`
+
+State cursor in /tmp/aiden-slack-listener-state (epoch float of last seen ts).
+On first run, starts from "now" — does not replay history.
+
+Env:
+    SLACK_BOT_TOKEN          (required)
+    SLACK_LISTENER_CHANNEL   (optional, default #execution = C0B3QB0K1GQ)
+    LISTENER_POLL_SECONDS    (optional, default 20)
+
+Required OAuth scopes (per Elliot's PR #675 finding 2026-05-11):
+    channels:history (public) OR groups:history (private). Without them,
+    conversations.history returns missing_scope error.
+
+Revert: systemctl --user stop aiden-slack-listener.service.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+CHANNEL = os.environ.get("SLACK_LISTENER_CHANNEL", "C0B3QB0K1GQ")
+POLL = float(os.environ.get("LISTENER_POLL_SECONDS", "20"))
+TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
+INBOX = Path("/tmp/telegram-relay-aiden/inbox")
+STATE_FILE = Path("/tmp/aiden-slack-listener-state")
+GROUP_CHAT_ID = -1003926592540  # preserved so relay_watcher's last_chat_id still works for any legacy tg reply paths
+
+CALLSIGN_TRIGGERS = ("aiden", "all", "both", "team")
+KEEP_TAGS = ("[ELLIOT]", "[MAX]", "[ENFORCER]", "[DAVE]")
+SELF_TAG = "[AIDEN]"
+
+
+def slack_get(method: str, params: dict) -> dict:
+    url = f"https://slack.com/api/{method}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {TOKEN}"})
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read())
+
+
+def load_cursor() -> str:
+    if STATE_FILE.exists():
+        return STATE_FILE.read_text().strip()
+    cursor = f"{time.time():.6f}"
+    STATE_FILE.write_text(cursor)
+    return cursor
+
+
+def save_cursor(ts: str) -> None:
+    STATE_FILE.write_text(ts)
+
+
+def should_keep(text: str, has_bot_id: bool) -> bool:
+    if text.startswith(SELF_TAG):
+        return False
+    low = text.lower()
+    if any(t.lower() in low for t in CALLSIGN_TRIGGERS):
+        return True
+    if any(tag in text for tag in KEEP_TAGS):
+        return True
+    return not has_bot_id
+
+
+def sender_from(msg: dict) -> str:
+    text = msg.get("text", "")
+    for tag in KEEP_TAGS:
+        if tag in text:
+            return tag.strip("[]").lower() + "bot"
+    if msg.get("bot_id"):
+        return "slackbot"
+    return msg.get("user", "human") or "human"
+
+
+def write_inbox(text: str, sender: str) -> None:
+    INBOX.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "type": "text",
+        "chat_id": GROUP_CHAT_ID,
+        "text": text,
+        "sender": sender,
+    }
+    fname = f"slack_{int(time.time())}_{uuid.uuid4().hex[:8]}.json"
+    (INBOX / fname).write_text(json.dumps(payload))
+
+
+def poll_once(cursor: str) -> str:
+    try:
+        result = slack_get("conversations.history", {"channel": CHANNEL, "oldest": cursor, "inclusive": "false", "limit": "100"})
+    except urllib.error.URLError as e:
+        print(f"slack history fetch failed: {e}", file=sys.stderr, flush=True)
+        return cursor
+    if not result.get("ok"):
+        print(f"slack rejected: {result}", file=sys.stderr, flush=True)
+        return cursor
+    messages = result.get("messages", [])
+    if not messages:
+        return cursor
+    messages.sort(key=lambda m: float(m.get("ts", "0")))
+    new_cursor = cursor
+    for msg in messages:
+        text = msg.get("text", "")
+        if not text:
+            continue
+        has_bot = bool(msg.get("bot_id"))
+        if should_keep(text, has_bot):
+            write_inbox(text, sender_from(msg))
+            print(f"inbox <- {msg.get('ts')} ({len(text)}ch)", flush=True)
+        new_cursor = msg.get("ts", new_cursor)
+    return new_cursor
+
+
+def main() -> int:
+    if not TOKEN:
+        print("ERROR: SLACK_BOT_TOKEN not set", file=sys.stderr)
+        return 2
+    cursor = load_cursor()
+    print(f"aiden_slack_listener: channel={CHANNEL} poll={POLL}s cursor={cursor}", flush=True)
+    while True:
+        cursor = poll_once(cursor)
+        save_cursor(cursor)
+        time.sleep(POLL)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/aiden_slack_listener.py
+++ b/scripts/aiden_slack_listener.py
@@ -40,7 +40,7 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
-CHANNELS = [c.strip() for c in os.environ.get("SLACK_LISTENER_CHANNELS", "C0B3QB0K1GQ,C0B2PM3TV0B").split(",") if c.strip()]
+CHANNELS = [c.strip() for c in os.environ.get("SLACK_LISTENER_CHANNELS", "C0B3QB0K1GQ").split(",") if c.strip()]
 POLL = float(os.environ.get("LISTENER_POLL_SECONDS", "20"))
 TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 INBOX = Path("/tmp/telegram-relay-aiden/inbox")

--- a/scripts/aiden_slack_listener.py
+++ b/scripts/aiden_slack_listener.py
@@ -40,11 +40,11 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
-CHANNEL = os.environ.get("SLACK_LISTENER_CHANNEL", "C0B3QB0K1GQ")
+CHANNELS = [c.strip() for c in os.environ.get("SLACK_LISTENER_CHANNELS", "C0B3QB0K1GQ,C0B2PM3TV0B").split(",") if c.strip()]
 POLL = float(os.environ.get("LISTENER_POLL_SECONDS", "20"))
 TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 INBOX = Path("/tmp/telegram-relay-aiden/inbox")
-STATE_FILE = Path("/tmp/aiden-slack-listener-state")
+STATE_DIR = Path("/tmp/aiden-slack-listener-state.d")
 GROUP_CHAT_ID = -1003926592540  # preserved so relay_watcher's last_chat_id still works for any legacy tg reply paths
 
 CALLSIGN_TRIGGERS = ("aiden", "all", "both", "team")
@@ -59,16 +59,22 @@ def slack_get(method: str, params: dict) -> dict:
         return json.loads(r.read())
 
 
-def load_cursor() -> str:
-    if STATE_FILE.exists():
-        return STATE_FILE.read_text().strip()
+def _state_path(channel: str) -> Path:
+    return STATE_DIR / f"{channel}.cursor"
+
+
+def load_cursor(channel: str) -> str:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    p = _state_path(channel)
+    if p.exists():
+        return p.read_text().strip()
     cursor = f"{time.time():.6f}"
-    STATE_FILE.write_text(cursor)
+    p.write_text(cursor)
     return cursor
 
 
-def save_cursor(ts: str) -> None:
-    STATE_FILE.write_text(ts)
+def save_cursor(channel: str, ts: str) -> None:
+    _state_path(channel).write_text(ts)
 
 
 def should_keep(text: str, has_bot_id: bool) -> bool:
@@ -104,14 +110,14 @@ def write_inbox(text: str, sender: str) -> None:
     (INBOX / fname).write_text(json.dumps(payload))
 
 
-def poll_once(cursor: str) -> str:
+def poll_once(channel: str, cursor: str) -> str:
     try:
-        result = slack_get("conversations.history", {"channel": CHANNEL, "oldest": cursor, "inclusive": "false", "limit": "100"})
+        result = slack_get("conversations.history", {"channel": channel, "oldest": cursor, "inclusive": "false", "limit": "100"})
     except urllib.error.URLError as e:
-        print(f"slack history fetch failed: {e}", file=sys.stderr, flush=True)
+        print(f"slack history fetch failed ({channel}): {e}", file=sys.stderr, flush=True)
         return cursor
     if not result.get("ok"):
-        print(f"slack rejected: {result}", file=sys.stderr, flush=True)
+        print(f"slack rejected ({channel}): {result}", file=sys.stderr, flush=True)
         return cursor
     messages = result.get("messages", [])
     if not messages:
@@ -125,7 +131,7 @@ def poll_once(cursor: str) -> str:
         has_bot = bool(msg.get("bot_id"))
         if should_keep(text, has_bot):
             write_inbox(text, sender_from(msg))
-            print(f"inbox <- {msg.get('ts')} ({len(text)}ch)", flush=True)
+            print(f"inbox <- {channel} {msg.get('ts')} ({len(text)}ch)", flush=True)
         new_cursor = msg.get("ts", new_cursor)
     return new_cursor
 
@@ -134,11 +140,12 @@ def main() -> int:
     if not TOKEN:
         print("ERROR: SLACK_BOT_TOKEN not set", file=sys.stderr)
         return 2
-    cursor = load_cursor()
-    print(f"aiden_slack_listener: channel={CHANNEL} poll={POLL}s cursor={cursor}", flush=True)
+    cursors = {ch: load_cursor(ch) for ch in CHANNELS}
+    print(f"aiden_slack_listener: channels={CHANNELS} poll={POLL}s", flush=True)
     while True:
-        cursor = poll_once(cursor)
-        save_cursor(cursor)
+        for ch in CHANNELS:
+            cursors[ch] = poll_once(ch, cursors[ch])
+            save_cursor(ch, cursors[ch])
         time.sleep(POLL)
 
 


### PR DESCRIPTION
## Summary

AIDEN-SLACK-MIGRATION-001 step 3.5 — Slack inbound counterpart to the `slack_relay.py` outbound shipped in PR #673. Mirrors Elliot's PR-#675 approach for ELLIOT callsign.

- `scripts/aiden_slack_listener.py` — poll `#execution` `conversations.history` every 20s, callsign filter, write matched messages to `/tmp/telegram-relay-aiden/inbox/` in the JSON shape `relay_watcher.sh` already consumes. tmux injection path unchanged.
- Cursor in `/tmp/aiden-slack-listener-state`; first run starts from "now" (no history replay).
- Self-loop guard: skip text starting with `[AIDEN]` (shared bot_id means we can't filter via `bot_id`).

## Filter rules

| Match | Action |
|---|---|
| text starts with `[AIDEN]` | drop (self-loop) |
| contains `aiden` / `all` / `both` / `team` (case-insensitive) | keep |
| starts with `[ELLIOT]` / `[MAX]` / `[ENFORCER]` / `[DAVE]` | keep |
| from non-bot user (Dave human) | keep |
| everything else | drop |

## Blocker — Slack OAuth scope (verbatim probe)

Same finding as Elliot's PR #675:

```
$ curl 'https://slack.com/api/conversations.history?channel=C0B3QB0K1GQ&limit=1' \\
    -H "Authorization: Bearer $SLACK_BOT_TOKEN"
{
  "ok": false,
  "error": "missing_scope",
  "needed": "channels:history,groups:history,mpim:history,im:history",
  "provided": "chat:write,chat:write.customize,channels:read,groups:read"
}
```

## Unblock action (Dave)

api.slack.com/apps → Agency OS app → OAuth & Permissions → add `channels:history` to Bot Token Scopes → Reinstall to Workspace. After scope lands, listener works without code change.

## Out-of-repo artefact

`~/.config/systemd/user/aiden-slack-listener.service` — user-service unit; `daemon-reload`'d but NOT started (gated on scope).

## Verification once scope lands

1. `systemctl --user enable --now aiden-slack-listener.service`
2. Dave posts a test message to `#execution` mentioning "aiden"
3. Verify within 30s: `/tmp/telegram-relay-aiden/inbox/slack_*.json` appears
4. `aiden-relay-watcher.service` (still active) picks it up, injects to my tmux

## Revert

```
systemctl --user stop aiden-slack-listener.service
```

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` syntax check
- [x] Scope probe confirms `missing_scope` (mirrors Elliot's finding)
- [x] systemd unit reloads cleanly
- [ ] Dave re-OAuth with `channels:history` scope
- [ ] Service starts + processes Dave test post within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)