### PR TITLE
[ATLAS] hotfix(kei77): launcher execvp uvicorn + cleanup pipefail

### DIFF
--- a/scripts/cognee_kuzu_capped_launcher.py
+++ b/scripts/cognee_kuzu_capped_launcher.py
@@ -62,10 +62,13 @@ def _apply_patch() -> None:
 
 def main() -> int:
     _apply_patch()
-    # Exec uvicorn with the patched runtime. Use os.execvp so cognee.service
-    # PID stays singular (no orphaned launcher process).
+    # Exec uvicorn with the patched runtime. sys.executable + `-m uvicorn` so
+    # the launcher works under systemd (where PATH doesn't include the venv's
+    # bin/ dir, and bare `uvicorn` is FileNotFoundError). Using -m also keeps
+    # cognee.service PID singular — execvp replaces the launcher process.
     args = [
-        "uvicorn",
+        sys.executable,
+        "-m", "uvicorn",
         "cognee.api.client:app",
         "--host", os.environ.get("COGNEE_HOST", "127.0.0.1"),
         "--port", os.environ.get("COGNEE_PORT", "8000"),

--- a/scripts/cognee_stale_path_cleanup.sh
+++ b/scripts/cognee_stale_path_cleanup.sh
@@ -26,10 +26,15 @@ if [[ ! -e "$STALE_PATH" ]]; then
 fi
 
 # Verify the live cognee process is NOT using this path (paranoid check).
-LIVE_DB_PATH=$(grep -h "database_path=" /home/elliotbot/clawd/logs/cognee.log 2>/dev/null | tail -1)
-if echo "$LIVE_DB_PATH" | grep -q "cognee_data"; then
-    echo "cognee_stale_path_cleanup: ABORT — live cognee.log database_path mentions cognee_data:" >&2
-    echo "  $LIVE_DB_PATH" >&2
+# Cognee structlog wraps fields in ANSI colour codes — match the literal
+# field name (no `=` required) and filter for the stale-path substring.
+# Failed grep returns 1 — use `|| true` to play nice with `set -e`.
+LIVE_HITS=$(grep -h "database_path" /home/elliotbot/clawd/logs/cognee.log 2>/dev/null \
+            | tail -50 | grep -c "/clawd/cognee_data" || true)
+if [[ "$LIVE_HITS" -gt 0 ]]; then
+    echo "cognee_stale_path_cleanup: ABORT — live cognee.log database_path mentions /clawd/cognee_data ($LIVE_HITS hits in tail -50)" >&2
+    grep -h "database_path" /home/elliotbot/clawd/logs/cognee.log 2>/dev/null \
+        | tail -1 >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Two post-merge-deploy bugs in PR #898 (ec841fc1) caught during live systemd deploy of KEI-77.

1. **`cognee_kuzu_capped_launcher.py`** — `os.execvp("uvicorn", ...)` → `FileNotFoundError` under systemd because systemd's PATH doesn't include the venv's bin/ dir. Fix: `sys.executable + "-m uvicorn"` so the `.venv/bin/python3` (sys.executable when running under the unit ExecStart) resolves uvicorn via site-packages.

2. **`cognee_stale_path_cleanup.sh`** — cognee structlog wraps field names in ANSI colour codes, so `grep database_path=` matched zero lines. The subsequent `if echo "" | grep -q` triggered pipefail on the empty grep, exiting 1 silently. Fix: match the bare field name, count hits in a separate var with `|| true`, test the count.

## Post-fix verification (LIVE — cognee.service is currently running with the patched launcher)

```
$ systemctl --user status cognee.service | head -3
● cognee.service - Agency OS — Cognee API server
     Active: active (running) since Sat 2026-05-16 12:46:01 UTC

$ curl -s -o /dev/null -w 'HTTP=%{http_code}\n' http://127.0.0.1:8000/health
HTTP=200

$ grep -c 'Mmap for size' ~/.cognee/logs/2026-05-16*.log | head
/home/elliotbot/.cognee/logs/2026-05-16_12-46-08.log:0
/home/elliotbot/.cognee/logs/2026-05-16_12-45-21.log:0
/home/elliotbot/.cognee/logs/2026-05-16_12-48-14.log:0
/home/elliotbot/.cognee/logs/2026-05-16_12-46-03.log:0
/home/elliotbot/.cognee/logs/2026-05-16_12-46-11.log:0
(5 files, all 0 — vs 1382 Mmap failures pre-fix on 2026-05-13)

$ bash scripts/cognee_stale_path_cleanup.sh
cognee_stale_path_cleanup: moved /home/elliotbot/clawd/cognee_data to trash
$ ls /home/elliotbot/clawd/cognee_data
ls: cannot access '/home/elliotbot/clawd/cognee_data': No such file or directory
```

## KEI-77 status

Kuzu mmap root cause fixed end-to-end. Stale path cleaned. A secondary blocker — `LLMAPIKeyNotSetError` in cognee_smoke.py LLM gateway — was exposed during smoke. Existed pre-fix but was masked by the Mmap crash (cognee died at Kuzu init before reaching LLM gateway). **Out of KEI-77 scope; will file separately.**

## Test plan

- [x] Patch applied + cognee.service restarted under live systemd → HTTP 200, no Mmap errors
- [x] Cleanup script idempotent, exits 0, trashes stale path
- [ ] Post-merge: auto_pull_main syncs to main worktree; cognee survives next restart cycle without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)