### PR TITLE
[ORION] feat(env-validation): SessionStart hook fail-fasts on critical-5 env vars

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -86,6 +86,11 @@
       {
         "hooks": [
           {
+            "command": "bash scripts/hooks/env_schema_validate.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
             "command": "/home/elliotbot/clawd/venv/bin/python3 scripts/session_start_audit.py",
             "timeout": 10,
             "type": "command"

--- a/scripts/hooks/env_schema_validate.sh
+++ b/scripts/hooks/env_schema_validate.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# env_schema_validate.sh — fail-fast guard for the 5 critical env vars
+# (Agency_OS-9erxio P1).
+#
+# Registered FIRST in the SessionStart hook chain so a misconfigured agent
+# environment surfaces with a clear, actionable error instead of failing
+# obscurely several hooks later (or, worse, succeeding through the hook
+# chain and then crashing inside Claude on the first MCP call).
+#
+# Critical-5 (per Elliot dispatch 2026-05-18):
+#   1. SUPABASE_DB_URL  OR  DATABASE_URL   (postgres DSN — either name OK)
+#   2. SLACK_BOT_TOKEN                     (inbound/outbound relay auth)
+#   3. ANTHROPIC_API_KEY                   (Claude API for sub-agents)
+#   4. OPENAI_API_KEY                      (Cognee embeddings + secondary models)
+#   5. CALLSIGN                            (identity discipline — LAW XVII)
+#
+# Behaviour:
+#   - Sources the canonical .env (path overridable via AGENCY_OS_ENV) if the
+#     env isn't already populated. Many hook chains start with a near-empty
+#     env; the .env file is the source of truth.
+#   - If any critical var is unset OR empty, print a list of missing vars +
+#     a remediation pointer to stderr, then exit 1. SessionStart treats a
+#     non-zero exit as a hook failure surfaced to the user.
+#   - Exit 0 silently when all 5 are present.
+#
+# Env (optional):
+#   AGENCY_OS_ENV — path to the .env file (default $HOME/.config/agency-os/.env)
+#   ENV_VALIDATE_DRY=1 — print which vars would be checked + exit 0 (test mode)
+#   ENV_VALIDATE_SKIP_SOURCE=1 — don't auto-source .env (test mode)
+
+set -u
+
+# `set -u` is in effect — guard $HOME so a stripped-env caller (tests, some
+# systemd contexts) doesn't trip "HOME: unbound variable".
+AGENCY_OS_ENV="${AGENCY_OS_ENV:-${HOME:-/nonexistent}/.config/agency-os/.env}"
+
+if [[ "${ENV_VALIDATE_DRY:-}" == "1" ]]; then
+    cat <<'EOF'
+env_schema_validate.sh — critical-5 vars:
+  - DATABASE_URL or SUPABASE_DB_URL
+  - SLACK_BOT_TOKEN
+  - ANTHROPIC_API_KEY
+  - OPENAI_API_KEY
+  - CALLSIGN
+EOF
+    exit 0
+fi
+
+# Auto-load .env when the calling shell hasn't already exported the critical
+# vars. SessionStart hooks tend to inherit a minimal env; the .env file is the
+# canonical source of truth for the Vultr deploy.
+if [[ "${ENV_VALIDATE_SKIP_SOURCE:-}" != "1" ]] \
+    && [[ -r "$AGENCY_OS_ENV" ]] \
+    && [[ -z "${SUPABASE_DB_URL:-}${DATABASE_URL:-}" \
+        || -z "${SLACK_BOT_TOKEN:-}" \
+        || -z "${ANTHROPIC_API_KEY:-}" \
+        || -z "${OPENAI_API_KEY:-}" \
+        || -z "${CALLSIGN:-}" ]]; then
+    # shellcheck disable=SC1090
+    set -a; source "$AGENCY_OS_ENV"; set +a
+fi
+
+missing=()
+
+# (1) Database — accept either canonical name. CALLSIGN-validated workers all
+# read DATABASE_URL; some legacy code paths still query SUPABASE_DB_URL.
+if [[ -z "${SUPABASE_DB_URL:-}" && -z "${DATABASE_URL:-}" ]]; then
+    missing+=("DATABASE_URL (or SUPABASE_DB_URL)")
+fi
+
+# (2) Slack relay token — without it tg + inbox watchers misfire silently.
+if [[ -z "${SLACK_BOT_TOKEN:-}" ]]; then
+    missing+=("SLACK_BOT_TOKEN")
+fi
+
+# (3) Anthropic — primary model auth.
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+    missing+=("ANTHROPIC_API_KEY")
+fi
+
+# (4) OpenAI — embeddings + secondary models.
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+    missing+=("OPENAI_API_KEY")
+fi
+
+# (5) Callsign — identity discipline. Worktrees that don't set CALLSIGN
+# mis-tag posts as the relay default and corrupt the audit trail.
+if [[ -z "${CALLSIGN:-}" ]]; then
+    missing+=("CALLSIGN")
+fi
+
+if (( ${#missing[@]} > 0 )); then
+    {
+        echo "ERROR: env_schema_validate.sh — ${#missing[@]} critical env var(s) missing:"
+        for v in "${missing[@]}"; do
+            echo "  - $v"
+        done
+        echo ""
+        echo "Remediation: populate $AGENCY_OS_ENV (or override AGENCY_OS_ENV)."
+        echo "             The session is blocked until the above are set."
+    } >&2
+    exit 1
+fi
+
+exit 0

--- a/tests/scripts/hooks/test_env_schema_validate.py
+++ b/tests/scripts/hooks/test_env_schema_validate.py
@@ -1,0 +1,188 @@
+"""env_schema_validate.sh — fail-fast critical-5 env vars (Agency_OS-9erxio).
+
+Dispatch (Elliot 2026-05-18): "Identify the 5 most critical env vars and add
+hook script that exits non-zero if any missing — registered in session-start
+hook chain. Acceptance: missing var blocks session start with clear error."
+
+Critical-5:
+  - DATABASE_URL or SUPABASE_DB_URL
+  - SLACK_BOT_TOKEN
+  - ANTHROPIC_API_KEY
+  - OPENAI_API_KEY
+  - CALLSIGN
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "hooks" / "env_schema_validate.sh"
+
+FULL_ENV = {
+    "DATABASE_URL": "postgresql://u:p@h:5432/db",
+    "SLACK_BOT_TOKEN": "xoxb-fake",
+    "ANTHROPIC_API_KEY": "sk-ant-fake",
+    "OPENAI_API_KEY": "sk-openai-fake",
+    "CALLSIGN": "orion",
+    "ENV_VALIDATE_SKIP_SOURCE": "1",  # tests must not depend on real .env
+    "PATH": "/usr/bin:/bin",
+}
+
+
+def _run(env_overrides: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env_overrides,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path: all 5 present
+# ---------------------------------------------------------------------------
+
+
+def test_all_five_present_exits_zero() -> None:
+    result = _run(FULL_ENV)
+    assert result.returncode == 0, (
+        f"exit={result.returncode}, stderr={result.stderr!r}, stdout={result.stdout!r}"
+    )
+    assert result.stderr == ""
+
+
+def test_supabase_db_url_substitutes_for_database_url() -> None:
+    env = dict(FULL_ENV)
+    del env["DATABASE_URL"]
+    env["SUPABASE_DB_URL"] = "postgresql://u:p@h:5432/db"
+    result = _run(env)
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Negative path: each missing var blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "drop_keys,expected_in_stderr",
+    [
+        (["DATABASE_URL"], "DATABASE_URL"),
+        (["SLACK_BOT_TOKEN"], "SLACK_BOT_TOKEN"),
+        (["ANTHROPIC_API_KEY"], "ANTHROPIC_API_KEY"),
+        (["OPENAI_API_KEY"], "OPENAI_API_KEY"),
+        (["CALLSIGN"], "CALLSIGN"),
+    ],
+)
+def test_single_missing_var_blocks(drop_keys: list[str], expected_in_stderr: str) -> None:
+    env = {k: v for k, v in FULL_ENV.items() if k not in drop_keys}
+    result = _run(env)
+    assert result.returncode == 1, (
+        f"expected exit 1 with {drop_keys} missing; got {result.returncode}"
+    )
+    assert expected_in_stderr in result.stderr, (
+        f"stderr should name the missing var: {result.stderr!r}"
+    )
+    assert "critical env var" in result.stderr
+
+
+def test_db_url_either_name_required() -> None:
+    # Drop both DB names — should fail with DATABASE_URL in the list.
+    env = {k: v for k, v in FULL_ENV.items() if k not in ("DATABASE_URL", "SUPABASE_DB_URL")}
+    result = _run(env)
+    assert result.returncode == 1
+    assert "DATABASE_URL" in result.stderr or "SUPABASE_DB_URL" in result.stderr
+
+
+def test_all_five_missing_lists_all_five() -> None:
+    env = {"PATH": "/usr/bin:/bin", "ENV_VALIDATE_SKIP_SOURCE": "1"}
+    result = _run(env)
+    assert result.returncode == 1
+    # Each critical var (or its acceptable alternative) should be named.
+    for token in (
+        "DATABASE_URL",
+        "SLACK_BOT_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "CALLSIGN",
+    ):
+        assert token in result.stderr, f"stderr should name '{token}'; got {result.stderr!r}"
+
+
+def test_empty_string_treated_as_missing() -> None:
+    # Empty-string env vars are common after a botched secret rotation and
+    # should be rejected just like unset ones.
+    env = dict(FULL_ENV)
+    env["SLACK_BOT_TOKEN"] = ""
+    result = _run(env)
+    assert result.returncode == 1
+    assert "SLACK_BOT_TOKEN" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Auto-source from .env fallback
+# ---------------------------------------------------------------------------
+
+
+def test_auto_sources_env_file_when_vars_missing(tmp_path: Path) -> None:
+    env_file = tmp_path / "agency-os.env"
+    env_file.write_text(
+        "DATABASE_URL=postgresql://from-envfile@h/db\n"
+        "SLACK_BOT_TOKEN=xoxb-from-envfile\n"
+        "ANTHROPIC_API_KEY=sk-ant-from-envfile\n"
+        "OPENAI_API_KEY=sk-openai-from-envfile\n"
+        "CALLSIGN=fromenvfile\n"
+    )
+    # Calling shell has NONE of the critical vars; helper should source the file.
+    env = {"PATH": "/usr/bin:/bin", "AGENCY_OS_ENV": str(env_file)}
+    result = _run(env)
+    assert result.returncode == 0, f"stderr={result.stderr!r}"
+
+
+# ---------------------------------------------------------------------------
+# DRY mode + script syntax
+# ---------------------------------------------------------------------------
+
+
+def test_dry_mode_lists_critical_five_and_exits_zero() -> None:
+    env = {"PATH": "/usr/bin:/bin", "ENV_VALIDATE_DRY": "1"}
+    result = _run(env)
+    assert result.returncode == 0
+    body = result.stdout
+    for token in (
+        "DATABASE_URL",
+        "SUPABASE_DB_URL",
+        "SLACK_BOT_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "CALLSIGN",
+    ):
+        assert token in body, f"DRY mode should list '{token}'; got {body!r}"
+
+
+def test_script_syntax_valid() -> None:
+    result = subprocess.run(["bash", "-n", str(SCRIPT)], capture_output=True, text=True, timeout=5)
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Hook is registered FIRST in the SessionStart chain
+# ---------------------------------------------------------------------------
+
+
+def test_hook_registered_first_in_session_start_chain() -> None:
+    settings = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text())
+    session_start = settings["hooks"]["SessionStart"]
+    # Find the "*" matcher block — the primary chain.
+    primary = next(b for b in session_start if b.get("matcher") == "*")
+    first_cmd = primary["hooks"][0]["command"]
+    assert "env_schema_validate.sh" in first_cmd, (
+        f"env_schema_validate.sh must be FIRST in the SessionStart * chain so "
+        f"misconfigured env fails fast; got {first_cmd!r}"
+    )


### PR DESCRIPTION
## Summary
- Misconfigured agent env (missing `DATABASE_URL` / `SLACK_BOT_TOKEN` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `CALLSIGN`) used to surface only when a downstream hook or the agent's first MCP call crashed. Slow, obscure recovery.
- New `scripts/hooks/env_schema_validate.sh` checks the critical-5 at session start, prints a clear remediation message naming each missing var, exits 1.
- Registered **FIRST** in the `SessionStart` `*` hook chain in `.claude/settings.json` so any miss fails fast.

## Behaviour
- Auto-sources `$AGENCY_OS_ENV` (default `$HOME/.config/agency-os/.env`) when the calling shell hasn't already exported the vars — SessionStart contexts often start with a near-empty env.
- `DATABASE_URL` OR `SUPABASE_DB_URL` satisfies the DB requirement (either canonical name accepted; legacy `SUPABASE_DB_URL` stays supported).
- Empty-string vars are treated as missing — catches botched secret rotations.
- `set -u` strict mode is safe under stripped-env callers (`$HOME` is guarded).

## Diff
- **New** `scripts/hooks/env_schema_validate.sh`
- `.claude/settings.json` `SessionStart` `*` chain — insert the new hook at index 0 (before `session_start_audit.py` etc.)
- **New** `tests/scripts/hooks/test_env_schema_validate.py` (14 tests)

## Tests
```
$ python3 -m pytest tests/scripts/hooks/test_env_schema_validate.py -v
============================== 14 passed in 0.13s ==============================
```
```
$ ruff check tests/scripts/hooks/test_env_schema_validate.py
All checks passed!
$ ruff format --check tests/scripts/hooks/test_env_schema_validate.py
1 file already formatted
$ bash -n scripts/hooks/env_schema_validate.sh
(syntax OK)
```

Coverage:
- All 5 present → exit 0 (happy path + `SUPABASE_DB_URL` substitution variant)
- Each single missing var blocks (parametrized × 5)
- Both DB names missing → blocks
- All 5 missing → all named in stderr
- Empty-string treated as missing
- Auto-source `.env` populates from file when shell is empty
- DRY mode lists vars + exits 0
- Bash syntax valid
- Hook registered **first** in `SessionStart` `*` chain (regression-guard against re-ordering)

## Real-env smoke
```
$ bash scripts/hooks/env_schema_validate.sh
$ echo $?
0
```
(production `.env` has all 5 — silent pass)

## Source
- Dispatch from Elliot 2026-05-18 — STEP 0 PRE-CONFIRMED. Beads `Agency_OS-9erxio` P1.
- Linear: https://linear.app/keiracom/issue/KEI-224

🤖 Generated with [Claude Code](https://claude.com/claude-code)