### PR TITLE
[AIDEN] feat(health): Task 1B Outcome 1 — service health monitor (5-min timer + alerts)

### DIFF
--- a/infra/alerts/agency-os-service-health-monitor.service
+++ b/infra/alerts/agency-os-service-health-monitor.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Agency OS — Service Health Monitor (System Health Monitoring Outcome 1, Dave directive 2026-05-12)
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/alerts/service_health_monitor.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+StandardOutput=append:/home/elliotbot/clawd/logs/service-health-monitor.log
+StandardError=append:/home/elliotbot/clawd/logs/service-health-monitor.log

--- a/infra/alerts/agency-os-service-health-monitor.timer
+++ b/infra/alerts/agency-os-service-health-monitor.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run service health monitor every 5 minutes (Dave System Health Monitoring Outcome 1)
+
+[Timer]
+OnCalendar=*:0/5
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/alerts/service_health_monitor.py
+++ b/scripts/alerts/service_health_monitor.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""service_health_monitor.py — 5-min systemd timer health check.
+
+Per Dave System Health Monitoring directive 2026-05-12 Outcome 1.
+
+Checks the systemd --user services that comprise the Slack listener +
+per-callsign relay infrastructure. Any service in non-active state →
+post to #execution with service name, callsign, state, and last log lines.
+
+Best-effort: a Slack-post failure does NOT raise. The monitor's job is
+liveness reporting; failures in reporting must not cascade into restart
+loops.
+
+Run via timer: agency-os-service-health-monitor.timer (OnCalendar *:0/5).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("service_health_monitor")
+
+# Services that comprise the Slack listener + per-callsign relay infrastructure.
+# Edit deliberately when adding new agents / clones.
+MONITORED_SERVICES: tuple[str, ...] = (
+    "agency-os-slack-central-listener",
+    "aiden-relay-watcher",
+    "atlas-relay-watcher",
+    "atlas-inbox-watcher",
+    "max-relay-watcher",
+    "orion-relay-watcher",
+    "orion-inbox-watcher",
+    "scout-relay-watcher",
+    "relay-watcher",
+)
+
+# Slack #execution channel ID
+EXECUTION_CHANNEL = "C0B3QB0K1GQ"
+
+
+def systemctl_user(*args: str) -> tuple[int, str]:
+    """Run `systemctl --user <args>` and return (returncode, stdout+stderr)."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "--user", *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        return 1, f"systemctl invocation failed: {exc}"
+    return result.returncode, (result.stdout or "") + (result.stderr or "")
+
+
+def get_service_state(service: str) -> str:
+    """Return systemd ActiveState ('active'|'inactive'|'failed'|'unknown')."""
+    rc, output = systemctl_user("is-active", service)
+    if rc == 0:
+        return "active"
+    # is-active returns non-zero for inactive/failed/etc; the stdout is the state.
+    return (output.strip() or "unknown").splitlines()[0]
+
+
+def get_recent_log(service: str, n: int = 5) -> str:
+    """Last N journal lines for the service. Empty string if unavailable."""
+    try:
+        result = subprocess.run(
+            ["journalctl", "--user", "-u", service, "-n", str(n), "--no-pager"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return ""
+    return (result.stdout or "").strip()
+
+
+def callsign_from_service_name(service: str) -> str:
+    """Best-effort callsign extraction from service name prefix."""
+    for cs in ("aiden", "atlas", "max", "orion", "scout", "elliot"):
+        if service.startswith(cs + "-"):
+            return cs
+    return "central"  # central_listener + shared relay-watcher
+
+
+def post_to_slack(text: str, channel: str = EXECUTION_CHANNEL) -> bool:
+    """Best-effort Slack post. Returns True on success, False otherwise.
+
+    Reads SLACK_BOT_TOKEN from env. No retry, no exception propagation.
+    """
+    token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if not token:
+        logger.warning("SLACK_BOT_TOKEN not set — cannot post health alert")
+        return False
+    payload = json.dumps(
+        {
+            "channel": channel,
+            "text": text,
+            "username": "ServiceHealth",
+            "icon_emoji": ":heartbeat:",
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            body = json.loads(r.read())
+            return bool(body.get("ok"))
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("Slack post failed: %s", exc)
+        return False
+
+
+def check_all_services() -> list[dict]:
+    """Check each monitored service, return list of {service, callsign, state, log}
+    entries for services that are NOT active.
+    """
+    failures: list[dict] = []
+    for service in MONITORED_SERVICES:
+        state = get_service_state(service)
+        if state == "active":
+            continue
+        failures.append(
+            {
+                "service": service,
+                "callsign": callsign_from_service_name(service),
+                "state": state,
+                "log": get_recent_log(service),
+            }
+        )
+    return failures
+
+
+def format_alert(failure: dict) -> str:
+    return (
+        f"[SERVICE-HEALTH] {failure['service']} — callsign={failure['callsign']} "
+        f"state={failure['state']}\n"
+        f"Recent journal:\n```\n{failure['log'][-500:] or '(no recent log)'}\n```"
+    )
+
+
+def main() -> int:
+    failures = check_all_services()
+    if not failures:
+        logger.info("All %d monitored services active.", len(MONITORED_SERVICES))
+        return 0
+    logger.warning("Detected %d failed/inactive service(s).", len(failures))
+    for f in failures:
+        text = format_alert(f)
+        posted = post_to_slack(text)
+        logger.info("Alert for %s: posted=%s", f["service"], posted)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_service_health_monitor.py
+++ b/tests/scripts/test_service_health_monitor.py
@@ -1,0 +1,229 @@
+"""tests for scripts/alerts/service_health_monitor.py — Dave System Health Outcome 1.
+
+Mocks subprocess.run (systemctl/journalctl) + urllib.request.urlopen (Slack)
+so tests run without systemd or network. Covers:
+  - Active service → not in failures
+  - Failed/inactive service → in failures
+  - Alert formatting + Slack post
+  - callsign extraction
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MONITOR_PATH = REPO_ROOT / "scripts" / "alerts" / "service_health_monitor.py"
+
+
+@pytest.fixture(scope="module")
+def monitor():
+    """Load service_health_monitor.py as a module."""
+    spec = importlib.util.spec_from_file_location("service_health_monitor", MONITOR_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["service_health_monitor"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# callsign_from_service_name
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_callsign_from_aiden_relay_watcher(monitor) -> None:
+    assert monitor.callsign_from_service_name("aiden-relay-watcher") == "aiden"
+
+
+def test_callsign_from_atlas_inbox_watcher(monitor) -> None:
+    assert monitor.callsign_from_service_name("atlas-inbox-watcher") == "atlas"
+
+
+def test_callsign_from_central_listener(monitor) -> None:
+    """Central listener has no callsign prefix → 'central'."""
+    assert monitor.callsign_from_service_name("agency-os-slack-central-listener") == "central"
+
+
+def test_callsign_from_unknown_service(monitor) -> None:
+    assert monitor.callsign_from_service_name("some-other-service") == "central"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# get_service_state
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_get_service_state_active(monitor) -> None:
+    with patch.object(monitor.subprocess, "run", return_value=_completed(0, "active\n")):
+        assert monitor.get_service_state("any-service") == "active"
+
+
+def test_get_service_state_inactive(monitor) -> None:
+    with patch.object(monitor.subprocess, "run", return_value=_completed(3, "inactive\n")):
+        assert monitor.get_service_state("any-service") == "inactive"
+
+
+def test_get_service_state_failed(monitor) -> None:
+    with patch.object(monitor.subprocess, "run", return_value=_completed(3, "failed\n")):
+        assert monitor.get_service_state("any-service") == "failed"
+
+
+def test_get_service_state_subprocess_failure(monitor) -> None:
+    """systemctl missing or timeout → 'unknown'."""
+    with patch.object(monitor.subprocess, "run", side_effect=FileNotFoundError("systemctl")):
+        # systemctl_user catches the exception and returns rc=1 + error string;
+        # is_active path treats that as non-active state.
+        assert monitor.get_service_state("any-service") != "active"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# check_all_services
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_check_all_services_all_active(monitor) -> None:
+    """All services active → empty failures list."""
+    with (
+        patch.object(monitor, "get_service_state", return_value="active"),
+        patch.object(monitor, "get_recent_log", return_value="ok"),
+    ):
+        failures = monitor.check_all_services()
+    assert failures == []
+
+
+def test_check_all_services_one_failed(monitor) -> None:
+    """One service failed → one entry in failures with callsign + state + log."""
+
+    def state_lookup(service):
+        if service == "aiden-relay-watcher":
+            return "failed"
+        return "active"
+
+    with (
+        patch.object(monitor, "get_service_state", side_effect=state_lookup),
+        patch.object(monitor, "get_recent_log", return_value="boom"),
+    ):
+        failures = monitor.check_all_services()
+    assert len(failures) == 1
+    assert failures[0]["service"] == "aiden-relay-watcher"
+    assert failures[0]["callsign"] == "aiden"
+    assert failures[0]["state"] == "failed"
+    assert failures[0]["log"] == "boom"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# format_alert
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_format_alert_contains_service_and_state(monitor) -> None:
+    text = monitor.format_alert(
+        {"service": "aiden-relay-watcher", "callsign": "aiden", "state": "failed", "log": "boom"}
+    )
+    assert "aiden-relay-watcher" in text
+    assert "failed" in text
+    assert "boom" in text
+    assert "callsign=aiden" in text
+
+
+def test_format_alert_handles_empty_log(monitor) -> None:
+    text = monitor.format_alert({"service": "x", "callsign": "y", "state": "inactive", "log": ""})
+    assert "(no recent log)" in text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# post_to_slack
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_post_to_slack_missing_token_returns_false(monitor, monkeypatch) -> None:
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    assert monitor.post_to_slack("test") is False
+
+
+def test_post_to_slack_success(monitor, monkeypatch) -> None:
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-fake")
+
+    class FakeResponse:
+        def read(self) -> bytes:
+            return json.dumps({"ok": True, "ts": "1.234"}).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    with patch.object(monitor.urllib.request, "urlopen", return_value=FakeResponse()):
+        assert monitor.post_to_slack("test") is True
+
+
+def test_post_to_slack_network_failure_returns_false(monitor, monkeypatch) -> None:
+    """urlopen raising URLError → False (best-effort)."""
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-fake")
+    from urllib.error import URLError
+
+    with patch.object(monitor.urllib.request, "urlopen", side_effect=URLError("network")):
+        assert monitor.post_to_slack("test") is False
+
+
+def test_post_to_slack_api_not_ok_returns_false(monitor, monkeypatch) -> None:
+    """Slack API ok=false → False."""
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-fake")
+
+    class FakeResponse:
+        def read(self) -> bytes:
+            return json.dumps({"ok": False, "error": "invalid_auth"}).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    with patch.object(monitor.urllib.request, "urlopen", return_value=FakeResponse()):
+        assert monitor.post_to_slack("test") is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# main entry
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_main_returns_zero_when_all_active(monitor) -> None:
+    with patch.object(monitor, "check_all_services", return_value=[]):
+        assert monitor.main() == 0
+
+
+def test_main_alerts_on_failure(monitor) -> None:
+    """When a service fails, main() calls post_to_slack and returns 0."""
+    fake_failure = {
+        "service": "aiden-relay-watcher",
+        "callsign": "aiden",
+        "state": "failed",
+        "log": "boom",
+    }
+    post_calls: list[str] = []
+
+    def fake_post(text, channel=monitor.EXECUTION_CHANNEL):
+        post_calls.append(text)
+        return True
+
+    with (
+        patch.object(monitor, "check_all_services", return_value=[fake_failure]),
+        patch.object(monitor, "post_to_slack", side_effect=fake_post),
+    ):
+        assert monitor.main() == 0
+    assert len(post_calls) == 1
+    assert "aiden-relay-watcher" in post_calls[0]


### PR DESCRIPTION
## Summary

Per Dave System Health Monitoring directive 2026-05-12 Outcome 1.

A single systemd --user timer that runs every 5 minutes and checks the core Slack listener + per-callsign relay infrastructure. Any service in non-active state → posts to #execution with service name, callsign, state, and last journal lines.

## Monitored services

- `agency-os-slack-central-listener` (Socket Mode subscriber)
- `{aiden,atlas,max,orion,scout}-relay-watcher` (per-callsign relay tmux injectors)
- `{atlas,orion}-inbox-watcher` (per-clone inbox dispatchers)
- `relay-watcher` (shared)

Edit the `MONITORED_SERVICES` tuple in `service_health_monitor.py` deliberately when adding new agents / clones.

## Test plan

- [x] `python3 -m pytest tests/scripts/test_service_health_monitor.py` — 18 passed in 0.23s
- [x] `ruff check scripts/alerts/service_health_monitor.py tests/scripts/test_service_health_monitor.py` — All checks passed
- [x] `ruff format ... --check` — clean
- [ ] CI green
- [ ] Manual install + first timer fire verified post-merge

## Test coverage (18 tests)

| Group | Tests |
|-------|-------|
| `callsign_from_service_name` | 4 |
| `get_service_state` | 4 (active/inactive/failed/subprocess-failure) |
| `check_all_services` | 2 (all-active / one-failed) |
| `format_alert` | 2 |
| `post_to_slack` | 4 (missing token / success / network failure / API ok=false) |
| `main` | 2 |

## Install (manual until install-script lands)

```bash
cp infra/alerts/agency-os-service-health-monitor.{service,timer} ~/.config/systemd/user/
systemctl --user daemon-reload
systemctl --user enable --now agency-os-service-health-monitor.timer
```

## Diff scope

4 files, +418, 0 source changes:
- `scripts/alerts/service_health_monitor.py` (new, ~140 LOC)
- `infra/alerts/agency-os-service-health-monitor.service` (systemd unit)
- `infra/alerts/agency-os-service-health-monitor.timer` (OnCalendar *:0/5)
- `tests/scripts/test_service_health_monitor.py` (18 mock-based tests)

## Best-effort semantics

Slack-post failures log but never raise (monitor's job is liveness reporting; failures in reporting must not cascade into restart loops). `SLACK_BOT_TOKEN` absent → log warning, exit 0.

## Outcome sequence

This is Outcome 1 of System Health Monitoring (5 outcomes total). Sequenced first per Elliot's recommendation — provides observability for the others. Next:
- Outcome 2: LAW XV mechanical enforcement (Max scoping the design spec)
- Outcome 3: Mandatory session-start logged query
- Outcome 4: Artifact freshness crons
- Outcome 5: Pre-compaction alert + HEARTBEAT.md template stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)