### PR TITLE
[ORION] fix(fleet-supervisor): NATS PUBLISH log line → INFO so Nova A6 observer can see it

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -131,7 +131,14 @@ def _nats_publish_state(callsign: str, state: str) -> None:
                 await nc.close()
 
         asyncio.run(_publish())
-        log.debug("[%s] NATS PUBLISH %s → %s", callsign, subject, state)
+        # INFO not DEBUG so the line lands in fleet-supervisor.log at the default
+        # log level. Required by scripts/a6_observation_check.sh (Nova PR #1162)
+        # which counts NATS PUBLISH lines as one side of the dual-publish ledger;
+        # without this the counter is structurally 0 in production + every run
+        # reports mismatch_pct=100% / status=ALARM. Symmetric with the Temporal
+        # signal-sent line which is already INFO in src/keiracom_system/temporal/
+        # signal_helpers.py:55.
+        log.info("[%s] NATS PUBLISH %s → %s", callsign, subject, state)
     except Exception as exc:  # noqa: BLE001
         log.warning("[%s] NATS publish failed (non-fatal): %s", callsign, exc)
     # Phase A6 dual-publish: signal FleetSupervisorWorkflow alongside NATS.


### PR DESCRIPTION
## Summary

One-line fix unblocking Nova PR #1162 HOLD-orion lift condition (Option A path I committed to in the HOLD comment).

`_nats_publish_state` logged `NATS PUBLISH` at `log.debug`; `logging.basicConfig` is at INFO threshold; the line never lands in `/home/elliotbot/clawd/logs/fleet-supervisor.log`. Nova's `a6_observation_check.sh` counts `NATS PUBLISH` lines as one side of the dual-publish ledger — current production behaviour is `count_nats=0` always → `mismatch_pct=100%` / `status=ALARM` on every run.

## Empirical evidence (this turn, on fleet host)

```
grep -cE 'NATS PUBLISH'        /home/elliotbot/clawd/logs/fleet-supervisor.log  →  0
grep -cE 'temporal signal sent' /home/elliotbot/clawd/logs/fleet-supervisor.log  →  3
```

Temporal signal-sent line is already INFO in `src/keiracom_system/temporal/signal_helpers.py:55`. This commit makes the NATS side symmetric.

## Why this PR is the right Option

A vs B vs C from my HOLD comment on PR #1162:
- **A (this PR)**: Orion-side 1-line log-level. Clean blame separation.
- B: Nova bundles into PR #1162. Faster but cross-couples.
- C: Enable DEBUG level via systemd EnvironmentFile. More LoC, lower fidelity (DEBUG noise floods log).

A wins.

## Test plan

- [x] ruff check + format --check clean
- [x] Inline comment names the WHY (PR #1162 dependency + symmetry with signal_helpers.py:55)
- [ ] Max + Aiden concur (1-line change; should be fast)
- [ ] Dual-concur → admin-merge → next fleet-supervisor.service cycle starts writing INFO NATS PUBLISH lines → PR #1162 can rerun CI cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)