### PR TITLE
[ATLAS] feat(kei107): 3-layer memory bring-up — weaviate cgroup + indexers

### DIFF
--- a/infra/systemd/agents/weaviate.service
+++ b/infra/systemd/agents/weaviate.service
@@ -10,6 +10,13 @@ StartLimitIntervalSec=300
 Type=simple
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS
 EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+# Cgroup memory cap (KEI-107, Dave directive 2026-05-17) — explicit at unit
+# level so the cap is visible to operators reading the unit file, not buried
+# in the launcher script default. The launcher passes this via
+# `systemd-run --user --scope -p MemoryMax=$AGENCY_OS_WEAVIATE_MAX_MEM`.
+# Per KEI-44 discovery: cgroup MemoryMax caps RSS only (not virtual), which
+# is the correct mechanism for Python+numpy+Go services on Vultr Sydney.
+Environment=AGENCY_OS_WEAVIATE_MAX_MEM=3G
 ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/orchestrator/weaviate_capped.sh
 Restart=on-failure
 RestartSec=15

--- a/scripts/orchestrator/weaviate_capped.sh
+++ b/scripts/orchestrator/weaviate_capped.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# weaviate_capped.sh — launch Weaviate under a 2.5 GB systemd memory cap.
+# weaviate_capped.sh — launch Weaviate under a 3 GB systemd memory cap.
+#
+# Default cap raised from 2.5G → 3G on 2026-05-17 (KEI-107, Dave directive)
+# to align with KEI-44 discovery + Max's verified cgroup pattern for
+# Python+numpy+Go services on Vultr Sydney.
 #
 # Closes Beads Agency_OS-... / Linear KEI-48 (Install Weaviate on Vultr Sydney).
 # Same pattern as scripts/orchestrator/cognee_capped.sh (KEI-44 sha 3b133132).
@@ -26,7 +30,7 @@
 #   WEAVIATE_HOST             default 127.0.0.1 (loopback-only; reverse-proxy if exposing)
 #   WEAVIATE_PORT             default 8090 (crowdsec holds 8080)
 #   WEAVIATE_DATA_DIR         default /home/elliotbot/clawd/weaviate-data
-#   AGENCY_OS_WEAVIATE_MAX_MEM    default 2.5G (passed to -p MemoryMax=)
+#   AGENCY_OS_WEAVIATE_MAX_MEM    default 3G (passed to -p MemoryMax=, KEI-107)
 #   AGENCY_OS_SYSTEMD_RUN     path to systemd-run binary (default 'systemd-run')
 #   AGENCY_OS_SYSTEMD_RUN_SKIP    if set, print resolved command + exit 0 (tests)
 #
@@ -35,7 +39,7 @@
 
 set -euo pipefail
 
-MAX_MEM="${AGENCY_OS_WEAVIATE_MAX_MEM:-2.5G}"
+MAX_MEM="${AGENCY_OS_WEAVIATE_MAX_MEM:-3G}"
 SYSTEMD_RUN="${AGENCY_OS_SYSTEMD_RUN:-systemd-run}"
 WEAVIATE_BIN="${WEAVIATE_BIN:-/home/elliotbot/clawd/weaviate-bin/weaviate}"
 WEAVIATE_HOST="${WEAVIATE_HOST:-127.0.0.1}"


### PR DESCRIPTION
## Summary

Restores Weaviate (with 3G cgroup MemoryMax — KEI-44 pattern) and restarts the auto-indexing pipelines. Meets Dave's proof gate end-to-end with verbatim evidence.

**Linear:** KEI-107 / KEI-71 driver
**Branch:** `atlas/kei107-weaviate-cgroup-indexers`
**Scope (per dispatch):** strict — `infra/systemd/`, `scripts/orchestrator/weaviate*`. Report-don't-fix everything else.

## Root cause

`/home/elliotbot/clawd/weaviate-bin/` had `LICENSE` + `README.md` only — **the actual `weaviate` binary was missing**. Data directory was intact (`schema.db`, per-collection dirs preserved). Binary likely cleaned up at some point without re-installing.

## Code changes (2 files, +14/-3)

### `infra/systemd/agents/weaviate.service`
Explicit `Environment=AGENCY_OS_WEAVIATE_MAX_MEM=3G` at unit level. Operators reading the unit see the cap directly. The launcher still applies it via `systemd-run --user --scope -p MemoryMax=$VAR` — actual cgroup mechanism unchanged.

### `scripts/orchestrator/weaviate_capped.sh`
Default `MAX_MEM=2.5G` → `3G`. Header doc cites KEI-44 + KEI-107.

## Operational bring-up (NOT in git; verbatim evidence below)

Downloaded `weaviate v1.37.3` linux-amd64 (sha `cbdefcd2…`); installed; `install -D` + `systemctl --user daemon-reload` + `enable --now` for:
- `weaviate.service`
- `tool-call-log-indexer.service`
- `completion-sync-worker.service`
- `indexing-queue-worker.service`

## Proof gate — VERBATIM

### Gate 1: Weaviate responding + data in ≥2 collections

```
$ curl -s -o /dev/null -w "HTTP=%{http_code}\n" http://127.0.0.1:8090/v1/.well-known/ready
HTTP=200

$ curl -s http://127.0.0.1:8090/v1/meta | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])"
1.37.3

$ systemctl --user show weaviate-335637.scope --property=MemoryMax
MemoryMax=3221225472                # exactly 3 GiB (3 × 2^30)

$ for class in Keis ToolCalls Sessions Decisions Staging_discoveries Discoveries Codebase; do …Aggregate.meta.count… done
Keis: 0
ToolCalls: 1            # post smoke-insert (was 0 pre-insert)
Sessions: 48666
Decisions: 0
Staging_discoveries: 0
Discoveries: 14202
Codebase: 0
```

3 collections with data (Sessions, Discoveries, ToolCalls). Gate 1 ✓.

### Gate 2: ≥1 auto-indexing pipeline indexed >0 in last hour

End-to-end smoke through the only Weaviate-bound indexer that exists in this repo (`tool_call_log_indexer.py`):

```
# Insert synthetic row in Postgres tool_call_log (03:49:29Z)
INSERT INTO public.tool_call_log (callsign, tool_name, tool_input, started_at, completed_at, exit_code)
VALUES ('atlas','kei107_proof_gate', '{"smoke":true,"kei":"KEI-107",…}'::jsonb, NOW(), NOW(), 0)
RETURNING id;
→ id=2246f831-1233-4bca-a20b-6f0a91127180, indexed=false, created_at=2026-05-17 03:49:29.657867+00

# tool-call-log-indexer log (03:49:54Z, 25s later)
2026-05-17 03:49:54,204 INFO batch: {'claimed': 1, 'done': 1, 'failed': 0}

# Postgres row marked indexed
SELECT id, indexed, indexed_at FROM tool_call_log WHERE id='2246f831…';
→ id=2246f831…, indexed=true, indexed_at=2026-05-17 03:49:53.856023+00

# Weaviate ToolCalls now contains the row (same UUID)
GraphQL Get{ToolCalls(limit:1){…_additional{id creationTimeUnix}}}
→ {"id":"2246f831-1233-4bca-a20b-6f0a91127180","creationTimeUnix":"1778989794014",
   "callsign":"atlas","tool_name":"kei107_proof_gate","started_at":"2026-05-17T03:49:29Z"}
```

Gate 2 ✓ — same UUID round-trips through the indexer pipeline within ~25 seconds.

### All 3 indexers active (verbatim systemctl status)

```
weaviate.service                Active: active (running) since 03:44:48Z; Memory: 80K (peak 1.1M)
  └─ weaviate-335637.scope      MemoryMax=3221225472 (3 GiB)
tool-call-log-indexer.service   Active: active (running) since 03:46:16Z; Memory: 34.4M (cap 512M)
completion-sync-worker.service  Active: active (running) since 03:46:56Z; Memory: 21.9M (cap 256M)
indexing-queue-worker.service   Active: active (running) since 03:46:56Z; Memory: 21.3M (cap 512M)
```

## Out-of-scope (reported, not fixed per dispatch)

1. **Multi-source indexers don't exist as code**: Dave's directive referenced "git/Slack/Linear/ceo_memory → Weaviate" pipelines. Repo search returns ONLY `tool_call_log_indexer.py`. `completion_sync_worker.py` is for **outbound** Linear+ceo_memory+drive_manual sync (not Weaviate inbound). `indexing_queue_worker.py` is a stub until KEI-46+KEI-49 ship (its own docstring says so). Suggest a follow-up KEI to build the Slack/Linear/git auto-indexers.

2. **Install runbook should be automated**: the unit symlink for `weaviate.service` was missing entirely from user systemd this session. Manual `install -D` + `systemctl --user enable --now` was required. Suggest `scripts/orchestrator/weaviate_install.sh` so the bring-up is one command and reproducible.

3. **Port mismatch in Dave's directive**: directive says verify on 8080; launcher uses 8090 (crowdsec holds 8080). Verified on 8090. Confirm 8090 is the canonical Weaviate port OR move crowdsec.

4. **completion-sync-worker has stale arg contract** (visible in worker log): `write_manual_mirror.py: error: unrecognized arguments: --task-id KEI-36`. The completion-sync-worker is calling write_manual_mirror.py with a `--task-id` flag that script doesn't accept. Several tasks failing on drive_manual sink. Out-of-scope to fix; flagging.

## Dual approval

Per session rules: **[ELLIOT] + [AIDEN]** must both CONCUR. Dave merges.

## Test plan

- [ ] Manual review of `weaviate.service` Environment= line
- [ ] Manual review of `weaviate_capped.sh` default change
- [ ] Verbatim evidence above sanity-checks against current host state (CI does not have systemd-user / weaviate binary; verification is host-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)