### PR TITLE
[AIDEN] feat(orchestrator): polling-loop rate-limit detection (Dave P1)

### DIFF
--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -35,11 +35,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -77,15 +78,50 @@ INBOX_PATHS: dict[str, str] = {
 }
 
 
+# tmux session name per callsign (empirical 2026-05-12: elliot+max sessions
+# are named with -bot suffix; clones + aiden use bare callsign).
+CALLSIGN_TO_TMUX: dict[str, str] = {
+    "elliot": "elliottbot",
+    "aiden": "aiden",
+    "max": "maxbot",
+    "atlas": "atlas",
+    "orion": "orion",
+    "scout": "scout",
+}
+
+# Anthropic throttle signal patterns. Case-insensitive substring match on the
+# last 10 lines of the agent's tmux pane. Anchored loosely — agents writing
+# the string 'rate limit' into source code mid-edit will trip false positives,
+# but the alternative is missing the actual throttle. Acceptable tradeoff per
+# Dave directive ts ~1778619750.
+THROTTLE_PATTERNS: tuple[str, ...] = (
+    r"rate limit",
+    r"\b429\b",
+    r"retry-?after",
+    r"brewed for",
+)
+THROTTLE_RE = re.compile("|".join(THROTTLE_PATTERNS), re.IGNORECASE)
+
+
 @dataclass
 class CycleSignals:
     bd_ready: list[dict]
     linear_stale: list[dict]
     idle_agents: list[str]
     prefect_failures: list[dict]
+    rate_limit_transitions: list[tuple[str, str, int]] = field(default_factory=list)
+    """List of (callsign, transition, duration_min) where transition is
+    'throttled' (first detection) or 'resumed' (clearing detection). Duration
+    is minutes-since-throttle-start for 'resumed' (0 for 'throttled')."""
 
     def is_silent(self) -> bool:
-        return not (self.bd_ready or self.linear_stale or self.idle_agents or self.prefect_failures)
+        return not (
+            self.bd_ready
+            or self.linear_stale
+            or self.idle_agents
+            or self.prefect_failures
+            or self.rate_limit_transitions
+        )
 
 
 # Time-of-day gate ───────────────────────────────────────────────────────────
@@ -240,6 +276,98 @@ def poll_prefect_failures(now: datetime | None = None) -> list[dict]:
         return []
 
 
+# Rate-limit detection ───────────────────────────────────────────────────────
+#
+# Per Dave directive ts ~1778619750. Poll each callsign's tmux pane for
+# Anthropic throttle signals; emit (callsign, transition, duration_min) on
+# state change. State persists across cycles via JSON file at /tmp/...
+#
+# State machine:
+#   (prev=clean, current=clean)      → no-op
+#   (prev=clean, current=throttled)  → emit ('throttled', 0); record start ts
+#   (prev=throttled, current=throttled) → no-op (already alerted)
+#   (prev=throttled, current=clean)  → emit ('resumed', duration_min); clear
+
+_THROTTLE_STATE_PATH_DEFAULT = "/tmp/elliot-polling-loop-throttle-state.json"  # NOSONAR — canonical state path for systemd-user loop, not user-supplied
+
+
+def _throttle_state_path() -> str:
+    return os.environ.get("AGENCY_OS_THROTTLE_STATE_PATH", _THROTTLE_STATE_PATH_DEFAULT)
+
+
+def _load_throttle_state() -> dict[str, str]:
+    """Return {callsign: throttled_since_iso}. Empty dict on missing/corrupt file."""
+    p = Path(_throttle_state_path())
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text() or "{}")
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("throttle state load failed: %s", exc)
+        return {}
+
+
+def _save_throttle_state(state: dict[str, str]) -> None:
+    p = Path(_throttle_state_path())
+    try:
+        p.write_text(json.dumps(state, indent=2, sort_keys=True))
+    except OSError as exc:
+        logger.warning("throttle state save failed: %s", exc)
+
+
+def _capture_pane_tail(session: str, lines: int = 10) -> str:
+    try:
+        proc = subprocess.run(  # noqa: S603 — controlled args, no shell
+            ["tmux", "capture-pane", "-t", f"{session}:0", "-p"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    out_lines = proc.stdout.splitlines()
+    return "\n".join(out_lines[-lines:])
+
+
+def poll_rate_limited_agents(
+    now: datetime | None = None,
+) -> list[tuple[str, str, int]]:
+    """Return list of (callsign, transition, duration_min) for THIS cycle.
+
+    transition ∈ {'throttled', 'resumed'}. duration_min is 0 for 'throttled'
+    and minutes-since-throttle-start for 'resumed'.
+    """
+    ts_now = now or datetime.now(UTC)
+    prior = _load_throttle_state()
+    next_state = dict(prior)
+    transitions: list[tuple[str, str, int]] = []
+
+    for callsign, session in CALLSIGN_TO_TMUX.items():
+        tail = _capture_pane_tail(session)
+        is_throttled = bool(THROTTLE_RE.search(tail)) if tail else False
+        prev_throttled_since = prior.get(callsign)
+
+        if is_throttled and not prev_throttled_since:
+            transitions.append((callsign, "throttled", 0))
+            next_state[callsign] = ts_now.isoformat()
+        elif not is_throttled and prev_throttled_since:
+            try:
+                start = datetime.fromisoformat(prev_throttled_since)
+                duration_min = max(0, int((ts_now - start).total_seconds() // 60))
+            except ValueError:
+                duration_min = 0
+            transitions.append((callsign, "resumed", duration_min))
+            next_state.pop(callsign, None)
+        # else: no transition
+
+    if next_state != prior:
+        _save_throttle_state(next_state)
+
+    return transitions
+
+
 # Aggregator + dispatcher ────────────────────────────────────────────────────
 
 
@@ -249,6 +377,7 @@ def collect_signals(now: datetime | None = None) -> CycleSignals:
         linear_stale=poll_linear_stale(now),
         idle_agents=poll_idle_agents(now),
         prefect_failures=poll_prefect_failures(now),
+        rate_limit_transitions=poll_rate_limited_agents(now),
     )
 
 
@@ -311,6 +440,29 @@ def compose_dispatches(signals: CycleSignals) -> list[tuple[str, str]]:
             + "\nIntent: create Linear KEI tagged pipeline-incident (manual until Linear MCP write wired)."
         )
         dispatches.append((CEO_CHANNEL_NAME, msg))
+
+    if signals.rate_limit_transitions:
+        throttled = [
+            (cs, dur) for cs, t, dur in signals.rate_limit_transitions if t == "throttled"
+        ]
+        resumed = [
+            (cs, dur) for cs, t, dur in signals.rate_limit_transitions if t == "resumed"
+        ]
+        if throttled:
+            names = ", ".join(cs for cs, _ in throttled)
+            msg = (
+                f"[PROPOSE:elliot] Anthropic throttle detected — {len(throttled)} agent(s): {names}.\n"
+                f"Throttle signal grep on tmux pane tail (rate limit / 429 / retry-after / brewed). "
+                f"Agents will resume on next clean cycle; this is informational not actionable."
+            )
+            dispatches.append((CEO_CHANNEL_NAME, msg))
+        if resumed:
+            lines = [f"  - {cs} resumed after {dur}m throttle" for cs, dur in resumed]
+            msg = (
+                f"[PROPOSE:elliot] Anthropic throttle cleared — {len(resumed)} agent(s):\n"
+                + "\n".join(lines)
+            )
+            dispatches.append((CEO_CHANNEL_NAME, msg))
 
     return dispatches
 

--- a/tests/scripts/test_elliot_polling_loop.py
+++ b/tests/scripts/test_elliot_polling_loop.py
@@ -12,6 +12,7 @@ run without bd, Linear, Prefect, asyncpg, or Slack. The script's contract:
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -423,3 +424,87 @@ def test_send_dispatch_inbox_missing_dir_drops_quietly(loop_mod, monkeypatch, tm
 def test_send_dispatch_unknown_inbox_callsign_drops(loop_mod):
     """inbox:<unmapped> drops quietly (best-effort)."""
     loop_mod.send_dispatch("inbox:unknown_callsign", "text")  # no raise
+
+
+# Rate-limit detection (Dave P1 directive ts ~1778619750) ────────────────────
+
+
+def _stub_capture_pane(loop_mod, monkeypatch, output_per_session: dict[str, str]):
+    """Patch _capture_pane_tail to return scripted output per session-name."""
+    def _fake(session, lines=10):
+        return output_per_session.get(session, "")
+    monkeypatch.setattr(loop_mod, "_capture_pane_tail", _fake)
+
+
+def test_poll_rate_limited_clean_to_clean_no_transition(loop_mod, monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENCY_OS_THROTTLE_STATE_PATH", str(tmp_path / "state.json"))
+    _stub_capture_pane(loop_mod, monkeypatch, {})  # all empty (clean)
+    assert loop_mod.poll_rate_limited_agents() == []
+
+
+def test_poll_rate_limited_clean_to_throttled_emits(loop_mod, monkeypatch, tmp_path):
+    state_path = tmp_path / "state.json"
+    monkeypatch.setenv("AGENCY_OS_THROTTLE_STATE_PATH", str(state_path))
+    _stub_capture_pane(
+        loop_mod,
+        monkeypatch,
+        {"aiden": "Working on PR...\nrate limit reached. retry-after 60\n"},
+    )
+    out = loop_mod.poll_rate_limited_agents(now=datetime(2026, 5, 12, 22, 0, tzinfo=UTC))
+    assert ("aiden", "throttled", 0) in out
+    assert state_path.exists()
+    state = json.loads(state_path.read_text())
+    assert "aiden" in state
+
+
+def test_poll_rate_limited_throttled_to_throttled_no_emit(loop_mod, monkeypatch, tmp_path):
+    state_path = tmp_path / "state.json"
+    monkeypatch.setenv("AGENCY_OS_THROTTLE_STATE_PATH", str(state_path))
+    state_path.write_text(json.dumps({"aiden": "2026-05-12T22:00:00+00:00"}))
+    _stub_capture_pane(
+        loop_mod,
+        monkeypatch,
+        {"aiden": "still rate limit-ed, brewed for 30 more seconds"},
+    )
+    out = loop_mod.poll_rate_limited_agents(now=datetime(2026, 5, 12, 22, 5, tzinfo=UTC))
+    assert out == []
+
+
+def test_poll_rate_limited_throttled_to_clean_emits_resumed(loop_mod, monkeypatch, tmp_path):
+    state_path = tmp_path / "state.json"
+    monkeypatch.setenv("AGENCY_OS_THROTTLE_STATE_PATH", str(state_path))
+    state_path.write_text(json.dumps({"aiden": "2026-05-12T22:00:00+00:00"}))
+    _stub_capture_pane(loop_mod, monkeypatch, {})  # clean now
+    out = loop_mod.poll_rate_limited_agents(now=datetime(2026, 5, 12, 22, 15, tzinfo=UTC))
+    # Resumed event for aiden with 15-min duration
+    assert any(t for t in out if t[0] == "aiden" and t[1] == "resumed" and t[2] == 15)
+    state = json.loads(state_path.read_text())
+    assert "aiden" not in state
+
+
+def test_poll_rate_limited_pattern_429_matches(loop_mod, monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENCY_OS_THROTTLE_STATE_PATH", str(tmp_path / "state.json"))
+    _stub_capture_pane(loop_mod, monkeypatch, {"orion": "HTTP 429 Too Many Requests"})
+    out = loop_mod.poll_rate_limited_agents()
+    assert any(t[0] == "orion" and t[1] == "throttled" for t in out)
+
+
+def test_compose_dispatches_throttle_transitions_to_ceo(loop_mod):
+    sig = loop_mod.CycleSignals(
+        bd_ready=[],
+        linear_stale=[],
+        idle_agents=[],
+        prefect_failures=[],
+        rate_limit_transitions=[
+            ("aiden", "throttled", 0),
+            ("orion", "resumed", 12),
+        ],
+    )
+    dispatches = loop_mod.compose_dispatches(sig)
+    # Two #ceo dispatches: one throttled-list, one resumed-list.
+    ceo_msgs = [m for chan, m in dispatches if chan == "#ceo"]
+    assert len(ceo_msgs) == 2
+    throttled_msg = next(m for m in ceo_msgs if "throttle detected" in m)
+    assert "aiden" in throttled_msg
+    resumed_msg = next(m for m in ceo_msgs if "throttle cleared" in m)
+    assert "orion resumed after 12m" in resumed_msg


### PR DESCRIPTION
## Summary

Per Dave directive ts ~1778619750 + Elliot Step 0 GO: poll each agent's tmux pane for Anthropic throttle signals; emit `[PROPOSE:elliot]` to `#ceo` on `(clean→throttled)` and `(throttled→clean)` transitions.

## Mechanism

- `tmux capture-pane -t <session>:0 -p | tail -10` per callsign.
- Regex grep: `rate limit` | `\b429\b` | `retry-?after` | `brewed for` (case-insensitive).
- JSON state at `/tmp/elliot-polling-loop-throttle-state.json` (env-overridable `AGENCY_OS_THROTTLE_STATE_PATH` for tests).
- State machine:

| prev | current | action |
|------|---------|--------|
| clean | clean | no-op |
| clean | throttled | emit `('throttled', 0)`; record `now()` |
| throttled | throttled | no-op (already alerted) |
| throttled | clean | emit `('resumed', duration_min)`; clear state |

## Empirical session-name map

Cross-checked via `tmux list-sessions` 2026-05-12. Elliot's pre-confirm assumption stated `session-name=callsign` but **elliot+max sessions have `-bot` suffix** in practice:

| Callsign | tmux session |
|---|---|
| elliot | `elliottbot` |
| aiden | `aiden` |
| max | `maxbot` |
| atlas | `atlas` |
| orion | `orion` |
| scout | `scout` |

`CALLSIGN_TO_TMUX` dict in the script encodes this.

## Tests (36/36 pass, ruff clean)

6 new:
- `test_poll_rate_limited_clean_to_clean_no_transition`
- `test_poll_rate_limited_clean_to_throttled_emits` (state file written, fixture verifies)
- `test_poll_rate_limited_throttled_to_throttled_no_emit`
- `test_poll_rate_limited_throttled_to_clean_emits_resumed` (15-min duration verified)
- `test_poll_rate_limited_pattern_429_matches` (`HTTP 429` detection)
- `test_compose_dispatches_throttle_transitions_to_ceo` (two `#ceo` dispatches when both lists present)

```
$ pytest tests/scripts/test_elliot_polling_loop.py
============================== 36 passed in 0.52s ==============================
```

Ruff clean.

## Acknowledged tradeoff

Pattern matching on tmux pane tail can false-positive on the literal string `rate limit` appearing in source code mid-edit. The alternative is missing actual throttles. Per Dave directive the false-positive cost is acceptable; the alternative isn't.

## Queue context

- ~~PR #800 BS routing phase-1~~ MERGED
- **This PR — rate-limit detection P1 (Dave directive ts ~1778619750)**
- Next: Step 0 Linear↔Beads sync automation (Urgent — pre-empted by this only because rate-limit-detection was already at branch-stage with ~80 LoC + tests in flight)

## Test plan

- [x] `pytest tests/scripts/test_elliot_polling_loop.py` — 36/36
- [x] `ruff check` — clean
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Post-merge: Elliot triggers a fake throttle (`echo "rate limit reached" | tee >(cat) ...` into a worktree tmux pane) → expects `#ceo` post on next peak cycle; then clear → expects "resumed" post

🤖 Generated with [Claude Code](https://claude.com/claude-code)