### PR TITLE
[ORION] fix(fleet-supervisor): release review claims on PR-merge + filter smoke fixtures

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -117,6 +117,15 @@ DESC_TRUNCATE = 2000
 # Stale claim threshold
 STALE_HOURS = 2
 
+# Smoke-test fixtures (Agency_OS-test001, KEI-TEST — title "smoke", NULL
+# priority, no scope) are not real work; they must never be claimed or nudged
+# on. SQL fragment excludes them by id and by any "smoke" in the title. Uses
+# %% so it survives psycopg's %s-param queries unescaped.
+_SMOKE_FIXTURE_EXCLUSION = (
+    "id NOT IN ('Agency_OS-test001', 'KEI-TEST') "
+    "AND lower(COALESCE(title, '')) NOT LIKE '%%smoke%%'"
+)
+
 # Inactivity threshold before nudge/restart (minutes)
 INACTIVITY_MINUTES = 15
 
@@ -251,9 +260,10 @@ def get_active_claim(conn: psycopg.Connection, callsign: str) -> tuple[str, str]
     """Return (task_id, title) for the active claim this callsign holds, or None."""
     with conn.cursor() as cur:
         cur.execute(
-            """
+            f"""
             SELECT id, title FROM public.tasks
             WHERE status = 'active' AND claimed_by = %s
+              AND {_SMOKE_FIXTURE_EXCLUSION}
             LIMIT 1
             """,
             (callsign,),
@@ -392,11 +402,12 @@ def _build_task_query(
     dependency-enforcement gate is universal (v1 + v2, with and without
     open-PR filter).
     """
-    base = """
+    base = f"""
         SELECT id, title, COALESCE(description, '') FROM public.tasks
         WHERE status = 'available'
           AND (phase IS NULL OR phase <= %s)
           AND (is_parent IS NULL OR is_parent = false)
+          AND {_SMOKE_FIXTURE_EXCLUSION}
     """
     base = base.rstrip() + "\n  " + _DEPS_CLAUSE
     # KEI-183 follow-up — phase ASC first so lower-phase work drains before
@@ -488,6 +499,54 @@ def release_stale_claims(conn: psycopg.Connection) -> int:
         count = cur.rowcount
     conn.commit()
     return count
+
+
+def release_merged_review_claims(conn: psycopg.Connection) -> int:
+    """Release REVIEW-PR-<N> claims whose PR has merged or closed.
+
+    A REVIEW-PR-<N> row (inserted by insert_review_task) stays status='active'
+    forever once claimed — nothing transitions it when the PR merges, so the
+    supervisor nudges the claimant indefinitely on a review that is already
+    done. This releases the claim (status='done') the moment its PR is no
+    longer open. Returns the count released. Fail-open: a gh failure on one
+    PR is logged and skipped, never aborts the sweep.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM public.tasks "
+            "WHERE status = 'active' AND id LIKE 'REVIEW-PR-%'"
+        )
+        review_ids = [r[0] for r in cur.fetchall()]
+    released = 0
+    for task_id in review_ids:
+        m = re.match(r"REVIEW-PR-(\d+)$", task_id)
+        if not m:
+            continue
+        pr_number = m.group(1)
+        try:
+            proc = subprocess.run(  # noqa: S603,S607 — controlled args, no shell
+                ["gh", "pr", "view", pr_number, "--json", "state", "-q", ".state"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            log.warning("release_merged_review_claims: gh pr view %s failed: %s", pr_number, exc)
+            continue
+        state = (proc.stdout or "").strip().upper()
+        if state in ("MERGED", "CLOSED"):
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE public.tasks SET status = 'done' "
+                    "WHERE id = %s AND status = 'active'",
+                    (task_id,),
+                )
+                released += cur.rowcount
+            log.info("released review claim %s — PR #%s is %s", task_id, pr_number, state)
+    if released:
+        conn.commit()
+    return released
 
 
 def get_last_tool_call(conn: psycopg.Connection, callsign: str) -> _dt.datetime | None:
@@ -1045,6 +1104,12 @@ def main() -> None:
         released = release_stale_claims(conn)
         if released:
             log.info("Released %d stale claim(s)", released)
+
+        # Release review claims whose PR has merged/closed — stops the
+        # supervisor nudging indefinitely on a review that is already done.
+        released_reviews = release_merged_review_claims(conn)
+        if released_reviews:
+            log.info("Released %d merged/closed review claim(s)", released_reviews)
 
         phase_max = get_phase_max(conn)
         prs = list_open_prs()

--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -524,7 +524,8 @@ def release_merged_review_claims(conn: psycopg.Connection) -> int:
             continue
         pr_number = m.group(1)
         try:
-            proc = subprocess.run(  # noqa: S603,S607 — controlled args, no shell
+            # gh CLI, literal args, no shell — pr_number is a \d+ regex capture.
+            proc = subprocess.run(  # noqa: S603,S607
                 ["gh", "pr", "view", pr_number, "--json", "state", "-q", ".state"],
                 capture_output=True,
                 text=True,

--- a/tests/scripts/test_fleet_supervisor.py
+++ b/tests/scripts/test_fleet_supervisor.py
@@ -972,3 +972,68 @@ def test_build_review_prompt_includes_sonar_block(monkeypatch):
     assert "issues_total" in prompt or "total NEW" in prompt
     assert "qg_status" in prompt or "status: ERROR" in prompt
     assert "BOTH endpoints" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Claim-release: REVIEW-PR claims released when the PR merges/closes
+# (Agency_OS-ln7j — kills infinite stale-nudge noise)
+# ---------------------------------------------------------------------------
+
+
+def _mock_conn():
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn, cursor
+
+
+def test_release_merged_review_claims_releases_merged_pr():
+    """A REVIEW-PR-<N> claim whose PR has MERGED is released (status='done')."""
+    conn, cursor = _mock_conn()
+    cursor.fetchall.return_value = [("REVIEW-PR-1106",)]
+    cursor.rowcount = 1
+    merged = MagicMock()
+    merged.stdout = "MERGED\n"
+    with patch.object(fs.subprocess, "run", return_value=merged):
+        released = fs.release_merged_review_claims(conn)
+    assert released == 1
+    update_sqls = [
+        c.args[0] for c in cursor.execute.call_args_list if "UPDATE" in c.args[0].upper()
+    ]
+    assert update_sqls, "merged review claim must fire an UPDATE"
+    assert "done" in update_sqls[0]
+    conn.commit.assert_called()
+
+
+def test_release_merged_review_claims_keeps_open_pr():
+    """A REVIEW-PR-<N> claim whose PR is still OPEN is NOT released."""
+    conn, cursor = _mock_conn()
+    cursor.fetchall.return_value = [("REVIEW-PR-2200",)]
+    cursor.rowcount = 1
+    open_pr = MagicMock()
+    open_pr.stdout = "OPEN\n"
+    with patch.object(fs.subprocess, "run", return_value=open_pr):
+        released = fs.release_merged_review_claims(conn)
+    assert released == 0
+    update_sqls = [
+        c.args[0] for c in cursor.execute.call_args_list if "UPDATE" in c.args[0].upper()
+    ]
+    assert not update_sqls, "an open PR's review claim must not be released"
+
+
+def test_candidate_sql_excludes_smoke_fixtures():
+    """claim_next_task's candidate query filters out the smoke-test fixtures."""
+    sql, _ = fs._build_task_query(v2=False, open_pr_keis=set(), callsign="orion", phase_max=99)
+    assert "Agency_OS-test001" in sql
+    assert "KEI-TEST" in sql
+    assert "smoke" in sql.lower()
+
+
+def test_get_active_claim_query_excludes_smoke_fixtures():
+    """get_active_claim never reports a smoke-test fixture as an active claim."""
+    conn, cursor = _mock_conn()
+    cursor.fetchone.return_value = None
+    fs.get_active_claim(conn, "orion")
+    sql = cursor.execute.call_args[0][0]
+    assert "Agency_OS-test001" in sql and "smoke" in sql.lower()


### PR DESCRIPTION
## Summary

`fleet_supervisor` never releases a `REVIEW-PR-<N>` claim when its PR merges/closes — it nudges the claimant indefinitely on a review that is already done. bd `Agency_OS-ln7j` (surfaced by the #1108 audit).

## Diagnosis

`insert_review_task` writes a `REVIEW-PR-<N>` row to `public.tasks` with `status='active'`. **Nothing transitions it off `'active'` when the PR merges** — `get_active_claim` keeps returning it, so scenario-3 nudges the claimant (`"You have REVIEW-PR-<N> claimed. Resume building"`) every 5 min, forever. `release_stale_claims` only catches it after `STALE_HOURS=2h`. This is why the Fleet Status report showed `REVIEW-PR-1104/05/06/07` as pending-nudged when all four were MERGED.

## Fix (runtime)

- **`release_merged_review_claims(conn)`** — new: scans active `REVIEW-PR-<N>` rows, checks each PR via `gh pr view <N> --json state`, releases (`status='done'`) those whose PR is `MERGED`/`CLOSED`. Fail-open per PR. Wired into `main()` right after `release_stale_claims`.
- **Smoke-fixture filter** — `Agency_OS-test001`, `KEI-TEST` (title "smoke") excluded from both the claim-candidate query (`_build_task_query`) and `get_active_claim` via a shared `_SMOKE_FIXTURE_EXCLUSION` SQL fragment — no longer claimable or nudgeable.

## Test plan

- [x] +4 tests: merged-PR review claim released; open-PR review claim kept; candidate SQL excludes smoke fixtures; `get_active_claim` excludes them. **68/68** `test_fleet_supervisor.py` pass; ruff clean.
- [ ] CI green
- [ ] Aiden + Max dual-concur

🤖 Generated with [Claude Code](https://claude.com/claude-code)