### PR TITLE
[MAX] feat(kei207): GitHub PR merge webhook → auto-close Supabase task

### DIFF
--- a/src/api/webhooks/github.py
+++ b/src/api/webhooks/github.py
@@ -1,6 +1,7 @@
 """src/api/webhooks/github.py — GitHub → public.tasks inbound webhook.
 
 KEI-97 Part A — Dave dispatch ts ~1779024750.
+KEI-207 — PR merge → auto-close KEI tasks in public.tasks.
 
 Receives GitHub webhook POSTs at /api/webhooks/github, verifies HMAC
 signature against GITHUB_WEBHOOK_SECRET (X-Hub-Signature-256 header),
@@ -9,7 +10,10 @@ and upserts REVIEW-PR-<N> rows in public.tasks.
 Event handling:
   - pull_request action='opened'|'reopened' → INSERT/upsert REVIEW-PR-<N>
     with status='available', excluded_callsign=PR author (lowercased).
-  - pull_request action='closed' (merged or not) → UPDATE status='done'.
+  - pull_request action='closed' (merged or not) → UPDATE REVIEW-PR-<N> status='done'.
+  - pull_request action='closed' AND merged=true → additionally close matching KEI
+    task: parse KEI-\\d+ from PR title (first match); fallback: match via
+    linear_url column. No match → log + skip, no error.
 
 Fail-open: HMAC fail → 401; malformed payload → 200 logged warning
 (retry-storm guard, same pattern as src/api/webhooks/linear.py).
@@ -22,11 +26,14 @@ import hmac
 import json
 import logging
 import os
+import re
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 
 logger = logging.getLogger(__name__)
+
+_KEI_RE = re.compile(r"KEI-\d+")
 
 router = APIRouter(prefix="/api/webhooks/github", tags=["webhooks", "github"])
 
@@ -107,7 +114,10 @@ def _close_review_task(pr_number: int) -> None:
     try:
         import psycopg
 
-        with psycopg.connect(dsn, connect_timeout=10) as conn, conn.cursor() as cur:
+        with (
+            psycopg.connect(dsn, connect_timeout=10, prepare_threshold=None) as conn,
+            conn.cursor() as cur,
+        ):
             cur.execute(
                 """
                 UPDATE public.tasks
@@ -120,6 +130,99 @@ def _close_review_task(pr_number: int) -> None:
         logger.info("github webhook: closed task %s", task_id)
     except Exception as exc:  # noqa: BLE001 — webhook discipline: fail-open
         logger.warning("github webhook tasks close failed for %s: %s", task_id, exc)
+
+
+# ── KEI-207 — close KEI task on PR merge ─────────────────────────────────
+
+
+def _close_kei_task_by_id(kei_id: str) -> None:
+    """Mark a KEI task done by exact id match. Fail-open.
+
+    KEI-207: called when KEI-\\d+ found in PR title on merge.
+    prepare_threshold=None per reference_psycopg_supabase_pgbouncer (pgbouncer
+    transaction mode drops PREPARE statements).
+    """
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        logger.warning("KEI-207: kei task close skipped — DATABASE_URL/SUPABASE_DB_URL unset")
+        return
+    dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+    try:
+        import psycopg
+
+        with (
+            psycopg.connect(dsn, connect_timeout=10, prepare_threshold=None) as conn,
+            conn.cursor() as cur,
+        ):
+            cur.execute(
+                "UPDATE public.tasks SET status = 'done', updated_at = NOW() WHERE id = %s",
+                (kei_id,),
+            )
+            conn.commit()
+        logger.info("KEI-207: closed kei task %s on PR merge", kei_id)
+    except Exception as exc:  # noqa: BLE001 — webhook discipline: fail-open
+        logger.warning("KEI-207: kei task close failed for %s: %s", kei_id, exc)
+
+
+def _close_kei_task_by_pr_url(pr_url: str) -> bool:
+    """Close KEI task by matching linear_url column. Returns True if a row was updated. Fail-open.
+
+    KEI-207 fallback: when PR title contains no KEI-\\d+, attempt to match
+    tasks.linear_url against the GitHub PR html_url. Returns False on DB error
+    or no match.
+    """
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        logger.warning("KEI-207: fallback close skipped — DATABASE_URL/SUPABASE_DB_URL unset")
+        return False
+    dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+    try:
+        import psycopg
+
+        with (
+            psycopg.connect(dsn, connect_timeout=10, prepare_threshold=None) as conn,
+            conn.cursor() as cur,
+        ):
+            cur.execute(
+                "UPDATE public.tasks SET status = 'done', updated_at = NOW() WHERE linear_url = %s RETURNING id",
+                (pr_url,),
+            )
+            rows = cur.fetchall()
+            conn.commit()
+        if rows:
+            logger.info(
+                "KEI-207: fallback closed kei task(s) %s via linear_url match", [r[0] for r in rows]
+            )
+            return True
+        return False
+    except Exception as exc:  # noqa: BLE001 — webhook discipline: fail-open
+        logger.warning("KEI-207: fallback kei task close failed for url %s: %s", pr_url, exc)
+        return False
+
+
+def _handle_kei_task_close_on_merge(pr_title: str, pr_url: str) -> None:
+    """KEI-207 entry point: parse KEI-\\d+ from title; fallback to linear_url query.
+
+    Chain: title regex match → _close_kei_task_by_id.
+    No title match → _close_kei_task_by_pr_url.
+    No match either way → log + skip. No error raised; webhook stays fail-open.
+
+    Note: regex is case-sensitive (`KEI-\\d+`) matching Linear's canonical
+    uppercase convention. Lowercase 'kei-123' is intentionally not matched.
+    """
+    m = _KEI_RE.search(pr_title)
+    if m:
+        kei_id = m.group(0)
+        logger.info("KEI-207: title match %s for PR %s", kei_id, pr_url)
+        _close_kei_task_by_id(kei_id)
+        return
+
+    # Title parse failed — try linear_url fallback
+    matched = _close_kei_task_by_pr_url(pr_url)
+    if not matched:
+        logger.info("KEI-207: no matching task for PR %s, skipping", pr_url)
 
 
 _RECEIVE_RESPONSES: dict[int | str, dict[str, Any]] = {
@@ -170,6 +273,11 @@ async def receive_github_webhook(request: Request) -> dict[str, str]:
 
     if action == "closed":
         _close_review_task(pr_number)
+        # KEI-207: if the PR was actually merged, also close the matching KEI task.
+        if pr.get("merged") is True:
+            pr_title: str = pr.get("title") or ""
+            pr_url: str = pr.get("html_url") or ""
+            _handle_kei_task_close_on_merge(pr_title, pr_url)
         return {"status": "ok", "action": action, "task_id": _task_id(pr_number)}
 
     # Other actions (assigned, labeled, synchronize, etc.) — ignore

--- a/tests/api/webhooks/test_github_kei207_merge.py
+++ b/tests/api/webhooks/test_github_kei207_merge.py
@@ -1,0 +1,363 @@
+"""Tests for KEI-207: GitHub PR merge webhook → auto-close KEI tasks.
+
+Covers the _handle_kei_task_close_on_merge path and the surrounding
+handler branch (action='closed', merged=True).
+
+Mock strategy: monkeypatch psycopg.connect; use FastAPI TestClient for
+HTTP-level tests. No live DB or live GitHub.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT = REPO_ROOT / "src" / "api" / "webhooks" / "github.py"
+TEST_SECRET = "test-kei207-secret"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    # Load into a fresh module name to avoid collision with test_github_webhook.py
+    spec = importlib.util.spec_from_file_location("github_webhook_kei207", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["github_webhook_kei207"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def _make_client(mod, monkeypatch, *, secret: str = TEST_SECRET):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", secret)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/kei207")
+    app = FastAPI()
+    app.include_router(mod.router)
+    return TestClient(app)
+
+
+def _sign(body: bytes, secret: str = TEST_SECRET) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _merge_payload(
+    number: int = 207,
+    title: str = "[MAX] feat(KEI-207): something",
+    html_url: str = "https://github.com/Keiracom/Agency_OS/pull/207",
+    merged: bool = True,
+    action: str = "closed",
+) -> dict:
+    return {
+        "action": action,
+        "pull_request": {
+            "number": number,
+            "title": title,
+            "html_url": html_url,
+            "body": "PR body — should not appear in logs per no-PII rule",
+            "merged": merged,
+            "user": {"login": "max"},
+        },
+    }
+
+
+def _make_fake_conn(monkeypatch, psycopg, *, rows=None):
+    """Return (fake_conn, fake_cur) mocks wired for psycopg.connect."""
+    fake_cur = MagicMock()
+    if rows is not None:
+        fake_cur.fetchall.return_value = rows
+    fake_conn = MagicMock()
+    fake_conn.__enter__ = MagicMock(return_value=fake_conn)
+    fake_conn.__exit__ = MagicMock(return_value=False)
+    fake_conn.cursor.return_value.__enter__ = MagicMock(return_value=fake_cur)
+    fake_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: fake_conn)
+    return fake_conn, fake_cur
+
+
+# ── 1. Title match closes KEI task ───────────────────────────────────────
+
+
+def test_pr_merge_with_kei_in_title_closes_task(mod, monkeypatch):
+    """PR merge with KEI-207 in title → UPDATE tasks SET status='done' WHERE id='KEI-207'."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/kei207")
+    import psycopg
+
+    fake_cur = MagicMock()
+    fake_cur.fetchall.return_value = []
+    fake_conn = MagicMock()
+    fake_conn.__enter__ = MagicMock(return_value=fake_conn)
+    fake_conn.__exit__ = MagicMock(return_value=False)
+    fake_conn.cursor.return_value.__enter__ = MagicMock(return_value=fake_cur)
+    fake_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    connect_calls: list[dict] = []
+
+    def fake_connect(*args, **kwargs):
+        connect_calls.append(kwargs)
+        return fake_conn
+
+    monkeypatch.setattr(psycopg, "connect", fake_connect)
+
+    mod._handle_kei_task_close_on_merge(
+        "[MAX] feat(KEI-207): GitHub PR merge webhook",
+        "https://github.com/Keiracom/Agency_OS/pull/207",
+    )
+
+    # psycopg.connect must use prepare_threshold=None (pgbouncer compat)
+    assert any(
+        kw.get("prepare_threshold") == 0 or "prepare_threshold" in kw for kw in connect_calls
+    ), "psycopg.connect must be called with prepare_threshold=None"
+    assert fake_cur.execute.called
+    sql, params = fake_cur.execute.call_args[0]
+    assert "status" in sql and "done" in sql
+    assert "KEI-207" in params
+
+
+# ── 2. Body-only KEI (no title match) falls back to linear_url ───────────
+
+
+def test_pr_merge_with_kei_in_body_only_misses_title_uses_fallback(mod, monkeypatch):
+    """Title without KEI, body has it → fallback _close_kei_task_by_pr_url is called."""
+    fallback_calls: list[str] = []
+    monkeypatch.setattr(
+        mod, "_close_kei_task_by_pr_url", lambda url: fallback_calls.append(url) or False
+    )
+
+    mod._handle_kei_task_close_on_merge(
+        "refactor: clean up code",  # no KEI in title
+        "https://github.com/Keiracom/Agency_OS/pull/999",
+    )
+
+    assert fallback_calls == ["https://github.com/Keiracom/Agency_OS/pull/999"]
+
+
+# ── 3. Uppercase KEI matches (case-sensitivity documented) ────────────────
+
+
+def test_pr_merge_uppercase_kei_matches(mod, monkeypatch):
+    """Regex KEI-\\d+ is case-sensitive; uppercase KEI-123 matches, lowercase kei-123 does not.
+
+    Linear's canonical format is uppercase. Lowercase is intentionally excluded.
+    """
+    close_calls: list[str] = []
+    monkeypatch.setattr(mod, "_close_kei_task_by_id", lambda kei_id: close_calls.append(kei_id))
+
+    # Uppercase match
+    mod._handle_kei_task_close_on_merge("feat(KEI-123): something", "https://github.com/x/y/pull/1")
+    assert "KEI-123" in close_calls
+
+    # Lowercase should NOT match — fallback path fires instead
+    close_calls.clear()
+    fallback_calls: list[str] = []
+    monkeypatch.setattr(
+        mod, "_close_kei_task_by_pr_url", lambda url: fallback_calls.append(url) or False
+    )
+    mod._handle_kei_task_close_on_merge("feat(kei-456): something", "https://github.com/x/y/pull/2")
+    assert not close_calls  # _close_kei_task_by_id NOT called
+    assert fallback_calls  # fallback fired
+
+
+# ── 4. Fallback: linear_url match closes task ────────────────────────────
+
+
+def test_pr_merge_no_kei_in_title_falls_back_to_linear_url_query(mod, monkeypatch):
+    """No KEI in title → fallback queries tasks.linear_url = pr_url, closes matching row."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/kei207")
+    import psycopg
+
+    fake_cur = MagicMock()
+    fake_cur.fetchall.return_value = [("KEI-501",)]  # one match
+    fake_conn = MagicMock()
+    fake_conn.__enter__ = MagicMock(return_value=fake_conn)
+    fake_conn.__exit__ = MagicMock(return_value=False)
+    fake_conn.cursor.return_value.__enter__ = MagicMock(return_value=fake_cur)
+    fake_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: fake_conn)
+
+    result = mod._close_kei_task_by_pr_url("https://github.com/Keiracom/Agency_OS/pull/501")
+
+    assert result is True
+    assert fake_cur.execute.called
+    sql, params = fake_cur.execute.call_args[0]
+    assert "linear_url" in sql
+    assert "https://github.com/Keiracom/Agency_OS/pull/501" in params
+
+
+# ── 5. No match anywhere → 200 + log (no error) ─────────────────────────
+
+
+def test_pr_merge_no_match_logs_and_returns_200(mod, monkeypatch):
+    """No KEI in title AND no linear_url match → webhook returns 200, no exception."""
+    monkeypatch.setattr(mod, "_close_review_task", lambda n: None)
+    monkeypatch.setattr(mod, "_handle_kei_task_close_on_merge", lambda title, url: None)
+    client = _make_client(mod, monkeypatch)
+
+    payload = _merge_payload(title="chore: cleanup with no kei reference", merged=True)
+    raw = json.dumps(payload).encode()
+    resp = client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": _sign(raw),
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+# ── 6. Closed but not merged → KEI close skipped ────────────────────────
+
+
+def test_pr_closed_but_not_merged_skipped(mod, monkeypatch):
+    """action=closed, merged=false → _handle_kei_task_close_on_merge NOT called."""
+    kei_close_calls: list = []
+    monkeypatch.setattr(mod, "_close_review_task", lambda n: None)
+    monkeypatch.setattr(
+        mod, "_handle_kei_task_close_on_merge", lambda t, u: kei_close_calls.append((t, u))
+    )
+    client = _make_client(mod, monkeypatch)
+
+    payload = _merge_payload(merged=False, action="closed")
+    raw = json.dumps(payload).encode()
+    resp = client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": _sign(raw),
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 200
+    assert kei_close_calls == []  # KEI-207 path NOT triggered
+
+
+# ── 7. PR opened → KEI close not triggered ──────────────────────────────
+
+
+def test_pr_opened_action_skipped(mod, monkeypatch):
+    """action=opened → KEI-207 path not triggered (KEI-97 territory only)."""
+    kei_close_calls: list = []
+    monkeypatch.setattr(mod, "_upsert_review_task", lambda pr: None)
+    monkeypatch.setattr(
+        mod, "_handle_kei_task_close_on_merge", lambda t, u: kei_close_calls.append((t, u))
+    )
+    client = _make_client(mod, monkeypatch)
+
+    payload = _merge_payload(action="opened", merged=False)
+    raw = json.dumps(payload).encode()
+    resp = client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": _sign(raw),
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 200
+    assert kei_close_calls == []
+
+
+# ── 8. synchronize action → skipped ─────────────────────────────────────
+
+
+def test_pr_synchronize_action_skipped(mod, monkeypatch):
+    """action=synchronize → ignored entirely, no KEI close."""
+    kei_close_calls: list = []
+    monkeypatch.setattr(
+        mod, "_handle_kei_task_close_on_merge", lambda t, u: kei_close_calls.append((t, u))
+    )
+    client = _make_client(mod, monkeypatch)
+
+    payload = _merge_payload(action="synchronize")
+    raw = json.dumps(payload).encode()
+    resp = client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": _sign(raw),
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ignored"
+    assert kei_close_calls == []
+
+
+# ── 9. DB error → fail-open, webhook returns 200 ────────────────────────
+
+
+def test_db_error_returns_200_logs_warning(mod, monkeypatch):
+    """psycopg.Error on UPDATE → fail-open: _close_kei_task_by_id swallows, webhook 200."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/kei207")
+    import psycopg
+
+    monkeypatch.setattr(
+        psycopg, "connect", MagicMock(side_effect=psycopg.OperationalError("conn refused"))
+    )
+
+    # Should not raise — fail-open contract
+    mod._close_kei_task_by_id("KEI-207")  # verifies no exception propagates
+
+
+def test_db_error_on_merge_webhook_returns_200(mod, monkeypatch):
+    """DB error during KEI close on PR merge → webhook still returns HTTP 200."""
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/kei207")
+    monkeypatch.setattr(mod, "_close_review_task", lambda n: None)
+    monkeypatch.setattr(
+        psycopg, "connect", MagicMock(side_effect=psycopg.OperationalError("conn refused"))
+    )
+    client = _make_client(mod, monkeypatch)
+
+    payload = _merge_payload(title="[MAX] feat(kei207): something", merged=True)
+    raw = json.dumps(payload).encode()
+    resp = client.post(
+        "/api/webhooks/github",
+        content=raw,
+        headers={
+            "x-hub-signature-256": _sign(raw),
+            "x-github-event": "pull_request",
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 200
+
+
+# ── 10. UPDATE query param binding shape ────────────────────────────────
+
+
+def test_update_query_uses_correct_id_param(mod, monkeypatch):
+    """_close_kei_task_by_id: UPDATE tasks SET status='done' WHERE id=%s with kei_id as param."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/kei207")
+    import psycopg
+
+    fake_cur = MagicMock()
+    fake_conn = MagicMock()
+    fake_conn.__enter__ = MagicMock(return_value=fake_conn)
+    fake_conn.__exit__ = MagicMock(return_value=False)
+    fake_conn.cursor.return_value.__enter__ = MagicMock(return_value=fake_cur)
+    fake_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: fake_conn)
+
+    mod._close_kei_task_by_id("KEI-999")
+
+    assert fake_cur.execute.called
+    sql, params = fake_cur.execute.call_args[0]
+    # Verify parameterised: id bound as positional arg, not interpolated
+    assert "%s" in sql or "$1" in sql
+    assert "KEI-999" in params
+    assert "done" in sql


### PR DESCRIPTION
## Summary

- Extends `src/api/webhooks/github.py` with a KEI task auto-close on PR merge
- On `pull_request` action=`closed` + `merged=true`: regex `KEI-\d+` parsed from PR title (first match wins); fallback queries `tasks.linear_url = pr_html_url`; no match → `logger.info` + skip — no error, no 5xx
- Fail-open on all DB errors: webhook always returns HTTP 200 (GitHub retries 5xx indefinitely)
- `psycopg.connect(prepare_threshold=None)` throughout KEI-207 helpers per `reference_psycopg_supabase_pgbouncer` memory pin (pgbouncer transaction mode drops PREPARE)
- KEI-108 gate confirmed: `src.api.webhooks.github` already wired in `main.py` from KEI-97 — no re-add

## Acceptance gates

| Gate | Result |
|------|--------|
| `pytest tests/api/webhooks/test_github_kei207_merge.py -v` | 11 passed |
| `pytest tests/api/webhooks/ -v` | 74 passed, 0 failed |
| `ruff check` + `ruff format --check` | clean |
| `check_operational_deployment.sh` (KEI-108) | exit 0 |

## Title regex + fallback chain

`re.compile(r'KEI-\d+').search(pr_title)` → first match → `_close_kei_task_by_id(kei_id)`. If no match: `_close_kei_task_by_pr_url(pr_html_url)` runs `UPDATE tasks ... WHERE linear_url = %s RETURNING id`. If still no rows: log + skip. Regex is case-sensitive (`KEI-` uppercase only, matching Linear's canonical format).

## Linear acceptance criteria coverage

- [x] PR merge webhook event handled in existing handler
- [x] KEI ID parsed from PR title (regex `KEI-\d+`)
- [x] Fallback via `linear_url` column if title parse fails
- [x] Task marked `done` on merge only (merged=false branch skipped)
- [x] No matching KEI → log + skip, no error
- [x] Fail-open: DB error → 200, not 5xx