### PR TITLE
[NOVA] feat(kei211): watchdog + reaper — zombie session detection and cleanup

### DIFF
--- a/src/dispatcher/__init__.py
+++ b/src/dispatcher/__init__.py
@@ -2,4 +2,39 @@
 
 Customer-facing product surface: container lifecycle (KEI-115), tenant JWT
 minting (KEI-164), governance proxy (KEI-165), LiteLLM routing (KEI-166).
+Supervisor surface: container_monitor (KEI-163), watchdog + reaper (KEI-211).
 """
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.dispatcher.reaper import Reaper
+    from src.dispatcher.watchdog import Watchdog
+
+
+def supervisor_health_snapshot(
+    watchdog: Watchdog | None = None,
+    reaper: Reaper | None = None,
+) -> dict[str, object]:
+    """Aggregate KEI-211 watchdog + reaper status for the dispatcher
+    health endpoint.
+
+    Top-level ``status`` is "green" iff every component reports "green".
+    Missing components are absent from the response (not synthesised as
+    green) so the consumer can see which supervisor pieces are wired up.
+    """
+    components: list[dict[str, object]] = []
+    if watchdog is not None:
+        components.append(watchdog.health_snapshot())
+    if reaper is not None:
+        components.append(reaper.health_snapshot())
+
+    overall = "green"
+    for c in components:
+        if c.get("status") != "green":
+            overall = "degraded"
+            break
+
+    return {"status": overall, "components": components}

--- a/src/dispatcher/reaper.py
+++ b/src/dispatcher/reaper.py
@@ -1,0 +1,318 @@
+"""KEI-211 — Dispatcher Reaper: zombie session detection + cleanup.
+
+Pairs with :mod:`src.dispatcher.watchdog`. The watchdog catches sessions
+that are *running but unresponsive*; the reaper catches sessions that
+were never properly torn down: tmux sessions / containers that the
+dispatcher's registry no longer knows about, or registered handles past
+their TTL.
+
+Scope safety — DO NOT misuse:
+This module enumerates **live tmux sessions and containers on the host**
+and kills anything not in the dispatcher's registry. To avoid reaping
+unrelated dev sessions, callers MUST supply a name prefix scope
+(``tmux_name_prefix`` / ``container_name_prefix``). Empty prefixes are
+rejected at construction time — there is no "reap all" mode.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import time
+from dataclasses import dataclass
+
+from src.dispatcher.container_lifecycle import (
+    DEFAULT_DOCKER_TEARDOWN_TIMEOUT_S,
+    DOCKER_CLI,
+    ContainerHandle,
+    DockerUnavailableError,
+    kill_and_remove,
+)
+from src.dispatcher.tmux_lifecycle import (
+    DEFAULT_TMUX_CMD_TIMEOUT_S,
+    TMUX_CLI,
+    SessionHandle,
+    TmuxUnavailableError,
+    terminate,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ReapEvent:
+    kind: str  # "tmux" | "container"
+    name_or_id: str
+    reason: str  # "orphan" | "ttl_exceeded"
+    success: bool
+
+
+@dataclass(frozen=True)
+class ReapResult:
+    scanned_tmux: int
+    scanned_containers: int
+    reaped: tuple[ReapEvent, ...]
+
+    @property
+    def total_reaped(self) -> int:
+        return len(self.reaped)
+
+
+def _list_tmux_sessions() -> list[str] | None:
+    """Return live tmux session names, or None when tmux unreachable.
+
+    None is a soft signal: caller MUST NOT treat "no tmux" as "no zombies"
+    and proceed to reap; it means "skip the tmux pass this cycle".
+    """
+    try:
+        result = subprocess.run(  # noqa: S603  # controlled args
+            [TMUX_CLI, "list-sessions", "-F", "#{session_name}"],
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_TMUX_CMD_TIMEOUT_S,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise TmuxUnavailableError(f"{TMUX_CLI} CLI not found on PATH") from exc
+    except subprocess.TimeoutExpired:
+        logger.warning("KEI-211 reaper: tmux list-sessions timed out — skipping pass")
+        return None
+    # tmux returns rc=1 when there are no sessions; that's "empty", not error.
+    if result.returncode != 0 and "no server running" not in result.stderr.lower():
+        logger.warning(
+            "KEI-211 reaper: tmux list-sessions rc=%d stderr=%s",
+            result.returncode,
+            result.stderr.strip()[:200],
+        )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _list_containers_by_prefix(prefix: str) -> list[tuple[str, str]] | None:
+    """Return [(id, name), ...] for containers whose name starts with prefix.
+
+    None means docker is unreachable for this cycle (skip the container pass).
+    """
+    try:
+        result = subprocess.run(  # noqa: S603  # controlled args
+            [
+                DOCKER_CLI,
+                "ps",
+                "-a",
+                "--filter",
+                f"name=^{prefix}",
+                "--format",
+                "{{.ID}} {{.Names}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_DOCKER_TEARDOWN_TIMEOUT_S,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise DockerUnavailableError(f"{DOCKER_CLI} CLI not found on PATH") from exc
+    except subprocess.TimeoutExpired:
+        logger.warning("KEI-211 reaper: docker ps timed out — skipping pass")
+        return None
+    if result.returncode != 0:
+        logger.warning(
+            "KEI-211 reaper: docker ps rc=%d stderr=%s",
+            result.returncode,
+            result.stderr.strip()[:200],
+        )
+        return None
+    out: list[tuple[str, str]] = []
+    for line in result.stdout.splitlines():
+        parts = line.split(maxsplit=1)
+        if len(parts) == 2:
+            out.append((parts[0], parts[1]))
+    return out
+
+
+class Reaper:
+    """Kills + cleans dispatcher sessions/containers no longer in registry.
+
+    The dispatcher registers each session it starts; when the session ends
+    normally it's unregistered. ``sweep()`` scans the host and kills
+    anything matching the name prefix that is not currently registered, OR
+    is registered but has exceeded its TTL.
+    """
+
+    def __init__(
+        self,
+        *,
+        tmux_name_prefix: str,
+        container_name_prefix: str,
+        default_ttl_s: float | None = None,
+    ) -> None:
+        if not tmux_name_prefix or not container_name_prefix:
+            raise ValueError(
+                "Reaper requires non-empty tmux_name_prefix and container_name_prefix "
+                "to avoid reaping unrelated sessions/containers on the host"
+            )
+        self._tmux_prefix = tmux_name_prefix
+        self._container_prefix = container_name_prefix
+        self._default_ttl_s = default_ttl_s
+        # Registered handles keyed by name (tmux) or id (container).
+        self._tmux_registry: dict[str, tuple[SessionHandle, float]] = {}
+        self._container_registry: dict[str, tuple[ContainerHandle, float]] = {}
+        self._last_result: ReapResult | None = None
+
+    # ------------------------------------------------------------------
+    # registry
+    # ------------------------------------------------------------------
+
+    def register_tmux(self, handle: SessionHandle, *, ttl_s: float | None = None) -> None:
+        if not handle.session_name.startswith(self._tmux_prefix):
+            raise ValueError(
+                f"tmux session {handle.session_name!r} does not start with "
+                f"registered prefix {self._tmux_prefix!r}"
+            )
+        ttl = ttl_s if ttl_s is not None else self._default_ttl_s
+        deadline = time.monotonic() + ttl if ttl is not None else float("inf")
+        self._tmux_registry[handle.session_name] = (handle, deadline)
+
+    def register_container(
+        self, handle: ContainerHandle, *, ttl_s: float | None = None
+    ) -> None:
+        if not handle.name.startswith(self._container_prefix):
+            raise ValueError(
+                f"container name {handle.name!r} does not start with "
+                f"registered prefix {self._container_prefix!r}"
+            )
+        ttl = ttl_s if ttl_s is not None else self._default_ttl_s
+        deadline = time.monotonic() + ttl if ttl is not None else float("inf")
+        self._container_registry[handle.id] = (handle, deadline)
+
+    def unregister_tmux(self, session_name: str) -> None:
+        self._tmux_registry.pop(session_name, None)
+
+    def unregister_container(self, container_id: str) -> None:
+        self._container_registry.pop(container_id, None)
+
+    # ------------------------------------------------------------------
+    # sweep
+    # ------------------------------------------------------------------
+
+    def _sweep_tmux(self) -> tuple[int, list[ReapEvent]]:
+        try:
+            live = _list_tmux_sessions()
+        except TmuxUnavailableError:
+            logger.info("KEI-211 reaper: tmux unavailable, skipping tmux sweep")
+            return (0, [])
+        if live is None:
+            return (0, [])
+        scoped = [s for s in live if s.startswith(self._tmux_prefix)]
+        events: list[ReapEvent] = []
+        now = time.monotonic()
+
+        # Orphans: live in tmux but not in our registry.
+        for name in scoped:
+            if name not in self._tmux_registry:
+                events.append(self._kill_tmux(name, reason="orphan"))
+
+        # TTL-exceeded: registered AND live AND past deadline.
+        for name, (handle, deadline) in list(self._tmux_registry.items()):
+            if name in scoped and now >= deadline:
+                events.append(self._kill_tmux(handle.session_name, reason="ttl_exceeded"))
+                self._tmux_registry.pop(name, None)
+
+        return (len(scoped), events)
+
+    def _sweep_containers(self) -> tuple[int, list[ReapEvent]]:
+        try:
+            live = _list_containers_by_prefix(self._container_prefix)
+        except DockerUnavailableError:
+            logger.info("KEI-211 reaper: docker unavailable, skipping container sweep")
+            return (0, [])
+        if live is None:
+            return (0, [])
+        events: list[ReapEvent] = []
+        now = time.monotonic()
+
+        registered_ids = set(self._container_registry)
+        # Orphans
+        for cid, name in live:
+            if cid not in registered_ids:
+                events.append(self._kill_container_by_id(cid, name, reason="orphan"))
+
+        # TTL-exceeded
+        live_ids = {cid for cid, _ in live}
+        for cid, (handle, deadline) in list(self._container_registry.items()):
+            if cid in live_ids and now >= deadline:
+                events.append(
+                    self._kill_container_by_id(cid, handle.name, reason="ttl_exceeded")
+                )
+                self._container_registry.pop(cid, None)
+
+        return (len(live), events)
+
+    def _kill_tmux(self, name: str, *, reason: str) -> ReapEvent:
+        try:
+            handle = self._tmux_registry.get(name, (None, 0.0))[0]
+            target = handle or SessionHandle(
+                session_name=name, working_dir="/", command=""
+            )
+            terminate(target)
+            logger.info("KEI-211 reaper killed tmux %r (%s)", name, reason)
+            return ReapEvent(kind="tmux", name_or_id=name, reason=reason, success=True)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("KEI-211 reaper failed to kill tmux %r: %s", name, exc)
+            return ReapEvent(kind="tmux", name_or_id=name, reason=reason, success=False)
+
+    def _kill_container_by_id(self, cid: str, name: str, *, reason: str) -> ReapEvent:
+        try:
+            handle = self._container_registry.get(cid, (None, 0.0))[0]
+            target = handle or ContainerHandle(id=cid, name=name, image="", port=0)
+            kill_and_remove(target)
+            logger.info("KEI-211 reaper killed container %s/%s (%s)", cid[:12], name, reason)
+            return ReapEvent(
+                kind="container", name_or_id=cid, reason=reason, success=True
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("KEI-211 reaper failed to kill container %s: %s", cid[:12], exc)
+            return ReapEvent(
+                kind="container", name_or_id=cid, reason=reason, success=False
+            )
+
+    def sweep(self) -> ReapResult:
+        """Run one full pass; reap orphans + TTL-exceeded. Best-effort."""
+        scanned_tmux, tmux_events = self._sweep_tmux()
+        scanned_containers, container_events = self._sweep_containers()
+        result = ReapResult(
+            scanned_tmux=scanned_tmux,
+            scanned_containers=scanned_containers,
+            reaped=tuple(tmux_events + container_events),
+        )
+        self._last_result = result
+        return result
+
+    # ------------------------------------------------------------------
+    # reporting
+    # ------------------------------------------------------------------
+
+    def health_snapshot(self) -> dict[str, object]:
+        """Status block for the dispatcher health endpoint.
+
+        ``status`` is "green" when the last sweep had no failed reaps,
+        otherwise "degraded". When ``sweep()`` has never run, status is
+        "unknown".
+        """
+        if self._last_result is None:
+            return {
+                "component": "reaper",
+                "status": "unknown",
+                "tracked_tmux": len(self._tmux_registry),
+                "tracked_containers": len(self._container_registry),
+                "last_reaped": 0,
+                "last_failed": 0,
+            }
+        failed = sum(1 for e in self._last_result.reaped if not e.success)
+        status = "green" if failed == 0 else "degraded"
+        return {
+            "component": "reaper",
+            "status": status,
+            "tracked_tmux": len(self._tmux_registry),
+            "tracked_containers": len(self._container_registry),
+            "last_reaped": self._last_result.total_reaped,
+            "last_failed": failed,
+        }

--- a/src/dispatcher/reaper.py
+++ b/src/dispatcher/reaper.py
@@ -171,9 +171,7 @@ class Reaper:
         deadline = time.monotonic() + ttl if ttl is not None else float("inf")
         self._tmux_registry[handle.session_name] = (handle, deadline)
 
-    def register_container(
-        self, handle: ContainerHandle, *, ttl_s: float | None = None
-    ) -> None:
+    def register_container(self, handle: ContainerHandle, *, ttl_s: float | None = None) -> None:
         if not handle.name.startswith(self._container_prefix):
             raise ValueError(
                 f"container name {handle.name!r} does not start with "
@@ -210,11 +208,16 @@ class Reaper:
             if name not in self._tmux_registry:
                 events.append(self._kill_tmux(name, reason="orphan"))
 
-        # TTL-exceeded: registered AND live AND past deadline.
-        for name, (handle, deadline) in list(self._tmux_registry.items()):
+        # TTL-exceeded: registered AND live AND past deadline. Collect first,
+        # then pop after the loop so we never mutate the dict mid-iteration.
+        ttl_exceeded: list[str] = []
+        for name, (_handle, deadline) in self._tmux_registry.items():
             if name in scoped and now >= deadline:
-                events.append(self._kill_tmux(handle.session_name, reason="ttl_exceeded"))
-                self._tmux_registry.pop(name, None)
+                ttl_exceeded.append(name)
+        for name in ttl_exceeded:
+            handle = self._tmux_registry[name][0]
+            events.append(self._kill_tmux(handle.session_name, reason="ttl_exceeded"))
+            self._tmux_registry.pop(name, None)
 
         return (len(scoped), events)
 
@@ -235,23 +238,23 @@ class Reaper:
             if cid not in registered_ids:
                 events.append(self._kill_container_by_id(cid, name, reason="orphan"))
 
-        # TTL-exceeded
+        # TTL-exceeded — collect first, mutate after.
         live_ids = {cid for cid, _ in live}
-        for cid, (handle, deadline) in list(self._container_registry.items()):
+        ttl_exceeded: list[str] = []
+        for cid, (_handle, deadline) in self._container_registry.items():
             if cid in live_ids and now >= deadline:
-                events.append(
-                    self._kill_container_by_id(cid, handle.name, reason="ttl_exceeded")
-                )
-                self._container_registry.pop(cid, None)
+                ttl_exceeded.append(cid)
+        for cid in ttl_exceeded:
+            handle = self._container_registry[cid][0]
+            events.append(self._kill_container_by_id(cid, handle.name, reason="ttl_exceeded"))
+            self._container_registry.pop(cid, None)
 
         return (len(live), events)
 
     def _kill_tmux(self, name: str, *, reason: str) -> ReapEvent:
         try:
             handle = self._tmux_registry.get(name, (None, 0.0))[0]
-            target = handle or SessionHandle(
-                session_name=name, working_dir="/", command=""
-            )
+            target = handle or SessionHandle(session_name=name, working_dir="/", command="")
             terminate(target)
             logger.info("KEI-211 reaper killed tmux %r (%s)", name, reason)
             return ReapEvent(kind="tmux", name_or_id=name, reason=reason, success=True)
@@ -265,14 +268,10 @@ class Reaper:
             target = handle or ContainerHandle(id=cid, name=name, image="", port=0)
             kill_and_remove(target)
             logger.info("KEI-211 reaper killed container %s/%s (%s)", cid[:12], name, reason)
-            return ReapEvent(
-                kind="container", name_or_id=cid, reason=reason, success=True
-            )
+            return ReapEvent(kind="container", name_or_id=cid, reason=reason, success=True)
         except Exception as exc:  # noqa: BLE001
             logger.warning("KEI-211 reaper failed to kill container %s: %s", cid[:12], exc)
-            return ReapEvent(
-                kind="container", name_or_id=cid, reason=reason, success=False
-            )
+            return ReapEvent(kind="container", name_or_id=cid, reason=reason, success=False)
 
     def sweep(self) -> ReapResult:
         """Run one full pass; reap orphans + TTL-exceeded. Best-effort."""

--- a/src/dispatcher/watchdog.py
+++ b/src/dispatcher/watchdog.py
@@ -218,7 +218,11 @@ class Watchdog:
     def probe_all(self) -> dict[str, State]:
         """Probe every registered entry. Errors are swallowed per-entry."""
         results: dict[str, State] = {}
-        for key in list(self._entries):
+        # Snapshot keys first so an alert callback that mutates the registry
+        # (unlikely, but possible if a caller wires unregister into alert_fn)
+        # cannot raise RuntimeError on a mid-iteration size change.
+        keys = tuple(self._entries.keys())
+        for key in keys:
             try:
                 results[key] = self.probe_one(key)
             except Exception as exc:  # noqa: BLE001 — must not crash the sweep

--- a/src/dispatcher/watchdog.py
+++ b/src/dispatcher/watchdog.py
@@ -1,0 +1,260 @@
+"""KEI-211 — Dispatcher Watchdog: liveness probe + hang detection.
+
+Companion to KEI-163 (container_monitor) and KEI-184 (tmux_lifecycle /
+container_lifecycle). KEI-163 reaps containers on clean *exit*; this module
+detects sessions that are *still running but not progressing* (hung agents,
+unresponsive containers) and raises an alert via callback.
+
+Detection model:
+- TMUX:      capture-pane output hashed; signature unchanged across
+             ``hung_threshold_s`` -> HUNG.
+- CONTAINER: GET <health_path> on each poll; non-2xx (or unreachable) for a
+             continuous window >= ``hung_threshold_s`` -> HUNG.
+
+Best-effort by design: probe failures never raise out of ``probe_all`` so
+this can run in a long-lived supervisor without crashing on a single bad
+session. The supervisor's health_snapshot() reports "degraded" when any
+entry is HUNG.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import http.client
+import logging
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from src.dispatcher.container_lifecycle import ContainerHandle
+from src.dispatcher.tmux_lifecycle import SessionHandle
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HUNG_THRESHOLD_S = 300.0  # 5 min default
+DEFAULT_PROBE_TIMEOUT_S = 2.0
+DEFAULT_TMUX_CMD_TIMEOUT_S = 5.0
+TMUX_CLI = "tmux"
+
+State = Literal["alive", "hung", "dead"]
+
+AlertFn = Callable[[str, "WatchdogEntry", str], None]
+"""Callback signature: (key, entry, reason) -> None. Called on transition
+to HUNG. Caller routes to TG/Slack/PagerDuty as appropriate."""
+
+
+@dataclass
+class WatchdogEntry:
+    """Tracked session/container state. Mutated in place by probes."""
+
+    handle: SessionHandle | ContainerHandle
+    hung_threshold_s: float = DEFAULT_HUNG_THRESHOLD_S
+    last_signature: str = ""
+    last_progress_at: float = 0.0  # monotonic
+    state: State = "alive"
+    consecutive_unhealthy_since: float | None = None  # monotonic; CONTAINER only
+
+
+def _capture_tmux_pane(session_name: str) -> str | None:
+    """Return the pane content, or None on error.
+
+    Errors (tmux missing, session gone, timeout) are swallowed and reported
+    as None so the watchdog can keep polling other entries.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603  # controlled args
+            [TMUX_CLI, "capture-pane", "-t", session_name, "-p"],
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_TMUX_CMD_TIMEOUT_S,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        logger.debug("watchdog capture-pane(%s) failed: %s", session_name, exc)
+        return None
+    if result.returncode != 0:
+        # Session gone -> caller treats as DEAD upstream
+        return None
+    return result.stdout
+
+
+def _hash_pane(pane: str) -> str:
+    return hashlib.sha256(pane.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _probe_http_health(host: str, port: int, path: str) -> bool:
+    """Return True iff GET responds 2xx within DEFAULT_PROBE_TIMEOUT_S."""
+    conn: http.client.HTTPConnection | None = None
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=DEFAULT_PROBE_TIMEOUT_S)
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        ok = 200 <= resp.status < 300
+        resp.read()
+        return ok
+    except (OSError, http.client.HTTPException):
+        return False
+    finally:
+        if conn is not None:
+            with contextlib.suppress(OSError):
+                conn.close()
+
+
+class Watchdog:
+    """Periodic liveness sweeper across registered sessions/containers.
+
+    Usage::
+
+        wd = Watchdog(alert_fn=my_alert)
+        wd.register("orion-task-42", session_handle)
+        wd.register("tenant-7-container", container_handle, hung_threshold_s=120)
+        # in a supervisor loop:
+        wd.probe_all()
+        snapshot = wd.health_snapshot()
+    """
+
+    def __init__(
+        self,
+        *,
+        alert_fn: AlertFn | None = None,
+        container_host: str = "127.0.0.1",
+    ) -> None:
+        self._entries: dict[str, WatchdogEntry] = {}
+        self._alert: AlertFn = alert_fn or (lambda _k, _e, _r: None)
+        self._container_host = container_host
+
+    # ------------------------------------------------------------------
+    # registry
+    # ------------------------------------------------------------------
+
+    def register(
+        self,
+        key: str,
+        handle: SessionHandle | ContainerHandle,
+        *,
+        hung_threshold_s: float = DEFAULT_HUNG_THRESHOLD_S,
+    ) -> None:
+        """Track ``handle`` under ``key``. Re-registering resets progress."""
+        now = time.monotonic()
+        self._entries[key] = WatchdogEntry(
+            handle=handle,
+            hung_threshold_s=hung_threshold_s,
+            last_progress_at=now,
+            state="alive",
+        )
+
+    def unregister(self, key: str) -> None:
+        self._entries.pop(key, None)
+
+    @property
+    def tracked(self) -> int:
+        return len(self._entries)
+
+    # ------------------------------------------------------------------
+    # probes
+    # ------------------------------------------------------------------
+
+    def _probe_tmux(self, entry: WatchdogEntry) -> State:
+        handle = entry.handle
+        assert isinstance(handle, SessionHandle)
+        pane = _capture_tmux_pane(handle.session_name)
+        if pane is None:
+            entry.state = "dead"
+            return "dead"
+        sig = _hash_pane(pane)
+        now = time.monotonic()
+        if sig != entry.last_signature:
+            entry.last_signature = sig
+            entry.last_progress_at = now
+            entry.state = "alive"
+            return "alive"
+        if (now - entry.last_progress_at) >= entry.hung_threshold_s:
+            entry.state = "hung"
+            return "hung"
+        return "alive"
+
+    def _probe_container(self, entry: WatchdogEntry) -> State:
+        handle = entry.handle
+        assert isinstance(handle, ContainerHandle)
+        ok = _probe_http_health(self._container_host, handle.port, handle.health_path)
+        now = time.monotonic()
+        if ok:
+            entry.last_progress_at = now
+            entry.consecutive_unhealthy_since = None
+            entry.state = "alive"
+            return "alive"
+        # Not OK — start or continue the unhealthy window.
+        if entry.consecutive_unhealthy_since is None:
+            entry.consecutive_unhealthy_since = now
+        elapsed = now - entry.consecutive_unhealthy_since
+        if elapsed >= entry.hung_threshold_s:
+            entry.state = "hung"
+            return "hung"
+        return "alive"
+
+    def probe_one(self, key: str) -> State:
+        """Probe one entry; mutate its state; fire alert on transition to HUNG.
+
+        Returns the new state. Unknown ``key`` -> "dead" (no entry to track).
+        """
+        entry = self._entries.get(key)
+        if entry is None:
+            return "dead"
+        prev = entry.state
+        if isinstance(entry.handle, SessionHandle):
+            new = self._probe_tmux(entry)
+        else:
+            new = self._probe_container(entry)
+        if new == "hung" and prev != "hung":
+            reason = self._format_reason(entry)
+            logger.warning("KEI-211 watchdog HUNG %s — %s", key, reason)
+            with contextlib.suppress(Exception):
+                self._alert(key, entry, reason)
+        return new
+
+    def probe_all(self) -> dict[str, State]:
+        """Probe every registered entry. Errors are swallowed per-entry."""
+        results: dict[str, State] = {}
+        for key in list(self._entries):
+            try:
+                results[key] = self.probe_one(key)
+            except Exception as exc:  # noqa: BLE001 — must not crash the sweep
+                logger.exception("KEI-211 watchdog probe_one(%s) raised: %s", key, exc)
+                results[key] = "dead"
+        return results
+
+    @staticmethod
+    def _format_reason(entry: WatchdogEntry) -> str:
+        elapsed = time.monotonic() - entry.last_progress_at
+        if isinstance(entry.handle, SessionHandle):
+            return (
+                f"tmux session {entry.handle.session_name!r} pane unchanged "
+                f"for {elapsed:.0f}s (threshold {entry.hung_threshold_s:.0f}s)"
+            )
+        return (
+            f"container {entry.handle.id[:12]} /healthz unhealthy "
+            f"for {elapsed:.0f}s (threshold {entry.hung_threshold_s:.0f}s)"
+        )
+
+    # ------------------------------------------------------------------
+    # reporting
+    # ------------------------------------------------------------------
+
+    def health_snapshot(self) -> dict[str, object]:
+        """Status block for the dispatcher health endpoint.
+
+        ``status`` is "green" when no entry is HUNG/DEAD, otherwise "degraded".
+        """
+        hung = sum(1 for e in self._entries.values() if e.state == "hung")
+        dead = sum(1 for e in self._entries.values() if e.state == "dead")
+        status = "green" if (hung == 0 and dead == 0) else "degraded"
+        return {
+            "component": "watchdog",
+            "status": status,
+            "tracked": len(self._entries),
+            "hung": hung,
+            "dead": dead,
+        }

--- a/tests/dispatcher/test_reaper.py
+++ b/tests/dispatcher/test_reaper.py
@@ -1,0 +1,234 @@
+"""Tests for KEI-211 reaper — zombie session detection + cleanup."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.dispatcher.container_lifecycle import ContainerHandle
+from src.dispatcher.reaper import Reaper
+from src.dispatcher.tmux_lifecycle import SessionHandle
+
+
+def _proc(stdout: str = "", returncode: int = 0, stderr: str = "") -> MagicMock:
+    p = MagicMock()
+    p.stdout = stdout
+    p.stderr = stderr
+    p.returncode = returncode
+    return p
+
+
+def _tmux_handle(name: str) -> SessionHandle:
+    return SessionHandle(session_name=name, working_dir="/tmp", command="bash")
+
+
+def _container_handle(cid: str, name: str) -> ContainerHandle:
+    return ContainerHandle(id=cid, name=name, image="img:latest", port=8080)
+
+
+class TestReaperConstruction:
+    def test_empty_prefix_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            Reaper(tmux_name_prefix="", container_name_prefix="kei211-")
+        with pytest.raises(ValueError, match="non-empty"):
+            Reaper(tmux_name_prefix="kei211-", container_name_prefix="")
+
+    def test_registry_rejects_mismatched_prefix_tmux(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        with pytest.raises(ValueError, match="does not start with"):
+            r.register_tmux(_tmux_handle("other-session"))
+
+    def test_registry_rejects_mismatched_prefix_container(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        with pytest.raises(ValueError, match="does not start with"):
+            r.register_container(_container_handle("abc", "other-container"))
+
+
+class TestReaperTmuxSweep:
+    def test_orphan_tmux_session_reaped(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        # Listed: kei211-orphan + kei211-known; only kei211-known is registered.
+        r.register_tmux(_tmux_handle("kei211-known"))
+        list_proc = _proc("kei211-orphan\nkei211-known\nunrelated-thing\n")
+        kill_calls: list[list[str]] = []
+
+        def fake_run(argv: list[str], **_kw: object) -> MagicMock:
+            kill_calls.append(argv)
+            if argv[1] == "list-sessions":
+                return list_proc
+            return _proc()
+
+        with (
+            patch("src.dispatcher.reaper.subprocess.run", side_effect=fake_run),
+            patch(
+                "src.dispatcher.reaper._list_containers_by_prefix",
+                return_value=[],
+            ),
+        ):
+            result = r.sweep()
+        # Orphan reaped, known left alone, unrelated never touched.
+        reaped_names = [e.name_or_id for e in result.reaped]
+        assert "kei211-orphan" in reaped_names
+        assert "kei211-known" not in reaped_names
+        assert "unrelated-thing" not in reaped_names
+        assert all(e.reason == "orphan" for e in result.reaped)
+
+    def test_ttl_exceeded_tmux_session_reaped(self) -> None:
+        r = Reaper(
+            tmux_name_prefix="kei211-",
+            container_name_prefix="kei211-c-",
+            default_ttl_s=10.0,
+        )
+        with patch("src.dispatcher.reaper.time.monotonic", return_value=100.0):
+            r.register_tmux(_tmux_handle("kei211-old"))
+        list_proc = _proc("kei211-old\n")
+        with (
+            patch("src.dispatcher.reaper.subprocess.run", return_value=list_proc),
+            patch("src.dispatcher.reaper.time.monotonic", return_value=200.0),
+            patch(
+                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
+            ),
+            patch("src.dispatcher.reaper.terminate") as mock_terminate,
+        ):
+            result = r.sweep()
+        assert len(result.reaped) == 1
+        assert result.reaped[0].reason == "ttl_exceeded"
+        mock_terminate.assert_called_once()
+
+    def test_no_zombies_no_reap(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        r.register_tmux(_tmux_handle("kei211-alive"))
+        with (
+            patch(
+                "src.dispatcher.reaper.subprocess.run",
+                return_value=_proc("kei211-alive\n"),
+            ),
+            patch(
+                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
+            ),
+            patch("src.dispatcher.reaper.terminate") as mock_terminate,
+        ):
+            result = r.sweep()
+        assert result.total_reaped == 0
+        mock_terminate.assert_not_called()
+
+    def test_tmux_unavailable_skips_pass_no_crash(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        with (
+            patch(
+                "src.dispatcher.reaper.subprocess.run",
+                side_effect=FileNotFoundError("no tmux"),
+            ),
+            patch(
+                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
+            ),
+        ):
+            result = r.sweep()
+        assert result.total_reaped == 0
+        assert result.scanned_tmux == 0
+
+
+class TestReaperContainerSweep:
+    def test_orphan_container_reaped(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        r.register_container(_container_handle("known-id", "kei211-c-known"))
+        with (
+            patch(
+                "src.dispatcher.reaper._list_tmux_sessions", return_value=[]
+            ),
+            patch(
+                "src.dispatcher.reaper._list_containers_by_prefix",
+                return_value=[
+                    ("orphan-id", "kei211-c-orphan"),
+                    ("known-id", "kei211-c-known"),
+                ],
+            ),
+            patch("src.dispatcher.reaper.kill_and_remove") as mock_kar,
+        ):
+            result = r.sweep()
+        assert mock_kar.call_count == 1
+        reaped_ids = [e.name_or_id for e in result.reaped]
+        assert reaped_ids == ["orphan-id"]
+        assert result.reaped[0].kind == "container"
+        assert result.reaped[0].reason == "orphan"
+
+    def test_ttl_exceeded_container_reaped(self) -> None:
+        r = Reaper(
+            tmux_name_prefix="kei211-",
+            container_name_prefix="kei211-c-",
+            default_ttl_s=10.0,
+        )
+        with patch("src.dispatcher.reaper.time.monotonic", return_value=100.0):
+            r.register_container(_container_handle("old-id", "kei211-c-old"))
+        with (
+            patch(
+                "src.dispatcher.reaper._list_tmux_sessions", return_value=[]
+            ),
+            patch(
+                "src.dispatcher.reaper._list_containers_by_prefix",
+                return_value=[("old-id", "kei211-c-old")],
+            ),
+            patch("src.dispatcher.reaper.time.monotonic", return_value=200.0),
+            patch("src.dispatcher.reaper.kill_and_remove") as mock_kar,
+        ):
+            result = r.sweep()
+        assert result.total_reaped == 1
+        assert result.reaped[0].reason == "ttl_exceeded"
+        mock_kar.assert_called_once()
+
+
+class TestReaperSnapshot:
+    def test_unknown_before_first_sweep(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        snap = r.health_snapshot()
+        assert snap["status"] == "unknown"
+
+    def test_green_after_clean_sweep(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        with (
+            patch("src.dispatcher.reaper._list_tmux_sessions", return_value=[]),
+            patch(
+                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
+            ),
+        ):
+            r.sweep()
+        snap = r.health_snapshot()
+        assert snap["status"] == "green"
+        assert snap["last_reaped"] == 0
+        assert snap["last_failed"] == 0
+
+    def test_degraded_on_kill_failure(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        with (
+            patch(
+                "src.dispatcher.reaper._list_tmux_sessions",
+                return_value=["kei211-orphan"],
+            ),
+            patch(
+                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
+            ),
+            patch(
+                "src.dispatcher.reaper.terminate", side_effect=RuntimeError("kaboom")
+            ),
+        ):
+            r.sweep()
+        snap = r.health_snapshot()
+        assert snap["status"] == "degraded"
+        assert snap["last_failed"] == 1
+
+
+class TestReaperRegistry:
+    def test_unregister_tmux_removes(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        r.register_tmux(_tmux_handle("kei211-a"))
+        assert r.health_snapshot()["tracked_tmux"] == 1
+        r.unregister_tmux("kei211-a")
+        assert r.health_snapshot()["tracked_tmux"] == 0
+
+    def test_unregister_container_removes(self) -> None:
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        r.register_container(_container_handle("cid", "kei211-c-x"))
+        assert r.health_snapshot()["tracked_containers"] == 1
+        r.unregister_container("cid")
+        assert r.health_snapshot()["tracked_containers"] == 0

--- a/tests/dispatcher/test_reaper.py
+++ b/tests/dispatcher/test_reaper.py
@@ -19,8 +19,12 @@ def _proc(stdout: str = "", returncode: int = 0, stderr: str = "") -> MagicMock:
     return p
 
 
-def _tmux_handle(name: str) -> SessionHandle:
-    return SessionHandle(session_name=name, working_dir="/tmp", command="bash")
+def _tmux_handle(name: str, working_dir: str) -> SessionHandle:
+    """Build a SessionHandle. ``working_dir`` MUST come from pytest's
+    ``tmp_path`` fixture (per-test isolated dir) — never the shared /tmp,
+    which Sonar S5443 flags as a path-traversal vector in tests.
+    """
+    return SessionHandle(session_name=name, working_dir=working_dir, command="bash")
 
 
 def _container_handle(cid: str, name: str) -> ContainerHandle:
@@ -34,10 +38,10 @@ class TestReaperConstruction:
         with pytest.raises(ValueError, match="non-empty"):
             Reaper(tmux_name_prefix="kei211-", container_name_prefix="")
 
-    def test_registry_rejects_mismatched_prefix_tmux(self) -> None:
+    def test_registry_rejects_mismatched_prefix_tmux(self, tmp_path) -> None:
         r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
         with pytest.raises(ValueError, match="does not start with"):
-            r.register_tmux(_tmux_handle("other-session"))
+            r.register_tmux(_tmux_handle("other-session", str(tmp_path)))
 
     def test_registry_rejects_mismatched_prefix_container(self) -> None:
         r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
@@ -46,10 +50,10 @@ class TestReaperConstruction:
 
 
 class TestReaperTmuxSweep:
-    def test_orphan_tmux_session_reaped(self) -> None:
+    def test_orphan_tmux_session_reaped(self, tmp_path) -> None:
         r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
         # Listed: kei211-orphan + kei211-known; only kei211-known is registered.
-        r.register_tmux(_tmux_handle("kei211-known"))
+        r.register_tmux(_tmux_handle("kei211-known", str(tmp_path)))
         list_proc = _proc("kei211-orphan\nkei211-known\nunrelated-thing\n")
         kill_calls: list[list[str]] = []
 
@@ -74,21 +78,19 @@ class TestReaperTmuxSweep:
         assert "unrelated-thing" not in reaped_names
         assert all(e.reason == "orphan" for e in result.reaped)
 
-    def test_ttl_exceeded_tmux_session_reaped(self) -> None:
+    def test_ttl_exceeded_tmux_session_reaped(self, tmp_path) -> None:
         r = Reaper(
             tmux_name_prefix="kei211-",
             container_name_prefix="kei211-c-",
             default_ttl_s=10.0,
         )
         with patch("src.dispatcher.reaper.time.monotonic", return_value=100.0):
-            r.register_tmux(_tmux_handle("kei211-old"))
+            r.register_tmux(_tmux_handle("kei211-old", str(tmp_path)))
         list_proc = _proc("kei211-old\n")
         with (
             patch("src.dispatcher.reaper.subprocess.run", return_value=list_proc),
             patch("src.dispatcher.reaper.time.monotonic", return_value=200.0),
-            patch(
-                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
-            ),
+            patch("src.dispatcher.reaper._list_containers_by_prefix", return_value=[]),
             patch("src.dispatcher.reaper.terminate") as mock_terminate,
         ):
             result = r.sweep()
@@ -96,17 +98,15 @@ class TestReaperTmuxSweep:
         assert result.reaped[0].reason == "ttl_exceeded"
         mock_terminate.assert_called_once()
 
-    def test_no_zombies_no_reap(self) -> None:
+    def test_no_zombies_no_reap(self, tmp_path) -> None:
         r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
-        r.register_tmux(_tmux_handle("kei211-alive"))
+        r.register_tmux(_tmux_handle("kei211-alive", str(tmp_path)))
         with (
             patch(
                 "src.dispatcher.reaper.subprocess.run",
                 return_value=_proc("kei211-alive\n"),
             ),
-            patch(
-                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
-            ),
+            patch("src.dispatcher.reaper._list_containers_by_prefix", return_value=[]),
             patch("src.dispatcher.reaper.terminate") as mock_terminate,
         ):
             result = r.sweep()
@@ -120,9 +120,7 @@ class TestReaperTmuxSweep:
                 "src.dispatcher.reaper.subprocess.run",
                 side_effect=FileNotFoundError("no tmux"),
             ),
-            patch(
-                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
-            ),
+            patch("src.dispatcher.reaper._list_containers_by_prefix", return_value=[]),
         ):
             result = r.sweep()
         assert result.total_reaped == 0
@@ -134,9 +132,7 @@ class TestReaperContainerSweep:
         r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
         r.register_container(_container_handle("known-id", "kei211-c-known"))
         with (
-            patch(
-                "src.dispatcher.reaper._list_tmux_sessions", return_value=[]
-            ),
+            patch("src.dispatcher.reaper._list_tmux_sessions", return_value=[]),
             patch(
                 "src.dispatcher.reaper._list_containers_by_prefix",
                 return_value=[
@@ -162,9 +158,7 @@ class TestReaperContainerSweep:
         with patch("src.dispatcher.reaper.time.monotonic", return_value=100.0):
             r.register_container(_container_handle("old-id", "kei211-c-old"))
         with (
-            patch(
-                "src.dispatcher.reaper._list_tmux_sessions", return_value=[]
-            ),
+            patch("src.dispatcher.reaper._list_tmux_sessions", return_value=[]),
             patch(
                 "src.dispatcher.reaper._list_containers_by_prefix",
                 return_value=[("old-id", "kei211-c-old")],
@@ -188,9 +182,7 @@ class TestReaperSnapshot:
         r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
         with (
             patch("src.dispatcher.reaper._list_tmux_sessions", return_value=[]),
-            patch(
-                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
-            ),
+            patch("src.dispatcher.reaper._list_containers_by_prefix", return_value=[]),
         ):
             r.sweep()
         snap = r.health_snapshot()
@@ -205,12 +197,8 @@ class TestReaperSnapshot:
                 "src.dispatcher.reaper._list_tmux_sessions",
                 return_value=["kei211-orphan"],
             ),
-            patch(
-                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
-            ),
-            patch(
-                "src.dispatcher.reaper.terminate", side_effect=RuntimeError("kaboom")
-            ),
+            patch("src.dispatcher.reaper._list_containers_by_prefix", return_value=[]),
+            patch("src.dispatcher.reaper.terminate", side_effect=RuntimeError("kaboom")),
         ):
             r.sweep()
         snap = r.health_snapshot()
@@ -219,9 +207,9 @@ class TestReaperSnapshot:
 
 
 class TestReaperRegistry:
-    def test_unregister_tmux_removes(self) -> None:
+    def test_unregister_tmux_removes(self, tmp_path) -> None:
         r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
-        r.register_tmux(_tmux_handle("kei211-a"))
+        r.register_tmux(_tmux_handle("kei211-a", str(tmp_path)))
         assert r.health_snapshot()["tracked_tmux"] == 1
         r.unregister_tmux("kei211-a")
         assert r.health_snapshot()["tracked_tmux"] == 0

--- a/tests/dispatcher/test_watchdog.py
+++ b/tests/dispatcher/test_watchdog.py
@@ -1,0 +1,248 @@
+"""Tests for KEI-211 watchdog — liveness probe + hang detection."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.dispatcher.container_lifecycle import ContainerHandle
+from src.dispatcher.tmux_lifecycle import SessionHandle
+from src.dispatcher.watchdog import Watchdog
+
+
+def _proc(stdout: str = "", returncode: int = 0) -> MagicMock:
+    p = MagicMock()
+    p.stdout = stdout
+    p.stderr = ""
+    p.returncode = returncode
+    return p
+
+
+class _Clock:
+    """Mutable fake clock so individual test points can advance time freely.
+
+    Avoids the ``iter(...)`` exhaustion trap where ``_format_reason`` consumes
+    an extra ``time.monotonic()`` call on every HUNG transition.
+    """
+
+    def __init__(self, t: float = 0.0) -> None:
+        self.t = t
+
+    def now(self) -> float:
+        return self.t
+
+    def set(self, t: float) -> None:
+        self.t = t
+
+
+TMUX = SessionHandle(session_name="kei211-test", working_dir="/tmp", command="bash")
+CONTAINER = ContainerHandle(
+    id="abc123def456", name="kei211-container", image="img:latest", port=8080
+)
+
+
+class TestWatchdogTmux:
+    def test_changing_pane_marks_alive(self) -> None:
+        wd = Watchdog()
+        wd.register("s1", TMUX, hung_threshold_s=10.0)
+        with patch("subprocess.run", side_effect=[_proc("hello\n"), _proc("hello world\n")]):
+            assert wd.probe_one("s1") == "alive"
+            assert wd.probe_one("s1") == "alive"
+
+    def test_static_pane_past_threshold_is_hung(self) -> None:
+        clock = _Clock(100.0)
+        with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
+            wd = Watchdog()
+            wd.register("s1", TMUX, hung_threshold_s=10.0)
+            with patch("subprocess.run", return_value=_proc("frozen\n")):
+                assert wd.probe_one("s1") == "alive"
+                clock.set(200.0)
+                assert wd.probe_one("s1") == "hung"
+
+    def test_static_pane_under_threshold_stays_alive(self) -> None:
+        clock = _Clock(100.0)
+        with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
+            wd = Watchdog()
+            wd.register("s1", TMUX, hung_threshold_s=300.0)
+            with patch("subprocess.run", return_value=_proc("frozen\n")):
+                assert wd.probe_one("s1") == "alive"
+                clock.set(200.0)
+                assert wd.probe_one("s1") == "alive"
+
+    def test_missing_session_is_dead(self) -> None:
+        wd = Watchdog()
+        wd.register("s1", TMUX)
+        with patch("subprocess.run", return_value=_proc("", returncode=1)):
+            assert wd.probe_one("s1") == "dead"
+
+    def test_tmux_missing_is_dead(self) -> None:
+        wd = Watchdog()
+        wd.register("s1", TMUX)
+        with patch("subprocess.run", side_effect=FileNotFoundError("no tmux")):
+            assert wd.probe_one("s1") == "dead"
+
+    def test_alert_fires_once_on_hung_transition(self) -> None:
+        alerts: list[tuple[str, str]] = []
+        clock = _Clock(100.0)
+        with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
+            wd = Watchdog(alert_fn=lambda k, _e, r: alerts.append((k, r)))
+            wd.register("s1", TMUX, hung_threshold_s=10.0)
+            with patch("subprocess.run", return_value=_proc("frozen\n")):
+                wd.probe_one("s1")  # alive
+                clock.set(200.0)
+                wd.probe_one("s1")  # hung -> alert
+                clock.set(300.0)
+                wd.probe_one("s1")  # still hung -> no new alert
+        assert len(alerts) == 1
+        assert alerts[0][0] == "s1"
+        assert "tmux" in alerts[0][1]
+
+
+class TestWatchdogContainer:
+    def test_healthy_container_is_alive(self) -> None:
+        wd = Watchdog()
+        wd.register("c1", CONTAINER, hung_threshold_s=10.0)
+        with patch(
+            "src.dispatcher.watchdog._probe_http_health", return_value=True
+        ):
+            assert wd.probe_one("c1") == "alive"
+
+    def test_unhealthy_under_threshold_stays_alive(self) -> None:
+        clock = _Clock(100.0)
+        with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
+            wd = Watchdog()
+            wd.register("c1", CONTAINER, hung_threshold_s=60.0)
+            with patch("src.dispatcher.watchdog._probe_http_health", return_value=False):
+                assert wd.probe_one("c1") == "alive"
+                clock.set(110.0)
+                assert wd.probe_one("c1") == "alive"
+
+    def test_unhealthy_past_threshold_is_hung(self) -> None:
+        clock = _Clock(100.0)
+        with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
+            wd = Watchdog()
+            wd.register("c1", CONTAINER, hung_threshold_s=10.0)
+            with patch("src.dispatcher.watchdog._probe_http_health", return_value=False):
+                assert wd.probe_one("c1") == "alive"
+                clock.set(200.0)
+                assert wd.probe_one("c1") == "hung"
+
+    def test_recovery_resets_unhealthy_window(self) -> None:
+        clock = _Clock(100.0)
+        probes = iter([False, True, False])
+        with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
+            wd = Watchdog()
+            wd.register("c1", CONTAINER, hung_threshold_s=10.0)
+            with patch(
+                "src.dispatcher.watchdog._probe_http_health",
+                side_effect=lambda *_a, **_k: next(probes),
+            ):
+                assert wd.probe_one("c1") == "alive"  # unhealthy starts window
+                clock.set(105.0)
+                assert wd.probe_one("c1") == "alive"  # healthy resets
+                clock.set(200.0)
+                # Without reset this would be HUNG (Δ100 > 10); recovery should keep alive.
+                assert wd.probe_one("c1") == "alive"
+
+
+class TestWatchdogSnapshot:
+    def test_empty_is_green(self) -> None:
+        wd = Watchdog()
+        snap = wd.health_snapshot()
+        assert snap["status"] == "green"
+        assert snap["tracked"] == 0
+
+    def test_all_alive_is_green(self) -> None:
+        wd = Watchdog()
+        wd.register("s1", TMUX)
+        with patch("subprocess.run", return_value=_proc("ok\n")):
+            wd.probe_all()
+        assert wd.health_snapshot()["status"] == "green"
+
+    def test_any_hung_is_degraded(self) -> None:
+        clock = _Clock(100.0)
+        with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
+            wd = Watchdog()
+            wd.register("s1", TMUX, hung_threshold_s=10.0)
+            with patch("subprocess.run", return_value=_proc("frozen\n")):
+                wd.probe_all()
+                clock.set(200.0)
+                wd.probe_all()
+        snap = wd.health_snapshot()
+        assert snap["status"] == "degraded"
+        assert snap["hung"] == 1
+
+    def test_probe_all_swallows_exception(self) -> None:
+        wd = Watchdog()
+        wd.register("s1", TMUX)
+        with patch.object(wd, "probe_one", side_effect=RuntimeError("boom")):
+            results = wd.probe_all()
+        assert results == {"s1": "dead"}
+
+
+class TestWatchdogRegistry:
+    def test_unregister_removes_entry(self) -> None:
+        wd = Watchdog()
+        wd.register("s1", TMUX)
+        assert wd.tracked == 1
+        wd.unregister("s1")
+        assert wd.tracked == 0
+
+    def test_probe_unknown_key_is_dead(self) -> None:
+        assert Watchdog().probe_one("nope") == "dead"
+
+    def test_re_register_resets_progress(self) -> None:
+        wd = Watchdog()
+        wd.register("s1", TMUX, hung_threshold_s=10.0)
+        entry_before = wd._entries["s1"]
+        wd.register("s1", TMUX, hung_threshold_s=20.0)
+        entry_after = wd._entries["s1"]
+        assert entry_after.hung_threshold_s == 20.0
+        assert entry_after is not entry_before
+
+
+@pytest.mark.parametrize("returncode", [1, 2])
+def test_tmux_capture_nonzero_returns_none(returncode: int) -> None:
+    """Direct unit test on the capture helper."""
+    from src.dispatcher.watchdog import _capture_tmux_pane
+
+    with patch("subprocess.run", return_value=_proc("", returncode=returncode)):
+        assert _capture_tmux_pane("s") is None
+
+
+class TestSupervisorSnapshot:
+    """KEI-211 composing helper for the dispatcher health endpoint."""
+
+    def test_empty_is_green(self) -> None:
+        from src.dispatcher import supervisor_health_snapshot
+
+        snap = supervisor_health_snapshot()
+        assert snap == {"status": "green", "components": []}
+
+    def test_both_green(self) -> None:
+        from src.dispatcher import supervisor_health_snapshot
+        from src.dispatcher.reaper import Reaper
+
+        wd = Watchdog()
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        with (
+            patch("src.dispatcher.reaper._list_tmux_sessions", return_value=[]),
+            patch(
+                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
+            ),
+        ):
+            r.sweep()
+        snap = supervisor_health_snapshot(wd, r)
+        assert snap["status"] == "green"
+        assert len(snap["components"]) == 2
+
+    def test_one_degraded_marks_overall_degraded(self) -> None:
+        from src.dispatcher import supervisor_health_snapshot
+        from src.dispatcher.reaper import Reaper
+
+        wd = Watchdog()
+        r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
+        # reaper never swept -> "unknown" -> overall != green
+        snap = supervisor_health_snapshot(wd, r)
+        assert snap["status"] == "degraded"

--- a/tests/dispatcher/test_watchdog.py
+++ b/tests/dispatcher/test_watchdog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,58 +37,67 @@ class _Clock:
         self.t = t
 
 
-TMUX = SessionHandle(session_name="kei211-test", working_dir="/tmp", command="bash")
 CONTAINER = ContainerHandle(
     id="abc123def456", name="kei211-container", image="img:latest", port=8080
 )
 
 
+@pytest.fixture
+def tmux_handle(tmp_path) -> SessionHandle:
+    """SessionHandle rooted in the per-test ``tmp_path`` dir.
+
+    The shared ``/tmp`` is rejected by Sonar S5443 (path-traversal vector
+    in tests); ``tmp_path`` is the per-test isolated dir pytest creates.
+    """
+    return SessionHandle(session_name="kei211-test", working_dir=str(tmp_path), command="bash")
+
+
 class TestWatchdogTmux:
-    def test_changing_pane_marks_alive(self) -> None:
+    def test_changing_pane_marks_alive(self, tmux_handle) -> None:
         wd = Watchdog()
-        wd.register("s1", TMUX, hung_threshold_s=10.0)
+        wd.register("s1", tmux_handle, hung_threshold_s=10.0)
         with patch("subprocess.run", side_effect=[_proc("hello\n"), _proc("hello world\n")]):
             assert wd.probe_one("s1") == "alive"
             assert wd.probe_one("s1") == "alive"
 
-    def test_static_pane_past_threshold_is_hung(self) -> None:
+    def test_static_pane_past_threshold_is_hung(self, tmux_handle) -> None:
         clock = _Clock(100.0)
         with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
             wd = Watchdog()
-            wd.register("s1", TMUX, hung_threshold_s=10.0)
+            wd.register("s1", tmux_handle, hung_threshold_s=10.0)
             with patch("subprocess.run", return_value=_proc("frozen\n")):
                 assert wd.probe_one("s1") == "alive"
                 clock.set(200.0)
                 assert wd.probe_one("s1") == "hung"
 
-    def test_static_pane_under_threshold_stays_alive(self) -> None:
+    def test_static_pane_under_threshold_stays_alive(self, tmux_handle) -> None:
         clock = _Clock(100.0)
         with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
             wd = Watchdog()
-            wd.register("s1", TMUX, hung_threshold_s=300.0)
+            wd.register("s1", tmux_handle, hung_threshold_s=300.0)
             with patch("subprocess.run", return_value=_proc("frozen\n")):
                 assert wd.probe_one("s1") == "alive"
                 clock.set(200.0)
                 assert wd.probe_one("s1") == "alive"
 
-    def test_missing_session_is_dead(self) -> None:
+    def test_missing_session_is_dead(self, tmux_handle) -> None:
         wd = Watchdog()
-        wd.register("s1", TMUX)
+        wd.register("s1", tmux_handle)
         with patch("subprocess.run", return_value=_proc("", returncode=1)):
             assert wd.probe_one("s1") == "dead"
 
-    def test_tmux_missing_is_dead(self) -> None:
+    def test_tmux_missing_is_dead(self, tmux_handle) -> None:
         wd = Watchdog()
-        wd.register("s1", TMUX)
+        wd.register("s1", tmux_handle)
         with patch("subprocess.run", side_effect=FileNotFoundError("no tmux")):
             assert wd.probe_one("s1") == "dead"
 
-    def test_alert_fires_once_on_hung_transition(self) -> None:
+    def test_alert_fires_once_on_hung_transition(self, tmux_handle) -> None:
         alerts: list[tuple[str, str]] = []
         clock = _Clock(100.0)
         with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
             wd = Watchdog(alert_fn=lambda k, _e, r: alerts.append((k, r)))
-            wd.register("s1", TMUX, hung_threshold_s=10.0)
+            wd.register("s1", tmux_handle, hung_threshold_s=10.0)
             with patch("subprocess.run", return_value=_proc("frozen\n")):
                 wd.probe_one("s1")  # alive
                 clock.set(200.0)
@@ -103,9 +113,7 @@ class TestWatchdogContainer:
     def test_healthy_container_is_alive(self) -> None:
         wd = Watchdog()
         wd.register("c1", CONTAINER, hung_threshold_s=10.0)
-        with patch(
-            "src.dispatcher.watchdog._probe_http_health", return_value=True
-        ):
+        with patch("src.dispatcher.watchdog._probe_http_health", return_value=True):
             assert wd.probe_one("c1") == "alive"
 
     def test_unhealthy_under_threshold_stays_alive(self) -> None:
@@ -153,18 +161,18 @@ class TestWatchdogSnapshot:
         assert snap["status"] == "green"
         assert snap["tracked"] == 0
 
-    def test_all_alive_is_green(self) -> None:
+    def test_all_alive_is_green(self, tmux_handle) -> None:
         wd = Watchdog()
-        wd.register("s1", TMUX)
+        wd.register("s1", tmux_handle)
         with patch("subprocess.run", return_value=_proc("ok\n")):
             wd.probe_all()
         assert wd.health_snapshot()["status"] == "green"
 
-    def test_any_hung_is_degraded(self) -> None:
+    def test_any_hung_is_degraded(self, tmux_handle) -> None:
         clock = _Clock(100.0)
         with patch("src.dispatcher.watchdog.time.monotonic", side_effect=clock.now):
             wd = Watchdog()
-            wd.register("s1", TMUX, hung_threshold_s=10.0)
+            wd.register("s1", tmux_handle, hung_threshold_s=10.0)
             with patch("subprocess.run", return_value=_proc("frozen\n")):
                 wd.probe_all()
                 clock.set(200.0)
@@ -173,18 +181,18 @@ class TestWatchdogSnapshot:
         assert snap["status"] == "degraded"
         assert snap["hung"] == 1
 
-    def test_probe_all_swallows_exception(self) -> None:
+    def test_probe_all_swallows_exception(self, tmux_handle) -> None:
         wd = Watchdog()
-        wd.register("s1", TMUX)
+        wd.register("s1", tmux_handle)
         with patch.object(wd, "probe_one", side_effect=RuntimeError("boom")):
             results = wd.probe_all()
         assert results == {"s1": "dead"}
 
 
 class TestWatchdogRegistry:
-    def test_unregister_removes_entry(self) -> None:
+    def test_unregister_removes_entry(self, tmux_handle) -> None:
         wd = Watchdog()
-        wd.register("s1", TMUX)
+        wd.register("s1", tmux_handle)
         assert wd.tracked == 1
         wd.unregister("s1")
         assert wd.tracked == 0
@@ -192,13 +200,14 @@ class TestWatchdogRegistry:
     def test_probe_unknown_key_is_dead(self) -> None:
         assert Watchdog().probe_one("nope") == "dead"
 
-    def test_re_register_resets_progress(self) -> None:
+    def test_re_register_resets_progress(self, tmux_handle) -> None:
         wd = Watchdog()
-        wd.register("s1", TMUX, hung_threshold_s=10.0)
+        wd.register("s1", tmux_handle, hung_threshold_s=10.0)
         entry_before = wd._entries["s1"]
-        wd.register("s1", TMUX, hung_threshold_s=20.0)
+        wd.register("s1", tmux_handle, hung_threshold_s=20.0)
         entry_after = wd._entries["s1"]
-        assert entry_after.hung_threshold_s == 20.0
+        # Sonar S1244: avoid float == — use math.isclose for tolerance-safe compare.
+        assert math.isclose(entry_after.hung_threshold_s, 20.0, rel_tol=1e-9)
         assert entry_after is not entry_before
 
 
@@ -228,9 +237,7 @@ class TestSupervisorSnapshot:
         r = Reaper(tmux_name_prefix="kei211-", container_name_prefix="kei211-c-")
         with (
             patch("src.dispatcher.reaper._list_tmux_sessions", return_value=[]),
-            patch(
-                "src.dispatcher.reaper._list_containers_by_prefix", return_value=[]
-            ),
+            patch("src.dispatcher.reaper._list_containers_by_prefix", return_value=[]),
         ):
             r.sweep()
         snap = supervisor_health_snapshot(wd, r)


### PR DESCRIPTION
## Summary

Two-component supervisor surface for the Dispatcher product layer (KEI-110 Part 17, KEI-211):

- **`watchdog.py`** — liveness probe + hang detection. TMUX: pane-content hash unchanged for `hung_threshold_s` → HUNG. CONTAINER: `/healthz` non-2xx continuous window ≥ threshold → HUNG. Alert callback fires once on transition.
- **`reaper.py`** — orphan + TTL cleanup. Enumerates live tmux sessions / containers under a **required** name prefix scope (empty prefixes rejected — no "reap all" mode). Kills via existing `terminate()` / `kill_and_remove()` primitives. Registered handles past TTL also reaped.
- **`__init__.py::supervisor_health_snapshot()`** — composes both component blocks for the dispatcher health endpoint. Overall "green" iff every component is "green".

Pairs with KEI-163 (`container_monitor` — clean-exit reaping) which handles the happy path; this PR covers the hang + zombie paths.

## DoD coverage

- ✅ Dispatcher health endpoint reports watchdog + reaper green — `supervisor_health_snapshot()` returns `{"status": "green", "components": [...]}`.
- ✅ Reaper cleans zombie sessions reliably — `test_orphan_tmux_session_reaped`, `test_orphan_container_reaped`, `test_ttl_exceeded_*`.
- ✅ Watchdog catches hung agents — `test_static_pane_past_threshold_is_hung`, `test_unhealthy_past_threshold_is_hung`, `test_alert_fires_once_on_hung_transition`.

## Test plan

- [x] 36 new tests (`test_watchdog.py`, `test_reaper.py`) — all subprocess boundaries mocked, no live tmux/docker required
- [x] Full dispatcher suite green: 108/108 passed
- [x] `ruff check src/dispatcher tests/dispatcher/test_{watchdog,reaper}.py` clean
- [x] `mypy src/dispatcher/` clean (10 source files)

## Parallel work / blockers

- Parallel with KEI-209 (Orion), KEI-210 (Scout), KEI-212 (Max)
- KEI-213 (Atlas deploy) blocks on all four merged

## Review

Dual-concur: any 2 of Aiden / Elliot / Max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)