### PR TITLE
[SCOUT] feat(kei210): interceptor_proxy — governance proxy for agents <-> LiteLLM

### DIFF
--- a/src/dispatcher/interceptor_proxy.py
+++ b/src/dispatcher/interceptor_proxy.py
@@ -1,0 +1,367 @@
+"""KEI-210 — interceptor_proxy: governance proxy between agents and LiteLLM.
+
+Sits in front of LiteLLM (port 4000). On every model call:
+  1. Schema + governance check (delegates to KEI-165 governance_proxy)
+  2. Spend budget check (Valkey ``spend:<tenant>:<YYYY-MM>`` vs tier limit)
+  3. Rate limit check (Valkey 60s sliding window per KEI-117A namespace)
+  4. If all pass: forward to LiteLLM, log allow event
+  5. If any fail: reject with structured error, log denial
+
+Acceptance (Linear KEI-210):
+  - interceptor_proxy.py in src/dispatcher/ ✓
+  - GET /interceptor/health → 200 OK
+  - Spend check queries Valkey correctly
+  - Rate limit uses Valkey ``rl:<tenant>:<window>`` namespace from KEI-117A
+  - Decisions logged to public.interceptor_events
+  - Rejected calls return structured JSON error, not silent failure
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Final
+
+import httpx
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from src.dispatcher.governance_proxy import ProxyDecision, evaluate
+from src.dispatcher.valkey_pool import (
+    get_valkey_client,
+    tenant_rl_key,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tier limits — sourced from CONSOLIDATED_RULES + dispatcher_customers tiers.
+# Hardcoded here for KEI-210; KEI-117C will lift these from the DB.
+# Spend caps are $AUD cents per calendar month (LAW II). Rate caps are
+# requests-per-minute (matches the 60-second window in KEI-117A).
+# ---------------------------------------------------------------------------
+
+TIER_DEFAULT: Final = "free"
+SPEND_BUDGET_AUD_CENTS: Final[dict[str, int]] = {
+    "free": 0,
+    "starter": 5_000_00,  # $5,000 AUD
+    "growth": 50_000_00,  # $50,000 AUD
+    "scale": 500_000_00,  # $500,000 AUD
+    "enterprise": 5_000_000_00,
+}
+RATE_LIMIT_PER_MINUTE: Final[dict[str, int]] = {
+    "free": 10,
+    "starter": 60,
+    "growth": 600,
+    "scale": 6_000,
+    "enterprise": 60_000,
+}
+
+SPEND_NAMESPACE_PREFIX: Final = "spend"
+RATE_WINDOW_SECONDS: Final = 60
+LITELLM_URL_ENV: Final = "LITELLM_URL"
+DEFAULT_LITELLM_URL: Final = "http://127.0.0.1:4000/v1/chat/completions"
+
+# ---------------------------------------------------------------------------
+# Decisions
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InterceptorDecision:
+    """Outcome of a single intercept_request call."""
+
+    allowed: bool
+    decision: str  # 'allow' | 'deny_spend' | 'deny_rate_limit' | 'deny_governance' | 'error'
+    reason: str | None = None
+    status_code: int = 200
+    payload: dict[str, Any] | None = None
+    headers: dict[str, str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers — internal
+# ---------------------------------------------------------------------------
+
+
+def _tier_for(body: dict, default: str = TIER_DEFAULT) -> str:
+    """Resolve tier off the body. Real wiring (KEI-117C) will query the DB
+    via tenant_id; until then accept an explicit ``tier`` hint or fall back
+    to ``free`` so denies stay conservative for unknown callers."""
+    tier = body.get("tier") or default
+    return tier if tier in SPEND_BUDGET_AUD_CENTS else default
+
+
+def _spend_key(tenant_id: str, now: dt.datetime | None = None) -> str:
+    ts = now or dt.datetime.now(dt.UTC)
+    return f"{SPEND_NAMESPACE_PREFIX}:{tenant_id}:{ts.strftime('%Y-%m')}"
+
+
+async def _check_spend_budget(tenant_id: str, tier: str) -> tuple[bool, int]:
+    """Return (allowed, spent_cents). Reads the monthly cumulative spend
+    counter from Valkey; missing key counts as 0. Caller is responsible for
+    incrementing after a successful forward via ``_accrue_spend``."""
+    budget = SPEND_BUDGET_AUD_CENTS.get(tier, 0)
+    client = get_valkey_client()
+    try:
+        raw = await client.get(_spend_key(tenant_id))
+        spent = int(raw) if raw is not None else 0
+    finally:
+        await client.aclose()
+    return (spent < budget, spent)
+
+
+async def _check_rate_limit(tenant_id: str, tier: str) -> tuple[bool, int]:
+    """Return (allowed, count). Increments the per-minute bucket and applies
+    a 60s TTL on first write so old buckets auto-evict. Uses KEI-117A
+    ``tenant_rl_key`` so the namespace stays canonical."""
+    limit = RATE_LIMIT_PER_MINUTE.get(tier, 0)
+    if limit <= 0:
+        return (False, 0)
+    bucket_start = int(time.time()) // RATE_WINDOW_SECONDS * RATE_WINDOW_SECONDS
+    key = tenant_rl_key(tenant_id, bucket_start)
+    client = get_valkey_client()
+    try:
+        count = await client.incr(key)
+        if count == 1:
+            await client.expire(key, RATE_WINDOW_SECONDS)
+    finally:
+        await client.aclose()
+    return (int(count) <= limit, int(count))
+
+
+async def _accrue_spend(tenant_id: str, cost_cents_aud: int) -> None:
+    """Bump the monthly spend counter after a successful forward."""
+    if cost_cents_aud <= 0:
+        return
+    client = get_valkey_client()
+    try:
+        await client.incrby(_spend_key(tenant_id), cost_cents_aud)
+    finally:
+        await client.aclose()
+
+
+async def _log_event(
+    tenant_id: str,
+    decision: str,
+    reason: str | None,
+    model: str | None,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    cost_cents_aud: int | None,
+    latency_ms: int | None,
+    insert_fn: Any | None = None,
+) -> None:
+    """Best-effort audit insert. ``insert_fn`` is injected for tests; real
+    callers leave it None and we'll resolve a Supabase client lazily so the
+    import surface doesn't pull supabase into unit tests."""
+    row = {
+        "id": str(uuid.uuid4()),
+        "tenant_id": tenant_id,
+        "decision": decision,
+        "reason": reason,
+        "model": model,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cost_cents_aud": cost_cents_aud,
+        "latency_ms": latency_ms,
+    }
+    try:
+        if insert_fn is not None:
+            await insert_fn(row)
+            return
+        from src.integrations.supabase import get_supabase_service_client
+
+        client = get_supabase_service_client()
+        client.table("interceptor_events").insert(row).execute()
+    except Exception as exc:  # noqa: BLE001 — audit must not break the hot path
+        logger.warning("interceptor_events insert failed (non-fatal): %s", exc)
+
+
+async def _forward_to_litellm(payload: dict, http_client: httpx.AsyncClient | None = None) -> dict:
+    """POST to LiteLLM and return the parsed JSON response. The client is
+    injectable for tests."""
+    url = os.environ.get(LITELLM_URL_ENV, DEFAULT_LITELLM_URL)
+    owns_client = http_client is None
+    client = http_client or httpx.AsyncClient(timeout=30.0)
+    try:
+        resp = await client.post(url, json=payload)
+        resp.raise_for_status()
+        return resp.json()
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def intercept_request(
+    body: dict,
+    *,
+    forward_fn: Any | None = None,
+    insert_fn: Any | None = None,
+) -> InterceptorDecision:
+    """Run the governance → spend → rate-limit → forward pipeline.
+
+    ``forward_fn`` and ``insert_fn`` are injection hooks for tests. Production
+    callers pass neither and we use the default Valkey + LiteLLM + Supabase
+    clients.
+    """
+    start = time.monotonic()
+    tenant_id = body.get("tenant_id") or ""
+    tier = _tier_for(body)
+    model = body.get("model")
+
+    governance: ProxyDecision = evaluate(body)
+    if not governance.allowed:
+        reason = governance.reason or "deny_governance"
+        await _log_event(
+            tenant_id,
+            "deny_governance",
+            reason,
+            model,
+            None,
+            None,
+            None,
+            _ms_since(start),
+            insert_fn,
+        )
+        return InterceptorDecision(
+            allowed=False,
+            decision="deny_governance",
+            reason=reason,
+            status_code=403,
+            payload={"error": "governance_denied", "reason": reason},
+        )
+
+    spend_ok, _ = await _check_spend_budget(tenant_id, tier)
+    if not spend_ok:
+        await _log_event(
+            tenant_id,
+            "deny_spend",
+            "monthly_budget_exhausted",
+            model,
+            None,
+            None,
+            None,
+            _ms_since(start),
+            insert_fn,
+        )
+        return InterceptorDecision(
+            allowed=False,
+            decision="deny_spend",
+            reason="monthly_budget_exhausted",
+            status_code=402,
+            payload={"error": "spend_budget_exceeded", "tier": tier},
+        )
+
+    rate_ok, _ = await _check_rate_limit(tenant_id, tier)
+    if not rate_ok:
+        await _log_event(
+            tenant_id,
+            "deny_rate_limit",
+            "per_minute_limit",
+            model,
+            None,
+            None,
+            None,
+            _ms_since(start),
+            insert_fn,
+        )
+        return InterceptorDecision(
+            allowed=False,
+            decision="deny_rate_limit",
+            reason="per_minute_limit",
+            status_code=429,
+            payload={"error": "rate_limit_exceeded", "tier": tier},
+            headers={"Retry-After": str(RATE_WINDOW_SECONDS)},
+        )
+
+    try:
+        result = await (forward_fn(body) if forward_fn else _forward_to_litellm(body))
+    except Exception as exc:  # noqa: BLE001 — upstream errors surface as structured
+        await _log_event(
+            tenant_id,
+            "error",
+            f"forward_failed:{type(exc).__name__}",
+            model,
+            None,
+            None,
+            None,
+            _ms_since(start),
+            insert_fn,
+        )
+        return InterceptorDecision(
+            allowed=False,
+            decision="error",
+            reason=f"forward_failed:{type(exc).__name__}",
+            status_code=502,
+            payload={"error": "upstream_unavailable"},
+        )
+
+    usage = result.get("usage") or {}
+    in_tok = usage.get("prompt_tokens")
+    out_tok = usage.get("completion_tokens")
+    cost = int(result.get("cost_cents_aud", 0))
+    if cost > 0:
+        await _accrue_spend(tenant_id, cost)
+    await _log_event(
+        tenant_id,
+        "allow",
+        None,
+        model,
+        in_tok,
+        out_tok,
+        cost,
+        _ms_since(start),
+        insert_fn,
+    )
+    return InterceptorDecision(allowed=True, decision="allow", payload=result)
+
+
+def _ms_since(start_monotonic: float) -> int:
+    return int((time.monotonic() - start_monotonic) * 1000)
+
+
+# ---------------------------------------------------------------------------
+# FastAPI router
+# ---------------------------------------------------------------------------
+
+router = APIRouter(prefix="/interceptor", tags=["interceptor"])
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    """Liveness probe. Returns 200 OK with a small body so the dispatcher
+    health aggregator can see component=interceptor_proxy green."""
+    return {"status": "ok", "component": "interceptor_proxy", "kei": "KEI-210"}
+
+
+@router.post("/forward")
+async def forward(body: dict) -> JSONResponse:
+    """Public entry. Runs the full intercept pipeline and surfaces the
+    decision as JSON. Rejected calls return structured error bodies so the
+    agent can branch on ``decision`` without parsing strings."""
+    decision = await intercept_request(body)
+    payload = decision.payload or {"decision": decision.decision}
+    return JSONResponse(
+        status_code=decision.status_code,
+        content={"decision": decision.decision, "reason": decision.reason, **payload},
+        headers=decision.headers or {},
+    )
+
+
+__all__ = [
+    "InterceptorDecision",
+    "RATE_LIMIT_PER_MINUTE",
+    "SPEND_BUDGET_AUD_CENTS",
+    "intercept_request",
+    "router",
+]

--- a/supabase/migrations/20260518_kei210_interceptor_events.sql
+++ b/supabase/migrations/20260518_kei210_interceptor_events.sql
@@ -1,0 +1,48 @@
+-- KEI-210: interceptor_events — audit log for every model call routed through
+-- the Dispatcher interceptor_proxy. Every decision (allow / deny_spend /
+-- deny_rate_limit / deny_governance / error) gets a row, including denied
+-- requests so the audit trail covers the rejection path too.
+--
+-- Companion to:
+--   - dispatcher_customers (KEI-111) — tenant_id references that table
+--   - governance_proxy.py (KEI-165) — emits deny_governance decisions
+--   - valkey_pool.py (KEI-117A) — rate-limit + spend checks live on Valkey;
+--     this table is the durable audit, Valkey is the hot path.
+
+CREATE TABLE IF NOT EXISTS public.interceptor_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.dispatcher_customers(id) ON DELETE CASCADE,
+    decision TEXT NOT NULL CHECK (decision IN (
+        'allow',
+        'deny_spend',
+        'deny_rate_limit',
+        'deny_governance',
+        'error'
+    )),
+    -- Free-form reason (e.g. governance rule name, error message). Never
+    -- contains prompt body — denial logs must not echo customer content
+    -- per governance_proxy.py contract.
+    reason TEXT,
+    model TEXT,
+    -- Token counts populated on 'allow' decisions only. NULL on denies.
+    input_tokens INT,
+    output_tokens INT,
+    -- Spend accrued for this call in $AUD cents (LAW II). Integer to dodge
+    -- float-rounding bugs at billing time.
+    cost_cents_aud INT,
+    -- End-to-end latency from interceptor entry to LiteLLM response.
+    latency_ms INT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_interceptor_events_tenant_created
+    ON public.interceptor_events (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_interceptor_events_decision
+    ON public.interceptor_events (decision)
+    WHERE decision <> 'allow';
+
+COMMENT ON TABLE public.interceptor_events IS
+    'KEI-210: audit log for every Dispatcher interceptor_proxy decision';
+COMMENT ON COLUMN public.interceptor_events.cost_cents_aud IS
+    '$AUD cents per LAW II — never USD';

--- a/tests/dispatcher/test_interceptor_proxy.py
+++ b/tests/dispatcher/test_interceptor_proxy.py
@@ -1,0 +1,270 @@
+"""Tests for KEI-210 interceptor_proxy.
+
+Mocks Valkey via a stub async client + injects forward/insert hooks so the
+unit suite needs neither a live Valkey, a live LiteLLM, nor a Supabase
+session. Covers the four decision branches (allow / deny_spend /
+deny_rate_limit / deny_governance), the error path, the health endpoint,
+and the Valkey key-shape contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.dispatcher import interceptor_proxy
+from src.dispatcher.interceptor_proxy import (
+    RATE_LIMIT_PER_MINUTE,
+    SPEND_BUDGET_AUD_CENTS,
+    InterceptorDecision,
+    intercept_request,
+    router,
+)
+
+# ─── Fake Valkey ─────────────────────────────────────────────────────────────
+
+
+class FakeValkey:
+    """In-memory async stub matching the subset of redis.asyncio we touch."""
+
+    def __init__(self, *, spend: dict[str, int] | None = None) -> None:
+        self.store: dict[str, int] = {}
+        self.expires: dict[str, int] = {}
+        if spend:
+            self.store.update(spend)
+        self.closed = False
+
+    async def get(self, key: str) -> str | None:
+        v = self.store.get(key)
+        return str(v) if v is not None else None
+
+    async def incr(self, key: str) -> int:
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    async def incrby(self, key: str, amount: int) -> int:
+        self.store[key] = self.store.get(key, 0) + amount
+        return self.store[key]
+
+    async def expire(self, key: str, ttl: int) -> bool:
+        self.expires[key] = ttl
+        return True
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def fake_valkey(monkeypatch: pytest.MonkeyPatch) -> FakeValkey:
+    fake = FakeValkey()
+    monkeypatch.setattr(interceptor_proxy, "get_valkey_client", lambda: fake)
+    return fake
+
+
+VALID_BODY: dict = {
+    "tenant_id": "11111111-1111-1111-1111-111111111111",
+    "prompt": "Summarise our Q3 revenue plan.",
+    "max_tokens": 256,
+    "model": "claude-sonnet-4-6",
+    "tier": "starter",
+}
+
+
+# ─── Health endpoint ────────────────────────────────────────────────────────
+
+
+def test_health_returns_200() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        resp = client.get("/interceptor/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["component"] == "interceptor_proxy"
+    assert body["kei"] == "KEI-210"
+
+
+# ─── Tier limit map sanity ──────────────────────────────────────────────────
+
+
+def test_tier_map_covers_dispatcher_customer_tiers() -> None:
+    """dispatcher_customers tier values must all be in the spend + rate map."""
+    expected = {"free", "starter", "growth", "scale", "enterprise"}
+    assert set(SPEND_BUDGET_AUD_CENTS) == expected
+    assert set(RATE_LIMIT_PER_MINUTE) == expected
+
+
+def test_free_tier_has_zero_spend_budget() -> None:
+    """Per pre-revenue posture: free tier must never accrue spend."""
+    assert SPEND_BUDGET_AUD_CENTS["free"] == 0
+
+
+# ─── Decision branches ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_allow_path_forwards_and_logs(fake_valkey: FakeValkey) -> None:
+    inserted: list[dict] = []
+
+    async def fake_insert(row: dict) -> None:
+        inserted.append(row)
+
+    async def fake_forward(body: dict) -> dict:
+        return {
+            "id": "resp-1",
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+            "cost_cents_aud": 12,
+        }
+
+    decision = await intercept_request(VALID_BODY, forward_fn=fake_forward, insert_fn=fake_insert)
+    assert decision.allowed is True
+    assert decision.decision == "allow"
+    assert decision.payload is not None
+    assert decision.payload["id"] == "resp-1"
+    assert len(inserted) == 1
+    assert inserted[0]["decision"] == "allow"
+    assert inserted[0]["input_tokens"] == 100
+    assert inserted[0]["output_tokens"] == 50
+    assert inserted[0]["cost_cents_aud"] == 12
+
+
+@pytest.mark.asyncio
+async def test_deny_spend_when_budget_exhausted(fake_valkey: FakeValkey) -> None:
+    tenant_id = VALID_BODY["tenant_id"]
+    # Pre-populate spend over the starter budget
+    over_budget = SPEND_BUDGET_AUD_CENTS["starter"] + 1
+    fake_valkey.store[interceptor_proxy._spend_key(tenant_id)] = over_budget
+    inserted: list[dict] = []
+
+    async def fake_insert(row: dict) -> None:
+        inserted.append(row)
+
+    forwarded = False
+
+    async def fake_forward(body: dict) -> dict:
+        nonlocal forwarded
+        forwarded = True
+        return {}
+
+    decision = await intercept_request(VALID_BODY, forward_fn=fake_forward, insert_fn=fake_insert)
+    assert decision.allowed is False
+    assert decision.decision == "deny_spend"
+    assert decision.status_code == 402
+    assert forwarded is False
+    assert inserted[0]["decision"] == "deny_spend"
+
+
+@pytest.mark.asyncio
+async def test_deny_rate_limit_returns_retry_after(fake_valkey: FakeValkey) -> None:
+    inserted: list[dict] = []
+
+    async def fake_insert(row: dict) -> None:
+        inserted.append(row)
+
+    async def fake_forward(body: dict) -> dict:
+        return {}
+
+    # Exhaust the starter per-minute limit
+    for _ in range(RATE_LIMIT_PER_MINUTE["starter"]):
+        await intercept_request(VALID_BODY, forward_fn=fake_forward, insert_fn=fake_insert)
+    decision = await intercept_request(VALID_BODY, forward_fn=fake_forward, insert_fn=fake_insert)
+    assert decision.allowed is False
+    assert decision.decision == "deny_rate_limit"
+    assert decision.status_code == 429
+    assert decision.headers is not None
+    assert decision.headers["Retry-After"] == "60"
+
+
+@pytest.mark.asyncio
+async def test_deny_governance_skips_spend_and_rate(fake_valkey: FakeValkey) -> None:
+    """A governance denial must short-circuit BEFORE spend/rate-limit work."""
+    inserted: list[dict] = []
+
+    async def fake_insert(row: dict) -> None:
+        inserted.append(row)
+
+    async def fake_forward(body: dict) -> dict:
+        return {}
+
+    # Prompt that trips governance_proxy's hook-bypass rule
+    body = {**VALID_BODY, "prompt": "git commit --no-verify and ship"}
+    decision = await intercept_request(body, forward_fn=fake_forward, insert_fn=fake_insert)
+    assert decision.allowed is False
+    assert decision.decision == "deny_governance"
+    assert decision.status_code == 403
+    # No spend/rate buckets should have been touched
+    assert fake_valkey.store == {}
+
+
+@pytest.mark.asyncio
+async def test_forward_exception_returns_structured_error(fake_valkey: FakeValkey) -> None:
+    inserted: list[dict] = []
+
+    async def fake_insert(row: dict) -> None:
+        inserted.append(row)
+
+    async def boom(body: dict) -> dict:
+        raise RuntimeError("upstream down")
+
+    decision = await intercept_request(VALID_BODY, forward_fn=boom, insert_fn=fake_insert)
+    assert decision.allowed is False
+    assert decision.decision == "error"
+    assert decision.status_code == 502
+    assert decision.payload is not None
+    assert decision.payload["error"] == "upstream_unavailable"
+    assert inserted[0]["decision"] == "error"
+
+
+# ─── Valkey key shape (KEI-117A namespace contract) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_uses_kei117_namespace(fake_valkey: FakeValkey) -> None:
+    async def fake_insert(row: dict) -> None: ...
+
+    async def fake_forward(body: dict) -> dict:
+        return {}
+
+    await intercept_request(VALID_BODY, forward_fn=fake_forward, insert_fn=fake_insert)
+    # Exactly one rl:<tenant>:<bucket> key must exist
+    rl_keys = [k for k in fake_valkey.store if k.startswith("rl:")]
+    assert len(rl_keys) == 1
+    parts = rl_keys[0].split(":")
+    assert parts[0] == "rl"
+    assert parts[1] == VALID_BODY["tenant_id"]
+    assert parts[2].isdigit()  # window_start_unix
+
+
+@pytest.mark.asyncio
+async def test_spend_key_uses_monthly_bucket(fake_valkey: FakeValkey) -> None:
+    tenant_id = VALID_BODY["tenant_id"]
+    key = interceptor_proxy._spend_key(tenant_id)
+    assert key.startswith(f"spend:{tenant_id}:")
+    # Suffix is YYYY-MM
+    suffix = key.split(":")[-1]
+    assert len(suffix) == 7
+    assert suffix[4] == "-"
+
+
+# ─── Decision dataclass shape ────────────────────────────────────────────────
+
+
+def test_interceptor_decision_is_frozen() -> None:
+    from dataclasses import FrozenInstanceError
+
+    d = InterceptorDecision(allowed=True, decision="allow")
+    with pytest.raises(FrozenInstanceError):
+        d.allowed = False  # type: ignore[misc]
+
+
+# ─── Tier resolver ───────────────────────────────────────────────────────────
+
+
+def test_tier_for_unknown_falls_back_to_free() -> None:
+    assert interceptor_proxy._tier_for({"tier": "mystery"}) == "free"
+
+
+def test_tier_for_missing_falls_back_to_free() -> None:
+    assert interceptor_proxy._tier_for({}) == "free"


### PR DESCRIPTION
## Summary
Builds the Dispatcher **interceptor_proxy** component (Linear KEI-210). Middleware between agents and LiteLLM (port 4000) that runs governance + spend + rate-limit checks per call, forwards to LiteLLM on accept, logs every decision to `interceptor_events`.

Parallel with KEI-209 (Orion) / KEI-211 (Nova) / KEI-212 (Max). KEI-213 (Atlas deploy) blocks on all four merged.

## Changes
- `supabase/migrations/20260518_kei210_interceptor_events.sql` — audit table with 5-decision CHECK, partial index on denials, AUD-cents per LAW II
- `src/dispatcher/interceptor_proxy.py` — `intercept_request()` orchestrator + FastAPI router (`/interceptor/health`, `/interceptor/forward`); spend check on Valkey `spend:<tenant>:<YYYY-MM>`; rate check on Valkey `rl:<tenant>:<window>` reusing KEI-117A `tenant_rl_key`; tier maps for free/starter/growth/scale/enterprise (hardcoded pending KEI-117C); structured `InterceptorDecision` — no silent failures
- `tests/dispatcher/test_interceptor_proxy.py` — 13 unit tests covering all 4 decision branches + error path + Valkey key-shape contract + health endpoint, all mocked via `FakeValkey` + injected forward/insert hooks

## Acceptance criteria (KEI-210 verbatim)
- [x] interceptor_proxy.py exists in dispatcher/ directory
- [x] Health endpoint returns 200
- [x] Spend check queries Valkey correctly
- [x] Rate limit check uses existing KEI-117 sliding window namespace
- [x] Interceptor events logged to interceptor_events Supabase table
- [x] Unit tests pass — paste verbatim pytest output
- [x] Rejected calls return structured error, not silent failure

## Verification (verbatim)
\`\`\`
$ ruff format --check src/dispatcher/interceptor_proxy.py tests/dispatcher/test_interceptor_proxy.py
2 files already formatted

$ ruff check src/dispatcher/interceptor_proxy.py tests/dispatcher/test_interceptor_proxy.py
All checks passed!

$ python3 -m pytest tests/dispatcher/test_interceptor_proxy.py -q
.............                                                            [100%]
13 passed in 0.48s

$ python3 -m pytest tests/dispatcher/ -q
........................................................................ [ 84%]
.............                                                            [100%]
85 passed in 0.69s
\`\`\`

## Test plan
- [ ] CI green
- [ ] Migration applies clean on a fresh Supabase
- [ ] Dual-concur review (Aiden + Elliot + Max minus author = 2 of 3)
- [ ] Wire-up into the Dispatcher health aggregator (Atlas's KEI-213 deploy)

Linear: https://linear.app/keiracom/issue/KEI-210
🤖 Generated with [Claude Code](https://claude.com/claude-code)