### PR TITLE
[ORION] fix(kei94): agent_keepalive.sh — in-pane respawn loop so tmux survives Claude exits

### DIFF
--- a/scripts/agent_keepalive.sh
+++ b/scripts/agent_keepalive.sh
@@ -51,7 +51,14 @@ if ! command -v tmux >/dev/null 2>&1; then
     exit 2
 fi
 
-claude_cmd="export CALLSIGN='$callsign' && cd '$worktree' && exec claude --dangerously-skip-permissions"
+# KEI-94 — in-pane respawn loop. The pane process is a `while true` shell;
+# claude runs as its child. When claude exits (clean shutdown, /clear path,
+# OOM, crash) the shell loops back, sleeps a moment to avoid a busy spawn
+# storm if claude crashes immediately, then re-spawns claude in the same
+# pane. The tmux session survives Claude exits — no full unit restart
+# needed. systemd's Restart=always remains the outer safety net for cases
+# where the wrapper itself dies.
+claude_cmd="export CALLSIGN='$callsign' && cd '$worktree' && while true; do claude --dangerously-skip-permissions; echo \"[keepalive] claude exited at \$(date -u +%FT%TZ), respawning in 2s\" >&2; sleep 2; done"
 
 if [[ -n "${KEEPALIVE_DRY:-}" ]]; then
     echo "[keepalive] would: tmux new-session -d -s '$session' -c '$worktree'"
@@ -101,18 +108,31 @@ else
     echo "[keepalive] tmux session=$session already alive — attaching watcher"
 fi
 
-# KEI-140 defense-in-depth: poll loop verifies the pane leader is `claude`,
-# not a stranded shell prompt. If claude failed to exec cleanly, send-keys
-# again. Cheap to check — one tmux + one /proc read per `poll_seconds`.
+# KEI-94 defense-in-depth: poll loop verifies that `claude` (or its in-pane
+# respawn-loop shell) is alive inside the pane's process tree. The pane leader
+# under the KEI-94 loop is bash (the `while true` wrapper); claude is bash's
+# child. So we walk children of the pane leader and look for claude. If no
+# claude child exists AND the pane leader itself isn't bash-running-the-loop
+# (i.e. the pane has been hijacked by a stranded shell prompt), re-issue the
+# claude_cmd via send-keys to recover. Cheap: one tmux + one pgrep per
+# `poll_seconds`.
 _pane_running_claude() {
     local pane_pid
     pane_pid=$(tmux list-panes -t "$session" -F '#{pane_pid}' 2>/dev/null | head -1 || true)
     [[ -n "$pane_pid" ]] || return 1
     [[ -d "/proc/$pane_pid" ]] || return 1
-    if [[ -r "/proc/$pane_pid/comm" ]]; then
-        grep -q claude "/proc/$pane_pid/comm" 2>/dev/null || return 1
+    # Walk the process tree under the pane leader. If claude appears anywhere,
+    # we're healthy. (Looking at pane leader alone would miss the KEI-94
+    # bash-loop-wrapping-claude topology.)
+    if pgrep -f -P "$pane_pid" claude >/dev/null 2>&1; then
+        return 0
     fi
-    return 0
+    # Pane leader itself running claude (legacy `exec claude` topology) also
+    # counts as healthy — supports gradual rollout.
+    if [[ -r "/proc/$pane_pid/comm" ]] && grep -q claude "/proc/$pane_pid/comm" 2>/dev/null; then
+        return 0
+    fi
+    return 1
 }
 
 # KEI-125: signal systemd we're ready (Type=notify requires this) + start

--- a/tests/scripts/test_agent_keepalive_kei94.py
+++ b/tests/scripts/test_agent_keepalive_kei94.py
@@ -1,0 +1,188 @@
+"""KEI-94 — agent_keepalive.sh: tmux survives Claude exits via in-pane respawn loop.
+
+Dispatch (Elliot 2026-05-18): "Claude Code exits on boot, destroying tmux
+sessions. Fix: Restart=always + keep-alive wrapper in each *-agent.service.
+Acceptance: agent service Restart=always; wrapper script keeps tmux alive
+across Claude exits. Test: kill Claude in tmux, verify wrapper respawns."
+
+Coverage:
+  - DRY mode emits the in-pane `while true` respawn loop (not `exec claude`)
+  - Required components present: CALLSIGN export, worktree cd, claude invocation,
+    sleep between respawns, log line on exit
+  - Bash syntax valid
+  - Missing-arg / missing-worktree rejection
+  - Integration smoke: real tmux pane survives inner-command exit and respawns
+
+The integration test substitutes `claude` with a stub via a PATH shim, so it
+exercises the loop without touching the real Claude binary.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "agent_keepalive.sh"
+
+
+# ---------------------------------------------------------------------------
+# DRY-mode unit tests — no real tmux / no real claude
+# ---------------------------------------------------------------------------
+
+
+def _dry_run(callsign: str, worktree: Path, session: str = "test-session") -> str:
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), session, callsign, str(worktree)],
+        env={**os.environ, "KEEPALIVE_DRY": "1"},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0, f"DRY exit {proc.returncode}: {proc.stderr}"
+    return proc.stdout
+
+
+def test_dry_run_emits_in_pane_respawn_loop(tmp_path: Path) -> None:
+    out = _dry_run("orion", tmp_path)
+    # Must NOT be the legacy `exec claude` form — `exec` makes claude REPLACE
+    # the shell, so when claude exits the pane process exits and tmux session
+    # dies. The KEI-94 fix wraps claude in `while true` so the shell survives.
+    assert "exec claude" not in out, "regression: legacy `exec claude` reintroduced"
+    assert "while true" in out, "in-pane respawn loop missing"
+    assert "claude --dangerously-skip-permissions" in out
+    assert "sleep 2" in out, "respawn backoff missing — could busy-spin on immediate-crash"
+    assert "claude exited" in out, "exit log line missing — observability"
+
+
+def test_dry_run_emits_callsign_export(tmp_path: Path) -> None:
+    out = _dry_run("aiden", tmp_path)
+    assert "export CALLSIGN='aiden'" in out, "callsign export missing — worktree mis-tag risk"
+
+
+def test_dry_run_emits_worktree_cd(tmp_path: Path) -> None:
+    out = _dry_run("scout", tmp_path)
+    assert f"cd '{tmp_path}'" in out, "worktree cd missing — wrong-dir spawn"
+
+
+def test_dry_run_rejects_missing_worktree() -> None:
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), "s", "cs", "/no/such/path"],
+        env={**os.environ, "KEEPALIVE_DRY": "1"},
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert proc.returncode == 2
+    assert "worktree missing" in proc.stderr
+
+
+def test_dry_run_rejects_missing_args(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env={**os.environ, "KEEPALIVE_DRY": "1"},
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert proc.returncode != 0
+
+
+def test_script_syntax_is_valid() -> None:
+    proc = subprocess.run(["bash", "-n", str(SCRIPT)], capture_output=True, text=True, timeout=5)
+    assert proc.returncode == 0, proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# Integration: real tmux pane survives inner-command exit + respawn
+# ---------------------------------------------------------------------------
+
+
+pytestmark_no_tmux = pytest.mark.skipif(
+    shutil.which("tmux") is None, reason="tmux not available on this host"
+)
+
+
+@pytestmark_no_tmux
+def test_real_tmux_in_pane_respawn_after_inner_exit(tmp_path: Path) -> None:
+    """Spawn a tmux session running the same in-pane loop the wrapper emits,
+    but with `claude` substituted by a tick-writer stub. The stub writes a
+    timestamped line to a file then exits. After waiting for two iterations
+    of the loop we expect ≥2 stub invocations recorded — proving the bash
+    loop respawns the inner command in the same pane (tmux session survives).
+    """
+    session = f"kei94-it-{os.getpid()}"
+    tick_file = tmp_path / "ticks.log"
+    # Stub: append one timestamped line then exit. Mimics claude exiting.
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    stub = stub_dir / "claude"
+    stub.write_text(f'#!/usr/bin/env bash\necho "tick $(date -u +%s%N)" >> "{tick_file}"\nexit 0\n')
+    stub.chmod(0o755)
+
+    # Build the exact loop shape the wrapper emits, but with the stub on PATH.
+    # Note: double-quote the PATH assignment so bash inside tmux expands $PATH;
+    # single quotes would assign the literal string and the stub wouldn't be
+    # findable.
+    loop_cmd = (
+        f'export PATH="{stub_dir}:$PATH" && '
+        f"while true; do claude --dangerously-skip-permissions; "
+        f'echo "[keepalive] claude exited at $(date -u +%FT%TZ), respawning in 2s" >&2; '
+        f"sleep 2; done"
+    )
+
+    try:
+        subprocess.run(
+            ["tmux", "new-session", "-d", "-s", session, "-c", str(tmp_path)],
+            check=True,
+            timeout=5,
+        )
+        subprocess.run(
+            ["tmux", "send-keys", "-t", session, loop_cmd, "Enter"],
+            check=True,
+            timeout=5,
+        )
+        # Loop iteration takes ~2s (sleep) + stub runtime (~ms). Wait for
+        # at least three ticks to land — confidently proves the loop is
+        # respawning, not a one-shot.
+        deadline = time.time() + 10
+        ticks: list[str] = []
+        while time.time() < deadline:
+            if tick_file.exists():
+                ticks = tick_file.read_text().splitlines()
+                if len(ticks) >= 3:
+                    break
+            time.sleep(0.2)
+
+        # tmux session must still be alive — that's the core acceptance.
+        sess_check = subprocess.run(
+            ["tmux", "has-session", "-t", session],
+            capture_output=True,
+            timeout=5,
+        )
+        assert sess_check.returncode == 0, (
+            "tmux session died — wrapper failed to keep tmux alive across claude exits"
+        )
+
+        # And the inner stub must have been respawned at least 3x — proves
+        # the bash loop is doing its job (not just one execution then idle).
+        assert len(ticks) >= 3, (
+            f"stub ran {len(ticks)} times; expected ≥3. tmux session is alive "
+            f"but the loop isn't respawning — regression to `exec` or first-exit-bails"
+        )
+
+        # Sanity: timestamps are strictly increasing (no duplicate-line race).
+        ns_values = [int(re.search(r"tick (\d+)", t).group(1)) for t in ticks]  # type: ignore[union-attr]
+        assert ns_values == sorted(ns_values)
+    finally:
+        subprocess.run(
+            ["tmux", "kill-session", "-t", session],
+            capture_output=True,
+            timeout=5,
+        )


### PR DESCRIPTION
## Summary
- `agent_keepalive.sh` used `exec claude …`, which made claude REPLACE the wrapping shell. When claude exited, the pane process exited → tmux session died → keepalive bailed → systemd respawned the WHOLE unit. Slow, visible recovery for what should be a transparent re-invocation.
- Wrap claude in `while true; do claude …; sleep 2; done` so the pane process is the bash loop; claude is its child; tmux session survives Claude exits.
- `Restart=always` already in place on all 7 `*-agent.service` files (audited; no service changes needed).

## Diff
- `scripts/agent_keepalive.sh`:
  - Replace `exec claude --dangerously-skip-permissions` with `while true; … sleep 2; done`
  - Update `_pane_running_claude` to walk children of pane leader (`pgrep -P`) since pane leader is now bash. Legacy `exec claude` topology still recognised as healthy for gradual rollout.
- KEI-140 SIGTERM trap is unchanged — killing pane leader (bash) still cascades SIGHUP to claude, so `systemctl restart` semantics are preserved.

## Tests — `tests/scripts/test_agent_keepalive_kei94.py`
```
$ python3 -m pytest tests/scripts/test_agent_keepalive_kei94.py -v
============================== 7 passed in 4.36s ===============================
```
```
$ ruff check tests/scripts/test_agent_keepalive_kei94.py
All checks passed!
$ ruff format --check tests/scripts/test_agent_keepalive_kei94.py
1 file already formatted
```

Coverage:
- DRY mode emits the `while true` respawn loop + claude invocation + `sleep 2` backoff + exit log line (regression-guards against re-introducing `exec claude`)
- CALLSIGN export + worktree cd present in DRY output
- Bash syntax valid (`bash -n`)
- Missing-arg / missing-worktree paths exit non-zero
- Real-tmux integration: spawn a pane with a stub `claude` that exits 0 immediately, wait 10s, assert tmux session is still alive AND the stub ran **≥3 times** — proves the bash loop respawns in-pane (matches Dave's acceptance "kill Claude in tmux, verify wrapper respawns"). Skipped gracefully if tmux isn't installed.

## Audit — Restart=always present on every agent service
```
$ grep -H "^Restart=" infra/systemd/agents/*-agent.service
infra/systemd/agents/elliot-agent.service:Restart=always
infra/systemd/agents/aiden-agent.service:Restart=always
infra/systemd/agents/max-agent.service:Restart=always
infra/systemd/agents/orion-agent.service:Restart=always
infra/systemd/agents/scout-agent.service:Restart=always
infra/systemd/agents/nova-agent.service:Restart=always
infra/systemd/agents/atlas-agent.service:Restart=always
```

## Source
- Dispatch from Elliot 2026-05-18 — STEP 0 PRE-CONFIRMED
- Linear: https://linear.app/keiracom/issue/KEI-223 (tracks KEI-94)

🤖 Generated with [Claude Code](https://claude.com/claude-code)