### PR TITLE
[ATLAS] fix(kei235-followup): Linear canceled→Postgres dismissed + broaden orchestrator exception catching

### DIFF
--- a/scripts/orchestrator/sync_orchestrator.py
+++ b/scripts/orchestrator/sync_orchestrator.py
@@ -88,10 +88,16 @@ def _dispatch_postgres(conn: Any, event: dict[str, Any]) -> None:
     bd_id = event.get("bd_id") or payload.get("bd_id")
     title = payload.get("title") or "(no title)"
     status = payload.get("status")
+    # KEI-235-followup: coerce 'cancelled' → 'dismissed' to match the
+    # tasks_status_check CHECK constraint. Pre-fix events emitted by the
+    # reconciler still carry the old payload.status='cancelled'; without
+    # this coercion they'd hit a CheckViolation forever.
+    if status == "cancelled":
+        status = "dismissed"
     priority = payload.get("priority")
     linear_url = payload.get("linear_url")
     with conn.cursor() as cur:
-        if status in ("done", "cancelled"):
+        if status in ("done", "dismissed"):
             _ensure_sync_verification(cur, task_id, status, event)
         cur.execute(
             """
@@ -332,12 +338,23 @@ def _process_event(conn: Any, event: dict[str, Any]) -> bool:
                 sp_cur.execute(f"ROLLBACK TO SAVEPOINT {sp}")
             errors.append(f"{target}: {exc}")
             logger.warning("[%s/%s] %s", event["task_id"], target, exc)
-        except psycopg.errors.RaiseException as exc:
+        except (
+            psycopg.errors.RaiseException,
+            psycopg.errors.IntegrityError,
+            psycopg.errors.DataError,
+        ) as exc:
+            # Governance trigger raise OR constraint violation (check / FK /
+            # unique / not-null / data type). All fall under "this write
+            # was refused by Postgres" — roll back just this savepoint,
+            # let the batch continue, and let MAX_ATTEMPTS retry decide
+            # whether to abandon. KEI-235-followup broadened from
+            # RaiseException-only after CheckViolation on 'cancelled'
+            # froze the batch.
             with conn.cursor() as sp_cur:
                 sp_cur.execute(f"ROLLBACK TO SAVEPOINT {sp}")
-            errors.append(f"{target}: trigger-blocked: {str(exc).splitlines()[0][:160]}")
+            errors.append(f"{target}: db-refused: {str(exc).splitlines()[0][:160]}")
             logger.warning(
-                "[%s/%s] trigger blocked: %s",
+                "[%s/%s] db-refused: %s",
                 event["task_id"],
                 target,
                 str(exc).splitlines()[0][:200],

--- a/scripts/reconcile_three_stores.py
+++ b/scripts/reconcile_three_stores.py
@@ -34,14 +34,19 @@ _LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
 _LINEAR_TEAM_ID_DEFAULT = "4686528f-ce77-4c2f-968b-3dc76b34d6fe"  # Keiracom
 _BD_BIN_DEFAULT = os.path.expanduser("~/.local/bin/bd")
 
-# Linear StateType → public.tasks.status (mirrors webhook mapping).
+# Linear StateType → public.tasks.status. Mirrors webhook mapping.
+# KEI-235-followup: Postgres tasks_status_check CHECK constraint allows
+# (available, active, pending_review, ready_for_execution, done, blocked,
+# dismissed) — NOT 'cancelled'. Linear's `canceled` therefore maps to
+# Postgres `dismissed`. CheckViolations on the old (canceled→cancelled)
+# mapping froze ~30 sync events 2026-05-19 14:42 UTC.
 LINEAR_STATE_TO_TASK_STATUS: dict[str, str] = {
     "backlog": "available",
     "unstarted": "available",
     "triage": "available",
     "started": "active",
     "completed": "done",
-    "canceled": "cancelled",
+    "canceled": "dismissed",
 }
 
 

--- a/src/api/webhooks/linear.py
+++ b/src/api/webhooks/linear.py
@@ -76,7 +76,9 @@ LINEAR_STATE_TO_TASK_STATUS: dict[str, str] = {
     "triage": "available",
     "started": "active",
     "completed": "done",
-    "canceled": "cancelled",
+    # KEI-235-followup: tasks_status_check rejects 'cancelled' — Linear canceled
+    # maps to Postgres 'dismissed' (matches the constraint's allowed values).
+    "canceled": "dismissed",
 }
 
 _BD_WRAPPER = "/home/elliotbot/clawd/Agency_OS/scripts/linear_to_bd.py"

--- a/tests/scripts/test_sync_orchestrator.py
+++ b/tests/scripts/test_sync_orchestrator.py
@@ -335,6 +335,40 @@ def test_process_event_rolls_back_on_trigger_block(monkeypatch) -> None:
     assert "ROLLBACK TO SAVEPOINT" in all_sql
 
 
+def test_process_event_rolls_back_on_check_violation(monkeypatch) -> None:
+    """KEI-235-followup — CheckViolation (e.g. status='cancelled' rejected
+    by tasks_status_check) must also roll back savepoint and let batch
+    continue, not crash the worker."""
+    import psycopg.errors
+
+    event = _event(id="evt-2", origin="bd")
+    conn = _FakeConn()
+    monkeypatch.setattr(
+        so,
+        "_dispatch_postgres",
+        lambda c, e: (_ for _ in ()).throw(
+            psycopg.errors.CheckViolation('new row violates check constraint "tasks_status_check"')
+        ),
+    )
+    monkeypatch.setattr(so, "_dispatch_bd", lambda e: None)
+    monkeypatch.setattr(so, "_dispatch_linear", lambda e: None)
+    ok = so._process_event(conn, event)
+    assert ok is False  # treated same as DispatchError — batch survives
+
+
+def test_dispatch_postgres_coerces_cancelled_to_dismissed(monkeypatch) -> None:
+    """Pre-fix events with payload.status='cancelled' get coerced to
+    'dismissed' so the CHECK constraint doesn't reject them. The synthetic
+    verification also fires since 'dismissed' is now a terminal transition."""
+    event = _event(event_type="close", payload={"status": "cancelled", "bd_id": "Agency_OS-x"})
+    conn = _FakeConn()
+    so._dispatch_postgres(conn, event)
+    all_params = [params for c in conn._cursors for _, params in c.executed]
+    # The tasks UPSERT params: (task_id, bd_id, title, status, priority, linear_url)
+    upsert_params = [p for p in all_params if "dismissed" in str(p)]
+    assert upsert_params, "expected coerced status='dismissed' in tasks upsert"
+
+
 # ---------------------------------------------------------------------------
 # Postgres status → bd mapping.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two-part fix surfaced after KEI-235 (PR #1082) deploy hit a new error: `CheckViolation on tasks_status_check` rejecting `status='cancelled'`.

**1. Linear `canceled` mapping change**
Postgres `tasks_status_check` allows `(available, active, pending_review, ready_for_execution, done, blocked, dismissed)` — **NOT `cancelled`**. The mapping in `reconcile_three_stores.py` + `webhooks/linear.py` used `"canceled" → "cancelled"`, which CheckViolated every Linear-canceled issue. Switched to `"canceled" → "dismissed"` (semantically equivalent, constraint-compliant). Plus a coercion guard in `_dispatch_postgres` for pre-fix events still carrying `cancelled` in payload.

**2. Broader exception catching in `_process_event`**
KEI-235 caught `RaiseException` (governance triggers) but not `IntegrityError` / `DataError`. One CheckViolation still poisoned the batch. Now catches `(RaiseException, IntegrityError, DataError)` — savepoint rolls back, batch survives. `OperationalError` still propagates so real DB outages crash the worker for systemd restart.

## Verbatim live verification

```
2026-05-19 14:46:42 INFO batch {'selected': 20, 'processed': 20, 'failed': 0, 'abandoned': 0}
```

Same batch shape that previously hit CheckViolation now processes cleanly.

## Tests

```
$ pytest tests/scripts/test_sync_orchestrator.py
============================== 26 passed in 0.21s ==============================
```

2 new tests:
- `test_process_event_rolls_back_on_check_violation`
- `test_dispatch_postgres_coerces_cancelled_to_dismissed`

## Lint

```
$ ruff check + format --check  → All checks passed!
```

## Test plan

- [x] Live drain: batch of 20 events including formerly-failing Linear-canceled KEIs processes cleanly (verbatim above)
- [x] 26 unit tests pass (2 new)
- [x] Lint clean
- [ ] **Dual-approve / Dave-authorised single-merge**

## Related

- Completes KEI-235's intent (this is a same-day followup, not a separate Linear KEI)
- Companion PR: #1082 (KEI-235 — synthetic verification + savepoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)