### PR TITLE
[AIDEN] feat(slack-listener P2): Socket Mode replacement

### DIFF
--- a/scripts/aiden_slack_listener.py
+++ b/scripts/aiden_slack_listener.py
@@ -41,7 +41,7 @@ import urllib.request
 from pathlib import Path
 
 CHANNELS = [c.strip() for c in os.environ.get("SLACK_LISTENER_CHANNELS", "C0B3QB0K1GQ").split(",") if c.strip()]
-POLL = float(os.environ.get("LISTENER_POLL_SECONDS", "20"))
+POLL = float(os.environ.get("LISTENER_POLL_SECONDS", "8"))
 TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 INBOX = Path("/tmp/telegram-relay-aiden/inbox")
 STATE_DIR = Path("/tmp/aiden-slack-listener-state.d")
@@ -50,6 +50,11 @@ GROUP_CHAT_ID = -1003926592540  # preserved so relay_watcher's last_chat_id stil
 CALLSIGN_TRIGGERS = ("aiden", "all", "both", "team")
 KEEP_TAGS = ("[ELLIOT]", "[MAX]", "[ENFORCER]", "[DAVE]")
 SELF_TAG = "[AIDEN]"
+
+BACKOFF_INITIAL = 30.0
+BACKOFF_MAX = 120.0
+_backoff_until: float = 0.0
+_backoff_current: float = BACKOFF_INITIAL
 
 
 def slack_get(method: str, params: dict) -> dict:
@@ -111,14 +116,32 @@ def write_inbox(text: str, sender: str) -> None:
 
 
 def poll_once(channel: str, cursor: str) -> str:
+    global _backoff_until, _backoff_current
+    if time.time() < _backoff_until:
+        return cursor
     try:
         result = slack_get("conversations.history", {"channel": channel, "oldest": cursor, "inclusive": "false", "limit": "100"})
+    except urllib.error.HTTPError as e:
+        if e.code == 429:
+            retry_after = float(e.headers.get("Retry-After") or _backoff_current)
+            _backoff_until = time.time() + retry_after
+            _backoff_current = min(_backoff_current * 2, BACKOFF_MAX)
+            print(f"history fetch 429 ({channel}): backoff {retry_after}s (next={_backoff_current})", file=sys.stderr, flush=True)
+            return cursor
+        print(f"slack history fetch failed ({channel}): {e}", file=sys.stderr, flush=True)
+        return cursor
     except urllib.error.URLError as e:
         print(f"slack history fetch failed ({channel}): {e}", file=sys.stderr, flush=True)
         return cursor
     if not result.get("ok"):
-        print(f"slack rejected ({channel}): {result}", file=sys.stderr, flush=True)
+        if result.get("error") == "ratelimited":
+            _backoff_until = time.time() + _backoff_current
+            _backoff_current = min(_backoff_current * 2, BACKOFF_MAX)
+            print(f"history fetch ratelimited ({channel}): backoff {_backoff_current}s", file=sys.stderr, flush=True)
+        else:
+            print(f"slack rejected ({channel}): {result}", file=sys.stderr, flush=True)
         return cursor
+    _backoff_current = BACKOFF_INITIAL
     messages = result.get("messages", [])
     if not messages:
         return cursor

--- a/scripts/aiden_socket_listener.py
+++ b/scripts/aiden_socket_listener.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""aiden_socket_listener.py — Slack Socket Mode replacement for the polling listener.
+
+WebSocket push subscription to message.channels + message.groups. Replaces
+scripts/aiden_slack_listener.py (poll conversations.history every 8s).
+
+Same filter logic + same inbox-write path:
+  - Drop messages whose text starts with `[AIDEN]` (self-loop guard; shared bot_id)
+  - Keep messages containing callsign tokens: aiden/all/both/team
+  - Keep messages tagged `[ELLIOT]` / `[MAX]` / `[ENFORCER]` / `[DAVE]`
+  - Keep non-bot messages (Dave/human posts)
+  - Channel allowlist: #execution + #alerts + #completed_directives
+
+Latency: ~50-500ms (WebSocket push) vs 0.5-8s (poll). Zero polling pressure
+on conversations.history Tier 3 rate limits.
+
+Env (read from /home/elliotbot/.config/agency-os/.env):
+  SLACK_BOT_TOKEN              xoxb-... (chat:write / channels:history scopes — same shared bot)
+  SLACK_ENFORCER_APP_TOKEN     xapp-1-... (reuse — same Slack app supports multiple sockets)
+  SLACK_LISTENER_CHANNELS      comma-separated allowlist (default = execution/alerts/completed_directives)
+
+Revert: systemctl --user stop aiden-slack-listener.service (after pointing the
+unit back at aiden_slack_listener.py).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+from slack_sdk.socket_mode import SocketModeClient
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.socket_mode.response import SocketModeResponse
+from slack_sdk.web import WebClient
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("aiden-socket-listener")
+
+BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
+APP_TOKEN = os.environ.get("SLACK_ENFORCER_APP_TOKEN", "")
+CHANNELS = {c.strip() for c in os.environ.get(
+    "SLACK_LISTENER_CHANNELS", "C0B3QB0K1GQ,C0B2EJU53EK,C0B2U15PSEA"
+).split(",") if c.strip()}
+INBOX = Path("/tmp/telegram-relay-aiden/inbox")
+GROUP_CHAT_ID = -1003926592540
+
+CALLSIGN_TRIGGERS = ("aiden", "all", "both", "team")
+KEEP_TAGS = ("[ELLIOT]", "[MAX]", "[ENFORCER]", "[DAVE]")
+SELF_TAG = "[AIDEN]"
+
+
+def should_keep(text: str, has_bot_id: bool) -> bool:
+    if text.startswith(SELF_TAG):
+        return False
+    low = text.lower()
+    if any(t in low for t in CALLSIGN_TRIGGERS):
+        return True
+    if any(tag in text for tag in KEEP_TAGS):
+        return True
+    return not has_bot_id
+
+
+def sender_from(msg: dict) -> str:
+    text = msg.get("text", "")
+    for tag in KEEP_TAGS:
+        if tag in text:
+            return tag.strip("[]").lower() + "bot"
+    if msg.get("bot_id"):
+        return "slackbot"
+    return msg.get("user", "human") or "human"
+
+
+def write_inbox(text: str, sender: str) -> None:
+    INBOX.mkdir(parents=True, exist_ok=True)
+    payload = {"type": "text", "chat_id": GROUP_CHAT_ID, "text": text, "sender": sender}
+    fname = f"slack_{int(time.time())}_{uuid.uuid4().hex[:8]}.json"
+    (INBOX / fname).write_text(json.dumps(payload))
+
+
+def process_event(event: dict) -> None:
+    if event.get("type") != "message":
+        return
+    if event.get("subtype") in ("message_changed", "message_deleted", "channel_join"):
+        return
+    channel = event.get("channel", "")
+    if channel not in CHANNELS:
+        return
+    text = event.get("text", "")
+    if not text:
+        return
+    has_bot = bool(event.get("bot_id"))
+    if not should_keep(text, has_bot):
+        return
+    write_inbox(text, sender_from(event))
+    logger.info("inbox <- %s %s (%dch)", channel, event.get("ts", "?"), len(text))
+
+
+def handle_request(client: SocketModeClient, req: SocketModeRequest) -> None:
+    client.send_socket_mode_response(SocketModeResponse(envelope_id=req.envelope_id))
+    if req.type != "events_api":
+        return
+    event = req.payload.get("event") or {}
+    try:
+        process_event(event)
+    except Exception as exc:
+        logger.exception("process_event error: %s", exc)
+
+
+def main() -> int:
+    if not BOT_TOKEN:
+        logger.error("SLACK_BOT_TOKEN not set")
+        return 2
+    if not APP_TOKEN:
+        logger.error("SLACK_ENFORCER_APP_TOKEN not set (xapp-1- Socket Mode token)")
+        return 2
+    web = WebClient(token=BOT_TOKEN)
+    sm = SocketModeClient(app_token=APP_TOKEN, web_client=web)
+    sm.socket_mode_request_listeners.append(handle_request)
+    logger.info("aiden-socket-listener starting — channels=%s", sorted(CHANNELS))
+    sm.connect()
+    try:
+        while True:
+            time.sleep(60)
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

AIDEN-SLACK-MIGRATION-001 Phase 2 — WebSocket push via Slack Socket Mode replaces 8s-poll listener. Option A per-callsign (peer-concurred at ts 1778478584).

- `scripts/aiden_socket_listener.py` (~110 LOC) — mirrors `src/slack_bot/enforcer_bot.py` Socket Mode pattern, stripped of LLM rule checks. Pure event→inbox bridge.
- Reuses `SLACK_ENFORCER_APP_TOKEN` (same Slack app supports multiple sockets).
- Channel allowlist via `SLACK_LISTENER_CHANNELS` env (default `#execution` + `#alerts` + `#completed_directives`).
- Same filter rules + same inbox JSON path as polling version → downstream `aiden-relay-watcher.service` inotify+tmux pipeline unchanged.

## Latency / rate-limit

| Mode | Latency | API pressure |
|---|---|---|
| Polling (prior) | 0.5–8s | conversations.history every 8s × 3 channels = 22 calls/min |
| Socket Mode (this PR) | ~50–500ms | 0 conversations.history calls; long-lived WebSocket |

844 HTTP 429 errors in pre-fix log → 0 expected post-cutover.

## Verbatim verification (R3)

Service restart log:
```
2026-05-11 09:19:42,834 INFO aiden-socket-listener starting — channels=['C0B2EJU53EK','C0B2U15PSEA','C0B3QB0K1GQ']
2026-05-11 09:19:43,656 INFO A new session has been established (session id: 240c2e1c-c9bc-495e-951a-b8533361888f)
2026-05-11 09:19:43,735 INFO Starting to receive messages from a new connection (session id: 240c2e1c-c9bc-495e-951a-b8533361888f)
```

`systemctl --user is-active aiden-slack-listener.service` → `active`

Filter unit tests:
```
[AIDEN] foo → False (self-loop)
hello aiden → True (callsign trigger)
[ELLIOT] x → True (KEEP_TAG)
random bot post → False
whats up (no bot_id, human) → True
```

## Out-of-repo

systemd unit `~/.config/systemd/user/aiden-slack-listener.service` updated to:
- `ExecStart=/home/elliotbot/clawd/venv/bin/python3 .../scripts/aiden_socket_listener.py`
- Removed `LISTENER_POLL_SECONDS` env (no longer applicable)

## Revert

Edit unit `ExecStart` back to `aiden_slack_listener.py` + restart. Polling listener kept in repo as fallback.

## Test plan

- [x] syntax + import check
- [x] filter unit tests pass (5 cases)
- [x] systemd unit restart clean
- [x] Socket Mode session established + receiving messages
- [ ] Live Slack post in `#execution` → inbox file appears within 500ms (next Dave/peer test post)

🤖 Generated with [Claude Code](https://claude.com/claude-code)