### PR TITLE
[ATLAS] feat(kei237): reconciler field_drift emits origin=postgres (Linear-as-mirror)

### DIFF
--- a/scripts/reconcile_three_stores.py
+++ b/scripts/reconcile_three_stores.py
@@ -247,7 +247,12 @@ def detect_drift(table: dict[str, dict[str, Any]]) -> dict[str, list[dict[str, A
 
 
 def _build_create_payload(kei: str, stores: dict[str, Any]) -> dict[str, Any]:
-    """Pick the canonical record from whichever stores have it."""
+    """Pick the canonical record from whichever stores have it.
+
+    Used for the `missing_*` buckets where the store-being-backfilled has
+    no row yet — Linear is preferred as the seed because it's where Dave
+    creates KEIs (title/priority/intent live there first).
+    """
     linear_iss = stores.get("linear") or {}
     bd_iss = stores.get("bd") or {}
     pg_row = stores.get("postgres") or {}
@@ -269,6 +274,32 @@ def _build_create_payload(kei: str, stores: dict[str, Any]) -> dict[str, Any]:
         "status": status,
         "priority": priority,
         "linear_url": url,
+    }
+
+
+def _build_postgres_payload(kei: str, stores: dict[str, Any]) -> dict[str, Any]:
+    """KEI-237 — build payload from Postgres-as-canonical for field_drift events.
+
+    Under the Dave 2026-05-19 policy (bd=CLI, Postgres=canonical,
+    Linear=mirror), field-level drift between Postgres and another store
+    is resolved by propagating Postgres's value OUT, never the reverse.
+    The orchestrator's `_dispatch_linear` (per KEI-236) only writes
+    Linear on terminal `close`/`reopen` transitions, so `update` events
+    from this path effectively only correct bd-Dolt — Linear stays
+    where it is until a real terminal transition flows from Postgres.
+    """
+    bd_iss = stores.get("bd") or {}
+    pg_row = stores.get("postgres") or {}
+    linear_iss = stores.get("linear") or {}
+    return {
+        "id": kei,
+        "bd_id": pg_row.get("bd_id") or bd_iss.get("id"),
+        "title": pg_row.get("title") or linear_iss.get("title") or "(no title)",
+        "status": pg_row.get("status") or "available",
+        "priority": pg_row.get("priority"),
+        "linear_url": pg_row.get("linear_url")
+        or linear_iss.get("url")
+        or f"https://linear.app/keiracom/issue/{kei}",
     }
 
 
@@ -302,13 +333,17 @@ def _emit_events(conn: Any, drift: dict[str, list[dict[str, Any]]]) -> int:
                 (origin, "create", entry["kei"], payload["bd_id"], json.dumps(payload)),
             )
             emitted += 1
-        # KEI-233 — field-drift bucket: Linear is canonical; orchestrator
-        # dispatches the corrected status to Postgres + bd via origin=linear.
+        # KEI-237 — field-drift bucket: under the new policy Postgres is
+        # canonical, so we emit origin=postgres with the Postgres-side
+        # payload. The orchestrator (KEI-236) will dispatch to bd (fixes
+        # bd-Dolt) but skip the Linear write for `update` events — Linear
+        # stays where it is until a real terminal transition flows out
+        # via `close`/`reopen` events from the trigger.
         for entry in drift["field_drift"]:
-            payload = _build_create_payload(entry["kei"], entry["stores"])
+            payload = _build_postgres_payload(entry["kei"], entry["stores"])
             cur.execute(
                 "SELECT public.fn_emit_sync_event(%s, %s, %s, %s, %s::jsonb)",
-                ("linear", "update", entry["kei"], payload["bd_id"], json.dumps(payload)),
+                ("postgres", "update", entry["kei"], payload["bd_id"], json.dumps(payload)),
             )
             emitted += 1
     conn.commit()

--- a/tests/scripts/test_reconcile_three_stores.py
+++ b/tests/scripts/test_reconcile_three_stores.py
@@ -287,3 +287,101 @@ def test_build_create_payload_default_linear_url(mod) -> None:
     assert payload["linear_url"] == "https://linear.app/keiracom/issue/KEI-11"
     assert payload["status"] == "available"
     assert payload["title"] == "(no title)"
+
+
+# ---------------------------------------------------------------------------
+# KEI-237 — postgres-canonical payload + emission flip.
+# ---------------------------------------------------------------------------
+
+
+def test_build_postgres_payload_prefers_postgres_status(mod) -> None:
+    """Under the new policy, Postgres is canonical — _build_postgres_payload
+    must return Postgres's status, NOT Linear's mapped status."""
+    stores = {
+        "linear": {
+            "title": "Linear title",
+            "state": {"type": "completed"},  # would map to 'done'
+            "priority": 1,
+            "url": "https://linear.app/keiracom/issue/KEI-9",
+        },
+        "postgres": {
+            "title": "Postgres title",
+            "status": "active",  # canonical under new policy
+            "priority": 4,
+            "bd_id": "Agency_OS-xxx",
+            "linear_url": "https://linear.app/keiracom/issue/KEI-9",
+        },
+        "bd": {"id": "Agency_OS-xxx"},
+    }
+    payload = mod._build_postgres_payload("KEI-9", stores)
+    assert payload["status"] == "active"  # Postgres wins
+    assert payload["title"] == "Postgres title"
+    assert payload["bd_id"] == "Agency_OS-xxx"
+
+
+def test_build_postgres_payload_falls_back_to_linear_url(mod) -> None:
+    """If pg.linear_url is missing, fall back to linear_iss.url, then default."""
+    stores = {
+        "postgres": {"status": "active"},
+        "linear": {"url": "https://linear.app/keiracom/issue/KEI-22/explicit-slug"},
+    }
+    payload = mod._build_postgres_payload("KEI-22", stores)
+    assert payload["linear_url"] == "https://linear.app/keiracom/issue/KEI-22/explicit-slug"
+
+
+def test_build_postgres_payload_default_status_available(mod) -> None:
+    """Missing pg.status → defaults to 'available' (KEI-237 ON CONFLICT-safe)."""
+    payload = mod._build_postgres_payload("KEI-30", {"postgres": {}})
+    assert payload["status"] == "available"
+
+
+def test_emit_events_field_drift_uses_postgres_origin(mod) -> None:
+    """KEI-237: field_drift entries emit origin='postgres' (not 'linear')."""
+
+    class _FakeCursor:
+        def __init__(self):
+            self.executed = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return None
+
+        def execute(self, sql, params=None):
+            self.executed.append((sql, params))
+
+    class _FakeConn:
+        def __init__(self):
+            self.cur = _FakeCursor()
+
+        def cursor(self):
+            return self.cur
+
+        def commit(self):
+            pass
+
+    drift = {
+        "missing_postgres": [],
+        "missing_bd": [],
+        "missing_linear": [],
+        "field_drift": [
+            {
+                "kei": "KEI-99",
+                "stores": {
+                    "linear": {"state": {"type": "completed"}},
+                    "postgres": {"status": "active", "bd_id": "Agency_OS-xx"},
+                    "bd": {"id": "Agency_OS-xx"},
+                },
+            }
+        ],
+    }
+    conn = _FakeConn()
+    emitted = mod._emit_events(conn, drift)
+    assert emitted == 1
+    sql, params = conn.cur.executed[0]
+    assert "fn_emit_sync_event" in sql
+    # params = (origin, event_type, task_id, bd_id, payload_json)
+    assert params[0] == "postgres", "field_drift must emit origin=postgres under KEI-237"
+    assert params[1] == "update"
+    assert params[2] == "KEI-99"


### PR DESCRIPTION
Completes the Linear-as-mirror policy. `_emit_events` field_drift branch now uses Postgres-canonical payload + `origin='postgres'`. Under the new policy (Dave 2026-05-19), Postgres is source of truth; Linear stays where it is on `update` events (per KEI-236) and only gets updated on canonical terminal transitions.

24/24 tests pass (4 new), ruff clean, KEI-108 N/A (no new service files).

Series 3/5 in Dave 2026-05-19 policy work. Next: KEI-238 (webhook echo skip), KEI-239 (bd complete).

Closes Linear KEI-237 + Agency_OS-hudz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)