### PR TITLE
[AIDEN] fix(orchestrator): loud auto-pull-main alerting + PEAK_HOURS_UTC log (Scout f42cc4d4)

### DIFF
--- a/scripts/auto_pull_main.sh
+++ b/scripts/auto_pull_main.sh
@@ -9,8 +9,14 @@
 #   - skip if rebase / merge / cherry-pick in progress (operator mid-flight)
 #   - else: git fetch origin main + git merge --ff-only origin/main
 #
-# All output goes to systemd-journal (no TG spam unless the user adds it).
-# Failures are non-fatal — the next 5-min cycle retries.
+# Loud SKIP alerting (added per Scout diagnosis f42cc4d4, Aiden PR ts ~1778620800):
+# Silent SKIPs masked the PR #782 peak-window staleness for >60 min on 2026-05-12.
+# Now: track consecutive-SKIP streak per worktree at
+#   $XDG_STATE_HOME/agency-os/auto-pull-main.<basename>.skip-streak
+# Reset to 0 on any non-SKIP outcome (PULLED/OK/FAIL). When streak crosses the
+# threshold (default 3 consecutive skips = 15 min stale), emit one Slack post
+# to #execution with the dirty/branch reason. Repeat-suppressed via flag file
+# so we don't spam every 5 min while staleness persists.
 #
 # Why this exists: 2026-05-09 session had two stale-main rebase incidents
 # (PR #657 force-push, smoke test ran on pre-#637 code) because the worktree
@@ -23,25 +29,94 @@ WORKTREES=(
     "/home/elliotbot/clawd/Agency_OS-aiden"
 )
 
+# Staleness alert config (env-overridable for tests).
+SKIP_ALERT_THRESHOLD="${AGENCY_OS_AUTO_PULL_SKIP_THRESHOLD:-3}"
+STATE_DIR="${AGENCY_OS_AUTO_PULL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/agency-os}"
+RELAY="${AGENCY_OS_AUTO_PULL_RELAY:-/home/elliotbot/clawd/Agency_OS/scripts/slack_relay.py}"
+
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+
+_state_path() {
+    # $1 = worktree path. Returns the streak-counter file path.
+    local basename
+    basename=$(echo "$1" | tr '/' '_' | sed 's/^_//')
+    echo "$STATE_DIR/auto-pull-main.${basename}.skip-streak"
+}
+
+_alerted_path() {
+    echo "$(_state_path "$1").alerted"
+}
+
+_streak_get() {
+    local f
+    f=$(_state_path "$1")
+    [ -f "$f" ] && cat "$f" 2>/dev/null || echo 0
+}
+
+_streak_inc() {
+    local f streak
+    f=$(_state_path "$1")
+    streak=$(_streak_get "$1")
+    streak=$((streak + 1))
+    echo "$streak" > "$f" 2>/dev/null || true
+}
+
+_streak_reset() {
+    rm -f "$(_state_path "$1")" "$(_alerted_path "$1")" 2>/dev/null || true
+}
+
+_emit_alert() {
+    # $1 = worktree, $2 = reason
+    local alerted_flag
+    alerted_flag=$(_alerted_path "$1")
+    [ -f "$alerted_flag" ] && return 0   # already alerted this streak
+    local streak msg
+    streak=$(_streak_get "$1")
+    local minutes=$((streak * 5))
+    msg="[PROPOSE:elliot] auto-pull-main staleness — $1 has SKIPed $streak consecutive cycles (~${minutes}m stale). Reason: $2. Resolve the worktree state so origin/main can ff-merge."
+    if [ -x "$RELAY" ] || [ -r "$RELAY" ]; then
+        /home/elliotbot/clawd/venv/bin/python3 "$RELAY" -g "$msg" >/dev/null 2>&1 || true
+    fi
+    touch "$alerted_flag" 2>/dev/null || true
+}
+
+_handle_skip() {
+    # $1 = worktree, $2 = reason
+    _streak_inc "$1"
+    local streak
+    streak=$(_streak_get "$1")
+    if [ "$streak" -ge "$SKIP_ALERT_THRESHOLD" ]; then
+        _emit_alert "$1" "$2"
+    fi
+}
+
 for wt in "${WORKTREES[@]}"; do
-    [ -d "$wt/.git" ] || [ -f "$wt/.git" ] || { echo "SKIP $wt: not a git worktree"; continue; }
+    if [ ! -d "$wt/.git" ] && [ ! -f "$wt/.git" ]; then
+        echo "SKIP $wt: not a git worktree"
+        _handle_skip "$wt" "not a git worktree"
+        continue
+    fi
     branch=$(git -C "$wt" symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")
     if [ "$branch" != "main" ]; then
         echo "SKIP $wt: on $branch (only auto-pull when on main)"
+        _handle_skip "$wt" "on $branch (only auto-pull when on main)"
         continue
     fi
     if [ -n "$(git -C "$wt" status --porcelain)" ]; then
         echo "SKIP $wt: working tree dirty"
+        _handle_skip "$wt" "working tree dirty"
         continue
     fi
     git_dir=$(git -C "$wt" rev-parse --git-dir)
     if [ -d "$git_dir/rebase-merge" ] || [ -d "$git_dir/rebase-apply" ] \
        || [ -f "$git_dir/MERGE_HEAD" ] || [ -f "$git_dir/CHERRY_PICK_HEAD" ]; then
         echo "SKIP $wt: rebase/merge/cherry-pick in progress"
+        _handle_skip "$wt" "rebase/merge/cherry-pick in progress"
         continue
     fi
     if ! git -C "$wt" fetch --quiet origin main 2>&1; then
         echo "FAIL $wt: fetch origin main failed"
+        _streak_reset "$wt"
         continue
     fi
     before=$(git -C "$wt" rev-parse HEAD)
@@ -52,7 +127,9 @@ for wt in "${WORKTREES[@]}"; do
         else
             echo "OK $wt: already at $before"
         fi
+        _streak_reset "$wt"
     else
         echo "FAIL $wt: ff-only merge refused (history diverged?)"
+        _streak_reset "$wt"
     fi
 done

--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -529,6 +529,15 @@ def send_dispatch(channel: str, text: str) -> None:
 
 def run_cycle(now: datetime | None = None) -> int:
     """Returns the number of dispatches sent (0 = silent cycle)."""
+    # Defense-in-depth per Scout's peak-window diagnosis (f42cc4d4): log the
+    # in-process PEAK_HOURS_UTC set every cycle so future drift between code
+    # and the worktree's actual checked-out file is diff-able from log alone.
+    n = now or datetime.now(UTC)
+    logger.info(
+        "cycle start — PEAK_HOURS_UTC=%s now=%s",
+        sorted(PEAK_HOURS_UTC),
+        n.isoformat(),
+    )
     if not should_run_now(now):
         logger.info("outside peak window + minute!=0 → silent skip")
         return 0

--- a/tests/scripts/test_auto_pull_main.py
+++ b/tests/scripts/test_auto_pull_main.py
@@ -1,0 +1,170 @@
+"""Tests for scripts/auto_pull_main.sh — peak-window staleness alerting.
+
+Verifies the SKIP-streak counter + alert-on-threshold logic added per Scout's
+peak-window diagnosis (f42cc4d4). The script's main pull loop hits real git,
+which we don't exercise here — we drive the streak-counter helpers via env
+overrides and assert state-file behaviour.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "auto_pull_main.sh"
+
+
+def _run_script(tmp_path: Path, relay_log: Path | None = None) -> subprocess.CompletedProcess:
+    """Run auto_pull_main.sh against a sandboxed state-dir + stubbed relay."""
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir(exist_ok=True)
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(exist_ok=True)
+    # Stub relay: writes calling args to relay_log if provided.
+    if relay_log is not None:
+        relay = shim_dir / "slack_relay.py"
+        relay.write_text(
+            f"#!/usr/bin/env python3\nimport sys\nopen('{relay_log}', 'a').write(' '.join(sys.argv[1:]) + chr(10))\n"
+        )
+        relay.chmod(0o755)
+    else:
+        relay = shim_dir / "slack_relay.py"
+        relay.write_text("#!/usr/bin/env python3\n")
+        relay.chmod(0o755)
+    env = os.environ.copy()
+    env["AGENCY_OS_AUTO_PULL_STATE_DIR"] = str(state_dir)
+    env["AGENCY_OS_AUTO_PULL_RELAY"] = str(relay)
+    env["AGENCY_OS_AUTO_PULL_SKIP_THRESHOLD"] = "3"
+    return subprocess.run(  # noqa: S603 — controlled args, no shell
+        ["/bin/bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _streak_file(tmp_path: Path, worktree: str) -> Path:
+    basename = worktree.replace("/", "_").lstrip("_")
+    return tmp_path / "state" / f"auto-pull-main.{basename}.skip-streak"
+
+
+# State-machine via direct shell invocation of the helpers ───────────────────
+
+
+def test_streak_increments_then_resets(tmp_path: Path) -> None:
+    """Source the script's helpers + verify _streak_inc / _streak_reset
+    behaviour against a sandboxed state dir. No real worktree touched."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    helper = tmp_path / "drive.sh"
+    helper.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+export AGENCY_OS_AUTO_PULL_STATE_DIR="{state_dir}"
+export AGENCY_OS_AUTO_PULL_SKIP_THRESHOLD=3
+export AGENCY_OS_AUTO_PULL_RELAY="/dev/null"
+# Source only the helper functions by extracting the top of the script.
+SKIP_ALERT_THRESHOLD="${{AGENCY_OS_AUTO_PULL_SKIP_THRESHOLD:-3}}"
+STATE_DIR="${{AGENCY_OS_AUTO_PULL_STATE_DIR}}"
+RELAY="${{AGENCY_OS_AUTO_PULL_RELAY}}"
+mkdir -p "$STATE_DIR"
+source <(sed -n '/^_state_path()/,/^for wt in/p' "{SCRIPT}" | sed '/^for wt in/d')
+WT="/tmp/test-worktree"
+_streak_inc "$WT"; _streak_inc "$WT"
+echo "after-2:$(_streak_get "$WT")"
+_streak_reset "$WT"
+echo "after-reset:$(_streak_get "$WT")"
+"""
+    )
+    helper.chmod(0o755)
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(helper)], capture_output=True, text=True, timeout=10
+    )
+    assert result.returncode == 0, result.stderr
+    assert "after-2:2" in result.stdout
+    assert "after-reset:0" in result.stdout
+
+
+def test_alert_fires_at_threshold(tmp_path: Path) -> None:
+    """When streak reaches threshold, the relay shim is called exactly once
+    per streak — repeat-suppressed via .alerted flag."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    relay_log = tmp_path / "relay.log"
+    helper = tmp_path / "drive.sh"
+    helper.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+export AGENCY_OS_AUTO_PULL_STATE_DIR="{state_dir}"
+export AGENCY_OS_AUTO_PULL_SKIP_THRESHOLD=3
+export AGENCY_OS_AUTO_PULL_RELAY="{tmp_path / 'shim' / 'slack_relay.py'}"
+mkdir -p "{tmp_path / 'shim'}"
+cat > "{tmp_path / 'shim' / 'slack_relay.py'}" <<'PY'
+#!/usr/bin/env python3
+import sys
+open("{relay_log}", "a").write(" ".join(sys.argv[1:]) + chr(10))
+PY
+chmod +x "{tmp_path / 'shim' / 'slack_relay.py'}"
+mkdir -p "/home/elliotbot/clawd/venv/bin" 2>/dev/null || true
+SKIP_ALERT_THRESHOLD="${{AGENCY_OS_AUTO_PULL_SKIP_THRESHOLD:-3}}"
+STATE_DIR="${{AGENCY_OS_AUTO_PULL_STATE_DIR}}"
+RELAY="${{AGENCY_OS_AUTO_PULL_RELAY}}"
+mkdir -p "$STATE_DIR"
+source <(sed -n '/^_state_path()/,/^for wt in/p' "{SCRIPT}" | sed '/^for wt in/d')
+WT="/tmp/test-worktree"
+_handle_skip "$WT" "working tree dirty"
+_handle_skip "$WT" "working tree dirty"
+_handle_skip "$WT" "working tree dirty"
+_handle_skip "$WT" "working tree dirty"
+_handle_skip "$WT" "working tree dirty"
+"""
+    )
+    helper.chmod(0o755)
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(helper)], capture_output=True, text=True, timeout=10
+    )
+    assert result.returncode == 0, result.stderr
+    # Streak now 5; .alerted flag prevents repeat-emit. Relay log should have
+    # exactly one entry (the first emit at threshold=3).
+    relay_lines = relay_log.read_text().splitlines() if relay_log.exists() else []
+    assert len(relay_lines) == 1, f"expected one relay call, got {relay_lines!r}"
+    assert "auto-pull-main staleness" in relay_lines[0]
+    assert "3 consecutive cycles" in relay_lines[0]
+
+
+def test_alert_resets_after_success(tmp_path: Path) -> None:
+    """After _streak_reset, a new SKIP run rebuilds the counter from 0."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    helper = tmp_path / "drive.sh"
+    helper.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+export AGENCY_OS_AUTO_PULL_STATE_DIR="{state_dir}"
+export AGENCY_OS_AUTO_PULL_SKIP_THRESHOLD=3
+export AGENCY_OS_AUTO_PULL_RELAY="/dev/null"
+SKIP_ALERT_THRESHOLD="${{AGENCY_OS_AUTO_PULL_SKIP_THRESHOLD:-3}}"
+STATE_DIR="${{AGENCY_OS_AUTO_PULL_STATE_DIR}}"
+RELAY="${{AGENCY_OS_AUTO_PULL_RELAY}}"
+mkdir -p "$STATE_DIR"
+source <(sed -n '/^_state_path()/,/^for wt in/p' "{SCRIPT}" | sed '/^for wt in/d')
+WT="/tmp/test-wt"
+_streak_inc "$WT"; _streak_inc "$WT"; _streak_inc "$WT"
+echo "before-reset:$(_streak_get "$WT")"
+_streak_reset "$WT"
+echo "after-reset:$(_streak_get "$WT")"
+_streak_inc "$WT"
+echo "after-new-inc:$(_streak_get "$WT")"
+"""
+    )
+    helper.chmod(0o755)
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(helper)], capture_output=True, text=True, timeout=10
+    )
+    assert result.returncode == 0, result.stderr
+    assert "before-reset:3" in result.stdout
+    assert "after-reset:0" in result.stdout
+    assert "after-new-inc:1" in result.stdout


### PR DESCRIPTION
## Summary

Per Scout's peak-window diagnosis at `docs/wave2/polling_loop_peak_window_diagnosis.md` (commit `f42cc4d4`). Two small interventions; **NO change to `should_run_now()`** which Scout confirmed is correct.

## Headline

The "outside peak window" log at UTC 13:35 on 2026-05-12 was **NOT** a code bug. `PEAK_HOURS_UTC` (`{0,1,...,13,21,22,23}`) is correct. `should_run_now()` is correct. The actual bug: `auto-pull-main.service` SKIPped silently for 60+ min after PR #782 merged because the main worktree had uncommitted state, so the on-disk file was the pre-#782 version with `range(0, 11)` where hour 13 correctly was NOT in peak.

## Changes

1. **`scripts/auto_pull_main.sh` — loud staleness alerting**
   - SKIP-streak counter per worktree (file-based, env-configurable state dir)
   - Reset on any non-SKIP outcome
   - Threshold (default 3 cycles = ~15 min) triggers ONE Slack `#execution` post via `slack_relay.py`
   - Repeat-suppressed via `.alerted` flag — no spam every 5 min while persistent
   - Env-overridable for tests: `AGENCY_OS_AUTO_PULL_STATE_DIR` / `_RELAY` / `_SKIP_THRESHOLD`

2. **`scripts/orchestrator/elliot_polling_loop.py:run_cycle()` — one log line**
   - `logger.info("cycle start — PEAK_HOURS_UTC=%s now=%s", sorted(PEAK_HOURS_UTC), n.isoformat())`
   - Defense-in-depth: future drift between code + runtime is diff-able from log alone

## Tests (3 new for auto-pull, 36/36 polling-loop unchanged)

- `test_streak_increments_then_resets` — `_streak_inc/get/reset` round-trip
- `test_alert_fires_at_threshold` — relay shim called exactly ONCE at threshold=3 even after 5 `_handle_skip` calls (`.alerted` flag suppresses repeats)
- `test_alert_resets_after_success` — `_streak_reset` clears state + flag; next `_streak_inc` starts at 1

```
$ pytest tests/scripts/test_auto_pull_main.py
============================== 3 passed in 0.53s ===============================
```

Ruff clean.

## Smoke plan (Elliot post-merge)

1. Leave any worktree dirty for >15 min → expects ONE `#execution` post `[PROPOSE:elliot] auto-pull-main staleness — <path> has SKIPed 3 consecutive cycles (~15m stale). Reason: working tree dirty.`
2. Clean the dirty state → next polling cycle's `PEAK_HOURS_UTC=...` log line in `journalctl -u elliot-polling-loop` confirms the runtime value.

## Out of scope (separate dispatches per Scout)

- Cross-worktree `elliot_polling_loop.py` hash divergence (3 distinct hashes across worktrees)
- Feature-branch auto-pull skip (intentional design)

## Test plan

- [x] `pytest tests/scripts/test_auto_pull_main.py` — 3/3
- [x] `pytest tests/scripts/test_elliot_polling_loop.py` — 36/36 (no regression)
- [x] `bash -n scripts/auto_pull_main.sh` — syntax clean
- [x] `ruff check` — clean
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Post-merge: Elliot smoke test per plan above

🤖 Generated with [Claude Code](https://claude.com/claude-code)