### PR TITLE
[ATLAS] feat(1x3x): Part 4 — one-way Supabase→Linear status push

### DIFF
--- a/infra/systemd/linear-oneway-push.service
+++ b/infra/systemd/linear-oneway-push.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Agency OS — One-way Supabase→Linear status push (Agency_OS-1x3x, sole sanctioned Linear writer)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/linear_oneway_push.py --apply
+StandardOutput=append:/home/elliotbot/clawd/logs/linear-oneway-push.log
+StandardError=append:/home/elliotbot/clawd/logs/linear-oneway-push.log
+TimeoutStartSec=600
+
+[Install]
+WantedBy=default.target

--- a/infra/systemd/linear-oneway-push.timer
+++ b/infra/systemd/linear-oneway-push.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Agency OS — One-way Supabase→Linear push cadence (15min, Agency_OS-1x3x)
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+RandomizedDelaySec=60
+Persistent=true
+Unit=linear-oneway-push.service
+
+[Install]
+WantedBy=timers.target

--- a/migrations/20260520_1x3x_linear_synced_status.sql
+++ b/migrations/20260520_1x3x_linear_synced_status.sql
@@ -30,6 +30,9 @@ RETURNS TRIGGER LANGUAGE plpgsql AS $$
 DECLARE
     v_event_type TEXT;
     v_payload    JSONB;
+    -- Terminal statuses — single source of truth (avoids repeating the
+    -- 'done'/'cancelled' literals across the close/reopen branches).
+    v_terminal   CONSTANT TEXT[] := ARRAY['done', 'cancelled'];
 BEGIN
     IF TG_OP = 'INSERT' THEN
         v_event_type := 'create';
@@ -44,11 +47,11 @@ BEGIN
            AND NEW.linear_synced_status IS DISTINCT FROM OLD.linear_synced_status THEN
             RETURN NEW;
         END IF;
-        -- Closing transitions (status in done/cancelled) emit 'close';
+        -- Closing transitions (status in a terminal state) emit 'close';
         -- everything else is 'update'.
-        IF NEW.status IN ('done', 'cancelled') AND NEW.status IS DISTINCT FROM OLD.status THEN
+        IF NEW.status = ANY(v_terminal) AND NEW.status IS DISTINCT FROM OLD.status THEN
             v_event_type := 'close';
-        ELSIF OLD.status IN ('done', 'cancelled') AND NEW.status NOT IN ('done', 'cancelled') THEN
+        ELSIF OLD.status = ANY(v_terminal) AND NEW.status <> ALL(v_terminal) THEN
             v_event_type := 'reopen';
         ELSIF NEW.priority IS DISTINCT FROM OLD.priority THEN
             v_event_type := 'priority_change';

--- a/migrations/20260520_1x3x_linear_synced_status.sql
+++ b/migrations/20260520_1x3x_linear_synced_status.sql
@@ -1,0 +1,90 @@
+-- Agency_OS-1x3x — Part 4: one-way Supabase→Linear push watermark.
+--
+-- Adds public.tasks.linear_synced_status — the watermark the controlled
+-- one-way push (scripts/orchestrator/linear_oneway_push.py) uses to record
+-- which status value it last successfully propagated to Linear. The push
+-- reads (status, linear_synced_status); a terminal transition is pending
+-- when they diverge and either side is a terminal status. After a
+-- successful Linear write the push sets linear_synced_status = status.
+-- This makes the push idempotent: a re-run sees them equal and skips.
+--
+-- The emit trigger fn_emit_sync_event_postgres is re-defined to SKIP
+-- emission when an UPDATE touches ONLY linear_synced_status. The push's
+-- watermark write is bookkeeping, not a cross-store change — emitting a
+-- sync_event for it would echo the push back into the sync pipeline as a
+-- Supabase change (the exact loop requirement c forbids).
+
+ALTER TABLE public.tasks
+    ADD COLUMN IF NOT EXISTS linear_synced_status TEXT;
+
+COMMENT ON COLUMN public.tasks.linear_synced_status IS
+    'Agency_OS-1x3x — one-way push watermark. Last task status value the '
+    'controlled Supabase→Linear push successfully propagated to Linear. '
+    'NULL = never pushed. Written ONLY by linear_oneway_push.py.';
+
+-- Re-definition of the KEI-228 emit trigger with the watermark guard.
+-- Body is identical to migrations/20260519_kei228_sync_events.sql except
+-- for the bookkeeping-skip guard at the top of the UPDATE branch.
+CREATE OR REPLACE FUNCTION public.fn_emit_sync_event_postgres()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+    v_event_type TEXT;
+    v_payload    JSONB;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        v_event_type := 'create';
+    ELSIF TG_OP = 'UPDATE' THEN
+        -- Agency_OS-1x3x watermark guard: an UPDATE that changes ONLY
+        -- linear_synced_status (status/title/priority all unchanged) is the
+        -- one-way push recording its own progress. Emit nothing — otherwise
+        -- the push's watermark write echoes back as a Supabase sync_event.
+        IF NEW.status IS NOT DISTINCT FROM OLD.status
+           AND NEW.title IS NOT DISTINCT FROM OLD.title
+           AND NEW.priority IS NOT DISTINCT FROM OLD.priority
+           AND NEW.linear_synced_status IS DISTINCT FROM OLD.linear_synced_status THEN
+            RETURN NEW;
+        END IF;
+        -- Closing transitions (status in done/cancelled) emit 'close';
+        -- everything else is 'update'.
+        IF NEW.status IN ('done', 'cancelled') AND NEW.status IS DISTINCT FROM OLD.status THEN
+            v_event_type := 'close';
+        ELSIF OLD.status IN ('done', 'cancelled') AND NEW.status NOT IN ('done', 'cancelled') THEN
+            v_event_type := 'reopen';
+        ELSIF NEW.priority IS DISTINCT FROM OLD.priority THEN
+            v_event_type := 'priority_change';
+        ELSIF NEW.title IS DISTINCT FROM OLD.title THEN
+            v_event_type := 'title_change';
+        ELSE
+            v_event_type := 'update';
+        END IF;
+    ELSE
+        RETURN NULL;
+    END IF;
+
+    v_payload := jsonb_build_object(
+        'id', NEW.id,
+        'bd_id', NEW.bd_id,
+        'title', NEW.title,
+        'status', NEW.status,
+        'priority', NEW.priority,
+        'linear_url', NEW.linear_url,
+        'claimed_by', NEW.claimed_by,
+        'tg_op', TG_OP
+    );
+
+    INSERT INTO public.sync_events (origin, event_type, task_id, bd_id, payload)
+    VALUES ('postgres', v_event_type, NEW.id, NEW.bd_id, v_payload)
+    ON CONFLICT (task_id, payload_hash) WHERE processed = FALSE DO NOTHING;
+
+    RETURN NEW;
+END;
+$$;
+
+-- Baseline backfill: declare every existing row's current status as
+-- already-synced, so the push starts from a clean baseline and acts only
+-- on FUTURE terminal transitions (not a one-time burst of redundant
+-- re-pushes of already-completed KEIs). The watermark guard above absorbs
+-- this UPDATE — no sync_events emitted.
+UPDATE public.tasks
+   SET linear_synced_status = status
+ WHERE status IS NOT NULL;

--- a/scripts/install_linear_oneway_push.sh
+++ b/scripts/install_linear_oneway_push.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# install_linear_oneway_push.sh — Agency_OS-1x3x installer.
+#
+# Installs linear-oneway-push.service + .timer (15min cadence) into the
+# user-systemd config dir. The push is the sole sanctioned Supabase→Linear
+# status writer.
+#
+# KEI-108 CI-gate compliance: anchors the literal unit name
+# `linear-oneway-push.service` for the grep gate.
+#
+# Prerequisites verified below (fail-loud — the push's loop-safety depends
+# on them):
+#   LINEAR_API_KEY        — Linear write auth.
+#   LINEAR_VIEWER_ID      — the API key's user id. The Linear webhook's
+#                           KEI-238 self-echo suppression drops updates
+#                           whose actor == LINEAR_VIEWER_ID; unset means a
+#                           push echoes back as a Supabase change.
+#   LINEAR_STATE_ID_DONE / _CANCELED — terminal-state UUIDs the push writes.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SYSTEMD_SRC="${REPO_ROOT}/infra/systemd"
+SYSTEMD_DST="${HOME}/.config/systemd/user"
+LOG_DIR="${HOME}/clawd/logs"
+ENV_FILE="/home/elliotbot/.config/agency-os/.env"
+
+missing=()
+for var in LINEAR_API_KEY LINEAR_VIEWER_ID LINEAR_STATE_ID_DONE LINEAR_STATE_ID_CANCELED; do
+    if ! grep -q "^${var}=" "${ENV_FILE}" 2>/dev/null; then
+        missing+=("${var}")
+    fi
+done
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "install_linear_oneway_push: missing required env var(s) in ${ENV_FILE}:" >&2
+    printf '  %s\n' "${missing[@]}" >&2
+    echo "  LINEAR_VIEWER_ID gates KEI-238 echo suppression — set it before install." >&2
+    exit 2
+fi
+
+mkdir -p "${SYSTEMD_DST}" "${LOG_DIR}"
+cp -v "${SYSTEMD_SRC}/linear-oneway-push.service" "${SYSTEMD_DST}/"
+cp -v "${SYSTEMD_SRC}/linear-oneway-push.timer"   "${SYSTEMD_DST}/"
+
+systemctl --user daemon-reload
+systemctl --user enable --now linear-oneway-push.timer
+
+echo
+echo "Installed. Verify:"
+echo "  systemctl --user status linear-oneway-push.timer"
+echo "  systemctl --user list-timers --all | grep linear-oneway-push"
+echo "  journalctl --user -u linear-oneway-push.service -n 50 --no-pager"
+echo "  tail -n 50 ~/clawd/logs/linear-oneway-push.log"

--- a/scripts/orchestrator/completion_sync_worker.py
+++ b/scripts/orchestrator/completion_sync_worker.py
@@ -3,7 +3,9 @@
 
 Drains public.completion_sync_queue rows WHERE processed=false in batches.
 Per row, dispatches by target_sink:
-    linear        — POST Linear GraphQL issueUpdate setting state
+    linear        — no-op since Agency_OS-1x3x (Part 4). Linear is read-only
+                    for automated processes; Supabase→Linear status goes via
+                    the one-way push (linear_oneway_push.py) only.
     ceo_memory    — INSERT public.ceo_memory row keyed completion:<task_id>
     drive_manual  — invoke scripts/write_manual_mirror.py <task_id>
 
@@ -22,15 +24,12 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import os
 import subprocess
 import sys
 import time
 from pathlib import Path
-from urllib import error as urlerror
-from urllib import request as urlrequest
 
 # KEI-91 Gate 4 heartbeat tick via shared shim.
 from _heartbeat_shim import heartbeat_tick as _heartbeat_tick  # noqa: E402
@@ -41,7 +40,6 @@ from src.governance.ceo_memory_writer import upsert_ceo_memory_key  # noqa: E402
 logger = logging.getLogger("completion_sync_worker")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
-LINEAR_API = "https://api.linear.app/graphql"
 DEFAULT_BATCH_SIZE = 20
 MAX_ATTEMPTS = 3
 POLL_INTERVAL_SECONDS = 30.0
@@ -60,37 +58,25 @@ def _dsn() -> str:
     return dsn.replace("+asyncpg", "")
 
 
-def _linear_state_id(target_status: str) -> str:
-    return os.environ.get(f"LINEAR_STATE_ID_{target_status.upper()}", "")
-
-
 def _sink_linear(task_id: str, target_status: str) -> None:
-    api_key = os.environ.get("LINEAR_API_KEY", "")
-    if not api_key:
-        raise SinkError("LINEAR_API_KEY missing")
-    state_id = _linear_state_id(target_status)
-    if not state_id:
-        raise SinkError(f"LINEAR_STATE_ID_{target_status.upper()} missing")
-    body = json.dumps(
-        {
-            "query": "mutation($id:String!,$state:String!){issueUpdate(id:$id,input:{stateId:$state}){success}}",
-            "variables": {"id": task_id, "state": state_id},
-        }
-    ).encode()
-    req = urlrequest.Request(
-        LINEAR_API,
-        data=body,
-        method="POST",
-        headers={"Authorization": api_key, "Content-Type": "application/json"},
+    """Linear sink — HARD-LOCKED to no-op (Dave ratified LAW 2026-05-20).
+
+    Agency_OS-1x3x Part 4: Linear is read-only for every automated process.
+    Supabase→Linear status propagation happens ONLY via the controlled
+    one-way push (scripts/orchestrator/linear_oneway_push.py) — the sole
+    sanctioned Linear writer. This sink previously POSTed an issueUpdate
+    mutation; that competing writer is retired.
+
+    The function is retained (not deleted) so any completion_sync_queue row
+    still enqueued with target_sink='linear' fails SAFE — it is marked
+    processed without a Linear write, rather than erroring or reviving the
+    write path. ceo_memory + drive_manual sinks are unaffected.
+    """
+    logger.info(
+        "[%s/linear] no-op — Linear writes go via the one-way push only (target_status=%s ignored)",
+        task_id,
+        target_status,
     )
-    try:
-        with urlrequest.urlopen(req, timeout=15) as resp:
-            payload = json.loads(resp.read())
-    except (urlerror.URLError, OSError) as exc:
-        raise SinkError(f"linear network: {exc}") from exc
-    ok = ((payload.get("data") or {}).get("issueUpdate") or {}).get("success", False)
-    if not ok:
-        raise SinkError(f"linear rejected: {payload.get('errors') or payload}")
 
 
 def _sink_ceo_memory(task_id: str, target_status: str) -> None:

--- a/scripts/orchestrator/linear_oneway_push.py
+++ b/scripts/orchestrator/linear_oneway_push.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""linear_oneway_push.py — Agency_OS-1x3x — controlled one-way Supabase→Linear push.
+
+The SOLE sanctioned Linear writer. Per the ratified architecture (Dave
+2026-05-20): Linear is the master record + read-only for every agent and
+automated process; Supabase public.tasks is the read-write replica; task
+STATUS changes propagate Supabase→Linear via THIS push and nothing else.
+
+Design — strictly one-way:
+  * Reads public.tasks (id, status, linear_synced_status). Reads nothing
+    from Linear. Writes nothing to Supabase except its own watermark.
+  * Writes Linear only — issueUpdate setting the workflow state.
+  * Pushes ONLY terminal status transitions: a task reaching a terminal
+    status (done / dismissed / cancelled) or reopening out of one. Pure
+    available↔active churn is never pushed. Titles/priority are never
+    pushed (Part 1's backfill owns titles, the other direction).
+
+Idempotency + loop-safety:
+  * linear_synced_status is the watermark — the status value last pushed.
+    A transition is pending only when status <> linear_synced_status and
+    a terminal status is on one side. After a successful Linear write the
+    push sets linear_synced_status = status; a re-run then skips. No
+    double-write.
+  * The watermark UPDATE touches only linear_synced_status, so the
+    KEI-228 emit trigger's Agency_OS-1x3x guard skips it — the push never
+    echoes back into sync_events as a Supabase change.
+  * The Linear write is actor-tagged: Linear records the actor as the API
+    key's user (LINEAR_VIEWER_ID). The Linear webhook's KEI-238 self-echo
+    suppression drops updates whose actor == LINEAR_VIEWER_ID — so a push
+    that lands does not echo back as a Supabase change. LINEAR_VIEWER_ID
+    MUST be set in the environment (the install script verifies it).
+
+This is a SEPARATE clean component — NOT a revival of sync_orchestrator's
+_dispatch_linear (hard-locked no-op since Part 2). It runs as a systemd
+service so the PreToolUse ad-hoc-agent Linear-write block does not gate
+it; this is the sanctioned path.
+
+Usage:
+    python3 scripts/orchestrator/linear_oneway_push.py            # dry-run
+    python3 scripts/orchestrator/linear_oneway_push.py --apply    # push to Linear
+
+Exit codes:
+  0  clean (dry-run, or every pending push succeeded)
+  1  one or more pushes failed (logged + alerted — fail-loud)
+  2  invocation/config error (no DSN, no LINEAR_API_KEY)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+logger = logging.getLogger("linear_oneway_push")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+_LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+_NATS_BIN = "/usr/local/bin/nats"
+_ALERT_SUBJECT = "keiracom.elliot.inbox"
+
+# Postgres terminal statuses — reaching or leaving one of these is the only
+# transition class the push propagates. tasks_status_check allows
+# 'dismissed' (Linear canceled maps there); 'cancelled' kept for legacy rows.
+TERMINAL_STATUSES = ("done", "dismissed", "cancelled")
+
+# public.tasks.status → LINEAR_STATE_ID_<SUFFIX> env var. The push resolves
+# the target Linear workflow-state UUID from these env vars — it never reads
+# Linear to discover state ids.
+_STATUS_TO_STATE_SUFFIX: dict[str, str] = {
+    "done": "DONE",
+    "dismissed": "CANCELED",
+    "cancelled": "CANCELED",
+    "available": "TODO",
+    "active": "ACTIVE",
+    "pending_review": "IN_REVIEW",
+    "ready_for_execution": "ACTIVE",
+    "blocked": "ACTIVE",
+}
+
+_ISSUE_UPDATE_MUTATION = (
+    "mutation($id:String!,$state:String!){issueUpdate(id:$id,input:{stateId:$state}){success}}"
+)
+
+
+def _dsn() -> str:
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL or SUPABASE_DB_URL must be set")
+    return dsn.replace("+asyncpg", "")
+
+
+def _linear_api_key() -> str:
+    key = os.environ.get("LINEAR_API_KEY")
+    if not key:
+        raise RuntimeError("LINEAR_API_KEY must be set")
+    return key
+
+
+def _linear_state_id(status: str) -> str:
+    """Resolve a public.tasks.status to its Linear workflow-state UUID."""
+    suffix = _STATUS_TO_STATE_SUFFIX.get(status)
+    if not suffix:
+        return ""
+    return os.environ.get(f"LINEAR_STATE_ID_{suffix}", "")
+
+
+def is_terminal_transition(status: str | None, synced: str | None) -> bool:
+    """True when (status, watermark) is a terminal transition worth pushing.
+
+    Terminal transition = the status changed AND a terminal status is on one
+    side: a CLOSE (reaching done/cancelled) or a REOPEN (leaving one). Two
+    non-terminal statuses differing (available↔active) is plain workflow
+    churn — not pushed. A never-pushed non-terminal task (synced is NULL,
+    status non-terminal) is likewise skipped.
+    """
+    if status == synced:
+        return False
+    return status in TERMINAL_STATUSES or synced in TERMINAL_STATUSES
+
+
+def fetch_pending(conn: Any) -> list[dict[str, str | None]]:
+    """Return tasks whose terminal-transition status has not reached Linear.
+
+    The SQL is a coarse candidate filter (KEI rows whose status differs from
+    the watermark); is_terminal_transition() is the precise gate.
+    """
+    out: list[dict[str, str | None]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, status, linear_synced_status FROM public.tasks "
+            "WHERE id LIKE 'KEI-%' AND status IS DISTINCT FROM linear_synced_status"
+        )
+        rows = cur.fetchall()
+    for row in rows:
+        if is_terminal_transition(row[1], row[2]):
+            out.append({"id": row[0], "status": row[1], "synced": row[2]})
+    return out
+
+
+def push_to_linear(api_key: str, kei: str, state_id: str) -> None:
+    """POST a single issueUpdate mutation. Raises RuntimeError on any failure.
+
+    Linear's issueUpdate accepts the KEI-N identifier as `id` (proven by the
+    legacy completion_sync_worker path). This is the only Linear WRITE in the
+    whole component.
+    """
+    body = json.dumps(
+        {"query": _ISSUE_UPDATE_MUTATION, "variables": {"id": kei, "state": state_id}}
+    ).encode()
+    req = urllib.request.Request(  # noqa: S310 — fixed https Linear endpoint
+        _LINEAR_GRAPHQL_URL,
+        data=body,
+        method="POST",
+        headers={"Authorization": api_key, "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310
+            payload = json.loads(resp.read() or "null")
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"linear network error: {exc}") from exc
+    if payload and payload.get("errors"):
+        raise RuntimeError(f"linear GraphQL errors: {payload['errors']}")
+    ok = (((payload or {}).get("data") or {}).get("issueUpdate") or {}).get("success")
+    if not ok:
+        raise RuntimeError(f"linear rejected issueUpdate: {payload}")
+
+
+def mark_synced(conn: Any, kei: str, status: str | None) -> None:
+    """Advance the watermark after a successful push. The KEI-228 emit
+    trigger's watermark guard skips this UPDATE — no sync_event echo."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE public.tasks SET linear_synced_status = %s WHERE id = %s",
+            (status, kei),
+        )
+    conn.commit()
+
+
+def _emit_failure_alert(failures: list[tuple[str, str]]) -> None:
+    """Fail-loud — publish a structured alert to elliot's inbox. The alert
+    itself is best-effort (a NATS outage must not mask the push failure,
+    which is already logged at ERROR)."""
+    lines = "\n".join(f"  {kei}: {err}" for kei, err in failures)
+    text = (
+        f"[ALERT:linear-oneway-push] {len(failures)} Linear push(es) FAILED — "
+        f"Supabase→Linear status drift NOT propagated:\n{lines}"
+    )
+    envelope = {"from": "linear-oneway-push", "kind": "blocker", "summary": text}
+    try:
+        subprocess.run(  # noqa: S603 — fixed args, no shell
+            [_NATS_BIN, "pub", _ALERT_SUBJECT, json.dumps(envelope)],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.error("failure-alert NATS publish failed: %s", exc)
+
+
+def run_once(conn: Any, api_key: str, *, apply: bool) -> dict[str, Any]:
+    """Push every pending terminal transition. Returns a stats dict."""
+    pending = fetch_pending(conn)
+    stats: dict[str, Any] = {"pending": len(pending), "pushed": 0, "failed": 0}
+    failures: list[tuple[str, str]] = []
+    for task in pending:
+        kei = str(task["id"])
+        status = task["status"]
+        state_id = _linear_state_id(status or "")
+        if not state_id:
+            msg = f"no LINEAR_STATE_ID for status {status!r}"
+            logger.error("%s: %s", kei, msg)
+            failures.append((kei, msg))
+            stats["failed"] += 1
+            continue
+        if not apply:
+            logger.info("[dry-run] would push %s → %s", kei, status)
+            continue
+        try:
+            push_to_linear(api_key, kei, state_id)
+            mark_synced(conn, kei, status)
+            stats["pushed"] += 1
+            logger.info("pushed %s → %s", kei, status)
+        except RuntimeError as exc:
+            logger.error("push failed for %s: %s", kei, exc)
+            failures.append((kei, str(exc)))
+            stats["failed"] += 1
+    if failures:
+        _emit_failure_alert(failures)
+    return stats
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Write Linear (default dry-run)")
+    args = parser.parse_args(argv)
+
+    try:
+        api_key = _linear_api_key()
+        dsn = _dsn()
+    except RuntimeError as exc:
+        logger.error("%s", exc)
+        return 2
+
+    try:
+        import psycopg
+    except ImportError:
+        logger.error("psycopg not installed")
+        return 2
+
+    with psycopg.connect(dsn, prepare_threshold=None) as conn:
+        stats = run_once(conn, api_key, apply=args.apply)
+
+    print(f"pending: {stats['pending']}  pushed: {stats['pushed']}  failed: {stats['failed']}")
+    return 1 if stats["failed"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/linear_oneway_push.py
+++ b/scripts/orchestrator/linear_oneway_push.py
@@ -214,15 +214,18 @@ def run_once(conn: Any, api_key: str, *, apply: bool) -> dict[str, Any]:
     for task in pending:
         kei = str(task["id"])
         status = task["status"]
+        if not apply:
+            # Dry-run only counts what WOULD push; it never writes Linear, so
+            # it must not resolve or require LINEAR_STATE_ID — that env var is
+            # absent in CI and would falsely mark the task `failed`.
+            logger.info("[dry-run] would push %s → %s", kei, status)
+            continue
         state_id = _linear_state_id(status or "")
         if not state_id:
             msg = f"no LINEAR_STATE_ID for status {status!r}"
             logger.error("%s: %s", kei, msg)
             failures.append((kei, msg))
             stats["failed"] += 1
-            continue
-        if not apply:
-            logger.info("[dry-run] would push %s → %s", kei, status)
             continue
         try:
             push_to_linear(api_key, kei, state_id)

--- a/scripts/orchestrator/linear_oneway_push.py
+++ b/scripts/orchestrator/linear_oneway_push.py
@@ -53,7 +53,6 @@ import logging
 import os
 import subprocess
 import sys
-import urllib.error
 import urllib.request
 from typing import Any
 
@@ -153,7 +152,8 @@ def push_to_linear(api_key: str, kei: str, state_id: str) -> None:
     body = json.dumps(
         {"query": _ISSUE_UPDATE_MUTATION, "variables": {"id": kei, "state": state_id}}
     ).encode()
-    req = urllib.request.Request(  # noqa: S310 — fixed https Linear endpoint
+    # S310: the URL is the fixed https Linear GraphQL endpoint, not user input.
+    req = urllib.request.Request(  # noqa: S310
         _LINEAR_GRAPHQL_URL,
         data=body,
         method="POST",
@@ -162,7 +162,8 @@ def push_to_linear(api_key: str, kei: str, state_id: str) -> None:
     try:
         with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310
             payload = json.loads(resp.read() or "null")
-    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+    except (OSError, json.JSONDecodeError) as exc:
+        # urllib.error.URLError is an OSError subclass — OSError covers it.
         raise RuntimeError(f"linear network error: {exc}") from exc
     if payload and payload.get("errors"):
         raise RuntimeError(f"linear GraphQL errors: {payload['errors']}")
@@ -193,14 +194,16 @@ def _emit_failure_alert(failures: list[tuple[str, str]]) -> None:
     )
     envelope = {"from": "linear-oneway-push", "kind": "blocker", "summary": text}
     try:
-        subprocess.run(  # noqa: S603 — fixed args, no shell
+        # S603: fixed argument list, no shell, no user-controlled input.
+        subprocess.run(  # noqa: S603
             [_NATS_BIN, "pub", _ALERT_SUBJECT, json.dumps(envelope)],
             capture_output=True,
             timeout=5,
             check=False,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-        logger.error("failure-alert NATS publish failed: %s", exc)
+    except (subprocess.TimeoutExpired, OSError):
+        # FileNotFoundError is an OSError subclass — OSError covers it.
+        logger.exception("failure-alert NATS publish failed")
 
 
 def run_once(conn: Any, api_key: str, *, apply: bool) -> dict[str, Any]:
@@ -227,7 +230,7 @@ def run_once(conn: Any, api_key: str, *, apply: bool) -> dict[str, Any]:
             stats["pushed"] += 1
             logger.info("pushed %s → %s", kei, status)
         except RuntimeError as exc:
-            logger.error("push failed for %s: %s", kei, exc)
+            logger.exception("push failed for %s", kei)
             failures.append((kei, str(exc)))
             stats["failed"] += 1
     if failures:
@@ -243,8 +246,8 @@ def main(argv: list[str] | None = None) -> int:
     try:
         api_key = _linear_api_key()
         dsn = _dsn()
-    except RuntimeError as exc:
-        logger.error("%s", exc)
+    except RuntimeError:
+        logger.exception("startup config error")
         return 2
 
     try:

--- a/tests/scripts/test_completion_sync_worker.py
+++ b/tests/scripts/test_completion_sync_worker.py
@@ -14,10 +14,11 @@ import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
+# completion_sync_worker imports `_heartbeat_shim` (a sibling in
+# scripts/orchestrator/) — that dir must be on sys.path or collection fails.
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "orchestrator"))
 
 from scripts.orchestrator import completion_sync_worker as csw  # noqa: E402
 
@@ -111,10 +112,24 @@ def test_process_row_records_error_on_sink_failure(monkeypatch):
     assert "attempts=attempts+1" in sql and "vendor 500" in params[0]
 
 
-def test_sink_linear_raises_when_api_key_missing(monkeypatch):
+def test_sink_linear_is_noop(monkeypatch):
+    """Agency_OS-1x3x Part 4: the linear sink is a hard no-op. It must NOT
+    raise and must NOT write Linear — Supabase→Linear status propagation
+    goes via the one-way push only. A row with target_sink='linear' fails
+    safe (processed, no write)."""
     monkeypatch.delenv("LINEAR_API_KEY", raising=False)
-    with pytest.raises(csw.SinkError):
-        csw._sink_linear("KEI-58", "done")
+    # No raise even with the API key absent — the sink does nothing.
+    assert csw._sink_linear("KEI-58", "done") is None
+
+
+def test_process_row_linear_marks_processed_without_write(monkeypatch):
+    """A target_sink='linear' row is marked processed (the no-op sink does
+    not raise SinkError) — it never retries, never writes Linear."""
+    conn = _FakeConn()
+    ok = csw._process_row(conn, _row(target_sink="linear"))
+    assert ok is True
+    sql, _ = conn.cursor_calls[-1].executed[-1]
+    assert "processed=TRUE" in sql
 
 
 def test_unknown_sink_records_error(monkeypatch):

--- a/tests/scripts/test_linear_oneway_push.py
+++ b/tests/scripts/test_linear_oneway_push.py
@@ -1,0 +1,288 @@
+"""tests for scripts/orchestrator/linear_oneway_push.py — Agency_OS-1x3x Part 4.
+
+Linear API + psycopg both mocked — no live Linear write. Verifies:
+  - is_terminal_transition: close / reopen push; non-terminal churn skipped
+  - _linear_state_id: status → LINEAR_STATE_ID_* env resolution
+  - fetch_pending: coarse SQL + precise Python gate
+  - push_to_linear: success / GraphQL-error / rejected / network-error
+  - mark_synced: watermark UPDATE touches ONLY linear_synced_status
+  - run_once: dry-run never writes; apply pushes + advances watermark;
+    failure path collects + alerts + fails loud
+  - one-way invariant: the module issues no Linear READ query
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "linear_oneway_push.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("linear_oneway_push", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["linear_oneway_push"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+class _Cursor:
+    def __init__(self, fetchall_rows=None):
+        self._all = fetchall_rows or []
+        self.executed: list[tuple[str, tuple | None]] = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchall(self):
+        return self._all
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return None
+
+
+class _Conn:
+    def __init__(self, cur):
+        self._cur = cur
+        self.commits = 0
+
+    def cursor(self):
+        return self._cur
+
+    def commit(self):
+        self.commits += 1
+
+
+# ─── is_terminal_transition ────────────────────────────────────────────────
+
+
+def test_close_transition_is_pending(mod):
+    """active → done (watermark active) — a close. Push it."""
+    assert mod.is_terminal_transition("done", "active") is True
+
+
+def test_first_close_with_null_watermark_is_pending(mod):
+    """done, never pushed (watermark NULL) — a close. Push it."""
+    assert mod.is_terminal_transition("done", None) is True
+
+
+def test_reopen_transition_is_pending(mod):
+    """done → active (watermark done) — a reopen. Push it."""
+    assert mod.is_terminal_transition("active", "done") is True
+
+
+def test_terminal_to_terminal_change_is_pending(mod):
+    """done → dismissed — still a terminal transition (reached cancelled)."""
+    assert mod.is_terminal_transition("dismissed", "done") is True
+
+
+def test_non_terminal_churn_is_not_pending(mod):
+    """available ↔ active is plain workflow churn — never pushed."""
+    assert mod.is_terminal_transition("active", "available") is False
+
+
+def test_non_terminal_first_sync_is_not_pending(mod):
+    """active, never pushed (watermark NULL) — not a terminal transition."""
+    assert mod.is_terminal_transition("active", None) is False
+
+
+def test_already_synced_is_not_pending(mod):
+    """status == watermark — idempotent skip, no double-write."""
+    assert mod.is_terminal_transition("done", "done") is False
+
+
+# ─── _linear_state_id ──────────────────────────────────────────────────────
+
+
+def test_linear_state_id_resolves_done(mod, monkeypatch):
+    monkeypatch.setenv("LINEAR_STATE_ID_DONE", "uuid-done")
+    assert mod._linear_state_id("done") == "uuid-done"
+
+
+def test_linear_state_id_dismissed_maps_to_canceled(mod, monkeypatch):
+    monkeypatch.setenv("LINEAR_STATE_ID_CANCELED", "uuid-cancel")
+    assert mod._linear_state_id("dismissed") == "uuid-cancel"
+
+
+def test_linear_state_id_unknown_status_returns_empty(mod):
+    assert mod._linear_state_id("nonsense_status") == ""
+
+
+# ─── fetch_pending ─────────────────────────────────────────────────────────
+
+
+def test_fetch_pending_filters_via_python_gate(mod):
+    """SQL is coarse (status <> watermark); the Python gate drops the
+    non-terminal-churn candidate the SQL still returns."""
+    cur = _Cursor(
+        fetchall_rows=[
+            ("KEI-1", "done", None),  # close → pending
+            ("KEI-2", "active", "available"),  # churn → dropped
+            ("KEI-3", "available", "done"),  # reopen → pending
+        ]
+    )
+    pending = mod.fetch_pending(_Conn(cur))
+    assert [p["id"] for p in pending] == ["KEI-1", "KEI-3"]
+
+
+def test_fetch_pending_sql_is_coarse_candidate_filter(mod):
+    cur = _Cursor()
+    mod.fetch_pending(_Conn(cur))
+    sql, _ = cur.executed[0]
+    assert "status IS DISTINCT FROM linear_synced_status" in sql
+    assert "id LIKE 'KEI-%'" in sql
+
+
+# ─── push_to_linear ────────────────────────────────────────────────────────
+
+
+def _fake_urlopen(response_obj):
+    import json as _json
+
+    class _Resp:
+        def __init__(self, body):
+            self._b = body
+
+        def read(self):
+            return self._b
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+    def _open(req, timeout=None):
+        return _Resp(_json.dumps(response_obj).encode())
+
+    return _open
+
+
+def test_push_to_linear_success(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        _fake_urlopen({"data": {"issueUpdate": {"success": True}}}),
+    )
+    mod.push_to_linear("key", "KEI-9", "state-uuid")  # no raise
+
+
+def test_push_to_linear_rejected_raises(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        _fake_urlopen({"data": {"issueUpdate": {"success": False}}}),
+    )
+    with pytest.raises(RuntimeError, match="rejected"):
+        mod.push_to_linear("key", "KEI-9", "state-uuid")
+
+
+def test_push_to_linear_graphql_errors_raise(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        _fake_urlopen({"errors": [{"message": "bad id"}]}),
+    )
+    with pytest.raises(RuntimeError, match="GraphQL errors"):
+        mod.push_to_linear("key", "KEI-9", "state-uuid")
+
+
+def test_push_to_linear_network_error_raises(mod, monkeypatch):
+    def _boom(req, timeout=None):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _boom)
+    with pytest.raises(RuntimeError, match="network error"):
+        mod.push_to_linear("key", "KEI-9", "state-uuid")
+
+
+# ─── mark_synced ───────────────────────────────────────────────────────────
+
+
+def test_mark_synced_updates_only_watermark_column(mod):
+    """The watermark UPDATE must touch ONLY linear_synced_status — so the
+    KEI-228 emit trigger guard skips it (no echo)."""
+    cur = _Cursor()
+    conn = _Conn(cur)
+    mod.mark_synced(conn, "KEI-5", "done")
+    sql, params = cur.executed[0]
+    assert "SET linear_synced_status = %s" in sql
+    assert "status =" not in sql.replace("linear_synced_status =", "")
+    assert "title" not in sql and "priority" not in sql
+    assert params == ("done", "KEI-5")
+    assert conn.commits == 1
+
+
+# ─── run_once ──────────────────────────────────────────────────────────────
+
+
+def test_run_once_dry_run_never_writes(mod, monkeypatch):
+    cur = _Cursor(fetchall_rows=[("KEI-1", "done", None)])
+    pushed = []
+    monkeypatch.setattr(mod, "push_to_linear", lambda *a: pushed.append(a))
+    stats = mod.run_once(_Conn(cur), "key", apply=False)
+    assert stats == {"pending": 1, "pushed": 0, "failed": 0}
+    assert pushed == []  # dry-run touched Linear zero times
+
+
+def test_run_once_apply_pushes_and_marks(mod, monkeypatch):
+    cur = _Cursor(fetchall_rows=[("KEI-1", "done", None)])
+    conn = _Conn(cur)
+    monkeypatch.setenv("LINEAR_STATE_ID_DONE", "uuid-done")
+    pushed = []
+    monkeypatch.setattr(mod, "push_to_linear", lambda *a: pushed.append(a))
+    stats = mod.run_once(conn, "key", apply=True)
+    assert stats["pushed"] == 1 and stats["failed"] == 0
+    assert pushed == [("key", "KEI-1", "uuid-done")]
+    # watermark advanced
+    update_sql = cur.executed[-1][0]
+    assert "linear_synced_status" in update_sql
+
+
+def test_run_once_failure_collects_and_alerts(mod, monkeypatch):
+    cur = _Cursor(fetchall_rows=[("KEI-1", "done", None)])
+    monkeypatch.setenv("LINEAR_STATE_ID_DONE", "uuid-done")
+
+    def _boom(*a):
+        raise RuntimeError("linear network error: down")
+
+    monkeypatch.setattr(mod, "push_to_linear", _boom)
+    alerts = []
+    monkeypatch.setattr(mod, "_emit_failure_alert", lambda f: alerts.append(f))
+    stats = mod.run_once(_Conn(cur), "key", apply=True)
+    assert stats["failed"] == 1 and stats["pushed"] == 0
+    assert alerts and alerts[0][0][0] == "KEI-1"  # fail-loud alert fired
+
+
+def test_run_once_missing_state_id_is_a_failure(mod, monkeypatch):
+    """No LINEAR_STATE_ID for the status → fail loud, do not push blind."""
+    cur = _Cursor(fetchall_rows=[("KEI-1", "done", None)])
+    monkeypatch.delenv("LINEAR_STATE_ID_DONE", raising=False)
+    alerts = []
+    monkeypatch.setattr(mod, "_emit_failure_alert", lambda f: alerts.append(f))
+    monkeypatch.setattr(mod, "push_to_linear", lambda *a: pytest.fail("must not push"))
+    stats = mod.run_once(_Conn(cur), "key", apply=True)
+    assert stats["failed"] == 1
+    assert alerts
+
+
+# ─── one-way invariant ─────────────────────────────────────────────────────
+
+
+def test_module_issues_no_linear_read_query(mod):
+    """One-way guard: the only Linear GraphQL the module emits is the
+    issueUpdate mutation — no `query {` read of Linear issue data."""
+    source = SCRIPT.read_text()
+    assert "issueUpdate" in source
+    # no Linear GraphQL *query* (read) — the push reads Supabase, not Linear
+    assert "issues(" not in source
+    assert "query(" not in source

--- a/tests/scripts/test_linear_oneway_push.py
+++ b/tests/scripts/test_linear_oneway_push.py
@@ -202,6 +202,11 @@ def test_mark_synced_updates_only_watermark_column(mod):
 
 
 def test_run_once_dry_run_never_writes(mod, monkeypatch):
+    """Dry-run must NOT resolve LINEAR_STATE_ID — that env var is absent in
+    CI; resolving it in dry-run falsely marked a terminal task `failed`
+    (regression lock for the run 26152062782 failure). Env var explicitly
+    cleared here so the test mirrors CI, not a state-id-set local proxy."""
+    monkeypatch.delenv("LINEAR_STATE_ID_DONE", raising=False)
     cur = _Cursor(fetchall_rows=[("KEI-1", "done", None)])
     pushed = []
     monkeypatch.setattr(mod, "push_to_linear", lambda *a: pushed.append(a))

--- a/tests/scripts/test_linear_oneway_push.py
+++ b/tests/scripts/test_linear_oneway_push.py
@@ -22,6 +22,12 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "linear_oneway_push.py"
 
+# Shared psycopg fakes — single source of truth, avoids Sonar
+# new_duplicated_lines_density on per-test cursor/conn stand-ins.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _db_mocks import FakeConn as _Conn  # noqa: E402
+from _db_mocks import FakeCursor as _Cursor  # noqa: E402
+
 
 @pytest.fixture(scope="module")
 def mod():
@@ -30,36 +36,6 @@ def mod():
     sys.modules["linear_oneway_push"] = m
     spec.loader.exec_module(m)
     return m
-
-
-class _Cursor:
-    def __init__(self, fetchall_rows=None):
-        self._all = fetchall_rows or []
-        self.executed: list[tuple[str, tuple | None]] = []
-
-    def execute(self, sql, params=None):
-        self.executed.append((sql, params))
-
-    def fetchall(self):
-        return self._all
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *a):
-        return None
-
-
-class _Conn:
-    def __init__(self, cur):
-        self._cur = cur
-        self.commits = 0
-
-    def cursor(self):
-        return self._cur
-
-    def commit(self):
-        self.commits += 1
 
 
 # ─── is_terminal_transition ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Dave directive 'complete sync', **Part 4** — the final sync item. Builds the controlled one-way Supabase→Linear status push: the **sole sanctioned Linear writer**.

**New — `scripts/orchestrator/linear_oneway_push.py`**
Reads `public.tasks` status, writes Linear via `issueUpdate`. Pushes **only terminal status transitions** (reaching done/dismissed/cancelled, or reopen) — `available↔active` churn and titles/priority are never pushed.
- **(a) One-way:** reads Supabase, writes Linear. Reads nothing from Linear (state UUIDs from `LINEAR_STATE_ID_*` env). A test asserts the module emits no Linear *read* query.
- **(c) Idempotent:** `linear_synced_status` watermark; `is_terminal_transition()` is the pure-Python gate (close/reopen/skip-churn/already-synced) — unit-tested exhaustively.
- **(c) Loop-safe:** the watermark UPDATE touches only `linear_synced_status` → the KEI-228 emit trigger's new guard skips it (no `sync_events` echo). The Linear write is actor-tagged; the webhook's KEI-238 self-echo suppression drops the echo.
- **(e) Fail-loud:** a failed push logs ERROR, fires a NATS alert to `keiracom.elliot.inbox`, exits non-zero.
- **(d) Service:** systemd oneshot on a 15-min timer — the sanctioned path, not gated by the PreToolUse ad-hoc-agent block.

**New — `migrations/20260520_1x3x_linear_synced_status.sql`**
Adds `public.tasks.linear_synced_status`. Re-defines `fn_emit_sync_event_postgres` with a guard so a watermark-only UPDATE emits no `sync_event`. Baseline backfill sets watermark = current status (push acts only on *future* transitions — no first-run burst); the guard absorbs the backfill.

**New — systemd service/timer + install script** (install fail-loud-verifies `LINEAR_API_KEY`, `LINEAR_VIEWER_ID`, `LINEAR_STATE_ID_DONE/_CANCELED`).

**Changed — `scripts/orchestrator/completion_sync_worker.py`**
GOV-9 finding: `_sink_linear` was a **live competing Linear writer** — incompatible with "the one-way push is the ONLY sanctioned writer" and with the ratified Linear-read-only LAW. No-op'd it (mirrors Part 2's `_dispatch_linear` lock); retained so queued `target_sink='linear'` rows fail safe. Removed now-dead imports/helpers.

## DIRECTIVE SCRUTINY — GOV-9

1. **`LINEAR_VIEWER_ID` not set in env** — KEI-238 echo suppression is a no-op without it. Value is `f29152a3-3700-4217-a451-d6070f09de3c`. **DEPLOY PREREQ** — install script verifies it; flagged for operator.
2. **7 other `issueUpdate` call sites exist** (auto_label_kei, restore_linear_state, betterstack_to_linear, central_listener, enforcer_deterministic, weekly_cycle_from_bd, tasks_cli) — flagged for a **separate audit KEI**; out of this PR's bounded scope.

## Test plan
- [x] 22 new push tests — transition gate (close/reopen/churn/already-synced/NULL), state-id resolution, fetch_pending coarse-SQL + Python-gate, push success/reject/GraphQL-error/network-error, watermark-only UPDATE, dry-run/apply/fail-loud, one-way invariant (no Linear read query)
- [x] 10 completion_sync_worker tests — 2 new (linear sink no-op + fails-safe-processed); also fixed a pre-existing collection break (`_heartbeat_shim` sys.path)
- [x] 32/32 pass; ruff check + format clean
- [ ] **Post-merge:** apply migration `20260520_1x3x_linear_synced_status.sql`, then `scripts/install_linear_oneway_push.sh` (after `LINEAR_VIEWER_ID` is set)
- [x] No live Linear write during build — tests mock the API; the service performs the real push in production

bd: `Agency_OS-1x3x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)