### PR TITLE
[ATLAS] feat(kei162): KEI-115A — container spawn + startup timeout + health check

### DIFF
--- a/src/dispatcher/__init__.py
+++ b/src/dispatcher/__init__.py
@@ -1,0 +1,3 @@
+"""Dispatcher product layer (Part 17) — container lifecycle, JWT minting,
+interceptor proxy. KEI-110 parent.
+"""

--- a/src/dispatcher/container_lifecycle.py
+++ b/src/dispatcher/container_lifecycle.py
@@ -61,8 +61,9 @@ class ContainerHandle:
 def _run_docker(
     args: list[str], timeout_s: float = DEFAULT_DOCKER_CMD_TIMEOUT_S
 ) -> subprocess.CompletedProcess:
+    # controlled args, no shell — S603 suppressed
     try:
-        return subprocess.run(  # noqa: S603 — controlled args, no shell
+        return subprocess.run(  # noqa: S603
             [DOCKER_CLI, *args],
             capture_output=True,
             text=True,

--- a/src/dispatcher/container_lifecycle.py
+++ b/src/dispatcher/container_lifecycle.py
@@ -1,0 +1,191 @@
+"""KEI-115A — Container spawn + startup timeout + health check.
+
+Foundational primitive for Part 17 dispatcher product layer. Wraps the
+local docker CLI via subprocess (one less dependency than docker-py;
+tracks vendor shape verbatim — see `empirical-smoke-catches-paper-review-3`).
+
+Caller responsibility: the container image must expose an HTTP health
+endpoint (default ``/healthz``) on the published port. ``wait_healthy``
+polls that endpoint and aborts cleanly via ``docker kill`` + ``docker
+rm -f`` if it doesn't respond 2xx within the startup timeout. KEI-163
+(KEI-115B) handles the longer-running lifecycle monitor; this module is
+spawn + wait + clean-abort only.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import http.client
+import logging
+import subprocess
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HEALTH_PATH = "/healthz"
+DEFAULT_STARTUP_TIMEOUT_S = 30.0
+DEFAULT_POLL_INTERVAL_S = 1.0
+DEFAULT_HEALTH_PROBE_TIMEOUT_S = 2.0
+DEFAULT_DOCKER_CMD_TIMEOUT_S = 30.0
+DEFAULT_DOCKER_TEARDOWN_TIMEOUT_S = 10.0
+DOCKER_CLI = "docker"
+
+
+class ContainerStartupError(RuntimeError):
+    """Container failed to start or become healthy within startup timeout.
+
+    On the wait_healthy timeout path, the container has already been
+    killed + removed before this is raised — caller does not need to
+    clean up.
+    """
+
+
+class DockerUnavailableError(RuntimeError):
+    """The docker CLI is not installed or not on PATH."""
+
+
+@dataclass(frozen=True)
+class ContainerHandle:
+    """Reference to a running container. Returned by `spawn_container`,
+    consumed by `wait_healthy` / `kill_and_remove` / future lifecycle ops.
+    """
+
+    id: str
+    name: str
+    image: str
+    port: int
+    health_path: str = DEFAULT_HEALTH_PATH
+
+
+def _run_docker(
+    args: list[str], timeout_s: float = DEFAULT_DOCKER_CMD_TIMEOUT_S
+) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(  # noqa: S603 — controlled args, no shell
+            [DOCKER_CLI, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise DockerUnavailableError(f"{DOCKER_CLI} CLI not found on PATH") from exc
+
+
+def spawn_container(
+    *,
+    image: str,
+    name: str,
+    port: int,
+    env: dict[str, str] | None = None,
+    health_path: str = DEFAULT_HEALTH_PATH,
+    extra_args: list[str] | None = None,
+) -> ContainerHandle:
+    """Start a detached container and return a handle.
+
+    Image-agnostic — caller passes ``image`` so the same primitive serves
+    the BYO-key Claude-side container and future per-tier containers.
+    Does NOT block on health; call ``wait_healthy(handle)`` next.
+
+    Raises:
+        DockerUnavailableError: docker CLI missing from PATH.
+        ContainerStartupError: ``docker run`` returned non-zero or empty id.
+    """
+    cmd: list[str] = ["run", "-d", "--name", name, "-p", f"{port}:{port}"]
+    for k, v in (env or {}).items():
+        cmd += ["-e", f"{k}={v}"]
+    if extra_args:
+        cmd += list(extra_args)
+    cmd.append(image)
+
+    out = _run_docker(cmd)
+    if out.returncode != 0:
+        raise ContainerStartupError(
+            f"docker run failed (rc={out.returncode}): {out.stderr.strip()[:300]}"
+        )
+    container_id = out.stdout.strip()
+    if not container_id:
+        raise ContainerStartupError("docker run returned empty container id")
+    return ContainerHandle(
+        id=container_id,
+        name=name,
+        image=image,
+        port=port,
+        health_path=health_path,
+    )
+
+
+def _probe_health(host: str, port: int, path: str) -> bool:
+    """Return True iff GET http://host:port<path> responds 2xx within
+    DEFAULT_HEALTH_PROBE_TIMEOUT_S. Any network/protocol error is False
+    (caller treats this as 'not yet ready' and retries until timeout).
+    """
+    conn = None
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=DEFAULT_HEALTH_PROBE_TIMEOUT_S)
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        ok = 200 <= resp.status < 300
+        resp.read()
+        return ok
+    except (OSError, http.client.HTTPException):
+        return False
+    finally:
+        if conn is not None:
+            with contextlib.suppress(OSError):
+                conn.close()
+
+
+def wait_healthy(
+    handle: ContainerHandle,
+    *,
+    timeout_s: float = DEFAULT_STARTUP_TIMEOUT_S,
+    interval_s: float = DEFAULT_POLL_INTERVAL_S,
+    host: str = "127.0.0.1",
+) -> bool:
+    """Poll the container's health endpoint until it returns 2xx or timeout.
+
+    On timeout: kill_and_remove the container, then raise
+    ContainerStartupError. The container is gone before the exception
+    surfaces — caller does not need to clean up.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if _probe_health(host, handle.port, handle.health_path):
+            logger.info(
+                "container %s healthy on %s:%d%s",
+                handle.id[:12],
+                host,
+                handle.port,
+                handle.health_path,
+            )
+            return True
+        time.sleep(interval_s)
+
+    logger.warning(
+        "container %s failed health check within %.1fs — aborting",
+        handle.id[:12],
+        timeout_s,
+    )
+    kill_and_remove(handle)
+    raise ContainerStartupError(
+        f"container {handle.id[:12]} ({handle.image}) failed health check within {timeout_s:.1f}s"
+    )
+
+
+def kill_and_remove(handle: ContainerHandle) -> None:
+    """Best-effort stop + remove. Logs but does not raise on docker
+    errors — the abort path must not mask the original failure for
+    callers using this from `wait_healthy`'s timeout branch.
+    """
+    for op in (["kill", handle.id], ["rm", "-f", handle.id]):
+        result = _run_docker(op, timeout_s=DEFAULT_DOCKER_TEARDOWN_TIMEOUT_S)
+        if result.returncode != 0:
+            logger.warning(
+                "docker %s %s failed (rc=%d): %s",
+                op[0],
+                handle.id[:12],
+                result.returncode,
+                result.stderr.strip()[:200],
+            )

--- a/tests/dispatcher/test_container_lifecycle.py
+++ b/tests/dispatcher/test_container_lifecycle.py
@@ -1,0 +1,267 @@
+"""KEI-115A — tests for src/dispatcher/container_lifecycle.
+
+All docker CLI calls are mocked at the subprocess.run boundary; no live
+docker daemon required for CI. Health probes are stubbed at the
+_probe_health helper boundary so tests don't open real sockets.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from src.dispatcher.container_lifecycle import (
+    ContainerHandle,
+    ContainerStartupError,
+    DockerUnavailableError,
+    kill_and_remove,
+    spawn_container,
+    wait_healthy,
+)
+
+
+def _docker_ok(stdout: str = "abc123\n", stderr: str = "", returncode: int = 0):
+    """Build a fake subprocess.run return value."""
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def _handle(**overrides) -> ContainerHandle:
+    defaults = {"id": "abc123def456", "name": "task-1", "image": "img:latest", "port": 8080}
+    defaults.update(overrides)
+    return ContainerHandle(**defaults)
+
+
+# ─── spawn_container ───────────────────────────────────────────────────────
+
+
+def test_spawn_container_runs_docker_with_expected_args(monkeypatch):
+    """Verify the docker CLI invocation shape: `docker run -d --name <n>
+    -p <port>:<port> <image>`."""
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return _docker_ok(stdout="abc123def456\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    h = spawn_container(image="python:3.12-slim", name="task-1", port=8080)
+    assert h.id == "abc123def456"
+    assert h.name == "task-1"
+    assert h.image == "python:3.12-slim"
+    assert h.port == 8080
+    assert h.health_path == "/healthz"
+    cmd = captured["cmd"]
+    assert cmd[:6] == ["docker", "run", "-d", "--name", "task-1", "-p"]
+    assert "8080:8080" in cmd
+    assert cmd[-1] == "python:3.12-slim"
+
+
+def test_spawn_container_passes_env_vars(monkeypatch):
+    """Each env entry becomes a separate `-e K=V` pair in argv order."""
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return _docker_ok()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    spawn_container(image="img", name="n", port=1, env={"FOO": "bar", "BAZ": "qux"})
+    cmd = captured["cmd"]
+    # -e flag appears for each entry
+    e_indices = [i for i, tok in enumerate(cmd) if tok == "-e"]
+    assert len(e_indices) == 2
+    e_values = {cmd[i + 1] for i in e_indices}
+    assert e_values == {"FOO=bar", "BAZ=qux"}
+
+
+def test_spawn_container_appends_extra_args(monkeypatch):
+    """extra_args are inserted before the image name (after env)."""
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return _docker_ok()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    spawn_container(
+        image="img",
+        name="n",
+        port=1,
+        extra_args=["--read-only", "--memory=512m"],
+    )
+    cmd = captured["cmd"]
+    assert "--read-only" in cmd
+    assert "--memory=512m" in cmd
+    # image is the last token
+    assert cmd[-1] == "img"
+    # extras appear before the image
+    assert cmd.index("--read-only") < cmd.index("img")
+
+
+def test_spawn_container_raises_clean_error_when_docker_missing(monkeypatch):
+    """FileNotFoundError from subprocess maps to DockerUnavailableError."""
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory: 'docker'")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(DockerUnavailableError, match="docker"):
+        spawn_container(image="img", name="n", port=1)
+
+
+def test_spawn_container_raises_on_nonzero_rc(monkeypatch):
+    """Non-zero docker run exit (e.g. port-in-use rc=125) raises
+    ContainerStartupError with the stderr preserved."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **kw: _docker_ok(stdout="", stderr="port already in use", returncode=125),
+    )
+    with pytest.raises(ContainerStartupError, match="rc=125") as exc_info:
+        spawn_container(image="img", name="n", port=1)
+    assert "port already in use" in str(exc_info.value)
+
+
+def test_spawn_container_raises_on_empty_stdout(monkeypatch):
+    """rc=0 but no container id is still a failure — defensive."""
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _docker_ok(stdout="   \n"))
+    with pytest.raises(ContainerStartupError, match="empty container id"):
+        spawn_container(image="img", name="n", port=1)
+
+
+# ─── wait_healthy ──────────────────────────────────────────────────────────
+
+
+def test_wait_healthy_returns_true_on_first_probe(monkeypatch):
+    """Healthy on the first probe — no retries, no kill."""
+    monkeypatch.setattr(
+        "src.dispatcher.container_lifecycle._probe_health",
+        lambda host, port, path: True,
+    )
+    # If wait_healthy called docker, the test would fail because no fake_run
+    # is wired here — confirms healthy path doesn't touch docker.
+    assert wait_healthy(_handle(), timeout_s=5.0, interval_s=0.01) is True
+
+
+def test_wait_healthy_returns_true_after_retries(monkeypatch):
+    """Probe returns False twice then True — wait_healthy retries through
+    the failures and reports healthy on the third probe."""
+    counter = {"n": 0}
+
+    def probe(host, port, path):
+        counter["n"] += 1
+        return counter["n"] >= 3
+
+    monkeypatch.setattr("src.dispatcher.container_lifecycle._probe_health", probe)
+    assert wait_healthy(_handle(), timeout_s=5.0, interval_s=0.01) is True
+    assert counter["n"] >= 3
+
+
+def test_wait_healthy_aborts_and_kills_on_timeout(monkeypatch):
+    """Health probe never succeeds — wait_healthy must:
+    1. raise ContainerStartupError
+    2. call `docker kill` + `docker rm -f` BEFORE raising."""
+    kill_cmds: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "src.dispatcher.container_lifecycle._probe_health",
+        lambda *args, **kwargs: False,
+    )
+
+    def fake_run(cmd, **kwargs):
+        kill_cmds.append(list(cmd))
+        return _docker_ok()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(ContainerStartupError, match="failed health check"):
+        wait_healthy(_handle(), timeout_s=0.05, interval_s=0.01)
+    ops = [cmd[1] for cmd in kill_cmds]
+    assert "kill" in ops
+    assert "rm" in ops
+    # rm runs after kill
+    assert ops.index("kill") < ops.index("rm")
+
+
+def test_wait_healthy_respects_custom_host(monkeypatch):
+    """Non-default host is passed through to _probe_health."""
+    captured: dict = {}
+
+    def probe(host, port, path):
+        captured["host"] = host
+        captured["port"] = port
+        captured["path"] = path
+        return True
+
+    monkeypatch.setattr("src.dispatcher.container_lifecycle._probe_health", probe)
+    assert wait_healthy(_handle(port=9000), timeout_s=1.0, interval_s=0.01, host="10.0.0.5")
+    assert captured == {"host": "10.0.0.5", "port": 9000, "path": "/healthz"}
+
+
+def test_wait_healthy_uses_handle_health_path(monkeypatch):
+    """Custom health_path on the handle is honoured by the probe."""
+    captured: dict = {}
+
+    def probe(host, port, path):
+        captured["path"] = path
+        return True
+
+    monkeypatch.setattr("src.dispatcher.container_lifecycle._probe_health", probe)
+    wait_healthy(_handle(), timeout_s=1.0, interval_s=0.01)
+    # default
+    assert captured["path"] == "/healthz"
+
+    captured.clear()
+    custom = ContainerHandle(id="x", name="y", image="z", port=1, health_path="/api/health")
+    wait_healthy(custom, timeout_s=1.0, interval_s=0.01)
+    assert captured["path"] == "/api/health"
+
+
+# ─── kill_and_remove ───────────────────────────────────────────────────────
+
+
+def test_kill_and_remove_runs_kill_then_rm(monkeypatch):
+    """Two docker invocations in order: kill then rm -f."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _docker_ok()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    kill_and_remove(_handle())
+    assert len(calls) == 2
+    assert calls[0][1] == "kill"
+    assert calls[1][1:3] == ["rm", "-f"]
+    # both target the container id
+    assert calls[0][-1] == "abc123def456"
+    assert calls[1][-1] == "abc123def456"
+
+
+def test_kill_and_remove_logs_but_does_not_raise_on_docker_error(monkeypatch, caplog):
+    """Stale containers, already-removed containers etc. produce non-zero
+    rcs. kill_and_remove must NOT raise — it's an abort path that runs
+    inside wait_healthy's exception branch and must not mask the
+    original ContainerStartupError."""
+
+    def fake_run(cmd, **kwargs):
+        return _docker_ok(returncode=1, stderr=f"Error: No such container: {cmd[-1]}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with caplog.at_level("WARNING"):
+        kill_and_remove(_handle())
+    assert any("No such container" in r.message for r in caplog.records)
+
+
+def test_kill_and_remove_propagates_docker_unavailable(monkeypatch):
+    """If docker disappears between spawn and teardown (impossible but
+    defensive), DockerUnavailableError must surface — not be swallowed —
+    so the operator sees the environment is broken."""
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("docker")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(DockerUnavailableError):
+        kill_and_remove(_handle())

--- a/tests/dispatcher/test_container_lifecycle.py
+++ b/tests/dispatcher/test_container_lifecycle.py
@@ -195,8 +195,8 @@ def test_wait_healthy_respects_custom_host(monkeypatch):
         return True
 
     monkeypatch.setattr("src.dispatcher.container_lifecycle._probe_health", probe)
-    assert wait_healthy(_handle(port=9000), timeout_s=1.0, interval_s=0.01, host="10.0.0.5")
-    assert captured == {"host": "10.0.0.5", "port": 9000, "path": "/healthz"}
+    assert wait_healthy(_handle(port=9000), timeout_s=1.0, interval_s=0.01, host="container-host")
+    assert captured == {"host": "container-host", "port": 9000, "path": "/healthz"}
 
 
 def test_wait_healthy_uses_handle_health_path(monkeypatch):


### PR DESCRIPTION
## Summary

Closes KEI-162 (KEI-115A). Foundational primitive for Part 17 dispatcher product layer (KEI-110): a Python wrapper around the local docker CLI that spawns a detached container, polls its HTTP health endpoint, returns the container ID once healthy, and aborts cleanly via `docker kill` + `docker rm -f` if the health check doesn't pass within 30s.

Wraps `docker` via `subprocess.run` rather than docker-py — one less dependency and tracks vendor shape verbatim (per `empirical-smoke-catches-paper-review-3`).

## Acceptance (Linear KEI-162)

- [x] spawn returns container ID → `ContainerHandle.id`
- [x] health check passes within 30s → `DEFAULT_STARTUP_TIMEOUT_S = 30.0`
- [x] timeout aborts cleanly → `kill_and_remove(handle)` runs before `ContainerStartupError` raises

## API

```python
from src.dispatcher.container_lifecycle import spawn_container, wait_healthy

h = spawn_container(image=\"task-runner:latest\", name=\"task-1\", port=8080,
                    env={\"TASK_ID\": \"KEI-162\"})
wait_healthy(h, timeout_s=30.0)  # raises ContainerStartupError on timeout
```

`ContainerHandle` is a frozen dataclass. Caller is responsible for the image exposing an HTTP `/healthz` (configurable) on the published port.

## Scope boundary

In:
- `spawn_container`, `wait_healthy`, `kill_and_remove`
- `ContainerHandle`, `ContainerStartupError`, `DockerUnavailableError`

Out (separate KEIs):
- KEI-163 / KEI-115B — long-running lifecycle monitor + reap
- KEI-164 / KEI-115C — JWT minting
- KEI-166 — LiteLLM router integration

## Test plan

- [x] `pytest tests/dispatcher/test_container_lifecycle.py` — 14/14 passed.
  - spawn argv shape (`docker run -d --name <n> -p <port>:<port> <image>`)
  - env vars → `-e K=V`
  - extra_args inserted before image
  - missing docker → `DockerUnavailableError`
  - `docker run` rc=125 → `ContainerStartupError` with stderr preserved
  - rc=0 + empty stdout → defensive `ContainerStartupError`
  - `wait_healthy` first-probe success (no docker calls)
  - `wait_healthy` retries through failures then succeeds
  - `wait_healthy` timeout → `kill` then `rm -f` then `ContainerStartupError`
  - custom host + custom `health_path` plumb through
  - `kill_and_remove` order (kill before rm)
  - `kill_and_remove` logs but does NOT raise on docker error (abort-path safety)
  - `kill_and_remove` does propagate `DockerUnavailableError` (environment broken)
- [x] `ruff check src/dispatcher tests/dispatcher` — All checks passed.
- [x] `ruff format --check src/dispatcher tests/dispatcher` — 4 files already formatted.

No live docker daemon required for CI — all docker CLI calls mocked at the `subprocess.run` boundary; health probes mocked at the `_probe_health` helper boundary. A live-daemon smoke test against a real `python:3.12-slim` image is appropriately scoped to KEI-163 (which actually owns a long-running container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)