### PR TITLE
[ATLAS] fix(kei77): Cognee Kuzu max_db_size cap — restore write path

### DIFF
--- a/infra/systemd/agents/cognee.service
+++ b/infra/systemd/agents/cognee.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Agency OS — Cognee API server (knowledge graph + memory layer)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Use Agency_OS/.venv (clean mistralai 1.9.11) — shared /home/elliotbot/clawd/venv/
+# has corrupted mistralai 2.0.5 (missing __init__.py) per Atlas + Elliot verify
+# 2026-05-12 ts 1778567xxx. Option C of A/B/C/D — narrowest-blast-radius fix.
+# KEI-77 — cognee_kuzu_capped_launcher.py monkey-patches ladybug Database init
+# to clamp max_db_size + buffer_pool_size, fixing the 4 GB mmap collision with
+# the KEI-44 3 GB cgroup cap. See: scripts/cognee_kuzu_capped_launcher.py.
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/cognee_kuzu_capped_launcher.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+# KEI-77 — Kuzu clamps (units = MB). 1024 MB max_db_size + 768 MB buffer_pool +
+# cognee runtime (~800 MB peak observed RSS) = ~2.5 GB; comfortable under the
+# 3 GB cgroup cap below.
+Environment="COGNEE_KUZU_MAX_DB_SIZE_MB=1024"
+Environment="COGNEE_KUZU_BUFFER_POOL_MB=768"
+Restart=on-failure
+RestartSec=5
+# KEI-44 — 3 GB cgroup memory cap on the long-running cognee service.
+# PR #846 shipped cognee_capped.sh (only capped ad-hoc subprocess launches);
+# the live service was bypassing the cap (verified 2026-05-14T07:48Z:
+# MemoryMax=infinity on PID 1278). 3 GB matches Orion's acceptance test in
+# scripts/orchestrator/cognee_cap_acceptance_test.sh.
+MemoryMax=3G
+MemoryHigh=2700M
+StandardOutput=append:/home/elliotbot/clawd/logs/cognee.log
+StandardError=append:/home/elliotbot/clawd/logs/cognee.log
+
+[Install]
+WantedBy=default.target

--- a/scripts/cognee_kuzu_capped_launcher.py
+++ b/scripts/cognee_kuzu_capped_launcher.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""cognee_kuzu_capped_launcher.py — KEI-77 fix.
+
+Cognee 1.0.9's ladybug adapter hard-codes `max_db_size=4 GB` in 4 places
+(`infrastructure/databases/graph/ladybug/adapter.py` lines 93, 127, 148,
+181). Kuzu mmap()'s the full max_db_size at Database init, which collides
+with the KEI-44 3 GB cgroup cap on cognee.service: every add()/cognify()
+fails with `Buffer manager exception: Mmap for size 4294967296 failed`
+(4294967296 == 4 GB exact). 1382 consecutive failures observed in
+~/.cognee/logs/2026-05-13_20-53-51.log on 2026-05-13 21:27, no successful
+writes since.
+
+This launcher monkey-patches `ladybug.database.Database.__init__` to clamp
+`max_db_size` and `buffer_pool_size` from env, then exec's uvicorn. Patch
+survives pip upgrades because it runs at process start, not in-source.
+
+Env (set in cognee.service unit):
+    COGNEE_KUZU_MAX_DB_SIZE_MB     default 1024  (was 4096, now fits 3G cap)
+    COGNEE_KUZU_BUFFER_POOL_MB     default 768   (was 2048, give DB headroom)
+
+The 1 GB max_db_size + 768 MB buffer pool + cognee runtime (~800 MB peak
+per `systemctl --user status cognee` observed RSS) = ~2.5 GB, well inside
+the 3 GB cgroup ceiling.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _apply_patch() -> None:
+    """Monkey-patch ladybug.database.Database.__init__ to clamp sizes."""
+    max_db_mb = int(os.environ.get("COGNEE_KUZU_MAX_DB_SIZE_MB", "1024"))
+    pool_mb = int(os.environ.get("COGNEE_KUZU_BUFFER_POOL_MB", "768"))
+    max_db_bytes = max_db_mb * 1024 * 1024
+    pool_bytes = pool_mb * 1024 * 1024
+
+    try:
+        from ladybug.database import Database
+    except ImportError:
+        print("WARNING: ladybug not importable; patch skipped", file=sys.stderr)
+        return
+
+    original_init = Database.__init__
+
+    def capped_init(self, *args, **kwargs):
+        # Clamp caller's value to our ceiling (don't expand, only shrink).
+        requested_max = kwargs.get("max_db_size", max_db_bytes) or max_db_bytes
+        kwargs["max_db_size"] = min(requested_max, max_db_bytes)
+        requested_pool = kwargs.get("buffer_pool_size", pool_bytes) or pool_bytes
+        kwargs["buffer_pool_size"] = min(requested_pool, pool_bytes)
+        return original_init(self, *args, **kwargs)
+
+    Database.__init__ = capped_init
+    print(
+        f"[cognee_kuzu_capped_launcher] patched: max_db_size<= {max_db_mb}MB, "
+        f"buffer_pool_size<= {pool_mb}MB",
+        file=sys.stderr,
+    )
+
+
+def main() -> int:
+    _apply_patch()
+    # Exec uvicorn with the patched runtime. Use os.execvp so cognee.service
+    # PID stays singular (no orphaned launcher process).
+    args = [
+        "uvicorn",
+        "cognee.api.client:app",
+        "--host", os.environ.get("COGNEE_HOST", "127.0.0.1"),
+        "--port", os.environ.get("COGNEE_PORT", "8000"),
+    ]
+    os.execvp(args[0], args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cognee_stale_path_cleanup.sh
+++ b/scripts/cognee_stale_path_cleanup.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# cognee_stale_path_cleanup.sh — KEI-77 follow-on cleanup.
+#
+# Q1 audit (docs/audits/hybrid_memory_q1_atlas.md) flagged two cognee DB paths:
+#   1. /home/elliotbot/clawd/cognee_data/      — STALE (215 MB SQLite, last 5/13)
+#   2. .venv/.../cognee/.cognee_system/databases/ — LIVE (what cognee actually uses)
+#
+# The stale path likely originated from an earlier cognee version that read
+# DB_PATH from env; the live cognee 1.0.9 ignores DB_PATH and writes inside
+# the venv. Stale path serves no purpose and confuses operators looking for
+# "cognee data" (was the Q1 audit's first-pass conclusion until I traced the
+# live process's database_path log line).
+#
+# Move-to-trash (not rm) so it's recoverable if someone needed it. Dave's
+# 2026-05-16 dispatch authorised cleanup in the KEI-77 PR.
+#
+# Run ONCE post-merge. Idempotent — exits 0 if path already gone.
+
+set -euo pipefail
+
+STALE_PATH="/home/elliotbot/clawd/cognee_data"
+
+if [[ ! -e "$STALE_PATH" ]]; then
+    echo "cognee_stale_path_cleanup: $STALE_PATH already absent — no-op"
+    exit 0
+fi
+
+# Verify the live cognee process is NOT using this path (paranoid check).
+LIVE_DB_PATH=$(grep -h "database_path=" /home/elliotbot/clawd/logs/cognee.log 2>/dev/null | tail -1)
+if echo "$LIVE_DB_PATH" | grep -q "cognee_data"; then
+    echo "cognee_stale_path_cleanup: ABORT — live cognee.log database_path mentions cognee_data:" >&2
+    echo "  $LIVE_DB_PATH" >&2
+    exit 1
+fi
+
+# Move to ~/.local/share/Trash (gio) if available, else mv to backup dir.
+if command -v gio >/dev/null; then
+    gio trash "$STALE_PATH"
+    echo "cognee_stale_path_cleanup: moved $STALE_PATH to trash"
+else
+    BACKUP="/home/elliotbot/.cognee_data_stale_backup_$(date +%Y%m%d_%H%M%S)"
+    mv "$STALE_PATH" "$BACKUP"
+    echo "cognee_stale_path_cleanup: moved $STALE_PATH to $BACKUP (gio not available)"
+fi


### PR DESCRIPTION
## Summary

KEI-77 Dave-direct dispatch 2026-05-16, Option B (Kuzu config clamp). Restores Cognee write path (broken since 2026-05-13 21:27 — 1382 consecutive add() failures). Preserves KEI-44 3GB cgroup safety floor.

## Root cause

`cognee/infrastructure/databases/graph/ladybug/adapter.py` hard-codes `max_db_size=4096*1024*1024` (4 GB exact) at 4 sites (L93/127/148/181). Kuzu mmaps the full max_db_size at Database init → 4 GB mmap collides with KEI-44 3 GB cgroup cap on cognee.service → `Buffer manager exception: Mmap for size 4294967296 failed` on every add(). `buffer_pool=2GB` was a red herring; `max_db_size=4GB` is the killer.

## Fix (3 files, 156 LoC)

- `scripts/cognee_kuzu_capped_launcher.py` — monkey-patches `ladybug.database.Database.__init__` to clamp `max_db_size` + `buffer_pool_size` from env, then `exec`'s uvicorn. Survives pip upgrades (no in-source venv edit).
- `infra/systemd/agents/cognee.service` — canonical unit. `ExecStart` → launcher. Adds `COGNEE_KUZU_MAX_DB_SIZE_MB=1024` + `COGNEE_KUZU_BUFFER_POOL_MB=768`. KEI-44 cgroup directives preserved.
- `scripts/cognee_stale_path_cleanup.sh` — idempotent gio-trash of `/home/elliotbot/clawd/cognee_data` (stale 215 MB SQLite — live cognee uses `.venv/.../cognee/.cognee_system/databases/` instead). Paranoid guard aborts if live cognee.log still references it. Bundled per Dave "same PR" dispatch.

## Empirical verification (verbatim, no mocks)

```
$ python3 -c '
    import os
    os.environ["COGNEE_KUZU_MAX_DB_SIZE_MB"]="1024"
    os.environ["COGNEE_KUZU_BUFFER_POOL_MB"]="768"
    import sys
    sys.path.insert(0, "scripts")
    from cognee_kuzu_capped_launcher import _apply_patch
    _apply_patch()
    import tempfile
    from ladybug.database import Database
    with tempfile.TemporaryDirectory() as td:
        db = Database(f"{td}/probe",
                      max_db_size=4096*1024*1024,
                      buffer_pool_size=2048*1024*1024)
        print("Database created successfully (patched)")
'
[cognee_kuzu_capped_launcher] patched: max_db_size<= 1024MB, buffer_pool_size<= 768MB
Database created successfully (patched)
```

Caller still passes 4 GB (mirrors cognee adapter.py); patch clamps to 1 GB; init succeeds where it previously threw Mmap.

## Memory math

`1024 MB max_db_size + 768 MB buffer_pool + ~800 MB cognee runtime peak RSS = ~2.5 GB`. Comfortable under the 3 GB cgroup ceiling.

## Post-merge deploy

```
# Auto_pull_main syncs the new files into /home/elliotbot/clawd/Agency_OS
cp infra/systemd/agents/cognee.service ~/.config/systemd/user/
systemctl --user daemon-reload
systemctl --user restart cognee.service
bash scripts/cognee_stale_path_cleanup.sh
# After-probe: scripts/cognee_smoke.py — verify add() returns OK
# + cognee_graph_ladybug mtime advances
```

## Test plan

- [x] Patch verified in isolation (probe constructs Database with 4 GB request → succeeds when patch is active)
- [ ] Post-merge: systemd restart + cognee_smoke.py round-trip
- [ ] Post-merge: `cognee_graph_ladybug` mtime advances after smoke
- [ ] Post-merge: stale path cleanup runs idempotently

🤖 Generated with [Claude Code](https://claude.com/claude-code)