### PR TITLE
[MAX] feat(kei103): wire agent_query into cmd_claim — populates retrieval_events on every claim (Phase 0 P0)

### DIFF
--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -247,6 +247,22 @@ def cmd_claim(args: argparse.Namespace) -> int:
         else:
             print("nothing to claim" if not args.id else f"could not claim {args.id}")
         return 0
+    # KEI-103 — fire retrieval_query on every successful claim so retrieval_events
+    # populates.  Scout diagnosis ts ~1779028392: writer (agent_query.query) and
+    # claim-path both exist; they were simply never wired together.
+    # Fail-open: retrieval failure must not block the claim itself — the DB write
+    # is a best-effort context-prime side-channel, not a hard dependency.
+    try:
+        from src.retrieval.agent_query import query as _retrieval_query
+
+        _retrieval_query(
+            row[1],  # task title (RETURNING col 1 — id=0, title=1)
+            agent=cs,
+            collections=("Discoveries", "Decisions", "Keis"),
+        )
+    except Exception:
+        logger.debug("KEI-103 retrieval_query failed (non-fatal)", exc_info=True)
+
     cols = ["id", "title", "priority", "status", "claimed_by", "linear_url", "tags"]
     claimed = dict(zip(cols, row, strict=False))
     if args.json:

--- a/tests/scripts/test_tasks_cli_kei103.py
+++ b/tests/scripts/test_tasks_cli_kei103.py
@@ -1,0 +1,148 @@
+"""KEI-103 — retrieval_query wired into cmd_claim.
+
+Three acceptance tests:
+  1. Successful claim fires retrieval_query once with task title + callsign.
+  2. retrieval_query exception is swallowed; cmd_claim still returns 0.
+  3. Claim race-loss (row=None) does NOT invoke retrieval_query.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "tasks_cli.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("tasks_cli_kei103", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["tasks_cli_kei103"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _db_mocks import FakeCursor, make_patch_connect  # type: ignore[import-not-found]  # noqa: E402
+
+_Cursor = FakeCursor
+
+
+@pytest.fixture
+def patch_connect(mod, monkeypatch):
+    return make_patch_connect(monkeypatch)
+
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+
+def _claim_row(title: str = "My Task Title") -> tuple:
+    """Return a 7-column RETURNING row matching the claim SELECT projection.
+
+    RETURNING id, title, priority, status, claimed_by, linear_url, tags
+               0    1         2       3         4           5        6
+    """
+    return ("KEI-103", title, 1, "active", "max", "https://linear.app/x", [])
+
+
+# ─── test 1: success path fires retrieval_query ────────────────────────────
+
+
+def test_claim_fires_retrieval_query_on_success(mod, patch_connect, monkeypatch) -> None:
+    """On a successful claim cmd_claim calls retrieval_query(title, agent=cs, ...)."""
+    monkeypatch.setenv("CALLSIGN", "max")
+
+    cur = _Cursor(fetchone_row=_claim_row("Implement the thing"))
+    patch_connect(cur)
+
+    mock_query = MagicMock(return_value=None)
+
+    # Patch at the import target inside tasks_cli's namespace.  The lazy import
+    # inside cmd_claim uses `from src.retrieval.agent_query import query as
+    # _retrieval_query`, so we patch the source module's attribute and also
+    # pre-populate sys.modules so the import resolves to our mock.
+    fake_aq = MagicMock()
+    fake_aq.query = mock_query
+    monkeypatch.setitem(sys.modules, "src.retrieval.agent_query", fake_aq)
+    # Also ensure the src.retrieval namespace exists.
+    if "src.retrieval" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src.retrieval", MagicMock())
+    if "src" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src", MagicMock())
+
+    rc = mod.main(["claim", "--id", "KEI-103", "--json"])
+
+    assert rc == 0
+    mock_query.assert_called_once()
+    call_args = mock_query.call_args
+    # Positional arg 0 is the task title
+    assert call_args.args[0] == "Implement the thing"
+    # keyword arg agent matches callsign
+    assert call_args.kwargs["agent"] == "max"
+    # collections tuple present
+    assert "collections" in call_args.kwargs
+    assert "Keis" in call_args.kwargs["collections"]
+
+
+# ─── test 2: retrieval_query exception is swallowed ────────────────────────
+
+
+def test_claim_swallows_retrieval_query_exception(mod, patch_connect, capsys, monkeypatch) -> None:
+    """If retrieval_query raises, cmd_claim still returns 0 and prints the row."""
+    monkeypatch.setenv("CALLSIGN", "max")
+
+    cur = _Cursor(fetchone_row=_claim_row("Exploding task"))
+    patch_connect(cur)
+
+    def _boom(*a, **kw):
+        raise RuntimeError("weaviate down")
+
+    fake_aq = MagicMock()
+    fake_aq.query = _boom
+    monkeypatch.setitem(sys.modules, "src.retrieval.agent_query", fake_aq)
+    if "src.retrieval" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src.retrieval", MagicMock())
+    if "src" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src", MagicMock())
+
+    rc = mod.main(["claim", "--id", "KEI-103", "--json"])
+
+    assert rc == 0
+    import json
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["id"] == "KEI-103"
+
+
+# ─── test 3: claim race-loss does NOT invoke retrieval_query ───────────────
+
+
+def test_claim_failure_path_does_not_call_retrieval_query(
+    mod, patch_connect, capsys, monkeypatch
+) -> None:
+    """When the UPDATE returns no row (race lost), retrieval_query is not called."""
+    monkeypatch.setenv("CALLSIGN", "max")
+
+    cur = _Cursor(fetchone_row=None)
+    patch_connect(cur)
+
+    mock_query = MagicMock(return_value=None)
+    fake_aq = MagicMock()
+    fake_aq.query = mock_query
+    monkeypatch.setitem(sys.modules, "src.retrieval.agent_query", fake_aq)
+    if "src.retrieval" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src.retrieval", MagicMock())
+    if "src" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src", MagicMock())
+
+    rc = mod.main(["claim", "--json"])
+
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "null"
+    mock_query.assert_not_called()


### PR DESCRIPTION
## Summary

- **Root cause fixed:** `cmd_claim` in `scripts/tasks_cli.py` had zero wiring to the retrieval layer. `agent_query.query()` is the sole writer of `public.retrieval_events`; its only caller was a smoke harness never invoked in normal flow. Scout diagnosis ts ~1779028392 confirmed: writer + claim-path both existed, simply never connected.
- **Fix:** After the successful claim `UPDATE ... RETURNING` commit, invoke `src.retrieval.agent_query.query(row[1], agent=cs, collections=('Discoveries','Decisions','Keis'))` in a fail-open `try/except`. A Weaviate/retrieval failure logs at DEBUG and does not block the claim (mechanical effect stands).
- **Column index confirmed:** RETURNING projection is `id=0, title=1, priority=2, status=3, claimed_by=4, linear_url=5, tags=6` — `row[1]` is the task title.
- **Write target confirmed:** `public.retrieval_events` via psycopg INSERT in `_record_event()` at `src/retrieval/agent_query.py` ~line 94.

## Tests

`tests/scripts/test_tasks_cli_kei103.py` — 3 new tests:

1. `test_claim_fires_retrieval_query_on_success` — mock `agent_query.query`; successful claim calls it once with correct title + callsign.
2. `test_claim_swallows_retrieval_query_exception` — mock raises `RuntimeError`; `cmd_claim` still returns 0, prints row.
3. `test_claim_failure_path_does_not_call_retrieval_query` — UPDATE returns None (race lost); query not called.

## Verification

```
COMMAND: python3 -m pytest tests/scripts/test_tasks_cli_kei103.py -v
OUTPUT:
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
collected 3 items

tests/scripts/test_tasks_cli_kei103.py::test_claim_fires_retrieval_query_on_success PASSED [ 33%]
tests/scripts/test_tasks_cli_kei103.py::test_claim_swallows_retrieval_query_exception PASSED [ 66%]
tests/scripts/test_tasks_cli_kei103.py::test_claim_failure_path_does_not_call_retrieval_query PASSED [100%]

3 passed in 0.17s

COMMAND: ruff check scripts/tasks_cli.py tests/scripts/test_tasks_cli_kei103.py && ruff format --check scripts/tasks_cli.py tests/scripts/test_tasks_cli_kei103.py
OUTPUT: All checks passed! / 2 files already formatted

COMMAND: BASE_REF=main bash scripts/ci/check_operational_deployment.sh; echo EXIT:$?
OUTPUT: EXIT: 0
```

## Post-merge acceptance

First `bd claim` against production Supabase should create at least one row in `public.retrieval_events` (requires `RETRIEVAL_EVENTS_DSN` or `DATABASE_URL` set in the agent env; if absent, the audit trail is the structured log line).