### PR TITLE
[AIDEN] fix(kei146): Sonar S3776 — extract _handle_http_error from _graphql

### DIFF
--- a/scripts/orchestrator/linear_state_indexer.py
+++ b/scripts/orchestrator/linear_state_indexer.py
@@ -128,6 +128,23 @@ INITIAL_BACKOFF_SECONDS = 1.0
 MAX_PAGINATION_PAGES = int(os.environ.get("LINEAR_STATE_MAX_PAGES", "20"))
 
 
+def _handle_http_error(exc: urlerror.HTTPError, attempt: int, backoff: float) -> float | None:
+    """Decide retry-or-raise for an HTTPError. Returns the next backoff value if
+    retryable (caller must `continue`); returns None if terminal (caller must
+    re-raise). Sleeps internally on retry."""
+    if exc.code == 429:
+        retry_after = _parse_retry_after(exc.headers.get("Retry-After"))
+        wait = retry_after if retry_after is not None else backoff
+        logger.warning("linear_api 429 (attempt=%d) — sleeping %ss", attempt, wait)
+        time.sleep(wait)
+        return backoff * 2
+    if 500 <= exc.code < 600:
+        logger.warning("linear_api %d (attempt=%d) — backoff %ss", exc.code, attempt, backoff)
+        time.sleep(backoff)
+        return backoff * 2
+    return None
+
+
 def _graphql(query: str, variables: dict) -> dict:
     """Linear GraphQL POST with retry + 429 Retry-After respect.
 
@@ -155,26 +172,10 @@ def _graphql(query: str, variables: dict) -> dict:
                 return json.loads(resp.read().decode("utf-8"))
         except urlerror.HTTPError as exc:
             last_exc = exc
-            if exc.code == 429:
-                retry_after = _parse_retry_after(exc.headers.get("Retry-After"))
-                wait = retry_after if retry_after is not None else backoff
-                logger.warning(
-                    "linear_api 429 (attempt=%d) — sleeping %ss",
-                    attempt,
-                    wait,
-                )
-                time.sleep(wait)
-                backoff *= 2
-                continue
-            if 500 <= exc.code < 600:
-                logger.warning(
-                    "linear_api %d (attempt=%d) — backoff %ss", exc.code, attempt, backoff
-                )
-                time.sleep(backoff)
-                backoff *= 2
-                continue
-            # 4xx other than 429 — terminal, do not retry.
-            raise
+            next_backoff = _handle_http_error(exc, attempt, backoff)
+            if next_backoff is None:
+                raise
+            backoff = next_backoff
         except (urlerror.URLError, OSError) as exc:
             last_exc = exc
             logger.warning(
@@ -182,7 +183,6 @@ def _graphql(query: str, variables: dict) -> dict:
             )
             time.sleep(backoff)
             backoff *= 2
-    # All retries exhausted.
     raise last_exc if last_exc else RuntimeError("linear_api retries exhausted")
 
 


### PR DESCRIPTION
## Summary
- KEI-146: drop cognitive complexity 16→13 on `scripts/orchestrator/linear_state_indexer.py:131` (`_graphql`)
- Extracted `_handle_http_error(exc, attempt, backoff) → float | None` to encapsulate the 429 / 5xx / 4xx-terminal decision
- Behaviour preserved: 11/11 existing tests pass; ruff check + format clean

## Why
PR #918 (KEI-153 / Phase B indexer) is gated on a single Sonar S3776 finding. This is the smallest mechanical change that clears it — unblocks the merge that lights up the Linear→Keis (Weaviate) read pathway. Per Dave's CEO directive 2026-05-17: KEI-152→155 are P1 because memory read is dead while memory write works.

## Verification
```
ruff check scripts/orchestrator/linear_state_indexer.py
> All checks passed!

ruff format --check scripts/orchestrator/linear_state_indexer.py
> 1 file already formatted

python3 -m pytest tests/scripts/test_linear_state_indexer.py -q
> ........... [100%]
> 11 passed in 0.10s
```

## Target
Base = `atlas/kei85-phase-b-linear-state` so this merges INTO PR #918, then #918 itself can ship dual-approved + Sonar-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)