### PR TITLE
[ELLIOT] feat(central-listener): clone fan-out tag-filtered (Option B)

### DIFF
--- a/src/slack_bot/central_listener.py
+++ b/src/slack_bot/central_listener.py
@@ -137,7 +137,11 @@ governance_events: dict = {}
 
 CHANNEL_ROUTES: dict[str, list[str]] = {
     "C0B2PM3TV0B": ["elliot"],  # #ceo
-    "C0B3QB0K1GQ": ["elliot", "aiden", "max"],  # #execution
+    # Per Dave 2026-05-12 (Option B): clones added to #execution routing with
+    # tag-filtered fan-out via _is_clone_addressed(). Catches @atlas /
+    # @orion / @scout / [ATLAS] / [ORION] / [SCOUT] references so explicit
+    # dispatches reach clones; ambient team chatter does not.
+    "C0B3QB0K1GQ": ["elliot", "aiden", "max", "atlas", "orion", "scout"],
     "C0B2EJU53EK": ["aiden"],  # #alerts
     "C0B2U15PSEA": ["aiden"],  # #completed_directives
 }
@@ -146,15 +150,43 @@ CALLSIGN_TO_INBOX: dict[str, list[Path]] = {
     "elliot": [Path("/tmp/telegram-relay-elliot/inbox")],
     "aiden": [Path("/tmp/telegram-relay-aiden/inbox")],
     "max": [Path("/tmp/telegram-relay-max/inbox"), Path("/tmp/coo-inbox")],
+    "atlas": [Path("/tmp/telegram-relay-atlas/inbox")],
+    "orion": [Path("/tmp/telegram-relay-orion/inbox")],
+    "scout": [Path("/tmp/telegram-relay-scout/inbox")],
 }
 
 SELF_TAG_BY_CALLSIGN = {
     "elliot": "[ELLIOT]",
     "aiden": "[AIDEN]",
     "max": "[MAX]",
+    "atlas": "[ATLAS]",
+    "orion": "[ORION]",
+    "scout": "[SCOUT]",
 }
 
-KEEP_TAGS = ("[ELLIOT]", "[AIDEN]", "[MAX]", "[ENFORCER]", "[DAVE]")
+# Clones receive #execution messages only when explicitly addressed. Tag-filter
+# keeps ambient team chatter out of clone inboxes (otherwise every message
+# would spam every clone). Matches: @atlas / [ATLAS] / "Atlas — " / "Atlas:" /
+# "Atlas," / case-insensitive on the bare word too if at sentence start.
+CLONE_CALLSIGNS = frozenset({"atlas", "orion", "scout"})
+_CLONE_ADDRESS_PATTERNS = {
+    cs: re.compile(
+        rf"@{cs}\b|\[{cs}\]|\b{cs}\s+(?:—|:|,|—)|^{cs}\b",
+        re.IGNORECASE | re.MULTILINE,
+    )
+    for cs in CLONE_CALLSIGNS
+}
+
+KEEP_TAGS = (
+    "[ELLIOT]",
+    "[AIDEN]",
+    "[MAX]",
+    "[ATLAS]",
+    "[ORION]",
+    "[SCOUT]",
+    "[ENFORCER]",
+    "[DAVE]",
+)
 GROUP_CHAT_ID = -1003926592540
 
 
@@ -166,6 +198,24 @@ def sender_from(msg: dict) -> str:
     if msg.get("bot_id"):
         return "slackbot"
     return msg.get("user") or "human"
+
+
+def _is_clone_addressed(callsign: str, text: str) -> bool:
+    """Return True if a #execution message specifically addresses this clone.
+
+    Tag-filter for clone fan-out (Option B per Dave 2026-05-12). Catches:
+      - @atlas / @orion / @scout (Slack-style mention without lookup)
+      - [ATLAS] / [ORION] / [SCOUT] (callsign tag prefix or inline)
+      - "Atlas — ..." / "Atlas: ..." / "Atlas, ..." (direct address forms)
+      - "atlas " at the start of a line (case-insensitive)
+
+    Returns False for any message that does not specifically reference the
+    clone — keeps ambient team chatter out of clone inboxes.
+    """
+    pattern = _CLONE_ADDRESS_PATTERNS.get(callsign)
+    if pattern is None:
+        return False
+    return bool(pattern.search(text))
 
 
 def write_inbox(callsign: str, text: str, sender: str) -> None:
@@ -385,6 +435,10 @@ def process_event(event: dict, web: WebClient | None = None) -> None:
         for callsign in routes:
             self_tag = SELF_TAG_BY_CALLSIGN.get(callsign, "")
             if self_tag and text.startswith(self_tag):
+                continue
+            # Clones receive #execution messages only when explicitly addressed.
+            # Primes (elliot/aiden/max) always receive (existing behavior).
+            if callsign in CLONE_CALLSIGNS and not _is_clone_addressed(callsign, text):
                 continue
             write_inbox(callsign, text, sender)
         logger.info(

--- a/src/slack_bot/central_listener.py
+++ b/src/slack_bot/central_listener.py
@@ -146,13 +146,19 @@ CHANNEL_ROUTES: dict[str, list[str]] = {
     "C0B2U15PSEA": ["aiden"],  # #completed_directives
 }
 
+# NOSONAR: /tmp/telegram-relay-<callsign>/inbox paths are the production contract
+# with the per-callsign inbox-watcher systemd units (e.g. atlas-inbox-watcher.service).
+# The listener writes INTO these dirs; the watcher services create them with
+# restrictive modes. Migration to $XDG_STATE_HOME is a Phase 2 candidate per the
+# 2026-05-12 memory audit (Pattern A — unclosed migrations). Don't migrate here
+# without also updating watcher unit files in lockstep.
 CALLSIGN_TO_INBOX: dict[str, list[Path]] = {
-    "elliot": [Path("/tmp/telegram-relay-elliot/inbox")],
-    "aiden": [Path("/tmp/telegram-relay-aiden/inbox")],
-    "max": [Path("/tmp/telegram-relay-max/inbox"), Path("/tmp/coo-inbox")],
-    "atlas": [Path("/tmp/telegram-relay-atlas/inbox")],
-    "orion": [Path("/tmp/telegram-relay-orion/inbox")],
-    "scout": [Path("/tmp/telegram-relay-scout/inbox")],
+    "elliot": [Path("/tmp/telegram-relay-elliot/inbox")],  # NOSONAR S5443
+    "aiden": [Path("/tmp/telegram-relay-aiden/inbox")],  # NOSONAR S5443
+    "max": [Path("/tmp/telegram-relay-max/inbox"), Path("/tmp/coo-inbox")],  # NOSONAR S5443
+    "atlas": [Path("/tmp/telegram-relay-atlas/inbox")],  # NOSONAR S5443
+    "orion": [Path("/tmp/telegram-relay-orion/inbox")],  # NOSONAR S5443
+    "scout": [Path("/tmp/telegram-relay-scout/inbox")],  # NOSONAR S5443
 }
 
 SELF_TAG_BY_CALLSIGN = {
@@ -419,6 +425,22 @@ def run_enforcer(event: dict, text: str, web: WebClient) -> None:
     _fire_violation(result, web)
 
 
+def _fanout_to_routes(routes: list[str], text: str, sender: str) -> None:
+    """Fan out a #execution-channel message to each callsign's inbox.
+
+    Skips self-tagged messages (e.g. [ELLIOT] prefix → elliot's inbox).
+    Skips ambient messages for clones (atlas/orion/scout) unless explicitly
+    addressed via _is_clone_addressed(). Primes always receive.
+    """
+    for callsign in routes:
+        self_tag = SELF_TAG_BY_CALLSIGN.get(callsign, "")
+        if self_tag and text.startswith(self_tag):
+            continue
+        if callsign in CLONE_CALLSIGNS and not _is_clone_addressed(callsign, text):
+            continue
+        write_inbox(callsign, text, sender)
+
+
 def process_event(event: dict, web: WebClient | None = None) -> None:
     if event.get("type") != "message":
         return
@@ -429,22 +451,11 @@ def process_event(event: dict, web: WebClient | None = None) -> None:
     text = event.get("text") or ""
     if not text:
         return
-    # FANOUT
     if routes:
-        sender = sender_from(event)
-        for callsign in routes:
-            self_tag = SELF_TAG_BY_CALLSIGN.get(callsign, "")
-            if self_tag and text.startswith(self_tag):
-                continue
-            # Clones receive #execution messages only when explicitly addressed.
-            # Primes (elliot/aiden/max) always receive (existing behavior).
-            if callsign in CLONE_CALLSIGNS and not _is_clone_addressed(callsign, text):
-                continue
-            write_inbox(callsign, text, sender)
+        _fanout_to_routes(routes, text, sender_from(event))
         logger.info(
             "fanout %s ts=%s -> %s (%dch)", channel, event.get("ts", "?"), routes, len(text)
         )
-    # ENFORCER (only on #execution)
     if web is not None:
         try:
             run_enforcer(event, text, web)

--- a/tests/slack_bot/test_central_listener_clone_fanout.py
+++ b/tests/slack_bot/test_central_listener_clone_fanout.py
@@ -1,0 +1,189 @@
+"""tests for clone fan-out tag-filter (Option B, Dave 2026-05-12).
+
+Per Dave directive ts 1778557944: clones (atlas/orion/scout) added to
+#execution routing with tag-filtered fan-out via _is_clone_addressed().
+Prevents the "Slack-#execution post never reaches clone" gap that surfaced
+when audit Stream 1 dispatch was missed by Orion + Atlas.
+
+Tests verify:
+  - Clones receive #execution messages when specifically addressed
+  - Clones do NOT receive ambient #execution messages
+  - Primes (elliot/aiden/max) always receive (unchanged behavior)
+  - Self-tag skip still applies to clones
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Stub slack_sdk before module import (same pattern as PR #711)
+for mod_name in (
+    "slack_sdk",
+    "slack_sdk.socket_mode",
+    "slack_sdk.socket_mode.request",
+    "slack_sdk.socket_mode.response",
+    "slack_sdk.web",
+):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+sys.modules["slack_sdk.socket_mode"].SocketModeClient = type("SocketModeClient", (), {})
+sys.modules["slack_sdk.socket_mode.request"].SocketModeRequest = type("SocketModeRequest", (), {})
+sys.modules["slack_sdk.socket_mode.response"].SocketModeResponse = type("SocketModeResponse", (), {})
+sys.modules["slack_sdk.web"].WebClient = type("WebClient", (), {})
+
+from src.slack_bot.central_listener import (  # noqa: E402
+    CALLSIGN_TO_INBOX,
+    CHANNEL_ROUTES,
+    CLONE_CALLSIGNS,
+    _is_clone_addressed,
+    process_event,
+)
+
+EXECUTION_CHANNEL = "C0B3QB0K1GQ"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CONFIG SHAPE TESTS — verify clones added to routing + inbox dicts
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_clones_routed_in_execution() -> None:
+    """All 3 clones in #execution routes (Option B per Dave 2026-05-12)."""
+    routes = CHANNEL_ROUTES[EXECUTION_CHANNEL]
+    assert "atlas" in routes
+    assert "orion" in routes
+    assert "scout" in routes
+
+
+def test_clones_have_inbox_paths() -> None:
+    """Each clone has a CALLSIGN_TO_INBOX entry pointing at telegram-relay-<cs>."""
+    for cs in ("atlas", "orion", "scout"):
+        assert cs in CALLSIGN_TO_INBOX
+        assert any(f"telegram-relay-{cs}" in str(p) for p in CALLSIGN_TO_INBOX[cs])
+
+
+def test_clone_callsigns_constant() -> None:
+    """CLONE_CALLSIGNS is the frozenset used by the fan-out filter."""
+    assert CLONE_CALLSIGNS == frozenset({"atlas", "orion", "scout"})
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ADDRESS-FILTER TESTS — _is_clone_addressed
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "@atlas dispatching empirical test",
+        "[ATLAS] post-PR-712 smoke verify",
+        "Atlas — picking up the next task",
+        "Atlas: please run the mem0 investigation",
+        "Atlas, can you smoke-test the gemini pivot?",
+        "atlas\nyou are READY",  # line-start, case-insensitive
+    ],
+)
+def test_atlas_addressed_match(text: str) -> None:
+    """Each form of addressing Atlas matches the filter."""
+    assert _is_clone_addressed("atlas", text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Random ambient chatter about PR #732",
+        "@aiden + @max sweep complete",
+        "Holding for next dispatch",
+        "the atlasing concept is interesting",  # bare word in middle, no boundary form
+    ],
+)
+def test_atlas_not_addressed_no_match(text: str) -> None:
+    """Ambient #execution chatter doesn't trigger atlas fan-out."""
+    assert not _is_clone_addressed("atlas", text)
+
+
+def test_orion_address_independent_of_atlas() -> None:
+    """Orion-addressed message does NOT trigger atlas filter."""
+    assert _is_clone_addressed("orion", "@orion start the filesystem audit")
+    assert not _is_clone_addressed("atlas", "@orion start the filesystem audit")
+
+
+def test_scout_address_independent() -> None:
+    """Scout filter only fires on scout-addressed messages."""
+    assert _is_clone_addressed("scout", "[SCOUT] attribution audit ping")
+    assert not _is_clone_addressed("atlas", "[SCOUT] attribution audit ping")
+    assert not _is_clone_addressed("orion", "[SCOUT] attribution audit ping")
+
+
+def test_unknown_callsign_returns_false() -> None:
+    """Non-clone callsign returns False (defensive)."""
+    assert not _is_clone_addressed("dave", "anything")
+    assert not _is_clone_addressed("elliot", "@elliot test")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# PROCESS_EVENT FAN-OUT TESTS — verify clones receive only addressed messages
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _event(text: str) -> dict:
+    return {"type": "message", "channel": EXECUTION_CHANNEL, "text": text, "ts": "1.0"}
+
+
+def test_addressed_clone_receives(tmp_path: Path) -> None:
+    """When #execution message addresses a clone, write_inbox fires for that clone."""
+    inbox_atlas = tmp_path / "atlas_inbox"
+    inbox_atlas.mkdir()
+    with patch.dict(CALLSIGN_TO_INBOX, {"atlas": [inbox_atlas]}):
+        process_event(_event("@atlas run the mem0 investigation"))
+    files = list(inbox_atlas.iterdir())
+    assert len(files) == 1
+
+
+def test_ambient_clone_skipped(tmp_path: Path) -> None:
+    """When #execution message does NOT address a clone, clone inbox stays empty."""
+    inbox_atlas = tmp_path / "atlas_inbox"
+    inbox_atlas.mkdir()
+    with patch.dict(CALLSIGN_TO_INBOX, {"atlas": [inbox_atlas]}):
+        process_event(_event("Random status update about PR #732 [STATE:max] merged"))
+    files = list(inbox_atlas.iterdir())
+    assert len(files) == 0
+
+
+def test_primes_always_receive(tmp_path: Path) -> None:
+    """Primes (elliot/aiden/max) receive every #execution message regardless of address."""
+    inbox_elliot = tmp_path / "elliot_inbox"
+    inbox_aiden = tmp_path / "aiden_inbox"
+    inbox_max = tmp_path / "max_inbox"
+    for p in (inbox_elliot, inbox_aiden, inbox_max):
+        p.mkdir()
+    with patch.dict(
+        CALLSIGN_TO_INBOX,
+        {"elliot": [inbox_elliot], "aiden": [inbox_aiden], "max": [inbox_max]},
+    ):
+        process_event(_event("Ambient team chatter, no clone mention"))
+    assert len(list(inbox_elliot.iterdir())) == 1
+    assert len(list(inbox_aiden.iterdir())) == 1
+    assert len(list(inbox_max.iterdir())) == 1
+
+
+def test_dispatch_reaches_targeted_clone_only(tmp_path: Path) -> None:
+    """A message addressing one clone should reach only that clone, not the others."""
+    inbox_atlas = tmp_path / "atlas_inbox"
+    inbox_orion = tmp_path / "orion_inbox"
+    inbox_scout = tmp_path / "scout_inbox"
+    for p in (inbox_atlas, inbox_orion, inbox_scout):
+        p.mkdir()
+    with patch.dict(
+        CALLSIGN_TO_INBOX,
+        {"atlas": [inbox_atlas], "orion": [inbox_orion], "scout": [inbox_scout]},
+    ):
+        process_event(_event("[DISPATCH] @atlas please re-run the empirical smoke test"))
+    assert len(list(inbox_atlas.iterdir())) == 1
+    assert len(list(inbox_orion.iterdir())) == 0
+    assert len(list(inbox_scout.iterdir())) == 0


### PR DESCRIPTION
## Summary

Per Dave directive 2026-05-12 (ts 1778557944 "Yes implement option b"): closes the chat→inbox fan-out gap that surfaced tonight when Stream 1 audit assignments addressed to @atlas + @orion in #execution silently dropped because the central listener routed #execution only to elliot/aiden/max.

## Changes

- `src/slack_bot/central_listener.py` (+56 -2):
  - `CHANNEL_ROUTES["#execution"]` now includes atlas/orion/scout
  - `CALLSIGN_TO_INBOX` extended with clone paths (`/tmp/telegram-relay-<cs>/inbox`)
  - `SELF_TAG_BY_CALLSIGN` + `KEEP_TAGS` extended for symmetry
  - `CLONE_CALLSIGNS = frozenset({"atlas", "orion", "scout"})`
  - New `_is_clone_addressed()` filter: clones only receive messages explicitly addressed (`@atlas` / `[ATLAS]` / `Atlas — ` / `Atlas:` / `Atlas,` / line-start `Atlas`). Ambient team chatter filtered out.
  - Primes (elliot/aiden/max) unchanged — receive every #execution message.
- `tests/slack_bot/test_central_listener_clone_fanout.py` (+189): 20 tests covering config shape, address-filter forms, fan-out behavior, defensive edge cases.

## Verification

```
$ ruff check src/slack_bot/central_listener.py tests/slack_bot/test_central_listener_clone_fanout.py
All checks passed!

$ ruff format src/slack_bot/central_listener.py tests/slack_bot/test_central_listener_clone_fanout.py --check
2 files already formatted

$ pytest tests/slack_bot/test_central_listener_clone_fanout.py -v
20 passed in 0.27s
```

## Test plan

- [x] Each address form matches the filter (`@atlas` / `[ATLAS]` / `Atlas — `/`Atlas: `/`Atlas,` / line-start bare)
- [x] Ambient chatter (no clone reference) does NOT trigger fan-out
- [x] Cross-clone independence: addressing one clone doesn't fan out to others
- [x] Primes always receive (regression guard on existing behavior)
- [x] `_is_clone_addressed("dave", ...)` and unknown callsigns return False
- [ ] Post-merge: listener restart → empirical verify with `@atlas test` and ambient message

## Post-merge

Restart central listener (5s op) so the new route map + filter activate at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)