### PR TITLE
[MAX] fix(cis_directive_metrics): Wave 1 Item 2 — dedup + UNIQUE + ON CONFLICT

### DIFF
--- a/scripts/three_store_save.py
+++ b/scripts/three_store_save.py
@@ -289,6 +289,12 @@ def save_metrics(
 
         conn = await asyncpg.connect(dsn, statement_cache_size=0)
         try:
+            # Wave 1 Item 2 (audit Pattern A fix): upsert on (directive_id,
+            # directive_ref) — compound key with NULLS NOT DISTINCT semantics
+            # (Postgres 15+ via supabase/migrations/20260512_cis_directive_
+            # metrics_unique_dedup.sql). Replay updates completed_date +
+            # increments execution_rounds + refreshes mutable fields; original
+            # issued_date + created_at are preserved.
             await conn.execute(
                 """
                 INSERT INTO cis_directive_metrics (
@@ -300,6 +306,15 @@ def save_metrics(
                   $5, $6, $7,
                   $8, $9, $10, $11, $12
                 )
+                ON CONFLICT (directive_id, directive_ref) DO UPDATE SET
+                  completed_date = EXCLUDED.completed_date,
+                  execution_rounds = cis_directive_metrics.execution_rounds + 1,
+                  scope_creep = EXCLUDED.scope_creep,
+                  verification_first_pass = EXCLUDED.verification_first_pass,
+                  save_completed = EXCLUDED.save_completed,
+                  agents_used = EXCLUDED.agents_used,
+                  notes = EXCLUDED.notes,
+                  callsign = EXCLUDED.callsign
                 """,
                 directive_id,
                 directive_ref,

--- a/supabase/migrations/20260512_cis_directive_metrics_unique_dedup.sql
+++ b/supabase/migrations/20260512_cis_directive_metrics_unique_dedup.sql
@@ -1,0 +1,63 @@
+-- Migration: cis_directive_metrics dedup + UNIQUE index
+-- Wave 1 Item 2 (Dave directive ts 1778565940, Elliot dispatch ts 1778566186,
+-- confirm-to-execute ts 1778566xxx).
+--
+-- Problem (audit Surprise — Aiden Stream 1 section, 2026-05-12):
+--   scripts/three_store_save.py INSERTs into public.cis_directive_metrics with
+--   no ON CONFLICT clause. Replay-save during directive retry creates duplicate
+--   rows. Empirical state at migration time: 195 total rows, 175 distinct
+--   (directive_id, directive_ref) keys → 20 duplicate-pair rows (all with
+--   directive_ref=NULL, i.e. numeric directives replayed).
+--
+-- Fix:
+--   1. Dedup: keep the latest row per (directive_id, directive_ref) by
+--      completed_date DESC NULLS LAST, created_at DESC tiebreak.
+--   2. Add UNIQUE index with NULLS NOT DISTINCT semantics so future replays
+--      can use INSERT ... ON CONFLICT (directive_id, directive_ref) DO UPDATE.
+--      Compound key is required because non-numeric directives use directive_id=0
+--      + a non-null directive_ref ('D1.8', 'CD-PLAYER-V1', etc.); a bare
+--      directive_id UNIQUE would collapse all those into one row.
+--   3. Postgres 15+ NULLS NOT DISTINCT — Supabase runs 15.x.
+--
+-- Re-runnable: dedup is idempotent (no rows to remove on second run); index is
+-- IF NOT EXISTS.
+
+-- Step 1: deduplicate. Keep latest by completed_date DESC NULLS LAST, then
+-- created_at DESC. CTE numbers rows per group; delete all but row_number=1.
+WITH ranked AS (
+    SELECT
+        id,
+        row_number() OVER (
+            PARTITION BY directive_id, directive_ref
+            ORDER BY completed_date DESC NULLS LAST, created_at DESC
+        ) AS rn
+    FROM public.cis_directive_metrics
+)
+DELETE FROM public.cis_directive_metrics
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- Step 2: add UNIQUE index. NULLS NOT DISTINCT means two rows with the same
+-- directive_id and both directive_ref=NULL count as a conflict (correct for
+-- numeric directives where directive_ref is always NULL).
+CREATE UNIQUE INDEX IF NOT EXISTS
+    cis_directive_metrics_directive_uniq
+    ON public.cis_directive_metrics (directive_id, directive_ref)
+    NULLS NOT DISTINCT;
+
+-- Step 3: dedupe verification — runtime sanity check that the index can be
+-- created. If duplicates remain (shouldn't), this raises in the same txn.
+DO $$
+DECLARE
+    dup_count INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO dup_count
+    FROM (
+        SELECT 1
+        FROM public.cis_directive_metrics
+        GROUP BY directive_id, directive_ref
+        HAVING COUNT(*) > 1
+    ) t;
+    IF dup_count > 0 THEN
+        RAISE EXCEPTION 'cis_directive_metrics still has % duplicate keys after dedup', dup_count;
+    END IF;
+END $$;

--- a/tests/test_three_store_save.py
+++ b/tests/test_three_store_save.py
@@ -180,6 +180,50 @@ def test_save_metrics_numeric_directive_uses_directive_id(monkeypatch):
     assert args[1] is None
 
 
+def test_save_metrics_includes_on_conflict_compound_key(monkeypatch):
+    """Wave 1 Item 2: replay must not duplicate rows. INSERT uses ON CONFLICT
+    (directive_id, directive_ref) DO UPDATE for the compound-key upsert
+    (NULLS NOT DISTINCT in the migration handles numeric directives where
+    directive_ref is always NULL)."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/d")
+    conn = _FakeConn()
+    _patch_asyncpg(monkeypatch, conn)
+    tss.save_metrics("D7", 707, "summary", dry_run=False, callsign="max")
+    sql, _ = conn.executed[0]
+    assert "INSERT INTO cis_directive_metrics" in sql
+    assert "ON CONFLICT (directive_id, directive_ref) DO UPDATE SET" in sql
+
+
+def test_save_metrics_on_conflict_increments_execution_rounds(monkeypatch):
+    """ON CONFLICT path increments execution_rounds (captures replay count)."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/d")
+    conn = _FakeConn()
+    _patch_asyncpg(monkeypatch, conn)
+    tss.save_metrics("D7", 707, "summary", dry_run=False)
+    sql, _ = conn.executed[0]
+    assert "execution_rounds = cis_directive_metrics.execution_rounds + 1" in sql
+
+
+def test_save_metrics_on_conflict_updates_mutable_fields(monkeypatch):
+    """ON CONFLICT replaces completed_date, notes, callsign, agents_used, and
+    the three boolean status flags with EXCLUDED.* — the replay's new values."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/d")
+    conn = _FakeConn()
+    _patch_asyncpg(monkeypatch, conn)
+    tss.save_metrics("D7", 707, "summary", dry_run=False)
+    sql, _ = conn.executed[0]
+    for field in (
+        "completed_date = EXCLUDED.completed_date",
+        "scope_creep = EXCLUDED.scope_creep",
+        "verification_first_pass = EXCLUDED.verification_first_pass",
+        "save_completed = EXCLUDED.save_completed",
+        "agents_used = EXCLUDED.agents_used",
+        "notes = EXCLUDED.notes",
+        "callsign = EXCLUDED.callsign",
+    ):
+        assert field in sql, f"missing {field!r} in DO UPDATE SET"
+
+
 def test_save_ceo_memory_swallows_asyncpg_error(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/d")
     import sys


### PR DESCRIPTION
## Summary

Wave 1 Item 2 fix per Dave directive ts 1778565940 + Elliot dispatch ts 1778566186 + confirm-to-execute on Step 0 addendum A/B/C.

Closes the audit Surprise from @aiden's Stream 1 section: `scripts/three_store_save.py` INSERT into `public.cis_directive_metrics` had no ON CONFLICT clause, so directive replays produced duplicate rows.

## Empirical pre-fix state (Rule 6)

```sql
WITH ranked AS (
    SELECT id, row_number() OVER (
        PARTITION BY directive_id, directive_ref
        ORDER BY completed_date DESC NULLS LAST, created_at DESC
    ) AS rn
    FROM public.cis_directive_metrics
)
SELECT
    (SELECT COUNT(*) FROM public.cis_directive_metrics) AS rows_before,
    (SELECT COUNT(*) FROM ranked WHERE rn > 1) AS rows_to_delete,
    (SELECT COUNT(*) FROM ranked WHERE rn = 1) AS rows_after_dedup;
-- → rows_before=195, rows_to_delete=20, rows_after_dedup=175
```

All 20 duplicate pairs have `directive_ref=NULL` — i.e. numeric directives replayed.

## Three-part fix

1. **`supabase/migrations/20260512_cis_directive_metrics_unique_dedup.sql`**
   - Dedup CTE keeps latest row per `(directive_id, directive_ref)` by `completed_date DESC NULLS LAST, created_at DESC`.
   - `CREATE UNIQUE INDEX ... ON (directive_id, directive_ref) NULLS NOT DISTINCT` (Postgres 15+).
   - DO block re-checks duplicate count post-dedup, raises if any remain.
   - Re-runnable (dedup idempotent + IF NOT EXISTS index).

2. **`scripts/three_store_save.py`** L292-326 INSERT updated:
   ```sql
   ON CONFLICT (directive_id, directive_ref) DO UPDATE SET
     completed_date = EXCLUDED.completed_date,
     execution_rounds = cis_directive_metrics.execution_rounds + 1,
     scope_creep = EXCLUDED.scope_creep,
     verification_first_pass = EXCLUDED.verification_first_pass,
     save_completed = EXCLUDED.save_completed,
     agents_used = EXCLUDED.agents_used,
     notes = EXCLUDED.notes,
     callsign = EXCLUDED.callsign
   ```
   `issued_date` + `created_at` preserve original timestamps. `execution_rounds` increments to capture replay count.

3. **`tests/test_three_store_save.py`** +3 tests asserting: compound conflict key in SQL, execution_rounds increment expression, all 7 EXCLUDED.X mutable-field assignments.

## Why compound key + NULLS NOT DISTINCT

Per Step 0 addendum question B (Aiden + Elliot CONCURRED): bare `directive_id` UNIQUE would silently collapse all `directive_id=0` rows (non-numeric directives like 'D1.8' use `directive_id=0` + `directive_ref='D1.8'`). `NULLS NOT DISTINCT` lets numeric directives (`directive_ref=NULL`) collide on `directive_id` alone, while non-numeric collide on the `directive_ref` string. Single index covers both shapes.

## Verification (Rule 6)

```
$ grep "ON CONFLICT" scripts/three_store_save.py
226:                ON CONFLICT (key) DO UPDATE  # existing ceo_memory upsert
309:                ON CONFLICT (directive_id, directive_ref) DO UPDATE SET

$ pytest tests/test_three_store_save.py
19 passed in 0.60s   (16 existing + 3 new)
```

## Test plan

- [x] 19/19 tests pass locally (3 new + 16 existing untouched)
- [x] Migration dry-run via SELECT confirms 195 → 175 row dedup outcome
- [x] Pre-existing `scripts/` lint NOT scoped to my edit (CI runs `ruff check src/` only)
- [ ] CI green
- [ ] Dual-CTO concur (@aiden + me; Elliot already confirmed-to-execute on Step 0)
- [ ] Migration applied on merge — `SELECT COUNT(*) FROM cis_directive_metrics WHERE directive_id=<test> = 1 after two replays` per directive evidence requirement

## Item 3 (mem0 retirement) follows separately

Per Step 0 A: two-PR split. Item 3 lands as a separate PR — different scope (data migration + env-flag flip), different blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)