### PR TITLE
[ORION] feat(kei184): SessionManager + tmux_lifecycle (mirror container_lifecycle, no caller yet)

### DIFF
--- a/src/dispatcher/session_manager.py
+++ b/src/dispatcher/session_manager.py
@@ -1,0 +1,157 @@
+"""KEI-184 — SessionManager: unified dispatcher interface for tmux + container backends.
+
+Routes ``spawn`` / ``wait_ready`` / ``send`` / ``terminate`` to either
+``tmux_lifecycle`` or ``container_lifecycle`` based on the configured
+``Backend``.  This is the abstraction layer for the Strangler Fig router
+(KEI-185); it is intentionally wire-free — no callers are touched here.
+
+Design notes:
+- Backend is chosen at construction time; one ``SessionManager`` instance
+  maps to one backend for the lifetime of a spawned session.
+- No ``SessionManager``-level exception class is added.  Callers handle
+  the backend-native exception types (``SessionStartupError`` /
+  ``ContainerStartupError``) so the same try/except covers each backend
+  uniformly.
+- ``send()`` for the CONTAINER backend raises ``NotImplementedError``:
+  containers expose an HTTP API, not a pane; LiteLLM router / dispatcher's
+  HTTP-forward path owns request forwarding for that backend.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from src.dispatcher import container_lifecycle, tmux_lifecycle
+
+
+class Backend(StrEnum):
+    """Supported session backends."""
+
+    TMUX = "tmux"
+    CONTAINER = "container"
+
+
+class SessionManager:
+    """Routes spawn / wait_ready / send / terminate to the configured backend.
+
+    Construction::
+
+        sm = SessionManager(backend=Backend.TMUX)
+        sm = SessionManager(backend=Backend.CONTAINER)
+
+    The backend is fixed at construction time — a single ``SessionManager``
+    instance is a stable choice for the lifetime of one spawned session.
+    The dispatcher's Strangler Fig router (KEI-185) picks the backend per
+    route and constructs accordingly.
+
+    All four methods raise the backend-native exception type so callers
+    handle once per backend and don't need a ``SessionManager``-level
+    wrapper exception.
+    """
+
+    def __init__(self, backend: Backend) -> None:
+        self._backend = backend
+
+    @property
+    def backend(self) -> Backend:
+        """The backend this manager is configured for."""
+        return self._backend
+
+    # ------------------------------------------------------------------
+    # spawn
+    # ------------------------------------------------------------------
+
+    def spawn(self, **kwargs: Any) -> Any:
+        """Spawn a session on the configured backend.
+
+        For ``TMUX``: forwards to ``tmux_lifecycle.spawn_session(**kwargs)``.
+        Returns a ``SessionHandle``.
+
+        For ``CONTAINER``: forwards to
+        ``container_lifecycle.spawn_container(**kwargs)``.
+        Returns a ``ContainerHandle``.
+
+        Raises:
+            tmux_lifecycle.TmuxUnavailableError:       TMUX, tmux missing.
+            tmux_lifecycle.SessionStartupError:        TMUX, non-zero rc.
+            container_lifecycle.DockerUnavailableError: CONTAINER, docker missing.
+            container_lifecycle.ContainerStartupError:  CONTAINER, non-zero rc.
+        """
+        if self._backend is Backend.TMUX:
+            return tmux_lifecycle.spawn_session(**kwargs)
+        return container_lifecycle.spawn_container(**kwargs)
+
+    # ------------------------------------------------------------------
+    # wait_ready
+    # ------------------------------------------------------------------
+
+    def wait_ready(self, handle: Any, **kwargs: Any) -> bool:
+        """Wait for the spawned session/container to become ready.
+
+        For ``TMUX``: ``tmux_lifecycle.wait_ready(handle, **kwargs)``.
+        For ``CONTAINER``: ``container_lifecycle.wait_healthy(handle, **kwargs)``.
+
+        Note the intentional name asymmetry in the underlying modules
+        (``wait_ready`` vs ``wait_healthy``); ``SessionManager`` normalises
+        both behind a single ``wait_ready`` call so callers need not know
+        which backend is active.
+
+        Returns:
+            ``True`` when ready/healthy.
+
+        Raises:
+            tmux_lifecycle.SessionStartupError:       TMUX timeout.
+            container_lifecycle.ContainerStartupError: CONTAINER timeout.
+        """
+        if self._backend is Backend.TMUX:
+            return tmux_lifecycle.wait_ready(handle, **kwargs)
+        return container_lifecycle.wait_healthy(handle, **kwargs)
+
+    # ------------------------------------------------------------------
+    # send
+    # ------------------------------------------------------------------
+
+    def send(self, handle: Any, text: str) -> None:
+        """Send free-form text to the session.
+
+        For ``TMUX``: ``tmux_lifecycle.send(handle, text)`` — uses the
+        two-call literal+Enter pattern from ``fleet_supervisor.py``.
+
+        For ``CONTAINER``: raises ``NotImplementedError``.  Containers
+        expose an HTTP API rather than a pane; the dispatcher's HTTP-forward
+        path (LiteLLM router) owns request forwarding for this backend.
+        Callers must route via the HTTP forward path instead of ``send``.
+
+        Raises:
+            NotImplementedError: when backend is ``CONTAINER``.
+        """
+        if self._backend is Backend.TMUX:
+            tmux_lifecycle.send(handle, text)
+            return
+        raise NotImplementedError(
+            "SessionManager.send() is not supported for the CONTAINER backend. "
+            "Route requests via the dispatcher's HTTP forward path (LiteLLM router)."
+        )
+
+    # ------------------------------------------------------------------
+    # terminate
+    # ------------------------------------------------------------------
+
+    def terminate(self, handle: Any) -> None:
+        """Terminate the session/container.
+
+        For ``TMUX``: ``tmux_lifecycle.terminate(handle)`` — best-effort,
+        logs but does not raise on tmux errors.
+
+        For ``CONTAINER``: ``container_lifecycle.kill_and_remove(handle)``
+        — best-effort, logs but does not raise on docker errors.
+
+        Note the intentional name asymmetry in the underlying modules
+        (``terminate`` vs ``kill_and_remove``); ``SessionManager`` normalises
+        both behind a single ``terminate`` call.
+        """
+        if self._backend is Backend.TMUX:
+            tmux_lifecycle.terminate(handle)
+            return
+        container_lifecycle.kill_and_remove(handle)

--- a/src/dispatcher/tmux_lifecycle.py
+++ b/src/dispatcher/tmux_lifecycle.py
@@ -1,0 +1,265 @@
+"""KEI-184 — tmux session spawn + startup polling + send/terminate.
+
+Mirrors the ``container_lifecycle`` interface for tmux sessions so the
+dispatcher's Strangler Fig router (KEI-185) can route uniformly to either
+backend.  This module is spawn + wait_ready + send + terminate only; a
+future lifecycle-monitor module (parallel to KEI-163/container_monitor)
+handles long-running supervision.
+
+Caller responsibility: the command passed to ``spawn_session`` must emit
+``ready_marker`` to its pane when it is ready to accept input.  The
+default ``"❯"`` matches Claude CLI's prompt character.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import time
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants — mirror DEFAULT_* naming from container_lifecycle for symmetry.
+# ---------------------------------------------------------------------------
+
+DEFAULT_SESSION_STARTUP_TIMEOUT_S = 15.0
+DEFAULT_SESSION_POLL_INTERVAL_S = 0.5
+DEFAULT_TMUX_CMD_TIMEOUT_S = 10.0
+TMUX_CLI = "tmux"
+
+# The Claude CLI prompt character used for default ready detection.
+_DEFAULT_READY_MARKER = "❯"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class SessionStartupError(RuntimeError):
+    """tmux session failed to start or become responsive within timeout.
+
+    On the ``wait_ready`` timeout path the session has already been
+    terminated before this is raised — caller does not need to clean up.
+    """
+
+
+class TmuxUnavailableError(RuntimeError):
+    """The tmux CLI is not installed or not on PATH."""
+
+
+# ---------------------------------------------------------------------------
+# Handle
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SessionHandle:
+    """Reference to a running tmux session.
+
+    Returned by ``spawn_session``, consumed by ``wait_ready`` / ``send`` /
+    ``terminate`` / future lifecycle ops.
+    """
+
+    session_name: str  # e.g. "orion:0" or just "orion"
+    working_dir: str
+    command: str  # e.g. "claude --resume"
+    ready_marker: str = field(default=_DEFAULT_READY_MARKER)
+
+
+# ---------------------------------------------------------------------------
+# Internal helper
+# ---------------------------------------------------------------------------
+
+
+def _run_tmux(
+    args: list[str],
+    timeout_s: float = DEFAULT_TMUX_CMD_TIMEOUT_S,
+) -> subprocess.CompletedProcess:
+    """Run a tmux sub-command and return the CompletedProcess.
+
+    Wraps FileNotFoundError in TmuxUnavailableError so callers only need
+    to handle the domain exception.
+    """
+    try:
+        # controlled args, no shell injection risk
+        return subprocess.run(  # noqa: S603
+            [TMUX_CLI, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise TmuxUnavailableError(f"{TMUX_CLI} CLI not found on PATH") from exc
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def spawn_session(
+    *,
+    session_name: str,
+    working_dir: str,
+    command: str,
+    env: dict[str, str] | None = None,
+    ready_marker: str = _DEFAULT_READY_MARKER,
+) -> SessionHandle:
+    """Start a detached tmux session running ``command``.
+
+    Returns a ``SessionHandle``.  Does NOT block on readiness — call
+    ``wait_ready(handle)`` next.
+
+    Args:
+        session_name: tmux session name (must be unique on this host).
+        working_dir:  The ``-c`` start directory passed to tmux.
+        command:      Shell command string run inside the session.
+        env:          Optional extra environment variables injected via
+                      ``-e KEY=VAL`` flags.
+        ready_marker: Pane text that signals the session is ready (default
+                      ``"❯"`` — Claude CLI prompt).
+
+    Raises:
+        TmuxUnavailableError: tmux CLI missing from PATH.
+        SessionStartupError:  ``tmux new-session`` returned non-zero rc.
+    """
+    cmd: list[str] = [
+        "new-session",
+        "-d",
+        "-s",
+        session_name,
+        "-c",
+        working_dir,
+    ]
+    for k, v in (env or {}).items():
+        cmd += ["-e", f"{k}={v}"]
+    # command is the last positional arg
+    cmd.append(command)
+
+    out = _run_tmux(cmd)
+    if out.returncode != 0:
+        raise SessionStartupError(
+            f"tmux new-session failed (rc={out.returncode}): {out.stderr.strip()[:300]}"
+        )
+
+    logger.info("tmux session %r started in %s", session_name, working_dir)
+    return SessionHandle(
+        session_name=session_name,
+        working_dir=working_dir,
+        command=command,
+        ready_marker=ready_marker,
+    )
+
+
+def wait_ready(
+    handle: SessionHandle,
+    *,
+    timeout_s: float = DEFAULT_SESSION_STARTUP_TIMEOUT_S,
+    interval_s: float = DEFAULT_SESSION_POLL_INTERVAL_S,
+) -> bool:
+    """Poll the session's pane until ``ready_marker`` appears or timeout.
+
+    On timeout: terminates the session via ``terminate(handle)``, then
+    raises ``SessionStartupError``.  The session is gone before the
+    exception surfaces — caller does not need to clean up.
+
+    Returns:
+        ``True`` when the marker is detected.
+
+    Raises:
+        SessionStartupError: marker not seen within ``timeout_s`` seconds.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        # controlled args, no shell injection risk
+        result = subprocess.run(  # noqa: S603
+            [TMUX_CLI, "capture-pane", "-t", handle.session_name, "-p"],
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_TMUX_CMD_TIMEOUT_S,
+            check=False,
+        )
+        if handle.ready_marker in result.stdout:
+            logger.info(
+                "session %r ready (marker %r found)",
+                handle.session_name,
+                handle.ready_marker,
+            )
+            return True
+        time.sleep(interval_s)
+
+    logger.warning(
+        "session %r did not become ready within %.1fs — terminating",
+        handle.session_name,
+        timeout_s,
+    )
+    terminate(handle)
+    raise SessionStartupError(
+        f"session {handle.session_name!r} (cmd={handle.command!r}) "
+        f"did not emit ready marker within {timeout_s:.1f}s"
+    )
+
+
+def send(handle: SessionHandle, text: str) -> None:
+    """Send ``text`` to the session pane followed by Enter.
+
+    Uses the two-call literal+Enter pattern from ``fleet_supervisor.py``
+    to avoid the embedded-newline soft-break trap (a single
+    ``["text", "Enter"]`` call is unreliable when text contains newlines
+    because Claude CLI interprets embedded ``\\n`` as a soft-break and may
+    eat the trailing Enter).
+    """
+    # First call: send text in literal mode (-l) so special chars are safe.
+    # controlled args, no shell injection risk
+    subprocess.run(  # noqa: S603
+        [TMUX_CLI, "send-keys", "-t", handle.session_name, "-l", text],
+        capture_output=True,
+        text=True,
+        timeout=DEFAULT_TMUX_CMD_TIMEOUT_S,
+        check=True,
+    )
+    # Second call: send the Enter key separately.
+    # controlled args, no shell injection risk
+    subprocess.run(  # noqa: S603
+        [TMUX_CLI, "send-keys", "-t", handle.session_name, "Enter"],
+        capture_output=True,
+        text=True,
+        timeout=DEFAULT_TMUX_CMD_TIMEOUT_S,
+        check=True,
+    )
+
+
+def terminate(handle: SessionHandle) -> None:
+    """Best-effort ``tmux kill-session -t <name>``.
+
+    Logs but does not raise on tmux errors — the abort path must not mask
+    the original failure for callers using this from ``wait_ready``'s
+    timeout branch.
+    """
+    try:
+        # controlled args, no shell injection risk
+        result = subprocess.run(  # noqa: S603
+            [TMUX_CLI, "kill-session", "-t", handle.session_name],
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_TMUX_CMD_TIMEOUT_S,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "tmux kill-session %r failed (rc=%d): %s",
+                handle.session_name,
+                result.returncode,
+                result.stderr.strip()[:200],
+            )
+    except FileNotFoundError:
+        logger.warning(
+            "tmux CLI not found during terminate(%r) — session may linger",
+            handle.session_name,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("terminate(%r) raised unexpectedly: %s", handle.session_name, exc)

--- a/tests/dispatcher/test_session_manager.py
+++ b/tests/dispatcher/test_session_manager.py
@@ -1,0 +1,147 @@
+"""Tests for src/dispatcher/session_manager.py (KEI-184)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.dispatcher.session_manager import Backend, SessionManager
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tmux_sm() -> SessionManager:
+    return SessionManager(backend=Backend.TMUX)
+
+
+def _container_sm() -> SessionManager:
+    return SessionManager(backend=Backend.CONTAINER)
+
+
+_FAKE_TMUX_HANDLE = MagicMock(name="SessionHandle")
+_FAKE_CONTAINER_HANDLE = MagicMock(name="ContainerHandle")
+
+
+# ---------------------------------------------------------------------------
+# backend property
+# ---------------------------------------------------------------------------
+
+
+class TestBackendProperty:
+    def test_backend_property_returns_configured_backend_tmux(self):
+        sm = SessionManager(backend=Backend.TMUX)
+        assert sm.backend is Backend.TMUX
+
+    def test_backend_property_returns_configured_backend_container(self):
+        sm = SessionManager(backend=Backend.CONTAINER)
+        assert sm.backend is Backend.CONTAINER
+
+
+# ---------------------------------------------------------------------------
+# spawn
+# ---------------------------------------------------------------------------
+
+
+class TestSpawn:
+    def test_backend_tmux_spawn_routes_to_tmux_lifecycle(self):
+        sm = _tmux_sm()
+        with patch(
+            "src.dispatcher.session_manager.tmux_lifecycle.spawn_session",
+            return_value=_FAKE_TMUX_HANDLE,
+        ) as mock_spawn:
+            result = sm.spawn(
+                session_name="orion",
+                working_dir="/tmp",
+                command="claude --resume",
+            )
+        mock_spawn.assert_called_once_with(
+            session_name="orion",
+            working_dir="/tmp",
+            command="claude --resume",
+        )
+        assert result is _FAKE_TMUX_HANDLE
+
+    def test_backend_container_spawn_routes_to_container_lifecycle(self):
+        sm = _container_sm()
+        with patch(
+            "src.dispatcher.session_manager.container_lifecycle.spawn_container",
+            return_value=_FAKE_CONTAINER_HANDLE,
+        ) as mock_spawn:
+            result = sm.spawn(image="myimg", name="mycontainer", port=8080)
+        mock_spawn.assert_called_once_with(image="myimg", name="mycontainer", port=8080)
+        assert result is _FAKE_CONTAINER_HANDLE
+
+
+# ---------------------------------------------------------------------------
+# wait_ready
+# ---------------------------------------------------------------------------
+
+
+class TestWaitReady:
+    def test_backend_tmux_wait_ready_routes_correctly(self):
+        sm = _tmux_sm()
+        with patch(
+            "src.dispatcher.session_manager.tmux_lifecycle.wait_ready",
+            return_value=True,
+        ) as mock_wait:
+            result = sm.wait_ready(_FAKE_TMUX_HANDLE, timeout_s=5.0)
+        mock_wait.assert_called_once_with(_FAKE_TMUX_HANDLE, timeout_s=5.0)
+        assert result is True
+
+    def test_backend_container_wait_ready_routes_to_wait_healthy(self):
+        """The CONTAINER backend normalises wait_ready → container_lifecycle.wait_healthy."""
+        sm = _container_sm()
+        with patch(
+            "src.dispatcher.session_manager.container_lifecycle.wait_healthy",
+            return_value=True,
+        ) as mock_healthy:
+            result = sm.wait_ready(_FAKE_CONTAINER_HANDLE, timeout_s=30.0)
+        mock_healthy.assert_called_once_with(_FAKE_CONTAINER_HANDLE, timeout_s=30.0)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# send
+# ---------------------------------------------------------------------------
+
+
+class TestSend:
+    def test_backend_tmux_send_routes_correctly(self):
+        sm = _tmux_sm()
+        with patch(
+            "src.dispatcher.session_manager.tmux_lifecycle.send",
+        ) as mock_send:
+            sm.send(_FAKE_TMUX_HANDLE, "hello")
+        mock_send.assert_called_once_with(_FAKE_TMUX_HANDLE, "hello")
+
+    def test_backend_container_send_raises_NotImplementedError(self):
+        sm = _container_sm()
+        with pytest.raises(NotImplementedError, match="HTTP forward path"):
+            sm.send(_FAKE_CONTAINER_HANDLE, "hello")
+
+
+# ---------------------------------------------------------------------------
+# terminate
+# ---------------------------------------------------------------------------
+
+
+class TestTerminate:
+    def test_backend_tmux_terminate_routes_correctly(self):
+        sm = _tmux_sm()
+        with patch(
+            "src.dispatcher.session_manager.tmux_lifecycle.terminate",
+        ) as mock_terminate:
+            sm.terminate(_FAKE_TMUX_HANDLE)
+        mock_terminate.assert_called_once_with(_FAKE_TMUX_HANDLE)
+
+    def test_backend_container_terminate_routes_to_kill_and_remove(self):
+        """terminate() normalises to container_lifecycle.kill_and_remove — name mismatch is intentional."""
+        sm = _container_sm()
+        with patch(
+            "src.dispatcher.session_manager.container_lifecycle.kill_and_remove",
+        ) as mock_kill:
+            sm.terminate(_FAKE_CONTAINER_HANDLE)
+        mock_kill.assert_called_once_with(_FAKE_CONTAINER_HANDLE)

--- a/tests/dispatcher/test_session_manager.py
+++ b/tests/dispatcher/test_session_manager.py
@@ -46,20 +46,21 @@ class TestBackendProperty:
 
 
 class TestSpawn:
-    def test_backend_tmux_spawn_routes_to_tmux_lifecycle(self):
+    def test_backend_tmux_spawn_routes_to_tmux_lifecycle(self, tmp_path):
         sm = _tmux_sm()
+        wd = str(tmp_path)
         with patch(
             "src.dispatcher.session_manager.tmux_lifecycle.spawn_session",
             return_value=_FAKE_TMUX_HANDLE,
         ) as mock_spawn:
             result = sm.spawn(
                 session_name="orion",
-                working_dir="/tmp",
+                working_dir=wd,
                 command="claude --resume",
             )
         mock_spawn.assert_called_once_with(
             session_name="orion",
-            working_dir="/tmp",
+            working_dir=wd,
             command="claude --resume",
         )
         assert result is _FAKE_TMUX_HANDLE
@@ -117,7 +118,7 @@ class TestSend:
             sm.send(_FAKE_TMUX_HANDLE, "hello")
         mock_send.assert_called_once_with(_FAKE_TMUX_HANDLE, "hello")
 
-    def test_backend_container_send_raises_NotImplementedError(self):
+    def test_backend_container_send_raises_not_implemented_error(self):
         sm = _container_sm()
         with pytest.raises(NotImplementedError, match="HTTP forward path"):
             sm.send(_FAKE_CONTAINER_HANDLE, "hello")

--- a/tests/dispatcher/test_tmux_lifecycle.py
+++ b/tests/dispatcher/test_tmux_lifecycle.py
@@ -26,9 +26,11 @@ _BAD_RC = MagicMock(returncode=1, stdout="", stderr="tmux: session already exist
 
 
 def _make_handle(**kwargs) -> SessionHandle:
+    # S5443: use a fake non-publicly-writable path; tests mock subprocess so the
+    # path is never actually accessed. Avoids the /tmp publicly-writable flag.
     defaults = {
         "session_name": "test-session",
-        "working_dir": "/tmp",
+        "working_dir": "/test/wd",
         "command": "claude --resume",
         "ready_marker": "❯",
     }
@@ -61,11 +63,11 @@ class TestSpawnSession:
         assert args_list[idx_c + 1] == "/home/elliotbot"
         assert args_list[-1] == "claude --resume"
 
-    def test_spawn_includes_env_flags(self):
+    def test_spawn_includes_env_flags(self, tmp_path):
         with patch("subprocess.run", return_value=_GOOD_RC) as mock_run:
             spawn_session(
                 session_name="orion",
-                working_dir="/tmp",
+                working_dir=str(tmp_path),
                 command="bash",
                 env={"FOO": "bar", "BAZ": "qux"},
             )
@@ -88,25 +90,25 @@ class TestSpawnSession:
         assert handle.command == "python main.py"
         assert handle.ready_marker == ">>"
 
-    def test_spawn_raises_TmuxUnavailableError_when_tmux_missing(self):
+    def test_spawn_raises_tmux_unavailable_error_when_tmux_missing(self, tmp_path):
         with (
             patch("subprocess.run", side_effect=FileNotFoundError("tmux not found")),
             pytest.raises(TmuxUnavailableError, match="not found on PATH"),
         ):
             spawn_session(
                 session_name="orion",
-                working_dir="/tmp",
+                working_dir=str(tmp_path),
                 command="bash",
             )
 
-    def test_spawn_raises_SessionStartupError_on_nonzero_rc(self):
+    def test_spawn_raises_session_startup_error_on_nonzero_rc(self, tmp_path):
         with (
             patch("subprocess.run", return_value=_BAD_RC),
             pytest.raises(SessionStartupError, match="rc=1"),
         ):
             spawn_session(
                 session_name="orion",
-                working_dir="/tmp",
+                working_dir=str(tmp_path),
                 command="bash",
             )
 
@@ -204,7 +206,7 @@ class TestTerminate:
         assert "kill-session" in args_list
         assert handle.session_name in args_list
 
-    def test_terminate_swallows_FileNotFoundError(self):
+    def test_terminate_swallows_file_not_found_error(self):
         handle = _make_handle()
         with patch("subprocess.run", side_effect=FileNotFoundError("tmux missing")):
             # Must not raise — tmux missing during teardown is tolerated

--- a/tests/dispatcher/test_tmux_lifecycle.py
+++ b/tests/dispatcher/test_tmux_lifecycle.py
@@ -1,0 +1,218 @@
+"""Tests for src/dispatcher/tmux_lifecycle.py (KEI-184)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.dispatcher.tmux_lifecycle import (
+    TMUX_CLI,
+    SessionHandle,
+    SessionStartupError,
+    TmuxUnavailableError,
+    send,
+    spawn_session,
+    terminate,
+    wait_ready,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GOOD_RC = MagicMock(returncode=0, stdout="", stderr="")
+_BAD_RC = MagicMock(returncode=1, stdout="", stderr="tmux: session already exists")
+
+
+def _make_handle(**kwargs) -> SessionHandle:
+    defaults = {
+        "session_name": "test-session",
+        "working_dir": "/tmp",
+        "command": "claude --resume",
+        "ready_marker": "❯",
+    }
+    defaults.update(kwargs)
+    return SessionHandle(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# spawn_session
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnSession:
+    def test_spawn_calls_tmux_new_session_with_correct_args(self):
+        with patch("subprocess.run", return_value=_GOOD_RC) as mock_run:
+            spawn_session(
+                session_name="orion",
+                working_dir="/home/elliotbot",
+                command="claude --resume",
+            )
+        args_list = mock_run.call_args[0][0]
+        assert args_list[0] == TMUX_CLI
+        assert "new-session" in args_list
+        assert "-d" in args_list
+        assert "-s" in args_list
+        idx_s = args_list.index("-s")
+        assert args_list[idx_s + 1] == "orion"
+        assert "-c" in args_list
+        idx_c = args_list.index("-c")
+        assert args_list[idx_c + 1] == "/home/elliotbot"
+        assert args_list[-1] == "claude --resume"
+
+    def test_spawn_includes_env_flags(self):
+        with patch("subprocess.run", return_value=_GOOD_RC) as mock_run:
+            spawn_session(
+                session_name="orion",
+                working_dir="/tmp",
+                command="bash",
+                env={"FOO": "bar", "BAZ": "qux"},
+            )
+        args_list = mock_run.call_args[0][0]
+        # Both env vars should appear as -e KEY=VAL pairs
+        flat = " ".join(args_list)
+        assert "-e FOO=bar" in flat or ("-e" in args_list and "FOO=bar" in args_list)
+        assert "-e BAZ=qux" in flat or ("-e" in args_list and "BAZ=qux" in args_list)
+
+    def test_spawn_returns_handle_with_provided_fields(self):
+        with patch("subprocess.run", return_value=_GOOD_RC):
+            handle = spawn_session(
+                session_name="my-session",
+                working_dir="/workspace",
+                command="python main.py",
+                ready_marker=">>",
+            )
+        assert handle.session_name == "my-session"
+        assert handle.working_dir == "/workspace"
+        assert handle.command == "python main.py"
+        assert handle.ready_marker == ">>"
+
+    def test_spawn_raises_TmuxUnavailableError_when_tmux_missing(self):
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError("tmux not found")),
+            pytest.raises(TmuxUnavailableError, match="not found on PATH"),
+        ):
+            spawn_session(
+                session_name="orion",
+                working_dir="/tmp",
+                command="bash",
+            )
+
+    def test_spawn_raises_SessionStartupError_on_nonzero_rc(self):
+        with (
+            patch("subprocess.run", return_value=_BAD_RC),
+            pytest.raises(SessionStartupError, match="rc=1"),
+        ):
+            spawn_session(
+                session_name="orion",
+                working_dir="/tmp",
+                command="bash",
+            )
+
+
+# ---------------------------------------------------------------------------
+# wait_ready
+# ---------------------------------------------------------------------------
+
+
+class TestWaitReady:
+    def _capture_result(self, pane_text: str) -> MagicMock:
+        return MagicMock(returncode=0, stdout=pane_text, stderr="")
+
+    def test_wait_ready_returns_true_when_marker_appears(self):
+        handle = _make_handle()
+        capture = self._capture_result("some output ❯ ")
+        with patch("subprocess.run", return_value=capture):
+            result = wait_ready(handle, timeout_s=5.0, interval_s=0.01)
+        assert result is True
+
+    def test_wait_ready_polls_until_marker(self):
+        handle = _make_handle()
+        empty = self._capture_result("")
+        found = self._capture_result("❯")
+        # First two calls return empty, third has marker
+        with (
+            patch("subprocess.run", side_effect=[empty, empty, found]),
+            patch("time.sleep"),  # avoid real sleep in tests
+        ):
+            result = wait_ready(handle, timeout_s=5.0, interval_s=0.01)
+        assert result is True
+
+    def test_wait_ready_terminates_and_raises_on_timeout(self):
+        handle = _make_handle()
+        empty = self._capture_result("")
+        # Patch time.monotonic to simulate immediate timeout after first poll
+        times = iter([0.0, 0.0, 999.0])  # start, loop check, deadline exceeded
+        terminate_calls = []
+
+        def fake_terminate(h):
+            terminate_calls.append(h)
+
+        with (
+            patch("subprocess.run", return_value=empty),
+            patch("time.monotonic", side_effect=times),
+            patch("time.sleep"),
+            patch("src.dispatcher.tmux_lifecycle.terminate", side_effect=fake_terminate),
+            pytest.raises(SessionStartupError, match="did not emit ready marker"),
+        ):
+            wait_ready(handle, timeout_s=0.001, interval_s=0.001)
+
+        assert len(terminate_calls) == 1
+        assert terminate_calls[0].session_name == handle.session_name
+
+
+# ---------------------------------------------------------------------------
+# send
+# ---------------------------------------------------------------------------
+
+
+class TestSend:
+    def test_send_uses_two_call_literal_then_enter_pattern(self):
+        handle = _make_handle()
+        with patch("subprocess.run", return_value=_GOOD_RC) as mock_run:
+            send(handle, "hello world")
+
+        assert mock_run.call_count == 2
+        first_call_args = mock_run.call_args_list[0][0][0]
+        second_call_args = mock_run.call_args_list[1][0][0]
+
+        # First call: literal mode with -l flag and the text
+        assert "-l" in first_call_args
+        assert "hello world" in first_call_args
+        assert "send-keys" in first_call_args
+
+        # Second call: Enter key (no -l flag)
+        assert "Enter" in second_call_args
+        assert "send-keys" in second_call_args
+        assert "-l" not in second_call_args
+
+
+# ---------------------------------------------------------------------------
+# terminate
+# ---------------------------------------------------------------------------
+
+
+class TestTerminate:
+    def test_terminate_invokes_kill_session_best_effort(self):
+        handle = _make_handle()
+        bad = MagicMock(returncode=1, stdout="", stderr="no session")
+        with patch("subprocess.run", return_value=bad) as mock_run:
+            # Should NOT raise even on non-zero rc
+            terminate(handle)
+        args_list = mock_run.call_args[0][0]
+        assert "kill-session" in args_list
+        assert handle.session_name in args_list
+
+    def test_terminate_swallows_FileNotFoundError(self):
+        handle = _make_handle()
+        with patch("subprocess.run", side_effect=FileNotFoundError("tmux missing")):
+            # Must not raise — tmux missing during teardown is tolerated
+            terminate(handle)
+
+    def test_terminate_calls_correct_session_name(self):
+        handle = _make_handle(session_name="my-unique-session")
+        with patch("subprocess.run", return_value=_GOOD_RC) as mock_run:
+            terminate(handle)
+        args_list = mock_run.call_args[0][0]
+        assert "my-unique-session" in args_list


### PR DESCRIPTION
## Summary

Step 2 of Elliot's Strangler Fig (KEI-B). New \`tmux_lifecycle\` module mirrors the \`container_lifecycle\` interface; \`SessionManager\` abstraction routes spawn / wait_ready / send / terminate to either backend uniformly. No caller wired — that's KEI-185 (Nova spawn) + KEI-191 (existing 6 agent migration).

## What ships (4 files, +787)

- \`src/dispatcher/tmux_lifecycle.py\` — SessionHandle + spawn_session / wait_ready / send / terminate. Mirrors container_lifecycle.py shape exactly (DEFAULT_* constants, _run_tmux helper paralleling _run_docker, fail-open terminate, two-call literal+Enter send pattern from fleet_supervisor.py).
- \`src/dispatcher/session_manager.py\` — Backend StrEnum (TMUX | CONTAINER) + SessionManager with mechanical dispatch. CONTAINER.send raises NotImplementedError (containers receive HTTP-forwarded LiteLLM requests, not free-text).
- \`tests/dispatcher/test_tmux_lifecycle.py\` — 12 mocked tests.
- \`tests/dispatcher/test_session_manager.py\` — 10 mocked tests.

## Verification — both Sonar dimensions check on PR open (per fresh lesson)

\`\`\`
$ python3 -m pytest tests/dispatcher/test_tmux_lifecycle.py tests/dispatcher/test_session_manager.py -v
22 passed in 0.10s

$ python3 -m pytest tests/dispatcher/  # full dispatcher regression
72 passed in 0.36s

$ python3 -m ruff check ...
All checks passed!

$ python3 -m ruff format --check ...
4 files already formatted

$ python3 -m mypy --follow-imports=skip src/dispatcher/tmux_lifecycle.py src/dispatcher/session_manager.py
Success: no issues found in 2 source files

$ python3 -c "from src.dispatcher.session_manager import SessionManager, Backend; from src.dispatcher.tmux_lifecycle import spawn_session, wait_ready, send, terminate, SessionHandle, SessionStartupError, TmuxUnavailableError; print('imports OK')"
imports OK
\`\`\`

## Design decisions

- **Backend at construct time** (not per-call) — Strangler Fig router picks backend per route; one SessionManager = one stable backend for a spawned session's lifetime.
- **No SessionManager-level exception class** — callers handle backend-native SessionStartupError / ContainerStartupError directly. One exception per backend keeps error semantics undiluted.
- **Backend.CONTAINER.send raises NotImplementedError** — explicit refusal beats silent no-op. HTTP-forward path is the right primitive for container backends.
- **wait_ready inlines capture-pane subprocess** (vs _run_tmux helper) — a missing tmux MID-poll should surface as failed wait, not "tmux unavailable". Same shape as container_lifecycle._probe_health vs _run_docker.
- **StrEnum (3.11+)** per ruff UP042 — identical runtime behavior, cleaner.

## Test plan

- [x] 22/22 unit tests pass
- [x] 72/72 dispatcher regression pass (no breakage to test_container_jwt / test_container_monitor / test_governance_proxy / test_valkey_pool)
- [x] Ruff lint + format clean
- [x] MyPy clean (isolated)
- [x] No callers wired (matches spec — that's KEI-185/191)
- [ ] CI gates (pending push)
- [ ] Dual-CTO review (Aiden + Max)

## Sequencing

Unblocks KEI-185 (Nova spawn via SessionManager) + KEI-191 (existing 6 agents migration). Per Dave's S4-cutover gate: Dispatcher /health 200 → Nova spawn → 6-agent migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)