### PR TITLE
[AIDEN] feat(observability): Better Stack Slack-routing readiness check (PR-C verify-only)

### DIFF
--- a/docs/runbooks/betterstack-slack-routing.md
+++ b/docs/runbooks/betterstack-slack-routing.md
@@ -1,0 +1,50 @@
+# Better Stack — Slack Alert Routing (Operator Runbook)
+
+## Why this is operator-action, not automatable
+
+Better Stack's Slack integration is OAuth-scoped: a new BS-side Slack integration must be authorised through the BS dashboard's OAuth flow. The BS v2 API does not expose integration creation endpoints, so the script at `scripts/orchestrator/betterstack_slack_routing.py` is read-only — it verifies whether the integration exists, and prints these instructions when it does not.
+
+The notification policy that references the integration (PR-C-v2, follow-up) can be API-driven once the integration_id is known. Policy step JSON schema for `type=slack` was empirically opaque on the BS v2 API as of 2026-05-12 (422 with vague "allowed_values: {type: slack}" on every field combo probed), so PR-C-v2 will need fresh probing once a real integration_id exists to reference.
+
+## Current state (2026-05-12)
+
+| Integration | Channel | id |
+|---|---|---|
+| Existing (active) | `#ceo` (C0B2PM3TV0B) | 102756 |
+| **Required for PR-C-v2** | `#alerts` (C0B2EJU53EK) | _operator must create_ |
+
+The `#ceo` integration is what routes today's incidents from BS to `#ceo` via the BS-installed Slack app. Per Dave's role-lock (2026-05-11), `#ceo` is Dave-Elliot exclusive, so flooding it with monitor/heartbeat alerts is wrong. PR-C-v2 will route alerts to `#alerts` instead.
+
+## Operator steps
+
+1. **Open** https://uptime.betterstack.com/team/integrations/slack
+2. **Click** "Add Slack workspace" — opens Slack OAuth consent page in a new tab.
+3. **Authorise** the Keiracom workspace for the Better Stack app. Requires workspace-admin rights (Dave).
+4. **Select** `#alerts` (channel id `C0B2EJU53EK`) as the default channel when prompted. Leave `on_call_notifications` enabled; `integration_type=verbose` matches the existing pattern.
+5. **Save** — BS dashboard now shows a second Slack integration row.
+6. **Verify** by running:
+   ```bash
+   BETTERSTACK_API_KEY=<key> python3 scripts/orchestrator/betterstack_slack_routing.py
+   ```
+   The script should now print `READY — #alerts integration found (id=<new-id>)`.
+
+## After verification
+
+- File PR-C-v2 (Aiden) to wire a Better Stack notification policy referencing the new integration_id + apply it to all 5 heartbeats (PR-A) + 3 uptime monitors (PR-B).
+- Manual smoke test: curl-fail the `agency-os-discovery` heartbeat and confirm a `#alerts` Slack post lands within 60s.
+
+## Why we keep email AND add Slack
+
+Defense in depth. Email is the BS default and survives Slack app outages. Slack adds real-time visibility. PR-C-v2 will not remove email — it will add Slack as a parallel step.
+
+## Why this isn't a `/schedule` or systemd timer
+
+The integration is a one-time setup (per-workspace), not a recurring check. The verify-only script is an operator-invoked diagnostic, not a scheduled job. Running it on a timer would just produce noise once the integration exists.
+
+## Related
+
+- `scripts/orchestrator/betterstack_setup.py` — heartbeats bootstrap (PR-A, merged)
+- `scripts/orchestrator/betterstack_uptime_monitors.py` — uptime monitors (PR-B, merged + PR #788 fixes)
+- `scripts/orchestrator/betterstack_slack_routing.py` — verify-only readiness check (PR-C, this file)
+- PR-C-v2 (future) — automated policy wire-in once OAuth done
+- PR-D — public status page (separate, planned)

--- a/scripts/orchestrator/betterstack_slack_routing.py
+++ b/scripts/orchestrator/betterstack_slack_routing.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""betterstack_slack_routing.py — Better Stack Slack-routing readiness check.
+
+PR-C (verify-only iteration) of the Better Stack bundle. Original scope was
+"create notification policy + wire all monitors/heartbeats to Slack #alerts",
+but the BS v2 API has two blockers preventing full automation:
+
+  1. Slack integrations are OAuth-scoped: a NEW BS Slack integration pointing
+     at #alerts must be operator-created via the BS dashboard's OAuth flow.
+     The v2 API doesn't expose integration creation.
+  2. Policy step JSON schema (for type="slack" / "team_email" / "webhook")
+     returns vague "allowed_values: {type: X}" errors on every field combo
+     probed empirically 2026-05-12. Cannot ratify schema without working
+     example, which depends on (1).
+
+So this PR ships a READ-ONLY verification script that:
+  - Lists existing BS Slack integrations + their channel routing.
+  - Detects whether an #alerts integration exists (channel C0B2EJU53EK).
+  - Prints either "READY for policy build" with the integration_id, OR
+    "OAuth required" with explicit operator steps.
+
+Once an operator completes the OAuth dance and re-runs this script with a
+positive verdict, PR-C-v2 wires the actual notification policy referencing
+the now-known integration_id.
+
+Usage:
+    BETTERSTACK_API_KEY=<key> python3 scripts/orchestrator/betterstack_slack_routing.py
+
+Env overrides (tests):
+    AGENCY_OS_BETTERSTACK_API_BASE — override API root (default uptime.betterstack.com/api/v2)
+
+Always exits 0 — operator-diagnostic, never blocks anything.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+# Target Slack channel for alerts (verified against scripts/slack_relay.py CHANNELS map).
+ALERTS_CHANNEL_ID = "C0B2EJU53EK"
+ALERTS_CHANNEL_NAME = "#alerts"
+
+API_BASE_DEFAULT = "https://uptime.betterstack.com/api/v2"
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+
+def _api_base() -> str:
+    return os.environ.get("AGENCY_OS_BETTERSTACK_API_BASE", API_BASE_DEFAULT)
+
+
+def list_slack_integrations(api_key: str) -> list[dict]:
+    """Return all BS Slack integrations for this team. Empty on error."""
+    url = f"{_api_base()}/slack-integrations?per_page=50"
+    req = urllib.request.Request(url, headers=_auth_headers(api_key), method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = json.loads(resp.read() or "null")
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+        print(f"[bs-slack] integrations list failed: {exc}", file=sys.stderr)
+        return []
+    return body.get("data", []) or []
+
+
+def find_alerts_integration(integrations: list[dict]) -> dict | None:
+    """Return the integration record pointing at #alerts, else None."""
+    for it in integrations:
+        attrs = it.get("attributes", {})
+        if attrs.get("slack_channel_id") == ALERTS_CHANNEL_ID:
+            return it
+        if attrs.get("slack_channel_name") in {ALERTS_CHANNEL_NAME, "alerts"}:
+            return it
+    return None
+
+
+def print_oauth_runbook() -> None:
+    """Operator-facing instructions when no #alerts integration exists."""
+    print(
+        "# Better Stack Slack-routing — operator OAuth required\n"
+        "#\n"
+        "# No existing BS Slack integration points at #alerts (channel\n"
+        f"# {ALERTS_CHANNEL_ID}). To enable PR-C-v2 (policy wire-in), an operator\n"
+        "# must complete BS's Slack OAuth flow via the dashboard. Steps:\n"
+        "#\n"
+        "#   1. Open https://uptime.betterstack.com/team/integrations/slack\n"
+        "#   2. Click 'Add Slack workspace' (OAuth flow opens Slack auth page)\n"
+        "#   3. Authorise the Keiracom workspace for the Better Stack app\n"
+        f"#   4. When prompted for default channel, select #alerts (id {ALERTS_CHANNEL_ID})\n"
+        "#   5. Save\n"
+        "#   6. Re-run this script — it should now report READY with the new\n"
+        "#      integration_id for PR-C-v2 to consume\n"
+        "#\n"
+        "# See docs/runbooks/betterstack-slack-routing.md for the full procedure.\n",
+        file=sys.stderr,
+    )
+
+
+def report(integrations: list[dict]) -> int:
+    """Print findings to stderr; return advisory exit-code value (always-0 in main)."""
+    print("# Better Stack Slack-routing — readiness check", file=sys.stderr)
+    print(f"# Looking for an integration pointing at {ALERTS_CHANNEL_NAME} ({ALERTS_CHANNEL_ID})", file=sys.stderr)
+    print(f"# Existing slack integrations: {len(integrations)}", file=sys.stderr)
+    for it in integrations:
+        attrs = it.get("attributes", {})
+        print(
+            f"#   id={it.get('id')} channel={attrs.get('slack_channel_name')} "
+            f"({attrs.get('slack_channel_id')}) status={attrs.get('slack_status')}",
+            file=sys.stderr,
+        )
+
+    match = find_alerts_integration(integrations)
+    if match:
+        print(
+            f"# READY — #alerts integration found (id={match.get('id')}). "
+            f"PR-C-v2 can wire the notification policy referencing this id.",
+            file=sys.stderr,
+        )
+        return 0
+    print("# NOT READY — no #alerts integration found.", file=sys.stderr)
+    print_oauth_runbook()
+    return 0
+
+
+def main() -> int:
+    api_key = os.environ.get("BETTERSTACK_API_KEY", "").strip()
+    if not api_key:
+        print("ERROR: BETTERSTACK_API_KEY env not set", file=sys.stderr)
+        return 0  # operator-diagnostic, never blocks
+    integrations = list_slack_integrations(api_key)
+    return report(integrations)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/orchestrator/test_betterstack_slack_routing.py
+++ b/tests/orchestrator/test_betterstack_slack_routing.py
@@ -1,0 +1,138 @@
+"""Tests for scripts/orchestrator/betterstack_slack_routing.py — PR-C verify-only.
+
+The script is a read-only diagnostic: it hits BS v2 /slack-integrations,
+inspects the response for an #alerts integration (channel C0B2EJU53EK),
+prints READY/NOT-READY to stderr, and always exits 0. Tests cover:
+
+  - find_alerts_integration: by channel id, by channel name, missing case
+  - report: READY path (#alerts present) and NOT-READY path (runbook printed)
+  - main: missing API key → still returns 0 (operator-diagnostic discipline)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "orchestrator" / "betterstack_slack_routing.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("bs_slack_routing", SCRIPT_PATH)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["bs_slack_routing"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+# find_alerts_integration ─────────────────────────────────────────────────────
+
+
+def test_find_alerts_integration_match_by_channel_id(mod):
+    integrations = [
+        {
+            "id": "999",
+            "attributes": {
+                "slack_channel_id": "C0B2EJU53EK",
+                "slack_channel_name": "#alerts",
+            },
+        },
+    ]
+    result = mod.find_alerts_integration(integrations)
+    assert result is not None
+    assert result["id"] == "999"
+
+
+def test_find_alerts_integration_match_by_channel_name(mod):
+    integrations = [
+        {
+            "id": "888",
+            "attributes": {
+                "slack_channel_id": "OTHER",
+                "slack_channel_name": "alerts",
+            },
+        },
+    ]
+    result = mod.find_alerts_integration(integrations)
+    assert result is not None
+    assert result["id"] == "888"
+
+
+def test_find_alerts_integration_missing_returns_none(mod):
+    integrations = [
+        {
+            "id": "102756",
+            "attributes": {
+                "slack_channel_id": "C0B2PM3TV0B",
+                "slack_channel_name": "#ceo",
+            },
+        },
+    ]
+    assert mod.find_alerts_integration(integrations) is None
+
+
+def test_find_alerts_integration_empty_list_returns_none(mod):
+    assert mod.find_alerts_integration([]) is None
+
+
+# report ──────────────────────────────────────────────────────────────────────
+
+
+def test_report_ready_when_alerts_integration_present(mod, capsys):
+    integrations = [
+        {
+            "id": "999",
+            "attributes": {
+                "slack_channel_id": "C0B2EJU53EK",
+                "slack_channel_name": "#alerts",
+                "slack_status": "active",
+            },
+        },
+    ]
+    rc = mod.report(integrations)
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "READY" in captured.err
+    assert "id=999" in captured.err
+
+
+def test_report_not_ready_prints_oauth_runbook(mod, capsys):
+    integrations = [
+        {
+            "id": "102756",
+            "attributes": {
+                "slack_channel_id": "C0B2PM3TV0B",
+                "slack_channel_name": "#ceo",
+                "slack_status": "active",
+            },
+        },
+    ]
+    rc = mod.report(integrations)
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "NOT READY" in captured.err
+    assert "OAuth required" in captured.err
+    assert "team/integrations/slack" in captured.err
+
+
+def test_report_no_integrations_prints_runbook(mod, capsys):
+    rc = mod.report([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "Existing slack integrations: 0" in captured.err
+    assert "OAuth required" in captured.err
+
+
+# main ────────────────────────────────────────────────────────────────────────
+
+
+def test_main_missing_api_key_returns_zero(mod, monkeypatch):
+    """Operator-diagnostic: never block. Missing key → return 0 silently-with-stderr."""
+    monkeypatch.delenv("BETTERSTACK_API_KEY", raising=False)
+    rc = mod.main()
+    assert rc == 0


### PR DESCRIPTION
## Summary

PR-C of the Better Stack bundle, re-scoped to read-only verification per dual-CTO concur on the API-blocker flag. Original plan was full automated Slack-routing wire-in, but empirical probing surfaced two blockers (detailed below). Ships a verify-only script + operator runbook so the OAuth gap is documented + the readiness signal is mechanical, not vibes.

## Why verify-only

Two empirical blockers on the BS v2 API as of 2026-05-12 (Slack messages ts ~1778617240):

1. **Slack integration creation is OAuth-scoped.** A new BS Slack integration pointing at `#alerts` (channel `C0B2EJU53EK`) requires the BS dashboard's Slack OAuth flow. The v2 API has no integration-creation endpoint. The existing integration is scoped to `#ceo` (id=102756) which is Dave-Elliot exclusive — can't re-point without breaking it.

2. **Policy step JSON schema opaque.** `POST /policies {steps:[{type:'slack'|'team_email'|'webhook'}]}` returns 422 with the vague string `'allowed_values: {type: <X>}'` on every field combo probed. Cannot ratify the schema without a working integration_id to reference.

Per [CONCUR:max] + [CONCUR:elliot] on option (A): ship the verify script + runbook; PR-C-v2 wires the actual policy after operator does OAuth.

## Deliverables

| File | LoC | Purpose |
|------|-----|---------|
| `scripts/orchestrator/betterstack_slack_routing.py` | 140 | Read `/slack-integrations`; report READY/NOT-READY with OAuth runbook snippet |
| `docs/runbooks/betterstack-slack-routing.md` | 50 | Operator step-by-step OAuth dance + why it's not automatable |
| `tests/orchestrator/test_betterstack_slack_routing.py` | 138 / 8 tests | find_alerts_integration + report + main fail-open paths |

```
$ pytest tests/orchestrator/test_betterstack_slack_routing.py -q
........                                                                 [100%]
8 passed in 0.15s
```

Ruff clean.

## PR-C-v2 follow-up gate

Dave does the OAuth flow → re-runs the script → script reports `READY — #alerts integration found (id=<new>)` → PR-C-v2 (Aiden) wires a notification policy referencing that id + applies to all 5 heartbeats (PR-A) + 3 monitors (PR-B). PR-C-v2 will also need fresh schema probing on the BS API for the step JSON shape.

## Pattern context

Matches the `GOV-9 defer-with-rationale` shape used for Vultr health endpoint (no default health URL) + Cognee localhost monitor (port 8000 not external-reachable) in PR-B. Document the blocker, ship the artefact, leave the operator path explicit.

## Test plan

- [x] `pytest tests/orchestrator/test_betterstack_slack_routing.py` — 8/8 pass
- [x] `ruff check` — clean
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Post-merge: Elliot pings Dave in `#ceo` with concrete operator step (link to runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)