### PR TITLE
[MAX] feat(kei90): Gate 3 — peer verify on deployment-class tasks (rebased)

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -6,16 +6,16 @@ start, snapshotted by the PreCompact hook (scripts/pre_compact_alert.py).
 
 ## Active Task
 
-- Directive: <directive number or label>
-- Goal: <one-line>
-- Phase: <scope/decompose/execute/verify/report>
-- Files touched (current PR): infra/systemd/agents/linear-state-indexer.service, scripts/install_linear_state_indexer.sh, scripts/orchestrator/linear_state_indexer.py, tests/scripts/test_linear_state_indexer.py
+- Directive: KEI-90 (Gate 3 — peer-verify on deployment-class KEIs)
+- Goal: rebuild PR #928 on post-#925 main; ship Gate 3 with Dave-solo-ops 2-of-3 path
+- Phase: verify → report (tests 11/11, ruff clean, KEI-108 gate clean; commit + push pending)
+- Files touched (current PR): scripts/tasks_cli.py, supabase/migrations/20260517_kei90_gate3_deployment_peer_verify.sql, tests/scripts/test_tasks_cli_gate3.py
 
 ## Last Good Commit
 
-- SHA: e0cbce13
-- Branch: main
-- Subject: [ATLAS] feat(kei85): phase B — linear_state_indexer (Linear KEI state → Keis)
+- SHA: 66696057
+- Branch: origin/main
+- Subject: refactor(kei107): deduplicate mock helpers in test_cognee_session_start (#926)
 
 ## Model
 
@@ -28,7 +28,7 @@ start, snapshotted by the PreCompact hook (scripts/pre_compact_alert.py).
 
 ## Next Action
 
-- <single concrete next step the next session should execute>
+- Commit + push max/kei90-gate3-rebased; update PR #928 (or open replacement). After dual-concur, merge per Dave PR-duty directive.
 
 ## Heartbeat Cadence (CLAUDE.md context thresholds)
 

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -262,6 +262,125 @@ def _print_ready_rows(rows: list[dict], agent: str) -> None:
     print(f"\n{len(rows)} available{suffix}")
 
 
+def _gate3_dave_solo_ops(
+    cur: Any,
+    verified_by: str,
+    secondary_verifier: str,
+    verifier_session: str,
+) -> tuple[str | None, str]:
+    """Dave-solo-ops 2-of-3 path (extracted; keeps cognitive complexity low).
+
+    Spec (3-way ratified KEI-128 ts ~1779010883, sharpened by Aiden's PR #928
+    review): when builder=='dave', require SIMULTANEOUS --verifier <a> +
+    --secondary-verifier <b> where a != b, neither is 'dave', and both have
+    distinct session_uuids (verifier_session != b's most-recent
+    tool_call_log session_uuid). Prevents single-agent fake-quorum via
+    session-renewal.
+    """
+    sb = (secondary_verifier or "").strip().lower()
+    if not sb:
+        return (
+            "ERROR: KEI-90 Gate 3 Dave-solo-ops — both --verifier and "
+            "--secondary-verifier <callsign> are required when builder=='dave'.",
+            verified_by,
+        )
+    if verified_by == sb:
+        return (
+            f"ERROR: KEI-90 Gate 3 Dave-solo-ops — --verifier ({verified_by!r}) "
+            f"and --secondary-verifier ({sb!r}) must be distinct callsigns.",
+            verified_by,
+        )
+    if verified_by == "dave" or sb == "dave":
+        return (
+            "ERROR: KEI-90 Gate 3 Dave-solo-ops — neither --verifier nor "
+            "--secondary-verifier may be 'dave' (builder is dave).",
+            verified_by,
+        )
+    cur.execute(
+        """
+        SELECT session_uuid FROM public.tool_call_log
+         WHERE callsign = %s ORDER BY created_at DESC LIMIT 1
+        """,
+        (sb,),
+    )
+    row = cur.fetchone()
+    sb_session = (row[0] if row and row[0] else "").strip()
+    if not sb_session:
+        return (
+            f"ERROR: KEI-90 Gate 3 Dave-solo-ops — secondary verifier ({sb!r}) "
+            "has no tool_call_log session_uuid on record (independence "
+            "cannot be proven).",
+            verified_by,
+        )
+    if sb_session == verifier_session:
+        return (
+            "ERROR: KEI-90 Gate 3 Dave-solo-ops — verifier_session_uuid and "
+            "secondary verifier's session_uuid must be distinct.",
+            verified_by,
+        )
+    return None, verified_by
+
+
+def _check_gate3_peer_verify(
+    cur: Any,
+    task_id: str,
+    callsign: str,
+    verifier_arg: str | None,
+    verifier_session: str,
+    secondary_verifier_arg: str | None = None,
+) -> tuple[str | None, str]:
+    """KEI-90 Gate 3: peer-verify on deployment-class tasks.
+
+    Returns (error_or_None, verified_by_callsign). When the task's
+    deployment=false the function is a no-op returning (None, callsign).
+    """
+    cur.execute(
+        "SELECT deployment, claimed_by FROM public.tasks WHERE id = %s",
+        (task_id,),
+    )
+    row = cur.fetchone()
+    deployment = bool(row[0]) if row and row[0] is not None else False
+    builder = (row[1] if row and row[1] else "").strip().lower()
+    if not deployment:
+        return None, callsign
+    if not verifier_arg:
+        return (
+            f"ERROR: KEI-90 Gate 3 — task is deployment=true; --verifier "
+            f"<callsign> is required (must differ from builder={builder!r}).",
+            callsign,
+        )
+    verified_by = (verifier_arg or "").strip().lower() or callsign
+    if not verifier_session:
+        return (
+            "ERROR: KEI-90 Gate 3 — evidence.verifier_session_uuid is "
+            "required for deployment=true tasks (session-independence).",
+            verified_by,
+        )
+    if builder == "dave":
+        err, verified_by = _gate3_dave_solo_ops(
+            cur, verified_by, secondary_verifier_arg or "", verifier_session
+        )
+        if err:
+            return err, verified_by
+    elif verified_by == builder:
+        return (
+            f"ERROR: KEI-90 Gate 3 — verifier ({verified_by!r}) must differ "
+            f"from builder ({builder!r}).",
+            verified_by,
+        )
+    cur.execute(
+        "SELECT 1 FROM public.tool_call_log WHERE callsign = %s AND session_uuid = %s LIMIT 1",
+        (builder, verifier_session),
+    )
+    if cur.fetchone() is not None:
+        return (
+            f"ERROR: KEI-90 Gate 3 — verifier_session_uuid matches a prior "
+            f"session of builder ({builder!r}); session-independence required.",
+            verified_by,
+        )
+    return None, verified_by
+
+
 def cmd_ready(args: argparse.Namespace) -> int:
     """List available tasks ordered by priority ASC then created_at ASC.
 
@@ -524,6 +643,9 @@ def cmd_complete(args: argparse.Namespace) -> int:
     canonical_str = json.dumps(evidence_payload, sort_keys=True, ensure_ascii=False)
     evidence_hash = _canonical_hash(evidence_payload)
     cs = _callsign(args.callsign)
+    verifier_arg = getattr(args, "verifier", None)
+    secondary_arg = getattr(args, "secondary_verifier", None)
+    verifier_session = str(evidence_payload.get("verifier_session_uuid", "")).strip()
     behavioral_test = (
         evidence_payload["acceptance_items"][0]
         if evidence_payload["acceptance_items"]
@@ -532,6 +654,13 @@ def cmd_complete(args: argparse.Namespace) -> int:
 
     try:
         with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
+            # KEI-90 Gate 3: deployment peer-verify (extracted helper).
+            gate3_err, verified_by = _check_gate3_peer_verify(
+                cur, args.id, cs, verifier_arg, verifier_session, secondary_arg
+            )
+            if gate3_err:
+                print(gate3_err, file=sys.stderr)
+                return 1
             prior_id, prior_ts = _check_hash_uniqueness(cur, args.id, evidence_hash)
             if prior_id is not None:
                 print(
@@ -541,7 +670,7 @@ def cmd_complete(args: argparse.Namespace) -> int:
                 )
                 return 1
             row = _execute_atomic_complete(
-                cur, args.id, cs, behavioral_test, canonical_str, args.force_mode
+                cur, args.id, verified_by, behavioral_test, canonical_str, args.force_mode
             )
             if row is None:
                 conn.rollback()
@@ -669,6 +798,17 @@ def main(argv: list[str] | None = None) -> int:
         default="strict",
         choices=["strict", "force"],
         help="force=allow completion regardless of claimed_by (admin)",
+    )
+    p_complete.add_argument(
+        "--verifier",
+        metavar="CALLSIGN",
+        help="KEI-90 Gate 3: verifier callsign for deployment=true tasks. Must differ from builder; verifier_session_uuid in evidence must differ from any builder tool_call_log session_uuid.",
+    )
+    p_complete.add_argument(
+        "--secondary-verifier",
+        dest="secondary_verifier",
+        metavar="CALLSIGN",
+        help="KEI-90 Gate 3 Dave-solo-ops: second verifier callsign when builder=='dave'. Must differ from --verifier; neither may be 'dave'; secondary's most-recent tool_call_log session_uuid must differ from verifier_session_uuid.",
     )
     p_complete.add_argument(
         "--evidence",

--- a/supabase/migrations/20260517_kei90_gate3_deployment_peer_verify.sql
+++ b/supabase/migrations/20260517_kei90_gate3_deployment_peer_verify.sql
@@ -1,0 +1,33 @@
+-- KEI-90 — Gate 3: peer-verify on deployment-class KEIs (KEI-128 Phase 0.5).
+--
+-- Adds public.tasks.deployment (boolean default false). When true, bd
+-- complete additionally requires --verifier <callsign> with verifier ≠
+-- builder AND verifier's session_uuid ≠ builder's session_uuid. The
+-- session_uuid independence check uses Gate 2's evidence schema (already
+-- enforces verifier_session_uuid as a required field via KEI-89).
+--
+-- Backfill: mark the known operational-deployment KEIs (install systemd
+-- unit / set env / restart service shape) as deployment=true. List is
+-- derived from today's audit sweeps (KEI-108 + KEI-32) — install
+-- references for systemd units + Railway env-set work + webhook router
+-- registration. Going forward, deployment=true is set explicitly on
+-- KEIs filed under the operational-deployment label.
+
+ALTER TABLE public.tasks
+  ADD COLUMN IF NOT EXISTS deployment boolean DEFAULT false NOT NULL;
+
+-- Backfill known operational KEIs (Phase 0 + 0.5 remediation set).
+-- Memory + observability install: KEI-45/66 (false-complete remediations)
+-- + KEI-86 (phase-lock) + KEI-91 (Gate 4 heartbeat) + KEI-92 (self-claim)
+-- + KEI-93 (reset handler) + KEI-100 (LiteLLM gateway) + KEI-101 (Valkey).
+-- KEI-87 (cross-cutting write-guard) DOES involve a migration but ships
+-- the trigger; the actual deploy-step is the apply_migration follow-up,
+-- which is a deployment-class task.
+UPDATE public.tasks SET deployment = true
+ WHERE id IN (
+   'KEI-45', 'KEI-66', 'KEI-86', 'KEI-87', 'KEI-91', 'KEI-92', 'KEI-93',
+   'KEI-100', 'KEI-101'
+ );
+
+COMMENT ON COLUMN public.tasks.deployment IS
+  'KEI-90 Gate 3 flag — true means bd complete requires --verifier ≠ builder with session_uuid independence (KEI-89 evidence schema cross-check). Dave-solo-ops 2-of-3 path applies when builder.callsign=dave.';

--- a/tests/scripts/test_tasks_cli_gate3.py
+++ b/tests/scripts/test_tasks_cli_gate3.py
@@ -1,0 +1,125 @@
+"""KEI-90 Gate 3 — tests for deployment peer-verify in scripts/tasks_cli.py.
+
+Strategy: exercises the extracted helper `_check_gate3_peer_verify` directly
+with a fake cursor that returns canned rows for the two SELECTs the helper
+issues (tasks deployment+claimed_by, then either dave-priors-count or
+tool_call_log session-match).
+
+Covers:
+  - deployment=false → no-op pass-through
+  - deployment=true + missing --verifier → explanatory error
+  - deployment=true + verifier == builder → independence error
+  - deployment=true + missing verifier_session_uuid → schema error
+  - deployment=true + verifier_session conflicts with builder's tool_call_log → error
+  - deployment=true + clean independent → success
+  - Dave-solo-ops + 0 priors → 2-of-3 path error
+  - Dave-solo-ops + 1 prior + distinct session → success
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "tasks_cli.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("tasks_cli_g3", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["tasks_cli_g3"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+class _GateCursor:
+    """Cursor that returns scripted fetchone() values in order."""
+
+    def __init__(self, replies: list[object]) -> None:
+        self._iter: Iterator[object] = iter(replies)
+        self.executed: list[tuple] = []
+
+    def execute(self, sql: str, params: tuple | None = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> object:
+        return next(self._iter, None)
+
+
+def test_deployment_false_passes_through(mod):
+    cur = _GateCursor([(False, "max"), None])
+    err, by = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", None, "")
+    assert err is None and by == "elliot"
+
+
+def test_deployment_true_missing_verifier(mod):
+    cur = _GateCursor([(True, "max")])
+    err, _ = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", None, "uuid-1")
+    assert err is not None and "--verifier" in err
+
+
+def test_deployment_true_verifier_equals_builder(mod):
+    cur = _GateCursor([(True, "max")])
+    err, by = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", "max", "uuid-1")
+    assert err is not None and "differ from builder" in err
+    assert by == "max"
+
+
+def test_deployment_true_missing_verifier_session(mod):
+    cur = _GateCursor([(True, "max")])
+    err, _ = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", "elliot", "")
+    assert err is not None and "verifier_session_uuid" in err
+
+
+def test_deployment_true_session_conflict(mod):
+    # First fetchone: tasks row. Second fetchone: tool_call_log MATCH.
+    cur = _GateCursor([(True, "max"), (1,)])
+    err, _ = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", "elliot", "uuid-collide")
+    assert err is not None and "session-independence" in err
+
+
+def test_deployment_true_clean_pass(mod):
+    # tasks row + tool_call_log returns None (no match).
+    cur = _GateCursor([(True, "max"), None])
+    err, by = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", "elliot", "uuid-clean")
+    assert err is None and by == "elliot"
+
+
+def test_dave_solo_ops_missing_secondary(mod):
+    # tasks row builder=dave + no --secondary-verifier passed.
+    cur = _GateCursor([(True, "dave")])
+    err, _ = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", "elliot", "uuid-1", None)
+    assert err is not None and "secondary-verifier" in err
+
+
+def test_dave_solo_ops_same_verifier_callsigns(mod):
+    cur = _GateCursor([(True, "dave")])
+    err, _ = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", "elliot", "uuid-1", "elliot")
+    assert err is not None and "distinct callsigns" in err
+
+
+def test_dave_solo_ops_secondary_is_dave(mod):
+    cur = _GateCursor([(True, "dave")])
+    err, _ = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", "elliot", "uuid-1", "dave")
+    assert err is not None and "may be 'dave'" in err
+
+
+def test_dave_solo_ops_clean_two_distinct_sessions(mod):
+    # tasks row builder=dave; secondary 'max' has tool_call_log session='uuid-b';
+    # final builder-vs-verifier tool_call_log check returns None.
+    cur = _GateCursor([(True, "dave"), ("uuid-b",), None])
+    err, by = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", "elliot", "uuid-a", "max")
+    assert err is None and by == "elliot"
+
+
+def test_dave_solo_ops_session_collision_with_secondary(mod):
+    # secondary 'max' has same session as the verifier's evidence uuid.
+    cur = _GateCursor([(True, "dave"), ("uuid-collide",)])
+    err, _ = mod._check_gate3_peer_verify(cur, "KEI-X", "elliot", "elliot", "uuid-collide", "max")
+    assert err is not None and "must be distinct" in err


### PR DESCRIPTION
## Summary

Replaces closed PR #928 (pre-#925 branch had no merge base against current main).

KEI-90 Gate 3 implementation — runtime peer-verify on deployment-class tasks. Rebased on post-#925 main (66696057, Aiden Gate 2 + Elliot's merge wave).

### Mechanism
- Adds `public.tasks.deployment` boolean (default false, NOT NULL).
- When `deployment=true`, `bd complete` requires `--verifier <callsign>` with:
  - builder ≠ verifier
  - `evidence.verifier_session_uuid` ≠ any prior builder session_uuid from `public.tool_call_log` (cross-session-uuid independence enforced via Gate 2's required schema field).
- **Dave-solo-ops 2-of-3 path:** when builder=='dave', additionally requires `--secondary-verifier <callsign>`. Both must be ≠'dave', ≠ each other; secondary's most-recent `tool_call_log.session_uuid` must differ from `verifier_session_uuid`.

### Wiring order in `cmd_complete` (post-Aiden #925)
1. Behavioral test extraction (KEI-89 schema)
2. Gate 3 check — `_check_gate3_peer_verify` (this PR)
3. Gate 2 hash uniqueness check
4. Atomic INSERT `task_verifications` + UPDATE `tasks` (with `verified_by = verifier`)

### Backfill
9 known operational KEIs flagged `deployment=true`: 45, 66, 86, 87, 91, 92, 93, 100, 101. Going forward, KEIs under the `operational-deployment` label are tagged explicitly at file time.

## Test plan
- [x] `python3 -m pytest tests/scripts/test_tasks_cli_gate3.py` → **11/11 pass** (happy path; missing-verifier; same-callsign; session collision; non-deployment skip; Dave-solo-ops happy + 4 error paths)
- [x] `ruff check` clean
- [x] `ruff format --check` clean (2 files)
- [x] `BASE_REF=main bash scripts/ci/check_operational_deployment.sh` clean
- [ ] Peer concur on Gate 3 + Dave-solo-ops semantics (Aiden / Elliot / Scout)
- [ ] Merge after dual concur per Dave PR-duty directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)