### PR TITLE
[ATLAS] feat(kei236): lock Linear to read-only mirror — orchestrator only pushes postgres-origin terminal transitions

### DIFF
--- a/scripts/orchestrator/sync_orchestrator.py
+++ b/scripts/orchestrator/sync_orchestrator.py
@@ -274,25 +274,26 @@ def _dispatch_linear(event: dict[str, Any]) -> None:
 def _event_to_linear_state(event: dict[str, Any]) -> str | None:
     """Map an event to the target Linear state name.
 
-    KEI-233 safety guard: `update` events that carry `status='available'`
-    are NOT propagated to Linear. Postgres and bd-Dolt both default new
-    rows to `available` — propagating that back as `todo` silently
-    downgrades any Linear issue currently in `Done` / `Canceled` / `In
-    Progress` to the canonical-but-wrong `Todo` state. Linear is the
-    human board; only confident, terminal-direction transitions
-    (`close` → `done`, explicit `update` to `active`/`done`) propagate.
-    Anything ambiguous is dropped (returns None) so we never overwrite
-    Linear with a lower-confidence value.
+    KEI-236 policy lock (Dave 2026-05-19): Postgres is canonical, bd is the
+    agent CLI, Linear is a one-way visibility mirror. Only Postgres-origin
+    terminal transitions (close / reopen) propagate to Linear. Everything
+    else returns None so the orchestrator never overwrites Linear from a
+    non-canonical source.
+
+    Combined with the prior KEI-233 guard (no `available` → todo), this
+    pins the orchestrator to:
+      - bd-origin events: never go to Linear
+      - linear-origin events: never round-trip to Linear (origin-tag
+        loop prevention also blocks this in _process_event)
+      - postgres-origin events: ONLY when event_type ∈ {close, reopen}
     """
+    if event.get("origin") != "postgres":
+        return None
     et = event["event_type"]
     if et == "close":
         return "done"
     if et == "reopen":
         return "active"
-    if et == "update":
-        status = event["payload"].get("status")
-        # `available` deliberately excluded — see safety-guard comment above.
-        return {"active": "active", "done": "done"}.get(status)
     return None
 
 

--- a/tests/scripts/test_sync_orchestrator.py
+++ b/tests/scripts/test_sync_orchestrator.py
@@ -237,35 +237,43 @@ def test_linear_dispatch_missing_state_id_raises(monkeypatch) -> None:
 
 
 def test_linear_event_to_state_close_returns_done() -> None:
-    assert so._event_to_linear_state(_event(event_type="close")) == "done"
+    # KEI-236: only postgres-origin close propagates to Linear.
+    assert so._event_to_linear_state(_event(event_type="close", origin="postgres")) == "done"
 
 
 def test_linear_event_to_state_reopen_returns_active() -> None:
-    assert so._event_to_linear_state(_event(event_type="reopen")) == "active"
+    # KEI-236: only postgres-origin reopen propagates to Linear.
+    assert so._event_to_linear_state(_event(event_type="reopen", origin="postgres")) == "active"
 
 
-def test_linear_event_to_state_update_uses_payload_status() -> None:
-    assert (
-        so._event_to_linear_state(_event(event_type="update", payload={"status": "active"}))
-        == "active"
-    )
-    assert (
-        so._event_to_linear_state(_event(event_type="update", payload={"status": "done"})) == "done"
-    )
+def test_linear_event_to_state_update_returns_none_under_kei236() -> None:
+    """KEI-236: `update` events NEVER propagate to Linear regardless of
+    payload.status. Linear is a one-way mirror — only terminal transitions
+    (close/reopen) flow Postgres→Linear."""
+    for status in ("active", "done", "available", "dismissed"):
+        assert (
+            so._event_to_linear_state(
+                _event(event_type="update", origin="postgres", payload={"status": status})
+            )
+            is None
+        ), f"update with status={status} should return None under KEI-236"
 
 
-def test_linear_event_to_state_update_available_returns_none(monkeypatch) -> None:
-    """KEI-233 safety guard: 'available' is the Postgres/bd default — never
-    propagate back to Linear, otherwise we silently downgrade Linear's
-    Done/Canceled/In Progress issues to Todo."""
-    assert (
-        so._event_to_linear_state(_event(event_type="update", payload={"status": "available"}))
-        is None
-    )
+def test_linear_event_to_state_bd_origin_returns_none() -> None:
+    """KEI-236: bd-origin events never reach Linear (orchestrator one-way push)."""
+    for et in ("close", "reopen", "update"):
+        assert so._event_to_linear_state(_event(event_type=et, origin="bd")) is None
+
+
+def test_linear_event_to_state_linear_origin_returns_none() -> None:
+    """KEI-236: linear-origin events never round-trip to Linear (also
+    enforced by origin-tag loop prevention in _process_event)."""
+    for et in ("close", "reopen", "update"):
+        assert so._event_to_linear_state(_event(event_type=et, origin="linear")) is None
 
 
 def test_linear_event_to_state_unmapped_returns_none() -> None:
-    assert so._event_to_linear_state(_event(event_type="title_change")) is None
+    assert so._event_to_linear_state(_event(event_type="title_change", origin="postgres")) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Dave directive 2026-05-19: **bd is the agent CLI. Postgres is the source of truth. Linear is a one-way visibility mirror.**

This PR implements the orchestrator-side lock — `_event_to_linear_state` refuses anything that isn't a canonical Postgres terminal transition.

## Change

`_event_to_linear_state` now:
- Returns `None` if `event.origin != 'postgres'` (refuse bd-origin and linear-origin events — no reverse propagation possible)
- Returns `None` for `event_type='update'` regardless of payload.status (Linear doesn't need mid-flight status churn)
- Only maps `close` → `done`, `reopen` → `active` when `origin=postgres`

Combined with the KEI-233 `available`-guard and KEI-235 verification handling, the bug class that downgraded 59 KEIs earlier today is now **structurally impossible** — no non-canonical source can reach Linear.

## Tests

```
$ pytest tests/scripts/test_sync_orchestrator.py
============================== 27 passed in 0.20s ==============================
```

Updated existing close/reopen tests to explicitly assert `origin=postgres`. 3 new tests:
- `test_linear_event_to_state_bd_origin_returns_none` — bd-origin events never reach Linear
- `test_linear_event_to_state_linear_origin_returns_none` — linear-origin events never round-trip
- `test_linear_event_to_state_update_returns_none_under_kei236` — `update` events never propagate (all status values)

## Lint

```
$ ruff check + format --check  → All checks passed!
```

## Live verification

Deployed to Elliot's worktree; orchestrator restarted; no Linear API calls fire for any non-postgres-origin event in subsequent batches.

## Test plan

- [x] 27 unit tests pass (3 new for KEI-236, 4 existing updated)
- [x] Lint clean
- [x] Live: orchestrator restart with KEI-236 code in place; sub-batch confirms no Linear-write for bd-origin events
- [ ] **Dual-approve / Dave-authorised single-merge**

## Closes

- Agency_OS-kq6k (bd)
- Linear KEI-236

## Series

This is 2/5 in the Dave 2026-05-19 policy series (KEI-235 → KEI-239). Next: KEI-237 (reconciler field_drift direction flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)