### PR TITLE
[ELLIOT] feat(skills): slack-file-upload — files_upload_v2 wrapper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -88,6 +88,13 @@ arize-phoenix-otel>=0.16.0,<1.0.0  # Phoenix OTLP tracer registration
 # 20260512_0115). ~3x cheaper than Anthropic Haiku for this payload shape.
 google-genai>=0.8.0
 
+# === Slack ===
+# Used by src/slack_bot/central_listener.py (socket-mode listener) +
+# skills/slack-file-upload/upload.py (files_upload_v2 wrapper). The package
+# was installed at deploy time pre-2026-05-12 but never declared here —
+# new envs failed silently. Added during the slack-file-upload skill build.
+slack_sdk>=3.41.0,<4.0.0
+
 # === Testing ===
 pytest>=7.4.0
 pytest-asyncio>=0.21.0

--- a/skills/slack-file-upload/SKILL.md
+++ b/skills/slack-file-upload/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: slack-file-upload
+description: Upload a file (e.g. .md audit doc) as a Slack file attachment to a named channel.
+---
+
+# Slack File Upload
+
+Upload a file as a Slack attachment. Wraps `files_upload_v2` (3-step external upload API) via the slack_sdk WebClient.
+
+## When to invoke
+
+- Posting audit docs to #ceo (e.g. `docs/audits/*.md`)
+- Sharing pipeline reports or exports to #execution or #completed_directives
+- Any time a file attachment is preferable to an inline paste
+
+## Required env vars
+
+| Var | Source | Notes |
+|-----|--------|-------|
+| `SLACK_BOT_TOKEN` | `/home/elliotbot/.config/agency-os/.env` | `xoxb-...` bot token |
+| `CALLSIGN` | env or `IDENTITY.md` | Prefix tag; defaults to `elliot` |
+
+## Required bot scope
+
+`files:write` — must be added to the Agency OS Slack App before this skill can upload. Without it the API returns `missing_scope`.
+
+> **Status (2026-05-12):** scope not yet granted. Tests are 100% mocked. Grant scope via api.slack.com → Your Apps → Agency OS → OAuth & Permissions → Bot Token Scopes → Add `files:write` → reinstall app.
+
+## Channel name → ID map
+
+| Name | ID |
+|------|----|
+| `ceo` | `C0B2PM3TV0B` |
+| `execution` | `C0B3QB0K1GQ` |
+| `alerts` | `C0B2EJU53EK` |
+| `completed_directives` | `C0B2U15PSEA` |
+| `ops` | `C0B2UCNRJ86` |
+
+Pass either the friendly name or the raw `C...` ID — the script resolves both.
+
+## Invocation
+
+```bash
+python /home/elliotbot/clawd/skills/slack-file-upload/upload.py <channel> <file_path> [--title=<title>] [--comment=<comment>]
+```
+
+### Arguments
+
+| Arg | Required | Description |
+|-----|----------|-------------|
+| `channel` | yes | Channel name (e.g. `ceo`) or ID (e.g. `C0B2PM3TV0B`) |
+| `file_path` | yes | Absolute or relative path to file to upload |
+| `--title=` | no | Display title shown in Slack (defaults to filename) |
+| `--comment=` | no | `initial_comment` posted alongside the file |
+
+The `[CALLSIGN_UPPER]` prefix is auto-prepended to `--comment` if not already present (mirrors `slack_relay.py` behaviour).
+
+## Examples
+
+```bash
+# Upload audit doc to #ceo
+python /home/elliotbot/clawd/skills/slack-file-upload/upload.py ceo \
+    docs/audits/memory_audit_2026-05-12.md \
+    --title="Memory Audit Synthesis" \
+    --comment="[ELLIOT] Phase 1 complete"
+
+# Upload to channel ID directly, no title
+python /home/elliotbot/clawd/skills/slack-file-upload/upload.py C0B3QB0K1GQ \
+    /tmp/report.md \
+    --comment="Pipeline run summary"
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success — file uploaded and shared |
+| `1` | Network or Slack API error (check stderr) |
+| `2` | Missing `SLACK_BOT_TOKEN`, missing scope, or disallowed channel |
+| `3` | File not found, or invalid / missing CLI arguments |
+
+## Flow (what upload.py does internally)
+
+`files_upload_v2` orchestrates three Slack API calls automatically:
+1. `files.getUploadURLExternal` — obtains a pre-signed S3 upload URL
+2. HTTP PUT to the S3 URL — streams file bytes directly
+3. `files.completeUploadExternal` — associates the upload with the channel and posts `initial_comment`
+
+The SDK hides this complexity behind a single method call.

--- a/skills/slack-file-upload/test_upload.py
+++ b/skills/slack-file-upload/test_upload.py
@@ -1,0 +1,177 @@
+"""test_upload.py — pytest suite for slack-file-upload skill.
+
+All tests are 100% mocked — no real Slack API calls.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SKILL_DIR = Path(__file__).parent
+
+
+def _load_upload(monkeypatch, token: str = "xoxb-test") -> types.ModuleType:
+    """Import upload.py with SLACK_BOT_TOKEN set and slack_sdk mocked."""
+    monkeypatch.setenv("SLACK_BOT_TOKEN", token)
+    monkeypatch.setenv("CALLSIGN", "elliot")
+
+    # Provide a minimal slack_sdk stub so import doesn't require the real package
+    sdk_stub = types.ModuleType("slack_sdk")
+    web_stub = types.ModuleType("slack_sdk.web")
+    errors_stub = types.ModuleType("slack_sdk.errors")
+
+    class _SlackApiError(Exception):
+        def __init__(self, message: str, response: dict):
+            super().__init__(message)
+            self.response = response
+
+    errors_stub.SlackApiError = _SlackApiError
+    web_stub.WebClient = MagicMock()
+    sdk_stub.web = web_stub
+    sdk_stub.errors = errors_stub
+
+    sys.modules.setdefault("slack_sdk", sdk_stub)
+    sys.modules.setdefault("slack_sdk.web", web_stub)
+    sys.modules.setdefault("slack_sdk.errors", errors_stub)
+
+    if "upload" in sys.modules:
+        del sys.modules["upload"]
+
+    spec = importlib.util.spec_from_file_location("upload", SKILL_DIR / "upload.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Test 1: missing channel/path args → exit 3
+# ---------------------------------------------------------------------------
+
+
+def test_missing_args_exits_3(monkeypatch, capsys):
+    mod = _load_upload(monkeypatch)
+    with pytest.raises(SystemExit) as exc:
+        mod.main([])
+    assert exc.value.code == 3
+    captured = capsys.readouterr()
+    assert "usage" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: channel name "ceo" resolves to correct ID
+# ---------------------------------------------------------------------------
+
+
+def test_channel_name_resolution(monkeypatch):
+    mod = _load_upload(monkeypatch)
+    assert mod._resolve_channel("ceo") == "C0B2PM3TV0B"
+    assert mod._resolve_channel("#execution") == "C0B3QB0K1GQ"
+    # raw ID passthrough
+    assert mod._resolve_channel("C0B2EJU53EK") == "C0B2EJU53EK"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: missing SLACK_BOT_TOKEN → exit 2
+# ---------------------------------------------------------------------------
+
+
+def test_missing_token_exits_2(monkeypatch, tmp_path, capsys):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.setenv("CALLSIGN", "elliot")
+
+    if "upload" in sys.modules:
+        del sys.modules["upload"]
+
+    spec = importlib.util.spec_from_file_location("upload", SKILL_DIR / "upload.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    dummy = tmp_path / "f.md"
+    dummy.write_text("hello")
+
+    with pytest.raises(SystemExit) as exc:
+        mod.main(["ceo", str(dummy)])
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "SLACK_BOT_TOKEN" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Test 4: files_upload_v2 called with correct kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_called_with_correct_kwargs(monkeypatch, tmp_path):
+    mod = _load_upload(monkeypatch)
+
+    dummy = tmp_path / "report.md"
+    dummy.write_text("# Report")
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.get.return_value = {"id": "F123"}
+    mock_client.files_upload_v2.return_value = mock_response
+
+    with patch.object(
+        mod, "WebClient" if hasattr(mod, "WebClient") else "__builtins__", create=True
+    ):
+        # Patch the WebClient inside the module's imported namespace
+        import slack_sdk.web as _web
+
+        original = _web.WebClient
+        _web.WebClient = MagicMock(return_value=mock_client)
+        try:
+            mod.main(["ceo", str(dummy), "--title=My Report", "--comment=[ELLIOT] done"])
+        finally:
+            _web.WebClient = original
+
+    mock_client.files_upload_v2.assert_called_once()
+    kwargs = mock_client.files_upload_v2.call_args.kwargs
+    assert kwargs["channel"] == "C0B2PM3TV0B"
+    assert kwargs["title"] == "My Report"
+    assert kwargs["filename"] == "report.md"
+    assert kwargs["initial_comment"] == "[ELLIOT] done"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: callsign prefix auto-applied to comment when missing
+# ---------------------------------------------------------------------------
+
+
+def test_callsign_prefix_applied(monkeypatch):
+    mod = _load_upload(monkeypatch)
+    # comment without prefix
+    result = mod._prefix_comment("Phase 1 done", "[ELLIOT]")
+    assert result == "[ELLIOT] Phase 1 done"
+    # comment already prefixed — no double-tag
+    result2 = mod._prefix_comment("[ELLIOT] Phase 1 done", "[ELLIOT]")
+    assert result2 == "[ELLIOT] Phase 1 done"
+    # None comment → just the tag
+    result3 = mod._prefix_comment(None, "[ELLIOT]")
+    assert result3 == "[ELLIOT]"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: file not found → exit 3
+# ---------------------------------------------------------------------------
+
+
+def test_file_not_found_exits_3(monkeypatch, tmp_path, capsys):
+    mod = _load_upload(monkeypatch)
+    missing = tmp_path / "does_not_exist.md"
+
+    with pytest.raises(SystemExit) as exc:
+        mod.main(["ceo", str(missing)])
+    assert exc.value.code == 3
+    captured = capsys.readouterr()
+    assert "not found" in captured.err.lower()

--- a/skills/slack-file-upload/upload.py
+++ b/skills/slack-file-upload/upload.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""upload.py — Slack file-upload skill (slack-file-upload).
+
+Usage:
+    upload.py <channel> <file_path> [--title=<title>] [--comment=<comment>]
+
+Env:
+    SLACK_BOT_TOKEN  (required) — xoxb-... bot token
+    CALLSIGN         (optional) — default "elliot"; prefix tag for comment
+
+Exit codes:
+    0  success
+    1  network / Slack API error
+    2  missing token, missing scope, or disallowed channel
+    3  file not found or invalid / missing arguments
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Channel map (mirrors slack_relay.py CHANNELS dict — keep in sync)
+# ---------------------------------------------------------------------------
+CHANNELS: dict[str, str] = {
+    "execution": "C0B3QB0K1GQ",
+    "ceo": "C0B2PM3TV0B",
+    "alerts": "C0B2EJU53EK",
+    "completed_directives": "C0B2U15PSEA",
+    "ops": "C0B2UCNRJ86",
+}
+
+
+def _resolve_callsign() -> str:
+    env_val = os.environ.get("CALLSIGN", "").strip()
+    if env_val:
+        return env_val.lower()
+    identity_path = Path(__file__).resolve().parent.parent.parent / "Agency_OS" / "IDENTITY.md"
+    if identity_path.exists():
+        match = re.search(
+            r"^\s*\*\*?CALLSIGN:?\*\*?\s*([A-Za-z]\w*)",
+            identity_path.read_text(),
+            re.IGNORECASE | re.MULTILINE,
+        )
+        if match:
+            return match.group(1).lower()
+    return "elliot"
+
+
+def _resolve_channel(raw: str) -> str:
+    """Return channel ID. Accept friendly name or raw C... ID."""
+    return CHANNELS.get(raw.lstrip("#"), raw)
+
+
+def _parse_args(argv: list[str]) -> tuple[str, Path, str | None, str | None]:
+    """Return (channel_id, file_path, title, comment). Exit 3 on bad args."""
+    if len(argv) < 2:
+        print(
+            "ERROR: usage: upload.py <channel> <file_path> [--title=...] [--comment=...]",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+
+    channel_id = _resolve_channel(argv[0])
+    file_path = Path(argv[1])
+    title: str | None = None
+    comment: str | None = None
+
+    for arg in argv[2:]:
+        if arg.startswith("--title="):
+            title = arg[len("--title=") :]
+        elif arg.startswith("--comment="):
+            comment = arg[len("--comment=") :]
+        else:
+            print(f"ERROR: unknown argument: {arg}", file=sys.stderr)
+            sys.exit(3)
+
+    return channel_id, file_path, title, comment
+
+
+def _prefix_comment(comment: str | None, tag: str) -> str:
+    """Prepend [CALLSIGN] tag to comment if not already present."""
+    if not comment:
+        return tag
+    if comment.startswith(tag):
+        return comment
+    return f"{tag} {comment}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    channel_id, file_path, title, comment = _parse_args(argv)
+
+    if not file_path.exists():
+        print(f"ERROR: file not found: {file_path}", file=sys.stderr)
+        sys.exit(3)
+
+    token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    if not token:
+        print("ERROR: SLACK_BOT_TOKEN not set", file=sys.stderr)
+        sys.exit(2)
+
+    callsign = _resolve_callsign()
+    tag = f"[{callsign.upper()}]"
+    initial_comment = _prefix_comment(comment, tag)
+
+    try:
+        from slack_sdk.errors import SlackApiError
+        from slack_sdk.web import WebClient
+    except ImportError:
+        print("ERROR: slack_sdk not installed — run: pip install slack-sdk", file=sys.stderr)
+        sys.exit(1)
+
+    client = WebClient(token=token)
+    try:
+        response = client.files_upload_v2(
+            channel=channel_id,
+            file=str(file_path),
+            filename=file_path.name,
+            title=title or file_path.name,
+            initial_comment=initial_comment,
+        )
+    except SlackApiError as e:
+        error_code = e.response.get("error", "unknown")
+        if error_code == "missing_scope":
+            print("ERROR: missing_scope — add files:write to bot scopes", file=sys.stderr)
+            sys.exit(2)
+        print(f"ERROR: Slack API error: {error_code}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"ERROR: network failure: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    file_id = response.get("file", {}).get("id", "unknown")
+    print(f"OK: uploaded {file_path.name} to {channel_id} (file_id={file_id})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/slack-file-upload/upload.py
+++ b/skills/slack-file-upload/upload.py
@@ -132,7 +132,7 @@ def main(argv: list[str] | None = None) -> int:
             sys.exit(2)
         print(f"ERROR: Slack API error: {error_code}", file=sys.stderr)
         sys.exit(1)
-    except Exception as e:
+    except (OSError, ConnectionError, TimeoutError) as e:
         print(f"ERROR: network failure: {e}", file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
## Summary

- New skill at `skills/slack-file-upload/` — Python CLI wrapper around `slack_sdk.WebClient.files_upload_v2()` for uploading files to Slack channels
- Channel name resolution (ceo / execution / alerts / completed_directives) + callsign-prefixed initial_comment + standard exit-code contract (0/1/2/3)
- Adds `slack_sdk>=3.41.0,<4.0.0` to requirements.txt (pre-existing gap — imported by `src/slack_bot/central_listener.py` but never declared)

## Why

Dave directive 2026-05-12 (ts 1778559189): "Research how to upload then implement it to have the skill of uploading files to slack". The existing `tg` / `slack_relay.py` chat-post path doesn't support file uploads. The audit synthesis .md needed to be posted as a real Slack file in #ceo, not just inline body text.

## Implementation

The SDK's `files_upload_v2()` hides Slack's 3-step API:
1. `files.getUploadURLExternal` → obtain presigned S3 URL
2. HTTP PUT file bytes to that URL
3. `files.completeUploadExternal` → associate with channel + post `initial_comment`

The wrapper exposes that as a single CLI call with sensible defaults (callsign prefix, channel name resolution, exit codes).

## Test plan

- [x] 6 mocked unit tests pass: argv parsing, channel resolution, missing token (exit 2), SDK kwargs, callsign prefix, file-not-found (exit 3)
- [x] Ruff check + format clean
- [x] Empirical end-to-end test: `python skills/slack-file-upload/upload.py ceo docs/audits/memory_audit_2026-05-12.md "--title=..." "--comment=..."` returned `OK: uploaded memory_audit_2026-05-12.md to C0B2PM3TV0B (file_id=F0B301QKB6X)`. File visible in #ceo as a real attachment.

## Scope notes

- Bot now has `files:write` scope added by Dave at 2026-05-12 ~04:20 UTC. Verified via `auth.test` response `x-oauth-scopes` header.
- Skill files duplicated at `/home/elliotbot/clawd/skills/slack-file-upload/` (build agent's output location). Audit Phase 1 flagged the clawd/skills vs Agency_OS/skills drift as Pattern A — separate Phase 2 candidate; not addressed here.

## Concur

Sub-agent build (build-2) authored the implementation; Elliot reviewed + tested empirically + opened the PR. Dual concur from Aiden + Max requested per dual-CTO rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)