### PR TITLE
[ORION] feat(kei237): reconciler flags drift for review — no auto-fix

### DIFF
--- a/scripts/reconcile_three_stores.py
+++ b/scripts/reconcile_three_stores.py
@@ -33,7 +33,6 @@ import logging
 import os
 import subprocess
 import sys
-import urllib.error
 import urllib.request
 from typing import Any
 
@@ -301,7 +300,8 @@ def post_to_slack(text: str, channel: str) -> bool:
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return bool(json.loads(r.read()).get("ok"))
-    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+    except (OSError, json.JSONDecodeError) as exc:
+        # urllib.error.URLError subclasses OSError — OSError covers it.
         logger.warning("Slack drift-alert post failed: %s", exc)
         return False
 

--- a/scripts/reconcile_three_stores.py
+++ b/scripts/reconcile_three_stores.py
@@ -2,10 +2,19 @@
 """reconcile_three_stores.py — KEI-230 K4 — belt-and-braces 3-store reconciler.
 
 Walks Linear + Postgres public.tasks + bd-Dolt, builds a canonical join
-table on (KEI-N, bd_id), detects drift (present in 1-of-3, 2-of-3, or
-all-3-but-divergent), and emits sync_events to backfill the missing
-rows. The K3 sync_orchestrator drains the events and writes to the
-target stores.
+table on (KEI-N, bd_id), and detects drift (present in 1-of-3, 2-of-3,
+or all-3-but-divergent).
+
+KEI-237 (Dave ratified 2026-05-20) — the reconciler RAISES A FLAG for
+human review; it does NOT auto-fix. ALL drift buckets (field_drift AND
+the three missing_* buckets) are flag-only. `--apply` posts ONE
+consolidated drift alert to the existing Slack alert path (#ceo by
+default) — the same channel the other scripts/alerts/* monitors use. It
+no longer emits sync_events and creates no new table. Propagation is
+handled by a controlled one-way push and/or a human acting on the
+alert — never by this detector. This removes the auto-fix feedback loop
+(reconciler emits event → orchestrator writes store → trigger emits
+event → …).
 
 Generalises scripts/reconcile_linear_supabase.py — which only does the
 Linear→Postgres direction one-shot — to a 3-way reconciler safe to run
@@ -13,7 +22,7 @@ on a 30-min systemd timer.
 
 Usage:
     python3 scripts/reconcile_three_stores.py            # dry-run summary
-    python3 scripts/reconcile_three_stores.py --apply    # emit events to sync_events
+    python3 scripts/reconcile_three_stores.py --apply    # post drift alert
 """
 
 from __future__ import annotations
@@ -24,6 +33,7 @@ import logging
 import os
 import subprocess
 import sys
+import urllib.error
 import urllib.request
 from typing import Any
 
@@ -33,6 +43,12 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 _LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
 _LINEAR_TEAM_ID_DEFAULT = "4686528f-ce77-4c2f-968b-3dc76b34d6fe"  # Keiracom
 _BD_BIN_DEFAULT = os.path.expanduser("~/.local/bin/bd")
+
+# KEI-237 — drift alerts route to the existing Slack alert path (same bot-token
+# chat.postMessage the scripts/alerts/* monitors use). #ceo is the human-review
+# surface; env-overridable.
+_SLACK_API_URL = "https://slack.com/api/chat.postMessage"
+_CEO_CHANNEL_DEFAULT = "C0B2PM3TV0B"
 
 # Linear StateType → public.tasks.status. Mirrors webhook mapping.
 # KEI-235-followup: Postgres tasks_status_check CHECK constraint allows
@@ -200,6 +216,12 @@ def _has_field_drift(entry: dict[str, Any]) -> bool:
     have no Linear equivalent — never flagged as drift. Postgres `done` /
     `cancelled` are sticky (matches the orchestrator's done-preservation
     invariant in `_dispatch_postgres`); never re-opened automatically here.
+
+    KEI-237 (c) — comparison is tightened: both sides are normalised
+    (strip + lower-case) so field-format noise (casing, surrounding
+    whitespace) cannot raise a false flag. Only the mapped `status` enum
+    is compared — timestamps (updated_at etc.) are never compared, so
+    timestamp jitter cannot drift-flag either.
     """
     stores = entry["stores"]
     linear_iss = stores.get("linear") or {}
@@ -207,14 +229,16 @@ def _has_field_drift(entry: dict[str, Any]) -> bool:
     canonical = _linear_canonical_status(linear_iss)
     if canonical is None:
         return False
-    actual = pg_row.get("status")
-    if actual in ("dismissed", "blocked"):
+    norm_actual = str(pg_row.get("status") or "").strip().lower()
+    norm_canonical = str(canonical).strip().lower()
+    # Postgres-only / sticky terminal statuses — not drift.
+    if norm_actual in ("dismissed", "blocked", "done", "cancelled"):
         return False
-    if actual in ("done", "cancelled"):
-        return False
-    # NULL pg.status counts as drift — the row exists but has no status set,
-    # so propagating Linear's canonical value is strictly an improvement.
-    return actual != canonical
+    # NULL/empty pg.status with a real canonical IS drift — the row exists
+    # but has no status set; the canonical value is worth surfacing.
+    if not norm_actual:
+        return True
+    return norm_actual != norm_canonical
 
 
 def detect_drift(table: dict[str, dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
@@ -246,118 +270,101 @@ def detect_drift(table: dict[str, dict[str, Any]]) -> dict[str, list[dict[str, A
     return out
 
 
-def _build_create_payload(kei: str, stores: dict[str, Any]) -> dict[str, Any]:
-    """Pick the canonical record from whichever stores have it.
+# Drift buckets that become reviewable flags. `in_all_three` is the
+# healthy bucket — never flagged.
+_FLAG_BUCKETS = ("missing_postgres", "missing_bd", "missing_linear", "field_drift")
 
-    Used for the `missing_*` buckets where the store-being-backfilled has
-    no row yet — Linear is preferred as the seed because it's where Dave
-    creates KEIs (title/priority/intent live there first).
+
+def post_to_slack(text: str, channel: str) -> bool:
+    """Best-effort Slack post via bot-token chat.postMessage. Returns True on ok.
+
+    Mirrors the proven pattern in scripts/alerts/service_health_monitor.py —
+    the existing alert path. No retry, no exception propagation: a drift
+    alert that fails to post must not crash the timer.
     """
-    linear_iss = stores.get("linear") or {}
-    bd_iss = stores.get("bd") or {}
-    pg_row = stores.get("postgres") or {}
-    title = linear_iss.get("title") or pg_row.get("title") or bd_iss.get("title") or "(no title)"
-    linear_state_type = (linear_iss.get("state") or {}).get("type") or ""
-    status = (
-        LINEAR_STATE_TO_TASK_STATUS.get(linear_state_type) or pg_row.get("status") or "available"
+    token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if not token:
+        logger.warning("SLACK_BOT_TOKEN not set — cannot post drift alert")
+        return False
+    payload = json.dumps(
+        {"channel": channel, "text": text, "username": "DriftReconciler", "icon_emoji": ":mag:"}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        _SLACK_API_URL,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        method="POST",
     )
-    priority = linear_iss.get("priority") or pg_row.get("priority")
-    url = (
-        linear_iss.get("url")
-        or pg_row.get("linear_url")
-        or f"https://linear.app/keiracom/issue/{kei}"
-    )
-    return {
-        "id": kei,
-        "bd_id": bd_iss.get("id") or pg_row.get("bd_id"),
-        "title": title,
-        "status": status,
-        "priority": priority,
-        "linear_url": url,
-    }
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return bool(json.loads(r.read()).get("ok"))
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("Slack drift-alert post failed: %s", exc)
+        return False
 
 
-def _build_postgres_payload(kei: str, stores: dict[str, Any]) -> dict[str, Any]:
-    """KEI-237 — build payload from Postgres-as-canonical for field_drift events.
+def _field_drift_detail(entry: dict[str, Any]) -> str:
+    """One-line linear-state vs pg-status detail for a field_drift entry."""
+    linear_iss = entry["stores"].get("linear") or {}
+    pg_row = entry["stores"].get("postgres") or {}
+    state = (linear_iss.get("state") or {}).get("type", "?")
+    return f"{entry['kei']} (linear={state} pg={pg_row.get('status')})"
 
-    Under the Dave 2026-05-19 policy (bd=CLI, Postgres=canonical,
-    Linear=mirror), field-level drift between Postgres and another store
-    is resolved by propagating Postgres's value OUT, never the reverse.
-    The orchestrator's `_dispatch_linear` (per KEI-236) only writes
-    Linear on terminal `close`/`reopen` transitions, so `update` events
-    from this path effectively only correct bd-Dolt — Linear stays
-    where it is until a real terminal transition flows from Postgres.
+
+def _format_drift_alert(drift: dict[str, list[dict[str, Any]]]) -> str | None:
+    """Build the consolidated drift alert text. None when there is no drift.
+
+    One message summarising every flagged bucket — KEI lists for the
+    missing_* buckets, linear-vs-pg detail for field_drift. The reviewer
+    resolves manually or via the controlled one-way push.
     """
-    bd_iss = stores.get("bd") or {}
-    pg_row = stores.get("postgres") or {}
-    linear_iss = stores.get("linear") or {}
-    return {
-        "id": kei,
-        "bd_id": pg_row.get("bd_id") or bd_iss.get("id"),
-        "title": pg_row.get("title") or linear_iss.get("title") or "(no title)",
-        "status": pg_row.get("status") or "available",
-        "priority": pg_row.get("priority"),
-        "linear_url": pg_row.get("linear_url")
-        or linear_iss.get("url")
-        or f"https://linear.app/keiracom/issue/{kei}",
-    }
+    total = sum(len(drift.get(b, [])) for b in _FLAG_BUCKETS)
+    if total == 0:
+        return None
+    lines = [f"[DRIFT] reconcile_three_stores — {total} KEI(s) need human review"]
+    for bucket in _FLAG_BUCKETS:
+        entries = drift.get(bucket, [])
+        if not entries:
+            continue
+        if bucket == "field_drift":
+            detail = ", ".join(_field_drift_detail(e) for e in entries[:20])
+        else:
+            detail = ", ".join(e["kei"] for e in entries[:20])
+        more = f" (+{len(entries) - 20} more)" if len(entries) > 20 else ""
+        lines.append(f"  {bucket} ({len(entries)}): {detail}{more}")
+    lines.append("Flag-only — no auto-fix. Resolve manually or via the one-way push.")
+    return "\n".join(lines)
 
 
-def _emit_events(conn: Any, drift: dict[str, list[dict[str, Any]]]) -> int:
-    """Insert sync_events to backfill missing stores. Returns event count emitted."""
-    emitted = 0
-    with conn.cursor() as cur:
-        # Each "missing X" bucket emits an event from the FIRST present store as origin.
-        # K3 then dispatches to the OTHER two (including the missing one).
-        for entry in drift["missing_postgres"]:
-            origin = "linear" if entry["stores"].get("linear") else "bd"
-            payload = _build_create_payload(entry["kei"], entry["stores"])
-            cur.execute(
-                "SELECT public.fn_emit_sync_event(%s, %s, %s, %s, %s::jsonb)",
-                (origin, "create", entry["kei"], payload["bd_id"], json.dumps(payload)),
-            )
-            emitted += 1
-        for entry in drift["missing_bd"]:
-            origin = "linear" if entry["stores"].get("linear") else "postgres"
-            payload = _build_create_payload(entry["kei"], entry["stores"])
-            cur.execute(
-                "SELECT public.fn_emit_sync_event(%s, %s, %s, %s, %s::jsonb)",
-                (origin, "create", entry["kei"], payload["bd_id"], json.dumps(payload)),
-            )
-            emitted += 1
-        for entry in drift["missing_linear"]:
-            origin = "bd" if entry["stores"].get("bd") else "postgres"
-            payload = _build_create_payload(entry["kei"], entry["stores"])
-            cur.execute(
-                "SELECT public.fn_emit_sync_event(%s, %s, %s, %s, %s::jsonb)",
-                (origin, "create", entry["kei"], payload["bd_id"], json.dumps(payload)),
-            )
-            emitted += 1
-        # KEI-237 — field-drift bucket: under the new policy Postgres is
-        # canonical, so we emit origin=postgres with the Postgres-side
-        # payload. The orchestrator (KEI-236) will dispatch to bd (fixes
-        # bd-Dolt) but skip the Linear write for `update` events — Linear
-        # stays where it is until a real terminal transition flows out
-        # via `close`/`reopen` events from the trigger.
-        for entry in drift["field_drift"]:
-            payload = _build_postgres_payload(entry["kei"], entry["stores"])
-            cur.execute(
-                "SELECT public.fn_emit_sync_event(%s, %s, %s, %s, %s::jsonb)",
-                ("postgres", "update", entry["kei"], payload["bd_id"], json.dumps(payload)),
-            )
-            emitted += 1
-    conn.commit()
-    return emitted
+def _post_drift_alert(drift: dict[str, list[dict[str, Any]]]) -> int:
+    """Post one consolidated drift alert to #ceo. Returns flagged-KEI count.
+
+    KEI-237 — replaces sync_event emission. The reconciler DETECTS and
+    FLAGS via the existing Slack alert path; it does not auto-fix and
+    creates no new table.
+    """
+    text = _format_drift_alert(drift)
+    if text is None:
+        logger.info("no drift — no alert posted")
+        return 0
+    channel = os.environ.get("DRIFT_ALERT_CHANNEL", _CEO_CHANNEL_DEFAULT)
+    ok = post_to_slack(text, channel)
+    total = sum(len(drift.get(b, [])) for b in _FLAG_BUCKETS)
+    logger.info("drift alert posted=%s — %d KEI(s) flagged", ok, total)
+    return total
 
 
-def _print_summary(drift: dict[str, list[dict[str, Any]]], emitted: int | None) -> None:
+def _print_summary(drift: dict[str, list[dict[str, Any]]], flagged: int | None) -> None:
     print(f"in_all_three:    {len(drift['in_all_three'])}")
     print(f"missing_postgres:{len(drift['missing_postgres'])}")
     print(f"missing_bd:      {len(drift['missing_bd'])}")
     print(f"missing_linear:  {len(drift['missing_linear'])}")
     print(f"field_drift:     {len(drift.get('field_drift', []))}")
-    if emitted is not None:
-        print(f"events_emitted:  {emitted}")
+    if flagged is not None:
+        print(f"alert_flagged:   {flagged}")
     for bucket in ("missing_postgres", "missing_bd", "missing_linear", "field_drift"):
         if drift.get(bucket):
             print(f"\n{bucket} (first 5):")
@@ -374,7 +381,11 @@ def _print_summary(drift: dict[str, list[dict[str, Any]]], emitted: int | None) 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--apply", action="store_true", help="Emit sync_events (default dry-run)")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Post the drift alert to Slack #ceo (default dry-run, no alert)",
+    )
     args = parser.parse_args(argv)
 
     api_key = os.environ.get("LINEAR_API_KEY", "")
@@ -404,11 +415,10 @@ def main(argv: list[str] | None = None) -> int:
 
         table = build_join_table(linear_issues, postgres_rows, bd_issues)
         drift = detect_drift(table)
-        emitted: int | None = None
-        if args.apply:
-            emitted = _emit_events(conn, drift)
-            logger.info("emitted %d sync_events", emitted)
-    _print_summary(drift, emitted)
+    flagged: int | None = None
+    if args.apply:
+        flagged = _post_drift_alert(drift)
+    _print_summary(drift, flagged)
     return 0
 
 

--- a/tests/scripts/test_reconcile_three_stores.py
+++ b/tests/scripts/test_reconcile_three_stores.py
@@ -1,10 +1,12 @@
-"""KEI-230 — tests for reconcile_three_stores.py.
+"""KEI-230 / KEI-237 — tests for reconcile_three_stores.py.
 
 Covers:
 - _kei_from_url: handles slug, no-slug, trailing-slash, empty
 - build_join_table: composes 3 store views by KEI
 - detect_drift: classifies in_all_three / missing_postgres / missing_bd / missing_linear
-- _build_create_payload: picks canonical fields (Linear status > postgres)
+- _has_field_drift: stale-status detection + KEI-237 normalised comparison
+- _format_drift_alert / _post_drift_alert: flag-only drift alert (KEI-237)
+- post_to_slack: token-absent guard
 """
 
 from __future__ import annotations
@@ -12,6 +14,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -142,7 +145,7 @@ def test_detect_drift_missing_linear(mod) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Field drift (KEI-233).
+# Field drift (KEI-233 + KEI-237 normalised comparison).
 # ---------------------------------------------------------------------------
 
 
@@ -203,7 +206,7 @@ def test_field_drift_skips_postgres_only_buckets(mod) -> None:
 
 
 def test_field_drift_null_pg_status_counts(mod) -> None:
-    """NULL pg.status with a canonical Linear value IS drift — propagate Linear."""
+    """NULL pg.status with a canonical Linear value IS drift — surface it."""
     table = {
         "KEI-4": {
             "linear": {"state": {"type": "backlog"}},
@@ -243,145 +246,122 @@ def test_field_drift_only_evaluated_for_in_all_three(mod) -> None:
     assert len(drift["missing_bd"]) == 1
 
 
-# ---------------------------------------------------------------------------
-# Payload construction.
-# ---------------------------------------------------------------------------
+def test_field_drift_comparison_is_case_and_whitespace_insensitive(mod) -> None:
+    """KEI-237 (c) — format noise (casing / whitespace) must NOT raise a flag.
 
-
-def test_build_create_payload_prefers_linear_status(mod) -> None:
-    stores = {
-        "linear": {
-            "title": "Linear title",
-            "state": {"type": "started", "name": "In Progress"},
-            "priority": 1,
-            "url": "https://linear.app/keiracom/issue/KEI-9",
-        },
-        "postgres": {"title": "Postgres title", "status": "done", "priority": 4},
-        "bd": {"id": "Agency_OS-xxx"},
+    Linear=started → canonical 'active'. Postgres status '  ACTIVE  ' differs
+    only in case + surrounding whitespace — normalised, it matches, so no
+    false field_drift flag.
+    """
+    table = {
+        "KEI-7": {
+            "linear": {"state": {"type": "started"}},  # canonical 'active'
+            "postgres": {"status": "  ACTIVE  "},
+            "bd": {"id": "Agency_OS-fff"},
+        }
     }
-    payload = mod._build_create_payload("KEI-9", stores)
-    assert payload["title"] == "Linear title"
-    assert payload["status"] == "active"  # started → active
-    assert payload["priority"] == 1
-    assert payload["bd_id"] == "Agency_OS-xxx"
-
-
-def test_build_create_payload_falls_back_to_postgres_when_no_linear(mod) -> None:
-    stores = {
-        "postgres": {
-            "title": "PG only",
-            "status": "available",
-            "priority": 3,
-            "bd_id": "Agency_OS-y",
-        },
-        "bd": {"id": "Agency_OS-y"},
-    }
-    payload = mod._build_create_payload("KEI-10", stores)
-    assert payload["title"] == "PG only"
-    assert payload["status"] == "available"
-    assert payload["bd_id"] == "Agency_OS-y"
-
-
-def test_build_create_payload_default_linear_url(mod) -> None:
-    payload = mod._build_create_payload("KEI-11", {})
-    assert payload["linear_url"] == "https://linear.app/keiracom/issue/KEI-11"
-    assert payload["status"] == "available"
-    assert payload["title"] == "(no title)"
+    drift = mod.detect_drift(table)
+    assert drift["field_drift"] == [], "case/whitespace noise must not drift-flag"
 
 
 # ---------------------------------------------------------------------------
-# KEI-237 — postgres-canonical payload + emission flip.
+# KEI-237 — flag-only drift alert (no auto-fix, no new table).
 # ---------------------------------------------------------------------------
 
 
-def test_build_postgres_payload_prefers_postgres_status(mod) -> None:
-    """Under the new policy, Postgres is canonical — _build_postgres_payload
-    must return Postgres's status, NOT Linear's mapped status."""
-    stores = {
-        "linear": {
-            "title": "Linear title",
-            "state": {"type": "completed"},  # would map to 'done'
-            "priority": 1,
-            "url": "https://linear.app/keiracom/issue/KEI-9",
-        },
-        "postgres": {
-            "title": "Postgres title",
-            "status": "active",  # canonical under new policy
-            "priority": 4,
-            "bd_id": "Agency_OS-xxx",
-            "linear_url": "https://linear.app/keiracom/issue/KEI-9",
-        },
-        "bd": {"id": "Agency_OS-xxx"},
-    }
-    payload = mod._build_postgres_payload("KEI-9", stores)
-    assert payload["status"] == "active"  # Postgres wins
-    assert payload["title"] == "Postgres title"
-    assert payload["bd_id"] == "Agency_OS-xxx"
-
-
-def test_build_postgres_payload_falls_back_to_linear_url(mod) -> None:
-    """If pg.linear_url is missing, fall back to linear_iss.url, then default."""
-    stores = {
-        "postgres": {"status": "active"},
-        "linear": {"url": "https://linear.app/keiracom/issue/KEI-22/explicit-slug"},
-    }
-    payload = mod._build_postgres_payload("KEI-22", stores)
-    assert payload["linear_url"] == "https://linear.app/keiracom/issue/KEI-22/explicit-slug"
-
-
-def test_build_postgres_payload_default_status_available(mod) -> None:
-    """Missing pg.status → defaults to 'available' (KEI-237 ON CONFLICT-safe)."""
-    payload = mod._build_postgres_payload("KEI-30", {"postgres": {}})
-    assert payload["status"] == "available"
-
-
-def test_emit_events_field_drift_uses_postgres_origin(mod) -> None:
-    """KEI-237: field_drift entries emit origin='postgres' (not 'linear')."""
-
-    class _FakeCursor:
-        def __init__(self):
-            self.executed = []
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_):
-            return None
-
-        def execute(self, sql, params=None):
-            self.executed.append((sql, params))
-
-    class _FakeConn:
-        def __init__(self):
-            self.cur = _FakeCursor()
-
-        def cursor(self):
-            return self.cur
-
-        def commit(self):
-            pass
-
-    drift = {
+def _drift(**buckets: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    base: dict[str, list[dict[str, Any]]] = {
+        "in_all_three": [],
         "missing_postgres": [],
         "missing_bd": [],
         "missing_linear": [],
-        "field_drift": [
+        "field_drift": [],
+    }
+    base.update(buckets)
+    return base
+
+
+def test_format_drift_alert_none_when_no_drift(mod) -> None:
+    """No drift in any actionable bucket → no alert text (None)."""
+    assert mod._format_drift_alert(_drift(in_all_three=[{"kei": "KEI-ok", "stores": {}}])) is None
+
+
+def test_format_drift_alert_lists_buckets_and_keis(mod) -> None:
+    drift = _drift(
+        missing_postgres=[{"kei": "KEI-20", "stores": {"linear": {}}}],
+        field_drift=[
             {
-                "kei": "KEI-99",
+                "kei": "KEI-21",
                 "stores": {
                     "linear": {"state": {"type": "completed"}},
-                    "postgres": {"status": "active", "bd_id": "Agency_OS-xx"},
-                    "bd": {"id": "Agency_OS-xx"},
+                    "postgres": {"status": "active"},
+                    "bd": {"id": "Agency_OS-x"},
                 },
             }
         ],
+    )
+    text = mod._format_drift_alert(drift)
+    assert text is not None
+    assert "[DRIFT]" in text
+    assert "2 KEI(s)" in text
+    assert "missing_postgres (1): KEI-20" in text
+    # field_drift entries carry the linear-vs-pg detail.
+    assert "KEI-21 (linear=completed pg=active)" in text
+    assert "no auto-fix" in text.lower()
+
+
+def test_format_drift_alert_truncates_long_bucket(mod) -> None:
+    """A bucket with >20 KEIs shows the first 20 + a (+N more) marker."""
+    drift = _drift(missing_bd=[{"kei": f"KEI-{i}", "stores": {"linear": {}}} for i in range(25)])
+    text = mod._format_drift_alert(drift)
+    assert text is not None
+    assert "(+5 more)" in text
+
+
+def test_post_drift_alert_no_drift_posts_nothing(mod, monkeypatch) -> None:
+    posted: list = []
+    monkeypatch.setattr(mod, "post_to_slack", lambda t, c: posted.append((t, c)) or True)
+    n = mod._post_drift_alert(_drift())
+    assert n == 0
+    assert posted == [], "no drift → no Slack post"
+
+
+def test_post_drift_alert_posts_consolidated_alert(mod, monkeypatch) -> None:
+    posted: list = []
+    monkeypatch.setattr(mod, "post_to_slack", lambda t, c: posted.append((t, c)) or True)
+    monkeypatch.delenv("DRIFT_ALERT_CHANNEL", raising=False)
+    drift = _drift(
+        missing_linear=[{"kei": "KEI-30", "stores": {"bd": {}}}],
+        missing_bd=[{"kei": "KEI-31", "stores": {"linear": {}}}],
+    )
+    n = mod._post_drift_alert(drift)
+    assert n == 2
+    assert len(posted) == 1, "exactly one consolidated alert"
+    text, channel = posted[0]
+    assert "KEI-30" in text and "KEI-31" in text
+    assert channel == mod._CEO_CHANNEL_DEFAULT  # defaults to #ceo
+
+
+def test_post_drift_alert_channel_is_env_overridable(mod, monkeypatch) -> None:
+    posted: list = []
+    monkeypatch.setattr(mod, "post_to_slack", lambda t, c: posted.append((t, c)) or True)
+    monkeypatch.setenv("DRIFT_ALERT_CHANNEL", "C-CUSTOM")
+    mod._post_drift_alert(_drift(missing_bd=[{"kei": "KEI-40", "stores": {"linear": {}}}]))
+    assert posted[0][1] == "C-CUSTOM"
+
+
+def test_post_to_slack_returns_false_without_token(mod, monkeypatch) -> None:
+    """No SLACK_BOT_TOKEN → best-effort no-op, returns False, never raises."""
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    assert mod.post_to_slack("hello", "C-X") is False
+
+
+def test_field_drift_detail_formats_linear_vs_pg(mod) -> None:
+    entry = {
+        "kei": "KEI-50",
+        "stores": {
+            "linear": {"state": {"type": "completed"}},
+            "postgres": {"status": "active"},
+        },
     }
-    conn = _FakeConn()
-    emitted = mod._emit_events(conn, drift)
-    assert emitted == 1
-    sql, params = conn.cur.executed[0]
-    assert "fn_emit_sync_event" in sql
-    # params = (origin, event_type, task_id, bd_id, payload_json)
-    assert params[0] == "postgres", "field_drift must emit origin=postgres under KEI-237"
-    assert params[1] == "update"
-    assert params[2] == "KEI-99"
+    assert mod._field_drift_detail(entry) == "KEI-50 (linear=completed pg=active)"

--- a/tests/scripts/test_reconcile_three_stores.py
+++ b/tests/scripts/test_reconcile_three_stores.py
@@ -347,6 +347,7 @@ def test_post_drift_alert_channel_is_env_overridable(mod, monkeypatch) -> None:
     monkeypatch.setattr(mod, "post_to_slack", lambda t, c: posted.append((t, c)) or True)
     monkeypatch.setenv("DRIFT_ALERT_CHANNEL", "C-CUSTOM")
     mod._post_drift_alert(_drift(missing_bd=[{"kei": "KEI-40", "stores": {"linear": {}}}]))
+    assert len(posted) == 1
     assert posted[0][1] == "C-CUSTOM"
 
 


### PR DESCRIPTION
## Summary

KEI-237 (Dave ratified 2026-05-20) — Part 3 of the complete-sync sequence. `scripts/reconcile_three_stores.py` previously DETECTED drift then AUTO-EMITTED `sync_events` that fixed it. The ratified model: the reconciler **raises a flag for human review — it never auto-fixes**. Propagation is the controlled one-way push (next item) or a human.

Tracked: bd `Agency_OS-0qta`.

## Changes (`scripts/reconcile_three_stores.py`)

- **(a)+(b) All drift buckets are flag-only** — `field_drift` AND the three `missing_*` buckets. `_emit_events`, `_build_create_payload`, `_build_postgres_payload` removed; no `fn_emit_sync_event` calls remain.
- **Routes to the existing alert path, NOT a new table.** A new drift table is Dave-gated (Atlas flag) — per Elliot's clarification the reconciler posts **one consolidated drift alert to Slack #ceo** via the bot-token `chat.postMessage` pattern every `scripts/alerts/*` monitor already uses (`post_to_slack` mirrors `service_health_monitor.py`). Channel env-overridable via `DRIFT_ALERT_CHANNEL`.
- **(c) Drift comparison tightened** — `_has_field_drift` normalises both sides (strip + lower-case) so casing/whitespace noise can't raise a false flag. Only the mapped status enum is compared; timestamps are never compared → no timestamp-jitter false flags.
- **(d) dry-run stays default** (summary only); `--apply` now posts the alert instead of emitting fix events.

No new table, no migration.

## Test plan

- [x] 26 tests pass (`pytest tests/scripts/test_reconcile_three_stores.py`)
- [x] Covers: detection (unchanged), KEI-237 normalised comparison (case/whitespace), alert formatting (None on no-drift, bucket lists, >20 truncation), `_post_drift_alert` (no-drift → no post, one consolidated post, env-overridable channel), `post_to_slack` token-absent guard
- [x] ruff check + format clean
- [ ] CI green
- [ ] Reviewer dual-concur (Aiden + Max)

🤖 Generated with [Claude Code](https://claude.com/claude-code)