### PR TITLE
[MAX] feat(kei75): hybrid memory quality PR2 — FlashRank reranker + Sessions source_id

### DIFF
--- a/infra/weaviate/schema.py
+++ b/infra/weaviate/schema.py
@@ -39,6 +39,11 @@ MANDATORY_PROPERTIES = (
     {"name": "created_at", "dataType": ["date"]},
     {"name": "agent", "dataType": ["text"]},
     {"name": "kei", "dataType": ["text"]},
+    # source_id (KEI-75 PR2): chunk_id / source_path / file_path / explicit
+    # origin marker so citation resolution can point at the doc that actually
+    # matched. Backfilled on existing Sessions via scripts/orchestrator/
+    # kei75_sessions_source_id.py; fresh installs pick it up at class create.
+    {"name": "source_id", "dataType": ["text"]},
 )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,6 +109,11 @@ slack_sdk>=3.41.0,<4.0.0
 llama-index>=0.12,<0.16
 llama-index-vector-stores-weaviate>=1.6,<2
 llama-index-embeddings-huggingface>=0.5,<1
+# FlashRank cross-encoder reranker — Scout design §6, KEI-75 PR2. ms-marco-
+# MiniLM-L-12-v2 model runs CPU-only at ~30ms per 20-node rerank pass.
+# orchestrator.retrieve_nodes bypass-falls back to raw ANN when FlashRank
+# either fails to import or exceeds the 200ms latency budget.
+flashrank>=0.2.7,<0.3
 # Upper bound 4.20: weaviate-client 4.20+ removed `_ContextManagerWrapper`,
 # which llama-index-vector-stores-weaviate 1.6.0 still imports. Empirical
 # proof: pip-install with weaviate-client 4.21.0 produces ImportError on

--- a/scripts/orchestrator/kei75_sessions_source_id.py
+++ b/scripts/orchestrator/kei75_sessions_source_id.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""KEI-75 PR2 — add source_id property to Sessions class + backfill.
+
+infra/weaviate/schema.py picks the property up for fresh installs (it's now
+in MANDATORY_PROPERTIES). This script handles the live cluster:
+
+    1. Issue POST /v1/schema/Sessions/properties to add source_id text
+       column. Idempotent — HTTP 422 on already-present is treated as
+       success.
+    2. Iterate existing Sessions objects in chunks of 200. For each row,
+       compute source_id from the chunk_id metadata Aiden's Wave 4 indexer
+       wrote into the LlamaIndex node store. Fall back to the Weaviate
+       object UUID prefixed with sessions: when chunk_id is absent.
+    3. PATCH each row with the new property. Skip rows that already have
+       a non-empty source_id so re-runs are idempotent.
+
+Dry-run by default — prints projected updates + sample. Pass --apply to
+commit changes. Pass --limit N to scope a smoke run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from typing import Any
+
+import weaviate
+
+WEAVIATE_HOST = "127.0.0.1"
+WEAVIATE_PORT_HTTP = 8090
+WEAVIATE_PORT_GRPC = 50051
+SESSIONS_CLASS = "Sessions"
+PROPERTY_NAME = "source_id"
+SAMPLE_LIMIT = 3
+
+
+def _add_property(base_url: str) -> str:
+    body = json.dumps({"name": PROPERTY_NAME, "dataType": ["text"]}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}/v1/schema/{SESSIONS_CLASS}/properties",
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as resp:  # noqa: S310
+            resp.read()
+        return "added"
+    except urllib.error.HTTPError as exc:
+        if exc.code == 422:
+            return "already_present"
+        body_text = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"property add failed: HTTP {exc.code} body={body_text[:200]}") from exc
+
+
+def _iter_sessions(client: Any, limit: int | None) -> Iterator[Any]:
+    collection = client.collections.get(SESSIONS_CLASS)
+    cursor = None
+    yielded = 0
+    while True:
+        result = collection.query.fetch_objects(limit=200, after=cursor, include_vector=False)
+        if not result.objects:
+            return
+        for obj in result.objects:
+            if limit is not None and yielded >= limit:
+                return
+            yield obj
+            yielded += 1
+        cursor = result.objects[-1].uuid
+
+
+def _resolve_source_id(obj: Any) -> str:
+    props = obj.properties or {}
+    existing = props.get(PROPERTY_NAME)
+    if existing and isinstance(existing, str) and existing.strip():
+        return ""  # signal "skip; already has source_id"
+    md = props.get("metadata") or {}
+    if isinstance(md, str):
+        with contextlib.suppress(Exception):
+            md = json.loads(md)
+    chunk_id = md.get("chunk_id") if isinstance(md, dict) else None
+    if chunk_id and isinstance(chunk_id, str) and chunk_id.strip():
+        return chunk_id
+    return f"sessions:{obj.uuid}"
+
+
+def run(host: str, port: int, apply: bool, limit: int | None) -> dict:
+    base_url = f"http://{host}:{port}"  # NOSONAR python:S5332 loopback-only
+    schema_action = _add_property(base_url)
+    client = weaviate.connect_to_local(host=host, port=port, grpc_port=WEAVIATE_PORT_GRPC)
+    collection = client.collections.get(SESSIONS_CLASS)
+    would_update = 0
+    skipped = 0
+    sample_updates: list[tuple[str, str]] = []
+    started = time.monotonic()
+    try:
+        for obj in _iter_sessions(client, limit):
+            resolved = _resolve_source_id(obj)
+            if not resolved:
+                skipped += 1
+                continue
+            if apply:
+                collection.data.update(uuid=obj.uuid, properties={PROPERTY_NAME: resolved})
+            would_update += 1
+            if len(sample_updates) < SAMPLE_LIMIT:
+                sample_updates.append((str(obj.uuid), resolved))
+    finally:
+        with contextlib.suppress(Exception):
+            client.close()
+    return {
+        "schema_action": schema_action,
+        "would_update": would_update,
+        "skipped_already_set": skipped,
+        "applied": apply,
+        "sample_updates": sample_updates,
+        "elapsed_sec": round(time.monotonic() - started, 1),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="KEI-75 PR2 Sessions source_id backfill")
+    parser.add_argument("--host", default=WEAVIATE_HOST)
+    parser.add_argument("--port", type=int, default=WEAVIATE_PORT_HTTP)
+    parser.add_argument("--apply", action="store_true", help="commit changes (default dry-run)")
+    parser.add_argument("--limit", type=int, default=None, help="cap iteration at N rows (smoke)")
+    args = parser.parse_args()
+    report = run(args.host, args.port, apply=args.apply, limit=args.limit)
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/retrieval/agent_query.py
+++ b/src/retrieval/agent_query.py
@@ -189,13 +189,13 @@ def query(
         `QueryResult` with answer + citations + elapsed_ms + bypass flag.
     """
     started = time.monotonic()
-    nodes = orchestrator.retrieve_nodes(
+    outcome = orchestrator.retrieve_with_outcome(
         text=text,
         collections=collections,
         k_initial=k_initial,
         k_returned=k_returned,
     )
-    citations = tuple(_node_to_citation(n) for n in nodes)
+    citations = tuple(_node_to_citation(n) for n in outcome.nodes)
     qualified = tuple(c for c in citations if c.score >= min_score)
     if citation_required and not qualified:
         answer = ""
@@ -212,12 +212,12 @@ def query(
         k_initial=k_initial,
         k_returned=k_returned,
         elapsed_ms=elapsed_ms,
-        bypass_rerank=orchestrator.RAW_ANN_RERANK_BYPASS,
+        bypass_rerank=outcome.bypass_rerank,
         top_citation=top,
     )
     return QueryResult(
         answer=answer,
         citations=emitted_citations,
         elapsed_ms=elapsed_ms,
-        bypass_rerank=orchestrator.RAW_ANN_RERANK_BYPASS,
+        bypass_rerank=outcome.bypass_rerank,
     )

--- a/src/retrieval/orchestrator.py
+++ b/src/retrieval/orchestrator.py
@@ -2,8 +2,9 @@
 
 Sits between `agent_query.query()` and the Weaviate vector store. Owns:
     * Multi-collection routing (one VectorStoreIndex per collection).
-    * Re-rank pass — disabled in PR1; raw ANN scores are returned and the
-      bypass flag is set to True. FlashRank wiring is a follow-up KEI.
+    * Two-stage retrieval: Weaviate k_initial vector hits → FlashRank
+      cross-encoder rerank → k_returned final. Bypass-falls-back to raw
+      ANN when FlashRank is unavailable or exceeds its latency budget.
     * Citation extraction — every retrieved node carries a source_id,
       collection, score, and 80-char excerpt back to the caller.
 
@@ -20,13 +21,16 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
-from src.retrieval import weaviate_store
+from src.retrieval import rerankers, weaviate_store
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_K_INITIAL = 20
 DEFAULT_K_RETURNED = 5
-RAW_ANN_RERANK_BYPASS = True  # PR1: no reranker; raw ANN only. Follow-up KEI wires FlashRank.
+# Legacy export retained so existing callers (and tests) that import the
+# bypass-default constant don't break — the actual bypass flag now comes
+# from `rerankers.rerank_top_k` per query (RerankOutcome.bypassed).
+RAW_ANN_RERANK_BYPASS = True
 
 
 @dataclass(frozen=True)
@@ -80,6 +84,72 @@ def index_document(
             weaviate_store.close_client(weaviate_client)
 
 
+@dataclass(frozen=True)
+class RetrievalOutcome:
+    nodes: tuple[RetrievedNode, ...]
+    bypass_rerank: bool
+    rerank_reason: str
+    rerank_elapsed_ms: int
+
+
+def _gather_ann_pool(
+    text: str,
+    collections: tuple[str, ...],
+    k_initial: int,
+    weaviate_client: Any,
+) -> list[RetrievedNode]:
+    pool: list[RetrievedNode] = []
+    for collection in collections:
+        try:
+            index = _build_index(weaviate_client, collection)
+            retriever = index.as_retriever(similarity_top_k=k_initial)
+            nodes = retriever.retrieve(text)
+        except Exception:  # noqa: BLE001
+            logger.warning("retrieve failed for %s", collection, exc_info=True)
+            continue
+        for node in nodes:
+            pool.append(
+                RetrievedNode(
+                    text=node.get_content(),
+                    score=float(node.score or 0.0),
+                    metadata=dict(node.metadata or {}),
+                    collection=collection,
+                )
+            )
+    pool.sort(key=lambda n: n.score, reverse=True)
+    return pool
+
+
+def retrieve_with_outcome(
+    text: str,
+    collections: tuple[str, ...],
+    *,
+    k_initial: int = DEFAULT_K_INITIAL,
+    k_returned: int = DEFAULT_K_RETURNED,
+    rerank: bool = True,
+    client: Any | None = None,
+) -> RetrievalOutcome:
+    """Run the two-stage retrieval and surface the bypass flag verbatim."""
+    owned = client is None
+    weaviate_client = client if client is not None else weaviate_store._connect_client()
+    try:
+        pool = _gather_ann_pool(text, collections, k_initial, weaviate_client)
+    finally:
+        if owned:
+            weaviate_store.close_client(weaviate_client)
+    if not pool:
+        return RetrievalOutcome((), False, "empty_pool", 0)
+    if not rerank:
+        return RetrievalOutcome(tuple(pool[:k_returned]), True, "rerank_disabled", 0)
+    outcome = rerankers.rerank_top_k(text, tuple(pool), top_k=k_returned)
+    return RetrievalOutcome(
+        nodes=outcome.nodes,
+        bypass_rerank=outcome.bypassed,
+        rerank_reason=outcome.reason,
+        rerank_elapsed_ms=outcome.elapsed_ms,
+    )
+
+
 def retrieve_nodes(
     text: str,
     collections: tuple[str, ...],
@@ -88,34 +158,14 @@ def retrieve_nodes(
     k_returned: int = DEFAULT_K_RETURNED,
     client: Any | None = None,
 ) -> tuple[RetrievedNode, ...]:
-    """Fan-out across collections, gather top-K nodes, sort by score desc.
-
-    No re-ranker in PR1 — returns raw ANN scores. The caller sees
-    `bypass_rerank=True` on the QueryResult so observability tells truth.
-    """
-    owned = client is None
-    weaviate_client = client if client is not None else weaviate_store._connect_client()
-    out: list[RetrievedNode] = []
-    try:
-        for collection in collections:
-            try:
-                index = _build_index(weaviate_client, collection)
-                retriever = index.as_retriever(similarity_top_k=k_initial)
-                nodes = retriever.retrieve(text)
-            except Exception:  # noqa: BLE001
-                logger.warning("retrieve failed for %s", collection, exc_info=True)
-                continue
-            for node in nodes:
-                out.append(
-                    RetrievedNode(
-                        text=node.get_content(),
-                        score=float(node.score or 0.0),
-                        metadata=dict(node.metadata or {}),
-                        collection=collection,
-                    )
-                )
-    finally:
-        if owned:
-            weaviate_store.close_client(weaviate_client)
-    out.sort(key=lambda n: n.score, reverse=True)
-    return tuple(out[:k_returned])
+    """Backwards-compatible thin wrapper — agents that only need the node
+    tuple keep calling this; agents that want the bypass flag call
+    `retrieve_with_outcome`."""
+    outcome = retrieve_with_outcome(
+        text=text,
+        collections=collections,
+        k_initial=k_initial,
+        k_returned=k_returned,
+        client=client,
+    )
+    return outcome.nodes

--- a/src/retrieval/rerankers.py
+++ b/src/retrieval/rerankers.py
@@ -1,0 +1,146 @@
+"""FlashRank cross-encoder reranker (KEI-75 PR2 / Scout design §6).
+
+Sits between Weaviate ANN retrieval and the agent_query response synth.
+Reorders the k_initial=20 vector hits to k_returned=5 using a CPU
+cross-encoder (ms-marco-MiniLM-L-12-v2 by default, ~30ms per pass on a
+modest box). Two failure modes both fall back to raw ANN scores rather
+than blocking the query:
+
+    1. flashrank not installed — typical first-boot / lean CI environment.
+    2. rerank latency exceeds the budget (default 200ms) — cold-start or
+       container OOM. The fallback preserves liveness; bypass is logged
+       via the QueryResult.bypass_rerank flag the orchestrator returns.
+
+The model itself is loaded lazily on first call and cached for the
+process lifetime so subsequent reranks pay zero startup cost.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = os.environ.get("AGENCY_OS_RERANK_MODEL", "ms-marco-MiniLM-L-12-v2")
+DEFAULT_BUDGET_MS = int(os.environ.get("AGENCY_OS_RERANK_BUDGET_MS", "200"))
+
+_RERANKER: Any | None = None
+_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class RerankOutcome:
+    """Return shape from `rerank_top_k`. `bypassed=True` means the caller
+    should treat scores as raw Weaviate ANN, not FlashRank-reranked."""
+
+    nodes: tuple[Any, ...]
+    bypassed: bool
+    reason: str
+    elapsed_ms: int
+
+
+def _get_reranker(model: str) -> Any | None:
+    """Load FlashRank lazily; return None if the dep isn't installed."""
+    global _RERANKER
+    if _RERANKER is not None:
+        return _RERANKER
+    with _LOCK:
+        if _RERANKER is not None:
+            return _RERANKER
+        try:
+            from flashrank import Ranker
+        except ImportError:
+            logger.info("flashrank not installed; rerank pass will bypass")
+            return None
+        try:
+            _RERANKER = Ranker(model_name=model)
+        except Exception:  # noqa: BLE001
+            logger.warning("flashrank Ranker init failed; rerank pass will bypass", exc_info=True)
+            _RERANKER = None
+        return _RERANKER
+
+
+def reset_reranker() -> None:
+    """Test-only: drop the cached Ranker so the next call re-resolves env."""
+    global _RERANKER
+    with _LOCK:
+        _RERANKER = None
+
+
+def _to_passage_dicts(nodes: tuple[Any, ...]) -> list[dict]:
+    out: list[dict] = []
+    for idx, node in enumerate(nodes):
+        out.append({"id": idx, "text": getattr(node, "text", "") or ""})
+    return out
+
+
+def rerank_top_k(
+    query_text: str,
+    nodes: tuple[Any, ...],
+    *,
+    top_k: int = 5,
+    latency_budget_ms: int = DEFAULT_BUDGET_MS,
+    model: str = DEFAULT_MODEL,
+) -> RerankOutcome:
+    """Rerank `nodes` against `query_text`, keep top_k. Bypass on budget miss
+    or missing dep — caller honours `bypassed`/`reason` to set
+    QueryResult.bypass_rerank verbatim."""
+    if not nodes:
+        return RerankOutcome(nodes=(), bypassed=False, reason="empty_input", elapsed_ms=0)
+    started = time.monotonic()
+    ranker = _get_reranker(model)
+    if ranker is None:
+        elapsed = int((time.monotonic() - started) * 1000)
+        return RerankOutcome(
+            nodes=nodes[:top_k],
+            bypassed=True,
+            reason="flashrank_not_available",
+            elapsed_ms=elapsed,
+        )
+    try:
+        from flashrank import RerankRequest
+
+        request = RerankRequest(query=query_text, passages=_to_passage_dicts(nodes))
+        scored = ranker.rerank(request)
+    except Exception:  # noqa: BLE001
+        elapsed = int((time.monotonic() - started) * 1000)
+        logger.warning("flashrank rerank call failed; bypassing", exc_info=True)
+        return RerankOutcome(
+            nodes=nodes[:top_k],
+            bypassed=True,
+            reason="rerank_call_failed",
+            elapsed_ms=elapsed,
+        )
+    elapsed = int((time.monotonic() - started) * 1000)
+    if elapsed > latency_budget_ms:
+        return RerankOutcome(
+            nodes=nodes[:top_k],
+            bypassed=True,
+            reason=f"latency_exceeded_{elapsed}ms_over_{latency_budget_ms}ms",
+            elapsed_ms=elapsed,
+        )
+    ordered_ids = [int(item.get("id", -1)) for item in scored if item.get("id", -1) >= 0]
+    reordered: list[Any] = []
+    seen: set[int] = set()
+    for original_id in ordered_ids:
+        if 0 <= original_id < len(nodes):
+            reordered.append(nodes[original_id])
+            seen.add(original_id)
+        if len(reordered) >= top_k:
+            break
+    for idx, node in enumerate(nodes):
+        if len(reordered) >= top_k:
+            break
+        if idx not in seen:
+            reordered.append(node)
+    return RerankOutcome(
+        nodes=tuple(reordered),
+        bypassed=False,
+        reason="reranked",
+        elapsed_ms=elapsed,
+    )

--- a/tests/retrieval/test_agent_query.py
+++ b/tests/retrieval/test_agent_query.py
@@ -25,9 +25,27 @@ def _mk_node(text: str, score: float, *, source_id: str = "doc-1") -> orchestrat
     )
 
 
+def _outcome(
+    nodes: tuple[orchestrator.RetrievedNode, ...],
+    *,
+    bypass_rerank: bool = True,
+    reason: str = "test",
+    elapsed_ms: int = 0,
+) -> orchestrator.RetrievalOutcome:
+    return orchestrator.RetrievalOutcome(
+        nodes=nodes,
+        bypass_rerank=bypass_rerank,
+        rerank_reason=reason,
+        rerank_elapsed_ms=elapsed_ms,
+    )
+
+
 def test_query_returns_top_citation_when_above_min_score():
     nodes = (_mk_node("the quick brown fox jumps over the lazy dog", 0.92),)
-    with patch("src.retrieval.agent_query.orchestrator.retrieve_nodes", return_value=nodes):
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
         result = agent_query.query("fox?", agent="test", min_score=0.5)
     assert result.citations
     assert result.citations[0].source_id == "doc-1"
@@ -38,7 +56,10 @@ def test_query_returns_top_citation_when_above_min_score():
 
 def test_citation_required_returns_empty_answer_when_below_threshold():
     nodes = (_mk_node("low-quality match", 0.20),)
-    with patch("src.retrieval.agent_query.orchestrator.retrieve_nodes", return_value=nodes):
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
         result = agent_query.query(
             "anything?", agent="test", citation_required=True, min_score=0.50
         )
@@ -48,7 +69,10 @@ def test_citation_required_returns_empty_answer_when_below_threshold():
 
 def test_citation_required_false_returns_low_score_answer():
     nodes = (_mk_node("still useful even if score is low", 0.20),)
-    with patch("src.retrieval.agent_query.orchestrator.retrieve_nodes", return_value=nodes):
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
         result = agent_query.query(
             "anything?", agent="test", citation_required=False, min_score=0.50
         )
@@ -59,13 +83,19 @@ def test_citation_required_false_returns_low_score_answer():
 def test_excerpt_is_capped_to_80_chars():
     long_text = "x" * 200
     nodes = (_mk_node(long_text, 0.90),)
-    with patch("src.retrieval.agent_query.orchestrator.retrieve_nodes", return_value=nodes):
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
         result = agent_query.query("anything?", agent="test", min_score=0.0)
     assert len(result.citations[0].excerpt) == 80
 
 
 def test_empty_retrieve_returns_empty_when_citation_required():
-    with patch("src.retrieval.agent_query.orchestrator.retrieve_nodes", return_value=()):
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(()),
+    ):
         result = agent_query.query("anything?", agent="test")
     assert result.answer == ""
     assert result.citations == ()
@@ -73,7 +103,10 @@ def test_empty_retrieve_returns_empty_when_citation_required():
 
 def test_synthesised_answer_carries_source_marker():
     nodes = (_mk_node("relevant fact about raspberries", 0.85, source_id="probe-123"),)
-    with patch("src.retrieval.agent_query.orchestrator.retrieve_nodes", return_value=nodes):
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
         result = agent_query.query("raspberries?", agent="test", min_score=0.0)
     assert "[probe-123]" in result.answer
 
@@ -81,6 +114,19 @@ def test_synthesised_answer_carries_source_marker():
 def test_max_tokens_bounds_answer_length():
     long_text = "alpha " * 200
     nodes = (_mk_node(long_text, 0.90, source_id="long-doc"),)
-    with patch("src.retrieval.agent_query.orchestrator.retrieve_nodes", return_value=nodes):
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
         result = agent_query.query("q?", agent="test", min_score=0.0, max_tokens=10)
     assert len(result.answer) <= 10 * 4 + 1
+
+
+def test_bypass_rerank_propagates_from_outcome():
+    nodes = (_mk_node("hit", 0.90),)
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes, bypass_rerank=False, reason="reranked"),
+    ):
+        result = agent_query.query("q?", agent="test", min_score=0.0)
+    assert result.bypass_rerank is False

--- a/tests/retrieval/test_rerankers.py
+++ b/tests/retrieval/test_rerankers.py
@@ -1,0 +1,120 @@
+"""Unit tests for src/retrieval/rerankers.
+
+FlashRank is mocked so tests run in any environment. The intent is to lock
+the contract under all four observable states: dep missing, latency-budget
+exceeded, empty input, healthy rerank.
+"""
+
+from __future__ import annotations
+
+import builtins
+import sys
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.retrieval import rerankers
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    rerankers.reset_reranker()
+    yield
+    rerankers.reset_reranker()
+
+
+def _mk_node(text: str, score: float = 0.5) -> SimpleNamespace:
+    return SimpleNamespace(text=text, score=score)
+
+
+def test_empty_input_returns_empty_outcome_with_no_bypass():
+    outcome = rerankers.rerank_top_k("q?", ())
+    assert outcome.nodes == ()
+    assert outcome.bypassed is False
+    assert outcome.reason == "empty_input"
+
+
+def test_missing_dep_bypasses_with_raw_topk():
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "flashrank":
+            raise ImportError("flashrank not installed in test env")
+        return real_import(name, *args, **kwargs)
+
+    nodes = tuple(_mk_node(f"node-{i}") for i in range(8))
+    with patch("builtins.__import__", side_effect=fake_import):
+        outcome = rerankers.rerank_top_k("q?", nodes, top_k=3)
+    assert outcome.bypassed is True
+    assert outcome.reason == "flashrank_not_available"
+    assert outcome.nodes == nodes[:3]
+
+
+def test_healthy_rerank_returns_reranked_ordering():
+    nodes = tuple(_mk_node(f"node-{i}") for i in range(5))
+    fake_module = MagicMock()
+    fake_ranker_instance = MagicMock()
+    fake_ranker_instance.rerank.return_value = [
+        {"id": 3, "score": 0.91},
+        {"id": 1, "score": 0.82},
+        {"id": 0, "score": 0.55},
+    ]
+    fake_module.Ranker.return_value = fake_ranker_instance
+    fake_module.RerankRequest = lambda query, passages: {"query": query, "passages": passages}
+
+    with patch.dict(sys.modules, {"flashrank": fake_module}):
+        outcome = rerankers.rerank_top_k("q?", nodes, top_k=3)
+    assert outcome.bypassed is False
+    assert outcome.reason == "reranked"
+    assert outcome.nodes == (nodes[3], nodes[1], nodes[0])
+
+
+def test_latency_budget_triggers_bypass():
+    nodes = tuple(_mk_node(f"node-{i}") for i in range(5))
+    fake_module = MagicMock()
+    fake_ranker_instance = MagicMock()
+
+    def slow_rerank(request):
+        time.sleep(0.05)
+        return [{"id": 0, "score": 0.9}]
+
+    fake_ranker_instance.rerank.side_effect = slow_rerank
+    fake_module.Ranker.return_value = fake_ranker_instance
+    fake_module.RerankRequest = lambda query, passages: {"query": query, "passages": passages}
+
+    with patch.dict(sys.modules, {"flashrank": fake_module}):
+        outcome = rerankers.rerank_top_k("q?", nodes, top_k=3, latency_budget_ms=10)
+    assert outcome.bypassed is True
+    assert outcome.reason.startswith("latency_exceeded_")
+    assert outcome.nodes == nodes[:3]
+
+
+def test_rerank_call_failure_bypasses_safely():
+    nodes = tuple(_mk_node(f"node-{i}") for i in range(3))
+    fake_module = MagicMock()
+    fake_ranker_instance = MagicMock()
+    fake_ranker_instance.rerank.side_effect = RuntimeError("model crashed")
+    fake_module.Ranker.return_value = fake_ranker_instance
+    fake_module.RerankRequest = lambda query, passages: {"query": query, "passages": passages}
+
+    with patch.dict(sys.modules, {"flashrank": fake_module}):
+        outcome = rerankers.rerank_top_k("q?", nodes, top_k=2)
+    assert outcome.bypassed is True
+    assert outcome.reason == "rerank_call_failed"
+    assert outcome.nodes == nodes[:2]
+
+
+def test_reranker_singleton_reused_across_calls():
+    nodes = tuple(_mk_node(f"n-{i}") for i in range(3))
+    fake_module = MagicMock()
+    fake_ranker_instance = MagicMock()
+    fake_ranker_instance.rerank.return_value = [{"id": 0, "score": 0.5}]
+    fake_module.Ranker.return_value = fake_ranker_instance
+    fake_module.RerankRequest = lambda query, passages: {"query": query, "passages": passages}
+
+    with patch.dict(sys.modules, {"flashrank": fake_module}):
+        rerankers.rerank_top_k("q1", nodes, top_k=1)
+        rerankers.rerank_top_k("q2", nodes, top_k=1)
+    assert fake_module.Ranker.call_count == 1

--- a/tests/retrieval/test_source_id_resolution.py
+++ b/tests/retrieval/test_source_id_resolution.py
@@ -22,9 +22,18 @@ def _mk_node(text: str, score: float, metadata: dict) -> orchestrator.RetrievedN
     )
 
 
+def _outcome(nodes: tuple[orchestrator.RetrievedNode, ...]) -> orchestrator.RetrievalOutcome:
+    return orchestrator.RetrievalOutcome(
+        nodes=nodes, bypass_rerank=True, rerank_reason="test", rerank_elapsed_ms=0
+    )
+
+
 def _query_top_source(metadata: dict) -> str:
     nodes = (_mk_node("hit", 0.95, metadata),)
-    with patch("src.retrieval.agent_query.orchestrator.retrieve_nodes", return_value=nodes):
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
         result = agent_query.query("anything?", agent="test", min_score=0.50)
     return result.citations[0].source_id
 
@@ -62,6 +71,9 @@ def test_collection_fallback_when_metadata_empty():
 def test_parent_path_falls_back_to_section_when_missing():
     md = {"chunk_id": "c-1", "section": "Anti-hallucination guard"}
     nodes = (_mk_node("hit", 0.95, md),)
-    with patch("src.retrieval.agent_query.orchestrator.retrieve_nodes", return_value=nodes):
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
         result = agent_query.query("q?", agent="test", min_score=0.50)
     assert result.citations[0].parent_path == "Anti-hallucination guard"

--- a/tests/scripts/test_kei75_sessions_source_id.py
+++ b/tests/scripts/test_kei75_sessions_source_id.py
@@ -1,0 +1,114 @@
+"""Unit tests for scripts/orchestrator/kei75_sessions_source_id.
+
+Mocks Weaviate fully. Locks the idempotent re-run guarantee + the
+chunk_id-first resolution that backfill writes onto existing rows.
+"""
+
+from __future__ import annotations
+
+import importlib
+import urllib.error
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+backfill = importlib.import_module("scripts.orchestrator.kei75_sessions_source_id")
+
+
+def _obj(uuid_str: str, properties: dict) -> SimpleNamespace:
+    return SimpleNamespace(uuid=uuid_str, properties=properties)
+
+
+def _make_client(objects: list[SimpleNamespace]) -> MagicMock:
+    client = MagicMock()
+    coll = MagicMock()
+
+    def fetch_objects(limit=200, after=None, include_vector=False):
+        if after is None:
+            start = 0
+        else:
+            start = next((i + 1 for i, o in enumerate(objects) if o.uuid == after), len(objects))
+        return SimpleNamespace(objects=objects[start : start + limit])
+
+    coll.query.fetch_objects.side_effect = fetch_objects
+    coll.data.update = MagicMock()
+    client.collections.get.return_value = coll
+    return client
+
+
+def test_resolve_uses_chunk_id_when_present():
+    obj = _obj("u-1", {"metadata": {"chunk_id": "chunk-A"}})
+    assert backfill._resolve_source_id(obj) == "chunk-A"
+
+
+def test_resolve_falls_back_to_sessions_prefix_uuid():
+    obj = _obj("u-2", {"metadata": {}})
+    assert backfill._resolve_source_id(obj) == "sessions:u-2"
+
+
+def test_resolve_skips_when_source_id_already_set():
+    obj = _obj("u-3", {"source_id": "already-here", "metadata": {"chunk_id": "ignored"}})
+    assert backfill._resolve_source_id(obj) == ""
+
+
+def test_resolve_handles_string_metadata_blob():
+    obj = _obj("u-4", {"metadata": '{"chunk_id": "from-json"}'})
+    assert backfill._resolve_source_id(obj) == "from-json"
+
+
+def test_resolve_treats_blank_existing_source_id_as_unset():
+    obj = _obj("u-5", {"source_id": "   ", "metadata": {"chunk_id": "fallback"}})
+    assert backfill._resolve_source_id(obj) == "fallback"
+
+
+def test_run_dry_run_does_not_call_update(monkeypatch):
+    objects = [_obj("u-1", {"metadata": {"chunk_id": "c-1"}})]
+    client = _make_client(objects)
+    monkeypatch.setattr(backfill.weaviate, "connect_to_local", lambda **_: client)
+    monkeypatch.setattr(backfill, "_add_property", lambda base_url: "already_present")
+    report = backfill.run(host="127.0.0.1", port=8090, apply=False, limit=None)
+    assert report["would_update"] == 1
+    assert report["applied"] is False
+    assert report["sample_updates"] == [("u-1", "c-1")]
+    assert client.collections.get(backfill.SESSIONS_CLASS).data.update.call_count == 0
+
+
+def test_run_apply_writes_updates(monkeypatch):
+    objects = [
+        _obj("u-1", {"metadata": {"chunk_id": "c-1"}}),
+        _obj("u-2", {"metadata": {}}),
+        _obj("u-3", {"source_id": "already", "metadata": {"chunk_id": "ignored"}}),
+    ]
+    client = _make_client(objects)
+    monkeypatch.setattr(backfill.weaviate, "connect_to_local", lambda **_: client)
+    monkeypatch.setattr(backfill, "_add_property", lambda base_url: "added")
+    report = backfill.run(host="127.0.0.1", port=8090, apply=True, limit=None)
+    assert report["would_update"] == 2
+    assert report["skipped_already_set"] == 1
+    update_mock = client.collections.get(backfill.SESSIONS_CLASS).data.update
+    assert update_mock.call_count == 2
+    call_props = [call.kwargs["properties"]["source_id"] for call in update_mock.call_args_list]
+    assert "c-1" in call_props
+    assert "sessions:u-2" in call_props
+
+
+def test_run_limit_caps_iteration(monkeypatch):
+    objects = [_obj(f"u-{i}", {"metadata": {"chunk_id": f"c-{i}"}}) for i in range(5)]
+    client = _make_client(objects)
+    monkeypatch.setattr(backfill.weaviate, "connect_to_local", lambda **_: client)
+    monkeypatch.setattr(backfill, "_add_property", lambda base_url: "already_present")
+    report = backfill.run(host="127.0.0.1", port=8090, apply=False, limit=2)
+    assert report["would_update"] == 2
+
+
+def test_add_property_treats_422_as_idempotent_success(monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(
+            req.full_url,
+            422,
+            "Unprocessable Entity",
+            {},
+            MagicMock(read=lambda: b"property exists"),
+        )
+
+    monkeypatch.setattr(backfill.urllib.request, "urlopen", fake_urlopen)
+    assert backfill._add_property("http://127.0.0.1:8090") == "already_present"


### PR DESCRIPTION
## Summary
PR2 of two for KEI-75. Closes the two retrieval-orchestrator weak-query gaps Atlas's probes surfaced + the Sessions schema gap Aiden flagged at ingest-time.

PR1 (#892) shipped the source_id citation fix + corpus-hygiene sweeps. PR2 adds the read-side teeth: FlashRank cross-encoder rerank pass with bypass-fallback semantics, plus the Sessions class source_id property add + 48,666-row backfill that lets PR1's citation precedence finally point at chunk_ids on the Wave-4 corpus.

## Components (681 LOC, 10 files)
- **src/retrieval/rerankers.py** — FlashRank cross-encoder wrapper. Process-global Ranker singleton (lazy load on first call). `rerank_top_k` returns a `RerankOutcome` carrying nodes + bypassed/reason/elapsed_ms so callers honour the bypass flag verbatim (no more constant `True` from PR1).
- **src/retrieval/orchestrator.py** — new `retrieve_with_outcome` runs the two-stage path (Weaviate ANN k=20 → FlashRank top-5) and surfaces the bypass flag. Legacy `retrieve_nodes` retained as a thin wrapper for callers that only need the tuple.
- **src/retrieval/agent_query.py** — `query()` now reads `outcome.bypass_rerank` rather than the legacy constant; QueryResult bypass flag finally reflects per-query reality.
- **infra/weaviate/schema.py** — adds `source_id` to `MANDATORY_PROPERTIES` so fresh installs declare the column on all 5 collections.
- **scripts/orchestrator/kei75_sessions_source_id.py** — applies the property to the existing live Sessions class via POST `/v1/schema/.../properties` (treats HTTP 422 as already-present idempotency) and backfills all 48,666 rows with chunk_id-derived source_id. Dry-run by default; `--apply` commits; `--limit N` caps for smoke runs.
- **requirements.txt** — pins `flashrank>=0.2.7,<0.3`.

## Tests (16 new + 19 existing = 35 total, all passing)
```
$ PYTHONPATH=. python3 -m pytest tests/retrieval/ tests/scripts/test_kei75_sessions_source_id.py -q
============================== 35 passed in 4.36s ==============================
```
- `tests/retrieval/test_rerankers.py` — 6 tests cover empty input, flashrank-missing bypass, healthy rerank ordering, latency-budget bypass, rerank-call-failure bypass, singleton reuse.
- `tests/scripts/test_kei75_sessions_source_id.py` — 9 tests cover chunk_id resolution, `sessions:` fallback, skip-when-set idempotency, string-blob metadata, dry-run vs apply, `--limit`, 422-as-success idempotency.
- `tests/retrieval/test_agent_query.py` — patched mocks to `retrieve_with_outcome`; added regression for bypass-flag propagation.
- `tests/retrieval/test_source_id_resolution.py` — same patch update.

## Bypass-rerank flag now meaningful
PR1 left `bypass_rerank=True` as a constant. PR2 wires the real state:
- FlashRank installed + healthy → `bypass_rerank=False` (rerank ran)
- FlashRank import fails → `bypass_rerank=True`, `reason=flashrank_not_available`
- Rerank exceeds latency budget → `bypass_rerank=True`, `reason=latency_exceeded_{N}ms_over_{M}ms`
- Rerank call raises → `bypass_rerank=True`, `reason=rerank_call_failed`

Observability stays honest. Operators can dashboard bypass-rate to detect FlashRank degradation.

## Out of scope (follow-up KEIs)
- KEI-70 deliberation re-chunk (Q3 weak-query gap) — separate scope per Elliot ratify; ships when there's measurable query-quality delta.
- KEI-75 PR1 sweep `--apply` runs — Dave authorisation pending.
- Live FlashRank model-load smoke against the populated corpus — CI runs the mocked tests; production install fires the lazy load on first query post-merge.

## Test plan
- [x] 35/35 unit tests pass (mocked FlashRank + mocked Weaviate; no live deps required for CI)
- [x] Ruff check + format clean on all 10 modified files
- [ ] CI green (Lint + Pytest + MyPy + Frontend + Sonar + Dead-Ref + Migration + Vercel)
- [ ] Triple-FINAL [FINAL:aiden] + [FINAL:elliot]
- [ ] Post-merge: run `kei75_sessions_source_id.py --apply` to backfill 48,666 Sessions rows; verify FlashRank rerank fires on a representative query
- [ ] Close KEI-75: insert task_verifications row + tasks_cli complete KEI-75

Linear: KEI-75
Closes KEI-75 (jointly with PR1 #892 already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)