### PR TITLE
[ATLAS] feat(kei202): supervisor → agent_memories observation writer (institutional knowledge capture)

### DIFF
--- a/docs/runbooks/s4_supervisor_v2_cutover_order.md
+++ b/docs/runbooks/s4_supervisor_v2_cutover_order.md
@@ -1,0 +1,106 @@
+# S4 Supervisor v2 Cutover Runbook — Sequential Migration Order
+
+**KEI:** [KEI-193](https://linear.app/keiracom/issue/KEI-193) (sub of [KEI-185](https://linear.app/keiracom/issue/KEI-185) Nova spawn + supervisor v2 flip)
+**Status:** Refinement doc — ratified, not gate (KEI-185 owns the flip itself).
+**Ratification:** 3-way ratified per Max's blast-radius concern. Replaces the parallel cutover plan that concentrated failure risk on the 3 highest-state agents.
+**Owner:** Elliot (orchestrator) executes; this doc anchors the sequence + rollback per agent.
+
+---
+
+## TL;DR
+
+```
+Nova → Scout → Orion → Atlas → Aiden → Max → Elliot
+  ^                                          ^
+  spawn-test                            blast-radius peak
+```
+
+Sequential, **24h validation gate between every cutover**. No parallel.
+
+---
+
+## Why sequential (Max's blast-radius concern)
+
+Parallel cutover of the 3 highest-state agents (Aiden / Max / Elliot) concentrates failure mode: any latent SessionManager bug surfaces simultaneously across the bots whose KEI-state recall is the most load-bearing. Sequential with a validation window between each lets:
+1. Nova/Scout/Orion (lower-state, easier rollback) prove the path.
+2. Atlas (moderate-state — 10 PRs this session, dispatcher chain ownership) is the canary for medium-blast-radius.
+3. Aiden / Max / Elliot (deliberators + orchestrator, highest KEI-state recall) come last so the bench is empirically validated before their state is moved.
+
+Cost: 6 × 24h = 6 days end-to-end. Acceptable in exchange for bounded blast radius. Big-bang would have been hours but fail-modes would be hours × N agents.
+
+---
+
+## Cutover sequence
+
+| # | Agent | Why this position | Pre-cutover state weight | Rollback complexity |
+|---|---|---|---|---|
+| 1 | **Nova** | Net-new agent — proves SessionManager from cold. No legacy state to migrate. | Zero (spawn-test) | Trivial (delete worktree, no state lost) |
+| 2 | **Scout** | Lowest legacy-state of the 6 — research/docs/component-shell lane. Latest 5 PRs are Wave-3 product shells, recoverable from git. | Low | Easy (re-checkout worktree, re-fetch IDENTITY) |
+| 3 | **Orion** | Next-lowest — pgcrypto + Paddle handlers + systemd. Schema-touching work is in main branch already; rollback = re-pull. | Low-medium | Easy (same as Scout) |
+| 4 | **Atlas** | Canary for medium blast radius — 10 PRs this session, dispatcher product chain ownership. If Atlas survives 24h, deliberator-tier is safe to follow. | Medium | Medium (active feature branches; document open stacks before cutover) |
+| 5 | **Aiden** | First deliberator. CONCUR-LOCK authority on PRs — rollback path needs explicit `[REVIEW]` history recovery via gh comments scan. | High | Medium-high |
+| 6 | **Max** | Second deliberator. CONCUR-LOCK + quality gate authority. Same recovery pattern as Aiden. | High | Medium-high |
+| 7 | **Elliot** | Orchestrator. KEI-state recall is load-bearing for dispatch + merge-decisions. Migrate last so the rest of the fleet is empirically stable before Elliot's queue-management moves. | Highest | High (orchestrator state — Linear API checkpoint required) |
+
+---
+
+## 24h validation gate (per cutover)
+
+After each agent's restart on the v2 path, the next agent in sequence does NOT cut over until ALL of:
+
+1. **Liveness** — `systemctl --user is-active <agent>-agent.service` returns `active` for the full 24h window (no Restart=on-failure flap).
+2. **Tool-call activity** — `SELECT COUNT(*) FROM public.tool_call_log WHERE callsign='<agent>' AND created_at > NOW() - INTERVAL '24 hours'` returns > 0 (proves the agent is actually doing work, not just up).
+3. **No regressions** — zero new `[REVIEW:HOLD:<agent>]` or `[CONCUR-LOCK:<agent>]` on PRs blamed on the SessionManager path (search Sonar comments + recent `gh pr list` for HOLD posts citing supervisor v2).
+4. **Claim cycle** — at least one `bd claim` → `bd close` cycle completed by the cut-over agent during the window. Proves the supervisor-v2 dispatch loop reaches the agent end-to-end.
+
+If any of 1-4 fails: HOLD the next cutover, revert the failing agent to v1 (rollback section below), document the failure mode in this runbook before retrying.
+
+---
+
+## Per-agent rollback procedure
+
+**Common steps** (all 6 existing agents):
+
+```bash
+# 1. Stop the v2-routed agent
+systemctl --user stop <agent>-agent.service
+
+# 2. Flip the per-agent supervisor flag back to v1 in agent_sessions table
+psql "$DATABASE_URL" -c "UPDATE public.agent_sessions SET supervisor_version = 1 WHERE callsign = '<agent>'"
+
+# 3. Re-pull IDENTITY.md (in case v2 cutover modified it)
+cd /home/elliotbot/clawd/Agency_OS-<agent>
+git checkout HEAD -- IDENTITY.md
+
+# 4. Restart on v1 path
+systemctl --user start <agent>-agent.service
+systemctl --user is-active <agent>-agent.service   # → active
+```
+
+**Per-agent specifics:**
+
+- **Nova rollback** — there's nothing to roll back. `rm -rf ~/clawd/Agency_OS-nova` + `bd update KEI-185 --notes 'nova spawn failed; reverted'`. Re-spawn after fix.
+- **Scout / Orion rollback** — clean. Common steps cover everything; no per-agent state files to restore.
+- **Atlas rollback** — IF cutover is mid-PR, document open stack on the worktree before rollback. Common-step #3 won't lose feature branches (they live in `.git`, not `IDENTITY.md`).
+- **Aiden / Max rollback** — additionally re-sync `[REVIEW]` history: `gh search prs --comments-include '[REVIEW:HOLD:<aiden|max>]' --limit 100 > /tmp/<agent>-reviews.json` so review-state is recoverable for the supervisor's re-dispatch dedup.
+- **Elliot rollback** — additionally checkpoint orchestrator state: snapshot `ceo_memory` + `cis_directive_metrics` rows touched in the cutover window so Linear-mirror + directive-counter don't drift.
+
+---
+
+## Acceptance (KEI-193)
+
+- [x] S4 migration plan doc reflects sequential order (this doc, Cutover sequence table)
+- [x] Each cutover has 24h validation gate before next (this doc, "24h validation gate (per cutover)" section)
+- [x] Rollback paths documented per agent (this doc, "Per-agent rollback procedure" section)
+
+Refinement-only; gates remain on KEI-185 (Nova spawn + v2 flip ON). KEI-191 (existing-6 migration) consumes this doc as its execution plan.
+
+---
+
+## Open questions for the orchestrator (Elliot)
+
+1. **agent_sessions schema** — this doc references `supervisor_version` column. Is that landing in KEI-183 (Supervisor v2) or a separate migration? If separate, file as KEI-193 dep before KEI-191 starts.
+2. **24h window override** — for the no-blocker case (clean cutover, agent healthy), is 24h hard or can it shrink to 6h? Worth a flag in the runbook.
+3. **Nova spawn rollback** — KEI-185 description doesn't specify what "spawn failed" looks like operationally. Worth a brief failure-mode catalog in KEI-185 itself.
+
+These are doc-clarifications, not gate items. Land them as follow-up edits to this runbook when KEI-185 ships.

--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import time
 import urllib.request
+import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -251,6 +252,91 @@ def release_stale_claims(conn: psycopg.Connection) -> int:
         count = cur.rowcount
     conn.commit()
     return count
+
+
+# ---------------------------------------------------------------------------
+# KEI-202 — supervisor observation writer (institutional knowledge capture).
+#
+# Every detection+resolution event in the supervisor cycle writes a row to
+# public.agent_memories so the dataset accumulates for the Dispatcher +
+# Weaviate to eventually learn from. The supervisor builds its own
+# replacement: hardcoded scenario handlers → learned patterns over time.
+# ---------------------------------------------------------------------------
+
+SUPERVISOR_VERSION = 1  # bumped to 2 when KEI-185 flips supervisor v2 ON.
+
+
+def _write_observation(
+    conn: psycopg.Connection,
+    *,
+    cycle_id: str,
+    scenario: str,
+    agent_callsign: str,
+    kei_id: str | None,
+    action: str,
+    outcome: str,
+) -> None:
+    """Insert one supervisor_observation row into public.agent_memories.
+
+    Best-effort: if the INSERT fails (transient DB error, schema drift),
+    log a warning and continue the supervisor cycle. The fleet must survive
+    institutional-memory write failures.
+
+    Args:
+        conn: live psycopg connection (shared across the cycle).
+        cycle_id: UUID generated once per supervisor cycle so all
+            observations in one cycle correlate.
+        scenario: one of `scenario_1_idle_with_queue`, `scenario_2_idle_no_queue`,
+            `scenario_3_nudge_stale`, `scenario_3_restart_context_full`,
+            `scenario_4_dead_session`, `scenario_5_shipped_pr_idle`,
+            `scenario_6_stale_claim_release`.
+        agent_callsign: the agent the observation is ABOUT (atlas, scout, ...).
+            Note: the row's top-level ``callsign`` is always 'system' — this
+            parameter goes into typed_metadata.agent.
+        kei_id: KEI id that was claimed / nudged / re-dispatched if any.
+        action: short verb — `claimed`, `restarted`, `nudged`, `released`,
+            `dispatched_review`, `marked_idle`.
+        outcome: short noun phrase describing the resolved state.
+    """
+    content = json.dumps(
+        {
+            "scenario": scenario,
+            "agent": agent_callsign,
+            "kei_id": kei_id,
+            "action": action,
+            "outcome": outcome,
+            "timestamp": _dt.datetime.now(_dt.UTC).isoformat(),
+        }
+    )
+    typed_metadata = {
+        "cycle_id": cycle_id,
+        "supervisor_version": SUPERVISOR_VERSION,
+        "agent": agent_callsign,
+        "kei_id": kei_id,
+        "action": action,
+    }
+    tags = ["supervisor", "fleet_observation", scenario, agent_callsign]
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO public.agent_memories
+                    (callsign, source_type, content, typed_metadata, tags,
+                     valid_from, state, confidence, trust, access_count)
+                VALUES
+                    ('system', 'supervisor_observation', %s, %s::jsonb, %s,
+                     NOW(), 'confirmed', 1.0, 'agent_extracted', 0)
+                """,
+                (content, json.dumps(typed_metadata), tags),
+            )
+        conn.commit()
+    except Exception as exc:  # noqa: BLE001 — institutional-memory write is best-effort
+        log.warning(
+            "supervisor observation write failed (scenario=%s agent=%s): %s",
+            scenario,
+            agent_callsign,
+            exc,
+        )
 
 
 def get_last_tool_call(conn: psycopg.Connection, callsign: str) -> _dt.datetime | None:
@@ -631,7 +717,12 @@ def process_agent(
     conn: psycopg.Connection,
     prs: list[dict],
     phase_max: int,
+    cycle_id: str | None = None,
 ) -> AgentStatus:
+    # KEI-202: per-cycle UUID so all observations from one supervisor
+    # cycle correlate. Caller supplies via main(); tests may omit.
+    if cycle_id is None:
+        cycle_id = str(uuid.uuid4())
     callsign = agent["callsign"]
     tmux_session = agent["tmux"]
     service = agent["service"]
@@ -643,6 +734,7 @@ def process_agent(
 
     result = _handle_dead_tmux(callsign, tmux_session, service, conn, phase_max, status)
     if result is not None:
+        _record_handler_observation(conn, cycle_id, "scenario_4_dead_session", result)
         return result
 
     status.tmux_alive = True
@@ -651,10 +743,73 @@ def process_agent(
     if claim is None:
         result = _handle_idle_with_queue(callsign, tmux_session, conn, phase_max, status)
         if result is not None:
+            _record_handler_observation(conn, cycle_id, "scenario_1_idle_with_queue", result)
             return result
-        return _handle_idle_no_queue(callsign, tmux_session, prs, conn, status)
+        result = _handle_idle_no_queue(callsign, tmux_session, prs, conn, status)
+        # _handle_idle_no_queue covers both scenario 2 (review or correctly-idle)
+        # and scenario 5 (shipped PR + idle) — pick scenario tag from summary.
+        scenario = (
+            "scenario_2_idle_no_queue"
+            if "reviewing" in (result.summary or "")
+            else (
+                "scenario_5_shipped_pr_idle"
+                if "shipped pull request" in (result.summary or "")
+                else "scenario_2_correctly_idle"
+            )
+        )
+        _record_handler_observation(conn, cycle_id, scenario, result)
+        return result
 
-    return _handle_active_claim(callsign, tmux_session, service, conn, claim, status)
+    result = _handle_active_claim(callsign, tmux_session, service, conn, claim, status)
+    # _handle_active_claim covers building-fine OR scenario-3 nudge OR scenario-3 restart.
+    summary = result.summary or ""
+    if "100%" in summary or "restarted" in summary:
+        scenario = "scenario_3_restart_context_full"
+    elif "nudged" in summary:
+        scenario = "scenario_3_nudge_stale"
+    else:
+        scenario = "scenario_3_building_fine"
+    _record_handler_observation(conn, cycle_id, scenario, result)
+    return result
+
+
+def _record_handler_observation(
+    conn: psycopg.Connection,
+    cycle_id: str,
+    scenario: str,
+    status: AgentStatus,
+) -> None:
+    """Bridge between scenario handlers + _write_observation. Pulls
+    action/outcome out of the AgentStatus the handler populated, so the
+    handlers themselves stay focused on side-effects + the
+    observation-write logic lives in one place."""
+    summary = status.summary or ""
+    # Classify the action from the resolved status summary. Order matters —
+    # `restarted` must check before `claimed` because the restart-then-reclaim
+    # summary contains "re-claimed" (which substring-matches "claimed").
+    if "restarted" in summary:
+        action = "restarted"
+    elif "claimed" in summary:
+        action = "claimed"
+    elif "reviewing" in summary:
+        action = "dispatched_review"
+    elif "nudged" in summary:
+        action = "nudged"
+    elif "shipped" in summary:
+        action = "marked_idle_shipped"
+    elif "building" in summary:
+        action = "no_op_building"
+    else:
+        action = "marked_idle"
+    _write_observation(
+        conn,
+        cycle_id=cycle_id,
+        scenario=scenario,
+        agent_callsign=status.callsign,
+        kei_id=status.active_task_id,
+        action=action,
+        outcome=summary,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -702,12 +857,25 @@ def post_ceo_status(report: FleetReport) -> None:
 def main() -> None:
     log.info("Fleet supervisor starting")
     conn = _connect()
+    # KEI-202: one cycle_id per supervisor invocation correlates every
+    # observation written across the 6 agents during this cycle.
+    cycle_id = str(uuid.uuid4())
+    log.info("supervisor cycle %s starting", cycle_id)
 
     try:
         # Scenario 6: release stale claims first
         released = release_stale_claims(conn)
         if released:
             log.info("Released %d stale claim(s)", released)
+            _write_observation(
+                conn,
+                cycle_id=cycle_id,
+                scenario="scenario_6_stale_claim_release",
+                agent_callsign="system",
+                kei_id=None,
+                action="released",
+                outcome=f"released {released} stale claim(s) past {STALE_HOURS}h with no verification",
+            )
 
         phase_max = get_phase_max(conn)
         prs = list_open_prs()
@@ -717,7 +885,7 @@ def main() -> None:
 
         for agent in AGENTS:
             try:
-                status = process_agent(agent, conn, prs, phase_max)
+                status = process_agent(agent, conn, prs, phase_max, cycle_id=cycle_id)
             except Exception as exc:
                 log.exception("[%s] unhandled error: %s", agent["callsign"], exc)
                 status = AgentStatus(

--- a/tests/scripts/test_fleet_supervisor.py
+++ b/tests/scripts/test_fleet_supervisor.py
@@ -484,3 +484,177 @@ def test_find_pr_for_review_callsign_case_insensitive(monkeypatch):
 
     # Despite uppercase AIDEN, the match should fire and the PR should be skipped
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# KEI-202 — supervisor observation writer (institutional knowledge capture)
+# ---------------------------------------------------------------------------
+
+
+def _capture_observations_conn():
+    """Build a fake psycopg connection that records every INSERT'd
+    observation payload for assertions."""
+    captured: list[dict] = []
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    def fake_execute(sql, params=None):
+        if "INSERT INTO public.agent_memories" in (sql or ""):
+            content, typed_metadata, tags = params
+            captured.append({"content": content, "typed_metadata": typed_metadata, "tags": tags})
+
+    cursor.execute = MagicMock(side_effect=fake_execute)
+    conn.commit = MagicMock()
+    conn._captured = captured
+    return conn
+
+
+def test_write_observation_inserts_correct_shape():
+    """One call → one INSERT with the documented column shape."""
+    import json as _json
+
+    conn = _capture_observations_conn()
+    fs._write_observation(
+        conn,
+        cycle_id="cycle-xyz",
+        scenario="scenario_1_idle_with_queue",
+        agent_callsign="atlas",
+        kei_id="KEI-202",
+        action="claimed",
+        outcome="was idle, claimed KEI-202, injected task",
+    )
+    assert len(conn._captured) == 1
+    row = conn._captured[0]
+    content = _json.loads(row["content"])
+    md = _json.loads(row["typed_metadata"])
+    assert content["scenario"] == "scenario_1_idle_with_queue"
+    assert content["agent"] == "atlas"
+    assert content["kei_id"] == "KEI-202"
+    assert content["action"] == "claimed"
+    assert content["outcome"] == "was idle, claimed KEI-202, injected task"
+    assert "timestamp" in content
+    assert md["cycle_id"] == "cycle-xyz"
+    assert md["supervisor_version"] == fs.SUPERVISOR_VERSION
+    assert md["agent"] == "atlas"
+    assert md["kei_id"] == "KEI-202"
+    assert md["action"] == "claimed"
+    assert "supervisor" in row["tags"]
+    assert "fleet_observation" in row["tags"]
+    assert "scenario_1_idle_with_queue" in row["tags"]
+    assert "atlas" in row["tags"]
+
+
+def test_write_observation_swallows_db_errors(caplog):
+    """Best-effort: institutional-memory write failure MUST NOT propagate.
+    The supervisor cycle survives + logs a warning (per feedback_silence_is_status
+    + supervisor-must-survive-downstream-outages)."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    cursor.execute = MagicMock(side_effect=RuntimeError("supabase pooler down"))
+    conn.commit = MagicMock()
+
+    with caplog.at_level("WARNING"):
+        fs._write_observation(
+            conn,
+            cycle_id="cycle-xyz",
+            scenario="scenario_4_dead_session",
+            agent_callsign="atlas",
+            kei_id=None,
+            action="restarted",
+            outcome="session dead, restarted, queue empty",
+        )
+    assert any("supabase pooler down" in r.message for r in caplog.records)
+
+
+def test_record_handler_observation_classifies_actions():
+    """The bridge function inspects status.summary to pick the right action."""
+    import json as _json
+
+    conn = _capture_observations_conn()
+    cases = [
+        ("was idle, claimed KEI-X, injected task", "claimed"),
+        ("was idle, reviewing PR #42", "dispatched_review"),
+        ("100%% context, restarted, re-claimed KEI-X", "restarted"),
+        ("nudged on KEI-X (16m stale)", "nudged"),
+        ("shipped pull request, idle, queue empty", "marked_idle_shipped"),
+        ("building KEI-X (last activity 3m ago)", "no_op_building"),
+        ("queue empty, no reviews — correctly idle", "marked_idle"),
+    ]
+    for summary, _ in cases:
+        status = fs.AgentStatus(
+            callsign="atlas",
+            tmux_session="atlas:0",
+            service_name="atlas-agent",
+            summary=summary,
+        )
+        fs._record_handler_observation(conn, "cycle-1", "scenario_test", status)
+    assert len(conn._captured) == 7
+    for i, (_, expected) in enumerate(cases):
+        assert _json.loads(conn._captured[i]["content"])["action"] == expected, (
+            f"case {i}: {cases[i][0]!r} → expected {expected}"
+        )
+
+
+def test_process_agent_writes_observation_on_idle_with_queue(monkeypatch):
+    """E2E Scenario 1 — process_agent writes one observation row per resolution."""
+    import json as _json
+
+    conn = _capture_observations_conn()
+    monkeypatch.setattr(fs, "get_active_claim", lambda c, cs: None)
+    monkeypatch.setattr(fs, "claim_next_task", lambda c, cs, ph: ("KEI-100", "Test task"))
+    monkeypatch.setattr(fs, "fetch_linear_description", lambda kei: ("Test", "Do X"))
+    monkeypatch.setattr(fs, "tmux_has_session", lambda s: True)
+    monkeypatch.setattr(fs, "inject_task", MagicMock())
+
+    status = fs.process_agent(AGENT_ELLIOT, conn, [], 99, cycle_id="cycle-abc")
+
+    assert status.active_task_id == "KEI-100"
+    assert len(conn._captured) == 1
+    md = _json.loads(conn._captured[0]["typed_metadata"])
+    assert md["cycle_id"] == "cycle-abc"
+    assert "scenario_1_idle_with_queue" in conn._captured[0]["tags"]
+    assert md["action"] == "claimed"
+
+
+def test_process_agent_writes_observation_on_dead_session(monkeypatch):
+    """E2E Scenario 4 — dead-tmux resolution writes its observation."""
+    conn = _capture_observations_conn()
+    monkeypatch.setattr(fs, "tmux_has_session", lambda s: False)
+    monkeypatch.setattr(fs, "restart_service", MagicMock())
+    monkeypatch.setattr(fs, "claim_next_task", lambda c, cs, ph: None)
+    monkeypatch.setattr(fs, "inject_task", MagicMock())
+
+    status = fs.process_agent(AGENT_ELLIOT, conn, [], 99, cycle_id="cycle-abc")
+    assert status.tmux_alive is False
+    assert len(conn._captured) == 1
+    assert "scenario_4_dead_session" in conn._captured[0]["tags"]
+
+
+def test_process_agent_writes_observation_per_cycle_id(monkeypatch):
+    """3 process_agent calls — first two share cycle_id, third differs.
+    Observations downstream correlate per cycle for retrieval/analysis."""
+    import json as _json
+
+    conn = _capture_observations_conn()
+    monkeypatch.setattr(fs, "get_active_claim", lambda c, cs: None)
+    monkeypatch.setattr(fs, "claim_next_task", lambda c, cs, ph: ("KEI-X", "X"))
+    monkeypatch.setattr(fs, "fetch_linear_description", lambda kei: ("X", "x"))
+    monkeypatch.setattr(fs, "tmux_has_session", lambda s: True)
+    monkeypatch.setattr(fs, "inject_task", MagicMock())
+
+    fs.process_agent(AGENT_ELLIOT, conn, [], 99, cycle_id="cycle-shared")
+    fs.process_agent(AGENT_ELLIOT, conn, [], 99, cycle_id="cycle-shared")
+    fs.process_agent(AGENT_ELLIOT, conn, [], 99, cycle_id="cycle-other")
+
+    cycles = [_json.loads(c["typed_metadata"])["cycle_id"] for c in conn._captured]
+    assert cycles == ["cycle-shared", "cycle-shared", "cycle-other"]
+
+
+def test_supervisor_version_constant_exists():
+    """SUPERVISOR_VERSION sentinel is exposed for typed_metadata + KEI-185 bump."""
+    assert isinstance(fs.SUPERVISOR_VERSION, int)
+    assert fs.SUPERVISOR_VERSION >= 1


### PR DESCRIPTION
## Summary

Closes KEI-202 (KEI-200 re-routed to atlas per Aiden's drift-release). Fleet supervisor writes one row to \`public.agent_memories\` on every detection+resolution event so the institutional-knowledge dataset accumulates for the Dispatcher + Weaviate to eventually replace hardcoded scenario handlers with learned patterns.

Aiden 2026-05-18 confirmed lane fit: *\"Infra/Schema lane per ratified Tier-2, matches Atlas's KEI-105 systemd + KEI-181 tenant_id work\"*.

## Acceptance (Linear KEI-202)

| Acceptance | Where covered |
|---|---|
| Supervisor writes one row per detection+resolution per cycle | \`_record_handler_observation\` called after each handler returns (4 handlers covering 6 scenarios) + scenario 6 hook in \`main()\` |
| Rows visible: \`callsign='system'\` + \`source_type='supervisor_observation'\` | Empirically verified via SELECT after live write — see Empirical Smoke section below |
| Observations correlate per cycle | \`typed_metadata.cycle_id\` — tested in \`test_process_agent_writes_observation_per_cycle_id\` |
| Schema matches Weaviate AgentMemories indexer (KEI-85 family) | Same \`callsign / source_type / content / tags\` shape |

## Empirical smoke (caught a real schema bug)

Initial code used \`trust='1.0'\` (text). Empirical write against real Supabase pooler:

\`\`\`
WARNING supervisor observation write failed: new row violates check constraint
\"agent_memories_trust_check\"
DETAIL: trust = ANY (ARRAY['dave_confirmed', 'dave_observed', 'agent_extracted', 'raw_ingest'])
\`\`\`

Fixed → \`trust='agent_extracted'\`. Re-smoked:

\`\`\`
row: ('system', 'supervisor_observation', 'confirmed', 'agent_extracted',
      '{supervisor,fleet_observation,scenario_test_smoke,atlas}')
cleanup: 1 row(s)
\`\`\`

This is the \`empirical-smoke-catches-paper-review-3\` pattern — mocked unit tests passed but real-DB write failed on schema constraint. **All 23 tests passed at the moment the live write failed.** Smoke against actual binary against actual DB caught it.

## API

\`\`\`python
_write_observation(conn, *,
    cycle_id: str,
    scenario: str,            # scenario_1_idle_with_queue | scenario_4_dead_session | ...
    agent_callsign: str,      # the agent the observation is ABOUT
    kei_id: str | None,
    action: str,              # claimed | restarted | nudged | released | dispatched_review | ...
    outcome: str,             # short noun phrase
) -> None  # best-effort; swallows DB errors + logs warning
\`\`\`

\`process_agent(..., cycle_id)\` accepts cycle_id; \`main()\` generates one cycle_id per supervisor invocation so the 6 agents' observations in one cycle correlate downstream.

## Classification (\`_record_handler_observation\`)

Bridges scenario handlers + \`_write_observation\` by classifying action verb from \`status.summary\`. Order-aware: \`restarted\` checks BEFORE \`claimed\` because the \"100% context, restarted, re-claimed\" summary contains \"claimed\" as substring of \"re-claimed\".

## Files

| Path | Change |
|---|---|
| \`scripts/fleet_supervisor.py\` | +145 / -3 — added \`uuid\` import, \`SUPERVISOR_VERSION\` constant, \`_write_observation\`, \`_record_handler_observation\`, threaded \`cycle_id\` through \`process_agent\` + \`main\`, scenario-6 hook |
| \`tests/scripts/test_fleet_supervisor.py\` | +200 / 0 — 7 new tests |

## Test plan

- [x] \`pytest tests/scripts/test_fleet_supervisor.py -v\` — 23/23 passed (16 inherited + 7 new).
- [x] \`ruff check\` — All checks passed.
- [x] \`ruff format --check\` — 2 files already formatted.
- [x] **Empirical smoke against real Supabase pooler** — write + SELECT + cleanup verified post-trust-enum fix.

Coverage:
- \`_write_observation\` shape verify (content JSON + typed_metadata + tags)
- \`_write_observation\` swallows DB errors + logs warning (best-effort guarantee)
- \`_record_handler_observation\` action classifier — 7-case table covering all scenario summaries including re-claimed-substring-vs-restarted edge
- E2E Scenario 1 (idle + claim) writes observation
- E2E Scenario 4 (dead session) writes observation
- Per-cycle_id correlation across multiple process_agent calls
- SUPERVISOR_VERSION constant exposed

## Out of scope (file as follow-up KEIs)

- Re-running observations through Weaviate indexer to enable retrieval — relies on the KEI-85 family AgentMemories indexer already running; should be picked up on the next index cycle.
- Supervisor v2 (\`SUPERVISOR_VERSION = 2\`) — bumped when KEI-185 (Nova spawn + flip v2 ON) lands.
- BetterStack / observability dashboard on observation throughput — separate KEI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)