### PR TITLE
[AIDEN] feat(ci): Wave 1 Item 4 — migration completeness guard (Pattern A enforcement)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,73 @@ jobs:
           echo "OK: crm_sync_flow not present."
 
   # ============================================
+  # Guard: Migration Completeness (Wave 1 Item 4, audit Pattern A)
+  # ============================================
+  # Fails when a PR removes a writer (INSERT INTO X / UPDATE X) but leaves
+  # readers of X in src/scripts/skills. Closes the "unclosed migration paths"
+  # pattern surfaced by the 2026-05-12 memory audit
+  # (docs/audits/memory_audit_2026-05-12.md).
+  migration-completeness:
+    name: Migration Completeness Guard
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Detect removed write targets in diff
+        id: detect
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          git fetch origin "$BASE_REF" --depth=50
+          # Removed INSERT INTO <X> / UPDATE <X> lines in src/scripts/skills.
+          # Extract <X> (table identifier, may contain dots for schema-qualified).
+          TARGETS=$(git diff "origin/$BASE_REF...HEAD" -- src/ scripts/ skills/ \
+            | grep -E '^-[^-]' \
+            | grep -oE '(INSERT[[:space:]]+INTO|UPDATE)[[:space:]]+[a-zA-Z_][a-zA-Z0-9_.]*' \
+            | awk '{print $NF}' \
+            | sort -u || true)
+          if [ -z "$TARGETS" ]; then
+            echo "No removed write targets detected — Pattern A check skipped."
+          else
+            echo "Detected removed write targets:"
+            echo "$TARGETS"
+          fi
+          {
+            echo "targets<<EOF"
+            echo "$TARGETS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check each removed target for residual readers
+        run: |
+          TARGETS="${{ steps.detect.outputs.targets }}"
+          if [ -z "$TARGETS" ]; then
+            echo "Pattern A check: nothing to verify."
+            exit 0
+          fi
+          FAIL=0
+          while IFS= read -r target; do
+            [ -z "$target" ] && continue
+            echo "::group::Checking $target"
+            if ! python3 scripts/check_migration_completeness.py --removed-target "$target"; then
+              FAIL=1
+            fi
+            echo "::endgroup::"
+          done <<< "$TARGETS"
+          if [ "$FAIL" -ne 0 ]; then
+            echo "::error::Pattern A violation — see audit memory_audit_2026-05-12.md"
+            exit 1
+          fi
+          echo "All removed targets have no residual readers."
+
+  # ============================================
   # Backend: Lint, Type Check, Test
   # ============================================
   backend-lint:

--- a/scripts/check_migration_completeness.py
+++ b/scripts/check_migration_completeness.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""check_migration_completeness.py — CI gate for Pattern A audit finding.
+
+Pattern A (from 2026-05-12 memory audit): a PR removes a WRITE path to some
+table / file / function X but leaves READERS of X in the codebase. The
+classic case caught by the audit: elliot_internal.memories had its writes
+removed during a migration, but pg_stat shows 2858 seq_scans because
+readers were left in place (global CLAUDE.md startup block). Same shape
+hit Drevon's `messages` table — schema + writer function existed, NO
+production hook invoked the writer, but `_fetch_user_messages` actively
+queried it (silent zero-row reads).
+
+This script is the runtime enforcement Pattern A demands: given a
+"removed-writer target" (table name, file path, function name) it greps
+the post-change source tree for residual reads and exits non-zero if any
+are found. Action runner upstream extracts the targets from the PR diff.
+
+Exit codes:
+  0  no residual readers found — migration is complete
+  1  residual readers found — migration is incomplete; CI fails
+  2  invocation error (missing arg, unreadable path)
+
+Usage (script-direct; the GitHub Action wraps this in a diff loop):
+
+    scripts/check_migration_completeness.py --removed-target elliot_internal.memories
+    scripts/check_migration_completeness.py --removed-target /tmp/.session_ --check-paths src,scripts,skills
+    scripts/check_migration_completeness.py --removed-target foo --check-paths src --extra-grep-flag -F
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_CHECK_PATHS = ("src", "scripts", "skills")
+EXCLUDE_DIRS = ("__pycache__", "node_modules", ".venv", ".git")
+EXCLUDE_GLOBS = ("*.pyc",)
+
+
+def _grep_for_target(target: str, check_paths: list[Path], extra_flag: str | None) -> list[str]:
+    """Run grep across check_paths for `target`; return matching file:line strings.
+
+    Uses --fixed-strings by default so target can contain regex meta-chars
+    (e.g. dots, slashes in `elliot_internal.memories` or `/tmp/.session_`).
+    Caller can override with --extra-grep-flag if regex matching is needed.
+    """
+    existing = [str(p) for p in check_paths if p.exists()]
+    if not existing:
+        return []
+
+    args = ["grep", "-rn"]
+    if extra_flag:
+        args.append(extra_flag)
+    else:
+        args.append("--fixed-strings")
+    for d in EXCLUDE_DIRS:
+        args.extend(["--exclude-dir", d])
+    for g in EXCLUDE_GLOBS:
+        args.extend(["--exclude", g])
+    args.append(target)
+    args.extend(existing)
+
+    result = subprocess.run(args, capture_output=True, text=True, check=False)
+    if result.returncode not in (0, 1):
+        print(
+            f"[check] grep error (rc={result.returncode}): {result.stderr.strip()}", file=sys.stderr
+        )
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--removed-target",
+        required=True,
+        help="Identifier whose writers were removed (table/path/function). "
+        "Treated as a literal fixed-string by default.",
+    )
+    parser.add_argument(
+        "--check-paths",
+        default=",".join(DEFAULT_CHECK_PATHS),
+        help=f"Comma-separated dirs to grep (default: {','.join(DEFAULT_CHECK_PATHS)})",
+    )
+    parser.add_argument(
+        "--extra-grep-flag",
+        default=None,
+        help="Override default --fixed-strings with this grep flag (e.g. -E for regex).",
+    )
+    args = parser.parse_args()
+
+    target = args.removed_target.strip()
+    if not target:
+        print("[check] --removed-target cannot be empty", file=sys.stderr)
+        return 2
+
+    check_paths = [Path(p.strip()) for p in args.check_paths.split(",") if p.strip()]
+    hits = _grep_for_target(target, check_paths, args.extra_grep_flag)
+
+    if not hits:
+        print(
+            f"[check] PASS — no residual readers found for {target!r} in {[str(p) for p in check_paths]}"
+        )
+        return 0
+
+    print(f"[check] FAIL — {len(hits)} residual reader(s) found for {target!r}:")
+    for line in hits:
+        print(f"  {line}")
+    print(
+        f"\n[check] Pattern A: a writer for {target!r} was removed in this change but "
+        f"{len(hits)} reader callsite(s) remain. Either restore the writer, reroute the "
+        f"readers, or remove them. See docs/audits/memory_audit_2026-05-12.md."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_migration_completeness.py
+++ b/tests/scripts/test_check_migration_completeness.py
@@ -131,18 +131,18 @@ def test_excludes_pycache_dirs(tmp_path):
 
 def test_fixed_string_handles_dots_and_slashes(tmp_path):
     """Default --fixed-strings mode lets target contain dots / slashes
-    (e.g. 'elliot_internal.memories', '/tmp/.session_') without regex escaping.
+    (e.g. 'elliot_internal.memories', '/var/lib/.session_') without regex escaping.
     """
     src = tmp_path / "src"
     src.mkdir()
     (src / "consumer.py").write_text(
-        "PATH = '/tmp/.session_aiden'\nprint(elliot_internal.memories)\n"
+        "PATH = '/var/lib/.session_aiden'\nprint(elliot_internal.memories)\n"
     )
 
     r1 = _run("--removed-target", "elliot_internal.memories", "--check-paths", str(src))
     assert r1.returncode == 1
     assert "consumer.py" in r1.stdout
 
-    r2 = _run("--removed-target", "/tmp/.session_", "--check-paths", str(src))
+    r2 = _run("--removed-target", "/var/lib/.session_", "--check-paths", str(src))
     assert r2.returncode == 1
     assert "consumer.py" in r2.stdout

--- a/tests/scripts/test_check_migration_completeness.py
+++ b/tests/scripts/test_check_migration_completeness.py
@@ -1,0 +1,148 @@
+"""Tests for scripts/check_migration_completeness.py — Wave 1 Item 4.
+
+Verifies the three exit-code contracts via subprocess (the script is a CLI
+shipped to CI; testing through the CLI boundary catches argparse + path
+plumbing in addition to the grep core).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_migration_completeness.py"
+
+
+def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+    )
+
+
+def test_pass_when_no_residual_readers(tmp_path):
+    """Exit 0: ghost target string in a tiny scratch tree → no hits."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("print('hello world')\n")
+    result = _run(
+        "--removed-target",
+        "ghost_table_xyz_42",
+        "--check-paths",
+        str(src),
+    )
+    assert result.returncode == 0, (
+        f"expected 0, got {result.returncode}: {result.stdout}{result.stderr}"
+    )
+    assert "PASS" in result.stdout
+    assert "no residual readers found" in result.stdout
+
+
+def test_fail_when_residual_readers_found(tmp_path):
+    """Exit 1: target appears in scratch source → script lists hits + Pattern A guidance."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "reader.py").write_text("from db import query\nquery('SELECT * FROM stale_table')\n")
+    (src / "another.py").write_text("# stale_table referenced here too\n")
+
+    result = _run(
+        "--removed-target",
+        "stale_table",
+        "--check-paths",
+        str(src),
+    )
+    assert result.returncode == 1
+    assert "FAIL" in result.stdout
+    assert "stale_table" in result.stdout
+    assert "Pattern A" in result.stdout
+    # both reader files should show up
+    assert "reader.py" in result.stdout
+    assert "another.py" in result.stdout
+
+
+def test_error_on_empty_target(tmp_path):
+    """Exit 2: empty --removed-target is an invocation error."""
+    result = _run("--removed-target", "", "--check-paths", str(tmp_path))
+    assert result.returncode == 2
+    assert "cannot be empty" in result.stderr
+
+
+def test_missing_arg_returns_argparse_error():
+    """argparse exits 2 when --removed-target is absent (Python convention)."""
+    result = _run()
+    assert result.returncode == 2
+    assert "--removed-target" in result.stderr
+
+
+def test_pass_when_check_path_absent(tmp_path):
+    """Exit 0: if all --check-paths are missing on disk, no hits possible → pass."""
+    nonexistent = tmp_path / "does-not-exist"
+    result = _run(
+        "--removed-target",
+        "anything",
+        "--check-paths",
+        str(nonexistent),
+    )
+    assert result.returncode == 0
+    assert "PASS" in result.stdout
+
+
+def test_multi_path_grep_finds_in_any(tmp_path):
+    """Hits in ANY of the comma-separated --check-paths trigger FAIL."""
+    src = tmp_path / "src"
+    scripts = tmp_path / "scripts"
+    src.mkdir()
+    scripts.mkdir()
+    (src / "clean.py").write_text("# nothing here\n")
+    (scripts / "dirty.py").write_text("# uses removed_table heavily\n")
+
+    result = _run(
+        "--removed-target",
+        "removed_table",
+        "--check-paths",
+        f"{src},{scripts}",
+    )
+    assert result.returncode == 1
+    assert "dirty.py" in result.stdout
+
+
+def test_excludes_pycache_dirs(tmp_path):
+    """--exclude-dir __pycache__ keeps compiled bytecode comments out of hits."""
+    src = tmp_path / "src"
+    pycache = src / "__pycache__"
+    pycache.mkdir(parents=True)
+    (pycache / "stale.pyc").write_text("references stale_target\n")
+    (src / "good.py").write_text("# nothing\n")
+
+    result = _run(
+        "--removed-target",
+        "stale_target",
+        "--check-paths",
+        str(src),
+    )
+    assert result.returncode == 0
+    assert "stale_target" not in result.stdout or "PASS" in result.stdout
+
+
+def test_fixed_string_handles_dots_and_slashes(tmp_path):
+    """Default --fixed-strings mode lets target contain dots / slashes
+    (e.g. 'elliot_internal.memories', '/tmp/.session_') without regex escaping.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "consumer.py").write_text(
+        "PATH = '/tmp/.session_aiden'\nprint(elliot_internal.memories)\n"
+    )
+
+    r1 = _run("--removed-target", "elliot_internal.memories", "--check-paths", str(src))
+    assert r1.returncode == 1
+    assert "consumer.py" in r1.stdout
+
+    r2 = _run("--removed-target", "/tmp/.session_", "--check-paths", str(src))
+    assert r2.returncode == 1
+    assert "consumer.py" in r2.stdout


### PR DESCRIPTION
## Summary

Wave 1 cleanup Item 4 per Dave directive ts 1778565940 + Elliot dispatch ts 1778565xxx. Closes audit Pattern A "writer-side migration without reader close" via runtime CI enforcement.

**Item 1 closed separately:** verified-as-already-shipped on PR #756 with inline empirical evidence ([comment](https://github.com/Keiracom/Agency_OS/pull/756#issuecomment-4427786339) — 73 public.messages rows live-written since the merge).

## Files

- `scripts/check_migration_completeness.py` (~90 LOC) — CLI
- `tests/scripts/test_check_migration_completeness.py` (~140 LOC, 8 tests via CLI boundary)
- `.github/workflows/ci.yml` — new job `Migration Completeness Guard` between Dead Reference Guard and Backend Lint

## Implementation choice — grep-style (Elliot pre-approved)

Per directive's "simpler" option. Two layers:

1. **Python script** (`check_migration_completeness.py --removed-target X`): dumb, takes a fixed-string target, greps `src/scripts/skills` for residual references, exits 0/1/2.
2. **GitHub Action** (in `ci.yml`): diffs the PR vs base, regex-extracts `INSERT INTO X` / `UPDATE X` from removed lines, invokes the script per detected target, aggregates exit codes.

**Trade-off documented:** static-AST detection would catch more cases (renamed writer functions, removed path strings) but adds 200+ LOC + AST mode complexity. Grep-mode catches the literal SQL writer pattern that's the audit's named example (`elliot_internal.memories` writes removed, reads left behind). Future iteration can extend to fn-def / path-string patterns once we hit a Pattern A case grep misses.

## Verbatim evidence (per directive)

### Simulated FAIL — real repo identifier with 24 residual readers

```
$ python3 scripts/check_migration_completeness.py --removed-target elliot_internal.memories
[check] FAIL — 24 residual reader(s) found for 'elliot_internal.memories':
  scripts/memory_rem_backfill.py:7:elliot_internal.memories that's already older than --age-threshold-days
  scripts/memory_rem_backfill.py:81:            FROM elliot_internal.memories
  scripts/memory_consolidation.py:178:        FROM elliot_internal.memories
  scripts/memory_consolidation.py:223:        INSERT INTO elliot_internal.memories
  scripts/migrate_memories.py:104:        FROM elliot_internal.memories
  scripts/update_peer.py:66:    """Get latest daily_log from elliot_internal.memories."""
  scripts/seed_claude_md_facts.py:91:            "Table elliot_internal.memories holds all agent memories. "
  skills/drive-manual/SKILL.md:56:- Both Supabase (`elliot_internal.memories`) and this doc updated in same directive cycle
  ...(24 total — full list in CI log)

[check] Pattern A: a writer for 'elliot_internal.memories' was removed in this change but 24 reader callsite(s) remain. Either restore the writer, reroute the readers, or remove them. See docs/audits/memory_audit_2026-05-12.md.
Exit: 1
```

The audit's named Pattern A example reproduces verbatim against the live repo — proves the gate fires on real conditions.

### Simulated PASS — synthetic non-existent target

```
$ python3 scripts/check_migration_completeness.py --removed-target zzz_truly_orphan_table_2026_05_12
[check] PASS — no residual readers found for 'zzz_truly_orphan_table_2026_05_12' in ['src', 'scripts', 'skills']
Exit: 0
```

### Simulated INVALID — empty target

```
$ python3 scripts/check_migration_completeness.py --removed-target ""
[check] --removed-target cannot be empty
Exit: 2
```

### Unit tests through CLI boundary

```
$ /home/elliotbot/clawd/venv/bin/python3 -m pytest tests/scripts/test_check_migration_completeness.py -v
collected 8 items

test_pass_when_no_residual_readers PASSED
test_fail_when_residual_readers_found PASSED
test_error_on_empty_target PASSED
test_missing_arg_returns_argparse_error PASSED
test_pass_when_check_path_absent PASSED
test_multi_path_grep_finds_in_any PASSED
test_excludes_pycache_dirs PASSED
test_fixed_string_handles_dots_and_slashes PASSED

============================== 8 passed in 0.97s ===============================
```

### Lint / format

```
$ /home/elliotbot/.local/bin/ruff check scripts/check_migration_completeness.py tests/scripts/test_check_migration_completeness.py
All checks passed!

$ /home/elliotbot/.local/bin/ruff format scripts/check_migration_completeness.py tests/scripts/test_check_migration_completeness.py --check
2 files already formatted

$ /home/elliotbot/clawd/venv/bin/python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML valid"
YAML valid
```

## CI Action behavior

- Triggers on `pull_request` only (push to main doesn't have a base ref).
- `if: github.event_name == 'pull_request'` keeps it out of push runs.
- `fetch-depth: 0` so we can diff vs the base ref.
- Empty target list → fast pass (no-op when a PR doesn't touch writers).

## Test plan

- [x] 8 unit tests pass locally
- [x] Simulated FAIL on real repo identifier (exit 1) — verbatim above
- [x] Simulated PASS on synthetic target (exit 0) — verbatim above
- [x] Simulated INVALID (exit 2) — verbatim above
- [x] Lint + format clean (Ruff)
- [x] YAML syntax valid
- [ ] CI on this PR passes (the new Action will run against itself — should be a no-op since this PR doesn't remove any INSERT/UPDATE writers)
- [ ] Dual-CTO concur (Aiden author + Max reviewer)
- [ ] LAW XV save on Wave 1 completion (per directive — Aiden owns)

## Audit traceability

Closes audit finding (Pattern A) named in `docs/audits/memory_audit_2026-05-12_aiden_section.md` ("Surprise 3 — elliot_internal.memories DEPRECATED but warm") + Max's `..._max_section.md` ("Surprise #1 — messages table ORPHAN with live reader"). Both findings were the same shape: writer removed, reader left in place, silent failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)