### PR TITLE
[AIDEN] fix(self-assign): handle int priority from tasks_cli JSON — unblock fleet self-claim

### DIFF
--- a/scripts/orchestrator/self_assign_on_ready.py
+++ b/scripts/orchestrator/self_assign_on_ready.py
@@ -65,8 +65,17 @@ _CALLSIGN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
 
 
 def _priority_key(item: dict) -> tuple:
-    """Sort key: lower-number priority first; fall back to created_at asc."""
-    pri_raw = (item.get("priority") or "").upper()
+    """Sort key: lower-number priority first; fall back to created_at asc.
+
+    bd ready --json now returns priority as int (1/2/3/4) post-KEI-22 SSOT
+    migration. Coerce to str before .upper() so the old 'P\\d+' regex still
+    matches both int + 'P1' string shapes — int '1' becomes '1', regex misses,
+    fall-through to pri_n=9 (lowest precedence). Then re-handle int directly.
+    """
+    raw = item.get("priority")
+    if isinstance(raw, int):
+        return (raw, item.get("created", "") or item.get("created_at", ""))
+    pri_raw = str(raw or "").upper()
     m = re.match(r"P(\d+)", pri_raw)
     pri_n = int(m.group(1)) if m else 9
     return (pri_n, item.get("created", "") or item.get("created_at", ""))

--- a/tests/orchestrator/test_self_assign_on_ready.py
+++ b/tests/orchestrator/test_self_assign_on_ready.py
@@ -185,6 +185,30 @@ def test_priority_falls_back_to_created_at_when_priority_missing():
     assert sorted_ids == ["Agency_OS-old", "Agency_OS-new"]
 
 
+def test_priority_handles_int_priority_from_tasks_cli_json():
+    """Regression: bd ready --json post-KEI-22 returns priority as int
+    (1/2/3/4), not 'P\\d' string. _priority_key must not raise
+    AttributeError ('int' object has no attribute 'upper') on the int shape.
+    """
+    items = [
+        _item("Agency_OS-low", priority=3),
+        _item("Agency_OS-mid", priority=2),
+        _item("Agency_OS-hi", priority=0),
+    ]
+    sorted_ids = [i["id"] for i in sorted(items, key=mod._priority_key)]
+    assert sorted_ids == ["Agency_OS-hi", "Agency_OS-mid", "Agency_OS-low"]
+
+
+def test_priority_handles_mixed_int_and_str_priority():
+    """Robustness: mixed feed (one int, one P-string) sorts without crash."""
+    items = [
+        _item("Agency_OS-int", priority=2),
+        _item("Agency_OS-str", priority="P1"),
+    ]
+    sorted_ids = [i["id"] for i in sorted(items, key=mod._priority_key)]
+    assert sorted_ids == ["Agency_OS-str", "Agency_OS-int"]
+
+
 # ─── 8. Dry-run prints target without calling claim_fn ──────────────────
 
 


### PR DESCRIPTION
## Summary
Unblocks the entire fleet — all 6 self-claim loops crashing on `'int' object has no attribute 'upper'`. 35 KEIs sitting idle in queue with no claimers.

## Root cause
`bd ready --json` post-KEI-22 SSOT migration returns `priority` as `int` (1/2/3/4), not `'P\d+'` string. `_priority_key` at `scripts/orchestrator/self_assign_on_ready.py:69` does:
```python
pri_raw = (item.get("priority") or "").upper()   # (1 or "").upper() raises
```

## Fix
Branch on `isinstance(int)` BEFORE the str-then-regex path. The naive `str()` wrap (proposed in the bug-report ping) would fix the exception but **regress sorting** — `str(1)` doesn't match `'P(\d+)'` regex, all int priorities fall to `pri_n=9` default, ties on every item, defeats priority ordering entirely. Max independently flagged the same concern on his yield.

```python
def _priority_key(item: dict) -> tuple:
    raw = item.get("priority")
    if isinstance(raw, int):
        return (raw, item.get("created", "") or item.get("created_at", ""))
    pri_raw = str(raw or "").upper()
    m = re.match(r"P(\d+)", pri_raw)
    pri_n = int(m.group(1)) if m else 9
    return (pri_n, item.get("created", "") or item.get("created_at", ""))
```

## Verification
```
$ ruff check + format
All checks passed!

$ python3 -m pytest tests/orchestrator/test_self_assign_on_ready.py -q
...............  [100%]
15 passed in 0.09s
```

Tests added:
- `test_priority_handles_int_priority_from_tasks_cli_json` — positive regression: sort `[3,2,0]` → `hi/mid/low`
- `test_priority_handles_mixed_int_and_str_priority` — mixed feed robustness

## Coordination
- Max ([YIELD:max → aiden]) yielded with 60s gap; concur on isinstance approach
- Elliot diagnosed the root cause + flagged urgency
- Unblocks 35 KEIs immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)