### PR TITLE
[ORION] feat(orchestrator): install_systemd_units.sh — Agency_OS-34s

### DIFF
--- a/scripts/orchestrator/install_systemd_units.sh
+++ b/scripts/orchestrator/install_systemd_units.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# install_systemd_units.sh — idempotent post-merge installer for repo systemd units.
+#
+# Closes Beads Agency_OS-34s. Pattern A class problem: PRs shipping new .service
+# / .timer files into the repo (e.g. PR #774 polling timer, PR #784 cleanup
+# timer, PR #776 + #777 alerters from this session) need a manual
+#   cp + systemctl --user daemon-reload + enable --now
+# on the host. Easy to forget — PR #774's timer silently didn't run for a
+# stretch until Dave noticed. This installer enumerates repo unit files,
+# diffs them against the host install dir, copies new/changed files,
+# daemon-reloads, and enables+starts NEW .timer files. Idempotent: re-runs
+# on an unchanged repo do nothing and exit 0.
+#
+# Scope decisions:
+#   - Enable+start applies to .timer files only. Companion .service files
+#     are pulled in by the timer's [Install] WantedBy=timers.target.
+#   - Standalone .service files (no companion .timer, e.g. relay-watchers
+#     or daemons) are INSTALLED but NOT auto-enabled — operator decides
+#     when to start a long-running daemon.
+#   - Units already on the host but REMOVED from the repo are LEFT ALONE.
+#     Removal is an explicit operator decision, not an automated sweep.
+#   - Dave-directed activation preserved: this script is invoked manually
+#     by an operator (no GH Action auto-run). Running it equals operator
+#     intent to activate everything in the repo.
+#
+# Usage:
+#   scripts/orchestrator/install_systemd_units.sh            # real install
+#   scripts/orchestrator/install_systemd_units.sh --dry-run  # report only
+#
+# Env overrides (testing + non-default hosts):
+#   AGENCY_OS_SYSTEMD_SOURCE_DIRS  — colon-separated list of source dirs
+#                                    (default: infra/alerts:infra/cron:infra/opa:systemd)
+#   AGENCY_OS_SYSTEMD_INSTALL_DIR  — host install dir (default ~/.config/systemd/user)
+#   AGENCY_OS_SYSTEMCTL            — systemctl binary path (default 'systemctl')
+#   AGENCY_OS_SYSTEMCTL_SKIP       — if set, skip every systemctl invocation
+#                                    (unit tests use this so they don't touch the
+#                                    real user systemd instance)
+#
+# Exit codes: 0 on success or clean no-op; 1 on copy/systemctl failure; 2 on
+# bad arguments.
+
+set -euo pipefail
+
+# ─── Args ──────────────────────────────────────────────────────────────
+DRY_RUN=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        -h | --help)
+            sed -n '2,40p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "error: unknown arg: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ─── Config ────────────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEFAULT_SOURCE_DIRS="infra/alerts:infra/cron:infra/opa:systemd"
+SOURCE_DIRS="${AGENCY_OS_SYSTEMD_SOURCE_DIRS:-$DEFAULT_SOURCE_DIRS}"
+INSTALL_DIR="${AGENCY_OS_SYSTEMD_INSTALL_DIR:-$HOME/.config/systemd/user}"
+SYSTEMCTL_BIN="${AGENCY_OS_SYSTEMCTL:-systemctl}"
+
+# ─── Helpers ───────────────────────────────────────────────────────────
+log() { printf '%s\n' "$*"; }
+note() { printf '[install_systemd_units] %s\n' "$*"; }
+
+run_systemctl() {
+    # Wraps systemctl --user so unit tests can short-circuit via env.
+    if [ -n "${AGENCY_OS_SYSTEMCTL_SKIP:-}" ]; then
+        note "(skipped) systemctl --user $*"
+        return 0
+    fi
+    "$SYSTEMCTL_BIN" --user "$@"
+}
+
+file_hash() { sha256sum "$1" 2>/dev/null | awk '{print $1}'; }
+
+# Returns "new" / "changed" / "unchanged" for a source unit file.
+classify_unit() {
+    local src="$1" dest="$2"
+    if [ ! -f "$dest" ]; then
+        echo "new"
+        return
+    fi
+    local sh dh
+    sh="$(file_hash "$src")"
+    dh="$(file_hash "$dest")"
+    if [ "$sh" = "$dh" ]; then
+        echo "unchanged"
+    else
+        echo "changed"
+    fi
+}
+
+# ─── Discover source units ─────────────────────────────────────────────
+declare -a SOURCE_UNITS=()
+IFS=':' read -r -a SRC_ARR <<<"$SOURCE_DIRS"
+for sd in "${SRC_ARR[@]}"; do
+    abs="$REPO_ROOT/$sd"
+    [ -d "$abs" ] || continue
+    while IFS= read -r -d '' f; do
+        SOURCE_UNITS+=("$f")
+    done < <(find "$abs" -maxdepth 1 -type f \( -name '*.service' -o -name '*.timer' \) -print0 2>/dev/null)
+done
+
+if [ "${#SOURCE_UNITS[@]}" -eq 0 ]; then
+    note "no source unit files found under: $SOURCE_DIRS"
+    exit 0
+fi
+
+# ─── Plan ──────────────────────────────────────────────────────────────
+declare -a NEW_FILES=()
+declare -a CHANGED_FILES=()
+declare -a NEW_TIMERS=()
+mkdir -p "$INSTALL_DIR"
+
+for src in "${SOURCE_UNITS[@]}"; do
+    name="$(basename "$src")"
+    dest="$INSTALL_DIR/$name"
+    cls="$(classify_unit "$src" "$dest")"
+    case "$cls" in
+        new)
+            NEW_FILES+=("$src")
+            [[ "$name" == *.timer ]] && NEW_TIMERS+=("$name")
+            ;;
+        changed)
+            CHANGED_FILES+=("$src")
+            ;;
+        unchanged) : ;;
+    esac
+done
+
+new_count=${#NEW_FILES[@]}
+chg_count=${#CHANGED_FILES[@]}
+total=$((new_count + chg_count))
+
+if [ "$total" -eq 0 ]; then
+    note "no-op — all ${#SOURCE_UNITS[@]} source unit(s) already match host. exit 0."
+    exit 0
+fi
+
+note "plan: ${new_count} new, ${chg_count} changed, ${#NEW_TIMERS[@]} timer(s) to enable+start"
+for f in "${NEW_FILES[@]}"; do note "  NEW     $(basename "$f")"; done
+for f in "${CHANGED_FILES[@]}"; do note "  CHANGED $(basename "$f")"; done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    note "--dry-run set — no files copied, no systemctl invoked. exit 0."
+    exit 0
+fi
+
+# ─── Apply ─────────────────────────────────────────────────────────────
+for src in "${NEW_FILES[@]}" "${CHANGED_FILES[@]}"; do
+    name="$(basename "$src")"
+    cp -f "$src" "$INSTALL_DIR/$name"
+    note "  copied $name"
+done
+
+note "running daemon-reload"
+run_systemctl daemon-reload
+
+for t in "${NEW_TIMERS[@]}"; do
+    note "  enable --now $t"
+    run_systemctl enable --now "$t"
+done
+
+note "done — installed $total file(s); enabled ${#NEW_TIMERS[@]} new timer(s). exit 0."
+exit 0

--- a/tests/orchestrator/test_install_systemd_units.py
+++ b/tests/orchestrator/test_install_systemd_units.py
@@ -1,0 +1,258 @@
+"""Tests for scripts/orchestrator/install_systemd_units.sh — Agency_OS-34s.
+
+Mocks systemd entirely via env overrides (AGENCY_OS_SYSTEMD_INSTALL_DIR points
+to a tmp dir; AGENCY_OS_SYSTEMCTL_SKIP=1 short-circuits systemctl calls).
+No real user systemd touched.
+
+Covers:
+  - new unit: source file present, host missing → install + (timer) enable
+  - changed unit: source differs from host → re-install
+  - removed-from-source: file gone from repo, still on host → LEFT ALONE
+  - no-op: source == host → exit 0, no copies
+  - dry-run mode: plan logged, no copies, no systemctl
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "install_systemd_units.sh"
+
+
+def _make_source_dir(tmp_path: Path) -> Path:
+    """Create an ephemeral repo-like source dir under tmp_path/src/alerts."""
+    d = tmp_path / "src" / "alerts"
+    d.mkdir(parents=True)
+    return d
+
+
+def _make_install_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "install" / "user"
+    d.mkdir(parents=True)
+    return d
+
+
+def _run_installer(
+    *,
+    source_dirs: list[Path],
+    install_dir: Path,
+    args: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    # Resolve relative-to-repo expansion via AGENCY_OS_SYSTEMD_SOURCE_DIRS — but
+    # since the installer joins against REPO_ROOT, we point it at an absolute
+    # path by setting REPO_ROOT-equivalent indirectly: the script computes
+    # REPO_ROOT from its own __file__ location. Easier: feed absolute source
+    # dirs via env (the script's `$abs="$REPO_ROOT/$sd"` resolves against
+    # REPO_ROOT, so we need relative paths). Use a symlink trick: create a
+    # subdir under the real repo path? No — much simpler: invoke a copy of
+    # the script from inside tmp_path so its computed REPO_ROOT lines up.
+    env["AGENCY_OS_SYSTEMD_INSTALL_DIR"] = str(install_dir)
+    env["AGENCY_OS_SYSTEMCTL_SKIP"] = "1"
+    # Source dirs are passed as absolute paths joined to a REPO_ROOT that the
+    # script computes relative to itself; we make REPO_ROOT == tmp by copying
+    # the script under tmp/scripts/orchestrator/install_systemd_units.sh.
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *(args or [])],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _stage_script_in_tmp(tmp_path: Path) -> Path:
+    """Copy the installer into tmp_path so its computed REPO_ROOT == tmp_path."""
+    target = tmp_path / "scripts" / "orchestrator" / "install_systemd_units.sh"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(SCRIPT.read_bytes())
+    target.chmod(0o755)
+    return target
+
+
+def _run_against_tmp_repo(
+    tmp_path: Path,
+    *,
+    source_subdir: str = "infra/alerts",
+    args: list[str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Stage the installer at tmp_path/scripts/orchestrator/ and run it. Source
+    dirs default to tmp_path/<source_subdir>/; install dir to tmp_path/install/."""
+    staged = _stage_script_in_tmp(tmp_path)
+    install_dir = tmp_path / "install"
+    install_dir.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env["AGENCY_OS_SYSTEMD_SOURCE_DIRS"] = source_subdir
+    env["AGENCY_OS_SYSTEMD_INSTALL_DIR"] = str(install_dir)
+    env["AGENCY_OS_SYSTEMCTL_SKIP"] = "1"
+    return subprocess.run(
+        ["bash", str(staged), *(args or [])],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _write_unit(dir_: Path, name: str, content: str) -> Path:
+    dir_.mkdir(parents=True, exist_ok=True)
+    p = dir_ / name
+    p.write_text(content)
+    return p
+
+
+# ─── 1. New unit: install + enable timer ───────────────────────────────
+
+
+def test_new_unit_installed_and_timer_enabled(tmp_path: Path):
+    src_dir = tmp_path / "infra" / "alerts"
+    _write_unit(src_dir, "agency-os-foo.service", "[Service]\nExecStart=/bin/true\n")
+    _write_unit(src_dir, "agency-os-foo.timer", "[Timer]\nOnCalendar=hourly\n")
+
+    result = _run_against_tmp_repo(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    # Files copied to install dir
+    assert (tmp_path / "install" / "agency-os-foo.service").is_file()
+    assert (tmp_path / "install" / "agency-os-foo.timer").is_file()
+    # daemon-reload + enable invoked (via the skip-marker log line)
+    assert "(skipped) systemctl --user daemon-reload" in result.stdout
+    assert "(skipped) systemctl --user enable --now agency-os-foo.timer" in result.stdout
+    # And it must NOT enable the .service directly (timer pulls it in)
+    assert "enable --now agency-os-foo.service" not in result.stdout
+
+
+# ─── 2. Changed unit: re-install + daemon-reload ───────────────────────
+
+
+def test_changed_unit_reinstalled(tmp_path: Path):
+    src_dir = tmp_path / "infra" / "alerts"
+    src = _write_unit(src_dir, "agency-os-bar.timer", "[Timer]\nOnCalendar=hourly\n")
+
+    # Stage a DIFFERENT version already on host
+    install_dir = tmp_path / "install"
+    install_dir.mkdir(parents=True, exist_ok=True)
+    (install_dir / "agency-os-bar.timer").write_text("[Timer]\nOnCalendar=daily\n")
+
+    result = _run_against_tmp_repo(tmp_path)
+    assert result.returncode == 0, result.stderr
+
+    # Host file now matches source
+    assert (install_dir / "agency-os-bar.timer").read_text() == src.read_text()
+    # daemon-reload invoked
+    assert "(skipped) systemctl --user daemon-reload" in result.stdout
+    # CHANGED diagnostic in plan
+    assert "CHANGED agency-os-bar.timer" in result.stdout
+
+
+# ─── 3. Removed-from-source: host file left alone ──────────────────────
+
+
+def test_unit_only_on_host_is_left_alone(tmp_path: Path):
+    # Source dir EMPTY (no units shipped from repo).
+    (tmp_path / "infra" / "alerts").mkdir(parents=True)
+
+    # Host has a legacy unit.
+    install_dir = tmp_path / "install"
+    install_dir.mkdir(parents=True, exist_ok=True)
+    legacy = install_dir / "agency-os-legacy.timer"
+    legacy.write_text("[Timer]\nOnCalendar=weekly\n")
+
+    result = _run_against_tmp_repo(tmp_path)
+    assert result.returncode == 0, result.stderr
+
+    # Legacy file untouched
+    assert legacy.is_file()
+    assert legacy.read_text() == "[Timer]\nOnCalendar=weekly\n"
+    # No copy happened
+    assert "copied" not in result.stdout
+
+
+# ─── 4. No-op: source matches host ─────────────────────────────────────
+
+
+def test_noop_when_source_matches_host(tmp_path: Path):
+    src_dir = tmp_path / "infra" / "alerts"
+    content = "[Timer]\nOnCalendar=hourly\n"
+    _write_unit(src_dir, "agency-os-baz.timer", content)
+    install_dir = tmp_path / "install"
+    install_dir.mkdir(parents=True, exist_ok=True)
+    (install_dir / "agency-os-baz.timer").write_text(content)
+
+    result = _run_against_tmp_repo(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "no-op" in result.stdout
+    # No daemon-reload, no enable
+    assert "daemon-reload" not in result.stdout
+    assert "enable --now" not in result.stdout
+
+
+# ─── 5. Dry-run: plans but does not copy or invoke systemctl ───────────
+
+
+def test_dry_run_plans_but_does_not_apply(tmp_path: Path):
+    src_dir = tmp_path / "infra" / "alerts"
+    _write_unit(src_dir, "agency-os-dry.timer", "[Timer]\nOnCalendar=hourly\n")
+
+    result = _run_against_tmp_repo(tmp_path, args=["--dry-run"])
+    assert result.returncode == 0, result.stderr
+    # Plan was logged
+    assert "NEW     agency-os-dry.timer" in result.stdout
+    # Nothing was copied (host install dir is empty)
+    install_dir = tmp_path / "install"
+    assert not (install_dir / "agency-os-dry.timer").exists()
+    # No systemctl skip-marker emitted (because we never got past the dry-run gate)
+    assert "(skipped) systemctl" not in result.stdout
+    assert "--dry-run set" in result.stdout
+
+
+# ─── 6. Bad arg → exit 2 ────────────────────────────────────────────────
+
+
+def test_bad_arg_exits_2(tmp_path: Path):
+    staged = _stage_script_in_tmp(tmp_path)
+    env = os.environ.copy()
+    env["AGENCY_OS_SYSTEMCTL_SKIP"] = "1"
+    env["AGENCY_OS_SYSTEMD_INSTALL_DIR"] = str(tmp_path / "install")
+    result = subprocess.run(
+        ["bash", str(staged), "--gibberish"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 2
+    assert "unknown arg" in result.stderr
+
+
+# ─── 7. Empty source set → clean exit 0 ────────────────────────────────
+
+
+def test_no_source_dirs_clean_exit(tmp_path: Path):
+    # No source subdir created → script reports "no source unit files found"
+    result = _run_against_tmp_repo(tmp_path)
+    assert result.returncode == 0
+    assert "no source unit files found" in result.stdout
+
+
+# ─── 8. Idempotency: second run after install is a no-op ───────────────
+
+
+def test_idempotent_second_run_is_noop(tmp_path: Path):
+    src_dir = tmp_path / "infra" / "alerts"
+    _write_unit(src_dir, "agency-os-idem.timer", "[Timer]\nOnCalendar=hourly\n")
+
+    r1 = _run_against_tmp_repo(tmp_path)
+    assert r1.returncode == 0
+    assert "copied agency-os-idem.timer" in r1.stdout
+
+    r2 = _run_against_tmp_repo(tmp_path)
+    assert r2.returncode == 0
+    assert "no-op" in r2.stdout
+    assert "copied" not in r2.stdout


### PR DESCRIPTION
## Summary

Closes Beads Agency_OS-34s (P2). Pattern A class problem from Elliot dispatch: PRs shipping new `.service`/`.timer` files into the repo (e.g. PR #774 polling timer, PR #784 cleanup timer, PR #776 + #777 KEI-11 alerters from this session) need a manual `cp + daemon-reload + enable --now` on the host. Easy to forget — PR #774 silently didn't run until Dave noticed.

This PR adds an idempotent post-merge installer (Option 1 from the dispatch — Option 2 = GH Action needs self-hosted runner, Option 3 = tmpfiles.d symlink deferred as long-term).

## Deliverables

| File | LOC | Purpose |
|---|---|---|
| `scripts/orchestrator/install_systemd_units.sh` | 154 | Diff + install + daemon-reload + enable-timers (bash, idempotent) |
| `tests/orchestrator/test_install_systemd_units.py` | 200 | 8 mocked tests (no real systemd touched) |

## Behaviour

- Source dirs: `infra/alerts/ : infra/cron/ : infra/opa/ : systemd/` (overridable via `AGENCY_OS_SYSTEMD_SOURCE_DIRS`)
- Host install dir: `~/.config/systemd/user/` (overridable)
- Diff via sha256 per file → classify each as `new` / `changed` / `unchanged`
- Apply: `cp` for new+changed → `systemctl --user daemon-reload` → `systemctl --user enable --now <timer>` for new timers
- **Companion `.service` files** (have a matching `.timer`) installed only, not directly enabled (the timer's `[Install]` pulls them in)
- **Standalone `.service` files** (no matching `.timer`) installed only — operator decides when to start (daemons aren't auto-enabled)
- **Units removed from repo but still on host** → LEFT ALONE (removal is an explicit operator decision)
- **No-op on unchanged repo**: re-runs exit 0 with `no-op` log line

## Dave-directed activation preserved

Script is operator-invoked manually (no GH Action auto-run, no cron). Running it equals operator intent to activate everything currently in the repo source dirs.

## Verbatim `--dry-run` against current repo on host

```
$ bash scripts/orchestrator/install_systemd_units.sh --dry-run
[install_systemd_units] plan: 4 new, 7 changed, 2 timer(s) to enable+start
[install_systemd_units]   NEW     agency-os-hook-failure-monitor.timer
[install_systemd_units]   NEW     agency-os-skill-pr-staleness-monitor.timer
[install_systemd_units]   NEW     agency-os-hook-failure-monitor.service
[install_systemd_units]   NEW     agency-os-skill-pr-staleness-monitor.service
[install_systemd_units]   CHANGED agency-os-alert-vendor-budget.service
[install_systemd_units]   CHANGED agency-os-alert-budget-threshold.service
[install_systemd_units]   CHANGED agency-os-alert-daily-digest.service
[install_systemd_units]   CHANGED agency-os-alert-pipeline-failure.service
[install_systemd_units]   CHANGED agency-os-alert-lead-quality.service
[install_systemd_units]   CHANGED agency-os-max-slack-listener.service
[install_systemd_units]   CHANGED agency-os-elliot-slack-listener.service
[install_systemd_units] --dry-run set — no files copied, no systemctl invoked. exit 0.
```

This is **exactly** the install-drift gap Dave flagged: the 2 KEI-11 timers from PRs #776 + #777 (just merged) are sitting in the repo but not yet on the host. Running the script (without `--dry-run`) installs them + enables them.

## Tests

```
$ pytest tests/orchestrator/test_install_systemd_units.py -v
8 passed in 1.40s

$ ruff check tests/orchestrator/test_install_systemd_units.py
All checks passed!
```

Tests cover:
1. New unit: copied + `.timer` enabled, `.service` not directly enabled
2. Changed unit: re-installed, daemon-reload invoked
3. Unit only on host (removed from repo): left untouched
4. No-op when source matches host
5. `--dry-run` plans but doesn't apply
6. Bad arg → exit 2
7. Empty source set → clean exit
8. Idempotency: second run is no-op

All tests inject `AGENCY_OS_SYSTEMD_INSTALL_DIR=<tmp>` + `AGENCY_OS_SYSTEMCTL_SKIP=1` — no real user systemd touched.

## LAW XVI note

The Orion worktree was recreated by Atlas this session (KEI-12 worktree-swap). `.claude/hooks/` and `.claude/modules/` became symlinks; git index still tracks them as regular files → 21 phantom deletions show in `git status`. **This PR commits ONLY the 3 new files via explicit `git add <path>` — no `-A` sweep.** Phantom-deletion cleanup is a separate Elliot-decision (Aiden flagged it earlier; awaiting option (a)/(b) call).

## Activation flow this PR enables

Post-merge to main, on the Vultr host:
```bash
cd /home/elliotbot/clawd/Agency_OS
git pull
bash scripts/orchestrator/install_systemd_units.sh --dry-run    # review
bash scripts/orchestrator/install_systemd_units.sh              # apply
```

For PRs #776 + #777 specifically: running the apply step installs both new alerter timers + enables them, satisfying the Dave-directed activation step those PRs preserved.

## Test plan

- [x] 8 tests pass, ruff clean
- [x] Manual `--dry-run` matches expected host-vs-repo drift
- [x] LAW XVI: explicit-paths-only commit (no `-A`)
- [ ] Post-merge: operator runs the apply step + observes timer activation in `systemctl --user list-timers`

## Dual-CTO concur

Aiden + Max please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)