### PR TITLE
[AIDEN] feat(kei58): discovery staleness governance — bd verify + freshness ladder

### DIFF
--- a/scripts/bd
+++ b/scripts/bd
@@ -84,6 +84,16 @@ case "$subcmd" in
         # Weaviate retrieval. Routes to tasks_cli.cmd_deprecate.
         exec python3 "$TASKS_CLI" deprecate "$@"
         ;;
+    verify)
+        # KEI-58 — `bd verify <kei>` discovery freshness (FRESH/STALE/EXPIRED).
+        # Routes to bd_verify.py over discovery_log.jsonl. Exit 0 on any verdict;
+        # non-zero only on missing row so callers can distinguish "stale" from
+        # "no such discovery". Falls through to bd-original if shim missing.
+        if [[ -f "$AGENCY_OS_REPO/scripts/bd_verify.py" ]]; then
+            exec env PYTHONPATH="$AGENCY_OS_REPO${PYTHONPATH:+:$PYTHONPATH}" python3 "$AGENCY_OS_REPO/scripts/bd_verify.py" "$@"
+        fi
+        exec "$BD_ORIGINAL" verify "$@"
+        ;;
     "")
         # No subcommand → bd-original handles help.
         exec "$BD_ORIGINAL"

--- a/scripts/bd_verify.py
+++ b/scripts/bd_verify.py
@@ -1,0 +1,50 @@
+"""bd_verify.py — KEI-58 CLI for `bd verify <kei-or-discovery-id>`.
+
+Routed via scripts/bd shim. Returns a freshness verdict on the most recent
+discovery_log row matching the given KEI. Exit 0 on any verdict (FRESH /
+STALE / EXPIRED) — non-zero only on missing row or hard error so the shim
+can distinguish "no such discovery" from "discovery is stale".
+
+Usage:
+    bd verify KEI-50
+    bd verify KEI-50 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from scripts.orchestrator.discovery_log import compute_freshness, load_all_discoveries
+
+
+def _latest_for_kei(kei: str) -> dict | None:
+    matches = [r for r in load_all_discoveries() if r.get("kei") == kei]
+    return matches[-1] if matches else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="bd verify")
+    parser.add_argument("kei", help="KEI id (e.g. KEI-50) or discovery row id")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of human text")
+    args = parser.parse_args(argv)
+
+    row = _latest_for_kei(args.kei)
+    if row is None:
+        print(f"ERROR: no discovery row with kei={args.kei!r}", file=sys.stderr)
+        return 2
+
+    f = compute_freshness(row)
+    if args.json:
+        print(json.dumps({"kei": args.kei, **f}))
+    else:
+        verdict = f["verdict"].upper()
+        print(f"{verdict} — {f['reason']}")
+        if f["drift"]:
+            print(f"  drift: {', '.join(f['drift'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestrator/context_version.py
+++ b/scripts/orchestrator/context_version.py
@@ -1,0 +1,79 @@
+"""context_version.py — KEI-58 environment snapshot for discovery freshness.
+
+Single source of truth for the `context_version` field on discovery_log rows.
+Used at both append-time (via bd discover when it ships) and verify-time
+(via bd verify) so drift detection compares like-for-like.
+
+Snapshot is intentionally narrow: vendor pins that materially change LLM /
+retrieval / DB behaviour, plus the kernel string. Keep narrow — adding fields
+invalidates every prior discovery the next time pins move.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import subprocess
+from functools import lru_cache
+from typing import Any
+
+VENDORED_PACKAGES = (
+    "anthropic",
+    "openai",
+    "supabase",
+    "weaviate-client",
+    "llama-index",
+    "cognee",
+    "psycopg",
+)
+
+
+def _pip_show_version(pkg: str) -> str | None:
+    try:
+        out = subprocess.run(
+            ["pip", "show", pkg],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if out.returncode != 0:
+        return None
+    for line in out.stdout.splitlines():
+        if line.startswith("Version:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+@lru_cache(maxsize=1)
+def current_context_version() -> dict[str, Any]:
+    """Return the current environment snapshot as the canonical context_version dict.
+
+    Cached per-process (pip lookups are slow). Missing packages emit None —
+    preserved in the dict so absence is itself a signal (e.g. a discovery
+    written when openai was installed becomes STALE when openai is uninstalled).
+
+    Override via env AGENCY_OS_CONTEXT_VERSION_JSON for tests / containers
+    that don't have pip available.
+    """
+    override = os.environ.get("AGENCY_OS_CONTEXT_VERSION_JSON")
+    if override:
+        return json.loads(override)
+    snapshot: dict[str, Any] = {"kernel": platform.release()}
+    for pkg in VENDORED_PACKAGES:
+        snapshot[pkg] = _pip_show_version(pkg)
+    return snapshot
+
+
+def context_drift(stored: dict[str, Any] | None, current: dict[str, Any]) -> list[str]:
+    """Return list of field names where stored != current. Empty = no drift.
+
+    Treats missing stored as full-drift over all current fields (legacy rows
+    pre-KEI-56 have no context_version). Caller decides how to weight that.
+    """
+    if not stored:
+        return list(current.keys())
+    return sorted({k for k in current if stored.get(k) != current.get(k)})

--- a/scripts/orchestrator/discovery_log.py
+++ b/scripts/orchestrator/discovery_log.py
@@ -18,15 +18,22 @@ Public API:
     load_active_discoveries() -> list[dict]   # filter out deprecated=True
     append_discovery(entry: dict) -> None     # write a new row
     mark_deprecated(kei: str, reason: str, by: str) -> dict  # mutate row
+    compute_freshness(row, now=None) -> dict  # KEI-58 — fresh|stale|expired + reason
+    load_fresh_discoveries() -> list[dict]    # KEI-58 — active AND not expired
 """
 
 from __future__ import annotations
 
 import json
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+
+from scripts.orchestrator.context_version import context_drift, current_context_version
+
+STALE_AGE = timedelta(days=30)
+EXPIRED_AGE = timedelta(days=90)
 
 DEFAULT_DISCOVERY_LOG = Path(
     os.environ.get(
@@ -126,3 +133,56 @@ def mark_deprecated(
             fh.write(json.dumps(r) + "\n")
     tmp.replace(path)
     return rows[target_idx]
+
+
+def _parse_iso(ts: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def compute_freshness(
+    row: dict[str, Any],
+    now: datetime | None = None,
+    *,
+    current_version: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Classify a discovery row's freshness. Returns {verdict, reason, age_days, drift}.
+
+    Rule (KEI-58, 30/90 ratified by Elliot ts ~1778899332):
+      EXPIRED if age > 90d (regardless of context drift — old lessons rot).
+      STALE   if age > 30d OR any context_version field differs from current.
+      FRESH   otherwise.
+    Verdict precedence: EXPIRED beats STALE beats FRESH.
+    """
+    now = now or datetime.now(UTC)
+    current_version = current_version if current_version is not None else current_context_version()
+    written_at = _parse_iso(row.get("created_at") or row.get("written_at") or "")
+    age = now - written_at if written_at else timedelta.max
+    age_days = age.days if age != timedelta.max else None
+    drift = context_drift(row.get("context_version"), current_version)
+    if age >= EXPIRED_AGE:
+        return {"verdict": "expired", "reason": f"age {age_days}d >= 90d", "age_days": age_days, "drift": drift}
+    if age >= STALE_AGE:
+        return {"verdict": "stale", "reason": f"age {age_days}d >= 30d", "age_days": age_days, "drift": drift}
+    if drift:
+        return {"verdict": "stale", "reason": f"context drift on {drift}", "age_days": age_days, "drift": drift}
+    return {"verdict": "fresh", "reason": "within 30d and context unchanged", "age_days": age_days, "drift": []}
+
+
+def load_fresh_discoveries(path: Path | None = None) -> list[dict[str, Any]]:
+    """Active rows minus EXPIRED. STALE retained but tagged via `_freshness` key.
+
+    Caller for bd recall + future bd claim auto-injection (KEI-51): exclude
+    EXPIRED entirely; surface STALE with the freshness tag so the UI can badge.
+    """
+    current = current_context_version()
+    out: list[dict[str, Any]] = []
+    for row in load_active_discoveries(path):
+        f = compute_freshness(row, current_version=current)
+        if f["verdict"] == "expired":
+            continue
+        row["_freshness"] = f
+        out.append(row)
+    return out

--- a/tests/orchestrator/test_discovery_freshness.py
+++ b/tests/orchestrator/test_discovery_freshness.py
@@ -1,0 +1,151 @@
+"""KEI-58 — behavioural tests for discovery freshness governance.
+
+Covers:
+  - compute_freshness verdict ladder (fresh -> stale-by-age -> stale-by-drift -> expired).
+  - load_fresh_discoveries excludes EXPIRED and tags STALE.
+  - bd_verify CLI exit codes + output for each verdict + missing row.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.orchestrator import discovery_log
+from scripts.orchestrator.discovery_log import (
+    append_discovery,
+    compute_freshness,
+    load_fresh_discoveries,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BD_VERIFY = REPO_ROOT / "scripts" / "bd_verify.py"
+
+
+@pytest.fixture
+def isolated_log(tmp_path, monkeypatch):
+    """Redirect discovery_log.jsonl to a temp path so tests don't touch the real store."""
+    p = tmp_path / "discovery_log.jsonl"
+    monkeypatch.setattr(discovery_log, "DEFAULT_DISCOVERY_LOG", p)
+    return p
+
+
+def _write(path: Path, kei: str, written_at: datetime, ctx: dict) -> None:
+    append_discovery(
+        {
+            "kei": kei,
+            "agent": "test",
+            "context": "test row",
+            "finding": "x",
+            "failed_path": "y",
+            "verified_path": "z",
+            "tags": [],
+            "created_at": written_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "context_version": ctx,
+        },
+        path=path,
+    )
+
+
+def test_fresh_within_30d_no_drift(isolated_log):
+    now = datetime.now(UTC)
+    ctx = {"kernel": "X", "anthropic": "1.0"}
+    _write(isolated_log, "KEI-T1", now - timedelta(days=5), ctx)
+    row = discovery_log.load_all_discoveries(isolated_log)[0]
+    f = compute_freshness(row, now=now, current_version=ctx)
+    assert f["verdict"] == "fresh", f
+
+
+def test_stale_by_age_between_30_and_90d(isolated_log):
+    now = datetime.now(UTC)
+    ctx = {"kernel": "X", "anthropic": "1.0"}
+    _write(isolated_log, "KEI-T2", now - timedelta(days=45), ctx)
+    row = discovery_log.load_all_discoveries(isolated_log)[0]
+    f = compute_freshness(row, now=now, current_version=ctx)
+    assert f["verdict"] == "stale"
+    assert "age" in f["reason"]
+
+
+def test_stale_by_context_drift_under_30d(isolated_log):
+    now = datetime.now(UTC)
+    written_ctx = {"kernel": "X", "anthropic": "1.0"}
+    current_ctx = {"kernel": "X", "anthropic": "2.0"}  # drift on anthropic
+    _write(isolated_log, "KEI-T3", now - timedelta(days=10), written_ctx)
+    row = discovery_log.load_all_discoveries(isolated_log)[0]
+    f = compute_freshness(row, now=now, current_version=current_ctx)
+    assert f["verdict"] == "stale"
+    assert "anthropic" in f["drift"]
+
+
+def test_expired_over_90d_regardless_of_drift(isolated_log):
+    now = datetime.now(UTC)
+    ctx = {"kernel": "X", "anthropic": "1.0"}
+    _write(isolated_log, "KEI-T4", now - timedelta(days=120), ctx)
+    row = discovery_log.load_all_discoveries(isolated_log)[0]
+    f = compute_freshness(row, now=now, current_version=ctx)
+    assert f["verdict"] == "expired"
+
+
+def test_load_fresh_excludes_expired_and_tags_stale(isolated_log, monkeypatch):
+    now = datetime.now(UTC)
+    ctx = {"kernel": "X"}
+    monkeypatch.setattr(
+        "scripts.orchestrator.discovery_log.current_context_version", lambda: ctx
+    )
+    _write(isolated_log, "KEI-FRESH", now - timedelta(days=5), ctx)
+    _write(isolated_log, "KEI-STALE", now - timedelta(days=45), ctx)
+    _write(isolated_log, "KEI-EXPIRED", now - timedelta(days=120), ctx)
+    fresh_set = load_fresh_discoveries(isolated_log)
+    keis = {r["kei"] for r in fresh_set}
+    assert "KEI-EXPIRED" not in keis
+    assert "KEI-FRESH" in keis and "KEI-STALE" in keis
+    stale_row = next(r for r in fresh_set if r["kei"] == "KEI-STALE")
+    assert stale_row["_freshness"]["verdict"] == "stale"
+
+
+def test_bd_verify_cli_returns_verdict_and_exit_zero(isolated_log, monkeypatch):
+    now = datetime.now(UTC)
+    ctx = {"kernel": "X"}
+    _write(isolated_log, "KEI-CLI", now - timedelta(days=5), ctx)
+    env = {
+        "PYTHONPATH": str(REPO_ROOT),
+        "AGENCY_OS_DISCOVERY_LOG": str(isolated_log),
+        "AGENCY_OS_CONTEXT_VERSION_JSON": json.dumps(ctx),
+        "PATH": "/usr/bin:/bin",
+    }
+    out = subprocess.run(
+        [sys.executable, str(BD_VERIFY), "KEI-CLI", "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=10,
+    )
+    assert out.returncode == 0, out.stderr
+    payload = json.loads(out.stdout)
+    assert payload["kei"] == "KEI-CLI"
+    assert payload["verdict"] in ("fresh", "stale", "expired")
+
+
+def test_bd_verify_cli_missing_kei_exits_two(isolated_log):
+    env = {
+        "PYTHONPATH": str(REPO_ROOT),
+        "AGENCY_OS_DISCOVERY_LOG": str(isolated_log),
+        "AGENCY_OS_CONTEXT_VERSION_JSON": json.dumps({"kernel": "X"}),
+        "PATH": "/usr/bin:/bin",
+    }
+    out = subprocess.run(
+        [sys.executable, str(BD_VERIFY), "KEI-DOES-NOT-EXIST"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=10,
+    )
+    assert out.returncode == 2
+    assert "no discovery row" in out.stderr


### PR DESCRIPTION
## Summary
- **context_version.py** — cached env snapshot (kernel + 7 vendor pins). Single source for both append-time + verify-time.
- **discovery_log.py** — `compute_freshness(row, now=None)` classifies on the 30d/90d ladder ratified by Elliot ts ~1778899332. STALE: age >= 30d OR context_version drift. EXPIRED: age >= 90d (precedence over STALE). `load_fresh_discoveries()` excludes EXPIRED + tags STALE rows with `_freshness` for callers.
- **bd_verify.py + bd shim** — `bd verify <kei>` emits FRESH/STALE/EXPIRED + reason. Exit 0 on any verdict; exit 2 on missing row so callers distinguish "stale" from "no such discovery". `--json` for programmatic consumers.
- **tests/orchestrator/test_discovery_freshness.py** — 7 behavioural tests (verdict ladder + load_fresh filtering + CLI exit codes).

## Step 0 trace
[STEP-0-RESTATE:aiden] posted Slack #execution ts 1778899338. [CONCUR:elliot] received ts ~1778899332 — "Defaults sound (30d STALE / 90d EXPIRED — peer-revisable). context_version helper as single source for append-time + verify-time is the right composability with future KEI-51 injection + KEI-46/47 Weaviate."

## Verification
```
$ PYTHONPATH=. python3 -m pytest tests/orchestrator/test_discovery_freshness.py -v
============================== 7 passed in 0.38s ===============================

$ bd verify KEI-FRESH      → FRESH — within 30d and context unchanged   (exit 0)
$ bd verify KEI-STALE      → STALE — age 45d >= 30d                     (exit 0)
$ bd verify KEI-EXPIRED    → EXPIRED — age 120d >= 90d                  (exit 0)
$ bd verify KEI-MISSING    → ERROR: no discovery row with kei=...       (exit 2)
$ bd verify KEI-FRESH (drift) → STALE — context drift on ['anthropic']  (exit 0)

$ ruff check scripts/orchestrator/context_version.py scripts/orchestrator/discovery_log.py scripts/bd_verify.py tests/orchestrator/test_discovery_freshness.py
All checks passed!
```

## Test plan
- [x] Unit + behavioural tests pass (7/7)
- [x] E2E shim smoke against real bd_verify.py (5/5 verdicts correct)
- [x] Ruff clean
- [ ] CI green
- [ ] Triple-FINAL: [FINAL:elliot] + [FINAL:max] in #execution
- [ ] Trigger-compliant close (acceptance_criteria + task_verifications row per KEI-54)

## Scope OUT (deferred)
- bd claim auto-injection (KEI-51 — Scout)
- LlamaIndex/Weaviate retrieval (KEI-49 — Max)
- Validation tier governance (KEI-55 — Orion)
- Backfill of context_version on legacy rows (KEI-48 auto-indexer handles on Weaviate ready)

Linear: KEI-58
Closes KEI-58

🤖 Generated with [Claude Code](https://claude.com/claude-code)