### PR TITLE
[ORION] docs(deep-dives): Layers 5 + 8 + 10 + 11 — KEI-SYSTEM-DEEP-DIVE

### DIFF
--- a/docs/architecture/deep_dives/layer_05_orchestration.md
+++ b/docs/architecture/deep_dives/layer_05_orchestration.md
@@ -1,0 +1,129 @@
+# Layer 5 — Orchestration (Temporal workflow engine)
+
+**Owner:** orion
+**Status:** **HARD GAP — DESIGNED, NEVER DEPLOYED** (per Cat 20 inventory line 519)
+**Directive:** KEI-SYSTEM-DEEP-DIVE 2026-05-25 ~1779746500
+
+## Notes — canonical evidence pasted per audit-dispatch checklist
+
+- `ceo:keiracom_architecture_v2_locked` — listed `temp.middleware` in `v2_locks_not_for_redeliberation`
+- `ceo:keiracom_build_priority.phase_e_capacity_abuse.e2` verbatim: "Rate limiting at LiteLLM + token spend hard-stop via Temporal middleware (already proposed)"
+- `ceo:keiracom_build_priority.phase_a_build_unblockers` — Temporal NOT in Phase A (no A1-A4 row deploys it)
+- Inventory Cat 5 row source attribution: `temporal_interception_layer 2026-05-25 (Elliot+Aiden concur)` — design ratified, no deployment record
+- Inventory Cat 20 verbatim (line 519): "Orchestration (Temporal workflow engine — designed, NEVER deployed) — Orion / LOOSE (deep-dive pending; HARD GAP)"
+- `ceo:cache_framework_canonical` — Layer 11 produces implementation spec; Layer 5 hosts the cache-check INLINE gate
+
+## §1 Designed
+
+Yes. Spec is locked across 10 inventory rows in Cat 5:
+
+| Row | Status | Role |
+|---|---|---|
+| `temp.middleware` | RATIFIED-CEO | Single chokepoint between chat input and LLM token call |
+| `temp.inline.listener` | RATIFIED-CEO | Reasoning Listener — capture "why" behind decisions |
+| `temp.inline.token_gate` | RATIFIED-CEO | Token spend hard-stop per call |
+| `temp.inline.cache_check` | RATIFIED-CEO | Layer 11 cache-strategy dispatch (prompt cache / Valkey / Hindsight) |
+| `temp.inline.tier_gate` | RATIFIED-CEO | Tier feature gating (Sandbox/Solo/Pro/Team/Enterprise) |
+| `temp.inline.audit` | RATIFIED-CEO | Audit trail emission to `dashboard` |
+| `temp.inline.content_check` | RATIFIED-CEO | Pre-call privacy/regulated-content checks |
+| `temp.async.post_validation` | RATIFIED-CEO | Async continuation — response shape + citation validity (Aiden refinement) |
+| `temp.contract_doc` | LOOSE (BLOCKER for build) | One-page per-gate contract: emit guarantees + enforce-vs-warn semantics. **ELLIOT OWES BEFORE BUILD.** |
+| `temp.dispatcher` | RATIFIED-CEO | Temporal as workflow engine for dispatcher (replaces NATS-loop/tmux-pane-injection per `v1_completion_criteria` criterion 1; ephemeral scoping PR #1140) |
+
+Design pattern: **6 inline gates + 1 async continuation, single chokepoint at temp.middleware.** Per Aiden refinement, inline gates fail-fast on policy violation; async continuation handles post-call validation that doesn't block user response.
+
+## §2 Built
+
+**Nothing.** Empirical scan:
+```
+grep -rliE 'temporal\.io|@temporalio|workflow.*temporal' src/  →  0 files
+grep -rliE 'temporal' .claude/  →  0 files
+ls /home/elliotbot/clawd/Agency_OS-orion/src/keiracom_system/temporal/  →  does not exist
+```
+
+Confirms Cat 20 dispatch attribution. Phase A (Vault + Hindsight deploy + Go Sidecar + memory cutover) does not include Temporal deploy. The dispatcher in `src/dispatcher/main.py` is the NATS-loop/tmux-pane pattern Temporal is meant to replace per `temp.dispatcher` + `v1_completion_criteria` criterion 1.
+
+`temp.contract_doc` is the LOOSE blocker that gates build. Elliot owes it. No build can start until that contract is written + deliberator-concurred.
+
+## §3 Measured
+
+**No production data — Temporal not deployed.** Honest framing per Cat 20 line 519. This section will populate after Phase E2 ("token spend hard-stop via Temporal middleware") deploys.
+
+The closest existing measurement is the metering pipeline (PR #1137) which captures token counts AFTER Hindsight emits a log line — i.e., per-call attribution, not per-workflow attribution. Temporal would add workflow-level attribution (a chat turn that triggers 6 LLM calls would be one workflow with 6 child activities), which the metering pipeline cannot currently produce.
+
+## §4 Token budget / cost behaviour
+
+Temporal IS the layer that enforces token budgets. `temp.inline.token_gate` is the runtime enforcement of the per-call cap + tier-scaled pool described in `cost.token_budget` (Cat 4 LOOSE — Viktor 4-component proposal). Without Temporal deployed:
+
+- Per-call cap: not enforced today (no chokepoint)
+- Tier-scaled pool: not enforced today (no dispatcher tracking budgets per tenant)
+- Hard-stop: not enforced today (no enforce-vs-warn surface)
+
+Cost behaviour AT this layer: zero direct LLM cost (workflow engine doesn't call LLMs itself). All cost is in the activities Temporal invokes — those activities live in Layers 2/3/4 (chat agent / deliberators / workers).
+
+Operational cost (Temporal Cloud vs self-host): not yet decided. Temporal Cloud is ~$200/mo for low-volume tier; self-host adds ops burden. Recommend deciding at build dispatch.
+
+## §5 Cache strategy applicable
+
+`temp.inline.cache_check` is the dispatch site for Layer 11 cache strategy. Per `ceo:cache_framework_canonical`:
+
+- **Anthropic prompt cache (0.10× input cost)** — applied to structurally stable per-domain content. Temporal middleware decides if the upcoming LLM call qualifies (content shape + tenant tier) and routes to the prompt-cache-enabled provider config.
+- **Uncached (1.0×)** — per-call dynamic content. Default fall-through.
+- **Valkey semantic cache** — repetitive query hits. Temporal middleware checks Valkey BEFORE the LLM call; cache hit short-circuits to cached response + emits audit event.
+- **Hindsight beyond active window** — context not held in active window; Temporal middleware retrieves via Hindsight recall before constructing the LLM prompt.
+
+All four strategies fan in to `temp.inline.cache_check`. Temporal is the integration point — Layer 11 spec is the routing logic.
+
+## §6 LOOSE items / open questions
+
+1. **`temp.contract_doc` (Elliot owes)** — per-gate contract: what's emitted, enforce-vs-warn semantics, error shape. Build blocker.
+2. **Temporal Cloud vs self-host** — operational cost trade-off undecided.
+3. **NATS coexistence** — Viktor 2026-05-25 verbatim retained NATS as inter-agent messaging fabric (separate from Temporal-as-workflow-engine). Boundary needs concrete naming in build dispatch: which signals stay on NATS, which become Temporal activities/signals.
+4. **Migration strategy from `src/dispatcher/main.py`** — current dispatcher is NATS-loop/tmux-pane. PR #1140 (Aiden ephemeral scoping) names this as 8 tmux-coupled subsystems requiring 5-stage migration. Temporal deploy depends on that migration sequencing.
+5. **Activity timeout policies** — LLM calls can take 30-120s; deliberator concurs take longer (minutes). Default Temporal activity timeouts may need tier-aware tuning.
+6. **Workflow versioning** — Temporal's deterministic-replay requires careful workflow code versioning. No spec yet for Keiracom's versioning approach (event sourcing? blue-green workflow code deploy?).
+7. **Where the post-validation async continuation lives** — Aiden refined to ASYNC. Spec doesn't yet name whether it's a separate child workflow or a continue-as-new activity.
+
+## §7 Per-tier behaviour variation
+
+| Tier | Tier multiplier (proposal per `ceo:cache_framework_canonical`) | Per-call cap | Temporal-specific |
+|---|---|---|---|
+| Sandbox | 0.5× | Smallest cap (free eval; 10 tasks/day per Cat 17) | Aggressive token-gate cut-off; cache-check force-hit prompt cache when available |
+| Solo | 1.0× | Baseline cap | Standard gates |
+| Pro | 1.5× | Looser cap | Multi-thread chats unlock (Pro+) → multiple parallel workflows per tenant; tier-gate enforces concurrency cap (4-6-8-14 curve) |
+| Team | 2.0× | Larger cap | Per-user budget pools (Team has multiple users); tier-gate dispatches per-user attribution |
+| Enterprise | custom | Custom | Per-tenant VPC topology A — Temporal cluster may be per-tenant for compliance verticals; tier-gate becomes per-tenant-instance config |
+
+Tier multipliers PROPOSAL — pressure-test in Phase 2 per `ceo:cache_framework_canonical.tier_multipliers_status`.
+
+Sandbox 10-tasks/day rate limit (Cat 17 `tier.sandbox`) is enforced at the dispatcher (Phase E e1 verbatim: "Tier capacity enforcement (4-6-8-14 curve at dispatcher)"); Temporal `tier-gate` is the runtime check on each workflow start.
+
+## §8 Per-agent-type variation
+
+| Agent type | Workflow shape | Temporal-specific |
+|---|---|---|
+| Chat agent (Keira, Tier 1 ephemeral) | One workflow per chat turn | Activity = LLM call. Inline gates apply per-activity. Async post-validation for citation checks. |
+| Deliberators (Tier 2 CONCUR-gated) | One workflow per CONCUR cycle | Activity = each deliberator's review call. tier-gate enforces min 3 deliberators on paid tiers (per `tier.baseline_rule`). |
+| Worker agents (Tier 3 domain execution) | Long-running workflow per task | Activities span minutes to hours; activity timeouts must accommodate. Heartbeat protocol mandatory. |
+
+Cross-cutting per agent type: every workflow emits `temp.inline.audit` events for dashboard reasoning-trace view (Cat 19 ux.surface.reasoning_trace). Audit shape needs to be one schema across all agent types so Layer 12 observability can aggregate.
+
+## Cross-cutting concerns
+
+- **Multi-tenancy enforcement** — Temporal namespace per tenant for Topology A (per-VPC); shared namespace + tenant_id metadata for Topology B. `tier-gate` enforces tenant_id == workflow.metadata.tenant_id. Mechanical check at activity-start, not UI.
+- **Security (BYOK + secret mgmt)** — `temp.inline.content_check` runs against `mcp.go_sidecar` static config to block raw-secret leakage into LLM context. Vault decryption happens at activity-level (via PR #1146 `VaultDecryptor`), never at workflow-level.
+- **CI/CD + rollback** — workflow code versioning unresolved (see §6). Activity code can rollout standard; workflow code needs deterministic-replay-safe deploy. Likely needs a sub-spike before build.
+- **Backup-DR** — Temporal event history IS the workflow source of truth. Lost = lost workflows. V1.x backup-DR (`infra.backup_dr`) must include Temporal event history alongside Hindsight + Postgres.
+- **Customer file system** — file uploads land in S3-compatible storage (V1 Vultr Object Storage per `infra.iac`); Temporal workflows reference them by URI. No file content in workflow state.
+- **Reasoning trace + audit trail** — emitted by `temp.inline.audit`; consumed by Layer 7 governance + Layer 12 observability. Schema TBD in `temp.contract_doc`.
+- **Compliance gates** — `temp.inline.content_check` is the runtime enforcement point. Privacy/regulated checks before any LLM call. Per-tier policy.
+
+## Sources
+
+- `ceo:keiracom_architecture_v2_locked` (queried 2026-05-25)
+- `ceo:cache_framework_canonical` (queried 2026-05-25)
+- `ceo:keiracom_build_priority` Phase E e2 (Temporal token-spend hard-stop)
+- Inventory rows Cat 5 (10 rows) + Cat 20 line 519
+- PR #1140 — Aiden ephemeral scoping
+- PR #1137 — metering pipeline (orthogonal data layer; not Temporal-aware)
+- `v1_completion_criteria` criterion 1 (ephemeral agent system replaces tmux)

--- a/docs/architecture/deep_dives/layer_08_integration.md
+++ b/docs/architecture/deep_dives/layer_08_integration.md
@@ -1,0 +1,148 @@
+# Layer 8 — Integration (MCP + Composio + LiteLLM)
+
+**Owner:** Orion (MCP + Composio sidecar wiring) + Atlas (joint)
+**Status:** PARTIAL — MCP tier-aware server merged (PR #1136); Composio per-tenant POC OPEN (`Agency_OS-aynv`); LiteLLM running per Cat 11 RATIFIED-CEO
+**Directive:** KEI-SYSTEM-DEEP-DIVE 2026-05-25 ~1779746500
+
+## Notes — canonical evidence pasted per audit-dispatch checklist
+
+Inventory Cat 10 (MCP) verbatim:
+
+- `mcp.abstraction` (RATIFIED-CEO, PR #1136) — "All tools exposed via MCP servers; tools/list resolves per-tenant allowed set"
+- `mcp.composio` (RATIFIED-DM, Viktor verbatim 2026-05-25 + Aiden anchor MAL §11) — "Composio as integration library beneath MCP (implementation choice; not architectural constraint)"
+- `mcp.go_sidecar` (RATIFIED-DM, BUILD pending) — "Go sidecar — security interceptor + tool-call validator; static config not knowledge graph; mechanical enforcement"
+- `mcp.tei_sidecar` (RATIFIED-CEO, running, PR #1133) — "TEI sidecar serving BAAI/bge-small-en-v1.5"
+
+Inventory Cat 11 (LiteLLM + BYOK) verbatim:
+- `gov.litellm_router` (RATIFIED-CEO, running) — "LiteLLM as governance router with BYOK key resolution — RATIFIED AND RUNNING (T0.2 audit)"
+
+`ceo:keiracom_architecture_v2_locked.v2_locks_not_for_redeliberation` includes `gov.litellm_router` + `gov.composio_per_customer_segregation`.
+
+`ceo:keiracom_build_priority.phase_b_v1_hard_gates.b2` verbatim: "Composio per-customer segregation (uses Agency_OS-aynv POC verification first)"
+
+## §1 Designed
+
+Three integration substrates, three roles:
+
+1. **MCP (Model Context Protocol)** — `mcp.abstraction`. All tool access goes through MCP servers. Per-tenant `tools/list` resolves the allowed set (tier-aware feature gating).
+2. **Composio** — `mcp.composio`. Sits BENEATH MCP as the integration library that wraps the 250+ underlying APIs (Salesforce, HubSpot, Slack, GitHub, etc.). Per Dave directive 2026-05-25 decision #3 + `gov.composio_per_customer_segregation` lock: **one Composio account per customer** (account-per-tenant model).
+3. **LiteLLM** — `gov.litellm_router`. Governance router that resolves BYOK keys at LLM-call time + applies rate limiting (per Phase E e2). Running today; pre-dates this audit.
+
+Plus two sidecars (Cat 10):
+4. **Go Sidecar** (`mcp.go_sidecar`) — security interceptor that intercepts MCP tool calls + validates against static-config domain whitelist. Mechanical enforcement, not knowledge graph. BUILD pending (Phase A4 `phase_a_build_unblockers.a4`).
+5. **TEI Sidecar** (`mcp.tei_sidecar`) — embedding service for Hindsight. RUNNING (PR #1133, my work).
+
+The layer's job: present a clean tool-call surface to agents (via MCP) while hiding the integration plumbing (Composio + LiteLLM) AND enforcing per-tenant access + security.
+
+## §2 Built
+
+| Component | Status | Evidence |
+|---|---|---|
+| `mcp.abstraction` (tier-aware MCP server) | MERGED | PR #1136 (Atlas) — `src/keiracom_system/mcp/` |
+| `mcp.tei_sidecar` | RUNNING | PR #1133 + dev container `keiracom-dev-hindsight` consumes via `http://embed:80`; production deploy via Phase A1 (Hindsight fleet) |
+| `gov.litellm_router` | RUNNING | T0.2 audit — pre-dates this work. No PR in this session's window. |
+| `mcp.composio` (architectural commitment) | DESIGNED | `gov.composio_per_customer_segregation` locked; `skills/composio-oauth/SKILL.md` is the integration skill stub |
+| `mcp.composio` (per-tenant segregation actually working) | POC OPEN | `Agency_OS-aynv` — Atlas spot-check HOLD anchor; verification not yet run |
+| `mcp.go_sidecar` | NOT BUILT | Phase A4 `phase_a_build_unblockers.a4`; "binary skeleton + domain whitelist + GitOps config" |
+
+Empirical scan:
+```
+ls src/keiracom_system/ → embeddings/ mcp/ memory/ metering/ tenant/ vault/
+grep -rli composio src/ skills/ → skills/composio-oauth/SKILL.md only (skill stub)
+```
+
+## §3 Measured
+
+**No production-scale data.** Layer 8 has shipped runtime components (MCP server merged, TEI running, LiteLLM running) but multi-tenant production traffic doesn't exist yet (pre-revenue).
+
+What is measurable today against the dev Hindsight container (per my il34 spike runs):
+- TEI sidecar embed call: ~0.7s for 100 fixtures via `retain` (which routes embedding via TEI internally; see PR #1137 §benchmark)
+- Hindsight ingest rate: 3.05 items/sec at n=100, 2.02 items/sec at n=1000 — slowing at scale (likely consolidation overhead, not TEI overhead)
+
+What is NOT measured:
+- MCP `tools/list` resolution latency per tenant
+- Composio API call latency / failure modes (no account provisioned yet)
+- LiteLLM routing decision overhead
+- Go Sidecar interception latency (not built)
+
+## §4 Token budget / cost behaviour
+
+**Tool calls themselves consume LLM tokens** (the model's "tool_use" + "tool_result" content blocks). Per Anthropic pricing, tool definitions count as input tokens (cacheable per Layer 11 strategy if structurally stable).
+
+Cost shape per integration substrate:
+- **MCP `tools/list`** — definition catalog; structurally stable per tenant tier; **Layer 1 prompt cache target** (0.10× input cost). Definitions can be 1-10K tokens depending on tool count. Cache lifetime ≥ tier-config TTL.
+- **Composio** — adds per-call cost (Composio API pricing) ON TOP of LLM token cost. Pricing model needs verification in `Agency_OS-aynv` POC (account-per-tenant means N customers = N Composio accounts = N billing relationships).
+- **LiteLLM** — passthrough cost (it's a proxy not an LLM); the routing decision itself is sub-millisecond. Rate-limiting may DROP calls (rejected before LLM cost incurred — net cost savings).
+- **TEI sidecar** — zero LLM cost (embeddings are local BGE-small inference). Cost = sidecar host time (~$0 marginal at fleet scale).
+- **Go Sidecar** — zero LLM cost (mechanical validation). Cost = latency added to every tool call.
+
+The metering pipeline (PR #1137 — my work) captures token spend per LLM call but does NOT yet attribute tool-call overhead separately. Layer 11 cost dashboard ought to show "tool overhead" as a distinct line if we want to monitor it.
+
+## §5 Cache strategy applicable
+
+Per `ceo:cache_framework_canonical`:
+
+| Cache layer | Layer 8 application |
+|---|---|
+| **Layer 1 — Anthropic prompt cache (0.10× input)** | MCP `tools/list` catalog (structurally stable per tier). Tier-config TTL determines re-cache cadence. |
+| **Layer 2 — uncached (1.0×)** | Each tool's parameters + return value (dynamic per call) |
+| **Valkey semantic cache** | Repetitive tool calls with identical args + recent recency (e.g., "fetch HubSpot company by domain X" — same X within N seconds returns cached result without hitting HubSpot). Cache key = canonical tool-call hash. |
+| **Hindsight beyond active window** | Tool-call audit trail beyond active context — recall via Hindsight for compliance / debugging. NOT a perf cache; an observability store. |
+
+Layer 8 routing decision: at MCP tool-call dispatch, check Valkey first (cache hit short-circuits the Composio call); on miss, hit Composio; on success, populate Valkey. Cache invalidation is per-tool: data-fetch tools have short TTL (~60s); definition fetches have long TTL (~24hr).
+
+**Post-ephemeral cache-validity question** (`cost.cache_post_ephemeral_validity` Aiden §3.C nit): when chat agents are ephemeral (spawn-execute-die per `eph.scoping`), each spawn loses local cache locality. Valkey is shared so cache hits survive across spawns; but the LLM prompt-cache only sticks within Anthropic's 5-min window per cache breakpoint. New ephemeral spawn = new connection = new prompt cache miss on first call.
+
+## §6 LOOSE items / open questions
+
+1. **`Agency_OS-aynv` Composio POC** — gates Phase B2. Needs to verify: (a) per-tenant OAuth segregation actually isolates data, (b) per-customer Composio account pricing model fits the unit economics, (c) onboarding flow when customer adds an integration (do they create their own Composio account, or do we create one on their behalf?).
+2. **`mcp.go_sidecar` build** — Phase A4 unblocker. Aiden Phase 1 §3.A item 7 spec'd it; no implementation yet. Domain whitelist source-of-truth + GitOps config flow needs naming.
+3. **MCP `tools/list` tier-resolution** — Atlas PR #1136 implements tier-aware filtering; needs deliberator-cross-check that the per-tier tool sets are correctly carved (Sandbox = view-only; Solo = read; Pro = write; Team/Enterprise = admin).
+4. **LiteLLM virtual-key per-tenant** — currently virtual keys exist; per-tenant assignment + rotation flow not yet defined as a runbook.
+5. **Composio cost ceiling** — if each tenant = 1 Composio account, what's the OPEX at N tenants? Cat 16 `infra.secrets_management` sub-item (d) flagged this as "HARD-GATE-WITHIN-HARD-GATE" — `Agency_OS-aynv` must answer.
+6. **Tool-overhead metering** — PR #1137 attributes LLM tokens but not tool-call overhead. Layer 11 dashboard column for "% of cost from tool calls vs raw LLM" is a useful visibility add (LOOSE).
+7. **Cache invalidation on Composio webhook** — Composio offers webhooks for data changes (e.g., HubSpot company updated). Spec doesn't yet say whether webhooks fan in to Valkey cache invalidation.
+
+## §7 Per-tier behaviour variation
+
+| Tier | MCP tool set | Composio | LiteLLM rate limit | Go Sidecar policy |
+|---|---|---|---|---|
+| Sandbox | View-only subset; 10 tasks/day rate limit | Disabled (no real tool calls in eval) | Aggressive (free tier protection) | Strictest whitelist (no external write tools) |
+| Solo | Read-mostly; one project | Standard | Per-tenant cap | Standard whitelist |
+| Pro | Read+write; multi-thread | Standard | Looser cap | Standard whitelist + Pro-only tools |
+| Team | Full + admin actions | Standard + multi-user attribution | Per-user cap | Per-user policy |
+| Enterprise | Custom — per-tenant whitelist | Per-tenant Composio account (already the default per `gov.composio_per_customer_segregation`); for Enterprise, may be per-instance | Per-tenant SLA | Customer-customisable whitelist + compliance attestation |
+
+Per Phase E e3 `Multi-tenant isolation enforcement at API layer` — Layer 8 is one of the enforcement surfaces. MCP `tools/list` per-tier filtering is mechanical; Go Sidecar domain whitelist is mechanical. Both fail-closed on tier-config mismatch.
+
+## §8 Per-agent-type variation
+
+| Agent type | MCP tool surface | Composio usage | LiteLLM routing | Go Sidecar exposure |
+|---|---|---|---|---|
+| Chat agent (Keira, Tier 1) | Read tools + customer-facing actions (within tier set) | Per-tenant account | Customer's BYOK key | Yes — every tool call validated |
+| Deliberators (Tier 2) | Governance read tools (Linear, GitHub PR lookup) | Internal-only (Keiracom-owned Composio account, not per-tenant) | Internal Gemini routing per `reference_model_routing.md` | No — internal-only, sidecar not in path |
+| Worker agents (Tier 3) | Domain-specific tool subset (e.g., HubSpot worker has HubSpot tools only) | Per-tenant account | Customer's BYOK key | Yes — every tool call validated |
+
+Worker agents are domain-scoped at the MCP `tools/list` level — a HubSpot worker can't see Salesforce tools even if the tenant has both integrations enabled. This is part of `mcp.go_sidecar` enforcement spec.
+
+## Cross-cutting concerns
+
+- **Multi-tenancy enforcement** — Composio per-tenant accounts (architectural lock) + MCP per-tenant `tools/list` + Go Sidecar per-tenant whitelist. THREE mechanical layers; if any one drifts, cross-tenant leakage risk. `Agency_OS-aynv` POC is the integration-test surface for this.
+- **Security (BYOK + per-customer segregation)** — Vault Transit (PR #1146) gives BYOK envelope; LiteLLM looks up the right tenant key at call time; Go Sidecar prevents the decrypted key leaking into LLM prompt (separate from `VaultDecryptor` — that's the read side; Go Sidecar is the egress side).
+- **CI/CD + rollback** — MCP server + Composio config + Go Sidecar config should ALL be GitOps-managed per `mcp.go_sidecar` "GitOps config" verbatim. PR-as-config-change with deliberator concur.
+- **Backup-DR (V1.x)** — Composio data is in customer's own Composio account; ergo backup-DR for integration data is OUTSIDE Keiracom's scope (we never hold it). LiteLLM virtual keys + MCP per-tenant config need backup.
+- **Customer file system** — file uploads via MCP file tool; sidecar validates allowed file types per tier. Storage is Vultr Object Storage (V1) per `infra.iac`.
+- **Reasoning trace + audit trail** — every MCP tool call emits an event consumed by Layer 12 observability. `Cat 19 ux.surface.reasoning_trace` is the customer-visible view.
+- **Compliance gates** — Go Sidecar is the runtime check; static config maps allowed tool → allowed tier → allowed customer (for regulated verticals). Compliance attestation per Enterprise tier (`tier.enterprise`).
+
+## Sources
+
+- `ceo:keiracom_architecture_v2_locked` (queried 2026-05-25)
+- `ceo:keiracom_build_priority` Phase A4 + B2 + E
+- Inventory Cat 10 (4 rows) + Cat 11 (2 rows of relevance) + Cat 20 line 522
+- PR #1136 — Atlas tier-aware MCP server
+- PR #1133 — Orion TEI sidecar (this layer's running embedding component)
+- PR #1146 — Orion Vault decryptor (cross-layer; called by LiteLLM at routing time)
+- bd `Agency_OS-aynv` — Composio per-tenant POC (Aiden owner)
+- `skills/composio-oauth/SKILL.md` — Composio integration skill stub
+- `reference_model_routing.md` — internal Gemini routing memo

--- a/docs/architecture/deep_dives/layer_10_infrastructure.md
+++ b/docs/architecture/deep_dives/layer_10_infrastructure.md
@@ -1,0 +1,160 @@
+# Layer 10 — Infrastructure (Vultr + Docker + Vault + Cloudflare)
+
+**Owner:** orion
+**Status:** PARTIAL — Vultr fleet host + Vault running; Docker conventions live; Cloudflare CDN DEFERRED to V1.1 per Cat 16
+**Directive:** KEI-SYSTEM-DEEP-DIVE 2026-05-25 ~1779746500
+
+## Notes — canonical evidence pasted per audit-dispatch checklist
+
+Inventory Cat 16 (Operability + Infrastructure) verbatim row excerpts:
+
+- `infra.observability` — "Better Stack (already in fleet env vars) + per-layer /health checks" — LOOSE V1-required
+- `infra.secrets_management` — "HashiCorp Vault self-hosted on Vultr (single node V1) with Transit engine for BYOK envelope encryption" — LOOSE-BLOCKER (now BUILT per PR #1146, this session)
+- `infra.rate_limiting` — "request throttling at LiteLLM virtual key + token spend hard-stop via Temporal middleware" — LOOSE V1-required
+- `infra.cdn` — "Cloudflare free tier. DEFERRED until ICP includes non-local customers" — DEFERRED
+- `infra.backup_dr` — "MOVED FROM V1 HARD GATE TO V1.x FEATURE per Dave directive 2026-05-25 ~1779738300" — LOOSE (V1.x)
+- `infra.cicd` — "GitHub Actions (partially exists today; gap audit needed)" — LOOSE V1-required
+- `infra.iac` — "Pulumi (Python SDK) over Terraform for V1. V1 narrow scope: tenant provisioning automation triggered by Temporal workflow" — LOOSE V1-required
+
+`ceo:keiracom_build_priority.phase_a_build_unblockers` — A2 (Vault) DONE, A4 (Go Sidecar) PENDING.
+
+## §1 Designed
+
+Five infrastructure substrates:
+
+1. **Vultr** — primary cloud (Sydney region for AEST locality). Already in use for fleet host (`vc2-6c-16gb` 149.28.182.216) + Vault host (`vc2-1c-1gb` 45.77.51.184, this session).
+2. **Docker** — runtime convention (containers for Hindsight, Weaviate, TEI, Vault, etc.). docker-compose for local-dev + service-config.
+3. **Vault** — Phase A2 substrate; per-tenant BYOK envelope; Transit engine. Shamir 5/3 unseal V1; GCP KMS upgrade as `Agency_OS-hpst` follow-up.
+4. **Cloudflare** — CDN tier, DEFERRED to V1.1 per Cat 16 row `infra.cdn`. Not built; not deployed; spec is "free tier when ICP geography expands".
+5. **Pulumi** — IaC choice over Terraform (Cat 16 `infra.iac`). Python SDK fits team-language continuity. V1 scope is narrow: tenant provisioning via Temporal workflow.
+
+Tying these together is `infra.observability` (Better Stack + per-layer /health) — already wired into fleet env (BETTERSTACK_* env vars present per earlier session work).
+
+## §2 Built
+
+| Component | Status | Evidence |
+|---|---|---|
+| Vultr fleet host | RUNNING | `vc2-6c-16gb` Sydney, 149.28.182.216, hosts Hindsight container + Weaviate + Cognee + 51 systemd services |
+| Vultr Vault host | RUNNING | `vc2-1c-1gb` Sydney, 45.77.51.184, Vault 2.0.1 unsealed + Transit configured (this session, Phase A2) |
+| Docker (fleet) | RUNNING | docker daemon + 16GB memory pressure (5GB swap used per session diagnostic); local-dev pattern at `keiracom_system/dev/{hindsight,vault}/` |
+| Vault | RUNNING | Shamir 5/3 unsealed; Transit engine; `keiracom-tenant-extension` policy; service token TTL 24h; UFW :8200 ALLOW from fleet only |
+| Vault Python client | MERGED | PR #1146 `src/keiracom_system/vault/vault_decryptor.py` (this session) |
+| Cloudflare | NOT DEPLOYED | DEFERRED V1.1 per `infra.cdn` |
+| Pulumi | NOT DEPLOYED | DESIGNED only; Cat 16 `infra.iac` LOOSE V1-required |
+| Better Stack | PARTIAL | env vars present; per-layer /health checks per-service status unknown |
+| systemd unit conventions | RUNNING | KEI-48 / KEI-44 patterns (memory-capped via `systemd-run --user --scope -p MemoryMax=...`) — established |
+| UFW firewall posture | RUNNING (Vault host) | Vault host: default DROP + :22 ALLOW + :8200 ALLOW FROM 149.28.182.216 only |
+
+Empirical scan:
+```
+ls /home/elliotbot/clawd/keiracom_system/dev/ → hindsight/ vault/ (the two local-dev rehearsals I built)
+ls /home/elliotbot/clawd/Agency_OS-orion/scripts/orchestrator/ → weaviate_capped.sh, cognee_capped.sh, weaviate_backup.sh, weaviate_capped.sh (memory-capped service launchers)
+```
+
+## §3 Measured
+
+Production data WHERE IT EXISTS (this session's empirical work):
+
+| Metric | Value | Source |
+|---|---|---|
+| Fleet host RAM total | 15Gi | `free -h` |
+| Fleet host RAM used | 9.0Gi | `free -h` |
+| Fleet host swap used | 5.0Gi of 5.3Gi | `free -h` — under pressure |
+| Top RSS consumers | weaviate 3.2GB, hindsight-api 1.4GB | `ps -eo rss,comm --sort=-rss` |
+| Vault host RAM available | 1GB total (vc2-1c-1gb) | Vultr plan spec |
+| Vault host Vault process RSS | ~100MB at idle | typical for single-node Vault, not yet sampled live |
+| Vault unseal time after restart | NOT MEASURED — requires deliberate restart test | n/a |
+| Vault encrypt latency (LAN) | ~50-100ms per call | informal smoke (criteria #3 verification, this session) |
+| Vault host UFW: :8200 blocked from non-fleet IPs | VERIFIED | tested via `timeout 5 bash -c '</dev/tcp/...'` from fleet pre + post UFW rule |
+| Hindsight container memory cap | 3GB | `weaviate_capped.sh` pattern (Weaviate) — Hindsight runs unbounded currently |
+| Vultr account balance | $0 | Vultr API at session start |
+| Vultr pending charges | $52.98 + $5/mo Vault = ~$58/mo current burn rate | Vultr API account endpoint |
+
+What is NOT measured:
+- Better Stack alert latency / coverage
+- Disk usage trajectory (fleet host SSD)
+- Per-service uptime (51 systemd services — no central dashboard)
+- Network egress bytes (CDN need would surface here)
+- Vultr Object Storage usage (file system — `infra.iac` references it but no use yet)
+
+## §4 Token budget / cost behaviour
+
+**Infrastructure itself consumes zero LLM tokens.** Cost shape at this layer:
+
+| Category | Per month |
+|---|---|
+| Fleet host (vc2-6c-16gb Sydney) | ~$48 USD pending charges suggests current spend |
+| Vault host (vc2-1c-1gb Sydney) | $5 USD ($7.75 AUD) — new this session |
+| Cloudflare (DEFERRED) | $0 (free tier when activated) |
+| Better Stack | Unknown — env vars present; tier TBD |
+| Pulumi state storage (Vultr Object Storage) | <$1 USD typical |
+| **Total Vultr current** | **~$53 USD/mo (~$82 AUD/mo)** |
+
+Infrastructure cost is LINEAR with tenant count for per-tenant infra (Topology A enterprise tier — per-tenant VPC). Shared infra (Topology B) is per-host fixed cost amortised over N tenants — sublinear scaling.
+
+`infra.iac` Pulumi tenant-provisioning workflow is the cost-control surface for V1: provisioning is automatic per signup, deprovisioning is automatic per churn — no human in the loop = bounded ops cost.
+
+## §5 Cache strategy applicable
+
+Infrastructure layer is BENEATH the cache strategy — caches run AT this layer (Valkey at Layer 11 needs a host, Hindsight pgvector at Layer 6 needs Postgres, Anthropic prompt cache is the provider's concern).
+
+What Layer 10 contributes to caching:
+- **Valkey deployment** — Cat 4 `cost.semantic_cache_valkey` RATIFIED-DM "Valkey running today". Layer 10 owns the host + healthcheck. Not yet capacity-planned per-tenant.
+- **Vault Transit caching** — Vault Transit has internal LRU cache for active keys; not Keiracom-tunable. At scale (N tenants × frequent decrypt), the in-Vault cache hit rate determines decrypt latency.
+- **Object Storage cache headers** — for V1 file uploads + Cloudflare-when-activated, cache TTL is set at Layer 10 storage config.
+
+## §6 LOOSE items / open questions
+
+1. **Fleet host memory pressure** — 5GB swap used of 5.3GB. Adding more services to this host risks OOM. Hindsight (1.4GB) is dev-only; can be torn down. Weaviate (3.2GB) is critical until memory-cutover Phase A3 retires it.
+2. **Better Stack coverage** — env vars present but per-layer health-check map is not documented. Layer 12 deep-dive (Scout+Atlas) addresses observability; Layer 10 needs to surface "what hosts are monitored".
+3. **Pulumi tenant-provisioning workflow** — `infra.iac` LOOSE V1-required. Depends on Temporal (Layer 5) which is DESIGNED NEVER DEPLOYED. Sequencing: Temporal deploy → Pulumi workflow → first tenant provisioned.
+4. **CI/CD gap audit** — `infra.cicd` LOOSE: "tests yes, deploys via Railway, rollouts via Vercel, rollbacks UNKNOWN — Phase 2 sub-item". Rollback procedure is the hard gap (Phase B3 `Rollback procedure + Vercel CI-gating`).
+5. **Cloudflare ICP-trigger** — `infra.cdn` DEFERRED until ICP geography expands. No defined trigger condition (which customer or which signup geo activates it?).
+6. **Vault HA tripwire** — Cat 16 `infra.secrets_management` sub-item (c): "3-node cluster at what threshold — probably mem.tenancy_tripwire 20-30 tenants". Naming `infra.vault_ha_tripwire` as own concept would clarify.
+7. **Composio per-tenant OAuth segregation** — Cat 16 sub-item (d) "HARD-GATE-WITHIN-HARD-GATE". Covered in Layer 8 deep-dive but the infra fault domain (one Composio account = one HTTP origin = one rate-limit pool per tenant) is Layer 10-shaped.
+8. **Backup-DR for Vault** — V1.x scope per `infra.backup_dr` reframe; Vault data dir + Shamir share rotation backup not yet defined. PR #1146 docs the recovery procedure but doesn't ship the backup mechanism.
+
+## §7 Per-tier behaviour variation
+
+| Tier | Infra topology | Host model |
+|---|---|---|
+| Sandbox | Topology B (shared fleet host) | No dedicated resources; 10 tasks/day rate limit at LiteLLM (Phase E e2) |
+| Solo | Topology B | Shared host, schema-per-tenant; minimal per-tenant overhead |
+| Pro | Topology B | Shared host, schema-per-tenant; multi-thread workflows allowed |
+| Team | Topology B | Shared host, schema-per-tenant; per-user accounting |
+| Enterprise | **Topology A** per-tenant VPC | Per-tenant Vultr instance (region of customer choice for compliance); per-tenant Hindsight + Vault + LiteLLM; per-tenant Composio account |
+
+Phase A `infra.iac` Pulumi automation handles Topology B provisioning (schema in shared Postgres). Topology A (Enterprise) requires `infra.iac` "Vultr VPC provisioning per tenant (Scale-tier only, re-introduce on first Scale-tier customer)" which is DEFERRED.
+
+## §8 Per-agent-type variation
+
+Infrastructure is largely agent-type-agnostic, BUT some specifics:
+
+| Agent type | Infra concern |
+|---|---|
+| Chat agent (Keira) | Customer-facing; latency-critical → benefits from Cloudflare CDN when activated for the dashboard + chat endpoints |
+| Deliberators | Internal-only → no CDN need; sit on fleet host's internal LAN to LiteLLM internal-Gemini route |
+| Worker agents | Long-running; need persistent host or workflow-engine durability (Temporal) — Layer 10 hosts the worker pool runtime |
+| Sidecar processes (TEI, Go Sidecar) | Per-tenant or per-instance; container resource cap conventions apply per `weaviate_capped.sh` pattern |
+
+## Cross-cutting concerns
+
+- **Multi-tenancy enforcement** — Vault Transit per-tenant key naming (`keiracom-tenant-{tenant_id}`) makes the cross-tenant decrypt attempt structurally impossible (verified PR #1146 + this session smoke). Topology A per-tenant VPC adds isolation at the infra level for Enterprise tier.
+- **Security (BYOK + secret mgmt)** — Vault is THE primary surface (Phase A2 done). Three secret categories per `infra.secrets_management`: customer BYOK keys (Vault Transit envelope, in Postgres), internal service credentials (Vault store, V1.x to wire), Composio OAuth tokens (per-tenant Composio account = customer-owned, not in Keiracom Vault).
+- **CI/CD + rollback** — `infra.cicd` LOOSE; Phase B3 has rollback gap. SonarCloud → CodeQL migration (PR #1138, `op.codeql_migration` RATIFIED-CEO) is one CI improvement; orchestrator-merge-after-NATS-concur pattern is the deploy-gate.
+- **Backup-DR (V1.x)** — Vault data dir backup not yet shipped; Hindsight per-tenant export is V1.x per Dave reframe; Postgres backup via Supabase PITR ($39/mo Pro tier mentioned in `infra.backup_dr`).
+- **Customer file system** — Vultr Object Storage as backend per `infra.iac`. Layer 10 owns the bucket + access policies; Layer 7 governance owns the per-tenant ACL.
+- **Reasoning trace + audit trail** — emitted by services in Layers 5/7/12; Layer 10 provides the storage substrate. Postgres for active; Hindsight for historical (post-active-window per cache framework).
+- **Compliance gates** — `tier.enterprise` compliance certifications (SOC 2 / HIPAA per `tier.enterprise` row) drive Layer 10 hardening: Topology A per-tenant VPC, separate Vault instance per regulated customer, region-locking.
+
+## Sources
+
+- `ceo:keiracom_architecture_v2_locked` (queried 2026-05-25)
+- `ceo:keiracom_build_priority` Phase A + B + Cat 16
+- Inventory Cat 16 (7 rows) + Cat 20 line 524
+- PR #1133 — TEI sidecar (running)
+- PR #1146 — Vault decryptor (this session)
+- bd `Agency_OS-31bk` — Phase A2 Vault parent
+- bd `Agency_OS-hpst` — Shamir → GCP KMS upgrade follow-up
+- `scripts/orchestrator/weaviate_capped.sh` — systemd memory-cap pattern (KEI-44 / KEI-48)
+- `/home/elliotbot/clawd/keiracom_system/dev/vault/PRODUCTION_DEPLOYMENT.md` — Shamir recovery procedure

--- a/docs/architecture/deep_dives/layer_11_cost_optimization.md
+++ b/docs/architecture/deep_dives/layer_11_cost_optimization.md
@@ -1,0 +1,201 @@
+# Layer 11 — Cost optimization (caching + token budgets + routing)
+
+**Owner:** Atlas + Orion (joint — Orion on cache strategy + LiteLLM routing)
+**Status:** PARTIAL — metering pipeline shipped (PR #1137); cache framework canonical registered (`ceo:cache_framework_canonical`); Valkey running per Cat 4; per-tier multipliers PROPOSAL pending pressure-test
+**Directive:** KEI-SYSTEM-DEEP-DIVE 2026-05-25 ~1779746500
+
+## Notes — canonical evidence pasted per audit-dispatch checklist
+
+`ceo:cache_framework_canonical` (queried 2026-05-25, verbatim):
+```json
+{
+  "directive": "KEI-SYSTEM-DEEP-DIVE",
+  "connects_to": ["cost.cache_discipline","cost.token_budget","cost.semantic_cache_valkey",
+                  "temp.inline.cache_check","deepdive.layer11_cost_optimization"],
+  "ratified_ts": "2026-05-25T~1779746500",
+  "layer_1_anthropic_prompt_cache": {"content":"structurally stable per-domain content","multiplier":"0.10x input cost"},
+  "layer_2_uncached": {"content":"per-call dynamic content","multiplier":"1.0x"},
+  "valkey_semantic_cache": "layered on top for repetitive query hits",
+  "history_beyond_active_window": "stored in Hindsight for queryable recall, NOT held in active context",
+  "per_tier_multipliers_proposal": {"sandbox":"0.5x","solo":"1.0x","pro":"1.5x","team":"2.0x","enterprise":"custom"},
+  "tier_multipliers_status": "PROPOSAL — pressure-test in Phase 2"
+}
+```
+
+Inventory Cat 4 verbatim:
+- `cost.metering_pipeline` (RATIFIED-CEO, PR #1137) — "V1 captures token-counts only; cost $AUD translation deferred to P3"
+- `cost.cache_discipline` (RATIFIED-CEO placement; LOOSE implementation) — "SHIFTING to Temporal interception layer per ratify 2026-05-25"
+- `cost.semantic_cache_valkey` (RATIFIED-DM) — "Valkey running today" per Viktor verbatim
+- `cost.token_budget` (LOOSE) — "per-call cap + tier-scaled pool + dispatcher-enforced + model-cost-calibrated"
+- `cost.dashboard` (LOOSE) — admin-dashboard panel per-tenant + per-callsign + per-agent-role
+- `cost.metering.production_wiring` (LOOSE, P1 Orion follow-up) — psycopg adapter + Prefect daily rollup
+- `cost.metering.log_shipper_config` (LOOSE, P2 Orion follow-up) — Vector or Filebeat
+- `cost.metering.provider_billing_api` (DEFERRED P3) — per-model-per-tenant $AUD translation
+
+## §1 Designed
+
+The framework is multi-layer:
+
+**Cache tiers (the cost-reduction substrate):**
+1. **Anthropic prompt cache** — 0.10× input cost; targets structurally stable content (per-domain knowledge, tool definitions, system prompts).
+2. **Uncached** — 1.0× baseline; per-call dynamic content.
+3. **Valkey semantic cache** — vector-similarity hits on repetitive queries. Layered on top of (1)/(2) — short-circuits the LLM call entirely when a similar prior query is in cache.
+4. **Hindsight beyond active window** — NOT a per-request cache; an observability + recall store for context beyond what fits in the active window. Stops being "cache" and starts being "memory" at this point.
+
+**Token budget (the cost-cap substrate):**
+- Per-call cap (hard ceiling on a single LLM request)
+- Tier-scaled pool (per-tenant aggregate budget per day/month — `cost.token_budget` Viktor 4-component proposal)
+- Dispatcher-enforced (the cap is checked by the dispatcher BEFORE the workflow starts, not after the LLM call completes)
+- Model-cost-calibrated (a Sonnet call counts more against the cap than a Haiku call, weighted by per-model $AUD)
+
+**Routing (the cost-control substrate):**
+- LiteLLM governance router (`gov.litellm_router` RATIFIED-CEO running) routes per BYOK key + per tier + per model preference
+- Internal fleet uses hardcoded Gemini 2.5 Flash per `reference_model_routing.md` (cost-optimal for internal governance)
+
+**Metering (the cost-visibility substrate):**
+- Per-call token attribution (PR #1137, this session — already shipped)
+- Per-tenant per-day per-model rollup table (`keiracom_tenant_metering` from PR #1137 migration)
+- Dashboard column "token-counts only V1; $AUD when P3 ships" per `cost.metering_pipeline` reframe
+
+## §2 Built
+
+| Component | Status | Evidence |
+|---|---|---|
+| Cache framework canonical | REGISTERED | `ceo:cache_framework_canonical` (2026-05-25) |
+| Cache placement decision | RATIFIED-CEO | `cost.cache_discipline` row 79 — placement at Temporal interception layer |
+| Cache implementation | LOOSE | Not yet built. Needs `temp.middleware` deploy (Layer 5 HARD GAP). |
+| Anthropic prompt cache | NOT WIRED | No Keiracom-side wiring; needs per-domain stable-content templates |
+| Valkey semantic cache | RUNNING | "Valkey running today" per Cat 4. Not yet wired into Temporal dispatch (which doesn't exist) |
+| Token budget (per-call cap) | NOT BUILT | LOOSE — needs `temp.inline.token_gate` (Layer 5 HARD GAP) |
+| Token budget (tier-scaled pool) | NOT BUILT | LOOSE — needs dispatcher tracking per-tenant pool |
+| LiteLLM router | RUNNING | T0.2 audit — pre-this-session |
+| Metering pipeline (V1: token-counts) | MERGED | PR #1137 (my work) — `src/keiracom_system/metering/` |
+| Metering production wiring | LOOSE (P1) | psycopg adapter + Prefect daily rollup — follow-up I named in PR #1137 |
+| Metering log shipper | LOOSE (P2) | Vector/Filebeat → metering service stdin |
+| Provider billing API ($AUD translation) | DEFERRED (P3) | post-first-paying-customer per PR #1128 §5 |
+| Cost dashboard | LOOSE | Admin panel per-tenant/callsign/agent-role |
+| Cost attribution wrappers | LOOSE | `cost.attribution_wrappers` Cat 4 row 77 — wrappers around 6 MAL primitives |
+| Governance cost attribution | LOOSE | `cost.governance_attribution` — PR-review + canonical-key query + audit-dispatch cost attribution |
+
+## §3 Measured
+
+What IS measured per PR #1137 metering pipeline + this session's il34 spike:
+
+| Metric | Value | Source |
+|---|---|---|
+| LLM tokens per Hindsight `retain` call | ~2,377 tokens per fixture (n=100 corpus) | il34 spike `/tmp/c7_bench.json` |
+| LLM tokens total at n=100 fixture ingest | 237,737 tokens (~$0.71 OpenAI gpt-4o-mini at quoted rates) | il34 spike |
+| LLM tokens total at n=1000 fixture ingest | 1,663,309 tokens (~$4.99) | il34 spike |
+| Hindsight extraction expansion at n=100 | 100 fixtures → 107 memory units (1.07× expansion) | il34 spike |
+| Hindsight CONSOLIDATION at n=1000 | 1000 fixtures → 719 memory units (0.72× — de-duplication kicks in at scale) | il34 spike |
+| Metering DB schema | `keiracom_tenant_metering(tenant_id, date_utc, model, request_count, input_tokens_sum, output_tokens_sum)` | PR #1137 migration |
+| Cost columns deferred to P3 | TRUE — no `cost_aud_sum` column V1 | PR #1137 migration verbatim |
+
+What is NOT measured:
+- Anthropic prompt cache hit rate (no Keiracom-side wiring)
+- Valkey semantic cache hit rate (not wired into a chokepoint to track)
+- Per-tier actual vs proposed multiplier (no production traffic)
+- LiteLLM routing latency overhead (not benchmarked)
+- Tool-call overhead vs LLM tokens (not separately attributed per Layer 8 §4)
+- $AUD spend per tenant per day (deferred to P3 provider-billing-API)
+
+## §4 Token budget / cost behaviour
+
+THIS layer's entire mandate is token budget + cost behaviour. Per-substrate:
+
+**Anthropic prompt cache** — 0.10× INPUT cost on cache hits. Output cost unchanged. Cache breakpoints + 5-min TTL per Anthropic spec. For Keiracom, this means:
+- Stable system prompts → cache breakpoint (cache hit on every subsequent call within 5 min)
+- MCP tools/list catalog → cache breakpoint
+- Tenant-specific context (BYOK, preferences) → cache breakpoint OR NOT depending on size threshold
+
+**Valkey semantic cache** — full call avoidance. Cache hit = 0 LLM cost + ~1ms Valkey lookup. Cache miss = baseline cost + ~1ms Valkey write.
+
+**Hindsight recall (beyond active window)** — recall is itself an LLM-mediated step in Hindsight (the reflect/recall calls hit the embedding model + sometimes the synthesis LLM). NOT zero cost. Per il34 spike, embedding via TEI sidecar is free (local BGE-small). Recall synthesis is ~hundreds of tokens depending on top-k.
+
+**Token budget enforcement** — runs at `temp.inline.token_gate` (Layer 5). Without Temporal: no enforcement today. With Temporal: per-call cap + per-tenant pool checked at workflow start.
+
+**Routing decisions:**
+- Customer-facing calls → customer's BYOK key (zero Keiracom cost; customer pays provider)
+- Internal governance calls → Keiracom-funded Gemini 2.5 Flash (low rate; per `reference_model_routing.md`)
+- Internal sub-tasks → may route to Haiku or local model depending on tier/model-cost-calibration (LOOSE)
+
+## §5 Cache strategy applicable
+
+THIS layer IS the cache strategy. Spec'd above in §1 + §4. Implementation pieces:
+
+- **Prompt cache wiring** — Keiracom-side template scaffold for per-domain stable content. NOT BUILT.
+- **Valkey wiring** — Valkey running but not yet wired into a dispatch chokepoint. Awaits Temporal deploy (Layer 5).
+- **Hindsight wiring** — TEI sidecar (PR #1133) + Hindsight wrappers (Atlas PR #1134) shipped. Recall already routed through them in dev.
+- **Cache invalidation policy** — PER-SUBSTRATE:
+  - Prompt cache: time-based (5-min Anthropic-side)
+  - Valkey: TTL per cache key (1min for live-data queries, 24hr for definitions)
+  - Hindsight: no invalidation — append-only memory; relevance scoring at recall time
+
+**Cache discipline enforcement** — `cost.cache_discipline` was "triple-option A discipline-doc + B runtime-warn + C PR-linter" but SHIFTED to Temporal interception layer per 2026-05-25 ratify (Cat 4 row 79). Means: gates A/B/C are SUPERSEDED by mechanical enforcement at `temp.inline.cache_check` (Layer 5). Without Temporal: no enforcement today.
+
+## §6 LOOSE items / open questions
+
+1. **Per-tier multipliers PROPOSAL pressure-test** — Sandbox 0.5× / Solo 1.0× / Pro 1.5× / Team 2.0× — no production data to validate. Phase 2 work per `ceo:cache_framework_canonical.tier_multipliers_status`.
+2. **Token budget Viktor 4-component proposal** — `cost.token_budget` LOOSE. Sub-deliberation per directive; not yet ratified.
+3. **Provider-billing-API integration (P3)** — DEFERRED post-first-paying-customer. Until then, dashboard shows token-counts only, no $AUD.
+4. **Cost attribution wrappers (`cost.attribution_wrappers`)** — wrappers around the 6 MAL primitives to attribute per-primitive cost. LOOSE; pending build.
+5. **Governance cost attribution (`cost.governance_attribution`)** — attribute PR review / canonical-key query / audit-dispatch cost to governance budget. LOOSE.
+6. **Cost dashboard scope** — admin only? customer-visible breakdown by callsign + agent-role? Cat 19 customer-product surface needs deliberator concur on scope.
+7. **Aiden §3.C nits**:
+   - `cost.tier_router_attribution` — how tier-router decides Solo/Pro/Scale topology routing (cost differs per topology)
+   - `cost.cache_post_ephemeral_validity` — semantic cache validity in ephemeral-agent world (each spawn loses local cache locality; Valkey shared survives across spawns but prompt cache resets)
+8. **Metering production wiring** — psycopg adapter + Prefect daily rollup deployment. LOOSE; I named as P1 follow-up in PR #1137.
+9. **Log shipper config** — Vector or Filebeat tailing Hindsight container logs → metering service stdin. LOOSE; P2 follow-up I named.
+
+## §7 Per-tier behaviour variation
+
+Per-tier multipliers PROPOSAL pressure-test (per `ceo:cache_framework_canonical`):
+
+| Tier | Multiplier | Practical meaning |
+|---|---|---|
+| Sandbox | 0.5× | Aggressive caching; force Anthropic prompt cache hits where possible; deny calls that miss cache budget. Free-tier protection. |
+| Solo | 1.0× | Baseline. Cache opportunistically; allow uncached calls within per-call cap. |
+| Pro | 1.5× | Looser per-call cap (multi-thread chats allowed → more parallel cache pressure). Higher Valkey TTL acceptable (Pro customers tolerate slightly stale data for $$ savings). |
+| Team | 2.0× | Per-user accounting → cache key includes user_id to avoid cross-user cache poisoning. Higher per-call cap. |
+| Enterprise | Custom | Per-tenant cache configuration (some Enterprise customers will WANT cache-busting for regulatory determinism — provable freshness). Per-tenant Valkey instance for Topology A. |
+
+The multipliers are PROPOSAL — pressure-test means: run a per-tier sample at first-paying-customer scale, observe actual cache hit rates + costs, calibrate up/down.
+
+The model-cost-calibration question (per `cost.token_budget`): a Sonnet call is ~3× more expensive than Haiku per token. Tier-scaled pool means a Sandbox user gets fewer Sonnet calls than a Solo user gets, weighted by $AUD-per-call. Token-budget enforcement needs the per-model multiplier baked in.
+
+## §8 Per-agent-type variation
+
+| Agent type | Cache profile | Cost-control specific |
+|---|---|---|
+| Chat agent (Keira, Tier 1) | Heavy Anthropic prompt cache (chat history is structurally stable per turn); Valkey for repetitive customer queries ("what's my balance" type) | Customer's BYOK key; per-tenant pool applies |
+| Deliberators (Tier 2) | Light prompt cache (each deliberator's prompt is structurally stable but per-PR content varies); minimal Valkey hits | Internal Gemini routing → low absolute cost; per-callsign attribution for governance budget |
+| Worker agents (Tier 3) | Tool-result cache via Valkey (HubSpot company lookup is cacheable for N seconds); minimal prompt cache | Customer's BYOK key; per-tenant pool; per-worker-type cost attribution wrapper |
+
+Ephemeral-agent caveat (Layer 8 §5 + Aiden §3.C nit `cost.cache_post_ephemeral_validity`):
+- Each agent spawn = new Anthropic prompt cache miss on first call (5-min TTL doesn't survive spawn cycles)
+- Valkey is shared so hits survive across spawns
+- Net: prompt cache effectiveness DROPS in ephemeral world; Valkey effectiveness UNCHANGED
+- Compensation: pre-warm Anthropic prompt cache from a "cache-warmer" workflow on tenant signup OR per-tier health check (LOOSE — name as follow-up)
+
+## Cross-cutting concerns
+
+- **Multi-tenancy enforcement** — Valkey cache keys MUST namespace by tenant_id (cross-tenant cache poisoning = data leakage). LiteLLM virtual key per tenant = per-tenant rate limiting. Metering rolls up per tenant.
+- **Security (BYOK + secret mgmt)** — Vault Transit (PR #1146) for BYOK envelope; LiteLLM looks up per-tenant key at call time. Cache layer NEVER stores decrypted keys. Go Sidecar (Layer 8) blocks key leakage into LLM context.
+- **CI/CD + rollback** — cache TTL / multiplier config should be GitOps-managed; rollback = re-apply prior config. No runtime mutation.
+- **Backup-DR (V1.x)** — Valkey cache is regenerable (no backup needed). Metering data IS critical (needs Postgres backup per `infra.backup_dr`). Hindsight memory is the long-term store; backup via per-tenant export (`Agency_OS-il34` V1.x).
+- **Customer file system** — file uploads NOT cached at this layer (binary data, no semantic cache value). Object Storage handles its own caching.
+- **Reasoning trace + audit trail** — every cache hit / miss / token spend → audit event for Layer 12 observability. Required for compliance attestation (Enterprise tier).
+- **Compliance gates** — regulated customers may demand provable cache-free path (every query = fresh LLM call). Enterprise tier per-tenant cache config supports this.
+
+## Sources
+
+- `ceo:cache_framework_canonical` (queried 2026-05-25)
+- `ceo:keiracom_architecture_v2_locked` Cat 4 + Cat 11
+- `ceo:keiracom_build_priority` Phase E e2 (rate limit + token spend hard-stop)
+- Inventory Cat 4 (10 rows) + Cat 11 (2 rows) + Cat 20 line 525
+- PR #1137 — metering pipeline (Orion, this session window)
+- PR #1128 — BYOK LLM routing spike (Orion)
+- PR #1133 — TEI sidecar (Orion)
+- PR #1146 — Vault decryptor (Orion, this session)
+- `reference_model_routing.md` — internal Gemini routing memo
+- il34 spike report at `/home/elliotbot/clawd/keiracom_system/dev/hindsight/spike/SPIKE_REPORT.md` (empirical per-corpus cost measurements)


### PR DESCRIPTION
## Summary

Per Dave directive KEI-SYSTEM-DEEP-DIVE 2026-05-25 ~1779746500 — twelve-layer architecture audit. **Orion-owned 4 layers** delivered here.

## Files (4)

| Layer | File | Status |
|---|---|---|
| **5 — Orchestration (Temporal)** | `docs/architecture/deep_dives/layer_05_orchestration.md` | **HARD GAP** — designed, NEVER deployed |
| **8 — Integration (MCP + Composio + LiteLLM)** | `docs/architecture/deep_dives/layer_08_integration.md` | PARTIAL — MCP merged (PR #1136); Composio POC open (`Agency_OS-aynv`); LiteLLM running |
| **10 — Infrastructure (Vultr + Docker + Vault + Cloudflare)** | `docs/architecture/deep_dives/layer_10_infrastructure.md` | PARTIAL — Vultr + Vault running; Cloudflare DEFERRED V1.1; Pulumi designed not built |
| **11 — Cost optimization (caching + budgets + routing)** | `docs/architecture/deep_dives/layer_11_cost_optimization.md` | PARTIAL — metering shipped (PR #1137); cache framework canonical; per-tier multipliers PROPOSAL pending pressure-test |

## Format compliance

All 4 docs follow the 8-section format per dispatch:
1. Designed (architecture spec exists)
2. Built (implementation done)
3. Measured (production data exists OR honestly stated no-data-yet)
4. Token budget / cost behaviour at this layer
5. Cache strategy applicable (Layer 1 prompt cache 0.10× / Layer 2 uncached 1.0× / Valkey / Hindsight)
6. LOOSE items / open questions
7. Per-tier behaviour variation (Sandbox 0.5× / Solo 1.0× / Pro 1.5× / Team 2.0× / Enterprise custom)
8. Per-agent-type variation (chat / deliberator / worker)

Plus cross-cutting concerns section per layer where touched.

## Canonical-key-query gate (audit-dispatch checklist)

Queried BEFORE writing artefact content:
- `ceo:keiracom_architecture_v2_locked`
- `ceo:cache_framework_canonical`
- `ceo:keiracom_build_priority`

Verbatim evidence pasted into each doc's `## Notes` section.

## Key empirical findings landed in the docs

- **Layer 5**: zero Temporal code in src/ — confirms Cat 20 line 519 "DESIGNED NEVER DEPLOYED" framing. `temp.contract_doc` (Elliot owes) is the LOOSE blocker before build.
- **Layer 8**: 5 integration substrates (MCP + Composio + LiteLLM + Go Sidecar + TEI Sidecar); cross-tenant enforcement at THREE mechanical layers; tool call overhead not separately attributed in metering today (Layer 11 follow-up nit).
- **Layer 10**: empirical fleet host memory pressure (5GB swap of 5.3GB used) flagged; current Vultr burn ~$53 USD/mo; Phase A2 Vault deploy DONE this session (PR #1146).
- **Layer 11**: per-corpus token spend empirical from il34 spike (n=100 ~$0.71, n=1000 ~$4.99 OpenAI); Hindsight consolidation at scale (0.72× expansion at n=1000); token budget enforcement requires Temporal (Layer 5 HARD GAP) so most cost-control gates are unenforced today.

## Plain English compliance

All 4 docs use plain English per dispatch. No timing predictions without observed basis (Keira rule). Honest about uncertainties — every `§6 LOOSE items` section enumerates open questions; `§3 Measured` flags "NOT measured" line items where data doesn't exist yet.

## Cross-cutting concerns addressed

Each doc has a `## Cross-cutting concerns` section covering: multi-tenancy enforcement, security (BYOK + secret mgmt + per-customer segregation), CI/CD + rollback, backup-DR (V1.x), customer file system, reasoning trace + audit trail, compliance gates — where the layer touches each.

## Test plan
- [x] All 4 docs created at canonical path `docs/architecture/deep_dives/layer_NN_name.md`
- [x] 8-section format per doc
- [x] Canonical keys queried + verbatim paste in Notes
- [x] Citations: spec references, PR numbers, canonical-key sub-keys throughout
- [x] Empirical data from this-session work (PR #1137 metering, PR #1146 Vault, il34 spike numbers) where applicable
- [x] Plain English, no timing predictions
- [ ] Atlas concur (joint owner on Layer 8 + Layer 11)
- [ ] Aiden review (architecture/governance lens)
- [ ] Dual-concur → admin-merge per orchestrator-merge-after-NATS-concur

🤖 Generated with [Claude Code](https://claude.com/claude-code)