### PR TITLE
[ORION] fix(fleet-supervisor): release review claims to 'dismissed' not 'done'

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -507,9 +507,15 @@ def release_merged_review_claims(conn: psycopg.Connection) -> int:
     A REVIEW-PR-<N> row (inserted by insert_review_task) stays status='active'
     forever once claimed — nothing transitions it when the PR merges, so the
     supervisor nudges the claimant indefinitely on a review that is already
-    done. This releases the claim (status='done') the moment its PR is no
-    longer open. Returns the count released. Fail-open: a gh failure on one
-    PR is logged and skipped, never aborts the sweep.
+    done. This releases the claim the moment its PR is no longer open.
+
+    Released to status='dismissed', NOT 'done': the require_verification_before
+    _done() Postgres trigger blocks 'done' without a task_verifications record,
+    and a review claim has none. Its own RAISE message prescribes 'dismissed'
+    for verification-less noise items — which a merged-PR review claim is.
+
+    Returns the count released. Fail-open: a gh failure on one PR is logged
+    and skipped, never aborts the sweep.
     """
     with conn.cursor() as cur:
         cur.execute(
@@ -539,7 +545,7 @@ def release_merged_review_claims(conn: psycopg.Connection) -> int:
         if state in ("MERGED", "CLOSED"):
             with conn.cursor() as cur:
                 cur.execute(
-                    "UPDATE public.tasks SET status = 'done' "
+                    "UPDATE public.tasks SET status = 'dismissed' "
                     "WHERE id = %s AND status = 'active'",
                     (task_id,),
                 )

--- a/tests/scripts/test_fleet_supervisor.py
+++ b/tests/scripts/test_fleet_supervisor.py
@@ -1002,7 +1002,10 @@ def test_release_merged_review_claims_releases_merged_pr():
         c.args[0] for c in cursor.execute.call_args_list if "UPDATE" in c.args[0].upper()
     ]
     assert update_sqls, "merged review claim must fire an UPDATE"
-    assert "done" in update_sqls[0]
+    # status='dismissed', not 'done' — the require_verification_before_done()
+    # PG trigger blocks 'done' without a task_verifications record.
+    assert "dismissed" in update_sqls[0]
+    assert "'done'" not in update_sqls[0]
     conn.commit.assert_called()
 
 


### PR DESCRIPTION
## Summary

Follow-up to #1110 (bd `Agency_OS-ln7j`). **Empirical verification caught a runtime bug #1110's mocked tests could not** — running the merged `fleet_supervisor.py` against the live DB:

```
psycopg.errors.RaiseException: BLOCKED: Task REVIEW-PR-1105 cannot be marked
done without a verification record. ... For auto-KEI noise items, use
status = 'dismissed' instead of 'done'.
```

`release_merged_review_claims` set `status='done'`. The `require_verification_before_done()` Postgres trigger blocks `'done'` on any task with no `task_verifications` row — a review claim has none — so the UPDATE raised, **aborting the whole supervisor run (exit 1)**.

## Fix

Release merged/closed review claims to **`status='dismissed'`** — the trigger's own RAISE message prescribes it for verification-less items. Test updated: asserts `"dismissed"`, asserts `"'done'"` absent. 68/68 fleet_supervisor tests pass.

## Verification (empirical, live DB)

- A direct `fleet_supervisor.py` run no longer hits the verification trigger.
- DB query: **zero `REVIEW-PR-*` rows remain `status='active'`** — the stale-nudge source is closed; `get_active_claim` (filters `status='active'`) returns nothing for review claims, so the `"you have REVIEW-PR-N claimed"` nudges stop.

## Note — separate pre-existing bug (not this PR / not #1110)

The supervisor's per-agent loop has no savepoint/rollback: one agent's `tasks_active_claim` unique-violation (`claimed_by=elliot already exists`) aborts the transaction for every agent after it. Flagged for its own bd issue.

## Test plan
- [x] 68/68 `test_fleet_supervisor.py` pass; ruff clean
- [x] Empirical: live run clears the trigger; 0 active REVIEW-PR rows
- [ ] CI green
- [ ] Aiden + Max dual-concur

🤖 Generated with [Claude Code](https://claude.com/claude-code)