### PR TITLE
[MAX] feat(kei92): agent self-claim loop — Linear KEI-92 / KEI-130 idle-loop fix

### DIFF
--- a/infra/systemd/agents/agent-self-claim-loop@.service
+++ b/infra/systemd/agents/agent-self-claim-loop@.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Keiracom agent self-claim loop (%i) — KEI-92 / Linear KEI-130
+Documentation=https://linear.app/keiracom/issue/KEI-92
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+Environment="CALLSIGN=%i"
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/orchestrator/agent_self_claim_loop.sh --callsign %i
+Restart=always
+RestartSec=10
+StandardOutput=append:/home/elliotbot/clawd/logs/agent-self-claim-loop-%i.log
+StandardError=append:/home/elliotbot/clawd/logs/agent-self-claim-loop-%i.log
+
+[Install]
+WantedBy=default.target

--- a/scripts/install_self_claim_loop.sh
+++ b/scripts/install_self_claim_loop.sh
@@ -17,6 +17,7 @@ TEMPLATE_DST="$UNIT_DIR/agent-self-claim-loop@.service"
 CALLSIGNS=("elliot" "aiden" "max" "atlas" "orion" "scout")
 
 install -d -m 0755 "$UNIT_DIR"
+install -d -m 0755 "/home/elliotbot/clawd/logs"
 install -m 0644 "$TEMPLATE_SRC" "$TEMPLATE_DST"
 
 systemctl --user daemon-reload

--- a/scripts/install_self_claim_loop.sh
+++ b/scripts/install_self_claim_loop.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Install + enable the agent self-claim loop (KEI-92 / Linear KEI-130) as
+# per-callsign systemd instances. Idempotent. Six callsigns: elliot, aiden,
+# max, atlas, orion, scout. Each runs agent-self-claim-loop@.service with
+# CALLSIGN=%i.
+#
+# Names the template unit explicitly so the KEI-108 anti-false-complete gate
+# (grep for agent-self-claim-loop@.service in this file) matches.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE_SRC="$REPO_ROOT/infra/systemd/agents/agent-self-claim-loop@.service"
+UNIT_DIR="$HOME/.config/systemd/user"
+TEMPLATE_DST="$UNIT_DIR/agent-self-claim-loop@.service"
+
+CALLSIGNS=("elliot" "aiden" "max" "atlas" "orion" "scout")
+
+install -d -m 0755 "$UNIT_DIR"
+install -m 0644 "$TEMPLATE_SRC" "$TEMPLATE_DST"
+
+systemctl --user daemon-reload
+
+for cs in "${CALLSIGNS[@]}"; do
+  systemctl --user enable "agent-self-claim-loop@${cs}.service" >/dev/null
+  systemctl --user restart "agent-self-claim-loop@${cs}.service"
+  echo "[install] agent-self-claim-loop@${cs}.service installed + active"
+done
+
+echo "--- post-install state ---"
+for cs in "${CALLSIGNS[@]}"; do
+  systemctl --user is-active "agent-self-claim-loop@${cs}.service" || true
+done

--- a/scripts/orchestrator/agent_self_claim_loop.sh
+++ b/scripts/orchestrator/agent_self_claim_loop.sh
@@ -23,8 +23,13 @@
 set -euo pipefail
 
 POLL_SECONDS="${POLL_SECONDS:-60}"
+# Emit [DEGRADED:callsign tg=bd_down] after this many consecutive non-eligible
+# non-claimed ticks where the underlying bd binary returned an unusable
+# response. Keeps the agent observably-failing instead of silently-running
+# (Gate 4 outcome-counter alignment).
+DEGRADED_AFTER="${DEGRADED_AFTER:-5}"
 CALLSIGN_ARG=""
-while [ $# -gt 0 ]; do
+while [[ $# -gt 0 ]]; do
   case "$1" in
     --callsign) CALLSIGN_ARG="$2"; shift 2;;
     --poll-seconds) POLL_SECONDS="$2"; shift 2;;
@@ -32,13 +37,15 @@ while [ $# -gt 0 ]; do
   esac
 done
 CALLSIGN="${CALLSIGN_ARG:-${CALLSIGN:-}}"
-[ -n "$CALLSIGN" ] || { echo "[self-claim-loop] CALLSIGN not set" >&2; exit 2; }
+[[ -n "$CALLSIGN" ]] || { echo "[self-claim-loop] CALLSIGN not set" >&2; exit 2; }
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # ASSIGN_PATH override lets tests inject a stub self_assign_on_ready.py.
 ASSIGN="${ASSIGN_PATH:-$REPO_ROOT/scripts/orchestrator/self_assign_on_ready.py}"
 TG_BIN="$(command -v tg || true)"
 READY_POSTED=0
+DEGRADED_POSTED=0
+DEGRADED_STREAK=0
 
 while true; do
   result=$(python3 "$ASSIGN" --callsign "$CALLSIGN" 2>/dev/null || echo '{"claimed":false,"reason":"exception"}')
@@ -48,14 +55,24 @@ while true; do
       issue=$(echo "$result" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("issue_id",""))')
       echo "[self-claim-loop:$CALLSIGN] claimed $issue"
       READY_POSTED=0
+      DEGRADED_POSTED=0
+      DEGRADED_STREAK=0
       ;;
     no_eligible_work)
-      if [ "$READY_POSTED" = "0" ] && [ -n "$TG_BIN" ]; then
+      if [[ "$READY_POSTED" = "0" && -n "$TG_BIN" ]]; then
         CALLSIGN="$CALLSIGN" "$TG_BIN" "[READY:$CALLSIGN]" >/dev/null 2>&1 || true
         READY_POSTED=1
       fi
+      DEGRADED_STREAK=0
       ;;
-    race_lost_all|bd_unavailable|invalid_callsign|exception|*)
+    bd_unavailable|exception)
+      DEGRADED_STREAK=$((DEGRADED_STREAK + 1))
+      if [[ "$DEGRADED_STREAK" -ge "$DEGRADED_AFTER" && "$DEGRADED_POSTED" = "0" && -n "$TG_BIN" ]]; then
+        CALLSIGN="$CALLSIGN" "$TG_BIN" "[DEGRADED:$CALLSIGN tg=bd_down]" >/dev/null 2>&1 || true
+        DEGRADED_POSTED=1
+      fi
+      ;;
+    race_lost_all|invalid_callsign|*)
       ;;
   esac
   sleep "$POLL_SECONDS"

--- a/scripts/orchestrator/agent_self_claim_loop.sh
+++ b/scripts/orchestrator/agent_self_claim_loop.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# agent_self_claim_loop.sh — KEI-92 / Linear KEI-130 self-claim daemon.
+#
+# Per-agent loop that closes the idle-loop bleed by polling the phase-gated
+# queue and auto-claiming eligible work. Replaces "post READY and wait for
+# Elliot dispatch" with self-service: phase-lock (KEI-86) already restricts
+# what's eligible, so orchestrator permission is redundant.
+#
+# Loop steps per Linear KEI-92 spec:
+#   1. bd ready → eligible KEIs
+#   2. items? → bd claim --callsign=$CALLSIGN (no --id → next available) → log
+#   3. zero items? → post [READY:callsign] ONCE → sleep $POLL_SECONDS → retry
+#   4. claim race-lost (rc != 0)? → retry from step 1 without re-posting READY
+#
+# Linear pre-assignment (Elliot override): a KEI assigned to a different
+# callsign in Linear is silently skipped via self_assign_on_ready.py's existing
+# "unassigned OR assignee == callsign" filter. No extra wiring here.
+#
+# Usage:
+#   agent_self_claim_loop.sh --callsign <name> [--poll-seconds 60]
+# Env fallback: CALLSIGN.
+
+set -euo pipefail
+
+POLL_SECONDS="${POLL_SECONDS:-60}"
+CALLSIGN_ARG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --callsign) CALLSIGN_ARG="$2"; shift 2;;
+    --poll-seconds) POLL_SECONDS="$2"; shift 2;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+CALLSIGN="${CALLSIGN_ARG:-${CALLSIGN:-}}"
+[ -n "$CALLSIGN" ] || { echo "[self-claim-loop] CALLSIGN not set" >&2; exit 2; }
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# ASSIGN_PATH override lets tests inject a stub self_assign_on_ready.py.
+ASSIGN="${ASSIGN_PATH:-$REPO_ROOT/scripts/orchestrator/self_assign_on_ready.py}"
+TG_BIN="$(command -v tg || true)"
+READY_POSTED=0
+
+while true; do
+  result=$(python3 "$ASSIGN" --callsign "$CALLSIGN" 2>/dev/null || echo '{"claimed":false,"reason":"exception"}')
+  reason=$(echo "$result" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("reason",""))' 2>/dev/null || echo "")
+  case "$reason" in
+    claimed)
+      issue=$(echo "$result" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("issue_id",""))')
+      echo "[self-claim-loop:$CALLSIGN] claimed $issue"
+      READY_POSTED=0
+      ;;
+    no_eligible_work)
+      if [ "$READY_POSTED" = "0" ] && [ -n "$TG_BIN" ]; then
+        CALLSIGN="$CALLSIGN" "$TG_BIN" "[READY:$CALLSIGN]" >/dev/null 2>&1 || true
+        READY_POSTED=1
+      fi
+      ;;
+    race_lost_all|bd_unavailable|invalid_callsign|exception|*)
+      ;;
+  esac
+  sleep "$POLL_SECONDS"
+done

--- a/tests/orchestrator/test_agent_self_claim_loop.py
+++ b/tests/orchestrator/test_agent_self_claim_loop.py
@@ -1,0 +1,91 @@
+"""Tests for scripts/orchestrator/agent_self_claim_loop.sh — KEI-92.
+
+Strategy:
+  - Provide a stub `self_assign_on_ready.py` that returns canned JSON.
+  - Stub `tg` via a temp PATH dir (logs to a file we can read).
+  - Redirect bash stdout to a file before kill so buffered lines survive.
+  - Run the loop with --poll-seconds=1, kill after a few seconds, inspect.
+
+Covers:
+  - reason=claimed → logs `claimed <id>` line + resets READY_POSTED
+  - reason=no_eligible_work → posts [READY:<callsign>] ONCE per idle streak
+  - missing CALLSIGN → exits 2 with diagnostic
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LOOP = REPO_ROOT / "scripts" / "orchestrator" / "agent_self_claim_loop.sh"
+
+
+def _make_stub(tmp: Path, json_out: str) -> Path:
+    stub_dir = tmp / "scripts" / "orchestrator"
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    target = stub_dir / "self_assign_on_ready.py"
+    target.write_text(f"#!/usr/bin/env python3\nprint({json_out!r})\n")
+    target.chmod(0o755)
+    return target
+
+
+def test_missing_callsign_exits_2():
+    env = {**os.environ, "CALLSIGN": ""}
+    proc = subprocess.run(
+        ["bash", str(LOOP)], env=env, capture_output=True, text=True, timeout=3, check=False
+    )
+    assert proc.returncode == 2
+    assert "CALLSIGN not set" in proc.stderr
+
+
+def _run_loop(tmp: Path, stub_json: str, callsign: str = "scout", seconds: float = 3.0) -> str:
+    _make_stub(tmp, stub_json)
+    fake_tg = tmp / "tg"
+    tg_log = tmp / "tg.log"
+    fake_tg.write_text(f'#!/usr/bin/env bash\necho "TG: $*" >> {tg_log}\n')
+    fake_tg.chmod(0o755)
+    stub_path = tmp / "scripts" / "orchestrator" / "self_assign_on_ready.py"
+    env = {
+        **os.environ,
+        "CALLSIGN": callsign,
+        "PATH": f"{tmp}:{os.environ.get('PATH', '')}",
+        "POLL_SECONDS": "1",
+        "ASSIGN_PATH": str(stub_path),
+    }
+    out_path = tmp / "loop.out"
+    with out_path.open("w") as out_f:
+        proc = subprocess.Popen(
+            ["bash", str(LOOP), "--callsign", callsign, "--poll-seconds", "1"],
+            env=env,
+            cwd=str(tmp),
+            stdout=out_f,
+            stderr=subprocess.STDOUT,
+            preexec_fn=os.setsid,
+        )
+        try:
+            proc.wait(timeout=seconds)
+        except subprocess.TimeoutExpired:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    return out_path.read_text()
+
+
+def test_claimed_path_logs_issue_id(tmp_path):
+    out = _run_loop(tmp_path, '{"claimed": true, "reason": "claimed", "issue_id": "KEI-XYZ"}')
+    assert "[self-claim-loop:scout] claimed KEI-XYZ" in out
+
+
+def test_no_eligible_posts_ready_once(tmp_path):
+    _run_loop(
+        tmp_path,
+        '{"claimed": false, "reason": "no_eligible_work", "issue_id": null}',
+        seconds=4.0,
+    )
+    log = (tmp_path / "tg.log").read_text() if (tmp_path / "tg.log").exists() else ""
+    assert log.count("[READY:scout]") == 1, f"expected 1 READY, got: {log!r}"


### PR DESCRIPTION
## Summary

Linear KEI-92 (P1 Urgent) — close the idle-loop bleed Dave called out in KEI-130. Agents now auto-claim eligible work from the phase-gated queue instead of posting `[READY:callsign]` and waiting on Elliot to dispatch. Phase-lock (KEI-86) already restricts what's eligible; orchestrator permission was redundant.

## Loop semantics (per Linear KEI-92 spec)

1. `bd ready` → list eligible KEIs (phase-filtered post-KEI-86)
2. items? → `bd claim --callsign=$CALLSIGN` (no `--id` → next available) → log `claimed <id>` + reset READY flag
3. zero items? → post `[READY:callsign]` ONCE → sleep `$POLL_SECONDS` (default 60) → retry
4. claim race-lost? → retry from step 1 without re-posting READY (handled by `self_assign_on_ready.py`'s existing retry policy)

Elliot override path preserved: `self_assign_on_ready.py` already filters `unassigned OR assignee == callsign`, so a Linear-assignee pre-assignment is silently skipped by other agents.

## What ships

| File | Purpose |
|---|---|
| `scripts/orchestrator/agent_self_claim_loop.sh` | The loop. Thin wrapper over `self_assign_on_ready.py`. `ASSIGN_PATH` env override lets tests inject stubs. |
| `infra/systemd/agents/agent-self-claim-loop@.service` | Templated unit (one file, six instances via `%i`). Restart=always. |
| `scripts/install_self_claim_loop.sh` | Idempotent installer — installs template into `~/.config/systemd/user/`, daemon-reload, enables + restarts all 6 instances (`elliot`/`aiden`/`max`/`atlas`/`orion`/`scout`). |
| `tests/orchestrator/test_agent_self_claim_loop.py` | 3 tests — CALLSIGN-required, claimed-path-log, READY-posted-once-per-idle-streak. |

## Verbatim test evidence

```
$ python3 -m pytest tests/orchestrator/test_agent_self_claim_loop.py -v
test_missing_callsign_exits_2 PASSED
test_claimed_path_logs_issue_id PASSED
test_no_eligible_posts_ready_once PASSED
3 passed in 7.08s

$ ruff check + ruff format --check tests/orchestrator/test_agent_self_claim_loop.py
All checks passed!
1 file already formatted

$ BASE_REF=main bash scripts/ci/check_operational_deployment.sh
(exit=0 — install_self_claim_loop.sh references agent-self-claim-loop@.service by literal name 4×, KEI-108 gate satisfied)
```

## Acceptance criteria (Linear KEI-92)

- [x] Per-agent READY-loop script implements the 4-step loop
- [x] Template systemd unit + installer for the 6 agent session configurations
- [x] Acceptance test 1 (synthetic Phase-0 claim) — covered by `test_claimed_path_logs_issue_id`
- [x] Acceptance test 2 (zero eligible → READY once, no spam) — covered by `test_no_eligible_posts_ready_once`
- [x] Acceptance test 3 (phase-lock interaction — Tier-2 invisible) — already covered by KEI-86 tests; this loop inherits the filter via `bd ready`
- [x] Elliot override (Linear assignee pre-assignment skipped by other agents) — preserved by `self_assign_on_ready.py` existing filter (no change needed)
- [x] KEI-108 anti-false-complete gate PASS — installer references unit by literal name

## Scope OUT

- Linear-assignee → callsign mapping path beyond what `self_assign_on_ready.py` already does (live MCP query per cycle if needed — defer to follow-up if pre-assignment proves insufficient in practice).
- Changes to `bd` binary or `tasks_cli.py` (unchanged from KEI-86 phase-lock shape).
- Operational install on prod (separate Dave-gated step; this PR ships the artifacts).

## Pairing

Max + Scout per Linear KEI-92. Scout's session-start wiring across 6 callsigns is the operational follow-up after merge.

Closes Linear KEI-92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)