### PR TITLE
[ATLAS] fix(3nwh): drive_strategic_indexer ensure_class drift + activate as 15min systemd timer

### DIFF
--- a/infra/systemd/drive-strategic-indexer.service
+++ b/infra/systemd/drive-strategic-indexer.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Agency OS — Drive strategic docs → Weaviate StrategicDocuments indexer (KEI Agency_OS-3nwh)
+After=network-online.target weaviate.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+Environment=PYTHONPATH=/home/elliotbot/clawd/Agency_OS/scripts/orchestrator
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/drive_strategic_indexer.py --once
+StandardOutput=append:/home/elliotbot/clawd/logs/drive-strategic-indexer.log
+StandardError=append:/home/elliotbot/clawd/logs/drive-strategic-indexer.log
+TimeoutStartSec=600
+MemoryMax=512M
+MemoryHigh=400M
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/drive-strategic-indexer.timer
+++ b/infra/systemd/drive-strategic-indexer.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Agency OS — Drive strategic indexer cadence (15min, KEI Agency_OS-3nwh)
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=15min
+RandomizedDelaySec=60
+Persistent=true
+Unit=drive-strategic-indexer.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/install_drive_strategic_indexer.sh
+++ b/scripts/install_drive_strategic_indexer.sh
@@ -1,35 +1,43 @@
 #!/usr/bin/env bash
-# install_drive_strategic_indexer.sh — KEI-208 install entry-point.
+# install_drive_strategic_indexer.sh — KEI Agency_OS-3nwh installer.
 #
-# KEI-108 CI-gate requirement: per-unit install wrapper anchors the literal
+# Installs drive-strategic-indexer.service + .timer (15min cadence) into
+# the user-systemd config dir. Replaces the KEI-208 thin wrapper that
+# called install_indexer.sh — generic installer didn't handle timers.
+#
+# KEI-108 CI-gate compliance: anchors the literal unit name
 # `drive-strategic-indexer.service` for the grep gate.
 #
-# What this does:
-#   1. Verifies /home/elliotbot/google-service-account.json exists
-#      (Drive auth — same keyfile write_manual_mirror.py uses)
-#   2. Copies the systemd user unit + enables + starts
-#   3. Tails the log to confirm first poll cycle started
-#
-# Re-runnable — daemon-reload + enable --now is idempotent.
-#
-# Usage:
-#   scripts/install_drive_strategic_indexer.sh
-#
-# Anchored unit: drive-strategic-indexer.service
+# Prerequisite: /home/elliotbot/google-service-account.json (Drive auth,
+# same keyfile write_manual_mirror.py uses). Operator must provision.
 
 set -euo pipefail
 
-UNIT="drive-strategic-indexer"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SYSTEMD_SRC="${REPO_ROOT}/infra/systemd"
+SYSTEMD_DST="${HOME}/.config/systemd/user"
+LOG_DIR="${HOME}/clawd/logs"
 SERVICE_ACCOUNT="/home/elliotbot/google-service-account.json"
 
 if [[ ! -f "${SERVICE_ACCOUNT}" ]]; then
     echo "install_drive_strategic_indexer: missing ${SERVICE_ACCOUNT}" >&2
-    echo "  KEI-208 indexer requires the same service-account JSON used by" >&2
+    echo "  KEI-208/3nwh indexer requires the same service-account JSON used by" >&2
     echo "  write_manual_mirror.py. Operator must provision before install." >&2
     exit 2
 fi
 
-# Use the existing generic indexer installer.
-exec /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/install_indexer.sh "${UNIT}"
+mkdir -p "${SYSTEMD_DST}" "${LOG_DIR}"
+cp -v "${SYSTEMD_SRC}/drive-strategic-indexer.service" "${SYSTEMD_DST}/"
+cp -v "${SYSTEMD_SRC}/drive-strategic-indexer.timer"   "${SYSTEMD_DST}/"
+
+systemctl --user daemon-reload
+systemctl --user enable --now drive-strategic-indexer.timer
+
+echo
+echo "Installed. Verify:"
+echo "  systemctl --user status drive-strategic-indexer.timer"
+echo "  systemctl --user list-timers --all | grep drive-strategic"
+echo "  journalctl --user -u drive-strategic-indexer.service -n 50 --no-pager"
+echo "  tail -n 50 ~/clawd/logs/drive-strategic-indexer.log"
 
 # Anchored unit: drive-strategic-indexer.service


### PR DESCRIPTION
Per Dave directive 2026-05-19 — activate StrategicDocuments Drive indexer.

**Two method-name drifts fixed:**
- `indexer.ensure_class()` → `indexer.ensure_target_class()` (BaseIndexer's bound wrapper around the module-level helper)
- `indexer.run_forever()` → inline daemon while-loop (mirrors session-transcript-indexer shape)

**Systemd activation:**
- `infra/systemd/drive-strategic-indexer.service` (Type=oneshot, calls --once)
- `infra/systemd/drive-strategic-indexer.timer` (OnUnitActiveSec=15min)
- `scripts/install_drive_strategic_indexer.sh` (self-contained installer, supersedes KEI-208 thin wrapper that didn't handle timers)

Lint clean, KEI-108 gate passes, --help exits cleanly.

**Post-merge operator action:** run `scripts/install_drive_strategic_indexer.sh` on Elliot's worktree; verify StrategicDocuments count grows over next 15min cycles.

Closes Agency_OS-3nwh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)