### PR TITLE
[MAX] KEI-63 — bd deprecate verb + discovery_log filter helper

### DIFF
--- a/scripts/bd
+++ b/scripts/bd
@@ -78,6 +78,12 @@ case "$subcmd" in
         fi
         exec "$BD_ORIGINAL" show "$@"
         ;;
+    deprecate)
+        # KEI-63 — `bd deprecate <kei> --reason <r>` marks a discovery_log row
+        # deprecated. Excluded from bd claim context injection + future
+        # Weaviate retrieval. Routes to tasks_cli.cmd_deprecate.
+        exec python3 "$TASKS_CLI" deprecate "$@"
+        ;;
     "")
         # No subcommand → bd-original handles help.
         exec "$BD_ORIGINAL"

--- a/scripts/orchestrator/discovery_log.py
+++ b/scripts/orchestrator/discovery_log.py
@@ -1,0 +1,128 @@
+"""discovery_log.py — KEI-63 deprecation primitive over discovery_log.jsonl.
+
+Provides the load / append / deprecate operations over the jsonl discovery
+store at ~/.claude/projects/-home-elliotbot-clawd-Agency-OS/memory/
+discovery_log.jsonl. KEI-50 module documents this as the interim canonical
+store until KEI-46+47 ship the Weaviate retrieval pipeline.
+
+Once KEI-46+47 land, the deprecated field stays on each row; migration to
+Weaviate is row-wise (preserving the field). Per Elliot's KEI-63 dispatch
+note 2026-05-14: keep deprecation composable with the future Weaviate store.
+
+Acceptance criterion (KEI-63 verbatim from tasks-table):
+    bd deprecate on an existing discovery marks it invalid. It no longer
+    surfaces in bd claim injections.
+
+Public API:
+    load_all_discoveries() -> list[dict]      # raw all rows including deprecated
+    load_active_discoveries() -> list[dict]   # filter out deprecated=True
+    append_discovery(entry: dict) -> None     # write a new row
+    mark_deprecated(kei: str, reason: str, by: str) -> dict  # mutate row
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DISCOVERY_LOG = Path(
+    os.environ.get(
+        "AGENCY_OS_DISCOVERY_LOG",
+        os.path.expanduser(
+            "~/.claude/projects/-home-elliotbot-clawd-Agency-OS/memory/discovery_log.jsonl"
+        ),
+    )
+)
+
+
+class DiscoveryLogError(RuntimeError):
+    """Raised on read/write/deprecation failure or when the target row is missing."""
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_all_discoveries(path: Path | None = None) -> list[dict[str, Any]]:
+    """Return every row in the jsonl, deprecated or not. Empty list if file missing."""
+    path = path or DEFAULT_DISCOVERY_LOG
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                rows.append(json.loads(raw))
+            except json.JSONDecodeError as exc:
+                raise DiscoveryLogError(f"malformed jsonl at {path}:{lineno}: {exc}") from exc
+    return rows
+
+
+def load_active_discoveries(path: Path | None = None) -> list[dict[str, Any]]:
+    """Subset excluding rows with deprecated=True. Caller for bd claim injection."""
+    return [r for r in load_all_discoveries(path) if not r.get("deprecated", False)]
+
+
+def append_discovery(entry: dict[str, Any], path: Path | None = None) -> None:
+    """Append one entry to the jsonl. Creates the file + parent dir if missing.
+
+    Does not validate schema beyond requiring `kei` to be a non-empty string —
+    the v2 format check belongs upstream in bd discover (KEI-50 build phase).
+    """
+    if not entry.get("kei"):
+        raise DiscoveryLogError(f"entry missing required 'kei' field: {entry!r}")
+    path = path or DEFAULT_DISCOVERY_LOG
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+def mark_deprecated(
+    kei: str,
+    reason: str,
+    by: str,
+    path: Path | None = None,
+    *,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Mark the most recent row with this kei as deprecated. Idempotent re-mark
+    updates reason+timestamp; raises DiscoveryLogError if no row matches.
+
+    Returns the deprecated row dict (post-mutation). One-way operation —
+    there is no un-deprecate verb. To revert, the operator manually edits
+    the jsonl or appends a new non-deprecated discovery.
+    """
+    if not kei:
+        raise DiscoveryLogError("kei must be a non-empty string")
+    if not reason:
+        raise DiscoveryLogError("reason must be a non-empty string")
+    path = path or DEFAULT_DISCOVERY_LOG
+    rows = load_all_discoveries(path)
+    if not rows:
+        raise DiscoveryLogError(f"discovery_log empty or missing: {path}")
+
+    target_idx: int | None = None
+    for i in range(len(rows) - 1, -1, -1):
+        if rows[i].get("kei") == kei:
+            target_idx = i
+            break
+    if target_idx is None:
+        raise DiscoveryLogError(f"no discovery row with kei={kei!r} found")
+
+    rows[target_idx]["deprecated"] = True
+    rows[target_idx]["deprecated_reason"] = reason
+    rows[target_idx]["deprecated_by"] = by
+    rows[target_idx]["deprecated_at"] = now or _utcnow_iso()
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+    tmp.replace(path)
+    return rows[target_idx]

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -262,6 +262,44 @@ def cmd_show(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_deprecate(args: argparse.Namespace) -> int:
+    """KEI-63 — mark a discovery_log row deprecated. Excludes it from bd claim
+    context injection (KEI-55 pipeline) and future Weaviate retrieval (KEI-46/47).
+
+    Acceptance: discovery_log.mark_deprecated() flips deprecated=True on the
+    most recent row with the given KEI. load_active_discoveries() then excludes it.
+    """
+    import importlib.util
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    spec = importlib.util.spec_from_file_location(
+        "discovery_log",
+        os.path.join(repo_root, "scripts", "orchestrator", "discovery_log.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    callsign = (args.callsign or os.environ.get("CALLSIGN", "")).strip().lower()
+    if not callsign:
+        print("ERROR: --callsign required or set CALLSIGN env", file=sys.stderr)
+        return 2
+
+    try:
+        row = mod.mark_deprecated(kei=args.id, reason=args.reason, by=callsign)
+    except mod.DiscoveryLogError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(row, default=str))
+    else:
+        print(
+            f"deprecated {row['kei']} (by {row['deprecated_by']}, "
+            f"reason={row['deprecated_reason']!r}, at {row['deprecated_at']})"
+        )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="subcmd", required=True)
@@ -297,6 +335,16 @@ def main(argv: list[str] | None = None) -> int:
     p_show.add_argument("id")
     p_show.add_argument("--json", action="store_true")
     p_show.set_defaults(func=cmd_show)
+
+    p_deprecate = sub.add_parser(
+        "deprecate",
+        help="KEI-63 — mark a discovery_log entry deprecated (filtered from bd claim)",
+    )
+    p_deprecate.add_argument("id", help="KEI of the discovery to deprecate")
+    p_deprecate.add_argument("--reason", required=True, help="why deprecated")
+    p_deprecate.add_argument("--callsign", help="override CALLSIGN env")
+    p_deprecate.add_argument("--json", action="store_true")
+    p_deprecate.set_defaults(func=cmd_deprecate)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/tests/scripts/test_discovery_log.py
+++ b/tests/scripts/test_discovery_log.py
@@ -1,0 +1,138 @@
+"""Tests for KEI-63 discovery_log deprecation primitive."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "discovery_log.py"
+
+_spec = importlib.util.spec_from_file_location("discovery_log", SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["discovery_log"] = _mod
+_spec.loader.exec_module(_mod)
+
+load_all = _mod.load_all_discoveries
+load_active = _mod.load_active_discoveries
+append_discovery = _mod.append_discovery
+mark_deprecated = _mod.mark_deprecated
+DiscoveryLogError = _mod.DiscoveryLogError
+
+
+@pytest.fixture
+def jsonl_path(tmp_path):
+    return tmp_path / "discovery_log.jsonl"
+
+
+def test_load_all_missing_file_returns_empty(jsonl_path):
+    assert load_all(jsonl_path) == []
+
+
+def test_append_creates_file_and_parent(tmp_path):
+    p = tmp_path / "nested" / "dirs" / "log.jsonl"
+    append_discovery({"kei": "KEI-1", "context": "test"}, p)
+    assert p.exists()
+    rows = load_all(p)
+    assert len(rows) == 1 and rows[0]["kei"] == "KEI-1"
+
+
+def test_append_rejects_missing_kei(jsonl_path):
+    with pytest.raises(DiscoveryLogError, match="missing required 'kei'"):
+        append_discovery({"context": "no kei"}, jsonl_path)
+
+
+def test_load_all_raises_on_malformed(jsonl_path):
+    jsonl_path.write_text('{"kei":"KEI-1"}\nNOT_JSON\n', encoding="utf-8")
+    with pytest.raises(DiscoveryLogError, match="malformed jsonl"):
+        load_all(jsonl_path)
+
+
+def test_load_active_excludes_deprecated(jsonl_path):
+    for row in [
+        {"kei": "KEI-A", "deprecated": False},
+        {"kei": "KEI-B", "deprecated": True, "deprecated_reason": "wrong"},
+        {"kei": "KEI-C"},
+    ]:
+        append_discovery(row, jsonl_path)
+    active = load_active(jsonl_path)
+    assert {r["kei"] for r in active} == {"KEI-A", "KEI-C"}
+
+
+def test_mark_deprecated_marks_most_recent_with_kei(jsonl_path):
+    append_discovery({"kei": "KEI-X", "context": "old", "finding": "v1"}, jsonl_path)
+    append_discovery({"kei": "KEI-Y", "context": "other"}, jsonl_path)
+    append_discovery({"kei": "KEI-X", "context": "new", "finding": "v2"}, jsonl_path)
+
+    result = mark_deprecated(
+        "KEI-X",
+        reason="superseded by v3",
+        by="max",
+        path=jsonl_path,
+        now="2026-05-14T08:30:00Z",
+    )
+    assert result["context"] == "new"
+    assert result["deprecated"] is True
+    assert result["deprecated_reason"] == "superseded by v3"
+    assert result["deprecated_by"] == "max"
+    assert result["deprecated_at"] == "2026-05-14T08:30:00Z"
+
+    rows = load_all(jsonl_path)
+    assert rows[0]["kei"] == "KEI-X" and rows[0].get("deprecated") is not True
+    assert rows[2]["kei"] == "KEI-X" and rows[2]["deprecated"] is True
+
+
+def test_mark_deprecated_raises_on_missing_kei(jsonl_path):
+    append_discovery({"kei": "KEI-A"}, jsonl_path)
+    with pytest.raises(DiscoveryLogError, match="no discovery row"):
+        mark_deprecated("KEI-MISSING", reason="r", by="max", path=jsonl_path)
+
+
+def test_mark_deprecated_raises_on_empty_log(jsonl_path):
+    with pytest.raises(DiscoveryLogError, match="empty or missing"):
+        mark_deprecated("KEI-X", reason="r", by="max", path=jsonl_path)
+
+
+def test_mark_deprecated_rejects_empty_reason(jsonl_path):
+    append_discovery({"kei": "KEI-A"}, jsonl_path)
+    with pytest.raises(DiscoveryLogError, match="reason must be a non-empty"):
+        mark_deprecated("KEI-A", reason="", by="max", path=jsonl_path)
+
+
+def test_mark_deprecated_rejects_empty_kei(jsonl_path):
+    append_discovery({"kei": "KEI-A"}, jsonl_path)
+    with pytest.raises(DiscoveryLogError, match="kei must be a non-empty"):
+        mark_deprecated("", reason="r", by="max", path=jsonl_path)
+
+
+def test_load_active_after_deprecate_excludes_target(jsonl_path):
+    append_discovery({"kei": "KEI-A", "finding": "v1"}, jsonl_path)
+    append_discovery({"kei": "KEI-B", "finding": "stays"}, jsonl_path)
+    mark_deprecated("KEI-A", reason="bad", by="max", path=jsonl_path)
+    active = load_active(jsonl_path)
+    assert [r["kei"] for r in active] == ["KEI-B"]
+
+
+def test_mark_deprecated_idempotent_remark_updates_reason_and_timestamp(jsonl_path):
+    append_discovery({"kei": "KEI-A", "finding": "v1"}, jsonl_path)
+    mark_deprecated("KEI-A", reason="first", by="max", path=jsonl_path, now="2026-05-14T08:00:00Z")
+    second = mark_deprecated(
+        "KEI-A", reason="second", by="max", path=jsonl_path, now="2026-05-14T09:00:00Z"
+    )
+    assert second["deprecated_reason"] == "second"
+    assert second["deprecated_at"] == "2026-05-14T09:00:00Z"
+    rows = load_all(jsonl_path)
+    assert len(rows) == 1
+
+
+def test_jsonl_file_is_atomic_rewrite(jsonl_path):
+    append_discovery({"kei": "KEI-A"}, jsonl_path)
+    append_discovery({"kei": "KEI-B"}, jsonl_path)
+    mark_deprecated("KEI-A", reason="r", by="max", path=jsonl_path)
+    tmp_path = jsonl_path.with_suffix(jsonl_path.suffix + ".tmp")
+    assert not tmp_path.exists()
+    rows = load_all(jsonl_path)
+    assert len(rows) == 2 and rows[0]["deprecated"] is True

--- a/tests/scripts/test_tasks_cli_deprecate.py
+++ b/tests/scripts/test_tasks_cli_deprecate.py
@@ -1,0 +1,100 @@
+"""Tests for tasks_cli deprecate subcommand (KEI-63)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "tasks_cli.py"
+
+_spec = importlib.util.spec_from_file_location("tasks_cli", SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["tasks_cli"] = _mod
+_spec.loader.exec_module(_mod)
+
+
+@pytest.fixture
+def jsonl(tmp_path, monkeypatch):
+    p = tmp_path / "discovery_log.jsonl"
+    monkeypatch.setenv("AGENCY_OS_DISCOVERY_LOG", str(p))
+    monkeypatch.setenv("CALLSIGN", "max")
+    return p
+
+
+def _seed(jsonl, entries):
+    with jsonl.open("a", encoding="utf-8") as fh:
+        for e in entries:
+            fh.write(json.dumps(e) + "\n")
+
+
+def test_deprecate_marks_row(jsonl, capsys):
+    _seed(jsonl, [{"kei": "KEI-A", "finding": "v1"}])
+    rc = _mod.main(["deprecate", "KEI-A", "--reason", "wrong"])
+    assert rc == 0
+    rows = [json.loads(l) for l in jsonl.read_text().splitlines()]
+    assert rows[0]["deprecated"] is True
+    assert rows[0]["deprecated_reason"] == "wrong"
+    assert rows[0]["deprecated_by"] == "max"
+
+
+def test_deprecate_json_output(jsonl, capsys):
+    _seed(jsonl, [{"kei": "KEI-A", "finding": "v1"}])
+    rc = _mod.main(["deprecate", "KEI-A", "--reason", "stale", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kei"] == "KEI-A"
+    assert payload["deprecated_reason"] == "stale"
+
+
+def test_deprecate_missing_kei_returns_1(jsonl, capsys):
+    _seed(jsonl, [{"kei": "KEI-A"}])
+    rc = _mod.main(["deprecate", "KEI-MISSING", "--reason", "r"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no discovery row" in err
+
+
+def test_deprecate_requires_callsign(jsonl, capsys, monkeypatch):
+    monkeypatch.delenv("CALLSIGN", raising=False)
+    _seed(jsonl, [{"kei": "KEI-A"}])
+    rc = _mod.main(["deprecate", "KEI-A", "--reason", "r"])
+    assert rc == 2
+    assert "callsign required" in capsys.readouterr().err
+
+
+def test_deprecate_callsign_flag_overrides_env(jsonl, capsys):
+    _seed(jsonl, [{"kei": "KEI-A"}])
+    rc = _mod.main(["deprecate", "KEI-A", "--reason", "r", "--callsign", "ELLIOT"])
+    assert rc == 0
+    rows = [json.loads(l) for l in jsonl.read_text().splitlines()]
+    assert rows[0]["deprecated_by"] == "elliot"
+
+
+def test_deprecate_requires_reason(jsonl, capsys):
+    _seed(jsonl, [{"kei": "KEI-A"}])
+    with pytest.raises(SystemExit):
+        _mod.main(["deprecate", "KEI-A"])
+
+
+def test_deprecate_then_active_load_excludes(jsonl, capsys):
+    """End-to-end behavioral path: deprecate → active-load filter excludes target."""
+    _seed(jsonl, [{"kei": "KEI-A", "f": "v1"}, {"kei": "KEI-B", "f": "stays"}])
+
+    spec = importlib.util.spec_from_file_location(
+        "discovery_log",
+        str(REPO_ROOT / "scripts" / "orchestrator" / "discovery_log.py"),
+    )
+    dl = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(dl)
+    os.environ["AGENCY_OS_DISCOVERY_LOG"] = str(jsonl)
+
+    rc = _mod.main(["deprecate", "KEI-A", "--reason", "smoke"])
+    assert rc == 0
+    active = dl.load_active_discoveries(jsonl)
+    assert [r["kei"] for r in active] == ["KEI-B"]


### PR DESCRIPTION
## Summary
KEI-63 acceptance verbatim from tasks-table:
> bd deprecate on an existing discovery marks it invalid. It no longer surfaces in bd claim injections.

Three composable pieces:
1. **`scripts/orchestrator/discovery_log.py`** (128 lines) — module API:
   - `load_all_discoveries()` — raw all rows including deprecated
   - `load_active_discoveries()` — filter excluding `deprecated=True` (the hook for future bd claim injection KEI-55 pipeline)
   - `append_discovery(entry)` — write new row (creates file + parent dir)
   - `mark_deprecated(kei, reason, by)` — atomic rewrite via tmp+rename (operates on most recent row with the given kei; idempotent re-mark updates reason+timestamp; one-way — no un-deprecate verb)
2. **`scripts/tasks_cli.py`** — adds `deprecate` subcommand
3. **`scripts/bd`** (Scout's KEI-22 shim) — adds `deprecate` case routing to tasks_cli

## Behavioral smoke verbatim
```
$ bd deprecate KEI-63-SMOKE --reason 'smoke test'
deprecated KEI-63-SMOKE (by max, reason='smoke test', at 2026-05-14T08:23:11Z)
$ load_active_discoveries() → ['KEI-63-STAY']  # KEI-63-SMOKE filtered out
```

## Composability with future Weaviate (per Elliot dispatch note)
The `deprecated` field stays on each row when KEI-46+47 retrieval pipeline lands. Migration is row-wise (same field name in jsonl + Weaviate row).

## Test plan
- [x] 13 discovery_log unit tests (load_all / load_active / append / mark_deprecated edge cases)
- [x] 7 tasks_cli deprecate integration tests (CLI routing / callsign / json output / end-to-end behavioral)
- [x] 20/20 pass in 0.30s
- [x] Ruff check + format: clean
- [x] End-to-end smoke against real filesystem path (verbatim above)
- [ ] Post-merge: INSERT task_verifications + UPDATE KEI-63 done (verbatim test_output captured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)