### PR TITLE
[AIDEN] feat(kei199): supervisor PR-existence pre-check — skip claim if open PR mentions KEI

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -18,6 +18,7 @@ import datetime as _dt
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -202,23 +203,89 @@ def get_active_claim(conn: psycopg.Connection, callsign: str) -> tuple[str, str]
     return (row[0], row[1]) if row else None
 
 
+_KEI_ID_RE = re.compile(r"\bkei[-\s]?\d+\b", re.IGNORECASE)
+
+
+def fetch_open_pr_kei_ids() -> set[str]:
+    """KEI-199 — return set of KEI-NNN identifiers mentioned in OPEN PR titles+bodies.
+
+    Used by claim_next_task() as a pre-claim filter to prevent the auto-claim
+    loop assigning work that's already in flight via an OPEN PR. Anchor:
+    4 drift-syncs in the 2026-05-17→18 session (KEI-90 / 122 / 187 / 188)
+    where agents were re-claimed onto KEIs that peers had already shipped.
+
+    Returns empty set on any gh CLI failure (fail-open — preserves prior
+    claim behaviour rather than blocking all claims on a CLI hiccup).
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--state", "open", "--json", "title,body", "--limit", "100"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (subprocess.SubprocessError, OSError):
+        log.debug("KEI-199: gh pr list failed — fail-open (returning empty set)")
+        return set()
+    if result.returncode != 0:
+        log.debug("KEI-199: gh pr list exit=%d — fail-open", result.returncode)
+        return set()
+    try:
+        prs = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return set()
+    kei_ids: set[str] = set()
+    for pr in prs:
+        title = pr.get("title") or ""
+        body = pr.get("body") or ""
+        for m in _KEI_ID_RE.findall(title) + _KEI_ID_RE.findall(body):
+            # Normalize to canonical KEI-NNN uppercase form (titles often
+            # carry lowercase "kei199" in commit-scope, identifiers in DB
+            # are always uppercase).
+            digits = "".join(c for c in m if c.isdigit())
+            if digits:
+                kei_ids.add(f"KEI-{digits}")
+    return kei_ids
+
+
 def claim_next_task(
     conn: psycopg.Connection, callsign: str, phase_max: int
 ) -> tuple[str, str] | None:
-    """Attempt to claim the highest-priority available task. Returns (id, title) or None."""
+    """Attempt to claim the highest-priority available task. Returns (id, title) or None.
+
+    KEI-199 — filters out KEIs that already have an OPEN PR (title or body
+    mentions). Without this, the supervisor loop re-claims already-shipped
+    work (KEI-90 / 122 / 187 / 188 drift-syncs in the 2026-05-17→18 session).
+    """
+    open_pr_keis = fetch_open_pr_kei_ids()
     with conn.cursor() as cur:
-        cur.execute(
-            """
-            SELECT id, title FROM public.tasks
-            WHERE status = 'available'
-              AND (phase IS NULL OR phase <= %s)
-              AND (is_parent IS NULL OR is_parent = false)
-            ORDER BY priority ASC, created_at ASC
-            LIMIT 1
-            FOR UPDATE SKIP LOCKED
-            """,
-            (phase_max,),
-        )
+        if open_pr_keis:
+            cur.execute(
+                """
+                SELECT id, title FROM public.tasks
+                WHERE status = 'available'
+                  AND (phase IS NULL OR phase <= %s)
+                  AND (is_parent IS NULL OR is_parent = false)
+                  AND id != ALL(%s::text[])
+                ORDER BY priority ASC, created_at ASC
+                LIMIT 1
+                FOR UPDATE SKIP LOCKED
+                """,
+                (phase_max, sorted(open_pr_keis)),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT id, title FROM public.tasks
+                WHERE status = 'available'
+                  AND (phase IS NULL OR phase <= %s)
+                  AND (is_parent IS NULL OR is_parent = false)
+                ORDER BY priority ASC, created_at ASC
+                LIMIT 1
+                FOR UPDATE SKIP LOCKED
+                """,
+                (phase_max,),
+            )
         row = cur.fetchone()
         if not row:
             return None

--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -205,6 +205,57 @@ def get_active_claim(conn: psycopg.Connection, callsign: str) -> tuple[str, str]
 
 _KEI_ID_RE = re.compile(r"\bkei[-\s]?\d+\b", re.IGNORECASE)
 
+# KEI-204 — dep-blocked drift filter. Captures the canonical phrasings used
+# by Elliot's filing scripts + Linear convention. Each pattern's capture
+# group is the KEI-NNN identifier that this row depends on; if any captured
+# blocker is still status != 'done', claim_next_task skips the row.
+# Patterns observed empirically across this session's 8 drift cases:
+#   "FOLLOW-UP after KEI-185"  (KEI-191)
+#   "depends on KEI-N"         (Linear convention)
+#   "gated on KEI-N"
+#   "blocked on KEI-N"
+#   "sub of KEI-185"           (KEI-193 / KEI-194)
+#   "(KEI-192 follow-up)"      (KEI-196 / KEI-197 / KEI-198)
+_BLOCKER_PATTERNS = [
+    re.compile(r"FOLLOW[\s-]?UP\s+after\s+(KEI-\d+)", re.IGNORECASE),
+    re.compile(r"depends\s+on\s+(KEI-\d+)", re.IGNORECASE),
+    re.compile(r"gated\s+on\s+(KEI-\d+)", re.IGNORECASE),
+    re.compile(r"blocked\s+on\s+(KEI-\d+)", re.IGNORECASE),
+    re.compile(r"sub\s+of\s+(KEI-\d+)", re.IGNORECASE),
+    re.compile(r"\((KEI-\d+)\s+follow[\s-]?up\)", re.IGNORECASE),
+]
+
+
+def extract_blocker_keis(text: str) -> set[str]:
+    """KEI-204 — extract KEI-NNN identifiers this row depends on from its
+    title+description. Uses the 6 canonical phrasings observed empirically
+    across the 2026-05-17→18 session's drift cases.
+
+    Returns the canonical uppercase set; caller is responsible for the
+    status='done' check against public.tasks.
+    """
+    if not text:
+        return set()
+    blockers: set[str] = set()
+    for pat in _BLOCKER_PATTERNS:
+        for m in pat.findall(text):
+            digits = "".join(c for c in m if c.isdigit())
+            if digits:
+                blockers.add(f"KEI-{digits}")
+    return blockers
+
+
+def _unfinished_blockers(cur: psycopg.Cursor, blocker_ids: set[str]) -> set[str]:
+    """KEI-204 — return the subset of blocker_ids whose tasks.status != 'done'.
+    Empty set means all blockers cleared; row is claimable."""
+    if not blocker_ids:
+        return set()
+    cur.execute(
+        "SELECT id FROM public.tasks WHERE id = ANY(%s::text[]) AND status != 'done'",
+        (sorted(blocker_ids),),
+    )
+    return {row[0] for row in cur.fetchall()}
+
 
 def fetch_open_pr_kei_ids() -> set[str]:
     """KEI-199 — return set of KEI-NNN identifiers mentioned in OPEN PR titles+bodies.
@@ -248,6 +299,9 @@ def fetch_open_pr_kei_ids() -> set[str]:
     return kei_ids
 
 
+_CANDIDATE_LIMIT = 10  # KEI-204 — top-N candidates to iterate; bounds dep-blocked rescan cost
+
+
 def claim_next_task(
     conn: psycopg.Connection, callsign: str, phase_max: int
 ) -> tuple[str, str] | None:
@@ -256,50 +310,67 @@ def claim_next_task(
     KEI-199 — filters out KEIs that already have an OPEN PR (title or body
     mentions). Without this, the supervisor loop re-claims already-shipped
     work (KEI-90 / 122 / 187 / 188 drift-syncs in the 2026-05-17→18 session).
+
+    KEI-204 — filters out FOLLOW-UP / sub-of / depends-on / gated-on rows
+    whose blocking KEI is still status != 'done'. Anchor: KEI-191
+    'FOLLOW-UP after KEI-C (KEI-185 Nova spawn)' was dispatched 3x in the
+    session despite the explicit dep gate (Max yield, Scout yield, Aiden
+    yield). Six canonical phrasings parsed via _BLOCKER_PATTERNS.
     """
     open_pr_keis = fetch_open_pr_kei_ids()
     with conn.cursor() as cur:
         if open_pr_keis:
             cur.execute(
                 """
-                SELECT id, title FROM public.tasks
+                SELECT id, title, COALESCE(description, '') FROM public.tasks
                 WHERE status = 'available'
                   AND (phase IS NULL OR phase <= %s)
                   AND (is_parent IS NULL OR is_parent = false)
                   AND id != ALL(%s::text[])
                 ORDER BY priority ASC, created_at ASC
-                LIMIT 1
+                LIMIT %s
                 FOR UPDATE SKIP LOCKED
                 """,
-                (phase_max, sorted(open_pr_keis)),
+                (phase_max, sorted(open_pr_keis), _CANDIDATE_LIMIT),
             )
         else:
             cur.execute(
                 """
-                SELECT id, title FROM public.tasks
+                SELECT id, title, COALESCE(description, '') FROM public.tasks
                 WHERE status = 'available'
                   AND (phase IS NULL OR phase <= %s)
                   AND (is_parent IS NULL OR is_parent = false)
                 ORDER BY priority ASC, created_at ASC
-                LIMIT 1
+                LIMIT %s
                 FOR UPDATE SKIP LOCKED
                 """,
-                (phase_max,),
+                (phase_max, _CANDIDATE_LIMIT),
             )
-        row = cur.fetchone()
-        if not row:
-            return None
-        task_id, title = row[0], row[1]
-        cur.execute(
-            """
-            UPDATE public.tasks
-            SET status = 'active', claimed_by = %s, claimed_at = NOW()
-            WHERE id = %s
-            """,
-            (callsign, task_id),
-        )
-    conn.commit()
-    return (task_id, title)
+        candidates = cur.fetchall()
+        for row in candidates:
+            task_id, title, description = row[0], row[1], row[2] or ""
+            blockers = extract_blocker_keis(title + "\n" + description)
+            if blockers:
+                unfinished = _unfinished_blockers(cur, blockers)
+                if unfinished:
+                    log.debug(
+                        "KEI-204: %s skipped — blocked by %s",
+                        task_id,
+                        sorted(unfinished),
+                    )
+                    continue
+            cur.execute(
+                """
+                UPDATE public.tasks
+                SET status = 'active', claimed_by = %s, claimed_at = NOW()
+                WHERE id = %s
+                """,
+                (callsign, task_id),
+            )
+            conn.commit()
+            return (task_id, title)
+    # Either no candidates OR all candidates dep-blocked
+    return None
 
 
 def release_stale_claims(conn: psycopg.Connection) -> int:

--- a/tests/scripts/test_fleet_supervisor.py
+++ b/tests/scripts/test_fleet_supervisor.py
@@ -533,42 +533,62 @@ def test_fetch_open_pr_kei_ids_handles_malformed_json(monkeypatch):
     assert ids == set()
 
 
+class _FakeCur:
+    """Test helper: configurable cursor returning preset rows."""
+
+    def __init__(self, candidates=None, blocker_rows=None):
+        self.candidates = list(candidates or [])
+        self.blocker_rows = list(blocker_rows or [])
+        self._next_fetchall = self.candidates
+        self.executed = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        # Heuristic: if the SQL references task_verifications OR public.tasks
+        # WHERE id = ANY (blocker lookup), the NEXT fetchall returns blocker_rows.
+        # Otherwise it returns the candidate list.
+        if "status != 'done'" in sql and "ANY" in sql:
+            self._next_fetchall = self.blocker_rows
+        else:
+            self._next_fetchall = self.candidates
+
+    def fetchall(self):
+        rows = self._next_fetchall
+        # Subsequent fetchall calls return [] unless re-armed by another execute.
+        self._next_fetchall = []
+        return rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, cur: _FakeCur):
+        self._cur = cur
+
+    def cursor(self):
+        return self._cur
+
+    def commit(self):
+        pass
+
+
 def test_claim_next_task_excludes_keis_with_open_prs(monkeypatch):
     """KEI-199 — when an open PR mentions KEI-N, claim_next_task SKIPS that
     KEI-N in the SELECT (id != ALL excluded_keis). Anchor scenario: the 4
     drift-syncs would have been prevented by this filter."""
-    # Mock fetch_open_pr_kei_ids to return one in-flight KEI
     with patch.object(fs, "fetch_open_pr_kei_ids", return_value={"KEI-188"}):
-        # Build a fake conn that records cursor.execute args
-        executed_queries = []
-
-        class _FakeCur:
-            def execute(self, sql, params=None):
-                executed_queries.append((sql, params))
-
-            def fetchone(self):
-                return ("KEI-200", "different task")
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_):
-                return False
-
-        class _FakeConn:
-            def cursor(self):
-                return _FakeCur()
-
-            def commit(self):
-                pass
-
-        result = fs.claim_next_task(_FakeConn(), "aiden", 99)
+        cur = _FakeCur(candidates=[("KEI-200", "different task", "")])
+        result = fs.claim_next_task(_FakeConn(cur), "aiden", 99)
         assert result == ("KEI-200", "different task")
-        # The SELECT must include id != ALL(...) with KEI-188 in the excluded list
-        select_query = next(q for q, _ in executed_queries if "SELECT id, title" in q)
+        select_query = next(q for q, _ in cur.executed if "SELECT id, title" in q)
         assert "!= ALL" in select_query
-        # Params should include the sorted exclusion list
-        select_params = next(p for q, p in executed_queries if "SELECT id, title" in q)
+        select_params = next(p for q, p in cur.executed if "SELECT id, title" in q)
+        # phase_max, sorted(open_pr_keis), candidate_limit
+        assert select_params[0] == 99
         assert select_params[1] == ["KEI-188"]
 
 
@@ -576,29 +596,77 @@ def test_claim_next_task_no_open_prs_uses_unfiltered_query(monkeypatch):
     """KEI-199 — when no open PRs exist (or fetch fails), the SELECT runs
     without the exclusion clause (preserves prior behaviour)."""
     with patch.object(fs, "fetch_open_pr_kei_ids", return_value=set()):
-        executed_queries = []
-
-        class _FakeCur:
-            def execute(self, sql, params=None):
-                executed_queries.append((sql, params))
-
-            def fetchone(self):
-                return ("KEI-300", "available task")
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_):
-                return False
-
-        class _FakeConn:
-            def cursor(self):
-                return _FakeCur()
-
-            def commit(self):
-                pass
-
-        result = fs.claim_next_task(_FakeConn(), "aiden", 99)
+        cur = _FakeCur(candidates=[("KEI-300", "available task", "")])
+        result = fs.claim_next_task(_FakeConn(cur), "aiden", 99)
         assert result == ("KEI-300", "available task")
-        select_query = next(q for q, _ in executed_queries if "SELECT id, title" in q)
+        select_query = next(q for q, _ in cur.executed if "SELECT id, title" in q)
         assert "!= ALL" not in select_query
+
+
+# ─── KEI-204: dep-blocked drift filter ──────────────────────────────────────
+
+
+def test_extract_blocker_keis_matches_six_canonical_phrasings():
+    """KEI-204 — the 6 patterns from this session's drift cases all extract."""
+    samples = {
+        "FOLLOW-UP after KEI-185": "KEI-185",
+        "depends on KEI-100": "KEI-100",
+        "gated on KEI-50": "KEI-50",
+        "blocked on KEI-99": "KEI-99",
+        "sub of KEI-185": "KEI-185",
+        "(KEI-192 follow-up)": "KEI-192",
+    }
+    for text, expected in samples.items():
+        blockers = fs.extract_blocker_keis(text)
+        assert expected in blockers, f"failed to extract {expected} from {text!r}"
+
+
+def test_extract_blocker_keis_empty_on_nondep_text():
+    """KEI-204 — no false positives when text mentions KEI-N without dep phrasing."""
+    assert fs.extract_blocker_keis("KEI-200: build feature") == set()
+    assert fs.extract_blocker_keis("") == set()
+    assert fs.extract_blocker_keis(None) == set()
+
+
+def test_claim_next_task_skips_dep_blocked_candidate(monkeypatch):
+    """KEI-204 — when top candidate's title says 'FOLLOW-UP after KEI-X' and
+    KEI-X is still status != 'done', claim_next_task skips it and tries next."""
+    with patch.object(fs, "fetch_open_pr_kei_ids", return_value=set()):
+        # Candidate 1: blocked on KEI-185 (not done). Candidate 2: clean.
+        cur = _FakeCur(
+            candidates=[
+                ("KEI-191", "FOLLOW-UP after KEI-185 migration", "details"),
+                ("KEI-300", "unblocked task", "no deps"),
+            ],
+            blocker_rows=[("KEI-185",)],  # KEI-185 still active = unfinished
+        )
+        result = fs.claim_next_task(_FakeConn(cur), "aiden", 99)
+        # Skip the blocked candidate, claim the clean one
+        assert result == ("KEI-300", "unblocked task")
+
+
+def test_claim_next_task_claims_dep_blocked_when_blocker_done(monkeypatch):
+    """KEI-204 — when 'FOLLOW-UP after KEI-X' AND KEI-X status == 'done',
+    claim_next_task proceeds with that row."""
+    with patch.object(fs, "fetch_open_pr_kei_ids", return_value=set()):
+        cur = _FakeCur(
+            candidates=[("KEI-191", "FOLLOW-UP after KEI-185 migration", "")],
+            blocker_rows=[],  # empty → KEI-185 is done OR not found
+        )
+        result = fs.claim_next_task(_FakeConn(cur), "aiden", 99)
+        assert result == ("KEI-191", "FOLLOW-UP after KEI-185 migration")
+
+
+def test_claim_next_task_returns_none_when_all_candidates_blocked(monkeypatch):
+    """KEI-204 — if every top-N candidate is dep-blocked, return None
+    instead of claiming a blocked row."""
+    with patch.object(fs, "fetch_open_pr_kei_ids", return_value=set()):
+        cur = _FakeCur(
+            candidates=[
+                ("KEI-301", "depends on KEI-100", ""),
+                ("KEI-302", "blocked on KEI-200", ""),
+            ],
+            blocker_rows=[("KEI-100",), ("KEI-200",)],  # both blockers unfinished
+        )
+        result = fs.claim_next_task(_FakeConn(cur), "aiden", 99)
+        assert result is None

--- a/tests/scripts/test_fleet_supervisor.py
+++ b/tests/scripts/test_fleet_supervisor.py
@@ -7,6 +7,7 @@ Covers all 6 scenarios + CEO post format check.
 from __future__ import annotations
 
 import datetime as _dt
+import json
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -484,3 +485,120 @@ def test_find_pr_for_review_callsign_case_insensitive(monkeypatch):
 
     # Despite uppercase AIDEN, the match should fire and the PR should be skipped
     assert result is None
+
+
+# ─── KEI-199: PR-existence pre-check for claim dispatch ─────────────────────
+
+
+def test_fetch_open_pr_kei_ids_extracts_from_title_and_body(monkeypatch):
+    """KEI-199 — open PR titles + bodies are scanned for KEI-NNN tokens.
+    Anchor: 4 drift-syncs (KEI-90/122/187/188) caused by supervisor
+    re-claiming work already in-flight via OPEN PRs."""
+    fake_output = json.dumps(
+        [
+            {
+                "title": "[AIDEN] feat(kei199): supervisor PR-existence pre-check",
+                "body": "Closes KEI-199",
+            },
+            {"title": "[MAX] fix(kei188): migration apply gate", "body": "Also touches KEI-90"},
+            {"title": "[ELLIOT] docs(no-kei)", "body": "no kei mentioned"},
+        ]
+    )
+    fake_result = MagicMock(returncode=0, stdout=fake_output)
+    with patch("subprocess.run", return_value=fake_result):
+        ids = fs.fetch_open_pr_kei_ids()
+    assert ids == {"KEI-199", "KEI-188", "KEI-90"}
+
+
+def test_fetch_open_pr_kei_ids_fail_open_on_gh_error(monkeypatch):
+    """KEI-199 — gh CLI failure must NOT block claims (fail-open)."""
+    fake_result = MagicMock(returncode=1, stdout="", stderr="gh: not found")
+    with patch("subprocess.run", return_value=fake_result):
+        ids = fs.fetch_open_pr_kei_ids()
+    assert ids == set()
+
+
+def test_fetch_open_pr_kei_ids_fail_open_on_subprocess_exception(monkeypatch):
+    """KEI-199 — subprocess.SubprocessError or OSError still fail-open."""
+    with patch("subprocess.run", side_effect=OSError("no gh in PATH")):
+        ids = fs.fetch_open_pr_kei_ids()
+    assert ids == set()
+
+
+def test_fetch_open_pr_kei_ids_handles_malformed_json(monkeypatch):
+    """KEI-199 — JSON parse failure fail-opens to empty set."""
+    fake_result = MagicMock(returncode=0, stdout="not valid json")
+    with patch("subprocess.run", return_value=fake_result):
+        ids = fs.fetch_open_pr_kei_ids()
+    assert ids == set()
+
+
+def test_claim_next_task_excludes_keis_with_open_prs(monkeypatch):
+    """KEI-199 — when an open PR mentions KEI-N, claim_next_task SKIPS that
+    KEI-N in the SELECT (id != ALL excluded_keis). Anchor scenario: the 4
+    drift-syncs would have been prevented by this filter."""
+    # Mock fetch_open_pr_kei_ids to return one in-flight KEI
+    with patch.object(fs, "fetch_open_pr_kei_ids", return_value={"KEI-188"}):
+        # Build a fake conn that records cursor.execute args
+        executed_queries = []
+
+        class _FakeCur:
+            def execute(self, sql, params=None):
+                executed_queries.append((sql, params))
+
+            def fetchone(self):
+                return ("KEI-200", "different task")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+        class _FakeConn:
+            def cursor(self):
+                return _FakeCur()
+
+            def commit(self):
+                pass
+
+        result = fs.claim_next_task(_FakeConn(), "aiden", 99)
+        assert result == ("KEI-200", "different task")
+        # The SELECT must include id != ALL(...) with KEI-188 in the excluded list
+        select_query = next(q for q, _ in executed_queries if "SELECT id, title" in q)
+        assert "!= ALL" in select_query
+        # Params should include the sorted exclusion list
+        select_params = next(p for q, p in executed_queries if "SELECT id, title" in q)
+        assert select_params[1] == ["KEI-188"]
+
+
+def test_claim_next_task_no_open_prs_uses_unfiltered_query(monkeypatch):
+    """KEI-199 — when no open PRs exist (or fetch fails), the SELECT runs
+    without the exclusion clause (preserves prior behaviour)."""
+    with patch.object(fs, "fetch_open_pr_kei_ids", return_value=set()):
+        executed_queries = []
+
+        class _FakeCur:
+            def execute(self, sql, params=None):
+                executed_queries.append((sql, params))
+
+            def fetchone(self):
+                return ("KEI-300", "available task")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+        class _FakeConn:
+            def cursor(self):
+                return _FakeCur()
+
+            def commit(self):
+                pass
+
+        result = fs.claim_next_task(_FakeConn(), "aiden", 99)
+        assert result == ("KEI-300", "available task")
+        select_query = next(q for q, _ in executed_queries if "SELECT id, title" in q)
+        assert "!= ALL" not in select_query


### PR DESCRIPTION
## Summary
KEI-199: closes the supervisor's auto-claim blind spot that produced **4 drift-syncs** in the 2026-05-17→18 session:
- KEI-90 (Max's deployment column migration)
- KEI-122 (Elliot's decomp umbrella PR #974)
- KEI-187 (Scout's legal corpus PR #989)
- KEI-188 (Max's apply gate PR #988)
- + Max's own KEI-191 drift-claim immediately after my pattern report

Each case: peer shipped PR → Supabase row not yet flipped to status='done' → supervisor's loop dispatched the already-in-flight KEI to a different agent → wasted cycle on drift-sync evidence writes instead of new work.

## Fix
- `fetch_open_pr_kei_ids() -> set[str]` runs `gh pr list --state open --json title,body` and extracts KEI-NNN identifiers via case-insensitive regex
- `claim_next_task()` filters the SELECT via `id != ALL(%s::text[])` when the set is non-empty
- Fail-open at every layer (gh CLI failure / JSON parse / subprocess exception → empty set → unfiltered SELECT preserves prior behaviour)

## Tests (5 new + 1 import fix)
```
$ python3 -m pytest tests/scripts/test_fleet_supervisor.py -q
......................                                                   [100%]
22 passed in 0.65s

$ ruff check + format
All checks passed!
```

- `test_fetch_open_pr_kei_ids_extracts_from_title_and_body` — mixed-case regex coverage
- `test_fetch_open_pr_kei_ids_fail_open_on_gh_error` — non-zero exit
- `test_fetch_open_pr_kei_ids_fail_open_on_subprocess_exception` — OSError
- `test_fetch_open_pr_kei_ids_handles_malformed_json` — JSON parse
- `test_claim_next_task_excludes_keis_with_open_prs` — SELECT carries `!= ALL` + sorted params
- `test_claim_next_task_no_open_prs_uses_unfiltered_query` — unfiltered SELECT preserved when set empty

## Companion in the supervisor-hardening track
- KEI-176 (PR #979 merged) — symmetric `[REVIEW:HOLD:...]` parsing  
- KEI-186 (Elliot PR #998 just shipped) — single-reviewer-eligible gate
- **KEI-199 (this PR)** — PR existence pre-check
- Together: the supervisor's 3 blind spots (claim, review, sonar) now have mechanical gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)