### PR TITLE
[ATLAS] docs(claude): Callsign → Model Assignment table + HEARTBEAT model field

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -17,6 +17,11 @@ start, snapshotted by the PreCompact hook (scripts/pre_compact_alert.py).
 - Branch: <branch-name>
 - Subject: <commit subject line>
 
+## Model
+
+- Configured: <callsign-from-IDENTITY.md → lookup in CLAUDE.md §Callsign → Model Assignment table>
+- Running: <actual `--model` flag at startup, if known; otherwise "unknown — check tmux session launch command">
+
 ## Blockers
 
 - <bulleted list, or "none">


### PR DESCRIPTION
## Summary

CEO directive 2026-05-12 ts ~1778625870 → corrected at ts ~1778626300 (**Option D**): model table goes in HEARTBEAT.md + ceo_memory only, NOT CLAUDE.md. HEARTBEAT.md is per-worktree by design; CLAUDE.md is guard-protected against drift.

**Scope (post v2 correction):**
- `HEARTBEAT.md`: new "Model" section with Configured + Running fields (pre-compact hook auto-populates per-callsign on snapshot)

**Out of scope per Option-D:**
- CLAUDE.md edit (DROPPED — Governance Equality Guard correctly rejects model-table drift)
- ceo_memory key `orchestration:model_assignment` (already written by Elliot at 22:45:30 UTC)
- Linear KEI-31 description (already updated via GraphQL in prior task)

## Diff

```
 HEARTBEAT.md | 5 +++++
 1 file changed, 5 insertions(+)
```

## Callsign → Model table (lives in ceo_memory + KEI-31, NOT this PR)

| Callsign | Model | Context |
|---|---|---|
| elliot, aiden, max | claude-opus-4-7 | 1M |
| atlas, orion | claude-sonnet-4-6 | 200K |
| scout | claude-sonnet-4-6 / claude-haiku-4-5 (mechanical) | 200K |

## Test plan

- [x] Single-file diff (HEARTBEAT.md only)
- [x] Governance Equality Guard non-applicable (no CLAUDE.md change)
- [x] Branched from origin/main HEAD (d848a12d)
- [ ] Dual-CTO concur (Aiden FINAL + Max already CONCUR'd Option-D in #execution)
- [ ] Self-merge per author+reviewer rule once CI green
- [ ] Post-merge: Dave operator restarts atlas/orion/scout tmux with new --model flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)