### PR TITLE
[AIDEN] feat(kei79): bd escalate state machine + ceo_decisions + direct-post hybrid

### DIFF
--- a/infra/systemd/ceo-decision-sweeper.service
+++ b/infra/systemd/ceo-decision-sweeper.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Agency OS — CEO Decision Sweeper (KEI-79)
+Documentation=https://linear.app/keiracom/issue/KEI-79
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/ceo_decision_sweeper.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+StandardOutput=append:/home/elliotbot/clawd/logs/ceo-decision-sweeper.log
+StandardError=append:/home/elliotbot/clawd/logs/ceo-decision-sweeper.log
+MemoryMax=128M

--- a/infra/systemd/ceo-decision-sweeper.timer
+++ b/infra/systemd/ceo-decision-sweeper.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Agency OS — CEO Decision Sweeper Timer (KEI-79; hourly)
+
+[Timer]
+OnBootSec=15min
+OnUnitActiveSec=1h
+Unit=ceo-decision-sweeper.service
+
+[Install]
+WantedBy=default.target

--- a/migrations/20260516_kei79_ceo_decisions.sql
+++ b/migrations/20260516_kei79_ceo_decisions.sql
@@ -1,0 +1,73 @@
+-- KEI-79 — bd escalate state machine + ceo_decisions table + trigger.
+--
+-- Locked from 3-way deliberation 2026-05-16T~12:30Z:
+-- - Max state machine + Option D direct-post hybrid (chat_postMessage with
+--   completion_sync_queue fallback)
+-- - Aiden ceo_decisions table + 1-trigger cascade
+-- - Elliot bd escalate CLI + Block Kit format + rate-limit + bd ceo-queue
+--
+-- bd escalate is agent-code (2-write txn: INSERT ceo_decisions; UPDATE tasks
+-- SET status='escalated'). No trigger on tasks→ceo_decisions because the
+-- trigger can't see agent context (description, options, escalated_by).
+--
+-- This trigger fires only on ceo_decisions UPDATE — cascades resolved
+-- decisions back to tasks.status (active|cancelled).
+
+CREATE TABLE IF NOT EXISTS public.ceo_decisions (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id          TEXT NOT NULL REFERENCES public.tasks(id) ON DELETE CASCADE,
+    escalated_by     TEXT NOT NULL,
+    requested_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    description      TEXT NOT NULL,
+    options          TEXT[],
+    status           TEXT NOT NULL DEFAULT 'awaiting'
+                         CHECK (status IN ('awaiting','decided','rejected','timeout')),
+    slack_ts         TEXT,
+    slack_reply_ts   TEXT,
+    decision_outcome TEXT,
+    dave_choice      TEXT,
+    resolved_by      TEXT,
+    resolved_at      TIMESTAMPTZ,
+    rate_limit_flagged BOOLEAN NOT NULL DEFAULT FALSE,
+    tenant_id        TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ceo_decisions_one_awaiting_per_task
+    ON public.ceo_decisions (task_id) WHERE status = 'awaiting';
+
+CREATE INDEX IF NOT EXISTS idx_ceo_decisions_awaiting_age
+    ON public.ceo_decisions (requested_at) WHERE status = 'awaiting';
+
+CREATE OR REPLACE FUNCTION public.trg_ceo_decisions_to_tasks()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    IF NEW.status IS DISTINCT FROM OLD.status THEN
+        IF NEW.status = 'decided' THEN
+            UPDATE public.tasks SET status = 'active', updated_at = NOW()
+             WHERE id = NEW.task_id AND status = 'escalated';
+        ELSIF NEW.status IN ('rejected', 'timeout') THEN
+            UPDATE public.tasks SET status = 'cancelled', updated_at = NOW()
+             WHERE id = NEW.task_id AND status = 'escalated';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ceo_decisions_cascade ON public.ceo_decisions;
+CREATE TRIGGER trg_ceo_decisions_cascade
+    AFTER UPDATE OF status ON public.ceo_decisions
+    FOR EACH ROW EXECUTE FUNCTION public.trg_ceo_decisions_to_tasks();
+
+-- Extend KEI-74 completion_sync_queue target_sink to include 'ceo_post_retry'
+-- per Max Option D direct-post fallback path.
+ALTER TABLE public.completion_sync_queue
+    DROP CONSTRAINT IF EXISTS completion_sync_queue_target_sink_check;
+ALTER TABLE public.completion_sync_queue
+    ADD CONSTRAINT completion_sync_queue_target_sink_check
+    CHECK (target_sink IN ('linear', 'ceo_memory', 'drive_manual', 'ceo_post_retry'));
+
+COMMENT ON TABLE public.ceo_decisions IS
+    'KEI-79 — escalation ledger: bd escalate writes a row, central_listener parses Dave reply, trigger cascades status to tasks.';

--- a/scripts/bd
+++ b/scripts/bd
@@ -94,6 +94,26 @@ case "$subcmd" in
         fi
         exec "$BD_ORIGINAL" verify "$@"
         ;;
+    escalate)
+        # KEI-79 — `bd escalate <description> [--options A,B,C] [--task KEI-X]`
+        # Writes ceo_decisions row + flips task to status=escalated + posts to #ceo.
+        exec env PYTHONPATH="$AGENCY_OS_REPO${PYTHONPATH:+:$PYTHONPATH}" python3 "$AGENCY_OS_REPO/scripts/bd_escalate.py" "$@"
+        ;;
+    ceo-queue)
+        # KEI-79 — `bd ceo-queue` lists awaiting escalations. Orchestrator visibility.
+        exec env PYTHONPATH="$AGENCY_OS_REPO${PYTHONPATH:+:$PYTHONPATH}" python3 -c "
+import os, psycopg
+dsn = (os.environ.get('DATABASE_URL') or os.environ.get('SUPABASE_DB_URL')).replace('+asyncpg','')
+with psycopg.connect(dsn, prepare_threshold=None, autocommit=True) as conn:
+    with conn.cursor() as cur:
+        cur.execute(\"SELECT task_id, escalated_by, requested_at, description, rate_limit_flagged FROM public.ceo_decisions WHERE status='awaiting' ORDER BY requested_at\")
+        rows = cur.fetchall()
+        if not rows: print('no awaiting escalations'); exit(0)
+        for tid, by, ts, desc, flag in rows:
+            tag = ' [RATE-LIMIT]' if flag else ''
+            print(f'{tid:10s} {by:8s} {ts:%Y-%m-%dT%H:%MZ}  {desc[:80]}{tag}')
+"
+        ;;
     "")
         # No subcommand → bd-original handles help.
         exec "$BD_ORIGINAL"

--- a/scripts/bd_escalate.py
+++ b/scripts/bd_escalate.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""bd_escalate.py — KEI-79 CLI for escalating a task to Dave via #ceo.
+
+Two-write transaction: INSERT ceo_decisions row, UPDATE tasks SET status=
+'escalated'. Then call direct_post.post_to_ceo with the escalation body.
+On success, UPDATE ceo_decisions.slack_ts = response.ts. On Slack outage,
+the direct_post helper enqueues a retry row in completion_sync_queue.
+
+Rate limit: >=4 escalations from one callsign in 24h get
+rate_limit_flagged=TRUE and a [RATE-LIMIT-EXCEEDED] prefix on the post
+(soft cap per Max R1.1 — Dave sees the meta-signal).
+
+KEI-72 Step-0 gate exemption: posts an [ESCALATION-INITIATED:<callsign>
+:<task_id>] sentinel via slack_relay BEFORE the direct-post call so the
+gate's allowlist recognizes the escalation as a Step-0 surrogate.
+
+Usage:
+    bd escalate <description> [--options A,B,C] [--task KEI-X] [--force]
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import subprocess
+
+RATE_LIMIT_PER_24H = 3
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL or SUPABASE_DB_URL must be set")
+    return dsn.replace("+asyncpg", "")
+
+
+def _callsign() -> str:
+    return os.environ.get("CALLSIGN") or os.environ.get("TASKS_CALLSIGN") or "unknown"
+
+
+def _resolve_task(cur, explicit: str | None, callsign: str) -> str:
+    if explicit:
+        return explicit
+    cur.execute(
+        "SELECT id FROM public.tasks WHERE claimed_by=%s AND status='active'",
+        (callsign,),
+    )
+    rows = cur.fetchall()
+    if len(rows) != 1:
+        raise SystemExit(
+            f"ERROR: cannot infer task — {len(rows)} active claim(s) for {callsign}; "
+            "use --task KEI-X"
+        )
+    return rows[0][0]
+
+
+def _rate_limit_check(cur, callsign: str, force: bool) -> bool:
+    if force:
+        return False
+    cur.execute(
+        "SELECT COUNT(*) FROM public.ceo_decisions "
+        "WHERE escalated_by=%s AND requested_at > NOW() - INTERVAL '24 hours'",
+        (callsign,),
+    )
+    return cur.fetchone()[0] >= RATE_LIMIT_PER_24H
+
+
+def _emit_sentinel(callsign: str, task_id: str) -> None:
+    relay = os.path.join(
+        os.environ.get("AGENCY_OS_REPO", "/home/elliotbot/clawd/Agency_OS"),
+        "scripts",
+        "slack_relay.py",
+    )
+    if not os.path.isfile(relay):
+        return
+    text = f"[ESCALATION-INITIATED:{callsign}:{task_id}]"
+    with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+        subprocess.run(
+            ["python3", relay, "-g", text],
+            env={**os.environ, "CALLSIGN": callsign},
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+
+
+def _build_text(
+    callsign: str, task_id: str, description: str, options: list[str] | None, flagged: bool
+) -> str:
+    prefix = "[RATE-LIMIT-EXCEEDED] " if flagged else ""
+    head = f"{prefix}[ESCALATION:{callsign}] {task_id} — {description}"
+    if options:
+        opts = "\n".join(f"  {chr(65 + i)}) {o.strip()}" for i, o in enumerate(options))
+        return f"{head}\nOptions:\n{opts}\nReply with letter (A/B/C…) or free-form."
+    return f"{head}\nReply with decision text."
+
+
+def _format_options(raw: str | None) -> list[str] | None:
+    if not raw:
+        return None
+    return [o.strip() for o in raw.split(",") if o.strip()]
+
+
+def escalate(args: argparse.Namespace) -> int:
+    import psycopg
+
+    callsign = _callsign()
+    options = _format_options(args.options)
+    with psycopg.connect(_dsn(), prepare_threshold=None, autocommit=False) as conn:
+        with conn.cursor() as cur:
+            task_id = _resolve_task(cur, args.task, callsign)
+            flagged = _rate_limit_check(cur, callsign, args.force)
+            cur.execute(
+                "INSERT INTO public.ceo_decisions "
+                "(task_id, escalated_by, description, options, rate_limit_flagged) "
+                "VALUES (%s, %s, %s, %s, %s) RETURNING id",
+                (task_id, callsign, args.description, options, flagged),
+            )
+            decision_id = str(cur.fetchone()[0])
+            cur.execute(
+                "UPDATE public.tasks SET status='escalated', updated_at=NOW() WHERE id=%s",
+                (task_id,),
+            )
+        conn.commit()
+
+    _emit_sentinel(callsign, task_id)
+
+    from src.slack_bot.direct_post import post_to_ceo
+
+    text = _build_text(callsign, task_id, args.description, options, flagged)
+    result = post_to_ceo(text, ceo_decision_id=decision_id)
+
+    if result["ok"] and result.get("ts"):
+        with (
+            psycopg.connect(_dsn(), prepare_threshold=None, autocommit=True) as conn,
+            conn.cursor() as cur,
+        ):
+            cur.execute(
+                "UPDATE public.ceo_decisions SET slack_ts=%s, updated_at=NOW() WHERE id=%s",
+                (result["ts"], decision_id),
+            )
+
+    print(
+        json.dumps(
+            {
+                "decision_id": decision_id,
+                "task_id": task_id,
+                "post_status": result["status"],
+                "rate_limit_flagged": flagged,
+            }
+        )
+    )
+    return 0 if result["ok"] or result["status"] == "queued_retry" else 1
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(prog="bd escalate")
+    p.add_argument("description", help="one-line escalation context (<=200 chars)")
+    p.add_argument("--options", help="comma-separated options (A,B,C)")
+    p.add_argument("--task", help="explicit task id; defaults to active claim")
+    p.add_argument("--force", action="store_true", help="bypass rate limit")
+    args = p.parse_args()
+    return escalate(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestrator/ceo_decision_sweeper.py
+++ b/scripts/orchestrator/ceo_decision_sweeper.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""ceo_decision_sweeper.py — KEI-79 timeout sweeper for awaiting escalations.
+
+Postgres lacks time-based triggers, so a separate hourly cron sweeps
+ceo_decisions rows older than 7 days WHERE status='awaiting' and flips
+them to status='timeout', resolved_by='system_timeout'. The trg_ceo_
+decisions_cascade trigger then bumps the originating tasks row to
+status='cancelled'.
+
+Idempotent: re-running re-evaluates the age-window predicate; rows
+already past 'awaiting' are no-op'd by the WHERE clause.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+
+import psycopg
+
+logger = logging.getLogger("ceo_decision_sweeper")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+TIMEOUT_DAYS = 7
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL or SUPABASE_DB_URL must be set")
+    return dsn.replace("+asyncpg", "")
+
+
+def sweep(dry_run: bool = False) -> dict:
+    stats = {"awaiting": 0, "timed_out": 0}
+    with psycopg.connect(_dsn(), prepare_threshold=None, autocommit=False) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, task_id FROM public.ceo_decisions "
+                "WHERE status='awaiting' AND requested_at < NOW() - INTERVAL %s",
+                (f"{TIMEOUT_DAYS} days",),
+            )
+            overdue = cur.fetchall()
+            stats["awaiting"] = len(overdue)
+            if dry_run or not overdue:
+                logger.info(
+                    "[%s] %d overdue awaiting rows%s",
+                    "dry-run" if dry_run else "sweep",
+                    len(overdue),
+                    "" if not overdue else f" (oldest task_id={overdue[0][1]})",
+                )
+                return stats
+            cur.execute(
+                "UPDATE public.ceo_decisions SET status='timeout', "
+                "resolved_by='system_timeout', resolved_at=NOW(), updated_at=NOW() "
+                "WHERE status='awaiting' AND requested_at < NOW() - INTERVAL %s "
+                "RETURNING id",
+                (f"{TIMEOUT_DAYS} days",),
+            )
+            stats["timed_out"] = len(cur.fetchall())
+        conn.commit()
+    logger.info("sweep complete: %s", stats)
+    return stats
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(prog="ceo_decision_sweeper")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+    sweep(dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bot_common/concur_gate.py
+++ b/src/bot_common/concur_gate.py
@@ -55,8 +55,22 @@ def _topic_sha(text: str) -> str:
     return hashlib.sha1(text.encode("utf-8")).hexdigest()[:12]
 
 
+# KEI-79 escalation sentinel — bd escalate emits this BEFORE the direct-post call so
+# downstream gates recognise the escalation as a Step-0 surrogate (Dave authorisation
+# IS the gate event for an escalation path). Exempt from CONCUR matching.
+_ESCALATION_SENTINEL = re.compile(
+    r"\[ESCALATION-INITIATED:[a-z][a-z0-9_-]*:[A-Z]+-\d+\]", re.IGNORECASE
+)
+
+
 def should_gate(text: str) -> bool:
-    """True if the text contains a literal [CONCUR:<callsign>] or [BLOCK:<callsign>] token."""
+    """True if the text contains a literal [CONCUR:<callsign>] or [BLOCK:<callsign>] token.
+
+    KEI-79 carve-out: [ESCALATION-INITIATED:<callsign>:<task-id>] sentinels are NOT gated
+    even if they incidentally contain a concur-shaped substring downstream.
+    """
+    if _ESCALATION_SENTINEL.search(text):
+        return False
     return bool(_GATE_TRIGGER.search(text))
 
 

--- a/src/slack_bot/direct_post.py
+++ b/src/slack_bot/direct_post.py
@@ -1,0 +1,82 @@
+"""src/slack_bot/direct_post.py — KEI-79 Option D hybrid #ceo post.
+
+bd escalate calls post_to_ceo() synchronously. On Slack API failure
+(network/429/5xx) it falls back to enqueueing a completion_sync_queue
+row with target_sink='ceo_post_retry'; the existing KEI-74 worker
+drains it on the regular cadence. ceo_decision_id is the idempotency
+key — worker checks ceo_decisions.slack_ts IS NULL before re-posting.
+
+Returns dict {status: 'posted'|'queued_retry', ok: bool, ts: str|None}.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from typing import Any
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+CEO_CHANNEL = "C0B2PM3TV0B"
+SLACK_API = "https://slack.com/api/chat.postMessage"
+
+
+def _post_via_urllib(text: str, blocks: list[dict] | None) -> dict[str, Any]:
+    token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if not token:
+        raise RuntimeError("SLACK_BOT_TOKEN missing")
+    payload: dict[str, Any] = {"channel": CEO_CHANNEL, "text": text}
+    if blocks:
+        payload["blocks"] = blocks
+    req = urlrequest.Request(
+        SLACK_API,
+        data=json.dumps(payload).encode(),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+    with urlrequest.urlopen(req, timeout=10) as resp:
+        body = json.loads(resp.read())
+    if not body.get("ok"):
+        raise RuntimeError(f"slack rejected: {body.get('error') or body}")
+    return body
+
+
+def _enqueue_retry(ceo_decision_id: str, error: str) -> None:
+    import psycopg
+
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+    if not dsn:
+        return
+    dsn = dsn.replace("+asyncpg", "")
+    with (
+        psycopg.connect(dsn, prepare_threshold=None, autocommit=True) as conn,
+        conn.cursor() as cur,
+    ):
+        cur.execute(
+            "INSERT INTO public.completion_sync_queue "
+            "(task_id, target_sink, target_status, error_message) "
+            "VALUES (%s, 'ceo_post_retry', 'pending', %s) "
+            "ON CONFLICT (task_id, target_sink) WHERE processed = FALSE DO UPDATE "
+            "SET error_message = EXCLUDED.error_message, updated_at = NOW()",
+            (ceo_decision_id, error[:500]),
+        )
+
+
+def post_to_ceo(
+    text: str,
+    blocks: list[dict] | None = None,
+    ceo_decision_id: str | None = None,
+) -> dict[str, Any]:
+    """Post to #ceo via Slack API; fall back to completion_sync_queue on failure."""
+    try:
+        body = _post_via_urllib(text, blocks)
+        return {"status": "posted", "ok": True, "ts": body.get("ts")}
+    except (urlerror.URLError, OSError, RuntimeError) as exc:
+        if ceo_decision_id:
+            with contextlib.suppress(Exception):
+                _enqueue_retry(ceo_decision_id, str(exc))
+        return {"status": "queued_retry", "ok": False, "ts": None, "error": str(exc)}

--- a/tests/scripts/test_bd_escalate.py
+++ b/tests/scripts/test_bd_escalate.py
@@ -1,0 +1,143 @@
+"""KEI-79 — behavioural tests for bd escalate + direct_post + concur_gate carve-out."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import bd_escalate  # noqa: E402
+from src.bot_common import concur_gate  # noqa: E402
+from src.slack_bot import direct_post  # noqa: E402
+
+
+def test_format_options_csv_strips():
+    assert bd_escalate._format_options(" A, B ,C") == ["A", "B", "C"]
+    assert bd_escalate._format_options(None) is None
+    assert bd_escalate._format_options("") is None
+
+
+def test_build_text_no_options_free_form():
+    out = bd_escalate._build_text("aiden", "KEI-58", "kuzu cap stuck", None, False)
+    assert "[ESCALATION:aiden] KEI-58" in out
+    assert "kuzu cap stuck" in out
+    assert "Reply with decision text" in out
+
+
+def test_build_text_with_options_labels_letters():
+    out = bd_escalate._build_text("aiden", "KEI-58", "pick path", ["foo", "bar", "baz"], False)
+    assert "A) foo" in out and "B) bar" in out and "C) baz" in out
+
+
+def test_build_text_rate_limit_prefix():
+    out = bd_escalate._build_text("max", "KEI-9", "x", None, True)
+    assert out.startswith("[RATE-LIMIT-EXCEEDED] [ESCALATION:max]")
+
+
+def test_concur_gate_carve_out_for_escalation_sentinel():
+    sentinel = "[ESCALATION-INITIATED:aiden:KEI-58]"
+    assert concur_gate.should_gate(sentinel) is False
+    plain_concur = "[CONCUR:aiden] looks good"
+    assert concur_gate.should_gate(plain_concur) is True
+
+
+def test_concur_gate_still_blocks_plain_concur_without_sentinel():
+    body = "Posting [CONCUR:elliot] on the schema slice"
+    assert concur_gate.should_gate(body) is True
+
+
+def test_direct_post_returns_queued_retry_on_slack_failure(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("slack 503")
+
+    monkeypatch.setattr(direct_post, "_post_via_urllib", boom)
+    monkeypatch.setattr(direct_post, "_enqueue_retry", lambda *a, **k: None)
+    out = direct_post.post_to_ceo("hi", ceo_decision_id="abc")
+    assert out["ok"] is False
+    assert out["status"] == "queued_retry"
+
+
+def test_direct_post_returns_posted_on_success(monkeypatch):
+    monkeypatch.setattr(
+        direct_post, "_post_via_urllib", lambda *a, **k: {"ok": True, "ts": "1.000"}
+    )
+    out = direct_post.post_to_ceo("hi", ceo_decision_id="abc")
+    assert out["ok"] is True
+    assert out["status"] == "posted"
+    assert out["ts"] == "1.000"
+
+
+def test_post_via_urllib_missing_token_raises(monkeypatch):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    with pytest.raises(RuntimeError):
+        direct_post._post_via_urllib("hi", None)
+
+
+def test_callsign_falls_through_env_chain(monkeypatch):
+    monkeypatch.delenv("CALLSIGN", raising=False)
+    monkeypatch.delenv("TASKS_CALLSIGN", raising=False)
+    assert bd_escalate._callsign() == "unknown"
+    monkeypatch.setenv("TASKS_CALLSIGN", "scout")
+    assert bd_escalate._callsign() == "scout"
+    monkeypatch.setenv("CALLSIGN", "aiden")
+    assert bd_escalate._callsign() == "aiden"
+
+
+def test_rate_limit_check_force_skips(monkeypatch):
+    cur = types.SimpleNamespace(execute=lambda *a, **k: None, fetchone=lambda: (99,))
+    assert bd_escalate._rate_limit_check(cur, "aiden", force=True) is False
+
+
+def test_rate_limit_check_triggers_at_threshold(monkeypatch):
+    class FakeCur:
+        def execute(self, *a, **k):
+            self._called = True
+
+        def fetchone(self):
+            return (bd_escalate.RATE_LIMIT_PER_24H,)
+
+    assert bd_escalate._rate_limit_check(FakeCur(), "aiden", force=False) is True
+
+
+def test_rate_limit_check_under_threshold_passes():
+    class FakeCur:
+        def execute(self, *a, **k):
+            pass
+
+        def fetchone(self):
+            return (bd_escalate.RATE_LIMIT_PER_24H - 1,)
+
+    assert bd_escalate._rate_limit_check(FakeCur(), "aiden", force=False) is False
+
+
+def test_resolve_task_returns_explicit_when_set():
+    cur = types.SimpleNamespace(execute=lambda *a, **k: None, fetchall=lambda: [])
+    assert bd_escalate._resolve_task(cur, "KEI-58", "aiden") == "KEI-58"
+
+
+def test_resolve_task_errors_on_zero_active_claims():
+    class FakeCur:
+        def execute(self, *a, **k):
+            pass
+
+        def fetchall(self):
+            return []
+
+    with pytest.raises(SystemExit):
+        bd_escalate._resolve_task(FakeCur(), None, "aiden")
+
+
+def test_resolve_task_returns_id_on_single_active_claim():
+    class FakeCur:
+        def execute(self, *a, **k):
+            pass
+
+        def fetchall(self):
+            return [("KEI-79",)]
+
+    assert bd_escalate._resolve_task(FakeCur(), None, "aiden") == "KEI-79"


### PR DESCRIPTION
## Summary
Ratified 3-way deliberation from KEI-70 / KEI-79 Round 1 (Max state machine + direct-post Option D; Aiden ceo_decisions schema; Elliot bd escalate CLI + UX) shipped as single PR per Dave-overnight directive.

**What it does:**
- `bd escalate <description> [--options A,B,C] [--task KEI-X] [--force]` posts an escalation to #ceo + writes a durable ceo_decisions row + flips the task to status='escalated'
- Dave's #ceo reply (parsed via central_listener thread-parent match — handler in follow-up PR) flips ceo_decisions.status='decided'/'rejected'
- Trigger cascades the resolved state back to tasks (decided→active resume; rejected/timeout→cancelled)
- 7-day timeout sweeper (hourly cron) catches stale awaiting rows

**Solves:** the Scout-coordination + Dave-decision-bottleneck gap. Same `completion_sync_queue` worker (KEI-74) handles Slack outage fallback via `ceo_post_retry` sink extension.

## Step 0 trace
[STEP-0-RESTATE:aiden] cleared by Dave-overnight ratify ts ~13:00Z. 3-way CONCUR locked from 2026-05-16T~12:30Z (Aiden + Max + Elliot all signed off on the joint architecture).

## Verbatim probes
```
$ apply_migration kei79_ceo_decisions
{"success":true}

$ PYTHONPATH=. pytest tests/scripts/test_bd_escalate.py tests/bot_common/test_concur_gate.py
============================== 44 passed in 0.25s ==============================

$ ruff check + ruff format --check
All checks passed!
5 files already formatted
```

## Scope (9 files, 601 LOC)
- migrations/20260516_kei79_ceo_decisions.sql — table + 2 indexes + trigger + KEI-74 sink-enum extension
- scripts/bd_escalate.py — CLI: 2-write txn + rate-limit + sentinel + direct-post + slack_ts persist
- src/slack_bot/direct_post.py — chat_postMessage + completion_sync_queue fallback
- src/bot_common/concur_gate.py — sentinel carve-out (28/28 regression-clean)
- scripts/orchestrator/ceo_decision_sweeper.py — hourly timeout sweep
- infra/systemd/ceo-decision-sweeper.{service,timer} — unit files
- scripts/bd — added `escalate` + `ceo-queue` verbs
- tests/scripts/test_bd_escalate.py — 16 behavioural tests

## Test plan
- [x] Migration applied (live Supabase)
- [x] 16/16 KEI-79 tests + 28/28 concur_gate regression tests pass
- [x] Ruff check + format clean
- [ ] CI green
- [ ] Triple-FINAL: [FINAL:elliot] + [FINAL:max] (dual-CTO merge authority overnight per Dave)
- [ ] Trigger-compliant close — KEI-79 close fires KEI-74 fan-out + KEI-78 dep unblock (triple-meta-validation)
- [ ] Ops handoff: cp ceo-decision-sweeper.{service,timer} → ~/.config/systemd/user/ + systemctl --user enable

## Scope OUT (deferred follow-ups)
- Block Kit structured-blocks v2 (single message body in v1)
- Dave-reply reaction-emoji parsing (Max R1 v2)
- central_listener thread-parent intercept handler (separate small PR; doesn't block table+CLI shipping)
- Multi-tenant RLS policies (column present, policy in P8 dispatcher KEI)
- decision_type ENUM v2 (free-text outcome v1)

Linear: KEI-79
Closes KEI-79

🤖 Generated with [Claude Code](https://claude.com/claude-code)