### PR TITLE
[AIDEN] fix(heartbeat): cherry-pick Atlas dangling-pointer fix to main (KEI-22-class drift)

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -19,7 +19,7 @@ start, snapshotted by the PreCompact hook (scripts/pre_compact_alert.py).
 
 ## Model
 
-- Configured: <callsign-from-IDENTITY.md → lookup in CLAUDE.md §Callsign → Model Assignment table>
+- Configured: <callsign-from-IDENTITY.md → lookup in ceo_memory key `orchestration:model_assignment` (SQL-anchored Elliot UPSERT 2026-05-12 22:45:30 UTC)>
 - Running: <actual `--model` flag at startup, if known; otherwise "unknown — check tmux session launch command">
 
 ## Blockers


### PR DESCRIPTION
## Summary

Cherry-picks Atlas commit `7163916b` from `atlas/heartbeat-fix-dangling-pointer` to main. Replaces dangling `CLAUDE.md §Callsign → Model Assignment table` reference with the canonical `ceo_memory orchestration:model_assignment` key.

Discovered during KEI-36 empirical smoke probe (post-PR-#829 merge) — Atlas's fix existed on branch but was never merged. Exactly the KEI-22 state-mismatch class (Elliot's mental model: "HEARTBEAT.md was already updated" / on-main reality: still dangling).

## Diff

```diff
- Configured: <callsign-from-IDENTITY.md → lookup in CLAUDE.md §Callsign → Model Assignment table>
+ Configured: <callsign-from-IDENTITY.md → lookup in ceo_memory key `orchestration:model_assignment` (SQL-anchored Elliot UPSERT 2026-05-12 22:45:30 UTC)>
```

1 line changed in HEARTBEAT.md.

## Why this matters for KEI-36 (just merged @ e6e7f4e2)

The HEARTBEAT.md auto-populate currently leaves the `<callsign-from-IDENTITY.md → lookup in CLAUDE.md ...>` field as a residual placeholder (no `Callsign → Model` table exists in CLAUDE.md). With this cherry-pick, the placeholder hint correctly points to the `ceo_memory` key — making a follow-up KEI-36 v2 wirable (query `mcp__memory__get_by_id orchestration:model_assignment` → populate Configured field).

## Test plan

- [x] 1-line text change in HEARTBEAT.md template.
- [x] Atlas's original commit metadata + message preserved.
- [ ] Post-merge: KEI-36 auto-populate continues to gracefully leave the Configured field as residual placeholder (no behavioural regression) — `mcp__memory` wiring is a follow-up.

## Authorship

Atlas authored the original fix (commit 7163916b, branch `atlas/heartbeat-fix-dangling-pointer`). Cherry-pick by Aiden. Commit metadata preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)