### PR TITLE
[ORION] feat(alerts): auto-enable 5 monitor timers + broaden install glob

### DIFF
--- a/infra/alerts/install.sh
+++ b/infra/alerts/install.sh
@@ -1,15 +1,30 @@
 #!/usr/bin/env bash
-# install.sh — copy Agency OS alert systemd units to ~/.config/systemd/user/.
+# install.sh — copy Agency OS alert + monitor systemd units to
+# ~/.config/systemd/user/, then enable+start the always-on monitor timers.
 #
-# Idempotent. Does NOT enable/start timers — that is left as a manual ops
-# step so the operator chooses when alerts go live:
+# Idempotent.
 #
-#   systemctl --user daemon-reload
-#   systemctl --user enable --now \
-#       agency-os-alert-pipeline-failure.timer \
-#       agency-os-alert-daily-digest.timer \
-#       agency-os-alert-budget-threshold.timer \
-#       agency-os-alert-lead-quality.timer
+# Units copied: every file in this directory matching
+# agency-os-*.service / agency-os-*.timer (the 4 alert pairs +
+# 5 monitor pairs).
+#
+# Units AUTO-ENABLED (gap-hunt 2026-05-20 — Elliot directive):
+#   agency-os-alert-vendor-budget.timer        (vendor cost drift)
+#   agency-os-artifact-freshness-monitor.timer (stale governance docs)
+#   agency-os-hook-failure-monitor.timer       (git hook breakage)
+#   agency-os-service-health-monitor.timer     (systemd failed-unit)
+#   agency-os-skill-pr-staleness-monitor.timer (skill PR drift)
+# These are always-on operator-facing watchdogs — no business logic decision
+# attached, so we enable them at install instead of leaving as a manual step
+# that nobody runs.
+#
+# Units NOT auto-enabled (operator chooses when alerts go live):
+#   agency-os-alert-pipeline-failure.timer
+#   agency-os-alert-daily-digest.timer
+#   agency-os-alert-budget-threshold.timer
+#   agency-os-alert-lead-quality.timer
+# Enable these manually when ready:
+#   systemctl --user enable --now <timer>
 #
 # To uninstall: systemctl --user disable --now <each timer>; rm the files;
 # systemctl --user daemon-reload.
@@ -21,11 +36,45 @@ DEST_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 
 mkdir -p "$DEST_DIR"
 
-for unit in "$SRC_DIR"/agency-os-alert-*.service "$SRC_DIR"/agency-os-alert-*.timer; do
+copied=0
+for unit in "$SRC_DIR"/agency-os-*.service "$SRC_DIR"/agency-os-*.timer; do
     install -m 0644 "$unit" "$DEST_DIR/"
     echo "installed: $(basename "$unit")"
+    copied=$((copied + 1))
 done
 
 echo
-echo "8 unit files copied to $DEST_DIR"
-echo "Next: systemctl --user daemon-reload && systemctl --user enable --now <timers>"
+echo "$copied unit files copied to $DEST_DIR"
+
+# Auto-enable monitor timers. Idempotent — systemctl enable --now is a no-op
+# if the timer is already enabled+active.
+AUTO_ENABLE_TIMERS=(
+    "agency-os-alert-vendor-budget.timer"
+    "agency-os-artifact-freshness-monitor.timer"
+    "agency-os-hook-failure-monitor.timer"
+    "agency-os-service-health-monitor.timer"
+    "agency-os-skill-pr-staleness-monitor.timer"
+)
+
+if command -v systemctl >/dev/null 2>&1; then
+    echo
+    echo "Reloading systemd user units..."
+    systemctl --user daemon-reload
+
+    echo "Enabling monitor timers..."
+    for timer in "${AUTO_ENABLE_TIMERS[@]}"; do
+        if systemctl --user enable --now "$timer" 2>&1; then
+            echo "  enabled: $timer"
+        else
+            echo "  WARN: failed to enable $timer (continuing)" >&2
+        fi
+    done
+
+    echo
+    echo "Monitor timers active. To check status:"
+    echo "  systemctl --user list-timers 'agency-os-*'"
+else
+    echo
+    echo "WARN: systemctl not on PATH; skipped daemon-reload + timer enable." >&2
+    echo "Run manually: systemctl --user daemon-reload && systemctl --user enable --now <timer>" >&2
+fi


### PR DESCRIPTION
## Summary

Closes gap-hunt finding (delivered to elliot.inbox 2026-05-20): `infra/alerts/install.sh` was missing the enable step for the 5 always-on monitor timers, AND its file-copy glob (`agency-os-alert-*`) didn't match the 4 newer `*-monitor` units. Fresh operators installing the alerts stack got: 4 of 9 units copied, 0 timers enabled.

Per Elliot directive 2026-05-20.

## Changes

`infra/alerts/install.sh`:
- Broaden glob to `agency-os-*.{service,timer}` — copies all 18 unit files (was 8).
- Add `systemctl --user daemon-reload` + `enable --now` for the 5 monitor timers:
  - `agency-os-alert-vendor-budget.timer`
  - `agency-os-artifact-freshness-monitor.timer`
  - `agency-os-hook-failure-monitor.timer`
  - `agency-os-service-health-monitor.timer`
  - `agency-os-skill-pr-staleness-monitor.timer`
- Leave the 4 business-alert timers manual (pipeline-failure, daily-digest, budget-threshold, lead-quality — operator-decision, not always-on).
- Fail-soft if systemctl absent: copy still succeeds, script warns + instructs manual enable.
- Idempotent throughout — `enable --now` is no-op if timer already active.

## Test plan

- [x] `bash -n infra/alerts/install.sh` — syntax OK
- [x] Smoke test with `XDG_CONFIG_HOME=<tmpdir>`: 18 files copied (was 8); 5 monitor timers report `enabled` after run.
- [x] Verified existing already-enabled timers are re-enabled idempotently (no failure on second run).
- [ ] CI green
- [ ] Reviewer concur

## Out of scope

Higher-impact missing-installer set (ceo-decision-sweeper, tier-promotion-worker, indexing-queue-worker, completion-sync-worker) — these need NEW install scripts (not glob extension), scoping as separate KEIs per dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)