### PR TITLE
[ORION] feat(keiracom-system): log-based per-tenant LLM metering — Phase 2 wave 2 item 3

### DIFF
--- a/src/keiracom_system/metering/__init__.py
+++ b/src/keiracom_system/metering/__init__.py
@@ -1,0 +1,15 @@
+"""Log-based per-tenant LLM metering — Phase 2 build wave 2 item 3."""
+
+from .aggregator import Aggregator, MeteringRow
+from .log_reader import DEFAULT_FIELD_MAP, LLM_CALL_EVENT_TYPES, LogReader, MeteringEvent
+from .sink import PostgresSink
+
+__all__ = [
+    "Aggregator",
+    "DEFAULT_FIELD_MAP",
+    "LLM_CALL_EVENT_TYPES",
+    "LogReader",
+    "MeteringEvent",
+    "MeteringRow",
+    "PostgresSink",
+]

--- a/src/keiracom_system/metering/aggregator.py
+++ b/src/keiracom_system/metering/aggregator.py
@@ -1,0 +1,85 @@
+"""aggregator.py — bucket MeteringEvent stream by (tenant_id, date_utc, model).
+
+Phase 2 build wave 2 item 3.
+
+Pure in-memory accumulator. Sink writes to DB. Separation keeps the
+aggregator deterministic + trivially testable (no DB in test path) and
+lets the sink swap (PostgresSink for prod, FakeSink for tests, future
+NullSink for dry-run replay).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .log_reader import MeteringEvent
+
+
+@dataclass(frozen=True)
+class _BucketKey:
+    tenant_id: str
+    date_utc: str
+    model: str
+
+
+@dataclass
+class MeteringRow:
+    """Aggregated metering row — one row per (tenant_id, date_utc, model) tuple.
+
+    Mirrors the primary key of public.keiracom_tenant_metering. The sink
+    UPSERTs on this composite key so re-running the pipeline over a
+    previously-processed log range is idempotent.
+    """
+
+    tenant_id: str
+    date_utc: str
+    model: str
+    request_count: int = 0
+    input_tokens_sum: int = 0
+    output_tokens_sum: int = 0
+
+    def add(self, event: MeteringEvent) -> None:
+        self.request_count += 1
+        self.input_tokens_sum += event.input_tokens
+        self.output_tokens_sum += event.output_tokens
+
+
+class Aggregator:
+    """Stream MeteringEvents → flushable batch of MeteringRows.
+
+    Memory bounded by the number of distinct (tenant, date, model) buckets
+    in a flush window. For V1 the pipeline runs daily over the previous
+    day's log range, so cardinality is bounded by tenant_count * model_count
+    (typically <1000 rows).
+    """
+
+    def __init__(self) -> None:
+        self._buckets: dict[_BucketKey, MeteringRow] = {}
+
+    def add_event(self, event: MeteringEvent) -> None:
+        key = _BucketKey(event.tenant_id, event.date_utc, event.model)
+        row = self._buckets.get(key)
+        if row is None:
+            row = MeteringRow(
+                tenant_id=event.tenant_id,
+                date_utc=event.date_utc,
+                model=event.model,
+            )
+            self._buckets[key] = row
+        row.add(event)
+
+    def add_events(self, events: Iterable[MeteringEvent]) -> None:
+        for ev in events:
+            self.add_event(ev)
+
+    def flush(self) -> list[MeteringRow]:
+        """Drain accumulator → list of MeteringRow + reset internal state.
+
+        Order is insertion-order of first event per bucket — stable for
+        snapshot diffing but not sorted. Sink is responsible for any
+        sorting it needs (e.g. for deterministic SQL parameter binding).
+        """
+        rows = list(self._buckets.values())
+        self._buckets.clear()
+        return rows

--- a/src/keiracom_system/metering/log_reader.py
+++ b/src/keiracom_system/metering/log_reader.py
@@ -1,0 +1,174 @@
+"""log_reader.py — read Hindsight JSON log lines, emit per-tenant metering events.
+
+Phase 2 build wave 2 item 3.
+
+CANONICAL KEY ANCHOR — ceo:memory_abstraction_layer_v1 (RATIFIED 2026-05-24):
+
+  eleven_agreed_positions[4] (position 5) verbatim:
+    "Collective scope: tenant-bounded only, never cross-tenant inference
+     (BYOK sovereignty)"
+
+This pipeline materialises the Keiracom-side of that sovereignty contract:
+tenants pay LLM providers DIRECTLY via their own BYOK key; this pipeline
+captures aggregate spend for our observability + future overage-billing
+view ONLY. Never used to bill tenants for inference (provider already did
+that) and never used to route to a Keiracom-owned LLM key.
+
+PR #1128 §7 P2 framing verbatim:
+  "P2 — log-based per-tenant metering pipeline (Atlas #1126 G4).
+   Vector/Filebeat → metering service → control plane spend table."
+
+PR #1128 §5 mechanism 1 verbatim:
+  "Hindsight-side log emission (Atlas #1126 finding #5): every JSON log
+   line carries `tenant` field. Keiracom log-shipper (Vector / Filebeat /
+   etc.) routes logs to a metering service that aggregates per-tenant
+   spend over time."
+
+PR #1128 §5 recommendation verbatim:
+  "ship V1 with log-based metering only (mechanism 1). Add provider-
+   billing-API integration (mechanism 2) as a P2 follow-up after first
+   paying customer."
+
+V1 SCOPE: log-based read-aggregate-sink. Provider-billing-API integration
+(mechanism 2 from §5) is a separate P3 follow-up bd issue deferred to
+post-first-paying-customer.
+
+DESIGN: field map is injectable so future Hindsight log-schema drift can be
+absorbed via env-var config rather than a code change. Non-LLM-call event
+types are filtered out at the reader so the aggregator only sees billing-
+relevant events.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import IO, Any
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MeteringEvent:
+    """Per-call LLM spend event extracted from a Hindsight JSON log line.
+
+    `timestamp` is timezone-aware UTC. `date_utc` is the YYYY-MM-DD bucket
+    used by the aggregator — derived here so the aggregator stays free of
+    timezone concerns.
+    """
+
+    tenant_id: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    timestamp: datetime
+
+    @property
+    def date_utc(self) -> str:
+        return self.timestamp.astimezone(UTC).date().isoformat()
+
+
+def _dig(obj: dict[str, Any], dotted_key: str) -> Any:
+    """Walk a nested dict via dotted-key path (e.g. 'usage.input_tokens')."""
+    cur: Any = obj
+    for part in dotted_key.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+# Default Hindsight log field map. Override via the constructor when Hindsight
+# updates its log schema — no code change needed in this reader.
+DEFAULT_FIELD_MAP: dict[str, str] = {
+    "tenant_id": "tenant",
+    "model": "model",
+    "input_tokens": "usage.input_tokens",
+    "output_tokens": "usage.output_tokens",
+    "timestamp": "ts",
+    "event_type": "event",
+}
+
+# Only LLM-call event types contribute to metering rows. Hindsight emits
+# many other event types (retain/recall/healthcheck) — those don't consume
+# LLM tokens so we skip them at the reader rather than the aggregator.
+LLM_CALL_EVENT_TYPES: frozenset[str] = frozenset({"llm_call", "reflect", "synthesize"})
+
+
+class LogReader:
+    """Stream Hindsight JSON-lines log → MeteringEvent iterator.
+
+    Defensive against malformed input: bad JSON lines are logged + skipped
+    (not raised) so a single bad log line doesn't poison a batch run.
+    Lines that lack required fields, fail timestamp parsing, or carry a
+    non-LLM event type are skipped without raising.
+    """
+
+    def __init__(
+        self,
+        stream: IO[str],
+        field_map: dict[str, str] | None = None,
+    ):
+        self._stream = stream
+        self._fmap = dict(field_map) if field_map else dict(DEFAULT_FIELD_MAP)
+
+    def read_events(self) -> Iterator[MeteringEvent]:
+        for line_num, raw in enumerate(self._stream, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                log.warning("log_reader: line %d malformed JSON: %s", line_num, exc)
+                continue
+            if not isinstance(obj, dict):
+                log.warning("log_reader: line %d not a JSON object", line_num)
+                continue
+            event = self._extract_event(obj, line_num)
+            if event is not None:
+                yield event
+
+    def _extract_event(self, obj: dict[str, Any], line_num: int) -> MeteringEvent | None:
+        event_type = _dig(obj, self._fmap.get("event_type", "event"))
+        if event_type not in LLM_CALL_EVENT_TYPES:
+            return None
+
+        tenant_id = _dig(obj, self._fmap["tenant_id"])
+        model = _dig(obj, self._fmap["model"])
+        ts_raw = _dig(obj, self._fmap["timestamp"])
+
+        if not tenant_id or not model or ts_raw is None:
+            log.warning("log_reader: line %d missing required fields (tenant/model/ts)", line_num)
+            return None
+
+        ts = self._parse_timestamp(ts_raw, line_num)
+        if ts is None:
+            return None
+
+        return MeteringEvent(
+            tenant_id=str(tenant_id),
+            model=str(model),
+            input_tokens=int(_dig(obj, self._fmap["input_tokens"]) or 0),
+            output_tokens=int(_dig(obj, self._fmap["output_tokens"]) or 0),
+            timestamp=ts,
+        )
+
+    @staticmethod
+    def _parse_timestamp(raw: Any, line_num: int) -> datetime | None:
+        """Accept ISO-8601 str (with optional trailing Z) or Unix epoch number."""
+        try:
+            if isinstance(raw, str):
+                return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            if isinstance(raw, int | float):
+                return datetime.fromtimestamp(raw, tz=UTC)
+        except (ValueError, TypeError, OSError) as exc:
+            log.warning("log_reader: line %d bad timestamp %r: %s", line_num, raw, exc)
+            return None
+        log.warning(
+            "log_reader: line %d timestamp type %s unsupported", line_num, type(raw).__name__
+        )
+        return None

--- a/src/keiracom_system/metering/sink.py
+++ b/src/keiracom_system/metering/sink.py
@@ -1,0 +1,52 @@
+"""sink.py — write aggregated MeteringRow batches to keiracom_tenant_metering.
+
+Phase 2 build wave 2 item 3.
+
+The sink is the only DB-touching surface in the metering pipeline. Tests
+inject a _DBProtocol-conformant fake; production wires a psycopg-backed
+client via from_env() (P1 follow-up — see below).
+
+Idempotency contract: UPSERT on (tenant_id, date_utc, model) with cumulative
+ADD on the count + token columns. Re-running the pipeline over the same log
+range therefore produces the correct totals as long as the same log lines
+appear (the underlying log shipper is assumed to provide exactly-once).
+
+For V1 the upsert SQL is owned by the database adapter (so the sink stays
+SQL-dialect-free). Production wiring lands in P1 follow-up bd alongside
+the psycopg adapter.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+from .aggregator import MeteringRow
+
+log = logging.getLogger(__name__)
+
+
+class _DBProtocol(Protocol):
+    """Minimal sink-side DB surface. One method, intentionally narrow."""
+
+    def upsert_metering_rows(self, rows: list[MeteringRow]) -> int:
+        """Apply rows to keiracom_tenant_metering. Returns affected count."""
+        ...
+
+
+class PostgresSink:
+    """Write MeteringRow batches to keiracom_tenant_metering via injected db.
+
+    Holds no connection state — single round-trip per write_rows call.
+    Connection pooling + transaction management are the adapter's job
+    (per Atlas's provisioning.py pattern).
+    """
+
+    def __init__(self, db: _DBProtocol):
+        self._db = db
+
+    def write_rows(self, rows: list[MeteringRow]) -> int:
+        """Persist rows; returns rows-affected count. Empty input is a no-op."""
+        if not rows:
+            return 0
+        return self._db.upsert_metering_rows(rows)

--- a/supabase/migrations/20260525_keiracom_tenant_metering.sql
+++ b/supabase/migrations/20260525_keiracom_tenant_metering.sql
@@ -1,0 +1,65 @@
+-- ============================================================================
+-- 20260525_keiracom_tenant_metering.sql
+--
+-- Phase 2 build wave 2 item 3 — log-based per-tenant LLM metering pipeline.
+-- bd: Agency_OS-3k8g
+--
+-- Stores per-tenant per-day per-model aggregate counts rolled up from
+-- Hindsight log streams (see src/keiracom_system/metering/).
+--
+-- Idempotent on (tenant_id, date_utc, model). The metering sink does
+-- ON CONFLICT UPDATE with cumulative ADD so re-running the pipeline over
+-- the same log range (e.g. log replay) produces the same totals — assuming
+-- the log shipper provides exactly-once delivery.
+--
+-- CANONICAL KEY ANCHOR — ceo:memory_abstraction_layer_v1 position 5:
+--   "Collective scope: tenant-bounded only, never cross-tenant inference
+--    (BYOK sovereignty)"
+--
+-- This table is for Keiracom-side observability + future overage billing
+-- ONLY. Tenants pay LLM providers DIRECTLY via their own BYOK key — we
+-- never bill tenants for the inference itself (provider already did),
+-- only for tier overage if their volume exceeds plan limits.
+--
+-- Cost columns (cost_aud_sum, etc.) are intentionally DEFERRED to P3 —
+-- they require provider-billing-API integration to translate token counts
+-- to per-model-per-tenant dollar amounts, which is the post-first-paying-
+-- customer follow-up per PR #1128 §5 recommendation.
+--
+-- KEI-87 bypass: SET LOCAL agency_os.callsign = 'dave' is required because
+-- this migration creates a public-schema table and the write-guard trigger
+-- otherwise blocks. Same pattern as 20260524_0scg_ceo_memory_context_not_null.sql.
+-- ============================================================================
+
+SET LOCAL agency_os.callsign = 'dave';
+
+CREATE TABLE IF NOT EXISTS public.keiracom_tenant_metering (
+    tenant_id           UUID         NOT NULL,
+    date_utc            DATE         NOT NULL,
+    model               TEXT         NOT NULL,
+    request_count       BIGINT       NOT NULL DEFAULT 0,
+    input_tokens_sum    BIGINT       NOT NULL DEFAULT 0,
+    output_tokens_sum   BIGINT       NOT NULL DEFAULT 0,
+    created_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, date_utc, model),
+    FOREIGN KEY (tenant_id) REFERENCES public.keiracom_tenants(tenant_id) ON DELETE CASCADE
+);
+
+-- Date-range scans for daily rollup reports + per-tenant trend dashboards.
+CREATE INDEX IF NOT EXISTS idx_keiracom_tenant_metering_date_utc
+    ON public.keiracom_tenant_metering (date_utc);
+
+CREATE INDEX IF NOT EXISTS idx_keiracom_tenant_metering_tenant_date
+    ON public.keiracom_tenant_metering (tenant_id, date_utc DESC);
+
+COMMENT ON TABLE public.keiracom_tenant_metering IS
+    'V1 log-based LLM metering aggregates per tenant/day/model. '
+    'Phase 2 wave 2 item 3 per PR #1128 §7 P2. Cost columns deferred to P3.';
+
+COMMENT ON COLUMN public.keiracom_tenant_metering.request_count IS
+    'Number of LLM-call events observed in the log for this bucket.';
+COMMENT ON COLUMN public.keiracom_tenant_metering.input_tokens_sum IS
+    'Cumulative input/prompt tokens. Used for tier-overage detection.';
+COMMENT ON COLUMN public.keiracom_tenant_metering.output_tokens_sum IS
+    'Cumulative output/completion tokens. Used for tier-overage detection.';

--- a/tests/keiracom_system/metering/test_aggregator.py
+++ b/tests/keiracom_system/metering/test_aggregator.py
@@ -1,0 +1,164 @@
+"""Tests for src/keiracom_system/metering/aggregator.py — Phase 2 wave 2 item 3.
+
+Bucket key = (tenant_id, date_utc, model). Need to verify each axis of the
+key actually splits buckets, plus the aggregation arithmetic + flush
+semantics.
+
+10 cases — 4 happy-path + 6 negative/edge.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.keiracom_system.metering.aggregator import (  # noqa: E402
+    Aggregator,
+    MeteringRow,
+)
+from src.keiracom_system.metering.log_reader import MeteringEvent  # noqa: E402
+
+
+def _ev(
+    tenant: str = "t1",
+    model: str = "gpt-4o-mini",
+    ts: str = "2026-05-25T10:00:00+00:00",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+) -> MeteringEvent:
+    return MeteringEvent(
+        tenant_id=tenant,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        timestamp=datetime.fromisoformat(ts),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Happy paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_single_event_produces_single_row():
+    """(1) one event → one row with count=1, tokens carried through."""
+    agg = Aggregator()
+    agg.add_event(_ev())
+    rows = agg.flush()
+    assert len(rows) == 1
+    r = rows[0]
+    assert r.tenant_id == "t1"
+    assert r.date_utc == "2026-05-25"
+    assert r.model == "gpt-4o-mini"
+    assert r.request_count == 1
+    assert r.input_tokens_sum == 100
+    assert r.output_tokens_sum == 50
+
+
+def test_two_events_same_bucket_aggregate():
+    """(2) same (tenant, date, model) → counts + tokens accumulate."""
+    agg = Aggregator()
+    agg.add_event(_ev(input_tokens=10, output_tokens=20))
+    agg.add_event(_ev(input_tokens=100, output_tokens=200))
+    rows = agg.flush()
+    assert len(rows) == 1
+    assert rows[0].request_count == 2
+    assert rows[0].input_tokens_sum == 110
+    assert rows[0].output_tokens_sum == 220
+
+
+def test_add_events_consumes_iterable():
+    """(3) add_events drains any iterable of events into the accumulator."""
+    agg = Aggregator()
+    agg.add_events(_ev() for _ in range(5))
+    rows = agg.flush()
+    assert len(rows) == 1
+    assert rows[0].request_count == 5
+
+
+def test_flush_resets_internal_state():
+    """(4) flush returns rows + clears accumulator → second flush is empty."""
+    agg = Aggregator()
+    agg.add_event(_ev())
+    first = agg.flush()
+    second = agg.flush()
+    assert len(first) == 1
+    assert second == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bucket-key axis tests — each axis must split buckets
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_different_tenant_id_creates_separate_buckets():
+    """(5) (t1, date, model) and (t2, date, model) → 2 rows."""
+    agg = Aggregator()
+    agg.add_event(_ev(tenant="t1"))
+    agg.add_event(_ev(tenant="t2"))
+    rows = agg.flush()
+    assert len(rows) == 2
+    assert {r.tenant_id for r in rows} == {"t1", "t2"}
+
+
+def test_different_date_utc_creates_separate_buckets():
+    """(6) same tenant/model but different UTC date → 2 rows.
+
+    Verifies the date_utc derivation cuts at midnight UTC regardless of
+    the source timestamp's offset. Day-rollover correctness anchor.
+    """
+    agg = Aggregator()
+    agg.add_event(_ev(ts="2026-05-25T23:59:59+00:00"))
+    agg.add_event(_ev(ts="2026-05-26T00:00:01+00:00"))
+    rows = agg.flush()
+    assert len(rows) == 2
+    assert {r.date_utc for r in rows} == {"2026-05-25", "2026-05-26"}
+
+
+def test_different_model_creates_separate_buckets():
+    """(7) same tenant + date but different model → 2 rows (per-model cost)."""
+    agg = Aggregator()
+    agg.add_event(_ev(model="gpt-4o-mini"))
+    agg.add_event(_ev(model="claude-opus"))
+    rows = agg.flush()
+    assert len(rows) == 2
+    assert {r.model for r in rows} == {"gpt-4o-mini", "claude-opus"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Negative + edge
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_flush_on_empty_aggregator_returns_empty_list():
+    """(8) flush() before any add_event → []. No exception on empty drain."""
+    assert Aggregator().flush() == []
+
+
+def test_zero_token_events_aggregate_to_zero_sums():
+    """(9) events with 0 input/output tokens still count requests + sum to 0."""
+    agg = Aggregator()
+    agg.add_event(_ev(input_tokens=0, output_tokens=0))
+    agg.add_event(_ev(input_tokens=0, output_tokens=0))
+    rows = agg.flush()
+    assert rows[0].request_count == 2
+    assert rows[0].input_tokens_sum == 0
+    assert rows[0].output_tokens_sum == 0
+
+
+def test_metering_row_add_mutates_in_place():
+    """(10) MeteringRow.add() mutates request_count + sums in place (no return value).
+
+    Locks the contract: aggregator relies on in-place mutation, not on a
+    new-row-per-add immutable pattern. If we ever switch to immutable rows
+    the aggregator's bucket lookup needs to update too.
+    """
+    row = MeteringRow(tenant_id="t1", date_utc="2026-05-25", model="x")
+    row.add(_ev(input_tokens=7, output_tokens=11))
+    assert row.request_count == 1
+    assert row.input_tokens_sum == 7
+    assert row.output_tokens_sum == 11

--- a/tests/keiracom_system/metering/test_aggregator.py
+++ b/tests/keiracom_system/metering/test_aggregator.py
@@ -39,11 +39,6 @@ def _ev(
     )
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Happy paths
-# ─────────────────────────────────────────────────────────────────────────────
-
-
 def test_single_event_produces_single_row():
     """(1) one event → one row with count=1, tokens carried through."""
     agg = Aggregator()
@@ -90,11 +85,6 @@ def test_flush_resets_internal_state():
     assert second == []
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Bucket-key axis tests — each axis must split buckets
-# ─────────────────────────────────────────────────────────────────────────────
-
-
 def test_different_tenant_id_creates_separate_buckets():
     """(5) (t1, date, model) and (t2, date, model) → 2 rows."""
     agg = Aggregator()
@@ -127,11 +117,6 @@ def test_different_model_creates_separate_buckets():
     rows = agg.flush()
     assert len(rows) == 2
     assert {r.model for r in rows} == {"gpt-4o-mini", "claude-opus"}
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Negative + edge
-# ─────────────────────────────────────────────────────────────────────────────
 
 
 def test_flush_on_empty_aggregator_returns_empty_list():

--- a/tests/keiracom_system/metering/test_log_reader.py
+++ b/tests/keiracom_system/metering/test_log_reader.py
@@ -1,0 +1,238 @@
+"""Tests for src/keiracom_system/metering/log_reader.py — Phase 2 wave 2 item 3.
+
+Negative-path discipline per feedback_negative_path_test_before_approve:
+the reader's job is to filter out malformed/non-billable lines without
+raising. Each filter branch needs explicit negative coverage on a
+synthetic offender.
+
+16 cases total — 4 happy paths + 12 negative/edge paths.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.keiracom_system.metering.log_reader import (  # noqa: E402
+    DEFAULT_FIELD_MAP,
+    LLM_CALL_EVENT_TYPES,
+    LogReader,
+    MeteringEvent,
+)
+
+
+def _line(**kw) -> str:
+    """Build a Hindsight-shaped JSON log line."""
+    base = {
+        "event": "llm_call",
+        "tenant": "tenant-A",
+        "model": "gpt-4o-mini",
+        "usage": {"input_tokens": 100, "output_tokens": 50},
+        "ts": "2026-05-25T10:00:00Z",
+    }
+    base.update(kw)
+    return json.dumps(base)
+
+
+def _stream(*lines: str) -> io.StringIO:
+    return io.StringIO("\n".join(lines) + "\n")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Happy paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_read_events_single_valid_line_emits_event():
+    """(1) one well-formed llm_call line → one MeteringEvent."""
+    events = list(LogReader(_stream(_line())).read_events())
+    assert len(events) == 1
+    ev = events[0]
+    assert isinstance(ev, MeteringEvent)
+    assert ev.tenant_id == "tenant-A"
+    assert ev.model == "gpt-4o-mini"
+    assert ev.input_tokens == 100
+    assert ev.output_tokens == 50
+    assert ev.date_utc == "2026-05-25"
+
+
+def test_read_events_multiple_valid_lines_emit_in_order():
+    """(2) 3 well-formed lines → 3 events, insertion-order preserved."""
+    lines = [
+        _line(tenant="t1"),
+        _line(tenant="t2"),
+        _line(tenant="t3"),
+    ]
+    events = list(LogReader(_stream(*lines)).read_events())
+    assert [e.tenant_id for e in events] == ["t1", "t2", "t3"]
+
+
+def test_read_events_unix_epoch_timestamp_parses():
+    """(3) Hindsight may emit numeric epoch — parses to UTC datetime.
+
+    2026-05-25T10:00:00Z == 1779703200 unix epoch
+    (verified: datetime(2026,5,25,10,0,0,tzinfo=UTC).timestamp()).
+    """
+    events = list(LogReader(_stream(_line(ts=1779703200))).read_events())
+    assert len(events) == 1
+    assert events[0].date_utc == "2026-05-25"
+
+
+def test_read_events_field_map_override_handles_alt_schema():
+    """(4) injected field_map absorbs Hindsight schema drift without code change."""
+    alt = json.dumps(
+        {
+            "kind": "llm_call",
+            "tenant_uuid": "alt-tenant",
+            "llm_model": "claude-opus",
+            "tokens_in": 5,
+            "tokens_out": 10,
+            "timestamp": "2026-05-25T10:00:00Z",
+        }
+    )
+    field_map = {
+        "tenant_id": "tenant_uuid",
+        "model": "llm_model",
+        "input_tokens": "tokens_in",
+        "output_tokens": "tokens_out",
+        "timestamp": "timestamp",
+        "event_type": "kind",
+    }
+    events = list(LogReader(_stream(alt), field_map=field_map).read_events())
+    assert len(events) == 1
+    assert events[0].tenant_id == "alt-tenant"
+    assert events[0].model == "claude-opus"
+    assert events[0].input_tokens == 5
+    assert events[0].output_tokens == 10
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Negative + edge paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_read_events_empty_lines_skipped():
+    """(5) blank / whitespace-only lines silently skipped."""
+    events = list(LogReader(_stream("", "   ", _line())).read_events())
+    assert len(events) == 1  # only the real line emitted
+
+
+def test_read_events_malformed_json_skipped_not_raised():
+    """(6) one bad-JSON line + one valid → reader yields the valid one only."""
+    events = list(LogReader(_stream("{not-json}", _line())).read_events())
+    assert len(events) == 1
+    assert events[0].tenant_id == "tenant-A"
+
+
+def test_read_events_non_dict_json_skipped():
+    """(7) a JSON array/scalar line is not a log object — skipped."""
+    events = list(LogReader(_stream("[1, 2, 3]", '"just a string"', _line())).read_events())
+    assert len(events) == 1
+
+
+def test_read_events_non_llm_event_types_filtered_out():
+    """(8) retain/recall/healthcheck lines never reach the aggregator."""
+    lines = [
+        _line(event="retain"),
+        _line(event="recall"),
+        _line(event="healthcheck"),
+        _line(event="llm_call"),  # only this one is billable
+    ]
+    events = list(LogReader(_stream(*lines)).read_events())
+    assert len(events) == 1
+    assert events[0].tenant_id == "tenant-A"
+
+
+def test_read_events_all_llm_event_types_accepted():
+    """(9) all three known LLM event types (llm_call, reflect, synthesize) emit events."""
+    lines = [_line(event=et) for et in LLM_CALL_EVENT_TYPES]
+    events = list(LogReader(_stream(*lines)).read_events())
+    assert len(events) == len(LLM_CALL_EVENT_TYPES)
+
+
+def test_read_events_missing_tenant_skipped():
+    """(10) line lacking the tenant field → skipped (logged at WARN)."""
+    bad = json.dumps({"event": "llm_call", "model": "x", "ts": "2026-05-25T10:00:00Z"})
+    events = list(LogReader(_stream(bad)).read_events())
+    assert events == []
+
+
+def test_read_events_missing_model_skipped():
+    """(11) line lacking the model field → skipped."""
+    bad = json.dumps({"event": "llm_call", "tenant": "t1", "ts": "2026-05-25T10:00:00Z"})
+    events = list(LogReader(_stream(bad)).read_events())
+    assert events == []
+
+
+def test_read_events_missing_timestamp_skipped():
+    """(12) line lacking the timestamp field → skipped (cannot bucket)."""
+    bad = json.dumps({"event": "llm_call", "tenant": "t1", "model": "x"})
+    events = list(LogReader(_stream(bad)).read_events())
+    assert events == []
+
+
+def test_read_events_bad_timestamp_string_skipped():
+    """(13) unparseable timestamp string → skipped, no exception."""
+    events = list(LogReader(_stream(_line(ts="not-a-date"))).read_events())
+    assert events == []
+
+
+def test_read_events_unsupported_timestamp_type_skipped():
+    """(14) timestamp of dict/list type → skipped (not a stringy or numeric ts)."""
+    events = list(LogReader(_stream(_line(ts={"year": 2026}))).read_events())
+    assert events == []
+
+
+def test_read_events_missing_token_counts_default_to_zero():
+    """(15) usage block absent or partial → tokens default to 0 (no skip).
+
+    Some Hindsight log events legitimately omit usage when the LLM provider
+    didn't return token counts. Treat as 0 rather than dropping the request
+    entirely — we still want to count the request_count.
+    """
+    no_usage = json.dumps(
+        {"event": "llm_call", "tenant": "t1", "model": "x", "ts": "2026-05-25T10:00:00Z"}
+    )
+    events = list(LogReader(_stream(no_usage)).read_events())
+    assert len(events) == 1
+    assert events[0].input_tokens == 0
+    assert events[0].output_tokens == 0
+
+
+def test_read_events_default_field_map_matches_documented_keys():
+    """(16) DEFAULT_FIELD_MAP is the documented Hindsight schema mapping.
+
+    Regression guard: future edits to the DEFAULT_FIELD_MAP need to preserve
+    the documented key names (or update PR #1128 §5 in lockstep). Locks the
+    contract surface so downstream readers know which env to override.
+    """
+    assert DEFAULT_FIELD_MAP["tenant_id"] == "tenant"
+    assert DEFAULT_FIELD_MAP["event_type"] == "event"
+    assert DEFAULT_FIELD_MAP["timestamp"] == "ts"
+    assert DEFAULT_FIELD_MAP["input_tokens"] == "usage.input_tokens"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Trailing parametrised edge cases
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "ts_input,expected_date",
+    [
+        ("2026-05-25T10:00:00Z", "2026-05-25"),
+        ("2026-05-25T23:59:59+00:00", "2026-05-25"),
+        ("2026-05-26T00:00:01+00:00", "2026-05-26"),
+    ],
+)
+def test_read_events_date_utc_derives_from_timestamp(ts_input, expected_date):
+    """(17a/b/c) UTC date-bucket derives correctly across day boundaries."""
+    events = list(LogReader(_stream(_line(ts=ts_input))).read_events())
+    assert events[0].date_utc == expected_date

--- a/tests/keiracom_system/metering/test_log_reader.py
+++ b/tests/keiracom_system/metering/test_log_reader.py
@@ -45,11 +45,6 @@ def _stream(*lines: str) -> io.StringIO:
     return io.StringIO("\n".join(lines) + "\n")
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Happy paths
-# ─────────────────────────────────────────────────────────────────────────────
-
-
 def test_read_events_single_valid_line_emits_event():
     """(1) one well-formed llm_call line → one MeteringEvent."""
     events = list(LogReader(_stream(_line())).read_events())
@@ -111,11 +106,6 @@ def test_read_events_field_map_override_handles_alt_schema():
     assert events[0].model == "claude-opus"
     assert events[0].input_tokens == 5
     assert events[0].output_tokens == 10
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Negative + edge paths
-# ─────────────────────────────────────────────────────────────────────────────
 
 
 def test_read_events_empty_lines_skipped():
@@ -217,11 +207,6 @@ def test_read_events_default_field_map_matches_documented_keys():
     assert DEFAULT_FIELD_MAP["event_type"] == "event"
     assert DEFAULT_FIELD_MAP["timestamp"] == "ts"
     assert DEFAULT_FIELD_MAP["input_tokens"] == "usage.input_tokens"
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Trailing parametrised edge cases
-# ─────────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.parametrize(

--- a/tests/keiracom_system/metering/test_sink.py
+++ b/tests/keiracom_system/metering/test_sink.py
@@ -1,0 +1,106 @@
+"""Tests for src/keiracom_system/metering/sink.py — Phase 2 wave 2 item 3.
+
+Sink is a thin pass-through to a _DBProtocol implementation. Tests inject
+a FakeDB that captures calls so we can assert the contract without psycopg
+in the test path.
+
+5 cases — 2 happy + 3 negative/edge.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.keiracom_system.metering.aggregator import MeteringRow  # noqa: E402
+from src.keiracom_system.metering.sink import PostgresSink  # noqa: E402
+
+
+class FakeDB:
+    """In-memory _DBProtocol — captures rows + returns configured count."""
+
+    def __init__(self, return_value: int = 0):
+        self.calls: list[list[MeteringRow]] = []
+        self._return_value = return_value
+
+    def upsert_metering_rows(self, rows: list[MeteringRow]) -> int:
+        self.calls.append(list(rows))
+        return self._return_value
+
+
+def _row(tenant: str = "t1", model: str = "x") -> MeteringRow:
+    return MeteringRow(
+        tenant_id=tenant,
+        date_utc="2026-05-25",
+        model=model,
+        request_count=1,
+        input_tokens_sum=10,
+        output_tokens_sum=5,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Happy paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_write_rows_passes_batch_to_db_and_returns_count():
+    """(1) non-empty batch → db.upsert called once, return value bubbled up."""
+    db = FakeDB(return_value=3)
+    sink = PostgresSink(db=db)
+    rows = [_row(tenant="t1"), _row(tenant="t2"), _row(tenant="t3")]
+    affected = sink.write_rows(rows)
+    assert affected == 3
+    assert len(db.calls) == 1
+    assert [r.tenant_id for r in db.calls[0]] == ["t1", "t2", "t3"]
+
+
+def test_write_rows_preserves_input_order():
+    """(2) sink does NOT reorder — caller (or db adapter) owns ordering."""
+    db = FakeDB(return_value=2)
+    sink = PostgresSink(db=db)
+    rows = [_row(model="z"), _row(model="a")]
+    sink.write_rows(rows)
+    assert [r.model for r in db.calls[0]] == ["z", "a"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Negative + edge
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_write_rows_empty_input_is_no_op_no_db_call():
+    """(3) empty rows → no DB round-trip + returns 0. Saves a no-op transaction."""
+    db = FakeDB(return_value=99)
+    sink = PostgresSink(db=db)
+    affected = sink.write_rows([])
+    assert affected == 0
+    assert db.calls == []  # no upsert call at all
+
+
+def test_write_rows_returns_zero_on_db_zero_affected():
+    """(4) db reports 0 affected rows → sink propagates 0 (not coerced to len)."""
+    db = FakeDB(return_value=0)
+    sink = PostgresSink(db=db)
+    rows = [_row()]
+    affected = sink.write_rows(rows)
+    assert affected == 0
+    assert len(db.calls) == 1  # call still made even when 0 affected
+
+
+def test_write_rows_multiple_calls_each_round_trip_db():
+    """(5) sink holds no batch state — each call is a fresh DB round-trip.
+
+    Locks the no-batching contract so callers know to batch upstream if they
+    want larger transactions.
+    """
+    db = FakeDB(return_value=1)
+    sink = PostgresSink(db=db)
+    sink.write_rows([_row(tenant="t1")])
+    sink.write_rows([_row(tenant="t2")])
+    sink.write_rows([_row(tenant="t3")])
+    assert len(db.calls) == 3
+    assert [batch[0].tenant_id for batch in db.calls] == ["t1", "t2", "t3"]

--- a/tests/keiracom_system/metering/test_sink.py
+++ b/tests/keiracom_system/metering/test_sink.py
@@ -42,11 +42,6 @@ def _row(tenant: str = "t1", model: str = "x") -> MeteringRow:
     )
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Happy paths
-# ─────────────────────────────────────────────────────────────────────────────
-
-
 def test_write_rows_passes_batch_to_db_and_returns_count():
     """(1) non-empty batch → db.upsert called once, return value bubbled up."""
     db = FakeDB(return_value=3)
@@ -65,11 +60,6 @@ def test_write_rows_preserves_input_order():
     rows = [_row(model="z"), _row(model="a")]
     sink.write_rows(rows)
     assert [r.model for r in db.calls[0]] == ["z", "a"]
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Negative + edge
-# ─────────────────────────────────────────────────────────────────────────────
 
 
 def test_write_rows_empty_input_is_no_op_no_db_call():


### PR DESCRIPTION
## Summary

Phase 2 build wave 2 **item 3** per Dave-ratified MAL V1 (`ceo:memory_abstraction_layer_v1` position 5: BYOK sovereignty) and PR #1128 §7 P2 design.

**V1 scope**: log-based read → aggregate → sink. Provider-billing-API integration (mechanism 2 from PR #1128 §5) deferred to **P3 post-first-paying-customer** per original recommendation.

## Files (9, +686 LoC)

| File | Purpose |
|---|---|
| `src/keiracom_system/metering/log_reader.py` | Stream Hindsight JSON-lines log → MeteringEvent iterator; injectable field_map; filters non-LLM event types |
| `src/keiracom_system/metering/aggregator.py` | Bucket by `(tenant_id, date_utc, model)`; pure in-memory; bounded by tenant_count × model_count |
| `src/keiracom_system/metering/sink.py` | Thin `PostgresSink` via injected `_DBProtocol`; no batch state; empty input no-op |
| `src/keiracom_system/metering/__init__.py` | Package exports |
| `supabase/migrations/20260525_keiracom_tenant_metering.sql` | `keiracom_tenant_metering` table — PK `(tenant_id, date_utc, model)`, FK to keiracom_tenants ON DELETE CASCADE, KEI-87 callsign-bypass |
| `tests/keiracom_system/metering/test_log_reader.py` | 17 cases (4 happy + 13 neg/edge) |
| `tests/keiracom_system/metering/test_aggregator.py` | 10 cases (4 happy + 6 axis/neg) |
| `tests/keiracom_system/metering/test_sink.py` | 5 cases (2 happy + 3 neg) |
| `tests/keiracom_system/metering/__init__.py` | Package marker |

## Test sweep — 34/34 PASS in 0.15s

```
tests/keiracom_system/metering/test_aggregator.py ..........             [ 29%]
tests/keiracom_system/metering/test_log_reader.py ...................    [ 85%]
tests/keiracom_system/metering/test_sink.py .....                        [100%]
============================== 34 passed in 0.15s ==============================
```

Lint: `ruff check` + `ruff format --check` clean.

## Negative-path coverage (per Aiden gate-validator discipline)

**Log reader (13 negatives)**: malformed JSON, non-dict JSON, non-LLM event types filtered, missing tenant/model/timestamp skipped, bad timestamp string, unsupported timestamp type, empty/whitespace lines, missing token counts default to 0, day-boundary parametrise across 3 ISO formats.

**Aggregator (6 axis/negatives)**: each bucket-key axis (tenant_id / date_utc / model) verified to split correctly, day-rollover anchor at midnight UTC, empty-flush returns [], zero-token sums, in-place mutation contract locked.

**Sink (3 negatives)**: empty input → no DB call, zero-affected count propagated (not coerced to `len(rows)`), multi-call shows no batching.

## Design choices

- **Field map injectable** — future Hindsight log schema drift absorbed via env-var, no code change here. `DEFAULT_FIELD_MAP` documented in PR #1128 §5; locked by regression test.
- **Filter at reader, not aggregator** — non-LLM event types (retain/recall/healthcheck) never reach the aggregator, saving cycles per `feedback_active_channels_canonical` style "filter early, lock contract".
- **Defensive parsing** — bad lines logged at WARN + skipped, never raised. Single bad log line doesn't poison a batch run.
- **Pure in-memory aggregator** — deterministic + trivially testable. Sink is the ONLY DB-touching surface.
- **Idempotent on (tenant_id, date_utc, model)** — re-running over the same log range produces correct totals (assuming log shipper provides exactly-once).
- **Cost columns deferred to P3** — V1 captures counts only; cost translation requires provider-billing-API integration.

## Atlas coordination

This pipeline reads Hindsight's JSON log field that Atlas's wrappers (PR #1134, merging) populate via Hindsight's existing log emission. **No interface change required on his side** — `DEFAULT_FIELD_MAP` matches documented Hindsight schema (`tenant`, `model`, `usage.input_tokens`, etc.).

## Canonical-key-query gate

Queried `ceo:memory_abstraction_layer_v1` BEFORE writing. Pasted **position 5 (BYOK sovereignty)** + **§7 P2 framing** + **§5 mechanism 1** verbatim into `log_reader.py` module docstring + migration header.

## Follow-up bd (to file post-concur)

- **P3**: provider-billing-API integration (mechanism 2 from PR #1128 §5) — post-first-paying-customer.
- **P1**: production wiring — psycopg-backed `PostgresDBAdapter` implementing `_DBProtocol.upsert_metering_rows()`; from_env() factory + Prefect deployment for daily rollup runs.
- **P2**: log-shipper config — Vector/Filebeat tailing Hindsight container logs → metering service stdin.

## Test plan
- [x] 34/34 pass in 0.15s (17 + 10 + 5 + 2 module-import tests)
- [x] ruff check + format --check clean
- [x] Migration uses KEI-87 callsign-bypass (`SET LOCAL agency_os.callsign='dave'`)
- [x] FK to keiracom_tenants ON DELETE CASCADE (tenant-deprovisioning safe)
- [x] Canonical key queried + verbatim paste in module docstring + migration header
- [x] Default field_map regression test locks documented schema
- [ ] Elliot impl-feasibility concur
- [ ] Aiden architecture-lens concur
- [ ] Max code-quality-lens concur
- [ ] Dual-concur (any 2 of 3) → Elliot admin-merge per orchestrator-merge-after-NATS-concur pattern

bd: `Agency_OS-3k8g`

🤖 Generated with [Claude Code](https://claude.com/claude-code)