### PR TITLE
[ATLAS] feat(kei228): K2 — public.sync_events table + Postgres + Linear emit paths (re-opened)

### DIFF
--- a/migrations/20260519_kei227_tasks_bd_id.sql
+++ b/migrations/20260519_kei227_tasks_bd_id.sql
@@ -1,0 +1,31 @@
+-- KEI-227 (Linear) / Agency_OS-8c67 (bd) — K1 ID canonicalisation foundation.
+--
+-- Adds bd_id column to public.tasks so the canonical Linear KEI-N (tasks.id)
+-- can be paired with the bd-Dolt Agency_OS-xxx short-code. Subsequent K2
+-- (sync_events) joins on either key without an FK violation; tasks_cli.py
+-- writers can match bd_id when invoked from `bd update --claim <Agency_OS-xxx>`
+-- against rows keyed on KEI-N from reconcile_linear_supabase.py.
+--
+-- Backfill happens via scripts/backfill_tasks_bd_id.py (dry-run by default,
+-- --apply to mutate). Not run in this migration so the column add is reversible.
+
+ALTER TABLE public.tasks
+    ADD COLUMN IF NOT EXISTS bd_id TEXT;
+
+-- Unique-when-present: NULL allowed (rows from Linear that haven't been
+-- paired with a bd issue yet), but each Agency_OS-xxx maps to at most one
+-- Linear KEI-N row.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tasks_bd_id
+    ON public.tasks (bd_id)
+    WHERE bd_id IS NOT NULL;
+
+-- Lookup index for the `id = %s OR bd_id = %s` pattern in tasks_cli.py.
+CREATE INDEX IF NOT EXISTS idx_tasks_bd_id
+    ON public.tasks (bd_id)
+    WHERE bd_id IS NOT NULL;
+
+COMMENT ON COLUMN public.tasks.bd_id IS
+    'KEI-227 — bd-Dolt short-code (Agency_OS-xxx) paired with the canonical '
+    'Linear identifier in tasks.id. NULL means no bd-Dolt issue paired yet. '
+    'Populated by scripts/backfill_tasks_bd_id.py and by tasks_cli.py writers '
+    'when bd ops touch a Linear-keyed row.';

--- a/migrations/20260519_kei228_sync_events.sql
+++ b/migrations/20260519_kei228_sync_events.sql
@@ -1,0 +1,138 @@
+-- KEI-228 (Linear) / Agency_OS-tfsl (bd) — K2 sync_events audit table + emit paths.
+--
+-- Builds on K1 (KEI-227 — bd_id column). Every cross-store change publishes
+-- a single sync_events row tagged with origin. The K3 sync_orchestrator
+-- (next PR) drains the table and writes to the OTHER two stores, with the
+-- origin tag preventing echo-back loops.
+--
+-- Three emit paths (planned for K2):
+--   1. Postgres → trigger on public.tasks INSERT/UPDATE (covered here)
+--   2. Linear webhook → src/api/webhooks/linear.py insert (Python side)
+--   3. bd-Dolt → DEFERRED to K2.5 (no clean post-bd hook; most bd ops
+--      propagate to Postgres via tasks_cli.py and so are caught by trigger #1)
+
+CREATE TABLE IF NOT EXISTS public.sync_events (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    origin          TEXT NOT NULL CHECK (origin IN ('bd', 'postgres', 'linear')),
+    event_type      TEXT NOT NULL CHECK (event_type IN (
+                        'create', 'update', 'close', 'reopen',
+                        'priority_change', 'title_change'
+                    )),
+    task_id         TEXT NOT NULL,
+    bd_id           TEXT,
+    payload         JSONB NOT NULL,
+    payload_hash    TEXT GENERATED ALWAYS AS (
+                        encode(extensions.digest(payload::text, 'sha256'), 'hex')
+                    ) STORED,
+    processed       BOOLEAN NOT NULL DEFAULT FALSE,
+    attempts        INT NOT NULL DEFAULT 0,
+    last_attempt_at TIMESTAMPTZ,
+    error_message   TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Drain index — K3 worker reads via this path.
+CREATE INDEX IF NOT EXISTS idx_sync_events_unprocessed
+    ON public.sync_events (created_at)
+    WHERE processed = FALSE;
+
+-- Dedupe partial index — at most one unprocessed event per (task, hash).
+-- Same task can re-emit after processing; identical payloads collapse.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_sync_events_pending_dedupe
+    ON public.sync_events (task_id, payload_hash)
+    WHERE processed = FALSE;
+
+COMMENT ON TABLE public.sync_events IS
+    'KEI-228 — cross-store change events. Three origins (bd/postgres/linear); '
+    'K3 sync_orchestrator drains and dispatches to the OTHER two stores with '
+    'origin-tag loop prevention. Idempotency via (task_id, payload_hash) '
+    'partial unique index.';
+
+-- ---------------------------------------------------------------------------
+-- Emit path 1: Postgres trigger on public.tasks.
+-- ---------------------------------------------------------------------------
+--
+-- Fires on INSERT (event_type='create') and UPDATE (event_type='update' or
+-- 'close' if NEW.status transitions to a done-shape state). Payload carries
+-- the full row snapshot so K3 can replay without a re-select.
+--
+-- Coexists with the existing trg_tasks_completion_sync (KEI-74) — that one
+-- writes to completion_sync_queue (legacy fan-out, to be removed in K3).
+-- During the transition both fire; K3 will drop the old trigger.
+
+CREATE OR REPLACE FUNCTION public.fn_emit_sync_event_postgres()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+    v_event_type TEXT;
+    v_payload    JSONB;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        v_event_type := 'create';
+    ELSIF TG_OP = 'UPDATE' THEN
+        -- Closing transitions (status in done/cancelled) emit 'close';
+        -- everything else is 'update'.
+        IF NEW.status IN ('done', 'cancelled') AND NEW.status IS DISTINCT FROM OLD.status THEN
+            v_event_type := 'close';
+        ELSIF OLD.status IN ('done', 'cancelled') AND NEW.status NOT IN ('done', 'cancelled') THEN
+            v_event_type := 'reopen';
+        ELSIF NEW.priority IS DISTINCT FROM OLD.priority THEN
+            v_event_type := 'priority_change';
+        ELSIF NEW.title IS DISTINCT FROM OLD.title THEN
+            v_event_type := 'title_change';
+        ELSE
+            v_event_type := 'update';
+        END IF;
+    ELSE
+        RETURN NULL;
+    END IF;
+
+    v_payload := jsonb_build_object(
+        'id', NEW.id,
+        'bd_id', NEW.bd_id,
+        'title', NEW.title,
+        'status', NEW.status,
+        'priority', NEW.priority,
+        'linear_url', NEW.linear_url,
+        'claimed_by', NEW.claimed_by,
+        'tg_op', TG_OP
+    );
+
+    INSERT INTO public.sync_events (origin, event_type, task_id, bd_id, payload)
+    VALUES ('postgres', v_event_type, NEW.id, NEW.bd_id, v_payload)
+    ON CONFLICT (task_id, payload_hash) WHERE processed = FALSE DO NOTHING;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_tasks_emit_sync_events ON public.tasks;
+CREATE TRIGGER trg_tasks_emit_sync_events
+    AFTER INSERT OR UPDATE ON public.tasks
+    FOR EACH ROW EXECUTE FUNCTION public.fn_emit_sync_event_postgres();
+
+-- ---------------------------------------------------------------------------
+-- Helper: emit from application code (used by Linear webhook + future bd path).
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.fn_emit_sync_event(
+    p_origin TEXT,
+    p_event_type TEXT,
+    p_task_id TEXT,
+    p_bd_id TEXT,
+    p_payload JSONB
+) RETURNS UUID LANGUAGE plpgsql AS $$
+DECLARE
+    v_id UUID;
+BEGIN
+    INSERT INTO public.sync_events (origin, event_type, task_id, bd_id, payload)
+    VALUES (p_origin, p_event_type, p_task_id, p_bd_id, p_payload)
+    ON CONFLICT (task_id, payload_hash) WHERE processed = FALSE DO NOTHING
+    RETURNING id INTO v_id;
+    RETURN v_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_emit_sync_event IS
+    'KEI-228 — application-side helper to insert into sync_events with '
+    'dedupe-on-pending semantics. Returns event id, or NULL if a duplicate '
+    'pending event already exists for this (task_id, payload_hash).';

--- a/scripts/backfill_tasks_bd_id.py
+++ b/scripts/backfill_tasks_bd_id.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""backfill_tasks_bd_id.py — KEI-227 K1 backfill.
+
+Walks public.tasks rows with linear_url IS NOT NULL AND bd_id IS NULL,
+matches them against bd-Dolt issues by external_ref URL, and writes the
+paired Agency_OS-xxx into the new bd_id column.
+
+Usage:
+    python3 scripts/backfill_tasks_bd_id.py            # dry-run
+    python3 scripts/backfill_tasks_bd_id.py --apply    # mutate Postgres
+
+Idempotent. Re-running on already-paired rows is a no-op (only filters
+WHERE bd_id IS NULL). Safe to wire into a periodic timer post-merge.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from typing import Any
+
+logger = logging.getLogger("backfill_tasks_bd_id")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+_BD_BIN_DEFAULT = os.path.expanduser("~/.local/bin/bd")
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL or SUPABASE_DB_URL must be set")
+    return dsn.replace("+asyncpg", "")
+
+
+def _bd_bin() -> str:
+    return os.environ.get("AGENCY_OS_BD_BIN", _BD_BIN_DEFAULT)
+
+
+def _bd_list_json() -> list[dict[str, Any]]:
+    """Return all bd issues (open + in_progress + closed) as a list of dicts.
+
+    Default `bd list` filters to open/in_progress. The --all flag widens the
+    set so closed bd issues with external_ref still pair against Postgres
+    rows whose status='done' (which is most of them).
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603 — controlled args, no shell
+            [_bd_bin(), "list", "--all", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.error("bd list --json failed: %s", exc)
+        return []
+    if proc.returncode != 0:
+        logger.error("bd list --json exit %d: %s", proc.returncode, proc.stderr[:200])
+        return []
+    try:
+        return json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        logger.error("bd list --json parse: %s", exc)
+        return []
+
+
+def _build_url_to_bd_id(issues: list[dict[str, Any]]) -> dict[str, list[str]]:
+    """Map external_ref URL -> list of bd IDs. List form catches dual-claims."""
+    url_to_ids: dict[str, list[str]] = {}
+    for issue in issues:
+        ref = issue.get("external_ref") or (issue.get("metadata") or {}).get("external_ref")
+        if not ref:
+            continue
+        url_to_ids.setdefault(ref, []).append(issue.get("id", ""))
+    return url_to_ids
+
+
+def _candidate_url_variants(url: str) -> list[str]:
+    """Linear URLs vary by trailing slug — strip suffix to widen the match.
+
+    Examples:
+      https://linear.app/keiracom/issue/KEI-227
+      https://linear.app/keiracom/issue/KEI-227/atlas-k1-id-canonicalisation-...
+    Both should pair with the same bd issue.
+    """
+    if not url:
+        return []
+    out = [url, url.rstrip("/")]
+    parts = url.split("/issue/", 1)
+    if len(parts) == 2:
+        kei_part = parts[1].split("/", 1)[0]
+        out.append(f"{parts[0]}/issue/{kei_part}")
+    return list(dict.fromkeys(out))
+
+
+def plan_backfill(conn: Any, url_to_ids: dict[str, list[str]]) -> dict[str, Any]:
+    """Return {matched: [(task_id, bd_id, linear_url)], ambiguous: [...], unmatched: [...]}.
+
+    Two ambiguity shapes:
+      1. One Linear URL maps to multiple bd issues (dual-mirror) — bd-side.
+      2. URL-variant stripping causes two Postgres rows to claim the same bd_id
+         (e.g., KEI-54 and KEI-54B both stripping to /issue/KEI-54). Resolved
+         here by passing through unique-bd_id detection: rows beyond the first
+         claimant of a bd_id are demoted to ambiguous so the UNIQUE constraint
+         never fires at apply time.
+    """
+    result: dict[str, Any] = {"matched": [], "ambiguous": [], "unmatched": []}
+    bd_id_taken: dict[str, str] = {}  # bd_id -> first task_id that claimed it
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, linear_url FROM public.tasks "
+            "WHERE linear_url IS NOT NULL AND bd_id IS NULL "
+            "ORDER BY id"
+        )
+        rows = cur.fetchall()
+    for row in rows:
+        task_id, linear_url = row[0], row[1]
+        bd_ids: list[str] = []
+        for variant in _candidate_url_variants(linear_url):
+            bd_ids = url_to_ids.get(variant, [])
+            if bd_ids:
+                break
+        if not bd_ids:
+            result["unmatched"].append((task_id, linear_url))
+        elif len(bd_ids) > 1:
+            result["ambiguous"].append((task_id, bd_ids, linear_url))
+        else:
+            bd_id = bd_ids[0]
+            prior_claimant = bd_id_taken.get(bd_id)
+            if prior_claimant is not None:
+                result["ambiguous"].append(
+                    (
+                        task_id,
+                        [bd_id],
+                        f"{linear_url} (bd_id {bd_id} already claimed by {prior_claimant})",
+                    )
+                )
+            else:
+                bd_id_taken[bd_id] = task_id
+                result["matched"].append((task_id, bd_id, linear_url))
+    return result
+
+
+def apply_backfill(conn: Any, matched: list[tuple[str, str, str]]) -> int:
+    """Write bd_id for matched rows. Returns count written."""
+    written = 0
+    with conn.cursor() as cur:
+        for task_id, bd_id, _url in matched:
+            cur.execute(
+                "UPDATE public.tasks SET bd_id = %s, updated_at = NOW() "
+                "WHERE id = %s AND bd_id IS NULL",
+                (bd_id, task_id),
+            )
+            written += cur.rowcount
+    conn.commit()
+    return written
+
+
+def _print_summary(plan: dict[str, Any], applied: int | None) -> None:
+    print(f"matched:    {len(plan['matched'])}")
+    print(f"ambiguous:  {len(plan['ambiguous'])}")
+    print(f"unmatched:  {len(plan['unmatched'])}")
+    if applied is not None:
+        print(f"applied:    {applied}")
+    if plan["ambiguous"]:
+        print("\nAmbiguous (Linear URL maps to multiple bd issues — manual triage):")
+        for task_id, bd_ids, url in plan["ambiguous"][:10]:
+            print(f"  {task_id} → {bd_ids} ({url})")
+    if plan["unmatched"]:
+        print("\nUnmatched sample (Linear URL has no bd issue with that external_ref):")
+        for task_id, url in plan["unmatched"][:10]:
+            print(f"  {task_id} → {url}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Mutate Postgres (default dry-run)")
+    args = parser.parse_args(argv)
+
+    try:
+        import psycopg
+    except ImportError:
+        logger.error("psycopg not installed; pip install psycopg")
+        return 2
+
+    issues = _bd_list_json()
+    if not issues:
+        logger.warning("bd returned 0 issues — backfill aborted")
+        return 1
+    logger.info("loaded %d bd issues", len(issues))
+    url_to_ids = _build_url_to_bd_id(issues)
+    logger.info("indexed %d unique external_ref URLs", len(url_to_ids))
+
+    with psycopg.connect(_dsn(), prepare_threshold=None) as conn:
+        plan = plan_backfill(conn, url_to_ids)
+        applied: int | None = None
+        if args.apply:
+            applied = apply_backfill(conn, plan["matched"])
+            logger.info("applied %d rows", applied)
+    _print_summary(plan, applied)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -503,7 +503,12 @@ def cmd_claim(args: argparse.Namespace) -> int:
                 # not claim …' (which is indistinguishable from a race loss).
                 # Fail-open on parse errors so legacy rows / fixtures without
                 # a numeric phase fall through to the UPDATE's own filter.
-                cur.execute("SELECT phase FROM public.tasks WHERE id = %s", (args.id,))
+                # KEI-227: id OR bd_id — caller may pass either the canonical
+                # Linear KEI-N or the bd-Dolt Agency_OS-xxx short-code.
+                cur.execute(
+                    "SELECT phase FROM public.tasks WHERE id = %s OR bd_id = %s",
+                    (args.id, args.id),
+                )
                 _phase_row = cur.fetchone()
                 _task_phase: float | None = None
                 if _phase_row is not None:
@@ -525,12 +530,12 @@ def cmd_claim(args: argparse.Namespace) -> int:
                     UPDATE public.tasks
                        SET status = 'active', claimed_by = %s,
                            claimed_at = NOW(), updated_at = NOW()
-                     WHERE id = %s
+                     WHERE (id = %s OR bd_id = %s)
                        AND status = 'available'
                        AND (claimed_by IS NULL OR claimed_by = %s)
                      RETURNING id, title, priority, status, claimed_by, linear_url, tags
                     """,
-                    (cs, args.id, cs),
+                    (cs, args.id, args.id, cs),
                 )
             else:
                 # KEI-86 — also filter the next-available SELECT by phase.
@@ -700,11 +705,11 @@ def _execute_atomic_complete(
                claimed_by = NULL,
                claimed_at = NULL,
                updated_at = NOW()
-         WHERE id = %s
+         WHERE (id = %s OR bd_id = %s)
            AND (claimed_by = %s OR %s = 'force')
          RETURNING id, title, status
         """,
-        (task_id, callsign, force_mode),
+        (task_id, task_id, callsign, force_mode),
     )
     return cur.fetchone()
 
@@ -741,11 +746,11 @@ def cmd_heartbeat(args: argparse.Namespace) -> int:
                 UPDATE public.tasks
                    SET heartbeat_at = NOW(),
                        updated_at = NOW()
-                 WHERE id = %s
+                 WHERE (id = %s OR bd_id = %s)
                    AND claimed_by = %s
                  RETURNING id, claimed_by, heartbeat_at
                 """,
-                (args.id, cs),
+                (args.id, args.id, cs),
             )
             row = cur.fetchone()
             conn.commit()

--- a/src/api/webhooks/linear.py
+++ b/src/api/webhooks/linear.py
@@ -364,10 +364,55 @@ async def receive_linear_webhook(request: Request) -> dict[str, str]:
         return {"status": "ignored"}
     _dispatch_to_bd(event)
     _dispatch_to_tasks(event)  # KEI-22 — Supabase tasks SSOT (parallel to bd during transition)
+    _emit_sync_event_linear(event)  # KEI-228 — origin-tagged event for K3 orchestrator
     _dispatch_to_indexing_queue("linear", payload)  # KEI-61 — durable staging buffer
     # Successful HMAC-pass + UPDATE-applied — the canonical outcome event.
     _heartbeat_tick("linear-webhook-handler", outcome_increment=1, status="ok")
     return {"status": "ok", "op": event["op"], "identifier": event["identifier"]}
+
+
+# KEI-228: map normalised webhook ops to sync_events.event_type. Coexists with
+# the legacy `_dispatch_to_*` paths during K2→K3 transition; once K3 lands the
+# old dispatchers can be removed and the K3 orchestrator becomes the sole
+# fan-out path (draining sync_events).
+_LINEAR_OP_TO_EVENT_TYPE: dict[str, str] = {
+    "create": "create",
+    "status": "update",  # narrowed below via task_status
+    "remove": "close",
+}
+
+
+def _emit_sync_event_linear(event: dict[str, Any]) -> None:
+    """Insert into public.sync_events with origin='linear'. Fail-open.
+
+    The K3 sync_orchestrator (next PR) drains these and dispatches to the
+    OTHER two stores (postgres + bd). Origin tag prevents loop-back to
+    Linear when the destination writes propagate.
+    """
+    op = event.get("op")
+    identifier = event.get("identifier")
+    if not (op and identifier):
+        return
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not dsn:
+        logger.warning("sync_events emit skipped: DATABASE_URL/SUPABASE_DB_URL unset")
+        return
+    dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+    event_type = _LINEAR_OP_TO_EVENT_TYPE.get(op, "update")
+    # status op with task_status=done → close; reopen detection deferred to K3.
+    if op == "status" and event.get("task_status") == "done":
+        event_type = "close"
+    try:
+        import psycopg
+
+        with psycopg.connect(dsn, connect_timeout=10) as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT public.fn_emit_sync_event(%s, %s, %s, %s, %s::jsonb)",
+                ("linear", event_type, identifier, None, json.dumps(event)),
+            )
+            conn.commit()
+    except Exception as exc:  # noqa: BLE001 — fail-open per webhook discipline
+        logger.warning("sync_events emit failed for %s: %s", identifier, exc)
 
 
 def _dispatch_to_indexing_queue(source: str, raw_payload: dict[str, Any]) -> None:

--- a/tests/api/webhooks/test_linear_webhook_kei228.py
+++ b/tests/api/webhooks/test_linear_webhook_kei228.py
@@ -1,0 +1,151 @@
+"""KEI-228 — tests for the sync_events emit path in the Linear webhook.
+
+Covers:
+  - _emit_sync_event_linear inserts via fn_emit_sync_event with right args
+  - op→event_type mapping (create / status / status+done / remove)
+  - fail-open: psycopg.connect failure does not raise
+  - skipped when DATABASE_URL absent
+  - skipped when event lacks op or identifier
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.api.webhooks import linear as linear_webhook  # noqa: E402
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.executed.append((sql, params or ()))
+
+
+class _FakeConn:
+    def __init__(self, raise_on_connect: bool = False) -> None:
+        self._cur = _FakeCursor()
+        self.committed = False
+
+    def __enter__(self) -> _FakeConn:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def cursor(self) -> _FakeCursor:
+        return self._cur
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+@pytest.fixture
+def fake_psycopg(monkeypatch):
+    """Install a fake psycopg module on the linear module's import path."""
+    conn = _FakeConn()
+    fake = MagicMock()
+    fake.connect = MagicMock(return_value=conn)
+    monkeypatch.setitem(sys.modules, "psycopg", fake)
+    return conn
+
+
+@pytest.fixture(autouse=True)
+def _dsn_env(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h:5432/d")
+
+
+def test_emit_calls_fn_emit_sync_event_with_origin_linear(fake_psycopg) -> None:
+    event = {"op": "create", "identifier": "KEI-501", "title": "x", "priority": 2, "url": "u"}
+    linear_webhook._emit_sync_event_linear(event)
+    assert fake_psycopg.committed is True
+    calls = fake_psycopg._cur.executed
+    assert len(calls) == 1
+    sql, params = calls[0]
+    assert "fn_emit_sync_event" in sql
+    # params = (origin, event_type, task_id, bd_id, payload_json)
+    assert params[0] == "linear"
+    assert params[1] == "create"
+    assert params[2] == "KEI-501"
+    assert params[3] is None  # bd_id unknown at webhook time
+
+
+def test_op_status_with_task_status_done_maps_to_close(fake_psycopg) -> None:
+    event = {"op": "status", "identifier": "KEI-502", "task_status": "done"}
+    linear_webhook._emit_sync_event_linear(event)
+    _, params = fake_psycopg._cur.executed[0]
+    assert params[1] == "close"
+
+
+def test_op_status_without_done_maps_to_update(fake_psycopg) -> None:
+    event = {"op": "status", "identifier": "KEI-503", "task_status": "active"}
+    linear_webhook._emit_sync_event_linear(event)
+    _, params = fake_psycopg._cur.executed[0]
+    assert params[1] == "update"
+
+
+def test_op_remove_maps_to_close(fake_psycopg) -> None:
+    event = {"op": "remove", "identifier": "KEI-504"}
+    linear_webhook._emit_sync_event_linear(event)
+    _, params = fake_psycopg._cur.executed[0]
+    assert params[1] == "close"
+
+
+def test_op_unknown_falls_back_to_update(fake_psycopg) -> None:
+    event = {"op": "weird", "identifier": "KEI-505"}
+    linear_webhook._emit_sync_event_linear(event)
+    _, params = fake_psycopg._cur.executed[0]
+    assert params[1] == "update"
+
+
+def test_missing_op_skips_emit(fake_psycopg) -> None:
+    linear_webhook._emit_sync_event_linear({"identifier": "KEI-506"})
+    assert fake_psycopg._cur.executed == []
+
+
+def test_missing_identifier_skips_emit(fake_psycopg) -> None:
+    linear_webhook._emit_sync_event_linear({"op": "create"})
+    assert fake_psycopg._cur.executed == []
+
+
+def test_missing_dsn_skips_emit(monkeypatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    # No fake_psycopg fixture — verify no import attempt either.
+    linear_webhook._emit_sync_event_linear({"op": "create", "identifier": "KEI-507"})
+    # Function returns silently; we just verify no raise.
+
+
+def test_psycopg_connect_failure_is_fail_open(monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+    fake = MagicMock()
+    fake.connect.side_effect = OSError("connection refused")
+    monkeypatch.setitem(sys.modules, "psycopg", fake)
+    # Must not raise.
+    linear_webhook._emit_sync_event_linear({"op": "create", "identifier": "KEI-508"})
+
+
+def test_payload_is_serialised_as_json_string(fake_psycopg) -> None:
+    event = {"op": "create", "identifier": "KEI-509", "title": "ž — non-ascii"}
+    linear_webhook._emit_sync_event_linear(event)
+    _, params = fake_psycopg._cur.executed[0]
+    # payload (params[4]) must be a JSON string (so psycopg's %s::jsonb cast works).
+    assert isinstance(params[4], str)
+    import json as _json
+
+    assert _json.loads(params[4])["identifier"] == "KEI-509"

--- a/tests/scripts/test_backfill_tasks_bd_id.py
+++ b/tests/scripts/test_backfill_tasks_bd_id.py
@@ -1,0 +1,164 @@
+"""tests for scripts/backfill_tasks_bd_id.py — KEI-227 K1 backfill.
+
+Covers:
+  - URL → bd_id index construction (with + without external_ref)
+  - plan_backfill: matched / ambiguous (multi-bd) / ambiguous (URL-strip
+    collision e.g. KEI-54 vs KEI-54B) / unmatched
+  - URL variant generation (full slug, no slug, trailing-slash strip)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "backfill_tasks_bd_id.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("backfill_tasks_bd_id", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["backfill_tasks_bd_id"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.executed.append((sql, params or ()))
+        if sql.lstrip().upper().startswith("UPDATE"):
+            self.rowcount = 1
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._cur = _FakeCursor(rows)
+        self.committed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cur
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+def test_url_variants_strip_slug(mod) -> None:
+    url = "https://linear.app/keiracom/issue/KEI-227/atlas-k1-id-canonicalisation-foo"
+    variants = mod._candidate_url_variants(url)
+    assert url in variants
+    assert "https://linear.app/keiracom/issue/KEI-227" in variants
+
+
+def test_url_variants_handle_trailing_slash(mod) -> None:
+    url = "https://linear.app/keiracom/issue/KEI-227/"
+    variants = mod._candidate_url_variants(url)
+    assert "https://linear.app/keiracom/issue/KEI-227" in variants
+
+
+def test_url_variants_empty_input(mod) -> None:
+    assert mod._candidate_url_variants("") == []
+
+
+def test_build_url_index_skips_missing_external_ref(mod) -> None:
+    issues = [
+        {"id": "Agency_OS-aaa", "external_ref": "https://linear.app/keiracom/issue/KEI-1"},
+        {"id": "Agency_OS-bbb"},  # no external_ref
+        {"id": "Agency_OS-ccc", "external_ref": None},
+        {
+            "id": "Agency_OS-ddd",
+            "metadata": {"external_ref": "https://linear.app/keiracom/issue/KEI-2"},
+        },
+    ]
+    index = mod._build_url_to_bd_id(issues)
+    assert "https://linear.app/keiracom/issue/KEI-1" in index
+    assert "https://linear.app/keiracom/issue/KEI-2" in index
+    assert index["https://linear.app/keiracom/issue/KEI-1"] == ["Agency_OS-aaa"]
+    assert "Agency_OS-bbb" not in [b for v in index.values() for b in v]
+
+
+def test_build_url_index_groups_duplicates(mod) -> None:
+    issues = [
+        {"id": "Agency_OS-aaa", "external_ref": "https://linear.app/keiracom/issue/KEI-18"},
+        {"id": "Agency_OS-bbb", "external_ref": "https://linear.app/keiracom/issue/KEI-18"},
+    ]
+    index = mod._build_url_to_bd_id(issues)
+    assert sorted(index["https://linear.app/keiracom/issue/KEI-18"]) == [
+        "Agency_OS-aaa",
+        "Agency_OS-bbb",
+    ]
+
+
+def test_plan_matched_simple_pairing(mod) -> None:
+    rows = [("KEI-227", "https://linear.app/keiracom/issue/KEI-227/atlas-k1-foo")]
+    url_to_ids = {"https://linear.app/keiracom/issue/KEI-227": ["Agency_OS-8c67"]}
+    plan = mod.plan_backfill(_FakeConn(rows), url_to_ids)
+    assert plan["matched"] == [("KEI-227", "Agency_OS-8c67", rows[0][1])]
+    assert plan["ambiguous"] == []
+    assert plan["unmatched"] == []
+
+
+def test_plan_ambiguous_bd_side_multi(mod) -> None:
+    rows = [("KEI-18", "https://linear.app/keiracom/issue/KEI-18")]
+    url_to_ids = {
+        "https://linear.app/keiracom/issue/KEI-18": ["Agency_OS-58f", "Agency_OS-jny867"],
+    }
+    plan = mod.plan_backfill(_FakeConn(rows), url_to_ids)
+    assert plan["matched"] == []
+    assert plan["ambiguous"][0][0] == "KEI-18"
+    assert sorted(plan["ambiguous"][0][1]) == ["Agency_OS-58f", "Agency_OS-jny867"]
+
+
+def test_plan_ambiguous_url_strip_collision(mod) -> None:
+    """KEI-54 and KEI-54B both strip-match to /issue/KEI-54 → second is ambiguous."""
+    rows = [
+        ("KEI-54", "https://linear.app/keiracom/issue/KEI-54"),
+        ("KEI-54B", "https://linear.app/keiracom/issue/KEI-54/kei-52-tool-call-log-export"),
+    ]
+    url_to_ids = {"https://linear.app/keiracom/issue/KEI-54": ["Agency_OS-r1krve"]}
+    plan = mod.plan_backfill(_FakeConn(rows), url_to_ids)
+    assert plan["matched"] == [("KEI-54", "Agency_OS-r1krve", rows[0][1])]
+    assert plan["ambiguous"][0][0] == "KEI-54B"
+    assert "already claimed by KEI-54" in plan["ambiguous"][0][2]
+
+
+def test_plan_unmatched_no_bd_pair(mod) -> None:
+    rows = [("KEI-999", "https://linear.app/keiracom/issue/KEI-999")]
+    url_to_ids: dict[str, list[str]] = {}
+    plan = mod.plan_backfill(_FakeConn(rows), url_to_ids)
+    assert plan["unmatched"] == [("KEI-999", rows[0][1])]
+
+
+def test_apply_writes_each_match(mod) -> None:
+    matched = [
+        ("KEI-227", "Agency_OS-8c67", "https://linear.app/keiracom/issue/KEI-227"),
+        ("KEI-228", "Agency_OS-tfsl", "https://linear.app/keiracom/issue/KEI-228"),
+    ]
+    conn = _FakeConn(rows=[])
+    written = mod.apply_backfill(conn, matched)
+    assert written == 2
+    assert conn.committed is True
+    updates = [e for e in conn._cur.executed if "UPDATE" in e[0]]
+    assert len(updates) == 2
+    # Verify the params order: (bd_id, task_id)
+    assert updates[0][1][0] == "Agency_OS-8c67"
+    assert updates[0][1][1] == "KEI-227"

--- a/tests/scripts/test_tasks_cli.py
+++ b/tests/scripts/test_tasks_cli.py
@@ -275,7 +275,8 @@ def test_claim_targeted_id(mod, patch_connect, capsys, monkeypatch) -> None:
     assert out["id"] == "KEI-39"
     assert out["claimed_by"] == "scout"
     update = _find_executed(cur, lambda s: "UPDATE public.tasks" in s and "claimed_by" in s)
-    assert update is not None and update[1] == ("scout", "KEI-39", "scout")
+    # KEI-227: WHERE (id = %s OR bd_id = %s) — args.id passed twice for the OR clause.
+    assert update is not None and update[1] == ("scout", "KEI-39", "KEI-39", "scout")
 
 
 def test_claim_next_available_uses_skip_locked(mod, patch_connect, monkeypatch) -> None:
@@ -599,7 +600,8 @@ def test_complete_force_mode_passes_force_sentinel(mod, patch_connect, monkeypat
     patch_connect(cur)
     mod.main(["complete", "KEI-39", "--force-mode", "force"])
     update = _find_executed(cur, lambda s: "UPDATE public.tasks" in s and "status = 'done'" in s)
-    assert update is not None and update[1] == ("KEI-39", "scout", "force")
+    # KEI-227: WHERE (id = %s OR bd_id = %s) — task_id passed twice for the OR clause.
+    assert update is not None and update[1] == ("KEI-39", "KEI-39", "scout", "force")
 
 
 # ─── KEI-105: heartbeat command ─────────────────────────────────────────────
@@ -619,7 +621,8 @@ def test_heartbeat_updates_when_claimed_by_caller(mod, patch_connect, capsys, mo
         cur, lambda s: "heartbeat_at = NOW()" in s and "UPDATE public.tasks" in s
     )
     assert update is not None
-    assert update[1] == ("KEI-39", "scout")
+    # KEI-227: WHERE (id = %s OR bd_id = %s) — args.id passed twice for the OR clause.
+    assert update[1] == ("KEI-39", "KEI-39", "scout")
 
 
 def test_heartbeat_returns_null_when_not_claimed_by_caller(


### PR DESCRIPTION
Re-opened after auto-close from stacked-PR collapse on K1 merge. Identical content to closed PR #1072. Squash merge against current main collapses correctly since K1 already landed.