### PR TITLE
[AIDEN] fix(orchestrator): polling-loop P1 — bd PATH + asyncpg pgbouncer compat (Agency_OS-yvz)

### DIFF
--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -106,9 +106,22 @@ def should_run_now(now: datetime | None = None) -> bool:
 # Source pollers ─────────────────────────────────────────────────────────────
 
 
+# Absolute path to the bd binary. systemd --user services inherit a restricted
+# PATH that does NOT include ~/.local/bin (where pipx-installed bd lives), so a
+# bare "bd" command resolves to FileNotFoundError under systemd. Path-in-code
+# is more robust against future systemd unit edits — Scout's recommendation
+# in docs/wave2/polling_loop_bug_diagnosis.md.
+_BD_BIN = os.path.expanduser("~/.local/bin/bd")
+
+
 def poll_bd_ready() -> list[dict]:
     try:
-        proc = subprocess.run(["bd", "ready", "--json"], capture_output=True, text=True, timeout=10)
+        proc = subprocess.run(  # noqa: S603 — absolute path, no shell, no user input
+            [_BD_BIN, "ready", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
         if proc.returncode != 0:
             logger.warning("bd ready exit %d: %s", proc.returncode, proc.stderr[:200])
             return []
@@ -174,7 +187,16 @@ def poll_idle_agents(now: datetime | None = None) -> list[str]:
         return []
 
     async def _q() -> list[str]:
-        conn = await asyncpg.connect(dsn.replace("postgresql+asyncpg://", "postgresql://"))
+        # statement_cache_size=0 disables asyncpg's automatic prepared-statement
+        # caching, which collides with Supabase's pgbouncer running in
+        # transaction pool mode. pgbouncer's own hint surfaces in the error:
+        # "pgbouncer with pool_mode set to transaction or statement does not
+        # support prepared statements properly." Per Scout's diagnosis in
+        # docs/wave2/polling_loop_bug_diagnosis.md.
+        conn = await asyncpg.connect(
+            dsn.replace("postgresql+asyncpg://", "postgresql://"),
+            statement_cache_size=0,
+        )
         try:
             rows = await conn.fetch(sql, candidates)
         finally:

--- a/tests/scripts/test_elliot_polling_loop.py
+++ b/tests/scripts/test_elliot_polling_loop.py
@@ -100,6 +100,26 @@ def test_poll_bd_ready_handles_bad_json(loop_mod, monkeypatch):
     assert loop_mod.poll_bd_ready() == []
 
 
+# Agency_OS-yvz fix (a): bd invoked via absolute ~/.local/bin/bd path so
+# systemd --user services with restricted PATH don't FileNotFoundError.
+
+
+def test_poll_bd_ready_uses_absolute_bd_path(loop_mod, monkeypatch):
+    captured: list[list[str]] = []
+
+    def _capture(cmd, *a, **k):
+        captured.append(cmd)
+        return MagicMock(returncode=0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(loop_mod.subprocess, "run", _capture)
+    loop_mod.poll_bd_ready()
+    assert captured, "subprocess.run was not invoked"
+    assert captured[0][0].endswith("/.local/bin/bd"), (
+        f"expected absolute bd path, got {captured[0][0]!r}"
+    )
+    assert captured[0][1:] == ["ready", "--json"]
+
+
 # poll_linear_stale ──────────────────────────────────────────────────────────
 
 
@@ -126,6 +146,39 @@ def test_poll_idle_agents_no_dsn(loop_mod, monkeypatch):
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.delenv("DATABASE_URL_MIGRATIONS", raising=False)
     assert loop_mod.poll_idle_agents() == []
+
+
+# Agency_OS-yvz fix (b): asyncpg.connect must pass statement_cache_size=0 so
+# Supabase's pgbouncer (transaction pool) doesn't error on prepared-statement
+# re-use across pool checkouts.
+
+
+def test_poll_idle_agents_passes_statement_cache_size_zero(loop_mod, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h:5432/d")
+    captured_kwargs: list[dict] = []
+
+    pytest.importorskip("asyncpg")  # skip if asyncpg isn't installed on this host
+
+    class _FakeConn:
+        async def fetch(self, *a, **k):
+            return []
+
+        async def close(self):
+            return None
+
+    async def _fake_connect(*args, **kwargs):
+        captured_kwargs.append(kwargs)
+        return _FakeConn()
+
+    import asyncpg
+
+    monkeypatch.setattr(asyncpg, "connect", _fake_connect)
+    out = loop_mod.poll_idle_agents()
+    assert out == []
+    assert captured_kwargs, "asyncpg.connect was not invoked"
+    assert captured_kwargs[0].get("statement_cache_size") == 0, (
+        f"expected statement_cache_size=0 for pgbouncer compat, got {captured_kwargs[0]!r}"
+    )
 
 
 # poll_prefect_failures ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two surgical fixes to `scripts/orchestrator/elliot_polling_loop.py` for Agency_OS-yvz P1 per Scout's diagnosis at `docs/wave2/polling_loop_bug_diagnosis.md` (commit `d70c7d5c`). Both bugs were silently zeroing signals in the production polling loop, causing the "idle agents" failure-mode Dave flagged earlier.

## Bug (a) — `bd_ready=0` every cycle

**Root cause:** `poll_bd_ready()` calls `subprocess.run(["bd", ...])` with a bare command name. systemd `--user` services inherit a restricted PATH that does **not** include `~/.local/bin` where pipx-installed `bd` lives → `FileNotFoundError` swallowed → empty list every cycle, even when `bd ready` actually has 8+ unblocked issues.

**Fix:** module-level `_BD_BIN = os.path.expanduser("~/.local/bin/bd")` + invocation with absolute path.

Path-in-code chosen over `Environment=PATH` in the systemd unit per Elliot's pre-confirm — more robust against future unit edits, matches Pattern A "fix at the call site" discipline.

## Bug (b) — `idle_agents=0` even with stale outboxes

**Root cause:** `poll_idle_agents()` calls `asyncpg.connect(dsn)` with default args. DSN routes through Supabase's pgbouncer in transaction pool mode. asyncpg aggressively prepares + caches every statement; pgbouncer doesn't preserve prepared-statement state across pool checkouts. Cycle 2 surfaces pgbouncer's own hint via the error verbatim.

**Fix:** pass `statement_cache_size=0` to `asyncpg.connect`. Canonical workaround per asyncpg docs + pgbouncer hint.

## Bug (c) — Prefect 404 — DEFERRED

`PREFECT_API_URL` points at a Railway hostname that now serves "Agency OS API v3.0.0" instead of Prefect. NOT a code bug. The line 197 `if not api_url: return []` guard cleanly short-circuits when operator unsets the env var. Operator/infra decision, separate from this PR.

## Tests (28/28 pass locally)

2 new in `tests/scripts/test_elliot_polling_loop.py`:

- `test_poll_bd_ready_uses_absolute_bd_path` — captures `subprocess.run` args, asserts `cmd[0].endswith("/.local/bin/bd")`.
- `test_poll_idle_agents_passes_statement_cache_size_zero` — mocks `asyncpg.connect`, captures kwargs, asserts `statement_cache_size == 0`.

```
$ python3 -m pytest tests/scripts/test_elliot_polling_loop.py -v
============================== 28 passed in 0.61s ==============================
```

Ruff clean.

## Post-merge verification

Elliot will tail `logs/elliot-polling-loop.log` on the next cycle to confirm `bd_ready=N>0` and no asyncpg statement-collision errors. Empirical evidence both bugs were silently active in production — see Scout's diagnosis log captures in d70c7d5c.

## Queue context

3rd of 4 sequential fixes:
1. ~~Stop-hook auto-[READY:] marker emit (PR #789)~~ MERGED 0638c8b6
2. ~~Clone-callsign role-filter (PR #791)~~ MERGED 60b0a413
3. **Polling-loop P1 fixes (this PR — Agency_OS-yvz)**
4. Worktree alignment + Better Stack PR-C/D

Per Elliot's pre-confirm: "Path-in-code over Environment=PATH approved. ~10 LOC + 2 tests. Bundle (a)+(b), defer (c). GO."

Max pre-concur on file open: "Standing peer-CTO concur when she opens PR" (ts ~1778615860).

## Test plan

- [x] `pytest tests/scripts/test_elliot_polling_loop.py -v` — 28/28
- [x] `ruff check` — All checks passed
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Post-merge live verification by Elliot (log tail next cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)