### PR TITLE
[AIDEN] feat(kei114): customer dashboard MVP scaffold — 4 stub subpages + scope doc

### DIFF
--- a/docs/wave3/kei114_dashboard_scope.md
+++ b/docs/wave3/kei114_dashboard_scope.md
@@ -1,0 +1,59 @@
+# KEI-114 — Customer Dashboard MVP Scope
+
+**Linear:** [KEI-114](https://linear.app/keiracom/issue/KEI-114)
+**Parent:** KEI-110 (Dispatcher Product Layer — Part 17)
+**Phase:** Product Layer / **Priority:** P1 (first-customer essential, post-Wave-3 bump from P2)
+
+This umbrella scaffold lays out the route group `(dispatcher)/dashboard/` and 4 stub pages. Sub-KEI implementers do the real UI + data wiring on top. Pattern mirrors Scout's KEI-113 onboarding scaffold (PR #953).
+
+---
+
+## Sub-KEI dep graph
+
+```
+                  KEI-110 (parent — Part 17)
+                          |
+                  KEI-114 (this scaffold)
+                          |
+        +-----------------+-----------------+-----------+
+        |                 |                 |           |
+   KEI-114A          KEI-114B          KEI-114C     KEI-114D
+   (KEI-158)         (KEI-159)         (KEI-160)    (KEI-161)
+   Feed Component    Cost Display      Key Mgmt UI  Usage Meter
+        |                 |                 |           |
+        v                 v                 v           v
+   needs:            needs:            needs:       needs:
+   KEI-111E (RLS)    KEI-114A first    KEI-111E +   KEI-117A
+   KEI-115B (live)                     KEI-116A/B/C (Valkey)
+```
+
+Critical-path observation: **KEI-114A (Feed) is the longest chain** because every other tile expects the feed exists to drill into. Start 114A first; 114B/C/D can run in parallel once 114A scaffolds.
+
+---
+
+## Sub-KEI map
+
+| Linear KEI | File | Implementer scope |
+|---|---|---|
+| KEI-114A / [KEI-158](https://linear.app/keiracom/issue/KEI-158) | `frontend/app/(dispatcher)/dashboard/feed/page.tsx` | Tasks table fetch + Realtime + pagination. Render-path components already exist via Scout's PR #957 (`frontend/components/dispatcher/TaskFeed.tsx`). |
+| KEI-114B / [KEI-159](https://linear.app/keiracom/issue/KEI-159) | `frontend/app/(dispatcher)/dashboard/costs/page.tsx` | Cost-per-task breakdown + cumulative AUD spend card. Materialised view or daily-rollup so render isn't a sum-on-every-load. |
+| KEI-114C / [KEI-160](https://linear.app/keiracom/issue/KEI-160) | `frontend/app/(dispatcher)/dashboard/keys/page.tsx` | List + rotate + revoke. Plaintext surfaced ONCE at create/rotate; otherwise display lookup-hash prefix only per KEI-116. |
+| KEI-114D / [KEI-161](https://linear.app/keiracom/issue/KEI-161) | `frontend/app/(dispatcher)/dashboard/usage/page.tsx` | Live thread counter from Valkey + tier indicator. Colour-banded gauge + upgrade CTA at sustained >80%. |
+
+---
+
+## Out of scope for this PR
+
+- Real data fetching, auth wiring, schema migrations — sub-KEIs.
+- The `(dispatcher)` route group base layout — shipped by Scout's PR #953.
+- Real Supabase RLS policies — KEI-111E.
+- BYO key encryption (pgcrypto) — KEI-116A/B/C.
+- Rate-limit Valkey wiring — KEI-117A/B/C.
+
+## Decision: separate route group, not sibling under existing `dashboard/`
+
+`frontend/app/dashboard/` already hosts the Agency_OS-internal dashboard (campaigns, leads, replies, pipeline, etc.). The dispatcher customer-facing dashboard is a different audience with different RLS scope. Scout's PR #953 established `(dispatcher)/` as the customer route group; this PR adds the dashboard subpages under that group. Clean separation, no risk of cross-leak of internal Agency_OS routes into customer view.
+
+## Source
+
+Dave KEI-114 in Wave 3 Part 17 decomposition (P2→P1 bump 3-of-3 ratified 2026-05-17). KEI-114 itself is umbrella scaffold; sub-KEIs do the implementation per Scout's KEI-113 (PR #953) pattern.

--- a/frontend/app/(dispatcher)/dashboard/costs/page.tsx
+++ b/frontend/app/(dispatcher)/dashboard/costs/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * FILE: frontend/app/(dispatcher)/dashboard/costs/page.tsx
+ * PURPOSE: Customer cost view — cost-per-task breakdown + cumulative spend.
+ * KEI: 114B (Linear KEI-159) — Cost Display implementation.
+ *      Deps: 114A (Feed Component must exist for the row → cost drill-down).
+ *
+ * Stub only. Implementer wires:
+ *   - SELECT task_id, container_run_seconds, cost_usd, cost_aud FROM public.tasks
+ *     JOIN public.cost_events ON task_id (table TBD by sub-KEI claimer)
+ *   - Per-AU-dollar conversion (Australia-first per LAW II — 1 USD = 1.55 AUD)
+ *   - Cumulative spend card (sum over the configured window — default 30d)
+ *   - Cost-per-task table (descending by cost_aud, drill-down link to feed row)
+ *   - Query optimisation: materialised view or daily rollup table for the
+ *     cumulative card so the page render doesn't sum every claim every load.
+ */
+
+export default function DispatcherDashboardCostsPage() {
+  return (
+    <main className="mx-auto max-w-5xl p-8">
+      <h1 className="text-2xl font-semibold">Costs</h1>
+      <p className="mt-4 text-sm text-muted-foreground">
+        Implementation pending KEI-114B (KEI-159). Cost-per-task breakdown +
+        cumulative AUD spend card land here. Currency labels match values per
+        LAW II (1 USD = 1.55 AUD).
+      </p>
+    </main>
+  );
+}

--- a/frontend/app/(dispatcher)/dashboard/feed/page.tsx
+++ b/frontend/app/(dispatcher)/dashboard/feed/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * FILE: frontend/app/(dispatcher)/dashboard/feed/page.tsx
+ * PURPOSE: Customer task feed — active + completed tasks per tenant.
+ * KEI: 114A (Linear KEI-158) — Feed Component implementation.
+ *      Deps: 111E (RLS on tasks), 115B (container monitor for live status).
+ *
+ * Stub only. Implementer wires:
+ *   - SELECT FROM public.tasks WHERE tenant_id = current_tenant() (RLS)
+ *   - Realtime subscription on tasks status transitions (Supabase Realtime)
+ *   - Pagination (created_at DESC, page size 25 default)
+ *   - Cost-per-row link to /dashboard/costs (KEI-114B / KEI-159)
+ *
+ * Render-path component family lives under frontend/components/dispatcher/
+ * (TaskFeed + Pagination + useTaskFeed hook — Scout PR #957 / KEI-158).
+ */
+
+export default function DispatcherDashboardFeedPage() {
+  return (
+    <main className="mx-auto max-w-5xl p-8">
+      <h1 className="text-2xl font-semibold">Task feed</h1>
+      <p className="mt-4 text-sm text-muted-foreground">
+        Implementation pending KEI-114A (KEI-158). Active + completed tasks for the
+        signed-in tenant land here with pagination + realtime updates.
+      </p>
+    </main>
+  );
+}

--- a/frontend/app/(dispatcher)/dashboard/keys/page.tsx
+++ b/frontend/app/(dispatcher)/dashboard/keys/page.tsx
@@ -1,0 +1,34 @@
+/**
+ * FILE: frontend/app/(dispatcher)/dashboard/keys/page.tsx
+ * PURPOSE: API key management — list + rotate + revoke (BYO key flow).
+ * KEI: 114C (Linear KEI-160) — Key Mgmt UI implementation.
+ *      Deps: 111E (RLS on api_keys), 116A/B/C (BYO key encryption chain —
+ *      schema + encrypt/decrypt wrappers + lookup hash, P0 per Max's
+ *      DPA-compliance escalation Wave 3 2026-05-17).
+ *
+ * Stub only. Implementer wires:
+ *   - SELECT id, lookup_hash, label, created_at, last_used_at FROM
+ *     public.api_keys WHERE tenant_id = current_tenant() — RLS enforces.
+ *     NEVER select encrypted_key on this page; display hash prefix only.
+ *   - Rotate flow: generate new key (server-side), encrypt-then-store,
+ *     return plaintext ONCE (clipboard-copy modal), old key flagged revoked.
+ *   - Revoke flow: UPDATE api_keys SET revoked_at = NOW() (soft delete).
+ *   - Display: short-hash label (sha256[:8]) so customer can identify the
+ *     key without ever seeing the plaintext. Plaintext shown only at
+ *     create/rotate time, never again.
+ *   - Audit: every rotate/revoke writes to audit_logs (table TBD).
+ */
+
+export default function DispatcherDashboardKeysPage() {
+  return (
+    <main className="mx-auto max-w-5xl p-8">
+      <h1 className="text-2xl font-semibold">API keys</h1>
+      <p className="mt-4 text-sm text-muted-foreground">
+        Implementation pending KEI-114C (KEI-160). List + rotate + revoke
+        controls land here. Plaintext keys are surfaced once at create/rotate
+        time and never again — the list shows lookup-hash prefix only per
+        KEI-116 BYO encryption.
+      </p>
+    </main>
+  );
+}

--- a/frontend/app/(dispatcher)/dashboard/usage/page.tsx
+++ b/frontend/app/(dispatcher)/dashboard/usage/page.tsx
@@ -1,0 +1,30 @@
+/**
+ * FILE: frontend/app/(dispatcher)/dashboard/usage/page.tsx
+ * PURPOSE: Thread usage meter — real-time count vs tier limit.
+ * KEI: 114D (Linear KEI-161) — Usage Meter implementation.
+ *      Deps: 117A (Valkey connection pool + key namespace).
+ *
+ * Stub only. Implementer wires:
+ *   - Read live counter from Valkey: KEY=`tenant:{id}:threads_active`
+ *     (per-tenant namespace per KEI-117A).
+ *   - Read tier limit from public.subscriptions (KEI-112B) → max_threads.
+ *   - Gauge component: current/max with colour bands (green <60%, amber
+ *     60-90%, red >=90%, hard-stop at 100% per rate limiter KEI-117B).
+ *   - Tier indicator: Basic / Pro / Enterprise label + upgrade CTA when
+ *     usage trends consistently >80% (3 polls in 5 min window).
+ *   - Refresh cadence: 5s polling at first; switch to Supabase Realtime
+ *     once the subscriptions table publishes ('threads_active' changes).
+ */
+
+export default function DispatcherDashboardUsagePage() {
+  return (
+    <main className="mx-auto max-w-5xl p-8">
+      <h1 className="text-2xl font-semibold">Thread usage</h1>
+      <p className="mt-4 text-sm text-muted-foreground">
+        Implementation pending KEI-114D (KEI-161). Real-time thread counter
+        vs tier limit with colour-banded gauge lands here. Reads from Valkey
+        (KEI-117A) once that pool is configured.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
Umbrella scaffold for Linear [KEI-114](https://linear.app/keiracom/issue/KEI-114) — customer dashboard MVP (task feed, costs, key mgmt, usage). Mirrors Scout's KEI-113 onboarding scaffold pattern (PR #953): ship route-group stubs + scope doc with dep graph; sub-KEI claimers implement the real UI + data wiring on top.

## Files
| Path | Sub-KEI |
|---|---|
| `frontend/app/(dispatcher)/dashboard/feed/page.tsx` | KEI-114A / KEI-158 |
| `frontend/app/(dispatcher)/dashboard/costs/page.tsx` | KEI-114B / KEI-159 |
| `frontend/app/(dispatcher)/dashboard/keys/page.tsx` | KEI-114C / KEI-160 |
| `frontend/app/(dispatcher)/dashboard/usage/page.tsx` | KEI-114D / KEI-161 |
| `docs/wave3/kei114_dashboard_scope.md` | dep graph + per-tile scope |

## Doc comments flag load-bearing constraints up-front
- `costs/` — LAW II (Australia-first, 1 USD = 1.55 AUD) + materialised-view rollup so render isn't sum-on-every-load
- `keys/` — plaintext surfaced ONCE rule + lookup-hash-only display per KEI-116 BYO encryption
- `usage/` — Valkey namespace (`tenant:{id}:threads_active`) + colour-banded gauge + tier upgrade CTA at sustained >80%
- `feed/` — Realtime subscription + per-tenant RLS + drill-down to `/dashboard/costs`

## Dep graph (verbatim from `docs/wave3/kei114_dashboard_scope.md`)
```
                  KEI-110 (parent — Part 17)
                          |
                  KEI-114 (this scaffold)
                          |
        +-----------------+-----------------+-----------+
        |                 |                 |           |
   KEI-114A          KEI-114B          KEI-114C     KEI-114D
   (KEI-158)         (KEI-159)         (KEI-160)    (KEI-161)
   Feed Component    Cost Display      Key Mgmt UI  Usage Meter
```

Critical-path observation: **KEI-114A (Feed) is the longest chain** — start there; B/C/D run in parallel once A scaffolds.

## Verification
```
$ cd frontend && npx tsc --noEmit -p tsconfig.json | grep "(dispatcher)/dashboard"
(empty — 0 errors on the 4 new files)
```

## Out of scope
- Real data fetching, auth wiring, schema migrations — sub-KEIs.
- The `(dispatcher)` route group base layout — Scout's PR #953.
- RLS policies — KEI-111E.
- BYO key encryption — KEI-116A/B/C.
- Valkey wiring — KEI-117A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)