### PR TITLE
[AIDEN] feat(enforcer): R10 LINEAR-KEI-GATE — Wave 2 Outcome 3

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -346,3 +346,104 @@ def check_r8(text: str, recent_messages: list[str] | None = None) -> dict | None
         "detail": f"Dispatch action without prior {' + '.join(missing)} in recent_messages.",
         "should_have": "Post [DISPATCH-PROPOSAL:<callsign>] and wait for peer [CONCUR] before dispatching.",
     }
+
+
+# ---------------------------------------------------------------------------
+# R10 — LINEAR-KEI-GATE (Wave 2 Outcome 3, Dave priority-reset ts 1778570450)
+# ---------------------------------------------------------------------------
+
+# Completion-claim phrases that should be paired with a Linear KEI status update.
+# Mirrors enforcer_rules.TRIGGER_PATTERNS for the completion-claim subset but
+# narrower — only the patterns that signal "work just shipped", not generic
+# discussion of work.
+_R10_COMPLETION_RE = re.compile(
+    r"\bpr\s*#\d+\s+(?:merged|shipped|landed|deployed)\b"
+    r"|\bmerged\s+(?:at\s+)?(?:sha\s+)?[a-f0-9]{7,40}\b"
+    r"|\[READY:[a-z]+\]"
+    r"|\b(?:directive|wave|outcome)\s+(?:\w+\s+)?(?:complete|completed|shipped|done)\b"
+    r"|\ball\s+stores?\s+written\b"
+    r"|\bfour[-\s]?store\s+save\s+complete\b",
+    re.IGNORECASE,
+)
+
+# Anti-broadening: exempt past-tense citations / future intent / negation.
+_R10_EXEMPT_RE = re.compile(
+    r"\b(?:will|going to|about to|planning to)\s+(?:ship|merge|deploy)"
+    r"|\bhaven't\s+(?:shipped|merged|deployed)\b"
+    r"|\bnot\s+(?:shipped|merged|deployed)\s+yet\b"
+    r"|\b(?:retro|review|recap)\b",
+    re.IGNORECASE,
+)
+
+# KEI tag extraction. Linear's identifier prefix is KEI-<digits>.
+_R10_KEI_RE = re.compile(r"\bKEI-\d+\b")
+
+
+def check_r10(
+    text: str,
+    *,
+    linear_kei_recently_updated: callable = None,
+    window_seconds: int = 60,
+) -> dict | None:
+    """R10 — LINEAR-KEI-GATE.
+
+    Fires when a completion claim (PR merged / [READY:] / sha line / wave done)
+    lacks a corresponding Linear KEI status update within `window_seconds`.
+
+    Two failure modes:
+      (a) Completion claim with NO KEI-<N> tag → "untaggable, can't verify".
+      (b) Completion claim with KEI tag, but Linear shows no recent updatedAt
+          mutation on that KEI → "claim without Linear sync".
+
+    `linear_kei_recently_updated(kei_id: str, window_seconds: int) -> bool` is
+    injected for testability; default None skips the (b) check entirely (returns
+    None for (a)-only mode) so tests can exercise just the pattern logic.
+    """
+    if not _R10_COMPLETION_RE.search(text):
+        return None
+    if _R10_EXEMPT_RE.search(text):
+        return None
+    kei_matches = _R10_KEI_RE.findall(text)
+
+    if not kei_matches:
+        return {
+            "violation": True,
+            "rule_number": 10,
+            "rule_name": "LINEAR-KEI-GATE",
+            "detail": (
+                "Completion claim without KEI-<N> tag — cannot verify Linear sync. "
+                "Tag the Linear issue so the orchestrator can mirror state."
+            ),
+            "should_have": (
+                "Include the KEI tag (e.g. 'KEI-17') in the completion message OR "
+                "ensure the PR title contains it."
+            ),
+        }
+
+    if linear_kei_recently_updated is None:
+        # No injectable check provided — treat as conservative pass (the tag is
+        # present; caller will run the Linear check separately if desired).
+        return None
+
+    stale_keis: list[str] = []
+    for kei in set(kei_matches):
+        try:
+            if not linear_kei_recently_updated(kei, window_seconds):
+                stale_keis.append(kei)
+        except Exception:  # noqa: BLE001 — best-effort; conservative pass on probe failure
+            continue
+    if not stale_keis:
+        return None
+    return {
+        "violation": True,
+        "rule_number": 10,
+        "rule_name": "LINEAR-KEI-GATE",
+        "detail": (
+            f"Completion claim references {', '.join(sorted(stale_keis))} but no "
+            f"Linear status update in last {window_seconds}s — sync KEI state."
+        ),
+        "should_have": (
+            "Update the Linear KEI state to Done / In Review / appropriate next state "
+            "before posting the completion claim — or within the 60s window after."
+        ),
+    }

--- a/tests/bot_common/test_enforcer_deterministic.py
+++ b/tests/bot_common/test_enforcer_deterministic.py
@@ -260,7 +260,10 @@ def test_r2_recent_messages_none_conservative_pass() -> None:
 
 def test_r2_exempt_fully_deployed_status() -> None:
     """Track 8: 'FULLY DEPLOYED' is status reporting, not new execution."""
-    assert check_r2("Track 7 FULLY DEPLOYED. Listener restarted at 01:24 UTC.", recent_messages=[]) is None
+    assert (
+        check_r2("Track 7 FULLY DEPLOYED. Listener restarted at 01:24 UTC.", recent_messages=[])
+        is None
+    )
 
 
 def test_r2_exempt_pr_tally() -> None:
@@ -281,7 +284,10 @@ def test_r2_exempt_shipped_in_pr() -> None:
 
 def test_r2_exempt_merge_pull_request() -> None:
     """Track 8: GitHub merge commit message format."""
-    assert check_r2("Merge pull request #741 from Keiracom/max/r9-standby-exempt", recent_messages=[]) is None
+    assert (
+        check_r2("Merge pull request #741 from Keiracom/max/r9-standby-exempt", recent_messages=[])
+        is None
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -334,3 +340,121 @@ def test_r8_recent_messages_none_conservative_pass() -> None:
     """recent_messages=None → conservative pass."""
     text = "Atlas dispatched per Dave directive."
     assert check_r8(text, recent_messages=None) is None
+
+
+# ---------------------------------------------------------------------------
+# R10 — LINEAR-KEI-GATE (Wave 2 Outcome 3)
+# ---------------------------------------------------------------------------
+
+
+def test_r10_no_completion_phrase_returns_none():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    assert check_r10("just chatting about KEI-17 design") is None
+
+
+def test_r10_pr_merged_without_kei_tag_fires():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    out = check_r10("PR #774 merged at sha abc1234")
+    assert out is not None
+    assert out["rule_number"] == 10
+    assert "without KEI-<N> tag" in out["detail"]
+
+
+def test_r10_pr_merged_with_kei_tag_no_check_fn_passes():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    # KEI tag present; no Linear-check fn injected → conservative pass.
+    out = check_r10("PR #774 merged (KEI-17) at sha abc1234")
+    assert out is None
+
+
+def test_r10_ready_marker_with_kei_tag_and_recent_linear_update_passes():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    # Inject a Linear-check fn that says "yes, KEI-17 was updated".
+    fresh = lambda kei, window: True  # noqa: E731
+    out = check_r10("[READY:aiden] KEI-17 polling loop shipped", linear_kei_recently_updated=fresh)
+    assert out is None
+
+
+def test_r10_ready_marker_with_stale_kei_fires():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    stale = lambda kei, window: False  # noqa: E731
+    out = check_r10(
+        "[READY:aiden] KEI-17 polling loop shipped",
+        linear_kei_recently_updated=stale,
+    )
+    assert out is not None
+    assert out["rule_number"] == 10
+    assert "KEI-17" in out["detail"]
+    assert "no Linear status update" in out["detail"]
+
+
+def test_r10_multiple_keis_mixed_fresh_and_stale_fires_only_on_stale():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    # KEI-17 fresh, KEI-18 stale.
+    def probe(kei, window):
+        return kei == "KEI-17"
+
+    out = check_r10(
+        "Wave 2 KEI-17 + KEI-18 outcomes complete — PR #774 merged",
+        linear_kei_recently_updated=probe,
+    )
+    assert out is not None
+    assert "KEI-18" in out["detail"]
+    assert "KEI-17" not in out["detail"]  # the fresh one is omitted
+
+
+def test_r10_exempt_future_intent_passes():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    # Future intent should NOT fire even with completion-shaped phrase.
+    assert check_r10("planning to merge PR #774 once CI greens") is None
+    assert check_r10("will deploy after smoke verifies") is None
+
+
+def test_r10_exempt_negation_passes():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    assert check_r10("we haven't merged PR #774 yet — Max is reviewing") is None
+
+
+def test_r10_exempt_retro_recap_passes():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    # Recap-style mention of past completion should not fire.
+    assert check_r10("retro of yesterday: PR #774 merged on time") is None
+
+
+def test_r10_completion_probe_failure_does_not_fire():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    # If the Linear-check fn raises, that single KEI is skipped (conservative).
+    def probe(kei, window):
+        raise RuntimeError("Linear API down")
+
+    out = check_r10(
+        "[READY:aiden] KEI-17 polling loop shipped",
+        linear_kei_recently_updated=probe,
+    )
+    assert out is None  # no stale_keis collected → conservative pass
+
+
+def test_r10_four_store_save_complete_phrase_fires_when_no_kei():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    out = check_r10("four-store save complete for Wave 1 cleanup")
+    assert out is not None
+    assert "without KEI-<N> tag" in out["detail"]
+
+
+def test_r10_directive_done_phrase_fires_when_no_kei():
+    from src.bot_common.enforcer_deterministic import check_r10
+
+    out = check_r10("Wave 2 Outcome 3 complete — enforcer rule shipped")
+    assert out is not None
+    assert "without KEI-<N> tag" in out["detail"]


### PR DESCRIPTION
## Summary

Per Dave priority-reset ts 1778570450 — Wave 2 Outcome 3. New deterministic enforcer rule (R10) fires when a completion claim lacks a corresponding Linear KEI status update. Closes audit Pattern A in the orchestration-state-drift domain (the orchestrator can't mirror state to Linear if completion claims don't tag the KEI).

**Two failure modes detected:**

1. **No KEI tag at all** — completion claim like `PR #774 merged at sha abc1234` with no `KEI-<N>` reference → fires, prompts to tag the Linear issue.
2. **KEI tag present, but Linear shows no recent update** — claim mentions `KEI-17` but the Linear `updatedAt` is older than the 60s window → fires, prompts to sync KEI state.

## Files

- `src/bot_common/enforcer_deterministic.py` (+101 LoC) — adds `check_r10()` + 2 supporting regex constants. Mirrors existing R2/R4/R6/R8 pattern (deterministic, per-rule function returning `dict | None`).
- `tests/bot_common/test_enforcer_deterministic.py` (+126 LoC, 12 new tests).

## API

```python
def check_r10(
    text: str,
    *,
    linear_kei_recently_updated: callable | None = None,
    window_seconds: int = 60,
) -> dict | None:
```

`linear_kei_recently_updated(kei_id: str, window_seconds: int) -> bool` is injected for testability. When `None`, mode (b) check is skipped — conservative pass so probe-failure doesn't false-positive. The caller (central listener / enforcer bot) provides the Linear-check fn against the live Linear GraphQL API.

## Verbatim verification

```
$ /home/elliotbot/clawd/venv/bin/python3 -m pytest tests/bot_common/test_enforcer_deterministic.py
============================== 56 passed in 0.25s ==============================
   (44 pre-existing tests still pass, 12 new R10 tests added)

$ /home/elliotbot/clawd/venv/bin/python3 -m pytest tests/bot_common/test_enforcer_deterministic.py -v -k r10
test_r10_no_completion_phrase_returns_none                            PASSED
test_r10_pr_merged_without_kei_tag_fires                              PASSED
test_r10_pr_merged_with_kei_tag_no_check_fn_passes                    PASSED
test_r10_ready_marker_with_kei_tag_and_recent_linear_update_passes    PASSED
test_r10_ready_marker_with_stale_kei_fires                            PASSED
test_r10_multiple_keis_mixed_fresh_and_stale_fires_only_on_stale      PASSED
test_r10_exempt_future_intent_passes                                  PASSED
test_r10_exempt_negation_passes                                       PASSED
test_r10_exempt_retro_recap_passes                                    PASSED
test_r10_completion_probe_failure_does_not_fire                       PASSED
test_r10_four_store_save_complete_phrase_fires_when_no_kei            PASSED
test_r10_directive_done_phrase_fires_when_no_kei                      PASSED
============================== 12 passed in 0.18s ==============================

$ /home/elliotbot/.local/bin/ruff check + format src/bot_common/enforcer_deterministic.py tests/bot_common/test_enforcer_deterministic.py
All checks passed! / 2 files already formatted
```

## Simulated trigger (verbatim)

Failure mode (1) — completion claim without KEI:

```python
>>> check_r10("PR #774 merged at sha abc1234")
{'violation': True, 'rule_number': 10, 'rule_name': 'LINEAR-KEI-GATE',
 'detail': 'Completion claim without KEI-<N> tag — cannot verify Linear sync. ...',
 'should_have': "Include the KEI tag (e.g. 'KEI-17') in the completion message OR ensure the PR title contains it."}
```

Failure mode (2) — stale KEI:

```python
>>> stale = lambda kei, window: False
>>> check_r10("[READY:aiden] KEI-17 polling loop shipped", linear_kei_recently_updated=stale)
{'violation': True, 'rule_number': 10, 'rule_name': 'LINEAR-KEI-GATE',
 'detail': "Completion claim references KEI-17 but no Linear status update in last 60s — sync KEI state.",
 'should_have': "Update the Linear KEI state to Done / In Review / appropriate next state before posting the completion claim — or within the 60s window after."}
```

## Simulated pass (verbatim)

```python
>>> fresh = lambda kei, window: True
>>> check_r10("[READY:aiden] KEI-17 polling loop shipped", linear_kei_recently_updated=fresh)
None   # KEI updated within window → quiet

>>> check_r10("planning to merge PR #774 once CI greens")
None   # Future intent exempt → quiet

>>> check_r10("retro of yesterday: PR #774 merged on time")
None   # Recap framing exempt → quiet
```

## Integration

R10 is registered in `enforcer_deterministic.py` following the existing per-rule pattern. The central listener / enforcer bot is responsible for calling `check_r10` with a Linear-check fn in its check pipeline (no listener-side wiring in this PR — Phase 1 integration concern, mirrors how R8 is wired).

## Test plan

- [x] 12 R10 tests pass locally; 44 pre-existing tests still pass (56 total)
- [x] Ruff check + format clean
- [ ] Backend Lint / Pytest / MyPy / Dead Ref / Frontend / SonarCloud / Migration Completeness Guard green in CI
- [ ] Dual-CTO concur (Aiden author + Max reviewer)
- [ ] After this + #774 (KEI-17) both land: LAW XV three-store save for the Dave priority-reset directive bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)