### PR TITLE
[ATLAS] docs(agents): replace stale Telegram chat-ID with Slack relay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,19 @@ This folder is home. Treat it that way.
 
 When background agents complete, **do not rely on heartbeat responses to notify Dave**.
 
-**Rule:** When all spawned agents for a task batch finish, immediately send a direct Telegram message using the `message` tool:
+**Rule:** When all spawned agents for a task batch finish, immediately post a Slack message via `scripts/slack_relay.py`:
 
 ```
-message(action=send, channel=telegram, to=7267788033, message="✅ All done. [1-line summary of what completed]. What's next?")
+scripts/slack_relay.py "✅ All done. [1-line summary of what completed]. What's next?"
 ```
+
+Default channel is `#execution` (routine completion alerts). For CEO-direct posts, target `#ceo` via the channel ID flag:
+
+```
+scripts/slack_relay.py -c <ceo-channel-id> "..."
+```
+
+Dave reads Slack `#execution`, not your terminal — completion claims that don't land in Slack don't exist.
 
 **When to send:**
 - Final agent in a wave completes → send wave summary


### PR DESCRIPTION
## Summary

Closes Beads `Agency_OS-680` (P3 — stale `chat-ID 7267788033` Telegram reference in `AGENTS.md` Proactive Completion Alerts block, pre-Slack-migration relic).

## Before (verbatim grep)

\`\`\`
$ grep -n '7267788033\|message(action=send, channel=telegram' AGENTS.md
9:**Rule:** When all spawned agents for a task batch finish, immediately send a direct Telegram message using the \`message\` tool:
12:message(action=send, channel=telegram, to=7267788033, message="✅ All done. [1-line summary of what completed]. What's next?")
\`\`\`

## After (verbatim grep)

\`\`\`
$ grep -niE 'telegram|7267788033|message\(action=send' AGENTS.md
(zero matches — clean)
\`\`\`

## Change

Swapped the example invocation from \`message(action=send, channel=telegram, ...)\` to \`scripts/slack_relay.py "..."\` (canonical Slack relay; same script wired into \`session_end_gate.py\`, \`concur_gate.py\`, \`session_start_audit.py\`). Default channel is \`#execution\`; CEO-direct via \`-c <channel-id>\`.

No touch on the rest of the file (`/kill`, Memory, Group Chats, Heartbeats, EVO Protocol blocks unchanged). No BEADS INTEGRATION auto-inject block present in this file to preserve.

## Test plan

- [x] Zero \`Telegram\` / \`7267788033\` / \`message(action=send\` matches in AGENTS.md after change
- [x] Diff is +10/-2, scoped strictly to lines 9-13 + insertion of #execution/#ceo channel guidance
- [ ] Aiden + Max rubber-stamp (5-15 LOC doc change per Elliot's dispatch)
- [ ] Post-merge: \`bd close Agency_OS-680\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)