### PR TITLE
[SCOUT] feat(kei161): ThreadUsageGauge component shell + useThreadUsage hook stub

### DIFF
--- a/frontend/components/dispatcher/__tests__/thread-usage-gauge.test.tsx
+++ b/frontend/components/dispatcher/__tests__/thread-usage-gauge.test.tsx
@@ -10,8 +10,8 @@ import { render, screen } from "@testing-library/react";
 
 import { ThreadUsageGauge, type ThreadUsage } from "../thread-usage-gauge";
 
-const _half: ThreadUsage = { active: 5, ceiling: 10, tier: "starter" };
-const _atCeiling: ThreadUsage = { active: 10, ceiling: 10, tier: "growth" };
+const _half: ThreadUsage = { active: 5, ceiling: 10, tier: "basic" };
+const _atCeiling: ThreadUsage = { active: 10, ceiling: 10, tier: "pro" };
 const _enterprise: ThreadUsage = { active: 1, ceiling: 1000, tier: "enterprise" };
 
 describe("ThreadUsageGauge", () => {
@@ -34,25 +34,27 @@ describe("ThreadUsageGauge", () => {
     render(<ThreadUsageGauge usage={_half} />);
     expect(screen.getByTestId("thread-usage-gauge")).toBeInTheDocument();
     expect(screen.getByText("5 / 10 threads")).toBeInTheDocument();
-    expect(screen.getByText("Starter")).toBeInTheDocument();
+    expect(screen.getByText("Basic")).toBeInTheDocument();
   });
 
   test("sets data-tier attribute to the usage.tier value", () => {
     render(<ThreadUsageGauge usage={_enterprise} />);
-    const gauge = screen.getByTestId("thread-usage-gauge");
-    expect(gauge.getAttribute("data-tier")).toBe("enterprise");
+    const gauge = screen.getByTestId("thread-usage-gauge") as HTMLElement;
+    expect(gauge.dataset.tier).toBe("enterprise");
   });
 
   test("shows at-ceiling banner when active >= ceiling", () => {
     render(<ThreadUsageGauge usage={_atCeiling} />);
     expect(screen.getByTestId("thread-usage-at-ceiling")).toBeInTheDocument();
-    expect(screen.getByTestId("thread-usage-gauge").getAttribute("data-at-ceiling")).toBe("true");
+    const gauge = screen.getByTestId("thread-usage-gauge") as HTMLElement;
+    expect(gauge.dataset.atCeiling).toBe("true");
   });
 
   test("hides at-ceiling banner when below ceiling", () => {
     render(<ThreadUsageGauge usage={_half} />);
     expect(screen.queryByTestId("thread-usage-at-ceiling")).toBeNull();
-    expect(screen.getByTestId("thread-usage-gauge").getAttribute("data-at-ceiling")).toBe("false");
+    const gauge = screen.getByTestId("thread-usage-gauge") as HTMLElement;
+    expect(gauge.dataset.atCeiling).toBe("false");
   });
 
   test("renders Progress bar element via data-testid pass-through", () => {
@@ -61,14 +63,14 @@ describe("ThreadUsageGauge", () => {
   });
 
   test("ceiling=0 edge case renders without divide-by-zero (pct clamps to 0)", () => {
-    const broken: ThreadUsage = { active: 0, ceiling: 0, tier: "free" };
+    const broken: ThreadUsage = { active: 0, ceiling: 0, tier: "basic" };
     render(<ThreadUsageGauge usage={broken} />);
     // active 0 >= ceiling 0 — at-ceiling banner shows
     expect(screen.getByTestId("thread-usage-at-ceiling")).toBeInTheDocument();
   });
 
   test("active > ceiling (burst race) clamps display to ceiling-equivalent banner", () => {
-    const burst: ThreadUsage = { active: 15, ceiling: 10, tier: "scale" };
+    const burst: ThreadUsage = { active: 15, ceiling: 10, tier: "basic" };
     render(<ThreadUsageGauge usage={burst} />);
     expect(screen.getByText("15 / 10 threads")).toBeInTheDocument();
     expect(screen.getByTestId("thread-usage-at-ceiling")).toBeInTheDocument();

--- a/frontend/components/dispatcher/__tests__/thread-usage-gauge.test.tsx
+++ b/frontend/components/dispatcher/__tests__/thread-usage-gauge.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for ThreadUsageGauge component shell (KEI-161).
+ *
+ * Render-path-only — sub-KEI claimer extends with realtime + tier-ceiling
+ * lookup tests once useThreadUsage is implemented.
+ */
+
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ThreadUsageGauge, type ThreadUsage } from "../thread-usage-gauge";
+
+const _half: ThreadUsage = { active: 5, ceiling: 10, tier: "starter" };
+const _atCeiling: ThreadUsage = { active: 10, ceiling: 10, tier: "growth" };
+const _enterprise: ThreadUsage = { active: 1, ceiling: 1000, tier: "enterprise" };
+
+describe("ThreadUsageGauge", () => {
+  test("renders loading-state when loading=true", () => {
+    render(<ThreadUsageGauge usage={null} loading />);
+    expect(screen.getByTestId("thread-usage-loading")).toBeInTheDocument();
+  });
+
+  test("renders custom loadingLabel override", () => {
+    render(<ThreadUsageGauge usage={null} loading loadingLabel="fetching…" />);
+    expect(screen.getByText("fetching…")).toBeInTheDocument();
+  });
+
+  test("renders empty-state when usage is null and not loading", () => {
+    render(<ThreadUsageGauge usage={null} />);
+    expect(screen.getByTestId("thread-usage-empty")).toBeInTheDocument();
+  });
+
+  test("renders active / ceiling text + tier label when usage populated", () => {
+    render(<ThreadUsageGauge usage={_half} />);
+    expect(screen.getByTestId("thread-usage-gauge")).toBeInTheDocument();
+    expect(screen.getByText("5 / 10 threads")).toBeInTheDocument();
+    expect(screen.getByText("Starter")).toBeInTheDocument();
+  });
+
+  test("sets data-tier attribute to the usage.tier value", () => {
+    render(<ThreadUsageGauge usage={_enterprise} />);
+    const gauge = screen.getByTestId("thread-usage-gauge");
+    expect(gauge.getAttribute("data-tier")).toBe("enterprise");
+  });
+
+  test("shows at-ceiling banner when active >= ceiling", () => {
+    render(<ThreadUsageGauge usage={_atCeiling} />);
+    expect(screen.getByTestId("thread-usage-at-ceiling")).toBeInTheDocument();
+    expect(screen.getByTestId("thread-usage-gauge").getAttribute("data-at-ceiling")).toBe("true");
+  });
+
+  test("hides at-ceiling banner when below ceiling", () => {
+    render(<ThreadUsageGauge usage={_half} />);
+    expect(screen.queryByTestId("thread-usage-at-ceiling")).toBeNull();
+    expect(screen.getByTestId("thread-usage-gauge").getAttribute("data-at-ceiling")).toBe("false");
+  });
+
+  test("renders Progress bar element via data-testid pass-through", () => {
+    render(<ThreadUsageGauge usage={_half} />);
+    expect(screen.getByTestId("thread-usage-bar")).toBeInTheDocument();
+  });
+
+  test("ceiling=0 edge case renders without divide-by-zero (pct clamps to 0)", () => {
+    const broken: ThreadUsage = { active: 0, ceiling: 0, tier: "free" };
+    render(<ThreadUsageGauge usage={broken} />);
+    // active 0 >= ceiling 0 — at-ceiling banner shows
+    expect(screen.getByTestId("thread-usage-at-ceiling")).toBeInTheDocument();
+  });
+
+  test("active > ceiling (burst race) clamps display to ceiling-equivalent banner", () => {
+    const burst: ThreadUsage = { active: 15, ceiling: 10, tier: "scale" };
+    render(<ThreadUsageGauge usage={burst} />);
+    expect(screen.getByText("15 / 10 threads")).toBeInTheDocument();
+    expect(screen.getByTestId("thread-usage-at-ceiling")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/dispatcher/thread-usage-gauge.tsx
+++ b/frontend/components/dispatcher/thread-usage-gauge.tsx
@@ -1,0 +1,94 @@
+/**
+ * FILE: frontend/components/dispatcher/thread-usage-gauge.tsx
+ * PURPOSE: Customer-facing thread-usage gauge for the Dispatcher dashboard.
+ *          Shows current concurrent thread count vs the tenant's tier
+ *          ceiling. Sub-KEI claimer wires the Valkey-backed live count
+ *          (acceptance: updates within 5s of consumption).
+ * KEI: 161 (Part 17.4 sub-KEI of KEI-114 dashboard MVP).
+ *
+ * Stub: typed component shell + props interface. Renders the shadcn
+ * Progress primitive at `(active / ceiling) * 100`. Data layer is the
+ * companion useThreadUsage hook stub. No realtime — sub-KEI implements.
+ */
+
+import * as React from "react";
+import { Progress } from "../ui/progress";
+
+export type DispatcherTier = "free" | "starter" | "growth" | "scale" | "enterprise";
+
+export interface ThreadUsage {
+  /** Live count of concurrent threads currently consumed by this tenant. */
+  active: number;
+  /** Hard ceiling for the tenant's current tier. */
+  ceiling: number;
+  /** Tier the tenant is on (display only — does NOT affect the bar math). */
+  tier: DispatcherTier;
+}
+
+export interface ThreadUsageGaugeProps {
+  usage: ThreadUsage | null;
+  loading?: boolean;
+  loadingLabel?: string;
+}
+
+const TIER_LABEL: Record<DispatcherTier, string> = {
+  free: "Free",
+  starter: "Starter",
+  growth: "Growth",
+  scale: "Scale",
+  enterprise: "Enterprise",
+};
+
+function _pct(usage: ThreadUsage): number {
+  if (usage.ceiling <= 0) return 0;
+  const raw = (usage.active / usage.ceiling) * 100;
+  // Cap at 100 so we don't visually overflow on burst-then-drain races.
+  return Math.min(100, Math.max(0, raw));
+}
+
+export function ThreadUsageGauge({
+  usage,
+  loading = false,
+  loadingLabel = "Loading thread usage…",
+}: Readonly<ThreadUsageGaugeProps>) {
+  if (loading) {
+    return (
+      <div
+        data-testid="thread-usage-loading"
+        className="py-4 text-sm text-muted-foreground"
+      >
+        {loadingLabel}
+      </div>
+    );
+  }
+  if (usage === null) {
+    return (
+      <div data-testid="thread-usage-empty" className="py-4 text-sm text-muted-foreground">
+        No usage data yet.
+      </div>
+    );
+  }
+  const pct = _pct(usage);
+  const isAtCeiling = usage.active >= usage.ceiling;
+  return (
+    <div
+      data-testid="thread-usage-gauge"
+      data-tier={usage.tier}
+      data-at-ceiling={isAtCeiling}
+      className="space-y-2 py-2"
+    >
+      <div className="flex items-baseline justify-between text-sm">
+        <span className="font-medium">
+          {usage.active} / {usage.ceiling} threads
+        </span>
+        <span className="text-muted-foreground">{TIER_LABEL[usage.tier]}</span>
+      </div>
+      <Progress value={pct} data-testid="thread-usage-bar" />
+      {isAtCeiling ? (
+        <p data-testid="thread-usage-at-ceiling" className="text-xs text-destructive">
+          At tier ceiling — new threads queue or fail until a slot frees.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/components/dispatcher/thread-usage-gauge.tsx
+++ b/frontend/components/dispatcher/thread-usage-gauge.tsx
@@ -14,7 +14,10 @@
 import * as React from "react";
 import { Progress } from "../ui/progress";
 
-export type DispatcherTier = "free" | "starter" | "growth" | "scale" | "enterprise";
+// Aligned with backend contract:
+//   src/dispatcher/tier_limits.py        Tier = Literal["basic", "pro", "enterprise"]
+//   customer_subscriptions_tier_chk      CHECK (tier_code IN ('basic','pro','enterprise'))
+export type DispatcherTier = "basic" | "pro" | "enterprise";
 
 export interface ThreadUsage {
   /** Live count of concurrent threads currently consumed by this tenant. */
@@ -32,10 +35,8 @@ export interface ThreadUsageGaugeProps {
 }
 
 const TIER_LABEL: Record<DispatcherTier, string> = {
-  free: "Free",
-  starter: "Starter",
-  growth: "Growth",
-  scale: "Scale",
+  basic: "Basic",
+  pro: "Pro",
   enterprise: "Enterprise",
 };
 

--- a/frontend/components/dispatcher/use-thread-usage.ts
+++ b/frontend/components/dispatcher/use-thread-usage.ts
@@ -1,0 +1,52 @@
+/**
+ * FILE: frontend/components/dispatcher/use-thread-usage.ts
+ * PURPOSE: Hook contract for ThreadUsageGauge data loading. Sub-KEI claimer
+ *          implements the Valkey-backed live count (subscribe to the tenant
+ *          channel via a backend SSE endpoint or supabase realtime); this
+ *          stub fixes the result shape so the gauge can compose against a
+ *          stable interface.
+ * KEI: 161 (Thread usage gauge) — data layer; depends on KEI-117A
+ *      (Valkey connection pool + per-tenant key namespace).
+ *
+ * Stub: returns null usage + loading=false. Replace with live subscription
+ * + a "tier ceiling" lookup against `public.tenants.tier` (or whatever
+ * KEI-117C tier-limits-from-database lands).
+ */
+
+import type { DispatcherTier, ThreadUsage } from "./thread-usage-gauge";
+
+export interface UseThreadUsageOptions {
+  /** Tenant id whose thread count to watch. When omitted the hook expects
+   *  the live implementation to derive it from the Supabase session. */
+  tenantId?: string;
+  /** Force a fixed tier for testing — production reads from the tenant row. */
+  tier?: DispatcherTier;
+  /** Poll interval (ms) used when realtime is unavailable. */
+  pollMs?: number;
+}
+
+export interface UseThreadUsageResult {
+  usage: ThreadUsage | null;
+  loading: boolean;
+  error: Error | null;
+  reload: () => void;
+}
+
+const DEFAULT_RESULT: UseThreadUsageResult = {
+  usage: null,
+  loading: false,
+  error: null,
+  reload: () => {},
+};
+
+export function useThreadUsage(_opts: UseThreadUsageOptions = {}): UseThreadUsageResult {
+  // Stub — sub-KEI implements:
+  //   - Live count: subscribe to backend SSE or supabase realtime channel
+  //     keyed by tenant id (KEI-117A namespace);
+  //   - Tier ceiling: SELECT tier FROM public.tenants WHERE id = <tenant_id>,
+  //     then look up ceiling via KEI-117C tier-limits table;
+  //   - Poll fallback when realtime drops: every pollMs (default 5000)
+  //     re-fetch active count from Valkey via backend endpoint;
+  //   - Cleanup on unmount.
+  return DEFAULT_RESULT;
+}


### PR DESCRIPTION
## Summary

KEI-161 (Part 17.4 sub-KEI of KEI-114 dashboard MVP): customer-facing thread usage gauge — current concurrent count vs tier ceiling. Render-path complete; data layer stubbed for sub-KEI claimer to wire Valkey-backed live count.

**Linear:** [KEI-161](https://linear.app/keiracom/issue/KEI-161) · **Branch:** off `d879c2fed` (post-#957 merge)

## What lands (3 files)

| File | Purpose |
|---|---|
| `frontend/components/dispatcher/thread-usage-gauge.tsx` | `<ThreadUsageGauge usage=...>` — shadcn Progress at `(active/ceiling)*100`, tier badge, at-ceiling banner |
| `frontend/components/dispatcher/use-thread-usage.ts` | Hook contract `{ usage, loading, error, reload }` — sub-KEI implements |
| `frontend/components/dispatcher/__tests__/thread-usage-gauge.test.tsx` | 10 render tests — vitest + @testing-library/react |

## States covered

- `loading=true` → loading text (override via `loadingLabel` prop)
- `usage=null` → empty-state text
- populated → tier label + `active / ceiling threads` text + Progress bar at clamped pct
- `active >= ceiling` → at-ceiling banner shown (data-at-ceiling attr)
- `ceiling=0` edge case → pct clamps to 0, banner shown (defensive)
- `active > ceiling` (burst race) → display shows raw values but bar clamped to 100%

## TypeScript shape

```ts
export type DispatcherTier = "free" | "starter" | "growth" | "scale" | "enterprise";

export interface ThreadUsage {
  active: number;
  ceiling: number;
  tier: DispatcherTier;
}
```

Per-row data-attrs (`data-tier`, `data-at-ceiling`) let realtime updates target the gauge without re-rendering siblings.

## Pre-emptive Sonar S6759

`Readonly<ThreadUsageGaugeProps>` already wrapped on the function signature — same lesson Max raised on #957.

## Out of scope (sub-KEI)

- Valkey live count: subscribe to backend SSE / supabase realtime channel keyed by tenant id (KEI-117A namespace)
- Tier ceiling lookup: `SELECT tier FROM public.tenants WHERE id = <session.user.tenant_id>` + KEI-117C tier-limits table
- Poll fallback when realtime drops (every `pollMs`, default 5000)
- RLS scoping (depends on KEI-111B auth)
- Cleanup on unmount

## Pattern context

Matches the KEI-158 TaskFeed shape that merged in PR #957 — three sibling KEIs remaining for Part 17.4: KEI-159 (cost-card), KEI-160 (key-mgmt-UI). Same scaffold pattern applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)