### PR TITLE
[AIDEN] feat(kei183-followup): structural dep enforcement in supervisor claim query

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -357,6 +357,25 @@ def fetch_open_pr_kei_ids() -> set[str]:
 
 _CANDIDATE_LIMIT = 10  # KEI-204 — top-N candidates to iterate; bounds dep-blocked rescan cost
 
+# KEI-183 follow-up (Dave 2026-05-18) — structural dep enforcement.
+# `tasks.dependencies` is a text[] ARRAY of task ids. A row is eligible only if
+# every entry resolves to a row in status='done'. This makes out-of-sequence
+# dispatch structurally impossible — no row reaches the candidate set unless
+# all its deps are done. Complements (does not replace) the title/description
+# keyword filter in extract_blocker_keis (KEI-204), which catches plain-prose
+# "depends on KEI-X" phrasings the dependencies column doesn't capture.
+_DEPS_CLAUSE = (
+    "AND (\n"
+    "    dependencies IS NULL\n"
+    "    OR cardinality(dependencies) = 0\n"
+    "    OR NOT EXISTS (\n"
+    "      SELECT 1 FROM unnest(dependencies) AS dep_id\n"
+    "      JOIN public.tasks t_dep ON t_dep.id = dep_id\n"
+    "      WHERE t_dep.status != 'done'\n"
+    "    )\n"
+    "  )\n"
+)
+
 
 def _build_task_query(
     v2: bool, open_pr_keis: set[str], callsign: str, phase_max: int
@@ -365,6 +384,10 @@ def _build_task_query(
 
     Extracted to reduce cognitive complexity in the caller (S3776).
     Four combinations: v2 × has_open_pr_filter.
+
+    KEI-183 follow-up — _DEPS_CLAUSE is injected on every path so the
+    dependency-enforcement gate is universal (v1 + v2, with and without
+    open-PR filter).
     """
     base = """
         SELECT id, title, COALESCE(description, '') FROM public.tasks
@@ -372,7 +395,10 @@ def _build_task_query(
           AND (phase IS NULL OR phase <= %s)
           AND (is_parent IS NULL OR is_parent = false)
     """
-    suffix = "ORDER BY priority ASC, created_at ASC\nLIMIT %s\nFOR UPDATE SKIP LOCKED"
+    base = base.rstrip() + "\n  " + _DEPS_CLAUSE
+    # KEI-183 follow-up — phase ASC first so lower-phase work drains before
+    # higher-phase work even within the same priority bucket (Dave directive).
+    suffix = "ORDER BY phase ASC NULLS LAST, priority ASC, created_at ASC\nLIMIT %s\nFOR UPDATE SKIP LOCKED"
     if open_pr_keis:
         if v2:
             sql = f"{base}  AND id != ALL(%s::text[])\n  AND (persona = %s OR persona IS NULL)\n{suffix}"

--- a/tests/scripts/test_fleet_supervisor_kei183.py
+++ b/tests/scripts/test_fleet_supervisor_kei183.py
@@ -176,3 +176,57 @@ def test_idle_v1_does_not_publish_nats(monkeypatch):
     fs.process_agent(AGENT_AIDEN, conn, [], 99)
 
     nats_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests 7-10: KEI-183 follow-up (Dave 2026-05-18) — structural dep enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_kei183_followup_deps_clause_present_in_all_query_paths():
+    """The dependencies-enforcement clause must inject into every path: v1 +
+    v2, with and without open-PR filter. Structural-impossibility guarantee.
+    """
+    for v2 in (False, True):
+        for open_prs in (set(), {"KEI-999"}):
+            sql, _params = fs._build_task_query(v2, open_prs, "elliot", 99)
+            assert "dependencies IS NULL" in sql, (
+                f"v2={v2} open_prs={open_prs}: dep-NULL guard missing"
+            )
+            assert "cardinality(dependencies) = 0" in sql, (
+                f"v2={v2} open_prs={open_prs}: empty-array guard missing"
+            )
+            assert "FROM unnest(dependencies)" in sql, (
+                f"v2={v2} open_prs={open_prs}: dep-row sub-query missing"
+            )
+            assert "t_dep.status != 'done'" in sql, (
+                f"v2={v2} open_prs={open_prs}: status-not-done predicate missing"
+            )
+
+
+def test_kei183_followup_order_by_phase_then_priority():
+    """ORDER BY must put phase ahead of priority — Dave directive 2026-05-18.
+    Lower-phase work drains first; priority sort breaks ties within a phase.
+    """
+    sql, _params = fs._build_task_query(False, set(), "elliot", 99)
+    phase_idx = sql.find("phase ASC")
+    priority_idx = sql.find("priority ASC")
+    assert phase_idx != -1, "ORDER BY phase ASC missing"
+    assert priority_idx != -1, "ORDER BY priority ASC missing"
+    assert phase_idx < priority_idx, "phase must precede priority in ORDER BY (Dave 2026-05-18)"
+
+
+def test_kei183_followup_deps_clause_does_not_double_inject():
+    """The dep clause appears exactly once per query (avoid double-AND
+    rewrite if _build_task_query is called twice).
+    """
+    sql, _params = fs._build_task_query(True, {"KEI-999"}, "elliot", 99)
+    assert sql.count("FROM unnest(dependencies)") == 1
+
+
+def test_kei183_followup_deps_clause_uses_qualified_join():
+    """The dep-row join must reference public.tasks explicitly so the SQL
+    works regardless of search_path (defensive against runtime schema drift).
+    """
+    sql, _params = fs._build_task_query(False, set(), "elliot", 99)
+    assert "public.tasks t_dep" in sql, "dep join must be schema-qualified"


### PR DESCRIPTION
## Summary

Per Dave directive 2026-05-18 — supervisor v2 claim query was falling back to keyword/title parsing for dep detection (KEI-204 extract_blocker_keis). The `tasks` table already has structured `dependencies` ARRAY + `phase` numeric columns. This PR makes out-of-sequence dispatch **structurally impossible** by injecting a SQL gate into `_build_task_query()` on every path (v1 + v2, with and without open-PR filter):

```sql
AND (
    dependencies IS NULL
    OR cardinality(dependencies) = 0
    OR NOT EXISTS (
      SELECT 1 FROM unnest(dependencies) AS dep_id
      JOIN public.tasks t_dep ON t_dep.id = dep_id
      WHERE t_dep.status != 'done'
    )
  )
```

ORDER BY also updated to `phase ASC NULLS LAST, priority ASC, created_at ASC` — phase ahead of priority so lower-phase work drains first within the same priority bucket (Dave directive).

KEI-204 Python-side `extract_blocker_keis` keyword filter is **retained as defense-in-depth** — catches plain-prose "depends on KEI-X" deps in task descriptions that the `dependencies` ARRAY column doesn't capture.

## Schema verification

`tasks.dependencies` is `text[]` ARRAY, `tasks.phase` is `numeric` — confirmed via Supabase MCP `information_schema.columns` query. No migration needed.

## Test plan

- [x] `pytest tests/scripts/test_fleet_supervisor_kei183.py`: 13/13 pass (4 new KEI-183 follow-up tests)
- [x] `pytest -k "claim_next_task or build_task_query or kei183"`: 5/5 pass
- [x] `ruff check` + `ruff format --check`: all green
- [x] KEI-108 wired-or-acceptance gate: exit 0 local
- [ ] CI: full mandatory pipeline green
- [ ] SonarCloud: NEW issues = 0 + QG = OK

## Files

- `scripts/fleet_supervisor.py` — _DEPS_CLAUSE constant + injected into every `_build_task_query` branch + ORDER BY change
- `tests/scripts/test_fleet_supervisor_kei183.py` — 4 new tests covering all branches, single-injection guarantee, schema-qualified join

## Out of scope

- 3 pre-existing `test_find_pr_for_review_*` failures (PR #990 removed `fetch_pr_comments` without updating tests) — left alone
- 4 pre-existing mypy errors on `_build_task_query` params tuple-shape + line 766 float/int — line numbers shift by +26 because of the new constant block, content unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)