### PR TITLE
[SCOUT] fix(kei103): wire retrieval_query into bd cmd_claim — retrieval_events fires per claim

### DIFF
--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -249,6 +249,18 @@ def cmd_claim(args: argparse.Namespace) -> int:
         return 0
     cols = ["id", "title", "priority", "status", "claimed_by", "linear_url", "tags"]
     claimed = dict(zip(cols, row, strict=False))
+    # KEI-103 — fire retrieval on every successful claim so cognee_recall/Weaviate
+    # is actually exercised (the writers existed but no production caller did).
+    # Records a row in public.retrieval_events for audit + observability.
+    # Fail-open: agent_query.query() has its own try/except for Weaviate-down
+    # and DSN-missing; we re-catch ImportError + anything else so a broken
+    # retrieval layer never blocks a claim.
+    try:
+        from src.retrieval.agent_query import query as _retrieval_query
+
+        _retrieval_query(claimed["title"], agent=claimed["claimed_by"])
+    except Exception:
+        logger.debug("retrieval query for claim failed (non-fatal)", exc_info=True)
     if args.json:
         print(json.dumps(claimed, default=str))
     else:

--- a/tests/scripts/test_tasks_cli.py
+++ b/tests/scripts/test_tasks_cli.py
@@ -290,6 +290,67 @@ def test_claim_refuses_explicit_unknown_callsign(mod, capsys, monkeypatch) -> No
     assert "DEFAULT_CALLSIGN sentinel" in capsys.readouterr().err
 
 
+# ─── KEI-103: retrieval hook on successful claim ─────────────────────────────
+
+
+def test_claim_fires_retrieval_query_on_success(mod, patch_connect, monkeypatch) -> None:
+    """KEI-103 — successful claim must invoke src.retrieval.agent_query.query
+    with the claimed task's title + claimed_by callsign. This is the wire that
+    makes public.retrieval_events receive a row per claim cycle.
+    """
+    monkeypatch.setenv("CALLSIGN", "scout")
+    cur = _Cursor(
+        fetchone_row=("KEI-39", "diagnose cognee read pathway", 1, "active", "scout", "url")
+    )
+    patch_connect(cur)
+
+    calls: list[tuple] = []
+
+    def _spy_query(text: str, *, agent: str, **kwargs):
+        calls.append((text, agent, kwargs))
+        return None  # query returns QueryResult in prod; tests don't care about return
+
+    import sys as _sys
+    import types as _types
+
+    fake_module = _types.ModuleType("src.retrieval.agent_query")
+    fake_module.query = _spy_query
+    monkeypatch.setitem(_sys.modules, "src.retrieval.agent_query", fake_module)
+
+    rc = mod.main(["claim", "--id", "KEI-39", "--json"])
+    assert rc == 0
+    assert len(calls) == 1
+    text, agent, _kwargs = calls[0]
+    assert text == "diagnose cognee read pathway"
+    assert agent == "scout"
+
+
+def test_claim_succeeds_when_retrieval_query_raises(
+    mod, patch_connect, capsys, monkeypatch
+) -> None:
+    """KEI-103 — retrieval failure (Weaviate down, import error, anything) must
+    NOT block the claim. Fail-open per cognee_recall + agent_query contract.
+    """
+    monkeypatch.setenv("CALLSIGN", "scout")
+    cur = _Cursor(fetchone_row=("KEI-39", "title", 1, "active", "scout", "url"))
+    patch_connect(cur)
+
+    def _broken_query(text, *, agent, **kwargs):
+        raise RuntimeError("simulated Weaviate down")
+
+    import sys as _sys
+    import types as _types
+
+    fake_module = _types.ModuleType("src.retrieval.agent_query")
+    fake_module.query = _broken_query
+    monkeypatch.setitem(_sys.modules, "src.retrieval.agent_query", fake_module)
+
+    rc = mod.main(["claim", "--id", "KEI-39", "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["id"] == "KEI-39"
+
+
 # ─── complete ────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes the wire gap that left `public.retrieval_events` at 0 rows despite 2,179+ tool calls writing memory. `bd claim` now invokes `src.retrieval.agent_query.query()` on every successful claim, which exercises Cognee/Weaviate AND writes an audit row.

**Linear:** [KEI-103](https://linear.app/keiracom/issue/KEI-103) (P0, Dave CEO direct dispatch 2026-05-17)
**Branch:** `scout/kei103-cognee-recall-bd-claim` off `origin/main` at 6f0da690

## Root cause (verbatim diagnosis)

```
$ grep -n "cognee_recall|agent_query|retrieval_events|cmd_claim" scripts/tasks_cli.py
157:def cmd_claim(args: argparse.Namespace) -> int:
404:    p_claim.set_defaults(func=cmd_claim)
# ZERO references to retrieval, agent_query, or cognee_recall.

$ grep -rn "agent_query.query" --include="*.py" | grep -v test_ | grep -v agent_query.py
scripts/retrieval_smoke.py:97:    result = agent_query.query(  # one-shot test harness only
```

The writer (src/retrieval/agent_query.py:94 INSERT INTO retrieval_events) and the cognee_recall text-enricher both shipped, but no production caller existed. cmd_claim was the obvious hook point per the KEI-103 acceptance ("retrieval_events > 0 after a bd claim cycle") and had never been wired.

## What lands

| File | Change |
|---|---|
| `scripts/tasks_cli.py` | +12 LoC in cmd_claim: lazy-import `agent_query.query`, call with `(title, agent=callsign)` after successful UPDATE, fail-open try/except |
| `tests/scripts/test_tasks_cli.py` | +61 LoC: 2 new tests (positive wire + fail-open) |

### The fix (verbatim)

```python
# After: claimed = dict(zip(cols, row, strict=False))
try:
    from src.retrieval.agent_query import query as _retrieval_query
    _retrieval_query(claimed["title"], agent=claimed["claimed_by"])
except Exception:
    logger.debug("retrieval query for claim failed (non-fatal)", exc_info=True)
```

Lazy import: keeps the bd CLI startup fast on environments without `src/` on the path. Broad except: agent_query.query has its own internal try/except for Weaviate-down + DSN-missing (src/retrieval/agent_query.py:108-112) — we re-catch ImportError plus anything else so a broken retrieval layer never blocks the claim.

## Verbatim verification

```
$ /home/elliotbot/.local/bin/ruff check scripts/tasks_cli.py tests/scripts/test_tasks_cli.py
All checks passed!

$ /home/elliotbot/.local/bin/ruff format --check scripts/tasks_cli.py tests/scripts/test_tasks_cli.py
3 files already formatted

$ /home/elliotbot/clawd/venv/bin/python3 -m pytest tests/scripts/test_tasks_cli.py -x -q
..........................                                               [100%]
26 passed in 0.25s

$ /home/elliotbot/clawd/venv/bin/python3 -m pytest tests/scripts/test_tasks_cli.py::test_claim_fires_retrieval_query_on_success tests/scripts/test_tasks_cli.py::test_claim_succeeds_when_retrieval_query_raises -v
tests/scripts/test_tasks_cli.py::test_claim_fires_retrieval_query_on_success PASSED [ 50%]
tests/scripts/test_tasks_cli.py::test_claim_succeeds_when_retrieval_query_raises PASSED [100%]
============================== 2 passed in 0.18s ===============================

$ python3 -c "from src.retrieval.agent_query import query; import inspect; print(inspect.signature(query))"
(text: 'str', *, agent: 'str', collections: 'tuple[str, ...]' = ('Discoveries', 'Decisions', 'Keis'), max_tokens: 'int' = 500, citation_required: 'bool' = True, min_score: 'float' = 0.5, k_initial: 'int' = 20, k_returned: 'int' = 5) -> 'QueryResult'
# Production import resolves; my call site `_retrieval_query(claimed["title"], agent=claimed["claimed_by"])` matches.
```

## Acceptance

- [x] `bd claim` calls `src.retrieval.agent_query.query()` on every successful UPDATE
- [x] Failure of the retrieval layer (Weaviate down, ImportError, DSN missing) does NOT block the claim — claim still returns 0 and outputs JSON normally
- [x] Unit tests assert both positive (wire fires with correct args) and negative (fail-open) paths
- [ ] Post-merge empirical: a real `bd claim <KEI-XX>` on an env with `RETRIEVAL_EVENTS_DSN` set produces +1 row in `public.retrieval_events`. Cannot verify pre-merge without a claimable test KEI + live DB.

## Empirical-test note (per feedback_empirical_test_catches_paper_concur_misses)

This PR ships with unit tests + import-resolution evidence. The acceptance criterion's empirical proof ("retrieval_events > 0 after a claim cycle") requires a real claim on a live environment — that proof comes post-merge from any subsequent `bd claim` on the fleet. Reviewers should treat as "shipped pending live confirmation"; if the next agent claim doesn't bump the count, I'll diagnose + follow up.

## Out of scope (intentional)

- Surfacing retrieval results to the agent's stdout (currently query result discarded). Future KEI: capture the QueryResult and emit a `## Recent context` markdown block alongside the existing KEI-51 preamble.
- Asyncifying the retrieval call (sync inside cmd_claim adds ~50-300ms to claim latency). If problematic, swap to subprocess fire-and-forget.

## Dual approval

[ELLIOT] + [AIDEN] per session rules. Dave merges (or merge-after-dual-concur per recent pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)