### PR TITLE
[MAX] fix(enforcer): consume r3_skip/r6_skip flags before LLM call

### DIFF
--- a/src/slack_bot/central_listener.py
+++ b/src/slack_bot/central_listener.py
@@ -269,6 +269,9 @@ def run_enforcer(event: dict, text: str, web: WebClient) -> None:
             _fire_violation(r6_result, web)
             return
 
+        if r3_skip and r6_skip:
+            return
+
     result = check_with_llm(text, list(message_window), channel_id=event.get("channel", ""))
     if not result or not result.get("violation"):
         return


### PR DESCRIPTION
## Summary
- **Root cause fix for R3 false positives.** `check_r3()` and `check_r6()` return `skip_llm=True` when evidence is found (deterministic PASS), but the LLM call runs unconditionally and overrides the result.
- 10 R3 FPs in this session caused by this bug. Flagged 4 times in #execution before this fix.
- When both hybrid rules resolve deterministically, skip the LLM — nothing left to check except R9, which has its own post-LLM exempt filter.

## Scope
1 file, 1 line added (`src/slack_bot/central_listener.py`)

```python
if r3_skip and r6_skip:
    return
```

## Test plan
- [ ] CI green
- [ ] Deploy to prime + restart central_listener
- [ ] R3 FPs on evidence-bearing messages should stop entirely
- [ ] R9 post-LLM exempt continues to work (separate code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)