### PR TITLE
[AIDEN] refactor(cognee): eager-init Lance writer semaphore — clarity follow-up to PR #826

### DIFF
--- a/src/cognee/client.py
+++ b/src/cognee/client.py
@@ -36,7 +36,13 @@ from typing import Any
 
 import cognee
 
-_LANCE_WRITE_SEM: asyncio.Semaphore | None = None
+# Eager init: asyncio.Semaphore() constructor is loop-agnostic in Python 3.10+
+# (attaches to loop on first acquire). Module-level eager-create eliminates any
+# theoretical race in the prior lazy-init `if None: assign` pattern (single-loop
+# asyncio is yield-point-atomic, but multi-loop test harnesses could theoretically
+# pass both `is None` checks before either assigns). Audit-and-clean-up follow-up
+# to PR #826 per Aiden+Max+Elliot triple-concur ts ~1778662900.
+_LANCE_WRITE_SEM: asyncio.Semaphore = asyncio.Semaphore(1)
 
 
 def _install_lance_writer_serialiser() -> None:
@@ -69,9 +75,6 @@ def _install_lance_writer_serialiser() -> None:
         return
 
     async def serialised_index_data_points(self, *args, **kwargs):  # type: ignore[no-untyped-def]
-        global _LANCE_WRITE_SEM
-        if _LANCE_WRITE_SEM is None:
-            _LANCE_WRITE_SEM = asyncio.Semaphore(1)
         async with _LANCE_WRITE_SEM:
             return await orig(self, *args, **kwargs)
 


### PR DESCRIPTION
## Summary

Audit follow-up to PR #826 per triple-concur ts ~1778662900 (Aiden audit + Max retract-and-CONCUR + Elliot CONCUR FINAL).

PR #826 used a lazy-init pattern. Single-loop asyncio analysis shows the lazy-init has NO real race — coroutines are yield-point-atomic and there is no `await` between the `is None` check and the assign. CPython GIL also guarantees the global-write is bytecode-atomic. The 3 lines of lazy-init guard add cognitive load with no upside in cognee's production single-loop model.

This PR replaces the lazy-init with module-level eager init. `asyncio.Semaphore()` constructor is loop-agnostic in Python 3.10+ (attaches to loop on first acquire), so module-load creation is safe.

## Diff

```diff
- _LANCE_WRITE_SEM: asyncio.Semaphore | None = None
+ _LANCE_WRITE_SEM: asyncio.Semaphore = asyncio.Semaphore(1)
```

Plus removal of 3 lines (`global` / `if None` / `assign`) inside the wrapper function.

Total: 7 insertions / 4 deletions, 1 file.

## Empirical anchor

Stream 2 ingest ran clean through 8h54min wall + 5036 pipeline runs since resume against the lazy-init version. **No in-wild reproduction** — this PR is clarity + defense-in-depth (P3), not a bug-fix.

## Test plan

- [x] 30/30 cognee tests still pass.
- [x] ruff check + ruff format clean.
- [ ] Will not affect any live Cognee ingest — Max's Stream 3+4 (PID 1620293) is running against the OLD lazy-init code path; this PR only affects new processes started after merge.

## Why now

Elliot proposed [PROPOSE:elliot] "file when bandwidth allows; not urgent" during Stream 3+4 gate. This is the bandwidth slot. Clean cleanup before the next ingest cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)