### PR TITLE
[ATLAS] feat(kei56): resource governance — Weaviate cgroup cap + RAM monitoring

### DIFF
--- a/docs/runbooks/resource-monitor.md
+++ b/docs/runbooks/resource-monitor.md
@@ -1,0 +1,100 @@
+# Resource governance — Weaviate cgroup cap + RAM monitoring (KEI-56)
+
+**Linear:** [KEI-56](https://linear.app/keiracom/issue/KEI-56) · **Author:** Atlas · **Driver:** Dave verbatim — "we crashed the server once already from an uncapped process. we must not repeat this."
+
+Three layers of defence against host OOM:
+
+1. **Hard cgroup caps** — Weaviate (2.5G via KEI-48 `weaviate_capped.sh`), Cognee (3G via KEI-44 `cognee_capped.sh`), agent sessions (per `*-agent.service` from KEI-43).
+2. **Continuous monitor** — `resource-monitor.service` writes a snapshot every 60s to `public.audit_logs.resource_snapshot` and alerts `#ceo` when any cgroup ≥ 90% of its cap.
+3. **Pre-deployment check** — `preflight_resources.py` blocks a new service from starting when `MemAvailable < 2GB`.
+
+## resource_snapshot JSON schema
+
+`public.audit_logs.resource_snapshot` JSONB blob, one row per cycle:
+
+```json
+{
+  "total_mb": 7935,
+  "used_mb": 5239,
+  "free_mb": 2696,
+  "load_avg": [0.5, 1.0, 1.5],
+  "disk_used_pct": 39,
+  "cgroups": {
+    "weaviate-922166.scope": {"memory_mb": 45, "memory_max_mb": 2560, "pct_of_cap": 1.8},
+    "cognee.service":         {"memory_mb": 412, "memory_max_mb": 3072, "pct_of_cap": 13.4}
+  },
+  "thresholds_breached": [
+    {"unit": "cognee.service", "pct": 91.1, "memory_mb": 2799}
+  ],
+  "captured_at": "2026-05-14T08:19:30.943+00:00"
+}
+```
+
+`thresholds_breached` is populated when any cgroup ≥ `RESOURCE_MONITOR_WARN_PCT` (default 90%). Each breach triggers one `#ceo` post per onset (deduped while the breach persists; cleared once the cgroup drops back under threshold).
+
+## Install (one-time, post-merge)
+
+```bash
+# 1. Migration (already-applied to live Supabase at install time; idempotent).
+psql "$DATABASE_URL_MIGRATIONS" < /home/elliotbot/clawd/Agency_OS/supabase/migrations/20260514_audit_logs_resource_snapshot.sql
+
+# 2. Install monitor systemd unit.
+install -D -m 0644 \
+    /home/elliotbot/clawd/Agency_OS/infra/systemd/agents/resource-monitor.service \
+    /home/elliotbot/.config/systemd/user/resource-monitor.service
+mkdir -p /home/elliotbot/clawd/logs
+systemctl --user daemon-reload
+systemctl --user enable --now resource-monitor.service
+systemctl --user status resource-monitor.service   # confirm Active=running
+
+# 3. Smoke (one cycle, prints + writes one row).
+python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/resource_monitor.py --once
+```
+
+## Preflight check (use before starting any new resource-intensive service)
+
+```bash
+# Defaults: 2 GB headroom required. Exit 0 = OK to start. Exit 1 = blocked.
+python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/preflight_resources.py \
+    --headroom-mb 2048 \
+    --service weaviate
+echo "exit=$?"
+```
+
+Wire as systemd `ExecStartPre=` to block service start when host is under pressure:
+
+```ini
+[Service]
+ExecStartPre=/home/elliotbot/clawd/venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/preflight_resources.py --headroom-mb 2048 --service weaviate
+ExecStart=...
+```
+
+## Tuning env vars
+
+| Env | Default | Purpose |
+|---|---|---|
+| `RESOURCE_MONITOR_INTERVAL_SECONDS` | `60` | Snapshot cadence |
+| `RESOURCE_MONITOR_WARN_PCT` | `90` | Cgroup breach threshold |
+| `RESOURCE_MONITOR_DISK_PATH` | `/home/elliotbot/clawd` | Disk-usage probe path |
+| `RESOURCE_MONITOR_CGROUP_ROOT` | `/sys/fs/cgroup/user.slice` | Root of cgroup walk |
+
+## Verification snapshot (install-time, 2026-05-14)
+
+```
+$ python3 scripts/orchestrator/resource_monitor.py --once
+2026-05-14 08:20:25,352 INFO: resource_monitor starting (interval=60s, warn_pct=90%, disk=/home/elliotbot/clawd, once=True)
+(silent — no breaches, snapshot written)
+
+$ psql -c "SELECT action, resource_snapshot->>'total_mb', resource_snapshot->>'used_mb', resource_snapshot->>'free_mb' FROM public.audit_logs WHERE action='resource_snapshot' ORDER BY created_at DESC LIMIT 1"
+action=resource_snapshot total_mb=7935 used_mb=5239 free_mb=2696
+
+$ python3 scripts/orchestrator/preflight_resources.py --service weaviate
+2026-05-14 08:19:31,086 INFO: preflight OK: weaviate — available=2796MB >= required=2048MB
+```
+
+## Related
+
+- KEI-43 — agent auto-start systemd services (merged `afdb692a`). Each agent has its own cgroup; the monitor picks them up automatically.
+- KEI-44 — Cognee 3 GB memory cap (merged `3b133132`). Same `*_capped.sh` pattern as Weaviate; the monitor reads `/sys/fs/cgroup/user.slice/.../memory.{current,max}` for both.
+- KEI-48 — Weaviate install (merged `a97ebebb`). Weaviate runs under `MemoryMax=2.5G` via `weaviate_capped.sh`.
+- Spec source: Linear KEI-56 description (3 fix parts: cgroup cap, continuous monitoring, pre-deployment check).

--- a/docs/runbooks/weaviate-install.md
+++ b/docs/runbooks/weaviate-install.md
@@ -1,0 +1,165 @@
+# Weaviate install on Vultr Sydney (KEI-48)
+
+**Linear:** [KEI-48](https://linear.app/keiracom/issue/KEI-48) · **Author:** Atlas · **Driver:** Dave verbatim 2026-05-14 06:39 AEST
+
+Foundation of the entire memory system. 12 downstream KEIs cannot start until
+Weaviate is installed. This runbook documents the **native-binary** install
+chosen because Docker is not installed on the Vultr Sydney host (per Elliot
+ts ~1778742500 pick of option (b)).
+
+## Acceptance criteria (all verified empirically at install time)
+
+| Criterion | How verified | Evidence |
+|---|---|---|
+| Weaviate process running | `systemctl --user list-units --type=scope` | `weaviate-<PID>.scope loaded active running` |
+| Cgroup MemoryMax=2.5G enforced | `systemctl --user show <scope>.scope --property=MemoryMax` | `MemoryMax=2684354560` (= 2.5 GiB) |
+| `/v1/meta` returns version | `curl http://127.0.0.1:8090/v1/meta` | `{"version":"1.37.3", ...}` |
+| 5 collections present | `curl http://127.0.0.1:8090/v1/schema` | `Codebase, Decisions, Discoveries, Keis, Sessions` |
+| Mandatory properties on every class | `infra/weaviate/smoke_test.py` step [2/5] | All 5 classes have `raw_text/environment_hash/created_at/agent/kei` |
+| Probe insert+retrieve+delete | `infra/weaviate/smoke_test.py` steps [3-5/5] | UUID round-trip verified |
+| Persistent volume mount | `ls -la /home/elliotbot/clawd/weaviate-data` | `classifications.db` + per-collection dirs created post-startup |
+
+## One-time install
+
+### Prerequisites
+
+- `loginctl show-user elliotbot --property=Linger` → `Linger=yes` (required for
+  `systemctl --user enable` to persist across reboots)
+- Port 8090 free (`ss -ltn | grep :8090` returns empty) — 8080 is held by crowdsec
+- `/home/elliotbot/clawd/Agency_OS/` worktree on `main` with the KEI-48 PR merged
+
+### Steps
+
+```bash
+# 1. Create directories.
+mkdir -p /home/elliotbot/clawd/weaviate-bin /home/elliotbot/clawd/weaviate-data
+
+# 2. Download Weaviate v1.37.3 linux-amd64 + verify SHA-256.
+cd /home/elliotbot/clawd/weaviate-bin
+curl -L -o weaviate-v1.37.3-linux-amd64.tar.gz \
+    https://github.com/weaviate/weaviate/releases/download/v1.37.3/weaviate-v1.37.3-linux-amd64.tar.gz
+curl -L -o weaviate-v1.37.3-linux-amd64.tar.gz.sha256 \
+    https://github.com/weaviate/weaviate/releases/download/v1.37.3/weaviate-v1.37.3-linux-amd64.tar.gz.sha256
+sha256sum -c weaviate-v1.37.3-linux-amd64.tar.gz.sha256
+# Expected: cbdefcd2205fef65cbc206e45194afac7a1965d1420e0baf711c20370c7747bf
+
+# 3. Extract binary.
+tar xzf weaviate-v1.37.3-linux-amd64.tar.gz
+chmod +x weaviate
+
+# 4. Install systemd-user unit (from the merged PR).
+install -D -m 0644 \
+    /home/elliotbot/clawd/Agency_OS/infra/systemd/agents/weaviate.service \
+    /home/elliotbot/.config/systemd/user/weaviate.service
+mkdir -p /home/elliotbot/clawd/logs
+
+# 5. Reload + enable + start.
+systemctl --user daemon-reload
+systemctl --user enable --now weaviate.service
+sleep 8   # Raft single-node bootstrap takes 4-6s on a warm host
+
+# 6. Verify readiness.
+curl -s -o /dev/null -w 'ready=%{http_code}\n' http://127.0.0.1:8090/v1/.well-known/ready   # expect ready=200
+curl -s http://127.0.0.1:8090/v1/meta | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])"   # expect 1.37.3
+
+# 7. Apply schema (idempotent — re-runs only add missing collections).
+cd /home/elliotbot/clawd/Agency_OS
+python3 infra/weaviate/schema.py --host 127.0.0.1 --port 8090
+
+# 8. Run smoke test.
+python3 infra/weaviate/smoke_test.py --host 127.0.0.1 --port 8090
+# Expect: "KEI-48 SMOKE PASSED — Weaviate 1.37.3 reachable, schema valid, round-trip OK."
+```
+
+## Why native binary, not Docker
+
+Empirical env check on Vultr Sydney 2026-05-14 found:
+
+- **`docker: command not found`** — no docker/podman/containerd/runc on PATH;
+  no `docker.service` unit; no `dpkg -l docker*` entries. Docker is not installed.
+- **Port 8080 held by `crowdsec` (pid 1632)** — Weaviate's default port is
+  unavailable; runbook uses **8090** instead.
+- **Memory pressure baseline** — 7.7G total, 4.2G used + 3.9G swap in use.
+  Cgroup hard ceiling at 2.5G via `systemd-run --user --scope -p MemoryMax=2.5G`
+  prevents Weaviate from OOM-killing the host (Cognee OOM precedent KEI-44).
+
+Native binary install:
+- Avoids the install-Docker yak-shave.
+- Cleaner cgroup integration — `systemd-run --user --scope` wraps the binary
+  directly, exactly as `cognee_capped.sh` (KEI-44) wraps `cognee_ingest.py`.
+- Smaller attack surface, faster start, smaller disk footprint.
+
+The wrapper is `scripts/orchestrator/weaviate_capped.sh`; the unit is
+`infra/systemd/agents/weaviate.service`; both mirror the KEI-44 + KEI-43 patterns.
+
+## Configuration env vars
+
+| Env | Default | Purpose |
+|---|---|---|
+| `WEAVIATE_BIN` | `/home/elliotbot/clawd/weaviate-bin/weaviate` | Path to extracted binary |
+| `WEAVIATE_HOST` | `127.0.0.1` | Loopback-only bind (reverse-proxy if exposing) |
+| `WEAVIATE_PORT` | `8090` | crowdsec holds 8080; 8090 free |
+| `WEAVIATE_DATA_DIR` | `/home/elliotbot/clawd/weaviate-data` | Persistent volume mount target |
+| `AGENCY_OS_WEAVIATE_MAX_MEM` | `2.5G` | Cgroup ceiling — KEI-56 pre-condition |
+| `CLUSTER_HOSTNAME` | `node1` | Single-node Raft cluster name |
+| `CLUSTER_ADVERTISE_ADDR` | `127.0.0.1` | Single-node Raft advertise (Vultr has no private IP) |
+| `RAFT_JOIN` | `node1` | Self-join for single-node bootstrap |
+| `DEFAULT_VECTORIZER_MODULE` | `none` | Schema doc convention: explicit vectors only |
+| `AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED` | `true` | Loopback-only host; auth at reverse-proxy layer |
+
+## Schema convention (per `docs/schema/weaviate-schema-requirements.md`)
+
+Every collection has these 5 properties (4 mandatory + 1 optional):
+
+```json
+{"name": "raw_text",         "dataType": ["text"]}   // mandatory — re-embedding insurance
+{"name": "environment_hash", "dataType": ["text"]}   // mandatory — reproducible re-embedding (KEI-60)
+{"name": "created_at",       "dataType": ["date"]}   // mandatory — ISO-8601 UTC
+{"name": "agent",            "dataType": ["text"]}   // mandatory — callsign or 'system'
+{"name": "kei",              "dataType": ["text"]}   // optional — KEI ID that triggered the write
+```
+
+`vectorizer=none` — agents write vectors directly using the
+`AGENCY_OS_EMBEDDING_MODEL`-pinned model (`gemini-embedding-001` by default).
+Server-side vectorization is deliberately disabled to keep model pinning explicit
+across the corpus.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `systemctl status weaviate.service` shows `code=exited` | Binary or data dir missing | Re-run install steps 1-3 |
+| `503 Service Unavailable` on `/v1/.well-known/ready` | Raft still bootstrapping (4-6s after start) | Wait 8s, retry |
+| `failed to get final advertise address: no private IP` | Cluster env vars missing | Verify `CLUSTER_ADVERTISE_ADDR=127.0.0.1` exported (already in `weaviate_capped.sh`) |
+| `address already in use :8090` | Old scope unit stuck | `systemctl --user stop 'weaviate-*.scope'` then restart |
+| Cgroup cap not enforced | Wrapper bypassed | Ensure unit's `ExecStart` points at `weaviate_capped.sh`, not at the bare binary |
+
+## Verification snapshot (install-time, 2026-05-14)
+
+```
+$ systemctl --user show weaviate-922166.scope --property=MemoryMax,MemoryAccounting,MemoryCurrent
+MemoryCurrent=45776896
+MemoryAccounting=yes
+MemoryMax=2684354560
+
+$ python3 infra/weaviate/smoke_test.py --host 127.0.0.1 --port 8090
+[1/5] GET http://127.0.0.1:8090/v1/meta
+      version=1.37.3
+[2/5] GET http://127.0.0.1:8090/v1/schema — expect classes=['Codebase', 'Decisions', 'Discoveries', 'Keis', 'Sessions']
+      OK: all 5 classes present
+[3/5] POST http://127.0.0.1:8090/v1/objects (id=137aac2b-..., class=Discoveries)
+      OK: insert response id=137aac2b-...
+[4/5] GET  http://127.0.0.1:8090/v1/objects/Discoveries/137aac2b-...
+      OK: round-trip raw_text contains obj_id
+[5/5] DELETE http://127.0.0.1:8090/v1/objects/Discoveries/137aac2b-...
+      OK: probe cleaned up
+KEI-48 SMOKE PASSED — Weaviate 1.37.3 reachable, schema valid, round-trip OK.
+```
+
+## Related
+
+- KEI-43 — agent auto-start systemd services (merged `afdb692a`); same systemd-user pattern as this unit.
+- KEI-44 — Cognee 3GB memory cap (merged `3b133132`); `cognee_capped.sh` is the wrapper pattern this runbook copies.
+- KEI-56 — memory-cap policy (this is one of its pre-conditions).
+- KEI-60 — embedding-model-independence + re_embed_corpus.py; the schema convention above implements the property contract.
+- 12 downstream KEIs blocked on this install (per Dave verbatim ts ~1778742300).

--- a/infra/systemd/agents/resource-monitor.service
+++ b/infra/systemd/agents/resource-monitor.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Agency OS resource monitor (KEI-56: cgroup + RAM → audit_logs)
+Documentation=https://linear.app/keiracom/issue/KEI-56
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+ExecStart=/home/elliotbot/clawd/venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/resource_monitor.py
+Restart=on-failure
+RestartSec=30
+StandardOutput=append:/home/elliotbot/clawd/logs/resource-monitor.log
+StandardError=append:/home/elliotbot/clawd/logs/resource-monitor.log
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/agents/weaviate.service
+++ b/infra/systemd/agents/weaviate.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Weaviate vector database (collective intelligence foundation, KEI-48)
+Documentation=https://linear.app/keiracom/issue/KEI-48
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=3
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/orchestrator/weaviate_capped.sh
+Restart=on-failure
+RestartSec=15
+StandardOutput=append:/home/elliotbot/clawd/logs/weaviate.log
+StandardError=append:/home/elliotbot/clawd/logs/weaviate.log
+
+[Install]
+WantedBy=default.target

--- a/infra/weaviate/schema.py
+++ b/infra/weaviate/schema.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""schema.py — KEI-48 Weaviate schema apply.
+
+Creates the 5 collections per Dave verbatim (codebase / decisions / discoveries /
+sessions / keis), each with the 5 mandatory properties from
+docs/schema/weaviate-schema-requirements.md:
+
+    raw_text          text    (required — re-embedding insurance per KEI-60)
+    environment_hash  text    (required — reproducible re-embedding)
+    created_at        date    (required — ISO-8601 UTC)
+    agent             text    (required — callsign or 'system')
+    kei               text    (optional — KEI ID that triggered the write)
+
+Vectorizer: `none`. The agent writes vectors directly (via gemini-embedding-001
+or whichever model the AGENCY_OS_EMBEDDING_MODEL env pins). Server-side
+vectorization is deliberately disabled to keep model pinning explicit.
+
+Idempotent: safe to re-run. Existing collections are left untouched (does not
+overwrite or drop) — re-runs only add missing collections.
+
+Usage:
+    python3 infra/weaviate/schema.py --host 127.0.0.1 --port 8090
+    python3 infra/weaviate/schema.py --dry-run   (print plan, no calls)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+COLLECTIONS = ("codebase", "decisions", "discoveries", "sessions", "keis")
+
+MANDATORY_PROPERTIES = (
+    {"name": "raw_text", "dataType": ["text"]},
+    {"name": "environment_hash", "dataType": ["text"]},
+    {"name": "created_at", "dataType": ["date"]},
+    {"name": "agent", "dataType": ["text"]},
+    {"name": "kei", "dataType": ["text"]},
+)
+
+
+def _get(url: str, timeout: float = 10.0) -> dict:
+    req = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _post(url: str, payload: dict, timeout: float = 10.0) -> dict:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8")
+        return json.loads(raw) if raw else {}
+
+
+def existing_classes(base_url: str) -> set[str]:
+    try:
+        data = _get(f"{base_url}/v1/schema")
+    except urllib.error.HTTPError as exc:
+        print(f"warn: GET /v1/schema returned HTTP {exc.code}", file=sys.stderr)
+        return set()
+    classes = data.get("classes") or []
+    return {c.get("class") for c in classes if c.get("class")}
+
+
+def class_definition(name: str) -> dict:
+    return {
+        "class": name.capitalize(),
+        "description": f"KEI-48 Agency OS — {name} collection",
+        "vectorizer": "none",
+        "properties": list(MANDATORY_PROPERTIES),
+    }
+
+
+def apply_schema(base_url: str, dry_run: bool = False) -> int:
+    existing = existing_classes(base_url)
+    plan = []
+    for name in COLLECTIONS:
+        cls = class_definition(name)
+        if cls["class"] in existing:
+            plan.append((name, "exists"))
+            continue
+        plan.append((name, "create"))
+        if dry_run:
+            continue
+        try:
+            _post(f"{base_url}/v1/schema", cls)
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            print(
+                f"ERROR creating {cls['class']}: HTTP {exc.code} body={body[:200]}",
+                file=sys.stderr,
+            )
+            return 1
+
+    for name, action in plan:
+        print(f"  {name:12s} → {action}")
+    print(
+        f"plan: {sum(1 for _, a in plan if a == 'create')} create, "
+        f"{sum(1 for _, a in plan if a == 'exists')} already exist"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8090)
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args(argv)
+    # NOSONAR python:S5332 — Weaviate is a loopback-only internal service
+    # (default --host 127.0.0.1). HTTPS on loopback adds cert-management
+    # overhead with no security benefit since there is no network attack
+    # surface. If Weaviate is ever exposed beyond loopback, terminate TLS at
+    # a reverse-proxy layer (nginx/caddy), not in this client.
+    base = f"http://{args.host}:{args.port}"  # NOSONAR python:S5332 loopback-only
+    return apply_schema(base, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/weaviate/smoke_test.py
+++ b/infra/weaviate/smoke_test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""smoke_test.py — KEI-48 Weaviate install verification.
+
+End-to-end acceptance test:
+
+    1. GET  /v1/meta                  → Weaviate version reachable
+    2. GET  /v1/schema                → 5 mandatory collections present
+    3. POST /v1/objects               → insert probe object into Discoveries
+    4. GET  /v1/objects/<uuid>        → retrieve by UUID, properties match
+    5. DELETE /v1/objects/<uuid>      → clean up
+
+Exits 0 on success; non-zero on first failure with verbatim error context.
+
+Usage:
+    python3 infra/weaviate/smoke_test.py --host 127.0.0.1 --port 8090
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+import uuid
+from datetime import UTC, datetime
+
+EXPECTED_CLASSES = {"Codebase", "Decisions", "Discoveries", "Sessions", "Keis"}
+
+
+def _req(url: str, method: str, payload: dict | None = None, timeout: float = 10.0) -> dict:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Content-Type": "application/json"} if payload is not None else {}
+    req = urllib.request.Request(url, data=body, method=method, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8")
+        return json.loads(raw) if raw else {}
+
+
+def meta_probe(base: str) -> dict:
+    return _req(f"{base}/v1/meta", "GET")
+
+
+def schema_probe(base: str) -> set[str]:
+    data = _req(f"{base}/v1/schema", "GET")
+    return {c.get("class") for c in (data.get("classes") or []) if c.get("class")}
+
+
+def insert_probe(base: str, obj_id: str) -> dict:
+    payload = {
+        "id": obj_id,
+        "class": "Discoveries",
+        "properties": {
+            "raw_text": f"KEI-48 smoke probe — {obj_id}",
+            "environment_hash": "smoke-test-fixed-hash-not-real",
+            "created_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "agent": "atlas",
+            "kei": "KEI-48",
+        },
+        # Skip vector — vectorizer is 'none', so absent vector is fine for a metadata probe.
+    }
+    return _req(f"{base}/v1/objects", "POST", payload)
+
+
+def fetch_probe(base: str, obj_id: str) -> dict:
+    return _req(f"{base}/v1/objects/Discoveries/{obj_id}", "GET")
+
+
+def delete_probe(base: str, obj_id: str) -> None:
+    _req(f"{base}/v1/objects/Discoveries/{obj_id}", "DELETE")
+
+
+def run(base: str) -> int:
+    print(f"[1/5] GET {base}/v1/meta")
+    meta = meta_probe(base)
+    version = meta.get("version", "?")
+    print(f"      version={version}")
+
+    print(f"[2/5] GET {base}/v1/schema — expect classes={sorted(EXPECTED_CLASSES)}")
+    classes = schema_probe(base)
+    missing = EXPECTED_CLASSES - classes
+    if missing:
+        print(f"      FAIL: missing classes: {sorted(missing)}", file=sys.stderr)
+        return 1
+    print(f"      OK: all 5 classes present (found={sorted(classes & EXPECTED_CLASSES)})")
+
+    obj_id = str(uuid.uuid4())
+    print(f"[3/5] POST {base}/v1/objects (id={obj_id}, class=Discoveries)")
+    insert_resp = insert_probe(base, obj_id)
+    print(f"      OK: insert response id={insert_resp.get('id', '?')}")
+
+    print(f"[4/5] GET  {base}/v1/objects/Discoveries/{obj_id}")
+    fetched = fetch_probe(base, obj_id)
+    rt = (fetched.get("properties") or {}).get("raw_text", "")
+    if obj_id not in rt:
+        print(f"      FAIL: round-trip mismatch. raw_text={rt!r}", file=sys.stderr)
+        return 1
+    print(f"      OK: round-trip raw_text contains obj_id={obj_id}")
+
+    print(f"[5/5] DELETE {base}/v1/objects/Discoveries/{obj_id}")
+    delete_probe(base, obj_id)
+    print("      OK: probe cleaned up")
+
+    print(f"\nKEI-48 SMOKE PASSED — Weaviate {version} reachable, schema valid, round-trip OK.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8090)
+    args = p.parse_args(argv)
+    # NOSONAR python:S5332 — Weaviate is loopback-only (see infra/weaviate/schema.py
+    # for the full rationale). HTTPS on 127.0.0.1 adds cert-mgmt overhead with no
+    # security benefit. TLS terminates at the reverse-proxy if Weaviate ever
+    # listens beyond loopback.
+    base = f"http://{args.host}:{args.port}"  # NOSONAR python:S5332 loopback-only
+    try:
+        return run(base)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:200]
+        print(f"FAIL: HTTP {exc.code} on {exc.url}: {body}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"FAIL: URLError on {base}: {exc.reason}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/preflight_resources.py
+++ b/scripts/orchestrator/preflight_resources.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""preflight_resources.py — KEI-56 pre-deployment resource check.
+
+Run BEFORE starting any new resource-intensive service (Weaviate, LlamaIndex,
+Cognee, additional Claude session). Verifies:
+
+    free_mb (MemAvailable) >= PREFLIGHT_MIN_HEADROOM_MB
+
+If insufficient: exit 1 + post warning to #ceo. The caller (operator or
+systemd unit's ExecStartPre=) should fail-fast on non-zero exit to block the
+new service from starting.
+
+Usage:
+    scripts/orchestrator/preflight_resources.py            # uses defaults
+    scripts/orchestrator/preflight_resources.py --headroom-mb 4096
+    scripts/orchestrator/preflight_resources.py --service weaviate
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+# Reuse the meminfo reader from resource_monitor.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from resource_monitor import _read_meminfo  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("preflight_resources")
+
+# Default headroom = 2 GiB per Linear KEI-56 spec.
+DEFAULT_MIN_HEADROOM_MB = 2 * 1024
+
+
+def check_headroom(min_headroom_mb: int) -> tuple[bool, int]:
+    """Return (ok, available_mb)."""
+    mem = _read_meminfo()
+    available = mem.get("MemAvailable", 0)
+    return available >= min_headroom_mb, available
+
+
+def _post_ceo_block(service: str, available_mb: int, required_mb: int) -> None:
+    relay = Path(__file__).resolve().parent.parent / "slack_relay.py"
+    if not relay.is_file():
+        logger.warning("slack_relay.py missing — dropping block post")
+        return
+    msg = (
+        f":no_entry: preflight BLOCK — service `{service}` start refused: "
+        f"available={available_mb}MB < required={required_mb}MB headroom. "
+        f"Source: preflight_resources (KEI-56)."
+    )
+    try:
+        subprocess.run(
+            ["python3", str(relay), "-c", "ceo", msg],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("slack_relay -c ceo failed: %s", exc)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--headroom-mb",
+        type=int,
+        default=DEFAULT_MIN_HEADROOM_MB,
+        help=f"Minimum MemAvailable in MiB to allow start (default {DEFAULT_MIN_HEADROOM_MB})",
+    )
+    p.add_argument(
+        "--service",
+        default="unspecified",
+        help="Service name for #ceo alert context",
+    )
+    args = p.parse_args(argv)
+
+    ok, available = check_headroom(args.headroom_mb)
+    if ok:
+        logger.info(
+            "preflight OK: %s — available=%dMB >= required=%dMB",
+            args.service,
+            available,
+            args.headroom_mb,
+        )
+        return 0
+
+    logger.error(
+        "preflight BLOCK: %s — available=%dMB < required=%dMB",
+        args.service,
+        available,
+        args.headroom_mb,
+    )
+    _post_ceo_block(args.service, available, args.headroom_mb)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/resource_monitor.py
+++ b/scripts/orchestrator/resource_monitor.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""resource_monitor.py — KEI-56 continuous resource monitoring.
+
+Every RESOURCE_MONITOR_INTERVAL_SECONDS (default 60s), captures:
+  - free/used/total RAM from /proc/meminfo
+  - load average from /proc/loadavg
+  - disk usage of /home/elliotbot/clawd
+  - per-cgroup memory usage + MemoryMax cap via systemd-cgtop equivalent
+    (we read /sys/fs/cgroup/user.slice/... directly to avoid the interactive
+    cgtop UI). Reports breaches at >=90% of MemoryMax.
+
+Writes each snapshot as a row in public.audit_logs with:
+  - action: 'resource_snapshot'
+  - resource_type: 'system'
+  - resource_snapshot: <JSONB blob, schema in docs/runbooks/resource-monitor.md>
+
+Threshold breaches post to #ceo via slack_relay.py:
+  - >=90% of MemoryMax → ":warning: high memory ..." (one-shot per breach onset)
+  - cgroup killed by OOM → ":octagonal_sign: cgroup OOM-killed ..."
+
+Best-effort: any individual capture failure is logged and the cycle continues.
+The systemd unit (infra/systemd/agents/resource-monitor.service) runs us under
+Restart=on-failure so a daemon crash auto-recovers.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("resource_monitor")
+
+RESOURCE_MONITOR_INTERVAL_SECONDS = int(os.environ.get("RESOURCE_MONITOR_INTERVAL_SECONDS", "60"))
+WARN_PCT = float(os.environ.get("RESOURCE_MONITOR_WARN_PCT", "90"))
+DISK_WATCH_PATH = os.environ.get("RESOURCE_MONITOR_DISK_PATH", "/home/elliotbot/clawd")
+CGROUP_ROOT = Path(os.environ.get("RESOURCE_MONITOR_CGROUP_ROOT", "/sys/fs/cgroup/user.slice"))
+
+# Track per-cgroup "already warned" state across cycles so we don't spam #ceo.
+_warned_breaches: set[str] = set()
+
+
+def _read_meminfo() -> dict[str, int]:
+    """Return MemTotal / MemFree / MemAvailable in MiB from /proc/meminfo."""
+    info: dict[str, int] = {}
+    try:
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            key, _, val = line.partition(":")
+            val = val.strip()
+            if val.endswith(" kB"):
+                info[key.strip()] = int(val[:-3]) // 1024  # kB → MiB
+    except OSError as exc:
+        logger.warning("meminfo read failed: %s", exc)
+    return info
+
+
+def _read_loadavg() -> list[float]:
+    try:
+        parts = Path("/proc/loadavg").read_text().split()
+        return [float(parts[0]), float(parts[1]), float(parts[2])]
+    except (OSError, ValueError, IndexError) as exc:
+        logger.warning("loadavg read failed: %s", exc)
+        return [0.0, 0.0, 0.0]
+
+
+def _disk_used_pct(path: str) -> int:
+    try:
+        proc = subprocess.run(
+            ["df", "--output=pcent", path],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return 0
+        lines = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+        # Format: header "Use%" then "39%"
+        if len(lines) >= 2:
+            return int(lines[1].rstrip("%"))
+    except (subprocess.TimeoutExpired, OSError, ValueError) as exc:
+        logger.warning("df failed: %s", exc)
+    return 0
+
+
+def _read_cgroup_memory(unit_dir: Path) -> tuple[int, int | None]:
+    """Return (memory_current_mb, memory_max_mb_or_none) for a cgroup dir."""
+    try:
+        current = int((unit_dir / "memory.current").read_text().strip())
+    except (OSError, ValueError):
+        return 0, None
+    try:
+        raw_max = (unit_dir / "memory.max").read_text().strip()
+        memory_max = None if raw_max == "max" else int(raw_max)
+    except (OSError, ValueError):
+        memory_max = None
+    cur_mb = current // (1024 * 1024)
+    max_mb = memory_max // (1024 * 1024) if memory_max is not None else None
+    return cur_mb, max_mb
+
+
+def _scan_cgroups() -> dict[str, dict]:
+    """Walk user.slice + nested scopes, returning per-unit memory snapshot."""
+    out: dict[str, dict] = {}
+    if not CGROUP_ROOT.is_dir():
+        return out
+    candidates = [CGROUP_ROOT, *CGROUP_ROOT.rglob("*")]
+    for path in candidates:
+        if not path.is_dir():
+            continue
+        name = path.name
+        if not name.endswith((".scope", ".service", ".slice")):
+            continue
+        cur_mb, max_mb = _read_cgroup_memory(path)
+        if cur_mb == 0 and max_mb is None:
+            continue  # not a real memory cgroup
+        pct = round(100.0 * cur_mb / max_mb, 1) if max_mb else None
+        out[name] = {"memory_mb": cur_mb, "memory_max_mb": max_mb, "pct_of_cap": pct}
+    return out
+
+
+def _detect_breaches(cgroups: dict[str, dict]) -> list[dict]:
+    """Return list of cgroup units >= WARN_PCT of their cap."""
+    breaches = []
+    for name, snap in cgroups.items():
+        pct = snap.get("pct_of_cap")
+        if pct is not None and pct >= WARN_PCT:
+            breaches.append({"unit": name, "pct": pct, "memory_mb": snap["memory_mb"]})
+    return breaches
+
+
+def collect_snapshot(now: datetime | None = None) -> dict:
+    ts = (now or datetime.now(UTC)).isoformat()
+    mem = _read_meminfo()
+    load = _read_loadavg()
+    disk_pct = _disk_used_pct(DISK_WATCH_PATH)
+    cgroups = _scan_cgroups()
+    breaches = _detect_breaches(cgroups)
+    total = mem.get("MemTotal", 0)
+    avail = mem.get("MemAvailable", 0)
+    return {
+        "total_mb": total,
+        "used_mb": total - avail,
+        "free_mb": avail,
+        "load_avg": load,
+        "disk_used_pct": disk_pct,
+        "cgroups": cgroups,
+        "thresholds_breached": breaches,
+        "captured_at": ts,
+    }
+
+
+def _supabase_write_snapshot(snapshot: dict) -> None:
+    """Write the snapshot row to public.audit_logs via asyncpg."""
+    dsn = os.environ.get("DATABASE_URL", "") or os.environ.get("DATABASE_URL_MIGRATIONS", "")
+    if not dsn:
+        logger.info("DATABASE_URL unset — skipping audit_logs write (dry mode)")
+        return
+    try:
+        import asyncio
+
+        import asyncpg
+    except ImportError:
+        logger.warning("asyncpg unavailable — skipping audit_logs write")
+        return
+
+    async def _run() -> None:
+        conn = await asyncpg.connect(
+            dsn.replace("postgresql+asyncpg://", "postgresql://"),
+            statement_cache_size=0,
+        )
+        try:
+            await conn.execute(
+                """
+                INSERT INTO public.audit_logs (
+                    id, action, resource_type, resource_snapshot, created_at
+                ) VALUES (gen_random_uuid(), 'resource_snapshot', 'system', $1::jsonb, NOW())
+                """,
+                json.dumps(snapshot),
+            )
+        finally:
+            await conn.close()
+
+    # Blanket Exception catch is deliberate — this is a best-effort write; any
+    # asyncpg / TLS / DSN parse failure logs and drops the row rather than
+    # crashing the 60s monitor loop.
+    try:
+        asyncio.run(_run())
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("audit_logs insert failed: %s", exc)
+
+
+def _post_ceo_breach(unit: str, pct: float, memory_mb: int) -> None:
+    """Post a one-shot #ceo alert per breach onset. Dedup via _warned_breaches."""
+    if unit in _warned_breaches:
+        return
+    _warned_breaches.add(unit)
+    relay = Path(__file__).resolve().parents[1] / "slack_relay.py"
+    if not relay.is_file():
+        logger.warning("slack_relay.py missing — dropping breach post")
+        return
+    msg = (
+        f":warning: high memory — cgroup `{unit}` at {pct:.1f}% of cap "
+        f"({memory_mb}MB used). Source: resource_monitor (KEI-56)."
+    )
+    try:
+        subprocess.run(
+            ["python3", str(relay), "-c", "ceo", msg],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("slack_relay -c ceo failed: %s", exc)
+
+
+def run_cycle() -> dict:
+    snapshot = collect_snapshot()
+    _supabase_write_snapshot(snapshot)
+    for breach in snapshot["thresholds_breached"]:
+        _post_ceo_breach(breach["unit"], breach["pct"], breach["memory_mb"])
+    # Clear dedup state for units that have dropped back below threshold so a
+    # re-breach later still alerts.
+    current_breach_units = {b["unit"] for b in snapshot["thresholds_breached"]}
+    _warned_breaches.intersection_update(current_breach_units)
+    return snapshot
+
+
+def main() -> int:
+    once = "--once" in sys.argv
+    logger.info(
+        "resource_monitor starting (interval=%ds, warn_pct=%g%%, disk=%s, once=%s)",
+        RESOURCE_MONITOR_INTERVAL_SECONDS,
+        WARN_PCT,
+        DISK_WATCH_PATH,
+        once,
+    )
+    while True:
+        run_cycle()
+        if once:
+            return 0
+        time.sleep(RESOURCE_MONITOR_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/weaviate_capped.sh
+++ b/scripts/orchestrator/weaviate_capped.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# weaviate_capped.sh — launch Weaviate under a 2.5 GB systemd memory cap.
+#
+# Closes Beads Agency_OS-... / Linear KEI-48 (Install Weaviate on Vultr Sydney).
+# Same pattern as scripts/orchestrator/cognee_capped.sh (KEI-44 sha 3b133132).
+#
+# Why a cgroup cap:
+#   Vultr Sydney has 7.7 GB RAM (already 4+ GB committed to claude sessions +
+#   cognee + systemd services). Without a hard ceiling, a Weaviate memory leak
+#   or large vector batch could OOM-kill the host. systemd-run --user --scope
+#   with MemoryMax wraps the daemon — cgroup memory.max enforces a hard RSS
+#   ceiling; the kernel OOM-kills the Weaviate child only, not the host.
+#
+# Why --scope (not --service):
+#   - scope wraps the foreground command; calling shell blocks until exit
+#   - exit code propagates back to the caller
+#   - unit dies cleanly when child exits, no leftover service to clean up
+#
+# Usage:
+#   scripts/orchestrator/weaviate_capped.sh           # start with defaults
+#   scripts/orchestrator/weaviate_capped.sh --no-cap  # local dev / non-systemd
+#   scripts/orchestrator/weaviate_capped.sh --max-mem=2G
+#
+# Env overrides:
+#   WEAVIATE_BIN              default /home/elliotbot/clawd/weaviate-bin/weaviate
+#   WEAVIATE_HOST             default 127.0.0.1 (loopback-only; reverse-proxy if exposing)
+#   WEAVIATE_PORT             default 8090 (crowdsec holds 8080)
+#   WEAVIATE_DATA_DIR         default /home/elliotbot/clawd/weaviate-data
+#   AGENCY_OS_WEAVIATE_MAX_MEM    default 2.5G (passed to -p MemoryMax=)
+#   AGENCY_OS_SYSTEMD_RUN     path to systemd-run binary (default 'systemd-run')
+#   AGENCY_OS_SYSTEMD_RUN_SKIP    if set, print resolved command + exit 0 (tests)
+#
+# Exit codes: child process exit code on success path; 2 on bad arguments;
+# 3 if systemd-run is unavailable and --no-cap was not requested.
+
+set -euo pipefail
+
+MAX_MEM="${AGENCY_OS_WEAVIATE_MAX_MEM:-2.5G}"
+SYSTEMD_RUN="${AGENCY_OS_SYSTEMD_RUN:-systemd-run}"
+WEAVIATE_BIN="${WEAVIATE_BIN:-/home/elliotbot/clawd/weaviate-bin/weaviate}"
+WEAVIATE_HOST="${WEAVIATE_HOST:-127.0.0.1}"
+WEAVIATE_PORT="${WEAVIATE_PORT:-8090}"
+WEAVIATE_DATA_DIR="${WEAVIATE_DATA_DIR:-/home/elliotbot/clawd/weaviate-data}"
+NO_CAP=0
+
+while (( $# )); do
+    case "$1" in
+        --no-cap) NO_CAP=1; shift ;;
+        --max-mem=*) MAX_MEM="${1#*=}"; shift ;;
+        --max-mem) MAX_MEM="$2"; shift 2 ;;
+        -h | --help) sed -n '2,40p' "$0"; exit 0 ;;
+        *) echo "error: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ ! -x "$WEAVIATE_BIN" ]]; then
+    echo "error: weaviate binary missing or not executable: $WEAVIATE_BIN" >&2
+    exit 3
+fi
+
+if [[ ! -d "$WEAVIATE_DATA_DIR" ]]; then
+    echo "error: data dir missing: $WEAVIATE_DATA_DIR (mkdir -p first)" >&2
+    exit 3
+fi
+
+# Weaviate config is env-driven; export the required vars.
+export PERSISTENCE_DATA_PATH="$WEAVIATE_DATA_DIR"
+export QUERY_DEFAULTS_LIMIT="${QUERY_DEFAULTS_LIMIT:-25}"
+export AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED="${AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED:-true}"
+export DEFAULT_VECTORIZER_MODULE="${DEFAULT_VECTORIZER_MODULE:-none}"
+export ENABLE_MODULES="${ENABLE_MODULES:-}"
+
+# Single-node cluster config — Weaviate's Raft layer wants explicit names + an
+# advertise address even when not clustered. CLUSTER_ADVERTISE_ADDR=127.0.0.1
+# pins the bind to loopback (matches WEAVIATE_HOST). RAFT_JOIN points at self
+# so the single node bootstraps cleanly. CLUSTER_GOSSIP/DATA_BIND_PORT keep the
+# Raft/memberlist sockets off the public-listen port.
+export CLUSTER_HOSTNAME="${CLUSTER_HOSTNAME:-node1}"
+export CLUSTER_ADVERTISE_ADDR="${CLUSTER_ADVERTISE_ADDR:-127.0.0.1}"
+export CLUSTER_GOSSIP_BIND_PORT="${CLUSTER_GOSSIP_BIND_PORT:-7946}"
+export CLUSTER_DATA_BIND_PORT="${CLUSTER_DATA_BIND_PORT:-7947}"
+export RAFT_BOOTSTRAP_EXPECT="${RAFT_BOOTSTRAP_EXPECT:-1}"
+export RAFT_JOIN="${RAFT_JOIN:-node1}"
+
+CHILD_CMD=("$WEAVIATE_BIN" --host "$WEAVIATE_HOST" --port "$WEAVIATE_PORT" --scheme http)
+UNIT_NAME="weaviate-$$.scope"
+
+if (( NO_CAP )); then
+    exec "${CHILD_CMD[@]}"
+fi
+
+if ! command -v "$SYSTEMD_RUN" >/dev/null 2>&1; then
+    echo "error: $SYSTEMD_RUN not available; pass --no-cap to bypass" >&2
+    exit 3
+fi
+
+FULL_CMD=("$SYSTEMD_RUN" --user --scope --unit="$UNIT_NAME"
+          -p "MemoryMax=$MAX_MEM" -p "MemoryAccounting=yes"
+          -- "${CHILD_CMD[@]}")
+
+if [[ -n "${AGENCY_OS_SYSTEMD_RUN_SKIP:-}" ]]; then
+    printf '%s\n' "${FULL_CMD[@]}"
+    exit 0
+fi
+
+exec "${FULL_CMD[@]}"

--- a/supabase/migrations/20260514_audit_logs_resource_snapshot.sql
+++ b/supabase/migrations/20260514_audit_logs_resource_snapshot.sql
@@ -1,0 +1,36 @@
+-- KEI-56 — Resource governance.
+-- Adds a resource_snapshot JSONB column to audit_logs so the resource monitor
+-- (scripts/orchestrator/resource_monitor.py) can write a 60s rolling snapshot
+-- of memory + cgroup + disk + load.
+--
+-- The column is nullable + no default, so this is an instant DDL on Postgres
+-- (no table rewrite). All existing audit_logs rows keep NULL.
+--
+-- Schema reference (from resource_monitor.py write_snapshot):
+--   {
+--     "free_mb": int,                       -- MemAvailable from /proc/meminfo
+--     "used_mb": int,                       -- MemTotal - MemAvailable
+--     "total_mb": int,                      -- MemTotal
+--     "load_avg": [1m, 5m, 15m],            -- /proc/loadavg
+--     "disk_used_pct": int,                 -- df -h /home/elliotbot/clawd
+--     "cgroups": {                          -- systemd-cgtop snapshot
+--       "<unit_name>": {
+--         "memory_mb": int,
+--         "memory_max_mb": int | null,      -- null = no cap
+--         "pct_of_cap": float | null
+--       }
+--     },
+--     "thresholds_breached": [...]          -- callouts >=90% or capped
+--   }
+
+-- audit_action is an enum; add the new label so action='resource_snapshot' rows insert cleanly.
+-- ALTER TYPE ... ADD VALUE IF NOT EXISTS is idempotent + non-transactional, safe to re-run.
+ALTER TYPE public.audit_action ADD VALUE IF NOT EXISTS 'resource_snapshot';
+
+ALTER TABLE public.audit_logs
+    ADD COLUMN IF NOT EXISTS resource_snapshot JSONB;
+
+COMMENT ON COLUMN public.audit_logs.resource_snapshot IS
+  'KEI-56 — Resource governance. 60s-rolling memory/cgroup/disk/load snapshot. '
+  'Written by scripts/orchestrator/resource_monitor.py. Schema documented in '
+  'docs/runbooks/resource-monitor.md.';

--- a/tests/scripts/test_preflight_resources.py
+++ b/tests/scripts/test_preflight_resources.py
@@ -1,0 +1,48 @@
+"""Unit tests for scripts/orchestrator/preflight_resources.py (KEI-56)."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from scripts.orchestrator import preflight_resources as pf
+
+
+def test_check_headroom_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pf, "_read_meminfo", lambda: {"MemAvailable": 4096})
+    ok, available = pf.check_headroom(2048)
+    assert ok is True
+    assert available == 4096
+
+
+def test_check_headroom_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pf, "_read_meminfo", lambda: {"MemAvailable": 1024})
+    ok, available = pf.check_headroom(2048)
+    assert ok is False
+    assert available == 1024
+
+
+def test_check_headroom_missing_meminfo_fails_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If MemAvailable can't be read, default to 0 → block."""
+    monkeypatch.setattr(pf, "_read_meminfo", lambda: {})
+    ok, _ = pf.check_headroom(2048)
+    assert ok is False
+
+
+def test_main_exit_0_on_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pf, "_read_meminfo", lambda: {"MemAvailable": 10000})
+    rc = pf.main(["--headroom-mb", "2048", "--service", "weaviate"])
+    assert rc == 0
+
+
+def test_main_exit_1_on_fail_and_posts_ceo(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pf, "_read_meminfo", lambda: {"MemAvailable": 500})
+    with mock.patch.object(pf, "_post_ceo_block") as post_mock:
+        rc = pf.main(["--headroom-mb", "2048", "--service", "weaviate"])
+    assert rc == 1
+    post_mock.assert_called_once()
+    args, _ = post_mock.call_args
+    assert args[0] == "weaviate"
+    assert args[1] == 500  # available
+    assert args[2] == 2048  # required

--- a/tests/scripts/test_resource_monitor.py
+++ b/tests/scripts/test_resource_monitor.py
@@ -1,0 +1,183 @@
+"""Unit tests for scripts/orchestrator/resource_monitor.py (KEI-56)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from scripts.orchestrator import resource_monitor as rm
+
+# /proc/meminfo parsing ─────────────────────────────────────────────────────
+
+
+def test_read_meminfo_parses_kb(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_text = (
+        "MemTotal:       16000000 kB\n"
+        "MemFree:         4000000 kB\n"
+        "MemAvailable:    8000000 kB\n"
+        "Cached:          2000000 kB\n"
+    )
+
+    class FakePath:
+        def __init__(self, *_a: object, **_kw: object) -> None: ...
+
+        def read_text(self) -> str:
+            return fake_text
+
+    monkeypatch.setattr(rm, "Path", FakePath)
+    info = rm._read_meminfo()
+    # 16,000,000 kB / 1024 ≈ 15625 MiB
+    assert info["MemTotal"] == 15625
+    assert info["MemAvailable"] == 7812
+
+
+# loadavg ───────────────────────────────────────────────────────────────────
+
+
+def test_read_loadavg_three_floats(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakePath:
+        def __init__(self, *_a: object, **_kw: object) -> None: ...
+
+        def read_text(self) -> str:
+            return "0.50 1.25 2.00 1/100 12345\n"
+
+    monkeypatch.setattr(rm, "Path", FakePath)
+    out = rm._read_loadavg()
+    assert out == [0.50, 1.25, 2.00]
+
+
+def test_read_loadavg_failure_returns_zeros(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakePath:
+        def __init__(self, *_a: object, **_kw: object) -> None: ...
+
+        def read_text(self) -> str:
+            raise OSError("nope")
+
+    monkeypatch.setattr(rm, "Path", FakePath)
+    out = rm._read_loadavg()
+    assert out == [0.0, 0.0, 0.0]
+
+
+# cgroup memory read ────────────────────────────────────────────────────────
+
+
+def test_read_cgroup_memory_with_cap(tmp_path: Path) -> None:
+    unit = tmp_path / "myunit.scope"
+    unit.mkdir()
+    (unit / "memory.current").write_text(str(100 * 1024 * 1024))  # 100 MiB
+    (unit / "memory.max").write_text(str(2 * 1024 * 1024 * 1024))  # 2 GiB
+    cur, mx = rm._read_cgroup_memory(unit)
+    assert cur == 100
+    assert mx == 2048
+
+
+def test_read_cgroup_memory_no_cap(tmp_path: Path) -> None:
+    unit = tmp_path / "uncapped.scope"
+    unit.mkdir()
+    (unit / "memory.current").write_text(str(50 * 1024 * 1024))
+    (unit / "memory.max").write_text("max\n")
+    cur, mx = rm._read_cgroup_memory(unit)
+    assert cur == 50
+    assert mx is None
+
+
+# breach detection ──────────────────────────────────────────────────────────
+
+
+def test_detect_breaches_flags_at_warn_pct() -> None:
+    cgroups = {
+        "weaviate.scope": {"memory_mb": 2300, "memory_max_mb": 2560, "pct_of_cap": 89.8},
+        "cognee.scope": {"memory_mb": 2800, "memory_max_mb": 3072, "pct_of_cap": 91.1},
+        "small.scope": {"memory_mb": 100, "memory_max_mb": 500, "pct_of_cap": 20.0},
+        "uncapped.scope": {"memory_mb": 9999, "memory_max_mb": None, "pct_of_cap": None},
+    }
+    breaches = rm._detect_breaches(cgroups)
+    # Only cognee.scope (91.1%) breached WARN_PCT=90.
+    assert len(breaches) == 1
+    assert breaches[0]["unit"] == "cognee.scope"
+    assert breaches[0]["pct"] == pytest.approx(91.1)
+
+
+def test_detect_breaches_empty_returns_empty() -> None:
+    assert rm._detect_breaches({}) == []
+
+
+# collect_snapshot integration ──────────────────────────────────────────────
+
+
+def test_collect_snapshot_assembles_all_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rm, "_read_meminfo", lambda: {"MemTotal": 16000, "MemAvailable": 4000})
+    monkeypatch.setattr(rm, "_read_loadavg", lambda: [0.5, 1.0, 1.5])
+    monkeypatch.setattr(rm, "_disk_used_pct", lambda _p: 42)
+    monkeypatch.setattr(
+        rm,
+        "_scan_cgroups",
+        lambda: {"x.scope": {"memory_mb": 100, "memory_max_mb": 200, "pct_of_cap": 50.0}},
+    )
+    snap = rm.collect_snapshot(now=datetime(2026, 5, 14, 8, 0, tzinfo=UTC))
+    assert snap["total_mb"] == 16000
+    assert snap["used_mb"] == 12000  # total - available
+    assert snap["free_mb"] == 4000
+    assert snap["load_avg"] == [0.5, 1.0, 1.5]
+    assert snap["disk_used_pct"] == 42
+    assert "x.scope" in snap["cgroups"]
+    assert snap["thresholds_breached"] == []
+    assert snap["captured_at"].startswith("2026-05-14T08:00")
+
+
+def test_collect_snapshot_includes_breach() -> None:
+    with (
+        mock.patch.object(rm, "_read_meminfo", return_value={"MemTotal": 16000, "MemAvailable": 1}),
+        mock.patch.object(rm, "_read_loadavg", return_value=[0, 0, 0]),
+        mock.patch.object(rm, "_disk_used_pct", return_value=0),
+        mock.patch.object(
+            rm,
+            "_scan_cgroups",
+            return_value={
+                "hot.scope": {"memory_mb": 950, "memory_max_mb": 1000, "pct_of_cap": 95.0}
+            },
+        ),
+    ):
+        snap = rm.collect_snapshot()
+    assert len(snap["thresholds_breached"]) == 1
+    assert snap["thresholds_breached"][0]["unit"] == "hot.scope"
+
+
+# breach-dedup state ────────────────────────────────────────────────────────
+
+
+def test_post_ceo_breach_dedups_within_state() -> None:
+    rm._warned_breaches.clear()
+    with mock.patch.object(rm.subprocess, "run") as run_mock:
+        rm._post_ceo_breach("hot.scope", 95.0, 950)
+        rm._post_ceo_breach("hot.scope", 96.0, 960)  # same unit, second call
+    # Slack_relay should only be invoked once (second is deduped).
+    assert run_mock.call_count == 1
+    rm._warned_breaches.clear()
+
+
+def test_run_cycle_clears_dedup_for_resolved_breaches(monkeypatch: pytest.MonkeyPatch) -> None:
+    rm._warned_breaches.clear()
+    rm._warned_breaches.add("old.scope")  # imagine prior cycle warned
+    monkeypatch.setattr(
+        rm,
+        "collect_snapshot",
+        lambda: {
+            "total_mb": 0,
+            "used_mb": 0,
+            "free_mb": 0,
+            "load_avg": [],
+            "disk_used_pct": 0,
+            "cgroups": {},
+            "thresholds_breached": [],
+            "captured_at": "x",
+        },
+    )
+    monkeypatch.setattr(rm, "_supabase_write_snapshot", lambda _s: None)
+    monkeypatch.setattr(rm, "_post_ceo_breach", lambda *a, **kw: None)
+    rm.run_cycle()
+    # Resolved → old.scope removed.
+    assert "old.scope" not in rm._warned_breaches

--- a/tests/scripts/test_weaviate_schema.py
+++ b/tests/scripts/test_weaviate_schema.py
@@ -1,0 +1,125 @@
+"""Unit tests for infra/weaviate/schema.py (KEI-48)."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from infra.weaviate import schema
+
+
+def test_collections_match_dave_spec() -> None:
+    """The 5 collection names must match Dave's KEI-48 spec verbatim."""
+    assert schema.COLLECTIONS == (
+        "codebase",
+        "decisions",
+        "discoveries",
+        "sessions",
+        "keis",
+    )
+
+
+def test_mandatory_properties_present() -> None:
+    """Every collection must have the 5 properties from
+    docs/schema/weaviate-schema-requirements.md.
+    """
+    names = {p["name"] for p in schema.MANDATORY_PROPERTIES}
+    assert names == {"raw_text", "environment_hash", "created_at", "agent", "kei"}
+
+    by_name = {p["name"]: p["dataType"] for p in schema.MANDATORY_PROPERTIES}
+    assert by_name["raw_text"] == ["text"]
+    assert by_name["environment_hash"] == ["text"]
+    assert by_name["created_at"] == ["date"]
+    assert by_name["agent"] == ["text"]
+    assert by_name["kei"] == ["text"]
+
+
+def test_class_definition_capitalises_name_and_pins_vectorizer_none() -> None:
+    cls = schema.class_definition("discoveries")
+    assert cls["class"] == "Discoveries"
+    assert cls["vectorizer"] == "none"
+    prop_names = [p["name"] for p in cls["properties"]]
+    assert prop_names == [
+        "raw_text",
+        "environment_hash",
+        "created_at",
+        "agent",
+        "kei",
+    ]
+
+
+@pytest.mark.parametrize(
+    "raw_name,expected_class",
+    [
+        ("codebase", "Codebase"),
+        ("decisions", "Decisions"),
+        ("discoveries", "Discoveries"),
+        ("sessions", "Sessions"),
+        ("keis", "Keis"),
+    ],
+)
+def test_class_definition_all_5_collections(raw_name: str, expected_class: str) -> None:
+    cls = schema.class_definition(raw_name)
+    assert cls["class"] == expected_class
+    assert cls["vectorizer"] == "none"
+    assert "Agency OS" in cls["description"]
+
+
+def test_apply_schema_dry_run_creates_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dry-run mode must not POST anywhere — only print the plan."""
+    monkeypatch.setattr(schema, "existing_classes", lambda _u: set())
+    post_calls: list = []
+    monkeypatch.setattr(schema, "_post", lambda *a, **kw: post_calls.append((a, kw)) or {})
+
+    rc = schema.apply_schema(
+        "http://test:8090",  # NOSONAR python:S5332 test fixture, no real network
+        dry_run=True,
+    )
+    assert rc == 0
+    assert post_calls == []
+
+
+def test_apply_schema_skips_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Idempotent: already-present collections are NOT re-created."""
+    monkeypatch.setattr(
+        schema,
+        "existing_classes",
+        lambda _u: {"Codebase", "Decisions"},
+    )
+    post_calls: list = []
+
+    def fake_post(url: str, payload: dict, timeout: float = 10.0) -> dict:
+        post_calls.append(payload["class"])
+        return {}
+
+    monkeypatch.setattr(schema, "_post", fake_post)
+    rc = schema.apply_schema(
+        "http://test:8090",  # NOSONAR python:S5332 test fixture, no real network
+        dry_run=False,
+    )
+    assert rc == 0
+    # Only the 3 missing get created.
+    assert set(post_calls) == {"Discoveries", "Sessions", "Keis"}
+
+
+def test_apply_schema_post_failure_returns_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+
+    monkeypatch.setattr(schema, "existing_classes", lambda _u: set())
+
+    def fake_post(*_a: object, **_kw: object) -> dict:
+        raise urllib.error.HTTPError(
+            "http://test:8090/v1/schema",  # NOSONAR python:S5332 test fixture, no real network
+            422,
+            "Unprocessable",
+            {},
+            mock.Mock(read=lambda: b"x"),
+        )
+
+    monkeypatch.setattr(schema, "_post", fake_post)
+    rc = schema.apply_schema(
+        "http://test:8090",  # NOSONAR python:S5332 test fixture, no real network
+        dry_run=False,
+    )
+    assert rc == 1


### PR DESCRIPTION
## Summary

Resource governance — three-layer defence against host OOM after the 2026-05-13 uncapped-Cognee crash.

**Linear:** [KEI-56](https://linear.app/keiracom/issue/KEI-56) · **public.tasks:** id=KEI-56 status=active claimed_by=atlas · **Driver:** Linear KEI-56 description verbatim

| Layer | Status | Source |
|---|---|---|
| 1. Hard cgroup caps | Already in place | KEI-43 agents · KEI-44 Cognee · KEI-48 Weaviate |
| 2. Continuous monitor → audit_logs | **This PR** | `scripts/orchestrator/resource_monitor.py` |
| 3. Pre-deployment headroom check | **This PR** | `scripts/orchestrator/preflight_resources.py` |

## What ships

| File | Purpose |
|---|---|
| `scripts/orchestrator/resource_monitor.py` | 60s daemon. Reads `/proc/meminfo` + `/proc/loadavg` + `df` + `/sys/fs/cgroup/user.slice/.../memory.*` directly (no `systemd-cgtop` UI dep). Writes `public.audit_logs` row per cycle. Breaches ≥90% of MemoryMax → one-shot `#ceo` alert (deduped while persisting; cleared once below threshold). |
| `scripts/orchestrator/preflight_resources.py` | Pre-deployment guard. Exit 0 = OK; exit 1 = blocked + `#ceo` alert. Default headroom = 2 GiB MemAvailable per spec. Wire as `ExecStartPre=` on resource-heavy services. |
| `infra/systemd/agents/resource-monitor.service` | `Type=simple`, `Restart=on-failure`, `RestartSec=30`, `WantedBy=default.target`. Same shape as KEI-43/KEI-48 units. |
| `supabase/migrations/20260514_audit_logs_resource_snapshot.sql` | `ALTER TYPE audit_action ADD VALUE 'resource_snapshot'` + `ALTER TABLE audit_logs ADD COLUMN resource_snapshot JSONB`. Both idempotent. **Applied to live Supabase at install time.** |
| `tests/scripts/test_resource_monitor.py` | 12 pytest cases. |
| `tests/scripts/test_preflight_resources.py` | 4 pytest cases. |
| `docs/runbooks/resource-monitor.md` | Install + schema + env vars + verbatim install-time evidence. |

## `resource_snapshot` JSONB schema

```jsonc
{
  "total_mb": 7935,
  "used_mb": 5239,
  "free_mb": 2696,
  "load_avg": [0.5, 1.0, 1.5],
  "disk_used_pct": 39,
  "cgroups": {
    "<unit>.scope|service": {
      "memory_mb": <int>,
      "memory_max_mb": <int|null>,   // null = no cap
      "pct_of_cap": <float|null>
    }
  },
  "thresholds_breached": [
    {"unit": "<name>", "pct": <float>, "memory_mb": <int>}
  ],
  "captured_at": "<ISO-8601 UTC>"
}
```

## Verification (LIVE)

| Gate | Result |
|---|---|
| `ruff check` (new files) | All checks passed |
| `ruff format --check` | 4 files already formatted |
| `pytest tests/scripts/test_{resource_monitor,preflight_resources}.py` | **16/16 pass in 0.22s** |
| `systemd-analyze --user verify resource-monitor.service` | clean |
| LIVE `--once` smoke wrote audit_logs row | id=`dbeaec4d-812a-4a52-b907-617dcd2ffe3a`, `total_mb=7935 used_mb=5239 free_mb=2696` |
| LIVE preflight | `available=2796MB >= required=2048MB` → exit 0 |
| Supabase migration applied | `audit_action` enum + `resource_snapshot` JSONB column both present |

## Reviewer asks (triple-bot FINAL — Aiden parked 85% cap)

- [ ] **Max** — verify the cgroup-walk pattern (`/sys/fs/cgroup/user.slice` rglob + `memory.{current,max}` read) is the right anchor vs `systemd-cgtop --batch`
- [ ] **Elliot** — verify the `audit_action` enum addition + `resource_snapshot` JSONB schema fit the broader audit-logs governance picture
- [ ] **Orion** — verify the dedup + breach-onset logic matches the KEI-44 / KEI-48 observability story

**Atlas explicit NO-MERGE** until all three FINAL specifically (post-#808 + post-#842 + post-#845 + post-#868 discipline).

## Out of scope

- Modifying the cgroup ceilings themselves (separate concern; existing caps from KEI-43/44/48 already in place)
- Binary Quantization on Weaviate collections (Linear KEI-56 mentions BQ; deferred to follow-up KEI since it's a Weaviate config change rather than monitoring infra, and the install runbook can apply it idempotently later)
- LlamaIndex (KEI-49) / persistent storage backup (KEI-60) — separate KEIs

## Operator install

```bash
psql "$DATABASE_URL_MIGRATIONS" < /home/elliotbot/clawd/Agency_OS/supabase/migrations/20260514_audit_logs_resource_snapshot.sql
install -D -m 0644 /home/elliotbot/clawd/Agency_OS/infra/systemd/agents/resource-monitor.service \
    ~/.config/systemd/user/resource-monitor.service
mkdir -p /home/elliotbot/clawd/logs
systemctl --user daemon-reload && systemctl --user enable --now resource-monitor.service
python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/resource_monitor.py --once   # smoke
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)