### PR TITLE
[SCOUT] fix(kei201): private+archived channel resolution + 323 missing rows backfilled

### DIFF
--- a/scripts/orchestrator/slack_history_ingest.py
+++ b/scripts/orchestrator/slack_history_ingest.py
@@ -253,11 +253,21 @@ def _slack_get(method: str, params: dict[str, Any]) -> dict[str, Any]:
 
 
 def resolve_channel_ids(slugs: tuple[str, ...]) -> dict[str, str]:
-    """Return {slug: channel_id} via conversations.list — slug = name without '#'."""
+    """Return {slug: channel_id} via conversations.list — slug = name without '#'.
+
+    Slack's conversations.list defaults to `types=public_channel`, which silently
+    drops private channels (#ops, #completed_directives, #alerts) even when the
+    bot is a member. `exclude_archived=False` lets archived channels (e.g. #ops)
+    be backfilled — their history is still readable and is in-scope per dispatch.
+    """
     mapping: dict[str, str] = {}
     cursor = ""
     while True:
-        params: dict[str, Any] = {"limit": 200, "exclude_archived": True}
+        params: dict[str, Any] = {
+            "limit": 200,
+            "exclude_archived": False,
+            "types": "public_channel,private_channel",
+        }
         if cursor:
             params["cursor"] = cursor
         body = _slack_get("conversations.list", params)

--- a/tests/scripts/test_slack_history_ingest.py
+++ b/tests/scripts/test_slack_history_ingest.py
@@ -268,3 +268,38 @@ def test_schema_has_required_properties(mod):
     # 5 standard + 4 corpus-specific
     assert {"raw_text", "environment_hash", "created_at", "agent", "kei"} <= props
     assert {"channel", "message_type", "ts", "thread_ts"} <= props
+
+
+# ─── Channel resolution ─────────────────────────────────────────────────────
+
+
+def test_resolve_channel_ids_includes_private_and_archived(mod, monkeypatch):
+    """conversations.list default is public_channel only — drops private channels
+    silently. Pre-fix this caused #ops, #completed_directives, #alerts to be
+    skipped on live extract (only #ceo + #execution made it into Slack_history).
+    Verify the fix passes types=public_channel,private_channel and
+    exclude_archived=False (so archived #ops backfills too).
+    """
+    captured: list[dict] = []
+
+    def fake_get(method, params):
+        captured.append({"method": method, "params": dict(params)})
+        return {
+            "channels": [
+                {"name": "ops", "id": "C_OPS", "is_private": True, "is_archived": True},
+                {"name": "ceo", "id": "C_CEO", "is_private": False},
+                {"name": "execution", "id": "C_EXEC", "is_private": False},
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+    monkeypatch.setattr(mod, "BOT_TOKEN", "xoxb-test")
+    monkeypatch.setattr(mod, "_slack_get", fake_get)
+
+    result = mod.resolve_channel_ids(("ops", "ceo", "execution"))
+
+    assert result == {"ops": "C_OPS", "ceo": "C_CEO", "execution": "C_EXEC"}
+    assert len(captured) == 1
+    p = captured[0]["params"]
+    assert p["types"] == "public_channel,private_channel"
+    assert p["exclude_archived"] is False


### PR DESCRIPTION
## Summary

Closes KEI-201 bulk-backfill — the literal Elliot dispatch (#execution, #ceo, #ops) plus PR #1001's full 5-channel spec (#completed_directives, #alerts) is now live in `Slack_history` Weaviate collection.

**Empirical root cause:** `slack_history_ingest.py.resolve_channel_ids` called `conversations.list` with no `types=` param. Slack's API default is `public_channel` only, so private channels were silently filtered out **even when the bot is a member**. PR #1001's live bulk extract therefore populated only the two public channels in `CHANNEL_SLUGS` (#ceo, #execution); #ops + #completed_directives + #alerts (all private; #ops also archived) failed to resolve and were skipped.

**Linear:** [KEI-201](https://linear.app/keiracom/issue/KEI-201) · **Off:** `7e068948a`

## What lands (2 files, +47 / -2 LoC)

| File | Change |
|---|---|
| `scripts/orchestrator/slack_history_ingest.py` | `resolve_channel_ids` passes `types=public_channel,private_channel` + `exclude_archived=False` |
| `tests/scripts/test_slack_history_ingest.py` | New test asserts both params land on the `_slack_get` call (monkeypatched), covers the private + archived path |

## Verbatim verify

```
$ python3 -m pytest tests/scripts/test_slack_history_ingest.py tests/scripts/test_slack_history_indexer.py -q
..................................................                       [100%]
50 passed in 0.22s

$ ruff check + format --check
All checks passed!
2 files already formatted

$ for ch in ops completed_directives alerts; do
    python3 scripts/orchestrator/slack_history_ingest.py --channel "$ch" | tail -3
  done
2026-05-18 20:35:18,577 INFO #ops done: 11 messages kept
2026-05-18 20:35:18,577 INFO summary: by_channel={"ops": 11} by_type={"agent_chatter": 11} skipped_noise=0 posted=11 failed=0
2026-05-18 20:35:49,528 INFO #completed_directives done: 64 messages kept
2026-05-18 20:35:49,528 INFO summary: by_channel={"completed_directives": 64} by_type={"ceo_directive": 4, "completion_report": 5, "agent_chatter": 55} skipped_noise=0 posted=64 failed=0
2026-05-18 20:37:42,412 INFO #alerts done: 248 messages kept
2026-05-18 20:37:42,412 INFO summary: by_channel={"alerts": 248} by_type={"agent_chatter": 169, "governance_event": 23, "ceo_directive": 54, "debug_session": 1, "completion_report": 1} skipped_noise=0 posted=248 failed=0
```

## Post-fix Weaviate state

```
$ curl http://127.0.0.1:8090/v1/graphql -d '{...Aggregate Slack_history groupBy: ["channel"]...}'
{
  "execution":            12890,
  "ceo":                   1559,
  "alerts":                 248,
  "completed_directives":    64,
  "ops":                     11
}
Total: 14,772 rows (5 channels — all KEI-201 spec channels live)
```

## Context — dispatch vs reality

Elliot's dispatch at 12:21 + 20:29 UTC framed KEI-201 as "bulk-backfill half still TODO". Empirical state on session start:

- PR #1001 (merged 2026-05-18T06:33Z) shipped the bulk extractor + Weaviate schema → **bulk extractor code IS the bulk backfill**, dispatch wording was stale.
- PR #1025 (merged 2026-05-18T09:58Z) shipped the incremental indexer + vectorizer-config fix.
- Live extract was kicked off at PR #1025 open-time. It populated 14,449 rows but **only 2 channels** — root cause uncovered this session.

So the actual remaining delta was a hidden bug, not net-new build. Surfacing because Slack relays are decommissioning per Dave 2026-05-18 — this is the last clean shot at the private-channel history before access deteriorates.

## Slack decommissioning context

Per Dave 2026-05-18 dispatch: "Slack relays now decommissioned; fleet on NATS." The Slack_history Weaviate collection is now an immutable archive of pre-NATS-era ops history. With this PR landing, that archive is complete per the original KEI-201 spec.

## Known follow-ups (not in this PR)

- **GOV-9 GAP from PR #1025 still standing:** `agent_chatter` fallback bucket = 11,738 / 14,772 = 79.5% of rows. Filter signal/noise inverted vs the dispatch's 80% noise-reduction target. Requires Dave call on whether to expand filter patterns past `[READY:]` / `[FLEET-STATUS:]` / bare-callsign / Vercel rate-limit, or accept the chatter for retrieval recall. Filing separate KEI for filter expansion would land cleanly.
- **Indexer timer install** — `systemd/slack_history_indexer.timer` exists but is not installed on prime hosts (separate ops task; with Slack decommissioning the incremental indexer's value is decaying).
- **Semantic query verification** — gated on KEI-196 vectorizer cutover for the existing 1536-dim classes (Discoveries/Decisions/Keis); Slack_history schema is already on 768-dim gemini-embedding-001 per PR #1025.

## Out of scope

- Filter expansion (separate KEI per GOV-10 — bounded gap is hidden-bug not filter-design)
- Indexer timer install on prime hosts (ops task, not Scout's lane)
- Re-vectorize legacy 1536-dim classes (KEI-196 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)