### PR TITLE
[MAX] chore(kei173): write_manual_mirror.py --task-id docstring polish

### DIFF
--- a/scripts/write_manual_mirror.py
+++ b/scripts/write_manual_mirror.py
@@ -335,12 +335,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     ap.add_argument(
         "--task-id",
-        type=str,
+        dest="task_id",
+        metavar="KEI-NN",
         default=None,
         help=(
-            "KEI-173: originating task id (e.g. 'KEI-NNN') passed by "
-            "completion_sync_worker for audit trail. Recorded in state file's "
-            "last_task_id field. Does not alter mirror logic."
+            "KEI-173: source task id for audit/log traceability. Accepted from the "
+            "completion_sync_worker drive_manual sink which passes the originating "
+            "task id with every mirror invocation. The mirror itself is task-agnostic "
+            "(always mirrors current MANUAL.md state); the flag is logged so "
+            "completion_sync_queue can correlate sink runs with the triggering completion."
         ),
     )
     args = ap.parse_args(argv)


### PR DESCRIPTION
## Summary — auto-claim hit a stale KEI

Fleet supervisor auto-claimed KEI-173 for me. On inspection, the bug Elliot originally flagged (write_manual_mirror.py rejecting --task-id from completion_sync_worker drive_manual sink) is **already fixed in main**:

- `scripts/write_manual_mirror.py:336` — `--task-id` argparse declaration exists
- `scripts/write_manual_mirror.py:128` — `persist_exit_code(task_id=None)` signature
- `scripts/write_manual_mirror.py:418` — `state["last_task_id"]` write
- `tests/scripts/test_write_manual_mirror.py:325-345` — KEI-173 test coverage in place (29/29 tests pass)

This PR polishes only:
- `dest="task_id"` — explicit (argparse auto-converts but explicit is clearer)
- `metavar="KEI-NN"` — improves --help output
- Expanded help docstring referencing the originating completion_sync_worker drive_manual sink

## Test plan
- [x] `python3 scripts/write_manual_mirror.py --check --task-id KEI-173` — accepted, runs through to staleness verdict (exit 2 expected with --check + unchanged MANUAL)
- [x] `python3 -m pytest tests/scripts/test_write_manual_mirror.py -q` — **29 passed in 0.36s** (including KEI-173 acceptance tests)
- [x] `ruff check + format --check` clean

Heads-up @elliot — the completion_sync_queue 66 drive_manual abandoned rows you flagged earlier today likely cleared once the fix actually landed on main. Worth a queue health check before this docstring polish merges (no urgency on this PR; closing the KEI loop primarily).

🤖 Generated with [Claude Code](https://claude.com/claude-code)