### PR TITLE
[AIDEN] feat(kei34): orchestrator-discipline enforcement — 2 components (strict-cycle)

### DIFF
--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -52,6 +52,13 @@ PEAK_HOURS_UTC = set(list(range(21, 24)) + list(range(0, 14)))  # 21–13 UTC in
 STALE_LINEAR_HOURS = 12
 IDLE_AGENT_MINUTES = 30
 PREFECT_WINDOW_MINUTES = 5
+# KEI-34 strict-cycle reading per Dave verbatim ts ~1778629860: 'Idle agents
+# with unblocked work is the failure we're fixing. 15 minutes is too long.'
+# Component 1 fires when an agent has been idle >= ORCHESTRATOR_IDLE_CYCLES *
+# current_cycle_period_seconds (60s peak, 3600s off-peak).
+ORCHESTRATOR_IDLE_CYCLES = 1
+PEAK_CYCLE_SECONDS = 60
+OFF_PEAK_CYCLE_SECONDS = 3600
 
 EXECUTION_CHANNEL_NAME = "#execution"
 CEO_CHANNEL_NAME = "#ceo"
@@ -103,6 +110,17 @@ THROTTLE_PATTERNS: tuple[str, ...] = (
 THROTTLE_RE = re.compile("|".join(THROTTLE_PATTERNS), re.IGNORECASE)
 
 
+def _cycle_period_seconds(now: datetime | None = None) -> int:
+    """KEI-34: return the current polling-cycle period in seconds.
+    Peak hours = 60s (run-every-minute); off-peak = 3600s (run-every-hour).
+    Used by _orchestrator_discipline_check to enforce strict-cycle staleness.
+    """
+    n = now or datetime.now(UTC)
+    if n.hour in PEAK_HOURS_UTC:
+        return PEAK_CYCLE_SECONDS
+    return OFF_PEAK_CYCLE_SECONDS
+
+
 @dataclass
 class CycleSignals:
     bd_ready: list[dict]
@@ -110,6 +128,9 @@ class CycleSignals:
     idle_agents: list[str]
     prefect_failures: list[dict]
     rate_limit_transitions: list[tuple[str, str, int]] = field(default_factory=list)
+    # KEI-34 component 1 — agents idle >= ORCHESTRATOR_IDLE_CYCLES * cycle_period
+    # (strict-cycle threshold; tighter than idle_agents which uses IDLE_AGENT_MINUTES).
+    orchestrator_idle_agents: list[str] = field(default_factory=list)
     """List of (callsign, transition, duration_min) where transition is
     'throttled' (first detection) or 'resumed' (clearing detection). Duration
     is minutes-since-throttle-start for 'resumed' (0 for 'throttled')."""
@@ -248,6 +269,58 @@ def poll_idle_agents(now: datetime | None = None) -> list[str]:
         return []
 
 
+def poll_orchestrator_idle_agents(now: datetime | None = None) -> list[str]:
+    """KEI-34 strict-cycle threshold per Dave verbatim ts ~1778629860.
+
+    Returns callsigns whose last_activity_at is older than
+    ORCHESTRATOR_IDLE_CYCLES * _cycle_period_seconds(now). At peak hours
+    cycle period = 60s; off-peak = 3600s. Tighter than IDLE_AGENT_MINUTES
+    (30m) — by design, per Dave's '15 minutes is too long' override.
+
+    Same DB query shape as poll_idle_agents but with the strict cutoff.
+    Best-effort: DB failure or DSN-unset returns []."""
+    dsn = os.environ.get("DATABASE_URL", "") or os.environ.get("DATABASE_URL_MIGRATIONS", "")
+    if not dsn:
+        return []
+    n = now or datetime.now(UTC)
+    threshold_s = ORCHESTRATOR_IDLE_CYCLES * _cycle_period_seconds(n)
+    cutoff = n - timedelta(seconds=threshold_s)
+    sql = (
+        "SELECT DISTINCT ON (callsign) callsign, last_activity_at "
+        "FROM keiracom_admin.agent_status_observations "
+        "WHERE callsign = ANY($1::text[]) "
+        "ORDER BY callsign, observed_at DESC"
+    )
+    candidates = list(PRIMES) + list(CLONES)
+    try:
+        import asyncio
+
+        import asyncpg
+    except ImportError:
+        return []
+
+    async def _q() -> list[str]:
+        conn = await asyncpg.connect(
+            dsn.replace("postgresql+asyncpg://", "postgresql://"),
+            statement_cache_size=0,
+        )
+        try:
+            rows = await conn.fetch(sql, candidates)
+        finally:
+            await conn.close()
+        return [
+            r["callsign"]
+            for r in rows
+            if r["last_activity_at"] and r["last_activity_at"] < cutoff
+        ]
+
+    try:
+        return asyncio.run(_q())
+    except (OSError, RuntimeError, Exception) as exc:  # noqa: BLE001 — best-effort
+        logger.warning("orchestrator-idle query failed: %s", exc)
+        return []
+
+
 def poll_prefect_failures(now: datetime | None = None) -> list[dict]:
     """Failed Prefect flow runs in the last PREFECT_WINDOW_MINUTES."""
     api_url = os.environ.get("PREFECT_API_URL", "").rstrip("/")
@@ -378,6 +451,7 @@ def collect_signals(now: datetime | None = None) -> CycleSignals:
         idle_agents=poll_idle_agents(now),
         prefect_failures=poll_prefect_failures(now),
         rate_limit_transitions=poll_rate_limited_agents(now),
+        orchestrator_idle_agents=poll_orchestrator_idle_agents(now),
     )
 
 
@@ -464,7 +538,67 @@ def compose_dispatches(signals: CycleSignals) -> list[tuple[str, str]]:
             )
             dispatches.append((CEO_CHANNEL_NAME, msg))
 
+    _orchestrator_discipline_check(signals, dispatches)
     return dispatches
+
+
+def _orchestrator_discipline_check(signals: CycleSignals, dispatches: list[tuple[str, str]]) -> None:
+    """KEI-34 component 1: surface orchestrator-discipline gap to #ceo when
+    bd_ready has unblocked items AND any agent is idle ≥1 cycle AND
+    compose_dispatches did NOT pair every idle agent (or no dispatch fired).
+
+    Per Dave verbatim ts ~1778629860 strict-cycle override:
+      'KEI-34 threshold: 1 polling cycle. Not 15 minutes. Idle agents with
+       unblocked work is the failure we're fixing.'
+
+    Uses signals.orchestrator_idle_agents (gated by ORCHESTRATOR_IDLE_CYCLES *
+    _cycle_period_seconds — 60s peak, 3600s off-peak). Distinct from
+    signals.idle_agents which is gated by IDLE_AGENT_MINUTES (30m, used for
+    the normal idle×ready pairing dispatch).
+
+    Fire conditions (EITHER):
+      (1) bd_ready has unblocked items AND zero idle-this-cycle agents have
+          been paired by compose_dispatches yet (compose_dispatches uses
+          idle_agents which is the looser 30m threshold — strict-cycle agents
+          may be a subset; if no strict-cycle agents got paired, we fire).
+      (2) Excess unblocked ready work beyond the dispatched pairs.
+
+    Mutates dispatches list in place. Always returns None.
+    """
+    ready_n = len(signals.bd_ready)
+    if ready_n == 0:
+        return
+    strict_idle = list(signals.orchestrator_idle_agents)
+    strict_idle_n = len(strict_idle)
+    loose_idle_n = len(signals.idle_agents)
+    paired_n = min(ready_n, loose_idle_n)
+    excess_ready = ready_n - paired_n
+    # Fire when:
+    #   (i)  strict-idle agents exist but compose_dispatches yielded fewer
+    #        pairings than strict-idle count (strict-idle ⊆ loose-idle, so
+    #        we expect every strict-idle to be in pairs)
+    #   (ii) excess ready work beyond loose pairing
+    #   (iii) zero loose-idle but non-zero ready
+    fire = False
+    if strict_idle_n > 0 and paired_n < strict_idle_n:
+        fire = True
+    if excess_ready > 0:
+        fire = True
+    if loose_idle_n == 0 and ready_n > 0:
+        fire = True
+    if not fire:
+        return
+    strict_idle_summary = ", ".join(strict_idle) if strict_idle else "none"
+    top = signals.bd_ready[0]
+    msg = (
+        f"[PROPOSE:elliot] {ready_n} unblocked item(s), "
+        f"{strict_idle_n} agent(s) idle ≥1 cycle, "
+        f"{loose_idle_n} agent(s) idle ≥{IDLE_AGENT_MINUTES}m, "
+        f"{paired_n} paired — orchestrator-discipline gap. "
+        f"Strict-idle: {strict_idle_summary}. "
+        f"Top ready: {top.get('id', '?')} (P{top.get('priority', '?')})."
+    )
+    dispatches.append((CEO_CHANNEL_NAME, msg))
 
 
 def _write_inbox_dispatch(callsign: str, text: str) -> None:

--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -570,3 +570,94 @@ def check_r11(text: str, *, channel: str | None = None) -> dict | None:
             "#execution. See feedback_ceo_plain_english_summaries.md."
         ),
     }
+
+
+# ---------------------------------------------------------------------------
+# R14 — ORCHESTRATOR-DISPATCH-DISCIPLINE (KEI-34 component 2)
+# ---------------------------------------------------------------------------
+#
+# Per CEO directive ts ~1778628900 + dual-CTO ratified Step 0 (Max+Elliot
+# ts ~1778629820+1778629779): an Elliot post in #execution that enumerates
+# idle agents (acknowledgement) MUST also contain a dispatch token in the
+# same message body. Strict-zero / inline-token shape parallel to R13.
+# Failure to dispatch within the same message → fire to #ceo.
+#
+# Pass: regex match for any dispatch token in the post body.
+# Fail: idle-status acknowledged but no dispatch token → fire.
+
+# Trigger phrases — idle-agent enumeration / acknowledgement patterns.
+_R14_IDLE_STATUS_RE = re.compile(
+    r"\bidle (?:agents?|clones?)\b"
+    r"|\[READY:[a-z]+\]"
+    r"|agent(?:s)? idle"
+    r"|standing(?:\sby)? (?:on )?(?:agents?|idle)",
+    re.IGNORECASE,
+)
+
+# Dispatch tokens — markers that the same message body contains a dispatch.
+_R14_DISPATCH_TOKEN_RE = re.compile(
+    r"\[DISPATCH-PROPOSAL:"
+    r"|\[DISPATCH:"
+    r"|\bdispatching\b"
+    r"|\bEXPLICIT (?:DISPATCH|GO)\b"
+    r"|\bbranch\s+[\w/-]+\b"
+    r"|\bopen(?:ing)?\s+PR\b"
+    r"|\bpicks?\s+up\s+KEI-\d+",
+    re.IGNORECASE,
+)
+
+# Elliot is the orchestrator under R14 — only Elliot's posts trigger.
+_R14_ORCHESTRATOR_CALLSIGN = "elliot"
+
+# Channel id for #execution. Orion's PR #814 R13 introduces a module-level
+# EXECUTION_CHANNEL_ID with the same value; this internal duplicate is
+# defensive against ordering. If #814 merges first the inline below stays
+# private + correct; if this PR merges first #814 reuses its own def.
+_R14_EXECUTION_CHANNEL_ID = "C0B3QB0K1GQ"
+
+
+def check_r14(
+    text: str,
+    *,
+    channel: str | None = None,
+    callsign: str | None = None,
+) -> dict | None:
+    """R14 — ORCHESTRATOR-DISPATCH-DISCIPLINE.
+
+    Strict-zero / inline-token interpretation (dual-CTO ratified):
+      - Applies only to messages on #execution (channel id C0B3QB0K1GQ).
+      - Applies only to Elliot's posts (orchestrator-specific discipline;
+        Aiden/Max/clones don't have orchestrator-dispatch responsibility).
+      - Fires when text matches IDLE_STATUS but NOT DISPATCH_TOKEN.
+      - No-op for #ceo posts (rule only enforces #execution leak),
+        for non-Elliot callsigns, for non-idle messages, and for any
+        message outside #execution.
+
+    Returns a violation dict for fire-to-#ceo, or None on pass / no-op.
+    """
+    if channel != _R14_EXECUTION_CHANNEL_ID:
+        return None
+    if (callsign or "").lower() != _R14_ORCHESTRATOR_CALLSIGN:
+        return None
+    if not _R14_IDLE_STATUS_RE.search(text):
+        return None
+    if _R14_DISPATCH_TOKEN_RE.search(text):
+        return None
+    return {
+        "violation": True,
+        "rule_number": 14,
+        "rule_name": "ORCHESTRATOR-DISPATCH-DISCIPLINE",
+        "detail": "Idle agents enumerated in #execution by Elliot without an "
+        "inline dispatch token in the same message body. Dave directive "
+        "ts ~1778628900: 'agents should never rely on Elliot to dispatch "
+        "routine work — Elliot becomes exception handler only.'",
+        "should_have": (
+            "Pair the idle-agent acknowledgement with a dispatch in the same "
+            "message body (e.g. '[DISPATCH-PROPOSAL:<callsign>] ...', "
+            "'Dispatching <callsign> to KEI-NN', 'EXPLICIT DISPATCH ...', "
+            "'Branch <name> off main') OR run bd ready + assign-first-unblocked "
+            "before posting idle-state."
+        ),
+        "fire_message": "Idle agents enumerated without dispatch — orchestrator "
+        "action gap. [paste message]",
+    }

--- a/tests/bot_common/test_enforcer_r14.py
+++ b/tests/bot_common/test_enforcer_r14.py
@@ -1,0 +1,79 @@
+"""Tests for KEI-34 component 2 — R14 ORCHESTRATOR-DISPATCH-DISCIPLINE."""
+
+from __future__ import annotations
+
+from src.bot_common.enforcer_deterministic import check_r14
+
+EXECUTION_CH = "C0B3QB0K1GQ"
+CEO_CH = "C0B2PM3TV0B"
+
+
+def test_r14_idle_with_dispatch_token_passes():
+    """Elliot acknowledges idle agents AND pairs with dispatch token → pass."""
+    msg = (
+        "idle agents: aiden, max. [DISPATCH-PROPOSAL:aiden] KEI-26 P1 — pick up "
+        "Better Stack incident webhook now."
+    )
+    assert check_r14(msg, channel=EXECUTION_CH, callsign="elliot") is None
+
+
+def test_r14_idle_without_dispatch_fires():
+    """Elliot enumerates idle without dispatch → fire."""
+    msg = "Standing on idle agents: aiden, max — awaiting Max's evidence post."
+    out = check_r14(msg, channel=EXECUTION_CH, callsign="elliot")
+    assert out is not None
+    assert out["rule_number"] == 14
+    assert out["rule_name"] == "ORCHESTRATOR-DISPATCH-DISCIPLINE"
+    assert "without an inline dispatch token" in out["detail"]
+
+
+def test_r14_ready_marker_without_dispatch_fires():
+    """Elliot acknowledges [READY:aiden] without dispatch → fire."""
+    msg = "[READY:aiden] noted. Standing by on Track 1 evidence."
+    out = check_r14(msg, channel=EXECUTION_CH, callsign="elliot")
+    assert out is not None
+    assert out["rule_number"] == 14
+
+
+def test_r14_in_ceo_channel_is_noop():
+    """Same trigger content in #ceo (not #execution) → no-op."""
+    msg = "Standing on idle agents: aiden — awaiting evidence."
+    assert check_r14(msg, channel=CEO_CH, callsign="elliot") is None
+
+
+def test_r14_non_elliot_callsign_is_noop():
+    """Aiden/Max/clones posting same content in #execution → no-op (not orchestrator)."""
+    msg = "Standing on idle agents: aiden, max — awaiting evidence."
+    assert check_r14(msg, channel=EXECUTION_CH, callsign="aiden") is None
+    assert check_r14(msg, channel=EXECUTION_CH, callsign="max") is None
+    assert check_r14(msg, channel=EXECUTION_CH, callsign="atlas") is None
+
+
+def test_r14_non_idle_content_in_execution_is_noop():
+    """Elliot non-idle messages in #execution → no-op."""
+    msg = "[CONCUR:aiden] FINAL on PR #815 — KEI-26 Better Stack incident webhook."
+    assert check_r14(msg, channel=EXECUTION_CH, callsign="elliot") is None
+
+
+def test_r14_explicit_dispatch_token_passes():
+    """The 'EXPLICIT DISPATCH' marker also counts as dispatch token."""
+    msg = "idle agents: aiden, max — EXPLICIT DISPATCH on KEI-34 Step 0 RESTATE NOW"
+    assert check_r14(msg, channel=EXECUTION_CH, callsign="elliot") is None
+
+
+def test_r14_dispatching_verb_passes():
+    """'Dispatching X' counts as dispatch token."""
+    msg = "idle agents: aiden — dispatching aiden to KEI-26 webhook build"
+    assert check_r14(msg, channel=EXECUTION_CH, callsign="elliot") is None
+
+
+def test_r14_picks_up_kei_passes():
+    """'picks up KEI-N' inline reference counts as dispatch token."""
+    msg = "idle agents: aiden — Aiden picks up KEI-26 immediately"
+    assert check_r14(msg, channel=EXECUTION_CH, callsign="elliot") is None
+
+
+def test_r14_no_callsign_is_noop():
+    """No callsign provided → no-op (can't verify orchestrator)."""
+    msg = "idle agents: aiden — no dispatch"
+    assert check_r14(msg, channel=EXECUTION_CH, callsign=None) is None

--- a/tests/scripts/test_orchestrator_discipline_check.py
+++ b/tests/scripts/test_orchestrator_discipline_check.py
@@ -1,0 +1,120 @@
+"""Tests for KEI-34 component 1 — _orchestrator_discipline_check in elliot_polling_loop.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "orchestrator" / "elliot_polling_loop.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("elliot_polling_loop_d", SCRIPT_PATH)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["elliot_polling_loop_d"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def _make_signals(mod, *, bd_ready=(), idle_agents=(), orchestrator_idle_agents=()):
+    return mod.CycleSignals(
+        bd_ready=[{"id": f"Agency_OS-{i}", "title": f"item-{i}", "priority": 1} for i in range(len(bd_ready))],
+        linear_stale=[],
+        idle_agents=list(idle_agents),
+        prefect_failures=[],
+        rate_limit_transitions=[],
+        orchestrator_idle_agents=list(orchestrator_idle_agents),
+    )
+
+
+def test_excess_ready_beyond_idle_fires(mod):
+    """3 ready items + 1 idle agent → 1 paired, 2 excess → fire."""
+    signals = _make_signals(
+        mod, bd_ready=range(3), idle_agents=["aiden"], orchestrator_idle_agents=["aiden"]
+    )
+    dispatches = [("inbox:aiden", "dispatch-for-aiden")]
+    mod._orchestrator_discipline_check(signals, dispatches)
+    ceo_msgs = [m for ch, m in dispatches if ch == mod.CEO_CHANNEL_NAME]
+    assert len(ceo_msgs) == 1
+    assert "orchestrator-discipline gap" in ceo_msgs[0]
+    assert "3 unblocked item(s)" in ceo_msgs[0]
+    assert "1 agent(s) idle ≥1 cycle" in ceo_msgs[0]
+
+
+def test_ready_with_zero_idle_fires(mod):
+    """2 ready + 0 idle → no dispatch path active → fire (zero loose-idle path)."""
+    signals = _make_signals(mod, bd_ready=range(2), idle_agents=[], orchestrator_idle_agents=[])
+    dispatches: list = []
+    mod._orchestrator_discipline_check(signals, dispatches)
+    ceo_msgs = [m for ch, m in dispatches if ch == mod.CEO_CHANNEL_NAME]
+    assert len(ceo_msgs) == 1
+    assert "0 agent(s) idle ≥1 cycle" in ceo_msgs[0]
+
+
+def test_strict_idle_with_no_dispatch_fires(mod):
+    """1 strict-idle agent + 1 ready but 0 paired (compose returned []) → fire on strict-idle path."""
+    signals = _make_signals(
+        mod, bd_ready=range(1), idle_agents=[], orchestrator_idle_agents=["scout"]
+    )
+    dispatches: list = []
+    mod._orchestrator_discipline_check(signals, dispatches)
+    ceo_msgs = [m for ch, m in dispatches if ch == mod.CEO_CHANNEL_NAME]
+    assert len(ceo_msgs) == 1
+    assert "scout" in ceo_msgs[0]
+
+
+def test_paired_with_no_excess_passes(mod):
+    """3 idle + 3 ready → fully paired, no excess, no strict-idle gap → no-op."""
+    signals = _make_signals(
+        mod, bd_ready=range(3),
+        idle_agents=["aiden", "max", "orion"],
+        orchestrator_idle_agents=[],
+    )
+    dispatches: list = [("c", "m"), ("c", "m"), ("c", "m")]
+    mod._orchestrator_discipline_check(signals, dispatches)
+    ceo_msgs = [m for ch, m in dispatches if ch == mod.CEO_CHANNEL_NAME]
+    assert len(ceo_msgs) == 0
+
+
+def test_no_ready_items_is_noop(mod):
+    """Empty bd_ready → no-op regardless of idle agents."""
+    signals = _make_signals(
+        mod, bd_ready=[], idle_agents=["aiden", "max"], orchestrator_idle_agents=["aiden"]
+    )
+    dispatches: list = []
+    mod._orchestrator_discipline_check(signals, dispatches)
+    assert dispatches == []
+
+
+def test_more_loose_idle_than_ready_no_strict_passes(mod):
+    """5 loose-idle + 2 ready + 0 strict-idle → fully paired (min=2), no excess, no strict → no-op."""
+    signals = _make_signals(
+        mod, bd_ready=range(2),
+        idle_agents=["a", "b", "c", "d", "e"],
+        orchestrator_idle_agents=[],
+    )
+    dispatches: list = [("c", "m"), ("c", "m")]
+    mod._orchestrator_discipline_check(signals, dispatches)
+    ceo_msgs = [m for ch, m in dispatches if ch == mod.CEO_CHANNEL_NAME]
+    assert len(ceo_msgs) == 0
+
+
+def test_cycle_period_seconds_peak_returns_60(mod):
+    from datetime import UTC as utc
+    from datetime import datetime
+
+    # 22:00 UTC = 08:00 AEST = peak window
+    assert mod._cycle_period_seconds(datetime(2026, 5, 12, 22, 0, tzinfo=utc)) == 60
+
+
+def test_cycle_period_seconds_offpeak_returns_3600(mod):
+    from datetime import UTC as utc
+    from datetime import datetime
+
+    # 15:00 UTC = 01:00 AEST = off-peak
+    assert mod._cycle_period_seconds(datetime(2026, 5, 12, 15, 0, tzinfo=utc)) == 3600


### PR DESCRIPTION
## Summary

KEI-34 P1 per Dave directive ts ~1778628900 + strict-cycle override ts ~1778629860 + dual-CTO concur (Max ts ~1778629820 + Elliot ts ~1778629779). Mechanises the orchestrator-idle-with-unblocked-work failure mode Dave called out.

## Dave verbatim strict-cycle override (anchor)

> **KEI-34 threshold: 1 polling cycle. Not 15 minutes.**
> Idle agents with unblocked work is the failure we're fixing. 15 minutes is too long. Ship at the strict reading — one cycle (60 seconds peak, 60 minutes off-peak). If noise is a problem after merge, the 5-line swap is trivial. Don't soften the enforcement before we know it's a problem.

Per Dave: my Step 0 assumption (b) "reuse IDLE_AGENT_MINUTES" was overridden. Ship strict.

## Component 1 — polling-loop discipline check

`scripts/orchestrator/elliot_polling_loop.py`:
- New constants: `ORCHESTRATOR_IDLE_CYCLES = 1`, `PEAK_CYCLE_SECONDS = 60`, `OFF_PEAK_CYCLE_SECONDS = 3600`.
- New `_cycle_period_seconds(now)` helper — returns 60 in peak hours, 3600 off-peak.
- New `poll_orchestrator_idle_agents(now)` — same DB shape as `poll_idle_agents` but with strict-cycle cutoff (`ORCHESTRATOR_IDLE_CYCLES * _cycle_period_seconds`).
- `CycleSignals` extended with `orchestrator_idle_agents: list[str]`.
- `_orchestrator_discipline_check()` fires `[PROPOSE:elliot]` to `#ceo` when EITHER:
  - strict-idle agents exist but `compose_dispatches` paired fewer than strict-idle count
  - excess unblocked ready beyond loose-pairing
  - zero loose-idle but non-zero ready

## Component 2 — R14 enforcer rule

`src/bot_common/enforcer_deterministic.py`:
- `check_r14(text, channel, callsign)` paralleling R13 strict-zero / inline-token shape.
- `_R14_IDLE_STATUS_RE`: matches Elliot's idle-agent enumeration (`'idle agents'`, `'[READY:<callsign>]'`, `'agent(s) idle'`, `'standing by on agents'`).
- `_R14_DISPATCH_TOKEN_RE`: matches inline dispatch tokens (`[DISPATCH-PROPOSAL:`, `[DISPATCH:`, `dispatching`, `EXPLICIT (DISPATCH|GO)`, `branch <name>`, `open(ing) PR`, `picks up KEI-N`).
- Channel-gate: `#execution` only. Callsign-gate: `elliot` only (orchestrator-specific).
- Fires on IDLE_STATUS match without DISPATCH_TOKEN.
- `_R14_EXECUTION_CHANNEL_ID` inline (defensive duplicate against Orion PR #814's module-level `EXECUTION_CHANNEL_ID` — dedupe on merge order).

## Tests (54/54 pass, ruff clean, format clean)

- 10 R14 enforcer tests: idle+dispatch passes (4 token variants) / idle-no-dispatch fires (2 patterns) / #ceo no-op / non-Elliot no-op (aiden/max/atlas) / non-idle no-op / no-callsign no-op
- 8 component 1 tests: excess fires / zero-loose-idle fires / strict-idle-no-dispatch fires / paired-no-excess passes / no-ready no-op / more-loose-idle no-op / cycle-period peak=60 / cycle-period off-peak=3600
- 36 existing polling-loop tests still pass (no regression)

```
$ pytest tests/bot_common/test_enforcer_r14.py tests/scripts/test_orchestrator_discipline_check.py tests/scripts/test_elliot_polling_loop.py
============================== 54 passed in 0.39s ==============================
```

## Out of scope

- Cross-callsign discipline (Aiden/Max/clones own queue management — orchestrator-specific only).
- Rule registry wire-in into running enforcer (Dave-directed activation post-merge).
- Changes to existing R10/R11/R13 rules (additive only).
- 5-line swap to softer threshold if noise materialises post-merge (per Dave: only if needed).

## Test plan

- [x] `pytest` — 54/54
- [x] `ruff check` — clean
- [x] `ruff format src/ --check` — clean
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Post-merge: leave 1+ unblocked bd item with strict-idle agent → next peak cycle fires #ceo; Elliot posts idle-agent-status without dispatch token → R14 fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)