### PR TITLE
[ELLIOT] feat(slack): ENFORCER-BUILD-001 — Slack enforcer (Socket Mode) + shared rules module

### DIFF
--- a/infra/cron/agency-os-enforcer-slack-bot.service
+++ b/infra/cron/agency-os-enforcer-slack-bot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Agency OS — Slack Enforcer Bot (ENFORCER-BUILD-001, Socket Mode)
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+ExecStart=/home/elliotbot/clawd/venv/bin/python3 -m src.slack_bot.enforcer_bot
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/src/bot_common/__init__.py
+++ b/src/bot_common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared constants + helpers for both TG and Slack enforcer bots."""

--- a/src/bot_common/enforcer_rules.py
+++ b/src/bot_common/enforcer_rules.py
@@ -1,0 +1,129 @@
+"""enforcer_rules.py — single source of truth for the 9 enforcer rules.
+
+Both src/telegram_bot/enforcer_bot.py (TG, archive) and src/slack_bot/enforcer_bot.py
+(Slack, live) import RULES_PROMPT + TRIGGER_PATTERNS + FLAG_COOLDOWN_SECONDS +
+MAX_WINDOW + CHECK_MODEL from here. Drift between the two bots during the dual-post
+phase is the highest-impact risk in the ENFORCER-REDESIGN-001 spec — this module
+prevents it.
+
+Per PR #672 ratified spec § 8 + Phase A. RULES_PROMPT preserved verbatim from
+src/telegram_bot/enforcer_bot.py as of 2026-05-11.
+
+Edit policy:
+- Rule logic edits MUST land here (not in either bot's file).
+- New rule (R10+) requires: prompt edit + TRIGGER_PATTERNS update + tests.
+- Decision-point #4 (post-PR #672 ratification): R3 + R6 violations route to
+  BOTH #execution AND #alerts; all other rules to #alerts only. Routing is
+  the bot's responsibility, not this module's.
+"""
+
+from __future__ import annotations
+
+CHECK_MODEL = "gpt-4o-mini"
+MAX_WINDOW = 20
+FLAG_COOLDOWN_SECONDS = 300
+
+# Per PR #672 decision #2: R3 (completion-without-evidence) + R6 (save-without-proof)
+# route to both #alerts AND #execution. Other rules to #alerts only.
+HIGH_SEVERITY_RULES: frozenset[int] = frozenset({3, 6})
+
+
+TRIGGER_PATTERNS: tuple[str, ...] = (
+    "dave —",
+    "dave,",
+    "your call",
+    "here's the plan",
+    "here's what",
+    "commit",
+    "pushed",
+    "pr #",
+    "merged",
+    "deployed",
+    "triggered",
+    "complete",
+    "done",
+    "all stores written",
+    "4-store",
+    "git push origin main",
+    "memory_listener.py",
+    "chat_bot.py",
+    "store.py",
+    "listener_discernment.py",
+    "claude.md",
+    "state saved",
+    "ceo_memory updated",
+    "manual updated",
+    "drive mirror",
+    "daily_log written",
+    "stores written",
+    "store save complete",
+    "session closed",
+    "[atlas]",
+    "[orion]",
+    "[final concur",
+    "final concur:elliot",
+    "final concur:aiden",
+)
+
+
+def should_check(text: str) -> bool:
+    """Pre-filter: only check messages matching trigger patterns."""
+    lower = text.lower()
+    return any(p in lower for p in TRIGGER_PATTERNS)
+
+
+RULES_PROMPT = """You are a governance enforcement bot for a multi-agent development team.
+
+You monitor group chat messages between two AI agents (Elliot and Aiden) and their human manager (Dave).
+
+CHECK these 7 rules against the CURRENT MESSAGE in context of the RECENT MESSAGES:
+
+Rule 1 — CONCUR-BEFORE-SUMMARY: If the current message is a bot addressing Dave with a summary, recommendation, or decision (look for "Dave —", "Dave,", "your call", "here's the plan", "here's what"), check if the OTHER bot posted explicit concurrence ("concur", "concur confirmed", "CONCUR") in recent messages OR in GOVERNANCE_EVENTS (last_concur_elliot / last_concur_aiden) for the same topic. Missing concurrence = VIOLATION. NOTE: /stage0 gating is handled externally in code — evaluate Rule 1 on its merits and report if concurrence is missing.
+
+Rule 2 — STEP-0-BEFORE-EXECUTION: If the current message shows execution starting (mentions committing, pushing, deploying, triggering flows, creating PRs), check whether EITHER of the following governance signals exists in recent_messages or governance_events for the same topic:
+  (a) a Dave-directed Step 0 / RESTATE post, OR
+  (b) a dual peer-Step-0 pair — BOTH `[FINAL CONCUR:ELLIOT]` AND `[FINAL CONCUR:AIDEN]` tags present in recent_messages on the same topic (dual-concur governance ratified 2026-04-22).
+Having EITHER signal = PASS. Missing BOTH = VIOLATION.
+EXCEPTIONS (always PASS, no Step 0 required):
+  (i)   PR merge on explicit CEO instruction (Dave posts "merge N" or "merge N + continue")
+  (ii)  Rebase performed as peer-review fix (continuation of original dispatch, not new directive)
+  (iii) Orchestrator tagging peer replies (acknowledgement, not execution)
+  (iv)  CEO removed Step 0 confirmation gate ("no more approvals" or "only merge approvals") — bots post RESTATE for discipline but execution proceeds without Dave-pause. Only PR-merge actions require explicit Dave approval.
+  (v)   Task approved via [PROPOSE:<callsign>] + Dave "approve" — execution starts immediately after approval without separate Step 0 post.
+
+Rule 3 — COMPLETION-REQUIRES-VERIFICATION: If the current message claims task completion ("complete", "done", "all stores written", "4-store save complete"), check if verification evidence was posted (terminal output, SQL results, test output, commit hashes). Claim without evidence = VIOLATION.
+EXCEPTIONS (always PASS, not a completion claim):
+  (i)   Messages starting with '[GOVERNANCE] Gatekeeper DENY' or '[GATEKEEPER-DENY:' — these are automated gate outputs (the opposite of completion claims), not bot assertions of done.
+  (ii)  Messages reporting a Gatekeeper allow/deny verdict as test evidence — the verdict IS the verification output.
+  (iii) Messages containing 'observe-only' or 'synthetic test' — these are test/verify actions, not real completion claims.
+
+Rule 4 — NO-UNREVIEWED-MAIN-PUSH: If the current message mentions pushing directly to main without mentioning PR review or peer approval, flag as WARNING (not hard violation).
+
+Rule 5 — SHARED-FILE-CLAIM: If the current message mentions editing memory_listener.py, chat_bot.py, store.py, listener_discernment.py, or any CLAUDE.md file, check if "[CLAIM:" was posted. Missing claim = VIOLATION.
+
+Rule 6 — SAVE-CLAIM-REQUIRES-PROOF: If the current message claims a save was completed ("state saved", "4-store save complete", "ceo_memory updated", "MANUAL updated", "Drive mirrored", "daily_log written", "stores written"), check that the message includes SPECIFIC EVIDENCE for EACH store claimed. Evidence means: commit hashes for MANUAL, SQL confirmation for ceo_memory, byte count or success message for Drive mirror, query result for daily_log. A bot saying "all stores written ✓" without showing the actual outputs for each store = VIOLATION. The claim must be backed by verifiable proof in recent messages, not just checkmarks.
+
+Rule 8 — DISPATCH-COORDINATION: If the current message shows a clone dispatch being injected (mentions "dispatched", "injected", "tmux paste", "ATLAS dispatched", "ORION dispatched", or dispatch JSON), check whether a [DISPATCH-PROPOSAL:<callsign>] was posted in recent_messages AND the peer posted [CONCUR] on that proposal BEFORE the dispatch. Dispatching without prior proposal + peer concur = VIOLATION. Exception: if only one bot is active (peer offline/reset), solo dispatch with proposal posted is sufficient.
+
+Rule 9 — DIRECTIVE-INITIATIVE: If the current message is from a bot (ELLIOT or AIDEN) and ends with open-ended agenda-setting phrases directed at Dave — such as "standing by for directive", "ready for next directive", "what's next", "awaiting your call", "what would you like", or any question asking Dave to SET the agenda rather than APPROVE a proposal — flag as VIOLATION. Bots must propose specific next work items using [PROPOSE:<callsign>] format, not ask Dave what to do. Exception: [SESSION-WRAP:<callsign>] is allowed for genuine end-of-session. First violation = warning, second = governance debt log.
+
+Rule 7 — CLONE-DIRECT-GROUP-POST: If the current message's bot/sender prefix is a CLONE callsign (ATLAS, ORION, or any `[<callsign>]` tag other than ELLIOT, AIDEN, DAVE, SCOUT, ENFORCER), flag as VIOLATION — clones are prohibited from posting to group per C3 Prime-Only Clone Channel. Clone output must go only to parent inbox via relay-watcher push. Parent surfaces clone artefacts to group via `[CONSUMED:<parent>] <path> + verbatim excerpt` post. Seeing a clone callsign in group means either (a) the clone violated C3 directly, or (b) a parent wrote under the wrong prefix — either way, flag.
+
+RESPOND WITH ONLY THIS JSON:
+{
+  "violation": true/false,
+  "rule_number": N or null,
+  "rule_name": "name" or null,
+  "detail": "specific issue" or null,
+  "should_have": "what should have happened" or null
+}
+
+If NO violation, return {"violation": false, "rule_number": null, "rule_name": null, "detail": null, "should_have": null}
+
+You also have access to GOVERNANCE_EVENTS — a state tracker of the most recent concur, Step 0, and /stage0 events. Use these to check rules even when the events fall outside the recent_messages window.
+
+IMPORTANT: Flag violations when detected. Err on the side of flagging — missed violations are worse than false alarms.
+Do NOT flag Dave's messages — he is not subject to bot rules.
+Do NOT flag messages that are clearly part of peer discussion (not Dave-facing).
+Messages labeled as 'test' or 'deliberate violation' are STILL subject to rule evaluation — flag them the same as real violations.
+"""

--- a/src/slack_bot/__init__.py
+++ b/src/slack_bot/__init__.py
@@ -1,0 +1,1 @@
+"""Slack-side bots (enforcer + future relays)."""

--- a/src/slack_bot/enforcer_bot.py
+++ b/src/slack_bot/enforcer_bot.py
@@ -1,0 +1,224 @@
+"""Slack enforcer bot — Socket Mode entrypoint (ENFORCER-BUILD-001).
+
+Mirrors src/telegram_bot/enforcer_bot.py shape but reads from Slack via
+slack_sdk.socket_mode.SocketModeClient instead of polling a filesystem inbox.
+Same gpt-4o-mini rule check, same cooldown, same interjection write-to-bot-
+inboxes for tmux visibility.
+
+Per PR #672 ratified spec + 4 decision points (all YES):
+  1. RULES_PROMPT etc. extracted to src/bot_common/enforcer_rules.py (DONE Phase A)
+  2. R3 + R6 violations route to BOTH #execution AND #alerts
+  3. Bot username 'Enforcer' + :rotating_light: icon
+  4. Phase C smoke includes cross-device deliberate-violation test
+
+Env (read from /home/elliotbot/.config/agency-os/.env):
+  SLACK_ENFORCER_BOT_TOKEN  — xoxb-... bot token (chat:write + chat:write.customize)
+  SLACK_ENFORCER_APP_TOKEN  — xapp-1-... Socket Mode app-level token (connections:write)
+  OPENAI_API_KEY            — gpt-4o-mini
+  SLACK_LISTEN_CHANNEL      — default #execution C0B3QB0K1GQ
+  SLACK_ALERTS_CHANNEL      — default #alerts C0B2EJU53EK
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from collections import deque
+from datetime import datetime, timezone
+
+import httpx
+from slack_sdk.socket_mode import SocketModeClient
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.socket_mode.response import SocketModeResponse
+from slack_sdk.web import WebClient
+
+from src.bot_common.enforcer_rules import (
+    CHECK_MODEL,
+    FLAG_COOLDOWN_SECONDS,
+    HIGH_SEVERITY_RULES,
+    MAX_WINDOW,
+    RULES_PROMPT,
+    should_check,
+)
+from src.slack_bot.enforcer_callsign_map import SHARED_BOT_ID, attribute
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("enforcer-slack")
+
+BOT_TOKEN = os.environ.get("SLACK_ENFORCER_BOT_TOKEN") or os.environ.get("SLACK_BOT_TOKEN", "")
+APP_TOKEN = os.environ.get("SLACK_ENFORCER_APP_TOKEN", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+LISTEN_CHANNEL = os.environ.get("SLACK_LISTEN_CHANNEL", "C0B3QB0K1GQ")
+ALERTS_CHANNEL = os.environ.get("SLACK_ALERTS_CHANNEL", "C0B2EJU53EK")
+ENFORCER_USERNAME = "Enforcer"
+ENFORCER_ICON = ":rotating_light:"
+
+# In-process state (lost on restart; reconstitutes from next 20 messages)
+message_window: deque = deque(maxlen=MAX_WINDOW)
+last_flag_times: dict[str, float] = {}
+governance_events: dict = {}
+
+# Bot inboxes — same write pattern as TG enforcer; tmux watchers consume
+BOT_INBOXES = (
+    "/tmp/telegram-relay-elliot/inbox",
+    "/tmp/telegram-relay-aiden/inbox",
+    "/tmp/telegram-relay-max/inbox",
+)
+
+
+def check_with_llm(current_msg: str, recent_msgs: list[str]) -> dict | None:
+    """Synchronous gpt-4o-mini call. Returns {violation, rule_number, ...} or None on failure."""
+    if not OPENAI_API_KEY:
+        logger.warning("OPENAI_API_KEY not set — rule check disabled")
+        return None
+    user_content = json.dumps(
+        {
+            "current_message": current_msg,
+            "recent_messages": list(recent_msgs)[-MAX_WINDOW:],
+            "governance_events": governance_events,
+        },
+        ensure_ascii=False,
+    )
+    try:
+        with httpx.Client(timeout=15) as client:
+            resp = client.post(
+                "https://api.openai.com/v1/chat/completions",
+                headers={"Authorization": f"Bearer {OPENAI_API_KEY}", "Content-Type": "application/json"},
+                json={
+                    "model": CHECK_MODEL,
+                    "messages": [
+                        {"role": "system", "content": RULES_PROMPT},
+                        {"role": "user", "content": user_content},
+                    ],
+                    "temperature": 0.1,
+                    "max_tokens": 300,
+                },
+            )
+            resp.raise_for_status()
+            return json.loads(resp.json()["choices"][0]["message"]["content"])
+    except Exception as exc:
+        logger.warning("LLM check failed: %s", exc)
+        return None
+
+
+def write_bot_inboxes(text: str) -> None:
+    """Mirror enforcer interjection into each bot inbox (same JSON shape as TG)."""
+    import uuid
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    for inbox in BOT_INBOXES:
+        try:
+            os.makedirs(inbox, exist_ok=True)
+            fname = f"{ts}_{uuid.uuid4().hex[:8]}.json"
+            payload = {
+                "id": fname.replace(".json", ""),
+                "type": "text",
+                "text": f"[ENFORCER]: {text}",
+                "sender": "enforcer",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "surface": "slack",
+            }
+            with open(os.path.join(inbox, fname), "w") as f:
+                json.dump(payload, f)
+        except Exception as exc:
+            logger.warning("inbox write failed for %s: %s", inbox, exc)
+
+
+def post_interjection(web: WebClient, text: str, rule_num: int) -> None:
+    """Post enforcer interjection. R3+R6 → both #execution and #alerts; others → #alerts only."""
+    targets = [ALERTS_CHANNEL]
+    if rule_num in HIGH_SEVERITY_RULES:
+        targets.append(LISTEN_CHANNEL)
+    for ch in targets:
+        try:
+            web.chat_postMessage(channel=ch, text=text, username=ENFORCER_USERNAME, icon_emoji=ENFORCER_ICON)
+        except Exception as exc:
+            logger.warning("post to %s failed: %s", ch, exc)
+    write_bot_inboxes(text)
+
+
+def process_event(event: dict, web: WebClient) -> None:
+    """Apply pre-filter + LLM rule check + interjection (with cooldown) to a single message."""
+    if event.get("subtype") in ("message_changed", "message_deleted", "channel_join"):
+        return
+    if event.get("channel") != LISTEN_CHANNEL:
+        return
+    text = event.get("text") or ""
+    if not text:
+        return
+
+    callsign = attribute(event)
+    message_window.append(f"[{callsign.upper()}] {text}")
+
+    # Skip own enforcer posts
+    if callsign == "enforcer":
+        return
+    # Skip Dave (humans not subject to bot rules per RULES_PROMPT)
+    if callsign == "dave":
+        return
+    if not should_check(text):
+        return
+
+    logger.info("CHECK msg from=%s text=%s", callsign, text[:80])
+    result = check_with_llm(text, list(message_window))
+    if not result or not result.get("violation"):
+        return
+
+    rule_num = result.get("rule_number")
+    rule_name = result.get("rule_name", "unknown")
+    detail = result.get("detail", "")
+    should_have = result.get("should_have", "")
+
+    flag_key = f"rule_{rule_num}"
+    now = time.time()
+    if flag_key in last_flag_times and (now - last_flag_times[flag_key]) < FLAG_COOLDOWN_SECONDS:
+        logger.info("cooldown skip rule %s", rule_num)
+        return
+    last_flag_times[flag_key] = now
+
+    interjection = f"Rule {rule_num} -- {rule_name}: {detail}. {should_have}."
+    logger.info("VIOLATION: %s", interjection)
+    post_interjection(web, interjection, rule_num if isinstance(rule_num, int) else 0)
+
+
+def handle_request(client: SocketModeClient, req: SocketModeRequest) -> None:
+    """Socket Mode dispatch — events_api carries channel messages."""
+    client.send_socket_mode_response(SocketModeResponse(envelope_id=req.envelope_id))
+    if req.type != "events_api":
+        return
+    event = req.payload.get("event") or {}
+    if event.get("type") != "message":
+        return
+    try:
+        process_event(event, client.web_client)
+    except Exception as exc:
+        logger.exception("process_event error: %s", exc)
+
+
+def main() -> int:
+    if not BOT_TOKEN:
+        logger.error("SLACK_ENFORCER_BOT_TOKEN (or SLACK_BOT_TOKEN) not set")
+        return 2
+    if not APP_TOKEN:
+        logger.error("SLACK_ENFORCER_APP_TOKEN not set (xapp-1- Socket Mode token)")
+        return 2
+
+    web = WebClient(token=BOT_TOKEN)
+    sm = SocketModeClient(app_token=APP_TOKEN, web_client=web)
+    sm.socket_mode_request_listeners.append(handle_request)
+
+    logger.info("enforcer (slack) starting — listen=%s alerts=%s shared_bot_id=%s", LISTEN_CHANNEL, ALERTS_CHANNEL, SHARED_BOT_ID)
+    sm.connect()
+    # Block forever (sm.connect spins a background thread; main holds via sleep loop)
+    try:
+        while True:
+            time.sleep(60)
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/slack_bot/enforcer_callsign_map.py
+++ b/src/slack_bot/enforcer_callsign_map.py
@@ -1,0 +1,46 @@
+"""Slack user-id ↔ callsign map for the enforcer bot.
+
+Allows the enforcer to attribute incoming Slack messages to their canonical
+callsign (elliot/aiden/max/dave/etc.) regardless of the Slack username
+override used at post time. Per PR #672 spec § 4.
+
+bot_id is shared across all our agency_os Slack-app posts (B0B2W7VL7T4); the
+differentiator at receive time is `event.username` (or `event.user` for human
+messages). We map both shapes here.
+"""
+
+from __future__ import annotations
+
+# All bots share this Slack app's bot_id (chat:write.customize lets each post
+# under a distinct username while sharing the underlying bot identity).
+SHARED_BOT_ID = "B0B2W7VL7T4"
+
+# bot username (set via chat:write.customize at post time) → canonical callsign
+USERNAME_TO_CALLSIGN: dict[str, str] = {
+    "Elliot": "elliot",
+    "Aiden": "aiden",
+    "Max": "max",
+    "Enforcer": "enforcer",
+    # future additions land here without a code change elsewhere
+}
+
+# Slack user ID (humans only — bot posts use bot_id + username) → callsign
+HUMAN_USER_TO_CALLSIGN: dict[str, str] = {
+    "U091TGTPB9": "dave",  # Dave's Slack user_id (verified 2026-05-11 via curl history)
+}
+
+
+def attribute(event: dict) -> str:
+    """Return canonical callsign for a Slack message event.
+
+    Resolution order:
+      1. bot_id == SHARED_BOT_ID  → look up by event.username
+      2. user present (human)     → look up by event.user
+      3. fallback                 → 'unknown'
+    """
+    if event.get("bot_id") == SHARED_BOT_ID:
+        return USERNAME_TO_CALLSIGN.get(event.get("username", ""), "unknown-bot")
+    user_id = event.get("user")
+    if user_id:
+        return HUMAN_USER_TO_CALLSIGN.get(user_id, f"human:{user_id}")
+    return "unknown"


### PR DESCRIPTION
## Summary
Per ratified PR #672 spec + Dave's 4 ratified decision points (all YES). Phase A (shared rules extract) + Phase B (Slack bot) + Phase C (cross-device smoke) shipped.

## Phase A — `src/bot_common/enforcer_rules.py`
Single source of truth for `RULES_PROMPT`, `TRIGGER_PATTERNS`, `CHECK_MODEL`, `MAX_WINDOW`, `FLAG_COOLDOWN_SECONDS`, `HIGH_SEVERITY_RULES = {3, 6}`, plus `should_check()` helper. Verbatim port from `src/telegram_bot/enforcer_bot.py` as of 2026-05-11. Drift between TG + Slack bots during dual-post is the highest-impact risk in PR #672 — this module prevents it.

## Phase B — Slack bot
| File | Purpose |
|---|---|
| `src/slack_bot/enforcer_bot.py` | Socket Mode entrypoint via `slack_sdk.SocketModeClient` + `WebClient`. handle_request → process_event → check_with_llm (gpt-4o-mini) → post_interjection. R3+R6 route to BOTH `#execution` AND `#alerts`; other rules to `#alerts` only. Bot inbox writes preserved (tmux watchers consume unchanged). |
| `src/slack_bot/enforcer_callsign_map.py` | bot_id+username/user_id → canonical callsign. Skips own enforcer + Dave (rule exempt). |
| `infra/cron/agency-os-enforcer-slack-bot.service` | systemd user-service using shared venv python (slack_sdk installed via `/home/elliotbot/clawd/venv`). |

## Phase C — verbatim cross-device smoke evidence
```
May 11 03:14:04 INFO A new session has been established (id 5eaff15b…)
May 11 03:14:04 INFO Starting to receive messages
…Dave enabled Event Subscriptions + subscribed message.channels…
May 11 03:26:18 INFO CHECK msg from=elliot text=[ELLIOT] Phase C re-test
May 11 03:26:20 INFO HTTP Request: POST openai chat/completions 200
May 11 03:26:20 INFO VIOLATION: Rule 3 -- COMPLETION-REQUIRES-VERIFICATION
```
End-to-end latency: ~2.5s violation post → enforcer flag → both surfaces. Slack receipts visible as `[TG-ENFORCER]` (TG dual-post via inbox writes) AND `[TG-B0B2W7VL7T4]` (Slack chat_postMessage).

## OAuth + Slack-app setup tracked during build
1. `channels:history` scope added (was missing) — Dave re-OAuth
2. Event Subscriptions enabled + bot subscribed to `message.channels` — Dave config
3. `xapp-1-` Socket Mode token generated — Dave provided

## Sequencing
Old TG enforcer (`src/telegram_bot/enforcer_bot.py`, 571 LOC) UNCHANGED this PR — runs in parallel for the dual-post phase per spec § 7. Decommission deferred to Phase 4 (7 days post-cutover).

## Out of scope (per directive)
- TG enforcer decommission
- Rule logic changes (R1-R9 verbatim preserved)
- gpt-4o-mini model swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)