### PR TITLE
[ATLAS] feat(kei221-bcd): NATS-route ready emission helper + per-agent flag

### DIFF
--- a/scripts/agent_ready_emit.sh
+++ b/scripts/agent_ready_emit.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# agent_ready_emit.sh — Emit [READY:<callsign>] via NATS (supervisor v2) or
+# Slack (legacy). KEI-221 (b)+(c) — Slack → NATS migration helper.
+#
+# Routing decision: AGENT_ROUTING_<CALLSIGN_UPPER> env var.
+#   value == "v2"  → nats pub keiracom.agent.status.<callsign> '{"state":"ready",…}'
+#   anything else  → tg "[READY:<callsign>]"  (legacy Slack path)
+#
+# Why a helper: two existing call-sites emit ready markers via `tg` directly
+# (scripts/orchestrator/agent_self_claim_loop.sh + scripts/hooks/emit_ready_marker.sh).
+# Centralising the route-decision here keeps the cutover atomic — flip
+# AGENT_ROUTING_<CALLSIGN>=v2 in .env and both call-sites switch in lockstep.
+#
+# Usage:
+#   agent_ready_emit.sh <callsign>
+#
+# Exit codes:
+#   0  emission attempted (success OR fail-open in legacy path)
+#   2  usage error (missing callsign)
+#
+# Fail-open: legacy `tg` path already wraps in `|| true` upstream, so failures
+# never block the caller. NATS path returns the publisher's exit code so the
+# supervisor can be alerted if NATS is down.
+
+set -u
+
+CALLSIGN="${1:-}"
+if [[ -z "$CALLSIGN" ]]; then
+    echo "usage: $0 <callsign>" >&2
+    exit 2
+fi
+
+CALLSIGN_LOWER="$(echo "$CALLSIGN" | tr '[:upper:]' '[:lower:]')"
+CALLSIGN_UPPER="$(echo "$CALLSIGN" | tr '[:lower:]' '[:upper:]')"
+
+FLAG_VAR="AGENT_ROUTING_${CALLSIGN_UPPER}"
+ROUTING="${!FLAG_VAR:-}"
+
+NATS_BIN="${NATS_BIN:-$(command -v nats || true)}"
+TG_BIN="${TG_BIN:-$(command -v tg || true)}"
+
+if [[ "$ROUTING" == "v2" && -n "$NATS_BIN" ]]; then
+    PAYLOAD="$(printf '{"state":"ready","callsign":"%s","ts":%s}' \
+        "$CALLSIGN_LOWER" "$(date +%s)")"
+    "$NATS_BIN" pub "keiracom.agent.status.${CALLSIGN_LOWER}" "$PAYLOAD" \
+        >/dev/null 2>&1
+    exit $?
+fi
+
+if [[ -n "$TG_BIN" ]]; then
+    CALLSIGN="$CALLSIGN_LOWER" "$TG_BIN" "[READY:${CALLSIGN_LOWER}]" \
+        >/dev/null 2>&1 || true
+fi
+exit 0

--- a/scripts/hooks/emit_ready_marker.sh
+++ b/scripts/hooks/emit_ready_marker.sh
@@ -56,8 +56,13 @@ if echo "$BODY" | grep -qi -E "\[READY:(${CALLSIGN}|${SHOUTY})\]"; then
     exit 0
 fi
 
-# 6. Emit via slack relay. Fail-open: || true swallows any error.
-if command -v tg >/dev/null 2>&1; then
+# 6. Emit via helper — routes NATS vs Slack per AGENT_ROUTING_<CALLSIGN_UPPER>=v2.
+#    KEI-221 (c). READY_EMIT env override exists for tests; prod path resolves
+#    to scripts/agent_ready_emit.sh relative to this hook's own location.
+READY_EMIT="${READY_EMIT:-$(dirname "$0")/../agent_ready_emit.sh}"
+if [[ -x "$READY_EMIT" ]]; then
+    bash "$READY_EMIT" "$CALLSIGN" >/dev/null 2>&1 || true
+elif command -v tg >/dev/null 2>&1; then
     tg "[READY:${CALLSIGN}]" >/dev/null 2>&1 || true
 else
     /home/elliotbot/clawd/venv/bin/python3 \

--- a/scripts/orchestrator/agent_self_claim_loop.sh
+++ b/scripts/orchestrator/agent_self_claim_loop.sh
@@ -42,6 +42,9 @@ CALLSIGN="${CALLSIGN_ARG:-${CALLSIGN:-}}"
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # ASSIGN_PATH override lets tests inject a stub self_assign_on_ready.py.
 ASSIGN="${ASSIGN_PATH:-$REPO_ROOT/scripts/orchestrator/self_assign_on_ready.py}"
+# READY_EMIT routes [READY:] via NATS or Slack per AGENT_ROUTING_<CALLSIGN_UPPER>=v2.
+# KEI-221 (c): override READY_EMIT in tests; prod path is the helper at scripts/.
+READY_EMIT="${READY_EMIT:-$REPO_ROOT/scripts/agent_ready_emit.sh}"
 TG_BIN="$(command -v tg || true)"
 READY_POSTED=0
 DEGRADED_POSTED=0
@@ -59,8 +62,8 @@ while true; do
       DEGRADED_STREAK=0
       ;;
     no_eligible_work)
-      if [[ "$READY_POSTED" = "0" && -n "$TG_BIN" ]]; then
-        CALLSIGN="$CALLSIGN" "$TG_BIN" "[READY:$CALLSIGN]" >/dev/null 2>&1 || true
+      if [[ "$READY_POSTED" = "0" && -x "$READY_EMIT" ]]; then
+        bash "$READY_EMIT" "$CALLSIGN" >/dev/null 2>&1 || true
         READY_POSTED=1
       fi
       DEGRADED_STREAK=0

--- a/tests/hooks/test_emit_ready_marker.py
+++ b/tests/hooks/test_emit_ready_marker.py
@@ -32,18 +32,25 @@ def _run_hook(
     callsign: str = "aiden",
     agent_id: str | None = None,
     tg_available: bool = True,
+    nats_available: bool = False,
+    routing_v2: bool = False,
     tmp_path: Path | None = None,
-) -> tuple[int, str, str]:
-    """Run the hook with a fake tg shim. Return (exit, stdout, tg_log)."""
+) -> tuple[int, str, str, str]:
+    """Run the hook with fake tg + optional nats shims. Return (exit, stdout, tg_log, nats_log)."""
     assert tmp_path is not None
     shim_dir = tmp_path / "bin"
     shim_dir.mkdir(parents=True, exist_ok=True)
     tg_log = tmp_path / "tg_invocations.log"
+    nats_log = tmp_path / "nats_invocations.log"
 
     if tg_available:
         tg_shim = shim_dir / "tg"
         tg_shim.write_text(f'#!/usr/bin/env bash\necho "$@" >> "{tg_log}"\nexit 0\n')
         tg_shim.chmod(0o755)
+    if nats_available:
+        nats_shim = shim_dir / "nats"
+        nats_shim.write_text(f'#!/usr/bin/env bash\necho "$@" >> "{nats_log}"\nexit 0\n')
+        nats_shim.chmod(0o755)
 
     env = os.environ.copy()
     env["CALLSIGN"] = callsign
@@ -51,6 +58,10 @@ def _run_hook(
     # Isolate from any real /tmp/.stop_event_payload.json on the host so tests
     # don't see leaked state from prior Stop events.
     env["STOP_EVENT_PAYLOAD_TEMP_PATH"] = str(tmp_path / "stop_payload.json")
+    if routing_v2:
+        env[f"AGENT_ROUTING_{callsign.upper()}"] = "v2"
+    else:
+        env.pop(f"AGENT_ROUTING_{callsign.upper()}", None)
     if agent_id:
         env["CLAUDE_AGENT_ID"] = agent_id
     else:
@@ -64,63 +75,66 @@ def _run_hook(
         env=env,
         timeout=10,
     )
-    log_contents = tg_log.read_text() if tg_log.exists() else ""
-    return proc.returncode, proc.stdout, log_contents
+    tg_contents = tg_log.read_text() if tg_log.exists() else ""
+    nats_contents = nats_log.read_text() if nats_log.exists() else ""
+    return proc.returncode, proc.stdout, tg_contents, nats_contents
 
 
 def test_empty_payload_fail_open(tmp_path: Path) -> None:
-    rc, _stdout, tg_log = _run_hook("", tmp_path=tmp_path)
+    rc, _stdout, tg_log, _nats_log = _run_hook("", tmp_path=tmp_path)
     assert rc == 0
     assert tg_log == ""
 
 
 def test_body_already_has_ready_marker_skips_emit(tmp_path: Path) -> None:
-    payload = json.dumps(
-        {"last_assistant_message": "Standing.\n\n[READY:aiden]"}
-    )
-    rc, _stdout, tg_log = _run_hook(payload, tmp_path=tmp_path)
+    payload = json.dumps({"last_assistant_message": "Standing.\n\n[READY:aiden]"})
+    rc, _stdout, tg_log, _nats_log = _run_hook(payload, tmp_path=tmp_path)
     assert rc == 0
     assert tg_log == ""
 
 
 def test_body_missing_marker_emits(tmp_path: Path) -> None:
-    payload = json.dumps(
-        {"last_assistant_message": "Holding for confirm — no marker here."}
-    )
-    rc, _stdout, tg_log = _run_hook(payload, tmp_path=tmp_path)
+    payload = json.dumps({"last_assistant_message": "Holding for confirm — no marker here."})
+    rc, _stdout, tg_log, _nats_log = _run_hook(payload, tmp_path=tmp_path)
     assert rc == 0
     assert "[READY:aiden]" in tg_log
 
 
 def test_subagent_skips_emit(tmp_path: Path) -> None:
     payload = json.dumps({"last_assistant_message": "Done. No marker."})
-    rc, _stdout, tg_log = _run_hook(
-        payload, agent_id="sub_abc123", tmp_path=tmp_path
-    )
+    rc, _stdout, tg_log, _nats_log = _run_hook(payload, agent_id="sub_abc123", tmp_path=tmp_path)
     assert rc == 0
     assert tg_log == ""
 
 
 def test_tg_missing_fail_open(tmp_path: Path) -> None:
     payload = json.dumps({"last_assistant_message": "Body without marker."})
-    rc, _stdout, _tg_log = _run_hook(
-        payload, tg_available=False, tmp_path=tmp_path
+    rc, _stdout, _tg_log, _nats_log = _run_hook(payload, tg_available=False, tmp_path=tmp_path)
+    assert rc == 0
+
+
+def test_routes_to_nats_when_v2_flag_set(tmp_path: Path) -> None:
+    """KEI-221 (c): with AGENT_ROUTING_AIDEN=v2 and nats present in PATH, the
+    hook must publish to NATS via agent_ready_emit.sh and NOT post to Slack tg."""
+    payload = json.dumps({"last_assistant_message": "Done — no marker."})
+    rc, _stdout, tg_log, nats_log = _run_hook(
+        payload, nats_available=True, routing_v2=True, tmp_path=tmp_path
     )
     assert rc == 0
+    assert "pub keiracom.agent.status.aiden" in nats_log
+    assert tg_log == "", f"tg must NOT be called when v2 routing flag set, got: {tg_log!r}"
 
 
 def test_case_insensitive_dedup(tmp_path: Path) -> None:
     payload = json.dumps({"last_assistant_message": "Wrap. [READY:AIDEN]"})
-    rc, _stdout, tg_log = _run_hook(payload, tmp_path=tmp_path)
+    rc, _stdout, tg_log, _nats_log = _run_hook(payload, tmp_path=tmp_path)
     assert rc == 0
     assert tg_log == ""
 
 
 def test_alt_body_key_message_content(tmp_path: Path) -> None:
-    payload = json.dumps(
-        {"message": {"content": "Reply via alt key. [READY:aiden]"}}
-    )
-    rc, _stdout, tg_log = _run_hook(payload, tmp_path=tmp_path)
+    payload = json.dumps({"message": {"content": "Reply via alt key. [READY:aiden]"}})
+    rc, _stdout, tg_log, _nats_log = _run_hook(payload, tmp_path=tmp_path)
     assert rc == 0
     assert tg_log == ""
 

--- a/tests/orchestrator/test_agent_self_claim_loop.py
+++ b/tests/orchestrator/test_agent_self_claim_loop.py
@@ -89,3 +89,48 @@ def test_no_eligible_posts_ready_once(tmp_path):
     )
     log = (tmp_path / "tg.log").read_text() if (tmp_path / "tg.log").exists() else ""
     assert log.count("[READY:scout]") == 1, f"expected 1 READY, got: {log!r}"
+
+
+def test_no_eligible_routes_to_nats_when_v2_flag_set(tmp_path):
+    """KEI-221 (c): with AGENT_ROUTING_SCOUT=v2, the loop must publish to NATS
+    via agent_ready_emit.sh and NOT post to Slack tg."""
+    _make_stub(
+        tmp_path,
+        '{"claimed": false, "reason": "no_eligible_work", "issue_id": null}',
+    )
+    fake_tg = tmp_path / "tg"
+    fake_nats = tmp_path / "nats"
+    tg_log = tmp_path / "tg.log"
+    nats_log = tmp_path / "nats.log"
+    fake_tg.write_text(f'#!/usr/bin/env bash\necho "TG: $*" >> {tg_log}\n')
+    fake_nats.write_text(f'#!/usr/bin/env bash\necho "NATS: $*" >> {nats_log}\n')
+    fake_tg.chmod(0o755)
+    fake_nats.chmod(0o755)
+    stub_path = tmp_path / "scripts" / "orchestrator" / "self_assign_on_ready.py"
+    env = {
+        **os.environ,
+        "CALLSIGN": "scout",
+        "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}",
+        "POLL_SECONDS": "1",
+        "ASSIGN_PATH": str(stub_path),
+        "AGENT_ROUTING_SCOUT": "v2",
+    }
+    proc = subprocess.Popen(
+        ["bash", str(LOOP), "--callsign", "scout", "--poll-seconds", "1"],
+        env=env,
+        cwd=str(tmp_path),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        preexec_fn=os.setsid,
+    )
+    try:
+        proc.wait(timeout=4.0)
+    except subprocess.TimeoutExpired:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    nats_text = nats_log.read_text() if nats_log.exists() else ""
+    assert "pub keiracom.agent.status.scout" in nats_text, f"expected NATS pub, got: {nats_text!r}"
+    assert not tg_log.exists(), "tg must NOT be called when AGENT_ROUTING_SCOUT=v2"

--- a/tests/scripts/test_agent_ready_emit.py
+++ b/tests/scripts/test_agent_ready_emit.py
@@ -1,0 +1,113 @@
+"""Tests for scripts/agent_ready_emit.sh — KEI-221 (b)+(c).
+
+Verifies the route-decision: AGENT_ROUTING_<CALLSIGN_UPPER>=v2 -> NATS publish,
+anything else -> Slack tg. Tests use fake NATS_BIN / TG_BIN stubs so no real
+network or Slack call happens.
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "agent_ready_emit.sh"
+
+
+def _write_capture_stub(tmp_path: Path, name: str, exit_code: int = 0) -> Path:
+    """Write a bash stub that appends its $@ to <name>.log and exits exit_code."""
+    stub = tmp_path / name
+    log = tmp_path / f"{name}.log"
+    stub.write_text(f'#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "{log}"\nexit {exit_code}\n')
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return stub
+
+
+def _run(env_overrides: dict[str, str], *args: str) -> subprocess.CompletedProcess:
+    base = {
+        "PATH": "/usr/bin:/bin",
+        "AGENT_ROUTING_ATLAS": "",
+        "NATS_BIN": "",
+        "TG_BIN": "",
+    }
+    base.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        env=base,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_routes_to_nats_when_flag_v2(tmp_path):
+    nats = _write_capture_stub(tmp_path, "nats")
+    tg = _write_capture_stub(tmp_path, "tg")
+    res = _run({"AGENT_ROUTING_ATLAS": "v2", "NATS_BIN": str(nats), "TG_BIN": str(tg)}, "atlas")
+    assert res.returncode == 0, res.stderr
+    nats_log = (tmp_path / "nats.log").read_text()
+    assert "pub keiracom.agent.status.atlas" in nats_log
+    assert '"state":"ready"' in nats_log
+    assert '"callsign":"atlas"' in nats_log
+    assert not (tmp_path / "tg.log").exists(), "tg must NOT be called when routing=v2"
+
+
+def test_routes_to_slack_when_flag_unset(tmp_path):
+    nats = _write_capture_stub(tmp_path, "nats")
+    tg = _write_capture_stub(tmp_path, "tg")
+    res = _run({"AGENT_ROUTING_ATLAS": "", "NATS_BIN": str(nats), "TG_BIN": str(tg)}, "atlas")
+    assert res.returncode == 0, res.stderr
+    tg_log = (tmp_path / "tg.log").read_text()
+    assert "[READY:atlas]" in tg_log
+    assert not (tmp_path / "nats.log").exists(), "nats must NOT be called when routing unset"
+
+
+def test_routes_to_slack_when_flag_not_v2(tmp_path):
+    nats = _write_capture_stub(tmp_path, "nats")
+    tg = _write_capture_stub(tmp_path, "tg")
+    res = _run({"AGENT_ROUTING_ATLAS": "v1", "NATS_BIN": str(nats), "TG_BIN": str(tg)}, "atlas")
+    assert res.returncode == 0, res.stderr
+    assert (tmp_path / "tg.log").exists()
+    assert not (tmp_path / "nats.log").exists()
+
+
+def test_callsign_case_normalised_to_lower(tmp_path):
+    nats = _write_capture_stub(tmp_path, "nats")
+    tg = _write_capture_stub(tmp_path, "tg")
+    res = _run({"AGENT_ROUTING_ATLAS": "v2", "NATS_BIN": str(nats), "TG_BIN": str(tg)}, "ATLAS")
+    assert res.returncode == 0, res.stderr
+    nats_log = (tmp_path / "nats.log").read_text()
+    assert "pub keiracom.agent.status.atlas" in nats_log
+
+
+def test_fails_when_callsign_missing(tmp_path):
+    res = _run(
+        {},
+    )
+    assert res.returncode == 2
+    assert "usage" in res.stderr.lower()
+
+
+def test_nats_failure_propagates_exit_code(tmp_path):
+    nats = _write_capture_stub(tmp_path, "nats", exit_code=7)
+    tg = _write_capture_stub(tmp_path, "tg")
+    res = _run({"AGENT_ROUTING_ATLAS": "v2", "NATS_BIN": str(nats), "TG_BIN": str(tg)}, "atlas")
+    assert res.returncode == 7
+
+
+def test_slack_failure_is_swallowed_fail_open(tmp_path):
+    """Legacy Slack path is fail-open — must NOT propagate tg's non-zero exit."""
+    nats = _write_capture_stub(tmp_path, "nats")
+    tg = _write_capture_stub(tmp_path, "tg", exit_code=9)
+    res = _run({"AGENT_ROUTING_ATLAS": "", "NATS_BIN": str(nats), "TG_BIN": str(tg)}, "atlas")
+    assert res.returncode == 0
+
+
+def test_flag_only_affects_matching_callsign(tmp_path):
+    """AGENT_ROUTING_ATLAS=v2 must NOT route ORION via NATS."""
+    nats = _write_capture_stub(tmp_path, "nats")
+    tg = _write_capture_stub(tmp_path, "tg")
+    res = _run({"AGENT_ROUTING_ATLAS": "v2", "NATS_BIN": str(nats), "TG_BIN": str(tg)}, "orion")
+    assert res.returncode == 0
+    assert not (tmp_path / "nats.log").exists()
+    assert (tmp_path / "tg.log").exists()


### PR DESCRIPTION
## Summary

Completes KEI-221 sub-scopes (b), (c), (d). Sub-scope (a) was [PR #1028](https://github.com/Keiracom/Agency_OS/pull/1028) (Orion, merged).

**Linear:** [KEI-221](https://linear.app/keiracom/issue/KEI-221) · **Off:** `origin/main`

## What lands

| File | Purpose |
|---|---|
| `scripts/agent_ready_emit.sh` | **New.** Central route-decision: `AGENT_ROUTING_<CALLSIGN_UPPER>=v2` → `nats pub keiracom.agent.status.<callsign>` JSON payload; anything else → legacy `tg "[READY:<callsign>]"`. Fail-open on legacy path. |
| `scripts/orchestrator/agent_self_claim_loop.sh` | Replaces direct `"$TG_BIN" "[READY:$CALLSIGN]"` with helper invocation. `READY_EMIT` env override for test injection. |
| `scripts/hooks/emit_ready_marker.sh` | Replaces tg/slack_relay fork with helper. Both legacy paths retained as fallback if helper unreachable. |
| `tests/scripts/test_agent_ready_emit.py` | 8 unit tests — v2→NATS, unset→Slack, v1→Slack, case normalisation, missing-arg exit-2, NATS error propagation, Slack fail-open, per-callsign flag isolation. |
| `tests/orchestrator/test_agent_self_claim_loop.py` | `+test_no_eligible_routes_to_nats_when_v2_flag_set` — negative-path: tg NOT called when v2 flag set. |
| `tests/hooks/test_emit_ready_marker.py` | `+test_routes_to_nats_when_v2_flag_set` — helper signature extended to return nats log. 4-tuple migration of 7 pre-existing tests. |

## Sub-scope (d) verified out-of-band via supabase MCP

```
SELECT column_name, data_type, is_nullable FROM information_schema.columns
WHERE table_schema='public' AND table_name='tasks' AND column_name='persona';
[{"column_name":"persona","data_type":"text","is_nullable":"YES"}]

SELECT indexname, indexdef FROM pg_indexes WHERE schemaname='public'
  AND tablename='tasks' AND indexname='idx_tasks_persona';
[{"indexname":"idx_tasks_persona","indexdef":"CREATE INDEX idx_tasks_persona
  ON public.tasks USING btree (persona) WHERE (status = 'available'::text)"}]
```

Migration `20260518_kei183_persona_column.sql` is applied in production.

## Sub-scope (b) — post-merge operator step (.env is gitignored)

```bash
# On Vultr, append to /home/elliotbot/.config/agency-os/.env:
AGENT_ROUTING_ELLIOT=v2
AGENT_ROUTING_AIDEN=v2
AGENT_ROUTING_MAX=v2
AGENT_ROUTING_ORION=v2
AGENT_ROUTING_SCOUT=v2
AGENT_ROUTING_NOVA=v2
AGENT_ROUTING_ATLAS=v2
# Then restart agents to load new code + flags.
```

With this code merged but flags unset, behaviour is identical to pre-change (legacy Slack path). The v2 cutover happens when an operator adds the 7 flags + restarts.

## Verbatim verify

```
$ ruff check tests/scripts/test_agent_ready_emit.py tests/hooks/test_emit_ready_marker.py tests/orchestrator/test_agent_self_claim_loop.py
All checks passed!

$ ruff format --check (same files)
3 files already formatted

$ pytest -q tests/scripts/test_agent_ready_emit.py tests/hooks/test_emit_ready_marker.py tests/orchestrator/test_agent_self_claim_loop.py
....................                                                     [100%]
20 passed in 11.32s

$ bash -n scripts/agent_ready_emit.sh scripts/orchestrator/agent_self_claim_loop.sh scripts/hooks/emit_ready_marker.sh
(no output — syntax OK)
```

## Acceptance map

| Acceptance criterion | Status |
|---|---|
| Zero `[READY]` in `#execution` for 10 minutes | DEFERRED — observable only after (b) post-merge + agent restart |
| `nats sub keiracom.agent.status.*` shows status events | DEFERRED — same |

The 10-minute observation is the operator step after merge + .env edit + restart. Surfacing here so the next operator (Atlas) knows what to verify.

## Scope coherence note

Per [[feedback_split_orthogonal_scope]] I authored earlier today: this PR bundles (c) code + (b) operator-instruction + (d) verified-out-of-band. All three are inseparable — (c) without (b) is a no-op; (d) is a one-query verification, not deployable code. Bundle justified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)