### PR TITLE
[ATLAS] fix(3uj7): cognee.client import-failure log → DEBUG (was WARNING)

### DIFF
--- a/scripts/cognee_recall.py
+++ b/scripts/cognee_recall.py
@@ -86,10 +86,11 @@ async def _search(query: str, org_id: str, app_id: str, agent_id: str | None):
     """
     try:
         import sys as _sys
+
         _sys.path.insert(0, "/home/elliotbot/clawd/Agency_OS/scripts")
         from cognee_http_client import search as http_search
     except ImportError as exc:
-        logger.warning("cognee_http_client import failed: %s", exc)
+        logger.debug("cognee_http_client import failed: %s", exc)
         return []
     try:
         result = http_search(query, top_k=5, search_type="GRAPH_COMPLETION")

--- a/tests/scripts/test_cognee_recall.py
+++ b/tests/scripts/test_cognee_recall.py
@@ -1,6 +1,6 @@
 """tests for scripts/cognee_recall.py — KEI-7 dispatch enrichment wrapper.
 
-Mocks `src.cognee.client.search` via the injectable search_fn parameter on
+Mocks `cognee_http_client.search` via the injectable search_fn parameter on
 enrich_dispatch (production routes through asyncio.run + import).
 """
 
@@ -180,3 +180,47 @@ def test_main_search_raises_passes_through_via_top_level_except(
     captured = capsys.readouterr()
     assert rc == 0
     assert captured.out == "original"
+
+
+def test_cognee_client_import_failure_logs_at_debug_not_warning(
+    recall_mod, monkeypatch, caplog
+) -> None:
+    """Agency_OS-3uj7: when cognee_http_client is absent (e.g. wrapper venv
+    missing the optional dep), the import-failure path must log at DEBUG, not
+    WARNING. Cognee is fail-open by contract; emitting WARNING on every
+    `bd claim` invocation creates stderr noise that clutters session-start
+    output.
+
+    Module reference updated on rebase: the underlying client was renamed from
+    src.cognee.client → cognee_http_client during the Cognee HTTP-route
+    migration. The DEBUG-level intent applies equally to the new name; the
+    test patches the new symbol.
+    """
+    import logging
+
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+
+    real_import = (
+        __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+    )
+
+    def fail_cognee_client(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "cognee_http_client":
+            raise ImportError("No module named cognee_http_client")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setitem(sys.modules, "cognee_http_client", None)
+    monkeypatch.setattr("builtins.__import__", fail_cognee_client)
+    monkeypatch.delitem(sys.modules, "cognee_http_client", raising=False)
+
+    caplog.set_level(logging.DEBUG, logger="cognee_recall")
+    out = recall_mod.enrich_dispatch("original brief")
+
+    assert out == "original brief"
+    import_failure_records = [
+        r for r in caplog.records if "cognee_http_client import failed" in r.getMessage()
+    ]
+    assert import_failure_records, "expected one DEBUG log for cognee_http_client import failure"
+    assert all(r.levelno == logging.DEBUG for r in import_failure_records), (
+        f"expected DEBUG, got levels {[r.levelname for r in import_failure_records]}"
+    )


### PR DESCRIPTION
## Summary

`scripts/cognee_recall.py:85` — `logger.warning` → `logger.debug` for the optional `src.cognee.client` import-failure path. Cognee is fail-open by contract (`bd claim` proceeds when Cognee context is unavailable); emitting WARNING on every invocation creates stderr noise that clutters session-start output and audit pipes.

Closes Agency_OS-3uj7 (P3 bug).

## Why DEBUG, not silenced

Option (b) from the bd description: `_session_start.md` §7 documents the cognee_session_start hook as fail-open and notes "If the file is absent or empty, proceed without it." `bd claim` should match that posture — the import outcome is debug-level diagnostic when run with `LOG_LEVEL=DEBUG`, never user-visible noise.

## Regression test

`tests/scripts/test_cognee_recall.py::test_cognee_client_import_failure_logs_at_debug_not_warning` — monkeypatches `builtins.__import__` to raise `ImportError` for `src.cognee.client`, calls `enrich_dispatch` (which routes through `asyncio.run(_search(...))` when no `search_fn` is supplied), and asserts:
1. Output equals input (fail-open contract preserved).
2. A record matching "cognee.client import failed" exists.
3. ALL such records are at level `DEBUG` (not WARNING).

Negative-path verified: with `logger.warning` in place, the level-assertion fails (`expected DEBUG, got levels ['WARNING']`).

## Verification

```
$ python3 -m pytest tests/scripts/test_cognee_recall.py -x -q
...............                                                          [100%]
15 passed in 0.12s

$ ruff check scripts/cognee_recall.py tests/scripts/test_cognee_recall.py
All checks passed!

$ ruff format --check scripts/cognee_recall.py tests/scripts/test_cognee_recall.py
2 files already formatted
```

## Scope

- 1 LoC in `scripts/cognee_recall.py`
- 37 LoC test addition in `tests/scripts/test_cognee_recall.py`
- No other call-site touched. `scripts/cognee_ingest.py:516` uses `logger.error` for a different code path (Phase 0 ingest, not recall); separate concern.

## Source

Discovered by Aiden during atlas-session drift audit 2026-05-18; 58 stderr WARNING lines observed in one session. P3 cosmetic per bd description.