### PR TITLE
[ATLAS] feat(kei43): agent auto-start systemd services — boot recovery (zero-Dave-touch)

### DIFF
--- a/docs/operations/agent-systemd-recovery.md
+++ b/docs/operations/agent-systemd-recovery.md
@@ -1,0 +1,122 @@
+# Agent auto-start systemd services (KEI-43)
+
+**Owner:** Atlas (build) · **Linear:** [KEI-43](https://linear.app/keiracom/issue/KEI-43) · **bd:** Agency_OS-idt
+
+## What this gives you
+
+Six `systemd --user` units — one per agent — that automatically spawn each
+agent's tmux session + `claude` resume on boot. A server reboot brings all 6
+agents back within ~2 minutes with **zero operator intervention**.
+
+| Service                | Callsign | tmux session | Worktree                                 |
+|------------------------|----------|--------------|------------------------------------------|
+| `elliot-agent.service` | elliot   | `elliottbot` | `/home/elliotbot/clawd/Agency_OS`        |
+| `aiden-agent.service`  | aiden    | `aiden`      | `/home/elliotbot/clawd/Agency_OS-aiden`  |
+| `max-agent.service`    | max      | `maxbot`     | `/home/elliotbot/clawd/Agency_OS-max`    |
+| `atlas-agent.service`  | atlas    | `atlas`      | `/home/elliotbot/clawd/Agency_OS-atlas`  |
+| `orion-agent.service`  | orion    | `orion`      | `/home/elliotbot/clawd/Agency_OS-orion`  |
+| `scout-agent.service`  | scout    | `scout`      | `/home/elliotbot/clawd/Agency_OS-scout`  |
+
+Map source-of-truth: `scripts/orchestrator/elliot_polling_loop.py CALLSIGN_TO_TMUX`.
+
+## Install (one-time, post-merge)
+
+```bash
+# 1. Make sure every worktree has the supervisor wrapper (it ships under main).
+for wt in /home/elliotbot/clawd/Agency_OS /home/elliotbot/clawd/Agency_OS-aiden \
+          /home/elliotbot/clawd/Agency_OS-max /home/elliotbot/clawd/Agency_OS-atlas \
+          /home/elliotbot/clawd/Agency_OS-orion /home/elliotbot/clawd/Agency_OS-scout; do
+    test -x "$wt/scripts/systemd_agent_supervisor.sh" \
+        || echo "MISSING: $wt — run 'git -C $wt pull' before continuing"
+done
+
+# 1b. CRITICAL: user services need linger enabled or they won't auto-start at boot.
+loginctl show-user elliotbot --property=Linger 2>/dev/null | grep -q "Linger=yes" \
+    || echo "WARN: linger OFF — services will NOT auto-start at boot. Fix: sudo loginctl enable-linger elliotbot"
+
+# 2. Copy unit files into the user systemd dir.
+install -D -m 0644 -t /home/elliotbot/.config/systemd/user/ \
+    /home/elliotbot/clawd/Agency_OS/infra/systemd/agents/*.service
+
+# 3. Make sure the log dir exists.
+mkdir -p /home/elliotbot/clawd/logs
+
+# 4. Reload + enable + start each unit.
+systemctl --user daemon-reload
+for svc in elliot-agent aiden-agent max-agent atlas-agent orion-agent scout-agent; do
+    systemctl --user enable --now "${svc}.service"
+done
+
+# 5. Verify all six are active.
+systemctl --user --type=service --state=active | grep -E "^(elliot|aiden|max|atlas|orion|scout)-agent"
+```
+
+## "How do I recover from a server reboot?"
+
+You don't. It auto-recovers.
+
+After a reboot, all 6 agent services start automatically via `WantedBy=default.target`,
+spawn their tmux sessions inside their canonical worktrees, and invoke
+`scripts/agent_session_launcher.sh <callsign>` which resumes the most recent
+watchdog-fresh `session_uuid` from Supabase (PR-C session resumption).
+
+Expected timeline after `reboot`:
+
+1. `t+0` — host comes back online.
+2. `t+0..30s` — `default.target` reached, `*-agent.service` units fire.
+3. `t+30s..2min` — each unit's supervisor spawns its tmux session and invokes
+   `agent_session_launcher.sh`, which `claude --resume <uuid>` reloads each
+   agent's prior session.
+4. `t≈2min` — all 6 agents online; inbox watchers (separate services) pick up
+   pending dispatches.
+
+If something is missing after ~3 minutes, see **Troubleshooting**.
+
+## How a crashed agent recovers
+
+Each service runs `scripts/systemd_agent_supervisor.sh <callsign> <tmux> <worktree>`,
+which polls the tmux session and exits non-zero when the session terminates.
+That triggers `Restart=on-failure` with `RestartSec=10`, so the agent is back
+within ~10 seconds of a crash. `StartLimitBurst=5` / `StartLimitIntervalSec=300`
+caps runaway restart loops (5 restarts in 5 minutes → systemd holds it failed).
+
+## Verify auto-restart without rebooting
+
+```bash
+# Pick one — the watcher should exit non-zero and systemd restart within ~10s.
+systemctl --user status atlas-agent.service                  # confirm Active=running
+tmux kill-session -t atlas                                   # kill the underlying session
+sleep 15
+systemctl --user status atlas-agent.service                  # should show ↻ Active=running (restarted)
+tmux has-session -t atlas && echo "OK — atlas tmux session is back"
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `systemctl --user status <svc>` shows `code=exited, status=2` | Worktree path missing OR `agent_session_launcher.sh` missing/non-exec | `git -C <worktree> pull && chmod +x scripts/agent_session_launcher.sh` |
+| Service flaps (start-limit-hit) | Persistent crash inside `claude` / `agent_session_launcher.sh` | `journalctl --user -u <svc> --since=-5min` and inspect; reset with `systemctl --user reset-failed <svc>` |
+| Two tmux sessions with the same name | Manual `tmux new-session -s atlas` while service is up | The supervisor is idempotent — kill the duplicate manually; service keeps the canonical one alive |
+| Service is `inactive`/`disabled` after reboot | `systemctl --user enable` was skipped | Re-run step 4 of the install procedure |
+| `lingering` not enabled — services don't auto-start at boot | User services need linger | `sudo loginctl enable-linger elliotbot` |
+
+## Why these files live in the repo
+
+Operator runbook + unit files are checked into the repo so:
+
+- The map between callsign / tmux name / worktree stays version-controlled.
+- A fresh server install just needs `git clone` + the install commands above.
+- PR review can catch drift if the canonical map in
+  `scripts/orchestrator/elliot_polling_loop.py` changes without these files
+  changing in lockstep.
+
+## Related
+
+- KEI-35 — detection-based session recovery (already shipped); complementary to
+  this boot-side path. KEI-35 catches a *running* agent that has gone dead;
+  KEI-43 catches the post-reboot cold-start.
+- KEI-44 — Cognee 3GB memory cap (Orion, parallel work — limits the OOM that
+  triggered the original 2026-05-13 incident).
+- `openclaw.service` — `/home/elliotbot/.config/systemd/user/openclaw.service`
+  was the reference pattern for the unit shape.

--- a/infra/systemd/agents/aiden-agent.service
+++ b/infra/systemd/agents/aiden-agent.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Agency OS Agent — AIDEN (callsign=aiden, tmux=aiden)
+Documentation=https://linear.app/keiracom/issue/KEI-43
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS-aiden
+ExecStart=/home/elliotbot/clawd/Agency_OS-aiden/scripts/systemd_agent_supervisor.sh aiden aiden /home/elliotbot/clawd/Agency_OS-aiden
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:/home/elliotbot/clawd/logs/aiden-agent.log
+StandardError=append:/home/elliotbot/clawd/logs/aiden-agent.log
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/agents/atlas-agent.service
+++ b/infra/systemd/agents/atlas-agent.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Agency OS Agent — ATLAS (callsign=atlas, tmux=atlas)
+Documentation=https://linear.app/keiracom/issue/KEI-43
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS-atlas
+ExecStart=/home/elliotbot/clawd/Agency_OS-atlas/scripts/systemd_agent_supervisor.sh atlas atlas /home/elliotbot/clawd/Agency_OS-atlas
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:/home/elliotbot/clawd/logs/atlas-agent.log
+StandardError=append:/home/elliotbot/clawd/logs/atlas-agent.log
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/agents/elliot-agent.service
+++ b/infra/systemd/agents/elliot-agent.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Agency OS Agent — ELLIOT (callsign=elliot, tmux=elliottbot)
+Documentation=https://linear.app/keiracom/issue/KEI-43
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/systemd_agent_supervisor.sh elliot elliottbot /home/elliotbot/clawd/Agency_OS
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:/home/elliotbot/clawd/logs/elliot-agent.log
+StandardError=append:/home/elliotbot/clawd/logs/elliot-agent.log
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/agents/max-agent.service
+++ b/infra/systemd/agents/max-agent.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Agency OS Agent — MAX (callsign=max, tmux=maxbot)
+Documentation=https://linear.app/keiracom/issue/KEI-43
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS-max
+ExecStart=/home/elliotbot/clawd/Agency_OS-max/scripts/systemd_agent_supervisor.sh max maxbot /home/elliotbot/clawd/Agency_OS-max
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:/home/elliotbot/clawd/logs/max-agent.log
+StandardError=append:/home/elliotbot/clawd/logs/max-agent.log
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/agents/orion-agent.service
+++ b/infra/systemd/agents/orion-agent.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Agency OS Agent — ORION (callsign=orion, tmux=orion)
+Documentation=https://linear.app/keiracom/issue/KEI-43
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS-orion
+ExecStart=/home/elliotbot/clawd/Agency_OS-orion/scripts/systemd_agent_supervisor.sh orion orion /home/elliotbot/clawd/Agency_OS-orion
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:/home/elliotbot/clawd/logs/orion-agent.log
+StandardError=append:/home/elliotbot/clawd/logs/orion-agent.log
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/agents/scout-agent.service
+++ b/infra/systemd/agents/scout-agent.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Agency OS Agent — SCOUT (callsign=scout, tmux=scout)
+Documentation=https://linear.app/keiracom/issue/KEI-43
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS-scout
+ExecStart=/home/elliotbot/clawd/Agency_OS-scout/scripts/systemd_agent_supervisor.sh scout scout /home/elliotbot/clawd/Agency_OS-scout
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:/home/elliotbot/clawd/logs/scout-agent.log
+StandardError=append:/home/elliotbot/clawd/logs/scout-agent.log
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd_agent_supervisor.sh
+++ b/scripts/systemd_agent_supervisor.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# systemd_agent_supervisor.sh — ExecStart wrapper for *-agent.service units (KEI-43).
+#
+# Idempotently ensures a tmux session is running the agent_session_launcher for
+# the given callsign, then blocks until that session terminates. Exits non-zero
+# on session death so systemd Restart=on-failure brings the agent back.
+#
+# Usage:
+#     scripts/systemd_agent_supervisor.sh <callsign> <tmux-session-name> <worktree-path>
+#
+# Canonical map (must stay in sync with scripts/orchestrator/elliot_polling_loop.py
+# CALLSIGN_TO_TMUX):
+#     elliot  -> elliottbot  -> /home/elliotbot/clawd/Agency_OS
+#     aiden   -> aiden       -> /home/elliotbot/clawd/Agency_OS-aiden
+#     max     -> maxbot      -> /home/elliotbot/clawd/Agency_OS-max
+#     atlas   -> atlas       -> /home/elliotbot/clawd/Agency_OS-atlas
+#     orion   -> orion       -> /home/elliotbot/clawd/Agency_OS-orion
+#     scout   -> scout       -> /home/elliotbot/clawd/Agency_OS-scout
+
+set -euo pipefail
+
+callsign="${1:?usage: systemd_agent_supervisor.sh <callsign> <tmux-session> <worktree>}"
+tmux_session="${2:?missing tmux session name}"
+worktree="${3:?missing worktree path}"
+poll_seconds="${SUPERVISOR_POLL_SECONDS:-30}"
+
+if [[ ! -d "$worktree" ]]; then
+    echo "[supervisor] worktree missing: $worktree" >&2
+    exit 2
+fi
+
+launcher="$worktree/scripts/agent_session_launcher.sh"
+if [[ ! -x "$launcher" ]]; then
+    echo "[supervisor] launcher missing or not executable: $launcher" >&2
+    exit 2
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "[supervisor] tmux not on PATH" >&2
+    exit 2
+fi
+
+if ! tmux has-session -t "$tmux_session" 2>/dev/null; then
+    echo "[supervisor] spawning tmux session=$tmux_session callsign=$callsign worktree=$worktree"
+    tmux new-session -d -s "$tmux_session" -c "$worktree" \
+        "exec '$launcher' '$callsign'"
+else
+    echo "[supervisor] tmux session=$tmux_session already alive — attaching watcher"
+fi
+
+while tmux has-session -t "$tmux_session" 2>/dev/null; do
+    sleep "$poll_seconds"
+done
+
+echo "[supervisor] tmux session=$tmux_session terminated — exiting non-zero for systemd restart" >&2
+exit 1


### PR DESCRIPTION
## Summary

Ships 6 `systemd --user` services (one per agent) + supervisor wrapper + operator runbook so a server reboot brings all 6 agents back within ~2 min with **zero Dave touch**. Closes the gap exposed by the 2026-05-13 OOM event where Dave had to SSH in and respawn tmux manually.

**Linear:** [KEI-43](https://linear.app/keiracom/issue/KEI-43) · **bd:** Agency_OS-idt · **Priority:** P1 Urgent · **Author:** atlas
**Driver:** Dave verbatim #ceo 2026-05-13 23:50 + 23:38 + 23:44 AEST
**Pairs with:** KEI-44 (Orion, Cognee 3GB cap) · **Complements:** KEI-35 (detection-based recovery, shipped)

## What ships

- `scripts/systemd_agent_supervisor.sh` — idempotent ExecStart wrapper: spawns `tmux new-session -d` if missing, blocks until the session terminates, exits non-zero on termination so `Restart=on-failure` re-spawns within ~10s. Validates worktree + launcher existence up front (exit 2 on misconfig).
- `infra/systemd/agents/*-agent.service` — 6 unit files: elliot/aiden/max/atlas/orion/scout.
- `docs/operations/agent-systemd-recovery.md` — install steps, reboot expectations, crash-recovery test, troubleshooting table.

### Canonical map (must stay in sync with `scripts/orchestrator/elliot_polling_loop.py CALLSIGN_TO_TMUX`)

| Service                | Callsign | tmux session | Worktree                                 |
|------------------------|----------|--------------|------------------------------------------|
| `elliot-agent.service` | elliot   | `elliottbot` | `/home/elliotbot/clawd/Agency_OS`        |
| `aiden-agent.service`  | aiden    | `aiden`      | `/home/elliotbot/clawd/Agency_OS-aiden`  |
| `max-agent.service`    | max      | `maxbot`     | `/home/elliotbot/clawd/Agency_OS-max`    |
| `atlas-agent.service`  | atlas    | `atlas`      | `/home/elliotbot/clawd/Agency_OS-atlas`  |
| `orion-agent.service`  | orion    | `orion`      | `/home/elliotbot/clawd/Agency_OS-orion`  |
| `scout-agent.service`  | scout    | `scout`      | `/home/elliotbot/clawd/Agency_OS-scout`  |

## Unit shape (atlas-agent.service shown; others identical pattern)

```ini
[Unit]
Description=Agency OS Agent — ATLAS (callsign=atlas, tmux=atlas)
Documentation=https://linear.app/keiracom/issue/KEI-43
After=network-online.target
Wants=network-online.target
StartLimitBurst=5
StartLimitIntervalSec=300

[Service]
Type=simple
WorkingDirectory=/home/elliotbot/clawd/Agency_OS-atlas
ExecStart=/home/elliotbot/clawd/Agency_OS-atlas/scripts/systemd_agent_supervisor.sh atlas atlas /home/elliotbot/clawd/Agency_OS-atlas
Restart=on-failure
RestartSec=10
StandardOutput=append:/home/elliotbot/clawd/logs/atlas-agent.log
StandardError=append:/home/elliotbot/clawd/logs/atlas-agent.log

[Install]
WantedBy=default.target
```

Reference pattern: `~/.config/systemd/user/openclaw.service`.

## Verification

- `systemd-analyze --user verify` — **all 6 clean**. Cross-worktree "Command ... not executable" warnings are expected (only `Agency_OS-atlas` has the wrapper pre-merge; resolves after each worktree runs `git pull`).
- `bash -n scripts/systemd_agent_supervisor.sh` — syntax OK.
- Supervisor smoke-test with bad worktree → exits 2 with clear message (validated locally).
- `ruff check .` — 829 errors on this branch, **all pre-existing on origin/main** (verified via `git stash -u`). KEI-43 introduces no Python.

## Install (post-merge, operator)

See `docs/operations/agent-systemd-recovery.md` §Install. tl;dr:

```bash
# Per-worktree git pull first (so each has the wrapper).
install -D -m 0644 -t ~/.config/systemd/user/ \
    /home/elliotbot/clawd/Agency_OS/infra/systemd/agents/*.service
mkdir -p /home/elliotbot/clawd/logs
systemctl --user daemon-reload
for svc in elliot-agent aiden-agent max-agent atlas-agent orion-agent scout-agent; do
    systemctl --user enable --now "${svc}.service"
done
```

## Out of scope (per dispatch)

- KEI-44 Cognee 3GB memory cap (Orion's lane).
- Agent business-logic changes.
- KEI-35 detection-based recovery (already shipped).

## Reviewer asks

Triple-bot concur required per dispatch: **Aiden + Elliot + Max** before merge.

- [ ] Aiden — verify supervisor restart semantics + StartLimitBurst tuning sane?
- [ ] Elliot — runbook clarity for post-reboot operator expectations?
- [ ] Max — clone-architecture C3 alignment (clones spawn under elliotbot user, paths correct)?

**Atlas explicit NO-MERGE** until all three FINAL concur tags posted. (Post-#808 discipline: do not substitute one peer's concur for another's specifically-named FINAL.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)