### PR TITLE
[AIDEN] feat(enforcer): R2 + R8 deterministic checks (PR #3)

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -4,8 +4,8 @@ Deterministic-first architecture: each check runs a fast regex/text scan
 BEFORE the LLM call. If deterministic returns a result, the caller skips
 gpt-4o-mini. If it returns None, the caller falls through to LLM.
 
-Rules implemented: R4 (deterministic)
-Stubs (pending subsequent PRs): R2, R3, R6, R8
+Rules implemented: R2, R4, R8 (deterministic)
+Stubs (pending Max PR #2): R3, R6 (hybrid pre-filter + LLM fallback)
 Retired (docs/governance/deprecated/): R1 (concur_gate.py), R5, R7
 LLM-only: R9 (semantic, stays in RULES_PROMPT)
 """
@@ -13,7 +13,6 @@ LLM-only: R9 (semantic, stays in RULES_PROMPT)
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # R4 — NO-UNREVIEWED-MAIN-PUSH
@@ -64,37 +63,123 @@ def check_r4(text: str) -> dict | None:
 
 
 # ---------------------------------------------------------------------------
-# Stubs — R2, R3, R6, R8  (return None = fall through to LLM)
+# Stubs — R3, R6  (return None = fall through to LLM until Max PR #2 lands)
 # R5 + R7 RETIRED — see docs/governance/deprecated/
 # ---------------------------------------------------------------------------
 
 
-def check_r2(
-    text: str,
-    inbox_dir: Path,
-    window_sec: int = 300,
-) -> dict | None:
-    """R2 — STEP-0-BEFORE-EXECUTION.  Stub — deterministic impl pending PR #2."""
-    return None
-
-
 def check_r3(text: str) -> tuple[dict | None, bool]:
-    """R3 — COMPLETION-REQUIRES-VERIFICATION.  Stub — deterministic impl pending PR #2.
+    """R3 — COMPLETION-REQUIRES-VERIFICATION.  Stub — pending Max PR #2 hybrid impl.
 
     Returns (result, skip_llm).  Both False here — fall through to LLM.
     """
     return None, False
-
 
 
 def check_r6(text: str) -> tuple[dict | None, bool]:
-    """R6 — SAVE-CLAIM-REQUIRES-PROOF.  Stub — deterministic impl pending PR #2.
+    """R6 — SAVE-CLAIM-REQUIRES-PROOF.  Stub — pending Max PR #2 hybrid impl.
 
     Returns (result, skip_llm).  Both False here — fall through to LLM.
     """
     return None, False
 
 
-def check_r8(text: str, recent_messages: list[str]) -> dict | None:
-    """R8 — DISPATCH-COORDINATION.  Stub — deterministic impl pending PR #2."""
-    return None
+# ---------------------------------------------------------------------------
+# R2 — STEP-0-BEFORE-EXECUTION
+# ---------------------------------------------------------------------------
+
+# Trigger: message indicates an execution-action is happening NOW.
+_R2_EXECUTION_RE = re.compile(
+    r"\b(?:committing|pushing|deploying|deployed|merging|merged|"
+    r"creating pr|opened pr|triggering flow|started flow|"
+    r"running migration|applied migration|shipping|shipped|"
+    r"executing|executed)\b",
+    re.IGNORECASE,
+)
+
+# Exemptions — these mention execution language but are NOT new actions.
+_R2_EXEMPT_RE = re.compile(
+    r"\bpr\s*#\d+\s+merged\s+(?:earlier|prior|already|2026)"
+    r"|\b(?:will|going to|about to|planning to|propose to)\s+(?:commit|push|deploy|merge|create|trigger)"
+    r"|\b(?:not|haven't|won't)\s+(?:yet\s+)?(?:committed|pushed|deployed|merged)"
+    r"|\[propose:"
+    r"|\[summary-draft:"
+    r"|\[concur-request:",
+    re.IGNORECASE,
+)
+
+# Step-0 governance signals — any of these in recent inbox = PASS.
+_R2_STEP0_RE = re.compile(
+    r"step\s*0|objective:|restate:|^\s*-\s*\*\*objective:?\*\*"
+    r"|\[final concur:|\[propose:.*approve",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def check_r2(text: str, recent_messages: list[str] | None = None) -> dict | None:
+    """R2 — STEP-0-BEFORE-EXECUTION.
+
+    If text indicates execution starting AND no Step-0 / Objective / final-concur
+    signal exists in the current message OR in recent_messages → VIOLATION.
+    Else PASS.
+    """
+    if _R2_EXEMPT_RE.search(text):
+        return None
+    if not _R2_EXECUTION_RE.search(text):
+        return None
+    if _R2_STEP0_RE.search(text):
+        return None  # the message itself contains the Step 0 signal
+    if recent_messages is None:
+        return None  # conservative pass when no context available
+    if any(_R2_STEP0_RE.search(m) for m in recent_messages):
+        return None
+    return {
+        "violation": True,
+        "rule_number": 2,
+        "rule_name": "STEP-0-BEFORE-EXECUTION",
+        "detail": "Execution starting without Step-0 / Objective / final-concur governance signal in recent_messages.",
+        "should_have": "Post Step 0 RESTATE (or get [FINAL CONCUR] / Dave directive) before execution.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# R8 — DISPATCH-COORDINATION
+# ---------------------------------------------------------------------------
+
+_R8_DISPATCH_RE = re.compile(
+    r"\b(?:dispatched|injected|tmux paste|tmux send-keys|"
+    r"atlas dispatched|orion dispatched|clone dispatch|"
+    r"sent dispatch|dispatching now)\b",
+    re.IGNORECASE,
+)
+
+_R8_PROPOSAL_RE = re.compile(r"\[dispatch-proposal:[^\]]+\]", re.IGNORECASE)
+_R8_CONCUR_RE = re.compile(r"\[concur:[^\]]+\]", re.IGNORECASE)
+
+
+def check_r8(text: str, recent_messages: list[str] | None = None) -> dict | None:
+    """R8 — DISPATCH-COORDINATION.
+
+    If text shows a clone dispatch happening, require [DISPATCH-PROPOSAL:<callsign>]
+    AND peer [CONCUR] in recent_messages before it. Missing either = VIOLATION.
+    """
+    if not _R8_DISPATCH_RE.search(text):
+        return None
+    if recent_messages is None:
+        return None  # conservative pass when no context available
+    has_proposal = any(_R8_PROPOSAL_RE.search(m) for m in recent_messages)
+    has_concur = any(_R8_CONCUR_RE.search(m) for m in recent_messages)
+    if has_proposal and has_concur:
+        return None
+    missing = []
+    if not has_proposal:
+        missing.append("[DISPATCH-PROPOSAL:<callsign>]")
+    if not has_concur:
+        missing.append("[CONCUR:<peer>]")
+    return {
+        "violation": True,
+        "rule_number": 8,
+        "rule_name": "DISPATCH-COORDINATION",
+        "detail": f"Dispatch action without prior {' + '.join(missing)} in recent_messages.",
+        "should_have": "Post [DISPATCH-PROPOSAL:<callsign>] and wait for peer [CONCUR] before dispatching.",
+    }

--- a/src/slack_bot/central_listener.py
+++ b/src/slack_bot/central_listener.py
@@ -51,7 +51,7 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web import WebClient
 
-from src.bot_common.enforcer_deterministic import check_r4
+from src.bot_common.enforcer_deterministic import check_r2, check_r4, check_r8
 from src.bot_common.enforcer_rules import (
     CHECK_MODEL,
     FLAG_COOLDOWN_SECONDS,
@@ -209,9 +209,9 @@ def _fire_violation(result: dict, web: WebClient) -> None:
 def run_enforcer(event: dict, text: str, web: WebClient) -> None:
     """Deterministic-first enforcer pipeline.
 
-    1. Run applicable deterministic checks (R4 now; R2/R3/R6/R8 via stubs).
+    1. Run applicable deterministic checks (R2, R4, R8; R3/R6 still stubs).
     2. If deterministic returns a violation → fire immediately, skip LLM.
-    3. If no deterministic result → fall through to LLM for remaining rules (R9 + stubs).
+    3. If no deterministic result → fall through to LLM for remaining rules (R9 + R3/R6 stubs).
     Set ENFORCER_DETERMINISTIC=0 to revert to LLM-only path.
     """
     if event.get("channel") != LISTEN_CHANNEL:
@@ -227,10 +227,16 @@ def run_enforcer(event: dict, text: str, web: WebClient) -> None:
     logger.info("ENFORCER CHECK from=%s text=%s", callsign, text[:80])
 
     if ENFORCER_DETERMINISTIC:
-        r4 = check_r4(text)
-        if r4:
-            _fire_violation(r4, web)
-            return
+        recent = list(message_window)
+        for check_fn, check_args in (
+            (check_r4, (text,)),
+            (check_r2, (text, recent)),
+            (check_r8, (text, recent)),
+        ):
+            result = check_fn(*check_args)
+            if result:
+                _fire_violation(result, web)
+                return
 
     result = check_with_llm(text, list(message_window), channel_id=event.get("channel", ""))
     if not result or not result.get("violation"):


### PR DESCRIPTION
## Summary

Phase 5 PR #3 — replaces R2 + R8 stubs in `enforcer_deterministic.py` with deterministic regex implementations. Wires both into the deterministic-first pipeline in `central_listener.run_enforcer`.

Per the Phase 5 lock (2026-05-11), this is the third of four enforcer PRs:
- ✅ PR #697 — R1 retired (Elliot)
- ✅ PR #698 — R1/R5/R7 deprecated/ notes (Aiden)
- ✅ PR #699 — scaffold + R4 (Max)
- 🚀 **THIS PR (Aiden #3)** — R2 + R8 deterministic
- ⏳ Max PR #2 — R3/R6 hybrid + strip `RULES_PROMPT` to R9-only

After this + Max PR #2 land: 8 of 9 rules deterministic, R9 LLM-only. Estimated ~85-90% reduction in enforcer LLM calls.

## R2 — STEP-0-BEFORE-EXECUTION

| Aspect | Logic |
|---|---|
| Trigger | execution-action verbs: `committing` / `pushing` / `deploying` / `merging` / etc |
| Exempt | planning language (`going to`, `planning to`, `won't yet`), PR-merged-earlier |
| Pass | Step 0 / Objective: / `[FINAL CONCUR:...]` / `[PROPOSE:...approve]` in current text OR recent_messages window |
| Violation | execution + no governance signal in scope |

## R8 — DISPATCH-COORDINATION

| Aspect | Logic |
|---|---|
| Trigger | dispatch verbs: `dispatched` / `injected` / `tmux paste` / `ATLAS dispatched` / etc |
| Pass | BOTH `[DISPATCH-PROPOSAL:<callsign>]` AND `[CONCUR:<peer>]` in recent_messages |
| Violation | dispatch + missing either tag |

## Pipeline change in `central_listener.run_enforcer`

```python
if ENFORCER_DETERMINISTIC:
    recent = list(message_window)
    for check_fn, check_args in (
        (check_r4, (text,)),
        (check_r2, (text, recent)),
        (check_r8, (text, recent)),
    ):
        result = check_fn(*check_args)
        if result:
            _fire_violation(result, web)
            return

result = check_with_llm(text, list(message_window), channel_id=...)
```

First deterministic violation fires + returns. Else falls through to LLM (which handles R3/R6 stubs + R9 semantic).

## Verbatim test output (R3 evidence)

### check_r2 (7/7 pass)
```
  1. execution + empty recent → VIOLATION (expected VIOLATION)
  2. execution + Step 0 in recent → pass (expected pass)
  3. Objective inline → pass (expected pass)
  4. 'going to commit' exempt → pass (expected pass)
  5. no execution → pass (expected pass)
  6. recent_messages=None → pass (expected pass)
  7. [FINAL CONCUR] in recent → pass (expected pass)
```

### check_r8 (5/5 pass)
```
  1. dispatch + no PROPOSAL+CONCUR → VIOLATION (expected VIOLATION)
  2. dispatch + PROPOSAL only → VIOLATION (expected VIOLATION)
  3. dispatch + PROPOSAL + CONCUR → pass (expected pass)
  4. no dispatch language → pass (expected pass)
  5. dispatch + recent_messages=None → pass (expected pass)
```

## Revert path

Set `ENFORCER_DETERMINISTIC=0` in central_listener service env, restart. Falls back to pure-LLM enforcement for all rules.

## Test plan

- [x] Syntax check both files pass
- [x] 7/7 R2 unit tests
- [x] 5/5 R8 unit tests
- [x] Pipeline integration: deterministic-first iteration over (R4, R2, R8)
- [ ] 24h FP-rate validation (Aiden, clock started at central_listener restart 11:22:24 UTC)
- [ ] Peer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)