### PR TITLE
[AIDEN] feat(cognee): Phase 0 wrapper + smoke runner + README

### DIFF
--- a/scripts/cognee_smoke.py
+++ b/scripts/cognee_smoke.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""cognee_smoke.py — Phase 0 smoke test for Cognee integration.
+
+Drives `src.cognee.client` through the directive's add → cognify → search
+sequence and asserts both verify conditions. Captures stdout for the Phase 0
+evidence items (#ceo post) and returns exit code 0 (pass) / 2 (fail) so CI +
+shell pipelines can gate on it.
+
+Usage (after [READY:atlas] + GEMINI_API_KEY present in .env):
+
+    python3 scripts/cognee_smoke.py
+
+Override scope (defaults match the directive smoke test verbatim):
+
+    python3 scripts/cognee_smoke.py \
+        --org-id keiracom_platform --app-id agency_os --agent-id aiden
+
+The assertion content + query are fixed to the directive spec so this script
+is the canonical Phase 0 → Phase 1 gate check; not parameterised on payload.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import traceback
+
+# Fixed per Phase 0 directive (Elliot dispatch ts 1778562982 step 5).
+SMOKE_CONTENT = (
+    "Agency OS uses DFS domain_metrics_by_categories as the sole working "
+    "discovery endpoint for AU dental."
+)
+SMOKE_QUERY = "What is the Agency OS discovery endpoint?"
+EXPECTED_TOKEN = "domain_metrics_by_categories"
+
+
+async def _run(org_id: str, app_id: str, agent_id: str) -> int:
+    from src.cognee.client import add, cognify, search
+
+    print(f"[smoke] add → dataset={org_id}__{app_id} agent={agent_id} node_set=[test]")
+    await add(
+        SMOKE_CONTENT,
+        org_id=org_id,
+        app_id=app_id,
+        agent_id=agent_id,
+        node_set=["test"],
+    )
+
+    print("[smoke] cognify → processing pending data into graph + embeddings")
+    await cognify()
+
+    print(f"[smoke] search → {SMOKE_QUERY!r}")
+    results = await search(SMOKE_QUERY, org_id=org_id, app_id=app_id)
+
+    print(f"[smoke] results: {results!r}")
+
+    # Assertion 1 — Phase 0 evidence item 2
+    if not results or len(results) == 0:
+        print("[smoke] FAIL — assertion 1: len(results) > 0 → False (0 results)")
+        return 2
+    print(f"[smoke] PASS — assertion 1: len(results) > 0 → True ({len(results)} result(s))")
+
+    # Assertion 2 — Phase 0 evidence item 3
+    results_text = str(results)
+    if EXPECTED_TOKEN not in results_text:
+        print(f"[smoke] FAIL — assertion 2: {EXPECTED_TOKEN!r} in results → False")
+        print(f"[smoke] results snippet: {results_text[:500]}")
+        return 2
+    print(f"[smoke] PASS — assertion 2: {EXPECTED_TOKEN!r} in results → True")
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--org-id", default="keiracom_platform")
+    parser.add_argument("--app-id", default="agency_os")
+    parser.add_argument("--agent-id", default="aiden")
+    args = parser.parse_args()
+
+    try:
+        return asyncio.run(_run(args.org_id, args.app_id, args.agent_id))
+    except Exception:
+        print("[smoke] FAIL — exception during smoke run:")
+        traceback.print_exc()
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cognee_smoke.py
+++ b/scripts/cognee_smoke.py
@@ -25,6 +25,46 @@ import argparse
 import asyncio
 import sys
 import traceback
+from pathlib import Path
+
+# Make the repo root importable so `from src.cognee.client import ...` works
+# when this script is invoked directly. The script lives at scripts/, so the
+# repo root is two parents up from __file__.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# --- .env pre-flight ---
+# Load /home/elliotbot/.config/agency-os/.env if not already in environment.
+# Cognee 1.0.9 reads pydantic-settings discrete env vars (DB_HOST, DB_PORT,
+# DB_USERNAME, DB_PASSWORD, DB_NAME and VECTOR_DB_* equivalents) — not a single
+# URL. Our .env stores connection info as DATABASE_URL_MIGRATIONS (postgres URL,
+# port 5432 / session mode). Parse it and inject the discrete vars Cognee
+# expects when they're absent from os.environ.
+import os
+from urllib.parse import urlparse
+
+
+def _inject_cognee_db_vars() -> None:
+    db_url = os.environ.get("DATABASE_URL_MIGRATIONS") or os.environ.get("DATABASE_URL")
+    if not db_url:
+        return
+    p = urlparse(db_url)
+    discrete = {
+        "DB_HOST": p.hostname or "",
+        "DB_PORT": str(p.port or ""),
+        "DB_USERNAME": p.username or "",
+        "DB_PASSWORD": p.password or "",
+        "DB_NAME": p.path.lstrip("/") or "postgres",
+        "VECTOR_DB_HOST": p.hostname or "",
+        "VECTOR_DB_PORT": str(p.port or ""),
+        "VECTOR_DB_USERNAME": p.username or "",
+        "VECTOR_DB_PASSWORD": p.password or "",
+        "VECTOR_DB_NAME": p.path.lstrip("/") or "postgres",
+    }
+    for k, v in discrete.items():
+        os.environ.setdefault(k, v)
+
+
+_inject_cognee_db_vars()
 
 # Fixed per Phase 0 directive (Elliot dispatch ts 1778562982 step 5).
 SMOKE_CONTENT = (
@@ -37,6 +77,16 @@ EXPECTED_TOKEN = "domain_metrics_by_categories"
 
 async def _run(org_id: str, app_id: str, agent_id: str) -> int:
     from src.cognee.client import add, cognify, search
+
+    # One-time bootstrap of Cognee's relational schema. Cognee's HTTP server
+    # (cognee.api.client:app) calls this at startup; the in-process SDK path
+    # we use in this wrapper needs it explicitly. Idempotent — safe on re-run.
+    from cognee.infrastructure.databases.relational.create_db_and_tables import (
+        create_db_and_tables,
+    )
+
+    print("[smoke] bootstrap → cognee.create_db_and_tables() (idempotent)")
+    await create_db_and_tables()
 
     print(f"[smoke] add → dataset={org_id}__{app_id} agent={agent_id} node_set=[test]")
     await add(

--- a/src/cognee/README.md
+++ b/src/cognee/README.md
@@ -1,0 +1,112 @@
+# src/cognee — Agency OS Cognee Wrapper
+
+**Sole call surface** for the [Cognee](https://github.com/topoteretes/cognee) knowledge-graph + memory layer. All Cognee usage in the Agency OS codebase MUST import from `src.cognee.client`. Direct `import cognee` outside this module is forbidden (LAW XII Skills-First; keeps tenant naming + agent provenance consistent).
+
+## When to use
+
+Reach for this wrapper when you need:
+
+- **Knowledge graph storage** with semantic search over agent activity / domain facts
+- **Cross-agent memory** scoped to a tenant (org+app) with per-agent provenance
+- **LLM-extracted entity / relationship retrieval** (Gemini 2.5 Flash via Cognee's LiteLLM bridge as of 2026-05-12)
+
+Don't use it for: raw key-value caching (Redis), structured business data (Supabase tables), or short-term session state (`public.agent_memories`).
+
+## API
+
+All functions are `async`. Import:
+
+```python
+from src.cognee.client import add, search, cognify, memify
+```
+
+### Tenant + agent encoding
+
+Every call is scoped by three IDs:
+
+- `org_id` — top-level tenant (e.g. `keiracom_platform`)
+- `app_id` — sub-tenant within an org (e.g. `agency_os`)
+- `agent_id` — writing agent (e.g. `aiden`, `max`, `orion`)
+
+Internally encoded as:
+
+```
+dataset_name = f"{org_id}__{app_id}"          # "keiracom_platform__agency_os"
+node_set     = [f"agent:{agent_id}", ...extras]  # ["agent:aiden", "test"]
+```
+
+Every chunk you `add()` carries the writing agent's tag automatically. `search()` can optionally filter to a specific agent.
+
+### Calls
+
+```python
+# Add content with caller-supplied extra tags
+await add(
+    "Some fact about the codebase.",
+    org_id="keiracom_platform", app_id="agency_os",
+    agent_id="aiden", node_set=["audit", "phase0"],
+)
+
+# Process pending adds into the knowledge graph + embeddings
+await cognify()
+
+# Optional second-pass memory enrichment over the cognified graph
+await memify()
+
+# Semantic search across all agents in this org+app
+results = await search(
+    "What discovery endpoint do we use?",
+    org_id="keiracom_platform", app_id="agency_os",
+)
+
+# Or scope to a single agent's writes
+results = await search(
+    "What did aiden touch in Phase 0?",
+    org_id="keiracom_platform", app_id="agency_os", agent_id="aiden",
+)
+```
+
+`add()` requires `agent_id` (provenance is mandatory on writes). `search()` makes it optional (defaults to all-agents).
+
+## Configuration
+
+Wrapper is **provider-agnostic**. Backing stores + LLM are read from `/home/elliotbot/.config/agency-os/.env`:
+
+| Concern    | Env var(s)                                | Value (2026-05-12)              |
+|------------|-------------------------------------------|---------------------------------|
+| LLM        | `LLM_PROVIDER`, `LLM_MODEL`, `GEMINI_API_KEY` | gemini / gemini-2.5-flash    |
+| Embedding  | `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`   | gemini / text-embedding-004     |
+| Vector DB  | `VECTOR_DB_PROVIDER`, `VECTOR_DB_URL`     | pgvector on `$SUPABASE_DB_URL`  |
+| Relational | `DB_PROVIDER`, `DB_URL`                   | sqlalchemy on `$SUPABASE_DB_URL`|
+| Graph DB   | `GRAPH_DB_PROVIDER`, `GRAPH_DB_PATH`      | kuzu / `~/clawd/cognee_graph/`  |
+
+Cognee's own HTTP API server runs as `systemd --user cognee.service` on `127.0.0.1:8000` (separate from this wrapper — wrapper calls the SDK in-process).
+
+## Smoke test
+
+```bash
+python3 scripts/cognee_smoke.py
+```
+
+Drives the directive's `add → cognify → search` sequence + asserts the two Phase 0 conditions. Exit code 0 (pass) / 2 (fail). See the script docstring for override flags.
+
+## Extending
+
+Add new methods to `src/cognee/client.py` only — never bypass with a direct `import cognee` elsewhere. Patterns for Phase 2+:
+
+- `delete(node_set, *, org_id, app_id)` — soft-delete chunks matching a tag
+- `update(content, *, chunk_id)` — replace a specific chunk's content
+- `prune(*, org_id, app_id, older_than)` — bulk-clean stale chunks per tenant
+
+Each extension MUST:
+
+1. Accept `org_id` + `app_id` (tenant scoping) — no global ops
+2. Encode through the same `_dataset_name` + `_agent_node_set` helpers if it touches writes
+3. Add unit tests with mocked Cognee SDK to `tests/cognee/test_client.py`
+
+## See also
+
+- `scripts/cognee_smoke.py` — Phase 0 verify runner
+- `scripts/cognee_ingest.py` — batch ingestion (Max, Phase 1)
+- `continuous_ingest.py` — continuous hook ingestion (Orion, Phase 1)
+- `/home/elliotbot/.config/systemd/user/cognee.service` — API server unit

--- a/src/cognee/README.md
+++ b/src/cognee/README.md
@@ -31,11 +31,15 @@ Every call is scoped by three IDs:
 Internally encoded as:
 
 ```
-dataset_name = f"{org_id}__{app_id}"          # "keiracom_platform__agency_os"
-node_set     = [f"agent:{agent_id}", ...extras]  # ["agent:aiden", "test"]
+user.email     = f"{org_id}@keiracom.local"        # mints per-tenant Cognee User
+user.tenant_id = org_id                            # propagates to dataset UUID
+dataset_name   = f"{org_id}__{app_id}"             # "keiracom_platform__agency_os"
+node_set       = [f"agent:{agent_id}", ...extras]  # ["agent:aiden", "test"]
 ```
 
 Every chunk you `add()` carries the writing agent's tag automatically. `search()` can optionally filter to a specific agent.
+
+**Cross-tenant isolation (Scout Q4, Elliot amendment ts 1778565xxx):** the wrapper auto-mints one Cognee User per `org_id` on first use (idempotent — looked up by email, then created if absent). Cognee derives `dataset.id = uuid5(NAMESPACE_OID, f"{dataset_name}{user.id}{user.tenant_id}")` and enforces per-user permission rows at the auth layer, so distinct `org_id` callers cannot read each other's datasets even if they pass the same `dataset_name` string. The User cache is process-local; the SDK-side User store is durable.
 
 ### Calls
 

--- a/src/cognee/__init__.py
+++ b/src/cognee/__init__.py
@@ -1,0 +1,5 @@
+"""Cognee integration package — sole call surface is src.cognee.client."""
+
+from src.cognee.client import add, cognify, memify, search
+
+__all__ = ["add", "cognify", "memify", "search"]

--- a/src/cognee/client.py
+++ b/src/cognee/client.py
@@ -5,9 +5,19 @@ all Cognee usage in this codebase MUST go through these four functions. Direct
 imports of the cognee SDK outside this module are forbidden — keeps the multi-
 tenant naming convention + agent-scoped node_set tagging consistent.
 
-Tenant encoding (per Dave gap-3 resolution):
-    dataset_name = f"{org_id}__{app_id}"      # e.g. "keiracom_platform__agency_os"
-    node_set     = [f"agent:{agent_id}"] + extras  # e.g. ["agent:aiden", "test"]
+Tenant encoding (per Dave gap-3 resolution + Scout Q4 + Elliot ts 1778565xxx):
+    user.email     = f"{org_id}@keiracom.local"        # mints per-tenant Cognee User
+    user.tenant_id = org_id                            # propagates to dataset UUID derivation
+    dataset_name   = f"{org_id}__{app_id}"             # e.g. "keiracom_platform__agency_os"
+    node_set       = [f"agent:{agent_id}"] + extras    # e.g. ["agent:aiden", "test"]
+
+Why per-tenant User minting (Scout Q4): Cognee derives
+    dataset.id = uuid5(NAMESPACE_OID, f"{dataset_name}{user.id}{user.tenant_id}")
+and scopes ops via set_database_global_context_variables(dataset.id, dataset.owner_id).
+If every Keiracom tenant wrote as one shared default User, distinct dataset_names
+would still share owner_id → Dave's Validation Query 4 (cross-namespace isolation)
+would fail. Minting one User per org_id with tenant_id=org_id gives true isolation
+at both the dataset-UUID and auth-permission layers.
 
 Backing stores (per /home/elliotbot/.config/agency-os/.env LLM_*/EMBEDDING_*
 block; Gemini amendment ts 1778563xxx swapped Ollama → Gemini):
@@ -24,6 +34,11 @@ from typing import Any
 
 import cognee
 
+# In-process cache so we mint each Cognee User exactly once per process. Cognee's
+# user store is the SQLAlchemy Dataset/User DB, so this is purely a hot-path
+# optimisation — cold lookups still go through get_user_by_email.
+_USER_CACHE: dict[str, Any] = {}
+
 
 def _dataset_name(org_id: str, app_id: str) -> str:
     """Compose the Cognee dataset name from org + app scopes."""
@@ -39,6 +54,37 @@ def _agent_node_set(agent_id: str, extras: list[str] | None) -> list[str]:
     return [f"agent:{agent_id}", *(extras or [])]
 
 
+def _tenant_email(org_id: str) -> str:
+    """Synthetic email used as the Cognee User identifier for a Keiracom tenant.
+
+    Not a real mailbox — Cognee uses email as the User primary lookup key.
+    Convention: f"{org_id}@keiracom.local" so per-org isolation is deterministic.
+    """
+    if not org_id:
+        raise ValueError(f"org_id required for tenant User minting (got {org_id!r})")
+    return f"{org_id}@keiracom.local"
+
+
+async def _get_or_create_user(org_id: str) -> Any:
+    """Return the Cognee User scoped to this Keiracom tenant; mint if absent.
+
+    Idempotent: caches the resolved User in-process; on cache miss, calls
+    cognee.modules.users.methods.get_user_by_email; if that returns None, calls
+    create_user with email + tenant_id=org_id. Subsequent calls hit the cache.
+    """
+    if org_id in _USER_CACHE:
+        return _USER_CACHE[org_id]
+
+    from cognee.modules.users.methods import create_user, get_user_by_email
+
+    email = _tenant_email(org_id)
+    user = await get_user_by_email(email)
+    if user is None:
+        user = await create_user(email=email, tenant_id=org_id, is_superuser=False)
+    _USER_CACHE[org_id] = user
+    return user
+
+
 async def add(
     content: str,
     *,
@@ -51,17 +97,20 @@ async def add(
 
     agent_id is required so every chunk is tagged with the writing agent —
     enables agent-scoped retrieval + audit trail for memory provenance.
+    Per-tenant Cognee User is auto-minted on first call for this org_id.
     """
     dataset = _dataset_name(org_id, app_id)
     tags = _agent_node_set(agent_id, node_set)
-    return await cognee.add(content, dataset_name=dataset, node_set=tags)
+    user = await _get_or_create_user(org_id)
+    return await cognee.add(content, dataset_name=dataset, node_set=tags, user=user)
 
 
 async def cognify() -> Any:
     """Process pending added data into the knowledge graph + embeddings.
 
     Must be called after add() before search() can return new content.
-    Cognee processes ALL pending datasets in one pass.
+    Cognee processes ALL pending datasets in one pass; per-tenant scoping
+    is already baked into each dataset's owner_id via the User-on-add path.
     """
     return await cognee.cognify()
 
@@ -83,14 +132,16 @@ async def search(
     app_id: str,
     agent_id: str | None = None,
 ) -> Any:
-    """Semantic search the per-org/app Cognee dataset.
+    """Semantic search the per-org/app Cognee dataset, scoped to this tenant's User.
 
     agent_id is optional on read — when set, scopes results to chunks tagged
     `agent:<agent_id>`. When None, returns results across all agents in the
-    org/app scope.
+    org/app scope. Cross-tenant reads are blocked by Cognee's auth layer
+    (per-User permission rows) because the User is org-specific.
     """
     dataset = _dataset_name(org_id, app_id)
-    kwargs: dict[str, Any] = {"datasets": [dataset]}
+    user = await _get_or_create_user(org_id)
+    kwargs: dict[str, Any] = {"datasets": [dataset], "user": user}
     if agent_id:
         kwargs["node_set"] = [f"agent:{agent_id}"]
     return await cognee.search(query, **kwargs)

--- a/src/cognee/client.py
+++ b/src/cognee/client.py
@@ -30,9 +30,24 @@ block; Gemini amendment ts 1778563xxx swapped Ollama → Gemini):
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import cognee
+
+
+def _access_control_enabled() -> bool:
+    """True iff Cognee's multi-user access control is on (env: ENABLE_BACKEND_ACCESS_CONTROL).
+
+    Per Dave's Option E ts 1778572400 + Aiden escalation-3 ts 1778571845: when
+    access control is off the wrapper skips per-tenant Cognee User minting so
+    the aiosqlite User-query path (segfault site on this server's Python 3.12.3
+    / aiosqlite 0.22.1 stack) is not exercised. Trade-off: Validation Query #4
+    cross-tenant isolation is not enforced at Phase 0 — Phase 0 is single-tenant
+    API-surface verify anyway, consistent with the directive's Phase 0 framing.
+    """
+    return os.environ.get("ENABLE_BACKEND_ACCESS_CONTROL", "").lower() == "true"
+
 
 # In-process cache so we mint each Cognee User exactly once per process. Cognee's
 # user store is the SQLAlchemy Dataset/User DB, so this is purely a hot-path
@@ -101,8 +116,10 @@ async def add(
     """
     dataset = _dataset_name(org_id, app_id)
     tags = _agent_node_set(agent_id, node_set)
-    user = await _get_or_create_user(org_id)
-    return await cognee.add(content, dataset_name=dataset, node_set=tags, user=user)
+    kwargs: dict[str, Any] = {"dataset_name": dataset, "node_set": tags}
+    if _access_control_enabled():
+        kwargs["user"] = await _get_or_create_user(org_id)
+    return await cognee.add(content, **kwargs)
 
 
 async def cognify() -> Any:
@@ -140,8 +157,9 @@ async def search(
     (per-User permission rows) because the User is org-specific.
     """
     dataset = _dataset_name(org_id, app_id)
-    user = await _get_or_create_user(org_id)
-    kwargs: dict[str, Any] = {"datasets": [dataset], "user": user}
+    kwargs: dict[str, Any] = {"datasets": [dataset]}
+    if _access_control_enabled():
+        kwargs["user"] = await _get_or_create_user(org_id)
     if agent_id:
         kwargs["node_set"] = [f"agent:{agent_id}"]
     return await cognee.search(query, **kwargs)

--- a/src/cognee/client.py
+++ b/src/cognee/client.py
@@ -1,0 +1,95 @@
+"""client.py — sole Cognee call surface for Agency OS.
+
+Per Cognee Phase 0 directive (Dave ts 1778562801, Elliot dispatch ts 1778562982):
+all Cognee usage in this codebase MUST go through these four functions. Direct
+imports of the cognee SDK outside this module are forbidden — keeps the multi-
+tenant naming convention + agent-scoped node_set tagging consistent.
+
+Tenant encoding (per Dave gap-3 resolution):
+    dataset_name = f"{org_id}__{app_id}"      # e.g. "keiracom_platform__agency_os"
+    node_set     = [f"agent:{agent_id}"] + extras  # e.g. ["agent:aiden", "test"]
+
+Backing stores (per /home/elliotbot/.config/agency-os/.env COGNEE_* block):
+    LLM       : Ollama llama3.2 (local)
+    Embedding : fastembed
+    Vector DB : pgvector on $SUPABASE_DB_URL
+    Relational: sqlalchemy on $SUPABASE_DB_URL
+    Graph DB  : Kuzu at /home/elliotbot/clawd/cognee_graph/
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cognee
+
+
+def _dataset_name(org_id: str, app_id: str) -> str:
+    """Compose the Cognee dataset name from org + app scopes."""
+    if not org_id or not app_id:
+        raise ValueError(f"org_id + app_id required (got org_id={org_id!r}, app_id={app_id!r})")
+    return f"{org_id}__{app_id}"
+
+
+def _agent_node_set(agent_id: str, extras: list[str] | None) -> list[str]:
+    """Prepend agent:<agent_id> tag onto caller-supplied node_set."""
+    if not agent_id:
+        raise ValueError(f"agent_id required for node_set encoding (got {agent_id!r})")
+    return [f"agent:{agent_id}", *(extras or [])]
+
+
+async def add(
+    content: str,
+    *,
+    org_id: str,
+    app_id: str,
+    agent_id: str,
+    node_set: list[str] | None = None,
+) -> Any:
+    """Add content to the per-org/app Cognee dataset with agent-scoped node_set.
+
+    agent_id is required so every chunk is tagged with the writing agent —
+    enables agent-scoped retrieval + audit trail for memory provenance.
+    """
+    dataset = _dataset_name(org_id, app_id)
+    tags = _agent_node_set(agent_id, node_set)
+    return await cognee.add(content, dataset_name=dataset, node_set=tags)
+
+
+async def cognify() -> Any:
+    """Process pending added data into the knowledge graph + embeddings.
+
+    Must be called after add() before search() can return new content.
+    Cognee processes ALL pending datasets in one pass.
+    """
+    return await cognee.cognify()
+
+
+async def memify() -> Any:
+    """Run memory-layer enrichment over the cognified graph.
+
+    Distinct from cognify(): memify operates on already-cognified data to
+    extract higher-order memory structures (entity links, recurring themes).
+    No-op safely if there's no cognified data yet.
+    """
+    return await cognee.memify()
+
+
+async def search(
+    query: str,
+    *,
+    org_id: str,
+    app_id: str,
+    agent_id: str | None = None,
+) -> Any:
+    """Semantic search the per-org/app Cognee dataset.
+
+    agent_id is optional on read — when set, scopes results to chunks tagged
+    `agent:<agent_id>`. When None, returns results across all agents in the
+    org/app scope.
+    """
+    dataset = _dataset_name(org_id, app_id)
+    kwargs: dict[str, Any] = {"datasets": [dataset]}
+    if agent_id:
+        kwargs["node_set"] = [f"agent:{agent_id}"]
+    return await cognee.search(query, **kwargs)

--- a/src/cognee/client.py
+++ b/src/cognee/client.py
@@ -9,9 +9,10 @@ Tenant encoding (per Dave gap-3 resolution):
     dataset_name = f"{org_id}__{app_id}"      # e.g. "keiracom_platform__agency_os"
     node_set     = [f"agent:{agent_id}"] + extras  # e.g. ["agent:aiden", "test"]
 
-Backing stores (per /home/elliotbot/.config/agency-os/.env COGNEE_* block):
-    LLM       : Ollama llama3.2 (local)
-    Embedding : fastembed
+Backing stores (per /home/elliotbot/.config/agency-os/.env LLM_*/EMBEDDING_*
+block; Gemini amendment ts 1778563xxx swapped Ollama → Gemini):
+    LLM       : Gemini 2.5 Flash via Google AI Studio (GEMINI_API_KEY)
+    Embedding : Gemini text-embedding-004 (768 dims)
     Vector DB : pgvector on $SUPABASE_DB_URL
     Relational: sqlalchemy on $SUPABASE_DB_URL
     Graph DB  : Kuzu at /home/elliotbot/clawd/cognee_graph/

--- a/tests/cognee/test_client.py
+++ b/tests/cognee/test_client.py
@@ -1,0 +1,160 @@
+"""Tests for src/cognee/client.py — mocked Cognee SDK, no live calls.
+
+Per Phase 0 dispatch (Elliot ts 1778562982): tests mock the Cognee SDK so they
+pass in CI before/regardless of cognee[fastembed] being pip-installed. Smoke
+test against real Cognee runs separately as Phase 0 evidence items 2-3.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+# Inject a fake `cognee` module into sys.modules BEFORE importing client.py so
+# the `import cognee` line in client.py picks up the mock. Real cognee SDK may
+# not be installed in test environments.
+@pytest.fixture(autouse=True)
+def fake_cognee(monkeypatch):
+    fake = SimpleNamespace(
+        add=AsyncMock(return_value="add-result"),
+        cognify=AsyncMock(return_value="cognify-result"),
+        memify=AsyncMock(return_value="memify-result"),
+        search=AsyncMock(return_value=["search-result"]),
+    )
+    monkeypatch.setitem(sys.modules, "cognee", fake)
+    sys.modules.pop("src.cognee.client", None)
+    sys.modules.pop("src.cognee", None)
+    return fake
+
+
+@pytest.fixture
+def client(fake_cognee):
+    from src.cognee import client as c
+
+    return c
+
+
+# _dataset_name ──────────────────────────────────────────────────────────────
+
+
+def test_dataset_name_composes_org_and_app(client):
+    assert client._dataset_name("keiracom_platform", "agency_os") == "keiracom_platform__agency_os"
+
+
+def test_dataset_name_rejects_empty_org(client):
+    with pytest.raises(ValueError, match="org_id"):
+        client._dataset_name("", "agency_os")
+
+
+def test_dataset_name_rejects_empty_app(client):
+    with pytest.raises(ValueError, match="app_id"):
+        client._dataset_name("keiracom_platform", "")
+
+
+# _agent_node_set ────────────────────────────────────────────────────────────
+
+
+def test_agent_node_set_prepends_agent_tag(client):
+    assert client._agent_node_set("aiden", ["test", "phase0"]) == [
+        "agent:aiden",
+        "test",
+        "phase0",
+    ]
+
+
+def test_agent_node_set_handles_none_extras(client):
+    assert client._agent_node_set("aiden", None) == ["agent:aiden"]
+
+
+def test_agent_node_set_rejects_empty_agent_id(client):
+    with pytest.raises(ValueError, match="agent_id"):
+        client._agent_node_set("", ["test"])
+
+
+# add ────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_add_calls_sdk_with_dataset_and_node_set(client, fake_cognee):
+    result = await client.add(
+        "hello",
+        org_id="keiracom_platform",
+        app_id="agency_os",
+        agent_id="aiden",
+        node_set=["test"],
+    )
+    fake_cognee.add.assert_awaited_once_with(
+        "hello",
+        dataset_name="keiracom_platform__agency_os",
+        node_set=["agent:aiden", "test"],
+    )
+    assert result == "add-result"
+
+
+@pytest.mark.asyncio
+async def test_add_handles_none_node_set(client, fake_cognee):
+    await client.add(
+        "hello",
+        org_id="o",
+        app_id="a",
+        agent_id="aiden",
+    )
+    _, kwargs = fake_cognee.add.call_args
+    assert kwargs["node_set"] == ["agent:aiden"]
+
+
+@pytest.mark.asyncio
+async def test_add_requires_agent_id(client):
+    with pytest.raises(ValueError, match="agent_id"):
+        await client.add("hello", org_id="o", app_id="a", agent_id="")
+
+
+# cognify / memify ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cognify_delegates(client, fake_cognee):
+    result = await client.cognify()
+    fake_cognee.cognify.assert_awaited_once_with()
+    assert result == "cognify-result"
+
+
+@pytest.mark.asyncio
+async def test_memify_delegates(client, fake_cognee):
+    result = await client.memify()
+    fake_cognee.memify.assert_awaited_once_with()
+    assert result == "memify-result"
+
+
+# search ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_without_agent_id_omits_node_set(client, fake_cognee):
+    result = await client.search(
+        "what is X?",
+        org_id="keiracom_platform",
+        app_id="agency_os",
+    )
+    fake_cognee.search.assert_awaited_once_with(
+        "what is X?",
+        datasets=["keiracom_platform__agency_os"],
+    )
+    assert result == ["search-result"]
+
+
+@pytest.mark.asyncio
+async def test_search_with_agent_id_scopes_to_node_set(client, fake_cognee):
+    await client.search(
+        "what is X?",
+        org_id="o",
+        app_id="a",
+        agent_id="aiden",
+    )
+    _, kwargs = fake_cognee.search.call_args
+    assert kwargs["node_set"] == ["agent:aiden"]
+    assert kwargs["datasets"] == ["o__a"]

--- a/tests/cognee/test_client.py
+++ b/tests/cognee/test_client.py
@@ -38,6 +38,9 @@ def fake_cognee(monkeypatch):
         side_effect=lambda email, tenant_id=None, **_: _make_user(email, tenant_id)
     )
 
+    # Default: access control ON. Tests of the OFF behavior monkeypatch this
+    # to a false-y value via the `client_no_access_control` fixture.
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "true")
     monkeypatch.setitem(sys.modules, "cognee", fake)
     monkeypatch.setitem(sys.modules, "cognee.modules.users.methods", users_methods)
     sys.modules.pop("src.cognee.client", None)
@@ -239,3 +242,54 @@ async def test_different_orgs_get_different_users(client, fake_cognee):
     assert add_users[0] is not add_users[1]
     assert add_users[0].tenant_id == "keiracom_platform"
     assert add_users[1].tenant_id == "other_org"
+
+
+# Access-control OFF behavior (Dave Option E, ts 1778572400) ────────────────
+
+
+@pytest.mark.asyncio
+async def test_add_skips_user_minting_when_access_control_off(client, fake_cognee, monkeypatch):
+    """Option E: ENABLE_BACKEND_ACCESS_CONTROL=false → wrapper does NOT mint
+    a User, does NOT call get_user_by_email/create_user. Avoids the aiosqlite
+    User-query path that segfaults on this server's stack.
+    """
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+    await client.add("hello", org_id="o", app_id="a", agent_id="aiden")
+    _, kwargs = fake_cognee.top.add.call_args
+    assert "user" not in kwargs
+    fake_cognee.users.get_user_by_email.assert_not_awaited()
+    fake_cognee.users.create_user.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_search_skips_user_minting_when_access_control_off(client, fake_cognee, monkeypatch):
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+    await client.search("q", org_id="o", app_id="a")
+    _, kwargs = fake_cognee.top.search.call_args
+    assert "user" not in kwargs
+    fake_cognee.users.get_user_by_email.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_add_passes_user_when_access_control_true(client, fake_cognee, monkeypatch):
+    """Inverse of the off case: access control ON (default per fixture) DOES
+    pass user= to cognee.add. Existing tests cover the prose; this is the
+    explicit boolean-toggle sanity test."""
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "true")
+    await client.add("hello", org_id="o", app_id="a", agent_id="aiden")
+    _, kwargs = fake_cognee.top.add.call_args
+    assert "user" in kwargs
+    assert kwargs["user"].tenant_id == "o"
+
+
+def test_access_control_enabled_is_case_insensitive(client, monkeypatch):
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "TRUE")
+    assert client._access_control_enabled() is True
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "TrUe")
+    assert client._access_control_enabled() is True
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+    assert client._access_control_enabled() is False
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "")
+    assert client._access_control_enabled() is False
+    monkeypatch.delenv("ENABLE_BACKEND_ACCESS_CONTROL", raising=False)
+    assert client._access_control_enabled() is False

--- a/tests/cognee/test_client.py
+++ b/tests/cognee/test_client.py
@@ -1,40 +1,57 @@
 """Tests for src/cognee/client.py — mocked Cognee SDK, no live calls.
 
-Per Phase 0 dispatch (Elliot ts 1778562982): tests mock the Cognee SDK so they
-pass in CI before/regardless of cognee[fastembed] being pip-installed. Smoke
-test against real Cognee runs separately as Phase 0 evidence items 2-3.
+Per Phase 0 dispatch (Elliot ts 1778562982) + tenant-isolation amendment
+(Scout Q4 + Elliot ts 1778565xxx): tests mock both the top-level cognee
+module AND `cognee.modules.users.methods` so the wrapper's User-minting
+path can be exercised without a live cognee install.
 """
 
 from __future__ import annotations
 
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 
-# Inject a fake `cognee` module into sys.modules BEFORE importing client.py so
-# the `import cognee` line in client.py picks up the mock. Real cognee SDK may
-# not be installed in test environments.
+def _make_user(email: str, tenant_id: str | None = None):
+    return SimpleNamespace(id=f"uid-{email}", email=email, tenant_id=tenant_id)
+
+
 @pytest.fixture(autouse=True)
 def fake_cognee(monkeypatch):
+    """Inject a fake `cognee` module + `cognee.modules.users.methods` submodule
+    BEFORE importing client.py, so its top-of-module imports + lazy submodule
+    import inside `_get_or_create_user` both resolve to mocks.
+    """
     fake = SimpleNamespace(
         add=AsyncMock(return_value="add-result"),
         cognify=AsyncMock(return_value="cognify-result"),
         memify=AsyncMock(return_value="memify-result"),
         search=AsyncMock(return_value=["search-result"]),
     )
+
+    users_methods = ModuleType("cognee.modules.users.methods")
+    users_methods.get_user_by_email = AsyncMock(return_value=None)
+    users_methods.create_user = AsyncMock(
+        side_effect=lambda email, tenant_id=None, **_: _make_user(email, tenant_id)
+    )
+
     monkeypatch.setitem(sys.modules, "cognee", fake)
+    monkeypatch.setitem(sys.modules, "cognee.modules.users.methods", users_methods)
     sys.modules.pop("src.cognee.client", None)
     sys.modules.pop("src.cognee", None)
-    return fake
+    return SimpleNamespace(top=fake, users=users_methods)
 
 
 @pytest.fixture
 def client(fake_cognee):
     from src.cognee import client as c
 
+    # Clear the in-process User cache between tests so mint/lookup paths are
+    # independent.
+    c._USER_CACHE.clear()
     return c
 
 
@@ -75,11 +92,66 @@ def test_agent_node_set_rejects_empty_agent_id(client):
         client._agent_node_set("", ["test"])
 
 
+# _tenant_email ──────────────────────────────────────────────────────────────
+
+
+def test_tenant_email_uses_keiracom_local_convention(client):
+    assert client._tenant_email("keiracom_platform") == "keiracom_platform@keiracom.local"
+
+
+def test_tenant_email_rejects_empty_org(client):
+    with pytest.raises(ValueError, match="org_id"):
+        client._tenant_email("")
+
+
+# _get_or_create_user ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_user_mints_when_missing(client, fake_cognee):
+    user = await client._get_or_create_user("acme_co")
+    fake_cognee.users.get_user_by_email.assert_awaited_once_with("acme_co@keiracom.local")
+    fake_cognee.users.create_user.assert_awaited_once_with(
+        email="acme_co@keiracom.local", tenant_id="acme_co", is_superuser=False
+    )
+    assert user.email == "acme_co@keiracom.local"
+    assert user.tenant_id == "acme_co"
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_user_reuses_existing_via_lookup(client, fake_cognee):
+    existing = _make_user("acme_co@keiracom.local", tenant_id="acme_co")
+    fake_cognee.users.get_user_by_email.return_value = existing
+
+    user = await client._get_or_create_user("acme_co")
+    fake_cognee.users.get_user_by_email.assert_awaited_once_with("acme_co@keiracom.local")
+    fake_cognee.users.create_user.assert_not_awaited()
+    assert user is existing
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_user_caches_in_process(client, fake_cognee):
+    user1 = await client._get_or_create_user("acme_co")
+    user2 = await client._get_or_create_user("acme_co")
+    assert user1 is user2
+    # Lookup only on first call; cache serves the second.
+    fake_cognee.users.get_user_by_email.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_user_distinct_per_org(client, fake_cognee):
+    a = await client._get_or_create_user("acme_co")
+    b = await client._get_or_create_user("bravo_inc")
+    assert a is not b
+    assert a.tenant_id == "acme_co"
+    assert b.tenant_id == "bravo_inc"
+
+
 # add ────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_add_calls_sdk_with_dataset_and_node_set(client, fake_cognee):
+async def test_add_passes_dataset_node_set_and_user(client, fake_cognee):
     result = await client.add(
         "hello",
         org_id="keiracom_platform",
@@ -87,23 +159,19 @@ async def test_add_calls_sdk_with_dataset_and_node_set(client, fake_cognee):
         agent_id="aiden",
         node_set=["test"],
     )
-    fake_cognee.add.assert_awaited_once_with(
-        "hello",
-        dataset_name="keiracom_platform__agency_os",
-        node_set=["agent:aiden", "test"],
-    )
+    fake_cognee.top.add.assert_awaited_once()
+    _, kwargs = fake_cognee.top.add.call_args
+    assert kwargs["dataset_name"] == "keiracom_platform__agency_os"
+    assert kwargs["node_set"] == ["agent:aiden", "test"]
+    assert kwargs["user"].email == "keiracom_platform@keiracom.local"
+    assert kwargs["user"].tenant_id == "keiracom_platform"
     assert result == "add-result"
 
 
 @pytest.mark.asyncio
 async def test_add_handles_none_node_set(client, fake_cognee):
-    await client.add(
-        "hello",
-        org_id="o",
-        app_id="a",
-        agent_id="aiden",
-    )
-    _, kwargs = fake_cognee.add.call_args
+    await client.add("hello", org_id="o", app_id="a", agent_id="aiden")
+    _, kwargs = fake_cognee.top.add.call_args
     assert kwargs["node_set"] == ["agent:aiden"]
 
 
@@ -119,14 +187,14 @@ async def test_add_requires_agent_id(client):
 @pytest.mark.asyncio
 async def test_cognify_delegates(client, fake_cognee):
     result = await client.cognify()
-    fake_cognee.cognify.assert_awaited_once_with()
+    fake_cognee.top.cognify.assert_awaited_once_with()
     assert result == "cognify-result"
 
 
 @pytest.mark.asyncio
 async def test_memify_delegates(client, fake_cognee):
     result = await client.memify()
-    fake_cognee.memify.assert_awaited_once_with()
+    fake_cognee.top.memify.assert_awaited_once_with()
     assert result == "memify-result"
 
 
@@ -134,27 +202,40 @@ async def test_memify_delegates(client, fake_cognee):
 
 
 @pytest.mark.asyncio
-async def test_search_without_agent_id_omits_node_set(client, fake_cognee):
-    result = await client.search(
-        "what is X?",
-        org_id="keiracom_platform",
-        app_id="agency_os",
-    )
-    fake_cognee.search.assert_awaited_once_with(
-        "what is X?",
-        datasets=["keiracom_platform__agency_os"],
-    )
+async def test_search_passes_dataset_and_user_without_agent(client, fake_cognee):
+    result = await client.search("what is X?", org_id="keiracom_platform", app_id="agency_os")
+    _, kwargs = fake_cognee.top.search.call_args
+    assert kwargs["datasets"] == ["keiracom_platform__agency_os"]
+    assert kwargs["user"].tenant_id == "keiracom_platform"
+    assert "node_set" not in kwargs
     assert result == ["search-result"]
 
 
 @pytest.mark.asyncio
 async def test_search_with_agent_id_scopes_to_node_set(client, fake_cognee):
-    await client.search(
-        "what is X?",
-        org_id="o",
-        app_id="a",
-        agent_id="aiden",
-    )
-    _, kwargs = fake_cognee.search.call_args
+    await client.search("what is X?", org_id="o", app_id="a", agent_id="aiden")
+    _, kwargs = fake_cognee.top.search.call_args
     assert kwargs["node_set"] == ["agent:aiden"]
     assert kwargs["datasets"] == ["o__a"]
+    assert kwargs["user"].tenant_id == "o"
+
+
+# Cross-tenant isolation — Dave's Validation Query 4 ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_different_orgs_get_different_users(client, fake_cognee):
+    """The architectural guarantee that closes Dave's Query 4 — distinct
+    org_id values mint distinct Cognee Users (distinct owner_id + tenant_id),
+    so cross-namespace search returns empty at the auth layer regardless of
+    what dataset_name strings the caller supplies.
+    """
+    await client.add(
+        "agency content", org_id="keiracom_platform", app_id="agency_os", agent_id="aiden"
+    )
+    await client.add("other content", org_id="other_org", app_id="other_app", agent_id="aiden")
+    # 2 adds with different orgs → 2 distinct users passed to cognee.add
+    add_users = [call.kwargs["user"] for call in fake_cognee.top.add.call_args_list]
+    assert add_users[0] is not add_users[1]
+    assert add_users[0].tenant_id == "keiracom_platform"
+    assert add_users[1].tenant_id == "other_org"


### PR DESCRIPTION
## Summary

Cognee Phase 0 architecture deliverables per Dave directive 2026-05-12 + Elliot dispatch ts 1778562982 (Gemini amendment ts 1778563xxx). DRAFT for early peer review — opening before Atlas's pip install + smoke test so Max + Elliot can review the wrapper API surface in parallel.

**Scope IN:**
- `src/cognee/client.py` — sole Cognee call surface (≤200 LOC, 95 actual). Native API per Gap 3: `add(content, *, org_id, app_id, agent_id, node_set)`, `search(query, *, org_id, app_id, agent_id=None)`, `cognify()`, `memify()`. Encodes `dataset_name=f"{org_id}__{app_id}"` and `node_set=[f"agent:{agent_id}", *extras]` so every chunk carries tenant + agent provenance.
- `tests/cognee/test_client.py` — 13 tests, mocked SDK so they pass without `cognee[fastembed]` installed.
- `scripts/cognee_smoke.py` — reproducible Phase 0 verify runner (add → cognify → search), exit 0 pass / 2 fail.
- `src/cognee/README.md` — 1-page wrapper guide.

**Scope OUT (other agents' parallel tracks):**
- `cognee[fastembed]` install + Ollama→Gemini config + KuzuDB dir (Atlas)
- `scripts/cognee_ingest.py` batch ingestion (Max)
- `continuous_ingest.py` hook (Orion)
- Cognee-internals research doc (Scout)

**Config (outside repo, at `/home/elliotbot/.config/`):**
- `systemd/user/cognee.service` — uvicorn cognee.api.client:app on 127.0.0.1:8000
- `agency-os/.env` Cognee block — plain (un-prefixed) `LLM_*`/`EMBEDDING_*` per Cognee/LiteLLM convention; provider=gemini/gemini-2.5-flash; vector=pgvector; graph=kuzu

## Verification

### Unit tests (run now)

```
$ /home/elliotbot/clawd/venv/bin/python3 -m pytest tests/cognee/test_client.py
13 passed in 0.20s

$ /home/elliotbot/.local/bin/ruff check src/cognee/ tests/cognee/ scripts/cognee_smoke.py
All checks passed!

$ /home/elliotbot/.local/bin/ruff format src/cognee/ tests/cognee/ scripts/cognee_smoke.py --check
All formatted
```

### Phase 0 smoke evidence (filled post-[READY:atlas])

**Evidence item 1 — systemctl status cognee.service:**

```
<pending — fills after Atlas READY + systemctl --user enable --now cognee.service>
```

**Evidence item 2 — smoke runner assertion 1 (len(results) > 0):**

```
<pending — fills from `python3 scripts/cognee_smoke.py` stdout>
```

**Evidence item 3 — smoke runner assertion 2 ('domain_metrics_by_categories' in results):**

```
<pending — fills from `python3 scripts/cognee_smoke.py` stdout>
```

### Atlas evidence (cross-PR inline per directive step 7)

```
<pending — Atlas's 4 install + KuzuDB evidence items will be appended here from her [READY:atlas] post>
```

## Phase 0 → Phase 1 Gate

Sign-off via `[PHASE-0-VERIFIED:aiden]` in #execution after all 3 of MY evidence items + Atlas's 4 land. No Phase 1 work (ingestion, hooks, ingest scripts) starts until this gate locks.

## Dual-CTO Concur

- Author: @aiden
- Reviewer: @max (please review wrapper API surface + encoding)
- Optional third: @elliot

Per Dave session brief author+reviewer = dual approval suffices.

## llama3.2 Quality Flag → RETIRED

Original directive had Ollama llama3.2 as the LLM. Dave amended to Gemini 2.5 Flash (ts 1778563xxx) — production-quality entity extractor. No fallback path; if Gemini fails, separate escalation.

## Test plan

- [x] 13 unit tests pass locally (mocked SDK)
- [x] Ruff check + format clean
- [x] Wrapper ≤200 LOC (95 actual)
- [x] systemd-analyze --user verify on cognee.service clean
- [x] .env Cognee block contains all 12 required values
- [ ] Backend Lint (Ruff) green in CI
- [ ] Backend Tests (Pytest) green in CI
- [ ] Backend Type Check (MyPy) green in CI
- [ ] SonarCloud A-rating
- [ ] Atlas `[READY:atlas]` received
- [ ] `GEMINI_API_KEY` non-empty in .env (already true per Elliot ts 1778563xxx)
- [ ] Smoke runner exit 0 → fill 3 evidence items above
- [ ] `[PHASE-0-VERIFIED:aiden]` posted to #execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)