### PR TITLE
[ORION] feat(enforcer): KEI-33 R13 — DECISION-MIRROR-TO-CEO (strict-zero)

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -661,3 +661,79 @@ def check_r14(
         "fire_message": "Idle agents enumerated without dispatch — orchestrator "
         "action gap. [paste message]",
     }
+
+
+# ---------------------------------------------------------------------------
+# R13 — DECISION-MIRROR-TO-CEO
+# ---------------------------------------------------------------------------
+#
+# Per CEO directive ts ~1778628200 + dual-CTO (Max+Elliot) strict-zero
+# interpretation ts ~1778626830: an Elliot-orchestrator post to #execution
+# that signals a Dave-bound decision MUST contain an inline #ceo-mirror token
+# in the same message body. No cross-channel state, no timing window, no
+# fingerprint cache — pure content check on the #execution post itself.
+#
+# Pass: regex match for the mirror-reference token in the post body.
+# Fail: no token → fire to #ceo flagging unescalated blocker.
+
+# Trigger phrases — decision-needed signals (Elliot-orchestrator-bound).
+_R13_DECISION_NEEDED_RE = re.compile(
+    r"\[PROPOSE:elliot\]"
+    r"|Dave decision"
+    r"|CEO call"
+    r"|standing for (?:Dave|CEO)"
+    r"|blocker requires? (?:Dave|CEO)",
+    re.IGNORECASE,
+)
+
+# CEO-mirror token — inline acknowledgement that the post is already
+# mirrored to or coordinated with #ceo.
+_R13_CEO_MIRROR_TOKEN_RE = re.compile(
+    r"mirrored to #ceo"
+    r"|posting to #ceo"
+    r"|\[CEO-MIRROR"
+    r"|#ceo mirror"
+    r"|per R13",
+    re.IGNORECASE,
+)
+
+# R14 (KEI-34) already defines _R14_EXECUTION_CHANNEL_ID privately. We keep
+# this module-level alias because (a) R14's comment explicitly says
+# "duplicate is defensive against ordering — if R13 merges second it
+# reuses its own def", and (b) external callers of check_r13 / R13 docs
+# reference EXECUTION_CHANNEL_ID by that name. Both constants resolve to
+# the same channel id; no behavioural conflict.
+EXECUTION_CHANNEL_ID = _R14_EXECUTION_CHANNEL_ID
+
+
+def check_r13(text: str, *, channel: str | None = None) -> dict | None:
+    """R13 — DECISION-MIRROR-TO-CEO.
+
+    Strict-zero / inline-token interpretation (dual-CTO ratified):
+      - Applies only to messages on #execution (channel id C0B3QB0K1GQ).
+      - Fires when text matches DECISION_NEEDED but NOT CEO_MIRROR.
+      - No-op for #ceo posts (rule only enforces the #execution leak),
+        for non-decision messages, and for any message outside #execution.
+
+    Returns a violation dict for fire-to-#ceo, or None on pass / no-op.
+    """
+    if channel != EXECUTION_CHANNEL_ID:
+        return None
+    if not _R13_DECISION_NEEDED_RE.search(text):
+        return None
+    if _R13_CEO_MIRROR_TOKEN_RE.search(text):
+        return None
+    return {
+        "violation": True,
+        "rule_number": 13,
+        "rule_name": "DECISION-MIRROR-TO-CEO",
+        "detail": "Blocker in #execution not escalated — Dave-bound decision posted "
+        "to #execution without an inline #ceo-mirror token.",
+        "should_have": (
+            "Add an inline reference to the #ceo mirror in the same message body "
+            "(e.g. 'Mirrored to #ceo', 'Posting to #ceo', '[CEO-MIRROR:...]') OR "
+            "post the decision-needed escalation to #ceo first per the "
+            "R13-blocker-escalation runbook."
+        ),
+        "fire_message": "Blocker in #execution not escalated — [paste message]",
+    }

--- a/tests/bot_common/test_enforcer_deterministic.py
+++ b/tests/bot_common/test_enforcer_deterministic.py
@@ -607,3 +607,102 @@ def test_r11_single_long_bullet_not_prose():
     # Either passes entirely or only flags non-prose issues.
     if out is not None:
         assert "prose paragraph" not in out["detail"]
+
+
+# ---------------------------------------------------------------------------
+# R13 — DECISION-MIRROR-TO-CEO
+# ---------------------------------------------------------------------------
+
+EXECUTION_CH = "C0B3QB0K1GQ"
+CEO_CH_R13 = "C0B2PM3TV0B"
+
+
+def test_r13_propose_with_inline_mirror_token_passes():
+    """Case 1: PROPOSE in #execution WITH inline mirror token → pass (no fire)."""
+    from src.bot_common.enforcer_deterministic import check_r13
+
+    msg = (
+        "[PROPOSE:elliot] Take ownership of the rate-limit detection P1. "
+        "Mirrored to #ceo for Dave visibility."
+    )
+    assert check_r13(msg, channel=EXECUTION_CH) is None
+
+
+def test_r13_propose_without_mirror_token_fires():
+    """Case 2: PROPOSE in #execution WITHOUT mirror token → fail (fires to #ceo)."""
+    from src.bot_common.enforcer_deterministic import check_r13
+
+    msg = (
+        "[PROPOSE:elliot] Need Dave decision on whether to proceed with the "
+        "destructive migration before the post-restart bundle ships."
+    )
+    out = check_r13(msg, channel=EXECUTION_CH)
+    assert out is not None
+    assert out["rule_number"] == 13
+    assert out["rule_name"] == "DECISION-MIRROR-TO-CEO"
+    assert "not escalated" in out["detail"]
+    assert out["fire_message"] == "Blocker in #execution not escalated — [paste message]"
+
+
+def test_r13_propose_in_ceo_is_noop():
+    """Case 3: PROPOSE in #ceo itself → no-op (rule only enforces #execution leak)."""
+    from src.bot_common.enforcer_deterministic import check_r13
+
+    msg = "[PROPOSE:elliot] Dave decision on the post-restart bundle ordering."
+    assert check_r13(msg, channel=CEO_CH_R13) is None
+
+
+def test_r13_non_propose_message_in_execution_is_noop():
+    """Case 4: non-PROPOSE message in #execution → no-op (rule only triggers on
+    decision-needed signals)."""
+    from src.bot_common.enforcer_deterministic import check_r13
+
+    msg = "Shipped PR #821 — CI green, awaiting peer FINAL on the diff."
+    assert check_r13(msg, channel=EXECUTION_CH) is None
+
+
+def test_r13_each_decision_trigger_phrase_fires_without_mirror():
+    """Spot-check every documented decision-needed trigger phrase fires when
+    no mirror token is present in #execution. Pins the regex shape against
+    accidental edits."""
+    from src.bot_common.enforcer_deterministic import check_r13
+
+    phrases = [
+        "[PROPOSE:elliot] some decision",
+        "This is a Dave decision",
+        "CEO call required here",
+        "Standing for Dave reply",
+        "Blocker requires Dave verbatim",
+        "Blocker requires CEO ratification",
+    ]
+    for p in phrases:
+        out = check_r13(p, channel=EXECUTION_CH)
+        assert out is not None, f"phrase did not fire R13: {p!r}"
+        assert out["rule_number"] == 13
+
+
+def test_r13_each_mirror_token_suppresses_fire():
+    """Spot-check every documented mirror-token form suppresses fire on a
+    decision-needed #execution post."""
+    from src.bot_common.enforcer_deterministic import check_r13
+
+    base = "[PROPOSE:elliot] something needs Dave decision."
+    tokens = [
+        "Mirrored to #ceo",
+        "Posting to #ceo now",
+        "[CEO-MIRROR: ts 1778628999]",
+        "#ceo mirror in flight",
+        "per R13",
+    ]
+    for t in tokens:
+        msg = f"{base} {t}"
+        out = check_r13(msg, channel=EXECUTION_CH)
+        assert out is None, f"token did not suppress R13: {t!r}"
+
+
+def test_r13_no_channel_defaults_to_pass():
+    """When channel is unknown / None, R13 must not fire — same convention as R11."""
+    from src.bot_common.enforcer_deterministic import check_r13
+
+    msg = "[PROPOSE:elliot] Dave decision needed."
+    assert check_r13(msg, channel=None) is None


### PR DESCRIPTION
## Summary

Closes **KEI-33** R13 enforcer build. CEO directive Dave ts ~1778628200 directly assigned this to Orion in #ceo. Strict-zero / inline-token interpretation dual-CTO ratified by Max + Elliot ts ~1778626830.

## Rule shape

| Condition | Behaviour |
|---|---|
| Channel is **#execution** (`C0B3QB0K1GQ`) AND text matches DECISION_NEEDED AND no CEO-mirror token | **FIRE** to #ceo with `'Blocker in #execution not escalated — [paste message]'` |
| Channel is #execution AND DECISION_NEEDED AND CEO-mirror token present | Pass (no fire) |
| Channel is #ceo itself | No-op (rule only enforces the #execution leak) |
| Channel is #execution but no DECISION_NEEDED match | No-op |
| Channel is anything else / None | No-op |

## Regexes (exact from dispatch + Aiden spec)

```python
_R13_DECISION_NEEDED_RE = re.compile(
    r"\[PROPOSE:elliot\]"
    r"|Dave decision"
    r"|CEO call"
    r"|standing for (?:Dave|CEO)"
    r"|blocker requires? (?:Dave|CEO)",
    re.IGNORECASE,
)

_R13_CEO_MIRROR_TOKEN_RE = re.compile(
    r"mirrored to #ceo"
    r"|posting to #ceo"
    r"|\[CEO-MIRROR"
    r"|#ceo mirror"
    r"|per R13",
    re.IGNORECASE,
)
```

Pure content check on the #execution post itself — **no cross-channel state, no timing window, no fingerprint cache**.

## Tests (7/7 pass, all 75 enforcer tests pass, ruff clean)

| # | Test | Dispatch case |
|---|---|---|
| 1 | `test_r13_propose_with_inline_mirror_token_passes` | Case 1 |
| 2 | `test_r13_propose_without_mirror_token_fires` | Case 2 |
| 3 | `test_r13_propose_in_ceo_is_noop` | Case 3 |
| 4 | `test_r13_non_propose_message_in_execution_is_noop` | Case 4 |
| 5 | `test_r13_each_decision_trigger_phrase_fires_without_mirror` | Bonus regression-pin on every trigger phrase |
| 6 | `test_r13_each_mirror_token_suppresses_fire` | Bonus regression-pin on every mirror token |
| 7 | `test_r13_no_channel_defaults_to_pass` | Channel=None convention consistency with R11 |

```
$ pytest tests/bot_common/test_enforcer_deterministic.py -q
75 passed in 0.78s

$ ruff check src/bot_common/enforcer_deterministic.py tests/bot_common/test_enforcer_deterministic.py
All checks passed!
```

## Out of scope (per dispatch literal)

- Cross-callsign decision-needed coverage (R13 is Elliot-orchestrator-specific per Dave verbatim *"If Elliot posts ..."*)
- State cache / timing window (rejected by strict-zero)
- KEI-34 mechanism (Aiden's separate post-restart lane)
- Wiring R13 into the dispatch entry-point that the running enforcer-bot calls (the function is added + tested; rule-registry wiring is the post-merge activation step Dave directs — same convention as other recent rules)

## LAW XVI note

Used `git worktree add /tmp/orion-kei33-r13` off `origin/main` (HEAD `5b2c4b09`) to bypass the Atlas-swap `.claude/*` symlink-vs-index conflict in the main Orion worktree. Isolated tree cleaned up post-push.

## Test plan

- [x] 7 new R13 tests pass
- [x] All 75 enforcer tests pass (no regression in R2/R3/R4/R6/R8/R10/R11)
- [x] ruff check + format clean
- [x] Strict-zero interpretation: no state, no timing, no cache
- [ ] Post-merge: rule-registry wire-in (Dave-directed activation step, same convention as recent rules)

## Dual-CTO concur

Aiden + Max please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)