### PR TITLE
[ORION] feat(fleet-supervisor): fast error-aware agent stall detector

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -10,6 +10,9 @@ Scenarios handled per agent:
     4. tmux session dead → restart service + claim
     5. Agent shipped PR + went idle → start next build task
     6. Stale claims (>2h, no verification) → release back to available
+    7. Claimed agent's pane shows a transient AI-provider error (rate-limit /
+       overloaded / API error) → resume-nudge + surface to the orchestrator,
+       FAST — no 15-min wait (Agency_OS-yerl).
 """
 
 from __future__ import annotations
@@ -92,6 +95,48 @@ def _nats_publish_state(callsign: str, state: str) -> None:
         log.debug("[%s] NATS PUBLISH %s → %s", callsign, subject, state)
     except Exception as exc:  # noqa: BLE001
         log.warning("[%s] NATS publish failed (non-fatal): %s", callsign, exc)
+
+
+def _nats_publish_stall(callsign: str, task_id: str, signature: str) -> None:
+    """Surface a detected agent stall to keiracom.elliot.inbox so the
+    orchestrator knows without a human nudge (Agency_OS-yerl).
+
+    kind='status' (not 'incident') — the elliot-nats-inbox bridge delivers it
+    to Elliot's pane, while peer_event_ceo_relay leaves 'status' silent, so a
+    routine operational stall does not reach #ceo. Fail-open.
+    """
+    try:
+        import asyncio  # noqa: PLC0415 — lazy import; nats-py optional on v1 path
+
+        import nats.aio.client as nats_client  # noqa: PLC0415 — nats-py optional
+
+        summary = (
+            f"[STALL:{callsign}] agent stalled on '{signature}' while holding "
+            f"{task_id}. Auto-resume nudge sent to its pane — verify recovery; "
+            f"restart only if it does not resume."
+        )
+        payload = json.dumps(
+            {
+                "kind": "status",
+                "from": "fleet-supervisor",
+                "summary": summary,
+                "ts": int(time.time()),
+            }
+        ).encode()
+
+        async def _publish() -> None:
+            nc = nats_client.Client()
+            await nc.connect(NATS_URL, connect_timeout=2)
+            try:
+                await nc.publish("keiracom.elliot.inbox", payload)
+                await nc.flush()
+            finally:
+                await nc.close()
+
+        asyncio.run(_publish())
+        log.info("[%s] STALL surfaced to keiracom.elliot.inbox (%s)", callsign, signature)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[%s] stall NATS publish failed (non-fatal): %s", callsign, exc)
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +265,44 @@ def context_is_full(session: str) -> bool:
     return bool(
         "context.*100%" in pane or "/clear to save" in pane or "100%" in pane and "context" in pane
     )
+
+
+# Signatures of a transient AI-provider stall in a Claude Code tmux pane
+# (Agency_OS-yerl). These are error-STATE phrasings — kept conservative so an
+# agent merely discussing rate limits in normal work is not false-flagged.
+_STALL_SIGNATURES = (
+    "rate_limit_error",
+    "overloaded_error",
+    "api_error",
+    "rate limit exceeded",
+    "exceeded your",
+    "usage limit reached",
+    "retrying in",
+    "error 429",
+    "error 529",
+    "http 429",
+    "http 529",
+    "connection error",
+    "api error:",
+)
+
+
+def detect_agent_stall(session: str) -> str | None:
+    """Return the matched stall signature if the agent's tmux pane shows a
+    transient AI-provider error (rate-limit / overloaded / API error), else
+    None.
+
+    A claimed agent stalled on such an error goes idle with no signal — the
+    orchestrator only learns of it on a human nudge. This catches it FAST (on
+    the next 5-min supervisor run), without waiting out the 15-minute generic
+    INACTIVITY_MINUTES gate. Today's incident: Aiden + Max both stalled on a
+    transient provider rate-limit mid-deliberation and nobody knew.
+    """
+    low = tmux_capture(session).lower()
+    for sig in _STALL_SIGNATURES:
+        if sig in low:
+            return sig
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -518,10 +601,7 @@ def release_merged_review_claims(conn: psycopg.Connection) -> int:
     and skipped, never aborts the sweep.
     """
     with conn.cursor() as cur:
-        cur.execute(
-            "SELECT id FROM public.tasks "
-            "WHERE status = 'active' AND id LIKE 'REVIEW-PR-%'"
-        )
+        cur.execute("SELECT id FROM public.tasks WHERE status = 'active' AND id LIKE 'REVIEW-PR-%'")
         review_ids = [r[0] for r in cur.fetchall()]
     released = 0
     for task_id in review_ids:
@@ -969,10 +1049,30 @@ def _handle_active_claim(
     claim: tuple[str, str],
     status: AgentStatus,
 ) -> AgentStatus:
-    """Scenario 3/6: agent has active claim — check activity, nudge or restart."""
+    """Scenario 3/6: agent has active claim — check activity, nudge or restart.
+
+    Scenario 7 (Agency_OS-yerl) runs FIRST: if the pane shows a transient
+    AI-provider error (rate-limit / overloaded / API error), the agent is
+    stalled even if its last tool call was recent — catch it now rather than
+    waiting out the 15-minute generic inactivity gate. A rate-limit stall is
+    recoverable by a fresh resume nudge, not a restart.
+    """
     task_id, title = claim
     status.active_task_id = task_id
     status.active_task_title = title
+
+    stall_sig = detect_agent_stall(tmux_session)
+    if stall_sig:
+        log.warning("[%s] STALL on %s — provider error signature %r", callsign, task_id, stall_sig)
+        resume = (
+            f"Your session hit a transient AI-provider error ({stall_sig}) while "
+            f"holding {task_id}. It has likely cleared — resume building. Title: {title}"
+        )
+        inject_task(tmux_session, resume)
+        _nats_publish_stall(callsign, task_id, stall_sig)
+        status.summary = f"STALL ({stall_sig}) — resume-nudged + surfaced to orchestrator"
+        return status
+
     last_call = get_last_tool_call(conn, callsign)
     status.last_tool_call = last_call
     now_utc = _dt.datetime.now(_dt.UTC)

--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -267,41 +267,59 @@ def context_is_full(session: str) -> bool:
     )
 
 
-# Signatures of a transient AI-provider stall in a Claude Code tmux pane
-# (Agency_OS-yerl). These are error-STATE phrasings — kept conservative so an
-# agent merely discussing rate limits in normal work is not false-flagged.
-_STALL_SIGNATURES = (
-    "rate_limit_error",
-    "overloaded_error",
-    "api_error",
-    "rate limit exceeded",
-    "exceeded your",
+# Claude Code renders an actual API/provider failure with one of these literal
+# banners (Agency_OS-yerl). The banner is the distinguishing signal: prose or
+# code that merely *mentions* rate limits — an agent reviewing a rate-limit PR,
+# error-handling code, pytest output containing "retrying in" — does not carry
+# Claude Code's own error rendering. Substring-matching loose phrasings anywhere
+# in the pane false-flags those working agents (PR #1112 review HOLD, Aiden).
+_STALL_BANNERS = (
+    "api error",
     "usage limit reached",
-    "retrying in",
-    "error 429",
-    "error 529",
-    "http 429",
-    "http 529",
-    "connection error",
-    "api error:",
+    "claude usage limit",
 )
+
+# A pane showing this is in the middle of a turn — Claude Code prints it only
+# while a request is running. An agent that is actively working is never a
+# stall, whatever strings are in its scrollback.
+_ACTIVE_WORK_MARKER = "esc to interrupt"
+
+# Only this many trailing non-blank lines count as the "idle tail". An error
+# banner is a stall only when it is the LAST meaningful content — not buried
+# in scrollback above ongoing work.
+_STALL_TAIL_LINES = 12
 
 
 def detect_agent_stall(session: str) -> str | None:
-    """Return the matched stall signature if the agent's tmux pane shows a
-    transient AI-provider error (rate-limit / overloaded / API error), else
-    None.
+    """Return the matched stall banner if the agent's tmux pane shows a
+    transient AI-provider error (rate-limit / overloaded / API error) as its
+    last idle-tail content, else None.
 
     A claimed agent stalled on such an error goes idle with no signal — the
     orchestrator only learns of it on a human nudge. This catches it FAST (on
     the next 5-min supervisor run), without waiting out the 15-minute generic
     INACTIVITY_MINUTES gate. Today's incident: Aiden + Max both stalled on a
     transient provider rate-limit mid-deliberation and nobody knew.
+
+    Three guards keep it false-positive-safe (PR #1112 HOLD):
+      1. an actively-working pane (turn spinner present) is never a stall;
+      2. the banner must be in the idle TAIL — the last few meaningful lines —
+         not anywhere in scrollback;
+      3. only Claude Code's own error-banner renderings count, not loose prose
+         mentioning rate limits.
     """
-    low = tmux_capture(session).lower()
-    for sig in _STALL_SIGNATURES:
-        if sig in low:
-            return sig
+    pane = tmux_capture(session)
+    low = pane.lower()
+    # Guard 1 — agent is mid-turn, not stalled.
+    if _ACTIVE_WORK_MARKER in low:
+        return None
+    # Guard 2 — only the idle tail counts.
+    tail_lines = [ln for ln in pane.splitlines() if ln.strip()][-_STALL_TAIL_LINES:]
+    tail = "\n".join(tail_lines).lower()
+    # Guard 3 — Claude Code error banner only.
+    for banner in _STALL_BANNERS:
+        if banner in tail:
+            return banner
     return None
 
 

--- a/tests/scripts/test_fleet_supervisor.py
+++ b/tests/scripts/test_fleet_supervisor.py
@@ -1044,24 +1044,26 @@ def test_get_active_claim_query_excludes_smoke_fixtures():
 
 # ---------------------------------------------------------------------------
 # Stall detection: fast error-aware detection of rate-limit/API-error stalls
-# (Agency_OS-yerl)
+# (Agency_OS-yerl). PR #1112 HOLD — must NOT false-flag working agents.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
     "pane",
     [
-        "...\nAPI Error: rate_limit_error — please slow down\n>",
-        "Overloaded_error from the provider, retrying\n",
-        "  Retrying in 12s...  ",
-        "Error 529: service overloaded",
-        "Connection error — could not reach api.anthropic.com",
+        # API Error banner as the idle-tail content, idle prompt after it.
+        "Editing src/foo.py\n... lots of prior work ...\n"
+        "API Error: 429 rate_limit_error — please slow down\n>",
+        # Anthropic overload — Claude Code renders it as an API Error banner.
+        "Running the build\nAPI Error: 529 overloaded_error\n\n> ",
+        # Claude Code usage-limit banner.
+        "deliberating PR #1100\nClaude usage limit reached. Resets at 3pm.\n> ",
     ],
 )
 def test_detect_agent_stall_matches_provider_errors(monkeypatch, pane):
     monkeypatch.setattr(fs, "tmux_capture", lambda _s: pane)
-    sig = fs.detect_agent_stall("aiden:0")
-    assert sig is not None, f"stall signature must be detected in: {pane!r}"
+    banner = fs.detect_agent_stall("aiden:0")
+    assert banner is not None, f"stall banner must be detected in: {pane!r}"
 
 
 def test_detect_agent_stall_clean_pane_returns_none(monkeypatch):
@@ -1069,6 +1071,58 @@ def test_detect_agent_stall_clean_pane_returns_none(monkeypatch):
     monkeypatch.setattr(
         fs, "tmux_capture", lambda _s: "Editing src/foo.py\nRunning pytest...\n5 passed\n>"
     )
+    assert fs.detect_agent_stall("aiden:0") is None
+
+
+# --- negative-path: working panes that CONTAIN signature strings → None -----
+# (PR #1112 HOLD, Aiden: a substring match anywhere false-flags these.)
+
+
+def test_detect_agent_stall_reviewing_rate_limit_pr_returns_none(monkeypatch):
+    """An agent reviewing PR #1112 itself — its diff contains the literal
+    error-type strings — must NOT be flagged as stalled."""
+    pane = (
+        "Reviewing PR #1112 — the stall detector.\n"
+        '_STALL_SIGNATURES = ("rate_limit_error", "overloaded_error", "api_error")\n'
+        "The detect_agent_stall helper matches rate_limit_error in the pane.\n"
+        "Looks good — posting CONCUR.\n> "
+    )
+    monkeypatch.setattr(fs, "tmux_capture", lambda _s: pane)
+    assert fs.detect_agent_stall("aiden:0") is None
+
+
+def test_detect_agent_stall_test_output_returns_none(monkeypatch):
+    """pytest output mentioning 'retrying in' / 429 is normal work, not a stall."""
+    pane = (
+        "test_retry_backoff PASSED  # retrying in 2s then 4s\n"
+        "test_http_429_handling PASSED\n"
+        "12 passed in 3.1s\n> "
+    )
+    monkeypatch.setattr(fs, "tmux_capture", lambda _s: pane)
+    assert fs.detect_agent_stall("aiden:0") is None
+
+
+def test_detect_agent_stall_active_turn_returns_none(monkeypatch):
+    """A pane mid-turn ('esc to interrupt' spinner) is working, not stalled —
+    even if an API Error banner is present in scrollback."""
+    pane = (
+        "API Error: 429 rate_limit_error\n"
+        "... agent recovered and is working again ...\n"
+        "* Crunching... (esc to interrupt)\n"
+    )
+    monkeypatch.setattr(fs, "tmux_capture", lambda _s: pane)
+    assert fs.detect_agent_stall("aiden:0") is None
+
+
+def test_detect_agent_stall_banner_in_scrollback_returns_none(monkeypatch):
+    """An error banner buried above >12 lines of subsequent work is not the
+    idle tail — the agent recovered; do not flag."""
+    pane = (
+        "API Error: 429 rate_limit_error\n"
+        + "\n".join(f"recovered line {i}" for i in range(20))
+        + "\n> "
+    )
+    monkeypatch.setattr(fs, "tmux_capture", lambda _s: pane)
     assert fs.detect_agent_stall("aiden:0") is None
 
 
@@ -1092,5 +1146,5 @@ def test_handle_active_claim_stall_resume_nudges_and_surfaces(monkeypatch):
     )
     assert injected, "a stalled agent must receive a resume nudge"
     assert "resume" in injected[0][1].lower()
-    assert surfaced == [("aiden", "KEI-9", "rate_limit_error")]
+    assert surfaced == [("aiden", "KEI-9", "api error")]
     assert "STALL" in result.summary

--- a/tests/scripts/test_fleet_supervisor.py
+++ b/tests/scripts/test_fleet_supervisor.py
@@ -1040,3 +1040,57 @@ def test_get_active_claim_query_excludes_smoke_fixtures():
     fs.get_active_claim(conn, "orion")
     sql = cursor.execute.call_args[0][0]
     assert "Agency_OS-test001" in sql and "smoke" in sql.lower()
+
+
+# ---------------------------------------------------------------------------
+# Stall detection: fast error-aware detection of rate-limit/API-error stalls
+# (Agency_OS-yerl)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pane",
+    [
+        "...\nAPI Error: rate_limit_error — please slow down\n>",
+        "Overloaded_error from the provider, retrying\n",
+        "  Retrying in 12s...  ",
+        "Error 529: service overloaded",
+        "Connection error — could not reach api.anthropic.com",
+    ],
+)
+def test_detect_agent_stall_matches_provider_errors(monkeypatch, pane):
+    monkeypatch.setattr(fs, "tmux_capture", lambda _s: pane)
+    sig = fs.detect_agent_stall("aiden:0")
+    assert sig is not None, f"stall signature must be detected in: {pane!r}"
+
+
+def test_detect_agent_stall_clean_pane_returns_none(monkeypatch):
+    """A normal working pane — no error state — is not flagged."""
+    monkeypatch.setattr(
+        fs, "tmux_capture", lambda _s: "Editing src/foo.py\nRunning pytest...\n5 passed\n>"
+    )
+    assert fs.detect_agent_stall("aiden:0") is None
+
+
+def test_handle_active_claim_stall_resume_nudges_and_surfaces(monkeypatch):
+    """A claimed agent whose pane shows a provider error → resume-nudged +
+    surfaced to the orchestrator, WITHOUT waiting the 15-min inactivity gate."""
+    injected: list = []
+    surfaced: list = []
+    monkeypatch.setattr(fs, "tmux_capture", lambda _s: "API Error: rate_limit_error\n>")
+    monkeypatch.setattr(fs, "inject_task", lambda s, t: injected.append((s, t)))
+    monkeypatch.setattr(
+        fs, "_nats_publish_stall", lambda cs, tid, sig: surfaced.append((cs, tid, sig))
+    )
+    # get_last_tool_call must NOT be reached — stall check returns first.
+    monkeypatch.setattr(
+        fs, "get_last_tool_call", lambda *_a: (_ for _ in ()).throw(AssertionError("reached"))
+    )
+    status = fs.AgentStatus("aiden", "aiden:0", "aiden-agent", summary="")
+    result = fs._handle_active_claim(
+        "aiden", "aiden:0", "aiden-agent", MagicMock(), ("KEI-9", "deliberate"), status
+    )
+    assert injected, "a stalled agent must receive a resume nudge"
+    assert "resume" in injected[0][1].lower()
+    assert surfaced == [("aiden", "KEI-9", "rate_limit_error")]
+    assert "STALL" in result.summary

--- a/tests/scripts/test_fleet_supervisor.py
+++ b/tests/scripts/test_fleet_supervisor.py
@@ -1136,10 +1136,12 @@ def test_handle_active_claim_stall_resume_nudges_and_surfaces(monkeypatch):
     monkeypatch.setattr(
         fs, "_nats_publish_stall", lambda cs, tid, sig: surfaced.append((cs, tid, sig))
     )
+
     # get_last_tool_call must NOT be reached — stall check returns first.
-    monkeypatch.setattr(
-        fs, "get_last_tool_call", lambda *_a: (_ for _ in ()).throw(AssertionError("reached"))
-    )
+    def _unreached(*_a):
+        raise AssertionError("get_last_tool_call reached — stall check must return first")
+
+    monkeypatch.setattr(fs, "get_last_tool_call", _unreached)
     status = fs.AgentStatus("aiden", "aiden:0", "aiden-agent", summary="")
     result = fs._handle_active_claim(
         "aiden", "aiden:0", "aiden-agent", MagicMock(), ("KEI-9", "deliberate"), status


### PR DESCRIPTION
## Summary

bd `Agency_OS-yerl`. Dave-flagged gap 2026-05-20: Aiden + Max both stalled on a transient AI-provider rate-limit mid-deliberation and went idle — the orchestrator had **no signal**; the stall was only found on a human nudge.

`fleet_supervisor`'s scenario-3 only nudges after `INACTIVITY_MINUTES=15min` of no `tool_call_log` activity — a rate-limit stall inside that window is invisible. This adds **scenario 7: error-aware, FAST**.

## Changes (`scripts/fleet_supervisor.py`)

- **`detect_agent_stall(session)`** — scans the agent's tmux pane for transient AI-provider error signatures (`rate_limit_error`, `overloaded_error`, `api_error`, `Retrying in`, `429`/`529`, `connection error`). Conservative — error-STATE phrasings only, so an agent merely discussing rate limits isn't false-flagged.
- **`_handle_active_claim`** runs the stall check **first**, before the 15-min gate. On a hit: injects a **resume nudge** into the pane (a rate-limit stall recovers from a fresh nudge, not a restart) and surfaces it to **`keiracom.elliot.inbox`** via `_nats_publish_stall` so the orchestrator knows without a human nudge.
- **`_nats_publish_stall`** publishes `kind='status'` — reaches Elliot's pane via the inbox bridge, stays out of #ceo (`peer_event_ceo_relay` leaves `status` silent) — a routine operational stall isn't a CEO event.

## Test plan

- [x] +7 tests: `detect_agent_stall` matches 5 provider-error pane shapes + returns `None` on a clean pane; `_handle_active_claim` stall path resume-nudges + surfaces + never reaches the 15-min gate. **75/75** `test_fleet_supervisor.py` pass; ruff clean.
- [ ] CI green
- [ ] Aiden + Max dual-concur

🤖 Generated with [Claude Code](https://claude.com/claude-code)