### PR TITLE
[ORION] feat(docs+tests): Drevon port retrospective + integration smoke

### DIFF
--- a/docs/architecture/drevon_port_2026-05-11.md
+++ b/docs/architecture/drevon_port_2026-05-11.md
@@ -1,0 +1,150 @@
+# Drevon Port — Architecture Retrospective
+
+**Compiled:** 2026-05-12 (post-PR-A.5 listener-integration cutover staging)
+**Author:** ORION
+**Scope:** Internal Claude Code tooling stack. NOT Agency OS pipeline (Stage 7/10/keyword_expander/anthropic_batch remain on the API).
+
+## Why "Drevon"
+
+Audit + replay + auto-skill-gen + session resumption stack — read sessions, replay claims, generate skills, resume context. Internal to Claude Code agent operations; OAuth-only ($0 incremental under Max plan).
+
+## Four Stages
+
+| # | Stage | PRs | Status |
+|---|-------|-----|--------|
+| 1 | Schema foundation | [#715](https://github.com/Keiracom/Agency_OS/pull/715), [#718](https://github.com/Keiracom/Agency_OS/pull/718) | MERGED |
+| 2 | Replay-on-claim | [#719](https://github.com/Keiracom/Agency_OS/pull/719), [#724](https://github.com/Keiracom/Agency_OS/pull/724) | #719 MERGED, #724 OPEN |
+| 3 | Auto skill-gen | [#720](https://github.com/Keiracom/Agency_OS/pull/720) | MERGED |
+| 4 | UUID resumption | [#725](https://github.com/Keiracom/Agency_OS/pull/725) | OPEN |
+
+## Stage 1 — Schema Foundation (PR-A)
+
+5-table audit/replay store. Every Claude Code action is recorded best-effort.
+
+```
+sessions ──┬─< messages       (user/assistant per session)
+           └─< turns ──┬─< turn_logs ──< turn_files
+                       │                  (tool I/O files)
+                       │
+                       └ atomic assistant turn (one user msg → tool calls → response)
+```
+
+All tables: `id UUID PK`, `started_at TIMESTAMPTZ`, soft-delete via `deleted_at TIMESTAMPTZ`, RLS-gated to platform admins. Partial indexes filter `deleted_at IS NULL`.
+
+**Recording side** ([`src/session_store/recorder.py`](../../src/session_store/recorder.py)): `record_session_start`, `record_message`, `record_turn_start`, `record_tool_call`, `record_turn_complete`, `record_session_end`, `mark_session_stuck`. All wrap `_safe_post`/`_safe_patch` — log+swallow on failure (never block the agent).
+
+**Hook wiring** (PR #718 → [`.claude/settings.json`](../../.claude/settings.json)):
+
+| Hook event | Script | Purpose |
+|---|---|---|
+| PostToolUse (matcher `*`) | `.claude/hooks/session_store_posttooluse.sh` | Append `turn_logs` row per tool call |
+| Stop (matcher `*`) | `.claude/hooks/session_store_stop.sh` | Close `sessions` row + flush trailing `turns` |
+
+No retroactive backfill — new sessions only.
+
+## Stage 2 — Replay-on-Claim (PR-A.5)
+
+Three-layer R3 (completion-claim) defense. Replay is the structural after-the-fact audit:
+
+1. **Discipline** (PR #717 module) — agents are reminded to verify before claiming.
+2. **Gate** (PR #703 verify_gate) — pre-LLM regex blocks obvious unverified claims.
+3. **Replay** (PR #719 — this stage) — post-LLM scan of `turn_logs` for verification evidence; suppresses LLM-flagged R3 violations when evidence exists.
+
+**Public entry** ([`src/replay/claim_verifier.py`](../../src/replay/claim_verifier.py)):
+
+```python
+def verify_completion_claim(text: str, callsign: str | None = None) -> tuple[bool, str]:
+    """Return (verified, reason). Conservative: True when uncertain."""
+```
+
+Extraction: PR# regex (`\bPRs?\s*#?\s*(\d+)\b` + `pull request N` + orphan `#N`) and 7–40 char hex commit hashes. Evidence patterns scanned in `turn_logs.tool_args_json`:
+
+- PR evidence: `verify_pr.sh`, `gh pr view`, `gh pr merge`, `gh pr checks`, `gh api repos`
+- Commit evidence: `git cat-file`, `git log`, `git show`
+
+Per-pattern query is `ilike.*pattern*` on `tool_args_json`, `limit=20`, ordered `started_at desc`. The PR# / hash must appear as a substring in the matched row's args.
+
+**Listener integration** (PR #724, OPEN): wires `verify_completion_claim` into the Slack central listener behind env flag `REPLAY_ON_CLAIM_ENABLED` so cutover is reversible.
+
+## Stage 3 — Auto Skill-Gen (PR-B)
+
+Reads a directive-bounded slice of `turn_logs`, compresses to a prompt, invokes `claude --no-hooks --print` via subprocess to synthesise a `SKILL.md`, writes to `skills/<derived-name>/SKILL.md`, opens a PR for human review.
+
+**Critical pattern — `--no-hooks` recursion guard**: the spawned `claude` process MUST be invoked with `--no-hooks`, otherwise the inner session triggers `PostToolUse` + `Stop` hooks that record into `session_store`, which would re-enter `skill_gen` if it's ever wired into a hook itself. The `--no-hooks` flag is mandatory for any subprocess `claude` invocation that runs inside a hook context. (Atlas chose Option B — per-call subprocess — over Option A long-lived worker; one-shot nature, simpler tests, fits the clone lifecycle.)
+
+OAuth-only — $0 incremental under Max plan. No API key required. NO Agency OS pipeline code touched.
+
+## Stage 4 — UUID Resumption (PR-C)
+
+Long-lived terminals preserve accumulated context across watchdog-restarts and `/clear` cycles by resuming on the prior `session_uuid`.
+
+**Public entry** ([`src/session_resumption/`](../../src/session_resumption/)):
+
+```python
+resolve_session_uuid(callsign, fresh_minutes=30) -> str | None
+claim_session_uuid(callsign, uuid, cwd, **opts) -> UUID | None     # delegates to recorder
+clear_stuck_sessions(callsign=None, stuck_minutes=60) -> int        # delegates to mark_session_stuck
+```
+
+Resolver query: `status=active AND ended_at IS NULL AND session_uuid IS NOT NULL AND deleted_at IS NULL AND started_at >= now() - INTERVAL fresh_minutes`, ordered `started_at desc`, limit 1. Watchdog: complementary sweep marks `ended_at IS NULL AND started_at < now() - INTERVAL stuck_minutes` as `status='stuck'` so stale rows fall out of the resolver.
+
+**Launcher** ([`scripts/agent_session_launcher.sh`](../../scripts/agent_session_launcher.sh)): bash wrapper. Calls resolver → picks `--resume` vs `--session-id` → `exec claude`. Best-effort: any DB failure falls through to a fresh UUID rather than blocking startup. `SESSION_LAUNCHER_DRY=1` skips ALL Supabase I/O for safe CLI testing.
+
+## Env-Flag Gates
+
+| Var | Default | Effect |
+|---|---|---|
+| `REPLAY_ON_CLAIM_ENABLED` (PR #724) | unset = off | Wires `verify_completion_claim` into listener post-LLM check |
+| `SESSION_LAUNCHER_DRY` (PR #725) | unset = live | Launcher skips resolve+claim, emits fresh UUID, prints would-exec |
+| `SESSION_FRESH_MINUTES` (PR #725) | 30 | Override resolver freshness window |
+| `SESSION_STUCK_MINUTES` (PR #725) | 60 | Override watchdog stale threshold |
+| `SESSION_WATCHDOG_SCOPE` (PR #725) | unset = all | Scope watchdog to a single callsign |
+
+## End-to-End Data Flow
+
+```
+agent terminal startup
+    └─→ scripts/agent_session_launcher.sh <callsign>          ── PR-C
+            │
+            ├─ resolve_session_uuid(callsign)                  ── PR-C
+            │     └─ sb_get sessions WHERE callsign=X AND fresh
+            │
+            ├─ claim_session_uuid(callsign, uuid, cwd)         ── PR-C → recorder.record_session_start (PR-A)
+            │
+            └─ exec claude --resume <uuid> | --session-id <uuid>
+                    │
+                    ├─ PostToolUse hook ── session_store_posttooluse.sh ── recorder.record_tool_call (PR-A)
+                    │                                                           │
+                    │                                                           └─→ turn_logs row appended
+                    │
+                    ├─ assistant claims "PR #N merged" in #execution
+                    │     └─ central_listener (if REPLAY_ON_CLAIM_ENABLED)
+                    │           └─ verify_completion_claim(text)               ── PR-A.5
+                    │                 └─ sb_get turn_logs WHERE tool_args ILIKE '%verify_pr.sh%' AND contains '#N'
+                    │
+                    └─ Stop hook ── session_store_stop.sh ── recorder.record_session_end (PR-A)
+
+watchdog (cron / systemd timer / agent loop)
+    └─→ .claude/hooks/session_resumption_watchdog.sh           ── PR-C
+            └─ clear_stuck_sessions(stuck_minutes=60)
+                  └─ mark_session_stuck per stale row          ── PR-A
+
+skill-gen (manual invocation)
+    └─→ python -m skill_gen <directive>                        ── PR-B
+            ├─ sb_get turn_logs WHERE session_id IN (directive bounds)
+            └─ subprocess: claude --no-hooks --print "..."     (recursion guard mandatory)
+                  └─ writes skills/<name>/SKILL.md
+                  └─ opens PR for human review
+```
+
+## Non-goals & open items
+
+- **No retroactive backfill**: all four stages assume new sessions only. Older Claude Code activity is invisible.
+- **PR #724 cutover**: replay-on-claim is shipped but not yet behind the listener flag in main. Concur pending.
+- **PR #725 cutover**: launcher is shipped but not yet wired into tmux startup. Concur pending; phased rollout per callsign expected.
+- **Watchdog cadence**: hook is operator-installed, not auto-wired into `settings.json`. Cron / systemd timer / agent loop — operator's call.
+- **Test isolation**: integration tests against real Supabase MUST use disposable callsigns + soft-delete cleanup (see `tests/integration/test_drevon_port_smoke.py`). Direct writes against real callsigns pollute the resolver until `mark_session_stuck` runs.
+
+## Discovered issues (logged from this retrospective's integration test)
+
+- **claim_verifier ilike-on-JSONB returns 404** ([`src/replay/claim_verifier.py`](../../src/replay/claim_verifier.py) `_query_turn_logs_for_pattern`): PostgREST cannot apply `ilike.*pattern*` directly to the JSONB column `turn_logs.tool_args_json` — server returns `42883 No operator matches`, function catches the exception, and every claim resolves to `(False, "no evidence")`. **Effect:** replay-on-claim currently never *finds* evidence; it only ever *fails to find*. Combined with the conservative-true semantics, this means R3 violations are correctly suppressed when claims have no PR/hash refs, but never suppressed when claims do have refs (over-firing). Fix path: extract a `command` field via `tool_args_json->>command` or add a generated text column for ilike. Tracked in PR body of `[ORION] feat(docs): drevon port retrospective`. Out-of-scope for this PR; flagged for Aiden + the PR-A.5 maintainer.

--- a/tests/integration/test_drevon_port_smoke.py
+++ b/tests/integration/test_drevon_port_smoke.py
@@ -1,0 +1,211 @@
+"""Drevon port end-to-end smoke against real Supabase.
+
+Env-gated: skipped unless INTEGRATION=1 AND SUPABASE_URL/SUPABASE_SERVICE_KEY
+are present. Default `pytest tests/integration/` collects but skips this file.
+Run with:
+
+    INTEGRATION=1 python3 -m pytest tests/integration/test_drevon_port_smoke.py -v
+
+Scenarios:
+  1. Inserts a synthetic session + turn + turn_log under a disposable callsign.
+  2. resolve_session_uuid finds the synthetic session (resume path).
+  3. verify_completion_claim returns True for a claim referencing the synthetic
+     PR# (evidence present in the turn_logs row's tool_args_json).
+  4. verify_completion_claim returns False for a claim referencing a PR# that
+     has no synthetic evidence.
+
+Cleanup: every synthetic row soft-deleted (`deleted_at = NOW()`) so production
+data and the partial indexes are unaffected.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import random
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+DEFAULT_DOTENV = Path("/home/elliotbot/.config/agency-os/.env")
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("INTEGRATION") != "1",
+    reason="Set INTEGRATION=1 to run (real-Supabase smoke).",
+)
+
+
+def _utc_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@pytest.fixture(autouse=True)
+def _real_supabase_creds(monkeypatch):
+    """tests/conftest.py overrides SUPABASE_URL/KEY to mock values for unit
+    tests. This integration test needs the real prod creds — pull them from
+    the .env file (or DREVON_DOTENV env override) and patch supabase_client's
+    cached module-level constants. Skips cleanly if creds aren't loadable."""
+    from dotenv import dotenv_values
+
+    dotenv_path = Path(os.environ.get("DREVON_DOTENV", DEFAULT_DOTENV))
+    if not dotenv_path.exists():
+        pytest.skip(f"dotenv not found at {dotenv_path}; cannot load real creds")
+    values = dotenv_values(dotenv_path)
+    url = values.get("SUPABASE_URL")
+    key = values.get("SUPABASE_SERVICE_KEY")
+    if not url or not key or "test.supabase.co" in url:
+        pytest.skip(f"real SUPABASE_URL/SUPABASE_SERVICE_KEY missing in {dotenv_path}")
+
+    from src.evo import supabase_client
+
+    monkeypatch.setattr(supabase_client, "_URL", url)
+    monkeypatch.setattr(supabase_client, "_KEY", key)
+    monkeypatch.setattr(
+        supabase_client,
+        "_HEADERS",
+        {
+            "apikey": key,
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+            "Prefer": "return=representation",
+        },
+    )
+
+
+@pytest.fixture
+def synthetic_drevon_rows():
+    """Insert sessions + turn + turn_log; yield IDs + a unique synthetic PR#;
+    soft-delete on teardown so prod pollution is bounded."""
+    from src.evo.supabase_client import sb_patch, sb_post
+
+    # Disposable callsign so resolver queries can't hit a real-callsign row.
+    suffix = uuid.uuid4().hex[:8]
+    callsign = f"orion-int-{suffix}"
+    # Bizarre 8-digit PR# unlikely to appear in real turn_logs (real PRs are
+    # currently 3-digit). Random within the range so concurrent runs collide
+    # at vanishing probability.
+    synthetic_pr = random.randint(99_000_000, 99_999_999)
+    fabricated_pr = random.randint(98_000_000, 98_999_999)
+    session_uid = str(uuid.uuid4())
+    session_row = sb_post(
+        "sessions",
+        {
+            "callsign": callsign,
+            "session_uuid": session_uid,
+            "working_directory": f"/tmp/drevon-port-smoke-{suffix}",
+            "started_at": _utc_iso(),
+            "status": "active",
+        },
+    )[0]
+    turn_row = sb_post(
+        "turns",
+        {
+            "session_id": session_row["id"],
+            "turn_index": 0,
+            "started_at": _utc_iso(),
+        },
+    )[0]
+    log_row = sb_post(
+        "turn_logs",
+        {
+            "turn_id": turn_row["id"],
+            "tool_name": "Bash",
+            "tool_args_json": {
+                "command": f"bash scripts/verify_pr.sh {synthetic_pr}",
+                "description": "drevon-port-smoke synthetic evidence",
+            },
+            "tool_result_summary": f"verify_pr.sh exited 0 for PR #{synthetic_pr}",
+            "exit_status": "success",
+            "started_at": _utc_iso(),
+        },
+    )[0]
+    yield {
+        "callsign": callsign,
+        "session_uuid": session_uid,
+        "synthetic_pr": synthetic_pr,
+        "fabricated_pr": fabricated_pr,
+        "session_id": session_row["id"],
+        "turn_id": turn_row["id"],
+        "log_id": log_row["id"],
+    }
+    deleted_iso = _utc_iso()
+    for table, row_id in (
+        ("turn_logs", log_row["id"]),
+        ("turns", turn_row["id"]),
+        ("sessions", session_row["id"]),
+    ):
+        # Best-effort cleanup — never fail teardown.
+        with contextlib.suppress(Exception):
+            sb_patch(table, {"id": f"eq.{row_id}"}, {"deleted_at": deleted_iso})
+
+
+def _import_resolver_or_skip():
+    """src.session_resumption ships in PR #725 (currently OPEN). Once merged
+    these tests run inline; until then they skip cleanly. Tests for the
+    `.resolver` submodule explicitly — a leftover __pycache__ would let the
+    namespace package import succeed but fail at the function lookup."""
+    pytest.importorskip(
+        "src.session_resumption.resolver",
+        reason="src.session_resumption.resolver not on main yet (PR #725 pending)",
+    )
+    from src.session_resumption.resolver import resolve_session_uuid
+
+    return resolve_session_uuid
+
+
+def test_resolve_session_uuid_finds_synthetic_session(synthetic_drevon_rows):
+    resolve_session_uuid = _import_resolver_or_skip()
+    found = resolve_session_uuid(synthetic_drevon_rows["callsign"])
+    assert found == synthetic_drevon_rows["session_uuid"]
+
+
+# DISCOVERED BUG: src.replay.claim_verifier issues `ilike.*pattern*` against
+# the JSONB column `turn_logs.tool_args_json`, which PostgREST rejects with
+# 404 (operator does not exist for jsonb). Because the function catches the
+# exception and returns []-for-each-pattern, every call resolves to (False,
+# "no evidence") regardless of input — so the True-evidence assertion below
+# is xfail and the False-evidence one would pass for the wrong reason. Fix
+# requires extracting a JSON field (tool_args_json->>0, or a dedicated text
+# column) — out of scope for this PR but reported in PR body + outbox.
+@pytest.mark.xfail(
+    reason="claim_verifier ilike-on-JSONB returns 404 in PostgREST (pre-existing bug discovered by this test); see PR body.",
+    strict=True,
+)
+def test_verify_completion_claim_returns_true_for_synthetic_evidence(
+    synthetic_drevon_rows,
+):
+    from src.replay.claim_verifier import verify_completion_claim
+
+    pr = synthetic_drevon_rows["synthetic_pr"]
+    verified, reason = verify_completion_claim(f"Done shipping PR #{pr} to main.")
+    assert verified is True, f"expected evidence-found, got reason={reason!r}"
+    assert "verify_pr.sh" in reason or str(pr) in reason
+
+
+def test_verify_completion_claim_handles_missing_evidence_path(synthetic_drevon_rows):
+    """Even with the ilike-JSONB bug above, the no-evidence path must remain
+    safe (returns False with a reason string, never raises). This anchors the
+    best-effort contract — the launcher / listener must never crash because
+    of a malformed query."""
+    from src.replay.claim_verifier import verify_completion_claim
+
+    pr = synthetic_drevon_rows["fabricated_pr"]
+    verified, reason = verify_completion_claim(f"Done shipping PR #{pr} to main.")
+    assert verified is False
+    assert isinstance(reason, str) and reason
+
+
+def test_soft_deleted_session_excluded_from_resolver(synthetic_drevon_rows):
+    """Cleanup contract — once deleted_at is set the resolver must not see it."""
+    from src.evo.supabase_client import sb_patch
+
+    resolve_session_uuid = _import_resolver_or_skip()
+    sb_patch(
+        "sessions",
+        {"id": f"eq.{synthetic_drevon_rows['session_id']}"},
+        {"deleted_at": _utc_iso()},
+    )
+    found = resolve_session_uuid(synthetic_drevon_rows["callsign"])
+    assert found is None


### PR DESCRIPTION
## Summary
Two deliverables for the Drevon port (4-stage internal Claude Code tooling stack):

1. **`docs/architecture/drevon_port_2026-05-11.md`** (150 lines) — architecture retrospective covering all 4 stages with PR map, table relationships, hook integration points, env-flag gates, end-to-end data flow, and Atlas's `--no-hooks` recursion guard from PR #720.
2. **`tests/integration/test_drevon_port_smoke.py`** (211 lines) — env-gated real-Supabase smoke. Default `pytest` skips; `INTEGRATION=1 pytest` runs against prod with disposable callsigns + soft-delete cleanup.

## Stages documented
| # | Stage | PRs | Status |
|---|---|---|---|
| 1 | Schema foundation | #715, #718 | MERGED |
| 2 | Replay-on-claim | #719, #724 | #719 MERGED, #724 OPEN |
| 3 | Auto skill-gen | #720 | MERGED |
| 4 | UUID resumption | #725 | OPEN (mine, awaiting concur) |

## ⚠ Discovered bug — claim_verifier ilike-on-JSONB

The integration test surfaced a real pre-existing bug in PR #719's `src.replay.claim_verifier._query_turn_logs_for_pattern`:

```
PostgREST 42883: ilike cannot be applied to JSONB column tool_args_json
```

**Effect:** `verify_completion_claim` always returns `(False, "no evidence")` for any claim with a PR# or commit hash because every `turn_logs` query 404s and the function defensively returns `[]`. The no-refs branch (`(True, "no claim refs")`) still works.

**Operational impact:** R3 over-fires on legitimate verified work — replay's job is to suppress R3 when evidence exists, but evidence is currently never found.

**Fix path** (out-of-scope for this PR): extract a JSON field via `tool_args_json->>command` or add a generated text mirror column. Flagged for Aiden + the PR-A.5 maintainer; documented in retrospective doc + commit body.

The corresponding test is marked `xfail(strict=True)` so the assertion converts to a pass once the bug is fixed.

## Forward compatibility
The two resolver tests use `pytest.importorskip("src.session_resumption.resolver")` since PR #725 is OPEN. They skip cleanly today and convert to passes once #725 merges — no rebase needed.

## Test isolation contract
- Real Supabase credentials loaded via autouse fixture from `/home/elliotbot/.config/agency-os/.env` (override path via `DREVON_DOTENV`); skips if creds missing.
- Disposable callsigns (`orion-int-<8hex>`) so resolver queries can't pick up real-callsign rows.
- Synthetic PR# in 99_000_000–99_999_999 range so concurrent test runs don't collide with real PRs (current main is at PR #725).
- Soft-delete cleanup (`deleted_at = NOW()`) on every synthetic row in fixture teardown.
- Post-run orphan check: 0 `orion-int-*` rows with `deleted_at IS NULL` after the suite. ✓

## Verification

### Default mode (no INTEGRATION env, CI-safe)
```
plugins: asyncio-1.3.0, logfire-4.25.0, anyio-4.12.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collecting ... collected 4 items

tests/integration/test_drevon_port_smoke.py::test_resolve_session_uuid_finds_synthetic_session SKIPPED [ 25%]
tests/integration/test_drevon_port_smoke.py::test_verify_completion_claim_returns_true_for_synthetic_evidence SKIPPED [ 50%]
tests/integration/test_drevon_port_smoke.py::test_verify_completion_claim_handles_missing_evidence_path SKIPPED [ 75%]
tests/integration/test_drevon_port_smoke.py::test_soft_deleted_session_excluded_from_resolver SKIPPED [100%]

============================== 4 skipped in 0.17s ==============================
```

### INTEGRATION=1 (real Supabase)
```
plugins: asyncio-1.3.0, logfire-4.25.0, anyio-4.12.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collecting ... collected 4 items

tests/integration/test_drevon_port_smoke.py::test_resolve_session_uuid_finds_synthetic_session SKIPPED [ 25%]
tests/integration/test_drevon_port_smoke.py::test_verify_completion_claim_returns_true_for_synthetic_evidence XFAIL [ 50%]
tests/integration/test_drevon_port_smoke.py::test_verify_completion_claim_handles_missing_evidence_path PASSED [ 75%]
tests/integration/test_drevon_port_smoke.py::test_soft_deleted_session_excluded_from_resolver SKIPPED [100%]

=================== 1 passed, 2 skipped, 1 xfailed in 9.84s ====================
```

### ruff
```
All checks passed!
1 file already formatted
```

## Test plan
- [x] ruff check + format clean
- [x] Default `pytest` → 4 skipped in 0.16s (CI-safe)
- [x] `INTEGRATION=1 pytest` → 1 passed, 2 skipped (PR #725 dep), 1 xfailed (JSONB bug)
- [x] Soft-delete cleanup verified — 0 orphan `orion-int-*` rows in prod
- [ ] Reviewer-side: read `docs/architecture/drevon_port_2026-05-11.md`, sanity-check the 4-stage map matches your mental model
- [ ] Reviewer-side: `INTEGRATION=1 pytest tests/integration/test_drevon_port_smoke.py -v` from your worktree should produce the same 1-passed/2-skipped/1-xfailed result
- [ ] Reviewer-side: when PR #725 merges, the 2 skipped resolver tests must convert to passes without code changes

## Review gating
Concur from Aiden (dispatcher) + Max/Elliot. No self-merge.

## Follow-up dispatch suggestions
- Fix `claim_verifier` JSONB-ilike (`tool_args_json->>command` or text-column mirror)
- Concur on PR #724 (replay-on-claim listener integration) — the fix above unblocks that ramp
- Concur on PR #725 (UUID resumption) — unblocks 2 skipped tests here

🤖 Generated with [Claude Code](https://claude.com/claude-code)