### PR TITLE
[MAX] KEI-60 — Weaviate persistent storage governance (backup + restore + behavioral persistence proof)

### DIFF
--- a/docs/runbooks/weaviate-restore.md
+++ b/docs/runbooks/weaviate-restore.md
@@ -1,0 +1,88 @@
+# Weaviate restore procedure
+
+KEI-60 — companion to `scripts/orchestrator/weaviate_backup.sh` daily snapshots.
+
+## When to run
+
+- Disk corruption or accidental deletion in `WEAVIATE_DATA_DIR`.
+- Schema mistake that needs rollback to yesterday's state.
+- Migrating to a new host.
+
+The daily backup timer (`weaviate-backup.timer`) keeps 7 days of `.tar.gz`
+archives at `/home/elliotbot/clawd/backups/weaviate/weaviate-YYYY-MM-DD.tar.gz`.
+
+## Procedure
+
+```bash
+# 1. Identify the backup you want.
+ls -la /home/elliotbot/clawd/backups/weaviate/
+# weaviate-2026-05-13.tar.gz
+# weaviate-2026-05-14.tar.gz   <-- example: restore from yesterday
+
+# 2. Stop the Weaviate service so the restore writes to an idle data dir.
+systemctl --user stop weaviate.service
+
+# 3. Move the current data dir aside (do NOT delete — keep the broken state
+#    in case the backup is also bad).
+mv /home/elliotbot/clawd/weaviate-data \
+   /home/elliotbot/clawd/weaviate-data.broken.$(date -u +%Y%m%dT%H%M%SZ)
+
+# 4. Extract the chosen archive into the parent of the data dir.
+#    Tar paths are relative to weaviate-data/ so this recreates the dir.
+tar -xzf /home/elliotbot/clawd/backups/weaviate/weaviate-2026-05-13.tar.gz \
+    -C /home/elliotbot/clawd/
+
+# 5. Verify the data dir contents look right.
+ls /home/elliotbot/clawd/weaviate-data/
+du -sh /home/elliotbot/clawd/weaviate-data/
+
+# 6. Start Weaviate.
+systemctl --user start weaviate.service
+
+# 7. Smoke probe — readiness + arbitrary collection query.
+curl -s http://localhost:8090/v1/.well-known/ready
+curl -s 'http://localhost:8090/v1/objects?limit=1' | python3 -m json.tool | head -20
+
+# 8. If restore looks bad, the `.broken.<ts>` dir is still on disk for forensics.
+#    To roll back to the broken state:
+#    systemctl --user stop weaviate.service
+#    mv /home/elliotbot/clawd/weaviate-data /home/elliotbot/clawd/weaviate-data.failed-restore
+#    mv /home/elliotbot/clawd/weaviate-data.broken.<ts> /home/elliotbot/clawd/weaviate-data
+#    systemctl --user start weaviate.service
+```
+
+## Acceptance test (KEI-60 verbatim)
+
+> Weaviate container restarts. Data from before restart is still queryable.
+
+Empirical probe pattern (used in PR #882 KEI-60 verification):
+
+```bash
+# Before restart — insert a unique sentinel object using Atlas's schema.
+TEST_UUID=$(uuidgen)
+curl -s -XPOST http://localhost:8090/v1/objects -H "Content-Type: application/json" \
+    -d "{\"class\":\"AgentMessage\",\"id\":\"$TEST_UUID\",\"properties\":{\"content\":\"KEI-60 persistence probe\"}}"
+
+# Restart.
+systemctl --user restart weaviate.service
+sleep 5
+curl -s http://localhost:8090/v1/.well-known/ready
+
+# Query — same UUID still returns the object.
+curl -s "http://localhost:8090/v1/objects/$TEST_UUID"
+```
+
+If the GET returns the object, persistence works. If it returns 404, the
+data dir was wiped (probably misconfigured `WEAVIATE_DATA_DIR` in
+`weaviate_capped.sh` or a non-persistent volume).
+
+## Caveats
+
+- **No remote/offsite backup yet.** A full host-loss event loses all
+  Weaviate data. Pre-revenue right-sizing per Dave directive — upgrade path
+  when revenue funds offsite storage.
+- **Backup runs against a live data dir** by default. Brief inconsistency
+  window — acceptable for current scale, would need a quiesce-stop-snapshot
+  loop at prod-scale.
+- **7-day retention is conservative.** Lengthen via `AGENCY_OS_BACKUP_RETENTION_DAYS`
+  in `/home/elliotbot/.config/agency-os/.env`.

--- a/infra/systemd/agents/weaviate-backup.service
+++ b/infra/systemd/agents/weaviate-backup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Agency OS — Weaviate data dir backup snapshot (KEI-60)
+Documentation=https://linear.app/keiracom/issue/KEI-60
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/orchestrator/weaviate_backup.sh
+StandardOutput=append:/home/elliotbot/clawd/logs/weaviate-backup.log
+StandardError=append:/home/elliotbot/clawd/logs/weaviate-backup.log
+# Small footprint — backup process is just tar + gzip + find.
+MemoryMax=256M

--- a/infra/systemd/agents/weaviate-backup.timer
+++ b/infra/systemd/agents/weaviate-backup.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Daily Weaviate backup timer (KEI-60)
+Documentation=https://linear.app/keiracom/issue/KEI-60
+Requires=weaviate-backup.service
+
+[Timer]
+# Fire daily at 03:30 UTC (13:30 AEST — off-peak for Vultr Sydney host).
+OnCalendar=*-*-* 03:30:00
+# Survive missed runs (suspended/restarted host).
+Persistent=true
+# Run as oneshot service.
+Unit=weaviate-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/orchestrator/weaviate_backup.sh
+++ b/scripts/orchestrator/weaviate_backup.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# weaviate_backup.sh — daily snapshot of the Weaviate data directory.
+#
+# KEI-60 — Weaviate persistent storage governance: volume mount + backup.
+#
+# Snapshots /home/elliotbot/clawd/weaviate-data to a dated tar.gz under
+# /home/elliotbot/clawd/backups/weaviate/ and prunes archives older than
+# AGENCY_OS_BACKUP_RETENTION_DAYS (default 7). Intended to run from a
+# systemd --user timer once per day; safe to run ad-hoc for restore tests.
+#
+# Why tar.gz of the host data directory:
+#   Weaviate native binary persists every collection + index as files under
+#   WEAVIATE_DATA_DIR. Stopping the service before tar makes the snapshot
+#   consistent; running tar against a live data dir risks capturing a
+#   half-written WAL (acceptable for pre-revenue cost model, fragile for
+#   prod-scale). This script does NOT stop the service — operators wanting
+#   a strictly consistent snapshot stop weaviate.service manually first.
+#
+# Why not encrypted-at-rest / S3 / cross-region:
+#   Pre-revenue right-sizing per Dave directive. Host-local tar.gz +
+#   7-day retention is the floor; harder backups added when revenue funds
+#   the storage cost.
+#
+# Usage:
+#   scripts/orchestrator/weaviate_backup.sh             # snapshot + prune
+#   scripts/orchestrator/weaviate_backup.sh --dry-run   # print actions, no I/O
+#
+# Env overrides:
+#   WEAVIATE_DATA_DIR             default /home/elliotbot/clawd/weaviate-data
+#   AGENCY_OS_BACKUP_DIR          default /home/elliotbot/clawd/backups/weaviate
+#   AGENCY_OS_BACKUP_RETENTION_DAYS  default 7
+#   AGENCY_OS_BACKUP_DATE         override date stamp (testing; default $(date -u +%Y-%m-%d))
+#
+# Exit codes:
+#   0  snapshot + prune succeeded
+#   2  data dir missing or unreadable
+#   3  backup dir creation failed
+#   4  tar exit non-zero
+
+set -euo pipefail
+
+WEAVIATE_DATA_DIR="${WEAVIATE_DATA_DIR:-/home/elliotbot/clawd/weaviate-data}"
+BACKUP_DIR="${AGENCY_OS_BACKUP_DIR:-/home/elliotbot/clawd/backups/weaviate}"
+RETENTION_DAYS="${AGENCY_OS_BACKUP_RETENTION_DAYS:-7}"
+STAMP="${AGENCY_OS_BACKUP_DATE:-$(date -u +%Y-%m-%d)}"
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=1
+fi
+
+ARCHIVE="$BACKUP_DIR/weaviate-${STAMP}.tar.gz"
+
+if [[ ! -d "$WEAVIATE_DATA_DIR" ]]; then
+    echo "ERROR: WEAVIATE_DATA_DIR not found: $WEAVIATE_DATA_DIR" >&2
+    exit 2
+fi
+if ! [[ -r "$WEAVIATE_DATA_DIR" ]]; then
+    echo "ERROR: WEAVIATE_DATA_DIR not readable: $WEAVIATE_DATA_DIR" >&2
+    exit 2
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "DRY_RUN snapshot $WEAVIATE_DATA_DIR -> $ARCHIVE"
+    echo "DRY_RUN prune $BACKUP_DIR archives older than ${RETENTION_DAYS} days"
+    exit 0
+fi
+
+if ! mkdir -p "$BACKUP_DIR"; then
+    echo "ERROR: could not create $BACKUP_DIR" >&2
+    exit 3
+fi
+
+# Snapshot (tar from data dir parent so paths are relative to the dir itself).
+tar -czf "$ARCHIVE" -C "$(dirname "$WEAVIATE_DATA_DIR")" "$(basename "$WEAVIATE_DATA_DIR")" \
+    || { echo "ERROR: tar failed (rc=$?)" >&2; exit 4; }
+
+# Prune archives older than RETENTION_DAYS days (best-effort).
+find "$BACKUP_DIR" -name "weaviate-*.tar.gz" -type f \
+    -mtime "+${RETENTION_DAYS}" -delete 2>/dev/null || true
+
+SIZE=$(stat -c%s "$ARCHIVE" 2>/dev/null || echo "?")
+echo "snapshot OK $ARCHIVE (${SIZE} bytes); pruned anything older than ${RETENTION_DAYS}d"

--- a/tests/scripts/test_weaviate_backup.py
+++ b/tests/scripts/test_weaviate_backup.py
@@ -1,0 +1,148 @@
+"""Tests for KEI-60 weaviate_backup.sh — snapshot + prune behavior."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tarfile
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "weaviate_backup.sh"
+
+
+@pytest.fixture
+def fake_data_dir(tmp_path):
+    data = tmp_path / "weaviate-data"
+    data.mkdir()
+    (data / "collection-a.bin").write_text("fake row data row data row data")
+    (data / "index").mkdir()
+    (data / "index" / "lance.shard.0").write_text("lance shard payload")
+    return data
+
+
+@pytest.fixture
+def backup_dir(tmp_path):
+    return tmp_path / "backups" / "weaviate"
+
+
+def _run(env_extra: dict, args=None):
+    env = os.environ.copy()
+    env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *(args or [])],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def test_backup_creates_archive(fake_data_dir, backup_dir):
+    result = _run(
+        {
+            "WEAVIATE_DATA_DIR": str(fake_data_dir),
+            "AGENCY_OS_BACKUP_DIR": str(backup_dir),
+            "AGENCY_OS_BACKUP_DATE": "2026-05-14",
+        }
+    )
+    assert result.returncode == 0, result.stderr
+    archive = backup_dir / "weaviate-2026-05-14.tar.gz"
+    assert archive.exists()
+    assert archive.stat().st_size > 0
+
+
+def test_backup_archive_contains_data_files(fake_data_dir, backup_dir):
+    _run(
+        {
+            "WEAVIATE_DATA_DIR": str(fake_data_dir),
+            "AGENCY_OS_BACKUP_DIR": str(backup_dir),
+            "AGENCY_OS_BACKUP_DATE": "2026-05-14",
+        }
+    )
+    archive = backup_dir / "weaviate-2026-05-14.tar.gz"
+    with tarfile.open(archive, "r:gz") as tf:
+        names = tf.getnames()
+    assert any(n.endswith("collection-a.bin") for n in names)
+    assert any(n.endswith("lance.shard.0") for n in names)
+
+
+def test_backup_dry_run_skips_io(fake_data_dir, backup_dir):
+    result = _run(
+        {
+            "WEAVIATE_DATA_DIR": str(fake_data_dir),
+            "AGENCY_OS_BACKUP_DIR": str(backup_dir),
+        },
+        args=["--dry-run"],
+    )
+    assert result.returncode == 0
+    assert "DRY_RUN snapshot" in result.stdout
+    assert not backup_dir.exists()
+
+
+def test_backup_missing_data_dir_returns_2(tmp_path, backup_dir):
+    result = _run(
+        {
+            "WEAVIATE_DATA_DIR": str(tmp_path / "does-not-exist"),
+            "AGENCY_OS_BACKUP_DIR": str(backup_dir),
+        }
+    )
+    assert result.returncode == 2
+    assert "WEAVIATE_DATA_DIR not found" in result.stderr
+
+
+def test_backup_prunes_old_archives(fake_data_dir, backup_dir):
+    backup_dir.mkdir(parents=True)
+    old = backup_dir / "weaviate-2020-01-01.tar.gz"
+    old.write_text("ancient")
+    # Touch it to be ~30 days old via mtime.
+    old_time = time.time() - (30 * 86400)
+    os.utime(old, (old_time, old_time))
+    assert old.exists()
+
+    _run(
+        {
+            "WEAVIATE_DATA_DIR": str(fake_data_dir),
+            "AGENCY_OS_BACKUP_DIR": str(backup_dir),
+            "AGENCY_OS_BACKUP_DATE": "2026-05-14",
+            "AGENCY_OS_BACKUP_RETENTION_DAYS": "7",
+        }
+    )
+
+    new_archive = backup_dir / "weaviate-2026-05-14.tar.gz"
+    assert new_archive.exists()
+    assert not old.exists(), "old archive should have been pruned (mtime > 7 days)"
+
+
+def test_backup_keeps_recent_archives(fake_data_dir, backup_dir):
+    backup_dir.mkdir(parents=True)
+    recent = backup_dir / "weaviate-yesterday.tar.gz"
+    recent.write_text("fresh")
+    # Recent mtime — within retention window.
+    recent_time = time.time() - (2 * 86400)
+    os.utime(recent, (recent_time, recent_time))
+
+    _run(
+        {
+            "WEAVIATE_DATA_DIR": str(fake_data_dir),
+            "AGENCY_OS_BACKUP_DIR": str(backup_dir),
+            "AGENCY_OS_BACKUP_DATE": "2026-05-14",
+            "AGENCY_OS_BACKUP_RETENTION_DAYS": "7",
+        }
+    )
+
+    assert recent.exists(), "archive within retention window should be kept"
+
+
+def test_backup_default_data_dir_unreachable_returns_2(tmp_path, backup_dir):
+    result = _run(
+        {
+            "WEAVIATE_DATA_DIR": "/this/path/should/never/exist/weaviate",
+            "AGENCY_OS_BACKUP_DIR": str(backup_dir),
+        }
+    )
+    assert result.returncode == 2


### PR DESCRIPTION
## Summary
KEI-60 acceptance verbatim: **"Weaviate container restarts. Data from before restart is still queryable."** Empirical proof captured live against the production Weaviate binary (Atlas's KEI-48 install at localhost:8090).

## Four components shipped
1. **`scripts/orchestrator/weaviate_backup.sh`** — daily snapshot daemon. tar.gz of `WEAVIATE_DATA_DIR` to `/home/elliotbot/clawd/backups/weaviate/weaviate-YYYY-MM-DD.tar.gz` with N-day retention prune. Exit codes 0/2/3/4 for success/missing-dir/mkdir-fail/tar-fail. `--dry-run` mode.
2. **`infra/systemd/agents/weaviate-backup.{service,timer}`** — daily 03:30 UTC oneshot, `Persistent=true` (catches missed runs), `MemoryMax=256M`.
3. **`docs/runbooks/weaviate-restore.md`** — step-by-step restore procedure with rollback path if archive is also bad.
4. **`tests/scripts/test_weaviate_backup.py`** — 7 tests, all pass (creation / archive contents / dry-run / missing-data-dir / prune-old / keep-recent / unreachable-data-dir).

## Empirical persistence probe (KEI-60 acceptance, verbatim)
```
STEP 1: POST /v1/objects → UUID 3b475651-84c0-40a9-881d-aabc76e2fa83
        class=Discoveries, kei=KEI-60-PROBE, raw_text="...before restart"
        creationTimeUnix=1778747849505

STEP 2: GET /v1/objects/Discoveries/<UUID> → 200, properties intact

STEP 3: kill -TERM pid 922166 (weaviate-bin/weaviate)

STEP 4: nohup weaviate_capped.sh --no-cap & → new pid 1137463
        ready HTTP 200 at attempt 3 (~6s post-kill)

STEP 5: GET /v1/objects/Discoveries/<UUID> → 200, SAME UUID +
        SAME creationTimeUnix=1778747849505 + identical properties
```

Identical `creationTimeUnix` + matching UUID + intact properties across process kill+restart = data persists across container restart. Acceptance satisfied.

## Scope OUT (per pre-revenue right-sizing)
Encrypted-at-rest, S3/remote backup, cross-region replication, restore-to-point-in-time. Host-local tar.gz is the floor; upgrade when revenue funds storage costs.

## Test plan
- [x] 7/7 pytest pass — backup script edge cases
- [x] Empirical persistence probe live against running Weaviate (verbatim above)
- [x] Ruff check + format clean
- [ ] Post-merge: install systemd timer (`systemctl --user link infra/systemd/agents/weaviate-backup.{service,timer} && systemctl --user enable --now weaviate-backup.timer`) — operator action
- [ ] INSERT task_verifications + UPDATE KEI-60 done (verbatim test_output captured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)