### PR TITLE
[MAX] feat(mem0): Wave 1 Item 3 — retire mem0 (82 rows migrated to agent_memories, dual-write+recall disabled, ceo_memory RETIRED)

### DIFF
--- a/scripts/wave1_retire_mem0.py
+++ b/scripts/wave1_retire_mem0.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""wave1_retire_mem0.py — staged retirement of mem0 cloud memory backend.
+
+Wave 1 Item 3 (Dave directive ts 1778565940, Elliot dispatch ts 1778566186,
+confirm-to-execute on Step 0 addendum C). Mem0 never worked in production
+(82 memories under wrong callsign per Atlas's mem0 audit section, empty
+recall by construction). This script rescues the data + retires the path.
+
+Steps run by this script:
+  1. Read all mem0 memories via MemoryClient.get_all() (paginated).
+  2. For each memory:
+       - infer correct callsign from content (case-insensitive scan for any
+         of {elliot, aiden, max, atlas, orion, scout}); fall back to the
+         mem0 user_id; fall back to 'unknown' as last resort.
+       - INSERT into public.agent_memories with:
+           source_type = 'rescued_from_mem0'
+           typed_metadata.node_set = ['rescued', 'mem0_migration']
+           typed_metadata.mem0_original_user_id = <original>
+           typed_metadata.mem0_id = <mem0 row id>
+           state = 'confirmed'
+  3. Print pre-migration count + post-migration insert count + Atlas's audit
+     baseline (82) for cross-check.
+
+NOT in this script (per directive — applied separately as PR evidence):
+  - .env update (MEMORY_RECALL_BACKEND=supabase; MEM0_INTEGRATION_ENABLED=false)
+  - ceo_memory key ceo:mem0_decision_2026-05-01 → "RETIRED"
+  - mem0_adapter.py retained, gated by existing env-var checks at callsites
+
+Usage:
+    wave1_retire_mem0.py [--dry-run] [--limit N] [--page-size N]
+
+    --dry-run (default): read mem0 + print what would be inserted; no DB writes.
+    --execute: actually INSERT into agent_memories.
+    --limit: cap total memories processed (default: all).
+    --page-size: mem0 pagination size (default: 100).
+
+Best-effort: per-memory failures log + continue. Exits 0 on success or
+dry-run; 1 on partial failures; 2 on fatal config / SDK / DB issues.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from uuid import uuid4
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("wave1_retire_mem0")
+
+KNOWN_CALLSIGNS = ("elliot", "aiden", "max", "atlas", "orion", "scout")
+_CALLSIGN_RE = re.compile(
+    r"\b(" + "|".join(KNOWN_CALLSIGNS) + r")\b", re.IGNORECASE
+)
+ATLAS_AUDIT_BASELINE = 82  # per Atlas mem0 audit section (cross-check)
+
+
+def infer_callsign(content: str, fallback: str = "unknown") -> str:
+    """Scan content for a known callsign mention; return lowercase or fallback."""
+    if not content:
+        return fallback
+    match = _CALLSIGN_RE.search(content)
+    if match:
+        return match.group(1).lower()
+    return fallback
+
+
+# mem0 v3 API requires non-empty filters on get_all. Iterate known callsigns
+# (and common fallbacks for "wrong callsign" rows per Atlas's audit) so we
+# enumerate the full retirement set.
+MEM0_FILTER_USER_IDS = (*KNOWN_CALLSIGNS, "unknown", "system", "claude")
+
+
+def fetch_mem0_memories(page_size: int = 100, limit: int | None = None) -> list[dict]:
+    """Iterate get_all() per known user_id filter; concatenate + dedupe by id.
+
+    Empty on SDK/auth failure (logged). Per-filter failure logs + continues.
+    """
+    try:
+        from mem0 import MemoryClient
+    except ImportError as exc:
+        logger.error("mem0 SDK not importable: %s", exc)
+        return []
+    api_key = os.environ.get("MEM0_API_KEY", "")
+    if not api_key:
+        logger.error("MEM0_API_KEY not set — cannot read mem0")
+        return []
+    try:
+        client = MemoryClient(api_key=api_key)
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.error("mem0 client init failed: %s", exc)
+        return []
+
+    seen_ids: set[str] = set()
+    rows: list[dict] = []
+
+    for user_id in MEM0_FILTER_USER_IDS:
+        page = 1
+        while True:
+            try:
+                resp = client.get_all(
+                    filters={"user_id": user_id},
+                    page=page,
+                    page_size=page_size,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("mem0 get_all user_id=%s page=%d failed: %s",
+                               user_id, page, exc)
+                break
+            # mem0 v3 returns dict {count, next, previous, results} OR plain list
+            # (older versions). Normalise.
+            if isinstance(resp, dict):
+                batch = resp.get("results", []) or []
+                has_next = bool(resp.get("next"))
+            else:
+                batch = resp or []
+                has_next = len(batch) >= page_size
+            if not batch:
+                break
+            for r in batch:
+                if not isinstance(r, dict):
+                    continue
+                rid = r.get("id")
+                if rid and rid not in seen_ids:
+                    seen_ids.add(rid)
+                    rows.append(r)
+            logger.info("mem0 user_id=%s page=%d → %d rows (running total %d)",
+                        user_id, page, len(batch), len(rows))
+            if limit is not None and len(rows) >= limit:
+                return rows[:limit]
+            if not has_next:
+                break
+            page += 1
+    return rows
+
+
+def build_agent_memory_row(mem0_row: dict) -> dict | None:
+    """Map a mem0 row to an agent_memories INSERT payload. None on bad shape."""
+    content = mem0_row.get("memory") or mem0_row.get("text") or ""
+    if not content:
+        return None
+    mem0_user_id = mem0_row.get("user_id") or ""
+    callsign = infer_callsign(content, fallback=mem0_user_id or "unknown")
+    typed_metadata = {
+        "node_set": ["rescued", "mem0_migration"],
+        "mem0_original_user_id": mem0_user_id,
+        "mem0_id": mem0_row.get("id", ""),
+        "mem0_metadata": mem0_row.get("metadata") or {},
+    }
+    return {
+        "id": str(uuid4()),
+        "callsign": callsign,
+        "source_type": "rescued_from_mem0",
+        "content": content,
+        "typed_metadata": typed_metadata,
+        "state": "confirmed",
+    }
+
+
+async def insert_rows(rows: Iterable[dict]) -> tuple[int, int]:
+    """INSERT each row into public.agent_memories via asyncpg. Returns (ok, fail)."""
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        logger.error("no DATABASE_URL / SUPABASE_DB_URL — cannot insert")
+        return 0, sum(1 for _ in rows)
+    dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+    import asyncpg
+
+    conn = await asyncpg.connect(dsn, statement_cache_size=0)
+    ok, fail = 0, 0
+    try:
+        for row in rows:
+            try:
+                await conn.execute(
+                    """
+                    INSERT INTO public.agent_memories
+                      (id, callsign, source_type, content, typed_metadata,
+                       created_at, valid_from, state)
+                    VALUES ($1, $2, $3, $4, $5::jsonb, NOW(), NOW(), $6)
+                    """,
+                    row["id"],
+                    row["callsign"],
+                    row["source_type"],
+                    row["content"],
+                    json.dumps(row["typed_metadata"]),
+                    row["state"],
+                )
+                ok += 1
+            except Exception as exc:  # noqa: BLE001 — best-effort
+                logger.warning("INSERT failed for mem0_id=%s: %s",
+                               row["typed_metadata"].get("mem0_id"), exc)
+                fail += 1
+    finally:
+        await conn.close()
+    return ok, fail
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", default=True,
+                        help="(default) Read + map without writing")
+    parser.add_argument("--execute", dest="dry_run", action="store_false",
+                        help="Actually INSERT into agent_memories")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--page-size", type=int, default=100)
+    args = parser.parse_args(argv)
+
+    logger.info("Fetching mem0 memories (page-size=%d, limit=%s)",
+                args.page_size, args.limit)
+    mem0_rows = fetch_mem0_memories(page_size=args.page_size, limit=args.limit)
+    logger.info("mem0 returned %d rows (Atlas audit baseline: %d)",
+                len(mem0_rows), ATLAS_AUDIT_BASELINE)
+    if len(mem0_rows) != ATLAS_AUDIT_BASELINE:
+        logger.warning(
+            "mem0 row count diverges from Atlas baseline (%d vs %d) — "
+            "Atlas's audit was point-in-time; current state is canonical for retirement",
+            len(mem0_rows), ATLAS_AUDIT_BASELINE,
+        )
+
+    payloads = []
+    for r in mem0_rows:
+        p = build_agent_memory_row(r)
+        if p is None:
+            logger.warning("skipping mem0 row with empty content: %s", r.get("id"))
+            continue
+        payloads.append(p)
+    logger.info("built %d agent_memories payloads", len(payloads))
+
+    if args.dry_run:
+        logger.info("[DRY-RUN] would INSERT %d rows; pass --execute to live-run", len(payloads))
+        for p in payloads[:3]:
+            logger.info("  sample: callsign=%s content=%r metadata=%s",
+                        p["callsign"], p["content"][:80], p["typed_metadata"])
+        return 0
+
+    ok, fail = asyncio.run(insert_rows(payloads))
+    logger.info("migration complete: %d ok / %d failed", ok, fail)
+    return 0 if fail == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_wave1_retire_mem0.py
+++ b/tests/scripts/test_wave1_retire_mem0.py
@@ -1,0 +1,193 @@
+"""tests for scripts/wave1_retire_mem0.py — Wave 1 Item 3 mem0 retirement.
+
+mem0 SDK + asyncpg mocked. Filesystem isolated. No live calls.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "wave1_retire_mem0.py"
+
+
+@pytest.fixture(scope="module")
+def retire_mod():
+    spec = importlib.util.spec_from_file_location("wave1_retire_mem0", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wave1_retire_mem0"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# infer_callsign ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        ("Elliot ran the deploy", "elliot"),
+        ("Aiden wrote the test", "aiden"),
+        ("Max merged the PR", "max"),
+        ("Atlas did the install", "atlas"),
+        ("ORION is offline", "orion"),
+        ("Scout researched X", "scout"),
+        ("no known names here", "unknown"),
+    ],
+)
+def test_infer_callsign_matches_known(retire_mod, content, expected) -> None:
+    assert retire_mod.infer_callsign(content) == expected
+
+
+def test_infer_callsign_falls_back_to_provided(retire_mod) -> None:
+    assert retire_mod.infer_callsign("nothing", fallback="custom") == "custom"
+
+
+def test_infer_callsign_empty_content(retire_mod) -> None:
+    assert retire_mod.infer_callsign("", fallback="x") == "x"
+
+
+def test_infer_callsign_lowercases(retire_mod) -> None:
+    assert retire_mod.infer_callsign("ELLIOT did it") == "elliot"
+
+
+# build_agent_memory_row ─────────────────────────────────────────────────────
+
+
+def test_build_row_uses_memory_field(retire_mod) -> None:
+    mem0_row = {"id": "m1", "user_id": "abc", "memory": "Elliot fixed it"}
+    row = retire_mod.build_agent_memory_row(mem0_row)
+    assert row is not None
+    assert row["callsign"] == "elliot"
+    assert row["content"] == "Elliot fixed it"
+    assert row["source_type"] == "rescued_from_mem0"
+    assert row["typed_metadata"]["node_set"] == ["rescued", "mem0_migration"]
+    assert row["typed_metadata"]["mem0_original_user_id"] == "abc"
+    assert row["typed_metadata"]["mem0_id"] == "m1"
+    assert row["state"] == "confirmed"
+
+
+def test_build_row_falls_back_to_text_field(retire_mod) -> None:
+    mem0_row = {"id": "m2", "user_id": "u", "text": "Aiden testing"}
+    row = retire_mod.build_agent_memory_row(mem0_row)
+    assert row is not None
+    assert row["content"] == "Aiden testing"
+
+
+def test_build_row_returns_none_on_empty_content(retire_mod) -> None:
+    assert retire_mod.build_agent_memory_row({"id": "m3", "user_id": "x"}) is None
+    assert retire_mod.build_agent_memory_row({"id": "m4", "memory": ""}) is None
+
+
+def test_build_row_no_known_callsign_falls_back_to_mem0_user_id(retire_mod) -> None:
+    mem0_row = {"id": "m5", "user_id": "custom_user", "memory": "no callsign here"}
+    row = retire_mod.build_agent_memory_row(mem0_row)
+    assert row["callsign"] == "custom_user"
+
+
+# fetch_mem0_memories ────────────────────────────────────────────────────────
+
+
+def test_fetch_no_api_key(retire_mod, monkeypatch) -> None:
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
+    # Stub the SDK so the ImportError path isn't reached
+    fake_module = MagicMock()
+    monkeypatch.setitem(sys.modules, "mem0", fake_module)
+    assert retire_mod.fetch_mem0_memories() == []
+
+
+def test_fetch_paginates_per_user_id_and_dedupes(retire_mod, monkeypatch) -> None:
+    """fetch_mem0_memories iterates MEM0_FILTER_USER_IDS, dedupes by id, stops
+    on short batch per filter."""
+    monkeypatch.setenv("MEM0_API_KEY", "test-key")
+    fake_client = MagicMock()
+
+    def get_all(filters, page, page_size):
+        user_id = filters.get("user_id")
+        if user_id == "elliot" and page == 1:
+            return [{"id": "shared_1", "memory": "x"}, {"id": "el_only", "memory": "x"}]
+        if user_id == "max" and page == 1:
+            # shared_1 should be deduped; max_only is new
+            return [{"id": "shared_1", "memory": "x"}, {"id": "max_only", "memory": "x"}]
+        # All other user_ids return empty (short batch → break)
+        return []
+
+    fake_client.get_all.side_effect = get_all
+    fake_module = MagicMock()
+    fake_module.MemoryClient.return_value = fake_client
+    monkeypatch.setitem(sys.modules, "mem0", fake_module)
+
+    rows = retire_mod.fetch_mem0_memories(page_size=100)
+    ids = [r["id"] for r in rows]
+    assert ids == ["shared_1", "el_only", "max_only"]  # deduped + insertion-ordered
+
+
+def test_fetch_respects_limit(retire_mod, monkeypatch) -> None:
+    monkeypatch.setenv("MEM0_API_KEY", "k")
+    fake_client = MagicMock()
+    fake_client.get_all.return_value = [{"id": f"m{i}", "memory": "x"} for i in range(100)]
+    fake_module = MagicMock()
+    fake_module.MemoryClient.return_value = fake_client
+    monkeypatch.setitem(sys.modules, "mem0", fake_module)
+
+    rows = retire_mod.fetch_mem0_memories(page_size=100, limit=5)
+    assert len(rows) == 5
+
+
+def test_fetch_swallows_sdk_errors(retire_mod, monkeypatch) -> None:
+    monkeypatch.setenv("MEM0_API_KEY", "k")
+    fake_client = MagicMock()
+    fake_client.get_all.side_effect = RuntimeError("network blip")
+    fake_module = MagicMock()
+    fake_module.MemoryClient.return_value = fake_client
+    monkeypatch.setitem(sys.modules, "mem0", fake_module)
+
+    assert retire_mod.fetch_mem0_memories() == []
+
+
+# main CLI ──────────────────────────────────────────────────────────────────
+
+
+def test_main_dry_run_default(retire_mod, monkeypatch) -> None:
+    """Default invocation is dry-run; never reaches DB."""
+    monkeypatch.setenv("MEM0_API_KEY", "k")
+    fake_module = MagicMock()
+    fake_client = MagicMock()
+    fake_client.get_all.return_value = [{"id": "a", "memory": "Aiden", "user_id": "old"}]
+    fake_module.MemoryClient.return_value = fake_client
+    monkeypatch.setitem(sys.modules, "mem0", fake_module)
+
+    result = retire_mod.main([])
+    assert result == 0
+
+
+def test_main_execute_requires_database_url(retire_mod, monkeypatch) -> None:
+    """--execute without DSN returns 1 (all fail) but doesn't crash."""
+    monkeypatch.setenv("MEM0_API_KEY", "k")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    fake_module = MagicMock()
+    fake_client = MagicMock()
+    fake_client.get_all.return_value = [{"id": "a", "memory": "Aiden", "user_id": "u"}]
+    fake_module.MemoryClient.return_value = fake_client
+    monkeypatch.setitem(sys.modules, "mem0", fake_module)
+
+    result = retire_mod.main(["--execute"])
+    assert result == 1
+
+
+def test_main_empty_mem0_dry_run_returns_zero(retire_mod, monkeypatch) -> None:
+    """Empty mem0 → no payloads → dry-run still returns 0."""
+    monkeypatch.setenv("MEM0_API_KEY", "k")
+    fake_module = MagicMock()
+    fake_client = MagicMock()
+    fake_client.get_all.return_value = []
+    fake_module.MemoryClient.return_value = fake_client
+    monkeypatch.setitem(sys.modules, "mem0", fake_module)
+
+    assert retire_mod.main([]) == 0

--- a/tests/scripts/test_wave1_retire_mem0.py
+++ b/tests/scripts/test_wave1_retire_mem0.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 


### PR DESCRIPTION
## Summary

Wave 1 Item 3 per Dave directive ts 1778565940 + Elliot confirm-to-execute on Step 0 addendum C. Mem0 never worked in production (audit finding: 82 memories all under wrong user_id `'system'`, recall returns empty by construction because `Mem0Adapter.search()` filters by per-agent callsign). This PR rescues the 82 rows and retires mem0 at every layer.

## Live execution evidence (Rule 6 — all four directive items)

**1. mem0 SDK pre-migration count = 82 (matches Atlas's audit baseline exactly)**
```
$ python scripts/wave1_retire_mem0.py --dry-run
INFO: mem0 user_id=system page=1 → 82 rows (running total 82)
INFO: mem0 returned 82 rows (Atlas audit baseline: 82)
INFO: built 82 agent_memories payloads
INFO: [DRY-RUN] would INSERT 82 rows
```

**2. agent_memories INSERT count after live --execute = 82 (0 failures)**
```
$ SELECT COUNT(*) FROM public.agent_memories WHERE source_type='rescued_from_mem0';
pre_count: 0

$ python scripts/wave1_retire_mem0.py --execute
INFO: mem0 returned 82 rows (Atlas audit baseline: 82)
INFO: built 82 agent_memories payloads
INFO: migration complete: 82 ok / 0 failed

$ SELECT COUNT(*) FROM public.agent_memories WHERE source_type='rescued_from_mem0';
post_count: 82
```

**3. .env dual-write gate disabled + recall backend switched off mem0**
```
$ grep -E "^(MEM0|MEMORY_RECALL)" /home/elliotbot/.config/agency-os/.env
MEM0_API_KEY=m0-nlcY...           # retained (key not invalidated; just unused)
MEMORY_RECALL_BACKEND=supabase    # was 'hybrid' — now skips recall_via_mem0 path
MEM0_INTEGRATION_ENABLED=false    # new line; was unset; explicit gate now
```

**4. ceo_memory key updated to RETIRED**
```sql
UPDATE public.ceo_memory
SET value = jsonb_set(jsonb_set(value, '{status}', '"RETIRED"'::jsonb),
                       '{retired_at}', to_jsonb(NOW())),
    updated_at = NOW()
WHERE key = 'ceo:mem0_decision_2026-05-01'
RETURNING key, value->'status' AS status, value->'retired_at' AS retired_at;

-- result:
key                              | status   | retired_at
ceo:mem0_decision_2026-05-01     | RETIRED  | 2026-05-12T06:29:50.930701+00:00
```

## Changes shipped in this PR

| File | Lines | Purpose |
|---|---|---|
| `scripts/wave1_retire_mem0.py` | +270 | One-shot retirement script (mem0 read + agent_memories migrate) |
| `tests/scripts/test_wave1_retire_mem0.py` | +175 | 21 mocked tests (no live calls) |

## Code that stays in place (per directive)

- `src/governance/mem0_adapter.py` — kept; existing env-var gates at callsites are sufficient:
  - `src/memory/store.py:208` — dual-write gated on `MEM0_INTEGRATION_ENABLED == "true"` (now false → skipped)
  - `src/coo_bot/memory_retriever.py:95` — recall gated on `MEMORY_RECALL_BACKEND in ("mem0","hybrid")` (now "supabase" → skipped)
- mem0 SDK install retained (still in requirements.txt). Future deletion is a separate cleanup.

## Notes for review

- **Env var naming**: directive said `MEM0_ENABLED=false`. The existing code uses `MEM0_INTEGRATION_ENABLED` as the gate variable in `src/memory/store.py:208`. I set the actual variable to match what the code reads. If a `MEM0_ENABLED` alias is also wanted, can add — flag if needed.
- **Callsign inference**: the 82 mem0 rows are not agent-specific memories — they're governance/architecture facts seeded by `LISTENER-KNOWLEDGE-SEED-V1` from `ARCHITECTURE.md` etc. Content has no per-agent callsign mentions, so all 82 fell through `infer_callsign()` → fallback to mem0 user_id `'system'`. Honest tagging; future cognee ingestion will use `typed_metadata.node_set` to identify them.
- **mem0 SDK v3 quirk**: `client.get_all()` returns dict `{count, next, previous, results}` not a plain list; requires non-empty `filters`. Script handles both shapes for resilience.

## Test plan

- [x] 21 unit tests pass (mocked mem0 SDK + asyncpg, no live calls)
- [x] Live --execute migrated exactly 82 rows, 0 failures
- [x] Pre-count 0 → post-count 82 (verified via SELECT COUNT(*))
- [x] .env updated; existing callsite gates already check these vars
- [x] ceo_memory key updated; RETURNING confirms RETIRED + retired_at
- [ ] CI green
- [ ] Dual-CTO concur (@aiden + me; Elliot confirm-to-execute already covers the dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)