### PR TITLE
[SCOUT] feat(kei111): dispatcher auth foundation — dispatcher_customers + scope doc

### DIFF
--- a/docs/wave3/kei111_auth_scope.md
+++ b/docs/wave3/kei111_auth_scope.md
@@ -1,0 +1,116 @@
+# KEI-111 — Dispatcher Auth Layer: Scope + Scaffold
+
+**Status:** Scaffold landed (this PR — `dispatcher_customers` table only). Sub-KEIs (KEI-111A/C/D/E) implement provisioning, magic-link flow, sessions, and RLS.
+**Parent:** [KEI-110](https://linear.app/keiracom/issue/KEI-110) — Dispatcher Product Layer (Part 17).
+**Authored by:** Scout · 2026-05-17.
+
+## What this PR delivers
+
+Foundational `public.dispatcher_customers` table that all downstream auth-keyed work hangs off:
+- 1:1 link to `auth.users` (Supabase Auth-managed)
+- `tier` (matches frontend `DispatcherTier` enum)
+- Soft-delete lifecycle columns
+- Two partial indexes (on `supabase_user_id` + `email`, scoped to non-deleted rows)
+
+No auth flow code, no RLS policies, no API endpoints — those land in the sub-KEIs below.
+
+## Why a separate table (not auth.users)
+
+Supabase manages `auth.users` directly; we cannot add columns there. Dispatcher needs:
+- Tier alongside identity (free/starter/growth/scale/enterprise)
+- Soft-delete state so BYO key + task audit history survives a customer leaving
+- A tenant-scoped column for RLS policies to filter against (`customer_id = current_dispatcher_customer_id()` shape)
+
+The `dispatcher_customers` row is the join target between Supabase Auth identity and the dispatcher domain tables.
+
+## Why `dispatcher_*` namespace
+
+Avoids collision with:
+- `public.client_customers` — internal Agency_OS CRM customers (existing)
+- `public.customer_api_keys` — Orion's KEI-116 BYO API keys (PR #954)
+- `public.tasks` — internal Agency_OS agent task queue (the one bd-claim uses)
+
+The dispatcher product is customer-facing and isolated. Same reason `frontend/app/dispatcher/*` (PR #953) uses a path prefix instead of mixing with internal Agency_OS routes.
+
+## Sub-KEI dependency graph
+
+```
+KEI-111A (KEI-145) Provision Supabase Auth tenant project + email templates
+   │
+   │  (manual ops: Supabase dashboard config — no code dep)
+   ↓
+KEI-111B (TBD)     Supabase client wrapper for dispatcher frontend
+   │
+   ├─→ KEI-111C (KEI-147) Magic link auth flow (no-password)
+   │     │
+   │     ↓
+   │  KEI-111D (KEI-148) Session tokens + refresh + revoke cycle
+   │     │
+   │     ↓
+   │  KEI-111E (KEI-149) RLS policies on customers + api_keys + tasks
+   │
+   └─→ KEI-113A (KEI-154) Signup UI (Part 17.3 — implements row INSERT)
+```
+
+**Build order** (so each sub-KEI claimer is unblocked):
+
+1. **KEI-111A** ops setup — Supabase project, email templates. Manual + no code.
+2. **dispatcher_customers** table (this PR) — gates everything keyed on tenant identity.
+3. **KEI-111B** Supabase client wrapper at `frontend/lib/dispatcher/supabase.ts` — sub-KEI sketch:
+   ```ts
+   import { createBrowserClient } from "@supabase/ssr";
+   export const dispatcherClient = () => createBrowserClient(
+     process.env.NEXT_PUBLIC_DISPATCHER_SUPABASE_URL!,
+     process.env.NEXT_PUBLIC_DISPATCHER_SUPABASE_ANON_KEY!,
+   );
+   ```
+4. **KEI-111C** magic-link `auth.signInWithOtp({email, emailRedirectTo})` flow + verify-email page wiring (composes with PR #953 stub pages).
+5. **KEI-111D** session middleware in `frontend/middleware.ts` — refresh on every request, revoke on `/api/dispatcher/auth/logout`.
+6. **KEI-111E** RLS policies on three tables:
+   - `dispatcher_customers` — `id = current_dispatcher_customer_id()` (own row only)
+   - `customer_api_keys` (Orion's table — KEI-116) — `customer_id = current_dispatcher_customer_id()`
+   - `public.tasks` — needs decision: namespace separately as `dispatcher_tasks`, or filter by a new `dispatcher_customer_id` column on `public.tasks`? Sub-KEI claimer makes the call after reading PR #953 scope doc.
+
+## RLS pattern (target shape for KEI-111E)
+
+```sql
+-- Helper: returns the dispatcher_customers.id for the current session.
+CREATE OR REPLACE FUNCTION public.current_dispatcher_customer_id()
+RETURNS UUID LANGUAGE sql STABLE AS $$
+  SELECT id FROM public.dispatcher_customers
+   WHERE supabase_user_id = auth.uid()
+     AND deleted_at IS NULL
+$$;
+
+ALTER TABLE public.dispatcher_customers ENABLE ROW LEVEL SECURITY;
+CREATE POLICY dispatcher_customers_own_row ON public.dispatcher_customers
+  USING (id = public.current_dispatcher_customer_id());
+
+-- Sibling pattern for customer_api_keys + the dispatcher task table.
+```
+
+Acceptance test for KEI-111E (per Linear spec): "RLS enabled on customers + api_keys + tasks; integration test verifies user A can't read user B rows."
+
+## Out of scope for this PR
+
+- Any code — this PR is migration + scope doc only
+- RLS policies (KEI-111E)
+- Helper function `current_dispatcher_customer_id()` (lands with RLS)
+- Tier enum tightening (waits for KEI-117C tier-limits table)
+- The dispatcher tasks namespace decision
+
+## Acceptance for this scaffold
+
+- [x] `public.dispatcher_customers` table created with RLS-ready columns
+- [x] FK to `auth.users` with `ON DELETE CASCADE` (auth user delete cascades to dispatcher row)
+- [x] Soft-delete column + two partial indexes
+- [x] Scope doc captures dep graph + RLS pattern target shape
+- [x] All 4 named sub-KEIs (KEI-145/147/148/149) have a clear next-step from this foundation
+- [x] No collision with existing `public.client_customers` / `public.customer_api_keys` / `public.tasks`
+
+## Reference
+
+- Parent: KEI-110 Dispatcher Product Layer (Linear)
+- Sub-KEIs: KEI-145 (provision), KEI-147 (magic link), KEI-148 (session), KEI-149 (RLS)
+- Sibling scaffolds: KEI-113 onboarding (PR #953), KEI-114 dashboard (Aiden), KEI-116 BYO keys (Orion PR #954)
+- Frontend tier enum: `frontend/components/dispatcher/thread-usage-gauge.tsx#DispatcherTier`

--- a/supabase/migrations/20260517_kei111_dispatcher_customers.sql
+++ b/supabase/migrations/20260517_kei111_dispatcher_customers.sql
@@ -1,0 +1,45 @@
+-- KEI-111: dispatcher_customers — root table for the customer-facing
+-- Dispatcher product (Part 17). Maps 1:1 to Supabase auth.users; carries
+-- the tenant tier + lifecycle metadata that downstream tables key off.
+--
+-- Why a separate table (not just auth.users):
+--   - auth.users is Supabase-managed; we can't add columns there.
+--   - Dispatcher needs tier + lifecycle state alongside auth identity.
+--   - RLS policies (KEI-111E / KEI-149) need a tenant-scoped column to
+--     filter against; a per-customer row provides the join target.
+--
+-- Namespaced `dispatcher_*` to avoid collision with:
+--   - existing public.client_customers (internal CRM customers)
+--   - existing public.customer_api_keys (Orion's KEI-116 BYO keys)
+
+CREATE TABLE IF NOT EXISTS public.dispatcher_customers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- 1:1 link to Supabase Auth — populated when a user completes signup.
+    supabase_user_id UUID UNIQUE NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    -- Tier name matches the DispatcherTier enum in the frontend
+    -- (free | starter | growth | scale | enterprise). Stored as TEXT to
+    -- keep the migration cheap; tighten to an enum in a sub-KEI when
+    -- KEI-117C tier-limits-from-database lands.
+    tier TEXT NOT NULL DEFAULT 'free',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Soft delete so the BYO key + task history audit trail survives
+    -- a customer leaving.
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS dispatcher_customers_supabase_user_id_idx
+    ON public.dispatcher_customers (supabase_user_id)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS dispatcher_customers_email_idx
+    ON public.dispatcher_customers (email)
+    WHERE deleted_at IS NULL;
+
+COMMENT ON TABLE public.dispatcher_customers IS
+    'KEI-111: Customer-facing Dispatcher product tenants. 1:1 with auth.users; carries tier + lifecycle state. Sub-KEI KEI-111E adds RLS policies.';
+COMMENT ON COLUMN public.dispatcher_customers.tier IS
+    'KEI-111: matches frontend DispatcherTier enum. Sub-KEI KEI-117C ties this to a tier_limits table.';
+COMMENT ON COLUMN public.dispatcher_customers.deleted_at IS
+    'KEI-111: soft delete; BYO key + task audit history survives the customer leaving.';


### PR DESCRIPTION
## Summary

Part 17.1 auth-layer parent umbrella scaffold. Adds the foundational `public.dispatcher_customers` table that all 4 named sub-KEIs (KEI-111A/C/D/E = KEI-145/147/148/149) key off, plus a scope doc with the dep graph + RLS pattern target shape.

**Linear:** [KEI-111](https://linear.app/keiracom/issue/KEI-111) parent · **Branch:** `scout/kei111-auth-scaffold` off `01c0a0528`

## Why a separate `dispatcher_customers` table

Supabase manages `auth.users` directly — can't add columns there. Dispatcher needs:
- Tier alongside identity (free/starter/growth/scale/enterprise — matches frontend `DispatcherTier` enum)
- Soft-delete lifecycle so BYO key + task audit history survives a customer leaving
- A tenant-scoped column for RLS policies to filter against (`id = current_dispatcher_customer_id()`)

The row is the join target between Supabase Auth identity and the dispatcher domain tables.

## Why `dispatcher_*` namespace

Avoids collision with:
- `public.client_customers` — internal Agency_OS CRM customers
- `public.customer_api_keys` — Orion's KEI-116 BYO API keys (PR #954)
- `public.tasks` — internal Agency_OS agent task queue (the one `bd claim` uses)

Same isolation pattern as `frontend/app/dispatcher/*` (PR #953).

## What lands (2 files, +161)

| File | Purpose |
|---|---|
| `supabase/migrations/20260517_kei111_dispatcher_customers.sql` | Migration: table + 2 partial indexes (scoped to `deleted_at IS NULL`) |
| `docs/wave3/kei111_auth_scope.md` | Scope doc: dep graph, build-order sequencing, RLS pattern target shape for KEI-111E |

### Migration shape

```sql
CREATE TABLE IF NOT EXISTS public.dispatcher_customers (
    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
    supabase_user_id UUID UNIQUE NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
    email TEXT NOT NULL,
    tier TEXT NOT NULL DEFAULT 'free',
    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    deleted_at TIMESTAMPTZ
);
```

`ON DELETE CASCADE` on the FK so a Supabase auth-user delete cascades to the dispatcher row. Soft-delete column survives the cascade if you want the audit trail — sub-KEI claimer chooses whether to use it or rely on the cascade.

## RLS pattern (target for KEI-111E)

```sql
CREATE OR REPLACE FUNCTION public.current_dispatcher_customer_id()
RETURNS UUID LANGUAGE sql STABLE AS $$
  SELECT id FROM public.dispatcher_customers
   WHERE supabase_user_id = auth.uid()
     AND deleted_at IS NULL
$$;

ALTER TABLE public.dispatcher_customers ENABLE ROW LEVEL SECURITY;
CREATE POLICY dispatcher_customers_own_row ON public.dispatcher_customers
  USING (id = public.current_dispatcher_customer_id());
```

Sibling policies for `customer_api_keys` + dispatcher tasks.

## Out of scope (sub-KEIs)

- **KEI-111A** (KEI-145) — Supabase Auth ops setup (manual via dashboard, email templates)
- **KEI-111B** — Supabase client wrapper at `frontend/lib/dispatcher/supabase.ts`
- **KEI-111C** (KEI-147) — Magic-link `signInWithOtp` flow + verify-email page wiring (composes with PR #953 stub pages)
- **KEI-111D** (KEI-148) — Session middleware in `frontend/middleware.ts` + revoke endpoint
- **KEI-111E** (KEI-149) — RLS policies on 3 tables + integration test (user A can't read user B rows)

## Open question for sub-KEI claimer

The dispatcher tasks namespace — separate `dispatcher_tasks` table, or filter `public.tasks` by a new `dispatcher_customer_id` column? Sub-KEI claimer decides after reading scope doc.

## Acceptance for this scaffold

- [x] `dispatcher_customers` table created with RLS-ready columns
- [x] FK to `auth.users` with `ON DELETE CASCADE`
- [x] Soft-delete column + 2 partial indexes
- [x] Scope doc captures dep graph + RLS target shape
- [x] All 4 named sub-KEIs have a clear next-step
- [x] No collision with existing tables

## Dual approval

[ELLIOT] + [AIDEN] per session rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)