### PR TITLE
[ELLIOT] docs(hierarchy): add _hierarchy.md module — auth chain (Dave directive #1)

### DIFF
--- a/.claude/modules/_hierarchy.md
+++ b/.claude/modules/_hierarchy.md
@@ -1,0 +1,16 @@
+## Authority Hierarchy (Dave 2026-05-11)
+
+Authoritative chain (work flows DOWN):
+
+```
+Dave → Claude (CEO) → Elliot (COO) → {Aiden, Max} (CTOs) → {Orion, Atlas} (engineers)
+```
+
+- **Engineers (Orion, Atlas)** — primary execution tier. Pick up dispatched tasks.
+- **CTOs (Aiden, Max)** — coordinate and queue when engineers saturated. Execute directly only when both engineers busy.
+- **COO (Elliot)** — operational protocols, audits, dispatch routing.
+- **CEO (Claude/Dave)** — strategic + governance.
+
+CTOs read `[BUSY:callsign:<task-id>]` / `[READY:callsign]` state from #execution before assigning. If engineer BUSY, CTO either does the work or drops a queue file in `/tmp/<callsign>-queue/<task-id>.json` for engineer to pick up on next `[READY]`.
+
+Work flows DOWN. Coordination + escalation flow UP.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@
 
 @.claude/modules/_law_architecture_first.md
 
+@.claude/modules/_hierarchy.md
+
 @.claude/modules/_mcp_bridge.md
 
 ## Supabase — Primary Memory Store (LAW IX)


### PR DESCRIPTION
## Summary

Per Dave 2026-05-11 operational directive #1: codify authority hierarchy in a `.claude/modules/_hierarchy.md` module that loads at every session start across all worktrees.

Authoritative chain (work flows DOWN):
```
Dave → Claude (CEO) → Elliot (COO) → {Aiden, Max} (CTOs) → {Orion, Atlas} (engineers)
```

## Why one PR, not five

All 5 worktrees (main, aiden, max, atlas, orion) share one repo. Committing once to main = every worktree inherits on rebase. No peer concur per Dave directive #1 ("no peer concur needed for doc adds").

## Changes

- `.claude/modules/_hierarchy.md` — 16-line module, new file
- `CLAUDE.md` — one `@.claude/modules/_hierarchy.md` import line between `_law_architecture_first.md` and `_mcp_bridge.md`

## Test plan

- [x] Module file syntactically valid markdown
- [x] CLAUDE.md @-import placed in correct slot (verified via `grep -n _hierarchy CLAUDE.md` → line 13)
- [ ] CI green (Backend Lint / MyPy / Tests / Frontend)
- [ ] After merge: peer worktrees rebase + module loads at next session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)