### PR TITLE
[SCOUT] feat(kei71): tasks_cli refuse claim on DEFAULT_CALLSIGN sentinel

### DIFF
--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -133,10 +133,26 @@ def cmd_ready(args: argparse.Namespace) -> int:
 
 
 def cmd_claim(args: argparse.Namespace) -> int:
-    """Atomically claim one task (by id, or the next available)."""
+    """Atomically claim one task (by id, or the next available).
+
+    KEI-71: refuse the claim when the resolved callsign is the
+    DEFAULT_CALLSIGN sentinel ('unknown') — Elliot Dave-direct callout
+    2026-05-14T08:30Z: silent sentinel-writes (`claimed_by='unknown'`)
+    leak when an agent omits `CALLSIGN=<callsign>` from the env. Fail
+    fast at the validation layer so the operator notices the env gap
+    instead of orphan-claiming a row.
+    """
     import psycopg
 
     cs = _callsign(args.callsign)
+    if cs == DEFAULT_CALLSIGN:
+        print(
+            "ERROR: callsign resolves to the DEFAULT_CALLSIGN sentinel "
+            f"({DEFAULT_CALLSIGN!r}). Set CALLSIGN=<your_callsign> in the env or "
+            "pass --callsign explicitly. Refusing to write a sentinel claim.",
+            file=sys.stderr,
+        )
+        return 1
     try:
         with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
             if args.id:

--- a/tests/scripts/test_tasks_cli.py
+++ b/tests/scripts/test_tasks_cli.py
@@ -270,6 +270,24 @@ def test_claim_returns_null_when_nothing_available(mod, patch_connect, capsys, m
     assert capsys.readouterr().out.strip() == "null"
 
 
+def test_claim_refuses_default_callsign_sentinel(mod, capsys, monkeypatch) -> None:
+    """KEI-71: cmd_claim refuses to write 'unknown' as claimed_by — fail-fast."""
+    monkeypatch.delenv("CALLSIGN", raising=False)
+    monkeypatch.delenv("TASKS_CALLSIGN", raising=False)
+    rc = mod.main(["claim", "--id", "KEI-39"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "DEFAULT_CALLSIGN sentinel" in captured.err
+    assert "'unknown'" in captured.err
+
+
+def test_claim_refuses_explicit_unknown_callsign(mod, capsys, monkeypatch) -> None:
+    """Explicit --callsign unknown also refused (defensive)."""
+    rc = mod.main(["claim", "--callsign", "unknown"])
+    assert rc == 1
+    assert "DEFAULT_CALLSIGN sentinel" in capsys.readouterr().err
+
+
 # ─── complete ────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Elliot Dave-direct callout 2026-05-14T08:30Z: KEI-51 task row had `claimed_by='unknown'` because an agent ran `tasks_cli claim` without `CALLSIGN` in env, and `cmd_claim` silently wrote the `DEFAULT_CALLSIGN` sentinel.

Fix: `cmd_claim` now refuses the claim when `_callsign()` resolves to `DEFAULT_CALLSIGN`. Returns exit code 1 with a stderr message naming the sentinel + telling the operator how to set CALLSIGN. Fail-fast at the validation layer instead of silent sentinel-writes.

## Scope

Narrowed from the initial KEI-71 plan (extract `_dsn` into `scripts/_db_dsn.py` shared util). Import-path complications with `importlib.util.spec_from_file_location` test loaders meant the extraction wasn't a clean drop-in. The `_dsn` dup is benign (didn't trip the dup-density gate; canonical tests in `test_tasks_cli.py` cover the shape). Filing `_dsn` extraction as a separate follow-up once the package-vs-script-as-module question is settled across `scripts/`.

## Test plan

- [x] `test_claim_refuses_default_callsign_sentinel` (env unset → exit 1, stderr names sentinel)
- [x] `test_claim_refuses_explicit_unknown_callsign` (`--callsign unknown` → same)
- [x] Existing 16 claim/complete/show/ready tests in test_tasks_cli.py: all pass
- [x] test_indexing_queue_worker.py + test_linear_webhook.py: no regression
- [x] 47/47 PASS overall; ruff clean

Refs: KEI-71 (filed in tasks table this turn). Closes Elliot's Dave-direct validation-layer gap.

🤖 Authored by [SCOUT] (Sonnet 4.6 research clone)