### PR TITLE
[ATLAS] feat(kei85): phase C — git_commits_indexer (git commits → Codebase)

### DIFF
--- a/infra/systemd/agents/git-commits-indexer.service
+++ b/infra/systemd/agents/git-commits-indexer.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Agency OS — git commits → Weaviate Codebase indexer (KEI-85 phase C)
+Documentation=https://linear.app/keiracom/issue/KEI-85
+After=network-online.target weaviate.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+Environment=PYTHONPATH=/home/elliotbot/clawd/Agency_OS/scripts/orchestrator
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/git_commits_indexer.py
+Restart=on-failure
+RestartSec=15
+StandardOutput=append:/home/elliotbot/clawd/logs/git-commits-indexer.log
+StandardError=append:/home/elliotbot/clawd/logs/git-commits-indexer.log
+# KEI-44 cgroup pattern — small worker footprint (git subprocess + JSON only).
+MemoryMax=256M
+MemoryHigh=200M
+
+[Install]
+WantedBy=default.target

--- a/scripts/install_git_commits_indexer.sh
+++ b/scripts/install_git_commits_indexer.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# install_git_commits_indexer.sh — KEI-85 phase C install entry-point.
+#
+# KEI-108 CI-gate requirement: per-unit install wrapper anchors the literal
+# `git-commits-indexer.service` for the grep gate.
+#
+# Usage:
+#   scripts/install_git_commits_indexer.sh
+
+set -euo pipefail
+
+UNIT="git-commits-indexer"
+exec /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/install_indexer.sh "${UNIT}"
+
+# Anchored unit: git-commits-indexer.service

--- a/scripts/orchestrator/git_commits_indexer.py
+++ b/scripts/orchestrator/git_commits_indexer.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""git_commits_indexer.py — KEI-85 phase C: index git commits into Weaviate Codebase.
+
+Reads commits from the Agency_OS git history via `git log --since <cursor>`
+and POSTs one Weaviate Codebase object per commit SHA. Each commit captures
+message subject + body + author + commit timestamp + changed-files
+fingerprint so agents can `bd recall` what changed in the codebase and why.
+
+Inherits BaseIndexer[GitCommit] (the ABC contract from phases A/B). Convergent
+via deterministic UUID = uuid5("git", commit_sha) — repeated runs on the
+same commit are no-ops (Weaviate 422 idempotent path).
+
+Cursor: tracks the latest commit timestamp seen so far in a tiny on-disk
+JSON. Per-poll `git log --since=$cursor` keeps the work bounded.
+
+Usage:
+    python3 scripts/orchestrator/git_commits_indexer.py            # daemon
+    python3 scripts/orchestrator/git_commits_indexer.py --once     # one batch
+    python3 scripts/orchestrator/git_commits_indexer.py --batch=200
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from _heartbeat_shim import heartbeat_tick as _heartbeat_tick  # noqa: E402
+from indexer_base import (
+    BaseIndexer,
+    aggregate_count,
+    deterministic_uuid,
+)
+
+logger = logging.getLogger("git_commits_indexer")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+CODEBASE_CLASS = "Codebase"
+SOURCE_NAME = "git"
+EPOCH_ISO = "1970-01-01T00:00:00Z"
+POLL_SECONDS = int(os.environ.get("GIT_COMMITS_POLL_SECONDS", "300"))  # 5 min — commits are slow
+BATCH_SIZE_DEFAULT = int(os.environ.get("GIT_COMMITS_BATCH_SIZE", "200"))
+REPO_PATH = Path(os.environ.get("GIT_COMMITS_REPO_PATH", "/home/elliotbot/clawd/Agency_OS"))
+CURSOR_PATH = Path(
+    os.environ.get(
+        "GIT_COMMITS_CURSOR_PATH",
+        "/home/elliotbot/clawd/logs/git_commits_indexer.cursor",
+    )
+)
+
+CODEBASE_SCHEMA = {
+    "class": CODEBASE_CLASS,
+    "vectorizer": "none",
+    "properties": [
+        {"name": "raw_text", "dataType": ["text"]},
+        {"name": "environment_hash", "dataType": ["text"]},
+        {"name": "created_at", "dataType": ["date"]},
+        {"name": "agent", "dataType": ["text"]},
+        {"name": "kei", "dataType": ["text"]},
+    ],
+}
+
+# Single-record terminator. Field separator is \x1f (US). Record separator
+# is \x1e (RS). Both are control chars that won't appear in commit messages.
+_FIELD_SEP = "\x1f"
+_RECORD_SEP = "\x1e"
+_LOG_FORMAT = _FIELD_SEP.join(("%H", "%an", "%aI", "%s", "%b")) + _RECORD_SEP
+
+
+@dataclass(frozen=True)
+class GitCommit:
+    sha: str
+    author: str
+    committed_iso: str
+    subject: str
+    body: str
+
+
+_shutdown_requested = False
+
+
+def _signal_handler(signum: int, _frame: Any) -> None:
+    global _shutdown_requested
+    logger.info("signal %s received — shutdown", signum)
+    _shutdown_requested = True
+
+
+signal.signal(signal.SIGTERM, _signal_handler)
+signal.signal(signal.SIGINT, _signal_handler)
+
+
+def _read_cursor() -> str:
+    if not CURSOR_PATH.exists():
+        return EPOCH_ISO
+    try:
+        return json.loads(CURSOR_PATH.read_text()).get("committed_iso", EPOCH_ISO)
+    except (ValueError, OSError):
+        return EPOCH_ISO
+
+
+def _write_cursor(committed_iso: str) -> None:
+    try:
+        CURSOR_PATH.parent.mkdir(parents=True, exist_ok=True)
+        CURSOR_PATH.write_text(json.dumps({"committed_iso": committed_iso}))
+    except OSError as exc:
+        logger.warning("cursor persist failed (%s) — non-fatal", exc)
+
+
+def _git_log_since(cursor_iso: str, limit: int) -> list[GitCommit]:
+    """Invoke `git log --since=...` and parse output.
+
+    `--since` accepts ISO-8601. We pass the cursor verbatim; the first poll
+    with EPOCH_ISO returns the entire history (bounded by --max-count).
+    """
+    cmd = [
+        "git",
+        "-C",
+        str(REPO_PATH),
+        "log",
+        f"--max-count={limit}",
+        f"--since={cursor_iso}",
+        "--reverse",  # oldest-first so the cursor advances monotonically
+        f"--pretty=format:{_LOG_FORMAT}",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.warning("git log failed (%s) — empty batch", exc)
+        return []
+    if proc.returncode != 0:
+        logger.warning("git log exit=%d stderr=%s", proc.returncode, proc.stderr[:200])
+        return []
+    records = [r for r in proc.stdout.split(_RECORD_SEP) if r.strip()]
+    commits: list[GitCommit] = []
+    for rec in records:
+        parts = rec.split(_FIELD_SEP)
+        if len(parts) < 5:
+            continue
+        sha, author, committed_iso, subject, body = parts[0], parts[1], parts[2], parts[3], parts[4]
+        commits.append(
+            GitCommit(
+                sha=sha.strip(),
+                author=author.strip(),
+                committed_iso=committed_iso.strip(),
+                subject=subject.strip(),
+                body=body.strip(),
+            )
+        )
+    return commits
+
+
+class GitCommitsIndexer(BaseIndexer[GitCommit]):
+    """git → Codebase concrete indexer (KEI-85 phase C)."""
+
+    source_name = SOURCE_NAME
+    target_class = CODEBASE_CLASS
+    class_schema = CODEBASE_SCHEMA
+
+    def __init__(self) -> None:
+        self._last_max_committed_iso: str | None = None
+
+    def fetch_batch(self, batch_size: int) -> list[GitCommit]:
+        cursor = _read_cursor()
+        commits = _git_log_since(cursor, batch_size)
+        if commits:
+            self._last_max_committed_iso = max(c.committed_iso for c in commits if c.committed_iso)
+        return commits
+
+    def build_object(self, row: GitCommit) -> dict:
+        return build_codebase_doc(row)
+
+    def advance_cursor(self) -> None:
+        if self._last_max_committed_iso:
+            _write_cursor(self._last_max_committed_iso)
+
+
+def _extract_kei(text: str) -> str:
+    """Pull the first KEI-N reference from a commit message, if any.
+
+    Most commits in this repo are prefixed `[ATLAS] feat(kei91):` or contain
+    `KEI-NN` in the body. Mining this lets `bd recall <KEI>` find every
+    commit that touched a KEI without needing full-text search.
+    """
+    import re
+
+    m = re.search(r"\b[kK][eE][iI][-_]?(\d+)\b", text)
+    return f"KEI-{m.group(1)}" if m else ""
+
+
+def build_codebase_doc(commit: GitCommit) -> dict:
+    body = {
+        "sha": commit.sha,
+        "author": commit.author,
+        "committed_iso": commit.committed_iso,
+        "subject": commit.subject,
+        "body": commit.body,
+    }
+    raw_text = json.dumps(body, sort_keys=True, default=str)
+    env_hash = hashlib.sha256(raw_text.encode("utf-8")).hexdigest()[:16]
+    return {
+        "class": CODEBASE_CLASS,
+        "id": deterministic_uuid(SOURCE_NAME, commit.sha),
+        "properties": {
+            "raw_text": raw_text,
+            "environment_hash": env_hash,
+            "created_at": commit.committed_iso or EPOCH_ISO,
+            "agent": "system",
+            "kei": _extract_kei(commit.subject + " " + commit.body),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--batch", type=int, default=BATCH_SIZE_DEFAULT)
+    args = parser.parse_args()
+
+    indexer = GitCommitsIndexer()
+    indexer.ensure_target_class()
+    logger.info(
+        "indexer start source=%s class=%s batch=%d repo=%s",
+        SOURCE_NAME,
+        CODEBASE_CLASS,
+        args.batch,
+        REPO_PATH,
+    )
+
+    if args.once:
+        outcome = indexer.index_once(args.batch)
+        indexer.advance_cursor()
+        logger.info(
+            "once outcome=%s class_count=%s cursor=%s",
+            outcome.to_dict(),
+            aggregate_count(CODEBASE_CLASS),
+            _read_cursor(),
+        )
+        _heartbeat_tick(
+            "git-commits-indexer",
+            outcome_increment=outcome.success,
+            status="ok" if outcome.failed == 0 else "degraded",
+        )
+        return
+    while not _shutdown_requested:
+        try:
+            outcome = indexer.index_once(args.batch)
+            indexer.advance_cursor()
+            logger.info(
+                "batch outcome=%s class_count=%s cursor=%s",
+                outcome.to_dict(),
+                aggregate_count(CODEBASE_CLASS),
+                _read_cursor(),
+            )
+            _heartbeat_tick(
+                "git-commits-indexer",
+                outcome_increment=outcome.success,
+                status="ok" if outcome.failed == 0 else "degraded",
+            )
+        except Exception as exc:  # noqa: BLE001 — daemon must survive
+            logger.exception("batch failed — sleeping then continuing")
+            _heartbeat_tick(
+                "git-commits-indexer",
+                outcome_increment=0,
+                status="error",
+                error_message=str(exc)[:500],
+            )
+        for _ in range(POLL_SECONDS):
+            if _shutdown_requested:
+                break
+            time.sleep(1)
+    logger.info("indexer exiting cleanly")
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/scripts/orchestrator/git_commits_indexer.py
+++ b/scripts/orchestrator/git_commits_indexer.py
@@ -148,15 +148,27 @@ def _git_log_since(cursor_iso: str, limit: int) -> list[GitCommit]:
     records = [r for r in proc.stdout.split(_RECORD_SEP) if r.strip()]
     commits: list[GitCommit] = []
     for rec in records:
-        parts = rec.split(_FIELD_SEP)
+        # maxsplit=4: keep body intact even if it contains embedded \x1f bytes
+        # (rare — binary-adjacent patch notes, pasted terminal output — but
+        # cheap to be safe per Aiden review).
+        parts = rec.split(_FIELD_SEP, 4)
         if len(parts) < 5:
             continue
         sha, author, committed_iso, subject, body = parts[0], parts[1], parts[2], parts[3], parts[4]
+        committed_iso = committed_iso.strip()
+        # `git log --since` is INCLUSIVE at the boundary second. Drop any
+        # commit whose timestamp equals the cursor — it was already indexed
+        # on the prior poll. Without this we'd re-POST 1 row per poll forever
+        # (Weaviate dedups via deterministic UUID so it's not a correctness
+        # bug, but it inflates the outcome counter and would silently mute
+        # the Gate 4 zero_outcome_window alert during truly-idle states).
+        if cursor_iso and committed_iso == cursor_iso:
+            continue
         commits.append(
             GitCommit(
                 sha=sha.strip(),
                 author=author.strip(),
-                committed_iso=committed_iso.strip(),
+                committed_iso=committed_iso,
                 subject=subject.strip(),
                 body=body.strip(),
             )

--- a/tests/scripts/test_git_commits_indexer.py
+++ b/tests/scripts/test_git_commits_indexer.py
@@ -99,3 +99,52 @@ def test_cursor_corrupt_returns_epoch(tmp_path, monkeypatch):
     bad.write_text("not-json")
     monkeypatch.setattr(mod, "CURSOR_PATH", bad)
     assert mod._read_cursor() == mod.EPOCH_ISO
+
+
+def test_git_log_since_drops_boundary_commit(monkeypatch):
+    """Aiden HOLD #1: `git log --since` is inclusive at the boundary second.
+    The fetch path must drop any commit whose committed_iso matches the cursor
+    exactly — otherwise it gets re-POSTed every poll.
+    """
+    cursor = "2026-05-17T10:00:00+00:00"
+    boundary_sha = "boundary123"
+    newer_sha = "newer456"
+
+    fake_stdout = (
+        f"{boundary_sha}\x1fatlas\x1f{cursor}\x1fboundary commit\x1f\x1e"
+        f"{newer_sha}\x1fatlas\x1f2026-05-17T11:00:00+00:00\x1fnewer commit\x1f\x1e"
+    )
+
+    class _Proc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **kw: _Proc())
+
+    out = mod._git_log_since(cursor, 50)
+    shas = [c.sha for c in out]
+    assert boundary_sha not in shas
+    assert newer_sha in shas
+
+
+def test_git_log_since_preserves_body_with_embedded_field_separator(monkeypatch):
+    """Aiden HOLD #2: rec.split(_FIELD_SEP, 4) must keep body intact even
+    when the body contains a \\x1f byte.
+    """
+    sha = "withbody789"
+    embedded_body = "line one\x1fembedded sep should not split"
+    fake_stdout = f"{sha}\x1fatlas\x1f2026-05-17T12:00:00+00:00\x1fsubj\x1f{embedded_body}\x1e"
+
+    class _Proc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **kw: _Proc())
+
+    out = mod._git_log_since("1970-01-01T00:00:00Z", 10)
+    assert len(out) == 1
+    assert out[0].sha == sha
+    # The embedded sep + everything after must be preserved in `body`.
+    assert "embedded sep should not split" in out[0].body

--- a/tests/scripts/test_git_commits_indexer.py
+++ b/tests/scripts/test_git_commits_indexer.py
@@ -1,0 +1,101 @@
+"""Unit tests for git_commits_indexer (KEI-85 phase C).
+
+No network / no live git. Tests cover the parse + UUID + ABC contract.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "orchestrator"))
+
+import git_commits_indexer as mod  # noqa: E402
+
+
+def _commit(sha: str = "abc123", iso: str = "2026-05-17T10:00:00+00:00") -> mod.GitCommit:
+    return mod.GitCommit(
+        sha=sha,
+        author="atlas",
+        committed_iso=iso,
+        subject="[ATLAS] feat(kei85): phase C — git commits → Codebase",
+        body="Body text mentioning KEI-99 and KEI-85.",
+    )
+
+
+def test_deterministic_uuid_per_sha():
+    a = mod.build_codebase_doc(_commit(sha="abc123"))["id"]
+    b = mod.build_codebase_doc(_commit(sha="abc123"))["id"]
+    assert a == b
+
+
+def test_uuid_differs_per_sha():
+    a = mod.build_codebase_doc(_commit(sha="abc123"))["id"]
+    b = mod.build_codebase_doc(_commit(sha="def456"))["id"]
+    assert a != b
+
+
+def test_build_codebase_doc_basic_shape():
+    doc = mod.build_codebase_doc(_commit())
+    assert doc["class"] == "Codebase"
+    props = doc["properties"]
+    assert props["agent"] == "system"
+    assert props["created_at"] == "2026-05-17T10:00:00+00:00"
+    assert "phase C" in props["raw_text"]
+    assert len(props["environment_hash"]) == 16
+    int(props["environment_hash"], 16)
+
+
+def test_kei_extracted_from_subject():
+    """`_extract_kei` walks the subject + body and pulls the first KEI-N hit."""
+    doc = mod.build_codebase_doc(_commit())
+    # Subject has kei85 in `feat(kei85)`. _extract_kei normalises to KEI-85.
+    assert doc["properties"]["kei"] == "KEI-85"
+
+
+def test_kei_empty_when_no_match():
+    commit = mod.GitCommit(
+        sha="aaaaaa",
+        author="x",
+        committed_iso="2026-05-17T00:00:00+00:00",
+        subject="initial commit",
+        body="",
+    )
+    assert mod.build_codebase_doc(commit)["properties"]["kei"] == ""
+
+
+def test_empty_iso_falls_back_to_epoch():
+    commit = mod.GitCommit(sha="x", author="x", committed_iso="", subject="s", body="")
+    assert mod.build_codebase_doc(commit)["properties"]["created_at"] == mod.EPOCH_ISO
+
+
+def test_indexer_satisfies_base_indexer_abc():
+    import indexer_base
+
+    assert issubclass(mod.GitCommitsIndexer, indexer_base.BaseIndexer)
+    assert mod.GitCommitsIndexer.source_name == "git"
+    assert mod.GitCommitsIndexer.target_class == "Codebase"
+    assert mod.GitCommitsIndexer.class_schema["class"] == "Codebase"
+    assert mod.GitCommitsIndexer.__abstractmethods__ == frozenset()
+
+
+def test_cursor_write_then_read(tmp_path, monkeypatch):
+    cursor = tmp_path / "git.cursor"
+    monkeypatch.setattr(mod, "CURSOR_PATH", cursor)
+    indexer = mod.GitCommitsIndexer()
+    indexer._last_max_committed_iso = "2026-05-17T10:00:00+00:00"
+    indexer.advance_cursor()
+    assert mod._read_cursor() == "2026-05-17T10:00:00+00:00"
+
+
+def test_cursor_missing_returns_epoch(tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "CURSOR_PATH", tmp_path / "no-such")
+    assert mod._read_cursor() == mod.EPOCH_ISO
+
+
+def test_cursor_corrupt_returns_epoch(tmp_path, monkeypatch):
+    bad = tmp_path / "bad.cursor"
+    bad.write_text("not-json")
+    monkeypatch.setattr(mod, "CURSOR_PATH", bad)
+    assert mod._read_cursor() == mod.EPOCH_ISO


### PR DESCRIPTION
## Summary

Phase C of 4 for KEI-85. Closes the empty-Codebase gap per Dave's direct dispatch ("Phase C: git → Codebase. Last empty Weaviate collection that's in scope. Ship it"). **Codebase: 0 → 11** end-to-end smoke proved.

**Linear:** KEI-85 · **Branch:** `atlas/kei85-phase-c-git-commits`

## What lands

| File | Purpose |
|---|---|
| `scripts/orchestrator/git_commits_indexer.py` | Inherits `BaseIndexer[GitCommit]`. Reads `git log --since $cursor --reverse --max-count $batch`, parses SHA/author/iso/subject/body via `\x1f` field + `\x1e` record separators, POSTs one Codebase object per commit SHA. Deterministic UUID = `uuid5("git", sha)`. Cursor persisted to disk. KEI-91 heartbeat after each batch. |
| `infra/systemd/agents/git-commits-indexer.service` | `MemoryMax=256M` per KEI-44 cgroup. `After=weaviate.service`. |
| `scripts/install_git_commits_indexer.sh` | KEI-108 CI-gate install wrapper. Anchors literal unit name. |
| `tests/scripts/test_git_commits_indexer.py` (10 tests) | UUID determinism, build shape, KEI extraction from subject/body, empty-iso fallback, ABC enforcement, cursor write/read/missing/corrupt. |

## Architectural notes

1. **KEI extraction** — `build_codebase_doc` runs a regex over subject + body to pull the first `KEI-N` reference, storing it in the Weaviate `kei` property. Lets `bd recall KEI-N` find every commit that touched the KEI without full-text search.
2. **Cursor — committed_iso** rather than SHA. Per-poll filter is `--since=$cursor` so monotonic time advances naturally. Commits re-introduced via rebase keep their original timestamp, so cursor advancement is stable.
3. **`\x1f` / `\x1e` separators** — non-printable control chars unlikely to appear in commit messages, robust delimiters for the multi-line `%b` body field.
4. **Heartbeat semantics** — empty batch (no new commits) emits `outcome=0, status=ok` so the monitor's `zero_outcome_window` doesn't fire on this naturally-sparse source.

## Verbatim verification

### Tests + lint
```
$ ruff check + ruff format       All checks passed!
$ pytest tests/scripts/test_git_commits_indexer.py
========================== 10 passed in 0.19s ==========================
```

### End-to-end smoke (live git + live Weaviate)
```
$ curl ... Aggregate.Codebase.meta.count   # pre
0

$ python3 scripts/orchestrator/git_commits_indexer.py --once --batch=50
2026-05-17 12:07:07 INFO class Codebase already exists
2026-05-17 12:07:07 INFO indexer start source=git class=Codebase batch=50 repo=/home/elliotbot/clawd/Agency_OS
2026-05-17 12:07:07 INFO once outcome={'selected': 11, 'success': 11, 'failed': 0} class_count=11 cursor=2026-05-17T20:58:29+10:00

$ curl ... Aggregate.Codebase.meta.count   # post
11
```

Note: Agency_OS main worktree on Vultr is a shallow clone with only 11 commits total — `git log --oneline | wc -l` confirms. The indexer correctly picked up all of them and advanced the cursor. As origin advances + this host fetches, new commits will be indexed.

## Phase 0 proof gate impact

Pre-this-PR: Sessions (48666), Discoveries (14202), ToolCalls (≥1), Decisions (≥50), Keis (pending Phase B merge), **Codebase (0)**, Staging_discoveries (0).

Post-this-PR: Codebase → **11**. Remaining zero collection in the gate's 7-list: Staging_discoveries. Phase D closes that gap per Elliot's KEI-117 (Slack → Sessions).

## Out of scope

- **Phase D** (Slack relay messages → Sessions). Separate PR.
- **Deep git history** — Vultr worktree is shallow. Could be widened with `git fetch --unshallow` in a follow-up; not in this PR's scope.

## Dual approval

Per session rules: **[ELLIOT] + [AIDEN]** must both CONCUR. Dave merges (or merge-on-direct per Elliot's recent KEI-91 pattern).

## Test plan

- [ ] CI ruff + pytest + KEI-108 install-wired gate green
- [ ] CI SonarCloud green (file is small + lint-clean; same patterns as phase B)
- [ ] Manual review: KEI-extraction regex — `_extract_kei` matches `kei91` / `KEI-85` / `Kei_99`. Good enough for retrieval?
- [ ] Manual review: cursor strategy on Vultr's shallow clone — is `git fetch --unshallow` worth adding to the systemd unit's ExecStartPre? (currently out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)