### PR TITLE
[ATLAS] feat(kei168): KEI-116B — pgcrypto pgp_sym encrypt/decrypt helpers

### DIFF
--- a/src/dispatcher/api_key_crypto.py
+++ b/src/dispatcher/api_key_crypto.py
@@ -1,0 +1,152 @@
+"""KEI-116B — pgcrypto pgp_sym encrypt/decrypt helpers for customer API keys.
+
+Server-side symmetric encryption via PostgreSQL's pgcrypto extension —
+plaintext keys never leave the database server (we send plaintext via
+parameterised psycopg query; pgcrypto encrypts inside the database and
+returns the ciphertext). Master keys are pulled from env vars indexed
+by ``rotation_id`` so a rolling key rotation can land without
+re-encrypting historical rows (caller stores ``rotation_id`` alongside
+the ``encrypted_key`` column so the decrypt call resolves the right
+master key).
+
+Env var convention:
+    DISPATCHER_API_KEY_MASTER_V1   # current key
+    DISPATCHER_API_KEY_MASTER_V2   # next rotation
+    ...
+
+Acceptance (Linear KEI-168):
+- INSERT encrypts via pgp_sym_encrypt(plaintext, master_key)
+- SELECT decrypts
+- rotation_id allows future key rotation
+
+Out of scope:
+- ``customer_api_keys.rotation_id`` column (KEI-167 schema PR).
+- ``lookup_hash`` SHA-256 derivation (KEI-169 / KEI-116C).
+- Master-key provisioning (operator concern; documented env contract).
+- Server-side function variant (current design sends plaintext via
+  parameterised psycopg query; future hardening can wrap the same
+  pgp_sym_encrypt call inside a PL/pgSQL SECURITY DEFINER function that
+  reads the master from a Supabase secret — same call shape from Python).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+ROTATION_ID_ENV_PREFIX = "DISPATCHER_API_KEY_MASTER_V"
+DEFAULT_ROTATION_ID = 1
+
+
+class MasterKeyMissingError(RuntimeError):
+    """The environment is missing the master key for the requested
+    ``rotation_id``. Fail-closed — never silently encrypt with a fallback
+    key, never silently decrypt with the wrong rotation."""
+
+
+class CryptoError(RuntimeError):
+    """pgcrypto returned an unexpected shape (empty row, wrong type).
+    pgp_sym_decrypt with a wrong key returns the encrypted bytes garbled
+    OR raises a Postgres error — we surface both as CryptoError."""
+
+
+def _resolve_master_key(rotation_id: int) -> str:
+    """Look up the master key for a rotation_id from the environment.
+    Strips trailing whitespace; refuses empty values."""
+    env_var = f"{ROTATION_ID_ENV_PREFIX}{int(rotation_id)}"
+    raw = os.environ.get(env_var, "")
+    key = raw.strip()
+    if not key:
+        raise MasterKeyMissingError(
+            f"env {env_var} unset or empty — no master key for rotation_id={rotation_id}"
+        )
+    return key
+
+
+def encrypt(conn, plaintext: str, *, rotation_id: int = DEFAULT_ROTATION_ID) -> bytes:
+    """Encrypt ``plaintext`` via ``pgp_sym_encrypt(plaintext, master_key)``.
+
+    Args:
+        conn: psycopg connection (sync). Reused — caller owns lifecycle.
+        plaintext: The API key string to encrypt. Must be non-empty.
+        rotation_id: Index into the rolling master-key env. Default 1.
+
+    Returns:
+        ``bytes`` — the bytea ciphertext suitable for storing in the
+        ``customer_api_keys.encrypted_key`` column.
+
+    Raises:
+        ValueError: plaintext empty/whitespace.
+        MasterKeyMissingError: env var for rotation_id is unset.
+        CryptoError: pgcrypto returned an unexpected shape.
+    """
+    if not plaintext or not plaintext.strip():
+        raise ValueError("plaintext must be a non-empty string")
+    master_key = _resolve_master_key(rotation_id)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT pgp_sym_encrypt(%s::text, %s::text)",
+            (plaintext, master_key),
+        )
+        row = cur.fetchone()
+    if row is None or row[0] is None:
+        raise CryptoError("pgp_sym_encrypt returned no row")
+    return bytes(row[0])
+
+
+def decrypt(conn, encrypted: bytes, *, rotation_id: int = DEFAULT_ROTATION_ID) -> str:
+    """Decrypt ``encrypted`` bytea via
+    ``pgp_sym_decrypt(encrypted, master_key)``.
+
+    Args:
+        conn: psycopg connection (sync).
+        encrypted: The bytea ciphertext read from ``encrypted_key``.
+        rotation_id: Must match the rotation_id used at encrypt time —
+            caller is responsible for tracking which rotation each
+            ``encrypted_key`` row was minted under.
+
+    Returns:
+        ``str`` — the original plaintext.
+
+    Raises:
+        ValueError: encrypted is empty.
+        MasterKeyMissingError: env var for rotation_id is unset.
+        CryptoError: pgcrypto returned an unexpected shape OR the master
+            key doesn't match the rotation (Postgres raises; we re-raise).
+    """
+    if not encrypted:
+        raise ValueError("encrypted must be a non-empty bytes-like")
+    master_key = _resolve_master_key(rotation_id)
+    with conn.cursor() as cur:
+        try:
+            cur.execute(
+                "SELECT pgp_sym_decrypt(%s::bytea, %s::text)",
+                (bytes(encrypted), master_key),
+            )
+            row = cur.fetchone()
+        except Exception as exc:
+            # pgcrypto raises on wrong key / corrupt ciphertext — surface as
+            # CryptoError so callers can branch without importing psycopg.
+            raise CryptoError(f"pgp_sym_decrypt failed: {exc}") from exc
+    if row is None or row[0] is None:
+        raise CryptoError("pgp_sym_decrypt returned no row")
+    return str(row[0])
+
+
+def encrypt_for_storage(
+    conn,
+    plaintext: str,
+    *,
+    rotation_id: int = DEFAULT_ROTATION_ID,
+) -> tuple[bytes, int]:
+    """Convenience wrapper returning ``(encrypted_key, rotation_id)`` ready
+    for INSERT alongside other columns.
+
+    Caller still composes the INSERT statement — this helper keeps the
+    encrypt + rotation_id pair atomic so callers don't accidentally store
+    a ciphertext under the wrong rotation_id (e.g. by reading the env
+    twice and getting different keys mid-flight, post-rotation).
+    """
+    return encrypt(conn, plaintext, rotation_id=rotation_id), int(rotation_id)

--- a/src/dispatcher/rate_limiter.py
+++ b/src/dispatcher/rate_limiter.py
@@ -115,7 +115,7 @@ async def check_and_increment(
     key = tenant_rl_key(tenant_id, window_start)
     ttl_s = window_size_s * _TTL_MULTIPLIER
 
-    client = await get_valkey_client()
+    client = get_valkey_client()
     try:
         # INCR returns the post-increment value. EXPIRE is idempotent —
         # safe to call every request even though we only need it on the

--- a/src/dispatcher/rate_limiter.py
+++ b/src/dispatcher/rate_limiter.py
@@ -1,0 +1,174 @@
+"""KEI-117B — sliding-window rate limiter for per-tenant enforcement.
+
+Builds on KEI-117A's Valkey pool + tenant key namespace. Implements a
+**fixed-window** counter strategy variant of "sliding window" — each
+window_size_s seconds gets its own INCR bucket keyed by
+``rl:<tenant_id>:<window_start_unix>``, with TTL = 2× window_size_s so
+the bucket auto-evicts after one full window has passed (Linear KEI-171
+acceptance "counter resets after window" is satisfied by the TTL).
+
+This is the simplest correct rate-limit primitive for the dispatcher
+product layer:
+* O(1) per request — INCR + EXPIRE.
+* Counter resets without manual cleanup (TTL).
+* Per-tenant isolation enforced at the key level (KEI-117A guard
+  refuses empty tenant_id).
+
+True log-of-events sliding-window (Redis ZSET / Lua) is OUT of scope
+here — the dispatcher's first-customer requirement is "block obvious
+abuse", not "millisecond-accurate burst smoothing". The ratified
+acceptance ("60s window; 100 req/min returns 429 on 101st") is
+satisfied by fixed windows; we can upgrade to ZSET-based sliding if a
+real customer complains about the bucket-edge effect.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+from src.dispatcher.valkey_pool import get_valkey_client, tenant_rl_key
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WINDOW_SIZE_S = 60
+DEFAULT_LIMIT = 100
+
+# TTL is 2× the window so the bucket is alive long enough for any
+# straggler probe within the window AND auto-evicts cleanly afterwards.
+_TTL_MULTIPLIER = 2
+
+
+class RateLimitExceededError(RuntimeError):
+    """Raised when ``check_and_increment`` would push the tenant past
+    their configured per-window limit. The caller surfaces this as a 429
+    to the customer (dispatcher proxy / API layer does the mapping)."""
+
+    def __init__(self, tenant_id: str, limit: int, window_size_s: int, current: int):
+        self.tenant_id = tenant_id
+        self.limit = limit
+        self.window_size_s = window_size_s
+        self.current = current
+        super().__init__(
+            f"rate limit exceeded for tenant {tenant_id}: "
+            f"{current} >= {limit} per {window_size_s}s window"
+        )
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    """Result of a check_and_increment call. ``allowed=True`` means the
+    increment landed and the caller may proceed. ``allowed=False`` means
+    the counter was at or above limit BEFORE increment and the caller
+    must refuse — the limiter does NOT roll back the increment in that
+    case (over-counting is preferred to under-blocking for security)."""
+
+    allowed: bool
+    current: int
+    limit: int
+    window_start_unix: int
+    window_size_s: int
+    retry_after_s: int
+
+
+def _window_start(now_unix: float, window_size_s: int) -> int:
+    """Snap ``now_unix`` down to the nearest window boundary so all calls
+    within the same window agree on the bucket key."""
+    return (int(now_unix) // window_size_s) * window_size_s
+
+
+async def check_and_increment(
+    *,
+    tenant_id: str,
+    limit: int = DEFAULT_LIMIT,
+    window_size_s: int = DEFAULT_WINDOW_SIZE_S,
+    now_unix: float | None = None,
+) -> RateLimitDecision:
+    """Atomically INCR the tenant's current-window counter and decide
+    whether the request should be allowed.
+
+    Args:
+        tenant_id: Customer UUID. Empty → ValueError from tenant_rl_key.
+        limit: Max requests per window before subsequent requests are
+            refused. The 101st request in a 100/window limit is refused.
+        window_size_s: Fixed window length in seconds.
+        now_unix: Override clock for tests. Defaults to ``time.time()``.
+
+    Returns:
+        RateLimitDecision with allowed/current/limit/window metadata.
+
+    Raises:
+        ValueError: tenant_id is empty/whitespace.
+        Whatever redis.asyncio raises: transport failure. Caller decides
+            whether to fail-open (allow) or fail-closed (refuse). This
+            module does NOT swallow transport errors because for
+            security-sensitive paths the operator must choose the policy.
+    """
+    if window_size_s <= 0:
+        raise ValueError(f"window_size_s must be positive (got {window_size_s})")
+    if limit <= 0:
+        raise ValueError(f"limit must be positive (got {limit})")
+
+    clock = time.time() if now_unix is None else now_unix
+    window_start = _window_start(clock, window_size_s)
+    key = tenant_rl_key(tenant_id, window_start)
+    ttl_s = window_size_s * _TTL_MULTIPLIER
+
+    client = await get_valkey_client()
+    try:
+        # INCR returns the post-increment value. EXPIRE is idempotent —
+        # safe to call every request even though we only need it on the
+        # first increment of each window (negligible cost vs the round-trip
+        # to add WATCH/MULTI for a "only on first" guard).
+        current = int(await client.incr(key))
+        await client.expire(key, ttl_s)
+    finally:
+        await client.aclose()
+
+    allowed = current <= limit
+    retry_after_s = max(0, window_start + window_size_s - int(clock))
+    if not allowed:
+        logger.info(
+            "rate limit hit tenant=%s window=%d current=%d limit=%d retry_after=%ds",
+            tenant_id,
+            window_start,
+            current,
+            limit,
+            retry_after_s,
+        )
+    return RateLimitDecision(
+        allowed=allowed,
+        current=current,
+        limit=limit,
+        window_start_unix=window_start,
+        window_size_s=window_size_s,
+        retry_after_s=retry_after_s,
+    )
+
+
+async def enforce(
+    *,
+    tenant_id: str,
+    limit: int = DEFAULT_LIMIT,
+    window_size_s: int = DEFAULT_WINDOW_SIZE_S,
+    now_unix: float | None = None,
+) -> RateLimitDecision:
+    """Convenience wrapper — calls check_and_increment, raises
+    RateLimitExceededError when the decision is ``allowed=False``.
+    Returns the decision on success so the caller can attach headers
+    (X-RateLimit-Remaining, Retry-After) to the customer response."""
+    decision = await check_and_increment(
+        tenant_id=tenant_id,
+        limit=limit,
+        window_size_s=window_size_s,
+        now_unix=now_unix,
+    )
+    if not decision.allowed:
+        raise RateLimitExceededError(
+            tenant_id=tenant_id,
+            limit=decision.limit,
+            window_size_s=decision.window_size_s,
+            current=decision.current,
+        )
+    return decision

--- a/src/dispatcher/tier_limits.py
+++ b/src/dispatcher/tier_limits.py
@@ -1,0 +1,150 @@
+"""KEI-117C — load tier limits + apply per-tenant rate limits.
+
+Builds on KEI-117B's sliding-window primitive. Maps each customer to a
+subscription tier (Basic / Pro / Enterprise) and enforces the tier's
+configured req-per-window limit via ``rate_limiter.enforce``.
+
+Tier configuration (Linear KEI-172 acceptance):
+    Basic       = 60 req / 60s window
+    Pro         = 300 req / 60s window
+    Enterprise  = 1000 req / 60s window
+
+Tier lookup is pluggable via ``set_tenant_tier_lookup(callable)``. The
+default lookup returns ``"basic"`` for all tenants — adequate until
+KEI-112B (subscriptions table) lands. Once the billing schema exists,
+the consumer swaps in a DB-backed lookup with one call; no rate-limiter
+contract change needed.
+
+Override via env var ``DISPATCHER_TIER_OVERRIDES`` (JSON
+``{"<tenant_id>": "pro", ...}``) for dev/staging without standing up
+the subscriptions table. Empty / missing → default lookup.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Callable
+from typing import Literal
+
+from src.dispatcher import rate_limiter
+from src.dispatcher.rate_limiter import RateLimitDecision
+
+logger = logging.getLogger(__name__)
+
+Tier = Literal["basic", "pro", "enterprise"]
+TenantTierLookup = Callable[[str], Tier]
+
+DEFAULT_TIER: Tier = "basic"
+TIER_OVERRIDES_ENV = "DISPATCHER_TIER_OVERRIDES"
+
+# (limit, window_size_s) per tier — matches Linear KEI-172 acceptance.
+TIER_LIMITS: dict[Tier, tuple[int, int]] = {
+    "basic": (60, 60),
+    "pro": (300, 60),
+    "enterprise": (1000, 60),
+}
+
+
+class UnknownTierError(ValueError):
+    """A tier lookup returned a value not in TIER_LIMITS — caller bug."""
+
+
+def _env_override_lookup(tenant_id: str) -> Tier:
+    """Read DISPATCHER_TIER_OVERRIDES JSON for tenant_id, fall through to
+    DEFAULT_TIER. Used by the default lookup so dev/staging can simulate
+    Pro/Enterprise tenants without the subscriptions table existing."""
+    raw = os.environ.get(TIER_OVERRIDES_ENV, "").strip()
+    if not raw:
+        return DEFAULT_TIER
+    try:
+        overrides = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "%s contains invalid JSON (%s) — falling back to %s",
+            TIER_OVERRIDES_ENV,
+            exc,
+            DEFAULT_TIER,
+        )
+        return DEFAULT_TIER
+    value = overrides.get(tenant_id)
+    if value in TIER_LIMITS:
+        return value  # type: ignore[return-value]
+    return DEFAULT_TIER
+
+
+_lookup: TenantTierLookup = _env_override_lookup
+
+
+def set_tenant_tier_lookup(lookup: TenantTierLookup) -> None:
+    """Swap the tier-lookup implementation. KEI-112B (billing schema)
+    consumer wires its DB-backed lookup via this once subscriptions land.
+    Tests use this to inject deterministic tiers."""
+    global _lookup
+    _lookup = lookup
+
+
+def reset_tenant_tier_lookup() -> None:
+    """Restore the default env-override lookup. Tests call this between
+    cases so a leftover injection doesn't bleed into the next test."""
+    global _lookup
+    _lookup = _env_override_lookup
+
+
+def get_tenant_tier(tenant_id: str) -> Tier:
+    """Resolve a tenant's tier via the active lookup. Defaults to basic
+    if the lookup raises or returns an unknown value — rate limiting
+    must NOT be bypassed because of a tier-store outage."""
+    if not tenant_id or not tenant_id.strip():
+        raise ValueError("tenant_id must be a non-empty string")
+    try:
+        tier = _lookup(tenant_id.strip())
+    except Exception as exc:  # noqa: BLE001 — tier lookup must fail-closed
+        logger.warning(
+            "tier lookup raised for tenant %s (%s) — defaulting to %s",
+            tenant_id,
+            exc,
+            DEFAULT_TIER,
+        )
+        return DEFAULT_TIER
+    if tier not in TIER_LIMITS:
+        logger.warning(
+            "tier lookup returned unknown tier %r for %s — defaulting to %s",
+            tier,
+            tenant_id,
+            DEFAULT_TIER,
+        )
+        return DEFAULT_TIER
+    return tier
+
+
+def limits_for(tier: Tier) -> tuple[int, int]:
+    """Return ``(limit, window_size_s)`` for a tier. Raises
+    UnknownTierError when ``tier`` is not in TIER_LIMITS — caller bug,
+    not a runtime fall-back case."""
+    if tier not in TIER_LIMITS:
+        raise UnknownTierError(f"unknown tier: {tier!r}")
+    return TIER_LIMITS[tier]
+
+
+async def enforce_for_tenant(
+    *,
+    tenant_id: str,
+    now_unix: float | None = None,
+) -> RateLimitDecision:
+    """Look up tenant tier, fetch tier limits, enforce via rate_limiter.
+
+    Convenience entry point for dispatcher API/proxy code — one call
+    handles tier lookup + limit application. Raises
+    ``RateLimitExceededError`` (re-raised from rate_limiter.enforce)
+    when the tenant is over their per-window limit; caller maps to 429.
+    """
+    tier = get_tenant_tier(tenant_id)
+    limit, window_size_s = limits_for(tier)
+    return await rate_limiter.enforce(
+        tenant_id=tenant_id,
+        limit=limit,
+        window_size_s=window_size_s,
+        now_unix=now_unix,
+    )

--- a/src/dispatcher/valkey_pool.py
+++ b/src/dispatcher/valkey_pool.py
@@ -1,0 +1,132 @@
+"""KEI-117A — Valkey connection pool + per-tenant key namespace.
+
+Foundation for the Part 17 dispatcher rate limiter (KEI-117B / KEI-171).
+Valkey speaks the Redis wire protocol so we reuse ``redis.asyncio`` —
+no new client dependency. Pool is separate from the agency-side
+``src/integrations/redis.py`` because the dispatcher product layer is a
+distinct tenancy (customer_id), not the agency's client_id model.
+
+Key namespace contract (documented here as the canonical spec — DO NOT
+duplicate in callers):
+
+    rl:<tenant_id>:<window_start_unix>
+
+* ``rl:`` — rate-limit family prefix. Other dispatcher families (e.g.
+  ``q:`` for queues, ``ses:`` for sessions) will sit alongside without
+  collision.
+* ``<tenant_id>`` — customer UUID string. Caller is responsible for
+  passing a validated id; the helper does not authenticate.
+* ``<window_start_unix>`` — INT seconds since epoch at the start of the
+  fixed-or-sliding window. Granularity is the caller's choice (minute,
+  hour, day). The sliding-window limiter (KEI-171) uses 60-second buckets.
+
+Smoke health check: ``await smoke_incr()`` runs ``INCR <smoke_key>`` +
+``EXPIRE <smoke_key> 60`` against the pool to confirm the connection is
+live. Returns the integer post-increment value (≥ 1 on a healthy
+connection). Smoke keys are namespaced ``rl:_smoke:<process_pid>`` so
+concurrent smokes don't collide and the bucket auto-evicts.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from redis.asyncio import ConnectionPool, Redis
+
+logger = logging.getLogger(__name__)
+
+VALKEY_URL_ENV = "VALKEY_URL"
+FALLBACK_URL_ENV = "REDIS_URL"
+DEFAULT_VALKEY_URL = "redis://127.0.0.1:6379/0"
+DEFAULT_MAX_CONNECTIONS = 20
+SMOKE_KEY_TTL_SECONDS = 60
+
+RL_NAMESPACE_PREFIX = "rl"
+
+_pool: ConnectionPool | None = None
+
+
+def _resolve_url() -> str:
+    """Prefer VALKEY_URL, fall back to REDIS_URL, fall back to local default.
+
+    The fallback chain lets the dispatcher run against the existing
+    agency-side Redis in dev without needing a second binary, while keeping
+    a knob for prod to split the two tenancies onto separate instances.
+    """
+    return os.environ.get(VALKEY_URL_ENV) or os.environ.get(FALLBACK_URL_ENV) or DEFAULT_VALKEY_URL
+
+
+async def get_valkey_pool() -> ConnectionPool:
+    """Lazy-init the dispatcher Valkey pool. Same instance for the lifetime
+    of the process — pool reset is handled by `reset_valkey_pool()` (test
+    fixtures only)."""
+    global _pool
+    if _pool is None:
+        url = _resolve_url()
+        _pool = ConnectionPool.from_url(
+            url,
+            decode_responses=True,
+            max_connections=DEFAULT_MAX_CONNECTIONS,
+        )
+        logger.info("valkey pool created url=%s max=%d", url, DEFAULT_MAX_CONNECTIONS)
+    return _pool
+
+
+async def get_valkey_client() -> Redis:
+    """Get a Redis client bound to the dispatcher pool. Caller is
+    responsible for `await client.aclose()` when done (or use as
+    `async with`)."""
+    pool = await get_valkey_pool()
+    return Redis(connection_pool=pool)
+
+
+async def reset_valkey_pool() -> None:
+    """Tear down the cached pool. Tests use this between cases; production
+    code should never call it. Safe to call when no pool exists."""
+    global _pool
+    if _pool is not None:
+        try:
+            await _pool.aclose()
+        except Exception as exc:  # noqa: BLE001 — teardown must not raise
+            logger.warning("valkey pool aclose failed (non-fatal): %s", exc)
+        _pool = None
+
+
+def tenant_rl_key(tenant_id: str, window_start_unix: int) -> str:
+    """Build a per-tenant rate-limit key.
+
+    Args:
+        tenant_id: Customer UUID string. Must be non-empty.
+        window_start_unix: Integer unix seconds at the start of the window.
+
+    Returns:
+        ``rl:<tenant_id>:<window_start_unix>``
+
+    Raises:
+        ValueError: ``tenant_id`` is empty / whitespace. We refuse to mint
+            an unscoped namespace because that would silently bucket ALL
+            tenants into one counter.
+    """
+    if not tenant_id or not tenant_id.strip():
+        raise ValueError("tenant_id must be a non-empty string")
+    return f"{RL_NAMESPACE_PREFIX}:{tenant_id.strip()}:{int(window_start_unix)}"
+
+
+async def smoke_incr() -> int:
+    """Health probe — INCR a per-process smoke key and set 60s TTL so the
+    bucket auto-evicts. Returns the integer post-increment value.
+
+    Use from boot checks / readiness probes. Returns ``>= 1`` when the
+    pool is live; raises whatever ``redis.asyncio`` raises on transport
+    failure so the caller can decide whether to treat it as degraded vs
+    fatal.
+    """
+    client = await get_valkey_client()
+    try:
+        smoke_key = f"{RL_NAMESPACE_PREFIX}:_smoke:{os.getpid()}"
+        value = await client.incr(smoke_key)
+        await client.expire(smoke_key, SMOKE_KEY_TTL_SECONDS)
+        return int(value)
+    finally:
+        await client.aclose()

--- a/src/dispatcher/valkey_pool.py
+++ b/src/dispatcher/valkey_pool.py
@@ -57,10 +57,15 @@ def _resolve_url() -> str:
     return os.environ.get(VALKEY_URL_ENV) or os.environ.get(FALLBACK_URL_ENV) or DEFAULT_VALKEY_URL
 
 
-async def get_valkey_pool() -> ConnectionPool:
+def get_valkey_pool() -> ConnectionPool:
     """Lazy-init the dispatcher Valkey pool. Same instance for the lifetime
     of the process — pool reset is handled by `reset_valkey_pool()` (test
-    fixtures only)."""
+    fixtures only).
+
+    Sync because pool creation is in-memory (no I/O until first command).
+    `redis.asyncio.ConnectionPool.from_url` doesn't open sockets — those
+    are minted lazily per command by the Redis client.
+    """
     global _pool
     if _pool is None:
         url = _resolve_url()
@@ -73,12 +78,11 @@ async def get_valkey_pool() -> ConnectionPool:
     return _pool
 
 
-async def get_valkey_client() -> Redis:
+def get_valkey_client() -> Redis:
     """Get a Redis client bound to the dispatcher pool. Caller is
     responsible for `await client.aclose()` when done (or use as
     `async with`)."""
-    pool = await get_valkey_pool()
-    return Redis(connection_pool=pool)
+    return Redis(connection_pool=get_valkey_pool())
 
 
 async def reset_valkey_pool() -> None:
@@ -93,12 +97,13 @@ async def reset_valkey_pool() -> None:
         _pool = None
 
 
-def tenant_rl_key(tenant_id: str, window_start_unix: int) -> str:
+def tenant_rl_key(tenant_id: str, window_start_unix: int | float) -> str:
     """Build a per-tenant rate-limit key.
 
     Args:
         tenant_id: Customer UUID string. Must be non-empty.
-        window_start_unix: Integer unix seconds at the start of the window.
+        window_start_unix: Unix seconds at the start of the window. Accepts
+            ``int`` or ``float`` (e.g. ``time.time()``) and truncates to int.
 
     Returns:
         ``rl:<tenant_id>:<window_start_unix>``
@@ -122,7 +127,7 @@ async def smoke_incr() -> int:
     failure so the caller can decide whether to treat it as degraded vs
     fatal.
     """
-    client = await get_valkey_client()
+    client = get_valkey_client()
     try:
         smoke_key = f"{RL_NAMESPACE_PREFIX}:_smoke:{os.getpid()}"
         value = await client.incr(smoke_key)

--- a/tests/dispatcher/test_api_key_crypto.py
+++ b/tests/dispatcher/test_api_key_crypto.py
@@ -1,0 +1,246 @@
+"""KEI-116B — tests for src/dispatcher/api_key_crypto.
+
+psycopg cursor is mocked at the conn.cursor boundary; no live Postgres
+required. Master keys are injected via monkeypatch.setenv so rotation
+behavior can be exercised deterministically.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.dispatcher import api_key_crypto
+from src.dispatcher.api_key_crypto import (
+    DEFAULT_ROTATION_ID,
+    ROTATION_ID_ENV_PREFIX,
+    CryptoError,
+    MasterKeyMissingError,
+    decrypt,
+    encrypt,
+    encrypt_for_storage,
+)
+
+
+def _fake_conn(row=(b"ciphertext-bytes",)):
+    """Build a psycopg-like sync connection whose cursor returns ``row``
+    from fetchone(). Cursor is exposed via conn._cursor for assertions."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+    cursor.fetchone = MagicMock(return_value=row)
+    conn.cursor = MagicMock(return_value=cursor)
+    conn._cursor = cursor
+    return conn
+
+
+@pytest.fixture(autouse=True)
+def _clean_master_keys(monkeypatch):
+    """Strip every DISPATCHER_API_KEY_MASTER_V* env so tests start clean."""
+    for k in list(__import__("os").environ.keys()):
+        if k.startswith(ROTATION_ID_ENV_PREFIX):
+            monkeypatch.delenv(k, raising=False)
+    yield
+
+
+# ─── _resolve_master_key ──────────────────────────────────────────────────
+
+
+def test_resolve_master_key_reads_env(monkeypatch):
+    """Default rotation reads DISPATCHER_API_KEY_MASTER_V1 from env."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "master-1-secret")
+    assert api_key_crypto._resolve_master_key(1) == "master-1-secret"
+
+
+def test_resolve_master_key_supports_multiple_rotations(monkeypatch):
+    """Each rotation_id maps to its own env var so callers can hold ALL
+    historical master keys for decrypt-side compatibility."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "v1-secret")
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}2", "v2-secret")
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}3", "v3-secret")
+    assert api_key_crypto._resolve_master_key(1) == "v1-secret"
+    assert api_key_crypto._resolve_master_key(2) == "v2-secret"
+    assert api_key_crypto._resolve_master_key(3) == "v3-secret"
+
+
+def test_resolve_master_key_strips_whitespace(monkeypatch):
+    """Trailing newlines / spaces from k8s-secret mounts are stripped."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "  master-with-padding  \n")
+    assert api_key_crypto._resolve_master_key(1) == "master-with-padding"
+
+
+def test_resolve_master_key_raises_when_env_missing():
+    """Missing env var → MasterKeyMissingError. Never silently fall back
+    to a default key — that would silently lose data on rotation."""
+    with pytest.raises(MasterKeyMissingError, match="V1"):
+        api_key_crypto._resolve_master_key(1)
+
+
+def test_resolve_master_key_raises_when_env_empty(monkeypatch):
+    """Empty / whitespace-only env value is the same as missing — fail."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "   ")
+    with pytest.raises(MasterKeyMissingError):
+        api_key_crypto._resolve_master_key(1)
+
+
+# ─── encrypt ──────────────────────────────────────────────────────────────
+
+
+def test_encrypt_calls_pgp_sym_encrypt_with_correct_args(monkeypatch):
+    """encrypt issues SELECT pgp_sym_encrypt(<plaintext>, <master_key>)
+    bound via psycopg %s placeholders — no string interpolation."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "master-1")
+    conn = _fake_conn(row=(b"encrypted-bytes",))
+    result = encrypt(conn, "sk-anthropic-abc123")
+    assert result == b"encrypted-bytes"
+    sql_arg = conn._cursor.execute.call_args.args[0]
+    params = conn._cursor.execute.call_args.args[1]
+    assert "pgp_sym_encrypt" in sql_arg
+    assert "%s" in sql_arg  # parameterised, not interpolated
+    assert params == ("sk-anthropic-abc123", "master-1")
+
+
+def test_encrypt_uses_requested_rotation(monkeypatch):
+    """rotation_id=2 → looks up V2 master key."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}2", "master-v2-newer")
+    conn = _fake_conn(row=(b"encrypted-v2",))
+    encrypt(conn, "plaintext", rotation_id=2)
+    params = conn._cursor.execute.call_args.args[1]
+    assert params[1] == "master-v2-newer"
+
+
+def test_encrypt_defaults_to_rotation_1(monkeypatch):
+    """No rotation_id arg → uses DEFAULT_ROTATION_ID (1)."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "v1-key")
+    assert DEFAULT_ROTATION_ID == 1
+    conn = _fake_conn(row=(b"ct",))
+    encrypt(conn, "pt")
+    assert conn._cursor.execute.call_args.args[1][1] == "v1-key"
+
+
+def test_encrypt_refuses_empty_plaintext(monkeypatch):
+    """Empty plaintext is a caller bug — refuse before touching the
+    database (no spurious 'empty encryption' row)."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "k")
+    with pytest.raises(ValueError, match="non-empty"):
+        encrypt(_fake_conn(), "")
+    with pytest.raises(ValueError, match="non-empty"):
+        encrypt(_fake_conn(), "   ")
+
+
+def test_encrypt_raises_crypto_error_when_no_row(monkeypatch):
+    """pgcrypto returning no row is shape failure — surface, don't swallow."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "k")
+    conn = _fake_conn(row=None)
+    with pytest.raises(CryptoError, match="no row"):
+        encrypt(conn, "pt")
+
+
+def test_encrypt_raises_crypto_error_when_row_value_none(monkeypatch):
+    """Row exists but column is NULL — same as no row."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "k")
+    conn = _fake_conn(row=(None,))
+    with pytest.raises(CryptoError, match="no row"):
+        encrypt(conn, "pt")
+
+
+def test_encrypt_propagates_master_key_missing(monkeypatch):
+    """Env not set → MasterKeyMissingError before DB call."""
+    conn = _fake_conn(row=(b"x",))
+    with pytest.raises(MasterKeyMissingError):
+        encrypt(conn, "pt")
+    conn._cursor.execute.assert_not_called()
+
+
+# ─── decrypt ──────────────────────────────────────────────────────────────
+
+
+def test_decrypt_calls_pgp_sym_decrypt_with_correct_args(monkeypatch):
+    """decrypt issues SELECT pgp_sym_decrypt(<encrypted>, <master_key>)."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "master-1")
+    conn = _fake_conn(row=("sk-anthropic-abc123",))
+    result = decrypt(conn, b"\\x80\\x01ciphertext-bytes")
+    assert result == "sk-anthropic-abc123"
+    sql_arg = conn._cursor.execute.call_args.args[0]
+    params = conn._cursor.execute.call_args.args[1]
+    assert "pgp_sym_decrypt" in sql_arg
+    assert "%s" in sql_arg
+    assert params[0] == b"\\x80\\x01ciphertext-bytes"
+    assert params[1] == "master-1"
+
+
+def test_decrypt_uses_requested_rotation(monkeypatch):
+    """rotation_id=2 looks up V2 master key — required for decrypting
+    historical rows minted before a rotation."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}2", "v2-key")
+    conn = _fake_conn(row=("pt",))
+    decrypt(conn, b"ct", rotation_id=2)
+    assert conn._cursor.execute.call_args.args[1][1] == "v2-key"
+
+
+def test_decrypt_refuses_empty_bytes(monkeypatch):
+    """Empty ciphertext is a caller bug."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "k")
+    with pytest.raises(ValueError, match="non-empty"):
+        decrypt(_fake_conn(), b"")
+
+
+def test_decrypt_wraps_db_exception_in_crypto_error(monkeypatch):
+    """pgcrypto raises on wrong key / corrupt ciphertext. We re-raise as
+    CryptoError so callers can branch without importing psycopg."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "wrong-key")
+    conn = _fake_conn()
+    conn._cursor.execute = MagicMock(side_effect=RuntimeError("Wrong key or corrupt data"))
+    with pytest.raises(CryptoError, match="pgp_sym_decrypt failed"):
+        decrypt(conn, b"some-bytes")
+
+
+def test_decrypt_raises_crypto_error_when_no_row(monkeypatch):
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "k")
+    conn = _fake_conn(row=None)
+    with pytest.raises(CryptoError, match="no row"):
+        decrypt(conn, b"ct")
+
+
+# ─── encrypt_for_storage ───────────────────────────────────────────────────
+
+
+def test_encrypt_for_storage_returns_pair(monkeypatch):
+    """encrypt_for_storage returns (ciphertext, rotation_id) atomic pair —
+    caller stores both alongside each other in customer_api_keys."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "k1")
+    conn = _fake_conn(row=(b"ct-bytes",))
+    ct, rot = encrypt_for_storage(conn, "plaintext-secret")
+    assert ct == b"ct-bytes"
+    assert rot == 1
+
+
+def test_encrypt_for_storage_preserves_explicit_rotation(monkeypatch):
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}5", "k5")
+    conn = _fake_conn(row=(b"v5-ct",))
+    ct, rot = encrypt_for_storage(conn, "plaintext", rotation_id=5)
+    assert ct == b"v5-ct"
+    assert rot == 5
+
+
+# ─── round-trip with mocked roundtrip ──────────────────────────────────────
+
+
+def test_encrypt_decrypt_roundtrip_returns_original_plaintext(monkeypatch):
+    """Mock pgcrypto as identity (ciphertext == plaintext bytes) — verifies
+    that the encrypt → store-shape → decrypt code path preserves the
+    payload without re-quoting / encoding bugs."""
+    monkeypatch.setenv(f"{ROTATION_ID_ENV_PREFIX}1", "master-1")
+    plaintext = "sk-anthropic-secret-xyz"
+
+    # encrypt path: pgcrypto returns the plaintext encoded as bytes
+    enc_conn = _fake_conn(row=(plaintext.encode(),))
+    ciphertext = encrypt(enc_conn, plaintext)
+    assert ciphertext == plaintext.encode()
+
+    # decrypt path: pgcrypto returns the original plaintext string
+    dec_conn = _fake_conn(row=(plaintext,))
+    recovered = decrypt(dec_conn, ciphertext)
+    assert recovered == plaintext

--- a/tests/dispatcher/test_rate_limiter.py
+++ b/tests/dispatcher/test_rate_limiter.py
@@ -22,17 +22,23 @@ from src.dispatcher.rate_limiter import (
 )
 
 
-def _client_with_counter(initial: int = 0) -> AsyncMock:
-    """Build a fake Redis async client whose INCR returns a monotonic
-    counter starting just above ``initial``. Tracks calls for assertions."""
+def _fake_incr_factory(initial: int = 0):
+    """Build a sync side_effect that returns a monotonic counter starting
+    just above ``initial`` — used by _client_with_counter for INCR."""
     state = {"n": initial}
 
-    async def fake_incr(key: str) -> int:
+    def fake_incr(_key: str) -> int:
         state["n"] += 1
         return state["n"]
 
+    return fake_incr
+
+
+def _client_with_counter(initial: int = 0) -> AsyncMock:
+    """Build a fake Redis async client whose INCR returns a monotonic
+    counter starting just above ``initial``. Tracks calls for assertions."""
     mock = AsyncMock()
-    mock.incr = AsyncMock(side_effect=fake_incr)
+    mock.incr = AsyncMock(side_effect=_fake_incr_factory(initial))
     mock.expire = AsyncMock(return_value=True)
     mock.aclose = AsyncMock()
     return mock
@@ -42,11 +48,7 @@ def _client_with_counter(initial: int = 0) -> AsyncMock:
 def fake_client(monkeypatch):
     """Stub get_valkey_client with a per-test counter mock."""
     client = _client_with_counter()
-
-    async def fake_get_client():
-        return client
-
-    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", lambda: client)
     return client
 
 
@@ -108,7 +110,7 @@ async def test_check_and_increment_uses_different_key_per_tenant(monkeypatch):
     cross-tenant counter sharing."""
     keys_incremented: list[str] = []
 
-    async def fake_incr(key):
+    def fake_incr(key):
         keys_incremented.append(key)
         return 1
 
@@ -117,10 +119,7 @@ async def test_check_and_increment_uses_different_key_per_tenant(monkeypatch):
     client.expire = AsyncMock()
     client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return client
-
-    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", lambda: client)
     await check_and_increment(tenant_id="alpha", limit=10, window_size_s=60, now_unix=1715904000)
     await check_and_increment(tenant_id="beta", limit=10, window_size_s=60, now_unix=1715904000)
     assert keys_incremented == ["rl:alpha:1715904000", "rl:beta:1715904000"]
@@ -136,10 +135,7 @@ async def test_check_and_increment_uses_different_key_per_window(monkeypatch):
     client.expire = AsyncMock()
     client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return client
-
-    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", lambda: client)
     await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904030)
     # 61 seconds later → next window
     await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904091)
@@ -173,10 +169,7 @@ async def test_check_and_increment_closes_client_on_failure(monkeypatch):
     client.expire = AsyncMock()
     client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return client
-
-    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", lambda: client)
     with pytest.raises(ConnectionError):
         await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904000)
     client.aclose.assert_awaited_once()

--- a/tests/dispatcher/test_rate_limiter.py
+++ b/tests/dispatcher/test_rate_limiter.py
@@ -1,0 +1,261 @@
+"""KEI-117B — tests for src/dispatcher/rate_limiter.
+
+The valkey client is AsyncMock'd so no live Valkey is required. Clock
+is fully controllable via the now_unix parameter — no time.sleep needed
+to exercise window-rollover scenarios.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.dispatcher import rate_limiter, valkey_pool
+from src.dispatcher.rate_limiter import (
+    DEFAULT_LIMIT,
+    DEFAULT_WINDOW_SIZE_S,
+    RateLimitDecision,
+    RateLimitExceededError,
+    check_and_increment,
+    enforce,
+)
+
+
+def _client_with_counter(initial: int = 0) -> AsyncMock:
+    """Build a fake Redis async client whose INCR returns a monotonic
+    counter starting just above ``initial``. Tracks calls for assertions."""
+    state = {"n": initial}
+
+    async def fake_incr(key: str) -> int:
+        state["n"] += 1
+        return state["n"]
+
+    mock = AsyncMock()
+    mock.incr = AsyncMock(side_effect=fake_incr)
+    mock.expire = AsyncMock(return_value=True)
+    mock.aclose = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    """Stub get_valkey_client with a per-test counter mock."""
+    client = _client_with_counter()
+
+    async def fake_get_client():
+        return client
+
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    return client
+
+
+# ─── check_and_increment ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_allows_first_request(fake_client):
+    """First request in a fresh window — allowed=True, current=1."""
+    decision = await check_and_increment(
+        tenant_id="cust-1", limit=10, window_size_s=60, now_unix=1715904030
+    )
+    assert decision.allowed is True
+    assert decision.current == 1
+    assert decision.limit == 10
+    assert decision.window_size_s == 60
+    # window_start snaps DOWN to nearest 60s boundary
+    assert decision.window_start_unix == 1715904000
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_allows_up_to_limit(fake_client):
+    """Requests 1..limit all allowed; 101st in a 100-limit refused."""
+    for _ in range(100):
+        d = await check_and_increment(
+            tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000
+        )
+        assert d.allowed is True
+    # 101st request — refused
+    d = await check_and_increment(tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000)
+    assert d.allowed is False
+    assert d.current == 101
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_refuses_at_boundary(fake_client):
+    """``current > limit`` is the refusal condition (101st > 100). The
+    100th request must still be allowed."""
+    # Pump 99 through
+    for _ in range(99):
+        await check_and_increment(tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000)
+    # 100th — allowed
+    d100 = await check_and_increment(
+        tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000
+    )
+    assert d100.allowed is True
+    assert d100.current == 100
+    # 101st — refused
+    d101 = await check_and_increment(
+        tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000
+    )
+    assert d101.allowed is False
+    assert d101.current == 101
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_uses_different_key_per_tenant(monkeypatch):
+    """Two tenants in the same window must hit different keys — no
+    cross-tenant counter sharing."""
+    keys_incremented: list[str] = []
+
+    async def fake_incr(key):
+        keys_incremented.append(key)
+        return 1
+
+    client = AsyncMock()
+    client.incr = AsyncMock(side_effect=fake_incr)
+    client.expire = AsyncMock()
+    client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return client
+
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    await check_and_increment(tenant_id="alpha", limit=10, window_size_s=60, now_unix=1715904000)
+    await check_and_increment(tenant_id="beta", limit=10, window_size_s=60, now_unix=1715904000)
+    assert keys_incremented == ["rl:alpha:1715904000", "rl:beta:1715904000"]
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_uses_different_key_per_window(monkeypatch):
+    """Same tenant in two different windows must hit two keys —
+    the counter MUST reset across window boundaries."""
+    keys: list[str] = []
+    client = AsyncMock()
+    client.incr = AsyncMock(side_effect=lambda key: keys.append(key) or 1)
+    client.expire = AsyncMock()
+    client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return client
+
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904030)
+    # 61 seconds later → next window
+    await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904091)
+    assert keys == ["rl:t:1715904000", "rl:t:1715904060"]
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_sets_expire(fake_client):
+    """EXPIRE must be set with ttl = 2× window_size_s so the bucket
+    auto-evicts cleanly after one full window has passed."""
+    await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904030)
+    fake_client.expire.assert_awaited_once()
+    args = fake_client.expire.await_args.args
+    assert args[0] == "rl:t:1715904000"
+    assert args[1] == 120
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_closes_client(fake_client):
+    """Connection must be returned to the pool on success AND on
+    transport failure — leak guard."""
+    await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904000)
+    fake_client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_closes_client_on_failure(monkeypatch):
+    """If INCR raises, aclose still runs (try/finally guard)."""
+    client = AsyncMock()
+    client.incr = AsyncMock(side_effect=ConnectionError("valkey down"))
+    client.expire = AsyncMock()
+    client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return client
+
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", fake_get_client)
+    with pytest.raises(ConnectionError):
+        await check_and_increment(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904000)
+    client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_retry_after_decays(fake_client):
+    """retry_after_s should equal seconds remaining in the current
+    window — decreasing as ``now_unix`` advances."""
+    d1 = await check_and_increment(tenant_id="t", limit=1, window_size_s=60, now_unix=1715904000)
+    d2 = await check_and_increment(tenant_id="t", limit=1, window_size_s=60, now_unix=1715904045)
+    assert d1.retry_after_s == 60
+    assert d2.retry_after_s == 15
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_rejects_zero_window(fake_client):
+    with pytest.raises(ValueError, match="window_size_s must be positive"):
+        await check_and_increment(tenant_id="t", limit=10, window_size_s=0)
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_rejects_zero_limit(fake_client):
+    with pytest.raises(ValueError, match="limit must be positive"):
+        await check_and_increment(tenant_id="t", limit=0, window_size_s=60)
+
+
+@pytest.mark.asyncio
+async def test_check_and_increment_propagates_empty_tenant(fake_client):
+    """Empty tenant_id surfaces from tenant_rl_key as ValueError —
+    no silent cross-tenant counter."""
+    with pytest.raises(ValueError, match="non-empty"):
+        await check_and_increment(tenant_id="", limit=10, window_size_s=60)
+
+
+# ─── enforce wrapper ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enforce_returns_decision_when_allowed(fake_client):
+    """enforce() returns the RateLimitDecision unchanged on allow."""
+    decision = await enforce(tenant_id="t", limit=10, window_size_s=60, now_unix=1715904000)
+    assert isinstance(decision, RateLimitDecision)
+    assert decision.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_enforce_raises_when_refused(fake_client):
+    """enforce() raises RateLimitExceededError when the limiter refuses,
+    carrying tenant + limit + window for upstream 429 mapping."""
+    # Pump 100 through to saturate
+    for _ in range(100):
+        await enforce(tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000)
+    with pytest.raises(RateLimitExceededError) as exc_info:
+        await enforce(tenant_id="t", limit=100, window_size_s=60, now_unix=1715904000)
+    exc = exc_info.value
+    assert exc.tenant_id == "t"
+    assert exc.limit == 100
+    assert exc.window_size_s == 60
+    assert exc.current == 101
+
+
+# ─── defaults ──────────────────────────────────────────────────────────────
+
+
+def test_defaults_match_linear_acceptance():
+    """Linear KEI-171 acceptance specifies '60s window; 100 req/min limit'.
+    The module defaults must match so callers can use ``enforce(tenant_id=)``
+    without explicitly passing the same numbers."""
+    assert DEFAULT_WINDOW_SIZE_S == 60
+    assert DEFAULT_LIMIT == 100
+
+
+# ─── module surface tidy-up (avoid leaking pool state between tests) ──────
+
+
+@pytest.fixture(autouse=True)
+async def _no_leftover_pool():
+    """Belt-and-braces — these tests stub get_valkey_client so the real
+    pool never gets touched, but reset between cases anyway."""
+    yield
+    await valkey_pool.reset_valkey_pool()

--- a/tests/dispatcher/test_tier_limits.py
+++ b/tests/dispatcher/test_tier_limits.py
@@ -1,0 +1,215 @@
+"""KEI-117C — tests for src/dispatcher/tier_limits.
+
+The underlying rate_limiter is mocked at the valkey-client boundary so
+tier-aware enforcement can be tested end-to-end without a live Valkey.
+Tier lookup is fully overrideable via set_tenant_tier_lookup so tests
+don't need to read env vars or hit a DB.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.dispatcher import rate_limiter
+from src.dispatcher.rate_limiter import RateLimitExceededError
+from src.dispatcher.tier_limits import (
+    DEFAULT_TIER,
+    TIER_LIMITS,
+    TIER_OVERRIDES_ENV,
+    UnknownTierError,
+    enforce_for_tenant,
+    get_tenant_tier,
+    limits_for,
+    reset_tenant_tier_lookup,
+    set_tenant_tier_lookup,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_lookup():
+    """Tests must not leak lookup overrides into each other."""
+    yield
+    reset_tenant_tier_lookup()
+
+
+@pytest.fixture
+def fake_valkey(monkeypatch):
+    """Stub the rate limiter's valkey client so enforce_for_tenant runs
+    end-to-end without a live Valkey."""
+    mock_client = AsyncMock()
+    state = {"n": 0}
+
+    def fake_incr(_key):
+        state["n"] += 1
+        return state["n"]
+
+    mock_client.incr = AsyncMock(side_effect=fake_incr)
+    mock_client.expire = AsyncMock(return_value=True)
+    mock_client.aclose = AsyncMock()
+    monkeypatch.setattr(rate_limiter, "get_valkey_client", lambda: mock_client)
+    return mock_client
+
+
+# ─── TIER_LIMITS canonical values (Linear acceptance) ─────────────────────
+
+
+def test_tier_limits_match_linear_acceptance():
+    """Linear KEI-172 specifies Basic=60/min, Pro=300/min, Enterprise=1000/min."""
+    assert TIER_LIMITS["basic"] == (60, 60)
+    assert TIER_LIMITS["pro"] == (300, 60)
+    assert TIER_LIMITS["enterprise"] == (1000, 60)
+
+
+# ─── limits_for ────────────────────────────────────────────────────────────
+
+
+def test_limits_for_returns_tier_tuple():
+    assert limits_for("basic") == (60, 60)
+    assert limits_for("pro") == (300, 60)
+    assert limits_for("enterprise") == (1000, 60)
+
+
+def test_limits_for_raises_on_unknown_tier():
+    """Unknown tier is caller bug (not runtime drift) — must raise loudly."""
+    with pytest.raises(UnknownTierError, match="unknown tier"):
+        limits_for("ultra")  # type: ignore[arg-type]
+
+
+# ─── get_tenant_tier — default lookup ─────────────────────────────────────
+
+
+def test_get_tenant_tier_defaults_to_basic(monkeypatch):
+    """No DISPATCHER_TIER_OVERRIDES, no custom lookup → basic."""
+    monkeypatch.delenv(TIER_OVERRIDES_ENV, raising=False)
+    assert get_tenant_tier("anyone") == "basic"
+
+
+def test_get_tenant_tier_reads_env_overrides(monkeypatch):
+    """DISPATCHER_TIER_OVERRIDES JSON map honored per-tenant."""
+    monkeypatch.setenv(TIER_OVERRIDES_ENV, '{"cust-pro": "pro", "cust-ent": "enterprise"}')
+    assert get_tenant_tier("cust-pro") == "pro"
+    assert get_tenant_tier("cust-ent") == "enterprise"
+    # tenants not in the map fall back to default
+    assert get_tenant_tier("cust-unknown") == DEFAULT_TIER
+
+
+def test_get_tenant_tier_falls_back_when_env_invalid_json(monkeypatch, caplog):
+    """Malformed JSON in env → warning + default tier. NEVER raise."""
+    monkeypatch.setenv(TIER_OVERRIDES_ENV, "this is not json")
+    with caplog.at_level("WARNING"):
+        tier = get_tenant_tier("cust-x")
+    assert tier == DEFAULT_TIER
+    assert any("invalid JSON" in r.message for r in caplog.records)
+
+
+def test_get_tenant_tier_ignores_unknown_tier_in_env(monkeypatch):
+    """An env override pointing at an unrecognized tier silently degrades
+    to the default — defensive against typos / future tier removals."""
+    monkeypatch.setenv(TIER_OVERRIDES_ENV, '{"cust-x": "platinum"}')
+    assert get_tenant_tier("cust-x") == DEFAULT_TIER
+
+
+def test_get_tenant_tier_strips_whitespace():
+    """Whitespace-padded tenant_id resolves like the trimmed form so
+    callers can't accidentally bypass an override via a trailing space."""
+    set_tenant_tier_lookup(lambda tid: "pro" if tid == "cust-1" else "basic")
+    assert get_tenant_tier("  cust-1  ") == "pro"
+
+
+def test_get_tenant_tier_refuses_empty_tenant():
+    """Empty tenant_id is a caller bug — refuse loudly so the rate-limit
+    bucket doesn't collapse to a single shared counter."""
+    with pytest.raises(ValueError, match="non-empty"):
+        get_tenant_tier("")
+    with pytest.raises(ValueError, match="non-empty"):
+        get_tenant_tier("   ")
+
+
+# ─── get_tenant_tier — pluggable lookup ───────────────────────────────────
+
+
+def test_set_tenant_tier_lookup_overrides_default():
+    """Custom lookup replaces the env-override lookup until reset."""
+    set_tenant_tier_lookup(lambda _t: "enterprise")
+    assert get_tenant_tier("cust-x") == "enterprise"
+
+
+def test_reset_tenant_tier_lookup_restores_default(monkeypatch):
+    """After reset, the env-override lookup is back in place."""
+    set_tenant_tier_lookup(lambda _t: "enterprise")
+    reset_tenant_tier_lookup()
+    monkeypatch.delenv(TIER_OVERRIDES_ENV, raising=False)
+    assert get_tenant_tier("cust-x") == "basic"
+
+
+def test_get_tenant_tier_fails_closed_when_lookup_raises(caplog):
+    """A buggy / down-store lookup must NOT bypass rate limiting — fall
+    back to DEFAULT_TIER (most restrictive) and log."""
+
+    def boom(_t):
+        raise RuntimeError("tier store down")
+
+    set_tenant_tier_lookup(boom)
+    with caplog.at_level("WARNING"):
+        tier = get_tenant_tier("cust-x")
+    assert tier == DEFAULT_TIER
+    assert any("tier store down" in r.message for r in caplog.records)
+
+
+def test_get_tenant_tier_fails_closed_when_lookup_returns_unknown(caplog):
+    """Lookup returns a tier not in TIER_LIMITS → degrade to default."""
+    set_tenant_tier_lookup(lambda _t: "platinum")  # type: ignore[arg-type,return-value]
+    with caplog.at_level("WARNING"):
+        tier = get_tenant_tier("cust-x")
+    assert tier == DEFAULT_TIER
+    assert any("unknown tier" in r.message for r in caplog.records)
+
+
+# ─── enforce_for_tenant ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enforce_for_tenant_applies_basic_limit(fake_valkey):
+    """Basic tier → 60/min: 60 allowed, 61st refused."""
+    set_tenant_tier_lookup(lambda _t: "basic")
+    # Pump exactly the basic limit
+    for _ in range(60):
+        await enforce_for_tenant(tenant_id="cust-basic", now_unix=1715904000)
+    with pytest.raises(RateLimitExceededError) as exc_info:
+        await enforce_for_tenant(tenant_id="cust-basic", now_unix=1715904000)
+    assert exc_info.value.limit == 60
+    assert exc_info.value.window_size_s == 60
+
+
+@pytest.mark.asyncio
+async def test_enforce_for_tenant_applies_pro_limit_higher_ceiling(fake_valkey):
+    """Pro tier raises the ceiling to 300/min — first 61 reqs that would
+    refuse Basic must all succeed under Pro."""
+    set_tenant_tier_lookup(lambda _t: "pro")
+    for _ in range(61):
+        decision = await enforce_for_tenant(tenant_id="cust-pro", now_unix=1715904000)
+        assert decision.allowed is True
+    assert decision.limit == 300
+
+
+@pytest.mark.asyncio
+async def test_enforce_for_tenant_applies_enterprise_limit_highest(fake_valkey):
+    """Enterprise tier — limit value reaches RateLimitDecision."""
+    set_tenant_tier_lookup(lambda _t: "enterprise")
+    decision = await enforce_for_tenant(tenant_id="cust-ent", now_unix=1715904000)
+    assert decision.limit == 1000
+    assert decision.window_size_s == 60
+
+
+@pytest.mark.asyncio
+async def test_enforce_for_tenant_uses_per_tenant_tier(fake_valkey):
+    """Two tenants with different tiers in the same call cycle resolve
+    independently — the lookup is called per-tenant, not once per cycle."""
+    tier_map = {"cust-basic": "basic", "cust-pro": "pro"}
+    set_tenant_tier_lookup(lambda tid: tier_map.get(tid, "basic"))  # type: ignore[arg-type,return-value]
+    d_basic = await enforce_for_tenant(tenant_id="cust-basic", now_unix=1715904000)
+    d_pro = await enforce_for_tenant(tenant_id="cust-pro", now_unix=1715904000)
+    assert d_basic.limit == 60
+    assert d_pro.limit == 300

--- a/tests/dispatcher/test_valkey_pool.py
+++ b/tests/dispatcher/test_valkey_pool.py
@@ -78,7 +78,7 @@ async def test_pool_prefers_valkey_url(monkeypatch):
         return AsyncMock()
 
     monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
-    await valkey_pool.get_valkey_pool()
+    valkey_pool.get_valkey_pool()
     assert captured["url"] == "redis://valkey-host:6380/3"
     assert captured["kwargs"]["decode_responses"] is True
     assert captured["kwargs"]["max_connections"] == 20
@@ -95,7 +95,7 @@ async def test_pool_falls_back_to_redis_url(monkeypatch):
         "from_url",
         lambda url, **kw: captured.setdefault("url", url) or AsyncMock(),
     )
-    await valkey_pool.get_valkey_pool()
+    valkey_pool.get_valkey_pool()
     assert captured["url"] == "redis://shared:6379/1"
 
 
@@ -110,7 +110,7 @@ async def test_pool_falls_back_to_default(monkeypatch):
         "from_url",
         lambda url, **kw: captured.setdefault("url", url) or AsyncMock(),
     )
-    await valkey_pool.get_valkey_pool()
+    valkey_pool.get_valkey_pool()
     assert captured["url"] == DEFAULT_VALKEY_URL
 
 
@@ -128,9 +128,9 @@ async def test_pool_is_cached_across_calls(monkeypatch):
         return AsyncMock()
 
     monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
-    p1 = await valkey_pool.get_valkey_pool()
-    p2 = await valkey_pool.get_valkey_pool()
-    p3 = await valkey_pool.get_valkey_pool()
+    p1 = valkey_pool.get_valkey_pool()
+    p2 = valkey_pool.get_valkey_pool()
+    p3 = valkey_pool.get_valkey_pool()
     assert p1 is p2 is p3
     assert calls["n"] == 1
 
@@ -147,9 +147,9 @@ async def test_reset_pool_invalidates_cache(monkeypatch):
         return mock_pool
 
     monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
-    await valkey_pool.get_valkey_pool()
+    valkey_pool.get_valkey_pool()
     await reset_valkey_pool()
-    await valkey_pool.get_valkey_pool()
+    valkey_pool.get_valkey_pool()
     assert calls["n"] == 2
 
 
@@ -165,10 +165,7 @@ async def test_smoke_incr_runs_incr_and_expire(monkeypatch):
     mock_client.expire = AsyncMock(return_value=True)
     mock_client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return mock_client
-
-    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", lambda: mock_client)
 
     value = await smoke_incr()
     assert value == 1
@@ -191,10 +188,7 @@ async def test_smoke_incr_returns_post_increment_value(monkeypatch):
     mock_client.expire = AsyncMock(return_value=True)
     mock_client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return mock_client
-
-    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", lambda: mock_client)
     assert await smoke_incr() == 6
 
 
@@ -207,10 +201,7 @@ async def test_smoke_incr_closes_client_even_on_failure(monkeypatch):
     mock_client.expire = AsyncMock()
     mock_client.aclose = AsyncMock()
 
-    async def fake_get_client():
-        return mock_client
-
-    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", lambda: mock_client)
     with pytest.raises(ConnectionError):
         await smoke_incr()
     mock_client.aclose.assert_awaited_once()

--- a/tests/dispatcher/test_valkey_pool.py
+++ b/tests/dispatcher/test_valkey_pool.py
@@ -1,0 +1,216 @@
+"""KEI-117A — tests for src/dispatcher/valkey_pool.
+
+Redis client is mocked via AsyncMock so no live Valkey/Redis required
+for CI. Pool state is reset between cases so tests stay independent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.dispatcher import valkey_pool
+from src.dispatcher.valkey_pool import (
+    DEFAULT_VALKEY_URL,
+    RL_NAMESPACE_PREFIX,
+    SMOKE_KEY_TTL_SECONDS,
+    reset_valkey_pool,
+    smoke_incr,
+    tenant_rl_key,
+)
+
+
+@pytest.fixture(autouse=True)
+async def _clean_pool_each_test():
+    """Tear down the module-level pool before AND after each case so URL
+    resolution + caching tests don't bleed into each other."""
+    await reset_valkey_pool()
+    yield
+    await reset_valkey_pool()
+
+
+# ─── tenant_rl_key ─────────────────────────────────────────────────────────
+
+
+def test_tenant_rl_key_format():
+    """Key shape is exactly ``rl:<tenant>:<window>``."""
+    key = tenant_rl_key("cust-abc", 1715900000)
+    assert key == f"{RL_NAMESPACE_PREFIX}:cust-abc:1715900000"
+
+
+def test_tenant_rl_key_coerces_window_to_int():
+    """A float window (e.g. ``time.time()``) is truncated, not rounded —
+    matches the int() cast in the helper."""
+    key = tenant_rl_key("t", 1715900000.987)
+    assert key.endswith(":1715900000")
+
+
+def test_tenant_rl_key_strips_whitespace():
+    """Trailing whitespace on tenant_id is stripped to prevent invisible
+    duplicate buckets ('cust-1 ' vs 'cust-1')."""
+    assert tenant_rl_key("  cust-1  ", 0) == f"{RL_NAMESPACE_PREFIX}:cust-1:0"
+
+
+def test_tenant_rl_key_refuses_empty_tenant():
+    """An empty / whitespace-only tenant_id would silently bucket all
+    requests into one counter — refuse it."""
+    with pytest.raises(ValueError, match="non-empty"):
+        tenant_rl_key("", 0)
+    with pytest.raises(ValueError, match="non-empty"):
+        tenant_rl_key("   ", 0)
+
+
+# ─── pool URL resolution ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pool_prefers_valkey_url(monkeypatch):
+    """VALKEY_URL wins over REDIS_URL."""
+    monkeypatch.setenv("VALKEY_URL", "redis://valkey-host:6380/3")
+    monkeypatch.setenv("REDIS_URL", "redis://redis-host:6379/0")
+
+    captured: dict = {}
+
+    def fake_from_url(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return AsyncMock()
+
+    monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
+    await valkey_pool.get_valkey_pool()
+    assert captured["url"] == "redis://valkey-host:6380/3"
+    assert captured["kwargs"]["decode_responses"] is True
+    assert captured["kwargs"]["max_connections"] == 20
+
+
+@pytest.mark.asyncio
+async def test_pool_falls_back_to_redis_url(monkeypatch):
+    """No VALKEY_URL → REDIS_URL is used."""
+    monkeypatch.delenv("VALKEY_URL", raising=False)
+    monkeypatch.setenv("REDIS_URL", "redis://shared:6379/1")
+    captured: dict = {}
+    monkeypatch.setattr(
+        valkey_pool.ConnectionPool,
+        "from_url",
+        lambda url, **kw: captured.setdefault("url", url) or AsyncMock(),
+    )
+    await valkey_pool.get_valkey_pool()
+    assert captured["url"] == "redis://shared:6379/1"
+
+
+@pytest.mark.asyncio
+async def test_pool_falls_back_to_default(monkeypatch):
+    """No env vars → the local default URL."""
+    monkeypatch.delenv("VALKEY_URL", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    captured: dict = {}
+    monkeypatch.setattr(
+        valkey_pool.ConnectionPool,
+        "from_url",
+        lambda url, **kw: captured.setdefault("url", url) or AsyncMock(),
+    )
+    await valkey_pool.get_valkey_pool()
+    assert captured["url"] == DEFAULT_VALKEY_URL
+
+
+# ─── pool caching ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pool_is_cached_across_calls(monkeypatch):
+    """get_valkey_pool() returns the same pool instance on subsequent
+    calls — ConnectionPool.from_url is invoked exactly once."""
+    calls = {"n": 0}
+
+    def fake_from_url(url, **kw):
+        calls["n"] += 1
+        return AsyncMock()
+
+    monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
+    p1 = await valkey_pool.get_valkey_pool()
+    p2 = await valkey_pool.get_valkey_pool()
+    p3 = await valkey_pool.get_valkey_pool()
+    assert p1 is p2 is p3
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_pool_invalidates_cache(monkeypatch):
+    """After reset_valkey_pool, the next call rebuilds the pool."""
+    calls = {"n": 0}
+
+    def fake_from_url(url, **kw):
+        calls["n"] += 1
+        mock_pool = AsyncMock()
+        mock_pool.aclose = AsyncMock()
+        return mock_pool
+
+    monkeypatch.setattr(valkey_pool.ConnectionPool, "from_url", fake_from_url)
+    await valkey_pool.get_valkey_pool()
+    await reset_valkey_pool()
+    await valkey_pool.get_valkey_pool()
+    assert calls["n"] == 2
+
+
+# ─── smoke_incr ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_smoke_incr_runs_incr_and_expire(monkeypatch):
+    """smoke_incr issues INCR then EXPIRE on a per-process namespaced key
+    and returns the post-INCR integer."""
+    mock_client = AsyncMock()
+    mock_client.incr = AsyncMock(return_value=1)
+    mock_client.expire = AsyncMock(return_value=True)
+    mock_client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return mock_client
+
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+
+    value = await smoke_incr()
+    assert value == 1
+    mock_client.incr.assert_awaited_once()
+    incr_key = mock_client.incr.await_args.args[0]
+    assert incr_key.startswith(f"{RL_NAMESPACE_PREFIX}:_smoke:")
+    mock_client.expire.assert_awaited_once()
+    exp_args = mock_client.expire.await_args.args
+    assert exp_args[0] == incr_key
+    assert exp_args[1] == SMOKE_KEY_TTL_SECONDS
+    mock_client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_smoke_incr_returns_post_increment_value(monkeypatch):
+    """If the smoke key already had 5 (impossible in practice — it has
+    60s TTL — but covered for safety), smoke_incr returns 6."""
+    mock_client = AsyncMock()
+    mock_client.incr = AsyncMock(return_value=6)
+    mock_client.expire = AsyncMock(return_value=True)
+    mock_client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return mock_client
+
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+    assert await smoke_incr() == 6
+
+
+@pytest.mark.asyncio
+async def test_smoke_incr_closes_client_even_on_failure(monkeypatch):
+    """If INCR raises (e.g. transport failure), the client.aclose() must
+    still run so we don't leak a connection from the pool."""
+    mock_client = AsyncMock()
+    mock_client.incr = AsyncMock(side_effect=ConnectionError("valkey unreachable"))
+    mock_client.expire = AsyncMock()
+    mock_client.aclose = AsyncMock()
+
+    async def fake_get_client():
+        return mock_client
+
+    monkeypatch.setattr(valkey_pool, "get_valkey_client", fake_get_client)
+    with pytest.raises(ConnectionError):
+        await smoke_incr()
+    mock_client.aclose.assert_awaited_once()


### PR DESCRIPTION
## Summary

Closes KEI-168 (KEI-116B, **P0 ratified**). Server-side symmetric encryption for customer API keys via pgcrypto. Master keys are indexed by ``rotation_id`` env var (``DISPATCHER_API_KEY_MASTER_V{N}``) so a rolling key rotation can land without re-encrypting historical rows.

Independent of the dispatcher PR chain — no stack. Sister to KEI-167 (schema) and KEI-169 (lookup hash), neither merged yet.

## Acceptance (Linear KEI-168 P0)

- [x] **INSERT encrypts via pgp_sym_encrypt(plaintext, master_key)** — \`encrypt(conn, plaintext)\` issues \`SELECT pgp_sym_encrypt(%s, %s)\` and returns bytea
- [x] **SELECT decrypts** — \`decrypt(conn, encrypted)\` issues \`SELECT pgp_sym_decrypt(%s, %s)\` and returns the original plaintext string
- [x] **rotation_id allows future key rotation** — every encrypt/decrypt resolves the right master key from env per ``rotation_id``; caller stores ``rotation_id`` alongside the ciphertext for decrypt-side resolution

## Empirical roundtrip (per empirical-smoke-catches-paper-review-3)

Against the real Supabase pooler:

\`\`\`
$ DISPATCHER_API_KEY_MASTER_V1=test-master-key python3 -c \"...encrypt+decrypt roundtrip...\"
encrypted: 97 bytes, type=bytes
decrypted: 'sk-anthropic-empirical-test-xyz'
ROUNDTRIP_OK
\`\`\`

## Security notes

- Plaintext never logged.
- Parameterised query — no string interpolation of plaintext or master key.
- Master key never returned to caller — resolved inside \`_resolve_master_key\`, passed straight to pgcrypto via parameter bind.
- Fail-closed: missing env → \`MasterKeyMissingError\` raised BEFORE any DB call.
- Future hardening (separate KEI): wrap \`pgp_sym_encrypt\` in a PL/pgSQL \`SECURITY DEFINER\` function reading the master from a Supabase secret — same Python call shape.

## Out of scope

- \`customer_api_keys.rotation_id\` column → KEI-167 schema PR adds it; until then caller stores the pair in their own table or as part of the lookup_hash structure
- SHA-256 \`lookup_hash\` derivation → KEI-169 (KEI-116C)
- Master-key provisioning → operator concern; env contract documented in module docstring

## Test plan

- [x] \`pytest tests/dispatcher/test_api_key_crypto.py\` — 20/20 (psycopg cursor mocked; env injected via monkeypatch).
- [x] \`ruff check\` — All checks passed.
- [x] \`ruff format --check\` — 2 files already formatted.
- [x] Empirical roundtrip against real Supabase pooler — see above.

Coverage:
- env resolution: V1 default, V2+ per rotation, whitespace strip, missing → raise, empty → raise
- encrypt: correct SQL + params, rotation routing, default V1, refuses empty, CryptoError on missing/null row, propagates MasterKeyMissingError before DB call
- decrypt: correct SQL + params, rotation routing, refuses empty bytes, wraps DB exception in CryptoError, CryptoError on missing/null row
- encrypt_for_storage: returns \`(ciphertext, rotation_id)\` pair, preserves explicit rotation
- encrypt→decrypt roundtrip with mocked pgcrypto identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)