### PR TITLE
[SCOUT] feat(kei155): BYO API key entry form + route + pgcrypto encrypt on store

### DIFF
--- a/frontend/app/dispatcher/onboarding/byo-key/page.tsx
+++ b/frontend/app/dispatcher/onboarding/byo-key/page.tsx
@@ -1,27 +1,99 @@
 /**
  * FILE: frontend/app/dispatcher/onboarding/byo-key/page.tsx
  * PURPOSE: Customer enters their own Anthropic/OpenAI API key.
- * KEI: 113B (KEI-155) — implements:
- *      - Form: API key input + provider select
- *      - On submit: POST → backend endpoint that pgp_sym_encrypts via
- *        pgcrypto + stores encrypted_key + SHA-256 lookup hash
- *      - Plaintext NEVER persisted; cleared from React state post-submit
- *      - Deps: KEI-116A pgcrypto schema (KEI-167), KEI-116B encrypt-on-insert (KEI-168),
- *        KEI-116C SHA-256 lookup hash (KEI-169)
- *      - On success → /dispatcher/onboarding/first-task
- *
- * Stub only.
+ * KEI: 113B (KEI-155) — wires:
+ *      - Controlled form: provider select + key input
+ *      - POST /api/v1/dispatcher/byo-key (pgcrypto pgp_sym_encrypt server-side)
+ *      - Plaintext cleared from React state on success — never persists in DOM
+ *      - On 201 → /dispatcher/onboarding/first-task
+ *      - Backend: src/api/routes/customer_api_keys.py wrapping
+ *        src/security/customer_api_keys.store_key (KEI-116A/B/C).
  */
 
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { APIError, api } from "@/lib/api";
+
+type Provider = "anthropic" | "openai";
+
 export default function DispatcherByoKeyPage() {
+  const router = useRouter();
+  const [provider, setProvider] = useState<Provider>("anthropic");
+  const [plaintext, setPlaintext] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    const inFlight = plaintext;
+    try {
+      await api.post("/api/v1/dispatcher/byo-key", {
+        provider,
+        plaintext: inFlight,
+      });
+      setPlaintext("");
+      router.push("/dispatcher/onboarding/first-task");
+    } catch (err) {
+      const msg =
+        err instanceof APIError
+          ? `Could not store key (${err.status}). Check the key and try again.`
+          : "Could not store key. Check your connection and try again.";
+      setError(msg);
+      setSubmitting(false);
+    }
+  };
+
   return (
     <main className="mx-auto max-w-md p-8">
       <h1 className="text-2xl font-semibold">Add your API key</h1>
-      <p className="mt-4 text-sm text-muted-foreground">
-        Implementation pending KEI-113B (KEI-155). Customer pastes their Anthropic
-        or OpenAI key; backend encrypts via pgp_sym_encrypt (KEI-116A/B/C schema);
-        plaintext never persisted; advance to first-task.
+      <p className="mt-2 text-sm text-muted-foreground">
+        We encrypt it on store (pgcrypto pgp_sym_encrypt). Plaintext is never written to disk.
       </p>
+      <form onSubmit={onSubmit} className="mt-6 space-y-4">
+        <label className="block">
+          <span className="text-sm font-medium">Provider</span>
+          <select
+            value={provider}
+            onChange={(e) => setProvider(e.target.value as Provider)}
+            className="mt-1 w-full rounded border px-3 py-2"
+            disabled={submitting}
+          >
+            <option value="anthropic">Anthropic</option>
+            <option value="openai">OpenAI</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium">API key</span>
+          <input
+            type="password"
+            autoComplete="off"
+            spellCheck={false}
+            value={plaintext}
+            onChange={(e) => setPlaintext(e.target.value)}
+            className="mt-1 w-full rounded border px-3 py-2 font-mono text-sm"
+            placeholder="sk-..."
+            minLength={8}
+            required
+            disabled={submitting}
+          />
+        </label>
+        {error && (
+          <p className="text-sm text-red-600" role="alert">
+            {error}
+          </p>
+        )}
+        <button
+          type="submit"
+          className="w-full rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+          disabled={submitting || plaintext.length < 8}
+        >
+          {submitting ? "Storing…" : "Store key and continue"}
+        </button>
+      </form>
     </main>
   );
 }

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -402,6 +402,7 @@ from src.api.routes.bu_readiness import router as bu_readiness_router
 from src.api.routes.campaign_generation import router as campaign_generation_router
 from src.api.routes.campaigns import router as campaigns_router
 from src.api.routes.crm import router as crm_router
+from src.api.routes.customer_api_keys import router as customer_api_keys_router
 from src.api.routes.customers import router as customers_router
 from src.api.routes.cycles import router as cycles_router
 from src.api.routes.dashboard import router as dashboard_router
@@ -447,6 +448,8 @@ app.include_router(patterns_router, prefix="/api/v1/patterns")
 app.include_router(crm_router, prefix="/api/v1")
 # Phase 24F: Customer Import
 app.include_router(customers_router, prefix="/api/v1")
+# KEI-155 (KEI-113B): BYO customer API key entry (encrypts via pgcrypto)
+app.include_router(customer_api_keys_router, prefix="/api/v1")
 # Phase 24H: LinkedIn Connection
 app.include_router(linkedin_router, prefix="/api/v1")
 # Phase 24A: Lead Pool

--- a/src/api/routes/customer_api_keys.py
+++ b/src/api/routes/customer_api_keys.py
@@ -42,7 +42,7 @@ class ByoKeyResponse(BaseModel):
     provider: str = Field(..., description="Provider echoed for confirmation")
 
 
-@router.post("/byo-key", response_model=ByoKeyResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/byo-key", status_code=status.HTTP_201_CREATED)
 async def store_byo_key(
     body: ByoKeyRequest,
     user: Annotated[CurrentUser, Depends(get_current_user_from_token)],

--- a/src/api/routes/customer_api_keys.py
+++ b/src/api/routes/customer_api_keys.py
@@ -1,0 +1,66 @@
+"""
+FILE: src/api/routes/customer_api_keys.py
+PURPOSE: BYO customer API key entry endpoint — KEI-155 (KEI-113B).
+
+Wraps src.security.customer_api_keys.store_key() behind an authenticated
+POST /api/v1/dispatcher/byo-key.
+
+Plaintext NEVER persisted. The route accepts the plaintext key in the request
+body, hands it directly to store_key() (which pgp_sym_encrypts via pgcrypto
+and stores ciphertext + SHA-256 lookup_hash), and discards the plaintext.
+
+customer_id is the authenticated user's id. The customer_api_keys.customer_id
+column has no FK constraint per KEI-116A migration — the intent is "the
+authenticated principal who owns this key", which for the dispatcher BYO
+self-onboarding flow is the auth user itself.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from src.api.dependencies import CurrentUser, get_current_user_from_token
+from src.security import customer_api_keys as keys_service
+
+router = APIRouter(prefix="/dispatcher", tags=["dispatcher"])
+
+
+class ByoKeyRequest(BaseModel):
+    provider: Literal["anthropic", "openai"] = Field(
+        ..., description="LLM provider — anthropic or openai only"
+    )
+    plaintext: str = Field(
+        ..., min_length=8, description="Customer API key (plaintext, in transit only)"
+    )
+
+
+class ByoKeyResponse(BaseModel):
+    id: str = Field(..., description="UUID of the stored customer_api_keys row")
+    provider: str = Field(..., description="Provider echoed for confirmation")
+
+
+@router.post("/byo-key", response_model=ByoKeyResponse, status_code=status.HTTP_201_CREATED)
+async def store_byo_key(
+    body: ByoKeyRequest,
+    user: Annotated[CurrentUser, Depends(get_current_user_from_token)],
+) -> ByoKeyResponse:
+    """Encrypt + store a customer-supplied LLM API key.
+
+    On success the plaintext is dropped (not logged, not returned).
+    Raises 500 if CUSTOMER_KEY_ENCRYPTION_KEY env var is unset on the server.
+    """
+    try:
+        row_id = keys_service.store_key(
+            customer_id=user.id,
+            provider=body.provider,
+            plaintext=body.plaintext,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"key storage misconfigured: {exc}",
+        ) from exc
+    return ByoKeyResponse(id=str(row_id), provider=body.provider)

--- a/tests/api/test_customer_api_keys_route.py
+++ b/tests/api/test_customer_api_keys_route.py
@@ -1,0 +1,130 @@
+"""Tests for src/api/routes/customer_api_keys.py — KEI-155 BYO key entry.
+
+Mocks the auth dep + store_key so the route is exercised without hitting
+Supabase or pgcrypto. Each test confirms:
+  - happy path returns 201 + UUID + provider echo
+  - plaintext never appears in response body
+  - plaintext never logged
+  - invalid provider rejected by Pydantic (422)
+  - too-short plaintext rejected by Pydantic (422)
+  - RuntimeError from store_key surfaces as 500
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.dependencies import get_current_user_from_token
+from src.api.routes.customer_api_keys import router
+
+USER_ID = uuid4()
+ROW_ID = uuid4()
+PLAINTEXT = "sk-anthropic-supersecret-abc123xyz"
+
+
+def _user_stub() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=USER_ID, email="t@example.com", full_name=None, is_platform_admin=False
+    )
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[get_current_user_from_token] = _user_stub
+    return app
+
+
+def test_byo_key_happy_path_returns_201_and_row_id():
+    app = _make_app()
+    with patch("src.api.routes.customer_api_keys.keys_service.store_key", return_value=ROW_ID) as m:
+        client = TestClient(app)
+        resp = client.post(
+            "/api/v1/dispatcher/byo-key",
+            json={"provider": "anthropic", "plaintext": PLAINTEXT},
+        )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["id"] == str(ROW_ID)
+    assert body["provider"] == "anthropic"
+    m.assert_called_once_with(customer_id=USER_ID, provider="anthropic", plaintext=PLAINTEXT)
+
+
+def test_byo_key_plaintext_never_in_response_body():
+    app = _make_app()
+    with patch("src.api.routes.customer_api_keys.keys_service.store_key", return_value=ROW_ID):
+        client = TestClient(app)
+        resp = client.post(
+            "/api/v1/dispatcher/byo-key",
+            json={"provider": "openai", "plaintext": PLAINTEXT},
+        )
+    assert resp.status_code == 201
+    assert PLAINTEXT not in resp.text
+    assert "plaintext" not in resp.json()
+
+
+def test_byo_key_plaintext_never_logged(caplog):
+    app = _make_app()
+    caplog.set_level(logging.DEBUG)
+    with patch("src.api.routes.customer_api_keys.keys_service.store_key", return_value=ROW_ID):
+        client = TestClient(app)
+        resp = client.post(
+            "/api/v1/dispatcher/byo-key",
+            json={"provider": "anthropic", "plaintext": PLAINTEXT},
+        )
+    assert resp.status_code == 201
+    for rec in caplog.records:
+        assert PLAINTEXT not in rec.getMessage()
+
+
+def test_byo_key_invalid_provider_returns_422():
+    app = _make_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/dispatcher/byo-key",
+        json={"provider": "google", "plaintext": PLAINTEXT},
+    )
+    assert resp.status_code == 422
+
+
+def test_byo_key_short_plaintext_returns_422():
+    app = _make_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/dispatcher/byo-key",
+        json={"provider": "anthropic", "plaintext": "short"},
+    )
+    assert resp.status_code == 422
+
+
+def test_byo_key_missing_provider_returns_422():
+    app = _make_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/dispatcher/byo-key",
+        json={"plaintext": PLAINTEXT},
+    )
+    assert resp.status_code == 422
+
+
+def test_byo_key_store_key_runtimeerror_returns_500():
+    """Unset CUSTOMER_KEY_ENCRYPTION_KEY env triggers RuntimeError from store_key —
+    route surfaces it as 500 with the underlying message exposed in detail."""
+    app = _make_app()
+    with patch(
+        "src.api.routes.customer_api_keys.keys_service.store_key",
+        side_effect=RuntimeError("CUSTOMER_KEY_ENCRYPTION_KEY env var required"),
+    ):
+        client = TestClient(app)
+        resp = client.post(
+            "/api/v1/dispatcher/byo-key",
+            json={"provider": "anthropic", "plaintext": PLAINTEXT},
+        )
+    assert resp.status_code == 500
+    assert "misconfigured" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

KEI-155 (KEI-113B) wired end-to-end on top of KEI-116A/B/C's encryption service.

**Linear:** [KEI-155](https://linear.app/keiracom/issue/KEI-155) · **Off:** `d52ad95e0`

## What lands (4 files, +285/-14 LoC)

| File | Purpose |
|---|---|
| `frontend/app/dispatcher/onboarding/byo-key/page.tsx` | Stub (27 LoC) → controlled form (104 LoC): provider select + password input + submit. On 2xx clears plaintext from React state and `router.push('/dispatcher/onboarding/first-task')`. |
| `src/api/routes/customer_api_keys.py` | NEW. `POST /api/v1/dispatcher/byo-key` — depends on `get_current_user_from_token`, passes `user.id` as `customer_id` to `keys_service.store_key()`. Pydantic validates provider ∈ `{anthropic, openai}` + plaintext min_length=8. |
| `src/api/main.py` | Wires `customer_api_keys_router` with prefix `/api/v1` after `customers_router`. |
| `tests/api/test_customer_api_keys_route.py` | NEW. 7 tests, mocked `store_key` + auth dep: happy path, plaintext-not-in-response, plaintext-not-logged, invalid provider 422, short plaintext 422, missing provider 422, store_key RuntimeError → 500. |

## Plaintext invariant

| Layer | Lifetime |
|---|---|
| Browser DOM | `<input type=password>` controlled by `useState`. Cleared on 2xx via `setPlaintext("")` before redirect. |
| HTTPS in flight | Standard TLS — visible to user-agent and the FastAPI route handler frame only. |
| Route handler | `body.plaintext` is bound only to the `store_key` call; the route returns `{id, provider}` — never echoes plaintext. |
| Service | `store_key()` (already shipped under KEI-116A) calls `pgp_sym_encrypt(%s, %s)` with the plaintext bound as a SQL param, then logs only `(row_id, customer_id, provider)`. Plaintext is never logged. |
| DB | `encrypted_key bytea` + `lookup_hash text` (SHA-256). No plaintext column exists. |

Test `test_byo_key_plaintext_never_logged` uses `caplog` to assert the route emits no log line containing the plaintext.

## customer_id resolution

`public.customer_api_keys.customer_id` has **no FK constraint** per KEI-116A migration (verified via `information_schema.table_constraints` — 0 rows). The intent is "the authenticated principal who owns this key"; for the dispatcher BYO self-onboarding flow that's the auth user itself. The route binds `customer_id = user.id` and documents this in the module docstring. If a separate customer table needs to be the canonical owner later, the column can be re-targeted without a schema change.

## Verbatim verify

```
$ python3 -m pytest tests/api/test_customer_api_keys_route.py tests/security/test_customer_api_keys.py -q
...................                                                      [100%]
19 passed, 23 warnings in 3.70s

$ python3 -c "from src.api.main import app; print('routes:', sum(1 for r in app.routes if hasattr(r, 'path')))"
routes: 211

$ ruff check + format --check src/api/routes/customer_api_keys.py tests/api/test_customer_api_keys_route.py
All checks passed!
2 files already formatted
```

## Pre-existing failure (NOT caused by this PR)

`tests/api/webhooks/test_betterstack_webhook.py::test_incident_started_dispatches` fails on `origin/main` too (payload shape drift `channel/severity` vs `incident_id/status/monitor`). Verified by `git checkout origin/main -- src/api/main.py && pytest …` → same failure. Out of scope here; separate concern.

## Acceptance per KEI-155 Linear spec

- [x] Key input form renders — `<form>` with provider `<select>` + password `<input>` + submit `<button>`
- [x] Submission encrypts via `pgp_sym_encrypt` — route → `store_key()` → `INSERT … VALUES (%s, %s, pgp_sym_encrypt(%s, %s), %s)`
- [x] DB stores `encrypted_key + lookup_hash` — existing `customer_api_keys` schema (bytea + sha256 hex)
- [x] Plaintext never persisted — verified by `test_byo_key_plaintext_never_logged` + service-level `logger.info` never includes plaintext + response model excludes plaintext field

## Out of scope (follow-up)

- `/dispatcher/dashboard/keys/page.tsx` list-and-manage UI (separate concern; uses different existing route)
- Key rotation UI surfacing `keys_service.rotate()` (separate KEI)
- Live Playwright e2e — no existing patterns in this scout worktree to extend cleanly
- `CUSTOMER_KEY_ENCRYPTION_KEY` env audit on staging/prod hosts (operator task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)