### PR TITLE
[MAX] fix(kei87): recover dropped Sonar fixes + migrate 14th ceo_memory INSERT

### DIFF
--- a/scripts/orchestrator/migration_apply_watcher.py
+++ b/scripts/orchestrator/migration_apply_watcher.py
@@ -30,6 +30,9 @@ from pathlib import Path
 
 import psycopg
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from src.governance.ceo_memory_writer import upsert_ceo_memory_key  # noqa: E402
+
 logger = logging.getLogger("migration_apply_watcher")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
@@ -188,33 +191,22 @@ def get_debt_row(conn: psycopg.Connection, key: str) -> dict | None:
 
 
 def upsert_debt_row(
-    conn: psycopg.Connection,
     key: str,
     *,
     filename: str,
     status: str,
 ) -> None:
-    import json as _json
-
-    now_iso = _dt.datetime.now(_dt.UTC).isoformat()
-    value = _json.dumps(
+    callsign = os.environ.get("CALLSIGN", "system")
+    upsert_ceo_memory_key(
+        callsign,
+        key,
         {
             "source": SOURCE_DOC_WATCHER,
             "filename": Path(filename).name,
             "status": status,
-            "updated_at": now_iso,
-        }
+            "updated_at": _dt.datetime.now(_dt.UTC).isoformat(),
+        },
     )
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            INSERT INTO public.ceo_memory (key, value, updated_at)
-            VALUES (%s, %s::jsonb, NOW())
-            ON CONFLICT (key) DO UPDATE
-              SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at
-            """,
-            (key, value),
-        )
 
 
 def _dsn() -> str:
@@ -287,7 +279,7 @@ def process_migration(
         existing = get_debt_row(conn, key)
         if existing and existing.get("status") == "pending":
             logger.info("%s: schema now applied — resolving debt row", filepath)
-            upsert_debt_row(conn, key, filename=filepath, status="resolved")
+            upsert_debt_row(key, filename=filepath, status="resolved")
         else:
             logger.info("%s: applied, no pending debt — nothing to do", filepath)
         return
@@ -311,7 +303,7 @@ def process_migration(
     logger.warning("%s: migration not applied after %.1f min — firing alert", filepath, age_min)
     emit_ceo_alert(filepath, dry_run=dry_run)
     if not dry_run:
-        upsert_debt_row(conn, key, filename=filepath, status="pending")
+        upsert_debt_row(key, filename=filepath, status="pending")
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/orchestration/flows/cis_learning_flow.py
+++ b/src/orchestration/flows/cis_learning_flow.py
@@ -191,9 +191,8 @@ async def save_updated_weights(weights: dict) -> bool:
 
     Performs upsert to ceo:propensity_weights_v3 in Supabase.
     """
-    async with get_db_session() as db:
-        result = await save_propensity_weights(db, weights)
-        return result.get("success", False)
+    result = save_propensity_weights(weights)
+    return result.get("success", False)
 
 
 @task(name="cis-log-run-start")

--- a/src/services/cis_outcome_service.py
+++ b/src/services/cis_outcome_service.py
@@ -364,17 +364,16 @@ async def get_propensity_weights(db: AsyncSession) -> dict:
         return {"weights": {}, "negative": {}}
 
 
-async def save_propensity_weights(
-    db: AsyncSession,
+def save_propensity_weights(
     weights: dict,
 ) -> dict[str, Any]:
     """
     Save updated propensity weights to ceo_memory.
 
-    Performs an upsert to ceo:propensity_weights_v3.
+    Performs an upsert to ceo:propensity_weights_v3 via the KEI-87
+    upsert_ceo_memory_key wrapper — no DB session needed.
 
     Args:
-        db: Database session
         weights: Updated weights dict
 
     Returns:

--- a/tests/governance/test_ceo_memory_writer.py
+++ b/tests/governance/test_ceo_memory_writer.py
@@ -240,6 +240,7 @@ def test_completion_sync_worker_sink_calls_upsert(monkeypatch: pytest.MonkeyPatc
 
     assert len(calls) == 1
     cs, key, value = calls[0]
+    assert cs == "system"
     assert key == "completion:KEI-58"
     assert value["status"] == "done"
     assert value["via"] == "kei74"
@@ -261,7 +262,6 @@ def test_completion_sync_worker_sink_calls_upsert(monkeypatch: pytest.MonkeyPatc
 
 def test_cis_outcome_service_calls_upsert(monkeypatch: pytest.MonkeyPatch) -> None:
     """save_propensity_weights delegates to upsert_ceo_memory_key."""
-    import asyncio
     import sys
     from pathlib import Path
 
@@ -285,11 +285,12 @@ def test_cis_outcome_service_calls_upsert(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(cos, "upsert_ceo_memory_key", _fake_upsert)
     monkeypatch.setenv("CALLSIGN", "system")
 
-    result = asyncio.run(cos.save_propensity_weights(db=None, weights={"tier_a": 0.7}))
+    result = cos.save_propensity_weights(weights={"tier_a": 0.7})
 
     assert result["success"] is True
     assert len(calls) == 1
     cs, key, value = calls[0]
+    assert cs == "system"
     assert key == "ceo:propensity_weights_v3"
     assert value == {"tier_a": 0.7}
 

--- a/tests/scripts/test_migration_apply_watcher.py
+++ b/tests/scripts/test_migration_apply_watcher.py
@@ -78,7 +78,6 @@ def test_migration_not_applied_after_window_fires_alert():
         )
     mock_alert.assert_called_once()
     mock_upsert.assert_called_once_with(
-        conn,
         maw.debt_key("supabase/migrations/m.sql"),
         filename="supabase/migrations/m.sql",
         status="pending",
@@ -105,7 +104,6 @@ def test_alert_clears_when_apply_detected():
             conn, "supabase/migrations/m.sql", _RECENT_TS, now=_NOW, dry_run=False
         )
     mock_upsert.assert_called_once_with(
-        conn,
         maw.debt_key("supabase/migrations/m.sql"),
         filename="supabase/migrations/m.sql",
         status="resolved",


### PR DESCRIPTION
## Summary
- **Recovery:** PR #1040 was squash-merged at stale PR head `b94e22a0a`; follow-up commit `ac8ac57ab` never reached main. Re-applies that delta — `save_propensity_weights` drops its vestigial `db: AsyncSession` param + `async` keyword (the function is synchronous after the ceo_memory write migration). Clears `S1172` (MAJOR), `S5655` (CRITICAL), `S7503`, `2x S1481` currently live on main.
- **KEI-87 completion:** the enforcer test `test_zero_direct_ceo_memory_inserts_in_repo` is **red on main** — `migration_apply_watcher.upsert_debt_row` was a 14th direct `INSERT INTO public.ceo_memory` that PR #1040 missed. Routed through `upsert_ceo_memory_key`; the `conn` param is dropped (now unused) and its 2 callers + mock-based tests updated.

## Context
This is post-merge recovery from the stale-head merge hazard on #972/#1040 (GitHub PR-sync lag — the `pulls` endpoint `head.sha` stalled behind the branch ref; the merge sweep took the pre-fix SHA).

## Test plan
- [x] `test_ceo_memory_writer.py` 13/13 + `test_migration_apply_watcher.py` 9/9 pass (22 total)
- [x] `test_zero_direct_ceo_memory_inserts_in_repo` now green (was red on main)
- [x] ruff check + format clean on all 5 files
- [ ] SonarCloud QG green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)