### PR TITLE
[AIDEN] fix(kei99): relay watcher session name resilience — priority list + fallback alert

### DIFF
--- a/scripts/orchestrator/relay_watcher.sh
+++ b/scripts/orchestrator/relay_watcher.sh
@@ -9,20 +9,56 @@ INBOX="${RELAY_DIR}/inbox"
 PROCESSED="${RELAY_DIR}/processed"
 STATE_FILE="${RELAY_DIR}/last_chat_id"
 
-# Map callsign to tmux session name
-if [ "$CALLSIGN" = "elliot" ]; then
-    TMUX_TARGET="elliottbot:0.0"
-elif [ "$CALLSIGN" = "aiden" ]; then
-    TMUX_TARGET="aiden:0.0"
-elif [ "$CALLSIGN" = "scout" ]; then
-    TMUX_TARGET="scout:0.0"
-else
-    TMUX_TARGET="${CALLSIGN}bot:0.0"
-fi
+# KEI-99 / Linear KEI-83 — Priority list per callsign. Tried in order; first
+# session that `tmux has-session` answers gets the message. If Dave manually
+# starts a session with a non-default name (e.g. `elliot` instead of
+# `elliottbot`), delivery still works.
+case "$CALLSIGN" in
+    elliot)  TMUX_CANDIDATES=("elliottbot:0.0" "elliot:0.0" "elliot-agent:0.0") ;;
+    aiden)   TMUX_CANDIDATES=("aiden:0.0" "aidenbot:0.0" "aiden-agent:0.0") ;;
+    scout)   TMUX_CANDIDATES=("scout:0.0" "scoutbot:0.0" "scout-agent:0.0") ;;
+    max)     TMUX_CANDIDATES=("maxbot:0.0" "max:0.0" "max-agent:0.0") ;;
+    *)       TMUX_CANDIDATES=("${CALLSIGN}bot:0.0" "${CALLSIGN}:0.0" "${CALLSIGN}-agent:0.0") ;;
+esac
+TMUX_TARGET="${TMUX_CANDIDATES[0]}"
+
+# Resolve a live tmux target. Sets TMUX_TARGET on success; returns 1 if all
+# candidates miss. Logs a promotion when we settle on a non-primary name.
+resolve_tmux_target() {
+    local candidate session previous="$TMUX_TARGET"
+    for candidate in "${TMUX_CANDIDATES[@]}"; do
+        session="${candidate%%:*}"
+        if tmux has-session -t "$session" 2>/dev/null; then
+            if [ "$candidate" != "$previous" ]; then
+                echo "[relay-watcher-${CALLSIGN}] PROMOTED session: $previous → $candidate"
+            fi
+            TMUX_TARGET="$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Alert on delivery failure. Elliot is the only callsign with #ceo access
+# (per acceptance criteria); every other callsign falls back to #execution
+# where peers can pick up the alert. Failures here are swallowed so the
+# watcher never crashes on a notification path.
+alert_delivery_failure() {
+    local tg_bin alert_channel msg
+    tg_bin="$(command -v tg 2>/dev/null)"
+    [ -x "$tg_bin" ] || return 0
+    if [ "$CALLSIGN" = "elliot" ]; then
+        alert_channel="ceo"
+    else
+        alert_channel="execution"
+    fi
+    msg="[SYSTEM] [${CALLSIGN^^}] relay delivery failed — no live tmux session under known names: ${TMUX_CANDIDATES[*]}. Manual intervention required."
+    CALLSIGN="$CALLSIGN" "$tg_bin" -c "$alert_channel" "$msg" >/dev/null 2>&1 || true
+}
 
 mkdir -p "$INBOX" "$PROCESSED"
 
-echo "[relay-watcher-${CALLSIGN}] Started. Watching $INBOX → tmux $TMUX_TARGET"
+echo "[relay-watcher-${CALLSIGN}] Started. Watching $INBOX → tmux candidates: ${TMUX_CANDIDATES[*]}"
 
 # H10 — also watch -e moved_to so we don't drop dispatches the Write tool
 # delivers via atomic rename (which fires moved_to, not create).
@@ -35,6 +71,16 @@ inotifywait -m -q -e create -e moved_to "$INBOX" --format '%f' 2>/dev/null | whi
 
     # Small delay to let file finish writing
     sleep 0.2
+
+    # KEI-99: Resolve a live tmux session BEFORE attempting delivery. If no
+    # candidate is live, alert #ceo and quarantine the message (move to
+    # processed so we don't busy-loop on the same file).
+    if ! resolve_tmux_target; then
+        echo "[relay-watcher-${CALLSIGN}] DELIVERY FAILED — no live tmux session in: ${TMUX_CANDIDATES[*]}"
+        alert_delivery_failure
+        mv "$fpath" "$PROCESSED/" 2>/dev/null
+        continue
+    fi
 
     # Parse the message
     msg_type=$(python3 -c "import json; print(json.load(open('$fpath')).get('type',''))" 2>/dev/null)


### PR DESCRIPTION
## Summary
- Fixes KEI-99 / Linear KEI-83. Production bug 2026-05-17: hardcoded `TMUX_TARGET=elliottbot:0.0` silently dropped four #ceo messages when Dave started the session as `elliot`.
- Replaces single hardcoded target with per-callsign priority candidate list, `tmux has-session` liveness check, promotion-on-fallback, and `#ceo`/`#execution` alert on full-fail.

## Files
- `scripts/orchestrator/relay_watcher.sh` (+57 / −11)

## Acceptance criteria (bd Agency_OS-p96e96)
- [x] Priority list config per agent
- [x] Delivery loop tries all known names before failing
- [x] Failed delivery fires alert (#ceo for elliot, #execution for peer callsigns)
- [x] Successful non-primary delivery logs PROMOTED and pins target for the loop
- [x] Smoke test against actual tmux: priority fallthrough + promotion logged + negative path returns 1

## Empirical smoke (verbatim)
```
Initial TMUX_TARGET=nonexistent-primary:0.0
PROMOTED: nonexistent-primary:0.0 → aiden-agent-smoke99:0.0
RESOLVED: aiden-agent-smoke99:0.0
---
Initial TMUX_TARGET=nonexistent-primary:0.0
RESOLVE_FAILED
Negative test exit code: 1 (expect 1)
```

## Step 0 concur trail
- [CONCUR:elliot] — token 8987e6498e23 released (ts 1778985212.866189)
- [CONCUR:max] — token f579a57c61fa released (ts 1778985240.443419). Max recommended `tmux has-session` over send-keys exit code — adopted.

## Out of scope (follow-up)
- `src/relay/relay_consumer.py` has the same `QUEUE_MAP` hardcoding pattern but is the Phase 2 Redis consumer (not currently running). Logged for separate KEI once Phase 2 cutover lands.

## Test plan
- [x] `bash -n` syntax check
- [x] Sandbox smoke: stand up tmux session under non-primary candidate, confirm resolve + PROMOTED log
- [x] Negative smoke: all candidates dead, confirm return 1 → alert path
- [ ] Post-merge: restart `relay-watcher.service` and confirm Dave's `elliot`-named session reproduction is fixed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)