### PR TITLE
[ATLAS] feat(kei143): callsign-vs-IDENTITY.md pre-commit hook (LAW XVII guard)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,17 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  # KEI-143: callsign-vs-IDENTITY.md mismatch guard. Blocks commits when the
+  # CALLSIGN env var is set but doesn't match the local IDENTITY.md. Catches
+  # the cross-worktree mistake before commits land with the wrong callsign tag.
+  # Skipped silently when CALLSIGN env is unset (humans without the agent env).
+  - repo: local
+    hooks:
+      - id: check-callsign-match
+        name: callsign matches IDENTITY.md (LAW XVII)
+        entry: bash scripts/git/check_callsign_match.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [commit]

--- a/scripts/git/check_callsign_match.sh
+++ b/scripts/git/check_callsign_match.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# check_callsign_match.sh — KEI-143 pre-commit hook.
+#
+# Enforces LAW XVII (Callsign Discipline): when CALLSIGN env is set, it MUST
+# match the IDENTITY.md in the current worktree. Blocks commits with mismatched
+# callsign so an agent operating in the wrong clone worktree can't accidentally
+# tag commits with another callsign's identity.
+#
+# Behavior:
+#   - CALLSIGN env unset                   → pass (warn-only). Humans running
+#                                            `git commit` without the env var
+#                                            shouldn't be blocked.
+#   - CALLSIGN env set + IDENTITY.md missing → FAIL. Governance violation per
+#                                            CLAUDE.md ("STOP if IDENTITY.md missing").
+#   - CALLSIGN env set + value matches     → pass.
+#   - CALLSIGN env set + value mismatches  → FAIL with clear error showing both
+#                                            expected and actual callsigns.
+#
+# Usage (manual):
+#   CALLSIGN=atlas bash scripts/git/check_callsign_match.sh
+#
+# Usage (pre-commit — wired via .pre-commit-config.yaml):
+#   pre-commit runs this on every staged commit; non-zero exit blocks the commit.
+
+set -eu
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+IDENTITY_FILE="${REPO_ROOT}/IDENTITY.md"
+
+# Unset CALLSIGN env → pass (humans + initial worktree setup before env is wired).
+if [[ -z "${CALLSIGN:-}" ]]; then
+    exit 0
+fi
+
+# CALLSIGN env set but IDENTITY.md missing → governance violation, block.
+if [[ ! -f "${IDENTITY_FILE}" ]]; then
+    echo "check_callsign_match: ERROR — CALLSIGN env is '${CALLSIGN}' but IDENTITY.md is missing from ${REPO_ROOT}." >&2
+    echo "  Governance: per CLAUDE.md + LAW XVII, every worktree must carry an IDENTITY.md anchoring the callsign." >&2
+    exit 1
+fi
+
+# Parse `**CALLSIGN:** <name>` from IDENTITY.md. Tolerant of leading/trailing
+# whitespace + extra blank lines. Case-insensitive match on the key, lowercase
+# the captured value for comparison.
+identity_callsign="$(awk -F'\\*\\*CALLSIGN:\\*\\*[[:space:]]+' '/CALLSIGN/ {print $2; exit}' "${IDENTITY_FILE}" | tr '[:upper:]' '[:lower:]' | xargs)"
+env_callsign="$(echo "${CALLSIGN}" | tr '[:upper:]' '[:lower:]' | xargs)"
+
+if [[ -z "${identity_callsign}" ]]; then
+    echo "check_callsign_match: ERROR — IDENTITY.md present but no '**CALLSIGN:** <name>' line found." >&2
+    echo "  Expected format: '**CALLSIGN:** atlas' (or elliot / aiden / max / orion / scout / nova)." >&2
+    exit 1
+fi
+
+if [[ "${env_callsign}" != "${identity_callsign}" ]]; then
+    echo "check_callsign_match: ERROR — callsign mismatch." >&2
+    echo "  CALLSIGN env: ${CALLSIGN}" >&2
+    echo "  IDENTITY.md:  ${identity_callsign}" >&2
+    echo "  You are running in the wrong worktree. Switch to the correct" >&2
+    echo "  clone OR set CALLSIGN to match IDENTITY.md before committing." >&2
+    exit 1
+fi
+
+exit 0

--- a/tests/scripts/test_check_callsign_match.py
+++ b/tests/scripts/test_check_callsign_match.py
@@ -1,0 +1,129 @@
+"""KEI-143 — tests for scripts/git/check_callsign_match.sh.
+
+Runs the hook script via subprocess against fixture IDENTITY.md files under
+tmp_path, asserting exit code + stderr per the documented behavior matrix.
+
+Tests use git worktree isolation via env GIT_TOPLEVEL_OVERRIDE NO — instead
+they invoke the script with cwd=tmp_path and the script's `git rev-parse
+--show-toplevel` returns tmp_path because we `git init` it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "git" / "check_callsign_match.sh"
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repo at tmp_path so the script's `git rev-parse
+    --show-toplevel` succeeds and resolves to tmp_path."""
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", "-q", str(tmp_path)],
+        check=True,
+    )
+    return tmp_path
+
+
+def _write_identity(repo: Path, callsign: str | None) -> None:
+    """Write IDENTITY.md with a CALLSIGN line, OR omit the file if None."""
+    if callsign is None:
+        return
+    (repo / "IDENTITY.md").write_text(
+        f"# IDENTITY\n\n**CALLSIGN:** {callsign}\n**Workspace:** {repo}\n"
+    )
+
+
+def _run_hook(repo: Path, env: dict[str, str]) -> subprocess.CompletedProcess:
+    """Invoke the hook with cwd=repo + the given env. Returns the
+    CompletedProcess for assertions."""
+    base_env = {k: v for k, v in os.environ.items() if k != "CALLSIGN"}
+    base_env.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=str(repo),
+        env=base_env,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ─── positive paths ───────────────────────────────────────────────────────
+
+
+def test_pass_when_callsign_env_unset(tmp_path):
+    """Humans without the env var must NOT be blocked — exit 0."""
+    repo = _init_repo(tmp_path)
+    _write_identity(repo, "atlas")
+    result = _run_hook(repo, env={})  # no CALLSIGN
+    assert result.returncode == 0, result.stderr
+
+
+def test_pass_on_exact_match(tmp_path):
+    repo = _init_repo(tmp_path)
+    _write_identity(repo, "atlas")
+    result = _run_hook(repo, env={"CALLSIGN": "atlas"})
+    assert result.returncode == 0, result.stderr
+
+
+def test_pass_on_case_insensitive_match(tmp_path):
+    """CALLSIGN=ATLAS env vs IDENTITY.md 'atlas' — match (case folded)."""
+    repo = _init_repo(tmp_path)
+    _write_identity(repo, "atlas")
+    result = _run_hook(repo, env={"CALLSIGN": "ATLAS"})
+    assert result.returncode == 0, result.stderr
+
+
+def test_pass_on_whitespace_tolerance(tmp_path):
+    """Trailing whitespace in IDENTITY.md line + env — both stripped."""
+    repo = _init_repo(tmp_path)
+    (repo / "IDENTITY.md").write_text("**CALLSIGN:** atlas   \n")
+    result = _run_hook(repo, env={"CALLSIGN": "  atlas  "})
+    assert result.returncode == 0, result.stderr
+
+
+# ─── negative paths (the actual point of the hook) ────────────────────────
+
+
+def test_fail_on_mismatch(tmp_path):
+    """CALLSIGN env says elliot, IDENTITY.md says atlas → blocked."""
+    repo = _init_repo(tmp_path)
+    _write_identity(repo, "atlas")
+    result = _run_hook(repo, env={"CALLSIGN": "elliot"})
+    assert result.returncode == 1
+    assert "mismatch" in result.stderr
+    assert "CALLSIGN env: elliot" in result.stderr
+    assert "IDENTITY.md:  atlas" in result.stderr
+
+
+def test_fail_when_identity_missing(tmp_path):
+    """CALLSIGN env set, IDENTITY.md absent → governance violation, block."""
+    repo = _init_repo(tmp_path)
+    # NO IDENTITY.md written
+    result = _run_hook(repo, env={"CALLSIGN": "atlas"})
+    assert result.returncode == 1
+    assert "IDENTITY.md is missing" in result.stderr
+
+
+def test_fail_when_identity_has_no_callsign_line(tmp_path):
+    """IDENTITY.md exists but lacks the CALLSIGN line — block with the
+    expected-format hint so the operator can fix the file."""
+    repo = _init_repo(tmp_path)
+    (repo / "IDENTITY.md").write_text("# IDENTITY\n\nSomething else here.\n")
+    result = _run_hook(repo, env={"CALLSIGN": "atlas"})
+    assert result.returncode == 1
+    assert "no '**CALLSIGN:** <name>' line found" in result.stderr
+
+
+def test_fail_message_includes_both_callsigns(tmp_path):
+    """The mismatch error must show BOTH the env value AND the file value
+    so the operator immediately sees which worktree they're in vs which
+    callsign they should switch to."""
+    repo = _init_repo(tmp_path)
+    _write_identity(repo, "orion")
+    result = _run_hook(repo, env={"CALLSIGN": "scout"})
+    assert result.returncode == 1
+    assert "scout" in result.stderr.lower()
+    assert "orion" in result.stderr.lower()


### PR DESCRIPTION
## Summary

Closes Linear KEI-143. Blocks commits when \`CALLSIGN\` env var is set but doesn't match local \`IDENTITY.md\` — catches the cross-worktree mistake before commits land with the wrong callsign tag.

## Why

Multi-clone architecture has 6+ worktrees (atlas / elliot / aiden / orion / max / scout) each with its own \`IDENTITY.md\`. The supervisor wraps each agent process with \`CALLSIGN=<name>\`. If an agent operates in the wrong clone (cd'd into another worktree, dispatch mis-routed), commits land tagged with the wrong callsign. \`[REVIEW:HOLD-FINAL:atlas]\` from elliot's worktree (or vice-versa) is a real outage shape — already happened per the \`feedback_check_branch_before_checkout\` pin anchored to PR #851 contamination.

This hook is the mechanical guard: env vs file must match, or commit is blocked at \`pre-commit\` stage.

## Behavior matrix

| CALLSIGN env | IDENTITY.md state | Outcome |
|---|---|---|
| unset | (any) | **pass** — humans without env not blocked |
| set | missing | **FAIL** — \"IDENTITY.md is missing\" |
| set | present, no `**CALLSIGN:**` line | **FAIL** with format hint |
| set | matches (case-folded, whitespace-tolerated) | **pass** |
| set | mismatches | **FAIL** with both values + worktree-switch hint |

## What ships (3 files, +206 / 0)

| Path | Purpose |
|---|---|
| \`scripts/git/check_callsign_match.sh\` | Bash hook script. Parses \`**CALLSIGN:** <name>\` via awk, case-folds + strips whitespace before compare, clear-message errors per failure mode |
| \`.pre-commit-config.yaml\` | Adds \`local\` repo entry alongside existing ruff hooks. \`always_run\` + \`pass_filenames=false\` so it runs once per commit regardless of staged files |
| \`tests/scripts/test_check_callsign_match.py\` | 8 tests via subprocess against fixture IDENTITY.md in tmp_path-isolated \`git init\` repos |

## Empirical smoke (this atlas worktree)

\`\`\`
$ CALLSIGN=atlas bash scripts/git/check_callsign_match.sh && echo OK
OK

$ CALLSIGN=elliot bash scripts/git/check_callsign_match.sh
check_callsign_match: ERROR — callsign mismatch.
  CALLSIGN env: elliot
  IDENTITY.md:  atlas
  You are running in the wrong worktree. Switch to the correct
  clone OR set CALLSIGN to match IDENTITY.md before committing.
(exit 1)

$ env -u CALLSIGN bash scripts/git/check_callsign_match.sh && echo OK
OK   (humans not blocked)
\`\`\`

## Test plan

- [x] \`pytest tests/scripts/test_check_callsign_match.py -v\` — **8/8 passed**.
- [x] \`ruff check + format --check\` — All checks passed.
- [x] \`bash -n scripts/git/check_callsign_match.sh\` — syntax OK.
- [x] Empirical 3-path smoke against real atlas worktree — match (OK), mismatch (blocked with both values), unset (OK).

Coverage:
- env-unset → pass
- exact-match → pass
- case-insensitive → pass (\`ATLAS\` env vs \`atlas\` file)
- whitespace-tolerated → pass
- mismatch → fail with both values in error
- IDENTITY.md missing → fail with governance citation
- IDENTITY.md present but no \`**CALLSIGN:**\` line → fail with format hint
- mismatch error contains both callsigns (operator clarity)

## Acceptance (Linear KEI-143)

- [x] Hook blocks commits with mismatched CALLSIGN → `test_fail_on_mismatch` + empirical
- [x] Test with wrong CALLSIGN env fails → same
- [x] Passes after fix → `test_pass_on_exact_match` + empirical

🤖 Generated with [Claude Code](https://claude.com/claude-code)