### PR TITLE
[ATLAS] feat(migration): Phase 1.2.5 artefact 4 — Weaviate cutover script + plan

### DIFF
--- a/docs/migration/weaviate_cutover_plan.md
+++ b/docs/migration/weaviate_cutover_plan.md
@@ -1,0 +1,196 @@
+# Weaviate Cutover Plan — `<source>` → `keiracom-product`
+
+**Phase 1.2.5 bundle artefact 4** (Aiden R6/G9).
+Authored 2026-05-24. Executes in Phase 2.0 when the product repo creates the `keiracom-product` collection.
+
+This document is the strategy + rollback companion to `scripts/migration/weaviate_cutover.py`. The script is the executable; this doc is the why, the no-flag-day principle, and the per-step rollback.
+
+---
+
+## Notes — canonical key values (per audit-dispatch checklist, `_orchestrator.md`)
+
+Both keys queried 2026-05-24 ahead of authoring. Pasted verbatim so the dispatcher and reviewers can cross-check claims in the doc + script against the SSOT.
+
+### `ceo:agency_os_keiracom_separation_v1` (updated 2026-05-24T11:04Z)
+
+> Status: **RATIFIED**. 3-repo topology: fleet repo (Dave internal agent team), product repo (Keiracom working name, V1.0 AI workforce code), archive repo (1100 prior PRs + dead BDR code).
+>
+> Sequencing:
+> 1. Phase 1.1 — V1.0 ratification (DONE 2026-05-24)
+> 2. Phase 1.2 — retire Agency OS architecture doc + V1.0-aligned doc + content audit
+> 3. **Phase 1.2.5 (INSERT) — pre-migration artefact bundle: 3-repo architecture doc + per-repo CLAUDE.md split decision + bd-routing policy + Weaviate cutover plan + discovery log classifier + migrated-manifest seed**
+> 4. Phase 1.3 — agent identity refresh for 4 PARTIAL IDENTITY files
+> 5. Phase 2.0 — repo creation: carve fleet repo, create fresh product repo, confirm archive state, namespace ceo_memory + Weaviate
+> 6. Phase 2.1 — Hindsight verification spike (6 items)
+> 7. Phase 2.2 — migrate product code via clean PRs subject to dynamic-exclusion migration manifest
+>
+> Consolidated gates relevant to this artefact:
+> - "Weaviate ingest gate: every payload declares target collection or rejected"
+> - "Recall scope gate: product agent recall hard-codes product collection; cross-collection blocked at helper layer"
+> - "Phase 1.2.5 architecture doc bundle BEFORE first product-migration PR"
+> - **"Weaviate cutover script with per-step verification; no flag-day"** ← this artefact
+> - "Backup gate: scripts cover both Weaviate collections"
+> - "Negative-path tests on namespace boundaries (positive + negative on ceo_memory + Weaviate)"
+
+### `ceo:memory_abstraction_layer_v1` (updated 2026-05-24T15:12Z)
+
+> Status: **RATIFIED**. Hindsight self-hosted (Vectorize.io MIT) as memory engine, deployed per-tenant VPC.
+>
+> Phase 2 build gating (Aiden 6 gates): A: Hindsight spike completes favourable BEFORE Phase 2 build starts; B: V1.0-aligned architecture doc lands BEFORE Phase 2 dispatches; C: Whiteboard-flush-through-Ingest is runtime code, not comment; D: Trace primitive empirically reconstructible; E: MCP swappability via dual-backend; F: Migration runner is P0 critical-path.
+>
+> Eleven agreed positions (relevant subset):
+> - "MCP swappability: agents call memory MCP tools, never SQL/Cypher; swap backend = rewrite DAL"
+> - "Whiteboard flush through Ingest at every task boundary"
+> - "Tenancy: schema-per-tenant + 20-30 tripwire + migration runner pre-launch"
+> - "Hindsight self-hosted as engine"
+
+**Read-out:** Weaviate is the current memory store; Hindsight is the post-Phase-2.1 target. This cutover handles the **Weaviate-to-Weaviate** collection split — a smaller scope than Hindsight migration. The Hindsight migration itself is a separate Phase 2.1+ artefact and is out of scope here. This cutover is purely about isolating product-tagged objects into their own Weaviate collection so the product repo can recall scope-bounded.
+
+---
+
+## Strategy
+
+### What the script does
+
+Moves objects whose `context_tag == "product"` from the existing collection (default `Decisions`) into the new `keiracom-product` collection. Each row gets a **deterministic UUID** derived from `(cutover_tag, source_id)` so re-runs upsert in place rather than duplicating.
+
+### What the script does NOT do
+
+- **Does not write Hindsight.** Hindsight migration is the Phase 2.1+ workstream after the spike concludes favourable.
+- **Does not delete from source by default.** Step 5 (`purge_old`) is opt-in via `--purge-old`; the source remains the recall fallback during the dual-write window.
+- **Does not rewrite agent code.** Step 4 (`repoint`) only edits configuration files listed in a manifest; the agent code paths that consume `collection_name` are unchanged.
+
+### No-flag-day principle
+
+Each of the five steps is independently invocable (`--step snapshot|write|verify|repoint|purge|all`) and reversible:
+
+| Step | Mutation | Rollback |
+| --- | --- | --- |
+| (1) snapshot | writes a single JSON file | `rm` the file |
+| (2) write | upserts to `keiracom-product` | step (5) `purge --target` (or manual `DELETE` per id; UUIDs are deterministic so trivial to enumerate) |
+| (3) verify | read-only, no rollback needed | n/a |
+| (4) repoint | edits configs listed in manifest; writes `.cutover-backup` per file | `mv <file>.cutover-backup <file>` |
+| (5) purge | deletes from source collection (opt-in) | restore from Weaviate backup gate ([backup script ownership](#open-followups)) |
+
+Operators run each step independently, verify, then proceed. The only step gated on a previous step's data is (2) `write` and (5) `purge`, which both consume the snapshot file from (1). Both tolerate a missing snapshot in `--dry-run`.
+
+---
+
+## Operator runbook — Phase 2.0 execution
+
+> Run from the product repo once the `keiracom-product` Weaviate class exists.
+
+```bash
+# Step 0 — dry-run the full plan to confirm intent
+python3 scripts/migration/weaviate_cutover.py --dry-run --step all
+
+# Step 1 — snapshot product-tagged rows
+python3 scripts/migration/weaviate_cutover.py --step snapshot
+
+# Step 2 — write to keiracom-product
+python3 scripts/migration/weaviate_cutover.py --step write
+
+# Step 3 — verify (HARD-REQUIRED — exits non-zero on mismatch)
+python3 scripts/migration/weaviate_cutover.py --step verify || { echo "verify FAILED, abort"; exit 1; }
+
+# Step 4 — repoint product agent configs (manifest filled in Phase 2.0)
+python3 scripts/migration/weaviate_cutover.py --step repoint --repoint-manifest scripts/migration/repoint_manifest.json
+
+# Step 5 — purge from source ONLY after dual-write window settles
+python3 scripts/migration/weaviate_cutover.py --step purge --purge-old
+```
+
+### Dual-write window
+
+Run steps (1)→(4) and leave the source collection untouched for a settling window (suggested: ≥ 7 days from production launch of the product repo, or until recall scope-boundary regression tests have run clean for a full deploy cycle). Only then run step (5).
+
+During the dual-write window, **every product-tagged WRITE made by the running agents must go to BOTH collections** so the cut is consistent at the moment step (5) fires. This dual-write is **not** the responsibility of `weaviate_cutover.py` — it lives in the indexer layer (the per-source indexers extending `indexer_base.IndexerBase`). Phase 2.0 implementation must add a dual-write toggle to the affected indexers; this script is purely the one-shot migration.
+
+---
+
+## Per-step rollback detail
+
+### (1) snapshot — rollback
+Delete `snapshot.json`. No Weaviate state was touched. Re-run later.
+
+### (2) write — rollback
+`keiracom-product` got new rows. To roll back without disturbing earlier intentional writes to that class:
+
+```bash
+# Re-snapshot what was cut over (snapshot file is idempotent + still present)
+# Then enumerate the deterministic target ids and DELETE them.
+python3 -c "
+import json, sys
+sys.path.insert(0, 'scripts/orchestrator')
+from indexer_base import deterministic_uuid
+payload = json.load(open('/tmp/weaviate_cutover_snapshot.json'))
+for row in payload['rows']:
+    src = row['_additional']['id']
+    print(deterministic_uuid('cutover_to_keiracom_product', src))
+" | xargs -I{} curl -s -X DELETE http://127.0.0.1:8090/v1/objects/Keiracom_Product/{}
+```
+
+### (3) verify — rollback
+Read-only. Nothing to roll back.
+
+### (4) repoint — rollback
+For every `<config>.cutover-backup` file the script left, restore:
+
+```bash
+for f in $(find . -name '*.cutover-backup'); do
+    mv "$f" "${f%.cutover-backup}"
+done
+```
+
+### (5) purge — rollback
+The hardest step to reverse — source rows are gone from Weaviate. Recover via Weaviate backup (S3 snapshot per the "backup gate" in `ceo:agency_os_keiracom_separation_v1` consolidated gates). This is why step (5) is opt-in and the dual-write window is mandatory.
+
+---
+
+## Verification gates
+
+| Gate | Where | Trigger |
+| --- | --- | --- |
+| Snapshot file atomicity | step (1) uses `tmp.replace(path)` — POSIX atomic | always |
+| Deterministic UUID | step (2) derives id from `(UUID_SOURCE_TAG, source_id)` | always |
+| Count match | step (3) `aggregate_count(target) >= len(snapshot.rows)` | required, exits 1 on fail |
+| Sample-read parity | step (3) re-GETs first `SAMPLE_PARITY_N` target ids | required, exits 1 on fail |
+| Config backup | step (4) writes `<file>.cutover-backup` before mutating | always non-dry-run |
+| Opt-in destructive | step (5) requires explicit `--purge-old` flag | always |
+
+---
+
+## Open follow-ups (sequenced post-Phase-2.0)
+
+- **Backup script ownership** (`ceo:agency_os_keiracom_separation_v1` gate: "Backup gate: scripts cover both Weaviate collections") — extending the existing Weaviate backup to cover `keiracom-product` is a separate artefact, not Phase 1.2.5.
+- **Cross-collection recall block at helper layer** (gate: "Recall scope gate") — enforce in `llama_recall_engine.py` / `bd recall` so product agents cannot cross-fetch from fleet collection. Phase 2.0 implementation.
+- **Dual-write toggle in `indexer_base`** — needed during the dual-write window described above. Phase 2.0 implementation.
+- **Hindsight migration** — separate Phase 2.1+ workstream after the spike concludes favourable.
+
+---
+
+## Test plan
+
+Unit tests live in `tests/scripts/migration/test_weaviate_cutover.py` and cover:
+
+- Snapshot idempotency (rerun → identical file)
+- Snapshot dry-run is read-only
+- Write uses deterministic UUID + strips internal `_additional`
+- Write dry-run never posts
+- Verify count mismatch → False
+- Verify aggregate-unreachable → False (not a silent pass)
+- Verify happy path → True
+- Repoint applies + leaves `.cutover-backup`
+- Repoint dry-run leaves filesystem untouched
+- Repoint missing manifest → 0 edits, warning, no crash
+- Purge opt-in semantics + dry-run never deletes
+
+Integration test against a live Weaviate is intentionally **not** in this artefact — there is no `keiracom-product` class yet, and the source class is production-shared. Integration test belongs in the Phase 2.0 PR that creates the class.
+
+CLI dry-run smoke:
+
+```bash
+python3 scripts/migration/weaviate_cutover.py --dry-run --step all --purge-old
+```
+
+Run `ruff check` + `ruff format --check` on the script + tests before PR; CI rules in `feedback_ruff_format_check_required`.

--- a/scripts/migration/weaviate_cutover.py
+++ b/scripts/migration/weaviate_cutover.py
@@ -247,9 +247,8 @@ def repoint(
             )
             continue
         _set_by_dotted_key(data, key_path, target_class)
-        target_file.write_text(
-            json.dumps(data, indent=2)
-        )  # NOSONAR S2083 — sanitised by _safe_resolve commonpath
+        new_body = json.dumps(data, indent=2)
+        target_file.write_text(new_body)  # NOSONAR S2083 — sanitised by _safe_resolve commonpath
         applied += 1
         log.info(
             "repoint applied: %s %s -> %s (backup at %s)",

--- a/scripts/migration/weaviate_cutover.py
+++ b/scripts/migration/weaviate_cutover.py
@@ -182,14 +182,25 @@ def _set_by_dotted_key(obj: dict, key_path: str, value: Any) -> None:
     cur[parts[-1]] = value
 
 
-def _safe_resolve(path: Path, root: Path) -> Path:
-    # Confine manifest-controlled paths to `root` (default REPO_ROOT) so a
-    # hostile manifest entry like {"file": "/etc/passwd"} cannot trigger an
-    # arbitrary-file overwrite. Closes pythonsecurity:S2083 BLOCKER ×2.
-    resolved = path.resolve()
+def _safe_resolve(raw: str, root: Path) -> Path:
+    # Validate the raw user-controlled string BEFORE any pathlib construction
+    # so Sonar's S2083 taint tracker sees sanitisation at the string boundary
+    # (taking a Path arg here would still flag the upstream Path(raw) site).
+    # Three string-level rejections, then a composed-path confinement check.
+    if not isinstance(raw, str) or not raw:
+        raise ValueError(f"manifest path must be non-empty string: {raw!r}")
+    if "\x00" in raw or "\n" in raw or "\r" in raw:
+        raise ValueError(f"manifest path contains control characters: {raw!r}")
+    if raw.startswith("~"):
+        raise ValueError(f"manifest path home-expansion forbidden: {raw!r}")
+    # Compose only AFTER string validation. Absolute inputs are allowed iff
+    # they resolve inside root (tests use tmp_path, an absolute confinement).
     root_resolved = root.resolve()
+    candidate = Path(raw)
+    composed = candidate if candidate.is_absolute() else root_resolved / candidate
+    resolved = composed.resolve()
     if resolved != root_resolved and root_resolved not in resolved.parents:
-        raise ValueError(f"manifest path escapes confinement root: {path} (root={root})")
+        raise ValueError(f"manifest path escapes confinement root: {raw} (root={root})")
     return resolved
 
 
@@ -211,10 +222,11 @@ def repoint(
     edits = manifest.get("edits", [])
     applied = 0
     for edit in edits:
+        raw_file = edit.get("file", "")
         try:
-            target_file = _safe_resolve(Path(edit["file"]), root)
-        except ValueError as exc:
-            log.error("repoint: rejected path-escape %s — %s", edit.get("file"), exc)
+            target_file = _safe_resolve(raw_file, root)
+        except ValueError:
+            log.exception("repoint: rejected path-escape %r", raw_file)
             continue
         key_path = edit["key_path"]
         if not target_file.exists():

--- a/scripts/migration/weaviate_cutover.py
+++ b/scripts/migration/weaviate_cutover.py
@@ -52,10 +52,17 @@ log = logging.getLogger("weaviate_cutover")
 DEFAULT_SOURCE_CLASS = "Decisions"
 DEFAULT_TARGET_CLASS = "Keiracom_Product"
 DEFAULT_FILTER_TAG = "product"
-DEFAULT_SNAPSHOT_PATH = Path("/tmp/weaviate_cutover_snapshot.json")
+# Confined sub-dir (mode 0o700) instead of bare /tmp: closes S5443 TOCTOU on
+# a world-writable + predictable path. Operators can override via --snapshot-path.
+_SNAPSHOT_DIR = Path("/tmp/weaviate_cutover")  # NOSONAR — created mode-0o700 below
+_SNAPSHOT_DIR.mkdir(mode=0o700, exist_ok=True)
+DEFAULT_SNAPSHOT_PATH = _SNAPSHOT_DIR / "snapshot.json"
 DEFAULT_BATCH_SIZE = 100
 SAMPLE_PARITY_N = 5
 UUID_SOURCE_TAG = "cutover_to_keiracom_product"
+_ERR_SNAPSHOT_MISSING = "snapshot file missing: %s"
+# Step 4 confines manifest-controlled paths to REPO_ROOT to close S2083 path injection.
+_REPOINT_ROOT = REPO_ROOT
 
 
 def _fetch_objects(class_name: str, filter_tag: str, batch_size: int) -> list[dict[str, Any]]:
@@ -75,8 +82,8 @@ def _fetch_objects(class_name: str, filter_tag: str, batch_size: int) -> list[di
         try:
             with _http_request("POST", "/v1/graphql", query) as resp:
                 body = json.loads(resp.read().decode("utf-8"))
-        except (urlerror.URLError, OSError) as exc:
-            log.error("graphql fetch failed at offset=%d: %s", offset, exc)
+        except (urlerror.URLError, OSError):
+            log.exception("graphql fetch failed at offset=%d", offset)
             raise
         rows = body.get("data", {}).get("Get", {}).get(class_name, []) or []
         if not rows:
@@ -109,7 +116,7 @@ def write_to_target(target_class: str, path: Path, dry_run: bool) -> tuple[int, 
         if dry_run:
             log.info("dry-run: snapshot file missing — would upsert rows once step 1 produces it")
             return (0, 0)
-        log.error("snapshot file missing: %s", path)
+        log.error(_ERR_SNAPSHOT_MISSING, path)
         raise FileNotFoundError(str(path))
     payload = json.loads(path.read_text())
     rows = payload["rows"]
@@ -132,10 +139,10 @@ def write_to_target(target_class: str, path: Path, dry_run: bool) -> tuple[int, 
     return (ok, fail)
 
 
-def verify(source_class: str, target_class: str, path: Path, filter_tag: str) -> bool:
+def verify(source_class: str, target_class: str, path: Path) -> bool:
     log.info("STEP 3 verify: source=%s target=%s snapshot=%s", source_class, target_class, path)
     if not path.exists():
-        log.error("snapshot file missing: %s", path)
+        log.error(_ERR_SNAPSHOT_MISSING, path)
         return False
     payload = json.loads(path.read_text())
     expected = len(payload["rows"])
@@ -153,9 +160,10 @@ def verify(source_class: str, target_class: str, path: Path, filter_tag: str) ->
         tgt_id = deterministic_uuid(UUID_SOURCE_TAG, src_id)
         try:
             with _http_request("GET", f"/v1/objects/{target_class}/{tgt_id}"):
+                # Existence-only probe — response body is irrelevant; HTTP 404 raises.
                 pass
-        except urlerror.HTTPError as exc:
-            log.error("verify: sample-read fail src=%s tgt=%s rc=%s", src_id, tgt_id, exc.code)
+        except urlerror.HTTPError:
+            log.exception("verify: sample-read fail src=%s tgt=%s", src_id, tgt_id)
             return False
     log.info(
         "verify OK: source-snapshot=%d target-aggregate=%d sample_parity=%d",
@@ -174,7 +182,23 @@ def _set_by_dotted_key(obj: dict, key_path: str, value: Any) -> None:
     cur[parts[-1]] = value
 
 
-def repoint(manifest_path: Path, target_class: str, dry_run: bool) -> int:
+def _safe_resolve(path: Path, root: Path) -> Path:
+    # Confine manifest-controlled paths to `root` (default REPO_ROOT) so a
+    # hostile manifest entry like {"file": "/etc/passwd"} cannot trigger an
+    # arbitrary-file overwrite. Closes pythonsecurity:S2083 BLOCKER ×2.
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    if resolved != root_resolved and root_resolved not in resolved.parents:
+        raise ValueError(f"manifest path escapes confinement root: {path} (root={root})")
+    return resolved
+
+
+def repoint(
+    manifest_path: Path,
+    target_class: str,
+    dry_run: bool,
+    confine_root: Path | None = None,
+) -> int:
     log.info("STEP 4 repoint: manifest=%s target=%s", manifest_path, target_class)
     if not manifest_path.exists():
         log.warning(
@@ -182,11 +206,16 @@ def repoint(manifest_path: Path, target_class: str, dry_run: bool) -> int:
             manifest_path,
         )
         return 0
+    root = confine_root if confine_root is not None else _REPOINT_ROOT
     manifest = json.loads(manifest_path.read_text())
     edits = manifest.get("edits", [])
     applied = 0
     for edit in edits:
-        target_file = Path(edit["file"])
+        try:
+            target_file = _safe_resolve(Path(edit["file"]), root)
+        except ValueError as exc:
+            log.error("repoint: rejected path-escape %s — %s", edit.get("file"), exc)
+            continue
         key_path = edit["key_path"]
         if not target_file.exists():
             log.warning("repoint: file missing %s — skipping", target_file)
@@ -228,7 +257,7 @@ def purge_old(source_class: str, path: Path, dry_run: bool) -> tuple[int, int]:
         if dry_run:
             log.info("dry-run: snapshot file missing — would delete rows once step 1 produces it")
             return (0, 0)
-        log.error("snapshot file missing: %s", path)
+        log.error(_ERR_SNAPSHOT_MISSING, path)
         raise FileNotFoundError(str(path))
     payload = json.loads(path.read_text())
     rows = payload["rows"]
@@ -284,12 +313,13 @@ def main() -> int:
         )
     if args.step in ("write", "all"):
         write_to_target(args.target_class, args.snapshot_path, args.dry_run)
-    if args.step in ("verify", "all"):
-        if not args.dry_run and not verify(
-            args.source_class, args.target_class, args.snapshot_path, args.filter_tag
-        ):
-            log.error("verify FAILED — aborting")
-            return 1
+    if (
+        args.step in ("verify", "all")
+        and not args.dry_run
+        and not verify(args.source_class, args.target_class, args.snapshot_path)
+    ):
+        log.error("verify FAILED — aborting")
+        return 1
     if args.step in ("repoint", "all") and args.repoint_manifest:
         repoint(args.repoint_manifest, args.target_class, args.dry_run)
     if args.step == "purge" or (args.step == "all" and args.purge_old):

--- a/scripts/migration/weaviate_cutover.py
+++ b/scripts/migration/weaviate_cutover.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -183,25 +184,21 @@ def _set_by_dotted_key(obj: dict, key_path: str, value: Any) -> None:
 
 
 def _safe_resolve(raw: str, root: Path) -> Path:
-    # Validate the raw user-controlled string BEFORE any pathlib construction
-    # so Sonar's S2083 taint tracker sees sanitisation at the string boundary
-    # (taking a Path arg here would still flag the upstream Path(raw) site).
-    # Three string-level rejections, then a composed-path confinement check.
+    # Defense in depth — string-level rejections first (cheap, fail fast on
+    # obvious-bad input), then the stdlib `os.path.realpath` + `commonpath`
+    # confinement check (which Sonar S2083 recognises as a sanitisation sink,
+    # so call sites do not need NOSONAR annotations).
     if not isinstance(raw, str) or not raw:
         raise ValueError(f"manifest path must be non-empty string: {raw!r}")
     if "\x00" in raw or "\n" in raw or "\r" in raw:
         raise ValueError(f"manifest path contains control characters: {raw!r}")
     if raw.startswith("~"):
         raise ValueError(f"manifest path home-expansion forbidden: {raw!r}")
-    # Compose only AFTER string validation. Absolute inputs are allowed iff
-    # they resolve inside root (tests use tmp_path, an absolute confinement).
-    root_resolved = root.resolve()
-    candidate = Path(raw)
-    composed = candidate if candidate.is_absolute() else root_resolved / candidate
-    resolved = composed.resolve()
-    if resolved != root_resolved and root_resolved not in resolved.parents:
-        raise ValueError(f"manifest path escapes confinement root: {raw} (root={root})")
-    return resolved
+    safe_root = os.path.realpath(str(root))
+    candidate = os.path.realpath(os.path.join(safe_root, raw))
+    if os.path.commonpath([candidate, safe_root]) != safe_root:
+        raise ValueError(f"manifest path escapes confinement root: {raw!r} (root={root})")
+    return Path(candidate)
 
 
 def repoint(
@@ -243,15 +240,7 @@ def repoint(
             )
             continue
         backup = target_file.with_suffix(target_file.suffix + ".cutover-backup")
-        # NOSONAR S2083 — `target_file` is the return value of _safe_resolve(raw_file, root),
-        # which validates the raw manifest string against four string-level rejections
-        # (non-empty, no control chars, no home-expansion, no absolute-or-relative
-        # path that resolves outside the confinement root) BEFORE constructing any
-        # Path. Sonar's taint tracker cannot follow custom validators; safety is
-        # locked by negative-path tests (test_safe_resolve_rejects_* ×5 +
-        # test_repoint_rejects_path_escape_attempt). Same rationale applies to the
-        # write_text call below.
-        backup.write_text(original)  # NOSONAR S2083
+        backup.write_text(original)
         data = json.loads(original) if target_file.suffix == ".json" else None
         if data is None:
             log.error(
@@ -259,7 +248,7 @@ def repoint(
             )
             continue
         _set_by_dotted_key(data, key_path, target_class)
-        target_file.write_text(json.dumps(data, indent=2))  # NOSONAR S2083
+        target_file.write_text(json.dumps(data, indent=2))
         applied += 1
         log.info(
             "repoint applied: %s %s -> %s (backup at %s)",

--- a/scripts/migration/weaviate_cutover.py
+++ b/scripts/migration/weaviate_cutover.py
@@ -243,7 +243,15 @@ def repoint(
             )
             continue
         backup = target_file.with_suffix(target_file.suffix + ".cutover-backup")
-        backup.write_text(original)
+        # NOSONAR S2083 — `target_file` is the return value of _safe_resolve(raw_file, root),
+        # which validates the raw manifest string against four string-level rejections
+        # (non-empty, no control chars, no home-expansion, no absolute-or-relative
+        # path that resolves outside the confinement root) BEFORE constructing any
+        # Path. Sonar's taint tracker cannot follow custom validators; safety is
+        # locked by negative-path tests (test_safe_resolve_rejects_* ×5 +
+        # test_repoint_rejects_path_escape_attempt). Same rationale applies to the
+        # write_text call below.
+        backup.write_text(original)  # NOSONAR S2083
         data = json.loads(original) if target_file.suffix == ".json" else None
         if data is None:
             log.error(
@@ -251,7 +259,7 @@ def repoint(
             )
             continue
         _set_by_dotted_key(data, key_path, target_class)
-        target_file.write_text(json.dumps(data, indent=2))
+        target_file.write_text(json.dumps(data, indent=2))  # NOSONAR S2083
         applied += 1
         log.info(
             "repoint applied: %s %s -> %s (backup at %s)",

--- a/scripts/migration/weaviate_cutover.py
+++ b/scripts/migration/weaviate_cutover.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""weaviate_cutover.py — five-step cutover from current Weaviate collection to keiracom-product.
+
+Phase 1.2.5 artefact 4. Authored ahead of Phase 2.0 execution: when the product
+repo creates the new `keiracom-product` collection, this script moves product-
+relevant entries across with per-step verification and no flag-day.
+
+Five steps (each independently runnable + rollback-able):
+  (1) snapshot — read product-tagged objects from source class to a JSON file.
+  (2) write    — upsert snapshotted objects into target class via deterministic UUID.
+  (3) verify   — count match + sample-read parity; HARD-REQUIRED, exits non-zero on mismatch.
+  (4) repoint  — apply a manifest of (file, key_path, new_value) edits with backup.
+  (5) purge    — delete snapshotted objects from source. Opt-in via --purge-old (default OFF).
+
+Design principles:
+  - No flag-day. Each step gated on its own verify and independently rollback-able.
+  - Step (1) is idempotent — re-running overwrites the snapshot atomically; consumers
+    of step (2) see consistent input.
+  - Step (3) is HARD-REQUIRED — calling --step verify with count mismatch exits 1.
+  - --dry-run flag plans every step without mutation.
+  - Logging at every step boundary.
+
+The actual product agent config files do not exist yet (Phase 2.0). Step (4) takes
+a manifest file so the path-list can be filled in once Phase 2.0 lands; the script
+itself is template-complete now.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib import error as urlerror
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "orchestrator"))
+from indexer_base import (  # noqa: E402
+    WEAVIATE_BASE,
+    _http_request,
+    aggregate_count,
+    deterministic_uuid,
+    post_object,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [cutover] %(message)s")
+log = logging.getLogger("weaviate_cutover")
+
+DEFAULT_SOURCE_CLASS = "Decisions"
+DEFAULT_TARGET_CLASS = "Keiracom_Product"
+DEFAULT_FILTER_TAG = "product"
+DEFAULT_SNAPSHOT_PATH = Path("/tmp/weaviate_cutover_snapshot.json")
+DEFAULT_BATCH_SIZE = 100
+SAMPLE_PARITY_N = 5
+UUID_SOURCE_TAG = "cutover_to_keiracom_product"
+
+
+def _fetch_objects(class_name: str, filter_tag: str, batch_size: int) -> list[dict[str, Any]]:
+    # Pull objects from `class_name` whose `context_tag` field equals filter_tag.
+    # GraphQL Get with a where clause; pagination via offset until empty page.
+    out: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        query = {
+            "query": (
+                f"{{Get{{{class_name}("
+                f"limit: {batch_size}, offset: {offset}, "
+                f'where: {{path: ["context_tag"], operator: Equal, valueString: "{filter_tag}"}}'
+                f"){{_additional{{id}} content context_tag created_at}}}}}}"
+            )
+        }
+        try:
+            with _http_request("POST", "/v1/graphql", query) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+        except (urlerror.URLError, OSError) as exc:
+            log.error("graphql fetch failed at offset=%d: %s", offset, exc)
+            raise
+        rows = body.get("data", {}).get("Get", {}).get(class_name, []) or []
+        if not rows:
+            break
+        out.extend(rows)
+        if len(rows) < batch_size:
+            break
+        offset += batch_size
+    return out
+
+
+def snapshot(source_class: str, filter_tag: str, path: Path, batch_size: int, dry_run: bool) -> int:
+    log.info("STEP 1 snapshot: source=%s filter=%s path=%s", source_class, filter_tag, path)
+    if dry_run:
+        log.info("dry-run: would fetch product-tagged rows; no write")
+        return 0
+    rows = _fetch_objects(source_class, filter_tag, batch_size)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps({"source_class": source_class, "filter_tag": filter_tag, "rows": rows}, indent=2)
+    )
+    tmp.replace(path)  # atomic swap — idempotent re-run produces same end state
+    log.info("snapshot wrote %d rows to %s", len(rows), path)
+    return len(rows)
+
+
+def write_to_target(target_class: str, path: Path, dry_run: bool) -> tuple[int, int]:
+    log.info("STEP 2 write: target=%s snapshot=%s", target_class, path)
+    if not path.exists():
+        if dry_run:
+            log.info("dry-run: snapshot file missing — would upsert rows once step 1 produces it")
+            return (0, 0)
+        log.error("snapshot file missing: %s", path)
+        raise FileNotFoundError(str(path))
+    payload = json.loads(path.read_text())
+    rows = payload["rows"]
+    if dry_run:
+        log.info("dry-run: would upsert %d rows to %s; no POST", len(rows), target_class)
+        return (len(rows), 0)
+    ok = fail = 0
+    for row in rows:
+        source_id = row.get("_additional", {}).get("id", "")
+        obj = {
+            "class": target_class,
+            "id": deterministic_uuid(UUID_SOURCE_TAG, source_id),
+            "properties": {k: v for k, v in row.items() if k != "_additional"},
+        }
+        if post_object(obj):
+            ok += 1
+        else:
+            fail += 1
+    log.info("write_to_target: ok=%d fail=%d", ok, fail)
+    return (ok, fail)
+
+
+def verify(source_class: str, target_class: str, path: Path, filter_tag: str) -> bool:
+    log.info("STEP 3 verify: source=%s target=%s snapshot=%s", source_class, target_class, path)
+    if not path.exists():
+        log.error("snapshot file missing: %s", path)
+        return False
+    payload = json.loads(path.read_text())
+    expected = len(payload["rows"])
+    actual = aggregate_count(target_class)
+    if actual is None:
+        log.error("verify: aggregate_count returned None for %s", target_class)
+        return False
+    if actual < expected:
+        log.error("verify: count mismatch — expected>=%d, got %d", expected, actual)
+        return False
+    # Sample parity: re-fetch N source rows by id and confirm corresponding target id exists
+    sample = payload["rows"][:SAMPLE_PARITY_N]
+    for row in sample:
+        src_id = row.get("_additional", {}).get("id", "")
+        tgt_id = deterministic_uuid(UUID_SOURCE_TAG, src_id)
+        try:
+            with _http_request("GET", f"/v1/objects/{target_class}/{tgt_id}"):
+                pass
+        except urlerror.HTTPError as exc:
+            log.error("verify: sample-read fail src=%s tgt=%s rc=%s", src_id, tgt_id, exc.code)
+            return False
+    log.info(
+        "verify OK: source-snapshot=%d target-aggregate=%d sample_parity=%d",
+        expected,
+        actual,
+        len(sample),
+    )
+    return True
+
+
+def _set_by_dotted_key(obj: dict, key_path: str, value: Any) -> None:
+    parts = key_path.split(".")
+    cur: Any = obj
+    for p in parts[:-1]:
+        cur = cur[p]
+    cur[parts[-1]] = value
+
+
+def repoint(manifest_path: Path, target_class: str, dry_run: bool) -> int:
+    log.info("STEP 4 repoint: manifest=%s target=%s", manifest_path, target_class)
+    if not manifest_path.exists():
+        log.warning(
+            "repoint manifest missing: %s — emitting empty plan (Phase 2.0 fills this)",
+            manifest_path,
+        )
+        return 0
+    manifest = json.loads(manifest_path.read_text())
+    edits = manifest.get("edits", [])
+    applied = 0
+    for edit in edits:
+        target_file = Path(edit["file"])
+        key_path = edit["key_path"]
+        if not target_file.exists():
+            log.warning("repoint: file missing %s — skipping", target_file)
+            continue
+        original = target_file.read_text()
+        if dry_run:
+            log.info(
+                "dry-run: would set %s.%s = %s in %s",
+                target_file,
+                key_path,
+                target_class,
+                target_file,
+            )
+            continue
+        backup = target_file.with_suffix(target_file.suffix + ".cutover-backup")
+        backup.write_text(original)
+        data = json.loads(original) if target_file.suffix == ".json" else None
+        if data is None:
+            log.error(
+                "repoint: unsupported config format %s (only .json in V1)", target_file.suffix
+            )
+            continue
+        _set_by_dotted_key(data, key_path, target_class)
+        target_file.write_text(json.dumps(data, indent=2))
+        applied += 1
+        log.info(
+            "repoint applied: %s %s -> %s (backup at %s)",
+            target_file,
+            key_path,
+            target_class,
+            backup,
+        )
+    return applied
+
+
+def purge_old(source_class: str, path: Path, dry_run: bool) -> tuple[int, int]:
+    log.info("STEP 5 purge: source=%s snapshot=%s (opt-in)", source_class, path)
+    if not path.exists():
+        if dry_run:
+            log.info("dry-run: snapshot file missing — would delete rows once step 1 produces it")
+            return (0, 0)
+        log.error("snapshot file missing: %s", path)
+        raise FileNotFoundError(str(path))
+    payload = json.loads(path.read_text())
+    rows = payload["rows"]
+    if dry_run:
+        log.info("dry-run: would delete %d rows from %s; no DELETE", len(rows), source_class)
+        return (len(rows), 0)
+    ok = fail = 0
+    for row in rows:
+        src_id = row.get("_additional", {}).get("id", "")
+        try:
+            with _http_request("DELETE", f"/v1/objects/{source_class}/{src_id}"):
+                ok += 1
+        except urlerror.HTTPError as exc:
+            log.warning("purge: src=%s rc=%s", src_id, exc.code)
+            fail += 1
+        except OSError as exc:
+            log.warning("purge: src=%s transient %s", src_id, exc)
+            fail += 1
+    log.info("purge: ok=%d fail=%d", ok, fail)
+    return (ok, fail)
+
+
+def _cli_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Weaviate cutover — current source -> keiracom-product")
+    p.add_argument("--source-class", default=DEFAULT_SOURCE_CLASS)
+    p.add_argument("--target-class", default=DEFAULT_TARGET_CLASS)
+    p.add_argument("--filter-tag", default=DEFAULT_FILTER_TAG)
+    p.add_argument("--snapshot-path", type=Path, default=DEFAULT_SNAPSHOT_PATH)
+    p.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    p.add_argument("--repoint-manifest", type=Path, default=None)
+    p.add_argument("--purge-old", action="store_true", help="Run step 5 (default off)")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument(
+        "--step",
+        choices=["snapshot", "write", "verify", "repoint", "purge", "all"],
+        default="all",
+    )
+    return p
+
+
+def main() -> int:
+    args = _cli_parser().parse_args()
+    log.info(
+        "weaviate_cutover start | WEAVIATE_BASE=%s | step=%s | dry_run=%s",
+        WEAVIATE_BASE,
+        args.step,
+        args.dry_run,
+    )
+    t0 = time.time()
+    if args.step in ("snapshot", "all"):
+        snapshot(
+            args.source_class, args.filter_tag, args.snapshot_path, args.batch_size, args.dry_run
+        )
+    if args.step in ("write", "all"):
+        write_to_target(args.target_class, args.snapshot_path, args.dry_run)
+    if args.step in ("verify", "all"):
+        if not args.dry_run and not verify(
+            args.source_class, args.target_class, args.snapshot_path, args.filter_tag
+        ):
+            log.error("verify FAILED — aborting")
+            return 1
+    if args.step in ("repoint", "all") and args.repoint_manifest:
+        repoint(args.repoint_manifest, args.target_class, args.dry_run)
+    if args.step == "purge" or (args.step == "all" and args.purge_old):
+        purge_old(args.source_class, args.snapshot_path, args.dry_run)
+    log.info("cutover done in %.2fs", time.time() - t0)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migration/weaviate_cutover.py
+++ b/scripts/migration/weaviate_cutover.py
@@ -186,8 +186,7 @@ def _set_by_dotted_key(obj: dict, key_path: str, value: Any) -> None:
 def _safe_resolve(raw: str, root: Path) -> Path:
     # Defense in depth — string-level rejections first (cheap, fail fast on
     # obvious-bad input), then the stdlib `os.path.realpath` + `commonpath`
-    # confinement check (which Sonar S2083 recognises as a sanitisation sink,
-    # so call sites do not need NOSONAR annotations).
+    # confinement check (the canonical Python idiom for path-injection guards).
     if not isinstance(raw, str) or not raw:
         raise ValueError(f"manifest path must be non-empty string: {raw!r}")
     if "\x00" in raw or "\n" in raw or "\r" in raw:
@@ -240,7 +239,7 @@ def repoint(
             )
             continue
         backup = target_file.with_suffix(target_file.suffix + ".cutover-backup")
-        backup.write_text(original)
+        backup.write_text(original)  # NOSONAR S2083 — sanitised by _safe_resolve commonpath
         data = json.loads(original) if target_file.suffix == ".json" else None
         if data is None:
             log.error(
@@ -248,7 +247,9 @@ def repoint(
             )
             continue
         _set_by_dotted_key(data, key_path, target_class)
-        target_file.write_text(json.dumps(data, indent=2))
+        target_file.write_text(
+            json.dumps(data, indent=2)
+        )  # NOSONAR S2083 — sanitised by _safe_resolve commonpath
         applied += 1
         log.info(
             "repoint applied: %s %s -> %s (backup at %s)",

--- a/tests/scripts/migration/test_weaviate_cutover.py
+++ b/tests/scripts/migration/test_weaviate_cutover.py
@@ -1,0 +1,231 @@
+"""tests for scripts/migration/weaviate_cutover.py — Phase 1.2.5 artefact 4.
+
+Coverage:
+- snapshot idempotency (rerun → same end state)
+- write_to_target deterministic UUID derivation
+- verify hard-required: count mismatch + sample-read miss both return False
+- repoint apply + backup + dry-run
+- purge_old opt-in semantics
+- dry-run is read-only (no Weaviate POST/DELETE)
+
+Weaviate is mocked end-to-end — no live broker required for the suite.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "migration" / "weaviate_cutover.py"
+
+
+@pytest.fixture
+def mod():
+    spec = importlib.util.spec_from_file_location("weaviate_cutover", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["weaviate_cutover"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def _sample_rows(n: int) -> list[dict]:
+    return [
+        {
+            "_additional": {"id": f"src-{i:04d}"},
+            "content": f"row {i}",
+            "context_tag": "product",
+            "created_at": "2026-05-24T00:00:00Z",
+        }
+        for i in range(n)
+    ]
+
+
+def test_snapshot_idempotent(mod, monkeypatch, tmp_path):
+    """Re-running snapshot with the same source produces the same file content."""
+    rows = _sample_rows(3)
+    monkeypatch.setattr(mod, "_fetch_objects", lambda *a, **kw: rows)
+    out = tmp_path / "snap.json"
+
+    n1 = mod.snapshot("Decisions", "product", out, 100, dry_run=False)
+    body1 = out.read_text()
+    n2 = mod.snapshot("Decisions", "product", out, 100, dry_run=False)
+    body2 = out.read_text()
+
+    assert n1 == n2 == 3
+    assert body1 == body2, "idempotent re-run must produce identical snapshot content"
+
+
+def test_snapshot_dry_run_writes_nothing(mod, monkeypatch, tmp_path):
+    """Dry-run does NOT call _fetch_objects and does NOT create the file."""
+    called = []
+    monkeypatch.setattr(mod, "_fetch_objects", lambda *a, **kw: called.append(1) or [])
+    out = tmp_path / "snap.json"
+
+    mod.snapshot("Decisions", "product", out, 100, dry_run=True)
+
+    assert called == [], "dry-run must not call _fetch_objects"
+    assert not out.exists(), "dry-run must not create snapshot file"
+
+
+def test_write_to_target_uses_deterministic_uuid(mod, monkeypatch, tmp_path):
+    """Each row gets a UUID derived from cutover-tag + source id (cross-run stable)."""
+    rows = _sample_rows(2)
+    snap = tmp_path / "snap.json"
+    snap.write_text(
+        json.dumps({"source_class": "Decisions", "filter_tag": "product", "rows": rows})
+    )
+    posted: list[dict] = []
+    monkeypatch.setattr(mod, "post_object", lambda obj: posted.append(obj) or True)
+
+    ok, fail = mod.write_to_target("Keiracom_Product", snap, dry_run=False)
+
+    assert (ok, fail) == (2, 0)
+    expected_id_0 = mod.deterministic_uuid(mod.UUID_SOURCE_TAG, "src-0000")
+    expected_id_1 = mod.deterministic_uuid(mod.UUID_SOURCE_TAG, "src-0001")
+    assert posted[0]["id"] == expected_id_0
+    assert posted[1]["id"] == expected_id_1
+    assert posted[0]["class"] == "Keiracom_Product"
+    assert "_additional" not in posted[0]["properties"], (
+        "internal _additional must not leak to target"
+    )
+
+
+def test_write_to_target_dry_run_no_posts(mod, monkeypatch, tmp_path):
+    """Dry-run never calls post_object."""
+    rows = _sample_rows(5)
+    snap = tmp_path / "snap.json"
+    snap.write_text(
+        json.dumps({"source_class": "Decisions", "filter_tag": "product", "rows": rows})
+    )
+    monkeypatch.setattr(
+        mod, "post_object", lambda obj: pytest.fail("post_object must not be called in dry-run")
+    )
+
+    ok, fail = mod.write_to_target("Keiracom_Product", snap, dry_run=True)
+
+    assert (ok, fail) == (5, 0), "dry-run reports planned count without posting"
+
+
+def test_verify_count_mismatch_returns_false(mod, monkeypatch, tmp_path):
+    """Hard-required gate: count short of snapshot returns False."""
+    rows = _sample_rows(10)
+    snap = tmp_path / "snap.json"
+    snap.write_text(
+        json.dumps({"source_class": "Decisions", "filter_tag": "product", "rows": rows})
+    )
+    monkeypatch.setattr(mod, "aggregate_count", lambda c: 7)  # less than 10
+
+    assert mod.verify("Decisions", "Keiracom_Product", snap, "product") is False
+
+
+def test_verify_aggregate_none_returns_false(mod, monkeypatch, tmp_path):
+    """If aggregate_count cannot reach the broker, treat as verify fail (not pass)."""
+    rows = _sample_rows(3)
+    snap = tmp_path / "snap.json"
+    snap.write_text(
+        json.dumps({"source_class": "Decisions", "filter_tag": "product", "rows": rows})
+    )
+    monkeypatch.setattr(mod, "aggregate_count", lambda c: None)
+
+    assert mod.verify("Decisions", "Keiracom_Product", snap, "product") is False
+
+
+def test_verify_ok_when_count_and_samples_match(mod, monkeypatch, tmp_path):
+    """Happy path — count >= expected AND every sample tgt_id exists in target."""
+    rows = _sample_rows(3)
+    snap = tmp_path / "snap.json"
+    snap.write_text(
+        json.dumps({"source_class": "Decisions", "filter_tag": "product", "rows": rows})
+    )
+    monkeypatch.setattr(mod, "aggregate_count", lambda c: 3)
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    monkeypatch.setattr(mod, "_http_request", lambda *a, **kw: _Resp())
+    assert mod.verify("Decisions", "Keiracom_Product", snap, "product") is True
+
+
+def test_repoint_applies_edits_with_backup(mod, tmp_path):
+    """Repoint writes target with new value AND leaves a .cutover-backup of the original."""
+    config = tmp_path / "agent.json"
+    original = {"memory": {"collection": "Decisions"}, "other": "unchanged"}
+    config.write_text(json.dumps(original))
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"edits": [{"file": str(config), "key_path": "memory.collection"}]})
+    )
+
+    applied = mod.repoint(manifest, "Keiracom_Product", dry_run=False)
+
+    assert applied == 1
+    written = json.loads(config.read_text())
+    assert written["memory"]["collection"] == "Keiracom_Product"
+    assert written["other"] == "unchanged"
+    backup = config.with_suffix(config.suffix + ".cutover-backup")
+    assert backup.exists()
+    assert json.loads(backup.read_text()) == original
+
+
+def test_repoint_dry_run_writes_nothing(mod, tmp_path):
+    """Dry-run leaves the config + filesystem untouched (no backup, no edit)."""
+    config = tmp_path / "agent.json"
+    original = {"memory": {"collection": "Decisions"}}
+    config.write_text(json.dumps(original))
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"edits": [{"file": str(config), "key_path": "memory.collection"}]})
+    )
+
+    mod.repoint(manifest, "Keiracom_Product", dry_run=True)
+
+    assert json.loads(config.read_text()) == original, "dry-run must not mutate target file"
+    assert not config.with_suffix(config.suffix + ".cutover-backup").exists()
+
+
+def test_repoint_missing_manifest_emits_empty_plan(mod, tmp_path, caplog):
+    """No manifest file = 0 edits applied with a warning, not a crash."""
+    missing = tmp_path / "no-such-manifest.json"
+    applied = mod.repoint(missing, "Keiracom_Product", dry_run=False)
+    assert applied == 0
+
+
+def test_purge_old_opt_in_only(mod, monkeypatch, tmp_path):
+    """Step 5 honours snapshot-driven delete; dry-run never calls DELETE."""
+    rows = _sample_rows(4)
+    snap = tmp_path / "snap.json"
+    snap.write_text(
+        json.dumps({"source_class": "Decisions", "filter_tag": "product", "rows": rows})
+    )
+    called: list[tuple] = []
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def _track_http(method, path, body=None):
+        called.append((method, path))
+        return _Resp()
+
+    monkeypatch.setattr(mod, "_http_request", _track_http)
+
+    ok_dry, fail_dry = mod.purge_old("Decisions", snap, dry_run=True)
+    assert (ok_dry, fail_dry) == (4, 0)
+    assert called == [], "dry-run must not call _http_request"
+
+    ok, fail = mod.purge_old("Decisions", snap, dry_run=False)
+    assert (ok, fail) == (4, 0)
+    assert len(called) == 4
+    assert all(m == "DELETE" for m, _ in called)

--- a/tests/scripts/migration/test_weaviate_cutover.py
+++ b/tests/scripts/migration/test_weaviate_cutover.py
@@ -85,6 +85,7 @@ def test_write_to_target_uses_deterministic_uuid(mod, monkeypatch, tmp_path):
     ok, fail = mod.write_to_target("Keiracom_Product", snap, dry_run=False)
 
     assert (ok, fail) == (2, 0)
+    assert len(posted) >= 2, "post_object must have been called once per row"
     expected_id_0 = mod.deterministic_uuid(mod.UUID_SOURCE_TAG, "src-0000")
     expected_id_1 = mod.deterministic_uuid(mod.UUID_SOURCE_TAG, "src-0001")
     assert posted[0]["id"] == expected_id_0
@@ -120,7 +121,7 @@ def test_verify_count_mismatch_returns_false(mod, monkeypatch, tmp_path):
     )
     monkeypatch.setattr(mod, "aggregate_count", lambda c: 7)  # less than 10
 
-    assert mod.verify("Decisions", "Keiracom_Product", snap, "product") is False
+    assert mod.verify("Decisions", "Keiracom_Product", snap) is False
 
 
 def test_verify_aggregate_none_returns_false(mod, monkeypatch, tmp_path):
@@ -132,7 +133,7 @@ def test_verify_aggregate_none_returns_false(mod, monkeypatch, tmp_path):
     )
     monkeypatch.setattr(mod, "aggregate_count", lambda c: None)
 
-    assert mod.verify("Decisions", "Keiracom_Product", snap, "product") is False
+    assert mod.verify("Decisions", "Keiracom_Product", snap) is False
 
 
 def test_verify_ok_when_count_and_samples_match(mod, monkeypatch, tmp_path):
@@ -149,10 +150,10 @@ def test_verify_ok_when_count_and_samples_match(mod, monkeypatch, tmp_path):
             return self
 
         def __exit__(self, *a):
-            pass
+            return None  # protocol-only fake; no cleanup needed
 
     monkeypatch.setattr(mod, "_http_request", lambda *a, **kw: _Resp())
-    assert mod.verify("Decisions", "Keiracom_Product", snap, "product") is True
+    assert mod.verify("Decisions", "Keiracom_Product", snap) is True
 
 
 def test_repoint_applies_edits_with_backup(mod, tmp_path):
@@ -165,7 +166,7 @@ def test_repoint_applies_edits_with_backup(mod, tmp_path):
         json.dumps({"edits": [{"file": str(config), "key_path": "memory.collection"}]})
     )
 
-    applied = mod.repoint(manifest, "Keiracom_Product", dry_run=False)
+    applied = mod.repoint(manifest, "Keiracom_Product", dry_run=False, confine_root=tmp_path)
 
     assert applied == 1
     written = json.loads(config.read_text())
@@ -186,7 +187,7 @@ def test_repoint_dry_run_writes_nothing(mod, tmp_path):
         json.dumps({"edits": [{"file": str(config), "key_path": "memory.collection"}]})
     )
 
-    mod.repoint(manifest, "Keiracom_Product", dry_run=True)
+    mod.repoint(manifest, "Keiracom_Product", dry_run=True, confine_root=tmp_path)
 
     assert json.loads(config.read_text()) == original, "dry-run must not mutate target file"
     assert not config.with_suffix(config.suffix + ".cutover-backup").exists()
@@ -197,6 +198,48 @@ def test_repoint_missing_manifest_emits_empty_plan(mod, tmp_path, caplog):
     missing = tmp_path / "no-such-manifest.json"
     applied = mod.repoint(missing, "Keiracom_Product", dry_run=False)
     assert applied == 0
+
+
+def test_repoint_rejects_path_escape_attempt(mod, tmp_path):
+    """Negative-path lock for S2083 — manifest paths outside confine_root MUST
+    be rejected (no read, no backup, no write). Anchored 2026-05-24 by Max's
+    BLOCKER review on PR #1119: a hostile manifest with `{"file": "/etc/passwd"}`
+    must not trigger an arbitrary-file overwrite."""
+    safe_target = tmp_path / "agent.json"
+    safe_target.write_text(json.dumps({"memory": {"collection": "Decisions"}}))
+    escape_target = "/etc/passwd"  # absolute path, outside tmp_path confinement
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "edits": [
+                    {"file": escape_target, "key_path": "memory.collection"},
+                    {"file": str(safe_target), "key_path": "memory.collection"},
+                ]
+            }
+        )
+    )
+
+    applied = mod.repoint(manifest, "Keiracom_Product", dry_run=False, confine_root=tmp_path)
+
+    # Escape entry skipped; safe entry applied — partial-progress on per-edit basis.
+    assert applied == 1
+    # Confirm the escape target was not even read (no backup written there).
+    assert not Path("/etc/passwd.cutover-backup").exists()
+
+
+def test_safe_resolve_accepts_in_root_paths(mod, tmp_path):
+    """Happy path — paths inside the confine root resolve cleanly."""
+    inside = tmp_path / "agent.json"
+    inside.touch()
+    resolved = mod._safe_resolve(inside, tmp_path)
+    assert resolved == inside.resolve()
+
+
+def test_safe_resolve_rejects_escape_paths(mod, tmp_path):
+    """Negative-path lock — explicit escape rejection."""
+    with pytest.raises(ValueError, match="escapes confinement root"):
+        mod._safe_resolve(Path("/etc/passwd"), tmp_path)
 
 
 def test_purge_old_opt_in_only(mod, monkeypatch, tmp_path):
@@ -213,7 +256,7 @@ def test_purge_old_opt_in_only(mod, monkeypatch, tmp_path):
             return self
 
         def __exit__(self, *a):
-            pass
+            return None  # protocol-only fake; no cleanup needed
 
     def _track_http(method, path, body=None):
         called.append((method, path))

--- a/tests/scripts/migration/test_weaviate_cutover.py
+++ b/tests/scripts/migration/test_weaviate_cutover.py
@@ -229,17 +229,48 @@ def test_repoint_rejects_path_escape_attempt(mod, tmp_path):
 
 
 def test_safe_resolve_accepts_in_root_paths(mod, tmp_path):
-    """Happy path — paths inside the confine root resolve cleanly."""
+    """Happy path — paths inside the confine root resolve cleanly (absolute form)."""
     inside = tmp_path / "agent.json"
     inside.touch()
-    resolved = mod._safe_resolve(inside, tmp_path)
+    resolved = mod._safe_resolve(str(inside), tmp_path)
     assert resolved == inside.resolve()
 
 
+def test_safe_resolve_accepts_relative_paths(mod, tmp_path):
+    """Relative manifest paths compose against confine_root."""
+    (tmp_path / "agent.json").touch()
+    resolved = mod._safe_resolve("agent.json", tmp_path)
+    assert resolved == (tmp_path / "agent.json").resolve()
+
+
 def test_safe_resolve_rejects_escape_paths(mod, tmp_path):
-    """Negative-path lock — explicit escape rejection."""
+    """Negative-path lock — absolute escape rejected."""
     with pytest.raises(ValueError, match="escapes confinement root"):
-        mod._safe_resolve(Path("/etc/passwd"), tmp_path)
+        mod._safe_resolve("/etc/passwd", tmp_path)
+
+
+def test_safe_resolve_rejects_dotdot_traversal(mod, tmp_path):
+    """Negative-path lock — relative ../../etc/passwd resolves outside root → reject."""
+    with pytest.raises(ValueError, match="escapes confinement root"):
+        mod._safe_resolve("../../etc/passwd", tmp_path)
+
+
+def test_safe_resolve_rejects_empty_string(mod, tmp_path):
+    """Negative-path lock — empty string is invalid manifest data."""
+    with pytest.raises(ValueError, match="non-empty string"):
+        mod._safe_resolve("", tmp_path)
+
+
+def test_safe_resolve_rejects_null_byte(mod, tmp_path):
+    """Negative-path lock — embedded null byte (classic path-truncation attack)."""
+    with pytest.raises(ValueError, match="control characters"):
+        mod._safe_resolve("agent.json\x00.bak", tmp_path)
+
+
+def test_safe_resolve_rejects_home_expansion(mod, tmp_path):
+    """Negative-path lock — `~` would be Path.expanduser-ambiguous, reject upfront."""
+    with pytest.raises(ValueError, match="home-expansion"):
+        mod._safe_resolve("~/secrets", tmp_path)
 
 
 def test_purge_old_opt_in_only(mod, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Phase 1.2.5 bundle artefact 4 (Aiden R6/G9). Authored ahead of Phase 2.0 product repo creation. Implements the consolidated gate **"Weaviate cutover script with per-step verification; no flag-day"** from `ceo:agency_os_keiracom_separation_v1`.

## Canonical key query gate (per audit-dispatch checklist `_orchestrator.md`)

Both keys queried 2026-05-24 before authoring; verbatim values pasted into the **Notes** section of `docs/migration/weaviate_cutover_plan.md` (the Notes section is the artefact's compliance proof — reviewers cross-check claims against the SSOT).

- `ceo:agency_os_keiracom_separation_v1` (updated 2026-05-24T11:04Z): 3-repo topology, Phase 1.2.5 sequencing, consolidated gates list including this artefact.
- `ceo:memory_abstraction_layer_v1` (updated 2026-05-24T15:12Z): Hindsight as engine, Phase 2 build gates, MCP swappability.

## Deliverables

- `scripts/migration/weaviate_cutover.py` — 5-step cutover (`snapshot → write → verify → repoint → optional purge`)
- `docs/migration/weaviate_cutover_plan.md` — strategy + no-flag-day principle + per-step rollback + operator runbook + Notes section
- `tests/scripts/migration/test_weaviate_cutover.py` — 11 unit tests, Weaviate mocked end-to-end

## Design principles enforced in code

- **No flag-day** — each step is independently invocable via `--step` and reversible (per-step rollback table in plan doc).
- **Idempotent** — Step 1 atomic `tmp.replace`; Step 2 deterministic UUID (`uuid5(UUID_SOURCE_TAG, source_id)`) so re-runs upsert in place.
- **Verify is HARD-REQUIRED** — Step 3 returns False on count mismatch OR aggregate-unreachable OR sample-read miss; main exits 1 on non-dry-run verify fail.
- **Purge is opt-in** — `--purge-old` flag required (default OFF); preserves dual-write fallback window.
- **`--dry-run`** at every step — full 5-step plan walks dry-run clean with zero Weaviate mutation.
- **Logging at every step boundary.**
- Reuses `scripts/orchestrator/indexer_base.py` primitives per LAW VI — no new HTTP/retry plumbing.

## Verification

```
$ ruff check scripts/migration/weaviate_cutover.py tests/scripts/migration/test_weaviate_cutover.py
All checks passed!

$ ruff format --check scripts/migration/weaviate_cutover.py tests/scripts/migration/test_weaviate_cutover.py
2 files already formatted

$ python3 -m pytest tests/scripts/migration/test_weaviate_cutover.py -q
...........                                                              [100%]
11 passed in 0.15s

$ python3 scripts/migration/weaviate_cutover.py --dry-run --step all --purge-old
[walks all 5 steps, zero mutation, exits 0]
```

Test coverage:
- `test_snapshot_idempotent` — rerun → identical content
- `test_snapshot_dry_run_writes_nothing` — dry-run never fetches or writes
- `test_write_to_target_uses_deterministic_uuid` — UUID derivation + `_additional` strip
- `test_write_to_target_dry_run_no_posts` — dry-run never POSTs
- `test_verify_count_mismatch_returns_false` — hard gate (negative path)
- `test_verify_aggregate_none_returns_false` — broker-unreachable is fail, not silent pass
- `test_verify_ok_when_count_and_samples_match` — happy path
- `test_repoint_applies_edits_with_backup` — atomic edit + `.cutover-backup`
- `test_repoint_dry_run_writes_nothing` — dry-run leaves filesystem untouched
- `test_repoint_missing_manifest_emits_empty_plan` — no manifest = 0 edits + warning
- `test_purge_old_opt_in_only` — dry-run never deletes; non-dry-run issues DELETE per row

Integration test against live Weaviate intentionally **omitted** — `keiracom-product` class does not exist yet (Phase 2.0); the integration test belongs in the Phase 2.0 PR that creates the class.

## Test plan
- [ ] Aiden: cross-check artefact claims against the cited canonical keys per audit-dispatch checklist.
- [ ] Aiden (architecture): no-flag-day + per-step rollback + dual-write window narrative.
- [ ] Max (quality): unit-test coverage + negative-path locks + ruff/format.
- [ ] Elliot (impl-feasibility, optional): dry-run CLI behaviour + indexer_base reuse.

Blocks Phase 2.0 repo creation + Weaviate namespace work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)