### PR TITLE
[AIDEN] fix(deploy): pydantic[email] — email-validator extras to unblock Railway boot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 fastapi>=0.109.0
 uvicorn>=0.27.0
 python-multipart>=0.0.6  # Required for form data parsing
-pydantic>=2.5.0
+pydantic[email]>=2.5.0  # [email] pulls email-validator — required by EmailStr at src/api/main.py:399
 pydantic-settings>=2.1.0
 python-dotenv>=1.0.0
 


### PR DESCRIPTION
## Summary

EMERGENCY UNBLOCK — Railway agency-os service has been failing to deploy for ~17min (5 deploys in a row, including PR #917/#919/#920 merges) because of a missing `email-validator` pip dependency. All today's main-branch work is sitting unmerged-to-production.

## Verbatim Railway log

Deploy `f5fdbe9d` (PR #919 merge, status=FAILED):

```
File "/app/src/api/main.py", line 399, in <module>
File ".../pydantic/networks.py", line 968, in import_email_validator
    raise ImportError("email-validator is not installed,
        run pip install 'pydantic[email]'") from e
ImportError: email-validator is not installed
```

## Fix

One-line change: `pydantic>=2.5.0` → `pydantic[email]>=2.5.0` in requirements.txt. The `[email]` extras pull `email-validator` (and `dnspython`) transitively.

## Why this matters

Net consequence of the deploy failures:
- KEI-86 phase-lock — code merged, NOT running on Railway
- KEI-91 Gate 4 heartbeat — code merged, NOT running on Railway
- KEI-92 self-claim loop — code merged, NOT running on Railway
- KEI-84 ID alignment, KEI-99 relay watcher, etc. — same

That's why `/api/webhooks/linear` returns HTTP 404 (route not registered — old deploy doesn't have it) and Linear→Supabase UPDATE propagation has been stuck. Fix 2 root cause.

Once this PR deploys, ALL today's work activates simultaneously.

## Test plan
- [x] One-line requirements.txt change verified
- [ ] CI green (ruff/mypy/pytest/Sonar/KEI-108 gate)
- [ ] Post-merge: Railway deploy succeeds (status=SUCCESS)
- [ ] Post-merge: `curl POST .../api/webhooks/linear/` returns 401 (HMAC enforced) not 404
- [ ] Post-merge: Linear KEI status flip → Supabase reflects within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)