### PR TITLE
[ATLAS] feat(ci): SonarCloud → CodeQL migration — code analysis layer swap

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+# CodeQL — code analysis layer for the Keiracom System repo.
+#
+# Replaces SonarCloud (Dave + Aiden concur 2026-05-25). CodeQL alerts are
+# native to GitHub: no separate API token, dismissal flows through the
+# repo's Security tab or `gh api` calls.
+#
+# Severity translation (for the discipline-language migration in
+# docs/governance/CONSOLIDATED_RULES.md):
+#   Sonar BLOCKER         → CodeQL error
+#   Sonar CRITICAL/MAJOR  → CodeQL warning
+#   Sonar MINOR/INFO      → CodeQL note
+#   Sonar "hotspot review" → "dismiss CodeQL alert with reason"
+#
+# Two analysed languages:
+#   - python      → src/, scripts/, tests/, supabase/ (Python migrations etc)
+#   - javascript  → frontend/ (covers both .js/.jsx and .ts/.tsx)
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly drift scan — Mondays 03:00 UTC. Catches dependency-driven regressions.
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-and-quality pack catches the same shape as Sonar's BLOCKER
+          # + CRITICAL (path injection, weak crypto, taint flows) plus quality
+          # smells (duplication, complexity). Default 'security-extended' is the
+          # SARIF-emitting baseline we want.
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/docs/governance/CONSOLIDATED_RULES.md
+++ b/docs/governance/CONSOLIDATED_RULES.md
@@ -369,8 +369,8 @@ The set is intentionally small. Each rule names a required section anchor that m
 |---|---|---|---|
 | Dual-concur + author-exclusion (KEI-206) | `## Dual-Concur` | fleet, product | Archive is read-only; no PRs accepted there. |
 | Author-tags every PR title (LAW XVII subset) | `## Callsign Discipline` or `## Author Tags` | fleet, product | Fleet uses callsign tags `[AIDEN]` etc.; product may use bot tags or engineer names — section name normalised. |
-| Sonar QG + issues both verified per `feedback_sonar_qg_not_just_issues` | `## CI + Sonar` | fleet, product | Archive: omit (read-only). |
-| Wait-for-CI-before-review per `feedback_wait_for_ci_before_review` | `## CI + Sonar` (combined with above) | fleet, product | Archive: omit. |
+| CodeQL findings verified per-PR (errors block; warnings reviewed; notes triaged) — replaces Sonar QG discipline | `## CI + CodeQL` | fleet, product | Archive: omit (read-only). Migrated from SonarCloud 2026-05-25 per Dave+Aiden concur. The historical `feedback_sonar_qg_not_just_issues` memory anchor still applies in spirit — the "QG passed but issues remain" trap is the same shape under CodeQL when error-count is 0 but warnings linger. |
+| Wait-for-CI-before-review per `feedback_wait_for_ci_before_review` | `## CI + CodeQL` (combined with above) | fleet, product | Archive: omit. |
 | Step 0 RESTATE if deliberators author (LAW XV-D) | `## Authoring Discipline` | fleet | Product CLAUDE.md only includes this IF deliberators ever author product code directly (currently no; engineers author + deliberators review). |
 | Negative-path tests before approve | `## Test Discipline` | fleet, product | Universal to gate/validator/enforcer PRs. |
 | Canonical-key-query gate (audit-dispatch checklist) | `## Canonical Key Query` | fleet | Fleet-specific (ceo_memory keys are fleet substrate). Product gets analogous discipline via MCP schema versioning when authored. |

--- a/docs/governance/_hot_pointer_cache.md
+++ b/docs/governance/_hot_pointer_cache.md
@@ -56,7 +56,7 @@ Token budget per Layered Governance Matrix v1: **≤2500 tokens**. Regenerator a
 |------|-------|--------|---------|------------|
 | `PERSONA elliot` | Elliot | deliberation layer — implementation lens | PR review on implementation feasibility, dispatch routing | `persona-elliot` |
 | `PERSONA aiden` | Aiden | deliberation layer — governance + architecture lens | PR review on architecture drift, dependency ordering, governance | `persona-aiden` |
-| `PERSONA max` | Max | deliberation layer — code quality + test coverage lens | PR review on Sonar QG, test edge cases, hardcoded values | `persona-max` |
+| `PERSONA max` | Max | deliberation layer — code quality + test coverage lens | PR review on CodeQL findings (errors/warnings/notes), test edge cases, hardcoded values | `persona-max` |
 | `PERSONA john` | John | face layer — Dave-facing communicator; never executes/reviews | Dave-facing summary translation, single-voice presentation | `persona-john` |
 | `PERSONA orion` | Orion | worker layer — unrestricted; claims any worker-lane KEI | engineer-tier build/test/fix work | `persona-orion` |
 | `PERSONA atlas` | Atlas | worker layer — unrestricted; operator-tier ops + builds | Vultr deploys, systemd install scripts, infra ops | `persona-atlas` |

--- a/docs/governance/layered_governance_matrix.md
+++ b/docs/governance/layered_governance_matrix.md
@@ -445,7 +445,7 @@ Each triggers so frequently that recall-on-demand has too much latency cost. Aid
 
 1. `feedback_silence_is_status` — every Dave-facing post
 2. `feedback_pre_revenue_reality` — every marketing/positioning decision
-3. `feedback_sonar_qg_not_just_issues` — every PR review
+3. `feedback_sonar_qg_not_just_issues` — every PR review (post-2026-05-25 Sonar→CodeQL migration: same "verify the gate AND the underlying findings" discipline, now phrased as "verify CodeQL error-count==0 AND triage warnings/notes — not just one of them")
 4. `feedback_wait_for_ci_before_review` — every PR review
 5. `feedback_no_pass_fail_annotation` — every test-output report
 6. `feedback_ceo_plain_english_summaries` — every Dave-facing post


### PR DESCRIPTION
## Summary

Dave + Aiden CONCUR 2026-05-25 — SonarCloud retired in favour of CodeQL. Unblocks PR #1133 (TEI sidecar stuck on SonarCloud hotspot review with no admin token configured).

Time-box honoured (~45 min of ~1-2h estimate).

## Changes

### NEW `.github/workflows/codeql.yml`
- Matrix over `python` + `javascript` (frontend has TS + JSX)
- `security-and-quality` query pack — catches Sonar BLOCKER/CRITICAL equivalents (path injection, weak crypto, taint flows) + quality smells
- Triggers on push + PR + weekly Monday 03:00 UTC drift scan
- Native GitHub integration — no separate API token, no admin gap

### Severity translation (documented in `codeql.yml` header)
| Sonar | CodeQL |
| --- | --- |
| BLOCKER | error (blocks merge) |
| CRITICAL / MAJOR | warning (triaged in review) |
| MINOR / INFO | note (triaged opportunistically) |
| "mark hotspot reviewed" | "dismiss alert with reason" (GitHub Security tab or `gh api`) |

### Governance doc updates
- `docs/governance/CONSOLIDATED_RULES.md` — repo CLAUDE.md section anchor `## CI + Sonar` → `## CI + CodeQL`. Inline note preserves the historical feedback memory anchor (same "verify gate AND underlying findings" discipline under the new severity model).
- `docs/governance/_hot_pointer_cache.md` — Max persona trigger updated from "PR review on Sonar QG" to "PR review on CodeQL findings".
- `docs/governance/layered_governance_matrix.md` — historical `feedback_sonar_qg_not_just_issues` anchor retained with translation note.

### Out of scope (surface to admin)
- **No Sonar workflow file to delete in this repo** — SonarCloud was configured externally via the SonarCloud GitHub App. Disabling that app is an admin action outside the repo. Recommend Elliot/Dave do this one-shot after merge so SonarCloud stops running on PRs in parallel with CodeQL.
- Historical feedback memory names (e.g. `feedback_sonar_qg_not_just_issues`) live in auto-memory outside the repo; renaming them is a separate effort. They remain valid as historical citations of the underlying discipline.

## Test plan
- [ ] Aiden (architecture/governance): doc updates land in the right anchors; section name change won't break fleet/product CLAUDE.md cross-refs (none currently use `## CI + Sonar` as a literal anchor).
- [ ] Max (quality): `security-and-quality` query pack is the right CodeQL severity surface to replace Sonar's BLOCKER + CRITICAL coverage; weekly drift scan cadence sane.
- [ ] Elliot (impl-feasibility, LOAD-BEARING): unblocks PR #1133 on rebase; confirm SonarCloud GitHub App can be disabled post-merge.

## Cascade
Once this lands → PR #1133 rebases onto main → CodeQL runs in place of SonarCloud → Phase 2 build wave 2 closes at 7/7 per dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)