### PR TITLE
[ATLAS] docs(manual): Section 13 entry for #10028 boundary matrix completion

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -1423,3 +1423,7 @@ Pipeline validated via integration test #300 (730 domains, all 11 stages). Segme
 | 8 — Outreach Execution | Salesforge + Unipile + ElevenAgents | WIRED, not yet live-tested |
 
 **Current gate:** Provider resolution (ContactOut, Forager, Reacher) before outreach goes live.
+
+### Directive #10028 — KEI-CEO-BOUNDARY-MATRIX-V1 (RATIFIED-CEO via CONCUR-Full)
+
+Ratified 2026-05-26 via CONCUR-Full (Aiden + Max + Viktor APPROVE). Canonical state: ceo:boundary_matrix_v1 + ceo:directive_10028_complete. Scaffold landed via PR #1169 at 08:53:44Z. Four CI guards in scripts/ci/ + governance doc at docs/governance/boundary_matrix_v1.md enforce the 8-layer ownership contracts + 7 boundary violations at runtime. Five-store completion: first end-to-end application of the five-store rule (ratified directive 10028) closes here.


### PR DESCRIPTION
Single-line follow-up to PR #1169 (merged 2026-05-26T08:53:44Z). Adds the docs/MANUAL.md Section 13 entry per LAW XV requirement. Substance already canonical in `ceo:directive_10028_complete` + `ceo:boundary_matrix_v1` + `cis_directive_metrics` row 10028. This PR just lands the repo mirror so LAW XV hook validates clean.

## Test plan
- [x] Diff is +4 lines (`docs/MANUAL.md` only).
- [x] Heading carries `#10028` so the LAW XV hook regex matches.
- [x] Body verbatim from Elliot dispatch.

bd: Agency_OS-manual-10028-followup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)