### PR TITLE
[ATLAS] fix(skill_gen): --no-hooks → env marker + extractor in-progress turn filter

### DIFF
--- a/.claude/hooks/session_store_posttooluse.sh
+++ b/.claude/hooks/session_store_posttooluse.sh
@@ -14,6 +14,12 @@
 
 set -u
 
+# Recursion guard for src/skill_gen — when this hook fires inside a
+# `claude` subprocess spawned by claude_invoke.invoke(), early-exit so we
+# don't cascade nested turn_logs writes / infinite loops. The marker
+# `CLAUDE_CODE_SKILL_GEN=1` is set in src/skill_gen/claude_invoke.py.
+[ "${CLAUDE_CODE_SKILL_GEN:-}" = "1" ] && exit 0
+
 LOG_DIR="${SESSION_STORE_LOG_DIR:-/tmp/agency-os-session-store}"
 mkdir -p "$LOG_DIR" 2>/dev/null || true
 

--- a/.claude/hooks/session_store_stop.sh
+++ b/.claude/hooks/session_store_stop.sh
@@ -6,6 +6,11 @@
 
 set -u
 
+# Recursion guard for src/skill_gen — see session_store_posttooluse.sh
+# for the same pattern. CLAUDE_CODE_SKILL_GEN=1 is set in
+# src/skill_gen/claude_invoke.py on every spawned `claude` subprocess.
+[ "${CLAUDE_CODE_SKILL_GEN:-}" = "1" ] && exit 0
+
 LOG_DIR="${SESSION_STORE_LOG_DIR:-/tmp/agency-os-session-store}"
 mkdir -p "$LOG_DIR" 2>/dev/null || true
 

--- a/src/skill_gen/claude_invoke.py
+++ b/src/skill_gen/claude_invoke.py
@@ -1,12 +1,21 @@
 """claude_invoke.py — subprocess wrapper around the `claude` CLI.
 
-Spawns a fresh `claude --no-hooks --print --session-id <uuid>` process for
-each invocation (Option B per Drevon PR-B dispatch). Per-call isolation: no
+Spawns a fresh `claude --print --session-id <uuid>` process for each
+invocation (Option B per Drevon PR-B dispatch). Per-call isolation: no
 shared state between invocations, no daemon, no tmux infra.
 
-`--no-hooks` is MANDATORY. Without it, PostToolUse/Stop hooks fire inside
-the spawned process and recurse into session_store.record_tool_call(),
-which would cascade nested turn_logs writes / infinite loops.
+Recursion guard via env marker: every spawned process gets
+`CLAUDE_CODE_SKILL_GEN=1` in its environment. The session_store hooks
+(`.claude/hooks/session_store_posttooluse.sh`, `session_store_stop.sh`)
+inspect that variable and early-exit on match — preventing PostToolUse /
+Stop hooks from cascading nested turn_logs writes / infinite loops inside
+the spawned process.
+
+The earlier design used `claude --no-hooks` but the installed CLI (v2.1.139)
+doesn't recognise that flag — the CLI's own hook-skip flag (`--bare`) is
+incompatible with OAuth (forces ANTHROPIC_API_KEY auth). The env-marker
+guard preserves OAuth/Max-plan billing ($0 incremental) while still
+preventing the recursion.
 
 Stdin: compressed prompt (str).
 Stdout: claude's response (str).
@@ -14,15 +23,18 @@ Stderr: captured for error diagnostics.
 
 Exit codes:
     0   success
-    !=0 → CalledProcessError raised; caller decides whether to retry / abort.
+    !=0 → caller inspects ClaudeResult.returncode and decides retry/abort.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from dataclasses import dataclass
 from uuid import uuid4
+
+RECURSION_GUARD_ENV = "CLAUDE_CODE_SKILL_GEN"
 
 
 @dataclass(frozen=True)
@@ -46,6 +58,13 @@ def _resolve_claude(claude_bin: str | None) -> str:
     return found
 
 
+def _build_env(parent_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Merge parent env (defaults to os.environ) with the recursion-guard marker."""
+    env = dict(parent_env if parent_env is not None else os.environ)
+    env[RECURSION_GUARD_ENV] = "1"
+    return env
+
+
 def invoke(
     prompt: str,
     *,
@@ -53,17 +72,22 @@ def invoke(
     claude_bin: str | None = None,
     extra_args: list[str] | None = None,
     runner=subprocess.run,
+    parent_env: dict[str, str] | None = None,
 ) -> ClaudeResult:
-    """Run `claude --no-hooks --print --session-id <new>` with `prompt` on stdin.
+    """Run `claude --print --session-id <new>` with `prompt` on stdin.
 
     `runner` is injectable for tests (default: subprocess.run). Tests pass a
     stub that returns CompletedProcess-shaped data without touching the OS.
+
+    `parent_env` is injectable for tests so they can assert env-merge behaviour
+    without depending on the live os.environ. Production callers omit it.
     """
     binary = _resolve_claude(claude_bin)
     session_id = str(uuid4())
-    cmd = [binary, "--no-hooks", "--print", "--session-id", session_id]
+    cmd = [binary, "--print", "--session-id", session_id]
     if extra_args:
         cmd.extend(extra_args)
+    env = _build_env(parent_env)
     completed = runner(
         cmd,
         input=prompt,
@@ -71,6 +95,7 @@ def invoke(
         text=True,
         timeout=timeout_seconds,
         check=False,
+        env=env,
     )
     return ClaudeResult(
         stdout=completed.stdout or "",

--- a/src/skill_gen/extractor.py
+++ b/src/skill_gen/extractor.py
@@ -40,12 +40,17 @@ _MAX_CHRONOLOGY = 200
 
 
 def _fetch_turns(session_id: str, start_ts: str, end_ts: str) -> list[dict]:
+    # PostgREST: lte on a nullable column excludes NULL (SQL three-valued
+    # logic). Active sessions have in-progress turns with completed_at=null;
+    # without the explicit `is.null` branch they were silently dropped from
+    # the compression window. or=() includes both. Bracketing the OR clause
+    # lets the `started_at gte` constraint AND with the whole disjunction.
     return sb_get(
         "turns",
         {
             "session_id": f"eq.{session_id}",
             "started_at": f"gte.{start_ts}",
-            "completed_at": f"lte.{end_ts}",
+            "or": f"(completed_at.is.null,completed_at.lte.{end_ts})",
             "order": "turn_index.asc",
         },
     )

--- a/tests/hooks/test_session_store_hook_skip.sh
+++ b/tests/hooks/test_session_store_hook_skip.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Smoke test: session_store_{posttooluse,stop}.sh must early-exit (status 0)
+# when CLAUDE_CODE_SKILL_GEN=1 is set in the environment. This is the
+# recursion guard for src/skill_gen — see src/skill_gen/claude_invoke.py.
+#
+# Runs both hooks twice:
+#   1. With CLAUDE_CODE_SKILL_GEN=1  → assert exit 0 AND no recorder log line.
+#   2. Without the env var          → assert exit 0 (best-effort recording).
+#
+# This is a shell smoke, not pytest. Run manually:
+#   bash tests/hooks/test_session_store_hook_skip.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+POSTTOOLUSE_HOOK="$REPO_ROOT/.claude/hooks/session_store_posttooluse.sh"
+STOP_HOOK="$REPO_ROOT/.claude/hooks/session_store_stop.sh"
+TMP_LOG_DIR="$(mktemp -d -t session-store-hook-smoke.XXXXXX)"
+trap "rm -rf '$TMP_LOG_DIR'" EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+# --- Case 1a: posttooluse with marker → early-exit, no log line written ---
+SESSION_STORE_LOG_DIR="$TMP_LOG_DIR" CLAUDE_CODE_SKILL_GEN=1 \
+    bash "$POSTTOOLUSE_HOOK" </dev/null
+[ ! -f "$TMP_LOG_DIR/posttooluse.log" ] || \
+    fail "posttooluse hook wrote log despite CLAUDE_CODE_SKILL_GEN=1"
+pass "posttooluse hook: early-exit when marker set; no log line"
+
+# --- Case 1b: stop with marker → early-exit, no log line written ---
+SESSION_STORE_LOG_DIR="$TMP_LOG_DIR" CLAUDE_CODE_SKILL_GEN=1 \
+    bash "$STOP_HOOK" </dev/null
+[ ! -f "$TMP_LOG_DIR/stop.log" ] || \
+    fail "stop hook wrote log despite CLAUDE_CODE_SKILL_GEN=1"
+pass "stop hook: early-exit when marker set; no log line"
+
+# --- Case 2a: posttooluse WITHOUT marker → exit 0 + log line written ---
+SESSION_STORE_LOG_DIR="$TMP_LOG_DIR" \
+    bash "$POSTTOOLUSE_HOOK" <<<'{}'
+[ -f "$TMP_LOG_DIR/posttooluse.log" ] || \
+    fail "posttooluse hook did NOT write log when marker absent"
+pass "posttooluse hook: writes log when marker absent (best-effort path intact)"
+
+# --- Case 2b: stop WITHOUT marker → exit 0 + log line written ---
+SESSION_STORE_LOG_DIR="$TMP_LOG_DIR" \
+    bash "$STOP_HOOK" </dev/null
+[ -f "$TMP_LOG_DIR/stop.log" ] || \
+    fail "stop hook did NOT write log when marker absent"
+pass "stop hook: writes log when marker absent (best-effort path intact)"
+
+echo "ALL HOOK SMOKE CASES PASS"

--- a/tests/skill_gen/test_claude_invoke.py
+++ b/tests/skill_gen/test_claude_invoke.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from src.skill_gen.claude_invoke import ClaudeNotInstalled, invoke
+from src.skill_gen.claude_invoke import RECURSION_GUARD_ENV, ClaudeNotInstalled, invoke
 
 
 def _stub_runner(stdout="", stderr="", returncode=0):
@@ -19,15 +19,49 @@ def _stub_runner(stdout="", stderr="", returncode=0):
     return runner, calls
 
 
-def test_invoke_passes_no_hooks_flag():
+def test_invoke_sets_recursion_guard_env_marker():
+    """CLAUDE_CODE_SKILL_GEN=1 must reach the subprocess env so session_store
+    hooks early-exit and skip nested turn_logs writes.
+
+    The earlier design relied on `--no-hooks`, which the installed claude CLI
+    (v2.1.139) rejects with `error: unknown option '--no-hooks'`. The
+    env-marker guard replaces it. Recorder hooks at
+    .claude/hooks/session_store_{posttooluse,stop}.sh inspect this variable
+    at the top of the script body and early-exit on match.
+    """
     runner, calls = _stub_runner(stdout="ok")
-    res = invoke("hello", claude_bin="/fake/claude", runner=runner)
+    res = invoke(
+        "hello",
+        claude_bin="/fake/claude",
+        runner=runner,
+        parent_env={"PATH": "/usr/bin"},  # explicit so we don't depend on test host env
+    )
     assert res.returncode == 0
     assert res.stdout == "ok"
     assert calls[0]["cmd"][0] == "/fake/claude"
-    assert "--no-hooks" in calls[0]["cmd"]
+    # The dead `--no-hooks` flag must NOT reappear; CLI v2.1.139 rejects it.
+    assert "--no-hooks" not in calls[0]["cmd"]
     assert "--print" in calls[0]["cmd"]
     assert "--session-id" in calls[0]["cmd"]
+    # Recursion-guard env reached the subprocess.
+    env = calls[0]["env"]
+    assert env[RECURSION_GUARD_ENV] == "1"
+    # Parent env still merged in (PATH preserved alongside the marker).
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_invoke_env_merges_parent_env():
+    """Pre-existing env vars in parent_env must survive — we merge, not overwrite."""
+    runner, calls = _stub_runner()
+    invoke(
+        "x",
+        claude_bin="/fake/claude",
+        runner=runner,
+        parent_env={"PATH": "/usr/bin", "CUSTOM_KEY": "preserved"},
+    )
+    env = calls[0]["env"]
+    assert env["CUSTOM_KEY"] == "preserved"
+    assert env[RECURSION_GUARD_ENV] == "1"
 
 
 def test_invoke_passes_prompt_via_stdin():

--- a/tests/skill_gen/test_extractor.py
+++ b/tests/skill_gen/test_extractor.py
@@ -125,3 +125,43 @@ def test_compress_truncates_long_user_messages():
     )
     assert len(out["user_messages"]) == 1
     assert len(out["user_messages"][0]) == 500
+
+
+def test_compress_includes_in_progress_turn_with_null_completed_at():
+    """Active sessions have turns with completed_at=null. The extractor's
+    _fetch_turns now uses or=(completed_at.is.null, completed_at.lte.<end>)
+    so the caller-side fetcher returns in-progress turns. The downstream
+    compress() must NOT drop them.
+
+    Empirical context: 2026-05-12 smoke run against session 102348b5 had 1
+    active turn with completed_at=null and 90 tool_calls; the original
+    `completed_at lte` filter returned [], producing an empty CompressedSession.
+    """
+    in_progress_turn = {
+        "id": "t-active",
+        "turn_index": 0,
+        "session_id": "s-active",
+        "started_at": "2026-05-11T23:49:52Z",
+        "completed_at": None,
+        "status": "in_progress",
+    }
+    log = {
+        "id": "log-1",
+        "turn_id": "t-active",
+        "tool_name": "Bash",
+        "exit_status": "success",
+        "tool_result_summary": "ran a command",
+        "started_at": "2026-05-11T23:50:00Z",
+    }
+    out = compress(
+        "s-active",
+        "2026-05-11T23:00:00Z",
+        "2026-05-12T01:00:00Z",
+        fetch_turns=lambda *a: [in_progress_turn],
+        fetch_turn_logs=lambda turn_ids: [log] if "t-active" in turn_ids else [],
+        fetch_turn_files=lambda *a: [],
+        fetch_user_messages=lambda *a: [],
+    )
+    assert out["turn_count"] == 1
+    assert out["tool_call_freq"] == {"Bash": 1}
+    assert out["chronology"][0]["tool"] == "Bash"


### PR DESCRIPTION
## Summary

Two coupled fixes for `src.skill_gen` (PR #720, merged 2026-05-11 23:44:05 UTC, commit `1d42144d`), both surfaced by the empirical smoke run last session (atlas outbox `20260512_0050_empirical_smoke_execution_PR720_acceptance.json`).

### Fix 1 — recursion guard via env marker (was `--no-hooks` flag)

- **Problem:** PR #720 spec called `--no-hooks` MANDATORY. Installed `claude` CLI v2.1.139 rejects it: `error: unknown option '--no-hooks'`.
- **Why not `--bare`:** the CLI's actual hook-skip flag (`--bare`) "Sets `CLAUDE_CODE_SIMPLE=1`. Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper — **OAuth and keychain are never read**." Incompatible with PR-B's `OAuth-only — $0 incremental under Max plan` spec.
- **Fix:** drop the dead CLI flag, instead set `CLAUDE_CODE_SKILL_GEN=1` in the subprocess env (merged with `os.environ`). Both `session_store_posttooluse.sh` and `session_store_stop.sh` early-exit (status 0, no log line, no recorder spawn) when the marker is present.

### Fix 2 — extractor includes in-progress turns

- **Problem:** `_fetch_turns` filter was `completed_at lte.<end_ts>`. PostgREST's `lte` on a nullable column excludes NULL (SQL three-valued logic). Active sessions whose only turn has `completed_at=null` were silently dropped — every empirical run against an active session would produce an empty CompressedSession.
- **Fix:** filter is now `or=(completed_at.is.null,completed_at.lte.<end_ts>)`.

## Diff scope

| File | Change |
|---|---|
| `src/skill_gen/claude_invoke.py` | Drop `--no-hooks`; build env dict with marker; expose `RECURSION_GUARD_ENV` constant; new `parent_env=` kwarg for tests |
| `src/skill_gen/extractor.py` | `_fetch_turns` uses `or=(...)` for null-tolerant `completed_at` filter |
| `.claude/hooks/session_store_posttooluse.sh` | Early-exit guard at top of script body |
| `.claude/hooks/session_store_stop.sh` | Early-exit guard at top of script body |
| `tests/skill_gen/test_claude_invoke.py` | Replace `test_invoke_passes_no_hooks_flag` with `test_invoke_sets_recursion_guard_env_marker` + new `test_invoke_env_merges_parent_env` |
| `tests/skill_gen/test_extractor.py` | New `test_compress_includes_in_progress_turn_with_null_completed_at` |
| `tests/hooks/test_session_store_hook_skip.sh` | New shell-based 4-case smoke for both hooks (with/without marker) |

7 files / +180 / -13.

## Verification (verbatim local output)

\`\`\`
$ ruff check src/skill_gen tests/skill_gen
All checks passed!

$ ruff format --check src/skill_gen tests/skill_gen
8 files already formatted

$ python3 -m pytest tests/skill_gen/ -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
collected 20 items

tests/skill_gen/test_claude_invoke.py::test_invoke_sets_recursion_guard_env_marker PASSED
tests/skill_gen/test_claude_invoke.py::test_invoke_env_merges_parent_env PASSED
tests/skill_gen/test_claude_invoke.py::test_invoke_passes_prompt_via_stdin PASSED
tests/skill_gen/test_claude_invoke.py::test_invoke_session_id_is_uuid_per_call PASSED
tests/skill_gen/test_claude_invoke.py::test_invoke_propagates_nonzero_exit_in_result PASSED
tests/skill_gen/test_claude_invoke.py::test_invoke_raises_when_claude_missing PASSED
tests/skill_gen/test_extractor.py::test_compress_shapes_freq_errors_files_chronology PASSED
tests/skill_gen/test_extractor.py::test_compress_empty_session_returns_zero_counts PASSED
tests/skill_gen/test_extractor.py::test_compress_truncates_long_user_messages PASSED
tests/skill_gen/test_extractor.py::test_compress_includes_in_progress_turn_with_null_completed_at PASSED
tests/skill_gen/test_generator.py::test_derive_skill_name_from_override PASSED
tests/skill_gen/test_generator.py::test_derive_skill_name_from_dominant_tool PASSED
tests/skill_gen/test_generator.py::test_derive_skill_name_default_when_empty PASSED
tests/skill_gen/test_generator.py::test_build_prompt_embeds_session_json PASSED
tests/skill_gen/test_generator.py::test_write_skill_creates_dir_and_file PASSED
tests/skill_gen/test_generator.py::test_write_skill_refuses_overwrite_by_default PASSED
tests/skill_gen/test_generator.py::test_open_pr_invokes_gh_with_expected_args PASSED
tests/skill_gen/test_generator.py::test_open_pr_returns_none_on_gh_failure PASSED
tests/skill_gen/test_generator.py::test_generate_end_to_end_with_stubs PASSED
tests/skill_gen/test_generator.py::test_generate_raises_on_claude_failure PASSED

============================== 20 passed in 0.36s ==============================
(+2 new vs PR #720's 18)

$ bash tests/hooks/test_session_store_hook_skip.sh
PASS: posttooluse hook: early-exit when marker set; no log line
PASS: stop hook: early-exit when marker set; no log line
PASS: posttooluse hook: writes log when marker absent (best-effort path intact)
PASS: stop hook: writes log when marker absent (best-effort path intact)
ALL HOOK SMOKE CASES PASS
\`\`\`

## Empirical re-run

Will be posted as a PR comment immediately after this PR opens — running \`scripts/smoke_test_skill_gen.py --run\` against a real session_id with the rebuilt invocation. Verbatim output, no fudging.

## Constraints honoured

- [x] Single PR, both fixes coupled (the second can't be exercised without the first)
- [x] Internal tooling only — no `src/pipeline/`, `src/intelligence/`, no `anthropic_batch.py`
- [x] Fresh branch off `origin/main` (`atlas/pr720-flag-fix-and-extractor-filter`)
- [x] OAuth/$0 promise preserved (no `--bare`, no API-key requirement)
- [x] ruff check + ruff format --check + pytest green
- [x] No self-merge

## Test plan

- [x] Unit: env marker reaches subprocess + parent env merged + no \`--no-hooks\` in cmd
- [x] Unit: extractor includes in-progress turn
- [x] Shell smoke: both hooks behave correctly with and without marker
- [x] Full \`tests/skill_gen/\` suite green (20)
- [ ] Empirical re-run vs real \`turn_logs\` slice (next: posted as PR comment)
- [ ] Aiden + Max review + merge

## Approval gate

DO NOT MERGE without dual-CTO review. Aiden + Max merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)