### PR TITLE
[ATLAS] docs(wave2): Beads cross-worktree sync research — state + recommendation

### DIFF
--- a/docs/wave2/beads_cross_worktree_sync_state.md
+++ b/docs/wave2/beads_cross_worktree_sync_state.md
@@ -1,0 +1,103 @@
+# Beads Cross-Worktree Sync — Current State (2026-05-12)
+
+**Author:** atlas
+**Beads tracking issue:** `Agency_OS-iji` — "Cross-worktree Beads DB sync — CTOs can't run bd locally until resolved"
+**Methodology:** read-only empirical inspection of `.beads/` per worktree, `bd where`, `bd dolt show`, `.git` link contents, and Dolt remote/ref state. No mutations.
+
+## TL;DR
+
+The Beads embedded Dolt DB lives at `/home/elliotbot/clawd/Agency_OS/.beads/embeddeddolt/` only. Four of six worktrees can reach it via `bd`'s "walk up to nearest .beads with embeddeddolt/" resolution; **two cannot** — `Agency_OS-max` and `Agency_OS-orion` are git-worktrees of a *different parent repo* (`/home/elliotbot/clawd/.git`), so `bd` does not walk up into Agency_OS and errors with "no beads database found". Today there is **no active sync** — no Dolt remote is configured (`bd dolt show: Remotes: (none)`), no `refs/dolt/data` ref is pushed to GitHub, and no central bd server is running. Sharing happens incidentally because four of six worktrees all touch the same physical DB file via filesystem traversal.
+
+## 1. Per-worktree DB resolution (empirical)
+
+`bd where` (verbatim):
+
+| Worktree | `bd where` result | bd works? |
+|---|---|---|
+| `/home/elliotbot/clawd/Agency_OS` (elliot) | `/home/elliotbot/clawd/Agency_OS/.beads` — prefix Agency_OS — database `.beads/embeddeddolt` | ✓ |
+| `/home/elliotbot/clawd/Agency_OS-aiden` | `/home/elliotbot/clawd/Agency_OS/.beads` (walked up) | ✓ |
+| `/home/elliotbot/clawd/Agency_OS-atlas` | `/home/elliotbot/clawd/Agency_OS/.beads` (walked up) | ✓ |
+| `/home/elliotbot/clawd/Agency_OS-scout` | `/home/elliotbot/clawd/Agency_OS/.beads` (walked up) | ✓ (no local `.beads/` exists) |
+| `/home/elliotbot/clawd/Agency_OS-max` | `/home/elliotbot/clawd/Agency_OS-max/.beads` (did NOT walk up) | ✗ — "Error: no beads database found" |
+| `/home/elliotbot/clawd/Agency_OS-orion` | `/home/elliotbot/clawd/Agency_OS-orion/.beads` (did NOT walk up) | ✗ — same error |
+
+## 2. Root cause — git-worktree alignment
+
+`.git` link contents per worktree (verbatim):
+
+| Worktree | `.git` link | Parent repo |
+|---|---|---|
+| Agency_OS | `(directory)` — primary worktree | self |
+| Agency_OS-aiden | `gitdir: /home/elliotbot/clawd/Agency_OS/.git/worktrees/Agency_OS-aiden` | **Agency_OS** ✓ |
+| Agency_OS-atlas | `gitdir: /home/elliotbot/clawd/Agency_OS/.git/worktrees/Agency_OS-atlas` | **Agency_OS** ✓ |
+| Agency_OS-scout | `gitdir: /home/elliotbot/clawd/Agency_OS/.git/worktrees/Agency_OS-scout` | **Agency_OS** ✓ |
+| Agency_OS-max | `gitdir: /home/elliotbot/clawd/.git/worktrees/Agency_OS-max` | **`/home/elliotbot/clawd/`** (different repo) ✗ |
+| Agency_OS-orion | `gitdir: /home/elliotbot/clawd/.git/worktrees/Agency_OS-orion` | **`/home/elliotbot/clawd/`** (different repo) ✗ |
+
+`/home/elliotbot/clawd/.git/HEAD` = `ref: refs/heads/main` — confirms `/home/elliotbot/clawd/` is an independent git repository (likely the parent ops/clawd repo), not Agency_OS.
+
+When `bd` resolves the working dir, it walks up looking for `.beads/embeddeddolt/`. For Agency_OS-max and Agency_OS-orion the upward traversal exits the Agency_OS tree before reaching `Agency_OS/.beads/embeddeddolt/` — so resolution stops at the local `.beads/` shell (which contains only the gitignored skeleton, no Dolt DB).
+
+## 3. `.beads/` contents per worktree (verbatim `ls`)
+
+| Worktree | Has `embeddeddolt/`? | Has `issues.jsonl`? | Has `metadata.json`? |
+|---|---|---|---|
+| Agency_OS (elliot) | **yes** (88 kB total) | yes (live) | yes (`export-state.json` present) |
+| Agency_OS-aiden | no | yes (8980 bytes) | yes |
+| Agency_OS-atlas | no | yes (8980 bytes) | yes |
+| Agency_OS-max | no | yes (8980 bytes) | yes |
+| Agency_OS-orion | no | yes (8980 bytes) | yes |
+| Agency_OS-scout | **no `.beads/` dir at all** | — | — |
+
+`.beads/.gitignore` (committed) lists `dolt/`, `embeddeddolt/`, `bd.sock`, `bd.sock.startlock`, `sync-state.json`, `last-touched`, `.exclusive-lock`, `daemon.*`, `push-state.json`, `*.lock` — i.e. **the Dolt DB itself is intentionally not in git**; only the JSONL passive export plus config + hooks + metadata are committed.
+
+## 4. Sync mechanism today (verbatim `bd dolt show`)
+
+```
+Dolt Configuration
+==================
+  Database: Agency_OS
+  Mode:     embedded (in-process Dolt engine)
+  Data:     /home/elliotbot/clawd/Agency_OS/.beads/embeddeddolt
+
+Remotes:
+  (none)
+```
+
+`git for-each-ref refs/dolt/` from Agency_OS root → no output (no `refs/dolt/data` ref locally). `git ls-remote origin` → no `refs/dolt/*` refs on GitHub either.
+
+**No `bd sync` top-level command** exists; the canonical sync surface is `bd dolt push` / `bd dolt pull` (plus `bd dolt remote add <name> <url>` to configure a remote). `bd linear sync --pull/--push` is a separate Linear↔Beads bridge, not Beads↔Beads.
+
+Backup posture: `config.yaml` documents an auto-JSONL-export-with-git-push backup mode, gated on whether a git remote exists. Empirically the `issues.jsonl` files have synchronised mtimes per worktree (all 09:00 on max, atlas, etc.) suggesting they're being refreshed during git operations rather than from live Dolt writes — i.e. **the JSONL export is the only cross-worktree visibility today**, and it's read-only on the consumer side.
+
+## 5. Friction observed in practice
+
+Per `Agency_OS-iji` (Aiden's PR #771 review observation #2):
+
+> "Use bd for ALL task tracking" rule across worktrees doesn't work today because the Beads embedded Dolt DB is per-worktree, not shared. Pragmatic interim: TaskCreate locally for CTOs/clones until cross-worktree Beads sync solved (per upstream's refs/dolt/data git-sync model).
+
+In addition (this audit):
+
+- Max and Orion **physically cannot run `bd create`/`bd update`/`bd ready`** from their own worktrees. Workaround: `cd /home/elliotbot/clawd/Agency_OS && bd …` — but `cd`-ing out of a worktree breaks branch context for the agent.
+- Atlas/Aiden/Scout *appear* to work but are actually writing to **Elliot's local Dolt DB** via shared FS — no isolation, no auditable per-agent action trail at the Dolt level.
+- A second machine (e.g. CI runner, secondary Vultr host) has no way to read state today — JSONL is the only off-host visibility path, and it's lossy (no audit log, no Dolt rev history).
+- `bd close` writes by clones currently surface as actor=`elliotbot` in audit trails because the `BEADS_ACTOR` env doesn't propagate consistently — but that's a separate gap.
+
+## 6. Upstream's intended model (per https://github.com/gastownhall/beads SYNC_CONCEPTS.md, summarised)
+
+- Local Dolt DB per worktree (`bd init` creates it).
+- A configured remote (`bd dolt remote add origin <url>`) — can be a real Dolt server (DoltHub or self-hosted) or `file://` path on shared FS.
+- `bd dolt push` / `bd dolt pull` ship Dolt revisions between local and remote.
+- Optional: enable backup mode to also push JSONL exports to a normal git remote on each flush — this is what makes `.beads/issues.jsonl` an "automatic git-pushed audit trail" alongside Dolt's own commit history.
+- The `refs/dolt/data` git ref is *one* possible remote shape: store Dolt commits in the same GitHub repo under a non-branch ref namespace.
+
+We have implemented **none** of this yet. Today's effective architecture is "single-host shared filesystem, hope nobody's writing concurrently".
+
+## 7. Open questions surfaced (for recommendation doc to resolve)
+
+1. Is fixing Max + Orion to be proper Agency_OS git-worktrees in-scope, or is preserving them as worktrees-of-the-clawd-parent intentional?
+2. Multi-machine readiness — required pre-revenue, or defer until first non-Vultr worker?
+3. Concurrent-write safety — is "elliot writes, everyone else reads" acceptable, or do we need true multi-writer?
+4. Audit trail granularity — should `BEADS_ACTOR` per agent become a hard requirement?
+
+Methodology caveats: `bd where` output may differ if `BEADS_DIR` env is set per-worktree (not checked). Permission warnings on max/orion `.beads/` (`0775` instead of `0700`) suggest the dirs were created by a different process than aiden/atlas/scout — possibly hand-`mkdir`'d during clone-onboarding rather than `bd init`'d.

--- a/docs/wave2/beads_sync_recommendation.md
+++ b/docs/wave2/beads_sync_recommendation.md
@@ -1,0 +1,150 @@
+# Beads Cross-Worktree Sync — Recommendation (2026-05-12)
+
+**Author:** atlas
+**Companion to:** `docs/wave2/beads_cross_worktree_sync_state.md`
+**Beads tracking issue:** `Agency_OS-iji`
+
+## TL;DR
+
+Two distinct problems are tangled in the current setup:
+
+- **P1 (setup bug, fixable in minutes):** Max + Orion are git-worktrees of `/home/elliotbot/clawd/.git`, not Agency_OS. They cannot run `bd` at all because `.beads/` traversal exits their git tree.
+- **P2 (architecture, multi-day):** Even after P1 is fixed, all worktrees share Elliot's single embedded Dolt DB via shared FS — no audit isolation, no off-host visibility, no concurrent-write safety guarantees.
+
+Recommended path is **staged**:
+
+| Phase | Scope | Solves | Cost |
+|---|---|---|---|
+| **0** | Re-add Max + Orion as proper Agency_OS worktrees (P1 fix) | bd is runnable from every worktree | minutes |
+| **1** | Adopt upstream's git-`refs/dolt/data` sync — `bd dolt remote add origin git+ref://…` | Off-host visibility, true per-worktree DB, audit trail in Dolt history | ~1-2 PRs |
+| **2** | Decide between (a) keep refs-based git-sync as canonical, or (b) stand up a local `bd dolt start` daemon on the Vultr host that all worktrees point at | Concurrency safety / single source of truth | scope after Phase 1 ships |
+
+Dave-callable decisions:
+- **D1 (Phase 0 unblock):** OK to re-create Max + Orion worktrees? Branches `max/*` + `orion/*` need to be preserved — confirm the local-only commits we're cataloging before re-add.
+- **D2 (Phase 1 commit):** Adopt git-`refs/dolt/data` model (matches upstream, multi-host-ready), or defer until first non-Vultr worker exists?
+- **D3 (Phase 2 deferred):** Skip Phase 2 entirely if Phase 1 is sufficient — only revisit when concurrent-write contention becomes empirical.
+
+## Options surveyed
+
+Six candidate architectures were considered. Comparison matrix below.
+
+| # | Option | Solves P1? | Solves P2? | LOC / Ops cost | Multi-host? | Concurrent-write safe? | Reversible? |
+|---|---|---|---|---|---|---|---|
+| **A** | Re-init Max + Orion as proper Agency_OS git-worktrees | ✓ | partial (still shared FS) | trivial | no (still single host) | no | yes |
+| **B** | `BEADS_DIR=/home/elliotbot/clawd/Agency_OS/.beads` env in each agent's shell init | ✓ | no (still single DB) | trivial | no | no | yes |
+| **C** | Move `.beads/` to `/home/elliotbot/clawd/.beads` (parent dir shared by all worktrees) | ✓ | no | small | no | no | maybe (non-standard layout) |
+| **D** | **Upstream `refs/dolt/data` git-sync** — `bd dolt remote add origin git+ref://github.com/Keiracom/Agency_OS.git` + per-worktree `bd init` + `push`/`pull` cadence | requires A first | **yes** | small-medium | **yes** | yes (Dolt MVCC) | yes |
+| **E** | Self-hosted Dolt SQL server daemon (`bd dolt start` on Vultr host); all worktrees set `bd dolt set host 127.0.0.1 port <N>` | requires A first | **yes** | medium | partial (host-bound) | yes | yes |
+| **F** | No-DB mode (`no-db: true` in `config.yaml`); JSONL becomes source of truth; commit JSONL on each change | ✓ | partial (loses Dolt entirely) | small | yes (git is the sync) | no (git merge conflicts) | yes |
+
+(A) and (B) are *not* mutually exclusive with (D)/(E) — they're prerequisites or workarounds.
+
+### Why A first (always)
+
+The Max/Orion worktree-misalignment is a **setup defect**, not a design choice. Until it's fixed, every higher-layer option still has these two worktrees as a special case requiring `BEADS_DIR` overrides or `cd` workarounds. Fixing it costs minutes; postponing it makes every subsequent choice more complex.
+
+### Why D over E for Phase 1
+
+- **Multi-host readiness**: D works the moment we add a second machine (a remote checkout pulls Dolt commits via `git fetch`). E pins to one host's port.
+- **Audit + revertability**: Every Dolt commit is also a git ref — `git log refs/dolt/data` gives full history and `git revert` semantics on bd state changes. E requires a separate Dolt-side rollback flow.
+- **Backup as a side effect**: A git push covers off-host backup automatically. E needs its own backup plan.
+- **No daemon to babysit**: D is stateless from the bd-process perspective. E needs a systemd unit for the Dolt server, restart-on-crash, port management.
+- **Upstream-canonical**: `Agency_OS-iji` description explicitly cites "per upstream's `refs/dolt/data` git-sync model" as the target. We don't fork from upstream guidance without a reason.
+
+E becomes attractive **only if** concurrent-write contention shows up empirically in Phase 1 (multiple agents push-pushing to the same Dolt branch fast enough that conflicts overwhelm Dolt's merge logic). Default assumption: 6 agents writing at human-paced cadence won't hit this.
+
+### Why not F (no-db / JSONL-only)
+
+JSONL is line-append friendly, but Beads issues mutate (state transitions, comments, dependency edges, label changes). Concurrent multi-agent edits to the same `issues.jsonl` produce git merge conflicts on a normal file basis — Dolt's row-level merge is the whole reason it exists. We'd lose:
+- Concurrent-write safety
+- Query power (`bd ready`, `bd graph`)
+- Audit trail (no per-event history; only end state)
+- Dependency-edge integrity
+
+F is a fallback if upstream Beads becomes unmaintained, not a forward path.
+
+## Recommended Phase 0 (Dave D1 to authorise)
+
+**Step-by-step**:
+
+1. Catalog in-flight work in `Agency_OS-max` and `Agency_OS-orion`:
+   ```bash
+   for wt in /home/elliotbot/clawd/Agency_OS-{max,orion}; do
+     cd "$wt"
+     git status --short                       # uncommitted changes
+     git log --oneline @{u}..HEAD             # unpushed commits
+     git for-each-ref refs/heads/             # local branches
+   done
+   ```
+2. Push any unpushed commits / stash any uncommitted changes to a safe branch.
+3. Remove the worktree records from `/home/elliotbot/clawd/.git`:
+   ```bash
+   cd /home/elliotbot/clawd
+   git worktree remove Agency_OS-max
+   git worktree remove Agency_OS-orion
+   ```
+4. Re-add as proper Agency_OS worktrees:
+   ```bash
+   cd /home/elliotbot/clawd/Agency_OS
+   git worktree add ../Agency_OS-max -b max/restored-2026-05-12
+   git worktree add ../Agency_OS-orion -b orion/restored-2026-05-12
+   ```
+5. Verify: `cd ../Agency_OS-max && bd where` should now resolve to `/home/elliotbot/clawd/Agency_OS/.beads/embeddeddolt`.
+6. Verify: identical check from `Agency_OS-orion`.
+
+Cost: ~10 minutes incl. branch-state preservation. Risk: any local-only branches need to be force-pushed somewhere before remove. **No code changes required.**
+
+## Recommended Phase 1 (Dave D2 to authorise)
+
+After Phase 0 is green:
+
+1. Add the Dolt git-refs remote on Elliot's worktree:
+   ```bash
+   cd /home/elliotbot/clawd/Agency_OS
+   bd dolt remote add origin https://ghp_…@github.com/Keiracom/Agency_OS.git
+   bd dolt push origin main
+   ```
+   First push creates `refs/dolt/data` on GitHub.
+2. Per-worktree `bd init` (each clone gets its own Dolt DB):
+   ```bash
+   for wt in /home/elliotbot/clawd/Agency_OS-{aiden,max,atlas,orion,scout}; do
+     cd "$wt"
+     bd init  # creates local .beads/embeddeddolt/
+     bd dolt remote add origin <same URL>
+     bd dolt pull origin main
+   done
+   ```
+3. Adopt a sync cadence:
+   - **Pre-write hook**: `bd dolt pull` before any `bd create`/`bd update`/`bd close`
+   - **Post-write hook**: `bd dolt push` after the same
+   - Conflicts: Dolt's row-level merge handles non-overlapping edits; semantic conflicts surface as `bd dolt status` dirty state — agent must resolve via `bd dolt commit` before re-push.
+   - Wire as a git pre-commit hook AND/OR a bd-native hook in `.beads/hooks/`.
+4. Add a CI check: `bd dolt verify` on PR — ensures `.beads/issues.jsonl` matches the Dolt source of truth (catches manual JSONL edits, drift, etc.).
+5. Update `~/.claude/CLAUDE.md` global session-start to include `bd dolt pull` before any `bd ready` call.
+
+Cost: ~1 PR for the per-worktree init + sync-hook script; ~1 PR for the CI verification + CLAUDE.md update. **Doc-and-config-heavy, low risk.**
+
+## Phase 2 (deferred — only if Phase 1 contention shows up)
+
+Indicators that would trigger Phase 2:
+- `bd dolt push` rejected by remote ≥1×/day due to non-fast-forward conflicts that aren't trivially auto-mergeable.
+- Two agents observed completing the same `bd close` racily and producing divergent Dolt branches.
+- Latency on `bd ready` (which requires a pull first) becomes a real coordination tax (>10s per call).
+
+Phase 2 options at that point:
+- (E) Switch to a `bd dolt start` daemon on Vultr — all worktrees point at `127.0.0.1:<port>`.
+- Adopt a fan-in pattern: only Elliot (orchestrator) writes; other worktrees use a thin proxy that posts intents to Elliot's queue.
+- Hosted DoltHub if multi-region becomes a real requirement.
+
+## Open questions / explicit non-decisions
+
+- **Actor attribution** (`BEADS_ACTOR=<callsign>` per worktree) is a separate bug worth fixing in the same Phase 0 sweep but is not strictly required to make `bd` runnable.
+- **Permissions** on max/orion `.beads/` are `0775` (vs recommended `0700`). The Phase 0 re-add fixes this incidentally since `bd init` creates fresh dirs.
+- **`/home/elliotbot/clawd/.git` purpose** — Phase 0 doesn't change what that repo is; the max/orion worktrees are simply removed *from* it. If that parent repo has Agency_OS files staged, those would need to be staged elsewhere.
+- **No claim** in this doc that Phase 1 is required *now*. Default position: Phase 0 alone is enough to unblock `Agency_OS-iji`; Phase 1 is the right next step but its urgency is gated on D2.
+
+## Recommendation summary
+
+1. **Do Phase 0 now** (Dave D1 confirm). Closes `Agency_OS-iji` for practical purposes.
+2. **Schedule Phase 1 within the next 1-2 sessions** (Dave D2 confirm). Match upstream's intended sync model; gain off-host visibility + audit trail.
+3. **Treat Phase 2 as a contingency**, not a roadmap item, until empirical contention forces it.


### PR DESCRIPTION
## Summary

Research-only contribution to Beads `Agency_OS-iji` ("Cross-worktree Beads DB sync — CTOs can't run bd locally"). Two docs at \`docs/wave2/\`:

- \`beads_cross_worktree_sync_state.md\` — empirical state with verbatim \`bd where\` / \`bd dolt show\` / \`.git\` link evidence
- \`beads_sync_recommendation.md\` — 6-option comparison matrix + staged Phase 0/1/2 path + 3 Dave-callable decisions

## Key finding

The real blocker for Max + Orion is **not** Beads architecture — it's a git-worktree setup bug. Their \`.git\` links point at \`/home/elliotbot/clawd/.git\` (a different parent repo), not Agency_OS, so \`bd\`'s upward traversal exits the Agency_OS tree before reaching the embedded Dolt DB.

\`\`\`
Agency_OS-aiden  → gitdir: /home/elliotbot/clawd/Agency_OS/.git/worktrees/...  ← correct, bd works
Agency_OS-atlas  → gitdir: /home/elliotbot/clawd/Agency_OS/.git/worktrees/...  ← correct, bd works
Agency_OS-scout  → gitdir: /home/elliotbot/clawd/Agency_OS/.git/worktrees/...  ← correct, bd works
Agency_OS-max    → gitdir: /home/elliotbot/clawd/.git/worktrees/Agency_OS-max   ← WRONG, bd errors
Agency_OS-orion  → gitdir: /home/elliotbot/clawd/.git/worktrees/Agency_OS-orion ← WRONG, bd errors
\`\`\`

Phase 0 fix (~minutes) is \`git worktree remove\` + re-add from the Agency_OS root. Phase 1 (upstream refs/dolt/data sync) is the real architecture pickup.

## Test plan

- [x] Doc 1 has verbatim \`bd where\` per worktree, \`bd dolt show\`, \`.beads/.gitignore\` content
- [x] Doc 2 has 6-option comparison matrix with reversibility / multi-host / concurrency columns
- [x] No code changes; no \`.beads/\` mutations during research
- [ ] Aiden + Max review for accuracy on upstream-Beads-model claims (refs/dolt/data, Dolt MVCC, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)