### PR TITLE
[MAX] feat(enforcer): R3/R6 hybrid + strip RULES_PROMPT to R9-only

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -4,8 +4,7 @@ Deterministic-first architecture: each check runs a fast regex/text scan
 BEFORE the LLM call. If deterministic returns a result, the caller skips
 gpt-4o-mini. If it returns None, the caller falls through to LLM.
 
-Rules implemented: R2, R4, R8 (deterministic)
-Stubs (pending Max PR #2): R3, R6 (hybrid pre-filter + LLM fallback)
+Rules implemented: R2, R4, R8 (deterministic); R3, R6 (hybrid pre-filter + LLM fallback)
 Retired (docs/governance/deprecated/): R1 (concur_gate.py), R5, R7
 LLM-only: R9 (semantic, stays in RULES_PROMPT)
 """
@@ -63,25 +62,136 @@ def check_r4(text: str) -> dict | None:
 
 
 # ---------------------------------------------------------------------------
-# Stubs — R3, R6  (return None = fall through to LLM until Max PR #2 lands)
+# R3 — COMPLETION-REQUIRES-VERIFICATION (hybrid)
 # R5 + R7 RETIRED — see docs/governance/deprecated/
 # ---------------------------------------------------------------------------
 
+# Exceptions: gatekeeper and synthetic messages always pass.
+_R3_EXCEPTION_RE = re.compile(
+    r"\[GOVERNANCE\]\s+Gatekeeper"
+    r"|observe-only"
+    r"|synthetic test",
+    re.IGNORECASE,
+)
+
+# STRICT completion triggers — always check for evidence.
+_R3_STRICT_RE = re.compile(
+    r"\bcomplete\b"
+    r"|all stores written"
+    r"|4-store save complete"
+    r"|store save complete"
+    r"|task complete"
+    r"|build complete",
+    re.IGNORECASE,
+)
+
+# SOFT trigger — "done" at word boundary, not preceded by "not", "isn't", "won't be".
+_R3_SOFT_RE = re.compile(r"(?<!not\s)(?<!isn't\s)(?<!won't be\s)\bdone\b", re.IGNORECASE)
+
+# Evidence patterns — if any match alongside a claim → PASS.
+_R3_EVIDENCE_RE = re.compile(
+    r"\b[0-9a-f]{7,40}\b"                     # commit hash
+    r"|PR\s*#\d+\s+(?:merged|closed|open)"     # PR reference with state
+    r"|^[\$>→]"                                 # terminal output line
+    r"|PID\s+\d+"                               # PID
+    r"|ActiveState="                            # systemd state
+    r"|exit\s+code"                             # exit code
+    r"|\d+/\d+\s+(?:pass|fail)"                # test counts
+    r"|tests?\s+pass"                           # test pass
+    r"|rows?\s+affected"                        # SQL output
+    r"|\bSELECT\b|\bINSERT\b|\bUPDATE\b"       # SQL keywords
+    r"|\d+\s+(?:insertion|deletion)"            # git diff stats
+    r"|\d{4}-\d{2}-\d{2}.*UTC"                 # timestamp with detail
+    r"|commit\s+[0-9a-f]{7,}",                 # commit message format
+    re.IGNORECASE | re.MULTILINE,
+)
+
 
 def check_r3(text: str) -> tuple[dict | None, bool]:
-    """R3 — COMPLETION-REQUIRES-VERIFICATION.  Stub — pending Max PR #2 hybrid impl.
+    """R3 — COMPLETION-REQUIRES-VERIFICATION (hybrid).
 
-    Returns (result, skip_llm).  Both False here — fall through to LLM.
+    Returns (result, skip_llm):
+      - STRICT claim + evidence    → (None, True)       PASS, skip LLM
+      - STRICT claim + no evidence → (violation, True)  VIOLATION, skip LLM
+      - SOFT "done" + evidence     → (None, True)       PASS, skip LLM
+      - SOFT "done" + no evidence  → (None, False)      ambiguous, fall through to LLM
+      - No claim                   → (None, False)      not applicable, fall through to LLM
     """
+    if _R3_EXCEPTION_RE.search(text):
+        return None, True
+
+    has_evidence = bool(_R3_EVIDENCE_RE.search(text))
+
+    if _R3_STRICT_RE.search(text):
+        if has_evidence:
+            return None, True
+        return {
+            "violation": True,
+            "rule_number": 3,
+            "rule_name": "COMPLETION-REQUIRES-VERIFICATION",
+            "detail": "Completion claim made without inline evidence (commit hash, PR state, terminal output, etc.).",
+            "should_have": "Every completion claim must include verifiable evidence such as a commit hash, PR number with state, or raw terminal output.",
+        }, True
+
+    if _R3_SOFT_RE.search(text):
+        if has_evidence:
+            return None, True
+        return None, False
+
     return None, False
+
+
+# ---------------------------------------------------------------------------
+# R6 — SAVE-CLAIM-REQUIRES-PROOF (hybrid)
+# ---------------------------------------------------------------------------
+
+_R6_SAVE_RE = re.compile(
+    r"state saved"
+    r"|4-store save complete"
+    r"|ceo_memory updated"
+    r"|manual updated"
+    r"|drive mirror"
+    r"|daily_log written"
+    r"|stores written"
+    r"|store save complete",
+    re.IGNORECASE,
+)
+
+_R6_EVIDENCE_RE = re.compile(
+    r"\b[0-9a-f]{7,40}\b"              # commit hash (MANUAL)
+    r"|rows?\s+affected"               # SQL output (ceo_memory)
+    r"|\bINSERT\b|\bupsert\b"          # SQL keywords (ceo_memory)
+    r"|updated_at"                     # ceo_memory field
+    r"|\d+\s*bytes?"                   # byte count (Drive)
+    r"|\bsuccess\b|\bmirrored\b"       # Drive success marker
+    r"|\bSELECT\b"                     # query result (daily_log)
+    r"|\brow\b"                        # row reference (daily_log)
+    r"|\bdaily_log\b",                 # explicit daily_log mention with evidence context
+    re.IGNORECASE,
+)
 
 
 def check_r6(text: str) -> tuple[dict | None, bool]:
-    """R6 — SAVE-CLAIM-REQUIRES-PROOF.  Stub — pending Max PR #2 hybrid impl.
+    """R6 — SAVE-CLAIM-REQUIRES-PROOF (hybrid).
 
-    Returns (result, skip_llm).  Both False here — fall through to LLM.
+    Returns (result, skip_llm):
+      - Save claim + ≥1 store evidence → (None, True)       PASS, skip LLM
+      - Save claim + 0 store evidence  → (violation, True)  VIOLATION, skip LLM
+      - No save claim                  → (None, False)      not applicable, fall through to LLM
     """
-    return None, False
+    if not _R6_SAVE_RE.search(text):
+        return None, False
+
+    if _R6_EVIDENCE_RE.search(text):
+        return None, True
+
+    return {
+        "violation": True,
+        "rule_number": 6,
+        "rule_name": "SAVE-CLAIM-REQUIRES-PROOF",
+        "detail": "Save/store claim made without store-specific evidence (commit hash, SQL output, byte count, etc.).",
+        "should_have": "Every save claim must include proof: commit hash for MANUAL, SQL rows affected for ceo_memory, byte count or 'mirrored' for Drive, query result for daily_log.",
+    }, True
 
 
 # ---------------------------------------------------------------------------

--- a/src/bot_common/enforcer_rules.py
+++ b/src/bot_common/enforcer_rules.py
@@ -1,20 +1,17 @@
-"""enforcer_rules.py — single source of truth for the 9 enforcer rules.
+"""enforcer_rules.py — LLM prompt + constants for governance enforcement.
 
-Both src/telegram_bot/enforcer_bot.py (TG, archive) and src/slack_bot/enforcer_bot.py
-(Slack, live) import RULES_PROMPT + TRIGGER_PATTERNS + FLAG_COOLDOWN_SECONDS +
-MAX_WINDOW + CHECK_MODEL from here. Drift between the two bots during the dual-post
-phase is the highest-impact risk in the ENFORCER-REDESIGN-001 spec — this module
-prevents it.
+Post Phase 5 round table (2026-05-11): 8 of 9 rules are now handled by
+deterministic checks in src/bot_common/enforcer_deterministic.py. This
+module retains RULES_PROMPT for the sole remaining LLM-checked rule (R9)
+plus R3 SOFT fallback context.
 
-Per PR #672 ratified spec § 8 + Phase A. RULES_PROMPT preserved verbatim from
-src/telegram_bot/enforcer_bot.py as of 2026-05-11.
+R1/R5/R7: retired (docs/governance/deprecated/)
+R2/R4/R8: deterministic (enforcer_deterministic.py)
+R3/R6: hybrid — deterministic pre-filter, LLM fallback for ambiguous cases
+R9: LLM-only (semantic check)
 
-Edit policy:
-- Rule logic edits MUST land here (not in either bot's file).
-- New rule (R10+) requires: prompt edit + TRIGGER_PATTERNS update + tests.
-- Decision-point #4 (post-PR #672 ratification): R3 + R6 violations route to
-  BOTH #execution AND #alerts; all other rules to #alerts only. Routing is
-  the bot's responsibility, not this module's.
+TRIGGER_PATTERNS, should_check(), and constants are still imported by
+concur_gate.py and central_listener.py.
 """
 
 from __future__ import annotations
@@ -76,64 +73,13 @@ RULES_PROMPT = """You are a governance enforcement bot for a multi-agent develop
 
 You monitor group chat messages between two AI agents (Elliot and Aiden) and their human manager (Dave).
 
-CHECK these 6 rules against the CURRENT MESSAGE in context of the RECENT MESSAGES:
+Most rules are now checked deterministically before this LLM call. You only need to check:
 
-(Rule 1 — CONCUR-BEFORE-SUMMARY — RETIRED 2026-05-11. Deterministic coverage by scripts/slack_relay.py + scripts/coo_slack_relay.py + src/bot_common/concur_gate.py outbound gate (PR #685). Outbound gate holds R1 trigger-pattern messages until peer [CONCUR:<my-callsign>] is visible in recent #execution. LLM check on inbound was redundant + had ~70% FP rate per 2026-05-11 audit. Phase 5 PR #1a retire.)
+Rule 3 — COMPLETION-REQUIRES-VERIFICATION (SOFT fallback only):
+If the current message uses "done" in a way that might be a completion claim (not "not done", "isn't done") but does NOT contain obvious evidence (commit hashes, PR references, terminal output, test results), evaluate whether the message is actually claiming task completion. If it is a genuine completion claim without evidence, flag as VIOLATION. If "done" is used conversationally ("done reviewing", "done for the day", "done discussing"), return no violation.
 
-Rule 2 — STEP-0-BEFORE-EXECUTION: If the current message shows execution starting (mentions committing, pushing, deploying, triggering flows, creating PRs), check whether ANY of the following governance signals exists in recent_messages or governance_events for the same topic:
-  (a) a Dave-directed Step 0 / RESTATE post, OR
-  (b) a dual peer-Step-0 pair — BOTH `[FINAL CONCUR:ELLIOT]` AND `[FINAL CONCUR:AIDEN]` tags present in recent_messages on the same topic (dual-concur governance ratified 2026-04-22), OR
-  (c) Elliot approved/directed from #ceo — Elliot has full Dave authority in #ceo (delegated 2026-05-11). An Elliot directive or approval in #ceo satisfies Step 0 the same as a Dave approval.
-Having ANY signal = PASS. Missing ALL = VIOLATION.
-EXCEPTIONS (always PASS, no Step 0 required):
-  (i)   PR merge on explicit CEO instruction (Dave or Elliot-from-#ceo posts "merge N" or "merge N + continue")
-  (ii)  Rebase performed as peer-review fix (continuation of original dispatch, not new directive)
-  (iii) Orchestrator tagging peer replies (acknowledgement, not execution)
-  (iv)  CEO removed Step 0 confirmation gate ("no more approvals" or "only merge approvals") — bots post RESTATE for discipline but execution proceeds without Dave-pause. Only PR-merge actions require explicit Dave approval.
-  (v)   Task approved via [PROPOSE:<callsign>] + Dave "approve" — execution starts immediately after approval without separate Step 0 post.
-
-Rule 3 — COMPLETION-REQUIRES-VERIFICATION: If the current message claims task completion ("complete", "done", "all stores written", "4-store save complete"), check if verification evidence was posted (terminal output, SQL results, test output, commit hashes). Claim without evidence = VIOLATION.
-EVIDENCE RECOGNITION — the following patterns COUNT as valid evidence when present in the same message as a completion claim (PASS, not violation):
-  - Commit hashes (7+ hex chars, e.g. "f2eaae09", "commit 067df9aa")
-  - PR references with state ("PR #694 merged", "gh pr view → MERGED")
-  - Terminal/command output (lines starting with $, >, →, or indented command output)
-  - grep/git/systemd output (PID numbers, ActiveState=, "passed", "15/15", exit codes)
-  - SQL results or query output
-  - Timestamps with specific operational details ("restarted Mon 2026-05-11 09:49:45 UTC")
-  - File diffs or stat output ("5 insertions, 4 deletions")
-  - Verbatim log lines or service output
-If a message contains BOTH a completion claim AND any of these evidence patterns inline, it is NOT a violation — the evidence is present.
-EXCEPTIONS (always PASS, not a completion claim):
-  (i)   Messages starting with '[GOVERNANCE] Gatekeeper DENY' or '[GATEKEEPER-DENY:' — these are automated gate outputs (the opposite of completion claims), not bot assertions of done.
-  (ii)  Messages reporting a Gatekeeper allow/deny verdict as test evidence — the verdict IS the verification output.
-  (iii) Messages containing 'observe-only' or 'synthetic test' — these are test/verify actions, not real completion claims.
-  (iv)  Peer-to-peer status updates in #execution that include inline evidence (systemd output, git log, grep results) — the evidence IS the verification.
-
-Rule 4 — NO-UNREVIEWED-MAIN-PUSH: If the current message mentions a DIRECT push to main without PR review or peer approval, flag as WARNING.
-SCOPE — Rule 4 ONLY triggers on RAW push patterns, not PR-merge language:
-  TRIGGER: "git push origin main" / "force-pushed to main" / "merged to main without PR" / "bypassed PR review" / "pushed straight to main"
-  EXEMPT (always PASS — legitimate PR merges, not raw pushes):
-    (i)   "PR #N merged" / "merge PR N" / "gh pr merge" / "merged commit <hash>" — PR merges with admin auth (under CEO instruction).
-    (ii)  "merge all PR" / "merge X" said by Dave or Elliot-from-#ceo — verbatim CEO instruction (Rule 2 exception (i) also applies).
-    (iii) "pushed to branch elliot/X" / "pushed to origin elliot/X" — feature-branch push, not main.
-    (iv)  Discussions about PR titles, descriptions, merge state, or commit history — meta-discussion, not an action.
-
-Rule 5 — SHARED-FILE-CLAIM: If the current message mentions editing memory_listener.py, chat_bot.py, store.py, listener_discernment.py, or any CLAUDE.md file, check if "[CLAIM:" was posted. Missing claim = VIOLATION.
-
-Rule 6 — SAVE-CLAIM-REQUIRES-PROOF: If the current message claims a save was completed ("state saved", "4-store save complete", "ceo_memory updated", "MANUAL updated", "Drive mirrored", "daily_log written", "stores written"), check that the message includes SPECIFIC EVIDENCE for EACH store claimed. Evidence means: commit hashes for MANUAL, SQL confirmation for ceo_memory, byte count or success message for Drive mirror, query result for daily_log. A bot saying "all stores written ✓" without showing the actual outputs for each store = VIOLATION. The claim must be backed by verifiable proof in recent messages, not just checkmarks.
-
-Rule 8 — DISPATCH-COORDINATION: If the current message shows a clone dispatch being injected (mentions "dispatched", "injected", "tmux paste", "ATLAS dispatched", "ORION dispatched", or dispatch JSON), check whether a [DISPATCH-PROPOSAL:<callsign>] was posted in recent_messages AND the peer posted [CONCUR] on that proposal BEFORE the dispatch. Dispatching without prior proposal + peer concur = VIOLATION. Exception: if only one bot is active (peer offline/reset), solo dispatch with proposal posted is sufficient.
-
-Rule 9 — DIRECTIVE-INITIATIVE: If the current message is from a bot (ELLIOT or AIDEN) and ends with open-ended agenda-setting phrases directed at Dave — such as "standing by for directive", "ready for next directive", "what's next", "awaiting your call", "what would you like", or any question asking Dave to SET the agenda rather than APPROVE a proposal — flag as VIOLATION. Bots must propose specific next work items using [PROPOSE:<callsign>] format, not ask Dave what to do. Exception: [SESSION-WRAP:<callsign>] is allowed for genuine end-of-session. First violation = warning, second = governance debt log.
-
-Rule 7 — CLONE-DIRECT-GROUP-POST: If the message SENDER is a CLONE (callsign attribution returns "atlas" or "orion"), flag as VIOLATION — clones must not post to group per C3. Parent surfaces clone artefacts via `[CONSUMED:<parent>]` post. NOTE: MAX is a PRIME agent (CTO), NOT a clone. [MAX] prefixed messages are legitimate group posts. Only ATLAS and ORION are clones.
-SCOPE — Rule 7 ONLY triggers on SENDER attribution, NOT on mentions of clone names:
-  TRIGGER: sender resolves to atlas/orion (via enforcer_callsign_map.attribute()) OR message text begins with `[ATLAS]` / `[ORION]` (clone-prefix self-tag).
-  EXEMPT (always PASS — legitimate references):
-    (i)   Mentions of ATLAS/ORION as WORKSPACE NAMES (e.g. "edited _session_start.md in Atlas worktree", "Agency_OS-atlas/scripts/X") — these are filesystem paths or workspace identifiers, not clone posts.
-    (ii)  Dispatch coordination posts ("ATLAS dispatched", "ORION queued") posted by parent callsigns (Elliot/Aiden/Max) — these report on clone work, don't BE clone work.
-    (iii) `[CONSUMED:<parent>]` parent-surfacing posts — explicitly allowed pattern.
-    (iv)  Discussions about clone migration, clone Rules, clone architecture from any non-clone sender.
+Rule 9 — DIRECTIVE-INITIATIVE:
+If the current message is from a bot (ELLIOT or AIDEN) and ends with open-ended agenda-setting phrases directed at Dave — such as "standing by for directive", "ready for next directive", "what's next", "awaiting your call", "what would you like", or any question asking Dave to SET the agenda rather than APPROVE a proposal — flag as VIOLATION. Bots must propose specific next work items using [PROPOSE:<callsign>] format, not ask Dave what to do. Exception: [SESSION-WRAP:<callsign>] is allowed for genuine end-of-session.
 
 RESPOND WITH ONLY THIS JSON:
 {
@@ -146,10 +92,7 @@ RESPOND WITH ONLY THIS JSON:
 
 If NO violation, return {"violation": false, "rule_number": null, "rule_name": null, "detail": null, "should_have": null}
 
-You also have access to GOVERNANCE_EVENTS — a state tracker of the most recent concur, Step 0, and /stage0 events. Use these to check rules even when the events fall outside the recent_messages window.
-
-IMPORTANT: Flag violations when detected. Err on the side of flagging — missed violations are worse than false alarms.
-Do NOT flag Dave's messages — he is not subject to bot rules.
-Do NOT flag messages that are clearly part of peer discussion (not Dave-facing).
-Messages labeled as 'test' or 'deliberate violation' are STILL subject to rule evaluation — flag them the same as real violations.
+IMPORTANT: Only check Rule 3 (soft) and Rule 9. All other rules are handled deterministically.
+Do NOT flag Dave's messages.
+Do NOT flag messages that are clearly part of peer discussion.
 """

--- a/src/slack_bot/central_listener.py
+++ b/src/slack_bot/central_listener.py
@@ -51,7 +51,7 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web import WebClient
 
-from src.bot_common.enforcer_deterministic import check_r2, check_r4, check_r8
+from src.bot_common.enforcer_deterministic import check_r2, check_r3, check_r4, check_r6, check_r8
 from src.bot_common.enforcer_rules import (
     CHECK_MODEL,
     FLAG_COOLDOWN_SECONDS,
@@ -209,9 +209,9 @@ def _fire_violation(result: dict, web: WebClient) -> None:
 def run_enforcer(event: dict, text: str, web: WebClient) -> None:
     """Deterministic-first enforcer pipeline.
 
-    1. Run applicable deterministic checks (R2, R4, R8; R3/R6 still stubs).
-    2. If deterministic returns a violation → fire immediately, skip LLM.
-    3. If no deterministic result → fall through to LLM for remaining rules (R9 + R3/R6 stubs).
+    1. Deterministic loop: R4, R2, R8 — violation fires immediately.
+    2. Hybrid: R3, R6 — evidence regex pre-filter; STRICT resolved, SOFT falls through.
+    3. LLM fallback: R3 SOFT "done" + R9 (semantic).
     Set ENFORCER_DETERMINISTIC=0 to revert to LLM-only path.
     """
     if event.get("channel") != LISTEN_CHANNEL:
@@ -237,6 +237,16 @@ def run_enforcer(event: dict, text: str, web: WebClient) -> None:
             if result:
                 _fire_violation(result, web)
                 return
+
+        r3_result, r3_skip = check_r3(text)
+        if r3_result:
+            _fire_violation(r3_result, web)
+            return
+
+        r6_result, r6_skip = check_r6(text)
+        if r6_result:
+            _fire_violation(r6_result, web)
+            return
 
     result = check_with_llm(text, list(message_window), channel_id=event.get("channel", ""))
     if not result or not result.get("violation"):


### PR DESCRIPTION
## Summary
- **R3 hybrid**: STRICT completion claims (`complete`, `all stores written`, etc.) → deterministic evidence check. SOFT `done` → LLM fallback for semantic disambiguation.
- **R6 hybrid**: save claims (`state saved`, `ceo_memory updated`, etc.) → deterministic store-specific evidence check.
- **RULES_PROMPT**: stripped from ~165L (all 9 rules) to ~27L (R3 SOFT + R9 only). ~80% prompt token reduction.
- **Pipeline**: R4/R2/R8 deterministic → R3/R6 hybrid → LLM (R3 SOFT + R9).

Part of Phase 5 enforcer optimization (governance round table 2026-05-11).

## Files changed
- `src/bot_common/enforcer_deterministic.py` — R3/R6 regex patterns + check functions (+128/-5)
- `src/bot_common/enforcer_rules.py` — RULES_PROMPT stripped, docstring updated (+12/-89)
- `src/slack_bot/central_listener.py` — R3/R6 wired into pipeline after R4/R2/R8 loop (+17/-5)

## Test plan
- [x] `check_r3` STRICT + evidence → PASS (skip LLM)
- [x] `check_r3` STRICT no evidence → VIOLATION (skip LLM)
- [x] `check_r3` SOFT no evidence → fall through to LLM
- [x] `check_r3` exception (gatekeeper) → PASS
- [x] `check_r6` save claim + evidence → PASS
- [x] `check_r6` save claim no evidence → VIOLATION
- [x] `check_r6` no claim → fall through to LLM
- [ ] 24h FP validation post-merge (Aiden owns metric)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>