### PR TITLE
[SCOUT] feat(orchestrator): KEI-29 weekly Linear cycle from bd ready

### DIFF
--- a/scripts/orchestrator/weekly_cycle_from_bd.py
+++ b/scripts/orchestrator/weekly_cycle_from_bd.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""weekly_cycle_from_bd.py — KEI-29 P2: weekly Linear cycle from bd ready.
+
+Every Monday 07:00 AEST (Sun 21:00 UTC) via systemd timer:
+  1. `bd ready --json` → list of unblocked issues.
+  2. Filter to priority IN (0, 1) (P0+P1) AND non-empty external_ref. Per
+     Dave ratification ts ~1778631920: full picture, not a cap.
+  3. Resolve each KEI-N external_ref → Linear issue UUID via GraphQL.
+  4. Compute target Monday 07:00 AEST (next Monday if today's Monday is past).
+  5. Idempotent: look up cycle with startsAt == target. Skip-create if exists;
+     reuse its UUID for issue top-up.
+  6. issueUpdate(input: {cycleId}) per resolved issue.
+
+Operator override: `--force-now` creates an ad-hoc cycle starting now.
+
+Exit codes:
+  0 — happy path OR idempotent skip OR no-eligible-items no-op
+  2 — LINEAR_API_KEY unset (operator misconfig signal — surfaces in timer log)
+
+Mirrors the GraphQL + state-path patterns in scripts/betterstack_to_linear.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime, timedelta
+
+logger = logging.getLogger("weekly_cycle_from_bd")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+_LINEAR_GRAPHQL = "https://api.linear.app/graphql"
+_DEFAULT_TEAM_ID = "4686528f-ce77-4c2f-968b-3dc76b34d6fe"  # Keiracom team
+_BD_BIN = os.path.expanduser("~/.local/bin/bd")
+_KEI_REF_RE = re.compile(r"linear\.app/[^/]+/issue/KEI-(\d+)", re.IGNORECASE)
+# AEST = UTC+10 (no DST in NSW; Brisbane). Monday 07:00 AEST → Sun 21:00 UTC prev day.
+_AEST_OFFSET_HOURS = 10
+_TARGET_HOUR_AEST = 7
+_CYCLE_DURATION_DAYS = 7
+
+
+def _linear_graphql(api_key: str, query: str, variables: dict | None = None) -> dict | None:
+    body = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        _LINEAR_GRAPHQL,
+        data=body,
+        headers={"Authorization": api_key, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read() or "null")
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Linear GraphQL failed: %s", exc)
+        return None
+
+
+def _bd_ready() -> list[dict]:
+    """Returns parsed `bd ready --json` output (empty list on any failure)."""
+    try:
+        proc = subprocess.run(  # noqa: S603 — absolute path, no shell, no user input
+            [_BD_BIN, "ready", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if proc.returncode != 0:
+            logger.warning("bd ready exit %d: %s", proc.returncode, proc.stderr[:200])
+            return []
+        return json.loads(proc.stdout or "[]")
+    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        logger.warning("bd ready failed: %s", exc)
+        return []
+
+
+def _extract_kei_number(external_ref: str) -> int | None:
+    """Parse 'https://linear.app/keiracom/issue/KEI-29' → 29; None if not a KEI URL."""
+    if not external_ref:
+        return None
+    m = _KEI_REF_RE.search(external_ref)
+    return int(m.group(1)) if m else None
+
+
+def filter_eligible(items: list[dict]) -> list[tuple[dict, int]]:
+    """Return (item, kei_number) pairs where priority in {0,1} AND external_ref is KEI."""
+    out: list[tuple[dict, int]] = []
+    for it in items:
+        if it.get("priority") not in (0, 1):
+            continue
+        kei_n = _extract_kei_number(it.get("external_ref", ""))
+        if kei_n is None:
+            logger.info("skip %s — no Linear external_ref", it.get("id", "?"))
+            continue
+        out.append((it, kei_n))
+    return out
+
+
+def _resolve_kei_to_uuid(api_key: str, kei_number: int) -> str | None:
+    """Translate KEI-N → Linear issue UUID."""
+    query = (
+        "query($n:Float!){issues(filter:{team:{key:{eq:\"KEI\"}},number:{eq:$n}}){nodes{id}}}"
+    )
+    resp = _linear_graphql(api_key, query, {"n": float(kei_number)})
+    nodes = (((resp or {}).get("data") or {}).get("issues") or {}).get("nodes") or []
+    return nodes[0].get("id") if nodes else None
+
+
+def compute_target_window(now: datetime | None = None) -> tuple[datetime, datetime]:
+    """Return (starts_at_utc, ends_at_utc) for the next Monday 07:00 AEST cycle.
+
+    If `now` is Monday before 07:00 AEST, use THIS Monday. Otherwise, next Monday.
+    """
+    n = now or datetime.now(UTC)
+    aest = n + timedelta(hours=_AEST_OFFSET_HOURS)
+    # weekday(): Monday=0 ... Sunday=6 in AEST frame.
+    days_until_monday = (7 - aest.weekday()) % 7
+    # If today IS Monday AND we're still before the target hour, fire for TODAY.
+    if aest.weekday() == 0 and aest.hour < _TARGET_HOUR_AEST:
+        days_until_monday = 0
+    elif days_until_monday == 0:
+        days_until_monday = 7  # already past Monday 07:00 — use next week
+    starts_aest = (aest + timedelta(days=days_until_monday)).replace(
+        hour=_TARGET_HOUR_AEST, minute=0, second=0, microsecond=0
+    )
+    starts_utc = starts_aest - timedelta(hours=_AEST_OFFSET_HOURS)
+    ends_utc = starts_utc + timedelta(days=_CYCLE_DURATION_DAYS)
+    return starts_utc.replace(tzinfo=UTC), ends_utc.replace(tzinfo=UTC)
+
+
+def _find_existing_cycle(api_key: str, team_id: str, starts_at_iso: str) -> str | None:
+    """Return UUID of cycle whose startsAt matches target, else None."""
+    query = (
+        "query($t:String!,$s:DateTimeOrDuration!){"
+        "team(id:$t){cycles(filter:{startsAt:{eq:$s}}){nodes{id startsAt}}}}"
+    )
+    resp = _linear_graphql(api_key, query, {"t": team_id, "s": starts_at_iso})
+    if resp is None:
+        # Fall back to scanning without filter — defensive against API schema drift.
+        return _scan_existing_cycle(api_key, team_id, starts_at_iso)
+    nodes = (((resp or {}).get("data") or {}).get("team") or {}).get("cycles", {}).get(
+        "nodes"
+    ) or []
+    return nodes[0].get("id") if nodes else None
+
+
+def _scan_existing_cycle(api_key: str, team_id: str, starts_at_iso: str) -> str | None:
+    query = "query($t:String!){team(id:$t){cycles{nodes{id startsAt}}}}"
+    resp = _linear_graphql(api_key, query, {"t": team_id})
+    nodes = (((resp or {}).get("data") or {}).get("team") or {}).get("cycles", {}).get(
+        "nodes"
+    ) or []
+    target = starts_at_iso.rstrip("Z")
+    for n in nodes:
+        sa = (n.get("startsAt") or "").rstrip("Z")
+        if sa.startswith(target[:19]):  # compare to second precision
+            return n.get("id")
+    return None
+
+
+def _create_cycle(
+    api_key: str, team_id: str, starts_at_iso: str, ends_at_iso: str, name: str
+) -> str | None:
+    mutation = (
+        "mutation($input:CycleCreateInput!){cycleCreate(input:$input){success cycle{id}}}"
+    )
+    input_fields = {
+        "teamId": team_id,
+        "name": name,
+        "startsAt": starts_at_iso,
+        "endsAt": ends_at_iso,
+    }
+    resp = _linear_graphql(api_key, mutation, {"input": input_fields})
+    cycle = (((resp or {}).get("data") or {}).get("cycleCreate") or {}).get("cycle")
+    return cycle.get("id") if cycle else None
+
+
+def _add_issue_to_cycle(api_key: str, issue_uuid: str, cycle_uuid: str) -> bool:
+    mutation = (
+        "mutation($id:String!,$cid:String!){"
+        "issueUpdate(id:$id,input:{cycleId:$cid}){success}}"
+    )
+    resp = _linear_graphql(api_key, mutation, {"id": issue_uuid, "cid": cycle_uuid})
+    return bool(
+        (((resp or {}).get("data") or {}).get("issueUpdate") or {}).get("success", False)
+    )
+
+
+def _cycle_name(starts_at_utc: datetime) -> str:
+    starts_aest = starts_at_utc + timedelta(hours=_AEST_OFFSET_HOURS)
+    return f"KEI Week of {starts_aest.strftime('%Y-%m-%d')}"
+
+
+def run(force_now: bool = False, now: datetime | None = None) -> int:
+    api_key = os.environ.get("LINEAR_API_KEY", "")
+    if not api_key:
+        logger.warning("LINEAR_API_KEY not set; cannot create Linear cycle")
+        return 2
+    team_id = os.environ.get("LINEAR_TEAM_ID", _DEFAULT_TEAM_ID)
+
+    eligible = filter_eligible(_bd_ready())
+    if not eligible:
+        logger.info("no P0/P1 unblocked items with Linear refs — no cycle created")
+        return 0
+
+    if force_now:
+        starts_utc = (now or datetime.now(UTC)).replace(microsecond=0)
+        ends_utc = starts_utc + timedelta(days=_CYCLE_DURATION_DAYS)
+    else:
+        starts_utc, ends_utc = compute_target_window(now)
+    starts_iso = starts_utc.isoformat().replace("+00:00", "Z")
+    ends_iso = ends_utc.isoformat().replace("+00:00", "Z")
+
+    cycle_uuid = _find_existing_cycle(api_key, team_id, starts_iso)
+    if cycle_uuid:
+        logger.info("idempotent reuse: existing cycle %s for startsAt=%s", cycle_uuid, starts_iso)
+    else:
+        cycle_uuid = _create_cycle(api_key, team_id, starts_iso, ends_iso, _cycle_name(starts_utc))
+        if not cycle_uuid:
+            logger.warning("cycleCreate returned no cycle — abort")
+            return 0
+        logger.info("created cycle %s (%s)", cycle_uuid, _cycle_name(starts_utc))
+
+    added = skipped = failed = 0
+    for _item, kei_n in eligible:
+        issue_uuid = _resolve_kei_to_uuid(api_key, kei_n)
+        if not issue_uuid:
+            logger.warning("skip KEI-%d — could not resolve UUID", kei_n)
+            skipped += 1
+            continue
+        if _add_issue_to_cycle(api_key, issue_uuid, cycle_uuid):
+            added += 1
+        else:
+            failed += 1
+    logger.info(
+        "cycle %s populated: %d added, %d skipped, %d failed (of %d eligible)",
+        cycle_uuid,
+        added,
+        skipped,
+        failed,
+        len(eligible),
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Weekly Linear cycle from bd ready (KEI-29)")
+    parser.add_argument(
+        "--force-now",
+        action="store_true",
+        help="Create cycle starting now instead of next Monday 07:00 AEST.",
+    )
+    args = parser.parse_args()
+    return run(force_now=args.force_now)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/systemd/weekly-cycle-from-bd.service
+++ b/systemd/weekly-cycle-from-bd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=KEI-29 Weekly Linear cycle from bd ready (one-shot)
+After=network.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+Environment="PYTHONPATH=/home/elliotbot/clawd/Agency_OS"
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+ExecStart=/usr/bin/python3 -B /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/weekly_cycle_from_bd.py
+StandardOutput=append:/home/elliotbot/clawd/logs/weekly-cycle-from-bd.log
+StandardError=append:/home/elliotbot/clawd/logs/weekly-cycle-from-bd.log

--- a/systemd/weekly-cycle-from-bd.timer
+++ b/systemd/weekly-cycle-from-bd.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=KEI-29 Weekly Linear cycle from bd ready — fires Monday 07:00 AEST (Sun 21:00 UTC)
+
+[Timer]
+OnCalendar=Sun *-*-* 21:00:00 UTC
+Persistent=true
+AccuracySec=1min
+
+[Install]
+WantedBy=timers.target

--- a/tests/scripts/test_weekly_cycle_from_bd.py
+++ b/tests/scripts/test_weekly_cycle_from_bd.py
@@ -1,0 +1,231 @@
+"""Tests for scripts/orchestrator/weekly_cycle_from_bd.py — KEI-29.
+
+bd CLI + Linear GraphQL + datetime.now are stubbed at the module level.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "orchestrator" / "weekly_cycle_from_bd.py"
+
+
+@pytest.fixture(scope="module")
+def wc_mod():
+    spec = importlib.util.spec_from_file_location("weekly_cycle_from_bd", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["weekly_cycle_from_bd"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# _extract_kei_number ────────────────────────────────────────────────────────
+
+
+def test_extract_kei_number_canonical_url(wc_mod):
+    assert wc_mod._extract_kei_number("https://linear.app/keiracom/issue/KEI-29") == 29
+
+
+def test_extract_kei_number_handles_other_workspaces(wc_mod):
+    assert wc_mod._extract_kei_number("https://linear.app/other-team/issue/KEI-7") == 7
+
+
+def test_extract_kei_number_returns_none_on_empty(wc_mod):
+    assert wc_mod._extract_kei_number("") is None
+
+
+def test_extract_kei_number_returns_none_on_non_linear_url(wc_mod):
+    assert wc_mod._extract_kei_number("https://github.com/Keiracom/Agency_OS/issues/19") is None
+
+
+# filter_eligible ────────────────────────────────────────────────────────────
+
+
+def test_filter_eligible_keeps_p0_p1_with_external_ref(wc_mod):
+    items = [
+        {"id": "a", "priority": 0, "external_ref": "https://linear.app/keiracom/issue/KEI-1"},
+        {"id": "b", "priority": 1, "external_ref": "https://linear.app/keiracom/issue/KEI-2"},
+        {"id": "c", "priority": 2, "external_ref": "https://linear.app/keiracom/issue/KEI-3"},
+        {"id": "d", "priority": 0, "external_ref": ""},
+    ]
+    out = wc_mod.filter_eligible(items)
+    assert [(it["id"], kei) for it, kei in out] == [("a", 1), ("b", 2)]
+
+
+def test_filter_eligible_handles_missing_priority(wc_mod):
+    # priority absent → not in {0,1} → filtered out (defensive).
+    assert wc_mod.filter_eligible([{"id": "x", "external_ref": "KEI-1"}]) == []
+
+
+# compute_target_window ──────────────────────────────────────────────────────
+
+
+def test_compute_target_window_from_monday_before_7am_aest(wc_mod):
+    # Monday 2026-05-18 02:00 AEST = Sunday 2026-05-17 16:00 UTC. Should target SAME Monday.
+    starts, ends = wc_mod.compute_target_window(datetime(2026, 5, 17, 16, 0, tzinfo=UTC))
+    # Target Monday 2026-05-18 07:00 AEST = Mon 2026-05-17 21:00 UTC.
+    assert starts == datetime(2026, 5, 17, 21, 0, tzinfo=UTC)
+    assert ends == datetime(2026, 5, 24, 21, 0, tzinfo=UTC)
+
+
+def test_compute_target_window_from_monday_after_7am_aest_uses_next_week(wc_mod):
+    # Mon 2026-05-18 10:00 AEST = Mon 2026-05-18 00:00 UTC. Past 07:00 AEST → next Mon.
+    starts, _ = wc_mod.compute_target_window(datetime(2026, 5, 18, 0, 0, tzinfo=UTC))
+    # Next Monday is 2026-05-25.
+    assert starts == datetime(2026, 5, 24, 21, 0, tzinfo=UTC)
+
+
+def test_compute_target_window_from_wednesday(wc_mod):
+    # Wed 2026-05-20 → next Monday is 2026-05-25.
+    starts, _ = wc_mod.compute_target_window(datetime(2026, 5, 20, 12, 0, tzinfo=UTC))
+    assert starts == datetime(2026, 5, 24, 21, 0, tzinfo=UTC)
+
+
+# _cycle_name ────────────────────────────────────────────────────────────────
+
+
+def test_cycle_name_uses_aest_date(wc_mod):
+    # startsAt UTC Sun 21:00 → AEST Mon 07:00.
+    name = wc_mod._cycle_name(datetime(2026, 5, 17, 21, 0, tzinfo=UTC))
+    assert name == "KEI Week of 2026-05-18"
+
+
+# run() integration ──────────────────────────────────────────────────────────
+
+
+def _install_graphql_stub(wc_mod, monkeypatch, responses: list):
+    """Each GraphQL call pops the next dict from `responses`."""
+    calls: list[tuple[str, dict]] = []
+
+    def fake_gql(api_key, query, variables=None):
+        calls.append((query, variables or {}))
+        return responses.pop(0) if responses else None
+
+    monkeypatch.setattr(wc_mod, "_linear_graphql", fake_gql)
+    return calls
+
+
+def test_run_no_api_key_returns_2(wc_mod, monkeypatch):
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    assert wc_mod.run() == 2
+
+
+def test_run_empty_bd_ready_is_noop(wc_mod, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "x")
+    monkeypatch.setattr(wc_mod, "_bd_ready", lambda: [])
+    _install_graphql_stub(wc_mod, monkeypatch, [])  # No GraphQL calls expected
+    assert wc_mod.run() == 0
+
+
+def test_run_no_eligible_items_is_noop(wc_mod, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "x")
+    monkeypatch.setattr(
+        wc_mod,
+        "_bd_ready",
+        lambda: [
+            {"id": "a", "priority": 2, "external_ref": "https://linear.app/keiracom/issue/KEI-9"},
+            {"id": "b", "priority": 0, "external_ref": ""},
+        ],
+    )
+    calls = _install_graphql_stub(wc_mod, monkeypatch, [])
+    assert wc_mod.run() == 0
+    assert calls == [], "no Linear calls expected when nothing is eligible"
+
+
+def test_run_idempotent_skip_on_existing_cycle(wc_mod, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "x")
+    monkeypatch.setattr(
+        wc_mod,
+        "_bd_ready",
+        lambda: [
+            {"id": "a", "priority": 0, "external_ref": "https://linear.app/keiracom/issue/KEI-9"},
+        ],
+    )
+    # Response 1: _find_existing_cycle returns an existing UUID
+    # Response 2: _resolve_kei_to_uuid returns the issue UUID
+    # Response 3: _add_issue_to_cycle success
+    existing_cycle_id = "cycle-already-here"
+    issue_uuid = "issue-uuid-9"
+    _install_graphql_stub(
+        wc_mod,
+        monkeypatch,
+        [
+            {"data": {"team": {"cycles": {"nodes": [{"id": existing_cycle_id}]}}}},
+            {"data": {"issues": {"nodes": [{"id": issue_uuid}]}}},
+            {"data": {"issueUpdate": {"success": True}}},
+        ],
+    )
+    # Pin time to a Tuesday so target is next Monday — deterministic.
+    monkeypatch.setattr(wc_mod, "datetime", _frozen_datetime(2026, 5, 19, 12, 0))
+    assert wc_mod.run() == 0
+
+
+def test_run_happy_path_creates_cycle_and_adds_issue(wc_mod, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "x")
+    monkeypatch.setattr(
+        wc_mod,
+        "_bd_ready",
+        lambda: [
+            {"id": "a", "priority": 1, "external_ref": "https://linear.app/keiracom/issue/KEI-19"},
+        ],
+    )
+    new_cycle_id = "freshly-created-cycle"
+    issue_uuid = "issue-uuid-19"
+    _install_graphql_stub(
+        wc_mod,
+        monkeypatch,
+        [
+            {"data": {"team": {"cycles": {"nodes": []}}}},  # _find_existing_cycle: none
+            {"data": {"cycleCreate": {"success": True, "cycle": {"id": new_cycle_id}}}},
+            {"data": {"issues": {"nodes": [{"id": issue_uuid}]}}},  # resolve KEI-19
+            {"data": {"issueUpdate": {"success": True}}},  # add to cycle
+        ],
+    )
+    monkeypatch.setattr(wc_mod, "datetime", _frozen_datetime(2026, 5, 19, 12, 0))
+    assert wc_mod.run() == 0
+
+
+def test_run_continues_when_one_resolve_fails(wc_mod, monkeypatch):
+    """Linear UUID lookup miss for one item should not block the cycle."""
+    monkeypatch.setenv("LINEAR_API_KEY", "x")
+    monkeypatch.setattr(
+        wc_mod,
+        "_bd_ready",
+        lambda: [
+            {"id": "a", "priority": 0, "external_ref": "https://linear.app/keiracom/issue/KEI-1"},
+            {"id": "b", "priority": 1, "external_ref": "https://linear.app/keiracom/issue/KEI-2"},
+        ],
+    )
+    _install_graphql_stub(
+        wc_mod,
+        monkeypatch,
+        [
+            {"data": {"team": {"cycles": {"nodes": []}}}},
+            {"data": {"cycleCreate": {"success": True, "cycle": {"id": "cyc"}}}},
+            {"data": {"issues": {"nodes": []}}},  # KEI-1 not found
+            {"data": {"issues": {"nodes": [{"id": "uuid2"}]}}},  # KEI-2 found
+            {"data": {"issueUpdate": {"success": True}}},  # add KEI-2
+        ],
+    )
+    monkeypatch.setattr(wc_mod, "datetime", _frozen_datetime(2026, 5, 19, 12, 0))
+    assert wc_mod.run() == 0
+
+
+# Helper: freezes datetime.now(UTC) at the given instant for compute_target_window.
+
+
+def _frozen_datetime(year, month, day, hour, minute):
+    real_datetime = datetime
+
+    class _Frozen(real_datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return real_datetime(year, month, day, hour, minute, tzinfo=tz or UTC)
+
+    return _Frozen


### PR DESCRIPTION
## Summary

Closes Linear KEI-29. Auto-populates a weekly Linear cycle from `bd ready` output, fires Monday 07:00 AEST via systemd timer. Selection policy ratified by Dave verbatim ts ~1778631920: **all unblocked P0+P1 items from bd ready, full picture, not a cap**. Build phase cleared per Elliot dispatch ts ~1778631920+.

Research doc: `docs/wave2/kei29_cycle_research.md` on branch `scout/kei29-weekly-cycle-research` @ `a7425dea`.

## Behaviour

1. systemd timer `OnCalendar=Sun *-*-* 21:00:00 UTC` (Mon 07:00 AEST) → one-shot service runs `weekly_cycle_from_bd.py`.
2. `bd ready --json` via absolute `~/.local/bin/bd` path (yvz fix pattern — systemd PATH excludes `~/.local/bin/`).
3. Filter: `priority IN (0, 1)` AND `external_ref` is a Linear `KEI-N` URL.
4. `compute_target_window` picks next-Monday-07:00-AEST (or same Monday if currently before 07:00 AEST). 7-day cycle window.
5. Idempotent: pre-create lookup on `team.cycles(filter: {startsAt: {eq: target}})` — skip `cycleCreate` if exists, reuse UUID for issue top-up. Defensive `_scan_existing_cycle` fallback if API filter syntax drifts.
6. Resolve each KEI-N → Linear issue UUID via `issues(filter: {team: {key: "KEI"}, number: {eq: N}})`. One round-trip per item.
7. `issueUpdate(input: {cycleId: <UUID>})` per resolved issue. Per-item failures are logged + skipped — no partial-state abort.
8. `--force-now` flag creates an ad-hoc cycle starting now (operator manual override outside Monday cadence).

Cycle name: `"KEI Week of YYYY-MM-DD"` (AEST Monday date).

GraphQL + state-path patterns mirror `scripts/betterstack_to_linear.py`.

## Verification

```
$ python3 -m pytest tests/scripts/test_weekly_cycle_from_bd.py
============================== 16 passed in 0.27s ==============================

$ ruff check scripts/orchestrator/weekly_cycle_from_bd.py tests/scripts/test_weekly_cycle_from_bd.py
All checks passed!

$ git diff --stat HEAD~1
 scripts/orchestrator/weekly_cycle_from_bd.py | 274 ++++++++
 systemd/weekly-cycle-from-bd.service         |  11 +
 systemd/weekly-cycle-from-bd.timer           |  10 +
 tests/scripts/test_weekly_cycle_from_bd.py   | 222 ++++++
 4 files changed, 517 insertions(+)
```

## Tests (16/16)

- `_extract_kei_number`: canonical URL, other-workspace URL, empty, non-Linear URL.
- `filter_eligible`: P0+P1 with external_ref kept; P2/empty-ref filtered.
- `compute_target_window`: 3 boundary cases — Mon before 7am AEST (same Monday), Mon after 7am AEST (next Monday), mid-week (next Monday).
- `_cycle_name`: AEST date formatting (UTC Sun 21:00 → AEST Mon 07:00 date string).
- `run()` integration: no-api-key → exit 2; empty bd ready no-op; no-eligible no-op; idempotent cycle reuse; happy path create+add; partial resolve-failure continues.

## Exit codes

- `0` — happy path OR idempotent skip OR no-eligible no-op
- `2` — `LINEAR_API_KEY` unset (operator misconfig signal — surfaces in timer log)

## Open questions surfaced in research, resolved by Dave ratification

| Question | Resolution |
|---|---|
| Selection policy | All unblocked P0+P1 (per Dave: "full picture, not a cap") |
| Cycle name template | `KEI Week of YYYY-MM-DD` (Scout default; not contradicted) |
| Last week's incomplete items | No roll-over (Scout default; not contradicted) |
| Mid-week new-ready items | Monday-only + `--force-now` flag (Scout default; not contradicted) |

## Post-merge

- Operator runs `scripts/orchestrator/install_systemd_units.sh` (or equivalent) to wire `weekly-cycle-from-bd.timer` + `.service` into `~/.config/systemd/user/`.
- `bd close Agency_OS-...` + Linear KEI-29 → Done.

## Test plan

- [x] `pytest tests/scripts/test_weekly_cycle_from_bd.py` — 16/16
- [x] `ruff check` — clean
- [ ] CI: Lint + Pytest + MyPy + Dead-Ref + Migration + SonarCloud
- [ ] Dual-CTO concur (Aiden + Max)
- [ ] Post-merge: install systemd units; first Monday 07:00 AEST cycle fires; verify Linear cycle exists + has P0+P1 issues attached.