### PR TITLE
[SCOUT] research(go_sidecar): Phase A4 — Go sidecar research + scaffold (mcp.go_sidecar Cat 10)

### DIFF
--- a/docs/wave2/phase_a4_go_sidecar_research_and_scaffold.md
+++ b/docs/wave2/phase_a4_go_sidecar_research_and_scaffold.md
@@ -1,0 +1,237 @@
+# Phase A4 — Go Sidecar: Research + Scaffold Findings
+
+**Agent:** scout
+**Dispatched by:** elliot (Dave directive: "wake now and continue", Phase A4 — Go Sidecar deployment, RESEARCH + SCAFFOLDING phase)
+**Date:** 2026-05-25
+**Mandate:** Research-tier ingestion of Go + sidecar patterns; deliver a minimal scaffold (~50-100 LoC) demonstrating shape; name engineer-tier handoff scope. NOT a full implementation. Read-only research + scaffold authoring.
+**Build-track:** `infra/keiracom_system/go_sidecar/` (mirrors TEI sidecar at `infra/keiracom_system/embeddings/`).
+**LAW XIV mandate:** verbatim evidence, raw output, no summary-only.
+
+---
+
+## NOTES — Canonical-key query gate (per `_orchestrator.md` audit-dispatch checklist, 2026-05-24)
+
+Queried `ceo:keiracom_architecture_v2_locked` (Supabase `public.ceo_memory`, updated_at `2026-05-25 13:17:35Z`). Pulled the V2 inventory at `/home/elliotbot/clawd/Agency_OS/docs/architecture/keiracom_architecture_v2_inventory.md` (62700 bytes). Verbatim relevant rows:
+
+**Cat 10 — `mcp.go_sidecar` (line 149 of inventory):**
+> `mcp.go_sidecar | Go sidecar — security interceptor + tool-call validator; static config not knowledge graph; mechanical enforcement | RATIFIED-DM | Viktor verbatim 2026-05-25 + Aiden Phase 1 §3.A item 7 | nothing | V1-launch (BUILD pending)`
+
+Cat 10 Owner: Atlas + Orion (engineer-tier).
+
+**Cat 19 — `ux.files.system_files_hidden` (line 364 of inventory):**
+> `ux.files.system_files_hidden | System files (reasoning traces, system prompts, governance configs, Temporal state) NEVER queryable by customer file system | RATIFIED-CEO | Dave directive | nothing | V1-launch`
+
+**Cross-dependency edge (line 461 of inventory, verbatim):**
+> `ux.files.system_files_hidden ← mcp.go_sidecar` **currently GAP/pending** — customer file system could leak system files without Go Sidecar enforcement
+
+**Cat 16 — `infra.secrets_management` cross-cite (line 208 of inventory, verbatim partial):**
+> "agents call Vault at spawn; **Go Sidecar validates no raw secret leaks into LLM context.** Depends on: mcp.go_sidecar + tenant.table + mem.byok."
+
+**Cat 19 — `ux.mobile_strategy` (line 484, anchoring the research-tier ingestion pattern):**
+> RATIFIED-CEO: "V1 ships web-only (Next.js); native mobile follows V1.1 once fleet has ingested React Native knowledge + completed practice phase. … Decision #1 — **fleet research + memory ingestion path chosen over hire-specialist**"
+
+**V2 locks not for redeliberation (from `ceo_memory` value):** `cat_19_5tab_nav_holds`, `cat_19_notifications_header_icon`, `cat_19_mobile_strategy_hybrid_b_plus_c`, `ux.mobile_strategy`, `ux.react_native_ingestion_programme` — i.e. Go Sidecar follows the same research-first ingestion-programme pattern that Dave ratified for React Native.
+
+**Empirical witness — zero existing Go in fleet:** `find /home/elliotbot/clawd -name "*.go" -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/vendor/*"` returned **0 files**. Confirms Aiden's "zero specialisation" assertion empirically.
+
+---
+
+## 1. Go-sidecar shape — three patterns considered
+
+### Shape A — Embedded Go library (in-process call)
+
+OPA (Open Policy Agent) supports embedding via `github.com/open-policy-agent/opa/v1/rego`:
+
+> "OPA can be embedded inside Go programs as a library… the simplest way to embed OPA as a library is to import the github.com/open-policy-agent/opa/rego package." — openpolicyagent.org/docs/integration
+
+Lowest latency (in-process function call), but **the consuming process must be Go.** Keiracom agents are Python (Claude Code subprocess + Python orchestrator), so an embedded Go library cannot be called directly. **REJECTED for V1.**
+
+### Shape B — HTTP sidecar (Envoy `ext_authz`-style) — RECOMMENDED
+
+> "With a sidecar, you configure Envoy's ext_authz filter to call a centralized policy engine on every request. The authorization decision happens in the sidecar before the request ever reaches your application code." — cloud.google.com/service-mesh/docs/gateway/security-envoy-setup
+
+Per-tenant Go HTTP server co-located with the agent container. Agents (Python) POST tool calls to `http://sidecar:4100/validate` before invoking the MCP server. Sidecar validates against static config + returns `allow`/`deny`. Network hop adds ~1-5ms; works regardless of agent language.
+
+**This is the recommended shape** because:
+1. **Language-agnostic** — Python agents call via stdlib `urllib`.
+2. **Matches mcp.go_sidecar Cat 10 phrasing** — "Go sidecar — security interceptor + tool-call validator". Sidecar = separate process = HTTP boundary.
+3. **Mirrors the TEI sidecar pattern** — `infra/keiracom_system/embeddings/docker-compose.tei.yml` is already shipped (Phase 2 wave 2 item 2, PR #1133). Same per-tenant docker-compose project pattern.
+4. **MCP Gateway/Interceptor literature converges on this shape** — see §2.
+
+### Shape C — Transparent network proxy (iptables redirect)
+
+> "In the sidecar pattern, Envoy is deployed as a companion container alongside each microservice container in a pod… It **intercepts all inbound and outbound network traffic** to/from the service." — Lukas Niessen, Medium 2026-03
+
+Service-mesh-grade: redirect traffic at L3/L4 so the agent doesn't even know the sidecar exists. Higher infra complexity (Envoy + Istio control plane or equivalent); only worth it when agent code can't be modified. **Overkill for V1.** Re-evaluate at V2 if agent code immutability becomes a constraint.
+
+---
+
+## 2. MCP-ecosystem evidence — interceptor pattern is the converging standard
+
+Verbatim from MCP-gateway literature (2026):
+
+> "An MCP gateway is a specialized middleware layer that sits between MCP clients (AI agents) and MCP servers (tools), acting as a single, centralized policy enforcement point. Its primary function is to intercept every request from an agent, apply a series of security, policy, and routing rules, and then forward the request to the appropriate upstream tool." — tyk.io/learning-center/mcp-gateway-architecture-technical-guide
+
+> "Interceptors act as programmable security filters/middleware that sit between AI clients and MCP tools, functioning as security guards that inspect, modify, or block every tool call in real-time. The interceptor pattern typically involves 'before' interceptors to inspect/modify/block tool calls, tool execution in secure containerized MCP servers, and 'after' interceptors to process/log/transform responses." — ChatForest, MCP Gateway & Proxy Patterns
+
+**Standardisation signal — MCP SEP-1763** (modelcontextprotocol/modelcontextprotocol#1763):
+> "SEP-1763: Interceptors for Model Context Protocol" — open proposal to standardise interceptor frameworks in 2025-2026. Our Go Sidecar should *not* deviate from whatever SEP-1763 ratifies; track it as a follow-up risk.
+
+Mapping: our sidecar = a "**before** interceptor" per the ChatForest taxonomy. Engineer-tier adds an "**after** interceptor" for response-side secret scanning (see §3.3).
+
+---
+
+## 3. Three enforcement responsibilities — mapped from V2 lock to scaffold
+
+The V2 inventory load-bears the sidecar across three categories. Scaffold demonstrates all three so engineer-tier doesn't accidentally drop one.
+
+### 3.1 Tool-call whitelist (Cat 10, RATIFIED-DM)
+
+Static config principle: "static config not knowledge graph; mechanical enforcement". No Rego, no OPA, no policy DSL. Just a Go struct keyed by tenant ID with `AllowedTools []string`. String-match at hot path; O(N) for small N (V1 tool counts in the 10s).
+
+> Scaffold: `internal/validator/validator.go` `DefaultValidator.Allow` — `contains(t.AllowedTools, c.Tool)`.
+
+### 3.2 System file isolation (Cat 19 `ux.files.system_files_hidden`, RATIFIED-CEO)
+
+Closes the **named GAP** at inventory line 461: "`ux.files.system_files_hidden ← mcp.go_sidecar` currently GAP/pending — customer file system could leak system files without Go Sidecar enforcement."
+
+Implementation: prefix-deny on `tenant.system_path_deny`. Example deny prefixes (from `config.example.json`):
+- `/var/keiracom/system/`
+- `/var/keiracom/reasoning_traces/`
+- `/var/keiracom/system_prompts/`
+- `/var/keiracom/governance/`
+- `/var/keiracom/temporal_state/`
+
+Any `read_file`/`write_file` tool call with a `Path` starting with one of these → 403.
+
+> Scaffold: `internal/validator/validator.go` `DefaultValidator.Allow` — `strings.HasPrefix(c.Path, deny)`.
+
+### 3.3 Secret leak prevention (Cat 16 `infra.secrets_management`, LOOSE-BLOCKER, V1 HARD GATE)
+
+> Inventory line 208 verbatim: "Go Sidecar validates no raw secret leaks into LLM context."
+
+Implementation: `ScanResponse` checks response body against tenant-specific + global secret patterns BEFORE the body reaches the agent's LLM context. Example global patterns: `BEGIN RSA PRIVATE KEY`, `BEGIN OPENSSH PRIVATE KEY`, `hvs.` (Vault tokens), `ghp_` (GitHub PATs). Tenant-specific: BYOK provider key prefixes (`sk-ant-`, `sk-proj-`, `AIza`).
+
+> Scaffold: `internal/validator/validator.go` `DefaultValidator.ScanResponse`.
+
+Engineer-tier upgrade path: replace substring match with compiled regex set; consider trufflehog detector library at V1.5 for high-recall pattern catalogue.
+
+---
+
+## 4. Scaffold deliverable
+
+**Files (`infra/keiracom_system/go_sidecar/`):**
+
+| Path | LoC (Go only) | Purpose |
+|---|---:|---|
+| `cmd/sidecar/main.go` | 57 | HTTP listener — `/health` + `/validate` |
+| `internal/config/config.go` | 48 | Static whitelist `Config` struct + JSON load (no external YAML dep) |
+| `internal/validator/validator.go` | 80 | `Validator` interface + `DefaultValidator` (tool/path/domain/secret-scan) |
+| **Go total** | **185** | (~115 non-blank-non-comment) |
+| `config.example.json` | n/a | Tenant config example — allowed tools, denied system paths, secret patterns |
+| `Dockerfile` | n/a | Multi-stage → distroless static binary |
+| `docker-compose.go-sidecar.yml` | n/a | Per-tenant compose snippet (mirrors TEI sidecar) |
+| `go.mod` | n/a | `go 1.22`, **zero external deps** in scaffold |
+| `README.md` | n/a | Quick-check curl snippets + responsibilities map |
+
+**LoC honesty note:** dispatch target was 50-100 LoC; scaffold lands at ~115 non-blank-non-comment Go LoC across three files. Trimming would force dropping one of the three V2-lock responsibilities (secret-scan being the easiest to drop). I exceeded the LoC ceiling to preserve responsibility coverage — secret-scan IS in the V2 lock at Cat 16 LOOSE-BLOCKER, so dropping it from the scaffold would misrepresent the work engineer-tier still has to do. Engineer-tier review may opt to trim if they prefer.
+
+**Zero-external-dep choice:** scaffold uses stdlib `encoding/json` instead of `gopkg.in/yaml.v3`. Engineer-tier picks YAML vs JSON for the production config format — both are 1-line swaps. Static config principle holds either way.
+
+**Local verify (engineer-tier runs — Go is not installed in scout's worktree):**
+
+```bash
+cd infra/keiracom_system/go_sidecar
+go build ./...
+docker compose -f docker-compose.go-sidecar.yml up --build
+curl -fsS http://localhost:4100/health   # {"ok":true}
+```
+
+---
+
+## 5. Existing-Go-in-fleet probe — verbatim
+
+```
+$ find /home/elliotbot/clawd -name "*.go" -not -path "*/node_modules/*" \
+    -not -path "*/.git/*" -not -path "*/vendor/*" 2>/dev/null | head -30
+[zero output — no Go files anywhere in the fleet]
+```
+
+Confirms Aiden's Cat 19 §3B "zero specialisation" — no prior Go work exists. This research/scaffold doc is the fleet's first Go memory anchor.
+
+Recommendation: also write a `bd discover` entry tagged `go-sidecar,first-go,scaffold-shape` to seed the Hindsight memory pool for the engineer-tier handoff — they should be able to `bd recall go-sidecar` and find this doc.
+
+---
+
+## 6. Engineer-tier handoff scope (what's left to build)
+
+**In-scope for engineer-tier (Atlas + Orion per Cat 10 ownership):**
+
+1. **Forwarding half** — `/validate` currently returns `{allow:true}` or 403. Production needs `/proxy` that validates THEN forwards to the upstream MCP server, streams the response back through `ScanResponse`, and returns to the agent. ~80 LoC.
+
+2. **Python agent client** — `src/keiracom_system/mcp/sidecar_client.py` with `validate_or_raise(tool_call)` + retry/timeout + circuit-breaker. ~50 LoC.
+
+3. **Hard-gate integration** — wire the client into the Python MCP server at `src/keiracom_system/mcp/server.py` so every `tools/call` request goes through the sidecar BEFORE the tool executes. ~30 LoC of changes.
+
+4. **YAML config format + hot-reload** — engineer-tier may prefer YAML over JSON; add `fsnotify`-based reload so config changes don't require container restart. ~40 LoC + 1 external dep.
+
+5. **Compiled-regex secret patterns** — swap `strings.Contains` for compiled regex set; benchmark cost on 10KB response bodies; cap at ~1ms p99 budget. ~30 LoC.
+
+6. **Metrics + observability** — Prometheus `/metrics` endpoint (deny-rate per tenant, latency histogram, panic counter). ~40 LoC + Prometheus client dep.
+
+7. **HMAC-signed tenant config** — config file integrity check at boot so a tampered config can't silently widen the allow-list. ~25 LoC.
+
+8. **Integration tests** — Go `_test.go` files + Python integration test that spins compose stack, asserts allow/deny matrix, asserts system-path deny, asserts secret-pattern hit. ~150 LoC of test code.
+
+9. **Atomic config swap with rollback** — `SIGHUP` triggers re-read of config; if new config fails validation, keep the old config in memory and log the failure to NATS. ~30 LoC.
+
+10. **Documentation** — runbook at `docs/runbooks/go-sidecar-operate.md` covering: how to add a tenant, how to add a tool to the allowlist, how to drill a deny scenario, how to rotate secret patterns. Mirrors KEI-126 Postgres restore runbook structure.
+
+**Out of scope for V1 (V1.5+):**
+
+- SEP-1763 conformance once MCP standardises interceptor spec.
+- Sigstore-signed config bundles.
+- WASM-pluggable validators (Envoy WASM pattern).
+- Multi-region sidecar replicas — V1 is single-region (syd1) per `vercel.json` regions setting.
+
+**LoC + complexity estimate for full V1 engineer-tier build:**
+
+| Item | Est. LoC | Est. complexity |
+|---|---:|---|
+| Items 1-3 (proxy, client, MCP wire-up) | ~160 | medium — touches Python MCP server hot-path |
+| Items 4-5 (YAML/hot-reload, regex secret patterns) | ~70 + 1 Go dep | low |
+| Items 6-7 (metrics, HMAC config) | ~65 + 1 Go dep | low |
+| Items 8-10 (tests, atomic swap, runbook) | ~180 + 1 runbook | medium — drills are mandatory per Cat 16 HARD GATE |
+| **Total V1 build (excluding scaffold)** | **~475 LoC** | medium |
+
+Compared with the TEI sidecar precedent (PR #1133): TEI shipped ~250 LoC Python client + ~30 LoC compose snippet + ~150 LoC install script + tests. Go Sidecar will be larger (~475 LoC) because the validation surface is broader than TEI's "forward embedding request" job.
+
+**Estimated engineer-tier time:** 2-4 work-days for Atlas + Orion in parallel (Atlas on proxy/MCP-integration, Orion on tests/runbook/config-hot-reload).
+
+---
+
+## 7. Risks + open questions for deliberation
+
+1. **Network-hop tax.** Every MCP tool call gets ~1-5ms added latency. For tool-heavy agents (10+ calls/turn) that's 50ms cumulative. Acceptable for V1; revisit if Cat 17 per-tier-pool benchmarks show contention.
+2. **Sidecar SPOF.** If the sidecar dies, MCP tool calls fail. Mitigation per Envoy precedent: `restart: unless-stopped` (in scaffold compose) + health-check gate from caller side. Engineer-tier should choose fail-closed (recommended for security) vs fail-open (recommended for availability). **Aiden + Elliot call.**
+3. **Config tampering surface.** Static config file = anyone with disk write on the sidecar host can widen allow-list. Mitigation: HMAC-signed config (item 7 above) + read-only volume mount in compose (already in scaffold). Worth raising as Phase 2 sub-deliberation.
+4. **SEP-1763 standardisation drift.** Our sidecar is an ad-hoc HTTP `/validate` endpoint. If MCP SEP-1763 ratifies a different RPC shape (e.g. gRPC), we'll need a v2 protocol layer. Track as P3 risk; low likelihood pre-V1.
+5. **Per-tenant sidecar count.** TEI sidecar pattern is per-tenant. If Go Sidecar follows, that's N containers for N tenants → 4 GB+ idle RSS at 100 tenants. Cat 17 hybrid (shared pool for Solo/Pro, dedicated for Team+) likely applies. **Engineer-tier benchmark before V1 launch.**
+
+---
+
+## SOURCES (verbatim probe trail)
+
+- `ceo:keiracom_architecture_v2_locked` ceo_memory key (updated_at `2026-05-25 13:17:35Z`)
+- `docs/architecture/keiracom_architecture_v2_inventory.md` (62700 bytes) — lines 143-170 (Cat 10), 199-215 (Cat 16), 289-491 (Cat 19), 461 (cross-dep edge)
+- `find /home/elliotbot/clawd -name "*.go" -not -path ...` (empirical zero-Go-files witness)
+- `git show origin/main:infra/keiracom_system/embeddings/README.md` + `docker-compose.tei.yml` (TEI sidecar pattern reference)
+- Web research (URLs):
+  - https://www.openpolicyagent.org/docs/integration — OPA Go embedding
+  - https://cloud.google.com/service-mesh/docs/gateway/security-envoy-setup — Envoy ext_authz
+  - https://tyk.io/learning-center/mcp-gateway-architecture-technical-guide/ — MCP gateway architecture
+  - https://chatforest.com/guides/mcp-gateway-proxy-patterns/ — MCP interceptor taxonomy
+  - https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1763 — SEP-1763 Interceptors proposal
+  - https://lukasniessen.medium.com/the-sidecar-pattern-why-every-major-tech-company-runs-proxies-on-every-pod-8138d79c597a — Sidecar pattern survey
+  - https://medium.com/@monishashah06/the-sidecar-security-microservice-pattern-enforcing-path-aware-security-at-scale-d56d02136da9 — Sidecar security micropattern
+  - https://pkg.go.dev/github.com/go-coldbrew/interceptors — Go interceptors reference (gRPC, not adopted)

--- a/infra/keiracom_system/go_sidecar/Dockerfile
+++ b/infra/keiracom_system/go_sidecar/Dockerfile
@@ -1,0 +1,16 @@
+# Multi-stage build — produces a ~10MB static binary on top of distroless.
+# Engineer-tier may swap to scratch + CGO_ENABLED=0 once dependencies are pinned.
+
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod ./
+# Engineer-tier adds go.sum once external deps land; scaffold has none.
+COPY cmd ./cmd
+COPY internal ./internal
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/sidecar ./cmd/sidecar
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/sidecar /usr/local/bin/sidecar
+EXPOSE 4100
+USER nonroot:nonroot
+ENTRYPOINT ["/usr/local/bin/sidecar"]

--- a/infra/keiracom_system/go_sidecar/README.md
+++ b/infra/keiracom_system/go_sidecar/README.md
@@ -1,0 +1,50 @@
+# Keiracom System — Go Sidecar (scaffold)
+
+Phase A4 research + scaffold. Canonical-key anchor: `ceo:keiracom_architecture_v2_locked` Cat 10 `mcp.go_sidecar` — **RATIFIED-DM**, V1-launch (BUILD pending). Owners: Atlas + Orion (engineer-tier).
+
+This directory is the **research scaffold only.** Engineer-tier builds the production sidecar on this shape; the research doc at `docs/wave2/phase_a4_go_sidecar_research_and_scaffold.md` carries the full findings + handoff scope.
+
+## What's here
+
+| Path | Purpose |
+|---|---|
+| `cmd/sidecar/main.go` | HTTP listener (`/health` + `/validate`) — entrypoint |
+| `internal/config/config.go` | Static whitelist `Config` struct + JSON load |
+| `internal/validator/validator.go` | `Validator` interface + `DefaultValidator` (tool / path / domain / secret-scan) |
+| `config.example.json` | Example tenant config — allowed tools, denied system paths, secret patterns |
+| `Dockerfile` | Multi-stage build → distroless static binary |
+| `docker-compose.go-sidecar.yml` | Per-tenant compose snippet (mirrors `embeddings/docker-compose.tei.yml`) |
+| `go.mod` | Module declaration — `go 1.22`, **zero external deps in scaffold** |
+
+## Quick check (engineer-tier will run)
+
+```bash
+cd infra/keiracom_system/go_sidecar
+go build ./...                              # scaffold compiles, no external deps
+docker compose -f docker-compose.go-sidecar.yml up --build  # local sidecar :4100
+curl -fsS http://localhost:4100/health      # {"ok":true}
+
+# Validate a sample tool call
+curl -fsS -X POST http://localhost:4100/validate \
+  -H 'content-type: application/json' \
+  -d '{"TenantID":"tenant_demo","Tool":"read_file","Path":"/workspace/tenant_demo/notes.md"}'
+# {"allow":true}
+
+# Same call but pointed at a system path → 403
+curl -i -X POST http://localhost:4100/validate \
+  -H 'content-type: application/json' \
+  -d '{"TenantID":"tenant_demo","Tool":"read_file","Path":"/var/keiracom/system/reasoning.log"}'
+# HTTP/1.1 403 Forbidden
+# validator: system path access denied (ux.files.system_files_hidden)
+```
+
+## Three enforcement responsibilities (from V2 lock)
+
+1. **Tool-call whitelist** — `mcp.go_sidecar` Cat 10. Mechanical, static config; agent's MCP tool name must appear in `tenant.allowed_tools`.
+2. **System file isolation** — `ux.files.system_files_hidden` Cat 19 (RATIFIED-CEO). System files (reasoning traces, system prompts, governance configs, Temporal state) NEVER queryable. Prefix-deny on `tenant.system_path_deny`. **Cross-dep:** `ux.files.system_files_hidden ← mcp.go_sidecar` is the named GAP closed by this build.
+3. **Secret leak prevention** — `infra.secrets_management` Cat 16 LOOSE-BLOCKER. "Go Sidecar validates no raw secret leaks into LLM context." Pattern scan on response bodies before they reach the LLM.
+
+## Engineer-tier handoff scope
+
+Full handoff scope + LoC estimate + complexity assessment in the research doc:
+`docs/wave2/phase_a4_go_sidecar_research_and_scaffold.md` §6.

--- a/infra/keiracom_system/go_sidecar/README.md
+++ b/infra/keiracom_system/go_sidecar/README.md
@@ -14,7 +14,8 @@ This directory is the **research scaffold only.** Engineer-tier builds the produ
 | `config.example.json` | Example tenant config — allowed tools, denied system paths, secret patterns |
 | `Dockerfile` | Multi-stage build → distroless static binary |
 | `docker-compose.go-sidecar.yml` | Per-tenant compose snippet (mirrors `embeddings/docker-compose.tei.yml`) |
-| `go.mod` | Module declaration — `go 1.22`, **zero external deps in scaffold** |
+| `go.mod` / `go.sum` | Module declaration — `go 1.22`, **zero external deps in scaffold** (empty `go.sum`) |
+| `internal/validator/validator_test.go` | 8 tests — 5 Allow negative + 1 Allow positive + 2 ScanResponse (one each side) |
 
 ## Quick check (engineer-tier will run)
 
@@ -48,3 +49,31 @@ curl -i -X POST http://localhost:4100/validate \
 
 Full handoff scope + LoC estimate + complexity assessment in the research doc:
 `docs/wave2/phase_a4_go_sidecar_research_and_scaffold.md` §6.
+
+### Architectural defaults — locked
+
+- **Fail-closed on SPOF.** Aiden architectural call 2026-05-25 (research doc §7 risk 2). If the sidecar `/validate` call fails for any reason — timeout, 5xx, connection refused — the upstream MCP tool call is **REJECTED**, not forwarded. Caller surfaces a sanitised denial to the LLM context. Reasoning: sidecar is the security interceptor per Cat 10 "mechanical enforcement"; failing-open silently bypasses security, failing-closed produces visible breakage that is recoverable via customer report + ops response. Consistent with Cat 16 HARD GATE posture (Vault sealed = fail; BYOK invalid = fail; rate limit hit = reject). Engineer-tier item 1 (`/proxy` forwarding half) MUST default fail-closed.
+
+### Engineer-tier NITs (non-blocking, track in build dispatch)
+
+Aiden surfaced 5 NITs against the scaffold during architectural review 2026-05-25. Non-blocking for scaffold merge; engineer-tier addresses during the production build:
+
+- **NIT-1 — Typed deny errors.** Replace `errors.New("...")` strings with typed sentinel errors (`ErrUnknownTenant`, `ErrToolNotAllowed`, `ErrSystemPathDenied`, `ErrDomainNotAllowed`, `ErrSecretLeak`). Improves caller branch logic + structured logging.
+- **NIT-2 — Compiled-regex secret patterns + p99 benchmark.** Swap `strings.Contains` for compiled regex set in `ScanResponse`. Benchmark on 10KB response body; cap at p99 ≤ 1ms.
+- **NIT-3 — Config.Load validates `len(Tenants) > 0`.** An empty `Tenants` map deserialises silently and denies every call — load should return an explicit error so misconfigured boots fail loud, not silent.
+- **NIT-4 — `SchemaVersion` field on `Config`.** Add `SchemaVersion int` so future HMAC-signed config migrations have a compat axis. Mirror Vault token schema versioning.
+- **NIT-5 — Request-ID propagation.** `/validate` reads `X-Request-ID` header (or generates one) and threads through logs + denial messages. Lets the agent-side caller correlate the denial back to the originating LLM turn for traceability.
+
+### Security posture (V1 build targets — Max review note)
+
+- **TLS posture.** Sidecar↔agent traffic V1: localhost-only loopback (intra-pod / intra-`docker-compose-network`), no TLS required. V1.1: mTLS once sidecar moves cross-pod (or once Cat 17 hybrid-pool surfaces sidecars on a shared subnet).
+- **Request size cap.** Engineer-tier MUST wrap incoming bodies with `http.MaxBytesReader` — default cap 64 KB on `/validate`, configurable per tenant. Prevents memory-exhaustion DoS on malformed payloads.
+- **Auth pattern.** Per-tenant HMAC bearer token on the `/validate` request (`Authorization: Bearer <hmac>`); secret material loaded from the same static config (`config.example.json` adds `auth_secrets[<tenant_id>]`). Upgrade to mTLS client-cert auth at V1.1 when cross-pod.
+
+### Known unknowns (engineer-tier resolves during build)
+
+- **Test strategy boundary** — unit tests live in `internal/validator/validator_test.go` (this PR); integration tests (compose-up + curl matrix) are engineer-tier item 8. Decide whether to run Go integration tests inside CI or only in a pre-merge smoke environment.
+- **Deployment secret material** — config files mounted read-only from `/etc/keiracom/sidecar.json`. Where does the config originate (Vault static-mount? K8s Secret? GitOps-templated)? Engineer-tier picks one path and documents it in the operate runbook.
+- **GitOps wiring** — which CD picks up sidecar config diff. If it's the same Railway+Vercel pipeline (per CI/CD audit `docs/cicd_gap_audit_findings.md`), engineer-tier wires the sidecar redeploy on `infra/keiracom_system/go_sidecar/**` paths-filter.
+- **Structured logging library** — `log/slog` (stdlib, Go 1.21+) vs `zap` (faster, more featureful). Default to `slog` for zero-dep posture unless benchmarks force `zap`. PII redaction policy: never log tenant payload bodies; log only `tenant_id + tool + denial_reason`.
+- **Liveness vs readiness probes** — `/health` currently serves both. Engineer-tier separates: `/health/live` (process up) vs `/health/ready` (config loaded + first config-validation pass succeeded). Critical for fail-closed: a not-ready sidecar must not receive traffic from upstream callers.

--- a/infra/keiracom_system/go_sidecar/cmd/sidecar/main.go
+++ b/infra/keiracom_system/go_sidecar/cmd/sidecar/main.go
@@ -1,0 +1,57 @@
+// Command sidecar — Go HTTP listener for the Keiracom security interceptor.
+//
+// Shape B from the research doc: per-tenant HTTP sidecar co-located with the
+// agent container. Agents POST tool calls; sidecar validates against static
+// config + forwards or rejects. Engineer-tier wires the forwarding half.
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/keiracom/keiracom_system/go_sidecar/internal/config"
+	"github.com/keiracom/keiracom_system/go_sidecar/internal/validator"
+)
+
+func main() {
+	cfgPath := os.Getenv("SIDECAR_CONFIG_PATH")
+	if cfgPath == "" {
+		cfgPath = "/etc/keiracom/sidecar.json"
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		log.Fatalf("config load: %v", err)
+	}
+	v := validator.New(cfg)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	mux.HandleFunc("/validate", func(w http.ResponseWriter, r *http.Request) {
+		var c validator.ToolCall
+		if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := v.Allow(c); err != nil {
+			// 403 + reason — agent caller logs and surfaces a sanitised denial to the LLM.
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"allow":true}`))
+	})
+
+	addr := os.Getenv("SIDECAR_ADDR")
+	if addr == "" {
+		addr = ":4100"
+	}
+	log.Printf("go_sidecar listening on %s (config %s)", addr, cfgPath)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/infra/keiracom_system/go_sidecar/config.example.json
+++ b/infra/keiracom_system/go_sidecar/config.example.json
@@ -1,0 +1,24 @@
+{
+  "tenants": {
+    "tenant_demo": {
+      "id": "tenant_demo",
+      "allowed_tools": ["read_file", "write_file", "http_get"],
+      "allowed_domains": ["api.example.com", "docs.example.com"],
+      "allowed_paths": ["/workspace/tenant_demo/"],
+      "system_path_deny": [
+        "/var/keiracom/system/",
+        "/var/keiracom/reasoning_traces/",
+        "/var/keiracom/system_prompts/",
+        "/var/keiracom/governance/",
+        "/var/keiracom/temporal_state/"
+      ],
+      "secret_patterns": ["sk-ant-", "sk-proj-", "AIza"]
+    }
+  },
+  "global_secret_patterns": [
+    "BEGIN RSA PRIVATE KEY",
+    "BEGIN OPENSSH PRIVATE KEY",
+    "hvs.",
+    "ghp_"
+  ]
+}

--- a/infra/keiracom_system/go_sidecar/docker-compose.go-sidecar.yml
+++ b/infra/keiracom_system/go_sidecar/docker-compose.go-sidecar.yml
@@ -1,0 +1,29 @@
+# Keiracom System — Go Sidecar (security interceptor + tool-call validator).
+#
+# Cat 10 mcp.go_sidecar (RATIFIED-DM). Per-tenant sidecar — same per-tenant
+# docker-compose project pattern as the TEI sidecar at infra/keiracom_system/
+# embeddings/docker-compose.tei.yml.
+#
+# Agents POST tool calls to http://sidecar:4100/validate before invoking MCP.
+# Engineer-tier ships the agent-side client + forward-or-deny half; scaffold
+# proves the listener shape compiles.
+
+services:
+  sidecar:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "4100:4100"
+    volumes:
+      # Per-tenant config mounted read-only — static config not knowledge graph.
+      - ./config.example.json:/etc/keiracom/sidecar.json:ro
+    environment:
+      SIDECAR_CONFIG_PATH: /etc/keiracom/sidecar.json
+      SIDECAR_ADDR: ":4100"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:4100/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+    restart: unless-stopped

--- a/infra/keiracom_system/go_sidecar/go.mod
+++ b/infra/keiracom_system/go_sidecar/go.mod
@@ -1,0 +1,8 @@
+// Go sidecar — security interceptor + tool-call validator (mcp.go_sidecar, Cat 10).
+// Module name follows infra/keiracom_system/<sidecar> convention; no external
+// imports yet (scaffold only). Engineer-tier picks the YAML library + HTTP
+// framework at build time per their preference.
+
+module github.com/keiracom/keiracom_system/go_sidecar
+
+go 1.22

--- a/infra/keiracom_system/go_sidecar/internal/config/config.go
+++ b/infra/keiracom_system/go_sidecar/internal/config/config.go
@@ -1,0 +1,48 @@
+// Package config — static whitelist config struct loaded from YAML at startup.
+//
+// Mechanical enforcement per `mcp.go_sidecar` Cat 10: "static config not
+// knowledge graph". No policy language, no runtime mutation — agents see what
+// the YAML lets them see.
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+// Tenant — the unit of isolation. One tenant per Keiracom customer.
+type Tenant struct {
+	ID              string   `json:"id"`
+	AllowedTools    []string `json:"allowed_tools"`     // MCP tool names whitelisted for this tenant
+	AllowedDomains  []string `json:"allowed_domains"`   // outbound HTTP domains allowed
+	AllowedPaths    []string `json:"allowed_paths"`     // file-system paths customer may read/write (PREFIX match)
+	SystemPathDeny  []string `json:"system_path_deny"`  // explicit deny list — system files NEVER queryable (ux.files.system_files_hidden)
+	SecretPatterns  []string `json:"secret_patterns"`   // regex/substring patterns scanned against responses (no raw secret leaks)
+}
+
+// Config — top level: tenant map + global deny patterns.
+type Config struct {
+	Tenants               map[string]Tenant `json:"tenants"`
+	GlobalSecretPatterns  []string          `json:"global_secret_patterns"`
+}
+
+// Load reads a JSON config file. YAML support is an engineer-tier choice;
+// JSON is stdlib-only and keeps the scaffold dependency-free.
+func Load(path string) (*Config, error) {
+	if path == "" {
+		return nil, errors.New("config: path required")
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var c Config
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, err
+	}
+	if c.Tenants == nil {
+		c.Tenants = make(map[string]Tenant)
+	}
+	return &c, nil
+}

--- a/infra/keiracom_system/go_sidecar/internal/validator/validator.go
+++ b/infra/keiracom_system/go_sidecar/internal/validator/validator.go
@@ -1,0 +1,80 @@
+// Package validator — Validator interface + DefaultValidator stub.
+//
+// Enforces the three mcp.go_sidecar responsibilities surfaced in the V2 lock:
+//  1. Tool-call whitelist (Cat 10).
+//  2. System file isolation (Cat 19 ux.files.system_files_hidden — deny prefix match).
+//  3. Secret leak detection on responses (Cat 16 infra.secrets_management).
+//
+// Engineer-tier fills out the per-rule logic; this scaffold proves the shape compiles.
+package validator
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/keiracom/keiracom_system/go_sidecar/internal/config"
+)
+
+// ToolCall — minimal shape of an MCP tool invocation.
+type ToolCall struct {
+	TenantID string
+	Tool     string
+	Path     string // file-system tools only (read_file, write_file, etc.)
+	Domain   string // http tools only
+}
+
+// Validator — interface that interceptors call before forwarding to MCP server.
+type Validator interface {
+	Allow(c ToolCall) error                // returns nil on allow, error on deny (with reason)
+	ScanResponse(tenantID string, body []byte) error // post-call: deny if secret pattern hit
+}
+
+// DefaultValidator — static-config implementation. Mechanical: string match, no regex eval at hot path.
+type DefaultValidator struct {
+	cfg *config.Config
+}
+
+func New(cfg *config.Config) *DefaultValidator {
+	return &DefaultValidator{cfg: cfg}
+}
+
+func (v *DefaultValidator) Allow(c ToolCall) error {
+	t, ok := v.cfg.Tenants[c.TenantID]
+	if !ok {
+		return errors.New("validator: unknown tenant")
+	}
+	if !contains(t.AllowedTools, c.Tool) {
+		return errors.New("validator: tool not in tenant allowlist")
+	}
+	for _, deny := range t.SystemPathDeny {
+		if c.Path != "" && strings.HasPrefix(c.Path, deny) {
+			return errors.New("validator: system path access denied (ux.files.system_files_hidden)")
+		}
+	}
+	if c.Domain != "" && !contains(t.AllowedDomains, c.Domain) {
+		return errors.New("validator: domain not in tenant allowlist")
+	}
+	return nil
+}
+
+func (v *DefaultValidator) ScanResponse(tenantID string, body []byte) error {
+	t := v.cfg.Tenants[tenantID]
+	patterns := append([]string{}, v.cfg.GlobalSecretPatterns...)
+	patterns = append(patterns, t.SecretPatterns...)
+	s := string(body)
+	for _, p := range patterns {
+		if strings.Contains(s, p) {
+			return errors.New("validator: secret pattern hit in response")
+		}
+	}
+	return nil
+}
+
+func contains(xs []string, x string) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}

--- a/infra/keiracom_system/go_sidecar/internal/validator/validator_test.go
+++ b/infra/keiracom_system/go_sidecar/internal/validator/validator_test.go
@@ -1,0 +1,134 @@
+// Tests for DefaultValidator — security-gate negative-path coverage per
+// feedback_negative_path_test_before_approve. Engineer-tier extends these as
+// the validator surface grows (regex secret patterns, schema versioning, etc).
+package validator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/keiracom/keiracom_system/go_sidecar/internal/config"
+)
+
+// fixture — small static config exercised by all tests.
+func fixture() *config.Config {
+	return &config.Config{
+		Tenants: map[string]config.Tenant{
+			"tenant_a": {
+				ID:             "tenant_a",
+				AllowedTools:   []string{"read_file", "http_get"},
+				AllowedDomains: []string{"api.example.com"},
+				AllowedPaths:   []string{"/workspace/tenant_a/"},
+				SystemPathDeny: []string{"/var/keiracom/system/", "/var/keiracom/reasoning_traces/"},
+				SecretPatterns: []string{"sk-ant-"},
+			},
+		},
+		GlobalSecretPatterns: []string{"BEGIN RSA PRIVATE KEY"},
+	}
+}
+
+// 1. negative — unknown tenant denied.
+func TestAllow_UnknownTenant(t *testing.T) {
+	v := New(fixture())
+	err := v.Allow(ToolCall{TenantID: "tenant_ghost", Tool: "read_file"})
+	if err == nil {
+		t.Fatal("expected deny for unknown tenant; got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown tenant") {
+		t.Fatalf("expected 'unknown tenant' reason; got %v", err)
+	}
+}
+
+// 2. negative — tool not in tenant allowlist.
+func TestAllow_ToolNotInAllowlist(t *testing.T) {
+	v := New(fixture())
+	err := v.Allow(ToolCall{TenantID: "tenant_a", Tool: "shell_exec"})
+	if err == nil {
+		t.Fatal("expected deny for out-of-allowlist tool; got nil")
+	}
+	if !strings.Contains(err.Error(), "tool not in tenant allowlist") {
+		t.Fatalf("expected 'tool not in tenant allowlist' reason; got %v", err)
+	}
+}
+
+// 3. negative — system path access denied (closes ux.files.system_files_hidden GAP).
+func TestAllow_SystemPathDenied(t *testing.T) {
+	v := New(fixture())
+	err := v.Allow(ToolCall{
+		TenantID: "tenant_a",
+		Tool:     "read_file",
+		Path:     "/var/keiracom/system/reasoning.log",
+	})
+	if err == nil {
+		t.Fatal("expected deny for system path; got nil")
+	}
+	if !strings.Contains(err.Error(), "system path access denied") {
+		t.Fatalf("expected 'system path access denied' reason; got %v", err)
+	}
+}
+
+// 4. negative — outbound domain not whitelisted.
+func TestAllow_DomainNotAllowed(t *testing.T) {
+	v := New(fixture())
+	err := v.Allow(ToolCall{
+		TenantID: "tenant_a",
+		Tool:     "http_get",
+		Domain:   "evil.example.org",
+	})
+	if err == nil {
+		t.Fatal("expected deny for non-whitelisted domain; got nil")
+	}
+	if !strings.Contains(err.Error(), "domain not in tenant allowlist") {
+		t.Fatalf("expected 'domain not in tenant allowlist' reason; got %v", err)
+	}
+}
+
+// 5. negative — empty payload (zero-value ToolCall) — no tenant resolves.
+func TestAllow_EmptyPayload(t *testing.T) {
+	v := New(fixture())
+	err := v.Allow(ToolCall{})
+	if err == nil {
+		t.Fatal("expected deny for empty payload (no tenant id); got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown tenant") {
+		t.Fatalf("expected 'unknown tenant' on empty payload; got %v", err)
+	}
+}
+
+// 6. positive — valid tenant + tool + safe path + whitelisted domain.
+func TestAllow_ValidCall(t *testing.T) {
+	v := New(fixture())
+	cases := []ToolCall{
+		{TenantID: "tenant_a", Tool: "read_file", Path: "/workspace/tenant_a/notes.md"},
+		{TenantID: "tenant_a", Tool: "http_get", Domain: "api.example.com"},
+	}
+	for i, c := range cases {
+		if err := v.Allow(c); err != nil {
+			t.Fatalf("case %d: expected allow; got deny: %v", i, err)
+		}
+	}
+}
+
+// 7. negative ScanResponse — secret pattern in body triggers deny.
+func TestScanResponse_SecretLeak(t *testing.T) {
+	v := New(fixture())
+	body := []byte("here is your key sk-ant-deadbeef1234, do not share")
+	err := v.ScanResponse("tenant_a", body)
+	if err == nil {
+		t.Fatal("expected deny on tenant-specific secret pattern hit; got nil")
+	}
+	// global pattern variant — same gate.
+	body2 := []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEo...")
+	if err := v.ScanResponse("tenant_a", body2); err == nil {
+		t.Fatal("expected deny on global secret pattern hit; got nil")
+	}
+}
+
+// 8. positive ScanResponse — clean body passes.
+func TestScanResponse_Clean(t *testing.T) {
+	v := New(fixture())
+	body := []byte(`{"result":"ok","items":[1,2,3]}`)
+	if err := v.ScanResponse("tenant_a", body); err != nil {
+		t.Fatalf("expected allow on clean response; got deny: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Phase A4 research + scaffold for the Go Sidecar build per `mcp.go_sidecar` Cat 10 (RATIFIED-DM, V1-launch, BUILD pending). Research-tier ingestion phase per Dave's React-Native-style fleet-research pattern — engineer-tier (Atlas + Orion) builds on this scaffold.

Canonical-key query gate honoured: `ceo:keiracom_architecture_v2_locked` Cat 10 + Cat 19 queried and pasted verbatim into the doc's NOTES section per `_orchestrator.md` audit-dispatch checklist.

## What this PR is

**Research doc:** `docs/wave2/phase_a4_go_sidecar_research_and_scaffold.md` — three sidecar shapes considered, MCP-ecosystem evidence, three V2-lock enforcement responsibilities mapped to scaffold lines, engineer-tier handoff scope, 5 risks for deliberation.

**Scaffold:** `infra/keiracom_system/go_sidecar/` — 185 LoC across 3 Go files (~115 non-blank-non-comment), zero external Go dependencies, distroless Dockerfile, per-tenant docker-compose snippet mirroring TEI sidecar (`infra/keiracom_system/embeddings/`).

## What this PR is NOT

- NOT a full production implementation.
- NOT wired into the Python MCP server hot-path.
- NOT tested (Go isn't installed in scout's worktree — engineer-tier verifies).
- NOT load-bearing for live tenants yet.

## Three enforcement responsibilities (from V2 lock, all scaffolded)

1. **Tool-call whitelist** — Cat 10 RATIFIED-DM (static config, mechanical).
2. **System file isolation** — Cat 19 `ux.files.system_files_hidden` RATIFIED-CEO. Closes the named GAP at inventory line 461 (`ux.files.system_files_hidden ← mcp.go_sidecar currently GAP/pending`).
3. **Secret leak prevention** — Cat 16 `infra.secrets_management` LOOSE-BLOCKER / V1 HARD GATE. "Go Sidecar validates no raw secret leaks into LLM context" (inventory line 208 verbatim).

## LoC honesty

Dispatch target was 50-100 LoC; scaffold lands at ~115 non-blank-non-comment Go LoC. Trimming would force dropping one of the three V2-lock responsibilities (secret-scan is easiest to cut). I exceeded the LoC ceiling to preserve responsibility coverage — engineer-tier review may trim if they prefer.

## Engineer-tier handoff scope (10 items, ~475 LoC, 2-4 work-days parallel)

Atlas + Orion own Cat 10 per the inventory. Full breakdown in §6 of the research doc. Top three:
1. Forwarding half — `/proxy` that validates AND forwards (currently only `/validate` allow/deny).
2. Python agent client — `src/keiracom_system/mcp/sidecar_client.py` with retry/timeout/circuit-breaker.
3. Hard-gate integration — wire client into `src/keiracom_system/mcp/server.py` so every `tools/call` goes through the sidecar BEFORE the tool runs.

## Risks named for deliberation

1. Network-hop tax (~1-5ms × 10+ calls/turn = ~50ms cumulative)
2. Sidecar SPOF — fail-closed vs fail-open (Aiden + Elliot call)
3. Config tampering surface — HMAC-signed config recommended
4. SEP-1763 standardisation drift — track as P3
5. Per-tenant sidecar count at 100 tenants (Cat 17 hybrid likely applies)

## Test plan

- [ ] Max code-quality lens: verify scaffold compiles (`go build ./...` — engineer-tier runs this in a worktree with Go installed)
- [ ] Aiden architecture lens: confirm three V2-lock responsibilities are correctly mapped + handoff scope is engineer-tier-appropriate
- [ ] Elliot impl-feasibility lens: confirm the shape (Shape B HTTP sidecar) matches the static-config principle in Cat 10
- [ ] Spot-check `ceo:keiracom_architecture_v2_locked` value still matches the quoted Cat 10 + Cat 19 rows at review time
- [ ] Mirror compose pattern against `infra/keiracom_system/embeddings/docker-compose.tei.yml` to confirm pattern consistency

## NATS

Completion notification will publish to `keiracom.elliot.inbox` after PR open per dispatch instruction.

Dispatch ref: `phase_a4_go_sidecar_research_scaffold`