### PR TITLE
[ORION] feat(phase-1.2.5): product-repo test allowlist + enforcer + classification doc

### DIFF
--- a/config/product_repo_test_allowlist.txt
+++ b/config/product_repo_test_allowlist.txt
@@ -1,0 +1,94 @@
+# Product Repo CI Test Allowlist — Agency_OS Phase 1.2.5 bundle artefact 7
+#
+# Authored 2026-05-24 per Elliot dispatch (Phase 1.2.5 artefact, Dave-ratified
+# separation directive AGENCY-OS-KEIRACOM-SEPARATION-V1).
+#
+# WHAT THIS IS:
+# Enumerated list of test paths that survive into the PRODUCT REPO CI matrix.
+# The product repo's CI runs ONLY tests whose path matches an entry here.
+# Any test file in tests/** not matched by this allowlist either (a) stays in
+# the fleet repo, or (b) goes to the archive repo with the dead BDR product.
+#
+# WHY STRIPPED:
+# Per ceo:agency_os_keiracom_separation_v1 sign-off item 2:
+#   "Stripped product-only matrix until first paying customer, with 3
+#    non-negotiable tests (tenant onboarding, MCP wrong-project-id rejection,
+#    namespace boundary negative-paths)."
+# Discipline: keep the matrix small enough that every test is currently green
+# and load-bearing for the V1.0 product surface. New product tests added as
+# product code lands; nothing carried over implicitly.
+#
+# FORMAT:
+#   - One path per line (relative to repo root).
+#   - Glob patterns supported: tests/dispatcher/*.py matches any direct child.
+#   - Recursive globs NOT supported (** disallowed) — keep enumeration explicit.
+#   - Blank lines + lines starting with # are ignored.
+#   - Trailing whitespace trimmed.
+#
+# ENFORCEMENT:
+# scripts/ci/check_product_test_allowlist.py walks tests/** and fails CI if
+# any *.py file is not matched. Run locally before push:
+#   python3 scripts/ci/check_product_test_allowlist.py
+# CI invocation: .github/workflows/product-repo-test-matrix.yml (snippet in
+# docs/migration/test_path_classification.md §6).
+
+# ─────────────────────────────────────────────────────────────────────────────
+# tests/dispatcher/ — V1.0 MCP dispatcher (primary product code)
+#   Auth, container lifecycle, JWT, monitor, reaper, session manager, spend
+#   tracker, Valkey pool, watchdog. All file-by-file enumerated below for
+#   visibility — when a new dispatcher test lands, add the path explicitly.
+# ─────────────────────────────────────────────────────────────────────────────
+tests/dispatcher/test_auth_minter.py
+tests/dispatcher/test_container_jwt.py
+tests/dispatcher/test_container_monitor.py
+tests/dispatcher/test_dispatcher_service_install.py
+tests/dispatcher/test_governance_proxy.py
+tests/dispatcher/test_heartbeat_reaper.py
+tests/dispatcher/test_heartbeat_watchdog.py
+tests/dispatcher/test_interceptor_proxy.py
+tests/dispatcher/test_jwt_hash_rotation.py
+tests/dispatcher/test_main_wiring.py
+tests/dispatcher/test_reaper.py
+tests/dispatcher/test_session_manager.py
+tests/dispatcher/test_spend_tracker.py
+tests/dispatcher/test_tmux_lifecycle.py
+tests/dispatcher/test_valkey_pool.py
+tests/dispatcher/test_watchdog.py
+
+# ─────────────────────────────────────────────────────────────────────────────
+# tests/memory/ — V1.0 Memory Abstraction Layer (primary product code)
+# ─────────────────────────────────────────────────────────────────────────────
+tests/memory/test_environment_hash.py
+tests/memory/test_memory.py
+tests/memory/test_sanitise.py
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Non-negotiable #1 — TENANT ONBOARDING
+# Per ceo:agency_os_keiracom_separation_v1 sign-off item 2.
+# ─────────────────────────────────────────────────────────────────────────────
+tests/test_services/test_onboarding_pipeline.py
+tests/test_flows/test_post_onboarding_flow.py
+tests/scripts/test_seed_demo_tenant.py
+tests/unit/test_set_tenant_session.py
+tests/live/test_onboarding_live.py
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Non-negotiable #3 — NAMESPACE BOUNDARY NEGATIVE-PATHS
+# Per ceo:agency_os_keiracom_separation_v1 sign-off item 2.
+# Note: ceo_memory + tenant-isolation tests cross the namespace boundary.
+# ─────────────────────────────────────────────────────────────────────────────
+tests/governance/test_ceo_memory_context_constraint.py
+tests/governance/test_ceo_memory_writer.py
+tests/integration/test_tenant_isolation.py
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Non-negotiable #2 — MCP WRONG-PROJECT-ID REJECTION
+# Per ceo:agency_os_keiracom_separation_v1 sign-off item 2.
+# TBD — test file not yet written. When the MCP project-id guard ships, the
+# test path expected is tests/dispatcher/test_mcp_project_id_rejection.py
+# (or similar). Add the path here in the same PR as the test file lands.
+# Until then this is a SHIPPING GATE: the product repo CI MUST fail to merge
+# any release-marked PR if this test does not exist.
+# Tracked: bd Agency_OS-TBD (file post-allowlist-merge).
+# ─────────────────────────────────────────────────────────────────────────────
+# tests/dispatcher/test_mcp_project_id_rejection.py    (NOT YET WRITTEN — placeholder)

--- a/docs/migration/test_path_classification.md
+++ b/docs/migration/test_path_classification.md
@@ -1,0 +1,188 @@
+# Test Path Classification — Phase 1.2.5 bundle artefact 7
+
+**Authored:** 2026-05-24 (orion, per Elliot dispatch)
+**Status:** RATIFIED-PENDING (Aiden architecture + Max quality dual-concur on PR)
+**Anchor:** `ceo:agency_os_keiracom_separation_v1` sign-off item 2
+
+## 1. Why this exists
+
+The Dave-ratified separation directive (`AGENCY-OS-KEIRACOM-SEPARATION-V1`, 2026-05-24) carves three repos out of the current Agency_OS monorepo:
+
+  - **Fleet repo** (working name `keiracom-fleet`) — internal agent fleet configs, NOT customer-facing.
+  - **Product repo** (TBD name, rename-ready) — V1.0 AI workforce code shipped to customers (Memory Abstraction Layer, MCP dispatcher, Go sidecar, tenant onboarding, install script, CLI).
+  - **Archive repo** (existing URL preserved) — 1100 prior PRs + dead BDR product (Agency OS / Siege Waterfall pipeline). Marked inactive in README.
+
+Sign-off item 2 of the separation directive specifies:
+
+> "Stripped product-only matrix until first paying customer, with 3 non-negotiable tests (tenant onboarding, MCP wrong-project-id rejection, namespace boundary negative-paths). Concrete enumerated allow-list of test paths as Phase 1.2.5 artefact (Elliot refinement)."
+
+This document is the artefact. It enumerates which test paths survive into the product repo CI matrix, why, and how the cutover sequences.
+
+## 2. Three buckets
+
+Every `tests/**/*.py` file lands in exactly one of:
+
+| Bucket | Repo | CI participation | Rationale |
+|---|---|---|---|
+| **PRODUCT** | product repo | Yes — stripped matrix | Tests covering V1.0 customer-facing surface (MCP dispatcher, Memory Abstraction Layer, tenant onboarding, namespace boundaries). |
+| **FLEET** | fleet repo | Yes — fleet matrix | Tests covering internal orchestrator plumbing, clone bring-up, governance enforcement, alerts, hooks. Not customer-facing. |
+| **ARCHIVE** | archive repo | No — frozen (archive repo CI disabled) | Tests for retired Agency OS BDR product (Siege Waterfall enrichment pipeline, vendor integrations, outreach engines, score models). Preserved for historical reference + audit, never run. |
+
+## 3. Classification rules
+
+Source-of-truth: `config/product_repo_test_allowlist.txt`. Anything not matched by an allowlist entry is fleet OR archive (decided at cutover by 3-repo migration manifest).
+
+### PRODUCT (explicit allowlist — see `config/product_repo_test_allowlist.txt` for the canonical list)
+
+- `tests/dispatcher/*.py` — MCP dispatcher (V1.0 primary product code). All 16 current files listed by name.
+- `tests/memory/*.py` — Memory Abstraction Layer (V1.0 primary product code). All 3 current files listed.
+- Tenant onboarding (non-negotiable #1):
+  - `tests/test_services/test_onboarding_pipeline.py`
+  - `tests/test_flows/test_post_onboarding_flow.py`
+  - `tests/scripts/test_seed_demo_tenant.py`
+  - `tests/unit/test_set_tenant_session.py`
+  - `tests/live/test_onboarding_live.py`
+- Namespace boundary (non-negotiable #3):
+  - `tests/governance/test_ceo_memory_context_constraint.py` (the `0scg` migration test — proves CHECK + NOT NULL on `ceo_memory.context`; cross-namespace gate)
+  - `tests/governance/test_ceo_memory_writer.py` (KEI-87 write-guard — only `elliot`/`dave` can write `ceo:*`; cross-callsign boundary)
+  - `tests/integration/test_tenant_isolation.py` (per-tenant data isolation)
+- MCP wrong-project-id rejection (non-negotiable #2): test file **not yet written**. Allowlist carries a comment placeholder + the gate is "no release-marked PR merges without this test existing". Tracked as a follow-up bd issue.
+
+### FLEET (anything NOT in product allowlist + matches one of):
+
+- `tests/orchestrator/*` — orchestrator plumbing (per Elliot dispatch hint). Examples: `test_next_work_prompter.py`, `test_supervisor_wake_publish.py`, `test_self_assign_on_ready.py`.
+- `tests/scripts/test_spawn_*.py` — clone bring-up (per dispatch hint).
+- `tests/governance/*` (except the 3 namespace-boundary tests promoted to product) — KEI-87 trigger discipline, layered governance, gatekeeper emit.
+- `tests/alerts/*` — fleet service-health alerts.
+- `tests/cognee/*` — fleet Cognee memory infra (read path for the existing pre-MAL recall).
+- `tests/hooks/*` — fleet PreToolUse / Stop hooks.
+- `tests/observability/*` — fleet BetterStack / instrumentation.
+- `tests/session_store/*`, `tests/session_resumption/*` — fleet session state.
+- `tests/ci_guards/*` — fleet CI policy enforcers.
+- `tests/dispatcher/test_dispatcher_service_install.py` — **also product** (installs are customer-facing). Cross-listed: appears in product allowlist + duplicated in fleet manifest with a `# duplicated` comment.
+
+### ARCHIVE (anything NOT in product allowlist + matches one of):
+
+- `tests/pipeline/*`, `tests/test_pipeline/*` — Siege Waterfall pipeline orchestration (per dispatch hint).
+- `tests/enrichment/*` — Agency OS multi-tier enrichment (ContactOut, Hunter, Leadmagic waterfalls).
+- `tests/test_engines/*` — Agency OS scoring/scout engines.
+- `tests/test_detectors/*` — Agency OS lead-detector signals.
+- `tests/outreach/*` — Agency OS outreach cadence + safety.
+- `tests/test_flows/*` (except `test_post_onboarding_flow.py` which is product) — Agency OS Prefect flows (Flow A/B).
+- `tests/test_skills/*` — most Agency OS skills (BDR-specific).
+- `tests/integrations/*` — Agency OS vendor integrations (Salesforge, Unipile, Telnyx, Leadmagic, Bright Data).
+- `tests/intelligence/*` — Agency OS competitive intelligence.
+- `tests/coo_bot/*`, `tests/slack_bot/*`, `tests/telegram_bot/*` — Agency OS bot UI (pre-NATS).
+- `tests/replay/*` — Agency OS replay harness.
+- `tests/skill_gen/*` — Agency OS skill generator.
+
+### SPLIT (case-by-case per file — manifest will be authored as part of Phase 2.2 migration runner):
+
+- `tests/skills/*` — per dispatch hint, some fleet skills (drive-manual, callback-poller, decomposer) survive; some product skills (BYO API key, dispatcher CLI) survive; some Agency OS skills (DataForSEO, ContactOut, Leadmagic) archive.
+- `tests/integration/*` — varies per integration target.
+- `tests/migrations/*` — varies per migration domain.
+- `tests/api/*` — split by endpoint: tenant + onboarding endpoints → product; pipeline + score endpoints → archive; webhook handlers fleet-or-product depending on source.
+
+## 4. Local verification
+
+Run the allowlist enforcer against the current `tests/**` tree:
+
+```bash
+python3 scripts/ci/check_product_test_allowlist.py --report
+```
+
+Expected output today (in the pre-migration Agency_OS monorepo):
+
+```
+product-repo allowlist: 27 / 475 test files matched (5.7%); 448 would be rejected.
+```
+
+The 5.7% reflects today's product-tier surface: 16 dispatcher + 3 memory + 5 onboarding + 3 namespace-boundary = 27 product tests vs 475 total. The 448 rejected files split fleet / archive / split-to-be-classified per §3 above. The bucket totals will refine as the §3 SPLIT manifest is authored in Phase 2.2.
+
+In the **product repo** post-migration, `tests/**` will only contain allowlisted paths, so the enforcer exits 0.
+
+## 5. Cutover sequence
+
+Reading from `ceo:agency_os_keiracom_separation_v1.sequencing`:
+
+  1. ✅ Phase 1.1 — V1.0 ratification (DONE 2026-05-24)
+  2. 🔄 Phase 1.2 — retire Agency OS architecture doc, V1.0-aligned doc, content audit pass (IN PROGRESS via Stage 0 staleness audit + Phase 1.3 IDENTITY refresh)
+  3. 🔄 Phase 1.2.5 — pre-migration artefact bundle: **this document is item 7 of the bundle**
+  4. ✅ Phase 1.3 — agent identity refresh for 4 PARTIAL IDENTITY files (DONE 2026-05-24 via Agency_OS-fwdb v3)
+  5. ⏳ Phase 2.0 — repo creation (product repo carved, fresh CI matrix enabled, this allowlist enforcer wired)
+  6. ⏳ Phase 2.1 — Hindsight verification spike (6 items)
+  7. ⏳ Phase 2.2 — migrate product code via clean PRs, subject to dynamic-exclusion migration manifest
+
+The allowlist enforcer (`check_product_test_allowlist.py`) starts running in CI at Phase 2.0 against the fresh product repo's pruned `tests/**` tree.
+
+## 6. CI rule (GitHub Actions workflow snippet)
+
+To be placed in the **product repo** at `.github/workflows/product-repo-test-matrix.yml`. Snippet that fails CI on any unmatched test path:
+
+```yaml
+name: Product Repo Test Matrix Enforcement
+
+on:
+  pull_request:
+    paths:
+      - "tests/**"
+      - "config/product_repo_test_allowlist.txt"
+  push:
+    branches: [main]
+
+jobs:
+  enforce-product-allowlist:
+    name: Stripped test matrix — allowlist enforcement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run product-repo allowlist enforcer
+        # Exit 1 if any tests/**/*.py file is not matched by an allowlist entry.
+        # Fix path: either add the path to config/product_repo_test_allowlist.txt
+        # (with review of whether the test actually belongs in the product repo
+        # CI matrix) OR move/delete the test file.
+        run: |
+          python3 scripts/ci/check_product_test_allowlist.py
+```
+
+## 7. Notes — `ceo:agency_os_keiracom_separation_v1` (queried 2026-05-24)
+
+Per the audit-dispatch checklist (canonical-key-query gate), the queried value of the canonical key is pasted here verbatim for review:
+
+```json
+{
+  "frame": {
+    "keiracom": "Was the internal agent fleet built in parallel; now the commercial venture. Working name; final brand TBD post-launch via market analysis.",
+    "agency_os": "The BDR product the fleet built for AU marketing agencies (discovery + enrichment + 4-channel outreach). RETIRED, preserved as archive, not deleted."
+  },
+  "status": "RATIFIED",
+  "ratified_at": "2026-05-24T10:23:00+00:00",
+  "ratified_by": "dave",
+  "directive_ref": "AGENCY-OS-KEIRACOM-SEPARATION-V1",
+  "repo_topology": [
+    "Internal fleet repo (working name keiracom-fleet) — Dave internal agent team configs, NOT customer-facing",
+    "Product repo (working name TBD, rename-ready) — V1.0 AI workforce code shipped to customers; Memory Abstraction Layer + Hindsight self-hosted + Go sidecar + MCP server + tenant onboarding + install script + CLI",
+    "Archive repo (existing URL preserved) — 1100 prior pull requests + dead BDR product code; marked inactive in README"
+  ],
+  "sign_off_decisions": {
+    "item_2_ci_matrix": "Stripped product-only matrix until first paying customer, with 3 non-negotiable tests (tenant onboarding, MCP wrong-project-id rejection, namespace boundary negative-paths). Concrete enumerated allow-list of test paths as Phase 1.2.5 artefact (Elliot refinement)"
+  }
+}
+```
+
+The three classifications in this document (PRODUCT / FLEET / ARCHIVE) are derived directly from the `repo_topology` + `sign_off_decisions.item_2_ci_matrix` fields above. The three non-negotiable tests (tenant onboarding, MCP wrong-project-id rejection, namespace boundary negative-paths) are explicitly carved out of the product allowlist (§3 PRODUCT, all 3 non-negotiables enumerated; #2 carries a placeholder since the test file has not yet been written — gate noted in `config/product_repo_test_allowlist.txt`).
+
+## 8. Acceptance criteria
+
+- [x] `config/product_repo_test_allowlist.txt` exists + enumerates ≥1 path per non-negotiable bucket.
+- [x] `scripts/ci/check_product_test_allowlist.py` runs locally with `--report` against current `tests/**` tree and reports counts.
+- [x] Reported "matched" percent is in the expected **~5-10%** band today (pre-migration; product code is small fraction of monorepo) — refines to ~30-40% in the post-migration product repo where `tests/**` is already pruned to the allowlist.
+- [x] CI workflow snippet provided as a paste-target for the product repo's `.github/workflows/product-repo-test-matrix.yml`.
+- [x] Canonical key `ceo:agency_os_keiracom_separation_v1` queried + pasted into §7 per audit-dispatch checklist.
+- [ ] Aiden architecture-lens concur on PR.
+- [ ] Max code-quality-lens concur on PR.
+- [ ] Dual-concur → Elliot admin-merge per orchestrator-merge-after-NATS-concur pattern.

--- a/scripts/ci/check_product_test_allowlist.py
+++ b/scripts/ci/check_product_test_allowlist.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""check_product_test_allowlist.py — Phase 1.2.5 bundle artefact 7 enforcer.
+
+CI guard for the PRODUCT REPO test matrix. Walks tests/** and fails (exit 1)
+if any test file is NOT matched by an entry in config/product_repo_test_allowlist.txt.
+
+WHY:
+Per ceo:agency_os_keiracom_separation_v1 sign-off item 2 — the product repo
+ships a STRIPPED test matrix until first paying customer (Dave-ratified
+2026-05-24). Discipline: every test in the product repo is explicitly
+enumerated; nothing carried over implicitly from the fleet repo.
+
+ALGORITHM:
+  1. Read allowlist (skip blank lines + # comments). Each non-comment line
+     is a path or glob (no `**`).
+  2. Walk tests/** for *.py files (skipping __init__.py and __pycache__).
+  3. For each test file, check if any allowlist entry matches via fnmatch.
+  4. If unmatched: print to stderr + collect for the final exit code.
+  5. Exit 0 if zero unmatched, 1 otherwise.
+
+USAGE:
+    python3 scripts/ci/check_product_test_allowlist.py
+    python3 scripts/ci/check_product_test_allowlist.py --allowlist <path>
+    python3 scripts/ci/check_product_test_allowlist.py --report  # show counts only
+
+LOCAL VERIFICATION expected output (in fleet repo today, before any migration):
+    most tests/** files are NOT product-repo-survivors — that is the design.
+    The script prints them to stderr as "rejected — not in product allowlist"
+    + exits 1. The product repo CI invocation (post-migration) walks a
+    tests/** tree that's already pruned to allowlist members; exit 0 then.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_ALLOWLIST = REPO_ROOT / "config" / "product_repo_test_allowlist.txt"
+DEFAULT_TESTS_ROOT = REPO_ROOT / "tests"
+
+
+def load_allowlist(path: Path) -> list[str]:
+    """Parse the allowlist file. Returns list of path patterns (sorted, deduped)."""
+    if not path.is_file():
+        sys.stderr.write(f"ERROR: allowlist not found: {path}\n")
+        sys.exit(2)
+    patterns: set[str] = set()
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "**" in line:
+            sys.stderr.write(
+                f"ERROR: '**' recursive glob disallowed in allowlist (line: {line!r})\n"
+                "Enumerate paths explicitly or use a single-level glob like dir/*.py\n"
+            )
+            sys.exit(2)
+        patterns.add(line)
+    return sorted(patterns)
+
+
+def walk_tests(tests_root: Path) -> list[Path]:
+    """All test files under tests_root, relative paths from repo root."""
+    if not tests_root.is_dir():
+        return []
+    files: list[Path] = []
+    for p in tests_root.rglob("*.py"):
+        if "__pycache__" in p.parts:
+            continue
+        if p.name == "__init__.py":
+            continue
+        files.append(p.relative_to(REPO_ROOT))
+    return sorted(files)
+
+
+def matches_any(path: Path, patterns: list[str]) -> bool:
+    """True if path matches at least one allowlist pattern via fnmatch."""
+    s = str(path)
+    return any(fnmatch.fnmatch(s, pat) for pat in patterns)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument(
+        "--allowlist",
+        type=Path,
+        default=DEFAULT_ALLOWLIST,
+        help="Path to allowlist file (default: config/product_repo_test_allowlist.txt)",
+    )
+    p.add_argument(
+        "--tests-root",
+        type=Path,
+        default=DEFAULT_TESTS_ROOT,
+        help="Path to tests root (default: tests/)",
+    )
+    p.add_argument(
+        "--report",
+        action="store_true",
+        help="Print counts (matched / unmatched / total) and exit 0 — no enforcement",
+    )
+    args = p.parse_args(argv)
+
+    patterns = load_allowlist(args.allowlist)
+    files = walk_tests(args.tests_root)
+
+    matched: list[Path] = []
+    unmatched: list[Path] = []
+    for f in files:
+        (matched if matches_any(f, patterns) else unmatched).append(f)
+
+    total = len(files)
+    pct_matched = (100.0 * len(matched) / total) if total else 0.0
+    sys.stderr.write(
+        f"product-repo allowlist: {len(matched)} / {total} test files matched "
+        f"({pct_matched:.1f}%); {len(unmatched)} would be rejected.\n"
+    )
+
+    if args.report:
+        sys.stderr.write(f"  allowlist patterns: {len(patterns)}\n")
+        for f in matched[:10]:
+            sys.stderr.write(f"  matched  {f}\n")
+        if len(matched) > 10:
+            sys.stderr.write(f"  ... + {len(matched) - 10} more matched\n")
+        for f in unmatched[:10]:
+            sys.stderr.write(f"  rejected {f}\n")
+        if len(unmatched) > 10:
+            sys.stderr.write(f"  ... + {len(unmatched) - 10} more rejected\n")
+        return 0
+
+    if unmatched:
+        sys.stderr.write(
+            "REJECT: the following test files are not in the product-repo allowlist. "
+            "Either add their path to config/product_repo_test_allowlist.txt (with "
+            "review of whether they actually belong in the product repo CI matrix) "
+            "OR move them to the fleet/archive repo before this check runs.\n"
+        )
+        for f in unmatched:
+            sys.stderr.write(f"  rejected — not in product allowlist: {f}\n")
+        return 1
+
+    sys.stderr.write("OK: every tests/** file is in the product allowlist.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_product_test_allowlist.py
+++ b/scripts/ci/check_product_test_allowlist.py
@@ -63,16 +63,27 @@ def load_allowlist(path: Path) -> list[str]:
 
 
 def walk_tests(tests_root: Path) -> list[Path]:
-    """All test files under tests_root, relative paths from repo root."""
+    """All test files under tests_root, relative paths from tests_root's parent.
+
+    Bug-fix 2026-05-24 (caught by negative-path test sweep): previously used
+    REPO_ROOT as the relativisation base, which broke when --tests-root pointed
+    outside the repo (e.g. a tmp_path test fixture or a separate worktree).
+    Using tests_root.parent makes the path display + allowlist matching work
+    consistently in both cases:
+      - default: tests_root = REPO_ROOT/tests → parent = REPO_ROOT → "tests/foo.py"
+      - test:    tests_root = /tmp/.../tests → parent = /tmp/... → "tests/foo.py"
+    Allowlist patterns reference 'tests/...' either way, so matching is stable.
+    """
     if not tests_root.is_dir():
         return []
+    base = tests_root.parent
     files: list[Path] = []
     for p in tests_root.rglob("*.py"):
         if "__pycache__" in p.parts:
             continue
         if p.name == "__init__.py":
             continue
-        files.append(p.relative_to(REPO_ROOT))
+        files.append(p.relative_to(base))
     return sorted(files)
 
 
@@ -80,6 +91,32 @@ def matches_any(path: Path, patterns: list[str]) -> bool:
     """True if path matches at least one allowlist pattern via fnmatch."""
     s = str(path)
     return any(fnmatch.fnmatch(s, pat) for pat in patterns)
+
+
+def _print_report(matched: list[Path], unmatched: list[Path], patterns: list[str]) -> None:
+    """Render --report-mode diagnostic to stderr (extracted from main per Max
+    HOLD on PR #1118 — Sonar S3776 cognitive-complexity refactor)."""
+    sys.stderr.write(f"  allowlist patterns: {len(patterns)}\n")
+    for f in matched[:10]:
+        sys.stderr.write(f"  matched  {f}\n")
+    if len(matched) > 10:
+        sys.stderr.write(f"  ... + {len(matched) - 10} more matched\n")
+    for f in unmatched[:10]:
+        sys.stderr.write(f"  rejected {f}\n")
+    if len(unmatched) > 10:
+        sys.stderr.write(f"  ... + {len(unmatched) - 10} more rejected\n")
+
+
+def _print_rejections(unmatched: list[Path]) -> None:
+    """Render enforcement-mode rejection block to stderr (extracted from main)."""
+    sys.stderr.write(
+        "REJECT: the following test files are not in the product-repo allowlist. "
+        "Either add their path to config/product_repo_test_allowlist.txt (with "
+        "review of whether they actually belong in the product repo CI matrix) "
+        "OR move them to the fleet/archive repo before this check runs.\n"
+    )
+    for f in unmatched:
+        sys.stderr.write(f"  rejected — not in product allowlist: {f}\n")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -119,26 +156,11 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     if args.report:
-        sys.stderr.write(f"  allowlist patterns: {len(patterns)}\n")
-        for f in matched[:10]:
-            sys.stderr.write(f"  matched  {f}\n")
-        if len(matched) > 10:
-            sys.stderr.write(f"  ... + {len(matched) - 10} more matched\n")
-        for f in unmatched[:10]:
-            sys.stderr.write(f"  rejected {f}\n")
-        if len(unmatched) > 10:
-            sys.stderr.write(f"  ... + {len(unmatched) - 10} more rejected\n")
+        _print_report(matched, unmatched, patterns)
         return 0
 
     if unmatched:
-        sys.stderr.write(
-            "REJECT: the following test files are not in the product-repo allowlist. "
-            "Either add their path to config/product_repo_test_allowlist.txt (with "
-            "review of whether they actually belong in the product repo CI matrix) "
-            "OR move them to the fleet/archive repo before this check runs.\n"
-        )
-        for f in unmatched:
-            sys.stderr.write(f"  rejected — not in product allowlist: {f}\n")
+        _print_rejections(unmatched)
         return 1
 
     sys.stderr.write("OK: every tests/** file is in the product allowlist.\n")

--- a/tests/scripts/test_check_product_test_allowlist.py
+++ b/tests/scripts/test_check_product_test_allowlist.py
@@ -1,0 +1,153 @@
+"""Tests for scripts/ci/check_product_test_allowlist.py — Phase 1.2.5 enforcer.
+
+Negative-path discipline (Max HOLD on PR #1118 — per
+feedback_negative_path_test_before_approve, gate/validator/enforcer PRs
+require negative-path tests on synthetic offenders before approve).
+
+7 test cases per Max's spec:
+  (1) test_unmatched_file_returns_exit_1 — synthetic offender → exit 1 + stderr 'rejected'
+  (2) test_all_matched_returns_exit_0 — synthetic happy-path → exit 0
+  (3) test_double_star_in_allowlist_returns_exit_2 — `**/x.py` → exit 2 + stderr `**`
+  (4) test_missing_allowlist_returns_exit_2 — --allowlist /nonexistent → exit 2
+  (5) test_report_mode_never_enforces — synthetic offender + --report → exit 0
+  (6) test_empty_tests_dir_returns_exit_0 — no .py files → exit 0
+  (7) test_pycache_and_init_skipped — __pycache__/__init__ files don't count
+
+All fixtures use tmp_path so no real-repo state touched.
+
+Pattern: subprocess invocation of the script — tests it as it'll actually
+run in CI (Python interpreter + argv + stderr inspection), not as an
+imported function. Catches argv/parsing/exit-code issues a unit test wouldn't.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "ci" / "check_product_test_allowlist.py"
+
+
+def _run(allowlist: Path, tests_root: Path, *extra: str) -> subprocess.CompletedProcess:
+    """Invoke the enforcer with explicit --allowlist + --tests-root."""
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--allowlist",
+            str(allowlist),
+            "--tests-root",
+            str(tests_root),
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def _make_test_file(root: Path, rel: str) -> Path:
+    """Create an empty test file at root/rel (parents created)."""
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# synthetic test\n")
+    return path
+
+
+def test_unmatched_file_returns_exit_1(tmp_path: Path):
+    """(1) — synthetic tree with 1 file NOT in allowlist → exit 1 + 'rejected' on stderr."""
+    allowlist = tmp_path / "allowlist.txt"
+    allowlist.write_text("# allowlist with a single matching path\ntests/keep.py\n")
+    tests_root = tmp_path / "tests"
+    _make_test_file(tests_root, "keep.py")
+    _make_test_file(tests_root, "stray.py")  # synthetic offender — not in allowlist
+    result = _run(allowlist, tests_root)
+    assert result.returncode == 1, f"expected exit 1, got {result.returncode}: {result.stderr}"
+    assert "rejected" in result.stderr
+    assert "stray.py" in result.stderr
+
+
+def test_all_matched_returns_exit_0(tmp_path: Path):
+    """(2) — synthetic tree where every file matches → exit 0."""
+    allowlist = tmp_path / "allowlist.txt"
+    allowlist.write_text("tests/a.py\ntests/sub/b.py\n")
+    tests_root = tmp_path / "tests"
+    _make_test_file(tests_root, "a.py")
+    _make_test_file(tests_root, "sub/b.py")
+    result = _run(allowlist, tests_root)
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}: {result.stderr}"
+    assert "OK: every tests/** file is in the product allowlist" in result.stderr
+
+
+def test_double_star_in_allowlist_returns_exit_2(tmp_path: Path):
+    """(3) — `**` recursive glob disallowed; exit 2 + stderr mentions `**`."""
+    allowlist = tmp_path / "allowlist.txt"
+    allowlist.write_text("tests/**/something.py\n")
+    tests_root = tmp_path / "tests"
+    tests_root.mkdir()
+    result = _run(allowlist, tests_root)
+    assert result.returncode == 2, f"expected exit 2, got {result.returncode}: {result.stderr}"
+    assert "**" in result.stderr
+    assert "disallowed" in result.stderr
+
+
+def test_missing_allowlist_returns_exit_2(tmp_path: Path):
+    """(4) — non-existent allowlist path → exit 2 + 'allowlist not found' on stderr."""
+    allowlist = tmp_path / "does_not_exist.txt"
+    tests_root = tmp_path / "tests"
+    tests_root.mkdir()
+    result = _run(allowlist, tests_root)
+    assert result.returncode == 2, f"expected exit 2, got {result.returncode}: {result.stderr}"
+    assert "allowlist not found" in result.stderr
+
+
+def test_report_mode_never_enforces(tmp_path: Path):
+    """(5) — synthetic offender + --report → exit 0 (diagnostic, not enforcement)."""
+    allowlist = tmp_path / "allowlist.txt"
+    allowlist.write_text("tests/keep.py\n")
+    tests_root = tmp_path / "tests"
+    _make_test_file(tests_root, "keep.py")
+    _make_test_file(tests_root, "would_reject.py")
+    result = _run(allowlist, tests_root, "--report")
+    assert result.returncode == 0, (
+        f"--report should never enforce; expected exit 0, got {result.returncode}: {result.stderr}"
+    )
+    # Diagnostic body still surfaces the rejected file even though exit 0.
+    assert "would_reject.py" in result.stderr
+
+
+def test_empty_tests_dir_returns_exit_0(tmp_path: Path):
+    """(6) — tests root exists but contains no .py files → exit 0 (nothing to enforce)."""
+    allowlist = tmp_path / "allowlist.txt"
+    allowlist.write_text("tests/anything.py\n")
+    tests_root = tmp_path / "tests"
+    tests_root.mkdir()
+    result = _run(allowlist, tests_root)
+    assert result.returncode == 0, (
+        f"expected exit 0 on empty tree, got {result.returncode}: {result.stderr}"
+    )
+
+
+def test_pycache_and_init_skipped(tmp_path: Path):
+    """(7) — __pycache__/*.py and __init__.py don't trigger enforcement.
+
+    Walks must skip both per walk_tests() logic. If a __pycache__ artefact
+    or __init__.py somehow ended up in the allowlist requirement it'd be a
+    silent gotcha during CI; this test pins the behaviour.
+    """
+    allowlist = tmp_path / "allowlist.txt"
+    allowlist.write_text("tests/real.py\n")
+    tests_root = tmp_path / "tests"
+    _make_test_file(tests_root, "real.py")
+    _make_test_file(tests_root, "__init__.py")  # should be skipped
+    _make_test_file(tests_root, "sub/__init__.py")  # should be skipped
+    _make_test_file(tests_root, "__pycache__/x.cpython-312.py")  # should be skipped
+    _make_test_file(tests_root, "sub/__pycache__/y.cpython-312.py")  # should be skipped
+    result = _run(allowlist, tests_root)
+    assert result.returncode == 0, (
+        f"__init__/__pycache__ should be skipped; expected exit 0, got "
+        f"{result.returncode}: {result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Phase 1.2.5 bundle artefact 7 (Elliot refinement on Viktor Item 2) per Dave-ratified separation directive `AGENCY-OS-KEIRACOM-SEPARATION-V1` (canonical key `ceo:agency_os_keiracom_separation_v1`, ratified 2026-05-24).

Delivers the concrete enumerated allowlist of test paths that survive into the product repo CI matrix, plus the enforcer that fails CI on any unmatched test, plus the narrative explaining the 3-bucket classification (PRODUCT / FLEET / ARCHIVE).

**Blocks:** Phase 2.0 product repo CI config.

## 3 files (+303 LoC)

| File | LoC | Purpose |
|---|---|---|
| `config/product_repo_test_allowlist.txt` | 80 | 27 explicit test paths surviving into product CI |
| `scripts/ci/check_product_test_allowlist.py` | 148 | Enforcer — exit 1 on any unmatched `tests/**/*.py` |
| `docs/migration/test_path_classification.md` | 162 | Narrative — buckets, rules, cutover, CI workflow snippet, canonical-key paste |

## Allowlist composition

- **`tests/dispatcher/*`** (16 files) — MCP dispatcher, V1.0 primary product code
- **`tests/memory/*`** (3 files) — Memory Abstraction Layer
- **Tenant onboarding** (5 files) — non-negotiable #1
- **Namespace boundary** (3 files) — non-negotiable #3, includes the `0scg` `ceo_memory.context` constraint test + KEI-87 write-guard test + tenant-isolation test
- **MCP wrong-project-id rejection** (placeholder) — non-negotiable #2, test file not yet written; allowlist carries a comment + the gate "no release-marked PR merges without this test existing"

## Local verification — current Agency_OS monorepo, pre-migration

```
$ python3 scripts/ci/check_product_test_allowlist.py --report
product-repo allowlist: 27 / 475 test files matched (5.7%); 448 would be rejected.
  allowlist patterns: 27
  matched  tests/dispatcher/test_auth_minter.py
  matched  tests/dispatcher/test_container_jwt.py
  matched  tests/dispatcher/test_container_monitor.py
  matched  tests/dispatcher/test_dispatcher_service_install.py
  matched  tests/dispatcher/test_governance_proxy.py
  matched  tests/dispatcher/test_heartbeat_reaper.py
  matched  tests/dispatcher/test_heartbeat_watchdog.py
  matched  tests/dispatcher/test_interceptor_proxy.py
  matched  tests/dispatcher/test_jwt_hash_rotation.py
  matched  tests/dispatcher/test_main_wiring.py
  ... + 17 more matched
  rejected tests/alerts/test_hook_failure_monitor.py
  rejected tests/alerts/test_skill_pr_staleness_monitor.py
  rejected tests/api/routes/test_approvals.py
  ... + 445 more rejected
```

**5.7% matches the expected band today** (pre-migration; product code is small fraction of the monorepo). Post-migration in the product repo, `tests/**` is already pruned to allowlist members → enforcer exits 0. Refines to **~30-40% surviving** per the dispatch's sanity check, as non-allowlisted tests move to fleet or archive per the §3 SPLIT manifest authored in Phase 2.2.

## Canonical key query gate (audit-dispatch checklist)

Queried `ceo:agency_os_keiracom_separation_v1` BEFORE writing. Verbatim value pasted into `docs/migration/test_path_classification.md` §7 per the canonical-key-query-gate requirement. Three classifications (PRODUCT / FLEET / ARCHIVE) derived directly from `repo_topology` + `sign_off_decisions.item_2_ci_matrix` fields.

## CI workflow snippet (for product repo, not this PR)

Included in `docs/migration/test_path_classification.md` §6 — drops into the product repo at `.github/workflows/product-repo-test-matrix.yml` post-migration:

```yaml
- name: Run product-repo allowlist enforcer
  run: python3 scripts/ci/check_product_test_allowlist.py
```

## Test plan
- [x] Allowlist file enumerates ≥1 path per non-negotiable bucket
- [x] Enforcer runs locally with `--report`; reports counts
- [x] Reported matched % in expected 5-10% band today (5.7%)
- [x] CI workflow snippet provided for paste into product repo
- [x] Canonical key queried + pasted into narrative §7
- [x] ruff check + format clean on the enforcer
- [ ] Aiden architecture-lens concur
- [ ] Max code-quality-lens concur
- [ ] Dual-concur → Elliot admin-merge per orchestrator-merge-after-NATS-concur pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)