### PR TITLE
[ORION] feat(kei22): Linear ↔ Beads bidirectional sync — 4 deliverables (URGENT)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -111,6 +111,11 @@
             "type": "command"
           },
           {
+            "command": "/home/elliotbot/clawd/venv/bin/python3 scripts/orchestrator/session_start_bd_linear_sync.py",
+            "timeout": 30,
+            "type": "command"
+          },
+          {
             "command": "/home/elliotbot/clawd/venv/bin/python3 scripts/anti_amnesia_capsule.py --read",
             "timeout": 5,
             "type": "command"

--- a/.github/workflows/kei-title-guard.yml
+++ b/.github/workflows/kei-title-guard.yml
@@ -1,0 +1,75 @@
+name: KEI Title Guard
+
+# KEI-22 D2 — CI gate enforcing KEI issue ID in PR title.
+#
+# Per Dave CEO directive ts ~1778653940 (KEI-22 Urgent): "KEI-25 (GitHub →
+# Linear native) is not catching all cases — PRs merged without proper KEI
+# issue ID references in PR title bypass the integration entirely."
+#
+# This gate fails CI when a PR title does NOT contain a KEI reference,
+# forcing every PR to be properly tracked at the Linear board level.
+#
+# Pass conditions: title contains any of:
+#   - KEI-N / kei-N    (canonical Linear issue id)
+#   - kei9 / kei22     (no-hyphen variants used in branch names)
+#   - keiN             (case-insensitive)
+#
+# Exempt conditions (no KEI ref required):
+#   - PR labelled 'no-kei' (operator opt-out for tooling/auto PRs)
+#   - PR title starts with 'chore(deps):' (dependabot)
+#   - PR title starts with 'Revert ' (revert PRs inherit the original's KEI)
+#
+# Pattern source: governance-equality-guard.yml (KEI-12 / Item #1 — CI-gate-
+# as-code rather than docs-only convention).
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [main]
+
+jobs:
+  kei-title-guard:
+    name: KEI ID required in PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title for KEI reference
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          title="$PR_TITLE"
+          labels="$PR_LABELS"
+
+          # Exempt label
+          if echo "$labels" | grep -qi '"no-kei"'; then
+            echo "::notice::PR labelled 'no-kei' — gate exempted."
+            exit 0
+          fi
+
+          # Exempt prefixes (case-sensitive — dependabot uses lowercase 'chore(deps)')
+          if echo "$title" | grep -qE '^(chore\(deps\):|Revert )'; then
+            echo "::notice::Exempt title prefix — gate skipped."
+            exit 0
+          fi
+
+          # KEI reference regex: KEI-N, kei-N, or kei<digits> (no hyphen).
+          if echo "$title" | grep -qiE '\b(kei[- ]?[0-9]+)\b'; then
+            echo "::notice::PR title carries KEI reference — gate passed."
+            exit 0
+          fi
+
+          echo "::error::PR title must contain a KEI issue id (e.g. 'KEI-22', 'kei-30', 'kei22')."
+          echo ""
+          echo "Current title: $title"
+          echo ""
+          echo "Why: KEI-22 D2 — Linear integration relies on PR titles for"
+          echo "issue↔PR linking. Titles without a KEI id bypass the auto-link"
+          echo "and create the board-drift bug that caused today's bad dispatch"
+          echo "(KEI-27/KEI-28 showed Todo in Linear when both were already Done)."
+          echo ""
+          echo "Fix: rename the PR title to include the KEI id, e.g."
+          echo "  '[ORION] feat(...): KEI-22 — Linear ↔ Beads sync'"
+          echo "Or add the 'no-kei' label if the PR is intentionally KEI-free"
+          echo "(tooling / dependabot / similar)."
+          exit 1

--- a/infra/alerts/agency-os-bd-linear-push.service
+++ b/infra/alerts/agency-os-bd-linear-push.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Agency OS — bd → Linear immediate push (KEI-22 D3, Dave directive 2026-05-13)
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/bd_status_to_linear_immediate.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+StandardOutput=append:/home/elliotbot/clawd/logs/bd-linear-push.log
+StandardError=append:/home/elliotbot/clawd/logs/bd-linear-push.log

--- a/infra/alerts/agency-os-bd-linear-push.timer
+++ b/infra/alerts/agency-os-bd-linear-push.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Push bd status changes to Linear every 60s (KEI-22 D3 — Dave-required immediate push cadence)
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=10s
+
+[Install]
+WantedBy=timers.target

--- a/infra/alerts/agency-os-linear-beads-divergence-sweep.service
+++ b/infra/alerts/agency-os-linear-beads-divergence-sweep.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Agency OS — Linear ↔ Beads weekly divergence sweep (KEI-22 D4, Dave directive 2026-05-13)
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/linear_beads_divergence_sweep.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+StandardOutput=append:/home/elliotbot/clawd/logs/linear-beads-divergence-sweep.log
+StandardError=append:/home/elliotbot/clawd/logs/linear-beads-divergence-sweep.log

--- a/infra/alerts/agency-os-linear-beads-divergence-sweep.timer
+++ b/infra/alerts/agency-os-linear-beads-divergence-sweep.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run Linear ↔ Beads divergence sweep weekly Sun 22:00 UTC (KEI-22 D4 — Mon 08:00 AEST)
+
+[Timer]
+OnCalendar=Sun 22:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/bd_status_to_linear_immediate.py
+++ b/scripts/bd_status_to_linear_immediate.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""bd_status_to_linear_immediate.py — KEI-22 D3.
+
+Per Dave CEO directive ts ~1778653940: bd status changes must push to
+Linear *immediately* (not on the next 20-minute pull cycle). Wraps the
+native `bd linear sync --push` (reuses canonical state-map). PR #807
+reverted a bespoke bd_to_linear.py in favour of this native — we
+reconstruct minimally as a thin push wrapper plus a 60-second systemd
+timer cadence so any bd state change reaches Linear within ~60 seconds.
+
+Operation:
+    bd linear sync --push
+        Native push: bd → Linear. Default conflict resolution is
+        newer-timestamp-wins; we keep that default (--prefer-local would
+        clobber Linear-side human edits).
+
+Best-effort: a push failure (Linear API outage, rate-limit, etc.) MUST
+NOT raise — the next 60s tick retries. We log to
+/home/elliotbot/clawd/logs/bd-linear-push.log and exit 0 either way.
+
+Run via timer (infra/alerts/agency-os-bd-linear-push.{service,timer},
+OnUnitActiveSec=60s).
+
+CLI:
+    --bd /path/to/bd   bd binary path (default 'bd' on PATH)
+    --dry-run          plan only, don't execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_LOG = Path("/home/elliotbot/clawd/logs/bd-linear-push.log")
+
+
+def _log(msg: str, log_path: Path = DEFAULT_LOG) -> None:
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a") as fh:
+            fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {msg}\n")
+    except OSError:
+        pass
+
+
+def run(
+    *,
+    bd_bin: str = "bd",
+    dry_run: bool = False,
+    log_path: Path = DEFAULT_LOG,
+    runner=None,
+) -> dict:
+    """Pure-Python entry. Always returns exit_code=0 (best-effort)."""
+    if not shutil.which(bd_bin) and bd_bin == "bd":
+        _log(f"bd_unavailable callsign={os.environ.get('CALLSIGN', '-')}", log_path)
+        return {"ok": False, "reason": "bd_unavailable", "exit_code": 0}
+
+    cmd = [bd_bin, "linear", "sync", "--push"]
+    if dry_run:
+        _log(f"dry_run: would exec {' '.join(cmd)}", log_path)
+        return {"ok": True, "reason": "dry_run", "exit_code": 0}
+
+    invoke = runner or (lambda: subprocess.run(cmd, capture_output=True, text=True, timeout=45))
+    try:
+        result = invoke()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        _log(f"push_failed_swallowed: {exc}", log_path)
+        return {"ok": False, "reason": f"exception: {exc}", "exit_code": 0}
+
+    if result.returncode != 0:
+        _log(
+            f"push_nonzero_swallowed rc={result.returncode} stderr={result.stderr[:200]}",
+            log_path,
+        )
+        return {"ok": False, "reason": f"bd_rc_{result.returncode}", "exit_code": 0}
+
+    _log(f"push_ok stdout={result.stdout[:200]}", log_path)
+    return {"ok": True, "reason": "pushed", "exit_code": 0}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bd", default="bd")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    result = run(bd_bin=args.bd, dry_run=args.dry_run)
+    print(f"[bd_status_to_linear_immediate] {result['reason']}")
+    return result["exit_code"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/linear_beads_divergence_sweep.py
+++ b/scripts/orchestrator/linear_beads_divergence_sweep.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""linear_beads_divergence_sweep.py — KEI-22 D4 weekly divergence sweep.
+
+Per Dave CEO directive ts ~1778653940: weekly Linear ↔ Beads divergence
+sweep, diff posted to #execution. Joins Linear issues to Beads issues by
+external-ref (Linear URL), surfaces:
+
+  - Linear In-Progress / Todo with NO bd row     (Linear-only)
+  - bd In-Progress / Open with NO Linear row     (bd-only)
+  - State mismatch (e.g. bd=closed, Linear=Todo) (divergent_state)
+
+Best-effort: any individual API failure (Linear GraphQL down, bd CLI
+missing, Slack POST 429) is logged + the sweep continues. Final summary
+posted to #execution with counts + first 10 lines of each bucket.
+
+Run via timer: infra/alerts/agency-os-linear-beads-divergence-sweep.{service,timer}
+  OnCalendar = Sun 22:00 UTC (Mon 08:00 AEST — hour after KEI-29 weekly cycle).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+EXECUTION_CHANNEL = "C0B3QB0K1GQ"
+LINEAR_GRAPHQL = "https://api.linear.app/graphql"
+DEFAULT_LOG = Path("/home/elliotbot/clawd/logs/linear-beads-divergence-sweep.log")
+
+
+def _log(msg: str, log_path: Path = DEFAULT_LOG) -> None:
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a") as fh:
+            fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {msg}\n")
+    except OSError:
+        pass
+
+
+def _fetch_linear_issues(api_key: str) -> list[dict]:
+    """Return list of {id, identifier, state_name, url}. [] on any failure."""
+    query = (
+        'query { issues(filter: {state: {type: {nin: ["completed", "canceled"]}}}, '
+        "first: 250) { nodes { id identifier title state { name type } url } } }"
+    )
+    req = urllib.request.Request(
+        LINEAR_GRAPHQL,
+        data=json.dumps({"query": query}).encode("utf-8"),
+        headers={"Authorization": api_key, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            body = json.loads(r.read())
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+        _log(f"linear_fetch_failed: {exc}")
+        return []
+    nodes = (((body.get("data") or {}).get("issues") or {}).get("nodes")) or []
+    return [
+        {
+            "id": n["id"],
+            "identifier": n["identifier"],
+            "title": n.get("title", ""),
+            "state_name": (n.get("state") or {}).get("name", "?"),
+            "state_type": (n.get("state") or {}).get("type", "?"),
+            "url": n.get("url", ""),
+        }
+        for n in nodes
+    ]
+
+
+def _fetch_bd_issues(bd_bin: str = "bd") -> list[dict]:
+    """`bd list --json`. [] on any failure."""
+    try:
+        r = subprocess.run(
+            [bd_bin, "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        _log(f"bd_fetch_failed: {exc}")
+        return []
+    if r.returncode != 0:
+        _log(f"bd_list_nonzero rc={r.returncode}")
+        return []
+    try:
+        data = json.loads(r.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    items = data if isinstance(data, list) else data.get("issues") or data.get("data") or []
+    return [
+        {
+            "id": i.get("id", ""),
+            "title": i.get("title", ""),
+            "status": (i.get("status") or "").lower(),
+            "external": i.get("external") or "",
+        }
+        for i in items
+        if isinstance(i, dict)
+    ]
+
+
+def _linear_id_from_external(ext: str) -> str | None:
+    """`https://linear.app/<team>/issue/KEI-22/...` → 'KEI-22'."""
+    if not ext:
+        return None
+    parts = ext.rstrip("/").split("/")
+    for i, p in enumerate(parts):
+        if p.lower() == "issue" and i + 1 < len(parts):
+            return parts[i + 1].split("?")[0]
+    return None
+
+
+def diff(linear_issues: list[dict], bd_issues: list[dict]) -> dict:
+    """Return three buckets: linear_only, bd_only, divergent_state."""
+    bd_by_kei: dict[str, dict] = {}
+    bd_unrefd: list[dict] = []
+    for b in bd_issues:
+        kei = _linear_id_from_external(b.get("external", ""))
+        if kei:
+            bd_by_kei[kei] = b
+        elif b.get("status") in ("open", "in_progress"):
+            bd_unrefd.append(b)
+
+    linear_only = [li for li in linear_issues if li["identifier"] not in bd_by_kei]
+
+    divergent: list[dict] = []
+    for li in linear_issues:
+        b = bd_by_kei.get(li["identifier"])
+        if not b:
+            continue
+        bd_closed = b["status"] in ("closed", "done")
+        linear_open = li["state_type"] not in ("completed", "canceled")
+        if bd_closed and linear_open:
+            divergent.append(
+                {
+                    "kei": li["identifier"],
+                    "bd_status": b["status"],
+                    "linear_state": li["state_name"],
+                    "linear_url": li["url"],
+                }
+            )
+
+    return {
+        "linear_only": linear_only,
+        "bd_only": bd_unrefd,
+        "divergent_state": divergent,
+    }
+
+
+def format_alert(buckets: dict) -> str:
+    lines = [
+        ":mag: *Weekly Linear ↔ Beads divergence sweep* — KEI-22 D4",
+        f"  • Linear-only (open in Linear, no bd row): {len(buckets['linear_only'])}",
+        f"  • bd-only (open in bd, no Linear external-ref): {len(buckets['bd_only'])}",
+        f"  • State mismatch (bd closed, Linear still open): {len(buckets['divergent_state'])}",
+    ]
+    for label, items, fmt in (
+        (
+            "Linear-only",
+            buckets["linear_only"][:10],
+            lambda x: f"      - {x['identifier']} ({x['state_name']}) — {x['title'][:60]}",
+        ),
+        (
+            "bd-only",
+            buckets["bd_only"][:10],
+            lambda x: f"      - {x['id']} ({x['status']}) — {x['title'][:60]}",
+        ),
+        (
+            "State mismatch",
+            buckets["divergent_state"][:10],
+            lambda x: f"      - {x['kei']}: bd={x['bd_status']} vs Linear={x['linear_state']}",
+        ),
+    ):
+        if items:
+            lines.append(f"\n  *{label}* (first 10):")
+            for it in items:
+                lines.append(fmt(it))
+    return "\n".join(lines)
+
+
+def post_to_slack(text: str, channel: str = EXECUTION_CHANNEL) -> bool:
+    token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if not token:
+        _log("slack_token_missing")
+        return False
+    payload = json.dumps(
+        {
+            "channel": channel,
+            "text": text,
+            "username": "LinearBeadsDivergence",
+            "icon_emoji": ":mag:",
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=payload,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            body = json.loads(r.read())
+            return bool(body.get("ok"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _log(f"slack_post_failed: {exc}")
+        return False
+
+
+def run(
+    *,
+    linear_fetch=None,
+    bd_fetch=None,
+    post_fn=None,
+) -> dict:
+    """Pure-Python entry. Injectable for tests."""
+    api_key = os.environ.get("LINEAR_API_KEY", "")
+    linear_fetch = linear_fetch or (lambda: _fetch_linear_issues(api_key))
+    bd_fetch = bd_fetch or _fetch_bd_issues
+    post_fn = post_fn or post_to_slack
+
+    linear = linear_fetch()
+    bd = bd_fetch()
+    buckets = diff(linear, bd)
+    text = format_alert(buckets)
+    posted = post_fn(text)
+    return {
+        "linear_count": len(linear),
+        "bd_count": len(bd),
+        "linear_only": len(buckets["linear_only"]),
+        "bd_only": len(buckets["bd_only"]),
+        "divergent_state": len(buckets["divergent_state"]),
+        "posted": posted,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        result = run(post_fn=lambda _t: True)
+    else:
+        result = run()
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/session_start_bd_linear_sync.py
+++ b/scripts/orchestrator/session_start_bd_linear_sync.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""session_start_bd_linear_sync.py — KEI-22 D1.
+
+Wraps `bd linear sync --pull-if-stale` for invocation from the SessionStart
+hook chain. Per Dave CEO directive ts ~1778653940: every agent boot must
+reconcile bd ↔ Linear so the board reflects truth before any dispatch
+decision (root cause of today's bad dispatch: KEI-27 / KEI-28 showed Todo
+in Linear when both were already Done).
+
+Operation:
+    bd linear sync --pull-if-stale --threshold 20m
+        Native staleness gate (20-minute threshold + 5-minute debounce per
+        Max empirical probe ts ~1778622767). Won't spin if data fresh.
+
+Hook-chain ordering (per dispatch literal, post-#813 KEI-31):
+    audit → context_compiler → cognee_recall --on-wake → bd_task_state
+        → session_uuid_resume → bd_sync_linear (THIS SCRIPT) → anti_amnesia_capsule
+
+Best-effort: bd sync failures must NEVER block session start. Failures
+are logged to /home/elliotbot/clawd/logs/bd-linear-sync.log + the script
+exits 0 either way.
+
+CLI:
+    --threshold 20m    bd staleness threshold (default per dispatch)
+    --bd /path/to/bd   bd binary path (default 'bd' on PATH)
+    --dry-run          print the planned command, don't execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_LOG = Path("/home/elliotbot/clawd/logs/bd-linear-sync.log")
+
+
+def _log(msg: str, log_path: Path = DEFAULT_LOG) -> None:
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a") as fh:
+            fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {msg}\n")
+    except OSError:
+        pass
+
+
+def run(
+    *,
+    threshold: str = "20m",
+    bd_bin: str = "bd",
+    dry_run: bool = False,
+    log_path: Path = DEFAULT_LOG,
+    runner=None,
+) -> dict:
+    """Pure-Python entry. Returns {'ok': bool, 'reason': str, 'exit_code': int}."""
+    if not shutil.which(bd_bin) and bd_bin == "bd":
+        _log(
+            f"bd_unavailable: bd binary not on PATH (callsign={os.environ.get('CALLSIGN', '-')})",
+            log_path,
+        )
+        return {"ok": False, "reason": "bd_unavailable", "exit_code": 0}
+
+    cmd = [bd_bin, "linear", "sync", "--pull-if-stale", "--threshold", threshold]
+    if dry_run:
+        _log(f"dry_run: would exec {' '.join(cmd)}", log_path)
+        return {"ok": True, "reason": "dry_run", "exit_code": 0}
+
+    invoke = runner or (lambda: subprocess.run(cmd, capture_output=True, text=True, timeout=30))
+    try:
+        result = invoke()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        _log(f"sync_failed_swallowed: {exc}", log_path)
+        return {"ok": False, "reason": f"exception: {exc}", "exit_code": 0}
+
+    if result.returncode != 0:
+        _log(
+            f"sync_nonzero_swallowed rc={result.returncode} stderr={result.stderr[:200]}",
+            log_path,
+        )
+        return {
+            "ok": False,
+            "reason": f"bd_rc_{result.returncode}",
+            "exit_code": 0,
+        }
+
+    _log(f"sync_ok stdout={result.stdout[:200]}", log_path)
+    return {"ok": True, "reason": "synced", "exit_code": 0}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--threshold", default="20m")
+    parser.add_argument("--bd", default="bd")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    result = run(threshold=args.threshold, bd_bin=args.bd, dry_run=args.dry_run)
+    print(f"[session_start_bd_linear_sync] {result['reason']}")
+    return result["exit_code"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/orchestrator/test_kei22_linear_beads_sync.py
+++ b/tests/orchestrator/test_kei22_linear_beads_sync.py
@@ -1,0 +1,301 @@
+"""Tests for KEI-22 deliverables — Linear ↔ Beads bidirectional sync.
+
+D1 — scripts/orchestrator/session_start_bd_linear_sync.py
+D3 — scripts/bd_status_to_linear_immediate.py
+D4 — scripts/orchestrator/linear_beads_divergence_sweep.py
+
+D2 (CI workflow .github/workflows/kei-title-guard.yml) is a YAML gate
+verified by repo-level shape tests below.
+
+All side effects (subprocess, urllib) are injected so tests run without
+real bd / Linear / Slack.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str, relpath: str):
+    p = REPO_ROOT / relpath
+    spec = importlib.util.spec_from_file_location(name, p)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+D1 = _load("session_start_bd_linear_sync", "scripts/orchestrator/session_start_bd_linear_sync.py")
+D3 = _load("bd_status_to_linear_immediate", "scripts/bd_status_to_linear_immediate.py")
+D4 = _load("linear_beads_divergence_sweep", "scripts/orchestrator/linear_beads_divergence_sweep.py")
+
+
+# ─── D1: session_start_bd_linear_sync ──────────────────────────────────
+
+
+def test_d1_success_logs_and_returns_ok(tmp_path):
+    log = tmp_path / "sync.log"
+    out = D1.run(
+        log_path=log,
+        runner=lambda: SimpleNamespace(returncode=0, stdout="pulled 3", stderr=""),
+    )
+    assert out == {"ok": True, "reason": "synced", "exit_code": 0}
+    assert "sync_ok" in log.read_text()
+
+
+def test_d1_bd_unavailable_swallowed_exit_zero(tmp_path):
+    """bd binary missing must NOT block session start — exit_code is 0.
+    Either shortcut path (bd_unavailable for default 'bd') or subprocess
+    exception path (custom bd_bin pointing nowhere) both qualify."""
+    out = D1.run(bd_bin="/nope/no-bd", log_path=tmp_path / "x.log")
+    assert out["ok"] is False
+    assert out["exit_code"] == 0
+    assert out["reason"] in ("bd_unavailable",) or out["reason"].startswith("exception:")
+
+
+def test_d1_nonzero_rc_swallowed_exit_zero(tmp_path):
+    """Real-world bd rc != 0 (network outage, Linear 429, etc.) must NOT
+    block session start. Exit 0; log surfaces the failure."""
+    log = tmp_path / "x.log"
+    out = D1.run(
+        log_path=log,
+        runner=lambda: SimpleNamespace(returncode=1, stdout="", stderr="Linear 429"),
+    )
+    assert out["exit_code"] == 0
+    assert out["ok"] is False
+    assert "nonzero_swallowed" in log.read_text()
+    assert "429" in log.read_text()
+
+
+def test_d1_dry_run_no_exec(tmp_path):
+    called = {"n": 0}
+
+    def runner():
+        called["n"] += 1
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    out = D1.run(dry_run=True, log_path=tmp_path / "x.log", runner=runner)
+    assert out["reason"] == "dry_run"
+    assert called["n"] == 0
+
+
+# ─── D2: kei-title-guard workflow file ─────────────────────────────────
+
+
+def test_d2_workflow_file_exists():
+    p = REPO_ROOT / ".github" / "workflows" / "kei-title-guard.yml"
+    assert p.is_file(), "kei-title-guard.yml must ship in this PR"
+
+
+def test_d2_workflow_fires_on_pull_request_to_main():
+    body = (REPO_ROOT / ".github" / "workflows" / "kei-title-guard.yml").read_text()
+    assert "on:" in body
+    assert "pull_request:" in body
+    assert "branches: [main]" in body
+
+
+def test_d2_workflow_exempts_dependabot_and_revert():
+    body = (REPO_ROOT / ".github" / "workflows" / "kei-title-guard.yml").read_text()
+    # Both exempt prefixes must be encoded.
+    assert "chore(deps)" in body
+    assert "Revert " in body
+    # 'no-kei' label exemption present.
+    assert "no-kei" in body
+
+
+def test_d2_workflow_matches_kei_id_in_title():
+    """Smoke the regex pattern shape on representative titles."""
+    import re
+
+    # Extract the grep pattern. The shell-side pattern is \b(kei[- ]?[0-9]+)\b.
+    pat = re.compile(r"\b(kei[- ]?[0-9]+)\b", re.IGNORECASE)
+    # Valid titles
+    for t in ("[ORION] feat: KEI-22 ...", "kei-30 something", "KEI 19 hotfix", "kei22 wip"):
+        assert pat.search(t), f"title should match: {t!r}"
+    # Invalid titles
+    for t in ("docs: README", "ship feature", "fix: bug"):
+        assert not pat.search(t), f"title should NOT match: {t!r}"
+
+
+# ─── D3: bd_status_to_linear_immediate ─────────────────────────────────
+
+
+def test_d3_push_success_logs_and_exit_zero(tmp_path):
+    log = tmp_path / "push.log"
+    out = D3.run(
+        log_path=log,
+        runner=lambda: SimpleNamespace(returncode=0, stdout="pushed 2", stderr=""),
+    )
+    assert out["ok"] is True
+    assert out["reason"] == "pushed"
+    assert out["exit_code"] == 0
+    assert "push_ok" in log.read_text()
+
+
+def test_d3_push_failure_swallowed_for_next_tick(tmp_path):
+    """Push failure on one 60s tick must not crash — next tick retries."""
+    log = tmp_path / "push.log"
+    out = D3.run(
+        log_path=log,
+        runner=lambda: SimpleNamespace(returncode=2, stdout="", stderr="rate limit"),
+    )
+    assert out["ok"] is False
+    assert out["exit_code"] == 0
+    assert "rate limit" in log.read_text()
+
+
+def test_d3_dry_run_does_not_execute(tmp_path):
+    invoked: list = []
+
+    def runner():
+        invoked.append(1)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    out = D3.run(dry_run=True, log_path=tmp_path / "x.log", runner=runner)
+    assert out["reason"] == "dry_run"
+    assert invoked == []
+
+
+# ─── D4: linear_beads_divergence_sweep ─────────────────────────────────
+
+
+def _li(identifier, state_name="Todo", state_type="unstarted", url=None):
+    return {
+        "id": f"L-{identifier}",
+        "identifier": identifier,
+        "title": f"{identifier} title",
+        "state_name": state_name,
+        "state_type": state_type,
+        "url": url or f"https://linear.app/keiracom/issue/{identifier}/x",
+    }
+
+
+def _bd(id_, status="open", external=""):
+    return {"id": id_, "title": f"{id_} title", "status": status, "external": external}
+
+
+def test_d4_linear_only_bucket():
+    linear = [_li("KEI-99")]
+    bd = []
+    buckets = D4.diff(linear, bd)
+    assert len(buckets["linear_only"]) == 1
+    assert buckets["linear_only"][0]["identifier"] == "KEI-99"
+
+
+def test_d4_bd_only_bucket_skips_closed():
+    linear = []
+    bd = [
+        _bd("Agency_OS-aaa", status="open", external=""),
+        _bd("Agency_OS-bbb", status="closed", external=""),  # closed → not in bucket
+    ]
+    buckets = D4.diff(linear, bd)
+    assert len(buckets["bd_only"]) == 1
+    assert buckets["bd_only"][0]["id"] == "Agency_OS-aaa"
+
+
+def test_d4_state_mismatch_bd_closed_linear_open():
+    linear = [_li("KEI-50", state_name="Todo", state_type="unstarted")]
+    bd = [
+        _bd(
+            "Agency_OS-x",
+            status="closed",
+            external="https://linear.app/keiracom/issue/KEI-50/title",
+        )
+    ]
+    buckets = D4.diff(linear, bd)
+    assert len(buckets["divergent_state"]) == 1
+    assert buckets["divergent_state"][0]["kei"] == "KEI-50"
+    assert buckets["divergent_state"][0]["bd_status"] == "closed"
+
+
+def test_d4_clean_state_no_divergence():
+    linear = [_li("KEI-50", state_type="completed")]
+    bd = [
+        _bd("Agency_OS-x", status="closed", external="https://linear.app/keiracom/issue/KEI-50/x")
+    ]
+    buckets = D4.diff(linear, bd)
+    assert buckets["linear_only"] == []
+    assert buckets["bd_only"] == []
+    # KEI-50 is completed in Linear + closed in bd → not divergent.
+    assert buckets["divergent_state"] == []
+
+
+def test_d4_format_alert_caps_at_10_per_bucket():
+    big = {
+        "linear_only": [_li(f"KEI-{i}") for i in range(50)],
+        "bd_only": [_bd(f"Agency_OS-{i}", status="open") for i in range(50)],
+        "divergent_state": [
+            {"kei": f"KEI-{i}", "bd_status": "closed", "linear_state": "Todo", "linear_url": "x"}
+            for i in range(50)
+        ],
+    }
+    text = D4.format_alert(big)
+    # Counts in summary should reflect full bucket sizes.
+    assert "50" in text
+    # But only 10 per bucket should be rendered as detail rows.
+    for kei_n in range(10):
+        assert f"KEI-{kei_n}" in text or f"Agency_OS-{kei_n}" in text
+    # KEI-49 should NOT appear (capped at 10).
+    assert "KEI-49" not in text
+
+
+def test_d4_run_aggregates_counts_and_posts(monkeypatch):
+    linear = [_li("KEI-99"), _li("KEI-50", state_type="unstarted")]
+    bd = [
+        _bd("Agency_OS-only", status="open"),
+        _bd("Agency_OS-x", status="closed", external="https://linear.app/keiracom/issue/KEI-50/x"),
+    ]
+    posted: list = []
+    result = D4.run(
+        linear_fetch=lambda: linear,
+        bd_fetch=lambda: bd,
+        post_fn=lambda text: posted.append(text) or True,
+    )
+    assert result["linear_count"] == 2
+    assert result["bd_count"] == 2
+    assert result["linear_only"] == 1  # KEI-99
+    assert result["bd_only"] == 1  # Agency_OS-only
+    assert result["divergent_state"] == 1  # KEI-50: bd closed, Linear open
+    assert result["posted"] is True
+    assert len(posted) == 1
+
+
+# ─── SessionStart hook chain ordering (D1 wire-in) ─────────────────────
+
+
+def test_session_start_hook_chain_includes_bd_linear_sync():
+    """The KEI-22 D1 wire-in inserts session_start_bd_linear_sync after
+    session_uuid_resume and before anti_amnesia_capsule per dispatch."""
+    import json
+
+    settings = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text())
+    chain = settings["hooks"]["SessionStart"][0]["hooks"]
+    cmds = [h["command"].split("/")[-1] for h in chain]
+
+    # Required entries present
+    assert any("session_start_bd_linear_sync" in c for c in cmds), (
+        "bd_linear_sync hook missing from SessionStart chain"
+    )
+    assert any("anti_amnesia_capsule" in c for c in cmds), (
+        "anti_amnesia_capsule must remain in chain"
+    )
+
+    # Order: bd_linear_sync BEFORE anti_amnesia_capsule
+    bd_idx = next(i for i, c in enumerate(cmds) if "session_start_bd_linear_sync" in c)
+    anti_idx = next(i for i, c in enumerate(cmds) if "anti_amnesia_capsule" in c)
+    assert bd_idx < anti_idx, (
+        "session_start_bd_linear_sync must run BEFORE anti_amnesia_capsule "
+        "(dispatch ordering: ... → session_uuid_resume → bd_sync_linear → "
+        "anti_amnesia_capsule LAST)"
+    )
+
+    # session_uuid_resume must come BEFORE bd_linear_sync
+    if any("session_uuid_resume" in c for c in cmds):
+        resume_idx = next(i for i, c in enumerate(cmds) if "session_uuid_resume" in c)
+        assert resume_idx < bd_idx


### PR DESCRIPTION
## Summary

Closes **KEI-22** (`Agency_OS-khf3an`) per Dave CEO directive ts ~1778653940 (**Urgent**). Root cause of today's bad dispatch: KEI-27/KEI-28 showed Todo in Linear when both were already Done; CEO dispatched duplicate work. Until KEI-22 is live, the board cannot be trusted for dispatch decisions. **Ships BEFORE Elliot restart.**

## Empirical probe first (per dual-CTO discipline)

```
$ bd linear sync --help
Synchronize issues between beads and Linear.
  Modes: --pull, --push, --pull-if-stale, (no flags) bidirectional
  --pull-if-stale --threshold 20m (default), 5-min debounce prevents loops
```

`bd linear sync` IS native (Max probe ts ~1778622767). All 4 deliverables wrap native commands — no bespoke sync reimplementation.

## Deliverables

### D1 — Session-start bd ↔ Linear reconciliation
- `scripts/orchestrator/session_start_bd_linear_sync.py` — thin wrapper over `bd linear sync --pull-if-stale --threshold 20m`
- `.claude/settings.json` SessionStart hook chain updated to insert between `session_uuid_resume` and `anti_amnesia_capsule` (exact dispatch order):
  ```
  session_start_audit → context_compiler → cognee_recall --on-wake
    → bd_task_state_injection → session_uuid_resume
    → session_start_bd_linear_sync   ← NEW
    → anti_amnesia_capsule --read    ← LAST (unchanged)
  ```
- Best-effort: bd unavailable / nonzero rc / exception → log + exit 0; never blocks session start

### D2 — CI gate enforcing KEI issue ID in PR title
- `.github/workflows/kei-title-guard.yml`
- Fires on `pull_request` `opened|edited|reopened|synchronize` → `main`
- Pattern: `\b(kei[- ]?[0-9]+)\b` case-insensitive
- Exempt: `no-kei` label, `chore(deps):` prefix, `Revert ` prefix
- Template source: `governance-equality-guard.yml` (KEI-12 / Item #1)

### D3 — bd status change → immediate Linear push
- `scripts/bd_status_to_linear_immediate.py` — thin wrapper over `bd linear sync --push`
- `infra/alerts/agency-os-bd-linear-push.{service,timer}` — `OnUnitActiveSec=60`
- Push failure swallowed; next 60s tick retries

### D4 — Weekly Linear ↔ Beads divergence sweep
- `scripts/orchestrator/linear_beads_divergence_sweep.py` — GraphQL pull Linear (non-completed) + `bd list --json`; join by external-ref → 3 buckets:
  - `linear_only` (open in Linear, no bd row)
  - `bd_only` (open in bd, no Linear external-ref)
  - `divergent_state` (bd closed but Linear still open)
- Slack post to #execution with counts + first 10 per bucket
- `infra/alerts/agency-os-linear-beads-divergence-sweep.{service,timer}` — `OnCalendar=Sun 22:00 UTC` (Mon 08:00 AEST — hour after KEI-29 weekly cycle)

## Pattern A safety (consistent across deliverables)

- bd binary missing → log + exit 0 (D1/D3)
- bd OR Linear API failure in D4 → that side's bucket empty; sweep continues + posts what it has
- Slack POST failure → log + return False (never raises)
- All long-running calls have timeouts (30–45s)
- State files / logs under `/home/elliotbot/clawd/logs/` (not `/tmp` — per state_paths convention)

## Verification

```
$ pytest tests/orchestrator/test_kei22_linear_beads_sync.py -q
18 passed in 0.85s

$ ruff check scripts/orchestrator/session_start_bd_linear_sync.py \
              scripts/bd_status_to_linear_immediate.py \
              scripts/orchestrator/linear_beads_divergence_sweep.py \
              tests/orchestrator/test_kei22_linear_beads_sync.py
All checks passed!
```

Test coverage map:
| Deliverable | Tests |
|---|---|
| D1 | success, bd_unavailable swallowed, nonzero_rc swallowed, dry_run |
| D2 | workflow exists; fires on PR-to-main; exempts dependabot/revert; regex matches; rejects KEI-free titles |
| D3 | push success, push failure swallowed, dry_run |
| D4 | linear_only bucket, bd_only skips closed, state mismatch, clean state, format caps at 10/bucket, end-to-end run |
| Wire-in | SessionStart hook chain ordering verified |

## Out of scope (per dispatch literal)

- Linear webhook receiver (PR #804 ships real-time inbound)
- New cron infrastructure (used existing systemd-user pattern from PR #790 + KEI-29 PR #823)
- Schema changes to bd or Linear data models
- systemd unit auto-enable — Dave-directed activation step preserved

## Activation flow this PR enables (post-merge)

```bash
bash scripts/orchestrator/install_systemd_units.sh    # picks up new timers
systemctl --user enable --now agency-os-bd-linear-push.timer
systemctl --user enable --now agency-os-linear-beads-divergence-sweep.timer
# D1 hook activates automatically on next agent session-start (settings.json edit)
# D2 gate activates automatically on next PR opened/edited
```

## LAW XVI

Isolated worktree `/tmp/orion-kei22` (Atlas-swap `.claude/*` symlink bypass), cleaned up post-push.

## Test plan

- [x] 18/18 tests pass, ruff + format clean
- [x] Empirical probe confirms `bd linear sync` native (no bespoke reimplementation)
- [x] Pattern A safety on every deliverable
- [x] SessionStart hook chain ordering verified by test
- [x] CI gate exemptions encoded (dependabot, revert, no-kei label)
- [ ] Post-merge: operator runs `install_systemd_units.sh` + enables the 2 new timers
- [ ] Post-merge: next agent session-start observes D1 sync log line

## Dual-CTO concur

Aiden + Max please review. **Urgent — ships before Elliot restart.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)