### PR TITLE
[AIDEN] docs(governance): add ceo:rule:* anchor per Dave backfill — Agency_OS-8lz follow-up

### DIFF
--- a/docs/wave2/governance_linear_kei_before_build.md
+++ b/docs/wave2/governance_linear_kei_before_build.md
@@ -3,6 +3,7 @@
 **Author:** Aiden (design only — per Dave verbatim ts ~1778666900)
 **Implementer:** Elliot (post-compact ratification + execute, bundled with KEI-37/38/39 + ceo_memory hygiene)
 **Beads:** Agency_OS-8lz — P2
+**ceo_memory:** `ceo:rule:no_build_without_linear_issue` (Dave backfilled ts ~1778667300 per new `ceo:rule:ceo_operational_directives_recorded` standing rule)
 **Self-referential:** this bd issue + design doc were created BEFORE the branch + commit per the rule it documents.
 
 ## Dave verbatim — canonical sources
@@ -16,6 +17,18 @@
 > Linear is the only source of work. Beads is the enforcement mechanism. Cannot build without active bd claim on Linear-sourced task. No exceptions. Chain: KEI in Linear → bd sync → bd claim → Enforcer confirms → build begins. Any step missing = HARD STOP at tool level.
 
 Applies to all 6 callsigns going forward. The hardening (Beads as enforcement mechanism, tool-level hard stop) shifts the rule from agent-discipline to mechanical-enforcement.
+
+### ceo_memory anchor (Dave backfilled ts ~1778667300)
+
+Per the new Dave standing rule "CEO directives establishing rules MUST be recorded in ceo_memory at issue-time" (`ceo:rule:ceo_operational_directives_recorded`), this rule's canonical anchor is:
+
+- **Key:** `ceo:rule:no_build_without_linear_issue`
+- **Companion key (Layer 3 enforcement):** `ceo:rule:beads_layer3_enforcement`
+- **Companion key (sourcing):** `ceo:rule:linear_only_source_of_work`
+
+KEI-37 boot_state schema includes a `rules_ref` array pointing at all active `ceo:rule:*` keys so every new CEO session loads them on start (Elliot's KEI-37 post-compact lane). KEI-22 deliverable 7 ships the auto-record mechanism that writes future Dave-issued rules to `ceo:rule:*` keys automatically via Slack-relay governance-trigger-phrase detection.
+
+Until KEI-22 deliverable 7 ships, Elliot writes rules to ceo_memory manually as they're issued. Dave's backfill ts ~1778667300 caught the prior 7 unrecorded rules.
 
 ## Rule restated for GOVERNANCE.md
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #836 (Linear-KEI-before-build design doc). Adds `ceo:rule:*` ceo_memory anchor per Dave's newest standing rule ts ~1778667300 ("CEO directives establishing rules MUST be recorded in ceo_memory at issue-time").

Within `Agency_OS-8lz` KEI scope (multi-task within one KEI per the rule's edge case). No new bd issue required.

## What changed

- **Frontmatter line added:** `ceo_memory: ceo:rule:no_build_without_linear_issue` — canonical anchor.
- **New section "ceo_memory anchor (Dave backfilled ts ~1778667300)"** — cites primary key + 2 companion keys (`ceo:rule:beads_layer3_enforcement` + `ceo:rule:linear_only_source_of_work`), the KEI-37 boot_state `rules_ref` array integration (Elliot's lane), and the KEI-22 deliverable 7 auto-record mechanism (Orion's lane).

13 lines added. Single file.

## Why a follow-up vs amend the original

PR #836 already merged @ 0cfafa8d before Dave's ts ~1778667300 directive landed. This is the fix-forward pattern (proven this session on KEI-26 + KEI-34 v3 + KEI-38 scope expansion).

## Composition

- KEI-37 boot_state schema includes `rules_ref` array → CEO new-session reads all active rules on boot.
- KEI-22 deliverable 7 = Slack-relay auto-rule-detect-and-record → future rules auto-write to `ceo:rule:*` keys.
- Until KEI-22 deliverable 7 ships, Elliot writes manually as Dave issues. Today's backfill caught 7 prior unrecorded rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)