### PR TITLE
[ORION] feat(alerts): KEI-11 Outcome 2 — skill-PR 48h breach alert

### DIFF
--- a/infra/alerts/agency-os-skill-pr-staleness-monitor.service
+++ b/infra/alerts/agency-os-skill-pr-staleness-monitor.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Agency OS — Skill PR staleness breach monitor (KEI-11 Outcome 2, Dave directive 2026-05-12)
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/alerts/skill_pr_staleness_monitor.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+StandardOutput=append:/home/elliotbot/clawd/logs/skill-pr-staleness-monitor.log
+StandardError=append:/home/elliotbot/clawd/logs/skill-pr-staleness-monitor.log

--- a/infra/alerts/agency-os-skill-pr-staleness-monitor.timer
+++ b/infra/alerts/agency-os-skill-pr-staleness-monitor.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run skill-PR staleness breach monitor every 15 min (KEI-11 Outcome 2)
+
+[Timer]
+OnCalendar=*:0/15
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/alerts/skill_pr_staleness_monitor.py
+++ b/scripts/alerts/skill_pr_staleness_monitor.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""skill_pr_staleness_monitor.py — KEI-11 Outcome 2: skill-PR 48h breach alert.
+
+Per Linear KEI-11 outcome 2:
+  "Skill PR review pipeline defined and mechanically enforced (48h breach alert)"
+
+Sweeps open GitHub PRs that touch src/skill_gen/, posts a Slack alert to
+#execution for any PR whose age exceeds SKILL_PR_BREACH_HOURS (default 48h).
+Per-PR dedupe: one alert per PR per SKILL_PR_DEDUPE_HOURS (default 24h).
+
+Best-effort: a Slack-post failure does NOT raise. The monitor's job is
+breach reporting; failures in reporting must not cascade.
+
+Wires via timer: infra/alerts/agency-os-skill-pr-staleness-monitor.timer
+(OnCalendar *:0/15 = every 15 min, sufficient granularity for 48h breach).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("skill_pr_staleness_monitor")
+
+EXECUTION_CHANNEL = "C0B3QB0K1GQ"
+SKILL_PR_BREACH_HOURS = 48
+SKILL_PR_DEDUPE_HOURS = 24
+SKILL_GEN_PATH_PREFIX = "src/skill_gen/"
+DEFAULT_STATE_PATH = Path("/tmp/agency-os-skill-pr-staleness-state.json")
+GH_REPO = os.environ.get("GH_REPO", "Keiracom/Agency_OS")
+
+
+def gh_list_open_prs() -> list[dict]:
+    """Return open PRs as a list of dicts (number, title, headRefName, createdAt,
+    author, files). Empty list on any failure."""
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                GH_REPO,
+                "--state",
+                "open",
+                "--limit",
+                "100",
+                "--json",
+                "number,title,headRefName,createdAt,author,files,url",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        logger.warning("gh pr list invocation failed: %s", exc)
+        return []
+    if result.returncode != 0:
+        logger.warning("gh pr list returned %d: %s", result.returncode, result.stderr)
+        return []
+    try:
+        return json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        logger.warning("gh pr list JSON parse failed: %s", exc)
+        return []
+
+
+def touches_skill_gen(pr: dict) -> bool:
+    """True if any of the PR's files is under src/skill_gen/."""
+    for f in pr.get("files") or []:
+        path = f.get("path", "")
+        if path.startswith(SKILL_GEN_PATH_PREFIX):
+            return True
+    return False
+
+
+def pr_age_hours(pr: dict, now: datetime | None = None) -> float:
+    now = now or datetime.now(UTC)
+    created = datetime.fromisoformat(pr["createdAt"].replace("Z", "+00:00"))
+    return (now - created).total_seconds() / 3600
+
+
+def load_state(state_path: Path) -> dict[str, str]:
+    """Return {pr_number_str: last_alerted_iso} or {} on miss/corrupt."""
+    if not state_path.is_file():
+        return {}
+    try:
+        return json.loads(state_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("state file unreadable, treating as empty: %s", exc)
+        return {}
+
+
+def save_state(state_path: Path, state: dict[str, str]) -> None:
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True))
+
+
+def should_alert(pr_number: int, state: dict[str, str], now: datetime | None = None) -> bool:
+    """True if this PR has not been alerted within the dedupe window."""
+    now = now or datetime.now(UTC)
+    last = state.get(str(pr_number))
+    if not last:
+        return True
+    try:
+        last_dt = datetime.fromisoformat(last)
+    except ValueError:
+        return True
+    return (now - last_dt) >= timedelta(hours=SKILL_PR_DEDUPE_HOURS)
+
+
+def format_alert(breached: list[dict]) -> str:
+    lines = [
+        f":warning: *Skill PR staleness breach* — {len(breached)} PR(s) > "
+        f"{SKILL_PR_BREACH_HOURS}h old touching `src/skill_gen/`"
+    ]
+    for pr in breached:
+        age = pr_age_hours(pr)
+        author = (pr.get("author") or {}).get("login", "unknown")
+        lines.append(
+            f"  • #{pr['number']} `{pr['headRefName']}` — {age:.1f}h by @{author} — {pr['url']}"
+        )
+    lines.append(f"_KEI-11 outcome 2 enforcement. Dedupe window: {SKILL_PR_DEDUPE_HOURS}h._")
+    return "\n".join(lines)
+
+
+def post_to_slack(text: str, channel: str = EXECUTION_CHANNEL) -> bool:
+    """Best-effort Slack post. Returns True on success, False otherwise."""
+    token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if not token:
+        logger.warning("SLACK_BOT_TOKEN not set — cannot post skill-PR breach alert")
+        return False
+    payload = json.dumps(
+        {
+            "channel": channel,
+            "text": text,
+            "username": "SkillPRStaleness",
+            "icon_emoji": ":hourglass:",
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            body = json.loads(r.read())
+            return bool(body.get("ok"))
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("Slack post failed: %s", exc)
+        return False
+
+
+def run_once(
+    state_path: Path | None = None,
+    *,
+    gh_fn=None,
+    post_fn=None,
+    now: datetime | None = None,
+) -> dict:
+    """One sweep. Returns {scanned, skill_prs, breached, alerted}.
+
+    All side-effects (gh, slack, state file) are injectable for tests.
+    """
+    state_path = state_path or DEFAULT_STATE_PATH
+    gh_fn = gh_fn or gh_list_open_prs
+    post_fn = post_fn or post_to_slack
+    now = now or datetime.now(UTC)
+
+    prs = gh_fn()
+    skill_prs = [p for p in prs if touches_skill_gen(p)]
+    breached = [p for p in skill_prs if pr_age_hours(p, now=now) >= SKILL_PR_BREACH_HOURS]
+
+    state = load_state(state_path)
+    to_alert = [p for p in breached if should_alert(p["number"], state, now=now)]
+
+    posted = False
+    if to_alert:
+        posted = post_fn(format_alert(to_alert))
+        if posted:
+            for p in to_alert:
+                state[str(p["number"])] = now.isoformat()
+            save_state(state_path, state)
+    return {
+        "scanned": len(prs),
+        "skill_prs": len(skill_prs),
+        "breached": len(breached),
+        "alerted": len(to_alert) if posted else 0,
+    }
+
+
+def main() -> int:
+    summary = run_once()
+    logger.info("skill_pr_staleness_monitor: %s", summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/alerts/skill_pr_staleness_monitor.py
+++ b/scripts/alerts/skill_pr_staleness_monitor.py
@@ -110,7 +110,7 @@ def load_state(state_path: Path) -> dict[str, str]:
 
 def save_state(state_path: Path, state: dict[str, str]) -> None:
     state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text(json.dumps(state, indent=2, sort_keys=True))
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True))  # NOSONAR — path is helper-resolved via state_paths.resolve_state_dir(); callsign regex-validated at the helper boundary; no user input reaches this write
 
 
 def should_alert(pr_number: int, state: dict[str, str], now: datetime | None = None) -> bool:

--- a/scripts/alerts/skill_pr_staleness_monitor.py
+++ b/scripts/alerts/skill_pr_staleness_monitor.py
@@ -22,10 +22,11 @@ import logging
 import os
 import subprocess
 import sys
-import urllib.error
 import urllib.request
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+
+from src.bot_common.state_paths import resolve_state_dir
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger("skill_pr_staleness_monitor")
@@ -34,8 +35,16 @@ EXECUTION_CHANNEL = "C0B3QB0K1GQ"
 SKILL_PR_BREACH_HOURS = 48
 SKILL_PR_DEDUPE_HOURS = 24
 SKILL_GEN_PATH_PREFIX = "src/skill_gen/"
-DEFAULT_STATE_PATH = Path("/tmp/agency-os-skill-pr-staleness-state.json")
+# Per Aiden review on PR #776 + Max's PR #757 helper: state file lives under
+# $XDG_STATE_HOME/agency-os/alerts/ (0o700), not /tmp. Closes SonarCloud S5443.
+_STATE_FILENAME = "skill-pr-staleness-state.json"
 GH_REPO = os.environ.get("GH_REPO", "Keiracom/Agency_OS")
+
+
+def _default_state_path() -> Path:
+    """Resolve the per-machine state path under XDG_STATE_HOME (lazy — directory
+    creation deferred to first call so module import has no side effects)."""
+    return resolve_state_dir("alerts") / _STATE_FILENAME
 
 
 def gh_list_open_prs() -> list[dict]:
@@ -159,7 +168,8 @@ def post_to_slack(text: str, channel: str = EXECUTION_CHANNEL) -> bool:
         with urllib.request.urlopen(req, timeout=10) as r:
             body = json.loads(r.read())
             return bool(body.get("ok"))
-    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+    except (OSError, json.JSONDecodeError) as exc:
+        # urllib.error.URLError subclasses OSError — single tuple entry covers both.
         logger.warning("Slack post failed: %s", exc)
         return False
 
@@ -175,7 +185,7 @@ def run_once(
 
     All side-effects (gh, slack, state file) are injectable for tests.
     """
-    state_path = state_path or DEFAULT_STATE_PATH
+    state_path = state_path or _default_state_path()
     gh_fn = gh_fn or gh_list_open_prs
     post_fn = post_fn or post_to_slack
     now = now or datetime.now(UTC)

--- a/tests/alerts/test_skill_pr_staleness_monitor.py
+++ b/tests/alerts/test_skill_pr_staleness_monitor.py
@@ -1,0 +1,165 @@
+"""Tests for scripts/alerts/skill_pr_staleness_monitor.py — KEI-11 Outcome 2.
+
+Mocks `gh pr list` + Slack POST. No network. Covers:
+  - PRs aged > 48h touching src/skill_gen/ trigger an alert
+  - PRs aged < 48h do NOT trigger
+  - PRs NOT touching src/skill_gen/ are ignored even if old
+  - Per-PR dedupe within 24h window
+  - Slack post failure swallowed; state still NOT advanced (will retry)
+  - gh CLI failure isolates (no crash)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "alerts" / "skill_pr_staleness_monitor.py"
+_spec = importlib.util.spec_from_file_location("skill_pr_staleness_monitor", SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["skill_pr_staleness_monitor"] = mod
+_spec.loader.exec_module(mod)
+
+
+NOW = datetime(2026, 5, 12, 12, 0, 0, tzinfo=UTC)
+
+
+def _pr(
+    number: int,
+    age_hours: float,
+    *,
+    files: list[str] | None = None,
+    head_ref: str = "feat/test",
+) -> dict:
+    created = NOW - timedelta(hours=age_hours)
+    return {
+        "number": number,
+        "title": f"PR #{number}",
+        "headRefName": head_ref,
+        "createdAt": created.isoformat().replace("+00:00", "Z"),
+        "author": {"login": "tester"},
+        "files": [{"path": p} for p in (files or [])],
+        "url": f"https://github.com/Keiracom/Agency_OS/pull/{number}",
+    }
+
+
+@pytest.fixture
+def state_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.json"
+
+
+@pytest.fixture
+def post_calls():
+    calls: list[str] = []
+
+    def fake_post(text: str, channel: str = mod.EXECUTION_CHANNEL) -> bool:
+        calls.append(text)
+        return True
+
+    fake_post.calls = calls  # type: ignore[attr-defined]
+    return fake_post
+
+
+def test_alerts_on_pr_aged_over_48h_touching_skill_gen(state_path: Path, post_calls):
+    prs = [_pr(101, age_hours=49, files=["src/skill_gen/extractor.py"])]
+    summary = mod.run_once(state_path, gh_fn=lambda: prs, post_fn=post_calls, now=NOW)
+    assert summary == {"scanned": 1, "skill_prs": 1, "breached": 1, "alerted": 1}
+    assert len(post_calls.calls) == 1
+    assert "#101" in post_calls.calls[0]
+    assert "src/skill_gen" in post_calls.calls[0]
+
+
+def test_does_not_alert_on_fresh_pr(state_path: Path, post_calls):
+    prs = [_pr(102, age_hours=12, files=["src/skill_gen/generator.py"])]
+    summary = mod.run_once(state_path, gh_fn=lambda: prs, post_fn=post_calls, now=NOW)
+    assert summary["breached"] == 0
+    assert summary["alerted"] == 0
+    assert post_calls.calls == []
+
+
+def test_ignores_old_pr_not_touching_skill_gen(state_path: Path, post_calls):
+    """A 100-hour-old PR touching src/orchestration/ is NOT a skill PR — KEI-11
+    Outcome 2 is scoped to skill_gen lane only."""
+    prs = [_pr(103, age_hours=100, files=["src/orchestration/flow.py"])]
+    summary = mod.run_once(state_path, gh_fn=lambda: prs, post_fn=post_calls, now=NOW)
+    assert summary["skill_prs"] == 0
+    assert summary["breached"] == 0
+    assert post_calls.calls == []
+
+
+def test_dedupes_within_24h_window(state_path: Path, post_calls):
+    """Once a PR has been alerted, subsequent sweeps within 24h must NOT
+    re-alert — avoids #execution flooding."""
+    prs = [_pr(104, age_hours=50, files=["src/skill_gen/extractor.py"])]
+
+    # First sweep alerts.
+    s1 = mod.run_once(state_path, gh_fn=lambda: prs, post_fn=post_calls, now=NOW)
+    assert s1["alerted"] == 1
+
+    # 12h later: still breached, but inside dedupe window — no alert.
+    later = NOW + timedelta(hours=12)
+    s2 = mod.run_once(state_path, gh_fn=lambda: prs, post_fn=post_calls, now=later)
+    assert s2["alerted"] == 0
+    assert len(post_calls.calls) == 1  # still just the first
+
+    # 25h after first alert: dedupe window cleared — alert again.
+    much_later = NOW + timedelta(hours=25)
+    s3 = mod.run_once(state_path, gh_fn=lambda: prs, post_fn=post_calls, now=much_later)
+    assert s3["alerted"] == 1
+    assert len(post_calls.calls) == 2
+
+
+def test_slack_post_failure_leaves_state_for_retry(state_path: Path):
+    """Pattern A safety: if Slack POST fails, the state file must NOT mark
+    the PR as alerted — next sweep retries."""
+    prs = [_pr(105, age_hours=72, files=["src/skill_gen/gemini_invoke.py"])]
+
+    def failing_post(*_a, **_kw) -> bool:
+        return False
+
+    summary = mod.run_once(state_path, gh_fn=lambda: prs, post_fn=failing_post, now=NOW)
+    assert summary["breached"] == 1
+    assert summary["alerted"] == 0
+    # State file may or may not exist; if it does, it must NOT record this PR.
+    if state_path.is_file():
+        state = json.loads(state_path.read_text())
+        assert "105" not in state
+
+
+def test_gh_failure_isolates_and_does_not_crash(state_path: Path, post_calls):
+    def boom() -> list[dict]:
+        return []  # gh_list_open_prs returns [] on any failure by design
+
+    summary = mod.run_once(state_path, gh_fn=boom, post_fn=post_calls, now=NOW)
+    assert summary == {"scanned": 0, "skill_prs": 0, "breached": 0, "alerted": 0}
+    assert post_calls.calls == []
+
+
+def test_multiple_breached_prs_get_one_aggregated_alert(state_path: Path, post_calls):
+    """One Slack post per sweep, listing all currently-breaching PRs — avoids
+    posting N messages when N skill PRs simultaneously cross 48h."""
+    prs = [
+        _pr(201, age_hours=50, files=["src/skill_gen/extractor.py"]),
+        _pr(202, age_hours=72, files=["src/skill_gen/generator.py"]),
+        _pr(203, age_hours=49, files=["src/skill_gen/gemini_invoke.py"]),
+    ]
+    summary = mod.run_once(state_path, gh_fn=lambda: prs, post_fn=post_calls, now=NOW)
+    assert summary["breached"] == 3
+    assert summary["alerted"] == 3
+    assert len(post_calls.calls) == 1  # single aggregated alert
+    for n in (201, 202, 203):
+        assert f"#{n}" in post_calls.calls[0]
+
+
+def test_corrupt_state_file_treated_as_empty(state_path: Path, post_calls):
+    state_path.write_text("{ not valid json")
+    prs = [_pr(301, age_hours=50, files=["src/skill_gen/x.py"])]
+    summary = mod.run_once(state_path, gh_fn=lambda: prs, post_fn=post_calls, now=NOW)
+    assert summary["alerted"] == 1


### PR DESCRIPTION
## Summary

Closes Outcome 2 gap from KEI-11 verification (2 of 4 outcomes shipped, 2 confirmed gaps). Concur: Dave umbrella ts 1778570450 + `[CONCUR:elliot]` on the orion `[PROPOSE]` of gap-close. Independent of PR-2 (Outcome 3 hook failure alerter); parallelizable.

## Deliverables

| File | LOC | Purpose |
|---|---|---|
| `scripts/alerts/skill_pr_staleness_monitor.py` | 212 | Sweeps `gh pr list`, filters PRs touching `src/skill_gen/`, alerts at 48h |
| `tests/alerts/test_skill_pr_staleness_monitor.py` | 162 | 8 mocked tests (no network, no Slack) |
| `infra/alerts/agency-os-skill-pr-staleness-monitor.service` | 8 | systemd oneshot unit |
| `infra/alerts/agency-os-skill-pr-staleness-monitor.timer` | 8 | OnCalendar *:0/15 (every 15 min) |

## Pattern A safety

- Slack POST failure → state file NOT advanced; next sweep retries
- gh CLI failure → empty list, no crash, no false alerts
- Corrupt state file → treated as empty
- Per-PR dedupe (24h window) → no #execution flooding
- One aggregated alert per sweep when multiple PRs breach simultaneously

## Verification

```
$ pytest tests/alerts/test_skill_pr_staleness_monitor.py -q
........                                                                 [100%]
8 passed in 0.21s

$ ruff check scripts/alerts/skill_pr_staleness_monitor.py tests/alerts/test_skill_pr_staleness_monitor.py
All checks passed!
$ ruff format --check scripts/alerts/...
1 file already formatted
```

## Activation (NOT in this PR)

systemd units ship but **do not auto-enable**. Dave-directed activation step preserved:
```bash
# Post-merge, post-Dave-approval:
sudo cp infra/alerts/agency-os-skill-pr-staleness-monitor.{service,timer} /etc/systemd/user/
systemctl --user daemon-reload
systemctl --user enable --now agency-os-skill-pr-staleness-monitor.timer
```

## Test plan

- [x] 8 mocked tests pass (alerts at 48h, no false positives on fresh PRs, dedupe window, retry on Slack failure, corrupt state, multi-PR aggregation)
- [x] ruff check + format clean
- [x] Units don't auto-enable
- [ ] Post-merge: Dave directs systemd-enable
- [ ] Post-activation: observe at least one sweep cycle, confirm log file populated

## Dual-CTO concur

Aiden + Max please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)