### PR TITLE
[ATLAS] feat(kei95): relay reconnection on reboot — openclaw dep ordering

### DIFF
--- a/docs/operations/agent-systemd-recovery.md
+++ b/docs/operations/agent-systemd-recovery.md
@@ -72,6 +72,31 @@ Expected timeline after `reboot`:
 
 If something is missing after ~3 minutes, see **Troubleshooting**.
 
+## OpenClaw relay dependency (KEI-95)
+
+Every `*-agent.service` unit declares `Requires=openclaw.service` +
+`After=network-online.target openclaw.service`. On a fresh boot the agent
+unit will NOT start until OpenClaw is up — preventing the silent-deaf
+agent failure mode where Claude Code initialises before the relay is ready
+and MCP/Slack inbound never reconnects.
+
+Two operator conditions must hold on a fresh host or after a reinstall:
+
+```bash
+# 1. Linger must be on (services need to start without a login session).
+sudo loginctl enable-linger elliotbot
+
+# 2. openclaw.service must be installed under ~/.config/systemd/user/
+#    and enabled. Source lives outside this repo; if it's missing,
+#    install_*_agent.sh exits and the dependency fails.
+systemctl --user is-enabled openclaw.service   # expect: enabled
+systemctl --user is-active  openclaw.service   # expect: active
+```
+
+If OpenClaw is unhealthy on boot, agent units stay in `inactive (waiting)`
+until OpenClaw becomes active — they will NOT crash-loop. Once OpenClaw
+comes up, agents follow within seconds.
+
 ## How a crashed agent recovers
 
 Each service runs `scripts/systemd_agent_supervisor.sh <callsign> <tmux> <worktree>`,

--- a/infra/systemd/agents/aiden-agent.service
+++ b/infra/systemd/agents/aiden-agent.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Keiracom aiden agent session (KEI-94 keep-alive)
 Documentation=https://linear.app/keiracom/issue/KEI-94
-After=network-online.target
+After=network-online.target openclaw.service
 Wants=network-online.target
+Requires=openclaw.service
 StartLimitBurst=5
 StartLimitIntervalSec=300
 

--- a/infra/systemd/agents/atlas-agent.service
+++ b/infra/systemd/agents/atlas-agent.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Keiracom atlas agent session (KEI-94 keep-alive)
 Documentation=https://linear.app/keiracom/issue/KEI-94
-After=network-online.target
+After=network-online.target openclaw.service
 Wants=network-online.target
+Requires=openclaw.service
 StartLimitBurst=5
 StartLimitIntervalSec=300
 

--- a/infra/systemd/agents/elliot-agent.service
+++ b/infra/systemd/agents/elliot-agent.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Keiracom elliot agent session (KEI-94 keep-alive)
 Documentation=https://linear.app/keiracom/issue/KEI-94
-After=network-online.target
+After=network-online.target openclaw.service
 Wants=network-online.target
+Requires=openclaw.service
 StartLimitBurst=5
 StartLimitIntervalSec=300
 

--- a/infra/systemd/agents/max-agent.service
+++ b/infra/systemd/agents/max-agent.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Keiracom max agent session (KEI-94 keep-alive)
 Documentation=https://linear.app/keiracom/issue/KEI-94
-After=network-online.target
+After=network-online.target openclaw.service
 Wants=network-online.target
+Requires=openclaw.service
 StartLimitBurst=5
 StartLimitIntervalSec=300
 

--- a/infra/systemd/agents/nova-agent.service
+++ b/infra/systemd/agents/nova-agent.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Keiracom nova agent session (KEI-185 Nova spawn)
 Documentation=https://linear.app/keiracom/issue/KEI-185
-After=network-online.target
+After=network-online.target openclaw.service
 Wants=network-online.target
+Requires=openclaw.service
 StartLimitBurst=5
 StartLimitIntervalSec=300
 

--- a/infra/systemd/agents/orion-agent.service
+++ b/infra/systemd/agents/orion-agent.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Keiracom orion agent session (KEI-94 keep-alive)
 Documentation=https://linear.app/keiracom/issue/KEI-94
-After=network-online.target
+After=network-online.target openclaw.service
 Wants=network-online.target
+Requires=openclaw.service
 StartLimitBurst=5
 StartLimitIntervalSec=300
 

--- a/infra/systemd/agents/scout-agent.service
+++ b/infra/systemd/agents/scout-agent.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Keiracom scout agent session (KEI-94 keep-alive)
 Documentation=https://linear.app/keiracom/issue/KEI-94
-After=network-online.target
+After=network-online.target openclaw.service
 Wants=network-online.target
+Requires=openclaw.service
 StartLimitBurst=5
 StartLimitIntervalSec=300
 

--- a/tests/infra/test_agent_service_units_kei95.py
+++ b/tests/infra/test_agent_service_units_kei95.py
@@ -1,0 +1,82 @@
+"""Tests for KEI-95 — Relay reconnection on reboot.
+
+Acceptance gate: every per-callsign agent systemd unit must list both
+`Requires=openclaw.service` and `After=openclaw.service` so the agent does
+not start before the OpenClaw relay is up. Together with
+`loginctl enable-linger elliotbot` (already-applied operator step,
+documented in docs/operations/agent-systemd-recovery.md) this closes the
+broken-relay-on-reboot loop.
+
+These tests fail if any agent unit drops either directive — runtime regression
+gate, not docstring promise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYSTEMD_DIR = REPO_ROOT / "infra" / "systemd" / "agents"
+
+CALLSIGNS = ("atlas", "aiden", "elliot", "max", "nova", "orion", "scout")
+
+
+@pytest.mark.parametrize("callsign", CALLSIGNS)
+def test_unit_has_requires_openclaw(callsign: str) -> None:
+    unit = SYSTEMD_DIR / f"{callsign}-agent.service"
+    assert unit.exists(), f"{unit} missing"
+    text = unit.read_text()
+    assert "Requires=openclaw.service" in text, (
+        f"{unit.name}: missing 'Requires=openclaw.service' (KEI-95 relay reboot gate)"
+    )
+
+
+@pytest.mark.parametrize("callsign", CALLSIGNS)
+def test_unit_has_after_openclaw(callsign: str) -> None:
+    unit = SYSTEMD_DIR / f"{callsign}-agent.service"
+    text = unit.read_text()
+    after_lines = [line for line in text.splitlines() if line.startswith("After=")]
+    assert any("openclaw.service" in line for line in after_lines), (
+        f"{unit.name}: no 'After=' line lists openclaw.service "
+        f"(KEI-95 start-ordering gate). Found After= lines: {after_lines}"
+    )
+
+
+@pytest.mark.parametrize("callsign", CALLSIGNS)
+def test_unit_orders_network_before_openclaw(callsign: str) -> None:
+    """Verify network-online.target is listed before openclaw on the After= line.
+    OpenClaw makes Slack API calls on startup, so it needs the network up first.
+    """
+    unit = SYSTEMD_DIR / f"{callsign}-agent.service"
+    text = unit.read_text()
+    after_line = next(
+        (
+            line
+            for line in text.splitlines()
+            if line.startswith("After=") and "openclaw.service" in line
+        ),
+        None,
+    )
+    assert after_line is not None, f"{unit.name}: no After= line containing openclaw.service"
+    targets = after_line.removeprefix("After=").split()
+    assert "network-online.target" in targets, (
+        f"{unit.name}: After= line missing network-online.target: {after_line}"
+    )
+    assert targets.index("network-online.target") < targets.index("openclaw.service"), (
+        f"{unit.name}: After= must order network-online.target before openclaw.service: {after_line}"
+    )
+
+
+def test_linger_runbook_references_loginctl() -> None:
+    """KEI-95 step 3: docs must instruct operators to enable linger.
+    Belt + braces — the runbook check that the operator runs
+    `loginctl enable-linger elliotbot` on a new host.
+    """
+    doc = REPO_ROOT / "docs" / "operations" / "agent-systemd-recovery.md"
+    assert doc.exists(), f"{doc} missing — recovery runbook must exist"
+    text = doc.read_text()
+    assert "loginctl enable-linger elliotbot" in text, (
+        "agent-systemd-recovery.md must document `loginctl enable-linger elliotbot` (KEI-95 step 3)"
+    )


### PR DESCRIPTION
## Summary

Closes [KEI-95](https://linear.app/keiracom/issue/KEI-81) (bd: `Agency_OS-242uos`) — Model A fix while Dispatcher builds. Adds `Requires=openclaw.service` + ordered `After=network-online.target openclaw.service` to all 7 per-callsign agent `.service` units, so agents do not start before the OpenClaw relay is healthy. Stops the silent-deaf-agent failure on cold boot.

**Linear:** [KEI-95](https://linear.app/keiracom/issue/KEI-81) · **Off:** `origin/main` · **STEP 0 PRE-CONFIRMED** by Elliot dispatch

## What lands (8 file edits, 1 new test file)

| File | Change |
|---|---|
| `infra/systemd/agents/{atlas,aiden,elliot,max,nova,orion,scout}-agent.service` × 7 | `+Requires=openclaw.service`; extend `After=` to include `openclaw.service` after `network-online.target` |
| `docs/operations/agent-systemd-recovery.md` | New section "OpenClaw relay dependency (KEI-95)" — two operator conditions (linger on + openclaw enabled/active) + inactive-waiting behaviour note |
| `tests/infra/test_agent_service_units_kei95.py` | **New.** 22 parametrised regression tests (3 × 7 callsigns + 1 runbook check) |

## Verbatim verify

```
$ pytest -q tests/infra/test_agent_service_units_kei95.py
......................                                                   [100%]
22 passed in 0.09s

$ ruff check tests/infra/test_agent_service_units_kei95.py
All checks passed!
$ ruff format --check tests/infra/test_agent_service_units_kei95.py
1 file already formatted

$ pytest -q tests/infra/test_agent_service_units_kei95.py tests/orchestrator/test_install_systemd_units.py
30 passed in 0.20s
```

## Negative-path test coverage

Per [[feedback_negative_path_test_before_approve]]:
- `test_unit_orders_network_before_openclaw` — fails if any unit lists openclaw BEFORE network-online (Slack API calls need network up first)
- All three test families are parametrised across 7 callsigns; drop a directive from any one unit and the corresponding case fails loudly

## State on this host (Vultr, where the PR will deploy)

```
$ systemctl --user is-active openclaw.service       # active
$ loginctl show-user elliotbot | grep Linger        # Linger=yes
```

Both operator conditions for the dependency to work are already in place. The post-merge step is just to copy the updated unit files + `daemon-reload` + restart agents. **Reboot test (acceptance criterion #3-#6) is Dave-gated** — that's the operator decision after this PR merges and units propagate.

## Acceptance map

| Criterion | Status |
|---|---|
| All 7 agent service files updated with `Requires=openclaw` + `After=openclaw` | DONE (verified by parametrised pytest) |
| `loginctl enable-linger elliotbot` confirmed active | DONE — `Linger=yes` on host; runbook documents the requirement |
| Server reboot test (all 7 post `[SYSTEM]`, Elliot posts fleet status <60s) | DEFERRED — Dave-gated; runbook documents the verify steps |
| Inbound relay confirmed post-reboot | DEFERRED — operator step |
| Verbatim `tmux ls` after reboot | DEFERRED — operator step |

## Out of scope (follow-up)

- The runbook still references 6 agents in the "What this gives you" table; nova (KEI-185) was added later. Updating the table is a doc-hygiene follow-up, not part of KEI-95.
- `scripts/install_*_agent.sh` only exists for nova currently; remaining 6 install scripts as a separate KEI if Dave wants them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)