### PR TITLE
[ATLAS] feat(kei85): phase B — linear_state_indexer (Linear KEI state → Keis)

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -9,22 +9,22 @@ start, snapshotted by the PreCompact hook (scripts/pre_compact_alert.py).
 - Directive: <directive number or label>
 - Goal: <one-line>
 - Phase: <scope/decompose/execute/verify/report>
-- Files touched (current PR): <list>
+- Files touched (current PR): infra/systemd/agents/linear-state-indexer.service, scripts/install_linear_state_indexer.sh, scripts/orchestrator/linear_state_indexer.py, tests/scripts/test_linear_state_indexer.py
 
 ## Last Good Commit
 
-- SHA: <git short-sha>
-- Branch: <branch-name>
-- Subject: <commit subject line>
+- SHA: e0cbce13
+- Branch: main
+- Subject: [ATLAS] feat(kei85): phase B — linear_state_indexer (Linear KEI state → Keis)
 
 ## Model
 
-- Configured: <callsign-from-IDENTITY.md → lookup in ceo_memory key `orchestration:model_assignment` (SQL-anchored Elliot UPSERT 2026-05-12 22:45:30 UTC)>
-- Running: <actual `--model` flag at startup, if known; otherwise "unknown — check tmux session launch command">
+- Configured: claude-opus-4-7
+- Running: unknown — check tmux session launch command
 
 ## Blockers
 
-- <bulleted list, or "none">
+- none
 
 ## Next Action
 

--- a/infra/systemd/agents/linear-state-indexer.service
+++ b/infra/systemd/agents/linear-state-indexer.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Agency OS — Linear KEI state → Weaviate Keis indexer (KEI-85 phase B)
+Documentation=https://linear.app/keiracom/issue/KEI-85
+After=network-online.target weaviate.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+Environment=PYTHONPATH=/home/elliotbot/clawd/Agency_OS/scripts/orchestrator
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/linear_state_indexer.py
+Restart=on-failure
+RestartSec=15
+StandardOutput=append:/home/elliotbot/clawd/logs/linear-state-indexer.log
+StandardError=append:/home/elliotbot/clawd/logs/linear-state-indexer.log
+# KEI-44 cgroup pattern — small worker footprint (Linear API + JSON only).
+MemoryMax=256M
+MemoryHigh=200M
+
+[Install]
+WantedBy=default.target

--- a/scripts/install_linear_state_indexer.sh
+++ b/scripts/install_linear_state_indexer.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# install_linear_state_indexer.sh — KEI-85 phase B install entry-point.
+#
+# KEI-108 CI-gate requirement: per-unit named install script anchors the
+# literal unit name `linear-state-indexer.service` for the grep gate.
+#
+# Usage:
+#   scripts/install_linear_state_indexer.sh
+
+set -euo pipefail
+
+UNIT="linear-state-indexer"
+exec /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/install_indexer.sh "${UNIT}"
+
+# Anchored unit: linear-state-indexer.service

--- a/scripts/orchestrator/indexer_base.py
+++ b/scripts/orchestrator/indexer_base.py
@@ -39,8 +39,9 @@ WEAVIATE_PORT = os.environ.get("WEAVIATE_PORT", "8090")
 # weaviate_capped.sh and serves plain HTTP. TLS is terminated at the
 # Cloudflare Tunnel layer (T0.3, separate KEI), never at the Weaviate process.
 # Switching this to https://127.0.0.1 would break the connection — there is
-# no TLS listener inside the cgroup. NOSONAR S5332 (loopback HTTP is safe).
-WEAVIATE_BASE = f"http://{WEAVIATE_HOST}:{WEAVIATE_PORT}"  # NOSONAR S5332
+# no TLS listener inside the cgroup. The NOSONAR below suppresses S5332 on
+# this line only; rationale is captured in this comment block.
+WEAVIATE_BASE = f"http://{WEAVIATE_HOST}:{WEAVIATE_PORT}"  # NOSONAR
 
 MAX_RETRIES = 3
 INITIAL_BACKOFF_SECONDS = 1.0

--- a/scripts/orchestrator/linear_state_indexer.py
+++ b/scripts/orchestrator/linear_state_indexer.py
@@ -128,6 +128,23 @@ INITIAL_BACKOFF_SECONDS = 1.0
 MAX_PAGINATION_PAGES = int(os.environ.get("LINEAR_STATE_MAX_PAGES", "20"))
 
 
+def _handle_http_error(exc: urlerror.HTTPError, attempt: int, backoff: float) -> float | None:
+    """Decide retry-or-raise for an HTTPError. Returns the next backoff value if
+    retryable (caller must `continue`); returns None if terminal (caller must
+    re-raise). Sleeps internally on retry."""
+    if exc.code == 429:
+        retry_after = _parse_retry_after(exc.headers.get("Retry-After"))
+        wait = retry_after if retry_after is not None else backoff
+        logger.warning("linear_api 429 (attempt=%d) — sleeping %ss", attempt, wait)
+        time.sleep(wait)
+        return backoff * 2
+    if 500 <= exc.code < 600:
+        logger.warning("linear_api %d (attempt=%d) — backoff %ss", exc.code, attempt, backoff)
+        time.sleep(backoff)
+        return backoff * 2
+    return None
+
+
 def _graphql(query: str, variables: dict) -> dict:
     """Linear GraphQL POST with retry + 429 Retry-After respect.
 
@@ -155,26 +172,10 @@ def _graphql(query: str, variables: dict) -> dict:
                 return json.loads(resp.read().decode("utf-8"))
         except urlerror.HTTPError as exc:
             last_exc = exc
-            if exc.code == 429:
-                retry_after = _parse_retry_after(exc.headers.get("Retry-After"))
-                wait = retry_after if retry_after is not None else backoff
-                logger.warning(
-                    "linear_api 429 (attempt=%d) — sleeping %ss",
-                    attempt,
-                    wait,
-                )
-                time.sleep(wait)
-                backoff *= 2
-                continue
-            if 500 <= exc.code < 600:
-                logger.warning(
-                    "linear_api %d (attempt=%d) — backoff %ss", exc.code, attempt, backoff
-                )
-                time.sleep(backoff)
-                backoff *= 2
-                continue
-            # 4xx other than 429 — terminal, do not retry.
-            raise
+            next_backoff = _handle_http_error(exc, attempt, backoff)
+            if next_backoff is None:
+                raise
+            backoff = next_backoff
         except (urlerror.URLError, OSError) as exc:
             last_exc = exc
             logger.warning(
@@ -182,7 +183,6 @@ def _graphql(query: str, variables: dict) -> dict:
             )
             time.sleep(backoff)
             backoff *= 2
-    # All retries exhausted.
     raise last_exc if last_exc else RuntimeError("linear_api retries exhausted")
 
 

--- a/scripts/orchestrator/linear_state_indexer.py
+++ b/scripts/orchestrator/linear_state_indexer.py
@@ -47,6 +47,8 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 
 KEIS_CLASS = "Keis"
 SOURCE_NAME = "linear"
+# Sonar S1192: define the epoch fallback literal once and reuse.
+EPOCH_ISO = "1970-01-01T00:00:00Z"
 POLL_SECONDS = int(os.environ.get("LINEAR_STATE_POLL_SECONDS", "60"))
 BATCH_SIZE_DEFAULT = int(os.environ.get("LINEAR_STATE_BATCH_SIZE", "100"))
 TEAM_KEY = os.environ.get("LINEAR_TEAM_KEY", "KEI")
@@ -106,11 +108,11 @@ def _api_key() -> str:
 
 def _read_cursor() -> str:
     if not CURSOR_PATH.exists():
-        return "1970-01-01T00:00:00Z"
+        return EPOCH_ISO
     try:
-        return json.loads(CURSOR_PATH.read_text()).get("updated_at", "1970-01-01T00:00:00Z")
+        return json.loads(CURSOR_PATH.read_text()).get("updated_at", EPOCH_ISO)
     except (ValueError, OSError):
-        return "1970-01-01T00:00:00Z"
+        return EPOCH_ISO
 
 
 def _write_cursor(updated_at: str) -> None:
@@ -230,6 +232,35 @@ def _parse_nodes(nodes: list[dict]) -> list[LinearIssue]:
     ]
 
 
+def _fetch_page(
+    cursor: str, batch_size: int, after: str | None
+) -> tuple[list[LinearIssue], str | None] | None:
+    """Single GraphQL page fetch. Returns `(issues, next_after)` on success;
+    `next_after` is None when this is the last page. Returns None on any
+    error so the caller can drop out of the pagination loop. Extracted so
+    `fetch_linear_issues` stays under SonarCloud's cognitive-complexity cap.
+    """
+    variables: dict[str, Any] = {
+        "filter": {
+            "team": {"key": {"eq": TEAM_KEY}},
+            "updatedAt": {"gt": cursor},
+        },
+        "first": batch_size,
+    }
+    if after:
+        variables["after"] = after
+    try:
+        body = _graphql(LINEAR_QUERY, variables)
+    except (urlerror.URLError, OSError, ValueError):
+        return None
+    if body.get("errors"):
+        return None
+    issues_block = body.get("data", {}).get("issues", {}) or {}
+    page_info = issues_block.get("pageInfo", {}) or {}
+    next_after = page_info.get("endCursor") if page_info.get("hasNextPage") else None
+    return _parse_nodes(issues_block.get("nodes", []) or []), next_after
+
+
 def fetch_linear_issues(cursor: str, batch_size: int) -> list[LinearIssue]:
     """Fetch ALL issues with updatedAt > cursor, paginating via hasNextPage.
 
@@ -239,40 +270,20 @@ def fetch_linear_issues(cursor: str, batch_size: int) -> list[LinearIssue]:
     collected: list[LinearIssue] = []
     after: str | None = None
     for page in range(1, MAX_PAGINATION_PAGES + 1):
-        variables: dict[str, Any] = {
-            "filter": {
-                "team": {"key": {"eq": TEAM_KEY}},
-                "updatedAt": {"gt": cursor},
-            },
-            "first": batch_size,
-        }
-        if after:
-            variables["after"] = after
-        try:
-            body = _graphql(LINEAR_QUERY, variables)
-        except (urlerror.URLError, OSError, ValueError) as exc:
+        result = _fetch_page(cursor, batch_size, after)
+        if result is None:
             logger.warning(
-                "linear_api transient on page %d (%s) — returning partial batch (%d so far)",
+                "linear_api page %d failed — returning partial batch (%d)",
                 page,
-                exc,
                 len(collected),
             )
             return collected
-        errors = body.get("errors")
-        if errors:
-            logger.warning("linear_api errors=%s — stopping at page %d", errors, page)
-            return collected
-        issues_block = body.get("data", {}).get("issues", {}) or {}
-        nodes = issues_block.get("nodes", []) or []
-        collected.extend(_parse_nodes(nodes))
-        page_info = issues_block.get("pageInfo", {}) or {}
-        if not page_info.get("hasNextPage"):
-            return collected
-        after = page_info.get("endCursor")
-        if not after:
+        issues, after = result
+        collected.extend(issues)
+        if after is None:
             return collected
     logger.warning(
-        "linear_api pagination cap hit at %d pages (%d issues) — next poll drains the rest",
+        "pagination cap %d reached (%d issues) — next poll drains the rest",
         MAX_PAGINATION_PAGES,
         len(collected),
     )
@@ -323,7 +334,7 @@ def build_keis_doc(issue: LinearIssue) -> dict:
         "properties": {
             "raw_text": raw_text,
             "environment_hash": env_hash,
-            "created_at": issue.updated_at or "1970-01-01T00:00:00Z",
+            "created_at": issue.updated_at or EPOCH_ISO,
             "agent": "system",
             "kei": issue.identifier,
         },

--- a/scripts/orchestrator/linear_state_indexer.py
+++ b/scripts/orchestrator/linear_state_indexer.py
@@ -121,25 +121,83 @@ def _write_cursor(updated_at: str) -> None:
         logger.warning("cursor persist failed (%s) — non-fatal", exc)
 
 
+MAX_GRAPHQL_RETRIES = 4
+INITIAL_BACKOFF_SECONDS = 1.0
+MAX_PAGINATION_PAGES = int(os.environ.get("LINEAR_STATE_MAX_PAGES", "20"))
+
+
 def _graphql(query: str, variables: dict) -> dict:
+    """Linear GraphQL POST with retry + 429 Retry-After respect.
+
+    Mirrors the indexer_base.post_object exponential-backoff shape so the
+    failure surface across Weaviate + Linear is uniform. On 429: parse
+    Retry-After header (seconds or http-date). On 5xx: exponential backoff.
+    On terminal failure: raise so caller surfaces the error.
+    """
     body = json.dumps({"query": query, "variables": variables}).encode("utf-8")
-    req = urlrequest.Request(
-        LINEAR_API,
-        data=body,
-        method="POST",
-        headers={
-            "Authorization": _api_key(),
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        },
-    )
-    with urlrequest.urlopen(req, timeout=20) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+    backoff = INITIAL_BACKOFF_SECONDS
+    last_exc: Exception | None = None
+    for attempt in range(1, MAX_GRAPHQL_RETRIES + 1):
+        req = urlrequest.Request(
+            LINEAR_API,
+            data=body,
+            method="POST",
+            headers={
+                "Authorization": _api_key(),
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+        )
+        try:
+            with urlrequest.urlopen(req, timeout=20) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urlerror.HTTPError as exc:
+            last_exc = exc
+            if exc.code == 429:
+                retry_after = _parse_retry_after(exc.headers.get("Retry-After"))
+                wait = retry_after if retry_after is not None else backoff
+                logger.warning(
+                    "linear_api 429 (attempt=%d) — sleeping %ss",
+                    attempt,
+                    wait,
+                )
+                time.sleep(wait)
+                backoff *= 2
+                continue
+            if 500 <= exc.code < 600:
+                logger.warning(
+                    "linear_api %d (attempt=%d) — backoff %ss", exc.code, attempt, backoff
+                )
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            # 4xx other than 429 — terminal, do not retry.
+            raise
+        except (urlerror.URLError, OSError) as exc:
+            last_exc = exc
+            logger.warning(
+                "linear_api transient %s (attempt=%d) — backoff %ss", exc, attempt, backoff
+            )
+            time.sleep(backoff)
+            backoff *= 2
+    # All retries exhausted.
+    raise last_exc if last_exc else RuntimeError("linear_api retries exhausted")
+
+
+def _parse_retry_after(header_value: str | None) -> float | None:
+    if not header_value:
+        return None
+    try:
+        return float(header_value)
+    except ValueError:
+        # http-date form — give up parsing and let caller fall back to backoff
+        return None
 
 
 LINEAR_QUERY = """
-query KeisSince($filter: IssueFilter!, $first: Int!) {
-  issues(filter: $filter, first: $first, orderBy: updatedAt) {
+query KeisSince($filter: IssueFilter!, $first: Int!, $after: String) {
+  issues(filter: $filter, first: $first, after: $after, orderBy: updatedAt) {
+    pageInfo { hasNextPage endCursor }
     nodes {
       id
       identifier
@@ -155,24 +213,7 @@ query KeisSince($filter: IssueFilter!, $first: Int!) {
 """
 
 
-def fetch_linear_issues(cursor: str, batch_size: int) -> list[LinearIssue]:
-    variables = {
-        "filter": {
-            "team": {"key": {"eq": TEAM_KEY}},
-            "updatedAt": {"gt": cursor},
-        },
-        "first": batch_size,
-    }
-    try:
-        body = _graphql(LINEAR_QUERY, variables)
-    except (urlerror.URLError, OSError, ValueError) as exc:
-        logger.warning("linear_api transient %s — empty batch", exc)
-        return []
-    errors = body.get("errors")
-    if errors:
-        logger.warning("linear_api errors=%s — empty batch", errors)
-        return []
-    nodes = body.get("data", {}).get("issues", {}).get("nodes", []) or []
+def _parse_nodes(nodes: list[dict]) -> list[LinearIssue]:
     return [
         LinearIssue(
             id=n["id"],
@@ -187,6 +228,55 @@ def fetch_linear_issues(cursor: str, batch_size: int) -> list[LinearIssue]:
         )
         for n in nodes
     ]
+
+
+def fetch_linear_issues(cursor: str, batch_size: int) -> list[LinearIssue]:
+    """Fetch ALL issues with updatedAt > cursor, paginating via hasNextPage.
+
+    Hard-capped at MAX_PAGINATION_PAGES per fetch to bound one daemon poll's
+    work. Remaining issues drain on the next poll (cursor will have advanced).
+    """
+    collected: list[LinearIssue] = []
+    after: str | None = None
+    for page in range(1, MAX_PAGINATION_PAGES + 1):
+        variables: dict[str, Any] = {
+            "filter": {
+                "team": {"key": {"eq": TEAM_KEY}},
+                "updatedAt": {"gt": cursor},
+            },
+            "first": batch_size,
+        }
+        if after:
+            variables["after"] = after
+        try:
+            body = _graphql(LINEAR_QUERY, variables)
+        except (urlerror.URLError, OSError, ValueError) as exc:
+            logger.warning(
+                "linear_api transient on page %d (%s) — returning partial batch (%d so far)",
+                page,
+                exc,
+                len(collected),
+            )
+            return collected
+        errors = body.get("errors")
+        if errors:
+            logger.warning("linear_api errors=%s — stopping at page %d", errors, page)
+            return collected
+        issues_block = body.get("data", {}).get("issues", {}) or {}
+        nodes = issues_block.get("nodes", []) or []
+        collected.extend(_parse_nodes(nodes))
+        page_info = issues_block.get("pageInfo", {}) or {}
+        if not page_info.get("hasNextPage"):
+            return collected
+        after = page_info.get("endCursor")
+        if not after:
+            return collected
+    logger.warning(
+        "linear_api pagination cap hit at %d pages (%d issues) — next poll drains the rest",
+        MAX_PAGINATION_PAGES,
+        len(collected),
+    )
+    return collected
 
 
 class LinearStateIndexer(BaseIndexer[LinearIssue]):

--- a/scripts/orchestrator/linear_state_indexer.py
+++ b/scripts/orchestrator/linear_state_indexer.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""linear_state_indexer.py — KEI-85 phase B: index Linear KEI state into Weaviate Keis.
+
+Polls Linear's GraphQL API for KEI issues belonging to team Keiracom, captures
+title + description + state name + state type + updatedAt, and POSTs one
+Weaviate Keis object per (linear_issue_id, updated_at) tuple. Each state
+transition produces a new Weaviate object — preserving history so agents can
+recall WHY a KEI moved Todo → In Progress → Done at recall time.
+
+Idempotent: deterministic UUID derived from `linear:{issue_id}:{updated_at}`.
+Re-polling unchanged issues returns 422 from Weaviate (already-exists) and is
+treated as a no-op.
+
+Cursor: tracks the max `updatedAt` seen so far in a tiny on-disk JSON. Each
+poll fetches `WHERE updatedAt > $cursor` to keep the per-poll set small.
+
+Usage:
+    python3 scripts/orchestrator/linear_state_indexer.py            # daemon loop
+    python3 scripts/orchestrator/linear_state_indexer.py --once     # one batch
+    python3 scripts/orchestrator/linear_state_indexer.py --batch=100
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import signal
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+from indexer_base import (
+    BaseIndexer,
+    aggregate_count,
+    deterministic_uuid,
+)
+
+logger = logging.getLogger("linear_state_indexer")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+KEIS_CLASS = "Keis"
+SOURCE_NAME = "linear"
+POLL_SECONDS = int(os.environ.get("LINEAR_STATE_POLL_SECONDS", "60"))
+BATCH_SIZE_DEFAULT = int(os.environ.get("LINEAR_STATE_BATCH_SIZE", "100"))
+TEAM_KEY = os.environ.get("LINEAR_TEAM_KEY", "KEI")
+CURSOR_PATH = Path(
+    os.environ.get(
+        "LINEAR_STATE_CURSOR_PATH", "/home/elliotbot/clawd/logs/linear_state_indexer.cursor"
+    )
+)
+
+LINEAR_API = "https://api.linear.app/graphql"
+
+KEIS_SCHEMA = {
+    "class": KEIS_CLASS,
+    "vectorizer": "none",
+    "properties": [
+        {"name": "raw_text", "dataType": ["text"]},
+        {"name": "environment_hash", "dataType": ["text"]},
+        {"name": "created_at", "dataType": ["date"]},
+        {"name": "agent", "dataType": ["text"]},
+        {"name": "kei", "dataType": ["text"]},
+    ],
+}
+
+
+@dataclass(frozen=True)
+class LinearIssue:
+    id: str
+    identifier: str
+    title: str
+    description: str
+    state_name: str
+    state_type: str
+    updated_at: str
+    assignee: str
+    priority_name: str
+
+
+_shutdown_requested = False
+
+
+def _signal_handler(signum: int, _frame: Any) -> None:
+    global _shutdown_requested
+    logger.info("signal %s received — shutdown", signum)
+    _shutdown_requested = True
+
+
+signal.signal(signal.SIGTERM, _signal_handler)
+signal.signal(signal.SIGINT, _signal_handler)
+
+
+def _api_key() -> str:
+    key = os.environ.get("LINEAR_API_KEY")
+    if not key:
+        raise SystemExit("indexer: LINEAR_API_KEY must be set")
+    return key
+
+
+def _read_cursor() -> str:
+    if not CURSOR_PATH.exists():
+        return "1970-01-01T00:00:00Z"
+    try:
+        return json.loads(CURSOR_PATH.read_text()).get("updated_at", "1970-01-01T00:00:00Z")
+    except (ValueError, OSError):
+        return "1970-01-01T00:00:00Z"
+
+
+def _write_cursor(updated_at: str) -> None:
+    try:
+        CURSOR_PATH.parent.mkdir(parents=True, exist_ok=True)
+        CURSOR_PATH.write_text(json.dumps({"updated_at": updated_at}))
+    except OSError as exc:
+        logger.warning("cursor persist failed (%s) — non-fatal", exc)
+
+
+def _graphql(query: str, variables: dict) -> dict:
+    body = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+    req = urlrequest.Request(
+        LINEAR_API,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": _api_key(),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    with urlrequest.urlopen(req, timeout=20) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+LINEAR_QUERY = """
+query KeisSince($filter: IssueFilter!, $first: Int!) {
+  issues(filter: $filter, first: $first, orderBy: updatedAt) {
+    nodes {
+      id
+      identifier
+      title
+      description
+      updatedAt
+      state { name type }
+      assignee { name }
+      priorityLabel
+    }
+  }
+}
+"""
+
+
+def fetch_linear_issues(cursor: str, batch_size: int) -> list[LinearIssue]:
+    variables = {
+        "filter": {
+            "team": {"key": {"eq": TEAM_KEY}},
+            "updatedAt": {"gt": cursor},
+        },
+        "first": batch_size,
+    }
+    try:
+        body = _graphql(LINEAR_QUERY, variables)
+    except (urlerror.URLError, OSError, ValueError) as exc:
+        logger.warning("linear_api transient %s — empty batch", exc)
+        return []
+    errors = body.get("errors")
+    if errors:
+        logger.warning("linear_api errors=%s — empty batch", errors)
+        return []
+    nodes = body.get("data", {}).get("issues", {}).get("nodes", []) or []
+    return [
+        LinearIssue(
+            id=n["id"],
+            identifier=n.get("identifier", ""),
+            title=n.get("title", ""),
+            description=n.get("description") or "",
+            state_name=(n.get("state") or {}).get("name", ""),
+            state_type=(n.get("state") or {}).get("type", ""),
+            updated_at=n.get("updatedAt", ""),
+            assignee=((n.get("assignee") or {}).get("name") or ""),
+            priority_name=n.get("priorityLabel", ""),
+        )
+        for n in nodes
+    ]
+
+
+class LinearStateIndexer(BaseIndexer[LinearIssue]):
+    """Linear KEI state → Keis concrete indexer (KEI-85 phase B)."""
+
+    source_name = SOURCE_NAME
+    target_class = KEIS_CLASS
+    class_schema = KEIS_SCHEMA
+
+    def __init__(self, batch_size: int) -> None:
+        self._batch_size = batch_size
+        self._last_max_updated_at: str | None = None
+
+    def fetch_batch(self, batch_size: int) -> list[LinearIssue]:
+        cursor = _read_cursor()
+        issues = fetch_linear_issues(cursor, batch_size)
+        if issues:
+            self._last_max_updated_at = max(i.updated_at for i in issues if i.updated_at)
+        return issues
+
+    def build_object(self, row: LinearIssue) -> dict:
+        return build_keis_doc(row)
+
+    def advance_cursor(self) -> None:
+        if self._last_max_updated_at:
+            _write_cursor(self._last_max_updated_at)
+
+
+def build_keis_doc(issue: LinearIssue) -> dict:
+    body = {
+        "identifier": issue.identifier,
+        "title": issue.title,
+        "description": issue.description,
+        "state_name": issue.state_name,
+        "state_type": issue.state_type,
+        "assignee": issue.assignee,
+        "priority": issue.priority_name,
+    }
+    raw_text = json.dumps(body, sort_keys=True, default=str)
+    env_hash = hashlib.sha256(raw_text.encode("utf-8")).hexdigest()[:16]
+    return {
+        "class": KEIS_CLASS,
+        "id": deterministic_uuid(SOURCE_NAME, f"{issue.id}:{issue.updated_at}"),
+        "properties": {
+            "raw_text": raw_text,
+            "environment_hash": env_hash,
+            "created_at": issue.updated_at or "1970-01-01T00:00:00Z",
+            "agent": "system",
+            "kei": issue.identifier,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--batch", type=int, default=BATCH_SIZE_DEFAULT)
+    args = parser.parse_args()
+
+    indexer = LinearStateIndexer(args.batch)
+    indexer.ensure_target_class()
+    logger.info(
+        "indexer start source=%s class=%s batch=%d team=%s",
+        SOURCE_NAME,
+        KEIS_CLASS,
+        args.batch,
+        TEAM_KEY,
+    )
+
+    if args.once:
+        outcome = indexer.index_once(args.batch)
+        indexer.advance_cursor()
+        logger.info(
+            "once outcome=%s class_count=%s cursor=%s",
+            outcome.to_dict(),
+            aggregate_count(KEIS_CLASS),
+            _read_cursor(),
+        )
+        return
+    while not _shutdown_requested:
+        try:
+            outcome = indexer.index_once(args.batch)
+            indexer.advance_cursor()
+            logger.info(
+                "batch outcome=%s class_count=%s cursor=%s",
+                outcome.to_dict(),
+                aggregate_count(KEIS_CLASS),
+                _read_cursor(),
+            )
+        except Exception:
+            logger.exception("batch failed — sleeping then continuing")
+        for _ in range(POLL_SECONDS):
+            if _shutdown_requested:
+                break
+            time.sleep(1)
+    logger.info("indexer exiting cleanly")
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/tests/scripts/test_linear_state_indexer.py
+++ b/tests/scripts/test_linear_state_indexer.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "scripts" / "orchestrator"))
 
@@ -100,12 +102,14 @@ def test_read_cursor_default_when_corrupt(tmp_path, monkeypatch):
     bad = tmp_path / "bad.cursor"
     bad.write_text("not-json-content")
     monkeypatch.setattr(mod, "CURSOR_PATH", bad)
-    assert mod._read_cursor() == "1970-01-01T00:00:00Z"
+    assert mod._read_cursor() == mod.EPOCH_ISO
 
 
 def test_parse_retry_after_seconds():
-    assert mod._parse_retry_after("30") == 30.0
-    assert mod._parse_retry_after("0.5") == 0.5
+    # Sonar S1244: avoid float equality. pytest.approx covers the tiny FP
+    # representation gap without losing the assertion's intent.
+    assert mod._parse_retry_after("30") == pytest.approx(30.0)
+    assert mod._parse_retry_after("0.5") == pytest.approx(0.5)
 
 
 def test_parse_retry_after_returns_none_on_unparseable():

--- a/tests/scripts/test_linear_state_indexer.py
+++ b/tests/scripts/test_linear_state_indexer.py
@@ -1,0 +1,103 @@
+"""Unit tests for linear_state_indexer (KEI-85 phase B).
+
+No network: pure-logic tests for build_keis_doc + deterministic UUID +
+ABC compliance. End-to-end smoke (live Linear API + live Weaviate) is
+in the PR body and runs against the host.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "orchestrator"))
+
+import linear_state_indexer as mod  # noqa: E402
+
+
+def _issue(updated_at: str = "2026-05-17T08:00:00Z") -> mod.LinearIssue:
+    return mod.LinearIssue(
+        id="lin-id-abc",
+        identifier="KEI-85",
+        title="Multi-source auto-indexers",
+        description="phase A/B/C/D scaffold",
+        state_name="In Progress",
+        state_type="started",
+        updated_at=updated_at,
+        assignee="atlas",
+        priority_name="Medium",
+    )
+
+
+def test_deterministic_uuid_stable_for_same_issue_and_ts():
+    a = mod.build_keis_doc(_issue())["id"]
+    b = mod.build_keis_doc(_issue())["id"]
+    assert a == b
+
+
+def test_deterministic_uuid_differs_when_updated_at_changes():
+    a = mod.build_keis_doc(_issue(updated_at="2026-05-17T08:00:00Z"))["id"]
+    b = mod.build_keis_doc(_issue(updated_at="2026-05-17T09:00:00Z"))["id"]
+    assert a != b
+
+
+def test_build_keis_doc_basic_shape():
+    doc = mod.build_keis_doc(_issue())
+    assert doc["class"] == "Keis"
+    props = doc["properties"]
+    assert props["kei"] == "KEI-85"
+    assert props["agent"] == "system"
+    assert props["created_at"] == "2026-05-17T08:00:00Z"
+    assert "Multi-source" in props["raw_text"]
+    assert len(props["environment_hash"]) == 16
+    int(props["environment_hash"], 16)
+
+
+def test_build_keis_doc_handles_empty_updated_at():
+    issue = mod.LinearIssue(
+        id="x",
+        identifier="KEI-X",
+        title="t",
+        description="",
+        state_name="",
+        state_type="",
+        updated_at="",
+        assignee="",
+        priority_name="",
+    )
+    doc = mod.build_keis_doc(issue)
+    assert doc["properties"]["created_at"] == "1970-01-01T00:00:00Z"
+
+
+def test_linear_state_indexer_satisfies_base_indexer_abc():
+    import indexer_base
+
+    assert issubclass(mod.LinearStateIndexer, indexer_base.BaseIndexer)
+    assert mod.LinearStateIndexer.source_name == "linear"
+    assert mod.LinearStateIndexer.target_class == "Keis"
+    assert mod.LinearStateIndexer.class_schema["class"] == "Keis"
+    assert mod.LinearStateIndexer.__abstractmethods__ == frozenset()
+
+
+def test_advance_cursor_writes_then_read_cursor_reads(tmp_path, monkeypatch):
+    cursor_file = tmp_path / "lin.cursor"
+    monkeypatch.setattr(mod, "CURSOR_PATH", cursor_file)
+
+    indexer = mod.LinearStateIndexer(batch_size=5)
+    indexer._last_max_updated_at = "2026-05-17T10:00:00Z"
+    indexer.advance_cursor()
+
+    assert mod._read_cursor() == "2026-05-17T10:00:00Z"
+
+
+def test_read_cursor_default_when_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "CURSOR_PATH", tmp_path / "no-such-file")
+    assert mod._read_cursor() == "1970-01-01T00:00:00Z"
+
+
+def test_read_cursor_default_when_corrupt(tmp_path, monkeypatch):
+    bad = tmp_path / "bad.cursor"
+    bad.write_text("not-json-content")
+    monkeypatch.setattr(mod, "CURSOR_PATH", bad)
+    assert mod._read_cursor() == "1970-01-01T00:00:00Z"

--- a/tests/scripts/test_linear_state_indexer.py
+++ b/tests/scripts/test_linear_state_indexer.py
@@ -101,3 +101,37 @@ def test_read_cursor_default_when_corrupt(tmp_path, monkeypatch):
     bad.write_text("not-json-content")
     monkeypatch.setattr(mod, "CURSOR_PATH", bad)
     assert mod._read_cursor() == "1970-01-01T00:00:00Z"
+
+
+def test_parse_retry_after_seconds():
+    assert mod._parse_retry_after("30") == 30.0
+    assert mod._parse_retry_after("0.5") == 0.5
+
+
+def test_parse_retry_after_returns_none_on_unparseable():
+    assert mod._parse_retry_after(None) is None
+    assert mod._parse_retry_after("") is None
+    # http-date form — we don't parse those, caller falls back to backoff.
+    assert mod._parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT") is None
+
+
+def test_parse_nodes_handles_missing_optional_fields():
+    nodes = [
+        {"id": "x1", "identifier": "KEI-1", "title": "t", "updatedAt": "2026-05-17T00:00:00Z"},
+        {
+            "id": "x2",
+            "identifier": "KEI-2",
+            "title": "t",
+            "description": None,
+            "state": None,
+            "assignee": None,
+            "priorityLabel": "",
+            "updatedAt": "2026-05-17T01:00:00Z",
+        },
+    ]
+    parsed = mod._parse_nodes(nodes)
+    assert len(parsed) == 2
+    assert parsed[0].description == ""
+    assert parsed[0].state_name == ""
+    assert parsed[1].state_type == ""
+    assert parsed[1].assignee == ""


### PR DESCRIPTION
## Summary

Phase B of 4 for KEI-85 (parent KEI-107). Linear KEI state → Weaviate Keis collection. Inherits the `BaseIndexer` ABC contract that landed in phase A (#915). Cursor-based incremental polling. **Keis: 0 → 50** in one `--once --batch=50` run.

**Linear:** KEI-85 (In Progress) · **Parent:** KEI-107 · **Phase 0 gate**
**Branch:** `atlas/kei85-phase-b-linear-state`

## What lands

| File | Purpose |
|---|---|
| `scripts/orchestrator/linear_state_indexer.py` | Polls Linear GraphQL for team Keiracom KEIs with `updatedAt > cursor`. Inherits `BaseIndexer[LinearIssue]`. One Weaviate Keis object per `(issue_id, updated_at)` tuple — preserves state-transition history. |
| `infra/systemd/agents/linear-state-indexer.service` | Durable user-systemd unit. `MemoryMax=256M` / `MemoryHigh=200M` per KEI-44 cgroup pattern. |
| `scripts/install_linear_state_indexer.sh` | KEI-108 CI-gate install wrapper. Anchors literal `linear-state-indexer.service`. Reuses generic `install_indexer.sh`. |
| `tests/scripts/test_linear_state_indexer.py` | 8 pure-logic tests: UUID determinism + differs-by-ts, build_keis_doc shape + empty-ts fallback, ABC subclass enforcement, cursor write/read/missing/corrupt paths. |

## Architectural notes

1. **History-preserving design.** Deterministic UUID = `uuid5(NS, "linear:{issue_id}:{updated_at}")`. Each state transition produces a NEW Weaviate object (different updated_at → different UUID). Agents querying "why did KEI-X move to Done at time T?" can recall the full transition chain, not just the latest state.

2. **Cursor-based polling.** Tiny on-disk JSON at `/home/elliotbot/clawd/logs/linear_state_indexer.cursor`. Per-poll `WHERE updatedAt > cursor` keeps each batch bounded even as the Linear KEI count grows. Cursor persists across restarts (idempotent — re-polling old issues just hits Weaviate's 422 dedup).

3. **ABC contract.** Inherits `BaseIndexer[LinearIssue]` from phase A. All abstract methods overridden (`__abstractmethods__ == frozenset()`). Phase C (git) and phase D (Slack) will follow the same pattern.

4. **Failure mode: API down.** `fetch_linear_issues` catches `urlerror.URLError/OSError/ValueError` and returns empty list — logged as warning. Daemon doesn't crash on transient Linear-side outage; just sleeps and retries next poll.

## Verbatim verification

### Tests + lint + format

```
$ ruff check + ruff format --check
All checks passed! · clean
$ pytest tests/scripts/test_linear_state_indexer.py
========================== 8 passed in 0.09s ==========================
```

### End-to-end smoke (live Linear API + live Weaviate)

```
$ curl -s ... Aggregate.Keis.meta.count   # pre
0

$ python3 scripts/orchestrator/linear_state_indexer.py --once --batch=50
2026-05-17 08:51:05 INFO class Keis already exists
2026-05-17 08:51:05 INFO indexer start source=linear class=Keis batch=50 team=KEI
2026-05-17 08:51:06 INFO once outcome={'selected': 50, 'success': 50, 'failed': 0} class_count=50 cursor=2026-05-17T07:31:03.603Z

$ curl -s ... Aggregate.Keis.meta.count   # post
50
```

**Keis 0 → 50.** Cursor advanced. Re-running would skip already-indexed issues.

## Install (KEI-108 gate)

```
scripts/install_linear_state_indexer.sh
```

Idempotent. Per-unit script anchors literal `linear-state-indexer.service` for the CI grep gate.

## Out of scope (phases C/D, separate PRs)

- **Phase C**: git commits → `Codebase` (cursor by SHA)
- **Phase D**: Slack relay messages → `Sessions` (per Elliot's KEI-117 directive; original plan was `Staging_discoveries`)

## Dual approval

Per session rules: **[ELLIOT] + [AIDEN]** must both CONCUR. Dave merges. Elliot's KEI-117 Phase 0 gate active.

## Test plan

- [ ] CI ruff + pytest + KEI-108 install-wired gate green
- [ ] CI SonarCloud green (same loopback NOSONAR + main()→None patterns as phase A — should inherit cleanly)
- [ ] Manual review: history-preserving UUID strategy (every state change = new Weaviate object). Acceptable, or should it be one-row-per-issue updated-in-place?
- [ ] Manual review: cursor strategy adequate, or should it move to a Postgres `index_cursors` table for multi-host parity?

🤖 Generated with [Claude Code](https://claude.com/claude-code)