### PR TITLE
[AIDEN] feat(hooks): Stop-hook auto-[READY:<callsign>] marker emit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -127,12 +127,17 @@
       {
         "hooks": [
           {
-            "command": "cd /home/elliotbot/clawd/Agency_OS \u0026\u0026 PYTHONPATH=/home/elliotbot/clawd/Agency_OS /home/elliotbot/clawd/venv/bin/python3 scripts/governance_router.py",
+            "command": "cd /home/elliotbot/clawd/Agency_OS && PYTHONPATH=/home/elliotbot/clawd/Agency_OS /home/elliotbot/clawd/venv/bin/python3 scripts/governance_router.py",
             "timeout": 10,
             "type": "command"
           },
           {
             "command": "bash /home/elliotbot/clawd/Agency_OS/.claude/hooks/stop_relay_hook.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "bash /home/elliotbot/clawd/Agency_OS/scripts/hooks/emit_ready_marker.sh",
             "timeout": 5,
             "type": "command"
           },

--- a/scripts/hooks/emit_ready_marker.sh
+++ b/scripts/hooks/emit_ready_marker.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Stop-hook companion: auto-emit [READY:<callsign>] marker if the agent's final
+# response did not already include one. Mechanical replacement for the
+# discipline-dependent "agent remembers to type [READY:<callsign>]" pattern.
+#
+# Layer-3-at-conversation-end fix per Dave directive ts ~1778589925 + Scout
+# design at docs/wave2/stop_hook_design.md (commit 6b4e6904).
+#
+# Ordering: registered in .claude/settings.json AFTER governance_router.py
+# (which consumes stdin and saves to /tmp/.stop_event_payload.json) AND AFTER
+# stop_relay_hook.sh (same temp-file fallback consumer). Read order MUST come
+# after both — this script uses the same fallback path.
+#
+# Fail-open everywhere: exit 0 on every path. Relay failure must never block
+# the assistant turn from ending.
+
+set -u
+
+# 1. Resolve callsign — CALLSIGN env preferred; IDENTITY.md fallback.
+CALLSIGN="${CALLSIGN:-}"
+if [[ -z "$CALLSIGN" && -r ./IDENTITY.md ]]; then
+    CALLSIGN="$(grep -m1 -oE '\*\*CALLSIGN:\*\* [A-Za-z]+' ./IDENTITY.md 2>/dev/null \
+        | awk '{print $NF}' | tr '[:upper:]' '[:lower:]')"
+fi
+CALLSIGN="${CALLSIGN:-unknown}"
+
+# 2. Skip sub-agents — parent surfaces results; double-emit otherwise.
+if [[ -n "${CLAUDE_AGENT_ID:-}" ]]; then
+    exit 0
+fi
+
+# 3. Read Stop payload — stdin first; fallback to temp-file written by
+#    governance_router.py upstream in the Stop chain. Path is overridable via
+#    STOP_EVENT_PAYLOAD_TEMP_PATH (tests use this; prod defaults to the
+#    canonical /tmp path that governance_router writes).
+TEMP_PATH="${STOP_EVENT_PAYLOAD_TEMP_PATH:-/tmp/.stop_event_payload.json}"  # NOSONAR — canonical Stop-hook payload location set by upstream governance_router.py, not user-supplied
+PAYLOAD="$(cat 2>/dev/null || true)"
+if [[ -z "$PAYLOAD" && -f "$TEMP_PATH" ]]; then
+    PAYLOAD="$(cat "$TEMP_PATH" 2>/dev/null || true)"
+fi
+[[ -z "$PAYLOAD" ]] && exit 0
+
+# 4. Extract final assistant response body. Keys discovered empirically per
+#    stop_relay_hook.sh:43-50 — not in public Claude Code docs.
+BODY=""
+if command -v jq >/dev/null 2>&1; then
+    BODY="$(printf '%s' "$PAYLOAD" | jq -r \
+        '.last_assistant_message // .message.content // .response // .text // ""' \
+        2>/dev/null || true)"
+fi
+
+# 5. De-dup — if body already contains [READY:<callsign>] (case-insensitive)
+#    OR with bracketed callsign prefix, skip emit.
+SHOUTY="$(echo "$CALLSIGN" | tr '[:lower:]' '[:upper:]')"
+if echo "$BODY" | grep -qi -E "\[READY:(${CALLSIGN}|${SHOUTY})\]"; then
+    exit 0
+fi
+
+# 6. Emit via slack relay. Fail-open: || true swallows any error.
+if command -v tg >/dev/null 2>&1; then
+    tg "[READY:${CALLSIGN}]" >/dev/null 2>&1 || true
+else
+    /home/elliotbot/clawd/venv/bin/python3 \
+        /home/elliotbot/clawd/Agency_OS/scripts/slack_relay.py \
+        -g "[READY:${CALLSIGN}]" >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/tests/hooks/test_emit_ready_marker.py
+++ b/tests/hooks/test_emit_ready_marker.py
@@ -1,0 +1,129 @@
+"""Tests for scripts/hooks/emit_ready_marker.sh (Stop-hook auto-[READY:] marker).
+
+Verifies the five behaviours Scout's design at docs/wave2/stop_hook_design.md
+calls out as must-pass:
+
+  1. Empty / missing payload -> exit 0, no emit (fail-open).
+  2. Body already contains [READY:<callsign>] -> skip emit (de-dup).
+  3. Body missing [READY:<callsign>] -> emit fires.
+  4. Sub-agent (CLAUDE_AGENT_ID set) -> skip emit.
+  5. Tg-cli unavailable -> exit 0 cleanly (fail-open).
+
+Each test spawns the hook script in a subprocess with a stubbed PATH so the
+'tg' / slack_relay invocation is observable but does not actually hit Slack.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / "scripts" / "hooks" / "emit_ready_marker.sh"
+
+
+def _run_hook(
+    payload: str | None,
+    callsign: str = "aiden",
+    agent_id: str | None = None,
+    tg_available: bool = True,
+    tmp_path: Path | None = None,
+) -> tuple[int, str, str]:
+    """Run the hook with a fake tg shim. Return (exit, stdout, tg_log)."""
+    assert tmp_path is not None
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    tg_log = tmp_path / "tg_invocations.log"
+
+    if tg_available:
+        tg_shim = shim_dir / "tg"
+        tg_shim.write_text(f'#!/usr/bin/env bash\necho "$@" >> "{tg_log}"\nexit 0\n')
+        tg_shim.chmod(0o755)
+
+    env = os.environ.copy()
+    env["CALLSIGN"] = callsign
+    env["PATH"] = f"{shim_dir}:/usr/bin:/bin"
+    # Isolate from any real /tmp/.stop_event_payload.json on the host so tests
+    # don't see leaked state from prior Stop events.
+    env["STOP_EVENT_PAYLOAD_TEMP_PATH"] = str(tmp_path / "stop_payload.json")
+    if agent_id:
+        env["CLAUDE_AGENT_ID"] = agent_id
+    else:
+        env.pop("CLAUDE_AGENT_ID", None)
+
+    proc = subprocess.run(  # noqa: S603 — controlled args, no shell
+        ["/bin/bash", str(HOOK)],
+        input=payload if payload is not None else "",
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    log_contents = tg_log.read_text() if tg_log.exists() else ""
+    return proc.returncode, proc.stdout, log_contents
+
+
+def test_empty_payload_fail_open(tmp_path: Path) -> None:
+    rc, _stdout, tg_log = _run_hook("", tmp_path=tmp_path)
+    assert rc == 0
+    assert tg_log == ""
+
+
+def test_body_already_has_ready_marker_skips_emit(tmp_path: Path) -> None:
+    payload = json.dumps(
+        {"last_assistant_message": "Standing.\n\n[READY:aiden]"}
+    )
+    rc, _stdout, tg_log = _run_hook(payload, tmp_path=tmp_path)
+    assert rc == 0
+    assert tg_log == ""
+
+
+def test_body_missing_marker_emits(tmp_path: Path) -> None:
+    payload = json.dumps(
+        {"last_assistant_message": "Holding for confirm — no marker here."}
+    )
+    rc, _stdout, tg_log = _run_hook(payload, tmp_path=tmp_path)
+    assert rc == 0
+    assert "[READY:aiden]" in tg_log
+
+
+def test_subagent_skips_emit(tmp_path: Path) -> None:
+    payload = json.dumps({"last_assistant_message": "Done. No marker."})
+    rc, _stdout, tg_log = _run_hook(
+        payload, agent_id="sub_abc123", tmp_path=tmp_path
+    )
+    assert rc == 0
+    assert tg_log == ""
+
+
+def test_tg_missing_fail_open(tmp_path: Path) -> None:
+    payload = json.dumps({"last_assistant_message": "Body without marker."})
+    rc, _stdout, _tg_log = _run_hook(
+        payload, tg_available=False, tmp_path=tmp_path
+    )
+    assert rc == 0
+
+
+def test_case_insensitive_dedup(tmp_path: Path) -> None:
+    payload = json.dumps({"last_assistant_message": "Wrap. [READY:AIDEN]"})
+    rc, _stdout, tg_log = _run_hook(payload, tmp_path=tmp_path)
+    assert rc == 0
+    assert tg_log == ""
+
+
+def test_alt_body_key_message_content(tmp_path: Path) -> None:
+    payload = json.dumps(
+        {"message": {"content": "Reply via alt key. [READY:aiden]"}}
+    )
+    rc, _stdout, tg_log = _run_hook(payload, tmp_path=tmp_path)
+    assert rc == 0
+    assert tg_log == ""
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Mechanical Layer-3 fix for the agent-forgot-to-emit-[READY:] failure mode Dave flagged. Hook fires on every Claude Code Stop event, de-dups against the agent's own response body, and emits `[READY:<callsign>]` if the agent forgot. Combined with existing layers:

- **Layer 3 — outbound interception:** `_maybe_self_assign` in `scripts/slack_relay.py` (already shipped #783).
- **Layer 2 — polling sweep:** `scripts/orchestrator/elliot_polling_loop.py` (KEI-17, shipped).
- **Layer 3 — turn-end:** `scripts/hooks/emit_ready_marker.sh` (this PR).

Agent only stalls if all three fail.

## Source

Built per Scout's design at `docs/wave2/stop_hook_design.md` (commit `6b4e6904` in `scout/cognee-internals-research`). Scout updated the doc post-flag to reflect Option (B) canonical path (commit `226728f4`).

## Deviation from Scout's original spec

Scout originally specified `.claude/hooks/emit_ready_marker.sh`. Flagged before building because, post-KEI-12, that path resolves through a symlink to `/home/elliotbot/.config/agency-os/hooks/` (per-machine config, outside the repo) — repo-tracked file at that path would be masked at runtime.

**Concurred by Max + Elliot + Scout: Option (B) — repo-tracked at `scripts/hooks/emit_ready_marker.sh`, referenced from settings.json by absolute path.** Matches the `governance_router.py` convention. Atomic + reviewable + version-controlled.

## Stop hook chain (after this PR)

| # | Hook | Reads | Action |
|---|------|-------|--------|
| 1 | `governance_router.py` | stdin | writes `/tmp/.stop_event_payload.json` |
| 2 | `stop_relay_hook.sh` | temp-file fallback | governance relay |
| 3 | **`emit_ready_marker.sh`** | temp-file fallback | **de-dup + emit `[READY:]` if missing** |
| 4 | `session_store_stop.sh` | n/a | closes session DB |

## Behaviour (7 pytest tests, all pass locally)

- Empty/missing payload → exit 0, no emit (fail-open)
- Body already contains `[READY:<callsign>]` (case-insensitive) → skip
- Body missing marker → emit via `tg` CLI (or `scripts/slack_relay.py` fallback)
- Sub-agent turn (`CLAUDE_AGENT_ID` set) → skip (parent surfaces results)
- `tg` unavailable → still exit 0
- Alt body keys `.message.content` / `.response` / `.text` → handled
- Case-insensitive de-dup (`[READY:AIDEN]` blocks emit too)

## Test isolation

`STOP_EVENT_PAYLOAD_TEMP_PATH` env var overrides the canonical `/tmp/.stop_event_payload.json` path so pytest doesn't see leaked state from real prior Stop events. Prod uses default.

```
$ python3 -m pytest tests/hooks/test_emit_ready_marker.py -v
============================== 7 passed in 1.05s ===============================
```

## Wire-up

`.claude/settings.json` gets ONE new entry in the Stop array (position 2: after stop_relay_hook.sh, before session_store_stop.sh — same temp-file consumer pattern). Other worktrees adopt by merging main + getting the same entry. Per Elliot's post-merge plan, he updates each worktree's settings.json + restarts slack listeners if needed.

## NOSONAR justification

`/tmp/.stop_event_payload.json` read is from the canonical Stop-hook payload location set by upstream `governance_router.py`, not user-supplied. Same suppression pattern accepted by SonarCloud on Orion's PR #776/#777.

## LAW XVI flag (separate, not blocking)

Aiden worktree shows 21 dirty deletions on `.claude/hooks/*` and `.claude/modules/*` from the KEI-12 symlink swap (PR #779 operator script). Not staged here. Follow-up: ~20 LOC Aiden-worktree-alignment PR per Elliot's option (a) call.

## Test plan

- [x] `bash -n` syntax check on hook script
- [x] `pytest tests/hooks/test_emit_ready_marker.py -v` — 7/7 pass
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Post-merge empirical: next agent turn-end produces `[READY:<callsign>]` without the agent body containing it (Elliot verifies via tmux pane capture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)