### PR TITLE
[MAX] feat(kei163): KEI-115B — container lifecycle monitor

### DIFF
--- a/src/dispatcher/container_lifecycle.py
+++ b/src/dispatcher/container_lifecycle.py
@@ -62,7 +62,8 @@ def _run_docker(
     args: list[str], timeout_s: float = DEFAULT_DOCKER_CMD_TIMEOUT_S
 ) -> subprocess.CompletedProcess:
     try:
-        return subprocess.run(  # noqa: S603 — controlled args, no shell
+        # controlled args, no shell injection risk
+        return subprocess.run(  # noqa: S603
             [DOCKER_CLI, *args],
             capture_output=True,
             text=True,

--- a/src/dispatcher/container_lifecycle.py
+++ b/src/dispatcher/container_lifecycle.py
@@ -1,0 +1,191 @@
+"""KEI-115A — Container spawn + startup timeout + health check.
+
+Foundational primitive for Part 17 dispatcher product layer. Wraps the
+local docker CLI via subprocess (one less dependency than docker-py;
+tracks vendor shape verbatim — see `empirical-smoke-catches-paper-review-3`).
+
+Caller responsibility: the container image must expose an HTTP health
+endpoint (default ``/healthz``) on the published port. ``wait_healthy``
+polls that endpoint and aborts cleanly via ``docker kill`` + ``docker
+rm -f`` if it doesn't respond 2xx within the startup timeout. KEI-163
+(KEI-115B) handles the longer-running lifecycle monitor; this module is
+spawn + wait + clean-abort only.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import http.client
+import logging
+import subprocess
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HEALTH_PATH = "/healthz"
+DEFAULT_STARTUP_TIMEOUT_S = 30.0
+DEFAULT_POLL_INTERVAL_S = 1.0
+DEFAULT_HEALTH_PROBE_TIMEOUT_S = 2.0
+DEFAULT_DOCKER_CMD_TIMEOUT_S = 30.0
+DEFAULT_DOCKER_TEARDOWN_TIMEOUT_S = 10.0
+DOCKER_CLI = "docker"
+
+
+class ContainerStartupError(RuntimeError):
+    """Container failed to start or become healthy within startup timeout.
+
+    On the wait_healthy timeout path, the container has already been
+    killed + removed before this is raised — caller does not need to
+    clean up.
+    """
+
+
+class DockerUnavailableError(RuntimeError):
+    """The docker CLI is not installed or not on PATH."""
+
+
+@dataclass(frozen=True)
+class ContainerHandle:
+    """Reference to a running container. Returned by `spawn_container`,
+    consumed by `wait_healthy` / `kill_and_remove` / future lifecycle ops.
+    """
+
+    id: str
+    name: str
+    image: str
+    port: int
+    health_path: str = DEFAULT_HEALTH_PATH
+
+
+def _run_docker(
+    args: list[str], timeout_s: float = DEFAULT_DOCKER_CMD_TIMEOUT_S
+) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(  # noqa: S603 — controlled args, no shell
+            [DOCKER_CLI, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise DockerUnavailableError(f"{DOCKER_CLI} CLI not found on PATH") from exc
+
+
+def spawn_container(
+    *,
+    image: str,
+    name: str,
+    port: int,
+    env: dict[str, str] | None = None,
+    health_path: str = DEFAULT_HEALTH_PATH,
+    extra_args: list[str] | None = None,
+) -> ContainerHandle:
+    """Start a detached container and return a handle.
+
+    Image-agnostic — caller passes ``image`` so the same primitive serves
+    the BYO-key Claude-side container and future per-tier containers.
+    Does NOT block on health; call ``wait_healthy(handle)`` next.
+
+    Raises:
+        DockerUnavailableError: docker CLI missing from PATH.
+        ContainerStartupError: ``docker run`` returned non-zero or empty id.
+    """
+    cmd: list[str] = ["run", "-d", "--name", name, "-p", f"{port}:{port}"]
+    for k, v in (env or {}).items():
+        cmd += ["-e", f"{k}={v}"]
+    if extra_args:
+        cmd += list(extra_args)
+    cmd.append(image)
+
+    out = _run_docker(cmd)
+    if out.returncode != 0:
+        raise ContainerStartupError(
+            f"docker run failed (rc={out.returncode}): {out.stderr.strip()[:300]}"
+        )
+    container_id = out.stdout.strip()
+    if not container_id:
+        raise ContainerStartupError("docker run returned empty container id")
+    return ContainerHandle(
+        id=container_id,
+        name=name,
+        image=image,
+        port=port,
+        health_path=health_path,
+    )
+
+
+def _probe_health(host: str, port: int, path: str) -> bool:
+    """Return True iff GET http://host:port<path> responds 2xx within
+    DEFAULT_HEALTH_PROBE_TIMEOUT_S. Any network/protocol error is False
+    (caller treats this as 'not yet ready' and retries until timeout).
+    """
+    conn = None
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=DEFAULT_HEALTH_PROBE_TIMEOUT_S)
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        ok = 200 <= resp.status < 300
+        resp.read()
+        return ok
+    except (OSError, http.client.HTTPException):
+        return False
+    finally:
+        if conn is not None:
+            with contextlib.suppress(OSError):
+                conn.close()
+
+
+def wait_healthy(
+    handle: ContainerHandle,
+    *,
+    timeout_s: float = DEFAULT_STARTUP_TIMEOUT_S,
+    interval_s: float = DEFAULT_POLL_INTERVAL_S,
+    host: str = "127.0.0.1",
+) -> bool:
+    """Poll the container's health endpoint until it returns 2xx or timeout.
+
+    On timeout: kill_and_remove the container, then raise
+    ContainerStartupError. The container is gone before the exception
+    surfaces — caller does not need to clean up.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if _probe_health(host, handle.port, handle.health_path):
+            logger.info(
+                "container %s healthy on %s:%d%s",
+                handle.id[:12],
+                host,
+                handle.port,
+                handle.health_path,
+            )
+            return True
+        time.sleep(interval_s)
+
+    logger.warning(
+        "container %s failed health check within %.1fs — aborting",
+        handle.id[:12],
+        timeout_s,
+    )
+    kill_and_remove(handle)
+    raise ContainerStartupError(
+        f"container {handle.id[:12]} ({handle.image}) failed health check within {timeout_s:.1f}s"
+    )
+
+
+def kill_and_remove(handle: ContainerHandle) -> None:
+    """Best-effort stop + remove. Logs but does not raise on docker
+    errors — the abort path must not mask the original failure for
+    callers using this from `wait_healthy`'s timeout branch.
+    """
+    for op in (["kill", handle.id], ["rm", "-f", handle.id]):
+        result = _run_docker(op, timeout_s=DEFAULT_DOCKER_TEARDOWN_TIMEOUT_S)
+        if result.returncode != 0:
+            logger.warning(
+                "docker %s %s failed (rc=%d): %s",
+                op[0],
+                handle.id[:12],
+                result.returncode,
+                result.stderr.strip()[:200],
+            )

--- a/src/dispatcher/container_monitor.py
+++ b/src/dispatcher/container_monitor.py
@@ -1,0 +1,210 @@
+"""KEI-163 — container lifecycle monitor: status poll + reap on exit.
+
+Long-running companion to spawn_container/wait_healthy (KEI-115A). Polls
+`docker inspect` on a configurable cadence; when state transitions to
+'exited', persists the final state to public.tasks (container_exit_code +
+container_ended_at) and best-effort reaps the container via kill_and_remove.
+
+Acceptance (Linear KEI-163): monitor detects exit within 5s; reaps
+container; logs final state to tasks table.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from src.dispatcher.container_lifecycle import (
+    ContainerHandle,
+    DockerUnavailableError,
+    kill_and_remove,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_POLL_INTERVAL_S: float = 2.0  # 2s ≤ 5s acceptance budget
+DEFAULT_INSPECT_TIMEOUT_S: float = 5.0
+DOCKER_CLI = "docker"
+
+_SOURCE_DOC = "KEI-163"
+
+
+@dataclass(frozen=True)
+class MonitorResult:
+    status: str  # 'exited' or 'timeout'
+    exit_code: int | None
+    ended_at: dt.datetime | None
+
+
+def _inspect_state(handle: ContainerHandle) -> tuple[str, int | None]:
+    """Return ('running'|'exited'|'unknown', exit_code_or_None).
+
+    Calls ``docker inspect --format '{{.State.Status}} {{.State.ExitCode}}'``.
+    Non-zero return code or FileNotFoundError → ('unknown', None).
+    DockerUnavailableError is re-raised so the caller can surface it.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603
+            [
+                DOCKER_CLI,
+                "inspect",
+                "--format",
+                "{{.State.Status}} {{.State.ExitCode}}",
+                handle.id,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_INSPECT_TIMEOUT_S,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise DockerUnavailableError(f"{DOCKER_CLI} CLI not found on PATH") from exc
+
+    if result.returncode != 0:
+        logger.debug(
+            "%s inspect rc=%d stderr=%s",
+            _SOURCE_DOC,
+            result.returncode,
+            result.stderr.strip()[:200],
+        )
+        return ("unknown", None)
+
+    raw = result.stdout.strip()
+    parts = raw.split(maxsplit=1)
+    if not parts:
+        return ("unknown", None)
+
+    status = parts[0].lower()
+    exit_code: int | None = None
+    if len(parts) == 2:
+        with __import__("contextlib").suppress(ValueError):
+            exit_code = int(parts[1])
+
+    return (status, exit_code)
+
+
+def _default_persist(task_id: str, result: MonitorResult) -> None:
+    """UPDATE public.tasks SET container_exit_code, container_ended_at WHERE id.
+
+    psycopg.Error is caught and logged — monitor reports the result
+    regardless of DB write success (fail-open by spec).
+    """
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        logger.warning(
+            "%s DATABASE_URL not set — skipping task persist for %s", _SOURCE_DOC, task_id
+        )
+        return
+
+    try:
+        import psycopg  # type: ignore[import]
+
+        with psycopg.connect(dsn, prepare_threshold=None) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE public.tasks
+                   SET container_exit_code = %s,
+                       container_ended_at  = %s
+                 WHERE id = %s
+                """,
+                (result.exit_code, result.ended_at, task_id),
+            )
+        logger.info(
+            "%s persisted exit_code=%s ended_at=%s for task %s",
+            _SOURCE_DOC,
+            result.exit_code,
+            result.ended_at,
+            task_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "%s persist failed for task %s: %s",
+            _SOURCE_DOC,
+            task_id,
+            exc,
+        )
+
+
+def monitor_container(
+    handle: ContainerHandle,
+    *,
+    task_id: str,
+    poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+    overall_timeout_s: float | None = None,
+    persist_fn: Callable[[str, MonitorResult], None] | None = None,
+    reap_fn: Callable[[ContainerHandle], None] | None = None,
+) -> MonitorResult:
+    """Block until the container exits, then reap + persist + return.
+
+    Returns MonitorResult(status='exited', exit_code=N, ended_at=now) when
+    inspect reports exited. Returns MonitorResult(status='timeout', ...)
+    if overall_timeout_s is set and elapsed before exit detected.
+
+    On exit: calls reap_fn(handle) (default = kill_and_remove) and
+    persist_fn(task_id, result) (default = _default_persist).
+    Persistence failures are logged not raised — caller still gets the
+    MonitorResult.
+
+    Raises:
+        DockerUnavailableError: if the docker CLI is absent (propagated from
+            _inspect_state on the very first poll).
+        ValueError: if poll_interval_s > 5.0 (enforcement of acceptance budget).
+    """
+    if poll_interval_s > 5.0:
+        raise ValueError(
+            f"poll_interval_s={poll_interval_s} exceeds 5s acceptance budget (KEI-163)"
+        )
+
+    _persist = persist_fn if persist_fn is not None else _default_persist
+    _reap = reap_fn if reap_fn is not None else kill_and_remove
+
+    start = time.monotonic()
+    deadline = (start + overall_timeout_s) if overall_timeout_s is not None else None
+
+    while True:
+        status, exit_code = _inspect_state(handle)
+
+        if status == "exited":
+            ended_at = dt.datetime.now(tz=dt.UTC)
+            result = MonitorResult(status="exited", exit_code=exit_code, ended_at=ended_at)
+            logger.info(
+                "%s container %s exited (code=%s) after %.1fs",
+                _SOURCE_DOC,
+                handle.id[:12],
+                exit_code,
+                time.monotonic() - start,
+            )
+            try:
+                _reap(handle)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("%s reap failed for %s: %s", _SOURCE_DOC, handle.id[:12], exc)
+
+            try:
+                _persist(task_id, result)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("%s persist_fn raised for task %s: %s", _SOURCE_DOC, task_id, exc)
+
+            return result
+
+        if deadline is not None and time.monotonic() >= deadline:
+            result = MonitorResult(status="timeout", exit_code=None, ended_at=None)
+            logger.warning(
+                "%s monitor timed out after %.1fs for container %s",
+                _SOURCE_DOC,
+                overall_timeout_s,
+                handle.id[:12],
+            )
+            try:
+                _persist(task_id, result)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "%s persist_fn raised on timeout for task %s: %s", _SOURCE_DOC, task_id, exc
+                )
+            return result
+
+        time.sleep(poll_interval_s)

--- a/src/dispatcher/container_monitor.py
+++ b/src/dispatcher/container_monitor.py
@@ -121,13 +121,62 @@ def _default_persist(task_id: str, result: MonitorResult) -> None:
             result.ended_at,
             task_id,
         )
-    except Exception as exc:  # noqa: BLE001
-        logger.error(
-            "%s persist failed for task %s: %s",
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "%s persist failed for task %s",
             _SOURCE_DOC,
             task_id,
-            exc,
         )
+
+
+def _one_poll(
+    handle: ContainerHandle,
+    *,
+    task_id: str,
+    start: float,
+    deadline: float | None,
+    persist_fn: Callable[[str, MonitorResult], None],
+    reap_fn: Callable[[ContainerHandle], None],
+    overall_timeout_s: float | None,
+) -> MonitorResult | None:
+    """Execute one inspect/timeout cycle; return MonitorResult on terminal state, None to continue."""
+    status, exit_code = _inspect_state(handle)
+
+    if status == "exited":
+        ended_at = dt.datetime.now(tz=dt.UTC)
+        result = MonitorResult(status="exited", exit_code=exit_code, ended_at=ended_at)
+        logger.info(
+            "%s container %s exited (code=%s) after %.1fs",
+            _SOURCE_DOC,
+            handle.id[:12],
+            exit_code,
+            time.monotonic() - start,
+        )
+        try:
+            reap_fn(handle)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("%s reap failed for %s: %s", _SOURCE_DOC, handle.id[:12], exc)
+        try:
+            persist_fn(task_id, result)
+        except Exception:  # noqa: BLE001
+            logger.exception("%s persist_fn raised for task %s", _SOURCE_DOC, task_id)
+        return result
+
+    if deadline is not None and time.monotonic() >= deadline:
+        result = MonitorResult(status="timeout", exit_code=None, ended_at=None)
+        logger.warning(
+            "%s monitor timed out after %.1fs for container %s",
+            _SOURCE_DOC,
+            overall_timeout_s,
+            handle.id[:12],
+        )
+        try:
+            persist_fn(task_id, result)
+        except Exception:  # noqa: BLE001
+            logger.exception("%s persist_fn raised on timeout for task %s", _SOURCE_DOC, task_id)
+        return result
+
+    return None
 
 
 def monitor_container(
@@ -167,44 +216,15 @@ def monitor_container(
     deadline = (start + overall_timeout_s) if overall_timeout_s is not None else None
 
     while True:
-        status, exit_code = _inspect_state(handle)
-
-        if status == "exited":
-            ended_at = dt.datetime.now(tz=dt.UTC)
-            result = MonitorResult(status="exited", exit_code=exit_code, ended_at=ended_at)
-            logger.info(
-                "%s container %s exited (code=%s) after %.1fs",
-                _SOURCE_DOC,
-                handle.id[:12],
-                exit_code,
-                time.monotonic() - start,
-            )
-            try:
-                _reap(handle)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("%s reap failed for %s: %s", _SOURCE_DOC, handle.id[:12], exc)
-
-            try:
-                _persist(task_id, result)
-            except Exception as exc:  # noqa: BLE001
-                logger.error("%s persist_fn raised for task %s: %s", _SOURCE_DOC, task_id, exc)
-
+        result = _one_poll(
+            handle,
+            task_id=task_id,
+            start=start,
+            deadline=deadline,
+            persist_fn=_persist,
+            reap_fn=_reap,
+            overall_timeout_s=overall_timeout_s,
+        )
+        if result is not None:
             return result
-
-        if deadline is not None and time.monotonic() >= deadline:
-            result = MonitorResult(status="timeout", exit_code=None, ended_at=None)
-            logger.warning(
-                "%s monitor timed out after %.1fs for container %s",
-                _SOURCE_DOC,
-                overall_timeout_s,
-                handle.id[:12],
-            )
-            try:
-                _persist(task_id, result)
-            except Exception as exc:  # noqa: BLE001
-                logger.error(
-                    "%s persist_fn raised on timeout for task %s: %s", _SOURCE_DOC, task_id, exc
-                )
-            return result
-
         time.sleep(poll_interval_s)

--- a/supabase/migrations/20260517_kei163_container_run_columns.sql
+++ b/supabase/migrations/20260517_kei163_container_run_columns.sql
@@ -1,0 +1,10 @@
+-- KEI-163: container lifecycle monitor — final state columns on public.tasks
+-- Apply before exercising the column-persist path in any environment.
+ALTER TABLE public.tasks
+  ADD COLUMN IF NOT EXISTS container_exit_code INT,
+  ADD COLUMN IF NOT EXISTS container_ended_at  TIMESTAMPTZ;
+
+COMMENT ON COLUMN public.tasks.container_exit_code IS
+  'KEI-163: final exit code from the dispatcher-spawned container. NULL while still running or never spawned.';
+COMMENT ON COLUMN public.tasks.container_ended_at IS
+  'KEI-163: timestamp the container exit was observed by the monitor. NULL while running.';

--- a/tests/dispatcher/test_container_monitor.py
+++ b/tests/dispatcher/test_container_monitor.py
@@ -1,0 +1,261 @@
+"""Tests for KEI-163 container_monitor module.
+
+All docker interactions are mocked at the subprocess.run boundary so no live
+docker daemon is required.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.dispatcher.container_lifecycle import ContainerHandle, DockerUnavailableError
+from src.dispatcher.container_monitor import (
+    DEFAULT_POLL_INTERVAL_S,
+    MonitorResult,
+    _inspect_state,
+    monitor_container,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+HANDLE = ContainerHandle(
+    id="abc123def456",
+    name="test-container",
+    image="test-image:latest",
+    port=8080,
+)
+
+TASK_ID = "task-uuid-1234"
+
+
+def _make_completed_proc(stdout: str, returncode: int = 0) -> MagicMock:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = ""
+    proc.returncode = returncode
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# _inspect_state unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestInspectState:
+    def test_running_status_returns_running(self) -> None:
+        proc = _make_completed_proc("running 0\n")
+        with patch("subprocess.run", return_value=proc) as mock_run:
+            status, code = _inspect_state(HANDLE)
+        assert status == "running"
+        assert code == 0
+        mock_run.assert_called_once()
+
+    def test_exited_137_parsed_correctly(self) -> None:
+        proc = _make_completed_proc("exited 137\n")
+        with patch("subprocess.run", return_value=proc):
+            status, code = _inspect_state(HANDLE)
+        assert status == "exited"
+        assert code == 137
+
+    def test_nonzero_rc_returns_unknown(self) -> None:
+        proc = _make_completed_proc("", returncode=1)
+        with patch("subprocess.run", return_value=proc):
+            status, code = _inspect_state(HANDLE)
+        assert status == "unknown"
+        assert code is None
+
+    def test_file_not_found_raises_docker_unavailable(self) -> None:
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError("docker not found")),
+            pytest.raises(DockerUnavailableError),
+        ):
+            _inspect_state(HANDLE)
+
+    def test_exited_zero_code(self) -> None:
+        proc = _make_completed_proc("exited 0\n")
+        with patch("subprocess.run", return_value=proc):
+            status, code = _inspect_state(HANDLE)
+        assert status == "exited"
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# monitor_container integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorContainer:
+    def test_detect_exit_calls_reap_and_persist(self) -> None:
+        """Monitor detects 'exited 0' on first poll, calls reap + persist."""
+        inspect_proc = _make_completed_proc("exited 0\n")
+        reap_fn = MagicMock()
+        persist_fn = MagicMock()
+
+        with patch("subprocess.run", return_value=inspect_proc):
+            result = monitor_container(
+                HANDLE,
+                task_id=TASK_ID,
+                poll_interval_s=0.01,
+                reap_fn=reap_fn,
+                persist_fn=persist_fn,
+            )
+
+        assert result.status == "exited"
+        assert result.exit_code == 0
+        assert isinstance(result.ended_at, datetime)
+        reap_fn.assert_called_once_with(HANDLE)
+        persist_fn.assert_called_once()
+
+    def test_persist_called_with_task_id_and_result(self) -> None:
+        """persist_fn receives (task_id, MonitorResult) with correct values."""
+        inspect_proc = _make_completed_proc("exited 137\n")
+        persist_fn = MagicMock()
+
+        with patch("subprocess.run", return_value=inspect_proc):
+            result = monitor_container(
+                HANDLE,
+                task_id=TASK_ID,
+                poll_interval_s=0.01,
+                reap_fn=MagicMock(),
+                persist_fn=persist_fn,
+            )
+
+        persist_fn.assert_called_once_with(TASK_ID, result)
+        assert result.exit_code == 137
+
+    def test_monitor_loops_until_exit(self) -> None:
+        """Monitor polls 'running' multiple times before detecting 'exited'."""
+        running_proc = _make_completed_proc("running 0\n")
+        exited_proc = _make_completed_proc("exited 0\n")
+        side_effects = [running_proc, running_proc, exited_proc]
+
+        reap_fn = MagicMock()
+        persist_fn = MagicMock()
+
+        with patch("subprocess.run", side_effect=side_effects):
+            result = monitor_container(
+                HANDLE,
+                task_id=TASK_ID,
+                poll_interval_s=0.01,
+                reap_fn=reap_fn,
+                persist_fn=persist_fn,
+            )
+
+        assert result.status == "exited"
+        reap_fn.assert_called_once_with(HANDLE)
+
+    def test_timeout_returns_timeout_status(self) -> None:
+        """overall_timeout_s exceeded → status='timeout', reap not called."""
+        running_proc = _make_completed_proc("running 0\n")
+        persist_fn = MagicMock()
+        reap_fn = MagicMock()
+
+        with patch("subprocess.run", return_value=running_proc):
+            result = monitor_container(
+                HANDLE,
+                task_id=TASK_ID,
+                poll_interval_s=0.01,
+                overall_timeout_s=0.05,
+                reap_fn=reap_fn,
+                persist_fn=persist_fn,
+            )
+
+        assert result.status == "timeout"
+        assert result.exit_code is None
+        assert result.ended_at is None
+        persist_fn.assert_called_once_with(TASK_ID, result)
+        reap_fn.assert_not_called()
+
+    def test_persist_error_logged_not_raised(self, caplog: pytest.LogCaptureFixture) -> None:
+        """persist_fn raising does not propagate — caller still gets MonitorResult."""
+        inspect_proc = _make_completed_proc("exited 1\n")
+
+        def bad_persist(task_id: str, result: MonitorResult) -> None:
+            raise RuntimeError("DB down")
+
+        with (
+            caplog.at_level(logging.ERROR, logger="src.dispatcher.container_monitor"),
+            patch("subprocess.run", return_value=inspect_proc),
+        ):
+            result = monitor_container(
+                HANDLE,
+                task_id=TASK_ID,
+                poll_interval_s=0.01,
+                reap_fn=MagicMock(),
+                persist_fn=bad_persist,
+            )
+
+        assert result.status == "exited"
+        assert any("persist_fn raised" in r.message for r in caplog.records)
+
+    def test_unknown_inspect_status_not_treated_as_exit(self) -> None:
+        """'unknown' status (non-zero rc) keeps looping, doesn't trigger reap."""
+        unknown_proc = _make_completed_proc("", returncode=1)
+        exited_proc = _make_completed_proc("exited 0\n")
+        side_effects = [unknown_proc, exited_proc]
+
+        reap_fn = MagicMock()
+        persist_fn = MagicMock()
+
+        with patch("subprocess.run", side_effect=side_effects):
+            result = monitor_container(
+                HANDLE,
+                task_id=TASK_ID,
+                poll_interval_s=0.01,
+                reap_fn=reap_fn,
+                persist_fn=persist_fn,
+            )
+
+        assert result.status == "exited"
+        reap_fn.assert_called_once()
+
+    def test_docker_unavailable_propagates(self) -> None:
+        """DockerUnavailableError from _inspect_state propagates to caller."""
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError("no docker")),
+            pytest.raises(DockerUnavailableError),
+        ):
+            monitor_container(
+                HANDLE,
+                task_id=TASK_ID,
+                poll_interval_s=0.01,
+                reap_fn=MagicMock(),
+                persist_fn=MagicMock(),
+            )
+
+    def test_poll_interval_over_5s_raises(self) -> None:
+        """poll_interval_s > 5.0 violates acceptance budget → ValueError."""
+        with pytest.raises(ValueError, match="5s acceptance budget"):
+            monitor_container(
+                HANDLE,
+                task_id=TASK_ID,
+                poll_interval_s=5.1,
+                reap_fn=MagicMock(),
+                persist_fn=MagicMock(),
+            )
+
+    def test_default_poll_interval_within_budget(self) -> None:
+        """DEFAULT_POLL_INTERVAL_S satisfies the ≤5s acceptance budget."""
+        assert DEFAULT_POLL_INTERVAL_S <= 5.0
+
+    def test_reap_fn_called_with_handle_on_exit(self) -> None:
+        """reap_fn receives the exact ContainerHandle that was passed in."""
+        inspect_proc = _make_completed_proc("exited 0\n")
+        reap_fn = MagicMock()
+
+        with patch("subprocess.run", return_value=inspect_proc):
+            monitor_container(
+                HANDLE,
+                task_id=TASK_ID,
+                poll_interval_s=0.01,
+                reap_fn=reap_fn,
+                persist_fn=MagicMock(),
+            )
+
+        reap_fn.assert_called_once_with(HANDLE)


### PR DESCRIPTION
## Summary

- Adds `src/dispatcher/container_monitor.py`: poll-loop that calls `docker inspect`, detects exit within the 5s acceptance budget (DEFAULT_POLL_INTERVAL_S=2.0s), reaps the container via `kill_and_remove`, and persists `container_exit_code` + `container_ended_at` to `public.tasks`
- Adds `tests/dispatcher/test_container_monitor.py`: 15 tests covering all acceptance criteria (all mock subprocess — no live docker required)
- Adds `supabase/migrations/20260517_kei163_container_run_columns.sql`: two new columns on `public.tasks`

## Acceptance criteria (Linear KEI-163)

- [x] Monitor detects exit within 5s — `DEFAULT_POLL_INTERVAL_S = 2.0` (enforced by `ValueError` on `poll_interval_s > 5.0`)
- [x] Reaps container — `kill_and_remove(handle)` called on exit detection
- [x] Logs final state to tasks table — `container_exit_code` + `container_ended_at` written via `_default_persist`

## Migration note

The column-persist path requires the migration to be applied first. Run via MCP `apply_migration` before exercising `_default_persist` in any non-local environment:

```
supabase/migrations/20260517_kei163_container_run_columns.sql
```

## Dep note

This branch includes `src/dispatcher/container_lifecycle.py` (KEI-115A, Atlas PR #952) because that PR was not yet merged to main at branch-cut time. On merge of PR #952, there will be a trivial conflict on that file — the incoming version from Atlas's branch is the canonical one and should be kept.

## Test plan

- [x] `python3 -m pytest tests/dispatcher/test_container_monitor.py -v` → 15 passed
- [x] `ruff check src/dispatcher/ tests/dispatcher/` → All checks passed
- [x] `ruff format --check src/dispatcher/ tests/dispatcher/` → 7 files already formatted
- [x] `BASE_REF=main bash <(git show origin/main:scripts/ci/check_operational_deployment.sh)` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)