### PR TITLE
[MAX] fix(kei157): clear S6754 dropped by stale-head merge of #972

### DIFF
--- a/frontend/components/dispatcher/use-first-task-watcher.ts
+++ b/frontend/components/dispatcher/use-first-task-watcher.ts
@@ -28,7 +28,6 @@
  * S1135 pre-empt: deferred work expressed as sub-KEIs in kei157_first_task_scope.md.
  */
 
-import { useState } from "react";
 import type { DispatcherTask } from "./task-feed";
 
 export interface UseFirstTaskWatcherOptions {
@@ -57,14 +56,11 @@ export interface UseFirstTaskWatcherResult {
 export function useFirstTaskWatcher(
   _options: Readonly<UseFirstTaskWatcherOptions> = {}
 ): UseFirstTaskWatcherResult {
-  // KEI-157B claimer reads the dismissed flag; the stub only needs the setter so
-  // `dismiss` still triggers a re-render. Destructure the setter alone to avoid
-  // an unused binding.
-  const [, setDismissed] = useState(false);
-
   return {
     firstCompletedTask: null,
     loading: false,
-    dismiss: () => setDismissed(true),
+    dismiss: () => {
+      /* KEI-157B claimer wires dismissal persistence; stub is a deliberate no-op. */
+    },
   };
 }


### PR DESCRIPTION
## Summary
- PR #972 was squash-merged at stale PR head `4baa5fdaf`; follow-up commit `95b8f0fe5` (which cleared S6754) never reached main.
- This re-applies that delta: `frontend/components/dispatcher/use-first-task-watcher.ts` — drop `useState` (the stub never reads dismissed state), replace with a documented no-op `dismiss`.
- Clears `typescript:S6754` (useState not destructured into value+setter pair) currently live on main.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] SonarCloud QG green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)