### PR TITLE
[SCOUT] feat(kei196): Weaviate re-ingest with text2vec-transformers — scaffold + plan + tests

### DIFF
--- a/docs/wave3/kei196_reingest_plan.md
+++ b/docs/wave3/kei196_reingest_plan.md
@@ -1,4 +1,4 @@
-# KEI-196 — Weaviate Re-ingest with text2vec-transformers: Plan
+# KEI-196 — Weaviate Re-ingest with text2vec-google: Plan
 
 **Status:** Script + plan shipped (this PR). Live cutover is operator-gated.
 **KEI:** [KEI-196](https://linear.app/keiracom/issue/KEI-196) (M1 follow-up from KEI-192 memory audit).
@@ -26,7 +26,7 @@ Global_governance_patterns: vectorizer=none
 
 Without an embeddings vectorizer, `agent_query` similarity scores return 0.0. The default `min_score=0.50` filter then drops every result, and 12/14 retrieval_events end up with `top_citation_id=NULL`. Memory recall is effectively dead despite the data being indexed.
 
-## Fix: re-ingest 5 collections with text2vec-transformers
+## Fix: re-ingest 5 collections with text2vec-google
 
 Target collections (in cutover order):
 1. `AgentMemories` — smallest, lowest blast radius, validate-first
@@ -37,21 +37,19 @@ Target collections (in cutover order):
 
 ## Prerequisites (operator verifies BEFORE --execute)
 
-**1. t2v-transformers inference container reachable from Weaviate.** Typical setup:
+**1. text2vec-google module enabled in live Weaviate.** Dave Option A — no local inference
+container required. Uses Google AI Studio (Gemini API key) instead of a self-hosted
+transformers inference container. Verify:
 ```bash
-docker run -d \
-  --name t2v-transformers \
-  -p 8081:8080 \
-  -e ENABLE_CUDA=0 \
-  semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2
+curl -s http://127.0.0.1:8090/v1/meta | python3 -c "import json,sys; print('text2vec-google' in json.load(sys.stdin).get('modules', {}))"
 ```
+Expected: `True`
 
-Weaviate's `text2vec-transformers` module must be configured with `TRANSFORMERS_INFERENCE_API=http://t2v-transformers:8080` (or whatever the inference host is). Verify:
-```bash
-curl -s http://127.0.0.1:8090/v1/meta | jq '.modules."text2vec-transformers"'
-```
+**2. GOOGLE_API_KEY env var set.** The text2vec-google module reads `GOOGLE_API_KEY` at
+embedding time. Confirm the Weaviate process has this env var (or it is injected via the
+Weaviate config). No projectId required for AI Studio (projectId is Vertex AI only).
 
-**2. Backup directory writable.** Default: `/home/elliotbot/clawd/logs/kei196_backup/`. Operator checks `ls -ld` permissions before --execute.
+**3. Backup directory writable.** Default: `/home/elliotbot/clawd/logs/kei196_backup/`. Operator checks `ls -ld` permissions before --execute.
 
 **3. KEI-197 cleanup ran first** (recommended). If KEI-197's 6560 NULL-raw_text orphan cleanup runs BEFORE the re-ingest, the post-restore Discoveries class is ~6560 rows smaller — saves embedding compute + cleaner downstream queries.
 
@@ -96,7 +94,7 @@ If recreate succeeds but restore fails partway:
 - [x] Restore handles 422 already-exists as success (idempotent on re-run)
 - [x] Validate runs a `nearText` probe + returns the top certainty score
 - [x] `--class <Name>` restricts to one collection for cautious cutover
-- [ ] **Live re-ingest run** — operator-gated. Requires inference container + Weaviate module config verified first.
+- [ ] **Live re-ingest run** — operator-gated. Requires text2vec-google module enabled in Weaviate + GOOGLE_API_KEY env var set.
 - [ ] **agent_query.query() returns scores > 0.0 on representative queries** — post-validate confirmation
 - [ ] **Behavioural recall test** — query 'psycopg asyncpg DSN bug' returns Atlas's fix as top result via semantic similarity (not LIKE/regex)
 
@@ -104,7 +102,7 @@ If recreate succeeds but restore fails partway:
 
 - Live cutover (operator decides timing + verifies prereqs)
 - Inference container setup if not already running (ops/Atlas DevOps lane per ratified Tier 2)
-- Tuning `text2vec-transformers` model choice (MiniLM-L6-v2 is the sensible default for SaaS retrieval; larger models would improve recall at higher compute cost)
+- Tuning `text2vec-google` model choice (`text-embedding-004` is the default; other Gemini embedding models can be specified via `modelId` in moduleConfig)
 - Score threshold tuning post-cutover (KEI-198 is the M3 follow-up that adjusts min_score from the static 0.5 to a score-distribution-aware default)
 - Per-class custom moduleConfig (e.g. `vectorizeClassName` per collection — current default uses one config for all 5)
 

--- a/docs/wave3/kei196_reingest_plan.md
+++ b/docs/wave3/kei196_reingest_plan.md
@@ -1,0 +1,116 @@
+# KEI-196 — Weaviate Re-ingest with text2vec-transformers: Plan
+
+**Status:** Script + plan shipped (this PR). Live cutover is operator-gated.
+**KEI:** [KEI-196](https://linear.app/keiracom/issue/KEI-196) (M1 follow-up from KEI-192 memory audit).
+**Authored by:** Scout · 2026-05-18.
+
+## Problem (from KEI-192 audit)
+
+All 5 retrieval-path collections have `vectorizer=none`:
+
+```
+$ curl -s http://127.0.0.1:8090/v1/schema | python3 -c "
+import json,sys
+for c in json.load(sys.stdin).get('classes', []):
+    print(f\"{c['class']}: vectorizer={c['vectorizer']}\")"
+Discoveries: vectorizer=none
+Codebase: vectorizer=none
+Keis: vectorizer=none
+AgentMemories: vectorizer=none
+Decisions: vectorizer=none
+ToolCalls: vectorizer=none
+Sessions: vectorizer=none
+Staging_discoveries: vectorizer=none
+Global_governance_patterns: vectorizer=none
+```
+
+Without an embeddings vectorizer, `agent_query` similarity scores return 0.0. The default `min_score=0.50` filter then drops every result, and 12/14 retrieval_events end up with `top_citation_id=NULL`. Memory recall is effectively dead despite the data being indexed.
+
+## Fix: re-ingest 5 collections with text2vec-transformers
+
+Target collections (in cutover order):
+1. `AgentMemories` — smallest, lowest blast radius, validate-first
+2. `Decisions` — small (ceo_memory rows)
+3. `Keis` — Linear KEI state, moderate
+4. `Discoveries` — largest, 6560 rows with NULL raw_text (see KEI-197)
+5. `Codebase` — git commits, indexed continuously
+
+## Prerequisites (operator verifies BEFORE --execute)
+
+**1. t2v-transformers inference container reachable from Weaviate.** Typical setup:
+```bash
+docker run -d \
+  --name t2v-transformers \
+  -p 8081:8080 \
+  -e ENABLE_CUDA=0 \
+  semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2
+```
+
+Weaviate's `text2vec-transformers` module must be configured with `TRANSFORMERS_INFERENCE_API=http://t2v-transformers:8080` (or whatever the inference host is). Verify:
+```bash
+curl -s http://127.0.0.1:8090/v1/meta | jq '.modules."text2vec-transformers"'
+```
+
+**2. Backup directory writable.** Default: `/home/elliotbot/clawd/logs/kei196_backup/`. Operator checks `ls -ld` permissions before --execute.
+
+**3. KEI-197 cleanup ran first** (recommended). If KEI-197's 6560 NULL-raw_text orphan cleanup runs BEFORE the re-ingest, the post-restore Discoveries class is ~6560 rows smaller — saves embedding compute + cleaner downstream queries.
+
+## Operator workflow (4 phases, gated)
+
+```
+# Phase 1 — backup (read-only, safe, idempotent)
+python3 scripts/orchestrator/kei196_reingest_with_vectorizer.py --step backup
+
+# Inspect:
+ls -la /home/elliotbot/clawd/logs/kei196_backup/
+wc -l /home/elliotbot/clawd/logs/kei196_backup/*.jsonl   # row counts per class
+
+# Phase 2 — recreate schema (DESTRUCTIVE — drops + recreates with new vectorizer)
+python3 scripts/orchestrator/kei196_reingest_with_vectorizer.py --step recreate --execute
+
+# Phase 3 — restore (re-POST each backed-up object; vectorizer auto-embeds)
+python3 scripts/orchestrator/kei196_reingest_with_vectorizer.py --step restore --execute
+
+# Phase 4 — validate scores
+python3 scripts/orchestrator/kei196_reingest_with_vectorizer.py --step validate
+```
+
+Or full cutover in one command (still requires --execute):
+```bash
+python3 scripts/orchestrator/kei196_reingest_with_vectorizer.py --step all --execute
+```
+
+`--class <Name>` flag restricts to one class — recommended for the first pass against AgentMemories. Validate scores > 0.0 before proceeding to the larger collections.
+
+## Rollback
+
+If recreate succeeds but restore fails partway:
+- The `.jsonl` backups remain. Re-run `--step restore --execute` to retry.
+- If the schema config itself is broken, delete the class manually and re-run from `--step recreate`.
+- Worst case: redeploy the prior schema definitions (from `infra/weaviate/schema.py`) and re-run an existing indexer (`linear_state_indexer.py`, `elliot_memories_indexer.py`, etc.) to reseed.
+
+## Acceptance per KEI-196
+
+- [x] Script handles all 4 phases (backup, recreate, restore, validate) with per-step --execute gating
+- [x] Backup is read-only and idempotent
+- [x] Restore handles 422 already-exists as success (idempotent on re-run)
+- [x] Validate runs a `nearText` probe + returns the top certainty score
+- [x] `--class <Name>` restricts to one collection for cautious cutover
+- [ ] **Live re-ingest run** — operator-gated. Requires inference container + Weaviate module config verified first.
+- [ ] **agent_query.query() returns scores > 0.0 on representative queries** — post-validate confirmation
+- [ ] **Behavioural recall test** — query 'psycopg asyncpg DSN bug' returns Atlas's fix as top result via semantic similarity (not LIKE/regex)
+
+## Out of scope (Elliot/Dave follow-up)
+
+- Live cutover (operator decides timing + verifies prereqs)
+- Inference container setup if not already running (ops/Atlas DevOps lane per ratified Tier 2)
+- Tuning `text2vec-transformers` model choice (MiniLM-L6-v2 is the sensible default for SaaS retrieval; larger models would improve recall at higher compute cost)
+- Score threshold tuning post-cutover (KEI-198 is the M3 follow-up that adjusts min_score from the static 0.5 to a score-distribution-aware default)
+- Per-class custom moduleConfig (e.g. `vectorizeClassName` per collection — current default uses one config for all 5)
+
+## Cross-reference
+
+- [[kei197_null_raw_text_evidence]] — KEI-197 cleanup should run BEFORE this re-ingest to avoid embedding 6560 NULL-raw_text rows
+- KEI-198 (M3) — min_score tuning follow-up after vectorizer is live
+- `infra/weaviate/schema.py` — current schema definitions (used as starting point for the recreate step)
+- `infra/weaviate/staging_schema.py` — Staging_discoveries schema (not in M1 scope; left vectorizer=none for now)

--- a/scripts/orchestrator/kei196_reingest_with_vectorizer.py
+++ b/scripts/orchestrator/kei196_reingest_with_vectorizer.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""kei196_reingest_with_vectorizer.py — re-ingest Weaviate collections with text2vec.
+
+KEI-192 audit found vectorizer=none on all 5 retrieval-path collections:
+Discoveries, Keis, AgentMemories, Decisions, Codebase. With no embeddings,
+agent_query similarity scores return 0.0, the default min_score=0.50 filter
+drops every result, and 12/14 retrieval_events end up with top_citation_id=NULL.
+
+This script:
+  1. Backs up each target collection's objects to a JSON file under
+     /home/elliotbot/clawd/logs/kei196_backup/<class>.jsonl
+  2. (Operator-gated) Drops the existing collection
+  3. (Operator-gated) Recreates with vectorizer=text2vec-transformers
+  4. (Operator-gated) Re-POSTs all backed-up objects (vectorizer auto-embeds)
+  5. Runs the score validation: agent_query returns score > 0.0 on a probe
+
+Prerequisites (operator must verify before --execute):
+  - t2v-transformers inference container reachable from Weaviate
+    (typical: docker run semitechnologies/transformers-inference:<MODEL>)
+  - Weaviate config has the text2vec-transformers module enabled
+  - Backup directory writable: /home/elliotbot/clawd/logs/kei196_backup/
+
+Steps are independent + idempotent:
+  --step backup    only back up; safe to run repeatedly
+  --step recreate  DROPS + recreates schema (destructive — needs operator gate)
+  --step restore   POSTs backed-up objects (idempotent via deterministic UUID
+                   where source pipelines used uuid5; new randomised UUIDs
+                   otherwise — safe but produces duplicates if rerun without
+                   recreate)
+  --step validate  agent_query probe — asserts score > 0.0
+  --step all       backup → recreate → restore → validate (full cutover)
+
+Default: dry-run with summary counts. --execute required to actually mutate
+Weaviate state. The --execute flag is mandatory for any destructive step.
+
+Rollback: if recreate succeeds but restore fails partway, the .jsonl backups
+let the operator re-run --step restore manually or with the
+--source-backup-dir override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+logger = logging.getLogger("kei196_reingest")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+WEAVIATE_HOST = os.environ.get("WEAVIATE_HOST", "127.0.0.1")
+WEAVIATE_PORT = int(os.environ.get("WEAVIATE_PORT", "8090"))
+WEAVIATE_BASE = f"http://{WEAVIATE_HOST}:{WEAVIATE_PORT}"  # NOSONAR
+
+BACKUP_DIR_DEFAULT = Path(
+    os.environ.get("KEI196_BACKUP_DIR", "/home/elliotbot/clawd/logs/kei196_backup")
+)
+
+TARGET_COLLECTIONS: tuple[str, ...] = (
+    "Discoveries",
+    "Keis",
+    "AgentMemories",
+    "Decisions",
+    "Codebase",
+)
+
+NEW_VECTORIZER = "text2vec-transformers"
+NEW_MODULE_CONFIG = {
+    "text2vec-transformers": {
+        "vectorizeClassName": False,
+        "poolingStrategy": "masked_mean",
+    }
+}
+
+
+def _http_get(path: str) -> dict:
+    req = urlrequest.Request(f"{WEAVIATE_BASE}{path}", method="GET")
+    with urlrequest.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _http_request(method: str, path: str, body: dict | None = None) -> dict | None:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urlrequest.Request(f"{WEAVIATE_BASE}{path}", data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    with urlrequest.urlopen(req, timeout=60) as resp:
+        raw = resp.read().decode()
+        return json.loads(raw) if raw else None
+
+
+def fetch_class_schema(class_name: str) -> dict | None:
+    """Return the existing class schema dict, or None if absent."""
+    try:
+        return _http_get(f"/v1/schema/{class_name}")
+    except urlerror.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def backup_class(class_name: str, backup_dir: Path) -> int:
+    """Page through the class and write each object as one JSONL line.
+
+    Returns the count of backed-up objects. Uses Weaviate's cursor pagination
+    via /v1/objects?class=<name>&limit=N&after=<id> for stable iteration.
+    """
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    out_path = backup_dir / f"{class_name}.jsonl"
+    n = 0
+    after = ""
+    page_size = 100
+    with out_path.open("w", encoding="utf-8") as fh:
+        while True:
+            qs = f"class={class_name}&limit={page_size}"
+            if after:
+                qs += f"&after={after}"
+            page = _http_get(f"/v1/objects?{qs}")
+            objects = page.get("objects", []) or []
+            if not objects:
+                break
+            for obj in objects:
+                fh.write(json.dumps(obj) + "\n")
+                n += 1
+            after = objects[-1].get("id", "")
+            if len(objects) < page_size:
+                break
+    logger.info("backup %s -> %s (%d objects)", class_name, out_path, n)
+    return n
+
+
+def recreate_class_with_vectorizer(class_name: str) -> bool:
+    """DROP + CREATE class with text2vec-transformers. DESTRUCTIVE — operator-gated."""
+    existing = fetch_class_schema(class_name)
+    if existing is None:
+        logger.warning("class %s does not exist — skipping recreate", class_name)
+        return False
+    properties = existing.get("properties", [])
+    new_schema = {
+        "class": class_name,
+        "vectorizer": NEW_VECTORIZER,
+        "moduleConfig": NEW_MODULE_CONFIG,
+        "properties": properties,
+    }
+    _http_request("DELETE", f"/v1/schema/{class_name}")
+    logger.info("dropped class %s", class_name)
+    _http_request("POST", "/v1/schema", new_schema)
+    logger.info("created class %s with vectorizer=%s", class_name, NEW_VECTORIZER)
+    return True
+
+
+def restore_class(class_name: str, backup_dir: Path) -> int:
+    """Re-POST every backed-up object to the (now vectorizer-enabled) class.
+
+    Objects are POST'd one at a time so the vectorizer module can compute
+    each embedding. Returns the count of successfully restored objects.
+    """
+    src = backup_dir / f"{class_name}.jsonl"
+    if not src.exists():
+        logger.warning("no backup at %s — skipping restore", src)
+        return 0
+    n_ok = 0
+    n_fail = 0
+    with src.open() as fh:
+        for line in fh:
+            obj = json.loads(line)
+            payload = {
+                "class": class_name,
+                "id": obj.get("id"),
+                "properties": obj.get("properties") or {},
+            }
+            try:
+                _http_request("POST", "/v1/objects", payload)
+                n_ok += 1
+            except urlerror.HTTPError as exc:
+                if exc.code == 422:
+                    n_ok += 1  # already exists — idempotent
+                    continue
+                logger.warning("restore %s/%s failed: %s", class_name, payload["id"], exc)
+                n_fail += 1
+    logger.info("restored %s: %d ok, %d failed", class_name, n_ok, n_fail)
+    return n_ok
+
+
+def validate_scores(class_name: str, probe_query: str = "memory recall") -> tuple[bool, float]:
+    """Run a GraphQL nearText probe and assert top score > 0.0.
+
+    Returns (passed, top_score). Passed=False means the vectorizer didn't
+    produce non-zero similarity — either the inference container is not
+    reachable or the data didn't index. Operator investigates.
+    """
+    gql = (
+        f'{{ Get {{ {class_name}(nearText: {{concepts: ["{probe_query}"]}}, limit: 1) '
+        "{ _additional { id certainty distance } } } }"
+    )
+    try:
+        body = _http_request("POST", "/v1/graphql", {"query": gql}) or {}
+    except urlerror.HTTPError as exc:
+        logger.error("validate %s failed: %s", class_name, exc)
+        return False, 0.0
+    rows = body.get("data", {}).get("Get", {}).get(class_name, []) or []
+    if not rows:
+        return False, 0.0
+    additional = rows[0].get("_additional", {}) or {}
+    certainty = float(additional.get("certainty") or 0.0)
+    return certainty > 0.0, certainty
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--step",
+        choices=("backup", "recreate", "restore", "validate", "all"),
+        default="backup",
+        help="step to run (default: backup — read-only)",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="REQUIRED for any destructive step (recreate, restore, all)",
+    )
+    parser.add_argument(
+        "--class",
+        dest="class_name",
+        choices=TARGET_COLLECTIONS,
+        default=None,
+        help="restrict to one class (default: all 5 target collections)",
+    )
+    parser.add_argument(
+        "--backup-dir",
+        default=str(BACKUP_DIR_DEFAULT),
+        help=f"backup directory (default: {BACKUP_DIR_DEFAULT})",
+    )
+    args = parser.parse_args(argv)
+
+    classes = (args.class_name,) if args.class_name else TARGET_COLLECTIONS
+    backup_dir = Path(args.backup_dir).resolve()
+
+    destructive = args.step in ("recreate", "restore", "all")
+    if destructive and not args.execute:
+        logger.error(
+            "--step %s is destructive — re-run with --execute. Dry-run note: "
+            "would backup→recreate→restore %d collection(s): %s",
+            args.step,
+            len(classes),
+            ",".join(classes),
+        )
+        return 1
+
+    if args.step in ("backup", "all"):
+        total = 0
+        for c in classes:
+            total += backup_class(c, backup_dir)
+        logger.info("backup step complete: %d objects across %d classes", total, len(classes))
+
+    if args.step in ("recreate", "all"):
+        for c in classes:
+            recreate_class_with_vectorizer(c)
+
+    if args.step in ("restore", "all"):
+        for c in classes:
+            restore_class(c, backup_dir)
+
+    if args.step in ("validate", "all"):
+        all_pass = True
+        for c in classes:
+            ok, score = validate_scores(c)
+            logger.info("validate %s: passed=%s top_certainty=%.3f", c, ok, score)
+            if not ok:
+                all_pass = False
+        if not all_pass:
+            logger.warning("validate failed for one or more classes — check inference container")
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/kei196_reingest_with_vectorizer.py
+++ b/scripts/orchestrator/kei196_reingest_with_vectorizer.py
@@ -10,14 +10,14 @@ This script:
   1. Backs up each target collection's objects to a JSON file under
      /home/elliotbot/clawd/logs/kei196_backup/<class>.jsonl
   2. (Operator-gated) Drops the existing collection
-  3. (Operator-gated) Recreates with vectorizer=text2vec-transformers
+  3. (Operator-gated) Recreates with vectorizer=text2vec-google (AI Studio / Gemini)
   4. (Operator-gated) Re-POSTs all backed-up objects (vectorizer auto-embeds)
   5. Runs the score validation: agent_query returns score > 0.0 on a probe
 
 Prerequisites (operator must verify before --execute):
-  - t2v-transformers inference container reachable from Weaviate
-    (typical: docker run semitechnologies/transformers-inference:<MODEL>)
-  - Weaviate config has the text2vec-transformers module enabled
+  - Live Weaviate instance has text2vec-google module enabled (Dave Option A —
+    no local inference container required; uses GOOGLE_API_KEY env var for AI Studio)
+  - GOOGLE_API_KEY env var set with a valid Gemini API key
   - Backup directory writable: /home/elliotbot/clawd/logs/kei196_backup/
 
 Steps are independent + idempotent:
@@ -68,11 +68,13 @@ TARGET_COLLECTIONS: tuple[str, ...] = (
     "Codebase",
 )
 
-NEW_VECTORIZER = "text2vec-transformers"
+NEW_VECTORIZER = "text2vec-google"
+# text2vec-google (AI Studio / Gemini) — no local inference container needed.
+# projectId is Vertex AI only; omit for AI Studio (key-based auth via GOOGLE_API_KEY).
 NEW_MODULE_CONFIG = {
-    "text2vec-transformers": {
+    "text2vec-google": {
+        "modelId": "text-embedding-004",
         "vectorizeClassName": False,
-        "poolingStrategy": "masked_mean",
     }
 }
 
@@ -133,7 +135,7 @@ def backup_class(class_name: str, backup_dir: Path) -> int:
 
 
 def recreate_class_with_vectorizer(class_name: str) -> bool:
-    """DROP + CREATE class with text2vec-transformers. DESTRUCTIVE — operator-gated."""
+    """DROP + CREATE class with text2vec-google. DESTRUCTIVE — operator-gated."""
     existing = fetch_class_schema(class_name)
     if existing is None:
         logger.warning("class %s does not exist — skipping recreate", class_name)
@@ -198,8 +200,8 @@ def validate_scores(class_name: str, probe_query: str = "memory recall") -> tupl
     )
     try:
         body = _http_request("POST", "/v1/graphql", {"query": gql}) or {}
-    except urlerror.HTTPError as exc:
-        logger.error("validate %s failed: %s", class_name, exc)
+    except urlerror.HTTPError:
+        logger.exception("validate %s failed", class_name)
         return False, 0.0
     rows = body.get("data", {}).get("Get", {}).get(class_name, []) or []
     if not rows:
@@ -207,6 +209,45 @@ def validate_scores(class_name: str, probe_query: str = "memory recall") -> tupl
     additional = rows[0].get("_additional", {}) or {}
     certainty = float(additional.get("certainty") or 0.0)
     return certainty > 0.0, certainty
+
+
+def _run_steps(
+    step: str,
+    classes: tuple[str, ...],
+    backup_dir: Path,
+) -> int:
+    """Execute the requested pipeline steps across all target classes.
+
+    Extracted from main() to keep cognitive complexity within Sonar S3776 limits.
+    Returns 0 on success, 2 if validation fails for any class.
+    """
+    if step in ("backup", "all"):
+        total = sum(backup_class(c, backup_dir) for c in classes)
+        logger.info("backup step complete: %d objects across %d classes", total, len(classes))
+
+    if step in ("recreate", "all"):
+        for c in classes:
+            recreate_class_with_vectorizer(c)
+
+    if step in ("restore", "all"):
+        for c in classes:
+            restore_class(c, backup_dir)
+
+    if step in ("validate", "all"):
+        all_pass = True
+        for c in classes:
+            ok, score = validate_scores(c)
+            logger.info("validate %s: passed=%s top_certainty=%.3f", c, ok, score)
+            if not ok:
+                all_pass = False
+        if not all_pass:
+            # text2vec-google: check GOOGLE_API_KEY env var and module enabled in /v1/meta
+            logger.warning(
+                "validate failed for one or more classes — check GOOGLE_API_KEY env and text2vec-google module in Weaviate /v1/meta"
+            )
+            return 2
+
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -250,32 +291,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    if args.step in ("backup", "all"):
-        total = 0
-        for c in classes:
-            total += backup_class(c, backup_dir)
-        logger.info("backup step complete: %d objects across %d classes", total, len(classes))
-
-    if args.step in ("recreate", "all"):
-        for c in classes:
-            recreate_class_with_vectorizer(c)
-
-    if args.step in ("restore", "all"):
-        for c in classes:
-            restore_class(c, backup_dir)
-
-    if args.step in ("validate", "all"):
-        all_pass = True
-        for c in classes:
-            ok, score = validate_scores(c)
-            logger.info("validate %s: passed=%s top_certainty=%.3f", c, ok, score)
-            if not ok:
-                all_pass = False
-        if not all_pass:
-            logger.warning("validate failed for one or more classes — check inference container")
-            return 2
-
-    return 0
+    return _run_steps(args.step, classes, backup_dir)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_kei196_reingest.py
+++ b/tests/scripts/test_kei196_reingest.py
@@ -1,0 +1,150 @@
+"""Tests for kei196_reingest_with_vectorizer — KEI-196 backup/restore/validate logic.
+
+Parser-only tests; no live Weaviate dependency. Covers:
+  - Module-level constants (target collections + new vectorizer config)
+  - CLI argparse (step + --execute gating + --class filter)
+  - Backup path construction
+  - validate_scores returns the expected shape
+
+Live integration (live Weaviate + inference container) is the operator-gated
+acceptance path documented in docs/wave3/kei196_reingest_plan.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "kei196_reingest_with_vectorizer.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("kei196_reingest", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["kei196_reingest"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_target_collections_five(mod):
+    """KEI-192 audit identified 5 retrieval-path collections."""
+    assert set(mod.TARGET_COLLECTIONS) == {
+        "Discoveries",
+        "Keis",
+        "AgentMemories",
+        "Decisions",
+        "Codebase",
+    }
+
+
+def test_new_vectorizer_is_text2vec_transformers(mod):
+    """Per ratification: text2vec-transformers (sentence-transformers) is the choice."""
+    assert mod.NEW_VECTORIZER == "text2vec-transformers"
+    assert "text2vec-transformers" in mod.NEW_MODULE_CONFIG
+
+
+def test_destructive_step_requires_execute_flag(mod, capsys):
+    """recreate/restore/all without --execute returns rc=1 + explanatory log."""
+    rc = mod.main(["--step", "recreate"])
+    assert rc == 1
+
+
+def test_backup_step_safe_without_execute(mod, monkeypatch, tmp_path):
+    """--step backup is read-only; runs without --execute. Mocks the HTTP call."""
+
+    def _fake_get(path):
+        # Return one page of 2 objects then an empty page (end of cursor).
+        if "after=" in path:
+            return {"objects": []}
+        return {
+            "objects": [
+                {"id": "obj-1", "properties": {"agent": "scout"}},
+                {"id": "obj-2", "properties": {"agent": "scout"}},
+            ]
+        }
+
+    monkeypatch.setattr(mod, "_http_get", _fake_get)
+    rc = mod.main(["--step", "backup", "--class", "AgentMemories", "--backup-dir", str(tmp_path)])
+    assert rc == 0
+    out_path = tmp_path / "AgentMemories.jsonl"
+    assert out_path.exists()
+    assert sum(1 for _ in out_path.read_text().splitlines()) == 2
+
+
+def test_class_filter_restricts_to_one(mod, monkeypatch, tmp_path):
+    """--class restricts the iteration to one target collection."""
+    seen: list[str] = []
+
+    def _fake_backup(class_name, backup_dir):
+        seen.append(class_name)
+        return 0
+
+    monkeypatch.setattr(mod, "backup_class", _fake_backup)
+    rc = mod.main(["--step", "backup", "--class", "AgentMemories", "--backup-dir", str(tmp_path)])
+    assert rc == 0
+    assert seen == ["AgentMemories"]
+
+
+def test_default_step_is_safe_backup(mod, monkeypatch, tmp_path):
+    """Default step is backup (read-only) — operator can't accidentally destruct."""
+    monkeypatch.setattr(mod, "backup_class", lambda _c, _d: 0)
+    # No --step + no --execute should still succeed (backup default).
+    rc = mod.main(["--backup-dir", str(tmp_path)])
+    assert rc == 0
+
+
+def test_validate_scores_returns_pass_when_certainty_positive(mod, monkeypatch):
+    """validate_scores returns (True, score) when nearText probe gets back a hit."""
+
+    def _fake_request(_method, _path, _body=None):
+        return {
+            "data": {
+                "Get": {
+                    "AgentMemories": [
+                        {"_additional": {"id": "x", "certainty": 0.78, "distance": 0.4}}
+                    ]
+                }
+            }
+        }
+
+    monkeypatch.setattr(mod, "_http_request", _fake_request)
+    passed, score = mod.validate_scores("AgentMemories", "test probe")
+    assert passed is True
+    assert score == pytest.approx(0.78)
+
+
+def test_validate_scores_returns_fail_when_certainty_zero(mod, monkeypatch):
+    """validate_scores returns (False, 0.0) when certainty is 0 (vectorizer not working)."""
+
+    def _fake_request(_method, _path, _body=None):
+        return {
+            "data": {
+                "Get": {
+                    "AgentMemories": [
+                        {"_additional": {"id": "x", "certainty": 0.0, "distance": 1.0}}
+                    ]
+                }
+            }
+        }
+
+    monkeypatch.setattr(mod, "_http_request", _fake_request)
+    passed, score = mod.validate_scores("AgentMemories", "test probe")
+    assert passed is False
+    assert score == 0.0
+
+
+def test_validate_scores_returns_fail_when_no_results(mod, monkeypatch):
+    """validate_scores returns (False, 0.0) when the probe returns no rows."""
+
+    def _fake_request(_method, _path, _body=None):
+        return {"data": {"Get": {"AgentMemories": []}}}
+
+    monkeypatch.setattr(mod, "_http_request", _fake_request)
+    passed, score = mod.validate_scores("AgentMemories", "test probe")
+    assert passed is False
+    assert score == 0.0

--- a/tests/scripts/test_kei196_reingest.py
+++ b/tests/scripts/test_kei196_reingest.py
@@ -42,10 +42,10 @@ def test_target_collections_five(mod):
     }
 
 
-def test_new_vectorizer_is_text2vec_transformers(mod):
-    """Per ratification: text2vec-transformers (sentence-transformers) is the choice."""
-    assert mod.NEW_VECTORIZER == "text2vec-transformers"
-    assert "text2vec-transformers" in mod.NEW_MODULE_CONFIG
+def test_new_vectorizer_is_text2vec_google(mod):
+    """Dave Option A: text2vec-google (AI Studio) — live Weaviate lacks text2vec-transformers."""
+    assert mod.NEW_VECTORIZER == "text2vec-google"
+    assert "text2vec-google" in mod.NEW_MODULE_CONFIG
 
 
 def test_destructive_step_requires_execute_flag(mod, capsys):
@@ -135,7 +135,8 @@ def test_validate_scores_returns_fail_when_certainty_zero(mod, monkeypatch):
     monkeypatch.setattr(mod, "_http_request", _fake_request)
     passed, score = mod.validate_scores("AgentMemories", "test probe")
     assert passed is False
-    assert score == 0.0
+    # certainty=0.0 exactly; use approx to avoid S1244 float-equality warning
+    assert score == pytest.approx(0.0)
 
 
 def test_validate_scores_returns_fail_when_no_results(mod, monkeypatch):
@@ -147,4 +148,5 @@ def test_validate_scores_returns_fail_when_no_results(mod, monkeypatch):
     monkeypatch.setattr(mod, "_http_request", _fake_request)
     passed, score = mod.validate_scores("AgentMemories", "test probe")
     assert passed is False
-    assert score == 0.0
+    # certainty defaults to 0.0 when no rows returned; use approx per S1244
+    assert score == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

KEI-196 (M1 — KEI-192 follow-up): cutover script + operator plan for the Weaviate vectorizer change. Audit found 5 retrieval-path collections all have `vectorizer=none`, killing semantic similarity scores → `min_score=0.50` filter drops every result. This PR ships the 4-phase script + tests + plan; operator runs the live re-ingest after verifying the inference container.

**Linear:** [KEI-196](https://linear.app/keiracom/issue/KEI-196) · **Branch:** off `08daf876f`

## What lands (3 files)

| File | Purpose |
|---|---|
| `scripts/orchestrator/kei196_reingest_with_vectorizer.py` | 4-phase script: backup → recreate → restore → validate, with `--execute` gating on destructive steps |
| `docs/wave3/kei196_reingest_plan.md` | Operator workflow + prerequisites + rollback |
| `tests/scripts/test_kei196_reingest.py` | 9 unit tests (no live Weaviate dep) |

## 4-phase workflow

```
# Phase 1 — backup (read-only, idempotent)
python3 scripts/orchestrator/kei196_reingest_with_vectorizer.py --step backup

# Phase 2 — recreate (DROPS + CREATEs with vectorizer=text2vec-transformers)
python3 scripts/orchestrator/kei196_reingest_with_vectorizer.py --step recreate --execute

# Phase 3 — restore (re-POST, vectorizer auto-embeds)
python3 scripts/orchestrator/kei196_reingest_with_vectorizer.py --step restore --execute

# Phase 4 — validate (nearText probe)
python3 scripts/orchestrator/kei196_reingest_with_vectorizer.py --step validate
```

Per-step `--execute` gating: destructive steps refuse to run without the flag. Default step is `backup` (read-only) — operator can't accidentally destruct.

## Prerequisites (operator verifies BEFORE --execute)

1. **t2v-transformers inference container reachable** from Weaviate. Without it, the vectorizer config writes but no embeddings get computed → certainty stays 0.0.
2. **Backup directory writable** at `/home/elliotbot/clawd/logs/kei196_backup/`.
3. **KEI-197 cleanup ran first** (recommended) — saves embedding compute on the 6560 NULL-raw_text orphans in Discoveries.

Full prereq + rollback workflow in `docs/wave3/kei196_reingest_plan.md`.

## Verbatim verify

```
$ python3 scripts/orchestrator/kei196_reingest_with_vectorizer.py --step backup --class AgentMemories --backup-dir /tmp/kei196-test
backup AgentMemories -> /tmp/kei196-test/AgentMemories.jsonl (200 objects)

$ pytest tests/scripts/test_kei196_reingest.py -q
.........                                                                [100%]
9 passed in 0.09s

$ ruff check + format
All checks passed!
```

## Tests (9)

- 5 target collections enumerated correctly
- text2vec-transformers + moduleConfig defaults
- Destructive steps require --execute (rc=1 without)
- Default step is safe (backup)
- --class filter restricts to one collection
- Backup pipeline writes JSONL (mocked HTTP)
- validate_scores returns (pass, score) — pass/fail/empty cases

## Acceptance per KEI-196

- [x] Script handles all 4 phases with --execute gating
- [x] Backup empirically verified (200 AgentMemories objects → JSONL)
- [x] Restore handles 422 already-exists as idempotent success
- [x] Validate returns top certainty score from nearText probe
- [x] --class flag for cautious cutover (start with AgentMemories — smallest)
- [ ] **Live cutover** — operator-gated. Needs inference container verify + 2-4h ingest run.
- [ ] **agent_query scores > 0.0** — post-cutover empirical confirmation
- [ ] **Behavioural recall test** — query "psycopg asyncpg DSN bug" returns Atlas's fix as top result via semantic similarity (not LIKE/regex)

## Out of scope

- Live cutover (operator decides timing + prereqs)
- t2v-transformers container setup (Atlas Infra/DevOps lane)
- Model choice tuning beyond MiniLM-L6-v2 default
- min_score tuning (KEI-198 M3 follow-up)
- Per-class custom moduleConfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)