### PR TITLE
[MAX] feat(enforcer): deterministic-first pipeline scaffold + R4 check

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -1,0 +1,100 @@
+"""enforcer_deterministic.py — deterministic governance rule checks.
+
+Deterministic-first architecture: each check runs a fast regex/text scan
+BEFORE the LLM call. If deterministic returns a result, the caller skips
+gpt-4o-mini. If it returns None, the caller falls through to LLM.
+
+Rules implemented: R4 (deterministic)
+Stubs (pending subsequent PRs): R2, R3, R6, R8
+Retired (docs/governance/deprecated/): R1 (concur_gate.py), R5, R7
+LLM-only: R9 (semantic, stays in RULES_PROMPT)
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# R4 — NO-UNREVIEWED-MAIN-PUSH
+# ---------------------------------------------------------------------------
+
+# Patterns that indicate a direct push to main without PR process.
+_R4_VIOLATION_RE = re.compile(
+    r"git push origin main"
+    r"|force.pushed to main"
+    r"|merged to main without pr"
+    r"|bypassed pr review"
+    r"|pushed straight to main",
+    re.IGNORECASE,
+)
+
+# Patterns that indicate a legitimate PR merge or feature-branch push.
+# If any match, we return None (PASS) even if a trigger phrase is present.
+_R4_EXEMPT_RE = re.compile(
+    r"pr\s*#\d+\s+merged"
+    r"|merge\s+pr\s+\d+"
+    r"|gh\s+pr\s+merge"
+    r"|merged\s+commit"
+    r"|merge\s+all\s+pr"
+    r"|pushed to branch"
+    r"|pushed to origin (?:elliot|aiden|max|feature|fix|chore|test)/",
+    re.IGNORECASE,
+)
+
+
+def check_r4(text: str) -> dict | None:
+    """R4 — NO-UNREVIEWED-MAIN-PUSH.
+
+    Returns a violation dict if the text describes a direct push to main
+    without a PR.  Returns None if no violation detected or the message is
+    covered by an exemption.
+    """
+    if _R4_EXEMPT_RE.search(text):
+        return None
+    if _R4_VIOLATION_RE.search(text):
+        return {
+            "violation": True,
+            "rule_number": 4,
+            "rule_name": "NO-UNREVIEWED-MAIN-PUSH",
+            "detail": "Message indicates a direct push to main without PR review.",
+            "should_have": "All changes to main must go through a PR with at least one peer review.",
+        }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Stubs — R2, R3, R6, R8  (return None = fall through to LLM)
+# R5 + R7 RETIRED — see docs/governance/deprecated/
+# ---------------------------------------------------------------------------
+
+
+def check_r2(
+    text: str,
+    inbox_dir: Path,
+    window_sec: int = 300,
+) -> dict | None:
+    """R2 — STEP-0-BEFORE-EXECUTION.  Stub — deterministic impl pending PR #2."""
+    return None
+
+
+def check_r3(text: str) -> tuple[dict | None, bool]:
+    """R3 — COMPLETION-REQUIRES-VERIFICATION.  Stub — deterministic impl pending PR #2.
+
+    Returns (result, skip_llm).  Both False here — fall through to LLM.
+    """
+    return None, False
+
+
+
+def check_r6(text: str) -> tuple[dict | None, bool]:
+    """R6 — SAVE-CLAIM-REQUIRES-PROOF.  Stub — deterministic impl pending PR #2.
+
+    Returns (result, skip_llm).  Both False here — fall through to LLM.
+    """
+    return None, False
+
+
+def check_r8(text: str, recent_messages: list[str]) -> dict | None:
+    """R8 — DISPATCH-COORDINATION.  Stub — deterministic impl pending PR #2."""
+    return None

--- a/src/slack_bot/central_listener.py
+++ b/src/slack_bot/central_listener.py
@@ -51,6 +51,7 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web import WebClient
 
+from src.bot_common.enforcer_deterministic import check_r4
 from src.bot_common.enforcer_rules import (
     CHECK_MODEL,
     FLAG_COOLDOWN_SECONDS,
@@ -67,6 +68,7 @@ logger = logging.getLogger("slack-central-listener")
 BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 APP_TOKEN = os.environ.get("SLACK_ENFORCER_APP_TOKEN", "")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+ENFORCER_DETERMINISTIC = os.environ.get("ENFORCER_DETERMINISTIC", "1") == "1"
 LISTEN_CHANNEL = os.environ.get("SLACK_LISTEN_CHANNEL", "C0B3QB0K1GQ")  # enforcer scope
 ALERTS_CHANNEL = os.environ.get("SLACK_ALERTS_CHANNEL", "C0B2EJU53EK")
 ENFORCER_USERNAME = "Enforcer"
@@ -188,8 +190,30 @@ def post_interjection(web: WebClient, text: str, rule_num: int) -> None:
                 logger.warning("enforcer inbox write failed %s: %s", inbox, exc)
 
 
+def _fire_violation(result: dict, web: WebClient) -> None:
+    """Post an enforcer interjection if not in cooldown."""
+    rule_num = result.get("rule_number")
+    flag_key = f"rule_{rule_num}"
+    now = time.time()
+    if flag_key in last_flag_times and (now - last_flag_times[flag_key]) < FLAG_COOLDOWN_SECONDS:
+        return
+    last_flag_times[flag_key] = now
+    rule_name = result.get("rule_name", "unknown")
+    detail = result.get("detail", "")
+    should_have = result.get("should_have", "")
+    interjection = f"Rule {rule_num} -- {rule_name}: {detail}. {should_have}."
+    logger.info("VIOLATION: %s", interjection)
+    post_interjection(web, interjection, rule_num if isinstance(rule_num, int) else 0)
+
+
 def run_enforcer(event: dict, text: str, web: WebClient) -> None:
-    """Enforcer check on #execution events (was in src/slack_bot/enforcer_bot.py)."""
+    """Deterministic-first enforcer pipeline.
+
+    1. Run applicable deterministic checks (R4 now; R2/R3/R6/R8 via stubs).
+    2. If deterministic returns a violation → fire immediately, skip LLM.
+    3. If no deterministic result → fall through to LLM for remaining rules (R9 + stubs).
+    Set ENFORCER_DETERMINISTIC=0 to revert to LLM-only path.
+    """
     if event.get("channel") != LISTEN_CHANNEL:
         return
     callsign = attribute(event)
@@ -201,21 +225,17 @@ def run_enforcer(event: dict, text: str, web: WebClient) -> None:
     if not should_check(text):
         return
     logger.info("ENFORCER CHECK from=%s text=%s", callsign, text[:80])
+
+    if ENFORCER_DETERMINISTIC:
+        r4 = check_r4(text)
+        if r4:
+            _fire_violation(r4, web)
+            return
+
     result = check_with_llm(text, list(message_window), channel_id=event.get("channel", ""))
     if not result or not result.get("violation"):
         return
-    rule_num = result.get("rule_number")
-    rule_name = result.get("rule_name", "unknown")
-    detail = result.get("detail", "")
-    should_have = result.get("should_have", "")
-    flag_key = f"rule_{rule_num}"
-    now = time.time()
-    if flag_key in last_flag_times and (now - last_flag_times[flag_key]) < FLAG_COOLDOWN_SECONDS:
-        return
-    last_flag_times[flag_key] = now
-    interjection = f"Rule {rule_num} -- {rule_name}: {detail}. {should_have}."
-    logger.info("VIOLATION: %s", interjection)
-    post_interjection(web, interjection, rule_num if isinstance(rule_num, int) else 0)
+    _fire_violation(result, web)
 
 
 def process_event(event: dict, web: WebClient | None = None) -> None:


### PR DESCRIPTION
## Summary
- Creates `src/bot_common/enforcer_deterministic.py` — deterministic-first enforcer architecture
- Implements `check_r4()` (NO-UNREVIEWED-MAIN-PUSH) as first deterministic rule
- Wires deterministic-first pipeline into `central_listener.py` (`run_enforcer()`)
- Adds `ENFORCER_DETERMINISTIC=1` env flag for rollback (set to 0 to revert to LLM-only)
- R1/R5/R7 documented as RETIRED in module docstring (deprecated/ notes in PR #698)
- Stubs for R2/R3/R6/R8 (fall through to LLM until implemented in subsequent PRs)

## Context
Phase 5 PR #1b from governance round table (three-way concur locked Phases 1-5).
Enforcer LLM costs ~330-400K tokens/session at ~5% signal-to-noise. This PR starts
the deterministic replacement: 6 of 9 rules → regex/grep, R9 stays LLM-only.

## B3 commitment
24h FP-rate validation post-merge. If deterministic FP rate >20%, revert via
`ENFORCER_DETERMINISTIC=0`. Aiden owns validation measurement.

## Test plan
- [ ] `python3 -c "from src.bot_common.enforcer_deterministic import check_r4"` — import succeeds
- [ ] R4 flags "git push origin main" correctly
- [ ] R4 exempts "PR #697 merged" and feature-branch pushes
- [ ] LLM fallback still fires for non-R4 rules (R9, stubs)
- [ ] `ENFORCER_DETERMINISTIC=0` reverts to LLM-only path
- [ ] C1: replay today's 28 violation events through check_r4() (Aiden pre-merge)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>