### PR TITLE
[MAX] KEI-54B — tool_call_log → Weaviate indexer worker

### DIFF
--- a/infra/systemd/agents/tool-call-log-indexer.service
+++ b/infra/systemd/agents/tool-call-log-indexer.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Agency OS — Tool call log indexer (KEI-54B Stage B)
+Documentation=https://linear.app/keiracom/issue/KEI-54
+After=network-online.target weaviate.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/tool_call_log_indexer.py
+Restart=on-failure
+RestartSec=15
+StandardOutput=append:/home/elliotbot/clawd/logs/tool-call-log-indexer.log
+StandardError=append:/home/elliotbot/clawd/logs/tool-call-log-indexer.log
+# Same memory ceiling as Scout's KEI-61 indexing_queue worker — small worker footprint.
+MemoryMax=512M
+MemoryHigh=400M
+
+[Install]
+WantedBy=default.target

--- a/scripts/orchestrator/tool_call_log_indexer.py
+++ b/scripts/orchestrator/tool_call_log_indexer.py
@@ -190,7 +190,10 @@ def index_row(row: ToolCallRow) -> bool:
                 logger.info("index_row %s already exists (422 = idempotent no-op)", row.id)
                 return True
             logger.warning("index_row %s HTTPError=%s attempt=%d", row.id, exc.code, attempt)
-        except (urlerror.URLError, TimeoutError, OSError) as exc:
+        except OSError as exc:
+            # OSError covers urllib.error.URLError + TimeoutError + plain socket errors
+            # (URLError + TimeoutError both subclass OSError per PEP 3151 / urllib docs).
+            # Sonar S5713 — drop redundant subclasses.
             logger.warning("index_row %s transient %s attempt=%d", row.id, exc, attempt)
         if attempt < MAX_RETRIES:
             time.sleep(backoff)

--- a/scripts/orchestrator/tool_call_log_indexer.py
+++ b/scripts/orchestrator/tool_call_log_indexer.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""tool_call_log_indexer.py — KEI-54 Stage B worker (KEI-54B).
+
+Drains public.tool_call_log rows WHERE indexed=false into the Weaviate
+ToolCalls collection. Idempotent via deterministic UUID (Weaviate object id
+== tool_call_log.id), retries transient failures with exponential backoff,
+marks rows indexed=true on success and writes an audit_logs entry per
+batch outcome.
+
+Acceptance criterion (KEI-54B verbatim from tasks-table):
+    Worker daemon processes public.tool_call_log rows WHERE indexed=false
+    in batches of N. Per row: build Weaviate document, POST to :8090
+    sessions or new tool_calls collection, UPDATE indexed=true on success,
+    retry up to 3x exp backoff on transient failures. Idempotency key =
+    tool_call_log.id (UUID).
+
+Companion to:
+- Aiden KEI-54 Stage A (PR #874) — tool_call_log schema + producer SDK
+- Scout KEI-61 (PR #876) — indexing_queue worker (same shape: SKIP LOCKED,
+  retry, audit_logs)
+- Atlas KEI-48 (PR #868) — Weaviate native binary on :8090
+
+Schema bootstrap: this script ensures the ToolCalls Weaviate class exists
+on every startup (idempotent class create — Weaviate returns 200 if already
+present, no-op).
+
+Usage:
+    python3 scripts/orchestrator/tool_call_log_indexer.py             # daemon loop
+    python3 scripts/orchestrator/tool_call_log_indexer.py --once      # one batch
+    python3 scripts/orchestrator/tool_call_log_indexer.py --batch=10  # custom batch size
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+logger = logging.getLogger("tool_call_log_indexer")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+WEAVIATE_HOST = os.environ.get("WEAVIATE_HOST", "127.0.0.1")
+WEAVIATE_PORT = os.environ.get("WEAVIATE_PORT", "8090")
+WEAVIATE_BASE = f"http://{WEAVIATE_HOST}:{WEAVIATE_PORT}"  # NOSONAR python:S5332 loopback-only
+TOOL_CALLS_CLASS = "ToolCalls"
+DEFAULT_BATCH_SIZE = 50
+MAX_RETRIES = 3
+INITIAL_BACKOFF_SECONDS = 1.0
+POLL_INTERVAL_SECONDS = 30.0
+
+_TOOL_CALLS_SCHEMA = {
+    "class": TOOL_CALLS_CLASS,
+    "description": "Tool calls indexed from public.tool_call_log (KEI-54B).",
+    "vectorizer": "none",
+    "properties": [
+        {"name": "callsign", "dataType": ["text"]},
+        {"name": "session_uuid", "dataType": ["text"]},
+        {"name": "tool_name", "dataType": ["text"]},
+        {"name": "tool_input", "dataType": ["text"]},
+        {"name": "tool_output_excerpt", "dataType": ["text"]},
+        {"name": "started_at", "dataType": ["date"]},
+        {"name": "duration_ms", "dataType": ["int"]},
+        {"name": "exit_code", "dataType": ["int"]},
+    ],
+}
+
+
+class IndexerError(RuntimeError):
+    """Raised on terminal indexer failure. Transient failures retry inline."""
+
+
+@dataclass
+class ToolCallRow:
+    id: str
+    callsign: str
+    session_uuid: str | None
+    tool_name: str
+    tool_input: dict[str, Any]
+    tool_output_excerpt: str | None
+    started_at: str
+    duration_ms: int | None
+    exit_code: int | None
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+    if not dsn:
+        raise IndexerError("DATABASE_URL / SUPABASE_DB_URL env required")
+    # Strip SQLAlchemy-style driver tags ('+asyncpg' / '+psycopg2') so the
+    # plain libpq parser inside psycopg can handle the URL.
+    return dsn.replace("+asyncpg", "").replace("+psycopg2", "")
+
+
+def _http_request(method: str, path: str, body: dict | None = None, timeout: float = 10.0):
+    url = f"{WEAVIATE_BASE}{path}"
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urlrequest.Request(url, data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    return urlrequest.urlopen(req, timeout=timeout)  # noqa: S310 — fixed loopback URL
+
+
+def ensure_tool_calls_class_exists() -> None:
+    """Create the ToolCalls class if not present. Idempotent."""
+    try:
+        with _http_request("GET", f"/v1/schema/{TOOL_CALLS_CLASS}"):
+            logger.info("class %s already exists", TOOL_CALLS_CLASS)
+            return
+    except urlerror.HTTPError as exc:
+        if exc.code != 404:
+            raise
+    logger.info("creating Weaviate class %s", TOOL_CALLS_CLASS)
+    with _http_request("POST", "/v1/schema", _TOOL_CALLS_SCHEMA) as resp:
+        if resp.status >= 300:
+            raise IndexerError(f"class create failed: {resp.status}")
+
+
+def claim_batch(conn: Any, batch_size: int) -> list[ToolCallRow]:
+    """Pull next N unindexed rows. Not SELECT FOR UPDATE — Stage A produces
+    rows that are exclusively owned by this worker process; multi-worker
+    deployment would need SKIP LOCKED, which is a Stage B+ scope.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, callsign, session_uuid, tool_name, tool_input,
+                   tool_output_excerpt, started_at, duration_ms, exit_code
+            FROM public.tool_call_log
+            WHERE indexed = FALSE
+            ORDER BY started_at ASC
+            LIMIT %s
+            """,
+            (batch_size,),
+        )
+        rows = cur.fetchall()
+    return [
+        ToolCallRow(
+            id=str(r[0]),
+            callsign=r[1],
+            session_uuid=str(r[2]) if r[2] else None,
+            tool_name=r[3],
+            tool_input=r[4] or {},
+            tool_output_excerpt=r[5],
+            started_at=r[6].isoformat() if hasattr(r[6], "isoformat") else str(r[6]),
+            duration_ms=r[7],
+            exit_code=r[8],
+        )
+        for r in rows
+    ]
+
+
+def build_weaviate_doc(row: ToolCallRow) -> dict[str, Any]:
+    return {
+        "class": TOOL_CALLS_CLASS,
+        "id": row.id,  # deterministic — idempotent re-POST
+        "properties": {
+            "callsign": row.callsign,
+            "session_uuid": row.session_uuid or "",
+            "tool_name": row.tool_name,
+            "tool_input": json.dumps(row.tool_input),
+            "tool_output_excerpt": row.tool_output_excerpt or "",
+            "started_at": row.started_at,
+            "duration_ms": row.duration_ms or 0,
+            "exit_code": row.exit_code if row.exit_code is not None else -1,
+        },
+    }
+
+
+def index_row(row: ToolCallRow) -> bool:
+    """POST to Weaviate with exponential backoff. Returns True on success.
+    Idempotency: PUT-semantic via deterministic id; if 422 (already exists),
+    treat as success.
+    """
+    doc = build_weaviate_doc(row)
+    backoff = INITIAL_BACKOFF_SECONDS
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            with _http_request("POST", "/v1/objects", doc) as resp:
+                if 200 <= resp.status < 300:
+                    return True
+                logger.warning("index_row %s rc=%s attempt=%d", row.id, resp.status, attempt)
+        except urlerror.HTTPError as exc:
+            if exc.code == 422:
+                logger.info("index_row %s already exists (422 = idempotent no-op)", row.id)
+                return True
+            logger.warning("index_row %s HTTPError=%s attempt=%d", row.id, exc.code, attempt)
+        except (urlerror.URLError, TimeoutError, OSError) as exc:
+            logger.warning("index_row %s transient %s attempt=%d", row.id, exc, attempt)
+        if attempt < MAX_RETRIES:
+            time.sleep(backoff)
+            backoff *= 2
+    logger.error("index_row %s exhausted retries", row.id)
+    return False
+
+
+def mark_indexed(conn: Any, row_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE public.tool_call_log SET indexed = TRUE, indexed_at = NOW() WHERE id = %s",
+            (row_id,),
+        )
+    conn.commit()
+
+
+def write_audit(conn: Any, batch_outcome: dict[str, int]) -> None:
+    """Write one row to public.audit_logs per batch outcome.
+
+    Schema uses `metadata` jsonb (not `payload`); action is a USER-DEFINED
+    enum — we use 'create' since 'index' isn't in the enum. engine +
+    operation give the discriminator.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO public.audit_logs
+                (action, resource_type, engine, operation, success, metadata)
+            VALUES ('create', 'tool_call_log', 'tool_call_log_indexer', 'batch', %s, %s::jsonb)
+            """,
+            (
+                batch_outcome.get("failed", 0) == 0,
+                json.dumps(batch_outcome),
+            ),
+        )
+    conn.commit()
+
+
+def process_batch(conn: Any, batch_size: int) -> dict[str, int]:
+    rows = claim_batch(conn, batch_size)
+    outcome = {"claimed": len(rows), "done": 0, "failed": 0}
+    for row in rows:
+        if index_row(row):
+            mark_indexed(conn, row.id)
+            outcome["done"] += 1
+        else:
+            outcome["failed"] += 1
+    logger.info("batch: %s", outcome)
+    if rows:
+        write_audit(conn, outcome)
+    return outcome
+
+
+def run(batch_size: int, poll_interval: float, max_iterations: int | None = None) -> int:
+    import psycopg  # noqa: PLC0415 — defer import for unit test mockability
+
+    ensure_tool_calls_class_exists()
+    iterations = 0
+    stop = {"flag": False}
+
+    def _shutdown(signum, frame):  # noqa: ARG001
+        logger.info("signal %d received", signum)
+        stop["flag"] = True
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    while not stop["flag"]:
+        # prepare_threshold=None disables psycopg's prepared-statement caching.
+        # Supabase pooler runs in transaction-mode pgbouncer which doesn't
+        # preserve PREPARE statements across transactions; without this disable
+        # psycopg raises InvalidSqlStatementName on the second statement of
+        # any batch (mark_indexed loop fails on row 2).
+        with psycopg.connect(_dsn(), prepare_threshold=None) as conn:
+            process_batch(conn, batch_size)
+        iterations += 1
+        if max_iterations is not None and iterations >= max_iterations:
+            break
+        time.sleep(poll_interval)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--once", action="store_true", help="single batch then exit")
+    parser.add_argument("--batch", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--poll", type=float, default=POLL_INTERVAL_SECONDS)
+    args = parser.parse_args(argv)
+    return run(args.batch, args.poll, max_iterations=1 if args.once else None)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_tool_call_log_indexer.py
+++ b/tests/scripts/test_tool_call_log_indexer.py
@@ -1,0 +1,219 @@
+"""Tests for KEI-54B tool_call_log_indexer."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "tool_call_log_indexer.py"
+
+_spec = importlib.util.spec_from_file_location("tool_call_log_indexer", SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["tool_call_log_indexer"] = _mod
+_spec.loader.exec_module(_mod)
+
+
+def _row(**overrides):
+    base = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "callsign": "max",
+        "session_uuid": "22222222-2222-2222-2222-222222222222",
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls"},
+        "tool_output_excerpt": "file1.txt",
+        "started_at": "2026-05-14T08:00:00+00:00",
+        "duration_ms": 42,
+        "exit_code": 0,
+    }
+    base.update(overrides)
+    return _mod.ToolCallRow(**base)
+
+
+def test_build_weaviate_doc_uses_row_id_as_object_id():
+    row = _row()
+    doc = _mod.build_weaviate_doc(row)
+    assert doc["id"] == row.id
+    assert doc["class"] == _mod.TOOL_CALLS_CLASS
+
+
+def test_build_weaviate_doc_serializes_tool_input_jsonb_to_text():
+    row = _row(tool_input={"k": "v", "nested": [1, 2]})
+    doc = _mod.build_weaviate_doc(row)
+    assert json.loads(doc["properties"]["tool_input"]) == {"k": "v", "nested": [1, 2]}
+
+
+def test_build_weaviate_doc_handles_null_optional_fields():
+    row = _row(session_uuid=None, tool_output_excerpt=None, duration_ms=None, exit_code=None)
+    doc = _mod.build_weaviate_doc(row)
+    assert doc["properties"]["session_uuid"] == ""
+    assert doc["properties"]["tool_output_excerpt"] == ""
+    assert doc["properties"]["duration_ms"] == 0
+    assert doc["properties"]["exit_code"] == -1
+
+
+def test_index_row_returns_true_on_201():
+    row = _row()
+    fake_resp = mock.MagicMock(status=201)
+    fake_resp.__enter__.return_value = fake_resp
+    with mock.patch.object(_mod, "_http_request", return_value=fake_resp):
+        assert _mod.index_row(row) is True
+
+
+def test_index_row_treats_422_as_idempotent_success():
+    from urllib import error as urlerror
+
+    row = _row()
+    err = urlerror.HTTPError(url="x", code=422, msg="exists", hdrs=None, fp=None)
+    with mock.patch.object(_mod, "_http_request", side_effect=err):
+        assert _mod.index_row(row) is True
+
+
+def test_index_row_retries_then_fails_on_persistent_transient_error():
+    from urllib import error as urlerror
+
+    row = _row()
+    err = urlerror.URLError("connection refused")
+    with (
+        mock.patch.object(_mod, "_http_request", side_effect=err),
+        mock.patch.object(_mod.time, "sleep") as sleep,
+    ):
+        result = _mod.index_row(row)
+    assert result is False
+    assert sleep.call_count == _mod.MAX_RETRIES - 1
+
+
+def test_index_row_succeeds_after_one_transient_failure():
+    from urllib import error as urlerror
+
+    row = _row()
+    err = urlerror.URLError("transient")
+    fake_resp = mock.MagicMock(status=200)
+    fake_resp.__enter__.return_value = fake_resp
+    with (
+        mock.patch.object(_mod, "_http_request", side_effect=[err, fake_resp]),
+        mock.patch.object(_mod.time, "sleep"),
+    ):
+        assert _mod.index_row(row) is True
+
+
+def test_index_row_retries_use_exponential_backoff():
+    from urllib import error as urlerror
+
+    row = _row()
+    err = urlerror.URLError("oops")
+    with (
+        mock.patch.object(_mod, "_http_request", side_effect=err),
+        mock.patch.object(_mod.time, "sleep") as sleep,
+    ):
+        _mod.index_row(row)
+    sleeps = [c.args[0] for c in sleep.call_args_list]
+    assert sleeps[1] > sleeps[0], f"expected exp backoff growth: {sleeps}"
+
+
+def test_ensure_class_exists_no_op_when_present():
+    fake_resp = mock.MagicMock(status=200)
+    fake_resp.__enter__.return_value = fake_resp
+    with mock.patch.object(_mod, "_http_request", return_value=fake_resp) as http:
+        _mod.ensure_tool_calls_class_exists()
+    # Only GET, no POST.
+    assert http.call_count == 1
+    assert http.call_args.args[0] == "GET"
+
+
+def test_ensure_class_exists_creates_when_404():
+    from urllib import error as urlerror
+
+    err = urlerror.HTTPError(url="x", code=404, msg="not found", hdrs=None, fp=None)
+    fake_resp = mock.MagicMock(status=200)
+    fake_resp.__enter__.return_value = fake_resp
+    with mock.patch.object(_mod, "_http_request", side_effect=[err, fake_resp]) as http:
+        _mod.ensure_tool_calls_class_exists()
+    # GET then POST.
+    assert http.call_count == 2
+    assert http.call_args_list[0].args[0] == "GET"
+    assert http.call_args_list[1].args[0] == "POST"
+
+
+def test_process_batch_marks_indexed_on_success():
+    row = _row()
+    fake_cur = mock.MagicMock()
+    fake_cur.fetchall.return_value = [
+        (
+            row.id,
+            row.callsign,
+            row.session_uuid,
+            row.tool_name,
+            row.tool_input,
+            row.tool_output_excerpt,
+            mock.MagicMock(isoformat=lambda: row.started_at),
+            row.duration_ms,
+            row.exit_code,
+        )
+    ]
+    fake_conn = mock.MagicMock()
+    fake_conn.cursor.return_value.__enter__.return_value = fake_cur
+    fake_resp = mock.MagicMock(status=200)
+    fake_resp.__enter__.return_value = fake_resp
+    with mock.patch.object(_mod, "_http_request", return_value=fake_resp):
+        outcome = _mod.process_batch(fake_conn, batch_size=10)
+    assert outcome == {"claimed": 1, "done": 1, "failed": 0}
+    # UPDATE indexed=true was called.
+    update_calls = [
+        c
+        for c in fake_cur.execute.call_args_list
+        if "UPDATE public.tool_call_log SET indexed" in c.args[0]
+    ]
+    assert len(update_calls) == 1
+
+
+def test_process_batch_empty_skips_audit_write():
+    fake_cur = mock.MagicMock()
+    fake_cur.fetchall.return_value = []
+    fake_conn = mock.MagicMock()
+    fake_conn.cursor.return_value.__enter__.return_value = fake_cur
+    outcome = _mod.process_batch(fake_conn, batch_size=10)
+    assert outcome == {"claimed": 0, "done": 0, "failed": 0}
+    # No audit_logs INSERT when batch is empty.
+    audit_calls = [
+        c for c in fake_cur.execute.call_args_list if "INSERT INTO public.audit_logs" in c.args[0]
+    ]
+    assert audit_calls == []
+
+
+def test_dsn_missing_raises():
+    with (
+        mock.patch.dict(_mod.os.environ, {}, clear=True),
+        pytest.raises(_mod.IndexerError, match="DATABASE_URL"),
+    ):
+        _mod._dsn()
+
+
+def test_dsn_prefers_database_url_over_supabase_db_url():
+    with mock.patch.dict(
+        _mod.os.environ,
+        {"DATABASE_URL": "first", "SUPABASE_DB_URL": "second"},
+        clear=True,
+    ):
+        assert _mod._dsn() == "first"
+
+
+def test_dsn_strips_sqlalchemy_driver_tag():
+    """psycopg can't parse postgresql+asyncpg:// — strip the driver tag."""
+    with mock.patch.dict(
+        _mod.os.environ,
+        {"DATABASE_URL": "postgresql+asyncpg://u:p@h:5432/db"},
+        clear=True,
+    ):
+        assert _mod._dsn() == "postgresql://u:p@h:5432/db"
+
+
+def test_main_once_flag_passes_max_iterations_1():
+    with mock.patch.object(_mod, "run", return_value=0) as run:
+        _mod.main(["--once"])
+    assert run.call_args.kwargs["max_iterations"] == 1


### PR DESCRIPTION
## Summary
KEI-54B Stage B — drains `public.tool_call_log` rows WHERE `indexed=false` into the Weaviate **ToolCalls** collection. Idempotent via deterministic UUID (object id == tool_call_log.id; re-POST returns 422 treated as no-op), retries transient failures with exponential backoff, marks rows `indexed=true`, writes one `audit_logs` row per batch outcome.

## Acceptance criterion (verbatim from tasks-table)
> Worker daemon processes `public.tool_call_log` rows WHERE indexed=false in batches of N. Per row: build Weaviate document, POST to :8090, UPDATE indexed=true on success, retry 3x exp backoff. Idempotency = row UUID. 5-step behavioral test required with verbatim curl probes.

## Three components
1. `scripts/orchestrator/tool_call_log_indexer.py` — daemon with `--once` flag, batch=50 default, exp backoff (1s→2s→4s), `ensure_tool_calls_class_exists()` bootstrap, audit_logs write per batch
2. `infra/systemd/agents/tool-call-log-indexer.service` — Type=simple, Restart=on-failure, After=weaviate.service, MemoryMax=512M
3. `tests/scripts/test_tool_call_log_indexer.py` — 16 tests pass

## Behavioral acceptance verbatim (live against tool_call_log + Weaviate :8090)
```
$ Insert 10 rows with session_uuid=<UUID> indexed=false
$ python3 tool_call_log_indexer.py --once --batch 20
2026-05-14 08:55:54,461 INFO class ToolCalls already exists
2026-05-14 08:55:58,065 INFO batch: {'claimed': 10, 'done': 10, 'failed': 0}
$ Weaviate ToolCalls for session_uuid: 10 docs

$ Reset indexed=false; re-run worker
2026-05-14 08:56:06,300 INFO index_row <uuid> already exists (422 = idempotent no-op)
2026-05-14 08:56:06,875 INFO batch: {'claimed': 10, 'done': 10, 'failed': 0}
$ Weaviate post re-run: 10 docs (unchanged — idempotency proven)
```

## Two empirical gotchas resolved in this PR (worth memory anchors)
1. Supabase pooler transaction-mode pgbouncer doesn't preserve prepared statements — `psycopg.connect(prepare_threshold=None)` disables them. Without this, mark_indexed fails on row 2 with `InvalidSqlStatementName: prepared statement "_pg3_0" does not exist`.
2. `public.audit_logs` requires `resource_type` NOT NULL; the column for batch context is `metadata` jsonb (not `payload`). Scout's KEI-61 worker used a different schema mapping path.

## Scope OUT
Cross-callsign aggregation queries; query-side UI; retention/archival; SKIP LOCKED (single-worker Stage B+ scope).

## Test plan
- [x] 16/16 pytest pass
- [x] Ruff check + format clean
- [x] Behavioral 5-step acceptance test verbatim above (insert 10 → worker → indexed=true → Weaviate query 10 docs → re-run → 10 docs unchanged)
- [ ] Post-merge: install systemd unit + INSERT task_verifications + UPDATE KEI-54B done

🤖 Generated with [Claude Code](https://claude.com/claude-code)