### PR TITLE
[AIDEN] feat(kei34-v2): 3 orchestrator-discipline additions atomic PR

### DIFF
--- a/scripts/auto_pull_main.sh
+++ b/scripts/auto_pull_main.sh
@@ -47,6 +47,13 @@ _alerted_path() {
     echo "$(_state_path "$1").alerted"
 }
 
+# KEI-34 v2 Addition 2 — dirty-worktree #ceo escalation flag (distinct from
+# .alerted which goes to #execution). Separate state file avoids alert-spam
+# both channels.
+_alerted_ceo_path() {
+    echo "$(_state_path "$1").alerted-ceo"
+}
+
 _streak_get() {
     local f
     f=$(_state_path "$1")
@@ -62,7 +69,7 @@ _streak_inc() {
 }
 
 _streak_reset() {
-    rm -f "$(_state_path "$1")" "$(_alerted_path "$1")" 2>/dev/null || true
+    rm -f "$(_state_path "$1")" "$(_alerted_path "$1")" "$(_alerted_ceo_path "$1")" 2>/dev/null || true
 }
 
 _emit_alert() {
@@ -80,11 +87,41 @@ _emit_alert() {
     touch "$alerted_flag" 2>/dev/null || true
 }
 
+# KEI-34 v2 Addition 2 — escalate to #ceo on dirty-worktree-skip-streak >=2.
+# Distinct alert channel + state flag from the #execution alert. Stale code
+# running silently is worse than no code running per Dave verbatim ts ~1778631000.
+_emit_dirty_worktree_ceo_alert() {
+    # $1 = worktree, $2 = reason (only fires when reason contains "working tree dirty")
+    case "$2" in
+        *"working tree dirty"*) ;;
+        *) return 0 ;;
+    esac
+    local alerted_ceo_flag
+    alerted_ceo_flag=$(_alerted_ceo_path "$1")
+    [ -f "$alerted_ceo_flag" ] && return 0   # already alerted #ceo this streak
+    local streak msg
+    streak=$(_streak_get "$1")
+    local minutes=$((streak * 5))
+    msg="[PROPOSE:elliot] DIRTY WORKTREE STALE CODE — $1 has had a dirty working tree for $streak consecutive auto-pull cycles (~${minutes}m). The polling loop is running STALE code that does not include recently-merged PRs. Resolve the dirty state immediately (stash or commit) so origin/main can ff-merge and the loop deploys current code. Per Dave verbatim ts ~1778631000."
+    if [ -x "$RELAY" ] || [ -r "$RELAY" ]; then
+        /home/elliotbot/clawd/venv/bin/python3 "$RELAY" -g "$msg" -c ceo >/dev/null 2>&1 || true
+    fi
+    touch "$alerted_ceo_flag" 2>/dev/null || true
+}
+
+# KEI-34 v2 Addition 2 threshold: 2 consecutive dirty skips is enough.
+# Dirty worktree = stale code, separate concern from the 3-cycle generic alert.
+DIRTY_WORKTREE_CEO_THRESHOLD="${AGENCY_OS_DIRTY_WORKTREE_CEO_THRESHOLD:-2}"
+
 _handle_skip() {
     # $1 = worktree, $2 = reason
     _streak_inc "$1"
     local streak
     streak=$(_streak_get "$1")
+    # Dirty-worktree-specific #ceo escalation at streak >= 2 (Addition 2).
+    if [ "$streak" -ge "$DIRTY_WORKTREE_CEO_THRESHOLD" ]; then
+        _emit_dirty_worktree_ceo_alert "$1" "$2"
+    fi
     if [ "$streak" -ge "$SKIP_ALERT_THRESHOLD" ]; then
         _emit_alert "$1" "$2"
     fi

--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -269,6 +269,108 @@ def poll_idle_agents(now: datetime | None = None) -> list[str]:
         return []
 
 
+def _descendant_pids(pid: int) -> list[int]:
+    """Walk the process tree under pid, returning all descendant PIDs.
+
+    KEI-34 v2 Addition 3 — empirical Max diagnostic 2026-05-13:
+      bash pane_pid (S 0% CPU) → bash wrapper child (S) → bash -c child (S)
+      → python3 ingest grandchild (R 78% CPU). Single-level pgrep -P misses
+      the long-running grandchild. Recursive walk is required.
+    """
+    descendants: list[int] = []
+    frontier = [pid]
+    seen: set[int] = {pid}
+    while frontier:
+        next_frontier: list[int] = []
+        for p in frontier:
+            try:
+                proc = subprocess.run(  # noqa: S603 — controlled args, no shell, pid is int
+                    ["pgrep", "-P", str(p)],
+                    capture_output=True,
+                    text=True,
+                    timeout=3,
+                    check=False,
+                )
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+                continue
+            if proc.returncode != 0:
+                continue
+            for line in proc.stdout.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    child = int(line)
+                except ValueError:
+                    continue
+                if child in seen:
+                    continue
+                seen.add(child)
+                descendants.append(child)
+                next_frontier.append(child)
+        frontier = next_frontier
+    return descendants
+
+
+def _agent_has_active_subprocess(callsign: str) -> bool:
+    """KEI-34 v2 Addition 3 — return True iff the callsign's tmux session has
+    ANY descendant process in R state OR with CPU > 0%.
+
+    Walks the full process tree under the pane_pid (per Max's diagnostic
+    ts ~1778631099: bash parent S 0% CPU + python3 grandchild R 78% CPU
+    is the canonical false-positive case). Single-level pgrep -P missed
+    the grandchild.
+
+    Best-effort: any subprocess/tmux failure returns False (conservative —
+    don't suppress idle dispatch if we can't probe).
+    """
+    session = CALLSIGN_TO_TMUX.get(callsign.lower())
+    if not session:
+        return False
+    try:
+        pane_proc = subprocess.run(  # noqa: S603 — controlled args, no shell
+            ["tmux", "list-panes", "-t", f"{session}:0", "-F", "#{pane_pid}"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    if pane_proc.returncode != 0:
+        return False
+    try:
+        pane_pid = int(pane_proc.stdout.strip().splitlines()[0])
+    except (IndexError, ValueError):
+        return False
+    pids_to_check = [pane_pid, *_descendant_pids(pane_pid)]
+    try:
+        ps_proc = subprocess.run(  # noqa: S603 — controlled args, no shell
+            ["ps", "-p", ",".join(str(p) for p in pids_to_check), "-o", "stat=,pcpu="],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    if ps_proc.returncode != 0:
+        return False
+    for line in ps_proc.stdout.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        stat = parts[0]
+        try:
+            cpu = float(parts[1])
+        except ValueError:
+            continue
+        # R = running; CPU > 0 = active in last sample window.
+        if "R" in stat or cpu > 0.0:
+            return True
+    return False
+
+
 def poll_orchestrator_idle_agents(now: datetime | None = None) -> list[str]:
     """KEI-34 strict-cycle threshold per Dave verbatim ts ~1778629860.
 
@@ -315,10 +417,13 @@ def poll_orchestrator_idle_agents(now: datetime | None = None) -> list[str]:
         ]
 
     try:
-        return asyncio.run(_q())
+        timestamp_idle = asyncio.run(_q())
     except (OSError, RuntimeError, Exception) as exc:  # noqa: BLE001 — best-effort
         logger.warning("orchestrator-idle query failed: %s", exc)
         return []
+    # KEI-34 v2 Addition 3 — filter out callsigns whose tmux session has an
+    # active descendant subprocess (Cognee ingest / long-running tool case).
+    return [cs for cs in timestamp_idle if not _agent_has_active_subprocess(cs)]
 
 
 def poll_prefect_failures(now: datetime | None = None) -> list[dict]:
@@ -674,6 +779,7 @@ def run_cycle(now: datetime | None = None) -> int:
     )
     if not should_run_now(now):
         logger.info("outside peak window + minute!=0 → silent skip")
+        _emit_dispatch_outcome_heartbeat([], None, no_work=True)
         return 0
     signals = collect_signals(now)
     if signals.is_silent():
@@ -684,11 +790,52 @@ def run_cycle(now: datetime | None = None) -> int:
             len(signals.idle_agents),
             len(signals.prefect_failures),
         )
+        _emit_dispatch_outcome_heartbeat([], signals, no_work=True)
         return 0
     dispatches = compose_dispatches(signals)
     for channel, text in dispatches:
         send_dispatch(channel, text)
+    _emit_dispatch_outcome_heartbeat(dispatches, signals, no_work=False)
     return len(dispatches)
+
+
+def _emit_dispatch_outcome_heartbeat(
+    dispatches: list[tuple[str, str]],
+    signals: CycleSignals | None,
+    *,
+    no_work: bool,
+) -> None:
+    """KEI-34 v2 Addition 1 — Better Stack dispatch-outcome heartbeat per Dave
+    verbatim ts ~1778631000.
+
+    Fires the heartbeat URL only when:
+      (a) one or more dispatches were emitted this cycle, OR
+      (b) no_work=True (genuine no-work state — silent skip OR is_silent()).
+
+    If the loop runs but idle agents exist AND ready work exists AND no
+    dispatch fires → no heartbeat fires → Better Stack alerts within 2 min
+    (per Dave's spec).
+
+    Env: BETTERSTACK_HB_DISPATCH_OUTCOME (operator-provisioned post-merge).
+    """
+    url = os.environ.get("BETTERSTACK_HB_DISPATCH_OUTCOME", "")
+    if not url:
+        return
+    # Suppress heartbeat when there IS work but no dispatch fired — that's
+    # the orchestrator-discipline-gap case BS should alert on.
+    if not no_work and not dispatches:
+        if signals is not None and (signals.bd_ready or signals.orchestrator_idle_agents):
+            return
+    try:
+        subprocess.run(  # noqa: S603 — controlled args, no shell
+            ["curl", "-fsS", "-m", "5", url],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("BS dispatch-outcome heartbeat failed: %s", exc)
 
 
 def _heartbeat() -> None:

--- a/tests/scripts/test_kei34_v2_additions.py
+++ b/tests/scripts/test_kei34_v2_additions.py
@@ -1,0 +1,207 @@
+"""Tests for KEI-34 v2 — 3 additions per Dave verbatim ts ~1778631000."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "elliot_polling_loop.py"
+AUTO_PULL_SCRIPT = REPO_ROOT / "scripts" / "auto_pull_main.sh"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("elliot_polling_loop_v2", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["elliot_polling_loop_v2"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+# ── Addition 1 — BS dispatch-outcome heartbeat ──────────────────────────────
+
+
+def test_heartbeat_skips_when_env_unset(mod, monkeypatch):
+    monkeypatch.delenv("BETTERSTACK_HB_DISPATCH_OUTCOME", raising=False)
+    called: list = []
+
+    def _fake_run(*args, **kwargs):
+        called.append(args)
+        return subprocess.CompletedProcess(args=[], returncode=0)
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    mod._emit_dispatch_outcome_heartbeat([("x", "y")], None, no_work=False)
+    assert called == []
+
+
+def test_heartbeat_fires_on_dispatch(mod, monkeypatch):
+    monkeypatch.setenv("BETTERSTACK_HB_DISPATCH_OUTCOME", "https://hb.example/abc")
+    called: list = []
+
+    def _fake_run(args, **kwargs):
+        called.append(args)
+        return subprocess.CompletedProcess(args=args, returncode=0)
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    mod._emit_dispatch_outcome_heartbeat([("#execution", "...")], None, no_work=False)
+    assert len(called) == 1
+    assert called[0][0] == "curl"
+
+
+def test_heartbeat_fires_on_no_work(mod, monkeypatch):
+    """no_work=True (silent skip OR is_silent()) → heartbeat fires."""
+    monkeypatch.setenv("BETTERSTACK_HB_DISPATCH_OUTCOME", "https://hb.example/abc")
+    called: list = []
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: called.append(a) or subprocess.CompletedProcess(args=[], returncode=0))
+    mod._emit_dispatch_outcome_heartbeat([], None, no_work=True)
+    assert len(called) == 1
+
+
+def test_heartbeat_suppressed_when_work_exists_but_no_dispatch(mod, monkeypatch):
+    """The orchestrator-discipline-gap case: bd_ready+idle but dispatches=[].
+    Heartbeat must NOT fire so BS dashboard alerts."""
+    monkeypatch.setenv("BETTERSTACK_HB_DISPATCH_OUTCOME", "https://hb.example/abc")
+    called: list = []
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: called.append(a) or subprocess.CompletedProcess(args=[], returncode=0))
+    signals = mod.CycleSignals(
+        bd_ready=[{"id": "x"}],
+        linear_stale=[],
+        idle_agents=[],
+        prefect_failures=[],
+        orchestrator_idle_agents=["aiden"],
+    )
+    mod._emit_dispatch_outcome_heartbeat([], signals, no_work=False)
+    assert called == []
+
+
+# ── Addition 2 — dirty-worktree #ceo escalation (auto_pull_main.sh) ─────────
+
+
+def test_dirty_worktree_ceo_alert_helper_fires_on_dirty_streak(tmp_path):
+    """Bash helper test: _emit_dirty_worktree_ceo_alert fires when streak>=2 + reason matches."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    relay_log = tmp_path / "ceo_relay.log"
+    helper = tmp_path / "drive.sh"
+    helper.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+export AGENCY_OS_AUTO_PULL_STATE_DIR="{state_dir}"
+export AGENCY_OS_DIRTY_WORKTREE_CEO_THRESHOLD=2
+export AGENCY_OS_AUTO_PULL_RELAY="{tmp_path / 'shim' / 'slack_relay.py'}"
+mkdir -p "{tmp_path / 'shim'}"
+cat > "{tmp_path / 'shim' / 'slack_relay.py'}" <<'PY'
+#!/usr/bin/env python3
+import sys
+open("{relay_log}", "a").write(" ".join(sys.argv[1:]) + chr(10))
+PY
+chmod +x "{tmp_path / 'shim' / 'slack_relay.py'}"
+
+SKIP_ALERT_THRESHOLD=3
+STATE_DIR="$AGENCY_OS_AUTO_PULL_STATE_DIR"
+RELAY="$AGENCY_OS_AUTO_PULL_RELAY"
+DIRTY_WORKTREE_CEO_THRESHOLD="$AGENCY_OS_DIRTY_WORKTREE_CEO_THRESHOLD"
+mkdir -p "$STATE_DIR"
+source <(sed -n '/^_state_path()/,/^for wt in/p' "{AUTO_PULL_SCRIPT}" | sed '/^for wt in/d')
+WT="/tmp/test-wt"
+_handle_skip "$WT" "working tree dirty"
+_handle_skip "$WT" "working tree dirty"
+_handle_skip "$WT" "working tree dirty"
+"""
+    )
+    helper.chmod(0o755)
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(helper)], capture_output=True, text=True, timeout=10
+    )
+    assert result.returncode == 0, result.stderr
+    relay_lines = relay_log.read_text().splitlines() if relay_log.exists() else []
+    ceo_lines = [line for line in relay_lines if "-c ceo" in line]
+    assert len(ceo_lines) == 1, f"expected one #ceo alert, got {ceo_lines!r}"
+    assert "DIRTY WORKTREE STALE CODE" in ceo_lines[0]
+
+
+def test_dirty_worktree_ceo_alert_skips_non_dirty_reason(tmp_path):
+    """Non-dirty SKIP reasons (on feature branch, etc.) don't fire #ceo alert."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    relay_log = tmp_path / "relay.log"
+    helper = tmp_path / "drive.sh"
+    helper.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+export AGENCY_OS_AUTO_PULL_STATE_DIR="{state_dir}"
+export AGENCY_OS_DIRTY_WORKTREE_CEO_THRESHOLD=2
+export AGENCY_OS_AUTO_PULL_RELAY="{tmp_path / 'shim' / 'slack_relay.py'}"
+mkdir -p "{tmp_path / 'shim'}"
+cat > "{tmp_path / 'shim' / 'slack_relay.py'}" <<'PY'
+#!/usr/bin/env python3
+import sys
+open("{relay_log}", "a").write(" ".join(sys.argv[1:]) + chr(10))
+PY
+chmod +x "{tmp_path / 'shim' / 'slack_relay.py'}"
+
+SKIP_ALERT_THRESHOLD=3
+STATE_DIR="$AGENCY_OS_AUTO_PULL_STATE_DIR"
+RELAY="$AGENCY_OS_AUTO_PULL_RELAY"
+DIRTY_WORKTREE_CEO_THRESHOLD="$AGENCY_OS_DIRTY_WORKTREE_CEO_THRESHOLD"
+mkdir -p "$STATE_DIR"
+source <(sed -n '/^_state_path()/,/^for wt in/p' "{AUTO_PULL_SCRIPT}" | sed '/^for wt in/d')
+WT="/tmp/test-wt"
+_handle_skip "$WT" "on feature/branch (only auto-pull when on main)"
+_handle_skip "$WT" "on feature/branch (only auto-pull when on main)"
+"""
+    )
+    helper.chmod(0o755)
+    result = subprocess.run(["/bin/bash", str(helper)], capture_output=True, text=True, timeout=10)  # noqa: S603
+    assert result.returncode == 0, result.stderr
+    relay_lines = relay_log.read_text().splitlines() if relay_log.exists() else []
+    ceo_lines = [line for line in relay_lines if "-c ceo" in line]
+    assert ceo_lines == [], f"expected NO #ceo alert for non-dirty reason, got {ceo_lines!r}"
+
+
+# ── Addition 3 — subprocess-aware idle detection ────────────────────────────
+
+
+def test_descendant_pids_returns_list(mod):
+    """_descendant_pids returns a list (smoke test — actual content depends on
+    runtime process tree)."""
+    descendants = mod._descendant_pids(1)  # PID 1 has many descendants on Linux
+    assert isinstance(descendants, list)
+
+
+def test_descendant_pids_invalid_pid_returns_empty(mod):
+    """Invalid/unknown pid returns empty list (no children)."""
+    # PID 999999 unlikely to exist
+    assert mod._descendant_pids(999999) == []
+
+
+def test_agent_has_active_subprocess_unknown_callsign_false(mod):
+    """Callsign not in CALLSIGN_TO_TMUX → False (conservative)."""
+    assert mod._agent_has_active_subprocess("unknown_callsign") is False
+
+
+def test_poll_orchestrator_idle_filters_active_subprocess(mod, monkeypatch):
+    """If timestamp-idle says aiden is idle but _agent_has_active_subprocess
+    says aiden has a running subprocess, aiden gets filtered out."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+
+    async def _fake_async():
+        return ["aiden", "max"]
+
+    # Stub the inner async _q via asyncio.run injection — simulate timestamp-idle returns [aiden, max].
+    # Easier: stub poll_orchestrator_idle_agents's internal asyncio call via monkeypatching asyncio.run.
+    import asyncio
+
+    monkeypatch.setattr(asyncio, "run", lambda coro: ["aiden", "max"] if hasattr(coro, "__await__") else [])
+    # Stub _agent_has_active_subprocess: aiden busy, max idle.
+    monkeypatch.setattr(mod, "_agent_has_active_subprocess", lambda cs: cs == "aiden")
+    # asyncpg import check inside the function — make sure it's importable.
+    pytest.importorskip("asyncpg")
+    out = mod.poll_orchestrator_idle_agents()
+    assert "aiden" not in out
+    assert "max" in out


### PR DESCRIPTION
## Summary

Per Dave verbatim ts ~1778631000 + triple-CTO Step 0 concur (Max + Elliot + Aiden). Three additions in one atomic PR close the orchestrator-discipline failure modes Dave caught at ts ~1778630760: stale code running + busy-process mistaken for idle + dispatch-not-firing-silent.

## Addition 1 — BS dispatch-outcome heartbeat

`scripts/orchestrator/elliot_polling_loop.py` — new `_emit_dispatch_outcome_heartbeat(dispatches, signals, no_work)` called at end of `run_cycle`. Env `BETTERSTACK_HB_DISPATCH_OUTCOME` (operator-provisioned post-merge). Fires the heartbeat URL ONLY when EITHER dispatches were emitted OR `no_work=True` (genuine no-work state). When the loop runs but `bd_ready`/`orchestrator_idle_agents` exist AND `dispatches=[]` → heartbeat suppressed → BS dashboard alerts within 2 min per Dave's spec.

## Addition 2 — dirty-worktree #ceo escalation

`scripts/auto_pull_main.sh` — extended PR #803 SKIP-streak counter. New `_emit_dirty_worktree_ceo_alert()` fires when `streak >= DIRTY_WORKTREE_CEO_THRESHOLD` (default 2) AND `reason` contains `"working tree dirty"`. Posts to `#ceo` via `slack_relay -c ceo`. New `.alerted-ceo` flag distinct from existing `.alerted` (which goes to `#execution`) — avoids alert-spam either channel. Per Dave: "stale code running silently is worse than no code running".

## Addition 3 — subprocess-aware idle detection

`scripts/orchestrator/elliot_polling_loop.py` — new helpers:
- `_descendant_pids(pid)`: **recursive** walk via `pgrep -P` (Max's design note ts ~1778631099 — single-level `pgrep -P` missed grandchild; the Max Cognee ingest case has bash sleeping waiting on python3 grandchild at 78% CPU)
- `_agent_has_active_subprocess(callsign)`: walks ALL descendants of tmux `pane_pid` + checks `ps stat=R` OR `pcpu>0` on any descendant

`poll_orchestrator_idle_agents` filters timestamp-idle results through `_agent_has_active_subprocess` → removes false-positive idles caused by long-running background tools.

## Empirical canonical test (pre-build, ratifies Max's design note)

```
$ tmux list-panes -t maxbot:0 -F '#{pane_pid}'  → 3428194
$ ps -p 3428194 -o stat,%cpu                    → Ss 0.0 bash  (parent sleeping)
$ _descendant_pids(3428194)                     → 23 descendants
                                                  including 844898 R 78% CPU
$ _agent_has_active_subprocess('max')           → True
```

Recursive walk catches the false-positive case. Confirmed pre-build with live Cognee ingest running.

## Tests (10/10 pass, 64 total polling-loop pass, ruff clean)

- Addition 1 (4): env-unset skip / dispatch fires / no_work fires / work-exists-but-no-dispatch suppressed (the orchestrator-discipline-gap case)
- Addition 2 (2): dirty-worktree streak≥2 fires #ceo / non-dirty reason no-op
- Addition 3 (4): `_descendant_pids` returns list / invalid pid empty / unknown-callsign False / `poll_orchestrator_idle_agents` filters via subprocess-aware check

```
$ pytest tests/scripts/test_kei34_v2_additions.py
============================== 10 passed in 11.52s ==============================
```

## Out of scope

- KEI-27 (queues immediately after this merges)
- R14 changes (already shipped in #818)
- `BETTERSTACK_HB_DISPATCH_OUTCOME` env provisioning (operator post-merge — Elliot triggers BS dashboard config + adds env var to `.env`)

## Test plan

- [x] `pytest` — 10/10 new + 54/54 prior = 64/64
- [x] `ruff check` — clean
- [x] `ruff format src/ --check` — clean
- [x] Empirical canonical test on live Cognee ingest — ratifies Max's design note
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Operator post-merge: provision `BETTERSTACK_HB_DISPATCH_OUTCOME` URL + add env var + trigger silent-dispatch-gap test

🤖 Generated with [Claude Code](https://claude.com/claude-code)