### PR TITLE
[AIDEN] feat(observability): Better Stack public status page (PR-D)

### DIFF
--- a/scripts/orchestrator/betterstack_status_page.py
+++ b/scripts/orchestrator/betterstack_status_page.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""betterstack_status_page.py — KEI Better Stack public status page bootstrap.
+
+PR-D of the Better Stack bundle. One-shot operator script that creates ONE
+public status page named "Agency OS" + attaches the 3 uptime monitors from
+PR-B and the 5 heartbeats from PR-A as page resources. Free-tier-supported
+(empirical 2026-05-12: POST /status-pages with timezone returns 201).
+
+Idempotent: re-runs reaffirm attachments by name; existing page (matched by
+subdomain) is reused; existing resources are not duplicated.
+
+Usage:
+    BETTERSTACK_API_KEY=<key> python3 scripts/orchestrator/betterstack_status_page.py
+
+After running this once, the public URL is:
+    https://<SUBDOMAIN>.betteruptime.com
+
+Env overrides (tests + non-default subdomains):
+    AGENCY_OS_BETTERSTACK_API_BASE — API root (default uptime.betterstack.com/api/v2)
+    AGENCY_OS_BETTERSTACK_STATUS_SUBDOMAIN — page subdomain (default 'agency-os')
+
+Exits 0 on success or clean no-op; non-zero only on missing API key.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API_BASE_DEFAULT = "https://uptime.betterstack.com/api/v2"
+
+# Page identity. Subdomain is the slug under .betteruptime.com.
+DEFAULT_SUBDOMAIN = "agency-os"
+PAGE_BODY = {
+    "company_name": "Agency OS",
+    "company_url": "https://agencyxos.ai",
+    "contact_url": "mailto:dvidstephens@gmail.com",
+    "timezone": "UTC",
+}
+
+# Resources to attach (name → matched by attribute on /monitors or /heartbeats).
+# Names match the pronounceable_name set in betterstack_uptime_monitors.py +
+# betterstack_setup.py. Public-facing labels rendered on the status page.
+MONITOR_RESOURCES: list[tuple[str, str]] = [
+    ("agencyxos.ai", "Agency OS marketing site"),
+    ("supabase-rest", "Supabase REST API"),
+    ("railway-prefect", "Railway Prefect server"),
+]
+HEARTBEAT_RESOURCES: list[tuple[str, str]] = [
+    ("elliot-polling-loop", "Elliot polling loop (KEI-17)"),
+    ("cognee-phase1-ingest", "Cognee Phase 1 ingestion"),
+    ("prefect-pipeline", "Prefect orchestrator flow"),
+    ("central-listener", "Slack central listener"),
+    ("agency-os-discovery", "Agency OS discovery pipeline"),
+]
+
+
+def _api_base() -> str:
+    return os.environ.get("AGENCY_OS_BETTERSTACK_API_BASE", API_BASE_DEFAULT)
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+
+def _request(method: str, path: str, api_key: str, body: dict | None = None) -> dict | None:
+    """Best-effort BS API call. Returns parsed JSON or None on error."""
+    url = f"{_api_base()}{path}"
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(url, data=data, headers=_auth_headers(api_key), method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read() or "null")
+    except urllib.error.HTTPError as exc:
+        body_text = exc.read().decode(errors="replace") if exc.fp else ""
+        print(f"[bs-status] HTTP {exc.code} on {method} {url}: {body_text[:200]}", file=sys.stderr)
+        return None
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+        print(f"[bs-status] network/parse error on {method} {url}: {exc}", file=sys.stderr)
+        return None
+
+
+def list_status_pages(api_key: str) -> list[dict]:
+    resp = _request("GET", "/status-pages?per_page=50", api_key)
+    return (resp or {}).get("data", []) or []
+
+
+def list_monitors(api_key: str) -> list[dict]:
+    resp = _request("GET", "/monitors?per_page=100", api_key)
+    return (resp or {}).get("data", []) or []
+
+
+def list_heartbeats(api_key: str) -> list[dict]:
+    resp = _request("GET", "/heartbeats?per_page=100", api_key)
+    return (resp or {}).get("data", []) or []
+
+
+def list_resources(api_key: str, page_id: str) -> list[dict]:
+    resp = _request("GET", f"/status-pages/{page_id}/resources?per_page=100", api_key)
+    return (resp or {}).get("data", []) or []
+
+
+def ensure_page(api_key: str, subdomain: str, existing: list[dict]) -> dict | None:
+    """Return the status-page record. Match by subdomain; create if absent."""
+    for p in existing:
+        if p.get("attributes", {}).get("subdomain") == subdomain:
+            return p
+    body = {**PAGE_BODY, "subdomain": subdomain}
+    resp = _request("POST", "/status-pages", api_key, body)
+    return (resp or {}).get("data") if resp else None
+
+
+def _resource_already_attached(
+    existing: list[dict], resource_id: int, resource_type: str
+) -> bool:
+    for r in existing:
+        attrs = r.get("attributes", {})
+        if attrs.get("resource_id") == resource_id and attrs.get("resource_type") == resource_type:
+            return True
+    return False
+
+
+def attach_resource(
+    api_key: str,
+    page_id: str,
+    resource_id: int,
+    resource_type: str,
+    public_name: str,
+    existing: list[dict],
+) -> dict | None:
+    if _resource_already_attached(existing, resource_id, resource_type):
+        return next(
+            (
+                r
+                for r in existing
+                if r.get("attributes", {}).get("resource_id") == resource_id
+                and r.get("attributes", {}).get("resource_type") == resource_type
+            ),
+            None,
+        )
+    body = {
+        "resource_id": resource_id,
+        "resource_type": resource_type,
+        "public_name": public_name,
+    }
+    resp = _request("POST", f"/status-pages/{page_id}/resources", api_key, body)
+    return (resp or {}).get("data") if resp else None
+
+
+def _by_name(records: list[dict], name: str, attr: str = "pronounceable_name") -> dict | None:
+    for r in records:
+        if r.get("attributes", {}).get(attr) == name:
+            return r
+    return None
+
+
+def _by_heartbeat_name(records: list[dict], name: str) -> dict | None:
+    return _by_name(records, name, attr="name")
+
+
+def main() -> int:
+    api_key = os.environ.get("BETTERSTACK_API_KEY", "").strip()
+    if not api_key:
+        print("ERROR: BETTERSTACK_API_KEY env not set", file=sys.stderr)
+        return 2
+
+    subdomain = os.environ.get("AGENCY_OS_BETTERSTACK_STATUS_SUBDOMAIN", DEFAULT_SUBDOMAIN)
+
+    print("# Better Stack status page — operator review", file=sys.stderr)
+    print(f"# Subdomain: {subdomain}", file=sys.stderr)
+
+    pages = list_status_pages(api_key)
+    page = ensure_page(api_key, subdomain, pages)
+    if not page:
+        print("# ERROR: status page create/fetch failed — review stderr", file=sys.stderr)
+        return 1
+
+    page_id = str(page.get("id"))
+    public_url = f"https://{subdomain}.betteruptime.com"
+    print(f"# Page id={page_id}  url={public_url}", file=sys.stderr)
+
+    monitors = list_monitors(api_key)
+    heartbeats = list_heartbeats(api_key)
+    existing_resources = list_resources(api_key, page_id)
+
+    attached = 0
+    for mon_name, public_name in MONITOR_RESOURCES:
+        m = _by_name(monitors, mon_name)
+        if not m:
+            print(f"#   SKIP monitor '{mon_name}' — not found in BS", file=sys.stderr)
+            continue
+        rid = int(m["id"])
+        result = attach_resource(api_key, page_id, rid, "Monitor", public_name, existing_resources)
+        if result:
+            attached += 1
+            print(f"#   monitor   '{mon_name}' (id={rid}) → '{public_name}'", file=sys.stderr)
+
+    for hb_name, public_name in HEARTBEAT_RESOURCES:
+        hb = _by_heartbeat_name(heartbeats, hb_name)
+        if not hb:
+            print(f"#   SKIP heartbeat '{hb_name}' — not found in BS", file=sys.stderr)
+            continue
+        rid = int(hb["id"])
+        result = attach_resource(api_key, page_id, rid, "Heartbeat", public_name, existing_resources)
+        if result:
+            attached += 1
+            print(f"#   heartbeat '{hb_name}' (id={rid}) → '{public_name}'", file=sys.stderr)
+
+    print(f"# done — {attached} resource(s) attached/affirmed. Public URL: {public_url}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/orchestrator/test_betterstack_status_page.py
+++ b/tests/orchestrator/test_betterstack_status_page.py
@@ -1,0 +1,149 @@
+"""Tests for scripts/orchestrator/betterstack_status_page.py — PR-D.
+
+Mocks the urllib request layer via a closure-captured fake _request injector.
+Verifies idempotency contract:
+  - ensure_page: match-by-subdomain returns existing, else POSTs new page.
+  - attach_resource: skips when (resource_id, resource_type) already present.
+  - _by_name + _by_heartbeat_name: pronounceable_name vs name attribute.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "orchestrator" / "betterstack_status_page.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("bs_status_page", SCRIPT_PATH)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["bs_status_page"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+# ensure_page ─────────────────────────────────────────────────────────────────
+
+
+def test_ensure_page_match_by_subdomain_returns_existing(mod, monkeypatch):
+    existing = [
+        {"id": "111", "attributes": {"subdomain": "agency-os", "company_name": "Agency OS"}},
+        {"id": "222", "attributes": {"subdomain": "other", "company_name": "Other"}},
+    ]
+
+    def _no_request(*args, **kwargs):
+        raise AssertionError("ensure_page should not POST when subdomain matches")
+
+    monkeypatch.setattr(mod, "_request", _no_request)
+    result = mod.ensure_page("k", "agency-os", existing)
+    assert result is not None
+    assert result["id"] == "111"
+
+
+def test_ensure_page_no_match_posts_new(mod, monkeypatch):
+    captured: list[tuple] = []
+
+    def _fake_request(method, path, api_key, body=None):
+        captured.append((method, path, body))
+        return {"data": {"id": "333", "attributes": {"subdomain": "agency-os"}}}
+
+    monkeypatch.setattr(mod, "_request", _fake_request)
+    result = mod.ensure_page("k", "agency-os", existing=[])
+    assert result is not None
+    assert result["id"] == "333"
+    assert captured[0][0] == "POST"
+    assert captured[0][1] == "/status-pages"
+    assert captured[0][2]["subdomain"] == "agency-os"
+    assert captured[0][2]["timezone"] == "UTC"
+
+
+# attach_resource ─────────────────────────────────────────────────────────────
+
+
+def test_attach_resource_skips_if_already_present(mod, monkeypatch):
+    existing = [
+        {
+            "id": "8858461",
+            "attributes": {"resource_id": 4400037, "resource_type": "Monitor", "public_name": "agencyxos.ai"},
+        },
+    ]
+
+    def _no_request(*args, **kwargs):
+        raise AssertionError("attach_resource must not POST when already present")
+
+    monkeypatch.setattr(mod, "_request", _no_request)
+    result = mod.attach_resource("k", "247160", 4400037, "Monitor", "agencyxos.ai", existing)
+    assert result is not None
+    assert result["id"] == "8858461"
+
+
+def test_attach_resource_posts_when_missing(mod, monkeypatch):
+    captured: list[tuple] = []
+
+    def _fake(method, path, api_key, body=None):
+        captured.append((method, path, body))
+        return {"data": {"id": "9999", "attributes": body or {}}}
+
+    monkeypatch.setattr(mod, "_request", _fake)
+    result = mod.attach_resource("k", "247160", 4400118, "Monitor", "supabase-rest", existing=[])
+    assert result is not None
+    assert captured[0][0] == "POST"
+    assert captured[0][1] == "/status-pages/247160/resources"
+    assert captured[0][2] == {
+        "resource_id": 4400118,
+        "resource_type": "Monitor",
+        "public_name": "supabase-rest",
+    }
+
+
+def test_attach_resource_distinguishes_type(mod, monkeypatch):
+    """resource_id collision across types must NOT block attach."""
+    existing = [
+        {"attributes": {"resource_id": 5, "resource_type": "Monitor"}},
+    ]
+    captured: list[tuple] = []
+
+    def _fake(method, path, api_key, body=None):
+        captured.append((method, path, body))
+        return {"data": {"id": "new"}}
+
+    monkeypatch.setattr(mod, "_request", _fake)
+    result = mod.attach_resource("k", "p", 5, "Heartbeat", "hb-name", existing)
+    assert result is not None
+    assert captured[0][0] == "POST"
+
+
+# _by_name + _by_heartbeat_name ───────────────────────────────────────────────
+
+
+def test_by_name_matches_pronounceable_name(mod):
+    monitors = [
+        {"id": "1", "attributes": {"pronounceable_name": "agencyxos.ai"}},
+        {"id": "2", "attributes": {"pronounceable_name": "supabase-rest"}},
+    ]
+    assert mod._by_name(monitors, "agencyxos.ai")["id"] == "1"
+    assert mod._by_name(monitors, "supabase-rest")["id"] == "2"
+    assert mod._by_name(monitors, "missing") is None
+
+
+def test_by_heartbeat_name_matches_name_attr(mod):
+    hbs = [
+        {"id": "10", "attributes": {"name": "elliot-polling-loop"}},
+        {"id": "11", "attributes": {"name": "cognee-phase1-ingest"}},
+    ]
+    assert mod._by_heartbeat_name(hbs, "elliot-polling-loop")["id"] == "10"
+    assert mod._by_heartbeat_name(hbs, "missing") is None
+
+
+# main ────────────────────────────────────────────────────────────────────────
+
+
+def test_main_missing_api_key_returns_2(mod, monkeypatch):
+    monkeypatch.delenv("BETTERSTACK_API_KEY", raising=False)
+    assert mod.main() == 2


### PR DESCRIPTION
## Summary

Final BS sub-PR. One-shot idempotent operator script that creates ONE public Better Stack status page ("Agency OS") and attaches all 8 resources:

- 3 uptime monitors from PR-B: `agencyxos.ai`, `supabase-rest`, `railway-prefect`
- 5 heartbeats from PR-A: `elliot-polling-loop`, `cognee-phase1-ingest`, `prefect-pipeline`, `central-listener`, `agency-os-discovery`

Public URL after operator run: `https://agency-os.betteruptime.com` (subdomain overridable via `AGENCY_OS_BETTERSTACK_STATUS_SUBDOMAIN`).

## Empirical API ratification (probes 2026-05-12)

- `POST /status-pages` requires `{company_name, company_url, contact_url, subdomain, timezone}` — 201 returns page_id. Free-tier supported.
- BS auto-attaches the first monitor on page creation. Idempotent attach loop reconciles by `(resource_id, resource_type)` so no duplicates.
- `POST /status-pages/{id}/resources` accepts `{resource_id, resource_type, public_name}`. 201 returns full record + 90-day status_history.
- `resource_type="Monitor"` verified working. `"Heartbeat"` attempted empirically — if BS rejects on heartbeat type, script logs SKIP and continues (fail-graceful per operator-script discipline).

## Idempotency contract (tested)

| Function | Behaviour |
|---|---|
| `ensure_page` | Match by subdomain → return existing; else POST new |
| `attach_resource` | Skip if `(resource_id, resource_type)` already in `/resources` list; else POST new |

## Tests (8/8 pass, ruff clean)

- `ensure_page` subdomain-match path: no POST when matching
- `ensure_page` no-match POSTs with correct body
- `attach_resource` skips when already present
- `attach_resource` POSTs when missing
- `attach_resource` distinguishes types (Monitor vs Heartbeat with shared `resource_id` numeric value doesn't false-positive)
- `_by_name` matches `pronounceable_name` (Monitor attr)
- `_by_heartbeat_name` matches `name` (Heartbeat attr, different from Monitor)
- `main` returns 2 on missing API key

```
$ pytest tests/orchestrator/test_betterstack_status_page.py -v
============================== 8 passed in 0.16s ===============================
```

## Better Stack bundle close-out

| PR | Scope | Status |
|---|---|---|
| ~~PR-A (#785)~~ | Heartbeats + polling-loop wire-in | MERGED |
| ~~PR-B (#786 + #788 fix)~~ | Uptime monitors + 422 fix | MERGED |
| ~~PR-C (#796 verify-only)~~ | Slack-routing readiness | MERGED |
| **PR-D (this)** | Public status page | OPEN |

GOV-9 deferred (out of scope, documented):
- Vultr health endpoint (no default external URL)
- Cognee localhost (port 8000 not external)
- PR-C-v2 policy wire-in (waiting on operator OAuth dance per `docs/runbooks/betterstack-slack-routing.md`)

## Test plan

- [x] `pytest tests/orchestrator/test_betterstack_status_page.py` — 8/8
- [x] `ruff check` — clean
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Post-merge: Elliot runs `python3 scripts/orchestrator/betterstack_status_page.py`, opens the public URL, confirms 8 resources visible (or partial-visible if Heartbeat resource_type empirically rejected — script logs SKIP either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)