### PR TITLE
[ORION] feat(keiracom-system/vault): Vault Transit envelope decryptor — Phase A2 (Agency_OS-31bk)

### DIFF
--- a/src/keiracom_system/tenant/keiracom_tenant_extension.py
+++ b/src/keiracom_system/tenant/keiracom_tenant_extension.py
@@ -163,12 +163,13 @@ class _DBProtocol(Protocol):
     def list_active_tenants(self) -> list[dict[str, Any]]: ...
 
 
-def _passthrough_decryptor(ciphertext: str) -> str:
-    """Default decryptor for tests + dev envs (no real pgcrypto round-trip).
+def _passthrough_decryptor(ciphertext: str, tenant_id: str) -> str:  # noqa: ARG001 — tenant_id unused in passthrough
+    """Default decryptor for tests + dev envs (no real Vault round-trip).
 
-    Production wires a real decryptor that calls pgcrypto.pgp_sym_decrypt
-    against the keys_service pattern from src/api/services/customer_api_keys.py
-    (existing Agency_OS-era code; pattern is reusable for Keiracom System).
+    Production wires a real decryptor — see src/keiracom_system/secrets/vault_decryptor.py
+    (Phase A2, bd Agency_OS-31bk). Vault decryptor calls Transit decrypt for
+    /v1/transit/decrypt/keiracom-tenant-{tenant_id} which is why the signature
+    takes tenant_id as well as ciphertext.
     """
     return ciphertext
 
@@ -193,7 +194,7 @@ class KeiracomTenantExtension(_HindsightTenantExtension):
     def __init__(
         self,
         db: _DBProtocol,
-        decryptor: Callable[[str], str] | None = None,
+        decryptor: Callable[[str, str], str] | None = None,
         api_key_header: str | None = None,
     ):
         """Construct with injected db client + decryptor (testability)."""
@@ -261,7 +262,7 @@ class KeiracomTenantExtension(_HindsightTenantExtension):
         except KeiracomTenantProvisioningError as exc:
             log.warning("get_tenant_config: %s", exc)
             return {}
-        decrypted_key = self._decrypt(cfg.llm_api_key)
+        decrypted_key = self._decrypt(cfg.llm_api_key, str(tenant_id))
         return {
             "llm_api_key": decrypted_key,
             "llm_model": cfg.llm_model,

--- a/src/keiracom_system/tenant/keiracom_tenant_extension.py
+++ b/src/keiracom_system/tenant/keiracom_tenant_extension.py
@@ -166,7 +166,7 @@ class _DBProtocol(Protocol):
 def _passthrough_decryptor(ciphertext: str, tenant_id: str) -> str:  # noqa: ARG001 — tenant_id unused in passthrough
     """Default decryptor for tests + dev envs (no real Vault round-trip).
 
-    Production wires a real decryptor — see src/keiracom_system/secrets/vault_decryptor.py
+    Production wires a real decryptor — see src/keiracom_system/vault/vault_decryptor.py
     (Phase A2, bd Agency_OS-31bk). Vault decryptor calls Transit decrypt for
     /v1/transit/decrypt/keiracom-tenant-{tenant_id} which is why the signature
     takes tenant_id as well as ciphertext.

--- a/src/keiracom_system/vault/__init__.py
+++ b/src/keiracom_system/vault/__init__.py
@@ -1,0 +1,18 @@
+"""keiracom_system.vault — secret-store adapters (Vault Transit envelope).
+
+Phase A2 build per bd Agency_OS-31bk.
+"""
+
+from .vault_decryptor import (
+    DEFAULT_KEY_NAME_PREFIX,
+    VaultDecryptError,
+    VaultDecryptor,
+    from_env,
+)
+
+__all__ = [
+    "DEFAULT_KEY_NAME_PREFIX",
+    "VaultDecryptError",
+    "VaultDecryptor",
+    "from_env",
+]

--- a/src/keiracom_system/vault/vault_decryptor.py
+++ b/src/keiracom_system/vault/vault_decryptor.py
@@ -1,0 +1,195 @@
+"""vault_decryptor.py — HashiCorp Vault Transit envelope decryptor.
+
+Phase A2 build per bd Agency_OS-31bk (HashiCorp Vault self-hosted on Vultr
+for BYOK envelope encryption).
+
+CANONICAL KEY ANCHOR — ceo:keiracom_architecture_v2_locked Cat 16
+infra.secrets_management (verbatim from
+/home/elliotbot/clawd/Agency_OS/docs/architecture/keiracom_architecture_v2_inventory.md
+line 208):
+
+  "Secrets management — HashiCorp Vault self-hosted on Vultr (single node V1)
+   with Transit engine for BYOK envelope encryption. Three categories:
+   customer BYOK keys (envelope-encrypted in Postgres, KMS-managed), internal
+   service credentials (Vault store), Composio OAuth tokens (managed by
+   Composio's credential store)."
+
+REPLACES the `_passthrough_decryptor` callable in
+src/keiracom_system/tenant/keiracom_tenant_extension.py (the prior plan was
+pgcrypto.pgp_sym_decrypt; Phase A2 supersedes that with Vault Transit per
+Aiden + Viktor Cat 16 ratify 2026-05-25).
+
+PER-TENANT KEYING: Vault Transit keys are named `<prefix><tenant_id>` so a
+ciphertext can only be decrypted by the Vault key that encrypted it. Cross-
+tenant decrypt attempts return HTTP 400 from Vault with "cipher: message
+authentication failed" — exactly the fail-closed shape the il34 spike
+criterion #3 verified for the placeholder envelope.
+
+USAGE:
+    from keiracom_system.vault import VaultDecryptor
+
+    decryptor = VaultDecryptor(
+        addr="https://vault.keiracom.internal:8200",
+        token=os.environ["VAULT_TOKEN"],
+    )
+    # Wire into KeiracomTenantExtension as the decryptor callable:
+    ext = KeiracomTenantExtension(db=db, decryptor=decryptor)
+
+TESTABILITY: `http_post` is injectable so unit tests don't need a live Vault
+or `requests`/`httpx` in the test path. Smoke tests against a real Vault use
+the default urllib transport.
+
+DEGRADED-MODE FALLBACK (documented but NOT implemented in V1 per Phase A2
+dispatch): when Vault is unreachable for >N seconds, the KeiracomTenantExtension
+should optionally fall back to reading from an envelope-encrypted Postgres
+cache populated at successful Vault decrypts. Build-track follow-up bd to be
+filed post-V1-launch; V1 ships with Vault as hard-dependency.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+DEFAULT_KEY_NAME_PREFIX = "keiracom-tenant-"
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+HTTPPostFn = Callable[[str, dict[str, Any], dict[str, str], float], "_HTTPResponse"]
+
+
+class VaultDecryptError(RuntimeError):
+    """Raised on any Vault-side or transport error during decrypt."""
+
+
+class _HTTPResponse:
+    """Minimal response shape — status_code + json — that both urllib and
+    a real httpx.Response can adapt to.
+    """
+
+    def __init__(self, status_code: int, body: bytes):
+        self.status_code = status_code
+        self._body = body
+
+    def json(self) -> Any:
+        return json.loads(self._body.decode("utf-8") or "null")
+
+    @property
+    def text(self) -> str:
+        return self._body.decode("utf-8", errors="replace")
+
+
+def _default_http_post(
+    url: str, payload: dict[str, Any], headers: dict[str, str], timeout: float
+) -> _HTTPResponse:
+    """Stdlib urllib POST — keeps the module dependency-free."""
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        method="POST",
+        data=body,
+        headers={"Content-Type": "application/json", **headers},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — trusted Vault URL
+            return _HTTPResponse(status_code=resp.status, body=resp.read())
+    except urllib.error.HTTPError as exc:
+        # Vault returns useful error bodies on 4xx — capture rather than re-raise
+        return _HTTPResponse(status_code=exc.code, body=exc.read())
+
+
+class VaultDecryptor:
+    """Callable that decrypts a Vault Transit ciphertext for a specific tenant.
+
+    Conforms to the `Callable[[str, str], str]` shape expected by
+    KeiracomTenantExtension's `decryptor` constructor arg
+    (signature: `(ciphertext, tenant_id) -> plaintext`).
+    """
+
+    def __init__(
+        self,
+        addr: str,
+        token: str,
+        key_name_prefix: str = DEFAULT_KEY_NAME_PREFIX,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        http_post: HTTPPostFn | None = None,
+    ):
+        self.addr = addr.rstrip("/")
+        self._token = token
+        self.key_name_prefix = key_name_prefix
+        self.timeout = timeout_seconds
+        self._http_post = http_post or _default_http_post
+
+    def _key_name(self, tenant_id: str) -> str:
+        return f"{self.key_name_prefix}{tenant_id}"
+
+    def __call__(self, ciphertext: str, tenant_id: str) -> str:
+        """Decrypt a Vault Transit ciphertext for the given tenant_id.
+
+        Raises VaultDecryptError on:
+          - Transport error (Vault unreachable)
+          - Non-2xx response from Vault (auth failure, key-not-found, ciphertext-tampered)
+          - Missing `data.plaintext` in response (Vault contract violation)
+          - Base64 decode failure on returned plaintext
+        """
+        if not ciphertext:
+            raise VaultDecryptError("ciphertext is empty")
+        if not tenant_id:
+            raise VaultDecryptError("tenant_id is empty")
+
+        url = f"{self.addr}/v1/transit/decrypt/{self._key_name(tenant_id)}"
+        headers = {"X-Vault-Token": self._token}
+        payload = {"ciphertext": ciphertext}
+        try:
+            resp = self._http_post(url, payload, headers, self.timeout)
+        except Exception as exc:
+            raise VaultDecryptError(f"vault transport error: {exc}") from exc
+
+        if resp.status_code != 200:
+            body_preview = resp.text[:200]
+            raise VaultDecryptError(
+                f"vault decrypt HTTP {resp.status_code} for tenant {tenant_id!r}: {body_preview}"
+            )
+
+        try:
+            data = resp.json()
+        except Exception as exc:
+            raise VaultDecryptError(f"vault response not JSON: {exc}") from exc
+
+        b64_plaintext = (data or {}).get("data", {}).get("plaintext")
+        if not b64_plaintext:
+            raise VaultDecryptError(
+                f"vault response missing data.plaintext for tenant {tenant_id!r}: {data!r}"
+            )
+
+        try:
+            plaintext_bytes = base64.b64decode(b64_plaintext)
+        except Exception as exc:
+            raise VaultDecryptError(f"vault plaintext not valid base64: {exc}") from exc
+
+        return plaintext_bytes.decode("utf-8")
+
+
+def from_env() -> VaultDecryptor:
+    """Construct a VaultDecryptor from VAULT_ADDR + VAULT_TOKEN env vars.
+
+    Optional env: KEIRACOM_VAULT_KEY_PREFIX (default 'keiracom-tenant-').
+    Raises EnvironmentError if required env vars are absent.
+    """
+    addr = os.environ.get("VAULT_ADDR")
+    token = os.environ.get("VAULT_TOKEN")
+    if not addr or not token:
+        raise OSError(
+            "VaultDecryptor.from_env(): VAULT_ADDR and VAULT_TOKEN must both be set "
+            f"(got VAULT_ADDR={'set' if addr else 'unset'}, "
+            f"VAULT_TOKEN={'set' if token else 'unset'})"
+        )
+    prefix = os.environ.get("KEIRACOM_VAULT_KEY_PREFIX", DEFAULT_KEY_NAME_PREFIX)
+    return VaultDecryptor(addr=addr, token=token, key_name_prefix=prefix)

--- a/tests/keiracom_system/tenant/test_keiracom_tenant_extension.py
+++ b/tests/keiracom_system/tenant/test_keiracom_tenant_extension.py
@@ -196,7 +196,9 @@ def test_get_tenant_config_returns_decrypted_llm_overrides():
     ext = KeiracomTenantExtension(db=db, decryptor=fake_decrypt)
     overrides = _run(ext.get_tenant_config(_ctx("key-t1")))
     assert overrides == {"llm_api_key": "sk-tenant-secret", "llm_model": "claude-opus-4-7"}
-    assert captured == [("ENC:sk-tenant-secret", "t1")], "decryptor should be called once with (ciphertext, tenant_id)"
+    assert captured == [("ENC:sk-tenant-secret", "t1")], (
+        "decryptor should be called once with (ciphertext, tenant_id)"
+    )
 
 
 def test_get_tenant_config_unknown_api_key_returns_empty_dict():

--- a/tests/keiracom_system/tenant/test_keiracom_tenant_extension.py
+++ b/tests/keiracom_system/tenant/test_keiracom_tenant_extension.py
@@ -184,17 +184,19 @@ def test_get_tenant_config_returns_decrypted_llm_overrides():
         ]
     )
     # Injected decryptor strips the ENC: prefix to prove the call happens.
-    captured: list[str] = []
+    # Signature (ct, tenant_id) reflects Phase A2 Vault Transit per-tenant keying
+    # (Agency_OS-31bk) — decryptor needs tenant_id to pick the right Vault key.
+    captured: list[tuple[str, str]] = []
 
-    def fake_decrypt(ct: str) -> str:
-        captured.append(ct)
+    def fake_decrypt(ct: str, tenant_id: str) -> str:
+        captured.append((ct, tenant_id))
         assert ct.startswith("ENC:"), f"decryptor expected ciphertext, got {ct!r}"
         return ct[len("ENC:") :]
 
     ext = KeiracomTenantExtension(db=db, decryptor=fake_decrypt)
     overrides = _run(ext.get_tenant_config(_ctx("key-t1")))
     assert overrides == {"llm_api_key": "sk-tenant-secret", "llm_model": "claude-opus-4-7"}
-    assert captured == ["ENC:sk-tenant-secret"], "decryptor should be called exactly once"
+    assert captured == [("ENC:sk-tenant-secret", "t1")], "decryptor should be called once with (ciphertext, tenant_id)"
 
 
 def test_get_tenant_config_unknown_api_key_returns_empty_dict():

--- a/tests/keiracom_system/vault/test_vault_decryptor.py
+++ b/tests/keiracom_system/vault/test_vault_decryptor.py
@@ -1,0 +1,267 @@
+"""Tests for src/keiracom_system/vault/vault_decryptor.py — Phase A2.
+
+Negative-path discipline per feedback_negative_path_test_before_approve:
+the decryptor's job is fail-closed for any non-success Vault response.
+Each branch needs explicit negative coverage.
+
+13 cases — 3 happy + 10 negative/edge.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.keiracom_system.vault.vault_decryptor import (  # noqa: E402
+    DEFAULT_KEY_NAME_PREFIX,
+    VaultDecryptError,
+    VaultDecryptor,
+    _HTTPResponse,
+    from_env,
+)
+
+
+def _resp(status: int, body: Any) -> _HTTPResponse:
+    if isinstance(body, (dict, list)):
+        body = json.dumps(body).encode("utf-8")
+    elif isinstance(body, str):
+        body = body.encode("utf-8")
+    return _HTTPResponse(status_code=status, body=body)
+
+
+def _make_post(response: _HTTPResponse | Exception):
+    """Build an http_post stub that returns `response` (or raises if Exception)."""
+    calls: list[tuple] = []
+
+    def _post(url: str, payload: dict, headers: dict, timeout: float) -> _HTTPResponse:
+        calls.append((url, payload, headers, timeout))
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    _post.calls = calls  # type: ignore[attr-defined]
+    return _post
+
+
+def _b64(s: str) -> str:
+    return base64.b64encode(s.encode("utf-8")).decode("ascii")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Happy paths
+
+
+def test_decrypt_round_trip_returns_plaintext():
+    """(1) happy: 200 + valid plaintext base64 -> decoded UTF-8 str."""
+    post = _make_post(_resp(200, {"data": {"plaintext": _b64("sk-tenant-secret")}}))
+    d = VaultDecryptor(addr="http://vault", token="tok", http_post=post)
+    assert d("vault:v1:abc", "tenant1") == "sk-tenant-secret"
+    url, payload, headers, _ = post.calls[0]  # type: ignore[attr-defined]
+    assert url == "http://vault/v1/transit/decrypt/keiracom-tenant-tenant1"
+    assert payload == {"ciphertext": "vault:v1:abc"}
+    assert headers["X-Vault-Token"] == "tok"
+
+
+def test_decrypt_uses_configured_key_name_prefix():
+    """(2) custom prefix flows through to URL path."""
+    post = _make_post(_resp(200, {"data": {"plaintext": _b64("ok")}}))
+    d = VaultDecryptor(addr="http://vault", token="tok", key_name_prefix="custom-", http_post=post)
+    d("ct", "t1")
+    url, _, _, _ = post.calls[0]  # type: ignore[attr-defined]
+    assert url.endswith("/transit/decrypt/custom-t1")
+
+
+def test_decrypt_handles_trailing_slash_in_addr():
+    """(3) trailing slash on addr is stripped (no double slash in URL)."""
+    post = _make_post(_resp(200, {"data": {"plaintext": _b64("x")}}))
+    d = VaultDecryptor(addr="http://vault/", token="tok", http_post=post)
+    d("ct", "t1")
+    url, _, _, _ = post.calls[0]  # type: ignore[attr-defined]
+    assert url == "http://vault/v1/transit/decrypt/keiracom-tenant-t1"
+    assert "//v1" not in url
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Negative + edge
+
+
+def test_decrypt_empty_ciphertext_raises():
+    """(4) empty ciphertext -> VaultDecryptError, no HTTP call."""
+    post = _make_post(_resp(500, "should not be called"))
+    d = VaultDecryptor(addr="http://vault", token="tok", http_post=post)
+    with pytest.raises(VaultDecryptError, match="ciphertext is empty"):
+        d("", "t1")
+    assert len(post.calls) == 0  # type: ignore[attr-defined]
+
+
+def test_decrypt_empty_tenant_id_raises():
+    """(5) empty tenant_id -> VaultDecryptError, no HTTP call."""
+    post = _make_post(_resp(500, "should not be called"))
+    d = VaultDecryptor(addr="http://vault", token="tok", http_post=post)
+    with pytest.raises(VaultDecryptError, match="tenant_id is empty"):
+        d("ct", "")
+    assert len(post.calls) == 0  # type: ignore[attr-defined]
+
+
+def test_decrypt_vault_403_raises_with_status_in_message():
+    """(6) Vault 403 (forbidden — bad token / policy) -> VaultDecryptError."""
+    post = _make_post(_resp(403, {"errors": ["permission denied"]}))
+    d = VaultDecryptor(addr="http://vault", token="bad", http_post=post)
+    with pytest.raises(VaultDecryptError, match="HTTP 403"):
+        d("ct", "t1")
+
+
+def test_decrypt_vault_400_wrong_key_fail_closed():
+    """(7) Vault 400 'cipher: message authentication failed' (wrong-tenant key) -> VaultDecryptError.
+
+    The il34 spike criterion #3 fail-closed shape applied to real Vault.
+    """
+    post = _make_post(_resp(400, {"errors": ["cipher: message authentication failed"]}))
+    d = VaultDecryptor(addr="http://vault", token="tok", http_post=post)
+    with pytest.raises(VaultDecryptError, match="HTTP 400"):
+        d("vault:v1:abc-from-other-tenant", "t1")
+
+
+def test_decrypt_vault_404_key_not_found_raises():
+    """(8) Vault 404 (key not in transit) -> VaultDecryptError."""
+    post = _make_post(_resp(404, {"errors": ["encryption key not found"]}))
+    d = VaultDecryptor(addr="http://vault", token="tok", http_post=post)
+    with pytest.raises(VaultDecryptError, match="HTTP 404"):
+        d("ct", "missing-tenant")
+
+
+def test_decrypt_transport_error_wrapped_as_decrypt_error():
+    """(9) urllib/connection error -> VaultDecryptError (not raw exception)."""
+    post = _make_post(ConnectionRefusedError("vault unreachable"))
+    d = VaultDecryptor(addr="http://vault", token="tok", http_post=post)
+    with pytest.raises(VaultDecryptError, match="vault transport error"):
+        d("ct", "t1")
+
+
+def test_decrypt_response_missing_data_plaintext_raises():
+    """(10) Vault returned 200 but no data.plaintext -> VaultDecryptError."""
+    post = _make_post(_resp(200, {"data": {}}))
+    d = VaultDecryptor(addr="http://vault", token="tok", http_post=post)
+    with pytest.raises(VaultDecryptError, match="missing data.plaintext"):
+        d("ct", "t1")
+
+
+def test_decrypt_response_not_json_raises():
+    """(11) Vault returned 200 with non-JSON body -> VaultDecryptError."""
+    post = _make_post(_resp(200, b"\xff\xfe garbage not json"))
+    d = VaultDecryptor(addr="http://vault", token="tok", http_post=post)
+    with pytest.raises(VaultDecryptError, match="not JSON"):
+        d("ct", "t1")
+
+
+def test_decrypt_response_invalid_base64_raises():
+    """(12) Vault returned 200 with non-base64 plaintext -> VaultDecryptError."""
+    post = _make_post(_resp(200, {"data": {"plaintext": "!!! not base64 !!!"}}))
+    d = VaultDecryptor(addr="http://vault", token="tok", http_post=post)
+    with pytest.raises(VaultDecryptError, match="not valid base64"):
+        d("ct", "t1")
+
+
+def test_default_key_name_prefix_constant_locked():
+    """(13) DEFAULT_KEY_NAME_PREFIX must match the canonical naming in dev/vault/.
+
+    Cross-references /home/elliotbot/clawd/keiracom_system/dev/vault/setup_transit.sh
+    which creates keys with the same prefix. Regression guard.
+    """
+    assert DEFAULT_KEY_NAME_PREFIX == "keiracom-tenant-"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# from_env() factory
+
+
+def test_from_env_constructs_with_addr_and_token(monkeypatch):
+    """(14) VAULT_ADDR + VAULT_TOKEN set -> factory returns a valid VaultDecryptor."""
+    monkeypatch.setenv("VAULT_ADDR", "http://vault.example:8200")
+    monkeypatch.setenv("VAULT_TOKEN", "tok-from-env")
+    monkeypatch.delenv("KEIRACOM_VAULT_KEY_PREFIX", raising=False)
+    d = from_env()
+    assert d.addr == "http://vault.example:8200"
+    assert d.key_name_prefix == "keiracom-tenant-"
+
+
+def test_from_env_missing_addr_raises(monkeypatch):
+    """(15) missing VAULT_ADDR -> OSError with specific message."""
+    monkeypatch.delenv("VAULT_ADDR", raising=False)
+    monkeypatch.setenv("VAULT_TOKEN", "tok")
+    with pytest.raises(OSError, match="VAULT_ADDR=unset"):
+        from_env()
+
+
+def test_from_env_missing_token_raises(monkeypatch):
+    """(16) missing VAULT_TOKEN -> OSError."""
+    monkeypatch.setenv("VAULT_ADDR", "http://vault")
+    monkeypatch.delenv("VAULT_TOKEN", raising=False)
+    with pytest.raises(OSError, match="VAULT_TOKEN=unset"):
+        from_env()
+
+
+def test_from_env_custom_key_prefix_honoured(monkeypatch):
+    """(17) KEIRACOM_VAULT_KEY_PREFIX overrides default."""
+    monkeypatch.setenv("VAULT_ADDR", "http://vault")
+    monkeypatch.setenv("VAULT_TOKEN", "tok")
+    monkeypatch.setenv("KEIRACOM_VAULT_KEY_PREFIX", "custom-")
+    d = from_env()
+    assert d.key_name_prefix == "custom-"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration test — opt-in against live dev Vault
+
+
+_INTEGRATION_ENABLED = os.environ.get("KEIRACOM_VAULT_INTEGRATION", "").strip() == "1"
+
+
+@pytest.mark.skipif(
+    not _INTEGRATION_ENABLED,
+    reason="KEIRACOM_VAULT_INTEGRATION=1 not set — live dev Vault test skipped",
+)
+def test_integration_live_vault_round_trip():
+    """(integration) — round-trip against live dev Vault.
+
+    Requires:
+      - dev Vault running at $VAULT_ADDR (default http://127.0.0.1:8200)
+      - $EXT_TOKEN env (or /tmp/keiracom_vault_ext_token file) — token bound to keiracom-tenant-extension policy
+      - keiracom-tenant-devtest key pre-created via setup_transit.sh
+    """
+    import urllib.request as ur
+
+    addr = os.environ.get("VAULT_ADDR", "http://127.0.0.1:8200")
+    token = os.environ.get("EXT_TOKEN") or Path("/tmp/keiracom_vault_ext_token").read_text().strip()
+    plaintext = "sk-live-test-byok-key"
+    b64_plain = base64.b64encode(plaintext.encode("utf-8")).decode("ascii")
+
+    # Encrypt via raw API (decryptor only handles decrypt)
+    enc_req = ur.Request(
+        f"{addr}/v1/transit/encrypt/keiracom-tenant-devtest",
+        method="POST",
+        data=json.dumps({"plaintext": b64_plain}).encode("utf-8"),
+        headers={"X-Vault-Token": token, "Content-Type": "application/json"},
+    )
+    with ur.urlopen(enc_req, timeout=10) as resp:  # noqa: S310
+        ciphertext = json.loads(resp.read())["data"]["ciphertext"]
+
+    # Decrypt via the VaultDecryptor class — should round-trip
+    d = VaultDecryptor(addr=addr, token=token)
+    recovered = d(ciphertext, "devtest")
+    assert recovered == plaintext
+
+    # Wrong tenant -> fail-closed
+    with pytest.raises(VaultDecryptError):
+        d(ciphertext, "other")
+    # Note: 'other' tenant key might not exist (404) or might exist but reject (400);
+    # both are fail-closed. The test asserts SOME VaultDecryptError is raised.

--- a/tests/keiracom_system/vault/test_vault_decryptor.py
+++ b/tests/keiracom_system/vault/test_vault_decryptor.py
@@ -56,10 +56,6 @@ def _b64(s: str) -> str:
     return base64.b64encode(s.encode("utf-8")).decode("ascii")
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Happy paths
-
-
 def test_decrypt_round_trip_returns_plaintext():
     """(1) happy: 200 + valid plaintext base64 -> decoded UTF-8 str."""
     post = _make_post(_resp(200, {"data": {"plaintext": _b64("sk-tenant-secret")}}))
@@ -88,10 +84,6 @@ def test_decrypt_handles_trailing_slash_in_addr():
     url, _, _, _ = post.calls[0]  # type: ignore[attr-defined]
     assert url == "http://vault/v1/transit/decrypt/keiracom-tenant-t1"
     assert "//v1" not in url
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Negative + edge
 
 
 def test_decrypt_empty_ciphertext_raises():
@@ -180,10 +172,6 @@ def test_default_key_name_prefix_constant_locked():
     assert DEFAULT_KEY_NAME_PREFIX == "keiracom-tenant-"
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# from_env() factory
-
-
 def test_from_env_constructs_with_addr_and_token(monkeypatch):
     """(14) VAULT_ADDR + VAULT_TOKEN set -> factory returns a valid VaultDecryptor."""
     monkeypatch.setenv("VAULT_ADDR", "http://vault.example:8200")
@@ -219,10 +207,6 @@ def test_from_env_custom_key_prefix_honoured(monkeypatch):
     assert d.key_name_prefix == "custom-"
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Integration test — opt-in against live dev Vault
-
-
 _INTEGRATION_ENABLED = os.environ.get("KEIRACOM_VAULT_INTEGRATION", "").strip() == "1"
 
 
@@ -235,13 +219,18 @@ def test_integration_live_vault_round_trip():
 
     Requires:
       - dev Vault running at $VAULT_ADDR (default http://127.0.0.1:8200)
-      - $EXT_TOKEN env (or /tmp/keiracom_vault_ext_token file) — token bound to keiracom-tenant-extension policy
+      - $EXT_TOKEN env — token bound to keiracom-tenant-extension policy.
+        ENV-ONLY (no /tmp/ fallback) per Aiden HOLD fix #1 (PR #1146) —
+        reading a world-writable /tmp/ path is a token-injection vector even
+        in opt-in integration tests.
       - keiracom-tenant-devtest key pre-created via setup_transit.sh
     """
     import urllib.request as ur
 
     addr = os.environ.get("VAULT_ADDR", "http://127.0.0.1:8200")
-    token = os.environ.get("EXT_TOKEN") or Path("/tmp/keiracom_vault_ext_token").read_text().strip()
+    token = os.environ.get("EXT_TOKEN")
+    if not token:
+        pytest.skip("EXT_TOKEN env required for live-Vault integration test")
     plaintext = "sk-live-test-byok-key"
     b64_plain = base64.b64encode(plaintext.encode("utf-8")).decode("ascii")
 


### PR DESCRIPTION
## Summary

Phase A2 build per `bd Agency_OS-31bk` — HashiCorp Vault self-hosted on Vultr for BYOK envelope encryption.

Replaces the prior `pgcrypto.pgp_sym_decrypt` plan with HashiCorp Vault Transit envelope per Cat 16 `infra.secrets_management` ratify 2026-05-25 (Dave + Viktor + Aiden CONCUR).

## Files (6, +485 LoC)

| File | Purpose |
|---|---|
| `src/keiracom_system/vault/__init__.py` | Package exports |
| `src/keiracom_system/vault/vault_decryptor.py` | `VaultDecryptor` class + `from_env()` factory + `VaultDecryptError` |
| `src/keiracom_system/tenant/keiracom_tenant_extension.py` | **Signature change**: `decryptor: Callable[[str], str]` → `Callable[[str, str], str]` (adds `tenant_id` arg) |
| `tests/keiracom_system/vault/__init__.py` | Package marker |
| `tests/keiracom_system/vault/test_vault_decryptor.py` | 17 unit + 1 opt-in integration |
| `tests/keiracom_system/tenant/test_keiracom_tenant_extension.py` | `fake_decrypt(ct, tenant_id)` signature bump |

## Test sweep

```
tests/keiracom_system/vault/test_vault_decryptor.py ............... .s   [100%]
tests/keiracom_system/tenant/test_keiracom_tenant_extension.py ......... 
.....                                                                    [100%]
```

**Unit: 17/17 vault + 14/14 tenant = 31/31 PASS**
**Integration (opt-in `KEIRACOM_VAULT_INTEGRATION=1`): PASS against live dev Vault 1.18.5**

Ruff check + format clean.

## Why the signature change

Vault Transit decrypt embeds the key name in the URL:
```
POST /v1/transit/decrypt/{key_name}
```
where `{key_name}` = `keiracom-tenant-{tenant_id}`. The decryptor needs `tenant_id` to pick the correct Vault key. Cross-tenant decrypt attempts hit Vault 400 `cipher: message authentication failed` — exactly the fail-closed shape verified in the il34 spike criterion #3.

## Negative-path coverage (per Aiden gate-validator discipline)

10 negative tests in `test_vault_decryptor.py`:
- empty ciphertext / empty tenant_id (no HTTP call)
- Vault 403 (auth)
- Vault 400 wrong-tenant-key (fail-closed)
- Vault 404 key-not-found
- Transport error wrapped as VaultDecryptError
- Response missing `data.plaintext`
- Response not JSON
- Response plaintext not valid base64
- DEFAULT_KEY_NAME_PREFIX constant locked (regression guard)

## Module naming note

Originally drafted as `keiracom_system/secrets/` but `secrets/` is repo-wide gitignored (line 70 of `.gitignore`). Renamed to `keiracom_system/vault/` — unambiguous purpose, matches `dev/vault/` convention.

## Dev rehearsal (NOT in this PR)

Local-dev Vault wire-up validated before this PR at `/home/elliotbot/clawd/keiracom_system/dev/vault/` (outside repo per dev/prod boundary):
- `docker-compose.yml` — `hashicorp/vault:1.18` dev mode
- `setup_transit.sh` — Transit engine + Keiracom policy + service token
- `smoke_envelope.sh` — round-trips an envelope (byte-exact + wrong-tenant fail-closed)

All 3 ran clean against `keiracom-dev-vault` container before this PR was opened. The opt-in integration test in this PR exercises the same path through the published `VaultDecryptor` class.

## Production Vault (next work — not in this PR)

- Provision Vultr VC2 1c1gb Sydney (separate instance per Elliot decision 2026-05-25)
- Install Vault + Shamir init
- Run setup_transit.sh + smoke against production
- Document Shamir recovery procedure
- This PR's `VaultDecryptor` works against ANY Vault address via `from_env()` — production deploy is a config swap (VAULT_ADDR + VAULT_TOKEN env), no code change

## Canonical-key-query gate

Queried `ceo:keiracom_architecture_v2_locked` Cat 16 `infra.secrets_management` row BEFORE writing. Pasted verbatim into `vault_decryptor.py` module docstring (CANONICAL KEY ANCHOR section).

## bd

- `Agency_OS-31bk` (parent — Phase A2 Vault self-hosted)
- `Agency_OS-hpst` (follow-up — Shamir → GCP KMS auto-unseal upgrade pre-first-paying-customer)

## Test plan
- [x] 17/17 unit pytest pass + 1 integration PASS against live dev Vault
- [x] 14/14 tenant tests still pass after signature change
- [x] ruff check + format clean
- [x] Canonical key queried + verbatim paste in module docstring
- [x] Module placed outside gitignored `secrets/` path
- [ ] Max code-quality concur
- [ ] Aiden architecture-lens concur (signature change blast radius)
- [ ] Dual-concur → Elliot admin-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)