### PR TITLE
[ORION] fix(supervisor-wake): lazy-import nats — unblock main CI (PR #1116 cascade)

### DIFF
--- a/scripts/orchestrator/supervisor_wake_publish.py
+++ b/scripts/orchestrator/supervisor_wake_publish.py
@@ -39,7 +39,13 @@ import os
 import sys
 import time
 
-import nats
+# nats-py is lazy-imported inside publish_wake() so this module remains
+# collectable on CI hosts where nats-py is not in the test venv. CI
+# regression caught 2026-05-24: top-level `import nats` made the test
+# file uncollectable (test imports this module → ImportError cascades →
+# pytest collection error → 3 consecutive main CI failures + PR #1116
+# inherit-blocked). Fix per Elliot dispatch: lazy-import only on the
+# live-publish path.
 
 DEFAULT_NATS_URL = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
 DEFAULT_SUBJECT = os.environ.get("SUPERVISOR_WAKE_SUBJECT", "keiracom.elliot.inbox")
@@ -66,6 +72,11 @@ def build_envelope(now: float | None = None) -> dict:
 
 async def publish_wake(nats_url: str, subject: str) -> int:
     """Publish one envelope to NATS. Returns 0 on success, 1 on failure."""
+    try:
+        import nats  # lazy — keeps module collectable on hosts without nats-py
+    except ImportError as exc:
+        log.error("supervisor_wake: nats-py not installed; publish skipped (%s)", exc)
+        return 1
     envelope = build_envelope()
     payload = json.dumps(envelope).encode("utf-8")
     try:


### PR DESCRIPTION
## Summary

Main CI failed 3 consecutive runs since commit `8e5e9c7cc`. pytest collection errored on `tests/orchestrator/test_supervisor_wake_publish.py` because the test file's `import supervisor_wake_publish` triggered an ImportError chain from the script's top-level `import nats` (nats-py not in the CI venv). PR #1116 inheriting main was blocked.

**Fix (per Elliot dispatch 2026-05-24):** lazy-import `nats` inside `publish_wake()` so module-level collection succeeds without nats-py, while live publishing still works in environments that do have nats-py installed.

## Behaviour preserved

- **With nats-py**: `publish_wake()` returns `0` on success, `1` on connect/publish error.
- **Without nats-py**: `publish_wake()` returns `1` with `"nats-py not installed"` log line (same exit code as connect failure — systemd timer catches the next 5min cycle either way).
- **Module collection**: succeeds in both cases.
- **`build_envelope()`**: pure function, no nats dependency, works in both cases.

## Verification — both venv states

### WITH nats-py installed (current dev env)

```
$ python3 -m pytest tests/orchestrator/test_supervisor_wake_publish.py -v
...
test_build_envelope_has_required_fields PASSED                            [ 14%]
test_build_envelope_uses_provided_timestamp PASSED                        [ 28%]
test_envelope_required_fields_set_matches_dispatch_contract PASSED        [ 42%]
test_default_subject_is_canonical_elliot_inbox PASSED                     [ 57%]
test_dry_run_prints_json_and_exits_zero PASSED                            [ 71%]
test_publish_wake_emits_envelope_to_subject PASSED                        [ 85%]
test_publish_wake_returns_1_on_bad_url PASSED                             [100%]
======================== 7 passed in 120.46s (0:02:00) =========================
```

### WITHOUT nats-py (`sys.modules['nats']=None` shadow — Python 3.12 idiom for simulating missing dependency without uninstalling)

```
$ python3 -c "
import sys
sys.modules['nats'] = None
sys.path.insert(0, 'scripts/orchestrator')
import supervisor_wake_publish as swp
print('OK: module collected without nats-py')
print('  build_envelope ts type:', type(swp.build_envelope()['ts']).__name__)
import asyncio
rc = asyncio.run(swp.publish_wake('nats://localhost:1', 'keiracom.test'))
print('  publish_wake rc =', rc, '(expected 1: lazy-import ImportError → graceful exit 1)')
assert rc == 1
print('  ✓ lazy-import contract verified')
"

2026-05-24 15:32:37,306 ERROR supervisor_wake: nats-py not installed; publish skipped (import of nats halted; None in sys.modules)
OK: module collected without nats-py
  build_envelope ts type: float
  publish_wake rc = 1 (expected 1: lazy-import ImportError → graceful exit 1)
  ✓ lazy-import contract verified
```

### Test collection without nats-py

```
$ python3 -c "
import sys
sys.modules['nats'] = None
sys.path.insert(0, 'scripts/orchestrator')
sys.path.insert(0, 'tests/orchestrator')
import test_supervisor_wake_publish as t
print('OK: test module collected without nats-py')
tests = [n for n in dir(t) if n.startswith('test_')]
print(f'  {len(tests)} test functions visible to pytest collection')
for name in tests:
    print(f'    - {name}')
"

OK: test module collected without nats-py
  7 test functions visible to pytest collection
    - test_build_envelope_has_required_fields
    - test_build_envelope_uses_provided_timestamp
    - test_default_subject_is_canonical_elliot_inbox
    - test_dry_run_prints_json_and_exits_zero
    - test_envelope_required_fields_set_matches_dispatch_contract
    - test_publish_wake_emits_envelope_to_subject
    - test_publish_wake_returns_1_on_bad_url
```

### Lint

```
$ ruff check scripts/orchestrator/supervisor_wake_publish.py
All checks passed!
$ ruff format --check scripts/orchestrator/supervisor_wake_publish.py
1 file already formatted
```

## Test plan
- [x] WITH nats-py: 7/7 pytest pass (incl. live NATS publish round-trip)
- [x] WITHOUT nats-py: module + test collection both succeed
- [x] WITHOUT nats-py: `publish_wake()` returns 1 (graceful, no raise)
- [x] ruff check + format clean
- [ ] Aiden architecture-lens concur
- [ ] Max code-quality-lens concur
- [ ] Elliot admin-merge per the orchestrator-merge-after-NATS-concur pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)