### PR TITLE
[MAX] feat(kei208): Drive → Weaviate indexer + StrategicDocuments collection

### DIFF
--- a/config/drive_index_targets.json
+++ b/config/drive_index_targets.json
@@ -1,0 +1,34 @@
+{
+  "targets": [
+    {
+      "doc_id": "1Br6SsCKizvyNk6dOvm9EQE_8drut1WRId7WJNddilDA",
+      "title": "Roadmap",
+      "ratified_by": "dave",
+      "ratified_at": "2026-05-18"
+    },
+    {
+      "doc_id": "1U5uet-IxJSNhE-iWlVdW3eZpNR8obf-7j3BzvaEWdH4",
+      "title": "Deliberation Floor Flow Architecture v2",
+      "ratified_by": "dave",
+      "ratified_at": "2026-05-18"
+    },
+    {
+      "doc_id": "113Ej0n62uS_qmyMwvase54kFI1eCCwHHwwrMN9GDlCc",
+      "title": "Team Structure",
+      "ratified_by": "dave",
+      "ratified_at": "2026-05-18"
+    },
+    {
+      "doc_id": "1NNoA-6MgXZS6mk35QCeer3mmEnqNVRSD7NBmu0fzfHw",
+      "title": "Architecture FINAL (Parts 1-16)",
+      "ratified_by": "dave",
+      "ratified_at": "2026-05-18"
+    },
+    {
+      "doc_id": "1kf-MVHeHaViwlMuy3ti_pZCS1DJE9ox8vIa3aZdspkY",
+      "title": "Team Structure Brief v2",
+      "ratified_by": "dave",
+      "ratified_at": "2026-05-18"
+    }
+  ]
+}

--- a/infra/systemd/agents/drive-strategic-indexer.service
+++ b/infra/systemd/agents/drive-strategic-indexer.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Agency OS — Drive → Weaviate StrategicDocuments indexer (KEI-208)
+Documentation=https://linear.app/keiracom/issue/KEI-208
+After=network-online.target weaviate.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+# OPENAI_API_KEY required for text2vec-openai vectorizer (KEI-196 Option A).
+# Set in EnvironmentFile above or in the calling environment.
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/drive_strategic_indexer.py --mode=incremental
+StandardOutput=append:/home/elliotbot/clawd/logs/drive_strategic_indexer.log
+StandardError=append:/home/elliotbot/clawd/logs/drive_strategic_indexer.log
+MemoryMax=512M
+MemoryHigh=400M
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/agents/drive-strategic-indexer.timer
+++ b/infra/systemd/agents/drive-strategic-indexer.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Fire Drive → Weaviate StrategicDocuments indexer every 6h (KEI-208)
+Requires=drive-strategic-indexer.service
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=6h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/install_drive_strategic_indexer.sh
+++ b/scripts/install_drive_strategic_indexer.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# install_drive_strategic_indexer.sh — KEI-208 installer for the Drive → Weaviate indexer.
+#
+# KEI-108 CI-gate requirement: every new service ships with a per-unit named
+# install script in the same PR, so a grep for the unit name finds the install
+# step.  The literal unit names below are the anchors the gate scans for.
+#
+# Installs both the oneshot service AND the 6h timer:
+#   drive-strategic-indexer.service
+#   drive-strategic-indexer.timer
+#
+# Usage:
+#   scripts/install_drive_strategic_indexer.sh           # install + enable + start timer
+#   scripts/install_drive_strategic_indexer.sh --dry-run # print plan, no systemctl calls
+
+set -euo pipefail
+
+REPO_ROOT="/home/elliotbot/clawd/Agency_OS"
+SRC_DIR="${REPO_ROOT}/infra/systemd/agents"
+DST_DIR="/home/elliotbot/.config/systemd/user"
+SERVICE_UNIT="drive-strategic-indexer.service"
+TIMER_UNIT="drive-strategic-indexer.timer"
+DRY_RUN=0
+
+for arg in "$@"; do
+  [[ "$arg" == "--dry-run" ]] && DRY_RUN=1
+done
+
+echo "install_drive_strategic_indexer: plan"
+echo "  service : ${SRC_DIR}/${SERVICE_UNIT} -> ${DST_DIR}/${SERVICE_UNIT}"
+echo "  timer   : ${SRC_DIR}/${TIMER_UNIT} -> ${DST_DIR}/${TIMER_UNIT}"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "  [dry-run] no systemctl calls"
+  echo "install_drive_strategic_indexer: dry-run OK"
+  exit 0
+fi
+
+install -D -m 0644 "${SRC_DIR}/${SERVICE_UNIT}" "${DST_DIR}/${SERVICE_UNIT}"
+install -D -m 0644 "${SRC_DIR}/${TIMER_UNIT}" "${DST_DIR}/${TIMER_UNIT}"
+
+systemctl --user daemon-reload
+systemctl --user enable --now "${TIMER_UNIT}"
+
+echo "install_drive_strategic_indexer: ${TIMER_UNIT} installed + enabled + started"
+systemctl --user --no-pager status "${TIMER_UNIT}" | head -10
+
+# Anchor text for KEI-108 gate:
+# drive-strategic-indexer.service
+# drive-strategic-indexer.timer

--- a/scripts/orchestrator/_strategic_collection_schema.py
+++ b/scripts/orchestrator/_strategic_collection_schema.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""_strategic_collection_schema.py — Weaviate StrategicDocuments collection bootstrap.
+
+Idempotent: if the class already exists, logs and skips.  On schema drift
+(class present but with different properties), logs a WARNING and does NOT
+auto-migrate destructively.  Destructive migration requires an explicit
+operator action outside this script.
+
+Vectorizer: text2vec-openai (Dave Option A, KEI-196 fix-up).
+Requires OPENAI_API_KEY in env.  The Weaviate container must be configured
+with the openai module (ENABLE_MODULES=text2vec-openai or equivalent).
+
+Usage (operator, post-merge OR first --mode=full run):
+    python -m scripts.orchestrator._strategic_collection_schema --create
+
+The main indexer (drive_strategic_indexer.py) calls ensure_strategic_class()
+automatically on every startup, so manual invocation is optional.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+sys.path.insert(0, __file__.rsplit("/orchestrator/", 1)[0] + "/orchestrator")
+
+from indexer_base import WEAVIATE_BASE, IndexerError  # noqa: E402
+
+logger = logging.getLogger("strategic_collection_schema")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+STRATEGIC_DOCS_CLASS = "StrategicDocuments"
+
+STRATEGIC_DOCS_SCHEMA: dict = {
+    "class": STRATEGIC_DOCS_CLASS,
+    "vectorizer": "text2vec-openai",
+    "properties": [
+        {"name": "doc_id", "dataType": ["text"]},
+        {"name": "doc_url", "dataType": ["text"]},
+        {"name": "title", "dataType": ["text"]},
+        {"name": "section", "dataType": ["text"]},
+        {"name": "content", "dataType": ["text"]},
+        {"name": "updated_at", "dataType": ["date"]},
+        {"name": "ratified_by", "dataType": ["text"]},
+        {"name": "ratified_at", "dataType": ["date"]},
+    ],
+}
+
+REQUEST_TIMEOUT = 10.0
+
+
+def _get(path: str) -> tuple[int, dict]:
+    req = urlrequest.Request(
+        f"{WEAVIATE_BASE}{path}",
+        headers={"Accept": "application/json"},
+    )
+    try:
+        with urlrequest.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urlerror.HTTPError as exc:
+        return exc.code, {}
+
+
+def _post(path: str, body: dict) -> tuple[int, dict]:
+    data = json.dumps(body).encode()
+    req = urlrequest.Request(
+        f"{WEAVIATE_BASE}{path}",
+        data=data,
+        method="POST",
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+    )
+    try:
+        with urlrequest.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urlerror.HTTPError as exc:
+        body_bytes = exc.read() if hasattr(exc, "read") else b""
+        return exc.code, {"error": body_bytes.decode(errors="replace")}
+
+
+def ensure_strategic_class() -> None:
+    """Idempotent class create.  Logs warning on drift, never destructs."""
+    status, existing = _get(f"/v1/schema/{STRATEGIC_DOCS_CLASS}")
+    if status == 200:
+        existing_props = {p["name"] for p in existing.get("properties", [])}
+        expected_props = {p["name"] for p in STRATEGIC_DOCS_SCHEMA["properties"]}
+        if existing_props != expected_props:
+            logger.warning(
+                "schema drift on %s: expected=%s got=%s — no auto-migration",
+                STRATEGIC_DOCS_CLASS,
+                sorted(expected_props),
+                sorted(existing_props),
+            )
+        else:
+            logger.info("class %s already exists with correct schema", STRATEGIC_DOCS_CLASS)
+        return
+    if status != 404:
+        raise IndexerError(f"unexpected GET /v1/schema status={status}")
+    logger.info("creating Weaviate class %s", STRATEGIC_DOCS_CLASS)
+    rc, resp_body = _post("/v1/schema", STRATEGIC_DOCS_SCHEMA)
+    if rc >= 300:
+        raise IndexerError(f"class create failed: {rc} — {resp_body}")
+    logger.info("created %s (rc=%s)", STRATEGIC_DOCS_CLASS, rc)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Bootstrap StrategicDocuments Weaviate class")
+    parser.add_argument("--create", action="store_true", help="Create the class if absent")
+    args = parser.parse_args()
+    if args.create:
+        ensure_strategic_class()
+        print(f"done — {STRATEGIC_DOCS_CLASS} class ready")
+    else:
+        parser.print_help()
+        sys.exit(1)

--- a/scripts/orchestrator/drive_strategic_indexer.py
+++ b/scripts/orchestrator/drive_strategic_indexer.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""drive_strategic_indexer.py — Drive → Weaviate StrategicDocuments indexer (KEI-208).
+
+Loads target doc IDs exclusively from config/drive_index_targets.json.
+No doc IDs are hardcoded in this file.  Adding a new document = append to
+config + restart the timer.
+
+Drive auth: uses the keiradrive MCP server via subprocess
+(mcp__keiradrive__keiradrive_read_doc pattern).  No googleapiclient
+dependency exists in the repo as of KEI-208.  If a future KEI adds
+google-api-python-client, migrate and update this docstring per LAW XIII.
+
+Vectorizer: text2vec-openai (OPENAI_API_KEY required in env).
+
+Modes:
+    --mode=full         Bulk backfill all targets (default)
+    --mode=incremental  Only re-index docs whose Drive modifiedTime advanced
+
+Usage:
+    python3 scripts/orchestrator/drive_strategic_indexer.py --mode=full
+    python3 scripts/orchestrator/drive_strategic_indexer.py --mode=incremental
+
+Per reference_psycopg_supabase_pgbouncer: psycopg with prepare_threshold=None
+and +asyncpg DSN prefix stripped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# ─── Path bootstrap ──────────────────────────────────────────────────────────
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG_PATH = _REPO_ROOT / "config" / "drive_index_targets.json"
+_LOG_PATH = Path("/home/elliotbot/clawd/logs/drive_strategic_indexer.log")
+
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "orchestrator"))
+
+from _strategic_collection_schema import ensure_strategic_class  # noqa: E402
+from indexer_base import WEAVIATE_BASE, deterministic_uuid, post_object  # noqa: E402
+
+# ─── Logging ─────────────────────────────────────────────────────────────────
+_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    handlers=[
+        logging.FileHandler(_LOG_PATH),
+        logging.StreamHandler(sys.stdout),
+    ],
+)
+logger = logging.getLogger("drive_strategic_indexer")
+
+SOURCE_NAME = "drive_strategic"
+STRATEGIC_DOCS_CLASS = "StrategicDocuments"
+_HEADING_RE = re.compile(r"^(#{1,3})\s+(.+)$", re.MULTILINE)
+
+# ─── Supabase DSN helpers ────────────────────────────────────────────────────
+REQUEST_TIMEOUT = 10.0
+_WEAVIATE_OBJECTS_URL = f"{WEAVIATE_BASE}/v1/objects"
+
+
+# ─── Config ───────────────────────────────────────────────────────────────────
+@dataclass(frozen=True)
+class DriveTarget:
+    doc_id: str
+    title: str
+    ratified_by: str
+    ratified_at: str
+
+
+def load_config(path: Path = _CONFIG_PATH) -> list[DriveTarget]:
+    """Load drive_index_targets.json.  Raises ValueError on missing 'targets'."""
+    raw = json.loads(path.read_text())
+    if "targets" not in raw:
+        raise ValueError(f"config missing 'targets' key: {path}")
+    return [
+        DriveTarget(
+            doc_id=t["doc_id"],
+            title=t["title"],
+            ratified_by=t["ratified_by"],
+            ratified_at=t["ratified_at"],
+        )
+        for t in raw["targets"]
+    ]
+
+
+# ─── Drive fetch (keiradrive MCP subprocess) ──────────────────────────────────
+_MCP_BRIDGE = str(_REPO_ROOT / "skills" / "mcp-bridge" / "scripts" / "mcp-bridge.js")
+
+
+def fetch_drive_doc(doc_id: str) -> dict[str, Any]:
+    """Fetch doc via keiradrive MCP bridge subprocess.
+
+    Returns dict with at minimum 'content' (markdown text) and
+    'modifiedTime' (ISO-8601 string or empty).
+    Raises RuntimeError on non-zero exit.
+    """
+    args_json = json.dumps({"fileId": doc_id})
+    result = subprocess.run(
+        ["node", _MCP_BRIDGE, "call", "keiradrive", "keiradrive_read_doc", args_json],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"keiradrive_read_doc failed for {doc_id}: {result.stderr[:500]}")
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"keiradrive_read_doc non-JSON response for {doc_id}: {result.stdout[:200]}"
+        ) from exc
+    return data
+
+
+# ─── Chunking ─────────────────────────────────────────────────────────────────
+@dataclass(frozen=True)
+class DocChunk:
+    section_title: str
+    content: str
+
+
+def chunk_by_heading(markdown: str) -> list[DocChunk]:
+    """Split markdown by h1/h2/h3 boundaries.  Each heading → one chunk.
+
+    Content before the first heading is emitted as a 'preamble' chunk
+    only if non-empty.  Section title = heading text (stripped of #).
+    """
+    chunks: list[DocChunk] = []
+    matches = list(_HEADING_RE.finditer(markdown))
+    if not matches:
+        stripped = markdown.strip()
+        if stripped:
+            chunks.append(DocChunk(section_title="(document)", content=stripped))
+        return chunks
+
+    preamble = markdown[: matches[0].start()].strip()
+    if preamble:
+        chunks.append(DocChunk(section_title="(preamble)", content=preamble))
+
+    for i, m in enumerate(matches):
+        section_title = m.group(2).strip()
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(markdown)
+        body = markdown[start:end].strip()
+        chunks.append(DocChunk(section_title=section_title, content=body))
+
+    return chunks
+
+
+# ─── UUID + object build ──────────────────────────────────────────────────────
+def section_uuid(doc_id: str, section_title: str) -> str:
+    """Deterministic UUID for (doc_id, section_title).  Stable across runs."""
+    return deterministic_uuid(SOURCE_NAME, f"{doc_id}::{section_title}")
+
+
+def build_weaviate_object(
+    target: DriveTarget,
+    chunk: DocChunk,
+    updated_at: str,
+) -> dict:
+    obj_id = section_uuid(target.doc_id, chunk.section_title)
+    return {
+        "id": obj_id,
+        "class": STRATEGIC_DOCS_CLASS,
+        "properties": {
+            "doc_id": target.doc_id,
+            "doc_url": f"https://docs.google.com/document/d/{target.doc_id}",
+            "title": target.title,
+            "section": chunk.section_title,
+            "content": chunk.content,
+            "updated_at": updated_at or "1970-01-01T00:00:00Z",
+            "ratified_by": target.ratified_by,
+            "ratified_at": target.ratified_at + "T00:00:00Z",
+        },
+    }
+
+
+# ─── CEO memory write ─────────────────────────────────────────────────────────
+def write_ceo_memory(summary: dict[str, Any]) -> None:
+    """Write indexer run summary to public.ceo_memory."""
+    raw_dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+    if not raw_dsn:
+        logger.warning("no DATABASE_URL — skipping ceo_memory write")
+        return
+    dsn = raw_dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+    try:
+        import psycopg  # noqa: PLC0415
+
+        sql = (
+            "INSERT INTO public.ceo_memory (key, value) "
+            "VALUES ('ceo:memory:drive_indexer', %s::jsonb) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+        )
+        with psycopg.connect(dsn, autocommit=True, prepare_threshold=None) as conn:
+            conn.execute(sql, (json.dumps(summary),))
+        logger.info("ceo_memory updated: ceo:memory:drive_indexer")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("ceo_memory write failed (non-fatal): %s", exc)
+
+
+# ─── Incremental state (modifiedTime cache) ───────────────────────────────────
+_STATE_FILE = _REPO_ROOT / ".drive_indexer_state.json"
+
+
+def load_modified_times() -> dict[str, str]:
+    try:
+        return json.loads(_STATE_FILE.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_modified_times(state: dict[str, str]) -> None:
+    _STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+# ─── Core index function ──────────────────────────────────────────────────────
+def index_target(
+    target: DriveTarget,
+    *,
+    force: bool = False,
+    modified_cache: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Fetch + chunk + upsert one target.  Returns per-doc outcome dict."""
+    outcome: dict[str, Any] = {
+        "doc_id": target.doc_id,
+        "title": target.title,
+        "skipped": False,
+        "chunks_total": 0,
+        "chunks_ok": 0,
+        "chunks_failed": 0,
+        "error": None,
+    }
+    try:
+        doc_data = fetch_drive_doc(target.doc_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("fetch failed for %s (%s): %s", target.doc_id, target.title, exc)
+        outcome["error"] = str(exc)
+        return outcome
+
+    modified_time = doc_data.get("modifiedTime", "") or doc_data.get("modified_time", "")
+
+    if not force and modified_cache is not None:
+        cached = modified_cache.get(target.doc_id)
+        if cached and cached == modified_time:
+            logger.info("skip %s — modifiedTime unchanged (%s)", target.title, modified_time)
+            outcome["skipped"] = True
+            return outcome
+
+    content = doc_data.get("content", "") or doc_data.get("text", "")
+    chunks = chunk_by_heading(content)
+    outcome["chunks_total"] = len(chunks)
+
+    for chunk in chunks:
+        obj = build_weaviate_object(target, chunk, modified_time)
+        if post_object(obj):
+            outcome["chunks_ok"] += 1
+        else:
+            outcome["chunks_failed"] += 1
+            logger.warning("upsert failed for %s :: %s", target.doc_id, chunk.section_title)
+
+    if modified_cache is not None:
+        modified_cache[target.doc_id] = modified_time
+
+    logger.info(
+        "indexed %s — chunks=%d ok=%d failed=%d",
+        target.title,
+        outcome["chunks_total"],
+        outcome["chunks_ok"],
+        outcome["chunks_failed"],
+    )
+    return outcome
+
+
+# ─── Entrypoint ──────────────────────────────────────────────────────────────
+def run(mode: str) -> None:
+    targets = load_config()
+    ensure_strategic_class()
+    logger.info("drive_strategic_indexer start mode=%s targets=%d", mode, len(targets))
+
+    force = mode == "full"
+    modified_cache = load_modified_times()
+
+    results: list[dict[str, Any]] = []
+    for target in targets:
+        results.append(index_target(target, force=force, modified_cache=modified_cache))
+
+    save_modified_times(modified_cache)
+
+    total_ok = sum(r["chunks_ok"] for r in results)
+    total_failed = sum(r["chunks_failed"] for r in results)
+    skipped = sum(1 for r in results if r.get("skipped"))
+    errors = sum(1 for r in results if r.get("error"))
+
+    summary = {
+        "mode": mode,
+        "docs": len(targets),
+        "skipped": skipped,
+        "errors": errors,
+        "chunks_ok": total_ok,
+        "chunks_failed": total_failed,
+    }
+    logger.info("run complete: %s", summary)
+    write_ceo_memory(summary)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Drive → Weaviate StrategicDocuments indexer")
+    parser.add_argument(
+        "--mode",
+        choices=["full", "incremental"],
+        default="full",
+        help="full=backfill all targets; incremental=only changed docs",
+    )
+    args = parser.parse_args()
+    run(args.mode)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_drive_strategic_indexer.py
+++ b/tests/scripts/test_drive_strategic_indexer.py
@@ -1,0 +1,287 @@
+"""Unit tests for drive_strategic_indexer.py (KEI-208).
+
+No live network — Drive client and Weaviate POST are fully monkeypatched.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "orchestrator"))
+
+import drive_strategic_indexer as mod  # noqa: E402, I001
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_config(tmp_path: Path, targets: list[dict] | None = None) -> Path:
+    if targets is None:
+        targets = [
+            {
+                "doc_id": "DOC_A",
+                "title": "Alpha",
+                "ratified_by": "dave",
+                "ratified_at": "2026-05-18",
+            },
+        ]
+    cfg = tmp_path / "drive_index_targets.json"
+    cfg.write_text(json.dumps({"targets": targets}))
+    return cfg
+
+
+def _fake_doc(content: str = "# H1\nbody\n", modified: str = "2026-05-18T00:00:00Z") -> dict:
+    return {"content": content, "modifiedTime": modified}
+
+
+# ─── Config tests ─────────────────────────────────────────────────────────────
+
+
+def test_load_config_from_json(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    targets = mod.load_config(cfg)
+    assert len(targets) == 1
+    assert targets[0].doc_id == "DOC_A"
+    assert targets[0].title == "Alpha"
+    assert targets[0].ratified_by == "dave"
+
+
+def test_load_config_rejects_missing_targets_key(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"docs": []}))
+    with pytest.raises(ValueError, match="missing 'targets'"):
+        mod.load_config(bad)
+
+
+# ─── Chunking tests ───────────────────────────────────────────────────────────
+
+
+def test_chunk_by_heading_h1_h2_h3() -> None:
+    md = "# Title\nbody one\n## Sub\nbody two\n### Sub-sub\nbody three\n"
+    chunks = mod.chunk_by_heading(md)
+    assert len(chunks) == 3
+
+
+def test_chunk_preserves_section_title() -> None:
+    md = "## My Section\ncontent here\n"
+    chunks = mod.chunk_by_heading(md)
+    assert chunks[0].section_title == "My Section"
+
+
+def test_chunk_no_headings_returns_single_document_chunk() -> None:
+    md = "just plain text\nno headings here\n"
+    chunks = mod.chunk_by_heading(md)
+    assert len(chunks) == 1
+    assert chunks[0].section_title == "(document)"
+
+
+# ─── UUID tests ───────────────────────────────────────────────────────────────
+
+
+def test_deterministic_uuid_for_same_doc_section() -> None:
+    a = mod.section_uuid("DOC_A", "Introduction")
+    b = mod.section_uuid("DOC_A", "Introduction")
+    assert a == b
+
+
+def test_deterministic_uuid_differs_for_different_section() -> None:
+    a = mod.section_uuid("DOC_A", "Introduction")
+    b = mod.section_uuid("DOC_A", "Conclusion")
+    assert a != b
+
+
+# ─── Full-mode integration tests (mocked Drive + Weaviate) ───────────────────
+
+
+def test_full_mode_indexes_all_targets(tmp_path: Path) -> None:
+    targets_data = [
+        {"doc_id": "DOC_A", "title": "Alpha", "ratified_by": "dave", "ratified_at": "2026-05-18"},
+        {"doc_id": "DOC_B", "title": "Beta", "ratified_by": "dave", "ratified_at": "2026-05-18"},
+    ]
+    cfg = _make_config(tmp_path, targets_data)
+    posted_ids: list[str] = []
+
+    def fake_fetch(doc_id: str) -> dict:
+        return _fake_doc(f"# Section\ncontent for {doc_id}", "2026-05-18T00:00:00Z")
+
+    def fake_post(obj: dict) -> bool:
+        posted_ids.append(obj["properties"]["doc_id"])
+        return True
+
+    state_file = tmp_path / "state.json"
+    with (
+        patch.object(mod, "load_config", return_value=mod.load_config(cfg)),
+        patch.object(mod, "fetch_drive_doc", side_effect=fake_fetch),
+        patch.object(mod, "post_object", side_effect=fake_post),
+        patch.object(mod, "_STATE_FILE", state_file),
+        patch.object(mod, "ensure_strategic_class"),
+        patch.object(mod, "write_ceo_memory"),
+    ):
+        mod.run("full")
+
+    assert "DOC_A" in posted_ids
+    assert "DOC_B" in posted_ids
+
+
+# ─── Incremental-mode tests ───────────────────────────────────────────────────
+
+
+def test_incremental_mode_skips_unchanged_modifiedTime(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"DOC_A": "2026-05-18T00:00:00Z"}))
+    posted_ids: list[str] = []
+
+    def fake_fetch(doc_id: str) -> dict:
+        return _fake_doc("# Section\nbody", "2026-05-18T00:00:00Z")
+
+    def fake_post(obj: dict) -> bool:
+        posted_ids.append(obj["properties"]["doc_id"])
+        return True
+
+    with (
+        patch.object(mod, "load_config", return_value=mod.load_config(cfg)),
+        patch.object(mod, "fetch_drive_doc", side_effect=fake_fetch),
+        patch.object(mod, "post_object", side_effect=fake_post),
+        patch.object(mod, "_STATE_FILE", state_file),
+        patch.object(mod, "ensure_strategic_class"),
+        patch.object(mod, "write_ceo_memory"),
+    ):
+        mod.run("incremental")
+
+    assert posted_ids == [], "unchanged doc should be skipped"
+
+
+def test_incremental_mode_reindexes_changed(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"DOC_A": "2026-05-17T00:00:00Z"}))
+    posted_ids: list[str] = []
+
+    def fake_fetch(doc_id: str) -> dict:
+        return _fake_doc("# Section\nnew body", "2026-05-18T00:00:00Z")
+
+    def fake_post(obj: dict) -> bool:
+        posted_ids.append(obj["properties"]["doc_id"])
+        return True
+
+    with (
+        patch.object(mod, "load_config", return_value=mod.load_config(cfg)),
+        patch.object(mod, "fetch_drive_doc", side_effect=fake_fetch),
+        patch.object(mod, "post_object", side_effect=fake_post),
+        patch.object(mod, "_STATE_FILE", state_file),
+        patch.object(mod, "ensure_strategic_class"),
+        patch.object(mod, "write_ceo_memory"),
+    ):
+        mod.run("incremental")
+
+    assert "DOC_A" in posted_ids, "changed doc should be re-indexed"
+
+
+# ─── Upsert idempotency test ──────────────────────────────────────────────────
+
+
+def test_upsert_overwrites_same_uuid(tmp_path: Path) -> None:
+    """Same (doc_id, section) must produce same UUID on second run."""
+    doc_id = "DOC_STABLE"
+    section = "Stable Section"
+    uuid_first = mod.section_uuid(doc_id, section)
+    uuid_second = mod.section_uuid(doc_id, section)
+    assert uuid_first == uuid_second, "same (doc_id, section) must yield same UUID"
+
+
+# ─── Error resilience test ────────────────────────────────────────────────────
+
+
+def test_drive_api_error_logs_and_continues(tmp_path: Path) -> None:
+    targets_data = [
+        {
+            "doc_id": "FAIL_DOC",
+            "title": "Will Fail",
+            "ratified_by": "dave",
+            "ratified_at": "2026-05-18",
+        },
+        {
+            "doc_id": "DOC_OK",
+            "title": "Will Succeed",
+            "ratified_by": "dave",
+            "ratified_at": "2026-05-18",
+        },
+    ]
+    cfg = _make_config(tmp_path, targets_data)
+    posted_ids: list[str] = []
+    state_file = tmp_path / "state.json"
+
+    def fake_fetch(doc_id: str) -> dict:
+        if doc_id == "FAIL_DOC":
+            raise RuntimeError("Drive auth error")
+        return _fake_doc("# Section\nbody", "2026-05-18T00:00:00Z")
+
+    def fake_post(obj: dict) -> bool:
+        posted_ids.append(obj["properties"]["doc_id"])
+        return True
+
+    with (
+        patch.object(mod, "load_config", return_value=mod.load_config(cfg)),
+        patch.object(mod, "fetch_drive_doc", side_effect=fake_fetch),
+        patch.object(mod, "post_object", side_effect=fake_post),
+        patch.object(mod, "_STATE_FILE", state_file),
+        patch.object(mod, "ensure_strategic_class"),
+        patch.object(mod, "write_ceo_memory"),
+    ):
+        mod.run("full")
+
+    assert "DOC_OK" in posted_ids, "healthy doc must still index despite peer failure"
+    assert "FAIL_DOC" not in posted_ids
+
+
+# ─── CEO memory test ──────────────────────────────────────────────────────────
+
+
+def test_ceo_memory_drive_indexer_key_written(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    state_file = tmp_path / "state.json"
+    memory_calls: list[dict] = []
+
+    def fake_fetch(doc_id: str) -> dict:
+        return _fake_doc("# Section\nbody", "2026-05-18T00:00:00Z")
+
+    with (
+        patch.object(mod, "load_config", return_value=mod.load_config(cfg)),
+        patch.object(mod, "fetch_drive_doc", side_effect=fake_fetch),
+        patch.object(mod, "post_object", return_value=True),
+        patch.object(mod, "_STATE_FILE", state_file),
+        patch.object(mod, "ensure_strategic_class"),
+        patch.object(mod, "write_ceo_memory", side_effect=memory_calls.append),
+    ):
+        mod.run("full")
+
+    assert len(memory_calls) == 1
+    assert memory_calls[0]["mode"] == "full"
+    assert "chunks_ok" in memory_calls[0]
+
+
+# ─── No-hardcoded-IDs enforcement ────────────────────────────────────────────
+
+
+def test_no_hardcoded_doc_ids_in_indexer_source() -> None:
+    """Gate: indexer Python source must contain zero Drive doc ID literals."""
+    drive_doc_ids = [
+        "1Br6SsCKizvyNk6dOvm9EQE_8drut1WRId7WJNddilDA",
+        "1U5uet-IxJSNhE-iWlVdW3eZpNR8obf-7j3BzvaEWdH4",
+        "113Ej0n62uS_qmyMwvase54kFI1eCCwHHwwrMN9GDlCc",
+        "1NNoA-6MgXZS6mk35QCeer3mmEnqNVRSD7NBmu0fzfHw",
+        "1kf-MVHeHaViwlMuy3ti_pZCS1DJE9ox8vIa3aZdspkY",
+    ]
+    indexer_src = (ROOT / "scripts" / "orchestrator" / "drive_strategic_indexer.py").read_text()
+    for doc_id in drive_doc_ids:
+        assert doc_id not in indexer_src, (
+            f"hardcoded doc ID {doc_id} found in drive_strategic_indexer.py — "
+            "IDs must live in config/drive_index_targets.json only"
+        )


### PR DESCRIPTION
## KEI-208 — Drive → Weaviate StrategicDocuments Indexer

### 4-Phase Linear Spec

**Phase 1 — StrategicDocuments Weaviate collection** (`_strategic_collection_schema.py`):
- `text2vec-openai` vectorizer (Dave Option A, KEI-196 fix-up)
- 8 properties: doc_id, doc_url, title, section, content, updated_at, ratified_by, ratified_at
- Idempotent: skip if exists, warn on drift, never auto-migrate destructive

**Phase 2 — Bulk backfill (5 docs)**:
All doc IDs live in `config/drive_index_targets.json` only:
- Roadmap (1Br6SsCKizvyNk6dOvm9EQE_8drut1WRId7WJNddilDA)
- Deliberation Floor Flow Architecture v2 (1U5uet-IxJSNhE-iWlVdW3eZpNR8obf-7j3BzvaEWdH4)
- Team Structure (113Ej0n62uS_qmyMwvase54kFI1eCCwHHwwrMN9GDlCc)
- Architecture FINAL Parts 1-16 (1NNoA-6MgXZS6mk35QCeer3mmEnqNVRSD7NBmu0fzfHw)
- Team Structure Brief v2 (1kf-MVHeHaViwlMuy3ti_pZCS1DJE9ox8vIa3aZdspkY)

**Phase 3 — Incremental indexer**:
- `--mode=full` backfills all targets; `--mode=incremental` skips unchanged modifiedTime
- Chunk strategy: heading boundary regex `^#{1,3}\s+` — each section = one Weaviate object
- Deterministic UUID per `(doc_id, section_title)` for idempotent upsert
- Drive auth: keiradrive MCP bridge subprocess (no googleapiclient in repo as of KEI-208)
- ceo_memory write at end: `key='ceo:memory:drive_indexer'`
- psycopg `prepare_threshold=None` + `+asyncpg` DSN strip per reference_psycopg_supabase_pgbouncer

**Phase 4 — Validation**: operator runs after merge + first timer fire (live Weaviate + OPENAI_API_KEY required). Phase 4 semantic query result pasted in PR comments post-deployment.

### Config-driven enforcement (Gate 5)
```
grep -E "1Br6SsCK|1U5uet|113Ej0n6|1NNoA|1kf-MVHe" scripts/orchestrator/drive_strategic_indexer.py
exit=1  (0 matches — IDs live in config only)
```

### Files shipped (7 files)
1. `config/drive_index_targets.json`
2. `scripts/orchestrator/drive_strategic_indexer.py`
3. `scripts/orchestrator/_strategic_collection_schema.py`
4. `infra/systemd/agents/drive-strategic-indexer.service` (Type=oneshot)
5. `infra/systemd/agents/drive-strategic-indexer.timer` (OnUnitActiveSec=6h)
6. `scripts/install_drive_strategic_indexer.sh` (KEI-108 anchor)
7. `tests/scripts/test_drive_strategic_indexer.py` (14 tests)

### Acceptance gates — all pass verbatim

**Gate 1 — pytest (14 tests)**:
```
============================= test session starts ==============================
collected 14 items
tests/scripts/test_drive_strategic_indexer.py::test_load_config_from_json PASSED
tests/scripts/test_drive_strategic_indexer.py::test_load_config_rejects_missing_targets_key PASSED
tests/scripts/test_drive_strategic_indexer.py::test_chunk_by_heading_h1_h2_h3 PASSED
tests/scripts/test_drive_strategic_indexer.py::test_chunk_preserves_section_title PASSED
tests/scripts/test_drive_strategic_indexer.py::test_chunk_no_headings_returns_single_document_chunk PASSED
tests/scripts/test_drive_strategic_indexer.py::test_deterministic_uuid_for_same_doc_section PASSED
tests/scripts/test_drive_strategic_indexer.py::test_deterministic_uuid_differs_for_different_section PASSED
tests/scripts/test_drive_strategic_indexer.py::test_full_mode_indexes_all_targets PASSED
tests/scripts/test_drive_strategic_indexer.py::test_incremental_mode_skips_unchanged_modifiedTime PASSED
tests/scripts/test_drive_strategic_indexer.py::test_incremental_mode_reindexes_changed PASSED
tests/scripts/test_drive_strategic_indexer.py::test_upsert_overwrites_same_uuid PASSED
tests/scripts/test_drive_strategic_indexer.py::test_drive_api_error_logs_and_continues PASSED
tests/scripts/test_drive_strategic_indexer.py::test_ceo_memory_drive_indexer_key_written PASSED
tests/scripts/test_drive_strategic_indexer.py::test_no_hardcoded_doc_ids_in_indexer_source PASSED
============================== 14 passed in 0.12s ==============================
```

**Gate 2 — ruff check**: `All checks passed!`

**Gate 3 — ruff format --check**: `3 files already formatted`

**Gate 4 — KEI-108 CI**: `exit=0`

**Gate 5 — no hardcoded doc IDs**: `exit=1` (grep 0 matches in indexer source)

**Gate 6 — dry-run installer**:
```
install_drive_strategic_indexer: plan
  service : .../drive-strategic-indexer.service -> ~/.config/systemd/user/drive-strategic-indexer.service
  timer   : .../drive-strategic-indexer.timer -> ~/.config/systemd/user/drive-strategic-indexer.timer
  [dry-run] no systemctl calls
install_drive_strategic_indexer: dry-run OK
```

### Drive auth path
keiradrive MCP server via subprocess (`node skills/mcp-bridge/scripts/mcp-bridge.js call keiradrive keiradrive_read_doc`). No `googleapiclient` in repo as of KEI-208. LAW XIII: if a future KEI adds google-api-python-client, update the module docstring in same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)