### PR TITLE
[ATLAS] fix(kei70st): indexer_base prepare_threshold=None — unblock psycopg+pgbouncer

### DIFF
--- a/scripts/orchestrator/indexer_base.py
+++ b/scripts/orchestrator/indexer_base.py
@@ -259,7 +259,12 @@ def run_db_indexer(
     signal.signal(signal.SIGTERM, _on_signal)
     signal.signal(signal.SIGINT, _on_signal)
 
-    with psycopg.connect(resolve_pg_dsn(), autocommit=True) as conn:
+    # prepare_threshold=None per reference_psycopg_supabase_pgbouncer (KEI-54B
+    # PR #881): Supabase pooler is pgbouncer txn-mode and drops PREPARE between
+    # leases. Without this, psycopg3 auto-prepares after 5 executions and the
+    # next batch hits DuplicatePreparedStatement → InvalidSqlStatementName loop
+    # (root cause of KEI-70st — 20h stuck error stream after first ~200 rows).
+    with psycopg.connect(resolve_pg_dsn(), autocommit=True, prepare_threshold=None) as conn:
         indexer = indexer_factory(conn)
         target_class = indexer.target_class
         logger.info(

--- a/tests/scripts/test_indexer_base_prepare_threshold_kei70st.py
+++ b/tests/scripts/test_indexer_base_prepare_threshold_kei70st.py
@@ -1,0 +1,78 @@
+"""Regression: run_db_indexer must pass prepare_threshold=None to psycopg.connect.
+
+KEI-70st root cause was Supabase pgbouncer txn-mode dropping PREPARE between
+leases. Without prepare_threshold=None, psycopg3 auto-prepares after 5
+executions and the next batch hits DuplicatePreparedStatement, then
+InvalidSqlStatementName forever. Locks the fix in place so a future
+refactor can't silently drop the kwarg.
+
+Pattern mirrors reference_psycopg_supabase_pgbouncer (PR #881 / KEI-54B).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "orchestrator"))
+
+
+def test_run_db_indexer_passes_prepare_threshold_none(monkeypatch):
+    """psycopg.connect must be called with prepare_threshold=None."""
+    import indexer_base as mod  # noqa: PLC0415
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
+    monkeypatch.setattr(sys, "argv", ["indexer_base_test", "--once"])
+
+    captured_kwargs: dict = {}
+
+    class _FakeConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_connect(dsn, **kwargs):
+        captured_kwargs.update(kwargs)
+        captured_kwargs["_dsn"] = dsn
+        return _FakeConn()
+
+    def _fake_indexer_factory(conn):
+        indexer = mock.MagicMock()
+        indexer.source_name = "test"
+        indexer.target_class = "TestClass"
+        indexer.ensure_target_class.return_value = None
+        indexer.index_once.return_value = mod.BatchOutcome(selected=0, success=0, failed=0)
+        return indexer
+
+    fake_psycopg = mock.MagicMock()
+    fake_psycopg.connect = _fake_connect
+    fake_heartbeat_shim = mock.MagicMock()
+    fake_heartbeat_shim.heartbeat_tick = mock.MagicMock()
+
+    with (
+        mock.patch.dict(
+            sys.modules, {"psycopg": fake_psycopg, "_heartbeat_shim": fake_heartbeat_shim}
+        ),
+        mock.patch.object(mod, "aggregate_count", return_value=0),
+    ):
+        mod.run_db_indexer(
+            _fake_indexer_factory,
+            unit_name="test-unit",
+            default_batch=10,
+            poll_seconds=1,
+        )
+
+    assert "prepare_threshold" in captured_kwargs, (
+        "psycopg.connect called without prepare_threshold kwarg — "
+        "Supabase pgbouncer will drop PREPARE between leases and trigger "
+        "DuplicatePreparedStatement after ~5 batches (see KEI-70st)."
+    )
+    assert captured_kwargs["prepare_threshold"] is None, (
+        f"prepare_threshold must be None to disable psycopg3 auto-prepare, "
+        f"got: {captured_kwargs['prepare_threshold']!r}"
+    )
+    assert captured_kwargs.get("autocommit") is True


### PR DESCRIPTION
## Summary

- `indexer_base.run_db_indexer` was calling `psycopg.connect()` without `prepare_threshold=None`. Supabase pooler is pgbouncer txn-mode and drops PREPARE between leases — psycopg3 auto-prepares after 5 executions and every subsequent batch hits `DuplicatePreparedStatement: "_pg3_0" already exists` → `InvalidSqlStatementName: "_pg3_0" does not exist`.
- Both `elliot-memories-indexer` and `ceo-memory-indexer` have been error-looping silently for ~20 hours (since 2026-05-18 00:40 UTC). Weaviate `AgentMemories` is stuck at 192 / `Decisions` similarly degraded.
- One-line fix mirrors `reference_psycopg_supabase_pgbouncer` (KEI-54B, PR #881) — 12+ files in `src/` already apply this pattern; indexer-side was missed.

## Drift framing correction

Aiden's original bug report cited `192 / 7432`. Two different tables conflated:

| Table | Rows | Indexed | Note |
|---|---|---|---|
| `elliot_internal.memories` (what indexer reads) | 1665 | 192 | **In-scope** — this PR fixes |
| `public.agent_memories` | 7433 | 0 | **Out of scope** — no indexer exists; new KEI to be filed |

Corrected in-scope drift: **192 / 1665 = 88% on elliot_internal alone**. The `public.agent_memories` coverage gap is a separate scope (new indexer module + Weaviate properties).

## Empirical evidence

```
2026-05-18 00:37:23,641 INFO indexer start source=elliot_memories class=AgentMemories batch=200
2026-05-18 00:37:24,856 INFO batch outcome={'selected': 200, 'success': 200, 'failed': 0} class_count=200
...
2026-05-18 00:40:02,412 ERROR batch failed — sleeping then continuing
psycopg.errors.DuplicatePreparedStatement: prepared statement "_pg3_0" already exists
...
2026-05-18 21:05:21,248 ERROR batch failed — sleeping then continuing
psycopg.errors.InvalidSqlStatementName: prepared statement "_pg3_1" does not exist
```

Aiden cited "zero log output in journalctl" — service routes stdout/stderr to `/home/elliotbot/clawd/logs/elliot-memories-indexer.log` via `StandardOutput=append:...` in the unit file, not journald. The log file has 30,961 lines of the error stream.

## Test plan

- [x] `tests/scripts/test_indexer_base_prepare_threshold_kei70st.py` — mocks psycopg + heartbeat_shim, asserts `prepare_threshold=None` kwarg passed
- [x] Negative-path verified: test FAILS when fix reverted (`AssertionError: psycopg.connect called without prepare_threshold kwarg`)
- [x] `ruff check` + `ruff format --check` clean
- [ ] Post-merge: `systemctl --user restart elliot-memories-indexer ceo-memory-indexer` from main worktree
- [ ] Verify Weaviate `AgentMemories` count climbs 192 → ~1665 within 5 minutes
- [ ] Verify Weaviate `Decisions` count climbs (ceo-memory)
- [ ] Verify `/home/elliotbot/clawd/logs/elliot-memories-indexer.log` shows clean `batch outcome` lines, no `DuplicatePreparedStatement`

## Follow-up (separate PR — KEI to be filed)

P2 KEI: build `agent_memories_indexer.py` covering `public.agent_memories` → Weaviate `AgentMemories` with `callsign` + `source_type` + `state` properties + 7433-row backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)