### PR TITLE
[MAX] feat(cognee): Better Stack heartbeat ping at end of cognee_ingest main()

### DIFF
--- a/scripts/cognee_ingest.py
+++ b/scripts/cognee_ingest.py
@@ -41,6 +41,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
+import subprocess
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -300,7 +302,35 @@ def main(argv: list[str] | None = None) -> int:
         )
     )
     logger.info("done: %d ok / %d failed", ok, fail)
+    # Better Stack heartbeat (GOV-9 C resolution from PR-B #786): cognee
+    # service runs on localhost so external HTTP monitoring isn't viable;
+    # we observe successful ingest runs via heartbeat instead. Skip on
+    # dry-run + on any failure so the monitor only ticks on clean success.
+    if not args.dry_run and fail == 0 and ok > 0:
+        _heartbeat()
     return 0 if fail == 0 else 1
+
+
+def _heartbeat() -> None:
+    """Better Stack heartbeat ping — best-effort, env-var-gated.
+
+    Sent as the LAST step of main() on clean success only (no dry-run, no
+    failures). Mirrors the pattern in elliot_polling_loop.py::_heartbeat.
+    Missing env → skip; subprocess failure → log + drop. Never raises.
+    """
+    url = os.environ.get("BETTERSTACK_HB_COGNEE_PHASE1_INGEST", "")
+    if not url:
+        return
+    try:
+        subprocess.run(
+            ["curl", "-fsS", "-m", "5", url],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.warning("BetterStack heartbeat ping failed: %s", exc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the GOV-9 C resolution Aiden flagged on PR-B #786: cognee.service runs on localhost so external HTTP monitoring isn't viable. Heartbeat-based monitoring of the actual ingest run is the answer per Better Stack PR-A foundation (PR #785).

## Changes

1 file, +30 LOC, 0 deletions.

- `scripts/cognee_ingest.py`: new `_heartbeat()` mirroring `elliot_polling_loop.py::_heartbeat`. Env-var-gated (`BETTERSTACK_HB_COGNEE_PHASE1_INGEST`), curl -fsS -m 5, best-effort, never raises.
- Call sited at END of `main()` AFTER ingest completion, gated on clean success: skip on `--dry-run`, skip on `fail>0`, skip on `ok=0`. Monitor only ticks on a real-data clean ingest run.

## Verification (Rule 6)

```
$ grep BETTERSTACK_HB scripts/cognee_ingest.py
url = os.environ.get("BETTERSTACK_HB_COGNEE_PHASE1_INGEST", "")

$ pytest tests/scripts/test_cognee_ingest.py
19 passed in 0.26s

$ ruff check scripts/cognee_ingest.py
All checks passed!

$ python3 scripts/cognee_ingest.py --dry-run | tail -1
INFO: done: 300 ok / 0 failed   (heartbeat skipped per dry-run guard)
```

## Test plan

- [x] 19 unit tests still pass (behavior additive + env-gated)
- [x] Dry-run skips heartbeat (verified)
- [x] Ruff + format clean
- [ ] CI green
- [ ] Dual-CTO concur (Aiden + Elliot)
- [ ] Operator appends `BETTERSTACK_HB_COGNEE_PHASE1_INGEST=<url>` to `.env` post-merge (URL provisioned by PR-A bootstrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)