### PR TITLE
[AIDEN] fix(replay): JSONB ilike — use ->>command arrow operator (Orion bug catch #727)

### DIFF
--- a/src/replay/claim_verifier.py
+++ b/src/replay/claim_verifier.py
@@ -68,11 +68,19 @@ def _extract_commit_hashes(text: str) -> list[str]:
 def _query_turn_logs_for_pattern(pattern: str, callsign: str | None) -> list[dict]:
     """Query turn_logs for tool_args_json containing `pattern`.
 
+    Per Orion integration smoke 2026-05-12 (PR #727): PostgREST rejects `ilike`
+    on JSONB type directly with error 42883. Extract the 'command' field via
+    `->>` operator first (the Bash tool's args are stored as
+    `{"command": "<bash>"}`), then ilike on the extracted text. Scopes the
+    query to tool_name='Bash' since command-line evidence (verify_pr.sh /
+    gh pr / git cat-file) only comes from Bash invocations.
+
     Caller's responsibility to filter further (PR# substring match, session match).
     """
     params: dict[str, str] = {
         "select": "id,turn_id,tool_name,tool_args_json,started_at",
-        "tool_args_json": f"ilike.*{pattern}*",
+        "tool_name": "eq.Bash",
+        "tool_args_json->>command": f"ilike.*{pattern}*",
         "order": "started_at.desc",
         "limit": "20",
     }

--- a/tests/replay/test_claim_verifier.py
+++ b/tests/replay/test_claim_verifier.py
@@ -25,7 +25,10 @@ def mock_sb_get():
     rows_by_pattern: dict[str, list[dict]] = {}
 
     def fake_get(table: str, params: dict) -> list[dict]:
-        ilike_val = params.get("tool_args_json", "")
+        # JSONB-fix (post-PR #727): real query now uses tool_args_json->>command
+        # instead of raw tool_args_json (PostgREST rejects ilike on JSONB type).
+        # Stub accepts both for backwards compat.
+        ilike_val = params.get("tool_args_json->>command", params.get("tool_args_json", ""))
         for needle, rows in rows_by_pattern.items():
             if needle in ilike_val:
                 return rows
@@ -168,6 +171,43 @@ def test_slack_channel_id_prefix_skipped(mock_sb_get) -> None:
     verified, reason = claim_verifier.verify_completion_claim(text)
     # The 'c0b...' hash is skipped, and no PR refs → no refs → verified True
     assert verified is True
+
+
+def test_query_uses_jsonb_arrow_operator_not_raw_jsonb_ilike() -> None:
+    """Regression: lock the JSONB-arrow query shape against the Orion-#727 bug.
+
+    Pre-fix, claim_verifier passed `tool_args_json=ilike.*pattern*` which
+    PostgREST rejects with 42883 (no operator: ilike vs jsonb). Post-fix,
+    the query uses `tool_args_json->>command=ilike.*pattern*` + `tool_name=eq.Bash`
+    scoping. This test asserts the params shape so the fix can't regress
+    silently.
+    """
+    captured_params: list[dict] = []
+
+    def capture(table: str, params: dict) -> list[dict]:
+        captured_params.append(dict(params))
+        return []
+
+    from unittest.mock import patch as _patch
+
+    with _patch.object(claim_verifier, "sb_get", side_effect=capture):
+        claim_verifier.verify_completion_claim("PR #715 merged")
+    assert captured_params, "expected at least one sb_get call"
+    first = captured_params[0]
+    # Critical: the broken shape is `tool_args_json: ilike...` directly on the JSONB col
+    keys = list(first)
+    # Critical: the broken shape is `tool_args_json: ilike...` directly on the JSONB col
+    assert "tool_args_json" not in keys or "->>" in keys[0], (
+        "regression — raw tool_args_json ilike will fail with PostgREST 42883 on JSONB"
+    )
+    # Correct shape: arrow-operator extraction + Bash scope
+    assert any("->>command" in k for k in keys), (
+        "expected tool_args_json->>command in params, got keys: " + str(keys)
+    )
+    assert first.get("tool_name") == "eq.Bash", (
+        "expected tool_name=eq.Bash scope on JSONB-extracted query, got: "
+        + str(first.get("tool_name"))
+    )
 
 
 def test_sb_get_failure_returns_no_evidence(mock_sb_get) -> None:


### PR DESCRIPTION
## Summary

URGENT fix per Orion integration-smoke discovery in PR #727. PostgREST rejects `ilike` on JSONB type with error 42883 ("no operator matches the given name and argument types (ilike vs jsonb)").

Pre-fix `_query_turn_logs_for_pattern` silently returned `[]` for every call → replay-on-claim never found positive evidence → R3 over-fires on legitimate verified work.

## Operational impact (pre-fix)

- R3 violations correctly suppressed for no-refs claims (lucky default path)
- R3 violations **never** suppressed when claims contained PR# or commit refs
- PR #724 listener integration would over-fire R3 if `REPLAY_ON_CLAIM_ENABLED=1` shipped to prod

## Fix

Extract the Bash command via PostgREST arrow operator before ilike:

```diff
-    "tool_args_json": f"ilike.*{pattern}*",
+    "tool_name": "eq.Bash",
+    "tool_args_json->>command": f"ilike.*{pattern}*",
```

Scoping to `tool_name='Bash'` is correct because all evidence-tool patterns (verify_pr.sh / gh pr / git cat-file) only appear in Bash invocations, and Bash stores args as `{"command": "<bash string>"}` where `->>command` extracts the text-typed string ilike can operate on.

## Regression test

`test_query_uses_jsonb_arrow_operator_not_raw_jsonb_ilike` — asserts the params shape so the fix can't regress silently. Locks the JSONB-arrow query pattern.

## Test plan

- [x] `python3 -m pytest tests/replay/test_claim_verifier.py -v` — 16 passed in 0.73s (15 original + 1 new regression)
- [x] `ruff check src/ tests/replay` — All checks passed
- [x] `ruff format src/ tests/replay --check` — 482 files already formatted
- [ ] CI green
- [ ] After merge: Orion's PR #727 xfailed test (`test_replay_finds_verify_pr_command`) auto-converts to PASS

## Unblocks

PR #724 listener integration is now safe to ship with `REPLAY_ON_CLAIM_ENABLED=1` in prod once Dave Step 0 confirms arm-three-passive Outcome 1.

## Cross-references

- PR #719 (original replay module) — Max's "ilike fragile for JSONB" non-blocking nit was real
- PR #724 (listener integration) — already merged, gated behind flag-default-OFF; this fix makes flag-flip safe
- PR #727 (Orion integration smoke) — discovered the bug via real-Supabase test; xfail strict test there auto-converts

🤖 Generated with [Claude Code](https://claude.com/claude-code)