### PR TITLE
[ATLAS] fix(scripts): tg -d rejects for clone callsigns (Option A patch)

### DIFF
--- a/scripts/tg
+++ b/scripts/tg
@@ -8,7 +8,7 @@ their messages land in Slack instead.
 Usage (preserved from pre-cutover tg):
     tg "msg"                 → #execution
     tg -g "msg"              → #execution (group)
-    tg -d "msg"              → #ceo (prime callsigns) | #execution (clones)
+    tg -d "msg"              → #ceo (prime callsigns) | exit 2 reject (clones)
     tg -c <channel> "msg"    → named channel ("execution", "ceo", ...) or ID
     echo "msg" | tg          → reads from stdin
 
@@ -47,8 +47,20 @@ def translate(argv: list[str], callsign: str) -> list[str]:
         if a in ("-g", "--group"):
             out.append("-g")
         elif a in ("-d", "--dm"):
-            channel = "ceo" if callsign.lower() in PRIME_CALLSIGNS else "execution"
-            out.extend(["-c", channel])
+            # Clone callsigns (atlas/orion/scout) have no DM privileges — they
+            # post to #execution only per Dave directive #6 worktree allowlist.
+            # Earlier behaviour silently fell back to #execution, hiding the
+            # intent mismatch. Reject explicitly so the caller sees the
+            # contract violation.
+            if callsign.lower() not in PRIME_CALLSIGNS:
+                print(
+                    f"tg: -d (DM routing) not supported for clone callsign "
+                    f"'{callsign}'. Clones post to #execution only. Use no "
+                    f"flag or '-g' instead.",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            out.extend(["-c", "ceo"])
         elif a in ("-c", "--chat", "--channel"):
             if i + 1 >= len(argv):
                 print("tg: -c requires a channel name or ID", file=sys.stderr)

--- a/tests/scripts/test_tg_shim.py
+++ b/tests/scripts/test_tg_shim.py
@@ -1,7 +1,7 @@
 """Tests for scripts/tg — Slack relay shim (callsign-fix Phase 2).
 
 Verifies:
-    - CLI flag translation (-g, -d prime, -d clone, -c, no-flag default)
+    - CLI flag translation (-g, -d prime, -d clone reject, -c, no-flag default)
     - stdin pipe pass-through
     - exit code propagation from slack_relay.py
     - callsign attribution preserved (via slack_relay.py, not re-prepended in tg)
@@ -42,10 +42,21 @@ def test_translate_dm_prime_routes_to_ceo():
         assert tg.translate(["-d", "msg"], callsign) == ["-c", "ceo", "msg"], callsign
 
 
-def test_translate_dm_clone_falls_back_to_execution():
+def test_translate_dm_clone_rejects_with_exit_2(capsys):
+    """Clones (atlas/orion/scout) have no DM privileges — -d must reject.
+
+    Falling back to #execution silently was the original PR #712 behaviour;
+    today's contract (Elliot dispatch 2026-05-12, concurred ts 1778544356.893729)
+    is explicit rejection so the operator sees the intent mismatch.
+    """
     tg = _load_tg()
     for callsign in ("atlas", "orion", "scout"):
-        assert tg.translate(["-d", "msg"], callsign) == ["-c", "execution", "msg"], callsign
+        with pytest.raises(SystemExit) as exc:
+            tg.translate(["-d", "msg"], callsign)
+        assert exc.value.code == 2, callsign
+        err = capsys.readouterr().err
+        assert "not supported for clone callsign" in err, callsign
+        assert callsign in err, callsign
 
 
 def test_translate_channel_flag_named_and_id():


### PR DESCRIPTION
## Summary

Tightens the `tg→slack_relay` shim's `-d` branch so clone callsigns (atlas/orion/scout) get an explicit **exit-2 rejection** instead of silently falling back to `-c execution`. Brings `-d` enforcement in line with `-c <forbidden-channel>` enforcement — both routes now error out so the caller sees the contract violation rather than misattributing the post.

Concurred in #execution 2026-05-12 ts `1778544356.893729`. Follows the PARTIAL result from yesterday's e2e smoke verify (post PR #712), where step 3 (`scripts/tg -d` from atlas) successfully posted to #execution instead of rejecting — see outbox `20260512_0024_tg_shim_e2e_verify_PR712.json`.

## Behaviour change

| Callsign class | Before (PR #712) | After (this PR) |
|---|---|---|
| Prime (elliot/aiden/enforcer/max) | `-d` → `-c ceo` | unchanged |
| Clone (atlas/orion/scout) | `-d` → silent fallback to `-c execution` | `-d` → **exit 2 + clear stderr** |

Rejection text:
```
tg: -d (DM routing) not supported for clone callsign '<name>'. Clones post to
#execution only. Use no flag or '-g' instead.
```

## Diff scope

| Path | +/- | Why |
|---|---|---|
| `scripts/tg` | +14 / -3 | Replace fallback with `sys.exit(2)` for clones; keep prime path; update docstring |
| `tests/scripts/test_tg_shim.py` | +14 / -3 | Replace `test_translate_dm_clone_falls_back_to_execution` (asserted dead behaviour) with `test_translate_dm_clone_rejects_with_exit_2` |

No source-of-truth files (`scripts/slack_relay.py`, `src/**`, ARCHITECTURE.md, IDENTITY.md) touched.

## Verification (verbatim local output)

```
$ ruff check scripts/tg tests/scripts/test_tg_shim.py
All checks passed!

$ ruff format --check scripts/tg tests/scripts/test_tg_shim.py
2 files already formatted

$ python3 -m pytest tests/scripts/test_tg_shim.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
collected 8 items

tests/scripts/test_tg_shim.py::test_translate_group_flag PASSED
tests/scripts/test_tg_shim.py::test_translate_dm_prime_routes_to_ceo PASSED
tests/scripts/test_tg_shim.py::test_translate_dm_clone_rejects_with_exit_2 PASSED
tests/scripts/test_tg_shim.py::test_translate_channel_flag_named_and_id PASSED
tests/scripts/test_tg_shim.py::test_translate_default_passes_message_through PASSED
tests/scripts/test_tg_shim.py::test_translate_channel_flag_requires_argument PASSED
tests/scripts/test_tg_shim.py::test_subprocess_propagates_relay_exit_code PASSED
tests/scripts/test_tg_shim.py::test_subprocess_stdin_passthrough PASSED

============================== 8 passed in 0.68s ==============================

$ python3 -m pytest tests/scripts/
============================== 236 passed in 2.94s ==============================
(full tests/scripts/ suite; no regressions)

$ set -a && source /home/elliotbot/.config/agency-os/.env && set +a && \
    CALLSIGN=atlas SLACK_BOT_USERNAME=Atlas R_VERIFY_SKIP=1 CONCUR_GATE_SKIP=1 \
    scripts/tg -d "should reject"
tg: -d (DM routing) not supported for clone callsign 'atlas'. Clones post to
#execution only. Use no flag or '-g' instead.
EXIT=2
(live smoke against the rebuilt shim — no Slack post made)
```

## Constraints honoured

- [x] Internal tooling only — no `src/pipeline/`, no `src/intelligence/`, no `scripts/slack_relay.py` changes
- [x] Fresh branch off `origin/main` (`atlas/tg-shim-dm-reject-clones`)
- [x] No contradictory dead tests: previous fallback assertion replaced (not stacked)
- [x] ruff check + ruff format --check + pytest green
- [x] No self-merge

## Test plan

- [x] Unit: all three clone callsigns reject with exit 2 + correct stderr
- [x] Unit: prime path (`-d` → `-c ceo`) unchanged
- [x] Full `tests/scripts/` suite green (236)
- [x] Live smoke against atlas worktree against the rebuilt shim — exit 2 + no Slack post
- [ ] Aiden + Max review + merge

## Approval gate

DO NOT MERGE without dual-CTO review. Aiden + Max merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)