### PR TITLE
[ATLAS] fix(kei103): wire Weaviate recall into bd claim + strip +asyncpg DSN

### DIFF
--- a/scripts/orchestrator/claim_context_injector.py
+++ b/scripts/orchestrator/claim_context_injector.py
@@ -3,13 +3,14 @@
 Formats a token-capped block of "related" discoveries before the
 `claimed <id> by <agent>: <title>` success line in tasks_cli.cmd_claim.
 
-Read path: discovery_log.load_active_discoveries() (KEI-63 deprecation-aware).
+Read path:
+  - discovery_log.load_active_discoveries() (KEI-63 deprecation-aware, jsonl)
+  - weaviate_recall_source(kei, title, callsign) (KEI-103, Weaviate via
+    src.retrieval.agent_query.query — also writes retrieval_events for
+    observability)
+
 Token cap: 500 (KEI-55 ratified). Lower-priority entries DROP entirely;
 mid-sentence truncation is forbidden (per KEI-55 design note).
-
-Weaviate retrieval (post-KEI-49 / PR #887) is an additive future source —
-extension point is the `extra_sources` kwarg: each callable returns a list
-of discovery dicts merged before ranking. Default keeps the jsonl-only path.
 
 Priority key (descending) — exact KEI match > tag overlap count > validation_tier
 weight (T3=3, T2=2, T1=1) > recency (later context_version write).
@@ -17,9 +18,12 @@ weight (T3=3, T2=2, T1=1) > recency (later context_version write).
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from collections.abc import Callable, Iterable
+
+logger = logging.getLogger("claim_context_injector")
 
 # scripts/orchestrator/ is not packaged (no __init__.py) — mirror the
 # sys.path pattern used implicitly by sibling shims (KEI-63 cmd_deprecate
@@ -29,9 +33,18 @@ _HERE = os.path.dirname(os.path.abspath(__file__))
 if _HERE not in sys.path:
     sys.path.insert(0, _HERE)
 
+# Repo root on sys.path so `from src.retrieval import agent_query` resolves
+# regardless of caller cwd (KEI-103 — Weaviate recall source needs the
+# `src` package importable from bd claim's child process).
+_REPO_ROOT = os.path.dirname(os.path.dirname(_HERE))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
 from discovery_log import load_active_discoveries  # noqa: E402
 
 TOKEN_CAP_DEFAULT = 500
+WEAVIATE_RECALL_K_RETURNED = 5
+WEAVIATE_RECALL_EXCERPT_PREVIEW_CHARS = 220
 
 
 def _approx_tokens(text: str) -> int:
@@ -51,11 +64,66 @@ def _priority_key(d: dict, target_kei: str, target_tags: set[str]) -> tuple:
 
 def _format_entry(d: dict) -> str:
     return (
-        f"  [{d.get('kei','?')} | T{_tier_weight(d)} | {d.get('agent','?')}] "
-        f"{d.get('finding','')}\n"
-        f"    failed: {d.get('failed_path','')}\n"
-        f"    verified: {d.get('verified_path','')}"
+        f"  [{d.get('kei', '?')} | T{_tier_weight(d)} | {d.get('agent', '?')}] "
+        f"{d.get('finding', '')}\n"
+        f"    failed: {d.get('failed_path', '')}\n"
+        f"    verified: {d.get('verified_path', '')}"
     )
+
+
+def weaviate_recall_source(kei: str, title: str, callsign: str) -> Callable[[], list[dict]]:
+    """KEI-103 — return a callable that recalls related context from Weaviate.
+
+    The returned callable performs one `src.retrieval.agent_query.query()`
+    against the default 3-collection set (Discoveries, Decisions, Keis) and
+    converts every Citation into the discovery-dict shape format_preamble
+    expects. Each dict is tagged with `kei=<claim_kei>` so the downstream
+    relevance filter (kei-match OR tag-overlap) keeps Weaviate hits in —
+    similarity score already established relevance, no need to re-filter.
+
+    Fail-open: import errors, missing DSN, or query failure → empty list
+    (callers must not block bd claim on knowledge-graph health).
+
+    Side-effect: `agent_query.query()` internally calls `_record_event()`
+    which logs the retrieval AND inserts a row into `public.retrieval_events`
+    when `RETRIEVAL_EVENTS_DSN` or `DATABASE_URL` is set. THIS is the wire
+    that makes retrieval_events count > 0 per bd claim cycle (KEI-103).
+    """
+
+    def _recall() -> list[dict]:
+        try:
+            from src.retrieval import agent_query  # noqa: PLC0415 — lazy import
+        except ImportError as exc:
+            logger.debug("KEI-103 weaviate recall import failed: %s", exc)
+            return []
+        query_text = f"{kei}: {title}".strip() if title else kei
+        try:
+            result = agent_query.query(query_text, agent=callsign or "atlas")
+        except Exception as exc:  # noqa: BLE001 — fail-open
+            logger.debug("KEI-103 weaviate recall query failed: %s", exc)
+            return []
+        out: list[dict] = []
+        for c in result.citations[:WEAVIATE_RECALL_K_RETURNED]:
+            preview = c.excerpt[:WEAVIATE_RECALL_EXCERPT_PREVIEW_CHARS]
+            if len(c.excerpt) > WEAVIATE_RECALL_EXCERPT_PREVIEW_CHARS:
+                preview += "…"
+            out.append(
+                {
+                    # Tag with claim KEI so format_preamble's relevance filter
+                    # (kei-match OR tag-overlap) keeps the Weaviate-derived
+                    # rows in — similarity score already established relevance.
+                    "kei": kei,
+                    "agent": "weaviate",
+                    "validation_tier": 2,
+                    "tags": ["weaviate-recall", c.collection.lower()],
+                    "finding": preview,
+                    "failed_path": "",
+                    "verified_path": f"[{c.source_id} | {c.collection} | score={c.score:.2f}]",
+                }
+            )
+        return out
+
+    return _recall
 
 
 def format_preamble(
@@ -78,10 +146,7 @@ def format_preamble(
         rows.extend(src() or [])
     if not rows:
         return ""
-    filtered = [
-        r for r in rows
-        if r.get("kei") == kei or (set(r.get("tags") or []) & target_tags)
-    ]
+    filtered = [r for r in rows if r.get("kei") == kei or (set(r.get("tags") or []) & target_tags)]
     if not filtered:
         return ""
     ranked = sorted(filtered, key=lambda r: _priority_key(r, kei, target_tags), reverse=True)

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -264,7 +264,18 @@ def cmd_claim(args: argparse.Namespace) -> int:
             )
             inj = _u.module_from_spec(spec)
             spec.loader.exec_module(inj)
-            preamble = inj.format_preamble(kei=claimed["id"], tags=claimed.get("tags") or [])
+            # KEI-103 — wire Weaviate recall source so retrieval_events grows
+            # per bd claim. Source is fail-open: import/query errors yield [].
+            weaviate_src = inj.weaviate_recall_source(
+                kei=claimed["id"],
+                title=claimed.get("title") or "",
+                callsign=claimed.get("claimed_by") or cs,
+            )
+            preamble = inj.format_preamble(
+                kei=claimed["id"],
+                tags=claimed.get("tags") or [],
+                extra_sources=(weaviate_src,),
+            )
             if preamble:
                 print(preamble)
         except Exception:

--- a/src/retrieval/agent_query.py
+++ b/src/retrieval/agent_query.py
@@ -82,6 +82,11 @@ def _record_event(
     dsn = os.environ.get("RETRIEVAL_EVENTS_DSN") or os.environ.get("DATABASE_URL")
     if not dsn:
         return
+    # KEI-103: Supabase pooler DSN often comes as `postgresql+asyncpg://...`
+    # but psycopg3 only parses `postgresql://`. Strip the dialect tag here so
+    # the INSERT actually fires; without this, _record_event silently no-ops
+    # and retrieval_events stays at 0 (memory: reference_psycopg_supabase_pgbouncer).
+    dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
     try:
         import psycopg
 

--- a/tests/retrieval/test_agent_query.py
+++ b/tests/retrieval/test_agent_query.py
@@ -130,3 +130,67 @@ def test_bypass_rerank_propagates_from_outcome():
     ):
         result = agent_query.query("q?", agent="test", min_score=0.0)
     assert result.bypass_rerank is False
+
+
+def test_record_event_strips_asyncpg_dialect_from_dsn(monkeypatch):
+    """KEI-103 — `_record_event` must rewrite `postgresql+asyncpg://` DSNs
+    to plain `postgresql://` so psycopg3 can parse the Supabase pooler URL.
+    Without the strip, psycopg.ProgrammingError fires and retrieval_events
+    silently stays at 0 (the actual KEI-103 root cause).
+    """
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://u:p@aws-1-ap-southeast-1.pooler.supabase.com:6543/postgres",
+    )
+    monkeypatch.delenv("RETRIEVAL_EVENTS_DSN", raising=False)
+
+    captured = {}
+
+    class _FakeCur:
+        def execute(self, *_a, **_k):
+            captured["executed"] = True
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    class _FakeConn:
+        def cursor(self):
+            return _FakeCur()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    def _fake_connect(dsn, **_kw):
+        captured["dsn"] = dsn
+        return _FakeConn()
+
+    import importlib  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+    import types  # noqa: PLC0415
+
+    fake_psycopg = types.ModuleType("psycopg")
+    fake_psycopg.connect = _fake_connect
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+    importlib.reload(agent_query)
+
+    agent_query._record_event(
+        agent="test",
+        query_text="q",
+        collections=("Discoveries",),
+        k_initial=1,
+        k_returned=1,
+        elapsed_ms=0,
+        bypass_rerank=True,
+        top_citation=None,
+    )
+    assert captured.get("executed") is True
+    # The DSN reaching psycopg.connect must be the stripped form, not the
+    # `postgresql+asyncpg://` raw env value.
+    assert captured["dsn"].startswith("postgresql://")
+    assert "+asyncpg" not in captured["dsn"]

--- a/tests/scripts/test_claim_context_injector.py
+++ b/tests/scripts/test_claim_context_injector.py
@@ -38,6 +38,26 @@ format_preamble = _inj.format_preamble
 append_discovery = _dl.append_discovery
 
 
+@pytest.fixture
+def _no_weaviate_recall(monkeypatch):
+    """KEI-103 — stub `src.retrieval.agent_query` so cmd_claim's Weaviate
+    recall source returns an empty citation list. Use this fixture in any
+    cmd_claim test that asserts the LOCAL (jsonl) preamble shape — without
+    it, live Weaviate hits leak into the preamble and break local-only
+    assertions.
+    """
+    import types  # noqa: PLC0415
+
+    if "src" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src", types.ModuleType("src"))
+    if "src.retrieval" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src.retrieval", types.ModuleType("src.retrieval"))
+    fake_mod = types.ModuleType("src.retrieval.agent_query")
+    fake_mod.query = lambda *_a, **_k: types.SimpleNamespace(citations=())
+    monkeypatch.setitem(sys.modules, "src.retrieval.agent_query", fake_mod)
+    monkeypatch.setattr(sys.modules["src.retrieval"], "agent_query", fake_mod, raising=False)
+
+
 @pytest.fixture(autouse=True)
 def _redirect_jsonl(tmp_path, monkeypatch):
     """Point every cached discovery_log module at a per-test tmp jsonl.
@@ -76,8 +96,15 @@ def test_no_match_returns_empty(_redirect_jsonl):
 def test_exact_kei_match_renders_entry(_redirect_jsonl):
     _seed(
         _redirect_jsonl,
-        {"kei": "KEI-51", "agent": "scout", "tags": ["python"],
-         "finding": "F", "failed_path": "X", "verified_path": "Y", "validation_tier": 2},
+        {
+            "kei": "KEI-51",
+            "agent": "scout",
+            "tags": ["python"],
+            "finding": "F",
+            "failed_path": "X",
+            "verified_path": "Y",
+            "validation_tier": 2,
+        },
     )
     out = format_preamble("KEI-51", tags=[])
     assert "KEI-51" in out and "scout" in out
@@ -88,10 +115,20 @@ def test_exact_kei_match_renders_entry(_redirect_jsonl):
 def test_kei_match_outranks_tag_match(_redirect_jsonl):
     _seed(
         _redirect_jsonl,
-        {"kei": "KEI-99", "agent": "max", "tags": ["python"],
-         "finding": "tag-only", "validation_tier": 3},
-        {"kei": "KEI-51", "agent": "scout", "tags": ["python"],
-         "finding": "kei-exact", "validation_tier": 1},
+        {
+            "kei": "KEI-99",
+            "agent": "max",
+            "tags": ["python"],
+            "finding": "tag-only",
+            "validation_tier": 3,
+        },
+        {
+            "kei": "KEI-51",
+            "agent": "scout",
+            "tags": ["python"],
+            "finding": "kei-exact",
+            "validation_tier": 1,
+        },
     )
     out = format_preamble("KEI-51", tags=["python"])
     assert out.index("kei-exact") < out.index("tag-only")
@@ -101,12 +138,24 @@ def test_token_cap_drops_lower_priority_entirely(_redirect_jsonl):
     big_finding = "A" * 1600
     _seed(
         _redirect_jsonl,
-        {"kei": "KEI-51", "agent": "scout", "tags": ["a"],
-         "finding": big_finding, "failed_path": "f", "verified_path": "v",
-         "validation_tier": 3},
-        {"kei": "KEI-51", "agent": "max", "tags": ["a"],
-         "finding": big_finding, "failed_path": "f", "verified_path": "v",
-         "validation_tier": 1},
+        {
+            "kei": "KEI-51",
+            "agent": "scout",
+            "tags": ["a"],
+            "finding": big_finding,
+            "failed_path": "f",
+            "verified_path": "v",
+            "validation_tier": 3,
+        },
+        {
+            "kei": "KEI-51",
+            "agent": "max",
+            "tags": ["a"],
+            "finding": big_finding,
+            "failed_path": "f",
+            "verified_path": "v",
+            "validation_tier": 1,
+        },
     )
     out = format_preamble("KEI-51", tags=[], max_tokens=500)
     assert "scout" in out
@@ -117,8 +166,7 @@ def test_token_cap_drops_lower_priority_entirely(_redirect_jsonl):
 def test_no_mid_sentence_truncation_marker(_redirect_jsonl):
     _seed(
         _redirect_jsonl,
-        {"kei": "KEI-51", "agent": "scout",
-         "finding": "F" * 10000, "validation_tier": 1},
+        {"kei": "KEI-51", "agent": "scout", "finding": "F" * 10000, "validation_tier": 1},
     )
     out = format_preamble("KEI-51", tags=[], max_tokens=50)
     assert "..." not in out
@@ -126,8 +174,7 @@ def test_no_mid_sentence_truncation_marker(_redirect_jsonl):
 
 
 def test_extra_sources_merged(_redirect_jsonl):
-    _seed(_redirect_jsonl,
-          {"kei": "KEI-51", "agent": "scout", "finding": "from-jsonl"})
+    _seed(_redirect_jsonl, {"kei": "KEI-51", "agent": "scout", "finding": "from-jsonl"})
 
     def weaviate_stub():
         return [{"kei": "KEI-51", "agent": "weaviate", "finding": "from-weaviate"}]
@@ -141,8 +188,14 @@ def test_deprecated_rows_excluded(_redirect_jsonl):
     _seed(
         _redirect_jsonl,
         {"kei": "KEI-51", "agent": "scout", "finding": "live"},
-        {"kei": "KEI-51", "agent": "scout", "finding": "stale",
-         "deprecated": True, "deprecated_reason": "x", "deprecated_by": "y"},
+        {
+            "kei": "KEI-51",
+            "agent": "scout",
+            "finding": "stale",
+            "deprecated": True,
+            "deprecated_reason": "x",
+            "deprecated_by": "y",
+        },
     )
     out = format_preamble("KEI-51", tags=[])
     assert "live" in out
@@ -158,6 +211,7 @@ def tasks_cli_mod():
     different in-function importlib path for the injector, which then races
     with our test's pre-registered sys.modules entry. Force a clean load."""
     import importlib.util as _u
+
     for _stale in ("tasks_cli",):
         sys.modules.pop(_stale, None)
     spec = _u.spec_from_file_location("tasks_cli", REPO_ROOT / "scripts" / "tasks_cli.py")
@@ -171,11 +225,12 @@ def tasks_cli_mod():
 def patch_connect(tasks_cli_mod, monkeypatch):
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     from _db_mocks import make_patch_connect  # noqa: PLC0415
+
     return make_patch_connect(monkeypatch)
 
 
 def test_cmd_claim_emits_preamble_before_success_line(
-    tasks_cli_mod, patch_connect, capsys, monkeypatch, _redirect_jsonl
+    tasks_cli_mod, patch_connect, capsys, monkeypatch, _redirect_jsonl, _no_weaviate_recall
 ):
     """KEI-51 acceptance — bd claim writes preamble before 'claimed X' line."""
     sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -183,19 +238,43 @@ def test_cmd_claim_emits_preamble_before_success_line(
 
     _seed(
         _redirect_jsonl,
-        {"kei": "KEI-51", "agent": "scout", "tags": ["python", "memory"],
-         "finding": "preamble-row-1", "failed_path": "f1", "verified_path": "v1",
-         "validation_tier": 2},
-        {"kei": "KEI-51", "agent": "max", "tags": ["python"],
-         "finding": "preamble-row-2", "failed_path": "f2", "verified_path": "v2",
-         "validation_tier": 1},
-        {"kei": "KEI-99", "agent": "atlas", "tags": ["rust"],
-         "finding": "unrelated-row", "validation_tier": 1},
+        {
+            "kei": "KEI-51",
+            "agent": "scout",
+            "tags": ["python", "memory"],
+            "finding": "preamble-row-1",
+            "failed_path": "f1",
+            "verified_path": "v1",
+            "validation_tier": 2,
+        },
+        {
+            "kei": "KEI-51",
+            "agent": "max",
+            "tags": ["python"],
+            "finding": "preamble-row-2",
+            "failed_path": "f2",
+            "verified_path": "v2",
+            "validation_tier": 1,
+        },
+        {
+            "kei": "KEI-99",
+            "agent": "atlas",
+            "tags": ["rust"],
+            "finding": "unrelated-row",
+            "validation_tier": 1,
+        },
     )
     monkeypatch.setenv("CALLSIGN", "scout")
     cur = FakeCursor(
-        fetchone_row=("KEI-51", "claim ctx injection", 1, "active",
-                      "scout", "url", ["python", "memory"]),
+        fetchone_row=(
+            "KEI-51",
+            "claim ctx injection",
+            1,
+            "active",
+            "scout",
+            "url",
+            ["python", "memory"],
+        ),
     )
     patch_connect(cur)
     rc = tasks_cli_mod.main(["claim", "--id", "KEI-51"])
@@ -223,8 +302,7 @@ def test_cmd_claim_json_path_skips_preamble(
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     from _db_mocks import FakeCursor  # noqa: PLC0415
 
-    _seed(_redirect_jsonl,
-          {"kei": "KEI-51", "agent": "scout", "finding": "should-not-appear"})
+    _seed(_redirect_jsonl, {"kei": "KEI-51", "agent": "scout", "finding": "should-not-appear"})
     monkeypatch.setenv("CALLSIGN", "scout")
     cur = FakeCursor(
         fetchone_row=("KEI-51", "x", 1, "active", "scout", "url", ["a"]),
@@ -236,13 +314,14 @@ def test_cmd_claim_json_path_skips_preamble(
     assert "context preamble" not in out
     assert "should-not-appear" not in out
     import json as _j
+
     data = _j.loads(out)
     assert data["id"] == "KEI-51"
     assert data["tags"] == ["a"]
 
 
 def test_cmd_claim_preamble_missing_jsonl_is_non_fatal(
-    tasks_cli_mod, patch_connect, capsys, monkeypatch, _redirect_jsonl
+    tasks_cli_mod, patch_connect, capsys, monkeypatch, _redirect_jsonl, _no_weaviate_recall
 ):
     """If discovery_log.jsonl missing, claim still succeeds (no preamble)."""
     sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -260,3 +339,110 @@ def test_cmd_claim_preamble_missing_jsonl_is_non_fatal(
     out = capsys.readouterr().out
     assert "context preamble" not in out
     assert "claimed KEI-51 by scout" in out
+
+
+# ─── KEI-103 — Weaviate recall source tests ──────────────────────────────────
+
+
+def test_weaviate_recall_source_returns_callable():
+    """Factory always returns a callable; no live deps on construction."""
+    src = _inj.weaviate_recall_source(kei="KEI-103", title="x", callsign="atlas")
+    assert callable(src)
+
+
+def test_weaviate_recall_source_fail_open_on_missing_module(monkeypatch):
+    """ImportError on `from src.retrieval import agent_query` → returns []
+    (fail-open per KEI-103 contract — bd claim must not block on graph health).
+    """
+    import types  # noqa: PLC0415
+
+    # Replace the package with a bare module object that has no `agent_query`
+    # attribute; `from src.retrieval import agent_query` then raises ImportError.
+    monkeypatch.setitem(sys.modules, "src", types.ModuleType("src"))
+    monkeypatch.setitem(sys.modules, "src.retrieval", types.ModuleType("src.retrieval"))
+    monkeypatch.delitem(sys.modules, "src.retrieval.agent_query", raising=False)
+
+    src = _inj.weaviate_recall_source(kei="KEI-103", title="x", callsign="atlas")
+    assert src() == []
+
+
+def test_weaviate_recall_source_fail_open_on_query_exception(monkeypatch):
+    """Any exception inside agent_query.query → returns [] (fail-open)."""
+    import types  # noqa: PLC0415
+
+    if "src" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src", types.ModuleType("src"))
+    if "src.retrieval" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src.retrieval", types.ModuleType("src.retrieval"))
+    fake_mod = types.ModuleType("src.retrieval.agent_query")
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("weaviate offline")
+
+    fake_mod.query = _boom
+    monkeypatch.setitem(sys.modules, "src.retrieval.agent_query", fake_mod)
+    monkeypatch.setattr(sys.modules["src.retrieval"], "agent_query", fake_mod, raising=False)
+
+    src = _inj.weaviate_recall_source(kei="KEI-103", title="x", callsign="atlas")
+    assert src() == []
+
+
+def test_weaviate_recall_source_converts_citations_to_dicts(monkeypatch):
+    """Citations from agent_query → list of discovery dicts shaped for
+    format_preamble; each entry tagged with the claim KEI so the relevance
+    filter keeps them in.
+    """
+    import types  # noqa: PLC0415
+
+    Citation = types.SimpleNamespace
+    citations = (
+        Citation(source_id="docs/x.md", collection="Discoveries", score=0.87, excerpt="hit-1"),
+        Citation(source_id="KEI-88", collection="Keis", score=0.71, excerpt="hit-2"),
+    )
+    if "src" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src", types.ModuleType("src"))
+    if "src.retrieval" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src.retrieval", types.ModuleType("src.retrieval"))
+    fake_mod = types.ModuleType("src.retrieval.agent_query")
+    fake_mod.query = lambda *_a, **_k: types.SimpleNamespace(citations=citations)
+    monkeypatch.setitem(sys.modules, "src.retrieval.agent_query", fake_mod)
+    monkeypatch.setattr(sys.modules["src.retrieval"], "agent_query", fake_mod, raising=False)
+
+    src = _inj.weaviate_recall_source(kei="KEI-103", title="fix recall", callsign="atlas")
+    out = src()
+    assert len(out) == 2
+    # All entries tagged with claim KEI — passes downstream relevance filter
+    assert all(d["kei"] == "KEI-103" for d in out)
+    assert all(d["agent"] == "weaviate" for d in out)
+    assert out[0]["finding"] == "hit-1"
+    assert "docs/x.md" in out[0]["verified_path"]
+    assert "Discoveries" in out[0]["verified_path"]
+    assert "0.87" in out[0]["verified_path"]
+
+
+def test_weaviate_recall_source_passes_query_text_with_kei_and_title(monkeypatch):
+    """Query text fed to agent_query.query is `f'{kei}: {title}'` —
+    captures the claim's full intent rather than just the KEI id.
+    """
+    import types  # noqa: PLC0415
+
+    captured = {}
+
+    def _capture(text, **kwargs):
+        captured["text"] = text
+        captured["agent"] = kwargs.get("agent")
+        return types.SimpleNamespace(citations=())
+
+    if "src" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src", types.ModuleType("src"))
+    if "src.retrieval" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "src.retrieval", types.ModuleType("src.retrieval"))
+    fake_mod = types.ModuleType("src.retrieval.agent_query")
+    fake_mod.query = _capture
+    monkeypatch.setitem(sys.modules, "src.retrieval.agent_query", fake_mod)
+    monkeypatch.setattr(sys.modules["src.retrieval"], "agent_query", fake_mod, raising=False)
+
+    src = _inj.weaviate_recall_source(kei="KEI-103", title="Fix cognee_recall", callsign="atlas")
+    src()
+    assert captured["text"] == "KEI-103: Fix cognee_recall"
+    assert captured["agent"] == "atlas"


### PR DESCRIPTION
## Summary
- KEI-103 — agents never read memory back on bd claim; retrieval_events stayed at 0 even though writes worked.
- Two-part fix: (1) wire `agent_query.query()` into `claim_context_injector.format_preamble` so bd claim actually queries Weaviate per-claim, (2) strip `postgresql+asyncpg://` dialect tag in `_record_event` so the resulting psycopg INSERT actually fires (was silently failing).
- Empirically verified: `retrieval_events` count `0 → 1` after one recall through the wired path (latest=2026-05-17T14:50:06Z).

## Acceptance (KEI-103)
> retrieval_events > 0 after a bd claim cycle

```
$ source /home/elliotbot/.config/agency-os/.env
$ python3 -c "import sys; sys.path[:0]=['.','scripts/orchestrator']; \
              import claim_context_injector as inj; \
              src = inj.weaviate_recall_source(kei='KEI-103', title='Fix cognee_recall', callsign='atlas'); \
              print(f'Returned {len(src())} entries')"
Returned 5 entries

$ # Then via Supabase MCP:
$ # SELECT COUNT(*), MAX(occurred_at) FROM public.retrieval_events;
$ # {"n":1,"latest":"2026-05-17 14:50:06.787515+00"}
```

Pre-fix: same invocation produced 5 citations but `retrieval_events` stayed at 0 — `_record_event` swallowed `psycopg.ProgrammingError: missing "=" after "postgresql+asyncpg://..."` via the broad-except. THAT was the silent failure mode hiding KEI-103.

## Why two parts?
The KEI title says "Fix cognee_recall read pathway". Two pathologies share that umbrella:

1. **Wiring gap**: `claim_context_injector` (the actual bd-claim preamble emitter) loaded jsonl-only via `discovery_log.load_active_discoveries()`. Its `extra_sources` extension point existed in the design but had never been wired. So `agent_query.query()` was NEVER invoked from bd claim. (`scripts/cognee_recall.py` is a different artefact — a Cognee semantic-search wrapper for inbox-watcher dispatch enrichment; it does NOT write retrieval_events.)

2. **DSN parse failure**: even when `agent_query.query()` IS invoked (from `scripts/retrieval_smoke.py`), the `_record_event` INSERT swallows a `psycopg.ProgrammingError` because `DATABASE_URL` arrives as `postgresql+asyncpg://...` from `.env` (the SQLAlchemy dialect tag — psycopg3 can't parse it). Memory `reference_psycopg_supabase_pgbouncer.md` already documents this: strip the tag the same way `ceo_memory_indexer` and `indexer_base.resolve_pg_dsn` do.

Fix #1 surfaces the bug. Fix #2 closes it. Either alone leaves retrieval_events at 0.

## Files
- `scripts/orchestrator/claim_context_injector.py` (+82 LoC) — adds `weaviate_recall_source(kei, title, callsign) -> Callable[[], list[dict]]`, repo-root sys.path entry, fail-open import/query guards. Each Weaviate citation converts to a discovery-dict tagged with the claim KEI so the existing relevance filter keeps it.
- `scripts/tasks_cli.py` (+11 LoC) — `cmd_claim` builds the Weaviate source and passes via `extra_sources=(weaviate_src,)`.
- `src/retrieval/agent_query.py` (+5 LoC) — strip `postgresql+asyncpg://` → `postgresql://` before `psycopg.connect`.
- `tests/scripts/test_claim_context_injector.py` (+136 LoC): 5 new Weaviate-source tests (factory shape, fail-open on ImportError, fail-open on query exception, citation→dict conversion + tagging, query-text composition) + `_no_weaviate_recall` shared fixture used by 2 existing local-preamble tests so they stay hermetic against live Weaviate.
- `tests/retrieval/test_agent_query.py` (+68 LoC): one new test locks the `_record_event` DSN strip via fake psycopg.connect capture.

## Test plan
- [x] ruff check + format clean
- [x] pytest tests/retrieval/test_agent_query.py + tests/scripts/test_claim_context_injector.py: 25/25 passed in 0.26s
- [x] Live empirical: retrieval_events 0 → 1 after one wired-path call
- [ ] CI: ruff + mypy + pytest + KEI-108 gate + SonarCloud all green
- [ ] Dual review (any 2 non-author peers)
- [ ] Merge to main; on next real bd claim from any agent, observe retrieval_events grows live

[READY:atlas] — awaiting dual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)