### PR TITLE
[MAX] feat(kei61): durable indexing queue Phase A — Supabase staging buffer

### DIFF
--- a/scripts/orchestrator/indexing_queue_writer.py
+++ b/scripts/orchestrator/indexing_queue_writer.py
@@ -30,13 +30,20 @@ import json
 import logging
 import os
 import subprocess
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 logger = logging.getLogger("indexing_queue_writer")
 
-VALID_SOURCES: frozenset[str] = frozenset({
-    "git", "slack", "linear", "ceo_memory", "tool_log",
-})
+VALID_SOURCES: frozenset[str] = frozenset(
+    {
+        "git",
+        "slack",
+        "linear",
+        "ceo_memory",
+        "tool_log",
+    }
+)
 
 DEFAULT_PROJECT_ID = os.environ.get("SUPABASE_PROJECT_ID", "jatzvazlbusedwsnqxzr")
 DEFAULT_MCP_BRIDGE = os.environ.get(
@@ -79,7 +86,7 @@ def _default_write_fn(source: str, payload: dict[str, Any]) -> str:
         f"VALUES ('{source}', '{payload_json}'::jsonb) RETURNING id"
     )
     mcp_args = {"project_id": DEFAULT_PROJECT_ID, "query": sql}
-    proc = subprocess.run(  # noqa: S603 — controlled args, no shell
+    proc = subprocess.run(  # noqa: S603
         [
             "node",
             os.path.join(DEFAULT_MCP_BRIDGE, "scripts", "mcp-bridge.js"),

--- a/scripts/orchestrator/indexing_queue_writer.py
+++ b/scripts/orchestrator/indexing_queue_writer.py
@@ -1,0 +1,103 @@
+"""indexing_queue_writer.py — KEI-61 Phase A capture-layer write API.
+
+Minimal SDK module for webhook receivers + capture-layer callers to write
+events to the public.indexing_queue staging buffer. Decouples webhook
+ingestion (fast, always 200) from indexing-into-Weaviate (heavy, may fail)
+by inserting a durable queue between them.
+
+Usage:
+    from scripts.orchestrator.indexing_queue_writer import queue_event
+
+    row_id = queue_event(
+        source='git',
+        payload={'event': 'push', 'commit': 'abc123', 'files': [...]},
+    )
+
+Contract:
+- write returns the row uuid (str) on success, raises on failure.
+- Webhook receivers should wrap in try/except and respond 200 even on
+  failure (don't ask upstream to retry; surface via alerting).
+- <5ms typical insert latency assumes managed Supabase + same-region call.
+- sanitise() integration with KEI-57 secret-redaction is a follow-up.
+
+Phase B (gated on Atlas-KEI-48 Weaviate landing): worker that consumes
+pending rows + retries failed + writes to Weaviate.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from typing import Any, Callable
+
+logger = logging.getLogger("indexing_queue_writer")
+
+VALID_SOURCES: frozenset[str] = frozenset({
+    "git", "slack", "linear", "ceo_memory", "tool_log",
+})
+
+DEFAULT_PROJECT_ID = os.environ.get("SUPABASE_PROJECT_ID", "jatzvazlbusedwsnqxzr")
+DEFAULT_MCP_BRIDGE = os.environ.get(
+    "AGENCY_OS_MCP_BRIDGE", "/home/elliotbot/clawd/skills/mcp-bridge"
+)
+
+
+class IndexingQueueError(RuntimeError):
+    """Raised when the queue write fails. Callers should log + return 200 to
+    upstream webhook (don't ask upstream to retry; surface via failed-row alert)."""
+
+
+def queue_event(
+    source: str,
+    payload: dict[str, Any],
+    *,
+    write_fn: Callable[[str, dict[str, Any]], str] | None = None,
+) -> str:
+    """Insert a webhook event into public.indexing_queue. Returns row uuid."""
+    if source not in VALID_SOURCES:
+        raise IndexingQueueError(
+            f"invalid source {source!r}; must be one of {sorted(VALID_SOURCES)}"
+        )
+
+    if write_fn is None:
+        write_fn = _default_write_fn
+
+    try:
+        return write_fn(source, payload)
+    except Exception as exc:  # noqa: BLE001 — bound to typed re-raise
+        logger.warning("indexing_queue insert failed: %s", exc)
+        raise IndexingQueueError(f"queue write failed: {exc}") from exc
+
+
+def _default_write_fn(source: str, payload: dict[str, Any]) -> str:
+    """Default Supabase insert via MCP bridge. Production code path."""
+    payload_json = json.dumps(payload).replace("'", "''")
+    sql = (
+        "INSERT INTO public.indexing_queue (source, payload) "
+        f"VALUES ('{source}', '{payload_json}'::jsonb) RETURNING id"
+    )
+    mcp_args = {"project_id": DEFAULT_PROJECT_ID, "query": sql}
+    proc = subprocess.run(  # noqa: S603 — controlled args, no shell
+        [
+            "node",
+            os.path.join(DEFAULT_MCP_BRIDGE, "scripts", "mcp-bridge.js"),
+            "call",
+            "supabase",
+            "execute_sql",
+            json.dumps(mcp_args),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise IndexingQueueError(
+            f"mcp-bridge returncode={proc.returncode} stderr={proc.stderr[:200]}"
+        )
+    for token in proc.stdout.split('"'):
+        if len(token) == 36 and token.count("-") == 4:
+            return token
+    raise IndexingQueueError(f"could not parse row uuid from response: {proc.stdout[:200]}")

--- a/supabase/migrations/20260514_kei61_indexing_queue.sql
+++ b/supabase/migrations/20260514_kei61_indexing_queue.sql
@@ -1,0 +1,26 @@
+-- KEI-61 Phase A — durable indexing queue (Supabase staging buffer).
+-- Per Linear KEI-61 spec + Dave architecture ts ~1778733600.
+-- Capture-layer webhooks (Linear/Slack/Git/ceo_memory/tool_log) write to
+-- indexing_queue first; worker (Phase B, post KEI-48 Weaviate landing)
+-- consumes pending rows. Prevents dropped events during indexer downtime.
+
+CREATE TABLE IF NOT EXISTS public.indexing_queue (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source        TEXT NOT NULL CHECK (source IN ('git', 'slack', 'linear', 'ceo_memory', 'tool_log')),
+    payload       JSONB NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'done', 'failed')),
+    attempts      INTEGER NOT NULL DEFAULT 0,
+    error         TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    processed_at  TIMESTAMPTZ,
+    indexed_at    TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_indexing_queue_status_created
+    ON public.indexing_queue (status, created_at);
+
+COMMENT ON TABLE  public.indexing_queue IS 'KEI-61 durable staging buffer for capture-layer webhooks before LlamaIndex/Weaviate indexing.';
+COMMENT ON COLUMN public.indexing_queue.source IS 'webhook source enum: git | slack | linear | ceo_memory | tool_log';
+COMMENT ON COLUMN public.indexing_queue.payload IS 'raw webhook payload pre-sanitisation; KEI-57 secret-redaction integration is a follow-up';
+COMMENT ON COLUMN public.indexing_queue.status IS 'pending → processing → done | failed (retry by reset to pending)';
+COMMENT ON COLUMN public.indexing_queue.attempts IS 'incremented on each worker pickup; retry policy lives in worker (Phase B)';

--- a/tests/scripts/test_indexing_queue_writer.py
+++ b/tests/scripts/test_indexing_queue_writer.py
@@ -1,0 +1,88 @@
+"""Tests for KEI-61 Phase A indexing_queue_writer."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "indexing_queue_writer.py"
+
+_spec = importlib.util.spec_from_file_location("indexing_queue_writer", SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["indexing_queue_writer"] = _mod
+_spec.loader.exec_module(_mod)
+
+VALID_SOURCES = _mod.VALID_SOURCES
+IndexingQueueError = _mod.IndexingQueueError
+queue_event = _mod.queue_event
+
+
+def test_queue_event_rejects_invalid_source():
+    with pytest.raises(IndexingQueueError, match="invalid source"):
+        queue_event(source="invalid_thing", payload={})
+
+
+def test_queue_event_accepts_all_valid_sources():
+    captured: list = []
+
+    def fake_write(source, payload):
+        captured.append((source, payload))
+        return "00000000-0000-0000-0000-000000000001"
+
+    for src in VALID_SOURCES:
+        row_id = queue_event(source=src, payload={"k": "v"}, write_fn=fake_write)
+        assert row_id == "00000000-0000-0000-0000-000000000001"
+    assert len(captured) == len(VALID_SOURCES)
+
+
+def test_queue_event_passes_payload_to_write_fn():
+    captured: dict = {}
+
+    def fake_write(source, payload):
+        captured["source"] = source
+        captured["payload"] = payload
+        return "row-uuid-1"
+
+    payload = {"event": "push", "commit": "abc1234", "files": ["a.py", "b.md"]}
+    queue_event(source="git", payload=payload, write_fn=fake_write)
+
+    assert captured["source"] == "git"
+    assert captured["payload"] == payload
+
+
+def test_queue_event_wraps_write_failure_in_typed_error():
+    def failing_write(source, payload):
+        raise RuntimeError("supabase unreachable")
+
+    with pytest.raises(IndexingQueueError, match="queue write failed"):
+        queue_event(source="slack", payload={}, write_fn=failing_write)
+
+
+def test_queue_event_returns_row_uuid():
+    expected = "11111111-2222-3333-4444-555555555555"
+
+    def fake_write(source, payload):
+        return expected
+
+    assert queue_event(source="linear", payload={"x": 1}, write_fn=fake_write) == expected
+
+
+def test_valid_sources_enum_complete():
+    assert VALID_SOURCES == frozenset({
+        "git", "slack", "linear", "ceo_memory", "tool_log",
+    })
+
+
+def test_queue_event_handles_empty_payload():
+    captured: dict = {}
+
+    def fake_write(source, payload):
+        captured["payload"] = payload
+        return "row-uuid-empty"
+
+    queue_event(source="tool_log", payload={}, write_fn=fake_write)
+    assert captured["payload"] == {}


### PR DESCRIPTION
## Summary

KEI-61 Phase A — Supabase durable staging buffer for capture-layer webhooks. Prevents dropped events during indexer downtime. Per Round-3-ratified architecture + Linear KEI-61 spec.

bd tasks-table: KEI-61 status=active claimed_by=max
Linear: [KEI-61](https://linear.app/keiracom/issue/KEI-61)

## Ships (3 files)

- `supabase/migrations/20260514_kei61_indexing_queue.sql`: CREATE TABLE public.indexing_queue + status/source enum CHECK constraints + status+created_at composite index. Idempotent.
- `scripts/orchestrator/indexing_queue_writer.py`: queue_event() SDK + typed IndexingQueueError + Supabase MCP-bridge default impl + injectable write_fn for tests.
- `tests/scripts/test_indexing_queue_writer.py`: 7 tests covering enum + payload + error-wrapping + uuid-return + empty-payload.

Phase B (deferred to KEI-48 Weaviate landing): worker that consumes pending rows + retries failed + indexes into Weaviate.

Local: 7/7 tests PASS.

Routing: Max author + Elliot + Orion FINAL chain (Aiden parked CONCUR-receive per Dave 85% directive).

🤖 Generated with Claude Opus 4.7