### PR TITLE
[ORION] feat(cognee): KEI-44 — 3 GB cgroup memory cap on cognee subprocesses

### DIFF
--- a/docs/runbooks/cognee-memory-cap.md
+++ b/docs/runbooks/cognee-memory-cap.md
@@ -1,0 +1,125 @@
+# Cognee 3 GB Memory Cap (KEI-44)
+
+Owner: orion · Status: shipped · Linear: [KEI-44](https://linear.app/keiracom/issue/KEI-44/kei-44-cognee-subprocess-3gb-memory-cap-cgroupulimit) · Beads: Agency_OS-ely
+
+## Why this exists
+
+2026-05-13 OOM crash: uncapped `cognee_ingest.py` + `uvicorn cognee.api.client`
+ran for 4+ hours, consumed all 6 GB of server RAM, killed six agent tmux
+sessions. Required manual Dave intervention to recover.
+
+The cap is **containment, not a fix**. Cognee memory growth is its own
+problem — this runbook just bounds the blast radius so it never takes the
+host down again.
+
+## What the cap does
+
+`scripts/orchestrator/cognee_capped.sh` wraps the launch under
+`systemd-run --user --scope -p MemoryMax=3G`. The kernel cgroup memcg
+hard-kills the child when RSS hits the cap. The host stays up. The
+neighbouring agent tmux sessions stay up. The cognee process dies with
+exit code 137 (SIGKILL) and a journal entry.
+
+## Always launch via the wrapper
+
+```bash
+# Stream-1 batch ingest
+scripts/orchestrator/cognee_capped.sh ingest -- --include-aux-skills
+
+# Uvicorn server on :8000
+scripts/orchestrator/cognee_capped.sh server
+
+# Anything else cognee-shaped
+scripts/orchestrator/cognee_capped.sh exec -- /usr/bin/env python -m mymodule
+```
+
+`exec` mode is the escape hatch for one-off scripts that touch cognee but
+aren't `cognee_ingest.py` or the uvicorn server.
+
+## Knobs
+
+| Flag / env                          | Default | Meaning                                                     |
+|-------------------------------------|---------|-------------------------------------------------------------|
+| `--max-mem=3G`                      | 3G      | Cap value (anything systemd accepts: `3G`, `1500M`, etc.)   |
+| `AGENCY_OS_COGNEE_CAP_MAX_MEM`      | 3G      | Same, via env (the wrapper picks `--max-mem` over env)      |
+| `--no-cap`                          | off     | Run direct, no systemd-run wrapper. Local dev only.         |
+| `AGENCY_OS_COGNEE_CAP_PYTHON`       | python3 | Override the python binary used for `ingest`/`server` modes |
+| `AGENCY_OS_SYSTEMD_RUN`             | systemd-run | Path to the systemd-run binary                          |
+
+## Verifying the cap is live
+
+```bash
+# Launch
+scripts/orchestrator/cognee_capped.sh ingest -- --dry-run &
+sleep 2
+
+# Find the scope and its cgroup
+systemctl --user list-units --type=scope | grep cognee-
+
+# Look at the kernel-level cap (truth)
+CG=$(systemctl --user show cognee-ingest-<PID>.scope -p ControlGroup --value)
+cat /sys/fs/cgroup${CG}/memory.max   # → 3221225472 (= 3 GB)
+```
+
+**Heads-up:** `systemctl --user show <scope> -p MemoryMax` returns
+`infinity` for transient scopes. That's a systemd display quirk — it does
+not mean the cap is missing. The cgroup `memory.max` file is the source
+of truth.
+
+## Acceptance test (10-chunk synthetic batch)
+
+```bash
+scripts/orchestrator/cognee_cap_acceptance_test.sh           # default --cap 1G
+scripts/orchestrator/cognee_cap_acceptance_test.sh --cap 3G  # real cap
+```
+
+The script allocates 10 × 400 MB chunks under the wrapper and verifies
+the child is SIGKILL'd by the cgroup OOM killer (rc=137) before completing
+all chunks. Default cap is 1 GB to keep dev workstation pressure low;
+the enforcement mechanism is identical at 3 GB.
+
+Verified 2026-05-13 (PR landing this runbook):
+
+```
+==> Wrapper exit code: 137
+==> Last log lines: chunk 1..5 allocated (~2000 MB virt)
+PASS: child SIGKILL'd by cgroup OOM (rc=137) at cap=1G
+```
+
+Kernel dmesg confirms scope-local memcg constraint:
+```
+oom-kill:constraint=CONSTRAINT_MEMCG,...
+oom_memcg=/user.slice/.../cognee-exec-<pid>.scope
+Memory cgroup out of memory: Killed process <pid> (python) anon-rss:1042304kB
+```
+
+## Resuming Streams 3+4 after the OOM freeze
+
+1. Confirm cognee freeze still in effect: no active `cognee_ingest.py` or
+   `uvicorn cognee.api.client` PIDs (`pgrep -f cognee_`).
+2. Restart the server under the cap:
+   ```bash
+   scripts/orchestrator/cognee_capped.sh server </dev/null >/tmp/cognee-server.log 2>&1 &
+   ```
+3. Re-run the ingest under the cap:
+   ```bash
+   scripts/orchestrator/cognee_capped.sh ingest -- --include-aux-skills
+   ```
+4. If the cap fires, the process exits 137 cleanly. Don't auto-retry — a
+   cap-hit means cognee's memory profile changed; investigate before
+   re-launching.
+
+## Failure modes
+
+| Symptom                                | Diagnosis                                                                 | Action                                                                  |
+|----------------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| Wrapper exits 3 with "not available"   | `systemd-run` missing or wrong path                                       | Set `AGENCY_OS_SYSTEMD_RUN=/usr/bin/systemd-run` or `--no-cap` for local |
+| Cognee process exits 137 unexpectedly  | Hit the 3 GB cap — workload grew past containment envelope                | Investigate chunking strategy / batch size. Don't widen the cap.        |
+| `memory.max` shows `max` (no number)   | Memory controller not delegated to user slice                             | `systemctl edit --force --full user-1001.slice` → add `MemoryAccounting=yes`; or contact infra |
+| Scope unit lingers after child exit    | Wrapper crashed mid-launch                                                | `systemctl --user reset-failed <unit>`                                  |
+
+## Related
+
+- KEI-43 (agent auto-start systemd services) — separate work; Atlas owns.
+- PR #790 (`install_systemd_units.sh`) — installer pattern this wrapper
+  doesn't use (no .service file ships; cap is applied per-invocation).

--- a/scripts/orchestrator/cognee_cap_acceptance_test.sh
+++ b/scripts/orchestrator/cognee_cap_acceptance_test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# cognee_cap_acceptance_test.sh — verify cognee_capped.sh enforces MemoryMax.
+#
+# 10-chunk synthetic batch (~400 MB/chunk = ~4 GB peak) launched under
+# cognee_capped.sh exec mode at --max-mem=$CAP (default 1G for the test).
+# Expected: kernel cgroup OOM-kills the child inside its scope memcg with
+# exit code 137. Failure of the test = the cap is not being enforced.
+#
+# Why 1G (not 3G) for the test default:
+#   3G allocation puts real pressure on dev workstations. The enforcement
+#   mechanism is identical regardless of cap value — 1G demonstrates the
+#   same memcg → OOM → 137 path with smaller resource footprint.
+#
+# Usage:
+#   scripts/orchestrator/cognee_cap_acceptance_test.sh
+#   scripts/orchestrator/cognee_cap_acceptance_test.sh --cap 3G
+#
+# Exit codes: 0 cap enforced; 1 cap NOT enforced (child completed); 2 bad args.
+
+set -euo pipefail
+
+CAP="1G"
+while (( $# )); do
+    case "$1" in
+        --cap) CAP="$2"; shift 2 ;;
+        --cap=*) CAP="${1#*=}"; shift ;;
+        -h | --help) sed -n '2,20p' "$0"; exit 0 ;;
+        *) echo "error: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/orchestrator/cognee_capped.sh"
+PYTHON_BIN="${AGENCY_OS_COGNEE_CAP_PYTHON:-$(command -v python3)}"
+ALLOCATOR=$(mktemp --suffix=.py)
+LOG=$(mktemp --suffix=.log)
+trap 'rm -f "$ALLOCATOR" "$LOG"' EXIT
+
+cat > "$ALLOCATOR" <<'PY'
+import os, time
+CHUNK_BYTES = 400 * 1024 * 1024
+held = []
+print(f"PID={os.getpid()} starting 10-chunk synthetic batch", flush=True)
+for i in range(10):
+    held.append(bytearray(CHUNK_BYTES))
+    for j in range(0, CHUNK_BYTES, 4096):
+        held[-1][j] = 1
+    print(f"chunk {i+1}/10 allocated (~{(i+1)*400} MB)", flush=True)
+    time.sleep(0.1)
+print("CHUNKS_DONE", flush=True)
+PY
+
+echo "==> Running 10-chunk synthetic batch under MemoryMax=$CAP"
+set +e
+bash "$WRAPPER" --max-mem="$CAP" exec -- "$PYTHON_BIN" "$ALLOCATOR" > "$LOG" 2>&1
+rc=$?
+set -e
+
+echo "==> Wrapper exit code: $rc"
+echo "==> Last log lines:"
+tail -10 "$LOG"
+
+if grep -q "CHUNKS_DONE" "$LOG"; then
+    echo "FAIL: child completed all 10 chunks — cap NOT enforced" >&2
+    exit 1
+fi
+
+if (( rc == 137 )); then
+    echo "PASS: child SIGKILL'd by cgroup OOM (rc=137) at cap=$CAP"
+    exit 0
+fi
+
+# Other non-zero exits could also indicate enforcement (e.g. Python MemoryError
+# raised before SIGKILL). Treat anything non-zero with no CHUNKS_DONE as pass,
+# but flag the unusual exit so the operator can investigate.
+echo "PASS-WITH-NOTE: child died (rc=$rc) before completing chunks at cap=$CAP"
+exit 0

--- a/scripts/orchestrator/cognee_capped.sh
+++ b/scripts/orchestrator/cognee_capped.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# cognee_capped.sh — launch cognee under a 3 GB systemd memory cap.
+#
+# Closes Beads Agency_OS-ely / Linear KEI-44. 2026-05-13 OOM crash:
+# uncapped Cognee Streams 3+4 consumed all 6 GB of server RAM, killed
+# six agent tmux sessions. Permanent fix is a cgroup hard ceiling.
+#
+# Implementation: systemd-run --user --scope -p MemoryMax=3G wraps the
+# child process. cgroup memory.max enforces — when the cap is hit the
+# kernel OOM-kills the child only (no host-wide drag-down). Visible via
+# `systemctl --user status <unit>` and /proc/<pid>/limits.
+#
+# Why --scope (not --service):
+#   - scope wraps the foreground command; calling shell blocks until exit
+#   - exit code propagates back to the caller
+#   - unit dies cleanly when child exits, no leftover service to clean up
+#
+# Why not ulimit -v:
+#   - virtual-memory limit produces false OOM on Python+numpy reservations
+#   - MemoryMax measures RSS only; matches the OOM failure mode we hit
+#
+# Modes:
+#   ingest   wraps `python scripts/cognee_ingest.py <args>`
+#   server   wraps `python -m uvicorn cognee.api.client:app --host 0.0.0.0 --port 8000 <args>`
+#   exec     wraps an arbitrary command after `--` (escape hatch)
+#
+# Usage:
+#   scripts/orchestrator/cognee_capped.sh ingest [-- args...]
+#   scripts/orchestrator/cognee_capped.sh server [-- args...]
+#   scripts/orchestrator/cognee_capped.sh exec -- /path/to/cmd args...
+#   scripts/orchestrator/cognee_capped.sh --no-cap ingest [-- args...]
+#   scripts/orchestrator/cognee_capped.sh --max-mem=2G ingest [-- args...]
+#
+# Env overrides:
+#   AGENCY_OS_COGNEE_CAP_MAX_MEM  default 3G (passed to -p MemoryMax=)
+#   AGENCY_OS_COGNEE_CAP_PYTHON   default $(command -v python3)
+#   AGENCY_OS_SYSTEMD_RUN         path to systemd-run binary (default 'systemd-run')
+#   AGENCY_OS_SYSTEMD_RUN_SKIP    if set, print resolved command + exit 0 (tests)
+#
+# Exit codes: child process exit code on success path; 2 on bad arguments;
+# 3 if systemd-run is unavailable and --no-cap was not requested.
+
+set -euo pipefail
+
+MAX_MEM="${AGENCY_OS_COGNEE_CAP_MAX_MEM:-3G}"
+PYTHON_BIN="${AGENCY_OS_COGNEE_CAP_PYTHON:-$(command -v python3 || true)}"
+SYSTEMD_RUN="${AGENCY_OS_SYSTEMD_RUN:-systemd-run}"
+NO_CAP=0
+
+# ─── Args ──────────────────────────────────────────────────────────────
+POSITIONAL=()
+while (( $# )); do
+    case "$1" in
+        --no-cap) NO_CAP=1; shift ;;
+        --max-mem=*) MAX_MEM="${1#*=}"; shift ;;
+        --max-mem) MAX_MEM="$2"; shift 2 ;;
+        -h | --help)
+            sed -n '2,40p' "$0"
+            exit 0
+            ;;
+        --) shift; POSITIONAL+=("$@"); break ;;
+        -*) echo "error: unknown arg: $1" >&2; exit 2 ;;
+        *) POSITIONAL+=("$1"); shift ;;
+    esac
+done
+
+if (( ${#POSITIONAL[@]} == 0 )); then
+    echo "error: missing mode (ingest|server|exec)" >&2
+    exit 2
+fi
+
+MODE="${POSITIONAL[0]}"
+EXTRA=("${POSITIONAL[@]:1}")
+
+# ─── Resolve mode → child argv ─────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+case "$MODE" in
+    ingest)
+        if [[ -z "$PYTHON_BIN" ]]; then
+            echo "error: python3 not found on PATH" >&2; exit 3
+        fi
+        CHILD_CMD=("$PYTHON_BIN" "$REPO_ROOT/scripts/cognee_ingest.py" "${EXTRA[@]}")
+        UNIT_NAME="cognee-ingest-$$.scope"
+        ;;
+    server)
+        if [[ -z "$PYTHON_BIN" ]]; then
+            echo "error: python3 not found on PATH" >&2; exit 3
+        fi
+        CHILD_CMD=("$PYTHON_BIN" -m uvicorn cognee.api.client:app
+                   --host 0.0.0.0 --port 8000 "${EXTRA[@]}")
+        UNIT_NAME="cognee-server-$$.scope"
+        ;;
+    exec)
+        if (( ${#EXTRA[@]} == 0 )); then
+            echo "error: exec mode requires '-- <cmd> [args]'" >&2; exit 2
+        fi
+        CHILD_CMD=("${EXTRA[@]}")
+        UNIT_NAME="cognee-exec-$$.scope"
+        ;;
+    *) echo "error: unknown mode: $MODE (want ingest|server|exec)" >&2; exit 2 ;;
+esac
+
+# ─── --no-cap escape (local dev / non-systemd hosts) ───────────────────
+if (( NO_CAP )); then
+    exec "${CHILD_CMD[@]}"
+fi
+
+# ─── Resolve systemd-run and dispatch ──────────────────────────────────
+if ! command -v "$SYSTEMD_RUN" >/dev/null 2>&1; then
+    echo "error: $SYSTEMD_RUN not available; pass --no-cap to bypass" >&2
+    exit 3
+fi
+
+FULL_CMD=("$SYSTEMD_RUN" --user --scope --unit="$UNIT_NAME"
+          -p "MemoryMax=$MAX_MEM" -p "MemoryAccounting=yes"
+          -- "${CHILD_CMD[@]}")
+
+if [[ -n "${AGENCY_OS_SYSTEMD_RUN_SKIP:-}" ]]; then
+    printf '%s\n' "${FULL_CMD[@]}"
+    exit 0
+fi
+
+exec "${FULL_CMD[@]}"

--- a/tests/scripts/test_cognee_capped.py
+++ b/tests/scripts/test_cognee_capped.py
@@ -1,0 +1,157 @@
+"""Unit tests for scripts/orchestrator/cognee_capped.sh.
+
+Tests use AGENCY_OS_SYSTEMD_RUN_SKIP=1 so systemd-run is never actually
+invoked — the wrapper prints the resolved command and exits 0, which
+lets us assert on argv shape without touching the user systemd instance.
+
+Acceptance test (10-chunk synthetic batch) lives outside CI as a manual
+runbook step — it requires real systemd-run + a deliberate OOM trigger.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER = REPO_ROOT / "scripts" / "orchestrator" / "cognee_capped.sh"
+
+
+def _run(
+    args: list[str], extra_env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["AGENCY_OS_SYSTEMD_RUN_SKIP"] = "1"
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [str(WRAPPER), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_help_exits_zero() -> None:
+    res = subprocess.run([str(WRAPPER), "--help"], check=False, capture_output=True, text=True)
+    assert res.returncode == 0
+    assert "cognee_capped.sh" in res.stdout
+    assert "MemoryMax" in res.stdout
+
+
+def test_missing_mode_exits_2() -> None:
+    res = _run([])
+    assert res.returncode == 2
+    assert "missing mode" in res.stderr
+
+
+def test_unknown_mode_exits_2() -> None:
+    res = _run(["totallyfake"])
+    assert res.returncode == 2
+    assert "unknown mode" in res.stderr
+
+
+def test_unknown_flag_exits_2() -> None:
+    res = _run(["--not-a-real-flag", "ingest"])
+    assert res.returncode == 2
+
+
+def test_ingest_resolves_systemd_run_command() -> None:
+    res = _run(["ingest", "--", "--dry-run"])
+    assert res.returncode == 0, res.stderr
+    lines = [ln for ln in res.stdout.splitlines() if ln]
+    assert lines[0] == "systemd-run"
+    assert "--user" in lines
+    assert "--scope" in lines
+    assert "MemoryMax=3G" in lines
+    assert "MemoryAccounting=yes" in lines
+    assert any(ln.endswith("cognee_ingest.py") for ln in lines)
+    assert "--dry-run" in lines
+
+
+def test_server_resolves_uvicorn() -> None:
+    res = _run(["server"])
+    assert res.returncode == 0, res.stderr
+    out = res.stdout
+    assert "uvicorn" in out
+    assert "cognee.api.client:app" in out
+    assert "--port" in out
+    assert "8000" in out
+
+
+def test_exec_mode_passes_arbitrary_command() -> None:
+    res = _run(["exec", "--", "/bin/true", "arg1"])
+    assert res.returncode == 0, res.stderr
+    lines = [ln for ln in res.stdout.splitlines() if ln]
+    assert "/bin/true" in lines
+    assert "arg1" in lines
+
+
+def test_exec_mode_requires_command() -> None:
+    res = _run(["exec"])
+    assert res.returncode == 2
+    assert "exec mode requires" in res.stderr
+
+
+def test_max_mem_override_equals_form() -> None:
+    res = _run(["--max-mem=2G", "ingest"])
+    assert res.returncode == 0
+    assert "MemoryMax=2G" in res.stdout
+
+
+def test_max_mem_override_space_form() -> None:
+    res = _run(["--max-mem", "1500M", "ingest"])
+    assert res.returncode == 0
+    assert "MemoryMax=1500M" in res.stdout
+
+
+def test_env_max_mem_override() -> None:
+    res = _run(["ingest"], extra_env={"AGENCY_OS_COGNEE_CAP_MAX_MEM": "4G"})
+    assert res.returncode == 0
+    assert "MemoryMax=4G" in res.stdout
+
+
+def test_unit_name_per_invocation() -> None:
+    res = _run(["ingest"])
+    out_lines = res.stdout.splitlines()
+    unit_lines = [ln for ln in out_lines if ln.startswith("--unit=")]
+    assert len(unit_lines) == 1
+    assert unit_lines[0].startswith("--unit=cognee-ingest-")
+    assert unit_lines[0].endswith(".scope")
+
+
+def test_no_cap_bypass_does_not_invoke_systemd_run(tmp_path: Path) -> None:
+    """--no-cap exec /bin/true should succeed without systemd-run on PATH."""
+    marker = tmp_path / "marker"
+    res = subprocess.run(
+        [str(WRAPPER), "--no-cap", "exec", "--", "/usr/bin/touch", str(marker)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": "/bin:/usr/bin"},  # systemd-run still on PATH but unused
+    )
+    assert res.returncode == 0, res.stderr
+    assert marker.exists()
+
+
+def test_systemd_run_missing_without_no_cap_exits_3(tmp_path: Path) -> None:
+    """If systemd-run is unreachable and --no-cap is not set, exit 3."""
+    env = os.environ.copy()
+    env.pop("AGENCY_OS_SYSTEMD_RUN_SKIP", None)
+    env["AGENCY_OS_SYSTEMD_RUN"] = str(tmp_path / "nope-systemd-run-binary")
+    res = subprocess.run(
+        [str(WRAPPER), "ingest"], check=False, capture_output=True, text=True, env=env
+    )
+    assert res.returncode == 3, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert "not available" in res.stderr
+
+
+@pytest.mark.parametrize("mode", ["ingest", "server"])
+def test_both_python_modes_resolve_python_bin(mode: str) -> None:
+    res = _run([mode])
+    assert res.returncode == 0
+    assert "python" in res.stdout.lower()


### PR DESCRIPTION
## Summary

Permanent containment for the 2026-05-13 OOM crash. Wraps cognee launches under `systemd-run --user --scope -p MemoryMax=3G`. Kernel cgroup memcg hard-kills the child when RSS hits the cap — host stays up, neighbour tmux sessions stay up, cognee dies clean with exit 137.

- `scripts/orchestrator/cognee_capped.sh` — wrapper (3 modes: `ingest`, `server`, `exec`)
- `scripts/orchestrator/cognee_cap_acceptance_test.sh` — 10-chunk synthetic batch verifier (acceptance criterion)
- `tests/scripts/test_cognee_capped.py` — 16 unit tests (argv-shape via `AGENCY_OS_SYSTEMD_RUN_SKIP`)
- `docs/runbooks/cognee-memory-cap.md` — runbook + resume procedure for Streams 3+4

**Linear:** [KEI-44](https://linear.app/keiracom/issue/KEI-44) · **Beads:** Agency_OS-ely · **Gate:** PR #790 (Agency_OS-34s) landed as 4a24e099 — satisfied.

## Why systemd-run --scope (not --service, not ulimit -v)

- `--scope` propagates the child's exit code and dies cleanly on child exit
- `ulimit -v` produces false OOM on Python + numpy virtual reservations; `MemoryMax` measures RSS only — matches the exact failure mode that took the host down

## Verification

### Live cgroup OOM kill (10-chunk synthetic batch, cap=1G)
```
$ bash scripts/orchestrator/cognee_cap_acceptance_test.sh --cap 1G
==> Running 10-chunk synthetic batch under MemoryMax=1G
==> Wrapper exit code: 137
PASS: child SIGKILL'd by cgroup OOM (rc=137) at cap=1G
```

Kernel dmesg (scope-local memcg constraint, no host-wide impact):
```
oom-kill:constraint=CONSTRAINT_MEMCG,...,
oom_memcg=/user.slice/user-1001.slice/user@1001.service/app.slice/cognee-exec-309639.scope,
task=python,pid=309639
Memory cgroup out of memory: Killed process 309639 (python) total-vm:2475740kB, anon-rss:1042304kB
```

### Cgroupfs `memory.max` is the source of truth
```
$ systemd-run --user --scope --unit=cap-probe.scope -p MemoryMax=500M -- ...
$ cat /sys/fs/cgroup/user.slice/.../cap-probe.scope/memory.max
524288000     # = exactly 500 MB
```

Heads-up: `systemctl --user show <scope> -p MemoryMax` returns `infinity` for transient scopes — that's a systemd display quirk (documented in the runbook). Trust the cgroupfs file.

### Unit tests
```
$ pytest tests/scripts/test_cognee_capped.py -q
................                                                         [100%]
16 passed in 0.34s
```

Ruff: `All checks passed` · format-check: clean.

## Test plan

- [x] 16 unit tests pass (argv-shape + env override + --no-cap bypass + missing-systemd-run rc=3)
- [x] Live cgroup OOM-kill verified at cap=500M, cap=1G — `memory.max` confirmed in cgroupfs
- [x] Kernel dmesg confirms `CONSTRAINT_MEMCG` scope-local kill (no host-wide impact)
- [x] Ruff lint + format clean
- [x] Runbook documents resume procedure for Streams 3+4 + the systemd `MemoryMax=infinity` display quirk
- [x] Branch off fresh `origin/main` (5913f715) in isolated worktree per LAW XVI

## Acceptance criteria (from Linear)

- [x] Cognee process limited to 3 GB measurable via cgroupfs `memory.max` (or `/proc/<pid>/limits` for legacy rlimits — but cgroup memcg is the real enforcement layer)
- [x] Reproducible test: `scripts/orchestrator/cognee_cap_acceptance_test.sh` runs 10-chunk synthetic batch, confirms cap is enforced
- [x] Runbook entry: `docs/runbooks/cognee-memory-cap.md` covers resume procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)