### PR TITLE
[AIDEN] feat(enforcer): R3 evidence regex — pytest "N passed/failed" form

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -105,7 +105,8 @@ _R3_EVIDENCE_RE = re.compile(
     r"|PID\s+\d+"  # PID
     r"|ActiveState="  # systemd state
     r"|exit\s+code"  # exit code
-    r"|\d+/\d+\s+(?:pass|fail)"  # test counts
+    r"|\d+/\d+\s+(?:pass|fail)"  # test counts ratio form
+    r"|\d+\s+(?:passed|failed|error|errors)\b"  # pytest "N passed in 0.69s" form
     r"|tests?\s+pass"  # test pass
     r"|rows?\s+affected"  # SQL output
     r"|\bSELECT\b|\bINSERT\b|\bUPDATE\b"  # SQL keywords

--- a/tests/test_enforcer_r3_pytest_pattern.py
+++ b/tests/test_enforcer_r3_pytest_pattern.py
@@ -1,0 +1,47 @@
+"""Regression tests for R3 evidence regex — pytest output pattern (PR #708 follow-up).
+
+Per Elliot non-blocking note on PR #707: `_R3_EVIDENCE_RE` missed pytest
+output ("4 passed in 0.69s" form) because the prior `\\d+/\\d+\\s+(?:pass|fail)`
+pattern only covered the ratio form ("4/4 pass"). This module asserts the
+new `\\d+\\s+(?:passed|failed|error|errors)\\b` token catches the pytest form.
+"""
+
+from __future__ import annotations
+
+from src.bot_common.enforcer_deterministic import check_r3
+
+
+def test_pytest_passed_form_satisfies_strict_claim() -> None:
+    """Completion claim + verbatim 'N passed in Xs' pytest output → PASS."""
+    text = "Build complete. tests/test_x.py — 4 passed in 0.69s"
+    result, skip_llm = check_r3(text)
+    assert result is None
+    assert skip_llm is True
+
+
+def test_pytest_failed_form_satisfies_strict_claim() -> None:
+    """Completion claim + 'N failed' pytest output → PASS."""
+    text = "Task complete. tests/test_y.py — 2 failed in 1.20s"
+    result, skip_llm = check_r3(text)
+    assert result is None
+    assert skip_llm is True
+
+
+def test_pytest_errors_form_satisfies_strict_claim() -> None:
+    """Completion claim + '3 errors' form → PASS."""
+    text = "All stores written. 5 passed, 3 errors in 2.10s"
+    result, skip_llm = check_r3(text)
+    assert result is None
+    assert skip_llm is True
+
+
+def test_strict_claim_without_any_evidence_still_violates() -> None:
+    """Sanity: regression test the regex addition didn't broaden too much.
+
+    A bare completion claim with no evidence should STILL fire R3.
+    """
+    text = "Task complete. Ship it."
+    result, skip_llm = check_r3(text)
+    assert result is not None
+    assert result["rule_number"] == 3
+    assert skip_llm is True


### PR DESCRIPTION
## Summary

Follow-up to PR #707 (FP-tuning). Per [CONCUR:elliot] on the [PROPOSE:AIDEN] R3-pytest pattern proposal — 2026-05-11 21:48 UTC.

`_R3_EVIDENCE_RE` missed pytest output of the form `4 passed in 0.69s` because the prior `\d+/\d+\s+(?:pass|fail)` token only covered the ratio form (`4/4 pass`). My PR #708 post triggered an R3 FP for exactly this reason.

## Change

Single-line addition to `_R3_EVIDENCE_RE`:

```python
r"|\d+\s+(?:passed|failed|error|errors)\b"  # pytest "N passed in 0.69s" form
```

## Test plan

- [x] `ruff check src/` — All checks passed
- [x] `ruff format src/ --check` — 468 files already formatted
- [x] `python3 -m pytest tests/test_enforcer_r3_pytest_pattern.py -v` — 4 passed in 0.16s
  - `test_pytest_passed_form_satisfies_strict_claim`
  - `test_pytest_failed_form_satisfies_strict_claim`
  - `test_pytest_errors_form_satisfies_strict_claim`
  - `test_strict_claim_without_any_evidence_still_violates` (broadening sanity)
- [ ] CI green
- [ ] Merge before 24h validation window closes ~2026-05-12 11:22 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)