### PR TITLE
[ATLAS] fix(cognee): Agency_OS-cuee — wire /cognify after /add + batch under MemoryHigh

### DIFF
--- a/scripts/cognee_auto_ingest.py
+++ b/scripts/cognee_auto_ingest.py
@@ -19,8 +19,14 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, "/home/elliotbot/clawd/Agency_OS/scripts")
+from cognee_http_client import cognify as cognee_cognify  # noqa: E402
 from cognee_http_client import health as cognee_health
 from cognee_http_client import ingest as cognee_ingest  # noqa: E402
+
+DEFAULT_DATASET = "governance"
+BATCH_SIZE_DEFAULT = 8
+BATCH_SETTLE_DEFAULT = 5.0  # seconds — relax cgroup memory after each cognify
+WATCH_SETTLE_DEFAULT = 1.0  # smaller settle for single-file deltas
 
 REPO_ROOT = Path("/home/elliotbot/clawd/Agency_OS")
 WORKTREE_PARENT = REPO_ROOT.parent  # /home/elliotbot/clawd
@@ -114,18 +120,38 @@ def ingest_one(path: Path) -> bool:
     return True
 
 
-def run_once() -> dict:
+def _cognify_settle(dataset: str = DEFAULT_DATASET, settle: float = BATCH_SETTLE_DEFAULT) -> None:
+    # Trigger graph rebuild for newly /added files, then sleep to let the
+    # cgroup memory pressure relax. Cognify on full 52-file delta wedges
+    # cognee.service at MemoryHigh=2700M (Agency_OS-cuee defect 2).
+    result = cognee_cognify(datasets=[dataset])
+    if isinstance(result, dict) and result.get("error"):
+        log.warning("cognify err %s: %s", dataset, result.get("error"))
+    else:
+        log.info("cognify ok %s", dataset)
+    if settle > 0:
+        time.sleep(settle)
+
+
+def run_once(batch_size: int = BATCH_SIZE_DEFAULT, settle: float = BATCH_SETTLE_DEFAULT) -> dict:
     h = cognee_health()
     if h.get("status") != "ready":
         log.error("cognee not ready: %s", h)
         return {"files": 0, "ok": 0, "errors": 1, "skipped_unhealthy": True}
     paths = targets()
-    stats = {"files": len(paths), "ok": 0, "errors": 0}
-    for p in paths:
-        if ingest_one(p):
-            stats["ok"] += 1
-        else:
-            stats["errors"] += 1
+    stats = {"files": len(paths), "ok": 0, "errors": 0, "batches": 0}
+    for i in range(0, len(paths), batch_size):
+        batch = paths[i : i + batch_size]
+        batch_ok = 0
+        for p in batch:
+            if ingest_one(p):
+                stats["ok"] += 1
+                batch_ok += 1
+            else:
+                stats["errors"] += 1
+        if batch_ok > 0:
+            _cognify_settle(settle=settle)
+            stats["batches"] += 1
     log.info("once done: %s", stats)
     return stats
 
@@ -178,7 +204,12 @@ def watch_loop() -> None:
             debounce[fpath] = now
             if ev.exists():
                 log.info("change detected: %s", fpath)
-                ingest_one(ev)
+                if ingest_one(ev):
+                    # Per Agency_OS-cuee defect 1: /add alone never rebuilds
+                    # the graph that GRAPH_COMPLETION recall reads. Single-file
+                    # cognify delta is bounded; settle prevents thundering herd
+                    # if many files change inside the 5s ingest debounce.
+                    _cognify_settle(settle=WATCH_SETTLE_DEFAULT)
         except KeyboardInterrupt:
             break
         except Exception as e:
@@ -190,9 +221,21 @@ def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--once", action="store_true")
     p.add_argument("--watch", action="store_true")
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=BATCH_SIZE_DEFAULT,
+        help="files per /add+/cognify batch in --once mode",
+    )
+    p.add_argument(
+        "--settle",
+        type=float,
+        default=BATCH_SETTLE_DEFAULT,
+        help="seconds to sleep after each /cognify call (--once)",
+    )
     args = p.parse_args()
     if args.once:
-        run_once()
+        run_once(batch_size=args.batch_size, settle=args.settle)
         return 0
     if args.watch:
         watch_loop()

--- a/scripts/cognee_http_client.py
+++ b/scripts/cognee_http_client.py
@@ -16,7 +16,10 @@ Public surface:
 Fail-open everywhere — never raises; returns empty/error dicts so hot-path
 callers don't crash the agent.
 """
+
 from __future__ import annotations
+
+import contextlib
 import json
 import os
 import time
@@ -43,17 +46,19 @@ def get_token() -> str | None:
             pass
     data = urllib.parse.urlencode({"username": LOGIN_USER, "password": LOGIN_PASS}).encode()
     req = urllib.request.Request(
-        f"{BASE}/api/v1/auth/login", data=data, method="POST",
+        f"{BASE}/api/v1/auth/login",
+        data=data,
+        method="POST",
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     try:
         raw = urllib.request.urlopen(req, timeout=5).read()
         token = json.loads(raw).get("access_token")
         if token:
-            try:
-                TOKEN_CACHE.write_text(json.dumps({"token": token, "expires_at": time.time() + TOKEN_TTL_SECONDS}))
-            except OSError:
-                pass
+            with contextlib.suppress(OSError):
+                TOKEN_CACHE.write_text(
+                    json.dumps({"token": token, "expires_at": time.time() + TOKEN_TTL_SECONDS})
+                )
             return token
     except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError):
         pass
@@ -75,16 +80,29 @@ def _authed_post(path: str, body: dict, timeout: int = 30) -> dict | list | None
         return json.loads(raw)
     except urllib.error.HTTPError as e:
         return {"error": f"HTTP_{e.code}", "body": e.read().decode()[:300]}
-    except (urllib.error.URLError, json.JSONDecodeError) as e:
-        return {"error": str(e)[:200]}
+    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError) as e:
+        # TimeoutError fires when urlopen's read() exceeds `timeout` mid-stream
+        # (urllib does not wrap socket timeouts in URLError for read-timeouts).
+        # /cognify can run minutes — without this branch the caller crashes.
+        return {"error": str(e)[:200] or type(e).__name__}
 
 
 def search(query: str, top_k: int = 5, search_type: str = "GRAPH_COMPLETION"):
-    return _authed_post("/api/v1/search", {"query": query, "top_k": top_k, "search_type": search_type})
+    return _authed_post(
+        "/api/v1/search", {"query": query, "top_k": top_k, "search_type": search_type}
+    )
 
 
 def recall(query: str, top_k: int = 5):
     return _authed_post("/api/v1/recall", {"query": query, "top_k": top_k})
+
+
+def cognify(datasets: list[str] | None = None, timeout: int = 600):
+    # Per Agency_OS-cuee: /add stores raw content; only /cognify rebuilds the
+    # knowledge graph that GRAPH_COMPLETION recall reads. /cognify processes
+    # only un-cognified pending data, so per-batch delta cost is bounded.
+    body = {"datasets": datasets} if datasets else {}
+    return _authed_post("/api/v1/cognify", body, timeout=timeout)
 
 
 def health() -> dict:
@@ -103,17 +121,22 @@ def ingest(text: str, source_path: str = "", dataset_name: str = "governance"):
     boundary = f"----cognee_ingest_{uuid.uuid4().hex[:16]}"
     filename = source_path.replace("/", "_") if source_path else f"chunk_{uuid.uuid4().hex[:8]}.txt"
     parts: list[bytes] = []
+
     def add_field(name: str, value: str) -> None:
         parts.append(f"--{boundary}\r\n".encode())
         parts.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode())
         parts.append(value.encode())
         parts.append(b"\r\n")
+
     def add_file(name: str, fname: str, content: bytes, ctype: str = "text/markdown") -> None:
         parts.append(f"--{boundary}\r\n".encode())
-        parts.append(f'Content-Disposition: form-data; name="{name}"; filename="{fname}"\r\n'.encode())
-        parts.append(f'Content-Type: {ctype}\r\n\r\n'.encode())
+        parts.append(
+            f'Content-Disposition: form-data; name="{name}"; filename="{fname}"\r\n'.encode()
+        )
+        parts.append(f"Content-Type: {ctype}\r\n\r\n".encode())
         parts.append(content)
         parts.append(b"\r\n")
+
     add_file("data", filename, text.encode("utf-8"))
     add_field("datasetName", dataset_name)
     parts.append(f"--{boundary}--\r\n".encode())
@@ -141,6 +164,7 @@ def ingest(text: str, source_path: str = "", dataset_name: str = "governance"):
 
 if __name__ == "__main__":
     import sys
+
     if len(sys.argv) > 1 and sys.argv[1] == "test":
         print("health:", health())
         print("token:", "ok" if get_token() else "FAIL")

--- a/tests/scripts/test_cognee_auto_ingest.py
+++ b/tests/scripts/test_cognee_auto_ingest.py
@@ -68,7 +68,8 @@ def test_files_in_uses_the_shared_root_core_constant(mod):
 
 def test_run_once_batches_to_groups_of_n(mod, monkeypatch):
     """52-file set → exactly 7 cognify calls (6×8 + 1×4); each batch sized ≤8."""
-    paths = [Path(f"/tmp/dummy_{i}.md") for i in range(52)]
+    # Pure-string Paths — never read or written; ingest_one is patched.
+    paths = [Path(f"dummy_{i}.md") for i in range(52)]
     monkeypatch.setattr(mod, "targets", lambda: paths)
     monkeypatch.setattr(mod, "cognee_health", lambda: {"status": "ready"})
     monkeypatch.setattr(mod, "ingest_one", lambda p: True)
@@ -85,7 +86,7 @@ def test_run_once_batches_to_groups_of_n(mod, monkeypatch):
 
 def test_run_once_partial_batch_failure_still_cognifies(mod, monkeypatch):
     """batch_ok > 0 must still trigger cognify even when half the batch failed."""
-    paths = [Path(f"/tmp/dummy_{i}.md") for i in range(8)]
+    paths = [Path(f"dummy_{i}.md") for i in range(8)]
     monkeypatch.setattr(mod, "targets", lambda: paths)
     monkeypatch.setattr(mod, "cognee_health", lambda: {"status": "ready"})
     calls = iter([False, False, False, False, True, True, True, True])
@@ -102,7 +103,7 @@ def test_run_once_partial_batch_failure_still_cognifies(mod, monkeypatch):
 
 def test_run_once_all_batch_fails_skips_cognify(mod, monkeypatch):
     """batch_ok == 0 must NOT trigger cognify — avoids cognify-on-empty-delta noise."""
-    paths = [Path(f"/tmp/dummy_{i}.md") for i in range(8)]
+    paths = [Path(f"dummy_{i}.md") for i in range(8)]
     monkeypatch.setattr(mod, "targets", lambda: paths)
     monkeypatch.setattr(mod, "cognee_health", lambda: {"status": "ready"})
     monkeypatch.setattr(mod, "ingest_one", lambda p: False)
@@ -128,8 +129,10 @@ def test_cognify_default_datasets_posts_empty_body(http, monkeypatch):
         lambda p, b, timeout=30: captured.append((p, b, timeout)) or {"ok": True},
     )
     http.cognify()
-    assert captured[0][0] == "/api/v1/cognify"
-    assert captured[0][1] == {}
+    assert len(captured) == 1, "cognify() must POST exactly once"
+    path, body, _ = captured[0]
+    assert path == "/api/v1/cognify"
+    assert body == {}
 
 
 def test_cognify_with_datasets_posts_list(http, monkeypatch):
@@ -141,7 +144,9 @@ def test_cognify_with_datasets_posts_list(http, monkeypatch):
         lambda p, b, timeout=30: captured.append((p, b, timeout)) or {"ok": True},
     )
     http.cognify(datasets=["governance"])
-    assert captured[0][1] == {"datasets": ["governance"]}
+    assert len(captured) == 1, "cognify(datasets) must POST exactly once"
+    _, body, _ = captured[0]
+    assert body == {"datasets": ["governance"]}
 
 
 def test_watch_loop_calls_cognify_after_successful_ingest(mod):

--- a/tests/scripts/test_cognee_auto_ingest.py
+++ b/tests/scripts/test_cognee_auto_ingest.py
@@ -1,13 +1,17 @@
-"""tests for scripts/cognee_auto_ingest.py — Agency_OS-zbvs watch-set fix.
+"""tests for scripts/cognee_auto_ingest.py + cognee_http_client.py.
 
-Regression lock: the --watch set must cover the same root-level core-truth
-docs as the --once set. Before the fix watch_loop watched only sub-dirs, so
-ARCHITECTURE.md edits never propagated to Cognee after the watcher started.
+Two scopes locked here:
+- Agency_OS-zbvs (watch-set parity): the --watch set must cover the same
+  root-level core-truth docs as the --once set (original anchor 2026-05-20).
+- Agency_OS-cuee (cognify wiring + batched cognify): every successful /add
+  must trigger /cognify, batched to bounded delta so cognee.service stays
+  under MemoryHigh=2700M; /cognify TimeoutError must NOT crash callers.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import sys
 from pathlib import Path
 
@@ -15,16 +19,31 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "cognee_auto_ingest.py"
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
+HTTP_SCRIPT = REPO_ROOT / "scripts" / "cognee_http_client.py"
 
 
-@pytest.fixture(scope="module")
-def mod():
-    spec = importlib.util.spec_from_file_location("cognee_auto_ingest", SCRIPT)
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
     m = importlib.util.module_from_spec(spec)
-    sys.modules["cognee_auto_ingest"] = m
+    sys.modules[name] = m
     spec.loader.exec_module(m)
     return m
+
+
+@pytest.fixture
+def http():
+    # Force-load THIS worktree's cognee_http_client so it carries the cognify()
+    # symbol the PR adds. cognee_auto_ingest hard-codes sys.path to the main
+    # worktree's scripts dir; pre-seeding sys.modules makes tests worktree-agnostic.
+    return _load("cognee_http_client", HTTP_SCRIPT)
+
+
+@pytest.fixture
+def mod(http):
+    return _load("cognee_auto_ingest", SCRIPT)
+
+
+# ------------- Agency_OS-zbvs (existing locks, retained) -------------
 
 
 def test_root_core_files_includes_architecture(mod):
@@ -42,3 +61,134 @@ def test_files_in_uses_the_shared_root_core_constant(mod):
     names = {p.name for p in files}
     for core in mod._ROOT_CORE_FILES:
         assert core in names, f"{core} missing from _files_in — watch/once drift risk"
+
+
+# ------------- Agency_OS-cuee Defect 2 (batched cognify) -------------
+
+
+def test_run_once_batches_to_groups_of_n(mod, monkeypatch):
+    """52-file set → exactly 7 cognify calls (6×8 + 1×4); each batch sized ≤8."""
+    paths = [Path(f"/tmp/dummy_{i}.md") for i in range(52)]
+    monkeypatch.setattr(mod, "targets", lambda: paths)
+    monkeypatch.setattr(mod, "cognee_health", lambda: {"status": "ready"})
+    monkeypatch.setattr(mod, "ingest_one", lambda p: True)
+    settle_calls: list[dict] = []
+    monkeypatch.setattr(mod, "_cognify_settle", lambda **kw: settle_calls.append(kw))
+
+    stats = mod.run_once()
+    assert stats["files"] == 52
+    assert stats["ok"] == 52
+    assert stats["errors"] == 0
+    assert stats["batches"] == 7
+    assert len(settle_calls) == 7
+
+
+def test_run_once_partial_batch_failure_still_cognifies(mod, monkeypatch):
+    """batch_ok > 0 must still trigger cognify even when half the batch failed."""
+    paths = [Path(f"/tmp/dummy_{i}.md") for i in range(8)]
+    monkeypatch.setattr(mod, "targets", lambda: paths)
+    monkeypatch.setattr(mod, "cognee_health", lambda: {"status": "ready"})
+    calls = iter([False, False, False, False, True, True, True, True])
+    monkeypatch.setattr(mod, "ingest_one", lambda p: next(calls))
+    settle_calls: list[dict] = []
+    monkeypatch.setattr(mod, "_cognify_settle", lambda **kw: settle_calls.append(kw))
+
+    stats = mod.run_once()
+    assert stats["ok"] == 4
+    assert stats["errors"] == 4
+    assert stats["batches"] == 1
+    assert len(settle_calls) == 1
+
+
+def test_run_once_all_batch_fails_skips_cognify(mod, monkeypatch):
+    """batch_ok == 0 must NOT trigger cognify — avoids cognify-on-empty-delta noise."""
+    paths = [Path(f"/tmp/dummy_{i}.md") for i in range(8)]
+    monkeypatch.setattr(mod, "targets", lambda: paths)
+    monkeypatch.setattr(mod, "cognee_health", lambda: {"status": "ready"})
+    monkeypatch.setattr(mod, "ingest_one", lambda p: False)
+    settle_calls: list[dict] = []
+    monkeypatch.setattr(mod, "_cognify_settle", lambda **kw: settle_calls.append(kw))
+
+    stats = mod.run_once()
+    assert stats["ok"] == 0
+    assert stats["errors"] == 8
+    assert stats["batches"] == 0
+    assert settle_calls == []
+
+
+# ------------- Agency_OS-cuee Defect 1 (cognify wiring) -------------
+
+
+def test_cognify_default_datasets_posts_empty_body(http, monkeypatch):
+    """cognify() with no dataset arg → empty body (lets Cognee process all pending)."""
+    captured: list[tuple] = []
+    monkeypatch.setattr(
+        http,
+        "_authed_post",
+        lambda p, b, timeout=30: captured.append((p, b, timeout)) or {"ok": True},
+    )
+    http.cognify()
+    assert captured[0][0] == "/api/v1/cognify"
+    assert captured[0][1] == {}
+
+
+def test_cognify_with_datasets_posts_list(http, monkeypatch):
+    """cognify(datasets=[...]) → POST body {'datasets': [...]} per CognifyPayloadDTO."""
+    captured: list[tuple] = []
+    monkeypatch.setattr(
+        http,
+        "_authed_post",
+        lambda p, b, timeout=30: captured.append((p, b, timeout)) or {"ok": True},
+    )
+    http.cognify(datasets=["governance"])
+    assert captured[0][1] == {"datasets": ["governance"]}
+
+
+def test_watch_loop_calls_cognify_after_successful_ingest(mod):
+    """Defect 1 regression — watch_loop's post-ingest path must call
+    _cognify_settle, gated on ingest_one returning True (not unconditional).
+
+    Structural lock: inotify-driven integration test would need subprocess +
+    filesystem mocks (~30 LoC), which is high-fragility for a wiring check.
+    Source inspection catches the same regressions (call removed, call before
+    ingest, wrong settle constant) with no flake surface.
+    """
+    source = inspect.getsource(mod.watch_loop)
+    assert "if ingest_one(ev):" in source, "ingest_one return value must gate cognify"
+    assert "_cognify_settle(settle=WATCH_SETTLE_DEFAULT" in source, (
+        "watch-mode cognify must use WATCH_SETTLE_DEFAULT (1s), not BATCH_SETTLE_DEFAULT (5s)"
+    )
+    ingest_pos = source.find("if ingest_one(ev):")
+    cognify_pos = source.find("_cognify_settle(settle=WATCH_SETTLE_DEFAULT")
+    assert ingest_pos < cognify_pos, "cognify must be inside the ingest_one success branch"
+
+
+# ------------- Agency_OS-cuee same-PR timeout fix -------------
+
+
+def test_authed_post_timeout_returns_error_dict(http, monkeypatch):
+    """TimeoutError on long /cognify must NOT crash — urllib does not wrap
+    socket read-timeouts in URLError, so they fall through the URLError except.
+    Regression-lock from empirical smoke catch (see PR #1114 description)."""
+    monkeypatch.setattr(http, "get_token", lambda: "fake-token")
+
+    def _raise_timeout(*args, **kwargs):
+        raise TimeoutError("read timeout")
+
+    monkeypatch.setattr(http.urllib.request, "urlopen", _raise_timeout)
+    result = http._authed_post("/api/v1/cognify", {"datasets": ["x"]}, timeout=1)
+    assert isinstance(result, dict)
+    assert result.get("error") == "read timeout"
+
+
+def test_authed_post_bare_timeout_falls_back_to_class_name(http, monkeypatch):
+    """Empty-message TimeoutError must fall back to type name via
+    `str(e)[:200] or type(e).__name__`, so the caller never gets an empty error."""
+    monkeypatch.setattr(http, "get_token", lambda: "fake-token")
+
+    def _raise_bare_timeout(*args, **kwargs):
+        raise TimeoutError()
+
+    monkeypatch.setattr(http.urllib.request, "urlopen", _raise_bare_timeout)
+    result = http._authed_post("/api/v1/cognify", {}, timeout=1)
+    assert result.get("error") == "TimeoutError"


### PR DESCRIPTION
## Summary
- Fixes `Agency_OS-cuee` — two linked defects in `scripts/cognee_auto_ingest.py` found 2026-05-20.
- **Defect 1:** `ingest()` only POSTed `/api/v1/add`. `/add` stores raw content; only `/cognify` rebuilds the knowledge graph that `GRAPH_COMPLETION` recall reads. `--once` and `--watch` both affected — recall drift could never clear.
- **Defect 2:** Manual `/cognify` on full 52-file governance dataset pushed `cognee.service` cgroup to MemoryCurrent=2703M vs MemoryHigh=2700M (100.1%); kernel throttle wedged the service ~45 min.

## Fix
- **`cognee_http_client.py`** — new `cognify(datasets, timeout=600)` wrapping `POST /api/v1/cognify` (`CognifyPayloadDTO` confirmed against live OpenAPI).
- **`cognee_auto_ingest.py`** — `run_once()` batches in groups of 8 (CLI `--batch-size`), each batch `/add`ed then `/cognify`d then sleeps 5s (CLI `--settle`). 52 files → 7 batches (6×8 + 1×4), peak delta bounded.
- **`watch_loop()`** — calls cognify after each successful single-file ingest with 1s settle to absorb burst changes inside the existing 5s ingest debounce.

## Same-file opportunistic cleans (per `feedback_non_blockers_are_blockers`)
Pre-existing in origin/main, fixed in same file scope:
- `I001` import sort + new `contextlib` import.
- `SIM105` `try/except/pass` → `contextlib.suppress(OSError)` in `get_token()`.

## Critical gap surfaced by smoke (per `feedback_empirical_test_catches_paper_concur_misses`)
- `_authed_post()` did not catch `TimeoutError` on long-running calls. urllib does not wrap socket read-timeouts in `URLError`. `/cognify` can run minutes — without this branch callers crash. Added `TimeoutError` to the except clause.

## Verification
- `ruff check` + `ruff format --check`: clean on both files.
- Wiring smoke: `cognee_auto_ingest.cognee_cognify is cognee_http_client.cognify` ✓
- `targets()` returns 52 → batches `[(1,8),(2,8),(3,8),(4,8),(5,8),(6,8),(7,4)]` ✓
- `/api/v1/cognify` request body confirmed via live OpenAPI (`CognifyPayloadDTO` accepts `{"datasets": ["governance"]}`).
- Negative path: bad URL + read-timeout → graceful `{'error': 'timed out'}` (not unhandled exception).
- **End-to-end blocked:** `cognee.service` is in degraded state (Kuzu WAL corruption, `UNREACHABLE_CODE wal_record.cpp:76` → `/health 503`). Same 2026-05-20 incident, never recovered. Escalated separately to elliot — cuee code-fix is contract-correct and ships independently of WAL recovery.

## Test plan
- [ ] Reviewer: `ruff check scripts/cognee_auto_ingest.py scripts/cognee_http_client.py`
- [ ] Reviewer: import smoke via `PYTHONPATH=$(pwd)/scripts python3 -c "from cognee_http_client import cognify; assert callable(cognify)"`
- [ ] Post-WAL-recovery: full `--once` run; confirm cognee.service `MemoryCurrent` stays under MemoryHigh=2700M across all 7 batches; confirm `GRAPH_COMPLETION` recall returns recently-added content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)