### PR TITLE
[SCOUT] feat(kei156): FirstTaskForm component + useFirstTaskSubmit hook stub

### DIFF
--- a/frontend/components/dispatcher/__tests__/first-task-form.test.tsx
+++ b/frontend/components/dispatcher/__tests__/first-task-form.test.tsx
@@ -74,7 +74,7 @@ describe("FirstTaskForm", () => {
     });
     expect(onSubmit).toHaveBeenCalledTimes(1);
     const form = screen.getByTestId("first-task-form");
-    expect(form.getAttribute("data-state")).toBe("pending");
+    expect((form as HTMLElement).dataset.state).toBe("pending");
   });
 
   test("custom pendingLabel prop overrides default", async () => {
@@ -118,13 +118,13 @@ describe("FirstTaskForm", () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     render(<FirstTaskForm onSubmit={onSubmit} />);
     const form = screen.getByTestId("first-task-form");
-    expect(form.getAttribute("data-state")).toBe("idle");
+    expect((form as HTMLElement).dataset.state).toBe("idle");
     fireEvent.change(screen.getByTestId("first-task-title-input"), {
       target: { value: "valid task" },
     });
     fireEvent.click(screen.getByTestId("first-task-submit"));
     await waitFor(() => {
-      expect(form.getAttribute("data-state")).toBe("pending");
+      expect((form as HTMLElement).dataset.state).toBe("pending");
     });
   });
 });

--- a/frontend/components/dispatcher/__tests__/first-task-form.test.tsx
+++ b/frontend/components/dispatcher/__tests__/first-task-form.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Tests for FirstTaskForm component shell (KEI-156).
+ *
+ * Interaction-heavy — covers validation, submit success, submit failure,
+ * pending state lockout. Sub-KEI extends with end-to-end Prefect enqueue
+ * confirmation tests once useFirstTaskSubmit is implemented.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { FirstTaskForm } from "../first-task-form";
+
+function _setup(onSubmit = vi.fn().mockResolvedValue(undefined)) {
+  render(<FirstTaskForm onSubmit={onSubmit} />);
+  const title = screen.getByTestId("first-task-title-input") as HTMLInputElement;
+  const desc = screen.getByTestId("first-task-description-input") as HTMLTextAreaElement;
+  const submit = screen.getByTestId("first-task-submit") as HTMLButtonElement;
+  return { onSubmit, title, desc, submit };
+}
+
+describe("FirstTaskForm", () => {
+  test("renders form heading, inputs, submit button", () => {
+    _setup();
+    expect(screen.getByTestId("first-task-form")).toBeInTheDocument();
+    expect(screen.getByText("Submit your first task")).toBeInTheDocument();
+    expect(screen.getByTestId("first-task-title-input")).toBeInTheDocument();
+    expect(screen.getByTestId("first-task-description-input")).toBeInTheDocument();
+    expect(screen.getByTestId("first-task-submit")).toBeInTheDocument();
+  });
+
+  test("custom heading prop overrides default", () => {
+    render(<FirstTaskForm onSubmit={vi.fn()} heading="Onboarding step 3" />);
+    expect(screen.getByText("Onboarding step 3")).toBeInTheDocument();
+  });
+
+  test("rejects title shorter than 4 chars with inline error", async () => {
+    const { onSubmit, title, submit } = _setup();
+    fireEvent.change(title, { target: { value: "hi" } });
+    fireEvent.click(submit);
+    await waitFor(() => {
+      expect(screen.getByTestId("first-task-error")).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("rejects empty title with inline error", async () => {
+    const { onSubmit, submit } = _setup();
+    fireEvent.click(submit);
+    await waitFor(() => {
+      expect(screen.getByTestId("first-task-error")).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("calls onSubmit with trimmed title + raw description when valid", async () => {
+    const { onSubmit, title, desc, submit } = _setup();
+    fireEvent.change(title, { target: { value: "  hello world  " } });
+    fireEvent.change(desc, { target: { value: "some details" } });
+    fireEvent.click(submit);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: "hello world",
+      description: "some details",
+    });
+  });
+
+  test("switches to pending state on success + locks form + shows pendingLabel", async () => {
+    const { onSubmit, title, submit } = _setup();
+    fireEvent.change(title, { target: { value: "valid task" } });
+    fireEvent.click(submit);
+    await waitFor(() => {
+      expect(screen.getByTestId("first-task-pending")).toBeInTheDocument();
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const form = screen.getByTestId("first-task-form");
+    expect(form.getAttribute("data-state")).toBe("pending");
+  });
+
+  test("custom pendingLabel prop overrides default", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<FirstTaskForm onSubmit={onSubmit} pendingLabel="hang tight" />);
+    fireEvent.change(screen.getByTestId("first-task-title-input"), {
+      target: { value: "valid task" },
+    });
+    fireEvent.click(screen.getByTestId("first-task-submit"));
+    await waitFor(() => {
+      expect(screen.getByText("hang tight")).toBeInTheDocument();
+    });
+  });
+
+  test("switches to error state when onSubmit rejects", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("network down"));
+    render(<FirstTaskForm onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByTestId("first-task-title-input"), {
+      target: { value: "valid task" },
+    });
+    fireEvent.click(screen.getByTestId("first-task-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("first-task-error")).toBeInTheDocument();
+    });
+    expect(screen.getByText("network down")).toBeInTheDocument();
+  });
+
+  test("non-Error thrown value surfaces generic error message", async () => {
+    const onSubmit = vi.fn().mockRejectedValue("string-not-error");
+    render(<FirstTaskForm onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByTestId("first-task-title-input"), {
+      target: { value: "valid task" },
+    });
+    fireEvent.click(screen.getByTestId("first-task-submit"));
+    await waitFor(() => {
+      expect(screen.getByText("Submission failed.")).toBeInTheDocument();
+    });
+  });
+
+  test("data-state attribute reflects current state machine", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<FirstTaskForm onSubmit={onSubmit} />);
+    const form = screen.getByTestId("first-task-form");
+    expect(form.getAttribute("data-state")).toBe("idle");
+    fireEvent.change(screen.getByTestId("first-task-title-input"), {
+      target: { value: "valid task" },
+    });
+    fireEvent.click(screen.getByTestId("first-task-submit"));
+    await waitFor(() => {
+      expect(form.getAttribute("data-state")).toBe("pending");
+    });
+  });
+});

--- a/frontend/components/dispatcher/first-task-form.tsx
+++ b/frontend/components/dispatcher/first-task-form.tsx
@@ -1,0 +1,148 @@
+/**
+ * FILE: frontend/components/dispatcher/first-task-form.tsx
+ * PURPOSE: Form for the customer's first dispatched task. Onboarding step
+ *          that lands them at their dashboard with a task in-flight.
+ * KEI: 156 (Part 17.3 sub-KEI — first-task submission).
+ *
+ * Render-path complete: typed form + client-side validation + submit
+ * callback contract. Sub-KEI claimer wires the backend `submitTask`
+ * function to INSERT into public.tasks + trigger the Prefect flow.
+ *
+ * Title/description trimmed pre-submit. Empty title rejects with inline
+ * error. Disable submit while in-flight + on the pending state.
+ */
+
+"use client";
+
+import * as React from "react";
+
+export interface FirstTaskFormValues {
+  title: string;
+  description: string;
+}
+
+export type FirstTaskSubmitState = "idle" | "submitting" | "pending" | "error";
+
+export interface FirstTaskFormProps {
+  /** Async hook to actually create the task. Returns nothing on success;
+   *  throws on failure. Sub-KEI implementation: INSERT public.tasks +
+   *  Prefect enqueue. */
+  onSubmit: (values: FirstTaskFormValues) => Promise<void>;
+  /** Visible after submission succeeds — sub-KEI dashboard-populate hook
+   *  uses this to wait for the first task to complete then redirect. */
+  pendingLabel?: string;
+  /** Override for the form heading (kept for the page.tsx wrapper). */
+  heading?: string;
+}
+
+const MAX_TITLE_LEN = 200;
+const MAX_DESC_LEN = 2000;
+const MIN_TITLE_LEN = 4;
+
+function _validate(values: FirstTaskFormValues): string | null {
+  const title = values.title.trim();
+  if (title.length < MIN_TITLE_LEN) {
+    return `Title must be at least ${MIN_TITLE_LEN} characters.`;
+  }
+  if (title.length > MAX_TITLE_LEN) {
+    return `Title must be ${MAX_TITLE_LEN} characters or fewer.`;
+  }
+  if (values.description.length > MAX_DESC_LEN) {
+    return `Description must be ${MAX_DESC_LEN} characters or fewer.`;
+  }
+  return null;
+}
+
+export function FirstTaskForm({
+  onSubmit,
+  pendingLabel = "Task submitted — preparing your dashboard…",
+  heading = "Submit your first task",
+}: Readonly<FirstTaskFormProps>) {
+  const [title, setTitle] = React.useState("");
+  const [description, setDescription] = React.useState("");
+  const [state, setState] = React.useState<FirstTaskSubmitState>("idle");
+  const [error, setError] = React.useState<string | null>(null);
+
+  const disabled = state === "submitting" || state === "pending";
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const values: FirstTaskFormValues = { title: title.trim(), description };
+    const validationError = _validate(values);
+    if (validationError) {
+      setError(validationError);
+      setState("error");
+      return;
+    }
+    setError(null);
+    setState("submitting");
+    try {
+      await onSubmit(values);
+      setState("pending");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Submission failed.");
+      setState("error");
+    }
+  };
+
+  return (
+    <form
+      data-testid="first-task-form"
+      data-state={state}
+      onSubmit={handleSubmit}
+      className="mx-auto max-w-md space-y-4 p-8"
+    >
+      <h1 className="text-2xl font-semibold">{heading}</h1>
+      <div className="space-y-2">
+        <label className="block text-sm font-medium" htmlFor="first-task-title">
+          Title
+        </label>
+        <input
+          id="first-task-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          maxLength={MAX_TITLE_LEN}
+          disabled={disabled}
+          required
+          className="w-full rounded border px-3 py-2 text-sm"
+          data-testid="first-task-title-input"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="block text-sm font-medium" htmlFor="first-task-description">
+          Description (optional)
+        </label>
+        <textarea
+          id="first-task-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          maxLength={MAX_DESC_LEN}
+          disabled={disabled}
+          rows={6}
+          className="w-full rounded border px-3 py-2 text-sm"
+          data-testid="first-task-description-input"
+        />
+      </div>
+      {error ? (
+        <p data-testid="first-task-error" className="text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+      {state === "pending" ? (
+        <p data-testid="first-task-pending" className="text-sm text-muted-foreground">
+          {pendingLabel}
+        </p>
+      ) : (
+        <button
+          type="submit"
+          disabled={disabled}
+          className="rounded border px-4 py-2 text-sm font-medium disabled:opacity-50"
+          data-testid="first-task-submit"
+        >
+          {state === "submitting" ? "Submitting…" : "Submit task"}
+        </button>
+      )}
+    </form>
+  );
+}

--- a/frontend/components/dispatcher/use-first-task-submit.ts
+++ b/frontend/components/dispatcher/use-first-task-submit.ts
@@ -1,0 +1,43 @@
+/**
+ * FILE: frontend/components/dispatcher/use-first-task-submit.ts
+ * PURPOSE: Hook contract for the FirstTaskForm onSubmit callback. Sub-KEI
+ *          claimer implements the actual public.tasks INSERT + Prefect
+ *          flow trigger; this stub fixes the signature so the form can
+ *          compose against a stable interface.
+ * KEI: 156 (First-task submission form → Prefect enqueue).
+ *
+ * Stub: returns a no-op async submitter that always resolves. Replace
+ * with the live POST /api/dispatcher/tasks (or supabase.from('tasks').insert)
+ * + Prefect deployment trigger.
+ */
+
+import type { FirstTaskFormValues } from "./first-task-form";
+
+export interface UseFirstTaskSubmitOptions {
+  /** Tenant whose task to create. When omitted the live hook derives it
+   *  from the Supabase session. */
+  tenantId?: string;
+  /** Prefect deployment name to trigger. Sub-KEI implements; default
+   *  follows the dispatcher convention. */
+  deployment?: string;
+}
+
+export interface UseFirstTaskSubmitResult {
+  submit: (values: FirstTaskFormValues) => Promise<void>;
+}
+
+export function useFirstTaskSubmit(_opts: UseFirstTaskSubmitOptions = {}): UseFirstTaskSubmitResult {
+  // Stub — sub-KEI implements:
+  //   1. INSERT into public.tasks via Supabase client OR a backend
+  //      /api/dispatcher/tasks POST endpoint (recommended — server can
+  //      set tenant_id from the session, status='pending').
+  //   2. Trigger the Prefect deployment via REST (or via a Supabase
+  //      database trigger on tasks INSERT that calls the deployment).
+  //   3. Return the created task id so the dashboard-populate hook
+  //      (KEI-113D) can subscribe to its completion.
+  return {
+    submit: async (_values: FirstTaskFormValues) => {
+      // No-op until sub-KEI implements.
+    },
+  };
+}


### PR DESCRIPTION
## Summary

KEI-156 (Part 17.3 sub-KEI): customer's first dispatched task form. Render-path + validation + state machine complete; sub-KEI claimer wires the live `INSERT public.tasks` + Prefect deployment trigger.

**Linear:** [KEI-156](https://linear.app/keiracom/issue/KEI-156) · **Branch:** off `01c0a0528` (post-#953 merge)

## What lands (3 files)

| File | Purpose |
|---|---|
| `frontend/components/dispatcher/first-task-form.tsx` | `<FirstTaskForm onSubmit=...>` — typed form, validation, state machine |
| `frontend/components/dispatcher/use-first-task-submit.ts` | Hook contract — sub-KEI implements `submit()` body |
| `frontend/components/dispatcher/__tests__/first-task-form.test.tsx` | 10 interaction tests — vitest + @testing-library/react |

## State machine

```
idle → submitting → pending  (success path — form locked, pending banner)
idle → error       (validation reject)
submitting → error (onSubmit rejects)
```

`data-state` attr on the form element reflects the current state for sub-KEI integration tests.

## Validation rules

- Title: trimmed, min 4 chars, max 200 chars (rejects with inline error)
- Description: max 2000 chars (optional)
- Empty title → `Title must be at least 4 characters.`

## Tests (10)

- render shape (form, inputs, submit button)
- custom heading override
- reject empty title
- reject title under 4 chars
- success calls onSubmit with `{title: trimmed, description: raw}`
- success → pending state + lockout
- custom pendingLabel override
- error state on `Error` throw — surfaces message
- error state on non-Error throw — generic "Submission failed."
- data-state attr reflects machine

## Pre-emptive Sonar

`Readonly<FirstTaskFormProps>` on the function signature — same lesson Max raised on PR #957.

## Out of scope (sub-KEI)

- Live `INSERT public.tasks` via Supabase or `POST /api/dispatcher/tasks` backend
- Prefect deployment trigger (REST or DB-trigger-on-INSERT)
- Return task id for KEI-113D dashboard-populate subscription
- RLS scoping (KEI-111B auth dep)
- Wire form into existing page.tsx (separate trivial PR)

## Pattern context

Matches the existing TaskFeed (KEI-158 #957 merged) + ThreadUsageGauge (KEI-161 #968 in review) shape. Composes with the existing stub page at `frontend/app/dispatcher/onboarding/first-task/page.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)