### PR TITLE
[AIDEN] feat(kei27): stale-in-progress alert — 24h silently-died lane to #ceo

### DIFF
--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -50,6 +50,11 @@ logger = logging.getLogger("elliot_polling_loop")
 # Time-of-day window. AEST = UTC+10.
 PEAK_HOURS_UTC = set(list(range(21, 24)) + list(range(0, 14)))  # 21–13 UTC inclusive = 07–23 AEST
 STALE_LINEAR_HOURS = 12
+# KEI-27 — broader "silently died" stale threshold. Linear KEI In Progress
+# for >24h with no commit/comment/status change → #ceo alert. Distinct lane
+# from STALE_LINEAR_HOURS (12h orchestrator-stale): KEI_STALE captures work
+# that's quietly dropped between sessions.
+STALE_KEI_HOURS = 24
 IDLE_AGENT_MINUTES = 30
 PREFECT_WINDOW_MINUTES = 5
 # KEI-34 strict-cycle reading per Dave verbatim ts ~1778629860: 'Idle agents
@@ -131,6 +136,9 @@ class CycleSignals:
     # KEI-34 component 1 — agents idle >= ORCHESTRATOR_IDLE_CYCLES * cycle_period
     # (strict-cycle threshold; tighter than idle_agents which uses IDLE_AGENT_MINUTES).
     orchestrator_idle_agents: list[str] = field(default_factory=list)
+    # KEI-27 — Linear KEI In Progress for >STALE_KEI_HOURS with no activity.
+    # Broader "silently died" lane vs linear_stale (orchestrator stale lane).
+    kei_stale: list[dict] = field(default_factory=list)
     """List of (callsign, transition, duration_min) where transition is
     'throttled' (first detection) or 'resumed' (clearing detection). Duration
     is minutes-since-throttle-start for 'resumed' (0 for 'throttled')."""
@@ -142,6 +150,7 @@ class CycleSignals:
             or self.idle_agents
             or self.prefect_failures
             or self.rate_limit_transitions
+            or self.kei_stale
         )
 
 
@@ -188,12 +197,12 @@ def poll_bd_ready() -> list[dict]:
         return []
 
 
-def poll_linear_stale(now: datetime | None = None) -> list[dict]:
-    """Linear In-Progress issues with no activity > STALE_LINEAR_HOURS."""
+def _query_linear_stale(hours: int, now: datetime | None) -> list[dict]:
+    """Shared Linear GraphQL: state=started + updatedAt < (now-hours)."""
     api_key = os.environ.get("LINEAR_API_KEY", "")
     if not api_key:
         return []
-    cutoff = (now or datetime.now(UTC)) - timedelta(hours=STALE_LINEAR_HOURS)
+    cutoff = (now or datetime.now(UTC)) - timedelta(hours=hours)
     query = """
     query StaleIssues($since: DateTimeOrDuration!) {
       issues(filter: {state: {type: {eq: "started"}}, updatedAt: {lt: $since}}, first: 20) {
@@ -211,8 +220,21 @@ def poll_linear_stale(now: datetime | None = None) -> list[dict]:
             body = json.loads(resp.read())
         return body.get("data", {}).get("issues", {}).get("nodes", []) or []
     except (urllib.error.URLError, json.JSONDecodeError, KeyError, OSError) as exc:
-        logger.warning("Linear stale query failed: %s", exc)
+        logger.warning("Linear stale query failed (%dh): %s", hours, exc)
         return []
+
+
+def poll_linear_stale(now: datetime | None = None) -> list[dict]:
+    """Linear In-Progress issues with no activity > STALE_LINEAR_HOURS (12h —
+    orchestrator-stale lane)."""
+    return _query_linear_stale(STALE_LINEAR_HOURS, now)
+
+
+def poll_kei_stale(now: datetime | None = None) -> list[dict]:
+    """KEI-27: Linear KEI In Progress with no activity > STALE_KEI_HOURS (24h
+    — silently-died lane). Distinct from poll_linear_stale (12h orchestrator
+    lane); both stay. Reuses shared _query_linear_stale helper."""
+    return _query_linear_stale(STALE_KEI_HOURS, now)
 
 
 def poll_idle_agents(now: datetime | None = None) -> list[str]:
@@ -557,6 +579,7 @@ def collect_signals(now: datetime | None = None) -> CycleSignals:
         prefect_failures=poll_prefect_failures(now),
         rate_limit_transitions=poll_rate_limited_agents(now),
         orchestrator_idle_agents=poll_orchestrator_idle_agents(now),
+        kei_stale=poll_kei_stale(now),
     )
 
 
@@ -604,6 +627,25 @@ def compose_dispatches(signals: CycleSignals) -> list[tuple[str, str]]:
             + "\n".join(lines)
         )
         dispatches.append((CEO_CHANNEL_NAME, msg))
+
+    if signals.kei_stale:
+        # KEI-27: 24h+ stale KEI alert. Dedupe against linear_stale (12h
+        # subset) so we don't double-post the same issues to #ceo.
+        already_in_linear_stale = {it.get("identifier") for it in signals.linear_stale}
+        kei_extras = [it for it in signals.kei_stale if it.get("identifier") not in already_in_linear_stale]
+        if kei_extras:
+            lines = [
+                f"  - {it.get('identifier', '?')} {it.get('title', '?')} "
+                f"(last update {it.get('updatedAt', '?')}, assignee {(it.get('assignee') or {}).get('name', '?')})"
+                for it in kei_extras[:10]
+            ]
+            msg = (
+                f"[PROPOSE:elliot] KEI silently-died sweep — "
+                f"{len(kei_extras)} issue(s) In Progress > {STALE_KEI_HOURS}h with "
+                f"no commit/comment/status-change:\n"
+                + "\n".join(lines)
+            )
+            dispatches.append((CEO_CHANNEL_NAME, msg))
 
     if signals.prefect_failures:
         lines = [

--- a/tests/scripts/test_kei27_stale_in_progress.py
+++ b/tests/scripts/test_kei27_stale_in_progress.py
@@ -1,0 +1,134 @@
+"""Tests for KEI-27 stale-in-progress alert (24h no activity → #ceo)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "elliot_polling_loop.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("elliot_polling_loop_kei27", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["elliot_polling_loop_kei27"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_poll_kei_stale_no_api_key_returns_empty(mod, monkeypatch):
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    assert mod.poll_kei_stale() == []
+
+
+def test_query_linear_stale_used_by_both_polls(mod, monkeypatch):
+    """Shared _query_linear_stale helper invoked by both poll_linear_stale + poll_kei_stale."""
+    calls: list[tuple[int, object]] = []
+
+    def _fake(hours, now):
+        calls.append((hours, now))
+        return []
+
+    monkeypatch.setattr(mod, "_query_linear_stale", _fake)
+    mod.poll_linear_stale()
+    mod.poll_kei_stale()
+    assert len(calls) == 2
+    hours_called = [c[0] for c in calls]
+    assert mod.STALE_LINEAR_HOURS in hours_called
+    assert mod.STALE_KEI_HOURS in hours_called
+    # Distinct hours values
+    assert mod.STALE_LINEAR_HOURS != mod.STALE_KEI_HOURS
+
+
+def test_compose_dispatches_kei_stale_emits_to_ceo(mod):
+    sig = mod.CycleSignals(
+        bd_ready=[],
+        linear_stale=[],
+        idle_agents=[],
+        prefect_failures=[],
+        kei_stale=[
+            {
+                "identifier": "KEI-99",
+                "title": "Silently died",
+                "updatedAt": "2026-05-11T00:00:00Z",
+                "assignee": {"name": "elliot"},
+            },
+        ],
+    )
+    dispatches = mod.compose_dispatches(sig)
+    ceo_msgs = [m for ch, m in dispatches if ch == mod.CEO_CHANNEL_NAME]
+    assert len(ceo_msgs) == 1
+    assert "KEI silently-died sweep" in ceo_msgs[0]
+    assert "KEI-99" in ceo_msgs[0]
+    assert "Silently died" in ceo_msgs[0]
+    assert "elliot" in ceo_msgs[0]
+
+
+def test_compose_dispatches_kei_stale_deduped_against_linear_stale(mod):
+    """KEI-27 must not double-post issues already in linear_stale (12h subset)."""
+    common = {
+        "identifier": "KEI-100",
+        "title": "Already in both",
+        "updatedAt": "2026-05-11T00:00:00Z",
+        "assignee": {"name": "aiden"},
+    }
+    sig = mod.CycleSignals(
+        bd_ready=[],
+        linear_stale=[common],
+        idle_agents=[],
+        prefect_failures=[],
+        kei_stale=[common],
+    )
+    dispatches = mod.compose_dispatches(sig)
+    ceo_msgs = [m for ch, m in dispatches if ch == mod.CEO_CHANNEL_NAME]
+    # Only one #ceo post (linear_stale) — kei_stale dedup'd out.
+    sweep_messages = [m for m in ceo_msgs if "silently-died" in m]
+    assert sweep_messages == [], "KEI-27 should not double-post issues already in linear_stale"
+    linear_messages = [m for m in ceo_msgs if "Linear stale-In-Progress" in m]
+    assert len(linear_messages) == 1
+
+
+def test_compose_dispatches_kei_stale_empty_is_noop(mod):
+    sig = mod.CycleSignals(
+        bd_ready=[],
+        linear_stale=[],
+        idle_agents=[],
+        prefect_failures=[],
+        kei_stale=[],
+    )
+    dispatches = mod.compose_dispatches(sig)
+    ceo_msgs = [m for ch, m in dispatches if ch == mod.CEO_CHANNEL_NAME]
+    sweep_messages = [m for m in ceo_msgs if "silently-died" in m]
+    assert sweep_messages == []
+
+
+def test_compose_dispatches_kei_stale_handles_null_assignee(mod):
+    """Same null-assignee defensiveness as PR #794 fix."""
+    sig = mod.CycleSignals(
+        bd_ready=[],
+        linear_stale=[],
+        idle_agents=[],
+        prefect_failures=[],
+        kei_stale=[
+            {
+                "identifier": "KEI-101",
+                "title": "Unassigned silently-died",
+                "updatedAt": "2026-05-11T00:00:00Z",
+                "assignee": None,
+            },
+        ],
+    )
+    dispatches = mod.compose_dispatches(sig)
+    ceo_msgs = [m for ch, m in dispatches if ch == mod.CEO_CHANNEL_NAME]
+    assert len(ceo_msgs) == 1
+    assert "KEI-101" in ceo_msgs[0]
+
+
+def test_stale_hours_constants_distinct(mod):
+    assert mod.STALE_LINEAR_HOURS == 12
+    assert mod.STALE_KEI_HOURS == 24


### PR DESCRIPTION
## Summary

KEI-27 P1 per Linear + Dave restart-readiness directive. Dual-CTO Step 0 concur (Max ts ~1778631942 + Elliot ts ~1778631906). Resume-in-flight after KEI-34 v2 pivot per Elliot's clearance ts ~1778631940.

Adds the broader "silently died" stale-detection lane on the polling loop. Distinct from existing `STALE_LINEAR_HOURS=12` (orchestrator stale — catches mid-day work stalling); `STALE_KEI_HOURS=24` catches work that quietly dies between sessions overnight.

## Implementation (DRY improvement over original Step 0)

- New `STALE_KEI_HOURS=24` constant
- Refactor `poll_linear_stale` → shared `_query_linear_stale(hours, now)` helper
- New `poll_kei_stale` calling shared helper with `STALE_KEI_HOURS`
- New `kei_stale: list[dict]` field on `CycleSignals` (default empty)
- `is_silent()` includes `kei_stale`
- `collect_signals` wires `poll_kei_stale`
- `compose_dispatches` new branch — emits `[PROPOSE:elliot]` to `#ceo` with verbatim stale-KEI list. **Dedupes** against `linear_stale` (12h subset of 24h) to avoid double-posting same issue
- Null-assignee defensive pattern from PR #794 reused

## Tests (7/7 pass + 36/36 prior = 43/43, ruff clean)

- `poll_kei_stale` no-API-key returns `[]`
- `_query_linear_stale` shared between both polls + distinct hours args
- `compose_dispatches` KEI stale emits to `#ceo` with identifier/title/assignee
- Dedup against `linear_stale` subset (same issue → one post not two)
- Empty `kei_stale` no-op
- Null-assignee handled defensively
- Constants distinct (12 vs 24)

```
$ pytest tests/scripts/test_kei27_stale_in_progress.py tests/scripts/test_elliot_polling_loop.py
============================== 43 passed in 0.57s ==============================
```

## Out of scope

- bd-side stale detection (separate item)
- Per-commit-activity check (Linear `updatedAt` covers via KEI-25 GitHub integration)
- Enforcer rule (polling-loop additive, not R-style)

## Test plan

- [x] `pytest` — 43/43 (7 new + 36 prior)
- [x] `ruff check` — clean
- [x] `ruff format src/ --check` — clean
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Post-merge: next peak cycle reports any KEI In Progress >24h in `#ceo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)