### PR TITLE
[ATLAS] feat(keiTH6): install_all_indexers.sh + missing 5th install wrapper

### DIFF
--- a/docs/runbooks/install_indexers_vultr.md
+++ b/docs/runbooks/install_indexers_vultr.md
@@ -1,0 +1,78 @@
+# Install the 5 Weaviate auto-indexers on Vultr Sydney
+
+**Dispatcher:** Elliot 2026-05-18 — install 4 indexers on Vultr. This PR ships the 5th install script (`tool_call_log` was missing one) + a one-shot wrapper that deploys the full set.
+
+**Indexer fleet** (5 units):
+
+| Indexer | Service unit | Source → Weaviate |
+|---|---|---|
+| ceo-memory | `ceo-memory-indexer.service` | `public.ceo_memory` → Weaviate `CeoMemory` |
+| elliot-memories | `elliot-memories-indexer.service` | `elliot_internal.memories` → Weaviate `AgentMemories` |
+| git-commits | `git-commits-indexer.service` | `git log` → Weaviate `GitCommits` |
+| linear-state | `linear-state-indexer.service` | Linear API → Weaviate `LinearKEIs` |
+| tool-call-log | `tool-call-log-indexer.service` | `public.tool_call_log` → Weaviate `ToolCallLog` |
+
+## Prerequisite
+
+Vultr Sydney host has the repo checked out at `/home/elliotbot/clawd/Agency_OS` + the venv at `/home/elliotbot/clawd/venv`. (Both seeded by KEI-48 / KEI-73 / KEI-74 / KEI-75 / KEI-179 — already done.)
+
+`/home/elliotbot/.config/agency-os/.env` carries:
+- `SUPABASE_DB_URL` (psycopg DSN — `postgres://` not `postgresql+asyncpg://`)
+- `WEAVIATE_URL`, `WEAVIATE_API_KEY`
+- `LINEAR_API_KEY` (linear-state-indexer only)
+
+## Deploy
+
+```bash
+ssh vultr-sydney
+cd /home/elliotbot/clawd/Agency_OS
+git pull
+bash scripts/install_all_indexers.sh
+```
+
+The orchestrator runs each per-unit installer, calls `systemctl --user daemon-reload + enable --now`, then verifies all 5 report `is-active = active`. Non-zero exit + named failures on any miss.
+
+## Verify (one-liner)
+
+```bash
+for u in ceo-memory elliot-memories git-commits linear-state tool-call-log; do
+    systemctl --user is-active "${u}-indexer.service" || echo "FAIL: ${u}"
+done
+```
+
+Expect 5 `active` lines, no `FAIL` lines.
+
+## Per-unit install (if installing one at a time)
+
+```bash
+scripts/install_ceo_memory_indexer.sh
+scripts/install_elliot_memories_indexer.sh
+scripts/install_git_commits_indexer.sh
+scripts/install_linear_state_indexer.sh
+scripts/install_tool_call_log_indexer.sh   # new in this PR
+```
+
+Each wraps `scripts/orchestrator/install_indexer.sh <unit>` so the KEI-108 grep-gate finds the literal `.service` unit name in `scripts/install*`.
+
+## Rollback
+
+```bash
+for u in ceo-memory elliot-memories git-commits linear-state tool-call-log; do
+    systemctl --user disable --now "${u}-indexer.service" || true
+    rm -f "${HOME}/.config/systemd/user/${u}-indexer.service"
+done
+systemctl --user daemon-reload
+```
+
+## What this PR does NOT do
+
+- Does **not** SSH to Vultr (atlas clone doesn't hold `vultr-sydney` SSH credentials). The install must be run by Dave or a callsign that does (Elliot worktree or devops).
+- Does **not** seed `agency-os/.env` — that's a per-host operator step.
+- Does **not** install Weaviate or LiteLLM — those are KEI-48 / KEI-73.
+- Does **not** add monitoring — see KEI-141 (systemd service health monitoring) for that follow-up.
+
+## What this PR adds
+
+1. `scripts/install_tool_call_log_indexer.sh` — missing 5th install script (sibling to the existing 4 — closes a KEI-108 gap where the `.service` was shipped without a per-unit installer wrapper).
+2. `scripts/install_all_indexers.sh` — one-shot orchestrator with verify + named-failure exit codes.
+3. `docs/runbooks/install_indexers_vultr.md` — this runbook.

--- a/scripts/install_all_indexers.sh
+++ b/scripts/install_all_indexers.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# install_all_indexers.sh — install all 5 Weaviate auto-indexers in one shot.
+#
+# Dispatcher KEI: Elliot 2026-05-18 directive — install the indexer fleet
+# on the Vultr Sydney host. Wraps the per-unit installers (each of which
+# wraps scripts/orchestrator/install_indexer.sh) so an operator with SSH
+# to the host can deploy the whole stack with one command.
+#
+# Idempotent — re-running on already-installed units just reloads.
+#
+# Usage:
+#   ssh vultr-sydney
+#   cd /home/elliotbot/clawd/Agency_OS && git pull
+#   bash scripts/install_all_indexers.sh
+#
+# Post-install verify (one-liner):
+#   for u in ceo-memory elliot-memories git-commits linear-state tool-call-log; do
+#       systemctl --user is-active "${u}-indexer.service" || echo "FAIL: ${u}"
+#   done
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="${HOME}/clawd/logs"
+mkdir -p "${LOG_DIR}"
+
+INDEXERS=(
+    ceo-memory
+    elliot-memories
+    git-commits
+    linear-state
+    tool-call-log
+)
+
+echo "install_all_indexers: installing ${#INDEXERS[@]} units"
+
+failed=()
+for name in "${INDEXERS[@]}"; do
+    script="${REPO_DIR}/scripts/install_${name//-/_}_indexer.sh"
+    if [[ ! -x "${script}" ]]; then
+        echo "install_all_indexers: SKIP ${name} — missing ${script}" >&2
+        failed+=("${name} (missing installer)")
+        continue
+    fi
+    echo "----- ${name} -----"
+    if ! bash "${script}"; then
+        echo "install_all_indexers: FAIL ${name}" >&2
+        failed+=("${name}")
+    fi
+done
+
+echo "----- verify -----"
+for name in "${INDEXERS[@]}"; do
+    unit="${name}-indexer.service"
+    if systemctl --user is-active "${unit}" >/dev/null 2>&1; then
+        echo "  ${unit}: active"
+    else
+        echo "  ${unit}: NOT ACTIVE" >&2
+        failed+=("${name} (not active post-install)")
+    fi
+done
+
+if ((${#failed[@]} > 0)); then
+    echo "install_all_indexers: ${#failed[@]} failure(s):" >&2
+    printf '  - %s\n' "${failed[@]}" >&2
+    exit 1
+fi
+
+echo "install_all_indexers: all ${#INDEXERS[@]} indexers installed + active"
+
+# Anchored units (KEI-108 grep targets — DO NOT remove):
+# - ceo-memory-indexer.service
+# - elliot-memories-indexer.service
+# - git-commits-indexer.service
+# - linear-state-indexer.service
+# - tool-call-log-indexer.service

--- a/scripts/install_tool_call_log_indexer.sh
+++ b/scripts/install_tool_call_log_indexer.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# install_tool_call_log_indexer.sh — KEI-54B install entry-point.
+#
+# KEI-108 CI-gate requirement: per-unit install wrapper anchors the literal
+# `tool-call-log-indexer.service` for the grep gate. The .service unit has
+# shipped without a matching install script — this PR closes that gap so
+# the KEI-108 grep over `scripts/install*` finds the unit name.
+#
+# Usage:
+#   scripts/install_tool_call_log_indexer.sh
+
+set -euo pipefail
+
+UNIT="tool-call-log-indexer"
+exec /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/install_indexer.sh "${UNIT}"
+
+# Anchored unit: tool-call-log-indexer.service


### PR DESCRIPTION
## Summary

Closes Elliot 2026-05-18 dispatch (\"@atlas KEI-th6 install 4 indexers on Vultr\"). KEI ID was a typo in the dispatch; no Linear KEI with title \"install 4 indexers Vultr\" exists. Interpreted the brief by inventorying what's actually shipped: 5 indexer \`.service\` units exist; only 4 had per-unit install wrappers; no one-shot orchestrator existed. This PR closes those gaps.

**Atlas-clone constraint:** no vultr-sydney SSH credentials → the install step itself runs on Vultr by an operator (Dave / Elliot worktree / devops). This PR ships everything the operator needs.

## What ships (3 files, +171/-0)

| File | Purpose |
|---|---|
| \`scripts/install_tool_call_log_indexer.sh\` | KEI-108 wrapper anchoring \`tool-call-log-indexer.service\` in \`scripts/install*\`. Closes the gap where the \`.service\` was shipped without a per-unit installer (would fail \`check_operational_deployment.sh\` on the next PR touching it). |
| \`scripts/install_all_indexers.sh\` | One-shot orchestrator. Iterates ceo-memory → elliot-memories → git-commits → linear-state → tool-call-log, calls each per-unit script, then verifies all 5 report \`is-active = active\`. Non-zero exit + named failures on any miss. Idempotent. |
| \`docs/runbooks/install_indexers_vultr.md\` | Operator runbook — ssh + git pull + bash install_all_indexers.sh + one-liner verify + rollback. |

## Acceptance — empirical local smoke

Ran the orchestrator against my local systemd (operator-equivalent — same \`systemctl --user\` surface as Vultr):

\`\`\`
$ bash scripts/install_all_indexers.sh
install_all_indexers: installing 5 units
----- ceo-memory -----
install_indexer: ceo-memory-indexer.service installed + enabled + started
...
----- tool-call-log -----
install_indexer: tool-call-log-indexer.service installed + enabled + started
----- verify -----
  ceo-memory-indexer.service: active
  elliot-memories-indexer.service: active
  git-commits-indexer.service: active
  linear-state-indexer.service: active
  tool-call-log-indexer.service: active
install_all_indexers: all 5 indexers installed + active
\`\`\`

## KEI-108 anchor verify

\`\`\`
$ for u in ceo-memory-indexer elliot-memories-indexer git-commits-indexer linear-state-indexer tool-call-log-indexer; do
    git grep -l \"\${u}.service\" -- 'scripts/install*' >/dev/null && echo \"  \${u}: anchored ✓\" || echo \"  \${u}: NOT anchored\"
  done
  ceo-memory-indexer: anchored ✓
  elliot-memories-indexer: anchored ✓
  git-commits-indexer: anchored ✓
  linear-state-indexer: anchored ✓
  tool-call-log-indexer: anchored ✓  (newly anchored by this PR)
\`\`\`

## Out of scope

- **SSH to vultr-sydney + actual deploy** — operator step (Dave / Elliot worktree / devops with creds).
- **Per-host \`.env\` seeding** — KEI-48 / KEI-73 / KEI-74 / KEI-75 / KEI-179 territory.
- **Indexer monitoring** — see KEI-141 (Backlog) for systemd-service-health follow-up.
- **The 5th vs 4 question** — Elliot's dispatch said \"4 indexers\". 5 \`.service\` units exist (KEI-85 + KEI-54B). Orchestrator installs all 5; operator can comment out tool-call-log if they want exactly 4. Worth a one-line clarification in the actual KEI Linear card.

## Test plan

- [x] \`bash -n\` syntax check on all 6 install scripts → all OK.
- [x] Live \`install_all_indexers.sh\` run against local systemd → all 5 active, exit 0.
- [x] KEI-108 grep verify → all 5 anchored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)