### PR TITLE
[ORION] fix(session_resumption): PR-C clean-close preserves UUID for --resume

### DIFF
--- a/.claude/hooks/session_store_stop.sh
+++ b/.claude/hooks/session_store_stop.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Drevon PR-A — Stop hook that closes the open session row (status='closed').
-# Companion to .claude/hooks/session_store_posttooluse.sh which opens it.
-# Best-effort recording — always exits 0. NOT yet wired in .claude/settings.json
-# (follow-up).
+# Drevon PR-A + PR-C clean-close — Stop hook closes the open session row with
+# status='closed_clean' so PR-C resolver can pick the UUID back up via
+# `claude --resume <uuid>` on the next launch. status='closed' is now reserved
+# for caller-initiated graceful closes that should NOT resume (none today).
+# Watchdog continues to mark unresponsive rows status='stuck'.
+# Best-effort recording — always exits 0.
 
 set -u
 
@@ -58,7 +60,7 @@ if os.path.exists(session_state):
         from uuid import UUID
         sid = open(session_state).read().strip().split(':')[0]
         if sid:
-            record_session_end(session_id=UUID(sid), status='closed')
+            record_session_end(session_id=UUID(sid), status='closed_clean')
         os.remove(session_state)
     except Exception as e:
         sys.stderr.write(f'session close failed: {e}\n')

--- a/src/session_resumption/__init__.py
+++ b/src/session_resumption/__init__.py
@@ -21,8 +21,10 @@ Design notes:
   - Freshness measured from sessions.started_at (no last_activity column on
     sessions per current schema). Watchdog complements this by reaping rows
     that exceed stuck_minutes regardless of activity.
-  - Resolver excludes status='stuck' and status='closed' explicitly so
-    clear_stuck_sessions takes effect immediately.
+  - Resolver accepts status IN ('active', 'closed_clean') — both are
+    resumable. 'closed_clean' rows are written by the Stop hook on planned
+    tmux kill / clean restart and preserve the session_uuid for `claude
+    --resume` (PR-C clean-close fix). 'stuck' and 'closed' are excluded.
   - All DB writes are best-effort: if Supabase is unreachable the launcher
     must still spawn `claude` with a fresh UUID rather than block startup.
 """

--- a/src/session_resumption/resolver.py
+++ b/src/session_resumption/resolver.py
@@ -1,8 +1,11 @@
 """resolver.py — read + claim Claude Code session_uuid for a callsign.
 
 Read path (resolve_session_uuid): PostgREST GET on sessions, filtered to
-watchdog-fresh + status='active' + session_uuid IS NOT NULL, ordered by
-started_at desc, limit 1. Returns the session_uuid string or None.
+watchdog-fresh + status IN ('active', 'closed_clean') + session_uuid IS NOT
+NULL, ordered by started_at desc, limit 1. Returns the session_uuid string
+or None. 'closed_clean' rows are planned-restart targets — the Stop hook
+writes that status to preserve the UUID for `claude --resume` on the next
+launcher invocation. 'stuck' and 'closed' rows are excluded.
 
 Write path (claim_session_uuid): delegates to src.session_store.recorder
 .record_session_start to keep schema knowledge in one place. Returns the
@@ -21,6 +24,7 @@ from src.evo.supabase_client import sb_get
 logger = logging.getLogger("session_resumption.resolver")
 
 DEFAULT_FRESH_MINUTES = 30
+RESUMABLE_STATUSES = ("active", "closed_clean")
 
 
 def resolve_session_uuid(
@@ -29,16 +33,18 @@ def resolve_session_uuid(
 ) -> str | None:
     """Return the most-recent resumable session_uuid for callsign, or None.
 
-    Resumable = ended_at IS NULL AND status='active' AND session_uuid IS NOT
-    NULL AND started_at >= NOW() - INTERVAL fresh_minutes. Best-effort: any
-    Supabase failure logs + returns None so the launcher falls through to a
-    fresh session rather than blocking.
+    Resumable = status IN ('active', 'closed_clean') AND session_uuid IS NOT
+    NULL AND started_at >= NOW() - INTERVAL fresh_minutes. ended_at is NOT
+    filtered — closed_clean rows have ended_at set by the Stop hook but are
+    still resumable targets for planned restarts (PR-C clean-close bug fix).
+    Stuck/closed rows are excluded by status. Best-effort: any Supabase
+    failure logs + returns None so the launcher falls through to a fresh
+    session rather than blocking.
     """
     cutoff_iso = (datetime.now(UTC) - timedelta(minutes=fresh_minutes)).isoformat()
     params = {
         "callsign": f"eq.{callsign}",
-        "status": "eq.active",
-        "ended_at": "is.null",
+        "status": f"in.({','.join(RESUMABLE_STATUSES)})",
         "session_uuid": "not.is.null",
         "started_at": f"gte.{cutoff_iso}",
         "deleted_at": "is.null",

--- a/src/session_resumption/watchdog.py
+++ b/src/session_resumption/watchdog.py
@@ -1,9 +1,14 @@
 """watchdog.py — mark stale active sessions as status='stuck'.
 
-Periodic sweep entry point. Finds sessions where ended_at IS NULL AND
-started_at < NOW() - INTERVAL stuck_minutes, then calls
-session_store.recorder.mark_session_stuck on each (which sets ended_at
-and status='stuck' atomically per row).
+Periodic sweep entry point. Finds sessions where status='active' AND
+ended_at IS NULL AND started_at < NOW() - INTERVAL stuck_minutes, then
+calls session_store.recorder.mark_session_stuck on each (which sets
+ended_at and status='stuck' atomically per row).
+
+PR-C clean-close note: rows with status='closed_clean' are LEFT ALONE.
+Those are planned-restart targets owned by the Stop hook + resolver pair.
+The resolver's started_at freshness window prevents resumption of stale
+closed_clean rows; no need for the watchdog to reap them.
 
 Called from .claude/hooks/session_resumption_watchdog.sh on a cadence
 chosen by the operator (cron / systemd timer / agent loop).

--- a/src/session_store/recorder.py
+++ b/src/session_store/recorder.py
@@ -202,8 +202,10 @@ def record_tool_call(
     return lid
 
 
-def record_session_end(session_id: UUID, *, status: str = "closed") -> None:
-    """Close a sessions row."""
+def record_session_end(session_id: UUID, *, status: str = "closed_clean") -> None:
+    """Close a sessions row. Default 'closed_clean' preserves UUID for PR-C
+    `claude --resume` on planned restarts. Pass status='closed' for graceful
+    closes that should NOT resume (no current caller does this)."""
     _safe_patch(
         "sessions",
         {"id": f"eq.{session_id}"},

--- a/supabase/migrations/20260512_pr_c_closed_clean_status.sql
+++ b/supabase/migrations/20260512_pr_c_closed_clean_status.sql
@@ -1,0 +1,22 @@
+-- Migration: 20260512_pr_c_closed_clean_status.sql
+-- Purpose: PR-C clean-close fix — formalise sessions.status='closed_clean'.
+--          'closed_clean' = planned tmux kill / graceful restart, UUID
+--          preserved so the next launcher call can `claude --resume <uuid>`.
+--          'closed' is now reserved for callers that explicitly want NO
+--          resume (no current caller); 'stuck' continues to mean unresponsive
+--          (set by watchdog).
+--
+-- Schema note: sessions.status is TEXT with no CHECK constraint, so the new
+-- value requires no DDL — this migration is documentation-only via COMMENT.
+-- Re-runnable: COMMENT ON is idempotent.
+--
+-- Companions:
+--   - .claude/hooks/session_store_stop.sh writes status='closed_clean'
+--   - src/session_resumption/resolver.py filters status IN ('active', 'closed_clean')
+--   - src/session_resumption/watchdog.py only touches status='active' rows
+--
+-- Created: 2026-05-12
+
+COMMENT ON COLUMN sessions.status IS
+    'active = open process; closed_clean = planned restart, UUID resumable; '
+    'closed = explicit no-resume close; stuck = watchdog-reaped unresponsive';

--- a/tests/session_resumption/test_resolver.py
+++ b/tests/session_resumption/test_resolver.py
@@ -42,16 +42,29 @@ def test_resolve_filters_by_callsign(captured_sb_get):
     assert captured_sb_get["params"]["callsign"] == "eq.max"
 
 
-def test_resolve_excludes_non_active_status(captured_sb_get):
+def test_resolve_filters_to_resumable_statuses(captured_sb_get):
+    """PR-C clean-close: status IN ('active', 'closed_clean'). Stuck/closed
+    sessions are still skipped; closed_clean rows (planned restart) ARE
+    resumable so the next launcher exec can `claude --resume <uuid>`."""
     resolver.resolve_session_uuid("elliot")
-    # Resolver must explicitly bound to active so stuck/closed sessions are skipped.
-    assert captured_sb_get["params"]["status"] == "eq.active"
+    assert captured_sb_get["params"]["status"] == "in.(active,closed_clean)"
 
 
-def test_resolve_excludes_ended_and_deleted_rows(captured_sb_get):
+def test_resolve_does_not_filter_ended_at(captured_sb_get):
+    """closed_clean rows have ended_at set by the Stop hook but are still
+    resumable, so the resolver must NOT add ended_at IS NULL."""
     resolver.resolve_session_uuid("scout")
-    assert captured_sb_get["params"]["ended_at"] == "is.null"
+    assert "ended_at" not in captured_sb_get["params"]
     assert captured_sb_get["params"]["deleted_at"] == "is.null"
+
+
+def test_resolve_returns_uuid_from_closed_clean_row(captured_sb_get):
+    """Empirical contract: planned tmux kill → Stop hook writes
+    status='closed_clean' + ended_at → next launcher resolves the same UUID
+    so `claude --resume` actually fires."""
+    uid = str(uuid4())
+    captured_sb_get["response"] = [{"session_uuid": uid}]
+    assert resolver.resolve_session_uuid("aiden") == uid
 
 
 def test_resolve_requires_session_uuid_present(captured_sb_get):

--- a/tests/session_resumption/test_stop_hook_status.py
+++ b/tests/session_resumption/test_stop_hook_status.py
@@ -1,0 +1,36 @@
+"""Regression guard for the PR-C clean-close Stop hook.
+
+The hook is a bash script with embedded Python (.claude/hooks/session_store_stop.sh).
+Its only behaviour relevant to PR-C is the literal `status='closed_clean'`
+argument passed to record_session_end — get that wrong (e.g. revert to
+`status='closed'`) and every planned tmux kill silently breaks `claude
+--resume`. Pin the literal so the bug can never quietly regress.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+HOOK = (
+    Path(__file__).resolve().parent.parent.parent
+    / ".claude"
+    / "hooks"
+    / "session_store_stop.sh"
+)
+
+
+def test_stop_hook_exists() -> None:
+    assert HOOK.is_file(), f"Stop hook missing at {HOOK}"
+
+
+def test_stop_hook_passes_closed_clean_status() -> None:
+    body = HOOK.read_text()
+    assert "record_session_end(session_id=UUID(sid), status='closed_clean')" in body, (
+        "Stop hook must call record_session_end with status='closed_clean' "
+        "(PR-C clean-close fix). 'closed' was the previous default and broke "
+        "--resume on planned restarts."
+    )
+    assert "status='closed')" not in body, (
+        "Stop hook still contains status='closed' literal — that path is now "
+        "reserved for explicit no-resume closes (no current caller)."
+    )

--- a/tests/session_store/test_recorder.py
+++ b/tests/session_store/test_recorder.py
@@ -165,6 +165,18 @@ def test_record_session_end_patches_sessions_row(captured_patches) -> None:
     assert "ended_at" in payload
 
 
+def test_record_session_end_defaults_to_closed_clean(captured_patches) -> None:
+    """PR-C clean-close fix: planned restarts (Stop hook) must default to
+    status='closed_clean' so the next launcher invocation resolves the UUID
+    and exec's `claude --resume <uuid>`. Regression guard: a previous default
+    of 'closed' silently broke resume on every clean tmux kill."""
+    sid = UUID("00000000-0000-0000-0000-000000000006")
+    recorder.record_session_end(session_id=sid)
+    _table, _params, payload = captured_patches[0]
+    assert payload["status"] == "closed_clean"
+    assert "ended_at" in payload
+
+
 def test_mark_session_stuck(captured_patches) -> None:
     sid = UUID("00000000-0000-0000-0000-000000000005")
     recorder.mark_session_stuck(session_id=sid)


### PR DESCRIPTION
## Summary

- Stop hook now writes `status='closed_clean'` (UUID preserved); resolver accepts `status IN ('active','closed_clean')` and drops the `ended_at IS NULL` filter — planned tmux kills now resume on the next launcher exec instead of starting fresh
- Watchdog unchanged (still marks only `status='active'` rows as `stuck`); `'closed'` retained for explicit no-resume closes (no current caller)
- Migration is COMMENT-only — `sessions.status` is already `TEXT` with no `CHECK`, so the new value requires no DDL

## Empirical bug

Tonight ~02:50 UTC, Aiden + Max both restarted via planned tmux kill. Pre-restart sessions were marked `closed` at 02:44/02:46 UTC. New sessions got fresh UUIDs (e.g. `7bbd25be...`) instead of `claude --resume <prior_uuid>`. Root cause: clean close → `status='closed'` → resolver's `status='eq.active'` filter excluded the row → fresh path.

## Fix

| Component | Before | After |
|---|---|---|
| `.claude/hooks/session_store_stop.sh` | `status='closed'` | `status='closed_clean'` |
| `src/session_resumption/resolver.py` | `status='eq.active' AND ended_at='is.null'` | `status='in.(active,closed_clean)'` (no `ended_at` filter) |
| `src/session_resumption/watchdog.py` | scans `status='active'` for stuck-marking | unchanged — `closed_clean` left alone, resolver freshness window prevents stale resume |
| `src/session_store/recorder.py` | `record_session_end` default `status='closed'` | default `status='closed_clean'` (explicit `closed` still accepted) |
| migration | — | new `20260512_pr_c_closed_clean_status.sql` (COMMENT only) |

## Validation

```
$ pytest tests/session_resumption/ tests/session_store/test_recorder.py -x -q
44 passed in 0.97s

$ ruff check src/session_resumption/ src/session_store/recorder.py tests/...
All checks passed!
```

Python-level simulation of resolver + launcher chain with a `closed_clean` row in fixture:

```
resolved_uuid: abc-def-1234
status_filter: in.(active,closed_clean)
ended_at_filter: <absent>
-- launcher bash would translate to: claude --resume <uuid>
```

Self-kill empirical validation skipped — would end this session. A peer (Aiden/Max) can kill their tmux and confirm `--resume` fires on relaunch once merged.

## Test plan

- [x] `test_resolve_filters_to_resumable_statuses` — status filter is `in.(active,closed_clean)`
- [x] `test_resolve_does_not_filter_ended_at` — `closed_clean` rows resumable despite `ended_at` set
- [x] `test_resolve_returns_uuid_from_closed_clean_row` — direct closed_clean → uuid path
- [x] `test_record_session_end_defaults_to_closed_clean` — recorder default flipped
- [x] `test_stop_hook_passes_closed_clean_status` — regression guard on the literal string in the hook
- [ ] Post-merge: peer-validated kill+relaunch cycle (Aiden/Max)

## Dual-CTO concur required

Aiden + Max please review and approve before merge per dual-bot rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)