### PR TITLE
[MAX] fix(enforcer): update RULES_PROMPT callsign list to all 6 agents

### DIFF
--- a/src/bot_common/enforcer_rules.py
+++ b/src/bot_common/enforcer_rules.py
@@ -73,7 +73,7 @@ def should_check(text: str) -> bool:
 
 RULES_PROMPT = """You are a governance enforcement bot for a multi-agent development team.
 
-You monitor group chat messages between two AI agents (Elliot and Aiden) and their human manager (Dave).
+You monitor group chat messages between AI agents (Elliot, Aiden, Max, Atlas, Orion, and Scout) and their human manager (Dave).
 
 Most rules are now checked deterministically before this LLM call. You only need to check:
 
@@ -81,7 +81,7 @@ Rule 3 — COMPLETION-REQUIRES-VERIFICATION (SOFT fallback only):
 If the current message uses "done" in a way that might be a completion claim (not "not done", "isn't done") but does NOT contain obvious evidence (commit hashes, PR references, terminal output, test results), evaluate whether the message is actually claiming task completion. If it is a genuine completion claim without evidence, flag as VIOLATION. If "done" is used conversationally ("done reviewing", "done for the day", "done discussing"), return no violation.
 
 Rule 9 — DIRECTIVE-INITIATIVE:
-If the current message is from a bot (ELLIOT or AIDEN) and ends with open-ended agenda-setting phrases directed at Dave — such as "standing by for directive", "ready for next directive", "what's next", "awaiting your call", "what would you like", or any question asking Dave to SET the agenda rather than APPROVE a proposal — flag as VIOLATION. Bots must propose specific next work items using [PROPOSE:<callsign>] format, not ask Dave what to do. Exception: [SESSION-WRAP:<callsign>] is allowed for genuine end-of-session.
+If the current message is from a bot (ELLIOT, AIDEN, MAX, ATLAS, ORION, or SCOUT) and ends with open-ended agenda-setting phrases directed at Dave — such as "standing by for directive", "ready for next directive", "what's next", "awaiting your call", "what would you like", or any question asking Dave to SET the agenda rather than APPROVE a proposal — flag as VIOLATION. Bots must propose specific next work items using [PROPOSE:<callsign>] format, not ask Dave what to do. Exception: [SESSION-WRAP:<callsign>] is allowed for genuine end-of-session.
 
 RESPOND WITH ONLY THIS JSON:
 {


### PR DESCRIPTION
## Summary
- R9 DIRECTIVE-INITIATIVE LLM check only named "ELLIOT or AIDEN" — Max, Atlas, Orion, and Scout were invisible to the rule
- Updated both references in `RULES_PROMPT` to list all 6 callsigns
- 106 bot_common tests green, 0 regressions

## Test plan
- [x] `pytest tests/bot_common/test_enforcer_rules.py` — 16 passed
- [x] `pytest tests/bot_common/` — 106 passed
- [ ] Peer concur (Elliot + Aiden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)