### PR TITLE
[ATLAS] feat(9dbw): Part 1 — backfill Linear titles into public.tasks + webhook title-refresh

### DIFF
--- a/scripts/backfill_task_titles_from_linear.py
+++ b/scripts/backfill_task_titles_from_linear.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""backfill_task_titles_from_linear.py — Part 1 title backfill (Dave directive 2026-05-20).
+
+Reads every Keiracom-team issue's {identifier, title} from the Linear GraphQL
+API and writes the title into public.tasks for rows that have no usable title
+(NULL / '' / '(no title)'). public.tasks.id IS the Linear identifier (KEI-N),
+so the join is a direct id match — no mapping table.
+
+LAW compliance: Linear-READ + Supabase-WRITE only. This script issues no
+Linear mutation. The ratified LAW (2026-05-20) forbids writing Linear, not
+reading it.
+
+Usage:
+    python3 scripts/backfill_task_titles_from_linear.py            # dry-run
+    python3 scripts/backfill_task_titles_from_linear.py --apply    # mutate Postgres
+
+Idempotent. The UPDATE's WHERE clause re-filters on the bad-title predicate,
+so re-running only touches rows still missing a title. Safe to wire into a
+periodic timer.
+
+Env:
+    LINEAR_API_KEY                 — Linear personal API key (Authorization header)
+    DATABASE_URL / SUPABASE_DB_URL — Postgres DSN to the Supabase pooler
+    LINEAR_TEAM_ID                 — override the Keiracom team UUID (optional)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import urllib.request
+from typing import Any
+
+logger = logging.getLogger("backfill_task_titles")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+LINEAR_API_URL = "https://api.linear.app/graphql"
+# Keiracom team UUID — single source of truth is src/api/webhooks/linear.py
+# (LINEAR_TEAM_ID_DEFAULT); duplicated here to keep scripts/ free of a src/
+# import dependency. Env LINEAR_TEAM_ID overrides.
+LINEAR_TEAM_ID_DEFAULT = "4686528f-ce77-4c2f-968b-3dc76b34d6fe"
+
+# Titles Postgres treats as "no usable title" — same predicate the UPDATE uses.
+_BAD_TITLES = ("", "(no title)")
+
+_ISSUES_QUERY = """
+query($teamId: ID!, $cursor: String) {
+  issues(
+    first: 250
+    after: $cursor
+    includeArchived: true
+    filter: { team: { id: { eq: $teamId } } }
+  ) {
+    nodes { identifier title }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+"""
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL or SUPABASE_DB_URL must be set")
+    return dsn.replace("+asyncpg", "")
+
+
+def _linear_api_key() -> str:
+    key = os.environ.get("LINEAR_API_KEY")
+    if not key:
+        raise RuntimeError("LINEAR_API_KEY must be set")
+    return key
+
+
+def _team_id() -> str:
+    return os.environ.get("LINEAR_TEAM_ID", LINEAR_TEAM_ID_DEFAULT)
+
+
+def fetch_linear_titles() -> dict[str, str]:
+    """Return {identifier: title} for every issue on the Keiracom team.
+
+    Paginates the Linear issues connection (250/page) until hasNextPage is
+    false. includeArchived=true so Done/Cancelled issues — whose titles we
+    still need for backfill — are not silently dropped.
+    """
+    key = _linear_api_key()
+    team_id = _team_id()
+    titles: dict[str, str] = {}
+    cursor: str | None = None
+    while True:
+        body = json.dumps(
+            {"query": _ISSUES_QUERY, "variables": {"teamId": team_id, "cursor": cursor}}
+        ).encode()
+        req = urllib.request.Request(  # noqa: S310 — fixed https Linear endpoint
+            LINEAR_API_URL,
+            data=body,
+            headers={"Authorization": key, "Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            payload = json.loads(resp.read())
+        if "errors" in payload:
+            raise RuntimeError(f"Linear GraphQL errors: {payload['errors']}")
+        conn = payload["data"]["issues"]
+        for node in conn["nodes"]:
+            titles[node["identifier"]] = node["title"]
+        page = conn["pageInfo"]
+        if not page["hasNextPage"]:
+            break
+        cursor = page["endCursor"]
+    logger.info("fetched %d issue titles from Linear", len(titles))
+    return titles
+
+
+def plan_backfill(conn: Any, linear_titles: dict[str, str]) -> dict[str, Any]:
+    """Partition bad-title task rows into {matched: [(id, title)], unmatched: [id]}.
+
+    A row is "unmatched" when its identifier has no Linear issue, or the Linear
+    issue itself has no usable title — either way the backfill cannot fix it
+    and the row is surfaced for human triage.
+    """
+    result: dict[str, Any] = {"matched": [], "unmatched": []}
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM public.tasks "
+            "WHERE title IS NULL OR title = '' OR title = '(no title)' "
+            "ORDER BY id"
+        )
+        bad_ids = [row[0] for row in cur.fetchall()]
+    for task_id in bad_ids:
+        linear_title = linear_titles.get(task_id)
+        if not linear_title or linear_title in _BAD_TITLES:
+            result["unmatched"].append(task_id)
+        else:
+            result["matched"].append((task_id, linear_title))
+    return result
+
+
+def apply_backfill(conn: Any, matched: list[tuple[str, str]]) -> int:
+    """Write title for matched rows. Returns count written.
+
+    The WHERE clause re-asserts the bad-title predicate so a row that gained a
+    title between plan and apply is left untouched (idempotent, race-safe).
+    """
+    written = 0
+    with conn.cursor() as cur:
+        for task_id, title in matched:
+            cur.execute(
+                "UPDATE public.tasks SET title = %s, updated_at = NOW() "
+                "WHERE id = %s "
+                "AND (title IS NULL OR title = '' OR title = '(no title)')",
+                (title, task_id),
+            )
+            written += cur.rowcount
+    conn.commit()
+    return written
+
+
+def count_remaining(conn: Any) -> int:
+    """Verify gate — rows still lacking a usable title after the run."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM public.tasks "
+            "WHERE title IS NULL OR title = '' OR title = '(no title)'"
+        )
+        return int(cur.fetchone()[0])
+
+
+def _print_summary(plan: dict[str, Any], applied: int | None, remaining: int | None) -> None:
+    print(f"matched (have Linear title):  {len(plan['matched'])}")
+    print(f"unmatched (no Linear title):  {len(plan['unmatched'])}")
+    if applied is not None:
+        print(f"applied (rows updated):       {applied}")
+    if remaining is not None:
+        print(f"remaining bad-title rows:     {remaining}")
+    if plan["unmatched"]:
+        print("\nUnmatched ids (no Linear issue, or Linear issue has no title):")
+        for task_id in plan["unmatched"]:
+            print(f"  {task_id}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Mutate Postgres (default dry-run)")
+    args = parser.parse_args(argv)
+
+    try:
+        import psycopg
+    except ImportError:
+        logger.error("psycopg not installed; pip install psycopg")
+        return 2
+
+    linear_titles = fetch_linear_titles()
+    if not linear_titles:
+        logger.warning("Linear returned 0 issues — backfill aborted")
+        return 1
+
+    with psycopg.connect(_dsn(), prepare_threshold=None) as conn:
+        plan = plan_backfill(conn, linear_titles)
+        applied: int | None = None
+        remaining: int | None = None
+        if args.apply:
+            applied = apply_backfill(conn, plan["matched"])
+            logger.info("applied %d rows", applied)
+            remaining = count_remaining(conn)
+    _print_summary(plan, applied, remaining)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/webhooks/linear.py
+++ b/src/api/webhooks/linear.py
@@ -199,6 +199,11 @@ def _normalise_event(payload: dict[str, Any]) -> dict[str, Any] | None:
                 "identifier": identifier,
                 "bd_status": LINEAR_STATE_TO_BD[state],
                 "task_status": LINEAR_STATE_TO_TASK_STATUS.get(state),
+                # Carry the title so _dispatch_to_tasks can refresh the
+                # public.tasks.title column. Issue.update payloads always
+                # include the current title; without this, a row created
+                # title-less is never repaired by subsequent status events.
+                "title": data.get("title"),
                 "url": data.get("url") or f"https://linear.app/keiracom/issue/{identifier}",
             }
     if action == "remove":
@@ -241,7 +246,10 @@ def _dispatch_to_tasks(event: dict[str, Any]) -> None:
 
     On create: INSERT (id, title, priority, status='available', linear_url).
     On status update: UPDATE status using the Linear state mapping —
-    started → active, completed/canceled → done (also clears claimed_by).
+    started → active, completed/canceled → done (also clears claimed_by) —
+    and refresh the title column (Part 1 b) so a row created title-less is
+    repaired by the next status event. A placeholder title never clobbers a
+    real one (COALESCE/NULLIF guard).
     Conflicts on existing id: UPDATE the mutable fields rather than skipping,
     so the webhook is idempotent against re-deliveries.
     """
@@ -294,26 +302,33 @@ def _dispatch_to_tasks(event: dict[str, Any]) -> None:
                 # KEI-84 invariant: never downgrade a 'done' task (Linear could
                 # legitimately re-open via state change, but the spec hard-no's
                 # downgrade). Skip the UPDATE on done rows.
+                # Part 1 (b): refresh title on every status event. The nested
+                # NULLIF collapses ''/'(no title)' (and a missing title key →
+                # NULL) so COALESCE falls back to the existing title — a good
+                # title is never clobbered by a placeholder.
+                title_refresh = event.get("title")
                 if new_status == "done":
                     cur.execute(
                         """
                         UPDATE public.tasks
                            SET status = 'done', claimed_by = NULL, claimed_at = NULL,
+                               title = COALESCE(NULLIF(NULLIF(%s, ''), '(no title)'), title),
                                linear_url = COALESCE(linear_url, %s), updated_at = NOW()
                          WHERE id = %s
                         """,
-                        (url, identifier),
+                        (title_refresh, url, identifier),
                     )
                 else:
                     cur.execute(
                         """
                         UPDATE public.tasks
                            SET status = %s,
+                               title = COALESCE(NULLIF(NULLIF(%s, ''), '(no title)'), title),
                                linear_url = COALESCE(linear_url, %s),
                                updated_at = NOW()
                          WHERE id = %s AND status != 'done'
                         """,
-                        (new_status, url, identifier),
+                        (new_status, title_refresh, url, identifier),
                     )
             elif op == "remove":
                 # KEI-84: Linear issue deletion → flip to cancelled. Same never-downgrade-done guard.

--- a/tests/api/webhooks/_webhook_mocks.py
+++ b/tests/api/webhooks/_webhook_mocks.py
@@ -1,0 +1,49 @@
+"""Shared psycopg fakes for tests/api/webhooks/ — extracted per Sonar
+new_duplicated_lines_density.
+
+Single source of truth for the in-memory cursor/connection stand-ins that
+intercept psycopg.connect() in webhook dispatch tests (test_linear_webhook_kei228,
+test_linear_webhook_part1_title). Mirrors the tests/scripts/_db_mocks.py pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class FakeCursor:
+    """Minimal psycopg cursor stand-in. Records every execute() call in
+    `executed` as [(sql, params), ...]."""
+
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    def __enter__(self) -> FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.executed.append((sql, params or ()))
+
+
+class FakeConn:
+    """Minimal psycopg connection stand-in. Exposes a single FakeCursor via
+    `_cur`; flips `committed` on commit()."""
+
+    def __init__(self, raise_on_connect: bool = False) -> None:
+        self._cur = FakeCursor()
+        self.committed = False
+
+    def __enter__(self) -> FakeConn:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def cursor(self) -> FakeCursor:
+        return self._cur
+
+    def commit(self) -> None:
+        self.committed = True

--- a/tests/api/webhooks/test_linear_webhook_kei228.py
+++ b/tests/api/webhooks/test_linear_webhook_kei228.py
@@ -12,53 +12,23 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _webhook_mocks import FakeConn  # noqa: E402 — shared psycopg fakes
 
 from src.api.webhooks import linear as linear_webhook  # noqa: E402
-
-
-class _FakeCursor:
-    def __init__(self) -> None:
-        self.executed: list[tuple[str, tuple[Any, ...]]] = []
-
-    def __enter__(self) -> _FakeCursor:
-        return self
-
-    def __exit__(self, *_exc: object) -> None:
-        return None
-
-    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
-        self.executed.append((sql, params or ()))
-
-
-class _FakeConn:
-    def __init__(self, raise_on_connect: bool = False) -> None:
-        self._cur = _FakeCursor()
-        self.committed = False
-
-    def __enter__(self) -> _FakeConn:
-        return self
-
-    def __exit__(self, *_exc: object) -> None:
-        return None
-
-    def cursor(self) -> _FakeCursor:
-        return self._cur
-
-    def commit(self) -> None:
-        self.committed = True
 
 
 @pytest.fixture
 def fake_psycopg(monkeypatch):
     """Install a fake psycopg module on the linear module's import path."""
-    conn = _FakeConn()
+    conn = FakeConn()
     fake = MagicMock()
     fake.connect = MagicMock(return_value=conn)
     monkeypatch.setitem(sys.modules, "psycopg", fake)

--- a/tests/api/webhooks/test_linear_webhook_part1_title.py
+++ b/tests/api/webhooks/test_linear_webhook_part1_title.py
@@ -12,52 +12,22 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _webhook_mocks import FakeConn  # noqa: E402 — shared psycopg fakes
 
 from src.api.webhooks import linear as linear_webhook  # noqa: E402
 
 
-class _FakeCursor:
-    def __init__(self) -> None:
-        self.executed: list[tuple[str, tuple[Any, ...]]] = []
-
-    def __enter__(self) -> _FakeCursor:
-        return self
-
-    def __exit__(self, *_exc: object) -> None:
-        return None
-
-    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
-        self.executed.append((sql, params or ()))
-
-
-class _FakeConn:
-    def __init__(self) -> None:
-        self._cur = _FakeCursor()
-        self.committed = False
-
-    def __enter__(self) -> _FakeConn:
-        return self
-
-    def __exit__(self, *_exc: object) -> None:
-        return None
-
-    def cursor(self) -> _FakeCursor:
-        return self._cur
-
-    def commit(self) -> None:
-        self.committed = True
-
-
 @pytest.fixture
 def fake_psycopg(monkeypatch):
-    conn = _FakeConn()
+    conn = FakeConn()
     fake = MagicMock()
     fake.connect = MagicMock(return_value=conn)
     monkeypatch.setitem(sys.modules, "psycopg", fake)

--- a/tests/api/webhooks/test_linear_webhook_part1_title.py
+++ b/tests/api/webhooks/test_linear_webhook_part1_title.py
@@ -1,0 +1,168 @@
+"""Part 1 (b) — tests for the Linear webhook title-refresh wire.
+
+Covers:
+  - _normalise_event update branch now carries the issue title
+  - _dispatch_to_tasks status op refreshes public.tasks.title
+  - the refresh SQL uses a COALESCE/NULLIF guard so a placeholder title
+    never clobbers a real one
+  - the done-branch status update also refreshes title
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.api.webhooks import linear as linear_webhook  # noqa: E402
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.executed.append((sql, params or ()))
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self._cur = _FakeCursor()
+        self.committed = False
+
+    def __enter__(self) -> _FakeConn:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def cursor(self) -> _FakeCursor:
+        return self._cur
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+@pytest.fixture
+def fake_psycopg(monkeypatch):
+    conn = _FakeConn()
+    fake = MagicMock()
+    fake.connect = MagicMock(return_value=conn)
+    monkeypatch.setitem(sys.modules, "psycopg", fake)
+    return conn
+
+
+@pytest.fixture(autouse=True)
+def _dsn_env(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h:5432/d")
+
+
+def _update_payload(identifier: str, state_type: str, title: str | None) -> dict:
+    data: dict = {
+        "identifier": identifier,
+        "state": {"type": state_type, "name": state_type},
+        "url": "https://linear.app/x",
+    }
+    if title is not None:
+        data["title"] = title
+    return {"action": "update", "type": "Issue", "data": data}
+
+
+# ─── _normalise_event carries title ────────────────────────────────────────
+
+
+def test_normalise_update_carries_title():
+    out = linear_webhook._normalise_event(_update_payload("KEI-100", "started", "Real issue title"))
+    assert out["op"] == "status"
+    assert out["title"] == "Real issue title"
+
+
+def test_normalise_update_title_none_when_absent():
+    out = linear_webhook._normalise_event(_update_payload("KEI-100", "started", None))
+    assert out["op"] == "status"
+    assert out["title"] is None
+
+
+# ─── _dispatch_to_tasks refreshes title (non-done branch) ───────────────────
+
+
+def test_dispatch_status_active_refreshes_title(fake_psycopg):
+    event = {
+        "op": "status",
+        "identifier": "KEI-200",
+        "task_status": "active",
+        "title": "Refreshed title",
+        "url": "u",
+    }
+    linear_webhook._dispatch_to_tasks(event)
+    sql, params = fake_psycopg._cur.executed[0]
+    assert "title = COALESCE(NULLIF(NULLIF(%s, ''), '(no title)'), title)" in sql
+    # param order: (new_status, title, url, identifier)
+    assert params == ("active", "Refreshed title", "u", "KEI-200")
+
+
+def test_dispatch_status_done_refreshes_title(fake_psycopg):
+    event = {
+        "op": "status",
+        "identifier": "KEI-201",
+        "task_status": "done",
+        "title": "Done-state title",
+        "url": "u",
+    }
+    linear_webhook._dispatch_to_tasks(event)
+    sql, params = fake_psycopg._cur.executed[0]
+    assert "title = COALESCE(NULLIF(NULLIF(%s, ''), '(no title)'), title)" in sql
+    # param order: (title, url, identifier)
+    assert params == ("Done-state title", "u", "KEI-201")
+
+
+def test_dispatch_status_placeholder_title_passed_for_nullif_guard(fake_psycopg):
+    """A '(no title)' event title is still passed as a param — the SQL's
+    nested NULLIF collapses it so COALESCE keeps the existing row title.
+    The guard lives in SQL, so the test asserts the param + the clause."""
+    event = {
+        "op": "status",
+        "identifier": "KEI-202",
+        "task_status": "active",
+        "title": "(no title)",
+        "url": "u",
+    }
+    linear_webhook._dispatch_to_tasks(event)
+    sql, params = fake_psycopg._cur.executed[0]
+    assert "NULLIF(NULLIF(%s, ''), '(no title)')" in sql
+    assert params[1] == "(no title)"
+
+
+def test_dispatch_status_missing_title_key_passes_none(fake_psycopg):
+    """No title key in the event → None param; COALESCE keeps existing title."""
+    event = {"op": "status", "identifier": "KEI-203", "task_status": "active", "url": "u"}
+    linear_webhook._dispatch_to_tasks(event)
+    _, params = fake_psycopg._cur.executed[0]
+    assert params[1] is None
+
+
+def test_dispatch_create_still_sets_title(fake_psycopg):
+    """Regression-lock: the create path's title INSERT is unchanged."""
+    event = {
+        "op": "create",
+        "identifier": "KEI-204",
+        "title": "Created title",
+        "priority": 2,
+        "url": "u",
+    }
+    linear_webhook._dispatch_to_tasks(event)
+    sql, params = fake_psycopg._cur.executed[0]
+    assert "INSERT INTO public.tasks" in sql
+    assert "Created title" in params

--- a/tests/scripts/test_backfill_task_titles_from_linear.py
+++ b/tests/scripts/test_backfill_task_titles_from_linear.py
@@ -1,0 +1,205 @@
+"""tests for scripts/backfill_task_titles_from_linear.py — Part 1 title backfill.
+
+Linear GraphQL + psycopg both mocked. Verifies:
+  - fetch_linear_titles paginates and builds {identifier: title}
+  - plan_backfill partitions bad-title rows into matched / unmatched
+  - unmatched: identifier absent from Linear, OR Linear title is a placeholder
+  - apply_backfill issues an idempotent UPDATE per matched row
+  - the UPDATE's WHERE clause re-asserts the bad-title predicate
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "backfill_task_titles_from_linear.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("backfill_task_titles", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["backfill_task_titles"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+class _Cursor:
+    """psycopg cursor stand-in with rowcount (the shared FakeCursor lacks it)."""
+
+    def __init__(self, fetchall_rows=None, fetchone_row=None):
+        self._all = fetchall_rows or []
+        self._one = fetchone_row
+        self.executed: list[tuple[str, tuple | None]] = []
+        self.rowcount = 1
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchall(self):
+        return self._all
+
+    def fetchone(self):
+        return self._one
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return None
+
+
+class _Conn:
+    def __init__(self, cur):
+        self._cur = cur
+        self.commits = 0
+
+    def cursor(self):
+        return self._cur
+
+    def commit(self):
+        self.commits += 1
+
+
+# ─── fetch_linear_titles ──────────────────────────────────────────────────
+
+
+def _fake_urlopen_factory(pages):
+    """Return a urlopen stand-in that yields each page response in order."""
+    calls = {"n": 0}
+
+    class _Resp:
+        def __init__(self, body):
+            self._body = body
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+    def _urlopen(req, timeout=None):
+        body = json.dumps(pages[calls["n"]]).encode()
+        calls["n"] += 1
+        return _Resp(body)
+
+    return _urlopen
+
+
+def test_fetch_linear_titles_paginates(mod, monkeypatch):
+    """Two-page Linear response → both pages merged into one dict."""
+    monkeypatch.setenv("LINEAR_API_KEY", "lin_test")
+    page1 = {
+        "data": {
+            "issues": {
+                "nodes": [{"identifier": "KEI-1", "title": "first"}],
+                "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+            }
+        }
+    }
+    page2 = {
+        "data": {
+            "issues": {
+                "nodes": [{"identifier": "KEI-2", "title": "second"}],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            }
+        }
+    }
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _fake_urlopen_factory([page1, page2]))
+    titles = mod.fetch_linear_titles()
+    assert titles == {"KEI-1": "first", "KEI-2": "second"}
+
+
+def test_fetch_linear_titles_raises_on_graphql_errors(mod, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "lin_test")
+    err_page = {"errors": [{"message": "team not found"}]}
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _fake_urlopen_factory([err_page]))
+    with pytest.raises(RuntimeError, match="Linear GraphQL errors"):
+        mod.fetch_linear_titles()
+
+
+def test_fetch_linear_titles_missing_key_raises(mod, monkeypatch):
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="LINEAR_API_KEY"):
+        mod.fetch_linear_titles()
+
+
+# ─── plan_backfill ─────────────────────────────────────────────────────────
+
+
+def test_plan_backfill_matches_good_titles(mod):
+    cur = _Cursor(fetchall_rows=[("KEI-1",), ("KEI-2",)])
+    linear = {"KEI-1": "real title one", "KEI-2": "real title two"}
+    plan = mod.plan_backfill(_Conn(cur), linear)
+    assert sorted(plan["matched"]) == [
+        ("KEI-1", "real title one"),
+        ("KEI-2", "real title two"),
+    ]
+    assert plan["unmatched"] == []
+
+
+def test_plan_backfill_unmatched_when_identifier_absent(mod):
+    """A bad-title row whose identifier has no Linear issue → unmatched."""
+    cur = _Cursor(fetchall_rows=[("KEI-1",), ("KEI-999",)])
+    linear = {"KEI-1": "real title"}
+    plan = mod.plan_backfill(_Conn(cur), linear)
+    assert plan["matched"] == [("KEI-1", "real title")]
+    assert plan["unmatched"] == ["KEI-999"]
+
+
+def test_plan_backfill_unmatched_when_linear_title_is_placeholder(mod):
+    """Linear issue exists but its title is itself a placeholder → unmatched
+    (the backfill cannot repair the row, so it is surfaced for triage)."""
+    cur = _Cursor(fetchall_rows=[("KEI-1",), ("KEI-2",), ("KEI-3",)])
+    linear = {"KEI-1": "real", "KEI-2": "(no title)", "KEI-3": ""}
+    plan = mod.plan_backfill(_Conn(cur), linear)
+    assert plan["matched"] == [("KEI-1", "real")]
+    assert sorted(plan["unmatched"]) == ["KEI-2", "KEI-3"]
+
+
+# ─── apply_backfill ────────────────────────────────────────────────────────
+
+
+def test_apply_backfill_issues_update_per_matched_row(mod):
+    cur = _Cursor()
+    written = mod.apply_backfill(_Conn(cur), [("KEI-1", "t1"), ("KEI-2", "t2")])
+    assert written == 2
+    assert len(cur.executed) == 2
+    sql, params = cur.executed[0]
+    assert "UPDATE public.tasks" in sql
+    assert params == ("t1", "KEI-1")
+
+
+def test_apply_backfill_where_clause_is_idempotent(mod):
+    """The UPDATE WHERE must re-assert the bad-title predicate so a row that
+    gained a title between plan and apply is left untouched."""
+    cur = _Cursor()
+    mod.apply_backfill(_Conn(cur), [("KEI-1", "t1")])
+    sql, _ = cur.executed[0]
+    assert "title IS NULL" in sql
+    assert "title = ''" in sql
+    assert "title = '(no title)'" in sql
+
+
+def test_apply_backfill_commits(mod):
+    cur = _Cursor()
+    conn = _Conn(cur)
+    mod.apply_backfill(conn, [("KEI-1", "t1")])
+    assert conn.commits == 1
+
+
+def test_count_remaining_reads_bad_title_predicate(mod):
+    cur = _Cursor(fetchone_row=(0,))
+    assert mod.count_remaining(_Conn(cur)) == 0
+    sql, _ = cur.executed[0]
+    assert "count(*)" in sql
+    assert "title = '(no title)'" in sql


### PR DESCRIPTION
## Summary

Dave directive 2026-05-20, **Part 1**. 174 rows in `public.tasks` had `title='(no title)'`. `public.tasks.id` IS the Linear identifier (`KEI-N`) — direct id match, no mapping table.

**(a) Backfill** — `scripts/backfill_task_titles_from_linear.py` (new)
- Reads every Keiracom-team issue `{identifier, title}` from the Linear GraphQL API — paginated, `includeArchived` so Done/Cancelled issues are not dropped.
- `UPDATE public.tasks SET title=<linear title> WHERE id=<identifier> AND (title IS NULL OR title='' OR title='(no title)')`.
- `--apply` gates the write (default dry-run). Idempotent — the UPDATE WHERE re-asserts the bad-title predicate. Reports any identifier with no Linear match.

**(b) Ongoing wire** — `src/api/webhooks/linear.py` (modified)
- `_normalise_event` update branch now carries the issue title.
- `_dispatch_to_tasks` status op refreshes `public.tasks.title` on every status event (done + non-done branches) — a row created title-less is now repaired by the next status event, not just by a create event.
- `COALESCE(NULLIF(NULLIF(%s,''),'(no title)'), title)` guard — a placeholder/missing event title never clobbers a real one.

## LAW compliance

Linear-**READ** + Supabase-**WRITE** only. No Linear mutation anywhere. The ratified LAW (2026-05-20, `CONSOLIDATED_RULES.md` §LAW — LINEAR IS READ-ONLY) forbids writing Linear, not reading it.

## Backfill run (verbatim, live `jatzvazlbusedwsnqxzr`)

```
$ python3 scripts/backfill_task_titles_from_linear.py --apply
INFO: fetched 239 issue titles from Linear
INFO: applied 174 rows
matched (have Linear title):  174
unmatched (no Linear title):  0
applied (rows updated):       174
remaining bad-title rows:     0
```

Independent verify (MCP bridge):
```
SELECT count(*) FROM tasks WHERE title IS NULL OR title='' OR title='(no title)'  →  0
```

Spot-check: `KEI-1` → "Get familiar with Linear", `KEI-108` → "Verify Weaviate collections populated after Phase B/C indexer merge", `KEI-239` → "[ATLAS] KEI-239 — `bd complete` becomes the canonical completion gesture…".

## Test plan
- [x] 10 backfill tests — pagination, GraphQL-error raise, missing-key raise, matched/unmatched partition, idempotent WHERE, commit
- [x] 7 webhook tests — title carried on update, title refresh on done + non-done status, placeholder NULLIF-guard, missing-title None, create-path regression lock
- [x] 12 existing kei84/kei228 webhook tests still pass (29 total)
- [x] ruff check + format clean
- [x] backfill applied to live DB; verify count = 0

bd: `Agency_OS-9dbw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)