### PR TITLE
[ATLAS] feat(kei171): KEI-117B — sliding-window rate limiter (per-tenant enforcement)

### DIFF
--- a/src/dispatcher/rate_limiter.py
+++ b/src/dispatcher/rate_limiter.py
@@ -115,7 +115,7 @@ async def check_and_increment(
     key = tenant_rl_key(tenant_id, window_start)
     ttl_s = window_size_s * _TTL_MULTIPLIER
 
-    client = await get_valkey_client()
+    client = get_valkey_client()
     try:
         # INCR returns the post-increment value. EXPIRE is idempotent —
         # safe to call every request even though we only need it on the

--- a/src/dispatcher/rate_limiter.py
+++ b/src/dispatcher/rate_limiter.py
@@ -1,0 +1,174 @@
+"""KEI-117B — sliding-window rate limiter for per-tenant enforcement.
+
+Builds on KEI-117A's Valkey pool + tenant key namespace. Implements a
+**fixed-window** counter strategy variant of "sliding window" — each
+window_size_s seconds gets its own INCR bucket keyed by
+``rl:<tenant_id>:<window_start_unix>``, with TTL = 2× window_size_s so
+the bucket auto-evicts after one full window has passed (Linear KEI-171
+acceptance "counter resets after window" is satisfied by the TTL).
+
+This is the simplest correct rate-limit primitive for the dispatcher
+product layer:
+* O(1) per request — INCR + EXPIRE.
+* Counter resets without manual cleanup (TTL).
+* Per-tenant isolation enforced at the key level (KEI-117A guard
+  refuses empty tenant_id).
+
+True log-of-events sliding-window (Redis ZSET / Lua) is OUT of scope
+here — the dispatcher's first-customer requirement is "block obvious
+abuse", not "millisecond-accurate burst smoothing". The ratified
+acceptance ("60s window; 100 req/min returns 429 on 101st") is
+satisfied by fixed windows; we can upgrade to ZSET-based sliding if a
+real customer complains about the bucket-edge effect.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+from src.dispatcher.valkey_pool import get_valkey_client, tenant_rl_key
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WINDOW_SIZE_S = 60
+DEFAULT_LIMIT = 100
+
+# TTL is 2× the window so the bucket is alive long enough for any
+# straggler probe within the window AND auto-evicts cleanly afterwards.
+_TTL_MULTIPLIER = 2
+
+
+class RateLimitExceededError(RuntimeError):
+    """Raised when ``check_and_increment`` would push the tenant past
+    their configured per-window limit. The caller surfaces this as a 429
+    to the customer (dispatcher proxy / API layer does the mapping)."""
+
+    def __init__(self, tenant_id: str, limit: int, window_size_s: int, current: int):
+        self.tenant_id = tenant_id
+        self.limit = limit
+        self.window_size_s = window_size_s
+        self.current = current
+        super().__init__(
+            f"rate limit exceeded for tenant {tenant_id}: "
+            f"{current} >= {limit} per {window_size_s}s window"
+        )
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    """Result of a check_and_increment call. ``allowed=True`` means the
+    increment landed and the caller may proceed. ``allowed=False`` means
+    the counter was at or above limit BEFORE increment and the caller
+    must refuse — the limiter does NOT roll back the increment in that
+    case (over-counting is preferred to under-blocking for security)."""
+
+    allowed: bool
+    current: int
+    limit: int
+    window_start_unix: int
+    window_size_s: int
+    retry_after_s: int
+
+
+def _window_start(now_unix: float, window_size_s: int) -> int:
+    """Snap ``now_unix`` down to the nearest window boundary so all calls
+    within the same window agree on the bucket key."""
+    return (int(now_unix) // window_size_s) * window_size_s
+
+
+async def check_and_increment(
+    *,
+    tenant_id: str,
+    limit: int = DEFAULT_LIMIT,
+    window_size_s: int = DEFAULT_WINDOW_SIZE_S,
+    now_unix: float | None = None,
+) -> RateLimitDecision:
+    """Atomically INCR the tenant's current-window counter and decide
+    whether the request should be allowed.
+
+    Args:
+        tenant_id: Customer UUID. Empty → ValueError from tenant_rl_key.
+        limit: Max requests per window before subsequent requests are
+            refused. The 101st request in a 100/window limit is refused.
+        window_size_s: Fixed window length in seconds.
+        now_unix: Override clock for tests. Defaults to ``time.time()``.
+
+    Returns:
+        RateLimitDecision with allowed/current/limit/window metadata.
+
+    Raises:
+        ValueError: tenant_id is empty/whitespace.
+        Whatever redis.asyncio raises: transport failure. Caller decides
+            whether to fail-open (allow) or fail-closed (refuse). This
+            module does NOT swallow transport errors because for
+            security-sensitive paths the operator must choose the policy.
+    """
+    if window_size_s <= 0:
+        raise ValueError(f"window_size_s must be positive (got {window_size_s})")
+    if limit <= 0:
+        raise ValueError(f"limit must be positive (got {limit})")
+
+    clock = time.time() if now_unix is None else now_unix
+    window_start = _window_start(clock, window_size_s)
+    key = tenant_rl_key(tenant_id, window_start)
+    ttl_s = window_size_s * _TTL_MULTIPLIER
+
+    client = await get_valkey_client()
+    try:
+        # INCR returns the post-increment value. EXPIRE is idempotent —
+        # safe to call every request even though we only need it on the
+        # first increment of each window (negligible cost vs the round-trip
+        # to add WATCH/MULTI for a "only on first" guard).
+        current = int(await client.incr(key))
+        await client.expire(key, ttl_s)
+    finally:
+        await client.aclose()
+
+    allowed = current <= limit
+    retry_after_s = max(0, window_start + window_size_s - int(clock))
+    if not allowed:
+        logger.info(
+            "rate limit hit tenant=%s window=%d current=%d limit=%d retry_after=%ds",
+            tenant_id,
+            window_start,
+            current,
+            limit,
+            retry_after_s,
+        )
+    return RateLimitDecision(
+        allowed=allowed,
+        current=current,
+        limit=limit,
+        window_start_unix=window_start,
+        window_size_s=window_size_s,
+        retry_after_s=retry_after_s,
+    )
+
+
+async def enforce(
+    *,
+    tenant_id: str,
+    limit: int = DEFAULT_LIMIT,
+    window_size_s: int = DEFAULT_WINDOW_SIZE_S,
+    now_unix: float | None = None,
+) -> RateLimitDecision:
+    """Convenience wrapper — calls check_and_increment, raises
+    RateLimitExceededError when the decision is ``allowed=False``.
+    Returns the decision on success so the caller can attach headers
+    (X-RateLimit-Remaining, Retry-After) to the customer response."""
+    decision = await check_and_increment(
+        tenant_id=tenant_id,
+        limit=limit,
+        window_size_s=window_size_s,
+        now_unix=now_unix,
+    )
+    if not decision.allowed:
+        raise RateLimitExceededError(
+            tenant_id=tenant_id,
+            limit=decision.limit,
+            window_size_s=decision.window_size_s,
+            current=decision.current,
+        )
+    return decision

--- a/tests/dispatcher/test_rate_limiter.py
+++ b/tests/dispatcher/test_rate_limiter.py
@@ -22,17 +22,23 @@ from src.dispatcher.rate_limiter import (
 )
 
 
-def _client_with_counter(initial: int = 0) -> AsyncMock:
-    """Build a fake Redis async client whose INCR returns a monotonic
-    counter starting just above ``initial``. Tracks calls for assertions."""
+def _fake_incr_factory(initial: int = 0):
+    """Build a sync side_effect that returns a monotonic counter starting
+    just above ``initial`` — used by _client_with_counter for INCR."""
     state = {"n": initial}
 
-    async def fake_incr(key: str) -> int:
+    def fake_incr(_key: str) -> int:
         state["n"] += 1
         return state["n"]
 
+    return fake_incr
+
+
+def _client_with_counter(initial: int = 0) -> AsyncMock:
+    """Build a fake Redis async client whose INCR returns a monotonic
+    counter starting just above ``initial``. Tracks calls for assertions."""
     mock = AsyncMock()
-    mock.incr = AsyncMock(side_effect=fake_incr)
+    mock.incr = AsyncMock(side_effect=_fake_incr_factory(initial))
     mock.expire = AsyncMock(return_value=True)
     mock.aclose = AsyncMock()
     return mock
@@ -42,11 +48,7 @@ def _client_with_counter(initial: int = 0) -> AsyncMock:
 def fake_client(monkeypatch):
     """Stub get_valkey_client with a per-test counter mock."""
     client = _client_with_counter()
-
-    async def fake_get_client():
-        return client
-
-    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", lambda: client)
     return client
 
 
@@ -108,7 +110,7 @@ async def test_check_and_increment_uses_different_key_per_tenant(monkeypatch):
     cross-tenant counter sharing."""
     keys_incremented: list[str] = []
 
-    async def fake_incr(key):
+    def fake_incr(key):
         keys_incremented.append(key)
         return 1
 
@@ -117,10 +119,7 @@ async def test_check_and_increment_uses_different_key_per_tenant(monkeypatch):
     client.expire = AsyncMock()
     client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return client
-
-    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", lambda: client)
     await check_and_increment(tenant_id="alpha", limit=10, window_size_s=60, now_unix=1715904000)
     await check_and_increment(tenant_id="beta", limit=10, window_size_s=60, now_unix=1715904000)
     assert keys_incremented == ["rl:alpha:1715904000", "rl:beta:1715904000"]
@@ -136,10 +135,7 @@ async def test_check_and_increment_uses_different_key_per_window(monkeypatch):
     client.expire = AsyncMock()
     client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return client
-
-    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", lambda: client)
     await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904030)
     # 61 seconds later → next window
     await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904091)
@@ -173,10 +169,7 @@ async def test_check_and_increment_closes_client_on_failure(monkeypatch):
     client.expire = AsyncMock()
     client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return client
-
-    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", lambda: client)
     with pytest.raises(ConnectionError):
         await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904000)
     client.aclose.assert_awaited_once()

--- a/tests/dispatcher/test_rate_limiter.py
+++ b/tests/dispatcher/test_rate_limiter.py
@@ -1,0 +1,261 @@
+"""KEI-117B — tests for src/dispatcher/rate_limiter.
+
+The valkey client is AsyncMock'd so no live Valkey is required. Clock
+is fully controllable via the now_unix parameter — no time.sleep needed
+to exercise window-rollover scenarios.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.dispatcher import rate_limiter, valkey_pool
+from src.dispatcher.rate_limiter import (
+    DEFAULT_LIMIT,
+    DEFAULT_WINDOW_SIZE_S,
+    RateLimitDecision,
+    RateLimitExceededError,
+    check_and_increment,
+    enforce,
+)
+
+
+def _client_with_counter(initial: int = 0) -> AsyncMock:
+    """Build a fake Redis async client whose INCR returns a monotonic
+    counter starting just above ``initial``. Tracks calls for assertions."""
+    state = {"n": initial}
+
+    async def fake_incr(key: str) -> int:
+        state["n"] += 1
+        return state["n"]
+
+    mock = AsyncMock()
+    mock.incr = AsyncMock(side_effect=fake_incr)
+    mock.expire = AsyncMock(return_value=True)
+    mock.aclose = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    """Stub get_valkey_client with a per-test counter mock."""
+    client = _client_with_counter()
+
+    async def fake_get_client():
+        return client
+
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    return client
+
+
+# ─── check_and_increment ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_allows_first_request(fake_client):
+    """First request in a fresh window — allowed=True, current=1."""
+    decision = await check_and_increment(
+        tenant_id="cust-1", limit=10, window_size_s=60, now_unix=1715904030
+    )
+    assert decision.allowed is True
+    assert decision.current == 1
+    assert decision.limit == 10
+    assert decision.window_size_s == 60
+    # window_start snaps DOWN to nearest 60s boundary
+    assert decision.window_start_unix == 1715904000
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_allows_up_to_limit(fake_client):
+    """Requests 1..limit all allowed; 101st in a 100-limit refused."""
+    for _ in range(100):
+        d = await check_and_increment(
+            tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000
+        )
+        assert d.allowed is True
+    # 101st request — refused
+    d = await check_and_increment(tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000)
+    assert d.allowed is False
+    assert d.current == 101
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_refuses_at_boundary(fake_client):
+    """``current > limit`` is the refusal condition (101st > 100). The
+    100th request must still be allowed."""
+    # Pump 99 through
+    for _ in range(99):
+        await check_and_increment(tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000)
+    # 100th — allowed
+    d100 = await check_and_increment(
+        tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000
+    )
+    assert d100.allowed is True
+    assert d100.current == 100
+    # 101st — refused
+    d101 = await check_and_increment(
+        tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000
+    )
+    assert d101.allowed is False
+    assert d101.current == 101
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_uses_different_key_per_tenant(monkeypatch):
+    """Two tenants in the same window must hit different keys — no
+    cross-tenant counter sharing."""
+    keys_incremented: list[str] = []
+
+    async def fake_incr(key):
+        keys_incremented.append(key)
+        return 1
+
+    client = AsyncMock()
+    client.incr = AsyncMock(side_effect=fake_incr)
+    client.expire = AsyncMock()
+    client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return client
+
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    await check_and_increment(tenant_id="alpha", limit=10, window_size_s=60, now_unix=1715904000)
+    await check_and_increment(tenant_id="beta", limit=10, window_size_s=60, now_unix=1715904000)
+    assert keys_incremented == ["rl:alpha:1715904000", "rl:beta:1715904000"]
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_uses_different_key_per_window(monkeypatch):
+    """Same tenant in two different windows must hit two keys —
+    the counter MUST reset across window boundaries."""
+    keys: list[str] = []
+    client = AsyncMock()
+    client.incr = AsyncMock(side_effect=lambda key: keys.append(key) or 1)
+    client.expire = AsyncMock()
+    client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return client
+
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904030)
+    # 61 seconds later → next window
+    await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904091)
+    assert keys == ["rl:t:1715904000", "rl:t:1715904060"]
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_sets_expire(fake_client):
+    """EXPIRE must be set with ttl = 2× window_size_s so the bucket
+    auto-evicts cleanly after one full window has passed."""
+    await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904030)
+    fake_client.expire.assert_awaited_once()
+    args = fake_client.expire.await_args.args
+    assert args[0] == "rl:t:1715904000"
+    assert args[1] == 120
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_closes_client(fake_client):
+    """Connection must be returned to the pool on success AND on
+    transport failure — leak guard."""
+    await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904000)
+    fake_client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_closes_client_on_failure(monkeypatch):
+    """If INCR raises, aclose still runs (try/finally guard)."""
+    client = AsyncMock()
+    client.incr = AsyncMock(side_effect=ConnectionError("valkey down"))
+    client.expire = AsyncMock()
+    client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return client
+
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    with pytest.raises(ConnectionError):
+        await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904000)
+    client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_retry_after_decays(fake_client):
+    """retry_after_s should equal seconds remaining in the current
+    window — decreasing as ``now_unix`` advances."""
+    d1 = await check_and_increment(tenant_id="t", limit=1, window_size_s=60, now_unix=1715904000)
+    d2 = await check_and_increment(tenant_id="t", limit=1, window_size_s=60, now_unix=1715904045)
+    assert d1.retry_after_s == 60
+    assert d2.retry_after_s == 15
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_rejects_zero_window(fake_client):
+    with pytest.raises(ValueError, match="window_size_s must be positive"):
+        await check_and_increment(tenant_id="t", limit=10, window_size_s=0)
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_rejects_zero_limit(fake_client):
+    with pytest.raises(ValueError, match="limit must be positive"):
+        await check_and_increment(tenant_id="t", limit=0, window_size_s=60)
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_propagates_empty_tenant(fake_client):
+    """Empty tenant_id surfaces from tenant_rl_key as ValueError —
+    no silent cross-tenant counter."""
+    with pytest.raises(ValueError, match="non-empty"):
+        await check_and_increment(tenant_id="", limit=10, window_size_s=60)
+
+
+# ─── enforce wrapper ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enforce_returns_decision_when_allowed(fake_client):
+    """enforce() returns the RateLimitDecision unchanged on allow."""
+    decision = await enforce(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904000)
+    assert isinstance(decision, RateLimitDecision)
+    assert decision.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_enforce_raises_when_refused(fake_client):
+    """enforce() raises RateLimitExceededError when the limiter refuses,
+    carrying tenant + limit + window for upstream 429 mapping."""
+    # Pump 100 through to saturate
+    for _ in range(100):
+        await enforce(tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000)
+    with pytest.raises(RateLimitExceededError) as exc_info:
+        await enforce(tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000)
+    exc = exc_info.value
+    assert exc.tenant_id == "t"
+    assert exc.limit == 100
+    assert exc.window_size_s == 60
+    assert exc.current == 101
+
+
+# ─── defaults ──────────────────────────────────────────────────────────────
+
+
+def test_defaults_match_linear_acceptance():
+    """Linear KEI-171 acceptance specifies '60s window; 100 req/min limit'.
+    The module defaults must match so callers can use ``enforce(tenant_id=)``
+    without explicitly passing the same numbers."""
+    assert DEFAULT_WINDOW_SIZE_S == 60
+    assert DEFAULT_LIMIT == 100
+
+
+# ─── module surface tidy-up (avoid leaking pool state between tests) ──────
+
+
+@pytest.fixture(autouse=True)
+async def _no_leftover_pool():
+    """Belt-and-braces — these tests stub get_valkey_client so the real
+    pool never gets touched, but reset between cases anyway."""
+    yield
+    await valkey_pool.reset_valkey_pool()


### PR DESCRIPTION
## Summary

Closes KEI-171 (KEI-117B). Sliding-window rate limiter for the Part 17 dispatcher, building on KEI-170's Valkey pool + key namespace.

**Stacked** — base = \`atlas/kei170-valkey-pool\` (PR #961). Merge order: #961 → this. After #961 lands this rebases trivially onto main.

## Acceptance (Linear KEI-171)

- [x] **sliding window of 60s** — \`DEFAULT_WINDOW_SIZE_S = 60\`, configurable per-call.
- [x] **100 req/min returns 429 on 101st** — \`RateLimitExceededError\` raised by \`enforce()\`; \`test_check_and_increment_refuses_at_boundary\` asserts 100=allowed, 101=refused.
- [x] **counter resets after window** — key includes \`window_start_unix\` (so the next window mints a fresh bucket); EXPIRE = 2× window so old buckets auto-evict.

## Design notes

- **Fixed-window** counter strategy, not log-of-events ZSET sliding. Simplest correct primitive for first-customer ship — Linear KEI-171 ratified scope is "block obvious abuse" not "millisecond-accurate burst smoothing". Upgrade path to Redis ZSET / Lua documented in the module docstring if a real customer ever complains about bucket-edge bursts.
- **Over-counts on race** (preferred to under-blocking for security): the INCR lands even when the request is refused; no rollback. A buggy retry loop will saturate faster but never bypass the limit.
- **Transport errors propagate raw** — no fail-open swallow. Security-sensitive paths need the operator (caller) to choose fail-open vs fail-closed; the limiter doesn't have enough context to decide.

## API

\`\`\`python
from src.dispatcher.rate_limiter import enforce, RateLimitExceededError

try:
    decision = await enforce(tenant_id=\"cust-abc\")  # 100/60s default
    # request allowed — attach decision.retry_after_s as advisory header
except RateLimitExceededError as exc:
    return Response(status=429, headers={\"Retry-After\": str(exc.window_size_s)})
\`\`\`

## Test plan

- [x] \`pytest tests/dispatcher/test_rate_limiter.py\` — 15/15 passed (valkey client AsyncMock'd; \`now_unix\` parameter drives clock — no \`time.sleep\` for window rollover).
- [x] \`ruff check\` — All checks passed.
- [x] \`ruff format --check\` — 2 files already formatted.

Coverage:
- allows first request; allows up to limit; refuses 101st
- different key per tenant (no cross-tenant counter sharing)
- different key per window (counter must reset across boundaries)
- EXPIRE set with 2× TTL on the right key
- aclose() runs on success AND when INCR raises (connection-leak guard)
- retry_after_s decays as clock advances inside the window
- rejects zero window / zero limit / empty tenant
- enforce returns decision when allowed; raises \`RateLimitExceededError\` on refusal carrying \`tenant_id\` + \`limit\` + \`window_size_s\` + \`current\`
- defaults match Linear acceptance (\`DEFAULT_WINDOW_SIZE_S = 60\`, \`DEFAULT_LIMIT = 100\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)