### PR TITLE
[MAX] fix(enforcer): sync R2 exempt protocol-tag list with Track 6

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -229,7 +229,7 @@ _R2_EXEMPT_RE = re.compile(
     r"|\bmergeCommit\b"  # Track 5: gh JSON field reference
     r"|\b(?:will|going to|about to|planning to|propose to)\s+(?:commit|push|deploy|merge|create|trigger)"
     r"|\b(?:not|haven't|won't)\s+(?:yet\s+)?(?:committed|pushed|deployed|merged)"
-    r"|\[(?:propose|summary-draft|concur-request|concur|ready|busy|fp-log|valid-fire|dispatch|dispatch-proposal)[\w:-]*\]",
+    r"|\[(?:propose|summary-draft|concur-request|concur|ready|busy|fp-log|valid-fire|dispatch|dispatch-proposal|dispatch-complete|state|complete)[\w:-]*\]",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
## Summary
- Adds `state`, `complete`, `dispatch-complete` to `_R2_EXEMPT_RE` in `enforcer_deterministic.py`
- Matches the Track 6 extension in `_UNIVERSAL_PROTOCOL_TAG_RE` (PR #734)
- Defense-in-depth: universal exempt fires first, but keeping both in sync prevents confusion

## Verification
```
$ ruff check src/bot_common/enforcer_deterministic.py
All checks passed!

$ python3 -m pytest tests/bot_common/ tests/test_track4_enforcer_fp_bundle.py tests/test_track5_r2_r8_followup.py tests/test_enforcer_r3_pytest_pattern.py tests/test_enforcer_r9_exempt_regex.py tests/test_enforcer_max_outbox.py tests/test_track6_universal_protocol_tag.py -x -q
198 passed in 1.43s
```

## Test plan
- [x] All 198 enforcer + bot_common tests pass
- [x] Ruff clean
- [x] 1-line diff, no behavioral change in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)