### PR TITLE
[ORION] feat(kei20): Better Stack severity-based Slack alert routing (P0→#ceo, P1→#execution, lower→#alerts)

### DIFF
--- a/src/api/webhooks/betterstack.py
+++ b/src/api/webhooks/betterstack.py
@@ -136,11 +136,12 @@ def _post_to_slack(channel: str, text: str) -> None:
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=5) as r:  # noqa: S310 — fixed Slack URL, controlled scheme
+        # Fixed Slack URL, controlled scheme — bandit S310 false positive.
+        with urllib.request.urlopen(req, timeout=5) as r:  # noqa: S310
             response = json.loads(r.read() or "null") or {}
         if not response.get("ok"):
             logger.warning("Slack chat.postMessage rejected: %s", response)
-    except (urllib.error.URLError, OSError, ValueError) as exc:
+    except (OSError, ValueError) as exc:
         logger.warning("Slack chat.postMessage failed (fail-open): %s", exc)
 
 

--- a/src/api/webhooks/betterstack.py
+++ b/src/api/webhooks/betterstack.py
@@ -21,15 +21,20 @@ import json
 import logging
 import os
 import subprocess
+import urllib.error
+import urllib.request
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
+
+from src.api.webhooks.betterstack_severity_router import route as route_severity
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/webhooks/betterstack", tags=["webhooks", "betterstack"])
 
 _BS_WRAPPER = "/home/elliotbot/clawd/Agency_OS/scripts/betterstack_to_linear.py"
+_SLACK_POST_URL = "https://slack.com/api/chat.postMessage"
 
 
 def _python_bin() -> str:
@@ -109,6 +114,44 @@ def _dispatch_to_linear(event: dict[str, Any]) -> None:
         logger.warning("betterstack_to_linear dispatch failed: %s", exc)
 
 
+def _post_to_slack(channel: str, text: str) -> None:
+    """Fire-and-forget POST to Slack chat.postMessage. Fail-open.
+
+    KEI-20 — severity-routed channel selection happens in the caller via
+    betterstack_severity_router. This helper just delivers the message and
+    swallows any error so the Linear dispatch always proceeds.
+    """
+    token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if not token:
+        logger.warning("SLACK_BOT_TOKEN unset — KEI-20 severity routing skipped")
+        return
+    body = json.dumps({"channel": channel, "text": text}).encode("utf-8")
+    req = urllib.request.Request(
+        _SLACK_POST_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as r:  # noqa: S310 — fixed Slack URL, controlled scheme
+            response = json.loads(r.read() or "null") or {}
+        if not response.get("ok"):
+            logger.warning("Slack chat.postMessage rejected: %s", response)
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        logger.warning("Slack chat.postMessage failed (fail-open): %s", exc)
+
+
+def _format_slack_alert(event: dict[str, Any], severity: str) -> str:
+    """Single-line Slack alert body for a routed incident."""
+    return (
+        f"[BetterStack][{severity}] {event['monitor_name']} — {event['cause']} "
+        f"(incident_id={event['incident_id']}, status={event['status']})"
+    )
+
+
 _WEBHOOK_RESPONSES = {
     401: {"description": "Token verification failed (missing or wrong BETTERSTACK_WEBHOOK_SECRET)"},
     200: {
@@ -138,4 +181,15 @@ async def receive_betterstack_webhook(request: Request) -> dict[str, str]:
     if event["status"] not in {"started", "downtime", "down"}:
         return {"status": "ignored", "reason": f"status={event['status']!r} not actionable"}
     _dispatch_to_linear(event)
-    return {"status": "ok", "incident_id": event["incident_id"], "monitor": event["monitor_name"]}
+    # KEI-20 — severity-routed Slack alert. Pure router on raw payload (it
+    # extracts priority/severity/metadata.Priority from the original payload
+    # rather than the normalised event, since _normalise_incident drops those).
+    severity, channel = route_severity(payload)
+    _post_to_slack(channel, _format_slack_alert(event, severity))
+    return {
+        "status": "ok",
+        "incident_id": event["incident_id"],
+        "monitor": event["monitor_name"],
+        "severity": severity,
+        "channel": channel,
+    }

--- a/src/api/webhooks/betterstack_severity_router.py
+++ b/src/api/webhooks/betterstack_severity_router.py
@@ -1,0 +1,116 @@
+"""betterstack_severity_router.py — KEI-20 severity → channel routing.
+
+Closes Linear KEI-20 / bd Agency_OS-lrcvie P0.
+
+The Better Stack webhook receiver at src/api/webhooks/betterstack.py already
+creates a Linear KEI for every incoming incident. KEI-20 layers Slack
+notification on top, routed by severity:
+
+    P0 (critical)        → #ceo         (C0B2PM3TV0B)
+    P1 (high)            → #execution   (C0B3QB0K1GQ)
+    P2 / P3 / P4 / lower → #alerts      (C0B2EJU53EK)
+
+This module is pure-function so it can be exercised against synthetic
+payloads without booting FastAPI or hitting Slack. The receiver wires it in
+as a fail-open step alongside the existing Linear dispatch — a Slack post
+failure (network blip, fake-token in tests, missing scope) must never block
+the incident from reaching Linear.
+
+Severity-field discovery:
+  Better Stack's incident webhook payload doesn't have a stable
+  documented `priority` field. Empirically (probed against the
+  attributes dict from /api/v2/incidents on 2026-05-18) the routing
+  signal lives in one of:
+      attributes.priority           — "P0" / "P1" / "high" / etc.
+      attributes.severity           — same shape on heartbeat events
+      attributes.metadata.Priority  — operator-set tag on monitor
+  This module reads ALL three; first non-empty wins. Anything that
+  doesn't parse as P0 / P1 falls through to the "alerts" bucket so we
+  never silently drop a routing decision.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+CHANNEL_CEO = "C0B2PM3TV0B"
+CHANNEL_EXECUTION = "C0B3QB0K1GQ"
+CHANNEL_ALERTS = "C0B2EJU53EK"
+
+# Canonical bucket names — receiver logs / metrics consume these strings.
+SEVERITY_P0 = "P0"
+SEVERITY_P1 = "P1"
+SEVERITY_OTHER = "OTHER"
+
+# Synonyms accepted from Better Stack payloads. Any token not in P0/P1 falls
+# through to the lower bucket — alerts.
+_P0_TOKENS = frozenset({"p0", "critical", "sev0", "sev-0", "urgent"})
+_P1_TOKENS = frozenset({"p1", "high", "sev1", "sev-1"})
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_-]+")
+
+
+def extract_severity_token(payload: dict[str, Any]) -> str:
+    """Return the raw severity token from a Better Stack incident payload.
+
+    Searches (in order): attributes.priority, attributes.severity,
+    attributes.metadata.Priority. Returns "" if no value found — caller
+    treats that as "OTHER" (routes to #alerts).
+    """
+    record = payload.get("data") or payload
+    if isinstance(record, list):
+        record = record[0] if record else {}
+    attrs = (record or {}).get("attributes") or {}
+    candidates = (
+        attrs.get("priority"),
+        attrs.get("severity"),
+        (attrs.get("metadata") or {}).get("Priority"),
+    )
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        token = str(candidate).strip()
+        if token:
+            return token
+    return ""
+
+
+def classify(token: str) -> str:
+    """Map a raw severity token to SEVERITY_P0 / SEVERITY_P1 / SEVERITY_OTHER.
+
+    Case-insensitive; matches synonyms (critical / urgent / high / sev0 …).
+    Empty / unknown → SEVERITY_OTHER so the unknown-case routes to #alerts
+    rather than silently dropping.
+    """
+    if not token:
+        return SEVERITY_OTHER
+    # Normalise: pick the first alphanumeric word, lowercase. Handles "P0",
+    # "P0 - critical", "sev-0", " P1 ", etc.
+    match = _TOKEN_RE.search(token)
+    if not match:
+        return SEVERITY_OTHER
+    norm = match.group(0).strip().lower()
+    if norm in _P0_TOKENS:
+        return SEVERITY_P0
+    if norm in _P1_TOKENS:
+        return SEVERITY_P1
+    return SEVERITY_OTHER
+
+
+def severity_to_channel(severity: str) -> str:
+    """Map a classified severity bucket to a Slack channel ID."""
+    if severity == SEVERITY_P0:
+        return CHANNEL_CEO
+    if severity == SEVERITY_P1:
+        return CHANNEL_EXECUTION
+    return CHANNEL_ALERTS
+
+
+def route(payload: dict[str, Any]) -> tuple[str, str]:
+    """One-shot: extract severity from payload + return (bucket, channel_id).
+
+    Caller posts to channel_id; bucket is for logging / metrics.
+    """
+    severity = classify(extract_severity_token(payload))
+    return severity, severity_to_channel(severity)

--- a/tests/api/webhooks/test_betterstack_kei20_severity.py
+++ b/tests/api/webhooks/test_betterstack_kei20_severity.py
@@ -118,7 +118,7 @@ def test_synthetic_p2_lands_in_alerts(client) -> None:
 
 
 def test_synthetic_no_severity_lands_in_alerts(client) -> None:
-    c, posted = client
+    c, _ = client
     resp = _post(c, _incident_payload(priority=None))
     assert resp.status_code == 200
     body = resp.json()
@@ -130,7 +130,7 @@ def test_synthetic_no_severity_lands_in_alerts(client) -> None:
 def test_synthetic_critical_synonym_routes_to_ceo(client) -> None:
     # BS sometimes emits human-readable severity tokens. The receiver must
     # treat "critical" as P0 → #ceo.
-    c, posted = client
+    c, _ = client
     resp = _post(c, _incident_payload("critical"))
     assert resp.json()["channel"] == CHANNEL_CEO
 

--- a/tests/api/webhooks/test_betterstack_kei20_severity.py
+++ b/tests/api/webhooks/test_betterstack_kei20_severity.py
@@ -1,0 +1,148 @@
+"""KEI-20 — receiver-side severity routing end-to-end.
+
+Synthesises POST /api/webhooks/betterstack with priority=P0 and asserts the
+receiver routes to #ceo. Same shape for P1 → #execution and P2 → #alerts.
+Both downstream side-effects (Linear dispatch + Slack POST) are stubbed so
+the test runs offline and asserts the receiver makes the right routing call.
+
+Dispatch acceptance: "synthetic P0 alert lands in #ceo, P1 in #execution".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.webhooks.betterstack_severity_router import (
+    CHANNEL_ALERTS,
+    CHANNEL_CEO,
+    CHANNEL_EXECUTION,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "src" / "api" / "webhooks" / "betterstack.py"
+SECRET = "test-bs-secret"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("bs_webhook_kei20", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["bs_webhook_kei20"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+@pytest.fixture
+def client(mod, monkeypatch):
+    monkeypatch.setenv("BETTERSTACK_WEBHOOK_SECRET", SECRET)
+    monkeypatch.setattr(mod, "_dispatch_to_linear", lambda event: None)
+    posted: list[tuple[str, str]] = []
+    monkeypatch.setattr(mod, "_post_to_slack", lambda ch, text: posted.append((ch, text)))
+    app = FastAPI()
+    app.include_router(mod.router)
+    return TestClient(app), posted
+
+
+def _incident_payload(priority: str | None) -> dict:
+    attrs: dict = {
+        "name": f"Synthetic {priority or 'unspecified'} incident",
+        "cause": "synthetic test",
+        "status": "started",
+        "started_at": "2026-05-18T11:00:00Z",
+        "metadata": {"Monitor URL": "https://example.test"},
+    }
+    if priority is not None:
+        attrs["priority"] = priority
+    return {
+        "data": {
+            "id": "incident-synthetic-1",
+            "attributes": attrs,
+            "relationships": {"monitor": {"data": {"id": "monitor-1"}}},
+        }
+    }
+
+
+def _post(c: TestClient, payload: dict):
+    return c.post(
+        "/api/webhooks/betterstack",
+        json=payload,
+        headers={"x-webhook-secret": SECRET},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic P0 / P1 / P2 routing
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_p0_lands_in_ceo(client) -> None:
+    c, posted = client
+    resp = _post(c, _incident_payload("P0"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["severity"] == "P0"
+    assert body["channel"] == CHANNEL_CEO
+    assert len(posted) == 1, "Slack post should fire exactly once per webhook"
+    channel, text = posted[0]
+    assert channel == CHANNEL_CEO
+    assert "[P0]" in text
+    assert "Synthetic P0 incident" in text
+
+
+def test_synthetic_p1_lands_in_execution(client) -> None:
+    c, posted = client
+    resp = _post(c, _incident_payload("P1"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["severity"] == "P1"
+    assert body["channel"] == CHANNEL_EXECUTION
+    assert posted[-1][0] == CHANNEL_EXECUTION
+    assert "[P1]" in posted[-1][1]
+
+
+def test_synthetic_p2_lands_in_alerts(client) -> None:
+    c, posted = client
+    resp = _post(c, _incident_payload("P2"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["severity"] == "OTHER"
+    assert body["channel"] == CHANNEL_ALERTS
+    assert posted[-1][0] == CHANNEL_ALERTS
+
+
+def test_synthetic_no_severity_lands_in_alerts(client) -> None:
+    c, posted = client
+    resp = _post(c, _incident_payload(priority=None))
+    assert resp.status_code == 200
+    body = resp.json()
+    # Missing severity must not silently drop — route to #alerts so an
+    # operator notices a payload-format change.
+    assert body["channel"] == CHANNEL_ALERTS
+
+
+def test_synthetic_critical_synonym_routes_to_ceo(client) -> None:
+    # BS sometimes emits human-readable severity tokens. The receiver must
+    # treat "critical" as P0 → #ceo.
+    c, posted = client
+    resp = _post(c, _incident_payload("critical"))
+    assert resp.json()["channel"] == CHANNEL_CEO
+
+
+def test_ignored_status_does_not_post(client) -> None:
+    # Non-actionable statuses (resolved, acknowledged) skip both dispatch
+    # paths. The current receiver short-circuits before Linear and Slack —
+    # KEI-20 should not regress that.
+    c, posted = client
+    payload = _incident_payload("P0")
+    payload["data"]["attributes"]["status"] = "resolved"
+    resp = _post(c, payload)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ignored"
+    assert posted == [], "resolved events must not fire a Slack post"

--- a/tests/api/webhooks/test_betterstack_severity_router.py
+++ b/tests/api/webhooks/test_betterstack_severity_router.py
@@ -1,0 +1,177 @@
+"""KEI-20 — severity → channel routing pure-function tests.
+
+Dispatch (Elliot 2026-05-18): "P0 → #ceo, P1 → #execution, lower → alerts.
+Configure Better Stack webhook router to split. Acceptance: synthetic P0
+alert lands in #ceo, P1 in #execution."
+
+Bucket constants live in the module under test — assert against canonical
+channel IDs explicitly so a typo doesn't silently re-route.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api.webhooks.betterstack_severity_router import (
+    CHANNEL_ALERTS,
+    CHANNEL_CEO,
+    CHANNEL_EXECUTION,
+    SEVERITY_OTHER,
+    SEVERITY_P0,
+    SEVERITY_P1,
+    classify,
+    extract_severity_token,
+    route,
+    severity_to_channel,
+)
+
+# ---------------------------------------------------------------------------
+# Canonical channel IDs — regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_channel_ids_are_canonical() -> None:
+    # Anchored to the IDs used elsewhere in the repo (slack_relay, BS routing
+    # policy). A drift here re-routes alerts silently.
+    assert CHANNEL_CEO == "C0B2PM3TV0B"
+    assert CHANNEL_EXECUTION == "C0B3QB0K1GQ"
+    assert CHANNEL_ALERTS == "C0B2EJU53EK"
+
+
+# ---------------------------------------------------------------------------
+# classify: token → bucket
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["P0", "p0", " P0 ", "critical", "Critical", "sev0", "sev-0", "urgent"],
+)
+def test_classify_p0_synonyms(token: str) -> None:
+    assert classify(token) == SEVERITY_P0
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["P1", "p1", " P1 ", "high", "High", "sev1", "sev-1"],
+)
+def test_classify_p1_synonyms(token: str) -> None:
+    assert classify(token) == SEVERITY_P1
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["P2", "P3", "P4", "low", "info", "warning", "warning - degraded", ""],
+)
+def test_classify_lower_severities_fall_through_to_other(token: str) -> None:
+    assert classify(token) == SEVERITY_OTHER
+
+
+def test_classify_unknown_string_falls_through() -> None:
+    # Defensive: unknown / malformed tokens MUST route to OTHER (which routes
+    # to #alerts), never silently drop. KEI-20 fail-noisy contract.
+    assert classify("garbage-token-xyz") == SEVERITY_OTHER
+    assert classify("!@#$") == SEVERITY_OTHER
+
+
+# ---------------------------------------------------------------------------
+# severity_to_channel: bucket → channel ID
+# ---------------------------------------------------------------------------
+
+
+def test_severity_to_channel_p0_routes_to_ceo() -> None:
+    assert severity_to_channel(SEVERITY_P0) == CHANNEL_CEO
+
+
+def test_severity_to_channel_p1_routes_to_execution() -> None:
+    assert severity_to_channel(SEVERITY_P1) == CHANNEL_EXECUTION
+
+
+def test_severity_to_channel_other_routes_to_alerts() -> None:
+    assert severity_to_channel(SEVERITY_OTHER) == CHANNEL_ALERTS
+
+
+def test_severity_to_channel_unknown_bucket_falls_to_alerts() -> None:
+    # If we ever add a new bucket and forget to extend severity_to_channel,
+    # the fallback must still be #alerts — never silently #ceo.
+    assert severity_to_channel("DEFINITELY_NOT_A_BUCKET") == CHANNEL_ALERTS
+
+
+# ---------------------------------------------------------------------------
+# extract_severity_token: payload → raw token (3-field probe order)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_severity_token_from_priority() -> None:
+    payload = {"data": {"attributes": {"priority": "P0"}}}
+    assert extract_severity_token(payload) == "P0"
+
+
+def test_extract_severity_token_from_severity_field() -> None:
+    payload = {"data": {"attributes": {"severity": "high"}}}
+    assert extract_severity_token(payload) == "high"
+
+
+def test_extract_severity_token_from_metadata() -> None:
+    payload = {"data": {"attributes": {"metadata": {"Priority": "P1"}}}}
+    assert extract_severity_token(payload) == "P1"
+
+
+def test_extract_severity_token_priority_wins_over_severity() -> None:
+    # Field-priority order: priority → severity → metadata. Test the
+    # tiebreaker explicitly.
+    payload = {"data": {"attributes": {"priority": "P0", "severity": "P1"}}}
+    assert extract_severity_token(payload) == "P0"
+
+
+def test_extract_severity_token_handles_list_envelope() -> None:
+    # BS sometimes wraps `data` as a list (when fan-out on a query endpoint
+    # gets routed back through a webhook). Take first element.
+    payload = {"data": [{"attributes": {"priority": "P0"}}]}
+    assert extract_severity_token(payload) == "P0"
+
+
+def test_extract_severity_token_handles_flat_payload() -> None:
+    # Operator-flattened payloads have attributes at the top level.
+    payload = {"attributes": {"priority": "P1"}}
+    assert extract_severity_token(payload) == "P1"
+
+
+def test_extract_severity_token_empty_when_no_signal() -> None:
+    payload = {"data": {"attributes": {"name": "monitor", "cause": "timeout"}}}
+    assert extract_severity_token(payload) == ""
+
+
+# ---------------------------------------------------------------------------
+# route: end-to-end (payload → (bucket, channel))
+# ---------------------------------------------------------------------------
+
+
+def test_route_synthetic_p0_lands_in_ceo() -> None:
+    payload = {"data": {"attributes": {"priority": "P0", "name": "Test P0 incident"}}}
+    bucket, channel = route(payload)
+    assert bucket == SEVERITY_P0
+    assert channel == CHANNEL_CEO
+
+
+def test_route_synthetic_p1_lands_in_execution() -> None:
+    payload = {"data": {"attributes": {"priority": "P1", "name": "Test P1 incident"}}}
+    bucket, channel = route(payload)
+    assert bucket == SEVERITY_P1
+    assert channel == CHANNEL_EXECUTION
+
+
+def test_route_synthetic_p2_lands_in_alerts() -> None:
+    payload = {"data": {"attributes": {"priority": "P2", "name": "Test P2 incident"}}}
+    bucket, channel = route(payload)
+    assert bucket == SEVERITY_OTHER
+    assert channel == CHANNEL_ALERTS
+
+
+def test_route_synthetic_no_severity_lands_in_alerts() -> None:
+    # KEI-20 fail-noisy: payloads without a routing signal default to the
+    # lowest-priority channel. They are NOT silently dropped.
+    payload = {"data": {"attributes": {"name": "Test unspecified"}}}
+    bucket, channel = route(payload)
+    assert bucket == SEVERITY_OTHER
+    assert channel == CHANNEL_ALERTS


### PR DESCRIPTION
## Summary
- The Better Stack webhook receiver created Linear KEIs but didn't post a Slack alert. Operators had no real-time visibility unless watching Linear.
- New pure-function router `src/api/webhooks/betterstack_severity_router.py` maps incident severity to a Slack channel.
- Receiver `src/api/webhooks/betterstack.py` dual-writes: existing Linear dispatch + new severity-routed Slack post, fail-open on Slack so Linear always proceeds.

## Routing table
| Severity | Channel | ID |
|---|---|---|
| P0 / critical / urgent / sev0 | #ceo | `C0B2PM3TV0B` |
| P1 / high / sev1 | #execution | `C0B3QB0K1GQ` |
| P2 / P3 / P4 / unknown / missing | #alerts | `C0B2EJU53EK` |

Severity-field discovery probes three locations in priority order (`attributes.priority` → `attributes.severity` → `attributes.metadata.Priority`); first non-empty wins. Missing / unknown values route to `OTHER` → `#alerts` (fail-noisy, never silently dropped).

## Tests
```
$ python3 -m pytest tests/api/webhooks/test_betterstack_severity_router.py \
                     tests/api/webhooks/test_betterstack_kei20_severity.py -v
============================== 46 passed in 1.27s ==============================
```
```
$ ruff check src/api/webhooks/betterstack.py \
             src/api/webhooks/betterstack_severity_router.py \
             tests/api/webhooks/test_betterstack_severity_router.py \
             tests/api/webhooks/test_betterstack_kei20_severity.py
All checks passed!
$ ruff format --check (same files)
4 files left unchanged
```

Coverage:
- Canonical channel IDs (regression-guard against silent re-routing)
- `classify` — P0 synonyms (P0/p0/critical/Critical/sev0/sev-0/urgent), P1 synonyms (P1/p1/high/High/sev1/sev-1), fall-through (P2/P3/P4/low/info/warning/empty/garbage)
- `severity_to_channel` — every bucket + unknown-bucket fallback to #alerts
- `extract_severity_token` — from priority, severity, metadata.Priority, priority-wins-tiebreaker, list-envelope handling, flat-payload handling, empty when no signal
- `route` end-to-end: P0 → ceo, P1 → execution, P2 → alerts, missing → alerts
- Receiver end-to-end (FastAPI TestClient + stubbed Slack/Linear): synthetic POST with priority=P0/P1/P2/critical synonym routes correctly, resolved status short-circuits without firing Slack post

## Source
- Dispatch from Elliot 2026-05-18 — STEP 0 PRE-CONFIRMED. Beads `Agency_OS-lrcvie` P0.
- Linear: https://linear.app/keiracom/issue/KEI-225 (tracks KEI-20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)