### PR TITLE
[ATLAS] feat(kei166): KEI-115E — LiteLLM router for customer dispatcher requests

### DIFF
--- a/src/dispatcher/llm_router.py
+++ b/src/dispatcher/llm_router.py
@@ -1,0 +1,234 @@
+"""KEI-115E — LiteLLM router for customer dispatcher requests.
+
+Forwards customer requests to the local LiteLLM gateway (default
+``http://127.0.0.1:4000``), retries on 429 with bounded backoff, emits
+cost-event metadata via an injectable ``cost_sink`` callback so the
+consumer chooses where to persist (no DB write in this layer — see KEI
+note: a dispatcher-customer cost table does not yet exist; existing
+``vendor_usage_log`` / ``sdk_usage_log`` are agency-CRM-shaped).
+
+Body is treated as an opaque pass-through. Governance/schema validation
+lives upstream in the proxy (KEI-115D / KEI-165). Auth headers + tenant
+context come from the caller — the router does not know about JWTs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GATEWAY_URL = "http://127.0.0.1:4000/v1/chat/completions"
+DEFAULT_HTTP_TIMEOUT_S = 60.0
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_BACKOFF_LADDER_S: tuple[float, ...] = (1.0, 2.0, 5.0)
+
+CostSink = Callable[["CostEvent"], None]
+
+
+class LiteLLMRouterError(RuntimeError):
+    """Non-retryable router failure — bad gateway response or transport error."""
+
+
+class LiteLLMRateLimitExhaustedError(LiteLLMRouterError):
+    """Gateway returned 429 ``max_retries`` times in a row. Caller may decide
+    to surface as a tier-limit message to the customer."""
+
+
+@dataclass(frozen=True)
+class CostEvent:
+    """One forwarded request's cost-tracking record. The router never
+    persists this — it hands it to ``cost_sink`` for the caller to write
+    to whichever ledger fits their tenant model."""
+
+    customer_id: str
+    task_id: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cost_aud: float
+    retry_count: int
+    duration_ms: int
+    success: bool
+    error_message: str | None = None
+
+
+def _extract_usage(response_body: dict[str, Any]) -> tuple[str, int, int, float]:
+    """Pull model + token counts + cost out of a LiteLLM response. Falls
+    back to zeros when LiteLLM didn't return the expected shape — cost
+    accounting is best-effort, not load-bearing for request success."""
+    model = str(response_body.get("model") or "unknown")
+    usage = response_body.get("usage") or {}
+    input_tokens = int(usage.get("prompt_tokens") or 0)
+    output_tokens = int(usage.get("completion_tokens") or 0)
+    # LiteLLM exposes per-request cost under the non-standard
+    # ``response_cost`` field when ``litellm.success_callback`` is set.
+    # Coerce to AUD if the deploy is configured for AUD pricing; this
+    # router does NOT do USD→AUD conversion (LAW II — let the gateway
+    # config own currency).
+    cost_aud = float(response_body.get("response_cost") or 0.0)
+    return model, input_tokens, output_tokens, cost_aud
+
+
+def _post_json(url: str, body: dict[str, Any], timeout_s: float) -> tuple[int, dict[str, Any]]:
+    """POST JSON to ``url``, return (status_code, parsed_body). Raises
+    LiteLLMRouterError on transport-level failure (DNS, refused, timeout)
+    so the caller's retry loop can distinguish from 429s.
+    """
+    raw = json.dumps(body).encode("utf-8")
+    req = urlrequest.Request(
+        url,
+        data=raw,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urlrequest.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 — fixed gateway URL
+            status = int(resp.status)
+            payload = json.loads(resp.read() or b"{}")
+            return status, payload
+    except urlerror.HTTPError as exc:
+        # HTTPError IS the response — capture status + body so retry logic
+        # can branch on 429 vs everything else.
+        try:
+            payload = json.loads(exc.read() or b"{}")
+        except (json.JSONDecodeError, OSError):
+            payload = {"error": str(exc)}
+        return int(exc.code), payload
+    except (urlerror.URLError, TimeoutError, OSError) as exc:
+        raise LiteLLMRouterError(f"litellm transport error: {exc}") from exc
+
+
+def forward(
+    *,
+    body: dict[str, Any],
+    customer_id: str,
+    task_id: str,
+    gateway_url: str = DEFAULT_GATEWAY_URL,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    backoff_s: tuple[float, ...] = DEFAULT_BACKOFF_LADDER_S,
+    timeout_s: float = DEFAULT_HTTP_TIMEOUT_S,
+    cost_sink: CostSink | None = None,
+) -> dict[str, Any]:
+    """Forward a chat-completion request to LiteLLM with retry-on-429.
+
+    Args:
+        body: Opaque LiteLLM-shaped request body (model, messages, ...).
+        customer_id: Tenant identifier — attached to the cost event only.
+        task_id: KEI / dispatcher task identifier — attached to cost event.
+        gateway_url: LiteLLM endpoint. Default is the systemd-managed local proxy.
+        max_retries: Max 429 retries before raising LiteLLMRateLimitExhaustedError.
+        backoff_s: Per-retry sleep ladder (truncated to ``max_retries``).
+        timeout_s: HTTP timeout per attempt.
+        cost_sink: Optional callback invoked once on success with a CostEvent.
+            Exceptions from the sink are caught + logged — sink failure must
+            NOT bubble into the forwarding result.
+
+    Returns:
+        Parsed LiteLLM response body on 2xx.
+
+    Raises:
+        LiteLLMRateLimitExhaustedError: 429 returned ``max_retries`` times.
+        LiteLLMRouterError: Transport failure or non-2xx non-429 response.
+    """
+    started_monotonic = time.monotonic()
+    retry_count = 0
+    last_status = 0
+    last_payload: dict[str, Any] = {}
+
+    for attempt in range(max_retries + 1):
+        status, payload = _post_json(gateway_url, body, timeout_s)
+        last_status, last_payload = status, payload
+        if 200 <= status < 300:
+            duration_ms = int((time.monotonic() - started_monotonic) * 1000)
+            _emit_cost(
+                payload,
+                customer_id=customer_id,
+                task_id=task_id,
+                retry_count=retry_count,
+                duration_ms=duration_ms,
+                success=True,
+                error_message=None,
+                cost_sink=cost_sink,
+            )
+            return payload
+        if status == 429 and attempt < max_retries:
+            sleep_for = backoff_s[min(attempt, len(backoff_s) - 1)]
+            logger.info(
+                "litellm 429 on attempt %d/%d — sleeping %.1fs",
+                attempt + 1,
+                max_retries,
+                sleep_for,
+            )
+            time.sleep(sleep_for)
+            retry_count += 1
+            continue
+        # Non-2xx and not a retryable 429 — fail terminal.
+        break
+
+    duration_ms = int((time.monotonic() - started_monotonic) * 1000)
+    error_message = (
+        json.dumps(last_payload)[:500] if last_payload else f"litellm status {last_status}"
+    )
+    _emit_cost(
+        last_payload,
+        customer_id=customer_id,
+        task_id=task_id,
+        retry_count=retry_count,
+        duration_ms=duration_ms,
+        success=False,
+        error_message=error_message,
+        cost_sink=cost_sink,
+    )
+    if last_status == 429:
+        raise LiteLLMRateLimitExhaustedError(
+            f"litellm 429 after {max_retries} retries: {error_message}"
+        )
+    raise LiteLLMRouterError(f"litellm status {last_status}: {error_message}")
+
+
+def _emit_cost(
+    response_body: dict[str, Any],
+    *,
+    customer_id: str,
+    task_id: str,
+    retry_count: int,
+    duration_ms: int,
+    success: bool,
+    error_message: str | None,
+    cost_sink: CostSink | None,
+) -> None:
+    """Build a CostEvent and hand it to ``cost_sink``. Sink failures are
+    swallowed — the router must not propagate ledger problems back to the
+    caller whose request actually completed."""
+    if cost_sink is None:
+        return
+    model, input_tokens, output_tokens, cost_aud = _extract_usage(response_body)
+    event = CostEvent(
+        customer_id=customer_id,
+        task_id=task_id,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_aud=cost_aud,
+        retry_count=retry_count,
+        duration_ms=duration_ms,
+        success=success,
+        error_message=error_message,
+    )
+    try:
+        cost_sink(event)
+    except Exception as exc:  # noqa: BLE001 — sink is consumer-owned; must isolate
+        logger.warning(
+            "cost_sink raised for task %s (customer %s): %s",
+            task_id,
+            customer_id,
+            exc,
+        )

--- a/src/dispatcher/llm_router.py
+++ b/src/dispatcher/llm_router.py
@@ -102,7 +102,8 @@ def _post_json(url: str, body: dict[str, Any], timeout_s: float) -> tuple[int, d
         except (json.JSONDecodeError, OSError):
             payload = {"error": str(exc)}
         return int(exc.code), payload
-    except (urlerror.URLError, TimeoutError, OSError) as exc:
+    except (urlerror.URLError, OSError) as exc:
+        # TimeoutError is a subclass of OSError in Python 3.10+, covered already
         raise LiteLLMRouterError(f"litellm transport error: {exc}") from exc
 
 

--- a/tests/dispatcher/test_llm_router.py
+++ b/tests/dispatcher/test_llm_router.py
@@ -1,0 +1,213 @@
+"""KEI-115E — tests for src/dispatcher/llm_router.
+
+All HTTP is mocked at the _post_json helper boundary; no live LiteLLM
+required. Backoff sleeps are also patched to zero so the test suite
+doesn't actually wait through the retry ladder.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.dispatcher import llm_router
+from src.dispatcher.llm_router import (
+    CostEvent,
+    LiteLLMRateLimitExhaustedError,
+    LiteLLMRouterError,
+    forward,
+)
+
+
+def _ok_payload(model: str = "claude-sonnet-4-6", in_tok: int = 12, out_tok: int = 34):
+    return {
+        "model": model,
+        "usage": {"prompt_tokens": in_tok, "completion_tokens": out_tok},
+        "response_cost": 0.000123,
+        "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch):
+    """Backoff sleeps are tested via the retry_count assertion, not by
+    actually waiting — patch time.sleep to a no-op so the suite is fast."""
+    monkeypatch.setattr(llm_router.time, "sleep", lambda _s: None)
+
+
+# ─── happy path ────────────────────────────────────────────────────────────
+
+
+def test_forward_returns_response_body_on_first_2xx(monkeypatch):
+    """A clean 200 path returns the parsed body and never retries."""
+    calls = {"n": 0}
+
+    def fake_post(url, body, timeout_s):
+        calls["n"] += 1
+        return 200, _ok_payload()
+
+    monkeypatch.setattr(llm_router, "_post_json", fake_post)
+    out = forward(body={"model": "x"}, customer_id="c1", task_id="KEI-166")
+    assert out["choices"][0]["message"]["content"] == "ok"
+    assert calls["n"] == 1
+
+
+def test_forward_invokes_cost_sink_with_event_shape(monkeypatch):
+    """cost_sink receives a CostEvent with every documented field set."""
+    monkeypatch.setattr(
+        llm_router,
+        "_post_json",
+        lambda url, body, timeout_s: (200, _ok_payload(in_tok=10, out_tok=20)),
+    )
+    events: list[CostEvent] = []
+    forward(
+        body={},
+        customer_id="cust-1",
+        task_id="KEI-166",
+        cost_sink=events.append,
+    )
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.customer_id == "cust-1"
+    assert ev.task_id == "KEI-166"
+    assert ev.model == "claude-sonnet-4-6"
+    assert ev.input_tokens == 10
+    assert ev.output_tokens == 20
+    assert ev.cost_aud == pytest.approx(0.000123)
+    assert ev.retry_count == 0
+    assert ev.success is True
+    assert ev.error_message is None
+    assert ev.duration_ms >= 0
+
+
+def test_forward_no_sink_does_not_raise(monkeypatch):
+    """cost_sink=None is a valid configuration — router must not require it."""
+    monkeypatch.setattr(llm_router, "_post_json", lambda url, body, timeout_s: (200, _ok_payload()))
+    # Should not raise:
+    forward(body={}, customer_id="c", task_id="t", cost_sink=None)
+
+
+# ─── 429 retry ─────────────────────────────────────────────────────────────
+
+
+def test_forward_retries_on_429_then_succeeds(monkeypatch):
+    """429 twice then 200 — router transparently retries and reports
+    retry_count=2 on the success cost event."""
+    responses = iter(
+        [(429, {"error": "rate_limited"}), (429, {"error": "rate_limited"}), (200, _ok_payload())]
+    )
+
+    def fake_post(url, body, timeout_s):
+        return next(responses)
+
+    monkeypatch.setattr(llm_router, "_post_json", fake_post)
+    events: list[CostEvent] = []
+    out = forward(
+        body={},
+        customer_id="c",
+        task_id="t",
+        max_retries=3,
+        cost_sink=events.append,
+    )
+    assert out["choices"][0]["message"]["content"] == "ok"
+    assert events[0].retry_count == 2
+    assert events[0].success is True
+
+
+def test_forward_raises_rate_limit_exhausted_after_max_retries(monkeypatch):
+    """Persistent 429 — raises LiteLLMRateLimitExhaustedError and emits a
+    failure cost event with retry_count=max_retries."""
+    monkeypatch.setattr(
+        llm_router,
+        "_post_json",
+        lambda url, body, timeout_s: (429, {"error": "tier_limit"}),
+    )
+    events: list[CostEvent] = []
+    with pytest.raises(LiteLLMRateLimitExhaustedError, match="after 3 retries"):
+        forward(
+            body={},
+            customer_id="c",
+            task_id="t",
+            max_retries=3,
+            cost_sink=events.append,
+        )
+    assert len(events) == 1
+    assert events[0].success is False
+    assert events[0].retry_count == 3
+    assert events[0].error_message is not None
+    assert "tier_limit" in events[0].error_message
+
+
+# ─── non-2xx non-429 ───────────────────────────────────────────────────────
+
+
+def test_forward_raises_router_error_on_500(monkeypatch):
+    """5xx is non-retryable here (LiteLLM owns upstream retries); router
+    fails the request immediately and emits a failure cost event."""
+    monkeypatch.setattr(
+        llm_router,
+        "_post_json",
+        lambda url, body, timeout_s: (500, {"error": "upstream"}),
+    )
+    events: list[CostEvent] = []
+    with pytest.raises(LiteLLMRouterError, match="status 500"):
+        forward(body={}, customer_id="c", task_id="t", cost_sink=events.append)
+    assert len(events) == 1
+    assert events[0].success is False
+    assert events[0].retry_count == 0
+
+
+def test_forward_propagates_transport_error_from_helper(monkeypatch):
+    """_post_json raising LiteLLMRouterError (e.g. DNS / refused) surfaces
+    to the caller; no cost event is emitted because we never got a response."""
+
+    def boom(url, body, timeout_s):
+        raise LiteLLMRouterError("transport: connection refused")
+
+    monkeypatch.setattr(llm_router, "_post_json", boom)
+    events: list[CostEvent] = []
+    with pytest.raises(LiteLLMRouterError, match="connection refused"):
+        forward(body={}, customer_id="c", task_id="t", cost_sink=events.append)
+    assert events == []
+
+
+# ─── cost-sink isolation ───────────────────────────────────────────────────
+
+
+def test_cost_sink_exception_does_not_break_forwarding(monkeypatch, caplog):
+    """A buggy cost_sink must not prevent the caller from receiving the
+    successful response — ledger writes are a side-channel, not load-bearing."""
+    monkeypatch.setattr(llm_router, "_post_json", lambda url, body, timeout_s: (200, _ok_payload()))
+
+    def explode(_event):
+        raise RuntimeError("ledger DB down")
+
+    with caplog.at_level("WARNING"):
+        out = forward(body={}, customer_id="c", task_id="t", cost_sink=explode)
+    assert out["choices"][0]["message"]["content"] == "ok"
+    assert any("ledger DB down" in r.message for r in caplog.records)
+
+
+# ─── usage extraction edge cases ───────────────────────────────────────────
+
+
+def test_forward_handles_missing_usage_block(monkeypatch):
+    """A response without ``usage`` (or with partial fields) still produces
+    a CostEvent — tokens default to 0, cost defaults to 0.0."""
+    payload = {"model": "x", "choices": [{"message": {"role": "assistant", "content": "hi"}}]}
+    monkeypatch.setattr(llm_router, "_post_json", lambda url, body, timeout_s: (200, payload))
+    events: list[CostEvent] = []
+    forward(body={}, customer_id="c", task_id="t", cost_sink=events.append)
+    assert events[0].input_tokens == 0
+    assert events[0].output_tokens == 0
+    assert events[0].cost_aud == 0.0
+    assert events[0].model == "x"
+
+
+def test_forward_handles_missing_model(monkeypatch):
+    """A response without ``model`` — CostEvent.model falls back to 'unknown'
+    so the ledger writer never sees None in a NOT NULL column."""
+    payload = {"usage": {"prompt_tokens": 1, "completion_tokens": 2}}
+    monkeypatch.setattr(llm_router, "_post_json", lambda url, body, timeout_s: (200, payload))
+    events: list[CostEvent] = []
+    forward(body={}, customer_id="c", task_id="t", cost_sink=events.append)
+    assert events[0].model == "unknown"

--- a/tests/dispatcher/test_llm_router.py
+++ b/tests/dispatcher/test_llm_router.py
@@ -199,7 +199,7 @@ def test_forward_handles_missing_usage_block(monkeypatch):
     forward(body={}, customer_id="c", task_id="t", cost_sink=events.append)
     assert events[0].input_tokens == 0
     assert events[0].output_tokens == 0
-    assert events[0].cost_aud == 0.0
+    assert events[0].cost_aud == pytest.approx(0.0)
     assert events[0].model == "x"
 
 


### PR DESCRIPTION
## Summary

Closes KEI-166 (KEI-115E). Runtime LiteLLM router for the Part 17 dispatcher product layer — forwards customer requests to the local LiteLLM gateway, retries on 429 with bounded backoff, emits cost-event metadata via injectable callback.

**Stacked PR** — base = \`atlas/kei162-container-spawn\` (PR #952). Merge order: #952 → this PR. Once #952 lands, this rebases trivially onto main.

## Acceptance (Linear KEI-166)

- [x] request routes via LiteLLM → POST to gateway_url (default \`http://127.0.0.1:4000/v1/chat/completions\`)
- [x] retry on 429 → bounded by \`max_retries\` with \`(1s, 2s, 5s)\` backoff ladder
- [x] cost logged per request → \`CostEvent\` → \`cost_sink\` callback (caller persists)

## Why cost_sink (not direct DB write)

Existing \`vendor_usage_log\` / \`sdk_usage_log\` are agency-CRM-shaped (\`client_id\` / \`lead_id\` / \`campaign_id\`) and don't fit the customer-tenant dispatcher model. A purpose-built \`dispatcher_costs\` table is a sibling KEI to surface — not in-scope for the router primitive. Sink exceptions are caught + logged so ledger problems can't break request forwarding.

## API

\`\`\`python
from src.dispatcher.llm_router import forward, CostEvent

def my_sink(event: CostEvent) -> None:
    # caller decides where this goes
    db.insert_dispatcher_cost(event)

response = forward(
    body={\"model\": \"claude-sonnet-4-6\", \"messages\": [...]},
    customer_id=\"cust-abc\",
    task_id=\"KEI-XXX\",
    max_retries=3,
    cost_sink=my_sink,
)
\`\`\`

## Test plan

- [x] \`pytest tests/dispatcher/test_llm_router.py\` — 10/10 passed (HTTP mocked at \`_post_json\` boundary; \`time.sleep\` no-op'd for fast retries).
- [x] Full dispatcher suite: 24/24 (10 new + 14 from KEI-162).
- [x] \`ruff check\` — All checks passed.
- [x] \`ruff format --check\` — 2 files already formatted.

Test coverage:
- happy path returns body on first 2xx (no retry)
- cost_sink invoked with full CostEvent shape (model, tokens, cost_aud, retry_count, duration_ms)
- cost_sink=None is valid (no-op emit)
- 429×2 then 200 → succeeds with retry_count=2
- 429 persistent → \`LiteLLMRateLimitExhaustedError\` after max_retries + failure cost event emitted
- 500 → \`LiteLLMRouterError\` immediately + failure cost event
- transport error from \`_post_json\` propagates, no cost event (no response received)
- cost_sink raising doesn't break \`forward()\` (ledger isolation)
- missing \`usage\` block → tokens default to 0, cost 0.0
- missing \`model\` → falls back to \"unknown\" (NOT NULL safety)

## Surface for Dave

No \`dispatcher_costs\` table exists. KEI-159 (cost-breakdown UI) will need one before it can ship. Sibling KEI proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)