### PR TITLE
[ATLAS] feat(kei170): KEI-117A — Valkey connection pool + per-tenant key namespace

### DIFF
--- a/src/dispatcher/valkey_pool.py
+++ b/src/dispatcher/valkey_pool.py
@@ -1,0 +1,132 @@
+"""KEI-117A — Valkey connection pool + per-tenant key namespace.
+
+Foundation for the Part 17 dispatcher rate limiter (KEI-117B / KEI-171).
+Valkey speaks the Redis wire protocol so we reuse ``redis.asyncio`` —
+no new client dependency. Pool is separate from the agency-side
+``src/integrations/redis.py`` because the dispatcher product layer is a
+distinct tenancy (customer_id), not the agency's client_id model.
+
+Key namespace contract (documented here as the canonical spec — DO NOT
+duplicate in callers):
+
+    rl:<tenant_id>:<window_start_unix>
+
+* ``rl:`` — rate-limit family prefix. Other dispatcher families (e.g.
+  ``q:`` for queues, ``ses:`` for sessions) will sit alongside without
+  collision.
+* ``<tenant_id>`` — customer UUID string. Caller is responsible for
+  passing a validated id; the helper does not authenticate.
+* ``<window_start_unix>`` — INT seconds since epoch at the start of the
+  fixed-or-sliding window. Granularity is the caller's choice (minute,
+  hour, day). The sliding-window limiter (KEI-171) uses 60-second buckets.
+
+Smoke health check: ``await smoke_incr()`` runs ``INCR <smoke_key>`` +
+``EXPIRE <smoke_key> 60`` against the pool to confirm the connection is
+live. Returns the integer post-increment value (≥ 1 on a healthy
+connection). Smoke keys are namespaced ``rl:_smoke:<process_pid>`` so
+concurrent smokes don't collide and the bucket auto-evicts.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from redis.asyncio import ConnectionPool, Redis
+
+logger = logging.getLogger(__name__)
+
+VALKEY_URL_ENV = "VALKEY_URL"
+FALLBACK_URL_ENV = "REDIS_URL"
+DEFAULT_VALKEY_URL = "redis://127.0.0.1:6379/0"
+DEFAULT_MAX_CONNECTIONS = 20
+SMOKE_KEY_TTL_SECONDS = 60
+
+RL_NAMESPACE_PREFIX = "rl"
+
+_pool: ConnectionPool | None = None
+
+
+def _resolve_url() -> str:
+    """Prefer VALKEY_URL, fall back to REDIS_URL, fall back to local default.
+
+    The fallback chain lets the dispatcher run against the existing
+    agency-side Redis in dev without needing a second binary, while keeping
+    a knob for prod to split the two tenancies onto separate instances.
+    """
+    return os.environ.get(VALKEY_URL_ENV) or os.environ.get(FALLBACK_URL_ENV) or DEFAULT_VALKEY_URL
+
+
+async def get_valkey_pool() -> ConnectionPool:
+    """Lazy-init the dispatcher Valkey pool. Same instance for the lifetime
+    of the process — pool reset is handled by `reset_valkey_pool()` (test
+    fixtures only)."""
+    global _pool
+    if _pool is None:
+        url = _resolve_url()
+        _pool = ConnectionPool.from_url(
+            url,
+            decode_responses=True,
+            max_connections=DEFAULT_MAX_CONNECTIONS,
+        )
+        logger.info("valkey pool created url=%s max=%d", url, DEFAULT_MAX_CONNECTIONS)
+    return _pool
+
+
+async def get_valkey_client() -> Redis:
+    """Get a Redis client bound to the dispatcher pool. Caller is
+    responsible for `await client.aclose()` when done (or use as
+    `async with`)."""
+    pool = await get_valkey_pool()
+    return Redis(connection_pool=pool)
+
+
+async def reset_valkey_pool() -> None:
+    """Tear down the cached pool. Tests use this between cases; production
+    code should never call it. Safe to call when no pool exists."""
+    global _pool
+    if _pool is not None:
+        try:
+            await _pool.aclose()
+        except Exception as exc:  # noqa: BLE001 — teardown must not raise
+            logger.warning("valkey pool aclose failed (non-fatal): %s", exc)
+        _pool = None
+
+
+def tenant_rl_key(tenant_id: str, window_start_unix: int) -> str:
+    """Build a per-tenant rate-limit key.
+
+    Args:
+        tenant_id: Customer UUID string. Must be non-empty.
+        window_start_unix: Integer unix seconds at the start of the window.
+
+    Returns:
+        ``rl:<tenant_id>:<window_start_unix>``
+
+    Raises:
+        ValueError: ``tenant_id`` is empty / whitespace. We refuse to mint
+            an unscoped namespace because that would silently bucket ALL
+            tenants into one counter.
+    """
+    if not tenant_id or not tenant_id.strip():
+        raise ValueError("tenant_id must be a non-empty string")
+    return f"{RL_NAMESPACE_PREFIX}:{tenant_id.strip()}:{int(window_start_unix)}"
+
+
+async def smoke_incr() -> int:
+    """Health probe — INCR a per-process smoke key and set 60s TTL so the
+    bucket auto-evicts. Returns the integer post-increment value.
+
+    Use from boot checks / readiness probes. Returns ``>= 1`` when the
+    pool is live; raises whatever ``redis.asyncio`` raises on transport
+    failure so the caller can decide whether to treat it as degraded vs
+    fatal.
+    """
+    client = await get_valkey_client()
+    try:
+        smoke_key = f"{RL_NAMESPACE_PREFIX}:_smoke:{os.getpid()}"
+        value = await client.incr(smoke_key)
+        await client.expire(smoke_key, SMOKE_KEY_TTL_SECONDS)
+        return int(value)
+    finally:
+        await client.aclose()

--- a/src/dispatcher/valkey_pool.py
+++ b/src/dispatcher/valkey_pool.py
@@ -57,10 +57,15 @@ def _resolve_url() -> str:
     return os.environ.get(VALKEY_URL_ENV) or os.environ.get(FALLBACK_URL_ENV) or DEFAULT_VALKEY_URL
 
 
-async def get_valkey_pool() -> ConnectionPool:
+def get_valkey_pool() -> ConnectionPool:
     """Lazy-init the dispatcher Valkey pool. Same instance for the lifetime
     of the process — pool reset is handled by `reset_valkey_pool()` (test
-    fixtures only)."""
+    fixtures only).
+
+    Sync because pool creation is in-memory (no I/O until first command).
+    `redis.asyncio.ConnectionPool.from_url` doesn't open sockets — those
+    are minted lazily per command by the Redis client.
+    """
     global _pool
     if _pool is None:
         url = _resolve_url()
@@ -73,12 +78,11 @@ async def get_valkey_pool() -> ConnectionPool:
     return _pool
 
 
-async def get_valkey_client() -> Redis:
+def get_valkey_client() -> Redis:
     """Get a Redis client bound to the dispatcher pool. Caller is
     responsible for `await client.aclose()` when done (or use as
     `async with`)."""
-    pool = await get_valkey_pool()
-    return Redis(connection_pool=pool)
+    return Redis(connection_pool=get_valkey_pool())
 
 
 async def reset_valkey_pool() -> None:
@@ -93,12 +97,13 @@ async def reset_valkey_pool() -> None:
         _pool = None
 
 
-def tenant_rl_key(tenant_id: str, window_start_unix: int) -> str:
+def tenant_rl_key(tenant_id: str, window_start_unix: int | float) -> str:
     """Build a per-tenant rate-limit key.
 
     Args:
         tenant_id: Customer UUID string. Must be non-empty.
-        window_start_unix: Integer unix seconds at the start of the window.
+        window_start_unix: Unix seconds at the start of the window. Accepts
+            ``int`` or ``float`` (e.g. ``time.time()``) and truncates to int.
 
     Returns:
         ``rl:<tenant_id>:<window_start_unix>``
@@ -122,7 +127,7 @@ async def smoke_incr() -> int:
     failure so the caller can decide whether to treat it as degraded vs
     fatal.
     """
-    client = await get_valkey_client()
+    client = get_valkey_client()
     try:
         smoke_key = f"{RL_NAMESPACE_PREFIX}:_smoke:{os.getpid()}"
         value = await client.incr(smoke_key)

--- a/tests/dispatcher/test_valkey_pool.py
+++ b/tests/dispatcher/test_valkey_pool.py
@@ -78,7 +78,7 @@ async def test_pool_prefers_valkey_url(monkeypatch):
         return AsyncMock()
 
     monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
-    await valkey_pool.get_valkey_pool()
+    valkey_pool.get_valkey_pool()
     assert captured["url"] == "redis://valkey-host:6380/3"
     assert captured["kwargs"]["decode_responses"] is True
     assert captured["kwargs"]["max_connections"] == 20
@@ -95,7 +95,7 @@ async def test_pool_falls_back_to_redis_url(monkeypatch):
         "from_url",
         lambda url, **kw: captured.setdefault("url", url) or AsyncMock(),
     )
-    await valkey_pool.get_valkey_pool()
+    valkey_pool.get_valkey_pool()
     assert captured["url"] == "redis://shared:6379/1"
 
 
@@ -110,7 +110,7 @@ async def test_pool_falls_back_to_default(monkeypatch):
         "from_url",
         lambda url, **kw: captured.setdefault("url", url) or AsyncMock(),
     )
-    await valkey_pool.get_valkey_pool()
+    valkey_pool.get_valkey_pool()
     assert captured["url"] == DEFAULT_VALKEY_URL
 
 
@@ -128,9 +128,9 @@ async def test_pool_is_cached_across_calls(monkeypatch):
         return AsyncMock()
 
     monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
-    p1 = await valkey_pool.get_valkey_pool()
-    p2 = await valkey_pool.get_valkey_pool()
-    p3 = await valkey_pool.get_valkey_pool()
+    p1 = valkey_pool.get_valkey_pool()
+    p2 = valkey_pool.get_valkey_pool()
+    p3 = valkey_pool.get_valkey_pool()
     assert p1 is p2 is p3
     assert calls["n"] == 1
 
@@ -147,9 +147,9 @@ async def test_reset_pool_invalidates_cache(monkeypatch):
         return mock_pool
 
     monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
-    await valkey_pool.get_valkey_pool()
+    valkey_pool.get_valkey_pool()
     await reset_valkey_pool()
-    await valkey_pool.get_valkey_pool()
+    valkey_pool.get_valkey_pool()
     assert calls["n"] == 2
 
 
@@ -165,10 +165,7 @@ async def test_smoke_incr_runs_incr_and_expire(monkeypatch):
     mock_client.expire = AsyncMock(return_value=True)
     mock_client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return mock_client
-
-    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", lambda: mock_client)
 
     value = await smoke_incr()
     assert value == 1
@@ -191,10 +188,7 @@ async def test_smoke_incr_returns_post_increment_value(monkeypatch):
     mock_client.expire = AsyncMock(return_value=True)
     mock_client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return mock_client
-
-    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", lambda: mock_client)
     assert await smoke_incr() == 6
 
 
@@ -207,10 +201,7 @@ async def test_smoke_incr_closes_client_even_on_failure(monkeypatch):
     mock_client.expire = AsyncMock()
     mock_client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return mock_client
-
-    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", lambda: mock_client)
     with pytest.raises(ConnectionError):
         await smoke_incr()
     mock_client.aclose.assert_awaited_once()

--- a/tests/dispatcher/test_valkey_pool.py
+++ b/tests/dispatcher/test_valkey_pool.py
@@ -1,0 +1,216 @@
+"""KEI-117A — tests for src/dispatcher/valkey_pool.
+
+Redis client is mocked via AsyncMock so no live Valkey/Redis required
+for CI. Pool state is reset between cases so tests stay independent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.dispatcher import valkey_pool
+from src.dispatcher.valkey_pool import (
+    DEFAULT_VALKEY_URL,
+    RL_NAMESPACE_PREFIX,
+    SMOKE_KEY_TTL_SECONDS,
+    reset_valkey_pool,
+    smoke_incr,
+    tenant_rl_key,
+)
+
+
+@pytest.fixture(autouse=True)
+async def _clean_pool_each_test():
+    """Tear down the module-level pool before AND after each case so URL
+    resolution + caching tests don't bleed into each other."""
+    await reset_valkey_pool()
+    yield
+    await reset_valkey_pool()
+
+
+# ─── tenant_rl_key ─────────────────────────────────────────────────────────
+
+
+def test_tenant_rl_key_format():
+    """Key shape is exactly ``rl:<tenant>:<window>``."""
+    key = tenant_rl_key("cust-abc", 1715900000)
+    assert key == f"{RL_NAMESPACE_PREFIX}:cust-abc:1715900000"
+
+
+def test_tenant_rl_key_coerces_window_to_int():
+    """A float window (e.g. ``time.time()``) is truncated, not rounded —
+    matches the int() cast in the helper."""
+    key = tenant_rl_key("t", 1715900000.987)
+    assert key.endswith(":1715900000")
+
+
+def test_tenant_rl_key_strips_whitespace():
+    """Trailing whitespace on tenant_id is stripped to prevent invisible
+    duplicate buckets ('cust-1 ' vs 'cust-1')."""
+    assert tenant_rl_key("  cust-1  ", 0) == f"{RL_NAMESPACE_PREFIX}:cust-1:0"
+
+
+def test_tenant_rl_key_refuses_empty_tenant():
+    """An empty / whitespace-only tenant_id would silently bucket all
+    requests into one counter — refuse it."""
+    with pytest.raises(ValueError, match="non-empty"):
+        tenant_rl_key("", 0)
+    with pytest.raises(ValueError, match="non-empty"):
+        tenant_rl_key("   ", 0)
+
+
+# ─── pool URL resolution ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pool_prefers_valkey_url(monkeypatch):
+    """VALKEY_URL wins over REDIS_URL."""
+    monkeypatch.setenv("VALKEY_URL", "redis://valkey-host:6380/3")
+    monkeypatch.setenv("REDIS_URL", "redis://redis-host:6379/0")
+
+    captured: dict = {}
+
+    def fake_from_url(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return AsyncMock()
+
+    monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
+    await valkey_pool.get_valkey_pool()
+    assert captured["url"] == "redis://valkey-host:6380/3"
+    assert captured["kwargs"]["decode_responses"] is True
+    assert captured["kwargs"]["max_connections"] == 20
+
+
+@pytest.mark.asyncio
+async def test_pool_falls_back_to_redis_url(monkeypatch):
+    """No VALKEY_URL → REDIS_URL is used."""
+    monkeypatch.delenv("VALKEY_URL", raising=False)
+    monkeypatch.setenv("REDIS_URL", "redis://shared:6379/1")
+    captured: dict = {}
+    monkeypatch.setattr(
+        valkey_pool.ConnectionPool,
+        "from_url",
+        lambda url, **kw: captured.setdefault("url", url) or AsyncMock(),
+    )
+    await valkey_pool.get_valkey_pool()
+    assert captured["url"] == "redis://shared:6379/1"
+
+
+@pytest.mark.asyncio
+async def test_pool_falls_back_to_default(monkeypatch):
+    """No env vars → the local default URL."""
+    monkeypatch.delenv("VALKEY_URL", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    captured: dict = {}
+    monkeypatch.setattr(
+        valkey_pool.ConnectionPool,
+        "from_url",
+        lambda url, **kw: captured.setdefault("url", url) or AsyncMock(),
+    )
+    await valkey_pool.get_valkey_pool()
+    assert captured["url"] == DEFAULT_VALKEY_URL
+
+
+# ─── pool caching ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pool_is_cached_across_calls(monkeypatch):
+    """get_valkey_pool() returns the same pool instance on subsequent
+    calls — ConnectionPool.from_url is invoked exactly once."""
+    calls = {"n": 0}
+
+    def fake_from_url(url, **kw):
+        calls["n"] += 1
+        return AsyncMock()
+
+    monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
+    p1 = await valkey_pool.get_valkey_pool()
+    p2 = await valkey_pool.get_valkey_pool()
+    p3 = await valkey_pool.get_valkey_pool()
+    assert p1 is p2 is p3
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_pool_invalidates_cache(monkeypatch):
+    """After reset_valkey_pool, the next call rebuilds the pool."""
+    calls = {"n": 0}
+
+    def fake_from_url(url, **kw):
+        calls["n"] += 1
+        mock_pool = AsyncMock()
+        mock_pool.aclose = AsyncMock()
+        return mock_pool
+
+    monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
+    await valkey_pool.get_valkey_pool()
+    await reset_valkey_pool()
+    await valkey_pool.get_valkey_pool()
+    assert calls["n"] == 2
+
+
+# ─── smoke_incr ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_smoke_incr_runs_incr_and_expire(monkeypatch):
+    """smoke_incr issues INCR then EXPIRE on a per-process namespaced key
+    and returns the post-INCR integer."""
+    mock_client = AsyncMock()
+    mock_client.incr = AsyncMock(return_value=1)
+    mock_client.expire = AsyncMock(return_value=True)
+    mock_client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return mock_client
+
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+
+    value = await smoke_incr()
+    assert value == 1
+    mock_client.incr.assert_awaited_once()
+    incr_key = mock_client.incr.await_args.args[0]
+    assert incr_key.startswith(f"{RL_NAMESPACE_PREFIX}:_smoke:")
+    mock_client.expire.assert_awaited_once()
+    exp_args = mock_client.expire.await_args.args
+    assert exp_args[0] == incr_key
+    assert exp_args[1] == SMOKE_KEY_TTL_SECONDS
+    mock_client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_smoke_incr_returns_post_increment_value(monkeypatch):
+    """If the smoke key already had 5 (impossible in practice — it has
+    60s TTL — but covered for safety), smoke_incr returns 6."""
+    mock_client = AsyncMock()
+    mock_client.incr = AsyncMock(return_value=6)
+    mock_client.expire = AsyncMock(return_value=True)
+    mock_client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return mock_client
+
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+    assert await smoke_incr() == 6
+
+
+@pytest.mark.asyncio
+async def test_smoke_incr_closes_client_even_on_failure(monkeypatch):
+    """If INCR raises (e.g. transport failure), the client.aclose() must
+    still run so we don't leak a connection from the pool."""
+    mock_client = AsyncMock()
+    mock_client.incr = AsyncMock(side_effect=ConnectionError("valkey unreachable"))
+    mock_client.expire = AsyncMock()
+    mock_client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return mock_client
+
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+    with pytest.raises(ConnectionError):
+        await smoke_incr()
+    mock_client.aclose.assert_awaited_once()


### PR DESCRIPTION
## Summary

Closes KEI-170 (KEI-117A). Foundation for the Part 17 dispatcher rate limiter (KEI-117B / KEI-171). Valkey speaks the Redis wire protocol, so this reuses ``redis.asyncio`` — no new dependency.

Independent of the KEI-162/166 stack — branches off main directly. Not stacked.

## Acceptance (Linear KEI-170)

- [x] **Connection pool live** — lazy ``ConnectionPool.from_url`` with ``decode_responses=True``, ``max_connections=20``.
- [x] **Key namespace documented** — module docstring captures the canonical ``rl:<tenant_id>:<window_start_unix>`` spec; ``tenant_rl_key`` is the only place it's minted.
- [x] **Smoke INCR returns 1** — ``smoke_incr()`` runs ``INCR`` + ``EXPIRE 60`` on a per-pid namespaced key, returns the post-INCR integer.

## Why separate from src/integrations/redis.py

The agency-side Redis client (\`src/integrations/redis.py\`) tenants by ``client_id`` (agency CRM model). The dispatcher product layer tenants by ``customer_id`` (Part 17 customer model). One pool would conflate the two namespaces and make tenant-level rate-limit guarantees impossible. URL fallback chain (\`VALKEY_URL\` → \`REDIS_URL\` → local default) lets dev share one binary while prod can split tenancies onto separate Valkey instances.

## API

\`\`\`python
from src.dispatcher.valkey_pool import (
    get_valkey_pool, get_valkey_client, reset_valkey_pool,
    tenant_rl_key, smoke_incr,
)

# health probe
assert await smoke_incr() >= 1

# rate-limit key minting (used by KEI-117B)
key = tenant_rl_key(\"cust-abc\", int(time.time()) // 60 * 60)  # rl:cust-abc:1715900000
\`\`\`

## Empty-tenant guard

``tenant_rl_key(\"\", N)`` raises ``ValueError`` — a missing tenant_id would silently bucket all requests into a single \`rl::N\` counter, defeating per-tenant isolation. Tested.

## Test plan

- [x] \`pytest tests/dispatcher/test_valkey_pool.py\` — 12/12 passed (redis client AsyncMock'd; no live Valkey for CI).
- [x] \`ruff check\` — All checks passed (first try).
- [x] \`ruff format --check\` — 2 files already formatted (first try).

Coverage:
- \`tenant_rl_key\` format / float-to-int / whitespace strip / empty-refuse
- URL resolution: \`VALKEY_URL\` wins, \`REDIS_URL\` fallback, local default
- Pool caching: \`ConnectionPool.from_url\` invoked exactly once across N \`get_pool\` calls
- \`reset_valkey_pool\` invalidates the cache, next call rebuilds
- \`smoke_incr\`: INCR+EXPIRE on namespaced key, returns post-INCR int
- \`smoke_incr\` connection-leak guard: \`client.aclose()\` runs even if INCR raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)