### PR TITLE
[AIDEN] feat(enforcer): R11 CEO-FORMAT-GATE — mechanical #ceo plain-English convention

### DIFF
--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -229,6 +229,19 @@ def main() -> int:
         if not allow and replacement is not None:
             message = replacement
             print("⚠  concur-gate HELD original; posting CONCUR-REQUEST instead", file=sys.stderr)
+    # R11 CEO-FORMAT-GATE — block #ceo posts violating plain-English bullets-only
+    # convention (Dave directive ts ~1778582530). Runs AFTER concur-gate so the
+    # system-generated CONCUR-REQUEST replacement passes through (it's exempt).
+    try:
+        from src.bot_common.enforcer_deterministic import check_r11
+
+        ceo_block = check_r11(message, channel=channel)
+        if ceo_block is not None:
+            print(f"R_CEO_FORMAT_BLOCKED: {ceo_block['detail']}", file=sys.stderr)
+            print(f"  should_have: {ceo_block['should_have']}", file=sys.stderr)
+            return 2
+    except ImportError:
+        pass  # repo not on sys.path; fall through ungated rather than break all posts
     result = post(channel, message)
     if not result.get("ok"):
         print(f"ERROR: Slack rejected: {result}", file=sys.stderr)

--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -447,3 +447,125 @@ def check_r10(
             "before posting the completion claim — or within the 60s window after."
         ),
     }
+
+
+# ---------------------------------------------------------------------------
+# R11 — CEO-FORMAT-GATE (Dave directive ts ~1778582530)
+# ---------------------------------------------------------------------------
+#
+# Mechanical enforcement of the #ceo plain-English bullets-only convention.
+# Fires on outbound to channel "ceo" (C0B2PM3TV0B) when the body violates the
+# format. Pin-discipline isn't enough; this is the runtime gate that blocks
+# bad-format posts BEFORE they hit Slack.
+#
+# Wired into scripts/slack_relay.py main() AFTER concur-gate (so the system-
+# generated CONCUR-REQUEST replacements pass through; only original agent text
+# is gated).
+
+# Bold category header — markdown ** ** at line start.
+_R11_HEADER_RE = re.compile(r"^\s*\*\*[^*]+\*\*", re.MULTILINE)
+
+# Bullet markers: -, *, •, numbered (1.) at line start.
+_R11_BULLET_RE = re.compile(r"^\s*(?:[-*•]|\d+\.)\s+", re.MULTILINE)
+
+# Banned tokens that indicate technical-density (not plain-English):
+_R11_BANNED_RES = (
+    re.compile(r"\bPR\s*#\d+", re.IGNORECASE),  # PR references
+    re.compile(r"\b[a-f0-9]{7,40}\b"),  # commit SHAs
+    re.compile(r"\bscripts/[A-Za-z0-9_/.\-]+"),  # file paths under scripts/
+    re.compile(r"\bsrc/[A-Za-z0-9_/.\-]+"),  # file paths under src/
+    re.compile(r"\.claude/[A-Za-z0-9_/.\-]+"),  # file paths under .claude/
+    re.compile(r"\b[A-Z][A-Z_]+_API_KEY\b"),  # env var names ending API_KEY
+    re.compile(r"\b[A-Z][A-Z_]+_PROVIDER\b"),  # env var names ending PROVIDER
+    re.compile(r"```"),  # code fences
+)
+
+# Exempt: system-generated CONCUR-REQUEST replacements (concur_gate output).
+_R11_EXEMPT_RE = re.compile(
+    r"\[CONCUR-REQUEST:[A-Z]+\]"
+    r"|requesting concurrence from peer",
+    re.IGNORECASE,
+)
+
+
+def _r11_prose_paragraph_present(text: str) -> bool:
+    """Heuristic: any 'line' that's >150 chars AND has 2+ sentences (period followed
+    by space) AND has NO bullet marker is a prose paragraph.
+
+    Threshold deliberately conservative — single long bulleted explanation is fine;
+    only un-bulleted multi-sentence runs trip the rule.
+    """
+    for line in text.splitlines():
+        s = line.strip()
+        if len(s) < 150:
+            continue
+        if _R11_BULLET_RE.match(line):
+            continue
+        # Count sentence terminators (period followed by space or end of line).
+        sentence_count = len(re.findall(r"\.\s+|\.$", s))
+        if sentence_count >= 2:
+            return True
+    return False
+
+
+def check_r11(text: str, *, channel: str | None = None) -> dict | None:
+    """R11 — CEO-FORMAT-GATE.
+
+    Fires when:
+      - channel is the #ceo channel (C0B2PM3TV0B); AND
+      - message body violates the plain-English bullets convention.
+
+    Failure modes:
+      (a) Lacks any **bold category header** (markdown ** ** at line start)
+      (b) Contains a prose paragraph (>=150 char un-bulleted line with 2+ sentences)
+      (c) Contains banned technical tokens: PR #N, commit SHAs, file paths
+          under scripts/|src/|.claude/, env var names ending _API_KEY|_PROVIDER,
+          code fences ```
+
+    `channel` defaults to None (treat as non-ceo → pass).
+    `text` body of the message.
+
+    Returns violation dict with `rule_number=11` + `detail` listing violations,
+    or None when channel != ceo OR text is exempt OR text passes all checks.
+    """
+    CEO_CHANNEL_ID = "C0B2PM3TV0B"
+    if channel != CEO_CHANNEL_ID:
+        return None
+    if _R11_EXEMPT_RE.search(text):
+        return None
+
+    violations: list[str] = []
+
+    # (a) Missing bold header
+    if not _R11_HEADER_RE.search(text):
+        violations.append("no bold category header (**...** at line start)")
+
+    # (b) Prose paragraph
+    if _r11_prose_paragraph_present(text):
+        violations.append("prose paragraph (un-bulleted line ≥150 chars with 2+ sentences)")
+
+    # (c) Banned technical tokens
+    banned_found: list[str] = []
+    for pat in _R11_BANNED_RES:
+        m = pat.search(text)
+        if m:
+            banned_found.append(m.group(0)[:30])
+    if banned_found:
+        violations.append(f"banned technical tokens: {', '.join(banned_found)}")
+
+    if not violations:
+        return None
+
+    return {
+        "violation": True,
+        "rule_number": 11,
+        "rule_name": "CEO-FORMAT-GATE",
+        "detail": "#ceo post violates plain-English bullets-only convention: "
+        + "; ".join(violations),
+        "should_have": (
+            "Rewrite as: **Bold Category** headers + bullet list (- or •) only. "
+            "Lead with OUTCOME + business meaning. No PR numbers, commit SHAs, "
+            "file paths, env vars, or code fences. Technical detail stays in "
+            "#execution. See feedback_ceo_plain_english_summaries.md."
+        ),
+    }

--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -502,7 +502,8 @@ def _r11_prose_paragraph_present(text: str) -> bool:
         if _R11_BULLET_RE.match(line):
             continue
         # Count sentence terminators (period followed by space or end of line).
-        sentence_count = len(re.findall(r"\.\s+|\.$", s))
+        # Non-capturing group makes alternation precedence explicit (SonarCloud S5850).
+        sentence_count = len(re.findall(r"(?:\.\s+|\.$)", s))
         if sentence_count >= 2:
             return True
     return False

--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -503,7 +503,7 @@ def _r11_prose_paragraph_present(text: str) -> bool:
             continue
         # Count sentence terminators (period followed by space or end of line).
         # Non-capturing group makes alternation precedence explicit (SonarCloud S5850).
-        sentence_count = len(re.findall(r"(?:\.\s+|\.$)", s))
+        sentence_count = len(re.findall(r"\.(?:\s+|$)", s))
         if sentence_count >= 2:
             return True
     return False

--- a/tests/bot_common/test_enforcer_deterministic.py
+++ b/tests/bot_common/test_enforcer_deterministic.py
@@ -458,3 +458,152 @@ def test_r10_directive_done_phrase_fires_when_no_kei():
     out = check_r10("Wave 2 Outcome 3 complete — enforcer rule shipped")
     assert out is not None
     assert "without KEI-<N> tag" in out["detail"]
+
+
+# ---------------------------------------------------------------------------
+# R11 — CEO-FORMAT-GATE (Wave 2 Dave directive)
+# ---------------------------------------------------------------------------
+
+CEO_CH = "C0B2PM3TV0B"
+EXEC_CH = "C0B3QB0K1GQ"
+
+
+def test_r11_non_ceo_channel_always_passes():
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    # Even a clearly bad-format message passes if channel isn't #ceo.
+    bad = "Random prose dump merged PR #774 with commit abc1234 in scripts/foo.py"
+    assert check_r11(bad, channel=EXEC_CH) is None
+    assert check_r11(bad, channel=None) is None
+
+
+def test_r11_ceo_well_formatted_passes():
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    good = """**Outcome**
+- Phase 0 verified end-to-end on local stack
+- Smoke test passed both assertions
+
+**Next**
+- Phase 1 ingest unblocked"""
+    assert check_r11(good, channel=CEO_CH) is None
+
+
+def test_r11_ceo_missing_bold_header_fires():
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    no_header = """- bullet one is fine on its own
+- bullet two also
+- but no header"""
+    out = check_r11(no_header, channel=CEO_CH)
+    assert out is not None
+    assert out["rule_number"] == 11
+    assert "no bold category header" in out["detail"]
+
+
+def test_r11_ceo_prose_paragraph_fires():
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    prose = (
+        "**Header**\n"
+        "This is one long sentence about something. "
+        "And this is a second sentence in the same line that makes it prose. "
+        "Plus a third for safety to ensure the heuristic trips on 2+ sentences in 150+ chars."
+    )
+    out = check_r11(prose, channel=CEO_CH)
+    assert out is not None
+    assert "prose paragraph" in out["detail"]
+
+
+def test_r11_ceo_pr_number_banned():
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    with_pr = """**Header**
+- something happened
+- merged PR #774 today"""
+    out = check_r11(with_pr, channel=CEO_CH)
+    assert out is not None
+    assert "PR #774" in out["detail"] or "banned technical tokens" in out["detail"]
+
+
+def test_r11_ceo_commit_sha_banned():
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    with_sha = """**Header**
+- something happened
+- at sha abc1234def56"""
+    out = check_r11(with_sha, channel=CEO_CH)
+    assert out is not None
+    assert "banned technical tokens" in out["detail"]
+
+
+def test_r11_ceo_file_path_banned():
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    with_path = """**Header**
+- changed src/cognee/client.py and scripts/foo.sh
+- result was good"""
+    out = check_r11(with_path, channel=CEO_CH)
+    assert out is not None
+    assert "banned technical tokens" in out["detail"]
+
+
+def test_r11_ceo_env_var_name_banned():
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    with_env = """**Header**
+- set GEMINI_API_KEY
+- and DB_PROVIDER too"""
+    out = check_r11(with_env, channel=CEO_CH)
+    assert out is not None
+    assert "banned technical tokens" in out["detail"]
+
+
+def test_r11_ceo_code_fence_banned():
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    with_fence = """**Header**
+- something
+```
+code block here
+```"""
+    out = check_r11(with_fence, channel=CEO_CH)
+    assert out is not None
+    assert "banned technical tokens" in out["detail"]
+
+
+def test_r11_concur_request_replacement_exempt():
+    """System-generated CONCUR-REQUEST messages from concur_gate pass through —
+    they're not agent-authored prose, they're a wrapper artifact."""
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    concur = "[AIDEN] [CONCUR-REQUEST:AIDEN] requesting concurrence from peer on: ..."
+    # Even though it doesn't have a bold header, exempt path returns None.
+    assert check_r11(concur, channel=CEO_CH) is None
+
+
+def test_r11_multiple_violations_stacked_in_detail():
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    bad = "merged PR #774 in scripts/foo.py"  # no header, PR, path
+    out = check_r11(bad, channel=CEO_CH)
+    assert out is not None
+    detail = out["detail"]
+    assert "no bold category header" in detail
+    assert "banned technical tokens" in detail
+
+
+def test_r11_single_long_bullet_not_prose():
+    """A SINGLE bulleted long line shouldn't trip prose-paragraph heuristic
+    (the rule targets un-bulleted multi-sentence runs)."""
+    from src.bot_common.enforcer_deterministic import check_r11
+
+    long_bullet = (
+        "**Header**\n"
+        "- this is a very long bullet that has a couple of sentences in it. "
+        "It's still a bullet though so the prose heuristic should not fire on it."
+    )
+    out = check_r11(long_bullet, channel=CEO_CH)
+    # Either passes entirely or only flags non-prose issues.
+    if out is not None:
+        assert "prose paragraph" not in out["detail"]


### PR DESCRIPTION
## Summary

Per Dave directive ts ~1778582530 + Elliot dispatch. Pin-discipline isn't enough; this is the runtime gate that blocks bad-format #ceo posts BEFORE they hit Slack.

R11 mirrors R10 (LINEAR-KEI-GATE) shape: deterministic check function returning violation dict or None, wired into `scripts/slack_relay.py main()` between concur-gate and `post()`.

## Trigger

- channel = `C0B2PM3TV0B` (#ceo) only
- message body violates ANY of:
  1. **Missing bold category header** (`**...**` at line start)
  2. **Prose paragraph** (un-bulleted line ≥150 chars with 2+ sentences)
  3. **Banned technical tokens**: PR #N, commit SHAs (`\b[a-f0-9]{7,40}\b`), file paths under `scripts/|src/|.claude/`, env var names matching `_API_KEY|_PROVIDER`, code fences `` ``` ``

## Exempt

- System-generated CONCUR-REQUEST replacements from concur_gate (matches `[CONCUR-REQUEST:CALLSIGN]` or `requesting concurrence from peer`) — wrapper artifacts, not agent-authored prose
- Non-#ceo channels (everything else passes through unchanged)

## Wiring

`scripts/slack_relay.py main()`:
1. verify_gate → exit 2 on fab
2. law_xv_gate → exit 2 on stale save
3. concur_gate → may replace message with CONCUR-REQUEST
4. **NEW: R11 CEO-FORMAT-GATE** → exit 2 on bad-format #ceo
5. post()

On violation: stderr prints `R_CEO_FORMAT_BLOCKED: <detail>` + `should_have: <rewrite hint>`, exit 2.

## Test plan

- [x] 12 R11 tests pass (positive + negative + exempt + edge cases)
- [x] 56 pre-existing tests still pass (68 total)
- [x] Lint + format clean
- [ ] CI: Backend Lint / Pytest / MyPy / Dead Ref / Frontend / SonarCloud / Migration Completeness Guard / Governance Equality Guard
- [ ] Dual-CTO concur (Aiden author + Max reviewer)

## Coverage detail

| Test | Asserts |
|---|---|
| `test_r11_non_ceo_channel_always_passes` | #execution + None channel → None |
| `test_r11_ceo_well_formatted_passes` | bullets + bold headers → None |
| `test_r11_ceo_missing_bold_header_fires` | bullets without header → fires |
| `test_r11_ceo_prose_paragraph_fires` | ≥150-char un-bulleted multi-sentence → fires |
| `test_r11_ceo_pr_number_banned` | `PR #774` → fires |
| `test_r11_ceo_commit_sha_banned` | `abc1234def56` → fires |
| `test_r11_ceo_file_path_banned` | `src/cognee/client.py` → fires |
| `test_r11_ceo_env_var_name_banned` | `GEMINI_API_KEY` / `DB_PROVIDER` → fires |
| `test_r11_ceo_code_fence_banned` | `` ``` `` → fires |
| `test_r11_concur_request_replacement_exempt` | system message passes |
| `test_r11_multiple_violations_stacked_in_detail` | multi-violation detail joins all |
| `test_r11_single_long_bullet_not_prose` | bulleted line with 2 sentences NOT flagged |

## Limitations (documented)

- Wrapper-level only (slack_relay.py). Agents calling Slack API directly bypass R11. Acceptable for v1; all agents use slack_relay.py per IDENTITY.md.
- Listener-side mirror (defense-in-depth) is a v2 candidate.
- 150-char prose threshold is conservative — may pass long bulleted explanations + may not catch short-but-prose-shaped lines. Tune in v2 if FP/FN ratio is bad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)