### PR TITLE
[AIDEN] feat(sync): PR-2 Beads→Linear outbound + auto-assign (Urgent)

### DIFF
--- a/scripts/bd_to_linear.py
+++ b/scripts/bd_to_linear.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""bd_to_linear.py — Beads→Linear outbound sync (PR-2 of Dave Urgent directive).
+
+Watches the local Beads export at `.beads/issues.jsonl` for status + assignee
+changes since the last sync, then PATCHes the matching Linear issue (joined
+by external_ref URL) via Linear's GraphQL API.
+
+Outcomes from directive (Dave ts ~1778620420):
+  - Outcome 2: bd close → Linear state=Done; bd update --status active →
+    Linear state="In Progress"
+  - Outcome 4: bd update --claim → Linear assignee=<claiming callsign>
+
+State tracking:
+  /home/elliotbot/.local/state/agency-os/bd-to-linear.state.json
+  shape: {<bd_issue_id>: {"status": "...", "assignee": "...", "linear_id": "..."}}
+  Diff against current bd export → only PATCH changed issues.
+
+GraphQL direct via urllib (LINEAR_API_KEY env) — same pattern as
+elliot_polling_loop.py:170 poll_linear_stale. Local mcp-bridge does NOT have
+linear-server; CLAUDE.md references the browser-side claude.ai HTTP MCP
+connector. urllib direct is portable + matches the existing in-repo pattern.
+
+Callsign → Linear user UUID:
+  Primary: AGENCY_OS_LINEAR_USER_<UPPER_CALLSIGN> env var (operator-configured,
+    one per agent). Looked up first.
+  Fallback: Linear `users` query by name (case-insensitive). If neither hits,
+  log warning + skip assignee field (status still PATCHes).
+
+Idempotency:
+  - State file persists across runs. First-run with empty state file emits
+    a PATCH for every bd issue with an external-ref + non-default status
+    (one-time bootstrap; operator can prime by deleting the state file).
+  - Subsequent runs PATCH only the diff.
+  - Failed Linear PATCHes are logged but DO NOT update state — they retry
+    on next run.
+
+Always exits 0 — operator-script discipline. Errors logged to stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger("bd_to_linear")
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+
+_LINEAR_GRAPHQL = "https://api.linear.app/graphql"
+_DEFAULT_STATE_PATH = os.path.expanduser("~/.local/state/agency-os/bd-to-linear.state.json")
+_DEFAULT_BEADS_PATH = ".beads/issues.jsonl"
+
+# Linear state TYPE values per StateType enum. UI names ("Done", "In Progress")
+# vary by workspace; the type values are fixed. We update state via the
+# stateId field, which we resolve from a workflow-states query on first use.
+_BD_TO_LINEAR_STATE_TYPE: dict[str, str] = {
+    "closed": "completed",
+    "active": "started",
+    "in_progress": "started",
+    "open": "unstarted",
+}
+
+
+def _state_path() -> Path:
+    return Path(os.environ.get("AGENCY_OS_BD_TO_LINEAR_STATE", _DEFAULT_STATE_PATH))
+
+
+def _beads_path() -> Path:
+    return Path(os.environ.get("AGENCY_OS_BEADS_EXPORT", _DEFAULT_BEADS_PATH))
+
+
+def _load_state() -> dict[str, dict]:
+    p = _state_path()
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text() or "{}")
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_state(state: dict[str, dict]) -> None:
+    p = _state_path()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(state, indent=2, sort_keys=True))
+    except OSError as exc:
+        logger.warning("save state failed: %s", exc)
+
+
+def _load_beads() -> list[dict]:
+    p = _beads_path()
+    if not p.exists():
+        return []
+    out: list[dict] = []
+    try:
+        for line in p.read_text().splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    out.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError as exc:
+        logger.warning("read beads export failed: %s", exc)
+    return out
+
+
+def _linear_id_from_external_ref(url: str) -> str | None:
+    """Extract the Linear issue identifier (KEI-NN) from an issue URL."""
+    m = re.search(r"/issue/([A-Z]+-\d+)", url)
+    return m.group(1) if m else None
+
+
+def _linear_graphql(api_key: str, query: str, variables: dict | None = None) -> dict | None:
+    body = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        _LINEAR_GRAPHQL,
+        data=body,
+        headers={"Authorization": api_key, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read() or "null")
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+        logger.warning("Linear GraphQL failed: %s", exc)
+        return None
+
+
+def _resolve_assignee_id(api_key: str, callsign: str) -> str | None:
+    """Try AGENCY_OS_LINEAR_USER_<UPPER> env first; else Linear users query."""
+    env_key = f"AGENCY_OS_LINEAR_USER_{callsign.upper()}"
+    if (uid := os.environ.get(env_key, "").strip()):
+        return uid
+    query = 'query($name:String!){users(filter:{name:{containsIgnoreCase:$name}},first:5){nodes{id name}}}'
+    resp = _linear_graphql(api_key, query, {"name": callsign})
+    nodes = ((resp or {}).get("data") or {}).get("users", {}).get("nodes") or []
+    for n in nodes:
+        if (n.get("name") or "").lower() == callsign.lower():
+            return n.get("id")
+    return nodes[0].get("id") if nodes else None
+
+
+def _resolve_state_id(api_key: str, identifier: str, target_type: str) -> str | None:
+    """Resolve the workflow state id for the issue's team matching target_type."""
+    query = '''query($id:String!){issue(id:$id){team{states{nodes{id name type}}}}}'''
+    resp = _linear_graphql(api_key, query, {"id": identifier})
+    states = (((resp or {}).get("data") or {}).get("issue") or {}).get("team", {}).get("states", {}).get("nodes") or []
+    for s in states:
+        if s.get("type") == target_type:
+            return s.get("id")
+    return None
+
+
+def _patch_linear_issue(
+    api_key: str, identifier: str, state_id: str | None, assignee_id: str | None
+) -> bool:
+    """PATCH a Linear issue via issueUpdate mutation. Returns True on success."""
+    if not (state_id or assignee_id):
+        return True
+    input_fields = {}
+    if state_id:
+        input_fields["stateId"] = state_id
+    if assignee_id:
+        input_fields["assigneeId"] = assignee_id
+    mutation = (
+        'mutation($id:String!,$input:IssueUpdateInput!){'
+        'issueUpdate(id:$id,input:$input){success}}'
+    )
+    resp = _linear_graphql(api_key, mutation, {"id": identifier, "input": input_fields})
+    return bool((((resp or {}).get("data") or {}).get("issueUpdate") or {}).get("success"))
+
+
+def compute_deltas(prior: dict[str, dict], current: list[dict]) -> list[dict]:
+    """Return list of {bd_id, linear_id, status_changed, assignee_changed, ...}
+    for each bd issue whose external_ref maps to a Linear identifier AND
+    whose status or assignee differs from the prior snapshot.
+    """
+    deltas: list[dict] = []
+    for issue in current:
+        bd_id = issue.get("id")
+        ref = issue.get("external_ref") or (issue.get("metadata") or {}).get("external_ref")
+        if not (bd_id and ref):
+            continue
+        linear_id = _linear_id_from_external_ref(ref)
+        if not linear_id:
+            continue
+        cur_status = (issue.get("status") or "").lower()
+        cur_assignee = (issue.get("assignee") or "").lower()
+        snap = prior.get(bd_id, {})
+        status_changed = snap.get("status") != cur_status
+        assignee_changed = (snap.get("assignee") or "") != cur_assignee
+        if status_changed or assignee_changed:
+            deltas.append(
+                {
+                    "bd_id": bd_id,
+                    "linear_id": linear_id,
+                    "status": cur_status,
+                    "assignee": cur_assignee,
+                    "status_changed": status_changed,
+                    "assignee_changed": assignee_changed,
+                }
+            )
+    return deltas
+
+
+def sync_once(api_key: str | None = None) -> int:
+    """Run one sync pass. Returns count of issues PATCHed successfully."""
+    key = api_key or os.environ.get("LINEAR_API_KEY", "")
+    if not key:
+        logger.warning("LINEAR_API_KEY not set; bd→linear sync no-op")
+        return 0
+    prior = _load_state()
+    current = _load_beads()
+    deltas = compute_deltas(prior, current)
+    if not deltas:
+        return 0
+    new_state = dict(prior)
+    patched = 0
+    for d in deltas:
+        state_id: str | None = None
+        if d["status_changed"]:
+            target_type = _BD_TO_LINEAR_STATE_TYPE.get(d["status"])
+            if target_type:
+                state_id = _resolve_state_id(key, d["linear_id"], target_type)
+        assignee_id: str | None = None
+        if d["assignee_changed"] and d["assignee"]:
+            assignee_id = _resolve_assignee_id(key, d["assignee"])
+        if _patch_linear_issue(key, d["linear_id"], state_id, assignee_id):
+            new_state[d["bd_id"]] = {
+                "status": d["status"],
+                "assignee": d["assignee"],
+                "linear_id": d["linear_id"],
+            }
+            patched += 1
+    _save_state(new_state)
+    return patched
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Compute deltas, log, but skip PATCH")
+    args = parser.parse_args(argv)
+    if args.dry_run:
+        deltas = compute_deltas(_load_state(), _load_beads())
+        for d in deltas:
+            print(f"# DELTA bd={d['bd_id']} linear={d['linear_id']} status={d['status']} assignee={d['assignee']}", file=sys.stderr)
+        return 0
+    n = sync_once()
+    if n > 0:
+        print(f"# bd→linear: PATCHed {n} issue(s)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/webhooks/linear.py
+++ b/src/api/webhooks/linear.py
@@ -50,6 +50,20 @@ LINEAR_STATE_TO_BD: dict[str, str] = {
 _BD_WRAPPER = "/home/elliotbot/clawd/Agency_OS/scripts/linear_to_bd.py"
 
 
+def _python_bin() -> str:
+    """Prefer repo-local .venv (canonical) over the legacy shared
+    /home/elliotbot/clawd/venv. Max's PR-2 review flagged the shared venv
+    as corrupt per Atlas's cognee-recall SKILL.md; switch to repo-local."""
+    candidates = (
+        "/home/elliotbot/clawd/Agency_OS/.venv/bin/python3",
+        "/home/elliotbot/clawd/venv/bin/python3",
+    )
+    for c in candidates:
+        if os.path.isfile(c):
+            return c
+    return "python3"
+
+
 def _verify_signature(secret: str, body: bytes, signature_header: str) -> bool:
     """Constant-time HMAC SHA-256 verify per Linear webhook docs."""
     if not signature_header or not secret:
@@ -109,7 +123,7 @@ def _dispatch_to_bd(event: dict[str, Any]) -> None:
     """Fire-and-forget subprocess to scripts/linear_to_bd.py. Fail-open."""
     try:
         subprocess.run(  # noqa: S603 — controlled args, no shell, payload validated
-            ["/home/elliotbot/clawd/venv/bin/python3", _BD_WRAPPER, "--json"],
+            [_python_bin(), _BD_WRAPPER, "--json"],
             input=json.dumps(event),
             text=True,
             capture_output=True,

--- a/tests/scripts/test_bd_to_linear.py
+++ b/tests/scripts/test_bd_to_linear.py
@@ -1,0 +1,204 @@
+"""Tests for scripts/bd_to_linear.py — PR-2 Beads→Linear outbound sync.
+
+Mocks the Linear GraphQL urllib endpoint + state-file/beads-export reads.
+Covers:
+  - _linear_id_from_external_ref: extract KEI-NN from Linear URL; None on
+    non-Linear strings
+  - _resolve_assignee_id: env primary, GraphQL fallback by name
+  - compute_deltas: status change / assignee change / both / no change
+  - sync_once: end-to-end happy path PATCHes Linear + writes state file
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "bd_to_linear.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("bd_to_linear", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["bd_to_linear"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+# _linear_id_from_external_ref ────────────────────────────────────────────────
+
+
+def test_linear_id_extraction_canonical_url(mod):
+    url = "https://linear.app/keiracom/issue/KEI-77/build-sync-receiver"
+    assert mod._linear_id_from_external_ref(url) == "KEI-77"
+
+
+def test_linear_id_extraction_missing_returns_none(mod):
+    assert mod._linear_id_from_external_ref("https://github.com/x/y/issues/1") is None
+    assert mod._linear_id_from_external_ref("") is None
+
+
+# _resolve_assignee_id ────────────────────────────────────────────────────────
+
+
+def test_resolve_assignee_env_primary(mod, monkeypatch):
+    monkeypatch.setenv("AGENCY_OS_LINEAR_USER_AIDEN", "uuid-aiden-from-env")
+
+    def _no_graphql(*args, **kwargs):
+        raise AssertionError("env hit should short-circuit GraphQL")
+
+    monkeypatch.setattr(mod, "_linear_graphql", _no_graphql)
+    assert mod._resolve_assignee_id("key", "aiden") == "uuid-aiden-from-env"
+
+
+def test_resolve_assignee_graphql_fallback(mod, monkeypatch):
+    monkeypatch.delenv("AGENCY_OS_LINEAR_USER_AIDEN", raising=False)
+
+    def _fake(api_key, query, variables=None):
+        return {"data": {"users": {"nodes": [{"id": "uuid-fallback", "name": "aiden"}]}}}
+
+    monkeypatch.setattr(mod, "_linear_graphql", _fake)
+    assert mod._resolve_assignee_id("key", "aiden") == "uuid-fallback"
+
+
+def test_resolve_assignee_empty_returns_none(mod, monkeypatch):
+    monkeypatch.delenv("AGENCY_OS_LINEAR_USER_AIDEN", raising=False)
+    monkeypatch.setattr(
+        mod, "_linear_graphql", lambda *a, **k: {"data": {"users": {"nodes": []}}}
+    )
+    assert mod._resolve_assignee_id("key", "aiden") is None
+
+
+# compute_deltas ──────────────────────────────────────────────────────────────
+
+
+def test_compute_deltas_status_change(mod):
+    prior = {"Agency_OS-abc": {"status": "open", "assignee": ""}}
+    current = [
+        {
+            "id": "Agency_OS-abc",
+            "status": "active",
+            "assignee": "",
+            "external_ref": "https://linear.app/keiracom/issue/KEI-77/x",
+        },
+    ]
+    deltas = mod.compute_deltas(prior, current)
+    assert len(deltas) == 1
+    assert deltas[0]["status_changed"] is True
+    assert deltas[0]["assignee_changed"] is False
+    assert deltas[0]["linear_id"] == "KEI-77"
+
+
+def test_compute_deltas_assignee_change(mod):
+    prior = {"Agency_OS-def": {"status": "open", "assignee": ""}}
+    current = [
+        {
+            "id": "Agency_OS-def",
+            "status": "open",
+            "assignee": "aiden",
+            "external_ref": "https://linear.app/keiracom/issue/KEI-88",
+        },
+    ]
+    deltas = mod.compute_deltas(prior, current)
+    assert len(deltas) == 1
+    assert deltas[0]["assignee_changed"] is True
+    assert deltas[0]["status_changed"] is False
+
+
+def test_compute_deltas_no_change_returns_empty(mod):
+    prior = {
+        "Agency_OS-x": {"status": "active", "assignee": "aiden", "linear_id": "KEI-99"}
+    }
+    current = [
+        {
+            "id": "Agency_OS-x",
+            "status": "active",
+            "assignee": "aiden",
+            "external_ref": "https://linear.app/keiracom/issue/KEI-99",
+        },
+    ]
+    assert mod.compute_deltas(prior, current) == []
+
+
+def test_compute_deltas_skip_no_external_ref(mod):
+    """bd issue without external_ref doesn't have a Linear counterpart — skip."""
+    current = [{"id": "Agency_OS-y", "status": "active", "assignee": "aiden"}]
+    assert mod.compute_deltas({}, current) == []
+
+
+def test_compute_deltas_skip_non_linear_ref(mod):
+    """external_ref that isn't a Linear URL — skip."""
+    current = [
+        {
+            "id": "Agency_OS-z",
+            "status": "active",
+            "external_ref": "https://github.com/x/y/issues/1",
+        }
+    ]
+    assert mod.compute_deltas({}, current) == []
+
+
+# sync_once end-to-end ────────────────────────────────────────────────────────
+
+
+def test_sync_once_no_api_key_no_op(mod, monkeypatch):
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    assert mod.sync_once() == 0
+
+
+def test_sync_once_patches_changed_issue(mod, monkeypatch, tmp_path):
+    monkeypatch.setenv("LINEAR_API_KEY", "test-key")
+    state_path = tmp_path / "state.json"
+    beads_path = tmp_path / "issues.jsonl"
+    monkeypatch.setenv("AGENCY_OS_BD_TO_LINEAR_STATE", str(state_path))
+    monkeypatch.setenv("AGENCY_OS_BEADS_EXPORT", str(beads_path))
+    monkeypatch.setenv("AGENCY_OS_LINEAR_USER_AIDEN", "uuid-aiden")
+
+    state_path.write_text(json.dumps({"Agency_OS-abc": {"status": "open", "assignee": ""}}))
+    beads_path.write_text(
+        json.dumps(
+            {
+                "id": "Agency_OS-abc",
+                "status": "closed",
+                "assignee": "aiden",
+                "external_ref": "https://linear.app/keiracom/issue/KEI-77/build",
+            }
+        )
+        + "\n"
+    )
+
+    captured: list[tuple] = []
+
+    def _fake(api_key, query, variables=None):
+        captured.append((query, variables))
+        if "team{states" in query:
+            return {
+                "data": {
+                    "issue": {
+                        "team": {
+                            "states": {
+                                "nodes": [{"id": "state-uuid", "name": "Done", "type": "completed"}]
+                            }
+                        }
+                    }
+                }
+            }
+        if "issueUpdate" in query:
+            return {"data": {"issueUpdate": {"success": True}}}
+        return {"data": {"users": {"nodes": []}}}
+
+    monkeypatch.setattr(mod, "_linear_graphql", _fake)
+    n = mod.sync_once()
+    assert n == 1
+    # State should now reflect the new snapshot
+    after = json.loads(state_path.read_text())
+    assert after["Agency_OS-abc"]["status"] == "closed"
+    assert after["Agency_OS-abc"]["assignee"] == "aiden"
+    # Linear update mutation must have been called
+    assert any("issueUpdate" in c[0] for c in captured)


### PR DESCRIPTION
## Summary

PR-2 of the 3-PR Linear↔Beads sync split. Outbound direction: bd state/assignee changes → Linear GraphQL PATCH. Satisfies Outcomes 2 + 4 from Dave Urgent directive ts ~1778620420. Bundles Max's PR-1 venv-path fix note.

## Empirical pivot from Step 0 (dual-CTO concurred)

Local mcp-bridge does **not** have a `linear-server` (available: supabase/redis/prefect/railway/prospeo/dataforseo/vercel/salesforge/vapi/telnyx/unipile/resend/memory). The `linear-server` referenced in `CLAUDE.md` is a claude.ai HTTP MCP connector (browser-side). Replaced with urllib direct GraphQL — same canonical pattern as `poll_linear_stale` in `elliot_polling_loop.py:170`. Same `LINEAR_API_KEY` env, no operator wait.

## Components

| Path | LoC | Role |
|------|-----|------|
| `scripts/bd_to_linear.py` | 236 | Watch bd export → diff vs state file → resolve state/assignee IDs → PATCH Linear via `issueUpdate` mutation |
| `src/api/webhooks/linear.py` | +16 | Venv-path fix (`_python_bin()` prefers repo-local `Agency_OS/.venv`) |
| `tests/scripts/test_bd_to_linear.py` | 204 | 12 tests |

## Coverage (Outcomes 2 + 4)

| bd operation | Linear PATCH |
|--------------|--------------|
| `bd close <id>` | `state → completed` (resolved Done state-id) |
| `bd update <id> --status active` | `state → started` (resolved In Progress state-id) |
| `bd update <id> --claim` (assignee set) | `assignee → <callsign>` resolved via env or users{} GraphQL |

## Idempotency

State file at `~/.local/state/agency-os/bd-to-linear.state.json`. Schema: `{bd_id: {status, assignee, linear_id}}`. `compute_deltas` returns empty when no bd snapshot drift. Failed PATCHes don't update snapshot — retry on next run.

## Tests (12/12 pass, ruff clean)

```
$ pytest tests/scripts/test_bd_to_linear.py tests/api/webhooks/test_linear_webhook.py
============================== 21 passed in 1.06s ==============================
```

Per surface:
- `_linear_id_from_external_ref`: extract KEI-NN / None on non-Linear / None on empty
- `_resolve_assignee_id`: env primary short-circuits GraphQL / GraphQL fallback / empty → None
- `compute_deltas`: status-change / assignee-change / no-change / no-external-ref / non-linear-ref
- `sync_once`: no API key → no-op / end-to-end PATCHes + writes state

## Out of scope (PR-3)

- `_session_start.md` adds `bd sync --linear` one-liner (Outcome 3 from directive)
- Systemd timer for periodic `bd_to_linear.py` invocation (operator post-merge step)
- IssueRelation/blockedBy bidirectional sync (PR-4 or further)

## Operator handoff post-merge

1. Populate `AGENCY_OS_LINEAR_USER_<CALLSIGN>` env vars in `.env` (6 vars: ELLIOT/AIDEN/MAX/ATLAS/ORION/SCOUT) — Linear user UUIDs from Settings → Members. **Fallback:** if env not set, the script falls back to Linear's `users{filter:{name}}` query — works as long as Linear member names match callsigns case-insensitively.
2. Schedule the script via systemd-user timer or cron — e.g. every 60s on a `agency-os-bd-to-linear.timer`.
3. **Evidence 2 from directive:** `bd close <id>` on a Linear-linked issue → Linear shows Done within the timer cadence.

## Test plan

- [x] `pytest` — 12/12 PR-2 + 9/9 PR-1 regression = 21/21
- [x] `ruff check` — clean
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Operator: populate env + schedule timer + smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)