### PR TITLE
[ATLAS] feat(kei127): Docker build + push Dispatcher to Railway via GH Actions

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,0 +1,49 @@
+name: Build + push Dispatcher image to Railway
+
+# KEI-127 / bd Agency_OS-7e18dw — Model B Dispatcher container deploy.
+#
+# On every push to main that touches dispatcher source or its packaging,
+# trigger a Railway deploy. Railway server-side reads `Dockerfile.dispatcher`
+# via the `dispatcher` service entry in `railway.toml`, builds the image,
+# pushes to Railway's internal registry, and redeploys the running service.
+# Existing `agency-os` deploy in `ci.yml` is unaffected.
+#
+# Auth: existing RAILWAY_TOKEN secret (same one ci.yml uses for the API
+# deploy). No new secrets required.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile.dispatcher"
+      - "src/dispatcher/**"
+      - "railway.toml"
+      - ".github/workflows/build-push-docker.yml"
+      - "requirements.txt"
+
+permissions:
+  contents: read
+
+concurrency:
+  # One Dispatcher deploy at a time on main. New push cancels in-flight build.
+  group: dispatcher-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    name: Build + push Dispatcher to Railway
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy Dispatcher to Railway
+        run: railway up --service dispatcher --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/Dockerfile.dispatcher
+++ b/Dockerfile.dispatcher
@@ -1,0 +1,55 @@
+# Dockerfile.dispatcher — KEI-127 / bd Agency_OS-7e18dw
+#
+# Model B Dispatcher container image. Built by Railway server-side via
+# `railway up --service dispatcher` from `.github/workflows/build-push-docker.yml`
+# on every main push touching dispatcher source or this file.
+#
+# Slim image — no need for the API/Worker apt deps (gcc, libpq-dev) because
+# the dispatcher uses asyncpg (no compile) + httpx + PyJWT (transitive from
+# fastapi-users) for auth_minter. nats-py is NOT a dispatcher dep; NATS
+# message bus is consumed via the FastAPI side, not the dispatcher process.
+#
+# Entrypoint: uvicorn src.dispatcher.main:app on $PORT (Railway sets PORT).
+
+# syntax=docker/dockerfile:1.4
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# curl is required for the HEALTHCHECK below.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# === Dependencies ===
+FROM base AS dependencies
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# === Production ===
+FROM dependencies AS production
+
+# Copy the dispatcher source. Dispatcher only imports from src.dispatcher.*
+# (verified via grep on `from src.` outside its own package — single match
+# is its own auth_minter side-effect import). Copy the full src/ tree to
+# stay forward-compatible with future cross-package imports without forcing
+# a Dockerfile change.
+COPY src/ ./src/
+
+# Non-root for runtime — same convention as Dockerfile (API/Worker).
+RUN adduser --disabled-password --gecos '' dispatcher \
+    && chown -R dispatcher:dispatcher /app
+USER dispatcher
+
+# Railway sets PORT; default to 4001 (matches the Vultr systemd default).
+EXPOSE 4001
+
+# Health probe hits /dispatcher/health — populated by src.dispatcher.main.app.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:${PORT:-4001}/dispatcher/health || exit 1
+
+CMD ["sh", "-c", "uvicorn src.dispatcher.main:app --host 0.0.0.0 --port ${PORT:-4001} --log-level info"]

--- a/railway.toml
+++ b/railway.toml
@@ -50,3 +50,21 @@ startCommand = "prefect worker start --pool default --type process"
 [services.resources]
 # 4 GB ceiling — workers spawn sub-agents that each need ~512 MB.
 memoryMB = 4096
+
+# ── Service: Dispatcher (KEI-127 / KEI-213, Model B) ─────────────────────
+# Per-service builder override — uses Dockerfile.dispatcher so the
+# dispatcher image stays slim (no API/Worker apt deps) and a change to
+# either Dockerfile cannot drag the other service into a rebuild.
+[[services]]
+name = "dispatcher"
+[services.build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile.dispatcher"
+[services.deploy]
+startCommand = "uvicorn src.dispatcher.main:app --host 0.0.0.0 --port ${PORT:-4001} --log-level info"
+healthcheckPath = "/dispatcher/health"
+healthcheckTimeout = 30
+[services.resources]
+# 1 GB — dispatcher is FastAPI + auth_minter + interceptor_proxy + spend_tracker
+# + watchdog + reaper. No sub-agent spawn (that runs on Vultr / future hosts).
+memoryMB = 1024

--- a/tests/infra/test_dispatcher_docker_build_kei127.py
+++ b/tests/infra/test_dispatcher_docker_build_kei127.py
@@ -1,0 +1,140 @@
+"""Tests for KEI-127 — Docker build + push to Railway via GH Actions.
+
+Acceptance gate: the workflow, Dockerfile, and railway.toml service entry
+must stay aligned. If any one is silently dropped or renamed, build-and-push
+breaks on next push to main.
+
+These tests are config-shape gates — they do NOT invoke `docker build` or
+`railway up` (no daemon, no credentials in CI). The actual end-to-end
+"workflow runs green on a test push" is the post-merge operator step.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build-push-docker.yml"
+DOCKERFILE = REPO_ROOT / "Dockerfile.dispatcher"
+RAILWAY_TOML = REPO_ROOT / "railway.toml"
+
+
+def _load_workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def _load_railway_toml() -> dict:
+    return tomllib.loads(RAILWAY_TOML.read_text())
+
+
+def test_workflow_file_exists() -> None:
+    assert WORKFLOW.exists(), f"{WORKFLOW} missing — KEI-127 workflow scaffold"
+
+
+def test_workflow_is_valid_yaml() -> None:
+    wf = _load_workflow()
+    assert isinstance(wf, dict), "workflow must parse as a YAML mapping"
+
+
+def test_workflow_triggers_only_on_main_push() -> None:
+    wf = _load_workflow()
+    # PyYAML rendering: the `on:` key — note `on` parses as bool True in YAML 1.1
+    # under the resolver default. Accept both forms so we survive any future
+    # YAML loader change without test rewrite.
+    on_key = wf.get("on") or wf.get(True)
+    assert on_key is not None, "workflow has no `on:` trigger block"
+    push = on_key.get("push")
+    assert push is not None, "workflow must trigger on push"
+    assert push.get("branches") == ["main"], (
+        f"expected branches=[main], got {push.get('branches')!r}"
+    )
+    paths = push.get("paths") or []
+    expected_paths = {
+        "Dockerfile.dispatcher",
+        "src/dispatcher/**",
+        "railway.toml",
+        ".github/workflows/build-push-docker.yml",
+    }
+    missing = expected_paths - set(paths)
+    assert not missing, f"workflow path filter missing entries: {missing}"
+
+
+def test_workflow_uses_railway_token_secret() -> None:
+    text = WORKFLOW.read_text()
+    assert "${{ secrets.RAILWAY_TOKEN }}" in text, "workflow must auth via RAILWAY_TOKEN secret"
+
+
+def test_workflow_targets_dispatcher_service() -> None:
+    text = WORKFLOW.read_text()
+    assert "--service dispatcher" in text, (
+        "workflow must `railway up --service dispatcher` (not agency-os) — "
+        "deploying to the wrong service would clobber the API."
+    )
+
+
+def test_workflow_has_concurrency_guard() -> None:
+    """Prevents two main pushes from racing the same Railway deploy."""
+    wf = _load_workflow()
+    assert wf.get("concurrency"), "workflow needs a concurrency: block"
+
+
+def test_dockerfile_dispatcher_exists() -> None:
+    assert DOCKERFILE.exists(), "Dockerfile.dispatcher missing"
+
+
+def test_dockerfile_dispatcher_starts_uvicorn() -> None:
+    text = DOCKERFILE.read_text()
+    assert "src.dispatcher.main:app" in text, (
+        "Dockerfile.dispatcher must start uvicorn against src.dispatcher.main:app"
+    )
+    assert 'CMD ["sh"' in text, (
+        "Dockerfile.dispatcher must have a CMD line invoking sh -c uvicorn …"
+    )
+
+
+def test_dockerfile_dispatcher_uses_pinned_python() -> None:
+    """Slim python:3.11-slim base — matches the API/Worker Dockerfile."""
+    text = DOCKERFILE.read_text()
+    assert "FROM python:3.11-slim" in text, "Dockerfile.dispatcher must FROM python:3.11-slim"
+
+
+def test_dockerfile_dispatcher_runs_non_root() -> None:
+    """Security — never run uvicorn as root in a container."""
+    text = DOCKERFILE.read_text()
+    assert "USER dispatcher" in text, (
+        "Dockerfile.dispatcher must drop privileges to a non-root user"
+    )
+
+
+def test_railway_toml_has_dispatcher_service() -> None:
+    cfg = _load_railway_toml()
+    services = cfg.get("services") or []
+    dispatcher = next((s for s in services if s.get("name") == "dispatcher"), None)
+    assert dispatcher is not None, "railway.toml has no [[services]] entry name='dispatcher'"
+
+
+def test_railway_toml_dispatcher_uses_correct_dockerfile() -> None:
+    cfg = _load_railway_toml()
+    dispatcher = next(s for s in cfg["services"] if s.get("name") == "dispatcher")
+    build = dispatcher.get("build", {})
+    assert build.get("dockerfilePath") == "Dockerfile.dispatcher", (
+        f"dispatcher service must point at Dockerfile.dispatcher, got {build.get('dockerfilePath')!r}"
+    )
+
+
+def test_railway_toml_dispatcher_healthcheck() -> None:
+    cfg = _load_railway_toml()
+    dispatcher = next(s for s in cfg["services"] if s.get("name") == "dispatcher")
+    deploy = dispatcher.get("deploy", {})
+    assert deploy.get("healthcheckPath") == "/dispatcher/health", (
+        "dispatcher service must health-check /dispatcher/health"
+    )
+
+
+def test_python_version_supports_tomllib() -> None:
+    """Guard: tomllib requires Python 3.11+. Catches CI image regressions."""
+    assert sys.version_info >= (3, 11), "tests require Python 3.11+ (tomllib)"


### PR DESCRIPTION
## Summary

Closes [KEI-127](https://linear.app/keiracom/issue/KEI-127) (bd `Agency_OS-7e18dw` P0). On every push to `main` that touches dispatcher source, the new workflow runs `railway up --service dispatcher --detach`. Railway server-side builds `Dockerfile.dispatcher`, pushes to its internal registry, and redeploys. Auth via existing `RAILWAY_TOKEN` secret — no new secrets.

**Linear:** [KEI-127](https://linear.app/keiracom/issue/KEI-127) · **Off:** `origin/main` · **STEP 0 PRE-CONFIRMED** by Elliot dispatch

## Three files land atomically

| File | Purpose |
|---|---|
| `.github/workflows/build-push-docker.yml` | New workflow. Path-filtered trigger, concurrency-guarded, minimal `contents:read` permission, 15-min timeout. Single step: `railway up --service dispatcher --detach`. |
| `Dockerfile.dispatcher` | Slim `python:3.11-slim`. No gcc/libpq-dev (dispatcher uses asyncpg + httpx — no compiled deps). Drops to non-root `dispatcher` user. HEALTHCHECK GET `/dispatcher/health`. CMD `uvicorn src.dispatcher.main:app` on `$PORT`. |
| `railway.toml` | Adds `[[services]] name = "dispatcher"` with per-service `[services.build] dockerfilePath = "Dockerfile.dispatcher"`. healthcheckPath `/dispatcher/health`. 1 GB memory ceiling. |

Splitting any one of these would land an un-runnable scaffold (workflow without Dockerfile, Dockerfile without service entry, service entry without workflow). Per [[feedback_split_orthogonal_scope]] atomicity exception — all three are deploy-interlocked; dependency documented inline.

## Verbatim verify

```
$ pytest -q tests/infra/test_dispatcher_docker_build_kei127.py
..............                                                           [100%]
14 passed in 0.09s

$ ruff check tests/infra/test_dispatcher_docker_build_kei127.py
All checks passed!
$ ruff format --check tests/infra/test_dispatcher_docker_build_kei127.py
1 file already formatted
```

14 config-shape tests gate the contract:
- Workflow YAML parses + triggers only on main push + path filter covers Dockerfile.dispatcher / src/dispatcher/** / railway.toml / workflow itself.
- Workflow uses `${{ secrets.RAILWAY_TOKEN }}` and `--service dispatcher` (not `agency-os` — wrong-target would clobber the API).
- Workflow has `concurrency:` block to prevent racing deploys.
- Dockerfile.dispatcher exists, FROMs python:3.11-slim, runs as non-root, CMD invokes `src.dispatcher.main:app`.
- railway.toml has dispatcher service entry with Dockerfile.dispatcher build override and `/dispatcher/health` healthcheck.

Tests do NOT invoke `docker build` or `railway up` (no daemon, no credentials in CI). The acceptance "workflow runs green on a test push" is the post-merge operator step (below).

## Acceptance map

| Criterion | Status |
|---|---|
| Workflow file exists + path-filtered + auths via RAILWAY_TOKEN | DONE (pytest gates) |
| Dockerfile suitable for Dispatcher image | DONE (Dockerfile.dispatcher) |
| Railway service entry pointing at the right Dockerfile | DONE (railway.toml `[[services]] name="dispatcher"`) |
| Workflow runs green on test push + Railway redeploys | DEFERRED — post-merge operator step (see below) |

## Post-merge operator steps

1. Confirm a Railway `dispatcher` service exists; if not, create it (Railway UI → new service from this repo's railway.toml, or `railway service create dispatcher`).
2. Confirm `RAILWAY_TOKEN` scope covers the `dispatcher` service.
3. Touch a sentinel path (e.g. amend a comment in `Dockerfile.dispatcher`) on a branch; merge to main; observe workflow goes green AND Railway dispatcher service redeploys.
4. `curl https://<railway-dispatcher-host>/dispatcher/health` → `{"status":"ok","components":{...all 5 green...}}`.

## Out of scope (follow-up KEIs)

- **Live Dispatcher cutover Vultr → Railway:** This PR enables the build pipeline; actual cutover (DNS/env-var swing) is a separate operator step. The Vultr Dispatcher (PR #1023 from earlier today, running green as of ~10:15 UTC) continues to serve until then.
- **PyJWT pin in requirements.txt:** currently transitive via fastapi-users / mcp / supabase-auth / twilio. Pin directly if dispatcher's `auth_minter` becomes its sole consumer.
- **nats-py:** NOT a dispatcher dep — NATS pub/sub is agent-side via the CLI helper from KEI-221 (PR #1030). Confirmed via grep on `src/dispatcher/` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)