### PR TITLE
[MAX] feat(kei181): tenant_id + RLS foundation (Phase 0.5 P0)

### DIFF
--- a/docs/architecture/tenant_isolation.md
+++ b/docs/architecture/tenant_isolation.md
@@ -1,0 +1,86 @@
+# Tenant Isolation — KEI-181
+
+**Phase:** 0.5 (Foundation)
+**Priority:** P0
+**Author:** MAX
+**Date:** 2026-05-17
+
+## Model
+
+Single Supabase project. All tenants share the same schema, same Fleet Supervisor, and same dashboard. Every work-table row carries a `tenant_id INTEGER NOT NULL DEFAULT 1` foreign-keyed to `public.tenants`.
+
+| tenant_id | Who |
+|---|---|
+| 1 | Dave / Agency_OS internal (default) |
+| 2+ | Paying customers |
+
+Row-Level Security on every work table scopes `SELECT / INSERT / UPDATE / DELETE` to the session's declared tenant.
+
+## Tables with tenant_id + RLS
+
+- `public.tasks`
+- `public.tool_call_log`
+- `public.retrieval_events`
+- `public.task_verifications`
+- `public.ceo_memory`
+- `public.agent_memories`
+- `public.completion_sync_queue`
+- `public.tenants` (new registry table — no RLS needed, append-only by admins)
+
+## RLS Policy Shape (3-clause)
+
+```sql
+USING (
+    current_setting('agency_os.tenant_id', true)::integer = tenant_id  -- normal caller
+    OR current_setting('role', true) = 'service_role'                   -- backend daemons / Fleet Supervisor
+    OR current_setting('agency_os.tenant_id', true) IS NULL             -- daemon hasn't set var yet
+)
+```
+
+Identical expression in `WITH CHECK`.
+
+**Clause 1** — anon/authenticated callers (customer dashboard via supabase-js anon key) must call `set_tenant_session()` before any query. The session var gates visibility.
+
+**Clause 2** — Supabase service-role key sets `role = service_role` automatically. Fleet Supervisor, `completion_sync_worker`, and every backend daemon use this path. No `set_tenant_session()` call needed.
+
+**Clause 3** — defensive: if a backend daemon connects with service-role and the var happens to be unset, it still passes. Belt-and-braces.
+
+## Helper API
+
+```python
+from src.integrations.supabase import set_tenant_session
+
+# Customer dashboard flow (must be called early in request lifecycle):
+await set_tenant_session(tenant_id=customer_id, connection=db_session)
+
+# Service-role daemons skip this entirely — RLS clause 2 passes automatically.
+```
+
+Source: `src/integrations/supabase.py:set_tenant_session`
+
+### Errors
+
+- `ValueError` — `tenant_id` not a positive integer.
+- `IntegrationError` — DB execute failure.
+
+## Migration
+
+`supabase/migrations/20260517_kei181_tenant_id_foundation.sql`
+
+Idempotent. Applied by Dave via Supabase MCP `apply_migration` after PR merges.
+Steps: CREATE TABLE tenants → seed Dave row → ADD COLUMN on 7 tables → backfill → indexes → ENABLE RLS → DROP/CREATE policies → COMMENT.
+
+## Out of Scope (KEI-181)
+
+- Per-tenant Paddle billing (KEI-150 / Phase 2)
+- Per-tenant dashboard UI
+- Per-tenant queue scoping in `fleet_supervisor.py`
+- Customer signup flow
+
+## Cross-References
+
+- **KEI-180** — Strangler-fig architecture (single system, tenant isolation strategy decision)
+- **KEI-111** — `dispatcher_customers` table (per-tenant outreach config, builds on this foundation)
+- `supabase/migrations/20260517_kei181_tenant_id_foundation.sql` — full migration
+- `src/integrations/supabase.py` — `set_tenant_session` helper
+- `tests/integration/test_tenant_isolation.py` — two-session isolation proof

--- a/src/integrations/supabase.py
+++ b/src/integrations/supabase.py
@@ -327,9 +327,47 @@ async def cleanup() -> None:
 # [x] All functions have type hints
 # [x] All functions have docstrings
 
-# ============================================
+# ============================================================
+# KEI-181: Tenant Session Helper
+# ============================================================
+
+
+async def set_tenant_session(tenant_id: int, *, connection: AsyncSession | None = None) -> None:
+    """Set the agency_os.tenant_id session variable for RLS enforcement.
+
+    Must be called at the start of any anon/authenticated session before
+    reading or writing work tables that have RLS enabled.
+
+    The service-role key bypasses RLS automatically (no call needed).
+    Backend daemons that have not called this function also bypass RLS via
+    the ``IS NULL`` clause in every policy (defensive default).
+
+    Args:
+        tenant_id: The tenant to scope this session to.
+                   Dave = 1, customers = 2+.
+        connection: An open AsyncSession to execute on.
+                    If None, a fresh session is opened via get_db_session().
+
+    Raises:
+        ValueError: If tenant_id is not a positive integer.
+        IntegrationError: If the SET LOCAL statement fails.
+    """
+    if not isinstance(tenant_id, int) or tenant_id < 1:
+        raise ValueError(f"tenant_id must be a positive integer, got: {tenant_id!r}")
+
+    stmt = text(f"SET LOCAL agency_os.tenant_id = '{tenant_id}'")
+
+    if connection is not None:
+        await connection.execute(stmt)
+        return
+
+    async with get_db_session() as session:
+        await session.execute(stmt)
+
+
+# ============================================================
 # Backward Compatibility Aliases
-# ============================================
+# ============================================================
 # Used by src/config/database.py and other modules
 get_async_engine = get_engine
 AsyncSessionLocal = get_session_factory

--- a/supabase/migrations/20260517_kei181_tenant_id_foundation.sql
+++ b/supabase/migrations/20260517_kei181_tenant_id_foundation.sql
@@ -1,0 +1,222 @@
+-- KEI-181: Tenant ID + RLS Foundation (Phase 0.5 P0)
+-- Author: MAX
+-- Idempotent: safe to re-run.
+-- Tables touched: public.tenants (new), public.tasks, public.tool_call_log,
+--   public.retrieval_events, public.task_verifications, public.ceo_memory,
+--   public.agent_memories, public.completion_sync_queue
+
+-- ============================================================
+-- 1. tenants table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.tenants (
+    id          integer     PRIMARY KEY,
+    name        text        NOT NULL,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    deleted_at  timestamptz
+);
+
+COMMENT ON TABLE public.tenants IS 'KEI-181: one row per tenant. Dave=1, customers=2+.';
+
+-- Seed Dave's tenant row
+INSERT INTO public.tenants (id, name)
+VALUES (1, 'Dave / Agency_OS internal')
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================
+-- 2. Add tenant_id column to each work table (idempotent)
+-- ============================================================
+
+ALTER TABLE public.tasks
+    ADD COLUMN IF NOT EXISTS tenant_id integer NOT NULL DEFAULT 1
+    REFERENCES public.tenants(id);
+
+ALTER TABLE public.tool_call_log
+    ADD COLUMN IF NOT EXISTS tenant_id integer NOT NULL DEFAULT 1
+    REFERENCES public.tenants(id);
+
+ALTER TABLE public.retrieval_events
+    ADD COLUMN IF NOT EXISTS tenant_id integer NOT NULL DEFAULT 1
+    REFERENCES public.tenants(id);
+
+ALTER TABLE public.task_verifications
+    ADD COLUMN IF NOT EXISTS tenant_id integer NOT NULL DEFAULT 1
+    REFERENCES public.tenants(id);
+
+ALTER TABLE public.ceo_memory
+    ADD COLUMN IF NOT EXISTS tenant_id integer NOT NULL DEFAULT 1
+    REFERENCES public.tenants(id);
+
+ALTER TABLE public.agent_memories
+    ADD COLUMN IF NOT EXISTS tenant_id integer NOT NULL DEFAULT 1
+    REFERENCES public.tenants(id);
+
+ALTER TABLE public.completion_sync_queue
+    ADD COLUMN IF NOT EXISTS tenant_id integer NOT NULL DEFAULT 1
+    REFERENCES public.tenants(id);
+
+-- ============================================================
+-- 3. Backfill (belt + braces — DEFAULT 1 already covers inserts)
+-- ============================================================
+
+UPDATE public.tasks             SET tenant_id = 1 WHERE tenant_id IS NULL;
+UPDATE public.tool_call_log     SET tenant_id = 1 WHERE tenant_id IS NULL;
+UPDATE public.retrieval_events  SET tenant_id = 1 WHERE tenant_id IS NULL;
+UPDATE public.task_verifications SET tenant_id = 1 WHERE tenant_id IS NULL;
+UPDATE public.ceo_memory        SET tenant_id = 1 WHERE tenant_id IS NULL;
+UPDATE public.agent_memories    SET tenant_id = 1 WHERE tenant_id IS NULL;
+UPDATE public.completion_sync_queue SET tenant_id = 1 WHERE tenant_id IS NULL;
+
+-- ============================================================
+-- 4. Indexes
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS tasks_tenant_id_idx
+    ON public.tasks (tenant_id);
+
+CREATE INDEX IF NOT EXISTS tool_call_log_tenant_id_idx
+    ON public.tool_call_log (tenant_id);
+
+CREATE INDEX IF NOT EXISTS retrieval_events_tenant_id_idx
+    ON public.retrieval_events (tenant_id);
+
+CREATE INDEX IF NOT EXISTS task_verifications_tenant_id_idx
+    ON public.task_verifications (tenant_id);
+
+CREATE INDEX IF NOT EXISTS ceo_memory_tenant_id_idx
+    ON public.ceo_memory (tenant_id);
+
+CREATE INDEX IF NOT EXISTS agent_memories_tenant_id_idx
+    ON public.agent_memories (tenant_id);
+
+CREATE INDEX IF NOT EXISTS completion_sync_queue_tenant_id_idx
+    ON public.completion_sync_queue (tenant_id);
+
+-- ============================================================
+-- 5. Enable RLS
+-- ============================================================
+
+ALTER TABLE public.tasks               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tool_call_log       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.retrieval_events    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.task_verifications  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ceo_memory          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.agent_memories      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.completion_sync_queue ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 6. RLS Policies  (DROP IF EXISTS first for idempotency)
+-- ============================================================
+-- 3-clause USING/WITH CHECK:
+--   clause 1: session var matches row's tenant_id  (normal anon/authenticated callers)
+--   clause 2: current_setting('role') = 'service_role'  (Supabase service-role key)
+--   clause 3: agency_os.tenant_id IS NULL  (backend daemons that haven't set the var)
+
+DROP POLICY IF EXISTS tenant_isolation_tasks ON public.tasks;
+CREATE POLICY tenant_isolation_tasks ON public.tasks
+    FOR ALL
+    USING (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    )
+    WITH CHECK (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    );
+
+DROP POLICY IF EXISTS tenant_isolation_tool_call_log ON public.tool_call_log;
+CREATE POLICY tenant_isolation_tool_call_log ON public.tool_call_log
+    FOR ALL
+    USING (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    )
+    WITH CHECK (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    );
+
+DROP POLICY IF EXISTS tenant_isolation_retrieval_events ON public.retrieval_events;
+CREATE POLICY tenant_isolation_retrieval_events ON public.retrieval_events
+    FOR ALL
+    USING (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    )
+    WITH CHECK (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    );
+
+DROP POLICY IF EXISTS tenant_isolation_task_verifications ON public.task_verifications;
+CREATE POLICY tenant_isolation_task_verifications ON public.task_verifications
+    FOR ALL
+    USING (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    )
+    WITH CHECK (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    );
+
+DROP POLICY IF EXISTS tenant_isolation_ceo_memory ON public.ceo_memory;
+CREATE POLICY tenant_isolation_ceo_memory ON public.ceo_memory
+    FOR ALL
+    USING (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    )
+    WITH CHECK (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    );
+
+DROP POLICY IF EXISTS tenant_isolation_agent_memories ON public.agent_memories;
+CREATE POLICY tenant_isolation_agent_memories ON public.agent_memories
+    FOR ALL
+    USING (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    )
+    WITH CHECK (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    );
+
+DROP POLICY IF EXISTS tenant_isolation_completion_sync_queue ON public.completion_sync_queue;
+CREATE POLICY tenant_isolation_completion_sync_queue ON public.completion_sync_queue
+    FOR ALL
+    USING (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    )
+    WITH CHECK (
+        current_setting('agency_os.tenant_id', true)::integer = tenant_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.tenant_id', true) IS NULL
+    );
+
+-- ============================================================
+-- 7. Column comments
+-- ============================================================
+
+COMMENT ON COLUMN public.tasks.tenant_id             IS 'KEI-181: tenant isolation. FK to public.tenants(id). Dave=1, customers=2+.';
+COMMENT ON COLUMN public.tool_call_log.tenant_id     IS 'KEI-181: tenant isolation. FK to public.tenants(id). Dave=1, customers=2+.';
+COMMENT ON COLUMN public.retrieval_events.tenant_id  IS 'KEI-181: tenant isolation. FK to public.tenants(id). Dave=1, customers=2+.';
+COMMENT ON COLUMN public.task_verifications.tenant_id IS 'KEI-181: tenant isolation. FK to public.tenants(id). Dave=1, customers=2+.';
+COMMENT ON COLUMN public.ceo_memory.tenant_id        IS 'KEI-181: tenant isolation. FK to public.tenants(id). Dave=1, customers=2+.';
+COMMENT ON COLUMN public.agent_memories.tenant_id    IS 'KEI-181: tenant isolation. FK to public.tenants(id). Dave=1, customers=2+.';
+COMMENT ON COLUMN public.completion_sync_queue.tenant_id IS 'KEI-181: tenant isolation. FK to public.tenants(id). Dave=1, customers=2+.';

--- a/tests/integration/test_tenant_isolation.py
+++ b/tests/integration/test_tenant_isolation.py
@@ -1,0 +1,163 @@
+"""
+KEI-181 — Tenant Isolation Integration Test.
+
+Proves read-isolation between two tenants on public.tasks using real psycopg
+sessions against the live Supabase Postgres instance.
+
+Requires: DATABASE_URL env var pointing at the Supabase direct/pooler connection.
+Skipped automatically when DATABASE_URL is absent.
+
+Mark: pytest.mark.integration
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+# Prefer INTEGRATION_DATABASE_URL (not overridden by tests/conftest.py).
+# Fall back to DATABASE_URL if it looks like a real remote DSN (not localhost).
+_RAW = os.environ.get("INTEGRATION_DATABASE_URL") or os.environ.get("DATABASE_URL", "")
+
+# Normalise asyncpg DSN → psycopg3 compatible (remove +asyncpg if present)
+_PG_DSN = _RAW.replace("+asyncpg", "").replace("postgresql+psycopg2", "postgresql")
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def pg_dsn() -> str:
+    if not _PG_DSN or not _PG_DSN.startswith("postgresql"):
+        pytest.skip("No real DATABASE_URL — skipping tenant isolation test")
+    # Skip if this looks like the conftest.py localhost test placeholder
+    if "localhost" in _PG_DSN or "127.0.0.1" in _PG_DSN:
+        pytest.skip(
+            "DATABASE_URL points at localhost (conftest.py override) — "
+            "set INTEGRATION_DATABASE_URL to a real Supabase DSN to run"
+        )
+    return _PG_DSN
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TENANT_2_ID = 2
+_TENANT_2_NAME = "test-tenant-2-kei181"
+_TASK_T1 = f"TEST-T1-{uuid.uuid4().hex[:8]}"
+_TASK_T2 = f"TEST-T2-{uuid.uuid4().hex[:8]}"
+
+
+def _open_connection(dsn: str):
+    """Return a plain synchronous psycopg3 connection with autocommit=False."""
+    try:
+        import psycopg  # psycopg3
+    except ImportError:
+        pytest.skip("psycopg (v3) not installed — skipping tenant isolation test")
+    return psycopg.connect(dsn, autocommit=False)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def seed_and_cleanup(pg_dsn: str):
+    """Insert test tenants + tasks, yield, then delete on teardown."""
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+
+    # Insert tenant 2 (idempotent)
+    cur.execute(
+        "INSERT INTO public.tenants (id, name) VALUES (%s, %s) ON CONFLICT (id) DO NOTHING",
+        (_TENANT_2_ID, _TENANT_2_NAME),
+    )
+
+    # Insert one task per tenant
+    for task_id, tid, title in [
+        (_TASK_T1, 1, "dave-only-kei181"),
+        (_TASK_T2, _TENANT_2_ID, "customer-only-kei181"),
+    ]:
+        cur.execute(
+            """
+            INSERT INTO public.tasks (id, tenant_id, title, status)
+            VALUES (%s, %s, %s, 'pending')
+            ON CONFLICT (id) DO NOTHING
+            """,
+            (task_id, tid, title),
+        )
+
+    conn.commit()
+    conn.close()
+
+    yield
+
+    # Teardown
+    conn2 = _open_connection(pg_dsn)
+    cur2 = conn2.cursor()
+    cur2.execute("DELETE FROM public.tasks WHERE id IN (%s, %s)", (_TASK_T1, _TASK_T2))
+    cur2.execute("DELETE FROM public.tenants WHERE id = %s", (_TENANT_2_ID,))
+    conn2.commit()
+    conn2.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_tenant1_sees_only_own_row(pg_dsn: str) -> None:
+    """Session A (tenant_id=1) must see TEST-T1 but NOT TEST-T2."""
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+
+    cur.execute("SET LOCAL agency_os.tenant_id = '1'")
+    cur.execute(
+        "SELECT id FROM public.tasks WHERE id IN (%s, %s)",
+        (_TASK_T1, _TASK_T2),
+    )
+    visible_ids = {row[0] for row in cur.fetchall()}
+    conn.rollback()
+    conn.close()
+
+    assert _TASK_T1 in visible_ids, f"Tenant 1 should see {_TASK_T1}"
+    assert _TASK_T2 not in visible_ids, f"Tenant 1 must NOT see {_TASK_T2}"
+
+
+def test_tenant2_sees_only_own_row(pg_dsn: str) -> None:
+    """Session B (tenant_id=2) must see TEST-T2 but NOT TEST-T1."""
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+
+    cur.execute("SET LOCAL agency_os.tenant_id = '2'")
+    cur.execute(
+        "SELECT id FROM public.tasks WHERE id IN (%s, %s)",
+        (_TASK_T1, _TASK_T2),
+    )
+    visible_ids = {row[0] for row in cur.fetchall()}
+    conn.rollback()
+    conn.close()
+
+    assert _TASK_T2 in visible_ids, f"Tenant 2 should see {_TASK_T2}"
+    assert _TASK_T1 not in visible_ids, f"Tenant 2 must NOT see {_TASK_T1}"
+
+
+def test_service_role_sees_both_rows(pg_dsn: str) -> None:
+    """Session C (agency_os.tenant_id IS NULL) must see BOTH rows (daemon bypass)."""
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+
+    # Do NOT set agency_os.tenant_id — simulates backend daemon via service-role bypass
+    cur.execute(
+        "SELECT id FROM public.tasks WHERE id IN (%s, %s)",
+        (_TASK_T1, _TASK_T2),
+    )
+    visible_ids = {row[0] for row in cur.fetchall()}
+    conn.rollback()
+    conn.close()
+
+    assert _TASK_T1 in visible_ids, f"Service-role should see {_TASK_T1}"
+    assert _TASK_T2 in visible_ids, f"Service-role should see {_TASK_T2}"

--- a/tests/unit/test_set_tenant_session.py
+++ b/tests/unit/test_set_tenant_session.py
@@ -1,0 +1,105 @@
+"""
+KEI-181 — Unit tests for set_tenant_session() helper.
+
+No database required — uses MagicMock to intercept execute calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.integrations.supabase import set_tenant_session
+
+# ---------------------------------------------------------------------------
+# Happy-path: explicit connection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_tenant_session_calls_set_local_with_connection() -> None:
+    """set_tenant_session(2, connection=...) must issue SET LOCAL with tenant_id=2."""
+    mock_conn = AsyncMock()
+
+    await set_tenant_session(2, connection=mock_conn)
+
+    mock_conn.execute.assert_called_once()
+    executed_sql = str(mock_conn.execute.call_args[0][0])
+    assert "SET LOCAL agency_os.tenant_id = '2'" in executed_sql
+
+
+@pytest.mark.asyncio
+async def test_set_tenant_session_calls_set_local_tenant_1() -> None:
+    """set_tenant_session(1, connection=...) sets tenant_id=1 (Dave)."""
+    mock_conn = AsyncMock()
+
+    await set_tenant_session(1, connection=mock_conn)
+
+    executed_sql = str(mock_conn.execute.call_args[0][0])
+    assert "SET LOCAL agency_os.tenant_id = '1'" in executed_sql
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: connection=None (opens own session)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_tenant_session_no_connection_uses_get_db_session() -> None:
+    """connection=None path must open a session via get_db_session()."""
+    mock_session = AsyncMock()
+
+    # get_db_session is an asynccontextmanager — patch it to yield mock_session
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def fake_db_session():
+        yield mock_session
+
+    with patch("src.integrations.supabase.get_db_session", fake_db_session):
+        await set_tenant_session(3)
+
+    mock_session.execute.assert_called_once()
+    executed_sql = str(mock_session.execute.call_args[0][0])
+    assert "SET LOCAL agency_os.tenant_id = '3'" in executed_sql
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_tenant_session_rejects_zero() -> None:
+    """tenant_id=0 must raise ValueError."""
+    with pytest.raises(ValueError, match="tenant_id must be a positive integer"):
+        await set_tenant_session(0)
+
+
+@pytest.mark.asyncio
+async def test_set_tenant_session_rejects_negative() -> None:
+    """Negative tenant_id must raise ValueError."""
+    with pytest.raises(ValueError, match="tenant_id must be a positive integer"):
+        await set_tenant_session(-5)
+
+
+@pytest.mark.asyncio
+async def test_set_tenant_session_rejects_string() -> None:
+    """String tenant_id must raise ValueError."""
+    with pytest.raises(ValueError, match="tenant_id must be a positive integer"):
+        await set_tenant_session("1")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_set_tenant_session_rejects_none() -> None:
+    """None tenant_id must raise ValueError."""
+    with pytest.raises(ValueError, match="tenant_id must be a positive integer"):
+        await set_tenant_session(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_set_tenant_session_rejects_float() -> None:
+    """Float tenant_id must raise ValueError (not a plain int)."""
+    with pytest.raises(ValueError, match="tenant_id must be a positive integer"):
+        await set_tenant_session(1.5)  # type: ignore[arg-type]


### PR DESCRIPTION
## KEI-181 — Tenant Isolation Foundation

**Phase:** 0.5 P0  
**Linear:** KEI-181

### What ships

5 files:
1. `supabase/migrations/20260517_kei181_tenant_id_foundation.sql` — idempotent migration
2. `src/integrations/supabase.py` — `set_tenant_session(tenant_id, *, connection)` helper
3. `docs/architecture/tenant_isolation.md` — model doc
4. `tests/integration/test_tenant_isolation.py` — two-session isolation proof
5. `tests/unit/test_set_tenant_session.py` — helper unit tests (8 cases, no DB needed)

### Tables touched (7 work tables + 1 new)

| Table | Change |
|---|---|
| `public.tenants` | NEW — id PK, name, created_at, deleted_at. Dave seeded as id=1 |
| `public.tasks` | ADD COLUMN tenant_id + RLS |
| `public.tool_call_log` | ADD COLUMN tenant_id + RLS |
| `public.retrieval_events` | ADD COLUMN tenant_id + RLS |
| `public.task_verifications` | ADD COLUMN tenant_id + RLS |
| `public.ceo_memory` | ADD COLUMN tenant_id + RLS |
| `public.agent_memories` | ADD COLUMN tenant_id + RLS |
| `public.completion_sync_queue` | ADD COLUMN tenant_id + RLS |

### RLS policy — 3-clause USING/WITH CHECK

```sql
USING (
    current_setting('agency_os.tenant_id', true)::integer = tenant_id
    OR current_setting('role', true) = 'service_role'
    OR current_setting('agency_os.tenant_id', true) IS NULL
)
```

- Clause 1: anon/authenticated callers scoped by session var (set via `set_tenant_session()`)
- Clause 2: service-role key bypasses — Fleet Supervisor + completion_sync_worker + all backend daemons
- Clause 3: defensive — daemon connecting without setting var also passes (belt + braces)

### Migration is idempotent

- `CREATE TABLE IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS`
- `INSERT … ON CONFLICT DO NOTHING` for tenant seed
- `DROP POLICY IF EXISTS` then `CREATE POLICY` for idempotent policy replacement
- `CREATE INDEX IF NOT EXISTS` for indexes
- Safe to re-run; no-op on second apply.

### Integration test design

Two psycopg3 sessions:
- Session A sets `agency_os.tenant_id = '1'` → sees only tenant-1 task
- Session B sets `agency_os.tenant_id = '2'` → sees only tenant-2 task
- Session C sets nothing → sees both rows (daemon bypass)

Skips automatically when `DATABASE_URL` points at localhost (conftest.py mock). Run against live Supabase by setting `INTEGRATION_DATABASE_URL`.

### Acceptance gates (all passed locally)

- [x] `python3 -m pytest tests/unit/test_set_tenant_session.py -v` → 8 passed
- [x] `python3 -m pytest tests/integration/test_tenant_isolation.py -v` → 3 skipped (no live DB in CI env; skip is clean)
- [x] `ruff check` clean on all 3 Python files
- [x] `ruff format --check` clean on all 3 Python files
- [x] `check_operational_deployment.sh` → exit 0

### Out of scope (explicit)

- Per-tenant Paddle billing (KEI-150 handles billing, Phase 2)
- Per-tenant dashboard UI
- Per-tenant queue scoping in `fleet_supervisor.py`
- Customer signup flow

### Migration apply

Dave applies via Supabase MCP `apply_migration` after merge. Do NOT apply before merging.