### PR TITLE
[ATLAS] fix(ljz5): indexer-side raw_text guard at BaseIndexer.index_once

### DIFF
--- a/scripts/orchestrator/indexer_base.py
+++ b/scripts/orchestrator/indexer_base.py
@@ -199,11 +199,42 @@ class BaseIndexer(ABC, Generic[R]):
         success = 0
         failed = 0
         for row in rows:
-            if post_object(self.build_object(row)):
+            obj = self.build_object(row)
+            if not _has_valid_raw_text(obj):
+                # KEI-103 / Agency_OS-ljz5: NULL or empty raw_text downstream
+                # crashes llama-index TextNode validation in retrieve_with_outcome,
+                # masking a 5-node ANN hit as a zero-hit miss. Belt-and-suspenders
+                # complement to Scout's PR #992 submit_discovery writer-side guard:
+                # this drops any indexer-produced object that would orphan in
+                # Weaviate. No POST occurs.
+                logger.warning(
+                    "indexer=%s skipping POST: id=%s has empty/NULL raw_text",
+                    self.source_name,
+                    obj.get("id"),
+                )
+                failed += 1
+                continue
+            if post_object(obj):
                 success += 1
             else:
                 failed += 1
         return BatchOutcome(selected=len(rows), success=success, failed=failed)
+
+
+def _has_valid_raw_text(obj: dict) -> bool:
+    """Return True if obj is safe to POST given the retrieval-orchestrator
+    contract (src/retrieval/weaviate_store.py WEAVIATE_TEXT_KEY = "raw_text").
+
+    No-op for indexers that don't write raw_text (drive_strategic uses
+    `content`, tool_call_log uses other fields) — their target classes are
+    not queried via the raw_text retrieval path.
+    """
+    props = obj.get("properties") or {}
+    if "raw_text" not in props:
+        # Indexer's class isn't on the raw_text retrieval contract — pass.
+        return True
+    rt = props["raw_text"]
+    return isinstance(rt, str) and bool(rt.strip())
 
 
 # ─── Shared DB-indexer runtime (KEI-109 dedup extraction) ────────────────────

--- a/tests/scripts/test_indexer_base_raw_text_guard_ljz5.py
+++ b/tests/scripts/test_indexer_base_raw_text_guard_ljz5.py
@@ -1,0 +1,138 @@
+"""Regression: BaseIndexer.index_once drops empty/NULL raw_text BEFORE POST.
+
+Agency_OS-ljz5 / KEI-103: NULL raw_text in Weaviate-indexed objects crashes
+llama-index TextNode validation in src.retrieval.orchestrator with:
+    text Input should be a valid string [input_value=None]
+Result: retrieve_with_outcome returns 0 nodes even when ANN matched, looking
+like a zero-hit miss when it was actually a malformed-row miss.
+
+Scout's PR #992 (KEI-197) ships writer-side guards at submit_discovery + a
+cleanup script (--class flag). This file locks in the indexer-side
+belt-and-suspenders guard at BaseIndexer.index_once so no future indexer
+(or refactor) can post NULL/empty raw_text to a retrieval-path collection.
+
+Empirical baseline 2026-05-18 21:50 UTC (atlas worktree probe):
+    Discoveries     14166    9390 NULL    0 empty   <- Scout's PR #992 territory
+    Keis              313       0 NULL    0 empty   <- clean
+    AgentMemories     192       0 NULL    0 empty   <- clean
+    Decisions         300       0 NULL    0 empty   <- clean
+    Codebase           94       0 NULL    0 empty   <- clean
+The 4 BaseIndexer-backed collections are clean today; this PR keeps them
+clean against future regressions.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "orchestrator"))
+
+import indexer_base as ib  # noqa: E402
+
+# ─── _has_valid_raw_text unit ─────────────────────────────────────────────
+
+
+def test_valid_raw_text_passes():
+    obj = {"id": "1", "class": "Keis", "properties": {"raw_text": "real content"}}
+    assert ib._has_valid_raw_text(obj) is True
+
+
+def test_null_raw_text_rejected():
+    obj = {"id": "1", "class": "Keis", "properties": {"raw_text": None}}
+    assert ib._has_valid_raw_text(obj) is False
+
+
+def test_empty_string_raw_text_rejected():
+    obj = {"id": "1", "class": "Keis", "properties": {"raw_text": ""}}
+    assert ib._has_valid_raw_text(obj) is False
+
+
+def test_whitespace_only_raw_text_rejected():
+    obj = {"id": "1", "class": "Keis", "properties": {"raw_text": "   \t\n  "}}
+    assert ib._has_valid_raw_text(obj) is False
+
+
+def test_missing_raw_text_property_passes():
+    """drive_strategic uses 'content' not 'raw_text' — its target class isn't
+    on the raw_text retrieval contract. The guard must not block its POSTs."""
+    obj = {"id": "1", "class": "StrategicDocuments", "properties": {"content": "section text"}}
+    assert ib._has_valid_raw_text(obj) is True
+
+
+def test_no_properties_at_all_passes():
+    """Defensive: malformed obj with no properties at all — let post_object
+    fail on its own with a real HTTP error, not a silent guard skip."""
+    obj = {"id": "1", "class": "Keis"}
+    assert ib._has_valid_raw_text(obj) is True
+
+
+# ─── index_once integration — fake indexer ────────────────────────────────
+
+
+class _FakeIndexer(ib.BaseIndexer[dict]):
+    source_name = "fake"
+    target_class = "Keis"
+    class_schema = {"class": "Keis"}
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetch_batch(self, batch_size):
+        return self._rows[:batch_size]
+
+    def build_object(self, row):
+        return row
+
+
+def test_index_once_skips_null_raw_text_no_post(monkeypatch):
+    posted = []
+    monkeypatch.setattr(ib, "post_object", lambda obj: posted.append(obj) or True)
+
+    indexer = _FakeIndexer(
+        [
+            {"id": "good-1", "class": "Keis", "properties": {"raw_text": "valid"}},
+            {"id": "bad-null", "class": "Keis", "properties": {"raw_text": None}},
+            {"id": "bad-empty", "class": "Keis", "properties": {"raw_text": ""}},
+            {"id": "good-2", "class": "Keis", "properties": {"raw_text": "also valid"}},
+        ]
+    )
+    outcome = indexer.index_once(batch_size=10)
+
+    assert outcome.selected == 4
+    assert outcome.success == 2, f"only good rows should POST; got success={outcome.success}"
+    assert outcome.failed == 2, f"bad rows should count as failed; got failed={outcome.failed}"
+    assert [o["id"] for o in posted] == ["good-1", "good-2"], (
+        f"only valid raw_text rows should reach Weaviate; got {[o['id'] for o in posted]}"
+    )
+
+
+def test_index_once_passes_through_non_raw_text_indexer(monkeypatch):
+    """Drive-style indexer uses 'content' not 'raw_text' — guard must be a no-op."""
+    posted = []
+    monkeypatch.setattr(ib, "post_object", lambda obj: posted.append(obj) or True)
+
+    indexer = _FakeIndexer(
+        [
+            {"id": "drive-1", "class": "StrategicDocuments", "properties": {"content": "x"}},
+            {"id": "drive-2", "class": "StrategicDocuments", "properties": {"content": "y"}},
+        ]
+    )
+    outcome = indexer.index_once(batch_size=10)
+
+    assert outcome.success == 2
+    assert outcome.failed == 0
+    assert [o["id"] for o in posted] == ["drive-1", "drive-2"]
+
+
+def test_index_once_propagates_post_failure(monkeypatch):
+    """Real HTTP failure (post_object returns False) is counted, not silently skipped."""
+    monkeypatch.setattr(ib, "post_object", lambda _obj: False)
+
+    indexer = _FakeIndexer(
+        [{"id": "x", "class": "Keis", "properties": {"raw_text": "valid"}}],
+    )
+    outcome = indexer.index_once(batch_size=10)
+    assert outcome.success == 0
+    assert outcome.failed == 1


### PR DESCRIPTION
## Summary

Belt-and-suspenders complement to Scout's PR #992 (KEI-197). Adds an indexer-side guard at `BaseIndexer.index_once` that drops any object with NULL/empty `raw_text` BEFORE the Weaviate POST — preventing orphan rows that crash llama-index `TextNode` validation in `src.retrieval.orchestrator`:

```
text Input should be a valid string [input_value=None]
```

Scout's #992 guards the writer side (`submit_discovery`); this PR guards the indexer side. They compose.

## Empirical baseline (atlas worktree probe, 2026-05-18 21:50 UTC)

```
Class            total    null   empty
Discoveries     14166    9390       0   <- Scout's PR #992 territory
Keis              313       0       0   <- clean
AgentMemories     192       0       0   <- clean
Decisions         300       0       0   <- clean
Codebase           94       0       0   <- clean
```

Two findings worth flagging:
- **Discoveries grew 43% in 21h** (6,560 → 9,390 NULL orphans since Scout's #992 was filed). #992 should merge urgently.
- **The 4 BaseIndexer-backed collections are clean today.** This guard prevents future regressions, not present bugs.

## Property-name-mismatch hypothesis ruled out

Scout's ljz5 description floated three fix paths. I checked option (c) — orchestrator property-mapping — and ruled it out:

```
$ grep "WEAVIATE_TEXT_KEY" src/retrieval/weaviate_store.py
31:WEAVIATE_TEXT_KEY = "raw_text"
```

Orchestrator already reads `raw_text` correctly. The failure mode is purely NULL VALUE, not property-name confusion. So the canonical fix is value-side validation, which is what both #992 and this PR ship.

## Implementation

- New `_has_valid_raw_text(obj)` helper in `indexer_base`:
  - Returns `True` if `raw_text` is absent from properties (e.g. `drive_strategic_indexer` uses `content`; its target class isn't on the raw_text retrieval contract — guard is a no-op).
  - Returns `True` if `raw_text` is present and non-empty after `.strip()`.
  - Returns `False` if `raw_text` is `None`, `""`, or whitespace-only.
- `BaseIndexer.index_once` now calls the helper; rejected objects log a warning with `source_name` + `obj id` and count as `failed` in the `BatchOutcome` (no Weaviate POST occurs, no silent skip).

## Out-of-scope (deliberately)

Per `feedback_split_orthogonal_scope` this PR doesn't:
- Touch the 9,390 existing Discoveries orphans (that's #992's cleanup script).
- Add per-collection schema NOT NULL constraints (Weaviate doesn't support cleanly on non-indexed fields).
- Modify any specific indexer's `build_object` (none of them are bleeding today; only the BaseIndexer-level guard is added).

## Test plan

- [x] 9 new unit tests in `test_indexer_base_raw_text_guard_ljz5.py`:
  - `_has_valid_raw_text` unit: valid pass / NULL rejected / empty rejected / whitespace rejected / missing-property pass / no-properties pass
  - `index_once` integration: mixed batch (good + null + empty + good) → only good rows POSTed; drive-style indexer (no raw_text) passes through; real `post_object` failures still counted as `failed`
- [x] 48 indexer-related tests pass overall (4 indexer test files + new ljz5 guard test + kei70st prepare_threshold test) — no regression from the `index_once` signature change
- [x] `ruff check` + `ruff format --check` clean

## Sibling context

- PR #992 (Scout / KEI-197) — writer-side guard + cleanup. **OPEN 21h, zero reviews, CI green.** Should merge urgently.
- PR #1046 (atlas / KEI-70st) — `prepare_threshold=None` fix for `elliot-memories-indexer` + `ceo-memory-indexer`; will refill `AgentMemories` from 192 → ~1665 once merged. This guard will protect those refills.
- PR #1049 (atlas / kei208-followup) — `drive_strategic_indexer` method-name fix. Class created in Weaviate but empty pending Agency_OS-jo68 follow-up (google-api-python-client dep + service install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)