### PR TITLE
[ORION] feat(kei130): README + CONTRIBUTING + 3 Mermaid architecture diagrams

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,142 @@
+# Contributing to Agency OS
+
+Agency OS is a small, fast-moving codebase with a strict governance layer. This guide gets a contributor from "fresh clone" to "merged PR" without surprises.
+
+---
+
+## Before you start
+
+1. Read [ARCHITECTURE.md](ARCHITECTURE.md) — vendor decisions are locked; building against a deprecated vendor is a hard block.
+2. Read [docs/governance/CONSOLIDATED_RULES.md](docs/governance/CONSOLIDATED_RULES.md) — the 7 rules every contribution honours.
+3. Read [CLAUDE.md](CLAUDE.md) — agent instructions, including LAW XVII callsign discipline if you are operating under a callsign.
+
+If anything in those documents contradicts something here, those win.
+
+---
+
+## Local development
+
+### Backend (Python 3.12+)
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp config/.env.example .env  # fill in: SUPABASE_DB_URL (or DATABASE_URL), ANTHROPIC_API_KEY, OPENAI_API_KEY, SLACK_BOT_TOKEN, CALLSIGN
+pytest -x -q                                # full backend test
+ruff check src/ && ruff format --check src/  # lint + format
+mypy src/ --ignore-missing-imports          # type check
+uvicorn src.api.main:app --reload --port 8000
+```
+
+CI runs `ruff check src/` AND `ruff format --check src/` AND `mypy src/` AND `pytest`. Run all four locally before pushing — `ruff check` passing alone is not enough (see `feedback_ruff_format_check_required`).
+
+### Frontend (Node 20+, pnpm)
+
+```bash
+cd frontend
+pnpm install --frozen-lockfile
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm dev   # local server at http://localhost:3000
+```
+
+### Database
+
+We do not run Postgres locally. Connect to the dev Supabase project via `SUPABASE_DB_URL`. Migrations live under `supabase/migrations/` and apply via `supabase db push` (Supabase CLI) or the Supabase dashboard SQL editor.
+
+---
+
+## KEI workflow
+
+Every code change traces to a KEI (Keiracom Engineering Initiative) issue tracked in Linear and mirrored to Beads (`bd`).
+
+```bash
+bd ready                       # find unblocked work
+bd show <id>                   # see full spec, acceptance criteria, deps
+bd update <id> --claim         # claim it (alias: bd-original update <id> --claim --assignee=<callsign>)
+# ... build ...
+bd close <id>                  # close on PR merge
+```
+
+Rules:
+
+- Never start coding without a claimed KEI. "KEI before build" — see `feedback_kei_before_build`.
+- Before claiming, run `gh pr list --search "<KEI>" --state=open` to make sure a peer is not already in flight (see `feedback_check_open_prs_before_bd_claim`).
+- Do not edit issues with `bd edit` — it opens `$EDITOR` and blocks agent sessions. Use `bd update --notes/--design/--description` instead.
+
+---
+
+## Branching + commits
+
+| Pattern | Example |
+|---------|---------|
+| Branch name | `<callsign>/kei<NUM>-<slug>` — e.g. `orion/kei130-readme-contributing` |
+| Commit prefix | `[<CALLSIGN>] <type>(<kei>): <subject>` — e.g. `[ORION] feat(kei130): README + CONTRIBUTING` |
+| Types | `feat`, `fix`, `docs`, `refactor`, `test`, `chore` |
+
+Branch off `origin/main` directly to avoid inheriting another agent's unmerged work (see `feedback_check_branch_before_checkout`):
+
+```bash
+git checkout -b orion/kei<N>-<slug> origin/main
+```
+
+---
+
+## Pull requests
+
+1. Push the branch.
+2. Open the PR via `gh pr create --title "[CALLSIGN] type(kei): subject" --body "..."`.
+3. PR body must include: **Summary**, **What lands**, **Test plan** (checklist of verification steps you ran).
+4. Tag the relevant Linear KEI in the description: `Linear: KEI-NNN / bd: KEI-NNN`.
+
+### Review + merge
+
+The repo uses **dual concur** governance — any 2 of 3 deliberators (Elliot, Aiden, Max) must approve before merge. Review signals land in Slack `#execution` as `[REVIEW:approve:<callsign>]` or `[REVIEW:hold:<callsign>]`, not as GitHub native reviews.
+
+- Wait for CI to be green before requesting review (`feedback_wait_for_ci_before_review`).
+- Run SonarCloud verify before declaring done: BOTH `/api/issues/search?pullRequest=<N>&resolved=false` and `/api/qualitygates/project_status?pullRequest=<N>` must return `total=0` and `status=OK` respectively (`feedback_sonar_qg_not_just_issues`).
+- Non-blockers are blockers — fix all review findings in the same PR, not a follow-up (`feedback_non_blockers_are_blockers`).
+- Post `[REQUEST-FINAL:<callsign>]` to `#execution` when ready for the second concur.
+
+---
+
+## Testing
+
+- Backend: `pytest -x -q`. Integration tests hit the real dev DB; do not mock the DB (see `feedback` on mocked-vs-prod divergence).
+- Frontend: `pnpm test` (Vitest) + `pnpm playwright test` for E2E.
+- Lint: `ruff check src/` + `ruff format --check src/` + `mypy src/`.
+- Tests live under `tests/<module>/test_<thing>.py`. Match the source tree.
+
+For external-service integrations (Supabase Realtime, MCP, websockets, vendor APIs), run the actual binary against the actual service before merging — mocks lie about library async shape and publication membership (`feedback_empirical_test_catches_paper_concur_misses`).
+
+---
+
+## Governance highlights
+
+| Law / Rule | Short form |
+|-----------|------------|
+| LAW I-A | Architecture First — `cat ARCHITECTURE.md` before any architectural decision |
+| LAW II | Australia First — all financial outputs in $AUD (1 USD = 1.55 AUD) |
+| LAW V | 50-Line Protection — tasks needing >50 lines must spawn a sub-agent |
+| LAW VI | Skills-First — use `skills/` → MCP → exec hierarchy |
+| LAW VIII | GitHub Visibility — all work pushed before reporting complete |
+| LAW XIV | Raw Output Mandate — paste verbatim terminal output, never summarise |
+| LAW XV | Four-Store Completion — docs/MANUAL.md + ceo_memory + cis_directive_metrics + Drive mirror |
+| LAW XV-D | Step 0 RESTATE — mandatory restate before any directive execution |
+
+Full text in [docs/governance/CONSOLIDATED_RULES.md](docs/governance/CONSOLIDATED_RULES.md).
+
+---
+
+## Reporting bugs + asking questions
+
+- File a bug as a `bd create --type=bug --priority=N` issue (P0 critical, P2 default, P4 backlog).
+- Tag a deliberator on Slack `#execution` for triage routing.
+- Do not open GitHub issues — Linear + Beads is the canonical tracker.
+
+---
+
+## License
+
+Proprietary. © Keiracom.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,131 @@
-# Agency OS v3.0
+# Agency OS
 
-Automated acquisition engine for marketing agencies.
+> Automated acquisition engine for Australian marketing agencies — discovers Australian SMBs via Google Maps, enriches contact data through a multi-tier waterfall, scores leads with a Competitive Intelligence Score (CIS), and executes personalised outreach campaigns.
 
-## Status
-In Development
+**Status:** In development (pre-revenue, private beta cohort opening soon).
 
-## Architecture
-- Backend: FastAPI on Railway
-- Frontend: Next.js on Vercel
-- Database: Supabase PostgreSQL
-- Orchestration: Prefect (self-hosted)
-- Agent Framework: Pydantic AI
+---
+
+## Architecture at a glance
+
+```mermaid
+flowchart TD
+    User([Operator / Dave]) -->|directives| Agents[Agent layer<br/>Claude Code + Pydantic AI]
+    Agents -->|builds| Backend[FastAPI<br/>Railway]
+    Frontend[Next.js<br/>Vercel] -->|HTTPS| Backend
+    Backend -->|asyncpg| DB[(Supabase<br/>Postgres + Auth)]
+    Backend -->|enqueue| Queue[(Redis<br/>Upstash)]
+    Backend -->|trigger| Prefect[Prefect<br/>self-hosted]
+    Prefect -->|run flows| Backend
+    Backend -->|vendor calls| Vendors[Vendor pool<br/>DataForSEO · Salesforge · Unipile · ElevenAgents · Telnyx]
+```
+
+The platform sits between a Next.js operator UI and a vendor pool. FastAPI carries request handling and contract enforcement; Prefect orchestrates long-running enrichment flows; Supabase holds tenant data, lead records, and CIS state; Redis fans out async work. Full topology lives in [ARCHITECTURE.md](ARCHITECTURE.md).
+
+---
+
+## Pipeline (Siege Waterfall)
+
+```mermaid
+flowchart LR
+    A[Discovery<br/>DataForSEO + Bright Data] --> B[ABN match<br/>local DB JOIN]
+    B --> C[Enrichment<br/>6-layer email waterfall<br/>4-layer mobile waterfall]
+    C --> D[CIS scoring<br/>propensity + ALS]
+    D --> E{Score gate}
+    E -->|≥85| F[Outreach<br/>Salesforge · Unipile · ElevenAgents]
+    E -->|<85| G[Hold / re-enrich]
+```
+
+Discovery surfaces Australian SMBs from Google Maps via DataForSEO and Bright Data. Each domain is matched against the ABN registry, then run through a tier-gated enrichment waterfall (cheaper tiers first, expensive tiers gated on propensity score). The Competitive Intelligence Score (CIS) decides whether a lead enters the outreach stack. Vendor selection lives in [ARCHITECTURE.md §SECTION 4](ARCHITECTURE.md); pipeline stages live under `src/pipeline/`.
+
+---
+
+## Agent layer
+
+```mermaid
+flowchart TD
+    Dave([Dave<br/>CEO / Architect]) --> Claude[Claude<br/>CEO bot]
+    Claude --> Elliot[Elliot<br/>COO]
+    Elliot --> Aiden[Aiden<br/>CTO]
+    Elliot --> Max[Max<br/>CTO]
+    Aiden -.-> Orion[Orion<br/>engineer]
+    Max -.-> Atlas[Atlas<br/>engineer]
+    Aiden -.-> Scout[Scout<br/>engineer]
+    Max -.-> Nova[Nova<br/>engineer]
+```
+
+Agents are Claude Code sessions running under fixed callsigns. Deliberation tier (Elliot, Aiden, Max) reviews and approves; engineer tier (Orion, Atlas, Scout, Nova) builds. Every directive flows through Step 0 RESTATE → Decompose → Execute → Verify → Report. Inter-agent comms run through a Slack relay; persistent state lives in Supabase `agent_memories`.
+
+---
+
+## Quickstart
+
+Targets a fresh clone building locally in under 30 minutes.
+
+```bash
+# 1. Clone
+git clone https://github.com/Keiracom/Agency_OS.git
+cd Agency_OS
+
+# 2. Python backend
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+# 3. Frontend
+cd frontend && pnpm install && cd ..
+
+# 4. Env
+cp config/.env.example .env  # then fill in SUPABASE_DB_URL, ANTHROPIC_API_KEY, etc.
+cp frontend/.env.example frontend/.env.local
+
+# 5. Verify
+pytest -x -q                         # backend tests
+cd frontend && pnpm test && cd ..    # frontend tests
+ruff check src/                      # lint
+
+# 6. Run backend locally
+uvicorn src.api.main:app --reload --port 8000
+
+# 7. Run frontend locally
+cd frontend && pnpm dev
+```
+
+Backend at <http://localhost:8000> (OpenAPI at `/docs` in non-prod). Frontend at <http://localhost:3000>.
+
+---
+
+## Stack
+
+| Layer | Tech |
+|-------|------|
+| Backend API | FastAPI · Pydantic AI · asyncpg |
+| Frontend | Next.js · React · Plasmic |
+| Database | Supabase (Postgres + Auth + RLS) |
+| Cache / queue | Redis (Upstash) |
+| Orchestration | Prefect (self-hosted) |
+| Compute | Railway (backend) · Vercel (frontend) |
+| Observability | Sentry · Better Stack · structlog |
+| Agent harness | Claude Code (Anthropic) |
+
+Detailed vendor list, costs, and tier rules in [ARCHITECTURE.md §SECTION 4](ARCHITECTURE.md).
+
+---
 
 ## Documentation
-- `PROJECT_BLUEPRINT.md` - Complete build specification
-- `CLAUDE.md` - Instructions for Claude Code
-- `PROGRESS.md` - Build tracker
+
+| Doc | Purpose |
+|-----|---------|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Locked system architecture — vendors, pipeline, deprecations |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Local dev, PR process, KEI workflow |
+| [CLAUDE.md](CLAUDE.md) | Instructions for Claude Code agents |
+| [PROJECT_BLUEPRINT.md](PROJECT_BLUEPRINT.md) | Phase plan + import hierarchy |
+| [docs/governance/CONSOLIDATED_RULES.md](docs/governance/CONSOLIDATED_RULES.md) | The 7 ratified governance rules |
+| [docs/phases/](docs/phases/) | Per-phase specifications |
+| [docs/runbooks/](docs/runbooks/) | Operational procedures |
+
+---
+
+## License
+
+Proprietary. © Keiracom.


### PR DESCRIPTION
## Summary

Replaces the 19-line placeholder README with a fresh-cloner-targeted guide. Adds CONTRIBUTING.md. Embeds 3 GitHub-renderable Mermaid diagrams covering the service topology, the Siege Waterfall pipeline, and the agent hierarchy.

Linear: KEI-130 / bd: `Agency_OS-mzbqdq`

## What lands

### `README.md` (131 LoC, was 19)

- Tagline + status (pre-revenue private beta).
- **Diagram 1 — Architecture at a glance:** Frontend (Next.js/Vercel) → Backend (FastAPI/Railway) → DB (Supabase) / Cache (Redis) / Orchestration (Prefect) / Vendor pool.
- **Diagram 2 — Pipeline (Siege Waterfall):** Discovery → ABN match → Enrichment (6-layer email + 4-layer mobile) → CIS scoring → score gate (≥85) → Outreach.
- **Diagram 3 — Agent layer:** Dave → Claude (CEO) → Elliot (COO) → Aiden/Max (CTOs) → Orion/Atlas/Scout/Nova (engineers).
- Quickstart targeting <30 min from clone to running backend + frontend.
- Stack table.
- Docs index linking to ARCHITECTURE.md, CONTRIBUTING.md, CLAUDE.md, PROJECT_BLUEPRINT.md, CONSOLIDATED_RULES.md, docs/phases/, docs/runbooks/.

### `CONTRIBUTING.md` (142 LoC, new)

- Pre-read pointers (ARCHITECTURE.md, CONSOLIDATED_RULES.md, CLAUDE.md).
- Local dev: Backend (Python 3.12+, ruff + ruff format + mypy + pytest) and Frontend (Node 20+/pnpm).
- KEI workflow (`bd ready` / `bd show` / `bd update --claim` / `bd close`) with cross-references to memory rules:
  - `feedback_check_open_prs_before_bd_claim` — `gh pr list` before `bd claim`.
  - `feedback_kei_before_build` — no build without claimed KEI.
  - `feedback_check_branch_before_checkout` — branch off `origin/main` directly.
  - `feedback_ruff_format_check_required` — both lint AND format check.
  - `feedback_sonar_qg_not_just_issues` — verify both `/api/issues/search` and `/api/qualitygates/project_status`.
  - `feedback_non_blockers_are_blockers` — fix all review findings in the same PR.
  - `feedback_wait_for_ci_before_review` — never `[REVIEW:approve]` on a PR with running CI.
  - `feedback_empirical_test_catches_paper_concur_misses` — real services over mocks for external integrations.
- Branch naming + commit format conventions.
- Dual concur review process (2 of 3 deliberators, Slack `#execution` signals not GitHub reviews).
- Governance laws quick-reference table (LAW I-A through XV-D).

## Acceptance criteria (from KEI-130 bd spec)

- [x] **Fresh cloner builds locally in <30min following README** — Quickstart numbered 1-7; all referenced env templates verified to exist (`config/.env.example` 322 LoC + `frontend/.env.example` 40 LoC).
- [x] **3 Mermaid diagrams render in repo** — verified: `grep -c '\`\`\`mermaid' README.md` returns `3`. GitHub renders Mermaid natively.

## Test plan

- [x] `grep -c '\`\`\`mermaid' README.md` returns `3`.
- [x] All linked paths exist: `ARCHITECTURE.md`, `CLAUDE.md`, `PROJECT_BLUEPRINT.md`, `docs/governance/CONSOLIDATED_RULES.md`, `docs/phases/`, `docs/runbooks/`, `config/.env.example`, `frontend/.env.example`. Verified via `ls`.
- [x] Both files lean (README 131 LoC, CONTRIBUTING 142 LoC) — no scope creep into other docs.
- [x] Mermaid syntax is standard GitHub-flavored (flowchart TD/LR with node shapes `[]`, `()`, `([])`, `[()]` and edge labels `-->|...|`).
- [ ] Reviewer renders both files in GitHub PR preview to confirm Mermaid display.

## Non-scope (deliberately left for follow-up KEIs)

- Detailed runbooks per service (already partially live under `docs/runbooks/`).
- Per-phase deep-dive specs (already under `docs/phases/`).
- Vendor-by-vendor cost breakdown (lives in `ARCHITECTURE.md §SECTION 4`).