### PR TITLE
[MAX] feat(migration): Phase 1.2.5 artefact 6 — migrated manifest seed + enforcer + CI gate (Agency_OS-fi4u)

### DIFF
--- a/.github/workflows/migration-manifest-gate.yml
+++ b/.github/workflows/migration-manifest-gate.yml
@@ -1,0 +1,44 @@
+name: Migration Manifest Gate
+
+# Phase 1.2.5 artefact 6 (Agency_OS-fi4u). Enforces the migrated-manifest
+# seed at docs/migration/migrated_manifest_seed.json — schema validity,
+# enumeration discipline (no globs), and path-existence on disk.
+#
+# Mode is INFORMATIONAL-WARNING in Phase 1.2.5 (this PR) — runs on PRs that
+# touch the manifest or P-classified paths, but failures do not block merge
+# yet. Becomes a HARD GATE post-Phase-2.0 carve (toggle by removing
+# `continue-on-error: true` below).
+
+on:
+  pull_request:
+    paths:
+      - "docs/migration/migrated_manifest_seed.json"
+      - "scripts/ci/check_migration_manifest.py"
+      - "src/dispatcher/**"
+      - "src/memory/**"
+      - "mcp-servers/memory-mcp/**"
+      - "tests/dispatcher/**"
+      - "tests/memory/**"
+      - "tests/governance/test_ceo_memory_*"
+      - "tests/integration/test_tenant_isolation.py"
+  push:
+    branches: [main]
+
+jobs:
+  enforce-migration-manifest:
+    name: Migration manifest — schema + path-existence + enumeration discipline
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run migration manifest enforcer
+        # Exit 1 on any schema/path/glob violation. Phase 1.2.5 = warn-only
+        # via continue-on-error; flip to hard-gate post-Phase-2.0 by removing
+        # the continue-on-error line.
+        continue-on-error: true
+        run: |
+          python3 scripts/ci/check_migration_manifest.py --report
+          python3 scripts/ci/check_migration_manifest.py

--- a/docs/migration/migrated_manifest_seed.json
+++ b/docs/migration/migrated_manifest_seed.json
@@ -1,0 +1,490 @@
+{
+  "source_repo": "agency-os (current monorepo)",
+  "manifest_version": "1.0-seed",
+  "generated_at": "2026-05-24T18:00:00Z",
+  "generated_by": "max (Agency_OS-fi4u)",
+  "schema_ref": "docs/architecture/three_repo_carveout_execution.md \u00a76 (PR #1122)",
+  "notes": "Seed manifest \u2014 enumerates P-classified paths from PR #1122 \u00a73.1 + \u00a74 that EXIST on origin/main. Forward-looking placeholders (infra/hindsight/, tenant schemas) excluded \u2014 they will be added when authored.",
+  "entries": [
+    {
+      "source_path": "src/dispatcher/__init__.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/__init__.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/auth_minter.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/auth_minter.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/container_jwt.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/container_jwt.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/container_lifecycle.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/container_lifecycle.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/container_monitor.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/container_monitor.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/governance_proxy.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/governance_proxy.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/heartbeat_reaper.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/heartbeat_reaper.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/heartbeat_watchdog.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/heartbeat_watchdog.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/interceptor_proxy.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/interceptor_proxy.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/main.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/main.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/ratified_hash.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/ratified_hash.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/reaper.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/reaper.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/session_manager.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/session_manager.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/spend_tracker.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/spend_tracker.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/tmux_lifecycle.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/tmux_lifecycle.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/valkey_pool.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/valkey_pool.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/dispatcher/watchdog.py",
+      "target_repo": "product",
+      "target_path": "src/dispatcher/watchdog.py",
+      "operation": "move",
+      "rationale": "V1.0 MCP dispatcher per docs/architecture/three_repo_carveout_execution.md \u00a74.8 (PR #1122)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/memory/__init__.py",
+      "target_repo": "product",
+      "target_path": "src/memory/__init__.py",
+      "operation": "move",
+      "rationale": "Memory Abstraction Layer V1 per docs/architecture/three_repo_carveout_execution.md \u00a74.8 + ceo:memory_abstraction_layer_v1 ratification",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/memory/client.py",
+      "target_repo": "product",
+      "target_path": "src/memory/client.py",
+      "operation": "move",
+      "rationale": "Memory Abstraction Layer V1 per docs/architecture/three_repo_carveout_execution.md \u00a74.8 + ceo:memory_abstraction_layer_v1 ratification",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/memory/environment_hash.py",
+      "target_repo": "product",
+      "target_path": "src/memory/environment_hash.py",
+      "operation": "move",
+      "rationale": "Memory Abstraction Layer V1 per docs/architecture/three_repo_carveout_execution.md \u00a74.8 + ceo:memory_abstraction_layer_v1 ratification",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/memory/organise.py",
+      "target_repo": "product",
+      "target_path": "src/memory/organise.py",
+      "operation": "move",
+      "rationale": "Memory Abstraction Layer V1 per docs/architecture/three_repo_carveout_execution.md \u00a74.8 + ceo:memory_abstraction_layer_v1 ratification",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/memory/ratelimit.py",
+      "target_repo": "product",
+      "target_path": "src/memory/ratelimit.py",
+      "operation": "move",
+      "rationale": "Memory Abstraction Layer V1 per docs/architecture/three_repo_carveout_execution.md \u00a74.8 + ceo:memory_abstraction_layer_v1 ratification",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/memory/recall.py",
+      "target_repo": "product",
+      "target_path": "src/memory/recall.py",
+      "operation": "move",
+      "rationale": "Memory Abstraction Layer V1 per docs/architecture/three_repo_carveout_execution.md \u00a74.8 + ceo:memory_abstraction_layer_v1 ratification",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/memory/retrieve.py",
+      "target_repo": "product",
+      "target_path": "src/memory/retrieve.py",
+      "operation": "move",
+      "rationale": "Memory Abstraction Layer V1 per docs/architecture/three_repo_carveout_execution.md \u00a74.8 + ceo:memory_abstraction_layer_v1 ratification",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/memory/sanitise.py",
+      "target_repo": "product",
+      "target_path": "src/memory/sanitise.py",
+      "operation": "move",
+      "rationale": "Memory Abstraction Layer V1 per docs/architecture/three_repo_carveout_execution.md \u00a74.8 + ceo:memory_abstraction_layer_v1 ratification",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/memory/store.py",
+      "target_repo": "product",
+      "target_path": "src/memory/store.py",
+      "operation": "move",
+      "rationale": "Memory Abstraction Layer V1 per docs/architecture/three_repo_carveout_execution.md \u00a74.8 + ceo:memory_abstraction_layer_v1 ratification",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "src/memory/types.py",
+      "target_repo": "product",
+      "target_path": "src/memory/types.py",
+      "operation": "move",
+      "rationale": "Memory Abstraction Layer V1 per docs/architecture/three_repo_carveout_execution.md \u00a74.8 + ceo:memory_abstraction_layer_v1 ratification",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "mcp-servers/memory-mcp/package-lock.json",
+      "target_repo": "product",
+      "target_path": "mcp-servers/memory-mcp/package-lock.json",
+      "operation": "move",
+      "rationale": "Memory MCP server (Hindsight integration per ceo:memory_abstraction_layer_v1)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "mcp-servers/memory-mcp/package.json",
+      "target_repo": "product",
+      "target_path": "mcp-servers/memory-mcp/package.json",
+      "operation": "move",
+      "rationale": "Memory MCP server (Hindsight integration per ceo:memory_abstraction_layer_v1)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "mcp-servers/memory-mcp/src/index.ts",
+      "target_repo": "product",
+      "target_path": "mcp-servers/memory-mcp/src/index.ts",
+      "operation": "move",
+      "rationale": "Memory MCP server (Hindsight integration per ceo:memory_abstraction_layer_v1)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "mcp-servers/memory-mcp/tsconfig.json",
+      "target_repo": "product",
+      "target_path": "mcp-servers/memory-mcp/tsconfig.json",
+      "operation": "move",
+      "rationale": "Memory MCP server (Hindsight integration per ceo:memory_abstraction_layer_v1)",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "scripts/ci/check_product_test_allowlist.py",
+      "target_repo": "product",
+      "target_path": "scripts/ci/check_product_test_allowlist.py",
+      "operation": "move",
+      "rationale": "Product test matrix enforcer per PR #1118 \u2014 moves with the allowlist it enforces",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "config/product_repo_test_allowlist.txt",
+      "target_repo": "product",
+      "target_path": "config/product_repo_test_allowlist.txt",
+      "operation": "move",
+      "rationale": "Product test matrix allowlist per PR #1118",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_auth_minter.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_auth_minter.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_container_jwt.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_container_jwt.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_container_monitor.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_container_monitor.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_dispatcher_service_install.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_dispatcher_service_install.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_governance_proxy.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_governance_proxy.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_heartbeat_reaper.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_heartbeat_reaper.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_heartbeat_watchdog.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_heartbeat_watchdog.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_interceptor_proxy.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_interceptor_proxy.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_jwt_hash_rotation.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_jwt_hash_rotation.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_main_wiring.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_main_wiring.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_reaper.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_reaper.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_session_manager.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_session_manager.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_spend_tracker.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_spend_tracker.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_tmux_lifecycle.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_tmux_lifecycle.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_valkey_pool.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_valkey_pool.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/dispatcher/test_watchdog.py",
+      "target_repo": "product",
+      "target_path": "tests/dispatcher/test_watchdog.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/memory/test_environment_hash.py",
+      "target_repo": "product",
+      "target_path": "tests/memory/test_environment_hash.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/memory/test_memory.py",
+      "target_repo": "product",
+      "target_path": "tests/memory/test_memory.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/memory/test_sanitise.py",
+      "target_repo": "product",
+      "target_path": "tests/memory/test_sanitise.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/test_services/test_onboarding_pipeline.py",
+      "target_repo": "product",
+      "target_path": "tests/test_services/test_onboarding_pipeline.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/test_flows/test_post_onboarding_flow.py",
+      "target_repo": "product",
+      "target_path": "tests/test_flows/test_post_onboarding_flow.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/scripts/test_seed_demo_tenant.py",
+      "target_repo": "product",
+      "target_path": "tests/scripts/test_seed_demo_tenant.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/unit/test_set_tenant_session.py",
+      "target_repo": "product",
+      "target_path": "tests/unit/test_set_tenant_session.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/live/test_onboarding_live.py",
+      "target_repo": "product",
+      "target_path": "tests/live/test_onboarding_live.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/governance/test_ceo_memory_context_constraint.py",
+      "target_repo": "product",
+      "target_path": "tests/governance/test_ceo_memory_context_constraint.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/governance/test_ceo_memory_writer.py",
+      "target_repo": "product",
+      "target_path": "tests/governance/test_ceo_memory_writer.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    },
+    {
+      "source_path": "tests/integration/test_tenant_isolation.py",
+      "target_repo": "product",
+      "target_path": "tests/integration/test_tenant_isolation.py",
+      "operation": "move",
+      "rationale": "Product-tier test per PR #1118 config/product_repo_test_allowlist.txt",
+      "active_pr_block": null
+    }
+  ]
+}

--- a/docs/migration/migrated_manifest_seed.md
+++ b/docs/migration/migrated_manifest_seed.md
@@ -1,0 +1,157 @@
+# Migrated Manifest Seed — Phase 1.2.5 Artefact 6
+
+**KEI:** `Agency_OS-fi4u`. **Author:** max (deliberator-tier governance per role-lock exception — my own G4 gate from MAL V1 deliberation).
+**Status:** seed authored 2026-05-24. **Blocks:** Phase 2.2 first product-migration PR.
+**Companion deliverable:** `docs/migration/migrated_manifest_seed.json` (machine-readable manifest).
+**Companion enforcer:** `scripts/ci/check_migration_manifest.py`.
+**CI workflow:** `.github/workflows/migration-manifest-gate.yml`.
+
+---
+
+## 1. Notes — canonical key paste (per audit-dispatch checklist `_orchestrator.md`)
+
+`ceo:agency_os_keiracom_separation_v1` queried 2026-05-24 ahead of authoring. The consolidated gate served by this artefact:
+
+> "Migration manifest with dynamic exclusion (paths with active PR/KEI work excluded)"
+
+Plus the sequencing entry:
+
+> "Phase 1.2.5 (INSERT) pre-migration artefact bundle: 3-repo architecture doc + per-repo CLAUDE.md split decision + bd-routing policy + Weaviate cutover plan + discovery log classifier + migrated-manifest seed"
+
+This artefact is the migrated-manifest-seed entry of that bundle (artefact 6 of 7).
+
+`ceo:memory_abstraction_layer_v1` queried for the `src/memory/*` rationale text — the MAL V1 spec is the authority that says these files are product-tier.
+
+`ceo:comm_architecture` does not classify any files (the substrate is fleet-only) — referenced for completeness; no manifest entries derived from it.
+
+---
+
+## 2. What this artefact is
+
+A **seed manifest** enumerating every file currently on `origin/main` that is classified **product (P)** per the just-merged `docs/architecture/three_repo_carveout_execution.md` (PR #1122). Each entry conforms to the schema from PR #1122 §6.
+
+**Seed semantics:**
+- The manifest is **forward-looking input** for the Phase 2.0 migration runner. It does not move any files itself.
+- Entries are **explicit enumerations** (no globs) following the same discipline as Orion's `config/product_repo_test_allowlist.txt` (PR #1118).
+- `active_pr_block` annotations are **dynamically refreshed** (see §4) so a file with in-flight PR work isn't moved while the work is pending.
+- The seed will **grow** as Keiracom V1.0 product code is authored (Hindsight wrappers, tenant onboarding, install script — all forward-looking placeholders today).
+
+**What this artefact is NOT:**
+- Not the migration runner itself (Phase 2.0 build per MAL V1 Gate F, P0 critical-path).
+- Not the actual file movement (Phase 2.2).
+- Not the repo carve operation (Phase 2.0 separate dispatch).
+- Not a full classification — it enumerates **only P** entries that exist on `origin/main`. Fleet/archive entries are derivable from the classification rules in PR #1122 §3 and §4 but not enumerated here (their tree stays in `keiracom-fleet`/`keiracom/agency-os` and doesn't need a move manifest).
+
+---
+
+## 3. Seed contents — 60 entries
+
+Per-category breakdown (verifiable via `jq` on the JSON):
+
+| Category | Count | Source rule |
+|---|---|---|
+| `src/dispatcher/*.py` | 17 | PR #1122 §4.8 — "V1.0 MCP dispatcher per PR #1118 allowlist" |
+| `src/memory/*.py` | 10 | PR #1122 §4.8 — "Memory Abstraction Layer V1" + `ceo:memory_abstraction_layer_v1` |
+| `mcp-servers/memory-mcp/*` | 4 | Memory MCP server (Hindsight integration) |
+| `scripts/ci/check_product_test_allowlist.py` | 1 | PR #1122 §4.6 — moves with the test enforcer |
+| `config/product_repo_test_allowlist.txt` | 1 | PR #1122 §4.2 — PR #1118 allowlist |
+| Test paths from PR #1118 allowlist | 27 | PR #1122 §4.10 — verbatim PR #1118 enumeration |
+| **Total** | **60** | |
+
+### Known classification gaps (deferred to follow-up)
+
+PR #1122 §3.1 classifies the whole `mcp-servers/` directory as P, but the directory contains **48 files across 13 MCP servers**, of which only a subset is genuinely product-tier:
+
+- **Product (in this seed):** `mcp-servers/memory-mcp/*` (4 files) — Hindsight memory integration.
+- **Likely archive (NOT in this seed):** `mcp-servers/{dataforseo, prospeo, resend, salesforge, telnyx, unipile, vapi}-mcp/*` — these wrap dead Agency OS vendors per `ARCHITECTURE.md §3`. Including them as P contradicts the dead-vendor lock; excluding them per per-MCP refinement.
+- **Likely fleet (NOT in this seed):** `mcp-servers/{gmail, telegram}/*` — fleet operator/relay integrations.
+- **Cross-product infra (NOT in this seed):** `mcp-servers/{prefect, railway, vercel}-mcp/*` — could be F or P depending on Phase 2.0 deployment model.
+
+**Recommend follow-up KEI:** refine PR #1122 §3.1 `mcp-servers/` row from `P` to `SPLIT` and add a §4 subsection with per-MCP classification. Filed as the open follow-up for this artefact (see §7).
+
+---
+
+## 4. Dynamic-exclusion contract — `active_pr_block` field
+
+Per PR #1122 §6 schema, every entry has an `active_pr_block` field:
+- `null` — no in-flight work; eligible for the next migration cycle.
+- `"PR #N"` or `"PR #N; PR #M"` or `"Agency_OS-XXXX"` — work is in-flight; **excluded from migration cycle** until the blocker closes.
+
+The enforcer's `--refresh-exclusions` flag queries:
+
+1. **Open GitHub PRs** via `gh pr list --state=open --json number,files` — any PR whose `files[].path` matches a manifest `source_path` (exact match or single-level glob — same fnmatch shape as Orion's allowlist enforcer).
+2. **Open bd KEIs** via `bd list --status=open --json` — heuristic substring match on the issue's `description + notes` body for the source_path.
+
+Annotations are written back via atomic `tmp.replace()` (same shape as PR #1119 Weaviate cutover snapshot — idempotent re-runs).
+
+**Why dynamic, not static:**
+- A static manifest breaks on the first in-flight PR conflict — file gets migrated mid-work, leaves the open PR with a missing path. Author has to rebase against the migrated path; cascade failures across the bundle.
+- Dynamic exclusion lets the Phase 2.0 migration runner re-evaluate the manifest each cycle. Entries become eligible automatically once their blocking PR merges.
+
+**Refresh cadence (Phase 2.0+):** the migration runner calls `--refresh-exclusions` immediately before each migration cycle. Phase 1.2.5 (this PR) refreshes manually via CLI or CI `workflow_dispatch`.
+
+---
+
+## 5. Enforcer — `scripts/ci/check_migration_manifest.py`
+
+**Three-tier exit codes** (same shape as PR #1118 `check_product_test_allowlist.py`):
+
+- `0` — all entries pass schema + path-existence + enumeration discipline.
+- `1` — enforcement violation: schema missing field, target_repo enum invalid, operation enum invalid, path contains glob, path doesn't exist on disk.
+- `2` — config error: manifest file missing, malformed JSON.
+
+**Validations enforced** (runtime CODE per GOV-12, not doc-claim):
+
+1. Top-level required fields present (`manifest_version`, `entries`).
+2. Each entry has all required fields (`source_path`, `target_repo`, `target_path`, `operation`, `rationale`, `active_pr_block`).
+3. `target_repo` in `{fleet, product, archive, both}`.
+4. `operation` in `{move, copy, archive}`.
+5. `source_path` has no glob characters (`*`, `?`, `[`, `]`) — enumeration discipline.
+6. `source_path` exists on disk (catches path-rot from removed files).
+
+**Why these and not more:**
+- Hash discipline (per PR #1122 §6 `source_sha256`/`target_sha256`) belongs to the migration runner, not the pre-migration manifest gate. Filed as Phase 2.0 follow-up.
+- `target_path` semantics (collision detection, parent-dir creation) belong to the runner.
+- `active_pr_block` annotation correctness is checked at refresh time, not enforced — the runner uses the annotation, the gate doesn't reject on it.
+
+---
+
+## 6. CI workflow integration — `migration-manifest-gate.yml`
+
+**Trigger paths:** the manifest itself + the enforcer script + every P-classified path (so any PR touching a product-bound path runs the gate).
+
+**Mode:** `continue-on-error: true` in Phase 1.2.5 (warn-only — failures surface in CI output but don't block merge). Flip to hard-gate post-Phase-2.0 carve by removing the line.
+
+**Why warn-only initially:** the seed manifest is forward-looking; entries reference paths that exist on `origin/main` today but will move during Phase 2.0. A hard gate now would block legitimate PRs that edit product-bound paths. Hard gate becomes meaningful once those paths live in `keiracom-product` and edits to them are migration violations.
+
+---
+
+## 7. Open follow-ups (Phase 2.0 sequencing)
+
+Filed as bd KEIs (or to be filed; some already exist):
+
+- **Per-MCP `mcp-servers/` classification refinement** — split the §3.1 P-blanket into per-server classification (memory→P, dead vendor→A, fleet relay→F, cross-product infra→F-or-P).
+- **Migration runner implementation** — consumes this manifest. Per MAL V1 Gate F, P0 critical-path, ships before launch.
+- **Hash-discipline checker** — runner-side SHA-256 source/target match (PR #1122 §6).
+- **Hard-gate flip** — remove `continue-on-error: true` from `.github/workflows/migration-manifest-gate.yml` once Phase 2.0 carve completes.
+- **Manifest growth as V1.0 lands** — add entries for `infra/hindsight/`, product-side prompts, tenant schemas, install script when those paths are authored.
+- **bd KEI body-match precision** — current `--refresh-exclusions` does substring match on bd issue body for source_path; replace with a structured `--touches-path <path>` field on bd issues when bd grows that affordance.
+
+---
+
+## 8. Acceptance criteria
+
+- [x] Canonical key queried + paste in §1 per audit-dispatch checklist.
+- [x] Explicit enumeration (no globs) — 60 entries individually listed.
+- [x] Schema conforms to PR #1122 §6 with all 6 required fields per entry.
+- [x] Dynamic-exclusion mechanism named + implemented in enforcer (`--refresh-exclusions`).
+- [x] CI gate config (`.github/workflows/migration-manifest-gate.yml`) — runtime enforcement per GOV-12.
+- [x] Negative-path tests on synthetic offenders per `feedback_negative_path_test_before_approve` (12 tests covering all 3 exit tiers + each validation rule + report mode).
+- [x] Seed manifest self-validates via `scripts/ci/check_migration_manifest.py` (test `test_seed_manifest_on_disk_validates`).
+- [ ] Elliot impl-feasibility lens concur (per author-exclusion: Max authored, eligible reviewers are Elliot + Aiden).
+- [ ] Aiden architecture/governance lens concur.
+- [ ] 2-of-2 author-excluded NATS concur → Elliot admin-merge per `_orchestrator.md §Orchestrator-merge-after-NATS-concur`.
+
+---
+
+_End artefact. Section additions or material revisions require an explicit dispatch naming this file._

--- a/scripts/ci/check_migration_manifest.py
+++ b/scripts/ci/check_migration_manifest.py
@@ -38,12 +38,41 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_MANIFEST = REPO_ROOT / "docs/migration/migrated_manifest_seed.json"
+
+
+def _safe_resolve(raw: str | Path, root: Path) -> Path:
+    """Confine a CLI-supplied path to REPO_ROOT (pythonsecurity:S2083 guard).
+
+    Same shape as scripts/migration/weaviate_cutover.py _safe_resolve
+    (PR #1119). Defence-in-depth: string-level rejections first (fail fast on
+    obvious-bad input), then the stdlib `os.path.realpath` + `commonpath`
+    confinement check — the canonical Python idiom for path-injection guards
+    Sonar's taint-tracking recognises as a sanitisation sink.
+
+    NOTE: kept inline rather than imported from scripts/migration/ to avoid
+    a CI-script depending on a migration-script. Per `feedback_split_orthogonal_scope`,
+    extracting to scripts/common/safe_path.py is scope-creep for this PR.
+    """
+    raw_str = str(raw) if isinstance(raw, Path) else raw
+    if not isinstance(raw_str, str) or not raw_str:
+        raise ValueError(f"manifest path must be non-empty: {raw!r}")
+    if "\x00" in raw_str or "\n" in raw_str or "\r" in raw_str:
+        raise ValueError(f"manifest path contains control characters: {raw!r}")
+    if raw_str.startswith("~"):
+        raise ValueError(f"manifest path home-expansion forbidden: {raw!r}")
+    safe_root = os.path.realpath(str(root))
+    candidate = os.path.realpath(os.path.join(safe_root, raw_str))
+    if os.path.commonpath([candidate, safe_root]) != safe_root:
+        raise ValueError(f"manifest path escapes confinement root: {raw!r} (root={root})")
+    return Path(candidate)
+
 
 VALID_TARGET_REPOS = frozenset({"fleet", "product", "archive", "both"})
 VALID_OPERATIONS = frozenset({"move", "copy", "archive"})
@@ -181,10 +210,18 @@ def refresh_exclusions(manifest: dict) -> dict:
 
 
 def write_manifest_atomic(manifest: dict, path: Path) -> None:
-    """Atomic write — tmp.replace pattern (idempotent re-runs)."""
+    """Atomic write — tmp.replace pattern (idempotent re-runs).
+
+    `path` MUST already be confined to REPO_ROOT via _safe_resolve at the caller
+    (main() does this at args-parse time so all downstream uses receive a
+    sanitised Path). Aiden HOLD on PR #1123 caught the S2083 path-injection at
+    this site; the fix moves confinement upstream to args parsing.
+    """
     tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(manifest, indent=2) + "\n")
-    tmp.replace(path)
+    tmp.write_text(  # NOSONAR S2083 — sanitised at main() via _safe_resolve commonpath
+        json.dumps(manifest, indent=2) + "\n"
+    )
+    tmp.replace(path)  # NOSONAR S2083 — sanitised at main() via _safe_resolve commonpath
 
 
 def _print_report(entries: list[dict], blocked_count: int) -> None:
@@ -200,6 +237,13 @@ def _print_report(entries: list[dict], blocked_count: int) -> None:
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    p.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Confinement root for manifest path (default: REPO_ROOT). "
+        "Test fixtures override this; production CI never sets it.",
+    )
     p.add_argument("--report", action="store_true", help="Print counts; exit 0 regardless")
     p.add_argument(
         "--refresh-exclusions",
@@ -208,7 +252,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = p.parse_args(argv)
 
-    manifest = load_manifest(args.manifest)
+    # Path confinement — every downstream path use receives a Path confined to
+    # --root (default REPO_ROOT). Fail fast (exit 2 config-error) on any escape.
+    # Closes pythonsecurity:S2083 caught by Aiden HOLD on PR #1123.
+    try:
+        manifest_path = _safe_resolve(args.manifest, args.root)
+    except ValueError as exc:
+        sys.stderr.write(f"ERROR: {exc}\n")
+        return 2
+
+    manifest = load_manifest(manifest_path)
     top_violations = validate_top_level(manifest)
     if top_violations:
         for v in top_violations:
@@ -217,7 +270,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.refresh_exclusions:
         manifest = refresh_exclusions(manifest)
-        write_manifest_atomic(manifest, args.manifest)
+        write_manifest_atomic(manifest, manifest_path)
         sys.stderr.write(f"refreshed active_pr_block for {len(manifest['entries'])} entries\n")
 
     all_violations: list[str] = []

--- a/scripts/ci/check_migration_manifest.py
+++ b/scripts/ci/check_migration_manifest.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""check_migration_manifest.py — Phase 1.2.5 artefact 6 enforcer (Agency_OS-fi4u).
+
+CI gate for the migration manifest seed. Validates every entry against the
+schema from `docs/architecture/three_repo_carveout_execution.md §6` (PR #1122)
+and enforces the enumeration-not-glob discipline (same shape as Orion's
+`config/product_repo_test_allowlist.txt` enforcer, PR #1118).
+
+VALIDATES:
+  1. JSON parses; top-level required fields present (manifest_version, entries).
+  2. Each entry has required fields: source_path, target_repo, target_path,
+     operation, rationale, active_pr_block.
+  3. target_repo in {fleet, product, archive, both}.
+  4. operation in {move, copy, archive}.
+  5. source_path EXISTS on disk (catches path-rot — file removed but still listed).
+  6. source_path has NO glob characters (* ? [ ]) — enumeration discipline
+     mirrors PR #1118 `**` rejection.
+
+DYNAMIC EXCLUSION (--refresh):
+  Queries open bd KEIs + open GitHub PRs touching each source_path. Updates
+  active_pr_block field in-place (atomic tmp.replace). Per the dispatch
+  workflow: build manifest first (a), then refresh (b) to annotate.
+
+EXIT CODES:
+  0 — all entries pass
+  1 — enforcement violation (schema/path/glob)
+  2 — config error (manifest missing, malformed JSON, refresh subprocess fail)
+
+USAGE:
+    python3 scripts/ci/check_migration_manifest.py
+    python3 scripts/ci/check_migration_manifest.py --report
+    python3 scripts/ci/check_migration_manifest.py --refresh-exclusions
+    python3 scripts/ci/check_migration_manifest.py --manifest <path>
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "docs/migration/migrated_manifest_seed.json"
+
+VALID_TARGET_REPOS = frozenset({"fleet", "product", "archive", "both"})
+VALID_OPERATIONS = frozenset({"move", "copy", "archive"})
+REQUIRED_ENTRY_FIELDS = frozenset(
+    {"source_path", "target_repo", "target_path", "operation", "rationale", "active_pr_block"}
+)
+REQUIRED_TOP_FIELDS = frozenset({"manifest_version", "entries"})
+GLOB_CHARS = frozenset("*?[]")
+
+
+def load_manifest(path: Path) -> dict:
+    """Parse manifest JSON. Exits 2 on missing/malformed."""
+    if not path.is_file():
+        sys.stderr.write(f"ERROR: manifest not found: {path}\n")
+        sys.exit(2)
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"ERROR: manifest is not valid JSON: {exc}\n")
+        sys.exit(2)
+
+
+def validate_top_level(manifest: dict) -> list[str]:
+    """Return list of top-level violation strings. Empty = pass."""
+    violations: list[str] = []
+    missing = REQUIRED_TOP_FIELDS - manifest.keys()
+    if missing:
+        violations.append(f"top-level missing required fields: {sorted(missing)}")
+    if "entries" in manifest and not isinstance(manifest["entries"], list):
+        violations.append("entries must be a JSON array")
+    return violations
+
+
+def _has_glob(path: str) -> bool:
+    return any(c in GLOB_CHARS for c in path)
+
+
+def validate_entry(entry: dict, index: int) -> list[str]:
+    """Return list of violation strings for one entry."""
+    violations: list[str] = []
+    missing = REQUIRED_ENTRY_FIELDS - entry.keys()
+    if missing:
+        violations.append(f"entry[{index}] missing fields: {sorted(missing)}")
+        return violations
+    if entry["target_repo"] not in VALID_TARGET_REPOS:
+        violations.append(
+            f"entry[{index}] source={entry['source_path']!r} target_repo "
+            f"{entry['target_repo']!r} not in {sorted(VALID_TARGET_REPOS)}"
+        )
+    if entry["operation"] not in VALID_OPERATIONS:
+        violations.append(
+            f"entry[{index}] source={entry['source_path']!r} operation "
+            f"{entry['operation']!r} not in {sorted(VALID_OPERATIONS)}"
+        )
+    source = entry["source_path"]
+    if _has_glob(source):
+        violations.append(
+            f"entry[{index}] source_path {source!r} contains glob char — enumerate explicitly"
+        )
+    if not (REPO_ROOT / source).exists():
+        violations.append(f"entry[{index}] source_path does not exist on disk: {source!r}")
+    return violations
+
+
+def _gh_pr_files() -> dict[int, set[str]]:
+    """{pr_number: {file_paths}} for open PRs. Empty dict on any subprocess fail."""
+    try:
+        cp = subprocess.run(
+            ["gh", "pr", "list", "--state=open", "--limit=50", "--json", "number,files"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if cp.returncode != 0:
+            return {}
+        data = json.loads(cp.stdout)
+        result: dict[int, set[str]] = {}
+        for pr in data:
+            num = pr.get("number")
+            paths = {f.get("path", "") for f in (pr.get("files") or []) if f.get("path")}
+            if num is not None and paths:
+                result[num] = paths
+        return result
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        return {}
+
+
+def _bd_open_kei_paths() -> list[tuple[str, str]]:
+    """Best-effort [(kei_id, body_text)] for open bd issues. Empty on any fail.
+
+    Path matching against bd issues is heuristic (issue body may mention paths
+    without strict structure). The seed annotates with the KEI ID; refinement
+    happens at Phase 2.0 when the migration runner runs.
+    """
+    try:
+        cp = subprocess.run(
+            ["bd", "list", "--status=open", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+            cwd=str(REPO_ROOT),
+        )
+        if cp.returncode != 0:
+            return []
+        data = json.loads(cp.stdout) if cp.stdout.strip() else []
+        items = data if isinstance(data, list) else data.get("issues", [])
+        out: list[tuple[str, str]] = []
+        for it in items:
+            kei = it.get("id", "")
+            body = (it.get("description", "") or "") + " " + (it.get("notes", "") or "")
+            if kei:
+                out.append((kei, body))
+        return out
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        return []
+
+
+def refresh_exclusions(manifest: dict) -> dict:
+    """Annotate active_pr_block per current bd + gh state. Returns mutated manifest."""
+    pr_files = _gh_pr_files()
+    bd_issues = _bd_open_kei_paths()
+    for entry in manifest.get("entries", []):
+        source = entry["source_path"]
+        blockers: list[str] = []
+        for pr_num, paths in pr_files.items():
+            if any(p == source or fnmatch.fnmatch(p, source) for p in paths):
+                blockers.append(f"PR #{pr_num}")
+        for kei, body in bd_issues:
+            if source in body:
+                blockers.append(kei)
+        entry["active_pr_block"] = "; ".join(blockers) if blockers else None
+    return manifest
+
+
+def write_manifest_atomic(manifest: dict, path: Path) -> None:
+    """Atomic write — tmp.replace pattern (idempotent re-runs)."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(manifest, indent=2) + "\n")
+    tmp.replace(path)
+
+
+def _print_report(entries: list[dict], blocked_count: int) -> None:
+    by_target: dict[str, int] = {}
+    for e in entries:
+        by_target[e["target_repo"]] = by_target.get(e["target_repo"], 0) + 1
+    sys.stderr.write(f"manifest entries: {len(entries)}\n")
+    for repo in sorted(by_target):
+        sys.stderr.write(f"  {repo}: {by_target[repo]}\n")
+    sys.stderr.write(f"  active_pr_block annotated: {blocked_count}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    p.add_argument("--report", action="store_true", help="Print counts; exit 0 regardless")
+    p.add_argument(
+        "--refresh-exclusions",
+        action="store_true",
+        help="Query bd + gh; annotate active_pr_block in-place (atomic write)",
+    )
+    args = p.parse_args(argv)
+
+    manifest = load_manifest(args.manifest)
+    top_violations = validate_top_level(manifest)
+    if top_violations:
+        for v in top_violations:
+            sys.stderr.write(f"REJECT: {v}\n")
+        return 1
+
+    if args.refresh_exclusions:
+        manifest = refresh_exclusions(manifest)
+        write_manifest_atomic(manifest, args.manifest)
+        sys.stderr.write(f"refreshed active_pr_block for {len(manifest['entries'])} entries\n")
+
+    all_violations: list[str] = []
+    for i, entry in enumerate(manifest.get("entries", [])):
+        all_violations.extend(validate_entry(entry, i))
+
+    blocked = sum(1 for e in manifest.get("entries", []) if e.get("active_pr_block"))
+    if args.report:
+        _print_report(manifest.get("entries", []), blocked)
+        for v in all_violations:
+            sys.stderr.write(f"  violation: {v}\n")
+        return 0
+
+    if all_violations:
+        sys.stderr.write(f"REJECT: {len(all_violations)} validation violation(s):\n")
+        for v in all_violations:
+            sys.stderr.write(f"  {v}\n")
+        return 1
+
+    sys.stderr.write(
+        f"OK: {len(manifest['entries'])} entries valid; "
+        f"{blocked} flagged active_pr_block (excluded from migration cycle).\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/ci/test_check_migration_manifest.py
+++ b/tests/scripts/ci/test_check_migration_manifest.py
@@ -18,14 +18,17 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SCRIPT = REPO_ROOT / "scripts/ci/check_migration_manifest.py"
 
 
-def _run(manifest_path: Path, *extra: str) -> tuple[int, str, str]:
-    cp = subprocess.run(
-        [sys.executable, str(SCRIPT), "--manifest", str(manifest_path), *extra],
-        capture_output=True,
-        text=True,
-        timeout=20,
-        check=False,
-    )
+def _run(manifest_path: Path, *extra: str, root: Path | None = None) -> tuple[int, str, str]:
+    """Subprocess-invoke the script. `root` defaults to manifest_path's parent
+    so tests can use tmp_path without falling foul of the REPO_ROOT confinement.
+    Production CI never passes --root."""
+    if root is None and manifest_path.is_absolute():
+        root = manifest_path.parent
+    args = [sys.executable, str(SCRIPT), "--manifest", str(manifest_path)]
+    if root is not None:
+        args.extend(["--root", str(root)])
+    args.extend(extra)
+    cp = subprocess.run(args, capture_output=True, text=True, timeout=20, check=False)
     return cp.returncode, cp.stdout, cp.stderr
 
 
@@ -164,3 +167,88 @@ def test_seed_manifest_on_disk_validates(tmp_path):
         pytest.skip("seed manifest absent (running before artefact lands)")
     rc, _out, err = _run(seed)
     assert rc == 0, f"seed manifest validation failed: {err}"
+
+
+# _safe_resolve negative-path tests — pythonsecurity:S2083 path-injection guard.
+# Same shape as PR #1119's _safe_resolve tests. Loads the module via importlib
+# so we can call the helper directly without spawning subprocesses.
+
+
+def _load_enforcer_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "cmm", REPO_ROOT / "scripts/ci/check_migration_manifest.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_safe_resolve_accepts_in_root_paths(tmp_path):
+    """In-root path resolves cleanly."""
+    mod = _load_enforcer_module()
+    inside = tmp_path / "manifest.json"
+    inside.write_text("{}")
+    resolved = mod._safe_resolve(str(inside), tmp_path)
+    assert resolved == inside.resolve()
+
+
+def test_safe_resolve_accepts_relative_paths(tmp_path):
+    """Relative path inside root resolves cleanly."""
+    mod = _load_enforcer_module()
+    resolved = mod._safe_resolve("subdir/manifest.json", tmp_path)
+    assert resolved == (tmp_path / "subdir/manifest.json").resolve()
+
+
+def test_safe_resolve_rejects_absolute_escape(tmp_path):
+    """Absolute path outside root → ValueError (S2083 guard)."""
+    mod = _load_enforcer_module()
+    with pytest.raises(ValueError, match="escapes confinement root"):
+        mod._safe_resolve("/etc/passwd", tmp_path)
+
+
+def test_safe_resolve_rejects_dotdot_escape(tmp_path):
+    """Relative ..-escape outside root → ValueError."""
+    mod = _load_enforcer_module()
+    with pytest.raises(ValueError, match="escapes confinement root"):
+        mod._safe_resolve("../../../../etc/passwd", tmp_path)
+
+
+def test_safe_resolve_rejects_home_expansion(tmp_path):
+    """~/foo home-expansion → ValueError (fail-fast string check)."""
+    mod = _load_enforcer_module()
+    with pytest.raises(ValueError, match="home-expansion forbidden"):
+        mod._safe_resolve("~/.ssh/id_rsa", tmp_path)
+
+
+def test_safe_resolve_rejects_null_byte(tmp_path):
+    """Null byte in path → ValueError (control-character guard)."""
+    mod = _load_enforcer_module()
+    with pytest.raises(ValueError, match="control characters"):
+        mod._safe_resolve("manifest.json\x00.evil", tmp_path)
+
+
+def test_safe_resolve_rejects_empty(tmp_path):
+    """Empty string → ValueError."""
+    mod = _load_enforcer_module()
+    with pytest.raises(ValueError, match="non-empty"):
+        mod._safe_resolve("", tmp_path)
+
+
+def test_main_rejects_manifest_escape_with_exit_2(tmp_path):
+    """End-to-end: --manifest /etc/passwd against --root tmp_path → exit 2
+    (config error). The path-confinement guard rejects any path outside
+    the configured root regardless of caller intent."""
+    # Use tmp_path as root so the manifest path /etc/passwd is empirically
+    # outside it; if --root defaulted to REPO_ROOT we'd still get exit 2
+    # but for different reasons.
+    cp = subprocess.run(
+        [sys.executable, str(SCRIPT), "--manifest", "/etc/passwd", "--root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert cp.returncode == 2
+    assert "escapes confinement root" in cp.stderr or "ERROR:" in cp.stderr

--- a/tests/scripts/ci/test_check_migration_manifest.py
+++ b/tests/scripts/ci/test_check_migration_manifest.py
@@ -1,0 +1,166 @@
+"""Tests for scripts/ci/check_migration_manifest.py — Agency_OS-fi4u.
+
+Negative-path discipline per feedback_negative_path_test_before_approve:
+every enforcer rule gets a synthetic-offender test that asserts the exact
+exit code. Subprocess invocation pattern (tests script as CI runs it).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts/ci/check_migration_manifest.py"
+
+
+def _run(manifest_path: Path, *extra: str) -> tuple[int, str, str]:
+    cp = subprocess.run(
+        [sys.executable, str(SCRIPT), "--manifest", str(manifest_path), *extra],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    return cp.returncode, cp.stdout, cp.stderr
+
+
+def _write(path: Path, manifest: dict) -> None:
+    path.write_text(json.dumps(manifest))
+
+
+def _valid_entry(source: str = "scripts/ci/check_migration_manifest.py") -> dict:
+    return {
+        "source_path": source,
+        "target_repo": "product",
+        "target_path": source,
+        "operation": "move",
+        "rationale": "test",
+        "active_pr_block": None,
+    }
+
+
+def test_valid_manifest_returns_exit_0(tmp_path):
+    """Path-on-disk + valid schema + no globs → exit 0."""
+    m = tmp_path / "m.json"
+    _write(m, {"manifest_version": "1.0", "entries": [_valid_entry()]})
+    rc, _out, err = _run(m)
+    assert rc == 0, f"expected 0, got {rc}: {err}"
+    assert "OK:" in err
+
+
+def test_missing_manifest_returns_exit_2(tmp_path):
+    """Manifest file absent → exit 2 (config error)."""
+    rc, _out, err = _run(tmp_path / "absent.json")
+    assert rc == 2
+    assert "manifest not found" in err
+
+
+def test_malformed_json_returns_exit_2(tmp_path):
+    """Manifest file present but not valid JSON → exit 2."""
+    m = tmp_path / "m.json"
+    m.write_text("{this is not json}")
+    rc, _out, err = _run(m)
+    assert rc == 2
+    assert "not valid JSON" in err
+
+
+def test_missing_top_level_field_returns_exit_1(tmp_path):
+    """Top-level missing 'entries' → exit 1."""
+    m = tmp_path / "m.json"
+    _write(m, {"manifest_version": "1.0"})
+    rc, _out, err = _run(m)
+    assert rc == 1
+    assert "missing required fields" in err
+
+
+def test_entry_missing_required_field_returns_exit_1(tmp_path):
+    """Entry missing 'rationale' → exit 1."""
+    m = tmp_path / "m.json"
+    entry = _valid_entry()
+    del entry["rationale"]
+    _write(m, {"manifest_version": "1.0", "entries": [entry]})
+    rc, _out, err = _run(m)
+    assert rc == 1
+    assert "missing fields" in err
+
+
+def test_invalid_target_repo_returns_exit_1(tmp_path):
+    """target_repo='produkt' (typo) → exit 1."""
+    m = tmp_path / "m.json"
+    entry = _valid_entry()
+    entry["target_repo"] = "produkt"
+    _write(m, {"manifest_version": "1.0", "entries": [entry]})
+    rc, _out, err = _run(m)
+    assert rc == 1
+    assert "target_repo" in err and "produkt" in err
+
+
+def test_invalid_operation_returns_exit_1(tmp_path):
+    """operation='translate' → exit 1."""
+    m = tmp_path / "m.json"
+    entry = _valid_entry()
+    entry["operation"] = "translate"
+    _write(m, {"manifest_version": "1.0", "entries": [entry]})
+    rc, _out, err = _run(m)
+    assert rc == 1
+    assert "operation" in err
+
+
+def test_glob_in_source_path_returns_exit_1(tmp_path):
+    """source_path='src/**/*.py' → exit 1 (enumeration discipline)."""
+    m = tmp_path / "m.json"
+    entry = _valid_entry()
+    entry["source_path"] = "src/**/*.py"
+    _write(m, {"manifest_version": "1.0", "entries": [entry]})
+    rc, _out, err = _run(m)
+    assert rc == 1
+    assert "glob char" in err
+
+
+def test_nonexistent_source_path_returns_exit_1(tmp_path):
+    """source_path that doesn't exist on disk → exit 1 (path-rot)."""
+    m = tmp_path / "m.json"
+    entry = _valid_entry()
+    entry["source_path"] = "src/dispatcher/nonexistent_ghost_module.py"
+    entry["target_path"] = entry["source_path"]
+    _write(m, {"manifest_version": "1.0", "entries": [entry]})
+    rc, _out, err = _run(m)
+    assert rc == 1
+    assert "does not exist on disk" in err
+
+
+def test_empty_entries_returns_exit_0(tmp_path):
+    """Empty manifest (entries: []) → exit 0 (no violations to fail)."""
+    m = tmp_path / "m.json"
+    _write(m, {"manifest_version": "1.0", "entries": []})
+    rc, _out, err = _run(m)
+    assert rc == 0
+    assert "OK:" in err
+
+
+def test_report_mode_never_enforces(tmp_path):
+    """Even with violations, --report exits 0 and prints counts."""
+    m = tmp_path / "m.json"
+    entry = _valid_entry()
+    entry["target_repo"] = "produkt"  # invalid
+    _write(m, {"manifest_version": "1.0", "entries": [entry]})
+    rc, _out, err = _run(m, "--report")
+    assert rc == 0
+    assert "manifest entries: 1" in err
+    assert "violation:" in err
+
+
+def test_seed_manifest_on_disk_validates(tmp_path):
+    """The real seed manifest at docs/migration/migrated_manifest_seed.json
+    parses + every entry validates against the schema + every source_path
+    exists on origin/main. Locks the artefact against silent regression."""
+    seed = REPO_ROOT / "docs/migration/migrated_manifest_seed.json"
+    if not seed.exists():
+        pytest.skip("seed manifest absent (running before artefact lands)")
+    rc, _out, err = _run(seed)
+    assert rc == 0, f"seed manifest validation failed: {err}"


### PR DESCRIPTION
## Summary

Phase 1.2.5 bundle artefact 6. Authors the migrated-manifest seed file (my own G4 gate from MAL V1 deliberation). 60 P-classified entries enumerated from the just-merged PR #1122 (`docs/architecture/three_repo_carveout_execution.md` §3.1 + §4).

Per Elliot's unblock dispatch confirming both (a)+(b) of my Step 0 RESTATE:

- **(a) Target paths** — enumerate the P-classified rows from #1122; explicit enumeration (no globs) following the same discipline as Orion's CI allow-list (PR #1118).
- **(b) Dynamic exclusion** — for each path, `--refresh-exclusions` queries open bd KEIs + open PRs touching the path; annotates `active_pr_block` per #1122 §6 schema. Atomic `tmp.replace()` write (idempotent re-runs).

## 5 new files (+1105 LoC total)

| File | LoC | Role |
|---|---|---|
| `docs/migration/migrated_manifest_seed.json` | 490 | The manifest itself — 60 entries conforming to #1122 §6 schema |
| `docs/migration/migrated_manifest_seed.md` | 157 | Companion doc — canonical-key Notes paste + rationale + classification gap surfacing |
| `scripts/ci/check_migration_manifest.py` | 248 | Enforcer with 3-tier exit codes (same shape as PR #1118) |
| `tests/scripts/ci/test_check_migration_manifest.py` | 166 | 12 negative-path tests + seed-self-validation lock |
| `.github/workflows/migration-manifest-gate.yml` | 44 | CI gate (warn-only in Phase 1.2.5; hard-gate post-Phase-2.0) |

## Seed contents — 60 entries

| Category | Count | Source rule |
|---|---|---|
| `src/dispatcher/*.py` | 17 | #1122 §4.8 — V1.0 MCP dispatcher |
| `src/memory/*.py` | 10 | #1122 §4.8 + `ceo:memory_abstraction_layer_v1` |
| `mcp-servers/memory-mcp/*` | 4 | Hindsight memory integration |
| `scripts/ci/check_product_test_allowlist.py` | 1 | #1122 §4.6 |
| `config/product_repo_test_allowlist.txt` | 1 | #1122 §4.2 |
| Test paths from PR #1118 allowlist | 27 | #1122 §4.10 |
| **Total** | **60** | |

## Known classification gap surfaced (filed as follow-up)

PR #1122 §3.1 classifies whole `mcp-servers/` as **P**, but the directory contains 48 files across 13 MCP servers:
- **Product (in this seed):** `memory-mcp/*` (4 files) — Hindsight integration.
- **Likely archive (NOT in this seed):** `{dataforseo, prospeo, resend, salesforge, telnyx, unipile, vapi}-mcp/*` — wraps dead Agency OS vendors per `ARCHITECTURE.md §3`.
- **Likely fleet (NOT in this seed):** `{gmail, telegram}/*`.
- **Cross-product infra (NOT in this seed):** `{prefect, railway, vercel}-mcp/*`.

Per `feedback_split_orthogonal_scope` not bundling the §3.1 refinement into this PR. Recommend follow-up to refine §3.1 `mcp-servers/` from `P` to `SPLIT` with per-MCP classification.

## Verification (locally on PR head before push)

```
$ ruff check scripts/ci/check_migration_manifest.py tests/scripts/ci/test_check_migration_manifest.py
All checks passed!

$ ruff format --check scripts/ci/check_migration_manifest.py tests/scripts/ci/test_check_migration_manifest.py
2 files already formatted

$ python3 -m pytest tests/scripts/ci/test_check_migration_manifest.py -q
............                                                             [100%]
12 passed in 0.62s

$ python3 scripts/ci/check_migration_manifest.py
OK: 60 entries valid; 0 flagged active_pr_block (excluded from migration cycle).
```

Includes `test_seed_manifest_on_disk_validates` — the seed self-validates against the schema as part of the test suite; locks the artefact against silent regression.

## Test plan

- [ ] Elliot (impl-feasibility): verify the enforcer's `--refresh-exclusions` mechanism (bd + gh queries) is the right shape for a Phase 2.0 migration runner to consume.
- [ ] Aiden (architecture/governance): cross-check classifications against the just-merged #1122 §3.1 + §4; surface any drift in my interpretation of the P rows. Also verify the classification-gap call for `mcp-servers/`.
- [ ] Run `python3 scripts/ci/check_migration_manifest.py --report` locally to see the per-target-repo counts.

## Reviewers

Per author-exclusion (KEI-206 + `_orchestrator.md §Orchestrator-merge-after-NATS-concur`): Max authored → eligible reviewers are **Elliot + Aiden**. 2-of-2 NATS concur → Elliot admin-merge.

**Blocks:** Phase 2.2 first product-migration PR. P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)