### PR TITLE
[AIDEN] fix(orchestrator): polling-loop Linear-stale assignee=null AttributeError (Agency_OS-3gy)

### DIFF
--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -284,7 +284,10 @@ def compose_dispatches(signals: CycleSignals) -> list[tuple[str, str]]:
     if signals.linear_stale:
         lines = [
             f"  - {it.get('identifier', '?')} {it.get('title', '?')} "
-            f"(last update {it.get('updatedAt', '?')}, assignee {it.get('assignee', {}).get('name', '?')})"
+            # `(it.get('assignee') or {})` — Linear returns assignee=null on
+            # unassigned issues (key present, value None); plain default-{}
+            # access returns None and .get('name') raises AttributeError.
+            f"(last update {it.get('updatedAt', '?')}, assignee {(it.get('assignee') or {}).get('name', '?')})"
             for it in signals.linear_stale[:10]
         ]
         msg = (

--- a/tests/scripts/test_elliot_polling_loop.py
+++ b/tests/scripts/test_elliot_polling_loop.py
@@ -252,6 +252,50 @@ def test_compose_dispatches_linear_stale_escalates_to_ceo(loop_mod):
     assert "KEI-99" in msg
 
 
+# Agency_OS-3gy: Linear returns assignee=null on unassigned issues (key
+# present, value None). Empirical crash on next polling cycle post the bd
+# subprocess + asyncpg fixes (PR #792). Trace: AttributeError 'NoneType'
+# object has no attribute 'get' in compose_dispatches.
+
+
+def test_compose_dispatches_linear_stale_handles_null_assignee(loop_mod):
+    """Linear-stale issue with assignee=None (unassigned) must not crash."""
+    sig = loop_mod.CycleSignals(
+        bd_ready=[],
+        linear_stale=[
+            {
+                "identifier": "KEI-100",
+                "title": "Unassigned stuck",
+                "updatedAt": "2026-05-11T00:00:00Z",
+                "assignee": None,  # ← the empirical Linear shape
+            },
+        ],
+        idle_agents=[],
+        prefect_failures=[],
+    )
+    dispatches = loop_mod.compose_dispatches(sig)
+    assert len(dispatches) == 1
+    chan, msg = dispatches[0]
+    assert chan == "#ceo"
+    assert "KEI-100" in msg
+    assert "assignee ?" in msg  # default '?' when assignee dict has no name
+
+
+def test_compose_dispatches_linear_stale_handles_missing_assignee_key(loop_mod):
+    """Linear-stale issue with no assignee key at all also must not crash."""
+    sig = loop_mod.CycleSignals(
+        bd_ready=[],
+        linear_stale=[
+            {"identifier": "KEI-101", "title": "No assignee key", "updatedAt": "x"},
+        ],
+        idle_agents=[],
+        prefect_failures=[],
+    )
+    dispatches = loop_mod.compose_dispatches(sig)
+    assert len(dispatches) == 1
+    assert "KEI-101" in dispatches[0][1]
+
+
 def test_compose_dispatches_prefect_failures_escalate_to_ceo(loop_mod):
     sig = loop_mod.CycleSignals(
         bd_ready=[],


### PR DESCRIPTION
## Summary

Fast-follow on PR #792 (polling-loop P1 fixes). Empirical post-merge crash captured by Elliot's tail-log: now that `bd_ready` + `asyncpg` no longer short-circuit, the next polling cycle hit a Linear-stale `AttributeError: 'NoneType' object has no attribute 'get'`.

**Root cause:** Linear's GraphQL response includes `assignee: null` for unassigned issues (key present, value None). The previous access pattern `it.get('assignee', {}).get('name', '?')` returns `None` (default-`{}` only fires on missing key), and the chained `.get('name')` raises.

**Fix:** 1-line change — `it.get('assignee', {})` → `(it.get('assignee') or {})`. Idiomatic Python for "treat None and missing-key the same".

## Tests (30/30 pass)

| Test | Pre-fix | Post-fix |
|------|---------|----------|
| `test_compose_dispatches_linear_stale_handles_null_assignee` (new) | CRASH | PASS |
| `test_compose_dispatches_linear_stale_handles_missing_assignee_key` (new) | PASS | PASS |
| `test_compose_dispatches_linear_stale_escalates_to_ceo` (existing happy path) | PASS | PASS |

```
$ pytest tests/scripts/test_elliot_polling_loop.py
============================== 30 passed in 0.24s ==============================
```

Ruff clean.

## Defensive grep flag (NOT bundled per Step 0 scope discipline)

Two other occurrences of the same `x.get(k, {}).get(...)` shape in this file, theoretical-not-empirical at this point. File separately if either crashes:

- `elliot_polling_loop.py:155` — `body.get("data", {}).get("issues", {}).get("nodes", []) or []`. GraphQL `data: null` is a documented partial-error case.
- `elliot_polling_loop.py:299` — `fr.get('state', {}).get('type', '?')`. Prefect flow_run `state: null` possible on errored runs.

## Queue context

Inserted before worktree alignment per Elliot's dispatch:
1. ~~Stop-hook (#789)~~ — DONE
2. ~~Clone-callsign role-filter (#791)~~ — DONE
3. ~~Polling-loop P1 fixes (#792)~~ — DONE
4. **Polling-loop Linear-stale null-assignee (this PR — Agency_OS-3gy)**
5. Worktree alignment + Better Stack PR-C/D

Secondary peak-window bug Elliot flagged ('outside peak window' at UTC 13:35) is a SEPARATE diagnosis — Scout may take it after this lands.

## Test plan

- [x] `pytest -v -k linear_stale` — 5/5 pass (3 happy + 2 new null cases)
- [x] `pytest tests/scripts/test_elliot_polling_loop.py` — 30/30
- [x] `ruff check` — All checks passed
- [ ] CI green
- [ ] Post-merge: Elliot tails log on next cycle; expect no AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)