### PR TITLE
[MAX] refactor(config): make repo CLAUDE.md callsign-neutral (Phase 6 W2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,6 @@
-# CLAUDE.md — Agency OS Project Config (Aiden worktree)
+# CLAUDE.md — Agency OS Project Config
+
+@IDENTITY.md
 
 @.claude/modules/_project_overview.md
 
@@ -20,7 +22,7 @@ Session START query:
 ```sql
 SELECT source_type AS type, LEFT(content, 200) AS preview, created_at::date AS date
 FROM public.agent_memories
-WHERE callsign = 'aiden' AND state != 'archived'
+WHERE callsign = '<your_callsign>' AND state != 'archived'
   AND source_type IN ('daily_log', 'core_fact')
 ORDER BY created_at DESC LIMIT 10;
 ```
@@ -28,7 +30,7 @@ ORDER BY created_at DESC LIMIT 10;
 Session END — write daily_log before closing:
 ```sql
 INSERT INTO public.agent_memories (id, callsign, source_type, content, typed_metadata, created_at, valid_from, state)
-VALUES (gen_random_uuid(), 'aiden', 'daily_log', '<summary: what was done, PRs, decisions, blockers>', '{}'::jsonb, NOW(), NOW(), 'confirmed');
+VALUES (gen_random_uuid(), '<your_callsign>', 'daily_log', '<summary: what was done, PRs, decisions, blockers>', '{}'::jsonb, NOW(), NOW(), 'confirmed');
 ```
 
 @.claude/modules/_governance_rules.md


### PR DESCRIPTION
## Summary
- Removed hardcoded "Aiden worktree" from repo CLAUDE.md title → generic "Agency OS Project Config"
- Added `@IDENTITY.md` import so each worktree auto-loads its per-worktree identity file at session start
- Parameterized `callsign = 'aiden'` → `callsign = '<your_callsign>'` in Supabase session queries

## Context (Phase 6 W2)
The repo CLAUDE.md is shared across all worktrees via git. It had Aiden-specific content (title, hardcoded callsign in SQL). This PR makes it callsign-neutral.

**Companion non-git changes (already applied):**
- `~/.claude/CLAUDE.md` trimmed 145→132 lines: removed Elliot identity block (→ IDENTITY.md), removed duplicate Step 0 RESTATE (kept in EVO Protocol), generalized Session Startup references
- Created `/home/elliotbot/clawd/Agency_OS/IDENTITY.md` for Elliot (gitignored, per-worktree)

## Verify
```
git diff main...HEAD -- CLAUDE.md
```

## Test plan
- [ ] Each worktree loads its local IDENTITY.md via @-import
- [ ] Supabase queries use correct callsign per worktree
- [ ] No governance content lost from global CLAUDE.md (132L, all cross-callsign sections intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)