### PR TITLE
[SCOUT] feat(kei72): gate slack_relay auto-claim on recent [STEP-0-RESTATE:<callsign>] marker

### DIFF
--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -371,9 +371,9 @@ _CLONE_CALLSIGNS: frozenset[str] = frozenset({"atlas", "orion", "scout"})
 # 5 is Elliot's directive value.
 _STEP0_INBOX_SCAN_DEPTH = 5
 # Inbox base dir, env-overridable for tests. Defaults to /tmp which is the
-# canonical relay-listener location on the host. NOSONAR S5443 — /tmp is the
-# documented runtime location for the per-callsign relay inbox; tests
-# override via AGENCY_OS_RELAY_INBOX_BASE.
+# documented runtime location for the per-callsign relay inbox; tests override
+# via AGENCY_OS_RELAY_INBOX_BASE. The S5443 suppression is the inline marker
+# on the assignment below.
 _RELAY_INBOX_BASE = os.environ.get("AGENCY_OS_RELAY_INBOX_BASE", "/tmp")  # NOSONAR
 
 

--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -363,6 +363,51 @@ def _is_ready_marker(message: str, callsign: str) -> bool:
 # that fix lands, which is preferable to the wrong-issue claim.
 _CLONE_CALLSIGNS: frozenset[str] = frozenset({"atlas", "orion", "scout"})
 
+# KEI-72: second-gate window for the Step-0-RESTATE auto-claim check.
+# Scans this many most-recently-processed inbox messages for the agent's
+# own [STEP-0-RESTATE:<callsign>] marker. Larger windows risk stale-claim
+# (an old Step 0 from a different directive); smaller windows tighten the
+# requirement but may miss legitimate Step 0s separated by peer chatter.
+# 5 is Elliot's directive value.
+_STEP0_INBOX_SCAN_DEPTH = 5
+
+
+def _has_recent_step0_restate(callsign: str) -> bool:
+    """KEI-72: True if a [STEP-0-RESTATE:<callsign>] marker appears in any of
+    the last `_STEP0_INBOX_SCAN_DEPTH` processed inbox messages.
+
+    Scans `/tmp/telegram-relay-<callsign>/processed/`. Messages there are
+    JSON dicts with at least a `text` field; the relay listener moves files
+    here once they're consumed. The agent's own Step-0-RESTATE outbound
+    (posted via tg) is echoed back through the central listener into the
+    same inbox, so this scan covers self-emitted markers.
+
+    Returns False (and skips the auto-claim) when the marker isn't found —
+    fail-fast at the validation layer. Closes the gap left by KEI-71 (which
+    only handled the env-unset path).
+    """
+    inbox_processed = Path(f"/tmp/telegram-relay-{callsign.lower()}/processed")
+    if not inbox_processed.is_dir():
+        return False
+    needle = f"[STEP-0-RESTATE:{callsign.upper()}]"
+    try:
+        files = sorted(
+            (p for p in inbox_processed.iterdir() if p.is_file()),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )[:_STEP0_INBOX_SCAN_DEPTH]
+    except OSError:
+        return False
+    for path in files:
+        try:
+            data = json.loads(path.read_text() or "{}")
+        except (OSError, json.JSONDecodeError):
+            continue
+        text = data.get("text", "") or ""
+        if needle in text:
+            return True
+    return False
+
 
 def _maybe_self_assign(message: str) -> None:
     """If message contains an anchored [READY:<my-callsign>], try bd ready → bd claim.
@@ -371,10 +416,23 @@ def _maybe_self_assign(message: str) -> None:
     + return. Never raises. The polling loop is the safety net if this fails.
 
     Clones (atlas/orion/scout) skip-claim entirely — see _CLONE_CALLSIGNS.
+
+    KEI-72: also refuse claim when there's no recent [STEP-0-RESTATE:<callsign>]
+    marker in the last _STEP0_INBOX_SCAN_DEPTH inbox messages. Closes the
+    'CALLSIGN-set-but-no-Step-0' auto-reclaim loop Elliot flagged at
+    2026-05-14T09:08Z.
     """
     if CALLSIGN.lower() in _CLONE_CALLSIGNS:
         return
     if not _is_ready_marker(message, CALLSIGN):
+        return
+    if not _has_recent_step0_restate(CALLSIGN):
+        print(
+            f"[self-assign] refusing claim — no [STEP-0-RESTATE:{CALLSIGN.upper()}] "
+            f"in the last {_STEP0_INBOX_SCAN_DEPTH} processed inbox messages. "
+            "Agent must post a Step 0 RESTATE before slack_relay auto-claims (KEI-72).",
+            file=sys.stderr,
+        )
         return
     import subprocess as _sub
 

--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -370,23 +370,29 @@ _CLONE_CALLSIGNS: frozenset[str] = frozenset({"atlas", "orion", "scout"})
 # requirement but may miss legitimate Step 0s separated by peer chatter.
 # 5 is Elliot's directive value.
 _STEP0_INBOX_SCAN_DEPTH = 5
+# Inbox base dir, env-overridable for tests. Defaults to /tmp which is the
+# canonical relay-listener location on the host. NOSONAR S5443 — /tmp is the
+# documented runtime location for the per-callsign relay inbox; tests
+# override via AGENCY_OS_RELAY_INBOX_BASE.
+_RELAY_INBOX_BASE = os.environ.get("AGENCY_OS_RELAY_INBOX_BASE", "/tmp")  # NOSONAR
 
 
 def _has_recent_step0_restate(callsign: str) -> bool:
     """KEI-72: True if a [STEP-0-RESTATE:<callsign>] marker appears in any of
     the last `_STEP0_INBOX_SCAN_DEPTH` processed inbox messages.
 
-    Scans `/tmp/telegram-relay-<callsign>/processed/`. Messages there are
-    JSON dicts with at least a `text` field; the relay listener moves files
-    here once they're consumed. The agent's own Step-0-RESTATE outbound
-    (posted via tg) is echoed back through the central listener into the
-    same inbox, so this scan covers self-emitted markers.
+    Scans `<_RELAY_INBOX_BASE>/telegram-relay-<callsign>/processed/`.
+    Messages there are JSON dicts with at least a `text` field; the relay
+    listener moves files here once they're consumed. The agent's own
+    Step-0-RESTATE outbound (posted via tg) is echoed back through the
+    central listener into the same inbox, so this scan covers self-emitted
+    markers.
 
     Returns False (and skips the auto-claim) when the marker isn't found —
     fail-fast at the validation layer. Closes the gap left by KEI-71 (which
     only handled the env-unset path).
     """
-    inbox_processed = Path(f"/tmp/telegram-relay-{callsign.lower()}/processed")
+    inbox_processed = Path(_RELAY_INBOX_BASE) / f"telegram-relay-{callsign.lower()}" / "processed"
     if not inbox_processed.is_dir():
         return False
     needle = f"[STEP-0-RESTATE:{callsign.upper()}]"

--- a/tests/scripts/test_step0_gate.py
+++ b/tests/scripts/test_step0_gate.py
@@ -1,14 +1,18 @@
 """tests for scripts/slack_relay.py — KEI-72 Step-0-RESTATE gate.
 
 Verifies _has_recent_step0_restate scans the right inbox/processed/
-directory + matches the marker case-insensitively (via callsign.upper())
-+ returns False when:
+directory + matches the marker + returns False when:
   - the inbox dir doesn't exist
   - no recent message contains the marker
   - JSON files are malformed
+  - the marker is older than _STEP0_INBOX_SCAN_DEPTH messages back
 
 Also verifies _maybe_self_assign refuses to invoke bd ready/claim when
 the gate fails (the integration check Elliot cares about).
+
+Inbox path resolution uses the AGENCY_OS_RELAY_INBOX_BASE env var so
+tests redirect into pytest's tmp_path without monkeypatching the Path
+constructor.
 """
 
 from __future__ import annotations
@@ -17,6 +21,7 @@ import importlib.util
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -47,113 +52,76 @@ def _write_inbox_message(inbox_dir: Path, name: str, text: str) -> Path:
 # ─── _has_recent_step0_restate ─────────────────────────────────────────────
 
 
-def test_step0_present_via_tmp_path(tmp_path: Path, monkeypatch) -> None:
-    """tmp_path-based: writes a STEP-0-RESTATE message + asserts True."""
-    mod = _load_slack_relay()
+def test_step0_present_returns_true(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Marker present in recent inbox → True."""
     callsign = "elliot"
+    monkeypatch.setenv("AGENCY_OS_RELAY_INBOX_BASE", str(tmp_path))
+    mod = _load_slack_relay()
     inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
     _write_inbox_message(inbox, "msg1.json", "[STEP-0-RESTATE:ELLIOT] objective scope")
-
-    # Patch Path constructor to redirect /tmp/telegram-relay-* to tmp_path.
-    real_path_cls = mod.Path
-
-    def fake_path(s: str) -> Path:
-        if s == f"/tmp/telegram-relay-{callsign}/processed":
-            return inbox
-        return real_path_cls(s)
-
-    monkeypatch.setattr(mod, "Path", fake_path)
     assert mod._has_recent_step0_restate(callsign) is True
 
 
-def test_step0_absent_returns_false(tmp_path: Path, monkeypatch) -> None:
-    mod = _load_slack_relay()
+def test_step0_absent_returns_false(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     callsign = "elliot"
+    monkeypatch.setenv("AGENCY_OS_RELAY_INBOX_BASE", str(tmp_path))
+    mod = _load_slack_relay()
     inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
     _write_inbox_message(inbox, "msg1.json", "some unrelated message")
     _write_inbox_message(inbox, "msg2.json", "[READY:elliot] but no step 0")
-
-    def fake_path(s: str) -> Path:
-        if s == f"/tmp/telegram-relay-{callsign}/processed":
-            return inbox
-        return Path(s)
-
-    monkeypatch.setattr(mod, "Path", fake_path)
     assert mod._has_recent_step0_restate(callsign) is False
 
 
-def test_step0_inbox_dir_missing_returns_false(tmp_path: Path, monkeypatch) -> None:
+def test_step0_inbox_dir_missing_returns_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No inbox dir for the callsign → False (no crash)."""
+    monkeypatch.setenv("AGENCY_OS_RELAY_INBOX_BASE", str(tmp_path))
     mod = _load_slack_relay()
-    callsign = "elliot"
-    missing = tmp_path / "does-not-exist"
-
-    def fake_path(s: str) -> Path:
-        if s == f"/tmp/telegram-relay-{callsign}/processed":
-            return missing
-        return Path(s)
-
-    monkeypatch.setattr(mod, "Path", fake_path)
-    assert mod._has_recent_step0_restate(callsign) is False
+    # No directory written at tmp_path/telegram-relay-elliot/processed.
+    assert mod._has_recent_step0_restate("elliot") is False
 
 
-def test_step0_malformed_json_skipped(tmp_path: Path, monkeypatch) -> None:
+def test_step0_malformed_json_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A malformed JSON file in processed/ must not crash the scan."""
-    mod = _load_slack_relay()
     callsign = "elliot"
+    monkeypatch.setenv("AGENCY_OS_RELAY_INBOX_BASE", str(tmp_path))
+    mod = _load_slack_relay()
     inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
     inbox.mkdir(parents=True)
     (inbox / "bad.json").write_text("not json at all {")
     _write_inbox_message(inbox, "good.json", "[STEP-0-RESTATE:ELLIOT] valid")
-
-    def fake_path(s: str) -> Path:
-        if s == f"/tmp/telegram-relay-{callsign}/processed":
-            return inbox
-        return Path(s)
-
-    monkeypatch.setattr(mod, "Path", fake_path)
     assert mod._has_recent_step0_restate(callsign) is True
 
 
-def test_step0_scan_depth_respected(tmp_path: Path, monkeypatch) -> None:
+def test_step0_scan_depth_respected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """If the marker is OLDER than _STEP0_INBOX_SCAN_DEPTH messages back, no match."""
-    mod = _load_slack_relay()
     callsign = "elliot"
+    monkeypatch.setenv("AGENCY_OS_RELAY_INBOX_BASE", str(tmp_path))
+    mod = _load_slack_relay()
     inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
     # Write the marker first (oldest mtime).
     _write_inbox_message(inbox, "msg_oldest.json", "[STEP-0-RESTATE:ELLIOT] ancient")
-    # Write SCAN_DEPTH + 1 newer messages without the marker.
-    import time
-
     time.sleep(0.01)
+    # Write SCAN_DEPTH + 1 newer messages without the marker.
     for i in range(mod._STEP0_INBOX_SCAN_DEPTH + 1):
         _write_inbox_message(inbox, f"msg_new_{i}.json", f"newer-{i} no marker")
         time.sleep(0.005)
-
-    def fake_path(s: str) -> Path:
-        if s == f"/tmp/telegram-relay-{callsign}/processed":
-            return inbox
-        return Path(s)
-
-    monkeypatch.setattr(mod, "Path", fake_path)
     assert mod._has_recent_step0_restate(callsign) is False
 
 
 # ─── _maybe_self_assign integration ─────────────────────────────────────────
 
 
-def test_self_assign_refuses_when_no_step0(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_self_assign_refuses_when_no_step0(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
     """KEI-72 acceptance: _maybe_self_assign refuses to invoke bd when no Step 0."""
-    mod = _load_slack_relay()
     callsign = "elliot"
+    monkeypatch.setenv("AGENCY_OS_RELAY_INBOX_BASE", str(tmp_path))
+    mod = _load_slack_relay()
     inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
     _write_inbox_message(inbox, "msg.json", "no step 0 here")
-
-    def fake_path(s: str) -> Path:
-        if s == f"/tmp/telegram-relay-{callsign}/processed":
-            return inbox
-        return Path(s)
-
-    monkeypatch.setattr(mod, "Path", fake_path)
 
     bd_calls: list[list[str]] = []
 
@@ -169,19 +137,15 @@ def test_self_assign_refuses_when_no_step0(tmp_path: Path, monkeypatch, capsys) 
     assert "STEP-0-RESTATE" in captured.err
 
 
-def test_self_assign_proceeds_when_step0_present(tmp_path: Path, monkeypatch) -> None:
+def test_self_assign_proceeds_when_step0_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """When Step 0 marker IS in inbox, _maybe_self_assign should proceed to bd ready."""
-    mod = _load_slack_relay()
     callsign = "elliot"
+    monkeypatch.setenv("AGENCY_OS_RELAY_INBOX_BASE", str(tmp_path))
+    mod = _load_slack_relay()
     inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
     _write_inbox_message(inbox, "msg.json", "[STEP-0-RESTATE:ELLIOT] continuing dispatch X")
-
-    def fake_path(s: str) -> Path:
-        if s == f"/tmp/telegram-relay-{callsign}/processed":
-            return inbox
-        return Path(s)
-
-    monkeypatch.setattr(mod, "Path", fake_path)
 
     bd_calls: list[list[str]] = []
 
@@ -193,18 +157,15 @@ def test_self_assign_proceeds_when_step0_present(tmp_path: Path, monkeypatch) ->
 
     def fake_subprocess_run(cmd: list[str], **kw: object):
         bd_calls.append(cmd)
-        # bd ready returns empty → _maybe_self_assign exits without claim.
         return FakeCompleted(returncode=0, stdout="[]")
 
     with patch("subprocess.run", fake_subprocess_run):
         mod._maybe_self_assign("[READY:elliot] continuing")
-    # bd ready should have been called (the gate let us through), even though
-    # nothing was claimed (empty queue).
     assert any("ready" in cmd for cmd in bd_calls), f"expected bd ready call, got {bd_calls}"
 
 
 @pytest.fixture(autouse=True)
-def _clean_callsign_env(monkeypatch):
+def _clean_callsign_env(monkeypatch: pytest.MonkeyPatch):
     """Ensure each test gets a fresh CALLSIGN=elliot (non-clone)."""
     monkeypatch.setenv("CALLSIGN", "elliot")
     monkeypatch.setenv("SLACK_BOT_TOKEN", "test-token")

--- a/tests/scripts/test_step0_gate.py
+++ b/tests/scripts/test_step0_gate.py
@@ -1,0 +1,211 @@
+"""tests for scripts/slack_relay.py — KEI-72 Step-0-RESTATE gate.
+
+Verifies _has_recent_step0_restate scans the right inbox/processed/
+directory + matches the marker case-insensitively (via callsign.upper())
++ returns False when:
+  - the inbox dir doesn't exist
+  - no recent message contains the marker
+  - JSON files are malformed
+
+Also verifies _maybe_self_assign refuses to invoke bd ready/claim when
+the gate fails (the integration check Elliot cares about).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "slack_relay.py"
+
+
+def _load_slack_relay():
+    """Reload the module under a non-clone CALLSIGN so the self-assign path runs."""
+    os.environ.setdefault("SLACK_BOT_TOKEN", "test-token")
+    os.environ["CALLSIGN"] = "elliot"  # not in _CLONE_CALLSIGNS
+    spec = importlib.util.spec_from_file_location("slack_relay_kei72", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["slack_relay_kei72"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_inbox_message(inbox_dir: Path, name: str, text: str) -> Path:
+    inbox_dir.mkdir(parents=True, exist_ok=True)
+    p = inbox_dir / name
+    p.write_text(json.dumps({"type": "text", "text": text, "sender": "test"}))
+    return p
+
+
+# ─── _has_recent_step0_restate ─────────────────────────────────────────────
+
+
+def test_step0_present_via_tmp_path(tmp_path: Path, monkeypatch) -> None:
+    """tmp_path-based: writes a STEP-0-RESTATE message + asserts True."""
+    mod = _load_slack_relay()
+    callsign = "elliot"
+    inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
+    _write_inbox_message(inbox, "msg1.json", "[STEP-0-RESTATE:ELLIOT] objective scope")
+
+    # Patch Path constructor to redirect /tmp/telegram-relay-* to tmp_path.
+    real_path_cls = mod.Path
+
+    def fake_path(s: str) -> Path:
+        if s == f"/tmp/telegram-relay-{callsign}/processed":
+            return inbox
+        return real_path_cls(s)
+
+    monkeypatch.setattr(mod, "Path", fake_path)
+    assert mod._has_recent_step0_restate(callsign) is True
+
+
+def test_step0_absent_returns_false(tmp_path: Path, monkeypatch) -> None:
+    mod = _load_slack_relay()
+    callsign = "elliot"
+    inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
+    _write_inbox_message(inbox, "msg1.json", "some unrelated message")
+    _write_inbox_message(inbox, "msg2.json", "[READY:elliot] but no step 0")
+
+    def fake_path(s: str) -> Path:
+        if s == f"/tmp/telegram-relay-{callsign}/processed":
+            return inbox
+        return Path(s)
+
+    monkeypatch.setattr(mod, "Path", fake_path)
+    assert mod._has_recent_step0_restate(callsign) is False
+
+
+def test_step0_inbox_dir_missing_returns_false(tmp_path: Path, monkeypatch) -> None:
+    mod = _load_slack_relay()
+    callsign = "elliot"
+    missing = tmp_path / "does-not-exist"
+
+    def fake_path(s: str) -> Path:
+        if s == f"/tmp/telegram-relay-{callsign}/processed":
+            return missing
+        return Path(s)
+
+    monkeypatch.setattr(mod, "Path", fake_path)
+    assert mod._has_recent_step0_restate(callsign) is False
+
+
+def test_step0_malformed_json_skipped(tmp_path: Path, monkeypatch) -> None:
+    """A malformed JSON file in processed/ must not crash the scan."""
+    mod = _load_slack_relay()
+    callsign = "elliot"
+    inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
+    inbox.mkdir(parents=True)
+    (inbox / "bad.json").write_text("not json at all {")
+    _write_inbox_message(inbox, "good.json", "[STEP-0-RESTATE:ELLIOT] valid")
+
+    def fake_path(s: str) -> Path:
+        if s == f"/tmp/telegram-relay-{callsign}/processed":
+            return inbox
+        return Path(s)
+
+    monkeypatch.setattr(mod, "Path", fake_path)
+    assert mod._has_recent_step0_restate(callsign) is True
+
+
+def test_step0_scan_depth_respected(tmp_path: Path, monkeypatch) -> None:
+    """If the marker is OLDER than _STEP0_INBOX_SCAN_DEPTH messages back, no match."""
+    mod = _load_slack_relay()
+    callsign = "elliot"
+    inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
+    # Write the marker first (oldest mtime).
+    _write_inbox_message(inbox, "msg_oldest.json", "[STEP-0-RESTATE:ELLIOT] ancient")
+    # Write SCAN_DEPTH + 1 newer messages without the marker.
+    import time
+
+    time.sleep(0.01)
+    for i in range(mod._STEP0_INBOX_SCAN_DEPTH + 1):
+        _write_inbox_message(inbox, f"msg_new_{i}.json", f"newer-{i} no marker")
+        time.sleep(0.005)
+
+    def fake_path(s: str) -> Path:
+        if s == f"/tmp/telegram-relay-{callsign}/processed":
+            return inbox
+        return Path(s)
+
+    monkeypatch.setattr(mod, "Path", fake_path)
+    assert mod._has_recent_step0_restate(callsign) is False
+
+
+# ─── _maybe_self_assign integration ─────────────────────────────────────────
+
+
+def test_self_assign_refuses_when_no_step0(tmp_path: Path, monkeypatch, capsys) -> None:
+    """KEI-72 acceptance: _maybe_self_assign refuses to invoke bd when no Step 0."""
+    mod = _load_slack_relay()
+    callsign = "elliot"
+    inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
+    _write_inbox_message(inbox, "msg.json", "no step 0 here")
+
+    def fake_path(s: str) -> Path:
+        if s == f"/tmp/telegram-relay-{callsign}/processed":
+            return inbox
+        return Path(s)
+
+    monkeypatch.setattr(mod, "Path", fake_path)
+
+    bd_calls: list[list[str]] = []
+
+    def boom_subprocess_run(cmd: list[str], **kw: object):
+        bd_calls.append(cmd)
+        raise AssertionError(f"bd should NOT have been called: {cmd}")
+
+    with patch("subprocess.run", boom_subprocess_run):
+        mod._maybe_self_assign("[READY:elliot] continuing")
+    assert bd_calls == []
+    captured = capsys.readouterr()
+    assert "refusing claim" in captured.err
+    assert "STEP-0-RESTATE" in captured.err
+
+
+def test_self_assign_proceeds_when_step0_present(tmp_path: Path, monkeypatch) -> None:
+    """When Step 0 marker IS in inbox, _maybe_self_assign should proceed to bd ready."""
+    mod = _load_slack_relay()
+    callsign = "elliot"
+    inbox = tmp_path / f"telegram-relay-{callsign}" / "processed"
+    _write_inbox_message(inbox, "msg.json", "[STEP-0-RESTATE:ELLIOT] continuing dispatch X")
+
+    def fake_path(s: str) -> Path:
+        if s == f"/tmp/telegram-relay-{callsign}/processed":
+            return inbox
+        return Path(s)
+
+    monkeypatch.setattr(mod, "Path", fake_path)
+
+    bd_calls: list[list[str]] = []
+
+    class FakeCompleted:
+        def __init__(self, *, returncode: int = 0, stdout: str = "[]") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = ""
+
+    def fake_subprocess_run(cmd: list[str], **kw: object):
+        bd_calls.append(cmd)
+        # bd ready returns empty → _maybe_self_assign exits without claim.
+        return FakeCompleted(returncode=0, stdout="[]")
+
+    with patch("subprocess.run", fake_subprocess_run):
+        mod._maybe_self_assign("[READY:elliot] continuing")
+    # bd ready should have been called (the gate let us through), even though
+    # nothing was claimed (empty queue).
+    assert any("ready" in cmd for cmd in bd_calls), f"expected bd ready call, got {bd_calls}"
+
+
+@pytest.fixture(autouse=True)
+def _clean_callsign_env(monkeypatch):
+    """Ensure each test gets a fresh CALLSIGN=elliot (non-clone)."""
+    monkeypatch.setenv("CALLSIGN", "elliot")
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "test-token")
+    yield


### PR DESCRIPTION
## Summary

Elliot Dave-direct dispatch 2026-05-14T09:08Z: `scripts/slack_relay.py` `_maybe_self_assign` auto-claims tasks on `[READY:<callsign>]` markers without requiring a Step 0 RESTATE from the agent. Every `[READY:]` echo triggers an auto-reclaim within ~30s of release. Stuck KEI-51 + KEI-58 in orphan-active state until this lands.

KEI-71 closed the env-unset path (CALLSIGN unset → `'unknown'` sentinel-write). KEI-72 closes the CALLSIGN-set-but-no-Step-0 path — the second gate Elliot named.

## Change

New `_has_recent_step0_restate(callsign)` function scans `/tmp/telegram-relay-<callsign>/processed/` for the last `_STEP0_INBOX_SCAN_DEPTH=5` messages and looks for the agent's own `[STEP-0-RESTATE:<CALLSIGN>]` marker. If absent, `_maybe_self_assign` short-circuits with a stderr message naming the gate. No `bd ready` subprocess + no `bd claim` subprocess.

The agent's own Step 0 RESTATE outbound (posted via tg) is echoed back through the central listener into the inbox, so the scan covers self-emitted markers without needing a separate outbound log.

## Test plan

- [x] `test_step0_present_via_tmp_path` — marker present → True
- [x] `test_step0_absent_returns_false` — no marker → False
- [x] `test_step0_inbox_dir_missing_returns_false` — missing dir → False
- [x] `test_step0_malformed_json_skipped` — bad JSON file doesn't crash scan
- [x] `test_step0_scan_depth_respected` — marker older than `SCAN_DEPTH` → False
- [x] `test_self_assign_refuses_when_no_step0` — bd subprocess NOT called
- [x] `test_self_assign_proceeds_when_step0_present` — bd ready IS called
- [x] 26/26 PASS across all slack_relay tests (anchor + KEI-40 backoff + KEI-72)
- [x] ruff check + format: clean

## Behaviour

Gated and reversible: agents that don't emit Step 0 RESTATE markers will silently skip auto-claim (consistent with the existing clone-skip pattern). Polling loop remains the safety net. Releases of KEI-51 + KEI-58 won't trigger silent re-claim after this lands.

Refs: KEI-72 (tasks-table row filed by Elliot this turn). Closes the KEI-51/KEI-58 orphan-active hold pattern.

🤖 Authored by [SCOUT] (Sonnet 4.6 research clone)