### PR TITLE
[ORION] fix(kei218): fleet_supervisor — strip +asyncpg DSN suffix

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -140,7 +140,8 @@ def _db_dsn() -> str:
     dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
     if not dsn:
         raise RuntimeError("DATABASE_URL / SUPABASE_DB_URL not set")
-    return dsn
+    # KEI-218: strip SQLAlchemy driver suffix — psycopg3 rejects '+asyncpg'.
+    return dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
 
 
 def _connect() -> psycopg.Connection:

--- a/tests/scripts/test_fleet_supervisor_kei218.py
+++ b/tests/scripts/test_fleet_supervisor_kei218.py
@@ -1,0 +1,55 @@
+"""KEI-218 — regression: _db_dsn() must strip SQLAlchemy '+asyncpg' suffix.
+
+The .env DATABASE_URL uses SQLAlchemy-style scheme `postgresql+asyncpg://`.
+psycopg3 raises ProgrammingError on that prefix at connect time, causing
+fleet-supervisor.service to crash-loop every 5min via fleet-supervisor.timer.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import fleet_supervisor as fs
+
+
+def test_db_dsn_strips_asyncpg_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://user:pass@host:5432/db?sslmode=require",
+    )
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    assert fs._db_dsn() == "postgresql://user:pass@host:5432/db?sslmode=require"
+
+
+def test_db_dsn_bare_postgresql_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql://user:pass@host:5432/db",
+    )
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    assert fs._db_dsn() == "postgresql://user:pass@host:5432/db"
+
+
+def test_db_dsn_raises_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    with pytest.raises(RuntimeError, match="DATABASE_URL"):
+        fs._db_dsn()
+
+
+def test_db_dsn_only_replaces_prefix_not_inline(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Defensive: replace('...', '...', 1) means only the first occurrence is
+    # rewritten. Verify a DSN whose password coincidentally contains the
+    # literal string is left alone after the leading scheme is fixed.
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://u:postgresql+asyncpg://@host/db",
+    )
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    assert fs._db_dsn() == "postgresql://u:postgresql+asyncpg://@host/db"


### PR DESCRIPTION
## Summary
- `scripts/fleet_supervisor.py:_db_dsn()` returned `DATABASE_URL` verbatim; `.env` uses SQLAlchemy-style `postgresql+asyncpg://` which psycopg3 rejects at connect time
- Service crash-looped every 5min via `fleet-supervisor.timer` (exit 1 within ~200ms)
- Strip the `+asyncpg` driver suffix before returning

## Diff (surgical)
```python
# scripts/fleet_supervisor.py:_db_dsn()
return dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
```

## Tests — `tests/scripts/test_fleet_supervisor_kei218.py`

```
$ python3 -m pytest tests/scripts/test_fleet_supervisor_kei218.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
collected 4 items

tests/scripts/test_fleet_supervisor_kei218.py::test_db_dsn_strips_asyncpg_suffix PASSED [ 25%]
tests/scripts/test_fleet_supervisor_kei218.py::test_db_dsn_bare_postgresql_passes_through PASSED [ 50%]
tests/scripts/test_fleet_supervisor_kei218.py::test_db_dsn_raises_when_unset PASSED [ 75%]
tests/scripts/test_fleet_supervisor_kei218.py::test_db_dsn_only_replaces_prefix_not_inline PASSED [100%]

============================== 4 passed in 0.18s ===============================
```

```
$ ruff check scripts/fleet_supervisor.py tests/scripts/test_fleet_supervisor_kei218.py
All checks passed!

$ ruff format --check scripts/fleet_supervisor.py tests/scripts/test_fleet_supervisor_kei218.py
2 files already formatted
```

## Post-merge verification (per dispatch)
```bash
systemctl --user restart fleet-supervisor.service
systemctl --user status fleet-supervisor.service   # expect: active or clean exit 0
```

## Source
- Dispatch from Elliot 2026-05-18 — STEP 0 PRE-CONFIRMED, one-line surgical fix
- Linear: https://linear.app/keiracom/issue/KEI-218

🤖 Generated with [Claude Code](https://claude.com/claude-code)