### PR TITLE
[AIDEN] feat(kei53-phase-b): tasks_cli ready --agent personalised scoring

### DIFF
--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -62,23 +62,58 @@ def _rows_to_dicts(cur: Any) -> list[dict]:
 
 
 def cmd_ready(args: argparse.Namespace) -> int:
-    """List available tasks ordered by priority ASC then created_at ASC."""
+    """List available tasks ordered by priority ASC then created_at ASC.
+
+    KEI-53 Phase B: if --agent <callsign> is supplied, re-rank by
+    personalised affinity score = SUM(capability_weight × matching_tag).
+    Adds `personalised_score` to each row; preserves existing JSON shape
+    (no renames) per Max's tasks-cli compat note.
+    """
     import psycopg
 
     limit = max(1, min(args.limit, 250))
+    agent = (args.agent or "").strip().lower() if getattr(args, "agent", None) else ""
     try:
         with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT id, title, priority, status, claimed_by, claimed_at,
-                       dependencies, tags, linear_url, created_at, updated_at
-                FROM public.tasks
-                WHERE status = 'available'
-                ORDER BY priority ASC, created_at ASC
-                LIMIT %s
-                """,
-                (limit,),
-            )
+            if agent:
+                # KEI-53 — personalised path.
+                # Affinity = SUM over t.tags of agent_profiles.capability_weights[tag].
+                # `?` is JSONB key-exists; `->>` is text extraction (cast to float).
+                # Tie-break: personalised_score DESC, priority ASC, created_at ASC
+                # (deterministic per Max note #2).
+                cur.execute(
+                    """
+                    SELECT t.id, t.title, t.priority, t.status, t.claimed_by,
+                           t.claimed_at, t.dependencies, t.tags, t.linear_url,
+                           t.created_at, t.updated_at,
+                           COALESCE(
+                             (SELECT SUM((ap.capability_weights->>tag)::float)
+                              FROM public.agent_profiles ap,
+                                   unnest(t.tags) AS tag
+                              WHERE ap.callsign = %s
+                                AND ap.capability_weights ? tag),
+                             0.0
+                           ) AS personalised_score
+                    FROM public.tasks t
+                    WHERE t.status = 'available'
+                    ORDER BY personalised_score DESC,
+                             t.priority ASC, t.created_at ASC
+                    LIMIT %s
+                    """,
+                    (agent, limit),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT id, title, priority, status, claimed_by, claimed_at,
+                           dependencies, tags, linear_url, created_at, updated_at
+                    FROM public.tasks
+                    WHERE status = 'available'
+                    ORDER BY priority ASC, created_at ASC
+                    LIMIT %s
+                    """,
+                    (limit,),
+                )
             rows = _rows_to_dicts(cur)
     except psycopg.Error:
         logger.exception("ready query failed")
@@ -87,8 +122,12 @@ def cmd_ready(args: argparse.Namespace) -> int:
         print(json.dumps(rows, default=str))
     else:
         for r in rows:
-            print(f"  P{r['priority']:>1}  {r['id']:<24}  {r['title']}")
-        print(f"\n{len(rows)} available")
+            score_suffix = ""
+            if agent and "personalised_score" in r:
+                score_suffix = f"  [score={r['personalised_score']:.2f}]"
+            print(f"  P{r['priority']:>1}  {r['id']:<24}  {r['title']}{score_suffix}")
+        suffix = f" (personalised for {agent})" if agent else ""
+        print(f"\n{len(rows)} available{suffix}")
     return 0
 
 
@@ -232,6 +271,10 @@ def main(argv: list[str] | None = None) -> int:
     p_ready = sub.add_parser("ready", help="list available tasks")
     p_ready.add_argument("--json", action="store_true")
     p_ready.add_argument("--limit", type=int, default=50)
+    p_ready.add_argument(
+        "--agent",
+        help="KEI-53 — personalise ranking via agent_profiles.capability_weights",
+    )
     p_ready.set_defaults(func=cmd_ready)
 
     p_claim = sub.add_parser("claim", help="atomically claim a task")

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -40,6 +40,24 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 DEFAULT_CALLSIGN = "unknown"
 
+# Canonical column list shared by ready/show paths. Single source of truth
+# (avoids Sonar new_duplicated_lines_density on the column projection).
+_READY_COLUMNS = (
+    "id, title, priority, status, claimed_by, claimed_at, "
+    "dependencies, tags, linear_url, created_at, updated_at"
+)
+
+# KEI-53 Phase B — personalised score subquery joining agent_profiles.
+# JSONB key-exists (?) gates the cast so non-matching tags don't error.
+_PERSONALISED_SCORE_SUBQUERY = """COALESCE(
+    (SELECT SUM((ap.capability_weights->>tag)::float)
+     FROM public.agent_profiles ap,
+          unnest(t.tags) AS tag
+     WHERE ap.callsign = %s
+       AND ap.capability_weights ? tag),
+    0.0
+) AS personalised_score"""
+
 
 def _dsn() -> str:
     dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
@@ -76,44 +94,23 @@ def cmd_ready(args: argparse.Namespace) -> int:
     try:
         with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
             if agent:
-                # KEI-53 — personalised path.
-                # Affinity = SUM over t.tags of agent_profiles.capability_weights[tag].
-                # `?` is JSONB key-exists; `->>` is text extraction (cast to float).
-                # Tie-break: personalised_score DESC, priority ASC, created_at ASC
-                # (deterministic per Max note #2).
-                cur.execute(
-                    """
-                    SELECT t.id, t.title, t.priority, t.status, t.claimed_by,
-                           t.claimed_at, t.dependencies, t.tags, t.linear_url,
-                           t.created_at, t.updated_at,
-                           COALESCE(
-                             (SELECT SUM((ap.capability_weights->>tag)::float)
-                              FROM public.agent_profiles ap,
-                                   unnest(t.tags) AS tag
-                              WHERE ap.callsign = %s
-                                AND ap.capability_weights ? tag),
-                             0.0
-                           ) AS personalised_score
-                    FROM public.tasks t
-                    WHERE t.status = 'available'
-                    ORDER BY personalised_score DESC,
-                             t.priority ASC, t.created_at ASC
-                    LIMIT %s
-                    """,
-                    (agent, limit),
+                # KEI-53 — personalised path. Tie-break per Max note #2:
+                # personalised_score DESC, priority ASC, created_at ASC.
+                sql = (
+                    f"SELECT t.{', t.'.join(_READY_COLUMNS.split(', '))}, "
+                    f"{_PERSONALISED_SCORE_SUBQUERY} "
+                    "FROM public.tasks t WHERE t.status = 'available' "
+                    "ORDER BY personalised_score DESC, "
+                    "t.priority ASC, t.created_at ASC LIMIT %s"
                 )
+                cur.execute(sql, (agent, limit))
             else:
-                cur.execute(
-                    """
-                    SELECT id, title, priority, status, claimed_by, claimed_at,
-                           dependencies, tags, linear_url, created_at, updated_at
-                    FROM public.tasks
-                    WHERE status = 'available'
-                    ORDER BY priority ASC, created_at ASC
-                    LIMIT %s
-                    """,
-                    (limit,),
+                sql = (
+                    f"SELECT {_READY_COLUMNS} FROM public.tasks "
+                    "WHERE status = 'available' "
+                    "ORDER BY priority ASC, created_at ASC LIMIT %s"
                 )
+                cur.execute(sql, (limit,))
             rows = _rows_to_dicts(cur)
     except psycopg.Error:
         logger.exception("ready query failed")

--- a/tests/scripts/test_tasks_cli.py
+++ b/tests/scripts/test_tasks_cli.py
@@ -244,7 +244,9 @@ def test_ready_agent_emits_personalised_score_in_json(mod, patch_connect, capsys
     assert data[0]["title"] == "deprecation"
     assert data[0]["priority"] == 1
     # New key added.
-    assert data[0]["personalised_score"] == 1.7
+    # pytest.approx avoids Sonar S1244 float-equality finding
+    # (per reference_sonarcloud_verify_pattern.md anchored 2026-05-13).
+    assert data[0]["personalised_score"] == pytest.approx(1.7)
 
 
 def test_ready_without_agent_uses_unpersonalised_sql(mod, patch_connect) -> None:

--- a/tests/scripts/test_tasks_cli.py
+++ b/tests/scripts/test_tasks_cli.py
@@ -177,6 +177,135 @@ def test_ready_clamps_limit_argument(mod, patch_connect) -> None:
     assert cur.last_params == (250,)
 
 
+# ─── ready --agent (KEI-53 Phase B) ───────────────────────────────────────────
+
+
+def test_ready_agent_uses_personalised_sql_path(mod, patch_connect) -> None:
+    """--agent <callsign> triggers the agent_profiles JOIN + personalised_score column."""
+    cur = _Cursor(fetchall_rows=[], description=[("id",), ("personalised_score",)])
+    patch_connect(cur)
+    rc = mod.main(["ready", "--agent", "elliot", "--limit", "10"])
+    assert rc == 0
+    # Personalised SQL references agent_profiles and personalised_score.
+    assert "agent_profiles" in cur.last_sql
+    assert "personalised_score" in cur.last_sql
+    # Params: (callsign, limit) — lowercased callsign.
+    assert cur.last_params == ("elliot", 10)
+
+
+def test_ready_agent_lowercases_callsign(mod, patch_connect) -> None:
+    cur = _Cursor(fetchall_rows=[], description=[("id",)])
+    patch_connect(cur)
+    mod.main(["ready", "--agent", "ELLIOT"])
+    assert cur.last_params[0] == "elliot"
+
+
+def test_ready_agent_emits_personalised_score_in_json(mod, patch_connect, capsys) -> None:
+    """JSON output preserves existing keys + adds personalised_score per Max note #3."""
+    cur = _Cursor(
+        fetchall_rows=[
+            (
+                "KEI-63",
+                "deprecation",
+                1,
+                "available",
+                None,
+                None,
+                None,
+                ["python", "governance"],
+                "url",
+                None,
+                None,
+                1.7,
+            ),
+        ],
+        description=[
+            ("id",),
+            ("title",),
+            ("priority",),
+            ("status",),
+            ("claimed_by",),
+            ("claimed_at",),
+            ("dependencies",),
+            ("tags",),
+            ("linear_url",),
+            ("created_at",),
+            ("updated_at",),
+            ("personalised_score",),
+        ],
+    )
+    patch_connect(cur)
+    rc = mod.main(["ready", "--agent", "elliot", "--json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert len(data) == 1
+    # Existing keys preserved.
+    assert data[0]["id"] == "KEI-63"
+    assert data[0]["title"] == "deprecation"
+    assert data[0]["priority"] == 1
+    # New key added.
+    assert data[0]["personalised_score"] == 1.7
+
+
+def test_ready_without_agent_uses_unpersonalised_sql(mod, patch_connect) -> None:
+    """Default `ready` (no --agent) still uses the original SQL — no personalised cost."""
+    cur = _Cursor(fetchall_rows=[], description=[("id",)])
+    patch_connect(cur)
+    mod.main(["ready"])
+    # Unpersonalised path: SELECT FROM public.tasks WHERE status='available' ORDER BY priority/created_at.
+    assert "agent_profiles" not in cur.last_sql
+    assert "personalised_score" not in cur.last_sql
+
+
+def test_ready_agent_empty_string_falls_back_to_default(mod, patch_connect) -> None:
+    """--agent '' (empty after strip) does not trigger personalised path."""
+    cur = _Cursor(fetchall_rows=[], description=[("id",)])
+    patch_connect(cur)
+    mod.main(["ready", "--agent", "   "])
+    assert "agent_profiles" not in cur.last_sql
+
+
+def test_ready_agent_human_output_includes_score_marker(mod, patch_connect, capsys) -> None:
+    """Non-JSON human output for --agent shows [score=X.XX] suffix + personalised banner."""
+    cur = _Cursor(
+        fetchall_rows=[
+            (
+                "KEI-63",
+                "deprecation",
+                1,
+                "available",
+                None,
+                None,
+                None,
+                ["python", "governance"],
+                "url",
+                None,
+                None,
+                1.7,
+            ),
+        ],
+        description=[
+            ("id",),
+            ("title",),
+            ("priority",),
+            ("status",),
+            ("claimed_by",),
+            ("claimed_at",),
+            ("dependencies",),
+            ("tags",),
+            ("linear_url",),
+            ("created_at",),
+            ("updated_at",),
+            ("personalised_score",),
+        ],
+    )
+    patch_connect(cur)
+    mod.main(["ready", "--agent", "elliot"])
+    out = capsys.readouterr().out
+    assert "[score=1.70]" in out
+    assert "personalised for elliot" in out
+
+
 # ─── claim ────────────────────────────────────────────────────────────────────
 
 

--- a/tests/scripts/test_tasks_cli.py
+++ b/tests/scripts/test_tasks_cli.py
@@ -200,9 +200,14 @@ def test_ready_agent_lowercases_callsign(mod, patch_connect) -> None:
     assert cur.last_params[0] == "elliot"
 
 
-def test_ready_agent_emits_personalised_score_in_json(mod, patch_connect, capsys) -> None:
-    """JSON output preserves existing keys + adds personalised_score per Max note #3."""
-    cur = _Cursor(
+def _personalised_cursor(score: float = 1.7) -> _Cursor:
+    """Factory: _Cursor mocking the personalised ready SQL response.
+
+    Single source of truth for the 12-column tuple + description used by
+    --agent path tests. Extracted to avoid Sonar new_duplicated_lines_density
+    flagging the inline cursor construction across multiple tests.
+    """
+    return _Cursor(
         fetchall_rows=[
             (
                 "KEI-63",
@@ -216,7 +221,7 @@ def test_ready_agent_emits_personalised_score_in_json(mod, patch_connect, capsys
                 "url",
                 None,
                 None,
-                1.7,
+                score,
             ),
         ],
         description=[
@@ -234,6 +239,11 @@ def test_ready_agent_emits_personalised_score_in_json(mod, patch_connect, capsys
             ("personalised_score",),
         ],
     )
+
+
+def test_ready_agent_emits_personalised_score_in_json(mod, patch_connect, capsys) -> None:
+    """JSON output preserves existing keys + adds personalised_score per Max note #3."""
+    cur = _personalised_cursor()
     patch_connect(cur)
     rc = mod.main(["ready", "--agent", "elliot", "--json"])
     assert rc == 0
@@ -243,8 +253,7 @@ def test_ready_agent_emits_personalised_score_in_json(mod, patch_connect, capsys
     assert data[0]["id"] == "KEI-63"
     assert data[0]["title"] == "deprecation"
     assert data[0]["priority"] == 1
-    # New key added.
-    # pytest.approx avoids Sonar S1244 float-equality finding
+    # pytest.approx avoids Sonar S1244 float-equality
     # (per reference_sonarcloud_verify_pattern.md anchored 2026-05-13).
     assert data[0]["personalised_score"] == pytest.approx(1.7)
 
@@ -269,38 +278,7 @@ def test_ready_agent_empty_string_falls_back_to_default(mod, patch_connect) -> N
 
 def test_ready_agent_human_output_includes_score_marker(mod, patch_connect, capsys) -> None:
     """Non-JSON human output for --agent shows [score=X.XX] suffix + personalised banner."""
-    cur = _Cursor(
-        fetchall_rows=[
-            (
-                "KEI-63",
-                "deprecation",
-                1,
-                "available",
-                None,
-                None,
-                None,
-                ["python", "governance"],
-                "url",
-                None,
-                None,
-                1.7,
-            ),
-        ],
-        description=[
-            ("id",),
-            ("title",),
-            ("priority",),
-            ("status",),
-            ("claimed_by",),
-            ("claimed_at",),
-            ("dependencies",),
-            ("tags",),
-            ("linear_url",),
-            ("created_at",),
-            ("updated_at",),
-            ("personalised_score",),
-        ],
-    )
+    cur = _personalised_cursor()
     patch_connect(cur)
     mod.main(["ready", "--agent", "elliot"])
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Adds `--agent <callsign>` flag to `scripts/tasks_cli.py ready` for personalised task ordering
- SQL joins `public.tasks × public.agent_profiles.capability_weights`, computes affinity score, returns deterministic ordering
- 6 new unit tests (22 total pass)

## KEI-53 acceptance criteria — SATISFIED
> "bd ready --agent=elliot returns different ranked tasks than bd ready --agent=scout. Personalisation is working."

## Behavioral test verbatim (live Supabase)
```
=== ELLIOT (orchestration+governance+python) ===
  P1  KEI-63  governance/deprecation  [score=1.70]    ← top
  P1  KEI-61  python+memory+cognee    [score=1.40]
  P1  KEI-51  python+memory+cognee    [score=1.40]
  P2  KEI-54  python+memory           [score=0.80]

=== SCOUT (research+analysis+documentation) ===
  P1  KEI-49  research+analysis+documentation  [score=2.40]  ← top
  P1  KEI-58  research+documentation            [score=1.60]

=== MAX (cognee+memory+python) ===
  P1  KEI-61  python+memory+cognee   [score=2.50]    ← top
  P1  KEI-51  python+memory+cognee   [score=2.50]
  P2  KEI-54  python+memory          [score=1.60]

=== ATLAS (systemd+infrastructure+python) ===
  P1  KEI-56  systemd+infrastructure  [score=1.70]   ← top
  P1  KEI-60  systemd+infrastructure  [score=1.70]
```

Different agents → different top-of-queue. Verified across 4 agents.

## Architecture (Max + Elliot CONCUR Step 0 ts ~1778743640)
- **SQL**: `WHERE status='available' ORDER BY personalised_score DESC, priority ASC, created_at ASC` — deterministic tie-break per Max note #2
- **Schema-probe before code**: `public.tasks.tags` verified as `ARRAY (text[])` via `information_schema.columns` — Max note #1 satisfied
- **JSON compat**: existing keys preserved; only adds `personalised_score: float` — Scout PR #859 webhook receivers + bd-Linear sync unaffected per Max note #3

## Out of scope (separate KEIs)
- `bd complete` EMA recalc hook for `capability_weights`
- `preferred_agent` 1.5× boost
- Legacy `bd` CLI binding (tasks_cli is canonical SSOT per Scout PR #859 + Dave directive)

## Test plan
- [x] `pytest tests/scripts/test_tasks_cli.py -v` → 22/22 pass
- [x] `ruff check + format --check` → clean
- [x] Schema probe → tags column confirmed text[]
- [x] Behavioral test → 4 agents, distinct top-of-queue
- [ ] CI green
- [ ] Sonar gate OK + resolved=false=0

## Post-merge
1. INSERT into `public.task_verifications` with verbatim behavioral test output
2. UPDATE `public.tasks` SET status='done' WHERE id='KEI-53' (trigger gate clears)
3. KEI-53 transitions to Done in Linear

Routing: Max + Elliot FINAL per Aiden 85% park.

🤖 Generated with [Claude Code](https://claude.com/claude-code)