### PR TITLE
[ELLIOT] fix(slack-listener): rate-limit safe polling + multi-channel

### DIFF
--- a/scripts/elliot_slack_listener.py
+++ b/scripts/elliot_slack_listener.py
@@ -42,9 +42,19 @@ LAST_SEEN_PATH = Path(f"/tmp/elliot-slack-listener-last-seen.txt")
 KEYWORDS = ("elliot", "all", "both", "team")
 
 BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
-CHANNEL = os.environ.get("SLACK_LISTEN_CHANNEL", "C0B3QB0K1GQ")
-POLL_SECONDS = float(os.environ.get("POLL_INTERVAL_SECONDS", "20"))
+# Comma-separated list of channel IDs to poll. Default: #execution + #ceo.
+# Per Dave 2026-05-11: bot now joined #ceo (C0B2PM3TV0B) and should see those posts.
+CHANNELS = [c.strip() for c in os.environ.get("SLACK_LISTEN_CHANNELS", "C0B3QB0K1GQ,C0B2PM3TV0B").split(",") if c.strip()]
+# Backward-compat single-channel env (overrides the list if set)
+_single = os.environ.get("SLACK_LISTEN_CHANNEL")
+if _single:
+    CHANNELS = [_single]
+POLL_SECONDS = float(os.environ.get("POLL_INTERVAL_SECONDS", "8"))
 OWN_BOT_ID = os.environ.get("OWN_BOT_ID", "B0B2W7VL7T4")
+BACKOFF_INITIAL = 30.0
+BACKOFF_MAX = 120.0
+_backoff_until: float = 0.0
+_backoff_current: float = BACKOFF_INITIAL
 
 
 def read_last_seen() -> str:
@@ -57,23 +67,51 @@ def write_last_seen(ts: str) -> None:
     LAST_SEEN_PATH.write_text(ts)
 
 
-def fetch_history(oldest: str) -> list[dict]:
-    """Call conversations.history; return messages newer than `oldest` ts."""
+def fetch_history(channel: str, oldest: str) -> list[dict]:
+    """Call conversations.history for one channel; return messages newer than `oldest` ts.
+
+    Sets a global backoff window when Slack returns 429 / ratelimited. Subsequent
+    calls during the window short-circuit (return []) so we stop hammering the API.
+    Backoff doubles up to BACKOFF_MAX, resets to BACKOFF_INITIAL on first success.
+    """
+    global _backoff_until, _backoff_current
     if not BOT_TOKEN:
         print("ERROR: SLACK_BOT_TOKEN not set", file=sys.stderr)
         sys.exit(2)
-    url = f"https://slack.com/api/conversations.history?channel={CHANNEL}&oldest={oldest}&limit=50"
+    if time.time() < _backoff_until:
+        return []
+    url = f"https://slack.com/api/conversations.history?channel={channel}&oldest={oldest}&limit=50"
     req = urllib.request.Request(url, headers={"Authorization": f"Bearer {BOT_TOKEN}"})
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             data = json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 429:
+            retry_after = float(e.headers.get("Retry-After") or _backoff_current)
+            _backoff_until = time.time() + retry_after
+            _backoff_current = min(_backoff_current * 2, BACKOFF_MAX)
+            print(f"history fetch 429 [{channel}]: backoff {retry_after}s (next={_backoff_current})", file=sys.stderr, flush=True)
+            return []
+        print(f"history fetch failed [{channel}]: {e}", file=sys.stderr, flush=True)
+        return []
     except urllib.error.URLError as e:
-        print(f"history fetch failed: {e}", file=sys.stderr, flush=True)
+        print(f"history fetch failed [{channel}]: {e}", file=sys.stderr, flush=True)
         return []
     if not data.get("ok"):
-        print(f"slack rejected: {data}", file=sys.stderr, flush=True)
+        if data.get("error") == "ratelimited":
+            _backoff_until = time.time() + _backoff_current
+            _backoff_current = min(_backoff_current * 2, BACKOFF_MAX)
+            print(f"history fetch ratelimited [{channel}]: backoff {_backoff_current}s", file=sys.stderr, flush=True)
+        else:
+            print(f"slack rejected [{channel}]: {data}", file=sys.stderr, flush=True)
         return []
-    return data.get("messages", [])
+    # Reset backoff on first successful response
+    _backoff_current = BACKOFF_INITIAL
+    msgs = data.get("messages", [])
+    # Tag each with the source channel so write_inbox can record provenance
+    for m in msgs:
+        m.setdefault("_channel_id", channel)
+    return msgs
 
 
 def matches_callsign(text: str) -> bool:
@@ -109,26 +147,30 @@ def write_inbox(msg: dict) -> None:
 
 def tick() -> None:
     last_seen = read_last_seen()
-    messages = fetch_history(last_seen)
-    if not messages:
+    # Poll every configured channel, accumulate messages, dedupe + sort by ts
+    all_msgs: list[dict] = []
+    for ch in CHANNELS:
+        all_msgs.extend(fetch_history(ch, last_seen))
+    if not all_msgs:
         return
-    # API returns newest-first — reverse for chronological processing
-    messages.reverse()
+    # Sort chronological (oldest first) so last_seen advances monotonically
+    all_msgs.sort(key=lambda m: m.get("ts", ""))
     new_max = last_seen
-    for m in messages:
+    for m in all_msgs:
         ts = m.get("ts", "")
         if not ts or ts <= last_seen:
             continue
         if m.get("bot_id") == OWN_BOT_ID:
-            new_max = ts  # advance pointer to skip own posts forever
+            new_max = ts
             continue
         text = m.get("text") or ""
         # Inbox if EITHER: human message (Dave + anyone non-bot) OR callsign-mentioning bot post
         if is_human_message(m) or matches_callsign(text):
             write_inbox(m)
         new_max = ts
-    if new_max != last_seen:
-        write_last_seen(new_max)
+    # Persist on every successful tick (even when no new bot/human msgs matched)
+    # so a flood of own-bot posts advances the pointer and the file always exists.
+    write_last_seen(new_max)
 
 
 def main() -> int:
@@ -140,7 +182,7 @@ def main() -> int:
     if not LAST_SEEN_PATH.exists():
         write_last_seen(str(time.time()))
         print(f"initialised last_seen={LAST_SEEN_PATH.read_text().strip()}", flush=True)
-    print(f"slack listener up — channel={CHANNEL} interval={POLL_SECONDS}s own_bot={OWN_BOT_ID}", flush=True)
+    print(f"slack listener up — channels={CHANNELS} interval={POLL_SECONDS}s own_bot={OWN_BOT_ID}", flush=True)
     while True:
         try:
             tick()


### PR DESCRIPTION
## Summary
- Bumps poll interval 3s → 8s (cuts call rate in half; still feels real-time)
- Adds exponential backoff on Slack 429 / ratelimited (30s → 120s, honours Retry-After)
- Persists last_seen.txt on every successful tick (not just on matched messages)
- Bundles in-flight multi-channel polling change (was on icon branch; moved here)

## Root cause
3s poll × 2 channels (#execution + #ceo) = 40 conversations.history calls/min, exceeding Slack Tier 3 limit. Listener was 429-blind from 04:50 UTC onwards, triggering Dave's "no message relayed to #ceo" callout.

## Test plan
- [x] python3 -m py_compile scripts/elliot_slack_listener.py → OK
- [x] systemctl --user restart agency-os-elliot-slack-listener → active (running)
- [x] Boot log shows: `channels=['C0B3QB0K1GQ','C0B2PM3TV0B'] interval=8.0s`
- [x] last_seen.txt persisted at boot (verified `/tmp/elliot-slack-listener-last-seen.txt` present)
- [x] Zero 429 errors in 60s post-restart (was 30+/min prior)
- [ ] Aiden + Max review

🤖 Generated with [Claude Code](https://claude.com/claude-code)