### PR TITLE
[AIDEN] feat(drevon-pra): session store — 5-table foundation + ORM + hooks + tests

### DIFF
--- a/.claude/hooks/session_store_posttooluse.sh
+++ b/.claude/hooks/session_store_posttooluse.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Drevon PR-A — PostToolUse hook that records turn_logs + turn_files rows
+# into the 5-table session store. NOT yet wired in .claude/settings.json
+# (follow-up). Standalone-callable for manual testing.
+#
+# Per Elliot dispatch 2026-05-11: Python ORM + Claude Code hooks for write
+# paths. Auto-creates a session row on first invocation if /tmp/.session_<callsign>
+# state file is missing. Stop hook closes the session.
+#
+# stdin format (Claude Code PostToolUse):
+#   { "tool_name": "Edit", "tool_input": {...}, "tool_response": {...}, ... }
+#
+# Best-effort recording — exits 0 on all failures. Never blocks the agent.
+
+set -u
+
+LOG_DIR="${SESSION_STORE_LOG_DIR:-/tmp/agency-os-session-store}"
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+
+PAYLOAD="$(cat || true)"
+
+callsign="${CALLSIGN:-}"
+if [[ -z "$callsign" && -r ./IDENTITY.md ]]; then
+    callsign="$(grep -m1 -oE '\*\*CALLSIGN:\*\* [A-Za-z]+' ./IDENTITY.md 2>/dev/null \
+        | sed 's/^.*\*\* //' | tr '[:upper:]' '[:lower:]')"
+fi
+callsign="${callsign:-unknown}"
+
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+SESSION_STATE_FILE="/tmp/.session_${callsign}"
+
+# Local audit line first (cheap, always works)
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+tool_name="unknown"
+if command -v jq >/dev/null 2>&1 && [[ -n "$PAYLOAD" ]]; then
+    tool_name="$(printf '%s' "$PAYLOAD" | jq -r '.tool_name // "unknown"' 2>/dev/null || echo unknown)"
+fi
+printf '%s\t%s\t%s\n' "$ts" "$callsign" "$tool_name" \
+    >>"$LOG_DIR/posttooluse.log" 2>/dev/null || true
+
+# Background recorder write (fire and forget, never blocks).
+(
+    PYTHONPATH="$REPO_ROOT" CALLSIGN="$callsign" \
+        /home/elliotbot/clawd/venv/bin/python3 -c "
+import json, os, sys, hashlib
+sys.path.insert(0, os.environ.get('PYTHONPATH', '.'))
+try:
+    from src.session_store.recorder import record_session_start, record_tool_call, record_turn_start
+except Exception as e:
+    sys.stderr.write(f'session_store import failed: {e}\n')
+    sys.exit(0)
+
+callsign = os.environ.get('CALLSIGN', 'unknown')
+state_file = f'/tmp/.session_{callsign}'
+
+# Resolve or create session
+sid = None
+if os.path.exists(state_file):
+    try:
+        sid = open(state_file).read().strip().split(':')[0] or None
+    except Exception:
+        sid = None
+if not sid:
+    new_sid = record_session_start(callsign=callsign, working_directory=os.getcwd())
+    if new_sid is not None:
+        sid = str(new_sid)
+        open(state_file, 'w').write(f'{sid}:0:0')  # session_id:turn_index:tool_index
+if not sid:
+    sys.exit(0)
+
+# Resolve or create turn (single turn per session for V1 — turn boundaries
+# in Claude Code aren't directly observable from hooks alone; Stop hook
+# will close it).
+parts = open(state_file).read().strip().split(':') if os.path.exists(state_file) else [sid, '0', '0']
+turn_index = int(parts[1]) if len(parts) > 1 else 0
+tool_index = int(parts[2]) if len(parts) > 2 else 0
+turn_id = None
+turn_state_file = f'/tmp/.turn_{callsign}'
+if os.path.exists(turn_state_file):
+    try:
+        turn_id = open(turn_state_file).read().strip() or None
+    except Exception:
+        turn_id = None
+if not turn_id:
+    from uuid import UUID
+    new_tid = record_turn_start(session_id=UUID(sid), turn_index=turn_index)
+    if new_tid is not None:
+        turn_id = str(new_tid)
+        open(turn_state_file, 'w').write(turn_id)
+if not turn_id:
+    sys.exit(0)
+
+# Parse payload + record tool call
+payload_text = sys.stdin.read().strip() if not sys.stdin.isatty() else ''
+try:
+    payload = json.loads(payload_text) if payload_text else {}
+except json.JSONDecodeError:
+    payload = {}
+
+tool_name = payload.get('tool_name') or 'unknown'
+tool_input = payload.get('tool_input') or {}
+
+# Build files list from tool_input where it makes sense
+files = []
+file_path = tool_input.get('file_path') or tool_input.get('notebook_path')
+if file_path and tool_name in ('Write', 'Edit', 'NotebookEdit', 'Read'):
+    op = 'write' if tool_name == 'Write' else ('edit' if tool_name in ('Edit', 'NotebookEdit') else 'read')
+    files.append({'file_path': file_path, 'operation': op})
+
+from uuid import UUID
+record_tool_call(
+    turn_id=UUID(turn_id),
+    tool_name=tool_name,
+    tool_args=tool_input,
+    exit_status='success',
+    files=files or None,
+)
+
+# Increment counters
+new_tool_index = tool_index + 1
+open(state_file, 'w').write(f'{sid}:{turn_index}:{new_tool_index}')
+" <<< "$PAYLOAD" 2>>"$LOG_DIR/recorder.err" &
+    disown 2>/dev/null || true
+)
+
+exit 0

--- a/.claude/hooks/session_store_stop.sh
+++ b/.claude/hooks/session_store_stop.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Drevon PR-A — Stop hook that closes the open session row (status='closed').
+# Companion to .claude/hooks/session_store_posttooluse.sh which opens it.
+# Best-effort recording — always exits 0. NOT yet wired in .claude/settings.json
+# (follow-up).
+
+set -u
+
+LOG_DIR="${SESSION_STORE_LOG_DIR:-/tmp/agency-os-session-store}"
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+
+callsign="${CALLSIGN:-}"
+if [[ -z "$callsign" && -r ./IDENTITY.md ]]; then
+    callsign="$(grep -m1 -oE '\*\*CALLSIGN:\*\* [A-Za-z]+' ./IDENTITY.md 2>/dev/null \
+        | sed 's/^.*\*\* //' | tr '[:upper:]' '[:lower:]')"
+fi
+callsign="${callsign:-unknown}"
+
+SESSION_STATE_FILE="/tmp/.session_${callsign}"
+TURN_STATE_FILE="/tmp/.turn_${callsign}"
+
+# Local audit line
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf '%s\t%s\t session_end\n' "$ts" "$callsign" \
+    >>"$LOG_DIR/stop.log" 2>/dev/null || true
+
+# Background write
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+(
+    PYTHONPATH="$REPO_ROOT" CALLSIGN="$callsign" \
+        /home/elliotbot/clawd/venv/bin/python3 -c "
+import os, sys
+sys.path.insert(0, os.environ.get('PYTHONPATH', '.'))
+try:
+    from src.session_store.recorder import record_session_end, record_turn_complete
+except Exception as e:
+    sys.stderr.write(f'session_store import failed: {e}\n')
+    sys.exit(0)
+
+callsign = os.environ.get('CALLSIGN', 'unknown')
+session_state = f'/tmp/.session_{callsign}'
+turn_state = f'/tmp/.turn_{callsign}'
+
+# Close open turn (if any)
+if os.path.exists(turn_state):
+    try:
+        from uuid import UUID
+        tid = open(turn_state).read().strip()
+        if tid:
+            record_turn_complete(turn_id=UUID(tid), status='completed')
+        os.remove(turn_state)
+    except Exception as e:
+        sys.stderr.write(f'turn close failed: {e}\n')
+
+# Close session
+if os.path.exists(session_state):
+    try:
+        from uuid import UUID
+        sid = open(session_state).read().strip().split(':')[0]
+        if sid:
+            record_session_end(session_id=UUID(sid), status='closed')
+        os.remove(session_state)
+    except Exception as e:
+        sys.stderr.write(f'session close failed: {e}\n')
+" 2>>"$LOG_DIR/recorder.err" &
+    disown 2>/dev/null || true
+)
+
+exit 0

--- a/src/models/session_store.py
+++ b/src/models/session_store.py
@@ -1,0 +1,132 @@
+"""
+Contract: src/models/session_store.py
+Purpose: SQLAlchemy models for Drevon PR-A session store (5 tables).
+Layer: 1 - models
+Imports: stdlib + src.models.base
+Consumers: src/session_store/recorder.py (write paths), Drevon PR-B/C/D (read paths)
+Migration: supabase/migrations/20260511_drevon_session_store.sql
+Spec: Drevon PR-A — Dave directive 2026-05-11, Elliot dispatch ts 1778540XXX
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base, SoftDeleteMixin, UUIDMixin
+
+
+class Session(Base, UUIDMixin, SoftDeleteMixin):
+    """One row per Claude Code process lifetime.
+
+    `session_uuid` is Claude Code's --session-id, used by PR-C UUID resumption.
+    `status` text enum: 'active' | 'closed' | 'stuck'.
+    """
+
+    __tablename__ = "sessions"
+
+    callsign: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    session_uuid: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    working_directory: Mapped[str] = mapped_column(Text, nullable=False)
+    tmux_session: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="active")
+    model_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    extra: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+
+
+class Message(Base, UUIDMixin, SoftDeleteMixin):
+    """User/assistant message within a session.
+
+    `role` text enum: 'user' | 'assistant' | 'system'.
+    `message_index` is 0-based ordering within the session.
+    Content may be stored as hash-only for large transcripts.
+    """
+
+    __tablename__ = "messages"
+
+    session_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("sessions.id", ondelete="CASCADE"), nullable=False
+    )
+    role: Mapped[str] = mapped_column(String(32), nullable=False)
+    message_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    content_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+
+class Turn(Base, UUIDMixin, SoftDeleteMixin):
+    """Atomic assistant turn (one user message → tool calls → response).
+
+    `status` text enum: 'in_progress' | 'completed' | 'error'.
+    Cost columns populated by Stop hook (per-turn rollup).
+    """
+
+    __tablename__ = "turns"
+
+    session_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("sessions.id", ondelete="CASCADE"), nullable=False
+    )
+    trigger_message_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("messages.id", ondelete="SET NULL"), nullable=True
+    )
+    turn_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="in_progress")
+    input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    output_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost_aud: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
+
+
+class TurnLog(Base, UUIDMixin, SoftDeleteMixin):
+    """Individual tool invocation within a turn.
+
+    `tool_name`: 'Bash' | 'Read' | 'Edit' | 'Write' | ... | 'Agent' | 'mcp__*'.
+    `exit_status` text enum: 'success' | 'error' | 'denied' | 'timeout'.
+    """
+
+    __tablename__ = "turn_logs"
+
+    turn_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("turns.id", ondelete="CASCADE"), nullable=False
+    )
+    tool_name: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    tool_args_json: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    tool_args_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tool_result_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tool_result_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    exit_status: Mapped[str] = mapped_column(String(32), nullable=False, default="success")
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+
+class TurnFile(Base, UUIDMixin, SoftDeleteMixin):
+    """File created/modified/read during a turn_log.
+
+    `operation` text enum: 'read' | 'write' | 'edit' | 'delete' | 'create'.
+    """
+
+    __tablename__ = "turn_files"
+
+    turn_log_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("turn_logs.id", ondelete="CASCADE"), nullable=False
+    )
+    file_path: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    operation: Mapped[str] = mapped_column(String(32), nullable=False)
+    bytes_written: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    bytes_read: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    lines_added: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    lines_removed: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/src/session_store/__init__.py
+++ b/src/session_store/__init__.py
@@ -1,0 +1,34 @@
+"""src/session_store — Drevon PR-A write paths for the 5-table session store.
+
+Public interface:
+    record_session_start(...) — open a sessions row when Claude Code launches.
+    record_message(...) — append a messages row.
+    record_turn_start(...) — open a turns row.
+    record_tool_call(...) — append a turn_logs row with optional turn_files rows.
+    record_turn_complete(...) — close a turns row with cost rollup.
+    record_session_end(...) — close a sessions row (status='closed').
+    mark_session_stuck(...) — watchdog marks status='stuck'.
+
+Hooks under .claude/hooks/ invoke these via subprocess. Models live in
+src/models/session_store.py; migration is supabase/migrations/20260511_drevon_session_store.sql.
+"""
+
+from src.session_store.recorder import (
+    mark_session_stuck,
+    record_message,
+    record_session_end,
+    record_session_start,
+    record_tool_call,
+    record_turn_complete,
+    record_turn_start,
+)
+
+__all__ = [
+    "mark_session_stuck",
+    "record_message",
+    "record_session_end",
+    "record_session_start",
+    "record_tool_call",
+    "record_turn_complete",
+    "record_turn_start",
+]

--- a/src/session_store/recorder.py
+++ b/src/session_store/recorder.py
@@ -1,0 +1,220 @@
+"""recorder.py — write paths for the Drevon PR-A session store.
+
+Thin functional layer over src.evo.supabase_client REST helpers. All writes
+are idempotent-on-id where possible (sessions: id returned by INSERT;
+subsequent rows reference that UUID).
+
+Hooks under .claude/hooks/ invoke these via subprocess (`python3 -c "from
+src.session_store import record_tool_call; record_tool_call(...)"`).
+
+Error handling: log + swallow. Recording is best-effort; missing rows must
+NEVER block agent execution. Per PR-A spec: NO retroactive backfill, NEW
+sessions only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from src.evo.supabase_client import sb_patch, sb_post
+
+logger = logging.getLogger("session_store.recorder")
+
+
+def _utc_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _safe_post(table: str, payload: dict) -> dict | None:
+    """POST + log+swallow on failure (best-effort recording)."""
+    try:
+        rows = sb_post(table, payload)
+        return rows[0] if rows else None
+    except Exception as exc:
+        logger.warning("session_store %s POST failed: %s", table, exc)
+        return None
+
+
+def _safe_patch(table: str, params: dict, payload: dict) -> None:
+    try:
+        sb_patch(table, params, payload)
+    except Exception as exc:
+        logger.warning("session_store %s PATCH failed: %s", table, exc)
+
+
+def record_session_start(
+    callsign: str,
+    working_directory: str,
+    *,
+    session_uuid: str | None = None,
+    tmux_session: str | None = None,
+    model_id: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> UUID | None:
+    """Open a sessions row. Returns the row's UUID, or None on failure."""
+    sid = uuid4()
+    payload = {
+        "id": str(sid),
+        "callsign": callsign,
+        "session_uuid": session_uuid,
+        "working_directory": working_directory,
+        "tmux_session": tmux_session,
+        "started_at": _utc_iso(),
+        "status": "active",
+        "model_id": model_id,
+        "extra": extra or {},
+    }
+    row = _safe_post("sessions", payload)
+    return sid if row else None
+
+
+def record_message(
+    session_id: UUID,
+    role: str,
+    message_index: int,
+    content_text: str | None = None,
+    *,
+    content_bytes: int | None = None,
+    store_full_content: bool = False,
+) -> UUID | None:
+    """Append a messages row. If store_full_content=False, content_text is None
+    in the row (only hash + bytes preserved). Caller decides the trade-off."""
+    mid = uuid4()
+    text_for_hash = content_text or ""
+    payload = {
+        "id": str(mid),
+        "session_id": str(session_id),
+        "role": role,
+        "message_index": message_index,
+        "timestamp": _utc_iso(),
+        "content_hash": _hash(text_for_hash) if text_for_hash else None,
+        "content_text": content_text if store_full_content else None,
+        "content_bytes": content_bytes
+        if content_bytes is not None
+        else len(text_for_hash.encode("utf-8")),
+    }
+    row = _safe_post("messages", payload)
+    return mid if row else None
+
+
+def record_turn_start(
+    session_id: UUID,
+    turn_index: int,
+    trigger_message_id: UUID | None = None,
+) -> UUID | None:
+    """Open a turns row."""
+    tid = uuid4()
+    payload = {
+        "id": str(tid),
+        "session_id": str(session_id),
+        "trigger_message_id": str(trigger_message_id) if trigger_message_id else None,
+        "turn_index": turn_index,
+        "started_at": _utc_iso(),
+        "status": "in_progress",
+    }
+    row = _safe_post("turns", payload)
+    return tid if row else None
+
+
+def record_turn_complete(
+    turn_id: UUID,
+    *,
+    status: str = "completed",
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    cost_aud: float | None = None,
+) -> None:
+    """Close a turns row with cost rollup."""
+    payload: dict[str, Any] = {
+        "completed_at": _utc_iso(),
+        "status": status,
+    }
+    if input_tokens is not None:
+        payload["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        payload["output_tokens"] = output_tokens
+    if cost_aud is not None:
+        payload["cost_aud"] = cost_aud
+    _safe_patch("turns", {"id": f"eq.{turn_id}"}, payload)
+
+
+def record_tool_call(
+    turn_id: UUID,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    *,
+    tool_result_summary: str | None = None,
+    tool_result_bytes: int | None = None,
+    exit_status: str = "success",
+    error_message: str | None = None,
+    duration_ms: int | None = None,
+    files: list[dict[str, Any]] | None = None,
+) -> UUID | None:
+    """Append a turn_logs row, plus optional turn_files rows for file ops.
+
+    files is a list of dicts with keys matching turn_files columns
+    (file_path, operation, bytes_written, bytes_read, content_hash,
+    lines_added, lines_removed).
+    """
+    lid = uuid4()
+    import json as _json
+
+    args_json_str = _json.dumps(tool_args, default=str)
+    payload = {
+        "id": str(lid),
+        "turn_id": str(turn_id),
+        "tool_name": tool_name,
+        "tool_args_json": tool_args,
+        "tool_args_bytes": len(args_json_str.encode("utf-8")),
+        "tool_result_summary": tool_result_summary,
+        "tool_result_bytes": tool_result_bytes,
+        "exit_status": exit_status,
+        "error_message": error_message,
+        "started_at": _utc_iso(),
+        "completed_at": _utc_iso(),
+        "duration_ms": duration_ms,
+    }
+    row = _safe_post("turn_logs", payload)
+    if not row:
+        return None
+    for f in files or []:
+        f_payload = {
+            "id": str(uuid4()),
+            "turn_log_id": str(lid),
+            "file_path": f["file_path"],
+            "operation": f["operation"],
+            "bytes_written": f.get("bytes_written"),
+            "bytes_read": f.get("bytes_read"),
+            "content_hash": f.get("content_hash"),
+            "lines_added": f.get("lines_added"),
+            "lines_removed": f.get("lines_removed"),
+            "timestamp": _utc_iso(),
+        }
+        _safe_post("turn_files", f_payload)
+    return lid
+
+
+def record_session_end(session_id: UUID, *, status: str = "closed") -> None:
+    """Close a sessions row."""
+    _safe_patch(
+        "sessions",
+        {"id": f"eq.{session_id}"},
+        {"ended_at": _utc_iso(), "status": status},
+    )
+
+
+def mark_session_stuck(session_id: UUID) -> None:
+    """Watchdog marker — sets status='stuck' and ended_at without graceful close."""
+    _safe_patch(
+        "sessions",
+        {"id": f"eq.{session_id}"},
+        {"ended_at": _utc_iso(), "status": "stuck"},
+    )

--- a/supabase/migrations/20260511_drevon_session_store.sql
+++ b/supabase/migrations/20260511_drevon_session_store.sql
@@ -1,0 +1,229 @@
+-- Migration: 20260511_drevon_session_store.sql
+-- Purpose: Drevon PR-A — session store foundation (Dave directive 2026-05-11,
+--          Elliot dispatch ts 1778540XXX). 5-table audit + replay store for
+--          every agent action. Unblocks PR-B (skill-gen), PR-C (UUID resume),
+--          PR-D (dynamic CLAUDE.md).
+--
+-- Tables:
+--   sessions    — one row per Claude Code process lifetime (includes session_uuid
+--                 for PR-C resumption)
+--   messages    — user/assistant messages within a session
+--   turns       — atomic assistant turn (one user msg → tool calls → response)
+--   turn_logs   — individual tool invocations within a turn
+--   turn_files  — files created/modified/read during a turn_log
+--
+-- Conventions follow vendor_usage_log precedent (PR #649):
+--   - UUID primary keys, gen_random_uuid()
+--   - TIMESTAMPTZ for all timestamps
+--   - Soft-delete via deleted_at
+--   - Partial indexes filtering deleted_at IS NULL
+--   - RLS enabled; platform admin (CRUD) + client member (read) policies
+--
+-- No retroactive backfill (Elliot explicit). New sessions only.
+-- Created: 2026-05-11
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table 1: sessions — Claude Code process lifetime
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Identity
+    callsign TEXT NOT NULL,                                  -- 'elliot'|'aiden'|'max'|'atlas'|'orion'|'scout'
+    session_uuid TEXT,                                       -- Claude Code's --session-id (PR-C resumption key)
+
+    -- Context
+    working_directory TEXT NOT NULL,                         -- worktree path
+    tmux_session TEXT,                                       -- e.g. 'aiden', 'orion' — nullable for non-tmux sessions
+
+    -- Lifecycle
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ended_at TIMESTAMPTZ,                                    -- NULL = active session
+    status TEXT NOT NULL DEFAULT 'active',                   -- 'active'|'closed'|'stuck' (text enum, no PG enum coupling)
+
+    -- Metadata
+    model_id TEXT,                                           -- e.g. 'claude-opus-4-7' captured at session start
+    extra JSONB NOT NULL DEFAULT '{}'::jsonb,                -- agent-specific context
+
+    -- Soft delete
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_callsign_started
+    ON sessions(callsign, started_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_sessions_session_uuid
+    ON sessions(session_uuid) WHERE session_uuid IS NOT NULL AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_sessions_active
+    ON sessions(callsign) WHERE ended_at IS NULL AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_sessions_status
+    ON sessions(status) WHERE deleted_at IS NULL;
+
+ALTER TABLE sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY sessions_platform_admin ON sessions
+    FOR ALL TO authenticated
+    USING (EXISTS (SELECT 1 FROM users u WHERE u.id = auth.uid() AND u.is_platform_admin = true));
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table 2: messages — user/assistant messages within a session
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+
+    -- Role + ordering
+    role TEXT NOT NULL,                                      -- 'user'|'assistant'|'system'
+    message_index INTEGER NOT NULL,                          -- 0-based ordering within session
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Content (text optional — large transcripts may store hash only)
+    content_hash TEXT,                                       -- sha256 of full content
+    content_text TEXT,                                       -- truncated or full body — caller's choice
+    content_bytes INTEGER,                                   -- byte count of full content
+
+    -- Soft delete
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_session_idx
+    ON messages(session_id, message_index) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_messages_session_ts
+    ON messages(session_id, timestamp) WHERE deleted_at IS NULL;
+
+ALTER TABLE messages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY messages_platform_admin ON messages
+    FOR ALL TO authenticated
+    USING (EXISTS (SELECT 1 FROM users u WHERE u.id = auth.uid() AND u.is_platform_admin = true));
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table 3: turns — atomic assistant turn (one user msg → tool calls → response)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS turns (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    trigger_message_id UUID REFERENCES messages(id) ON DELETE SET NULL,
+
+    -- Ordering
+    turn_index INTEGER NOT NULL,                             -- 0-based within session
+
+    -- Lifecycle
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    status TEXT NOT NULL DEFAULT 'in_progress',              -- 'in_progress'|'completed'|'error'
+
+    -- Cost (per-turn rollup written by Stop hook)
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cost_aud DECIMAL(10, 6),
+
+    -- Soft delete
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_turns_session_idx
+    ON turns(session_id, turn_index) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_turns_session_started
+    ON turns(session_id, started_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_turns_status
+    ON turns(status) WHERE deleted_at IS NULL;
+
+ALTER TABLE turns ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY turns_platform_admin ON turns
+    FOR ALL TO authenticated
+    USING (EXISTS (SELECT 1 FROM users u WHERE u.id = auth.uid() AND u.is_platform_admin = true));
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table 4: turn_logs — individual tool invocations within a turn
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS turn_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    turn_id UUID NOT NULL REFERENCES turns(id) ON DELETE CASCADE,
+
+    -- Tool invocation
+    tool_name TEXT NOT NULL,                                 -- 'Bash'|'Read'|'Edit'|'Write'|...|'Agent'|'mcp__...'
+    tool_args_json JSONB NOT NULL DEFAULT '{}'::jsonb,       -- captured args (may be redacted/truncated)
+    tool_args_bytes INTEGER,                                 -- original arg-payload byte count
+
+    -- Result
+    tool_result_summary TEXT,                                -- first N chars or hash for evidence
+    tool_result_bytes INTEGER,                               -- result-payload byte count
+    exit_status TEXT NOT NULL DEFAULT 'success',             -- 'success'|'error'|'denied'|'timeout'
+    error_message TEXT,                                      -- non-null when exit_status != 'success'
+
+    -- Lifecycle
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    duration_ms INTEGER,
+
+    -- Soft delete
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_turn_logs_turn_started
+    ON turn_logs(turn_id, started_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_turn_logs_tool_name
+    ON turn_logs(tool_name) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_turn_logs_exit_status
+    ON turn_logs(exit_status) WHERE deleted_at IS NULL;
+
+ALTER TABLE turn_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY turn_logs_platform_admin ON turn_logs
+    FOR ALL TO authenticated
+    USING (EXISTS (SELECT 1 FROM users u WHERE u.id = auth.uid() AND u.is_platform_admin = true));
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table 5: turn_files — files created/modified/read during a turn_log
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS turn_files (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    turn_log_id UUID NOT NULL REFERENCES turn_logs(id) ON DELETE CASCADE,
+
+    -- File identity
+    file_path TEXT NOT NULL,                                 -- absolute path
+    operation TEXT NOT NULL,                                 -- 'read'|'write'|'edit'|'delete'|'create'
+
+    -- Change tracking
+    bytes_written INTEGER,                                   -- write/edit/create only
+    bytes_read INTEGER,                                      -- read only
+    content_hash TEXT,                                       -- sha256 of post-operation content (write/edit)
+    lines_added INTEGER,                                     -- edit/write only
+    lines_removed INTEGER,                                   -- edit only
+
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Soft delete
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_turn_files_turn_log
+    ON turn_files(turn_log_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_turn_files_path
+    ON turn_files(file_path) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_turn_files_operation
+    ON turn_files(operation) WHERE deleted_at IS NULL;
+
+ALTER TABLE turn_files ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY turn_files_platform_admin ON turn_files
+    FOR ALL TO authenticated
+    USING (EXISTS (SELECT 1 FROM users u WHERE u.id = auth.uid() AND u.is_platform_admin = true));
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Updated-at trigger (mirrors the agency-wide pattern)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Not adding updated_at columns by default — these tables are append-mostly.
+-- If a future migration adds updated_at, follow the trigger pattern from
+-- ceo_memory / agent_memories.
+
+COMMENT ON TABLE sessions IS 'Drevon PR-A — one row per Claude Code process lifetime';
+COMMENT ON TABLE messages IS 'Drevon PR-A — user/assistant messages within a session';
+COMMENT ON TABLE turns IS 'Drevon PR-A — atomic assistant turn (one user msg → tool calls → response)';
+COMMENT ON TABLE turn_logs IS 'Drevon PR-A — individual tool invocations within a turn';
+COMMENT ON TABLE turn_files IS 'Drevon PR-A — files created/modified/read during a turn_log';

--- a/tests/session_store/test_recorder.py
+++ b/tests/session_store/test_recorder.py
@@ -110,16 +110,17 @@ def test_record_turn_start_writes_turns_row(captured_posts) -> None:
     assert payload["status"] == "in_progress"
 
 
-def test_record_tool_call_writes_log_and_files(captured_posts) -> None:
+def test_record_tool_call_writes_log_and_files(captured_posts, tmp_path) -> None:
     tid = UUID("00000000-0000-0000-0000-000000000002")
+    fake_file = str(tmp_path / "x.py")
     lid = recorder.record_tool_call(
         turn_id=tid,
         tool_name="Edit",
-        tool_args={"file_path": "/tmp/x.py", "old_string": "a", "new_string": "b"},
+        tool_args={"file_path": fake_file, "old_string": "a", "new_string": "b"},
         exit_status="success",
         files=[
             {
-                "file_path": "/tmp/x.py",
+                "file_path": fake_file,
                 "operation": "edit",
                 "lines_added": 1,
                 "lines_removed": 1,
@@ -134,7 +135,7 @@ def test_record_tool_call_writes_log_and_files(captured_posts) -> None:
     assert log_call[1]["tool_name"] == "Edit"
     assert log_call[1]["exit_status"] == "success"
     assert files_call[0] == "turn_files"
-    assert files_call[1]["file_path"] == "/tmp/x.py"
+    assert files_call[1]["file_path"] == fake_file
     assert files_call[1]["operation"] == "edit"
     assert files_call[1]["lines_added"] == 1
 
@@ -150,7 +151,7 @@ def test_record_turn_complete_patches_turns_row(captured_patches) -> None:
     assert payload["status"] == "completed"
     assert payload["input_tokens"] == 1000
     assert payload["output_tokens"] == 500
-    assert payload["cost_aud"] == 0.05
+    assert payload["cost_aud"] == pytest.approx(0.05)
     assert "completed_at" in payload
 
 
@@ -167,17 +168,17 @@ def test_record_session_end_patches_sessions_row(captured_patches) -> None:
 def test_mark_session_stuck(captured_patches) -> None:
     sid = UUID("00000000-0000-0000-0000-000000000005")
     recorder.mark_session_stuck(session_id=sid)
-    table, params, payload = captured_patches[0]
+    table, _params, payload = captured_patches[0]
     assert table == "sessions"
     assert payload["status"] == "stuck"
 
 
-def test_swallow_on_failure() -> None:
+def test_swallow_on_failure(tmp_path) -> None:
     """sb_post raises → recorder returns None, no exception bubbles up."""
 
     def raise_fn(*args, **kwargs):
         raise RuntimeError("supabase down")
 
     with patch.object(recorder, "sb_post", side_effect=raise_fn):
-        sid = recorder.record_session_start(callsign="aiden", working_directory="/tmp")
+        sid = recorder.record_session_start(callsign="aiden", working_directory=str(tmp_path))
         assert sid is None  # best-effort: no row created, but no exception

--- a/tests/session_store/test_recorder.py
+++ b/tests/session_store/test_recorder.py
@@ -1,0 +1,183 @@
+"""tests for src/session_store/recorder.py — write paths for Drevon PR-A.
+
+Mocks supabase_client.sb_post + sb_patch so tests run without Supabase
+network access. Asserts: correct payload shape per table + best-effort
+swallow-on-failure semantics.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+
+from src.session_store import recorder
+
+
+@pytest.fixture
+def captured_posts() -> list[tuple[str, dict]]:
+    """Capture all sb_post calls. Each entry is (table, payload)."""
+    calls: list[tuple[str, dict]] = []
+
+    def fake_post(table: str, payload: dict) -> list:
+        calls.append((table, payload))
+        return [{"id": payload.get("id", "fake-id")}]
+
+    with patch.object(recorder, "sb_post", side_effect=fake_post):
+        yield calls
+
+
+@pytest.fixture
+def captured_patches() -> list[tuple[str, dict, dict]]:
+    """Capture all sb_patch calls. Each entry is (table, params, payload)."""
+    calls: list[tuple[str, dict, dict]] = []
+
+    def fake_patch(table: str, params: dict, payload: dict) -> list:
+        calls.append((table, params, payload))
+        return []
+
+    with patch.object(recorder, "sb_patch", side_effect=fake_patch):
+        yield calls
+
+
+def test_record_session_start_writes_sessions_row(captured_posts) -> None:
+    sid = recorder.record_session_start(
+        callsign="aiden",
+        working_directory="/home/elliotbot/clawd/Agency_OS-aiden",
+        session_uuid="abc-123",
+        tmux_session="aiden",
+        model_id="claude-opus-4-7",
+        extra={"hello": "world"},
+    )
+    assert sid is not None
+    assert isinstance(sid, UUID)
+    assert len(captured_posts) == 1
+    table, payload = captured_posts[0]
+    assert table == "sessions"
+    assert payload["callsign"] == "aiden"
+    assert payload["session_uuid"] == "abc-123"
+    assert payload["working_directory"] == "/home/elliotbot/clawd/Agency_OS-aiden"
+    assert payload["tmux_session"] == "aiden"
+    assert payload["model_id"] == "claude-opus-4-7"
+    assert payload["extra"] == {"hello": "world"}
+    assert payload["status"] == "active"
+    assert "started_at" in payload
+
+
+def test_record_message_with_full_content(captured_posts) -> None:
+    sid = UUID("00000000-0000-0000-0000-000000000001")
+    mid = recorder.record_message(
+        session_id=sid,
+        role="user",
+        message_index=0,
+        content_text="hello world",
+        store_full_content=True,
+    )
+    assert mid is not None
+    table, payload = captured_posts[0]
+    assert table == "messages"
+    assert payload["session_id"] == str(sid)
+    assert payload["role"] == "user"
+    assert payload["message_index"] == 0
+    assert payload["content_text"] == "hello world"
+    assert payload["content_hash"] is not None
+    assert payload["content_bytes"] == len(b"hello world")
+
+
+def test_record_message_hash_only(captured_posts) -> None:
+    sid = UUID("00000000-0000-0000-0000-000000000001")
+    recorder.record_message(
+        session_id=sid,
+        role="assistant",
+        message_index=1,
+        content_text="big response",
+        store_full_content=False,
+    )
+    _, payload = captured_posts[0]
+    assert payload["content_text"] is None
+    assert payload["content_hash"] is not None
+
+
+def test_record_turn_start_writes_turns_row(captured_posts) -> None:
+    sid = UUID("00000000-0000-0000-0000-000000000001")
+    tid = recorder.record_turn_start(session_id=sid, turn_index=0)
+    assert tid is not None
+    table, payload = captured_posts[0]
+    assert table == "turns"
+    assert payload["session_id"] == str(sid)
+    assert payload["turn_index"] == 0
+    assert payload["status"] == "in_progress"
+
+
+def test_record_tool_call_writes_log_and_files(captured_posts) -> None:
+    tid = UUID("00000000-0000-0000-0000-000000000002")
+    lid = recorder.record_tool_call(
+        turn_id=tid,
+        tool_name="Edit",
+        tool_args={"file_path": "/tmp/x.py", "old_string": "a", "new_string": "b"},
+        exit_status="success",
+        files=[
+            {
+                "file_path": "/tmp/x.py",
+                "operation": "edit",
+                "lines_added": 1,
+                "lines_removed": 1,
+            }
+        ],
+    )
+    assert lid is not None
+    assert len(captured_posts) == 2  # turn_logs + turn_files
+    log_call = captured_posts[0]
+    files_call = captured_posts[1]
+    assert log_call[0] == "turn_logs"
+    assert log_call[1]["tool_name"] == "Edit"
+    assert log_call[1]["exit_status"] == "success"
+    assert files_call[0] == "turn_files"
+    assert files_call[1]["file_path"] == "/tmp/x.py"
+    assert files_call[1]["operation"] == "edit"
+    assert files_call[1]["lines_added"] == 1
+
+
+def test_record_turn_complete_patches_turns_row(captured_patches) -> None:
+    tid = UUID("00000000-0000-0000-0000-000000000003")
+    recorder.record_turn_complete(
+        turn_id=tid, status="completed", input_tokens=1000, output_tokens=500, cost_aud=0.05
+    )
+    table, params, payload = captured_patches[0]
+    assert table == "turns"
+    assert params == {"id": f"eq.{tid}"}
+    assert payload["status"] == "completed"
+    assert payload["input_tokens"] == 1000
+    assert payload["output_tokens"] == 500
+    assert payload["cost_aud"] == 0.05
+    assert "completed_at" in payload
+
+
+def test_record_session_end_patches_sessions_row(captured_patches) -> None:
+    sid = UUID("00000000-0000-0000-0000-000000000004")
+    recorder.record_session_end(session_id=sid, status="closed")
+    table, params, payload = captured_patches[0]
+    assert table == "sessions"
+    assert params == {"id": f"eq.{sid}"}
+    assert payload["status"] == "closed"
+    assert "ended_at" in payload
+
+
+def test_mark_session_stuck(captured_patches) -> None:
+    sid = UUID("00000000-0000-0000-0000-000000000005")
+    recorder.mark_session_stuck(session_id=sid)
+    table, params, payload = captured_patches[0]
+    assert table == "sessions"
+    assert payload["status"] == "stuck"
+
+
+def test_swallow_on_failure() -> None:
+    """sb_post raises → recorder returns None, no exception bubbles up."""
+
+    def raise_fn(*args, **kwargs):
+        raise RuntimeError("supabase down")
+
+    with patch.object(recorder, "sb_post", side_effect=raise_fn):
+        sid = recorder.record_session_start(callsign="aiden", working_directory="/tmp")
+        assert sid is None  # best-effort: no row created, but no exception


### PR DESCRIPTION
## Summary

Drevon PR-A per Dave directive 2026-05-11 + Elliot dispatch ts 1778540XXX. Foundation layer for Drevon-port: 5-table session store + ORM + recorder + hooks. Unblocks Atlas's PR-B (skill-gen) and Orion's PR-C (UUID resumption).

## Scope

| Layer | File | Purpose |
|-------|------|---------|
| Migration | `supabase/migrations/20260511_drevon_session_store.sql` | 5 tables + indexes + RLS |
| ORM | `src/models/session_store.py` | SQLAlchemy declarative models |
| Recorder | `src/session_store/recorder.py` | Write paths (REST helpers) |
| Hooks | `.claude/hooks/session_store_{posttooluse,stop}.sh` | Wire to recorder |
| Tests | `tests/session_store/test_recorder.py` | 9 mock-based unit tests |

**No retroactive backfill** (Elliot explicit). New sessions only.

## Schema

```
sessions ──┬── messages
           │
           └── turns ──── turn_logs ──── turn_files
```

- `sessions`: callsign + working_directory + session_uuid (PR-C key) + started_at/ended_at/status
- `messages`: role + message_index + content_hash/text/bytes
- `turns`: trigger_message_id + turn_index + status + cost rollup (input/output/cost_aud)
- `turn_logs`: tool_name + tool_args_json + tool_result_summary + exit_status + duration_ms
- `turn_files`: file_path + operation + bytes_read/written + content_hash + lines_added/removed

Follows `vendor_usage_log` precedent: UUID PK, TIMESTAMPTZ, soft-delete via `deleted_at`, partial indexes filtering deleted_at, RLS with platform_admin policy.

## Recorder API

```python
sid = record_session_start(callsign, working_directory, session_uuid=...)
mid = record_message(sid, role='user', message_index=0, content_text=...)
tid = record_turn_start(sid, turn_index=0, trigger_message_id=mid)
lid = record_tool_call(tid, tool_name='Edit', tool_args={...}, files=[...])
record_turn_complete(tid, input_tokens=..., output_tokens=..., cost_aud=...)
record_session_end(sid, status='closed')
mark_session_stuck(sid)  # watchdog
```

Best-effort: all writes log+swallow on failure. Recording must NEVER block agent execution.

## Hooks

PostToolUse + Stop scripts shipped under `.claude/hooks/`, NOT yet wired in `.claude/settings.json` (follow-up). Auto-create session row on first call; state at `/tmp/.session_<callsign>` and `/tmp/.turn_<callsign>`. Always exit 0.

Wiring is a one-line append in settings.json once schema is applied to staging.

## Test plan

- [x] `ruff check src/ tests/session_store/` — All checks passed
- [x] `ruff format src/ tests/session_store/ --check` — 473 files already formatted
- [x] `python3 -m pytest tests/session_store/ -v` — 9 passed in 0.22s
- [ ] CI green
- [ ] Schema applied to Supabase staging via `apply_migration` (deploy step, post-merge)
- [ ] Hooks wired in `.claude/settings.json` (follow-up PR or amendment)

## Downstream

- **PR-B (Atlas, skill-gen)** — unblocked once PR-A merges. Cost gate VALIDATED by Max (PR-B should target ~20K compressed tokens; Haiku ~\$35 AUD/mo, Sonnet ~\$419 AUD/mo).
- **PR-C (Orion, UUID resumption)** — unblocked once PR-A merges. Reads `sessions.session_uuid` for `claude --resume`.
- **PR-A.5 (Aiden, replay-on-claim)** — follow-up. Queries `turn_logs` to deterministically verify "PR #N merged" claims against actual session history. Replaces R3 LLM fabrication-detection.
- **PR-D (dynamic CLAUDE.md)** — deprioritized per Dave decision #4.

## Dispatch + concur

Drevon umbrella Step 0 at ts 1778538696 stands; Dave 2-way concur sufficient per #ceo decision #1. [PROPOSE:AIDEN] this PR + Track 4 enforcer bundle follows after this opens for concur (Elliot's queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)