### PR TITLE
[ORION] fix(kei221a): canonicalise FLEET_SUPERVISOR_V2_ENABLED — eliminate silent-misroute

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -29,18 +29,25 @@ from typing import Any
 import psycopg
 
 # ---------------------------------------------------------------------------
-# KEI-183: Supervisor v2 feature flags
+# KEI-183 / KEI-222: Supervisor v2 feature flags
 # ---------------------------------------------------------------------------
-# SUPERVISOR_V2_ENABLED=1  enables v2 for agents whose AGENT_ROUTING=v2.
+# FLEET_SUPERVISOR_V2_ENABLED=1  enables v2 for agents whose AGENT_ROUTING=v2.
 # AGENT_ROUTING_<CALLSIGN>=v2 (e.g. AGENT_ROUTING_ELLIOT=v2) opts that agent in.
-# Both default OFF — v1 path is unchanged when flags absent.
+# Both default OFF — v1 path is unchanged when flags absent. The flag is read
+# at runtime (not import time) so install/test env writes always take effect.
 
-SUPERVISOR_V2_ENABLED: bool = os.environ.get("SUPERVISOR_V2_ENABLED", "0") == "1"
+FLEET_SUPERVISOR_V2_ENV = "FLEET_SUPERVISOR_V2_ENABLED"
 
 # NATS connection details — canonical messaging backbone per KEI-205.
 # Valkey stays for KEI-117 rate limiting + KV state only; NATS is the
 # canonical messaging backbone per KEI-205.
 NATS_URL: str = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
+
+
+def _supervisor_v2_enabled() -> bool:
+    """KEI-185 — read `FLEET_SUPERVISOR_V2_ENABLED` env truthy-flag."""
+    raw = os.environ.get(FLEET_SUPERVISOR_V2_ENV, "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 def _agent_routing(callsign: str) -> str:
@@ -51,7 +58,7 @@ def _agent_routing(callsign: str) -> str:
 
 def _is_v2(callsign: str) -> bool:
     """True when both global flag and per-agent routing are set to v2."""
-    return SUPERVISOR_V2_ENABLED and _agent_routing(callsign) == "v2"
+    return _supervisor_v2_enabled() and _agent_routing(callsign) == "v2"
 
 
 def _nats_publish_state(callsign: str, state: str) -> None:
@@ -100,11 +107,6 @@ AGENTS = [
     {"callsign": "scout", "tmux": "scout:0", "service": "scout-agent"},
     {"callsign": "nova", "tmux": "nova:0", "service": "nova-agent"},
 ]
-
-# KEI-185 — supervisor v2 enable flag. When set to truthy, main() routes to
-# `src.fleet.supervisor_v2.run()` (KEI-183, Elliot PR #990). Falls back to v1
-# with a logged warning if v2 module is missing — flip-on order is enforced.
-FLEET_SUPERVISOR_V2_ENV = "FLEET_SUPERVISOR_V2_ENABLED"
 
 # tmux send-keys delay in seconds
 TMUX_DELAY = "0.5"
@@ -883,12 +885,6 @@ def post_ceo_status(report: FleetReport) -> None:
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
-
-
-def _supervisor_v2_enabled() -> bool:
-    """KEI-185 — read `FLEET_SUPERVISOR_V2_ENABLED` env truthy-flag."""
-    raw = os.environ.get(FLEET_SUPERVISOR_V2_ENV, "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
 
 
 def _try_run_supervisor_v2() -> bool:

--- a/tests/scripts/test_fleet_supervisor_kei183.py
+++ b/tests/scripts/test_fleet_supervisor_kei183.py
@@ -54,19 +54,21 @@ def test_agent_routing_returns_v2_when_set(monkeypatch):
 
 
 def test_is_v2_false_when_global_flag_off(monkeypatch):
-    monkeypatch.setattr(fs, "SUPERVISOR_V2_ENABLED", False)
+    # KEI-222: canonical env path replaces the import-time SUPERVISOR_V2_ENABLED
+    # bool constant. Tests now setenv FLEET_SUPERVISOR_V2_ENABLED directly.
+    monkeypatch.delenv("FLEET_SUPERVISOR_V2_ENABLED", raising=False)
     monkeypatch.setenv("AGENT_ROUTING_ELLIOT", "v2")
     assert fs._is_v2("elliot") is False
 
 
 def test_is_v2_false_when_agent_routing_v1(monkeypatch):
-    monkeypatch.setattr(fs, "SUPERVISOR_V2_ENABLED", True)
+    monkeypatch.setenv("FLEET_SUPERVISOR_V2_ENABLED", "1")
     monkeypatch.setenv("AGENT_ROUTING_ELLIOT", "v1")
     assert fs._is_v2("elliot") is False
 
 
 def test_is_v2_true_when_both_set(monkeypatch):
-    monkeypatch.setattr(fs, "SUPERVISOR_V2_ENABLED", True)
+    monkeypatch.setenv("FLEET_SUPERVISOR_V2_ENABLED", "1")
     monkeypatch.setenv("AGENT_ROUTING_ELLIOT", "v2")
     assert fs._is_v2("elliot") is True
 


### PR DESCRIPTION
## Summary
- Two divergent reads of the v2 enable flag coexisted in `scripts/fleet_supervisor.py`: an import-time bool reading `SUPERVISOR_V2_ENABLED` env, and a runtime helper reading `FLEET_SUPERVISOR_V2_ENABLED` env
- Install scripts + personas + `test_fleet_supervisor.py` already use the long-name. `_is_v2(callsign)` (drives persona-lane filter + NATS publish) silently fell back to v1 per-agent routing under documented deploys — latent misroute
- Single source of truth: `_supervisor_v2_enabled()` reading canonical `FLEET_SUPERVISOR_V2_ENABLED` at runtime
- Dual-concurred (Aiden + Max) — Dave directive 2026-05-18

## Diff
- Delete `SUPERVISOR_V2_ENABLED: bool = …` import-time constant
- Promote `_supervisor_v2_enabled()` + `FLEET_SUPERVISOR_V2_ENV` to the v2-flags section near top
- `_is_v2()` now calls `_supervisor_v2_enabled()`
- `tests/scripts/test_fleet_supervisor_kei183.py`: `monkeypatch.setattr(fs, "SUPERVISOR_V2_ENABLED", …)` → `monkeypatch.setenv("FLEET_SUPERVISOR_V2_ENABLED", "1")`

## Grep audit (post-fix)
```
$ grep -rn "SUPERVISOR_V2_ENABLED" --include="*.py" --include="*.sh" --include="*.md" .
scripts/fleet_supervisor.py:34:# FLEET_SUPERVISOR_V2_ENABLED=1  enables v2 for agents whose AGENT_ROUTING=v2.
scripts/fleet_supervisor.py:39:FLEET_SUPERVISOR_V2_ENV = "FLEET_SUPERVISOR_V2_ENABLED"
scripts/fleet_supervisor.py:48:    """KEI-185 — read `FLEET_SUPERVISOR_V2_ENABLED` env truthy-flag."""
scripts/fleet_supervisor.py:899:            "FLEET_SUPERVISOR_V2_ENABLED=1 but supervisor_v2 module missing "
scripts/install_nova_agent.sh:11:#   4. KEI-183 (supervisor v2, Elliot PR #990) merged + FLEET_SUPERVISOR_V2_ENABLED=1
tests/scripts/test_fleet_supervisor_kei183.py:57:    # KEI-222: canonical env path replaces the import-time SUPERVISOR_V2_ENABLED
tests/scripts/test_fleet_supervisor_kei183.py:59:    monkeypatch.delenv("FLEET_SUPERVISOR_V2_ENABLED", raising=False)
tests/scripts/test_fleet_supervisor_kei183.py:65:    monkeypatch.setenv("FLEET_SUPERVISOR_V2_ENABLED", "1")
tests/scripts/test_fleet_supervisor_kei183.py:71:    monkeypatch.setenv("FLEET_SUPERVISOR_V2_ENABLED", "1")
tests/scripts/test_fleet_supervisor.py:692:    monkeypatch.delenv("FLEET_SUPERVISOR_V2_ENABLED", raising=False)
tests/scripts/test_fleet_supervisor.py:698:    monkeypatch.setenv("FLEET_SUPERVISOR_V2_ENABLED", val)
tests/scripts/test_fleet_supervisor.py:704:    monkeypatch.setenv("FLEET_SUPERVISOR_V2_ENABLED", val)
personas/nova.md:44:Nova is gated on the supervisor v2 flag flip (KEI-185). Until `FLEET_SUPERVISOR_V2_ENABLED=1` lands in production env, …
personas/worker4.md:83:Worker-4 is gated on KEI-185 supervisor v2 flag flip + KEI-206 role activation. Until `FLEET_SUPERVISOR_V2_ENABLED=1` AND …
```
All remaining matches are substrings of the canonical long-name; no standalone short-name reads or writes.

## Tests
```
$ python3 -m pytest tests/scripts/test_fleet_supervisor_kei183.py -v
============================== 13 passed in 0.19s ==============================
```
```
$ ruff check scripts/fleet_supervisor.py tests/scripts/test_fleet_supervisor_kei183.py
All checks passed!
$ ruff format --check scripts/fleet_supervisor.py tests/scripts/test_fleet_supervisor_kei183.py
2 files already formatted
```

## Pre-existing, not in scope
`tests/scripts/test_fleet_supervisor.py::test_find_pr_for_review_*` (3 tests) fail with `AttributeError: module 'fleet_supervisor' has no attribute 'fetch_pr_comments'`. Confirmed present on `origin/main` before this PR (verified via stashed-diff rerun). Separate concern — filing follow-up.

## Source
- Dispatch from Elliot 2026-05-18 — STEP 0 PRE-CONFIRMED; drift follow-up confirmed latent silent-misroute
- Linear: https://linear.app/keiracom/issue/KEI-222 (sub-issue of KEI-221)

🤖 Generated with [Claude Code](https://claude.com/claude-code)