### PR TITLE
[ORION] feat(kei22): D5+D6+D7 — Layer 1/2/3 enforcement (URGENT pre-restart)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# .githooks/pre-commit — KEI-22 D6 Layer 3 mechanical gate.
+#
+# Per Dave CEO directive ts ~1778667100:
+#
+#   BRANCH=$(git branch --show-current)
+#   CLAIM=$(bd check-claim --branch $BRANCH)
+#   if [ -z "$CLAIM" ]; then
+#     echo 'ERROR: No active bd claim for $BRANCH. Run bd claim [KEI-ID] first.'
+#     exit 1
+#   fi
+#
+# No bd claim = commit physically fails. Hard stop. No LLM involved.
+#
+# Installation: operator runs `scripts/orchestrator/install_pre_commit_hook.sh`
+# per-worktree to point git's hooksPath at this directory.
+#
+# Pattern A escape hatches:
+#   AGENCY_OS_BD_HARDFAIL=0 (default)   — degrade soft if bd binary missing
+#                                          (don't cascade infra outage to
+#                                           commit outage). Warns once.
+#   AGENCY_OS_BD_HARDFAIL=1             — fail closed even when bd is down.
+#                                          Strict mode; production-grade.
+#   GIT_NO_VERIFY=1                     — git's standard --no-verify bypass.
+#                                          Logged; visible in commit metadata.
+
+set -u
+
+# Resolve branch name. Detached-HEAD (rebases, cherry-picks) → skip the
+# gate — git operations in that state are mid-flight and have their own
+# semantics.
+BRANCH="$(git branch --show-current 2>/dev/null || echo "")"
+if [[ -z "$BRANCH" ]]; then
+    exit 0
+fi
+
+# Exempt branch prefixes that are operator/automated workflow, not agent build.
+case "$BRANCH" in
+    main | master | release/* | hotfix/*)
+        # main-class branches don't go through pre-commit on routine commits
+        # (PR merges + force-pushes bypass anyway). Soft-allow.
+        exit 0
+        ;;
+esac
+
+# Locate the bd_check_claim wrapper.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+CHECK="$REPO_ROOT/scripts/orchestrator/bd_check_claim.sh"
+if [[ ! -x "$CHECK" ]]; then
+    # Wrapper missing — likely a worktree on a branch that pre-dates KEI-22.
+    # Degrade-soft so historical work doesn't break.
+    echo "warning: $CHECK missing — Layer 3 gate skipped." >&2
+    exit 0
+fi
+
+"$CHECK" --branch "$BRANCH" >/dev/null 2>&1
+rc=$?
+
+if [[ $rc -eq 0 ]]; then
+    # Valid claim — allow commit. Exit code is the source of truth (the
+    # claim id itself is informational, not needed by the gate).
+    exit 0
+fi
+
+if [[ $rc -eq 2 ]]; then
+    # bd binary missing. Pattern A: soft-allow unless HARDFAIL=1.
+    if [[ "${AGENCY_OS_BD_HARDFAIL:-0}" == "1" ]]; then
+        echo "ERROR (HARDFAIL=1): bd binary missing — commit refused." >&2
+        exit 1
+    fi
+    echo "warning: bd binary missing — Layer 3 gate degraded-soft." >&2
+    exit 0
+fi
+
+# rc=1 = no valid claim. HARD STOP per Dave directive.
+cat >&2 <<EOF
+ERROR: KEI-22 D6 Layer 3 mechanical gate — no active bd claim for branch '$BRANCH'.
+
+Dave standing rule (CEO ts ~1778667000 + ~1778667100):
+  "Linear is the only source of work. Beads is the enforcement mechanism.
+   Cannot build without active bd claim on Linear-sourced task."
+
+Required chain:
+  1. KEI exists in Linear (Todo / In Progress)
+  2. bd sync --pull-if-stale (D1 SessionStart hook does this)
+  3. bd update <Agency_OS-id> --assignee <callsign>
+  4. bd update <Agency_OS-id> --claim   (sets status=in_progress)
+  5. Commit retries — this gate will pass.
+
+Quick fix:
+  bd ready                          # find an unblocked KEI
+  bd update <Agency_OS-id> --assignee \$CALLSIGN
+  bd update <Agency_OS-id> --claim
+  git commit ...                    # retry
+
+Escape hatch (operator-authorised only):
+  git commit --no-verify ...
+
+Companion: KEI-22 D5 PreToolUse hook (scripts/orchestrator/check_bd_claim_before_build.py)
+provides the same gate at the Claude Code tool-call level.
+EOF
+exit 1

--- a/scripts/orchestrator/bd_check_claim.sh
+++ b/scripts/orchestrator/bd_check_claim.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# bd_check_claim.sh — KEI-22 D6 thin wrapper providing `bd check-claim --branch`.
+#
+# Per Dave CEO directive ts ~1778667100: pre-commit hook must call this to
+# physically refuse commits without an active bd claim. bd itself doesn't
+# have `check-claim` as a native subcommand (verified by `bd check-claim
+# --help` returning 'unknown command'). We wrap `bd list --json` + filter
+# logic that mirrors KEI-22 D5 PreToolUse hook semantics:
+#
+#   Claim is valid iff there exists a bd issue where:
+#     - assignee == <callsign>  (callsign derived from branch prefix or env)
+#     - status   == in_progress
+#     - external contains 'linear.app' (proves Linear-sourced per Dave rule)
+#
+# Usage:
+#     bd_check_claim.sh --branch <name>      # exits 0 + prints claim id if valid
+#     bd_check_claim.sh --branch <name> --quiet
+#     CALLSIGN=orion bd_check_claim.sh        # uses env, no branch parse
+#
+# Exit codes:
+#     0 — valid claim found (prints claim id to stdout)
+#     1 — no valid claim (prints reason to stderr)
+#     2 — bd binary missing or unexpected error
+#
+# Pattern A: bd binary missing exits 2 (not 0); pre-commit caller can then
+# decide whether to fail-open (degrade-soft per D5) or fail-closed. The
+# default `.githooks/pre-commit` shipped alongside fails CLOSED on exit 2
+# only when AGENCY_OS_BD_HARDFAIL=1 is set, else degrades soft with a
+# warning — matches D5's bd-down soft-allow design.
+
+set -u
+
+BRANCH=""
+QUIET=0
+BD_BIN="${AGENCY_OS_BD_BIN:-bd}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --branch)
+            BRANCH="${2:-}"
+            shift 2
+            ;;
+        --quiet)
+            QUIET=1
+            shift
+            ;;
+        -h | --help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "error: unknown arg: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+log() { [[ $QUIET -eq 1 ]] || printf '%s\n' "$*" >&2; }
+
+# Resolve callsign: prefer env CALLSIGN; fall back to branch prefix
+# (orion/foo → orion). Branch prefix must be one of the known callsigns.
+callsign="${CALLSIGN:-}"
+if [[ -z "$callsign" && -n "$BRANCH" ]]; then
+    prefix="${BRANCH%%/*}"
+    case "$prefix" in
+        orion | atlas | scout | elliot | aiden | max)
+            callsign="$prefix"
+            ;;
+    esac
+fi
+callsign="${callsign,,}"
+
+if [[ -z "$callsign" ]]; then
+    log "error: cannot resolve callsign (CALLSIGN env unset + branch=$BRANCH not callsign-prefixed)"
+    exit 1
+fi
+
+# Empirical probe: bd binary present?
+if ! command -v "$BD_BIN" >/dev/null 2>&1; then
+    log "warning: $BD_BIN binary not on PATH — Pattern A degrade-soft for caller"
+    exit 2
+fi
+
+# Pull bd list and filter via embedded Python (avoids jq dependency).
+result_json="$("$BD_BIN" list --json 2>/dev/null || echo "[]")"
+
+claim_id="$(
+    BD_LIST_JSON="$result_json" CALLSIGN="$callsign" /home/elliotbot/clawd/venv/bin/python3 - <<'PY'
+import json
+import os
+import sys
+
+raw = os.environ.get("BD_LIST_JSON", "[]")
+callsign = os.environ.get("CALLSIGN", "").lower()
+try:
+    data = json.loads(raw or "[]")
+except json.JSONDecodeError:
+    sys.exit(0)
+items = data if isinstance(data, list) else data.get("issues") or data.get("data") or []
+for i in items:
+    if not isinstance(i, dict):
+        continue
+    if (i.get("assignee") or "").strip().lower() != callsign:
+        continue
+    if (i.get("status") or "").lower() != "in_progress":
+        continue
+    if "linear.app" not in (i.get("external") or "").lower():
+        continue
+    print(i.get("id", ""))
+    sys.exit(0)
+sys.exit(0)
+PY
+)"
+
+if [[ -n "$claim_id" ]]; then
+    [[ $QUIET -eq 1 ]] || printf '%s\n' "$claim_id"
+    exit 0
+fi
+
+log "no_valid_claim: no bd issue assigned to '$callsign' with status=in_progress + Linear external-ref"
+exit 1

--- a/scripts/orchestrator/ceo_rule_auto_record.py
+++ b/scripts/orchestrator/ceo_rule_auto_record.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""ceo_rule_auto_record.py — KEI-22 D7 Slack-relay auto-rule-detect-and-record.
+
+Per Dave CEO directive ts ~1778667300:
+    "Every CEO operational directive that establishes a standing rule must
+     be recorded in ceo_memory at the time of issue. Key pattern:
+     ceo:rule:[rule-name]"
+
+Pattern source: KEI-26 BS-incident → Linear KEI auto-create webhook (PR #815).
+This script provides the same shape for ceo_memory rule capture.
+
+Invocation (by Slack relay on every Dave #ceo post):
+
+    python3 scripts/orchestrator/ceo_rule_auto_record.py \
+        --channel C0B2PM3TV0B \
+        --author dave \
+        --slug optional_explicit_slug \
+        --body-file /tmp/msg.txt
+
+Filter chain (all must match for the auto-record to fire):
+    1. channel == #ceo (C0B2PM3TV0B) — other channels never trigger
+    2. author == 'dave' (case-insensitive) — only Dave's posts establish rules
+    3. body matches at least one governance trigger phrase
+
+Trigger phrases (matching Dave's verbatim language):
+    - 'standing rule'
+    - 'effective immediately'
+    - 'from now on'
+    - 'no exceptions'
+    - 'hard stop'
+    - 'no build without'           (Dave's pattern for negative rules)
+    - 'must be recorded'           (self-referential rule)
+
+Slug resolution (in priority order):
+    1. --slug CLI arg (relay-provided, e.g. LLM-extracted)
+    2. Body explicit pattern: 'ceo:rule:<slug>' or 'Key: ceo:rule:<slug>'
+    3. Heuristic: snake-case the first 5-8 words after the trigger phrase
+
+Output: JSON to stdout with {'fired': bool, 'key': str|null, 'reason': str}.
+
+Best-effort: ceo_memory write failure is logged + returns fired=False, reason=
+'write_failed' so the relay can retry on the next dispatch. Exit code 0 either
+way (never crashes the relay).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+DEFAULT_LOG = Path("/home/elliotbot/clawd/logs/ceo-rule-auto-record.log")
+CEO_CHANNEL_ID = "C0B2PM3TV0B"
+
+_TRIGGER_RE = re.compile(
+    r"\bstanding rule\b"
+    r"|\beffective immediately\b"
+    r"|\bfrom now on\b"
+    r"|\bno exceptions\b"
+    r"|\bhard stop\b"
+    r"|\bno build without\b"
+    r"|\bmust be recorded\b",
+    re.IGNORECASE,
+)
+
+_EXPLICIT_KEY_RE = re.compile(
+    r"ceo:rule:([a-z][a-z0-9_]*)",
+    re.IGNORECASE,
+)
+
+
+def _log(msg: str, log_path: Path = DEFAULT_LOG) -> None:
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a") as fh:
+            fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {msg}\n")
+    except OSError:
+        pass
+
+
+def _heuristic_slug(body: str) -> str:
+    """Snake-case first 5-8 content words after the first trigger phrase."""
+    m = _TRIGGER_RE.search(body)
+    if not m:
+        return "unnamed_rule"
+    after = body[m.end() :].strip().lower()
+    # Strip common stopwords + punctuation
+    tokens: list[str] = []
+    stop = {
+        "the",
+        "a",
+        "an",
+        "is",
+        "are",
+        "be",
+        "for",
+        "of",
+        "to",
+        "and",
+        "or",
+        "in",
+        "on",
+        "this",
+        "that",
+        "it",
+        "as",
+        "at",
+    }
+    for tok in re.split(r"[^\w]+", after):
+        if not tok or tok in stop:
+            continue
+        tokens.append(tok)
+        if len(tokens) >= 6:
+            break
+    return "_".join(tokens) or "unnamed_rule"
+
+
+def resolve_slug(*, slug_arg: str | None, body: str) -> str:
+    """Return the slug to use, in priority: --slug → ceo:rule:<x> in body → heuristic."""
+    if slug_arg:
+        return re.sub(r"[^a-z0-9_]+", "_", slug_arg.lower()).strip("_") or "unnamed_rule"
+    m = _EXPLICIT_KEY_RE.search(body)
+    if m:
+        return m.group(1).lower()
+    return _heuristic_slug(body)
+
+
+def should_fire(
+    *,
+    channel: str,
+    author: str,
+    body: str,
+) -> tuple[bool, str]:
+    """Return (fire, reason)."""
+    if channel != CEO_CHANNEL_ID:
+        return False, "wrong_channel"
+    if (author or "").strip().lower() != "dave":
+        return False, "not_dave"
+    if not _TRIGGER_RE.search(body):
+        return False, "no_trigger_phrase"
+    return True, "governance_trigger_matched"
+
+
+def record_rule(
+    *,
+    channel: str,
+    author: str,
+    body: str,
+    slug_arg: str | None = None,
+    upsert_fn: Callable[[str, dict[str, Any]], bool] | None = None,
+    now_iso: str | None = None,
+) -> dict[str, Any]:
+    """Pure-Python entry. upsert_fn is injectable for tests."""
+    fire, reason = should_fire(channel=channel, author=author, body=body)
+    if not fire:
+        _log(f"skipped reason={reason} author={author!r} channel={channel!r}")
+        return {"fired": False, "key": None, "reason": reason}
+
+    slug = resolve_slug(slug_arg=slug_arg, body=body)
+    key = f"ceo:rule:{slug}"
+    value = {
+        "rule_body": body.strip(),
+        "author": author,
+        "recorded_at": now_iso or time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "channel": channel,
+        "source": "kei22_d7_auto_record",
+    }
+
+    if upsert_fn is None:
+        upsert_fn = _default_upsert_fn
+
+    try:
+        ok = upsert_fn(key, value)
+    except Exception as exc:
+        _log(f"write_failed key={key!r} exc={exc}")
+        return {"fired": False, "key": key, "reason": f"write_failed: {exc}"}
+
+    if not ok:
+        _log(f"write_returned_false key={key!r}")
+        return {"fired": False, "key": key, "reason": "write_failed"}
+
+    _log(f"recorded key={key!r} author={author!r}")
+    return {"fired": True, "key": key, "reason": "recorded"}
+
+
+def _default_upsert_fn(key: str, value: dict[str, Any]) -> bool:
+    """Default upsert via Supabase REST. Best-effort; returns False on failure."""
+    try:
+        from src.evo.supabase_client import sb_post
+    except Exception:
+        return False
+    try:
+        sb_post(
+            "ceo_memory",
+            {"key": key, "value": value},
+        )
+        return True
+    except Exception:
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel", required=True)
+    parser.add_argument("--author", required=True)
+    parser.add_argument("--slug", default=None)
+    parser.add_argument(
+        "--body-file",
+        type=Path,
+        help="Path to a file containing the message body (avoids shell-escaping).",
+    )
+    parser.add_argument(
+        "--body",
+        default=None,
+        help="Inline message body (alternative to --body-file).",
+    )
+    args = parser.parse_args(argv)
+
+    body = ""
+    if args.body_file:
+        try:
+            body = args.body_file.read_text()
+        except OSError:
+            body = ""
+    elif args.body:
+        body = args.body
+    else:
+        body = sys.stdin.read() if not sys.stdin.isatty() else ""
+
+    result = record_rule(
+        channel=args.channel,
+        author=args.author,
+        body=body,
+        slug_arg=args.slug,
+    )
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/check_bd_claim_before_build.py
+++ b/scripts/orchestrator/check_bd_claim_before_build.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""check_bd_claim_before_build.py — KEI-22 D5 Beads hard-block.
+
+Per Dave CEO directive ts ~1778667000:
+    "Linear is the only source of work. Beads is the enforcement mechanism.
+     Cannot build without active bd claim on Linear-sourced task. No
+     exceptions. Chain: KEI in Linear → bd sync → bd claim → Enforcer
+     confirms → build begins. Any step missing = HARD STOP at tool level."
+
+This script is a Claude Code PreToolUse-hook-compatible gate. When the
+agent attempts a write/build tool call, this hook:
+
+    1. Reads tool name + args from stdin (PreToolUse contract).
+    2. Filters to write/build operations (Edit, Write, NotebookEdit, and
+       Bash commands that commit/push). Read-only tools (Read, Grep,
+       Glob, Bash for status/diff/log) ALWAYS pass — exploration is not
+       gated.
+    3. For a write op, queries `bd list --json` for an issue:
+         - assignee = $CALLSIGN
+         - status   = in_progress
+         - external = Linear URL (proves Linear-sourced)
+    4. If no qualifying claim → exit 1 with JSON error explaining the
+       chain. If found → exit 0.
+
+Pattern A safety:
+  - bd binary missing → DEGRADE-SOFT (exit 0 + log). Don't cascade an
+    infra outage into a build outage; operator sees the log on next
+    sweep. This is the explicit Pattern A trade-off — false-allow once
+    on bd-down beats false-block-forever on a known infra hole.
+  - Read-only tools ALWAYS pass — no governance value in gating Read.
+  - Hook input JSON malformed → exit 0 + log (defensive; never crash
+    Claude Code's hook chain).
+
+NOT auto-activated. Wiring into `.claude/settings.json` is a Dave-directed
+step Dave + Elliot run post-merge once the rule is live elsewhere
+(Enforcer R2 retest after KEI-38 regex fix, etc.).
+
+Exit codes (PreToolUse contract):
+    0 = allow (read-op OR claim valid OR bd-down soft-allow)
+    1 = HARD BLOCK (write-op + no qualifying claim)
+    2 = hook error (unexpected exception)
+
+CLI:
+    --callsign <name>    fallback if $CALLSIGN unset
+    --bd <path>          bd binary path
+    --check-mode <name>  manual test mode: 'pass'|'block' bypass for tests
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_LOG = Path("/home/elliotbot/clawd/logs/bd-claim-hard-block.log")
+
+# Tool names that constitute a "build/write op" — these gate on claim.
+# All other tool names (Read, Grep, Glob, Bash-readonly, etc.) pass through.
+_WRITE_TOOLS = frozenset({"Edit", "Write", "NotebookEdit"})
+
+# Bash commands that constitute a build/write op (substring match on `command`).
+# Read-only git/file ops bypass.
+_BASH_WRITE_SUBSTRINGS = (
+    "git commit",
+    "git push",
+    "git merge",
+    "git rebase",
+    "git reset --hard",
+    "git tag",
+    "gh pr create",
+    "gh pr merge",
+    "gh api -X PUT",
+    "gh api -X POST",
+    "gh api -X DELETE",
+)
+
+
+def _log(msg: str, log_path: Path = DEFAULT_LOG) -> None:
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a") as fh:
+            fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {msg}\n")
+    except OSError:
+        pass
+
+
+def is_write_op(tool: str, tool_input: dict | None) -> bool:
+    """True if the tool call is a build/write that should gate on claim."""
+    if tool in _WRITE_TOOLS:
+        return True
+    if tool == "Bash":
+        cmd = ((tool_input or {}).get("command") or "").lower()
+        return any(s in cmd for s in _BASH_WRITE_SUBSTRINGS)
+    return False
+
+
+def _bd_list(bd_bin: str) -> list[dict]:
+    """`bd list --json`. Empty list on any failure."""
+    try:
+        r = subprocess.run(
+            [bd_bin, "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+    if r.returncode != 0:
+        return []
+    try:
+        data = json.loads(r.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    items = data if isinstance(data, list) else data.get("issues") or data.get("data") or []
+    return items if isinstance(items, list) else []
+
+
+def has_valid_claim(
+    callsign: str,
+    *,
+    bd_fn=None,
+    bd_bin: str = "bd",
+) -> tuple[bool, dict | None]:
+    """Return (claim_found, claim_dict). Claim = assignee == callsign AND
+    status == in_progress AND external is a Linear URL (proves Linear-sourced)."""
+    bd_fn = bd_fn or (lambda: _bd_list(bd_bin))
+    items = bd_fn()
+    for i in items:
+        if not isinstance(i, dict):
+            continue
+        assignee = (i.get("assignee") or "").strip().lower()
+        if assignee != callsign.lower():
+            continue
+        status = (i.get("status") or "").lower()
+        if status != "in_progress":
+            continue
+        external = (i.get("external") or "").lower()
+        if "linear.app" not in external:
+            continue
+        return True, i
+    return False, None
+
+
+def block_payload(callsign: str, tool: str) -> dict:
+    """Structured error payload returned via stderr on hard-block."""
+    return {
+        "decision": "block",
+        "rule": "KEI-22 D5 — Beads hard-block (Dave directive ts ~1778667000)",
+        "reason": f"No active Linear-sourced bd claim for callsign={callsign!r}.",
+        "tool_blocked": tool,
+        "chain_required": [
+            "1. KEI exists in Linear (Todo / In Progress)",
+            "2. bd sync --pull-if-stale (D1 SessionStart hook does this)",
+            "3. bd update <Agency_OS-id> --assignee <callsign>",
+            "4. bd update <Agency_OS-id> --claim   (sets status=in_progress)",
+            "5. Build begins.",
+        ],
+        "fix": (
+            "Either (a) claim an existing Linear-sourced bd issue for this "
+            f"callsign via `bd update <id> --assignee {callsign} --claim`, or "
+            "(b) raise a new KEI in Linear first per the Linear-KEI-before-"
+            "build standing rule, then bd sync + claim."
+        ),
+    }
+
+
+def decide(
+    *,
+    tool: str,
+    tool_input: dict | None,
+    callsign: str,
+    bd_bin: str = "bd",
+    bd_fn=None,
+    bd_available: bool | None = None,
+) -> dict:
+    """Pure decision function — no I/O. Returns {decision, exit_code, reason,
+    claim} dict."""
+    if not is_write_op(tool, tool_input):
+        return {
+            "decision": "allow",
+            "exit_code": 0,
+            "reason": "read_only_tool",
+            "claim": None,
+        }
+
+    if bd_available is None:
+        bd_available = bool(shutil.which(bd_bin)) or bd_bin != "bd"
+
+    if not bd_available:
+        # Pattern A: bd-down does NOT cascade into a build outage.
+        return {
+            "decision": "allow",
+            "exit_code": 0,
+            "reason": "bd_unavailable_soft_allow",
+            "claim": None,
+        }
+
+    found, claim = has_valid_claim(callsign, bd_fn=bd_fn, bd_bin=bd_bin)
+    if found:
+        return {
+            "decision": "allow",
+            "exit_code": 0,
+            "reason": "claim_valid",
+            "claim": claim,
+        }
+    return {
+        "decision": "block",
+        "exit_code": 1,
+        "reason": "no_claim_hard_block",
+        "claim": None,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--callsign",
+        default=os.environ.get("CALLSIGN", "").strip().lower() or "unknown",
+    )
+    parser.add_argument("--bd", default="bd")
+    args = parser.parse_args(argv)
+
+    raw = sys.stdin.read() if not sys.stdin.isatty() else ""
+    try:
+        payload = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        _log("hook_input_malformed_soft_allow")
+        return 0
+
+    tool = payload.get("tool") or payload.get("tool_name") or ""
+    tool_input = payload.get("tool_input") or payload.get("args") or {}
+
+    result = decide(
+        tool=tool,
+        tool_input=tool_input,
+        callsign=args.callsign,
+        bd_bin=args.bd,
+    )
+
+    _log(
+        f"decision={result['decision']} tool={tool!r} callsign={args.callsign} "
+        f"reason={result['reason']}"
+    )
+
+    if result["decision"] == "block":
+        sys.stderr.write(json.dumps(block_payload(args.callsign, tool), indent=2) + "\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/install_pre_commit_hook.sh
+++ b/scripts/orchestrator/install_pre_commit_hook.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# install_pre_commit_hook.sh — KEI-22 D6 installer (operator-run, per-worktree).
+#
+# Per Dave directive ts ~1778667100: pre-commit hook installs in all 6
+# worktrees (elliot/aiden/max/atlas/orion/scout).
+#
+# This script sets `core.hooksPath` on the current worktree to point at
+# the repo-shipped `.githooks/` directory, so the pre-commit hook lives
+# under version control + is automatically picked up.
+#
+# Idempotent: re-running on a worktree already pointing at .githooks/ is
+# a no-op with a notice. Doesn't touch other worktrees on the same repo
+# (git config --local is per-worktree by default with worktreeConfig
+# enabled; we set it that way explicitly).
+#
+# Usage:
+#     bash scripts/orchestrator/install_pre_commit_hook.sh
+#     bash scripts/orchestrator/install_pre_commit_hook.sh --uninstall
+#
+# Dave-directed activation step — NOT run automatically by CI.
+
+set -euo pipefail
+
+UNINSTALL=0
+for arg in "$@"; do
+    case "$arg" in
+        --uninstall) UNINSTALL=1 ;;
+        -h | --help)
+            sed -n '2,25p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "error: unknown arg: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$REPO_ROOT/.githooks"
+WORKTREE="$(pwd)"
+
+if [[ ! -d "$HOOKS_DIR" ]]; then
+    echo "error: $HOOKS_DIR missing — run from a worktree that has KEI-22 D6 shipped." >&2
+    exit 1
+fi
+
+if [[ ! -x "$HOOKS_DIR/pre-commit" ]]; then
+    chmod +x "$HOOKS_DIR/pre-commit"
+fi
+
+if [[ $UNINSTALL -eq 1 ]]; then
+    git config --unset core.hooksPath 2>/dev/null || true
+    echo "Layer 3 pre-commit gate uninstalled on $WORKTREE."
+    exit 0
+fi
+
+current="$(git config --get core.hooksPath || echo "")"
+if [[ "$current" == "$HOOKS_DIR" || "$current" == ".githooks" ]]; then
+    echo "Already installed — core.hooksPath=$current. No-op."
+    exit 0
+fi
+
+git config core.hooksPath "$HOOKS_DIR"
+echo "Layer 3 pre-commit gate installed on $WORKTREE."
+echo "  core.hooksPath -> $HOOKS_DIR"
+echo "  hook script    -> $HOOKS_DIR/pre-commit"
+echo ""
+echo "To verify: try 'git commit --allow-empty -m test' on a branch without a"
+echo "valid bd claim. The hook should HARD-BLOCK with the KEI-22 D6 message."
+echo ""
+echo "Escape hatch for operator-authorised override: 'git commit --no-verify ...'."
+echo "Strict mode (refuse even on bd-down): export AGENCY_OS_BD_HARDFAIL=1."

--- a/tests/orchestrator/test_bd_check_claim_and_precommit.py
+++ b/tests/orchestrator/test_bd_check_claim_and_precommit.py
@@ -1,0 +1,395 @@
+"""Tests for KEI-22 D6 — Layer 3 mechanical gates.
+
+bd_check_claim.sh         — wrapper providing `bd check-claim --branch` semantics
+.githooks/pre-commit       — repo-shipped hook
+install_pre_commit_hook.sh — operator-run installer (sets core.hooksPath)
+
+Tests shell out to bash with a fake bd binary on PATH so we don't depend on
+real Beads. The fake bd is a small script that emits canned JSON.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CHECK_CLAIM = REPO_ROOT / "scripts" / "orchestrator" / "bd_check_claim.sh"
+PRECOMMIT = REPO_ROOT / ".githooks" / "pre-commit"
+INSTALLER = REPO_ROOT / "scripts" / "orchestrator" / "install_pre_commit_hook.sh"
+
+
+def _fake_bd(tmp_path: Path, list_json: str) -> Path:
+    """Write a fake `bd` binary that prints `list_json` on `bd list --json`.
+    Stores the JSON in a sibling file so we avoid heredoc-indent hazards."""
+    bdir = tmp_path / "bin"
+    bdir.mkdir()
+    json_path = bdir / "list.json"
+    json_path.write_text(list_json)
+    fake = bdir / "bd"
+    fake.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "$1" == "list" && "$2" == "--json" ]]; then\n'
+        f"    cat {json_path}\n"
+        "    exit 0\n"
+        "fi\n"
+        'echo "fake bd: unknown args $*" >&2\n'
+        "exit 1\n"
+    )
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC)
+    return bdir
+
+
+def _env_with_fake_bd(fake_bin_dir: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin_dir}:{env.get('PATH', '')}"
+    # Clear CALLSIGN so tests deterministically use --branch parsing.
+    env.pop("CALLSIGN", None)
+    return env
+
+
+# ─── bd_check_claim.sh ─────────────────────────────────────────────────
+
+
+def test_check_claim_files_exist():
+    assert CHECK_CLAIM.is_file()
+    assert PRECOMMIT.is_file()
+    assert INSTALLER.is_file()
+    # Executable bits set
+    assert os.access(CHECK_CLAIM, os.X_OK)
+    assert os.access(PRECOMMIT, os.X_OK)
+    assert os.access(INSTALLER, os.X_OK)
+
+
+def test_check_claim_succeeds_on_valid_claim(tmp_path: Path):
+    bd_dir = _fake_bd(
+        tmp_path,
+        '[{"id":"Agency_OS-khf3an","status":"in_progress","assignee":"orion",'
+        '"external":"https://linear.app/keiracom/issue/KEI-22/x"}]',
+    )
+    r = subprocess.run(
+        ["bash", str(CHECK_CLAIM), "--branch", "orion/kei22-d6"],
+        capture_output=True,
+        text=True,
+        env=_env_with_fake_bd(bd_dir),
+        timeout=15,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "Agency_OS-khf3an" in r.stdout
+
+
+def test_check_claim_fails_on_no_claim(tmp_path: Path):
+    bd_dir = _fake_bd(tmp_path, "[]")
+    r = subprocess.run(
+        ["bash", str(CHECK_CLAIM), "--branch", "orion/kei22-d6"],
+        capture_output=True,
+        text=True,
+        env=_env_with_fake_bd(bd_dir),
+        timeout=15,
+    )
+    assert r.returncode == 1
+    assert "no_valid_claim" in r.stderr
+
+
+def test_check_claim_blocks_peer_assigned_work(tmp_path: Path):
+    """Atlas's claim does NOT let orion commit on an orion/* branch."""
+    bd_dir = _fake_bd(
+        tmp_path,
+        '[{"id":"Agency_OS-atlas","status":"in_progress","assignee":"atlas",'
+        '"external":"https://linear.app/keiracom/issue/KEI-99/x"}]',
+    )
+    r = subprocess.run(
+        ["bash", str(CHECK_CLAIM), "--branch", "orion/kei22-d6"],
+        capture_output=True,
+        text=True,
+        env=_env_with_fake_bd(bd_dir),
+        timeout=15,
+    )
+    assert r.returncode == 1
+
+
+def test_check_claim_blocks_non_in_progress_claim(tmp_path: Path):
+    bd_dir = _fake_bd(
+        tmp_path,
+        '[{"id":"Agency_OS-x","status":"open","assignee":"orion",'
+        '"external":"https://linear.app/keiracom/issue/KEI-99/x"}]',
+    )
+    r = subprocess.run(
+        ["bash", str(CHECK_CLAIM), "--branch", "orion/kei22-d6"],
+        capture_output=True,
+        text=True,
+        env=_env_with_fake_bd(bd_dir),
+        timeout=15,
+    )
+    assert r.returncode == 1
+
+
+def test_check_claim_blocks_non_linear_external_ref(tmp_path: Path):
+    bd_dir = _fake_bd(
+        tmp_path,
+        '[{"id":"Agency_OS-x","status":"in_progress","assignee":"orion",'
+        '"external":"https://github.com/Keiracom/x/issues/1"}]',
+    )
+    r = subprocess.run(
+        ["bash", str(CHECK_CLAIM), "--branch", "orion/kei22-d6"],
+        capture_output=True,
+        text=True,
+        env=_env_with_fake_bd(bd_dir),
+        timeout=15,
+    )
+    assert r.returncode == 1
+
+
+def test_check_claim_exits_2_when_bd_missing(tmp_path: Path):
+    """Pattern A: bd binary missing → exit 2 (NOT 0 or 1). Pre-commit caller
+    decides whether to fail-open or fail-closed via AGENCY_OS_BD_HARDFAIL."""
+    # Keep system PATH for bash + coreutils; just remove anywhere bd lives.
+    sys_path = "/usr/bin:/bin"
+    env = os.environ.copy()
+    env["PATH"] = sys_path
+    env.pop("CALLSIGN", None)
+    r = subprocess.run(
+        ["bash", str(CHECK_CLAIM), "--branch", "orion/foo"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert r.returncode == 2, r.stderr
+
+
+def test_check_claim_callsign_env_overrides_branch_parse(tmp_path: Path):
+    """CALLSIGN env wins over branch-prefix parse — useful for non-standard
+    branch names."""
+    bd_dir = _fake_bd(
+        tmp_path,
+        '[{"id":"Agency_OS-mine","status":"in_progress","assignee":"orion",'
+        '"external":"https://linear.app/keiracom/issue/KEI-22/x"}]',
+    )
+    env = _env_with_fake_bd(bd_dir)
+    env["CALLSIGN"] = "orion"
+    r = subprocess.run(
+        ["bash", str(CHECK_CLAIM), "--branch", "weird-name-no-prefix"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert r.returncode == 0
+
+
+def test_check_claim_no_callsign_resolvable_fails(tmp_path: Path):
+    bd_dir = _fake_bd(tmp_path, "[]")
+    env = _env_with_fake_bd(bd_dir)
+    env.pop("CALLSIGN", None)
+    r = subprocess.run(
+        ["bash", str(CHECK_CLAIM), "--branch", "weird-name-no-prefix"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert r.returncode == 1
+
+
+# ─── pre-commit hook ───────────────────────────────────────────────────
+
+
+def _git_init_repo(tmp_path: Path, hook_dir: Path) -> Path:
+    """Init a tmp git repo with worktree + point core.hooksPath at hook_dir.
+    Returns the repo path."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "test-main"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@test"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "core.hooksPath", str(hook_dir)],
+        check=True,
+    )
+    # Seed initial commit so HEAD exists.
+    (repo / "seed").write_text("x")
+    subprocess.run(["git", "-C", str(repo), "add", "seed"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "--no-verify", "-m", "seed"],
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_DATE": "2026-05-13T00:00:00",
+            "GIT_COMMITTER_DATE": "2026-05-13T00:00:00",
+        },
+    )
+    return repo
+
+
+def _hooks_dir(tmp_path: Path, bd_check_claim_path: Path) -> Path:
+    """Stage .githooks/pre-commit + a wrapping setup that points the hook
+    at our local copies of bd_check_claim.sh."""
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    pre = hooks / "pre-commit"
+    # Copy the real hook + override REPO_ROOT lookup so it finds OUR bd_check_claim copy.
+    body = PRECOMMIT.read_text()
+    # Hack: the hook resolves CHECK via REPO_ROOT/scripts/orchestrator/bd_check_claim.sh.
+    # We can't override REPO_ROOT cleanly — instead we copy the real wrapper to a
+    # matching path under the tmp repo.
+    pre.write_text(body)
+    pre.chmod(pre.stat().st_mode | stat.S_IEXEC)
+    return hooks
+
+
+def test_pre_commit_blocks_on_no_claim(tmp_path: Path):
+    """End-to-end: tmp repo with hook installed + fake bd returning empty
+    list → git commit fails with the KEI-22 D6 message."""
+    hooks = _hooks_dir(tmp_path, CHECK_CLAIM)
+    repo = _git_init_repo(tmp_path, hooks)
+    # Stage real bd_check_claim alongside the hook (the hook's REPO_ROOT
+    # lookup uses `git rev-parse --show-toplevel`).
+    (repo / "scripts" / "orchestrator").mkdir(parents=True, exist_ok=True)
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").write_text(CHECK_CLAIM.read_text())
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").chmod(0o755)
+
+    # Fake bd returns empty.
+    bd_dir = _fake_bd(tmp_path, "[]")
+    env = _env_with_fake_bd(bd_dir)
+
+    # Create branch + try to commit.
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "orion/kei22-d6"], check=True)
+    (repo / "file.txt").write_text("change")
+    subprocess.run(["git", "-C", str(repo), "add", "file.txt"], check=True)
+    r = subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "feat: x"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert r.returncode != 0, "pre-commit must block when no claim"
+    assert "KEI-22 D6 Layer 3 mechanical gate" in r.stderr
+
+
+def test_pre_commit_allows_on_valid_claim(tmp_path: Path):
+    hooks = _hooks_dir(tmp_path, CHECK_CLAIM)
+    repo = _git_init_repo(tmp_path, hooks)
+    (repo / "scripts" / "orchestrator").mkdir(parents=True, exist_ok=True)
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").write_text(CHECK_CLAIM.read_text())
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").chmod(0o755)
+
+    bd_dir = _fake_bd(
+        tmp_path,
+        '[{"id":"Agency_OS-khf3an","status":"in_progress","assignee":"orion",'
+        '"external":"https://linear.app/keiracom/issue/KEI-22/x"}]',
+    )
+    env = _env_with_fake_bd(bd_dir)
+
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "orion/kei22-d6"], check=True)
+    (repo / "file.txt").write_text("change")
+    subprocess.run(["git", "-C", str(repo), "add", "file.txt"], check=True)
+    r = subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "feat: x"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_pre_commit_no_verify_bypass(tmp_path: Path):
+    """git commit --no-verify is the operator-authorised escape hatch."""
+    hooks = _hooks_dir(tmp_path, CHECK_CLAIM)
+    repo = _git_init_repo(tmp_path, hooks)
+    (repo / "scripts" / "orchestrator").mkdir(parents=True, exist_ok=True)
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").write_text(CHECK_CLAIM.read_text())
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").chmod(0o755)
+
+    bd_dir = _fake_bd(tmp_path, "[]")  # no claim
+    env = _env_with_fake_bd(bd_dir)
+
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "orion/kei22-d6"], check=True)
+    (repo / "file.txt").write_text("change")
+    subprocess.run(["git", "-C", str(repo), "add", "file.txt"], check=True)
+    r = subprocess.run(
+        ["git", "-C", str(repo), "commit", "--no-verify", "-m", "feat: emergency"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_pre_commit_exempts_main_branch(tmp_path: Path):
+    hooks = _hooks_dir(tmp_path, CHECK_CLAIM)
+    repo = _git_init_repo(tmp_path, hooks)
+    (repo / "scripts" / "orchestrator").mkdir(parents=True, exist_ok=True)
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").write_text(CHECK_CLAIM.read_text())
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").chmod(0o755)
+
+    bd_dir = _fake_bd(tmp_path, "[]")
+    env = _env_with_fake_bd(bd_dir)
+
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "main"], check=True)
+    (repo / "file.txt").write_text("change")
+    subprocess.run(["git", "-C", str(repo), "add", "file.txt"], check=True)
+    r = subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "main: x"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_pre_commit_soft_allows_when_bd_missing(tmp_path: Path):
+    """bd binary missing → soft-allow unless AGENCY_OS_BD_HARDFAIL=1."""
+    hooks = _hooks_dir(tmp_path, CHECK_CLAIM)
+    repo = _git_init_repo(tmp_path, hooks)
+    (repo / "scripts" / "orchestrator").mkdir(parents=True, exist_ok=True)
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").write_text(CHECK_CLAIM.read_text())
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = "/usr/bin:/bin"  # system PATH minus bd
+    env.pop("CALLSIGN", None)
+
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "orion/kei22-d6"], check=True)
+    (repo / "file.txt").write_text("change")
+    subprocess.run(["git", "-C", str(repo), "add", "file.txt"], check=True)
+    r = subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "feat: x"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_pre_commit_hardfail_refuses_when_bd_missing(tmp_path: Path):
+    hooks = _hooks_dir(tmp_path, CHECK_CLAIM)
+    repo = _git_init_repo(tmp_path, hooks)
+    (repo / "scripts" / "orchestrator").mkdir(parents=True, exist_ok=True)
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").write_text(CHECK_CLAIM.read_text())
+    (repo / "scripts" / "orchestrator" / "bd_check_claim.sh").chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = "/usr/bin:/bin"  # system PATH minus bd
+    env["AGENCY_OS_BD_HARDFAIL"] = "1"
+    env.pop("CALLSIGN", None)
+
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "orion/kei22-d6"], check=True)
+    (repo / "file.txt").write_text("change")
+    subprocess.run(["git", "-C", str(repo), "add", "file.txt"], check=True)
+    r = subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "feat: x"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert r.returncode != 0
+    assert "HARDFAIL=1" in r.stderr

--- a/tests/orchestrator/test_ceo_rule_auto_record.py
+++ b/tests/orchestrator/test_ceo_rule_auto_record.py
@@ -1,0 +1,253 @@
+"""Tests for KEI-22 D7 — Slack-relay auto-rule-detect-and-record.
+
+scripts/orchestrator/ceo_rule_auto_record.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "ceo_rule_auto_record.py"
+_spec = importlib.util.spec_from_file_location("ceo_rule_auto_record", SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["ceo_rule_auto_record"] = mod
+_spec.loader.exec_module(mod)
+
+
+CEO_CH = "C0B2PM3TV0B"
+EXEC_CH = "C0B3QB0K1GQ"
+
+
+# ─── should_fire filter chain ──────────────────────────────────────────
+
+
+def test_fires_on_dave_ceo_with_standing_rule():
+    fire, reason = mod.should_fire(
+        channel=CEO_CH,
+        author="dave",
+        body="Standing rule: Linear is the only source of work.",
+    )
+    assert fire is True
+    assert reason == "governance_trigger_matched"
+
+
+def test_does_not_fire_outside_ceo_channel():
+    fire, reason = mod.should_fire(
+        channel=EXEC_CH,
+        author="dave",
+        body="Standing rule: x.",
+    )
+    assert fire is False
+    assert reason == "wrong_channel"
+
+
+def test_does_not_fire_for_non_dave_author():
+    """Standing rules can only be established by Dave."""
+    for author in ("elliot", "aiden", "max", "orion", "atlas", "scout"):
+        fire, reason = mod.should_fire(
+            channel=CEO_CH,
+            author=author,
+            body="Standing rule: x.",
+        )
+        assert fire is False, f"{author} should not establish rules"
+        assert reason == "not_dave"
+
+
+def test_does_not_fire_without_trigger_phrase():
+    fire, reason = mod.should_fire(
+        channel=CEO_CH,
+        author="dave",
+        body="Just a chat message, nothing rule-shaped.",
+    )
+    assert fire is False
+    assert reason == "no_trigger_phrase"
+
+
+def test_each_documented_trigger_phrase_fires():
+    """Pins every Dave trigger phrase from the dispatch."""
+    for phrase in (
+        "standing rule",
+        "effective immediately",
+        "from now on",
+        "no exceptions",
+        "hard stop",
+        "no build without",
+        "must be recorded",
+    ):
+        fire, _ = mod.should_fire(
+            channel=CEO_CH,
+            author="Dave",  # case-insensitive
+            body=f"prelude. {phrase} the rest.",
+        )
+        assert fire is True, f"trigger missed: {phrase!r}"
+
+
+# ─── slug resolution ───────────────────────────────────────────────────
+
+
+def test_slug_explicit_cli_arg_wins():
+    slug = mod.resolve_slug(slug_arg="linear_only_source_of_work", body="body text")
+    assert slug == "linear_only_source_of_work"
+
+
+def test_slug_explicit_in_body_when_no_cli_arg():
+    body = "Standing rule. Key pattern: ceo:rule:beads_layer3_enforcement."
+    slug = mod.resolve_slug(slug_arg=None, body=body)
+    assert slug == "beads_layer3_enforcement"
+
+
+def test_slug_heuristic_after_trigger_phrase():
+    """When neither --slug nor ceo:rule:<x> in body, derive from words after
+    the trigger phrase."""
+    slug = mod.resolve_slug(
+        slug_arg=None,
+        body="From now on agents claim before build. No exceptions.",
+    )
+    # Heuristic: first 6 content words after "from now on" → "agents_claim_before_build_no_exceptions"
+    # (stopwords stripped).
+    assert "agents" in slug
+    assert "claim" in slug
+    assert "build" in slug
+
+
+def test_slug_normaliser_strips_special_chars():
+    slug = mod.resolve_slug(slug_arg="Linear-Only Source / Work", body="")
+    assert slug == "linear_only_source_work"
+
+
+# ─── record_rule end-to-end ────────────────────────────────────────────
+
+
+def test_record_writes_to_ceo_memory_when_fires():
+    writes: list[tuple[str, dict]] = []
+
+    def fake_upsert(key, value):
+        writes.append((key, value))
+        return True
+
+    result = mod.record_rule(
+        channel=CEO_CH,
+        author="dave",
+        body="Standing rule: Linear is the only source of work. No exceptions.",
+        slug_arg="linear_only_source_of_work",
+        upsert_fn=fake_upsert,
+    )
+    assert result["fired"] is True
+    assert result["key"] == "ceo:rule:linear_only_source_of_work"
+    assert result["reason"] == "recorded"
+    assert len(writes) == 1
+    key, value = writes[0]
+    assert key == "ceo:rule:linear_only_source_of_work"
+    assert value["author"] == "dave"
+    assert value["channel"] == CEO_CH
+    assert "Linear is the only source of work" in value["rule_body"]
+    assert value["source"] == "kei22_d7_auto_record"
+
+
+def test_record_does_not_write_when_filter_rejects():
+    writes: list[tuple[str, dict]] = []
+
+    result = mod.record_rule(
+        channel=EXEC_CH,  # wrong channel
+        author="dave",
+        body="Standing rule: x.",
+        upsert_fn=lambda k, v: writes.append((k, v)) or True,
+    )
+    assert result["fired"] is False
+    assert result["reason"] == "wrong_channel"
+    assert writes == []
+
+
+def test_record_write_failure_returns_fired_false_with_reason():
+    """upsert returning False → fired=False, reason='write_failed'. Relay
+    can retry on the next dispatch."""
+    result = mod.record_rule(
+        channel=CEO_CH,
+        author="dave",
+        body="Standing rule: x.",
+        upsert_fn=lambda k, v: False,
+    )
+    assert result["fired"] is False
+    assert result["reason"] == "write_failed"
+    assert result["key"] == "ceo:rule:x"
+
+
+def test_record_write_exception_is_caught():
+    def boom(k, v):
+        raise RuntimeError("supabase 503")
+
+    result = mod.record_rule(
+        channel=CEO_CH,
+        author="dave",
+        body="Standing rule: x.",
+        upsert_fn=boom,
+    )
+    assert result["fired"] is False
+    assert result["reason"].startswith("write_failed")
+
+
+def test_record_value_carries_full_body_for_audit():
+    """Audit trail: the full Dave message body is persisted under
+    'rule_body' so future agents can read the exact verbatim language."""
+    writes: list[tuple[str, dict]] = []
+    body = (
+        "Standing rule. Beads must become Layer 3 — infrastructure physically "
+        "refuses non-compliant actions. Not Layer 2 voluntary tracking. No exceptions."
+    )
+    mod.record_rule(
+        channel=CEO_CH,
+        author="dave",
+        body=body,
+        slug_arg="beads_layer3_enforcement",
+        upsert_fn=lambda k, v: writes.append((k, v)) or True,
+    )
+    assert "Layer 3" in writes[0][1]["rule_body"]
+    assert "voluntary tracking" in writes[0][1]["rule_body"]
+
+
+# ─── CLI main() with --body-file ───────────────────────────────────────
+
+
+def test_main_body_file_path(tmp_path, capsys, monkeypatch):
+    body_file = tmp_path / "msg.txt"
+    body_file.write_text("Standing rule: from now on, no exceptions.")
+    # Patch the default upsert so it doesn't try Supabase.
+    monkeypatch.setattr(mod, "_default_upsert_fn", lambda k, v: True)
+
+    rc = mod.main(
+        [
+            "--channel",
+            CEO_CH,
+            "--author",
+            "dave",
+            "--body-file",
+            str(body_file),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["fired"] is True
+    assert payload["key"].startswith("ceo:rule:")
+
+
+def test_main_returns_zero_even_when_filter_rejects(capsys):
+    """Slack relay calls this on every Dave post — must exit 0 always so
+    the relay doesn't error-loop."""
+    rc = mod.main(
+        [
+            "--channel",
+            EXEC_CH,
+            "--author",
+            "elliot",
+            "--body",
+            "Standing rule: but wrong author + channel.",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["fired"] is False

--- a/tests/orchestrator/test_check_bd_claim_before_build.py
+++ b/tests/orchestrator/test_check_bd_claim_before_build.py
@@ -1,0 +1,303 @@
+"""Tests for KEI-22 D5 — Beads hard-block on no-claim-execution.
+
+scripts/orchestrator/check_bd_claim_before_build.py — PreToolUse hook gate.
+
+Pure decision function `decide(...)` is injectable; tests don't shell out
+to real `bd`. CLI `main()` is also tested with stdin injection.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "check_bd_claim_before_build.py"
+_spec = importlib.util.spec_from_file_location("check_bd_claim_before_build", SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["check_bd_claim_before_build"] = mod
+_spec.loader.exec_module(mod)
+
+
+def _valid_claim(callsign: str = "orion", id_: str = "Agency_OS-khf3an") -> dict:
+    return {
+        "id": id_,
+        "title": "KEI-22 — Linear ↔ Beads bidirectional sync",
+        "status": "in_progress",
+        "assignee": callsign,
+        "external": "https://linear.app/keiracom/issue/KEI-22/sync",
+    }
+
+
+# ─── Read-only tools always pass ───────────────────────────────────────
+
+
+def test_read_tool_always_allowed_even_without_claim():
+    result = mod.decide(
+        tool="Read",
+        tool_input={"file_path": "/tmp/foo"},
+        callsign="orion",
+        bd_fn=lambda: [],  # no claims at all
+        bd_available=True,
+    )
+    assert result["decision"] == "allow"
+    assert result["reason"] == "read_only_tool"
+    assert result["exit_code"] == 0
+
+
+def test_grep_tool_always_allowed():
+    result = mod.decide(
+        tool="Grep",
+        tool_input={"pattern": "x"},
+        callsign="orion",
+        bd_fn=lambda: [],
+        bd_available=True,
+    )
+    assert result["decision"] == "allow"
+
+
+def test_bash_readonly_command_passes():
+    """Bash 'git status' / 'git log' / 'git diff' / 'cat' / 'ls' must pass."""
+    for cmd in ("git status", "git log -1", "git diff origin/main", "ls scripts/", "cat README.md"):
+        result = mod.decide(
+            tool="Bash",
+            tool_input={"command": cmd},
+            callsign="orion",
+            bd_fn=lambda: [],
+            bd_available=True,
+        )
+        assert result["decision"] == "allow", f"read-only bash should pass: {cmd!r}"
+
+
+# ─── Write tools — valid claim allows ──────────────────────────────────
+
+
+def test_write_tool_with_valid_claim_allowed():
+    result = mod.decide(
+        tool="Write",
+        tool_input={"file_path": "/x"},
+        callsign="orion",
+        bd_fn=lambda: [_valid_claim("orion")],
+        bd_available=True,
+    )
+    assert result["decision"] == "allow"
+    assert result["reason"] == "claim_valid"
+    assert result["claim"]["id"] == "Agency_OS-khf3an"
+
+
+def test_edit_tool_with_valid_claim_allowed():
+    result = mod.decide(
+        tool="Edit",
+        tool_input={"file_path": "/x", "old_string": "a", "new_string": "b"},
+        callsign="orion",
+        bd_fn=lambda: [_valid_claim("orion")],
+        bd_available=True,
+    )
+    assert result["decision"] == "allow"
+
+
+def test_bash_git_commit_with_valid_claim_allowed():
+    result = mod.decide(
+        tool="Bash",
+        tool_input={"command": "git commit -m 'feat: x'"},
+        callsign="orion",
+        bd_fn=lambda: [_valid_claim("orion")],
+        bd_available=True,
+    )
+    assert result["decision"] == "allow"
+
+
+# ─── Write tools — NO claim hard-blocks ────────────────────────────────
+
+
+def test_write_tool_with_no_claim_hard_blocks():
+    result = mod.decide(
+        tool="Write",
+        tool_input={"file_path": "/x"},
+        callsign="orion",
+        bd_fn=lambda: [],  # no claims
+        bd_available=True,
+    )
+    assert result["decision"] == "block"
+    assert result["reason"] == "no_claim_hard_block"
+    assert result["exit_code"] == 1
+
+
+def test_bash_git_push_with_no_claim_blocks():
+    result = mod.decide(
+        tool="Bash",
+        tool_input={"command": "git push -u origin orion/foo"},
+        callsign="orion",
+        bd_fn=lambda: [],
+        bd_available=True,
+    )
+    assert result["decision"] == "block"
+    assert result["exit_code"] == 1
+
+
+def test_gh_pr_create_with_no_claim_blocks():
+    result = mod.decide(
+        tool="Bash",
+        tool_input={"command": "gh pr create --title x --body y"},
+        callsign="orion",
+        bd_fn=lambda: [],
+        bd_available=True,
+    )
+    assert result["decision"] == "block"
+
+
+# ─── Peer's claim is NOT mine (Pattern A: no poach) ────────────────────
+
+
+def test_peer_claim_does_not_satisfy_my_callsign():
+    """Issue assigned to atlas does NOT let orion write. Same Pattern A
+    semantics as the self-assign hook PR #817."""
+    result = mod.decide(
+        tool="Write",
+        tool_input={"file_path": "/x"},
+        callsign="orion",
+        bd_fn=lambda: [_valid_claim("atlas")],  # atlas's claim, not orion's
+        bd_available=True,
+    )
+    assert result["decision"] == "block"
+
+
+# ─── status != in_progress fails ───────────────────────────────────────
+
+
+def test_claim_with_wrong_status_fails():
+    item = _valid_claim("orion")
+    item["status"] = "open"  # not yet started
+    result = mod.decide(
+        tool="Write",
+        tool_input={"file_path": "/x"},
+        callsign="orion",
+        bd_fn=lambda: [item],
+        bd_available=True,
+    )
+    assert result["decision"] == "block"
+
+
+def test_closed_claim_does_not_count():
+    item = _valid_claim("orion")
+    item["status"] = "closed"
+    result = mod.decide(
+        tool="Edit",
+        tool_input={"file_path": "/x", "old_string": "a", "new_string": "b"},
+        callsign="orion",
+        bd_fn=lambda: [item],
+        bd_available=True,
+    )
+    assert result["decision"] == "block"
+
+
+# ─── Linear-sourced check (external must contain linear.app) ───────────
+
+
+def test_non_linear_sourced_claim_does_not_satisfy():
+    """Dave standing rule: 'Linear is the only source of work.' A bd-only
+    task (no Linear external-ref) does NOT satisfy the claim check."""
+    item = _valid_claim("orion")
+    item["external"] = ""  # bd-only, not Linear-sourced
+    result = mod.decide(
+        tool="Write",
+        tool_input={"file_path": "/x"},
+        callsign="orion",
+        bd_fn=lambda: [item],
+        bd_available=True,
+    )
+    assert result["decision"] == "block"
+
+
+def test_github_external_ref_does_not_count():
+    """An external-ref pointing at a GitHub issue (not Linear) should not
+    satisfy — Dave rule is Linear-only."""
+    item = _valid_claim("orion")
+    item["external"] = "https://github.com/Keiracom/Agency_OS/issues/42"
+    result = mod.decide(
+        tool="Write",
+        tool_input={"file_path": "/x"},
+        callsign="orion",
+        bd_fn=lambda: [item],
+        bd_available=True,
+    )
+    assert result["decision"] == "block"
+
+
+# ─── Pattern A: bd-down soft-allows ────────────────────────────────────
+
+
+def test_bd_unavailable_soft_allows_write():
+    """If bd binary is missing or unreachable, the gate degrades-soft:
+    allow with reason='bd_unavailable_soft_allow'. Pattern A teaching —
+    do NOT cascade an infra outage into a build outage."""
+    result = mod.decide(
+        tool="Write",
+        tool_input={"file_path": "/x"},
+        callsign="orion",
+        bd_fn=lambda: [],
+        bd_available=False,
+    )
+    assert result["decision"] == "allow"
+    assert result["reason"] == "bd_unavailable_soft_allow"
+
+
+# ─── Block payload structure ───────────────────────────────────────────
+
+
+def test_block_payload_includes_chain_and_fix():
+    payload = mod.block_payload("orion", "Write")
+    assert payload["decision"] == "block"
+    assert "KEI-22 D5" in payload["rule"]
+    assert "callsign='orion'" in payload["reason"]
+    assert payload["tool_blocked"] == "Write"
+    assert isinstance(payload["chain_required"], list)
+    assert any("bd update" in step for step in payload["chain_required"])
+    assert "bd update" in payload["fix"]
+
+
+# ─── CLI main() with stdin ─────────────────────────────────────────────
+
+
+def test_main_allow_on_read_op(monkeypatch, capsys):
+    """Read op → exit 0, no stderr."""
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(json.dumps({"tool": "Read", "tool_input": {"file_path": "/x"}})),
+    )
+    rc = mod.main(["--callsign", "orion"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert err == ""
+
+
+def test_main_blocks_write_with_no_claim(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(json.dumps({"tool": "Write", "tool_input": {"file_path": "/x"}})),
+    )
+    # Force bd_unavailable=False by injecting an empty bd response.
+    monkeypatch.setattr(mod, "_bd_list", lambda _bd: [])
+    monkeypatch.setattr(mod.shutil, "which", lambda _bin: "/usr/bin/bd")  # bd exists
+    rc = mod.main(["--callsign", "orion"])
+    assert rc == 1
+    err_payload = json.loads(capsys.readouterr().err)
+    assert err_payload["decision"] == "block"
+    assert err_payload["tool_blocked"] == "Write"
+
+
+def test_main_malformed_stdin_soft_allows(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO("{not json"))
+    rc = mod.main(["--callsign", "orion"])
+    assert rc == 0  # never crash the hook chain
+
+
+def test_main_empty_stdin_soft_allows(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    # isatty defaults False under StringIO; empty body parsed as {} → tool="" → read_only path
+    rc = mod.main(["--callsign", "orion"])
+    assert rc == 0


### PR DESCRIPTION
## Summary

KEI-22 scope expansion deliverables **5, 6, 7** per three Dave CEO directives (ts ~1778667000, ~1778667100, ~1778667300). Follow-up to PR #831 (D1-D4). Ships **before Elliot restart**.

## Layered enforcement model

| Layer | Where | When it fires | This PR |
|---|---|---|---|
| 1 | D2 CI gate (PR #831) | PR title without `KEI-N` reference | already shipped |
| 2 | D5 PreToolUse hook | Edit/Write/Bash-write before tool call | this PR |
| 3 | D6 git pre-commit | `git commit` before object writes | this PR |

D7 is the **rule capture** complement — every Dave standing-rule post auto-recorded to `ceo_memory`.

## D5 — PreToolUse hook (Layer 2)

`scripts/orchestrator/check_bd_claim_before_build.py` — reads stdin tool name + args (Claude Code PreToolUse contract). Filters to write/build ops; for each, queries `bd list --json` for an issue assigned to `$CALLSIGN` with `status=in_progress` AND `external` containing `linear.app`. No claim → exit 1 + structured JSON to stderr.

**Read-only tools always pass** — Read, Grep, Glob, bash readonly commands (status/log/diff/cat/ls).

**Pattern A**: `bd` binary missing → soft-allow (exit 0). Infra outage doesn't cascade into build outage.

## D6 — git pre-commit hook (Layer 3)

```bash
# scripts/orchestrator/bd_check_claim.sh
# Empirical probe: `bd check-claim --help` → 'unknown command'.
# Wrap bd list --json + filter; same semantics as Dave's literal.

# .githooks/pre-commit
# Calls bd_check_claim.sh; HARD-BLOCKS commit when rc != 0.

# scripts/orchestrator/install_pre_commit_hook.sh
# Operator-run installer (sets core.hooksPath). --uninstall flag.
```

**Escape hatches**:
- `AGENCY_OS_BD_HARDFAIL=0` (default): bd-down soft-allows
- `AGENCY_OS_BD_HARDFAIL=1`: strict mode (refuse even when bd down)
- `git commit --no-verify`: operator-authorised bypass

**Branch exemptions**: `main`, `master`, `release/*`, `hotfix/*`, detached HEAD.

## D7 — Slack-relay auto-rule-detect-and-record

`scripts/orchestrator/ceo_rule_auto_record.py`. Same pattern as KEI-26 BS-incident → Linear KEI auto-create (PR #815).

**Filter chain** (all must match):
1. channel == `#ceo` (`C0B2PM3TV0B`)
2. author == `dave` (case-insensitive)
3. body matches one of: `standing rule`, `effective immediately`, `from now on`, `no exceptions`, `hard stop`, `no build without`, `must be recorded`

**Slug resolution**: `--slug` CLI → `ceo:rule:<x>` in body → heuristic (snake-case first 6 content words after trigger).

Writes to `ceo_memory` under `ceo:rule:<slug>` with full body for audit.

## Empirical probes (per dual-CTO discipline)

| Probe | Result |
|---|---|
| `bd find-duplicates --help` | native (KEI-30 lesson) |
| `bd check-claim --help` | **NOT native** ('unknown command') → wrap with thin script |
| `bd linear sync --help` | native (KEI-22 D1-D4 lesson) |

## Tests (51/51 pass, ruff + format clean)

```
$ pytest tests/orchestrator/test_check_bd_claim_before_build.py \
         tests/orchestrator/test_bd_check_claim_and_precommit.py \
         tests/orchestrator/test_ceo_rule_auto_record.py -q
51 passed in 1.24s

$ ruff check ...                  All checks passed!
$ ruff format --check ...         all files already formatted
```

Coverage breakdown:
- D5: 20 tests — read-only pass, write+claim allow, write-no-claim block, peer-claim Pattern A, status filter, Linear-external filter, bd-down soft-allow, CLI stdin parsing
- D6: 15 tests — `bd_check_claim.sh` paths (valid, no claim, peer, non-Linear, bd missing exit 2, env override, branch parse) + end-to-end `git commit` (block, allow, --no-verify, main-exempt, bd-down soft, HARDFAIL=1)
- D7: 16 tests — `should_fire` filter (channel/author/trigger), slug resolution priority (CLI/explicit/heuristic), `record_rule` writes, write-failure isolation, audit-body preservation, CLI

## Out of scope (per dispatch literals)

- Wiring D5 hook into `.claude/settings.json` (Dave-directed activation; same convention as recent rules)
- Auto-running `install_pre_commit_hook.sh` on all 6 worktrees (operator-run per-worktree)
- Adding `check-claim` as upstream `bd` subcommand (out of repo)
- LLM-extracted slug in D7 (relay can pass `--slug` if desired)

## Activation flow this PR enables

Post-merge, operator runs per-worktree:
```bash
# D6 Layer 3 pre-commit gate
bash scripts/orchestrator/install_pre_commit_hook.sh

# D5 Layer 2 PreToolUse hook (wire into .claude/settings.json on Dave green-light)
# D7 wired into Slack relay's Dave-post-handler on Dave green-light
```

## LAW XVI

Isolated worktree `/tmp/orion-kei22-d5` (Atlas-swap `.claude/*` symlink bypass), cleaned up post-push.

## Test plan

- [x] 51/51 tests pass
- [x] ruff check + format clean
- [x] Pattern A safety on every deliverable (bd-down soft, peer-claim no-poach, write-failure isolation)
- [x] Empirical probe documented; thin-wrapper pattern not bespoke
- [x] LAW XVI explicit-paths-only commit
- [ ] Post-merge: operator wires each layer per Dave green-light

## Dual-CTO concur

Aiden + Max please review. **Urgent — pre-restart blocker per Dave directive chain.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)