### PR TITLE
[ATLAS] feat(kei238): Linear webhook ignores self-echo from orchestrator writes

### DIFF
--- a/scripts/sync_linear_viewer_env.py
+++ b/scripts/sync_linear_viewer_env.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""sync_linear_viewer_env.py — KEI-238 helper.
+
+Queries Linear `{ viewer { id } }` and prints `export LINEAR_VIEWER_ID=<uuid>`
+ready for paste into `~/.config/agency-os/.env`. The viewer id is the user
+uuid that the API key authenticates as — needed by the Linear webhook
+handler to recognise + skip its own echo events.
+
+Usage:
+    python3 scripts/sync_linear_viewer_env.py
+    # → export LINEAR_VIEWER_ID=f29152a3-3700-4217-a451-d6070f09de3c
+
+Exits 0 on success, 2 on missing LINEAR_API_KEY, 1 on GraphQL failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+_LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+
+
+def main() -> int:
+    api_key = os.environ.get("LINEAR_API_KEY", "")
+    if not api_key:
+        print("ERROR: LINEAR_API_KEY not set", file=sys.stderr)
+        return 2
+    body = json.dumps({"query": "{ viewer { id name email } }"}).encode()
+    req = urllib.request.Request(
+        _LINEAR_GRAPHQL_URL,
+        data=body,
+        headers={"Authorization": api_key, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            payload = json.loads(resp.read() or "null")
+    except (json.JSONDecodeError, urllib.error.URLError, OSError) as exc:
+        print(f"ERROR: viewer query failed: {exc}", file=sys.stderr)
+        return 1
+    viewer = ((payload or {}).get("data") or {}).get("viewer") or {}
+    viewer_id = viewer.get("id")
+    if not viewer_id:
+        print(f"ERROR: no viewer.id in response: {payload}", file=sys.stderr)
+        return 1
+    print(f"# Linear viewer: {viewer.get('name', '?')} <{viewer.get('email', '?')}>")
+    print(f"export LINEAR_VIEWER_ID={viewer_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/webhooks/linear.py
+++ b/src/api/webhooks/linear.py
@@ -126,7 +126,9 @@ def _normalise_event(payload: dict[str, Any]) -> dict[str, Any] | None:
         "type": "Issue" | "Comment" | "IssueRelation",
         "data": { "id": "...", "identifier": "KEI-NN", "title": "...",
                    "priority": 0..4, "state": {"name": "...", "type": "..."},
-                   "url": "https://linear.app/...", ... },
+                   "url": "https://linear.app/...",
+                   "actor": { "id": "<uuid>", ... },
+                   ... },
         "createdAt": "...",
       }
     """
@@ -142,6 +144,24 @@ def _normalise_event(payload: dict[str, Any]) -> dict[str, Any] | None:
     identifier = data.get("identifier")
     if not identifier:
         return None
+
+    # KEI-238 — defence-in-depth against the loop pattern that downgraded
+    # 59 KEIs on 2026-05-19. When the orchestrator's own `issueUpdate`
+    # calls echo back via webhook, the `data.actor.id` matches LINEAR_VIEWER_ID
+    # (the API key's user id). Skip status-changes from our own writes —
+    # they would re-emit sync_events and risk loops if KEI-236's mirror-lock
+    # were ever weakened. `create` and `remove` actions still propagate
+    # (those are intentional Dave actions even if API-driven).
+    if action == "update":
+        actor_id = (data.get("actor") or {}).get("id") or ""
+        viewer_id = os.environ.get("LINEAR_VIEWER_ID", "")
+        if viewer_id and actor_id == viewer_id:
+            logger.info(
+                "ignored_self_echo: identifier=%s actor=%s — skipping webhook handler",
+                identifier,
+                actor_id,
+            )
+            return None
 
     # KEI-100 title-guard: if title starts with KEI-N prefix, it must match identifier.
     # This catches mis-routed creates (e.g. Auto-KEI inserted a Supabase row with a

--- a/tests/api/webhooks/test_linear_webhook_kei238.py
+++ b/tests/api/webhooks/test_linear_webhook_kei238.py
@@ -1,0 +1,79 @@
+"""KEI-238 — Linear webhook ignores self-echo from orchestrator writes.
+
+When the orchestrator pushes a state change to Linear via `issueUpdate`,
+Linear echoes that change back through the webhook. The actor.id on the
+echo equals our API key's viewer.id (LINEAR_VIEWER_ID env). Without the
+echo skip, the webhook would write that state back to Postgres, risking
+the loop pattern that downgraded 59 KEIs on 2026-05-19.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.api.webhooks import linear as linear_webhook  # noqa: E402
+
+_VIEWER_ID = "f29152a3-3700-4217-a451-d6070f09de3c"
+_OTHER_ACTOR = "0000aaaa-bbbb-cccc-dddd-eeeeffff0000"
+
+
+def _payload(action: str, identifier: str, state_type: str, actor_id: str) -> dict:
+    return {
+        "action": action,
+        "type": "Issue",
+        "data": {
+            "identifier": identifier,
+            "title": "test",
+            "priority": 2,
+            "url": "https://linear.app/x",
+            "state": {"type": state_type, "name": state_type},
+            "actor": {"id": actor_id},
+        },
+    }
+
+
+def test_update_from_own_viewer_id_is_ignored(monkeypatch) -> None:
+    """KEI-238: actor.id == LINEAR_VIEWER_ID + action=update → return None."""
+    monkeypatch.setenv("LINEAR_VIEWER_ID", _VIEWER_ID)
+    out = linear_webhook._normalise_event(_payload("update", "KEI-100", "completed", _VIEWER_ID))
+    assert out is None, "self-echo update must be skipped"
+
+
+def test_update_from_other_actor_passes_through(monkeypatch) -> None:
+    """Updates from other actors (Dave, integrations) still propagate."""
+    monkeypatch.setenv("LINEAR_VIEWER_ID", _VIEWER_ID)
+    out = linear_webhook._normalise_event(_payload("update", "KEI-100", "completed", _OTHER_ACTOR))
+    assert out is not None
+    assert out["op"] == "status"
+    assert out["task_status"] == "done"
+
+
+def test_create_from_own_viewer_id_still_propagates(monkeypatch) -> None:
+    """KEI-238: only `update` is skipped — `create` from our API key is
+    still a real intent (e.g. atlas creating a new KEI via MCP)."""
+    monkeypatch.setenv("LINEAR_VIEWER_ID", _VIEWER_ID)
+    out = linear_webhook._normalise_event(_payload("create", "KEI-101", "backlog", _VIEWER_ID))
+    assert out is not None
+    assert out["op"] == "create"
+
+
+def test_update_when_viewer_id_unset_passes_through(monkeypatch) -> None:
+    """If LINEAR_VIEWER_ID env not set, no skip — fail-open to existing
+    behaviour (the env var is the lock, not a hard dependency)."""
+    monkeypatch.delenv("LINEAR_VIEWER_ID", raising=False)
+    out = linear_webhook._normalise_event(_payload("update", "KEI-100", "completed", _VIEWER_ID))
+    assert out is not None
+    assert out["op"] == "status"
+
+
+def test_update_with_missing_actor_passes_through(monkeypatch) -> None:
+    """Linear payloads sometimes omit actor (system events) — propagate."""
+    monkeypatch.setenv("LINEAR_VIEWER_ID", _VIEWER_ID)
+    payload = _payload("update", "KEI-100", "completed", _VIEWER_ID)
+    payload["data"].pop("actor", None)
+    out = linear_webhook._normalise_event(payload)
+    assert out is not None  # missing actor != viewer match → don't skip

--- a/tests/api/webhooks/test_linear_webhook_kei84.py
+++ b/tests/api/webhooks/test_linear_webhook_kei84.py
@@ -60,9 +60,11 @@ def test_normalise_update_completed_maps_to_done():
     assert out["task_status"] == "done"
 
 
-def test_normalise_update_canceled_maps_to_cancelled():
+def test_normalise_update_canceled_maps_to_dismissed():
+    # KEI-235-followup: Postgres tasks_status_check rejects 'cancelled'.
+    # Linear canceled → Postgres dismissed (constraint-compliant).
     out = linear_webhook._normalise_event(_payload("update", "KEI-100", "canceled"))
-    assert out["task_status"] == "cancelled"
+    assert out["task_status"] == "dismissed"
 
 
 def test_normalise_remove_returns_cancelled_op():
@@ -93,8 +95,10 @@ def test_state_mapping_constants_cover_all_linear_state_types():
 
 
 def test_state_mapping_canceled_is_distinct_from_done():
-    # KEI-84 regression: prior code mapped canceled→closed→done; spec requires cancelled.
-    assert linear_webhook.LINEAR_STATE_TO_TASK_STATUS["canceled"] == "cancelled"
+    # KEI-235-followup: tasks_status_check rejects 'cancelled'. Linear `canceled`
+    # maps to Postgres `dismissed` (the constraint-compliant equivalent).
+    # Still must be distinct from completed→done.
+    assert linear_webhook.LINEAR_STATE_TO_TASK_STATUS["canceled"] == "dismissed"
     assert linear_webhook.LINEAR_STATE_TO_TASK_STATUS["completed"] == "done"
     assert (
         linear_webhook.LINEAR_STATE_TO_TASK_STATUS["canceled"]


### PR DESCRIPTION
Defence-in-depth lock against the loop pattern that downgraded 59 KEIs 2026-05-19. KEI-236 locked the orchestrator's outbound side; this PR locks the inbound side — even if a non-postgres write path were re-introduced, its echo via the Linear webhook is rejected.

`_normalise_event` skips events where action=update AND actor.id == LINEAR_VIEWER_ID. Creates/removes still propagate. Missing env → fail-open.

Includes `scripts/sync_linear_viewer_env.py` helper (verbatim live: outputs `export LINEAR_VIEWER_ID=f29152a3-3700-4217-a451-d6070f09de3c`).

**Operator action post-merge:** add LINEAR_VIEWER_ID env to ~/.config/agency-os/.env.

17/17 tests pass (5 new), ruff clean. Closes KEI-238 / Agency_OS-6x5q. Series 4/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)