### PR TITLE
[SCOUT] feat(kei158): TaskFeed component shell + pagination + useTaskFeed hook stub

### DIFF
--- a/frontend/components/dispatcher/__tests__/task-feed.test.tsx
+++ b/frontend/components/dispatcher/__tests__/task-feed.test.tsx
@@ -16,7 +16,7 @@ const _sample: DispatcherTask[] = [
     id: "task-1",
     title: "First customer task",
     status: "done",
-    cost_usd: 0.12,
+    cost_aud: 0.12,
     created_at: "2026-05-17T10:00:00Z",
     completed_at: "2026-05-17T10:05:00Z",
   },
@@ -24,7 +24,7 @@ const _sample: DispatcherTask[] = [
     id: "task-2",
     title: "Second task running",
     status: "active",
-    cost_usd: null,
+    cost_aud: null,
     created_at: "2026-05-17T10:30:00Z",
     completed_at: null,
   },
@@ -48,9 +48,9 @@ describe("TaskFeed", () => {
     expect(screen.getByText("Second task running")).toBeInTheDocument();
   });
 
-  test("renders dash for null cost and dollar for present cost", () => {
+  test("renders dash for null cost and AUD-prefixed dollar for present cost", () => {
     render(<TaskFeed tasks={_sample} />);
-    expect(screen.getByText("$0.12")).toBeInTheDocument();
+    expect(screen.getByText("A$0.12")).toBeInTheDocument();
     expect(screen.getByText("—")).toBeInTheDocument();
   });
 

--- a/frontend/components/dispatcher/__tests__/task-feed.test.tsx
+++ b/frontend/components/dispatcher/__tests__/task-feed.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Tests for TaskFeed + TaskFeedPagination component shells.
+ *
+ * Render-path-only — sub-KEI claimer extends with realtime + cursor tests
+ * once useTaskFeed is implemented.
+ */
+
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { TaskFeed, type DispatcherTask } from "../task-feed";
+import { TaskFeedPagination } from "../task-feed-pagination";
+
+const _sample: DispatcherTask[] = [
+  {
+    id: "task-1",
+    title: "First customer task",
+    status: "done",
+    cost_usd: 0.12,
+    created_at: "2026-05-17T10:00:00Z",
+    completed_at: "2026-05-17T10:05:00Z",
+  },
+  {
+    id: "task-2",
+    title: "Second task running",
+    status: "active",
+    cost_usd: null,
+    created_at: "2026-05-17T10:30:00Z",
+    completed_at: null,
+  },
+];
+
+describe("TaskFeed", () => {
+  test("renders empty-state message when tasks=[]", () => {
+    render(<TaskFeed tasks={[]} />);
+    expect(screen.getByTestId("task-feed-empty")).toBeInTheDocument();
+  });
+
+  test("renders loading-state when loading=true", () => {
+    render(<TaskFeed tasks={[]} loading />);
+    expect(screen.getByTestId("task-feed-loading")).toBeInTheDocument();
+  });
+
+  test("renders one row per task when populated", () => {
+    render(<TaskFeed tasks={_sample} />);
+    expect(screen.getByTestId("task-feed-table")).toBeInTheDocument();
+    expect(screen.getByText("First customer task")).toBeInTheDocument();
+    expect(screen.getByText("Second task running")).toBeInTheDocument();
+  });
+
+  test("renders dash for null cost and dollar for present cost", () => {
+    render(<TaskFeed tasks={_sample} />);
+    expect(screen.getByText("$0.12")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  test("custom empty message overrides default", () => {
+    render(<TaskFeed tasks={[]} emptyMessage="custom empty text" />);
+    expect(screen.getByText("custom empty text")).toBeInTheDocument();
+  });
+});
+
+describe("TaskFeedPagination", () => {
+  test("both buttons disabled when no prev and no next", () => {
+    render(<TaskFeedPagination hasPrev={false} hasNext={false} />);
+    expect(screen.getByText(/Previous/)).toBeDisabled();
+    expect(screen.getByText(/Next/)).toBeDisabled();
+  });
+
+  test("next enabled when hasNext=true", () => {
+    render(<TaskFeedPagination hasPrev={false} hasNext />);
+    expect(screen.getByText(/Next/)).toBeEnabled();
+  });
+
+  test("prev enabled when hasPrev=true", () => {
+    render(<TaskFeedPagination hasPrev hasNext={false} />);
+    expect(screen.getByText(/Previous/)).toBeEnabled();
+  });
+
+  test("renders page label when provided", () => {
+    render(<TaskFeedPagination hasPrev hasNext pageLabel="Page 2 of 5" />);
+    expect(screen.getByText("Page 2 of 5")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/dispatcher/task-feed-pagination.tsx
+++ b/frontend/components/dispatcher/task-feed-pagination.tsx
@@ -1,0 +1,49 @@
+/**
+ * FILE: frontend/components/dispatcher/task-feed-pagination.tsx
+ * PURPOSE: Page controls for TaskFeed. Cursor-based to match the
+ *          existing public.tasks indexes (id + created_at). Sub-KEI
+ *          claimer wires the cursor advance/back into useTaskFeed hook.
+ * KEI: 158 — Task feed pagination (sibling of task-feed.tsx).
+ *
+ * Stub: button shell + props interface. Disabled state when no prev/next.
+ */
+
+import * as React from "react";
+
+export interface TaskFeedPaginationProps {
+  hasPrev: boolean;
+  hasNext: boolean;
+  onPrev?: () => void;
+  onNext?: () => void;
+  pageLabel?: string;
+}
+
+export function TaskFeedPagination({
+  hasPrev,
+  hasNext,
+  onPrev,
+  onNext,
+  pageLabel,
+}: TaskFeedPaginationProps) {
+  return (
+    <div data-testid="task-feed-pagination" className="flex items-center justify-between py-4">
+      <button
+        type="button"
+        disabled={!hasPrev}
+        onClick={onPrev}
+        className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+      >
+        ← Previous
+      </button>
+      {pageLabel ? <span className="text-sm text-muted-foreground">{pageLabel}</span> : null}
+      <button
+        type="button"
+        disabled={!hasNext}
+        onClick={onNext}
+        className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+      >
+        Next →
+      </button>
+    </div>
+  );
+}

--- a/frontend/components/dispatcher/task-feed-pagination.tsx
+++ b/frontend/components/dispatcher/task-feed-pagination.tsx
@@ -24,7 +24,7 @@ export function TaskFeedPagination({
   onPrev,
   onNext,
   pageLabel,
-}: TaskFeedPaginationProps) {
+}: Readonly<TaskFeedPaginationProps>) {
   return (
     <div data-testid="task-feed-pagination" className="flex items-center justify-between py-4">
       <button

--- a/frontend/components/dispatcher/task-feed.tsx
+++ b/frontend/components/dispatcher/task-feed.tsx
@@ -32,7 +32,10 @@ export interface DispatcherTask {
   id: string;
   title: string;
   status: DispatcherTaskStatus;
-  cost_usd: number | null;
+  // LAW II Australia First — all financial values stored + displayed in $AUD.
+  // Field name carries the unit so sub-KEI claimers can't silently propagate
+  // USD through 10+ consumer files (anchored: feedback_currency_label_must_match_value 2026-05-08).
+  cost_aud: number | null;
   created_at: string;
   completed_at: string | null;
 }
@@ -76,7 +79,7 @@ export function TaskFeed({
         <TableRow>
           <TableHead>Title</TableHead>
           <TableHead>Status</TableHead>
-          <TableHead className="text-right">Cost</TableHead>
+          <TableHead className="text-right">Cost (AUD)</TableHead>
           <TableHead className="text-right">Submitted</TableHead>
         </TableRow>
       </TableHeader>
@@ -86,7 +89,7 @@ export function TaskFeed({
             <TableCell className="font-medium">{task.title}</TableCell>
             <TableCell>{STATUS_LABEL[task.status]}</TableCell>
             <TableCell className="text-right">
-              {task.cost_usd === null ? "—" : `$${task.cost_usd.toFixed(2)}`}
+              {task.cost_aud === null ? "—" : `A$${task.cost_aud.toFixed(2)}`}
             </TableCell>
             <TableCell className="text-right text-muted-foreground">
               {new Date(task.created_at).toLocaleString()}

--- a/frontend/components/dispatcher/task-feed.tsx
+++ b/frontend/components/dispatcher/task-feed.tsx
@@ -1,0 +1,99 @@
+/**
+ * FILE: frontend/components/dispatcher/task-feed.tsx
+ * PURPOSE: Customer-facing task feed for the Dispatcher dashboard.
+ *          Lists active + completed tasks in chronological order with
+ *          pagination. Sub-KEI claimer wires data loading + Supabase
+ *          realtime subscription.
+ * KEI: 158 — Part 17 dashboard MVP (parent KEI-114).
+ *
+ * Stub: typed component shell + props interface. Render path uses the
+ * shared shadcn Table primitives. No data fetching — caller passes
+ * `tasks` in. Pagination + status transitions land in sub-PR.
+ */
+
+import * as React from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+
+export type DispatcherTaskStatus =
+  | "pending"
+  | "active"
+  | "done"
+  | "failed"
+  | "cancelled";
+
+export interface DispatcherTask {
+  id: string;
+  title: string;
+  status: DispatcherTaskStatus;
+  cost_usd: number | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export interface TaskFeedProps {
+  tasks: DispatcherTask[];
+  loading?: boolean;
+  emptyMessage?: string;
+}
+
+const STATUS_LABEL: Record<DispatcherTaskStatus, string> = {
+  pending: "Pending",
+  active: "Active",
+  done: "Done",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+
+export function TaskFeed({
+  tasks,
+  loading = false,
+  emptyMessage = "No tasks yet. Submit your first task to get started.",
+}: TaskFeedProps) {
+  if (loading) {
+    return (
+      <div data-testid="task-feed-loading" className="py-8 text-center text-sm text-muted-foreground">
+        Loading tasks…
+      </div>
+    );
+  }
+  if (tasks.length === 0) {
+    return (
+      <div data-testid="task-feed-empty" className="py-8 text-center text-sm text-muted-foreground">
+        {emptyMessage}
+      </div>
+    );
+  }
+  return (
+    <Table data-testid="task-feed-table">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Title</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="text-right">Cost</TableHead>
+          <TableHead className="text-right">Submitted</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {tasks.map((task) => (
+          <TableRow key={task.id} data-task-id={task.id} data-task-status={task.status}>
+            <TableCell className="font-medium">{task.title}</TableCell>
+            <TableCell>{STATUS_LABEL[task.status]}</TableCell>
+            <TableCell className="text-right">
+              {task.cost_usd === null ? "—" : `$${task.cost_usd.toFixed(2)}`}
+            </TableCell>
+            <TableCell className="text-right text-muted-foreground">
+              {new Date(task.created_at).toLocaleString()}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/frontend/components/dispatcher/task-feed.tsx
+++ b/frontend/components/dispatcher/task-feed.tsx
@@ -58,7 +58,7 @@ export function TaskFeed({
   tasks,
   loading = false,
   emptyMessage = "No tasks yet. Submit your first task to get started.",
-}: TaskFeedProps) {
+}: Readonly<TaskFeedProps>) {
   if (loading) {
     return (
       <div data-testid="task-feed-loading" className="py-8 text-center text-sm text-muted-foreground">

--- a/frontend/components/dispatcher/use-task-feed.ts
+++ b/frontend/components/dispatcher/use-task-feed.ts
@@ -1,0 +1,61 @@
+/**
+ * FILE: frontend/components/dispatcher/use-task-feed.ts
+ * PURPOSE: Hook contract for TaskFeed data loading. Sub-KEI claimer
+ *          implements the Supabase query + realtime subscription;
+ *          this stub fixes the shape so TaskFeed + Pagination can be
+ *          composed against a stable interface.
+ * KEI: 158 (Task feed UI) — data layer; depends on KEI-111B (auth)
+ *      for the customer-id RLS scoping.
+ *
+ * Stub: returns the resolved shape with sensible defaults. Replace
+ * the body with `useEffect` + `supabase.from('tasks').select(...)`.
+ */
+
+import type { DispatcherTask } from "./task-feed";
+
+export interface UseTaskFeedOptions {
+  pageSize?: number;
+  cursor?: string | null;
+  /**
+   * Customer id whose tasks to fetch. When omitted, the hook expects
+   * the implementing version to derive it from the Supabase session.
+   */
+  customerId?: string;
+}
+
+export interface UseTaskFeedResult {
+  tasks: DispatcherTask[];
+  loading: boolean;
+  error: Error | null;
+  hasPrev: boolean;
+  hasNext: boolean;
+  nextCursor: string | null;
+  prevCursor: string | null;
+  reload: () => void;
+}
+
+const DEFAULT_RESULT: UseTaskFeedResult = {
+  tasks: [],
+  loading: false,
+  error: null,
+  hasPrev: false,
+  hasNext: false,
+  nextCursor: null,
+  prevCursor: null,
+  reload: () => {},
+};
+
+export function useTaskFeed(_opts: UseTaskFeedOptions = {}): UseTaskFeedResult {
+  // Stub — sub-KEI implements:
+  //   - Supabase query: SELECT id, title, status, cost_usd, created_at, completed_at
+  //                     FROM public.tasks
+  //                    WHERE customer_id = <session.user.id>
+  //                    ORDER BY created_at DESC
+  //                    LIMIT pageSize + 1
+  //                    (KEY-SET pagination via cursor)
+  //   - Realtime subscription: supabase
+  //       .channel('public:tasks:<customer_id>')
+  //       .on('postgres_changes', { event: '*', schema: 'public', table: 'tasks' }, …)
+  //   - Cleanup on unmount
+  return DEFAULT_RESULT;
+}

--- a/frontend/components/dispatcher/use-task-feed.ts
+++ b/frontend/components/dispatcher/use-task-feed.ts
@@ -47,7 +47,7 @@ const DEFAULT_RESULT: UseTaskFeedResult = {
 
 export function useTaskFeed(_opts: UseTaskFeedOptions = {}): UseTaskFeedResult {
   // Stub — sub-KEI implements:
-  //   - Supabase query: SELECT id, title, status, cost_usd, created_at, completed_at
+  //   - Supabase query: SELECT id, title, status, cost_aud, created_at, completed_at
   //                     FROM public.tasks
   //                    WHERE customer_id = <session.user.id>
   //                    ORDER BY created_at DESC


### PR DESCRIPTION
## Summary

KEI-158 (Part 17.4 sub-KEI of KEI-114 dashboard MVP): customer-facing task feed component family. Render-path complete; data layer is stubbed for sub-KEI claimer to wire Supabase query + realtime subscription.

**Linear:** [KEI-158](https://linear.app/keiracom/issue/KEI-158) · **Branch:** off main

## What lands (4 files, +293)

| File | Purpose |
|---|---|
| `frontend/components/dispatcher/task-feed.tsx` | `<TaskFeed tasks=... loading=... />` shadcn-Table render, loading/empty/populated states, status label map |
| `frontend/components/dispatcher/task-feed-pagination.tsx` | Cursor-based prev/next buttons, disabled states, optional page-label |
| `frontend/components/dispatcher/use-task-feed.ts` | Hook contract + default stub. Sub-KEI implements Supabase query + realtime |
| `frontend/components/dispatcher/__tests__/task-feed.test.tsx` | 9 render tests (5 TaskFeed + 4 Pagination) — vitest + @testing-library/react |

## Why componentize early

KEI-113D dashboard populate + KEI-114B cost-card + KEI-114C key-mgmt + KEI-114D thread-gauge all need to compose this surface. Shipping the shell first lets sub-KEI claimers focus on data + business logic instead of re-implementing the table chrome.

`useTaskFeed` hook contract is the load-bearing decision — fixing it now means sub-KEI implementations can be drop-in without breaking consumers.

## Render path (verbatim from TaskFeed.tsx)

```tsx
<TaskFeed
  tasks={tasks}        // DispatcherTask[]
  loading={loading}    // boolean
  emptyMessage="..."   // optional
/>
```

States covered:
- `loading=true` → `<div data-testid="task-feed-loading">Loading tasks…</div>`
- `tasks.length === 0` → empty-message
- populated → shadcn `<Table>` with one `<TableRow>` per task, `data-task-id` + `data-task-status` attrs for realtime row updates

Per-row data-attrs `data-task-id` + `data-task-status` let the future realtime subscription target rows without re-rendering the whole table.

## Out of scope (sub-KEI)

- Supabase `select` + cursor-based pagination (implement `useTaskFeed` body)
- Realtime subscription via `supabase.channel('public:tasks:<customer_id>').on('postgres_changes', ...)`
- RLS scoping (depends on KEI-111B auth landing first)
- Cleanup-on-unmount
- Wire into `/(dispatcher)/dashboard/page.tsx` (PR #953 has the page; this PR is component-only)

## Acceptance

- [x] TaskFeed renders empty / loading / populated states
- [x] TaskFeedPagination renders prev/next with disabled state
- [x] useTaskFeed exports a stable result shape
- [x] 9 render tests cover all branches
- [x] No backend or Supabase coupling — pure component shell

Local node_modules missing → vitest run skipped locally; CI installs + runs.

## Dual approval

[ELLIOT] + [AIDEN] per session rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)