### PR TITLE
[AIDEN] feat(observability): Better Stack routing policy phase-1 (PR-C-v2)

### DIFF
--- a/docs/runbooks/betterstack-slack-routing.md
+++ b/docs/runbooks/betterstack-slack-routing.md
@@ -41,10 +41,33 @@ Defense in depth. Email is the BS default and survives Slack app outages. Slack 
 
 The integration is a one-time setup (per-workspace), not a recurring check. The verify-only script is an operator-invoked diagnostic, not a scheduled job. Running it on a timer would just produce noise once the integration exists.
 
+## PR-C-v2 phase 1 (shipped 2026-05-12)
+
+`scripts/orchestrator/betterstack_routing_policy.py` creates a single notification policy ("Agency OS — Critical incidents") with one escalation step targeting `all_slack_integrations`. Until the `#execution` integration exists, that's only the `#ceo` one (id 102756) — so phase-1 routes critical incidents to `#ceo`, matching the first arm of Dave's spec.
+
+Empirical schema (probed against BS v2 + docs at `betterstack.com/docs/uptime/api/escalation-policies/`):
+
+```json
+{
+  "name": "Agency OS — Critical incidents",
+  "steps": [{
+    "type": "escalation",
+    "wait_before": 0,
+    "urgency_id": <created via POST /urgencies>,
+    "step_members": [{"type": "all_slack_integrations"}]
+  }]
+}
+```
+
+## PR-C-v2 phase 2 (gated on OAuth from §steps above)
+
+When the operator OAuth dance creates the `#execution` integration, re-run `betterstack_routing_policy.py`. It is idempotent — script picks up the new integration via `all_slack_integrations` automatically. To route resolved + routine to `#execution` ONLY (not `#ceo`), a separate policy + step targeting the specific integration is required; phase-2 will add that in a fast-follow PR.
+
 ## Related
 
 - `scripts/orchestrator/betterstack_setup.py` — heartbeats bootstrap (PR-A, merged)
 - `scripts/orchestrator/betterstack_uptime_monitors.py` — uptime monitors (PR-B, merged + PR #788 fixes)
-- `scripts/orchestrator/betterstack_slack_routing.py` — verify-only readiness check (PR-C, this file)
-- PR-C-v2 (future) — automated policy wire-in once OAuth done
-- PR-D — public status page (separate, planned)
+- `scripts/orchestrator/betterstack_slack_routing.py` — verify-only readiness check (PR-C, merged)
+- `scripts/orchestrator/betterstack_routing_policy.py` — automated policy wire-in (PR-C-v2 phase-1, this file)
+- `scripts/orchestrator/betterstack_status_page.py` — public status page (PR-D, merged)
+- PR-C-v3 (future) — second policy + integration-specific routing once OAuth done

--- a/scripts/orchestrator/betterstack_routing_policy.py
+++ b/scripts/orchestrator/betterstack_routing_policy.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""betterstack_routing_policy.py — Better Stack notification policy wire-in.
+
+PR-C-v2 of the Better Stack bundle. Creates a Better Stack notification
+policy that routes incidents to all configured Slack integrations + applies
+the policy to all 5 heartbeats (PR-A) and 3 uptime monitors (PR-B).
+
+Per Dave directive ts ~1778618200: critical incidents → #ceo. Routine
++ resolved → #execution (phase 2, gated on a SECOND Slack integration
+that does not yet exist).
+
+Phase 1 (THIS script):
+  - Creates / reuses one urgency profile (name="Agency OS — Critical").
+  - Creates / reuses one policy (name="Agency OS — Critical incidents")
+    with a single escalation step: wait_before=0, urgency_id=<above>,
+    step_members=[{type: all_slack_integrations}].
+  - PATCHes policy_id onto all 3 uptime monitors + 5 heartbeats.
+  - Result: BS routes incident-creation events on those resources through
+    every Slack integration the team has — currently only the #ceo one
+    (id 102756) per BS dashboard state.
+
+Phase 2 (separate fast-follow, gated on Dave OAuth):
+  - When operator runs BS Slack OAuth pointing at #execution, this script
+    re-runs and (when phase-2 enabled) creates a SECOND policy +
+    second urgency for "Routine + Resolved" with step_members targeting
+    the #execution integration specifically.
+  - Until that integration exists, phase-2 logic is dormant — script logs
+    the gate and skips.
+
+Idempotency contract:
+  - Urgency matched by `name`. Reused if present, created otherwise.
+  - Policy matched by `name`. Reused if present; PATCHed if step drift
+    detected. Steps drift = step type or urgency_id or member type
+    differs.
+  - Resource policy_id matched by `policy_id` on each monitor/heartbeat
+    attribute. PATCH-set only if missing or different.
+
+Schema source (BS docs probed 2026-05-12 via 14-curl probe):
+    https://betterstack.com/docs/uptime/api/escalation-policies/
+
+Working policy create body:
+    {"name":"X","steps":[{"type":"escalation","wait_before":0,
+                          "urgency_id":<id>,
+                          "step_members":[{"type":"all_slack_integrations"}]}]}
+
+Usage:
+    BETTERSTACK_API_KEY=<key> python3 scripts/orchestrator/betterstack_routing_policy.py
+
+Env overrides (tests + alt names):
+    AGENCY_OS_BETTERSTACK_API_BASE — API root
+    AGENCY_OS_BETTERSTACK_POLICY_NAME — policy name (default "Agency OS — Critical incidents")
+    AGENCY_OS_BETTERSTACK_URGENCY_NAME — urgency name (default "Agency OS — Critical")
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API_BASE_DEFAULT = "https://uptime.betterstack.com/api/v2"
+
+DEFAULT_POLICY_NAME = "Agency OS — Critical incidents"
+DEFAULT_URGENCY_NAME = "Agency OS — Critical"
+
+# Resource names to apply the policy to (must match PR-A heartbeats + PR-B monitors).
+MONITOR_NAMES: tuple[str, ...] = ("agencyxos.ai", "supabase-rest", "railway-prefect")
+HEARTBEAT_NAMES: tuple[str, ...] = (
+    "elliot-polling-loop",
+    "cognee-phase1-ingest",
+    "prefect-pipeline",
+    "central-listener",
+    "agency-os-discovery",
+)
+
+
+def _api_base() -> str:
+    return os.environ.get("AGENCY_OS_BETTERSTACK_API_BASE", API_BASE_DEFAULT)
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+
+def _request(method: str, path: str, api_key: str, body: dict | None = None) -> dict | None:
+    url = f"{_api_base()}{path}"
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(url, data=data, headers=_auth_headers(api_key), method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read() or "null")
+    except urllib.error.HTTPError as exc:
+        body_text = exc.read().decode(errors="replace") if exc.fp else ""
+        print(f"[bs-routing] HTTP {exc.code} on {method} {url}: {body_text[:200]}", file=sys.stderr)
+        return None
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+        print(f"[bs-routing] network/parse error on {method} {url}: {exc}", file=sys.stderr)
+        return None
+
+
+def ensure_urgency(api_key: str, name: str) -> dict | None:
+    """Find by name or POST. Email-on, push/sms/call off (Slack covers the rest)."""
+    resp = _request("GET", "/urgencies?per_page=100", api_key)
+    for u in (resp or {}).get("data", []) or []:
+        if u.get("attributes", {}).get("name") == name:
+            return u
+    body = {"name": name, "email": True, "push": False, "sms": False, "call": False}
+    return (_request("POST", "/urgencies", api_key, body) or {}).get("data")
+
+
+def _step_drift(existing_steps: list[dict], desired_urgency_id: int) -> bool:
+    """True iff the policy's steps don't match our desired single-escalation step."""
+    if len(existing_steps) != 1:
+        return True
+    s = existing_steps[0]
+    if s.get("type") != "escalation":
+        return True
+    if s.get("urgency_id") != desired_urgency_id:
+        return True
+    members = s.get("step_members") or []
+    return not (len(members) == 1 and members[0].get("type") == "all_slack_integrations")
+
+
+def ensure_policy(api_key: str, name: str, urgency_id: int) -> dict | None:
+    """Match by name. Create if missing; PATCH if step drift."""
+    resp = _request("GET", "/policies?per_page=100", api_key)
+    existing = (resp or {}).get("data", []) or []
+    step = {
+        "type": "escalation",
+        "wait_before": 0,
+        "urgency_id": urgency_id,
+        "step_members": [{"type": "all_slack_integrations"}],
+    }
+    for p in existing:
+        if p.get("attributes", {}).get("name") == name:
+            if not _step_drift(p.get("attributes", {}).get("steps") or [], urgency_id):
+                return p
+            return (_request("PATCH", f"/policies/{p.get('id')}", api_key, {"steps": [step]}) or {}).get("data") or p
+    return (_request("POST", "/policies", api_key, {"name": name, "steps": [step]}) or {}).get("data")
+
+
+def apply_policy_to_monitor(api_key: str, monitor_id: str, policy_id: int) -> bool:
+    """PATCH monitor.policy_id if missing/different. Returns True if changed."""
+    cur = _request("GET", f"/monitors/{monitor_id}", api_key)
+    if (cur or {}).get("data", {}).get("attributes", {}).get("policy_id") == policy_id:
+        return False
+    return _request("PATCH", f"/monitors/{monitor_id}", api_key, {"policy_id": policy_id}) is not None
+
+
+def apply_policy_to_heartbeat(api_key: str, hb_id: str, policy_id: int) -> bool:
+    cur = _request("GET", f"/heartbeats/{hb_id}", api_key)
+    if (cur or {}).get("data", {}).get("attributes", {}).get("policy_id") == policy_id:
+        return False
+    return _request("PATCH", f"/heartbeats/{hb_id}", api_key, {"policy_id": policy_id}) is not None
+
+
+def list_monitors(api_key: str) -> list[dict]:
+    return (_request("GET", "/monitors?per_page=100", api_key) or {}).get("data", []) or []
+
+
+def list_heartbeats(api_key: str) -> list[dict]:
+    return (_request("GET", "/heartbeats?per_page=100", api_key) or {}).get("data", []) or []
+
+
+def _find(records: list[dict], name: str, attr: str) -> dict | None:
+    return next((r for r in records if r.get("attributes", {}).get(attr) == name), None)
+
+
+def main() -> int:
+    api_key = os.environ.get("BETTERSTACK_API_KEY", "").strip()
+    if not api_key:
+        print("ERROR: BETTERSTACK_API_KEY env not set", file=sys.stderr)
+        return 2
+
+    policy_name = os.environ.get("AGENCY_OS_BETTERSTACK_POLICY_NAME", DEFAULT_POLICY_NAME)
+    urgency_name = os.environ.get("AGENCY_OS_BETTERSTACK_URGENCY_NAME", DEFAULT_URGENCY_NAME)
+
+    print("# Better Stack routing policy — operator review", file=sys.stderr)
+    urgency = ensure_urgency(api_key, urgency_name)
+    if not urgency:
+        print("# ERROR: urgency create/fetch failed", file=sys.stderr)
+        return 1
+    urgency_id = int(urgency["id"])
+    print(f"#   urgency '{urgency_name}' id={urgency_id}", file=sys.stderr)
+
+    policy = ensure_policy(api_key, policy_name, urgency_id)
+    if not policy:
+        print("# ERROR: policy create/fetch failed", file=sys.stderr)
+        return 1
+    policy_id = int(policy["id"])
+    print(f"#   policy  '{policy_name}' id={policy_id}", file=sys.stderr)
+
+    monitors = list_monitors(api_key)
+    heartbeats = list_heartbeats(api_key)
+
+    applied = 0
+    for mon in MONITOR_NAMES:
+        m = _find(monitors, mon, "pronounceable_name")
+        if not m:
+            print(f"#   SKIP monitor '{mon}' — not found in BS", file=sys.stderr)
+            continue
+        if apply_policy_to_monitor(api_key, m["id"], policy_id):
+            applied += 1
+            print(f"#   applied policy to monitor '{mon}' (id={m['id']})", file=sys.stderr)
+    for hb in HEARTBEAT_NAMES:
+        h = _find(heartbeats, hb, "name")
+        if not h:
+            print(f"#   SKIP heartbeat '{hb}' — not found in BS", file=sys.stderr)
+            continue
+        if apply_policy_to_heartbeat(api_key, h["id"], policy_id):
+            applied += 1
+            print(f"#   applied policy to heartbeat '{hb}' (id={h['id']})", file=sys.stderr)
+
+    print(f"# done — {applied} resource(s) PATCHed; existing routed unchanged.", file=sys.stderr)
+    print(
+        "# Phase 2 gate: routine + resolved → #execution requires a SECOND Slack\n"
+        "# integration via BS Slack OAuth (Dave action). See\n"
+        "# docs/runbooks/betterstack-slack-routing.md.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/orchestrator/test_betterstack_routing_policy.py
+++ b/tests/orchestrator/test_betterstack_routing_policy.py
@@ -1,0 +1,228 @@
+"""Tests for scripts/orchestrator/betterstack_routing_policy.py — PR-C-v2.
+
+Idempotency contract:
+  - ensure_urgency: match by name; create if missing.
+  - ensure_policy: match by name; PATCH if step drift; POST if missing.
+  - _step_drift: detect mismatch on len/type/urgency_id/member_type.
+  - apply_policy_to_*: PATCH only if policy_id missing/different.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "orchestrator" / "betterstack_routing_policy.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("bs_routing", SCRIPT_PATH)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["bs_routing"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+# _step_drift ─────────────────────────────────────────────────────────────────
+
+
+def test_step_drift_correct_step_returns_false(mod):
+    steps = [
+        {
+            "type": "escalation",
+            "urgency_id": 42,
+            "step_members": [{"type": "all_slack_integrations"}],
+        }
+    ]
+    assert mod._step_drift(steps, 42) is False
+
+
+def test_step_drift_wrong_urgency_returns_true(mod):
+    steps = [
+        {
+            "type": "escalation",
+            "urgency_id": 42,
+            "step_members": [{"type": "all_slack_integrations"}],
+        }
+    ]
+    assert mod._step_drift(steps, 999) is True
+
+
+def test_step_drift_no_steps_returns_true(mod):
+    assert mod._step_drift([], 42) is True
+
+
+def test_step_drift_wrong_type_returns_true(mod):
+    steps = [{"type": "time_branching", "urgency_id": 42, "step_members": []}]
+    assert mod._step_drift(steps, 42) is True
+
+
+def test_step_drift_wrong_member_type_returns_true(mod):
+    steps = [
+        {
+            "type": "escalation",
+            "urgency_id": 42,
+            "step_members": [{"type": "current_on_call"}],
+        }
+    ]
+    assert mod._step_drift(steps, 42) is True
+
+
+def test_step_drift_too_many_steps_returns_true(mod):
+    steps = [
+        {"type": "escalation", "urgency_id": 42, "step_members": [{"type": "all_slack_integrations"}]},
+        {"type": "escalation", "urgency_id": 42, "step_members": [{"type": "all_slack_integrations"}]},
+    ]
+    assert mod._step_drift(steps, 42) is True
+
+
+# ensure_urgency ──────────────────────────────────────────────────────────────
+
+
+def test_ensure_urgency_reuses_existing(mod, monkeypatch):
+    calls: list[tuple] = []
+
+    def _fake_request(method, path, api_key, body=None):
+        calls.append((method, path))
+        if path.startswith("/urgencies?per_page"):
+            return {"data": [{"id": "100", "attributes": {"name": "Critical"}}]}
+        raise AssertionError("should not POST when urgency exists")
+
+    monkeypatch.setattr(mod, "_request", _fake_request)
+    result = mod.ensure_urgency("k", "Critical")
+    assert result is not None
+    assert result["id"] == "100"
+    assert all(c[0] == "GET" for c in calls)
+
+
+def test_ensure_urgency_creates_when_missing(mod, monkeypatch):
+    captured_body: dict | None = None
+
+    def _fake_request(method, path, api_key, body=None):
+        nonlocal captured_body
+        if path == "/urgencies?per_page=100":
+            return {"data": []}
+        if method == "POST" and path == "/urgencies":
+            captured_body = body
+            return {"data": {"id": "200", "attributes": body}}
+        return None
+
+    monkeypatch.setattr(mod, "_request", _fake_request)
+    result = mod.ensure_urgency("k", "Critical")
+    assert result is not None
+    assert result["id"] == "200"
+    assert captured_body == {"name": "Critical", "email": True, "push": False, "sms": False, "call": False}
+
+
+# ensure_policy ───────────────────────────────────────────────────────────────
+
+
+def test_ensure_policy_reuses_when_correct(mod, monkeypatch):
+    existing_step = {
+        "type": "escalation",
+        "urgency_id": 42,
+        "step_members": [{"type": "all_slack_integrations"}],
+    }
+    calls: list[tuple] = []
+
+    def _fake_request(method, path, api_key, body=None):
+        calls.append((method, path))
+        if path == "/policies?per_page=100":
+            return {
+                "data": [
+                    {"id": "300", "attributes": {"name": "Critical", "steps": [existing_step]}},
+                ]
+            }
+        raise AssertionError(f"no further calls expected: {method} {path}")
+
+    monkeypatch.setattr(mod, "_request", _fake_request)
+    result = mod.ensure_policy("k", "Critical", 42)
+    assert result is not None
+    assert result["id"] == "300"
+
+
+def test_ensure_policy_patches_on_drift(mod, monkeypatch):
+    stale = {"type": "escalation", "urgency_id": 99, "step_members": []}
+    captured: list[tuple] = []
+
+    def _fake_request(method, path, api_key, body=None):
+        captured.append((method, path, body))
+        if path == "/policies?per_page=100":
+            return {"data": [{"id": "301", "attributes": {"name": "Critical", "steps": [stale]}}]}
+        if method == "PATCH":
+            return {"data": {"id": "301", "attributes": {"steps": body["steps"]}}}
+        return None
+
+    monkeypatch.setattr(mod, "_request", _fake_request)
+    result = mod.ensure_policy("k", "Critical", 42)
+    assert result is not None
+    patches = [c for c in captured if c[0] == "PATCH"]
+    assert len(patches) == 1
+    assert patches[0][1] == "/policies/301"
+
+
+def test_ensure_policy_creates_when_missing(mod, monkeypatch):
+    captured: list[tuple] = []
+
+    def _fake_request(method, path, api_key, body=None):
+        captured.append((method, path, body))
+        if path == "/policies?per_page=100":
+            return {"data": []}
+        if method == "POST" and path == "/policies":
+            return {"data": {"id": "302", "attributes": body}}
+        return None
+
+    monkeypatch.setattr(mod, "_request", _fake_request)
+    result = mod.ensure_policy("k", "Critical", 42)
+    assert result is not None
+    posts = [c for c in captured if c[0] == "POST"]
+    assert len(posts) == 1
+    assert posts[0][2]["name"] == "Critical"
+    step = posts[0][2]["steps"][0]
+    assert step["type"] == "escalation"
+    assert step["urgency_id"] == 42
+    assert step["step_members"] == [{"type": "all_slack_integrations"}]
+
+
+# apply_policy_to_monitor ─────────────────────────────────────────────────────
+
+
+def test_apply_policy_to_monitor_skips_if_already_set(mod, monkeypatch):
+    def _fake_request(method, path, api_key, body=None):
+        if method == "GET":
+            return {"data": {"attributes": {"policy_id": 42}}}
+        raise AssertionError("must not PATCH when policy_id already matches")
+
+    monkeypatch.setattr(mod, "_request", _fake_request)
+    assert mod.apply_policy_to_monitor("k", "4400037", 42) is False
+
+
+def test_apply_policy_to_monitor_patches_when_unset(mod, monkeypatch):
+    captured: list[tuple] = []
+
+    def _fake_request(method, path, api_key, body=None):
+        captured.append((method, path, body))
+        if method == "GET":
+            return {"data": {"attributes": {"policy_id": None}}}
+        if method == "PATCH":
+            return {"data": {"attributes": {"policy_id": 42}}}
+        return None
+
+    monkeypatch.setattr(mod, "_request", _fake_request)
+    assert mod.apply_policy_to_monitor("k", "4400037", 42) is True
+    patches = [c for c in captured if c[0] == "PATCH"]
+    assert len(patches) == 1
+    assert patches[0][2] == {"policy_id": 42}
+
+
+# main ────────────────────────────────────────────────────────────────────────
+
+
+def test_main_missing_api_key_returns_2(mod, monkeypatch):
+    monkeypatch.delenv("BETTERSTACK_API_KEY", raising=False)
+    assert mod.main() == 2


### PR DESCRIPTION
## Summary

PR-C-v2 phase-1: idempotent BS notification policy that routes incidents on all 8 BS resources (3 monitors + 5 heartbeats) through Slack integrations. Currently only the `#ceo` integration (id 102756) exists, so critical incidents route to `#ceo` — first arm of Dave's spec ts ~1778618200 satisfied immediately. Phase-2 gates on Dave OAuth for a second integration pointing at `#execution`.

## Empirical schema ratification

14 curl probes 2026-05-12 against the BS v2 API. The prior 422 ("allowed_values: type=slack") on PR-C was because those aren't the right step types. The correct shape per `betterstack.com/docs/uptime/api/escalation-policies/`:

```json
{
  "name": "Agency OS — Critical incidents",
  "steps": [{
    "type": "escalation",
    "wait_before": 0,
    "urgency_id": <created via POST /urgencies>,
    "step_members": [{"type": "all_slack_integrations"}]
  }]
}
```

Probe 14 returned 201 with policy id 114144 (cleaned up). Schema accepted.

## Idempotency contract (14/14 tests pass)

| Function | Behaviour |
|---|---|
| `ensure_urgency` | Match by name; POST if missing |
| `ensure_policy` | Match by name; PATCH if step drift; POST if missing |
| `_step_drift` | Detect mismatch on `len(steps)`, `step.type`, `urgency_id`, member type |
| `apply_policy_to_monitor` | PATCH `policy_id` only if missing/different |
| `apply_policy_to_heartbeat` | Same shape; for `/heartbeats/{id}` |

```
$ pytest tests/orchestrator/test_betterstack_routing_policy.py -v
============================== 14 passed in 0.44s ==============================
```

Ruff clean.

## Phase-2 gate

Routine + resolved → `#execution` is Dave's second arm. Each BS Slack integration is bound to one channel and integration creation requires the BS dashboard's Slack OAuth flow (no API path). Until that integration exists, the script's `all_slack_integrations` member targets only `#ceo`. Once OAuth done:

- Re-running this script picks up the new integration automatically via `all_slack_integrations`.
- For #execution-specific routing of routine+resolved (not #ceo), a separate policy + integration-specific step_members is the **PR-C-v3** follow-up.

Documented in `docs/runbooks/betterstack-slack-routing.md` (updated in this PR).

## Operator handoff

Post-merge: Elliot runs `python3 scripts/orchestrator/betterstack_routing_policy.py`. Expected output:

```
# Better Stack routing policy — operator review
#   urgency 'Agency OS — Critical' id=<X>
#   policy  'Agency OS — Critical incidents' id=<Y>
#   applied policy to monitor 'agencyxos.ai' (id=4400037)
#   applied policy to monitor 'supabase-rest' (id=4400118)
#   applied policy to monitor 'railway-prefect' (id=4400119)
#   applied policy to heartbeat 'elliot-polling-loop' (id=459824)
#   ...5 heartbeats total...
# done — 8 resource(s) PATCHed; existing routed unchanged.
```

Re-run is a no-op (idempotent).

## Queue context

- ~~PR-C verify-only (#796)~~ — MERGED
- **PR-C-v2 phase-1 (this PR)** — open
- Rate-limit detection in polling loop (NEW P1 per Dave ts ~1778619750) — next after this merges
- PR-C-v3 phase-2 routing — gated on Dave OAuth + emerges from operator handoff above

## Test plan

- [x] `pytest tests/orchestrator/test_betterstack_routing_policy.py` — 14/14
- [x] `ruff check` — clean
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Post-merge: Elliot runs script + smoke-tests one resource (curl-fail a heartbeat, expect Slack #ceo post within 60s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)