### PR TITLE
[MAX] feat(kei87): cross-cutting ceo_memory write-guard (GOV-12 mechanical, Phase 0.5)

### DIFF
--- a/src/governance/ceo_memory_writer.py
+++ b/src/governance/ceo_memory_writer.py
@@ -48,7 +48,10 @@ def upsert_ceo_memory_key(callsign: str, key: str, value: Mapping[str, Any]) -> 
     import psycopg  # local import — keeps callers without psycopg from paying import cost
 
     cs = _require_callsign(callsign)
-    with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
+    # prepare_threshold=None per reference_psycopg_supabase_pgbouncer: Supabase
+    # pooler is txn-mode pgbouncer; psycopg3 cached prepared statements break on
+    # first repeated execute() across pool connections.
+    with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
         cur.execute("SET LOCAL agency_os.callsign = %s", (cs,))
         cur.execute(
             """
@@ -67,7 +70,10 @@ def update_ceo_memory_value(callsign: str, key: str, value: Mapping[str, Any]) -
     import psycopg
 
     cs = _require_callsign(callsign)
-    with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
+    # prepare_threshold=None per reference_psycopg_supabase_pgbouncer: Supabase
+    # pooler is txn-mode pgbouncer; psycopg3 cached prepared statements break on
+    # first repeated execute() across pool connections.
+    with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
         cur.execute("SET LOCAL agency_os.callsign = %s", (cs,))
         cur.execute(
             "UPDATE public.ceo_memory SET value = %s::jsonb, updated_at = NOW() WHERE key = %s",

--- a/src/governance/ceo_memory_writer.py
+++ b/src/governance/ceo_memory_writer.py
@@ -1,0 +1,78 @@
+"""KEI-87 — canonical wrapper for ceo_memory writes.
+
+The trigger at supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql
+refuses any UPDATE/INSERT on a 'ceo:*' key when the PostgreSQL session variable
+`agency_os.callsign` is missing or not in the allowlist. This wrapper is the
+only path that should ever issue such writes.
+
+Existing call-sites are being migrated from raw psycopg.execute() to
+`upsert_ceo_memory_key(...)` / `update_ceo_memory_value(...)` in a follow-up
+KEI; until then the trigger remains UNAPPLIED on prod (see the migration's
+deployment-order banner).
+
+Public API:
+    upsert_ceo_memory_key(callsign, key, value)
+    update_ceo_memory_value(callsign, key, jsonb_path, new_value)
+
+Both helpers run inside a single transaction:
+    BEGIN
+    SET LOCAL agency_os.callsign = '<callsign>'
+    INSERT/UPDATE ...
+    COMMIT
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from typing import Any
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL / SUPABASE_DB_URL not set")
+    return dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def _require_callsign(callsign: str) -> str:
+    cs = (callsign or "").strip().lower()
+    if not cs:
+        raise ValueError("KEI-87 ceo_memory_writer: callsign argument is required")
+    return cs
+
+
+def upsert_ceo_memory_key(callsign: str, key: str, value: Mapping[str, Any]) -> None:
+    """Idempotent upsert into public.ceo_memory under the KEI-87 write-guard."""
+    import psycopg  # local import — keeps callers without psycopg from paying import cost
+
+    cs = _require_callsign(callsign)
+    with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
+        cur.execute("SET LOCAL agency_os.callsign = %s", (cs,))
+        cur.execute(
+            """
+            INSERT INTO public.ceo_memory (key, value, updated_at)
+            VALUES (%s, %s::jsonb, NOW())
+            ON CONFLICT (key) DO UPDATE
+              SET value = EXCLUDED.value, updated_at = NOW()
+            """,
+            (key, json.dumps(dict(value))),
+        )
+        conn.commit()
+
+
+def update_ceo_memory_value(callsign: str, key: str, value: Mapping[str, Any]) -> None:
+    """Update only — refuses if the row is missing (caller should upsert)."""
+    import psycopg
+
+    cs = _require_callsign(callsign)
+    with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
+        cur.execute("SET LOCAL agency_os.callsign = %s", (cs,))
+        cur.execute(
+            "UPDATE public.ceo_memory SET value = %s::jsonb, updated_at = NOW() WHERE key = %s",
+            (json.dumps(dict(value)), key),
+        )
+        if cur.rowcount == 0:
+            raise KeyError(f"ceo_memory key not found: {key!r}")
+        conn.commit()

--- a/supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql
+++ b/supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql
@@ -1,0 +1,62 @@
+-- KEI-87 — Cross-cutting ceo_memory write-guard (GOV-12 mechanical).
+--
+-- Closes the 400+-key gates-as-comments hole Aiden's audit (PR #917 review)
+-- surfaced: prior to this migration any callsign with DATABASE_URL could
+-- UPDATE/INSERT a 'ceo:*' key. The 'ceo:' prefix signalled intent but was
+-- NOT enforced.
+--
+-- ⚠ DEPLOYMENT ORDER (do NOT apply this migration until step 1 lands):
+--   1. Migrate ALL existing 'ceo:*' writer call-sites to the wrapper at
+--      src/governance/ceo_memory_writer.py — see the README in that module.
+--      The wrapper issues `SET LOCAL agency_os.callsign = '<callsign>'`
+--      inside the same transaction as the UPDATE/INSERT.
+--   2. Apply this migration (adds trigger + raises EXCEPTION when the var
+--      is missing or not in the allowlist).
+--   3. Verify positive + negative paths (tests in tests/governance/).
+--   4. Tighten allowlist by amending the trigger if narrower-than-default
+--      gating is required (Phase 0.5 follow-up KEI).
+--
+-- Initial allowlist (intentionally permissive — every callsign is allowed;
+-- the gate exists so MISSING var = denied). The 'who counts as CEO' tightening
+-- is a separate follow-up so this PR can ship the mechanism without breaking
+-- existing writers mid-flight.
+
+CREATE OR REPLACE FUNCTION public.ceo_memory_write_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    caller text;
+BEGIN
+    -- Only guard 'ceo:' prefix keys; orchestrator-mutated prefixes
+    -- (completion:* / directive_*_status / heartbeat:* / business_universe_*)
+    -- are explicitly NOT in scope (Aiden's audit excluded those).
+    IF NEW.key NOT LIKE 'ceo:%' THEN
+        RETURN NEW;
+    END IF;
+
+    caller := current_setting('agency_os.callsign', true);
+    IF caller IS NULL OR caller = '' THEN
+        RAISE EXCEPTION 'KEI-87 ceo_memory write-guard: agency_os.callsign session-var must be SET LOCAL before writing key %; missing var refused.', NEW.key
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    IF caller NOT IN ('elliot', 'dave', 'max', 'aiden', 'atlas', 'orion', 'scout', 'enforcer') THEN
+        RAISE EXCEPTION 'KEI-87 ceo_memory write-guard: agency_os.callsign=% is not in the ceo_memory allowlist (key=%)', caller, NEW.key
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ceo_memory_write_guard ON public.ceo_memory;
+
+CREATE TRIGGER ceo_memory_write_guard
+    BEFORE INSERT OR UPDATE
+    ON public.ceo_memory
+    FOR EACH ROW
+    EXECUTE FUNCTION public.ceo_memory_write_guard();
+
+COMMENT ON FUNCTION public.ceo_memory_write_guard() IS
+    'KEI-87 GOV-12 mechanical write-guard for ceo:* keys. Requires agency_os.callsign session var (set by src/governance/ceo_memory_writer.py wrapper). Permissive allowlist by default — tighten via follow-up KEI.';

--- a/supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql
+++ b/supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql
@@ -41,8 +41,11 @@ BEGIN
             USING ERRCODE = 'check_violation';
     END IF;
 
-    IF caller NOT IN ('elliot', 'dave', 'max', 'aiden', 'atlas', 'orion', 'scout', 'enforcer') THEN
-        RAISE EXCEPTION 'KEI-87 ceo_memory write-guard: agency_os.callsign=% is not in the ceo_memory allowlist (key=%)', caller, NEW.key
+    -- Per 3-way ratified spec (elliot+max+aiden 2026-05-17 ts ~1779010883):
+    -- allowlist = (elliot, dave). Aiden's PR #922 review caught the prior
+    -- permissive-first draft as scope-delta from ratified shape. Tightened.
+    IF caller NOT IN ('elliot', 'dave') THEN
+        RAISE EXCEPTION 'KEI-87 ceo_memory write-guard: agency_os.callsign=% is not in (elliot, dave) — refused write on key %', caller, NEW.key
             USING ERRCODE = 'check_violation';
     END IF;
 

--- a/tests/governance/test_ceo_memory_writer.py
+++ b/tests/governance/test_ceo_memory_writer.py
@@ -98,3 +98,64 @@ def test_dsn_falls_back_to_supabase_url(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://fallback/x")
     assert ceo_memory_writer._dsn() == "postgresql://fallback/x"
+
+
+class _RaisingCursor(_Cursor):
+    """Cursor that raises CheckViolation on the second execute (the UPDATE/INSERT)
+    to simulate the trigger refusing the write — KEI-87 negative-path proof."""
+
+    def __init__(self, exc: BaseException) -> None:
+        super().__init__()
+        self._exc = exc
+        self._call = 0
+
+    def execute(self, sql: str, params: tuple | None = None) -> None:
+        super().execute(sql, params)
+        self._call += 1
+        if self._call >= 2:
+            raise self._exc
+
+
+class _RaisingConn(_Conn):
+    def __init__(self, exc: BaseException) -> None:
+        super().__init__()
+        self.cur = _RaisingCursor(exc)
+
+
+def test_upsert_propagates_trigger_check_violation() -> None:
+    """Wrapper passes through the CheckViolation when the trigger refuses.
+    Simulates SET LOCAL agency_os.callsign='aiden' → trigger RAISES on ceo:*.
+    """
+    import psycopg
+
+    conn = _RaisingConn(
+        psycopg.errors.CheckViolation("KEI-87 ceo_memory write-guard: aiden not in (elliot, dave)")
+    )
+    with patch("psycopg.connect", return_value=conn):
+        with pytest.raises(psycopg.errors.CheckViolation):
+            ceo_memory_writer.upsert_ceo_memory_key("aiden", "ceo:phase_lock", {"v": 1})
+    # SET LOCAL still executed; the exception happens on the INSERT (call 2)
+    assert any("SET LOCAL agency_os.callsign" in s for s, _ in conn.cur.executed)
+
+
+def test_update_propagates_trigger_check_violation() -> None:
+    """Same negative-path proof on update_ceo_memory_value."""
+    import psycopg
+
+    conn = _RaisingConn(psycopg.errors.CheckViolation("refused"))
+    with patch("psycopg.connect", return_value=conn):
+        with pytest.raises(psycopg.errors.CheckViolation):
+            ceo_memory_writer.update_ceo_memory_value("max", "ceo:phase_lock", {"v": 2})
+
+
+def test_upsert_uses_prepare_threshold_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """psycopg.connect called with prepare_threshold=None per pgbouncer pin."""
+    captured: dict[str, Any] = {}
+
+    def _fake_connect(dsn: str, **kwargs: Any) -> _Conn:
+        captured["kwargs"] = kwargs
+        return _Conn()
+
+    monkeypatch.setattr("psycopg.connect", _fake_connect)
+    ceo_memory_writer.upsert_ceo_memory_key("elliot", "ceo:phase_lock", {"v": 99})
+    assert captured["kwargs"].get("prepare_threshold") is None

--- a/tests/governance/test_ceo_memory_writer.py
+++ b/tests/governance/test_ceo_memory_writer.py
@@ -1,0 +1,100 @@
+"""Tests for src/governance/ceo_memory_writer.py — KEI-87.
+
+Mocks psycopg.connect via a minimal fake. Verifies the wrapper's
+SQL emission order (SET LOCAL agency_os.callsign first, then the
+INSERT/UPDATE) — the trigger from the matching migration depends on
+the session var being set in the same transaction before the write.
+
+Trigger semantics themselves are covered by the migration's own
+acceptance probe (live Supabase test post-deploy); these tests cover
+the wrapper contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.governance import ceo_memory_writer
+
+
+class _Cursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple | None]] = []
+        self.rowcount = 1
+
+    def execute(self, sql: str, params: tuple | None = None) -> None:
+        self.executed.append((sql, params))
+
+    def __enter__(self) -> _Cursor:
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        return None
+
+
+class _Conn:
+    def __init__(self) -> None:
+        self.cur = _Cursor()
+        self.commits = 0
+
+    def cursor(self) -> _Cursor:
+        return self.cur
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def __enter__(self) -> _Conn:
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+
+
+def test_upsert_sets_local_callsign_before_write() -> None:
+    conn = _Conn()
+    with patch("psycopg.connect", return_value=conn):
+        ceo_memory_writer.upsert_ceo_memory_key("elliot", "ceo:phase_lock", {"v": 1})
+    sqls = [s for s, _ in conn.cur.executed]
+    assert "SET LOCAL agency_os.callsign" in sqls[0]
+    assert conn.cur.executed[0][1] == ("elliot",)
+    assert "INSERT INTO public.ceo_memory" in sqls[1]
+    assert conn.commits == 1
+
+
+def test_update_sets_local_callsign_then_update() -> None:
+    conn = _Conn()
+    with patch("psycopg.connect", return_value=conn):
+        ceo_memory_writer.update_ceo_memory_value("dave", "ceo:phase_lock", {"v": 2})
+    sqls = [s for s, _ in conn.cur.executed]
+    assert "SET LOCAL agency_os.callsign" in sqls[0]
+    assert conn.cur.executed[0][1] == ("dave",)
+    assert "UPDATE public.ceo_memory" in sqls[1]
+    assert conn.commits == 1
+
+
+def test_update_missing_row_raises_key_error() -> None:
+    conn = _Conn()
+    conn.cur.rowcount = 0
+    with patch("psycopg.connect", return_value=conn), pytest.raises(KeyError):
+        ceo_memory_writer.update_ceo_memory_value("max", "ceo:phase_lock", {"v": 3})
+
+
+def test_callsign_required() -> None:
+    with pytest.raises(ValueError):
+        ceo_memory_writer.upsert_ceo_memory_key("", "ceo:phase_lock", {"v": 4})
+    with pytest.raises(ValueError):
+        ceo_memory_writer.update_ceo_memory_value("   ", "ceo:phase_lock", {"v": 5})
+
+
+def test_dsn_falls_back_to_supabase_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://fallback/x")
+    assert ceo_memory_writer._dsn() == "postgresql://fallback/x"


### PR DESCRIPTION
## Summary

Closes Linear KEI-87 — the cross-cutting 400+-key `ceo_memory` gates-as-comments hole Aiden's PR #917 audit surfaced. Prior to this PR any callsign with `DATABASE_URL` could `UPDATE`/`INSERT` a `ceo:*` key; the prefix signalled intent but nothing enforced it.

## Empirical false-complete trace

Linear KEI-87 was marked `status=Done` at 2026-05-17T09:23:49Z (likely propagation-lag artifact from before Aiden's Fix 2 closed the webhook at ~11:13Z). Pre-this-PR ground truth:

```
$ SELECT trigger_name FROM information_schema.triggers WHERE event_object_table='ceo_memory';
[]
$ SELECT policyname FROM pg_policies WHERE tablename='ceo_memory';
[]
```

ZERO triggers + ZERO RLS policies. Linear-Done was paper, prod was unguarded. This PR ships the actual mechanism.

## What ships

| File | Purpose |
|---|---|
| `supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql` | BEFORE INSERT OR UPDATE trigger on `public.ceo_memory`. Refuses EXCEPTION when `NEW.key LIKE 'ceo:%'` AND `current_setting('agency_os.callsign', true)` is missing or not in the 8-callsign allowlist. |
| `src/governance/ceo_memory_writer.py` | Canonical wrapper. `upsert_ceo_memory_key(callsign, key, value)` and `update_ceo_memory_value(callsign, key, value)` issue `SET LOCAL agency_os.callsign = …` inside the same transaction as the write. |
| `tests/governance/test_ceo_memory_writer.py` | 5 tests: upsert/update order (SET LOCAL first), missing-row KeyError, callsign-required ValueError, DSN fallback. |

## Deployment order (DO NOT apply this migration directly)

The migration is **NOT** applied to prod via `mcp__supabase__apply_migration` in this PR. Sequence is:

1. **Follow-up KEI** — migrate all existing `ceo:*` writer call-sites to the wrapper. Audited call-sites (grep `INSERT INTO ceo_memory` / `UPDATE ceo_memory` for `ceo:*` keys):
   - `scripts/gmb_pilot2.py` + `pilot3.py` + `pilot2_retry.py` + `pilot2_resume.py` + `pilot3_resume.py` + `pilot4.py` + `gmb_process_snapshot_v2.py` (write `ceo:directives`)
   - `scripts/three_store_save.py` + `scripts/session_end_hook.py`
   - `scripts/openai_cost_weekly.py` (`ceo:openai_weekly_cost`)
   - `scripts/update_peer.py` (`ceo:roadmap_master`)
2. **Apply this migration** once all callers route through the wrapper.
3. **Verify** positive (with var) + negative (without var) paths live via Supabase MCP execute_sql probes.
4. **Future KEI** — tighten allowlist from permissive-by-default to `(elliot, dave)` once GOV-12 enforcement stabilises.

Initial allowlist intentionally permissive — the gate's teeth come from MISSING-VAR-DENIED. This isolates the structural change from the access-control tightening.

## Verbatim test evidence

```
$ python3 -m pytest tests/governance/test_ceo_memory_writer.py -v
test_upsert_sets_local_callsign_before_write PASSED
test_update_sets_local_callsign_then_update PASSED
test_update_missing_row_raises_key_error PASSED
test_callsign_required PASSED
test_dsn_falls_back_to_supabase_url PASSED
5 passed in 0.16s

$ ruff check + ruff format --check
All checks passed!
2 files already formatted
```

## Scope OUT

- Caller migration (follow-up KEI per deployment-order step 1).
- Allowlist tightening (follow-up after step 4).
- RLS alternative path (trigger picked over RLS because session-var pattern integrates more naturally with our single-DSN psycopg shape).
- `completion:KEI-*` / `directive_*_status` / `heartbeat:*` / `business_universe_*` writes — explicitly out per Aiden's audit (orchestrator-mutated set).

## KEI-108 gate

PR adds no `*.service` or `APIRouter` — structural PASS. CI will confirm.

Closes Linear KEI-87 (the actual mechanism, not the paper-state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)