### PR TITLE
[ATLAS] fix(skill_gen): include stdout in claude-failure RuntimeError

### DIFF
--- a/src/skill_gen/generator.py
+++ b/src/skill_gen/generator.py
@@ -154,9 +154,14 @@ def generate(
         invoke_kwargs["runner"] = claude_runner
     claude_result = invoke(prompt, **invoke_kwargs)
     if claude_result.returncode != 0:
+        # claude --print writes CLI errors (e.g. "Credit balance is too low",
+        # auth failures, plan-limit messages) to STDOUT, not stderr. Earlier
+        # versions only surfaced stderr — leaving the RuntimeError text empty
+        # and the real cause invisible. Include both so callers can diagnose.
         raise RuntimeError(
             f"claude invocation failed (exit {claude_result.returncode}): "
-            f"{claude_result.stderr[:500]}"
+            f"stdout={claude_result.stdout[:500]!r} "
+            f"stderr={claude_result.stderr[:500]!r}"
         )
     skill_name = derive_skill_name(session, skill_name_override)
     skill_path = write_skill(repo_root, skill_name, claude_result.stdout, overwrite=overwrite)

--- a/tests/skill_gen/test_generator.py
+++ b/tests/skill_gen/test_generator.py
@@ -162,7 +162,49 @@ def test_generate_end_to_end_with_stubs(tmp_path: Path):
     assert "[ATLAS] feat(skills): auto-generated from dir-#42" in pr_calls["cmd"]
 
 
-def test_generate_raises_on_claude_failure(tmp_path: Path):
+def test_generate_raises_on_claude_failure_surfaces_stdout_and_stderr(tmp_path: Path):
+    """RuntimeError must include both streams.
+
+    claude --print writes CLI errors to STDOUT (e.g. "Credit balance is too
+    low"), not stderr. Previous error message format dropped stdout, leaving
+    the real cause invisible. Verified empirically against PR #728 re-run
+    (atlas outbox 20260512_0115_pr720_flag_fix_complete.json).
+    """
+
+    def claude_runner(cmd, **kwargs):
+        # Real-world failure mode: error on stdout, stderr empty, non-zero exit.
+        return SimpleNamespace(stdout="Credit balance is too low", stderr="", returncode=1)
+
+    extractor_overrides = {
+        "fetch_turns": lambda *a: [],
+        "fetch_turn_logs": lambda *a: [],
+        "fetch_turn_files": lambda *a: [],
+        "fetch_user_messages": lambda *a: [],
+    }
+    with pytest.raises(RuntimeError) as exc_info:
+        generate(
+            repo_root=tmp_path,
+            session_id="s1",
+            start_ts="t0",
+            end_ts="t1",
+            directive_ref="r",
+            claude_runner=claude_runner,
+            pr_runner=lambda *a, **kw: SimpleNamespace(stdout="", stderr="", returncode=0),
+            extractor_overrides=extractor_overrides,
+        )
+    msg = str(exc_info.value)
+    assert "claude invocation failed" in msg
+    assert "Credit balance is too low" in msg, (
+        f"stdout content missing from RuntimeError; got: {msg!r}"
+    )
+    # exit code visible
+    assert "exit 1" in msg
+
+
+def test_generate_raises_includes_stderr_when_present(tmp_path: Path):
+    """The stderr branch still surfaces — the polish includes BOTH streams, not
+    a swap. Asymmetry would re-hide whichever stream is the real cause."""
+
     def claude_runner(cmd, **kwargs):
         return SimpleNamespace(stdout="", stderr="rate limited", returncode=2)
 
@@ -172,7 +214,7 @@ def test_generate_raises_on_claude_failure(tmp_path: Path):
         "fetch_turn_files": lambda *a: [],
         "fetch_user_messages": lambda *a: [],
     }
-    with pytest.raises(RuntimeError, match="claude invocation failed"):
+    with pytest.raises(RuntimeError, match="rate limited"):
         generate(
             repo_root=tmp_path,
             session_id="s1",


### PR DESCRIPTION
## Summary

Tiny diagnostic polish surfaced by PR #728's empirical re-run. `claude --print` writes CLI errors (e.g. *"Credit balance is too low"*, auth failures, plan-limit messages) to **STDOUT** rather than stderr. The earlier `RuntimeError` format only included stderr, which left the real cause invisible whenever stderr was empty.

**Before:**
```
RuntimeError: claude invocation failed (exit 1):
                                                ^ empty — real cause hidden
```

**After:**
```
RuntimeError: claude invocation failed (exit 1): stdout='Credit balance is too low' stderr=''
```

The stderr branch is retained (not swapped) — failure modes that DO emit on stderr still surface there.

## Diff scope

| File | Change |
|---|---|
| `src/skill_gen/generator.py` | RuntimeError includes both streams, 500-char cap each, `repr()` for safe quoting (+1 explanatory comment) |
| `tests/skill_gen/test_generator.py` | Rename failure-raise test + assert stdout content surfaces; new asymmetric-stderr test so neither stream can be silently dropped by a future regression |

2 files / +50 / -3.

## Verification (verbatim local output)

```
$ ruff check src/skill_gen/generator.py tests/skill_gen/test_generator.py
All checks passed!

$ ruff format --check src/skill_gen/generator.py tests/skill_gen/test_generator.py
2 files already formatted

$ python3 -m pytest tests/skill_gen/test_generator.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
collected 11 items

tests/skill_gen/test_generator.py::test_derive_skill_name_from_override PASSED
tests/skill_gen/test_generator.py::test_derive_skill_name_from_dominant_tool PASSED
tests/skill_gen/test_generator.py::test_derive_skill_name_default_when_empty PASSED
tests/skill_gen/test_generator.py::test_build_prompt_embeds_session_json PASSED
tests/skill_gen/test_generator.py::test_write_skill_creates_dir_and_file PASSED
tests/skill_gen/test_generator.py::test_write_skill_refuses_overwrite_by_default PASSED
tests/skill_gen/test_generator.py::test_open_pr_invokes_gh_with_expected_args PASSED
tests/skill_gen/test_generator.py::test_open_pr_returns_none_on_gh_failure PASSED
tests/skill_gen/test_generator.py::test_generate_end_to_end_with_stubs PASSED
tests/skill_gen/test_generator.py::test_generate_raises_on_claude_failure_surfaces_stdout_and_stderr PASSED
tests/skill_gen/test_generator.py::test_generate_raises_includes_stderr_when_present PASSED

============================== 11 passed in 0.27s ==============================
(+1 vs PR #728's 10 in test_generator.py)

$ python3 -m pytest tests/skill_gen/ tests/scripts/
270 passed in 2.84s   (no regressions in either suite)
```

## Audit-trail

Follow-on to PR #728 (merged 2026-05-12 — `dd2f6b21`). The empirical re-run posted to #728 as comment 4426250725 had an empty RuntimeError tail because claude wrote the real diagnostic to stdout. This PR closes that observability gap.

Authorized by Elliot dispatch 2026-05-12 ("tiny scope, go") — derived from atlas outbox `20260512_0115_pr720_flag_fix_complete.json` follow-up suggestion #1.

## Constraints honoured

- [x] Internal tooling only — no `src/pipeline/`, no `src/intelligence/`
- [x] Fresh branch off `origin/main` (`atlas/skill-gen-error-message-polish`)
- [x] ruff check + ruff format --check + pytest green
- [x] No self-merge

## Test plan

- [x] New stdout-surfaces test mocks the real PR #728 failure mode
- [x] New asymmetric stderr test prevents silent regression
- [x] Full `tests/skill_gen/` + `tests/scripts/` suites green (270)
- [ ] Aiden + Max review + merge

## Approval gate

DO NOT MERGE without dual-CTO review. Aiden + Max merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)