### PR TITLE
[AIDEN] feat(kei89): Gate 2 bd complete --evidence — JSON schema + hash uniqueness + atomic

### DIFF
--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -29,6 +29,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -98,6 +99,93 @@ def _current_phase_max(cur: Any) -> float:
         return float(row[0]["current_phase_max"])
     except (KeyError, TypeError, ValueError):
         return 99.0
+
+
+# ─── KEI-89 Gate 2: evidence validation helpers ─────────────────────────────
+
+# Minimum characters required in any commands[].output field. Catches lazy
+# single-word pastes like "ok" or "exit 0" that provide no verification signal.
+_EVIDENCE_MIN_OUTPUT_LEN = 16
+
+
+def _validate_evidence_schema(payload: dict) -> str | None:
+    """Validate the evidence JSON payload shape. Returns an error string on
+    failure, or None when the payload is valid.
+
+    Required fields:
+      - acceptance_items  list[str], non-empty
+      - commands          list[{cmd: str, output: str}] where each output >= 16 chars
+      - verifier_session_uuid  str, non-empty
+      - timestamp         str (ISO 8601), non-empty
+    """
+    required = ("acceptance_items", "commands", "verifier_session_uuid", "timestamp")
+    for field in required:
+        if field not in payload:
+            return f"{field} missing"
+
+    items = payload["acceptance_items"]
+    if not isinstance(items, list) or len(items) == 0:
+        return "acceptance_items must be a non-empty list"
+
+    cmds = payload["commands"]
+    if not isinstance(cmds, list) or len(cmds) == 0:
+        return "commands must be a non-empty list"
+    for i, entry in enumerate(cmds):
+        if not isinstance(entry, dict):
+            return f"commands[{i}] must be an object"
+        if "cmd" not in entry:
+            return f"commands[{i}].cmd missing"
+        if "output" not in entry:
+            return f"commands[{i}].output missing"
+        if len(str(entry["output"])) < _EVIDENCE_MIN_OUTPUT_LEN:
+            return (
+                f"commands[{i}].output too short "
+                f"(min {_EVIDENCE_MIN_OUTPUT_LEN} chars, got {len(str(entry['output']))})"
+            )
+
+    if not str(payload.get("verifier_session_uuid", "")).strip():
+        return "verifier_session_uuid must be a non-empty string"
+    if not str(payload.get("timestamp", "")).strip():
+        return "timestamp must be a non-empty string"
+
+    return None
+
+
+def _canonical_hash(payload: dict) -> str:
+    """Return sha256 hex of the canonical JSON representation (sort_keys=True)."""
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _check_hash_uniqueness(
+    cur: Any, task_id: str, evidence_hash: str
+) -> tuple[str | None, str | None]:
+    """Check task_verifications for reuse of the same evidence text on a
+    DIFFERENT task within the last 30 days.
+
+    Returns (prior_task_id, prior_created_at) if a collision is found,
+    or (None, None) if the evidence is unique.
+    """
+    cur.execute(
+        """
+        SELECT task_id, test_output, created_at
+          FROM public.task_verifications
+         WHERE task_id != %s
+           AND created_at >= NOW() - INTERVAL '30 days'
+        """,
+        (task_id,),
+    )
+    rows = cur.fetchall()
+    for row in rows:
+        prior_task_id_val, stored_output, prior_ts = row[0], row[1], row[2]
+        try:
+            stored_payload = json.loads(stored_output)
+            stored_hash = _canonical_hash(stored_payload)
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            continue
+        if stored_hash == evidence_hash:
+            return str(prior_task_id_val), str(prior_ts)
+    return None, None
 
 
 def cmd_ready(args: argparse.Namespace) -> int:
@@ -274,12 +362,76 @@ def cmd_claim(args: argparse.Namespace) -> int:
 
 
 def cmd_complete(args: argparse.Namespace) -> int:
-    """Mark a claimed task done."""
+    """Mark a claimed task done.
+
+    KEI-89 Gate 2: --evidence <path|-> is required. Without it the command
+    exits with a non-zero code and an explanatory error. With it, the
+    evidence JSON is schema-validated and checked for hash uniqueness before
+    the atomic INSERT+UPDATE transaction.
+    """
     import psycopg
 
+    # ── Gate 2: evidence required ────────────────────────────────────────────
+    evidence_path: str | None = getattr(args, "evidence", None)
+    if not evidence_path:
+        print(
+            "ERROR: --evidence <path|-> is required. Pass a JSON file path or '-' to "
+            "read from stdin. Refusing to complete without structured evidence.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # ── Load evidence ────────────────────────────────────────────────────────
+    try:
+        if evidence_path == "-":
+            raw = sys.stdin.read()
+        else:
+            with open(evidence_path) as fh:
+                raw = fh.read()
+        evidence_payload = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: could not load evidence from {evidence_path!r}: {exc}", file=sys.stderr)
+        return 1
+
+    # ── Schema validation ─────────────────────────────────────────────────────
+    schema_err = _validate_evidence_schema(evidence_payload)
+    if schema_err:
+        print(f"evidence schema invalid: {schema_err}", file=sys.stderr)
+        return 1
+
+    canonical_str = json.dumps(evidence_payload, sort_keys=True, ensure_ascii=False)
+    evidence_hash = _canonical_hash(evidence_payload)
+
     cs = _callsign(args.callsign)
+    behavioral_test = (
+        evidence_payload["acceptance_items"][0]
+        if evidence_payload["acceptance_items"]
+        else "see commands"
+    )
+
     try:
         with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
+            # ── Hash uniqueness check ─────────────────────────────────────────
+            prior_id, prior_ts = _check_hash_uniqueness(cur, args.id, evidence_hash)
+            if prior_id is not None:
+                print(
+                    f"evidence text matches prior verification on task {prior_id} "
+                    f"at {prior_ts} — reuse not allowed",
+                    file=sys.stderr,
+                )
+                return 1
+
+            # ── Atomic transaction: INSERT verification + UPDATE task ─────────
+            import uuid as _uuid
+
+            cur.execute(
+                """
+                INSERT INTO public.task_verifications
+                       (id, task_id, verified_by, behavioral_test, test_output, created_at)
+                VALUES (%s, %s, %s, %s, %s, NOW())
+                """,
+                (str(_uuid.uuid4()), args.id, cs, behavioral_test, canonical_str),
+            )
             cur.execute(
                 """
                 UPDATE public.tasks
@@ -294,16 +446,18 @@ def cmd_complete(args: argparse.Namespace) -> int:
                 (args.id, cs, args.force_mode),
             )
             row = cur.fetchone()
+            if row is None:
+                conn.rollback()
+                if args.json:
+                    print("null")
+                else:
+                    print(f"could not complete {args.id} (not claimed by {cs}?)")
+                return 1
             conn.commit()
     except psycopg.Error:
         logger.exception("complete query failed")
         return 2
-    if row is None:
-        if args.json:
-            print("null")
-        else:
-            print(f"could not complete {args.id} (not claimed by {cs}?)")
-        return 1
+
     if args.json:
         print(json.dumps({"id": row[0], "title": row[1], "status": row[2]}))
     else:
@@ -411,6 +565,11 @@ def main(argv: list[str] | None = None) -> int:
         default="strict",
         choices=["strict", "force"],
         help="force=allow completion regardless of claimed_by (admin)",
+    )
+    p_complete.add_argument(
+        "--evidence",
+        metavar="PATH",
+        help="KEI-89 Gate 2: path to evidence JSON file, or '-' to read from stdin. Required.",
     )
     p_complete.add_argument("--json", action="store_true")
     p_complete.set_defaults(func=cmd_complete)

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -108,6 +108,23 @@ def _current_phase_max(cur: Any) -> float:
 _EVIDENCE_MIN_OUTPUT_LEN = 16
 
 
+def _validate_command_entry(i: int, entry: object) -> str | None:
+    """Validate a single commands[] entry shape + min-length on output."""
+    if not isinstance(entry, dict):
+        return f"commands[{i}] must be an object"
+    if "cmd" not in entry:
+        return f"commands[{i}].cmd missing"
+    if "output" not in entry:
+        return f"commands[{i}].output missing"
+    output_len = len(str(entry["output"]))
+    if output_len < _EVIDENCE_MIN_OUTPUT_LEN:
+        return (
+            f"commands[{i}].output too short "
+            f"(min {_EVIDENCE_MIN_OUTPUT_LEN} chars, got {output_len})"
+        )
+    return None
+
+
 def _validate_evidence_schema(payload: dict) -> str | None:
     """Validate the evidence JSON payload shape. Returns an error string on
     failure, or None when the payload is valid.
@@ -118,8 +135,7 @@ def _validate_evidence_schema(payload: dict) -> str | None:
       - verifier_session_uuid  str, non-empty
       - timestamp         str (ISO 8601), non-empty
     """
-    required = ("acceptance_items", "commands", "verifier_session_uuid", "timestamp")
-    for field in required:
+    for field in ("acceptance_items", "commands", "verifier_session_uuid", "timestamp"):
         if field not in payload:
             return f"{field} missing"
 
@@ -131,17 +147,9 @@ def _validate_evidence_schema(payload: dict) -> str | None:
     if not isinstance(cmds, list) or len(cmds) == 0:
         return "commands must be a non-empty list"
     for i, entry in enumerate(cmds):
-        if not isinstance(entry, dict):
-            return f"commands[{i}] must be an object"
-        if "cmd" not in entry:
-            return f"commands[{i}].cmd missing"
-        if "output" not in entry:
-            return f"commands[{i}].output missing"
-        if len(str(entry["output"])) < _EVIDENCE_MIN_OUTPUT_LEN:
-            return (
-                f"commands[{i}].output too short "
-                f"(min {_EVIDENCE_MIN_OUTPUT_LEN} chars, got {len(str(entry['output']))})"
-            )
+        err = _validate_command_entry(i, entry)
+        if err:
+            return err
 
     if not str(payload.get("verifier_session_uuid", "")).strip():
         return "verifier_session_uuid must be a non-empty string"

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -361,6 +361,58 @@ def cmd_claim(args: argparse.Namespace) -> int:
     return 0
 
 
+def _load_evidence_payload(evidence_path: str) -> dict | None:
+    """Read evidence from a file path or stdin ('-'). Returns the parsed JSON
+    dict on success, or None on read/parse failure (after printing the error)."""
+    try:
+        if evidence_path == "-":
+            raw = sys.stdin.read()
+        else:
+            with open(evidence_path) as fh:
+                raw = fh.read()
+        return json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: could not load evidence from {evidence_path!r}: {exc}", file=sys.stderr)
+        return None
+
+
+def _execute_atomic_complete(
+    cur: Any,
+    task_id: str,
+    callsign: str,
+    behavioral_test: str,
+    canonical_str: str,
+    force_mode: str,
+) -> tuple[Any, ...] | None:
+    """INSERT task_verifications row + UPDATE tasks.status='done' in a single
+    transaction. Returns the UPDATE's RETURNING row, or None when the task is
+    not claimed by the caller (caller-side rollback expected)."""
+    import uuid as _uuid
+
+    cur.execute(
+        """
+        INSERT INTO public.task_verifications
+               (id, task_id, verified_by, behavioral_test, test_output, created_at)
+        VALUES (%s, %s, %s, %s, %s, NOW())
+        """,
+        (str(_uuid.uuid4()), task_id, callsign, behavioral_test, canonical_str),
+    )
+    cur.execute(
+        """
+        UPDATE public.tasks
+           SET status = 'done',
+               claimed_by = NULL,
+               claimed_at = NULL,
+               updated_at = NOW()
+         WHERE id = %s
+           AND (claimed_by = %s OR %s = 'force')
+         RETURNING id, title, status
+        """,
+        (task_id, callsign, force_mode),
+    )
+    return cur.fetchone()
+
+
 def cmd_complete(args: argparse.Namespace) -> int:
     """Mark a claimed task done.
 
@@ -371,7 +423,7 @@ def cmd_complete(args: argparse.Namespace) -> int:
     """
     import psycopg
 
-    # ── Gate 2: evidence required ────────────────────────────────────────────
+    # Gate 2: evidence flag required.
     evidence_path: str | None = getattr(args, "evidence", None)
     if not evidence_path:
         print(
@@ -381,19 +433,10 @@ def cmd_complete(args: argparse.Namespace) -> int:
         )
         return 1
 
-    # ── Load evidence ────────────────────────────────────────────────────────
-    try:
-        if evidence_path == "-":
-            raw = sys.stdin.read()
-        else:
-            with open(evidence_path) as fh:
-                raw = fh.read()
-        evidence_payload = json.loads(raw)
-    except (OSError, json.JSONDecodeError) as exc:
-        print(f"ERROR: could not load evidence from {evidence_path!r}: {exc}", file=sys.stderr)
+    evidence_payload = _load_evidence_payload(evidence_path)
+    if evidence_payload is None:
         return 1
 
-    # ── Schema validation ─────────────────────────────────────────────────────
     schema_err = _validate_evidence_schema(evidence_payload)
     if schema_err:
         print(f"evidence schema invalid: {schema_err}", file=sys.stderr)
@@ -401,7 +444,6 @@ def cmd_complete(args: argparse.Namespace) -> int:
 
     canonical_str = json.dumps(evidence_payload, sort_keys=True, ensure_ascii=False)
     evidence_hash = _canonical_hash(evidence_payload)
-
     cs = _callsign(args.callsign)
     behavioral_test = (
         evidence_payload["acceptance_items"][0]
@@ -411,7 +453,6 @@ def cmd_complete(args: argparse.Namespace) -> int:
 
     try:
         with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
-            # ── Hash uniqueness check ─────────────────────────────────────────
             prior_id, prior_ts = _check_hash_uniqueness(cur, args.id, evidence_hash)
             if prior_id is not None:
                 print(
@@ -420,32 +461,9 @@ def cmd_complete(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
                 return 1
-
-            # ── Atomic transaction: INSERT verification + UPDATE task ─────────
-            import uuid as _uuid
-
-            cur.execute(
-                """
-                INSERT INTO public.task_verifications
-                       (id, task_id, verified_by, behavioral_test, test_output, created_at)
-                VALUES (%s, %s, %s, %s, %s, NOW())
-                """,
-                (str(_uuid.uuid4()), args.id, cs, behavioral_test, canonical_str),
+            row = _execute_atomic_complete(
+                cur, args.id, cs, behavioral_test, canonical_str, args.force_mode
             )
-            cur.execute(
-                """
-                UPDATE public.tasks
-                   SET status = 'done',
-                       claimed_by = NULL,
-                       claimed_at = NULL,
-                       updated_at = NOW()
-                 WHERE id = %s
-                   AND (claimed_by = %s OR %s = 'force')
-                 RETURNING id, title, status
-                """,
-                (args.id, cs, args.force_mode),
-            )
-            row = cur.fetchone()
             if row is None:
                 conn.rollback()
                 if args.json:

--- a/src/governance/ceo_memory_writer.py
+++ b/src/governance/ceo_memory_writer.py
@@ -1,0 +1,84 @@
+"""KEI-87 — canonical wrapper for ceo_memory writes.
+
+The trigger at supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql
+refuses any UPDATE/INSERT on a 'ceo:*' key when the PostgreSQL session variable
+`agency_os.callsign` is missing or not in the allowlist. This wrapper is the
+only path that should ever issue such writes.
+
+Existing call-sites are being migrated from raw psycopg.execute() to
+`upsert_ceo_memory_key(...)` / `update_ceo_memory_value(...)` in a follow-up
+KEI; until then the trigger remains UNAPPLIED on prod (see the migration's
+deployment-order banner).
+
+Public API:
+    upsert_ceo_memory_key(callsign, key, value)
+    update_ceo_memory_value(callsign, key, jsonb_path, new_value)
+
+Both helpers run inside a single transaction:
+    BEGIN
+    SET LOCAL agency_os.callsign = '<callsign>'
+    INSERT/UPDATE ...
+    COMMIT
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from typing import Any
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL / SUPABASE_DB_URL not set")
+    return dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def _require_callsign(callsign: str) -> str:
+    cs = (callsign or "").strip().lower()
+    if not cs:
+        raise ValueError("KEI-87 ceo_memory_writer: callsign argument is required")
+    return cs
+
+
+def upsert_ceo_memory_key(callsign: str, key: str, value: Mapping[str, Any]) -> None:
+    """Idempotent upsert into public.ceo_memory under the KEI-87 write-guard."""
+    import psycopg  # local import — keeps callers without psycopg from paying import cost
+
+    cs = _require_callsign(callsign)
+    # prepare_threshold=None per reference_psycopg_supabase_pgbouncer: Supabase
+    # pooler is txn-mode pgbouncer; psycopg3 cached prepared statements break on
+    # first repeated execute() across pool connections.
+    with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
+        cur.execute("SET LOCAL agency_os.callsign = %s", (cs,))
+        cur.execute(
+            """
+            INSERT INTO public.ceo_memory (key, value, updated_at)
+            VALUES (%s, %s::jsonb, NOW())
+            ON CONFLICT (key) DO UPDATE
+              SET value = EXCLUDED.value, updated_at = NOW()
+            """,
+            (key, json.dumps(dict(value))),
+        )
+        conn.commit()
+
+
+def update_ceo_memory_value(callsign: str, key: str, value: Mapping[str, Any]) -> None:
+    """Update only — refuses if the row is missing (caller should upsert)."""
+    import psycopg
+
+    cs = _require_callsign(callsign)
+    # prepare_threshold=None per reference_psycopg_supabase_pgbouncer: Supabase
+    # pooler is txn-mode pgbouncer; psycopg3 cached prepared statements break on
+    # first repeated execute() across pool connections.
+    with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
+        cur.execute("SET LOCAL agency_os.callsign = %s", (cs,))
+        cur.execute(
+            "UPDATE public.ceo_memory SET value = %s::jsonb, updated_at = NOW() WHERE key = %s",
+            (json.dumps(dict(value)), key),
+        )
+        if cur.rowcount == 0:
+            raise KeyError(f"ceo_memory key not found: {key!r}")
+        conn.commit()

--- a/supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql
+++ b/supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql
@@ -1,0 +1,65 @@
+-- KEI-87 — Cross-cutting ceo_memory write-guard (GOV-12 mechanical).
+--
+-- Closes the 400+-key gates-as-comments hole Aiden's audit (PR #917 review)
+-- surfaced: prior to this migration any callsign with DATABASE_URL could
+-- UPDATE/INSERT a 'ceo:*' key. The 'ceo:' prefix signalled intent but was
+-- NOT enforced.
+--
+-- ⚠ DEPLOYMENT ORDER (do NOT apply this migration until step 1 lands):
+--   1. Migrate ALL existing 'ceo:*' writer call-sites to the wrapper at
+--      src/governance/ceo_memory_writer.py — see the README in that module.
+--      The wrapper issues `SET LOCAL agency_os.callsign = '<callsign>'`
+--      inside the same transaction as the UPDATE/INSERT.
+--   2. Apply this migration (adds trigger + raises EXCEPTION when the var
+--      is missing or not in the allowlist).
+--   3. Verify positive + negative paths (tests in tests/governance/).
+--   4. Tighten allowlist by amending the trigger if narrower-than-default
+--      gating is required (Phase 0.5 follow-up KEI).
+--
+-- Initial allowlist (intentionally permissive — every callsign is allowed;
+-- the gate exists so MISSING var = denied). The 'who counts as CEO' tightening
+-- is a separate follow-up so this PR can ship the mechanism without breaking
+-- existing writers mid-flight.
+
+CREATE OR REPLACE FUNCTION public.ceo_memory_write_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    caller text;
+BEGIN
+    -- Only guard 'ceo:' prefix keys; orchestrator-mutated prefixes
+    -- (completion:* / directive_*_status / heartbeat:* / business_universe_*)
+    -- are explicitly NOT in scope (Aiden's audit excluded those).
+    IF NEW.key NOT LIKE 'ceo:%' THEN
+        RETURN NEW;
+    END IF;
+
+    caller := current_setting('agency_os.callsign', true);
+    IF caller IS NULL OR caller = '' THEN
+        RAISE EXCEPTION 'KEI-87 ceo_memory write-guard: agency_os.callsign session-var must be SET LOCAL before writing key %; missing var refused.', NEW.key
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    -- Per 3-way ratified spec (elliot+max+aiden 2026-05-17 ts ~1779010883):
+    -- allowlist = (elliot, dave). Aiden's PR #922 review caught the prior
+    -- permissive-first draft as scope-delta from ratified shape. Tightened.
+    IF caller NOT IN ('elliot', 'dave') THEN
+        RAISE EXCEPTION 'KEI-87 ceo_memory write-guard: agency_os.callsign=% is not in (elliot, dave) — refused write on key %', caller, NEW.key
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ceo_memory_write_guard ON public.ceo_memory;
+
+CREATE TRIGGER ceo_memory_write_guard
+    BEFORE INSERT OR UPDATE
+    ON public.ceo_memory
+    FOR EACH ROW
+    EXECUTE FUNCTION public.ceo_memory_write_guard();
+
+COMMENT ON FUNCTION public.ceo_memory_write_guard() IS
+    'KEI-87 GOV-12 mechanical write-guard for ceo:* keys. Requires agency_os.callsign session var (set by src/governance/ceo_memory_writer.py wrapper). Permissive allowlist by default — tighten via follow-up KEI.';

--- a/tests/governance/test_ceo_memory_writer.py
+++ b/tests/governance/test_ceo_memory_writer.py
@@ -1,0 +1,161 @@
+"""Tests for src/governance/ceo_memory_writer.py — KEI-87.
+
+Mocks psycopg.connect via a minimal fake. Verifies the wrapper's
+SQL emission order (SET LOCAL agency_os.callsign first, then the
+INSERT/UPDATE) — the trigger from the matching migration depends on
+the session var being set in the same transaction before the write.
+
+Trigger semantics themselves are covered by the migration's own
+acceptance probe (live Supabase test post-deploy); these tests cover
+the wrapper contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.governance import ceo_memory_writer
+
+
+class _Cursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple | None]] = []
+        self.rowcount = 1
+
+    def execute(self, sql: str, params: tuple | None = None) -> None:
+        self.executed.append((sql, params))
+
+    def __enter__(self) -> _Cursor:
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        return None
+
+
+class _Conn:
+    def __init__(self) -> None:
+        self.cur = _Cursor()
+        self.commits = 0
+
+    def cursor(self) -> _Cursor:
+        return self.cur
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def __enter__(self) -> _Conn:
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+
+
+def test_upsert_sets_local_callsign_before_write() -> None:
+    conn = _Conn()
+    with patch("psycopg.connect", return_value=conn):
+        ceo_memory_writer.upsert_ceo_memory_key("elliot", "ceo:phase_lock", {"v": 1})
+    sqls = [s for s, _ in conn.cur.executed]
+    assert "SET LOCAL agency_os.callsign" in sqls[0]
+    assert conn.cur.executed[0][1] == ("elliot",)
+    assert "INSERT INTO public.ceo_memory" in sqls[1]
+    assert conn.commits == 1
+
+
+def test_update_sets_local_callsign_then_update() -> None:
+    conn = _Conn()
+    with patch("psycopg.connect", return_value=conn):
+        ceo_memory_writer.update_ceo_memory_value("dave", "ceo:phase_lock", {"v": 2})
+    sqls = [s for s, _ in conn.cur.executed]
+    assert "SET LOCAL agency_os.callsign" in sqls[0]
+    assert conn.cur.executed[0][1] == ("dave",)
+    assert "UPDATE public.ceo_memory" in sqls[1]
+    assert conn.commits == 1
+
+
+def test_update_missing_row_raises_key_error() -> None:
+    conn = _Conn()
+    conn.cur.rowcount = 0
+    with patch("psycopg.connect", return_value=conn), pytest.raises(KeyError):
+        ceo_memory_writer.update_ceo_memory_value("max", "ceo:phase_lock", {"v": 3})
+
+
+def test_callsign_required() -> None:
+    with pytest.raises(ValueError):
+        ceo_memory_writer.upsert_ceo_memory_key("", "ceo:phase_lock", {"v": 4})
+    with pytest.raises(ValueError):
+        ceo_memory_writer.update_ceo_memory_value("   ", "ceo:phase_lock", {"v": 5})
+
+
+def test_dsn_falls_back_to_supabase_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://fallback/x")
+    assert ceo_memory_writer._dsn() == "postgresql://fallback/x"
+
+
+class _RaisingCursor(_Cursor):
+    """Cursor that raises CheckViolation on the second execute (the UPDATE/INSERT)
+    to simulate the trigger refusing the write — KEI-87 negative-path proof."""
+
+    def __init__(self, exc: BaseException) -> None:
+        super().__init__()
+        self._exc = exc
+        self._call = 0
+
+    def execute(self, sql: str, params: tuple | None = None) -> None:
+        super().execute(sql, params)
+        self._call += 1
+        if self._call >= 2:
+            raise self._exc
+
+
+class _RaisingConn(_Conn):
+    def __init__(self, exc: BaseException) -> None:
+        super().__init__()
+        self.cur = _RaisingCursor(exc)
+
+
+def test_upsert_propagates_trigger_check_violation() -> None:
+    """Wrapper passes through the CheckViolation when the trigger refuses.
+    Simulates SET LOCAL agency_os.callsign='aiden' → trigger RAISES on ceo:*.
+    """
+    import psycopg
+
+    conn = _RaisingConn(
+        psycopg.errors.CheckViolation("KEI-87 ceo_memory write-guard: aiden not in (elliot, dave)")
+    )
+    with patch("psycopg.connect", return_value=conn):
+        with pytest.raises(psycopg.errors.CheckViolation):
+            ceo_memory_writer.upsert_ceo_memory_key("aiden", "ceo:phase_lock", {"v": 1})
+    # SET LOCAL still executed; the exception happens on the INSERT (call 2)
+    assert any("SET LOCAL agency_os.callsign" in s for s, _ in conn.cur.executed)
+
+
+def test_update_propagates_trigger_check_violation() -> None:
+    """Same negative-path proof on update_ceo_memory_value."""
+    import psycopg
+
+    conn = _RaisingConn(psycopg.errors.CheckViolation("refused"))
+    with patch("psycopg.connect", return_value=conn):
+        with pytest.raises(psycopg.errors.CheckViolation):
+            ceo_memory_writer.update_ceo_memory_value("max", "ceo:phase_lock", {"v": 2})
+
+
+def test_upsert_uses_prepare_threshold_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """psycopg.connect called with prepare_threshold=None per pgbouncer pin."""
+    captured: dict[str, Any] = {}
+
+    def _fake_connect(dsn: str, **kwargs: Any) -> _Conn:
+        captured["kwargs"] = kwargs
+        return _Conn()
+
+    monkeypatch.setattr("psycopg.connect", _fake_connect)
+    ceo_memory_writer.upsert_ceo_memory_key("elliot", "ceo:phase_lock", {"v": 99})
+    assert captured["kwargs"].get("prepare_threshold") is None

--- a/tests/scripts/test_tasks_cli_evidence.py
+++ b/tests/scripts/test_tasks_cli_evidence.py
@@ -1,0 +1,293 @@
+"""KEI-89 Gate 2 — tests for bd complete --evidence in scripts/tasks_cli.py.
+
+Covers:
+  (1) positive_valid_evidence     — completes task, task_verifications row
+                                    inserted with correct test_output,
+                                    tasks.status set to 'done'.
+  (2) negative_missing_evidence   — no --evidence flag → exits 1 with
+                                    explanatory error.
+  (3) negative_schema_fail        — missing required field → exits 1 with
+                                    "evidence schema invalid" message.
+  (4) negative_hash_collision     — re-using identical evidence on a
+                                    different task → exits 1 with
+                                    "matches prior verification" message.
+  (5) positive_no_side_effects    — valid evidence path inserts ONE
+                                    verification row (no extra DB writes).
+
+Uses FakeCursor / FakeConn from _db_mocks (shared infra); does NOT touch
+the live Supabase DB.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "tasks_cli.py"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _db_mocks import FakeCursor, make_patch_connect  # type: ignore[import-not-found]  # noqa: E402
+
+# ─── module fixture ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("tasks_cli_ev", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["tasks_cli_ev"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+@pytest.fixture
+def patch_connect(mod, monkeypatch):
+    return make_patch_connect(monkeypatch)
+
+
+# ─── shared evidence fixture ──────────────────────────────────────────────────
+
+_VALID_EVIDENCE = {
+    "acceptance_items": ["All four pytest tests pass with no failures"],
+    "commands": [
+        {
+            "cmd": "pytest tests/scripts/test_tasks_cli_evidence.py -v",
+            "output": "4 passed in 0.42s — PASSED acceptance gate confirmed",
+        }
+    ],
+    "verifier_session_uuid": "abc123-session-uuid-def456",
+    "timestamp": "2026-05-17T10:00:00+10:00",
+}
+
+
+def _canonical(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, ensure_ascii=False)
+
+
+# ─── FakeConn that supports rollback tracking ─────────────────────────────────
+
+
+class TrackingFakeConn:
+    """FakeConn variant that tracks rollbacks and supports multi-fetchone calls."""
+
+    def __init__(self, cur: FakeCursor) -> None:
+        self._cur = cur
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self) -> FakeCursor:
+        return self._cur
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def __enter__(self) -> TrackingFakeConn:
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        return None
+
+
+class MultiStepCursor(FakeCursor):
+    """Cursor that cycles through a pre-configured sequence of fetchone/fetchall
+    responses, one per execute() call. Enables testing multi-step transactions.
+    """
+
+    def __init__(self, step_responses: list[tuple | list | None]) -> None:
+        super().__init__()
+        self._steps = list(step_responses)
+        self._step_idx = 0
+
+    def execute(self, sql: str, params: tuple | None = None) -> None:
+        self.executed.append((sql, params))
+        self._step_idx += 1
+
+    def fetchone(self) -> tuple | None:
+        idx = self._step_idx - 1
+        if idx < len(self._steps):
+            val = self._steps[idx]
+            return val if isinstance(val, tuple) else None
+        return None
+
+    def fetchall(self) -> list[tuple]:
+        idx = self._step_idx - 1
+        if idx < len(self._steps):
+            val = self._steps[idx]
+            return val if isinstance(val, list) else []
+        return []
+
+
+# ─── (1) positive valid evidence ─────────────────────────────────────────────
+
+
+def test_positive_valid_evidence_completes_task(mod, monkeypatch, tmp_path, capsys):
+    """Valid evidence: task_verifications INSERT + tasks UPDATE both fire,
+    commit is called, exit code 0.
+    """
+    ev_file = tmp_path / "evidence.json"
+    ev_file.write_text(json.dumps(_VALID_EVIDENCE))
+
+    # Step sequence:
+    #  execute[0] = hash-uniqueness SELECT  → fetchall returns []  (no collision)
+    #  execute[1] = INSERT task_verifications → fetchone not called
+    #  execute[2] = UPDATE tasks RETURNING → fetchone returns the done row
+    cur = MultiStepCursor(
+        step_responses=[
+            [],  # hash check fetchall → no prior rows
+            None,  # INSERT (no return used)
+            ("KEI-89", "Gate 2 evidence test", "done"),  # UPDATE RETURNING
+        ]
+    )
+    conn = TrackingFakeConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setenv("CALLSIGN", "aiden")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+
+    rc = mod.main(["complete", "KEI-89", "--evidence", str(ev_file)])
+    assert rc == 0, capsys.readouterr().err
+
+    # Three execute calls fired: hash check, INSERT, UPDATE
+    assert len(cur.executed) == 3
+
+    # INSERT contained the canonical JSON as test_output param
+    insert_sql, insert_params = cur.executed[1]
+    assert "task_verifications" in insert_sql
+    assert insert_params[1] == "KEI-89"  # task_id
+    assert insert_params[2] == "aiden"  # verified_by
+    stored_output = insert_params[4]  # test_output
+    round_tripped = json.loads(stored_output)
+    assert round_tripped["acceptance_items"] == _VALID_EVIDENCE["acceptance_items"]
+
+    # Commit fired; no rollback
+    assert conn.commits == 1
+    assert conn.rollbacks == 0
+
+    out = capsys.readouterr().out
+    assert "KEI-89" in out
+
+
+# ─── (2) negative missing evidence ───────────────────────────────────────────
+
+
+def test_negative_missing_evidence_exits_nonzero(mod, monkeypatch, capsys):
+    """No --evidence flag → exits 1 with explanatory error on stderr."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setenv("CALLSIGN", "aiden")
+
+    rc = mod.main(["complete", "KEI-89"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "--evidence" in err
+    assert "required" in err.lower() or "refusing" in err.lower()
+
+
+# ─── (3) negative schema fail ────────────────────────────────────────────────
+
+
+def test_negative_schema_fail_missing_required_field(mod, monkeypatch, tmp_path, capsys):
+    """Evidence missing 'commands' field → exits 1, stderr contains
+    'evidence schema invalid'.
+    """
+    bad_evidence = {
+        "acceptance_items": ["Some item"],
+        # 'commands' intentionally omitted
+        "verifier_session_uuid": "uuid-xyz",
+        "timestamp": "2026-05-17T10:00:00+10:00",
+    }
+    ev_file = tmp_path / "bad_evidence.json"
+    ev_file.write_text(json.dumps(bad_evidence))
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setenv("CALLSIGN", "aiden")
+
+    rc = mod.main(["complete", "KEI-89", "--evidence", str(ev_file)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "evidence schema invalid" in err
+
+
+# ─── (4) negative hash collision ─────────────────────────────────────────────
+
+
+def test_negative_hash_collision_rejects_reuse(mod, monkeypatch, tmp_path, capsys):
+    """Re-using identical evidence on a different task → exits 1, stderr
+    contains 'matches prior verification'.
+    """
+    ev_file = tmp_path / "evidence.json"
+    ev_file.write_text(json.dumps(_VALID_EVIDENCE))
+
+    canonical_str = _canonical(_VALID_EVIDENCE)
+
+    # The hash-check SELECT returns one prior row from a different task
+    # with the same canonical JSON as test_output.
+    prior_row = ("KEI-88", canonical_str, "2026-05-16T08:00:00+10:00")
+
+    cur = MultiStepCursor(
+        step_responses=[
+            [prior_row],  # hash check fetchall → collision found
+        ]
+    )
+    conn = TrackingFakeConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setenv("CALLSIGN", "aiden")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+
+    rc = mod.main(["complete", "KEI-89", "--evidence", str(ev_file)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "matches prior verification" in err
+    assert "KEI-88" in err
+
+    # Only the hash-check SELECT fired; no INSERT or UPDATE
+    assert len(cur.executed) == 1
+
+
+# ─── (5) positive no extra side effects ──────────────────────────────────────
+
+
+def test_positive_evidence_path_inserts_exactly_one_verification_row(
+    mod, monkeypatch, tmp_path, capsys
+):
+    """Valid evidence: exactly one INSERT into task_verifications fires
+    (no duplicate writes, no phantom statements).
+    """
+    ev_file = tmp_path / "evidence.json"
+    ev_file.write_text(json.dumps(_VALID_EVIDENCE))
+
+    cur = MultiStepCursor(
+        step_responses=[
+            [],  # hash check
+            None,  # INSERT
+            ("KEI-89", "Side-effect test task", "done"),  # UPDATE RETURNING
+        ]
+    )
+    conn = TrackingFakeConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setenv("CALLSIGN", "aiden")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+
+    rc = mod.main(["complete", "KEI-89", "--evidence", str(ev_file)])
+    assert rc == 0
+
+    insert_calls = [
+        sql for sql, _ in cur.executed if "INSERT" in sql.upper() and "task_verifications" in sql
+    ]
+    assert len(insert_calls) == 1, f"expected 1 INSERT, got {len(insert_calls)}: {insert_calls}"


### PR DESCRIPTION
## Summary

- `cmd_complete` now requires `--evidence <path|->` — exits 1 with explanatory error if omitted. Mechanically prevents the false-complete pattern that shipped ~11 KEIs per 2026-05-17 audit.
- `_validate_evidence_schema()`: handwritten validator (zero new deps). Required fields: `acceptance_items` (non-empty list), `commands` (list of `{cmd, output}` where `output >= 16 chars`), `verifier_session_uuid`, `timestamp`.
- `_check_hash_uniqueness()`: sha256 of `json.dumps(payload, sort_keys=True)`; rejects if same hash found in `task_verifications` for a *different* task within last 30 days. Error: `evidence text matches prior verification on task <id> at <ts> — reuse not allowed`.
- Atomic transaction: `INSERT task_verifications` then `UPDATE tasks`; ROLLBACK + non-zero exit if UPDATE returns 0 rows (task not claimed by callsign or already done).
- Existing `--force-mode` / `--callsign` / `--json` args and KEI-86 phase-lock guard fully preserved.

## Acceptance Criteria Checked

- [x] AC-1: valid evidence → task_verifications row inserted + tasks.status='done' + exit 0
- [x] AC-2: missing `--evidence` → exit 1 + stderr contains `--evidence` + `required`/`refusing`
- [x] AC-3: schema fail (missing required field) → exit 1 + stderr `evidence schema invalid`
- [x] AC-4: hash collision (same evidence different task) → exit 1 + stderr `matches prior verification` + prior task_id cited
- [x] AC-5 (bonus): exactly 1 INSERT fires — no phantom side-effects

## Quality Gates

```
ruff check scripts/tasks_cli.py tests/scripts/test_tasks_cli_evidence.py
All checks passed!

ruff format --check scripts/tasks_cli.py tests/scripts/test_tasks_cli_evidence.py
2 files already formatted

pytest tests/scripts/test_tasks_cli_evidence.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
collected 5 items

tests/scripts/test_tasks_cli_evidence.py::test_positive_valid_evidence_completes_task PASSED [ 20%]
tests/scripts/test_tasks_cli_evidence.py::test_negative_missing_evidence_exits_nonzero PASSED [ 40%]
tests/scripts/test_tasks_cli_evidence.py::test_negative_schema_fail_missing_required_field PASSED [ 60%]
tests/scripts/test_tasks_cli_evidence.py::test_negative_hash_collision_rejects_reuse PASSED [ 80%]
tests/scripts/test_tasks_cli_evidence.py::test_positive_evidence_path_inserts_exactly_one_verification_row PASSED [100%]

5 passed in 0.20s
```

## KEI-108 Gate

No new `.service` file. No new `APIRouter`. Structural pass confirmed.

## References

- Linear KEI-89 / KEI-128 phase 0.5
- 3-way ratified spec (Elliot+Max+Aiden ts ~1779010883)
- Phase-lock=1 unlocked by Dave at ts ~1779019758

🤖 Generated with [Claude Code](https://claude.com/claude-code)