### PR TITLE
[ORION] feat(heartbeat): per-callsign HEARTBEAT.md customisation

### DIFF
--- a/config/heartbeat_callsigns.yaml
+++ b/config/heartbeat_callsigns.yaml
@@ -1,0 +1,115 @@
+# Per-callsign HEARTBEAT.md customisation (Task 1B Outcome — 20-item roadmap #2).
+#
+# One template, six customised instances. scripts/heartbeat_generator.py reads
+# this file + HEARTBEAT.md (base template from PR #751) and emits one
+# HEARTBEAT.<callsign>.md per entry below. Each generated file shows the
+# agent its budget, file-path lanes, prohibited actions, and escalation
+# trigger at session start.
+#
+# Adding a new callsign? Drop a new top-level key under `callsigns:` with the
+# five required fields and re-run the generator. Tests will fail loudly if a
+# required field is missing.
+#
+# Fields:
+#   role                — short human-readable role string
+#   max_token_budget    — absolute upper limit per session (informational)
+#   allowed_paths       — directory prefixes this callsign may write to
+#   prohibited_actions  — explicit "do not do" list
+#   escalation_trigger  — when/how this callsign escalates upward
+
+callsigns:
+  elliot:
+    role: "Chief Operating Officer (COO)"
+    max_token_budget: 200000
+    allowed_paths:
+      - docs/
+      - .claude/modules/
+      - scripts/
+      - tests/
+    prohibited_actions:
+      - "Direct merges without dual-CTO concur (RULE 3 APPROVE)"
+      - "Writing into src/ implementation code (delegate to Aiden/Atlas)"
+      - "Bypassing Manual mirror on directive completion"
+    escalation_trigger: >-
+      Telegram Dave + drop scope when context > 60% or a peer agent has been
+      blocked for 30+ minutes.
+
+  aiden:
+    role: "Chief Technology Officer — backend + governance lead"
+    max_token_budget: 200000
+    allowed_paths:
+      - src/
+      - tests/
+      - supabase/migrations/
+      - .claude/hooks/
+      - scripts/
+    prohibited_actions:
+      - "Merging own PRs (require Max or Elliot as second approver)"
+      - "Schema changes without ARCHITECTURE.md update in same PR"
+      - "Touching frontend/Next.js code (out of lane)"
+    escalation_trigger: >-
+      Telegram #execution when build blocked >30 min or schema migration
+      risks production data.
+
+  max:
+    role: "Chief Technology Officer — frontend + integrations lead"
+    max_token_budget: 200000
+    allowed_paths:
+      - frontend/
+      - src/integrations/
+      - tests/
+      - skills/
+    prohibited_actions:
+      - "Merging own PRs (require Aiden or Elliot as second approver)"
+      - "Schema migrations (delegate to Aiden)"
+      - "Direct API calls outside skills/ (LAW XII Skills-First)"
+    escalation_trigger: >-
+      Telegram #execution when integration vendor is down >15 min or
+      frontend deploy fails twice.
+
+  atlas:
+    role: "Engineer clone of Elliot (operational execution)"
+    max_token_budget: 180000
+    allowed_paths:
+      - docs/
+      - scripts/
+      - tests/
+      - .claude/modules/
+    prohibited_actions:
+      - "Cross-dispatch to ORION or SCOUT (clones do not dispatch peers)"
+      - "Writing into src/ without explicit Elliot brief"
+      - "Merging any PR (review-only — parent Elliot merges)"
+    escalation_trigger: >-
+      Write to /tmp/telegram-relay-elliot/outbox/ when dispatch ambiguous
+      or blocked > 20 minutes.
+
+  orion:
+    role: "Engineer clone of Aiden (parallel build execution)"
+    max_token_budget: 180000
+    allowed_paths:
+      - src/
+      - tests/
+      - supabase/migrations/
+      - .claude/hooks/
+      - scripts/
+    prohibited_actions:
+      - "Cross-dispatch to ATLAS or SCOUT (clones do not dispatch peers)"
+      - "Merging any PR (review-only — parent Aiden merges)"
+      - "Touching frontend/ (Max's lane)"
+    escalation_trigger: >-
+      Write to /tmp/telegram-relay-aiden/outbox/ when dispatch ambiguous,
+      build blocked > 30 min, or schema risk surfaces.
+
+  scout:
+    role: "Research + reconnaissance clone (read-mostly)"
+    max_token_budget: 120000
+    allowed_paths:
+      - docs/
+      - tests/
+    prohibited_actions:
+      - "Any write to src/, supabase/, frontend/, or .claude/"
+      - "Dispatching work to other agents (research output only)"
+      - "Merging PRs"
+    escalation_trigger: >-
+      Write to /tmp/telegram-relay-elliot/outbox/ when research target
+      unreachable for > 15 min or finding requires action.

--- a/scripts/heartbeat_generator.py
+++ b/scripts/heartbeat_generator.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""heartbeat_generator.py — emit per-callsign HEARTBEAT.md from one template.
+
+Task 1B 20-item roadmap #2: Aiden's PR #751 shipped HEARTBEAT.md as a
+shared BASE template. This generator reads the BASE + config/
+heartbeat_callsigns.yaml and writes six customised instances
+(HEARTBEAT.<callsign>.md) so each agent sees its own budget, file-path
+lanes, prohibited actions, and escalation trigger at session start.
+
+Usage:
+    python3 scripts/heartbeat_generator.py
+    python3 scripts/heartbeat_generator.py --output-dir /tmp/heartbeats
+    python3 scripts/heartbeat_generator.py \
+        --template HEARTBEAT.md \
+        --config config/heartbeat_callsigns.yaml \
+        --output-dir build/heartbeats
+
+Exit codes: 0 on success, 1 on config / template error. The generator is
+deterministic — same inputs produce byte-identical output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_TEMPLATE = REPO_ROOT / "HEARTBEAT.md"
+DEFAULT_CONFIG = REPO_ROOT / "config" / "heartbeat_callsigns.yaml"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "build" / "heartbeats"
+
+REQUIRED_FIELDS = (
+    "role",
+    "max_token_budget",
+    "allowed_paths",
+    "prohibited_actions",
+    "escalation_trigger",
+)
+
+SECTION_HEADER = "## Per-Callsign Context"
+
+
+def load_config(path: Path) -> dict[str, dict[str, Any]]:
+    raw = yaml.safe_load(path.read_text())
+    if not isinstance(raw, dict) or "callsigns" not in raw:
+        raise ValueError(f"{path}: missing top-level 'callsigns' key")
+    callsigns = raw["callsigns"]
+    if not isinstance(callsigns, dict) or not callsigns:
+        raise ValueError(f"{path}: 'callsigns' must be a non-empty mapping")
+    for name, spec in callsigns.items():
+        if not isinstance(spec, dict):
+            raise ValueError(f"{path}: callsign {name!r} must be a mapping")
+        missing = [f for f in REQUIRED_FIELDS if f not in spec]
+        if missing:
+            raise ValueError(
+                f"{path}: callsign {name!r} missing required fields: {missing}"
+            )
+    return callsigns
+
+
+def render_section(callsign: str, spec: dict[str, Any]) -> str:
+    allowed = "\n".join(f"  - `{p}`" for p in spec["allowed_paths"])
+    prohibited = "\n".join(f"  - {a}" for a in spec["prohibited_actions"])
+    escalation = " ".join(spec["escalation_trigger"].split())
+    return (
+        f"\n{SECTION_HEADER}\n\n"
+        f"- **Callsign:** `{callsign}`\n"
+        f"- **Role:** {spec['role']}\n"
+        f"- **Max token budget:** {spec['max_token_budget']:,}\n"
+        f"- **Allowed paths:**\n{allowed}\n"
+        f"- **Prohibited actions:**\n{prohibited}\n"
+        f"- **Escalation trigger:** {escalation}\n"
+    )
+
+
+def generate(
+    template: Path,
+    config: Path,
+    output_dir: Path,
+) -> list[Path]:
+    base = template.read_text()
+    callsigns = load_config(config)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for name in sorted(callsigns):
+        body = base.rstrip() + "\n" + render_section(name, callsigns[name])
+        out = output_dir / f"HEARTBEAT.{name}.md"
+        out.write_text(body)
+        written.append(out)
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+
+    for label, p in [("template", args.template), ("config", args.config)]:
+        if not p.is_file():
+            print(f"error: {label} not found at {p}", file=sys.stderr)
+            return 1
+    try:
+        written = generate(args.template, args.config, args.output_dir)
+    except (ValueError, yaml.YAMLError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    for p in written:
+        print(p)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_heartbeat_generator.py
+++ b/tests/scripts/test_heartbeat_generator.py
@@ -1,0 +1,160 @@
+"""Tests for scripts/heartbeat_generator.py — Task 1B 20-item roadmap #2.
+
+Verifies the generator turns one BASE HEARTBEAT.md + per-callsign YAML into
+six customised HEARTBEAT.<callsign>.md files. Each file must:
+  - preserve the BASE template content
+  - include its own callsign's role / token budget / allowed paths /
+    prohibited actions / escalation trigger
+  - NOT include another callsign's data
+
+Tests use real repo BASE + real config. No network, no Supabase.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "heartbeat_generator.py"
+BASE_TEMPLATE = REPO_ROOT / "HEARTBEAT.md"
+CONFIG_PATH = REPO_ROOT / "config" / "heartbeat_callsigns.yaml"
+
+_spec = importlib.util.spec_from_file_location("heartbeat_generator", SCRIPT_PATH)
+hb = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["heartbeat_generator"] = hb
+_spec.loader.exec_module(hb)
+
+
+EXPECTED_CALLSIGNS = ["aiden", "atlas", "elliot", "max", "orion", "scout"]
+
+
+@pytest.fixture
+def generated(tmp_path: Path) -> dict[str, str]:
+    """Run the generator into tmp_path and return {callsign: file_content}."""
+    written = hb.generate(BASE_TEMPLATE, CONFIG_PATH, tmp_path)
+    bodies: dict[str, str] = {}
+    for p in written:
+        # filename HEARTBEAT.<callsign>.md
+        callsign = p.name.removeprefix("HEARTBEAT.").removesuffix(".md")
+        bodies[callsign] = p.read_text()
+    return bodies
+
+
+def test_generator_emits_six_files(generated):
+    assert sorted(generated) == EXPECTED_CALLSIGNS
+
+
+def test_each_file_preserves_base_template(generated):
+    base_content = BASE_TEMPLATE.read_text().rstrip()
+    for callsign, body in generated.items():
+        # BASE must appear verbatim at the top so agents read the same
+        # heartbeat cadence + headings regardless of callsign.
+        assert body.startswith(base_content), (
+            f"HEARTBEAT.{callsign}.md does not start with BASE template"
+        )
+
+
+def test_each_file_has_per_callsign_section(generated):
+    for callsign, body in generated.items():
+        assert "## Per-Callsign Context" in body
+        assert f"- **Callsign:** `{callsign}`" in body
+
+
+def test_each_callsign_section_contains_required_fields(generated):
+    for callsign, body in generated.items():
+        for label in (
+            "- **Role:**",
+            "- **Max token budget:**",
+            "- **Allowed paths:**",
+            "- **Prohibited actions:**",
+            "- **Escalation trigger:**",
+        ):
+            assert label in body, f"HEARTBEAT.{callsign}.md missing {label!r}"
+
+
+def test_token_budgets_are_callsign_specific(generated):
+    # Spot-check that elliot vs scout get different budgets — proves the
+    # per-callsign config is actually being applied, not a static copy.
+    assert "200,000" in generated["elliot"]
+    assert "120,000" in generated["scout"]
+
+
+def test_files_are_distinct(generated):
+    bodies = list(generated.values())
+    unique = set(bodies)
+    assert len(unique) == len(bodies), (
+        "Generator produced duplicate output — per-callsign customisation "
+        "must make every file textually distinct."
+    )
+
+
+def test_no_cross_contamination(generated):
+    # Orion's "Touching frontend/ (Max's lane)" should NOT appear in Elliot's
+    # file; Elliot's "drop scope when context > 60%" should NOT appear in
+    # Atlas's file. Validates that callsign sections are isolated.
+    assert "Touching frontend/ (Max's lane)" in generated["orion"]
+    assert "Touching frontend/ (Max's lane)" not in generated["elliot"]
+    assert "drop scope when context > 60%" in generated["elliot"]
+    assert "drop scope when context > 60%" not in generated["atlas"]
+
+
+def test_missing_required_field_raises(tmp_path: Path):
+    bad_config = tmp_path / "bad.yaml"
+    bad_config.write_text(
+        "callsigns:\n"
+        "  foo:\n"
+        "    role: incomplete\n"
+        "    max_token_budget: 1\n"
+        # missing allowed_paths / prohibited_actions / escalation_trigger
+    )
+    with pytest.raises(ValueError, match="missing required fields"):
+        hb.load_config(bad_config)
+
+
+def test_generator_cli_returns_zero(tmp_path: Path, capsys):
+    rc = hb.main(
+        [
+            "--template",
+            str(BASE_TEMPLATE),
+            "--config",
+            str(CONFIG_PATH),
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    for cs in EXPECTED_CALLSIGNS:
+        assert f"HEARTBEAT.{cs}.md" in stdout
+
+
+def test_generator_is_deterministic(tmp_path: Path):
+    """Same inputs must produce byte-identical output across runs — gives
+    operators a clean diff signal when config genuinely changes."""
+    out1 = tmp_path / "run1"
+    out2 = tmp_path / "run2"
+    hb.generate(BASE_TEMPLATE, CONFIG_PATH, out1)
+    hb.generate(BASE_TEMPLATE, CONFIG_PATH, out2)
+    for cs in EXPECTED_CALLSIGNS:
+        assert (out1 / f"HEARTBEAT.{cs}.md").read_bytes() == (
+            out2 / f"HEARTBEAT.{cs}.md"
+        ).read_bytes()
+
+
+def test_missing_template_returns_nonzero(tmp_path: Path, capsys):
+    rc = hb.main(
+        [
+            "--template",
+            str(tmp_path / "nope.md"),
+            "--config",
+            str(CONFIG_PATH),
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 1


### PR DESCRIPTION
## Summary

Task 1B 20-item roadmap #2 — extends Aiden's PR #751 (BASE `HEARTBEAT.md` + PreCompact hook) with **one template, six customised instances**. Every agent reads its own budget, file-path lanes, prohibited actions, and escalation trigger at session start.

## What's in

| File | Purpose |
|---|---|
| `config/heartbeat_callsigns.yaml` | Per-callsign spec for elliot, aiden, max, atlas, orion, scout (5 required fields each) |
| `scripts/heartbeat_generator.py` | Reads BASE + YAML, emits 6 `HEARTBEAT.<callsign>.md` files; deterministic + CLI-driven |
| `tests/scripts/test_heartbeat_generator.py` | 11 tests covering generation, validation, isolation, determinism |

## Smoke

```
$ python3 scripts/heartbeat_generator.py --output-dir /tmp/hb_smoke
/tmp/hb_smoke/HEARTBEAT.aiden.md
/tmp/hb_smoke/HEARTBEAT.atlas.md
/tmp/hb_smoke/HEARTBEAT.elliot.md
/tmp/hb_smoke/HEARTBEAT.max.md
/tmp/hb_smoke/HEARTBEAT.orion.md
/tmp/hb_smoke/HEARTBEAT.scout.md

$ pytest tests/scripts/test_heartbeat_generator.py
11 passed in 0.40s

$ ruff check scripts/heartbeat_generator.py tests/scripts/test_heartbeat_generator.py
All checks passed!
```

Sample tail of `HEARTBEAT.orion.md`:

```
## Per-Callsign Context

- **Callsign:** `orion`
- **Role:** Engineer clone of Aiden (parallel build execution)
- **Max token budget:** 180,000
- **Allowed paths:**
  - `src/`
  - `tests/`
  - `supabase/migrations/`
  - `.claude/hooks/`
  - `scripts/`
- **Prohibited actions:**
  - Cross-dispatch to ATLAS or SCOUT (clones do not dispatch peers)
  - Merging any PR (review-only — parent Aiden merges)
  - Touching frontend/ (Max's lane)
- **Escalation trigger:** Write to /tmp/telegram-relay-aiden/outbox/ ...
```

## Wiring (out of scope for this PR)

Output lands in `build/heartbeats/` by default. Operators copy or symlink the per-callsign file into each worktree's `HEARTBEAT.md` when wiring it into `session_start`. Follow-up PR can automate that step into the launcher.

## Test plan

- [x] 11/11 pytest pass — generator emits 6 distinct files, BASE preserved, callsign sections isolated
- [x] `test_generator_is_deterministic` — same inputs → byte-identical output across runs
- [x] `test_missing_required_field_raises` — config validation fails loud
- [x] `ruff check` clean
- [ ] Post-merge: operator wires per-callsign file into respective worktrees

## Dual-CTO concur required

Aiden + Max please review and approve before merge per dual-bot rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)