### PR TITLE
[SCOUT] feat(kei72-followup): systemd CALLSIGN env audit + 6-unit patch (acceptance b+c)

### DIFF
--- a/infra/systemd/agents/aiden-agent.service
+++ b/infra/systemd/agents/aiden-agent.service
@@ -8,6 +8,7 @@ StartLimitIntervalSec=300
 
 [Service]
 Type=simple
+Environment="CALLSIGN=aiden"
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS-aiden
 ExecStart=/home/elliotbot/clawd/Agency_OS-aiden/scripts/systemd_agent_supervisor.sh aiden aiden /home/elliotbot/clawd/Agency_OS-aiden
 Restart=on-failure

--- a/infra/systemd/agents/atlas-agent.service
+++ b/infra/systemd/agents/atlas-agent.service
@@ -8,6 +8,7 @@ StartLimitIntervalSec=300
 
 [Service]
 Type=simple
+Environment="CALLSIGN=atlas"
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS-atlas
 ExecStart=/home/elliotbot/clawd/Agency_OS-atlas/scripts/systemd_agent_supervisor.sh atlas atlas /home/elliotbot/clawd/Agency_OS-atlas
 Restart=on-failure

--- a/infra/systemd/agents/elliot-agent.service
+++ b/infra/systemd/agents/elliot-agent.service
@@ -8,6 +8,7 @@ StartLimitIntervalSec=300
 
 [Service]
 Type=simple
+Environment="CALLSIGN=elliot"
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS
 ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/systemd_agent_supervisor.sh elliot elliottbot /home/elliotbot/clawd/Agency_OS
 Restart=on-failure

--- a/infra/systemd/agents/max-agent.service
+++ b/infra/systemd/agents/max-agent.service
@@ -8,6 +8,7 @@ StartLimitIntervalSec=300
 
 [Service]
 Type=simple
+Environment="CALLSIGN=max"
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS-max
 ExecStart=/home/elliotbot/clawd/Agency_OS-max/scripts/systemd_agent_supervisor.sh max maxbot /home/elliotbot/clawd/Agency_OS-max
 Restart=on-failure

--- a/infra/systemd/agents/orion-agent.service
+++ b/infra/systemd/agents/orion-agent.service
@@ -8,6 +8,7 @@ StartLimitIntervalSec=300
 
 [Service]
 Type=simple
+Environment="CALLSIGN=orion"
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS-orion
 ExecStart=/home/elliotbot/clawd/Agency_OS-orion/scripts/systemd_agent_supervisor.sh orion orion /home/elliotbot/clawd/Agency_OS-orion
 Restart=on-failure

--- a/infra/systemd/agents/scout-agent.service
+++ b/infra/systemd/agents/scout-agent.service
@@ -8,6 +8,7 @@ StartLimitIntervalSec=300
 
 [Service]
 Type=simple
+Environment="CALLSIGN=scout"
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS-scout
 ExecStart=/home/elliotbot/clawd/Agency_OS-scout/scripts/systemd_agent_supervisor.sh scout scout /home/elliotbot/clawd/Agency_OS-scout
 Restart=on-failure

--- a/scripts/audit_callsign_env.sh
+++ b/scripts/audit_callsign_env.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# audit_callsign_env.sh — KEI-72 item (b): scan agent-*.service unit files in
+# infra/systemd/agents/ for an Environment=CALLSIGN= declaration. Reports any
+# unit that's missing the env declaration. Exit code 0 if all units have it,
+# 1 if any are missing (operator action required).
+#
+# Why this matters: tasks_cli + slack_relay + scripts in the agent process tree
+# read CALLSIGN from os.environ. If the systemd unit doesn't set it, the
+# process tree inherits an unset value → tasks_cli falls back to
+# DEFAULT_CALLSIGN ('unknown') unless rescued by KEI-71 (now blocks the claim).
+# KEI-72 (a) gates auto-claim on Step-0-RESTATE; (b) audits the upstream env
+# declaration so the gate isn't load-bearing on its own.
+#
+# Usage:
+#   bash scripts/audit_callsign_env.sh [-v]
+#   bash scripts/audit_callsign_env.sh --units-dir infra/systemd/agents
+#
+# Exit codes:
+#   0 — all units declare Environment=CALLSIGN=
+#   1 — one or more units missing the declaration
+#   2 — units-dir not found / operator misconfig
+
+set -euo pipefail
+
+UNITS_DIR="${UNITS_DIR:-infra/systemd/agents}"
+VERBOSE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--verbose) VERBOSE=1; shift ;;
+        --units-dir)  UNITS_DIR="$2"; shift 2 ;;
+        -h|--help)
+            sed -n 's/^# //p' "$0" | head -40
+            exit 0
+            ;;
+        *) echo "ERROR: unknown arg $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ ! -d "$UNITS_DIR" ]]; then
+    echo "ERROR: units dir not found: $UNITS_DIR" >&2
+    exit 2
+fi
+
+missing=()
+ok=()
+
+shopt -s nullglob
+for unit in "$UNITS_DIR"/*-agent.service; do
+    name="$(basename "$unit" .service)"
+    if grep -qE '^Environment=("?)CALLSIGN=' "$unit"; then
+        ok+=("$name")
+        [[ "$VERBOSE" == "1" ]] && echo "  OK      $name"
+    else
+        missing+=("$name")
+        echo "  MISSING $name  ($unit has no Environment=CALLSIGN= line)"
+    fi
+done
+
+echo ""
+echo "Summary: ${#ok[@]} OK, ${#missing[@]} missing"
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo ""
+    echo "Fix: add 'Environment=\"CALLSIGN=<callsign>\"' to each [Service] section."
+    echo "Example for aiden-agent.service:"
+    echo "  [Service]"
+    echo "  Environment=\"CALLSIGN=aiden\""
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

KEI-72 acceptance items (b) + (c) — companion to PR #884 (item (a) — gate slack_relay auto-claim on Step-0-RESTATE marker, already merged at SHA `4aba4492`).

**Item (b)** — `scripts/audit_callsign_env.sh`: scans `infra/systemd/agents/*-agent.service` for `Environment=CALLSIGN=`, reports MISSING units, suggests the fix line. Exit 0 if all declared, 1 if any missing, 2 on operator misconfig. Reusable for CI pre-flight + operator drift detection.

**Item (c)** — unit patches: all 6 agent unit files (aiden/atlas/elliot/max/orion/scout) now declare `Environment="CALLSIGN=<callsign>"` in their `[Service]` sections.

## Why

`tasks_cli` + `slack_relay` + every Python script in the agent process tree reads `CALLSIGN` from `os.environ`. Without the `Environment=` declaration in systemd, the inherited env may be unset → `tasks_cli` falls back to `DEFAULT_CALLSIGN` ('unknown') — the exact KEI-71 sentinel-write path Elliot flagged on KEI-51 earlier today. KEI-71 + KEI-72(a) gate the symptom; KEI-72(b)+(c) fix the upstream cause.

## Verification

```
$ bash scripts/audit_callsign_env.sh -v
  OK      aiden-agent
  OK      atlas-agent
  OK      elliot-agent
  OK      max-agent
  OK      orion-agent
  OK      scout-agent
Summary: 6 OK, 0 missing
Exit 0.
```

## Operator action post-merge

Each host runs `systemctl --user daemon-reload && systemctl --user restart <callsign>-agent.service` to pick up the env declaration. Or wait for the next natural restart cycle.

Refs: KEI-72 acceptance (b) + (c). Items (d) [behavioural test] + (e) [orphan-release idempotence] are covered by PR #884 + Elliot's domain respectively.

🤖 Authored by [SCOUT] (Sonnet 4.6 research clone)