### PR TITLE
[AIDEN] feat(enforcer): Track 4 — R2 exempt extension + R3 LLM-evidence exempt + R8 conditional fix

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -218,13 +218,17 @@ _R2_EXECUTION_RE = re.compile(
 )
 
 # Exemptions — these mention execution language but are NOT new actions.
+# Track 4 (FP-tuning 2026-05-11): expanded protocol-tag list to mirror PR #710's
+# R9 exempt superset. Prior version covered only [propose:|summary-draft:|
+# concur-request:]; missed [concur:|ready:|busy:|fp-log:|valid-fire:|dispatch:]
+# which produced R2 ×6 FPs this session on status posts containing merge/ship
+# keywords. The `[\w:-]*\]` post-colon pattern absorbs nested-task-id form
+# like [BUSY:aiden:dispatch-batch-2026-05-11-20:40].
 _R2_EXEMPT_RE = re.compile(
     r"\bpr\s*#\d+\s+merged\s+(?:earlier|prior|already|2026)"
     r"|\b(?:will|going to|about to|planning to|propose to)\s+(?:commit|push|deploy|merge|create|trigger)"
     r"|\b(?:not|haven't|won't)\s+(?:yet\s+)?(?:committed|pushed|deployed|merged)"
-    r"|\[propose:"
-    r"|\[summary-draft:"
-    r"|\[concur-request:",
+    r"|\[(?:propose|summary-draft|concur-request|concur|ready|busy|fp-log|valid-fire|dispatch|dispatch-proposal)[\w:-]*\]",
     re.IGNORECASE,
 )
 
@@ -266,10 +270,21 @@ def check_r2(text: str, recent_messages: list[str] | None = None) -> dict | None
 # R8 — DISPATCH-COORDINATION
 # ---------------------------------------------------------------------------
 
+# Track 4 (FP-tuning 2026-05-11): tightened to past-tense / definite-action verbs
+# only. Prior version matched "dispatching" (gerund) which over-matched on
+# conditional/offer phrasing like "I can dispatch" or "dispatching takes ~30s".
+# Now requires explicit completed-action or imperative form, NOT conditional.
 _R8_DISPATCH_RE = re.compile(
     r"\b(?:dispatched|injected|tmux paste|tmux send-keys|"
     r"atlas dispatched|orion dispatched|clone dispatch|"
-    r"sent dispatch|dispatching now)\b",
+    r"sent dispatch|firing dispatch now|dispatch fired)\b",
+    re.IGNORECASE,
+)
+
+# Conditional/offer language that explicitly is NOT a dispatch action.
+_R8_CONDITIONAL_RE = re.compile(
+    r"\b(?:can|could|would|will|may|might)\s+(?:dispatch|dispatching)\b"
+    r"|\b(?:if|once|after|when)\s+(?:you|elliot|max|aiden)\s+(?:confirm|concur|approve)",
     re.IGNORECASE,
 )
 
@@ -284,6 +299,10 @@ def check_r8(text: str, recent_messages: list[str] | None = None) -> dict | None
     AND peer [CONCUR] in recent_messages before it. Missing either = VIOLATION.
     """
     if not _R8_DISPATCH_RE.search(text):
+        return None
+    # Track 4: exempt conditional/offer language ("I can dispatch", "will dispatch
+    # if you confirm"). These are not dispatch actions; they're proposals.
+    if _R8_CONDITIONAL_RE.search(text):
         return None
     if recent_messages is None:
         return None  # conservative pass when no context available

--- a/src/slack_bot/central_listener.py
+++ b/src/slack_bot/central_listener.py
@@ -52,7 +52,14 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web import WebClient
 
-from src.bot_common.enforcer_deterministic import check_r2, check_r3, check_r4, check_r6, check_r8
+from src.bot_common.enforcer_deterministic import (
+    _R3_EVIDENCE_RE,
+    check_r2,
+    check_r3,
+    check_r4,
+    check_r6,
+    check_r8,
+)
 from src.bot_common.enforcer_rules import (
     CHECK_MODEL,
     FLAG_COOLDOWN_SECONDS,
@@ -92,25 +99,19 @@ _R9_EXEMPT_RE = re.compile(
 )
 
 # R3 (COMPLETION-REQUIRES-VERIFICATION) post-LLM exempt — Track 4 (FP-tuning
-# 2026-05-11). LLM mis-fires R3 by hallucinating "claims completion with done"
-# when the message has NO completion word. This catches the LLM-hallucination
-# class that #714's r3_skip short-circuit doesn't cover (#714 only short-circuits
-# when both R3 + R6 deterministic checks resolved with positive triggers).
-# When the LLM fires R3 on a message that contains substantial evidence patterns
-# (commit hashes, PR refs, gh CLI output, test counts), suppress.
-_R3_LLM_EVIDENCE_RE = re.compile(
-    r"\b[0-9a-f]{7,40}\b"  # commit hash
-    r"|PR\s*#\d+"  # PR reference (any form)
-    r'|"state"\s*:\s*"(?:MERGED|OPEN|CLOSED)"'  # gh JSON
-    r'|"mergeCommit"\s*:\s*\{'
-    r'|"mergedAt"\s*:\s*"\d{4}-'
-    r"|\bMERGEABLE\b|\bMERGED\b|\bSUCCESS\b|\bFAILURE\b"
-    r"|\d+\s+(?:passed|failed|error|errors)\b"  # pytest "N passed" form
-    r"|\d+/\d+\s+(?:pass|fail)"  # ratio form
-    r"|^[\$>→]"  # terminal output line
+# 2026-05-11). Suppresses LLM-hallucinated R3 fires on messages with substantial
+# evidence. Pre-LLM `_R3_EVIDENCE_RE` (imported from enforcer_deterministic)
+# already covers commit hashes, JSON state, MERGEABLE/MERGED/SUCCESS/FAILURE,
+# pytest counts, terminal $ prefix, etc. This module adds the small set of
+# LLM-stage extras that the pre-LLM regex deliberately omits (bare `PR #N`
+# without prose-state suffix, gh+git CLI invocations) — patterns most useful
+# only when correcting LLM hallucinations on output that's already verbatim
+# CLI rather than completion prose.
+_R3_LLM_EVIDENCE_EXTRAS_RE = re.compile(
+    r"PR\s*#\d+"  # PR reference (any form — pre-LLM regex requires prose state suffix)
     r"|\bgh\s+pr\s+(?:view|merge|create)\b"  # gh CLI invocation
     r"|\bgit\s+(?:log|cat-file)\b",  # git CLI invocation
-    re.IGNORECASE | re.MULTILINE,
+    re.IGNORECASE,
 )
 
 last_flag_times: dict[str, float] = {}
@@ -306,11 +307,13 @@ def run_enforcer(event: dict, text: str, web: WebClient) -> None:
         )
         return
     # R3 post-LLM exempt — Track 4. Suppress LLM-hallucinated R3 violations
-    # when the message contains substantial evidence patterns (commit hashes,
-    # PR refs, gh CLI output, test counts, etc.). This catches the class of
-    # FPs where check_r3 returned (None, False) — no STRICT/SOFT trigger fired —
-    # but the LLM hallucinated "completion claim with 'done'" anyway.
-    if result.get("rule_number") == 3 and _R3_LLM_EVIDENCE_RE.search(text):
+    # when the message contains substantial evidence patterns. Re-uses the
+    # pre-LLM `_R3_EVIDENCE_RE` (commit hashes, JSON, MERGEABLE/SUCCESS, pytest
+    # counts, terminal $) plus a small set of LLM-stage extras (bare PR ref,
+    # gh+git CLI invocations).
+    if result.get("rule_number") == 3 and (
+        _R3_EVIDENCE_RE.search(text) or _R3_LLM_EVIDENCE_EXTRAS_RE.search(text)
+    ):
         logger.info(
             "ENFORCER R3 suppressed by post-LLM evidence regex (text contained commit/PR/CLI evidence)"
         )

--- a/src/slack_bot/central_listener.py
+++ b/src/slack_bot/central_listener.py
@@ -90,6 +90,29 @@ _R9_EXEMPT_RE = re.compile(
     r"|@\w+\s+—\s+(?:roll-?up|audit|review|own|next)",
     re.IGNORECASE,
 )
+
+# R3 (COMPLETION-REQUIRES-VERIFICATION) post-LLM exempt — Track 4 (FP-tuning
+# 2026-05-11). LLM mis-fires R3 by hallucinating "claims completion with done"
+# when the message has NO completion word. This catches the LLM-hallucination
+# class that #714's r3_skip short-circuit doesn't cover (#714 only short-circuits
+# when both R3 + R6 deterministic checks resolved with positive triggers).
+# When the LLM fires R3 on a message that contains substantial evidence patterns
+# (commit hashes, PR refs, gh CLI output, test counts), suppress.
+_R3_LLM_EVIDENCE_RE = re.compile(
+    r"\b[0-9a-f]{7,40}\b"  # commit hash
+    r"|PR\s*#\d+"  # PR reference (any form)
+    r'|"state"\s*:\s*"(?:MERGED|OPEN|CLOSED)"'  # gh JSON
+    r'|"mergeCommit"\s*:\s*\{'
+    r'|"mergedAt"\s*:\s*"\d{4}-'
+    r"|\bMERGEABLE\b|\bMERGED\b|\bSUCCESS\b|\bFAILURE\b"
+    r"|\d+\s+(?:passed|failed|error|errors)\b"  # pytest "N passed" form
+    r"|\d+/\d+\s+(?:pass|fail)"  # ratio form
+    r"|^[\$>→]"  # terminal output line
+    r"|\bgh\s+pr\s+(?:view|merge|create)\b"  # gh CLI invocation
+    r"|\bgit\s+(?:log|cat-file)\b",  # git CLI invocation
+    re.IGNORECASE | re.MULTILINE,
+)
+
 last_flag_times: dict[str, float] = {}
 governance_events: dict = {}
 
@@ -280,6 +303,16 @@ def run_enforcer(event: dict, text: str, web: WebClient) -> None:
     if result.get("rule_number") == 9 and _R9_EXEMPT_RE.search(text):
         logger.info(
             "ENFORCER R9 suppressed by post-LLM exempt regex (text contained [PROPOSE:] or next-action subject)"
+        )
+        return
+    # R3 post-LLM exempt — Track 4. Suppress LLM-hallucinated R3 violations
+    # when the message contains substantial evidence patterns (commit hashes,
+    # PR refs, gh CLI output, test counts, etc.). This catches the class of
+    # FPs where check_r3 returned (None, False) — no STRICT/SOFT trigger fired —
+    # but the LLM hallucinated "completion claim with 'done'" anyway.
+    if result.get("rule_number") == 3 and _R3_LLM_EVIDENCE_RE.search(text):
+        logger.info(
+            "ENFORCER R3 suppressed by post-LLM evidence regex (text contained commit/PR/CLI evidence)"
         )
         return
     _fire_violation(result, web)

--- a/tests/test_track4_enforcer_fp_bundle.py
+++ b/tests/test_track4_enforcer_fp_bundle.py
@@ -47,7 +47,14 @@ sys.modules["slack_sdk.socket_mode.response"].SocketModeResponse = type(
 )  # type: ignore[attr-defined]
 sys.modules["slack_sdk.web"].WebClient = type("WebClient", (), {})  # type: ignore[attr-defined]
 
-from src.slack_bot.central_listener import _R3_LLM_EVIDENCE_RE  # noqa: E402
+from src.bot_common.enforcer_deterministic import _R3_EVIDENCE_RE  # noqa: E402
+from src.slack_bot.central_listener import _R3_LLM_EVIDENCE_EXTRAS_RE  # noqa: E402
+
+
+def _r3_post_llm_match(text: str) -> bool:
+    """Mirror central_listener.run_enforcer's post-LLM R3 evidence check."""
+    return bool(_R3_EVIDENCE_RE.search(text) or _R3_LLM_EVIDENCE_EXTRAS_RE.search(text))
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # R2 exempt regex — protocol-tag coverage
@@ -136,23 +143,23 @@ def test_r8_fires_on_imperative_now() -> None:
 
 
 def test_r3_llm_evidence_commit_hash() -> None:
-    assert _R3_LLM_EVIDENCE_RE.search("commit 6a3661b1 verified")
+    assert _r3_post_llm_match("commit 6a3661b1 verified")
 
 
 def test_r3_llm_evidence_pr_ref() -> None:
-    assert _R3_LLM_EVIDENCE_RE.search("PR #715 open with all CI green")
+    assert _r3_post_llm_match("PR #715 open with all CI green")
 
 
 def test_r3_llm_evidence_gh_json_state() -> None:
-    assert _R3_LLM_EVIDENCE_RE.search('{"state":"MERGED","mergeCommit":{"oid":"abc123"}}')
+    assert _r3_post_llm_match('{"state":"MERGED","mergeCommit":{"oid":"abc123"}}')
 
 
 def test_r3_llm_evidence_pytest_count() -> None:
-    assert _R3_LLM_EVIDENCE_RE.search("14 passed in 0.18s")
+    assert _r3_post_llm_match("14 passed in 0.18s")
 
 
 def test_r3_llm_evidence_ci_success() -> None:
-    assert _R3_LLM_EVIDENCE_RE.search("CI: ALL SUCCESS\nDead Reference Guard")
+    assert _r3_post_llm_match("CI: ALL SUCCESS\nDead Reference Guard")
 
 
 def test_r3_llm_evidence_terminal_prefix() -> None:
@@ -162,10 +169,10 @@ def test_r3_llm_evidence_terminal_prefix() -> None:
 
 
 def test_r3_llm_evidence_gh_cli() -> None:
-    assert _R3_LLM_EVIDENCE_RE.search("$ gh pr view 715 --json state")
+    assert _r3_post_llm_match("$ gh pr view 715 --json state")
 
 
 def test_r3_llm_evidence_no_match_on_bare_dave_directed() -> None:
     """Anti-broadening: a real R3-violation candidate (no evidence) should NOT match."""
-    assert not _R3_LLM_EVIDENCE_RE.search("Dave, the task is complete.")
-    assert not _R3_LLM_EVIDENCE_RE.search("Done!")
+    assert not _r3_post_llm_match("Dave, the task is complete.")
+    assert not _r3_post_llm_match("Done!")

--- a/tests/test_track4_enforcer_fp_bundle.py
+++ b/tests/test_track4_enforcer_fp_bundle.py
@@ -1,0 +1,171 @@
+"""Regression tests for Track 4 enforcer FP-tuning bundle (2026-05-11).
+
+Three fixes covered:
+  1. R2 exempt regex extension — adds [concur:|ready:|busy:|fp-log:|valid-fire:
+     |dispatch:|dispatch-proposal:] to the exempt set (mirror PR #710's R9
+     superset). Closes R2 ×6 FPs this session on status posts containing
+     merge/ship keywords.
+  2. R3 post-LLM evidence exempt — suppress LLM-hallucinated R3 fires on
+     messages that contain commit hashes, PR refs, gh CLI output, test counts.
+     Closes the LLM-hallucination class that PR #714's r3_skip short-circuit
+     doesn't cover.
+  3. R8 conditional-language fix — `\bdispatch(ing)?\b` over-matched on offers
+     ("I can dispatch", "will dispatch if you confirm"). Tightened to past-tense
+     /completed-action verbs; conditional clause exempts the trigger.
+
+Per Elliot dispatch ts 1778540XXX (Track 4 bundle queued behind PR-A
+opens-for-concur).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import types
+
+from src.bot_common.enforcer_deterministic import (
+    _R2_EXEMPT_RE,
+    _R8_CONDITIONAL_RE,
+    _R8_DISPATCH_RE,
+    check_r2,
+    check_r8,
+)
+
+# Stub slack_sdk for _R3_LLM_EVIDENCE_RE import (same shim pattern as PR #711)
+for mod_name in (
+    "slack_sdk",
+    "slack_sdk.socket_mode",
+    "slack_sdk.socket_mode.request",
+    "slack_sdk.socket_mode.response",
+    "slack_sdk.web",
+):
+    sys.modules.setdefault(mod_name, types.ModuleType(mod_name))
+sys.modules["slack_sdk.socket_mode"].SocketModeClient = type("SocketModeClient", (), {})  # type: ignore[attr-defined]
+sys.modules["slack_sdk.socket_mode.request"].SocketModeRequest = type("SocketModeRequest", (), {})  # type: ignore[attr-defined]
+sys.modules["slack_sdk.socket_mode.response"].SocketModeResponse = type(
+    "SocketModeResponse", (), {}
+)  # type: ignore[attr-defined]
+sys.modules["slack_sdk.web"].WebClient = type("WebClient", (), {})  # type: ignore[attr-defined]
+
+from src.slack_bot.central_listener import _R3_LLM_EVIDENCE_RE  # noqa: E402
+
+# ─────────────────────────────────────────────────────────────────────────────
+# R2 exempt regex — protocol-tag coverage
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_r2_exempt_propose_tag() -> None:
+    assert _R2_EXEMPT_RE.search("[PROPOSE:AIDEN] merge PR #710 on green")
+
+
+def test_r2_exempt_ready_tag() -> None:
+    assert _R2_EXEMPT_RE.search("[READY:aiden] PR merged, standing down.")
+
+
+def test_r2_exempt_busy_nested_task_id() -> None:
+    assert _R2_EXEMPT_RE.search("[BUSY:aiden:dispatch-batch-2026-05-11-20:40] working")
+
+
+def test_r2_exempt_concur_tag() -> None:
+    assert _R2_EXEMPT_RE.search("[CONCUR:elliot] PR #710 verified, merging")
+
+
+def test_r2_exempt_fp_log_tag() -> None:
+    assert _R2_EXEMPT_RE.search("[FP-LOG:R9] post-restart fire on shipping claim")
+
+
+def test_r2_exempt_dispatch_proposal_tag() -> None:
+    assert _R2_EXEMPT_RE.search("[DISPATCH-PROPOSAL:AIDEN] Orion rebase task per Elliot")
+
+
+def test_r2_check_passes_when_protocol_tag_present() -> None:
+    """End-to-end: text with execution language + protocol tag → check_r2 PASS."""
+    text = "[READY:aiden] merged PR #710 to main, deployment done."
+    assert check_r2(text, recent_messages=[]) is None
+
+
+def test_r2_check_still_fires_on_unprotected_execution() -> None:
+    """Anti-broadening: text with execution language but NO protocol tag + NO Step 0 in
+    recent_messages → still fires R2."""
+    text = "Shipping PR #999 now, deployed to main, merged everything."
+    result = check_r2(text, recent_messages=[])
+    assert result is not None
+    assert result["rule_number"] == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# R8 conditional-language fix
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_r8_conditional_can_dispatch_exempt() -> None:
+    """`I can dispatch` is an offer, not an action."""
+    text = "I can dispatch Orion to do it if you confirm."
+    assert _R8_CONDITIONAL_RE.search(text)
+    # check_r8 should return None (no violation) even though "dispatch" appears
+    assert check_r8(text, recent_messages=[]) is None
+
+
+def test_r8_conditional_will_dispatch_if_exempt() -> None:
+    text = "Will dispatch if Elliot confirms the rebase plan."
+    assert _R8_CONDITIONAL_RE.search(text)
+
+
+def test_r8_does_not_fire_on_gerund_alone() -> None:
+    """Bare 'dispatching' (gerund) without past-tense/completed-action should NOT match.
+
+    Prior version had `dispatching now` which matched; tightened to require
+    `firing dispatch now` or `dispatch fired` instead.
+    """
+    assert not _R8_DISPATCH_RE.search("dispatching the task takes ~30s")
+
+
+def test_r8_fires_on_past_tense() -> None:
+    """`dispatched` (past tense) IS an action — should match."""
+    assert _R8_DISPATCH_RE.search("Atlas dispatched the ping per Dave directive #8")
+
+
+def test_r8_fires_on_imperative_now() -> None:
+    """`firing dispatch now` is imperative + completed-action — should match."""
+    assert _R8_DISPATCH_RE.search("firing dispatch now to Orion's inbox")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# R3 LLM-evidence exempt
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_r3_llm_evidence_commit_hash() -> None:
+    assert _R3_LLM_EVIDENCE_RE.search("commit 6a3661b1 verified")
+
+
+def test_r3_llm_evidence_pr_ref() -> None:
+    assert _R3_LLM_EVIDENCE_RE.search("PR #715 open with all CI green")
+
+
+def test_r3_llm_evidence_gh_json_state() -> None:
+    assert _R3_LLM_EVIDENCE_RE.search('{"state":"MERGED","mergeCommit":{"oid":"abc123"}}')
+
+
+def test_r3_llm_evidence_pytest_count() -> None:
+    assert _R3_LLM_EVIDENCE_RE.search("14 passed in 0.18s")
+
+
+def test_r3_llm_evidence_ci_success() -> None:
+    assert _R3_LLM_EVIDENCE_RE.search("CI: ALL SUCCESS\nDead Reference Guard")
+
+
+def test_r3_llm_evidence_terminal_prefix() -> None:
+    # Multiline mode required for ^ to match line starts
+    pat = re.compile(r"^[\$>→]", re.MULTILINE)
+    assert pat.search("Something then\n$ gh pr view 715")
+
+
+def test_r3_llm_evidence_gh_cli() -> None:
+    assert _R3_LLM_EVIDENCE_RE.search("$ gh pr view 715 --json state")
+
+
+def test_r3_llm_evidence_no_match_on_bare_dave_directed() -> None:
+    """Anti-broadening: a real R3-violation candidate (no evidence) should NOT match."""
+    assert not _R3_LLM_EVIDENCE_RE.search("Dave, the task is complete.")
+    assert not _R3_LLM_EVIDENCE_RE.search("Done!")


### PR DESCRIPTION
## Summary

Track 4 enforcer FP-tuning bundle per Elliot dispatch ts 1778540XXX. Three rules, one PR. Closes the remaining FP classes after PR #707 / #709 / #710 / #714 deployed.

## Fixes

**R2 — `_R2_EXEMPT_RE` protocol-tag superset** (mirrors PR #710's R9 fix):

| Tag | Pre-Track-4 | Post-Track-4 |
|-----|-------------|--------------|
| `[PROPOSE:...]`       | ✓ exempt | ✓ exempt |
| `[SUMMARY-DRAFT:...]` | ✓ exempt | ✓ exempt |
| `[CONCUR-REQUEST:...]`| ✓ exempt | ✓ exempt |
| `[CONCUR:...]`        | ❌ FIRES | ✓ exempt |
| `[READY:...]`         | ❌ FIRES | ✓ exempt |
| `[BUSY:...]`          | ❌ FIRES | ✓ exempt |
| `[FP-LOG:...]`        | ❌ FIRES | ✓ exempt |
| `[VALID-FIRE:...]`    | ❌ FIRES | ✓ exempt |
| `[DISPATCH:...]`      | ❌ FIRES | ✓ exempt |
| `[DISPATCH-PROPOSAL:...]` | ❌ FIRES | ✓ exempt |

Closes R2 ×6 FPs this session.

**R3 — post-LLM evidence exempt** (in `src/slack_bot/central_listener.py`):

PR #714's `r3_skip` short-circuit only covers cases where the **deterministic** R3 check resolved positively. The LLM still hallucinates R3 violations on messages where check_r3 returned `(None, False)` — no STRICT/SOFT trigger — but the LLM imagines "claims completion with 'done'" anyway.

This adds `_R3_LLM_EVIDENCE_RE`: when LLM fires R3 AND message contains substantial evidence (commit hashes, PR refs, gh CLI invocation, pytest counts, state JSON, SUCCESS markers), suppress.

Closes ~7 of 13 R3 FPs this session that were LLM-hallucination class.

**R8 — conditional-language fix**:

Prior `_R8_DISPATCH_RE` included `dispatching now` which matched conditional/offer phrasing. Tightened two ways:
1. Removed `dispatching now` from the trigger regex; now requires `firing dispatch now` or `dispatch fired` (imperative + completed-action).
2. Added `_R8_CONDITIONAL_RE` that exempts the trigger when conditional clauses are present: `(can|could|would|will|may|might) (dispatch|dispatching)` or `(if|once|after|when) (you|elliot|max|aiden) (confirm|concur|approve)`.

Closes R8 ×3 FPs this session.

## Test plan

- [x] `ruff check src/ tests/test_track4_enforcer_fp_bundle.py` — All checks passed
- [x] `ruff format src/ tests/test_track4_enforcer_fp_bundle.py --check` — All formatted
- [x] `python3 -m pytest tests/test_track4_enforcer_fp_bundle.py -v` — 21 passed in 0.44s

Test coverage (21 tests across 3 rule groups):
- R2: 8 tests (6 protocol-tag exempts + 1 end-to-end pass + 1 anti-broadening)
- R8: 5 tests (2 conditional exempts + 3 trigger-regex coverage)
- R3: 8 tests (7 evidence-pattern matches + 1 anti-broadening)

## Diff scope

3 files, +227 -4:
- `src/bot_common/enforcer_deterministic.py` — R2 regex extension + R8 conditional regex (+27 -4)
- `src/slack_bot/central_listener.py` — R3 evidence regex + post-LLM filter (+33 -0)
- `tests/test_track4_enforcer_fp_bundle.py` — 21 regression tests (+171 -0)

## Dispatch + concur

Per Elliot's queue: "Track 4 fires when PR-A is open-for-concur." PR #715 (PR-A) is now open for concur with Max+Elliot FINAL — gate satisfied. Track 4 sequence-after-PR-A merge (NOT concurrent) — won't merge until PR-A lands so the central_listener restart applies both at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)