### PR TITLE
[MAX] feat(kei165): KEI-115D — governance proxy stub

### DIFF
--- a/src/dispatcher/governance_proxy.py
+++ b/src/dispatcher/governance_proxy.py
@@ -1,0 +1,117 @@
+"""KEI-165 — governance model proxy: body-schema validation + N enumerated denials.
+
+Stub for the Part 17 product layer. Validates inbound request bodies against
+a minimal schema, then applies an enumerated deny-list derived from
+docs/governance/CONSOLIDATED_RULES.md (3 patterns for the stub; full rule-set
+is a later KEI). Denials are LOGGED at WARNING level with the reason code +
+tenant_id (no body payload — denial logs must not echo prompt contents).
+
+Acceptance (Linear KEI-165): proxy accepts valid body; denies enumerated
+patterns (start with 3); logs denials.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+SOURCE_DOC: Final = "docs/governance/CONSOLIDATED_RULES.md"
+
+# Enumerated deny patterns (verbatim string names from CONSOLIDATED_RULES.md):
+DENY_VERIFY_RULE: Final = "verify_rule_no_inline_evidence"
+DENY_BUSINESS_RULE: Final = "business_rule_usd_without_aud"
+DENY_GOVERN_RULE: Final = "govern_rule_hook_bypass"
+
+_COMPLETION_WORDS = re.compile(r"\b(done|complete|merged|shipped)\b", re.IGNORECASE)
+_EVIDENCE_MARKER = re.compile(r"\$\s")  # dollar-space — standard shell-prompt evidence shape
+_USD_PATTERNS = re.compile(r"(?:\bUSD\b|\$USD|U\$)")
+_AUD_PATTERNS = re.compile(r"(?:\bAUD\b|\$AUD|A\$)")
+_HOOK_BYPASS = re.compile(r"(?:--no-verify|--no-gpg-sign|--skip-hooks)")
+
+
+@dataclass(frozen=True)
+class RequestBody:
+    tenant_id: str
+    prompt: str
+    max_tokens: int
+
+
+@dataclass(frozen=True)
+class ProxyDecision:
+    allowed: bool
+    reason: str | None = None
+    body: RequestBody | None = None
+
+
+class SchemaError(ValueError):
+    """Raised when the request body fails minimal schema validation."""
+
+
+def _validate_schema(body_dict: dict) -> RequestBody:
+    """Parse + validate minimal request shape. Raises SchemaError on failure."""
+    tenant_id = body_dict.get("tenant_id")
+    if not tenant_id:
+        raise SchemaError("tenant_id is required and must be non-empty")
+
+    prompt = body_dict.get("prompt")
+    if prompt is None:
+        raise SchemaError("prompt is required")
+    if not isinstance(prompt, str) or prompt == "":
+        raise SchemaError("prompt must be a non-empty string")
+
+    max_tokens = body_dict.get("max_tokens")
+    if max_tokens is None:
+        raise SchemaError("max_tokens is required")
+    if not isinstance(max_tokens, int) or isinstance(max_tokens, bool) or max_tokens <= 0:
+        raise SchemaError("max_tokens must be a positive integer")
+
+    return RequestBody(tenant_id=str(tenant_id), prompt=prompt, max_tokens=max_tokens)
+
+
+def _check_enumerated_denials(prompt: str) -> str | None:
+    """Apply the 3 enumerated patterns. Returns the matching deny reason or None.
+
+    Evaluation order is deterministic: VERIFY -> BUSINESS -> GOVERN.
+    """
+    # RULE 1 VERIFY: bare completion claim without shell-prompt evidence
+    if _COMPLETION_WORDS.search(prompt) and not _EVIDENCE_MARKER.search(prompt):
+        return DENY_VERIFY_RULE
+
+    # RULE 7 BUSINESS: USD mentioned without AUD counterpart
+    if _USD_PATTERNS.search(prompt) and not _AUD_PATTERNS.search(prompt):
+        return DENY_BUSINESS_RULE
+
+    # RULE 6 GOVERN: hook bypass flags present
+    if _HOOK_BYPASS.search(prompt):
+        return DENY_GOVERN_RULE
+
+    return None
+
+
+def evaluate(body_dict: dict) -> ProxyDecision:
+    """Single-call entry: validate schema then check deny patterns.
+
+    Returns:
+        ProxyDecision(allowed=True, body=RequestBody) on accept;
+        ProxyDecision(allowed=False, reason='schema:<msg>') on schema failure;
+        ProxyDecision(allowed=False, reason='deny:<rule_name>') on enumerated deny.
+    """
+    try:
+        body = _validate_schema(body_dict)
+    except SchemaError as exc:
+        return ProxyDecision(allowed=False, reason=f"schema:{exc}")
+
+    denial_reason = _check_enumerated_denials(body.prompt)
+    if denial_reason is not None:
+        logger.warning(
+            "governance_proxy: DENY tenant_id=%s reason=%s",
+            body.tenant_id,
+            denial_reason,
+        )
+        return ProxyDecision(allowed=False, reason=f"deny:{denial_reason}")
+
+    return ProxyDecision(allowed=True, body=body)

--- a/tests/dispatcher/test_governance_proxy.py
+++ b/tests/dispatcher/test_governance_proxy.py
@@ -1,0 +1,118 @@
+"""Tests for KEI-165 governance proxy stub."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from src.dispatcher.governance_proxy import (
+    DENY_BUSINESS_RULE,
+    DENY_GOVERN_RULE,
+    DENY_VERIFY_RULE,
+    RequestBody,
+    evaluate,
+)
+
+VALID_BODY: dict = {
+    "tenant_id": "tenant-abc",
+    "prompt": "Please summarise the quarterly revenue.",
+    "max_tokens": 256,
+}
+
+
+class TestSchemaValidation:
+    def test_valid_body_allowed(self) -> None:
+        decision = evaluate(VALID_BODY)
+        assert decision.allowed is True
+        assert decision.body is not None
+        assert isinstance(decision.body, RequestBody)
+        assert decision.body.tenant_id == "tenant-abc"
+        assert decision.body.max_tokens == 256
+
+    def test_missing_tenant_id(self) -> None:
+        body = {**VALID_BODY}
+        del body["tenant_id"]
+        decision = evaluate(body)
+        assert decision.allowed is False
+        assert decision.reason is not None
+        assert decision.reason.startswith("schema:")
+
+    def test_missing_prompt(self) -> None:
+        body = {**VALID_BODY}
+        del body["prompt"]
+        decision = evaluate(body)
+        assert decision.allowed is False
+        assert decision.reason is not None
+        assert decision.reason.startswith("schema:")
+
+    def test_empty_prompt(self) -> None:
+        body = {**VALID_BODY, "prompt": ""}
+        decision = evaluate(body)
+        assert decision.allowed is False
+        assert decision.reason is not None
+        assert decision.reason.startswith("schema:")
+
+    def test_max_tokens_zero(self) -> None:
+        body = {**VALID_BODY, "max_tokens": 0}
+        decision = evaluate(body)
+        assert decision.allowed is False
+        assert decision.reason is not None
+        assert decision.reason.startswith("schema:")
+
+    def test_max_tokens_negative(self) -> None:
+        body = {**VALID_BODY, "max_tokens": -5}
+        decision = evaluate(body)
+        assert decision.allowed is False
+        assert decision.reason is not None
+        assert decision.reason.startswith("schema:")
+
+
+class TestEnumeratedDenials:
+    def test_completion_word_without_evidence_denied(self) -> None:
+        body = {**VALID_BODY, "prompt": "Looking done on that feature."}
+        decision = evaluate(body)
+        assert decision.allowed is False
+        assert decision.reason == f"deny:{DENY_VERIFY_RULE}"
+
+    def test_completion_word_with_evidence_allowed(self) -> None:
+        body = {**VALID_BODY, "prompt": "Looking done $ git log abc123"}
+        decision = evaluate(body)
+        assert decision.allowed is True
+
+    def test_usd_without_aud_denied(self) -> None:
+        body = {**VALID_BODY, "prompt": "Send a $50 USD invoice to the client."}
+        decision = evaluate(body)
+        assert decision.allowed is False
+        assert decision.reason == f"deny:{DENY_BUSINESS_RULE}"
+
+    def test_usd_with_aud_allowed(self) -> None:
+        body = {**VALID_BODY, "prompt": "Cost is $50 USD = $77 AUD."}
+        decision = evaluate(body)
+        assert decision.allowed is True
+
+    def test_hook_bypass_denied(self) -> None:
+        body = {**VALID_BODY, "prompt": "git commit --no-verify -m 'skip hooks'"}
+        decision = evaluate(body)
+        assert decision.allowed is False
+        assert decision.reason == f"deny:{DENY_GOVERN_RULE}"
+
+    def test_combination_verify_takes_priority(self) -> None:
+        """VERIFY fires before GOVERN in deterministic order."""
+        body = {**VALID_BODY, "prompt": "shipped --no-verify"}
+        decision = evaluate(body)
+        assert decision.allowed is False
+        assert decision.reason == f"deny:{DENY_VERIFY_RULE}"
+
+    def test_denial_logs_reason_and_tenant_not_prompt(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        body = {**VALID_BODY, "prompt": "git commit --no-verify", "tenant_id": "t-secret-99"}
+        with caplog.at_level(logging.WARNING, logger="src.dispatcher.governance_proxy"):
+            decision = evaluate(body)
+        assert decision.allowed is False
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert "t-secret-99" in record.message
+        assert DENY_GOVERN_RULE in record.message
+        assert "git commit" not in record.message


### PR DESCRIPTION
## Summary

KEI-165 (KEI-115D) — governance model proxy stub for the Agency OS dispatcher product layer.

- **Schema validation**: `RequestBody` dataclass (`tenant_id: str`, `prompt: str`, `max_tokens: int`). Rejects missing/empty fields and non-positive `max_tokens`.
- **3 enumerated deny patterns** (stub; full rule-set is a follow-up KEI):

| # | Rule | Trigger | Reason code |
|---|------|---------|-------------|
| 1 | RULE 1 VERIFY | completion word (done/complete/merged/shipped) with no `$ ` evidence marker | `verify_rule_no_inline_evidence` |
| 2 | RULE 7 BUSINESS | USD token present without AUD counterpart | `business_rule_usd_without_aud` |
| 3 | RULE 6 GOVERN | `--no-verify` / `--no-gpg-sign` / `--skip-hooks` | `govern_rule_hook_bypass` |

- Denials log `WARNING` with `tenant_id` + `reason` — **prompt content is never echoed to logs**.
- Evaluation order is deterministic: VERIFY → BUSINESS → GOVERN.

## Acceptance criteria (Linear KEI-165)

- [x] Proxy accepts valid body → `ProxyDecision(allowed=True, body=RequestBody)`
- [x] Denies 3 enumerated patterns → `ProxyDecision(allowed=False, reason='deny:<rule>')`
- [x] Logs denials at WARNING with reason code + tenant_id only

## Test plan

- [x] 13 tests, all passing (`pytest tests/dispatcher/test_governance_proxy.py -v`)
- [x] Schema: valid body, missing tenant_id, missing prompt, empty prompt, max_tokens=0, max_tokens=-5
- [x] Deny: completion-word no evidence, completion-word with evidence (allow), USD no AUD, USD+AUD (allow), hook bypass, combination (VERIFY wins), caplog asserts tenant+reason only
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `check_operational_deployment.sh` exit 0

## Note

This is a **STUB**. The full governance rule-set is scoped to a separate follow-up KEI per Aiden's 3-way scope-tightening ratification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)