### PR TITLE
[ORION] fix(next_work_prompter): three-state classifier (AUTHOR/REVIEWER/INFRA) — Agency_OS-sg29

### DIFF
--- a/scripts/orchestrator/next_work_prompter.py
+++ b/scripts/orchestrator/next_work_prompter.py
@@ -233,6 +233,37 @@ def _reset_main_head_cache() -> None:
     _MAIN_HEAD_FAILURES = None
 
 
+def _fetch_main_failures_for(
+    endpoint: str, list_key: str, name_key: str, state_key: str
+) -> set[str]:
+    """Pull FAILURE context names from one GitHub API endpoint.
+
+    Structural extraction from _main_head_failures (Aiden HOLD-FINAL on PR #1113,
+    Sonar S3776 cognitive-complexity refactor). One endpoint, one try block, one
+    pass through results — keeps each function simple enough to read top-to-bottom.
+    """
+    failures: set[str] = set()
+    try:
+        cp = subprocess.run(
+            ["gh", "api", endpoint],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        if cp.returncode != 0 or not cp.stdout.strip():
+            return failures
+        data = json.loads(cp.stdout)
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        return failures
+    for item in data.get(list_key, []):
+        if (item.get(state_key) or "").lower() == "failure":
+            n = item.get(name_key)
+            if n:
+                failures.add(n)
+    return failures
+
+
 def _main_head_failures() -> set[str]:
     """Context names of currently-failing checks on origin/main HEAD.
 
@@ -248,28 +279,11 @@ def _main_head_failures() -> set[str]:
     if _MAIN_HEAD_FAILURES is not None:
         return _MAIN_HEAD_FAILURES
     failures: set[str] = set()
-    for endpoint, list_key, name_key, state_key in (
+    for args in (
         ("repos/keiracom/Agency_OS/commits/main/status", "statuses", "context", "state"),
         ("repos/keiracom/Agency_OS/commits/main/check-runs", "check_runs", "name", "conclusion"),
     ):
-        try:
-            cp = subprocess.run(
-                ["gh", "api", endpoint],
-                capture_output=True,
-                text=True,
-                timeout=15,
-                check=False,
-            )
-            if cp.returncode != 0 or not cp.stdout.strip():
-                continue
-            data = json.loads(cp.stdout)
-            for item in data.get(list_key, []):
-                if (item.get(state_key) or "").lower() == "failure":
-                    n = item.get(name_key)
-                    if n:
-                        failures.add(n)
-        except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
-            pass
+        failures |= _fetch_main_failures_for(*args)
     _MAIN_HEAD_FAILURES = failures
     return _MAIN_HEAD_FAILURES
 

--- a/scripts/orchestrator/next_work_prompter.py
+++ b/scripts/orchestrator/next_work_prompter.py
@@ -35,12 +35,12 @@ Usage:
     python3 next_work_prompter.py --callsign aiden
     python3 next_work_prompter.py --callsign elliot --dry-run
 """
+
 from __future__ import annotations
 
 import argparse
 import json
 import logging
-import os
 import re
 import subprocess
 import sys
@@ -95,7 +95,10 @@ def _pane_idle(callsign: str) -> bool:
     try:
         cp = subprocess.run(
             ["tmux", "capture-pane", "-t", target, "-p"],
-            capture_output=True, text=True, timeout=5, check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
@@ -103,9 +106,7 @@ def _pane_idle(callsign: str) -> bool:
         return False
     tail = "\n".join(cp.stdout.splitlines()[-12:]).lower()
     # Mid-turn markers — Claude Code shows these only while processing.
-    if "esc to interrupt" in tail or "tokens ·" in tail or "tokens ·" in tail:
-        return False
-    return True
+    return not ("esc to interrupt" in tail or "tokens ·" in tail)
 
 
 def _inject(callsign: str, text: str) -> bool:
@@ -116,12 +117,18 @@ def _inject(callsign: str, text: str) -> bool:
     try:
         subprocess.run(
             ["tmux", "send-keys", "-t", target, text],
-            capture_output=True, text=True, timeout=5, check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
         )
         time.sleep(0.4)
         subprocess.run(
             ["tmux", "send-keys", "-t", target, "C-m"],
-            capture_output=True, text=True, timeout=5, check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
         )
         log.info("injected -> %s: %s", target, text[:120])
         return True
@@ -134,7 +141,10 @@ def _bd_in_progress(callsign: str) -> dict | None:
     try:
         cp = subprocess.run(
             ["bd", "list", "--status=in_progress", "--json"],
-            capture_output=True, text=True, timeout=10, check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
             cwd="/home/elliotbot/clawd/Agency_OS",
         )
         if cp.returncode != 0:
@@ -154,13 +164,17 @@ def _bd_next_ready_for(callsign: str) -> dict | None:
     try:
         cp = subprocess.run(
             ["bd", "ready", "--json"],
-            capture_output=True, text=True, timeout=10, check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
             cwd="/home/elliotbot/clawd/Agency_OS",
         )
         if cp.returncode != 0:
             return None
         data = json.loads(cp.stdout) if cp.stdout.strip() else []
         items = data if isinstance(data, list) else data.get("issues", [])
+
         # Priority sort + assignee filter
         def pri(it):
             p = it.get("priority")
@@ -168,6 +182,7 @@ def _bd_next_ready_for(callsign: str) -> dict | None:
                 return p
             m = re.match(r"P?(\d+)", str(p or ""))
             return int(m.group(1)) if m else 9
+
         items.sort(key=pri)
         for it in items:
             assignee = (it.get("assignee") or "").lower()
@@ -188,15 +203,155 @@ REVIEW_VERDICT_RE = re.compile(
 def _open_prs() -> list[dict]:
     try:
         cp = subprocess.run(
-            ["gh", "pr", "list", "--state=open", "--limit=50",
-             "--json", "number,title,updatedAt,comments,author,statusCheckRollup"],
-            capture_output=True, text=True, timeout=30, check=False,
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state=open",
+                "--limit=50",
+                "--json",
+                "number,title,updatedAt,comments,author,statusCheckRollup,commits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
         )
         if cp.returncode != 0:
             return []
         return json.loads(cp.stdout) if cp.stdout.strip() else []
     except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
         return []
+
+
+_MAIN_HEAD_FAILURES: set[str] | None = None
+
+
+def _reset_main_head_cache() -> None:
+    """Test hook — clears the per-process main-HEAD failures cache."""
+    global _MAIN_HEAD_FAILURES
+    _MAIN_HEAD_FAILURES = None
+
+
+def _main_head_failures() -> set[str]:
+    """Context names of currently-failing checks on origin/main HEAD.
+
+    Combines legacy commit statuses (StatusContext — Vercel, third-party CI)
+    and modern check-runs (GH Actions). Cached for the process lifetime so
+    classification of multiple PRs in one prompter cycle reuses one snapshot.
+
+    Used by _classify_pr_block to detect INFRA-blocked PRs per Agency_OS-sg29:
+    a check that's red on the PR AND red on main HEAD is repo-wide infra, not
+    author-caused — author has nothing to do, no nudge.
+    """
+    global _MAIN_HEAD_FAILURES
+    if _MAIN_HEAD_FAILURES is not None:
+        return _MAIN_HEAD_FAILURES
+    failures: set[str] = set()
+    for endpoint, list_key, name_key, state_key in (
+        ("repos/keiracom/Agency_OS/commits/main/status", "statuses", "context", "state"),
+        ("repos/keiracom/Agency_OS/commits/main/check-runs", "check_runs", "name", "conclusion"),
+    ):
+        try:
+            cp = subprocess.run(
+                ["gh", "api", endpoint],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            if cp.returncode != 0 or not cp.stdout.strip():
+                continue
+            data = json.loads(cp.stdout)
+            for item in data.get(list_key, []):
+                if (item.get(state_key) or "").lower() == "failure":
+                    n = item.get(name_key)
+                    if n:
+                        failures.add(n)
+        except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+            pass
+    _MAIN_HEAD_FAILURES = failures
+    return _MAIN_HEAD_FAILURES
+
+
+def _pr_check_failures(pr: dict) -> set[str]:
+    """Context names of FAILURE checks on this PR's head."""
+    names: set[str] = set()
+    for chk in pr.get("statusCheckRollup", []) or []:
+        verdict = (chk.get("conclusion") or chk.get("state") or "").upper()
+        if verdict == "FAILURE":
+            n = chk.get("name") or chk.get("context")
+            if n:
+                names.add(n)
+    return names
+
+
+def _pr_latest_commit_ts(pr: dict) -> str:
+    """ISO timestamp of the PR's most recent commit (empty if unknown)."""
+    latest = ""
+    for c in pr.get("commits", []) or []:
+        commit = c.get("commit") or {}
+        committer = commit.get("committer") or {}
+        ts = committer.get("date") or c.get("committedDate") or ""
+        if ts > latest:
+            latest = ts
+    return latest
+
+
+_HOLD_BODY_RE = re.compile(r"\[review:hold|\[hold-final|changes_requested", re.IGNORECASE)
+
+
+def _latest_hold_ts(pr: dict) -> str:
+    """ISO timestamp of the most recent HOLD/CHANGES_REQUESTED comment."""
+    latest = ""
+    for c in pr.get("comments", []) or []:
+        if _HOLD_BODY_RE.search(c.get("body") or ""):
+            at = c.get("createdAt") or ""
+            if at > latest:
+                latest = at
+    return latest
+
+
+def classify_pr_block(pr: dict) -> str | None:
+    """Three-state classifier per Agency_OS-sg29.
+
+    Returns one of: 'author', 'reviewer', 'infra', or None.
+
+      - 'author':   real CI red NOT mirrored on main, OR a HOLD/CHANGES_REQUESTED
+                    comment newer than the author's latest commit. Author must act.
+      - 'infra':    every failing PR check is ALSO failing on origin/main HEAD —
+                    repo-wide infra regression, not author-caused. Author has
+                    nothing to do; orchestrator should investigate main red
+                    separately (e.g. via a [PROPOSE:investigate-main-red]).
+      - 'reviewer': CI green AND author's latest commit newer than every HOLD
+                    AND not yet dual-approved. Waiting on reviewer verdict.
+      - None:       not blocked (green + dual-approved, or no signal).
+
+    INFRA detection uses main-HEAD parity (per Aiden's note) — not check-name
+    pattern matching, which would drift as context names change.
+    """
+    pr_failures = _pr_check_failures(pr)
+    if pr_failures:
+        main_failures = _main_head_failures()
+        author_caused = pr_failures - main_failures
+        if author_caused:
+            return "author"
+        if pr_failures.issubset(main_failures):
+            return "infra"
+    latest_commit = _pr_latest_commit_ts(pr)
+    latest_hold = _latest_hold_ts(pr)
+    if latest_hold and latest_hold > latest_commit:
+        return "author"
+    state = _verdicts_on(pr)
+    author = _author_callsign(pr)
+    non_auth = [d for d in ("elliot", "aiden", "max") if d != author]
+    approves = sum(1 for d in non_auth if state.get(d) == "approve")
+    if approves >= 2:
+        return None
+    has_hold = any(v == "hold" for v in state.values())
+    if has_hold or not pr_failures:
+        return "reviewer"
+    return None
 
 
 def _verdicts_on(pr: dict) -> dict:
@@ -240,25 +395,19 @@ def _reviewer_pending(callsign: str) -> list[int]:
 
 
 def _own_prs_needing_fix(callsign: str) -> list[int]:
-    """PRs this callsign authored that carry a HOLD or CI failure.
+    """PRs this callsign authored that are AUTHOR-blocked (author must act).
 
-    Closes the gap (Dave 2026-05-20): a reviewer with an empty review queue
-    would idle even while their own authored PRs sit blocked. Everyone is
-    responsible for their own authored PRs regardless of role.
+    Per Agency_OS-sg29: REVIEWER-blocked (author already responded, waiting on
+    re-review) and INFRA-blocked (CI red on contexts also red on main HEAD,
+    not author-caused) are EXCLUDED — author has nothing to do for those,
+    so no nudge. Only AUTHOR-blocked PRs are returned for the [NEXT-WORK]
+    fix-up dispatch.
     """
     out = []
     for pr in _open_prs():
         if _author_callsign(pr) != callsign:
             continue
-        state = _verdicts_on(pr)
-        has_hold = any(v == "hold" for v in state.values())
-        # CI failure check
-        ci_fail = False
-        for chk in pr.get("statusCheckRollup", []) or []:
-            if (chk.get("conclusion") or "").upper() == "FAILURE":
-                ci_fail = True
-                break
-        if has_hold or ci_fail:
+        if classify_pr_block(pr) == "author":
             out.append(pr["number"])
     return out
 
@@ -278,9 +427,13 @@ def _orchestrator_actions(callsign: str) -> str | None:
             merge_ready.append(pr["number"])
     parts = []
     if merge_ready:
-        parts.append(f"{len(merge_ready)} PRs merge-eligible — poll and merge: {sorted(merge_ready)[:5]}{'...' if len(merge_ready) > 5 else ''}")
+        parts.append(
+            f"{len(merge_ready)} PRs merge-eligible — poll and merge: {sorted(merge_ready)[:5]}{'...' if len(merge_ready) > 5 else ''}"
+        )
     if holds:
-        parts.append(f"{len(holds)} PRs HOLD — check author fix-ups: {sorted(holds)[:5]}{'...' if len(holds) > 5 else ''}")
+        parts.append(
+            f"{len(holds)} PRs HOLD — check author fix-ups: {sorted(holds)[:5]}{'...' if len(holds) > 5 else ''}"
+        )
     return " | ".join(parts) if parts else None
 
 
@@ -328,7 +481,9 @@ def prompt_orchestrator(callsign: str) -> str | None:
     summary = _orchestrator_actions(callsign)
     if not summary:
         return None
-    return f"[NEXT-WORK:{callsign}] PR queue state — {summary}. Poll, dispatch, merge as appropriate."
+    return (
+        f"[NEXT-WORK:{callsign}] PR queue state — {summary}. Poll, dispatch, merge as appropriate."
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -336,9 +491,10 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--callsign", required=True)
     p.add_argument("--dry-run", action="store_true")
     p.add_argument(
-        "--poll-mode", action="store_true",
+        "--poll-mode",
+        action="store_true",
         help="Called from the 60s self-claim loop — require an idle pane "
-             "before injecting (don't interrupt mid-turn work).",
+        "before injecting (don't interrupt mid-turn work).",
     )
     args = p.parse_args(argv)
     cs = args.callsign.lower()

--- a/tests/orchestrator/test_next_work_prompter.py
+++ b/tests/orchestrator/test_next_work_prompter.py
@@ -1,0 +1,215 @@
+"""Tests for scripts/orchestrator/next_work_prompter.py — Agency_OS-sg29.
+
+Classifier discipline (Aiden's note on the bd issue):
+  - AUTHOR-blocked: CI red on the PR with at least one failing context NOT
+    red on origin/main HEAD, OR a HOLD comment newer than the author's
+    latest commit. Author must act → 1 nudge.
+  - REVIEWER-blocked: CI green AND author's latest commit newer than every
+    HOLD AND not yet dual-approved. Waiting on reviewer → 0 nudges to author.
+  - INFRA-blocked: every failing PR check is also failing on main HEAD →
+    repo-wide infra, not author-caused → 0 nudges to author.
+  - MIXED: PR red on context X + main green on X (even if PR red on Y +
+    main red on Y) → author owns X → 1 nudge.
+
+Negative-path discipline (feedback_negative_path_test_before_approve):
+  every fixture asserts the EXACT nudge count expected, not just "no error".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "orchestrator"))
+
+import next_work_prompter as nwp  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch):
+    nwp._reset_main_head_cache()
+    yield
+    nwp._reset_main_head_cache()
+
+
+def _pr(
+    number: int,
+    title: str = "[ORION] feat(x): thing",
+    failing_checks: list[str] | None = None,
+    commits_ts: list[str] | None = None,
+    hold_comments: list[tuple[str, str]] | None = None,
+    approvals: list[str] | None = None,
+) -> dict:
+    """Build a synthetic PR record matching gh pr list --json shape."""
+    rollup = []
+    for name in failing_checks or []:
+        rollup.append({"name": name, "conclusion": "FAILURE"})
+    commits = [{"commit": {"committer": {"date": ts}}} for ts in (commits_ts or [])]
+    comments = []
+    for body, at in hold_comments or []:
+        comments.append({"body": body, "createdAt": at})
+    for cs in approvals or []:
+        comments.append({"body": f"[CONCUR:{cs}]", "createdAt": "2099-01-01T00:00:00Z"})
+    return {
+        "number": number,
+        "title": title,
+        "statusCheckRollup": rollup,
+        "commits": commits,
+        "comments": comments,
+    }
+
+
+def _stub_main_failures(monkeypatch, failures: set[str]) -> None:
+    monkeypatch.setattr(nwp, "_main_head_failures", lambda: failures)
+
+
+def test_author_blocked_pr_red_main_green_one_nudge(monkeypatch):
+    """PR backend test red + main backend test green → author owns it → AUTHOR."""
+    pr = _pr(
+        2001,
+        failing_checks=["Backend Tests (Pytest)"],
+        commits_ts=["2026-05-23T10:00:00Z"],
+    )
+    _stub_main_failures(monkeypatch, set())  # main is green on everything
+
+    assert nwp.classify_pr_block(pr) == "author"
+
+    monkeypatch.setattr(nwp, "_open_prs", lambda: [pr])
+    assert nwp._own_prs_needing_fix("orion") == [2001]
+
+
+def test_reviewer_blocked_green_ci_author_responded_zero_nudges(monkeypatch):
+    """CI green, no HOLD newer than author's latest commit → REVIEWER."""
+    pr = _pr(
+        2002,
+        failing_checks=[],
+        commits_ts=["2026-05-23T15:00:00Z"],  # author commit AFTER any HOLD
+        hold_comments=[("[REVIEW:HOLD:aiden] please fix X", "2026-05-23T12:00:00Z")],
+    )
+    _stub_main_failures(monkeypatch, set())
+
+    assert nwp.classify_pr_block(pr) == "reviewer"
+
+    monkeypatch.setattr(nwp, "_open_prs", lambda: [pr])
+    assert nwp._own_prs_needing_fix("orion") == []
+
+
+def test_infra_blocked_pr_red_main_also_red_zero_nudges(monkeypatch):
+    """PR Vercel red + main Vercel red on same context → INFRA → no nudge.
+
+    This is exactly the PR #1112 scenario that fired the false-nudge loop.
+    """
+    pr = _pr(
+        1112,
+        title="[ORION] feat(fleet-supervisor): fast error-aware agent stall detector",
+        failing_checks=["Vercel – frontend"],
+        commits_ts=["2026-05-20T22:49:00Z"],
+    )
+    _stub_main_failures(monkeypatch, {"Vercel – frontend"})
+
+    assert nwp.classify_pr_block(pr) == "infra"
+
+    monkeypatch.setattr(nwp, "_open_prs", lambda: [pr])
+    assert nwp._own_prs_needing_fix("orion") == []
+
+
+def test_mixed_pr_red_on_author_context_main_red_on_other_one_nudge(monkeypatch):
+    """PR red on Backend Tests + Vercel; main red ONLY on Vercel.
+
+    Author owns Backend Tests failure (NOT mirrored on main). Even though
+    Vercel red mirrors main, the presence of a non-mirrored failure makes
+    the whole PR AUTHOR-blocked → 1 nudge.
+    """
+    pr = _pr(
+        2003,
+        failing_checks=["Backend Tests (Pytest)", "Vercel – frontend"],
+        commits_ts=["2026-05-23T10:00:00Z"],
+    )
+    _stub_main_failures(monkeypatch, {"Vercel – frontend"})
+
+    assert nwp.classify_pr_block(pr) == "author"
+
+    monkeypatch.setattr(nwp, "_open_prs", lambda: [pr])
+    assert nwp._own_prs_needing_fix("orion") == [2003]
+
+
+def test_author_blocked_hold_newer_than_latest_commit(monkeypatch):
+    """CI green BUT a HOLD comment is newer than author's latest commit →
+    author has not yet responded to the HOLD → AUTHOR."""
+    pr = _pr(
+        2004,
+        failing_checks=[],
+        commits_ts=["2026-05-23T10:00:00Z"],
+        hold_comments=[("[REVIEW:HOLD:aiden] please fix Z", "2026-05-23T14:00:00Z")],
+    )
+    _stub_main_failures(monkeypatch, set())
+
+    assert nwp.classify_pr_block(pr) == "author"
+
+
+def test_dual_approved_returns_none(monkeypatch):
+    """Two non-author CONCURs + green CI → merge-ready, classifier returns None."""
+    pr = _pr(
+        2005,
+        title="[ORION] feat(x): thing",
+        failing_checks=[],
+        commits_ts=["2026-05-23T10:00:00Z"],
+        approvals=["aiden", "max"],
+    )
+    _stub_main_failures(monkeypatch, set())
+
+    assert nwp.classify_pr_block(pr) is None
+
+    monkeypatch.setattr(nwp, "_open_prs", lambda: [pr])
+    assert nwp._own_prs_needing_fix("orion") == []
+
+
+def test_author_exclusion_other_callsigns_pr_ignored(monkeypatch):
+    """A PR authored by SCOUT is not in orion's fix list, even if AUTHOR-blocked."""
+    scout_pr = _pr(
+        2006,
+        title="[SCOUT] feat(y): other",
+        failing_checks=["Backend Tests (Pytest)"],
+        commits_ts=["2026-05-23T10:00:00Z"],
+    )
+    _stub_main_failures(monkeypatch, set())
+
+    monkeypatch.setattr(nwp, "_open_prs", lambda: [scout_pr])
+    assert nwp._own_prs_needing_fix("orion") == []
+    assert nwp._own_prs_needing_fix("scout") == [2006]
+
+
+def test_prompt_worker_silent_on_infra_blocked_pr(monkeypatch):
+    """End-to-end: orion has only an INFRA-blocked PR + nothing in bd ready
+    → prompt_worker returns None (silent — no nudge to inject)."""
+    pr = _pr(
+        1112,
+        title="[ORION] feat(fleet-supervisor): fast error-aware agent stall detector",
+        failing_checks=["Vercel – frontend"],
+        commits_ts=["2026-05-20T22:49:00Z"],
+    )
+    _stub_main_failures(monkeypatch, {"Vercel – frontend"})
+    monkeypatch.setattr(nwp, "_open_prs", lambda: [pr])
+    monkeypatch.setattr(nwp, "_bd_in_progress", lambda cs: None)
+    monkeypatch.setattr(nwp, "_bd_next_ready_for", lambda cs: None)
+
+    assert nwp.prompt_worker("orion") is None
+
+
+def test_prompt_worker_nudges_on_author_blocked_pr(monkeypatch):
+    """End-to-end: AUTHOR-blocked PR → prompt_worker returns a [NEXT-WORK] string."""
+    pr = _pr(
+        2007,
+        failing_checks=["Backend Tests (Pytest)"],
+        commits_ts=["2026-05-23T10:00:00Z"],
+    )
+    _stub_main_failures(monkeypatch, set())
+    monkeypatch.setattr(nwp, "_open_prs", lambda: [pr])
+
+    prompt = nwp.prompt_worker("orion")
+    assert prompt is not None
+    assert "[NEXT-WORK:orion]" in prompt
+    assert "2007" in prompt


### PR DESCRIPTION
## Summary

bd **Agency_OS-sg29** (P2) — `next_work_prompter.py` was nudging PR authors on any open PR with `has_hold OR ci_fail`, with no discrimination between:

- **AUTHOR-blocked** — real CI red or HOLD newer than latest commit (author must act).
- **REVIEWER-blocked** — author already responded, waiting on re-review (author has nothing to do).
- **INFRA-blocked** — CI red because `main` is red, not because of author commits (Aiden's noted subcase; new in this PR).

Concrete trigger this session: PR #1112 (orion fleet-supervisor, Python-only) hit the prompter loop 3 consecutive cycles because `Vercel – frontend` was FAILURE — but that same check has been FAILURE on every deploy across every branch + `main` since 2026-05-19 22:19 UTC (filed as bd `Agency_OS-9xxe`). Author had nothing to fix; prompter wouldn't stop.

## Classifier (per Aiden's CONCUR notes)

- **AUTHOR**: a failing PR check NOT mirrored on `main` HEAD, OR a HOLD/CHANGES_REQUESTED comment newer than the author's latest commit.
- **INFRA**: every failing PR check is ALSO failing on `origin/main` HEAD. INFRA detection uses **main-HEAD parity** (Aiden's explicit instruction) — not check-name pattern matching, which would drift.
- **REVIEWER**: CI green AND author's latest commit newer than every HOLD AND not yet dual-approved.
- **None**: not blocked.

`_main_head_failures()` aggregates both **StatusContext** (`commits/main/status` — Vercel, third-party CI) and **CheckRun** (`commits/main/check-runs` — GH Actions) with a per-process cache so classifying multiple PRs in one cycle reuses one snapshot.

`_own_prs_needing_fix()` now returns AUTHOR-blocked only. REVIEWER/INFRA are filtered out of the `[NEXT-WORK]` fix-up dispatch.

## Test plan (9/9, 0.13s — `tests/orchestrator/test_next_work_prompter.py`)

Aiden's four required fixtures + 5 supporting:

- [x] `test_author_blocked_pr_red_main_green_one_nudge` — PR backend red, main green → AUTHOR → 1 nudge.
- [x] `test_reviewer_blocked_green_ci_author_responded_zero_nudges` — green + author commit newer than HOLD → REVIEWER → 0.
- [x] `test_infra_blocked_pr_red_main_also_red_zero_nudges` — exact PR #1112 / Vercel scenario → INFRA → 0.
- [x] `test_mixed_pr_red_on_author_context_main_red_on_other_one_nudge` — PR red on Backend Tests + Vercel, main red ONLY on Vercel → AUTHOR → 1.
- [x] `test_author_blocked_hold_newer_than_latest_commit`
- [x] `test_dual_approved_returns_none`
- [x] `test_author_exclusion_other_callsigns_pr_ignored`
- [x] `test_prompt_worker_silent_on_infra_blocked_pr` — end-to-end silence on the live PR #1112 case.
- [x] `test_prompt_worker_nudges_on_author_blocked_pr` — end-to-end nudge on AUTHOR-blocked.

Per `feedback_negative_path_test_before_approve`: every fixture asserts the exact nudge count, not just absence-of-error.

Full orchestrator suite: 123/123 pass (no regressions).

## Verification against live state

```
$ python3 scripts/orchestrator/next_work_prompter.py --callsign orion --dry-run
[NEXT-WORK:orion] Claim REVIEW-PR-1112: …
```

False-fix-up nudge on PR #1112 is gone. (The REVIEW-PR-* suggestion is a separate role-lock issue — REVIEW-PR-* items shouldn't surface in worker `bd ready` — orthogonal per `feedback_split_orthogonal_scope`.)

## In-pass cleanups (`feedback_non_blockers_are_blockers`)

- F401: dropped unused `import os` (line 43).
- SIM103: inlined negated condition in `_pane_idle()` (line 106).
- ruff format applied.

## Reviewers

Aiden + Max for dual-concur (per Aiden's CONCUR message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)