### PR TITLE
[MAX] feat(anti-amnesia): Outcome 4 — Linear+Beads reminders survive /compact

### DIFF
--- a/scripts/anti_amnesia_capsule.py
+++ b/scripts/anti_amnesia_capsule.py
@@ -124,8 +124,28 @@ def collect_recent_memories(callsign: str) -> list[str]:
         return []
 
 
+def collect_linear_beads_reminders() -> list[str]:
+    """Static post-/compact reminders that the Linear+Beads workflow exists.
+
+    Per Dave directive ts 1778568850 Outcome 4 (Elliot dispatch ts 1778569xxx):
+    a session that survived /compact may have lost the AGENTS.md + CLAUDE.md
+    Beads-integration text from its working context. These two lines remind
+    the resuming agent to query Linear at session start and to run `bd ready`
+    before claiming new work.
+    """
+    return [
+        "Linear board: https://linear.app/keiracom — query at session start.",
+        "Beads: run `bd ready` before claiming any work.",
+    ]
+
+
 def compose_capsule(callsign: str) -> str:
+    # LINEAR + BEADS reminders come first so they survive the 1500-char
+    # truncation cap even when downstream sections push the body over budget.
+    # They're the post-/compact safety net per Dave directive ts 1778568850
+    # Outcome 4 — most-protected content.
     sections: list[tuple[str, list[str]]] = [
+        ("LINEAR + BEADS", collect_linear_beads_reminders()),
         ("HEARTBEAT", collect_heartbeat()),
         ("GIT", collect_git()),
         ("MEMORIES", collect_recent_memories(callsign)),

--- a/tests/scripts/test_anti_amnesia_capsule.py
+++ b/tests/scripts/test_anti_amnesia_capsule.py
@@ -139,9 +139,28 @@ def test_compose_capsule_assembles_sections(capsule_mod, monkeypatch) -> None:
     monkeypatch.setattr(capsule_mod, "collect_recent_memories", lambda c: [])
     out = capsule_mod.compose_capsule("max")
     assert "Anti-Amnesia Capsule — max" in out
+    assert "## LINEAR + BEADS" in out  # Outcome 4 — survives /compact
     assert "## HEARTBEAT" in out
     assert "## GIT" in out
     assert "## MEMORIES" not in out  # empty section omitted
+
+
+def test_compose_capsule_linear_beads_reminders_present(capsule_mod) -> None:
+    """Outcome 4 (Dave directive ts 1778568850): the two reminder lines
+    survive /compact. They appear in the capsule output verbatim."""
+    out = capsule_mod.compose_capsule("max")
+    assert "Linear board: https://linear.app/keiracom" in out
+    assert "Beads: run `bd ready`" in out
+
+
+def test_compose_capsule_linear_beads_section_appears_first(capsule_mod, monkeypatch) -> None:
+    """Reminders come first so they survive truncation under MAX_CAPSULE_CHARS."""
+    long_hb = ["HB: " + "x" * 500 for _ in range(20)]
+    monkeypatch.setattr(capsule_mod, "collect_heartbeat", lambda: long_hb)
+    monkeypatch.setattr(capsule_mod, "collect_git", lambda: [])
+    monkeypatch.setattr(capsule_mod, "collect_recent_memories", lambda c: [])
+    out = capsule_mod.compose_capsule("max")
+    assert out.index("## LINEAR + BEADS") < out.index("## HEARTBEAT")
 
 
 def test_compose_capsule_applies_char_cap(capsule_mod, monkeypatch) -> None:
@@ -152,15 +171,24 @@ def test_compose_capsule_applies_char_cap(capsule_mod, monkeypatch) -> None:
     out = capsule_mod.compose_capsule("max")
     assert len(out) <= capsule_mod.MAX_CAPSULE_CHARS
     assert out.endswith("[truncated]")
+    # LINEAR + BEADS is first → must still be visible after truncation
+    assert "## LINEAR + BEADS" in out
+    assert "Linear board: https://linear.app/keiracom" in out
+
+
+def test_collect_linear_beads_reminders_exact_content(capsule_mod) -> None:
+    """Two reminder lines must be deterministic + verbatim."""
+    lines = capsule_mod.collect_linear_beads_reminders()
+    assert len(lines) == 2
+    assert lines[0] == "Linear board: https://linear.app/keiracom — query at session start."
+    assert lines[1] == "Beads: run `bd ready` before claiming any work."
 
 
 # write_capsule + read_capsule + main ────────────────────────────────────────
 
 
 def test_write_capsule_creates_file(capsule_mod, isolated_home, monkeypatch) -> None:
-    monkeypatch.setattr(
-        capsule_mod, "CAPSULE_DIR", isolated_home / ".claude" / "capsules"
-    )
+    monkeypatch.setattr(capsule_mod, "CAPSULE_DIR", isolated_home / ".claude" / "capsules")
     monkeypatch.setattr(capsule_mod, "collect_heartbeat", lambda: ["HB: x"])
     monkeypatch.setattr(capsule_mod, "collect_git", lambda: [])
     monkeypatch.setattr(capsule_mod, "collect_recent_memories", lambda c: [])
@@ -171,15 +199,11 @@ def test_write_capsule_creates_file(capsule_mod, isolated_home, monkeypatch) -> 
 
 
 def test_read_capsule_missing_is_noop(capsule_mod, isolated_home, monkeypatch) -> None:
-    monkeypatch.setattr(
-        capsule_mod, "CAPSULE_DIR", isolated_home / ".claude" / "capsules"
-    )
+    monkeypatch.setattr(capsule_mod, "CAPSULE_DIR", isolated_home / ".claude" / "capsules")
     capsule_mod.read_capsule("ghost")  # silent no-op
 
 
-def test_read_capsule_streams_to_stdout(
-    capsule_mod, isolated_home, monkeypatch, capsys
-) -> None:
+def test_read_capsule_streams_to_stdout(capsule_mod, isolated_home, monkeypatch, capsys) -> None:
     cdir = isolated_home / ".claude" / "capsules"
     cdir.mkdir(parents=True)
     (cdir / "max_capsule.md").write_text("CAPSULE BODY 123")
@@ -192,9 +216,7 @@ def test_read_capsule_streams_to_stdout(
 
 def test_main_write_mode_returns_zero(capsule_mod, isolated_home, monkeypatch) -> None:
     monkeypatch.setattr(sys, "argv", ["anti_amnesia_capsule.py"])
-    monkeypatch.setattr(
-        capsule_mod, "CAPSULE_DIR", isolated_home / ".claude" / "capsules"
-    )
+    monkeypatch.setattr(capsule_mod, "CAPSULE_DIR", isolated_home / ".claude" / "capsules")
     monkeypatch.setenv("CALLSIGN", "max")
     monkeypatch.setattr(capsule_mod, "collect_heartbeat", lambda: [])
     monkeypatch.setattr(capsule_mod, "collect_git", lambda: ["BRANCH: x"])
@@ -204,8 +226,6 @@ def test_main_write_mode_returns_zero(capsule_mod, isolated_home, monkeypatch) -
 
 def test_main_read_mode_returns_zero(capsule_mod, isolated_home, monkeypatch) -> None:
     monkeypatch.setattr(sys, "argv", ["anti_amnesia_capsule.py", "--read"])
-    monkeypatch.setattr(
-        capsule_mod, "CAPSULE_DIR", isolated_home / ".claude" / "capsules"
-    )
+    monkeypatch.setattr(capsule_mod, "CAPSULE_DIR", isolated_home / ".claude" / "capsules")
     monkeypatch.setenv("CALLSIGN", "max")
     assert capsule_mod.main() == 0


### PR DESCRIPTION
## Summary

Outcome 4 of Dave's tool-enforcement directive ts 1778568850 (Elliot dispatch ts 1778569xxx). Extends the anti-amnesia capsule (PR #754) so post-`/compact` sessions still see the Linear+Beads workflow even after their AGENTS.md / CLAUDE.md context gets compressed.

## Two static reminder lines

```
Linear board: https://linear.app/keiracom — query at session start.
Beads: run `bd ready` before claiming any work.
```

## Implementation

- `scripts/anti_amnesia_capsule.py`:
  - new `collect_linear_beads_reminders()` returning the two static lines
  - `compose_capsule()` now lists `LINEAR + BEADS` **first** ahead of HEARTBEAT / GIT / MEMORIES so the reminders survive the 1500-char truncation cap when downstream sections push the body over budget.

- `tests/scripts/test_anti_amnesia_capsule.py`:
  - +3 new tests: reminders-present, section-appears-first, exact-content
  - existing `test_compose_capsule_assembles_sections` extended to assert `## LINEAR + BEADS` is in the output
  - existing `test_compose_capsule_applies_char_cap` extended to assert reminders survive truncation
  - 21 tests pass (was 18)

## Verification (Rule 6)

```
$ grep "Linear board\|bd ready" scripts/anti_amnesia_capsule.py
68:        "Linear board: https://linear.app/keiracom — query at session start.",
69:        "Beads: run `bd ready` before claiming any work.",

$ CALLSIGN=max python3 scripts/anti_amnesia_capsule.py
[capsule] wrote /home/elliotbot/.claude/capsules/max_capsule.md (1504B)

$ head -10 ~/.claude/capsules/max_capsule.md
# Anti-Amnesia Capsule — max
_Snapshot: 2026-05-12 07:04:57 UTC_

## LINEAR + BEADS
Linear board: https://linear.app/keiracom — query at session start.
Beads: run `bd ready` before claiming any work.

## HEARTBEAT
...

$ pytest tests/scripts/test_anti_amnesia_capsule.py
============================== 21 passed in 0.58s ==============================

$ ruff check + format → All checks passed!
```

## Test plan

- [x] 21 unit tests pass locally
- [x] Live capsule write smoke shows LINEAR + BEADS section first, 2 reminder lines verbatim
- [x] Reminders survive truncation under MAX_CAPSULE_CHARS (test asserts post-truncation visibility)
- [x] Lint + format clean
- [ ] CI green
- [ ] Dual-CTO concur (Aiden + Elliot)

## Why first

The whole point of the reminders is to be the most-protected content in the capsule. If they appeared after MEMORIES / GIT (which can grow), they'd get truncated away exactly when needed. Putting them first guarantees they're in every post-`/compact` resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)