### PR TITLE
[SCOUT] feat(kei198): score-distribution-aware citation selection in agent_query

### DIFF
--- a/src/retrieval/agent_query.py
+++ b/src/retrieval/agent_query.py
@@ -164,6 +164,43 @@ def _synthesise_answer(citations: tuple[Citation, ...], max_tokens: int) -> str:
     return answer[:char_cap]
 
 
+def _select_citations(
+    citations: tuple[Citation, ...],
+    min_score: float,
+    score_distribution_aware: bool,
+) -> tuple[Citation, ...]:
+    """KEI-198 — pick the best citations to emit.
+
+    Default (score_distribution_aware=True):
+        1. Sort by score descending.
+        2. If the top score is > 0.0 (meaningful distribution), keep citations
+           where score >= min_score; if that drops everything, fall back to the
+           sorted top-N so callers still see best-available.
+        3. If ALL scores are exactly 0.0 (sentinel for the KEI-192 vectorless
+           regression), skip the min_score filter and return the sorted top-N
+           anyway — discoverable retrieval beats silent emptiness.
+
+    Legacy (score_distribution_aware=False):
+        Apply the hard min_score floor only; matches pre-KEI-198 behaviour.
+
+    The function always returns a tuple sorted by score descending so callers
+    that look at `[0]` always get the strongest citation.
+    """
+    if not citations:
+        return ()
+    ranked = tuple(sorted(citations, key=lambda c: c.score, reverse=True))
+    if not score_distribution_aware:
+        # Legacy hard-floor only.
+        return tuple(c for c in ranked if c.score >= min_score)
+    top_score = ranked[0].score
+    if top_score <= 0.0:
+        # KEI-192 vectorless sentinel — all scores are zero, return best-N anyway.
+        return ranked
+    qualified = tuple(c for c in ranked if c.score >= min_score)
+    # If the threshold drops everything, surface best-available instead of nothing.
+    return qualified or ranked
+
+
 def query(
     text: str,
     *,
@@ -174,6 +211,7 @@ def query(
     min_score: float = DEFAULT_MIN_SCORE,
     k_initial: int = orchestrator.DEFAULT_K_INITIAL,
     k_returned: int = orchestrator.DEFAULT_K_RETURNED,
+    score_distribution_aware: bool = True,
 ) -> QueryResult:
     """Run one retrieval query.
 
@@ -183,12 +221,18 @@ def query(
         collections: Which Weaviate collections to search (default 3-tuple
             covers the most common precision-retrieval surfaces).
         max_tokens: Response synthesis ceiling (KEI-55, 500-token default).
-        citation_required: When True (default) and no citation passes
-            `min_score`, return `answer=""` instead of synthesising.
-        min_score: Floor for citation eligibility under
-            `citation_required=True`.
+        citation_required: When True (default) and the ranked citation list
+            is empty, return `answer=""` instead of synthesising.
+        min_score: Soft floor under score_distribution_aware=True
+            (KEI-198 default); hard floor under score_distribution_aware=False
+            (legacy pre-KEI-198 behaviour).
         k_initial: ANN top-K per collection.
         k_returned: Citations returned (post-rank — raw ANN in PR1).
+        score_distribution_aware: KEI-198 — when True (default), the
+            min_score filter becomes a SOFT threshold: empty filter result
+            falls back to the sorted top-N rather than dropping everything,
+            and all-zero scores (vectorless regression sentinel) skip the
+            filter entirely. Set False to restore the legacy hard floor.
 
     Returns:
         `QueryResult` with answer + citations + elapsed_ms + bypass flag.
@@ -201,12 +245,10 @@ def query(
         k_returned=k_returned,
     )
     citations = tuple(_node_to_citation(n) for n in outcome.nodes)
-    qualified = tuple(c for c in citations if c.score >= min_score)
-    if citation_required and not qualified:
+    emitted_citations = _select_citations(citations, min_score, score_distribution_aware)
+    if citation_required and not emitted_citations:
         answer = ""
-        emitted_citations: tuple[Citation, ...] = ()
     else:
-        emitted_citations = qualified or citations
         answer = _synthesise_answer(emitted_citations, max_tokens)
     elapsed_ms = int((time.monotonic() - started) * 1000)
     top = emitted_citations[0] if emitted_citations else None

--- a/tests/retrieval/test_agent_query.py
+++ b/tests/retrieval/test_agent_query.py
@@ -54,14 +54,21 @@ def test_query_returns_top_citation_when_above_min_score():
     assert result.bypass_rerank is True
 
 
-def test_citation_required_returns_empty_answer_when_below_threshold():
+def test_citation_required_returns_empty_answer_when_below_threshold_legacy():
+    """Legacy pre-KEI-198 behaviour: hard min_score floor drops everything
+    → citation_required=True returns answer="". Preserved via
+    score_distribution_aware=False."""
     nodes = (_mk_node("low-quality match", 0.20),)
     with patch(
         "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
         return_value=_outcome(nodes),
     ):
         result = agent_query.query(
-            "anything?", agent="test", citation_required=True, min_score=0.50
+            "anything?",
+            agent="test",
+            citation_required=True,
+            min_score=0.50,
+            score_distribution_aware=False,
         )
     assert result.answer == ""
     assert result.citations == ()
@@ -194,3 +201,125 @@ def test_record_event_strips_asyncpg_dialect_from_dsn(monkeypatch):
     # `postgresql+asyncpg://` raw env value.
     assert captured["dsn"].startswith("postgresql://")
     assert "+asyncpg" not in captured["dsn"]
+
+
+# ============================================================================
+# KEI-198 — score-distribution-aware citation selection
+# ============================================================================
+
+
+def test_kei198_all_zero_scores_returns_top_n_anyway():
+    """KEI-192 vectorless sentinel: all scores 0.0 → top-N returned not nothing."""
+    nodes = (
+        _mk_node("relevant-looking content", 0.0),
+        _mk_node("also looks ok", 0.0),
+        _mk_node("third one", 0.0),
+    )
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
+        result = agent_query.query(
+            "any query?",
+            agent="test",
+            citation_required=True,
+            min_score=0.50,
+            # score_distribution_aware=True is the default
+        )
+    # All three citations come back despite scores being below the 0.50 floor.
+    assert len(result.citations) == 3
+    assert result.answer != ""
+
+
+def test_kei198_low_score_fallback_returns_best_available():
+    """When the min_score filter would drop everything, return ranked top-N."""
+    nodes = (
+        _mk_node("low-score content", 0.20),
+        _mk_node("very-low-score content", 0.10),
+    )
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
+        result = agent_query.query(
+            "any query?",
+            agent="test",
+            citation_required=True,
+            min_score=0.50,  # would drop both under legacy hard floor
+        )
+    # New behaviour: sorted top-N returned instead of empty.
+    assert len(result.citations) == 2
+    assert result.citations[0].score >= result.citations[1].score
+    assert result.answer != ""
+
+
+def test_kei198_mixed_scores_returns_highest_first():
+    """Citations sorted by score descending — best result is index [0]."""
+    nodes = (
+        _mk_node("middle score", 0.55),
+        _mk_node("highest score", 0.90),
+        _mk_node("lowest score", 0.30),
+    )
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
+        result = agent_query.query(
+            "any query?",
+            agent="test",
+            citation_required=True,
+            min_score=0.50,
+        )
+    # Two pass the floor (0.90 and 0.55); 0.30 dropped under meaningful distribution.
+    assert len(result.citations) == 2
+    assert result.citations[0].score == pytest.approx(0.90)
+    assert result.citations[1].score == pytest.approx(0.55)
+
+
+def test_kei198_empty_retrieval_still_empty():
+    """No nodes returned → citation_required=True still gives empty answer."""
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(()),
+    ):
+        result = agent_query.query("any?", agent="test", citation_required=True)
+    assert result.answer == ""
+    assert result.citations == ()
+
+
+def test_kei198_legacy_mode_preserves_hard_floor():
+    """score_distribution_aware=False keeps the pre-KEI-198 behaviour."""
+    nodes = (_mk_node("low", 0.10),)
+    with patch(
+        "src.retrieval.agent_query.orchestrator.retrieve_with_outcome",
+        return_value=_outcome(nodes),
+    ):
+        result = agent_query.query(
+            "q?",
+            agent="test",
+            citation_required=True,
+            min_score=0.50,
+            score_distribution_aware=False,
+        )
+    assert result.citations == ()
+    assert result.answer == ""
+
+
+def test_kei198_select_citations_helper_sorts_desc():
+    """_select_citations returns sorted-desc-by-score regardless of input order."""
+    from src.retrieval.agent_query import Citation, _select_citations
+
+    cites = (
+        Citation(source_id="a", collection="X", score=0.3, excerpt=""),
+        Citation(source_id="b", collection="X", score=0.9, excerpt=""),
+        Citation(source_id="c", collection="X", score=0.6, excerpt=""),
+    )
+    out = _select_citations(cites, min_score=0.5, score_distribution_aware=True)
+    assert [c.source_id for c in out] == ["b", "c"]
+
+
+def test_kei198_select_citations_empty_input_returns_empty():
+    """Defensive: empty input doesn't raise."""
+    from src.retrieval.agent_query import _select_citations
+
+    assert _select_citations((), min_score=0.5, score_distribution_aware=True) == ()


### PR DESCRIPTION
## Summary

KEI-198 (M3 — KEI-192 follow-up): replaces the hard `min_score=0.50` floor in `agent_query.query()` with a top-N picker. Always returns best-available citations, falls back to sorted top-N when the soft threshold would drop everything, and skips the filter entirely when all scores are 0.0 (KEI-192 vectorless regression sentinel).

**Linear:** [KEI-198](https://linear.app/keiracom/issue/KEI-198) · **Branch:** off `08daf876f`

## Policy

```
score_distribution_aware=True  (NEW DEFAULT)
  1. Sort citations by score descending.
  2. If top score > 0.0:
       Apply min_score filter — but if it drops everything, fall back to
       sorted top-N. Discoverable retrieval > silent emptiness.
  3. If all scores == 0.0 (vectorless sentinel):
       Skip filter entirely; return top-N anyway.

score_distribution_aware=False  (LEGACY OPT-OUT)
  Hard min_score floor as in pre-KEI-198 code. Available for callers
  with a real reason to drop low-score matches.
```

`citation_required=True` still gates EMPTY result (no citations at all) — semantics aligned with the new policy.

## What lands (2 files, +181/-10)

| File | Change |
|---|---|
| `src/retrieval/agent_query.py` | New `_select_citations` helper + `score_distribution_aware: bool = True` kwarg on `query()` |
| `tests/retrieval/test_agent_query.py` | 7 new KEI-198 tests + 1 existing test renamed/updated to verify legacy opt-out |

## Verbatim verify

```
$ pytest tests/retrieval/test_agent_query.py -q
................                                                         [100%]
16 passed in 0.20s

$ ruff check + format
All checks passed!
```

## Tests (7 new)

- `test_kei198_all_zero_scores_returns_top_n_anyway` — vectorless sentinel path
- `test_kei198_low_score_fallback_returns_best_available` — soft-threshold fallback
- `test_kei198_mixed_scores_returns_highest_first` — sorted desc + hard filter applies
- `test_kei198_empty_retrieval_still_empty` — citation_required still gates empty
- `test_kei198_legacy_mode_preserves_hard_floor` — `score_distribution_aware=False` opt-out
- `test_kei198_select_citations_helper_sorts_desc` — unit on the helper
- `test_kei198_select_citations_empty_input_returns_empty` — defensive

Plus 1 existing test renamed (`_legacy`) + updated to set `score_distribution_aware=False`.

## Acceptance per KEI-198

- [x] Synthetic 0-score citations return top-N (not empty)
- [x] Mixed-score citations return highest-scored first
- [x] Empty retrieval: `citation_required=True` still returns empty answer
- [x] Legacy hard-floor preserved as opt-out
- [ ] **Integration test against vectorless collections returns SOMETHING** — gated on KEI-196 cutover (PR #994 scaffold). Post-merge probe: `agent_query.query("test", agent="scout")` returns non-empty against current Discoveries.

## Cross-reference

- KEI-196 (PR #994) — Weaviate vectorizer cutover; until the live re-ingest runs, all scores are 0.0 and KEI-198's sentinel branch is what actually returns citations.
- KEI-103 (merged) — wired `agent_query.query()` into `bd claim`; the score-aware behaviour helps every claim get useful recall.
- `feedback_sonarcloud_verify_pattern` — applies to this PR's review: run both `/api/issues/search` AND `/api/qualitygates/project_status` before APPROVE.

## Out of scope

- Empirical post-KEI-196 confirmation (gated on the live re-ingest)
- Per-collection score-threshold tuning (future micro-KEI if telemetry shows the soft-floor pattern needs adjusting)
- Reranker integration (PR1 has bypass_rerank=True; rerank pass is a separate KEI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)