### PR TITLE
[ATLAS] feat(kei227): bd↔Linear sync periodic timer — close stale-warning drift loop

### DIFF
--- a/scripts/bd_linear_sync_periodic.sh
+++ b/scripts/bd_linear_sync_periodic.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# bd_linear_sync_periodic.sh — Agency_OS-iosu.
+#
+# Cron-driven wrapper around `bd linear sync --pull --threshold 5m`. Closes the
+# "Linear data is Xh stale" warning loop that long-running agent sessions hit
+# because the session-start sync drifts during multi-hour work.
+#
+# Fail-open: a single sync miss should never crash the timer. systemd retries
+# on the next tick. Exit 0 always.
+
+set -u
+
+LOG_FILE="${BD_LINEAR_SYNC_LOG:-/home/elliotbot/clawd/logs/bd-linear-sync.log}"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+if ! command -v bd >/dev/null 2>&1; then
+    echo "$(date -u +%FT%TZ) bd_linear_sync_periodic: bd CLI not on PATH — skipping" >>"$LOG_FILE"
+    exit 0
+fi
+
+echo "$(date -u +%FT%TZ) bd_linear_sync_periodic: starting" >>"$LOG_FILE"
+bd linear sync --pull --threshold 5m >>"$LOG_FILE" 2>&1 || true
+echo "$(date -u +%FT%TZ) bd_linear_sync_periodic: done (exit=$?)" >>"$LOG_FILE"
+exit 0

--- a/scripts/install_bd_linear_sync.sh
+++ b/scripts/install_bd_linear_sync.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# install_bd_linear_sync.sh — Agency_OS-iosu systemd-user installer.
+#
+# Installs:
+#   ~/.config/systemd/user/bd_linear_sync.service
+#   ~/.config/systemd/user/bd_linear_sync.timer
+#
+# Then daemon-reloads, enables, and starts the timer.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SYSTEMD_SRC="${REPO_ROOT}/systemd"
+SYSTEMD_DST="${HOME}/.config/systemd/user"
+
+mkdir -p "${SYSTEMD_DST}"
+cp -v "${SYSTEMD_SRC}/bd_linear_sync.service" "${SYSTEMD_DST}/"
+cp -v "${SYSTEMD_SRC}/bd_linear_sync.timer"   "${SYSTEMD_DST}/"
+
+systemctl --user daemon-reload
+systemctl --user enable --now bd_linear_sync.timer
+
+echo
+echo "Installed. Verify:"
+echo "  systemctl --user status bd_linear_sync.timer"
+echo "  systemctl --user list-timers --all | grep bd_linear_sync"
+echo "  journalctl --user -u bd_linear_sync.service -n 50 --no-pager"
+echo "  tail -n 20 ~/clawd/logs/bd-linear-sync.log"

--- a/systemd/bd_linear_sync.service
+++ b/systemd/bd_linear_sync.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Agency_OS-iosu — periodic bd↔Linear sync pull
+Documentation=https://linear.app/keiracom/issue/KEI-227
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/agency-os/.env
+WorkingDirectory=%h/clawd/Agency_OS
+ExecStart=/bin/bash %h/clawd/Agency_OS/scripts/bd_linear_sync_periodic.sh
+Nice=10
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=120
+
+[Install]
+WantedBy=default.target

--- a/systemd/bd_linear_sync.timer
+++ b/systemd/bd_linear_sync.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Agency_OS-iosu — bd↔Linear sync every 10 minutes
+Documentation=https://linear.app/keiracom/issue/KEI-227
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+RandomizedDelaySec=60
+Persistent=true
+Unit=bd_linear_sync.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Adds a user-systemd timer that runs `bd linear sync --pull --threshold 5m` every 10 min (with 60s jitter) so multi-hour agent sessions don't drift past the threshold and trip the *"Linear data is Xh stale"* warning on every subsequent `bd ready` / `bd list`.

Pattern matches existing `agency-os-*.timer` units already in `~/.config/systemd/user/`. Distinct from `completion-sync-worker.service` (KEI-74 Supabase↔Linear) and `linear-state-indexer.service` (KEI-85 Linear→Weaviate) — neither runs `bd linear sync --pull`.

## Files (83 LOC, 4 new)

| File | LOC | Purpose |
|---|---|---|
| `scripts/bd_linear_sync_periodic.sh` | 24 | Fail-open wrapper: `bd linear sync --pull --threshold 5m`; exit 0 always; logs to `~/clawd/logs/bd-linear-sync.log` |
| `scripts/install_bd_linear_sync.sh` | 28 | Copies units to `~/.config/systemd/user/`, `daemon-reload`, `enable --now` |
| `systemd/bd_linear_sync.service` | 18 | `Type=oneshot`, `EnvironmentFile=%h/.config/agency-os/.env`, `WorkingDirectory=%h/clawd/Agency_OS`, 120s timeout |
| `systemd/bd_linear_sync.timer` | 13 | `OnBootSec=2min`, `OnUnitActiveSec=10min`, `RandomizedDelaySec=60`, `Persistent=true` |

## Origin

Drift audit 2026-05-18. Atlas saw stale claims on `96ou`, `7xsk5j`, `rt9zer` during the audit session. `_session_start.md` tells agents to sync at session-start but multi-hour sessions drift mid-session — every `bd ready`/`bd list` then warns. Owner Aiden, assigned atlas.

## Test plan

- [x] `bash -n scripts/bd_linear_sync_periodic.sh` — OK
- [x] `bash -n scripts/install_bd_linear_sync.sh` — OK
- [ ] **Post-merge** — on Elliot's main worktree box, run `scripts/install_bd_linear_sync.sh`
- [ ] **Post-merge** — `systemctl --user list-timers --all | grep bd_linear_sync` shows active timer
- [ ] **Post-merge** — `journalctl --user -u bd_linear_sync.service -n 20 --no-pager` shows successful pulls
- [ ] **Post-merge** — `bd ready` no longer shows >15m stale warning in normal operation

## Acceptance (per bd issue Agency_OS-iosu)

- [x] Timer wrapper + units + installer present
- [x] Fail-open on `bd` error (`exit 0` in script + `Type=oneshot` ignores non-zero)
- [ ] Timer active on each agent box (post-merge: run install script)
- [ ] `bd ready` no longer shows >15m stale in normal operation (post-merge observation)

## Related

- Closes `Agency_OS-iosu` (KEI-227)
- Pattern source: `/home/elliotbot/.config/systemd/user/agency-os-*.timer`
- _Not_ duplicate of: `completion-sync-worker.service` (KEI-74), `linear-state-indexer.service` (KEI-85)

🤖 Generated with [Claude Code](https://claude.com/claude-code)