### PR TITLE
[ATLAS] fix(kei173): drive_manual sink — accept --task-id + treat rc=2 as success

### DIFF
--- a/scripts/orchestrator/completion_sync_worker.py
+++ b/scripts/orchestrator/completion_sync_worker.py
@@ -104,6 +104,14 @@ def _sink_ceo_memory(conn, task_id: str, target_status: str) -> None:
 
 
 def _sink_drive_manual(task_id: str) -> None:
+    """Invoke the Drive mirror for the originating task.
+
+    KEI-173: rc=2 means MANUAL.md is unchanged since the last successful
+    mirror (write_manual_mirror.py outcome 'refused_unchanged'). Drive is
+    already consistent — no work to do — so the sink treats it as success,
+    not a SinkError. Otherwise repeated completions between Manual edits
+    would each retry 3× and abandon, polluting the queue.
+    """
     script = os.path.join(SCRIPT_ROOT, "scripts", "write_manual_mirror.py")
     if not os.path.isfile(script):
         raise SinkError(f"missing {script}")
@@ -117,8 +125,12 @@ def _sink_drive_manual(task_id: str) -> None:
         )
     except subprocess.TimeoutExpired as exc:
         raise SinkError("drive_manual timeout") from exc
-    if out.returncode != 0:
-        raise SinkError(f"drive_manual exit={out.returncode}: {out.stderr[:200]}")
+    if out.returncode == 0:
+        return
+    if out.returncode == 2:
+        logger.info("[%s/drive_manual] MANUAL.md unchanged — Drive already current", task_id)
+        return
+    raise SinkError(f"drive_manual exit={out.returncode}: {out.stderr[:200]}")
 
 
 def _due_now(row) -> bool:

--- a/scripts/write_manual_mirror.py
+++ b/scripts/write_manual_mirror.py
@@ -149,10 +149,9 @@ def persist_exit_code(exit_code: int, outcome: str, task_id: str | None = None) 
         state = load_state() or {}
         state["last_exit_code"] = int(exit_code)
         state["last_outcome"] = str(outcome)
+        # controlled args, no shell — S603 suppressed
         state["last_exit_recorded_at"] = (
-            subprocess.check_output(  # noqa: S603 — controlled args, no shell
-                ["date", "-Iseconds"]
-            )
+            subprocess.check_output(["date", "-Iseconds"])  # noqa: S603
             .decode()
             .strip()
         )

--- a/scripts/write_manual_mirror.py
+++ b/scripts/write_manual_mirror.py
@@ -125,7 +125,7 @@ def save_state(state: dict) -> None:
     STATE_PATH.write_text(json.dumps(state, indent=2), encoding="utf-8")
 
 
-def persist_exit_code(exit_code: int, outcome: str) -> None:
+def persist_exit_code(exit_code: int, outcome: str, task_id: str | None = None) -> None:
     """KEI-9 Wave 2 item 3: persist Drive mirror exit code + outcome label
     to the state file so post-restart sessions can read whether the last
     mirror succeeded.
@@ -137,6 +137,11 @@ def persist_exit_code(exit_code: int, outcome: str) -> None:
       2 / "refused_unchanged" — main run refused due to unchanged content
       3 / "missing_manual"    — MANUAL.md not found
 
+    KEI-173: task_id captures the originating completion_sync_queue task
+    (e.g. "KEI-XYZ") so the state file back-links to the directive that
+    triggered the mirror. Worker (completion_sync_worker._sink_drive_manual)
+    passes it via --task-id.
+
     Best-effort: failures here must not change the main() exit code. This
     is observability metadata, not control flow.
     """
@@ -144,9 +149,15 @@ def persist_exit_code(exit_code: int, outcome: str) -> None:
         state = load_state() or {}
         state["last_exit_code"] = int(exit_code)
         state["last_outcome"] = str(outcome)
-        state["last_exit_recorded_at"] = subprocess.check_output(  # noqa: S603 — controlled args, no shell
-            ["date", "-Iseconds"]
-        ).decode().strip()
+        state["last_exit_recorded_at"] = (
+            subprocess.check_output(  # noqa: S603 — controlled args, no shell
+                ["date", "-Iseconds"]
+            )
+            .decode()
+            .strip()
+        )
+        if task_id:
+            state["last_task_id"] = str(task_id)
         save_state(state)
     except (OSError, subprocess.SubprocessError) as exc:
         logger.warning("persist_exit_code failed (non-fatal): %s", exc)
@@ -323,6 +334,16 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Install the post-commit hook (git config core.hooksPath .githooks) and exit.",
     )
+    ap.add_argument(
+        "--task-id",
+        type=str,
+        default=None,
+        help=(
+            "KEI-173: originating task id (e.g. 'KEI-NNN') passed by "
+            "completion_sync_worker for audit trail. Recorded in state file's "
+            "last_task_id field. Does not alter mirror logic."
+        ),
+    )
     args = ap.parse_args(argv)
 
     # M11-1 — handle install first; it doesn't need MANUAL.md.
@@ -334,7 +355,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if not MANUAL_PATH.exists():
         logger.error(f"MANUAL.md not found at {MANUAL_PATH}")
-        persist_exit_code(3, "missing_manual")
+        persist_exit_code(3, "missing_manual", task_id=args.task_id)
         return 3
 
     current_fp = fingerprint(MANUAL_PATH)
@@ -351,10 +372,10 @@ def main(argv: list[str] | None = None) -> int:
                 current_fp.get("git_blob", "n/a"),
                 current_fp["sha256"][:12],
             )
-            persist_exit_code(2, "check_unchanged")
+            persist_exit_code(2, "check_unchanged", task_id=args.task_id)
             return 2
         logger.info("MANUAL.md CHANGED since last mirror — mirror would proceed.")
-        persist_exit_code(0, "check_changed")
+        persist_exit_code(0, "check_changed", task_id=args.task_id)
         return 0
 
     if unchanged and not args.force:
@@ -365,7 +386,7 @@ def main(argv: list[str] | None = None) -> int:
             current_fp.get("git_blob", "n/a"),
             current_fp["sha256"][:12],
         )
-        persist_exit_code(2, "refused_unchanged")
+        persist_exit_code(2, "refused_unchanged", task_id=args.task_id)
         return 2
 
     if args.force and unchanged:
@@ -382,7 +403,10 @@ def main(argv: list[str] | None = None) -> int:
     # block the staleness check.
     state["last_fingerprint"] = current_fp
     state["last_mirrored_at"] = subprocess.check_output(["date", "-Iseconds"]).decode().strip()
+    if args.task_id:
+        state["last_task_id"] = str(args.task_id)
     save_state(state)
+    persist_exit_code(0, "mirrored", task_id=args.task_id)
     logger.info(f"State persisted to {STATE_PATH}")
     logger.info("Done.")
     return 0

--- a/tests/scripts/test_completion_sync_worker.py
+++ b/tests/scripts/test_completion_sync_worker.py
@@ -119,3 +119,45 @@ def test_unknown_sink_records_error(monkeypatch):
     assert ok is False
     err = conn.cursor_calls[-1].executed[-1][1][0]
     assert "unknown sink" in err
+
+
+# KEI-173 — drive_manual sink must treat rc=2 (MANUAL unchanged) as success.
+
+
+def test_drive_manual_rc2_treated_as_success(monkeypatch):
+    """rc=2 means write_manual_mirror refused to re-mirror identical content
+    ('refused_unchanged'). Drive is already current — sink succeeds, queue row
+    is marked processed=true. Without this, repeated completions between Manual
+    edits would each retry 3× and abandon."""
+
+    def fake_run(args, **kwargs):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(returncode=2, stderr="unchanged")
+
+    monkeypatch.setattr(csw.subprocess, "run", fake_run)
+    monkeypatch.setattr(csw.os.path, "isfile", lambda p: True)
+    conn = _FakeConn()
+    ok = csw._process_row(conn, _row(target_sink="drive_manual"))
+    assert ok is True
+    final_sql = conn.cursor_calls[-1].executed[-1][0]
+    assert "processed=TRUE" in final_sql
+
+
+def test_drive_manual_rc3_still_treated_as_failure(monkeypatch):
+    """rc=3 (missing_manual) is a real error — sink must raise SinkError so
+    the worker records attempts++ and eventually abandons after MAX_ATTEMPTS."""
+
+    def fake_run(args, **kwargs):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(returncode=3, stderr="MANUAL.md not found")
+
+    monkeypatch.setattr(csw.subprocess, "run", fake_run)
+    monkeypatch.setattr(csw.os.path, "isfile", lambda p: True)
+    conn = _FakeConn()
+    ok = csw._process_row(conn, _row(target_sink="drive_manual"))
+    assert ok is False
+    sql, params = conn.cursor_calls[-1].executed[-1]
+    assert "attempts=attempts+1" in sql
+    assert "exit=3" in params[0]

--- a/tests/scripts/test_write_manual_mirror.py
+++ b/tests/scripts/test_write_manual_mirror.py
@@ -275,7 +275,12 @@ def test_persist_exit_code_writes_state(tmp_manual):
 
 def test_persist_exit_code_preserves_existing_state(tmp_manual):
     """persist_exit_code MUST NOT clobber the fingerprint or mirrored_at fields."""
-    mirror.save_state({"last_fingerprint": {"git_blob": "abc123"}, "last_mirrored_at": "2026-05-12T22:00:00+00:00"})
+    mirror.save_state(
+        {
+            "last_fingerprint": {"git_blob": "abc123"},
+            "last_mirrored_at": "2026-05-12T22:00:00+00:00",
+        }
+    )
     mirror.persist_exit_code(2, "refused_unchanged")
     state = mirror.load_state()
     assert state["last_fingerprint"] == {"git_blob": "abc123"}
@@ -315,3 +320,48 @@ def test_main_persists_exit_code_on_check_unchanged(tmp_manual, monkeypatch):
     state = mirror.load_state()
     assert state.get("last_exit_code") == 2
     assert state.get("last_outcome") == "check_unchanged"
+
+
+# KEI-173 — --task-id flag accepted + recorded for completion_sync_worker audit
+
+
+def test_task_id_flag_accepted_on_check(tmp_manual):
+    """--task-id is accepted alongside --check (no argparse error) and
+    persists to state.last_task_id for audit traceability."""
+    rc = mirror.main(["--check", "--task-id", "KEI-173"])
+    assert rc == 0  # fresh state → treated as 'changed'
+    state = mirror.load_state()
+    assert state.get("last_task_id") == "KEI-173"
+
+
+def test_task_id_flag_recorded_on_refused_unchanged(tmp_manual):
+    """When the second call refuses (rc=2), --task-id is still recorded so
+    the audit trail shows which task triggered the (refused) sink call."""
+    with patch.object(mirror, "mirror_to_drive"):
+        mirror.main(["--task-id", "KEI-100"])  # initial mirror
+    rc = mirror.main(["--task-id", "KEI-173"])
+    assert rc == 2
+    state = mirror.load_state()
+    assert state.get("last_task_id") == "KEI-173"
+    assert state.get("last_outcome") == "refused_unchanged"
+
+
+def test_task_id_flag_recorded_on_successful_mirror(tmp_manual):
+    """Happy path: a fresh mirror records the task_id on the success path."""
+    with patch.object(mirror, "mirror_to_drive") as m:
+        rc = mirror.main(["--task-id", "KEI-173"])
+    assert rc == 0
+    m.assert_called_once()
+    state = mirror.load_state()
+    assert state.get("last_task_id") == "KEI-173"
+    assert state.get("last_outcome") == "mirrored"
+
+
+def test_no_task_id_flag_still_works(tmp_manual):
+    """Backwards compatible: bare invocation (post-commit hook, manual run)
+    still works without --task-id and does not write last_task_id."""
+    with patch.object(mirror, "mirror_to_drive"):
+        rc = mirror.main([])
+    assert rc == 0
+    state = mirror.load_state()
+    assert "last_task_id" not in state


### PR DESCRIPTION
## Summary

Fixes KEI-173. The completion_sync_worker's `drive_manual` sink invokes `write_manual_mirror.py --task-id <id>`, but the mirror only accepted `--force/--check/--install` → argparse error → 3 retries → abandoned at MAX_ATTEMPTS on every completion.

Two-bug fix in one PR (per `feedback_non_blockers_are_blockers`):

1. **`scripts/write_manual_mirror.py`** — add optional `--task-id ID`. When set, recorded in state file's `last_task_id` field for audit traceability back to the originating completion. Mirror logic unchanged.

2. **`scripts/orchestrator/completion_sync_worker._sink_drive_manual`** — treat rc=2 (MANUAL unchanged → `refused_unchanged`) as success. Drive is already consistent; repeated completions between Manual edits no longer 3×retry+abandon. rc=3 (missing_manual) still raises SinkError.

## Test plan

- [x] `pytest tests/scripts/test_write_manual_mirror.py tests/scripts/test_completion_sync_worker.py` — 38/38 passed (4 new mirror tests, 2 new worker tests).
- [x] `ruff check` — All checks passed.
- [x] `ruff format --check` — 4 files already formatted.
- [x] **Empirical smoke** (per `empirical-smoke-catches-paper-review-3`):
  - `python3 scripts/write_manual_mirror.py --check --task-id KEI-173` → rc=2, state file shows `last_task_id=KEI-173`, `last_outcome=check_unchanged`.
  - `_sink_drive_manual('KEI-173-smoke')` against the real script → returns cleanly, logs "MANUAL.md unchanged — Drive already current", no SinkError raised.

## New tests

**Worker** (`test_completion_sync_worker.py`):
- `test_drive_manual_rc2_treated_as_success` — rc=2 path → `processed=TRUE` (negative-path for the absorbed bug).
- `test_drive_manual_rc3_still_treated_as_failure` — rc=3 still increments attempts (guardrail).

**Mirror** (`test_write_manual_mirror.py`):
- `test_task_id_flag_accepted_on_check`
- `test_task_id_flag_recorded_on_refused_unchanged`
- `test_task_id_flag_recorded_on_successful_mirror`
- `test_no_task_id_flag_still_works` — backwards-compat for post-commit hook + manual runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)