### PR TITLE
[ORION] feat(kei141): systemd service health monitor — failed-unit detection + #ceo alert

### DIFF
--- a/infra/systemd/agents/systemd-health-monitor.service
+++ b/infra/systemd/agents/systemd-health-monitor.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Agency OS — KEI-141 systemd service health monitor
+Documentation=https://linear.app/keiracom/issue/KEI-141
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/systemd_health_monitor.py
+StandardOutput=append:/home/elliotbot/clawd/logs/systemd-health-monitor.log
+StandardError=append:/home/elliotbot/clawd/logs/systemd-health-monitor.log
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/agents/systemd-health-monitor.timer
+++ b/infra/systemd/agents/systemd-health-monitor.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Agency OS — KEI-141 systemd health monitor timer
+Documentation=https://linear.app/keiracom/issue/KEI-141
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=30s
+AccuracySec=5s
+Unit=systemd-health-monitor.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/install_systemd_health_monitor.sh
+++ b/scripts/install_systemd_health_monitor.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# install_systemd_health_monitor.sh — KEI-141 install entry-point.
+#
+# KEI-108 CI gate: this file anchors systemd-health-monitor.service for the grep gate.
+#
+# Installs the systemd-health-monitor.service (oneshot) and its 30s timer.
+# Does NOT install or modify any other unit files (unit-file changes are
+# Atlas's lane — file as KEI-141-followup).
+#
+# Usage:
+#   scripts/install_systemd_health_monitor.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UNIT_DIR="$HOME/.config/systemd/user"
+LOG_DIR="/home/elliotbot/clawd/logs"
+
+SVC_SRC="$REPO_ROOT/infra/systemd/agents/systemd-health-monitor.service"
+TMR_SRC="$REPO_ROOT/infra/systemd/agents/systemd-health-monitor.timer"
+
+# ── preflight ────────────────────────────────────────────────────────────────
+for src in "$SVC_SRC" "$TMR_SRC"; do
+    if [[ ! -f "$src" ]]; then
+        echo "install_systemd_health_monitor: missing source: $src" >&2
+        exit 2
+    fi
+done
+
+install -d -m 0755 "$UNIT_DIR"
+install -d -m 0755 "$LOG_DIR"
+
+# ── copy unit files ──────────────────────────────────────────────────────────
+install -m 0644 "$SVC_SRC" "$UNIT_DIR/systemd-health-monitor.service"
+install -m 0644 "$TMR_SRC" "$UNIT_DIR/systemd-health-monitor.timer"
+
+systemctl --user daemon-reload
+
+# ── enable + start timer (timer drives the oneshot service) ─────────────────
+systemctl --user enable systemd-health-monitor.timer
+systemctl --user restart systemd-health-monitor.timer
+
+echo "[install] systemd-health-monitor.timer installed + active"
+echo "--- post-install timer state ---"
+systemctl --user is-active systemd-health-monitor.timer || true
+
+# Anchored unit: systemd-health-monitor.service

--- a/scripts/orchestrator/systemd_health_monitor.py
+++ b/scripts/orchestrator/systemd_health_monitor.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""KEI-141 — systemd service health monitor.
+
+Polls `systemctl --user list-units --state=failed --no-legend` every 30s
+(via the .timer below) for failed Agency_OS fleet units. Posts a #ceo
+alert via the `tg` CLI on first detection of each failure; dedups
+subsequent cycles via an on-disk state file so we don't spam alerts.
+
+When a previously-failed unit returns to 'active', clears it from
+the state file (and posts a #ceo recovery note).
+
+Fleet patterns monitored (all matched against `systemctl --user
+list-units --all` output, NOT hardcoded — picks up new units automatically):
+  - *-agent.service          (agent services)
+  - *-indexer.service        (Weaviate indexers)
+  - *-watcher.service        (relay watchers)
+  - central-listener.service (Slack relay listener)
+  - fleet-supervisor.service (the supervisor itself)
+
+NOT in scope this PR:
+  - Restart-loop cap via StartLimitBurst/StartLimitIntervalSec on each
+    unit file — that's Atlas's unit-files lane; file as KEI-141-followup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import fnmatch
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger("systemd_health_monitor")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+# Reasonable defaults; overridable via env for testing
+DEFAULT_STATE_PATH = Path(
+    os.environ.get(
+        "HEALTH_MONITOR_STATE",
+        "/home/elliotbot/clawd/logs/systemd_health_state.json",
+    )
+)
+DEFAULT_TG_CLI = os.environ.get("HEALTH_MONITOR_TG_CLI", "/home/elliotbot/.local/bin/tg")
+SYSTEMCTL = "systemctl"
+
+# Patterns we care about — anything matching one of these globs is in fleet scope
+FLEET_PATTERNS = (
+    "*-agent.service",
+    "*-indexer.service",
+    "*-watcher.service",
+    "central-listener.service",
+    "fleet-supervisor.service",
+)
+
+
+def _matches_fleet(name: str) -> bool:
+    return any(fnmatch.fnmatch(name, pattern) for pattern in FLEET_PATTERNS)
+
+
+def _run_systemctl(extra_args: list[str]) -> list[str]:
+    """Run systemctl --user with extra_args; return stdout lines.
+
+    Raises FileNotFoundError if systemctl is absent (config error → exit 2).
+    Returns [] on any other subprocess error (fail-open per monitor discipline).
+    """
+    cmd = [SYSTEMCTL, "--user", "--no-legend", "--plain", "--all"] + extra_args
+    try:
+        result = subprocess.run(  # noqa: S603 — controlled args, no shell
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        return result.stdout.splitlines()
+    except FileNotFoundError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — fail-open per monitor discipline
+        logger.warning("systemctl invocation error — fail-open: %s", exc)
+        return []
+
+
+def list_failed_units() -> list[str]:
+    """Return names of fleet units currently in failed state.
+
+    Uses systemctl --user list-units --state=failed --no-legend --plain --all
+    + fnmatch filter against FLEET_PATTERNS.
+    """
+    lines = _run_systemctl(["list-units", "--state=failed"])
+    names: list[str] = []
+    for line in lines:
+        parts = line.split()
+        if not parts:
+            continue
+        name = parts[0]
+        if _matches_fleet(name):
+            names.append(name)
+    return names
+
+
+def list_active_units() -> list[str]:
+    """Return names of fleet units currently in active state.
+
+    Used for recovery detection — checks which previously-failed units are
+    now healthy.
+    """
+    lines = _run_systemctl(["list-units", "--state=active"])
+    names: list[str] = []
+    for line in lines:
+        parts = line.split()
+        if not parts:
+            continue
+        name = parts[0]
+        if _matches_fleet(name):
+            names.append(name)
+    return names
+
+
+def load_state(path: Path) -> dict:
+    """Load on-disk state file. Returns {} on missing/malformed."""
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:  # noqa: BLE001 — fail-open per monitor discipline
+        logger.warning("load_state: failed to read %s — returning empty: %s", path, exc)
+        return {}
+
+
+def save_state(path: Path, state: dict) -> None:
+    """Best-effort save. Logs on failure but doesn't raise."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2))
+    except Exception as exc:  # noqa: BLE001 — fail-open per monitor discipline
+        logger.warning("save_state: failed to write %s: %s", path, exc)
+
+
+def post_alert(tg_cli: str, message: str) -> bool:
+    """Run `tg -c ceo <message>` via subprocess. Returns True on success.
+
+    Logs warning and returns False on any error — never raises (fail-open
+    so monitor keeps running even if tg breaks).
+    """
+    try:
+        result = subprocess.run(  # noqa: S603 — controlled args, no shell
+            [tg_cli, "-c", "ceo", message],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "post_alert: tg returned rc=%d — stderr: %s",
+                result.returncode,
+                result.stderr.strip(),
+            )
+            return False
+        return True
+    except Exception as exc:  # noqa: BLE001 — fail-open per monitor discipline
+        logger.warning("post_alert: tg invocation failed: %s", exc)
+        return False
+
+
+def _derive_callsign(unit: str) -> str:
+    """Derive a human-readable callsign from unit name.
+
+    <callsign>-agent.service → <callsign>
+    All other patterns      → "system"
+    """
+    if unit.endswith("-agent.service"):
+        return unit[: -len("-agent.service")]
+    return "system"
+
+
+def detect_changes(
+    failed_now: list[str],
+    active_now: list[str],
+    previously_failed: list[str],
+) -> tuple[list[str], list[str]]:
+    """Return (newly_failed, recovered) for alert generation.
+
+    - newly_failed: in failed_now AND NOT in previously_failed
+    - recovered:    in active_now AND in previously_failed
+    """
+    failed_now_set = set(failed_now)
+    active_now_set = set(active_now)
+    prev_set = set(previously_failed)
+
+    newly_failed = sorted(failed_now_set - prev_set)
+    recovered = sorted(active_now_set & prev_set)
+    return newly_failed, recovered
+
+
+def main(argv: list[str] | None = None) -> int:
+    """One-shot run. systemd timer invokes every 30s.
+
+    Flow:
+      1. List failed + active fleet units now.
+      2. Load previously-failed state.
+      3. Detect newly-failed (alert with 🚨) and recovered (alert with ✅).
+      4. Save new state = currently-failed.
+      5. Exit 0 unless DETECTOR itself errored (systemctl not present etc.)
+         — fail-open on alert failure (logged).
+    """
+    parser = argparse.ArgumentParser(description="KEI-141 systemd health monitor")
+    parser.add_argument(
+        "--state",
+        type=Path,
+        default=DEFAULT_STATE_PATH,
+        help="Path to on-disk dedup state file",
+    )
+    parser.add_argument(
+        "--tg-cli",
+        default=DEFAULT_TG_CLI,
+        help="Path to the tg CLI binary",
+    )
+    args = parser.parse_args(argv)
+
+    ts = _dt.datetime.now(_dt.UTC).isoformat()
+
+    try:
+        failed_now = list_failed_units()
+        active_now = list_active_units()
+    except FileNotFoundError:
+        logger.error("systemctl not found — cannot monitor fleet (configuration error)")
+        return 2
+
+    state = load_state(args.state)
+    previously_failed: list[str] = state.get("failed_units", [])
+
+    newly_failed, recovered = detect_changes(failed_now, active_now, previously_failed)
+
+    for unit in newly_failed:
+        callsign = _derive_callsign(unit)
+        msg = f"🚨 systemd: {unit} failed (callsign={callsign} at {ts})"
+        logger.warning(msg)
+        post_alert(args.tg_cli, msg)
+
+    for unit in recovered:
+        msg = f"✅ systemd: {unit} recovered"
+        logger.info(msg)
+        post_alert(args.tg_cli, msg)
+
+    save_state(args.state, {"failed_units": failed_now, "updated_at": ts})
+
+    logger.info(
+        "scan complete — failed=%d newly_failed=%d recovered=%d",
+        len(failed_now),
+        len(newly_failed),
+        len(recovered),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/systemd_health_monitor.py
+++ b/scripts/orchestrator/systemd_health_monitor.py
@@ -69,7 +69,8 @@ def _run_systemctl(extra_args: list[str]) -> list[str]:
     """
     cmd = [SYSTEMCTL, "--user", "--no-legend", "--plain", "--all"] + extra_args
     try:
-        result = subprocess.run(  # noqa: S603 — controlled args, no shell
+        # Controlled args (constant SYSTEMCTL + literal flags), no shell.
+        result = subprocess.run(  # noqa: S603
             cmd,
             capture_output=True,
             text=True,
@@ -147,7 +148,8 @@ def post_alert(tg_cli: str, message: str) -> bool:
     so monitor keeps running even if tg breaks).
     """
     try:
-        result = subprocess.run(  # noqa: S603 — controlled args, no shell
+        # Controlled args (tg cli + literal channel name), no shell.
+        result = subprocess.run(  # noqa: S603
             [tg_cli, "-c", "ceo", message],
             capture_output=True,
             text=True,

--- a/tests/scripts/test_systemd_health_monitor.py
+++ b/tests/scripts/test_systemd_health_monitor.py
@@ -1,0 +1,246 @@
+"""Tests for scripts/orchestrator/systemd_health_monitor.py — KEI-141.
+
+All subprocess calls are mocked; no real systemctl or tg invocations.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "orchestrator" / "systemd_health_monitor.py"
+
+
+@pytest.fixture(scope="module")
+def mon():
+    spec = importlib.util.spec_from_file_location("systemd_health_monitor", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["systemd_health_monitor"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── list_failed_units ────────────────────────────────────────────────────────
+
+_SYSTEMCTL_FAILED_OUTPUT = """\
+orion-agent.service       loaded failed failed  Orion agent
+atlas-agent.service       loaded failed failed  Atlas agent
+cron.service              loaded failed failed  Cron daemon
+"""
+
+
+def test_list_failed_units_parses_systemctl_output(mon, monkeypatch):
+    """Parses first token per line and returns matching fleet unit names."""
+    fake = CompletedProcess(args=[], returncode=0, stdout=_SYSTEMCTL_FAILED_OUTPUT, stderr="")
+    monkeypatch.setattr(
+        "systemd_health_monitor.subprocess.run",
+        lambda *a, **kw: fake,
+    )
+    result = mon.list_failed_units()
+    assert "orion-agent.service" in result
+    assert "atlas-agent.service" in result
+
+
+def test_list_failed_units_filters_non_fleet(mon, monkeypatch):
+    """Units not matching FLEET_PATTERNS are excluded."""
+    fake = CompletedProcess(args=[], returncode=0, stdout=_SYSTEMCTL_FAILED_OUTPUT, stderr="")
+    monkeypatch.setattr(
+        "systemd_health_monitor.subprocess.run",
+        lambda *a, **kw: fake,
+    )
+    result = mon.list_failed_units()
+    assert "cron.service" not in result
+
+
+def test_list_failed_units_empty_when_no_failures(mon, monkeypatch):
+    """Empty stdout produces an empty list."""
+    fake = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    monkeypatch.setattr(
+        "systemd_health_monitor.subprocess.run",
+        lambda *a, **kw: fake,
+    )
+    result = mon.list_failed_units()
+    assert result == []
+
+
+# ── load_state ───────────────────────────────────────────────────────────────
+
+
+def test_load_state_missing_returns_empty(mon, tmp_path):
+    """Non-existent path returns {} without raising."""
+    path = tmp_path / "nonexistent_state.json"
+    assert mon.load_state(path) == {}
+
+
+def test_load_state_malformed_returns_empty(mon, tmp_path):
+    """Corrupt JSON content returns {} without raising."""
+    path = tmp_path / "bad_state.json"
+    path.write_text("this is not json {{{{")
+    assert mon.load_state(path) == {}
+
+
+# ── save_state ───────────────────────────────────────────────────────────────
+
+
+def test_save_state_writes_json(mon, tmp_path):
+    """Round-trip: save then load recovers the original dict."""
+    path = tmp_path / "state.json"
+    data = {"failed_units": ["orion-agent.service"], "updated_at": "2026-05-18T00:00:00+00:00"}
+    mon.save_state(path, data)
+    recovered = json.loads(path.read_text())
+    assert recovered == data
+
+
+def test_save_state_swallows_oserror(mon, tmp_path):
+    """Read-only directory: save_state logs but does not raise."""
+    ro_dir = tmp_path / "readonly"
+    ro_dir.mkdir(mode=0o444)
+    path = ro_dir / "state.json"
+    # Should complete without raising even though write will fail
+    mon.save_state(path, {"failed_units": []})
+    # If we reach here the function did not raise
+    ro_dir.chmod(0o755)  # restore so tmp_path cleanup works
+
+
+# ── post_alert ───────────────────────────────────────────────────────────────
+
+
+def test_post_alert_invokes_tg_cli_with_ceo_channel(mon, monkeypatch):
+    """tg is called with -c ceo and the message string."""
+    captured: list = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(cmd)
+        return CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("systemd_health_monitor.subprocess.run", fake_run)
+    result = mon.post_alert("/usr/local/bin/tg", "test alert")
+    assert result is True
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert cmd[0] == "/usr/local/bin/tg"
+    assert "-c" in cmd
+    assert "ceo" in cmd
+    assert "test alert" in cmd
+
+
+def test_post_alert_returns_false_on_tg_failure(mon, monkeypatch):
+    """Non-zero returncode from tg returns False without raising."""
+    fake = CompletedProcess(args=[], returncode=1, stdout="", stderr="error from tg")
+    monkeypatch.setattr(
+        "systemd_health_monitor.subprocess.run",
+        lambda *a, **kw: fake,
+    )
+    result = mon.post_alert("/usr/local/bin/tg", "fail message")
+    assert result is False
+
+
+# ── detect_changes ───────────────────────────────────────────────────────────
+
+
+def test_detect_changes_newly_failed(mon):
+    """Unit in failed_now but not in previously_failed → newly_failed."""
+    newly, recovered = mon.detect_changes(
+        failed_now=["orion-agent.service"],
+        active_now=[],
+        previously_failed=[],
+    )
+    assert "orion-agent.service" in newly
+    assert recovered == []
+
+
+def test_detect_changes_recovered(mon):
+    """Unit in active_now that was previously_failed → recovered."""
+    newly, recovered = mon.detect_changes(
+        failed_now=[],
+        active_now=["orion-agent.service"],
+        previously_failed=["orion-agent.service"],
+    )
+    assert newly == []
+    assert "orion-agent.service" in recovered
+
+
+def test_detect_changes_persistent_failure_no_alert(mon):
+    """Unit in both failed_now and previously_failed → no change (dedup)."""
+    newly, recovered = mon.detect_changes(
+        failed_now=["orion-agent.service"],
+        active_now=[],
+        previously_failed=["orion-agent.service"],
+    )
+    assert newly == []
+    assert recovered == []
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+
+def test_main_alerts_on_newly_failed(mon, tmp_path, monkeypatch):
+    """When a fleet unit is newly failed, main() calls tg with 🚨 and unit name."""
+    state_path = tmp_path / "state.json"
+    alerts_sent: list[str] = []
+
+    monkeypatch.setattr(mon, "list_failed_units", lambda: ["orion-agent.service"])
+    monkeypatch.setattr(mon, "list_active_units", lambda: [])
+    monkeypatch.setattr(mon, "post_alert", lambda cli, msg: alerts_sent.append(msg) or True)
+
+    rc = mon.main(["--state", str(state_path), "--tg-cli", "/usr/local/bin/tg"])
+
+    assert rc == 0
+    assert len(alerts_sent) == 1
+    assert "orion-agent.service" in alerts_sent[0]
+    assert "🚨" in alerts_sent[0]
+
+
+def test_main_alerts_on_recovery(mon, tmp_path, monkeypatch):
+    """When a previously-failed unit is now active, main() calls tg with ✅."""
+    state_path = tmp_path / "state.json"
+    # Seed state with a previously-failed unit
+    state_path.write_text(json.dumps({"failed_units": ["orion-agent.service"]}))
+    alerts_sent: list[str] = []
+
+    monkeypatch.setattr(mon, "list_failed_units", lambda: [])
+    monkeypatch.setattr(mon, "list_active_units", lambda: ["orion-agent.service"])
+    monkeypatch.setattr(mon, "post_alert", lambda cli, msg: alerts_sent.append(msg) or True)
+
+    rc = mon.main(["--state", str(state_path), "--tg-cli", "/usr/local/bin/tg"])
+
+    assert rc == 0
+    assert len(alerts_sent) == 1
+    assert "orion-agent.service" in alerts_sent[0]
+    assert "✅" in alerts_sent[0]
+
+
+def test_main_no_alert_on_steady_state(mon, tmp_path, monkeypatch):
+    """A unit that was failed last cycle and is still failed → no alert this cycle."""
+    state_path = tmp_path / "state.json"
+    state_path.write_text(json.dumps({"failed_units": ["orion-agent.service"]}))
+    alerts_sent: list[str] = []
+
+    monkeypatch.setattr(mon, "list_failed_units", lambda: ["orion-agent.service"])
+    monkeypatch.setattr(mon, "list_active_units", lambda: [])
+    monkeypatch.setattr(mon, "post_alert", lambda cli, msg: alerts_sent.append(msg) or True)
+
+    rc = mon.main(["--state", str(state_path), "--tg-cli", "/usr/local/bin/tg"])
+
+    assert rc == 0
+    assert alerts_sent == []
+
+
+def test_main_exits_2_when_systemctl_missing(mon, tmp_path, monkeypatch):
+    """FileNotFoundError from systemctl → exit code 2."""
+    state_path = tmp_path / "state.json"
+
+    def raise_fnf():
+        raise FileNotFoundError("systemctl not found")
+
+    monkeypatch.setattr(mon, "list_failed_units", raise_fnf)
+
+    rc = mon.main(["--state", str(state_path), "--tg-cli", "/usr/local/bin/tg"])
+
+    assert rc == 2


### PR DESCRIPTION
## Summary

KEI-141 — periodic systemd health monitor. Polls every 30s; on first detection of any failed fleet unit posts \`🚨 systemd: <unit> failed (callsign=<X> at <ts>)\` to #ceo via the \`tg\` CLI. Dedups subsequent cycles via on-disk state. Posts \`✅ recovered\` when a previously-failed unit returns to active.

Per CEO directive 2026-05-18 queue-empty dispatch.

## What ships (5 files)

| File | Purpose | LoC |
|---|---|---|
| \`scripts/orchestrator/systemd_health_monitor.py\` | one-shot poller (systemctl + fnmatch + tg) | 161 |
| \`infra/systemd/agents/systemd-health-monitor.service\` | oneshot service | 14 |
| \`infra/systemd/agents/systemd-health-monitor.timer\` | 30s timer (OnUnitActiveSec=30s, AccuracySec=5s) | 12 |
| \`scripts/install_systemd_health_monitor.sh\` | install + KEI-108 anchor | 30 |
| \`tests/scripts/test_systemd_health_monitor.py\` | 16 mocked pytest tests | ~180 |

## Fleet patterns monitored

\`*-agent.service\`, \`*-indexer.service\`, \`*-watcher.service\`, \`central-listener.service\`, \`fleet-supervisor.service\` — glob-matched against live \`systemctl --user list-units --all\` output so new units auto-included without code changes.

## Verification (verbatim — both Sonar endpoints will be checked on push)

\`\`\`
$ python3 -m pytest tests/scripts/test_systemd_health_monitor.py -v
16 passed in 0.09s

$ python3 -m ruff check ...
All checks passed!

$ python3 -m ruff format --check ...
2 files already formatted

$ bash -n scripts/install_systemd_health_monitor.sh
(exit 0)

$ grep -l "systemd-health-monitor.service" scripts/install_systemd_health_monitor.sh
scripts/install_systemd_health_monitor.sh
\`\`\`

## Out of scope (intentional — filed as KEI-141-followup in code comment)

- \`StartLimitBurst\` / \`StartLimitIntervalSec\` restart-loop caps on the 10+ existing unit files. Atlas's unit-files lane; independent of detection. This PR ships **detection + alerting**, not unit-config hardening.

## Test plan

- [x] 16/16 unit tests pass (fully mocked subprocess + state I/O)
- [x] Ruff lint + format clean
- [x] bash syntax OK
- [x] KEI-108 op-deployment anchor present
- [x] Fail-open on tg/state/save errors (logged)
- [x] Exit 2 only on systemctl-missing (config error)
- [ ] CI gates (pending push)
- [ ] Dual-CTO review

## Acceptance (from Linear)

- ✅ Service failure detection + #ceo Slack alert within 30s (30s timer + 5s accuracy)
- ⏭ Restart loop cap via systemd MaxStartCount — **DEFERRED** to KEI-141-followup (touches Atlas's unit files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)