### PR TITLE
[SCOUT] feat(kei124): Composio OAuth — data layer + skill contract (scaffold)

### DIFF
--- a/skills/composio-oauth/SKILL.md
+++ b/skills/composio-oauth/SKILL.md
@@ -1,0 +1,73 @@
+# SKILL: Composio OAuth — Slack / Linear / GitHub day-1 agent access
+
+**Purpose:** Provision OAuth tokens for Slack, Linear, and GitHub via Composio.dev so Dispatcher agents can read/write across all three on day-1 of a tenant onboarding. Single integration vendor (Composio) replaces three direct OAuth implementations.
+
+**Status:** ⚠️ **Data layer only landed (migration `oauth_provider_tokens`).** Handler + routes ship in follow-up KEI once Dave-action prerequisites (below) complete. Do NOT call any `composio_oauth` function — none exist yet.
+
+**Source:** Composio.dev REST API (https://docs.composio.dev/). Vendor docs pinned at the version that exists when the handler PR lands — record the docs URL + retrieval date in the handler-PR description.
+
+**Cost gate:** Composio Free tier allows ~1k connected accounts/month, sufficient for early customer cohort. Growth tier required at ~10k+ active connections — current per-seat AUD pricing TBC in the handler-PR research pass (vendor pricing not stable at scope-time).
+
+---
+
+## Dave-action prerequisites (BLOCKS handler PR)
+
+The handler + routes cannot be built without these one-time setup steps, all owned by Dave:
+
+1. **Composio.dev account creation** — sign up Agency_OS-scout as the organisation owner.
+2. **OAuth app registration on each provider** — three steps, all done from within the Composio dashboard:
+   - Slack OAuth app (scopes: `channels:read`, `chat:write`, `users:read`, `team:read`).
+   - Linear OAuth app (scopes: `read`, `write` over Issues, Comments, Projects).
+   - GitHub OAuth app (scopes: `repo`, `read:org`, `read:user`).
+3. **Issue Composio master API key** — store as env var `COMPOSIO_API_KEY` (production) and `COMPOSIO_API_KEY_DEV` (staging). Per-environment.
+4. **Configure callback URL** in Composio's OAuth config: `https://api.keiracom.com/api/v1/composio/callback` (prod) and the equivalent staging host.
+5. **Confirm `CUSTOMER_KEY_ENCRYPTION_KEY` is provisioned** in both prod + staging (already required by KEI-116 customer_api_keys; this skill reuses the same secret).
+
+When all five are confirmed in `elliot_internal.api_keys_ledger`, the handler-PR is unblocked.
+
+---
+
+## At-a-Glance contract (for the follow-up handler PR)
+
+**What:** Two-call OAuth flow brokered by Composio:
+1. `POST /api/v1/composio/connect?provider=<slack|linear|github>` → returns `oauth_url` (Composio's hosted consent page) + CSRF `state`.
+2. `GET /api/v1/composio/callback?state=<csrf>&composio_connection_id=<conn>` → exchanges `composio_connection_id` for `{access_token, refresh_token, expires_at}` via Composio's REST API, encrypts tokens with `pgp_sym_encrypt`, writes to `oauth_provider_tokens`, then 302s to `${frontend_url}/settings/integrations?provider=<p>&status=connected`.
+
+**Why Composio (vs three direct integrations):**
+- One vendor relationship vs three. One audit, one rotation policy, one rate-limit budget to monitor.
+- Refresh-token lifecycle managed vendor-side — no per-provider refresh-cron in our codebase.
+- Vendor takes liability for upstream OAuth-flow changes (Slack/Linear/GitHub all version their OAuth surfaces independently).
+
+**When NOT to use:**
+- NOT for end-user identity (Composio is for *bot* identities authorised by an end-user). For end-user signup use Supabase Auth (KEI-111A).
+- NOT for storing customer-provided keys (those go through KEI-116 `customer_api_keys`).
+- NOT if Composio.dev quota is exhausted — fail-fast in handler with a `503` and surface to `#ceo` via the existing alert path.
+- NOT for any provider not in the {slack, linear, github} allowlist. The provider param is validated against a hard-coded set; widening requires a Dave-ratified KEI.
+
+**Caveats:**
+- **Composio API stability** is the single point of failure for three integrations. The handler-PR must include a `composio_health` check that runs on Dispatcher startup; failure-mode is "skip provider call, log to `interceptor_events`, surface in agent UI as 'connector temporarily unavailable'".
+- **Token encryption is at-rest only.** Decrypted tokens live in process memory for the duration of a single agent action — no caching across requests. Mirror customer_api_keys handling for parity with KEI-116.
+- **`composio_connection_id` is the source of truth on Composio's side.** Our `oauth_provider_tokens` row is the read-replica for our queries; if a user revokes from Composio's dashboard, Composio webhooks our `/composio/webhook` endpoint (to be added in handler-PR) and we soft-revoke the row.
+- **Revocation cascade:** when a `dispatcher_customers` row is soft-deleted, all matching `oauth_provider_tokens` rows must be soft-revoked in the same transaction. Handler-PR adds that trigger.
+
+**Returns (handler-PR shape, not in this scaffold):**
+- `POST /connect`: `{oauth_url: str, state: str}`.
+- `GET /callback`: `302` redirect to `${frontend_url}/settings/integrations?provider=<p>&status=connected`.
+- `oauth_provider_tokens` row: `{id, tenant_id, provider, composio_connection_id, encrypted_access_token, encrypted_refresh_token, expires_at, created_at, revoked_at}`.
+
+---
+
+## What landed in this scaffold PR
+
+- `supabase/migrations/20260519_kei124_oauth_provider_tokens.sql` — the durable data layer (table + two indexes + comments). Encrypted-at-rest via pgcrypto, mirrors KEI-116 customer_api_keys pattern.
+- This skill doc — contract sketch + prerequisites checklist for the handler-PR.
+
+## What ships in the follow-up KEI (bd-created post-merge)
+
+- `src/auth/composio_oauth.py` — handler (start_oauth_flow + finalize_connection + store_tokens, ~150 LOC).
+- `src/api/routes/composio.py` — POST /connect + GET /callback + (optional) POST /webhook (~150 LOC).
+- `tests/auth/test_composio_oauth.py` + `tests/api/routes/test_composio.py` — vendor calls mocked.
+- Settings additions for `COMPOSIO_API_KEY`, `COMPOSIO_BASE_URL`, `COMPOSIO_CALLBACK_URL`.
+- Router registration in `src/api/main.py`.
+
+The handler-PR cannot be opened until all five Dave-action prerequisites in the section above are recorded as live in `elliot_internal.api_keys_ledger`.

--- a/supabase/migrations/20260519_kei124_oauth_provider_tokens.sql
+++ b/supabase/migrations/20260519_kei124_oauth_provider_tokens.sql
@@ -1,0 +1,78 @@
+-- =============================================================================
+-- KEI-124 — Composio OAuth provider tokens (data layer)
+-- =============================================================================
+-- Stores per-tenant OAuth tokens minted by Composio.dev for day-1 Slack, Linear,
+-- and GitHub agent access. This migration is the durable data layer landed
+-- ahead of the handler + routes (follow-up KEI) so that vendor onboarding can
+-- proceed in parallel with implementation review.
+--
+-- Design rationale:
+--   • Tokens are encrypted at rest with pgcrypto (mirrors customer_api_keys
+--     pattern at KEI-116). The encryption secret is the same env var
+--     CUSTOMER_KEY_ENCRYPTION_KEY — one secret per environment, no per-table
+--     proliferation. Decryption only happens at the auth-service boundary,
+--     never in long-lived application memory.
+--   • composio_connection_id is the Composio.dev connected-account ID — the
+--     primary key on their side. Stored so we can re-fetch / revoke via the
+--     Composio API without re-running OAuth from the user.
+--   • Provider list is intentionally TEXT (not an enum) at this stage; the
+--     handler validates against an allowlist of {'slack','linear','github'}.
+--     Tighten to a Postgres enum in a sub-KEI once the three providers are
+--     wired and stable.
+--   • Soft revocation only — historical tokens stay queryable for incident
+--     forensics (e.g. "did this agent action use a token revoked at time X?")
+--     and partial unique indexes ensure only one ACTIVE token per
+--     (tenant, provider) pair.
+--   • No FK on tenant_id at this migration — public.dispatcher_customers FK
+--     is added in a sub-KEI alongside RLS policies (KEI-111E pattern). Keeps
+--     this migration replayable in dev environments that haven't run KEI-111
+--     yet.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.oauth_provider_tokens (
+    id                      UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id               UUID         NOT NULL,
+    -- One of: 'slack' | 'linear' | 'github'. Validated at the application
+    -- layer; widen to an enum in a sub-KEI once the providers stabilise.
+    provider                TEXT         NOT NULL,
+    -- Composio.dev's connected-account identifier. Used to refresh / revoke
+    -- through their API without re-running OAuth from the end user.
+    composio_connection_id  TEXT         NOT NULL,
+    -- AES-256 ciphertext via pgp_sym_encrypt(plaintext, CUSTOMER_KEY_ENCRYPTION_KEY).
+    encrypted_access_token  BYTEA        NOT NULL,
+    -- Nullable: some providers (e.g. GitHub OAuth apps) don't issue refresh
+    -- tokens. Composio handles re-auth transparently when null.
+    encrypted_refresh_token BYTEA,
+    -- Wall-clock expiry of the access_token. NULL means "long-lived / managed
+    -- by Composio" — handler treats null expires_at as never-expiring at the
+    -- AOS layer and defers to Composio's own refresh logic.
+    expires_at              TIMESTAMPTZ,
+    created_at              TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    -- Set when the user disconnects or admin revokes; row stays for audit.
+    revoked_at              TIMESTAMPTZ
+);
+
+-- Active-only unique constraint: at most one live token per (tenant, provider).
+-- Revoked rows excluded so disconnect → reconnect doesn't violate uniqueness
+-- while still blocking double-store of an active token.
+CREATE UNIQUE INDEX IF NOT EXISTS oauth_provider_tokens_tenant_provider_active_idx
+    ON public.oauth_provider_tokens (tenant_id, provider)
+    WHERE revoked_at IS NULL;
+
+-- Lookup by composio_connection_id for webhook-driven token refresh /
+-- revocation events from Composio's side.
+CREATE INDEX IF NOT EXISTS oauth_provider_tokens_composio_connection_id_idx
+    ON public.oauth_provider_tokens (composio_connection_id);
+
+COMMENT ON TABLE public.oauth_provider_tokens IS
+    'KEI-124: per-tenant OAuth tokens minted via Composio.dev for Slack / Linear / GitHub day-1 agent access. Encrypted at rest with pgcrypto. Handler + routes ship in follow-up KEI.';
+COMMENT ON COLUMN public.oauth_provider_tokens.composio_connection_id IS
+    'KEI-124: Composio.dev connected-account ID. Used to refresh or revoke without re-running user-facing OAuth.';
+COMMENT ON COLUMN public.oauth_provider_tokens.encrypted_access_token IS
+    'KEI-124: pgp_sym_encrypt(access_token, CUSTOMER_KEY_ENCRYPTION_KEY). Same env secret as KEI-116 customer_api_keys.';
+COMMENT ON COLUMN public.oauth_provider_tokens.encrypted_refresh_token IS
+    'KEI-124: nullable — some providers (GitHub OAuth apps) do not issue refresh tokens. Composio handles re-auth when null.';
+COMMENT ON COLUMN public.oauth_provider_tokens.expires_at IS
+    'KEI-124: nullable; null means "managed by Composio side", AOS layer treats as never-expiring locally.';
+COMMENT ON COLUMN public.oauth_provider_tokens.revoked_at IS
+    'KEI-124: soft revoke; row survives for audit. Partial unique index excludes revoked rows so reconnect is allowed.';


### PR DESCRIPTION
## Summary

Lands the durable data layer for **KEI-124 Composio OAuth** ahead of handler + routes (follow-up bd `Agency_OS-kk1a`, P1). Scope-limited per `feedback_pre_work_during_gate` — handler implementation is gated on Dave-action vendor onboarding.

## What ships in this PR

- **`supabase/migrations/20260519_kei124_oauth_provider_tokens.sql`** — per-tenant OAuth token storage. Encrypted at rest via pgcrypto (mirrors KEI-116 `customer_api_keys`). Active-only unique index on `(tenant_id, provider)` — disconnect/reconnect supported without violating uniqueness.
- **`skills/composio-oauth/SKILL.md`** — integration contract: prerequisites checklist, At-a-Glance shape, When-NOT-to-use, caveats, follow-up scope. Matches `skills/hubspot/` template.

## Dave-action prerequisites (block follow-up handler PR)

Per the skill doc — five one-time setup steps:

1. Composio.dev account creation (org = Agency_OS-scout).
2. OAuth app registration on Slack / Linear / GitHub via Composio dashboard (scopes per skill doc).
3. Issue `COMPOSIO_API_KEY` + record in `elliot_internal.api_keys_ledger`.
4. Configure Composio callback URL: `https://api.keiracom.com/api/v1/composio/callback` (+ staging).
5. Confirm `CUSTOMER_KEY_ENCRYPTION_KEY` provisioned (reused from KEI-116).

When all five are recorded as live, follow-up bd `Agency_OS-kk1a` unblocks.

## Why scaffold-only this PR

- Composio.dev account + OAuth app reg are Dave-actions. Without those, the handler cannot be end-to-end tested.
- Landing the migration + contract now unblocks vendor onboarding to run **in parallel** with handler design — Dave registers apps while Scout/peer designs handler against the contract here.
- Avoids `feedback_pre_work_during_gate` violation (don't burn the gate by speculating on vendor API shape).
- Migration is a defensible single-concern PR (`feedback_split_orthogonal_scope`).

## Test plan

- [ ] Migration SQL syntax validates (CREATE TABLE IF NOT EXISTS, two indexes, COMMENTs only — no DDL surprises).
- [ ] No new Sonar issues (no code, just SQL + Markdown).
- [ ] Follow-up bd `Agency_OS-kk1a` is open with full Dave-action checklist + acceptance criteria.

## Related

- bd: `Agency_OS-61k5ni` (KEI-124 — this PR closes the data-layer portion)
- bd: `Agency_OS-kk1a` (KEI-124 follow-up — handler + routes, depends-on 61k5ni)
- Skills precedent: `skills/hubspot/SKILL.md`
- Migration precedent: KEI-116 `customer_api_keys` encryption pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)