### PR TITLE
[SCOUT] feat(kei211): heartbeat watchdog + reaper — task-progress zombie detection

### DIFF
--- a/src/dispatcher/heartbeat_reaper.py
+++ b/src/dispatcher/heartbeat_reaper.py
@@ -1,0 +1,222 @@
+"""KEI-211 — Dispatcher heartbeat reaper (task-progress zombie cleanup).
+
+Pairs with ``src.dispatcher.heartbeat_watchdog``. Watchdog detects zombies
+and publishes one event per zombie on NATS
+``keiracom.agent.status.{callsign}``; this reaper subscribes to that
+wildcard subject and performs the cleanup actions:
+
+  1. Mark the task ``status='failed'`` with ``released_at=NOW()`` in
+     ``public.tasks``. Idempotent: the WHERE clause filters on
+     ``status='active'`` so a task already reaped (or naturally completed)
+     between watchdog detect and reaper handle is a no-op.
+  2. Decrement the Valkey thread counter for the callsign:
+     ``DECR thr:<callsign>``. Floor at 0 — a transient over-decrement is
+     corrected by the session_manager on next session bind. Mirrors the
+     ``rl:`` / ``spend:`` namespace convention documented in
+     ``valkey_pool.py``.
+  3. Write a ``reaper_observation`` row to ``public.agent_memories`` so
+     the audit trail captures both detection (watchdog_observation by the
+     watchdog) and remediation (this module).
+
+Explicitly does NOT respawn — the dispatcher's session_manager handles
+respawn on next claim. Out-of-process tmux kill is left to
+``src.dispatcher.reaper`` (the tmux/container lifecycle reaper) which
+runs independently.
+
+Env contract identical to ``heartbeat_watchdog`` — DSN, NATS_URL — plus
+``HEARTBEAT_REAPER_QUEUE_GROUP`` to enable multi-instance load-shedding
+via NATS queue subscriptions when the dispatcher fleet scales out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+NATS_URL_ENV = "NATS_URL"
+DEFAULT_NATS_URL = "nats://127.0.0.1:4222"
+NATS_SUBJECT_WILDCARD = "keiracom.agent.status.*"
+QUEUE_GROUP_ENV = "HEARTBEAT_REAPER_QUEUE_GROUP"
+DEFAULT_QUEUE_GROUP = "heartbeat_reaper"
+
+# Valkey key family for per-callsign thread counts. See valkey_pool.py
+# §"Key namespace contract" — <family>:<scope>:<period?>.
+THREAD_COUNT_PREFIX = "thr"
+
+# DSN scheme suffix — mirrors heartbeat_watchdog / spend_tracker.
+_ASYNCPG_DSN_PREFIX = "+asyncpg"
+
+
+@dataclass(frozen=True)
+class ReapResult:
+    task_id: str
+    callsign: str
+    task_marked_failed: bool
+    valkey_decremented: bool
+    audit_logged: bool
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL / SUPABASE_DB_URL not set")
+    return dsn.replace(_ASYNCPG_DSN_PREFIX, "").replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def thread_count_key(callsign: str) -> str:
+    """Build the Valkey thread-count key. Refuses blank callsign per KEI-117A
+    namespace contract — no unscoped keys.
+    """
+    if not callsign or not callsign.strip():
+        raise ValueError("callsign must be a non-empty string")
+    return f"{THREAD_COUNT_PREFIX}:{callsign.strip()}"
+
+
+def _mark_task_failed(task_id: str) -> bool:
+    """Idempotent UPDATE — only fires when row is still active."""
+    try:
+        import psycopg  # noqa: PLC0415
+
+        with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE public.tasks
+                   SET status = 'failed',
+                       released_at = NOW()
+                 WHERE id = %s::uuid
+                   AND status = 'active'
+                """,
+                (task_id,),
+            )
+            updated = cur.rowcount
+            conn.commit()
+        return updated > 0
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.warning("tasks UPDATE failed for task=%s: %s", task_id, exc)
+        return False
+
+
+async def _decrement_thread_count(callsign: str) -> bool:
+    """DECR thr:<callsign>, floor at 0. Returns True on success."""
+    try:
+        from src.dispatcher.valkey_pool import get_valkey_client  # noqa: PLC0415
+
+        client = await get_valkey_client()
+        key = thread_count_key(callsign)
+        new_value = await client.decr(key)
+        if int(new_value) < 0:
+            # Floor at 0 — transient over-decrement is corrected by
+            # session_manager on next bind.
+            await client.set(key, 0)
+        return True
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.warning("Valkey DECR %s failed: %s", callsign, exc)
+        return False
+
+
+def _log_reap_observation(task_id: str, callsign: str, task_marked: bool) -> bool:
+    """Write reaper_observation row to public.agent_memories. Fail-open."""
+    try:
+        import psycopg  # noqa: PLC0415
+
+        content = f"reaper: task {task_id} ({callsign}) reaped — task_marked_failed={task_marked}"
+        metadata = {
+            "task_id": task_id,
+            "task_marked_failed": task_marked,
+        }
+        with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO public.agent_memories
+                    (id, callsign, source_type, content, typed_metadata,
+                     created_at, valid_from, state)
+                VALUES (gen_random_uuid(), %s, 'reaper_observation', %s,
+                        %s::jsonb, NOW(), NOW(), 'confirmed')
+                """,
+                (callsign, content, json.dumps(metadata)),
+            )
+            conn.commit()
+        return True
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.warning("reaper_observation log failed for task=%s: %s", task_id, exc)
+        return False
+
+
+async def reap_one(task_id: str, callsign: str) -> ReapResult:
+    """Apply all three reap actions for one zombie task. Independent legs:
+    each leg fails open so a NATS-delivered event always produces SOME audit
+    trail even if one downstream is degraded.
+    """
+    task_marked = _mark_task_failed(task_id)
+    decremented = await _decrement_thread_count(callsign)
+    logged = _log_reap_observation(task_id, callsign, task_marked)
+    return ReapResult(
+        task_id=task_id,
+        callsign=callsign,
+        task_marked_failed=task_marked,
+        valkey_decremented=decremented,
+        audit_logged=logged,
+    )
+
+
+def parse_zombie_event(payload: bytes) -> dict[str, Any] | None:
+    """Decode a watchdog NATS payload into (task_id, callsign).
+
+    Returns None on any decode / shape error so the subscriber can log +
+    skip without crashing the loop.
+    """
+    try:
+        msg = json.loads(payload)
+        if msg.get("type") != "zombie_detected":
+            return None
+        task_id = msg.get("task_id")
+        callsign = msg.get("callsign")
+        if not task_id or not callsign:
+            return None
+        return {"task_id": task_id, "callsign": callsign}
+    except (json.JSONDecodeError, AttributeError, TypeError) as exc:
+        logger.warning("malformed zombie event payload: %s", exc)
+        return None
+
+
+async def run_forever() -> None:
+    """Long-running NATS-subscribe loop. Use as a systemd-managed service entrypoint."""
+    import nats.aio.client as nats_client  # noqa: PLC0415
+
+    url = os.environ.get(NATS_URL_ENV, DEFAULT_NATS_URL)
+    queue_group = os.environ.get(QUEUE_GROUP_ENV, DEFAULT_QUEUE_GROUP)
+    nc = nats_client.Client()
+    await nc.connect(url, connect_timeout=2)
+    logger.info(
+        "heartbeat_reaper subscribed to %s (queue=%s)",
+        NATS_SUBJECT_WILDCARD,
+        queue_group,
+    )
+
+    async def _on_msg(msg: Any) -> None:
+        parsed = parse_zombie_event(msg.data)
+        if parsed is None:
+            return
+        result = await reap_one(parsed["task_id"], parsed["callsign"])
+        logger.info("reap_one result: %s", result)
+
+    await nc.subscribe(NATS_SUBJECT_WILDCARD, queue=queue_group, cb=_on_msg)
+    # Sleep forever — subscription runs in the background. Never returns
+    # under normal operation; systemd restarts on crash.
+    while True:
+        await asyncio.sleep(3600)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    asyncio.run(run_forever())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dispatcher/heartbeat_watchdog.py
+++ b/src/dispatcher/heartbeat_watchdog.py
@@ -1,0 +1,228 @@
+"""KEI-211 — Dispatcher heartbeat watchdog (task-progress liveness).
+
+Complements ``src.dispatcher.watchdog`` (process-liveness via tmux capture-pane
+hash + container HTTP probe) by watching the *task* layer instead: any task
+that has been ``status='active'`` for longer than the configured stale
+threshold without writing ``heartbeat_at`` is flagged as a zombie and
+published to NATS so ``heartbeat_reaper`` can take cleanup action.
+
+Detection model:
+
+  • Polls ``public.tasks`` every ``poll_interval_s`` seconds (default 60s).
+  • A row is a zombie when ``status='active'`` AND
+    ``heartbeat_at < NOW() - stale_threshold_s`` (default 300s = 5 min).
+    Rows with ``heartbeat_at IS NULL`` are EXCLUDED — KEI-105 documents
+    that null heartbeat is legitimate for legacy / yet-to-tick rows, and
+    failing-open here is required to avoid paging on baseline state.
+  • Each zombie publishes one event on NATS subject
+    ``keiracom.agent.status.{callsign}`` and writes one
+    ``agent_memories`` row with ``source_type='watchdog_observation'``.
+
+Fail-open by design — any leg (DB read, NATS publish, agent_memories log)
+that raises is logged and silently skipped so a single bad task or a
+transient NATS outage doesn't tear down the whole supervisor.
+
+Env contract:
+
+  • ``SUPABASE_DB_URL`` or ``DATABASE_URL`` — psycopg DSN. ``+asyncpg``
+    suffix is stripped (KEI-207 / KEI-54B prior art).
+  • ``NATS_URL`` — NATS server URL (default ``nats://127.0.0.1:4222``).
+  • ``HEARTBEAT_STALE_THRESHOLD_S`` — override default 300 if needed.
+  • ``HEARTBEAT_POLL_INTERVAL_S`` — override default 60 if needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STALE_THRESHOLD_S = 300
+DEFAULT_POLL_INTERVAL_S = 60
+NATS_URL_ENV = "NATS_URL"
+DEFAULT_NATS_URL = "nats://127.0.0.1:4222"
+NATS_SUBJECT_TEMPLATE = "keiracom.agent.status.{callsign}"
+
+# DSN scheme suffix to strip — mirrors spend_tracker / claim_queue_metrics_export.
+_ASYNCPG_DSN_PREFIX = "+asyncpg"
+
+
+@dataclass(frozen=True)
+class ZombieEvent:
+    """Single zombie task detection. Emitted to NATS + logged to agent_memories."""
+
+    task_id: str
+    callsign: str
+    last_heartbeat_at: datetime
+    stale_seconds: int
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL / SUPABASE_DB_URL not set")
+    return dsn.replace(_ASYNCPG_DSN_PREFIX, "").replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def poll_once(threshold_seconds: int = DEFAULT_STALE_THRESHOLD_S) -> list[ZombieEvent]:
+    """Return zombie events from one poll of public.tasks.
+
+    Synchronous; uses psycopg with prepare_threshold=None (Supabase pgbouncer
+    txn-mode compatibility per reference_psycopg_supabase_pgbouncer.md).
+    """
+    import psycopg  # noqa: PLC0415 — optional at import time
+
+    sql = """
+        SELECT id::text, callsign, heartbeat_at,
+               EXTRACT(EPOCH FROM (NOW() - heartbeat_at))::bigint AS stale_seconds
+          FROM public.tasks
+         WHERE status = 'active'
+           AND heartbeat_at IS NOT NULL
+           AND heartbeat_at < NOW() - make_interval(secs => %s)
+    """
+    with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
+        cur.execute(sql, (threshold_seconds,))
+        rows = cur.fetchall()
+    return [
+        ZombieEvent(
+            task_id=r[0],
+            callsign=r[1],
+            last_heartbeat_at=r[2],
+            stale_seconds=int(r[3]),
+        )
+        for r in rows
+    ]
+
+
+async def _nats_publish(url: str, subject: str, payload: bytes) -> None:
+    """Single-message NATS publish. Extracted as a seam for testability —
+    tests patch this helper rather than the inline import.
+    """
+    import nats.aio.client as nats_client  # noqa: PLC0415 — optional dep
+
+    nc = nats_client.Client()
+    await nc.connect(url, connect_timeout=2)
+    try:
+        await nc.publish(subject, payload)
+        await nc.flush()
+    finally:
+        await nc.close()
+
+
+async def publish_zombie(event: ZombieEvent) -> bool:
+    """Publish one zombie event to NATS keiracom.agent.status.<callsign>.
+
+    Returns True on successful publish. False on any failure (NATS down,
+    optional dep missing) — fail-open per module contract.
+    """
+    url = os.environ.get(NATS_URL_ENV, DEFAULT_NATS_URL)
+    subject = NATS_SUBJECT_TEMPLATE.format(callsign=event.callsign)
+    payload = json.dumps(
+        {
+            "type": "zombie_detected",
+            "task_id": event.task_id,
+            "callsign": event.callsign,
+            "last_heartbeat_at": event.last_heartbeat_at.isoformat(),
+            "stale_seconds": event.stale_seconds,
+        }
+    ).encode()
+    try:
+        await _nats_publish(url, subject, payload)
+        return True
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.warning("NATS publish failed for task=%s: %s", event.task_id, exc)
+        return False
+
+
+def log_observation(event: ZombieEvent) -> bool:
+    """Write one watchdog_observation row to public.agent_memories.
+
+    Fail-open — caller continues to next event on any DB error.
+    """
+    try:
+        import psycopg  # noqa: PLC0415
+
+        content = (
+            f"watchdog: task {event.task_id} ({event.callsign}) zombie — "
+            f"heartbeat last seen {event.last_heartbeat_at.isoformat()} "
+            f"({event.stale_seconds}s ago)"
+        )
+        metadata = {
+            "task_id": event.task_id,
+            "stale_seconds": event.stale_seconds,
+            "last_heartbeat_at": event.last_heartbeat_at.isoformat(),
+        }
+        with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO public.agent_memories
+                    (id, callsign, source_type, content, typed_metadata,
+                     created_at, valid_from, state)
+                VALUES (gen_random_uuid(), %s, 'watchdog_observation', %s,
+                        %s::jsonb, NOW(), NOW(), 'confirmed')
+                """,
+                (event.callsign, content, json.dumps(metadata)),
+            )
+            conn.commit()
+        return True
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.warning("agent_memories log failed for task=%s: %s", event.task_id, exc)
+        return False
+
+
+async def run_one_cycle(threshold_seconds: int = DEFAULT_STALE_THRESHOLD_S) -> dict[str, Any]:
+    """One poll → publish → log cycle. Returns counters for caller visibility."""
+    try:
+        zombies = poll_once(threshold_seconds)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("poll_once failed (skipping cycle): %s", exc)
+        return {"polled": 0, "published": 0, "logged": 0, "errors": 1}
+
+    published = 0
+    logged = 0
+    for event in zombies:
+        if await publish_zombie(event):
+            published += 1
+        if log_observation(event):
+            logged += 1
+    return {
+        "polled": len(zombies),
+        "published": published,
+        "logged": logged,
+        "errors": 0,
+    }
+
+
+async def run_forever(
+    poll_interval_s: int = DEFAULT_POLL_INTERVAL_S,
+    threshold_seconds: int = DEFAULT_STALE_THRESHOLD_S,
+) -> None:
+    """Long-running poll loop. Use as a systemd-managed service entrypoint."""
+    logger.info(
+        "heartbeat_watchdog starting — poll=%ds threshold=%ds",
+        poll_interval_s,
+        threshold_seconds,
+    )
+    while True:
+        counters = await run_one_cycle(threshold_seconds)
+        if counters["polled"] > 0:
+            logger.info("heartbeat_watchdog cycle: %s", counters)
+        await asyncio.sleep(poll_interval_s)
+
+
+def main() -> None:
+    """Entry-point for systemd / CLI. Reads thresholds from env, runs forever."""
+    threshold = int(os.environ.get("HEARTBEAT_STALE_THRESHOLD_S", str(DEFAULT_STALE_THRESHOLD_S)))
+    interval = int(os.environ.get("HEARTBEAT_POLL_INTERVAL_S", str(DEFAULT_POLL_INTERVAL_S)))
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    asyncio.run(run_forever(poll_interval_s=interval, threshold_seconds=threshold))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dispatcher/test_heartbeat_reaper.py
+++ b/tests/dispatcher/test_heartbeat_reaper.py
@@ -1,0 +1,210 @@
+"""KEI-211 — tests for src.dispatcher.heartbeat_reaper.
+
+Covers:
+  - thread_count_key() namespace + blank rejection
+  - _mark_task_failed() idempotent UPDATE
+  - _decrement_thread_count() with floor-at-zero behaviour
+  - _log_reap_observation() with reaper_observation source_type
+  - reap_one() all-legs success + partial-failure fail-open
+  - parse_zombie_event() valid + malformed payloads
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.dispatcher import heartbeat_reaper as hr
+
+# ─── thread_count_key ────────────────────────────────────────────────────────
+
+
+def test_thread_count_key_builds_namespaced():
+    assert hr.thread_count_key("scout") == "thr:scout"
+    assert hr.thread_count_key("  atlas  ") == "thr:atlas"
+
+
+def test_thread_count_key_rejects_blank():
+    with pytest.raises(ValueError, match="callsign"):
+        hr.thread_count_key("")
+    with pytest.raises(ValueError, match="callsign"):
+        hr.thread_count_key("   ")
+
+
+# ─── _mark_task_failed ───────────────────────────────────────────────────────
+
+
+def test_mark_task_failed_updates_only_active_rows(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    cur = MagicMock()
+    cur.rowcount = 1
+    cur_ctx = MagicMock()
+    cur_ctx.__enter__ = MagicMock(return_value=cur)
+    cur_ctx.__exit__ = MagicMock(return_value=False)
+    conn = MagicMock()
+    conn.cursor.return_value = cur_ctx
+    conn.commit = MagicMock()
+    conn_ctx = MagicMock()
+    conn_ctx.__enter__ = MagicMock(return_value=conn)
+    conn_ctx.__exit__ = MagicMock(return_value=False)
+    with patch("psycopg.connect", return_value=conn_ctx):
+        assert hr._mark_task_failed("task-uuid-1") is True
+    sql = cur.execute.call_args[0][0]
+    assert "UPDATE public.tasks" in sql
+    assert "status = 'failed'" in sql
+    assert "released_at = NOW()" in sql
+    assert "status = 'active'" in sql  # idempotency guard
+
+
+def test_mark_task_failed_returns_false_when_no_rows_affected(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    cur = MagicMock()
+    cur.rowcount = 0
+    cur_ctx = MagicMock()
+    cur_ctx.__enter__ = MagicMock(return_value=cur)
+    cur_ctx.__exit__ = MagicMock(return_value=False)
+    conn = MagicMock()
+    conn.cursor.return_value = cur_ctx
+    conn.commit = MagicMock()
+    conn_ctx = MagicMock()
+    conn_ctx.__enter__ = MagicMock(return_value=conn)
+    conn_ctx.__exit__ = MagicMock(return_value=False)
+    with patch("psycopg.connect", return_value=conn_ctx):
+        assert hr._mark_task_failed("task-uuid-1") is False
+
+
+def test_mark_task_failed_fails_open_on_db_error(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    with patch("psycopg.connect", side_effect=OSError("db down")):
+        assert hr._mark_task_failed("task-uuid-1") is False
+
+
+# ─── _decrement_thread_count ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_decrement_thread_count_decrs_key():
+    fake = MagicMock()
+    fake.decr = AsyncMock(return_value=3)
+    fake.set = AsyncMock()
+    with patch("src.dispatcher.valkey_pool.get_valkey_client", new=AsyncMock(return_value=fake)):
+        ok = await hr._decrement_thread_count("scout")
+    assert ok is True
+    fake.decr.assert_awaited_once_with("thr:scout")
+    fake.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_decrement_thread_count_floors_at_zero():
+    """If DECR returns negative (transient over-decrement), reset to 0."""
+    fake = MagicMock()
+    fake.decr = AsyncMock(return_value=-1)
+    fake.set = AsyncMock()
+    with patch("src.dispatcher.valkey_pool.get_valkey_client", new=AsyncMock(return_value=fake)):
+        ok = await hr._decrement_thread_count("scout")
+    assert ok is True
+    fake.set.assert_awaited_once_with("thr:scout", 0)
+
+
+@pytest.mark.asyncio
+async def test_decrement_thread_count_fails_open_on_valkey_error():
+    with patch(
+        "src.dispatcher.valkey_pool.get_valkey_client",
+        new=AsyncMock(side_effect=OSError("valkey down")),
+    ):
+        ok = await hr._decrement_thread_count("scout")
+    assert ok is False
+
+
+# ─── _log_reap_observation ───────────────────────────────────────────────────
+
+
+def test_log_reap_observation_uses_correct_source_type(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    cur = MagicMock()
+    cur_ctx = MagicMock()
+    cur_ctx.__enter__ = MagicMock(return_value=cur)
+    cur_ctx.__exit__ = MagicMock(return_value=False)
+    conn = MagicMock()
+    conn.cursor.return_value = cur_ctx
+    conn.commit = MagicMock()
+    conn_ctx = MagicMock()
+    conn_ctx.__enter__ = MagicMock(return_value=conn)
+    conn_ctx.__exit__ = MagicMock(return_value=False)
+    with patch("psycopg.connect", return_value=conn_ctx):
+        ok = hr._log_reap_observation("task-uuid-1", "scout", True)
+    assert ok is True
+    sql = cur.execute.call_args[0][0]
+    assert "reaper_observation" in sql
+    assert "agent_memories" in sql
+
+
+def test_log_reap_observation_fails_open_on_db_error(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    with patch("psycopg.connect", side_effect=OSError("db down")):
+        assert hr._log_reap_observation("t-1", "scout", True) is False
+
+
+# ─── reap_one ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reap_one_all_legs_succeed():
+    with (
+        patch.object(hr, "_mark_task_failed", return_value=True),
+        patch.object(hr, "_decrement_thread_count", new=AsyncMock(return_value=True)),
+        patch.object(hr, "_log_reap_observation", return_value=True),
+    ):
+        result = await hr.reap_one("t-1", "scout")
+    assert result.task_id == "t-1"
+    assert result.callsign == "scout"
+    assert result.task_marked_failed is True
+    assert result.valkey_decremented is True
+    assert result.audit_logged is True
+
+
+@pytest.mark.asyncio
+async def test_reap_one_partial_failure_does_not_abort_other_legs():
+    """If task UPDATE fails, Valkey + audit log must still run."""
+    with (
+        patch.object(hr, "_mark_task_failed", return_value=False),
+        patch.object(hr, "_decrement_thread_count", new=AsyncMock(return_value=True)),
+        patch.object(hr, "_log_reap_observation", return_value=True),
+    ):
+        result = await hr.reap_one("t-1", "scout")
+    assert result.task_marked_failed is False
+    assert result.valkey_decremented is True
+    assert result.audit_logged is True
+
+
+# ─── parse_zombie_event ──────────────────────────────────────────────────────
+
+
+def test_parse_zombie_event_valid_payload():
+    payload = json.dumps(
+        {
+            "type": "zombie_detected",
+            "task_id": "t-1",
+            "callsign": "scout",
+            "last_heartbeat_at": "2026-05-19T12:00:00+00:00",
+            "stale_seconds": 600,
+        }
+    ).encode()
+    parsed = hr.parse_zombie_event(payload)
+    assert parsed == {"task_id": "t-1", "callsign": "scout"}
+
+
+def test_parse_zombie_event_wrong_type_returns_none():
+    payload = json.dumps({"type": "something_else", "task_id": "t-1", "callsign": "scout"}).encode()
+    assert hr.parse_zombie_event(payload) is None
+
+
+def test_parse_zombie_event_missing_fields_returns_none():
+    payload = json.dumps({"type": "zombie_detected", "task_id": "t-1"}).encode()  # no callsign
+    assert hr.parse_zombie_event(payload) is None
+
+
+def test_parse_zombie_event_malformed_json_returns_none():
+    assert hr.parse_zombie_event(b"not-json") is None

--- a/tests/dispatcher/test_heartbeat_watchdog.py
+++ b/tests/dispatcher/test_heartbeat_watchdog.py
@@ -100,7 +100,9 @@ async def test_publish_zombie_emits_correct_subject_and_payload(monkeypatch):
 
     captured: dict[str, object] = {}
 
-    async def _capture(url, subject, payload):
+    async def _capture(
+        url, subject, payload
+    ):  # NOSONAR python:S7503 — _nats_publish is awaited; mock side_effect must return awaitable
         captured["url"] = url
         captured["subject"] = subject
         captured["payload"] = payload

--- a/tests/dispatcher/test_heartbeat_watchdog.py
+++ b/tests/dispatcher/test_heartbeat_watchdog.py
@@ -1,0 +1,213 @@
+"""KEI-211 — tests for src.dispatcher.heartbeat_watchdog.
+
+Covers:
+  - ZombieEvent dataclass + DSN munging (+asyncpg stripping)
+  - poll_once() shape with mocked psycopg
+  - publish_zombie() success + NATS-down fail-open
+  - log_observation() success + DB-down fail-open
+  - run_one_cycle() counters
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.dispatcher import heartbeat_watchdog as hw
+
+# ─── ZombieEvent + DSN helpers ───────────────────────────────────────────────
+
+
+def test_zombie_event_dataclass_frozen():
+    ev = hw.ZombieEvent(
+        task_id="t-1", callsign="scout", last_heartbeat_at=datetime.now(UTC), stale_seconds=600
+    )
+    with pytest.raises(FrozenInstanceError):
+        ev.task_id = "tampered"  # type: ignore[misc]
+
+
+def test_dsn_strips_asyncpg_suffix(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@h/db")
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    assert hw._dsn() == "postgresql://u:p@h/db"
+
+
+def test_dsn_raises_when_unset(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    with pytest.raises(RuntimeError, match="DATABASE_URL"):
+        hw._dsn()
+
+
+# ─── poll_once ───────────────────────────────────────────────────────────────
+
+
+def test_poll_once_maps_rows_to_zombie_events(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    fixed = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+    rows = [
+        ("task-uuid-1", "scout", fixed - timedelta(seconds=600), 600),
+        ("task-uuid-2", "atlas", fixed - timedelta(seconds=900), 900),
+    ]
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    cur_ctx = MagicMock()
+    cur_ctx.__enter__ = MagicMock(return_value=cur)
+    cur_ctx.__exit__ = MagicMock(return_value=False)
+    conn = MagicMock()
+    conn.cursor.return_value = cur_ctx
+    conn_ctx = MagicMock()
+    conn_ctx.__enter__ = MagicMock(return_value=conn)
+    conn_ctx.__exit__ = MagicMock(return_value=False)
+    with patch("psycopg.connect", return_value=conn_ctx):
+        events = hw.poll_once(threshold_seconds=300)
+    assert len(events) == 2
+    assert events[0].task_id == "task-uuid-1"
+    assert events[0].callsign == "scout"
+    assert events[0].stale_seconds == 600
+    assert events[1].callsign == "atlas"
+
+
+def test_poll_once_empty_returns_empty_list(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    cur = MagicMock()
+    cur.fetchall.return_value = []
+    cur_ctx = MagicMock()
+    cur_ctx.__enter__ = MagicMock(return_value=cur)
+    cur_ctx.__exit__ = MagicMock(return_value=False)
+    conn = MagicMock()
+    conn.cursor.return_value = cur_ctx
+    conn_ctx = MagicMock()
+    conn_ctx.__enter__ = MagicMock(return_value=conn)
+    conn_ctx.__exit__ = MagicMock(return_value=False)
+    with patch("psycopg.connect", return_value=conn_ctx):
+        assert hw.poll_once() == []
+
+
+# ─── publish_zombie ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_publish_zombie_emits_correct_subject_and_payload(monkeypatch):
+    monkeypatch.setenv("NATS_URL", "nats://test:4222")
+    fixed = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+    event = hw.ZombieEvent(
+        task_id="t-1", callsign="scout", last_heartbeat_at=fixed, stale_seconds=600
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _capture(url, subject, payload):
+        captured["url"] = url
+        captured["subject"] = subject
+        captured["payload"] = payload
+
+    with patch.object(hw, "_nats_publish", side_effect=_capture):
+        ok = await hw.publish_zombie(event)
+
+    assert ok is True
+    assert captured["url"] == "nats://test:4222"
+    assert captured["subject"] == "keiracom.agent.status.scout"
+    import json as _j
+
+    body = _j.loads(captured["payload"])
+    assert body["type"] == "zombie_detected"
+    assert body["task_id"] == "t-1"
+    assert body["callsign"] == "scout"
+    assert body["stale_seconds"] == 600
+
+
+@pytest.mark.asyncio
+async def test_publish_zombie_fails_open_on_nats_down():
+    event = hw.ZombieEvent(
+        task_id="t-1", callsign="scout", last_heartbeat_at=datetime.now(UTC), stale_seconds=600
+    )
+    with patch.object(hw, "_nats_publish", side_effect=OSError("connection refused")):
+        ok = await hw.publish_zombie(event)
+    assert ok is False
+
+
+# ─── log_observation ─────────────────────────────────────────────────────────
+
+
+def test_log_observation_inserts_with_correct_source_type(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    event = hw.ZombieEvent(
+        task_id="t-1", callsign="scout", last_heartbeat_at=datetime.now(UTC), stale_seconds=600
+    )
+    cur = MagicMock()
+    cur_ctx = MagicMock()
+    cur_ctx.__enter__ = MagicMock(return_value=cur)
+    cur_ctx.__exit__ = MagicMock(return_value=False)
+    conn = MagicMock()
+    conn.cursor.return_value = cur_ctx
+    conn.commit = MagicMock()
+    conn_ctx = MagicMock()
+    conn_ctx.__enter__ = MagicMock(return_value=conn)
+    conn_ctx.__exit__ = MagicMock(return_value=False)
+    with patch("psycopg.connect", return_value=conn_ctx):
+        ok = hw.log_observation(event)
+    assert ok is True
+    sql = cur.execute.call_args[0][0]
+    assert "watchdog_observation" in sql
+    assert "agent_memories" in sql
+
+
+def test_log_observation_fails_open_on_db_error(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    event = hw.ZombieEvent(
+        task_id="t-1", callsign="scout", last_heartbeat_at=datetime.now(UTC), stale_seconds=600
+    )
+    with patch("psycopg.connect", side_effect=OSError("db down")):
+        ok = hw.log_observation(event)
+    assert ok is False
+
+
+# ─── run_one_cycle ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_one_cycle_counters_on_happy_path(monkeypatch):
+    fixed = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+    events = [
+        hw.ZombieEvent(
+            task_id=f"t-{i}", callsign="scout", last_heartbeat_at=fixed, stale_seconds=600
+        )
+        for i in range(3)
+    ]
+    with (
+        patch.object(hw, "poll_once", return_value=events),
+        patch.object(hw, "publish_zombie", new=AsyncMock(return_value=True)),
+        patch.object(hw, "log_observation", return_value=True),
+    ):
+        counters = await hw.run_one_cycle()
+    assert counters == {"polled": 3, "published": 3, "logged": 3, "errors": 0}
+
+
+@pytest.mark.asyncio
+async def test_run_one_cycle_fails_open_when_poll_raises():
+    with patch.object(hw, "poll_once", side_effect=OSError("db down")):
+        counters = await hw.run_one_cycle()
+    assert counters == {"polled": 0, "published": 0, "logged": 0, "errors": 1}
+
+
+@pytest.mark.asyncio
+async def test_run_one_cycle_partial_publish_failure_continues():
+    fixed = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+    events = [
+        hw.ZombieEvent(task_id="t-1", callsign="scout", last_heartbeat_at=fixed, stale_seconds=600),
+        hw.ZombieEvent(task_id="t-2", callsign="atlas", last_heartbeat_at=fixed, stale_seconds=900),
+    ]
+    pub_results = iter([True, False])
+    with (
+        patch.object(hw, "poll_once", return_value=events),
+        patch.object(hw, "publish_zombie", new=AsyncMock(side_effect=lambda _e: next(pub_results))),
+        patch.object(hw, "log_observation", return_value=True),
+    ):
+        counters = await hw.run_one_cycle()
+    assert counters["polled"] == 2
+    assert counters["published"] == 1
+    assert counters["logged"] == 2


### PR DESCRIPTION
## Summary

Lands the **task-heartbeat layer** that `Agency_OS-ul3slp` (KEI-211) specifies. Complements Nova's PR #1022 (`src/dispatcher/watchdog.py` + `reaper.py`) which ships the **process-liveness layer** (tmux capture-pane hash + container HTTP probe). These two pairs are complementary, not duplicate.

| Layer | Watches | Module | Author |
|---|---|---|---|
| Process-liveness | tmux pane signature + container /health | `watchdog.py` + `reaper.py` | Nova PR #1022 |
| **Task-progress** | **`public.tasks.heartbeat_at`** | **`heartbeat_watchdog.py` + `heartbeat_reaper.py`** | **Scout this PR** |

## Why both layers

ul3slp's bd description (verbatim) calls for: polls `public.tasks.heartbeat_at` every 60s, 5-min stale → publish NATS `keiracom.agent.status.{callsign}`, reaper marks `status='failed'` + decrements Valkey thread count, logs to `agent_memories`. Nova's PR shipped a DIFFERENT scope (tmux/container lifecycle). Surfaced via ul3slp NOTES + scout inbox to Elliot earlier this session — building the task-heartbeat half here on the working assumption that both are needed (a process can be alive but its task can be stalled).

## What this PR adds

### `src/dispatcher/heartbeat_watchdog.py` (228 LOC)
- `poll_once(threshold_seconds=300)` — synchronous SELECT against `public.tasks` filtered by `status='active' AND heartbeat_at < NOW() - interval`. Excludes `heartbeat_at IS NULL` rows per KEI-105 (legitimate baseline).
- `publish_zombie(event)` — NATS publish via `_nats_publish()` seam (extracted helper for testability).
- `log_observation(event)` — inserts one `source_type='watchdog_observation'` row into `public.agent_memories`.
- `run_one_cycle()` / `run_forever()` — driver loop with counters.
- Fail-open on every leg.
- psycopg DSN handling mirrors `claim_queue_metrics_export.py` (`prepare_threshold=None`, `+asyncpg` strip per `reference_psycopg_supabase_pgbouncer.md`).

### `src/dispatcher/heartbeat_reaper.py` (222 LOC)
- `reap_one(task_id, callsign)` — three independent legs (each fail-open):
  1. `UPDATE public.tasks SET status='failed', released_at=NOW() WHERE id=$1 AND status='active'` — idempotent.
  2. `DECR thr:<callsign>` on Valkey, floor at 0.
  3. `INSERT INTO public.agent_memories ... source_type='reaper_observation'` for audit trail.
- `parse_zombie_event(payload)` — payload validation + shape check.
- `run_forever()` — NATS subscribe with queue-group support for multi-instance load-shed.
- `thread_count_key(callsign)` — `thr:<callsign>` namespace per KEI-117A valkey_pool contract; rejects blank callsign.

### Tests (28 total, all passing)
- `tests/dispatcher/test_heartbeat_watchdog.py` — 14 tests covering ZombieEvent dataclass freeze, DSN munging, poll_once row mapping, publish_zombie success + NATS-down fail-open, log_observation success + DB-down fail-open, run_one_cycle counters (happy path + poll failure + partial publish failure).
- `tests/dispatcher/test_heartbeat_reaper.py` — 14 tests covering thread_count_key namespace + blank rejection, _mark_task_failed idempotency + no-rows-affected + DB fail-open, _decrement_thread_count + floor-at-zero + Valkey fail-open, _log_reap_observation source_type assertion, reap_one all-legs success + partial-failure isolation, parse_zombie_event valid + 3 negative cases.

## Test plan

```
$ pytest tests/dispatcher/test_heartbeat_watchdog.py tests/dispatcher/test_heartbeat_reaper.py -q
............................                                             [100%]
28 passed in 0.25s

$ ruff check src/dispatcher/heartbeat_*.py tests/dispatcher/test_heartbeat_*.py
All checks passed!

$ ruff format --check src/dispatcher/heartbeat_*.py tests/dispatcher/test_heartbeat_*.py
4 files already formatted
```

## Related

- bd: `Agency_OS-ul3slp` (KEI-211)
- Complements PR #1022 (Nova — lifecycle layer)
- Migration prerequisite: KEI-105 `heartbeat_at` column (already on main)
- Discovery this session: 6 orphan dispatcher bds closed with verbatim PR evidence (auth_minter, interceptor_proxy, spend_tracker, strangler fig, env-validation hook, and previously watchdog/reaper). ul3slp was the only one with genuine open work (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)