### PR TITLE
[SCOUT] feat(kei136): claim-queue observability — view + BS heartbeat exporter + runbook

### DIFF
--- a/docs/runbooks/claim_queue_observability.md
+++ b/docs/runbooks/claim_queue_observability.md
@@ -1,0 +1,113 @@
+# Claim-Queue Observability — KEI-136
+
+Better Stack heartbeat-based alerting on claim-queue stalls.
+
+## What this delivers
+
+- `public.claim_queue_metrics_v` — read-only single-row aggregate over `public.tasks`.
+- `scripts/orchestrator/claim_queue_metrics_export.py` — runs every 60s, pings BS heartbeat when healthy, **skips** ping when stalled.
+- Better Stack alerts via existing severity-routing wired by KEI-20 (Orion). Missed heartbeats fire to `#ceo` via the critical policy.
+
+## Why heartbeat-skip is the alert mechanism
+
+Heartbeat creation in Better Stack is one-time operator-gated (BS Slack OAuth not API-creatable per the existing pattern in `scripts/orchestrator/betterstack_setup.py` docstring). Once the heartbeat exists with `period=60s, grace=240s` (5min total tolerance), the exporter's contract is simple: **ping when healthy, silence when stalled**. BS does the alerting.
+
+This inverts the usual "fire alert from app" pattern — but matches the existing KEI-20 wiring, doesn't require BS API monitor creation, and the absence-of-signal semantics make it survive process restarts gracefully.
+
+## Stall criteria
+
+Implemented in `is_stalled()`:
+
+1. **Available aging past SLA:** `available_count > 0` AND `oldest_available_age_sec > STALL_THRESHOLD_SEC` (default 300). Work waiting unclaimed for >5min.
+2. **Active task idle past SLA:** `max_idle_seconds NOT NULL` AND `max_idle_seconds > STALL_THRESHOLD_SEC`. Some active row hasn't heartbeated in >5min.
+
+NULL `max_idle_seconds` is **fail-open** — not treated as stall — because `tasks.heartbeat_at` is currently unpopulated in production. Turning NULL into an alert would page on baseline state.
+
+## One-time Better Stack setup (operator)
+
+1. **Create the heartbeat in BS dashboard** (API not available for OAuth-linked teams):
+   - Name: `claim-queue-stall`
+   - Period: `60 seconds`
+   - Grace: `240 seconds`
+   - Group: `Keiracom Agent Team`
+   - Severity policy: critical (routes to `#ceo`) — same `policy_id` as `elliot-polling-loop`.
+
+2. **Copy the heartbeat URL** from BS (format: `https://uptime.betterstack.com/api/v1/heartbeat/<TOKEN>`).
+
+3. **Append to env:**
+   ```bash
+   echo "CLAIM_QUEUE_HEARTBEAT_URL=https://uptime.betterstack.com/api/v1/heartbeat/<TOKEN>" \
+     >> ~/.config/agency-os/.env
+   ```
+
+4. **Install the timer:**
+   ```bash
+   bash scripts/install_claim_queue_metrics.sh
+   ```
+
+5. **Verify ping in BS dashboard:** within 60-90s the heartbeat should show "received" with no missed pings.
+
+## Manual metric query
+
+```sql
+SELECT * FROM public.claim_queue_metrics_v;
+```
+
+Sample healthy:
+```
+ available_count | active_count | blocked_count | oldest_available_age_sec | oldest_active_age_sec | max_idle_seconds | computed_at
+-----------------+--------------+---------------+--------------------------+-----------------------+------------------+-----------------------------
+               0 |            2 |             1 |                          |                   300 |                  | 2026-05-18 22:37:58.112607+00
+```
+
+Sample stalled (alert pending):
+```
+ available_count | active_count | blocked_count | oldest_available_age_sec | oldest_active_age_sec | max_idle_seconds | computed_at
+-----------------+--------------+---------------+--------------------------+-----------------------+------------------+-----------------------------
+               5 |            1 |             0 |                      600 |                   120 |                  | 2026-05-18 22:37:58.112607+00
+```
+
+## Alert response — when BS pages #ceo on missed heartbeat
+
+1. **Query the view manually** to confirm stall vs exporter failure:
+   ```bash
+   psql "$DATABASE_URL" -c "SELECT * FROM public.claim_queue_metrics_v;"
+   ```
+
+2. **Check exporter logs:**
+   ```bash
+   journalctl --user -u claim_queue_metrics.service -n 50 --no-pager
+   ```
+
+3. **Identify root cause:**
+   - `available_count > 0 AND oldest_available_age_sec > 300` → no agent claiming. Check `fleet_supervisor` is running + agents alive.
+   - `max_idle_seconds > 300` → an active task has stalled. Check `journalctl --user -u <agent>` for the claimed agent.
+   - Exporter log says `fetch_metrics failed` → DB unreachable. Check Supabase pooler.
+   - Exporter log says `CLAIM_QUEUE_HEARTBEAT_URL unset` → operator step 3 missed.
+
+## Reverting
+
+Disable the timer; the BS heartbeat then fires (intended — false alert until heartbeat is deleted in BS dashboard):
+
+```bash
+systemctl --user disable --now claim_queue_metrics.timer
+```
+
+To silence without uninstalling, unset the env var and restart the timer:
+
+```bash
+sed -i '/^CLAIM_QUEUE_HEARTBEAT_URL=/d' ~/.config/agency-os/.env
+systemctl --user restart claim_queue_metrics.timer
+```
+
+The exporter exits clean when the URL is unset.
+
+## References
+
+- `supabase/migrations/20260518_kei136_claim_queue_metrics_view.sql` — view definition.
+- `scripts/orchestrator/claim_queue_metrics_export.py` — exporter logic.
+- `systemd/claim_queue_metrics.service` + `.timer` — 60s cadence.
+- `scripts/install_claim_queue_metrics.sh` — installer.
+- `tests/scripts/test_claim_queue_metrics_export.py` — 13 tests covering stall criteria + fail-open paths.
+- KEI-20 (Orion) — Better Stack severity-routing wiring this depends on.
+- KEI-136 Linear: <https://linear.app/keiracom/issue/KEI-136>

--- a/scripts/install_claim_queue_metrics.sh
+++ b/scripts/install_claim_queue_metrics.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# install_claim_queue_metrics.sh — KEI-136 systemd-user installer.
+#
+# Installs:
+#   ~/.config/systemd/user/claim_queue_metrics.service
+#   ~/.config/systemd/user/claim_queue_metrics.timer
+#
+# Then daemon-reloads, enables, and starts the timer.
+#
+# Prerequisites (one-time operator setup):
+#   1. Create the BS heartbeat — see docs/runbooks/claim_queue_observability.md
+#   2. Append CLAIM_QUEUE_HEARTBEAT_URL=https://uptime.betterstack.com/api/v1/heartbeat/...
+#      to ~/.config/agency-os/.env
+#
+# Without CLAIM_QUEUE_HEARTBEAT_URL the exporter exits clean (no fail-loud);
+# safe to install before BS setup is complete.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SYSTEMD_SRC="${REPO_ROOT}/systemd"
+SYSTEMD_DST="${HOME}/.config/systemd/user"
+
+mkdir -p "${SYSTEMD_DST}"
+cp -v "${SYSTEMD_SRC}/claim_queue_metrics.service" "${SYSTEMD_DST}/"
+cp -v "${SYSTEMD_SRC}/claim_queue_metrics.timer"   "${SYSTEMD_DST}/"
+
+systemctl --user daemon-reload
+systemctl --user enable --now claim_queue_metrics.timer
+
+echo
+echo "Installed. Verify:"
+echo "  systemctl --user status claim_queue_metrics.timer"
+echo "  systemctl --user list-timers --all | grep claim_queue"
+echo "  journalctl --user -u claim_queue_metrics.service -n 50 --no-pager"

--- a/scripts/orchestrator/claim_queue_metrics_export.py
+++ b/scripts/orchestrator/claim_queue_metrics_export.py
@@ -1,0 +1,149 @@
+"""claim_queue_metrics_export.py — KEI-136 Better Stack heartbeat exporter.
+
+Reads `public.claim_queue_metrics_v` and pings the Better Stack heartbeat URL
+when the queue is healthy. Skipping the heartbeat is the alert signal: Better
+Stack fires when no heartbeat arrives within `period + grace` (configured on
+the BS side at heartbeat creation — see HEARTBEATS in betterstack_setup.py).
+
+Run via systemd timer every 60 seconds:
+    systemd/claim_queue_metrics.service + .timer
+    scripts/install_claim_queue_metrics.sh
+
+Stall criteria (any one ⇒ skip heartbeat ⇒ BS alert fires after grace):
+    available_count > 0 AND oldest_available_age_sec > STALL_THRESHOLD_SEC
+        — work waiting unclaimed past the SLA.
+    max_idle_seconds NOT NULL AND max_idle_seconds > STALL_THRESHOLD_SEC
+        — an active task hasn't heartbeated in over SLA.
+
+NULL `max_idle_seconds` (no heartbeat data on any active row) is fail-open —
+NOT treated as stall — because `tasks.heartbeat_at` is currently unpopulated
+in production; turning that into an alert would page on baseline state.
+
+Env contract:
+    CLAIM_QUEUE_HEARTBEAT_URL — Better Stack heartbeat URL. If unset, the
+        exporter logs a warning and exits cleanly (no fail-loud).
+    DATABASE_URL / SUPABASE_DB_URL — Postgres DSN (psycopg3, +asyncpg stripped).
+    CLAIM_QUEUE_STALL_THRESHOLD_SEC — override default 300s if needed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+DEFAULT_STALL_THRESHOLD_SEC = 300
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL / SUPABASE_DB_URL not set")
+    return dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def fetch_metrics() -> dict:
+    """Read one row from claim_queue_metrics_v. Returns dict with named columns."""
+    import psycopg
+
+    with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT available_count, active_count, blocked_count,
+                   oldest_available_age_sec, oldest_active_age_sec,
+                   max_idle_seconds
+              FROM public.claim_queue_metrics_v
+            """
+        )
+        row = cur.fetchone()
+    if row is None:
+        return {}
+    return {
+        "available_count": row[0] or 0,
+        "active_count": row[1] or 0,
+        "blocked_count": row[2] or 0,
+        "oldest_available_age_sec": row[3],
+        "oldest_active_age_sec": row[4],
+        "max_idle_seconds": row[5],
+    }
+
+
+def is_stalled(metrics: dict, threshold_sec: int) -> tuple[bool, str]:
+    """Return (stalled, reason). Reason is empty when healthy."""
+    available = metrics.get("available_count", 0) or 0
+    oldest_avail = metrics.get("oldest_available_age_sec")
+    max_idle = metrics.get("max_idle_seconds")
+
+    if available > 0 and oldest_avail is not None and oldest_avail > threshold_sec:
+        return True, (
+            f"available work aging past SLA: oldest_available_age_sec={oldest_avail} "
+            f"> threshold={threshold_sec}"
+        )
+    if max_idle is not None and max_idle > threshold_sec:
+        return (
+            True,
+            f"active task idle past SLA: max_idle_seconds={max_idle} > threshold={threshold_sec}",
+        )
+    return False, ""
+
+
+def post_heartbeat(url: str) -> bool:
+    """GET the BS heartbeat URL. Returns True on 2xx, False otherwise.
+
+    BS heartbeats accept GET or POST; GET is the documented norm. We treat any
+    non-2xx as failure but do not raise — exporter logs and continues so the
+    timer keeps firing.
+    """
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
+        logger.warning("heartbeat POST failed: %s", exc)
+        return False
+
+
+def main() -> int:
+    heartbeat_url = os.environ.get("CLAIM_QUEUE_HEARTBEAT_URL", "")
+    if not heartbeat_url:
+        logger.warning(
+            "CLAIM_QUEUE_HEARTBEAT_URL unset — exporter exiting clean. "
+            "Set it after Better Stack heartbeat creation (see runbook)."
+        )
+        return 0
+
+    threshold = int(
+        os.environ.get("CLAIM_QUEUE_STALL_THRESHOLD_SEC", str(DEFAULT_STALL_THRESHOLD_SEC))
+    )
+
+    try:
+        metrics = fetch_metrics()
+    except Exception as exc:
+        logger.warning("fetch_metrics failed (skipping heartbeat — DB unreachable): %s", exc)
+        return 0
+
+    stalled, reason = is_stalled(metrics, threshold)
+    if stalled:
+        logger.warning(
+            "queue stalled — SKIPPING heartbeat (BS will alert after grace). %s. metrics=%s",
+            reason,
+            metrics,
+        )
+        return 0
+
+    ok = post_heartbeat(heartbeat_url)
+    logger.info(
+        "heartbeat %s — metrics=%s",
+        "ok" if ok else "failed",
+        metrics,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/claim_queue_metrics_export.py
+++ b/scripts/orchestrator/claim_queue_metrics_export.py
@@ -30,8 +30,6 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
-import urllib.error
 import urllib.request
 
 logger = logging.getLogger(__name__)
@@ -103,19 +101,19 @@ def post_heartbeat(url: str) -> bool:
         req = urllib.request.Request(url, method="GET")
         with urllib.request.urlopen(req, timeout=10) as resp:
             return 200 <= resp.status < 300
-    except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
+    except OSError as exc:
         logger.warning("heartbeat POST failed: %s", exc)
         return False
 
 
-def main() -> int:
+def main() -> None:
     heartbeat_url = os.environ.get("CLAIM_QUEUE_HEARTBEAT_URL", "")
     if not heartbeat_url:
         logger.warning(
             "CLAIM_QUEUE_HEARTBEAT_URL unset — exporter exiting clean. "
             "Set it after Better Stack heartbeat creation (see runbook)."
         )
-        return 0
+        return
 
     threshold = int(
         os.environ.get("CLAIM_QUEUE_STALL_THRESHOLD_SEC", str(DEFAULT_STALL_THRESHOLD_SEC))
@@ -125,7 +123,7 @@ def main() -> int:
         metrics = fetch_metrics()
     except Exception as exc:
         logger.warning("fetch_metrics failed (skipping heartbeat — DB unreachable): %s", exc)
-        return 0
+        return
 
     stalled, reason = is_stalled(metrics, threshold)
     if stalled:
@@ -134,7 +132,7 @@ def main() -> int:
             reason,
             metrics,
         )
-        return 0
+        return
 
     ok = post_heartbeat(heartbeat_url)
     logger.info(
@@ -142,8 +140,7 @@ def main() -> int:
         "ok" if ok else "failed",
         metrics,
     )
-    return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/supabase/migrations/20260518_kei136_claim_queue_metrics_view.sql
+++ b/supabase/migrations/20260518_kei136_claim_queue_metrics_view.sql
@@ -19,16 +19,16 @@
 
 CREATE OR REPLACE VIEW public.claim_queue_metrics_v AS
 SELECT
-    COUNT(*) FILTER (WHERE status = 'available')                  AS available_count,
-    COUNT(*) FILTER (WHERE status = 'active')                     AS active_count,
-    COUNT(*) FILTER (WHERE status = 'blocked')                    AS blocked_count,
+    COUNT(*) FILTER (WHERE status = 'available')                  AS available_count,  -- NOSONAR plsql:S1192 — 'available'/'active'/'blocked' are public.tasks.status enum values
+    COUNT(*) FILTER (WHERE status = 'active')                     AS active_count,     -- NOSONAR plsql:S1192 — enum value
+    COUNT(*) FILTER (WHERE status = 'blocked')                    AS blocked_count,    -- NOSONAR plsql:S1192 — enum value
     EXTRACT(EPOCH FROM (NOW() - MIN(created_at)
-        FILTER (WHERE status = 'available')))::bigint              AS oldest_available_age_sec,
+        FILTER (WHERE status = 'available')))::bigint              AS oldest_available_age_sec,  -- NOSONAR plsql:S1192 — enum value
     EXTRACT(EPOCH FROM (NOW() - MIN(claimed_at)
-        FILTER (WHERE status = 'active' AND claimed_at IS NOT NULL)))::bigint
+        FILTER (WHERE status = 'active' AND claimed_at IS NOT NULL)))::bigint  -- NOSONAR plsql:S1192 — enum value
                                                                    AS oldest_active_age_sec,
     EXTRACT(EPOCH FROM (NOW() - MIN(heartbeat_at)
-        FILTER (WHERE status = 'active' AND heartbeat_at IS NOT NULL)))::bigint
+        FILTER (WHERE status = 'active' AND heartbeat_at IS NOT NULL)))::bigint  -- NOSONAR plsql:S1192 — enum value
                                                                    AS max_idle_seconds,
     NOW()                                                          AS computed_at
 FROM public.tasks;

--- a/supabase/migrations/20260518_kei136_claim_queue_metrics_view.sql
+++ b/supabase/migrations/20260518_kei136_claim_queue_metrics_view.sql
@@ -1,0 +1,37 @@
+-- KEI-136 — Claim-queue observability view.
+--
+-- Read-only view over public.tasks exposing the metrics that the periodic
+-- exporter (scripts/orchestrator/claim_queue_metrics_export.py) needs to
+-- decide whether to ping the Better Stack heartbeat or skip (stall alert).
+--
+-- Post-KEI-150: equal-worker model — no per-clone queues, so the metrics are
+-- single-row aggregates over public.tasks.
+--
+-- Columns:
+--   available_count            — open work waiting to be claimed
+--   active_count               — claimed + in-progress
+--   blocked_count              — depends_on unresolved
+--   oldest_available_age_sec   — NOW() − MIN(created_at) over available rows
+--   oldest_active_age_sec      — NOW() − MIN(claimed_at) over active rows
+--   max_idle_seconds           — NOW() − MIN(heartbeat_at) over active rows
+--                                (i.e. longest time since any active task heartbeat)
+--   computed_at                — server timestamp for staleness checks
+
+CREATE OR REPLACE VIEW public.claim_queue_metrics_v AS
+SELECT
+    COUNT(*) FILTER (WHERE status = 'available')                  AS available_count,
+    COUNT(*) FILTER (WHERE status = 'active')                     AS active_count,
+    COUNT(*) FILTER (WHERE status = 'blocked')                    AS blocked_count,
+    EXTRACT(EPOCH FROM (NOW() - MIN(created_at)
+        FILTER (WHERE status = 'available')))::bigint              AS oldest_available_age_sec,
+    EXTRACT(EPOCH FROM (NOW() - MIN(claimed_at)
+        FILTER (WHERE status = 'active' AND claimed_at IS NOT NULL)))::bigint
+                                                                   AS oldest_active_age_sec,
+    EXTRACT(EPOCH FROM (NOW() - MIN(heartbeat_at)
+        FILTER (WHERE status = 'active' AND heartbeat_at IS NOT NULL)))::bigint
+                                                                   AS max_idle_seconds,
+    NOW()                                                          AS computed_at
+FROM public.tasks;
+
+COMMENT ON VIEW public.claim_queue_metrics_v IS
+    'KEI-136 — single-row aggregate of claim-queue state for Better Stack heartbeat export. NULLs in age columns mean no rows in the corresponding status bucket.';

--- a/systemd/claim_queue_metrics.service
+++ b/systemd/claim_queue_metrics.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=KEI-136 claim-queue metrics → Better Stack heartbeat (oneshot)
+Documentation=https://linear.app/keiracom/issue/KEI-136
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/agency-os/.env
+WorkingDirectory=%h/clawd/Agency_OS
+ExecStart=/usr/bin/python3 %h/clawd/Agency_OS/scripts/orchestrator/claim_queue_metrics_export.py
+Nice=10
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60
+# Don't restart on failure — timer triggers next run; missing heartbeats are the alert signal
+
+[Install]
+WantedBy=default.target

--- a/systemd/claim_queue_metrics.timer
+++ b/systemd/claim_queue_metrics.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=KEI-136 fires claim_queue_metrics.service every 60s
+Documentation=https://linear.app/keiracom/issue/KEI-136
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=60s
+AccuracySec=5s
+Persistent=true
+Unit=claim_queue_metrics.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/scripts/test_claim_queue_metrics_export.py
+++ b/tests/scripts/test_claim_queue_metrics_export.py
@@ -1,0 +1,225 @@
+"""Tests for scripts/orchestrator/claim_queue_metrics_export.py — KEI-136.
+
+Covers:
+  - is_stalled() logic for all stall conditions + healthy + NULL fail-open
+  - fetch_metrics() shape via mocked psycopg
+  - main() heartbeat-skip on stall + heartbeat-post on healthy
+  - main() exits clean when CLAIM_QUEUE_HEARTBEAT_URL is unset (fail-open)
+  - main() exits clean when DB fetch fails (no fail-loud)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "claim_queue_metrics_export.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("claim_queue_metrics_export", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["claim_queue_metrics_export"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+# ─── is_stalled ──────────────────────────────────────────────────────────────
+
+
+def test_is_stalled_healthy_queue(mod):
+    metrics = {
+        "available_count": 0,
+        "oldest_available_age_sec": None,
+        "max_idle_seconds": None,
+    }
+    stalled, reason = mod.is_stalled(metrics, 300)
+    assert stalled is False
+    assert reason == ""
+
+
+def test_is_stalled_available_aging_past_threshold(mod):
+    metrics = {
+        "available_count": 3,
+        "oldest_available_age_sec": 600,
+        "max_idle_seconds": None,
+    }
+    stalled, reason = mod.is_stalled(metrics, 300)
+    assert stalled is True
+    assert "available work aging" in reason
+
+
+def test_is_stalled_available_under_threshold(mod):
+    metrics = {
+        "available_count": 5,
+        "oldest_available_age_sec": 100,
+        "max_idle_seconds": None,
+    }
+    stalled, reason = mod.is_stalled(metrics, 300)
+    assert stalled is False
+
+
+def test_is_stalled_no_available_rows_ignored(mod):
+    """available_count=0 means nothing to wait for — even if oldest_available_age
+    is somehow non-null (shouldn't be), it must NOT stall."""
+    metrics = {
+        "available_count": 0,
+        "oldest_available_age_sec": 999999,
+        "max_idle_seconds": None,
+    }
+    stalled, reason = mod.is_stalled(metrics, 300)
+    assert stalled is False
+
+
+def test_is_stalled_max_idle_past_threshold(mod):
+    metrics = {
+        "available_count": 0,
+        "oldest_available_age_sec": None,
+        "max_idle_seconds": 900,
+    }
+    stalled, reason = mod.is_stalled(metrics, 300)
+    assert stalled is True
+    assert "idle past SLA" in reason
+
+
+def test_is_stalled_max_idle_null_is_failopen(mod):
+    """NULL max_idle_seconds (no heartbeat data on any active row) must NOT
+    be treated as stall — tasks.heartbeat_at is unpopulated in production."""
+    metrics = {
+        "available_count": 0,
+        "oldest_available_age_sec": None,
+        "max_idle_seconds": None,
+    }
+    stalled, reason = mod.is_stalled(metrics, 300)
+    assert stalled is False
+
+
+# ─── fetch_metrics ───────────────────────────────────────────────────────────
+
+
+def test_fetch_metrics_returns_named_dict(mod, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
+    cur = MagicMock()
+    cur.fetchone.return_value = (5, 2, 1, 600, 120, None)
+    cur_ctx = MagicMock()
+    cur_ctx.__enter__ = MagicMock(return_value=cur)
+    cur_ctx.__exit__ = MagicMock(return_value=False)
+    conn = MagicMock()
+    conn.cursor.return_value = cur_ctx
+    conn_ctx = MagicMock()
+    conn_ctx.__enter__ = MagicMock(return_value=conn)
+    conn_ctx.__exit__ = MagicMock(return_value=False)
+
+    with patch("psycopg.connect", return_value=conn_ctx):
+        result = mod.fetch_metrics()
+
+    assert result == {
+        "available_count": 5,
+        "active_count": 2,
+        "blocked_count": 1,
+        "oldest_available_age_sec": 600,
+        "oldest_active_age_sec": 120,
+        "max_idle_seconds": None,
+    }
+
+
+def test_fetch_metrics_empty_view_returns_empty_dict(mod, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
+    cur = MagicMock()
+    cur.fetchone.return_value = None
+    cur_ctx = MagicMock()
+    cur_ctx.__enter__ = MagicMock(return_value=cur)
+    cur_ctx.__exit__ = MagicMock(return_value=False)
+    conn = MagicMock()
+    conn.cursor.return_value = cur_ctx
+    conn_ctx = MagicMock()
+    conn_ctx.__enter__ = MagicMock(return_value=conn)
+    conn_ctx.__exit__ = MagicMock(return_value=False)
+    with patch("psycopg.connect", return_value=conn_ctx):
+        assert mod.fetch_metrics() == {}
+
+
+# ─── main entry ──────────────────────────────────────────────────────────────
+
+
+def test_main_exits_clean_when_heartbeat_url_unset(mod, monkeypatch, caplog):
+    """No CLAIM_QUEUE_HEARTBEAT_URL = exporter logs warning + returns 0.
+    Critical: must not error out — runbook says heartbeat URL is set AFTER install."""
+    monkeypatch.delenv("CLAIM_QUEUE_HEARTBEAT_URL", raising=False)
+    rc = mod.main()
+    assert rc == 0
+
+
+def test_main_posts_heartbeat_on_healthy_queue(mod, monkeypatch):
+    monkeypatch.setenv(
+        "CLAIM_QUEUE_HEARTBEAT_URL", "https://uptime.betterstack.com/api/v1/heartbeat/TOKEN"
+    )
+    healthy = {
+        "available_count": 0,
+        "active_count": 1,
+        "blocked_count": 0,
+        "oldest_available_age_sec": None,
+        "oldest_active_age_sec": 60,
+        "max_idle_seconds": None,
+    }
+    with (
+        patch.object(mod, "fetch_metrics", return_value=healthy),
+        patch.object(mod, "post_heartbeat", return_value=True) as ph,
+    ):
+        rc = mod.main()
+    assert rc == 0
+    ph.assert_called_once_with("https://uptime.betterstack.com/api/v1/heartbeat/TOKEN")
+
+
+def test_main_skips_heartbeat_on_stalled_queue(mod, monkeypatch, caplog):
+    monkeypatch.setenv(
+        "CLAIM_QUEUE_HEARTBEAT_URL", "https://uptime.betterstack.com/api/v1/heartbeat/TOKEN"
+    )
+    stalled = {
+        "available_count": 3,
+        "active_count": 0,
+        "blocked_count": 0,
+        "oldest_available_age_sec": 600,
+        "oldest_active_age_sec": None,
+        "max_idle_seconds": None,
+    }
+    with (
+        patch.object(mod, "fetch_metrics", return_value=stalled),
+        patch.object(mod, "post_heartbeat") as ph,
+    ):
+        rc = mod.main()
+    assert rc == 0
+    ph.assert_not_called()  # BS alert fires via missed heartbeat
+
+
+def test_main_exits_clean_when_db_unreachable(mod, monkeypatch):
+    """fetch_metrics raising → exporter logs + returns 0 (no fail-loud, no
+    cascade kill of subsequent timer fires)."""
+    monkeypatch.setenv("CLAIM_QUEUE_HEARTBEAT_URL", "https://example.com/hb")
+    with patch.object(mod, "fetch_metrics", side_effect=OSError("connection refused")):
+        rc = mod.main()
+    assert rc == 0
+
+
+def test_main_threshold_override_via_env(mod, monkeypatch):
+    """Operator can override the 300s stall threshold via env."""
+    monkeypatch.setenv("CLAIM_QUEUE_HEARTBEAT_URL", "https://example.com/hb")
+    monkeypatch.setenv("CLAIM_QUEUE_STALL_THRESHOLD_SEC", "60")
+    metrics = {
+        "available_count": 1,
+        "oldest_available_age_sec": 120,  # >60 → stall, but <300 default
+        "max_idle_seconds": None,
+    }
+    with (
+        patch.object(mod, "fetch_metrics", return_value=metrics),
+        patch.object(mod, "post_heartbeat") as ph,
+    ):
+        rc = mod.main()
+    assert rc == 0
+    ph.assert_not_called()

--- a/tests/scripts/test_claim_queue_metrics_export.py
+++ b/tests/scripts/test_claim_queue_metrics_export.py
@@ -61,7 +61,7 @@ def test_is_stalled_available_under_threshold(mod):
         "oldest_available_age_sec": 100,
         "max_idle_seconds": None,
     }
-    stalled, reason = mod.is_stalled(metrics, 300)
+    stalled, _ = mod.is_stalled(metrics, 300)
     assert stalled is False
 
 
@@ -73,7 +73,7 @@ def test_is_stalled_no_available_rows_ignored(mod):
         "oldest_available_age_sec": 999999,
         "max_idle_seconds": None,
     }
-    stalled, reason = mod.is_stalled(metrics, 300)
+    stalled, _ = mod.is_stalled(metrics, 300)
     assert stalled is False
 
 
@@ -96,7 +96,7 @@ def test_is_stalled_max_idle_null_is_failopen(mod):
         "oldest_available_age_sec": None,
         "max_idle_seconds": None,
     }
-    stalled, reason = mod.is_stalled(metrics, 300)
+    stalled, _ = mod.is_stalled(metrics, 300)
     assert stalled is False
 
 
@@ -153,7 +153,7 @@ def test_main_exits_clean_when_heartbeat_url_unset(mod, monkeypatch, caplog):
     Critical: must not error out — runbook says heartbeat URL is set AFTER install."""
     monkeypatch.delenv("CLAIM_QUEUE_HEARTBEAT_URL", raising=False)
     rc = mod.main()
-    assert rc == 0
+    assert rc is None
 
 
 def test_main_posts_heartbeat_on_healthy_queue(mod, monkeypatch):
@@ -173,7 +173,7 @@ def test_main_posts_heartbeat_on_healthy_queue(mod, monkeypatch):
         patch.object(mod, "post_heartbeat", return_value=True) as ph,
     ):
         rc = mod.main()
-    assert rc == 0
+    assert rc is None
     ph.assert_called_once_with("https://uptime.betterstack.com/api/v1/heartbeat/TOKEN")
 
 
@@ -194,7 +194,7 @@ def test_main_skips_heartbeat_on_stalled_queue(mod, monkeypatch, caplog):
         patch.object(mod, "post_heartbeat") as ph,
     ):
         rc = mod.main()
-    assert rc == 0
+    assert rc is None
     ph.assert_not_called()  # BS alert fires via missed heartbeat
 
 
@@ -204,7 +204,7 @@ def test_main_exits_clean_when_db_unreachable(mod, monkeypatch):
     monkeypatch.setenv("CLAIM_QUEUE_HEARTBEAT_URL", "https://example.com/hb")
     with patch.object(mod, "fetch_metrics", side_effect=OSError("connection refused")):
         rc = mod.main()
-    assert rc == 0
+    assert rc is None
 
 
 def test_main_threshold_override_via_env(mod, monkeypatch):
@@ -221,5 +221,5 @@ def test_main_threshold_override_via_env(mod, monkeypatch):
         patch.object(mod, "post_heartbeat") as ph,
     ):
         rc = mod.main()
-    assert rc == 0
+    assert rc is None
     ph.assert_not_called()


### PR DESCRIPTION
## Summary

KEI-136's three Linear acceptance items wired against `public.tasks` (post-KEI-150 equal-worker model):

1. **Queue metrics dashboard live** — Better Stack heartbeat surface. Reuses existing KEI-20 severity-routing (Orion) end-to-end.
2. **Zero-idle-time SLA monitored** — `STALL_THRESHOLD_SEC` default 300, env-overridable.
3. **Alerts on queue stalls >5min** — heartbeat-skip semantics: BS fires alert via missed-heartbeat policy after `period + grace = 60 + 240 = 300s`.

**Linear:** [KEI-136](https://linear.app/keiracom/issue/KEI-136) · **Off:** `d52ad95e0`

## What lands (7 files, +332 LoC)

| File | Purpose |
|---|---|
| `supabase/migrations/20260518_kei136_claim_queue_metrics_view.sql` | `public.claim_queue_metrics_v` — single-row aggregate (available/active/blocked counts + age seconds + max_idle_seconds + computed_at). Read-only. |
| `scripts/orchestrator/claim_queue_metrics_export.py` | Fetches view, evaluates `is_stalled()`, pings BS heartbeat URL when healthy + **skips** when stalled (BS fires alert). Fail-open: missing env / DB unreachable / fetch error → log + exit 0. |
| `systemd/claim_queue_metrics.service` | `Type=oneshot`, `EnvironmentFile=%h/.config/agency-os/.env`. |
| `systemd/claim_queue_metrics.timer` | `OnUnitActiveSec=60s`, `Persistent=true`. |
| `scripts/install_claim_queue_metrics.sh` | systemd-user installer. |
| `tests/scripts/test_claim_queue_metrics_export.py` | 13 tests covering `is_stalled` branches (healthy / available-stale / idle-stale / NULL fail-open / threshold-override / no-available-rows-ignored), `fetch_metrics` shape, `main()` exits clean on missing env + DB unreachable, posts on healthy, skips on stall. |
| `docs/runbooks/claim_queue_observability.md` | One-time BS heartbeat creation (operator-gated, OAuth not API-creatable) + manual metric query + alert response triage + revert. |

## Stall criteria (`is_stalled()`)

| Condition | Reason |
|---|---|
| `available_count > 0 AND oldest_available_age_sec > 300` | Work waiting unclaimed past SLA. |
| `max_idle_seconds NOT NULL AND max_idle_seconds > 300` | Active task hasn't heartbeated past SLA. |

**NULL `max_idle_seconds` is fail-open** — NOT a stall. `tasks.heartbeat_at` is currently unpopulated in production; alerting on NULL would page on baseline state. Once heartbeat writing is wired (separate KEI), the criterion already evaluates correctly.

## Architectural choice: heartbeat-SKIP semantics

Better Stack heartbeat creation is one-time operator-gated (BS Slack OAuth not API-creatable per `scripts/orchestrator/betterstack_setup.py` docstring). Once the heartbeat exists, the exporter's contract is simple: **ping when healthy, silence when stalled**. BS does the alerting via missed-heartbeat policy already wired by KEI-20 (Orion).

This inverts the usual fire-alert-from-app pattern but:
- Adds zero new BS API plumbing.
- Reuses existing severity routing (critical → `#ceo`) wholesale.
- Survives exporter process restarts gracefully (absence-of-signal semantics).

## Verbatim verify

```
$ python3 -m pytest tests/scripts/test_claim_queue_metrics_export.py -q
.............                                                            [100%]
13 passed in 0.18s

$ ruff check + format --check
All checks passed!
2 files already formatted

$ psql -c "SELECT * FROM public.claim_queue_metrics_v;"
 available_count | active_count | blocked_count | oldest_available_age_sec | oldest_active_age_sec | max_idle_seconds | computed_at
-----------------+--------------+---------------+--------------------------+-----------------------+------------------+-------------
               1 |            2 |             2 |                   130055 |                   599 |                  | 2026-05-18 22:37:58
```

(live snapshot at PR-open — 1 P2 in queue, 2 active, 2 blocked, max_idle NULL per fail-open caveat)

Migration applied via `mcp__supabase__apply_migration kei136_claim_queue_metrics_view` → `{"success":true}`.

## Acceptance per KEI-136 Linear spec

- [x] Queue metrics dashboard live — `claim_queue_metrics_v` queryable in Supabase; BS heartbeat surface ready (operator step 1-time)
- [x] Zero-idle-time SLA monitored — 300s default, env-overridable via `CLAIM_QUEUE_STALL_THRESHOLD_SEC`
- [x] Alerts on queue stalls >5min — heartbeat-skip semantics + missed-heartbeat policy fires `#ceo`

## Out of scope (separate KEIs)

- Bespoke Next.js dashboard page (BS is the dashboard surface per existing pattern).
- `heartbeat_at` population on `public.tasks` (separate observability gap; fail-open handles current NULL baseline).
- `fleet_supervisor.py` changes (already handles claim hygiene; exporter is a passive observer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)