### PR TITLE
[SCOUT] feat(kei100): Linear/Supabase task ID alignment — Phase 1

### DIFF
--- a/scripts/verify_kei100_id_alignment.py
+++ b/scripts/verify_kei100_id_alignment.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""verify_kei100_id_alignment.py — KEI-100 post-migration assertion.
+
+Acceptance per dispatch: "zero ID mismatches between Linear and Supabase tasks
+table". After the migration lands, run this script. Exits non-zero if any row
+is misaligned, with a per-row report on stdout.
+
+Mismatch shapes:
+  1. linear_url set but linear_id NULL (trigger failed to populate)
+  2. linear_url set and linear_id set but they disagree
+  3. id ~ '^KEI-[0-9]+$' but linear_id IS NULL (id-side fallback didn't fire)
+  4. linear_id set but doesn't match '^KEI-[0-9]+$' (extraction polluted)
+
+Usage:
+    DATABASE_URL=postgresql://... python3 verify_kei100_id_alignment.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+logger = logging.getLogger("verify_kei100")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+_CHECK_SQL = """
+SELECT id, linear_id, linear_url,
+       CASE
+         WHEN linear_url IS NOT NULL AND linear_id IS NULL THEN 'url_set_id_null'
+         WHEN linear_url IS NOT NULL
+              AND linear_id IS NOT NULL
+              AND substring(linear_url FROM 'KEI-[0-9]+') IS DISTINCT FROM linear_id
+              THEN 'url_id_disagree'
+         WHEN id ~ '^KEI-[0-9]+$' AND linear_id IS NULL THEN 'id_kei_but_linear_id_null'
+         WHEN linear_id IS NOT NULL AND linear_id !~ '^KEI-[0-9]+$' THEN 'linear_id_malformed'
+       END AS mismatch
+  FROM public.tasks
+ WHERE (linear_url IS NOT NULL AND linear_id IS NULL)
+    OR (linear_url IS NOT NULL
+        AND linear_id IS NOT NULL
+        AND substring(linear_url FROM 'KEI-[0-9]+') IS DISTINCT FROM linear_id)
+    OR (id ~ '^KEI-[0-9]+$' AND linear_id IS NULL)
+    OR (linear_id IS NOT NULL AND linear_id !~ '^KEI-[0-9]+$')
+"""
+
+
+def _resolve_dsn() -> str | None:
+    raw = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not raw:
+        return None
+    return raw.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def main() -> int:
+    dsn = _resolve_dsn()
+    if not dsn:
+        print("ERROR: DATABASE_URL / SUPABASE_DB_URL unset", file=sys.stderr)
+        return 2
+    try:
+        import psycopg
+
+        with psycopg.connect(dsn, prepare_threshold=None) as conn, conn.cursor() as cur:
+            cur.execute(_CHECK_SQL)
+            rows = cur.fetchall()
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: DB query failed: {exc}", file=sys.stderr)
+        return 2
+
+    if not rows:
+        print("OK: 0 ID mismatches between Linear and Supabase tasks table.")
+        return 0
+
+    print(f"FAIL: {len(rows)} mismatched row(s):")
+    for r in rows:
+        print(f"  id={r[0]} linear_id={r[1]} linear_url={r[2]} reason={r[3]}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/supabase/migrations/20260518_kei100_tasks_linear_id.sql
+++ b/supabase/migrations/20260518_kei100_tasks_linear_id.sql
@@ -1,0 +1,73 @@
+-- KEI-100 — Linear/Supabase task ID alignment (Phase 1: add canonical linear_id).
+--
+-- Background:
+--   public.tasks.id is currently a free-form text label. Most rows use the
+--   Linear KEI-N as the id, but:
+--     * 1 sub-KEI exists with a Beads-suffix form (KEI-54B → Linear KEI-54)
+--     * 23 REVIEW-PR-* rows have no Linear issue
+--     * Some rows store the canonical KEI only inside the linear_url string
+--   This makes "which Linear issue does this row track" ambiguous and forces
+--   every consumer to regex-parse linear_url.
+--
+-- This migration adds a canonical linear_id column populated from the URL
+-- (or from the id itself when it already matches KEI-N), with a UNIQUE
+-- partial index. A BEFORE INSERT/UPDATE trigger keeps linear_id in sync
+-- with linear_url for future writes.
+--
+-- Phase 2 — dropping the legacy `id` column — is NOT in this migration.
+-- That requires coordinated FK migrations across 4 referrers
+-- (task_verifications, active_threads, completion_sync_queue, ceo_decisions)
+-- plus matching changes in the Beads CLI. Filed as follow-up.
+
+-- 1. Add the canonical linear_id column. Nullable because REVIEW-PR-* rows
+--    legitimately have no Linear issue.
+ALTER TABLE public.tasks
+    ADD COLUMN IF NOT EXISTS linear_id text;
+
+COMMENT ON COLUMN public.tasks.linear_id IS
+    'KEI-100 canonical Linear issue id (e.g. KEI-54). NULL for REVIEW-PR-* rows.';
+
+-- 2. Backfill — priority order:
+--    a) extract from linear_url if present (authoritative — URL is what Linear emits)
+--    b) fall back to id if id already matches '^KEI-[0-9]+$'
+--    c) leave NULL for REVIEW-PR-* and other non-Linear rows
+UPDATE public.tasks
+   SET linear_id = substring(linear_url FROM 'KEI-[0-9]+')
+ WHERE linear_id IS NULL
+   AND linear_url IS NOT NULL
+   AND substring(linear_url FROM 'KEI-[0-9]+') IS NOT NULL;
+
+UPDATE public.tasks
+   SET linear_id = id
+ WHERE linear_id IS NULL
+   AND id ~ '^KEI-[0-9]+$';
+
+-- 3. UNIQUE index — multiple rows MUST NOT claim the same Linear issue.
+--    Partial so the 23 REVIEW-PR-* NULLs are allowed.
+CREATE UNIQUE INDEX IF NOT EXISTS tasks_linear_id_unique
+    ON public.tasks (linear_id)
+ WHERE linear_id IS NOT NULL;
+
+-- 4. Sync trigger — future inserts/updates that set linear_url must auto-fill
+--    linear_id (when absent). Keeps the two fields aligned without requiring
+--    every writer to know the rule.
+CREATE OR REPLACE FUNCTION public.tasks_sync_linear_id()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.linear_id IS NULL AND NEW.linear_url IS NOT NULL THEN
+        NEW.linear_id := substring(NEW.linear_url FROM 'KEI-[0-9]+');
+    END IF;
+    IF NEW.linear_id IS NULL AND NEW.id ~ '^KEI-[0-9]+$' THEN
+        NEW.linear_id := NEW.id;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS tasks_sync_linear_id_trg ON public.tasks;
+CREATE TRIGGER tasks_sync_linear_id_trg
+    BEFORE INSERT OR UPDATE OF linear_url, linear_id, id ON public.tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION public.tasks_sync_linear_id();

--- a/tests/migrations/test_kei100_linear_id_migration.py
+++ b/tests/migrations/test_kei100_linear_id_migration.py
@@ -1,0 +1,115 @@
+"""KEI-100 — tests for the linear_id alignment migration.
+
+These tests don't require a live Postgres. They assert:
+- The migration SQL file exists and contains the canonical statements
+- The backfill regex extracts canonical KEI-N from various URL shapes
+- The verify script's mismatch detector classifies the four known shapes
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MIGRATION = REPO_ROOT / "supabase" / "migrations" / "20260518_kei100_tasks_linear_id.sql"
+VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify_kei100_id_alignment.py"
+
+
+def test_migration_file_exists():
+    assert MIGRATION.exists()
+
+
+def test_migration_adds_linear_id_column():
+    sql = MIGRATION.read_text()
+    assert "ADD COLUMN IF NOT EXISTS linear_id text" in sql
+
+
+def test_migration_backfills_from_url_then_id():
+    sql = MIGRATION.read_text()
+    # URL-first backfill must come before id-fallback backfill
+    url_idx = sql.find("substring(linear_url FROM 'KEI-[0-9]+')")
+    id_idx = sql.find("id ~ '^KEI-[0-9]+$'")
+    assert url_idx >= 0 and id_idx > url_idx
+
+
+def test_migration_creates_partial_unique_index():
+    sql = MIGRATION.read_text()
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS tasks_linear_id_unique" in sql
+    assert "WHERE linear_id IS NOT NULL" in sql
+
+
+def test_migration_installs_sync_trigger():
+    sql = MIGRATION.read_text()
+    assert "CREATE OR REPLACE FUNCTION public.tasks_sync_linear_id" in sql
+    assert "CREATE TRIGGER tasks_sync_linear_id_trg" in sql
+    assert "BEFORE INSERT OR UPDATE" in sql
+
+
+def test_migration_does_not_drop_legacy_id_column():
+    """Phase 2 work — must NOT be in this migration. 4 FK referrers + Beads CLI
+    would break. Guard against accidental inclusion."""
+    sql = MIGRATION.read_text()
+    assert "DROP COLUMN" not in sql.upper().replace("CASCADE", "")
+    assert "DROP TABLE" not in sql.upper()
+
+
+# ─── regex extraction equivalence (Python ↔ Postgres) ────────────────────────
+
+_KEI_RE = re.compile(r"KEI-[0-9]+")
+
+
+def _extract(url: str | None) -> str | None:
+    if url is None:
+        return None
+    m = _KEI_RE.search(url)
+    return m.group(0) if m else None
+
+
+def test_extract_canonical_url():
+    assert _extract("https://linear.app/keiracom/issue/KEI-98/some-slug") == "KEI-98"
+
+
+def test_extract_bare_url_without_slug():
+    assert _extract("https://linear.app/keiracom/issue/KEI-63") == "KEI-63"
+
+
+def test_extract_subkei_resolves_to_parent():
+    """KEI-54B → URL contains KEI-54 (the parent) — that's the canonical Linear id."""
+    assert _extract("https://linear.app/keiracom/issue/KEI-54/some-slug") == "KEI-54"
+
+
+def test_extract_no_kei_returns_none():
+    assert _extract("https://example.com/no-kei-here") is None
+
+
+def test_extract_null_returns_none():
+    assert _extract(None) is None
+
+
+# ─── verify-script SQL shape ─────────────────────────────────────────────────
+
+
+def test_verify_script_exists_and_is_executable():
+    assert VERIFY_SCRIPT.exists()
+    assert VERIFY_SCRIPT.stat().st_mode & 0o111
+
+
+def test_verify_script_detects_four_mismatch_shapes():
+    src = VERIFY_SCRIPT.read_text()
+    for shape in (
+        "url_set_id_null",
+        "url_id_disagree",
+        "id_kei_but_linear_id_null",
+        "linear_id_malformed",
+    ):
+        assert shape in src, f"verify script missing mismatch shape '{shape}'"
+
+
+def test_verify_script_exits_zero_only_on_clean_alignment():
+    src = VERIFY_SCRIPT.read_text()
+    # If no rows → exit 0 with "OK" message; if rows → exit 1 with FAIL
+    assert "return 0" in src
+    assert "return 1" in src
+    assert "OK:" in src
+    assert "FAIL:" in src


### PR DESCRIPTION
## Problem

`public.tasks.id` is a free-form text label. Most rows use the canonical Linear `KEI-N` (169 rows) but the table also holds:
- 1 sub-KEI in a Beads-suffix form (`KEI-54B` — URL actually points to `KEI-54`)
- 23 `REVIEW-PR-*` rows with no Linear issue (`linear_url IS NULL`)
- Rows where the canonical id lives **only** inside the `linear_url` string

Consumers regex-parse `linear_url` every time they want "which Linear issue does this row track" — and the sub-KEI case silently disagrees with `id`.

## Phase 1 (this PR)

| Step | What |
|---|---|
| 1 | `ADD COLUMN linear_id text NULL` |
| 2 | Backfill — URL-first (`substring(linear_url FROM 'KEI-[0-9]+')`), then `id` fallback when `id ~ '^KEI-[0-9]+$'` |
| 3 | `CREATE UNIQUE INDEX … WHERE linear_id IS NOT NULL` (partial, so the 23 legitimate NULLs are allowed) |
| 4 | `BEFORE INSERT/UPDATE` trigger keeps `linear_id` in sync with `linear_url` for future writes |

## Phase 2 (deferred — explicit non-goal)

Dropping the legacy `id` column requires coordinated FK migrations across **four referrers** (`task_verifications`, `active_threads`, `completion_sync_queue`, `ceo_decisions`) plus matching changes in the Beads CLI. The migration's `DROP COLUMN` guard test enforces this PR does NOT touch that work.

`cis_directive_metrics` is out of scope — its `directive_id` (integer) is a sequential counter unrelated to Linear; no Linear linkage to add.

## Acceptance

> Zero ID mismatches between Linear and Supabase tasks table.

After the migration applies, `scripts/verify_kei100_id_alignment.py` runs the mismatch query and exits 0 on a clean state. The query classifies four mismatch shapes:

| Shape | Condition |
|---|---|
| `url_set_id_null` | `linear_url IS NOT NULL AND linear_id IS NULL` |
| `url_id_disagree` | URL-extracted KEI ≠ `linear_id` |
| `id_kei_but_linear_id_null` | `id ~ '^KEI-[0-9]+$' AND linear_id IS NULL` |
| `linear_id_malformed` | `linear_id` doesn't match `^KEI-[0-9]+$` |

## Test plan

- [x] `python3 -m pytest tests/migrations/test_kei100_linear_id_migration.py` → **14 passed in 0.08s**
- [x] `ruff check && ruff format --check` → all clean
- [x] Regex extraction Python ↔ Postgres equivalence (5 URL shapes)
- [x] Migration shape: column, ordered backfill, partial unique index, trigger
- [x] **Guard test** — migration MUST NOT contain `DROP COLUMN` (Phase 2 protection)
- [ ] (post-merge) Apply migration on Supabase, run `verify_kei100_id_alignment.py`, confirm `OK: 0 ID mismatches`

## Refs

- Linear: KEI-100
- Beads: `Agency_OS-k0edyt`
- Dispatch: elliot (`kei100-linear-supabase-id-align`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)