### PR TITLE
[ATLAS] feat(kei151): KEI-112B — Subscription CRUD endpoints + tier-code mapping

### DIFF
--- a/infra/systemd/agents/dispatcher.service
+++ b/infra/systemd/agents/dispatcher.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Keiracom Customer Dispatcher (KEI-179)
+Documentation=https://linear.app/keiracom/issue/KEI-179
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/elliotbot/clawd/venv/bin/python3 -m src.dispatcher
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+StandardOutput=append:/home/elliotbot/clawd/logs/dispatcher.log
+StandardError=append:/home/elliotbot/clawd/logs/dispatcher.log
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/scripts/install_dispatcher.sh
+++ b/scripts/install_dispatcher.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# install_dispatcher.sh — Install dispatcher.service user unit (KEI-179).
+# References: dispatcher.service
+set -euo pipefail
+
+UNITS_DIR="${HOME}/.config/systemd/user"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AGENTS_DIR="${REPO_DIR}/infra/systemd/agents"
+LOG_DIR="${HOME}/clawd/logs"
+
+mkdir -p "${UNITS_DIR}" "${LOG_DIR}"
+
+cp "${AGENTS_DIR}/dispatcher.service" "${UNITS_DIR}/"
+
+systemctl --user daemon-reload
+systemctl --user enable --now dispatcher.service
+
+systemctl --user is-active dispatcher.service
+echo "dispatcher.service installed and started"

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -417,6 +417,7 @@ from src.api.routes.patterns import router as patterns_router
 from src.api.routes.pool import router as pool_router
 from src.api.routes.replies import router as replies_router
 from src.api.routes.reports import router as reports_router
+from src.api.routes.subscriptions import router as subscriptions_router
 from src.api.routes.tiers import router as tiers_router
 from src.api.routes.unipile import router as unipile_router
 from src.api.routes.webhooks import router as webhooks_router
@@ -451,6 +452,8 @@ app.include_router(linkedin_router, prefix="/api/v1")
 app.include_router(pool_router, prefix="/api/v1")
 # Phase H, Item 44: Daily Digest
 app.include_router(digest_router, prefix="/api/v1")
+# KEI-151: Customer Subscriptions CRUD (Part 17.2)
+app.include_router(subscriptions_router, prefix="/api/v1")
 # Unipile BYOA Multi-Tenancy
 app.include_router(unipile_router, prefix="/api/v1")
 # Step 8/8: Stripe Billing

--- a/src/api/routes/subscriptions.py
+++ b/src/api/routes/subscriptions.py
@@ -1,0 +1,222 @@
+"""KEI-151 (KEI-112B) — Subscription CRUD endpoints + tier-code mapping.
+
+POST   /api/v1/subscriptions          — create
+GET    /api/v1/subscriptions/{id}     — fetch
+PATCH  /api/v1/subscriptions/{id}     — update tier
+DELETE /api/v1/subscriptions/{id}     — soft-cancel (status=canceled)
+
+Tier limits come from src.dispatcher.tier_limits.TIER_LIMITS (KEI-172).
+GET response embeds the resolved (limit, window_size_s) so the customer's
+frontend can render the tier ceiling without a second round-trip.
+
+Soft-cancel pattern: DELETE marks status='canceled' + canceled_at=NOW().
+The partial unique index ``customer_subscriptions_active_per_customer``
+allows a new active row to be created after cancellation. Hard DELETE is
+not exposed — audit trail preservation is a regulatory requirement.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.dependencies import get_db_session
+from src.dispatcher.tier_limits import TIER_LIMITS, Tier, limits_for
+
+router = APIRouter(prefix="/subscriptions", tags=["subscriptions"])
+
+
+class SubscriptionCreate(BaseModel):
+    customer_id: UUID
+    tier_code: Tier
+    paddle_subscription_id: str | None = Field(default=None, max_length=128)
+
+
+class SubscriptionUpdate(BaseModel):
+    tier_code: Tier
+
+
+class SubscriptionRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    customer_id: UUID
+    tier_code: Tier
+    paddle_subscription_id: str | None
+    status: str
+    limit_per_window: int
+    window_size_s: int
+    created_at: datetime
+    updated_at: datetime
+    canceled_at: datetime | None
+
+
+def _row_to_read(row) -> SubscriptionRead:
+    """Build a SubscriptionRead from a SQLAlchemy Row, attaching the
+    tier's (limit, window) so the response doesn't force another lookup."""
+    tier_code: Tier = row.tier_code  # type: ignore[assignment]
+    limit, window_size_s = limits_for(tier_code)
+    return SubscriptionRead(
+        id=row.id,
+        customer_id=row.customer_id,
+        tier_code=tier_code,
+        paddle_subscription_id=row.paddle_subscription_id,
+        status=row.status,
+        limit_per_window=limit,
+        window_size_s=window_size_s,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        canceled_at=row.canceled_at,
+    )
+
+
+@router.post("", response_model=SubscriptionRead, status_code=status.HTTP_201_CREATED)
+async def create_subscription(
+    payload: SubscriptionCreate,
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> SubscriptionRead:
+    """Create an active subscription for a customer.
+
+    Returns 409 if the customer already has an active subscription (the
+    partial unique index blocks duplicates; cancel the existing one first
+    via DELETE /subscriptions/<old-id>).
+    """
+    if payload.tier_code not in TIER_LIMITS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"unknown tier_code: {payload.tier_code!r}",
+        )
+    try:
+        result = await db.execute(
+            text(
+                """
+                INSERT INTO public.customer_subscriptions
+                    (customer_id, tier_code, paddle_subscription_id)
+                VALUES (:customer_id, :tier_code, :paddle_subscription_id)
+                RETURNING id, customer_id, tier_code, paddle_subscription_id,
+                          status, created_at, updated_at, canceled_at
+                """
+            ),
+            {
+                "customer_id": str(payload.customer_id),
+                "tier_code": payload.tier_code,
+                "paddle_subscription_id": payload.paddle_subscription_id,
+            },
+        )
+        row = result.one()
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="customer already has an active subscription",
+        ) from exc
+    return _row_to_read(row)
+
+
+@router.get("/{subscription_id}", response_model=SubscriptionRead)
+async def get_subscription(
+    subscription_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> SubscriptionRead:
+    """Fetch a subscription by id, including its tier-derived limits."""
+    result = await db.execute(
+        text(
+            """
+            SELECT id, customer_id, tier_code, paddle_subscription_id,
+                   status, created_at, updated_at, canceled_at
+            FROM public.customer_subscriptions
+            WHERE id = :id
+            """
+        ),
+        {"id": str(subscription_id)},
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="subscription not found")
+    return _row_to_read(row)
+
+
+@router.patch("/{subscription_id}", response_model=SubscriptionRead)
+async def update_subscription_tier(
+    subscription_id: UUID,
+    payload: SubscriptionUpdate,
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> SubscriptionRead:
+    """Update tier_code on an active subscription. Canceled rows are
+    immutable — caller must create a fresh subscription instead.
+    """
+    if payload.tier_code not in TIER_LIMITS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"unknown tier_code: {payload.tier_code!r}",
+        )
+    result = await db.execute(
+        text(
+            """
+            UPDATE public.customer_subscriptions
+            SET tier_code = :tier_code,
+                updated_at = NOW()
+            WHERE id = :id AND status = 'active'
+            RETURNING id, customer_id, tier_code, paddle_subscription_id,
+                      status, created_at, updated_at, canceled_at
+            """
+        ),
+        {"id": str(subscription_id), "tier_code": payload.tier_code},
+    )
+    row = result.one_or_none()
+    if row is None:
+        # Either id not found or row is canceled — distinguish in the message
+        # via a second cheap query.
+        check = await db.execute(
+            text("SELECT status FROM public.customer_subscriptions WHERE id = :id"),
+            {"id": str(subscription_id)},
+        )
+        existing = check.one_or_none()
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="subscription not found"
+            )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"subscription is {existing.status}, not active — cannot update tier",
+        )
+    await db.commit()
+    return _row_to_read(row)
+
+
+@router.delete("/{subscription_id}", response_model=SubscriptionRead)
+async def cancel_subscription(
+    subscription_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> SubscriptionRead:
+    """Soft-cancel: status='canceled', canceled_at=NOW(). Idempotent —
+    a second call on an already-canceled row returns the same row with
+    no change. Hard DELETE is not exposed (audit trail preservation)."""
+    now = datetime.now(UTC)
+    result = await db.execute(
+        text(
+            """
+            UPDATE public.customer_subscriptions
+            SET status = 'canceled',
+                canceled_at = COALESCE(canceled_at, :now),
+                updated_at = :now
+            WHERE id = :id
+            RETURNING id, customer_id, tier_code, paddle_subscription_id,
+                      status, created_at, updated_at, canceled_at
+            """
+        ),
+        {"id": str(subscription_id), "now": now},
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="subscription not found")
+    await db.commit()
+    return _row_to_read(row)

--- a/src/api/routes/subscriptions.py
+++ b/src/api/routes/subscriptions.py
@@ -32,6 +32,8 @@ from src.dispatcher.tier_limits import TIER_LIMITS, Tier, limits_for
 
 router = APIRouter(prefix="/subscriptions", tags=["subscriptions"])
 
+_NOT_FOUND_DETAIL = "subscription not found"
+
 
 class SubscriptionCreate(BaseModel):
     customer_id: UUID
@@ -77,7 +79,7 @@ def _row_to_read(row) -> SubscriptionRead:
     )
 
 
-@router.post("", response_model=SubscriptionRead, status_code=status.HTTP_201_CREATED)
+@router.post("", status_code=status.HTTP_201_CREATED)
 async def create_subscription(
     payload: SubscriptionCreate,
     db: Annotated[AsyncSession, Depends(get_db_session)],
@@ -121,7 +123,7 @@ async def create_subscription(
     return _row_to_read(row)
 
 
-@router.get("/{subscription_id}", response_model=SubscriptionRead)
+@router.get("/{subscription_id}")
 async def get_subscription(
     subscription_id: UUID,
     db: Annotated[AsyncSession, Depends(get_db_session)],
@@ -140,11 +142,11 @@ async def get_subscription(
     )
     row = result.one_or_none()
     if row is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="subscription not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND_DETAIL)
     return _row_to_read(row)
 
 
-@router.patch("/{subscription_id}", response_model=SubscriptionRead)
+@router.patch("/{subscription_id}")
 async def update_subscription_tier(
     subscription_id: UUID,
     payload: SubscriptionUpdate,
@@ -181,9 +183,7 @@ async def update_subscription_tier(
         )
         existing = check.one_or_none()
         if existing is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="subscription not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND_DETAIL)
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"subscription is {existing.status}, not active — cannot update tier",
@@ -192,7 +192,7 @@ async def update_subscription_tier(
     return _row_to_read(row)
 
 
-@router.delete("/{subscription_id}", response_model=SubscriptionRead)
+@router.delete("/{subscription_id}")
 async def cancel_subscription(
     subscription_id: UUID,
     db: Annotated[AsyncSession, Depends(get_db_session)],
@@ -217,6 +217,6 @@ async def cancel_subscription(
     )
     row = result.one_or_none()
     if row is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="subscription not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND_DETAIL)
     await db.commit()
     return _row_to_read(row)

--- a/src/dispatcher/__init__.py
+++ b/src/dispatcher/__init__.py
@@ -1,5 +1,7 @@
 """Dispatcher product layer — KEI-110 Part 17.
 
 Customer-facing product surface: container lifecycle (KEI-115), tenant JWT
-minting (KEI-164), governance proxy (KEI-165), LiteLLM routing (KEI-166).
+minting (KEI-164), governance proxy (KEI-165), LiteLLM routing (KEI-166),
+Valkey rate limiting (KEI-117), and the dispatcher service entrypoint
+(KEI-179).
 """

--- a/src/dispatcher/__main__.py
+++ b/src/dispatcher/__main__.py
@@ -1,0 +1,24 @@
+"""KEI-179 — uvicorn entrypoint for the dispatcher service.
+
+Run via ``python3 -m src.dispatcher`` (see systemd unit + install script
+for production).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import uvicorn
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8090
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    host = os.environ.get("DISPATCHER_HOST", DEFAULT_HOST)
+    port = int(os.environ.get("DISPATCHER_PORT", str(DEFAULT_PORT)))
+    uvicorn.run("src.dispatcher.app:app", host=host, port=port, log_level="info")

--- a/src/dispatcher/app.py
+++ b/src/dispatcher/app.py
@@ -1,0 +1,164 @@
+"""KEI-179 — Customer Dispatcher service entrypoint.
+
+FastAPI app exposing the customer-facing dispatcher endpoint that Max's
+KEI-180 Strangler Fig router forwards Model B traffic to. Separate from
+the existing src/api/main.py (agency-side app) — the dispatcher is a
+distinct tenancy (customer_id, not client_id) and runs as its own
+systemd unit on a separate port so blast radius stays contained.
+
+Endpoints:
+    GET  /health                — liveness probe (no auth, no DB)
+    POST /dispatch              — accept a customer task body, rate-limit
+                                  via tier, forward through the LiteLLM
+                                  router, return the model response
+
+Run locally:
+    python3 -m src.dispatcher                       # uvicorn on :8090
+    DISPATCHER_PORT=8091 python3 -m src.dispatcher  # override port
+
+Run as a service:
+    bash scripts/install_dispatcher.sh              # installs systemd unit
+    systemctl --user start dispatcher.service
+    systemctl --user is-active dispatcher           # → "active"
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel, Field
+
+from src.dispatcher.llm_router import (
+    CostEvent,
+    LiteLLMRateLimitExhaustedError,
+    LiteLLMRouterError,
+    forward,
+)
+from src.dispatcher.rate_limiter import RateLimitExceededError
+from src.dispatcher.tier_limits import enforce_for_tenant
+
+logger = logging.getLogger(__name__)
+
+
+def _log_id(value: str) -> str:
+    """Return a short SHA-256 prefix of a user-controlled identifier — safe
+    for logs. Hashing (Sonar S5145 sanitizer pattern) prevents log injection
+    (CRLF, ANSI escapes) AND PII leakage. 12 hex chars = 48 bits, enough
+    for in-cycle correlation; operators with the plaintext id can recompute
+    the prefix to grep historical logs."""
+    return hashlib.sha256(str(value).encode("utf-8", errors="replace")).hexdigest()[:12]
+
+
+app = FastAPI(
+    title="Keiracom Dispatcher",
+    description="Customer-facing dispatcher service (KEI-179). Receives Model B "
+    "traffic from the Strangler Fig router (KEI-180); rate-limits per tier; "
+    "forwards through LiteLLM; logs cost events.",
+    version="0.1.0",
+)
+
+
+class DispatchRequest(BaseModel):
+    customer_id: str = Field(min_length=1)
+    task_id: str = Field(min_length=1)
+    body: dict[str, Any] = Field(
+        description="Opaque LiteLLM-shaped request body (model, messages, ...). "
+        "Validated upstream by the governance proxy (KEI-115D)."
+    )
+
+
+class DispatchResponse(BaseModel):
+    customer_id: str
+    task_id: str
+    rate_limit_decision: dict[str, Any]
+    response: dict[str, Any]
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Liveness probe — returns 200 if the process is alive. Intentionally
+    does NOT touch the DB / Valkey / LiteLLM so a downstream outage
+    doesn't take this service out of the load balancer."""
+    return {"status": "ok", "service": "dispatcher"}
+
+
+@app.post("/dispatch", response_model=None)
+async def dispatch(payload: DispatchRequest) -> DispatchResponse:
+    """Rate-limit the tenant per their subscription tier, then forward
+    the request body through LiteLLM.
+
+    Returns:
+        200 with the LiteLLM response + the rate-limit decision metadata
+        (limit, remaining headroom) so the customer can self-throttle.
+
+    Raises:
+        429 — tenant exceeded their per-window limit (tier-derived).
+        502 — LiteLLM gateway returned a non-2xx non-429 OR transport error.
+        500 — unexpected router failure.
+    """
+    safe_tenant = _log_id(payload.customer_id)
+    safe_task = _log_id(payload.task_id)
+    try:
+        decision = await enforce_for_tenant(tenant_id=payload.customer_id)
+    except RateLimitExceededError as exc:
+        logger.info(
+            "dispatcher 429 tenant=%s task=%s limit=%d window=%ds",
+            safe_tenant,
+            safe_task,
+            exc.limit,
+            exc.window_size_s,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+            headers={"Retry-After": str(exc.window_size_s)},
+        ) from exc
+
+    cost_events: list[CostEvent] = []
+    try:
+        response_body = forward(
+            body=payload.body,
+            customer_id=payload.customer_id,
+            task_id=payload.task_id,
+            cost_sink=cost_events.append,
+        )
+    except LiteLLMRateLimitExhaustedError as exc:
+        # Upstream LiteLLM gateway exhausted retries — surface as 429
+        # with a longer Retry-After than the tenant limit suggests so the
+        # customer doesn't immediately retry into the same upstream issue.
+        logger.warning(
+            "dispatcher upstream-429 tenant=%s task=%s",
+            safe_tenant,
+            safe_task,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+            headers={"Retry-After": "60"},
+        ) from exc
+    except LiteLLMRouterError as exc:
+        logger.warning(
+            "dispatcher 502 tenant=%s task=%s err=%s",
+            safe_tenant,
+            safe_task,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
+
+    return DispatchResponse(
+        customer_id=payload.customer_id,
+        task_id=payload.task_id,
+        rate_limit_decision={
+            "limit": decision.limit,
+            "current": decision.current,
+            "window_size_s": decision.window_size_s,
+            "retry_after_s": decision.retry_after_s,
+        },
+        response=response_body,
+    )

--- a/src/dispatcher/container_lifecycle.py
+++ b/src/dispatcher/container_lifecycle.py
@@ -1,0 +1,192 @@
+"""KEI-115A — Container spawn + startup timeout + health check.
+
+Foundational primitive for Part 17 dispatcher product layer. Wraps the
+local docker CLI via subprocess (one less dependency than docker-py;
+tracks vendor shape verbatim — see `empirical-smoke-catches-paper-review-3`).
+
+Caller responsibility: the container image must expose an HTTP health
+endpoint (default ``/healthz``) on the published port. ``wait_healthy``
+polls that endpoint and aborts cleanly via ``docker kill`` + ``docker
+rm -f`` if it doesn't respond 2xx within the startup timeout. KEI-163
+(KEI-115B) handles the longer-running lifecycle monitor; this module is
+spawn + wait + clean-abort only.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import http.client
+import logging
+import subprocess
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HEALTH_PATH = "/healthz"
+DEFAULT_STARTUP_TIMEOUT_S = 30.0
+DEFAULT_POLL_INTERVAL_S = 1.0
+DEFAULT_HEALTH_PROBE_TIMEOUT_S = 2.0
+DEFAULT_DOCKER_CMD_TIMEOUT_S = 30.0
+DEFAULT_DOCKER_TEARDOWN_TIMEOUT_S = 10.0
+DOCKER_CLI = "docker"
+
+
+class ContainerStartupError(RuntimeError):
+    """Container failed to start or become healthy within startup timeout.
+
+    On the wait_healthy timeout path, the container has already been
+    killed + removed before this is raised — caller does not need to
+    clean up.
+    """
+
+
+class DockerUnavailableError(RuntimeError):
+    """The docker CLI is not installed or not on PATH."""
+
+
+@dataclass(frozen=True)
+class ContainerHandle:
+    """Reference to a running container. Returned by `spawn_container`,
+    consumed by `wait_healthy` / `kill_and_remove` / future lifecycle ops.
+    """
+
+    id: str
+    name: str
+    image: str
+    port: int
+    health_path: str = DEFAULT_HEALTH_PATH
+
+
+def _run_docker(
+    args: list[str], timeout_s: float = DEFAULT_DOCKER_CMD_TIMEOUT_S
+) -> subprocess.CompletedProcess:
+    # controlled args, no shell — S603 suppressed
+    try:
+        return subprocess.run(  # noqa: S603
+            [DOCKER_CLI, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise DockerUnavailableError(f"{DOCKER_CLI} CLI not found on PATH") from exc
+
+
+def spawn_container(
+    *,
+    image: str,
+    name: str,
+    port: int,
+    env: dict[str, str] | None = None,
+    health_path: str = DEFAULT_HEALTH_PATH,
+    extra_args: list[str] | None = None,
+) -> ContainerHandle:
+    """Start a detached container and return a handle.
+
+    Image-agnostic — caller passes ``image`` so the same primitive serves
+    the BYO-key Claude-side container and future per-tier containers.
+    Does NOT block on health; call ``wait_healthy(handle)`` next.
+
+    Raises:
+        DockerUnavailableError: docker CLI missing from PATH.
+        ContainerStartupError: ``docker run`` returned non-zero or empty id.
+    """
+    cmd: list[str] = ["run", "-d", "--name", name, "-p", f"{port}:{port}"]
+    for k, v in (env or {}).items():
+        cmd += ["-e", f"{k}={v}"]
+    if extra_args:
+        cmd += list(extra_args)
+    cmd.append(image)
+
+    out = _run_docker(cmd)
+    if out.returncode != 0:
+        raise ContainerStartupError(
+            f"docker run failed (rc={out.returncode}): {out.stderr.strip()[:300]}"
+        )
+    container_id = out.stdout.strip()
+    if not container_id:
+        raise ContainerStartupError("docker run returned empty container id")
+    return ContainerHandle(
+        id=container_id,
+        name=name,
+        image=image,
+        port=port,
+        health_path=health_path,
+    )
+
+
+def _probe_health(host: str, port: int, path: str) -> bool:
+    """Return True iff GET http://host:port<path> responds 2xx within
+    DEFAULT_HEALTH_PROBE_TIMEOUT_S. Any network/protocol error is False
+    (caller treats this as 'not yet ready' and retries until timeout).
+    """
+    conn = None
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=DEFAULT_HEALTH_PROBE_TIMEOUT_S)
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        ok = 200 <= resp.status < 300
+        resp.read()
+        return ok
+    except (OSError, http.client.HTTPException):
+        return False
+    finally:
+        if conn is not None:
+            with contextlib.suppress(OSError):
+                conn.close()
+
+
+def wait_healthy(
+    handle: ContainerHandle,
+    *,
+    timeout_s: float = DEFAULT_STARTUP_TIMEOUT_S,
+    interval_s: float = DEFAULT_POLL_INTERVAL_S,
+    host: str = "127.0.0.1",
+) -> bool:
+    """Poll the container's health endpoint until it returns 2xx or timeout.
+
+    On timeout: kill_and_remove the container, then raise
+    ContainerStartupError. The container is gone before the exception
+    surfaces — caller does not need to clean up.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if _probe_health(host, handle.port, handle.health_path):
+            logger.info(
+                "container %s healthy on %s:%d%s",
+                handle.id[:12],
+                host,
+                handle.port,
+                handle.health_path,
+            )
+            return True
+        time.sleep(interval_s)
+
+    logger.warning(
+        "container %s failed health check within %.1fs — aborting",
+        handle.id[:12],
+        timeout_s,
+    )
+    kill_and_remove(handle)
+    raise ContainerStartupError(
+        f"container {handle.id[:12]} ({handle.image}) failed health check within {timeout_s:.1f}s"
+    )
+
+
+def kill_and_remove(handle: ContainerHandle) -> None:
+    """Best-effort stop + remove. Logs but does not raise on docker
+    errors — the abort path must not mask the original failure for
+    callers using this from `wait_healthy`'s timeout branch.
+    """
+    for op in (["kill", handle.id], ["rm", "-f", handle.id]):
+        result = _run_docker(op, timeout_s=DEFAULT_DOCKER_TEARDOWN_TIMEOUT_S)
+        if result.returncode != 0:
+            logger.warning(
+                "docker %s %s failed (rc=%d): %s",
+                op[0],
+                handle.id[:12],
+                result.returncode,
+                result.stderr.strip()[:200],
+            )

--- a/src/dispatcher/llm_router.py
+++ b/src/dispatcher/llm_router.py
@@ -1,0 +1,244 @@
+"""KEI-115E — LiteLLM router for customer dispatcher requests.
+
+Forwards customer requests to the local LiteLLM gateway (default
+``http://127.0.0.1:4000``), retries on 429 with bounded backoff, emits
+cost-event metadata via an injectable ``cost_sink`` callback so the
+consumer chooses where to persist (no DB write in this layer — see KEI
+note: a dispatcher-customer cost table does not yet exist; existing
+``vendor_usage_log`` / ``sdk_usage_log`` are agency-CRM-shaped).
+
+Body is treated as an opaque pass-through. Governance/schema validation
+lives upstream in the proxy (KEI-115D / KEI-165). Auth headers + tenant
+context come from the caller — the router does not know about JWTs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GATEWAY_URL = "http://127.0.0.1:4000/v1/chat/completions"
+DEFAULT_HTTP_TIMEOUT_S = 60.0
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_BACKOFF_LADDER_S: tuple[float, ...] = (1.0, 2.0, 5.0)
+
+CostSink = Callable[["CostEvent"], None]
+
+
+class LiteLLMRouterError(RuntimeError):
+    """Non-retryable router failure — bad gateway response or transport error."""
+
+
+class LiteLLMRateLimitExhaustedError(LiteLLMRouterError):
+    """Gateway returned 429 ``max_retries`` times in a row. Caller may decide
+    to surface as a tier-limit message to the customer."""
+
+
+@dataclass(frozen=True)
+class CostEvent:
+    """One forwarded request's cost-tracking record. The router never
+    persists this — it hands it to ``cost_sink`` for the caller to write
+    to whichever ledger fits their tenant model."""
+
+    customer_id: str
+    task_id: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cost_aud: float
+    retry_count: int
+    duration_ms: int
+    success: bool
+    error_message: str | None = None
+
+
+def _extract_usage(response_body: dict[str, Any]) -> tuple[str, int, int, float]:
+    """Pull model + token counts + cost out of a LiteLLM response. Falls
+    back to zeros when LiteLLM didn't return the expected shape — cost
+    accounting is best-effort, not load-bearing for request success."""
+    model = str(response_body.get("model") or "unknown")
+    usage = response_body.get("usage") or {}
+    input_tokens = int(usage.get("prompt_tokens") or 0)
+    output_tokens = int(usage.get("completion_tokens") or 0)
+    # LiteLLM exposes per-request cost under the non-standard
+    # ``response_cost`` field when ``litellm.success_callback`` is set.
+    # Coerce to AUD if the deploy is configured for AUD pricing; this
+    # router does NOT do USD→AUD conversion (LAW II — let the gateway
+    # config own currency).
+    cost_aud = float(response_body.get("response_cost") or 0.0)
+    return model, input_tokens, output_tokens, cost_aud
+
+
+def _post_json(url: str, body: dict[str, Any], timeout_s: float) -> tuple[int, dict[str, Any]]:
+    """POST JSON to ``url``, return (status_code, parsed_body). Raises
+    LiteLLMRouterError on transport-level failure (DNS, refused, timeout)
+    so the caller's retry loop can distinguish from 429s.
+    """
+    raw = json.dumps(body).encode("utf-8")
+    req = urlrequest.Request(
+        url,
+        data=raw,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urlrequest.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 — fixed gateway URL
+            status = int(resp.status)
+            payload = json.loads(resp.read() or b"{}")
+            return status, payload
+    except urlerror.HTTPError as exc:
+        # HTTPError IS the response — capture status + body so retry logic
+        # can branch on 429 vs everything else.
+        try:
+            payload = json.loads(exc.read() or b"{}")
+        except (json.JSONDecodeError, OSError):
+            payload = {"error": str(exc)}
+        return int(exc.code), payload
+    except (urlerror.URLError, OSError) as exc:
+        # TimeoutError is a subclass of OSError in Python 3.10+, covered already
+        raise LiteLLMRouterError(f"litellm transport error: {exc}") from exc
+
+
+def forward(
+    *,
+    body: dict[str, Any],
+    customer_id: str,
+    task_id: str,
+    gateway_url: str = DEFAULT_GATEWAY_URL,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    backoff_s: tuple[float, ...] = DEFAULT_BACKOFF_LADDER_S,
+    timeout_s: float = DEFAULT_HTTP_TIMEOUT_S,
+    cost_sink: CostSink | None = None,
+) -> dict[str, Any]:
+    """Forward a chat-completion request to LiteLLM with retry-on-429.
+
+    Args:
+        body: Opaque LiteLLM-shaped request body (model, messages, ...).
+        customer_id: Tenant identifier — attached to the cost event only.
+        task_id: KEI / dispatcher task identifier — attached to cost event.
+        gateway_url: LiteLLM endpoint. Default is the systemd-managed local proxy.
+        max_retries: Max 429 retries before raising LiteLLMRateLimitExhaustedError.
+        backoff_s: Per-retry sleep ladder (truncated to ``max_retries``).
+        timeout_s: HTTP timeout per attempt.
+        cost_sink: Optional callback invoked once on success with a CostEvent.
+            Exceptions from the sink are caught + logged — sink failure must
+            NOT bubble into the forwarding result.
+
+    Returns:
+        Parsed LiteLLM response body on 2xx.
+
+    Raises:
+        LiteLLMRateLimitExhaustedError: 429 returned ``max_retries`` times.
+        LiteLLMRouterError: Transport failure or non-2xx non-429 response.
+    """
+    started_monotonic = time.monotonic()
+    retry_count = 0
+    last_status = 0
+    last_payload: dict[str, Any] = {}
+
+    for attempt in range(max_retries + 1):
+        status, payload = _post_json(gateway_url, body, timeout_s)
+        last_status, last_payload = status, payload
+        if 200 <= status < 300:
+            duration_ms = int((time.monotonic() - started_monotonic) * 1000)
+            _emit_cost(
+                payload,
+                customer_id=customer_id,
+                task_id=task_id,
+                retry_count=retry_count,
+                duration_ms=duration_ms,
+                success=True,
+                error_message=None,
+                cost_sink=cost_sink,
+            )
+            return payload
+        if status == 429 and attempt < max_retries:
+            sleep_for = backoff_s[min(attempt, len(backoff_s) - 1)]
+            logger.info(
+                "litellm 429 on attempt %d/%d — sleeping %.1fs",
+                attempt + 1,
+                max_retries,
+                sleep_for,
+            )
+            time.sleep(sleep_for)
+            retry_count += 1
+            continue
+        # Non-2xx and not a retryable 429 — fail terminal.
+        break
+
+    duration_ms = int((time.monotonic() - started_monotonic) * 1000)
+    error_message = (
+        json.dumps(last_payload)[:500] if last_payload else f"litellm status {last_status}"
+    )
+    _emit_cost(
+        last_payload,
+        customer_id=customer_id,
+        task_id=task_id,
+        retry_count=retry_count,
+        duration_ms=duration_ms,
+        success=False,
+        error_message=error_message,
+        cost_sink=cost_sink,
+    )
+    if last_status == 429:
+        raise LiteLLMRateLimitExhaustedError(
+            f"litellm 429 after {max_retries} retries: {error_message}"
+        )
+    raise LiteLLMRouterError(f"litellm status {last_status}: {error_message}")
+
+
+def _emit_cost(
+    response_body: dict[str, Any],
+    *,
+    customer_id: str,
+    task_id: str,
+    retry_count: int,
+    duration_ms: int,
+    success: bool,
+    error_message: str | None,
+    cost_sink: CostSink | None,
+) -> None:
+    """Build a CostEvent and hand it to ``cost_sink``. Sink failures are
+    swallowed — the router must not propagate ledger problems back to the
+    caller whose request actually completed."""
+    if cost_sink is None:
+        return
+    model, input_tokens, output_tokens, cost_aud = _extract_usage(response_body)
+    event = CostEvent(
+        customer_id=customer_id,
+        task_id=task_id,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_aud=cost_aud,
+        retry_count=retry_count,
+        duration_ms=duration_ms,
+        success=success,
+        error_message=error_message,
+    )
+    try:
+        cost_sink(event)
+    except Exception as exc:  # noqa: BLE001 — sink is consumer-owned; must isolate
+        # SHA-256 prefix is Sonar S5145's recognised sanitiser pattern for
+        # user-controlled identifiers — defends against log injection AND
+        # PII leakage. Operators with the plaintext id can recompute to grep.
+        import hashlib
+
+        task_hash = hashlib.sha256(str(task_id).encode("utf-8", errors="replace")).hexdigest()[:12]
+        customer_hash = hashlib.sha256(
+            str(customer_id).encode("utf-8", errors="replace")
+        ).hexdigest()[:12]
+        logger.warning(
+            "cost_sink raised for task=%s customer=%s: %s",
+            task_hash,
+            customer_hash,
+            exc,
+        )

--- a/supabase/migrations/20260517_kei151_customer_subscriptions.sql
+++ b/supabase/migrations/20260517_kei151_customer_subscriptions.sql
@@ -12,34 +12,38 @@
 --   paused    → reserved for future Paddle pause-resume; not used in this PR.
 --
 -- Idempotent: CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+-- DO-block wrap follows Max's KEI-45 fix pattern (CONSTANT for repeated SQL
+-- literal — Sonar S1192). The literal 'active' would otherwise repeat 3×
+-- (DEFAULT + CHECK + partial index WHERE), tripping S1192.
 -- =============================================================================
 
-CREATE TABLE IF NOT EXISTS public.customer_subscriptions (
-    id                     UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-    customer_id            UUID         NOT NULL,
-    -- tier code maps to src.dispatcher.tier_limits.TIER_LIMITS keys.
-    -- Valid values: 'basic' | 'pro' | 'enterprise'.
-    tier_code              TEXT         NOT NULL,
-    -- Paddle subscription id (KEI-150 / KEI-112A integration). NULLable so
-    -- a free-tier or beta subscription can exist before Paddle is wired.
-    paddle_subscription_id TEXT,
-    -- Subscription lifecycle status. CHECK constraint enforces the enum.
-    status                 TEXT         NOT NULL DEFAULT 'active',
-    created_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-    updated_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-    canceled_at            TIMESTAMPTZ,
-    CONSTRAINT customer_subscriptions_status_chk
-        CHECK (status IN ('active', 'canceled', 'paused')),
-    CONSTRAINT customer_subscriptions_tier_chk
-        CHECK (tier_code IN ('basic', 'pro', 'enterprise'))
-);
+DO $migration$
+DECLARE
+    status_active CONSTANT text := 'active';
+BEGIN
+    EXECUTE format($ddl$
+        CREATE TABLE IF NOT EXISTS public.customer_subscriptions (
+            id                     UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+            customer_id            UUID         NOT NULL,
+            tier_code              TEXT         NOT NULL,
+            paddle_subscription_id TEXT,
+            status                 TEXT         NOT NULL DEFAULT %1$L,
+            created_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+            updated_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+            canceled_at            TIMESTAMPTZ,
+            CONSTRAINT customer_subscriptions_status_chk
+                CHECK (status IN (%1$L, 'canceled', 'paused')),
+            CONSTRAINT customer_subscriptions_tier_chk
+                CHECK (tier_code IN ('basic', 'pro', 'enterprise'))
+        );
 
--- One ACTIVE subscription per customer (rotate-on-tier-change pattern via
--- INSERT+UPDATE). Canceled rows retained for audit history.
-CREATE UNIQUE INDEX IF NOT EXISTS customer_subscriptions_active_per_customer
-    ON public.customer_subscriptions (customer_id)
-    WHERE status = 'active';
+        CREATE UNIQUE INDEX IF NOT EXISTS customer_subscriptions_active_per_customer
+            ON public.customer_subscriptions (customer_id)
+            WHERE status = %1$L;
 
-CREATE INDEX IF NOT EXISTS customer_subscriptions_paddle_id_idx
-    ON public.customer_subscriptions (paddle_subscription_id)
-    WHERE paddle_subscription_id IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS customer_subscriptions_paddle_id_idx
+            ON public.customer_subscriptions (paddle_subscription_id)
+            WHERE paddle_subscription_id IS NOT NULL;
+    $ddl$, status_active);
+END
+$migration$;

--- a/supabase/migrations/20260517_kei151_customer_subscriptions.sql
+++ b/supabase/migrations/20260517_kei151_customer_subscriptions.sql
@@ -1,0 +1,45 @@
+-- =============================================================================
+-- KEI-151 (KEI-112B) — Customer Subscriptions (Part 17.2)
+-- =============================================================================
+-- Stores one row per customer-subscription. Tier code drives the rate-limit
+-- + cost-cap policy (loaded from src/dispatcher/tier_limits.py TIER_LIMITS,
+-- shipped as KEI-172 / KEI-117C).
+--
+-- Status lifecycle:
+--   active    → customer is paying, all tier policies apply
+--   canceled  → DELETE /subscriptions/<id> sets canceled_at + status; row
+--                kept for audit. New subscription gets a fresh row.
+--   paused    → reserved for future Paddle pause-resume; not used in this PR.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.customer_subscriptions (
+    id                     UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id            UUID         NOT NULL,
+    -- tier code maps to src.dispatcher.tier_limits.TIER_LIMITS keys.
+    -- Valid values: 'basic' | 'pro' | 'enterprise'.
+    tier_code              TEXT         NOT NULL,
+    -- Paddle subscription id (KEI-150 / KEI-112A integration). NULLable so
+    -- a free-tier or beta subscription can exist before Paddle is wired.
+    paddle_subscription_id TEXT,
+    -- Subscription lifecycle status. CHECK constraint enforces the enum.
+    status                 TEXT         NOT NULL DEFAULT 'active',
+    created_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    canceled_at            TIMESTAMPTZ,
+    CONSTRAINT customer_subscriptions_status_chk
+        CHECK (status IN ('active', 'canceled', 'paused')),
+    CONSTRAINT customer_subscriptions_tier_chk
+        CHECK (tier_code IN ('basic', 'pro', 'enterprise'))
+);
+
+-- One ACTIVE subscription per customer (rotate-on-tier-change pattern via
+-- INSERT+UPDATE). Canceled rows retained for audit history.
+CREATE UNIQUE INDEX IF NOT EXISTS customer_subscriptions_active_per_customer
+    ON public.customer_subscriptions (customer_id)
+    WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS customer_subscriptions_paddle_id_idx
+    ON public.customer_subscriptions (paddle_subscription_id)
+    WHERE paddle_subscription_id IS NOT NULL;

--- a/tests/api/routes/test_subscriptions.py
+++ b/tests/api/routes/test_subscriptions.py
@@ -48,7 +48,9 @@ def _make_db_session(execute_results: list):
     session = MagicMock()
     results_iter = iter(execute_results)
 
-    async def fake_execute(_query, _params=None):
+    def fake_execute(_query, _params=None):
+        # AsyncMock(side_effect=sync_callable) returns this value as the
+        # awaited result — no internal await needed in the stub itself.
         item = next(results_iter)
         if isinstance(item, Exception):
             raise item
@@ -136,7 +138,7 @@ def test_create_subscription_rejects_unknown_tier(client_with_db):
 def test_create_subscription_conflict_on_duplicate_active(client_with_db):
     """Partial unique index raises IntegrityError → 409 with friendly msg."""
     client_with_db.db_results["results"] = [
-        IntegrityError("dup", {}, Exception("active subscription exists"))
+        IntegrityError("dup", {}, RuntimeError("active subscription exists"))
     ]
     resp = client_with_db.post(
         "/api/v1/subscriptions",

--- a/tests/api/routes/test_subscriptions.py
+++ b/tests/api/routes/test_subscriptions.py
@@ -1,0 +1,252 @@
+"""KEI-151 (KEI-112B) — tests for src/api/routes/subscriptions.
+
+The SQLAlchemy AsyncSession dependency is overridden with a fake that
+records executed SQL + responds with pre-canned row mocks. No live DB.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+from src.api.dependencies import get_db_session
+from src.api.main import app
+
+
+def _row(
+    *,
+    sub_id=None,
+    customer_id=None,
+    tier_code="basic",
+    paddle_subscription_id=None,
+    sub_status="active",
+    canceled_at=None,
+):
+    """Build a fake row with the columns the route's RETURNING/SELECT expect."""
+    return SimpleNamespace(
+        id=sub_id or uuid4(),
+        customer_id=customer_id or uuid4(),
+        tier_code=tier_code,
+        paddle_subscription_id=paddle_subscription_id,
+        status=sub_status,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        canceled_at=canceled_at,
+    )
+
+
+def _make_db_session(execute_results: list):
+    """Build an AsyncSession-like that yields each execute_results entry
+    per .execute() call in order. Each entry is the .one()/.one_or_none()
+    return value (or an Exception to raise from .execute())."""
+    session = MagicMock()
+    results_iter = iter(execute_results)
+
+    async def fake_execute(_query, _params=None):
+        item = next(results_iter)
+        if isinstance(item, Exception):
+            raise item
+        result = MagicMock()
+        result.one = MagicMock(return_value=item)
+        result.one_or_none = MagicMock(return_value=item)
+        return result
+
+    session.execute = AsyncMock(side_effect=fake_execute)
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def client_with_db():
+    """Build a TestClient with the AsyncSession dependency override-able
+    per test via the .db_results attribute."""
+    holder: dict = {"results": []}
+
+    def _override():
+        session = _make_db_session(holder["results"])
+        holder["session"] = session
+        return session
+
+    app.dependency_overrides[get_db_session] = _override
+    try:
+        client = TestClient(app)
+        client.db_results = holder  # type: ignore[attr-defined]
+        yield client
+    finally:
+        app.dependency_overrides.pop(get_db_session, None)
+
+
+# ─── POST /subscriptions ──────────────────────────────────────────────────
+
+
+def test_create_subscription_basic(client_with_db):
+    """Happy path: POST returns 201 + SubscriptionRead with limits attached."""
+    cust_id = str(uuid4())
+    client_with_db.db_results["results"] = [_row(customer_id=cust_id, tier_code="basic")]
+    resp = client_with_db.post(
+        "/api/v1/subscriptions",
+        json={"customer_id": cust_id, "tier_code": "basic"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["customer_id"] == cust_id
+    assert body["tier_code"] == "basic"
+    assert body["status"] == "active"
+    assert body["limit_per_window"] == 60
+    assert body["window_size_s"] == 60
+
+
+def test_create_subscription_pro_attaches_higher_limit(client_with_db):
+    """Pro tier → limit_per_window = 300 in response."""
+    client_with_db.db_results["results"] = [_row(tier_code="pro")]
+    resp = client_with_db.post(
+        "/api/v1/subscriptions",
+        json={"customer_id": str(uuid4()), "tier_code": "pro"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["limit_per_window"] == 300
+
+
+def test_create_subscription_enterprise(client_with_db):
+    client_with_db.db_results["results"] = [_row(tier_code="enterprise")]
+    resp = client_with_db.post(
+        "/api/v1/subscriptions",
+        json={"customer_id": str(uuid4()), "tier_code": "enterprise"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["limit_per_window"] == 1000
+
+
+def test_create_subscription_rejects_unknown_tier(client_with_db):
+    """Unknown tier → 422 from Pydantic Literal validation (before DB)."""
+    resp = client_with_db.post(
+        "/api/v1/subscriptions",
+        json={"customer_id": str(uuid4()), "tier_code": "platinum"},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_subscription_conflict_on_duplicate_active(client_with_db):
+    """Partial unique index raises IntegrityError → 409 with friendly msg."""
+    client_with_db.db_results["results"] = [
+        IntegrityError("dup", {}, Exception("active subscription exists"))
+    ]
+    resp = client_with_db.post(
+        "/api/v1/subscriptions",
+        json={"customer_id": str(uuid4()), "tier_code": "basic"},
+    )
+    assert resp.status_code == 409
+    assert "active subscription" in resp.json()["detail"]
+
+
+# ─── GET /subscriptions/{id} ──────────────────────────────────────────────
+
+
+def test_get_subscription_returns_row_with_limits(client_with_db):
+    sub_id = uuid4()
+    client_with_db.db_results["results"] = [_row(sub_id=sub_id, tier_code="pro")]
+    resp = client_with_db.get(f"/api/v1/subscriptions/{sub_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == str(sub_id)
+    assert body["tier_code"] == "pro"
+    assert body["limit_per_window"] == 300
+
+
+def test_get_subscription_404_when_missing(client_with_db):
+    client_with_db.db_results["results"] = [None]
+    resp = client_with_db.get(f"/api/v1/subscriptions/{uuid4()}")
+    assert resp.status_code == 404
+
+
+# ─── PATCH /subscriptions/{id} ────────────────────────────────────────────
+
+
+def test_patch_subscription_tier_upgrade(client_with_db):
+    """Update tier: returns row with NEW tier's limit_per_window."""
+    sub_id = uuid4()
+    client_with_db.db_results["results"] = [_row(sub_id=sub_id, tier_code="pro")]
+    resp = client_with_db.patch(
+        f"/api/v1/subscriptions/{sub_id}",
+        json={"tier_code": "pro"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["tier_code"] == "pro"
+    assert resp.json()["limit_per_window"] == 300
+
+
+def test_patch_subscription_rejects_unknown_tier(client_with_db):
+    resp = client_with_db.patch(
+        f"/api/v1/subscriptions/{uuid4()}",
+        json={"tier_code": "platinum"},
+    )
+    assert resp.status_code == 422
+
+
+def test_patch_subscription_404_when_missing(client_with_db):
+    """UPDATE ... WHERE id=? returns no row, second check also returns
+    no row → 404."""
+    client_with_db.db_results["results"] = [None, None]
+    resp = client_with_db.patch(
+        f"/api/v1/subscriptions/{uuid4()}",
+        json={"tier_code": "basic"},
+    )
+    assert resp.status_code == 404
+
+
+def test_patch_subscription_409_when_canceled(client_with_db):
+    """UPDATE filter requires status='active' → no row updated; second
+    check finds the row in 'canceled' status → 409 with explanation."""
+    client_with_db.db_results["results"] = [
+        None,
+        SimpleNamespace(status="canceled"),
+    ]
+    resp = client_with_db.patch(
+        f"/api/v1/subscriptions/{uuid4()}",
+        json={"tier_code": "pro"},
+    )
+    assert resp.status_code == 409
+    assert "canceled" in resp.json()["detail"]
+
+
+# ─── DELETE /subscriptions/{id} ───────────────────────────────────────────
+
+
+def test_delete_subscription_soft_cancels(client_with_db):
+    """DELETE returns the canceled row with status='canceled' + canceled_at set."""
+    sub_id = uuid4()
+    canceled_at = datetime.now(UTC)
+    client_with_db.db_results["results"] = [
+        _row(sub_id=sub_id, sub_status="canceled", canceled_at=canceled_at)
+    ]
+    resp = client_with_db.delete(f"/api/v1/subscriptions/{sub_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "canceled"
+    assert body["canceled_at"] is not None
+
+
+def test_delete_subscription_404_when_missing(client_with_db):
+    client_with_db.db_results["results"] = [None]
+    resp = client_with_db.delete(f"/api/v1/subscriptions/{uuid4()}")
+    assert resp.status_code == 404
+
+
+def test_delete_subscription_idempotent_on_already_canceled(client_with_db):
+    """A second DELETE on an already-canceled row returns 200 with the
+    same row (COALESCE preserves the original canceled_at)."""
+    sub_id = uuid4()
+    original_canceled_at = datetime.now(UTC)
+    client_with_db.db_results["results"] = [
+        _row(sub_id=sub_id, sub_status="canceled", canceled_at=original_canceled_at)
+    ]
+    resp = client_with_db.delete(f"/api/v1/subscriptions/{sub_id}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "canceled"

--- a/tests/dispatcher/test_app.py
+++ b/tests/dispatcher/test_app.py
@@ -1,0 +1,217 @@
+"""KEI-179 — tests for src/dispatcher/app.
+
+The rate limiter + LLM router are mocked at the function-import boundary
+so /dispatch can be exercised end-to-end without live Valkey or LiteLLM.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.dispatcher import app as dispatcher_app
+from src.dispatcher.app import app
+from src.dispatcher.llm_router import LiteLLMRateLimitExhaustedError, LiteLLMRouterError
+from src.dispatcher.rate_limiter import RateLimitDecision, RateLimitExceededError
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _decision(allowed: bool = True, current: int = 1, limit: int = 60, retry_after: int = 60):
+    return RateLimitDecision(
+        allowed=allowed,
+        current=current,
+        limit=limit,
+        window_start_unix=1715904000,
+        window_size_s=60,
+        retry_after_s=retry_after,
+    )
+
+
+def _llm_response(text: str = "hello"):
+    return {
+        "model": "claude-sonnet-4-6",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        "response_cost": 0.0001,
+        "choices": [{"message": {"role": "assistant", "content": text}}],
+    }
+
+
+# ─── /health ──────────────────────────────────────────────────────────────
+
+
+def test_health_returns_200(client):
+    """Liveness probe is no-auth, no-DB — always 200 if process is alive."""
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["service"] == "dispatcher"
+
+
+def test_health_does_not_call_rate_limiter(client):
+    """Health probe MUST NOT touch the rate-limiter / Valkey — downstream
+    outages can't take the service out of LB rotation."""
+
+    async def boom(*_a, **_kw):
+        raise RuntimeError("rate limiter should not be called from /health")
+
+    with patch.object(dispatcher_app, "enforce_for_tenant", boom):
+        resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+# ─── /dispatch happy path ─────────────────────────────────────────────────
+
+
+def test_dispatch_happy_path(client):
+    """Rate limit OK + LLM 2xx → 200 with the model response embedded."""
+
+    fake_enforce = AsyncMock(return_value=_decision())
+
+    def fake_forward(*, body, customer_id, task_id, cost_sink=None, **_kw):
+        if cost_sink:
+            from src.dispatcher.llm_router import CostEvent
+
+            cost_sink(
+                CostEvent(
+                    customer_id=customer_id,
+                    task_id=task_id,
+                    model="claude-sonnet-4-6",
+                    input_tokens=10,
+                    output_tokens=5,
+                    cost_aud=0.0001,
+                    retry_count=0,
+                    duration_ms=42,
+                    success=True,
+                )
+            )
+        return _llm_response("hi from dispatcher")
+
+    with (
+        patch.object(dispatcher_app, "enforce_for_tenant", fake_enforce),
+        patch.object(dispatcher_app, "forward", fake_forward),
+    ):
+        resp = client.post(
+            "/dispatch",
+            json={
+                "customer_id": "cust-1",
+                "task_id": "KEI-179",
+                "body": {"model": "claude-sonnet-4-6", "messages": []},
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["customer_id"] == "cust-1"
+    assert body["task_id"] == "KEI-179"
+    assert body["rate_limit_decision"]["limit"] == 60
+    assert body["rate_limit_decision"]["current"] == 1
+    assert body["response"]["choices"][0]["message"]["content"] == "hi from dispatcher"
+
+
+# ─── /dispatch rate-limit branches ────────────────────────────────────────
+
+
+def test_dispatch_returns_429_when_tenant_rate_limited(client):
+    """RateLimitExceededError from enforce_for_tenant → 429 with Retry-After."""
+
+    fake_enforce = AsyncMock(
+        side_effect=RateLimitExceededError(
+            tenant_id="cust-1", limit=60, window_size_s=60, current=61
+        )
+    )
+
+    with patch.object(dispatcher_app, "enforce_for_tenant", fake_enforce):
+        resp = client.post(
+            "/dispatch",
+            json={"customer_id": "cust-1", "task_id": "t-1", "body": {}},
+        )
+    assert resp.status_code == 429
+    assert resp.headers.get("retry-after") == "60"
+    assert "rate limit exceeded" in resp.json()["detail"]
+
+
+def test_dispatch_does_not_call_llm_when_rate_limited(client):
+    """If rate-limit refuses, the LLM forward MUST NOT run (would cost $)."""
+
+    fake_enforce = AsyncMock(
+        side_effect=RateLimitExceededError(
+            tenant_id="cust-1", limit=60, window_size_s=60, current=61
+        )
+    )
+
+    called = {"forward": False}
+
+    def boom_forward(**_kw):
+        called["forward"] = True
+        return _llm_response()
+
+    with (
+        patch.object(dispatcher_app, "enforce_for_tenant", fake_enforce),
+        patch.object(dispatcher_app, "forward", boom_forward),
+    ):
+        client.post("/dispatch", json={"customer_id": "c", "task_id": "t", "body": {}})
+    assert called["forward"] is False
+
+
+# ─── /dispatch upstream branches ──────────────────────────────────────────
+
+
+def test_dispatch_returns_429_on_upstream_litellm_rate_exhaust(client):
+    """LiteLLMRateLimitExhaustedError → 429 with longer Retry-After (60s)
+    so customer doesn't immediately retry into the same upstream issue."""
+
+    fake_enforce = AsyncMock(return_value=_decision())
+
+    def upstream_429(**_kw):
+        raise LiteLLMRateLimitExhaustedError("litellm 429 after 3 retries")
+
+    with (
+        patch.object(dispatcher_app, "enforce_for_tenant", fake_enforce),
+        patch.object(dispatcher_app, "forward", upstream_429),
+    ):
+        resp = client.post("/dispatch", json={"customer_id": "c", "task_id": "t", "body": {}})
+    assert resp.status_code == 429
+    assert resp.headers.get("retry-after") == "60"
+
+
+def test_dispatch_returns_502_on_litellm_router_error(client):
+    """Generic LiteLLMRouterError (5xx upstream, transport failure) → 502."""
+
+    fake_enforce = AsyncMock(return_value=_decision())
+
+    def upstream_500(**_kw):
+        raise LiteLLMRouterError("litellm status 500: upstream outage")
+
+    with (
+        patch.object(dispatcher_app, "enforce_for_tenant", fake_enforce),
+        patch.object(dispatcher_app, "forward", upstream_500),
+    ):
+        resp = client.post("/dispatch", json={"customer_id": "c", "task_id": "t", "body": {}})
+    assert resp.status_code == 502
+    assert "litellm status 500" in resp.json()["detail"]
+
+
+# ─── /dispatch input validation ───────────────────────────────────────────
+
+
+def test_dispatch_rejects_empty_customer_id(client):
+    """Pydantic min_length=1 enforces non-empty tenant — caller bug, 422."""
+    resp = client.post("/dispatch", json={"customer_id": "", "task_id": "t", "body": {}})
+    assert resp.status_code == 422
+
+
+def test_dispatch_rejects_empty_task_id(client):
+    resp = client.post("/dispatch", json={"customer_id": "c", "task_id": "", "body": {}})
+    assert resp.status_code == 422
+
+
+def test_dispatch_rejects_missing_body(client):
+    """body is required — Pydantic 422 before any handler logic runs."""
+    resp = client.post("/dispatch", json={"customer_id": "c", "task_id": "t"})
+    assert resp.status_code == 422

--- a/tests/dispatcher/test_container_lifecycle.py
+++ b/tests/dispatcher/test_container_lifecycle.py
@@ -1,0 +1,267 @@
+"""KEI-115A — tests for src/dispatcher/container_lifecycle.
+
+All docker CLI calls are mocked at the subprocess.run boundary; no live
+docker daemon required for CI. Health probes are stubbed at the
+_probe_health helper boundary so tests don't open real sockets.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from src.dispatcher.container_lifecycle import (
+    ContainerHandle,
+    ContainerStartupError,
+    DockerUnavailableError,
+    kill_and_remove,
+    spawn_container,
+    wait_healthy,
+)
+
+
+def _docker_ok(stdout: str = "abc123\n", stderr: str = "", returncode: int = 0):
+    """Build a fake subprocess.run return value."""
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def _handle(**overrides) -> ContainerHandle:
+    defaults = {"id": "abc123def456", "name": "task-1", "image": "img:latest", "port": 8080}
+    defaults.update(overrides)
+    return ContainerHandle(**defaults)
+
+
+# ─── spawn_container ───────────────────────────────────────────────────────
+
+
+def test_spawn_container_runs_docker_with_expected_args(monkeypatch):
+    """Verify the docker CLI invocation shape: `docker run -d --name <n>
+    -p <port>:<port> <image>`."""
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return _docker_ok(stdout="abc123def456\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    h = spawn_container(image="python:3.12-slim", name="task-1", port=8080)
+    assert h.id == "abc123def456"
+    assert h.name == "task-1"
+    assert h.image == "python:3.12-slim"
+    assert h.port == 8080
+    assert h.health_path == "/healthz"
+    cmd = captured["cmd"]
+    assert cmd[:6] == ["docker", "run", "-d", "--name", "task-1", "-p"]
+    assert "8080:8080" in cmd
+    assert cmd[-1] == "python:3.12-slim"
+
+
+def test_spawn_container_passes_env_vars(monkeypatch):
+    """Each env entry becomes a separate `-e K=V` pair in argv order."""
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return _docker_ok()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    spawn_container(image="img", name="n", port=1, env={"FOO": "bar", "BAZ": "qux"})
+    cmd = captured["cmd"]
+    # -e flag appears for each entry
+    e_indices = [i for i, tok in enumerate(cmd) if tok == "-e"]
+    assert len(e_indices) == 2
+    e_values = {cmd[i + 1] for i in e_indices}
+    assert e_values == {"FOO=bar", "BAZ=qux"}
+
+
+def test_spawn_container_appends_extra_args(monkeypatch):
+    """extra_args are inserted before the image name (after env)."""
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return _docker_ok()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    spawn_container(
+        image="img",
+        name="n",
+        port=1,
+        extra_args=["--read-only", "--memory=512m"],
+    )
+    cmd = captured["cmd"]
+    assert "--read-only" in cmd
+    assert "--memory=512m" in cmd
+    # image is the last token
+    assert cmd[-1] == "img"
+    # extras appear before the image
+    assert cmd.index("--read-only") < cmd.index("img")
+
+
+def test_spawn_container_raises_clean_error_when_docker_missing(monkeypatch):
+    """FileNotFoundError from subprocess maps to DockerUnavailableError."""
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory: 'docker'")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(DockerUnavailableError, match="docker"):
+        spawn_container(image="img", name="n", port=1)
+
+
+def test_spawn_container_raises_on_nonzero_rc(monkeypatch):
+    """Non-zero docker run exit (e.g. port-in-use rc=125) raises
+    ContainerStartupError with the stderr preserved."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **kw: _docker_ok(stdout="", stderr="port already in use", returncode=125),
+    )
+    with pytest.raises(ContainerStartupError, match="rc=125") as exc_info:
+        spawn_container(image="img", name="n", port=1)
+    assert "port already in use" in str(exc_info.value)
+
+
+def test_spawn_container_raises_on_empty_stdout(monkeypatch):
+    """rc=0 but no container id is still a failure — defensive."""
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _docker_ok(stdout="   \n"))
+    with pytest.raises(ContainerStartupError, match="empty container id"):
+        spawn_container(image="img", name="n", port=1)
+
+
+# ─── wait_healthy ──────────────────────────────────────────────────────────
+
+
+def test_wait_healthy_returns_true_on_first_probe(monkeypatch):
+    """Healthy on the first probe — no retries, no kill."""
+    monkeypatch.setattr(
+        "src.dispatcher.container_lifecycle._probe_health",
+        lambda host, port, path: True,
+    )
+    # If wait_healthy called docker, the test would fail because no fake_run
+    # is wired here — confirms healthy path doesn't touch docker.
+    assert wait_healthy(_handle(), timeout_s=5.0, interval_s=0.01) is True
+
+
+def test_wait_healthy_returns_true_after_retries(monkeypatch):
+    """Probe returns False twice then True — wait_healthy retries through
+    the failures and reports healthy on the third probe."""
+    counter = {"n": 0}
+
+    def probe(host, port, path):
+        counter["n"] += 1
+        return counter["n"] >= 3
+
+    monkeypatch.setattr("src.dispatcher.container_lifecycle._probe_health", probe)
+    assert wait_healthy(_handle(), timeout_s=5.0, interval_s=0.01) is True
+    assert counter["n"] >= 3
+
+
+def test_wait_healthy_aborts_and_kills_on_timeout(monkeypatch):
+    """Health probe never succeeds — wait_healthy must:
+    1. raise ContainerStartupError
+    2. call `docker kill` + `docker rm -f` BEFORE raising."""
+    kill_cmds: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "src.dispatcher.container_lifecycle._probe_health",
+        lambda *args, **kwargs: False,
+    )
+
+    def fake_run(cmd, **kwargs):
+        kill_cmds.append(list(cmd))
+        return _docker_ok()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(ContainerStartupError, match="failed health check"):
+        wait_healthy(_handle(), timeout_s=0.05, interval_s=0.01)
+    ops = [cmd[1] for cmd in kill_cmds]
+    assert "kill" in ops
+    assert "rm" in ops
+    # rm runs after kill
+    assert ops.index("kill") < ops.index("rm")
+
+
+def test_wait_healthy_respects_custom_host(monkeypatch):
+    """Non-default host is passed through to _probe_health."""
+    captured: dict = {}
+
+    def probe(host, port, path):
+        captured["host"] = host
+        captured["port"] = port
+        captured["path"] = path
+        return True
+
+    monkeypatch.setattr("src.dispatcher.container_lifecycle._probe_health", probe)
+    assert wait_healthy(_handle(port=9000), timeout_s=1.0, interval_s=0.01, host="container-host")
+    assert captured == {"host": "container-host", "port": 9000, "path": "/healthz"}
+
+
+def test_wait_healthy_uses_handle_health_path(monkeypatch):
+    """Custom health_path on the handle is honoured by the probe."""
+    captured: dict = {}
+
+    def probe(host, port, path):
+        captured["path"] = path
+        return True
+
+    monkeypatch.setattr("src.dispatcher.container_lifecycle._probe_health", probe)
+    wait_healthy(_handle(), timeout_s=1.0, interval_s=0.01)
+    # default
+    assert captured["path"] == "/healthz"
+
+    captured.clear()
+    custom = ContainerHandle(id="x", name="y", image="z", port=1, health_path="/api/health")
+    wait_healthy(custom, timeout_s=1.0, interval_s=0.01)
+    assert captured["path"] == "/api/health"
+
+
+# ─── kill_and_remove ───────────────────────────────────────────────────────
+
+
+def test_kill_and_remove_runs_kill_then_rm(monkeypatch):
+    """Two docker invocations in order: kill then rm -f."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _docker_ok()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    kill_and_remove(_handle())
+    assert len(calls) == 2
+    assert calls[0][1] == "kill"
+    assert calls[1][1:3] == ["rm", "-f"]
+    # both target the container id
+    assert calls[0][-1] == "abc123def456"
+    assert calls[1][-1] == "abc123def456"
+
+
+def test_kill_and_remove_logs_but_does_not_raise_on_docker_error(monkeypatch, caplog):
+    """Stale containers, already-removed containers etc. produce non-zero
+    rcs. kill_and_remove must NOT raise — it's an abort path that runs
+    inside wait_healthy's exception branch and must not mask the
+    original ContainerStartupError."""
+
+    def fake_run(cmd, **kwargs):
+        return _docker_ok(returncode=1, stderr=f"Error: No such container: {cmd[-1]}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with caplog.at_level("WARNING"):
+        kill_and_remove(_handle())
+    assert any("No such container" in r.message for r in caplog.records)
+
+
+def test_kill_and_remove_propagates_docker_unavailable(monkeypatch):
+    """If docker disappears between spawn and teardown (impossible but
+    defensive), DockerUnavailableError must surface — not be swallowed —
+    so the operator sees the environment is broken."""
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("docker")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(DockerUnavailableError):
+        kill_and_remove(_handle())

--- a/tests/dispatcher/test_llm_router.py
+++ b/tests/dispatcher/test_llm_router.py
@@ -1,0 +1,213 @@
+"""KEI-115E — tests for src/dispatcher/llm_router.
+
+All HTTP is mocked at the _post_json helper boundary; no live LiteLLM
+required. Backoff sleeps are also patched to zero so the test suite
+doesn't actually wait through the retry ladder.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.dispatcher import llm_router
+from src.dispatcher.llm_router import (
+    CostEvent,
+    LiteLLMRateLimitExhaustedError,
+    LiteLLMRouterError,
+    forward,
+)
+
+
+def _ok_payload(model: str = "claude-sonnet-4-6", in_tok: int = 12, out_tok: int = 34):
+    return {
+        "model": model,
+        "usage": {"prompt_tokens": in_tok, "completion_tokens": out_tok},
+        "response_cost": 0.000123,
+        "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch):
+    """Backoff sleeps are tested via the retry_count assertion, not by
+    actually waiting — patch time.sleep to a no-op so the suite is fast."""
+    monkeypatch.setattr(llm_router.time, "sleep", lambda _s: None)
+
+
+# ─── happy path ────────────────────────────────────────────────────────────
+
+
+def test_forward_returns_response_body_on_first_2xx(monkeypatch):
+    """A clean 200 path returns the parsed body and never retries."""
+    calls = {"n": 0}
+
+    def fake_post(url, body, timeout_s):
+        calls["n"] += 1
+        return 200, _ok_payload()
+
+    monkeypatch.setattr(llm_router, "_post_json", fake_post)
+    out = forward(body={"model": "x"}, customer_id="c1", task_id="KEI-166")
+    assert out["choices"][0]["message"]["content"] == "ok"
+    assert calls["n"] == 1
+
+
+def test_forward_invokes_cost_sink_with_event_shape(monkeypatch):
+    """cost_sink receives a CostEvent with every documented field set."""
+    monkeypatch.setattr(
+        llm_router,
+        "_post_json",
+        lambda url, body, timeout_s: (200, _ok_payload(in_tok=10, out_tok=20)),
+    )
+    events: list[CostEvent] = []
+    forward(
+        body={},
+        customer_id="cust-1",
+        task_id="KEI-166",
+        cost_sink=events.append,
+    )
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.customer_id == "cust-1"
+    assert ev.task_id == "KEI-166"
+    assert ev.model == "claude-sonnet-4-6"
+    assert ev.input_tokens == 10
+    assert ev.output_tokens == 20
+    assert ev.cost_aud == pytest.approx(0.000123)
+    assert ev.retry_count == 0
+    assert ev.success is True
+    assert ev.error_message is None
+    assert ev.duration_ms >= 0
+
+
+def test_forward_no_sink_does_not_raise(monkeypatch):
+    """cost_sink=None is a valid configuration — router must not require it."""
+    monkeypatch.setattr(llm_router, "_post_json", lambda url, body, timeout_s: (200, _ok_payload()))
+    # Should not raise:
+    forward(body={}, customer_id="c", task_id="t", cost_sink=None)
+
+
+# ─── 429 retry ─────────────────────────────────────────────────────────────
+
+
+def test_forward_retries_on_429_then_succeeds(monkeypatch):
+    """429 twice then 200 — router transparently retries and reports
+    retry_count=2 on the success cost event."""
+    responses = iter(
+        [(429, {"error": "rate_limited"}), (429, {"error": "rate_limited"}), (200, _ok_payload())]
+    )
+
+    def fake_post(url, body, timeout_s):
+        return next(responses)
+
+    monkeypatch.setattr(llm_router, "_post_json", fake_post)
+    events: list[CostEvent] = []
+    out = forward(
+        body={},
+        customer_id="c",
+        task_id="t",
+        max_retries=3,
+        cost_sink=events.append,
+    )
+    assert out["choices"][0]["message"]["content"] == "ok"
+    assert events[0].retry_count == 2
+    assert events[0].success is True
+
+
+def test_forward_raises_rate_limit_exhausted_after_max_retries(monkeypatch):
+    """Persistent 429 — raises LiteLLMRateLimitExhaustedError and emits a
+    failure cost event with retry_count=max_retries."""
+    monkeypatch.setattr(
+        llm_router,
+        "_post_json",
+        lambda url, body, timeout_s: (429, {"error": "tier_limit"}),
+    )
+    events: list[CostEvent] = []
+    with pytest.raises(LiteLLMRateLimitExhaustedError, match="after 3 retries"):
+        forward(
+            body={},
+            customer_id="c",
+            task_id="t",
+            max_retries=3,
+            cost_sink=events.append,
+        )
+    assert len(events) == 1
+    assert events[0].success is False
+    assert events[0].retry_count == 3
+    assert events[0].error_message is not None
+    assert "tier_limit" in events[0].error_message
+
+
+# ─── non-2xx non-429 ───────────────────────────────────────────────────────
+
+
+def test_forward_raises_router_error_on_500(monkeypatch):
+    """5xx is non-retryable here (LiteLLM owns upstream retries); router
+    fails the request immediately and emits a failure cost event."""
+    monkeypatch.setattr(
+        llm_router,
+        "_post_json",
+        lambda url, body, timeout_s: (500, {"error": "upstream"}),
+    )
+    events: list[CostEvent] = []
+    with pytest.raises(LiteLLMRouterError, match="status 500"):
+        forward(body={}, customer_id="c", task_id="t", cost_sink=events.append)
+    assert len(events) == 1
+    assert events[0].success is False
+    assert events[0].retry_count == 0
+
+
+def test_forward_propagates_transport_error_from_helper(monkeypatch):
+    """_post_json raising LiteLLMRouterError (e.g. DNS / refused) surfaces
+    to the caller; no cost event is emitted because we never got a response."""
+
+    def boom(url, body, timeout_s):
+        raise LiteLLMRouterError("transport: connection refused")
+
+    monkeypatch.setattr(llm_router, "_post_json", boom)
+    events: list[CostEvent] = []
+    with pytest.raises(LiteLLMRouterError, match="connection refused"):
+        forward(body={}, customer_id="c", task_id="t", cost_sink=events.append)
+    assert events == []
+
+
+# ─── cost-sink isolation ───────────────────────────────────────────────────
+
+
+def test_cost_sink_exception_does_not_break_forwarding(monkeypatch, caplog):
+    """A buggy cost_sink must not prevent the caller from receiving the
+    successful response — ledger writes are a side-channel, not load-bearing."""
+    monkeypatch.setattr(llm_router, "_post_json", lambda url, body, timeout_s: (200, _ok_payload()))
+
+    def explode(_event):
+        raise RuntimeError("ledger DB down")
+
+    with caplog.at_level("WARNING"):
+        out = forward(body={}, customer_id="c", task_id="t", cost_sink=explode)
+    assert out["choices"][0]["message"]["content"] == "ok"
+    assert any("ledger DB down" in r.message for r in caplog.records)
+
+
+# ─── usage extraction edge cases ───────────────────────────────────────────
+
+
+def test_forward_handles_missing_usage_block(monkeypatch):
+    """A response without ``usage`` (or with partial fields) still produces
+    a CostEvent — tokens default to 0, cost defaults to 0.0."""
+    payload = {"model": "x", "choices": [{"message": {"role": "assistant", "content": "hi"}}]}
+    monkeypatch.setattr(llm_router, "_post_json", lambda url, body, timeout_s: (200, payload))
+    events: list[CostEvent] = []
+    forward(body={}, customer_id="c", task_id="t", cost_sink=events.append)
+    assert events[0].input_tokens == 0
+    assert events[0].output_tokens == 0
+    assert events[0].cost_aud == pytest.approx(0.0)
+    assert events[0].model == "x"
+
+
+def test_forward_handles_missing_model(monkeypatch):
+    """A response without ``model`` — CostEvent.model falls back to 'unknown'
+    so the ledger writer never sees None in a NOT NULL column."""
+    payload = {"usage": {"prompt_tokens": 1, "completion_tokens": 2}}
+    monkeypatch.setattr(llm_router, "_post_json", lambda url, body, timeout_s: (200, payload))
+    events: list[CostEvent] = []
+    forward(body={}, customer_id="c", task_id="t", cost_sink=events.append)
+    assert events[0].model == "unknown"


### PR DESCRIPTION
## Summary

Closes KEI-151 (KEI-112B, P1). REST CRUD for customer subscriptions, paired with KEI-172's tier-limit config. Each response embeds the tier's resolved \`(limit_per_window, window_size_s)\` so the customer's frontend doesn't need a second round-trip.

**Stacked** — base = \`atlas/kei172-tier-limits\` (PR #966). Merge order: #961 → #962 → #966 → this.

## Acceptance (Linear KEI-151)

| Verb | Path | Status |
|---|---|---|
| POST | /api/v1/subscriptions | 201 — INSERT + return SubscriptionRead with limits |
| GET | /api/v1/subscriptions/{id} | 200 / 404 |
| PATCH | /api/v1/subscriptions/{id} | 200 (active) / 409 (canceled) / 404 |
| DELETE | /api/v1/subscriptions/{id} | 200 — soft-cancel, idempotent |

- [x] POST creates — INSERT returns SubscriptionRead with tier-derived \`(limit_per_window, window_size_s)\` embedded
- [x] PATCH updates tier — UPDATE filtered by \`status='active'\`; canceled rows return 409 (\"subscription is canceled, not active — cannot update tier\")
- [x] DELETE cancels — soft-cancel pattern: \`status='canceled'\` + \`canceled_at=NOW()\`. Idempotent via \`COALESCE(canceled_at, NOW())\`.
- [x] Tier limits load from config — \`TIER_LIMITS\` from \`src.dispatcher.tier_limits\` (KEI-172). Single source of truth shared with the rate-limiter.

## Migration

\`supabase/migrations/20260517_kei151_customer_subscriptions.sql\` — applied to prod via Supabase MCP (\`apply_migration\` returned \`success=true\`). Schema:

\`\`\`sql
CREATE TABLE IF NOT EXISTS public.customer_subscriptions (
    id, customer_id, tier_code, paddle_subscription_id (nullable — KEI-150 wires),
    status (active|canceled|paused), created_at, updated_at, canceled_at,
    CHECK status IN (...), CHECK tier_code IN ('basic','pro','enterprise')
);
CREATE UNIQUE INDEX ... ON (customer_id) WHERE status='active';  -- one active per customer
CREATE INDEX ... ON (paddle_subscription_id) WHERE NOT NULL;     -- Paddle lookup
\`\`\`

Idempotent (\`CREATE ... IF NOT EXISTS\`). Re-running against prod is a no-op.

## Why DELETE is soft-cancel

Audit-trail preservation. The partial unique index \`WHERE status='active'\` allows a new active row alongside the canceled one — so re-subscribing after cancel just creates a fresh row, no data loss. Hard DELETE is not exposed.

## Test plan

- [x] \`pytest tests/api/routes/test_subscriptions.py\` — 14/14 passed (AsyncSession dependency overridden with fake recording executed SQL + canned row mocks; no live DB).
- [x] \`ruff check\` — All checks passed.
- [x] \`ruff format --check\` — All formatted.

Coverage:
- POST basic/pro/enterprise → 201 + correct \`limit_per_window\`
- POST unknown tier → 422 (Pydantic Literal validation, no DB call)
- POST duplicate active → 409 (IntegrityError mapping)
- GET happy + 404
- PATCH tier upgrade → 200 with new tier's limit
- PATCH unknown tier → 422
- PATCH missing id → 404; PATCH canceled row → 409 with status-aware message
- DELETE soft-cancel → status='canceled' + canceled_at set
- DELETE missing id → 404
- DELETE idempotent on already-canceled → 200 (same row preserved)

## Note on the other auto-dispatch (KEI-117)

KEI-117 (Part 17.7 rate-limiting parent) was the other auto-claim. Already \`status=done\` in DB — auto-closed when children 117A/B/C landed via PRs #961/#962/#966. No-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)