### PR TITLE
[ATLAS] fix(kei233): reconciler field-drift + orchestrator Linear-overwrite safety guard

### DIFF
--- a/scripts/orchestrator/sync_orchestrator.py
+++ b/scripts/orchestrator/sync_orchestrator.py
@@ -204,6 +204,18 @@ def _dispatch_linear(event: dict[str, Any]) -> None:
 
 
 def _event_to_linear_state(event: dict[str, Any]) -> str | None:
+    """Map an event to the target Linear state name.
+
+    KEI-233 safety guard: `update` events that carry `status='available'`
+    are NOT propagated to Linear. Postgres and bd-Dolt both default new
+    rows to `available` — propagating that back as `todo` silently
+    downgrades any Linear issue currently in `Done` / `Canceled` / `In
+    Progress` to the canonical-but-wrong `Todo` state. Linear is the
+    human board; only confident, terminal-direction transitions
+    (`close` → `done`, explicit `update` to `active`/`done`) propagate.
+    Anything ambiguous is dropped (returns None) so we never overwrite
+    Linear with a lower-confidence value.
+    """
     et = event["event_type"]
     if et == "close":
         return "done"
@@ -211,7 +223,8 @@ def _event_to_linear_state(event: dict[str, Any]) -> str | None:
         return "active"
     if et == "update":
         status = event["payload"].get("status")
-        return {"available": "todo", "active": "active", "done": "done"}.get(status)
+        # `available` deliberately excluded — see safety-guard comment above.
+        return {"active": "active", "done": "done"}.get(status)
     return None
 
 

--- a/scripts/reconcile_three_stores.py
+++ b/scripts/reconcile_three_stores.py
@@ -63,8 +63,11 @@ def _bd_bin() -> str:
 
 def _fetch_linear_issues(api_key: str, team_id: str) -> list[dict[str, Any]]:
     """Paginate through all Linear issues for the team."""
+    # KEI-233: Linear schema changed — team.id filter now requires ID! not String!.
+    # Old `$teamId: String!` was accepted historically; current Linear validates
+    # strictly and returns GRAPHQL_VALIDATION_FAILED on a mismatch.
     query = """
-    query($teamId: String!, $after: String) {
+    query($teamId: ID!, $after: String) {
       issues(filter: { team: { id: { eq: $teamId } } }, first: 100, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes { identifier title priority url state { type name } }
@@ -179,13 +182,46 @@ def build_join_table(
     return table
 
 
+def _linear_canonical_status(linear_iss: dict[str, Any]) -> str | None:
+    """Return the Postgres-shaped status mapped from Linear state, or None."""
+    state_type = (linear_iss.get("state") or {}).get("type") or ""
+    return LINEAR_STATE_TO_TASK_STATUS.get(state_type)
+
+
+def _has_field_drift(entry: dict[str, Any]) -> bool:
+    """True if a KEI present in all 3 stores has a stale Postgres status.
+
+    Treats Linear as canonical. Postgres-only buckets (`dismissed`, `blocked`)
+    have no Linear equivalent — never flagged as drift. Postgres `done` /
+    `cancelled` are sticky (matches the orchestrator's done-preservation
+    invariant in `_dispatch_postgres`); never re-opened automatically here.
+    """
+    stores = entry["stores"]
+    linear_iss = stores.get("linear") or {}
+    pg_row = stores.get("postgres") or {}
+    canonical = _linear_canonical_status(linear_iss)
+    if canonical is None:
+        return False
+    actual = pg_row.get("status")
+    if actual in ("dismissed", "blocked"):
+        return False
+    if actual in ("done", "cancelled"):
+        return False
+    # NULL pg.status counts as drift — the row exists but has no status set,
+    # so propagating Linear's canonical value is strictly an improvement.
+    return actual != canonical
+
+
 def detect_drift(table: dict[str, dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
-    """Classify each KEI into one of four buckets."""
+    """Classify each KEI into one of five buckets — four presence buckets plus
+    `field_drift` for KEIs present in all three stores but with a stale
+    Postgres status vs Linear (KEI-233)."""
     out: dict[str, list[dict[str, Any]]] = {
         "in_all_three": [],
         "missing_postgres": [],
         "missing_bd": [],
         "missing_linear": [],
+        "field_drift": [],
     }
     for kei, stores in table.items():
         # `is not None` (not truthiness) — an empty dict {} from a row with
@@ -194,6 +230,8 @@ def detect_drift(table: dict[str, dict[str, Any]]) -> dict[str, list[dict[str, A
         entry = {"kei": kei, "stores": stores}
         if has == {"linear", "postgres", "bd"}:
             out["in_all_three"].append(entry)
+            if _has_field_drift(entry):
+                out["field_drift"].append(entry)
         elif "postgres" not in has:
             out["missing_postgres"].append(entry)
         elif "bd" not in has:
@@ -259,6 +297,15 @@ def _emit_events(conn: Any, drift: dict[str, list[dict[str, Any]]]) -> int:
                 (origin, "create", entry["kei"], payload["bd_id"], json.dumps(payload)),
             )
             emitted += 1
+        # KEI-233 — field-drift bucket: Linear is canonical; orchestrator
+        # dispatches the corrected status to Postgres + bd via origin=linear.
+        for entry in drift["field_drift"]:
+            payload = _build_create_payload(entry["kei"], entry["stores"])
+            cur.execute(
+                "SELECT public.fn_emit_sync_event(%s, %s, %s, %s, %s::jsonb)",
+                ("linear", "update", entry["kei"], payload["bd_id"], json.dumps(payload)),
+            )
+            emitted += 1
     conn.commit()
     return emitted
 
@@ -268,13 +315,21 @@ def _print_summary(drift: dict[str, list[dict[str, Any]]], emitted: int | None) 
     print(f"missing_postgres:{len(drift['missing_postgres'])}")
     print(f"missing_bd:      {len(drift['missing_bd'])}")
     print(f"missing_linear:  {len(drift['missing_linear'])}")
+    print(f"field_drift:     {len(drift.get('field_drift', []))}")
     if emitted is not None:
         print(f"events_emitted:  {emitted}")
-    for bucket in ("missing_postgres", "missing_bd", "missing_linear"):
-        if drift[bucket]:
+    for bucket in ("missing_postgres", "missing_bd", "missing_linear", "field_drift"):
+        if drift.get(bucket):
             print(f"\n{bucket} (first 5):")
             for entry in drift[bucket][:5]:
-                print(f"  {entry['kei']}")
+                if bucket == "field_drift":
+                    l = entry["stores"].get("linear") or {}
+                    p = entry["stores"].get("postgres") or {}
+                    print(
+                        f"  {entry['kei']} linear={(l.get('state') or {}).get('type', '?')} pg_status={p.get('status')}"
+                    )
+                else:
+                    print(f"  {entry['kei']}")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/scripts/test_reconcile_three_stores.py
+++ b/tests/scripts/test_reconcile_three_stores.py
@@ -142,6 +142,108 @@ def test_detect_drift_missing_linear(mod) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Field drift (KEI-233).
+# ---------------------------------------------------------------------------
+
+
+def test_field_drift_linear_completed_pg_available(mod) -> None:
+    """Linear says completed, Postgres says available → flagged as field_drift."""
+    table = {
+        "KEI-1": {
+            "linear": {"state": {"type": "completed"}},
+            "postgres": {"status": "available"},
+            "bd": {"id": "Agency_OS-aaa"},
+        }
+    }
+    drift = mod.detect_drift(table)
+    assert len(drift["field_drift"]) == 1
+    assert drift["field_drift"][0]["kei"] == "KEI-1"
+    # Also still appears in in_all_three — those buckets overlap.
+    assert len(drift["in_all_three"]) == 1
+
+
+def test_field_drift_skipped_when_status_already_matches(mod) -> None:
+    """Linear=completed → expected status='done'; Postgres=done → no drift."""
+    table = {
+        "KEI-2": {
+            "linear": {"state": {"type": "completed"}},
+            "postgres": {"status": "done"},
+            "bd": {"id": "Agency_OS-bbb"},
+        }
+    }
+    drift = mod.detect_drift(table)
+    assert drift["field_drift"] == []
+
+
+def test_field_drift_done_pg_is_sticky_even_if_linear_reopened(mod) -> None:
+    """Postgres `done` is preserved — orchestrator never re-opens done rows."""
+    table = {
+        "KEI-3": {
+            "linear": {"state": {"type": "started"}},
+            "postgres": {"status": "done"},
+            "bd": {"id": "Agency_OS-ccc"},
+        }
+    }
+    drift = mod.detect_drift(table)
+    assert drift["field_drift"] == []
+
+
+def test_field_drift_skips_postgres_only_buckets(mod) -> None:
+    """Postgres `dismissed` / `blocked` have no Linear equivalent — not drift."""
+    for status in ("dismissed", "blocked"):
+        table = {
+            "KEI-x": {
+                "linear": {"state": {"type": "completed"}},
+                "postgres": {"status": status},
+                "bd": {"id": "Agency_OS-x"},
+            }
+        }
+        drift = mod.detect_drift(table)
+        assert drift["field_drift"] == [], f"unexpected drift on pg={status}"
+
+
+def test_field_drift_null_pg_status_counts(mod) -> None:
+    """NULL pg.status with a canonical Linear value IS drift — propagate Linear."""
+    table = {
+        "KEI-4": {
+            "linear": {"state": {"type": "backlog"}},
+            "postgres": {"status": None},
+            "bd": {"id": "Agency_OS-ddd"},
+        }
+    }
+    drift = mod.detect_drift(table)
+    assert len(drift["field_drift"]) == 1
+    assert drift["field_drift"][0]["kei"] == "KEI-4"
+
+
+def test_field_drift_unmapped_linear_state_skipped(mod) -> None:
+    """If Linear state.type is not in our mapping, we can't decide canonical."""
+    table = {
+        "KEI-5": {
+            "linear": {"state": {"type": "weird-unknown"}},
+            "postgres": {"status": "available"},
+            "bd": {"id": "Agency_OS-eee"},
+        }
+    }
+    drift = mod.detect_drift(table)
+    assert drift["field_drift"] == []
+
+
+def test_field_drift_only_evaluated_for_in_all_three(mod) -> None:
+    """A KEI missing from a store is NOT also flagged as field_drift."""
+    table = {
+        "KEI-6": {
+            "linear": {"state": {"type": "completed"}},
+            "postgres": {"status": "available"},
+            # bd missing
+        }
+    }
+    drift = mod.detect_drift(table)
+    assert drift["field_drift"] == []
+    assert len(drift["missing_bd"]) == 1
+
+
+# ---------------------------------------------------------------------------
 # Payload construction.
 # ---------------------------------------------------------------------------
 

--- a/tests/scripts/test_sync_orchestrator.py
+++ b/tests/scripts/test_sync_orchestrator.py
@@ -245,6 +245,19 @@ def test_linear_event_to_state_update_uses_payload_status() -> None:
         so._event_to_linear_state(_event(event_type="update", payload={"status": "active"}))
         == "active"
     )
+    assert (
+        so._event_to_linear_state(_event(event_type="update", payload={"status": "done"})) == "done"
+    )
+
+
+def test_linear_event_to_state_update_available_returns_none(monkeypatch) -> None:
+    """KEI-233 safety guard: 'available' is the Postgres/bd default — never
+    propagate back to Linear, otherwise we silently downgrade Linear's
+    Done/Canceled/In Progress issues to Todo."""
+    assert (
+        so._event_to_linear_state(_event(event_type="update", payload={"status": "available"}))
+        is None
+    )
 
 
 def test_linear_event_to_state_unmapped_returns_none() -> None:


### PR DESCRIPTION
## Summary

Two coupled fixes — both required for Linear↔Postgres sync to be safe — plus an urgent stop-the-bleeding action.

## ⚠️ Operational state (read first)

**`sync-orchestrator.service` was STOPPED + DISABLED before this commit** to prevent ongoing Linear-state damage discovered during verification. After merge, the operator should re-enable it.

**~45 Linear KEIs were silently downgraded to Todo** during the diagnostic window because of a latent bug in K3 (the orchestrator). This PR fixes the bug; a separate follow-up KEI is needed to restore the original Linear states from Linear's `Issue.history` field.

## Changes

| File | Purpose |
|---|---|
| `scripts/reconcile_three_stores.py` | Adds `field_drift` bucket + Linear GraphQL `$teamId: ID!` schema fix |
| `scripts/orchestrator/sync_orchestrator.py` | Drops `available` from `_event_to_linear_state` update-mapping |
| `tests/scripts/test_reconcile_three_stores.py` | +7 tests for field_drift cases |
| `tests/scripts/test_sync_orchestrator.py` | +1 test for the `available`-guard |

## Why three things in one PR

1. **Field-drift detection** — was the planned K4-followup. Caught the issue.
2. **GraphQL fix** — discovered during live dry-run; reconciler was completely broken since Linear's schema change. Tests mocked HTTP so missed it.
3. **Linear-overwrite guard** — discovered while verifying #1; immediate orchestrator hazard. Cannot ship #1 without #3 because re-enabling reconciler with the bug live would just re-trigger the downgrade cycle.

## Verbatim verification

**Live reconciler dry-run (post-fix, with `--dry-run`):**
```
INFO:   → 233 Linear issues
INFO:   → 258 postgres tasks
INFO:   → 336 bd issues
in_all_three:    232
missing_postgres:1     (KEI-233 — just-filed, not yet propagated)
missing_bd:      1     (KEI-54B — known unpaired sub-issue)
missing_linear:  1     (KEI-TEST)
field_drift:     1     (KEI-227 — has NULL status)
```

**Tests:**
```
$ pytest tests/scripts/test_reconcile_three_stores.py tests/scripts/test_sync_orchestrator.py
============================== 40 passed in 0.28s ==============================
```

**Lint:**
```
$ ruff check scripts/reconcile_three_stores.py scripts/orchestrator/sync_orchestrator.py tests/scripts/*
All checks passed!
$ ruff format --check ...
4 files already formatted
```

## Test plan

- [x] Field-drift detection: 7 new tests cover Linear-completed/pg-available, pg-done sticky, postgres-only buckets skipped, NULL pg-status, unmapped Linear state, all-three-only evaluation
- [x] Orchestrator safety guard: 1 new test asserts `event_to_linear_state(update, status=available) == None`
- [x] Live reconciler dry-run against production state (verbatim above)
- [x] No regressions in existing 32 sync tests
- [ ] **Dual approve / Dave-authorised single-merge**
- [ ] **Post-merge**: operator restarts + re-enables `sync-orchestrator.service`
- [ ] **Post-merge**: file follow-up KEI for Linear state restoration from `Issue.history`

## Damage assessment (for the follow-up KEI)

During the ~30-minute window the orchestrator ran with the buggy `_event_to_linear_state`, it propagated Postgres `available` status to Linear for every `update` event it dispatched. Issues whose Linear state was `Done`, `Canceled`, or `In Progress` had `Authorization: linearapi` → `issueUpdate(state: <todo>)` calls fired. **Restoration via Linear's `Issue.history` is possible** — that field exposes every state change with a timestamp and the actor (`AgentSession` vs human). A restoration script can pick the most-recent non-Atlas-actor state and replay it.

## Related

- Closes `Agency_OS-p8rg` (bd) / Linear KEI-233
- Depends on PRs #1071, #1077, #1078, #1079 (K1–K4, all merged)
- **Blocks** restoration follow-up KEI (to be filed after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)