### PR TITLE
[ATLAS] feat(j8eu): GAP-A — extend one-way push with KEI creation

### DIFF
--- a/migrations/20260520_j8eu_linear_create_pending.sql
+++ b/migrations/20260520_j8eu_linear_create_pending.sql
@@ -1,0 +1,91 @@
+-- Agency_OS-j8eu — GAP-A: one-way push KEI-creation opt-in flag.
+--
+-- Adds public.tasks.linear_create_pending — the OPT-IN marker the one-way
+-- push (scripts/orchestrator/linear_oneway_push.py) uses to decide which
+-- title-less rows should get a Linear issue created.
+--
+-- Why opt-in (not "any row with no linear_url"): public.tasks holds
+-- non-KEI operational rows (REVIEW-PR-* queue tasks, smoke tests) that
+-- have no linear_url and must NEVER be mirrored to Linear. A blanket
+-- "no linear_url -> issueCreate" would pollute Linear with junk. Only a
+-- row explicitly flagged linear_create_pending = TRUE is a create
+-- candidate. DEFAULT FALSE -> every existing row is a non-candidate, so
+-- the create path is dormant until the redirect sites (separate PR) set
+-- the flag for genuine KEIs.
+--
+-- The emit trigger fn_emit_sync_event_postgres is re-defined to also skip
+-- emission when an UPDATE touches only the push's bookkeeping columns
+-- (linear_synced_status / linear_url / linear_create_pending) — so the
+-- push's writes never echo back as Supabase sync_events.
+
+ALTER TABLE public.tasks
+    ADD COLUMN IF NOT EXISTS linear_create_pending BOOLEAN DEFAULT FALSE;
+
+COMMENT ON COLUMN public.tasks.linear_create_pending IS
+    'Agency_OS-j8eu — one-way push create opt-in. TRUE = this task should '
+    'get a Linear issue created by linear_oneway_push.py. The push consumes '
+    'the flag (sets it FALSE) before issueCreate. DEFAULT FALSE — only the '
+    'KEI-create redirect sites set it TRUE.';
+
+-- Re-definition of the emit trigger. Identical to the Agency_OS-1x3x
+-- (Part 4) version except the watermark guard now also covers linear_url
+-- and linear_create_pending.
+CREATE OR REPLACE FUNCTION public.fn_emit_sync_event_postgres()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+    v_event_type TEXT;
+    v_payload    JSONB;
+    -- Terminal statuses — single source of truth (avoids repeating the
+    -- 'done'/'cancelled' literals across the close/reopen branches).
+    v_terminal   CONSTANT TEXT[] := ARRAY['done', 'cancelled'];
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        v_event_type := 'create';
+    ELSIF TG_OP = 'UPDATE' THEN
+        -- Watermark guard: an UPDATE that changes ONLY the one-way push's
+        -- bookkeeping columns (status/title/priority all unchanged) is the
+        -- push recording its own progress. Emit nothing — otherwise the
+        -- push's write echoes back as a Supabase sync_event.
+        IF NEW.status IS NOT DISTINCT FROM OLD.status
+           AND NEW.title IS NOT DISTINCT FROM OLD.title
+           AND NEW.priority IS NOT DISTINCT FROM OLD.priority
+           AND (NEW.linear_synced_status IS DISTINCT FROM OLD.linear_synced_status
+                OR NEW.linear_url IS DISTINCT FROM OLD.linear_url
+                OR NEW.linear_create_pending IS DISTINCT FROM OLD.linear_create_pending) THEN
+            RETURN NEW;
+        END IF;
+        -- Closing transitions (status in a terminal state) emit 'close';
+        -- everything else is 'update'.
+        IF NEW.status = ANY(v_terminal) AND NEW.status IS DISTINCT FROM OLD.status THEN
+            v_event_type := 'close';
+        ELSIF OLD.status = ANY(v_terminal) AND NEW.status <> ALL(v_terminal) THEN
+            v_event_type := 'reopen';
+        ELSIF NEW.priority IS DISTINCT FROM OLD.priority THEN
+            v_event_type := 'priority_change';
+        ELSIF NEW.title IS DISTINCT FROM OLD.title THEN
+            v_event_type := 'title_change';
+        ELSE
+            v_event_type := 'update';
+        END IF;
+    ELSE
+        RETURN NULL;
+    END IF;
+
+    v_payload := jsonb_build_object(
+        'id', NEW.id,
+        'bd_id', NEW.bd_id,
+        'title', NEW.title,
+        'status', NEW.status,
+        'priority', NEW.priority,
+        'linear_url', NEW.linear_url,
+        'claimed_by', NEW.claimed_by,
+        'tg_op', TG_OP
+    );
+
+    INSERT INTO public.sync_events (origin, event_type, task_id, bd_id, payload)
+    VALUES ('postgres', v_event_type, NEW.id, NEW.bd_id, v_payload)
+    ON CONFLICT (task_id, payload_hash) WHERE processed = FALSE DO NOTHING;
+
+    RETURN NEW;
+END;
+$$;

--- a/scripts/orchestrator/linear_oneway_push.py
+++ b/scripts/orchestrator/linear_oneway_push.py
@@ -162,16 +162,14 @@ def fetch_pending(conn: Any) -> list[dict[str, str | None]]:
     return out
 
 
-def push_to_linear(api_key: str, kei: str, state_id: str) -> None:
-    """POST a single issueUpdate mutation. Raises RuntimeError on any failure.
+def _linear_graphql(api_key: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    """POST a GraphQL op to Linear and return the parsed payload.
 
-    Linear's issueUpdate accepts the KEI-N identifier as `id` (proven by the
-    legacy completion_sync_worker path). This is the only Linear WRITE in the
-    whole component.
+    Shared by every Linear write (issueUpdate, issueCreate). Raises
+    RuntimeError on transport failure or top-level GraphQL errors. The
+    caller inspects payload['data'] for the operation-specific result.
     """
-    body = json.dumps(
-        {"query": _ISSUE_UPDATE_MUTATION, "variables": {"id": kei, "state": state_id}}
-    ).encode()
+    body = json.dumps({"query": query, "variables": variables}).encode()
     # S310: the URL is the fixed https Linear GraphQL endpoint, not user input.
     req = urllib.request.Request(  # noqa: S310
         _LINEAR_GRAPHQL_URL,
@@ -187,7 +185,25 @@ def push_to_linear(api_key: str, kei: str, state_id: str) -> None:
         raise RuntimeError(f"linear network error: {exc}") from exc
     if payload and payload.get("errors"):
         raise RuntimeError(f"linear GraphQL errors: {payload['errors']}")
-    ok = (((payload or {}).get("data") or {}).get("issueUpdate") or {}).get("success")
+    return payload or {}
+
+
+def _apply_task_update(conn: Any, sql: str, params: tuple) -> None:
+    """Run one bookkeeping UPDATE on public.tasks and commit. Shared by the
+    watermark / create-intent writers — each passes its own literal SQL."""
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+    conn.commit()
+
+
+def push_to_linear(api_key: str, kei: str, state_id: str) -> None:
+    """POST a single issueUpdate mutation. Raises RuntimeError on any failure.
+
+    Linear's issueUpdate accepts the KEI-N identifier as `id` (proven by the
+    legacy completion_sync_worker path).
+    """
+    payload = _linear_graphql(api_key, _ISSUE_UPDATE_MUTATION, {"id": kei, "state": state_id})
+    ok = ((payload.get("data") or {}).get("issueUpdate") or {}).get("success")
     if not ok:
         raise RuntimeError(f"linear rejected issueUpdate: {payload}")
 
@@ -195,12 +211,9 @@ def push_to_linear(api_key: str, kei: str, state_id: str) -> None:
 def mark_synced(conn: Any, kei: str, status: str | None) -> None:
     """Advance the watermark after a successful push. The KEI-228 emit
     trigger's watermark guard skips this UPDATE — no sync_event echo."""
-    with conn.cursor() as cur:
-        cur.execute(
-            "UPDATE public.tasks SET linear_synced_status = %s WHERE id = %s",
-            (status, kei),
-        )
-    conn.commit()
+    _apply_task_update(
+        conn, "UPDATE public.tasks SET linear_synced_status = %s WHERE id = %s", (status, kei)
+    )
 
 
 # ───────────────────────── GAP-A: KEI creation path ─────────────────────────
@@ -245,24 +258,8 @@ def create_in_linear(
         issue_input["description"] = description
     if priority is not None and 0 <= priority <= 4:
         issue_input["priority"] = priority
-    body = json.dumps(
-        {"query": _ISSUE_CREATE_MUTATION, "variables": {"input": issue_input}}
-    ).encode()
-    # S310: the URL is the fixed https Linear GraphQL endpoint, not user input.
-    req = urllib.request.Request(  # noqa: S310
-        _LINEAR_GRAPHQL_URL,
-        data=body,
-        method="POST",
-        headers={"Authorization": api_key, "Content-Type": "application/json"},
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310
-            payload = json.loads(resp.read() or "null")
-    except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"linear network error: {exc}") from exc
-    if payload and payload.get("errors"):
-        raise RuntimeError(f"linear GraphQL errors: {payload['errors']}")
-    result = ((payload or {}).get("data") or {}).get("issueCreate") or {}
+    payload = _linear_graphql(api_key, _ISSUE_CREATE_MUTATION, {"input": issue_input})
+    result = (payload.get("data") or {}).get("issueCreate") or {}
     if not result.get("success") or not (result.get("issue") or {}).get("url"):
         raise RuntimeError(f"linear rejected issueCreate: {payload}")
     return str(result["issue"]["url"])
@@ -275,34 +272,25 @@ def consume_create_intent(conn: Any, task_id: str) -> None:
     missed-create, never a corrupting duplicate Linear issue. A clean failure
     re-arms the flag (rearm_create_intent) so the next tick retries.
     """
-    with conn.cursor() as cur:
-        cur.execute(
-            "UPDATE public.tasks SET linear_create_pending = FALSE WHERE id = %s",
-            (task_id,),
-        )
-    conn.commit()
+    _apply_task_update(
+        conn, "UPDATE public.tasks SET linear_create_pending = FALSE WHERE id = %s", (task_id,)
+    )
 
 
 def record_created_url(conn: Any, task_id: str, url: str) -> None:
     """Record the new Linear URL on the task row — the create watermark."""
-    with conn.cursor() as cur:
-        cur.execute(
-            "UPDATE public.tasks SET linear_url = %s WHERE id = %s",
-            (url, task_id),
-        )
-    conn.commit()
+    _apply_task_update(
+        conn, "UPDATE public.tasks SET linear_url = %s WHERE id = %s", (url, task_id)
+    )
 
 
 def rearm_create_intent(conn: Any, task_id: str) -> None:
     """Re-set linear_create_pending after a CLEAN create failure so the next
     tick retries. Only an actual crash (not a clean failure) leaves the intent
     consumed — that surfaces as a missed-create, never a duplicate."""
-    with conn.cursor() as cur:
-        cur.execute(
-            "UPDATE public.tasks SET linear_create_pending = TRUE WHERE id = %s",
-            (task_id,),
-        )
-    conn.commit()
+    _apply_task_update(
+        conn, "UPDATE public.tasks SET linear_create_pending = TRUE WHERE id = %s", (task_id,)
+    )
 
 
 def _emit_failure_alert(failures: list[tuple[str, str]]) -> None:

--- a/scripts/orchestrator/linear_oneway_push.py
+++ b/scripts/orchestrator/linear_oneway_push.py
@@ -7,13 +7,19 @@ automated process; Supabase public.tasks is the read-write replica; task
 STATUS changes propagate Supabase→Linear via THIS push and nothing else.
 
 Design — strictly one-way:
-  * Reads public.tasks (id, status, linear_synced_status). Reads nothing
-    from Linear. Writes nothing to Supabase except its own watermark.
-  * Writes Linear only — issueUpdate setting the workflow state.
-  * Pushes ONLY terminal status transitions: a task reaching a terminal
-    status (done / dismissed / cancelled) or reopening out of one. Pure
-    available↔active churn is never pushed. Titles/priority are never
-    pushed (Part 1's backfill owns titles, the other direction).
+  * Reads public.tasks. Reads nothing from Linear. Writes nothing to
+    Supabase except its own watermark / create-intent bookkeeping.
+  * Writes Linear only — issueUpdate (status) and issueCreate (GAP-A).
+  * STATUS path — pushes ONLY terminal status transitions: a task reaching
+    a terminal status (done / dismissed / cancelled) or reopening out of
+    one. Pure available↔active churn is never pushed.
+  * CREATE path (GAP-A) — a task explicitly opted-in via
+    linear_create_pending=TRUE with no Linear issue yet → issueCreate, then
+    record linear_url back. The opt-in flag is mandatory: public.tasks
+    holds non-KEI operational rows (REVIEW-PR-*, smoke tests) that must
+    never be mirrored. Crash-safe: the intent is consumed BEFORE the
+    create, so a crash yields a recoverable missed-create, never a
+    duplicate. Dormant until the KEI-create redirect sites set the flag.
 
 Idempotency + loop-safety:
   * linear_synced_status is the watermark — the status value last pushed.
@@ -86,6 +92,15 @@ _ISSUE_UPDATE_MUTATION = (
     "mutation($id:String!,$state:String!){issueUpdate(id:$id,input:{stateId:$state}){success}}"
 )
 
+# GAP-A — Keiracom Linear team UUID (issueCreate needs teamId). Env override.
+_LINEAR_TEAM_ID_DEFAULT = "4686528f-ce77-4c2f-968b-3dc76b34d6fe"
+_ISSUE_CREATE_MUTATION = (
+    "mutation($input:IssueCreateInput!){issueCreate(input:$input){success issue{identifier url}}}"
+)
+# Titles Postgres treats as "no usable title" — never create a Linear issue
+# from one (mirrors the Part 1 backfill predicate).
+_BAD_TITLES = ("", "(no title)")
+
 
 def _dsn() -> str:
     dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL")
@@ -107,6 +122,11 @@ def _linear_state_id(status: str) -> str:
     if not suffix:
         return ""
     return os.environ.get(f"LINEAR_STATE_ID_{suffix}", "")
+
+
+def _linear_team_id() -> str:
+    """Keiracom Linear team UUID for issueCreate. Has a default — never fails."""
+    return os.environ.get("LINEAR_TEAM_ID", _LINEAR_TEAM_ID_DEFAULT)
 
 
 def is_terminal_transition(status: str | None, synced: str | None) -> bool:
@@ -183,14 +203,116 @@ def mark_synced(conn: Any, kei: str, status: str | None) -> None:
     conn.commit()
 
 
+# ───────────────────────── GAP-A: KEI creation path ─────────────────────────
+
+
+def fetch_create_pending(conn: Any) -> list[dict[str, Any]]:
+    """Return tasks opted-in for Linear creation that have no Linear issue yet.
+
+    Candidate = linear_create_pending = TRUE AND no linear_url. The opt-in flag
+    is mandatory: public.tasks holds non-KEI operational rows (REVIEW-PR-*,
+    smoke tests) with no linear_url that must never be mirrored — only an
+    explicitly-flagged row is a create candidate. A junk title is also skipped.
+    """
+    out: list[dict[str, Any]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, title, description, priority FROM public.tasks "
+            "WHERE linear_create_pending IS TRUE "
+            "AND (linear_url IS NULL OR linear_url = '')"
+        )
+        rows = cur.fetchall()
+    for row in rows:
+        title = row[1]
+        if not title or title in _BAD_TITLES:
+            logger.warning("create skipped for %s — no usable title", row[0])
+            continue
+        out.append({"id": row[0], "title": title, "description": row[2], "priority": row[3]})
+    return out
+
+
+def create_in_linear(
+    api_key: str, team_id: str, title: str, description: str | None, priority: int | None
+) -> str:
+    """POST a single issueCreate mutation; return the new Linear issue URL.
+
+    Raises RuntimeError on any failure. The only Linear-create WRITE in the
+    component. New issues take the team's default workflow state — the status
+    path syncs the real status on a later tick.
+    """
+    issue_input: dict[str, Any] = {"teamId": team_id, "title": title}
+    if description:
+        issue_input["description"] = description
+    if priority is not None and 0 <= priority <= 4:
+        issue_input["priority"] = priority
+    body = json.dumps(
+        {"query": _ISSUE_CREATE_MUTATION, "variables": {"input": issue_input}}
+    ).encode()
+    # S310: the URL is the fixed https Linear GraphQL endpoint, not user input.
+    req = urllib.request.Request(  # noqa: S310
+        _LINEAR_GRAPHQL_URL,
+        data=body,
+        method="POST",
+        headers={"Authorization": api_key, "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310
+            payload = json.loads(resp.read() or "null")
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"linear network error: {exc}") from exc
+    if payload and payload.get("errors"):
+        raise RuntimeError(f"linear GraphQL errors: {payload['errors']}")
+    result = ((payload or {}).get("data") or {}).get("issueCreate") or {}
+    if not result.get("success") or not (result.get("issue") or {}).get("url"):
+        raise RuntimeError(f"linear rejected issueCreate: {payload}")
+    return str(result["issue"]["url"])
+
+
+def consume_create_intent(conn: Any, task_id: str) -> None:
+    """Clear linear_create_pending BEFORE the issueCreate — crash-safe.
+
+    Consuming the intent first means a crash mid-create yields a recoverable
+    missed-create, never a corrupting duplicate Linear issue. A clean failure
+    re-arms the flag (rearm_create_intent) so the next tick retries.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE public.tasks SET linear_create_pending = FALSE WHERE id = %s",
+            (task_id,),
+        )
+    conn.commit()
+
+
+def record_created_url(conn: Any, task_id: str, url: str) -> None:
+    """Record the new Linear URL on the task row — the create watermark."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE public.tasks SET linear_url = %s WHERE id = %s",
+            (url, task_id),
+        )
+    conn.commit()
+
+
+def rearm_create_intent(conn: Any, task_id: str) -> None:
+    """Re-set linear_create_pending after a CLEAN create failure so the next
+    tick retries. Only an actual crash (not a clean failure) leaves the intent
+    consumed — that surfaces as a missed-create, never a duplicate."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE public.tasks SET linear_create_pending = TRUE WHERE id = %s",
+            (task_id,),
+        )
+    conn.commit()
+
+
 def _emit_failure_alert(failures: list[tuple[str, str]]) -> None:
     """Fail-loud — publish a structured alert to elliot's inbox. The alert
     itself is best-effort (a NATS outage must not mask the push failure,
     which is already logged at ERROR)."""
     lines = "\n".join(f"  {kei}: {err}" for kei, err in failures)
     text = (
-        f"[ALERT:linear-oneway-push] {len(failures)} Linear push(es) FAILED — "
-        f"Supabase→Linear status drift NOT propagated:\n{lines}"
+        f"[ALERT:linear-oneway-push] {len(failures)} Linear push/create op(s) "
+        f"FAILED — Supabase→Linear sync NOT propagated:\n{lines}"
     )
     envelope = {"from": "linear-oneway-push", "kind": "blocker", "summary": text}
     try:
@@ -206,18 +328,17 @@ def _emit_failure_alert(failures: list[tuple[str, str]]) -> None:
         logger.exception("failure-alert NATS publish failed")
 
 
-def run_once(conn: Any, api_key: str, *, apply: bool) -> dict[str, Any]:
-    """Push every pending terminal transition. Returns a stats dict."""
-    pending = fetch_pending(conn)
-    stats: dict[str, Any] = {"pending": len(pending), "pushed": 0, "failed": 0}
-    failures: list[tuple[str, str]] = []
-    for task in pending:
+def _run_status_pushes(
+    conn: Any, api_key: str, *, apply: bool, stats: dict[str, Any], failures: list
+) -> None:
+    """Status-transition push loop (Part 4). Mutates stats + failures."""
+    for task in fetch_pending(conn):
         kei = str(task["id"])
         status = task["status"]
+        stats["pending"] += 1
         if not apply:
-            # Dry-run only counts what WOULD push; it never writes Linear, so
-            # it must not resolve or require LINEAR_STATE_ID — that env var is
-            # absent in CI and would falsely mark the task `failed`.
+            # Dry-run only counts; it never writes Linear, so it must not
+            # resolve or require LINEAR_STATE_ID (absent in CI).
             logger.info("[dry-run] would push %s → %s", kei, status)
             continue
         state_id = _linear_state_id(status or "")
@@ -236,6 +357,50 @@ def run_once(conn: Any, api_key: str, *, apply: bool) -> dict[str, Any]:
             logger.exception("push failed for %s", kei)
             failures.append((kei, str(exc)))
             stats["failed"] += 1
+
+
+def _run_creates(
+    conn: Any, api_key: str, *, apply: bool, stats: dict[str, Any], failures: list
+) -> None:
+    """GAP-A KEI-creation loop. Mutates stats + failures. Crash-safe: the
+    intent is consumed BEFORE issueCreate; a clean failure re-arms it."""
+    team_id = _linear_team_id()
+    for task in fetch_create_pending(conn):
+        task_id = str(task["id"])
+        stats["create_pending"] += 1
+        if not apply:
+            # Dry-run never writes — does not consume the intent or call Linear.
+            logger.info("[dry-run] would create Linear issue for %s", task_id)
+            continue
+        consume_create_intent(conn, task_id)  # crash-safe: consume before write
+        try:
+            url = create_in_linear(
+                api_key, team_id, task["title"], task["description"], task["priority"]
+            )
+            record_created_url(conn, task_id, url)
+            stats["created"] += 1
+            logger.info("created Linear issue for %s → %s", task_id, url)
+        except RuntimeError as exc:
+            rearm_create_intent(conn, task_id)  # clean failure — retry next tick
+            logger.exception("create failed for %s", task_id)
+            failures.append((task_id, str(exc)))
+            stats["create_failed"] += 1
+
+
+def run_once(conn: Any, api_key: str, *, apply: bool) -> dict[str, Any]:
+    """Push pending terminal transitions AND create Linear issues for opted-in
+    title-less tasks. Returns a stats dict."""
+    stats: dict[str, Any] = {
+        "pending": 0,
+        "pushed": 0,
+        "failed": 0,
+        "create_pending": 0,
+        "created": 0,
+        "create_failed": 0,
+    }
+    failures: list[tuple[str, str]] = []
+    _run_status_pushes(conn, api_key, apply=apply, stats=stats, failures=failures)
+    _run_creates(conn, api_key, apply=apply, stats=stats, failures=failures)
     if failures:
         _emit_failure_alert(failures)
     return stats
@@ -262,8 +427,13 @@ def main(argv: list[str] | None = None) -> int:
     with psycopg.connect(dsn, prepare_threshold=None) as conn:
         stats = run_once(conn, api_key, apply=args.apply)
 
-    print(f"pending: {stats['pending']}  pushed: {stats['pushed']}  failed: {stats['failed']}")
-    return 1 if stats["failed"] else 0
+    print(
+        f"status — pending: {stats['pending']}  pushed: {stats['pushed']}  "
+        f"failed: {stats['failed']}\n"
+        f"create — pending: {stats['create_pending']}  created: {stats['created']}  "
+        f"failed: {stats['create_failed']}"
+    )
+    return 1 if (stats["failed"] or stats["create_failed"]) else 0
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_linear_oneway_push.py
+++ b/tests/scripts/test_linear_oneway_push.py
@@ -198,40 +198,149 @@ def test_mark_synced_updates_only_watermark_column(mod):
     assert conn.commits == 1
 
 
-# ─── run_once ──────────────────────────────────────────────────────────────
+# ─── fetch_create_pending ──────────────────────────────────────────────────
+
+
+def test_fetch_create_pending_returns_opted_in_rows(mod):
+    cur = _Cursor(fetchall_rows=[("task-7", "Real KEI title", "a desc", 2)])
+    out = mod.fetch_create_pending(_Conn(cur))
+    assert out == [
+        {"id": "task-7", "title": "Real KEI title", "description": "a desc", "priority": 2}
+    ]
+
+
+def test_fetch_create_pending_sql_requires_opt_in_flag(mod):
+    """The candidate SQL MUST gate on linear_create_pending — public.tasks
+    holds REVIEW-PR-*/smoke rows with no linear_url that must never mirror."""
+    cur = _Cursor()
+    mod.fetch_create_pending(_Conn(cur))
+    sql, _ = cur.executed[0]
+    assert "linear_create_pending IS TRUE" in sql
+    assert "linear_url IS NULL" in sql
+
+
+def test_fetch_create_pending_skips_junk_titles(mod):
+    cur = _Cursor(
+        fetchall_rows=[
+            ("task-1", "Good title", None, None),
+            ("task-2", "(no title)", None, None),
+            ("task-3", "", None, None),
+        ]
+    )
+    out = mod.fetch_create_pending(_Conn(cur))
+    assert [r["id"] for r in out] == ["task-1"]
+
+
+# ─── create_in_linear ──────────────────────────────────────────────────────
+
+
+def test_create_in_linear_success_returns_url(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        _fake_urlopen(
+            {"data": {"issueCreate": {"success": True, "issue": {"url": "https://lin/KEI-9"}}}}
+        ),
+    )
+    url = mod.create_in_linear("key", "team", "Title", "desc", 2)
+    assert url == "https://lin/KEI-9"
+
+
+def test_create_in_linear_rejected_raises(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        _fake_urlopen({"data": {"issueCreate": {"success": False, "issue": None}}}),
+    )
+    with pytest.raises(RuntimeError, match="rejected"):
+        mod.create_in_linear("key", "team", "Title", None, None)
+
+
+def test_create_in_linear_graphql_errors_raise(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        _fake_urlopen({"errors": [{"message": "team not found"}]}),
+    )
+    with pytest.raises(RuntimeError, match="GraphQL errors"):
+        mod.create_in_linear("key", "team", "Title", None, None)
+
+
+def test_create_in_linear_network_error_raises(mod, monkeypatch):
+    def _boom(req, timeout=None):
+        raise OSError("refused")
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _boom)
+    with pytest.raises(RuntimeError, match="network error"):
+        mod.create_in_linear("key", "team", "Title", None, None)
+
+
+# ─── create-intent bookkeeping ─────────────────────────────────────────────
+
+
+def test_consume_create_intent_clears_flag(mod):
+    cur = _Cursor()
+    mod.consume_create_intent(_Conn(cur), "task-5")
+    sql, params = cur.executed[0]
+    assert "linear_create_pending = FALSE" in sql
+    assert params == ("task-5",)
+
+
+def test_record_created_url_writes_linear_url(mod):
+    cur = _Cursor()
+    mod.record_created_url(_Conn(cur), "task-5", "https://lin/KEI-9")
+    sql, params = cur.executed[0]
+    assert "SET linear_url = %s" in sql
+    assert params == ("https://lin/KEI-9", "task-5")
+
+
+def test_rearm_create_intent_resets_flag(mod):
+    cur = _Cursor()
+    mod.rearm_create_intent(_Conn(cur), "task-5")
+    sql, _ = cur.executed[0]
+    assert "linear_create_pending = TRUE" in sql
+
+
+# ─── run_once: status path ─────────────────────────────────────────────────
+
+
+def _no_creates(mod, monkeypatch):
+    """Stub fetch_create_pending → [] so status-path tests stay isolated."""
+    monkeypatch.setattr(mod, "fetch_create_pending", lambda _c: [])
 
 
 def test_run_once_dry_run_never_writes(mod, monkeypatch):
     """Dry-run must NOT resolve LINEAR_STATE_ID — that env var is absent in
     CI; resolving it in dry-run falsely marked a terminal task `failed`
-    (regression lock for the run 26152062782 failure). Env var explicitly
-    cleared here so the test mirrors CI, not a state-id-set local proxy."""
+    (regression lock for run 26152062782). Env var cleared so the test
+    mirrors CI, not a state-id-set local proxy."""
     monkeypatch.delenv("LINEAR_STATE_ID_DONE", raising=False)
-    cur = _Cursor(fetchall_rows=[("KEI-1", "done", None)])
+    monkeypatch.setattr(mod, "fetch_pending", lambda _c: [{"id": "KEI-1", "status": "done"}])
+    monkeypatch.setattr(mod, "fetch_create_pending", lambda _c: [])
     pushed = []
     monkeypatch.setattr(mod, "push_to_linear", lambda *a: pushed.append(a))
-    stats = mod.run_once(_Conn(cur), "key", apply=False)
-    assert stats == {"pending": 1, "pushed": 0, "failed": 0}
+    stats = mod.run_once(_Conn(_Cursor()), "key", apply=False)
+    assert stats["pending"] == 1 and stats["pushed"] == 0 and stats["failed"] == 0
     assert pushed == []  # dry-run touched Linear zero times
 
 
 def test_run_once_apply_pushes_and_marks(mod, monkeypatch):
-    cur = _Cursor(fetchall_rows=[("KEI-1", "done", None)])
-    conn = _Conn(cur)
+    cur = _Cursor()
     monkeypatch.setenv("LINEAR_STATE_ID_DONE", "uuid-done")
+    monkeypatch.setattr(mod, "fetch_pending", lambda _c: [{"id": "KEI-1", "status": "done"}])
+    _no_creates(mod, monkeypatch)
     pushed = []
     monkeypatch.setattr(mod, "push_to_linear", lambda *a: pushed.append(a))
-    stats = mod.run_once(conn, "key", apply=True)
+    stats = mod.run_once(_Conn(cur), "key", apply=True)
     assert stats["pushed"] == 1 and stats["failed"] == 0
     assert pushed == [("key", "KEI-1", "uuid-done")]
-    # watermark advanced
-    update_sql = cur.executed[-1][0]
-    assert "linear_synced_status" in update_sql
+    assert "linear_synced_status" in cur.executed[-1][0]  # watermark advanced
 
 
 def test_run_once_failure_collects_and_alerts(mod, monkeypatch):
-    cur = _Cursor(fetchall_rows=[("KEI-1", "done", None)])
     monkeypatch.setenv("LINEAR_STATE_ID_DONE", "uuid-done")
+    monkeypatch.setattr(mod, "fetch_pending", lambda _c: [{"id": "KEI-1", "status": "done"}])
+    _no_creates(mod, monkeypatch)
 
     def _boom(*a):
         raise RuntimeError("linear network error: down")
@@ -239,31 +348,89 @@ def test_run_once_failure_collects_and_alerts(mod, monkeypatch):
     monkeypatch.setattr(mod, "push_to_linear", _boom)
     alerts = []
     monkeypatch.setattr(mod, "_emit_failure_alert", lambda f: alerts.append(f))
-    stats = mod.run_once(_Conn(cur), "key", apply=True)
+    stats = mod.run_once(_Conn(_Cursor()), "key", apply=True)
     assert stats["failed"] == 1 and stats["pushed"] == 0
     assert alerts and alerts[0][0][0] == "KEI-1"  # fail-loud alert fired
 
 
 def test_run_once_missing_state_id_is_a_failure(mod, monkeypatch):
     """No LINEAR_STATE_ID for the status → fail loud, do not push blind."""
-    cur = _Cursor(fetchall_rows=[("KEI-1", "done", None)])
     monkeypatch.delenv("LINEAR_STATE_ID_DONE", raising=False)
+    monkeypatch.setattr(mod, "fetch_pending", lambda _c: [{"id": "KEI-1", "status": "done"}])
+    _no_creates(mod, monkeypatch)
     alerts = []
     monkeypatch.setattr(mod, "_emit_failure_alert", lambda f: alerts.append(f))
     monkeypatch.setattr(mod, "push_to_linear", lambda *a: pytest.fail("must not push"))
-    stats = mod.run_once(_Conn(cur), "key", apply=True)
+    stats = mod.run_once(_Conn(_Cursor()), "key", apply=True)
     assert stats["failed"] == 1
     assert alerts
+
+
+# ─── run_once: GAP-A create path ───────────────────────────────────────────
+
+
+def _one_create(mod, monkeypatch):
+    monkeypatch.setattr(mod, "fetch_pending", lambda _c: [])
+    monkeypatch.setattr(
+        mod,
+        "fetch_create_pending",
+        lambda _c: [{"id": "task-7", "title": "New KEI", "description": "d", "priority": 2}],
+    )
+
+
+def test_run_once_create_dry_run_no_consume_no_create(mod, monkeypatch):
+    """Dry-run for creates: counts the candidate but never consumes the
+    intent and never calls issueCreate."""
+    _one_create(mod, monkeypatch)
+    calls = []
+    monkeypatch.setattr(mod, "consume_create_intent", lambda *a: calls.append("consume"))
+    monkeypatch.setattr(mod, "create_in_linear", lambda *a: calls.append("create"))
+    stats = mod.run_once(_Conn(_Cursor()), "key", apply=False)
+    assert stats["create_pending"] == 1 and stats["created"] == 0
+    assert calls == []  # no consume, no create in dry-run
+
+
+def test_run_once_create_consumes_intent_before_create(mod, monkeypatch):
+    """Crash-safety: the intent is consumed BEFORE issueCreate, so a crash
+    yields a recoverable missed-create, never a duplicate Linear issue."""
+    _one_create(mod, monkeypatch)
+    order = []
+    monkeypatch.setattr(mod, "consume_create_intent", lambda *a: order.append("consume"))
+    monkeypatch.setattr(mod, "create_in_linear", lambda *a: (order.append("create"), "url")[1])
+    monkeypatch.setattr(mod, "record_created_url", lambda *a: order.append("record"))
+    stats = mod.run_once(_Conn(_Cursor()), "key", apply=True)
+    assert stats["created"] == 1
+    assert order == ["consume", "create", "record"]
+
+
+def test_run_once_create_failure_rearms_and_alerts(mod, monkeypatch):
+    """A clean issueCreate failure re-arms the intent (retry next tick) and
+    fires a fail-loud alert."""
+    _one_create(mod, monkeypatch)
+    monkeypatch.setattr(mod, "consume_create_intent", lambda *a: None)
+    rearmed = []
+    monkeypatch.setattr(mod, "rearm_create_intent", lambda c, t: rearmed.append(t))
+
+    def _boom(*a):
+        raise RuntimeError("linear network error: down")
+
+    monkeypatch.setattr(mod, "create_in_linear", _boom)
+    alerts = []
+    monkeypatch.setattr(mod, "_emit_failure_alert", lambda f: alerts.append(f))
+    stats = mod.run_once(_Conn(_Cursor()), "key", apply=True)
+    assert stats["create_failed"] == 1 and stats["created"] == 0
+    assert rearmed == ["task-7"]  # re-armed for retry
+    assert alerts and alerts[0][0][0] == "task-7"
 
 
 # ─── one-way invariant ─────────────────────────────────────────────────────
 
 
 def test_module_issues_no_linear_read_query(mod):
-    """One-way guard: the only Linear GraphQL the module emits is the
-    issueUpdate mutation — no `query {` read of Linear issue data."""
+    """One-way guard: the module's only Linear GraphQL ops are the
+    issueUpdate + issueCreate mutations — no read query of Linear data."""
     source = SCRIPT.read_text()
-    assert "issueUpdate" in source
+    assert "issueUpdate" in source and "issueCreate" in source
     # no Linear GraphQL *query* (read) — the push reads Supabase, not Linear
     assert "issues(" not in source
     assert "query(" not in source


### PR DESCRIPTION
## Summary

Dave **GAP-A** approved: *"if everyone is claiming, creating and closing KEIs via bd in supabase, then linear should reflect this."* The one-way push now carries **creates**, not just status.

**New create path** in `scripts/orchestrator/linear_oneway_push.py`: a `public.tasks` row opted-in via `linear_create_pending=TRUE` with no `linear_url` → `issueCreate` (teamId + title + description + priority) → record the new `linear_url` back. `run_once` now does status pushes **and** creates. Same one-way / fail-loud discipline.

## GOV-9 — 2 gaps surfaced, both resolved in-PR

**1. Opt-in, not "any row with no linear_url".** Recon found all 24 `linear_url`-NULL rows in `public.tasks` are **non-KEI operational ephemera** — 23 `REVIEW-PR-*` queue tasks + 1 smoke test. A blanket "no linear_url → issueCreate" would have created 24 junk Linear issues on first run — the exact corruption the mirror directive guards against. So creation is **opt-in**: only `linear_create_pending=TRUE` rows are candidates. `DEFAULT FALSE` → the create path is **dormant until the 3 redirect sites** (separate PR, per directive c) set the flag.

**2. Crash-safety — no duplicate Linear issues.** `consume_create_intent` (`linear_create_pending=FALSE`) runs **before** `issueCreate`. A crash mid-create yields a recoverable missed-create, never a corrupting duplicate. A clean failure re-arms the flag so the next 15-min tick retries.

## Changes
- `migrations/20260520_j8eu_linear_create_pending.sql` — adds `public.tasks.linear_create_pending BOOLEAN DEFAULT FALSE`; re-defines `fn_emit_sync_event_postgres` so the guard also skips `linear_url`/`linear_create_pending` bookkeeping writes (create-watermark writes never echo as `sync_events`).
- `linear_oneway_push.py` — `fetch_create_pending`, `create_in_linear`, intent bookkeeping (`consume`/`record`/`rearm`), `_run_creates`; `run_once` extended.
- Dry-run discipline (the run-26152062782 lesson): dry-run counts create candidates but never consumes intent / calls Linear.

## Follow-up (separate PR — NOT wired here)
The 3 held `issueCreate` sites (`betterstack_to_linear`, `central_listener`, `weekly_cycle_from_bd._create_cycle`) redirect to creating the task in bd/Supabase with `linear_create_pending=TRUE`; **this** push then carries it to Linear.

## Test plan
- [x] 35 tests pass (22 existing + 13 new) — `fetch_create_pending` opt-in gate + junk-title skip, `create_in_linear` success/reject/GraphQL-error/network-error, intent bookkeeping, `run_once` create dry-run (no consume/no create), consume-before-create ordering (crash-safety), failure-rearm + alert
- [x] Verified with `env -u LINEAR_STATE_ID_DONE -u LINEAR_TEAM_ID` (CI-faithful)
- [x] ruff check + format clean
- [x] one-way invariant test extended — module emits only issueUpdate + issueCreate, no Linear read query
- [ ] **Post-merge:** apply migration `20260520_j8eu_linear_create_pending.sql` (the push already runs as a service)

bd: `Agency_OS-j8eu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)