### PR TITLE
[ELLIOT] feat(slack-relay): per-callsign default icon — Elliot :technologist: permanent

### DIFF
--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -41,7 +41,13 @@ USERNAME = os.environ.get("SLACK_BOT_USERNAME", CALLSIGN.capitalize())
 # Optional per-callsign icon override. Slack accepts either an emoji shortcode
 # (":technologist:") via icon_emoji OR a fully-qualified URL via icon_url. We
 # expose both so callers can choose; URL wins if both are set.
-ICON_EMOJI = os.environ.get("SLACK_BOT_ICON_EMOJI", "")
+# Per Dave 2026-05-11: Elliot's :technologist: must be permanent (no inline
+# env required). Per-callsign defaults below; env override still wins.
+_DEFAULT_ICON_BY_CALLSIGN: dict[str, str] = {
+    "elliot": ":technologist:",
+    "enforcer": ":rotating_light:",
+}
+ICON_EMOJI = os.environ.get("SLACK_BOT_ICON_EMOJI", _DEFAULT_ICON_BY_CALLSIGN.get(CALLSIGN, ""))
 ICON_URL = os.environ.get("SLACK_BOT_ICON_URL", "")
 
 # Channel IDs (verified 2026-05-11 per AIDEN-SLACK-MIGRATION-001 dispatch)


### PR DESCRIPTION
Tiny follow-up to merged #678. Adds per-callsign default icon dict so Elliot's `:technologist:` (and Enforcer's `:rotating_light:`) don't need inline `SLACK_BOT_ICON_EMOJI` at every callsite.

Resolution order (unchanged where overridden):
`SLACK_BOT_ICON_URL` env > `SLACK_BOT_ICON_EMOJI` env > per-callsign default > none

Verified: ts `1778471022.073449` posted with no env override — `:technologist:` rendered.

Per Dave 2026-05-11 'icon must be permanent' directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)