### PR TITLE
[MAX] feat(kei164): KEI-115C — container JWT minting (tenant + scope claims)

### DIFF
--- a/src/dispatcher/__init__.py
+++ b/src/dispatcher/__init__.py
@@ -1,0 +1,5 @@
+"""Dispatcher product layer — KEI-110 Part 17.
+
+Customer-facing product surface: container lifecycle (KEI-115), tenant JWT
+minting (KEI-164), governance proxy (KEI-165), LiteLLM routing (KEI-166).
+"""

--- a/src/dispatcher/container_jwt.py
+++ b/src/dispatcher/container_jwt.py
@@ -1,0 +1,69 @@
+"""KEI-164 — JWT minting for container spawn.
+
+Issues per-container JWT with tenant_id + scope claims; verified via shared
+HS256 secret. Default scopes: task:read, task:write. Sits in the dispatcher
+product layer (KEI-110); used by KEI-115 container lifecycle when a customer
+spawns a managed Claude container, so the container can authenticate against
+the dispatcher API without holding a tenant-wide credential.
+
+Acceptance (Linear KEI-164): JWT issued per container spawn; includes
+tenant_id + scope=['task:read', 'task:write']; signature verifies.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+logger = logging.getLogger(__name__)
+
+JWT_ALGORITHM = "HS256"
+DEFAULT_SCOPES: tuple[str, ...] = ("task:read", "task:write")
+DEFAULT_EXPIRES_IN_SECONDS = 3600  # 1 hour
+_DEV_FALLBACK_SECRET = "dev-container-jwt-secret-not-for-production"
+
+
+def _signing_secret() -> str:
+    """Read CONTAINER_JWT_SECRET; fail fast in production if unset."""
+    secret = os.environ.get("CONTAINER_JWT_SECRET", "").strip()
+    if secret:
+        return secret
+    if os.environ.get("ENVIRONMENT", "").lower() == "production":
+        raise RuntimeError("CONTAINER_JWT_SECRET must be set in production")
+    logger.warning("CONTAINER_JWT_SECRET unset — using dev fallback (not for production)")
+    return _DEV_FALLBACK_SECRET
+
+
+def mint_container_jwt(
+    tenant_id: str,
+    *,
+    scopes: tuple[str, ...] | list[str] | None = None,
+    expires_in_seconds: int = DEFAULT_EXPIRES_IN_SECONDS,
+) -> str:
+    """Mint a JWT for a container spawn.
+
+    Raises ValueError when tenant_id is blank — prevents anonymous container
+    tokens that would later confuse the dispatcher tenant-isolation layer.
+    """
+    if not tenant_id or not tenant_id.strip():
+        raise ValueError("tenant_id is required and must be non-blank")
+    now = datetime.now(UTC)
+    payload: dict = {
+        "tenant_id": tenant_id,
+        "scope": list(scopes) if scopes is not None else list(DEFAULT_SCOPES),
+        "iat": now,
+        "exp": now + timedelta(seconds=expires_in_seconds),
+    }
+    return jwt.encode(payload, _signing_secret(), algorithm=JWT_ALGORITHM)
+
+
+def verify_container_jwt(token: str) -> dict:
+    """Verify + decode a container JWT.
+
+    Raises jwt.InvalidTokenError (or one of its subclasses — ExpiredSignatureError,
+    InvalidSignatureError, etc.) on any verification failure.
+    """
+    return jwt.decode(token, _signing_secret(), algorithms=[JWT_ALGORITHM])

--- a/tests/dispatcher/test_container_jwt.py
+++ b/tests/dispatcher/test_container_jwt.py
@@ -1,0 +1,83 @@
+"""KEI-164 — tests for container JWT minting + verification."""
+
+from __future__ import annotations
+
+import jwt
+import pytest
+
+from src.dispatcher.container_jwt import (
+    DEFAULT_SCOPES,
+    mint_container_jwt,
+    verify_container_jwt,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_jwt_secret(monkeypatch):
+    """Pin the signing secret + clear ENVIRONMENT so dev path is exercised
+    in every test except the explicit production-required-secret case."""
+    monkeypatch.setenv("CONTAINER_JWT_SECRET", "test-secret-kei164")
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+
+def test_mint_returns_three_part_jwt_string():
+    tok = mint_container_jwt("tenant-abc")
+    assert isinstance(tok, str)
+    assert tok.count(".") == 2  # header.payload.signature
+
+
+def test_mint_includes_tenant_id():
+    claims = verify_container_jwt(mint_container_jwt("tenant-abc"))
+    assert claims["tenant_id"] == "tenant-abc"
+
+
+def test_default_scopes_are_task_read_and_task_write():
+    claims = verify_container_jwt(mint_container_jwt("tenant-abc"))
+    assert claims["scope"] == ["task:read", "task:write"]
+    assert set(claims["scope"]) == set(DEFAULT_SCOPES)
+
+
+def test_custom_scopes_override_defaults():
+    claims = verify_container_jwt(mint_container_jwt("tenant-abc", scopes=["task:read"]))
+    assert claims["scope"] == ["task:read"]
+
+
+def test_iat_and_exp_claims_present_and_ordered():
+    claims = verify_container_jwt(mint_container_jwt("tenant-abc", expires_in_seconds=60))
+    assert "iat" in claims and "exp" in claims
+    assert claims["exp"] > claims["iat"]
+
+
+def test_verify_rejects_wrong_secret(monkeypatch):
+    tok = mint_container_jwt("tenant-abc")
+    monkeypatch.setenv("CONTAINER_JWT_SECRET", "different-secret")
+    with pytest.raises(jwt.InvalidSignatureError):
+        verify_container_jwt(tok)
+
+
+def test_verify_rejects_tampered_payload():
+    tok = mint_container_jwt("tenant-abc")
+    parts = tok.split(".")
+    parts[1] = "eyJ0ZW5hbnRfaWQiOiJoYWNrZXIifQ"  # different payload
+    with pytest.raises(jwt.InvalidTokenError):
+        verify_container_jwt(".".join(parts))
+
+
+def test_verify_rejects_expired_token():
+    tok = mint_container_jwt("tenant-abc", expires_in_seconds=-1)
+    with pytest.raises(jwt.ExpiredSignatureError):
+        verify_container_jwt(tok)
+
+
+def test_mint_rejects_blank_tenant_id():
+    with pytest.raises(ValueError, match="tenant_id is required"):
+        mint_container_jwt("")
+    with pytest.raises(ValueError, match="tenant_id is required"):
+        mint_container_jwt("   ")
+
+
+def test_production_requires_explicit_secret(monkeypatch):
+    monkeypatch.delenv("CONTAINER_JWT_SECRET", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    with pytest.raises(RuntimeError, match="must be set in production"):
+        mint_container_jwt("tenant-abc")


### PR DESCRIPTION
## Summary

Closes Linear **KEI-164** (KEI-115C in the product-layer numbering): container JWT minter for the dispatcher product layer (KEI-110 / Part 17.5 KEI-115).

Per the Linear acceptance criteria (verbatim):
> JWT issued per container spawn; includes tenant_id + scope=['task:read', 'task:write']; signature verifies.

### Surface

```python
from src.dispatcher.container_jwt import mint_container_jwt, verify_container_jwt

token = mint_container_jwt("tenant-abc")           # default scopes + 1h expiry
claims = verify_container_jwt(token)                # → {'tenant_id': 'tenant-abc', 'scope': [...], 'iat': ..., 'exp': ...}
```

`mint_container_jwt(tenant_id, *, scopes=None, expires_in_seconds=3600) -> str`
`verify_container_jwt(token) -> dict` (raises `jwt.InvalidTokenError` and subclasses on failure)

### Secret + environment

- Reads `CONTAINER_JWT_SECRET` env var. Fail-fast `RuntimeError` if unset when `ENVIRONMENT=production`.
- Outside production, falls back to a dev sentinel with a logged warning. Mirrors `src.services.unsubscribe_token_service` pattern but isolated to the new `src.dispatcher` namespace so rotation surface stays scoped to product-layer consumers.

### Why a new namespace

`src.dispatcher` is the home for KEI-110 Part 17 product-layer modules (KEI-115 container lifecycle, KEI-164 JWT, KEI-165 governance proxy, KEI-166 LiteLLM router). First file in the namespace; `__init__.py` lists the planned siblings so the layout intent is documented in code, not just Linear.

## Test plan
- [x] `python3 -m pytest tests/dispatcher/test_container_jwt.py` → **10/10 pass in 0.10s**
- [x] `ruff check src/dispatcher/ tests/dispatcher/` clean
- [x] `ruff format --check src/dispatcher/ tests/dispatcher/` (4 files already formatted)
- [x] Local KEI-108 gate clean (no new `*.service` / `*.timer` / `src/api/webhooks/*.py` touched)
- [ ] Peer review

### Coverage (10 tests)
1. Three-part JWT string shape
2. tenant_id claim present
3. Default scopes are `['task:read', 'task:write']`
4. Custom scopes override defaults
5. `iat` + `exp` claims present and `exp > iat`
6. Wrong-secret verification → `InvalidSignatureError`
7. Tampered payload → `InvalidTokenError`
8. Expired token → `ExpiredSignatureError`
9. Blank tenant_id rejected (ValueError)
10. Production-requires-secret guard fires when env unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)