### PR TITLE
[ATLAS] fix(ruff): format enforcer_deterministic.py — carry-over from #1160

### DIFF
--- a/src/bot_common/enforcer_deterministic.py
+++ b/src/bot_common/enforcer_deterministic.py
@@ -471,9 +471,7 @@ _R11_HEADER_RE = re.compile(r"^\s*\*\*[^*]+\*\*", re.MULTILINE)
 # Middle character class explicitly excludes box-drawing chars + newline to bound
 # backtracking (closes Sonar S5852 ReDoS risk from naive `.*?` greedy-lazy).
 # Either this OR a bold header satisfies the scannability requirement (Viktor voice authorisation 2026-05-26).
-_R11_DIVIDER_RE = re.compile(
-    r"^\s*[─━]{3,}\s+[^─━\n]{1,200}\s+[─━]{3,}\s*$", re.MULTILINE
-)
+_R11_DIVIDER_RE = re.compile(r"^\s*[─━]{3,}\s+[^─━\n]{1,200}\s+[─━]{3,}\s*$", re.MULTILINE)
 
 # Viktor-voice italic-bold section header — `*Bold Section*` at line start (single asterisks, Slack mrkdwn).
 # Either this OR markdown bold or divider satisfies scannability.
@@ -616,8 +614,7 @@ def check_r11(text: str, *, channel: str | None = None) -> dict | None:
         "violation": True,
         "rule_number": 11,
         "rule_name": "CEO-FORMAT-GATE",
-        "detail": "#ceo post violates plain-English convention: "
-        + "; ".join(violations),
+        "detail": "#ceo post violates plain-English convention: " + "; ".join(violations),
         "should_have": (
             "Use one of: **Bold Category** headers, ─── DIVIDER ─── lines, OR "
             "*Italic Section* headers (Viktor voice). Lead with OUTCOME + business "


### PR DESCRIPTION
## Summary

Inherited format drift from `b4fade730` (PR #1160) blocking Backend Lint (Ruff) on every open PR built against current main, including Nova's PR #1162.

## Repair

```
ruff format src/bot_common/enforcer_deterministic.py
```

1-line repair. 2 insertions, 5 deletions. No semantic change.

## Verification

```
$ ruff format --check src/bot_common/enforcer_deterministic.py
1 file already formatted

$ ruff check src/bot_common/enforcer_deterministic.py
All checks passed!
```

## Test plan
- [x] `ruff format --check` passes
- [x] `ruff check` passes
- [ ] CI Backend Lint (Ruff) green on this PR
- [ ] Rebase fan-out unblocks downstream PRs (#1162 + others)

🤖 Generated with [Claude Code](https://claude.com/claude-code)