### PR TITLE
[AIDEN] feat(kei-5vu): scaffold Cognee SYSTEM_ROOT relocation script + safety gate

### DIFF
--- a/scripts/migrate_cognee_system_root.py
+++ b/scripts/migrate_cognee_system_root.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""migrate_cognee_system_root.py — Agency_OS-5vu: relocate Cognee .cognee_system
+tree from venv-resident to stable storage.
+
+Problem: Cognee's default base_config.system_root_directory falls back to
+`.cognee_system/` under the installed package directory (i.e. inside the venv).
+`pip install --upgrade cognee` wipes this — including 1.6 GB of Lance vector
+data + the Ladybug graph + the SQLite cognee_db that hold Phase 1 ingest
+(~4332 nodes / 6486 edges per cognee-recall skill).
+
+Fix shape: set `SYSTEM_ROOT_DIRECTORY=<stable-path>` in .env, then move
+the existing tree to that path. Cognee's Pydantic BaseSettings picks up
+the env var on next process start (cognee/base_config.py:13).
+
+Execution gate (Max CRITICAL CORRECTION ts ~1778653100): cp -a + env-flip
+BLOCKED while Stream 2 (or any other cognify run) is active. This script
+refuses to execute when any cognee ingest process is detected.
+
+Usage:
+    python3 scripts/migrate_cognee_system_root.py --dry-run
+    python3 scripts/migrate_cognee_system_root.py --execute
+
+--dry-run: prints plan + safety checks, makes no changes.
+--execute: requires explicit flag, runs cp -a then verifies size match.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_STABLE_PATH = Path("/home/elliotbot/.cognee_system")
+COGNEE_INGEST_PATTERNS: tuple[str, ...] = (
+    r"cognee_ingest",
+    r"pipeline_runner",
+    r"cognify",
+)
+_COGNEE_RE = re.compile("|".join(COGNEE_INGEST_PATTERNS), re.IGNORECASE)
+
+
+def _venv_cognee_system_root() -> Path | None:
+    """Return current venv-resident .cognee_system path, or None if cognee not importable."""
+    try:
+        import cognee  # type: ignore[import-untyped]
+    except ImportError:
+        return None
+    cognee_dir = Path(cognee.__file__).resolve().parent
+    candidate = cognee_dir / ".cognee_system"
+    return candidate if candidate.exists() else None
+
+
+def _detect_active_cognee_processes() -> list[str]:
+    """Return command-lines of any running cognee ingest/cognify processes.
+    Returns [] if clean to migrate. Returns non-empty list = refuse migration.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["/usr/bin/ps", "-ef"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    matches = []
+    for line in result.stdout.splitlines():
+        if _COGNEE_RE.search(line) and "migrate_cognee_system_root" not in line:
+            matches.append(line.strip())
+    return matches
+
+
+def _dir_size_bytes(path: Path) -> int:
+    """Recursive size of a directory in bytes."""
+    return sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
+
+
+def plan(src: Path, dst: Path) -> dict:
+    """Return a migration plan + safety status dict."""
+    return {
+        "src": str(src),
+        "dst": str(dst),
+        "src_exists": src.exists(),
+        "dst_exists": dst.exists(),
+        "src_size_bytes": _dir_size_bytes(src) if src.exists() else 0,
+        "active_cognee_processes": _detect_active_cognee_processes(),
+    }
+
+
+def print_plan(p: dict) -> None:
+    print(f"Source: {p['src']}  (exists={p['src_exists']}, size={p['src_size_bytes']:,} bytes)")
+    print(f"Target: {p['dst']}  (exists={p['dst_exists']})")
+    active = p["active_cognee_processes"]
+    if active:
+        print(f"\nREFUSE: {len(active)} active cognee process(es) detected:")
+        for line in active:
+            print(f"  {line}")
+        print("\nMigration BLOCKED. Wait until all cognee ingest/cognify processes finish.")
+    else:
+        print("\nNo active cognee processes — migration would be safe NOW.")
+    print("\nPost-migration manual step:")
+    print(f"  Add to /home/elliotbot/.config/agency-os/.env:  SYSTEM_ROOT_DIRECTORY={p['dst']}")
+
+
+def execute(src: Path, dst: Path) -> int:
+    """Run the migration. Returns 0 on success, non-zero on failure."""
+    active = _detect_active_cognee_processes()
+    if active:
+        print("REFUSE: active cognee process(es) — migration blocked.", file=sys.stderr)
+        for line in active:
+            print(f"  {line}", file=sys.stderr)
+        return 2
+    if not src.exists():
+        print(f"REFUSE: source path does not exist: {src}", file=sys.stderr)
+        return 3
+    if dst.exists():
+        print(f"REFUSE: target path already exists: {dst} — remove it first.", file=sys.stderr)
+        return 4
+    src_size = _dir_size_bytes(src)
+    print(f"Copying {src} → {dst}  ({src_size:,} bytes)...")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(src, dst, symlinks=True)
+    dst_size = _dir_size_bytes(dst)
+    if dst_size != src_size:
+        print(f"FAIL: post-copy size mismatch — src={src_size:,} dst={dst_size:,}", file=sys.stderr)
+        return 5
+    print(
+        f"OK: {dst_size:,} bytes copied. Source preserved at {src} (delete manually after verify)."
+    )
+    print(f"\nNEXT: add SYSTEM_ROOT_DIRECTORY={dst} to /home/elliotbot/.config/agency-os/.env")
+    print("THEN: restart any Cognee-using services + smoke-test cognee_recall.py.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Migrate Cognee .cognee_system tree out of venv.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print plan + safety check, make no changes."
+    )
+    parser.add_argument("--execute", action="store_true", help="Run cp -a + verify.")
+    parser.add_argument(
+        "--src", type=Path, default=None, help="Source path (default: auto-detect venv-resident)."
+    )
+    parser.add_argument(
+        "--dst",
+        type=Path,
+        default=DEFAULT_STABLE_PATH,
+        help=f"Target path (default: {DEFAULT_STABLE_PATH}).",
+    )
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.execute:
+        parser.error("must specify --dry-run or --execute")
+    if args.dry_run and args.execute:
+        parser.error("--dry-run and --execute are mutually exclusive")
+
+    src = args.src or _venv_cognee_system_root()
+    if src is None:
+        print(
+            "ERROR: could not auto-detect venv-resident .cognee_system path. Pass --src.",
+            file=sys.stderr,
+        )
+        return 1
+    dst = args.dst
+
+    p = plan(src, dst)
+    print_plan(p)
+
+    if args.dry_run:
+        return 0
+    return execute(src, dst)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_migrate_cognee_system_root.py
+++ b/tests/scripts/test_migrate_cognee_system_root.py
@@ -1,0 +1,139 @@
+"""Tests for scripts/migrate_cognee_system_root.py — Agency_OS-5vu scaffold."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "migrate_cognee_system_root.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("migrate_cognee_system_root", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["migrate_cognee_system_root"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_cognee_re_matches_canonical_ingest_command(mod):
+    """Live Stream 2 command line must match the active-process detector."""
+    assert mod._COGNEE_RE.search("python3 scripts/cognee_ingest.py --streams 2") is not None
+    assert mod._COGNEE_RE.search("/usr/bin/python3 pipeline_runner.py --cohort small") is not None
+
+
+def test_cognee_re_no_false_positive_on_self(mod):
+    """The migration script's own ps line must not be matched (filtered upstream too)."""
+    # Pattern alone WOULD match 'cognify' word; the filter at call site excludes 'migrate_cognee_system_root'.
+    line = "python3 scripts/migrate_cognee_system_root.py --dry-run"
+    assert "migrate_cognee_system_root" in line  # self-exclusion key
+
+
+def test_detect_active_processes_returns_list(mod, monkeypatch):
+    """Smoke test — _detect_active_cognee_processes returns a list."""
+    out = mod._detect_active_cognee_processes()
+    assert isinstance(out, list)
+
+
+def test_detect_active_processes_filters_self(mod, monkeypatch):
+    """Mocked ps output containing the migration script itself must be filtered out."""
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = "user 123 1 0 python3 scripts/migrate_cognee_system_root.py --dry-run\n"
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: FakeCompleted())
+    assert mod._detect_active_cognee_processes() == []
+
+
+def test_detect_active_processes_catches_cognify(mod, monkeypatch):
+    """Mocked ps output with a cognify call must NOT be filtered (real ingest detected)."""
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = "user 456 1 99 python3 -c 'import cognee; cognee.cognify()'\n"
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: FakeCompleted())
+    out = mod._detect_active_cognee_processes()
+    assert len(out) == 1
+    assert "cognify" in out[0]
+
+
+def test_detect_active_processes_ps_failure_returns_empty(mod, monkeypatch):
+    """ps subprocess error returns [] (fail-safe — don't block on detection failure)."""
+
+    def fake_run(*a, **k):
+        raise FileNotFoundError("ps not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert mod._detect_active_cognee_processes() == []
+
+
+def test_plan_dict_shape(mod, tmp_path):
+    """plan() returns the expected fields for dry-run reporting."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "f.txt").write_text("hello")
+    dst = tmp_path / "dst"
+    p = mod.plan(src, dst)
+    assert p["src"] == str(src)
+    assert p["dst"] == str(dst)
+    assert p["src_exists"] is True
+    assert p["dst_exists"] is False
+    assert p["src_size_bytes"] == 5
+    assert isinstance(p["active_cognee_processes"], list)
+
+
+def test_execute_refuses_when_active_cognee(mod, monkeypatch, tmp_path):
+    """execute() must refuse when any cognee process is detected."""
+    monkeypatch.setattr(mod, "_detect_active_cognee_processes", lambda: ["fake-cognify-line"])
+    src = tmp_path / "src"
+    src.mkdir()
+    dst = tmp_path / "dst"
+    assert mod.execute(src, dst) == 2
+    assert not dst.exists()
+
+
+def test_execute_refuses_when_target_exists(mod, monkeypatch, tmp_path):
+    """execute() must refuse if target path already exists."""
+    monkeypatch.setattr(mod, "_detect_active_cognee_processes", lambda: [])
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "f.txt").write_text("data")
+    dst = tmp_path / "dst"
+    dst.mkdir()  # target pre-exists
+    assert mod.execute(src, dst) == 4
+
+
+def test_execute_refuses_when_source_missing(mod, monkeypatch, tmp_path):
+    """execute() must refuse if source does not exist."""
+    monkeypatch.setattr(mod, "_detect_active_cognee_processes", lambda: [])
+    src = tmp_path / "nonexistent"
+    dst = tmp_path / "dst"
+    assert mod.execute(src, dst) == 3
+
+
+def test_execute_happy_path(mod, monkeypatch, tmp_path):
+    """execute() copies + verifies size match when conditions clean."""
+    monkeypatch.setattr(mod, "_detect_active_cognee_processes", lambda: [])
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.txt").write_text("abc")
+    (src / "b.lance").mkdir()
+    (src / "b.lance" / "data.bin").write_text("xxxx")
+    dst = tmp_path / "dst"
+    assert mod.execute(src, dst) == 0
+    assert (dst / "a.txt").read_text() == "abc"
+    assert (dst / "b.lance" / "data.bin").read_text() == "xxxx"
+
+
+def test_main_requires_mode_flag(mod):
+    """main() exits with parser error when neither --dry-run nor --execute given."""
+    with pytest.raises(SystemExit):
+        mod.main()  # argparse default sys.argv is [], parser.error raises SystemExit


### PR DESCRIPTION
## Summary

Scaffold-only PR for Agency_OS-5vu (Move Cognee Lance datasets out of venv to stable storage). Per Elliot + Max execution gate (Max CRITICAL CORRECTION ts ~1778653100 on Stream 2 alive), cp -a + env-flip are BLOCKED until Track 1 unblock (Stream 2 sealed + VQ1-4 pass + Max re-FINAL).

**Why this matters:** Cognee defaults `system_root_directory` to `.cognee_system/` under the installed package directory (i.e. inside the venv). `pip install --upgrade cognee` would wipe **1.5 GB** of Lance vector data + Ladybug graph + SQLite cognee_db — including the Phase 1 ingest corpus that drives `cognee-recall`.

**Fix shape:** holistic — set `SYSTEM_ROOT_DIRECTORY=<stable-path>` in `.env` (Cognee's Pydantic BaseSettings hook at `base_config.py:13`), move the entire `.cognee_system` tree once via `cp -a`. NO Cognee fork/monkeypatch.

## What ships

- `scripts/migrate_cognee_system_root.py` (180 lines) — `--dry-run` + `--execute` modes. Auto-detects venv-resident path. **Refuses to execute when any cognee/cognify process is running** (regex match on `ps -ef`, self-filters out the migration script).
- `tests/scripts/test_migrate_cognee_system_root.py` (12 tests) — pattern matching, self-filter, mocked active-process detection, fail-safe on ps error, plan-dict shape, all `execute()` refuse paths, happy-path copy, main flag requirement.

## Empirical safety probe (live)

```
Source: .venv/.../cognee/.cognee_system  (1,488,492,165 bytes ≈ 1.5 GB)
Target: /home/elliotbot/.cognee_system  (does not exist)

REFUSE: 1 active cognee process(es) detected:
  elliotb+ 1387477  ... /home/elliotbot/clawd/Agency_OS/.venv/bin/python3 scripts/cognee_ingest.py --streams 2
```

Gate validated against the actual live Stream 2 ingest.

## Test plan

- [x] 12 unit tests pass + ruff clean.
- [x] Live `--dry-run` against Stream 2 → REFUSE (as designed).
- [ ] Post-Track-1 unblock: `--execute` against quiesced env, env-flip in .env, restart any Cognee-using services, smoke `cognee_recall.py` against a known governance query.

## Out of scope for this PR

- `.env` edit (gated on Track 1 unblock).
- Actual `cp -a` execution (gated on Track 1 unblock).
- Source-tree cleanup post-verify (manual after verify).
- Post-relocation cognee_recall smoke against a governance query (separate verify PR or commit after execute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)