### PR TITLE
[MAX] fix(test): lift xfail on JSONB integration test

### DIFF
--- a/docs/architecture/drevon_port_2026-05-11.md
+++ b/docs/architecture/drevon_port_2026-05-11.md
@@ -13,9 +13,9 @@ Audit + replay + auto-skill-gen + session resumption stack — read sessions, re
 | # | Stage | PRs | Status |
 |---|-------|-----|--------|
 | 1 | Schema foundation | [#715](https://github.com/Keiracom/Agency_OS/pull/715), [#718](https://github.com/Keiracom/Agency_OS/pull/718) | MERGED |
-| 2 | Replay-on-claim | [#719](https://github.com/Keiracom/Agency_OS/pull/719), [#724](https://github.com/Keiracom/Agency_OS/pull/724) | #719 MERGED, #724 OPEN |
-| 3 | Auto skill-gen | [#720](https://github.com/Keiracom/Agency_OS/pull/720) | MERGED |
-| 4 | UUID resumption | [#725](https://github.com/Keiracom/Agency_OS/pull/725) | OPEN |
+| 2 | Replay-on-claim | [#719](https://github.com/Keiracom/Agency_OS/pull/719), [#724](https://github.com/Keiracom/Agency_OS/pull/724) | MERGED |
+| 3 | Auto skill-gen | [#720](https://github.com/Keiracom/Agency_OS/pull/720), [#728](https://github.com/Keiracom/Agency_OS/pull/728) | MERGED |
+| 4 | UUID resumption | [#725](https://github.com/Keiracom/Agency_OS/pull/725) | MERGED |
 
 ## Stage 1 — Schema Foundation (PR-A)
 
@@ -62,15 +62,15 @@ Extraction: PR# regex (`\bPRs?\s*#?\s*(\d+)\b` + `pull request N` + orphan `#N`)
 - PR evidence: `verify_pr.sh`, `gh pr view`, `gh pr merge`, `gh pr checks`, `gh api repos`
 - Commit evidence: `git cat-file`, `git log`, `git show`
 
-Per-pattern query is `ilike.*pattern*` on `tool_args_json`, `limit=20`, ordered `started_at desc`. The PR# / hash must appear as a substring in the matched row's args.
+Per-pattern query is `ilike.*pattern*` on `tool_args_json->>command` (scoped to `tool_name=Bash`), `limit=20`, ordered `started_at desc`. The PR# / hash must appear as a substring in the matched row's args.
 
 **Listener integration** (PR #724, OPEN): wires `verify_completion_claim` into the Slack central listener behind env flag `REPLAY_ON_CLAIM_ENABLED` so cutover is reversible.
 
 ## Stage 3 — Auto Skill-Gen (PR-B)
 
-Reads a directive-bounded slice of `turn_logs`, compresses to a prompt, invokes `claude --no-hooks --print` via subprocess to synthesise a `SKILL.md`, writes to `skills/<derived-name>/SKILL.md`, opens a PR for human review.
+Reads a directive-bounded slice of `turn_logs`, compresses to a prompt, invokes `claude --print --session-id <uuid>` via subprocess to synthesise a `SKILL.md`, writes to `skills/<derived-name>/SKILL.md`, opens a PR for human review.
 
-**Critical pattern — `--no-hooks` recursion guard**: the spawned `claude` process MUST be invoked with `--no-hooks`, otherwise the inner session triggers `PostToolUse` + `Stop` hooks that record into `session_store`, which would re-enter `skill_gen` if it's ever wired into a hook itself. The `--no-hooks` flag is mandatory for any subprocess `claude` invocation that runs inside a hook context. (Atlas chose Option B — per-call subprocess — over Option A long-lived worker; one-shot nature, simpler tests, fits the clone lifecycle.)
+**Critical pattern — env-marker recursion guard** (PR #728): the spawned `claude` process gets `CLAUDE_CODE_SKILL_GEN=1` in its environment. The session_store hooks (`.claude/hooks/session_store_posttooluse.sh`, `session_store_stop.sh`) check this variable at script entry and `exit 0` on match — preventing nested `turn_logs` writes / infinite loops. The earlier `--no-hooks` flag was a phantom (doesn't exist in Claude CLI v2.1.139); `--bare` exists but forces API-key auth (incompatible with OAuth). (Atlas chose Option B — per-call subprocess — over Option A long-lived worker; one-shot nature, simpler tests, fits the clone lifecycle.)
 
 OAuth-only — $0 incremental under Max plan. No API key required. NO Agency OS pipeline code touched.
 

--- a/tests/integration/test_drevon_port_smoke.py
+++ b/tests/integration/test_drevon_port_smoke.py
@@ -161,18 +161,6 @@ def test_resolve_session_uuid_finds_synthetic_session(synthetic_drevon_rows):
     assert found == synthetic_drevon_rows["session_uuid"]
 
 
-# DISCOVERED BUG: src.replay.claim_verifier issues `ilike.*pattern*` against
-# the JSONB column `turn_logs.tool_args_json`, which PostgREST rejects with
-# 404 (operator does not exist for jsonb). Because the function catches the
-# exception and returns []-for-each-pattern, every call resolves to (False,
-# "no evidence") regardless of input — so the True-evidence assertion below
-# is xfail and the False-evidence one would pass for the wrong reason. Fix
-# requires extracting a JSON field (tool_args_json->>0, or a dedicated text
-# column) — out of scope for this PR but reported in PR body + outbox.
-@pytest.mark.xfail(
-    reason="claim_verifier ilike-on-JSONB returns 404 in PostgREST (pre-existing bug discovered by this test); see PR body.",
-    strict=True,
-)
 def test_verify_completion_claim_returns_true_for_synthetic_evidence(
     synthetic_drevon_rows,
 ):
@@ -185,10 +173,8 @@ def test_verify_completion_claim_returns_true_for_synthetic_evidence(
 
 
 def test_verify_completion_claim_handles_missing_evidence_path(synthetic_drevon_rows):
-    """Even with the ilike-JSONB bug above, the no-evidence path must remain
-    safe (returns False with a reason string, never raises). This anchors the
-    best-effort contract — the launcher / listener must never crash because
-    of a malformed query."""
+    """No-evidence path must remain safe (returns False with a reason string,
+    never raises). Anchors the best-effort contract."""
     from src.replay.claim_verifier import verify_completion_claim
 
     pr = synthetic_drevon_rows["fabricated_pr"]


### PR DESCRIPTION
## Summary
- Lifts `@pytest.mark.xfail(strict=True)` from `test_verify_completion_claim_returns_true_for_synthetic_evidence` in the Drevon integration smoke test
- The xfail was correctly added by Orion in PR #727 when `claim_verifier.py` used raw `ilike` on JSONB (PostgREST 42883 rejection)
- PR #729 (Aiden) fixed the root cause with `tool_args_json->>command` arrow-operator extraction
- With both PRs merged, the xfail would XPASS → `strict=True` → CI failure on main

## Test plan
- [ ] `ruff check` passes
- [ ] Integration test passes without xfail (requires Supabase connectivity)
- [ ] No other xfail references remain in the file

```
$ ruff check tests/integration/test_drevon_port_smoke.py
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)