### PR TITLE
[ORION] fix(fleet-supervisor): correct keiracom_system import path for dual-publish — Phase A6 deploy

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -82,7 +82,18 @@ def _temporal_signal_state(callsign: str, state: str) -> None:
     if os.environ.get("TEMPORAL_DUAL_PUBLISH_ENABLED", "").strip() != "1":
         return
     try:
-        from keiracom_system.temporal import signal_fleet_supervisor_sync  # noqa: PLC0415
+        # Ensure repo root is on sys.path so `src.keiracom_system.*` resolves when
+        # fleet_supervisor.py runs as a standalone script (fleet-supervisor.service
+        # invokes `python3 scripts/fleet_supervisor.py` with no PYTHONPATH override).
+        # The src.* prefix matches the test convention (tests/keiracom_system/temporal/
+        # test_*.py) — the prior PR #1155 used `keiracom_system.*` which resolved only
+        # under PYTHONPATH=.../src and crashed under the default service env.
+        from pathlib import Path as _Path  # noqa: PLC0415
+
+        _repo_root = str(_Path(__file__).resolve().parent.parent)
+        if _repo_root not in sys.path:
+            sys.path.insert(0, _repo_root)
+        from src.keiracom_system.temporal import signal_fleet_supervisor_sync  # noqa: PLC0415
 
         signal_fleet_supervisor_sync(callsign, state)
     except Exception as exc:  # noqa: BLE001 — dual-publish must never crash supervisor


### PR DESCRIPTION
## Summary

Discovered during Phase A6 deploy smoke (PR #1155 merged). The dual-publish `_temporal_signal_state()` imported `keiracom_system.temporal` which only resolves under `PYTHONPATH=.../src`. The fleet-supervisor.service runs `python3 scripts/fleet_supervisor.py` with NO PYTHONPATH override, so the import raised ModuleNotFoundError + dual-publish silently failed (fail-open kept supervisor running but no Temporal signal arrived).

## Fix

`scripts/fleet_supervisor.py:_temporal_signal_state()`:
- Switch import to `from src.keiracom_system.temporal import ...` matching test convention
- Add explicit `sys.path.insert` of repo root at call site (idempotent)

## End-to-end verification post-fix

```
_temporal_signal_state("orion", "ready") → "temporal signal sent" log
tctl workflow query --query_type get_signals_received → [1]
```

Counter went 0 → 1 immediately. Signal arrived. Fix works.

## Test plan
- [x] ruff check + format clean
- [x] End-to-end signal round-trip verified live against PROD Temporal fleet-supervisor-v1 workflow
- [ ] Max + Aiden concur
- [ ] Dual-concur → admin-merge → fleet-supervisor.service picks up new code on next restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)