### PR TITLE
[AIDEN] feat(kei53): agent_profiles table + pre_compact_alert.py SQL lookup — Phase A

### DIFF
--- a/scripts/pre_compact_alert.py
+++ b/scripts/pre_compact_alert.py
@@ -279,8 +279,9 @@ def _configured_model_for_callsign(callsign: str) -> str:
                 model = rows[0].get("configured_model")
                 if isinstance(model, str) and model:
                     return model
-        except (OSError, json.JSONDecodeError, ValueError) as exc:
-            # urllib.error.URLError is an OSError subclass — kept implicit per Sonar S5713.
+        except (OSError, ValueError) as exc:
+            # urllib.error.URLError ⊂ OSError; json.JSONDecodeError ⊂ ValueError —
+            # both caught implicitly per Sonar S5713 (no redundant subclasses).
             logger.warning("agent_profiles lookup for %s failed (%s); using fallback map", cs, exc)
     return _CONFIGURED_MODEL_FALLBACK.get(cs, "")
 

--- a/scripts/pre_compact_alert.py
+++ b/scripts/pre_compact_alert.py
@@ -41,10 +41,11 @@ HEARTBEAT_PATH = Path("HEARTBEAT.md")
 # auto_populate_heartbeat() arguments.
 _PLACEHOLDER_PATTERN = re.compile(r"<[^>\n]+>")
 
-# KEI-36 follow-up (2026-05-14) — callsign → configured model. Static interim
-# map; the directive's reference to ceo_memory key `orchestration:model_assignment`
-# is a future migration target. Values match recent commit authors' actual model.
-_CONFIGURED_MODEL_MAP = {
+# KEI-53 — fallback callsign → model map used only when agent_profiles
+# Supabase read fails (network down, RLS blocked, etc). Primary source of
+# truth is public.agent_profiles.configured_model (migration
+# 20260514_kei53_agent_profiles.sql). Values stay in lockstep with seed.
+_CONFIGURED_MODEL_FALLBACK = {
     "aiden": "claude-opus-4-7",
     "max": "claude-opus-4-7",
     "elliot": "claude-opus-4-7",
@@ -52,6 +53,13 @@ _CONFIGURED_MODEL_MAP = {
     "orion": "claude-sonnet-4-6",
     "scout": "claude-sonnet-4-6",
 }
+
+# KEI-53 — Supabase PostgREST endpoint for agent_profiles reads. Public
+# anon-readable per migration; we only SELECT, never write here.
+_SUPABASE_URL = os.environ.get("SUPABASE_URL", "https://jatzvazlbusedwsnqxzr.supabase.co").rstrip(
+    "/"
+)
+_SUPABASE_ANON_KEY = os.environ.get("SUPABASE_ANON_KEY", "")
 
 # Placeholders that are intentional agent-fill (no mechanical source). The
 # residual-detector skips lines containing these so [HEARTBEAT-INCOMPLETE]
@@ -242,12 +250,38 @@ def _git_commit_subject() -> str:
 
 
 def _configured_model_for_callsign(callsign: str) -> str:
-    """KEI-36 follow-up — look up configured model from static callsign map.
+    """KEI-53 — look up configured model from public.agent_profiles.
 
-    Returns the model id from _CONFIGURED_MODEL_MAP or '' if callsign unknown.
-    Future: replace with ceo_memory `orchestration:model_assignment` SQL read.
+    Primary path: SELECT configured_model FROM public.agent_profiles
+    WHERE callsign=$1 via Supabase PostgREST. Times out at 3s.
+    Fallback path: _CONFIGURED_MODEL_FALLBACK map (kept in lockstep with
+    migration seed). Returns '' if callsign unknown and Supabase down.
     """
-    return _CONFIGURED_MODEL_MAP.get(callsign.lower(), "")
+    cs = callsign.lower()
+    if _SUPABASE_ANON_KEY:
+        try:
+            import urllib.error
+            import urllib.parse
+            import urllib.request
+
+            qs = urllib.parse.urlencode({"callsign": f"eq.{cs}", "select": "configured_model"})
+            req = urllib.request.Request(
+                f"{_SUPABASE_URL}/rest/v1/agent_profiles?{qs}",
+                headers={
+                    "apikey": _SUPABASE_ANON_KEY,
+                    "Authorization": f"Bearer {_SUPABASE_ANON_KEY}",
+                    "Accept": "application/json",
+                },
+            )
+            with urllib.request.urlopen(req, timeout=3) as r:
+                rows = json.loads(r.read())
+            if isinstance(rows, list) and rows and isinstance(rows[0], dict):
+                model = rows[0].get("configured_model")
+                if isinstance(model, str) and model:
+                    return model
+        except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError) as exc:
+            logger.warning("agent_profiles lookup for %s failed (%s); using fallback map", cs, exc)
+    return _CONFIGURED_MODEL_FALLBACK.get(cs, "")
 
 
 def _running_model() -> str:

--- a/scripts/pre_compact_alert.py
+++ b/scripts/pre_compact_alert.py
@@ -279,7 +279,8 @@ def _configured_model_for_callsign(callsign: str) -> str:
                 model = rows[0].get("configured_model")
                 if isinstance(model, str) and model:
                     return model
-        except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError) as exc:
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            # urllib.error.URLError is an OSError subclass — kept implicit per Sonar S5713.
             logger.warning("agent_profiles lookup for %s failed (%s); using fallback map", cs, exc)
     return _CONFIGURED_MODEL_FALLBACK.get(cs, "")
 

--- a/supabase/migrations/20260514_kei53_agent_profiles.sql
+++ b/supabase/migrations/20260514_kei53_agent_profiles.sql
@@ -33,33 +33,40 @@ COMMENT ON COLUMN public.agent_profiles.capability_weights IS
 
 -- Initial seed for 6 known callsigns (matches global CLAUDE.md agent table
 -- + Dave's KEI-53 description seed; model values from KEI-36 _CONFIGURED_MODEL_MAP
--- which this row supersedes).
-INSERT INTO public.agent_profiles
-    (callsign, configured_model, context_tags, capability_weights)
-VALUES
-    ('elliot', 'claude-opus-4-7',
-        ARRAY['orchestration', 'governance', 'python'],
-        '{"orchestration": 0.9, "governance": 0.9, "python": 0.8, "cognee": 0.6}'::jsonb),
-    ('aiden',  'claude-opus-4-7',
-        ARRAY['code_review', 'refactoring', 'python', 'ci'],
-        '{"code_review": 0.9, "refactoring": 0.8, "python": 0.8, "ci": 0.7}'::jsonb),
-    ('max',    'claude-opus-4-7',
-        ARRAY['cognee', 'memory', 'python'],
-        '{"cognee": 0.9, "memory": 0.9, "python": 0.7, "systemd": 0.3}'::jsonb),
-    ('atlas',  'claude-sonnet-4-6',
-        ARRAY['systemd', 'infrastructure', 'python'],
-        '{"systemd": 0.9, "infrastructure": 0.8, "python": 0.6, "cognee": 0.3}'::jsonb),
-    ('orion',  'claude-sonnet-4-6',
-        ARRAY['parallel_build', 'python', 'infrastructure'],
-        '{"parallel_build": 0.8, "python": 0.7, "infrastructure": 0.7}'::jsonb),
-    ('scout',  'claude-sonnet-4-6',
-        ARRAY['research', 'analysis', 'documentation'],
-        '{"research": 0.9, "analysis": 0.8, "documentation": 0.7}'::jsonb)
-ON CONFLICT (callsign) DO UPDATE SET
-    configured_model   = EXCLUDED.configured_model,
-    context_tags       = EXCLUDED.context_tags,
-    capability_weights = EXCLUDED.capability_weights,
-    updated_at         = NOW();
+-- which this row supersedes). Model id strings hoisted into PL/pgSQL
+-- variables per Sonar plsql:S1192 (no duplicate literals).
+DO $$
+DECLARE
+    opus_model   CONSTANT TEXT := 'claude-opus-4-7';
+    sonnet_model CONSTANT TEXT := 'claude-sonnet-4-6';
+BEGIN
+    INSERT INTO public.agent_profiles
+        (callsign, configured_model, context_tags, capability_weights)
+    VALUES
+        ('elliot', opus_model,
+            ARRAY['orchestration', 'governance', 'python'],
+            '{"orchestration": 0.9, "governance": 0.9, "python": 0.8, "cognee": 0.6}'::jsonb),
+        ('aiden',  opus_model,
+            ARRAY['code_review', 'refactoring', 'python', 'ci'],
+            '{"code_review": 0.9, "refactoring": 0.8, "python": 0.8, "ci": 0.7}'::jsonb),
+        ('max',    opus_model,
+            ARRAY['cognee', 'memory', 'python'],
+            '{"cognee": 0.9, "memory": 0.9, "python": 0.7, "systemd": 0.3}'::jsonb),
+        ('atlas',  sonnet_model,
+            ARRAY['systemd', 'infrastructure', 'python'],
+            '{"systemd": 0.9, "infrastructure": 0.8, "python": 0.6, "cognee": 0.3}'::jsonb),
+        ('orion',  sonnet_model,
+            ARRAY['parallel_build', 'python', 'infrastructure'],
+            '{"parallel_build": 0.8, "python": 0.7, "infrastructure": 0.7}'::jsonb),
+        ('scout',  sonnet_model,
+            ARRAY['research', 'analysis', 'documentation'],
+            '{"research": 0.9, "analysis": 0.8, "documentation": 0.7}'::jsonb)
+    ON CONFLICT (callsign) DO UPDATE SET
+        configured_model   = EXCLUDED.configured_model,
+        context_tags       = EXCLUDED.context_tags,
+        capability_weights = EXCLUDED.capability_weights,
+        updated_at         = NOW();
+END $$;
 
 -- Update trigger to keep updated_at fresh on any column change.
 CREATE OR REPLACE FUNCTION public._agent_profiles_set_updated_at()

--- a/supabase/migrations/20260514_kei53_agent_profiles.sql
+++ b/supabase/migrations/20260514_kei53_agent_profiles.sql
@@ -1,0 +1,76 @@
+-- KEI-53 — Agent profiles: personalised bd ready queue with capability affinity
+-- Ratified Dave 2026-05-13; claimed by Aiden ts 2026-05-14 07:00:48 UTC per
+-- pull-model first-mover-wins (Max [CONCUR-on-routing:max] ts ~1778742280).
+--
+-- Purpose: store per-callsign capability weights + recent task tags so
+-- bd ready can return personalised orderings rather than global queue.
+-- Also resolves Max's PR #861 caveat by giving pre_compact_alert.py a
+-- canonical SQL source for callsign → configured-model lookup (replaces
+-- the interim static _CONFIGURED_MODEL_MAP).
+
+CREATE TABLE IF NOT EXISTS public.agent_profiles (
+    callsign           TEXT        PRIMARY KEY,
+    configured_model   TEXT        NOT NULL,
+    context_tags       TEXT[]      NOT NULL DEFAULT '{}',
+    recent_kei_types   TEXT[]      NOT NULL DEFAULT '{}',
+    capability_weights JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.agent_profiles IS
+    'KEI-53 — per-callsign capability + model profile. Source of truth for '
+    'bd ready --agent personalisation and for pre_compact_alert.py Configured '
+    'Model lookup (replaces static map per KEI-36 follow-up caveat).';
+
+COMMENT ON COLUMN public.agent_profiles.configured_model IS
+    'Anthropic model id (claude-opus-4-7 / claude-sonnet-4-6 / etc). Read by '
+    'pre_compact_alert.py to fill HEARTBEAT.md Configured Model field.';
+
+COMMENT ON COLUMN public.agent_profiles.capability_weights IS
+    'JSONB map of capability → weight (0.0-1.0). Used by bd ready scoring '
+    'to re-rank unclaimed KEIs per agent. Updated by bd complete via EMA.';
+
+-- Initial seed for 6 known callsigns (matches global CLAUDE.md agent table
+-- + Dave's KEI-53 description seed; model values from KEI-36 _CONFIGURED_MODEL_MAP
+-- which this row supersedes).
+INSERT INTO public.agent_profiles
+    (callsign, configured_model, context_tags, capability_weights)
+VALUES
+    ('elliot', 'claude-opus-4-7',
+        ARRAY['orchestration', 'governance', 'python'],
+        '{"orchestration": 0.9, "governance": 0.9, "python": 0.8, "cognee": 0.6}'::jsonb),
+    ('aiden',  'claude-opus-4-7',
+        ARRAY['code_review', 'refactoring', 'python', 'ci'],
+        '{"code_review": 0.9, "refactoring": 0.8, "python": 0.8, "ci": 0.7}'::jsonb),
+    ('max',    'claude-opus-4-7',
+        ARRAY['cognee', 'memory', 'python'],
+        '{"cognee": 0.9, "memory": 0.9, "python": 0.7, "systemd": 0.3}'::jsonb),
+    ('atlas',  'claude-sonnet-4-6',
+        ARRAY['systemd', 'infrastructure', 'python'],
+        '{"systemd": 0.9, "infrastructure": 0.8, "python": 0.6, "cognee": 0.3}'::jsonb),
+    ('orion',  'claude-sonnet-4-6',
+        ARRAY['parallel_build', 'python', 'infrastructure'],
+        '{"parallel_build": 0.8, "python": 0.7, "infrastructure": 0.7}'::jsonb),
+    ('scout',  'claude-sonnet-4-6',
+        ARRAY['research', 'analysis', 'documentation'],
+        '{"research": 0.9, "analysis": 0.8, "documentation": 0.7}'::jsonb)
+ON CONFLICT (callsign) DO UPDATE SET
+    configured_model   = EXCLUDED.configured_model,
+    context_tags       = EXCLUDED.context_tags,
+    capability_weights = EXCLUDED.capability_weights,
+    updated_at         = NOW();
+
+-- Update trigger to keep updated_at fresh on any column change.
+CREATE OR REPLACE FUNCTION public._agent_profiles_set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_agent_profiles_updated_at ON public.agent_profiles;
+CREATE TRIGGER trg_agent_profiles_updated_at
+    BEFORE UPDATE ON public.agent_profiles
+    FOR EACH ROW EXECUTE FUNCTION public._agent_profiles_set_updated_at();

--- a/supabase/migrations/20260514_kei53_agent_profiles.sql
+++ b/supabase/migrations/20260514_kei53_agent_profiles.sql
@@ -39,24 +39,28 @@ DO $$
 DECLARE
     opus_model   CONSTANT TEXT := 'claude-opus-4-7';
     sonnet_model CONSTANT TEXT := 'claude-sonnet-4-6';
+    -- Common tag literals hoisted per Sonar plsql:S1192 (≥4 repeats).
+    py           CONSTANT TEXT := 'python';
+    cognee_tag   CONSTANT TEXT := 'cognee';
+    infra_tag    CONSTANT TEXT := 'infrastructure';
 BEGIN
     INSERT INTO public.agent_profiles
         (callsign, configured_model, context_tags, capability_weights)
     VALUES
         ('elliot', opus_model,
-            ARRAY['orchestration', 'governance', 'python'],
+            ARRAY['orchestration', 'governance', py],
             '{"orchestration": 0.9, "governance": 0.9, "python": 0.8, "cognee": 0.6}'::jsonb),
         ('aiden',  opus_model,
-            ARRAY['code_review', 'refactoring', 'python', 'ci'],
+            ARRAY['code_review', 'refactoring', py, 'ci'],
             '{"code_review": 0.9, "refactoring": 0.8, "python": 0.8, "ci": 0.7}'::jsonb),
         ('max',    opus_model,
-            ARRAY['cognee', 'memory', 'python'],
+            ARRAY[cognee_tag, 'memory', py],
             '{"cognee": 0.9, "memory": 0.9, "python": 0.7, "systemd": 0.3}'::jsonb),
         ('atlas',  sonnet_model,
-            ARRAY['systemd', 'infrastructure', 'python'],
+            ARRAY['systemd', infra_tag, py],
             '{"systemd": 0.9, "infrastructure": 0.8, "python": 0.6, "cognee": 0.3}'::jsonb),
         ('orion',  sonnet_model,
-            ARRAY['parallel_build', 'python', 'infrastructure'],
+            ARRAY['parallel_build', py, infra_tag],
             '{"parallel_build": 0.8, "python": 0.7, "infrastructure": 0.7}'::jsonb),
         ('scout',  sonnet_model,
             ARRAY['research', 'analysis', 'documentation'],

--- a/tests/scripts/test_pre_compact_alert.py
+++ b/tests/scripts/test_pre_compact_alert.py
@@ -511,16 +511,66 @@ def test_post_heartbeat_incomplete_warning_calls_slack(alert, monkeypatch):
     assert "<x>" in text and "<y>" in text
 
 
-def test_configured_model_for_callsign_known(alert):
-    """KEI-36 follow-up: known callsigns map to current model."""
+def test_configured_model_for_callsign_known_via_fallback(alert, monkeypatch):
+    """KEI-53: when SUPABASE_ANON_KEY unset, fall back to static map."""
+    monkeypatch.setattr(alert, "_SUPABASE_ANON_KEY", "")
     assert alert._configured_model_for_callsign("aiden") == "claude-opus-4-7"
     assert alert._configured_model_for_callsign("orion") == "claude-sonnet-4-6"
     assert alert._configured_model_for_callsign("AIDEN") == "claude-opus-4-7"  # case-insensitive
 
 
-def test_configured_model_for_callsign_unknown_returns_empty(alert):
+def test_configured_model_for_callsign_unknown_returns_empty(alert, monkeypatch):
+    monkeypatch.setattr(alert, "_SUPABASE_ANON_KEY", "")
     assert alert._configured_model_for_callsign("nobody") == ""
     assert alert._configured_model_for_callsign("") == ""
+
+
+def test_configured_model_for_callsign_uses_supabase_when_key_set(alert, monkeypatch):
+    """KEI-53: primary path queries agent_profiles via PostgREST."""
+    monkeypatch.setattr(alert, "_SUPABASE_ANON_KEY", "test-anon-key")
+    import urllib.request
+
+    class FakeResp:
+        def read(self) -> bytes:
+            return b'[{"configured_model": "claude-sonnet-4-7-experimental"}]'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    with patch.object(urllib.request, "urlopen", return_value=FakeResp()):
+        assert alert._configured_model_for_callsign("aiden") == "claude-sonnet-4-7-experimental"
+
+
+def test_configured_model_for_callsign_supabase_failure_falls_back(alert, monkeypatch):
+    """KEI-53: PostgREST failure → fallback map (resilience)."""
+    monkeypatch.setattr(alert, "_SUPABASE_ANON_KEY", "test-anon-key")
+    import urllib.error
+    import urllib.request
+
+    with patch.object(urllib.request, "urlopen", side_effect=urllib.error.URLError("conn refused")):
+        assert alert._configured_model_for_callsign("max") == "claude-opus-4-7"
+
+
+def test_configured_model_for_callsign_supabase_empty_rows_falls_back(alert, monkeypatch):
+    """KEI-53: empty PostgREST response → fallback map (callsign not yet seeded)."""
+    monkeypatch.setattr(alert, "_SUPABASE_ANON_KEY", "test-anon-key")
+    import urllib.request
+
+    class FakeResp:
+        def read(self) -> bytes:
+            return b"[]"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    with patch.object(urllib.request, "urlopen", return_value=FakeResp()):
+        assert alert._configured_model_for_callsign("scout") == "claude-sonnet-4-6"
 
 
 def test_running_model_from_env(alert, monkeypatch):


### PR DESCRIPTION
## Summary
- Adds `public.agent_profiles` table to Supabase (migration `20260514_kei53_agent_profiles.sql`) — seeds 6 callsigns with configured_model + capability_weights + tags
- Wires `scripts/pre_compact_alert.py` `_configured_model_for_callsign()` to read from PostgREST; static map demoted to fallback-only
- 4 new tests cover SQL primary path + URLError fallback + empty-rows fallback + no-anon-key fallback (47/47 pass)

## Phase scope
Right-sized for 85% Aiden budget per Dave-park constraint + Max [CONCUR-on-routing:max] ts ~1778742280.

**IN this PR**:
- Migration applied: `CREATE TABLE agent_profiles` + 6-callsign seed + updated_at trigger
- `pre_compact_alert.py` SQL primary / static fallback
- Resolves Max's PR #861 caveat (static map → canonical SoT)

**OUT (separate Phase B KEI)**:
- `bd ready --agent` personalisation scoring function
- `bd complete` EMA recalc hook for capability_weights
- preferred_agent 1.5× boost logic

## Routing
Aiden claimed via pull-model first-mover-wins. Linear description hint owner='Max' superseded by Max's explicit [CONCUR-on-routing:max] + Max single-track-blocked on KEI-45.

Aiden parked from inbound CONCUR-receive per Dave 85% directive — routing FINAL requests to **Max + Elliot**.

## Verification verbatim
```
$ python3 -m pytest tests/scripts/test_pre_compact_alert.py -v
47 passed in 6.39s

$ ruff check scripts/pre_compact_alert.py tests/scripts/test_pre_compact_alert.py
All checks passed!

$ ruff format scripts/pre_compact_alert.py tests/scripts/test_pre_compact_alert.py --check
2 files already formatted

$ mcp__supabase__apply_migration result: {"success": true}
```

## Tasks-table state
Row `KEI-53` claimed 2026-05-14T07:00:48Z by aiden. Will transition to `done` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)