### PR TITLE
[MAX] fix(enforcer): Track 8 — R2 status-report exempt

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -238,8 +238,8 @@ _R2_EXEMPT_RE = re.compile(
     r"|\d+\s+PRs?\s+merged"
     r"|\bsession\s+(?:total|tally)\b.*\bmerged\b"
     r"|\bmerge\s+pull\s+request\b"
-    r"|\bdeployed\s+(?:at|to|on|via)\b"
-    r"|\bshipped\s+(?:in|via|to|as)\b",
+    r"|\bdeployed\s+at\s+\d"
+    r"|\bshipped\s+in\s+PR\b",
     re.IGNORECASE,
 )
 

--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -231,7 +231,15 @@ _R2_EXEMPT_RE = re.compile(
     r"|\bmergeCommit\b"  # Track 5: gh JSON field reference
     r"|\b(?:will|going to|about to|planning to|propose to)\s+(?:commit|push|deploy|merge|create|trigger)"
     r"|\b(?:not|haven't|won't)\s+(?:yet\s+)?(?:committed|pushed|deployed|merged)"
-    r"|\[(?:propose|summary-draft|concur-request|concur|ready|busy|fp-log|valid-fire|dispatch|dispatch-proposal|dispatch-complete|state|complete)[\w:-]*\]",
+    r"|\[(?:propose|summary-draft|concur-request|concur|ready|busy|fp-log|valid-fire|dispatch|dispatch-proposal|dispatch-complete|state|complete)[\w:-]*\]"
+    # Track 8: status-report exempts — past-tense reporting, not new execution
+    r"|\bdeployed\b.*\blistener\s+restart"
+    r"|\bfully\s+deployed\b"
+    r"|\d+\s+PRs?\s+merged"
+    r"|\bsession\s+(?:total|tally)\b.*\bmerged\b"
+    r"|\bmerge\s+pull\s+request\b"
+    r"|\bdeployed\s+(?:at|to|on|via)\b"
+    r"|\bshipped\s+(?:in|via|to|as)\b",
     re.IGNORECASE,
 )
 

--- a/tests/bot_common/test_enforcer_deterministic.py
+++ b/tests/bot_common/test_enforcer_deterministic.py
@@ -270,12 +270,12 @@ def test_r2_exempt_pr_tally() -> None:
 
 
 def test_r2_exempt_deployed_at_timestamp() -> None:
-    """Track 8: 'deployed at <timestamp>' is past-tense status."""
+    """Track 8: 'deployed at <digit>' is past-tense status."""
     assert check_r2("Deployed at 01:12:05 UTC. R9 LAYER 2 active.", recent_messages=[]) is None
 
 
 def test_r2_exempt_shipped_in_pr() -> None:
-    """Track 8: 'shipped in PR #N' is past-tense reference."""
+    """Track 8: 'shipped in PR' is past-tense reference."""
     assert check_r2("Shipped in PR #740 to main.", recent_messages=[]) is None
 
 

--- a/tests/bot_common/test_enforcer_deterministic.py
+++ b/tests/bot_common/test_enforcer_deterministic.py
@@ -258,6 +258,32 @@ def test_r2_recent_messages_none_conservative_pass() -> None:
     assert check_r2(text, recent_messages=None) is None
 
 
+def test_r2_exempt_fully_deployed_status() -> None:
+    """Track 8: 'FULLY DEPLOYED' is status reporting, not new execution."""
+    assert check_r2("Track 7 FULLY DEPLOYED. Listener restarted at 01:24 UTC.", recent_messages=[]) is None
+
+
+def test_r2_exempt_pr_tally() -> None:
+    """Track 8: '19 PRs merged' is a tally, not new merge execution."""
+    assert check_r2("Session total: 19 PRs merged (#722-741).", recent_messages=[]) is None
+    assert check_r2("19 PRs merged this session.", recent_messages=[]) is None
+
+
+def test_r2_exempt_deployed_at_timestamp() -> None:
+    """Track 8: 'deployed at <timestamp>' is past-tense status."""
+    assert check_r2("Deployed at 01:12:05 UTC. R9 LAYER 2 active.", recent_messages=[]) is None
+
+
+def test_r2_exempt_shipped_in_pr() -> None:
+    """Track 8: 'shipped in PR #N' is past-tense reference."""
+    assert check_r2("Shipped in PR #740 to main.", recent_messages=[]) is None
+
+
+def test_r2_exempt_merge_pull_request() -> None:
+    """Track 8: GitHub merge commit message format."""
+    assert check_r2("Merge pull request #741 from Keiracom/max/r9-standby-exempt", recent_messages=[]) is None
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # check_r8 — DISPATCH-COORDINATION
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- R2 STEP-0-BEFORE-EXECUTION fired on deployment-status and tally posts containing past-tense execution words
- Added 7 exempt patterns for status-report phrasing: "fully deployed", "N PRs merged", "session total...merged", "Merge pull request", "deployed at/to", "shipped in/via/to", "deployed...listener restart"
- 5 new regression tests (44 total in `test_enforcer_deterministic.py`)
- 115 bot_common tests green

## Context
R2 fired 3x on Elliot's deployment-status post "Track 7 FULLY DEPLOYED. Listener restarted at..." and Max's tally post "19 PRs merged this session." Both are past-tense status reports, not new execution starts requiring Step 0.

## Test plan
- [x] `pytest tests/bot_common/test_enforcer_deterministic.py` — 44 passed
- [x] `pytest tests/bot_common/` — 115 passed
- [x] Manual verification: FP cases → None, real violations → VIOLATION
- [ ] Peer concur (Elliot + Aiden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)