### PR TITLE
[ATLAS] fix(kei190): supervisor symmetric HOLD parsing — recognise [REVIEW:HOLD:callsign]

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -353,7 +353,12 @@ def fetch_pr_comments(pr_number: int) -> list[dict]:
         return []
 
 
-_REVIEW_COMMENT_PATTERN_TMPL = r"\[REVIEW(?::(?:approve|hold(?:-final)))?:{callsign}\]"
+# KEI-190: `-final` made optional. Without the `?`, the prior pattern matched
+# only `[REVIEW:hold-final:callsign]` and missed the plain `[REVIEW:HOLD:callsign]`
+# variant that Scout/Atlas/Aiden/Max actually post — so the supervisor
+# re-dispatched the same HOLD'd PR to the same reviewer every 5 min.
+# Symmetric handling: approve, hold, hold-final all recognised; case-insensitive.
+_REVIEW_COMMENT_PATTERN_TMPL = r"\[REVIEW(?::(?:approve|hold(?:-final)?))?:{callsign}\]"
 
 
 def comment_has_review_marker(body: str, callsign: str) -> bool:

--- a/tests/scripts/test_fleet_supervisor.py
+++ b/tests/scripts/test_fleet_supervisor.py
@@ -484,3 +484,97 @@ def test_find_pr_for_review_callsign_case_insensitive(monkeypatch):
 
     # Despite uppercase AIDEN, the match should fire and the PR should be skipped
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# KEI-190 — symmetric HOLD parsing (recognise [REVIEW:HOLD:callsign] same
+# as [REVIEW:approve:callsign]). Anchored ts 2026-05-18: prior regex required
+# `hold-final` literally and missed the plain `hold` form Scout/Atlas/Aiden
+# post — so supervisor re-dispatched HOLD'd PRs every 5 min to the same agent.
+# ---------------------------------------------------------------------------
+
+
+def test_comment_has_review_marker_bare_form():
+    """Plain `[REVIEW:callsign]` (no middle qualifier) — recognised."""
+    assert fs.comment_has_review_marker("[REVIEW:atlas] APPROVE notes", "atlas") is True
+
+
+def test_comment_has_review_marker_approve_variant():
+    """`[REVIEW:approve:callsign]` — recognised."""
+    assert fs.comment_has_review_marker("[REVIEW:approve:atlas] looks good", "atlas") is True
+
+
+def test_comment_has_review_marker_hold_lowercase():
+    """`[REVIEW:hold:callsign]` (lowercase, no -final) — KEI-190 fix.
+    Prior regex required `hold-final` and missed this form."""
+    assert fs.comment_has_review_marker("[REVIEW:hold:atlas] needs fix", "atlas") is True
+
+
+def test_comment_has_review_marker_hold_uppercase():
+    """`[REVIEW:HOLD:callsign]` (uppercase) — actual form agents post in
+    practice. Was the regression that caused 4+ re-dispatches per HOLD'd PR
+    today (anchor: Scout/Aiden/Max on #981/#982)."""
+    assert fs.comment_has_review_marker("[REVIEW:HOLD:atlas] blockers below", "atlas") is True
+
+
+def test_comment_has_review_marker_hold_final_preserved():
+    """`[REVIEW:HOLD-FINAL:callsign]` — backwards-compat with the variant
+    the prior regex did match. KEI-190 fix must not regress it."""
+    assert fs.comment_has_review_marker("[REVIEW:HOLD-FINAL:atlas] final blockers", "atlas") is True
+
+
+def test_comment_has_review_marker_negative_different_callsign():
+    """Negative path per feedback_negative_path_test_before_approve:
+    `[REVIEW:HOLD:scout]` MUST NOT match for callsign=atlas — otherwise
+    supervisor would skip dispatch even though atlas hasn't reviewed."""
+    assert fs.comment_has_review_marker("[REVIEW:HOLD:scout] needs fix", "atlas") is False
+    assert fs.comment_has_review_marker("[REVIEW:approve:scout] looks good", "atlas") is False
+
+
+def test_comment_has_review_marker_no_marker():
+    """Plain comment body with no review marker — no match."""
+    assert (
+        fs.comment_has_review_marker("Just a regular comment, no review marker here.", "atlas")
+        is False
+    )
+
+
+def test_find_pr_for_review_skips_on_hold_marker(monkeypatch):
+    """End-to-end: agent who already posted `[REVIEW:HOLD:callsign]` MUST
+    NOT be re-dispatched (the real bug that motivated this KEI)."""
+    pr = {
+        "number": 982,
+        "title": "[ATLAS] feat(kei179): dispatcher service",
+        "url": "https://github.com/org/repo/pull/982",
+        "reviews": [],
+    }
+
+    def fake_fetch_comments(pr_number):
+        return [{"body": "[REVIEW:HOLD:scout] 4× S5145 + 3× S7503, fix recipe below"}]
+
+    monkeypatch.setattr(fs, "fetch_pr_comments", fake_fetch_comments)
+    result = fs.find_pr_for_review([pr], "scout")
+    assert result is None, "scout already HOLD'd this PR; supervisor must not re-dispatch"
+
+
+def test_find_pr_for_review_still_dispatches_to_other_agent_on_hold(monkeypatch):
+    """Negative-path E2E: if scout HOLD'd, atlas (different callsign) IS
+    still eligible to review. The HOLD is per-callsign, not per-PR."""
+    pr = {
+        "number": 982,
+        "title": "[ATLAS] feat(kei179): dispatcher service",
+        "url": "https://github.com/org/repo/pull/982",
+        "reviews": [],
+    }
+
+    def fake_fetch_comments(pr_number):
+        return [{"body": "[REVIEW:HOLD:scout] blockers"}]
+
+    monkeypatch.setattr(fs, "fetch_pr_comments", fake_fetch_comments)
+    # atlas hasn't HOLD'd or approved — supervisor should select this PR for atlas
+    # NOTE: is_authored_by_callsign would also filter out PRs authored by the
+    # candidate; we use scout (not authored by atlas) so the find_pr_for_review
+    # decision is purely about review-marker recognition.
+    result = fs.find_pr_for_review([pr], "aiden")
+    assert result is not None
+    assert result["number"] == 982


### PR DESCRIPTION
## Summary

Closes KEI-190 (KEI-H per Elliot's parallel-dispatch sequence). 1-char regex fix on the fleet supervisor's review-marker recognition.

## Root cause (Aiden 2026-05-18 anchor)

> \"Scout + Max + I each got 4+ re-dispatches on #981/#982 today\"

Prior regex on \`scripts/fleet_supervisor.py:356\`:

\`\`\`python
_REVIEW_COMMENT_PATTERN_TMPL = r\"\[REVIEW(?::(?:approve|hold(?:-final)))?:{callsign}\]\"
\`\`\`

The inner \`(?:-final)\` is **required** — no \`?\` suffix. So the regex matches \`[REVIEW:hold-final:callsign]\` but **misses** \`[REVIEW:HOLD:callsign]\` / \`[REVIEW:hold:callsign]\` — the actual form agents post in practice. Supervisor re-dispatched HOLD'd PRs every 5 min to the same reviewer because their HOLD comment wasn't recognised.

## Fix (1 character)

\`\`\`diff
- _REVIEW_COMMENT_PATTERN_TMPL = r\"\[REVIEW(?::(?:approve|hold(?:-final)))?:{callsign}\]\"
+ _REVIEW_COMMENT_PATTERN_TMPL = r\"\[REVIEW(?::(?:approve|hold(?:-final)?))?:{callsign}\]\"
\`\`\`

One \`?\` after \`(?:-final)\` makes \`-final\` truly optional. Symmetric recognition of:
- bare \`[REVIEW:callsign]\`
- \`[REVIEW:approve:callsign]\`
- \`[REVIEW:hold:callsign]\` (lowercase, no -final)
- \`[REVIEW:HOLD:callsign]\` (uppercase, no -final — **the regression**)
- \`[REVIEW:hold-final:callsign]\` (still recognised — backwards-compat preserved)
- \`[REVIEW:HOLD-FINAL:callsign]\`

## Empirical verification (verbatim)

**Before fix** — \`[REVIEW:HOLD:atlas]\` returned False:
\`\`\`
match=    1  body='[REVIEW:atlas] APPROVE'
match=    1  body='[REVIEW:approve:atlas]'
match=    0  body='[REVIEW:HOLD:atlas] needs fix'      ← BUG
match=    0  body='[REVIEW:hold:atlas] lowercase'      ← BUG
match=    1  body='[REVIEW:hold-final:atlas] final'
\`\`\`

**After fix** — all variants match, negative paths still reject:
\`\`\`
match=    1  body='[REVIEW:atlas] APPROVE'
match=    1  body='[REVIEW:approve:atlas]'
match=    1  body='[REVIEW:HOLD:atlas] needs fix'           ← FIXED
match=    1  body='[REVIEW:hold:atlas] lowercase'           ← FIXED
match=    1  body='[REVIEW:hold-final:atlas] final'
match=    1  body='[REVIEW:HOLD-FINAL:atlas] caps final'
match=    0  body='[REVIEW:approve:scout] not atlas'        ← still rejected (good)
match=    0  body='[REVIEW:HOLD:scout] different callsign'  ← still rejected (good)
\`\`\`

## Tests

25/25 pass — 16 inherited + 9 new for KEI-190:

| Test | Asserts |
|---|---|
| \`test_comment_has_review_marker_bare_form\` | \`[REVIEW:atlas]\` matches |
| \`test_comment_has_review_marker_approve_variant\` | \`[REVIEW:approve:atlas]\` matches |
| \`test_comment_has_review_marker_hold_lowercase\` | \`[REVIEW:hold:atlas]\` matches (was bug) |
| \`test_comment_has_review_marker_hold_uppercase\` | \`[REVIEW:HOLD:atlas]\` matches (was bug) |
| \`test_comment_has_review_marker_hold_final_preserved\` | \`[REVIEW:HOLD-FINAL:atlas]\` matches (backwards-compat) |
| \`test_comment_has_review_marker_negative_different_callsign\` | \`[REVIEW:HOLD:scout]\` does NOT match for atlas (negative path) |
| \`test_comment_has_review_marker_no_marker\` | Plain comment with no marker — no match |
| \`test_find_pr_for_review_skips_on_hold_marker\` | E2E: agent who HOLD'd MUST NOT be re-dispatched |
| \`test_find_pr_for_review_still_dispatches_to_other_agent_on_hold\` | E2E: HOLD is per-callsign — different agent still eligible |

Negative-path coverage per \`feedback_negative_path_test_before_approve\`.

## Test plan

- [x] \`pytest tests/scripts/test_fleet_supervisor.py -v\` — 25/25 passed.
- [x] \`ruff check\` — All checks passed.
- [x] \`ruff format --check\` — 2 files already formatted (after auto-reformat).
- [x] Empirical regex evaluation pre/post fix — output above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)