### PR TITLE
[AIDEN] feat(orchestrator): KEI-17 schedule update — peak 07-24 AEST

### DIFF
--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -47,7 +47,7 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger("elliot_polling_loop")
 
 # Time-of-day window. AEST = UTC+10.
-PEAK_HOURS_UTC = set(list(range(21, 24)) + list(range(0, 11)))  # 21–10 UTC inclusive
+PEAK_HOURS_UTC = set(list(range(21, 24)) + list(range(0, 14)))  # 21–13 UTC inclusive = 07–23 AEST
 STALE_LINEAR_HOURS = 12
 IDLE_AGENT_MINUTES = 30
 PREFECT_WINDOW_MINUTES = 5

--- a/tests/scripts/test_elliot_polling_loop.py
+++ b/tests/scripts/test_elliot_polling_loop.py
@@ -50,6 +50,34 @@ def test_should_run_now_overnight_other_minute(loop_mod):
     assert loop_mod.should_run_now(datetime(2026, 5, 12, 15, 30, tzinfo=UTC)) is False
 
 
+# New boundary tests for Dave's KEI-17 schedule amendment ts ~1778584000:
+# Peak window AEST 07:00–24:00 (UTC 21:00 prev day → 14:00 today, exclusive).
+# Off-peak AEST 00:00–07:00 (UTC 14:00 → 21:00, exclusive).
+
+
+def test_should_run_now_peak_window_late_boundary(loop_mod):
+    # 13:59 UTC = 23:59 AEST — last minute of peak window
+    assert loop_mod.should_run_now(datetime(2026, 5, 12, 13, 59, tzinfo=UTC)) is True
+
+
+def test_should_run_now_off_peak_starts_at_14_utc(loop_mod):
+    # 14:00 UTC = 00:00 AEST — first hour of off-peak; minute==0 still fires (hourly)
+    assert loop_mod.should_run_now(datetime(2026, 5, 12, 14, 0, tzinfo=UTC)) is True
+    # 14:30 UTC = 00:30 AEST — off-peak hour, minute!=0 → skip
+    assert loop_mod.should_run_now(datetime(2026, 5, 12, 14, 30, tzinfo=UTC)) is False
+
+
+def test_should_run_now_off_peak_late_skip(loop_mod):
+    # 20:59 UTC = 06:59 AEST — last off-peak hour, minute!=0 → skip
+    assert loop_mod.should_run_now(datetime(2026, 5, 12, 20, 59, tzinfo=UTC)) is False
+
+
+def test_should_run_now_peak_starts_at_21_utc(loop_mod):
+    # 21:00 UTC = 07:00 AEST — first hour of peak; any minute runs
+    assert loop_mod.should_run_now(datetime(2026, 5, 12, 21, 0, tzinfo=UTC)) is True
+    assert loop_mod.should_run_now(datetime(2026, 5, 12, 21, 37, tzinfo=UTC)) is True
+
+
 # poll_bd_ready ──────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Per Dave KEI-17 polling schedule amendment ts ~1778584000:
- Peak (every-minute): 07:00–24:00 AEST (was 07:00–21:00) — 17 hours
- Off-peak (hourly):   00:00–07:00 AEST (was 21:00–07:00) —  7 hours

3-char change in `scripts/orchestrator/elliot_polling_loop.py`: `range(0, 11)` → `range(0, 14)` (extends UTC peak window to include hours 11/12/13, which are AEST 21/22/23).

## UTC translation

AEST = UTC+10.

- **Peak UTC**: hours `{21, 22, 23} ∪ {0..13}` = UTC 21:00 prev day → 14:00 today (exclusive of 14)
- **Off-peak UTC**: hours `{14..20}` = UTC 14:00 → 21:00 today (exclusive of 21)

## Tests

18 → 22. New boundary cases for the amended schedule:

| Test | UTC | AEST | Expected |
|---|---|---|---|
| `test_should_run_now_peak_window_late_boundary` | 13:59 | 23:59 | True (last peak minute) |
| `test_should_run_now_off_peak_starts_at_14_utc` | 14:00, 14:30 | 00:00, 00:30 | True (hourly fire), False (skip) |
| `test_should_run_now_off_peak_late_skip` | 20:59 | 06:59 | False (last off-peak hour, skip) |
| `test_should_run_now_peak_starts_at_21_utc` | 21:00, 21:37 | 07:00, 07:37 | True, True |

Pre-existing tests (22:30 UTC = 08:30 AEST peak; 15:00 UTC = 01:00 AEST overnight hourly; 15:30 overnight skip) remain valid — semantics preserved.

## Test plan

- [x] 22 tests pass (was 18; +4 boundary cases for new schedule)
- [x] Ruff check + format clean
- [ ] CI green
- [ ] Dual-CTO concur (Aiden author + Max reviewer)
- [ ] Post-merge: Elliot runs `systemctl --user restart elliot-polling-loop.timer` to pick up live schedule
- [ ] LAW XV save (bundled with prior Wave 2 + KEI-12 cleanup-bak save per Elliot's rolling-bundle pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)