### PR TITLE
[MAX] feat(kei79): bd resolve — flip awaiting decision + restore task active state

### DIFF
--- a/scripts/bd
+++ b/scripts/bd
@@ -99,6 +99,11 @@ case "$subcmd" in
         # Writes ceo_decisions row + flips task to status=escalated + posts to #ceo.
         exec env PYTHONPATH="$AGENCY_OS_REPO${PYTHONPATH:+:$PYTHONPATH}" python3 "$AGENCY_OS_REPO/scripts/bd_escalate.py" "$@"
         ;;
+    resolve)
+        # KEI-79 — `bd resolve --task <id> --pick <option> [--outcome <text>]`
+        # Flips ceo_decisions row to resolved + UPDATE tasks SET status='active'.
+        exec env PYTHONPATH="$AGENCY_OS_REPO${PYTHONPATH:+:$PYTHONPATH}" python3 "$AGENCY_OS_REPO/scripts/bd_resolve.py" "$@"
+        ;;
     fleet-check)
         # KEI-94 + KEI-97 — `bd fleet-check [--no-post] [--channel ceo|execution]`
         # Captures last 10 lines from each agent tmux pane and posts a bullet

--- a/scripts/bd_resolve.py
+++ b/scripts/bd_resolve.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""bd_resolve.py — KEI-79 CLI for resolving an awaiting ceo_decisions row.
+
+Flips an awaiting escalation to resolved and restores the task to active so
+the original claimant can resume.  Two-write transaction, fail-open Slack
+notification after commit.
+
+Usage:
+    bd resolve --task <id> --pick <option> [--outcome <text>] [--callsign <c>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Helpers (shared pattern — mirrors bd_escalate.py)
+# ---------------------------------------------------------------------------
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL or SUPABASE_DB_URL must be set")
+    return dsn.replace("+asyncpg", "")
+
+
+def _callsign(override: str | None = None) -> str:
+    if override:
+        return override
+    return os.environ.get("CALLSIGN") or os.environ.get("TASKS_CALLSIGN") or "dave"
+
+
+def _sanitize(value: str) -> str:
+    """Strip newlines/CRs from user-supplied strings before logging (S5145)."""
+    return value.replace("\n", " ").replace("\r", " ") if value else value
+
+
+# ---------------------------------------------------------------------------
+# Core logic — extracted for testability (S3776: keeps main() shallow)
+# ---------------------------------------------------------------------------
+
+
+def fetch_awaiting_decision(cur: object, task_id: str) -> tuple[str, list[str]]:
+    """Return (decision_id, options) for the most-recent awaiting row.
+
+    Raises SystemExit(2) with a human-readable message when none exists.
+    """
+    cur.execute(  # type: ignore[attr-defined]
+        "SELECT id, options FROM public.ceo_decisions "
+        "WHERE task_id=%s AND status='awaiting' "
+        "ORDER BY requested_at DESC LIMIT 1",
+        (task_id,),
+    )
+    row = cur.fetchone()  # type: ignore[attr-defined]
+    if row is None:
+        print(f"no awaiting decision for task {task_id}", file=sys.stderr)
+        raise SystemExit(2)
+    decision_id: str = str(row[0])
+    options: list[str] = list(row[1]) if row[1] else []
+    return decision_id, options
+
+
+def validate_pick(pick: str, options: list[str], task_id: str) -> None:
+    """Exit 2 if pick is not in the declared options list."""
+    if options and pick not in options:
+        formatted = ", ".join(options)
+        print(f"pick '{pick}' not in options [{formatted}]", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def apply_resolve(
+    cur: object,
+    decision_id: str,
+    task_id: str,
+    pick: str,
+    outcome: str | None,
+    resolved_by: str,
+) -> None:
+    """Write both UPDATE statements inside the caller's transaction."""
+    cur.execute(  # type: ignore[attr-defined]
+        "UPDATE public.ceo_decisions "
+        "SET status='resolved', dave_choice=%s, decision_outcome=%s, "
+        "    resolved_by=%s, resolved_at=NOW(), updated_at=NOW() "
+        "WHERE id=%s",
+        (pick, outcome, resolved_by, decision_id),
+    )
+    # WHERE status='escalated' guards against double-applying on a task that
+    # was manually unstuck — fail-soft policy: ceo_decisions still resolved
+    # but tasks row untouched.
+    cur.execute(  # type: ignore[attr-defined]
+        "UPDATE public.tasks "
+        "SET status='active', updated_at=NOW() "
+        "WHERE id=%s AND status='escalated'",
+        (task_id,),
+    )
+
+
+def _build_ceo_text(resolved_by: str, task_id: str, pick: str, outcome: str | None) -> str:
+    lines = [
+        f"*[RESOLVED:{resolved_by}]* {task_id}",
+        f"  - Decision: {pick}",
+    ]
+    if outcome:
+        lines.append(f"  - Outcome: {outcome}")
+    lines.append("  - Task restored to active — claimant can resume.")
+    return "\n".join(lines)
+
+
+def _post_resolution(resolved_by: str, task_id: str, pick: str, outcome: str | None) -> None:
+    """Best-effort #ceo notification — never raises."""
+    try:
+        from src.slack_bot.direct_post import post_to_ceo
+
+        text = _build_ceo_text(resolved_by, task_id, pick, outcome)
+        post_to_ceo(text)
+    except Exception as exc:  # noqa: BLE001
+        print(f"warn: ceo post failed: {exc}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def resolve(args: argparse.Namespace) -> int:
+    import psycopg
+
+    resolved_by = _callsign(args.callsign)
+    task_id: str = args.task
+    pick: str = args.pick
+    outcome: str | None = args.outcome
+
+    try:
+        with psycopg.connect(_dsn(), prepare_threshold=None, autocommit=False) as conn:
+            with conn.cursor() as cur:
+                decision_id, options = fetch_awaiting_decision(cur, task_id)
+                validate_pick(pick, options, task_id)
+                apply_resolve(cur, decision_id, task_id, pick, outcome, resolved_by)
+            conn.commit()
+    except SystemExit:
+        raise
+    except Exception as exc:
+        print(f"error: transaction failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "task_id": _sanitize(task_id),
+                "pick": _sanitize(pick),
+                "resolved_by": _sanitize(resolved_by),
+                "outcome": _sanitize(outcome) if outcome else None,
+            }
+        )
+    )
+
+    try:
+        _post_resolution(resolved_by, task_id, pick, outcome)
+    except Exception as exc:  # noqa: BLE001
+        print(f"warn: ceo post failed: {exc}", file=sys.stderr)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="bd resolve")
+    p.add_argument("--task", required=True, help="task ID (e.g. KEI-79)")
+    p.add_argument("--pick", required=True, help="option value that matches ceo_decisions.options")
+    p.add_argument("--outcome", default=None, help="free-text decision outcome (optional)")
+    p.add_argument("--callsign", default=None, help="override resolved_by (default: CALLSIGN env)")
+    args = p.parse_args(argv)
+    return resolve(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bd_resolve.py
+++ b/scripts/bd_resolve.py
@@ -68,7 +68,10 @@ def validate_pick(pick: str, options: list[str], task_id: str) -> None:
     """Exit 2 if pick is not in the declared options list."""
     if options and pick not in options:
         formatted = ", ".join(options)
-        print(f"pick '{pick}' not in options [{formatted}]", file=sys.stderr)
+        print(
+            f"pick '{pick}' not in options [{formatted}] for task {task_id}",
+            file=sys.stderr,
+        )
         raise SystemExit(2)
 
 

--- a/tests/scripts/test_bd_resolve.py
+++ b/tests/scripts/test_bd_resolve.py
@@ -296,11 +296,10 @@ def test_slack_failure_warn_to_stderr(monkeypatch: Any, capsys: Any) -> None:
     monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
 
     # Patch _post_resolution to raise — resolve() must swallow and warn
-    monkeypatch.setattr(
-        bd_resolve,
-        "_post_resolution",
-        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("rate limit")),
-    )
+    def _raise_rate_limit(*_a: Any, **_k: Any) -> None:
+        raise RuntimeError("rate limit")
+
+    monkeypatch.setattr(bd_resolve, "_post_resolution", _raise_rate_limit)
     result = bd_resolve.resolve(_make_args(pick="A"))
     assert result == 0
     assert "warn: ceo post failed" in capsys.readouterr().err

--- a/tests/scripts/test_bd_resolve.py
+++ b/tests/scripts/test_bd_resolve.py
@@ -1,0 +1,348 @@
+"""KEI-79 — behavioural tests for bd resolve (flip awaiting → resolved + restore task active).
+
+Test matrix:
+  - happy path: awaiting decision + valid pick → resolved, task active, exit 0
+  - negative: no awaiting decision → exit 2, "no awaiting decision" in stderr
+  - negative: pick not in options → exit 2, "not in options" in stderr
+  - fail-soft: task not in 'escalated' state → ceo_decisions resolved, task WHERE guard no-ops
+  - slack failure: post_to_ceo raises → still exit 0 (fail-open)
+  - transaction atomicity: if apply_resolve raises mid-way, tasks UPDATE rolls back
+  - helper unit tests: _sanitize, _callsign, _build_ceo_text, _dsn
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import bd_resolve  # noqa: E402
+from tests.scripts._db_mocks import FakeConn, FakeCursor, make_patch_connect  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patch_connect(monkeypatch: Any) -> Any:
+    return make_patch_connect(monkeypatch)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pure helpers (no psycopg)
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_strips_newlines() -> None:
+    assert bd_resolve._sanitize("foo\nbar\rbaz") == "foo bar baz"
+
+
+def test_sanitize_empty_string() -> None:
+    assert bd_resolve._sanitize("") == ""
+
+
+def test_callsign_explicit_override() -> None:
+    assert bd_resolve._callsign("max") == "max"
+
+
+def test_callsign_env_fallback(monkeypatch: Any) -> None:
+    monkeypatch.delenv("CALLSIGN", raising=False)
+    monkeypatch.delenv("TASKS_CALLSIGN", raising=False)
+    assert bd_resolve._callsign() == "dave"
+    monkeypatch.setenv("TASKS_CALLSIGN", "scout")
+    assert bd_resolve._callsign() == "scout"
+    monkeypatch.setenv("CALLSIGN", "elliot")
+    assert bd_resolve._callsign() == "elliot"
+
+
+def test_build_ceo_text_no_outcome() -> None:
+    text = bd_resolve._build_ceo_text("dave", "KEI-79", "A", None)
+    assert "[RESOLVED:dave]" in text
+    assert "KEI-79" in text
+    assert "Decision: A" in text
+    assert "Outcome" not in text
+
+
+def test_build_ceo_text_with_outcome() -> None:
+    text = bd_resolve._build_ceo_text("dave", "KEI-79", "B", "use option B")
+    assert "Outcome: use option B" in text
+
+
+def test_dsn_strips_asyncpg(monkeypatch: Any) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://host/db")
+    assert "+asyncpg" not in bd_resolve._dsn()
+
+
+def test_dsn_raises_when_unset(monkeypatch: Any) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    with pytest.raises(RuntimeError):
+        bd_resolve._dsn()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — fetch_awaiting_decision
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_awaiting_decision_returns_id_and_options() -> None:
+    cur = FakeCursor(fetchone_row=("uuid-abc", ["Retry", "Abort"]))
+    decision_id, options = bd_resolve.fetch_awaiting_decision(cur, "KEI-79")
+    assert decision_id == "uuid-abc"
+    assert options == ["Retry", "Abort"]
+
+
+def test_fetch_awaiting_decision_no_row_exits_2() -> None:
+    cur = FakeCursor(fetchone_row=None)
+    with pytest.raises(SystemExit) as exc_info:
+        bd_resolve.fetch_awaiting_decision(cur, "KEI-79")
+    assert exc_info.value.code == 2
+
+
+def test_fetch_awaiting_decision_none_options_returns_empty_list() -> None:
+    cur = FakeCursor(fetchone_row=("uuid-xyz", None))
+    _, options = bd_resolve.fetch_awaiting_decision(cur, "KEI-79")
+    assert options == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — validate_pick
+# ---------------------------------------------------------------------------
+
+
+def test_validate_pick_in_options_passes() -> None:
+    bd_resolve.validate_pick("Retry", ["Retry", "Abort"], "KEI-79")  # no exception
+
+
+def test_validate_pick_not_in_options_exits_2(capsys: Any) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        bd_resolve.validate_pick("Unknown", ["Retry", "Abort"], "KEI-79")
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "not in options" in captured.err
+
+
+def test_validate_pick_empty_options_passes() -> None:
+    # When no options declared, any pick is valid (free-form decision).
+    bd_resolve.validate_pick("anything", [], "KEI-79")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — apply_resolve SQL shapes
+# ---------------------------------------------------------------------------
+
+
+def test_apply_resolve_writes_correct_sql() -> None:
+    cur = FakeCursor()
+    bd_resolve.apply_resolve(cur, "dec-1", "KEI-79", "Retry", "go again", "dave")
+
+    assert len(cur.executed) == 2
+    # First UPDATE: ceo_decisions
+    sql0, params0 = cur.executed[0]
+    assert "ceo_decisions" in sql0
+    assert "status='resolved'" in sql0
+    assert params0 == ("Retry", "go again", "dave", "dec-1")
+    # Second UPDATE: tasks
+    sql1, params1 = cur.executed[1]
+    assert "public.tasks" in sql1
+    assert "status='active'" in sql1
+    assert "status='escalated'" in sql1  # WHERE guard
+    assert params1 == ("KEI-79",)
+
+
+def test_apply_resolve_null_outcome() -> None:
+    cur = FakeCursor()
+    bd_resolve.apply_resolve(cur, "dec-1", "KEI-79", "A", None, "dave")
+    _, params0 = cur.executed[0]
+    assert params0[1] is None  # decision_outcome
+
+
+# ---------------------------------------------------------------------------
+# Integration — resolve() function via monkeypatched psycopg
+# ---------------------------------------------------------------------------
+
+
+def _make_args(
+    task: str = "KEI-79",
+    pick: str = "Retry",
+    outcome: str | None = None,
+    callsign: str | None = None,
+) -> types.SimpleNamespace:
+    return types.SimpleNamespace(task=task, pick=pick, outcome=outcome, callsign=callsign)
+
+
+def test_happy_path_exits_0(monkeypatch: Any, capsys: Any) -> None:
+    """awaiting decision + valid pick → resolved, exit 0, JSON stdout."""
+    cur = FakeCursor(fetchone_row=("dec-uuid", ["Retry", "Abort"]))
+    conn = FakeConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+    monkeypatch.setattr(bd_resolve, "_post_resolution", lambda *a, **k: None)
+
+    result = bd_resolve.resolve(_make_args(pick="Retry"))
+    assert result == 0
+    assert conn.commits == 1
+
+    out = capsys.readouterr().out
+    data = __import__("json").loads(out)
+    assert data["task_id"] == "KEI-79"
+    assert data["pick"] == "Retry"
+
+
+def test_no_awaiting_decision_exits_2(monkeypatch: Any) -> None:
+    """When no awaiting row exists, exit 2."""
+    cur = FakeCursor(fetchone_row=None)
+    conn = FakeConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+
+    with pytest.raises(SystemExit) as exc_info:
+        bd_resolve.resolve(_make_args())
+    assert exc_info.value.code == 2
+
+
+def test_no_awaiting_decision_stderr_message(monkeypatch: Any, capsys: Any) -> None:
+    cur = FakeCursor(fetchone_row=None)
+    conn = FakeConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+
+    with pytest.raises(SystemExit):
+        bd_resolve.resolve(_make_args())
+    assert "no awaiting decision" in capsys.readouterr().err
+
+
+def test_pick_not_in_options_exits_2(monkeypatch: Any, capsys: Any) -> None:
+    """Pick value not in declared options → exit 2, 'not in options' in stderr."""
+    cur = FakeCursor(fetchone_row=("dec-uuid", ["Retry", "Abort"]))
+    conn = FakeConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+
+    with pytest.raises(SystemExit) as exc_info:
+        bd_resolve.resolve(_make_args(pick="UnknownOption"))
+    assert exc_info.value.code == 2
+    assert "not in options" in capsys.readouterr().err
+
+
+def test_task_not_escalated_fails_soft(monkeypatch: Any) -> None:
+    """Policy: if task is NOT in 'escalated' state the WHERE guard on tasks
+    UPDATE silently no-ops — ceo_decisions still resolved (commit still
+    happens). Simulated by the cursor being correctly formed; the WHERE guard
+    is enforced by the DB not by Python, so we just assert commit still fires.
+    """
+    cur = FakeCursor(fetchone_row=("dec-uuid", ["A", "B"]))
+    conn = FakeConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+    monkeypatch.setattr(bd_resolve, "_post_resolution", lambda *a, **k: None)
+
+    result = bd_resolve.resolve(_make_args(pick="A"))
+    assert result == 0
+    assert conn.commits == 1
+    # Both SQL statements were still sent (guard is in SQL WHERE, not Python)
+    assert any("public.tasks" in sql for sql, _ in cur.executed)
+
+
+def test_slack_failure_still_exits_0(monkeypatch: Any) -> None:
+    """If post_to_ceo raises, resolve must still exit 0 (fail-open)."""
+    cur = FakeCursor(fetchone_row=("dec-uuid", ["A"]))
+    conn = FakeConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+
+    def boom(*a: Any, **k: Any) -> None:
+        raise RuntimeError("slack 503")
+
+    monkeypatch.setattr(bd_resolve, "_post_resolution", boom)
+
+    result = bd_resolve.resolve(_make_args(pick="A"))
+    assert result == 0
+
+
+def test_slack_failure_warn_to_stderr(monkeypatch: Any, capsys: Any) -> None:
+    """Slack failure prints 'warn: ceo post failed:' to stderr, exit 0."""
+    cur = FakeCursor(fetchone_row=("dec-uuid", ["A"]))
+    conn = FakeConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+
+    # Patch _post_resolution to raise — resolve() must swallow and warn
+    monkeypatch.setattr(
+        bd_resolve,
+        "_post_resolution",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("rate limit")),
+    )
+    result = bd_resolve.resolve(_make_args(pick="A"))
+    assert result == 0
+    assert "warn: ceo post failed" in capsys.readouterr().err
+
+
+def test_transaction_atomicity_on_exception(monkeypatch: Any) -> None:
+    """If apply_resolve raises mid-transaction, rollback fires and exit is 1.
+
+    We simulate this by making the cursor's second execute() raise; a real
+    psycopg conn would rollback on __exit__. FakeConn doesn't auto-rollback
+    but we track commits — zero commits means the write never landed.
+    """
+
+    class ExplodingCursor(FakeCursor):
+        def __init__(self) -> None:
+            super().__init__(fetchone_row=("dec-uuid", ["A", "B"]))
+            self._execute_count = 0
+
+        def execute(self, sql: str, params: Any = None) -> None:
+            self._execute_count += 1
+            if self._execute_count == 2:
+                # Simulate DB error on second UPDATE (tasks)
+                raise RuntimeError("DB constraint violation")
+            super().execute(sql, params)
+
+    cur = ExplodingCursor()
+
+    class RollbackConn(FakeConn):
+        def __init__(self, c: Any) -> None:
+            super().__init__(c)
+            self.rolled_back = False
+
+        def __exit__(self, *a: Any) -> None:
+            self.rolled_back = True
+
+    conn = RollbackConn(cur)
+
+    import psycopg
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: conn)
+
+    result = bd_resolve.resolve(_make_args(pick="A"))
+    assert result == 1
+    assert conn.commits == 0  # commit never called because exception raised first


### PR DESCRIPTION
## Summary

- `bd escalate` shipped 2026-05-17 (KEI-79); `bd resolve` was missing — the only way to clear the queue was the 7-day timeout sweeper
- This PR adds the missing half: `bd resolve --task <id> --pick <option> [--outcome <text>]` flips the `ceo_decisions` row to `resolved` and restores `tasks.status='active'` in a single atomic transaction
- Fail-open Slack #ceo post after commit; Slack outage never blocks the resolve

## Files changed (3)

- `scripts/bd_resolve.py` — two-write transaction, exit-2 on no awaiting row or bad pick, S5145 log-injection sanitizer, S3776 complexity managed via helper extraction
- `scripts/bd` — `resolve` case routes to `bd_resolve.py` (same pattern as `escalate`)
- `tests/scripts/test_bd_resolve.py` — 24 tests: happy path, two negatives (no awaiting / bad pick), fail-soft task-not-escalated, Slack fail-open, transaction atomicity, all pure-helper units

## Schema

No migration needed. All required columns (`dave_choice`, `resolved_by`, `resolved_at`, `decision_outcome`) already exist in `public.ceo_decisions`.

## Test coverage

```
24 passed in 0.20s
```

Negative-path tests per `feedback_negative_path_test_before_approve`: pick-not-in-options and no-awaiting-decision both tested with exit-code and stderr assertions.

## References

KEI-79 (Agency_OS-glot7k)

Reviewers: @Aiden @Elliot

🤖 Generated with [Claude Code](https://claude.com/claude-code)