### PR TITLE
[AIDEN] feat(health): Task 1B Outcome 5 — PreCompact alert + HEARTBEAT.md template

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,6 +71,18 @@
         ]
       }
     ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/elliotbot/clawd/venv/bin/python3 scripts/pre_compact_alert.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit|NotebookEdit",

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -1,10 +1,41 @@
 # HEARTBEAT.md
 
-On heartbeat, check:
+Agent-maintained continuation anchor. Updated before context fills up so the
+post-compaction session can resume without re-deriving state. Read at session
+start, snapshotted by the PreCompact hook (scripts/pre_compact_alert.py).
 
-1. **Context health** — If >60%, alert Dave and prepare for restart.
-2. **Anything urgent?** — Blockers, failures, opportunities that need immediate attention.
-3. **Active work?** — Is there something in progress that needs follow-up?
+## Active Task
+
+- Directive: <directive number or label>
+- Goal: <one-line>
+- Phase: <scope/decompose/execute/verify/report>
+- Files touched (current PR): <list>
+
+## Last Good Commit
+
+- SHA: <git short-sha>
+- Branch: <branch-name>
+- Subject: <commit subject line>
+
+## Blockers
+
+- <bulleted list, or "none">
+
+## Next Action
+
+- <single concrete next step the next session should execute>
+
+## Heartbeat Cadence (CLAUDE.md context thresholds)
+
+- 40% — self-alert; consider HEARTBEAT update
+- 50% — alert Dave via Slack
+- 60% — execute session-end protocol
+- 70% — pre-compaction warning fires (this template snapshotted)
+
+On heartbeat check:
+1. Context health — if >60%, alert Dave and prepare for restart.
+2. Anything urgent? — blockers, failures, opportunities.
+3. Active work? — something in progress that needs follow-up?
 
 If nothing needs attention: `HEARTBEAT_OK`
-If something does: Brief summary, no fluff.
+If something does: brief summary, no fluff.

--- a/scripts/pre_compact_alert.py
+++ b/scripts/pre_compact_alert.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""pre_compact_alert.py — Claude Code PreCompact hook → Slack alert.
+
+Per Dave System Health Monitoring directive 2026-05-12 Outcome 5:
+  "Pre-compaction alert at 70% + HEARTBEAT.md template stub."
+
+When Claude Code is about to auto-compact context (≈95% threshold internally;
+the directive's "70%" is the *self-alert target* in CLAUDE.md, not a value
+this hook can observe), this script fires once. It dumps:
+
+  - callsign + UTC timestamp
+  - HEARTBEAT.md snapshot (agent-maintained state)
+  - last 3 git commits in the worktree
+  - branch name + clean/dirty status
+
+…to #execution. Best-effort: failures DO NOT block compaction. Compaction
+proceeds either way; the alert is observability, not a gate.
+
+Wired in .claude/settings.json under "PreCompact" matcher.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("pre_compact_alert")
+
+EXECUTION_CHANNEL = "C0B3QB0K1GQ"
+HEARTBEAT_PATH = Path("HEARTBEAT.md")
+
+
+def resolve_callsign() -> str:
+    """env → IDENTITY.md → 'unknown' (mirrors session_start_audit.py)."""
+    env_val = os.environ.get("CALLSIGN", "").strip()
+    if env_val:
+        return env_val.lower()
+    import re
+
+    for candidate in (Path.cwd() / "IDENTITY.md", Path.cwd().parent / "IDENTITY.md"):
+        if candidate.exists():
+            match = re.search(
+                r"^\s*\*\*?CALLSIGN:?\*\*?\s*([A-Za-z]\w*)",
+                candidate.read_text(),
+                re.IGNORECASE | re.MULTILINE,
+            )
+            if match:
+                return match.group(1).lower()
+    return "unknown"
+
+
+def read_heartbeat() -> str:
+    """Read HEARTBEAT.md from worktree root. '' if missing."""
+    if HEARTBEAT_PATH.exists():
+        try:
+            text = HEARTBEAT_PATH.read_text()
+            # Cap to 2000 chars to keep Slack message bounded
+            return text[:2000]
+        except OSError as exc:
+            logger.warning("HEARTBEAT.md read failed: %s", exc)
+    return ""
+
+
+def _run(args: list[str]) -> str:
+    """Run a git command, return stdout stripped. '' on failure."""
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, timeout=5)
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        logger.warning("git command %s failed: %s", args, exc)
+        return ""
+
+
+def git_context() -> dict:
+    """Branch + last 3 commits + dirty/clean."""
+    branch = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    log = _run(["git", "log", "--oneline", "-3"])
+    porcelain = _run(["git", "status", "--porcelain"])
+    return {
+        "branch": branch or "?",
+        "log": log or "(no commits)",
+        "dirty": bool(porcelain),
+        "porcelain": porcelain[:500],
+    }
+
+
+def format_alert(callsign: str, hook_input: dict, heartbeat: str, git: dict) -> str:
+    when = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    trigger = hook_input.get("trigger", "unknown")
+    heartbeat_block = heartbeat.strip() or "(HEARTBEAT.md empty or missing)"
+    dirty_marker = " [DIRTY]" if git["dirty"] else ""
+    return (
+        f"[PRE-COMPACT] callsign={callsign} branch={git['branch']}{dirty_marker} "
+        f"trigger={trigger} when={when}\n"
+        f"HEARTBEAT:\n```\n{heartbeat_block}\n```\n"
+        f"Recent commits:\n```\n{git['log']}\n```"
+    )
+
+
+def post_to_slack(text: str, channel: str = EXECUTION_CHANNEL) -> bool:
+    token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if not token:
+        logger.warning("SLACK_BOT_TOKEN not set — cannot post pre-compact alert")
+        return False
+    import urllib.error
+    import urllib.request
+
+    body = json.dumps(
+        {
+            "channel": channel,
+            "text": text,
+            "username": "PreCompact",
+            "icon_emoji": ":card_index_dividers:",
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            response = json.loads(r.read())
+            return bool(response.get("ok"))
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("Slack alert post failed: %s", exc)
+        return False
+
+
+def read_hook_input() -> dict:
+    """Read JSON hook input from stdin. {} if stdin empty / invalid."""
+    if sys.stdin.isatty():
+        return {}
+    try:
+        raw = sys.stdin.read()
+        return json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        logger.warning("PreCompact hook input not JSON: %s", exc)
+        return {}
+
+
+def main() -> int:
+    hook_input = read_hook_input()
+    callsign = resolve_callsign()
+    heartbeat = read_heartbeat()
+    git = git_context()
+    text = format_alert(callsign, hook_input, heartbeat, git)
+    posted = post_to_slack(text)
+    logger.info(
+        "PreCompact alert: callsign=%s branch=%s posted=%s",
+        callsign,
+        git["branch"],
+        posted,
+    )
+    return 0  # Best-effort: never block compaction
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_pre_compact_alert.py
+++ b/tests/scripts/test_pre_compact_alert.py
@@ -1,0 +1,281 @@
+"""tests for scripts/pre_compact_alert.py — Dave System Health Outcome 5.
+
+Mocks Slack + git subprocess + HEARTBEAT.md to test:
+  - resolve_callsign env / IDENTITY.md / fallback
+  - read_heartbeat reads worktree HEARTBEAT.md / caps at 2000 chars
+  - git_context returns branch + log + dirty flag
+  - format_alert composes complete message
+  - post_to_slack: no-token / network-error / ok=true paths
+  - read_hook_input: tty / empty / valid JSON / invalid JSON
+  - main() always returns 0 (best-effort)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ALERT_PATH = REPO_ROOT / "scripts" / "pre_compact_alert.py"
+
+
+@pytest.fixture(scope="module")
+def alert():
+    spec = importlib.util.spec_from_file_location("pre_compact_alert", ALERT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["pre_compact_alert"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# resolve_callsign
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_resolve_callsign_from_env(alert, monkeypatch) -> None:
+    monkeypatch.setenv("CALLSIGN", "aiden")
+    assert alert.resolve_callsign() == "aiden"
+
+
+def test_resolve_callsign_lowercases(alert, monkeypatch) -> None:
+    monkeypatch.setenv("CALLSIGN", "AIDEN")
+    assert alert.resolve_callsign() == "aiden"
+
+
+def test_resolve_callsign_fallback_unknown(alert, monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("CALLSIGN", raising=False)
+    monkeypatch.chdir(tmp_path)
+    assert alert.resolve_callsign() == "unknown"
+
+
+def test_resolve_callsign_from_identity_md(alert, monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("CALLSIGN", raising=False)
+    (tmp_path / "IDENTITY.md").write_text("# IDENTITY\n\n**CALLSIGN:** aiden\n")
+    monkeypatch.chdir(tmp_path)
+    assert alert.resolve_callsign() == "aiden"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# read_heartbeat
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_read_heartbeat_returns_empty_when_missing(alert, monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert alert.read_heartbeat() == ""
+
+
+def test_read_heartbeat_returns_content(alert, monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "HEARTBEAT.md").write_text("Active task: build outcome 5\n")
+    assert "Active task" in alert.read_heartbeat()
+
+
+def test_read_heartbeat_caps_at_2000_chars(alert, monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "HEARTBEAT.md").write_text("x" * 5000)
+    assert len(alert.read_heartbeat()) == 2000
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# git_context
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_git_context_returns_fields(alert) -> None:
+    def fake_run(args: list[str]) -> str:
+        if args[:2] == ["git", "rev-parse"]:
+            return "feature/branch"
+        if args[:2] == ["git", "log"]:
+            return "abc123 commit message"
+        if args[:2] == ["git", "status"]:
+            return ""  # clean
+        return ""
+
+    with patch.object(alert, "_run", side_effect=fake_run):
+        ctx = alert.git_context()
+    assert ctx["branch"] == "feature/branch"
+    assert ctx["log"] == "abc123 commit message"
+    assert ctx["dirty"] is False
+
+
+def test_git_context_marks_dirty_when_porcelain_nonempty(alert) -> None:
+    def fake_run(args: list[str]) -> str:
+        if args[:2] == ["git", "rev-parse"]:
+            return "main"
+        if args[:2] == ["git", "log"]:
+            return "deadbeef commit"
+        if args[:2] == ["git", "status"]:
+            return " M file.py\n?? other.py"
+        return ""
+
+    with patch.object(alert, "_run", side_effect=fake_run):
+        ctx = alert.git_context()
+    assert ctx["dirty"] is True
+
+
+def test_git_context_handles_missing_git(alert) -> None:
+    with patch.object(alert, "_run", return_value=""):
+        ctx = alert.git_context()
+    assert ctx["branch"] == "?"
+    assert ctx["log"] == "(no commits)"
+    assert ctx["dirty"] is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _run
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_run_returns_empty_on_filenotfound(alert) -> None:
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        assert alert._run(["nonexistent"]) == ""
+
+
+def test_run_returns_empty_on_timeout(alert) -> None:
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5)):
+        assert alert._run(["git", "log"]) == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# format_alert
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_format_alert_composes_all_fields(alert) -> None:
+    git = {
+        "branch": "aiden/test-branch",
+        "log": "abc123 fix(x): y",
+        "dirty": False,
+        "porcelain": "",
+    }
+    text = alert.format_alert(
+        "aiden",
+        {"trigger": "auto"},
+        "Active task: outcome 5",
+        git,
+    )
+    assert "[PRE-COMPACT]" in text
+    assert "callsign=aiden" in text
+    assert "branch=aiden/test-branch" in text
+    assert "trigger=auto" in text
+    assert "outcome 5" in text
+    assert "abc123" in text
+    assert "[DIRTY]" not in text
+
+
+def test_format_alert_marks_dirty_branch(alert) -> None:
+    git = {"branch": "main", "log": "x", "dirty": True, "porcelain": "M file"}
+    text = alert.format_alert("aiden", {}, "h", git)
+    assert "[DIRTY]" in text
+
+
+def test_format_alert_handles_empty_heartbeat(alert) -> None:
+    git = {"branch": "main", "log": "x", "dirty": False, "porcelain": ""}
+    text = alert.format_alert("aiden", {}, "", git)
+    assert "HEARTBEAT.md empty or missing" in text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# read_hook_input
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_read_hook_input_returns_empty_when_tty(alert) -> None:
+    with patch.object(sys, "stdin") as mock_stdin:
+        mock_stdin.isatty.return_value = True
+        assert alert.read_hook_input() == {}
+
+
+def test_read_hook_input_parses_valid_json(alert) -> None:
+    fake_stdin = io.StringIO('{"trigger": "auto"}')
+    fake_stdin.isatty = lambda: False
+    with patch.object(sys, "stdin", fake_stdin):
+        assert alert.read_hook_input() == {"trigger": "auto"}
+
+
+def test_read_hook_input_returns_empty_on_invalid_json(alert) -> None:
+    fake_stdin = io.StringIO("not json {")
+    fake_stdin.isatty = lambda: False
+    with patch.object(sys, "stdin", fake_stdin):
+        assert alert.read_hook_input() == {}
+
+
+def test_read_hook_input_returns_empty_on_blank(alert) -> None:
+    fake_stdin = io.StringIO("")
+    fake_stdin.isatty = lambda: False
+    with patch.object(sys, "stdin", fake_stdin):
+        assert alert.read_hook_input() == {}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# post_to_slack
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_post_to_slack_no_token_returns_false(alert, monkeypatch) -> None:
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    assert alert.post_to_slack("test") is False
+
+
+def test_post_to_slack_ok_true_returns_true(alert, monkeypatch) -> None:
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-fake")
+    import urllib.request
+
+    class FakeResponse:
+        def read(self) -> bytes:
+            return json.dumps({"ok": True}).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    with patch.object(urllib.request, "urlopen", return_value=FakeResponse()):
+        assert alert.post_to_slack("test") is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# main
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_main_returns_zero_on_success(alert, monkeypatch) -> None:
+    monkeypatch.setenv("CALLSIGN", "aiden")
+    with (
+        patch.object(alert, "read_hook_input", return_value={"trigger": "auto"}),
+        patch.object(alert, "read_heartbeat", return_value="task: x"),
+        patch.object(
+            alert,
+            "git_context",
+            return_value={"branch": "main", "log": "x", "dirty": False, "porcelain": ""},
+        ),
+        patch.object(alert, "post_to_slack", return_value=True) as mock_post,
+    ):
+        assert alert.main() == 0
+    assert mock_post.call_count == 1
+
+
+def test_main_returns_zero_even_on_slack_failure(alert, monkeypatch) -> None:
+    """Best-effort — compaction must NEVER be blocked."""
+    monkeypatch.setenv("CALLSIGN", "aiden")
+    with (
+        patch.object(alert, "read_hook_input", return_value={}),
+        patch.object(alert, "read_heartbeat", return_value=""),
+        patch.object(
+            alert,
+            "git_context",
+            return_value={"branch": "?", "log": "", "dirty": False, "porcelain": ""},
+        ),
+        patch.object(alert, "post_to_slack", return_value=False),
+    ):
+        assert alert.main() == 0


### PR DESCRIPTION
## Summary

Per Dave System Health Monitoring directive 2026-05-12 Outcome 5:
> "Pre-compaction alert at 70% + HEARTBEAT.md template stub."

When Claude Code is about to auto-compact context, this hook dumps the agent's continuation state to #execution: callsign + UTC timestamp + HEARTBEAT.md snapshot + last 3 git commits + branch + dirty-flag.

Best-effort throughout: failures DO NOT block compaction. The alert is observability, not a gate.

## On the "70%" framing

Dave's "70%" is the *self-alert target* for agents in CLAUDE.md, not a threshold this hook observes. Claude Code fires PreCompact at its internal ~95% threshold. HEARTBEAT discipline (this PR's template + global CLAUDE.md context thresholds: 40 self-alert / 50 alert-Dave / 60 session-end / 70 pre-compaction-warning) bridges the gap. When agents follow the 60% session-end protocol, this hook rarely fires; when they don't, the hook is the safety net.

## Files

- `scripts/pre_compact_alert.py` (169 lines) — reads PreCompact hook JSON from stdin, resolves callsign, snapshots HEARTBEAT.md (2000-char cap), git context, posts to #execution
- `HEARTBEAT.md` — expanded template stub: Active Task / Last Good Commit / Blockers / Next Action / Heartbeat Cadence
- `.claude/settings.json` — adds `"PreCompact"` matcher firing the hook (timeout=10s)
- `tests/scripts/test_pre_compact_alert.py` (281 lines, 23 tests)

## Live smoke verified end-to-end

```
$ echo '{"trigger": "smoke_test"}' | python3 scripts/pre_compact_alert.py
INFO: PreCompact alert: callsign=aiden branch=aiden/task1b-outcome5-precompact-alert posted=True
```

Real Slack ts 1778553084 visible in #execution with full HEARTBEAT + git snapshot (caused the earlier `[TG-AIDENBOT] [PRE-COMPACT]` post in chat — that was the smoke, not a real compaction).

## Test plan

- [x] `pytest tests/scripts/test_pre_compact_alert.py` → 23 passed in 0.29s
- [x] `ruff check + ruff format --check` → All clean
- [x] `python -c "import json; json.load(open('.claude/settings.json'))"` → valid; PreCompact key present
- [x] End-to-end smoke (stdin JSON → Slack post) → posted=True

## Sequence (Task 1B System Health Monitoring)

- Outcome 1 ✓ (PR #747 merged)
- Outcome 2 — spec received from Max, building next
- Outcome 3 ✓ (PR #748 merged)
- Outcome 4 ✓ (PR #750 merged)
- **Outcome 5 ✓ this PR**
- Outcome 6 ✓ (PR #749 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)