### PR TITLE
[SCOUT] feat(kei22): bd shim — bd ready now reads Supabase tasks (closes the SSOT loop)

### DIFF
--- a/scripts/bd
+++ b/scripts/bd
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# bd — KEI-22 SSOT shim.
+#
+# Intercepts the three queue commands (ready / update --claim / close) and
+# routes them to scripts/tasks_cli.py which queries public.tasks in Supabase
+# (project jatzvazlbusedwsnqxzr). All other bd subcommands fall through to the
+# real Beads binary at $BD_ORIGINAL (default ~/.local/bin/bd-original).
+#
+# Installed at ~/.local/bin/bd by scripts/install_bd_shim.sh, which renames the
+# real binary to bd-original first. Dave directive 2026-05-14: "bd ready
+# returns tasks from Supabase. Run it. If it returns Supabase tasks, paste the
+# output. If it still hits Beads — finish the wiring."
+#
+# Env:
+#   BD_ORIGINAL — path to the renamed real bd binary (default
+#                 ~/.local/bin/bd-original).
+#   AGENCY_OS_REPO — path to repo root (default /home/elliotbot/clawd/Agency_OS).
+#   DATABASE_URL or SUPABASE_DB_URL — postgres DSN (consumed by tasks_cli).
+#   CALLSIGN — claimant identifier (consumed by tasks_cli for claim/close).
+#
+# Exit codes pass through from tasks_cli or bd-original.
+
+set -euo pipefail
+
+BD_ORIGINAL="${BD_ORIGINAL:-$HOME/.local/bin/bd-original}"
+AGENCY_OS_REPO="${AGENCY_OS_REPO:-/home/elliotbot/clawd/Agency_OS}"
+TASKS_CLI="$AGENCY_OS_REPO/scripts/tasks_cli.py"
+AGENCY_OS_ENV="${AGENCY_OS_ENV:-$HOME/.config/agency-os/.env}"
+
+# Auto-load DATABASE_URL / CALLSIGN / etc. from the canonical env file if the
+# parent shell hasn't already set them. This lets every agent's bd-ready hit
+# Supabase without each agent's tmux launcher needing to pre-export anything.
+if [[ -z "${DATABASE_URL:-}${SUPABASE_DB_URL:-}" && -r "$AGENCY_OS_ENV" ]]; then
+    # shellcheck disable=SC1090
+    set -a; source "$AGENCY_OS_ENV"; set +a
+fi
+
+# If tasks_cli is missing (e.g. shim installed but repo moved) fall through to
+# bd-original for everything so we don't break the agent loop.
+if [[ ! -x "$TASKS_CLI" && ! -f "$TASKS_CLI" ]]; then
+    exec "$BD_ORIGINAL" "$@"
+fi
+
+subcmd="${1:-}"
+shift || true
+
+case "$subcmd" in
+    ready)
+        # `bd ready` — list available tasks. JSON shape compatible with the
+        # legacy `bd ready --json` callers (slack_relay self-assign, polling
+        # loops, weekly_cycle_from_bd, pre_compact_alert).
+        exec python3 "$TASKS_CLI" ready "$@"
+        ;;
+    claim|close)
+        # `bd close <id>` → tasks_cli complete <id>.
+        # `bd claim <id>` / `bd claim --any` → tasks_cli claim.
+        # (Beads' `bd update <id> --claim` form is handled in the catch-all.)
+        if [[ "$subcmd" == "close" ]]; then
+            exec python3 "$TASKS_CLI" complete "$@"
+        else
+            exec python3 "$TASKS_CLI" claim "$@"
+        fi
+        ;;
+    update)
+        # `bd update <id> --claim` is the Beads idiom for claiming. Detect it.
+        if [[ "$#" -ge 1 && "$*" == *"--claim"* ]]; then
+            # Extract the id (first positional arg before --claim).
+            id="$1"
+            exec python3 "$TASKS_CLI" claim --id "$id"
+        fi
+        exec "$BD_ORIGINAL" "$subcmd" "$@"
+        ;;
+    show)
+        # `bd show <id>` — Supabase first (if id matches a row), else fall
+        # through to bd-original. Best-effort: ignore Supabase failure.
+        if [[ "$#" -ge 1 ]] && python3 "$TASKS_CLI" show "$1" --json > /dev/null 2>&1; then
+            exec python3 "$TASKS_CLI" show "$@"
+        fi
+        exec "$BD_ORIGINAL" show "$@"
+        ;;
+    "")
+        # No subcommand → bd-original handles help.
+        exec "$BD_ORIGINAL"
+        ;;
+    *)
+        # Everything else (linear sync, dolt, prime, etc.) → real bd.
+        exec "$BD_ORIGINAL" "$subcmd" "$@"
+        ;;
+esac

--- a/scripts/install_bd_shim.sh
+++ b/scripts/install_bd_shim.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# install_bd_shim.sh — KEI-22 install step.
+#
+# Renames the real bd binary to bd-original and installs scripts/bd as the
+# new bd. Idempotent — safe to re-run. Reversible via uninstall_bd_shim.sh.
+#
+# Run once per agent host:
+#   bash scripts/install_bd_shim.sh
+#
+# Dave directive 2026-05-14 (via Elliot): bd ready must return Supabase tasks
+# for all agents.
+
+set -euo pipefail
+
+LOCAL_BIN="${LOCAL_BIN:-$HOME/.local/bin}"
+BD="$LOCAL_BIN/bd"
+BD_ORIGINAL="$LOCAL_BIN/bd-original"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SHIM_SRC="$REPO_ROOT/scripts/bd"
+
+if [[ ! -x "$SHIM_SRC" ]]; then
+    echo "ERROR: shim source not executable: $SHIM_SRC" >&2
+    exit 1
+fi
+
+if [[ ! -e "$BD" ]]; then
+    echo "ERROR: no existing bd binary at $BD — nothing to wrap" >&2
+    exit 1
+fi
+
+# If $BD is already our shim (symlink to repo scripts/bd OR file content
+# matches), skip the rename — we're already installed.
+if [[ -L "$BD" ]] && [[ "$(readlink -f "$BD")" == "$SHIM_SRC" ]]; then
+    echo "shim already installed (symlink to $SHIM_SRC) — nothing to do"
+    exit 0
+fi
+
+# Move the real binary aside if we haven't already.
+if [[ ! -e "$BD_ORIGINAL" ]]; then
+    echo "preserving real bd → bd-original"
+    mv "$BD" "$BD_ORIGINAL"
+elif [[ -e "$BD" && ! -L "$BD" ]]; then
+    # bd-original exists but bd is also a real file → backup conflict.
+    echo "ERROR: both $BD and $BD_ORIGINAL exist as real files. Resolve manually." >&2
+    exit 1
+fi
+
+# Install the shim as $BD via symlink (so repo updates apply immediately).
+ln -sfn "$SHIM_SRC" "$BD"
+chmod +x "$SHIM_SRC"
+
+echo "installed: $BD → $SHIM_SRC"
+echo "preserved: $BD_ORIGINAL"
+echo ""
+echo "Smoke:"
+echo "  bd ready                  # → Supabase tasks (KEI-22 SSOT)"
+echo "  bd linear sync --pull     # → falls through to bd-original"

--- a/scripts/uninstall_bd_shim.sh
+++ b/scripts/uninstall_bd_shim.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# uninstall_bd_shim.sh — reverse install_bd_shim.sh.
+#
+# Removes the shim symlink at ~/.local/bin/bd and restores the real binary
+# from bd-original. Idempotent.
+
+set -euo pipefail
+
+LOCAL_BIN="${LOCAL_BIN:-$HOME/.local/bin}"
+BD="$LOCAL_BIN/bd"
+BD_ORIGINAL="$LOCAL_BIN/bd-original"
+
+if [[ ! -e "$BD_ORIGINAL" ]]; then
+    echo "no bd-original to restore — shim wasn't installed?"
+    exit 0
+fi
+
+# Remove the shim symlink if present.
+if [[ -L "$BD" ]]; then
+    rm "$BD"
+fi
+
+mv "$BD_ORIGINAL" "$BD"
+echo "restored: $BD (real Beads binary)"


### PR DESCRIPTION
## Summary

Dave directive 2026-05-14 (via Elliot): `KEI-22 is incomplete. bd ready must return Supabase tasks. Orion ran bd ready and got Beads stale-queue output. The legacy bd CLI must be replaced with the tasks_cli wrapper OR the bd shim/PATH must route to tasks_cli.`

This PR closes the SSOT loop with a PATH-based shim:
- `scripts/bd` — bash wrapper, intercepts `ready` / `claim` / `close` / `update --claim` / `show`, routes to `scripts/tasks_cli.py` (KEI-22's Supabase CLI shipped in #859).
- All other subcommands (`linear sync`, `dolt`, `prime`, etc.) fall through to the preserved real Beads binary at `~/.local/bin/bd-original`.
- `scripts/install_bd_shim.sh` — one-shot install per agent host (renames real binary, symlinks the shim).
- `scripts/uninstall_bd_shim.sh` — reverse the install.
- Auto-sources `~/.config/agency-os/.env` so agents whose tmux launcher doesn't pre-export `DATABASE_URL`/`SUPABASE_DB_URL` still get the Supabase routing.

## Behavioural verification (the KEI-22 acceptance criterion)

```
$ bd ready
  P1  KEI-60   Weaviate persistent storage governance: volume mount + backup
  P1  KEI-51   bd claim context injection: auto-retrieve prior knowledge
  P1  KEI-56   Resource governance: Weaviate cgroup cap + RAM monitoring
  P1  KEI-58   Discovery staleness governance: context_version + age flags
  P1  KEI-63   Explicit deprecation layer: bd deprecate + environment invalidation
  P1  KEI-61   Durable indexing queue: Supabase staging buffer for webhooks
  P1  KEI-49   LlamaIndex OSS: retrieval orchestration layer over Weaviate
  P2  KEI-54   Claude Code tool call log export into Weaviate
  8 available
```

That output is direct from `public.tasks` (Supabase, project `jatzvazlbusedwsnqxzr`) — NOT the Beads Dolt DB. Verbatim record inserted into `public.task_verifications` id=`bb5f7288-8f76-4615-8a60-8f88cb4350a3` (satisfies the `require_verification_before_done()` trigger).

## Per-agent install

Each agent host runs `bash scripts/install_bd_shim.sh` once. Atlas KEI-43 systemd-agent provisioning is the right place to chain this in for new clones (follow-up KEI). For now Orion + Aiden + Max + Elliot run the install script manually to get Supabase routing.

## Test plan

- [x] `bd ready` returns Supabase tasks (verified inline above)
- [x] Verbatim output captured + inserted to `task_verifications`
- [x] Shim falls through to real bd for non-queue subcommands (verified by command shape; `bd linear sync` will exec bd-original)
- [x] `.env` auto-source works under `env -i` (no pre-exported DATABASE_URL)
- [x] Idempotent install (re-running install_bd_shim.sh detects already-installed state)

Refs: Linear KEI-22, tasks-table id `KEI-22` re-claimed by scout after the original verification-trigger refusal. PR #859 (tasks_cli + Linear webhook tasks dispatch) shipped the Supabase surface; this PR wires the bd CLI caller surface to it.

🤖 Authored by [SCOUT] (Sonnet 4.6 research clone)