### PR TITLE
[ATLAS] feat(kei45): Layer 3 idle enforcement daemon — mechanical tmux send-keys injection

### DIFF
--- a/docs/operations/agent-systemd-recovery.md
+++ b/docs/operations/agent-systemd-recovery.md
@@ -111,11 +111,60 @@ Operator runbook + unit files are checked into the repo so:
   `scripts/orchestrator/elliot_polling_loop.py` changes without these files
   changing in lockstep.
 
-## Related
+## Layer 3 idle enforcement (KEI-45)
+
+In addition to the 6 boot services above, KEI-45 adds a single master daemon —
+`agent-idle-enforcer.service` — that runs every 5 minutes and mechanically
+injects unclaimed `bd ready` work into idle agents' tmux sessions. This closes
+the "agent is alive but stopped pulling new work" failure mode (which is
+distinct from the KEI-43 boot-side cold-start and the KEI-35 detection-based
+restart).
+
+### What it does, per 5-min cycle, per agent
+
+1. Captures the tail of the agent's tmux pane (20 lines).
+2. **Weekly-cap detection** — matches the Anthropic "You've used X% of your
+   weekly limit · resets <date>" banner → posts to `#ceo` once, suppresses
+   retries until reset (state written to `ceo:boot_state_current`).
+3. **Transient throttle detection** — reuses the existing `THROTTLE_RE`
+   (`429` / `retry-after` / `Brewed for`) → exponential-backoff state, no
+   escalation.
+4. **BUSY-guard** — if the pane shows a recent `[BUSY:<callsign>:<task>]`
+   tag, skip (the agent is mid-task; don't double-dispatch).
+5. **Idle derivation** — `HEARTBEAT.md` file mtime in each worktree.
+6. **Idle ≥10 min + unclaimed `bd ready --assignee=<callsign>` work + not
+   rate-limited + not BUSY** → `tmux send-keys -t <session>:0 "<brief>" Enter`.
+   This is Layer 3 mechanical: cannot be bypassed by agent reasoning.
+7. **Idle ≥30 min with work still pending** → escalate to `#ceo`
+   (deduped to 60 min per callsign so we don't spam Dave).
+8. Upserts the per-agent snapshot to `public.ceo_memory key ceo:boot_state_current`
+   (jsonb), schema documented in the script docstring.
+
+### Install (one-time, post-merge)
+
+```bash
+install -D -m 0644 /home/elliotbot/clawd/Agency_OS/infra/systemd/agents/agent-idle-enforcer.service \
+    /home/elliotbot/.config/systemd/user/agent-idle-enforcer.service
+systemctl --user daemon-reload
+systemctl --user enable --now agent-idle-enforcer.service
+systemctl --user status agent-idle-enforcer.service   # confirm Active=running
+```
+
+### Verify a real injection (one-shot smoke)
+
+```bash
+# From the Agency_OS worktree (the WorkingDirectory of the unit):
+python3 scripts/idle_enforcer.py --once
+# Then in Supabase:
+#   SELECT jsonb_pretty(value) FROM public.ceo_memory WHERE key='ceo:boot_state_current';
+```
+
+### Related
 
 - KEI-35 — detection-based session recovery (already shipped); complementary to
   this boot-side path. KEI-35 catches a *running* agent that has gone dead;
   KEI-43 catches the post-reboot cold-start.
+- KEI-45 — Layer 3 idle enforcement (this file's §Layer 3 idle enforcement).
 - KEI-44 — Cognee 3GB memory cap (Orion, parallel work — limits the OOM that
   triggered the original 2026-05-13 incident).
 - `openclaw.service` — `/home/elliotbot/.config/systemd/user/openclaw.service`

--- a/infra/systemd/agents/agent-idle-enforcer.service
+++ b/infra/systemd/agents/agent-idle-enforcer.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Agency OS Layer 3 Idle Enforcement Daemon (KEI-45)
+Documentation=https://linear.app/keiracom/issue/KEI-45
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+ExecStart=/home/elliotbot/clawd/venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/idle_enforcer.py
+Restart=on-failure
+RestartSec=30
+StandardOutput=append:/home/elliotbot/clawd/logs/agent-idle-enforcer.log
+StandardError=append:/home/elliotbot/clawd/logs/agent-idle-enforcer.log
+
+[Install]
+WantedBy=default.target

--- a/scripts/idle_enforcer.py
+++ b/scripts/idle_enforcer.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""idle_enforcer.py — KEI-45 Layer 3 idle enforcement daemon.
+
+Polls all 6 agents every IDLE_CHECK_INTERVAL_SECONDS. Per cycle, per agent:
+
+  1. Capture tail of agent's tmux pane (reuses elliot_polling_loop primitives).
+  2. Weekly-cap detection — if Anthropic banner "You've used X% of your weekly
+     limit · resets <date>" matches → post #ceo, suppress retries until reset.
+  3. Transient throttle detection (THROTTLE_RE: 429 / "Server is temporarily
+     limiting requests" / "Brewed for") → exponential backoff, no escalation.
+  4. BUSY-guard — if pane shows recent [BUSY:<callsign>:<task>] tag, skip
+     (the agent is actively working; don't double-dispatch).
+  5. Idle-derivation — file mtime of HEARTBEAT.md (per-worktree) is the
+     freshness signal, since the template's structured fields are placeholders
+     unless an agent explicitly populated them. Augments (not replaces) the
+     existing keiracom_admin.agent_status_observations source.
+  6. Idle >= IDLE_DISPATCH_MINUTES (10) + unclaimed bd ready work + no rate
+     limit + not BUSY → mechanical tmux send-keys injection of the work brief.
+     This is Layer 3 mechanical: cannot be bypassed by agent reasoning.
+  7. Idle >= IDLE_ESCALATION_MINUTES (30) + still has pending work → #ceo
+     escalation (one-shot per cycle, deduped by callsign).
+  8. Upsert per-agent state into public.ceo_memory key ceo:boot_state_current
+     (jsonb), schema documented in BOOT_STATE_SCHEMA below.
+
+Idempotent + best-effort: any agent's failure logs + continues. Daemon survives
+reboots via Restart=on-failure + WantedBy=default.target (KEI-43 pattern).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+# Reuse existing primitives from elliot_polling_loop.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from orchestrator.elliot_polling_loop import (  # noqa: E402
+    CALLSIGN_TO_TMUX,
+    THROTTLE_RE,
+    _capture_pane_tail,
+    _extract_throttle_duration,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("idle_enforcer")
+
+# Tuning constants ──────────────────────────────────────────────────────────
+IDLE_CHECK_INTERVAL_SECONDS = int(os.environ.get("IDLE_CHECK_INTERVAL_SECONDS", "300"))
+IDLE_DISPATCH_MINUTES = int(os.environ.get("IDLE_DISPATCH_MINUTES", "10"))
+IDLE_ESCALATION_MINUTES = int(os.environ.get("IDLE_ESCALATION_MINUTES", "30"))
+BUSY_GUARD_PANE_LINES = 20
+
+WORKTREE_BASE = "/home/elliotbot/clawd"
+CALLSIGN_TO_WORKTREE: dict[str, str] = {
+    "elliot": f"{WORKTREE_BASE}/Agency_OS",
+    "aiden": f"{WORKTREE_BASE}/Agency_OS-aiden",
+    "max": f"{WORKTREE_BASE}/Agency_OS-max",
+    "atlas": f"{WORKTREE_BASE}/Agency_OS-atlas",
+    "orion": f"{WORKTREE_BASE}/Agency_OS-orion",
+    "scout": f"{WORKTREE_BASE}/Agency_OS-scout",
+}
+
+# Weekly-cap banner — Anthropic CLI prints e.g.:
+#   "You've used 92% of your weekly limit · resets 2026-05-20"
+#   "You've used 100% of your weekly limit. Resets Friday at 10am UTC"
+# Loose match: capture % + the resets-prefixed remainder so the parser can
+# extract whatever date format Anthropic uses today (string, no enforcement).
+WEEKLY_CAP_RE = re.compile(
+    r"you[''']?ve used\s+(?P<pct>\d{1,3})%\s+of your weekly limit"
+    r"[\s.·,-]*resets?[\s:]+(?P<resets>[A-Za-z0-9 ,.\-:/]+?)(?:[\n\r]|$)",
+    re.IGNORECASE,
+)
+
+# BUSY tag emitted by agents per orchestrator-discipline (KEI-39 protocol).
+BUSY_RE = re.compile(r"\[BUSY:(?P<callsign>\w+):(?P<task>[^\]]+)\]", re.IGNORECASE)
+
+CEO_CHANNEL_NAME = "ceo"
+
+BOOT_STATE_SCHEMA = """
+{
+  "<callsign>": {
+    "last_activity": "<ISO-8601 UTC>",
+    "idle_minutes": int,
+    "work_available_count": int,
+    "last_dispatch_at": "<ISO-8601 UTC | null>",
+    "rate_limit_state": "ok | transient | weekly_cap_until=<date>"
+  }
+}
+"""
+
+
+@dataclass
+class AgentState:
+    callsign: str
+    last_activity: str
+    idle_minutes: int
+    work_available_count: int = 0
+    last_dispatch_at: str | None = None
+    rate_limit_state: str = "ok"
+
+
+# Suppress escalation re-emission for the same callsign more often than this.
+_last_escalation_at: dict[str, datetime] = {}
+ESCALATION_DEDUP_MINUTES = 60
+
+
+def _heartbeat_mtime(callsign: str) -> datetime | None:
+    """Return UTC mtime of the callsign's HEARTBEAT.md, or None on miss."""
+    wt = CALLSIGN_TO_WORKTREE.get(callsign)
+    if not wt:
+        return None
+    p = Path(wt) / "HEARTBEAT.md"
+    if not p.is_file():
+        return None
+    try:
+        ts = p.stat().st_mtime
+    except OSError:
+        return None
+    return datetime.fromtimestamp(ts, tz=UTC)
+
+
+def _compute_idle_minutes(callsign: str, now: datetime) -> tuple[int, str]:
+    """Return (idle_minutes, last_activity_iso). Falls back to 0 if unknown."""
+    mtime = _heartbeat_mtime(callsign)
+    if mtime is None:
+        return 0, now.isoformat()
+    delta = now - mtime
+    return max(0, int(delta.total_seconds() // 60)), mtime.isoformat()
+
+
+def detect_weekly_cap(pane_text: str) -> tuple[bool, str | None]:
+    """Return (matched, resets_string). resets_string is None if no match."""
+    m = WEEKLY_CAP_RE.search(pane_text)
+    if not m:
+        return False, None
+    return True, m.group("resets").strip()
+
+
+def detect_busy(pane_text: str, callsign: str) -> bool:
+    """True iff a [BUSY:<callsign>:<task>] tag appears in the pane tail."""
+    return any(m.group("callsign").lower() == callsign.lower() for m in BUSY_RE.finditer(pane_text))
+
+
+def bd_ready_for(callsign: str) -> list[dict]:
+    """Return ready bd issues assigned to callsign. Best-effort."""
+    try:
+        proc = subprocess.run(
+            ["bd", "ready", "--assignee", callsign, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.warning("bd ready failed for %s: %s", callsign, exc)
+        return []
+    if proc.returncode != 0:
+        return []
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def inject_dispatch(callsign: str, brief: str) -> bool:
+    """Mechanically inject brief into agent tmux via send-keys. Returns success."""
+    session = CALLSIGN_TO_TMUX.get(callsign)
+    if not session:
+        logger.warning("no tmux mapping for callsign %r", callsign)
+        return False
+    # Defensive: verify session is alive before injecting.
+    try:
+        check = subprocess.run(
+            ["tmux", "has-session", "-t", session],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    if check.returncode != 0:
+        return False
+    # Send-keys: target the first pane of window 0.
+    target = f"{session}:0"
+    try:
+        # First the brief text...
+        subprocess.run(
+            ["tmux", "send-keys", "-t", target, brief],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+        # ...then Enter as a separate key so the brief doesn't have an embedded \n.
+        subprocess.run(
+            ["tmux", "send-keys", "-t", target, "Enter"],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.warning("send-keys failed for %s: %s", callsign, exc)
+        return False
+    logger.info("injected dispatch into %s (callsign=%s)", session, callsign)
+    return True
+
+
+def post_ceo(message: str) -> None:
+    """Post to #ceo via slack_relay.py. Best-effort."""
+    relay = Path(__file__).resolve().parent / "slack_relay.py"
+    if not relay.is_file():
+        logger.warning("slack_relay.py missing at %s — dropping ceo post", relay)
+        return
+    try:
+        subprocess.run(
+            ["python3", str(relay), "-c", CEO_CHANNEL_NAME, message],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("slack_relay -c ceo failed: %s", exc)
+
+
+def upsert_boot_state(states: dict[str, AgentState]) -> None:
+    """Upsert per-agent state into public.ceo_memory key ceo:boot_state_current."""
+    dsn = os.environ.get("DATABASE_URL", "") or os.environ.get("DATABASE_URL_MIGRATIONS", "")
+    if not dsn:
+        logger.info("DATABASE_URL unset — skipping boot_state write (dry mode)")
+        return
+    try:
+        import asyncio
+
+        import asyncpg
+    except ImportError:
+        logger.warning("asyncpg unavailable — skipping boot_state write")
+        return
+
+    payload = {cs: asdict(s) for cs, s in states.items()}
+
+    async def _run() -> None:
+        conn = await asyncpg.connect(
+            dsn.replace("postgresql+asyncpg://", "postgresql://"),
+            statement_cache_size=0,
+        )
+        try:
+            await conn.execute(
+                """
+                INSERT INTO public.ceo_memory (key, value, updated_at)
+                VALUES ($1, $2::jsonb, NOW())
+                ON CONFLICT (key) DO UPDATE
+                  SET value = EXCLUDED.value, updated_at = NOW()
+                """,
+                "ceo:boot_state_current",
+                json.dumps(payload),
+            )
+        finally:
+            await conn.close()
+
+    try:
+        asyncio.run(_run())
+    except (OSError, RuntimeError, Exception) as exc:  # noqa: BLE001 — best-effort
+        logger.warning("boot_state upsert failed: %s", exc)
+
+
+def _parse_weekly_cap_until(resets: str) -> str:
+    """Cap state string. Stores raw resets string when we can't parse a date."""
+    return f"weekly_cap_until={resets}"
+
+
+def process_callsign(callsign: str, now: datetime) -> AgentState:
+    """One agent's full per-cycle evaluation. Returns the snapshot state."""
+    pane = _capture_pane_tail(CALLSIGN_TO_TMUX[callsign], lines=BUSY_GUARD_PANE_LINES)
+    idle_min, last_activity = _compute_idle_minutes(callsign, now)
+    state = AgentState(
+        callsign=callsign,
+        last_activity=last_activity,
+        idle_minutes=idle_min,
+    )
+
+    weekly_hit, resets = detect_weekly_cap(pane)
+    if weekly_hit:
+        state.rate_limit_state = _parse_weekly_cap_until(resets or "unknown")
+        last = _last_escalation_at.get(f"weekly:{callsign}")
+        if last is None or (now - last) >= timedelta(minutes=ESCALATION_DEDUP_MINUTES):
+            post_ceo(
+                f":octagonal_sign: [{callsign}] hit Anthropic weekly cap. "
+                f"Resets: {resets or 'unknown'}. Daemon will suppress retries "
+                f"until reset. Source: pane capture (idle_enforcer KEI-45)."
+            )
+            _last_escalation_at[f"weekly:{callsign}"] = now
+        return state
+
+    if pane and THROTTLE_RE.search(pane):
+        dur_min, source = _extract_throttle_duration(pane)
+        state.rate_limit_state = f"transient(retry_in={dur_min}m,source={source})"
+        return state
+
+    if detect_busy(pane, callsign):
+        # Agent is actively working; do not dispatch — but BUSY counts as activity.
+        state.idle_minutes = 0
+        state.last_activity = now.isoformat()
+        return state
+
+    work = bd_ready_for(callsign)
+    state.work_available_count = len(work)
+
+    if idle_min >= IDLE_DISPATCH_MINUTES and work:
+        first = work[0]
+        issue_id = first.get("id", "unknown")
+        title = (first.get("title", "no title"))[:160]
+        brief = (
+            f"[ENFORCER:KEI-45] Idle {idle_min}m + ready work — pick up {issue_id}: "
+            f"{title}. Run: bd update {issue_id} --claim. Source: idle_enforcer."
+        )
+        if inject_dispatch(callsign, brief):
+            state.last_dispatch_at = now.isoformat()
+
+    if idle_min >= IDLE_ESCALATION_MINUTES and work:
+        last = _last_escalation_at.get(f"idle:{callsign}")
+        if last is None or (now - last) >= timedelta(minutes=ESCALATION_DEDUP_MINUTES):
+            post_ceo(
+                f":hourglass_flowing_sand: [{callsign}] idle {idle_min}m with "
+                f"{len(work)} ready work item(s). Mechanical inject attempted; "
+                f"escalating to #ceo (idle_enforcer KEI-45)."
+            )
+            _last_escalation_at[f"idle:{callsign}"] = now
+
+    return state
+
+
+def run_cycle(now: datetime | None = None) -> dict[str, AgentState]:
+    """One pass over all callsigns. Returns per-callsign state."""
+    ts = now or datetime.now(UTC)
+    states: dict[str, AgentState] = {}
+    for cs in CALLSIGN_TO_TMUX:
+        try:
+            states[cs] = process_callsign(cs, ts)
+        except (OSError, RuntimeError, Exception) as exc:  # noqa: BLE001
+            logger.warning("cycle failed for %s: %s", cs, exc)
+            states[cs] = AgentState(callsign=cs, last_activity=ts.isoformat(), idle_minutes=0)
+    upsert_boot_state(states)
+    return states
+
+
+def main() -> int:
+    once = "--once" in sys.argv
+    logger.info(
+        "idle_enforcer starting (interval=%ds, dispatch>=%dm, escalate>=%dm, once=%s)",
+        IDLE_CHECK_INTERVAL_SECONDS,
+        IDLE_DISPATCH_MINUTES,
+        IDLE_ESCALATION_MINUTES,
+        once,
+    )
+    while True:
+        run_cycle()
+        if once:
+            return 0
+        time.sleep(IDLE_CHECK_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_idle_enforcer.py
+++ b/tests/scripts/test_idle_enforcer.py
@@ -1,0 +1,278 @@
+"""Unit tests for scripts/idle_enforcer.py (KEI-45 Layer 3 idle daemon)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from scripts import idle_enforcer
+
+# Weekly-cap detection ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_hit", "expected_resets_substr"),
+    [
+        (
+            "You've used 92% of your weekly limit · resets 2026-05-20",
+            True,
+            "2026-05-20",
+        ),
+        (
+            "You've used 100% of your weekly limit. Resets Friday at 10am UTC",
+            True,
+            "Friday",
+        ),
+        (
+            # Loosely-formatted but still parseable (em-dash + lowercase 'resets').
+            "you've used 80% of your weekly limit - resets 2026-06-01",
+            True,
+            "2026-06-01",
+        ),
+        ("Server is temporarily limiting requests. retry-after: 60", False, None),
+        ("HTTP 429 Too Many Requests", False, None),
+        ("normal pane output, nothing rate-limit-shaped", False, None),
+    ],
+)
+def test_weekly_cap_detection(
+    text: str, expected_hit: bool, expected_resets_substr: str | None
+) -> None:
+    hit, resets = idle_enforcer.detect_weekly_cap(text)
+    assert hit is expected_hit
+    if expected_resets_substr is not None:
+        assert resets is not None
+        assert expected_resets_substr in resets
+
+
+# BUSY guard ────────────────────────────────────────────────────────────────
+
+
+def test_busy_guard_matches_own_callsign() -> None:
+    pane = "some chatter\n[BUSY:atlas:KEI-45] running\nmore output"
+    assert idle_enforcer.detect_busy(pane, "atlas") is True
+
+
+def test_busy_guard_skips_other_callsign() -> None:
+    pane = "[BUSY:aiden:KEI-22] doing things"
+    assert idle_enforcer.detect_busy(pane, "atlas") is False
+
+
+def test_busy_guard_no_match_on_empty() -> None:
+    assert idle_enforcer.detect_busy("", "atlas") is False
+
+
+# Idle minutes from HEARTBEAT mtime ─────────────────────────────────────────
+
+
+def test_compute_idle_minutes_uses_heartbeat_mtime(tmp_path: Path) -> None:
+    fake_worktree = tmp_path / "Agency_OS-fake"
+    fake_worktree.mkdir()
+    hb = fake_worktree / "HEARTBEAT.md"
+    hb.write_text("# HEARTBEAT.md\n")
+    now = datetime.now(UTC)
+    old_mtime = (now - timedelta(minutes=42)).timestamp()
+    import os
+
+    os.utime(hb, (old_mtime, old_mtime))
+
+    with mock.patch.dict(idle_enforcer.CALLSIGN_TO_WORKTREE, {"fake": str(fake_worktree)}):
+        idle, last = idle_enforcer._compute_idle_minutes("fake", now)
+
+    assert 41 <= idle <= 43, f"expected ~42 min idle, got {idle}"
+    assert last.startswith(now.strftime("%Y-%m-%dT")[:8]) or "T" in last
+
+
+def test_compute_idle_minutes_returns_zero_when_heartbeat_missing(
+    tmp_path: Path,
+) -> None:
+    with mock.patch.dict(idle_enforcer.CALLSIGN_TO_WORKTREE, {"missing": str(tmp_path)}):
+        idle, _ = idle_enforcer._compute_idle_minutes("missing", datetime.now(UTC))
+    assert idle == 0
+
+
+# inject_dispatch — verify it issues the right tmux command shape ──────────
+
+
+def test_inject_dispatch_calls_send_keys_when_session_alive() -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *_a, **_kw):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        # has-session returncode=0 (alive); send-keys ignored.
+        result = mock.Mock()
+        result.returncode = 0
+        return result
+
+    with mock.patch("scripts.idle_enforcer.subprocess.run", side_effect=fake_run):
+        ok = idle_enforcer.inject_dispatch("atlas", "[ENFORCER] pick up KEI-99")
+    assert ok is True
+    # First call: has-session check.
+    assert calls[0][:2] == ["tmux", "has-session"]
+    # Subsequent calls: send-keys with brief, then Enter.
+    send_calls = [c for c in calls if c[:2] == ["tmux", "send-keys"]]
+    assert any("[ENFORCER]" in " ".join(c) for c in send_calls)
+    assert any(c[-1] == "Enter" for c in send_calls)
+
+
+def test_inject_dispatch_aborts_when_session_dead() -> None:
+    def fake_run(_cmd, *_a, **_kw):  # type: ignore[no-untyped-def]
+        result = mock.Mock()
+        result.returncode = 1  # has-session: not found
+        return result
+
+    with mock.patch("scripts.idle_enforcer.subprocess.run", side_effect=fake_run):
+        assert idle_enforcer.inject_dispatch("atlas", "x") is False
+
+
+# bd_ready_for — JSON parsing happy + sad paths ─────────────────────────────
+
+
+def test_bd_ready_for_parses_json_array() -> None:
+    proc = mock.Mock()
+    proc.returncode = 0
+    proc.stdout = json.dumps([{"id": "Agency_OS-abc", "title": "do thing"}])
+    with mock.patch("scripts.idle_enforcer.subprocess.run", return_value=proc):
+        out = idle_enforcer.bd_ready_for("atlas")
+    assert out == [{"id": "Agency_OS-abc", "title": "do thing"}]
+
+
+def test_bd_ready_for_returns_empty_on_bad_json() -> None:
+    proc = mock.Mock()
+    proc.returncode = 0
+    proc.stdout = "not-json"
+    with mock.patch("scripts.idle_enforcer.subprocess.run", return_value=proc):
+        assert idle_enforcer.bd_ready_for("atlas") == []
+
+
+def test_bd_ready_for_returns_empty_on_nonzero_exit() -> None:
+    proc = mock.Mock()
+    proc.returncode = 2
+    proc.stdout = ""
+    with mock.patch("scripts.idle_enforcer.subprocess.run", return_value=proc):
+        assert idle_enforcer.bd_ready_for("atlas") == []
+
+
+# process_callsign — wiring through the layers ──────────────────────────────
+
+
+def test_process_callsign_skips_dispatch_when_weekly_cap_active() -> None:
+    pane = "You've used 95% of your weekly limit · resets 2026-05-20"
+    now = datetime.now(UTC)
+    with (
+        mock.patch("scripts.idle_enforcer._capture_pane_tail", return_value=pane),
+        mock.patch(
+            "scripts.idle_enforcer._compute_idle_minutes", return_value=(99, now.isoformat())
+        ),
+        mock.patch("scripts.idle_enforcer.bd_ready_for") as bd_mock,
+        mock.patch("scripts.idle_enforcer.inject_dispatch") as inj_mock,
+        mock.patch("scripts.idle_enforcer.post_ceo") as ceo_mock,
+    ):
+        state = idle_enforcer.process_callsign("atlas", now)
+    # Weekly cap → no bd ready, no injection.
+    bd_mock.assert_not_called()
+    inj_mock.assert_not_called()
+    # First weekly hit posts to #ceo (dedup map empty).
+    ceo_mock.assert_called_once()
+    assert state.rate_limit_state.startswith("weekly_cap_until=")
+
+
+def test_process_callsign_skips_when_busy() -> None:
+    pane = "[BUSY:atlas:KEI-45] running tests"
+    now = datetime.now(UTC)
+    with (
+        mock.patch("scripts.idle_enforcer._capture_pane_tail", return_value=pane),
+        mock.patch(
+            "scripts.idle_enforcer._compute_idle_minutes", return_value=(20, now.isoformat())
+        ),
+        mock.patch("scripts.idle_enforcer.bd_ready_for") as bd_mock,
+        mock.patch("scripts.idle_enforcer.inject_dispatch") as inj_mock,
+    ):
+        state = idle_enforcer.process_callsign("atlas", now)
+    bd_mock.assert_not_called()
+    inj_mock.assert_not_called()
+    assert state.idle_minutes == 0  # BUSY counts as activity
+
+
+def test_process_callsign_injects_when_idle_with_work() -> None:
+    now = datetime.now(UTC)
+    work_item = {"id": "Agency_OS-test", "title": "do the thing"}
+    with (
+        mock.patch("scripts.idle_enforcer._capture_pane_tail", return_value="ok"),
+        mock.patch(
+            "scripts.idle_enforcer._compute_idle_minutes", return_value=(15, now.isoformat())
+        ),
+        mock.patch("scripts.idle_enforcer.bd_ready_for", return_value=[work_item]),
+        mock.patch("scripts.idle_enforcer.inject_dispatch", return_value=True) as inj_mock,
+        mock.patch("scripts.idle_enforcer.post_ceo"),
+    ):
+        state = idle_enforcer.process_callsign("atlas", now)
+    inj_mock.assert_called_once()
+    args, _ = inj_mock.call_args
+    assert args[0] == "atlas"
+    assert "Agency_OS-test" in args[1]
+    assert state.last_dispatch_at is not None
+    assert state.work_available_count == 1
+
+
+def test_process_callsign_no_inject_under_threshold() -> None:
+    now = datetime.now(UTC)
+    with (
+        mock.patch("scripts.idle_enforcer._capture_pane_tail", return_value=""),
+        mock.patch(
+            "scripts.idle_enforcer._compute_idle_minutes", return_value=(5, now.isoformat())
+        ),
+        mock.patch(
+            "scripts.idle_enforcer.bd_ready_for",
+            return_value=[{"id": "x", "title": "y"}],
+        ),
+        mock.patch("scripts.idle_enforcer.inject_dispatch") as inj_mock,
+    ):
+        state = idle_enforcer.process_callsign("atlas", now)
+    inj_mock.assert_not_called()
+    assert state.last_dispatch_at is None
+
+
+def test_escalation_fires_at_30_minutes_with_work() -> None:
+    now = datetime.now(UTC)
+    idle_enforcer._last_escalation_at.clear()  # reset dedup map
+    with (
+        mock.patch("scripts.idle_enforcer._capture_pane_tail", return_value=""),
+        mock.patch(
+            "scripts.idle_enforcer._compute_idle_minutes",
+            return_value=(35, now.isoformat()),
+        ),
+        mock.patch(
+            "scripts.idle_enforcer.bd_ready_for",
+            return_value=[{"id": "x", "title": "y"}],
+        ),
+        mock.patch("scripts.idle_enforcer.inject_dispatch", return_value=True),
+        mock.patch("scripts.idle_enforcer.post_ceo") as ceo_mock,
+    ):
+        idle_enforcer.process_callsign("atlas", now)
+    ceo_mock.assert_called_once()
+
+
+def test_escalation_deduped_within_window() -> None:
+    now = datetime.now(UTC)
+    idle_enforcer._last_escalation_at.clear()
+    # Prime the dedup map.
+    idle_enforcer._last_escalation_at["idle:atlas"] = now - timedelta(minutes=10)
+    with (
+        mock.patch("scripts.idle_enforcer._capture_pane_tail", return_value=""),
+        mock.patch(
+            "scripts.idle_enforcer._compute_idle_minutes",
+            return_value=(35, now.isoformat()),
+        ),
+        mock.patch(
+            "scripts.idle_enforcer.bd_ready_for",
+            return_value=[{"id": "x", "title": "y"}],
+        ),
+        mock.patch("scripts.idle_enforcer.inject_dispatch", return_value=True),
+        mock.patch("scripts.idle_enforcer.post_ceo") as ceo_mock,
+    ):
+        idle_enforcer.process_callsign("atlas", now)
+    ceo_mock.assert_not_called()


### PR DESCRIPTION
## Summary

Layer 3 idle enforcement: a single `systemd --user` master daemon that polls all 6 agents every 5 minutes and **mechanically injects unclaimed `bd ready` work into idle agents' tmux sessions via `tmux send-keys`**. This is the layer that cannot be bypassed by agent reasoning.

Builds on top of KEI-43 (boot recovery, merged `afdb692a`) and complements KEI-35 (detection-based session recovery, already shipped). Closes the "agent is alive but stopped pulling new work" failure mode.

**Linear:** [KEI-45](https://linear.app/keiracom/issue/KEI-45) · **bd:** Agency_OS-q9b · **Priority:** P1 Urgent · **Author:** atlas
**Driver:** Dave verbatim #ceo 2026-05-14 ts ~1778705500

## What ships

| File | Purpose |
|------|---------|
| `scripts/idle_enforcer.py` | Daemon. Reuses `elliot_polling_loop` primitives (`CALLSIGN_TO_TMUX`, `THROTTLE_RE`, `_capture_pane_tail`, `_extract_throttle_duration`). Adds weekly-cap regex, BUSY-guard, `tmux send-keys` injector, `ceo:boot_state_current` upsert. `--once` flag for ad-hoc smoke runs. |
| `infra/systemd/agents/agent-idle-enforcer.service` | `Type=simple`, `Restart=on-failure`, `RestartSec=30`, `WantedBy=default.target`. Logs to `/home/elliotbot/clawd/logs/agent-idle-enforcer.log`. |
| `tests/scripts/test_idle_enforcer.py` | 22 pytest cases (weekly-cap regex parametrised, BUSY guard, idle-from-mtime, inject mock, bd_ready_for happy+sad, process_callsign wiring, escalation dedup). |
| `docs/operations/agent-systemd-recovery.md` | §Layer 3 idle enforcement addendum (install + smoke + behaviour summary). |

## Per-cycle, per-agent behaviour

1. Capture last 20 lines of tmux pane.
2. **Weekly-cap detect** — `WEEKLY_CAP_RE` matches Anthropic's "You've used X% of your weekly limit · resets <date>" → `slack_relay.py -c ceo` once, suppress retries until reset (dedup 60m).
3. **Transient throttle** — `THROTTLE_RE` (`429`/`retry-after`/`Brewed for`) → record backoff state, no escalation.
4. **BUSY-guard** — `[BUSY:<callsign>:<task>]` in pane → skip (don't double-dispatch); BUSY counts as activity (idle reset to 0).
5. Idle minutes derived from per-worktree `HEARTBEAT.md` mtime.
6. **Idle ≥10m + `bd ready --assignee=<cs>` work + not rate-limited + not BUSY** → `tmux send-keys -t <session>:0 "<brief>" Enter`. Mechanical, agent cannot bypass.
7. **Idle ≥30m + work still pending** → `#ceo` escalation (deduped 60m per callsign).
8. Upsert per-agent snapshot into `public.ceo_memory` key `ceo:boot_state_current` (jsonb).

### `ceo:boot_state_current` schema

```jsonc
{
  "<callsign>": {
    "callsign": "<cs>",
    "last_activity": "<ISO-8601 UTC>",
    "idle_minutes": <int>,
    "work_available_count": <int>,
    "last_dispatch_at": "<ISO-8601 UTC | null>",
    "rate_limit_state": "ok | transient(retry_in=<m>,source=<...>) | weekly_cap_until=<resets-string>"
  }
}
```

## Verification

- `ruff check scripts/idle_enforcer.py tests/scripts/test_idle_enforcer.py` → **All checks passed!**
- `ruff format --check ...` → **2 files already formatted**
- `python3 -m pytest tests/scripts/test_idle_enforcer.py -q` → **22 passed in 0.25s**
- `systemd-analyze --user verify agent-idle-enforcer.service` → **clean**
- `python3 -c "import ast; ast.parse(...)"` → **syntax OK**
- **LIVE DRY-RUN** against prod Supabase: `python3 scripts/idle_enforcer.py --once` wrote `ceo:boot_state_current` row at 21:14:27 UTC with all 6 callsigns + HEARTBEAT.md-mtime-derived `last_activity` values. **No injections fired** (no `bd ready` work for any callsign — correct behaviour).

## Anti-patterns checked (per dispatch)

- ✅ Does NOT modify `bd ready` behaviour — consumes its existing `--json` API.
- ✅ Does NOT replace KEI-35 (detection-based recovery) — additive Layer 3.
- ✅ Does NOT inject when agent is BUSY — `BUSY_RE.finditer(pane_text)` guard.

## Install (post-merge, operator)

See `docs/operations/agent-systemd-recovery.md` §Layer 3 idle enforcement. tl;dr:

```bash
install -D -m 0644 /home/elliotbot/clawd/Agency_OS/infra/systemd/agents/agent-idle-enforcer.service \
    /home/elliotbot/.config/systemd/user/agent-idle-enforcer.service
systemctl --user daemon-reload
systemctl --user enable --now agent-idle-enforcer.service
```

## Reviewer asks

Triple-bot concur required per dispatch: **Aiden + Elliot + Max** before merge.

- [ ] Aiden — verify weekly-cap regex shape vs the actual Anthropic banner you've seen; verify `tmux send-keys` semantics for our setup
- [ ] Elliot — verify orchestrator-discipline alignment (Layer 3 mechanical vs Layer 2 cognitive)
- [ ] Max — verify `ceo:boot_state_current` schema fits CEO oversight needs

**Atlas explicit NO-MERGE** until all three FINAL concur tags posted specifically (post-#808 + post-#842 discipline: do not substitute one peer's concur for another's specifically-named FINAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)