### PR TITLE
[ATLAS] fix(bd-ready): coerce NULL priority to PX — unblock bd ready CLI

### DIFF
--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -295,7 +295,18 @@ def _print_ready_rows(rows: list[dict], agent: str) -> None:
             if agent and "personalised_score" in r
             else ""
         )
-        print(f"  P{r['priority']:>1}  {r['id']:<24}  {r['title']}{score_suffix}")
+        # Coerce NULL priority to 'X' — Postgres NULL → Python None on
+        # the priority column throws TypeError on the :>1 format spec.
+        # Render as 'X' (unset) and stderr-warn so the row stays visible
+        # rather than being silently filtered out of bd ready.
+        priority = r["priority"]
+        if priority is None:
+            sys.stderr.write(
+                f"[tasks_cli] warning: {r['id']} has NULL priority — "
+                f"rendering as PX. Fix via `bd update {r['id']} --priority=N`.\n"
+            )
+            priority = "X"
+        print(f"  P{priority:>1}  {r['id']:<24}  {r['title']}{score_suffix}")
     suffix = f" (personalised for {agent})" if agent else ""
     print(f"\n{len(rows)} available{suffix}")
 

--- a/tests/scripts/test_tasks_cli.py
+++ b/tests/scripts/test_tasks_cli.py
@@ -133,6 +133,44 @@ def test_ready_emits_json(mod, patch_connect, capsys) -> None:
     assert data[0]["priority"] == 1
 
 
+def test_ready_human_output_handles_null_priority(mod, patch_connect, capsys) -> None:
+    """bd ready must not crash when a row has priority=None (Postgres NULL).
+
+    Pre-fix: tasks_cli.py:298 raised
+        TypeError: unsupported format string passed to NoneType.__format__
+    on `print(f"  P{r['priority']:>1}  ...")`. Coerce None → 'X' + warn
+    so the row stays visible.
+    """
+    cur = _Cursor(
+        fetchall_rows=[
+            ("KEI-TEST", "smoke", None, "available", None, None, None, None, "url", None, None),
+        ],
+        description=[
+            ("id",),
+            ("title",),
+            ("priority",),
+            ("status",),
+            ("claimed_by",),
+            ("claimed_at",),
+            ("dependencies",),
+            ("tags",),
+            ("linear_url",),
+            ("created_at",),
+            ("updated_at",),
+        ],
+    )
+    patch_connect(cur)
+    rc = mod.main(["ready"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "PX" in captured.out, f"Expected 'PX' marker in stdout, got: {captured.out!r}"
+    assert "KEI-TEST" in captured.out
+    assert "NULL priority" in captured.err, (
+        f"Expected NULL-priority warning in stderr, got: {captured.err!r}"
+    )
+    assert "KEI-TEST" in captured.err
+
+
 def test_ready_clamps_limit_argument(mod, patch_connect, monkeypatch) -> None:
     monkeypatch.setattr(mod, "_current_phase_max", lambda _cur: 0.0)
     cur = _Cursor(fetchall_rows=[], description=[("id",)])


### PR DESCRIPTION
## Summary

`bd ready` was crashing with `TypeError: unsupported format string passed to NoneType.__format__` whenever any row in the queue had NULL priority. `Agency_OS-KEI-TEST` currently has priority=None, so every `bd ready` invocation across the fleet was failing.

- `scripts/tasks_cli.py:298` — coerce `r['priority']` → `'X'` when None, stderr-warn naming the offending id with a `bd update <id> --priority=N` remediation hint
- `tests/scripts/test_tasks_cli.py` — new test `test_ready_human_output_handles_null_priority` covering the NULL-priority row path

## Verification

**Pre-fix (origin/main):**
```
$ bd ready
  P4  Agency_OS-test001         bd claim smoke test
Traceback (most recent call last):
  ...
  File ".../scripts/tasks_cli.py", line 298, in _print_ready_rows
    print(f"  P{r['priority']:>1}  {r['id']:<24}  {r['title']}{score_suffix}")
TypeError: unsupported format string passed to NoneType.__format__
```

**Post-fix (atlas worktree):**
```
$ python3 scripts/tasks_cli.py ready
[tasks_cli] warning: KEI-TEST has NULL priority — rendering as PX. Fix via `bd update KEI-TEST --priority=N`.
  P4  Agency_OS-test001         bd claim smoke test
  PX  KEI-TEST                  smoke

2 available
$ echo $?
0
```

**Tests:**
- `pytest tests/scripts/test_tasks_cli.py` → 39 passed, 3 xfailed (existing) in 13.06s
- New test (`-k null_priority`) → 1 passed in 0.23s
- `ruff check` + `ruff format --check` → clean

## Test plan
- [x] New test covers None-priority row (asserts `PX` in stdout, warning in stderr naming the id)
- [x] Existing 39 tests still pass
- [x] Empirical `python3 scripts/tasks_cli.py ready` runs clean against live queue (KEI-TEST + Agency_OS-test001)
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)