### PR TITLE
[MAX] feat(cognee): Phase 1 Stream 1 ingestion script (DRAFT — gated on Phase 0)

### DIFF
--- a/scripts/cognee_ingest.py
+++ b/scripts/cognee_ingest.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""cognee_ingest.py — Stream 1 batch ingestion of Agency OS canonical files.
+
+Phase 1 dispatch (Max, per Elliot ts 1778562982 / ts 1778565xxx source-list
+confirm, Dave umbrella ts 1778562801). Sole Cognee call surface:
+`src.cognee.client.{add, cognify}` (Aiden Phase 0 wrapper, PR #764). Direct
+cognee SDK imports outside that wrapper are forbidden.
+
+Stream 1 covers .md files only:
+    docs/MANUAL.md                            (CEO SSOT, manual)
+    ARCHITECTURE.md                           (system architecture)
+    DEFINITION_OF_DONE.md                     (governance acceptance criteria)
+    .claude/modules/*.md                      (canonical CLAUDE.md modules — main worktree only, lockstep)
+    skills/*/SKILL.md                         (one per skill, 15 expected)
+    .../Agency_OS-{callsign}/IDENTITY.md      (per-worktree, tagged agent_id)
+    .../Agency_OS-{callsign}/HEARTBEAT.md     (per-worktree, tagged agent_id)
+
+Streams 2/3/4 (SQL tables, cloud APIs, file paths beyond .md) deferred to
+follow-up PRs — different ingest shapes; not in this PR's scope.
+
+Usage:
+    cognee_ingest.py [--sources path1,path2,...] [--include-aux-skills]
+                     [--dry-run] [--org-id ID] [--app-id ID] [--agent-id ID]
+                     [--skip-cognify]
+
+    --sources: comma-separated explicit paths (overrides STREAM_1_SOURCES default)
+    --include-aux-skills: also ingest skills/**/*.md beyond just SKILL.md
+                          (off by default — auxiliary skill docs skew the graph)
+    --dry-run: print what would be ingested; do not call add() or cognify()
+    --org-id: default 'keiracom_platform'
+    --app-id: default 'agency_os'
+    --agent-id: default 'max' — tagged on every chunk (override per ingest run)
+    --skip-cognify: don't call cognify() at the end
+
+Missing-on-disk sources log to stderr + skip (idempotent; directive expects
+tolerant). Exit codes: 0 ok or dry-run, 1 partial failure, 2 fatal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("cognee_ingest")
+
+DEFAULT_ORG = "keiracom_platform"
+DEFAULT_APP = "agency_os"
+DEFAULT_AGENT = "max"
+CHUNK_CHAR_CAP = 4000
+
+# Per Orion's filesystem audit (PR #758) — clawd root contains six worktrees.
+# Each has its own IDENTITY.md + HEARTBEAT.md tagged with that callsign so
+# the graph distinguishes per-agent identity / continuation state.
+CLAWD_ROOT = REPO_ROOT.parent  # /home/elliotbot/clawd
+WORKTREES: dict[str, Path] = {
+    "elliot": CLAWD_ROOT / "Agency_OS",
+    "aiden": CLAWD_ROOT / "Agency_OS-aiden",
+    "max": CLAWD_ROOT / "Agency_OS-max",
+    "atlas": CLAWD_ROOT / "Agency_OS-atlas",
+    "orion": CLAWD_ROOT / "Agency_OS-orion",
+    "scout": CLAWD_ROOT / "Agency_OS-scout",
+}
+
+
+def _stream_1_sources() -> list[tuple[Path, str, list[str]]]:
+    """Return [(path, source_tag, extra_node_set), ...] for the default ingest.
+
+    extra_node_set is per-file metadata (file:..., agent:... for worktrees).
+    """
+    out: list[tuple[Path, str, list[str]]] = []
+
+    # Top-level governance + architecture docs (main worktree)
+    for name, tag in (
+        ("docs/MANUAL.md", "manual"),
+        ("ARCHITECTURE.md", "architecture"),
+        ("DEFINITION_OF_DONE.md", "dod"),
+    ):
+        out.append((REPO_ROOT / name, tag, [f"file:{name}"]))
+
+    # CLAUDE.md modules — lockstep across worktrees, ingest from main only
+    modules_dir = REPO_ROOT / ".claude" / "modules"
+    if modules_dir.is_dir():
+        for path in sorted(modules_dir.glob("*.md")):
+            out.append((path, "claude_modules", [f"file:.claude/modules/{path.name}"]))
+
+    # Skills — by default just SKILL.md (one per skill)
+    skills_dir = REPO_ROOT / "skills"
+    if skills_dir.is_dir():
+        for path in sorted(skills_dir.glob("*/SKILL.md")):
+            skill_name = path.parent.name
+            out.append(
+                (path, "skill", [f"skill:{skill_name}", f"file:skills/{skill_name}/SKILL.md"])
+            )
+
+    # Per-worktree IDENTITY.md + HEARTBEAT.md, tagged with worktree's callsign
+    for callsign, root in WORKTREES.items():
+        for filename, tag in (("IDENTITY.md", "identity"), ("HEARTBEAT.md", "heartbeat")):
+            out.append((root / filename, tag, [f"agent:{callsign}", f"worktree:{callsign}"]))
+
+    return out
+
+
+def _aux_skill_sources() -> list[tuple[Path, str, list[str]]]:
+    """Auxiliary skill docs (READMEs, examples, supplements) — opt-in via flag."""
+    out: list[tuple[Path, str, list[str]]] = []
+    skills_dir = REPO_ROOT / "skills"
+    if skills_dir.is_dir():
+        for path in sorted(skills_dir.rglob("*.md")):
+            if path.name == "SKILL.md":
+                continue
+            try:
+                rel = path.relative_to(REPO_ROOT)
+            except ValueError:
+                continue
+            skill_name = path.parts[len(REPO_ROOT.parts)]  # 'skills', then subdir
+            out.append((path, "skill_aux", [f"skill:{skill_name}", f"file:{rel}"]))
+    return out
+
+
+def _split_markdown(text: str, max_chars: int = CHUNK_CHAR_CAP) -> list[str]:
+    """Split markdown into ~max_chars chunks at ## boundaries; falls back to fixed-size."""
+    sections: list[str] = []
+    buf: list[str] = []
+    for line in text.splitlines(keepends=True):
+        if line.startswith("## ") and buf:
+            sections.append("".join(buf))
+            buf = [line]
+        else:
+            buf.append(line)
+    if buf:
+        sections.append("".join(buf))
+
+    out: list[str] = []
+    for section in sections:
+        section = section.strip()
+        if not section:
+            continue
+        if len(section) <= max_chars:
+            out.append(section)
+        else:
+            for i in range(0, len(section), max_chars):
+                piece = section[i : i + max_chars].strip()
+                if piece:
+                    out.append(piece)
+    return out
+
+
+def load_file_chunks(
+    path: Path, source_tag: str, extra_node_set: list[str]
+) -> list[tuple[str, str, list[str]]]:
+    """Return [(source_tag, chunk, node_set), ...] for one file. Missing → []."""
+    if not path.exists():
+        logger.warning("source file missing: %s (skipped)", path)
+        return []
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        logger.warning("read failed for %s: %s", path, exc)
+        return []
+    return [
+        (source_tag, chunk, [f"source:{source_tag}", *extra_node_set])
+        for chunk in _split_markdown(text)
+    ]
+
+
+def collect_chunks(
+    sources: Iterable[tuple[Path, str, list[str]]],
+) -> list[tuple[str, str, list[str]]]:
+    """Walk sources, return [(source_tag, chunk, node_set), ...]."""
+    chunks: list[tuple[str, str, list[str]]] = []
+    for path, source_tag, extra in sources:
+        chunks.extend(load_file_chunks(path, source_tag, extra))
+    return chunks
+
+
+def parse_sources_override(raw: str) -> list[tuple[Path, str, list[str]]]:
+    """`--sources` value to (path, tag, extras) triples. Tag = 'override:<filename>'."""
+    out: list[tuple[Path, str, list[str]]] = []
+    for raw_path in (p.strip() for p in raw.split(",") if p.strip()):
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = REPO_ROOT / path
+        out.append((path, "override", [f"file:{path.name}"]))
+    return out
+
+
+async def ingest(
+    chunks: list[tuple[str, str, list[str]]],
+    *,
+    org_id: str,
+    app_id: str,
+    agent_id: str,
+    dry_run: bool,
+    skip_cognify: bool,
+) -> tuple[int, int]:
+    """Run add() per chunk; cognify() once at end. Returns (ok, fail)."""
+    if dry_run:
+        for source_tag, chunk, node_set in chunks:
+            logger.info(
+                "[DRY-RUN] would add %s chunk (%d chars, node_set=%s)",
+                source_tag,
+                len(chunk),
+                node_set,
+            )
+        return len(chunks), 0
+
+    try:
+        from src.cognee.client import add, cognify
+    except ImportError as exc:
+        logger.error("cognee.client import failed: %s — Phase 0 not live?", exc)
+        return 0, len(chunks)
+
+    ok, fail = 0, 0
+    for source_tag, chunk, node_set in chunks:
+        try:
+            await add(
+                chunk,
+                org_id=org_id,
+                app_id=app_id,
+                agent_id=agent_id,
+                node_set=node_set,
+            )
+            ok += 1
+        except Exception as exc:  # noqa: BLE001 — best-effort per chunk
+            logger.warning("add() failed for %s chunk: %s", source_tag, exc)
+            fail += 1
+
+    if ok > 0 and not skip_cognify:
+        try:
+            await cognify()
+            logger.info("cognify() complete")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("cognify() failed: %s", exc)
+            fail += 1
+
+    return ok, fail
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sources",
+        default="",
+        help="comma-separated explicit paths (overrides STREAM_1_SOURCES default)",
+    )
+    parser.add_argument(
+        "--include-aux-skills",
+        action="store_true",
+        help="ingest skills/**/*.md beyond SKILL.md (off — keeps graph signal high)",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--org-id", default=DEFAULT_ORG)
+    parser.add_argument("--app-id", default=DEFAULT_APP)
+    parser.add_argument("--agent-id", default=DEFAULT_AGENT)
+    parser.add_argument("--skip-cognify", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.sources.strip():
+        sources = parse_sources_override(args.sources)
+        logger.info("--sources override: %d explicit paths", len(sources))
+    else:
+        sources = _stream_1_sources()
+        if args.include_aux_skills:
+            sources.extend(_aux_skill_sources())
+        logger.info(
+            "STREAM_1_SOURCES default: %d files%s",
+            len(sources),
+            " (+ aux skills)" if args.include_aux_skills else "",
+        )
+
+    chunks = collect_chunks(sources)
+    if not chunks:
+        logger.warning("no chunks collected — nothing to ingest")
+        return 1
+
+    logger.info(
+        "collected %d chunks (org=%s app=%s agent=%s)",
+        len(chunks),
+        args.org_id,
+        args.app_id,
+        args.agent_id,
+    )
+
+    ok, fail = asyncio.run(
+        ingest(
+            chunks,
+            org_id=args.org_id,
+            app_id=args.app_id,
+            agent_id=args.agent_id,
+            dry_run=args.dry_run,
+            skip_cognify=args.skip_cognify,
+        )
+    )
+    logger.info("done: %d ok / %d failed", ok, fail)
+    return 0 if fail == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_cognee_ingest.py
+++ b/tests/scripts/test_cognee_ingest.py
@@ -1,0 +1,278 @@
+"""tests for scripts/cognee_ingest.py — Stream 1 batch ingestion.
+
+All Cognee calls mocked (sole call surface via src.cognee.client wrapper).
+Filesystem isolated via tmp_path + monkeypatch on REPO_ROOT / WORKTREES.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "cognee_ingest.py"
+
+
+@pytest.fixture(scope="module")
+def ingest_mod():
+    spec = importlib.util.spec_from_file_location("cognee_ingest", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["cognee_ingest"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# _split_markdown ────────────────────────────────────────────────────────────
+
+
+def test_split_markdown_at_h2_boundaries(ingest_mod) -> None:
+    text = "intro\n\n## A\nbody-a\n\n## B\nbody-b"
+    chunks = ingest_mod._split_markdown(text)
+    assert len(chunks) == 3
+    assert chunks[0] == "intro"
+    assert chunks[1].startswith("## A")
+    assert chunks[2].startswith("## B")
+
+
+def test_split_markdown_falls_back_to_fixed_size(ingest_mod) -> None:
+    huge = "x" * 9500
+    chunks = ingest_mod._split_markdown(huge, max_chars=4000)
+    assert len(chunks) == 3
+    assert all(len(c) <= 4000 for c in chunks)
+
+
+def test_split_markdown_drops_empty_sections(ingest_mod) -> None:
+    text = "\n\n\n## A\nbody\n\n## B\n\n"
+    chunks = ingest_mod._split_markdown(text)
+    assert all(c.strip() for c in chunks)
+    assert any("body" in c for c in chunks)
+
+
+# load_file_chunks ───────────────────────────────────────────────────────────
+
+
+def test_load_file_chunks_missing_file(ingest_mod, tmp_path) -> None:
+    assert ingest_mod.load_file_chunks(tmp_path / "absent.md", "manual", []) == []
+
+
+def test_load_file_chunks_attaches_source_and_extras(ingest_mod, tmp_path) -> None:
+    p = tmp_path / "x.md"
+    p.write_text("## Heading\nbody text")
+    chunks = ingest_mod.load_file_chunks(p, "manual", ["file:custom"])
+    assert chunks
+    source_tag, chunk, node_set = chunks[0]
+    assert source_tag == "manual"
+    assert "body text" in chunk
+    assert "source:manual" in node_set
+    assert "file:custom" in node_set
+
+
+# _stream_1_sources ──────────────────────────────────────────────────────────
+
+
+def test_stream_1_sources_includes_top_level_docs(ingest_mod) -> None:
+    sources = ingest_mod._stream_1_sources()
+    rel_paths = [
+        str(p.relative_to(ingest_mod.REPO_ROOT))
+        for p, _, _ in sources
+        if p.is_relative_to(ingest_mod.REPO_ROOT)
+    ]
+    assert "docs/MANUAL.md" in rel_paths
+    assert "ARCHITECTURE.md" in rel_paths
+    assert "DEFINITION_OF_DONE.md" in rel_paths
+
+
+def test_stream_1_sources_includes_six_worktree_identity_and_heartbeat(ingest_mod) -> None:
+    sources = ingest_mod._stream_1_sources()
+    identity_tags = [tags for _, tag, tags in sources if tag == "identity"]
+    heartbeat_tags = [tags for _, tag, tags in sources if tag == "heartbeat"]
+    assert len(identity_tags) == 6
+    assert len(heartbeat_tags) == 6
+    # Each is tagged with the agent callsign
+    callsigns = {t.split(":")[1] for tags in identity_tags for t in tags if t.startswith("agent:")}
+    assert callsigns == {"elliot", "aiden", "max", "atlas", "orion", "scout"}
+
+
+# parse_sources_override ─────────────────────────────────────────────────────
+
+
+def test_parse_sources_override_resolves_relative_to_repo(ingest_mod) -> None:
+    out = ingest_mod.parse_sources_override("docs/MANUAL.md,ARCHITECTURE.md")
+    assert len(out) == 2
+    assert all(p.is_absolute() for p, _, _ in out)
+    assert all(tag == "override" for _, tag, _ in out)
+
+
+def test_parse_sources_override_empty(ingest_mod) -> None:
+    assert ingest_mod.parse_sources_override("") == []
+    assert ingest_mod.parse_sources_override("   ,  ,") == []
+
+
+def test_parse_sources_override_absolute_path_preserved(ingest_mod, tmp_path) -> None:
+    out = ingest_mod.parse_sources_override(str(tmp_path / "x.md"))
+    assert len(out) == 1
+    assert out[0][0] == tmp_path / "x.md"
+
+
+# collect_chunks ─────────────────────────────────────────────────────────────
+
+
+def test_collect_chunks_filters_missing_files(ingest_mod, tmp_path) -> None:
+    real = tmp_path / "real.md"
+    real.write_text("body")
+    sources = [
+        (real, "manual", ["file:real"]),
+        (tmp_path / "fake.md", "manual", ["file:fake"]),
+    ]
+    chunks = ingest_mod.collect_chunks(sources)
+    assert len(chunks) == 1
+    assert "body" in chunks[0][1]
+
+
+# ingest (the async core) ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ingest_dry_run_does_not_call_add(ingest_mod) -> None:
+    chunks = [("manual", "text", ["source:manual"])]
+    ok, fail = await ingest_mod.ingest(
+        chunks,
+        org_id="org",
+        app_id="app",
+        agent_id="max",
+        dry_run=True,
+        skip_cognify=False,
+    )
+    assert ok == 1
+    assert fail == 0
+
+
+@pytest.mark.asyncio
+async def test_ingest_calls_wrapper_add_and_cognify(ingest_mod, monkeypatch) -> None:
+    fake_add = AsyncMock(return_value="added")
+    fake_cognify = AsyncMock(return_value="cognified")
+    # Inject a fake src.cognee.client module
+    fake_module = MagicMock()
+    fake_module.add = fake_add
+    fake_module.cognify = fake_cognify
+    monkeypatch.setitem(sys.modules, "src.cognee.client", fake_module)
+
+    chunks = [
+        ("manual", "text1", ["source:manual"]),
+        ("architecture", "text2", ["source:architecture"]),
+    ]
+    ok, fail = await ingest_mod.ingest(
+        chunks,
+        org_id="org",
+        app_id="app",
+        agent_id="max",
+        dry_run=False,
+        skip_cognify=False,
+    )
+    assert ok == 2
+    assert fail == 0
+    assert fake_add.await_count == 2
+    assert fake_cognify.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ingest_skip_cognify(ingest_mod, monkeypatch) -> None:
+    fake_add = AsyncMock(return_value="ok")
+    fake_cognify = AsyncMock()
+    fake_module = MagicMock()
+    fake_module.add = fake_add
+    fake_module.cognify = fake_cognify
+    monkeypatch.setitem(sys.modules, "src.cognee.client", fake_module)
+
+    await ingest_mod.ingest(
+        [("manual", "t", [])],
+        org_id="org",
+        app_id="app",
+        agent_id="max",
+        dry_run=False,
+        skip_cognify=True,
+    )
+    assert fake_cognify.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_ingest_per_chunk_failure_continues(ingest_mod, monkeypatch) -> None:
+    async def flaky_add(content, **kwargs):
+        if "bad" in content:
+            raise RuntimeError("simulated cognee failure")
+        return "ok"
+
+    fake_module = MagicMock()
+    fake_module.add = flaky_add
+    fake_module.cognify = AsyncMock()
+    monkeypatch.setitem(sys.modules, "src.cognee.client", fake_module)
+
+    chunks = [
+        ("manual", "good1", []),
+        ("manual", "bad", []),
+        ("manual", "good2", []),
+    ]
+    ok, fail = await ingest_mod.ingest(
+        chunks,
+        org_id="org",
+        app_id="app",
+        agent_id="max",
+        dry_run=False,
+        skip_cognify=True,
+    )
+    assert ok == 2
+    assert fail == 1
+
+
+@pytest.mark.asyncio
+async def test_ingest_wrapper_import_failure_returns_all_fail(ingest_mod, monkeypatch) -> None:
+    # Force import of src.cognee.client to fail
+    real_import = (
+        __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+    )
+
+    def fake_import(name, *args, **kwargs):
+        if name == "src.cognee.client":
+            raise ImportError("not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "src.cognee.client", raising=False)
+
+    chunks = [("manual", "t1", []), ("manual", "t2", [])]
+    ok, fail = await ingest_mod.ingest(
+        chunks,
+        org_id="org",
+        app_id="app",
+        agent_id="max",
+        dry_run=False,
+        skip_cognify=True,
+    )
+    assert ok == 0
+    assert fail == 2
+
+
+# main CLI ──────────────────────────────────────────────────────────────────
+
+
+def test_main_dry_run_returns_zero(ingest_mod, monkeypatch, tmp_path) -> None:
+    p = tmp_path / "x.md"
+    p.write_text("body")
+    result = ingest_mod.main(["--sources", str(p), "--dry-run"])
+    assert result == 0
+
+
+def test_main_no_chunks_returns_one(ingest_mod, tmp_path) -> None:
+    # All --sources point to non-existent files → no chunks
+    result = ingest_mod.main(["--sources", str(tmp_path / "absent.md"), "--dry-run"])
+    assert result == 1
+
+
+def test_main_default_args_dry_run(ingest_mod) -> None:
+    # Default uses STREAM_1_SOURCES; --dry-run avoids wrapper import
+    result = ingest_mod.main(["--dry-run"])
+    assert result == 0


### PR DESCRIPTION
## Summary

Phase 1 dispatch per @elliot ts 1778562982 + source-list confirm ts 1778565xxx, Dave umbrella ts 1778562801. Builds `scripts/cognee_ingest.py` against @aiden's Phase 0 wrapper (PR #764).

**Sole Cognee call surface** is `src.cognee.client.{add, cognify}` per the Gap-3 architecture. Direct cognee SDK imports outside that wrapper are forbidden.

## Stream 1 source list (per Elliot's confirm)

| Source | Count | Tag |
|---|---|---|
| `docs/MANUAL.md` | 1 | `manual` |
| `ARCHITECTURE.md` | 1 | `architecture` |
| `DEFINITION_OF_DONE.md` | 1 | `dod` |
| `.claude/modules/*.md` | ~13 | `claude_modules` |
| `skills/*/SKILL.md` | ~15 | `skill` |
| Per-worktree `IDENTITY.md` × 6 | 6 | `identity` (+ `agent:<cs>`) |
| Per-worktree `HEARTBEAT.md` × 6 | 6 | `heartbeat` (+ `agent:<cs>`) |

Dropped `CONSOLIDATED_RULES.md` / `GOVERNANCE.md` per Elliot — the directive's reference is stale (file missing per Orion's audit; LAW XV-C says don't recreate).

`--include-aux-skills` flag opts in to `skills/**/*.md` beyond SKILL.md (off by default to keep graph signal high).

Streams 2/3/4 (SQL tables, cloud APIs, file paths beyond .md) deferred to separate PRs.

## CLI

```
--sources path1,path2,...      explicit override (testing / subset)
--include-aux-skills           ingest skills/**/*.md beyond SKILL.md
--dry-run                      print without calling add()/cognify()
--org-id / --app-id / --agent-id   passed through to wrapper
--skip-cognify                 incremental ingest mode
```

## Multi-tenant note

@aiden's revised position (per Scout Q4 finding + Elliot's authoritative call): Phase 0 wrapper will mint a Cognee User per Keiracom tenant before this PR can run live. My script's public API is unchanged either way — it just calls `client.add(..., org_id, app_id, agent_id, node_set)`. When Aiden's User-minting lands internally in the wrapper, this script benefits automatically.

## Verification (Rule 6)

```
$ pytest tests/scripts/test_cognee_ingest.py
============================== 19 passed in 0.28s ==============================

$ ruff check + format --check
All checks passed!

$ python3 scripts/cognee_ingest.py --dry-run | tail -1
INFO: done: 301 ok / 0 failed   (44 STREAM_1 files → 301 chunks, one Scout IDENTITY.md missing per Orion audit, gracefully skipped)
```

## Test plan

- [x] 19 unit tests pass (filesystem isolated via tmp_path, wrapper mocked via sys.modules injection)
- [x] Dry-run smoke produces 301 chunks across 44 files
- [x] Missing source files logged + skipped (idempotent + tolerant per directive)
- [x] Per-chunk failure continues; failure count returned at exit
- [ ] Live ingest against running Cognee — **gated on @aiden's `[PHASE-0-VERIFIED:aiden]` signal**
- [ ] Cross-namespace isolation (Dave's Validation Query 4) — gated on Aiden's per-tenant User-minting landing in wrapper

## Gating

This PR stays `[DRAFT]` until:
1. Atlas posts `[READY:atlas]` (install complete)
2. Aiden's PR #764 lands the per-tenant User-minting addition
3. Aiden's smoke evidence (3 items) lands in `#ceo`
4. `[PHASE-0-VERIFIED:aiden]` posted to `#execution`

Then this PR converts to non-draft + we run the live ingest behind a feature flag or manual trigger.

## Dual-CTO review

@aiden — peer review on the script shape, especially `_stream_1_sources()` source list + node_set tagging convention. Anything diverge from your wrapper's expected `node_set` semantics?
@elliot — source list matches your confirm; flag if any path is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)