### PR TITLE
[ORION] feat(orchestrator): KEI-30 — duplicate-KEI detector (thin wrapper)

### DIFF
--- a/scripts/kei_duplicate_detector.py
+++ b/scripts/kei_duplicate_detector.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""kei_duplicate_detector.py — KEI-30 thin wrapper over `bd find-duplicates`.
+
+Per Elliot dispatch STEP 0 PRE-CONFIRMED ts ~1778630929 (Dave-relay):
+duplicate-KEI detection at issue-create time. Empirical probe confirmed
+`bd find-duplicates` is native (mechanical Jaccard default + AI mode).
+This script wraps that — no bespoke similarity reimplementation
+(per `feedback_empirical_probe_before_concur` lesson: vendor X DOES Y →
+don't bespoke).
+
+Flow on a newly-created Linear KEI:
+    1. Caller invokes this script with the new issue's title + description
+       + Linear issue id (from PR #804 webhook receiver).
+    2. We run `bd find-duplicates --json --status open --threshold <T>`.
+    3. For each `pair` that includes the new issue's mirrored bd id (or
+       whose title-prefix matches), we surface the conflict.
+    4. If `--linear-comment` and the duplicate score >= the comment
+       threshold, we post a Linear comment via the existing GraphQL
+       pattern flagging the existing issue inline for human review
+       (auto-close is OUT of scope per dispatch).
+    5. Emit structured JSON to stdout for the webhook receiver to log.
+
+Output JSON shape (always parseable):
+    {
+      "duplicate_found":     bool,
+      "candidate_title":     str,
+      "candidate_bd_id":     str|null,
+      "best_match": {
+        "bd_id":             str,
+        "title":             str,
+        "similarity":        float,
+        "linear_url":        str|null
+      } | null,
+      "all_matches":         [ {bd_id, title, similarity}, ...],
+      "linear_comment":      "posted" | "skipped" | "failed" | "disabled",
+      "reason":              "above_threshold" | "below_threshold" |
+                             "no_pairs" | "bd_unavailable" | "candidate_not_in_bd"
+    }
+
+Exit codes:
+    0 — duplicate-found OR clean-no-dupe (caller chooses on JSON)
+    1 — bd binary missing or unexpected exception
+
+Out of scope (per dispatch):
+  - Auto-close duplicates (human review only)
+  - Cross-team detection
+  - Webhook receiver wiring (PR #804)
+
+CLI:
+    scripts/kei_duplicate_detector.py \
+        --candidate-bd-id Agency_OS-abc123 \
+        --threshold 0.85 \
+        --linear-comment            # POST a Linear comment on match
+        --linear-issue-id KEI-99    # the just-created Linear KEI to comment on
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+_BD_ID_RE = re.compile(r"^[A-Za-z0-9_]+-[A-Za-z0-9]+$")
+_LINEAR_GRAPHQL = "https://api.linear.app/graphql"
+
+
+def _bd_find_duplicates(
+    bd_bin: str,
+    *,
+    threshold: float,
+    status: str = "open",
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Return parsed JSON from `bd find-duplicates`. Empty dict on failure."""
+    try:
+        result = subprocess.run(
+            [
+                bd_bin,
+                "find-duplicates",
+                "--json",
+                "--status",
+                status,
+                "--threshold",
+                str(threshold),
+                "--limit",
+                str(limit),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return {}
+    if result.returncode != 0:
+        return {}
+    try:
+        return json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+def _filter_pairs_for_candidate(pairs: list[dict], candidate_bd_id: str) -> list[dict]:
+    """Return pairs that involve the candidate, normalised so the OTHER
+    issue is the 'match' (i.e. the existing duplicate)."""
+    matches: list[dict] = []
+    for p in pairs:
+        a = p.get("a") or {}
+        b = p.get("b") or {}
+        sim = float(p.get("similarity", 0.0))
+        if a.get("id") == candidate_bd_id:
+            matches.append({"bd_id": b.get("id"), "title": b.get("title"), "similarity": sim})
+        elif b.get("id") == candidate_bd_id:
+            matches.append({"bd_id": a.get("id"), "title": a.get("title"), "similarity": sim})
+    matches.sort(key=lambda m: m["similarity"], reverse=True)
+    return matches
+
+
+def _post_linear_comment(
+    *,
+    linear_issue_id: str,
+    body: str,
+    api_key: str,
+) -> bool:
+    """Linear GraphQL commentCreate. Returns True on ok=true, else False.
+    Best-effort: any network/JSON failure returns False without raising."""
+    query = (
+        "mutation Comment($issueId: String!, $body: String!) {"
+        "  commentCreate(input: {issueId: $issueId, body: $body}) {"
+        "    success comment { id } } }"
+    )
+    payload = json.dumps(
+        {"query": query, "variables": {"issueId": linear_issue_id, "body": body}}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        _LINEAR_GRAPHQL,
+        data=payload,
+        headers={
+            "Authorization": api_key,
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            body_obj = json.loads(r.read())
+    except (urllib.error.URLError, OSError, json.JSONDecodeError):
+        return False
+    return bool((body_obj.get("data") or {}).get("commentCreate", {}).get("success"))
+
+
+def _format_linear_comment(best_match: dict) -> str:
+    return (
+        f":mag: **Possible duplicate detected** (similarity "
+        f"{best_match['similarity']:.2f}).\n\n"
+        f"Existing issue: **{best_match['title']}** "
+        f"(`{best_match['bd_id']}`).\n\n"
+        f"_Flagged for human review by KEI-30 duplicate detector. "
+        f"Not auto-closed._"
+    )
+
+
+def run(
+    *,
+    candidate_bd_id: str,
+    threshold: float = 0.85,
+    linear_comment: bool = False,
+    linear_issue_id: str | None = None,
+    bd_bin: str = "bd",
+    bd_fn=None,
+    comment_fn=None,
+) -> dict[str, Any]:
+    """Pure-Python entry point. Side effects injectable for tests."""
+    bd_fn = bd_fn or (lambda: _bd_find_duplicates(bd_bin, threshold=threshold))
+
+    base = {
+        "duplicate_found": False,
+        "candidate_title": None,
+        "candidate_bd_id": candidate_bd_id,
+        "best_match": None,
+        "all_matches": [],
+        "linear_comment": "disabled" if not linear_comment else "skipped",
+        "reason": "no_pairs",
+    }
+
+    if not _BD_ID_RE.fullmatch(candidate_bd_id or ""):
+        base["reason"] = "candidate_not_in_bd"
+        return base
+
+    if not shutil.which(bd_bin) and bd_bin == "bd":
+        base["reason"] = "bd_unavailable"
+        return base
+
+    data = bd_fn()
+    pairs = data.get("pairs") or []
+    matches = _filter_pairs_for_candidate(pairs, candidate_bd_id)
+    base["all_matches"] = matches
+
+    if not matches:
+        base["reason"] = "no_pairs"
+        return base
+
+    best = matches[0]
+    base["best_match"] = best
+    if best["similarity"] < threshold:
+        base["reason"] = "below_threshold"
+        return base
+
+    base["duplicate_found"] = True
+    base["reason"] = "above_threshold"
+
+    if linear_comment and linear_issue_id:
+        api_key = os.environ.get("LINEAR_API_KEY", "")
+        body = _format_linear_comment(best)
+        commenter = comment_fn or (
+            lambda iid, b: _post_linear_comment(linear_issue_id=iid, body=b, api_key=api_key)
+        )
+        ok = commenter(linear_issue_id, body)
+        base["linear_comment"] = "posted" if ok else "failed"
+
+    return base
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-bd-id", required=True)
+    parser.add_argument("--threshold", type=float, default=0.85)
+    parser.add_argument("--bd", default="bd")
+    parser.add_argument("--linear-comment", action="store_true")
+    parser.add_argument("--linear-issue-id", default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        result = run(
+            candidate_bd_id=args.candidate_bd_id,
+            threshold=args.threshold,
+            linear_comment=args.linear_comment,
+            linear_issue_id=args.linear_issue_id,
+            bd_bin=args.bd,
+        )
+    except Exception as exc:  # pragma: no cover — defensive
+        print(json.dumps({"duplicate_found": False, "reason": f"exception: {exc}"}))
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kei_duplicate_detector.py
+++ b/scripts/kei_duplicate_detector.py
@@ -63,11 +63,10 @@ import re
 import shutil
 import subprocess
 import sys
-import urllib.error
 import urllib.request
 from typing import Any
 
-_BD_ID_RE = re.compile(r"^[A-Za-z0-9_]+-[A-Za-z0-9]+$")
+_BD_ID_RE = re.compile(r"^\w+-[A-Za-z0-9]+$")
 _LINEAR_GRAPHQL = "https://api.linear.app/graphql"
 
 
@@ -150,7 +149,8 @@ def _post_linear_comment(
     try:
         with urllib.request.urlopen(req, timeout=15) as r:
             body_obj = json.loads(r.read())
-    except (urllib.error.URLError, OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError):
+        # urllib.error.URLError subclasses OSError — single tuple entry covers both.
         return False
     return bool((body_obj.get("data") or {}).get("commentCreate", {}).get("success"))
 

--- a/tests/orchestrator/test_kei_duplicate_detector.py
+++ b/tests/orchestrator/test_kei_duplicate_detector.py
@@ -1,0 +1,241 @@
+"""Tests for scripts/kei_duplicate_detector.py — KEI-30.
+
+bd find-duplicates + Linear commentCreate are injected via bd_fn /
+comment_fn. No real bd, no real Linear network.
+
+Covers:
+  - duplicate above threshold → flagged + Linear comment posted
+  - duplicate below threshold → not flagged, no comment
+  - no pairs returned → clean no-dupe
+  - candidate not present in bd output → no_pairs fallthrough
+  - candidate ID malformed → candidate_not_in_bd
+  - bd output parsing tolerates malformed json (returns {})
+  - linear_comment=False → linear_comment field reads 'disabled'
+  - Linear comment failure → linear_comment='failed', but duplicate_found stays true
+  - multiple matches sorted by similarity desc; best_match is the top one
+  - candidate appears in either side ('a' or 'b') of the pair
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "kei_duplicate_detector.py"
+_spec = importlib.util.spec_from_file_location("kei_duplicate_detector", SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["kei_duplicate_detector"] = mod
+_spec.loader.exec_module(mod)
+
+
+def _bd_response(pairs: list[dict]) -> dict:
+    return {
+        "count": len(pairs),
+        "method": "mechanical",
+        "pairs": pairs,
+        "schema_version": 1,
+        "threshold": 0.5,
+    }
+
+
+def _pair(a_id: str, b_id: str, similarity: float, *, a_title="A", b_title="B") -> dict:
+    return {
+        "a": {"id": a_id, "title": a_title},
+        "b": {"id": b_id, "title": b_title},
+        "similarity": similarity,
+    }
+
+
+# ─── 1. Duplicate above threshold → flagged + comment posted ────────────
+
+
+def test_duplicate_above_threshold_flags_and_posts_comment():
+    pairs = [_pair("Agency_OS-cand", "Agency_OS-exist", 0.92, b_title="Existing KEI")]
+    comments: list[tuple[str, str]] = []
+
+    result = mod.run(
+        candidate_bd_id="Agency_OS-cand",
+        threshold=0.85,
+        linear_comment=True,
+        linear_issue_id="KEI-99",
+        bd_fn=lambda: _bd_response(pairs),
+        comment_fn=lambda iid, body: comments.append((iid, body)) or True,
+    )
+
+    assert result["duplicate_found"] is True
+    assert result["reason"] == "above_threshold"
+    assert result["best_match"]["bd_id"] == "Agency_OS-exist"
+    assert result["best_match"]["similarity"] == 0.92
+    assert result["linear_comment"] == "posted"
+    assert len(comments) == 1
+    assert comments[0][0] == "KEI-99"
+    assert "0.92" in comments[0][1]
+    assert "Existing KEI" in comments[0][1]
+
+
+# ─── 2. Duplicate below threshold → not flagged ─────────────────────────
+
+
+def test_duplicate_below_threshold_does_not_flag():
+    pairs = [_pair("Agency_OS-cand", "Agency_OS-exist", 0.40)]
+    comments: list = []
+
+    result = mod.run(
+        candidate_bd_id="Agency_OS-cand",
+        threshold=0.85,
+        linear_comment=True,
+        linear_issue_id="KEI-99",
+        bd_fn=lambda: _bd_response(pairs),
+        comment_fn=lambda i, b: comments.append((i, b)) or True,
+    )
+
+    assert result["duplicate_found"] is False
+    assert result["reason"] == "below_threshold"
+    assert result["best_match"]["similarity"] == 0.40
+    assert comments == []
+
+
+# ─── 3. No pairs returned → no_pairs ────────────────────────────────────
+
+
+def test_no_pairs_returns_clean_no_dupe():
+    result = mod.run(
+        candidate_bd_id="Agency_OS-cand",
+        threshold=0.85,
+        bd_fn=lambda: _bd_response([]),
+    )
+    assert result["duplicate_found"] is False
+    assert result["reason"] == "no_pairs"
+    assert result["best_match"] is None
+
+
+# ─── 4. Candidate absent from bd output → no_pairs ──────────────────────
+
+
+def test_candidate_absent_from_pairs_returns_no_pairs():
+    """Bd returned pairs but none involve the candidate id — same shape as
+    'no pairs' from the candidate's perspective."""
+    pairs = [_pair("Agency_OS-x", "Agency_OS-y", 0.90)]
+    result = mod.run(
+        candidate_bd_id="Agency_OS-cand",
+        threshold=0.85,
+        bd_fn=lambda: _bd_response(pairs),
+    )
+    assert result["duplicate_found"] is False
+    assert result["reason"] == "no_pairs"
+    assert result["all_matches"] == []
+
+
+# ─── 5. Malformed candidate ID → candidate_not_in_bd ────────────────────
+
+
+def test_malformed_candidate_id_rejected():
+    for bad in ("", "no-prefix-or-suffix", "spaces in id", "../etc/passwd"):
+        result = mod.run(
+            candidate_bd_id=bad,
+            threshold=0.85,
+            bd_fn=lambda: _bd_response([]),
+        )
+        assert result["reason"] == "candidate_not_in_bd", f"failed: {bad!r}"
+
+
+# ─── 6. linear_comment=False → comment field reads 'disabled' ───────────
+
+
+def test_linear_comment_disabled_when_flag_off():
+    pairs = [_pair("Agency_OS-cand", "Agency_OS-exist", 0.95)]
+    result = mod.run(
+        candidate_bd_id="Agency_OS-cand",
+        threshold=0.85,
+        linear_comment=False,
+        bd_fn=lambda: _bd_response(pairs),
+    )
+    assert result["duplicate_found"] is True
+    assert result["linear_comment"] == "disabled"
+
+
+# ─── 7. Linear comment failure → marked failed, duplicate_found stays ──
+
+
+def test_linear_comment_failure_marks_failed_but_keeps_duplicate_found():
+    """Comment posting is best-effort; a Linear API outage must NOT
+    swallow the duplicate signal from the caller's perspective."""
+    pairs = [_pair("Agency_OS-cand", "Agency_OS-exist", 0.95)]
+    result = mod.run(
+        candidate_bd_id="Agency_OS-cand",
+        threshold=0.85,
+        linear_comment=True,
+        linear_issue_id="KEI-99",
+        bd_fn=lambda: _bd_response(pairs),
+        comment_fn=lambda i, b: False,  # Linear API error
+    )
+    assert result["duplicate_found"] is True
+    assert result["linear_comment"] == "failed"
+
+
+# ─── 8. Multiple matches sorted by similarity desc ──────────────────────
+
+
+def test_multiple_matches_sorted_best_first():
+    pairs = [
+        _pair("Agency_OS-cand", "Agency_OS-mid", 0.72, b_title="Mid"),
+        _pair("Agency_OS-cand", "Agency_OS-top", 0.93, b_title="Top"),
+        _pair("Agency_OS-cand", "Agency_OS-low", 0.51, b_title="Low"),
+    ]
+    result = mod.run(
+        candidate_bd_id="Agency_OS-cand",
+        threshold=0.85,
+        bd_fn=lambda: _bd_response(pairs),
+    )
+    assert result["best_match"]["bd_id"] == "Agency_OS-top"
+    assert [m["bd_id"] for m in result["all_matches"]] == [
+        "Agency_OS-top",
+        "Agency_OS-mid",
+        "Agency_OS-low",
+    ]
+
+
+# ─── 9. Candidate appears as 'b' side of pair ───────────────────────────
+
+
+def test_candidate_on_b_side_of_pair_still_matches():
+    pairs = [_pair("Agency_OS-exist", "Agency_OS-cand", 0.91, a_title="Existing")]
+    result = mod.run(
+        candidate_bd_id="Agency_OS-cand",
+        threshold=0.85,
+        bd_fn=lambda: _bd_response(pairs),
+    )
+    assert result["duplicate_found"] is True
+    assert result["best_match"]["bd_id"] == "Agency_OS-exist"
+    assert result["best_match"]["title"] == "Existing"
+
+
+# ─── 10. bd_fn returns empty dict (parse failure) → no_pairs ────────────
+
+
+def test_bd_parse_failure_falls_through_to_no_pairs():
+    result = mod.run(
+        candidate_bd_id="Agency_OS-cand",
+        threshold=0.85,
+        bd_fn=lambda: {},  # simulates bd unavailable / malformed JSON
+    )
+    assert result["duplicate_found"] is False
+    assert result["reason"] == "no_pairs"
+
+
+# ─── 11. CLI main exits 0 + prints JSON ─────────────────────────────────
+
+
+def test_cli_main_prints_json_exit_zero(capsys, monkeypatch):
+    import json as _json
+
+    monkeypatch.setattr(mod, "_bd_find_duplicates", lambda *a, **kw: _bd_response([]))
+    rc = mod.main(["--candidate-bd-id", "Agency_OS-test"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = _json.loads(out)
+    assert payload["candidate_bd_id"] == "Agency_OS-test"
+    assert payload["duplicate_found"] is False

--- a/tests/orchestrator/test_kei_duplicate_detector.py
+++ b/tests/orchestrator/test_kei_duplicate_detector.py
@@ -22,6 +22,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "kei_duplicate_detector.py"
 _spec = importlib.util.spec_from_file_location("kei_duplicate_detector", SCRIPT)
@@ -68,7 +70,7 @@ def test_duplicate_above_threshold_flags_and_posts_comment():
     assert result["duplicate_found"] is True
     assert result["reason"] == "above_threshold"
     assert result["best_match"]["bd_id"] == "Agency_OS-exist"
-    assert result["best_match"]["similarity"] == 0.92
+    assert result["best_match"]["similarity"] == pytest.approx(0.92)
     assert result["linear_comment"] == "posted"
     assert len(comments) == 1
     assert comments[0][0] == "KEI-99"
@@ -94,7 +96,7 @@ def test_duplicate_below_threshold_does_not_flag():
 
     assert result["duplicate_found"] is False
     assert result["reason"] == "below_threshold"
-    assert result["best_match"]["similarity"] == 0.40
+    assert result["best_match"]["similarity"] == pytest.approx(0.40)
     assert comments == []
 
 


### PR DESCRIPTION
## Summary

Closes **KEI-30** (`Agency_OS-m3cwj7`) per Elliot dispatch `STEP 0 PRE-CONFIRMED` ts ~1778630929 (Dave-relay). Duplicate detection at Linear KEI create-time.

## Empirical probe first (per `feedback_empirical_probe_before_concur` lesson)

```
$ bd find-duplicates --help
Find issues that are semantically similar but not exact duplicates.
  Approaches:
    mechanical  Token-based text similarity (default, no API key needed)
    ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY)
  Flags: --method, --threshold, --json, --status, --limit

$ bd find-duplicates --json --status open --limit 5
{"count": 0, "method": "mechanical", "pairs": [],
 "schema_version": 1, "threshold": 0.5}
```

**`bd find-duplicates` IS native.** Per dispatch literal *"If yes → wrap + close KEI-30 with audit note (like the bd linear sync lesson)"* — this PR is the **wrapper**, not a reimplementation.

## Deliverables

| File | LoC | Purpose |
|---|---|---|
| `scripts/kei_duplicate_detector.py` | ~245 | Thin wrapper over `bd find-duplicates` + Linear `commentCreate` flag-on-match |
| `tests/orchestrator/test_kei_duplicate_detector.py` | ~250 | 11/11 mocked tests (no real bd, no real Linear network) |

## Behaviour

1. CLI invoked by PR #804 webhook receiver with `--candidate-bd-id <id> --linear-issue-id <KEI-N>`
2. Runs `bd find-duplicates --json --status open --threshold <T>` (default `T=0.85` per dispatch)
3. Filters returned pairs to those involving the candidate bd id
4. Sorts matches by similarity desc; best-match is the top
5. If best-match similarity ≥ threshold → `duplicate_found=true`
6. If `--linear-comment` + `--linear-issue-id` given → posts Linear `commentCreate` GraphQL mutation flagging the existing issue inline for **human review** (auto-close is OUT of scope per dispatch)
7. Always emits structured JSON to stdout

## Output JSON shape

```json
{
  "duplicate_found":  bool,
  "candidate_bd_id":  string,
  "best_match":       { "bd_id", "title", "similarity" } | null,
  "all_matches":      [ { "bd_id", "title", "similarity" }, ... ],
  "linear_comment":   "posted" | "skipped" | "failed" | "disabled",
  "reason":           "above_threshold" | "below_threshold" | "no_pairs"
                    | "bd_unavailable" | "candidate_not_in_bd"
}
```

## Pattern A safety

- Candidate bd id regex-validated (`^[A-Za-z0-9_]+-[A-Za-z0-9]+$`) — no shell injection
- `bd` binary missing → `bd_unavailable` reason, no crash
- `bd` JSON parse failure → empty dict → `no_pairs` fallthrough
- Linear comment failure → `failed` reason but `duplicate_found` stays `true` (best-effort comment doesn't swallow the signal)
- Auto-close explicitly out of scope (human-review only per dispatch)

## Tests (11/11 pass, ruff + format clean)

| # | Test | Covers |
|---|---|---|
| 1 | duplicate_above_threshold_flags_and_posts_comment | Happy path — flag + comment |
| 2 | duplicate_below_threshold_does_not_flag | Threshold gate |
| 3 | no_pairs_returns_clean_no_dupe | Empty bd output path |
| 4 | candidate_absent_from_pairs_returns_no_pairs | Bd returned pairs but none involve candidate |
| 5 | malformed_candidate_id_rejected | Injection-safety |
| 6 | linear_comment_disabled_when_flag_off | Flag-off path |
| 7 | linear_comment_failure_marks_failed_but_keeps_duplicate_found | Best-effort comment doesn't swallow duplicate signal |
| 8 | multiple_matches_sorted_best_first | Sort policy |
| 9 | candidate_on_b_side_of_pair_still_matches | Symmetric pair matching |
| 10 | bd_parse_failure_falls_through_to_no_pairs | Bd-output-malformed fallthrough |
| 11 | cli_main_prints_json_exit_zero | CLI smoke |

```
$ pytest tests/orchestrator/test_kei_duplicate_detector.py -q
11 passed in 0.50s

$ ruff check scripts/kei_duplicate_detector.py tests/orchestrator/test_kei_duplicate_detector.py
All checks passed!
$ ruff format --check ...
2 files already formatted
```

## Out of scope (per dispatch literal)

- **Auto-close duplicates** — human review only
- **Cross-team detection** — single-team only
- **Wiring into PR #804 webhook receiver** — mechanism shipped; activation is Dave-directed

## Activation flow this PR enables

```bash
# PR #804 webhook receiver invokes on Issue.create:
python3 scripts/kei_duplicate_detector.py \
    --candidate-bd-id "$BD_ID" \
    --linear-comment \
    --linear-issue-id "$LINEAR_ISSUE_ID" \
    --threshold 0.85
# Output → JSON for the webhook handler to log / forward to #ceo if duplicate_found
```

## LAW XVI

Isolated worktree `/tmp/orion-kei30` (Atlas-swap `.claude/*` symlink bypass), cleaned up post-push.

## Test plan

- [x] Empirical probe confirms bd find-duplicates is native (audit note in commit)
- [x] 11 mocked tests pass; ruff + format clean
- [x] Pattern A safety: regex-validated input, best-effort externals
- [x] Auto-close NOT implemented (per dispatch)
- [ ] Post-merge: PR #804 webhook receiver wires this script

## Dual-CTO concur

Aiden + Max please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)