### PR TITLE
[ELLIOT] feat(kei18): mechanical auto-KEI creation in central_listener [CEO]-prefix intercept

### DIFF
--- a/src/slack_bot/central_listener.py
+++ b/src/slack_bot/central_listener.py
@@ -47,6 +47,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
+import psycopg
 from slack_sdk.socket_mode import SocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
@@ -79,6 +80,11 @@ OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
 ENFORCER_DETERMINISTIC = os.environ.get("ENFORCER_DETERMINISTIC", "1") == "1"
 LISTEN_CHANNEL = os.environ.get("SLACK_LISTEN_CHANNEL", "C0B3QB0K1GQ")  # enforcer scope
 ALERTS_CHANNEL = os.environ.get("SLACK_ALERTS_CHANNEL", "C0B2EJU53EK")
+DATABASE_URL = os.environ.get("DATABASE_URL", "")
+
+# Auto-KEI: #ceo channel id — messages starting with [CEO] trigger task creation.
+CEO_CHANNEL = "C0B2PM3TV0B"
+CEO_PREFIX = "[CEO]"
 ENFORCER_USERNAME = "Enforcer"
 ENFORCER_ICON = ":rotating_light:"
 
@@ -441,6 +447,89 @@ def _fanout_to_routes(routes: list[str], text: str, sender: str) -> None:
         write_inbox(callsign, text, sender)
 
 
+def _extract_ceo_title(text: str) -> str | None:
+    """Strip [CEO] prefix and return the first non-empty line (max 200 chars).
+
+    Returns None if the body is empty after stripping — e.g. bare '[CEO]' post.
+    """
+    body = text
+    if body.upper().startswith(CEO_PREFIX.upper()):
+        body = body[len(CEO_PREFIX) :]
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped[:200]
+    return None
+
+
+def _insert_kei_task(title: str) -> str | None:
+    """Insert a new KEI task into public.tasks and return the new KEI id.
+
+    Uses a single psycopg connection per call (listener is long-running; avoid
+    holding a persistent connection across arbitrary idle periods).
+
+    Returns None on any failure so the caller can log-and-skip gracefully.
+    Idempotency: tasks.id has a UNIQUE constraint; duplicate inserts raise
+    IntegrityError which is caught and treated as a skip (one winner).
+    """
+    db_url = DATABASE_URL.replace("+asyncpg", "")
+    if not db_url:
+        logger.warning("auto-KEI: DATABASE_URL not set — skipping insert")
+        return None
+    try:
+        with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT COALESCE(MAX((substring(id FROM 'KEI-([0-9]+)'))::int), 0) + 1"
+                " FROM public.tasks WHERE id ~ '^KEI-[0-9]+$'"
+            )
+            row = cur.fetchone()
+            next_n: int = row[0] if row else 1
+            kei_id = f"KEI-{next_n}"
+            cur.execute(
+                "INSERT INTO public.tasks (id, title, status, dependencies, required_persona)"
+                " VALUES (%s, %s, %s, %s, %s)",
+                (kei_id, title, "available", [], None),
+            )
+            conn.commit()
+            logger.info("auto-KEI: inserted %s — %s", kei_id, title)
+            return kei_id
+    except psycopg.errors.UniqueViolation:
+        logger.info("auto-KEI: duplicate insert skipped (race guard)")
+        return None
+    except Exception as exc:
+        logger.warning("auto-KEI: DB insert failed: %s", exc)
+        return None
+
+
+def _maybe_auto_create_kei(event: dict, web: WebClient | None) -> None:
+    """Auto-KEI intercept for [CEO]-prefixed messages in #ceo channel.
+
+    Fires BEFORE the normal fanout so it runs regardless of fanout outcome.
+    Best-effort: any failure is logged but never blocks the fanout relay.
+    """
+    channel = event.get("channel", "")
+    text = (event.get("text") or "").strip()
+    if channel != CEO_CHANNEL:
+        return
+    if not text.upper().startswith(CEO_PREFIX.upper()):
+        return
+    title = _extract_ceo_title(text)
+    if not title:
+        logger.info("auto-KEI: [CEO] post has empty body after strip — skip")
+        return
+    kei_id = _insert_kei_task(title)
+    if kei_id is None:
+        return
+    if web is not None:
+        try:
+            web.chat_postMessage(
+                channel=CEO_CHANNEL,
+                text=f"[System] {kei_id} created — {title}",
+            )
+        except Exception as exc:
+            logger.warning("auto-KEI: confirmation post failed: %s", exc)
+
+
 def process_event(event: dict, web: WebClient | None = None) -> None:
     if event.get("type") != "message":
         return
@@ -451,6 +540,12 @@ def process_event(event: dict, web: WebClient | None = None) -> None:
     text = event.get("text") or ""
     if not text:
         return
+    # Auto-KEI intercept: fires BEFORE fanout; best-effort; does not block relay.
+    try:
+        _maybe_auto_create_kei(event, web)
+    except Exception as exc:
+        logger.exception("auto-KEI error (non-blocking): %s", exc)
+
     if routes:
         _fanout_to_routes(routes, text, sender_from(event))
         logger.info(

--- a/tests/slack_bot/test_central_listener_auto_kei.py
+++ b/tests/slack_bot/test_central_listener_auto_kei.py
@@ -1,0 +1,231 @@
+"""Tests for auto-KEI creation in central_listener.py (KEI-18).
+
+Per Dave-direct mandate 2026-05-16: messages in #ceo channel starting with
+[CEO] prefix trigger automatic task insertion into public.tasks and a
+confirmation post back to #ceo. Fanout relay must still fire regardless of
+auto-KEI outcome.
+
+All tests use mocks — no live Slack or Supabase calls.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+# Stub slack_sdk and psycopg before module import (same pattern as PR #711)
+for mod_name in (
+    "slack_sdk",
+    "slack_sdk.socket_mode",
+    "slack_sdk.socket_mode.request",
+    "slack_sdk.socket_mode.response",
+    "slack_sdk.web",
+):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+sys.modules["slack_sdk.socket_mode"].SocketModeClient = type("SocketModeClient", (), {})
+sys.modules["slack_sdk.socket_mode.request"].SocketModeRequest = type("SocketModeRequest", (), {})
+sys.modules["slack_sdk.socket_mode.response"].SocketModeResponse = type(
+    "SocketModeResponse", (), {}
+)
+sys.modules["slack_sdk.web"].WebClient = type("WebClient", (), {})
+
+# Stub psycopg at the top level before importing central_listener
+psycopg_stub = types.ModuleType("psycopg")
+psycopg_errors_stub = types.ModuleType("psycopg.errors")
+
+
+class _UniqueViolation(Exception):
+    pass
+
+
+psycopg_errors_stub.UniqueViolation = _UniqueViolation
+psycopg_stub.errors = psycopg_errors_stub
+psycopg_stub.connect = MagicMock()
+sys.modules["psycopg"] = psycopg_stub
+sys.modules["psycopg.errors"] = psycopg_errors_stub
+
+from src.slack_bot.central_listener import (  # noqa: E402
+    CALLSIGN_TO_INBOX,
+    CEO_CHANNEL,
+    _extract_ceo_title,
+    _insert_kei_task,
+    _maybe_auto_create_kei,
+    process_event,
+)
+
+CEO_EVENT_TEXT = "[CEO] File the migration KEI now."
+NON_CEO_TEXT = "Status check on Wave 4"
+EMPTY_CEO_TEXT = "[CEO]\n"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helper: build a #ceo Slack event dict
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _ceo_event(text: str) -> dict:
+    return {"type": "message", "channel": CEO_CHANNEL, "text": text, "ts": "1.0"}
+
+
+def _execution_event(text: str) -> dict:
+    return {"type": "message", "channel": "C0B3QB0K1GQ", "text": text, "ts": "1.0"}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# TEST 1: [CEO] prefix triggers INSERT with correct fields
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_ceo_prefix_inserts_task() -> None:
+    """Mocked psycopg cursor receives INSERT with computed next id + extracted title + status='available'."""
+    mock_cursor = MagicMock()
+    mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_cursor.__exit__ = MagicMock(return_value=False)
+    mock_cursor.fetchone.return_value = (42,)
+
+    mock_conn = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cursor
+
+    with (
+        patch("src.slack_bot.central_listener.DATABASE_URL", "postgresql://fake/db"),
+        patch("src.slack_bot.central_listener.psycopg.connect", return_value=mock_conn),
+    ):
+        kei_id = _insert_kei_task("File the migration KEI now.")
+
+    assert kei_id == "KEI-42"
+    # Verify INSERT was called with the right arguments
+    insert_call = mock_cursor.execute.call_args_list[1]
+    args = insert_call[0][1]  # positional args tuple passed to execute
+    assert args[0] == "KEI-42"
+    assert args[1] == "File the migration KEI now."
+    assert args[2] == "available"
+    assert args[3] == []
+    assert args[4] is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# TEST 2: No [CEO] prefix → INSERT not called
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_no_prefix_skips_insert() -> None:
+    """Non-[CEO] message in #ceo channel does not trigger any INSERT."""
+    mock_web = MagicMock()
+    event = _ceo_event(NON_CEO_TEXT)
+
+    with patch("src.slack_bot.central_listener.psycopg.connect") as mock_connect:
+        _maybe_auto_create_kei(event, mock_web)
+        mock_connect.assert_not_called()
+
+    mock_web.chat_postMessage.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# TEST 3: Empty body after [CEO] strip → INSERT skipped
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_empty_body_skips_insert() -> None:
+    """A bare [CEO] post (nothing after the prefix) skips auto-create."""
+    mock_web = MagicMock()
+    event = _ceo_event(EMPTY_CEO_TEXT)
+
+    with patch("src.slack_bot.central_listener.psycopg.connect") as mock_connect:
+        _maybe_auto_create_kei(event, mock_web)
+        mock_connect.assert_not_called()
+
+    mock_web.chat_postMessage.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# TEST 4: Successful insert → confirmation posted to #ceo
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_confirmation_posted_on_success() -> None:
+    """After a successful insert, chat_postMessage is called with [System] KEI-N created — …"""
+    mock_cursor = MagicMock()
+    mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_cursor.__exit__ = MagicMock(return_value=False)
+    mock_cursor.fetchone.return_value = (7,)
+
+    mock_conn = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cursor
+
+    mock_web = MagicMock()
+    event = _ceo_event(CEO_EVENT_TEXT)
+
+    with (
+        patch("src.slack_bot.central_listener.DATABASE_URL", "postgresql://fake/db"),
+        patch("src.slack_bot.central_listener.psycopg.connect", return_value=mock_conn),
+    ):
+        _maybe_auto_create_kei(event, mock_web)
+
+    mock_web.chat_postMessage.assert_called_once_with(
+        channel=CEO_CHANNEL,
+        text="[System] KEI-7 created — File the migration KEI now.",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# TEST 5: Auto-create failure does NOT block fanout relay
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_fanout_still_fires(tmp_path) -> None:
+    """write_inbox (fanout) fires even when _maybe_auto_create_kei raises."""
+    inbox_elliot = tmp_path / "elliot_inbox"
+    inbox_elliot.mkdir()
+
+    event = _ceo_event(CEO_EVENT_TEXT)
+
+    with (
+        patch(
+            "src.slack_bot.central_listener._maybe_auto_create_kei",
+            side_effect=RuntimeError("db down"),
+        ),
+        patch.dict(CALLSIGN_TO_INBOX, {"elliot": [inbox_elliot]}),
+    ):
+        process_event(event)
+
+    # Elliot's inbox should have received the fanout despite the auto-KEI failure
+    files = list(inbox_elliot.iterdir())
+    assert len(files) == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# TITLE EXTRACTION UNIT TESTS
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_title_basic() -> None:
+    assert _extract_ceo_title("[CEO] File the migration KEI now.") == "File the migration KEI now."
+
+
+def test_extract_title_multiline_takes_first() -> None:
+    text = "[CEO]\nFirst meaningful line\nSecond line"
+    assert _extract_ceo_title(text) == "First meaningful line"
+
+
+def test_extract_title_empty_returns_none() -> None:
+    assert _extract_ceo_title("[CEO]\n") is None
+    assert _extract_ceo_title("[CEO]") is None
+    assert _extract_ceo_title("[CEO]   ") is None
+
+
+def test_extract_title_truncates_at_200() -> None:
+    long_title = "A" * 250
+    text = f"[CEO] {long_title}"
+    result = _extract_ceo_title(text)
+    assert result is not None
+    assert len(result) == 200
+
+
+def test_extract_title_case_insensitive_prefix() -> None:
+    assert _extract_ceo_title("[ceo] lower case prefix") == "lower case prefix"


### PR DESCRIPTION
## Summary
Adds a best-effort [CEO]-prefix intercept to the central Slack listener that automatically creates a KEI task in public.tasks whenever Dave posts to #ceo with the [CEO] prefix, then posts a [System] confirmation back to the channel. The fanout relay always fires regardless of auto-KEI outcome.

## Dave Verbatim Spec
"ON message received in #ceo matching [CEO] prefix: 1) Extract directive title (first meaningful line after [CEO]). 2) INSERT into tasks table immediately: id = next KEI number, title = extracted title, status = 'available', dependencies = [], required_persona = null. 3) Post confirmation '[System] KEI-XX created — {title}' to #ceo. 4) THEN relay directive to Elliot as normal."

## Scope
**Files changed:**
- `src/slack_bot/central_listener.py` — added `_extract_ceo_title()`, `_insert_kei_task()`, `_maybe_auto_create_kei()` helpers + `DATABASE_URL`/`CEO_CHANNEL`/`CEO_PREFIX` constants; wired `_maybe_auto_create_kei()` call in `process_event()` BEFORE the existing fanout block.
- `tests/slack_bot/test_central_listener_auto_kei.py` — new file, 10 unit tests.

**Behaviour change:** additive only. Enforcer pass and fanout-to-inbox logic are untouched. The intercept is wrapped in `try/except` so any DB/Slack failure cannot block the relay.

## Test Plan
- `test_ceo_prefix_inserts_task` — mocked psycopg cursor; verifies INSERT called with KEI-42, correct title, status='available', empty dependencies, null persona.
- `test_no_prefix_skips_insert` — non-[CEO] text; verifies zero INSERT calls.
- `test_empty_body_skips_insert` — bare `[CEO]\n`; verifies skip.
- `test_confirmation_posted_on_success` — mocked WebClient; verifies chat_postMessage called with `[System] KEI-7 created — …`.
- `test_fanout_still_fires` — auto-KEI raises RuntimeError; verifies elliot's inbox write still fires.
- Plus 5 `_extract_ceo_title` unit tests covering basic, multiline, empty, truncation, and case-insensitive prefix.

**All 10 tests green. ruff check + ruff format clean.**

## Open Questions
None — spec fully locked per Dave-direct mandate 2026-05-16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)