### PR TITLE
[MAX] fix(enforcer): R9 exempt regex — cover all protocol tags

### DIFF
--- a/src/slack_bot/central_listener.py
+++ b/src/slack_bot/central_listener.py
@@ -80,10 +80,11 @@ message_window: deque = deque(maxlen=MAX_WINDOW)
 
 # R9 (DIRECTIVE-INITIATIVE) post-LLM exempt patterns. FP-tuning 2026-05-11:
 # LLM mis-fires R9 on dispatches that already name concrete next-action subjects
-# ([PROPOSE:], "I'll/will <verb>", "@<name> ships/drops/owns <X>", @-mentions
-# for audit roll-ups). Suppress R9 fires when any of these are present.
+# ([PROPOSE:], [READY:], [BUSY:], [CONCUR-REQUEST], [FP-LOG:], [DISPATCH],
+# "I'll/will <verb>", "@<name> ships/drops/owns <X>"). Suppress R9 fires
+# when any of these structured protocol tags are present.
 _R9_EXEMPT_RE = re.compile(
-    r"\[propose:\w+\]"
+    r"\[(?:propose|ready|busy|concur-request|concur|fp-log|valid-fire|dispatch)[\w:-]*\]"
     r"|\b(?:i'?ll|i will|aiden will|elliot will|max will|orion will|atlas will|scout will)\b"
     r"|@\w+\s+(?:ships?|drops?|owns?|takes?|opens?|merges?|files?|pushes?)\b"
     r"|@\w+\s+—\s+(?:roll-?up|audit|review|own|next)",


### PR DESCRIPTION
## Summary
- Expand `_R9_EXEMPT_RE` from `[propose:]` only to all structured protocol tags: `[ready:]`, `[busy:]`, `[concur-request]`, `[concur:]`, `[fp-log:]`, `[valid-fire:]`, `[dispatch]`
- These tags are definitionally not agenda-setting — they are governance coordination protocol, not requests for Dave to set the agenda
- Post-tuning FP data: R9 fired 3x on messages with `[READY:aiden]` and `[CONCUR-REQUEST:aiden]` that the prior regex didn't cover

## Scope
1 file, 1 regex line changed (`src/slack_bot/central_listener.py`)

## Test plan
- [ ] CI green (lint, mypy, pytest, frontend)
- [ ] Deploy to prime worktree + restart central_listener
- [ ] Monitor R9 fires in remaining validation window — protocol-tagged messages should no longer trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)