### PR TITLE
[SCOUT] fix(kei88): Sonar triage — 15 findings across PRs #895/#913/#916

### DIFF
--- a/scripts/install_litellm.sh
+++ b/scripts/install_litellm.sh
@@ -11,7 +11,7 @@ CFG_DST="$HOME/.config/litellm/config.yaml"
 UNIT_SRC="$REPO_ROOT/infra/litellm/litellm.service"
 UNIT_DST="$HOME/.config/systemd/user/litellm.service"
 
-if [ ! -x "$VENV/bin/python" ]; then
+if [[ ! -x "$VENV/bin/python" ]]; then
   python3 -m venv "$VENV"
 fi
 

--- a/scripts/litellm_boot_check.py
+++ b/scripts/litellm_boot_check.py
@@ -173,7 +173,8 @@ def mode_post() -> int:
             body = resp.read().decode("utf-8", errors="replace")
             log("INFO", f"liveliness ok ({resp.status}): {body[:200]}")
             return 0
-    except (urllib.error.URLError, TimeoutError, OSError) as e:
+    except OSError as e:
+        # OSError covers URLError + TimeoutError per PEP 3151 (Sonar S5713 — drop redundant subclasses).
         log("FATAL", f"liveliness probe failed: {e}")
         return 1
 

--- a/src/governance/discovery_validation.py
+++ b/src/governance/discovery_validation.py
@@ -40,6 +40,8 @@ WEAVIATE_BASE = f"http://{WEAVIATE_HOST}:{WEAVIATE_PORT}"  # NOSONAR python:S533
 STAGING_COLLECTION = "Staging_discoveries"
 PERMANENT_COLLECTION = "Discoveries"
 
+_ISO8601_Z = "%Y-%m-%dT%H:%M:%SZ"
+
 # Tier expiry windows.
 _TIER_EXPIRY: dict[int, timedelta] = {
     1: timedelta(hours=24),
@@ -142,14 +144,14 @@ def submit_discovery(
         "properties": {
             "raw_text": text,
             "environment_hash": environment_hash,
-            "created_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "created_at": now.strftime(_ISO8601_Z),
             "agent": agent,
             "kei": kei,
             "validation_tier": tier,
             "tier_classification_reason": reason,
             "state": "staging",
             "submitted_by": agent,
-            "expires_at": expires_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "expires_at": expires_at.strftime(_ISO8601_Z),
             "concur_callsign": "",
             "challenged_by": "",
             "counter_findings": "",
@@ -196,7 +198,7 @@ def submit_concur(discovery_id: str, peer_callsign: str) -> bool:
     patch = {
         "properties": {
             "concur_callsign": peer_callsign,
-            "concur_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "concur_at": datetime.now(UTC).strftime(_ISO8601_Z),
         }
     }
     _patch_object(discovery_id, patch)
@@ -269,7 +271,7 @@ def challenge(
         "properties": {
             "state": "challenged",
             "challenged_by": challenged_by_callsign,
-            "challenged_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "challenged_at": datetime.now(UTC).strftime(_ISO8601_Z),
             "counter_findings": appended,
         }
     }
@@ -362,8 +364,9 @@ def _patch_object(object_id: str, patch: dict) -> None:
     """PATCH partial update on a Weaviate Staging_discoveries object."""
     path = f"/v1/objects/{STAGING_COLLECTION}/{object_id}"
     try:
-        with _http_request("PATCH", path, patch):
-            pass
+        # Side-effect-only call: response body unused, only HTTP status matters.
+        with _http_request("PATCH", path, patch) as _resp:
+            _resp.read()
     except urlerror.HTTPError as exc:
         raise RuntimeError(f"_patch_object {object_id} failed: HTTP {exc.code}") from exc
 
@@ -392,8 +395,8 @@ def _query_staging_objects() -> list[dict[str, Any]]:
     try:
         with _http_request("POST", "/v1/graphql", query) as resp:
             data = _read_response(resp)
-    except OSError as exc:
-        logger.error("_query_staging_objects: Weaviate unreachable — %s", exc)
+    except OSError:
+        logger.exception("_query_staging_objects: Weaviate unreachable")
         return []
 
     items = (data.get("data", {}).get("Get", {}).get("Staging_discoveries", [])) or []
@@ -417,7 +420,8 @@ def _notify_dave(discovery_id: str, text: str) -> None:
         f"text (first 200 chars): {text[:200]}"
     )
     with contextlib.suppress(Exception):
-        subprocess.run(  # noqa: S603 — fixed argv, no shell
+        # Fixed argv, no shell — S603 suppressed; argv is a literal list.
+        subprocess.run(  # noqa: S603
             ["tg", "-c", "ceo", msg],
             timeout=10,
             check=False,

--- a/tests/hooks/test_tool_call_log_writer.py
+++ b/tests/hooks/test_tool_call_log_writer.py
@@ -170,17 +170,17 @@ class TestDbInsert:
         mock_connect, mock_cur = _capture_connect()
         self._run_main_with_mock_db(
             monkeypatch,
-            {"tool_name": "Read", "tool_input": {"file_path": "/tmp/x"}, "tool_response": "ok"},
+            {"tool_name": "Read", "tool_input": {"file_path": "/tmp/x"}, "tool_response": "ok"},  # noqa: S5443 — fixture payload, not FS path (KEI-88)
             mock_connect,
         )
-        sql, params = _last_execute(mock_cur)
+        sql, _ = _last_execute(mock_cur)
         assert "public.tool_call_log" in sql
 
     def test_insert_params_callsign(self, monkeypatch):
         mock_connect, mock_cur = _capture_connect()
         self._run_main_with_mock_db(
             monkeypatch,
-            {"tool_name": "Read", "tool_input": {"file_path": "/tmp/x"}, "tool_response": "ok"},
+            {"tool_name": "Read", "tool_input": {"file_path": "/tmp/x"}, "tool_response": "ok"},  # noqa: S5443
             mock_connect,
         )
         _, params = _last_execute(mock_cur)
@@ -200,7 +200,7 @@ class TestDbInsert:
         mock_connect, mock_cur = _capture_connect()
         self._run_main_with_mock_db(
             monkeypatch,
-            {"tool_name": "Read", "tool_input": {"file_path": "/tmp/x"}, "tool_response": "ok"},
+            {"tool_name": "Read", "tool_input": {"file_path": "/tmp/x"}, "tool_response": "ok"},  # noqa: S5443
             mock_connect,
         )
         _, params = _last_execute(mock_cur)
@@ -208,7 +208,7 @@ class TestDbInsert:
         tool_input_json = params[3]
         assert isinstance(tool_input_json, str)
         parsed = json.loads(tool_input_json)
-        assert parsed["file_path"] == "/tmp/x"
+        assert parsed["file_path"] == "/tmp/x"  # noqa: S5443 — fixture string, not FS path (KEI-88)
 
 
 # ---------------------------------------------------------------------------
@@ -218,7 +218,7 @@ class TestDbInsert:
 
 class TestToolInputCap:
     def test_small_payload_preserved(self):
-        small = {"file_path": "/tmp/test.py"}
+        small = {"file_path": "/tmp/test.py"}  # noqa: S5443 — fixture payload string (KEI-88)
         result = _cap_tool_input(small)
         parsed = json.loads(result)
         assert parsed == small

--- a/tests/integration/test_litellm_bypass.py
+++ b/tests/integration/test_litellm_bypass.py
@@ -41,7 +41,8 @@ def _proxy_reachable(
     try:
         with socket.create_connection((host, port), timeout=timeout):
             return True
-    except (TimeoutError, OSError):
+    except OSError:
+        # TimeoutError subclasses OSError per PEP 3151 (Sonar S5713).
         return False
 
 


### PR DESCRIPTION
## Summary
- KEI-88 Sonar triage: 15 findings across 3 already-merged PRs addressed in one fix-PR
- Headline: 5× CRITICAL VULNERABILITY S5443 on `tests/hooks/test_tool_call_log_writer.py` confirmed false-positives (fixture payload strings, not filesystem ops) — `# noqa: S5443` with KEI-88 backlink
- Per `feedback_sonarcloud_verify_pattern`: SonarCloud `/api/issues` is empirical floor; green check rollup hid these

## Findings addressed

### PR #916 (KEI-116 tool-call writer) — 6
- 5× CRITICAL VULNERABILITY S5443 — fixture payload strings → `# noqa: S5443` (KEI-88)
- 1× MINOR S1481 unused `params` → `_`

### PR #895 (KEI-55 discovery validation) — 4
- CRITICAL S1192 string-dup `"%Y-%m-%dT%H:%M:%SZ"` ×4 → `_ISO8601_Z` constant
- MAJOR S108 empty `with` block → `as _resp: _resp.read()`
- MAJOR S8572 `logger.error(..., exc)` → `logger.exception(...)`
- MAJOR S7632 inline noqa + trailing text → bare noqa, rationale on preceding line (anchored `feedback_async_script_lint_gotchas`)

### PR #913 (KEI-100 LiteLLM) — 4
- MAJOR shelldre:S7688 `[ ]` → `[[ ]]` modern bash
- MINOR S5713 ×2 `(URLError, TimeoutError, OSError)` → `OSError` only (PEP 3151)
- MINOR S5713 `(TimeoutError, OSError)` → `OSError` only

## Test plan
- [x] ruff check: All checks passed
- [x] ruff format --check: 4 files already formatted
- [x] pytest test_tool_call_log_writer.py + test_kei55_discovery_validation.py + test_litellm_bypass.py: 52 passed, 1 skipped
- [x] bash -n install_litellm.sh: exit 0
- [ ] CI green
- [ ] Post-merge SonarCloud `/api/issues` probe shows 0 unresolved on listed paths

Linear: https://linear.app/keiracom/issue/KEI-88

🤖 Generated with [Claude Code](https://claude.com/claude-code)