### PR TITLE
[ATLAS] fix(kei201-followup): kei196_reingest_with_vectorizer config + AI Studio key header

### DIFF
--- a/scripts/orchestrator/kei196_reingest_with_vectorizer.py
+++ b/scripts/orchestrator/kei196_reingest_with_vectorizer.py
@@ -16,8 +16,11 @@ This script:
 
 Prerequisites (operator must verify before --execute):
   - Live Weaviate instance has text2vec-google module enabled (Dave Option A —
-    no local inference container required; uses GOOGLE_API_KEY env var for AI Studio)
-  - GOOGLE_API_KEY env var set with a valid Gemini API key
+    no local inference container required; AI Studio v1beta endpoint).
+  - GOOGLE_API_KEY env var set in THIS SCRIPT'S process with a valid Gemini
+    API key. Weaviate process itself does not need the key — auth is via
+    X-Goog-Studio-Api-Key header attached per-request by this script (KEI-201
+    follow-up PR #1025 commit ef408fe05).
   - Backup directory writable: /home/elliotbot/clawd/logs/kei196_backup/
 
 Steps are independent + idempotent:
@@ -60,6 +63,12 @@ BACKUP_DIR_DEFAULT = Path(
     os.environ.get("KEI196_BACKUP_DIR", "/home/elliotbot/clawd/logs/kei196_backup")
 )
 
+# Read at script-process level (not Weaviate-process). KEI-201 follow-up:
+# Scout's PR #1025 empirically confirmed Weaviate process does not carry
+# GOOGLE_API_KEY in its env, so AI Studio auth must come from a per-request
+# X-Goog-Studio-Api-Key header attached by THIS script.
+GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY", "")
+
 TARGET_COLLECTIONS: tuple[str, ...] = (
     "Discoveries",
     "Keis",
@@ -70,17 +79,39 @@ TARGET_COLLECTIONS: tuple[str, ...] = (
 
 NEW_VECTORIZER = "text2vec-google"
 # text2vec-google (AI Studio / Gemini) — no local inference container needed.
-# projectId is Vertex AI only; omit for AI Studio (key-based auth via GOOGLE_API_KEY).
+# KEI-201 follow-up corrections from Scout's empirical fix in PR #1025
+# (commit ef408fe05):
+#   - apiEndpoint=generativelanguage.googleapis.com — required for Weaviate to
+#     flip into AI-Studio (key-based) mode instead of Vertex (projectId-based).
+#   - modelId=gemini-embedding-001 — text-embedding-004 is the Vertex name and
+#     404s on AI Studio v1beta; gemini-embedding-001 is the supported AI Studio
+#     name per Gemini ListModels.
+# Auth pattern: per-request X-Goog-Studio-Api-Key header attached in
+# _http_request below (Weaviate process does not carry GOOGLE_API_KEY).
 NEW_MODULE_CONFIG = {
     "text2vec-google": {
-        "modelId": "text-embedding-004",
+        "apiEndpoint": "generativelanguage.googleapis.com",
+        "modelId": "gemini-embedding-001",
         "vectorizeClassName": False,
     }
 }
 
 
+def _attach_studio_key(req: urlrequest.Request) -> None:
+    """Add the AI Studio per-request key header when GOOGLE_API_KEY is set.
+
+    Weaviate's text2vec-google module needs this header to authenticate with
+    AI Studio v1beta on every embedding-triggering request (POST /v1/objects,
+    POST /v1/graphql nearText). Weaviate process does not carry the key in
+    its env — see KEI-201 PR #1025 / commit ef408fe05.
+    """
+    if GOOGLE_API_KEY:
+        req.add_header("X-Goog-Studio-Api-Key", GOOGLE_API_KEY)
+
+
 def _http_get(path: str) -> dict:
     req = urlrequest.Request(f"{WEAVIATE_BASE}{path}", method="GET")
+    _attach_studio_key(req)
     with urlrequest.urlopen(req, timeout=60) as resp:
         return json.loads(resp.read().decode())
 
@@ -89,6 +120,7 @@ def _http_request(method: str, path: str, body: dict | None = None) -> dict | No
     data = json.dumps(body).encode() if body is not None else None
     req = urlrequest.Request(f"{WEAVIATE_BASE}{path}", data=data, method=method)
     req.add_header("Content-Type", "application/json")
+    _attach_studio_key(req)
     with urlrequest.urlopen(req, timeout=60) as resp:
         raw = resp.read().decode()
         return json.loads(raw) if raw else None

--- a/skills/SKILL_INDEX.md
+++ b/skills/SKILL_INDEX.md
@@ -21,6 +21,7 @@
 | smartlead | `skills/smartlead/SKILL.md` | MCP bridge dispatch (116 tools) | Replaces Salesforge |
 | superpowers | `skills/superpowers/SKILL.md` | Agent capability extensions | |
 | three-store-save | `skills/three-store-save/SKILL.md` | Session persistence | |
+| weaviate-vectorizer | `skills/weaviate-vectorizer/SKILL.md` | `scripts/orchestrator/slack_history_ingest.py`, `scripts/orchestrator/kei196_reingest_with_vectorizer.py` | text2vec-google AI Studio config + per-request key header (KEI-196 / KEI-201 follow-up) |
 
 ## Legacy Skills (non-standard naming, kept as reference)
 

--- a/skills/weaviate-vectorizer/SKILL.md
+++ b/skills/weaviate-vectorizer/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: weaviate-vectorizer
+description: Canonical configuration for Weaviate text2vec-google against AI Studio v1beta. Use for any new collection schema that needs embeddings, or when patching a script that creates / re-creates a Weaviate class. Covers schema config, per-request auth header, and the two empirical traps from KEI-196 + KEI-201.
+---
+
+# Weaviate text2vec-google — AI Studio v1beta configuration
+
+Dave Option A (KEI-196 ratified): use Google AI Studio (`generativelanguage.googleapis.com`) over Vertex AI for embeddings — no projectId, no service account, no self-hosted inference container. Auth is API-key based via a per-request header attached by the calling script.
+
+## Schema config (use this verbatim for new collections)
+
+```python
+NEW_MODULE_CONFIG = {
+    "text2vec-google": {
+        "apiEndpoint": "generativelanguage.googleapis.com",
+        "modelId": "gemini-embedding-001",
+        "vectorizeClassName": False,
+    }
+}
+```
+
+Two traps documented by empirical KEI-201 work (PR #1025 commit `ef408fe05`):
+
+1. **`apiEndpoint` is REQUIRED.** Without it, Weaviate's text2vec-google module assumes Vertex AI and demands `projectId`. Setting `apiEndpoint=generativelanguage.googleapis.com` flips the module into AI-Studio (key-based) mode.
+
+2. **`modelId` is `gemini-embedding-001`, not `text-embedding-004`.** `text-embedding-004` is the Vertex AI name; AI Studio v1beta returns 404. `gemini-embedding-001` is the supported AI Studio name per Gemini ListModels.
+
+## Per-request auth header (REQUIRED on every embedding-triggering request)
+
+Weaviate process does NOT carry `GOOGLE_API_KEY` in its env. Auth must come from a per-request header attached by the script that POSTs to Weaviate. Read the key at the script-process level:
+
+```python
+GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY", "")
+
+def _attach_studio_key(req: urlrequest.Request) -> None:
+    if GOOGLE_API_KEY:
+        req.add_header("X-Goog-Studio-Api-Key", GOOGLE_API_KEY)
+```
+
+Apply on every:
+- `POST /v1/objects` (insert — vectorizer fires to compute embedding)
+- `POST /v1/graphql` with `nearText` (query — vectorizer fires to embed the query string)
+
+Schema CRUD (`POST /v1/schema`, `DELETE /v1/schema/<class>`) and read endpoints (`GET /v1/objects?class=...`) don't trigger embeddings so the header is optional there — but attaching it uniformly is safe and avoids per-call decisions.
+
+## Live-code references
+
+- `scripts/orchestrator/slack_history_ingest.py` — Slack_history collection ingest (PR #1025, the empirical reference)
+- `scripts/orchestrator/kei196_reingest_with_vectorizer.py` — multi-collection reingest tool covering `Discoveries, Keis, AgentMemories, Decisions, Codebase` (this skill's update PR — see commit on `atlas/kei201-followup-reingest-vectorizer-fix`)
+
+## Failure modes that this skill prevents
+
+| Symptom | Root cause |
+|---|---|
+| `422` on first non-dry-run POST `/v1/objects` | Missing `apiEndpoint` OR wrong `modelId` |
+| `404` from AI Studio `/v1beta/models/<id>:embedContent` in Weaviate logs | `modelId=text-embedding-004` (Vertex name) on AI Studio endpoint |
+| Vectorizer-active class accepts inserts but `nearText` returns empty / score 0.0 | Missing `X-Goog-Studio-Api-Key` header on query requests |
+| All embeddings zero / `certainty=0.0` on probe | Same — header missing, OR `GOOGLE_API_KEY` unset in script-process env |
+
+## Verification probe
+
+After bringing up a vectorizer-active class, run:
+
+```python
+gql = '{ Get { <Class>(nearText: {concepts: ["memory recall"]}, limit: 1) { _additional { certainty } } } }'
+```
+
+Top `certainty > 0.0` confirms the vectorizer is computing real embeddings. `0.0` indicates the embedding pipeline is broken — check `GOOGLE_API_KEY` env + the per-request header is being attached.
+
+## Sources
+
+- KEI-196 commit `12cfaf93a` — original schema swap (had two of the three bugs documented above).
+- KEI-201 PR #1025 commit `ef408fe05` — Scout's empirical fix on `slack_history_ingest.py`; canonical working pattern.
+- KEI-201 follow-up (this PR) — applied the same pattern to `kei196_reingest_with_vectorizer.py` + created this skill.

--- a/tests/scripts/test_kei196_reingest_vectorizer_config.py
+++ b/tests/scripts/test_kei196_reingest_vectorizer_config.py
@@ -1,0 +1,81 @@
+"""Regression: kei196_reingest_with_vectorizer.py vectorizer config + key header.
+
+Locks in the three corrections from KEI-201 follow-up (Scout's empirical fix
+in PR #1025 commit ef408fe05):
+
+1. moduleConfig has apiEndpoint=generativelanguage.googleapis.com (without
+   this, Weaviate's text2vec-google module assumes Vertex and demands
+   projectId).
+2. modelId=gemini-embedding-001 (NOT text-embedding-004 — that's the Vertex
+   name and 404s on AI Studio v1beta).
+3. _attach_studio_key attaches X-Goog-Studio-Api-Key header from the
+   script-process GOOGLE_API_KEY env (Weaviate process does not carry it).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from urllib import request as urlrequest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "orchestrator"))
+
+
+def _load_module(monkeypatch, *, google_api_key: str = "fake-test-key"):
+    """Reload the module with a controlled GOOGLE_API_KEY env."""
+    monkeypatch.setenv("GOOGLE_API_KEY", google_api_key)
+    sys.modules.pop("kei196_reingest_with_vectorizer", None)
+    return importlib.import_module("kei196_reingest_with_vectorizer")
+
+
+def test_module_config_has_ai_studio_api_endpoint(monkeypatch):
+    mod = _load_module(monkeypatch)
+    cfg = mod.NEW_MODULE_CONFIG["text2vec-google"]
+    assert cfg["apiEndpoint"] == "generativelanguage.googleapis.com", (
+        "Missing apiEndpoint pins Weaviate to Vertex AI mode (demands projectId). "
+        "AI Studio mode requires apiEndpoint=generativelanguage.googleapis.com — "
+        "see KEI-201 PR #1025."
+    )
+
+
+def test_module_config_uses_ai_studio_model_id(monkeypatch):
+    mod = _load_module(monkeypatch)
+    cfg = mod.NEW_MODULE_CONFIG["text2vec-google"]
+    assert cfg["modelId"] == "gemini-embedding-001", (
+        f"modelId must be gemini-embedding-001 (AI Studio v1beta name). "
+        f"text-embedding-004 is the Vertex name and 404s on AI Studio. "
+        f"Got: {cfg['modelId']!r}"
+    )
+
+
+def test_module_config_disables_class_name_vectorization(monkeypatch):
+    mod = _load_module(monkeypatch)
+    cfg = mod.NEW_MODULE_CONFIG["text2vec-google"]
+    assert cfg["vectorizeClassName"] is False
+
+
+def test_attach_studio_key_sets_header_when_env_present(monkeypatch):
+    mod = _load_module(monkeypatch, google_api_key="real-test-key")
+    req = urlrequest.Request("http://localhost/v1/objects", method="POST")
+    mod._attach_studio_key(req)
+    assert req.get_header("X-goog-studio-api-key") == "real-test-key"
+
+
+def test_attach_studio_key_skips_header_when_env_blank(monkeypatch):
+    mod = _load_module(monkeypatch, google_api_key="")
+    req = urlrequest.Request("http://localhost/v1/objects", method="POST")
+    mod._attach_studio_key(req)
+    assert req.get_header("X-goog-studio-api-key") is None, (
+        "When GOOGLE_API_KEY is unset the script must not attach an empty "
+        "header (would 401 the Weaviate request with a confusing blank-key)."
+    )
+
+
+def test_target_collections_includes_agent_memories(monkeypatch):
+    """KEI-70st sibling: AgentMemories needs vectorizer reingest after the
+    indexer-base prepare_threshold fix refills the collection."""
+    mod = _load_module(monkeypatch)
+    assert "AgentMemories" in mod.TARGET_COLLECTIONS
+    assert len(mod.TARGET_COLLECTIONS) >= 5


### PR DESCRIPTION
## Summary

Patches `scripts/orchestrator/kei196_reingest_with_vectorizer.py` to match the empirically-validated working pattern Scout landed in PR #1025 (commit `ef408fe05`) for `slack_history_ingest`. Three concrete defects from the original KEI-196 swap (commit `12cfaf93a`) were carried into the reingest script and would have caused first non-dry-run to 422.

| # | Defect | Fix |
|---|---|---|
| 1 | `moduleConfig` missing `apiEndpoint` — Weaviate's text2vec-google falls into Vertex mode and demands `projectId` | Added `apiEndpoint=generativelanguage.googleapis.com` to flip into AI Studio (key-based) mode |
| 2 | `modelId=text-embedding-004` — that's the Vertex name; AI Studio v1beta returns 404 | Changed to `modelId=gemini-embedding-001` (supported AI Studio name per Gemini ListModels) |
| 3 | Weaviate process doesn't carry `GOOGLE_API_KEY` in its env — AI Studio auth had no path | Added `_attach_studio_key()` helper; reads `GOOGLE_API_KEY` at script-process level + attaches `X-Goog-Studio-Api-Key` header on every request |

## LAW XIII skill update

Created `skills/weaviate-vectorizer/SKILL.md` as the canonical reference for text2vec-google AI Studio configuration. Both `slack_history_ingest` (KEI-201) and `kei196_reingest_with_vectorizer` (this PR) cite it. Indexed in `skills/SKILL_INDEX.md`.

## Live staging smoke evidence

Probe class `Kei201Probe` created with the new config, single object POSTed, nearText probe validated, then dropped:

```
[KEY] present (len=39)
[CFG] {"text2vec-google": {"apiEndpoint": "generativelanguage.googleapis.com", "modelId": "gemini-embedding-001", "vectorizeClassName": false}}
[STEP] created Kei201Probe with new vectorizer config — HTTP 200
[STEP] POSTed test object id=06652289… — HTTP 200
[VALIDATE] passed=True certainty=0.8586
[STEP] dropped Kei201Probe (cleanup) — HTTP 200
[RESULT] PASS
```

certainty=**0.8586** > 0.0 proves the entire embedding pipeline is wired correctly: schema accepted → POST didn't 422 → AI Studio authenticated via the header → embedding computed → nearText returns non-zero similarity.

## Dry-run probe

```
$ python kei196_reingest_with_vectorizer.py --step backup --class AgentMemories --backup-dir /tmp/kei201_followup_probe
2026-05-18 21:24:37,812 INFO backup AgentMemories -> /tmp/kei201_followup_probe/AgentMemories.jsonl (192 objects)
2026-05-18 21:24:37,812 INFO backup step complete: 192 objects across 1 classes

$ python kei196_reingest_with_vectorizer.py --step all --class AgentMemories
2026-05-18 21:24:37,872 ERROR --step all is destructive — re-run with --execute.
```

Dry-run safety gate still works correctly.

## Test plan

- [x] 6 unit tests in `tests/scripts/test_kei196_reingest_vectorizer_config.py` — pass
- [x] Negative-path verified: 4/6 fail when fix is reverted (apiEndpoint, modelId, header-present, header-absent)
- [x] `ruff check` + `ruff format --check` clean
- [x] Live staging smoke against Weaviate `text2vec-google` module — certainty=0.8586
- [x] Dry-run probe on AgentMemories class (192 objects backed up)
- [ ] Post-merge: operator runs `--step all --execute` per collection during scheduled maintenance window (separate ops task)

## Sibling context

KEI-70st (PR #1046, awaiting merge) restores `AgentMemories` from 192 → ~1665 by unblocking the indexer-base prepare_threshold bug. This PR makes that restored data **embeddings-correct** when the operator runs reingest. Order doesn't matter — they're orthogonal — but combined they restore the memory-recall path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)