### PR TITLE
[ORION] feat(kei111e): RLS on dispatcher_customers + customer_api_keys (KEI-181-shape session-var policy)

### DIFF
--- a/supabase/migrations/20260519_kei111e_rls_dispatcher_customers_api_keys.sql
+++ b/supabase/migrations/20260519_kei111e_rls_dispatcher_customers_api_keys.sql
@@ -1,0 +1,89 @@
+-- KEI-111E: Row-level security on customer-facing Dispatcher tables.
+-- Author: ORION (Linear KEI-149 / bd Agency_OS-fd3fsr)
+-- Idempotent: safe to re-run.
+-- Tables touched: public.dispatcher_customers, public.customer_api_keys
+--
+-- Rationale:
+--   * dispatcher_customers (KEI-111) is the per-customer root row for the
+--     customer-facing Dispatcher product. Multiple customers share the table;
+--     a customer must not be able to read another customer's row.
+--   * customer_api_keys (KEI-116) stores encrypted BYO API keys keyed by
+--     customer_id. Same isolation requirement — and the consequence of a
+--     leak here is far worse (decryption key compromise → cross-tenant
+--     key exposure).
+--   * The 3rd "tasks" table named in the KEI-111E spec is already covered
+--     by KEI-181's tenant_isolation_tasks policy (PR shipped 2026-05-17).
+--     This migration covers the remaining two.
+--
+-- Policy shape mirrors KEI-181 — session-local var, service-role bypass,
+-- null-var bypass for backend daemons that have not yet set the var.
+-- The var name here is `agency_os.dispatcher_user_id` (UUID) rather than
+-- `agency_os.tenant_id` (integer) because dispatcher_customers is keyed by
+-- supabase_user_id (the auth.users UUID), not by the integer tenant_id
+-- foundation.
+
+-- ============================================================
+-- 1. Enable RLS on both tables (idempotent)
+-- ============================================================
+
+ALTER TABLE public.dispatcher_customers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.customer_api_keys    ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 2. Policies on public.dispatcher_customers
+-- ============================================================
+-- A row is visible when ANY of:
+--   1. session var agency_os.dispatcher_user_id matches the row's
+--      supabase_user_id  (normal customer-authenticated callers)
+--   2. current_setting('role') = 'service_role'  (Supabase service-role key)
+--   3. agency_os.dispatcher_user_id IS NULL  (backend daemons that
+--      have not set the var — same bypass shape as KEI-181 keeps
+--      legacy callers working until they switch to set-the-var)
+
+DROP POLICY IF EXISTS tenant_isolation_dispatcher_customers ON public.dispatcher_customers;
+CREATE POLICY tenant_isolation_dispatcher_customers ON public.dispatcher_customers
+    FOR ALL
+    USING (
+        current_setting('agency_os.dispatcher_user_id', true)::uuid = supabase_user_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.dispatcher_user_id', true) IS NULL
+    )
+    WITH CHECK (
+        current_setting('agency_os.dispatcher_user_id', true)::uuid = supabase_user_id
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.dispatcher_user_id', true) IS NULL
+    );
+
+-- ============================================================
+-- 3. Policies on public.customer_api_keys
+-- ============================================================
+-- customer_api_keys.customer_id references dispatcher_customers.id (per
+-- application-layer convention — there is no FK in the table definition
+-- because the table was created before dispatcher_customers existed). The
+-- RLS policy resolves the chain: row visible iff customer_id belongs to
+-- the dispatcher_customers row matching the session user.
+
+DROP POLICY IF EXISTS tenant_isolation_customer_api_keys ON public.customer_api_keys;
+CREATE POLICY tenant_isolation_customer_api_keys ON public.customer_api_keys
+    FOR ALL
+    USING (
+        customer_id IN (
+            SELECT id FROM public.dispatcher_customers
+            WHERE supabase_user_id = current_setting('agency_os.dispatcher_user_id', true)::uuid
+        )
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.dispatcher_user_id', true) IS NULL
+    )
+    WITH CHECK (
+        customer_id IN (
+            SELECT id FROM public.dispatcher_customers
+            WHERE supabase_user_id = current_setting('agency_os.dispatcher_user_id', true)::uuid
+        )
+        OR current_setting('role', true) = 'service_role'
+        OR current_setting('agency_os.dispatcher_user_id', true) IS NULL
+    );
+
+COMMENT ON POLICY tenant_isolation_dispatcher_customers ON public.dispatcher_customers IS
+    'KEI-111E: per-customer isolation via agency_os.dispatcher_user_id session var. Service-role + null-var bypass for backend daemons.';
+COMMENT ON POLICY tenant_isolation_customer_api_keys ON public.customer_api_keys IS
+    'KEI-111E: chained isolation via dispatcher_customers join on supabase_user_id. Service-role + null-var bypass for backend.';

--- a/tests/integration/test_rls_dispatcher_isolation.py
+++ b/tests/integration/test_rls_dispatcher_isolation.py
@@ -1,0 +1,238 @@
+"""
+KEI-111E — Dispatcher customer RLS isolation integration test.
+
+Mirrors the KEI-181 tenant isolation test shape against the two
+customer-facing tables covered by this PR:
+  * public.dispatcher_customers
+  * public.customer_api_keys
+
+Proves read-isolation between two simulated dispatcher customers using real
+psycopg sessions against the live Supabase Postgres instance.
+
+Requires: INTEGRATION_DATABASE_URL (or DATABASE_URL when it points at a real
+remote DSN, not the conftest.py localhost placeholder). Skipped otherwise.
+
+Mark: pytest.mark.integration
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_RAW = os.environ.get("INTEGRATION_DATABASE_URL") or os.environ.get("DATABASE_URL", "")
+_PG_DSN = _RAW.replace("+asyncpg", "").replace("postgresql+psycopg2", "postgresql")
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def pg_dsn() -> str:
+    if not _PG_DSN or not _PG_DSN.startswith("postgresql"):
+        pytest.skip("No real DATABASE_URL — skipping RLS isolation test")
+    if "localhost" in _PG_DSN or "127.0.0.1" in _PG_DSN:
+        pytest.skip(
+            "DATABASE_URL points at localhost (conftest.py override) — "
+            "set INTEGRATION_DATABASE_URL to a real Supabase DSN to run"
+        )
+    return _PG_DSN
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: two customers + two API keys, one per customer
+# ---------------------------------------------------------------------------
+
+_USER_A = str(uuid.uuid4())
+_USER_B = str(uuid.uuid4())
+_CUST_A = str(uuid.uuid4())
+_CUST_B = str(uuid.uuid4())
+_KEY_A = str(uuid.uuid4())
+_KEY_B = str(uuid.uuid4())
+
+
+def _open_connection(dsn: str):
+    try:
+        import psycopg  # psycopg3
+    except ImportError:
+        pytest.skip("psycopg (v3) not installed — skipping RLS isolation test")
+    return psycopg.connect(dsn, autocommit=False)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def seed_and_cleanup(pg_dsn: str):
+    """Seed 2 customers + 2 keys; yield; teardown on exit."""
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+
+    # auth.users rows — required because dispatcher_customers.supabase_user_id
+    # has ON DELETE CASCADE referencing auth.users(id). Insert with the
+    # service-role bypass active (default session has no
+    # agency_os.dispatcher_user_id set, so null-var bypass applies).
+    for u in (_USER_A, _USER_B):
+        cur.execute(
+            """
+            INSERT INTO auth.users (id, instance_id, email, created_at, updated_at, aud, role)
+            VALUES (%s::uuid, '00000000-0000-0000-0000-000000000000'::uuid,
+                    %s, NOW(), NOW(), 'authenticated', 'authenticated')
+            ON CONFLICT (id) DO NOTHING
+            """,
+            (u, f"rls-test-{u[:8]}@example.test"),
+        )
+
+    for cust_id, user_id, email in [
+        (_CUST_A, _USER_A, f"a-{_USER_A[:8]}@rls.test"),
+        (_CUST_B, _USER_B, f"b-{_USER_B[:8]}@rls.test"),
+    ]:
+        cur.execute(
+            """
+            INSERT INTO public.dispatcher_customers
+              (id, supabase_user_id, email, tier)
+            VALUES (%s::uuid, %s::uuid, %s, 'free')
+            ON CONFLICT (id) DO NOTHING
+            """,
+            (cust_id, user_id, email),
+        )
+
+    for key_id, cust_id in [(_KEY_A, _CUST_A), (_KEY_B, _CUST_B)]:
+        cur.execute(
+            """
+            INSERT INTO public.customer_api_keys
+              (id, customer_id, provider, encrypted_key, lookup_hash)
+            VALUES (%s::uuid, %s::uuid, 'anthropic', '\\x00'::bytea, %s)
+            ON CONFLICT (id) DO NOTHING
+            """,
+            (key_id, cust_id, f"rls-hash-{key_id[:32]}"),
+        )
+
+    conn.commit()
+    conn.close()
+
+    yield
+
+    conn2 = _open_connection(pg_dsn)
+    cur2 = conn2.cursor()
+    cur2.execute(
+        "DELETE FROM public.customer_api_keys WHERE id IN (%s::uuid, %s::uuid)",
+        (_KEY_A, _KEY_B),
+    )
+    cur2.execute(
+        "DELETE FROM public.dispatcher_customers WHERE id IN (%s::uuid, %s::uuid)",
+        (_CUST_A, _CUST_B),
+    )
+    cur2.execute(
+        "DELETE FROM auth.users WHERE id IN (%s::uuid, %s::uuid)",
+        (_USER_A, _USER_B),
+    )
+    conn2.commit()
+    conn2.close()
+
+
+# ---------------------------------------------------------------------------
+# dispatcher_customers isolation
+# ---------------------------------------------------------------------------
+
+
+def test_user_a_sees_only_own_customer_row(pg_dsn: str) -> None:
+    """Session as user A must see CUST_A but NOT CUST_B."""
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+    cur.execute(f"SET LOCAL agency_os.dispatcher_user_id = '{_USER_A}'")
+    cur.execute(
+        "SELECT id::text FROM public.dispatcher_customers WHERE id IN (%s::uuid, %s::uuid)",
+        (_CUST_A, _CUST_B),
+    )
+    visible = {row[0] for row in cur.fetchall()}
+    conn.rollback()
+    conn.close()
+    assert _CUST_A in visible, f"User A should see own customer row {_CUST_A}"
+    assert _CUST_B not in visible, f"User A must NOT see other-customer row {_CUST_B}"
+
+
+def test_user_b_sees_only_own_customer_row(pg_dsn: str) -> None:
+    """Session as user B must see CUST_B but NOT CUST_A."""
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+    cur.execute(f"SET LOCAL agency_os.dispatcher_user_id = '{_USER_B}'")
+    cur.execute(
+        "SELECT id::text FROM public.dispatcher_customers WHERE id IN (%s::uuid, %s::uuid)",
+        (_CUST_A, _CUST_B),
+    )
+    visible = {row[0] for row in cur.fetchall()}
+    conn.rollback()
+    conn.close()
+    assert _CUST_B in visible, f"User B should see own customer row {_CUST_B}"
+    assert _CUST_A not in visible, f"User B must NOT see other-customer row {_CUST_A}"
+
+
+# ---------------------------------------------------------------------------
+# customer_api_keys isolation (chained via dispatcher_customers)
+# ---------------------------------------------------------------------------
+
+
+def test_user_a_sees_only_own_api_key(pg_dsn: str) -> None:
+    """Session as user A must see KEY_A but NOT KEY_B."""
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+    cur.execute(f"SET LOCAL agency_os.dispatcher_user_id = '{_USER_A}'")
+    cur.execute(
+        "SELECT id::text FROM public.customer_api_keys WHERE id IN (%s::uuid, %s::uuid)",
+        (_KEY_A, _KEY_B),
+    )
+    visible = {row[0] for row in cur.fetchall()}
+    conn.rollback()
+    conn.close()
+    assert _KEY_A in visible, f"User A should see own api key {_KEY_A}"
+    assert _KEY_B not in visible, f"User A must NOT see other-customer api key {_KEY_B}"
+
+
+def test_user_b_sees_only_own_api_key(pg_dsn: str) -> None:
+    """Session as user B must see KEY_B but NOT KEY_A."""
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+    cur.execute(f"SET LOCAL agency_os.dispatcher_user_id = '{_USER_B}'")
+    cur.execute(
+        "SELECT id::text FROM public.customer_api_keys WHERE id IN (%s::uuid, %s::uuid)",
+        (_KEY_A, _KEY_B),
+    )
+    visible = {row[0] for row in cur.fetchall()}
+    conn.rollback()
+    conn.close()
+    assert _KEY_B in visible, f"User B should see own api key {_KEY_B}"
+    assert _KEY_A not in visible, f"User B must NOT see other-customer api key {_KEY_A}"
+
+
+# ---------------------------------------------------------------------------
+# Backend (null-var) bypass — backend daemons that haven't set the var
+# must still see both rows (KEI-181 parity).
+# ---------------------------------------------------------------------------
+
+
+def test_backend_null_var_sees_both_customers(pg_dsn: str) -> None:
+    """No agency_os.dispatcher_user_id set → null-var bypass → see all rows."""
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id::text FROM public.dispatcher_customers WHERE id IN (%s::uuid, %s::uuid)",
+        (_CUST_A, _CUST_B),
+    )
+    visible = {row[0] for row in cur.fetchall()}
+    conn.rollback()
+    conn.close()
+    assert _CUST_A in visible
+    assert _CUST_B in visible
+
+
+def test_backend_null_var_sees_both_api_keys(pg_dsn: str) -> None:
+    conn = _open_connection(pg_dsn)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id::text FROM public.customer_api_keys WHERE id IN (%s::uuid, %s::uuid)",
+        (_KEY_A, _KEY_B),
+    )
+    visible = {row[0] for row in cur.fetchall()}
+    conn.rollback()
+    conn.close()
+    assert _KEY_A in visible
+    assert _KEY_B in visible


### PR DESCRIPTION
## Summary

KEI-111E (Linear KEI-149 / bd `Agency_OS-fd3fsr`). Adds row-level security + tenant-isolation policy to the two customer-facing Dispatcher tables (`dispatcher_customers` + `customer_api_keys`). The third table named in the bd spec — `tasks` — is already covered by max's KEI-181 (`tenant_isolation_tasks` policy, merged 2026-05-17).

## What lands

| File | LoC | Purpose |
|------|-----|---------|
| `supabase/migrations/20260519_kei111e_rls_dispatcher_customers_api_keys.sql` | 89 | `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` + 2 `CREATE POLICY` blocks (idempotent). |
| `tests/integration/test_rls_dispatcher_isolation.py` | 238 | 6 pytest cases mirroring KEI-181 test shape. |

**Total: 327 LoC across 2 files.**

## Policy shape

Mirrors KEI-181 exactly — three-clause `USING` + `WITH CHECK`:

1. Session var `agency_os.dispatcher_user_id::uuid = supabase_user_id` (customer-authenticated callers).
2. `current_setting('role') = 'service_role'` (Supabase service-role key bypass).
3. `agency_os.dispatcher_user_id IS NULL` (backend daemon bypass — same shape as KEI-181 to keep legacy callers working until they set the var).

The var is `agency_os.dispatcher_user_id` (UUID) rather than KEI-181's `agency_os.tenant_id` (integer) because `dispatcher_customers` is keyed on `auth.users.id` (UUID), not the integer `tenants` foundation.

`customer_api_keys` uses a chained subquery (`customer_id IN SELECT id FROM dispatcher_customers WHERE supabase_user_id = <session>`) — no FK exists between the two tables (KEI-116's table was created before `dispatcher_customers` existed; the convention is application-layer enforced).

## Acceptance criteria (KEI-111E spec)

- [x] **RLS enabled on customers** → `public.dispatcher_customers` (the customer-facing Dispatcher product table, per KEI-111 design rationale comment in the table's source migration line 6).
- [x] **RLS enabled on api_keys** → `public.customer_api_keys`.
- [x] **RLS on tasks already shipped** → KEI-181 by max, PR merged 2026-05-17. Linked here for completeness.
- [x] **Integration test verifies user A can't read user B rows** — 4 cross-isolation cases + 2 backend-bypass cases (6 total).

## Test plan

- [x] `ruff check tests/integration/test_rls_dispatcher_isolation.py` → `All checks passed!`
- [x] `ruff format --check tests/integration/test_rls_dispatcher_isolation.py` → `1 file already formatted`
- [x] Migration is idempotent (`ALTER TABLE ... ENABLE ROW LEVEL SECURITY` is a no-op when already enabled; `DROP POLICY IF EXISTS` then `CREATE POLICY` is the standard re-runnable pattern).
- [ ] **Integration test runs against dev DB (CI)** — requires `INTEGRATION_DATABASE_URL` env in the CI runner. Skipped when absent; runs when present.

## Test cases

1. **User A sees own `dispatcher_customers` row, NOT user B's.**
2. **User B sees own `dispatcher_customers` row, NOT user A's.**
3. **User A sees own `customer_api_keys` row, NOT user B's** (chained via the subquery).
4. **User B sees own `customer_api_keys` row, NOT user A's.**
5. **Backend null-var bypass sees both `dispatcher_customers` rows** — preserves KEI-181 parity for backend daemons.
6. **Backend null-var bypass sees both `customer_api_keys` rows.**

## Non-scope (deliberate)

- Tightening the null-var bypass to require a more explicit backend-context flag — that's a cross-cutting governance change touching every KEI-181 policy. Out of scope for this single-KEI PR.
- Adding the missing FK `customer_api_keys.customer_id REFERENCES dispatcher_customers.id` — flagged as application-layer convention by the KEI-116 migration; an FK migration is a separate concern.