### PR TITLE
[MAX] fix(enforcer): Track 7 — R3 STRICT adjective-form FP fix

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -76,12 +76,14 @@ _R3_EXCEPTION_RE = re.compile(
 
 # STRICT completion triggers — always check for evidence.
 _R3_STRICT_RE = re.compile(
-    r"\bcomplete\b"
-    r"|all stores written"
+    r"all stores written"
     r"|4-store save complete"
     r"|store save complete"
     r"|task complete"
-    r"|build complete",
+    r"|build complete"
+    r"|deployment complete"
+    r"|migration complete"
+    r"|merge complete",
     re.IGNORECASE,
 )
 

--- a/tests/bot_common/test_enforcer_deterministic.py
+++ b/tests/bot_common/test_enforcer_deterministic.py
@@ -177,6 +177,35 @@ def test_r3_exception_governance_gatekeeper_passes() -> None:
     assert skip is True
 
 
+def test_r3_adjective_complete_not_strict() -> None:
+    """Track 7: 'coverage chain complete' is adjective, not completion claim."""
+    result, skip = check_r3("coverage chain complete — bot_common fully unit-tested")
+    assert result is None
+    assert skip is False
+
+
+def test_r3_adjective_is_complete_not_strict() -> None:
+    """Track 7: 'X is complete' adjective form falls through to LLM."""
+    result, skip = check_r3("bot_common coverage chain is complete")
+    assert result is None
+    assert skip is False
+
+
+def test_r3_deployment_complete_without_evidence_violates() -> None:
+    """Track 7: compound 'deployment complete' still triggers STRICT."""
+    result, skip = check_r3("Deployment complete. All services green.")
+    assert result is not None
+    assert result["rule_number"] == 3
+    assert skip is True
+
+
+def test_r3_migration_complete_with_evidence_passes() -> None:
+    """Track 7: compound 'migration complete' + commit hash → PASS."""
+    result, skip = check_r3("Migration complete — commit abc1234 applied.")
+    assert result is None
+    assert skip is True
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # check_r2 — STEP-0-BEFORE-EXECUTION
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Removed standalone `\bcomplete\b` from `_R3_STRICT_RE` — it over-matched adjective forms ("coverage chain complete", "bot_common is complete") as completion claims
- Added compound patterns: `deployment complete`, `migration complete`, `merge complete` alongside existing `task complete`, `build complete`, `store save complete`
- 4 new regression tests: 2 FP cases (adjective → no trigger), 2 real claims (compound → STRICT)
- 110 bot_common tests green

## Context
FP-LOG:R3 ×3 on 2026-05-11 ~23:30–23:45 (Aiden logged). Adjective "complete" in status posts fired R3 STRICT even when there was no completion claim.

## Test plan
- [x] `pytest tests/bot_common/test_enforcer_deterministic.py -k r3` — 11 passed
- [x] `pytest tests/bot_common/` — 110 passed
- [x] Manual verification: "coverage chain complete" → no trigger, "task complete" → STRICT
- [ ] Peer concur (Elliot + Aiden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)