### PR TITLE
[AIDEN] feat(slack-relay): callsign-fix — explicit CALLSIGN + per-callsign allowlist

### DIFF
--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -30,11 +30,41 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
 
-CALLSIGN = os.environ.get("CALLSIGN", "aiden")
+
+def _resolve_callsign() -> str:
+    """Resolve callsign from env → IDENTITY.md → hard fail.
+
+    Per Dave directive #6 (callsign bug fix 2026-05-11): no silent default.
+    A relay that defaults to 'aiden' when run from the wrong worktree can
+    misattribute posts. Require explicit env OR ./IDENTITY.md resolution.
+    """
+    env_val = os.environ.get("CALLSIGN", "").strip()
+    if env_val:
+        return env_val.lower()
+    identity_path = Path(__file__).resolve().parent.parent / "IDENTITY.md"
+    if identity_path.exists():
+        match = re.search(
+            r"^\s*\*\*?CALLSIGN:?\*\*?\s*([A-Za-z]\w*)",
+            identity_path.read_text(),
+            re.IGNORECASE | re.MULTILINE,
+        )
+        if match:
+            return match.group(1).lower()
+    print(
+        "ERROR: CALLSIGN unresolved — set CALLSIGN env var or ensure "
+        f"{identity_path} contains a `**CALLSIGN:** <name>` header",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+CALLSIGN = _resolve_callsign()
 CALLSIGN_TAG = f"[{CALLSIGN.upper()}]"
 BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 USERNAME = os.environ.get("SLACK_BOT_USERNAME", CALLSIGN.capitalize())
@@ -50,14 +80,43 @@ _DEFAULT_ICON_BY_CALLSIGN: dict[str, str] = {
 ICON_EMOJI = os.environ.get("SLACK_BOT_ICON_EMOJI", _DEFAULT_ICON_BY_CALLSIGN.get(CALLSIGN, ""))
 ICON_URL = os.environ.get("SLACK_BOT_ICON_URL", "")
 
-# Channel IDs (verified 2026-05-11 per AIDEN-SLACK-MIGRATION-001 dispatch)
+# Channel IDs (verified 2026-05-11 per AIDEN-SLACK-MIGRATION-001 dispatch).
+# "ops" = Max's COO channel (mirrors coo_slack_relay.py CHANNELS dict).
 CHANNELS = {
     "execution": "C0B3QB0K1GQ",
     "ceo": "C0B2PM3TV0B",
     "alerts": "C0B2EJU53EK",
     "completed_directives": "C0B2U15PSEA",
+    "ops": "C0B2UCNRJ86",
 }
 DEFAULT_CHANNEL = os.environ.get("SLACK_DEFAULT_CHANNEL", CHANNELS["execution"])
+
+# Per-callsign outbound allowlist (Dave directive #6 callsign bug fix 2026-05-11).
+# Worktree's CALLSIGN determines which channels it may post to. #ceo is always
+# Dave-Elliot exclusive; clones (atlas/orion/scout) post to #execution only.
+# Aiden also writes #completed_directives per Protocol #4 (directive completion log).
+_ALLOWED_CHANNELS_BY_CALLSIGN: dict[str, frozenset[str]] = {
+    # Elliot (COO, runs prime worktree): execution + ceo + ops + completed_directives.
+    # Per Elliot Step 0 12:00:24 UTC ("main = execution+ceo+ops") + Protocol #4
+    # (completion log channel added to dispatch 2026-05-11 20:42).
+    "elliot": frozenset(
+        {
+            CHANNELS["execution"],
+            CHANNELS["ceo"],
+            CHANNELS["ops"],
+            CHANNELS["completed_directives"],
+        }
+    ),
+    # Aiden (build agent): execution + completed_directives (Protocol #4 mandate).
+    "aiden": frozenset({CHANNELS["execution"], CHANNELS["completed_directives"]}),
+    # Max (CTO): execution only (mirrors coo_slack_relay.py).
+    "max": frozenset({CHANNELS["execution"]}),
+    # Clones (atlas/orion/scout): execution only per Step 0.
+    "atlas": frozenset({CHANNELS["execution"]}),
+    "orion": frozenset({CHANNELS["execution"]}),
+    "scout": frozenset({CHANNELS["execution"]}),
+}
+ALLOWED_CHANNELS = _ALLOWED_CHANNELS_BY_CALLSIGN.get(CALLSIGN, frozenset({CHANNELS["execution"]}))
 
 
 def parse_args(argv: list[str]) -> tuple[str, str]:
@@ -95,6 +154,14 @@ def post(channel: str, text: str) -> dict:
     if not BOT_TOKEN:
         print("ERROR: SLACK_BOT_TOKEN not set", file=sys.stderr)
         sys.exit(2)
+    if channel not in ALLOWED_CHANNELS:
+        print(
+            f"ERROR: {CALLSIGN}-relay refuses post to {channel} — "
+            f"not in worktree allowlist {sorted(ALLOWED_CHANNELS)} "
+            f"(Dave directive #6, callsign bug fix)",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     if not text.startswith(CALLSIGN_TAG):
         text = f"{CALLSIGN_TAG} {text}"
     payload: dict = {"channel": channel, "text": text, "username": USERNAME}
@@ -129,6 +196,7 @@ def main() -> int:
         if _repo not in sys.path:
             sys.path.insert(0, _repo)
         from src.bot_common.verify_gate import gate_check as verify_gate_check
+
         ok, blocker = verify_gate_check(message)
         if not ok:
             print(f"R_VERIFY_BLOCKED: {blocker}", file=sys.stderr)
@@ -148,7 +216,7 @@ def main() -> int:
         allow, replacement = gate_check(message, CALLSIGN, BOT_TOKEN)
         if not allow and replacement is not None:
             message = replacement
-            print(f"⚠  concur-gate HELD original; posting CONCUR-REQUEST instead", file=sys.stderr)
+            print("⚠  concur-gate HELD original; posting CONCUR-REQUEST instead", file=sys.stderr)
     result = post(channel, message)
     if not result.get("ok"):
         print(f"ERROR: Slack rejected: {result}", file=sys.stderr)

--- a/tests/test_slack_relay_callsign_fix.py
+++ b/tests/test_slack_relay_callsign_fix.py
@@ -1,0 +1,94 @@
+"""tests for slack_relay.py CALLSIGN resolution + ALLOWED_CHANNELS guard.
+
+Per Dave directive #6 (callsign bug fix 2026-05-11): slack_relay must
+refuse to run without explicit CALLSIGN env or ./IDENTITY.md, and must
+refuse to post to channels not in the per-callsign allowlist.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RELAY = REPO_ROOT / "scripts" / "slack_relay.py"
+
+
+def _run(env: dict[str, str], args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    base_env = {"PATH": os.environ.get("PATH", "")}
+    base_env.update(env)
+    return subprocess.run(
+        [sys.executable, str(RELAY), *args],
+        env=base_env,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_callsign_resolves_from_identity_md(tmp_path: Path) -> None:
+    """No CALLSIGN env + IDENTITY.md present → resolves callsign from file."""
+    result = _run(
+        env={
+            "SLACK_BOT_TOKEN": "fake-token",
+            "R_VERIFY_SKIP": "1",
+            "CONCUR_GATE_SKIP": "1",
+        },
+        args=["-c", "C0B2PM3TV0B", "test"],
+    )
+    assert result.returncode == 2
+    assert "aiden-relay refuses post" in result.stderr
+    assert "not in worktree allowlist" in result.stderr
+
+
+def test_callsign_unresolved_exits_2(tmp_path: Path) -> None:
+    """No env, no IDENTITY.md → exit 2 with clear error."""
+    fake_repo = tmp_path / "fakerepo"
+    (fake_repo / "scripts").mkdir(parents=True)
+    relay_copy = fake_repo / "scripts" / "slack_relay.py"
+    relay_copy.write_bytes(RELAY.read_bytes())
+    result = subprocess.run(
+        [sys.executable, str(relay_copy), "-g", "test"],
+        env={"PATH": os.environ.get("PATH", "")},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 2
+    assert "CALLSIGN unresolved" in result.stderr
+
+
+def test_forbidden_channel_blocks() -> None:
+    """Posting to #ceo from aiden worktree → exit 2 with allowlist message."""
+    result = _run(
+        env={
+            "SLACK_BOT_TOKEN": "fake-token",
+            "R_VERIFY_SKIP": "1",
+            "CONCUR_GATE_SKIP": "1",
+            "CALLSIGN": "aiden",
+        },
+        args=["-c", "C0B2PM3TV0B", "ceo-block"],
+    )
+    assert result.returncode == 2
+    assert "aiden-relay refuses post to C0B2PM3TV0B" in result.stderr
+
+
+def test_env_callsign_overrides_identity(tmp_path: Path) -> None:
+    """CALLSIGN env wins over IDENTITY.md."""
+    result = _run(
+        env={
+            "SLACK_BOT_TOKEN": "fake-token",
+            "R_VERIFY_SKIP": "1",
+            "CONCUR_GATE_SKIP": "1",
+            "CALLSIGN": "elliot",
+        },
+        args=["-c", "C0B2EJU53EK", "alerts-block-for-elliot"],
+    )
+    # elliot allowlist = execution + ceo + completed_directives. #alerts blocked.
+    assert result.returncode == 2
+    assert "elliot-relay refuses post to C0B2EJU53EK" in result.stderr


### PR DESCRIPTION
## Summary

Per Dave directive #6 (Discussion #1 from Elliot dispatch 2026-05-11). Lock down `scripts/slack_relay.py` so it cannot misattribute or post to forbidden channels.

**Phase 1** — main + aiden worktrees (this PR).
**Phase 2** — atlas/orion clones (deferred per Step 0 sequencing).

## Changes

**(a) CALLSIGN resolution** — `_resolve_callsign()`:
1. CALLSIGN env var (if set, wins)
2. `./IDENTITY.md` `**CALLSIGN:** <name>` regex
3. Exit 2 with clear error

No silent default. Prevents the prime-worktree script defaulting to "aiden" when run from an elliot-context without explicit env.

**(b) Per-callsign outbound allowlist** — `_ALLOWED_CHANNELS_BY_CALLSIGN`:

| callsign | allowed channels |
|----------|-------------------|
| elliot   | execution + ceo + ops + completed_directives |
| aiden    | execution + completed_directives |
| max      | execution only (mirrors `coo_slack_relay.py`) |
| atlas/orion/scout | execution only |

`post()` refuses non-allowlisted channels with `exit 2`.

**(c) "ops" channel** (`C0B2UCNRJ86`) added to `CHANNELS` dict for parity with `coo_slack_relay.py`.

**(d) In-pass fix**: F541 (f-string without placeholders) on existing line 203 ("non-blockers are blockers").

## Test plan

- [x] `ruff check scripts/slack_relay.py` — All checks passed
- [x] `ruff format scripts/slack_relay.py --check` — 1 file already formatted
- [x] `python3 -m pytest tests/test_slack_relay_callsign_fix.py -v` — 4 passed in 0.69s
  - `test_callsign_resolves_from_identity_md` — IDENTITY.md resolution
  - `test_callsign_unresolved_exits_2` — no env + no IDENTITY.md → exit 2
  - `test_forbidden_channel_blocks` — #ceo from aiden refused
  - `test_env_callsign_overrides_identity` — env wins over IDENTITY.md
- [ ] CI green
- [ ] After merge: prime worktree auto-pull + restart any services using slack_relay

## Dispatch + concur status

[CONCUR:elliot] on Step 0 already posted 2026-05-11 20:43. Three-way: Max parked. Dual-concur authority sufficient per "Dual concur authority" rule.

[PROPOSE:AIDEN] merge after Elliot CI-green concur. Phase 2 (clones) follows after clone config audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)