### PR TITLE
[ORION] feat(kei-ngw2): three-tier governance loader — HOT/POINTER/REFERENCE with fail-loud budgets (Phase 1)

### DIFF
--- a/src/governance/loader.py
+++ b/src/governance/loader.py
@@ -1,0 +1,198 @@
+"""Three-tier governance loader — Agency_OS-ngw2 / KEI-ngw2.
+
+Replaces the flat `@-import` auto-load chain in CLAUDE.md with a tier-aware
+loader per Layered Governance Matrix v1 (ratified 2026-05-19).
+
+Tiers:
+  - HOT (always loaded, pre-prompt, ≤8000 tokens hard):
+        slim CLAUDE.md + docs/governance/_hot_pointer_cache.md + IDENTITY.md
+  - POINTER (lazy, on agent trigger via cognee_recall, ≤500 tokens/call):
+        the agent passes a recall_key from _hot_pointer_cache.md; the
+        loader runs cognee_recall and returns the top-N matched chunks.
+  - REFERENCE (on-demand only):
+        raw file content for a specific rule/persona document; counts
+        against the cumulative session-recall budget (≤5000 tokens
+        across all POINTER + REFERENCE fetches in one session).
+
+Fail-loud per Layered Governance Matrix v1 §FAIL-LOUD SEMANTICS:
+  Any budget violation raises GovernanceBudgetExceeded AND writes
+  `FAIL-LOUD: <detail>` to stderr. Required-file-missing raises
+  GovernanceConfigError. Callers MUST NOT silently swallow these.
+
+Phase 1 (this PR): loader module + tests. The CLAUDE.md @-import chain
+removal + SessionStart hook wiring is a Phase 2 follow-up KEI so the
+mechanism + the call-site migration are reviewable separately.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BUDGET_HOT_TOKENS = 8000
+BUDGET_POINTER_PER_CALL_TOKENS = 500
+BUDGET_SESSION_RECALL_TOKENS = 5000
+
+# Same chars-per-token heuristic as scripts/governance/regen_hot_pointer_cache.py
+# so HOT-tier accounting stays consistent across writer + loader.
+CHARS_PER_TOKEN = 4
+
+
+class GovernanceBudgetExceeded(RuntimeError):
+    """Raised when a tier load would exceed its budget. Fail-loud — never swallow."""
+
+
+class GovernanceConfigError(RuntimeError):
+    """Raised when a required governance file is missing. Fail-loud."""
+
+
+def estimate_tokens(text: str) -> int:
+    return len(text) // CHARS_PER_TOKEN
+
+
+def _fail_loud(detail: str, exc: type[Exception]) -> None:
+    """Emit FAIL-LOUD marker to stderr and raise."""
+    print(f"FAIL-LOUD: {detail}", file=sys.stderr)
+    raise exc(detail)
+
+
+def _default_cognee_recall(recall_key: str, repo_root: Path) -> str:
+    """Default POINTER backend: shell out to scripts/cognee_recall.py.
+
+    Wraps the existing CLI used by inbox-watcher delivery enrichment.
+    The CLI is fail-open by contract — empty stdout means no hits or
+    cognee unavailable. The loader's per-call budget still applies.
+    """
+    script = repo_root / "scripts" / "cognee_recall.py"
+    if not script.exists():
+        _fail_loud(f"cognee_recall script missing at {script}", GovernanceConfigError)
+    python = shutil.which("python3") or "python3"
+    proc = subprocess.run(
+        [python, str(script), "--text", recall_key, "--limit", "5"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    return proc.stdout
+
+
+@dataclass
+class GovernanceLoader:
+    """Three-tier loader with budget enforcement + fail-loud semantics."""
+
+    repo_root: Path
+    callsign: str
+    recall_fn: Callable[[str], str] | None = None
+    _session_recall_used: int = field(default=0, init=False)
+
+    # ------------------------------------------------------------------
+    # HOT tier — always loaded into every session pre-prompt
+    # ------------------------------------------------------------------
+
+    def load_hot(self) -> str:
+        """Concatenate the three HOT files and assert ≤8000 token budget."""
+        identity = self.repo_root / "IDENTITY.md"
+        cache = self.repo_root / "docs" / "governance" / "_hot_pointer_cache.md"
+        claude_md = self.repo_root / "CLAUDE.md"
+
+        for required in (identity, cache, claude_md):
+            if not required.exists():
+                _fail_loud(
+                    f"HOT-tier required file missing: {required}",
+                    GovernanceConfigError,
+                )
+
+        parts = [
+            f"<!-- HOT TIER 1/3 — IDENTITY.md ({self.callsign}) -->\n",
+            identity.read_text(),
+            "\n<!-- HOT TIER 2/3 — _hot_pointer_cache.md -->\n",
+            cache.read_text(),
+            "\n<!-- HOT TIER 3/3 — CLAUDE.md -->\n",
+            claude_md.read_text(),
+        ]
+        combined = "".join(parts)
+        tokens = estimate_tokens(combined)
+        if tokens > BUDGET_HOT_TOKENS:
+            _fail_loud(
+                f"HOT tier {tokens} tokens exceeds {BUDGET_HOT_TOKENS} budget. "
+                f"Slim CLAUDE.md or trim _hot_pointer_cache.md before re-running.",
+                GovernanceBudgetExceeded,
+            )
+        return combined
+
+    # ------------------------------------------------------------------
+    # POINTER tier — lazy, on agent trigger
+    # ------------------------------------------------------------------
+
+    def load_pointer(self, recall_key: str) -> str:
+        """Fetch a POINTER-tier slice via cognee_recall by recall_key.
+
+        Enforces per-call budget (≤500 tokens) AND cumulative
+        session-recall budget (≤5000 tokens across all pointer+reference
+        loads in this loader instance's lifetime).
+        """
+        recall_fn = self.recall_fn or (lambda k: _default_cognee_recall(k, self.repo_root))
+        result = recall_fn(recall_key)
+        tokens = estimate_tokens(result)
+        if tokens > BUDGET_POINTER_PER_CALL_TOKENS:
+            _fail_loud(
+                f"POINTER recall_key={recall_key!r} returned {tokens} tokens "
+                f"(>{BUDGET_POINTER_PER_CALL_TOKENS} per-call budget). "
+                f"Tighten the recall key or split the underlying source.",
+                GovernanceBudgetExceeded,
+            )
+        self._charge_session_recall(tokens, source=f"pointer:{recall_key}")
+        return result
+
+    # ------------------------------------------------------------------
+    # REFERENCE tier — on-demand, raw file
+    # ------------------------------------------------------------------
+
+    def load_reference(self, rel_path: str) -> str:
+        """Read a governance/reference file relative to repo_root.
+
+        Counts toward the cumulative session-recall budget. No per-call
+        cap (reference files are explicitly opt-in by the agent), but
+        the session-cumulative cap still applies — pulling 6 KB of
+        reference text uses ~1500 tokens of the 5000-token session
+        budget.
+        """
+        target = self.repo_root / rel_path
+        if not target.exists():
+            _fail_loud(
+                f"REFERENCE file missing: {rel_path}",
+                GovernanceConfigError,
+            )
+        text = target.read_text()
+        tokens = estimate_tokens(text)
+        self._charge_session_recall(tokens, source=f"reference:{rel_path}")
+        return text
+
+    # ------------------------------------------------------------------
+    # Session-recall budget accounting
+    # ------------------------------------------------------------------
+
+    @property
+    def session_recall_used(self) -> int:
+        return self._session_recall_used
+
+    @property
+    def session_recall_remaining(self) -> int:
+        return BUDGET_SESSION_RECALL_TOKENS - self._session_recall_used
+
+    def _charge_session_recall(self, tokens: int, *, source: str) -> None:
+        proposed = self._session_recall_used + tokens
+        if proposed > BUDGET_SESSION_RECALL_TOKENS:
+            _fail_loud(
+                f"session-recall total would reach {proposed} tokens "
+                f"(>{BUDGET_SESSION_RECALL_TOKENS} budget) after charging "
+                f"{tokens} tokens from {source}. Drop a previously-loaded "
+                f"slice or end the session.",
+                GovernanceBudgetExceeded,
+            )
+        self._session_recall_used = proposed

--- a/tests/governance/test_loader.py
+++ b/tests/governance/test_loader.py
@@ -1,0 +1,206 @@
+"""Unit tests for src.governance.loader — Agency_OS-ngw2.
+
+Covers the three-tier loader's HOT/POINTER/REFERENCE behaviours and
+fail-loud budget enforcement. No external dependencies — tests build a
+synthetic repo root inside tmp_path + inject a fake recall_fn for the
+POINTER tier so cognee_recall isn't required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.governance.loader import (
+    BUDGET_HOT_TOKENS,
+    BUDGET_SESSION_RECALL_TOKENS,
+    GovernanceBudgetExceeded,
+    GovernanceConfigError,
+    GovernanceLoader,
+    estimate_tokens,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: synthetic repo root with the three HOT-tier required files
+# ---------------------------------------------------------------------------
+
+
+def _build_repo(tmp_path: Path, *, claude_md_chars: int = 2000, cache_chars: int = 2000) -> Path:
+    """Return tmp_path with IDENTITY.md, CLAUDE.md, _hot_pointer_cache.md."""
+    (tmp_path / "IDENTITY.md").write_text("callsign: orion\n")
+    (tmp_path / "CLAUDE.md").write_text("c" * claude_md_chars)
+    gov_dir = tmp_path / "docs" / "governance"
+    gov_dir.mkdir(parents=True)
+    (gov_dir / "_hot_pointer_cache.md").write_text("h" * cache_chars)
+    return tmp_path
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    return _build_repo(tmp_path)
+
+
+@pytest.fixture
+def loader(repo: Path) -> GovernanceLoader:
+    return GovernanceLoader(repo_root=repo, callsign="orion", recall_fn=lambda k: "x" * 100)
+
+
+# ---------------------------------------------------------------------------
+# estimate_tokens — sanity
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_tokens_matches_4_chars_per_token() -> None:
+    assert estimate_tokens("x" * 400) == 100
+    assert estimate_tokens("") == 0
+
+
+# ---------------------------------------------------------------------------
+# HOT tier
+# ---------------------------------------------------------------------------
+
+
+def test_load_hot_succeeds_under_budget(loader: GovernanceLoader) -> None:
+    text = loader.load_hot()
+    assert "callsign: orion" in text
+    assert "HOT TIER 1/3" in text and "HOT TIER 2/3" in text and "HOT TIER 3/3" in text
+    assert estimate_tokens(text) <= BUDGET_HOT_TOKENS
+
+
+def test_load_hot_fails_loud_over_budget(tmp_path: Path) -> None:
+    # Hot budget is 8000 tokens = ~32000 chars. Make CLAUDE.md big enough
+    # to push the combined past that.
+    repo = _build_repo(tmp_path, claude_md_chars=34000, cache_chars=100)
+    loader = GovernanceLoader(repo_root=repo, callsign="orion")
+    with pytest.raises(GovernanceBudgetExceeded, match="HOT tier"):
+        loader.load_hot()
+
+
+def test_load_hot_fails_loud_when_identity_missing(tmp_path: Path) -> None:
+    repo = _build_repo(tmp_path)
+    (repo / "IDENTITY.md").unlink()
+    loader = GovernanceLoader(repo_root=repo, callsign="orion")
+    with pytest.raises(GovernanceConfigError, match="IDENTITY.md"):
+        loader.load_hot()
+
+
+def test_load_hot_fails_loud_when_pointer_cache_missing(tmp_path: Path) -> None:
+    repo = _build_repo(tmp_path)
+    (repo / "docs" / "governance" / "_hot_pointer_cache.md").unlink()
+    loader = GovernanceLoader(repo_root=repo, callsign="orion")
+    with pytest.raises(GovernanceConfigError, match="_hot_pointer_cache.md"):
+        loader.load_hot()
+
+
+def test_load_hot_fails_loud_when_claude_md_missing(tmp_path: Path) -> None:
+    repo = _build_repo(tmp_path)
+    (repo / "CLAUDE.md").unlink()
+    loader = GovernanceLoader(repo_root=repo, callsign="orion")
+    with pytest.raises(GovernanceConfigError, match="CLAUDE.md"):
+        loader.load_hot()
+
+
+# ---------------------------------------------------------------------------
+# POINTER tier
+# ---------------------------------------------------------------------------
+
+
+def test_load_pointer_returns_recall_result_under_budget(loader: GovernanceLoader) -> None:
+    out = loader.load_pointer("law-i-a-architecture-first")
+    assert out == "x" * 100
+    # ~25 tokens charged; session budget mostly untouched
+    assert loader.session_recall_used == estimate_tokens("x" * 100)
+
+
+def test_load_pointer_fails_loud_when_recall_exceeds_per_call_budget(repo: Path) -> None:
+    # Per-call budget is 500 tokens = ~2000 chars. Return 2500 chars → fail.
+    big_recall = lambda k: "y" * 2500  # noqa: E731
+    loader = GovernanceLoader(repo_root=repo, callsign="orion", recall_fn=big_recall)
+    with pytest.raises(GovernanceBudgetExceeded, match="POINTER recall_key"):
+        loader.load_pointer("rule-1-verify")
+
+
+def test_load_pointer_passes_recall_key_to_backend(repo: Path) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_recall(k: str) -> str:
+        captured["key"] = k
+        return "ok"
+
+    loader = GovernanceLoader(repo_root=repo, callsign="orion", recall_fn=fake_recall)
+    loader.load_pointer("persona-orion")
+    assert captured["key"] == "persona-orion"
+
+
+# ---------------------------------------------------------------------------
+# REFERENCE tier
+# ---------------------------------------------------------------------------
+
+
+def test_load_reference_returns_file_text(loader: GovernanceLoader, repo: Path) -> None:
+    (repo / "ARCHITECTURE.md").write_text("# arch\nstuff\n")
+    text = loader.load_reference("ARCHITECTURE.md")
+    assert text == "# arch\nstuff\n"
+
+
+def test_load_reference_fails_loud_when_missing(loader: GovernanceLoader) -> None:
+    with pytest.raises(GovernanceConfigError, match="REFERENCE file missing"):
+        loader.load_reference("does/not/exist.md")
+
+
+def test_load_reference_charges_session_recall_budget(loader: GovernanceLoader, repo: Path) -> None:
+    (repo / "big.md").write_text("z" * 4000)  # ~1000 tokens
+    loader.load_reference("big.md")
+    assert loader.session_recall_used == 1000
+
+
+# ---------------------------------------------------------------------------
+# Cumulative session-recall budget
+# ---------------------------------------------------------------------------
+
+
+def test_session_recall_cumulative_pointer_charges(repo: Path) -> None:
+    # Each pointer call returns 400 chars = 100 tokens; do 10 calls → 1000 tokens used
+    loader = GovernanceLoader(repo_root=repo, callsign="orion", recall_fn=lambda k: "x" * 400)
+    for _ in range(10):
+        loader.load_pointer("rule-1-verify")
+    assert loader.session_recall_used == 1000
+    assert loader.session_recall_remaining == BUDGET_SESSION_RECALL_TOKENS - 1000
+
+
+def test_session_recall_fails_loud_when_cumulative_exceeded(repo: Path) -> None:
+    # 11 pointer calls × 500 tokens each = 5500 tokens > 5000-token session budget
+    loader = GovernanceLoader(repo_root=repo, callsign="orion", recall_fn=lambda k: "x" * 2000)
+    # 10 calls cleanly consume 5000 (10 * 500)
+    for _ in range(10):
+        loader.load_pointer("rule-1-verify")
+    assert loader.session_recall_used == 5000
+    # 11th call charges 500 more → trips cumulative budget
+    with pytest.raises(GovernanceBudgetExceeded, match="session-recall total"):
+        loader.load_pointer("rule-2-coordinate")
+
+
+def test_session_recall_mixed_pointer_and_reference_share_budget(
+    loader: GovernanceLoader, repo: Path
+) -> None:
+    # Load a 1000-token reference, then 100-token pointers; total stays in budget
+    (repo / "big.md").write_text("z" * 4000)
+    loader.load_reference("big.md")  # +1000 tokens
+    assert loader.session_recall_used == 1000
+    loader.load_pointer("rule-1-verify")  # +25 tokens
+    assert loader.session_recall_used == 1025
+
+
+# ---------------------------------------------------------------------------
+# FAIL-LOUD stderr marker
+# ---------------------------------------------------------------------------
+
+
+def test_fail_loud_emits_stderr_marker(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    loader = GovernanceLoader(repo_root=repo, callsign="orion", recall_fn=lambda k: "y" * 2500)
+    with pytest.raises(GovernanceBudgetExceeded):
+        loader.load_pointer("law-xv-d-step-0-restate")
+    err = capsys.readouterr().err
+    assert "FAIL-LOUD:" in err
+    assert "POINTER recall_key" in err


### PR DESCRIPTION
## Summary

`Agency_OS-ngw2` (P1, owner=aiden, assignee=orion). Per **Layered Governance Matrix v1** (ratified 2026-05-19). Builds the loader module that will replace the flat `@-import` chain in `CLAUDE.md` with tier-aware loading + explicit budget enforcement + fail-loud semantics.

**Sequenced after** PR #1089 (KEI-`wk3q`) which delivered the hot pointer cache the HOT tier loads.

## Phasing

| Phase | Scope | Status |
|-------|-------|--------|
| **1 (this PR)** | Loader module + 16-case test suite. No call-site changes. | ✅ ready |
| 2 (follow-up KEI) | Replace `@-import` chain in `CLAUDE.md` + `.claude/modules/*.md` with a `SessionStart` hook calling `GovernanceLoader.load_hot()`. | out of scope |

Splitting at the loader/call-site boundary keeps Phase 1 reviewable + lets Phase 2 (which surgically edits `CLAUDE.md` — a governance doc) be reviewed against the exact mechanism it depends on. Same split rationale as KEI-142 Phase 1.

## Tiers + budgets

| Tier | Per-call budget | Cumulative cap | When loaded |
|------|----------------|----------------|-------------|
| **HOT** | n/a — combined ≤ 8000 t | per-session, hard | every session, pre-prompt |
| **POINTER** | ≤ 500 t / cognee_recall | shares 5000-t session cap | lazy, on agent trigger |
| **REFERENCE** | n/a (opt-in raw read) | shares 5000-t session cap | on-demand, explicit |

`estimate_tokens` uses the same 4-chars/token heuristic as `scripts/governance/regen_hot_pointer_cache.py` so HOT-tier accounting stays consistent between writer + reader.

## Fail-loud per Matrix §FAIL-LOUD SEMANTICS

Every budget or missing-file violation:

1. Writes `FAIL-LOUD: <detail>` to **stderr** (so it shows up in agent transcripts).
2. **Raises** `GovernanceBudgetExceeded` or `GovernanceConfigError`.
3. Single `_fail_loud()` helper → no silent-swallow path.

## What lands

| File | LoC | Purpose |
|------|-----|---------|
| `src/governance/loader.py` | 198 | `GovernanceLoader` dataclass + three tier methods + `_default_cognee_recall` backend + `_fail_loud` helper. |
| `tests/governance/test_loader.py` | 208 | **16 unit tests, all green.** Synthetic `tmp_path` repo + injected `recall_fn` — no external dependencies. |

**Total: 406 LoC across 4 files (the 2 `__init__.py` markers are empty).**

## Test coverage

- `estimate_tokens` sanity
- HOT happy-path under budget
- HOT over-budget fail-loud (`load_hot` with 34KB CLAUDE.md)
- HOT missing-file fail-loud × 3 (IDENTITY.md / `_hot_pointer_cache.md` / CLAUDE.md)
- POINTER happy-path
- POINTER per-call over-budget fail-loud (mock returns 2500 chars > 2000-char budget)
- POINTER recall_key passthrough to backend
- REFERENCE happy-path
- REFERENCE missing-file fail-loud
- REFERENCE charges session budget
- Cumulative session-recall under budget (10 × 100t = 1000t)
- Cumulative session-recall fail-loud (10 × 500t fills budget, 11th trips it)
- Mixed pointer + reference share budget
- FAIL-LOUD stderr marker present

## Acceptance criteria (KEI-ngw2 spec)

- [x] HOT loaded into every session pre-prompt → `load_hot()`
- [x] POINTER lazy-loaded on trigger via `cognee_recall` → `load_pointer(recall_key)`
- [x] REFERENCE on-demand only → `load_reference(rel_path)`
- [x] HOT ≤ 8000 t hard — enforced + tested
- [x] POINTER recall ≤ 500 t / call — enforced + tested
- [x] Session-recall total ≤ 5000 t — enforced + tested
- [x] Fail-loud per matrix — every violation hits the `FAIL-LOUD:` stderr marker
- [x] Cold session start loads HOT only — `load_hot()` independent of pointer/reference
- [x] Triggers fetch POINTER on demand — `load_pointer` opt-in
- [x] Exceeded budgets trigger explicit failure markers — verified by `test_fail_loud_emits_stderr_marker`

## Test plan

- [x] `PYTHONPATH=$PWD python3 -m pytest tests/governance/test_loader.py -x -q` → **16 passed in 0.10s**
- [x] `ruff check src/governance/loader.py tests/governance/test_loader.py` → `All checks passed!`
- [x] `ruff format --check ...` → `2 files already formatted`
- [ ] Reviewer eyeballs that the 4-chars/token heuristic matches the writer (`scripts/governance/regen_hot_pointer_cache.py:CHARS_PER_TOKEN = 4`).