### PR TITLE
[ATLAS] fix(hzk5): ceo_memory_indexer prepare_threshold=None — same bug at second site (#1046 followup)

### DIFF
--- a/scripts/orchestrator/ceo_memory_indexer.py
+++ b/scripts/orchestrator/ceo_memory_indexer.py
@@ -157,7 +157,15 @@ def main() -> None:
         "indexer start source=%s class=%s batch=%d", SOURCE_NAME, DECISIONS_CLASS, args.batch
     )
 
-    with psycopg.connect(_dsn(), autocommit=True) as conn:
+    # prepare_threshold=None per reference_psycopg_supabase_pgbouncer (KEI-54B
+    # PR #881): Supabase pooler is pgbouncer txn-mode and drops PREPARE between
+    # leases. Without this, psycopg3 auto-prepares after 5 executions and the
+    # next batch hits DuplicatePreparedStatement → InvalidSqlStatementName loop.
+    # PR #1046 fixed this same bug in indexer_base.run_db_indexer; ceo_memory
+    # has its own main() that bypasses run_db_indexer (predates KEI-109 dedup
+    # extraction), so the fix must be reapplied here. Anchored Decisions count
+    # stuck at 300 — Agency_OS-hzk5.
+    with psycopg.connect(_dsn(), autocommit=True, prepare_threshold=None) as conn:
         indexer = CeoMemoryIndexer(conn)
         indexer.ensure_target_class()
 

--- a/tests/scripts/test_ceo_memory_indexer_prepare_threshold_hzk5.py
+++ b/tests/scripts/test_ceo_memory_indexer_prepare_threshold_hzk5.py
@@ -1,0 +1,72 @@
+"""Regression: ceo_memory_indexer.main() must pass prepare_threshold=None to psycopg.connect.
+
+Agency_OS-hzk5 — ceo_memory_indexer.py has its OWN main() that bypasses
+indexer_base.run_db_indexer (predates KEI-109 dedup extraction), so PR #1046's
+fix to indexer_base did NOT reach this file. Decisions count was stuck at 300
+across multiple restarts because every batch after the first ~5 executions
+hit DuplicatePreparedStatement against the Supabase pgbouncer pool.
+
+Locks the fix in place at the second site so a future refactor can't silently
+drop the kwarg from this main() either. Pattern mirrors
+test_indexer_base_prepare_threshold_kei70st (PR #1046).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "orchestrator"))
+
+import ceo_memory_indexer as mod  # noqa: E402
+
+
+def test_ceo_memory_indexer_main_passes_prepare_threshold_none(monkeypatch):
+    """ceo_memory_indexer.main() must call psycopg.connect with prepare_threshold=None."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
+    monkeypatch.setattr(sys, "argv", ["ceo_memory_indexer", "--once"])
+
+    captured_kwargs: dict = {}
+
+    class _FakeConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def cursor(self):
+            return mock.MagicMock()
+
+    def _fake_connect(dsn, **kwargs):
+        captured_kwargs.update(kwargs)
+        captured_kwargs["_dsn"] = dsn
+        return _FakeConn()
+
+    monkeypatch.setattr(mod.psycopg, "connect", _fake_connect)
+    monkeypatch.setattr(mod, "_heartbeat_tick", mock.MagicMock())
+    monkeypatch.setattr(mod, "aggregate_count", lambda _c: 0)
+
+    fake_indexer = mock.MagicMock()
+    fake_indexer.ensure_target_class.return_value = None
+    fake_indexer.index_once.return_value = mock.MagicMock(
+        success=0,
+        failed=0,
+        to_dict=lambda: {"selected": 0, "success": 0, "failed": 0},
+    )
+    monkeypatch.setattr(mod, "CeoMemoryIndexer", lambda _conn: fake_indexer)
+
+    mod.main()
+
+    assert "prepare_threshold" in captured_kwargs, (
+        "psycopg.connect called without prepare_threshold kwarg — "
+        "Supabase pgbouncer will drop PREPARE between leases and trigger "
+        "DuplicatePreparedStatement after ~5 batches (see Agency_OS-hzk5)."
+    )
+    assert captured_kwargs["prepare_threshold"] is None, (
+        f"prepare_threshold must be None to disable psycopg3 auto-prepare, "
+        f"got: {captured_kwargs['prepare_threshold']!r}"
+    )
+    assert captured_kwargs.get("autocommit") is True


### PR DESCRIPTION
## Summary

PR #1046 fixed psycopg+pgbouncer DuplicatePreparedStatement in `indexer_base.run_db_indexer`. `ceo_memory_indexer.py` has its OWN `main()` that bypasses `run_db_indexer` (predates KEI-109 dedup extraction), so PR #1046's fix did not reach this file. Decisions count was stuck at 300 across multiple restarts.

One-line fix at the second site: `psycopg.connect(_dsn(), autocommit=True)` → `psycopg.connect(_dsn(), autocommit=True, prepare_threshold=None)`. Same pattern as PR #1046 + `reference_psycopg_supabase_pgbouncer` memory.

## Empirical evidence (pre-fix)

`/home/elliotbot/clawd/logs/ceo-memory-indexer.log` was bleeding the identical error stream as elliot-memories-indexer before PR #1046:

```
psycopg.errors.InvalidSqlStatementName: prepared statement "_pg3_0" does not exist
```

Visible in the log timestamps at 2026-05-18 21:05 (the same instant elliot-memories-indexer's log showed the same error before PR #1046 landed).

## Test plan

- [x] `tests/scripts/test_ceo_memory_indexer_prepare_threshold_hzk5.py` — mocks `psycopg.connect` + `CeoMemoryIndexer` + heartbeat_shim, asserts `prepare_threshold=None` kwarg passed
- [x] Negative-path verified: test FAILS when fix is reverted (`AssertionError: psycopg.connect called without prepare_threshold kwarg`)
- [x] `ruff check` + `ruff format --check` clean
- [ ] Post-merge operator action: `systemctl --user restart ceo-memory-indexer` from main worktree
- [ ] Post-merge verification: Weaviate `Decisions` count climbs off 300 within ~3 min; logs show clean batch outcomes, no `DuplicatePreparedStatement`

## Sibling context

- PR #1046 (kei70st, awaiting merge) — same fix in `indexer_base.run_db_indexer` for elliot-memories-indexer
- This PR addresses the second psycopg.connect site that #1046 didn't reach
- Both fixes are required to fully clear the 20h+ error-loop seen across both indexers since 2026-05-18 00:40 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)