### PR TITLE
[ATLAS] feat(kei227): K1 — public.tasks.bd_id column + backfill (sync foundation)

### DIFF
--- a/migrations/20260519_kei227_tasks_bd_id.sql
+++ b/migrations/20260519_kei227_tasks_bd_id.sql
@@ -1,0 +1,31 @@
+-- KEI-227 (Linear) / Agency_OS-8c67 (bd) — K1 ID canonicalisation foundation.
+--
+-- Adds bd_id column to public.tasks so the canonical Linear KEI-N (tasks.id)
+-- can be paired with the bd-Dolt Agency_OS-xxx short-code. Subsequent K2
+-- (sync_events) joins on either key without an FK violation; tasks_cli.py
+-- writers can match bd_id when invoked from `bd update --claim <Agency_OS-xxx>`
+-- against rows keyed on KEI-N from reconcile_linear_supabase.py.
+--
+-- Backfill happens via scripts/backfill_tasks_bd_id.py (dry-run by default,
+-- --apply to mutate). Not run in this migration so the column add is reversible.
+
+ALTER TABLE public.tasks
+    ADD COLUMN IF NOT EXISTS bd_id TEXT;
+
+-- Unique-when-present: NULL allowed (rows from Linear that haven't been
+-- paired with a bd issue yet), but each Agency_OS-xxx maps to at most one
+-- Linear KEI-N row.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tasks_bd_id
+    ON public.tasks (bd_id)
+    WHERE bd_id IS NOT NULL;
+
+-- Lookup index for the `id = %s OR bd_id = %s` pattern in tasks_cli.py.
+CREATE INDEX IF NOT EXISTS idx_tasks_bd_id
+    ON public.tasks (bd_id)
+    WHERE bd_id IS NOT NULL;
+
+COMMENT ON COLUMN public.tasks.bd_id IS
+    'KEI-227 — bd-Dolt short-code (Agency_OS-xxx) paired with the canonical '
+    'Linear identifier in tasks.id. NULL means no bd-Dolt issue paired yet. '
+    'Populated by scripts/backfill_tasks_bd_id.py and by tasks_cli.py writers '
+    'when bd ops touch a Linear-keyed row.';

--- a/scripts/backfill_tasks_bd_id.py
+++ b/scripts/backfill_tasks_bd_id.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""backfill_tasks_bd_id.py — KEI-227 K1 backfill.
+
+Walks public.tasks rows with linear_url IS NOT NULL AND bd_id IS NULL,
+matches them against bd-Dolt issues by external_ref URL, and writes the
+paired Agency_OS-xxx into the new bd_id column.
+
+Usage:
+    python3 scripts/backfill_tasks_bd_id.py            # dry-run
+    python3 scripts/backfill_tasks_bd_id.py --apply    # mutate Postgres
+
+Idempotent. Re-running on already-paired rows is a no-op (only filters
+WHERE bd_id IS NULL). Safe to wire into a periodic timer post-merge.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from typing import Any
+
+logger = logging.getLogger("backfill_tasks_bd_id")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+_BD_BIN_DEFAULT = os.path.expanduser("~/.local/bin/bd")
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL or SUPABASE_DB_URL must be set")
+    return dsn.replace("+asyncpg", "")
+
+
+def _bd_bin() -> str:
+    return os.environ.get("AGENCY_OS_BD_BIN", _BD_BIN_DEFAULT)
+
+
+def _bd_list_json() -> list[dict[str, Any]]:
+    """Return all bd issues (open + in_progress + closed) as a list of dicts.
+
+    Default `bd list` filters to open/in_progress. The --all flag widens the
+    set so closed bd issues with external_ref still pair against Postgres
+    rows whose status='done' (which is most of them).
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603 — controlled args, no shell
+            [_bd_bin(), "list", "--all", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.error("bd list --json failed: %s", exc)
+        return []
+    if proc.returncode != 0:
+        logger.error("bd list --json exit %d: %s", proc.returncode, proc.stderr[:200])
+        return []
+    try:
+        return json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        logger.error("bd list --json parse: %s", exc)
+        return []
+
+
+def _build_url_to_bd_id(issues: list[dict[str, Any]]) -> dict[str, list[str]]:
+    """Map external_ref URL -> list of bd IDs. List form catches dual-claims."""
+    url_to_ids: dict[str, list[str]] = {}
+    for issue in issues:
+        ref = issue.get("external_ref") or (issue.get("metadata") or {}).get("external_ref")
+        if not ref:
+            continue
+        url_to_ids.setdefault(ref, []).append(issue.get("id", ""))
+    return url_to_ids
+
+
+def _candidate_url_variants(url: str) -> list[str]:
+    """Linear URLs vary by trailing slug — strip suffix to widen the match.
+
+    Examples:
+      https://linear.app/keiracom/issue/KEI-227
+      https://linear.app/keiracom/issue/KEI-227/atlas-k1-id-canonicalisation-...
+    Both should pair with the same bd issue.
+    """
+    if not url:
+        return []
+    out = [url, url.rstrip("/")]
+    parts = url.split("/issue/", 1)
+    if len(parts) == 2:
+        kei_part = parts[1].split("/", 1)[0]
+        out.append(f"{parts[0]}/issue/{kei_part}")
+    return list(dict.fromkeys(out))
+
+
+def plan_backfill(conn: Any, url_to_ids: dict[str, list[str]]) -> dict[str, Any]:
+    """Return {matched: [(task_id, bd_id, linear_url)], ambiguous: [...], unmatched: [...]}.
+
+    Two ambiguity shapes:
+      1. One Linear URL maps to multiple bd issues (dual-mirror) — bd-side.
+      2. URL-variant stripping causes two Postgres rows to claim the same bd_id
+         (e.g., KEI-54 and KEI-54B both stripping to /issue/KEI-54). Resolved
+         here by passing through unique-bd_id detection: rows beyond the first
+         claimant of a bd_id are demoted to ambiguous so the UNIQUE constraint
+         never fires at apply time.
+    """
+    result: dict[str, Any] = {"matched": [], "ambiguous": [], "unmatched": []}
+    bd_id_taken: dict[str, str] = {}  # bd_id -> first task_id that claimed it
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, linear_url FROM public.tasks "
+            "WHERE linear_url IS NOT NULL AND bd_id IS NULL "
+            "ORDER BY id"
+        )
+        rows = cur.fetchall()
+    for row in rows:
+        task_id, linear_url = row[0], row[1]
+        bd_ids: list[str] = []
+        for variant in _candidate_url_variants(linear_url):
+            bd_ids = url_to_ids.get(variant, [])
+            if bd_ids:
+                break
+        if not bd_ids:
+            result["unmatched"].append((task_id, linear_url))
+        elif len(bd_ids) > 1:
+            result["ambiguous"].append((task_id, bd_ids, linear_url))
+        else:
+            bd_id = bd_ids[0]
+            prior_claimant = bd_id_taken.get(bd_id)
+            if prior_claimant is not None:
+                result["ambiguous"].append(
+                    (
+                        task_id,
+                        [bd_id],
+                        f"{linear_url} (bd_id {bd_id} already claimed by {prior_claimant})",
+                    )
+                )
+            else:
+                bd_id_taken[bd_id] = task_id
+                result["matched"].append((task_id, bd_id, linear_url))
+    return result
+
+
+def apply_backfill(conn: Any, matched: list[tuple[str, str, str]]) -> int:
+    """Write bd_id for matched rows. Returns count written."""
+    written = 0
+    with conn.cursor() as cur:
+        for task_id, bd_id, _url in matched:
+            cur.execute(
+                "UPDATE public.tasks SET bd_id = %s, updated_at = NOW() "
+                "WHERE id = %s AND bd_id IS NULL",
+                (bd_id, task_id),
+            )
+            written += cur.rowcount
+    conn.commit()
+    return written
+
+
+def _print_summary(plan: dict[str, Any], applied: int | None) -> None:
+    print(f"matched:    {len(plan['matched'])}")
+    print(f"ambiguous:  {len(plan['ambiguous'])}")
+    print(f"unmatched:  {len(plan['unmatched'])}")
+    if applied is not None:
+        print(f"applied:    {applied}")
+    if plan["ambiguous"]:
+        print("\nAmbiguous (Linear URL maps to multiple bd issues — manual triage):")
+        for task_id, bd_ids, url in plan["ambiguous"][:10]:
+            print(f"  {task_id} → {bd_ids} ({url})")
+    if plan["unmatched"]:
+        print("\nUnmatched sample (Linear URL has no bd issue with that external_ref):")
+        for task_id, url in plan["unmatched"][:10]:
+            print(f"  {task_id} → {url}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Mutate Postgres (default dry-run)")
+    args = parser.parse_args(argv)
+
+    try:
+        import psycopg
+    except ImportError:
+        logger.error("psycopg not installed; pip install psycopg")
+        return 2
+
+    issues = _bd_list_json()
+    if not issues:
+        logger.warning("bd returned 0 issues — backfill aborted")
+        return 1
+    logger.info("loaded %d bd issues", len(issues))
+    url_to_ids = _build_url_to_bd_id(issues)
+    logger.info("indexed %d unique external_ref URLs", len(url_to_ids))
+
+    with psycopg.connect(_dsn(), prepare_threshold=None) as conn:
+        plan = plan_backfill(conn, url_to_ids)
+        applied: int | None = None
+        if args.apply:
+            applied = apply_backfill(conn, plan["matched"])
+            logger.info("applied %d rows", applied)
+    _print_summary(plan, applied)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -503,7 +503,12 @@ def cmd_claim(args: argparse.Namespace) -> int:
                 # not claim …' (which is indistinguishable from a race loss).
                 # Fail-open on parse errors so legacy rows / fixtures without
                 # a numeric phase fall through to the UPDATE's own filter.
-                cur.execute("SELECT phase FROM public.tasks WHERE id = %s", (args.id,))
+                # KEI-227: id OR bd_id — caller may pass either the canonical
+                # Linear KEI-N or the bd-Dolt Agency_OS-xxx short-code.
+                cur.execute(
+                    "SELECT phase FROM public.tasks WHERE id = %s OR bd_id = %s",
+                    (args.id, args.id),
+                )
                 _phase_row = cur.fetchone()
                 _task_phase: float | None = None
                 if _phase_row is not None:
@@ -525,12 +530,12 @@ def cmd_claim(args: argparse.Namespace) -> int:
                     UPDATE public.tasks
                        SET status = 'active', claimed_by = %s,
                            claimed_at = NOW(), updated_at = NOW()
-                     WHERE id = %s
+                     WHERE (id = %s OR bd_id = %s)
                        AND status = 'available'
                        AND (claimed_by IS NULL OR claimed_by = %s)
                      RETURNING id, title, priority, status, claimed_by, linear_url, tags
                     """,
-                    (cs, args.id, cs),
+                    (cs, args.id, args.id, cs),
                 )
             else:
                 # KEI-86 — also filter the next-available SELECT by phase.
@@ -700,11 +705,11 @@ def _execute_atomic_complete(
                claimed_by = NULL,
                claimed_at = NULL,
                updated_at = NOW()
-         WHERE id = %s
+         WHERE (id = %s OR bd_id = %s)
            AND (claimed_by = %s OR %s = 'force')
          RETURNING id, title, status
         """,
-        (task_id, callsign, force_mode),
+        (task_id, task_id, callsign, force_mode),
     )
     return cur.fetchone()
 
@@ -741,11 +746,11 @@ def cmd_heartbeat(args: argparse.Namespace) -> int:
                 UPDATE public.tasks
                    SET heartbeat_at = NOW(),
                        updated_at = NOW()
-                 WHERE id = %s
+                 WHERE (id = %s OR bd_id = %s)
                    AND claimed_by = %s
                  RETURNING id, claimed_by, heartbeat_at
                 """,
-                (args.id, cs),
+                (args.id, args.id, cs),
             )
             row = cur.fetchone()
             conn.commit()

--- a/tests/scripts/test_backfill_tasks_bd_id.py
+++ b/tests/scripts/test_backfill_tasks_bd_id.py
@@ -1,0 +1,164 @@
+"""tests for scripts/backfill_tasks_bd_id.py — KEI-227 K1 backfill.
+
+Covers:
+  - URL → bd_id index construction (with + without external_ref)
+  - plan_backfill: matched / ambiguous (multi-bd) / ambiguous (URL-strip
+    collision e.g. KEI-54 vs KEI-54B) / unmatched
+  - URL variant generation (full slug, no slug, trailing-slash strip)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "backfill_tasks_bd_id.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("backfill_tasks_bd_id", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["backfill_tasks_bd_id"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.executed.append((sql, params or ()))
+        if sql.lstrip().upper().startswith("UPDATE"):
+            self.rowcount = 1
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._cur = _FakeCursor(rows)
+        self.committed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cur
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+def test_url_variants_strip_slug(mod) -> None:
+    url = "https://linear.app/keiracom/issue/KEI-227/atlas-k1-id-canonicalisation-foo"
+    variants = mod._candidate_url_variants(url)
+    assert url in variants
+    assert "https://linear.app/keiracom/issue/KEI-227" in variants
+
+
+def test_url_variants_handle_trailing_slash(mod) -> None:
+    url = "https://linear.app/keiracom/issue/KEI-227/"
+    variants = mod._candidate_url_variants(url)
+    assert "https://linear.app/keiracom/issue/KEI-227" in variants
+
+
+def test_url_variants_empty_input(mod) -> None:
+    assert mod._candidate_url_variants("") == []
+
+
+def test_build_url_index_skips_missing_external_ref(mod) -> None:
+    issues = [
+        {"id": "Agency_OS-aaa", "external_ref": "https://linear.app/keiracom/issue/KEI-1"},
+        {"id": "Agency_OS-bbb"},  # no external_ref
+        {"id": "Agency_OS-ccc", "external_ref": None},
+        {
+            "id": "Agency_OS-ddd",
+            "metadata": {"external_ref": "https://linear.app/keiracom/issue/KEI-2"},
+        },
+    ]
+    index = mod._build_url_to_bd_id(issues)
+    assert "https://linear.app/keiracom/issue/KEI-1" in index
+    assert "https://linear.app/keiracom/issue/KEI-2" in index
+    assert index["https://linear.app/keiracom/issue/KEI-1"] == ["Agency_OS-aaa"]
+    assert "Agency_OS-bbb" not in [b for v in index.values() for b in v]
+
+
+def test_build_url_index_groups_duplicates(mod) -> None:
+    issues = [
+        {"id": "Agency_OS-aaa", "external_ref": "https://linear.app/keiracom/issue/KEI-18"},
+        {"id": "Agency_OS-bbb", "external_ref": "https://linear.app/keiracom/issue/KEI-18"},
+    ]
+    index = mod._build_url_to_bd_id(issues)
+    assert sorted(index["https://linear.app/keiracom/issue/KEI-18"]) == [
+        "Agency_OS-aaa",
+        "Agency_OS-bbb",
+    ]
+
+
+def test_plan_matched_simple_pairing(mod) -> None:
+    rows = [("KEI-227", "https://linear.app/keiracom/issue/KEI-227/atlas-k1-foo")]
+    url_to_ids = {"https://linear.app/keiracom/issue/KEI-227": ["Agency_OS-8c67"]}
+    plan = mod.plan_backfill(_FakeConn(rows), url_to_ids)
+    assert plan["matched"] == [("KEI-227", "Agency_OS-8c67", rows[0][1])]
+    assert plan["ambiguous"] == []
+    assert plan["unmatched"] == []
+
+
+def test_plan_ambiguous_bd_side_multi(mod) -> None:
+    rows = [("KEI-18", "https://linear.app/keiracom/issue/KEI-18")]
+    url_to_ids = {
+        "https://linear.app/keiracom/issue/KEI-18": ["Agency_OS-58f", "Agency_OS-jny867"],
+    }
+    plan = mod.plan_backfill(_FakeConn(rows), url_to_ids)
+    assert plan["matched"] == []
+    assert plan["ambiguous"][0][0] == "KEI-18"
+    assert sorted(plan["ambiguous"][0][1]) == ["Agency_OS-58f", "Agency_OS-jny867"]
+
+
+def test_plan_ambiguous_url_strip_collision(mod) -> None:
+    """KEI-54 and KEI-54B both strip-match to /issue/KEI-54 → second is ambiguous."""
+    rows = [
+        ("KEI-54", "https://linear.app/keiracom/issue/KEI-54"),
+        ("KEI-54B", "https://linear.app/keiracom/issue/KEI-54/kei-52-tool-call-log-export"),
+    ]
+    url_to_ids = {"https://linear.app/keiracom/issue/KEI-54": ["Agency_OS-r1krve"]}
+    plan = mod.plan_backfill(_FakeConn(rows), url_to_ids)
+    assert plan["matched"] == [("KEI-54", "Agency_OS-r1krve", rows[0][1])]
+    assert plan["ambiguous"][0][0] == "KEI-54B"
+    assert "already claimed by KEI-54" in plan["ambiguous"][0][2]
+
+
+def test_plan_unmatched_no_bd_pair(mod) -> None:
+    rows = [("KEI-999", "https://linear.app/keiracom/issue/KEI-999")]
+    url_to_ids: dict[str, list[str]] = {}
+    plan = mod.plan_backfill(_FakeConn(rows), url_to_ids)
+    assert plan["unmatched"] == [("KEI-999", rows[0][1])]
+
+
+def test_apply_writes_each_match(mod) -> None:
+    matched = [
+        ("KEI-227", "Agency_OS-8c67", "https://linear.app/keiracom/issue/KEI-227"),
+        ("KEI-228", "Agency_OS-tfsl", "https://linear.app/keiracom/issue/KEI-228"),
+    ]
+    conn = _FakeConn(rows=[])
+    written = mod.apply_backfill(conn, matched)
+    assert written == 2
+    assert conn.committed is True
+    updates = [e for e in conn._cur.executed if "UPDATE" in e[0]]
+    assert len(updates) == 2
+    # Verify the params order: (bd_id, task_id)
+    assert updates[0][1][0] == "Agency_OS-8c67"
+    assert updates[0][1][1] == "KEI-227"

--- a/tests/scripts/test_tasks_cli.py
+++ b/tests/scripts/test_tasks_cli.py
@@ -275,7 +275,8 @@ def test_claim_targeted_id(mod, patch_connect, capsys, monkeypatch) -> None:
     assert out["id"] == "KEI-39"
     assert out["claimed_by"] == "scout"
     update = _find_executed(cur, lambda s: "UPDATE public.tasks" in s and "claimed_by" in s)
-    assert update is not None and update[1] == ("scout", "KEI-39", "scout")
+    # KEI-227: WHERE (id = %s OR bd_id = %s) — args.id passed twice for the OR clause.
+    assert update is not None and update[1] == ("scout", "KEI-39", "KEI-39", "scout")
 
 
 def test_claim_next_available_uses_skip_locked(mod, patch_connect, monkeypatch) -> None:
@@ -599,7 +600,8 @@ def test_complete_force_mode_passes_force_sentinel(mod, patch_connect, monkeypat
     patch_connect(cur)
     mod.main(["complete", "KEI-39", "--force-mode", "force"])
     update = _find_executed(cur, lambda s: "UPDATE public.tasks" in s and "status = 'done'" in s)
-    assert update is not None and update[1] == ("KEI-39", "scout", "force")
+    # KEI-227: WHERE (id = %s OR bd_id = %s) — task_id passed twice for the OR clause.
+    assert update is not None and update[1] == ("KEI-39", "KEI-39", "scout", "force")
 
 
 # ─── KEI-105: heartbeat command ─────────────────────────────────────────────
@@ -619,7 +621,8 @@ def test_heartbeat_updates_when_claimed_by_caller(mod, patch_connect, capsys, mo
         cur, lambda s: "heartbeat_at = NOW()" in s and "UPDATE public.tasks" in s
     )
     assert update is not None
-    assert update[1] == ("KEI-39", "scout")
+    # KEI-227: WHERE (id = %s OR bd_id = %s) — args.id passed twice for the OR clause.
+    assert update[1] == ("KEI-39", "KEI-39", "scout")
 
 
 def test_heartbeat_returns_null_when_not_claimed_by_caller(


### PR DESCRIPTION
## Summary

K1 of 4 — foundation for bi-directional Linear↔Postgres↔bd sync.

Adds `public.tasks.bd_id TEXT` (+ unique-when-present index) to pair the canonical Linear `KEI-N` with the bd-Dolt `Agency_OS-xxx` short-code. Updates `tasks_cli.py` writers to look up by either key. Ships a one-shot backfill that paired **149 of 152 existing Linear-keyed rows** with their bd siblings.

## Why

`bd update --claim Agency_OS-50hd4r` against a Linear-imported Postgres row returned "could not claim" — no join key between bd-Dolt's `Agency_OS-*` and Postgres' `KEI-*`. Caught live in atlas session 2026-05-19 as a `psycopg.errors.ForeignKeyViolation` on `bd close --evidence`. Diagnosed as root cause #1 of 5 in the drift between bd (147 active) vs Postgres (3 active) — 144-row gap.

## Changes

| File | Purpose |
|---|---|
| `migrations/20260519_kei227_tasks_bd_id.sql` | Adds `bd_id` column + 2 indexes (applied to project `jatzvazlbusedwsnqxzr`) |
| `scripts/backfill_tasks_bd_id.py` | One-shot URL-keyed pairing of `tasks.linear_url` ↔ `bd external_ref` |
| `scripts/tasks_cli.py` | 4 writer WHERE clauses now match `(id = %s OR bd_id = %s)` |
| `tests/scripts/test_backfill_tasks_bd_id.py` | 10 new unit tests (ambiguity detection, URL variants, apply) |
| `tests/scripts/test_tasks_cli.py` | 3 param-tuple assertions updated for new OR-clause shape |

## Verification

**Migration:**
```
$ mcp supabase apply_migration kei227_tasks_bd_id
{"success":true}
```

**Backfill (dry-run then apply):**
```
matched:    149
ambiguous:  3
unmatched:  0
applied:    149
```

**Ambiguous (manual triage — NOT blocking K2):**
- `KEI-18` → 2 bd siblings share `external_ref` (`Agency_OS-58f`, `jny867`)
- `KEI-45` → 2 bd siblings share `external_ref` (`Agency_OS-999`, `q9b`)
- `KEI-54B` → URL-strip collision with `KEI-54` (both point to `/issue/KEI-54`)

**Tests:**
```
$ pytest tests/scripts/test_tasks_cli.py tests/scripts/test_backfill_tasks_bd_id.py
======================== 48 passed, 3 xfailed in 11.27s ========================
```

**Lint:**
```
$ ruff check scripts/backfill_tasks_bd_id.py scripts/tasks_cli.py tests/scripts/test_backfill_tasks_bd_id.py tests/scripts/test_tasks_cli.py
All checks passed!
$ ruff format --check ...
4 files already formatted
```

## Test plan

- [x] Migration applied to live Supabase project (verbatim above)
- [x] Backfill dry-run summary (verbatim above)
- [x] Backfill `--apply` 149 rows (verbatim above)
- [x] `tasks_cli.py` writers updated; existing tests pass (verbatim above)
- [x] New `test_backfill_tasks_bd_id.py` — 10 tests covering matching + ambiguity
- [x] `ruff check && ruff format --check` clean (verbatim above)
- [ ] **Dual approval (Elliot + Aiden)** before merge

## Related

- Closes `Agency_OS-8c67` (bd) / Linear KEI-227
- **Blocks** K2 (`Agency_OS-tfsl` / KEI-228 — `sync_events` table)
- **Blocks** K3 (`Agency_OS-w8ig` / KEI-229 — `sync_orchestrator`)
- **Blocks** K4 (`Agency_OS-lc7b` / KEI-230 — `reconcile_three_stores`)

## Why this is safe

- `bd_id` column NULL-defaults — existing rows unaffected until backfill paired them
- Backfill is idempotent (`WHERE bd_id IS NULL`) — re-runs are no-ops
- Backfill ambiguous detection prevents UNIQUE-violation failures during apply
- `tasks_cli.py` writer change is additive — old `id = %s` callers still match (the OR clause is a superset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)