### PR TITLE
[AIDEN] feat(kei97): auto-create review-PR tasks via GitHub webhook + excluded_callsign filter

### DIFF
--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -128,12 +128,6 @@ def _validate_command_entry(i: int, entry: object) -> str | None:
 def _validate_evidence_schema(payload: dict) -> str | None:
     """Validate the evidence JSON payload shape. Returns an error string on
     failure, or None when the payload is valid.
-
-    Required fields:
-      - acceptance_items  list[str], non-empty
-      - commands          list[{cmd: str, output: str}] where each output >= 16 chars
-      - verifier_session_uuid  str, non-empty
-      - timestamp         str (ISO 8601), non-empty
     """
     for field in ("acceptance_items", "commands", "verifier_session_uuid", "timestamp"):
         if field not in payload:
@@ -170,9 +164,6 @@ def _check_hash_uniqueness(
 ) -> tuple[str | None, str | None]:
     """Check task_verifications for reuse of the same evidence text on a
     DIFFERENT task within the last 30 days.
-
-    Returns (prior_task_id, prior_created_at) if a collision is found,
-    or (None, None) if the evidence is unique.
     """
     cur.execute(
         """
@@ -196,6 +187,53 @@ def _check_hash_uniqueness(
     return None, None
 
 
+def _build_ready_sql(agent: str, callsign: str, phase_max: int, limit: int) -> tuple[str, tuple]:
+    """Compose the ready-query SQL + params for personalised/legacy and
+    callsign-excluded/all variants. Extracted so cmd_ready stays under
+    SonarCloud's cognitive-complexity cap (S3776)."""
+    exclusion_clause = (
+        "AND (t.excluded_callsign IS NULL OR t.excluded_callsign != %s) " if callsign else ""
+    )
+    if agent:
+        sql = (
+            f"SELECT t.{', t.'.join(_READY_COLUMNS.split(', '))}, "
+            f"{_PERSONALISED_SCORE_SUBQUERY} "
+            "FROM public.tasks t WHERE t.status = 'available' AND t.claimed_by IS NULL "
+            "AND t.phase <= %s "
+            f"{exclusion_clause}"
+            "ORDER BY personalised_score DESC, "
+            "t.priority ASC, t.created_at ASC LIMIT %s"
+        )
+        params: tuple = (
+            (agent, phase_max, callsign, limit) if callsign else (agent, phase_max, limit)
+        )
+        return sql, params
+    # KEI-97 — exclusion clause splices in identically on the non-personalised path.
+    sql = (
+        f"SELECT {_READY_COLUMNS} FROM public.tasks "
+        "WHERE status = 'available' AND claimed_by IS NULL "
+        "AND phase <= %s "
+        f"{exclusion_clause}"
+        "ORDER BY priority ASC, created_at ASC LIMIT %s"
+    )
+    params = (phase_max, callsign, limit) if callsign else (phase_max, limit)
+    return sql, params
+
+
+def _print_ready_rows(rows: list[dict], agent: str) -> None:
+    """Render the human-readable ready listing. Extracted from cmd_ready
+    so the main entry-point stays under S3776's complexity cap."""
+    for r in rows:
+        score_suffix = (
+            f"  [score={r['personalised_score']:.2f}]"
+            if agent and "personalised_score" in r
+            else ""
+        )
+        print(f"  P{r['priority']:>1}  {r['id']:<24}  {r['title']}{score_suffix}")
+    suffix = f" (personalised for {agent})" if agent else ""
+    print(f"\n{len(rows)} available{suffix}")
+
+
 def cmd_ready(args: argparse.Namespace) -> int:
     """List available tasks ordered by priority ASC then created_at ASC.
 
@@ -213,48 +251,13 @@ def cmd_ready(args: argparse.Namespace) -> int:
 
     limit = max(1, min(args.limit, 250))
     agent = (args.agent or "").strip().lower() if getattr(args, "agent", None) else ""
-    # KEI-97 — callsign for author-exclusion filter (distinct from --agent
-    # personalisation). Falls back to env; None means no exclusion filter.
     callsign_arg = getattr(args, "callsign", None)
     callsign = (callsign_arg or "").strip().lower() if callsign_arg else ""
     try:
         with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
             phase_max = _current_phase_max(cur)
-            # KEI-97 — exclusion clause appended only when --callsign given.
-            exclusion_clause = (
-                "AND (t.excluded_callsign IS NULL OR t.excluded_callsign != %s) "
-                if callsign
-                else ""
-            )
-            if agent:
-                # KEI-53 — personalised path. Tie-break per Max note #2:
-                # personalised_score DESC, priority ASC, created_at ASC.
-                # KEI-86 — also filter by phase <= current_phase_max.
-                sql = (
-                    f"SELECT t.{', t.'.join(_READY_COLUMNS.split(', '))}, "
-                    f"{_PERSONALISED_SCORE_SUBQUERY} "
-                    "FROM public.tasks t WHERE t.status = 'available' AND t.claimed_by IS NULL "
-                    "AND t.phase <= %s "
-                    f"{exclusion_clause}"
-                    "ORDER BY personalised_score DESC, "
-                    "t.priority ASC, t.created_at ASC LIMIT %s"
-                )
-                params: tuple = (
-                    (agent, phase_max, callsign, limit) if callsign else (agent, phase_max, limit)
-                )
-                cur.execute(sql, params)
-            else:
-                # KEI-86 — phase-lock filter on the non-personalised path too.
-                # KEI-97 — exclusion clause spliced in when callsign known.
-                sql = (
-                    f"SELECT {_READY_COLUMNS} FROM public.tasks "
-                    "WHERE status = 'available' AND claimed_by IS NULL "
-                    "AND phase <= %s "
-                    f"{exclusion_clause}"
-                    "ORDER BY priority ASC, created_at ASC LIMIT %s"
-                )
-                params = (phase_max, callsign, limit) if callsign else (phase_max, limit)
-                cur.execute(sql, params)
+            sql, params = _build_ready_sql(agent, callsign, phase_max, limit)
+            cur.execute(sql, params)
             rows = _rows_to_dicts(cur)
     except psycopg.Error:
         logger.exception("ready query failed")
@@ -262,13 +265,7 @@ def cmd_ready(args: argparse.Namespace) -> int:
     if args.json:
         print(json.dumps(rows, default=str))
     else:
-        for r in rows:
-            score_suffix = ""
-            if agent and "personalised_score" in r:
-                score_suffix = f"  [score={r['personalised_score']:.2f}]"
-            print(f"  P{r['priority']:>1}  {r['id']:<24}  {r['title']}{score_suffix}")
-        suffix = f" (personalised for {agent})" if agent else ""
-        print(f"\n{len(rows)} available{suffix}")
+        _print_ready_rows(rows, agent)
     return 0
 
 

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -203,14 +203,29 @@ def cmd_ready(args: argparse.Namespace) -> int:
     personalised affinity score = SUM(capability_weight × matching_tag).
     Adds `personalised_score` to each row; preserves existing JSON shape
     (no renames) per Max's tasks-cli compat note.
+
+    KEI-97: if --callsign is supplied, filter out tasks where
+    excluded_callsign matches the given callsign (author-exclusion for
+    REVIEW-PR tasks). Without --callsign, the exclusion filter is skipped
+    (legacy behaviour preserved).
     """
     import psycopg
 
     limit = max(1, min(args.limit, 250))
     agent = (args.agent or "").strip().lower() if getattr(args, "agent", None) else ""
+    # KEI-97 — callsign for author-exclusion filter (distinct from --agent
+    # personalisation). Falls back to env; None means no exclusion filter.
+    callsign_arg = getattr(args, "callsign", None)
+    callsign = (callsign_arg or "").strip().lower() if callsign_arg else ""
     try:
         with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
             phase_max = _current_phase_max(cur)
+            # KEI-97 — exclusion clause appended only when --callsign given.
+            exclusion_clause = (
+                "AND (t.excluded_callsign IS NULL OR t.excluded_callsign != %s) "
+                if callsign
+                else ""
+            )
             if agent:
                 # KEI-53 — personalised path. Tie-break per Max note #2:
                 # personalised_score DESC, priority ASC, created_at ASC.
@@ -220,19 +235,26 @@ def cmd_ready(args: argparse.Namespace) -> int:
                     f"{_PERSONALISED_SCORE_SUBQUERY} "
                     "FROM public.tasks t WHERE t.status = 'available' AND t.claimed_by IS NULL "
                     "AND t.phase <= %s "
+                    f"{exclusion_clause}"
                     "ORDER BY personalised_score DESC, "
                     "t.priority ASC, t.created_at ASC LIMIT %s"
                 )
-                cur.execute(sql, (agent, phase_max, limit))
+                params: tuple = (
+                    (agent, phase_max, callsign, limit) if callsign else (agent, phase_max, limit)
+                )
+                cur.execute(sql, params)
             else:
                 # KEI-86 — phase-lock filter on the non-personalised path too.
+                # KEI-97 — exclusion clause spliced in when callsign known.
                 sql = (
                     f"SELECT {_READY_COLUMNS} FROM public.tasks "
                     "WHERE status = 'available' AND claimed_by IS NULL "
                     "AND phase <= %s "
+                    f"{exclusion_clause}"
                     "ORDER BY priority ASC, created_at ASC LIMIT %s"
                 )
-                cur.execute(sql, (phase_max, limit))
+                params = (phase_max, callsign, limit) if callsign else (phase_max, limit)
+                cur.execute(sql, params)
             rows = _rows_to_dicts(cur)
     except psycopg.Error:
         logger.exception("ready query failed")
@@ -597,6 +619,10 @@ def main(argv: list[str] | None = None) -> int:
     p_ready.add_argument(
         "--agent",
         help="KEI-53 — personalise ranking via agent_profiles.capability_weights",
+    )
+    p_ready.add_argument(
+        "--callsign",
+        help="KEI-97 — exclude tasks where excluded_callsign matches this callsign (author-exclusion for REVIEW-PR tasks)",
     )
     p_ready.set_defaults(func=cmd_ready)
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -422,6 +422,7 @@ from src.api.routes.unipile import router as unipile_router
 from src.api.routes.webhooks import router as webhooks_router
 from src.api.routes.webhooks_outbound import router as webhooks_outbound_router
 from src.api.webhooks.elevenagents import router as elevenagents_router
+from src.api.webhooks.github import router as github_webhook_router
 from src.api.webhooks.linear import router as linear_webhook_router
 
 app.include_router(health_router, prefix="/api/v1")
@@ -464,6 +465,8 @@ app.include_router(cycles_router, prefix="/api/v1")
 app.include_router(elevenagents_router)
 # Linear webhook → Beads sync inbound (router has own /api/webhooks/linear prefix)
 app.include_router(linear_webhook_router)
+# KEI-97: GitHub PR webhook → auto-create REVIEW-PR-N tasks (router has own /api/webhooks/github prefix)
+app.include_router(github_webhook_router)
 # Task #20: Email backend (Resend send + status + HMAC-verified webhook).
 # email_router carries its own `/api/email` prefix — no extra prefix here.
 app.include_router(email_router)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -465,7 +465,7 @@ app.include_router(cycles_router, prefix="/api/v1")
 app.include_router(elevenagents_router)
 # Linear webhook → Beads sync inbound (router has own /api/webhooks/linear prefix)
 app.include_router(linear_webhook_router)
-# KEI-97: GitHub PR webhook → auto-create REVIEW-PR-N tasks (router has own /api/webhooks/github prefix)
+# src.api.webhooks.github — KEI-97 GitHub PR webhook auto-creates REVIEW-PR-N tasks (router carries /api/webhooks/github prefix).
 app.include_router(github_webhook_router)
 # Task #20: Email backend (Resend send + status + HMAC-verified webhook).
 # email_router carries its own `/api/email` prefix — no extra prefix here.

--- a/src/api/webhooks/github.py
+++ b/src/api/webhooks/github.py
@@ -122,8 +122,13 @@ def _close_review_task(pr_number: int) -> None:
         logger.warning("github webhook tasks close failed for %s: %s", task_id, exc)
 
 
-@router.post("")
-@router.post("/")
+_RECEIVE_RESPONSES: dict[int | str, dict[str, Any]] = {
+    401: {"description": "HMAC signature verification failed."}
+}
+
+
+@router.post("", responses=_RECEIVE_RESPONSES)
+@router.post("/", responses=_RECEIVE_RESPONSES)
 async def receive_github_webhook(request: Request) -> dict[str, str]:
     """Receive a GitHub webhook event, verify HMAC, dispatch to public.tasks.
 

--- a/src/api/webhooks/github.py
+++ b/src/api/webhooks/github.py
@@ -1,0 +1,171 @@
+"""src/api/webhooks/github.py — GitHub → public.tasks inbound webhook.
+
+KEI-97 Part A — Dave dispatch ts ~1779024750.
+
+Receives GitHub webhook POSTs at /api/webhooks/github, verifies HMAC
+signature against GITHUB_WEBHOOK_SECRET (X-Hub-Signature-256 header),
+and upserts REVIEW-PR-<N> rows in public.tasks.
+
+Event handling:
+  - pull_request action='opened'|'reopened' → INSERT/upsert REVIEW-PR-<N>
+    with status='available', excluded_callsign=PR author (lowercased).
+  - pull_request action='closed' (merged or not) → UPDATE status='done'.
+
+Fail-open: HMAC fail → 401; malformed payload → 200 logged warning
+(retry-storm guard, same pattern as src/api/webhooks/linear.py).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/webhooks/github", tags=["webhooks", "github"])
+
+_OPEN_ACTIONS = frozenset({"opened", "reopened"})
+
+
+def _verify_signature(secret: str, body: bytes, signature_header: str) -> bool:
+    """Constant-time HMAC SHA-256 verify per GitHub webhook docs.
+
+    GitHub sends 'sha256=<hex>' in X-Hub-Signature-256. We strip the prefix
+    before comparing so the caller can pass either the raw header value or
+    just the hex portion.
+    """
+    if not signature_header or not secret:
+        return False
+    sig = signature_header.removeprefix("sha256=").strip()
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, sig)
+
+
+def _task_id(pr_number: int) -> str:
+    return f"REVIEW-PR-{pr_number}"
+
+
+def _upsert_review_task(pr: dict[str, Any]) -> None:
+    """INSERT or UPDATE a REVIEW-PR-<N> row in public.tasks. Fail-open."""
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        logger.warning("github webhook tasks upsert skipped: DATABASE_URL/SUPABASE_DB_URL unset")
+        return
+    dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+    pr_number: int = pr["number"]
+    pr_title: str = pr.get("title") or ""
+    pr_url: str = pr.get("html_url") or ""
+    pr_body: str = pr.get("body") or ""
+    author: str = (pr.get("user") or {}).get("login") or ""
+    author_lower = author.lower()
+
+    task_id = _task_id(pr_number)
+    task_title = f"Review PR #{pr_number} — {pr_title}"
+    task_description = pr_url + "\n\n" + pr_body[:500]
+
+    try:
+        import psycopg
+
+        with psycopg.connect(dsn, connect_timeout=10) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO public.tasks (
+                    id, title, description, status, phase, claim_source,
+                    excluded_callsign, created_at, updated_at
+                )
+                VALUES (%s, %s, %s, 'available', 0, 'manual', %s, NOW(), NOW())
+                ON CONFLICT (id) DO UPDATE
+                    SET title             = EXCLUDED.title,
+                        description       = EXCLUDED.description,
+                        excluded_callsign = EXCLUDED.excluded_callsign,
+                        updated_at        = NOW()
+                """,
+                (task_id, task_title, task_description, author_lower or None),
+            )
+            conn.commit()
+        logger.info("github webhook: upserted task %s (author=%s)", task_id, author_lower)
+    except Exception as exc:  # noqa: BLE001 — webhook discipline: fail-open
+        logger.warning("github webhook tasks upsert failed for %s: %s", task_id, exc)
+
+
+def _close_review_task(pr_number: int) -> None:
+    """Mark REVIEW-PR-<N> done when PR is closed. Fail-open."""
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        logger.warning("github webhook tasks close skipped: DATABASE_URL/SUPABASE_DB_URL unset")
+        return
+    dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+    task_id = _task_id(pr_number)
+    try:
+        import psycopg
+
+        with psycopg.connect(dsn, connect_timeout=10) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE public.tasks
+                   SET status = 'done', updated_at = NOW()
+                 WHERE id = %s
+                """,
+                (task_id,),
+            )
+            conn.commit()
+        logger.info("github webhook: closed task %s", task_id)
+    except Exception as exc:  # noqa: BLE001 — webhook discipline: fail-open
+        logger.warning("github webhook tasks close failed for %s: %s", task_id, exc)
+
+
+@router.post("")
+@router.post("/")
+async def receive_github_webhook(request: Request) -> dict[str, str]:
+    """Receive a GitHub webhook event, verify HMAC, dispatch to public.tasks.
+
+    Handles pull_request events only:
+      - opened/reopened → upsert REVIEW-PR-<N> task
+      - closed          → mark task done
+    All other event types return status='ignored'.
+    """
+    body = await request.body()
+    secret = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
+    signature = request.headers.get("x-hub-signature-256", "")
+
+    if not _verify_signature(secret, body, signature):
+        logger.warning("github webhook signature verify failed")
+        raise HTTPException(status_code=401, detail="signature verification failed")
+
+    # Check event type header — GitHub sends X-GitHub-Event
+    event_type = request.headers.get("x-github-event", "")
+    if event_type != "pull_request":
+        return {"status": "ignored", "event": event_type}
+
+    try:
+        payload = json.loads(body or b"{}")
+    except json.JSONDecodeError:
+        logger.warning("github webhook malformed json payload")
+        return {"status": "malformed"}
+
+    action = payload.get("action", "")
+    pr = payload.get("pull_request") or {}
+    pr_number = pr.get("number")
+
+    if pr_number is None:
+        logger.warning("github webhook: pull_request payload missing number field")
+        return {"status": "malformed"}
+
+    if action in _OPEN_ACTIONS:
+        _upsert_review_task(pr)
+        return {"status": "ok", "action": action, "task_id": _task_id(pr_number)}
+
+    if action == "closed":
+        _close_review_task(pr_number)
+        return {"status": "ok", "action": action, "task_id": _task_id(pr_number)}
+
+    # Other actions (assigned, labeled, synchronize, etc.) — ignore
+    return {"status": "ignored", "action": action}

--- a/supabase/migrations/20260517_kei97_excluded_callsign.sql
+++ b/supabase/migrations/20260517_kei97_excluded_callsign.sql
@@ -1,0 +1,9 @@
+-- KEI-97: add excluded_callsign column to public.tasks
+-- Author-exclusion for REVIEW-PR tasks: the PR author cannot auto-claim
+-- the review task for their own PR. bd ready filters this column out.
+
+ALTER TABLE public.tasks
+  ADD COLUMN IF NOT EXISTS excluded_callsign TEXT;
+
+COMMENT ON COLUMN public.tasks.excluded_callsign IS
+  'KEI-97: callsign that cannot auto-claim this task (e.g. PR author for review tasks). bd ready filters where excluded_callsign IS NULL OR excluded_callsign != current_callsign.';

--- a/tests/api/webhooks/test_github_webhook.py
+++ b/tests/api/webhooks/test_github_webhook.py
@@ -1,0 +1,333 @@
+"""Tests for src/api/webhooks/github.py — KEI-97 GitHub PR → tasks upsert.
+
+Covers:
+  - PR opened → REVIEW-PR-<N> row inserted with correct fields
+  - PR closed → row status='done'
+  - HMAC fail → 401 + no DB write
+  - Malformed payload → 200 + log
+  - Author exclusion: PR opened by aiden → excluded_callsign='aiden'
+
+Mocks psycopg + httpx; no live DB or live GitHub.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT = REPO_ROOT / "src" / "api" / "webhooks" / "github.py"
+TEST_SECRET = "test-github-webhook-secret"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("github_webhook", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["github_webhook"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def _make_client(mod, monkeypatch, *, secret: str = TEST_SECRET):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", secret)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    app = FastAPI()
+    app.include_router(mod.router)
+    return TestClient(app)
+
+
+def _sign(body: bytes, secret: str = TEST_SECRET) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _pr_payload(
+    number: int = 42,
+    title: str = "My Feature",
+    html_url: str = "https://github.com/org/repo/pull/42",
+    body: str = "PR body",
+    author: str = "aiden",
+    action: str = "opened",
+) -> dict:
+    return {
+        "action": action,
+        "pull_request": {
+            "number": number,
+            "title": title,
+            "html_url": html_url,
+            "body": body,
+            "user": {"login": author},
+        },
+    }
+
+
+# ── HMAC verification ───────────────────────────────────────────────────────
+
+
+def test_missing_signature_returns_401(mod, monkeypatch):
+    client = _make_client(mod, monkeypatch)
+    resp = client.post(
+        "/api/webhooks/github",
+        json=_pr_payload(),
+        headers={"x-github-event": "pull_request"},
+    )
+    assert resp.status_code == 401
+
+
+def test_wrong_signature_returns_401(mod, monkeypatch):
+    client = _make_client(mod, monkeypatch)
+    raw = json.dumps(_pr_payload()).encode()
+    resp = client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": "sha256=" + "0" * 64,
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_hmac_fail_does_not_write_db(mod, monkeypatch):
+    """No DB write on HMAC failure — upsert and close helpers must NOT be called."""
+    upsert_calls: list = []
+    close_calls: list = []
+    monkeypatch.setattr(mod, "_upsert_review_task", lambda pr: upsert_calls.append(pr))
+    monkeypatch.setattr(mod, "_close_review_task", lambda n: close_calls.append(n))
+    client = _make_client(mod, monkeypatch)
+    raw = json.dumps(_pr_payload()).encode()
+    client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": "sha256=" + "0" * 64,
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert upsert_calls == []
+    assert close_calls == []
+
+
+# ── PR opened ──────────────────────────────────────────────────────────────
+
+
+def test_pr_opened_upserts_task(mod, monkeypatch):
+    """PR opened → _upsert_review_task called with correct PR dict."""
+    upsert_calls: list = []
+    monkeypatch.setattr(mod, "_upsert_review_task", lambda pr: upsert_calls.append(pr))
+    monkeypatch.setattr(mod, "_close_review_task", lambda n: None)
+    client = _make_client(mod, monkeypatch)
+
+    payload = _pr_payload(number=7, title="Fix Bug", author="elliot", action="opened")
+    raw = json.dumps(payload).encode()
+    resp = client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": _sign(raw),
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["task_id"] == "REVIEW-PR-7"
+    assert len(upsert_calls) == 1
+    assert upsert_calls[0]["number"] == 7
+
+
+def test_pr_reopened_upserts_task(mod, monkeypatch):
+    """PR reopened → same upsert path as opened."""
+    upsert_calls: list = []
+    monkeypatch.setattr(mod, "_upsert_review_task", lambda pr: upsert_calls.append(pr))
+    monkeypatch.setattr(mod, "_close_review_task", lambda n: None)
+    client = _make_client(mod, monkeypatch)
+
+    payload = _pr_payload(number=9, action="reopened")
+    raw = json.dumps(payload).encode()
+    resp = client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": _sign(raw),
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert len(upsert_calls) == 1
+
+
+# ── PR closed ──────────────────────────────────────────────────────────────
+
+
+def test_pr_closed_marks_done(mod, monkeypatch):
+    """PR closed → _close_review_task called with PR number."""
+    close_calls: list = []
+    monkeypatch.setattr(mod, "_upsert_review_task", lambda pr: None)
+    monkeypatch.setattr(mod, "_close_review_task", lambda n: close_calls.append(n))
+    client = _make_client(mod, monkeypatch)
+
+    payload = _pr_payload(number=42, action="closed")
+    raw = json.dumps(payload).encode()
+    resp = client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": _sign(raw),
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["task_id"] == "REVIEW-PR-42"
+    assert close_calls == [42]
+
+
+# ── Malformed payload ──────────────────────────────────────────────────────
+
+
+def test_malformed_payload_returns_200(mod, monkeypatch):
+    """Malformed JSON → 200 (fail-open, no retry-storm)."""
+    client = _make_client(mod, monkeypatch)
+    bad_body = b"not json{"
+    sig = _sign(bad_body)
+    resp = client.post(
+        "/api/webhooks/github",
+        content=bad_body,
+        headers={
+            "x-hub-signature-256": sig,
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "malformed"
+
+
+# ── Author exclusion ───────────────────────────────────────────────────────
+
+
+def test_pr_author_exclusion_stored(mod, monkeypatch):
+    """PR opened by 'aiden' → DB upsert sets excluded_callsign='aiden'."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+
+    fake_cur = MagicMock()
+    fake_conn = MagicMock()
+    fake_conn.__enter__ = MagicMock(return_value=fake_conn)
+    fake_conn.__exit__ = MagicMock(return_value=False)
+    fake_conn.cursor.return_value.__enter__ = MagicMock(return_value=fake_cur)
+    fake_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    import psycopg
+
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: fake_conn)
+
+    pr = {
+        "number": 15,
+        "title": "Aiden's PR",
+        "html_url": "https://github.com/org/repo/pull/15",
+        "body": "body text",
+        "user": {"login": "Aiden"},  # mixed-case — should be lowercased
+    }
+    mod._upsert_review_task(pr)
+
+    assert fake_cur.execute.called
+    sql, params = fake_cur.execute.call_args[0]
+    # excluded_callsign param should be lowercased 'aiden'
+    assert "excluded_callsign" in sql
+    assert "aiden" in params
+
+
+# ── Non-PR events ─────────────────────────────────────────────────────────
+
+
+def test_non_pr_event_ignored(mod, monkeypatch):
+    """push events are ignored (status='ignored')."""
+    client = _make_client(mod, monkeypatch)
+    payload = {"ref": "refs/heads/main", "commits": []}
+    raw = json.dumps(payload).encode()
+    resp = client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": _sign(raw),
+            "x-github-event": "push",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ignored"
+
+
+# ── DB upsert internals ────────────────────────────────────────────────────
+
+
+def test_upsert_writes_correct_fields(mod, monkeypatch):
+    """_upsert_review_task writes title, description, status=available, phase=0, claim_source=manual."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+
+    fake_cur = MagicMock()
+    fake_conn = MagicMock()
+    fake_conn.__enter__ = MagicMock(return_value=fake_conn)
+    fake_conn.__exit__ = MagicMock(return_value=False)
+    fake_conn.cursor.return_value.__enter__ = MagicMock(return_value=fake_cur)
+    fake_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    import psycopg
+
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: fake_conn)
+
+    pr = {
+        "number": 5,
+        "title": "Test PR",
+        "html_url": "https://github.com/org/repo/pull/5",
+        "body": "Some description",
+        "user": {"login": "elliot"},
+    }
+    mod._upsert_review_task(pr)
+
+    assert fake_cur.execute.called
+    sql, params = fake_cur.execute.call_args[0]
+    assert "REVIEW-PR-5" in params
+    assert "Review PR #5 — Test PR" in params
+    assert "available" in sql
+    assert "elliot" in params
+
+
+def test_close_task_writes_done(mod, monkeypatch):
+    """_close_review_task sets status='done'."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+
+    fake_cur = MagicMock()
+    fake_conn = MagicMock()
+    fake_conn.__enter__ = MagicMock(return_value=fake_conn)
+    fake_conn.__exit__ = MagicMock(return_value=False)
+    fake_conn.cursor.return_value.__enter__ = MagicMock(return_value=fake_cur)
+    fake_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    import psycopg
+
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: fake_conn)
+
+    mod._close_review_task(99)
+
+    assert fake_cur.execute.called
+    sql, params = fake_cur.execute.call_args[0]
+    assert "done" in sql
+    assert "REVIEW-PR-99" in params

--- a/tests/scripts/test_tasks_cli_excluded_callsign.py
+++ b/tests/scripts/test_tasks_cli_excluded_callsign.py
@@ -1,0 +1,225 @@
+"""Tests for KEI-97 excluded_callsign filter in scripts/tasks_cli.py cmd_ready.
+
+Covers:
+  - bd ready --callsign=aiden does NOT return rows where excluded_callsign='aiden'
+  - bd ready --callsign=elliot DOES return rows where excluded_callsign='aiden'
+  - bd ready (no --callsign) returns all rows (backward compat, no exclusion filter)
+
+Mocks psycopg cursor; no live DB.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "tasks_cli.py"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _db_mocks import FakeCursor, make_patch_connect  # type: ignore[import-not-found]  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("tasks_cli_excl", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["tasks_cli_excl"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+@pytest.fixture
+def patch_connect(mod, monkeypatch):
+    return make_patch_connect(monkeypatch)
+
+
+# Column list for the ready query result rows (matches _READY_COLUMNS in tasks_cli.py)
+_COLS = [
+    ("id",),
+    ("title",),
+    ("priority",),
+    ("status",),
+    ("claimed_by",),
+    ("claimed_at",),
+    ("dependencies",),
+    ("tags",),
+    ("linear_url",),
+    ("created_at",),
+    ("updated_at",),
+]
+
+# A phase-lock row returned by the ceo_memory query (phase_max=99 = unlocked)
+_PHASE_ROW = (json.dumps({"current_phase_max": 99}),)
+
+
+def _make_cursor(rows: list[tuple]) -> FakeCursor:
+    """Build a FakeCursor that returns _PHASE_ROW first, then rows."""
+    cur = FakeCursor(
+        fetchall_rows=rows,
+        fetchone_row=_PHASE_ROW,
+        description=_COLS,
+    )
+    # Override fetchone to return phase row on first call, then the rows via fetchall.
+    # FakeCursor.fetchone always returns _one; that's fine because phase-lock query
+    # uses fetchone and the ready query uses fetchall.
+    return cur
+
+
+# ── --callsign exclusion path ──────────────────────────────────────────────
+
+
+def test_ready_with_callsign_includes_exclusion_clause(mod, patch_connect, capsys):
+    """--callsign=aiden: SQL must contain the excluded_callsign != %s predicate."""
+    review_row = (
+        "REVIEW-PR-1",
+        "Review PR #1",
+        2,
+        "available",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    cur = _make_cursor([review_row])
+    patch_connect(cur)
+
+    ret = mod.cmd_ready(
+        type(
+            "A",
+            (),
+            {
+                "json": True,
+                "limit": 50,
+                "agent": None,
+                "callsign": "aiden",
+            },
+        )()
+    )
+    assert ret == 0
+
+    # Find the ready SQL (second execute — first is the phase-lock query)
+    ready_exec = [e for e in cur.executed if "excluded_callsign" in e[0]]
+    assert len(ready_exec) == 1, "Expected exactly one execute with excluded_callsign clause"
+    sql, params = ready_exec[0]
+    assert "excluded_callsign" in sql
+    assert "aiden" in params
+
+
+def test_ready_callsign_aiden_receives_non_excluded_rows(mod, patch_connect, capsys):
+    """Rows where excluded_callsign IS NULL pass through for callsign=aiden."""
+    # In this mock, the DB already filters; we simulate the DB returning 1 row.
+    row = ("REVIEW-PR-2", "Review PR #2", 2, "available", None, None, None, None, None, None, None)
+    cur = _make_cursor([row])
+    patch_connect(cur)
+
+    ret = mod.cmd_ready(
+        type(
+            "A",
+            (),
+            {
+                "json": True,
+                "limit": 50,
+                "agent": None,
+                "callsign": "aiden",
+            },
+        )()
+    )
+    assert ret == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert len(data) == 1
+    assert data[0]["id"] == "REVIEW-PR-2"
+
+
+def test_ready_callsign_elliot_receives_rows_excluded_for_aiden(mod, patch_connect, capsys):
+    """Rows excluded for 'aiden' are visible to 'elliot'."""
+    # For elliot, excluded_callsign='aiden' row should pass the filter.
+    row = ("REVIEW-PR-3", "Review PR #3", 2, "available", None, None, None, None, None, None, None)
+    cur = _make_cursor([row])
+    patch_connect(cur)
+
+    ret = mod.cmd_ready(
+        type(
+            "A",
+            (),
+            {
+                "json": True,
+                "limit": 50,
+                "agent": None,
+                "callsign": "elliot",
+            },
+        )()
+    )
+    assert ret == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert len(data) == 1
+
+    # SQL must contain exclusion for 'elliot', not 'aiden'
+    ready_exec = [e for e in cur.executed if "excluded_callsign" in e[0]]
+    assert len(ready_exec) == 1
+    _, params = ready_exec[0]
+    assert "elliot" in params
+
+
+# ── Backward compat: no --callsign ────────────────────────────────────────
+
+
+def test_ready_without_callsign_no_exclusion_clause(mod, patch_connect, capsys):
+    """bd ready without --callsign does not add excluded_callsign filter (legacy)."""
+    row = ("KEI-50", "Some task", 3, "available", None, None, None, None, None, None, None)
+    cur = _make_cursor([row])
+    patch_connect(cur)
+
+    ret = mod.cmd_ready(
+        type(
+            "A",
+            (),
+            {
+                "json": True,
+                "limit": 50,
+                "agent": None,
+                "callsign": None,
+            },
+        )()
+    )
+    assert ret == 0
+
+    # No execute should contain excluded_callsign clause
+    excl_execs = [e for e in cur.executed if "excluded_callsign" in e[0]]
+    assert excl_execs == [], "excluded_callsign clause must NOT appear without --callsign"
+
+
+def test_ready_without_callsign_returns_all_rows(mod, patch_connect, capsys):
+    """Without --callsign, all available rows are returned (no exclusion)."""
+    rows = [
+        ("REVIEW-PR-10", "Review PR #10", 2, "available", None, None, None, None, None, None, None),
+        ("KEI-55", "Another task", 3, "available", None, None, None, None, None, None, None),
+    ]
+    cur = _make_cursor(rows)
+    patch_connect(cur)
+
+    ret = mod.cmd_ready(
+        type(
+            "A",
+            (),
+            {
+                "json": True,
+                "limit": 50,
+                "agent": None,
+                "callsign": None,
+            },
+        )()
+    )
+    assert ret == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert len(data) == 2


### PR DESCRIPTION
## Summary

- **New** `src/api/webhooks/github.py`: FastAPI APIRouter at `/api/webhooks/github` that receives GitHub `pull_request` events, verifies HMAC against `GITHUB_WEBHOOK_SECRET` (X-Hub-Signature-256), upserts `REVIEW-PR-<N>` rows in `public.tasks` on `opened`/`reopened`, and marks them `done` on `closed`. PR author stored as `excluded_callsign` so the author cannot self-assign their own PR review.
- **New migration** `supabase/migrations/20260517_kei97_excluded_callsign.sql`: `ADD COLUMN IF NOT EXISTS excluded_callsign TEXT` on `public.tasks`.
- **Updated** `scripts/tasks_cli.py` `cmd_ready`: new `--callsign` flag adds `AND (excluded_callsign IS NULL OR excluded_callsign != %s)` predicate; omitting `--callsign` preserves legacy behaviour (no exclusion filter).
- **Router registered** in `src/api/main.py` — KEI-108 anti-false-complete gate satisfied (`include_router(github_webhook_router)` confirmed present).

## Acceptance Criteria (Linear KEI-97)

- [x] `POST /api/webhooks/github` with valid HMAC + `pull_request.opened` → `REVIEW-PR-<N>` row in `public.tasks` with `status='available'`, `phase=0`, `claim_source='manual'`, `excluded_callsign=<lowercased author>`
- [x] `pull_request.reopened` → same upsert path
- [x] `pull_request.closed` → `status='done'`
- [x] Invalid HMAC → 401, no DB write
- [x] Malformed payload → 200 (fail-open, no retry-storm)
- [x] `bd ready --callsign=<author>` excludes that author's REVIEW-PR tasks
- [x] `bd ready --callsign=<other>` returns REVIEW-PR tasks excluded for author
- [x] `bd ready` (no `--callsign`) — no exclusion filter, backward compat
- [x] Router registered in `src/api/main.py` (KEI-108 gate)
- [x] Migration file for `excluded_callsign` column

## Test Output (verbatim)

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
asyncio: mode=Mode.AUTO

tests/api/webhooks/test_github_webhook.py::test_missing_signature_returns_401 PASSED [  6%]
tests/api/webhooks/test_github_webhook.py::test_wrong_signature_returns_401 PASSED [ 12%]
tests/api/webhooks/test_github_webhook.py::test_hmac_fail_does_not_write_db PASSED [ 18%]
tests/api/webhooks/test_github_webhook.py::test_pr_opened_upserts_task PASSED [ 25%]
tests/api/webhooks/test_github_webhook.py::test_pr_reopened_upserts_task PASSED [ 31%]
tests/api/webhooks/test_github_webhook.py::test_pr_closed_marks_done PASSED [ 37%]
tests/api/webhooks/test_github_webhook.py::test_malformed_payload_returns_200 PASSED [ 43%]
tests/api/webhooks/test_github_webhook.py::test_pr_author_exclusion_stored PASSED [ 50%]
tests/api/webhooks/test_github_webhook.py::test_non_pr_event_ignored PASSED [ 56%]
tests/api/webhooks/test_github_webhook.py::test_upsert_writes_correct_fields PASSED [ 62%]
tests/api/webhooks/test_github_webhook.py::test_close_task_writes_done PASSED [ 68%]
tests/scripts/test_tasks_cli_excluded_callsign.py::test_ready_with_callsign_includes_exclusion_clause PASSED [ 75%]
tests/scripts/test_tasks_cli_excluded_callsign.py::test_ready_callsign_aiden_receives_non_excluded_rows PASSED [ 81%]
tests/scripts/test_tasks_cli_excluded_callsign.py::test_ready_callsign_elliot_receives_rows_excluded_for_aiden PASSED [ 87%]
tests/scripts/test_tasks_cli_excluded_callsign.py::test_ready_without_callsign_no_exclusion_clause PASSED [ 93%]
tests/scripts/test_tasks_cli_excluded_callsign.py::test_ready_without_callsign_returns_all_rows PASSED [100%]

16 passed in 0.51s
```

## Ruff (verbatim)

```
All checks passed!
4 files already formatted
```

## KEI-108 Gate (verbatim)

```
$ grep -n 'github_webhook_router' src/api/main.py
425:from src.api.webhooks.github import router as github_webhook_router
469:app.include_router(github_webhook_router)
```

## Notes

- **Part B (GitHub branch protection config)** is OUT OF SCOPE — Dave admin step (requires GitHub org-admin access to configure branch protection rules).
- Spec: Linear KEI-97 / Dave dispatch ts ~1779024750
- Author-exclusion: `excluded_callsign` column (new in this PR) stores the lowercased PR author login, preventing self-review auto-claim via `bd ready --callsign`.
- Fail-open pattern matches `src/api/webhooks/linear.py`: HMAC fail → 401; malformed payload → 200 + log warning (prevents GitHub retry-storms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)