### PR TITLE
[ATLAS] feat(skill-gen): smoke-test harness for >70% overlap acceptance

### DIFF
--- a/scripts/smoke_test_skill_gen.py
+++ b/scripts/smoke_test_skill_gen.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""smoke_test_skill_gen.py — empirical acceptance test for src.skill_gen.
+
+Workflow (post-merge of PR #720):
+    1. Parse Max's manual reference (14 patterns: 8 HOW + 6 AVOID).
+    2. Invoke skill_gen.generator.generate(...) on a captured session_id.
+    3. Substring-match each reference pattern against the generated SKILL.md.
+    4. Report: matched / total, hard-req matched / missing.
+    5. Exit 0 if >= 10/14 total AND all 5 hard-req patterns captured; else 1.
+
+The parser + match_patterns + evaluate functions are PURE — covered by unit
+tests in tests/scripts/test_smoke_test_skill_gen.py. The `--run` CLI path is
+e2e and intentionally deferred: do NOT invoke against real data until ~2-3
+directive cycles have accumulated in turn_logs (per Elliot dispatch 2026-05-11).
+
+Reference: /tmp/max_session_skill_notes_c322aa37.md (session c322aa37).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Repo-root on sys.path so src.skill_gen imports resolve regardless of cwd.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Hard-requirement keyword tags. Each entry must appear (substring match,
+# case-insensitive) in at least one matched pattern for the overall test to
+# pass. Sourced from Elliot dispatch 2026-05-11: the 5 patterns Max flagged
+# as non-negotiable for an empirical skill-gen pass.
+_HARD_REQ_KEYWORDS: list[tuple[str, str]] = [
+    ("verify_pr", "verify_pr.sh usage pattern"),
+    ("git cat-file", "git cat-file commit verification"),
+    ("sonarcloud", "SonarCloud bot comment retrieval"),
+    ("tg -g", "tg -g env sourcing pattern"),
+    ("fabricat", "fabrication avoidance (covers fabricate/fabrication/fabricated)"),
+]
+
+_HOW_HEADING = "## HOW"
+_AVOID_HEADING = "## AVOID"
+
+
+@dataclass(frozen=True)
+class Pattern:
+    kind: str  # "HOW" | "AVOID"
+    text: str
+    is_hard_req: bool
+    hard_req_label: str | None  # populated when is_hard_req
+
+
+@dataclass(frozen=True)
+class MatchReport:
+    matched: list[Pattern]
+    missed: list[Pattern]
+    hard_req_matched: list[str]
+    hard_req_missing: list[str]
+
+    @property
+    def total(self) -> int:
+        return len(self.matched) + len(self.missed)
+
+    @property
+    def matched_count(self) -> int:
+        return len(self.matched)
+
+
+def _is_hard_req(text: str) -> tuple[bool, str | None]:
+    low = text.lower()
+    for kw, label in _HARD_REQ_KEYWORDS:
+        if kw.lower() in low:
+            return True, label
+    return False, None
+
+
+def parse_reference(path: Path) -> list[Pattern]:
+    """Read Max's reference markdown, return all HOW + AVOID dash-bullet patterns."""
+    lines = path.read_text().splitlines()
+    patterns: list[Pattern] = []
+    current_kind: str | None = None
+    for raw in lines:
+        line = raw.rstrip()
+        if line.startswith(_HOW_HEADING):
+            current_kind = "HOW"
+            continue
+        if line.startswith(_AVOID_HEADING):
+            current_kind = "AVOID"
+            continue
+        if line.startswith("## "):
+            current_kind = None  # any other H2 ends pattern collection
+            continue
+        if current_kind and line.startswith("- "):
+            text = line[2:].strip()
+            if not text:
+                continue
+            hard, label = _is_hard_req(text)
+            patterns.append(
+                Pattern(kind=current_kind, text=text, is_hard_req=hard, hard_req_label=label)
+            )
+    return patterns
+
+
+def match_patterns(generated_md: str, reference: list[Pattern]) -> MatchReport:
+    """Substring-match each reference pattern (case-insensitive) against generated_md.
+
+    A pattern matches if at least one ~3-word keyphrase from its text appears
+    verbatim in the generated SKILL.md, OR for hard-req patterns if the
+    hard-req keyword itself appears. Simple, deterministic — no LLM.
+    """
+    body = generated_md.lower()
+    matched: list[Pattern] = []
+    missed: list[Pattern] = []
+    seen_hard: set[str] = set()
+    for p in reference:
+        keys = _candidate_keys(p)
+        hit = any(k in body for k in keys)
+        if hit:
+            matched.append(p)
+            if p.is_hard_req and p.hard_req_label:
+                seen_hard.add(p.hard_req_label)
+        else:
+            missed.append(p)
+    all_hard = {label for _, label in _HARD_REQ_KEYWORDS}
+    return MatchReport(
+        matched=matched,
+        missed=missed,
+        hard_req_matched=sorted(seen_hard),
+        hard_req_missing=sorted(all_hard - seen_hard),
+    )
+
+
+def _candidate_keys(p: Pattern) -> list[str]:
+    """Generate lowercase substring keys for a pattern. Always includes any
+    hard-req keyword tag plus the first few words of the pattern."""
+    keys: list[str] = []
+    if p.is_hard_req:
+        for kw, _ in _HARD_REQ_KEYWORDS:
+            if kw.lower() in p.text.lower():
+                keys.append(kw.lower())
+    words = p.text.lower().split()
+    if len(words) >= 3:
+        keys.append(" ".join(words[:3]))
+    return keys
+
+
+def evaluate(report: MatchReport) -> tuple[bool, str]:
+    """Apply Dave's acceptance rule: >=10/14 total AND all 5 hard-reqs hit."""
+    passed = report.matched_count >= 10 and not report.hard_req_missing
+    lines = [
+        f"matched={report.matched_count}/{report.total}",
+        f"hard_req_matched={len(report.hard_req_matched)}/5",
+    ]
+    if report.hard_req_missing:
+        lines.append("hard_req_missing: " + ", ".join(report.hard_req_missing))
+    if report.missed:
+        lines.append("missed_patterns:")
+        for m in report.missed:
+            lines.append(f"  - [{m.kind}] {m.text[:120]}")
+    return passed, "\n".join(lines)
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument(
+        "--reference",
+        default="/tmp/max_session_skill_notes_c322aa37.md",
+        help="Path to Max's manual reference file",
+    )
+    p.add_argument("--session-id", help="Captured session_id (UUID) to run skill_gen against")
+    p.add_argument("--start-ts", help="Window start (ISO8601)")
+    p.add_argument("--end-ts", help="Window end (ISO8601)")
+    p.add_argument("--directive-ref", default="smoke-test", help="Directive label for PR title")
+    p.add_argument(
+        "--run",
+        action="store_true",
+        help="Actually invoke skill_gen.generate (e2e). Default: parse-only dry-run.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_argparser().parse_args(argv if argv is not None else sys.argv[1:])
+    ref_path = Path(args.reference)
+    if not ref_path.exists():
+        print(f"reference file not found: {ref_path}", file=sys.stderr)
+        return 2
+    reference = parse_reference(ref_path)
+    print(f"parsed {len(reference)} patterns from {ref_path}")
+    print(f"  - HOW: {sum(1 for p in reference if p.kind == 'HOW')}")
+    print(f"  - AVOID: {sum(1 for p in reference if p.kind == 'AVOID')}")
+    categories_covered = {p.hard_req_label for p in reference if p.is_hard_req}
+    categories_covered.discard(None)
+    print(f"  - patterns flagged is_hard_req: {sum(1 for p in reference if p.is_hard_req)}")
+    print(f"  - hard-req categories covered: {len(categories_covered)}/5")
+    if not args.run:
+        print("parse-only mode; pass --run plus --session-id/--start-ts/--end-ts to evaluate")
+        return 0
+    if not (args.session_id and args.start_ts and args.end_ts):
+        print("--run requires --session-id, --start-ts, --end-ts", file=sys.stderr)
+        return 2
+    from src.skill_gen.generator import generate  # imported lazily for parse-only dry-run
+
+    result = generate(
+        repo_root=_REPO_ROOT,
+        session_id=args.session_id,
+        start_ts=args.start_ts,
+        end_ts=args.end_ts,
+        directive_ref=args.directive_ref,
+    )
+    body = result.skill_path.read_text()
+    report = match_patterns(body, reference)
+    passed, summary = evaluate(report)
+    print(summary, file=sys.stderr)
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_smoke_test_skill_gen.py
+++ b/tests/scripts/test_smoke_test_skill_gen.py
@@ -1,0 +1,205 @@
+"""Tests for scripts/smoke_test_skill_gen.py — parser + matcher + evaluator only.
+
+NO e2e: tests never invoke src.skill_gen.generator.generate() or any real
+subprocess. Per Elliot dispatch 2026-05-11, real-data run is deferred until
+~2-3 directive cycles have accumulated in turn_logs.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "smoke_test_skill_gen.py"
+_REFERENCE = Path("/tmp/max_session_skill_notes_c322aa37.md")
+
+
+def _load_harness():
+    """Load scripts/smoke_test_skill_gen.py as a module.
+
+    Registers the module in sys.modules before exec_module — required because
+    @dataclass(frozen=True) with PEP-604 unions (`str | None`) calls
+    `sys.modules.get(cls.__module__).__dict__` during field type resolution,
+    which crashes if the module isn't registered first.
+    """
+    name = "smoke_test_skill_gen_harness"
+    loader = SourceFileLoader(name, str(_SCRIPT))
+    spec = importlib.util.spec_from_loader(name, loader)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    try:
+        loader.exec_module(mod)
+    except BaseException:
+        sys.modules.pop(name, None)
+        raise
+    return mod
+
+
+# ---------- Parser tests against Max's real reference ----------
+
+
+@pytest.mark.skipif(not _REFERENCE.exists(), reason="Max's reference file not on this host")
+def test_parser_returns_14_patterns():
+    h = _load_harness()
+    patterns = h.parse_reference(_REFERENCE)
+    assert len(patterns) == 14
+
+
+@pytest.mark.skipif(not _REFERENCE.exists(), reason="Max's reference file not on this host")
+def test_parser_categorises_how_avoid_correctly():
+    h = _load_harness()
+    patterns = h.parse_reference(_REFERENCE)
+    how = [p for p in patterns if p.kind == "HOW"]
+    avoid = [p for p in patterns if p.kind == "AVOID"]
+    assert len(how) == 8
+    assert len(avoid) == 6
+
+
+@pytest.mark.skipif(not _REFERENCE.exists(), reason="Max's reference file not on this host")
+def test_parser_covers_all_5_hard_req_categories():
+    h = _load_harness()
+    patterns = h.parse_reference(_REFERENCE)
+    labels = {p.hard_req_label for p in patterns if p.is_hard_req}
+    labels.discard(None)
+    assert len(labels) == 5, f"expected 5 hard-req categories, got {labels}"
+
+
+# ---------- Synthetic-input parser tests ----------
+
+
+def test_parser_handles_synthetic_input(tmp_path: Path):
+    h = _load_harness()
+    p = tmp_path / "synthetic.md"
+    p.write_text(
+        "# header\n"
+        "## WHAT\n"
+        "- skipped (not HOW/AVOID)\n"
+        "## HOW\n"
+        "- Run verify_pr.sh for sanity\n"
+        "- Use git cat-file -t to confirm hashes\n"
+        "## AVOID\n"
+        "- Do NOT fabricate completion claims\n"
+    )
+    patterns = h.parse_reference(p)
+    assert len(patterns) == 3
+    assert [pp.kind for pp in patterns] == ["HOW", "HOW", "AVOID"]
+    assert all(pp.is_hard_req for pp in patterns)
+
+
+def test_parser_skips_blank_bullets(tmp_path: Path):
+    h = _load_harness()
+    p = tmp_path / "blank.md"
+    p.write_text("## HOW\n- \n- Real pattern here\n")
+    patterns = h.parse_reference(p)
+    assert len(patterns) == 1
+    assert patterns[0].text == "Real pattern here"
+
+
+# ---------- match_patterns tests ----------
+
+
+def test_match_patterns_finds_all_when_skillmd_quotes_each(tmp_path: Path):
+    h = _load_harness()
+    ref_md = tmp_path / "ref.md"
+    ref_md.write_text(
+        "## HOW\n"
+        "- Run verify_pr.sh before each merge\n"
+        "- Use git cat-file -t to check hashes\n"
+        "## AVOID\n"
+        "- Do NOT fabricate PR numbers\n"
+    )
+    reference = h.parse_reference(ref_md)
+    generated = "Steps: run verify_pr.sh first, then git cat-file -t. Never fabricate PR numbers."
+    report = h.match_patterns(generated, reference)
+    assert report.matched_count == 3
+    assert report.missed == []
+
+
+def test_match_patterns_sparse_skillmd_reports_missed(tmp_path: Path):
+    h = _load_harness()
+    ref_md = tmp_path / "ref.md"
+    ref_md.write_text(
+        "## HOW\n"
+        "- Run verify_pr.sh first\n"
+        "- Read SonarCloud bot output\n"
+        "- Source env before tg -g\n"
+    )
+    reference = h.parse_reference(ref_md)
+    generated = "Just run verify_pr.sh. Nothing else."
+    report = h.match_patterns(generated, reference)
+    assert report.matched_count == 1
+    assert len(report.missed) == 2
+    assert "SonarCloud bot comment retrieval" in report.hard_req_missing
+    assert "tg -g env sourcing pattern" in report.hard_req_missing
+
+
+# ---------- evaluate tests ----------
+
+
+def test_evaluate_pass_requires_10_total_and_all_hard_reqs():
+    h = _load_harness()
+    matched = [
+        h.Pattern("HOW", "x", True, label)
+        for _, label in h._HARD_REQ_KEYWORDS  # all 5 hard-reqs hit
+    ] + [h.Pattern("HOW", f"p{i}", False, None) for i in range(5)]  # +5 non-hard = 10 total matched
+    missed = [h.Pattern("AVOID", f"m{i}", False, None) for i in range(4)]  # 4 missed -> 14 ref
+    report = h.MatchReport(matched=matched, missed=missed, hard_req_matched=[], hard_req_missing=[])
+    passed, summary = h.evaluate(report)
+    assert passed is True
+    assert "matched=10/14" in summary
+
+
+def test_evaluate_fail_when_hard_req_missing():
+    h = _load_harness()
+    matched = [h.Pattern("HOW", f"p{i}", False, None) for i in range(12)]
+    missed = [h.Pattern("AVOID", "m", False, None)]
+    report = h.MatchReport(
+        matched=matched,
+        missed=missed,
+        hard_req_matched=["verify_pr.sh usage pattern"],
+        hard_req_missing=["git cat-file commit verification"],
+    )
+    passed, summary = h.evaluate(report)
+    assert passed is False
+    assert "git cat-file" in summary
+
+
+def test_evaluate_fail_when_below_10_matches():
+    h = _load_harness()
+    matched = [h.Pattern("HOW", f"p{i}", False, None) for i in range(9)]
+    missed = [h.Pattern("AVOID", "m", False, None) for _ in range(5)]
+    report = h.MatchReport(matched=matched, missed=missed, hard_req_matched=[], hard_req_missing=[])
+    passed, _ = h.evaluate(report)
+    assert passed is False
+
+
+# ---------- CLI tests (parse-only mode, no e2e) ----------
+
+
+def test_cli_parse_only_returns_zero_when_reference_present():
+    h = _load_harness()
+    if not _REFERENCE.exists():
+        pytest.skip("Max's reference file not on this host")
+    rc = h.main([])  # no --run -> parse-only
+    assert rc == 0
+
+
+def test_cli_returns_two_when_reference_missing(tmp_path: Path):
+    h = _load_harness()
+    fake = tmp_path / "does-not-exist.md"
+    rc = h.main(["--reference", str(fake)])
+    assert rc == 2
+
+
+def test_cli_run_without_session_id_returns_two():
+    h = _load_harness()
+    if not _REFERENCE.exists():
+        pytest.skip("Max's reference file not on this host")
+    rc = h.main(["--run"])  # --run without --session-id
+    assert rc == 2


### PR DESCRIPTION
## Summary

Scaffolds the post-merge empirical validation test for `src.skill_gen` (PR #720, merged 2026-05-11 23:44:05 UTC, commit `1d42144d`).

**Harness only.** Real-data run is intentionally deferred — turn_logs were just seeded post-#718 + #720 hook wiring; there isn't enough accumulated history yet for a meaningful overlap test. Run this once ~2-3 directive cycles have landed.

## What's here

| File | Lines | Purpose |
|---|---|---|
| `scripts/smoke_test_skill_gen.py` | 162 | CLI harness: parser + matcher + evaluator + lazy e2e |
| `tests/scripts/test_smoke_test_skill_gen.py` | 191 | 13 unit tests — parser/matcher/evaluator/CLI (no e2e) |

## How it works

1. **Parse** Max's reference at `/tmp/max_session_skill_notes_c322aa37.md` → 14 typed patterns (8 HOW + 6 AVOID).
2. **Tag** hard-requirement patterns via keyword substring: `verify_pr`, `git cat-file`, `sonarcloud`, `tg -g`, `fabricat`. Six reference lines hit at least one keyword, covering all 5 hard-req categories.
3. **Match** (when `--run` provided): substring-match each pattern against the generated SKILL.md body produced by `src.skill_gen.generator.generate()`.
4. **Evaluate** per Dave's acceptance rule:
   - PASS: `matched_count >= 10/14` AND all 5 hard-req categories covered
   - FAIL: otherwise; verbatim mismatch report on stderr; exit 1

## CLI

```
$ python3 scripts/smoke_test_skill_gen.py            # parse-only, exit 0
$ python3 scripts/smoke_test_skill_gen.py --run \\
    --session-id <uuid> --start-ts <iso> --end-ts <iso>    # e2e, exit 0|1
```

`--run` without `--session-id/start-ts/end-ts` → exit 2.

The `src.skill_gen.generator.generate` import is **lazy** — only loaded inside the `--run` branch. Parse-only mode has zero `src/` dependency, so the harness loads cleanly even if `src.skill_gen` is uninstalled.

## Verification (verbatim local output)

```
$ ruff check scripts/smoke_test_skill_gen.py tests/scripts/test_smoke_test_skill_gen.py
All checks passed!

$ ruff format --check scripts/smoke_test_skill_gen.py tests/scripts/test_smoke_test_skill_gen.py
2 files already formatted

$ python3 -m pytest tests/scripts/test_smoke_test_skill_gen.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
collected 13 items

tests/scripts/test_smoke_test_skill_gen.py::test_parser_returns_14_patterns PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_parser_categorises_how_avoid_correctly PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_parser_covers_all_5_hard_req_categories PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_parser_handles_synthetic_input PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_parser_skips_blank_bullets PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_match_patterns_finds_all_when_skillmd_quotes_each PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_match_patterns_sparse_skillmd_reports_missed PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_evaluate_pass_requires_10_total_and_all_hard_reqs PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_evaluate_fail_when_hard_req_missing PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_evaluate_fail_when_below_10_matches PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_cli_parse_only_returns_zero_when_reference_present PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_cli_returns_two_when_reference_missing PASSED
tests/scripts/test_smoke_test_skill_gen.py::test_cli_run_without_session_id_returns_two PASSED

============================== 13 passed in 0.30s ==============================

$ python3 -m pytest tests/scripts/
249 passed in 4.98s   (full tests/scripts/ suite; no regressions)

$ python3 scripts/smoke_test_skill_gen.py
parsed 14 patterns from /tmp/max_session_skill_notes_c322aa37.md
  - HOW: 8
  - AVOID: 6
  - patterns flagged is_hard_req: 6
  - hard-req categories covered: 5/5
parse-only mode; pass --run plus --session-id/--start-ts/--end-ts to evaluate
```

## Design notes

- **Hard-req categories vs flagged patterns**: 5 categories (as Max specified), 6 reference lines flag at least one category keyword (because `git cat-file` appears in both a HOW and an AVOID line). The evaluator counts distinct categories covered, not raw line count.
- **Reference-file-skip guards**: parser tests against the real Max file use `pytest.mark.skipif` so the suite doesn't break on hosts where `/tmp/max_session_skill_notes_c322aa37.md` isn't present. Synthetic-input tests provide coverage everywhere.
- **`dataclass(frozen=True)` + PEP-604 `str | None`**: dataclasses resolves field annotations against `sys.modules[cls.__module__].__dict__`. Loading the harness via `SourceFileLoader` requires registering the module in `sys.modules` before `exec_module`; this is documented inline in `_load_harness()`.
- **Lazy import** of `src.skill_gen.generator`: the `--run` path imports the module at call time, so parse-only mode and the harness's own tests don't drag the supabase httpx client into the import graph.

## Constraints honoured

- [x] Internal tooling only — no `src/pipeline/`, `src/intelligence/`, `anthropic_batch.py` changes
- [x] Fresh branch off `origin/main` (`atlas/skill-gen-smoke-test`)
- [x] Imports from `src.skill_gen` (PR #720)
- [x] NO e2e run against real data — only parser/matcher/evaluator unit tests
- [x] ruff check + ruff format --check + pytest green locally
- [x] No self-merge

## Test plan

- [x] 13 unit tests covering parser/matcher/evaluator/CLI usage modes
- [x] Full `tests/scripts/` suite green (249 passed, no regressions)
- [x] Manual CLI smoke: `--help` + parse-only mode
- [ ] After 2-3 directive cycles: invoke `--run --session-id <real> --start-ts ... --end-ts ...` to validate the e2e path against accumulated turn_logs
- [ ] Aiden + Max review + merge

## Approval gate

DO NOT MERGE without dual-CTO review. Aiden + Max merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)