### PR TITLE
[ATLAS] fix(memory-remediation): unfreeze 2 indexers + declare drive deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -123,6 +123,14 @@ flashrank>=0.2.7,<0.3
 # importing the removed symbol.
 weaviate-client>=4.5,<4.20
 
+# === Google Drive / Docs (drive_strategic_indexer — KEI-208) ===
+# scripts/orchestrator/drive_strategic_indexer.py imports googleapiclient +
+# google.auth to read the strategic-docs corpus. These were never declared,
+# so the indexer crashed on import every run (memory-group audit 2026-05-20,
+# Agency_OS-e4c1) — the StrategicDocuments Weaviate collection stayed empty.
+google-api-python-client>=2.100
+google-auth>=2.30
+
 # === Testing ===
 pytest>=7.4.0
 pytest-asyncio>=0.21.0

--- a/scripts/indexing_queue_worker.py
+++ b/scripts/indexing_queue_worker.py
@@ -56,6 +56,21 @@ DEFAULT_BACKEND = "stub"
 DEFAULT_SLACK_RELAY = "/home/elliotbot/clawd/Agency_OS/scripts/slack_relay.py"
 _RUNNING = True
 
+# Supabase-pooler-safe psycopg connection kwargs (memory-group audit 2026-05-20):
+# - prepare_threshold=None: txn-mode pgbouncer drops PREPAREs across
+#   transactions; without this psycopg auto-prepares after 5 executes and
+#   raises DuplicatePreparedStatement (the crash that froze this worker).
+# - connect_timeout + TCP keepalives: a stalled / black-holed connection
+#   fails fast instead of hanging forever in poll() with no recovery.
+_CONNECT_KWARGS = {
+    "prepare_threshold": None,
+    "connect_timeout": 10,
+    "keepalives": 1,
+    "keepalives_idle": 30,
+    "keepalives_interval": 10,
+    "keepalives_count": 3,
+}
+
 
 def _dsn() -> str:
     dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
@@ -249,7 +264,7 @@ def run(
     processor = _processor_id()
     iteration = 0
     try:
-        with psycopg.connect(_dsn()) as conn:
+        with psycopg.connect(_dsn(), **_CONNECT_KWARGS) as conn:
             reset = reset_stuck(conn)
             if reset:
                 logger.info("startup: reset %d stuck rows back to pending", reset)

--- a/scripts/orchestrator/tool_call_log_indexer.py
+++ b/scripts/orchestrator/tool_call_log_indexer.py
@@ -59,6 +59,21 @@ MAX_RETRIES = 3
 INITIAL_BACKOFF_SECONDS = 1.0
 POLL_INTERVAL_SECONDS = 30.0
 
+# Supabase-pooler-safe psycopg connection kwargs (memory-group audit 2026-05-20):
+# - prepare_threshold=None: txn-mode pgbouncer drops PREPAREs across
+#   transactions (without it psycopg raises on the 2nd statement of a batch).
+# - connect_timeout + TCP keepalives: a stalled / black-holed connection
+#   fails fast instead of hanging forever in poll() — the failure mode that
+#   froze this indexer for 3 days with no error and no recovery.
+_CONNECT_KWARGS = {
+    "prepare_threshold": None,
+    "connect_timeout": 10,
+    "keepalives": 1,
+    "keepalives_idle": 30,
+    "keepalives_interval": 10,
+    "keepalives_count": 3,
+}
+
 _TOOL_CALLS_SCHEMA = {
     "class": TOOL_CALLS_CLASS,
     "description": "Tool calls indexed from public.tool_call_log (KEI-54B).",
@@ -273,12 +288,10 @@ def run(batch_size: int, poll_interval: float, max_iterations: int | None = None
     signal.signal(signal.SIGINT, _shutdown)
 
     while not stop["flag"]:
-        # prepare_threshold=None disables psycopg's prepared-statement caching.
-        # Supabase pooler runs in transaction-mode pgbouncer which doesn't
-        # preserve PREPARE statements across transactions; without this disable
-        # psycopg raises InvalidSqlStatementName on the second statement of
-        # any batch (mark_indexed loop fails on row 2).
-        with psycopg.connect(_dsn(), prepare_threshold=None) as conn:
+        # _CONNECT_KWARGS hardens the connection against the Supabase pooler
+        # (prepare-statement drop) AND against an indefinite poll() hang on a
+        # stalled connection (connect_timeout + keepalives).
+        with psycopg.connect(_dsn(), **_CONNECT_KWARGS) as conn:
             process_batch(conn, batch_size)
         iterations += 1
         if max_iterations is not None and iterations >= max_iterations:

--- a/tests/scripts/test_indexing_queue_worker.py
+++ b/tests/scripts/test_indexing_queue_worker.py
@@ -233,3 +233,17 @@ def test_run_max_iterations_exits_clean(mod, patch_connect, monkeypatch) -> None
     monkeypatch.setattr("time.sleep", lambda _s: None)
     rc = mod.run(batch_size=1, poll_interval=1, max_attempts=3, max_iterations=2)
     assert rc == 0
+
+
+def test_connect_kwargs_pooler_safe(mod) -> None:
+    """Regression lock (Agency_OS-wf2v): the worker's psycopg connection MUST
+    pass prepare_threshold=None — txn-mode pgbouncer drops PREPAREs, and
+    without it psycopg auto-prepares after 5 executes and raises
+    DuplicatePreparedStatement (the crash that froze the worker for 3 days).
+    It must also set connect_timeout + TCP keepalives so a stalled connection
+    cannot hang forever in poll()."""
+    kw = mod._CONNECT_KWARGS
+    assert kw["prepare_threshold"] is None
+    assert kw["connect_timeout"] > 0
+    assert kw["keepalives"] == 1
+    assert kw["keepalives_idle"] > 0 and kw["keepalives_count"] > 0

--- a/tests/scripts/test_tool_call_log_indexer.py
+++ b/tests/scripts/test_tool_call_log_indexer.py
@@ -12,11 +12,27 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "orchestrator" / "tool_call_log_indexer.py"
+# tool_call_log_indexer imports `_heartbeat_shim` (a sibling in
+# scripts/orchestrator/) — that dir must be on sys.path or collection fails.
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "orchestrator"))
 
 _spec = importlib.util.spec_from_file_location("tool_call_log_indexer", SCRIPT)
 _mod = importlib.util.module_from_spec(_spec)
 sys.modules["tool_call_log_indexer"] = _mod
 _spec.loader.exec_module(_mod)
+
+
+def test_connect_kwargs_pooler_safe() -> None:
+    """Regression lock (Agency_OS-telw): the indexer's psycopg connection MUST
+    set connect_timeout + TCP keepalives so a stalled / black-holed Supabase
+    connection fails fast instead of hanging forever in poll() — the failure
+    mode that froze this indexer for 3 days with no error. prepare_threshold
+    stays None for the txn-mode pooler."""
+    kw = _mod._CONNECT_KWARGS
+    assert kw["prepare_threshold"] is None
+    assert kw["connect_timeout"] > 0
+    assert kw["keepalives"] == 1
+    assert kw["keepalives_idle"] > 0 and kw["keepalives_count"] > 0
 
 
 def _row(**overrides):


### PR DESCRIPTION
## Summary

The memory-group functional audit (Dave-authorised 2026-05-20) found 3 indexers down despite `systemctl` showing `active(running)` — the Cognee-class "service up ≠ functional" failure. Each diagnosed to root cause and permanently fixed. One PR for the group.

## Agency_OS-wf2v — indexing-queue-worker frozen ~3 days
**Root cause:** `run()` opened `psycopg.connect(_dsn())` with **no `prepare_threshold=None`**. Supabase's transaction-mode pgbouncer drops `PREPARE`s across transactions; psycopg auto-prepares after 5 executes → `DuplicatePreparedStatement` (verbatim traceback in the frozen log). The poisoned connection then hung in `poll()` — process alive, log frozen, no recovery.
**Fix:** `psycopg.connect(_dsn(), **_CONNECT_KWARGS)` — `prepare_threshold=None` + `connect_timeout` + TCP keepalives.

## Agency_OS-telw — tool-call-log-indexer frozen ~3 days
**Root cause:** `run()` did `psycopg.connect` with `prepare_threshold=None` but **no `connect_timeout`/keepalives** and no try/except. When the pooler stalled, the indexer hung indefinitely in `poll()` on the DB socket (verified `/proc/<pid>/wchan=do_poll`) — clean last log line, no error, process alive 3 days.
**Fix:** same `_CONNECT_KWARGS` — `connect_timeout` + keepalives so a stalled connection fails fast and systemd `Restart=on-failure` recovers it.

## Agency_OS-e4c1 — drive-strategic-indexer never ran
**Root cause (layered):** (a) `install_drive_strategic_indexer.sh` was never executed on the host — *merge ≠ deploy*, no systemd timer existed; (b) the indexer imports `googleapiclient` + `google.auth`, **never declared in requirements.txt nor installed** in the `.venv` → crashed on import every run.
**Fix here:** declare `google-api-python-client` + `google-auth` in `requirements.txt`. Timer install + `.venv` pip-install done live as ops. A 3rd layer — the Google service-account lacks read permission on the target Drive docs (`403 PERMISSION_DENIED`) — is escalated to Dave (Drive-sharing action, not code-fixable).

Also fixes a pre-existing collection break in `test_tool_call_log_indexer.py` (`_heartbeat_shim` sys.path) so the new regression test runs.

## Verification (verbatim — fixed code, `--once` against live DB)
```
$ python3 scripts/indexing_queue_worker.py --max-iterations 1
... batch: claimed=5 done=5 retry=0 failed=0
... clean shutdown after 1 iterations

$ python3 scripts/orchestrator/tool_call_log_indexer.py --once
... batch: {'claimed': 50, 'done': 50, 'failed': 0}
```
Both live services restarted — now processing (tool-call-log `claimed=50 done=50` ×2; indexing-queue `claimed=5 done=5`). Note: **indexing-queue-worker on un-merged code re-hits `DuplicatePreparedStatement` within minutes** — merge + post-merge service restart is urgent for it.

## Test plan
- [x] 32 tests pass (both indexer suites) incl. 2 new `test_connect_kwargs_pooler_safe` regression locks
- [x] ruff check + format clean
- [x] empirical `--once` runs processed real batches (0 failed)
- [ ] **Post-merge:** restart `indexing-queue-worker` + `tool-call-log-indexer` services to pick up the fix

bd: `Agency_OS-wf2v`, `Agency_OS-telw`, `Agency_OS-e4c1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)