### PR TITLE
[AIDEN] feat(orchestrator): self-assign hook + polling hole A (Dave urgent)

### DIFF
--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -62,10 +62,18 @@ PRIMES = ("aiden", "max")  # elliot orchestrates; she doesn't dispatch to hersel
 # Clones receive dispatches via inbox-watcher JSON drops, NOT via Slack channel
 # fan-out (the listener path is uptime-sensitive; direct inbox write is the
 # Layer 3 mechanical close).
+# NOSONAR S5443 ×3 below: /tmp/telegram-relay-<cs>/inbox is the systemd
+# inotify-watcher contract (per .claude/hooks/inbox_check_hook.sh + the
+# per-callsign relay-watcher services). Cannot migrate to ~/.local/state
+# without a coordinated watcher refactor. Defense-in-depth: callsign keys
+# are regex-validated upstream (PR #757 state_paths.resolve_state_dir
+# pattern + per_callsign_outbound_allowlist in slack_relay.py); no user
+# input reaches the path string. Same justification as central_listener.py
+# inbox-watcher integration.
 INBOX_PATHS: dict[str, str] = {
-    "atlas": "/tmp/telegram-relay-atlas/inbox",
-    "orion": "/tmp/telegram-relay-orion/inbox",
-    "scout": "/tmp/telegram-relay-scout/inbox",
+    "atlas": "/tmp/telegram-relay-atlas/inbox",  # NOSONAR
+    "orion": "/tmp/telegram-relay-orion/inbox",  # NOSONAR
+    "scout": "/tmp/telegram-relay-scout/inbox",  # NOSONAR
 }
 
 

--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -58,6 +58,16 @@ CEO_CHANNEL_NAME = "#ceo"
 CLONES = ("atlas", "orion", "scout")
 PRIMES = ("aiden", "max")  # elliot orchestrates; she doesn't dispatch to herself
 
+# Inbox-path map for clones (Dave directive ts ~1778584800 — polling hole A).
+# Clones receive dispatches via inbox-watcher JSON drops, NOT via Slack channel
+# fan-out (the listener path is uptime-sensitive; direct inbox write is the
+# Layer 3 mechanical close).
+INBOX_PATHS: dict[str, str] = {
+    "atlas": "/tmp/telegram-relay-atlas/inbox",
+    "orion": "/tmp/telegram-relay-orion/inbox",
+    "scout": "/tmp/telegram-relay-scout/inbox",
+}
+
 
 @dataclass
 class CycleSignals:
@@ -233,7 +243,13 @@ def compose_dispatches(signals: CycleSignals) -> list[tuple[str, str]]:
             f"Polled by KEI-17 elliot_polling_loop; agent {callsign} idle "
             f"≥{IDLE_AGENT_MINUTES}m, this Beads item is ready (no blockers)."
         )
-        dispatches.append((EXECUTION_CHANNEL_NAME, msg))
+        # Clones receive dispatches via inbox-watcher JSON (Dave directive
+        # ts ~1778584800 polling hole A — direct write, not Slack fan-out).
+        # Primes (aiden/max) get the #execution post for human visibility.
+        if callsign in CLONES:
+            dispatches.append((f"inbox:{callsign}", msg))
+        else:
+            dispatches.append((EXECUTION_CHANNEL_NAME, msg))
 
     if signals.linear_stale:
         lines = [
@@ -266,8 +282,47 @@ def compose_dispatches(signals: CycleSignals) -> list[tuple[str, str]]:
     return dispatches
 
 
+def _write_inbox_dispatch(callsign: str, text: str) -> None:
+    """Write a dispatch JSON to the clone's inbox directory (Dave polling hole A
+    fix ts ~1778584800). Clones' inbox-watchers pick up the file + inject into
+    their tmux session. Direct write — doesn't depend on central listener
+    Slack fan-out being live.
+    """
+    inbox = INBOX_PATHS.get(callsign)
+    if not inbox:
+        logger.warning("no inbox path for callsign %r — dropping dispatch", callsign)
+        return
+    inbox_dir = Path(inbox)
+    if not inbox_dir.is_dir():
+        logger.warning("inbox dir %s missing — dropping dispatch", inbox)
+        return
+    import uuid
+
+    payload = {
+        "type": "task_dispatch",
+        "from": "elliot_polling_loop",
+        "brief": text,
+        "polled_at": datetime.now(UTC).isoformat(),
+    }
+    fname = f"{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}_polling_{uuid.uuid4().hex[:8]}.json"
+    target = inbox_dir / fname
+    try:
+        target.write_text(json.dumps(payload, indent=2))
+    except OSError as exc:
+        logger.warning("inbox write %s failed: %s", target, exc)
+
+
 def send_dispatch(channel: str, text: str) -> None:
-    """Post via scripts/slack_relay.py. Best-effort; relay failure logs + drops."""
+    """Route dispatch by target type. Best-effort; failures log + drop.
+
+    - 'inbox:<callsign>' → write JSON to clone's inbox dir (Dave polling hole A).
+    - '#execution' / '#ceo' / other → scripts/slack_relay.py.
+    """
+    if channel.startswith("inbox:"):
+        callsign = channel.split(":", 1)[1]
+        _write_inbox_dispatch(callsign, text)
+        return
+
     relay = Path(__file__).resolve().parent / "slack_relay.py"
     flag = "-g" if channel == EXECUTION_CHANNEL_NAME else "-c"
     try:

--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -257,13 +257,39 @@ def main() -> int:
     return 0
 
 
+def _is_ready_marker(message: str, callsign: str) -> bool:
+    """True iff message contains an ANCHORED [READY:<callsign>] state marker.
+
+    v2 anchoring (Dave directive + Elliot dispatch ts ~1778586700) — fixes the
+    false-positive from the empirical first-fire (PR #783 announce post had
+    [READY:aiden] in PROSE describing the hook behaviour; the substring-anywhere
+    match fired + claimed an unrelated P0 issue).
+
+    Match position rules (any one matches → ready):
+      - Start of message (optionally preceded by whitespace)
+      - Start of any line in the message
+      - Right after the callsign tag prefix '[<CALLSIGN>]' at start
+
+    Prose mentions of '[READY:aiden]' embedded mid-sentence DO NOT match.
+    """
+    # `]` is a literal delimiter — no \b needed; the brackets themselves are
+    # the bookends. Anchored at (start-of-string | newline) + optional callsign
+    # tag prefix, so prose 'Next live [READY:aiden] emission' (mid-sentence)
+    # does NOT match.
+    pattern = re.compile(
+        rf"(?:^|\n)\s*(?:\[{re.escape(callsign.upper())}\]\s*)?\[READY:{re.escape(callsign)}\]",
+        re.IGNORECASE,
+    )
+    return bool(pattern.search(message))
+
+
 def _maybe_self_assign(message: str) -> None:
-    """If message contains [READY:<my-callsign>], try bd ready → bd claim first.
+    """If message contains an anchored [READY:<my-callsign>], try bd ready → bd claim.
 
     Best-effort + non-blocking: subprocess timeouts + missing bd binary log
     + return. Never raises. The polling loop is the safety net if this fails.
     """
-    if f"[READY:{CALLSIGN}]".lower() not in message.lower():
+    if not _is_ready_marker(message, CALLSIGN):
         return
     import subprocess as _sub
 

--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -249,7 +249,61 @@ def main() -> int:
     ts = result.get("ts", "")
     ch = result.get("channel", channel)
     print(f"→ {CALLSIGN_TAG} sent to Slack #{ch} (ts {ts})")
+    # Layer-3 mechanical self-assignment (Dave directive ts ~1778584800).
+    # On [READY:<callsign>] emission, fire bd ready + claim first unblocked
+    # so the agent self-assigns immediately rather than waiting for the
+    # 60s polling loop. Best-effort: subprocess failures log + drop.
+    _maybe_self_assign(message)
     return 0
+
+
+def _maybe_self_assign(message: str) -> None:
+    """If message contains [READY:<my-callsign>], try bd ready → bd claim first.
+
+    Best-effort + non-blocking: subprocess timeouts + missing bd binary log
+    + return. Never raises. The polling loop is the safety net if this fails.
+    """
+    if f"[READY:{CALLSIGN}]".lower() not in message.lower():
+        return
+    import subprocess as _sub
+
+    try:
+        proc = _sub.run(["bd", "ready", "--json"], capture_output=True, text=True, timeout=10)
+    except (FileNotFoundError, _sub.TimeoutExpired, OSError) as exc:
+        print(f"[self-assign] bd ready unavailable: {exc}", file=sys.stderr)
+        return
+    if proc.returncode != 0:
+        print(f"[self-assign] bd ready exit {proc.returncode}", file=sys.stderr)
+        return
+    try:
+        issues = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        print(f"[self-assign] bd ready json parse: {exc}", file=sys.stderr)
+        return
+    if not issues:
+        print("[self-assign] bd ready empty — nothing to claim", file=sys.stderr)
+        return
+    first_id = issues[0].get("id")
+    if not first_id:
+        return
+    try:
+        claim = _sub.run(
+            ["bd", "update", first_id, "--claim"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, _sub.TimeoutExpired, OSError) as exc:
+        print(f"[self-assign] bd claim unavailable: {exc}", file=sys.stderr)
+        return
+    if claim.returncode != 0:
+        print(
+            f"[self-assign] claim race on {first_id} (exit {claim.returncode}) — "
+            f"falling back to polling-loop dispatch",
+            file=sys.stderr,
+        )
+        return
+    print(f"[self-assign] claimed {first_id} — work starts immediately", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -269,7 +269,7 @@ def _maybe_self_assign(message: str) -> None:
 
     try:
         proc = _sub.run(["bd", "ready", "--json"], capture_output=True, text=True, timeout=10)
-    except (FileNotFoundError, _sub.TimeoutExpired, OSError) as exc:
+    except (_sub.TimeoutExpired, OSError) as exc:
         print(f"[self-assign] bd ready unavailable: {exc}", file=sys.stderr)
         return
     if proc.returncode != 0:
@@ -293,7 +293,7 @@ def _maybe_self_assign(message: str) -> None:
             text=True,
             timeout=10,
         )
-    except (FileNotFoundError, _sub.TimeoutExpired, OSError) as exc:
+    except (_sub.TimeoutExpired, OSError) as exc:
         print(f"[self-assign] bd claim unavailable: {exc}", file=sys.stderr)
         return
     if claim.returncode != 0:

--- a/tests/scripts/test_elliot_polling_loop.py
+++ b/tests/scripts/test_elliot_polling_loop.py
@@ -271,3 +271,58 @@ def test_run_cycle_dispatches_when_signals_present(loop_mod, monkeypatch):
     assert len(sent) == 1
     assert sent[0][0] == "#execution"
     assert "[DISPATCH-PROPOSAL:aiden]" in sent[0][1]
+
+
+# Polling hole A (Dave directive ts ~1778584800) — clone inbox dispatch ─────
+
+
+def test_compose_dispatches_clone_targets_inbox_not_execution(loop_mod):
+    """Clone callsigns (atlas/orion/scout) get inbox:<cs> target, not #execution.
+    Primes (aiden/max) still get #execution."""
+    sig = loop_mod.CycleSignals(
+        bd_ready=[
+            {"id": "A1", "title": "T1", "priority": 0},
+            {"id": "A2", "title": "T2", "priority": 0},
+            {"id": "A3", "title": "T3", "priority": 0},
+        ],
+        linear_stale=[],
+        idle_agents=["atlas", "aiden", "orion"],
+        prefect_failures=[],
+    )
+    dispatches = loop_mod.compose_dispatches(sig)
+    assert len(dispatches) == 3
+    targets = [d[0] for d in dispatches]
+    assert "inbox:atlas" in targets
+    assert "#execution" in targets
+    assert "inbox:orion" in targets
+
+
+def test_send_dispatch_inbox_writes_json_file(loop_mod, monkeypatch, tmp_path):
+    """send_dispatch('inbox:atlas', text) writes a JSON dispatch file to the
+    monkeypatched inbox path."""
+    inbox = tmp_path / "telegram-relay-atlas" / "inbox"
+    inbox.mkdir(parents=True)
+    monkeypatch.setitem(loop_mod.INBOX_PATHS, "atlas", str(inbox))
+
+    loop_mod.send_dispatch("inbox:atlas", "[DISPATCH-PROPOSAL:atlas] do thing")
+    files = list(inbox.iterdir())
+    assert len(files) == 1
+    import json as _json
+
+    payload = _json.loads(files[0].read_text())
+    assert payload["type"] == "task_dispatch"
+    assert payload["from"] == "elliot_polling_loop"
+    assert "[DISPATCH-PROPOSAL:atlas]" in payload["brief"]
+
+
+def test_send_dispatch_inbox_missing_dir_drops_quietly(loop_mod, monkeypatch, tmp_path):
+    """If the clone's inbox dir doesn't exist (clone offline / pre-watcher),
+    drop the dispatch instead of crashing."""
+    monkeypatch.setitem(loop_mod.INBOX_PATHS, "atlas", str(tmp_path / "nonexistent"))
+    # Should not raise.
+    loop_mod.send_dispatch("inbox:atlas", "text")
+
+
+def test_send_dispatch_unknown_inbox_callsign_drops(loop_mod):
+    """inbox:<unmapped> drops quietly (best-effort)."""
+    loop_mod.send_dispatch("inbox:unknown_callsign", "text")  # no raise

--- a/tests/scripts/test_self_assign_anchor.py
+++ b/tests/scripts/test_self_assign_anchor.py
@@ -1,0 +1,61 @@
+"""Tests for the anchored [READY:<callsign>] regex (PR #783 v2)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path("/home/elliotbot/clawd/Agency_OS-aiden")
+SCRIPT_PATH = REPO_ROOT / "scripts" / "slack_relay.py"
+
+
+def _load_slack_relay():
+    # Module-level code reads SLACK_BOT_TOKEN + resolves CALLSIGN; ensure both
+    # are set before import.
+    import os
+
+    os.environ.setdefault("SLACK_BOT_TOKEN", "test-token")
+    os.environ.setdefault("CALLSIGN", "aiden")
+    spec = importlib.util.spec_from_file_location("slack_relay_test", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["slack_relay_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_anchored_start_of_message_fires():
+    mod = _load_slack_relay()
+    assert mod._is_ready_marker("[READY:aiden] starting work", "aiden") is True
+
+
+def test_anchored_after_callsign_tag_fires():
+    mod = _load_slack_relay()
+    assert mod._is_ready_marker("[AIDEN] [READY:aiden] starting work", "aiden") is True
+
+
+def test_anchored_start_of_line_fires():
+    mod = _load_slack_relay()
+    assert mod._is_ready_marker("Some preamble\n[READY:aiden] continuing", "aiden") is True
+
+
+def test_prose_reference_does_not_fire():
+    """The empirical false-positive that fired on PR #783's own announce:
+    '[READY:aiden] emission' embedded mid-sentence with no line-anchor."""
+    mod = _load_slack_relay()
+    prose = "Next live [READY:aiden] emission should see [self-assign] claimed <id>"
+    assert mod._is_ready_marker(prose, "aiden") is False
+
+
+def test_wrong_callsign_does_not_fire():
+    mod = _load_slack_relay()
+    assert mod._is_ready_marker("[READY:max] not me", "aiden") is False
+
+
+def test_case_insensitive_matches():
+    mod = _load_slack_relay()
+    assert mod._is_ready_marker("[ready:AIDEN] case insensitive", "aiden") is True
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Per Dave urgent directive ts ~1778584800. Closes idle-agent miss-mode at the speed-of-emission, not the speed-of-poll.

**Outcome 1 — bd resume completion hook (Layer 3 MECHANICAL).** `scripts/slack_relay.py` main() now fires `_maybe_self_assign(message)` after `post()` success. If the message contains `[READY:<my-callsign>]` (case-insensitive against the agent's CALLSIGN), spawn `bd ready --json` → claim first unblocked via `bd update <id> --claim`. Best-effort: subprocess timeouts + missing-binary log + return; never blocks. Polling loop is the safety net.

**Outcome 2 — Polling hole A.** `scripts/orchestrator/elliot_polling_loop.py`:
- New `INBOX_PATHS` map: atlas/orion/scout → `/tmp/telegram-relay-<cs>/inbox/`
- `compose_dispatches()` routes clone callsigns to `inbox:<cs>` target, primes stay on `#execution`
- `send_dispatch()` new branch: `inbox:<cs>` → write JSON file via `_write_inbox_dispatch`; Slack relay path preserved for channels
- Direct inbox write — doesn't depend on central-listener Slack fan-out uptime

**Outcome 3 — 60s cadence preserved.** No timer changes per Dave's explicit "no 15s cadence".

## Test plan

- [x] 26 tests pass (was 22; +4 for clone inbox dispatch paths)
- [x] Ruff check + format clean
- [x] Self-assign hook import smoke OK
- [ ] CI green
- [ ] Dual-CTO concur (Aiden author + Max reviewer)
- [ ] Empirical first-fire: next live `[READY:aiden]` post should print `[self-assign] claimed <id>` to stderr (or one of the documented failure-path messages)
- [ ] LAW XV save (bundled with Wave 2 + KEI-12 cleanup-bak per Elliot's rolling-bundle pattern)

## Verbatim verification

```
$ /home/elliotbot/clawd/venv/bin/python3 -m pytest tests/scripts/test_elliot_polling_loop.py -v
collected 26 items
...
test_compose_dispatches_clone_targets_inbox_not_execution PASSED
test_send_dispatch_inbox_writes_json_file PASSED
test_send_dispatch_inbox_missing_dir_drops_quietly PASSED
test_send_dispatch_unknown_inbox_callsign_drops PASSED
============================== 26 passed in 0.48s ===============================

$ /home/elliotbot/.local/bin/ruff check scripts/orchestrator/elliot_polling_loop.py scripts/slack_relay.py tests/scripts/test_elliot_polling_loop.py
All checks passed!

$ /home/elliotbot/clawd/venv/bin/python3 -c "from scripts.slack_relay import _maybe_self_assign; print('imported OK')"
imported OK
```

## Self-assign hook behavior table

| Condition | Action |
|---|---|
| Message doesn't contain `[READY:<my-callsign>]` | No-op (return immediately) |
| `bd` binary not on PATH | Log + return |
| `bd ready --json` exit non-zero | Log + return |
| `bd ready --json` returns empty | Log "nothing to claim" + return |
| `bd update <id> --claim` succeeds | Print `[self-assign] claimed <id>` + return |
| `bd update <id> --claim` fails (race) | Log + return (polling loop picks up later) |

## Polling-loop dispatch routing

| Idle callsign | Target | Why |
|---|---|---|
| `aiden` / `max` | `#execution` channel | primes — human-visible dispatch in Slack |
| `atlas` / `orion` / `scout` | `inbox:<cs>` → JSON file in `/tmp/telegram-relay-<cs>/inbox/` | direct inbox-watcher injection, no Slack fan-out dependency |

🤖 Generated with [Claude Code](https://claude.com/claude-code)