### PR TITLE
[ATLAS] feat(kei140): keepalive ExecStartPre + claude-PID supervision

### DIFF
--- a/infra/systemd/agents/aiden-agent.service
+++ b/infra/systemd/agents/aiden-agent.service
@@ -11,6 +11,9 @@ Type=simple
 Environment="CALLSIGN=aiden"
 EnvironmentFile=/home/elliotbot/.config/agency-os/.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS-aiden
+# KEI-140 ExecStartPre — fail-open via '-' prefix. See atlas-agent.service for full rationale.
+ExecStartPre=-/usr/bin/git -C /home/elliotbot/clawd/Agency_OS-aiden pull origin main --rebase --autostash
+ExecStartPre=-/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/cognee_session_start.py --callsign aiden
 ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/agent_keepalive.sh aiden aiden /home/elliotbot/clawd/Agency_OS-aiden
 ExecStartPost=/home/elliotbot/clawd/Agency_OS/scripts/agent_online_notify.sh AIDEN 15 C0B3QB0K1GQ
 Restart=always

--- a/infra/systemd/agents/atlas-agent.service
+++ b/infra/systemd/agents/atlas-agent.service
@@ -11,6 +11,17 @@ Type=simple
 Environment="CALLSIGN=atlas"
 EnvironmentFile=/home/elliotbot/.config/agency-os/.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS-atlas
+# KEI-140 ExecStartPre — both fail-open via '-' prefix:
+# (a) rebase the worktree onto origin/main so each restart picks up the latest
+#     code. --autostash handles dirty trees; on conflict, git logs and exits
+#     non-zero — '-' makes systemd treat that as success so the keepalive
+#     still starts (Gate 4 outcome counter on the agent will eventually flag
+#     the missing pulls).
+# (b) hydrate /tmp/cognee-context-<callsign>.md from recent Cognee memory so
+#     the fresh claude session has Phase 0 context before its first turn.
+#     Empty/missing stub OK — script handles fail-open per its own contract.
+ExecStartPre=-/usr/bin/git -C /home/elliotbot/clawd/Agency_OS-atlas pull origin main --rebase --autostash
+ExecStartPre=-/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/cognee_session_start.py --callsign atlas
 ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/agent_keepalive.sh atlas atlas /home/elliotbot/clawd/Agency_OS-atlas
 ExecStartPost=/home/elliotbot/clawd/Agency_OS/scripts/agent_online_notify.sh ATLAS 15 C0B3QB0K1GQ
 Restart=always

--- a/infra/systemd/agents/elliot-agent.service
+++ b/infra/systemd/agents/elliot-agent.service
@@ -11,6 +11,10 @@ Type=simple
 Environment="CALLSIGN=elliot"
 EnvironmentFile=/home/elliotbot/.config/agency-os/.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+# KEI-140 ExecStartPre — fail-open via '-' prefix. See atlas-agent.service for full rationale.
+# Elliot runs from the main worktree (Agency_OS).
+ExecStartPre=-/usr/bin/git -C /home/elliotbot/clawd/Agency_OS pull origin main --rebase --autostash
+ExecStartPre=-/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/cognee_session_start.py --callsign elliot
 ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/agent_keepalive.sh elliottbot elliot /home/elliotbot/clawd/Agency_OS
 ExecStartPost=/home/elliotbot/clawd/Agency_OS/scripts/elliot_fleet_notify.sh 20
 Restart=always

--- a/infra/systemd/agents/max-agent.service
+++ b/infra/systemd/agents/max-agent.service
@@ -11,6 +11,9 @@ Type=simple
 Environment="CALLSIGN=max"
 EnvironmentFile=/home/elliotbot/.config/agency-os/.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS-max
+# KEI-140 ExecStartPre — fail-open via '-' prefix. See atlas-agent.service for full rationale.
+ExecStartPre=-/usr/bin/git -C /home/elliotbot/clawd/Agency_OS-max pull origin main --rebase --autostash
+ExecStartPre=-/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/cognee_session_start.py --callsign max
 ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/agent_keepalive.sh maxbot max /home/elliotbot/clawd/Agency_OS-max
 ExecStartPost=/home/elliotbot/clawd/Agency_OS/scripts/agent_online_notify.sh MAX 15 C0B3QB0K1GQ
 Restart=always

--- a/infra/systemd/agents/orion-agent.service
+++ b/infra/systemd/agents/orion-agent.service
@@ -11,6 +11,9 @@ Type=simple
 Environment="CALLSIGN=orion"
 EnvironmentFile=/home/elliotbot/.config/agency-os/.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS-orion
+# KEI-140 ExecStartPre — fail-open via '-' prefix. See atlas-agent.service for full rationale.
+ExecStartPre=-/usr/bin/git -C /home/elliotbot/clawd/Agency_OS-orion pull origin main --rebase --autostash
+ExecStartPre=-/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/cognee_session_start.py --callsign orion
 ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/agent_keepalive.sh orion orion /home/elliotbot/clawd/Agency_OS-orion
 ExecStartPost=/home/elliotbot/clawd/Agency_OS/scripts/agent_online_notify.sh ORION 15 C0B3QB0K1GQ
 Restart=always

--- a/infra/systemd/agents/scout-agent.service
+++ b/infra/systemd/agents/scout-agent.service
@@ -11,6 +11,9 @@ Type=simple
 Environment="CALLSIGN=scout"
 EnvironmentFile=/home/elliotbot/.config/agency-os/.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS-scout
+# KEI-140 ExecStartPre — fail-open via '-' prefix. See atlas-agent.service for full rationale.
+ExecStartPre=-/usr/bin/git -C /home/elliotbot/clawd/Agency_OS-scout pull origin main --rebase --autostash
+ExecStartPre=-/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/cognee_session_start.py --callsign scout
 ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/agent_keepalive.sh scout scout /home/elliotbot/clawd/Agency_OS-scout
 ExecStartPost=/home/elliotbot/clawd/Agency_OS/scripts/agent_online_notify.sh SCOUT 15 C0B3QB0K1GQ
 Restart=always

--- a/scripts/agent_keepalive.sh
+++ b/scripts/agent_keepalive.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# agent_keepalive.sh — ExecStart wrapper for *-agent.service units (KEI-94).
+# agent_keepalive.sh — ExecStart wrapper for *-agent.service units (KEI-94 + KEI-140).
 #
 # Type=simple + Restart=always keep-alive for agent claude sessions. Each unit
 # blocks on this script until the tmux session terminates; systemd then
@@ -8,6 +8,21 @@
 # Locks worktree (-c) AND callsign (send-keys export) inside the tmux session
 # itself, bypassing the tmux server env-inheritance trap that produced phantom
 # Elliots in the fleet on 2026-05-16 (Dave directive KEI-94).
+#
+# KEI-140 — supervised restart:
+#   Previous behaviour: tmux + claude persisted across `systemctl restart` because
+#   the keepalive was killed but the tmux session it spawned was not. Restart was
+#   a no-op for claude — operator's "reset all" did nothing visible.
+#   Fix: install a SIGTERM trap that kills the pane's leader PID (which IS the
+#   claude process, since the spawn line uses `exec claude`). Killing the pane
+#   leader terminates the pane → terminates the tmux session → keepalive's
+#   `tmux has-session` loop drops out → keepalive exits → systemd restarts the
+#   unit → fresh tmux + fresh claude. Operator sees claude's banner.
+#
+#   Defense-in-depth: the poll loop also verifies the pane leader's /proc/<pid>/comm
+#   contains 'claude'. If a stranded shell ever ended up holding the pane (could
+#   happen if `exec claude` failed mid-line), re-issue the claude_cmd via send-keys
+#   so the pane recovers.
 #
 # Usage:
 #     agent_keepalive.sh <tmux_session> <callsign> <worktree>
@@ -44,6 +59,27 @@ if [[ -n "${KEEPALIVE_DRY:-}" ]]; then
     exit 0
 fi
 
+# KEI-140 — SIGTERM trap. systemd's `systemctl restart` sends SIGTERM to the
+# keepalive process. By default this kills the keepalive but leaves the tmux
+# session (and claude inside it) running, so the restart is invisible.
+# The trap kills the pane's leader PID — which IS claude (we exec'd into it) —
+# so the session unwinds: claude dies → pane dies → tmux session dies → next
+# unit start spawns a fresh session + claude. Operator sees claude's banner.
+_kill_claude_on_term() {
+    echo "[keepalive] received SIGTERM/SIGINT — killing pane leader so restart respawns claude" >&2
+    if tmux has-session -t "$session" 2>/dev/null; then
+        local pane_pid
+        pane_pid=$(tmux list-panes -t "$session" -F '#{pane_pid}' 2>/dev/null | head -1 || true)
+        if [[ -n "$pane_pid" ]] && [[ -d "/proc/$pane_pid" ]]; then
+            kill -TERM "$pane_pid" 2>/dev/null || true
+            # Give claude a moment to clean up before the pane is reaped.
+            sleep 1
+        fi
+    fi
+    exit 0
+}
+trap _kill_claude_on_term TERM INT
+
 if ! tmux has-session -t "$session" 2>/dev/null; then
     echo "[keepalive] spawning tmux session=$session callsign=$callsign worktree=$worktree"
     tmux new-session -d -s "$session" -c "$worktree"
@@ -52,7 +88,25 @@ else
     echo "[keepalive] tmux session=$session already alive — attaching watcher"
 fi
 
+# KEI-140 defense-in-depth: poll loop verifies the pane leader is `claude`,
+# not a stranded shell prompt. If claude failed to exec cleanly, send-keys
+# again. Cheap to check — one tmux + one /proc read per `poll_seconds`.
+_pane_running_claude() {
+    local pane_pid
+    pane_pid=$(tmux list-panes -t "$session" -F '#{pane_pid}' 2>/dev/null | head -1 || true)
+    [[ -n "$pane_pid" ]] || return 1
+    [[ -d "/proc/$pane_pid" ]] || return 1
+    if [[ -r "/proc/$pane_pid/comm" ]]; then
+        grep -q claude "/proc/$pane_pid/comm" 2>/dev/null || return 1
+    fi
+    return 0
+}
+
 while tmux has-session -t "$session" 2>/dev/null; do
+    if ! _pane_running_claude; then
+        echo "[keepalive] pane leader is not claude — re-issuing claude_cmd" >&2
+        tmux send-keys -t "$session" "$claude_cmd" Enter
+    fi
     sleep "$poll_seconds"
 done
 


### PR DESCRIPTION
## Summary

Closes the silent-restart gap: `systemctl --user restart <agent>.service` will now visibly restart claude (previous behaviour: tmux + claude persisted across keepalive restart, making restart a no-op). Adds per-restart `git pull --rebase --autostash` + `cognee_session_start.py` hydration via `ExecStartPre`. Phase 0.5 critical per Dave's KEI-140 (enables hands-free "reset all").

**Linear:** [KEI-140](https://linear.app/keiracom/issue/KEI-140) · **Branch:** `atlas/kei140-keepalive-supervised-restart`

## What lands (7 files)

### (a) ExecStartPre on all 6 agent units
| Unit | Worktree |
|---|---|
| `atlas-agent.service` | `Agency_OS-atlas` |
| `aiden-agent.service` | `Agency_OS-aiden` |
| `elliot-agent.service` | `Agency_OS` (main worktree) |
| `max-agent.service` | `Agency_OS-max` |
| `orion-agent.service` | `Agency_OS-orion` |
| `scout-agent.service` | `Agency_OS-scout` |

Each unit adds two `ExecStartPre=-` lines (the `-` prefix = systemd treats non-zero exit as success → true fail-open):

```
ExecStartPre=-/usr/bin/git -C <worktree> pull origin main --rebase --autostash
ExecStartPre=-/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/cognee_session_start.py --callsign <callsign>
```

### (b) Supervised restart in `scripts/agent_keepalive.sh`
1. **SIGTERM/SIGINT trap** kills the pane leader PID. Since the spawn line uses `exec claude`, the pane leader IS claude. Killing it → pane terminates → tmux session terminates → keepalive's `tmux has-session` loop drops out → keepalive exits → systemd restarts → fresh tmux + fresh claude. Operator sees claude's banner.
2. **Defense-in-depth poll**: verifies `/proc/<pane_pid>/comm` contains `claude`. If a stranded shell ever holds the pane, re-issues `claude_cmd` via send-keys.

## Acceptance (per dispatch — verifiable host-side post deploy)

- [ ] `journalctl --user-unit atlas-agent.service` (post-restart) shows the `ExecStartPre` git pull invocation verbatim.
- [ ] `/tmp/cognee-context-<callsign>.md` regenerated (or empty stub) on each restart.
- [ ] `systemctl --user restart atlas-agent.service` visibly restarts claude — pane sees the claude banner; pre/post claude PID differs.
- [ ] KEI-108 anti-false-complete gate green (this PR modifies existing units + script; no new units needing matched install path).

## Local verification limits

The SIGTERM trap path requires a live systemd + tmux to exercise. CI can't simulate it. Verbatim acceptance evidence comes from a live restart on Vultr post-deploy — per dispatch's coordination note: "keepalive change affects ALL 6 agent services; coordinate with Elliot before fleet-wide restart for the test."

`KEEPALIVE_DRY=1` still works for arg-parsing smoke (existing path unchanged).

## Out of scope (intentional follow-up)

- Fleet-wide deployment coordination — keepalive change ripples through every restart. Elliot coordinates before fleet restart.
- A bats/pytest smoke for the SIGTERM trap — needs live tmux + systemd. Acceptance is operational, not CI.

## Dual approval

[ELLIOT] + [AIDEN]. Dave merges (or merge-after-dual-concur per recent pattern).

## Test plan

- [ ] CI ruff + dead-ref + migration-guard green
- [ ] CI KEI-108 install-wired gate green (no new units; existing units unchanged in structure)
- [ ] Manual review: SIGTERM trap correctness — kill pane leader, expect cascade
- [ ] Manual review: ExecStartPre order — git pull → cognee_session_start → keepalive. Ordering correct for the spawn dependency chain.
- [ ] Coordinate with Elliot for the post-merge fleet restart to verify acceptance criteria verbatim on Vultr

🤖 Generated with [Claude Code](https://claude.com/claude-code)