### PR TITLE
[MAX] feat(kei157): KEI-113D first-task-success banner

### DIFF
--- a/docs/wave3/kei157_first_task_scope.md
+++ b/docs/wave3/kei157_first_task_scope.md
@@ -1,0 +1,91 @@
+# KEI-157 — First-Task-Success Banner: Scope & Sub-KEI Dep Graph
+
+**Status:** Shipped (banner shell + watcher stub, PR this doc rides)
+**Phase:** Product Layer — Wave 3 Dashboard MVP
+**Priority:** P1 (3-way ratified)
+**Parent:** KEI-113D / KEI-114A
+**Author:** MAX
+
+---
+
+## What shipped in KEI-157 (this PR)
+
+| File | Purpose |
+|------|---------|
+| `frontend/components/dispatcher/first-task-success-banner.tsx` | Banner component — renders task title + "Your first task is done" + Dismiss button |
+| `frontend/components/dispatcher/use-first-task-watcher.ts` | Contract hook stub — typed interface; sub-KEI claimers wire realtime + persistence |
+| `frontend/components/dispatcher/__tests__/first-task-success-banner.test.tsx` | 7 render tests covering null/visible/copy/ARIA/dismiss |
+
+---
+
+## Sub-KEI Dep Graph
+
+```
+KEI-157
+├── KEI-157A  Supabase realtime channel wiring
+│             Blocker: none (Supabase project live)
+│             Owner: unclaimed
+│             Pattern (from use-first-task-watcher.ts doc-comment):
+│               supabase.channel('first-task-watcher')
+│                 .on('postgres_changes', { event: 'UPDATE', schema: 'public',
+│                     table: 'tasks', filter: 'status=eq.done' }, handler)
+│                 .subscribe()
+│             Acceptance: realtime UPDATE on tasks where status=done populates
+│                         firstCompletedTask and banner becomes visible.
+│
+├── KEI-157B  Dismiss persistence
+│             Blocker: KEI-157A (needs a task to dismiss first)
+│             Owner: unclaimed
+│             Options: localStorage key `dispatcher.first_task_banner_dismissed`
+│                      OR user_prefs table row (persistent across devices).
+│             Acceptance: dismiss survives page reload; banner does not reappear.
+│
+└── KEI-157C  Polling fallback
+              Blocker: none (independent of 157A)
+              Owner: unclaimed
+              Pattern: useEffect + setTimeout loop using pollIntervalMs option
+                       from UseFirstTaskWatcherOptions. Queries
+                       tasks?status=eq.done&order=completed_at.asc&limit=1
+                       via Supabase REST. Falls back automatically when
+                       supabase.channel subscribe times out or errors.
+              Acceptance: in a jsdom environment with realtime stubbed out,
+                          polling surfaces a completed task within 2 × pollIntervalMs.
+```
+
+---
+
+## Integration point
+
+`frontend/app/(dispatcher)/dashboard/feed/page.tsx` (KEI-114 scaffold) should
+compose the watcher + banner above its TaskFeed:
+
+```typescript
+const { firstCompletedTask, loading, dismiss } = useFirstTaskWatcher({ tenantId });
+
+return (
+  <>
+    <FirstTaskSuccessBanner
+      task={firstCompletedTask}
+      visible={!loading && firstCompletedTask !== null}
+      onDismiss={dismiss}
+    />
+    <TaskFeed tasks={tasks} loading={tasksLoading} />
+  </>
+);
+```
+
+The dashboard page integration is out of scope for this PR (KEI-157 is the
+component shell). The page wiring is deferred to KEI-157A claimer.
+
+---
+
+## Constraints carried forward
+
+- LAW II: `cost_aud` field (typed `number | null`) carries the AUD unit in
+  its name. All display code must prefix with `A$`. Banner itself shows no
+  cost — cost display lives in TaskFeed rows.
+- `feedback_pre_revenue_reality`: banner copy says "Your first task is done"
+  (factual). No aggregate stats, no social proof, no fabricated counts.
+- Sonar S6759: `Readonly<T>` applied to all component props.
+- Sonar S1135: no `TODO`/`FIXME` markers; deferred work expressed as sub-KEIs
+  in this doc and as sub-KEI stub comments in `use-first-task-watcher.ts`.

--- a/frontend/components/dispatcher/__tests__/first-task-success-banner.test.tsx
+++ b/frontend/components/dispatcher/__tests__/first-task-success-banner.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for FirstTaskSuccessBanner.
+ * KEI: 157 — KEI-113D dashboard populate on first-task completion.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import {
+  FirstTaskSuccessBanner,
+} from "../first-task-success-banner";
+import type { DispatcherTask } from "../task-feed";
+
+const sampleTask: DispatcherTask = {
+  id: "task-99",
+  title: "Prospect Australian SMBs in Melbourne",
+  status: "done",
+  cost_aud: 1.25,
+  created_at: "2026-05-17T08:00:00Z",
+  completed_at: "2026-05-17T08:10:00Z",
+};
+
+describe("FirstTaskSuccessBanner", () => {
+  test("returns null when task is null", () => {
+    const { container } = render(
+      <FirstTaskSuccessBanner task={null} visible onDismiss={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("returns null when visible is false", () => {
+    const { container } = render(
+      <FirstTaskSuccessBanner task={sampleTask} visible={false} onDismiss={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders task title when visible and task is set", () => {
+    render(
+      <FirstTaskSuccessBanner task={sampleTask} visible onDismiss={vi.fn()} />
+    );
+    expect(screen.getByTestId("banner-task-title")).toHaveTextContent(
+      "Prospect Australian SMBs in Melbourne"
+    );
+  });
+
+  test("renders dismiss button when visible", () => {
+    render(
+      <FirstTaskSuccessBanner task={sampleTask} visible onDismiss={vi.fn()} />
+    );
+    expect(screen.getByTestId("banner-dismiss-button")).toBeInTheDocument();
+  });
+
+  test("dismiss click invokes onDismiss callback", () => {
+    const onDismiss = vi.fn();
+    render(
+      <FirstTaskSuccessBanner task={sampleTask} visible onDismiss={onDismiss} />
+    );
+    fireEvent.click(screen.getByTestId("banner-dismiss-button"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test("banner copy contains 'first task' phrase", () => {
+    render(
+      <FirstTaskSuccessBanner task={sampleTask} visible onDismiss={vi.fn()} />
+    );
+    expect(
+      screen.getByRole("status").textContent?.toLowerCase()
+    ).toContain("first task");
+  });
+
+  test("banner has role='status' for accessible announcement", () => {
+    render(
+      <FirstTaskSuccessBanner task={sampleTask} visible onDismiss={vi.fn()} />
+    );
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/dispatcher/first-task-success-banner.tsx
+++ b/frontend/components/dispatcher/first-task-success-banner.tsx
@@ -1,0 +1,60 @@
+/**
+ * FILE: frontend/components/dispatcher/first-task-success-banner.tsx
+ * PURPOSE: Celebratory banner shown when a customer's first task completes.
+ *          Composes with useFirstTaskWatcher — caller passes watcher output
+ *          straight through.
+ * KEI: 157 — KEI-113D dashboard populate on first-task completion.
+ *
+ * Readonly<T> on props satisfies Sonar S6759.
+ * S1135 pre-empt: no task-marker comments in this file.
+ */
+
+import * as React from "react";
+import type { DispatcherTask } from "./task-feed";
+
+export interface FirstTaskSuccessBannerProps {
+  task: DispatcherTask | null;
+  visible: boolean;
+  onDismiss: () => void;
+}
+
+/**
+ * Renders a celebratory success banner when a customer's first task is done.
+ *
+ * Returns null if `visible` is false or `task` is null — caller drives
+ * visibility via useFirstTaskWatcher.
+ */
+export function FirstTaskSuccessBanner({
+  task,
+  visible,
+  onDismiss,
+}: Readonly<FirstTaskSuccessBannerProps>) {
+  if (!visible || task === null) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="first-task-success-banner"
+      className="flex items-start justify-between gap-4 rounded-lg border border-green-200 bg-green-50 p-4 text-green-900"
+    >
+      <div className="flex flex-col gap-1">
+        <p className="font-semibold">Your first task is done!</p>
+        <p className="text-sm text-green-700" data-testid="banner-task-title">
+          {task.title}
+        </p>
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss success banner"
+        data-testid="banner-dismiss-button"
+        onClick={onDismiss}
+        className="shrink-0 rounded px-3 py-1 text-sm font-medium text-green-800 hover:bg-green-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/frontend/components/dispatcher/use-first-task-watcher.ts
+++ b/frontend/components/dispatcher/use-first-task-watcher.ts
@@ -1,0 +1,70 @@
+/**
+ * FILE: frontend/components/dispatcher/use-first-task-watcher.ts
+ * PURPOSE: Contract hook — watches for the customer's first completed task and
+ *          drives FirstTaskSuccessBanner visibility.
+ * KEI: 157 — KEI-113D dashboard populate on first-task completion.
+ *
+ * Stub: returns safe default state so banner renders deterministically in
+ * tests and the dashboard shell without a live Supabase connection.
+ *
+ * Sub-KEI claimers wire the subscription:
+ *   KEI-157A — Supabase realtime channel:
+ *     supabase
+ *       .channel('first-task-watcher')
+ *       .on(
+ *         'postgres_changes',
+ *         {
+ *           event: 'UPDATE',
+ *           schema: 'public',
+ *           table: 'tasks',
+ *           filter: `status=eq.done`,
+ *         },
+ *         (payload) => { ... }
+ *       )
+ *       .subscribe()
+ *   KEI-157B — banner dismiss persistence via localStorage / user_prefs.
+ *   KEI-157C — polling fallback for environments where realtime is unavailable.
+ *
+ * S1135 pre-empt: deferred work expressed as sub-KEIs in kei157_first_task_scope.md.
+ */
+
+import { useState } from "react";
+import type { DispatcherTask } from "./task-feed";
+
+export interface UseFirstTaskWatcherOptions {
+  /** Polling interval in ms for KEI-157C fallback. Sub-KEI claimer honours. */
+  pollIntervalMs?: number;
+  /** Tenant scope filter. Sub-KEI claimer passes to realtime filter. */
+  tenantId?: string;
+}
+
+export interface UseFirstTaskWatcherResult {
+  /** The first task to reach `done` status, or null if none yet. */
+  firstCompletedTask: DispatcherTask | null;
+  /** True while the initial query is in-flight. */
+  loading: boolean;
+  /** Call to hide the success banner and persist the dismissal (KEI-157B). */
+  dismiss: () => void;
+}
+
+/**
+ * Watches for the customer's first completed task.
+ *
+ * Stub implementation returns `{ firstCompletedTask: null, loading: false }`.
+ * KEI-157A claimer replaces this body with a Supabase realtime subscription
+ * (see module doc-comment for the subscription pattern).
+ */
+export function useFirstTaskWatcher(
+  _options: Readonly<UseFirstTaskWatcherOptions> = {}
+): UseFirstTaskWatcherResult {
+  const [dismissed, setDismissed] = useState(false);
+
+  return {
+    firstCompletedTask: null,
+    loading: false,
+    dismiss: () => setDismissed(true),
+  };
+
+  // Suppress unused-variable warning for dismissed — KEI-157B claimer reads it.
+  void dismissed;
+}

--- a/frontend/components/dispatcher/use-first-task-watcher.ts
+++ b/frontend/components/dispatcher/use-first-task-watcher.ts
@@ -57,14 +57,14 @@ export interface UseFirstTaskWatcherResult {
 export function useFirstTaskWatcher(
   _options: Readonly<UseFirstTaskWatcherOptions> = {}
 ): UseFirstTaskWatcherResult {
-  const [dismissed, setDismissed] = useState(false);
+  // KEI-157B claimer reads the dismissed flag; the stub only needs the setter so
+  // `dismiss` still triggers a re-render. Destructure the setter alone to avoid
+  // an unused binding.
+  const [, setDismissed] = useState(false);
 
   return {
     firstCompletedTask: null,
     loading: false,
     dismiss: () => setDismissed(true),
   };
-
-  // Suppress unused-variable warning for dismissed — KEI-157B claimer reads it.
-  void dismissed;
 }


### PR DESCRIPTION
## Summary
- `FirstTaskSuccessBanner`: celebratory card rendered on first task completion (`role=status`, Dismiss button, `Readonly<T>` — Sonar S6759 pre-empt)
- `useFirstTaskWatcher`: typed contract hook stub; doc-comment specifies KEI-157A realtime pattern (`supabase.channel.on('postgres_changes')`) for sub-KEI claimer
- 7 render tests — all pass (null task, visible=false, populated, title, dismiss callback, 'first task' copy, ARIA role)
- `docs/wave3/kei157_first_task_scope.md`: sub-KEI dep graph (157A realtime, 157B dismiss persistence, 157C polling fallback) + dashboard integration snippet

## Acceptance gates
1. Tests: 7/7 pass
2. `tsc --noEmit`: 0 new errors
3. `grep -nE 'TODO|FIXME' ...`: 0 matches (S1135 pre-empt)
4. `grep -nE 'Readonly<' banner.tsx`: 2 matches (S6759 pre-empt)
5. `check_operational_deployment.sh`: exit 0

## Constraints
- LAW II: no cost display in banner; `cost_aud` field carries AUD unit in name
- `feedback_pre_revenue_reality`: copy is factual — 'Your first task is done'
- DispatcherTask imported from `./task-feed` — no redefinition
- No `TODO`/`FIXME` markers anywhere in the 4 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)