### PR TITLE
[ORION] feat(linear-lock): lock 4 residual Linear-write call sites — read-only LAW

### DIFF
--- a/scripts/auto_label_kei.py
+++ b/scripts/auto_label_kei.py
@@ -119,7 +119,9 @@ def label_issue(issue_id: str, title: str, description: str) -> dict[str, Any]:
             "matched_no_change": True,
         }
 
-    current_ids, current_names = _issue_label_ids(issue_id)
+    # Only the label NAMES are needed — the id list fed the issueUpdate
+    # write, which is LAW-locked out. Index [1] so no unused var is bound.
+    current_names = _issue_label_ids(issue_id)[1]
     to_add_names = [n for n in matched_names if n not in current_names]
     if not to_add_names:
         return {

--- a/scripts/auto_label_kei.py
+++ b/scripts/auto_label_kei.py
@@ -45,7 +45,6 @@ logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
 LINEAR_API_URL = "https://api.linear.app/graphql"
 KEI_TEAM_ID = "4686528f-ce77-4c2f-968b-3dc76b34d6fe"
-DEFAULT_LABEL_COLOR = "#95A5A6"  # neutral grey for auto-created labels
 
 LABEL_PATTERNS: list[tuple[str, list[str]]] = [
     ("audit-finding", ["audit", "pattern"]),
@@ -88,46 +87,10 @@ def infer_labels(title: str, description: str) -> list[str]:
     return matched
 
 
-def _team_label_map() -> dict[str, str]:
-    """Return {label_name: label_id} for the KEI team. Cached per call."""
-    data = _post(
-        "query($id: String!) { team(id: $id) { labels { nodes { id name } } } }",
-        {"id": KEI_TEAM_ID},
-    )
-    nodes = (data.get("data") or {}).get("team", {}).get("labels", {}).get("nodes", []) or []
-    return {n["name"]: n["id"] for n in nodes}
-
-
-def _create_label(name: str) -> str | None:
-    """Create a missing label in the KEI team. Returns new label id or None."""
-    data = _post(
-        "mutation($name: String!, $teamId: String!, $color: String!) {"
-        "  issueLabelCreate(input: { name: $name, teamId: $teamId, color: $color }) {"
-        "    success issueLabel { id name }"
-        "  }"
-        "}",
-        {"name": name, "teamId": KEI_TEAM_ID, "color": DEFAULT_LABEL_COLOR},
-    )
-    payload = (data.get("data") or {}).get("issueLabelCreate", {}) or {}
-    if payload.get("success"):
-        return (payload.get("issueLabel") or {}).get("id")
-    logger.warning("issueLabelCreate failed for %r: %s", name, data)
-    return None
-
-
-def _resolve_label_ids(names: list[str]) -> list[str]:
-    """Map label names → ids, creating any that don't exist."""
-    existing = _team_label_map()
-    out: list[str] = []
-    for name in names:
-        lid = existing.get(name)
-        if not lid:
-            lid = _create_label(name)
-            if lid:
-                existing[name] = lid
-        if lid:
-            out.append(lid)
-    return out
+# Linear-read-only LAW (Dave ratified 2026-05-20): the team-label-map read,
+# _create_label (issueLabelCreate) and _resolve_label_ids writer chain were
+# removed — auto_label_kei no longer writes Linear in any form. Label
+# inference still runs (read-only) via _issue_label_ids + infer_labels.
 
 
 def _issue_label_ids(issue_id: str) -> tuple[list[str], list[str]]:
@@ -166,19 +129,19 @@ def label_issue(issue_id: str, title: str, description: str) -> dict[str, Any]:
             "matched_no_change": True,
         }
 
-    new_ids = _resolve_label_ids(to_add_names)
-    final_ids = current_ids + new_ids
-
-    _post(
-        "mutation($id: String!, $labelIds: [String!]!) {"
-        "  issueUpdate(id: $id, input: { labelIds: $labelIds }) { success }"
-        "}",
-        {"id": issue_id, "labelIds": final_ids},
+    # Linear-read-only LAW (Dave ratified 2026-05-20): the issueUpdate label
+    # write is locked to a no-op. Linear is read-only — no automated process
+    # writes it. Label inference above still runs (read-only) so callers see
+    # what WOULD be applied; nothing is written to Linear.
+    logger.info(
+        "Linear-read-only LAW: label write suppressed for %s (would-add: %s)",
+        issue_id,
+        to_add_names,
     )
 
     return {
         "issue_id": issue_id,
-        "applied": to_add_names,
+        "applied": [],
         "skipped_already_present": [n for n in matched_names if n in current_names],
         "matched_no_change": False,
     }

--- a/scripts/orchestrator/weekly_cycle_from_bd.py
+++ b/scripts/orchestrator/weekly_cycle_from_bd.py
@@ -104,9 +104,7 @@ def filter_eligible(items: list[dict]) -> list[tuple[dict, int]]:
 
 def _resolve_kei_to_uuid(api_key: str, kei_number: int) -> str | None:
     """Translate KEI-N → Linear issue UUID."""
-    query = (
-        "query($n:Float!){issues(filter:{team:{key:{eq:\"KEI\"}},number:{eq:$n}}){nodes{id}}}"
-    )
+    query = 'query($n:Float!){issues(filter:{team:{key:{eq:"KEI"}},number:{eq:$n}}){nodes{id}}}'
     resp = _linear_graphql(api_key, query, {"n": float(kei_number)})
     nodes = (((resp or {}).get("data") or {}).get("issues") or {}).get("nodes") or []
     return nodes[0].get("id") if nodes else None
@@ -167,9 +165,7 @@ def _scan_existing_cycle(api_key: str, team_id: str, starts_at_iso: str) -> str 
 def _create_cycle(
     api_key: str, team_id: str, starts_at_iso: str, ends_at_iso: str, name: str
 ) -> str | None:
-    mutation = (
-        "mutation($input:CycleCreateInput!){cycleCreate(input:$input){success cycle{id}}}"
-    )
+    mutation = "mutation($input:CycleCreateInput!){cycleCreate(input:$input){success cycle{id}}}"
     input_fields = {
         "teamId": team_id,
         "name": name,
@@ -182,14 +178,14 @@ def _create_cycle(
 
 
 def _add_issue_to_cycle(api_key: str, issue_uuid: str, cycle_uuid: str) -> bool:
-    mutation = (
-        "mutation($id:String!,$cid:String!){"
-        "issueUpdate(id:$id,input:{cycleId:$cid}){success}}"
-    )
-    resp = _linear_graphql(api_key, mutation, {"id": issue_uuid, "cid": cycle_uuid})
-    return bool(
-        (((resp or {}).get("data") or {}).get("issueUpdate") or {}).get("success", False)
-    )
+    """Locked to a no-op under the Linear-read-only LAW (Dave ratified
+    2026-05-20). This previously POSTed an issueUpdate to assign an issue to
+    a Linear cycle. Linear is read-only — no automated process writes it.
+    Returns False — no cycle assignment was written.
+    """
+    del api_key, issue_uuid, cycle_uuid  # intentionally unused — write suppressed
+    logger.info("Linear-read-only LAW: cycle-assignment write suppressed")
+    return False
 
 
 def _cycle_name(starts_at_utc: datetime) -> str:

--- a/scripts/restore_linear_state.py
+++ b/scripts/restore_linear_state.py
@@ -173,18 +173,17 @@ def find_pre_damage_state(
 
 
 def apply_restore(api_key: str, issue_uuid: str, state_id: str) -> bool:
-    """Set the issue's state via Linear's issueUpdate mutation. True on success."""
-    mutation = """
-    mutation($id: String!, $state: String!) {
-      issueUpdate(id: $id, input: { stateId: $state }) {
-        success
-        issue { state { type name } }
-      }
-    }
+    """Locked to a no-op under the Linear-read-only LAW (Dave ratified
+    2026-05-20). This previously POSTed an issueUpdate to restore an issue's
+    state. Linear is read-only — no automated process writes it. The recovery
+    model is now: fix the canonical store (Supabase), and the controlled
+    one-way push (scripts/orchestrator/linear_oneway_push.py) propagates the
+    corrected status to Linear. Returns False — no write was performed; the
+    detection/dry-run logic above still reports what WOULD be restored.
     """
-    resp = _graphql(api_key, mutation, {"id": issue_uuid, "state": state_id})
-    success = (((resp or {}).get("data") or {}).get("issueUpdate") or {}).get("success", False)
-    return bool(success)
+    del api_key, issue_uuid, state_id  # intentionally unused — write suppressed
+    logger.info("Linear-read-only LAW: restore write suppressed — recover via Supabase + push")
+    return False
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -85,31 +85,20 @@ def _rows_to_dicts(cur: Any) -> list[dict]:
 
 
 def _enqueue_linear_sync(task_id: str, target_status: str) -> None:
-    """KEI-106 — enqueue Supabase→Linear status sync on claim/complete.
+    """Locked to a no-op under the Linear-read-only LAW (Dave ratified
+    2026-05-20).
 
-    The completion_sync_worker (KEI-74) drains public.completion_sync_queue and
-    POSTs Linear's issueUpdate per row. This helper just lands the row; the
-    worker owns the Linear API call + retries. Fail-open: queue INSERT failure
-    must not block the originating claim/complete write. The KEI-74 backfill
-    script catches any dropped events.
+    This previously enqueued a public.completion_sync_queue row with
+    target_sink='linear' for the completion_sync_worker to POST as an
+    issueUpdate. Since Agency_OS-1x3x (Part 4) that worker's linear sink is
+    itself a hard no-op, so the enqueued rows were dead writes. Linear status
+    now propagates via the controlled one-way push
+    (scripts/orchestrator/linear_oneway_push.py) only.
 
-    Existing rows in completion_sync_queue use the KEI-NN identifier directly
-    in task_id (Linear's issueUpdate accepts identifiers, not just UUIDs).
+    Kept as a no-op stub so the claim/complete call sites need no change.
     """
-    import psycopg
-
-    try:
-        with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
-            cur.execute(
-                "INSERT INTO public.completion_sync_queue "
-                "(id, task_id, target_sink, target_status, attempts, processed, "
-                "created_at, updated_at) "
-                "VALUES (gen_random_uuid(), %s, 'linear', %s, 0, FALSE, NOW(), NOW())",
-                (task_id, target_status),
-            )
-            conn.commit()
-    except Exception:
-        logger.debug("KEI-106 linear-sync enqueue failed (non-fatal)", exc_info=True)
+    del task_id, target_status  # intentionally unused — enqueue suppressed
+    logger.debug("Linear-read-only LAW: linear-sync enqueue suppressed (no-op)")
 
 
 def _current_phase_max(cur: Any) -> float:

--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -778,11 +778,12 @@ def check_r12(
         f"{_R12_KEI_CREATE_WINDOW_SECONDS // 60} minutes. Conversational "
         "directives must land in Linear for tracked-work continuity.",
         "should_have": (
-            "Elliot (or any agent the directive targets) creates a Linear KEI "
-            "within 5 minutes of the #ceo directive — `bd create` + Linear "
-            "sync OR direct Linear GraphQL issueCreate. Use 'orchestration:"
-            "directive_NN' ceo_memory anchor if the directive is governance- "
-            "or rule-level."
+            "Elliot (or any agent the directive targets) creates a KEI "
+            "within 5 minutes of the #ceo directive via `bd create`. Linear "
+            "is read-only (Dave ratified LAW 2026-05-20) — no direct Linear "
+            "writes; status propagates via the one-way push. Use "
+            "'orchestration:directive_NN' ceo_memory anchor if the directive "
+            "is governance- or rule-level."
         ),
         "fire_message": (
             f"[R12-REMINDER:elliot] CEO directive at {directive_ts.isoformat()} "

--- a/tests/scripts/test_auto_label_kei.py
+++ b/tests/scripts/test_auto_label_kei.py
@@ -101,8 +101,10 @@ def test_label_issue_idempotent_when_already_present(mod, monkeypatch):
     assert len(calls) == 1
 
 
-def test_label_issue_creates_missing_label_and_applies(mod, monkeypatch):
-    """Full flow: matched, not present on issue, label doesn't exist in team → create + apply."""
+def test_label_issue_law_locked_suppresses_linear_write(mod, monkeypatch):
+    """Linear-read-only LAW (Dave 2026-05-20): a label is matched and absent
+    on the issue, but the issueUpdate write is suppressed — applied is empty
+    and no issueUpdate is POSTed to Linear."""
     calls: list[tuple[str, dict]] = []
     team_label_map_state = {}  # starts empty (no labels in team)
 
@@ -140,9 +142,8 @@ def test_label_issue_creates_missing_label_and_applies(mod, monkeypatch):
 
     monkeypatch.setattr(mod, "_post", fake_post)
     rep = mod.label_issue("abc-123", "Build a new feature", "")
+    # A label WAS matched + absent → matched_no_change is False, but the
+    # write is LAW-locked: applied is empty, no issueUpdate is POSTed.
     assert rep["matched_no_change"] is False
-    assert rep["applied"] == ["build"]
-    # confirm the issueUpdate call carried our new label id
-    update_calls = [c for c in calls if "issueUpdate" in c[0]]
-    assert len(update_calls) == 1
-    assert update_calls[0][1]["labelIds"] == ["created-build"]
+    assert rep["applied"] == []
+    assert [c for c in calls if "issueUpdate" in c[0]] == [], "issueUpdate must be suppressed"

--- a/tests/scripts/test_restore_linear_state.py
+++ b/tests/scripts/test_restore_linear_state.py
@@ -130,3 +130,14 @@ def test_window_inclusive_at_boundaries(mod) -> None:
     history_end = [_event("2026-05-19T12:24:00Z", _ACTOR, "completed")]
     assert mod.find_pre_damage_state(history_start, _ACTOR, _W_START, _W_END) is not None
     assert mod.find_pre_damage_state(history_end, _ACTOR, _W_START, _W_END) is not None
+
+
+def test_apply_restore_is_law_locked_noop(mod, monkeypatch):
+    """Linear-read-only LAW (Dave 2026-05-20): apply_restore is locked to a
+    no-op — it returns False and never calls Linear's GraphQL endpoint.
+    Recovery is now: fix Supabase + let the one-way push propagate."""
+    called: list = []
+    monkeypatch.setattr(mod, "_graphql", lambda *a, **k: called.append(a) or {})
+    result = mod.apply_restore("fake-key", "issue-uuid", "state-uuid")
+    assert result is False
+    assert called == [], "apply_restore must not call Linear GraphQL"

--- a/tests/scripts/test_tasks_cli.py
+++ b/tests/scripts/test_tasks_cli.py
@@ -545,10 +545,12 @@ def _find_queue_insert(cur) -> tuple[str, tuple] | None:
     return None
 
 
-def test_claim_enqueues_linear_sync_active(mod, patch_connect, monkeypatch) -> None:
-    """KEI-106 — successful claim INSERTs a row in completion_sync_queue with
-    target_sink='linear' AND target_status='active' so the worker (KEI-74)
-    flips the matching Linear KEI to In Progress.
+def test_claim_does_not_enqueue_linear_sync_law_locked(mod, patch_connect, monkeypatch) -> None:
+    """Linear-read-only LAW (Dave 2026-05-20): _enqueue_linear_sync is locked
+    to a no-op — a successful claim no longer INSERTs a target_sink='linear'
+    completion_sync_queue row. Linear status propagates via the one-way push
+    only; the previously-enqueued rows were dead writes (the worker's linear
+    sink is itself a no-op since Agency_OS-1x3x).
     """
     monkeypatch.setenv("CALLSIGN", "aiden")
     cur = _Cursor(
@@ -557,10 +559,7 @@ def test_claim_enqueues_linear_sync_active(mod, patch_connect, monkeypatch) -> N
     patch_connect(cur)
     rc = mod.main(["claim", "--id", "KEI-106", "--json"])
     assert rc == 0
-    insert = _find_queue_insert(cur)
-    assert insert is not None, "claim must enqueue completion_sync_queue row"
-    _sql, params = insert
-    assert params == ("KEI-106", "active")
+    assert _find_queue_insert(cur) is None, "linear-sink enqueue must be suppressed"
 
 
 def test_claim_race_loss_does_not_enqueue(mod, patch_connect, monkeypatch) -> None:

--- a/tests/scripts/test_tasks_cli_evidence.py
+++ b/tests/scripts/test_tasks_cli_evidence.py
@@ -160,8 +160,10 @@ def test_positive_valid_evidence_completes_task(mod, monkeypatch, tmp_path, caps
     rc = mod.main(["complete", "KEI-89", "--evidence", str(ev_file)])
     assert rc == 0, capsys.readouterr().err
 
-    # Five execute calls fired: Gate 3, hash check, INSERT, UPDATE, KEI-106 linear sync enqueue
-    assert len(cur.executed) == 5
+    # Four execute calls fired: Gate 3, hash check, INSERT task_verifications,
+    # UPDATE tasks. The KEI-106 linear-sync enqueue is gone — _enqueue_linear_sync
+    # is locked to a no-op under the Linear-read-only LAW (Dave 2026-05-20).
+    assert len(cur.executed) == 4
 
     # INSERT contained the canonical JSON as test_output param
     insert_sql, insert_params = cur.executed[2]
@@ -172,9 +174,17 @@ def test_positive_valid_evidence_completes_task(mod, monkeypatch, tmp_path, caps
     round_tripped = json.loads(stored_output)
     assert round_tripped["acceptance_items"] == _VALID_EVIDENCE["acceptance_items"]
 
-    # Commits fired (main complete + KEI-106 linear sync enqueue); no rollback
-    assert conn.commits == 2
+    # One commit fired (main complete); no rollback. The KEI-106 linear-sync
+    # enqueue's separate connect+commit is gone — _enqueue_linear_sync is a
+    # no-op under the Linear-read-only LAW.
+    assert conn.commits == 1
     assert conn.rollbacks == 0
+
+    # Linear-read-only LAW guard — PROVES the lock: no completion_sync_queue
+    # (linear-sink) INSERT fired. _enqueue_linear_sync is a hard no-op.
+    assert not any("completion_sync_queue" in sql for sql, _ in cur.executed), (
+        "linear-sink enqueue must be suppressed under the Linear-read-only LAW"
+    )
 
     out = capsys.readouterr().out
     assert "KEI-89" in out

--- a/tests/scripts/test_weekly_cycle_from_bd.py
+++ b/tests/scripts/test_weekly_cycle_from_bd.py
@@ -229,3 +229,13 @@ def _frozen_datetime(year, month, day, hour, minute):
             return real_datetime(year, month, day, hour, minute, tzinfo=tz or UTC)
 
     return _Frozen
+
+
+def test_add_issue_to_cycle_is_law_locked_noop(wc_mod, monkeypatch):
+    """Linear-read-only LAW (Dave 2026-05-20): _add_issue_to_cycle is locked
+    to a no-op — it returns False and never calls Linear's GraphQL endpoint."""
+    called: list = []
+    monkeypatch.setattr(wc_mod, "_linear_graphql", lambda *a, **k: called.append(a) or {})
+    result = wc_mod._add_issue_to_cycle("fake-key", "issue-uuid", "cycle-uuid")
+    assert result is False
+    assert called == [], "_add_issue_to_cycle must not call Linear GraphQL"


### PR DESCRIPTION
## Summary

Enforces the ratified **Linear-read-only LAW** (Dave 2026-05-20). Atlas's Part 4 (#1101) made `linear_oneway_push.py` the sole sanctioned Linear writer; this PR locks the residual direct-write call sites. bd `Agency_OS-lr1k`.

## 4 NO-OPs

- **`auto_label_kei.py`** — `label_issue`'s `issueUpdate(labelIds)` write suppressed; inference still runs (read-only). Also removed the now-dead `_team_label_map` / `_create_label` (`issueLabelCreate`) / `_resolve_label_ids` writer chain — no Linear-writer code remains in the file.
- **`restore_linear_state.py`** — `apply_restore()` locked to no-op (was `issueUpdate` stateId). Recovery model: fix Supabase, let the one-way push propagate. Script kept; only the write suppressed.
- **`weekly_cycle_from_bd.py`** — `_add_issue_to_cycle()` locked to no-op (was `issueUpdate` cycleId).
- **`tasks_cli.py`** — `_enqueue_linear_sync()` locked to no-op; it enqueued `target_sink='linear'` rows the worker's linear sink already no-ops since #1101 (dead writes).

## Rule-text fix

- **`enforcer_deterministic.py`** — R12 `should_have` text no longer recommends "direct Linear GraphQL issueCreate" (contradicted the LAW). Audit-flagged as the 7th site but it's a **false positive** — the grep hit rule text, not a call; only the stale text is fixed.

## Out of scope (held)

- `betterstack_to_linear` + `central_listener` `issueCreate` — **GAP A**, escalated to Dave (how new KEIs enter Linear under the read-only LAW). Separate follow-up.
- `weekly_cycle_from_bd._create_cycle` (`cycleCreate`) — a create-write discovered in the same file; same create-shaped class as GAP A. Left for the GAP-A follow-up rather than silently no-op'ing out of scope.

## Test plan

- [x] Each no-op has a negative-path test proving the Linear GraphQL endpoint is NOT called (`test_*_law_locked_noop` / `test_label_issue_law_locked_suppresses_linear_write` / `test_claim_does_not_enqueue_linear_sync_law_locked`)
- [x] 146 tests pass across the 5 affected test modules; ruff check + format clean
- [ ] CI green
- [ ] Reviewer dual-concur (Aiden + Max)

🤖 Generated with [Claude Code](https://claude.com/claude-code)