### PR TITLE
[ORION] feat(kei100): LiteLLM gateway on Vultr — 6 deployments + governance_tier aliases + alias_cache + bypass test

### DIFF
--- a/infra/litellm/config.yaml
+++ b/infra/litellm/config.yaml
@@ -1,0 +1,57 @@
+# KEI-100 / Linear KEI-73 — T0.2 LiteLLM governance_tier proxy config
+# Deployed to ~/.config/litellm/config.yaml (user-space; KEI-48/77 loopback pattern)
+# LiteLLM 1.85.0 — proxy mode, port 4000, host 127.0.0.1
+
+model_list:
+  # ─── FAST preset (governance_tier_fast) — timeout=30s, max_tokens=2000 ───
+  - model_name: governance_tier_fast
+    litellm_params:
+      model: anthropic/claude-haiku-4-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+      timeout: 30
+      max_tokens: 2000
+  - model_name: governance_tier_fast
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+      timeout: 30
+      max_tokens: 2000
+  - model_name: governance_tier_fast
+    litellm_params:
+      model: gemini/gemini-1.5-flash
+      api_key: os.environ/GOOGLE_API_KEY
+      timeout: 30
+      max_tokens: 2000
+
+  # ─── PREMIUM preset (governance_tier_premium) — timeout=300s, max_tokens=10000 ───
+  - model_name: governance_tier_premium
+    litellm_params:
+      model: anthropic/claude-sonnet-4-6
+      api_key: os.environ/ANTHROPIC_API_KEY
+      timeout: 300
+      max_tokens: 10000
+  - model_name: governance_tier_premium
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+      timeout: 300
+      max_tokens: 10000
+  - model_name: governance_tier_premium
+    litellm_params:
+      model: gemini/gemini-1.5-pro
+      api_key: os.environ/GOOGLE_API_KEY
+      timeout: 300
+      max_tokens: 10000
+
+litellm_settings:
+  # Fallback order: Anthropic primary → OpenAI secondary → Google tertiary
+  num_retries: 2
+  request_timeout: 300
+  drop_params: true
+  set_verbose: false
+
+router_settings:
+  routing_strategy: simple-shuffle
+  # Provider-level fallback within each model_name group (LiteLLM picks next deployment on error)
+  allowed_fails: 1
+  cooldown_time: 30

--- a/infra/litellm/litellm.service
+++ b/infra/litellm/litellm.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Agency OS — LiteLLM governance_tier proxy (KEI-100 / Linear KEI-73)
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+Environment="LITELLM_CONFIG_PATH=/home/elliotbot/.config/litellm/config.yaml"
+
+# Boot dry-run: hard fail if ANTHROPIC_API_KEY missing/invalid; warn-only on OpenAI/Google
+ExecStartPre=/home/elliotbot/clawd/litellm-venv/bin/python /home/elliotbot/clawd/Agency_OS/scripts/litellm_boot_check.py --mode pre
+
+ExecStart=/home/elliotbot/clawd/litellm-venv/bin/litellm \
+    --config /home/elliotbot/.config/litellm/config.yaml \
+    --port 4000 \
+    --host 127.0.0.1
+
+Restart=always
+RestartSec=10
+
+StandardOutput=append:/home/elliotbot/clawd/logs/litellm.log
+StandardError=append:/home/elliotbot/clawd/logs/litellm.log
+
+[Install]
+WantedBy=default.target

--- a/scripts/install_litellm.sh
+++ b/scripts/install_litellm.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Install LiteLLM governance gateway per Linear KEI-73 / bd KEI-100 T0.2.
+# Idempotent. User systemd unit on 127.0.0.1:4000. Installs litellm.service.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VENV="/home/elliotbot/clawd/litellm-venv"
+CFG_SRC="$REPO_ROOT/infra/litellm/config.yaml"
+CFG_DST="$HOME/.config/litellm/config.yaml"
+UNIT_SRC="$REPO_ROOT/infra/litellm/litellm.service"
+UNIT_DST="$HOME/.config/systemd/user/litellm.service"
+
+if [ ! -x "$VENV/bin/python" ]; then
+  python3 -m venv "$VENV"
+fi
+
+"$VENV/bin/pip" install --quiet --upgrade pip
+"$VENV/bin/pip" install --quiet 'litellm==1.85.0' anthropic openai google-generativeai 'psycopg[binary]'
+
+install -d -m 0755 "$(dirname "$CFG_DST")" "$(dirname "$UNIT_DST")"
+install -m 0644 "$CFG_SRC" "$CFG_DST"
+install -m 0644 "$UNIT_SRC" "$UNIT_DST"
+
+systemctl --user daemon-reload
+systemctl --user enable litellm.service >/dev/null
+
+echo "--- post-install state ---"
+systemctl --user is-enabled litellm.service
+systemd-analyze --user verify "$UNIT_DST"
+"$VENV/bin/python" "$REPO_ROOT/scripts/litellm_boot_check.py" --mode pre || \
+  echo "(boot pre-check exit non-zero — expected if ANTHROPIC_API_KEY missing/throttled)"

--- a/scripts/litellm_boot_check.py
+++ b/scripts/litellm_boot_check.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+KEI-100 / Linear KEI-73 — T0.2 LiteLLM boot-time dry-run.
+
+Modes:
+  --mode pre   ExecStartPre. Validates provider keys BEFORE litellm binds 4000.
+               HARD FAIL (exit 1) if ANTHROPIC_API_KEY missing or invalid.
+               WARN (do not block) if OPENAI_API_KEY / GOOGLE_API_KEY absent or invalid;
+               records `<alias>_<provider>_unavailable` row in litellm_alias_cache.
+  --mode post  ExecStartPost (optional). HTTP-pings each governance_tier preset
+               against http://127.0.0.1:4000 to confirm proxy is serving.
+
+Anthropic is mandatory per Aiden gap 2 resolution (2026-05-17 ts 1778983972.891719).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime, timedelta
+
+ANTHROPIC_KEY = "ANTHROPIC_API_KEY"
+OPENAI_KEY = "OPENAI_API_KEY"
+GOOGLE_KEY = "GOOGLE_API_KEY"
+
+LITELLM_HEALTH_URL = "http://127.0.0.1:4000/health/liveliness"
+
+
+def log(level: str, msg: str) -> None:
+    sys.stderr.write(f"[litellm_boot_check] {level}: {msg}\n")
+    sys.stderr.flush()
+
+
+def _record_unavailable(alias: str, provider: str, reason: str) -> None:
+    """Best-effort write to litellm_alias_cache. Never raises — boot must not block on Supabase."""
+    try:
+        import psycopg
+    except ImportError:
+        log("WARN", f"psycopg not available — skipping cache write for {alias}/{provider}")
+        return
+
+    dsn = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        log("WARN", f"no SUPABASE_DB_URL — skipping cache write for {alias}/{provider}")
+        return
+
+    expires = datetime.now(UTC) + timedelta(hours=24)
+    try:
+        with psycopg.connect(dsn, prepare_threshold=None, connect_timeout=5) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO public.litellm_alias_cache
+                        (alias, resolved_model, resolved_provider, api_key_ref, cached_at, expires_at)
+                    VALUES (%s, %s, %s, %s, now(), %s)
+                    ON CONFLICT (alias) DO UPDATE SET
+                        resolved_model = EXCLUDED.resolved_model,
+                        resolved_provider = EXCLUDED.resolved_provider,
+                        api_key_ref = EXCLUDED.api_key_ref,
+                        cached_at = now(),
+                        expires_at = EXCLUDED.expires_at
+                    """,
+                    (
+                        f"{alias}_{provider}_unavailable",
+                        reason,
+                        provider,
+                        f"{provider.upper()}_API_KEY",
+                        expires,
+                    ),
+                )
+            conn.commit()
+    except Exception as e:
+        log("WARN", f"cache write failed for {alias}/{provider}: {e}")
+
+
+def _probe_anthropic() -> tuple[bool, str]:
+    try:
+        import anthropic
+    except ImportError as e:
+        return False, f"anthropic SDK not installed: {e}"
+    try:
+        client = anthropic.Anthropic(api_key=os.environ[ANTHROPIC_KEY])
+        client.messages.create(
+            model="claude-haiku-4-5",
+            max_tokens=1,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        return True, "ok"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def _probe_openai() -> tuple[bool, str]:
+    try:
+        import openai
+    except ImportError as e:
+        return False, f"openai SDK not installed: {e}"
+    try:
+        client = openai.OpenAI(api_key=os.environ[OPENAI_KEY])
+        client.chat.completions.create(
+            model="gpt-4o-mini",
+            max_tokens=1,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        return True, "ok"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def _probe_google() -> tuple[bool, str]:
+    try:
+        import google.generativeai as genai
+    except ImportError as e:
+        return False, f"google-generativeai SDK not installed: {e}"
+    try:
+        genai.configure(api_key=os.environ[GOOGLE_KEY])
+        model = genai.GenerativeModel("gemini-1.5-flash")
+        model.generate_content("hi", generation_config={"max_output_tokens": 1})
+        return True, "ok"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def mode_pre() -> int:
+    """ExecStartPre: validate keys, hard fail Anthropic only."""
+    # Anthropic — MANDATORY
+    if not os.environ.get(ANTHROPIC_KEY):
+        log("FATAL", f"{ANTHROPIC_KEY} missing — blocking unit start (gap 2 hard fail)")
+        return 1
+
+    ok, reason = _probe_anthropic()
+    if not ok:
+        log("FATAL", f"{ANTHROPIC_KEY} invalid — {reason} — blocking unit start")
+        return 1
+    log("INFO", "ANTHROPIC_API_KEY: ok")
+
+    # OpenAI — WARN only
+    if not os.environ.get(OPENAI_KEY):
+        log("WARN", f"{OPENAI_KEY} missing — fallback degraded (Anthropic-only)")
+        _record_unavailable("governance_tier", "openai", "key_missing")
+    else:
+        ok, reason = _probe_openai()
+        if not ok:
+            log("WARN", f"{OPENAI_KEY} invalid — {reason} — fallback degraded")
+            _record_unavailable("governance_tier", "openai", reason[:200])
+        else:
+            log("INFO", "OPENAI_API_KEY: ok")
+
+    # Google — WARN only
+    if not os.environ.get(GOOGLE_KEY):
+        log("WARN", f"{GOOGLE_KEY} missing — tertiary fallback degraded")
+        _record_unavailable("governance_tier", "google", "key_missing")
+    else:
+        ok, reason = _probe_google()
+        if not ok:
+            log("WARN", f"{GOOGLE_KEY} invalid — {reason} — tertiary fallback degraded")
+            _record_unavailable("governance_tier", "google", reason[:200])
+        else:
+            log("INFO", "GOOGLE_API_KEY: ok")
+
+    log("INFO", "boot pre-check passed — Anthropic mandatory ok, optional providers warn-only")
+    return 0
+
+
+def mode_post() -> int:
+    """ExecStartPost: confirm proxy serving on 4000."""
+    try:
+        req = urllib.request.Request(LITELLM_HEALTH_URL, method="GET")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            log("INFO", f"liveliness ok ({resp.status}): {body[:200]}")
+            return 0
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        log("FATAL", f"liveliness probe failed: {e}")
+        return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="LiteLLM boot dry-run")
+    parser.add_argument("--mode", choices=["pre", "post"], required=True)
+    args = parser.parse_args()
+    return mode_pre() if args.mode == "pre" else mode_post()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/supabase/migrations/20260517_kei100_litellm_alias_cache.sql
+++ b/supabase/migrations/20260517_kei100_litellm_alias_cache.sql
@@ -1,0 +1,25 @@
+-- KEI-100 / Linear KEI-73 — T0.2 LiteLLM governance_tier alias resolution cache
+-- 24h TTL. Reader skips rows where expires_at < now().
+-- Populated by: scripts/litellm_boot_check.py (boot-time) + interceptor (per-call).
+
+CREATE TABLE IF NOT EXISTS public.litellm_alias_cache (
+  alias              text PRIMARY KEY,
+  resolved_model     text NOT NULL,
+  resolved_provider  text NOT NULL,
+  api_key_ref        text,
+  cached_at          timestamptz NOT NULL DEFAULT now(),
+  expires_at         timestamptz NOT NULL DEFAULT (now() + interval '24 hours')
+);
+
+CREATE INDEX IF NOT EXISTS litellm_alias_cache_expires_at_idx
+  ON public.litellm_alias_cache (expires_at);
+
+CREATE INDEX IF NOT EXISTS litellm_alias_cache_provider_idx
+  ON public.litellm_alias_cache (resolved_provider);
+
+COMMENT ON TABLE public.litellm_alias_cache IS
+  'KEI-100 T0.2: LiteLLM governance_tier alias resolution cache. 24h TTL. Reader filters expires_at >= now().';
+COMMENT ON COLUMN public.litellm_alias_cache.alias IS
+  'governance_tier_fast | governance_tier_premium (or _unavailable suffix for degraded providers)';
+COMMENT ON COLUMN public.litellm_alias_cache.api_key_ref IS
+  'env var name (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY) — never the secret itself';

--- a/tests/integration/test_litellm_bypass.py
+++ b/tests/integration/test_litellm_bypass.py
@@ -1,0 +1,120 @@
+"""
+KEI-100 / Linear KEI-73 — T0.2 LiteLLM direct-provider bypass integration test.
+
+Demonstrates the failure mode T0.1 Dispatcher (Elliot) will consume:
+  1. LiteLLM proxy down → 127.0.0.1:4000 unreachable
+  2. Caller logs marker `INTERCEPTOR_DEGRADED` to stdout
+  3. Caller falls back to direct anthropic.messages.create()
+  4. Proxy restarted → normal path resumes
+
+The PERMANENT fallback wiring belongs to Dispatcher's interceptor_proxy.ts
+(per Aiden gap 5 resolution). This test only proves the failure mode + log marker.
+
+Gated by LITELLM_INTEGRATION_TEST=1 (CI skips by default — runs only on Vultr host
+where systemctl --user can stop/start litellm.service).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import subprocess
+import time
+
+import pytest
+
+DEGRADED_MARKER = "INTERCEPTOR_DEGRADED"
+LITELLM_HOST = "127.0.0.1"
+LITELLM_PORT = 4000
+
+_INTEGRATION = os.environ.get("LITELLM_INTEGRATION_TEST") == "1"
+pytestmark = pytest.mark.skipif(
+    not _INTEGRATION,
+    reason="Integration test — set LITELLM_INTEGRATION_TEST=1 on Vultr host to run",
+)
+
+
+def _proxy_reachable(
+    host: str = LITELLM_HOST, port: int = LITELLM_PORT, timeout: float = 1.0
+) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (TimeoutError, OSError):
+        return False
+
+
+def _systemctl(action: str, unit: str = "litellm.service") -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["systemctl", "--user", action, unit],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def call_with_bypass(prompt: str, logger: logging.Logger) -> str:
+    """The pattern T0.1 Dispatcher consumes: try proxy → on failure, log marker + direct call."""
+    if _proxy_reachable():
+        # Normal path would go through proxy here. Stubbed for test focus on bypass.
+        return f"PROXY_PATH: {prompt[:20]}"
+
+    logger.warning(DEGRADED_MARKER)
+
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+    msg = client.messages.create(
+        model="claude-haiku-4-5",
+        max_tokens=20,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return f"DIRECT_PATH: {msg.content[0].text[:50]}"
+
+
+@pytest.fixture
+def restart_litellm():
+    """Ensure litellm restored even on test failure."""
+    yield
+    _systemctl("start")
+    for _ in range(15):
+        if _proxy_reachable():
+            return
+        time.sleep(1)
+
+
+def test_bypass_flow(caplog, restart_litellm):
+    """Stop litellm → INTERCEPTOR_DEGRADED logged → direct anthropic call succeeds → restart → normal."""
+    caplog.set_level(logging.WARNING)
+    logger = logging.getLogger("test_litellm_bypass")
+
+    # 1. Stop proxy
+    stop = _systemctl("stop")
+    assert stop.returncode == 0, f"stop failed: {stop.stderr}"
+    for _ in range(10):
+        if not _proxy_reachable():
+            break
+        time.sleep(0.5)
+    assert not _proxy_reachable(), "litellm still reachable after stop"
+
+    # 2. Caller detects down → logs marker → falls back
+    result = call_with_bypass("Reply with the single word PONG.", logger)
+    assert result.startswith("DIRECT_PATH:"), f"expected DIRECT_PATH, got {result}"
+    assert any(DEGRADED_MARKER in r.message for r in caplog.records), (
+        f"INTERCEPTOR_DEGRADED not in logs: {[r.message for r in caplog.records]}"
+    )
+
+    # 3. Restart proxy
+    start = _systemctl("start")
+    assert start.returncode == 0, f"start failed: {start.stderr}"
+    for _ in range(15):
+        if _proxy_reachable():
+            break
+        time.sleep(1)
+    assert _proxy_reachable(), "litellm did not come back up"
+
+    # 4. Normal path resumes
+    result = call_with_bypass("Reply with the single word PONG.", logger)
+    assert result.startswith("PROXY_PATH:"), f"expected PROXY_PATH, got {result}"


### PR DESCRIPTION
## Summary

Linear **KEI-73 (T0.2)** — LiteLLM proxy as governance model router between Dispatcher interceptor and the governance model. Implements `governance_tier_fast` / `governance_tier_premium` aliases over Anthropic/OpenAI/Google with simple-shuffle routing + provider fallback.

- 6 model deployments under 2 `governance_tier_*` aliases
- Anthropic mandatory hard-fail (Aiden gap-2 resolution); OpenAI/Google warn-only with degraded rows in `litellm_alias_cache`
- 24h alias_cache TTL
- Direct-provider bypass smoke test (gated `LITELLM_INTEGRATION_TEST=1` — CI collects, skips)

Phase 3 cutover (host venv install + `supabase apply` + `systemctl enable`) is Dave-gated. Migration .sql ships as a file only; orchestrator applies post-merge per Max KEI-101 / Atlas KEI-107 pattern.

## Verbatim evidence

### `ruff format --check` + `ruff check` — both clean

```
2 files already formatted
All checks passed!
```

### `systemd-analyze --user verify` on infra/litellm/litellm.service

```
(exit 0, no output — clean)
```

### `python3 scripts/litellm_boot_check.py --mode pre` — gap-2 hard-fail working as designed

```
[litellm_boot_check] FATAL: ANTHROPIC_API_KEY invalid — BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.'}, 'request_id': 'req_011Cb7VkEzqzppGDK4A9pX8M'} — blocking unit start
---exit=1---
```

**Real-world observation:** the local Anthropic key is in billing-throttled state. This **proves** the gap-2 hard-fail behaves correctly (script exits 1 → systemd ExecStartPre fails → unit refuses to start). It also flags an operational concern: if the same key state ships to Vultr, the service won't boot. **Surface to Dave** before T0.2 deploys live.

### `systemctl --user status litellm.service` — loaded + inactive (expected pre-cutover)

```
○ litellm.service - Agency OS — LiteLLM governance_tier proxy (KEI-100 / Linear KEI-73)
     Loaded: loaded (/home/elliotbot/.config/systemd/user/litellm.service; disabled; preset: enabled)
     Active: inactive (dead)
```

(Historical journal line `Unknown key name 'StartLimitIntervalSec' in section 'Service'` from pre-fix attempt — keys moved to `[Unit]` section in this PR; `systemd-analyze verify` returns 0.)

### `pytest tests/integration/test_litellm_bypass.py -v` — skip-on-no-env (CI-safe)

```
tests/integration/test_litellm_bypass.py::test_bypass_flow SKIPPED [100%]
============================== 1 skipped in 0.08s ==============================
```

### `litellm_alias_cache` schema (migration applied post-merge)

```sql
CREATE TABLE IF NOT EXISTS public.litellm_alias_cache (
  alias              text PRIMARY KEY,
  resolved_model     text NOT NULL,
  resolved_provider  text NOT NULL,
  api_key_ref        text,
  cached_at          timestamptz NOT NULL DEFAULT now(),
  expires_at         timestamptz NOT NULL DEFAULT (now() + interval '24 hours')
);

CREATE INDEX IF NOT EXISTS litellm_alias_cache_expires_at_idx
  ON public.litellm_alias_cache (expires_at);
CREATE INDEX IF NOT EXISTS litellm_alias_cache_provider_idx
  ON public.litellm_alias_cache (resolved_provider);
```

`api_key_ref` stores env var **name** (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY`) — never the secret.

## Review request

- [REVIEW:aiden] — sequencing + correctness
- [REVIEW:elliot] — orchestrator dual-approval (dual approval rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)