### PR TITLE
[AIDEN] chore(drevon-pra): wire session_store hooks into .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,23 @@
             "type": "command",
             "command": "bash /home/elliotbot/clawd/Agency_OS/.claude/hooks/stop_relay_hook.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/session_store_stop.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/session_store_posttooluse.sh",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary

Follow-up to PR #715 (Drevon PR-A). Wires the session_store hook scripts (`.claude/hooks/session_store_{posttooluse,stop}.sh`, shipped in #715) into `.claude/settings.json` so they actually fire.

Pre-requisite for PR-A.5 (Aiden replay-on-claim) — without hooks producing turn_logs rows, replay has nothing to query.

## Changes

Single file, +17 lines, additive only:

1. **NEW PostToolUse event** (matcher `*`):
   ```json
   "PostToolUse": [{"matcher": "*", "hooks": [{
     "type": "command",
     "command": "bash .claude/hooks/session_store_posttooluse.sh",
     "timeout": 5
   }]}]
   ```

2. **APPENDED to existing Stop event** (matcher `*`):
   ```json
   {"type": "command",
    "command": "bash .claude/hooks/session_store_stop.sh",
    "timeout": 5}
   ```

## Operational impact

- Fires on EVERY tool call across ALL worktrees (matcher `*`).
- Background python via disown — non-blocking, exit 0 unconditional.
- Volume estimate: ~50-200 tool calls/directive × 5-10 directives/day × 6 callsigns ≈ **1.5K-12K turn_logs rows/day**.
- Sessions table populated on first tool call per agent session; closed on Stop.

## Pre-requisite state (verified)

- Migration applied to Supabase `jatzvazlbusedwsnqxzr` at 2026-05-11T23:21 UTC. All 5 tables (sessions, messages, turns, turn_logs, turn_files) live with RLS + indexes + platform_admin policies.
- Hook scripts shipped in PR #715 (commit 286b4f0d). chmod +x.
- Recorder shipped in #715. REST writes via `sb_post`/`sb_patch`, log+swallow.

## Test plan

- [x] `python3 -c "import json; print(json.load(open('.claude/settings.json'))['hooks'].keys())"` returns dict including `PostToolUse`
- [ ] CI green
- [ ] Manual: on next session-start in any worktree, expect new sessions row + turn_logs entries appearing in Supabase
- [ ] After 1 day: query `SELECT count(*) FROM turn_logs` should show ~1K-10K rows

## Unblocks

**PR-A.5 (Aiden replay-on-claim)** — query turn_logs for verify_pr.sh invocations + replay output to deterministically verify "PR #N merged" claims (per Max's three-layer defense architecture).

## Rollback

If volume or latency becomes a problem: remove the PostToolUse block + the appended Stop hook. Recorder writes are independent of the rest of the system; removal is reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)