### PR TITLE
[MAX] feat(governance): completion-claim discipline module

### DIFF
--- a/.claude/modules/_completion_discipline.md
+++ b/.claude/modules/_completion_discipline.md
@@ -1,0 +1,12 @@
+## Completion Claim Discipline (HARD BLOCK)
+
+Before posting ANY message containing completion language ("shipped", "merged", "landed", "deployed", "PR #N merged", commit hashes), you MUST:
+
+1. Run the actual verification command and capture its output:
+   - PR claims: `bash scripts/verify_pr.sh <N>` — check state=MERGED
+   - Commit claims: `git cat-file -t <hash>` — must return "commit"
+   - Deploy claims: `systemctl --user status <service>` — must show active
+2. Paste VERBATIM terminal output in your message. Never paraphrase.
+3. If verification fails or command errors: do NOT post the claim. Fix first.
+
+Context compaction can cause you to conflate "will do" with "did" and generate plausible-but-fake PR numbers, commit hashes, and verify_pr.sh output. This rule exists because 5 fabricated completion claims were caught by peer git verification on 2026-05-11. You cannot trust your own memory of what shipped — only trust shell output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@
 
 @.claude/modules/_hierarchy.md
 
+@.claude/modules/_completion_discipline.md
+
 @.claude/modules/_mcp_bridge.md
 
 ## Supabase — Primary Memory Store (LAW IX)


### PR DESCRIPTION
## Summary
- Adds `_completion_discipline.md` governance module requiring verification commands before any completion language in outbound messages
- Wires module into CLAUDE.md between `_hierarchy.md` and `_mcp_bridge.md`
- Prevents fabricated completion claims (PR merged, commit hashes, deploy status) caused by context compaction conflating intent with action

## Context
5 fabricated completion claims caught by peer git verification on 2026-05-11. This module codifies the discipline: run `verify_pr.sh`, `git cat-file`, or `systemctl status` and paste verbatim output before claiming anything shipped.

## Test plan
- [ ] Verify `_completion_discipline.md` loads via `@` import in CLAUDE.md
- [ ] Verify module content renders in Claude Code context window

🤖 Generated with [Claude Code](https://claude.com/claude-code)