### PR TITLE
[AIDEN] feat(kei160): API key mgmt UI — list/rotate/revoke shell (KEI-114C)

### DIFF
--- a/frontend/app/(dispatcher)/dashboard/keys/page.tsx
+++ b/frontend/app/(dispatcher)/dashboard/keys/page.tsx
@@ -1,34 +1,85 @@
 /**
  * FILE: frontend/app/(dispatcher)/dashboard/keys/page.tsx
  * PURPOSE: API key management — list + rotate + revoke (BYO key flow).
- * KEI: 114C (Linear KEI-160) — Key Mgmt UI implementation.
- *      Deps: 111E (RLS on api_keys), 116A/B/C (BYO key encryption chain —
- *      schema + encrypt/decrypt wrappers + lookup hash, P0 per Max's
- *      DPA-compliance escalation Wave 3 2026-05-17).
+ * KEI: 160 (KEI-114C) — Key Mgmt UI implementation. Replaces the KEI-114
+ *      scaffold stub. Wires the render-component family (api-key-list.tsx +
+ *      api-key-rotate-dialog.tsx) on top of mock data; sub-KEI claimer
+ *      wires the real Supabase RLS + Orion's KEI-116 BYO crypto on top.
  *
- * Stub only. Implementer wires:
- *   - SELECT id, lookup_hash, label, created_at, last_used_at FROM
- *     public.api_keys WHERE tenant_id = current_tenant() — RLS enforces.
- *     NEVER select encrypted_key on this page; display hash prefix only.
- *   - Rotate flow: generate new key (server-side), encrypt-then-store,
- *     return plaintext ONCE (clipboard-copy modal), old key flagged revoked.
- *   - Revoke flow: UPDATE api_keys SET revoked_at = NOW() (soft delete).
- *   - Display: short-hash label (sha256[:8]) so customer can identify the
- *     key without ever seeing the plaintext. Plaintext shown only at
- *     create/rotate time, never again.
- *   - Audit: every rotate/revoke writes to audit_logs (table TBD).
+ * Render-path-only (matches Scout's KEI-158 PR #957 pattern): mock data
+ * inline, action callbacks log to console. Sub-KEI claimer:
+ *   - Replace `_mockKeys` with `useApiKeys()` hook reading public.api_keys
+ *     under RLS (sees only the signed-in tenant's rows).
+ *   - Replace `onRotate` with a server-action calling /api/dispatcher/keys/
+ *     rotate which generates a key, encrypts via pgp_sym_encrypt (KEI-116B),
+ *     writes lookup_hash via SHA-256 (KEI-116C), returns plaintext ONCE.
+ *   - Replace `onRevoke` with a server-action UPDATE-ing revoked_at=NOW().
+ *   - Audit log writes on every rotate/revoke (table TBD).
+ *
+ * Display contract (load-bearing):
+ *   - Plaintext only surfaces inside ApiKeyRotateDialog after a successful
+ *     rotate. The dialog's plaintext prop must be reset to null at close.
+ *   - lookup_hash_prefix is the only key-identifier shown in the list.
  */
 
+"use client";
+
+import * as React from "react";
+
+import {
+  ApiKeyList,
+  type ApiKey,
+} from "@/components/dispatcher/api-key-list";
+import { ApiKeyRotateDialog } from "@/components/dispatcher/api-key-rotate-dialog";
+
+const _mockKeys: ApiKey[] = [
+  {
+    id: "key-1",
+    label: "production",
+    lookup_hash_prefix: "a3f8b2c0",
+    created_at: "2026-05-01T10:00:00Z",
+    last_used_at: "2026-05-17T09:15:00Z",
+    revoked_at: null,
+  },
+];
+
 export default function DispatcherDashboardKeysPage() {
+  const [rotateOpen, setRotateOpen] = React.useState(false);
+  const [rotatingLabel, setRotatingLabel] = React.useState("");
+
+  const handleRotate = React.useCallback((keyId: string) => {
+    const key = _mockKeys.find((k) => k.id === keyId);
+    setRotatingLabel(key?.label ?? "");
+    setRotateOpen(true);
+  }, []);
+
+  const handleRevoke = React.useCallback((keyId: string) => {
+    // Sub-KEI claimer: server action UPDATE api_keys SET revoked_at = NOW().
+    // eslint-disable-next-line no-console
+    console.info("[stub] revoke", keyId);
+  }, []);
+
   return (
     <main className="mx-auto max-w-5xl p-8">
-      <h1 className="text-2xl font-semibold">API keys</h1>
-      <p className="mt-4 text-sm text-muted-foreground">
-        Implementation pending KEI-114C (KEI-160). List + rotate + revoke
-        controls land here. Plaintext keys are surfaced once at create/rotate
-        time and never again — the list shows lookup-hash prefix only per
-        KEI-116 BYO encryption.
-      </p>
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold">API keys</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Keys appear once at create / rotate time and never again — copy the
+          plaintext immediately. The list below shows lookup-hash prefixes
+          only.
+        </p>
+      </header>
+      <ApiKeyList
+        keys={_mockKeys}
+        onRotate={handleRotate}
+        onRevoke={handleRevoke}
+      />
+      <ApiKeyRotateDialog
+        open={rotateOpen}
+        onOpenChange={setRotateOpen}
+        plaintext={null}
+        label={rotatingLabel}
+      />
     </main>
   );
 }

--- a/frontend/components/dispatcher/__tests__/api-key-list.test.tsx
+++ b/frontend/components/dispatcher/__tests__/api-key-list.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Tests for ApiKeyList + ApiKeyRotateDialog component shells (KEI-160).
+ *
+ * Render-path-only — sub-KEI claimer extends with server-action tests once
+ * the encrypt-and-show-once + revoke wires land on top of Orion's KEI-116
+ * BYO crypto.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { ApiKeyList, type ApiKey } from "../api-key-list";
+import { ApiKeyRotateDialog } from "../api-key-rotate-dialog";
+
+const _sample: ApiKey[] = [
+  {
+    id: "key-1",
+    label: "production",
+    lookup_hash_prefix: "a3f8b2c0",
+    created_at: "2026-05-01T10:00:00Z",
+    last_used_at: "2026-05-17T09:15:00Z",
+    revoked_at: null,
+  },
+  {
+    id: "key-2",
+    label: "ci-pipeline",
+    lookup_hash_prefix: "9e1d4f77",
+    created_at: "2026-04-12T08:30:00Z",
+    last_used_at: null,
+    revoked_at: null,
+  },
+  {
+    id: "key-3",
+    label: "old-key",
+    lookup_hash_prefix: "11abcd22",
+    created_at: "2026-03-01T08:30:00Z",
+    last_used_at: "2026-04-30T22:00:00Z",
+    revoked_at: "2026-05-10T11:00:00Z",
+  },
+];
+
+describe("ApiKeyList", () => {
+  test("renders empty-state when keys=[]", () => {
+    render(<ApiKeyList keys={[]} />);
+    expect(screen.getByTestId("api-key-list-empty")).toBeInTheDocument();
+  });
+
+  test("renders loading-state when loading=true", () => {
+    render(<ApiKeyList keys={[]} loading />);
+    expect(screen.getByTestId("api-key-list-loading")).toBeInTheDocument();
+  });
+
+  test("renders table with one row per key", () => {
+    render(<ApiKeyList keys={_sample} />);
+    const table = screen.getByTestId("api-key-list-table");
+    expect(table).toBeInTheDocument();
+    expect(screen.getByText("production")).toBeInTheDocument();
+    expect(screen.getByText("ci-pipeline")).toBeInTheDocument();
+    expect(screen.getByText("old-key")).toBeInTheDocument();
+  });
+
+  test("renders hash prefix with ellipsis (never plaintext)", () => {
+    render(<ApiKeyList keys={_sample} />);
+    expect(screen.getByText("a3f8b2c0…")).toBeInTheDocument();
+    expect(screen.getByText("9e1d4f77…")).toBeInTheDocument();
+  });
+
+  test("shows '—' for keys never used", () => {
+    render(<ApiKeyList keys={[_sample[1]]} />);
+    // never-used row renders em-dash in the last-used cell
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("revoked key shows Revoked status and disables actions", () => {
+    const onRotate = vi.fn();
+    const onRevoke = vi.fn();
+    render(
+      <ApiKeyList keys={[_sample[2]]} onRotate={onRotate} onRevoke={onRevoke} />,
+    );
+    expect(screen.getByText("Revoked")).toBeInTheDocument();
+    const rotateButton = screen.getByRole("button", { name: "Rotate" });
+    const revokeButton = screen.getByRole("button", { name: "Revoke" });
+    expect(rotateButton).toBeDisabled();
+    expect(revokeButton).toBeDisabled();
+  });
+
+  test("active key calls onRotate(keyId) when Rotate clicked", () => {
+    const onRotate = vi.fn();
+    render(<ApiKeyList keys={[_sample[0]]} onRotate={onRotate} />);
+    fireEvent.click(screen.getByRole("button", { name: "Rotate" }));
+    expect(onRotate).toHaveBeenCalledWith("key-1");
+  });
+
+  test("active key calls onRevoke(keyId) when Revoke clicked", () => {
+    const onRevoke = vi.fn();
+    render(<ApiKeyList keys={[_sample[0]]} onRevoke={onRevoke} />);
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    expect(onRevoke).toHaveBeenCalledWith("key-1");
+  });
+});
+
+describe("ApiKeyRotateDialog", () => {
+  test("renders 'Generating…' placeholder when plaintext=null", () => {
+    render(
+      <ApiKeyRotateDialog
+        open
+        onOpenChange={() => {}}
+        plaintext={null}
+        label="production"
+      />,
+    );
+    expect(screen.getByTestId("api-key-rotate-pending")).toBeInTheDocument();
+  });
+
+  test("renders plaintext in pre block when supplied", () => {
+    render(
+      <ApiKeyRotateDialog
+        open
+        onOpenChange={() => {}}
+        plaintext="sk-live-ABCDEF1234567890"
+        label="production"
+      />,
+    );
+    const pre = screen.getByTestId("api-key-rotate-plaintext");
+    expect(pre).toHaveTextContent("sk-live-ABCDEF1234567890");
+  });
+
+  test("'I've saved it' button calls onAcknowledge + closes dialog", () => {
+    const onAcknowledge = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ApiKeyRotateDialog
+        open
+        onOpenChange={onOpenChange}
+        plaintext="sk-live-ABC"
+        label="production"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /saved it/i }));
+    expect(onAcknowledge).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  test("Copy button is disabled when plaintext is null", () => {
+    render(
+      <ApiKeyRotateDialog
+        open
+        onOpenChange={() => {}}
+        plaintext={null}
+        label="production"
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /copy to clipboard/i }),
+    ).toBeDisabled();
+  });
+});

--- a/frontend/components/dispatcher/api-key-list.tsx
+++ b/frontend/components/dispatcher/api-key-list.tsx
@@ -1,0 +1,143 @@
+/**
+ * FILE: frontend/components/dispatcher/api-key-list.tsx
+ * PURPOSE: Customer-facing API key list for the Dispatcher dashboard.
+ *          Renders existing keys (lookup-hash prefix + label + last_used_at)
+ *          and emits rotate / revoke action callbacks. Sub-KEI claimer wires
+ *          data loading + server actions for the rotate (encrypt-and-show-once)
+ *          + revoke (soft-delete) flows on top of Orion's KEI-116 BYO crypto.
+ * KEI: 160 (KEI-114C) — child of Aiden's KEI-114 dashboard scaffold.
+ *
+ * Stub: typed component shell + props interface. Render path uses the shared
+ * shadcn Table + Button primitives. NO plaintext key handling here — keys
+ * appear ONCE at create/rotate time via api-key-rotate-dialog.tsx, never again.
+ *
+ * LAW II: no monetary values on this page (key metadata only); $AUD-only rule
+ * does not apply but ApiKeyRow shape stays free of any USD-named field so
+ * future "key with attached cost cap" extensions inherit the AUD-first norm.
+ *
+ * Security shape (load-bearing for sub-KEI claimer):
+ *   - DISPLAY field is `lookup_hash_prefix` (first 8 hex chars of SHA-256 hash).
+ *   - The plaintext `secret` is NEVER passed into this component. It only
+ *     exists on the rotate-dialog momentarily and then must be cleared.
+ *   - `last_used_at` is observed via api_keys.last_used_at (KEI-116C lookup
+ *     hash table write). Stale-key detection (e.g. >90d unused) lives in a
+ *     later sub-KEI, not here.
+ */
+
+import * as React from "react";
+
+import { Button } from "../ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+
+export interface ApiKey {
+  id: string;
+  label: string;
+  /** First 8 hex chars of SHA-256 lookup hash; full key never returned to UI. */
+  lookup_hash_prefix: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface ApiKeyListProps {
+  keys: ApiKey[];
+  loading?: boolean;
+  emptyMessage?: string;
+  onRotate?: (keyId: string) => void;
+  onRevoke?: (keyId: string) => void;
+}
+
+const formatTimestamp = (iso: string | null): string =>
+  iso === null ? "—" : new Date(iso).toLocaleString();
+
+export function ApiKeyList({
+  keys,
+  loading = false,
+  emptyMessage = "No API keys yet. Generate your first key to get started.",
+  onRotate,
+  onRevoke,
+}: Readonly<ApiKeyListProps>) {
+  if (loading) {
+    return (
+      <div
+        data-testid="api-key-list-loading"
+        className="py-8 text-center text-sm text-muted-foreground"
+      >
+        Loading keys…
+      </div>
+    );
+  }
+  if (keys.length === 0) {
+    return (
+      <div
+        data-testid="api-key-list-empty"
+        className="py-8 text-center text-sm text-muted-foreground"
+      >
+        {emptyMessage}
+      </div>
+    );
+  }
+  return (
+    <Table data-testid="api-key-list-table">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Label</TableHead>
+          <TableHead>Hash prefix</TableHead>
+          <TableHead>Created</TableHead>
+          <TableHead>Last used</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {keys.map((k) => {
+          const isRevoked = k.revoked_at !== null;
+          return (
+            <TableRow
+              key={k.id}
+              data-key-id={k.id}
+              data-key-revoked={isRevoked ? "true" : "false"}
+            >
+              <TableCell className="font-medium">{k.label}</TableCell>
+              <TableCell className="font-mono text-xs">
+                {k.lookup_hash_prefix}…
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {formatTimestamp(k.created_at)}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {formatTimestamp(k.last_used_at)}
+              </TableCell>
+              <TableCell>{isRevoked ? "Revoked" : "Active"}</TableCell>
+              <TableCell className="text-right space-x-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isRevoked || !onRotate}
+                  onClick={() => onRotate?.(k.id)}
+                >
+                  Rotate
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isRevoked || !onRevoke}
+                  onClick={() => onRevoke?.(k.id)}
+                >
+                  Revoke
+                </Button>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}

--- a/frontend/components/dispatcher/api-key-rotate-dialog.tsx
+++ b/frontend/components/dispatcher/api-key-rotate-dialog.tsx
@@ -1,0 +1,107 @@
+/**
+ * FILE: frontend/components/dispatcher/api-key-rotate-dialog.tsx
+ * PURPOSE: One-shot plaintext-key display modal for the rotate flow.
+ *          The customer sees the new plaintext key EXACTLY ONCE (this dialog
+ *          renders); after dismiss, the plaintext is gone from the UI and
+ *          can never be retrieved again (server-side encrypted via Orion's
+ *          KEI-116 pgcrypto; UI only sees plaintext at create/rotate time).
+ * KEI: 160 (KEI-114C) — sibling to api-key-list.tsx.
+ *
+ * Stub: typed component shell. Sub-KEI claimer wires the actual server-action
+ * that POSTs to a /api/dispatcher/keys/rotate handler, receives the plaintext
+ * (in the response body, NEVER stored client-side beyond this dialog's lifetime),
+ * and triggers re-render with the new plaintext via the `plaintext` prop.
+ *
+ * The dialog deliberately exposes a "Copy to clipboard" affordance because the
+ * customer MUST capture the plaintext before dismissing — otherwise they lose
+ * access. After dismiss, this component's `plaintext` prop should be reset to
+ * null at the call-site so the value drops out of React state.
+ */
+
+import * as React from "react";
+
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+
+export interface ApiKeyRotateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Plaintext API key — present ONLY for the duration of this dialog. */
+  plaintext: string | null;
+  /** Label of the rotated key, for display in the description text. */
+  label: string;
+  /** Called when the customer confirms they've captured the key. */
+  onAcknowledge?: () => void;
+}
+
+export function ApiKeyRotateDialog({
+  open,
+  onOpenChange,
+  plaintext,
+  label,
+  onAcknowledge,
+}: Readonly<ApiKeyRotateDialogProps>) {
+  const handleCopy = React.useCallback(() => {
+    if (plaintext === null) return;
+    void navigator.clipboard?.writeText(plaintext);
+  }, [plaintext]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="api-key-rotate-dialog" className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Save your new API key</DialogTitle>
+          <DialogDescription>
+            Copy the key below before closing this dialog. We don&apos;t store
+            the plaintext — once you dismiss, you cannot retrieve it.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <p className="text-sm font-medium">{label}</p>
+          {plaintext === null ? (
+            <p
+              data-testid="api-key-rotate-pending"
+              className="rounded-md bg-muted p-3 font-mono text-sm text-muted-foreground"
+            >
+              Generating…
+            </p>
+          ) : (
+            <pre
+              data-testid="api-key-rotate-plaintext"
+              className="overflow-x-auto whitespace-pre-wrap break-all rounded-md bg-muted p-3 font-mono text-sm"
+            >
+              {plaintext}
+            </pre>
+          )}
+        </div>
+        <DialogFooter className="gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={plaintext === null}
+            onClick={handleCopy}
+          >
+            Copy to clipboard
+          </Button>
+          <Button
+            type="button"
+            disabled={plaintext === null}
+            onClick={() => {
+              onAcknowledge?.();
+              onOpenChange(false);
+            }}
+          >
+            I&apos;ve saved it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
Linear [KEI-160 / KEI-114C](https://linear.app/keiracom/issue/KEI-160) — API key management UI for the dispatcher dashboard. Replaces the KEI-114 scaffold stub at `frontend/app/(dispatcher)/dashboard/keys/page.tsx` with a working render of the ApiKeyList + ApiKeyRotateDialog component family. Mock data inline; sub-KEI claimer wires real Supabase RLS + Orion's KEI-116 BYO crypto server actions.

Mirrors Scout's KEI-158 TaskFeed (PR #957) pattern: render-path-only shell with `Readonly<TProps>` pre-emptive per Sonar S6759.

## Files (4)
| Path | What |
|---|---|
| `frontend/components/dispatcher/api-key-list.tsx` | `ApiKeyList` + `ApiKey` type |
| `frontend/components/dispatcher/api-key-rotate-dialog.tsx` | One-shot plaintext-display modal w/ Copy + Acknowledge |
| `frontend/components/dispatcher/__tests__/api-key-list.test.tsx` | 12 render tests |
| `frontend/app/(dispatcher)/dashboard/keys/page.tsx` | Wires ApiKeyList with mock data |

## Security-shape constraints baked into types
- `ApiKey.lookup_hash_prefix` is the ONLY identifier field on the list type — sub-KEI claimer cannot accidentally pull `encrypted_key` into the UI surface
- No `secret` / `plaintext` / `encrypted_key` field on `ApiKey` — those never reach the list
- Plaintext only exists in `ApiKeyRotateDialog.plaintext` (one-shot prop); call-site MUST reset to null after dialog close
- `Readonly<TProps>` wraps on both components (pre-emptive S6759 fix per Scout's #957 pattern)

## LAW II compliance
No monetary values on this page. Type stays free of any USD-named field so future "cost cap per key" extensions inherit the AUD-first norm.

## Sub-KEI claimer scope (NOT in this PR)
- Replace `_mockKeys` with `useApiKeys()` hook reading `public.api_keys` under RLS (KEI-111E)
- `onRotate` → server-action calling `/api/dispatcher/keys/rotate` → generates key, encrypts via `pgp_sym_encrypt` (KEI-116B), writes lookup_hash via SHA-256 (KEI-116C), returns plaintext ONCE
- `onRevoke` → server-action `UPDATE api_keys SET revoked_at = NOW()` soft-delete
- Audit log writes on every rotate/revoke

## Verification (verbatim)
```
$ cd frontend && npx tsc --noEmit -p tsconfig.json | grep -E "api-key|keys/page"
(empty — 0 errors on new files)

$ npx vitest run components/dispatcher/__tests__/api-key-list.test.tsx
 ✓ components/dispatcher/__tests__/api-key-list.test.tsx (12 tests) 238ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

## Sibling PRs in the KEI-114 family
- PR #957 (Scout KEI-158 TaskFeed — A) — open, pending Elliot merge
- PR #968 (Scout KEI-161 ThreadUsageGauge — D) — open
- KEI-159 (Cost-per-task — B) — shipped earlier today

🤖 Generated with [Claude Code](https://claude.com/claude-code)