### PR TITLE
[ORION] feat(kei209): auth_minter — 15-min agent-session JWTs (Dispatcher)

### DIFF
--- a/src/dispatcher/auth_minter.py
+++ b/src/dispatcher/auth_minter.py
@@ -1,0 +1,70 @@
+"""KEI-209 — Auth minter for Dispatcher agent sessions.
+
+Mints short-lived (15-minute TTL) HS256 JWTs identifying an agent session to
+the Dispatcher API. Distinct from `container_jwt.py` (KEI-164) which issues
+longer-lived tokens for managed-container spawns: this component identifies
+an *agent session* (tenant_id + callsign + session_id) and is auto-reissued
+by the Dispatcher before expiry.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+logger = logging.getLogger(__name__)
+
+JWT_ALGORITHM = "HS256"
+TOKEN_TTL_SECONDS = 15 * 60
+
+
+def _signing_secret() -> str:
+    """Read DISPATCHER_JWT_SECRET; fail fast if unset.
+
+    No dev fallback — every environment must provide an explicit secret per
+    KEI-209 acceptance criterion "No hardcoded secrets".
+    """
+    secret = os.environ.get("DISPATCHER_JWT_SECRET", "").strip()
+    if not secret:
+        raise RuntimeError("DISPATCHER_JWT_SECRET must be set")
+    return secret
+
+
+def mint_token(tenant_id: str, callsign: str, session_id: str) -> str:
+    """Mint a short-lived agent-session JWT.
+
+    Payload claims: tenant_id, callsign, session_id, iat, exp.
+    Raises ValueError on any blank required field — prevents anonymous tokens.
+    """
+    if not tenant_id or not tenant_id.strip():
+        raise ValueError("tenant_id is required and must be non-blank")
+    if not callsign or not callsign.strip():
+        raise ValueError("callsign is required and must be non-blank")
+    if not session_id or not session_id.strip():
+        raise ValueError("session_id is required and must be non-blank")
+    now = datetime.now(UTC)
+    payload: dict = {
+        "tenant_id": tenant_id,
+        "callsign": callsign,
+        "session_id": session_id,
+        "iat": now,
+        "exp": now + timedelta(seconds=TOKEN_TTL_SECONDS),
+    }
+    return jwt.encode(payload, _signing_secret(), algorithm=JWT_ALGORITHM)
+
+
+def verify_token(token: str) -> dict | None:
+    """Verify + decode an agent-session JWT.
+
+    Returns the decoded claims dict on success, or None on any verification
+    failure (expired, tampered, wrong secret, malformed). Callers must check
+    for None before trusting the result.
+    """
+    try:
+        return jwt.decode(token, _signing_secret(), algorithms=[JWT_ALGORITHM])
+    except jwt.InvalidTokenError as exc:
+        logger.debug("auth_minter verify_token rejected: %s", exc)
+        return None

--- a/tests/dispatcher/test_auth_minter.py
+++ b/tests/dispatcher/test_auth_minter.py
@@ -1,0 +1,105 @@
+"""KEI-209 — tests for auth_minter mint + verify."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+
+from src.dispatcher.auth_minter import (
+    TOKEN_TTL_SECONDS,
+    mint_token,
+    verify_token,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_jwt_secret(monkeypatch):
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test-secret-kei209")
+
+
+def test_mint_returns_three_part_jwt_string():
+    tok = mint_token("tenant-abc", "orion", "sess-1")
+    assert isinstance(tok, str)
+    assert tok.count(".") == 2
+
+
+def test_mint_includes_all_required_claims():
+    claims = verify_token(mint_token("tenant-abc", "orion", "sess-1"))
+    assert claims is not None
+    assert claims["tenant_id"] == "tenant-abc"
+    assert claims["callsign"] == "orion"
+    assert claims["session_id"] == "sess-1"
+    assert "iat" in claims
+    assert "exp" in claims
+
+
+def test_token_ttl_is_15_minutes():
+    claims = verify_token(mint_token("tenant-abc", "orion", "sess-1"))
+    assert claims is not None
+    assert claims["exp"] - claims["iat"] == TOKEN_TTL_SECONDS
+    assert TOKEN_TTL_SECONDS == 900
+
+
+def test_verify_valid_token_returns_dict():
+    tok = mint_token("tenant-abc", "orion", "sess-1")
+    result = verify_token(tok)
+    assert isinstance(result, dict)
+    assert result["callsign"] == "orion"
+
+
+def test_verify_expired_token_returns_none():
+    past = datetime.now(UTC) - timedelta(hours=1)
+    tok = jwt.encode(
+        {
+            "tenant_id": "t",
+            "callsign": "orion",
+            "session_id": "s",
+            "iat": past,
+            "exp": past,
+        },
+        "test-secret-kei209",
+        algorithm="HS256",
+    )
+    assert verify_token(tok) is None
+
+
+def test_verify_tampered_payload_returns_none():
+    tok = mint_token("tenant-abc", "orion", "sess-1")
+    parts = tok.split(".")
+    parts[1] = "eyJ0ZW5hbnRfaWQiOiJoYWNrZXIifQ"
+    assert verify_token(".".join(parts)) is None
+
+
+def test_verify_wrong_secret_returns_none(monkeypatch):
+    tok = mint_token("tenant-abc", "orion", "sess-1")
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "rotated-secret")
+    assert verify_token(tok) is None
+
+
+def test_verify_malformed_token_returns_none():
+    assert verify_token("not-a-jwt") is None
+
+
+def test_mint_rejects_blank_tenant_id():
+    with pytest.raises(ValueError, match="tenant_id is required"):
+        mint_token("", "orion", "sess-1")
+    with pytest.raises(ValueError, match="tenant_id is required"):
+        mint_token("   ", "orion", "sess-1")
+
+
+def test_mint_rejects_blank_callsign():
+    with pytest.raises(ValueError, match="callsign is required"):
+        mint_token("tenant-abc", "", "sess-1")
+
+
+def test_mint_rejects_blank_session_id():
+    with pytest.raises(ValueError, match="session_id is required"):
+        mint_token("tenant-abc", "orion", "")
+
+
+def test_secret_required_no_dev_fallback(monkeypatch):
+    monkeypatch.delenv("DISPATCHER_JWT_SECRET", raising=False)
+    with pytest.raises(RuntimeError, match="DISPATCHER_JWT_SECRET must be set"):
+        mint_token("tenant-abc", "orion", "sess-1")


### PR DESCRIPTION
## Summary

Builds the **auth_minter** component for the Dispatcher (Linear [KEI-209](https://linear.app/keiracom/issue/KEI-209), bd `Agency_OS-irpcwf`). Mints short-lived (15-minute TTL) HS256 JWTs identifying an agent session to the Dispatcher API. Distinct from KEI-164 `container_jwt.py` which issues longer-lived tokens for managed-container spawns: this component identifies an *agent session* (tenant_id + callsign + session_id) and is auto-reissued by the Dispatcher before expiry.

## Files

- `src/dispatcher/auth_minter.py` (70 lines)
  - `mint_token(tenant_id, callsign, session_id) -> str`
  - `verify_token(token) -> dict | None` — returns None on any failure (callers must None-check)
  - HS256 signing; `DISPATCHER_JWT_SECRET` env var; fail-fast if unset (no dev fallback)
  - Payload: `tenant_id`, `callsign`, `session_id`, `iat`, `exp`
  - Blank-input `ValueError` on all three required fields

- `tests/dispatcher/test_auth_minter.py` (105 lines, 12 tests)
  - mint shape; required claims; 15-min TTL exactly; verify-valid round-trip
  - **Negative paths** (per `feedback_negative_path_test_before_approve`): expired, tampered payload, wrong secret, malformed token → all return `None`
  - Blank-input guards on each required arg
  - Secret-required (no dev fallback)

## Acceptance criteria (KEI-209)

- [x] `auth_minter.py` exists in `dispatcher/` directory (lands at `src/dispatcher/auth_minter.py` — matches sibling layout)
- [x] `mint_token` and `verify_token` functions implemented
- [x] Tokens expire after 15 minutes (`TOKEN_TTL_SECONDS = 900`, asserted in test)
- [x] Unit tests pass — verbatim:

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/elliotbot/clawd/Agency_OS-orion
configfile: pytest.ini
plugins: asyncio-1.3.0, logfire-4.25.0, anyio-4.12.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collecting ... collected 12 items

tests/dispatcher/test_auth_minter.py::test_mint_returns_three_part_jwt_string PASSED [  8%]
tests/dispatcher/test_auth_minter.py::test_mint_includes_all_required_claims PASSED [ 16%]
tests/dispatcher/test_auth_minter.py::test_token_ttl_is_15_minutes PASSED [ 25%]
tests/dispatcher/test_auth_minter.py::test_verify_valid_token_returns_dict PASSED [ 33%]
tests/dispatcher/test_auth_minter.py::test_verify_expired_token_returns_none PASSED [ 41%]
tests/dispatcher/test_auth_minter.py::test_verify_tampered_payload_returns_none PASSED [ 50%]
tests/dispatcher/test_auth_minter.py::test_verify_wrong_secret_returns_none PASSED [ 58%]
tests/dispatcher/test_auth_minter.py::test_verify_malformed_token_returns_none PASSED [ 66%]
tests/dispatcher/test_auth_minter.py::test_mint_rejects_blank_tenant_id PASSED [ 75%]
tests/dispatcher/test_auth_minter.py::test_mint_rejects_blank_callsign PASSED [ 83%]
tests/dispatcher/test_auth_minter.py::test_mint_rejects_blank_session_id PASSED [ 91%]
tests/dispatcher/test_auth_minter.py::test_secret_required_no_dev_fallback PASSED [100%]

============================== 12 passed in 0.09s ==============================
```

- [x] No hardcoded secrets — reads `DISPATCHER_JWT_SECRET`, raises `RuntimeError` if unset (no dev fallback)

## Lint

```
ruff check src/dispatcher/auth_minter.py tests/dispatcher/test_auth_minter.py
All checks passed!

ruff format --check src/dispatcher/auth_minter.py tests/dispatcher/test_auth_minter.py
2 files already formatted
```

## Relationship to KEI-164 (`container_jwt.py`)

| | `container_jwt` (KEI-164) | `auth_minter` (KEI-209) |
|--|--|--|
| Purpose | Container spawn auth | Agent session auth |
| TTL | 1 hour | 15 min (auto-reissued) |
| Secret env | `CONTAINER_JWT_SECRET` | `DISPATCHER_JWT_SECRET` |
| Payload | tenant_id + scope | tenant_id + callsign + session_id |
| On verify fail | raises `InvalidTokenError` | returns `None` |
| Dev fallback | yes (outside prod) | no — fail-fast always |

Separate components are justified by different audiences (container vs session) and different TTL/secret requirements. Future unification can fold both behind a common signing layer if desired.

## Siblings on `origin/main`

- KEI-210 `interceptor_proxy` (Scout, `1c5df74d51`, merged)
- KEI-212 `spend_tracker` (Max, `a0e6248d50`, merged)

Blocks: KEI-213 Atlas Dispatcher deploy (this + KEI-211 watchdog+reaper).

## Reviewers

Dual-concur per DOD — any 2 of 3 = merge eligible (author-excluded):
- @Aiden
- @Max
- @Elliot

## Test plan

- [x] `pytest tests/dispatcher/test_auth_minter.py -v` — 12 passed
- [x] `ruff check` + `ruff format --check` — clean
- [ ] CI green (running)
- [ ] Dispatcher health endpoint registration (out of scope for this PR — sibling task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)