### PR TITLE
[SCOUT] feat(kei69): add nova to fallback poller — covers 7 fleet sessions

### DIFF
--- a/scripts/orchestrator/auto_session_recovery.py
+++ b/scripts/orchestrator/auto_session_recovery.py
@@ -37,7 +37,8 @@ logger = logging.getLogger("auto_session_recovery")
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 # Canonical callsign → tmux session name map. Mirrors CALLSIGN_TO_TMUX in
-# elliot_polling_loop.py:111 (elliot+max use -bot suffix; clones + aiden bare).
+# elliot_polling_loop.py (elliot+max use -bot suffix; clones + aiden bare).
+# KEI-69 — nova added so session recovery covers all 7 fleet sessions.
 CALLSIGN_TO_TMUX: dict[str, str] = {
     "elliot": "elliottbot",
     "aiden": "aiden",
@@ -45,6 +46,7 @@ CALLSIGN_TO_TMUX: dict[str, str] = {
     "atlas": "atlas",
     "orion": "orion",
     "scout": "scout",
+    "nova": "nova",
 }
 
 # Per-callsign worktree paths. elliot → main; others → -<callsign> suffix.
@@ -56,6 +58,7 @@ CALLSIGN_TO_WORKTREE: dict[str, str] = {
     "atlas": f"{_WORKTREE_ROOT}/Agency_OS-atlas",
     "orion": f"{_WORKTREE_ROOT}/Agency_OS-orion",
     "scout": f"{_WORKTREE_ROOT}/Agency_OS-scout",
+    "nova": f"{_WORKTREE_ROOT}/Agency_OS-nova",
 }
 
 CLAUDE_PROJECTS_ROOT = Path.home() / ".claude" / "projects"

--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -84,14 +84,14 @@ LONG_RUNNING_TRACK_PROGRESS_MIN = 30
 EXECUTION_CHANNEL_NAME = "#execution"
 CEO_CHANNEL_NAME = "#ceo"
 
-CLONES = ("atlas", "orion", "scout")
+CLONES = ("atlas", "orion", "scout", "nova")  # KEI-69 — nova added
 PRIMES = ("aiden", "max")  # elliot orchestrates; she doesn't dispatch to herself
 
 # Inbox-path map for clones (Dave directive ts ~1778584800 — polling hole A).
 # Clones receive dispatches via inbox-watcher JSON drops, NOT via Slack channel
 # fan-out (the listener path is uptime-sensitive; direct inbox write is the
 # Layer 3 mechanical close).
-# NOSONAR S5443 ×3 below: /tmp/telegram-relay-<cs>/inbox is the systemd
+# NOSONAR S5443 ×4 below: /tmp/telegram-relay-<cs>/inbox is the systemd
 # inotify-watcher contract (per .claude/hooks/inbox_check_hook.sh + the
 # per-callsign relay-watcher services). Cannot migrate to ~/.local/state
 # without a coordinated watcher refactor. Defense-in-depth: callsign keys
@@ -103,11 +103,13 @@ INBOX_PATHS: dict[str, str] = {
     "atlas": "/tmp/telegram-relay-atlas/inbox",  # NOSONAR
     "orion": "/tmp/telegram-relay-orion/inbox",  # NOSONAR
     "scout": "/tmp/telegram-relay-scout/inbox",  # NOSONAR
+    "nova": "/tmp/telegram-relay-nova/inbox",  # NOSONAR — KEI-69
 }
 
 
 # tmux session name per callsign (empirical 2026-05-12: elliot+max sessions
-# are named with -bot suffix; clones + aiden use bare callsign).
+# are named with -bot suffix; clones + aiden use bare callsign). KEI-69 adds
+# nova so the fallback poller monitors all 7 fleet sessions (elliot + 6).
 CALLSIGN_TO_TMUX: dict[str, str] = {
     "elliot": "elliottbot",
     "aiden": "aiden",
@@ -115,6 +117,7 @@ CALLSIGN_TO_TMUX: dict[str, str] = {
     "atlas": "atlas",
     "orion": "orion",
     "scout": "scout",
+    "nova": "nova",
 }
 
 # Anthropic throttle signal patterns. Case-insensitive substring match on the
@@ -790,6 +793,7 @@ def _callsign_to_worktree(callsign: str) -> str:
         "atlas": "/home/elliotbot/clawd/Agency_OS-atlas",
         "orion": "/home/elliotbot/clawd/Agency_OS-orion",
         "scout": "/home/elliotbot/clawd/Agency_OS-scout",
+        "nova": "/home/elliotbot/clawd/Agency_OS-nova",  # KEI-69
     }
     return _WORKTREES.get(callsign.lower(), "")
 

--- a/tests/scripts/test_auto_session_recovery.py
+++ b/tests/scripts/test_auto_session_recovery.py
@@ -36,13 +36,17 @@ def _stub_alive(asr_mod, monkeypatch, names: set[str]) -> None:
 
 
 def test_detect_dead_all_alive(asr_mod, monkeypatch):
-    _stub_alive(asr_mod, monkeypatch, {"elliottbot", "aiden", "maxbot", "atlas", "orion", "scout"})
+    _stub_alive(
+        asr_mod,
+        monkeypatch,
+        {"elliottbot", "aiden", "maxbot", "atlas", "orion", "scout", "nova"},
+    )
     assert asr_mod.detect_dead_callsigns() == []
 
 
 def test_detect_dead_max_missing(asr_mod, monkeypatch):
-    _stub_alive(asr_mod, monkeypatch, {"elliottbot", "aiden", "atlas", "orion", "scout"})
-    # maxbot session absent → max callsign reported dead
+    _stub_alive(asr_mod, monkeypatch, {"elliottbot", "aiden", "atlas", "orion", "scout", "nova"})
+    # maxbot session absent → max callsign reported dead (nova alive, not flagged)
     assert asr_mod.detect_dead_callsigns() == ["max"]
 
 
@@ -163,9 +167,7 @@ def test_run_two_attempt_threshold_then_escalate(asr_mod, monkeypatch, tmp_path)
         )
     )
     recover_calls: list[str] = []
-    monkeypatch.setattr(
-        asr_mod, "recover_session", lambda cs: recover_calls.append(cs) or False
-    )
+    monkeypatch.setattr(asr_mod, "recover_session", lambda cs: recover_calls.append(cs) or False)
     escalations: list[tuple[str, int]] = []
     monkeypatch.setattr(asr_mod, "_escalate_to_ceo", lambda cs, n: escalations.append((cs, n)))
     asr_mod.run(now=datetime(2026, 5, 13, 0, 5, tzinfo=UTC))

--- a/tests/scripts/test_kei69_fleet_coverage.py
+++ b/tests/scripts/test_kei69_fleet_coverage.py
@@ -46,10 +46,10 @@ def test_polling_clones_tuple_includes_nova():
 def test_polling_inbox_paths_covers_all_clones():
     mod = _load("elliot_polling_loop", POLLING)
     assert set(mod.INBOX_PATHS.keys()) == EXPECTED_CLONES
-    # NOSONAR S5443 — string-equality assertion, not a filesystem write. The
-    # /tmp inbox path is the systemd-relay convention asserted against
-    # elliot_polling_loop.INBOX_PATHS (which itself carries NOSONAR S5443).
-    assert mod.INBOX_PATHS["nova"] == "/tmp/telegram-relay-nova/inbox"  # NOSONAR S5443
+    # String-equality assertion, not a filesystem write. The /tmp inbox path is
+    # the systemd-relay convention asserted against elliot_polling_loop.INBOX_PATHS
+    # (which itself carries NOSONAR(S5443)).
+    assert mod.INBOX_PATHS["nova"] == "/tmp/telegram-relay-nova/inbox"  # NOSONAR(S5443)
 
 
 def test_recovery_callsign_to_tmux_covers_7_sessions():

--- a/tests/scripts/test_kei69_fleet_coverage.py
+++ b/tests/scripts/test_kei69_fleet_coverage.py
@@ -1,0 +1,68 @@
+"""KEI-69 — fallback poller must cover all 7 fleet sessions.
+
+Acceptance per dispatch: poller reports state for all 7 sessions
+(elliot + atlas + orion + scout + nova + aiden + max).
+
+Guards against future regressions where adding a new clone forgets to wire
+the poller, session-recovery, or workspace maps.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+POLLING = REPO_ROOT / "scripts" / "orchestrator" / "elliot_polling_loop.py"
+RECOVERY = REPO_ROOT / "scripts" / "orchestrator" / "auto_session_recovery.py"
+
+EXPECTED_FLEET = frozenset({"elliot", "aiden", "max", "atlas", "orion", "scout", "nova"})
+EXPECTED_CLONES = frozenset({"atlas", "orion", "scout", "nova"})
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_polling_callsign_to_tmux_covers_7_sessions():
+    """elliot_polling_loop.CALLSIGN_TO_TMUX includes nova and totals 7."""
+    mod = _load("elliot_polling_loop", POLLING)
+    assert set(mod.CALLSIGN_TO_TMUX.keys()) == EXPECTED_FLEET
+    assert len(mod.CALLSIGN_TO_TMUX) == 7
+    assert mod.CALLSIGN_TO_TMUX["nova"] == "nova"
+
+
+def test_polling_clones_tuple_includes_nova():
+    mod = _load("elliot_polling_loop", POLLING)
+    assert set(mod.CLONES) == EXPECTED_CLONES
+    assert "nova" in mod.CLONES
+
+
+def test_polling_inbox_paths_covers_all_clones():
+    mod = _load("elliot_polling_loop", POLLING)
+    assert set(mod.INBOX_PATHS.keys()) == EXPECTED_CLONES
+    assert mod.INBOX_PATHS["nova"] == "/tmp/telegram-relay-nova/inbox"
+
+
+def test_recovery_callsign_to_tmux_covers_7_sessions():
+    mod = _load("auto_session_recovery", RECOVERY)
+    assert set(mod.CALLSIGN_TO_TMUX.keys()) == EXPECTED_FLEET
+    assert mod.CALLSIGN_TO_TMUX["nova"] == "nova"
+
+
+def test_recovery_callsign_to_worktree_covers_7_sessions():
+    mod = _load("auto_session_recovery", RECOVERY)
+    assert set(mod.CALLSIGN_TO_WORKTREE.keys()) == EXPECTED_FLEET
+    assert mod.CALLSIGN_TO_WORKTREE["nova"].endswith("/Agency_OS-nova")
+
+
+def test_polling_and_recovery_tmux_maps_agree():
+    """Both modules must agree on tmux session names — drift = silent misroute."""
+    poll = _load("elliot_polling_loop", POLLING)
+    rec = _load("auto_session_recovery", RECOVERY)
+    assert poll.CALLSIGN_TO_TMUX == rec.CALLSIGN_TO_TMUX

--- a/tests/scripts/test_kei69_fleet_coverage.py
+++ b/tests/scripts/test_kei69_fleet_coverage.py
@@ -46,7 +46,10 @@ def test_polling_clones_tuple_includes_nova():
 def test_polling_inbox_paths_covers_all_clones():
     mod = _load("elliot_polling_loop", POLLING)
     assert set(mod.INBOX_PATHS.keys()) == EXPECTED_CLONES
-    assert mod.INBOX_PATHS["nova"] == "/tmp/telegram-relay-nova/inbox"
+    # NOSONAR S5443 — string-equality assertion, not a filesystem write. The
+    # /tmp inbox path is the systemd-relay convention asserted against
+    # elliot_polling_loop.INBOX_PATHS (which itself carries NOSONAR S5443).
+    assert mod.INBOX_PATHS["nova"] == "/tmp/telegram-relay-nova/inbox"  # NOSONAR S5443
 
 
 def test_recovery_callsign_to_tmux_covers_7_sessions():


### PR DESCRIPTION
## Summary

The polling-loop fleet maps did not include **nova**, so the fallback poller (`elliot_polling_loop.py`) and the session-recovery layer (`auto_session_recovery.py`) silently skipped nova. Result: nova outages went undetected by the orchestrator path.

## Fix

Add nova to every fleet map that participates in poller coverage:

| File | Map | Before | After |
|---|---|---|---|
| `elliot_polling_loop.py` | `CLONES` | `(atlas, orion, scout)` | `(atlas, orion, scout, nova)` |
| `elliot_polling_loop.py` | `INBOX_PATHS` | 3 clones | 4 clones (+`/tmp/telegram-relay-nova/inbox`) |
| `elliot_polling_loop.py` | `CALLSIGN_TO_TMUX` | 6 sessions | 7 sessions (+`nova → nova`) |
| `elliot_polling_loop.py` | `_WORKTREES` (fallback) | 6 sessions | 7 sessions (+`/home/elliotbot/clawd/Agency_OS-nova`) |
| `auto_session_recovery.py` | `CALLSIGN_TO_TMUX` | 6 sessions | 7 sessions |
| `auto_session_recovery.py` | `CALLSIGN_TO_WORKTREE` | 6 sessions | 7 sessions |

Inbox `NOSONAR S5443` carried over from the existing clone entries — same justification (systemd inotify-watcher contract, callsign keys regex-validated upstream).

## Acceptance

> Poller reports state for all 7 sessions (elliot + 6 above).

After this change, `CALLSIGN_TO_TMUX` has all 7 entries. New test `test_polling_and_recovery_tmux_maps_agree` enforces no future drift between the polling loop and session-recovery maps.

## Test plan

- [x] `python3 -m pytest tests/scripts/test_kei69_fleet_coverage.py tests/scripts/test_elliot_polling_loop.py tests/scripts/test_elliot_polling_loop_kei63.py tests/scripts/test_auto_session_recovery.py` → **78 passed**
- [x] `ruff check && ruff format --check` → all clean
- [x] Six new KEI-69 coverage tests asserting nova present in all four dicts
- [x] Two existing tests updated to include nova in alive-set fixtures

## Out of scope

`config/heartbeat_callsigns.yaml` is missing nova too — that drives HEARTBEAT.md generation (separate concern from the fallback poller). Filed as follow-up, not bundled here per scope discipline.

## Refs

- Linear: KEI-69
- Beads: `Agency_OS-m52dw2`
- Dispatch: elliot (`kei69-openclaw-clone-coverage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)