### PR TITLE
[AIDEN] feat(observability): Better Stack heartbeats setup + polling-loop wire-in (PR-A of 4)

### DIFF
--- a/scripts/orchestrator/betterstack_setup.py
+++ b/scripts/orchestrator/betterstack_setup.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""betterstack_setup.py — KEI Better Stack heartbeats + groups bootstrap.
+
+Per Dave directive ts ~1778588500 + Elliot dispatch. One-shot operator script
+that creates the 5 heartbeat monitors + 2 groups via Better Stack API.
+
+Usage:
+    BETTERSTACK_API_KEY=<key> python3 scripts/orchestrator/betterstack_setup.py
+    # → prints heartbeat tokens + URLs as KEY=VALUE lines for .env append.
+
+After running this once, operator appends the printed lines to
+/home/elliotbot/.config/agency-os/.env, then wires `curl -m 5 <url>` as the
+LAST line of each scheduled process script:
+
+  - elliot-polling-loop.py (per-cycle end)              → BETTERSTACK_HB_ELLIOT_POLLING_LOOP
+  - cognee_ingest.py (per-batch end)                    → BETTERSTACK_HB_COGNEE_PHASE1_INGEST
+  - prefect orchestrator flow (per-flow end)            → BETTERSTACK_HB_PREFECT_PIPELINE
+  - slack_bot/central_listener.py (per-loop iter end)   → BETTERSTACK_HB_CENTRAL_LISTENER
+  - agency-os-discovery pipeline (per-stage end)        → BETTERSTACK_HB_AGENCY_OS_DISCOVERY
+
+API: https://uptime.betterstack.com/api/v2/heartbeats (Bearer auth).
+
+Idempotent: if a heartbeat with the same name exists, skip creation +
+print existing token. Re-run is safe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+API_BASE = "https://uptime.betterstack.com/api/v2"
+
+# Heartbeat name → (period_sec, grace_sec, group_name) per Elliot dispatch.
+HEARTBEATS: list[tuple[str, int, int, str]] = [
+    ("elliot-polling-loop", 60, 90, "Keiracom Agent Team"),
+    ("cognee-phase1-ingest", 600, 300, "Keiracom Agent Team"),
+    ("prefect-pipeline", 600, 300, "Keiracom Agent Team"),
+    ("central-listener", 300, 120, "Keiracom Agent Team"),
+    ("agency-os-discovery", 1800, 600, "Agency OS Pipeline"),
+]
+
+GROUP_NAMES: tuple[str, ...] = ("Keiracom Agent Team", "Agency OS Pipeline")
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+
+def _request(method: str, url: str, api_key: str, body: dict | None = None) -> dict | None:
+    """Best-effort Better Stack API call. Returns parsed JSON or None on error."""
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(url, data=data, headers=_auth_headers(api_key), method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return json.loads(r.read() or "null")
+    except urllib.error.HTTPError as exc:
+        # 422 on duplicate-name is expected (idempotent path); other 4xx/5xx are errors.
+        body_text = exc.read().decode(errors="replace") if exc.fp else ""
+        print(f"[bs] HTTP {exc.code} on {method} {url}: {body_text[:200]}", file=sys.stderr)
+        return None
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+        print(f"[bs] network/parse error on {method} {url}: {exc}", file=sys.stderr)
+        return None
+
+
+def list_heartbeats(api_key: str) -> list[dict]:
+    """Return all existing heartbeats (paginated, single page assumed sufficient)."""
+    resp = _request("GET", f"{API_BASE}/heartbeats?per_page=100", api_key)
+    if not resp:
+        return []
+    return resp.get("data", []) or []
+
+
+def list_heartbeat_groups(api_key: str) -> list[dict]:
+    resp = _request("GET", f"{API_BASE}/heartbeat-groups?per_page=100", api_key)
+    if not resp:
+        return []
+    return resp.get("data", []) or []
+
+
+def ensure_group(api_key: str, name: str, existing: list[dict]) -> str | None:
+    """Return group_id; create if absent. None on failure."""
+    for g in existing:
+        if g.get("attributes", {}).get("name") == name:
+            return str(g.get("id"))
+    resp = _request("POST", f"{API_BASE}/heartbeat-groups", api_key, {"name": name})
+    if not resp:
+        return None
+    return str(resp.get("data", {}).get("id"))
+
+
+def ensure_heartbeat(
+    api_key: str,
+    name: str,
+    period_sec: int,
+    grace_sec: int,
+    group_id: str | None,
+    existing: list[dict],
+) -> dict | None:
+    """Return the heartbeat record (existing or newly created)."""
+    for hb in existing:
+        if hb.get("attributes", {}).get("name") == name:
+            return hb
+    body: dict[str, Any] = {
+        "name": name,
+        "period": period_sec,
+        "grace": grace_sec,
+    }
+    if group_id:
+        body["heartbeat_group_id"] = group_id
+    resp = _request("POST", f"{API_BASE}/heartbeats", api_key, body)
+    if not resp:
+        return None
+    return resp.get("data")
+
+
+def main() -> int:
+    api_key = os.environ.get("BETTERSTACK_API_KEY", "").strip()
+    if not api_key:
+        print("ERROR: BETTERSTACK_API_KEY env not set", file=sys.stderr)
+        return 2
+
+    print("# Better Stack heartbeats — paste into .env", file=sys.stderr)
+    print("# Source: scripts/orchestrator/betterstack_setup.py")
+    print("# Generated: $(date -u)")
+    print("")
+
+    existing_groups = list_heartbeat_groups(api_key)
+    existing_hbs = list_heartbeats(api_key)
+
+    group_ids: dict[str, str | None] = {}
+    for gname in GROUP_NAMES:
+        gid = ensure_group(api_key, gname, existing_groups)
+        group_ids[gname] = gid
+        print(f"# group: {gname} → id={gid}", file=sys.stderr)
+
+    for name, period, grace, group_name in HEARTBEATS:
+        hb = ensure_heartbeat(api_key, name, period, grace, group_ids.get(group_name), existing_hbs)
+        if not hb:
+            print(f"# {name}: CREATE FAILED — review stderr", file=sys.stderr)
+            continue
+        attrs = hb.get("attributes", {})
+        url = attrs.get("url") or ""
+        env_key = "BETTERSTACK_HB_" + name.upper().replace("-", "_")
+        print(f"{env_key}={url}")
+
+    print("", file=sys.stderr)
+    print(
+        "# Append the KEY=VALUE lines above to /home/elliotbot/.config/agency-os/.env",
+        file=sys.stderr,
+    )
+    print(
+        '# Then wire `curl -fsS -m 5 "$BETTERSTACK_HB_<NAME>" >/dev/null 2>&1 || true`',
+        file=sys.stderr,
+    )
+    print("# as the LAST line of each scheduled process script.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -371,9 +371,30 @@ def run_cycle(now: datetime | None = None) -> int:
     return len(dispatches)
 
 
+def _heartbeat() -> None:
+    """Better Stack heartbeat ping (Dave directive ts ~1778588500). Sent as the
+    LAST step of each cycle so the monitor only ticks on a clean cycle.
+    Best-effort: no key set → skip; subprocess failure → log + drop.
+    """
+    url = os.environ.get("BETTERSTACK_HB_ELLIOT_POLLING_LOOP", "")
+    if not url:
+        return
+    try:
+        subprocess.run(
+            ["curl", "-fsS", "-m", "5", url],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("betterstack heartbeat failed: %s", exc)
+
+
 def main() -> int:
     sent = run_cycle()
     logger.info("cycle complete — %d dispatch(es) sent", sent)
+    _heartbeat()
     return 0
 
 


### PR DESCRIPTION
## Summary

Per Dave directive ts ~1778588500 + Elliot dispatch. PR-A of 4 (Better Stack wiring split by Outcome):
- **PR-A (this PR)** — Outcome 1: heartbeat setup + polling-loop wire-in
- PR-B (follow-up) — Outcome 2: uptime HTTP monitors
- PR-C (follow-up) — Outcome 4: Slack alert routing
- PR-D (follow-up) — Outcome 5: public status page

Outcome 3 (MCP install) owned by Atlas — not in this PR.

## Files

- `scripts/orchestrator/betterstack_setup.py` (+170 LoC) — bootstrap API client; idempotent; outputs KEY=VALUE for .env append
- `scripts/orchestrator/elliot_polling_loop.py` (+18 LoC) — `_heartbeat()` called at end of `main()`; curl-pings if `BETTERSTACK_HB_ELLIOT_POLLING_LOOP` env set

## Heartbeat spec (per dispatch)

| Name | Period | Grace | Group |
|---|---|---|---|
| elliot-polling-loop | 60s | 90s | Keiracom Agent Team |
| cognee-phase1-ingest | 600s | 300s | Keiracom Agent Team |
| prefect-pipeline | 600s | 300s | Keiracom Agent Team |
| central-listener | 300s | 120s | Keiracom Agent Team |
| agency-os-discovery | 1800s | 600s | Agency OS Pipeline |

## Operator workflow post-merge

```bash
BETTERSTACK_API_KEY=<key> python3 scripts/orchestrator/betterstack_setup.py >> /tmp/bs.env
# Review /tmp/bs.env (one KEY=VALUE line per heartbeat) → manually append to .env
systemctl --user restart elliot-polling-loop.timer
# First cycle (60s later) will ping the heartbeat
```

Other 4 wire-ins (cognee_ingest / prefect / central-listener / discovery) are per-script edits; follow-up PRs by their respective script owners can add `curl -fsS -m 5 "$BETTERSTACK_HB_<NAME>" >/dev/null 2>&1 || true` as the LAST line of each.

## GOV-9 deferred (carried forward from Step 0)

- B: Vultr health endpoint research → PR-B
- C: Cognee external-monitor strategy (lean toward host-side polling script vs firewall opening) → PR-B
- A: MCP install → Atlas Outcome 3

## Test plan

- [x] Lint + format clean (Ruff)
- [x] Smoke: no-API-key error path returns exit 2 with stderr message
- [x] No regression: 26 existing polling-loop tests still pass
- [ ] CI green
- [ ] Dual-CTO concur (Aiden author + Max reviewer)
- [ ] LAW XV save (bundled with PR-B/C/D completion — ceo_memory + cis_directive_metrics, no Drive mirror per directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)