### PR TITLE
[MAX] feat(kei150): remove assignee filtering from self-claim loop (Phase 0)

### DIFF
--- a/scripts/orchestrator/self_assign_on_ready.py
+++ b/scripts/orchestrator/self_assign_on_ready.py
@@ -110,16 +110,18 @@ def _bd_claim(bd_bin: str, issue_id: str) -> bool:
 
 
 def _eligible(item: dict, callsign: str) -> bool:
-    """Filter rule: unassigned OR assigned to this callsign — never poach."""
-    owner = (item.get("owner") or "").strip()
-    assignee = (item.get("assignee") or "").strip()
-    # 'owner' on bd is typically the email user; 'assignee' (set by --assignee
-    # flag) carries the callsign. Either being equal to callsign is fine.
-    if assignee == callsign:
-        return True
-    if not owner and not assignee:
-        return True
-    return owner == callsign
+    """KEI-150 — assignee filtering removed (Dave 2026-05-17).
+
+    Phase-lock (KEI-86) + SELECT FOR UPDATE SKIP LOCKED already gate
+    eligibility mechanically; the prior owner/assignee-match heuristic
+    blocked agents from picking up work that no peer was actively
+    building. Returning True universally lets any agent claim any
+    visible KEI from the phase-gated queue. The `item` and `callsign`
+    arguments are retained for backwards-compatible test fixtures and
+    a possible future per-row policy hook.
+    """
+    del item, callsign  # intentionally unused — see docstring
+    return True
 
 
 def _result(

--- a/tests/orchestrator/test_self_assign_on_ready.py
+++ b/tests/orchestrator/test_self_assign_on_ready.py
@@ -6,8 +6,8 @@ Covers:
   - claim race lost on first → retry next, eventually succeed
   - claim race lost on all attempts → graceful no-op
   - no eligible work (empty bd ready)
-  - eligibility filter: never claim a peer's assigned work
-  - eligibility filter: unassigned OR same-callsign assignee both pass
+  - eligibility filter: KEI-150 — any agent can claim any item (assignee
+    filtering removed; phase-lock + SKIP LOCKED gate mechanically)
   - priority ordering: P0 beats P1, P1 beats P2
   - dry-run prints the target without calling claim_fn
   - invalid callsign rejected
@@ -119,14 +119,15 @@ def test_no_eligible_work_when_bd_ready_empty():
     assert result["reason"] == "no_eligible_work"
 
 
-# ─── 5. Eligibility filter: never poach peer's work ─────────────────────
+# ─── 5. KEI-150 — assignee filtering removed; any agent can claim any item ───
 
 
-def test_does_not_claim_peer_assigned_work():
-    """Issue assigned to atlas must NEVER be claimed by orion — Pattern A
-    teaching: writer-side migration must include reader close. Same shape
-    here: claiming a peer's work would steal context that peer already
-    started accumulating."""
+def test_claims_peer_assigned_work_kei150():
+    """KEI-150 (Dave 2026-05-17) — assignee filtering removed. Phase-lock
+    + SKIP LOCKED handle eligibility mechanically; an item assigned to
+    atlas in Linear is still claimable by orion via the auto-claim loop.
+    The prior 'never poach' rule blocked agents from picking up stale
+    pre-assignments and was the #1 source of READY-loop idle time."""
     items = [
         _item("Agency_OS-peer", priority="P0", assignee="atlas"),
     ]
@@ -137,9 +138,9 @@ def test_does_not_claim_peer_assigned_work():
         return True
 
     result = mod.run(callsign="orion", ready_fn=lambda: items, claim_fn=claim_fn)
-    assert result["claimed"] is False
-    assert result["reason"] == "no_eligible_work"
-    assert claimed == []
+    assert result["claimed"] is True
+    assert result["issue_id"] == "Agency_OS-peer"
+    assert claimed == ["Agency_OS-peer"]
 
 
 # ─── 6. Eligibility filter: own-callsign assignee passes ────────────────


### PR DESCRIPTION
Linear KEI-150 — remove assignee-filtering from `scripts/orchestrator/self_assign_on_ready.py:_eligible`. Phase-lock (KEI-86) + SELECT FOR UPDATE SKIP LOCKED in cmd_claim already gate eligibility mechanically; the prior 'unassigned OR assignee == callsign' heuristic was Dave's #1 named source of READY-loop idle time (KEI-130 dispatch).

## Change

`_eligible` now unconditionally returns True. Args retained for backwards-compat with existing test fixtures and a possible future per-row policy hook.

## Tests

The existing 'never poach' test inverted to assert the new claim (orion can claim atlas-assigned work because phase-lock + SKIP LOCKED is the gate). 13/13 self_assign tests pass.

```
$ python3 -m pytest tests/orchestrator/test_self_assign_on_ready.py
13 passed in 0.10s

$ ruff check + ruff format --check
All checks passed!
2 files already formatted
```

## KEI-108 gate

Structural pass (no new .service or APIRouter). +24/-21 across 2 files.

Closes Linear KEI-150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)