### PR TITLE
[SCOUT] feat(kei201): Slack history incremental indexer + vectorizer-config fix

### DIFF
--- a/scripts/install_slack_history_indexer.sh
+++ b/scripts/install_slack_history_indexer.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# install_slack_history_indexer.sh — KEI-201 Phase 2 systemd-user installer.
+#
+# Installs:
+#   ~/.config/systemd/user/slack_history_indexer.service
+#   ~/.config/systemd/user/slack_history_indexer.timer
+#
+# Then daemon-reloads, enables, and starts the timer.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SYSTEMD_SRC="${REPO_ROOT}/systemd"
+SYSTEMD_DST="${HOME}/.config/systemd/user"
+
+mkdir -p "${SYSTEMD_DST}"
+cp -v "${SYSTEMD_SRC}/slack_history_indexer.service" "${SYSTEMD_DST}/"
+cp -v "${SYSTEMD_SRC}/slack_history_indexer.timer"   "${SYSTEMD_DST}/"
+
+systemctl --user daemon-reload
+systemctl --user enable --now slack_history_indexer.timer
+
+echo
+echo "Installed. Verify:"
+echo "  systemctl --user status slack_history_indexer.timer"
+echo "  systemctl --user list-timers --all | grep slack_history"
+echo "  journalctl --user -u slack_history_indexer.service -n 50 --no-pager"

--- a/scripts/orchestrator/slack_history_indexer.py
+++ b/scripts/orchestrator/slack_history_indexer.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""slack_history_indexer.py — KEI-201 Phase 2: incremental Slack → Weaviate daemon.
+
+One-shot run: reads a per-channel `last_ts` checkpoint, calls Slack's
+conversations.history with `oldest=<last_ts>` for each of the 5 ratified
+channels, filters + classifies (reusing `slack_history_ingest`'s logic), upserts
+new messages into Weaviate `Slack_history`, and writes the new checkpoint on
+success.
+
+Invoked by `slack_history_indexer.timer` every 15 min.
+
+Checkpoint location (XDG state):
+    $XDG_STATE_HOME/agency-os/slack_history_checkpoint.json
+    default: ~/.local/state/agency-os/slack_history_checkpoint.json
+
+Override via env var SLACK_HISTORY_CHECKPOINT (absolute path).
+
+Cold start: no checkpoint file → bootstrap with current timestamp so the
+indexer only catches messages from "now forward". Bulk backfill is the
+companion `slack_history_ingest.py` extractor's job (KEI-201 Phase 1).
+
+Exit codes:
+    0  success (any posts/failures logged)
+    1  SLACK_BOT_TOKEN missing
+    2  channel resolution failed
+    3  Weaviate class missing AND ensure_class failed
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import importlib.util
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPTS = REPO_ROOT / "scripts" / "orchestrator"
+INGEST_PATH = SCRIPTS / "slack_history_ingest.py"
+
+
+def _load_ingest():
+    spec = importlib.util.spec_from_file_location("slack_history_ingest", INGEST_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {INGEST_PATH}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["slack_history_ingest"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ingest = _load_ingest()
+
+logger = logging.getLogger("slack_history_indexer")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def checkpoint_path() -> Path:
+    """Resolve checkpoint path: env override → XDG_STATE_HOME → ~/.local/state."""
+    override = os.environ.get("SLACK_HISTORY_CHECKPOINT")
+    if override:
+        return Path(override)
+    state_root = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(state_root) / "agency-os" / "slack_history_checkpoint.json"
+
+
+def load_checkpoint(path: Path) -> dict[str, str]:
+    """Return {channel_slug: last_ts} or {} if no checkpoint yet (cold start)."""
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("checkpoint %s unreadable (%s) — treating as cold start", path, exc)
+        return {}
+
+
+def save_checkpoint(path: Path, data: dict[str, str]) -> None:
+    """Atomic write: tmp + rename → no torn writes if process dies mid-write."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True))
+    tmp.replace(path)
+
+
+def bootstrap_now_ts() -> str:
+    """Slack ts format: 'unix_seconds.microseconds_padded' — used as cold-start anchor."""
+    now = _dt.datetime.now(_dt.UTC).timestamp()
+    return f"{now:.6f}"
+
+
+def index_channel(
+    slug: str,
+    ch_id: str,
+    oldest: str,
+    by_type: dict[str, int],
+) -> tuple[int, int, int, str]:
+    """Returns (kept, posted, failed, new_last_ts) for one channel.
+
+    new_last_ts = max(message.ts seen) — used as next checkpoint. Falls back to
+    `oldest` if no new messages (so checkpoint advances only when we saw data).
+    """
+    kept = posted = failed = 0
+    max_ts = oldest
+    for raw in ingest.paginate_history(ch_id, oldest=oldest, total_cap=5_000):
+        msg = ingest.slack_to_message(slug, raw)
+        if msg is None:
+            continue
+        if msg.ts > max_ts:
+            max_ts = msg.ts
+        by_type[msg.message_type] = by_type.get(msg.message_type, 0) + 1
+        kept += 1
+        if ingest.post_object(ingest.build_object(msg)):
+            posted += 1
+        else:
+            failed += 1
+    return kept, posted, failed, max_ts
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="resolve channels + fetch since checkpoint, but do not POST or update checkpoint",
+    )
+    parser.add_argument(
+        "--channel",
+        choices=ingest.CHANNEL_SLUGS,
+        default=None,
+        help="restrict to one channel (default: all 5)",
+    )
+    parser.add_argument(
+        "--reset-checkpoint",
+        action="store_true",
+        help="ignore current checkpoint and bootstrap from now (use after schema cutover)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if not ingest.BOT_TOKEN:
+        logger.error("SLACK_BOT_TOKEN not set — required for incremental indexer")
+        return 1
+
+    cp_path = checkpoint_path()
+    checkpoint = {} if args.reset_checkpoint else load_checkpoint(cp_path)
+    channels = (args.channel,) if args.channel else ingest.CHANNEL_SLUGS
+
+    if not args.dry_run:
+        try:
+            ingest.ensure_class()
+        except Exception as exc:  # noqa: BLE001 — surface any schema-create failure
+            logger.error("ensure_class failed: %s", exc)
+            return 3
+
+    channel_ids = ingest.resolve_channel_ids(channels)
+    if not channel_ids:
+        logger.error("none of the named channels resolved — check bot permissions")
+        return 2
+
+    new_checkpoint = dict(checkpoint)
+    by_channel: dict[str, int] = {}
+    by_type: dict[str, int] = {}
+    total_posted = total_failed = 0
+    started = time.time()
+
+    for slug in channels:
+        ch_id = channel_ids.get(slug)
+        if not ch_id:
+            logger.warning("channel #%s did not resolve — skipping", slug)
+            continue
+        oldest = checkpoint.get(slug) or bootstrap_now_ts()
+        cold_start = slug not in checkpoint
+        logger.info(
+            "indexing #%s (%s) since ts=%s%s",
+            slug,
+            ch_id,
+            oldest,
+            " [cold-start]" if cold_start else "",
+        )
+        kept, posted, failed, new_last_ts = index_channel(slug, ch_id, oldest, by_type)
+        by_channel[slug] = kept
+        total_posted += posted
+        total_failed += failed
+        new_checkpoint[slug] = new_last_ts
+
+    if not args.dry_run and total_failed == 0:
+        save_checkpoint(cp_path, new_checkpoint)
+
+    elapsed_ms = int((time.time() - started) * 1000)
+    logger.info(
+        "incremental_summary: by_channel=%s by_type=%s posted=%d failed=%d elapsed_ms=%d "
+        "checkpoint=%s",
+        json.dumps(by_channel),
+        json.dumps(by_type),
+        total_posted,
+        total_failed,
+        elapsed_ms,
+        cp_path,
+    )
+    return 0 if total_failed == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/slack_history_indexer.py
+++ b/scripts/orchestrator/slack_history_indexer.py
@@ -59,16 +59,15 @@ logger = logging.getLogger("slack_history_indexer")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
 
-# Sonar S2083 — Path Traversal guard.
+# Sonar S2083 / S5443 — Path Traversal + publicly writable directories.
 # SLACK_HISTORY_CHECKPOINT and XDG_STATE_HOME flow from the process environment;
 # an operator with env access could otherwise redirect writes anywhere on disk.
-# We canonicalize both via Path.resolve() and require the result to sit under
-# one of these safe parents before honouring the override.
+# We canonicalize via Path.resolve() and require the result to sit under one of
+# these private safe parents. /tmp is intentionally excluded (S5443: world-writable).
 def _safe_state_parents() -> tuple[Path, ...]:
     return (
         Path.home().resolve(),
-        Path("/var/lib").resolve(),
-        Path("/tmp").resolve(),
+        Path("/var/lib/agency-os").resolve(),
     )
 
 
@@ -108,6 +107,11 @@ def checkpoint_path() -> Path:
     return Path.home() / ".local" / "state" / "agency-os" / "slack_history_checkpoint.json"
 
 
+def _sanitize_log_value(raw: object) -> str:
+    """Strip CR/LF from user-controlled values before logging (Sonar S5145)."""
+    return str(raw).replace("\n", "\\n").replace("\r", "\\r")
+
+
 def load_checkpoint(path: Path) -> dict[str, str]:
     """Return {channel_slug: last_ts} or {} if no checkpoint yet (cold start)."""
     if not path.exists():
@@ -120,11 +124,19 @@ def load_checkpoint(path: Path) -> dict[str, str]:
 
 
 def save_checkpoint(path: Path, data: dict[str, str]) -> None:
-    """Atomic write: tmp + rename → no torn writes if process dies mid-write."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(data, indent=2, sort_keys=True))
-    tmp.replace(path)
+    """Atomic write: tmp + rename → no torn writes if process dies mid-write.
+
+    Defence-in-depth: re-validate that the resolved path is under a safe parent
+    before writing (Sonar S2083 — taint analyzer may not follow upstream
+    validator across function boundaries).
+    """
+    resolved = path.resolve()
+    if not any(resolved.is_relative_to(p) for p in _safe_state_parents()):
+        raise ValueError(f"refusing to write checkpoint outside safe roots: {resolved}")
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    tmp = resolved.with_suffix(resolved.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True))  # NOSONAR S2083 — path checked above
+    tmp.replace(resolved)
 
 
 def bootstrap_now_ts() -> str:
@@ -182,6 +194,35 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _ensure_schema_or_log() -> int:
+    """Return 0 on success, 3 on ensure_class failure. Logged with traceback."""
+    try:
+        ingest.ensure_class()
+    except Exception:  # noqa: BLE001 — surface any schema-create failure
+        logger.exception("ensure_class failed")
+        return 3
+    return 0
+
+
+def _index_one_channel(
+    slug: str,
+    ch_id: str,
+    checkpoint: dict[str, str],
+    by_type: dict[str, int],
+) -> tuple[int, int, int, str]:
+    """Wrapper around index_channel that emits the structured log line."""
+    oldest = checkpoint.get(slug) or bootstrap_now_ts()
+    cold_start = slug not in checkpoint
+    logger.info(
+        "indexing #%s (%s) since ts=%s%s",
+        _sanitize_log_value(slug),
+        _sanitize_log_value(ch_id),
+        _sanitize_log_value(oldest),
+        " [cold-start]" if cold_start else "",
+    )
+    return index_channel(slug, ch_id, oldest, by_type)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     if not ingest.BOT_TOKEN:
@@ -193,11 +234,9 @@ def main(argv: list[str] | None = None) -> int:
     channels = (args.channel,) if args.channel else ingest.CHANNEL_SLUGS
 
     if not args.dry_run:
-        try:
-            ingest.ensure_class()
-        except Exception as exc:  # noqa: BLE001 — surface any schema-create failure
-            logger.error("ensure_class failed: %s", exc)
-            return 3
+        schema_rc = _ensure_schema_or_log()
+        if schema_rc != 0:
+            return schema_rc
 
     channel_ids = ingest.resolve_channel_ids(channels)
     if not channel_ids:
@@ -213,18 +252,9 @@ def main(argv: list[str] | None = None) -> int:
     for slug in channels:
         ch_id = channel_ids.get(slug)
         if not ch_id:
-            logger.warning("channel #%s did not resolve — skipping", slug)
+            logger.warning("channel #%s did not resolve — skipping", _sanitize_log_value(slug))
             continue
-        oldest = checkpoint.get(slug) or bootstrap_now_ts()
-        cold_start = slug not in checkpoint
-        logger.info(
-            "indexing #%s (%s) since ts=%s%s",
-            slug,
-            ch_id,
-            oldest,
-            " [cold-start]" if cold_start else "",
-        )
-        kept, posted, failed, new_last_ts = index_channel(slug, ch_id, oldest, by_type)
+        kept, posted, failed, new_last_ts = _index_one_channel(slug, ch_id, checkpoint, by_type)
         by_channel[slug] = kept
         total_posted += posted
         total_failed += failed
@@ -242,7 +272,7 @@ def main(argv: list[str] | None = None) -> int:
         total_posted,
         total_failed,
         elapsed_ms,
-        cp_path,
+        _sanitize_log_value(cp_path),
     )
     return 0 if total_failed == 0 else 2
 

--- a/scripts/orchestrator/slack_history_indexer.py
+++ b/scripts/orchestrator/slack_history_indexer.py
@@ -59,13 +59,53 @@ logger = logging.getLogger("slack_history_indexer")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
 
+# Sonar S2083 — Path Traversal guard.
+# SLACK_HISTORY_CHECKPOINT and XDG_STATE_HOME flow from the process environment;
+# an operator with env access could otherwise redirect writes anywhere on disk.
+# We canonicalize both via Path.resolve() and require the result to sit under
+# one of these safe parents before honouring the override.
+def _safe_state_parents() -> tuple[Path, ...]:
+    return (
+        Path.home().resolve(),
+        Path("/var/lib").resolve(),
+        Path("/tmp").resolve(),
+    )
+
+
+def _validated_env_path(env_name: str, raw: str) -> Path | None:
+    """Reject env-supplied paths containing '..' or resolving outside safe roots."""
+    if ".." in Path(raw).parts:
+        logger.warning("%s contains '..' segment — ignoring override", env_name)
+        return None
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        logger.warning("%s must be absolute — ignoring override", env_name)
+        return None
+    resolved = candidate.resolve()
+    if not any(resolved.is_relative_to(p) for p in _safe_state_parents()):
+        logger.warning("%s resolves outside safe roots — ignoring override", env_name)
+        return None
+    return resolved
+
+
 def checkpoint_path() -> Path:
-    """Resolve checkpoint path: env override → XDG_STATE_HOME → ~/.local/state."""
+    """Resolve checkpoint path: env override → XDG_STATE_HOME → ~/.local/state.
+
+    Both env overrides are validated via _validated_env_path to prevent
+    path traversal (Sonar S2083). Invalid overrides are logged and ignored,
+    falling through to the default safe location under $HOME/.local/state.
+    """
     override = os.environ.get("SLACK_HISTORY_CHECKPOINT")
     if override:
-        return Path(override)
-    state_root = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
-    return Path(state_root) / "agency-os" / "slack_history_checkpoint.json"
+        safe = _validated_env_path("SLACK_HISTORY_CHECKPOINT", override)
+        if safe is not None:
+            return safe
+    xdg = os.environ.get("XDG_STATE_HOME")
+    if xdg:
+        safe_xdg = _validated_env_path("XDG_STATE_HOME", xdg)
+        if safe_xdg is not None:
+            return safe_xdg / "agency-os" / "slack_history_checkpoint.json"
+    return Path.home() / ".local" / "state" / "agency-os" / "slack_history_checkpoint.json"
 
 
 def load_checkpoint(path: Path) -> dict[str, str]:

--- a/scripts/orchestrator/slack_history_ingest.py
+++ b/scripts/orchestrator/slack_history_ingest.py
@@ -71,6 +71,7 @@ WEAVIATE_BASE = f"http://{WEAVIATE_HOST}:{WEAVIATE_PORT}"  # NOSONAR
 
 SLACK_API = "https://slack.com/api"
 BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
+GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY", "")  # for text2vec-google AI Studio auth
 
 # Channel id → friendly slug used in metadata + filtering.
 # The actual channel ids are looked up via conversations.list at runtime; this
@@ -85,11 +86,18 @@ CHANNEL_SLUGS: tuple[str, ...] = (
 
 CORPUS_SCHEMA = {
     "class": CORPUS_CLASS,
-    "vectorizer": "text2vec-transformers",
+    # Dave Option A (KEI-196 swap): text2vec-google over text2vec-transformers
+    # — no self-hosted inference container. AI Studio endpoint (not Vertex)
+    # avoids projectId requirement. modelId=gemini-embedding-001 is the AI Studio
+    # name (KEI-196 commit 12cfaf93a's "text-embedding-004" is the Vertex name —
+    # empirically 404s on AI Studio v1beta; gemini-embedding-001 is the supported
+    # name per ListModels). Auth via X-Goog-Studio-Api-Key header per request.
+    "vectorizer": "text2vec-google",
     "moduleConfig": {
-        "text2vec-transformers": {
+        "text2vec-google": {
+            "apiEndpoint": "generativelanguage.googleapis.com",
+            "modelId": "gemini-embedding-001",
             "vectorizeClassName": False,
-            "poolingStrategy": "masked_mean",
         }
     },
     "properties": [
@@ -371,10 +379,17 @@ def build_object(msg: SlackMessage) -> dict[str, Any]:
 
 
 def post_object(obj: dict[str, Any]) -> bool:
-    """POST one object to Weaviate. Returns True on 200/422 (idempotent)."""
+    """POST one object to Weaviate. Returns True on 200/422 (idempotent).
+
+    Sends X-Goog-Studio-Api-Key header so Weaviate's text2vec-google module can
+    auth against AI Studio (Weaviate process does not have GOOGLE_APIKEY in
+    its env — see KEI-196 swap notes).
+    """
     data = json.dumps(obj).encode()
     req = urlrequest.Request(f"{WEAVIATE_BASE}/v1/objects", data=data, method="POST")
     req.add_header("Content-Type", "application/json")
+    if GOOGLE_API_KEY:
+        req.add_header("X-Goog-Studio-Api-Key", GOOGLE_API_KEY)
     try:
         with urlrequest.urlopen(req, timeout=30) as resp:
             return resp.status in (200, 201)

--- a/scripts/orchestrator/slack_history_ingest.py
+++ b/scripts/orchestrator/slack_history_ingest.py
@@ -115,15 +115,28 @@ _FLEET_STATUS_RE = re.compile(
     r"^\s*(?:\[FLEET-?STATUS:[a-z0-9_-]+\]|\[SUPERVISOR\]\s+(?:fleet|cycle))",
     re.IGNORECASE,
 )
+_BARE_CALLSIGN_RE = re.compile(
+    r"^\s*\[(?:atlas|orion|scout|nova|max|aiden|elliot|claude|dave)\]\s*$",
+    re.IGNORECASE,
+)
+_VERCEL_RATELIMIT_RE = re.compile(
+    r"vercel.*(?:rate.?limit|too many requests|429)|"
+    r"(?:rate.?limit|too many requests|429).*vercel",
+    re.IGNORECASE,
+)
 
 
 def is_noise(text: str) -> bool:
-    """Return True if the message is a [READY:] heartbeat / fleet-status mirror."""
+    """Return True if the message is a heartbeat / fleet-mirror / bare-ping / Vercel-throttle."""
     if not text or not text.strip():
         return True
     if _READY_HEARTBEAT_RE.match(text):
         return True
-    if _FLEET_STATUS_RE.match(text):  # noqa: SIM103 — explicit return clearer than chain
+    if _FLEET_STATUS_RE.match(text):
+        return True
+    if _BARE_CALLSIGN_RE.match(text):
+        return True
+    if _VERCEL_RATELIMIT_RE.search(text):  # noqa: SIM103 — explicit return clearer than chain
         return True
     return False
 
@@ -250,11 +263,20 @@ def resolve_channel_ids(slugs: tuple[str, ...]) -> dict[str, str]:
     return mapping
 
 
-def paginate_history(channel_id: str, limit_per_page: int = 200, total_cap: int = 100_000):
+def paginate_history(
+    channel_id: str,
+    limit_per_page: int = 200,
+    total_cap: int = 100_000,
+    oldest: str = "",
+):
     """Yield message dicts from conversations.history for one channel.
 
     Sleeps 1.0s between pages to stay well under Slack's tier-2 rate limit
     (20 req/min on conversations.history for many workspaces).
+
+    `oldest`: if set (Slack ts like "1779065531.123456"), only messages with
+    ts > oldest are returned — used by the incremental indexer for the
+    since-last-checkpoint window.
     """
     cursor = ""
     yielded = 0
@@ -262,6 +284,8 @@ def paginate_history(channel_id: str, limit_per_page: int = 200, total_cap: int 
         params: dict[str, Any] = {"channel": channel_id, "limit": limit_per_page}
         if cursor:
             params["cursor"] = cursor
+        if oldest:
+            params["oldest"] = oldest
         try:
             body = _slack_get("conversations.history", params)
         except (urlerror.URLError, urlerror.HTTPError, RuntimeError) as exc:

--- a/systemd/slack_history_indexer.service
+++ b/systemd/slack_history_indexer.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=KEI-201 Slack history → Weaviate incremental indexer (one-shot)
+Documentation=https://linear.app/keiracom/issue/KEI-201
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/agency-os/.env
+WorkingDirectory=%h/clawd/Agency_OS
+ExecStart=/usr/bin/python3 %h/clawd/Agency_OS/scripts/orchestrator/slack_history_indexer.py
+Nice=10
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=300
+# Don't restart on failure — timer triggers next run; failures surface via journalctl
+
+[Install]
+WantedBy=default.target

--- a/systemd/slack_history_indexer.timer
+++ b/systemd/slack_history_indexer.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=KEI-201 fires slack_history_indexer.service every 15 min
+Documentation=https://linear.app/keiracom/issue/KEI-201
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=15min
+AccuracySec=30s
+Persistent=true
+Unit=slack_history_indexer.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/scripts/test_slack_history_indexer.py
+++ b/tests/scripts/test_slack_history_indexer.py
@@ -1,0 +1,221 @@
+"""Tests for slack_history_indexer — KEI-201 Phase 2 incremental daemon.
+
+Covers checkpoint round-trip, oldest= filter wiring, bootstrap-now ts shape,
+atomic write, and the index_channel walk against a stubbed paginate_history.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "slack_history_indexer.py"
+
+
+@pytest.fixture(scope="module")
+def indexer():
+    spec = importlib.util.spec_from_file_location("slack_history_indexer", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["slack_history_indexer"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+# ─── checkpoint_path resolution ──────────────────────────────────────────────
+
+
+def test_checkpoint_path_default(indexer, monkeypatch, tmp_path):
+    monkeypatch.delenv("SLACK_HISTORY_CHECKPOINT", raising=False)
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    p = indexer.checkpoint_path()
+    assert p == tmp_path / ".local" / "state" / "agency-os" / "slack_history_checkpoint.json"
+
+
+def test_checkpoint_path_xdg_state_home_wins(indexer, monkeypatch, tmp_path):
+    monkeypatch.delenv("SLACK_HISTORY_CHECKPOINT", raising=False)
+    state = tmp_path / "xdg-state"
+    monkeypatch.setenv("XDG_STATE_HOME", str(state))
+    p = indexer.checkpoint_path()
+    assert p == state / "agency-os" / "slack_history_checkpoint.json"
+
+
+def test_checkpoint_path_env_override_wins(indexer, monkeypatch, tmp_path):
+    override = tmp_path / "custom.json"
+    monkeypatch.setenv("SLACK_HISTORY_CHECKPOINT", str(override))
+    monkeypatch.setenv("XDG_STATE_HOME", "/should/be/ignored")
+    assert indexer.checkpoint_path() == override
+
+
+# ─── load/save round-trip ────────────────────────────────────────────────────
+
+
+def test_load_checkpoint_cold_start_returns_empty(indexer, tmp_path):
+    assert indexer.load_checkpoint(tmp_path / "nope.json") == {}
+
+
+def test_load_checkpoint_malformed_returns_empty(indexer, tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("{not json")
+    assert indexer.load_checkpoint(p) == {}
+
+
+def test_save_then_load_round_trip(indexer, tmp_path):
+    p = tmp_path / "cp.json"
+    data = {"ceo": "1779065531.123", "execution": "1779065532.456"}
+    indexer.save_checkpoint(p, data)
+    assert indexer.load_checkpoint(p) == data
+
+
+def test_save_checkpoint_creates_parent_dir(indexer, tmp_path):
+    p = tmp_path / "nested" / "deeper" / "cp.json"
+    indexer.save_checkpoint(p, {"ceo": "1.1"})
+    assert p.exists()
+    assert json.loads(p.read_text()) == {"ceo": "1.1"}
+
+
+def test_save_checkpoint_atomic_via_tmp_rename(indexer, tmp_path):
+    """Write goes through .tmp + rename → no partial file under target name."""
+    p = tmp_path / "cp.json"
+    indexer.save_checkpoint(p, {"ceo": "1.1"})
+    # No leftover .tmp after success
+    assert not (tmp_path / "cp.json.tmp").exists()
+    assert p.exists()
+
+
+# ─── bootstrap_now_ts shape ──────────────────────────────────────────────────
+
+
+def test_bootstrap_now_ts_shape(indexer):
+    """Slack ts format: 'unix_seconds.microseconds_padded' — must be float-parseable."""
+    ts = indexer.bootstrap_now_ts()
+    assert "." in ts
+    parsed = float(ts)
+    assert parsed > 1_700_000_000  # after 2023-11
+    assert parsed < 2_000_000_000  # before 2033
+
+
+# ─── index_channel walk ──────────────────────────────────────────────────────
+
+
+def test_index_channel_advances_max_ts(indexer):
+    """new_last_ts must be max(ts) seen across kept messages."""
+    raws = [
+        {"text": "real content one", "ts": "1779065531.100", "user": "U1"},
+        {"text": "[READY:scout]", "ts": "1779065532.200", "user": "U2"},  # noise
+        {"text": "real content two", "ts": "1779065533.300", "user": "U3"},
+    ]
+    by_type: dict[str, int] = {}
+    with (
+        patch.object(indexer.ingest, "paginate_history", return_value=iter(raws)),
+        patch.object(indexer.ingest, "post_object", return_value=True),
+    ):
+        kept, posted, failed, new_ts = indexer.index_channel(
+            "ceo", "C-CEO", oldest="1779065530.000", by_type=by_type
+        )
+    assert kept == 2
+    assert posted == 2
+    assert failed == 0
+    assert new_ts == "1779065533.300"
+
+
+def test_index_channel_no_new_messages_holds_oldest(indexer):
+    """Empty page → checkpoint stays at oldest (no regression)."""
+    by_type: dict[str, int] = {}
+    with patch.object(indexer.ingest, "paginate_history", return_value=iter([])):
+        kept, posted, failed, new_ts = indexer.index_channel(
+            "ceo", "C-CEO", oldest="1779065530.000", by_type=by_type
+        )
+    assert kept == 0
+    assert posted == 0
+    assert failed == 0
+    assert new_ts == "1779065530.000"
+
+
+def test_index_channel_post_failure_counts(indexer):
+    """post_object False → counted as failed, NOT posted."""
+    raws = [{"text": "real content", "ts": "1779065531.100", "user": "U1"}]
+    by_type: dict[str, int] = {}
+    with (
+        patch.object(indexer.ingest, "paginate_history", return_value=iter(raws)),
+        patch.object(indexer.ingest, "post_object", return_value=False),
+    ):
+        kept, posted, failed, _new_ts = indexer.index_channel(
+            "ceo", "C-CEO", oldest="0", by_type=by_type
+        )
+    assert kept == 1
+    assert posted == 0
+    assert failed == 1
+
+
+def test_index_channel_idempotent_on_redelivery(indexer):
+    """post_object returns True on 422-already-exists per ingest.post_object — counted as posted."""
+    raws = [
+        {"text": "real content one", "ts": "1779065531.100", "user": "U1"},
+        {"text": "real content one repeat", "ts": "1779065531.100", "user": "U1"},
+    ]
+    by_type: dict[str, int] = {}
+    with (
+        patch.object(indexer.ingest, "paginate_history", return_value=iter(raws)),
+        patch.object(indexer.ingest, "post_object", return_value=True),
+    ):
+        kept, posted, failed, _new_ts = indexer.index_channel(
+            "ceo", "C-CEO", oldest="0", by_type=by_type
+        )
+    assert kept == 2
+    assert posted == 2
+    assert failed == 0
+
+
+def test_index_channel_by_type_accumulates_across_calls(indexer):
+    """by_type dict is the running counter — verifies the caller-owned mutation contract."""
+    by_type: dict[str, int] = {"ceo_directive": 5}
+    raws = [
+        {"text": "Dave directive: ship it", "ts": "1779065531.100", "user": "U1"},
+        {"text": "[SHIPPED] PR #999 merged", "ts": "1779065532.200", "user": "U2"},
+    ]
+    with (
+        patch.object(indexer.ingest, "paginate_history", return_value=iter(raws)),
+        patch.object(indexer.ingest, "post_object", return_value=True),
+    ):
+        indexer.index_channel("ceo", "C-CEO", oldest="0", by_type=by_type)
+    assert by_type["ceo_directive"] == 6  # pre-existing 5 + 1 new
+    assert by_type["completion_report"] == 1
+
+
+# ─── paginate_history wiring ─────────────────────────────────────────────────
+
+
+def test_paginate_history_passes_oldest_to_slack(indexer):
+    """The indexer's incremental contract: oldest= must end up in the Slack API params."""
+    captured = {}
+
+    def fake_slack_get(method: str, params: dict) -> dict:
+        captured["method"] = method
+        captured["params"] = params
+        return {"messages": [], "response_metadata": {}}
+
+    with patch.object(indexer.ingest, "_slack_get", side_effect=fake_slack_get):
+        list(indexer.ingest.paginate_history("C-CEO", oldest="1779065530.000"))
+    assert captured["method"] == "conversations.history"
+    assert captured["params"]["channel"] == "C-CEO"
+    assert captured["params"]["oldest"] == "1779065530.000"
+
+
+def test_paginate_history_omits_oldest_when_empty(indexer):
+    """Bulk extractor compatibility: paginate_history with no oldest must not send the param."""
+    captured = {}
+
+    def fake_slack_get(method: str, params: dict) -> dict:
+        captured["params"] = params
+        return {"messages": [], "response_metadata": {}}
+
+    with patch.object(indexer.ingest, "_slack_get", side_effect=fake_slack_get):
+        list(indexer.ingest.paginate_history("C-CEO"))
+    assert "oldest" not in captured["params"]

--- a/tests/scripts/test_slack_history_indexer.py
+++ b/tests/scripts/test_slack_history_indexer.py
@@ -39,6 +39,8 @@ def test_checkpoint_path_default(indexer, monkeypatch, tmp_path):
 
 
 def test_checkpoint_path_xdg_state_home_wins(indexer, monkeypatch, tmp_path):
+    """Safe roots are $HOME + /var/lib/agency-os; pytest tmp_path is set as HOME."""
+    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("SLACK_HISTORY_CHECKPOINT", raising=False)
     state = tmp_path / "xdg-state"
     monkeypatch.setenv("XDG_STATE_HOME", str(state))
@@ -47,10 +49,10 @@ def test_checkpoint_path_xdg_state_home_wins(indexer, monkeypatch, tmp_path):
 
 
 def test_checkpoint_path_env_override_wins(indexer, monkeypatch, tmp_path):
+    """Override must resolve under safe parents — set HOME=tmp_path to make it so."""
+    monkeypatch.setenv("HOME", str(tmp_path))
     override = tmp_path / "custom.json"
     monkeypatch.setenv("SLACK_HISTORY_CHECKPOINT", str(override))
-    # XDG override here is also under tmp_path (safe). The S2083 rejection of
-    # arbitrary outside-safe-roots paths is exercised in the tests below.
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg-ignored"))
     assert indexer.checkpoint_path() == override.resolve()
 
@@ -94,6 +96,21 @@ def test_checkpoint_path_rejects_outside_safe_roots_xdg(indexer, monkeypatch, tm
     assert p == tmp_path / ".local" / "state" / "agency-os" / "slack_history_checkpoint.json"
 
 
+def test_save_checkpoint_refuses_unsafe_path(indexer, monkeypatch, tmp_path):
+    """Sink-side defence-in-depth: save_checkpoint rejects paths outside safe roots."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    unsafe = Path("/etc/agency-os-pwn.json")
+    with pytest.raises(ValueError, match="outside safe roots"):
+        indexer.save_checkpoint(unsafe, {"ceo": "1.1"})
+
+
+def test_sanitize_log_value_strips_crlf(indexer):
+    """Sonar S5145 — newlines/CR are escaped so log lines can't be forged."""
+    assert indexer._sanitize_log_value("evil\nINJECTED") == "evil\\nINJECTED"
+    assert indexer._sanitize_log_value("crlf\r\nattack") == "crlf\\r\\nattack"
+    assert indexer._sanitize_log_value("clean") == "clean"
+
+
 # ─── load/save round-trip ────────────────────────────────────────────────────
 
 
@@ -107,22 +124,25 @@ def test_load_checkpoint_malformed_returns_empty(indexer, tmp_path):
     assert indexer.load_checkpoint(p) == {}
 
 
-def test_save_then_load_round_trip(indexer, tmp_path):
+def test_save_then_load_round_trip(indexer, monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
     p = tmp_path / "cp.json"
     data = {"ceo": "1779065531.123", "execution": "1779065532.456"}
     indexer.save_checkpoint(p, data)
     assert indexer.load_checkpoint(p) == data
 
 
-def test_save_checkpoint_creates_parent_dir(indexer, tmp_path):
+def test_save_checkpoint_creates_parent_dir(indexer, monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
     p = tmp_path / "nested" / "deeper" / "cp.json"
     indexer.save_checkpoint(p, {"ceo": "1.1"})
     assert p.exists()
     assert json.loads(p.read_text()) == {"ceo": "1.1"}
 
 
-def test_save_checkpoint_atomic_via_tmp_rename(indexer, tmp_path):
+def test_save_checkpoint_atomic_via_tmp_rename(indexer, monkeypatch, tmp_path):
     """Write goes through .tmp + rename → no partial file under target name."""
+    monkeypatch.setenv("HOME", str(tmp_path))
     p = tmp_path / "cp.json"
     indexer.save_checkpoint(p, {"ceo": "1.1"})
     # No leftover .tmp after success

--- a/tests/scripts/test_slack_history_indexer.py
+++ b/tests/scripts/test_slack_history_indexer.py
@@ -49,8 +49,49 @@ def test_checkpoint_path_xdg_state_home_wins(indexer, monkeypatch, tmp_path):
 def test_checkpoint_path_env_override_wins(indexer, monkeypatch, tmp_path):
     override = tmp_path / "custom.json"
     monkeypatch.setenv("SLACK_HISTORY_CHECKPOINT", str(override))
-    monkeypatch.setenv("XDG_STATE_HOME", "/should/be/ignored")
-    assert indexer.checkpoint_path() == override
+    # XDG override here is also under tmp_path (safe). The S2083 rejection of
+    # arbitrary outside-safe-roots paths is exercised in the tests below.
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg-ignored"))
+    assert indexer.checkpoint_path() == override.resolve()
+
+
+# ─── Sonar S2083 — Path Traversal guard ──────────────────────────────────────
+
+
+def test_checkpoint_path_rejects_dotdot_override(indexer, monkeypatch, tmp_path):
+    """Override containing '..' segment is ignored; default is used."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SLACK_HISTORY_CHECKPOINT", str(tmp_path / ".." / "escape.json"))
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    p = indexer.checkpoint_path()
+    assert p == tmp_path / ".local" / "state" / "agency-os" / "slack_history_checkpoint.json"
+
+
+def test_checkpoint_path_rejects_relative_override(indexer, monkeypatch, tmp_path):
+    """Relative override is ignored; default is used."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SLACK_HISTORY_CHECKPOINT", "relative/cp.json")
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    p = indexer.checkpoint_path()
+    assert p == tmp_path / ".local" / "state" / "agency-os" / "slack_history_checkpoint.json"
+
+
+def test_checkpoint_path_rejects_outside_safe_roots(indexer, monkeypatch, tmp_path):
+    """Absolute override outside $HOME / /var/lib / /tmp is ignored."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SLACK_HISTORY_CHECKPOINT", "/etc/passwd")
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    p = indexer.checkpoint_path()
+    assert p == tmp_path / ".local" / "state" / "agency-os" / "slack_history_checkpoint.json"
+
+
+def test_checkpoint_path_rejects_outside_safe_roots_xdg(indexer, monkeypatch, tmp_path):
+    """XDG_STATE_HOME override outside safe roots is ignored; default is used."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("SLACK_HISTORY_CHECKPOINT", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", "/etc")
+    p = indexer.checkpoint_path()
+    assert p == tmp_path / ".local" / "state" / "agency-os" / "slack_history_checkpoint.json"
 
 
 # ─── load/save round-trip ────────────────────────────────────────────────────

--- a/tests/scripts/test_slack_history_ingest.py
+++ b/tests/scripts/test_slack_history_ingest.py
@@ -54,6 +54,32 @@ def test_noise_filter_keeps_real_content(mod):
     assert not mod.is_noise("Building KEI-201 now")
 
 
+def test_noise_filter_drops_bare_callsign_ping(mod):
+    """Bare-bracket pings like '[ATLAS]' alone are pure protocol noise."""
+    assert mod.is_noise("[ATLAS]")
+    assert mod.is_noise("[scout]")
+    assert mod.is_noise("  [ORION]  ")
+    assert mod.is_noise("[NOVA]")
+
+
+def test_noise_filter_keeps_callsign_with_payload(mod):
+    """Bracketed callsign with content after MUST be kept (it's a real ping with body)."""
+    assert not mod.is_noise("[ATLAS] please claim KEI-99")
+    assert not mod.is_noise("[SCOUT] dispatch received")
+
+
+def test_noise_filter_drops_vercel_ratelimit(mod):
+    assert mod.is_noise("Vercel rate limit hit on deploy")
+    assert mod.is_noise("429 too many requests from vercel API")
+    assert mod.is_noise("VERCEL: rate-limit retry after 60s")
+
+
+def test_noise_filter_keeps_vercel_non_ratelimit(mod):
+    """Vercel mentioned in non-ratelimit context (e.g. deploy success) must NOT be noise."""
+    assert not mod.is_noise("Vercel deploy succeeded for PR #1024")
+    assert not mod.is_noise("checking vercel logs for the build failure")
+
+
 def test_noise_filter_regex_precedence_supervisor_midstring(mod):
     """S5850 regression: `[SUPERVISOR] fleet` mid-string must NOT be flagged as noise.
 

--- a/tests/scripts/test_slack_history_ingest.py
+++ b/tests/scripts/test_slack_history_ingest.py
@@ -250,8 +250,17 @@ def test_deterministic_id_differs_across_ts(mod):
 # ─── Schema ─────────────────────────────────────────────────────────────────
 
 
-def test_schema_uses_text2vec_transformers(mod):
-    assert mod.CORPUS_SCHEMA["vectorizer"] == "text2vec-transformers"
+def test_schema_uses_text2vec_google_ai_studio(mod):
+    """Dave Option A (KEI-196 swap) + KEI-201 empirical fix:
+    vectorizer=text2vec-google, AI Studio endpoint (no projectId), modelId
+    gemini-embedding-001 (NOT text-embedding-004 — that's the Vertex name
+    and 404s on AI Studio v1beta).
+    """
+    assert mod.CORPUS_SCHEMA["vectorizer"] == "text2vec-google"
+    mc = mod.CORPUS_SCHEMA["moduleConfig"]["text2vec-google"]
+    assert mc["apiEndpoint"] == "generativelanguage.googleapis.com"
+    assert mc["modelId"] == "gemini-embedding-001"
+    assert mc["vectorizeClassName"] is False
 
 
 def test_schema_has_required_properties(mod):


### PR DESCRIPTION
## Summary

KEI-201 Phase 2: incremental Slack → Weaviate `Slack_history` indexer daemon (companion to PR #1001's bulk extractor) **+** an empirical fix to the bulk extractor's vectorizer config that was broken on merge.

**Linear:** [KEI-201](https://linear.app/keiracom/issue/KEI-201) · **Off:** `6d104122a` (main HEAD as of dispatch)

## What lands (7 files, +574 LoC)

| File | Purpose |
|---|---|
| `scripts/orchestrator/slack_history_indexer.py` | Incremental daemon: read checkpoint → paginate with `oldest=last_ts` → filter + classify (reuses ingest.py) → POST → atomic checkpoint write |
| `systemd/slack_history_indexer.service` | Type=oneshot, EnvironmentFile=.env, runs ingest's indexer entry-point |
| `systemd/slack_history_indexer.timer` | `OnUnitActiveSec=15min`, `Persistent=true`, fires 2min after boot |
| `scripts/install_slack_history_indexer.sh` | systemd-user install — copy, daemon-reload, enable --now |
| `tests/scripts/test_slack_history_indexer.py` | 15 tests: checkpoint resolution (env / XDG / default), round-trip, atomic write, `index_channel` walk, `oldest=` wiring, idempotency on redelivery |
| `scripts/orchestrator/slack_history_ingest.py` | Phase 1 modifications: `paginate_history(oldest=...)`, extended `is_noise()` (bare-callsign + Vercel rate-limit), **vectorizer config fix** |
| `tests/scripts/test_slack_history_ingest.py` | +6 noise tests (bare callsign + Vercel) + updated schema test |

## Vectorizer config fix (caught by empirical smoke — paper-review-not-tested in KEI-196)

PR #1001's merged schema specified `text2vec-transformers`. **First non-dry-run 422'd** because that module is not installed on this Weaviate (v1.37.3). KEI-196 (commit `12cfaf93a`) already swapped to `text2vec-google` for OTHER classes — but the Slack_history schema was not updated to match. Additionally, KEI-196's commit had two paper-review-not-tested claims that empirical smoke caught:

| Claim in KEI-196 | Empirical truth |
|---|---|
| ``"no projectId required for AI Studio"`` | Wrong — need `apiEndpoint: generativelanguage.googleapis.com` to flip mode |
| ``modelId: "text-embedding-004"`` | Wrong — that's the **Vertex** name; AI Studio v1beta returns 404. Correct: `gemini-embedding-001` (verified via ListModels) |
| Implicit: ``Weaviate has GOOGLE_API_KEY in its env`` | Wrong — Weaviate looks for `GOOGLE_APIKEY` (no underscore) or `PALM_APIKEY`; ours is `GOOGLE_API_KEY`. Solution: send `X-Goog-Studio-Api-Key` header on every POST |

**Final config (verified end-to-end with a 768-dim vector on test class):**

```python
CORPUS_SCHEMA = {
    "vectorizer": "text2vec-google",
    "moduleConfig": {
        "text2vec-google": {
            "apiEndpoint": "generativelanguage.googleapis.com",
            "modelId": "gemini-embedding-001",
            "vectorizeClassName": False,
        }
    },
    ...
}
```

`post_object` now adds `X-Goog-Studio-Api-Key` from `GOOGLE_API_KEY` env var.

> **KEI-196 follow-up needed:** `scripts/orchestrator/kei196_reingest_with_vectorizer.py` carries the same broken config (projectId + text-embedding-004). Filing fix-up KEI separately.

## Verbatim verify

```
$ pytest tests/scripts/test_slack_history_ingest.py tests/scripts/test_slack_history_indexer.py -q
...........................................                              [100%]
43 passed in 0.23s

$ ruff check + format --check
All checks passed!
4 files already formatted

$ python3 scripts/orchestrator/slack_history_indexer.py --dry-run --channel execution
2026-05-18 08:46:47,615 INFO indexing #execution (C0B3QB0K1GQ) since ts=1779094007.615220 [cold-start]
2026-05-18 08:46:47,861 INFO incremental_summary: by_channel={"execution": 0} ... posted=0 failed=0 elapsed_ms=246
# Cold-start bootstrap works; --dry-run honors (no checkpoint written, no POST)

$ Live vectorizer round-trip (test class, see commit message)
vec_dim: 768
vec_first3: [0.0053842505, 0.0010497723, 0.0031145003]
```

## Acceptance status per dispatch

- [x] Collection exists with text2vec-google vectorizer (gemini-embedding-001) — created by `ensure_class()` on first run
- [x] Filter expansion: bare-callsign pings + Vercel rate-limit (per dispatch)
- [x] Indexer.timer firing 15min (Persistent=true, OnUnitActiveSec=15min) — install via `bash scripts/install_slack_history_indexer.sh`
- [ ] **Live bulk extract running** (in progress — kicked off at PR-open time, ~30min wall-clock per channel × 5; current count visible via `Aggregate{Slack_history{meta{count}}}`). Will surface row counts + ~noise-reduction-ratio empirics + semantic query results to `#execution` once complete.
- [ ] **GOV-9 GAP surfaced from dry-run:** filter on raw #ceo history hit only **0.76% noise reduction** (12 of 1571 messages). Dispatch acceptance target was ~80%. Filter design from PR #1001 only matches very specific patterns ([READY:], fleet-status, [FLEET-STATUS:]); 64% of remaining messages fall into the `agent_chatter` fallback bucket. Empirical signal that more filter patterns are needed OR the 80% threshold is aspirational. Surfacing in #execution post for Elliot/Dave decision rather than over-filtering speculatively in this PR.

## Out of scope (follow-up KEIs)

- KEI-196 reingest script `kei196_reingest_with_vectorizer.py` carries the same broken config — separate fix-up
- Filter expansion past bare-callsign + Vercel — requires Dave's call on noise threshold vs false-positive risk
- Re-vectorizing existing 1536-dim classes (Discoveries, Decisions, Keis) to match 768-dim gemini — separate KEI-196 follow-up
- Live bulk extract completion + semantic query verification — runs in background, evidence to #execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)