### PR TITLE
[MAX] feat(bot_common): state_paths helper (XDG_STATE_HOME) — closes systemic SonarCloud S5443

### DIFF
--- a/src/bot_common/state_paths.py
+++ b/src/bot_common/state_paths.py
@@ -63,8 +63,7 @@ def resolve_state_dir(callsign: str) -> Path:
     """
     if not _CALLSIGN_RE.fullmatch(callsign):
         raise ValueError(
-            f"invalid callsign for state path: {callsign!r} "
-            f"(must match {_CALLSIGN_RE.pattern})"
+            f"invalid callsign for state path: {callsign!r} (must match {_CALLSIGN_RE.pattern})"
         )
     base = _xdg_state_home() / _APP_SUBDIR / callsign
     base.mkdir(parents=True, exist_ok=True, mode=0o700)

--- a/src/bot_common/state_paths.py
+++ b/src/bot_common/state_paths.py
@@ -1,0 +1,71 @@
+"""state_paths.py — XDG_STATE_HOME-rooted per-callsign state directory helper.
+
+Replaces ad-hoc `/tmp/...` state-file paths across session-store hooks +
+adjacent tooling with a single shared resolver. /tmp is world-writable and
+flagged by SonarCloud S5443 (publicly writable directory). XDG_STATE_HOME
+($HOME/.local/state by default) is the correct location for per-user,
+per-machine state that should persist across reboots but isn't user-data.
+
+Adopted 2026-05-12 (Aiden audit + Elliot ratification) — Option A from the
+PR #754 + PR #756 SonarCloud blocker analysis.
+
+Public API:
+
+    resolve_state_dir(callsign: str) -> Path
+
+        Returns $XDG_STATE_HOME/agency-os/<callsign>/ as a Path. Creates the
+        directory tree (mode 0o700 — owner only) on first call. Callsign is
+        validated against ^[A-Za-z][A-Za-z0-9_-]*$ — empty / traversal /
+        special chars raise ValueError.
+
+Callers that previously wrote to /tmp:
+    /tmp/.session_<callsign>      → resolve_state_dir(<cs>) / "session"
+    /tmp/.msgidx_<callsign>       → resolve_state_dir(<cs>) / "msgidx"
+    /tmp/.turn_<callsign>         → resolve_state_dir(<cs>) / "turn"
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+_CALLSIGN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+_APP_SUBDIR = "agency-os"
+
+
+def _xdg_state_home() -> Path:
+    """Resolve $XDG_STATE_HOME with the spec-mandated fallback to ~/.local/state."""
+    raw = os.environ.get("XDG_STATE_HOME", "").strip()
+    if raw:
+        path = Path(raw).expanduser()
+        if path.is_absolute():
+            return path
+    return Path.home() / ".local" / "state"
+
+
+def resolve_state_dir(callsign: str) -> Path:
+    """Return $XDG_STATE_HOME/agency-os/<callsign>/, creating it if missing.
+
+    Args:
+        callsign: agent callsign (alphanumeric, underscore, dash; must start
+            with a letter). Validated against `^[A-Za-z][A-Za-z0-9_-]*$`.
+
+    Returns:
+        Absolute Path to the per-callsign state directory. Permissions 0o700
+        (owner read/write/execute only) on directories created here.
+
+    Raises:
+        ValueError: callsign fails the regex (empty, contains path traversal
+            segments, or has special characters).
+        OSError: directory creation fails (unwritable parent, disk full,
+            permission denied). NOT swallowed — callers should know.
+    """
+    if not _CALLSIGN_RE.fullmatch(callsign):
+        raise ValueError(
+            f"invalid callsign for state path: {callsign!r} "
+            f"(must match {_CALLSIGN_RE.pattern})"
+        )
+    base = _xdg_state_home() / _APP_SUBDIR / callsign
+    base.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return base

--- a/tests/bot_common/test_state_paths.py
+++ b/tests/bot_common/test_state_paths.py
@@ -8,14 +8,12 @@ Covers:
 
 from __future__ import annotations
 
-import os
 import stat
 from pathlib import Path
 
 import pytest
 
 from src.bot_common import state_paths as sp
-
 
 # _xdg_state_home ────────────────────────────────────────────────────────────
 

--- a/tests/bot_common/test_state_paths.py
+++ b/tests/bot_common/test_state_paths.py
@@ -1,0 +1,120 @@
+"""tests for src/bot_common/state_paths.py — XDG_STATE_HOME state-dir helper.
+
+Covers:
+  - _xdg_state_home: default fallback / env override / relative-path fallback
+  - resolve_state_dir: happy path / env-override / dir auto-create / 0o700
+  - callsign validation: empty / traversal / special chars / leading digit
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from src.bot_common import state_paths as sp
+
+
+# _xdg_state_home ────────────────────────────────────────────────────────────
+
+
+def test_xdg_state_home_default(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert sp._xdg_state_home() == tmp_path / ".local" / "state"
+
+
+def test_xdg_state_home_env_override(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "custom"))
+    assert sp._xdg_state_home() == tmp_path / "custom"
+
+
+def test_xdg_state_home_relative_env_falls_back(monkeypatch, tmp_path) -> None:
+    """Spec says XDG_STATE_HOME must be absolute — relative values are ignored."""
+    monkeypatch.setenv("XDG_STATE_HOME", "relative/path")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert sp._xdg_state_home() == tmp_path / ".local" / "state"
+
+
+def test_xdg_state_home_empty_env_falls_back(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", "   ")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert sp._xdg_state_home() == tmp_path / ".local" / "state"
+
+
+# resolve_state_dir ──────────────────────────────────────────────────────────
+
+
+def test_resolve_state_dir_creates_under_xdg(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    p = sp.resolve_state_dir("max")
+    assert p == tmp_path / "agency-os" / "max"
+    assert p.is_dir()
+
+
+def test_resolve_state_dir_default_under_home(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    p = sp.resolve_state_dir("aiden")
+    assert p == tmp_path / ".local" / "state" / "agency-os" / "aiden"
+    assert p.is_dir()
+
+
+def test_resolve_state_dir_idempotent(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    p1 = sp.resolve_state_dir("orion")
+    p2 = sp.resolve_state_dir("orion")
+    assert p1 == p2
+    assert p1.is_dir()
+
+
+def test_resolve_state_dir_sets_owner_only_permissions(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    p = sp.resolve_state_dir("atlas")
+    mode = stat.S_IMODE(p.stat().st_mode)
+    # owner rwx (group + other should be unset; some systems mask differently
+    # so we assert group/world are no broader than empty)
+    assert mode & 0o700 == 0o700
+    assert mode & 0o077 == 0
+
+
+def test_resolve_state_dir_callsigns_are_isolated(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    a = sp.resolve_state_dir("elliot")
+    b = sp.resolve_state_dir("max")
+    assert a != b
+    assert a.parent == b.parent  # both under agency-os/
+
+
+# Callsign validation ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "../etc",
+        "max/sub",
+        "max\\sub",
+        "max.path",
+        "max ",
+        " max",
+        "1max",  # must start with letter
+        "max ../escape",
+        ".hidden",
+    ],
+)
+def test_resolve_state_dir_rejects_bad_callsign(bad, monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    with pytest.raises(ValueError, match="invalid callsign"):
+        sp.resolve_state_dir(bad)
+
+
+@pytest.mark.parametrize("good", ["max", "aiden", "orion-demo", "max_v2", "M1xeD"])
+def test_resolve_state_dir_accepts_valid_callsigns(good, monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    p = sp.resolve_state_dir(good)
+    assert p.name == good
+    assert p.is_dir()


### PR DESCRIPTION
## Summary

New tiny utility (`src/bot_common/state_paths.py`) closing the systemic SonarCloud S5443 ("publicly writable directory") finding that blocks both PR #754 and PR #756. Adopted per @aiden audit-derived analysis + @elliot Option A ratification 2026-05-12.

Replaces ad-hoc `/tmp/...` state-file paths with `$XDG_STATE_HOME/agency-os/<callsign>/` — the spec-correct location for per-user persistent machine state. Directories are owner-only (mode 0o700), and the callsign is regex-validated to prevent path injection.

## Public API

```python
resolve_state_dir(callsign: str) -> Path
```

Creates `$XDG_STATE_HOME/agency-os/<callsign>/` (fallback to `$HOME/.local/state/agency-os/<callsign>/` when `XDG_STATE_HOME` is unset or non-absolute, per the XDG Base Directory Specification). Raises `ValueError` on invalid callsigns.

## Migration targets (follow-up rebases on this PR)

| Legacy /tmp path | New path |
|---|---|
| `/tmp/.session_<callsign>` | `resolve_state_dir(<cs>) / "session"` |
| `/tmp/.msgidx_<callsign>`  | `resolve_state_dir(<cs>) / "msgidx"`  |
| `/tmp/.turn_<callsign>`    | `resolve_state_dir(<cs>) / "turn"`    |

This PR is the helper ONLY. Callsite migrations land in:
- PR #754 (anti-amnesia capsule) — rebase replaces `collect_recent_outbox` /tmp path
- PR #756 (messages-orphan fix) — rebase replaces handler's `session_state_dir` default
- Existing `.claude/hooks/session_store_posttooluse.sh` + `session_store_stop.sh` — separate PR

## Verification (Rule 6 — SAVE-CLAIM-REQUIRES-PROOF)

```
$ pytest tests/bot_common/test_state_paths.py
============================== 24 passed in 0.21s ==============================
```

24 cases cover:
- `_xdg_state_home`: env override, default fallback, relative-path ignore, empty-env fallback
- `resolve_state_dir`: dir auto-creation, 0o700 permissions, idempotency, callsign isolation
- callsign validation: 10 invalid rejections (empty, `../etc`, `max/sub`, `max\\sub`, `max.path`, leading/trailing space, `1max` leading digit, `max ../escape`, `.hidden`) + 5 valid acceptances (`max`, `aiden`, `orion-demo`, `max_v2`, `M1xeD`)

## Test plan

- [x] `pytest tests/bot_common/test_state_paths.py` — 24 pass in 0.21s
- [x] All callers sanitise callsigns upstream; helper re-validates at boundary (defense in depth)
- [x] No /tmp usage anywhere in the helper itself
- [x] mode 0o700 verified via `stat.S_IMODE(p.stat().st_mode)` assertion
- [x] XDG_STATE_HOME spec compliance: relative + empty env values fall back to `$HOME/.local/state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)