### PR TITLE
[ELLIOT] fix-up(kei176): restore hold(?:-final)? regex + remove orphan migration

### DIFF
--- a/migrations/paddle_subscription_id.sql
+++ b/migrations/paddle_subscription_id.sql
@@ -1,8 +1,0 @@
--- KEI-150: Add paddle_subscription_id to public.customers
--- Paddle MoR account scaffold — nullable text column, safe to run multiple times.
-
-ALTER TABLE public.customers
-  ADD COLUMN IF NOT EXISTS paddle_subscription_id TEXT;
-
-COMMENT ON COLUMN public.customers.paddle_subscription_id IS
-  'Paddle subscription ID assigned by Paddle MoR on first successful payment (KEI-150).';

--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -570,6 +570,34 @@ def list_open_prs() -> list[dict[str, Any]]:
         return []
 
 
+def fetch_pr_comments(pr_number: int) -> list[dict]:
+    """Fetch PR comments via gh pr view --json comments. Returns list of comment dicts."""
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "comments"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        log.warning("gh pr view %d comments failed: %s", pr_number, result.stderr)
+        return []
+    try:
+        data = json.loads(result.stdout) or {}
+        return data.get("comments") or []
+    except json.JSONDecodeError:
+        return []
+
+
+_REVIEW_COMMENT_PATTERN_TMPL = r"\[REVIEW(?::(?:approve|hold(?:-final)?))?:{callsign}\]"
+
+
+def comment_has_review_marker(body: str, callsign: str) -> bool:
+    """Return True if body contains any [REVIEW:...:<callsign>] variant (case-insensitive)."""
+    import re
+
+    pattern = _REVIEW_COMMENT_PATTERN_TMPL.format(callsign=re.escape(callsign))
+    return bool(re.search(pattern, body, re.IGNORECASE))
+
+
 def agent_has_reviewed(pr: dict, callsign: str) -> bool:
     """Check if callsign already posted a [REVIEW:callsign] comment on this PR."""
     reviews = pr.get("reviews") or []


### PR DESCRIPTION
## Summary
- Restore trailing ? on (?:-final) in supervisor REVIEW-comment regex (PR #979 sub-agent regression)
- Remove orphan migrations/paddle_subscription_id.sql at wrong path (canonical lives at supabase/migrations/)

## Why
Aiden caught after PR #979 merged: regex change accidentally made -final mandatory, so [REVIEW:HOLD:scout] no longer matches. Plus orphan migration was at the wrong location.

## Test plan
- [x] regex now matches both [REVIEW:HOLD:scout] and [REVIEW:HOLD-FINAL:scout]
- [x] orphan migration removed
- [ ] CI converges