### PR TITLE
[ORION] feat(keiracom-system/cache): Phase A7 build — cache architecture + cost infrastructure (Agency_OS-rw8e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,23 @@ jobs:
       - name: (d) Governance policy (ceo:*) forbidden in Hindsight wrappers
         run: ./scripts/ci/check_no_governance_policy_in_hindsight.sh
 
+  # ============================================
+  # Guard: Phase A7 cache discipline (CB-10)
+  # ============================================
+  # Source: docs/architecture/design/a7_cache_architecture.md §13 CB-10.
+  # All Valkey key construction MUST go through ValkeyClient.canonical_cache_key().
+  # Complements src/keiracom_system/cache/valkey_client.py runtime guard
+  # (defence-in-depth: linter at PR-review time + runtime guard at request time).
+  cache-discipline-guards:
+    name: Cache Discipline Guards (A7 CB-10)
+    runs-on: ubuntu-latest
+    needs: backend-lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: No raw redis/valkey calls outside ValkeyClient
+        run: ./scripts/ci/check_no_raw_valkey_outside_client.sh
+
   backend-typecheck:
     name: Backend Type Check (MyPy)
     runs-on: ubuntu-latest

--- a/scripts/cache_baseline_48h.py
+++ b/scripts/cache_baseline_48h.py
@@ -1,0 +1,178 @@
+"""48h cache-hit-rate baseline observation report — Phase A7 sub-task 5.
+
+Per design §7 (docs/architecture/design/a7_cache_architecture.md) — runs
+post-A9-migration validation gate; reports cache hit rates to
+keiracom.elliot.inbox.
+
+HONEST FRAMING (per design §7): N=1 tenant (Dave), 48h window. Not
+representative of multi-tenant production scale. First 3 paying customers
++ their first month of traffic = real calibration data.
+
+ACTION THRESHOLDS (per design §13 CB-8):
+  - Valkey hit rate <10%  → BLOCKING-V1 (re-tune _quantise_to_bucket + re-baseline)
+  - Valkey hit rate 10-40% → TRACK-AND-IMPROVE (flagged, non-blocking)
+  - Valkey hit rate >40%  → HEALTHY
+  - Anthropic prompt cache read/(create+read+standard) >50% → HEALTHY
+  - Anthropic prompt cache read/(...) <20%                   → TRACK-AND-IMPROVE (Anthropic-side measurement, non-customer-facing)
+
+Reads metrics from Better Stack via injected `metrics_fetcher` callable to
+keep this module testable (no live Better Stack call in unit tests).
+
+USAGE:
+    python scripts/cache_baseline_48h.py --tenant-id 00000000-...-001 --out /tmp/baseline.md
+
+Output is Markdown to STDOUT or --out path. Post to keiracom.elliot.inbox
+manually via tg or via the orchestrator after running.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+# Action thresholds — keep in sync with design §13 CB-8.
+VALKEY_BLOCKING_THRESHOLD: float = 0.10
+VALKEY_HEALTHY_THRESHOLD: float = 0.40
+ANTHROPIC_HEALTHY_THRESHOLD: float = 0.50
+ANTHROPIC_TRACK_THRESHOLD: float = 0.20
+
+# Metrics fetcher: caller-injected. Returns dict of metric_name -> aggregated value.
+# Signature: (metric_name, tags_filter, window_start, window_end) -> dict[str, int]
+MetricsFetcher = Callable[
+    [str, dict[str, str], datetime, datetime],
+    dict[str, int],
+]
+
+
+def _classify_valkey(hit_rate: float) -> str:
+    if hit_rate < VALKEY_BLOCKING_THRESHOLD:
+        return "BLOCKING-V1 (re-tune buckets + re-baseline before paying customer)"
+    if hit_rate < VALKEY_HEALTHY_THRESHOLD:
+        return "TRACK-AND-IMPROVE (flagged, non-blocking)"
+    return "HEALTHY"
+
+
+def _classify_anthropic(read_ratio: float) -> str:
+    if read_ratio < ANTHROPIC_TRACK_THRESHOLD:
+        return "TRACK-AND-IMPROVE (breakpoint placement misaligned)"
+    if read_ratio < ANTHROPIC_HEALTHY_THRESHOLD:
+        return "MARGINAL (between TRACK and HEALTHY thresholds)"
+    return "HEALTHY"
+
+
+def _safe_divide(numerator: int, denominator: int) -> float:
+    return numerator / denominator if denominator > 0 else 0.0
+
+
+def generate_report(
+    *,
+    tenant_id: str,
+    window_start: datetime,
+    window_end: datetime,
+    metrics_fetcher: MetricsFetcher,
+) -> str:
+    """Generate the Markdown baseline report. Pure function — no I/O."""
+    valkey = metrics_fetcher(
+        "keiracom.cache.valkey.lookup",
+        {"tenant_id": tenant_id},
+        window_start,
+        window_end,
+    )
+    anthropic = metrics_fetcher(
+        "keiracom.cache.anthropic.input_tokens",
+        {"tenant_id": tenant_id},
+        window_start,
+        window_end,
+    )
+
+    hits = int(valkey.get("hit", 0))
+    misses = int(valkey.get("miss", 0))
+    total = hits + misses
+    hit_rate = _safe_divide(hits, total)
+
+    cache_read = int(anthropic.get("read", 0))
+    cache_create = int(anthropic.get("create", 0))
+    standard = int(anthropic.get("standard", 0))
+    anthropic_total = cache_read + cache_create + standard
+    read_ratio = _safe_divide(cache_read, anthropic_total)
+
+    return f"""# 48h Cache-Hit Baseline — {tenant_id}
+
+**Window:** {window_start.isoformat()} → {window_end.isoformat()} UTC
+**N:** 1 tenant (Dave dogfooding). NOT representative of multi-tenant production scale.
+**First-paying-customer calibration:** required before treating these as definitive.
+
+## Valkey semantic cache
+
+| Field | Value |
+|---|---|
+| Hits | {hits:,} |
+| Misses | {misses:,} |
+| Total lookups | {total:,} |
+| Hit rate | {hit_rate:.1%} |
+| Classification | {_classify_valkey(hit_rate)} |
+
+## Anthropic prompt cache (per Anthropic API usage block)
+
+| Field | Value |
+|---|---|
+| cache_read_input_tokens | {cache_read:,} |
+| cache_creation_input_tokens | {cache_create:,} |
+| standard input_tokens | {standard:,} |
+| Total | {anthropic_total:,} |
+| Read ratio | {read_ratio:.1%} |
+| Classification | {_classify_anthropic(read_ratio)} |
+
+## Action
+
+- Valkey: {_classify_valkey(hit_rate)}
+- Anthropic prompt cache: {_classify_anthropic(read_ratio)}
+
+If Valkey is BLOCKING-V1, re-tune `_quantise_to_bucket` (num_buckets) in
+`src/keiracom_system/cache/valkey_client.py` and re-run this baseline
+before customer onboarding.
+"""
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tenant-id", required=True)
+    parser.add_argument("--out", default="-", help="output path or '-' for stdout")
+    parser.add_argument("--hours", type=int, default=48)
+    return parser.parse_args()
+
+
+def _placeholder_fetcher(*_args: Any, **_kwargs: Any) -> dict[str, int]:
+    """Placeholder fetcher when running this script standalone without Better Stack.
+
+    Real production wire-up injects a Better Stack metrics API client.
+    Returning zeros documents the contract; the report will show 0%
+    hit rate which classifies as BLOCKING-V1 — the script doesn't lie about
+    its inputs, the caller wires the real fetcher.
+    """
+    return {"hit": 0, "miss": 0, "create": 0, "read": 0, "standard": 0}
+
+
+def main() -> int:
+    args = _parse_args()
+    end = datetime.now(UTC)
+    start = end - timedelta(hours=args.hours)
+    report = generate_report(
+        tenant_id=args.tenant_id,
+        window_start=start,
+        window_end=end,
+        metrics_fetcher=_placeholder_fetcher,
+    )
+    if args.out == "-":
+        sys.stdout.write(report)
+    else:
+        with open(args.out, "w") as fh:
+            fh.write(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_no_raw_valkey_outside_client.sh
+++ b/scripts/ci/check_no_raw_valkey_outside_client.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Phase A7 CB-10 guard — direct redis/valkey imports forbidden outside the
+# cache layer. All Valkey access MUST go through ValkeyClient — importing
+# redis/valkey directly elsewhere in src/keiracom_system/ creates a parallel
+# path that bypasses the tenant-prefix invariant + cross-tenant isolation
+# guarantee enforced at ValkeyClient.canonical_cache_key() + _enforce_tenant_prefix().
+#
+# Canonical source: docs/architecture/design/a7_cache_architecture.md §13 CB-10
+# Complements: src/keiracom_system/cache/valkey_client.py _enforce_tenant_prefix()
+# (defence-in-depth — linter catches at PR-review time; runtime guard catches
+# at read/write boundary at request time)
+#
+# Pattern shape mirrors boundary-matrix-v1 guard (b) (PR #1169 import-detection).
+# Detecting calls (e.g. `client.set(...)`) would require flow analysis; the
+# import barrier is the chokepoint — no import = no call.
+#
+# Scope: src/keiracom_system/ ONLY. Legacy Agency_OS BDR surface in
+# src/pipeline/ uses redis for KEI-117 rate limiting + KV state, which is
+# out-of-scope for this cache-layer rule (separate concern; would be caught
+# by the boundary-matrix-v1 expansion at 3-repo carve-out per Phase 2.0).
+#
+# Exempt paths inside scope:
+#   - src/keiracom_system/cache/  (the canonical cache module)
+#
+# Pattern: `import redis` / `from redis` / `import valkey` / `from valkey`
+# at start-of-line.
+
+set -euo pipefail
+
+SCOPE="src/keiracom_system"
+
+if [ ! -d "$SCOPE" ]; then
+  echo "OK (cache-discipline): $SCOPE not present — guard inactive."
+  exit 0
+fi
+
+PATTERN='^[[:space:]]*(import[[:space:]]+(redis|valkey)|from[[:space:]]+(redis|valkey)(\.|[[:space:]]))'
+
+raw=$(grep -rnE --include='*.py' "$PATTERN" "$SCOPE" 2>/dev/null || true)
+
+# Exempt the cache module — ValkeyClient lives there and legitimately imports redis.
+hits=$(printf '%s\n' "$raw" \
+  | grep -v -E '^src/keiracom_system/cache/' \
+  | grep -v -E '^[[:space:]]*$' || true)
+
+if [ -n "$hits" ]; then
+  echo "FAIL (cache-discipline): direct redis/valkey imports found outside"
+  echo "src/keiracom_system/cache/. All Valkey access MUST go through"
+  echo "ValkeyClient to preserve the tenant-prefix invariant + cross-tenant"
+  echo "isolation guarantee. Route the call through ValkeyClient or move the"
+  echo "module under src/keiracom_system/cache/ if it IS a cache-layer module."
+  echo ""
+  echo "See docs/architecture/design/a7_cache_architecture.md §13 CB-10."
+  echo ""
+  echo "Offending lines:"
+  echo "$hits"
+  exit 1
+fi
+
+echo "OK (cache-discipline): no raw redis/valkey imports outside cache module."
+exit 0

--- a/src/keiracom_system/cache/__init__.py
+++ b/src/keiracom_system/cache/__init__.py
@@ -1,0 +1,49 @@
+"""Keiracom cache layer — Phase A7 cache architecture + cost infrastructure.
+
+Implements the design canonicalised in docs/architecture/design/a7_cache_architecture.md
+(PR #1156 merged 2026-05-26) + §13 build clarifications (PR #1165 merged 2026-05-26).
+
+Three substrates, layered:
+  - Anthropic prompt cache (Layer 1)  → 0.10x input cost on stable prefix content
+  - Valkey semantic cache (Layer N/A) → ~1ms lookup, short-circuits whole LLM call
+  - Hindsight beyond-active-window    → memory recall, NOT a perf cache
+
+Canonical key anchor: ceo:cache_framework_canonical.
+Module-level public surface re-exported below for callers.
+"""
+
+from src.keiracom_system.cache.constants import (
+    CACHE_LAYER_1_MULTIPLIER,
+    CACHE_LAYER_2_MULTIPLIER,
+    TIER_MULTIPLIERS_PROPOSAL,
+    VALKEY_TTL_DEFINITION_FETCH,
+    VALKEY_TTL_MUTATION,
+    VALKEY_TTL_READ_MOSTLY,
+)
+from src.keiracom_system.cache.litellm_helpers import (
+    inject_cache_control_markers,
+)
+from src.keiracom_system.cache.metrics import (
+    emit_anthropic_cache_tokens,
+    make_better_stack_emitter,
+)
+from src.keiracom_system.cache.token_budget_policy import (
+    TIER_DEFAULTS,
+    TenantBudgetPolicy,
+)
+from src.keiracom_system.cache.valkey_client import ValkeyClient
+
+__all__ = [
+    "CACHE_LAYER_1_MULTIPLIER",
+    "CACHE_LAYER_2_MULTIPLIER",
+    "TIER_DEFAULTS",
+    "TIER_MULTIPLIERS_PROPOSAL",
+    "VALKEY_TTL_DEFINITION_FETCH",
+    "VALKEY_TTL_MUTATION",
+    "VALKEY_TTL_READ_MOSTLY",
+    "TenantBudgetPolicy",
+    "ValkeyClient",
+    "emit_anthropic_cache_tokens",
+    "inject_cache_control_markers",
+    "make_better_stack_emitter",
+]

--- a/src/keiracom_system/cache/constants.py
+++ b/src/keiracom_system/cache/constants.py
@@ -1,0 +1,71 @@
+"""Cache framework canonical constants — Phase A7 sub-task 1.
+
+CANONICAL KEY ANCHOR — ceo:cache_framework_canonical (queried 2026-05-26, verbatim):
+
+  layer_1_anthropic_prompt_cache:
+    content:    "structurally stable per-domain content"
+    multiplier: "0.10x input cost"
+  layer_2_uncached:
+    content:    "per-call dynamic content"
+    multiplier: "1.0x"
+  per_tier_multipliers_proposal:
+    sandbox: 0.5x
+    solo:    1.0x
+    pro:     1.5x
+    team:    2.0x
+    enterprise: custom
+  tier_multipliers_status: "PROPOSAL — pressure-test in Phase 2"
+
+These constants are the single source-of-truth for consumers. If
+ceo:cache_framework_canonical changes, this module is the load-bearing fix
+and a test in tests/keiracom_system/cache/test_constants.py locks the values.
+
+Status: PROPOSAL on tier multipliers — see design doc §11 LOOSE items #4, #6.
+"""
+
+from __future__ import annotations
+
+# Multiplier on standard input cost when Anthropic prompt cache HITS.
+# Source: ceo:cache_framework_canonical.layer_1_anthropic_prompt_cache.multiplier
+CACHE_LAYER_1_MULTIPLIER: float = 0.10
+
+# Multiplier when no cache (baseline / uncached).
+# Source: ceo:cache_framework_canonical.layer_2_uncached.multiplier
+CACHE_LAYER_2_MULTIPLIER: float = 1.0
+
+# Per-tier multipliers PROPOSAL (pressure-test in Phase 2 with real traffic).
+# Source: ceo:cache_framework_canonical.per_tier_multipliers_proposal
+# Enterprise: "custom" sentinel; resolved at per-tenant onboarding time.
+TIER_MULTIPLIERS_PROPOSAL: dict[str, float | str] = {
+    "sandbox": 0.5,
+    "solo": 1.0,
+    "pro": 1.5,
+    "team": 2.0,
+    "enterprise": "custom",
+}
+
+# Per-tool-type Valkey TTL (seconds). Conservative V1 defaults; refine post 48h
+# baseline per design §6 + §11 LOOSE item #4.
+#
+# Read-mostly: HubSpot company lookup, Slack channel list, etc. Short TTL keeps
+# reads fresh against upstream changes.
+VALKEY_TTL_READ_MOSTLY: int = 60
+
+# Definition fetches: tools/list catalog, mental-model lookups — these rarely
+# change within a day. Long TTL is fine.
+VALKEY_TTL_DEFINITION_FETCH: int = 24 * 3600
+
+# Mutation tools (HubSpot company create, Slack message send): TTL 0 = no cache.
+# Mutations always hit the LLM with no Valkey check. Caching mutations is a
+# correctness bug, not a perf optimisation.
+VALKEY_TTL_MUTATION: int = 0
+
+# Valkey key namespace prefix. All keys MUST start with v1:{tenant_id}: per
+# design §4 cross-tenant isolation invariant. ValkeyClient enforces this at
+# the read/write boundary (defence-in-depth per CB-Atlas).
+VALKEY_KEY_NAMESPACE_PREFIX: str = "v1:"
+
+# Embedding bucket count for canonical_cache_key semantic component. V1
+# PROPOSAL per design §4 + §11 LOOSE item #1; tune from measured collision
+# rate post-baseline. 4096 = 12 bits.
+EMBEDDING_BUCKET_COUNT: int = 4096

--- a/src/keiracom_system/cache/litellm_helpers.py
+++ b/src/keiracom_system/cache/litellm_helpers.py
@@ -1,0 +1,155 @@
+"""LiteLLM helpers — Phase A7 sub-task 3.
+
+`cache_control` marker injection at the caller layer per CB-4 verification:
+LiteLLM has no global `cache_control_enabled: true` YAML option — markers
+are set per content block at message-construction time, matching the
+Anthropic API spec (`cache_control: {"type": "ephemeral"}`).
+
+CANONICAL DESIGN — docs/architecture/design/a7_cache_architecture.md §3 + §13
+CB-4 (helper-not-flag) + CB-5 (Anthropic cache-rate metric naming).
+
+REPO PRECEDENT — src/pipeline/intelligence.py uses this exact per-block
+cache_control pattern; this helper consolidates it into a reusable form for
+the cache layer's callers.
+
+DEFERRED to follow-up: Dave's tenant LiteLLM virtual_key YAML stanza
+(design §5). Reason — adding anthropic/* deployments to infra/litellm/config.yaml
+crosses Dave's 2026-05-20 internal-governance-never-Anthropic policy without
+explicit re-ratify. The virtual key only activates against a deployed Anthropic
+model group; deployment + key ship together at V1 customer onboarding gate
+(Phase C5). Bd follow-up filed in PR description.
+
+ANTHROPIC CACHE BREAKPOINT THRESHOLD: Anthropic requires >=1024 tokens between
+breakpoint markers (per Anthropic API spec). Per-tier system prompts smaller
+than this get no Layer 1 benefit. The helper exposes a minimum-tokens parameter
+so callers can short-circuit cache_control injection for under-threshold
+prompts (per design §3 edge case).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Anthropic API spec: minimum input tokens between cache breakpoints.
+# Below this threshold, Anthropic refuses to populate a cache breakpoint.
+# Source: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+ANTHROPIC_CACHE_MIN_TOKENS: int = 1024
+
+# Default cache_control marker payload (ephemeral type per Anthropic API).
+EPHEMERAL_CACHE_CONTROL: dict[str, str] = {"type": "ephemeral"}
+
+
+def _estimate_tokens(content: str | list[Any]) -> int:
+    """Rough token estimator: ~4 chars per token for English text.
+
+    Conservative — under-estimates somewhat (tokens are sometimes longer for
+    rare words / code), which is the safe direction (we'd rather skip
+    cache_control injection on a borderline prompt than fail the Anthropic
+    >=1024 check at runtime).
+
+    Caller can pass a real token counter via `token_counter` to
+    `inject_cache_control_markers()` for higher accuracy.
+    """
+    if isinstance(content, str):
+        return len(content) // 4
+    if isinstance(content, list):
+        # Anthropic content blocks: [{"type": "text", "text": "..."}, ...]
+        total = 0
+        for block in content:
+            if isinstance(block, dict) and isinstance(block.get("text"), str):
+                total += len(block["text"]) // 4
+        return total
+    return 0
+
+
+def inject_cache_control_markers(
+    messages: list[dict[str, Any]],
+    *,
+    breakpoint_policy: dict[str, bool] | None = None,
+    min_tokens: int = ANTHROPIC_CACHE_MIN_TOKENS,
+    token_counter: Any = None,
+) -> list[dict[str, Any]]:
+    """Inject Anthropic `cache_control` markers on stable-prefix message blocks.
+
+    Returns a new list; does not mutate input.
+
+    Per design §3 default policy (V1):
+        - system prompt → cache YES (if over min_tokens)
+        - tools/list → cache YES (if over min_tokens, configured at tool-list build time)
+        - per-domain knowledge → cache YES (if >1024 tokens)
+        - user input → cache NO
+        - tool result → cache NO
+
+    `breakpoint_policy` overrides defaults per role:
+        {"system": True, "user": False, "assistant": False, "tool": False}
+
+    `min_tokens` is the lower bound; messages estimating below this skip
+    cache_control entirely (the Anthropic API would reject the breakpoint
+    otherwise).
+
+    `token_counter` (optional) is a callable taking (content) -> int for more
+    accurate counting; default is the 4-chars-per-token estimator.
+    """
+    if breakpoint_policy is None:
+        breakpoint_policy = {
+            "system": True,
+            "user": False,
+            "assistant": False,
+            "tool": False,
+        }
+    counter = token_counter if token_counter is not None else _estimate_tokens
+
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        new_msg = dict(msg)
+        role = msg.get("role", "")
+        if not breakpoint_policy.get(role, False):
+            out.append(new_msg)
+            continue
+        content = msg.get("content")
+        if content is None:
+            out.append(new_msg)
+            continue
+        token_count = counter(content)
+        if token_count < min_tokens:
+            out.append(new_msg)
+            continue
+        new_msg["content"] = _apply_cache_control(content)
+        out.append(new_msg)
+    return out
+
+
+def _apply_cache_control(content: str | list[Any]) -> list[dict[str, Any]]:
+    """Wrap content in Anthropic content-block list with cache_control on the LAST block.
+
+    Anthropic's cache_control marker on a single content block marks the END of
+    a cacheable prefix; subsequent blocks (after this one) are NOT in the cache
+    breakpoint. Putting cache_control on the LAST block of role=system marks
+    the entire system prompt as cacheable.
+
+    String content is converted to a single text block with cache_control.
+    List content gets cache_control on its last text block.
+    """
+    if isinstance(content, str):
+        return [
+            {
+                "type": "text",
+                "text": content,
+                "cache_control": EPHEMERAL_CACHE_CONTROL,
+            }
+        ]
+    if isinstance(content, list):
+        if not content:
+            return []
+        new_blocks: list[dict[str, Any]] = []
+        for block in content[:-1]:
+            new_blocks.append(dict(block) if isinstance(block, dict) else block)
+        last = content[-1]
+        if isinstance(last, dict):
+            last_with_cc = dict(last)
+            last_with_cc["cache_control"] = EPHEMERAL_CACHE_CONTROL
+            new_blocks.append(last_with_cc)
+        else:
+            new_blocks.append(last)
+        return new_blocks
+    return []

--- a/src/keiracom_system/cache/metrics.py
+++ b/src/keiracom_system/cache/metrics.py
@@ -1,0 +1,128 @@
+"""Cache metrics emitter — Phase A7 sub-task 4.
+
+Better Stack instrumentation hook for cache layer metrics. Provides a
+MetricEmitter callable matching ValkeyClient's injection signature.
+
+CANONICAL DESIGN — docs/architecture/design/a7_cache_architecture.md §4
+(Valkey lookup metric) + §13 CB-5 (Anthropic prompt cache rate metric).
+
+METRIC NAMES (per design + CB-5):
+  - keiracom.cache.valkey.lookup{tenant_id, tool_name, outcome=hit|miss}
+  - keiracom.cache.anthropic.input_tokens{type=create|read|standard, tenant_id, model}
+
+CARDINALITY FLAG (per CB-5): tenant_id × tool_name × outcome at scale
+(200+ tenants × 50 tools × 2 outcomes = 20K series) is a Better Stack
+billing concern. V1 (Dave N=1) is unaffected; Phase 2 follow-up bd for
+pre-aggregation hook.
+
+DEPENDENCY INJECTION: caller provides http_post + base_url + auth_token so
+the emitter is testable without a live Better Stack endpoint. Default
+http_post uses stdlib urllib (no httpx dependency).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Better Stack telemetry HTTP API base. Env var override at construction time.
+DEFAULT_BETTERSTACK_INGEST_URL: str = "https://in.logs.betterstack.com/metrics"
+DEFAULT_TIMEOUT_SECONDS: float = 5.0
+
+
+HTTPPostFn = Callable[[str, dict[str, Any], dict[str, str], float], int]
+
+
+def _default_http_post(
+    url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+    timeout: float,
+) -> int:
+    """Stdlib urllib POST returning HTTP status code. Fail-open on transport error.
+
+    Cache metrics are fire-and-forget — failing the LLM call because Better
+    Stack is unreachable would be worse than dropping a metric.
+    """
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status
+    except urllib.error.URLError as exc:
+        log.warning("better_stack_metric_emitter: %s", exc)
+        return 0
+
+
+def make_better_stack_emitter(
+    *,
+    ingest_url: str = DEFAULT_BETTERSTACK_INGEST_URL,
+    source_token: str,
+    http_post: HTTPPostFn | None = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Callable[[str, dict[str, str]], None]:
+    """Build a MetricEmitter that POSTs one metric per call to Better Stack.
+
+    Returned signature matches ValkeyClient's `metric_emitter` parameter:
+        (metric_name: str, tags: dict[str, str]) -> None
+
+    Phase 2 follow-up: buffer + flush to reduce per-call HTTP overhead +
+    address the cardinality flag from CB-5. V1 (N=1 Dave) is single-emit fine.
+    """
+    poster = http_post or _default_http_post
+    headers = {"Authorization": f"Bearer {source_token}"}
+
+    def emit(metric_name: str, tags: dict[str, str]) -> None:
+        payload = {
+            "metric": metric_name,
+            "tags": tags,
+            "value": 1,
+        }
+        poster(ingest_url, payload, headers, timeout_seconds)
+
+    return emit
+
+
+def emit_anthropic_cache_tokens(
+    emitter: Callable[[str, dict[str, str]], None] | None,
+    *,
+    tenant_id: str,
+    model: str,
+    cache_creation_input_tokens: int,
+    cache_read_input_tokens: int,
+    standard_input_tokens: int,
+) -> None:
+    """Emit one metric per category from an Anthropic API response usage block.
+
+    Caller extracts the three token counts from `response.usage.*` and passes
+    them in. Metric shape per CB-5:
+        keiracom.cache.anthropic.input_tokens{type, tenant_id, model}
+
+    No-op when emitter is None (e.g. in tests / pre-Better-Stack envs).
+    """
+    if emitter is None:
+        return
+    for token_type, token_count in (
+        ("create", cache_creation_input_tokens),
+        ("read", cache_read_input_tokens),
+        ("standard", standard_input_tokens),
+    ):
+        if token_count > 0:
+            emitter(
+                "keiracom.cache.anthropic.input_tokens",
+                {
+                    "type": token_type,
+                    "tenant_id": tenant_id,
+                    "model": model,
+                    "count": str(token_count),
+                },
+            )

--- a/src/keiracom_system/cache/token_budget_policy.py
+++ b/src/keiracom_system/cache/token_budget_policy.py
@@ -1,0 +1,155 @@
+"""TenantBudgetPolicy — Phase A7 sub-task 2.
+
+Policy data hook for temp.inline.token_gate (LLM-call workflow #2 enforces;
+A7 only ships the data + Postgres table).
+
+CANONICAL DESIGN — docs/architecture/design/a7_cache_architecture.md §6 + §13
+CB-3 (point-in-time schema, no effective_from/until) + CB-9 (tier CHECK).
+
+CONSUMERS:
+  - LLM-call workflow #2 token_gate activity — calls from_db(db, tenant_id),
+    enforces per_call_cap_tokens + daily_pool_tokens + monthly_pool_tokens
+    before each LLM call.
+  - 48h baseline observation script — reads default tier policies for the
+    cost-attribution report.
+
+DEPENDENCY INJECTION: caller passes any object implementing _DBProtocol
+(execute(query, *params) + fetchone()). This avoids direct asyncpg/psycopg
+import inside the cache module — required by boundary-matrix-v1 guard (b)
+which exempts only memory/ + control_plane/ paths (see PR #1169 +
+docs/governance/boundary_matrix_v1.md).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+# Tier identifiers — mirror the CHECK constraint in the SQL migration.
+# Keep in sync with supabase/migrations/20260526_keiracom_tenant_budgets.sql.
+TIER_SANDBOX = "sandbox"
+TIER_SOLO = "solo"
+TIER_PRO = "pro"
+TIER_TEAM = "team"
+TIER_ENTERPRISE = "enterprise"
+
+VALID_TIERS: frozenset[str] = frozenset(
+    {TIER_SANDBOX, TIER_SOLO, TIER_PRO, TIER_TEAM, TIER_ENTERPRISE}
+)
+
+
+class TenantBudgetPolicyError(RuntimeError):
+    """Raised on invalid tier or missing tenant budget row."""
+
+
+class _DBProtocol(Protocol):
+    """Subset of a DB cursor/connection we depend on for from_db().
+
+    Mirrors the protocol-injection pattern from PR #1132 KeiracomTenantExtension.
+    Lets unit tests inject a fake without importing asyncpg/psycopg here.
+    """
+
+    def execute(self, query: str, *params: Any) -> Any: ...
+    def fetchone(self) -> Any: ...
+
+
+# Default per-tier model cost calibration weight. Mirrors design §6.
+# Keys are LiteLLM model identifiers (provider/model) per gov.litellm_router.
+# Values are multipliers vs Haiku-baseline (Haiku 3.5 = 1.0x).
+DEFAULT_MODEL_COST_CALIBRATION: dict[str, float] = {
+    "anthropic/claude-3-5-sonnet": 3.0,
+    "anthropic/claude-3-5-haiku": 1.0,
+    "openai/gpt-4o": 2.5,
+    "openai/gpt-4o-mini": 0.8,
+    "google/gemini-2.5-flash": 0.5,
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class TenantBudgetPolicy:
+    """Per-tenant policy data the token_gate enforces against.
+
+    Frozen dataclass — policies are immutable values; mutations create a new
+    instance and UPDATE the row. updated_at column tracks the last write.
+    Per CB-3 point-in-time schema; no effective_from/until history.
+    """
+
+    tenant_id: str
+    tier: str
+    per_call_cap_tokens: int
+    daily_pool_tokens: int
+    monthly_pool_tokens: int
+    model_cost_calibration: dict[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.tier not in VALID_TIERS:
+            raise TenantBudgetPolicyError(f"tier {self.tier!r} not in {sorted(VALID_TIERS)}")
+        if self.per_call_cap_tokens <= 0:
+            raise TenantBudgetPolicyError("per_call_cap_tokens must be > 0")
+        if self.daily_pool_tokens <= 0:
+            raise TenantBudgetPolicyError("daily_pool_tokens must be > 0")
+        if self.monthly_pool_tokens <= 0:
+            raise TenantBudgetPolicyError("monthly_pool_tokens must be > 0")
+
+    @classmethod
+    def from_db(cls, db: _DBProtocol, tenant_id: str) -> TenantBudgetPolicy:
+        """Load policy from Postgres for a given tenant_id.
+
+        Raises TenantBudgetPolicyError if the tenant has no budget row.
+        Caller injects any object with execute() + fetchone() — keeps this
+        module driver-agnostic per boundary-matrix-v1 guard (b).
+        """
+        db.execute(
+            "SELECT tier, per_call_cap_tokens, daily_pool_tokens, "
+            "monthly_pool_tokens, model_cost_calibration "
+            "FROM keiracom_tenant_budgets WHERE tenant_id = %s",
+            tenant_id,
+        )
+        row = db.fetchone()
+        if row is None:
+            raise TenantBudgetPolicyError(
+                f"no budget row for tenant_id={tenant_id!r}; seed via migration"
+            )
+        return cls(
+            tenant_id=tenant_id,
+            tier=row[0],
+            per_call_cap_tokens=int(row[1]),
+            daily_pool_tokens=int(row[2]),
+            monthly_pool_tokens=int(row[3]),
+            model_cost_calibration=dict(row[4]) if row[4] else {},
+        )
+
+
+# Default per-tier policies (V1 PROPOSAL — pressure-test in Phase 2 per design §6).
+# Sandbox 50K/day cap per amendment 2 (Agency_OS-tpxj).
+# Enterprise = sentinel record; per-tenant operator override required at onboard.
+TIER_DEFAULTS: dict[str, dict[str, int]] = {
+    TIER_SANDBOX: {
+        "per_call_cap_tokens": 10_000,
+        "daily_pool_tokens": 50_000,
+        "monthly_pool_tokens": 500_000,
+    },
+    TIER_SOLO: {
+        "per_call_cap_tokens": 50_000,
+        "daily_pool_tokens": 1_000_000,
+        "monthly_pool_tokens": 30_000_000,
+    },
+    TIER_PRO: {
+        "per_call_cap_tokens": 100_000,
+        "daily_pool_tokens": 5_000_000,
+        "monthly_pool_tokens": 150_000_000,
+    },
+    TIER_TEAM: {
+        "per_call_cap_tokens": 200_000,
+        "daily_pool_tokens": 20_000_000,
+        "monthly_pool_tokens": 600_000_000,
+    },
+    # Enterprise = custom; placeholder values that will be overridden by
+    # operator at onboarding. Non-zero because the dataclass invariant
+    # forbids zero — operator MUST replace these with real per-tenant caps.
+    TIER_ENTERPRISE: {
+        "per_call_cap_tokens": 1_000_000,
+        "daily_pool_tokens": 100_000_000,
+        "monthly_pool_tokens": 3_000_000_000,
+    },
+}

--- a/src/keiracom_system/cache/valkey_client.py
+++ b/src/keiracom_system/cache/valkey_client.py
@@ -1,0 +1,189 @@
+"""ValkeyClient — Phase A7 sub-task 1.
+
+Per-tenant Valkey semantic cache client. Wraps the redis-py / valkey-protocol
+connection with:
+  - canonical_cache_key()  — deterministic key construction across spawns
+  - tenant prefix guard    — read/write boundary check (CB-Atlas)
+  - instrumentation hook   — Better Stack lookup metric emission (sub-task 4)
+
+CANONICAL DESIGN — docs/architecture/design/a7_cache_architecture.md §4 + §13
+(PR #1156 + PR #1165 merged 2026-05-26).
+
+DESIGN DECISIONS folded in per build-time clarifications (§13):
+  CB-1 — uses redis>=5.0.0 (already in requirements.txt; not valkey-py)
+  CB-2 — dependency-injection of redis.Redis + TEIClient at __init__
+  CB-10 — all key construction MUST go through canonical_cache_key()
+  CB-Atlas — _enforce_tenant_prefix() at read/write boundary (defence-in-depth)
+
+TESTABILITY: redis client + TEI client + metric emitter are all injectable so
+unit tests don't need a live Valkey or TEI container. The runtime caller (LLM
+workflow #2 activity factory) constructs the real instances from env config
+and injects.
+
+CONSUMERS:
+  - LLM-call workflow #2 (separate dispatch) — wraps each LLM call's cache_check
+  - 48h baseline observation script (sub-task 5) — reads cache_lookup metrics
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import struct
+from collections.abc import Callable
+from typing import Any, Protocol
+
+from src.keiracom_system.cache.constants import (
+    EMBEDDING_BUCKET_COUNT,
+    VALKEY_KEY_NAMESPACE_PREFIX,
+)
+from src.keiracom_system.embeddings.tei_client import TEIClient
+
+log = logging.getLogger(__name__)
+
+# Outcome label for cache_lookup metric (per design §4 instrumentation).
+OUTCOME_HIT = "hit"
+OUTCOME_MISS = "miss"
+
+
+class _RedisProtocol(Protocol):
+    """Subset of redis.Redis we depend on. Lets unit tests inject a fake."""
+
+    def get(self, key: str) -> bytes | None: ...
+    def set(self, key: str, value: str | bytes) -> Any: ...
+    def setex(self, key: str, time: int, value: str | bytes) -> Any: ...
+    def delete(self, *keys: str) -> Any: ...
+
+
+# Metric emitter: caller-injected callable. None = no instrumentation.
+# Signature: (metric_name, tags_dict) -> None. Pre-aggregation at scale is a
+# Phase 2 follow-up per CB-5 (cardinality cap on tenant_id × tool_name × outcome).
+MetricEmitter = Callable[[str, dict[str, str]], None]
+
+
+class ValkeyClientError(RuntimeError):
+    """Raised on any Valkey-side or tenant-isolation violation."""
+
+
+class ValkeyClient:
+    """Per-tenant cache client.
+
+    Each instance is bound to a single tenant_id. Cross-tenant access raises
+    ValkeyClientError via _enforce_tenant_prefix() — read/write boundary guard.
+    """
+
+    def __init__(
+        self,
+        *,
+        redis_client: _RedisProtocol,
+        tei_client: TEIClient,
+        tenant_id: str,
+        metric_emitter: MetricEmitter | None = None,
+    ):
+        if not tenant_id:
+            raise ValkeyClientError("tenant_id is required (cross-tenant isolation invariant)")
+        self._redis = redis_client
+        self._tei = tei_client
+        self._tenant_id = tenant_id
+        self._metric_emitter = metric_emitter
+        self._expected_prefix = f"{VALKEY_KEY_NAMESPACE_PREFIX}{tenant_id}:"
+
+    @property
+    def tenant_id(self) -> str:
+        return self._tenant_id
+
+    def canonical_cache_key(
+        self,
+        *,
+        tool_name: str,
+        args: dict[str, Any],
+        query_text: str | None = None,
+    ) -> str:
+        """Construct the canonical Valkey key for a tool call.
+
+        Deterministic across spawns — same (tenant_id, tool_name, args,
+        query_text) always yields the same key, so ephemeral agent #2 hits
+        the cache populated by ephemeral agent #1.
+
+        With query_text, includes a semantic bucket component derived from the
+        BGE-small-en-v1.5 embedding (via TEIClient). Without query_text,
+        falls back to args-hash only.
+        """
+        if not tool_name:
+            raise ValkeyClientError("tool_name is required")
+        args_normalised = json.dumps(args, sort_keys=True, separators=(",", ":"))
+        args_hash = hashlib.sha256(args_normalised.encode("utf-8")).hexdigest()[:16]
+        if query_text:
+            embedding = self._tei.embed([query_text])[0]
+            bucket = self._quantise_to_bucket(embedding)
+            return f"{self._expected_prefix}{tool_name}:{args_hash}:b{bucket}"
+        return f"{self._expected_prefix}{tool_name}:{args_hash}"
+
+    @staticmethod
+    def _quantise_to_bucket(
+        embedding: list[float], num_buckets: int = EMBEDDING_BUCKET_COUNT
+    ) -> int:
+        """Map a 384-dim embedding to a bucket index in [0, num_buckets).
+
+        V1 — sign-bit hash projection. Stable per (embedding, num_buckets).
+        Phase 2 may swap to a learned hash (e.g. LSH); the canonical key
+        format is stable across implementations because the bucket index is
+        a single integer.
+        """
+        # Pack floats deterministically, hash, then modulo into the bucket space.
+        packed = struct.pack(f"{len(embedding)}f", *embedding)
+        digest = hashlib.sha256(packed).digest()
+        # Take leading 4 bytes as unsigned int, modulo num_buckets.
+        leading = int.from_bytes(digest[:4], byteorder="big", signed=False)
+        return leading % num_buckets
+
+    def _enforce_tenant_prefix(self, key: str) -> None:
+        """Reject any key not matching v1:{self._tenant_id}:* at the read/write boundary.
+
+        Defence-in-depth: even if a caller bypasses canonical_cache_key(), this
+        guard catches it. Complements the PR-linter pattern in
+        scripts/ci/check_no_raw_valkey_outside_client.sh (per CB-10 + CB-Atlas).
+        """
+        if not key.startswith(self._expected_prefix):
+            raise ValkeyClientError(
+                f"valkey key {key!r} does not match expected tenant prefix "
+                f"{self._expected_prefix!r} — all keys MUST go through "
+                "ValkeyClient.canonical_cache_key()"
+            )
+
+    def get(self, key: str, *, tool_name: str | None = None) -> bytes | None:
+        """Read from Valkey. Emits cache_lookup{outcome=hit|miss} metric."""
+        self._enforce_tenant_prefix(key)
+        value = self._redis.get(key)
+        outcome = OUTCOME_HIT if value is not None else OUTCOME_MISS
+        if self._metric_emitter is not None:
+            self._metric_emitter(
+                "keiracom.cache.valkey.lookup",
+                {
+                    "tenant_id": self._tenant_id,
+                    "tool_name": tool_name or "unknown",
+                    "outcome": outcome,
+                },
+            )
+        return value
+
+    def set(self, key: str, value: str | bytes, *, ttl_seconds: int = 0) -> None:
+        """Write to Valkey with optional TTL. ttl_seconds=0 means no expiry.
+
+        Per design §4 per-tool-type TTL — caller passes the right TTL from
+        constants.py (VALKEY_TTL_READ_MOSTLY / DEFINITION_FETCH / MUTATION).
+        Mutation tools should never reach set() because TTL=0 + caller
+        contract — but the client doesn't enforce that here (caller's
+        responsibility).
+        """
+        self._enforce_tenant_prefix(key)
+        if ttl_seconds > 0:
+            self._redis.setex(key, ttl_seconds, value)
+        else:
+            self._redis.set(key, value)
+
+    def delete(self, key: str) -> None:
+        """Explicit invalidation — rare path (Composio webhook handler etc.)."""
+        self._enforce_tenant_prefix(key)
+        self._redis.delete(key)

--- a/supabase/migrations/20260526_keiracom_tenant_budgets.sql
+++ b/supabase/migrations/20260526_keiracom_tenant_budgets.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- 20260526_keiracom_tenant_budgets.sql
+--
+-- Phase A7 sub-task 2 — per-tenant LLM token budget policy data.
+-- bd: Agency_OS-rw8e
+--
+-- Sibling to keiracom_tenant_metering (PR #1137). Stores the per-tenant tier
+-- + per-call cap + daily/monthly pool sizes + model-cost calibration weights
+-- that the LLM-call workflow #2 token_gate enforces against.
+--
+-- CANONICAL DESIGN — docs/architecture/design/a7_cache_architecture.md §6 +
+-- §13 CB-3 (point-in-time schema, no effective_from/until per build clarification)
+-- + CB-9 (tier CHECK constraint).
+--
+-- Schema decisions (per CB-3):
+--   - PRIMARY KEY (tenant_id) — one current policy per tenant
+--   - NO effective_from/until columns (point-in-time only)
+--   - updated_at tracks last write via app-layer UPSERT
+--   - Historical "what was Pro's cap in March?" reconstruction via
+--     keiracom_tenant_metering rollup + future budget-change audit log
+--     (separate follow-up if needed; not required for V1 pre-revenue)
+--
+-- CHECK (tier IN (...)) per CB-9 prevents typos at INSERT/UPDATE time;
+-- mirrors VALID_TIERS in src/keiracom_system/cache/token_budget_policy.py.
+--
+-- Seed rows: 5 tier-default placeholders (Dave's tenant assigned 'team' tier
+-- per design §5 "team-equivalent for capacity allocation"). Operator inserts
+-- per-tenant override row at onboarding for Enterprise (custom caps).
+--
+-- KEI-87 bypass: SET LOCAL agency_os.callsign = 'dave' required because this
+-- migration creates a public-schema table — same pattern as the metering
+-- migration (PR #1137) and 20260524_0scg_ceo_memory_context_not_null.sql.
+-- ============================================================================
+
+SET LOCAL agency_os.callsign = 'dave';
+
+CREATE TABLE IF NOT EXISTS public.keiracom_tenant_budgets (
+    tenant_id              UUID         NOT NULL,
+    tier                   TEXT         NOT NULL
+        CHECK (tier IN ('sandbox','solo','pro','team','enterprise')),
+    per_call_cap_tokens    BIGINT       NOT NULL CHECK (per_call_cap_tokens > 0),
+    daily_pool_tokens      BIGINT       NOT NULL CHECK (daily_pool_tokens > 0),
+    monthly_pool_tokens    BIGINT       NOT NULL CHECK (monthly_pool_tokens > 0),
+    model_cost_calibration JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    updated_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id),
+    FOREIGN KEY (tenant_id) REFERENCES public.keiracom_tenants(tenant_id) ON DELETE CASCADE
+);
+
+-- "All Pro tenants" / "all Team tenants" queries — per CB-3 index decision.
+CREATE INDEX IF NOT EXISTS idx_keiracom_tenant_budgets_tier
+    ON public.keiracom_tenant_budgets (tier);
+
+-- Trigger: refresh updated_at on any UPDATE so the column tracks the last
+-- policy change accurately even if the writer forgets to set it explicitly.
+CREATE OR REPLACE FUNCTION public.keiracom_tenant_budgets_set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_keiracom_tenant_budgets_updated_at
+    ON public.keiracom_tenant_budgets;
+
+CREATE TRIGGER trg_keiracom_tenant_budgets_updated_at
+    BEFORE UPDATE ON public.keiracom_tenant_budgets
+    FOR EACH ROW
+    EXECUTE FUNCTION public.keiracom_tenant_budgets_set_updated_at();
+
+-- ----------------------------------------------------------------------------
+-- Seed: Dave's tenant gets 'team' tier defaults (design §5 + metadata tier).
+-- Dave is tenant_id 00000000-0000-0000-0000-000000000001 per
+-- ceo:keiracom_architecture_v2 tenant.single_supabase amendment (PR #1168).
+-- Other tenants seeded at their per-customer onboarding (Phase C5).
+-- ----------------------------------------------------------------------------
+
+INSERT INTO public.keiracom_tenant_budgets (
+    tenant_id,
+    tier,
+    per_call_cap_tokens,
+    daily_pool_tokens,
+    monthly_pool_tokens,
+    model_cost_calibration
+)
+SELECT
+    '00000000-0000-0000-0000-000000000001'::uuid AS tenant_id,
+    'team'::text                                  AS tier,
+    200000::bigint                                AS per_call_cap_tokens,
+    20000000::bigint                              AS daily_pool_tokens,
+    600000000::bigint                             AS monthly_pool_tokens,
+    jsonb_build_object(
+        'anthropic/claude-3-5-sonnet', 3.0,
+        'anthropic/claude-3-5-haiku',  1.0,
+        'openai/gpt-4o',               2.5,
+        'openai/gpt-4o-mini',          0.8,
+        'google/gemini-2.5-flash',     0.5
+    )                                              AS model_cost_calibration
+WHERE EXISTS (
+    SELECT 1 FROM public.keiracom_tenants
+    WHERE tenant_id = '00000000-0000-0000-0000-000000000001'::uuid
+)
+ON CONFLICT (tenant_id) DO NOTHING;

--- a/tests/keiracom_system/cache/test_constants.py
+++ b/tests/keiracom_system/cache/test_constants.py
@@ -1,0 +1,55 @@
+"""Lock cache constants against ceo:cache_framework_canonical — Phase A7 sub-task 1.
+
+If ceo:cache_framework_canonical changes upstream, this test breaks and the
+constants module is the load-bearing fix.
+"""
+
+from src.keiracom_system.cache.constants import (
+    CACHE_LAYER_1_MULTIPLIER,
+    CACHE_LAYER_2_MULTIPLIER,
+    EMBEDDING_BUCKET_COUNT,
+    TIER_MULTIPLIERS_PROPOSAL,
+    VALKEY_KEY_NAMESPACE_PREFIX,
+    VALKEY_TTL_DEFINITION_FETCH,
+    VALKEY_TTL_MUTATION,
+    VALKEY_TTL_READ_MOSTLY,
+)
+
+
+def test_layer_1_multiplier_matches_canonical():
+    assert CACHE_LAYER_1_MULTIPLIER == 0.10
+
+
+def test_layer_2_multiplier_matches_canonical():
+    assert CACHE_LAYER_2_MULTIPLIER == 1.0
+
+
+def test_tier_multipliers_match_canonical_proposal():
+    assert TIER_MULTIPLIERS_PROPOSAL["sandbox"] == 0.5
+    assert TIER_MULTIPLIERS_PROPOSAL["solo"] == 1.0
+    assert TIER_MULTIPLIERS_PROPOSAL["pro"] == 1.5
+    assert TIER_MULTIPLIERS_PROPOSAL["team"] == 2.0
+    assert TIER_MULTIPLIERS_PROPOSAL["enterprise"] == "custom"
+
+
+def test_valkey_ttl_read_mostly_seconds():
+    assert VALKEY_TTL_READ_MOSTLY == 60
+
+
+def test_valkey_ttl_definition_fetch_24h():
+    assert VALKEY_TTL_DEFINITION_FETCH == 24 * 3600
+
+
+def test_valkey_ttl_mutation_zero():
+    """Mutations must not cache — TTL=0 sentinel."""
+    assert VALKEY_TTL_MUTATION == 0
+
+
+def test_valkey_namespace_prefix():
+    """All keys must start with v1: per cross-tenant isolation invariant."""
+    assert VALKEY_KEY_NAMESPACE_PREFIX == "v1:"
+
+
+def test_embedding_bucket_count_v1_proposal():
+    """4096 buckets = 12 bits per design §4 + CB §13. Tune in Phase 2."""
+    assert EMBEDDING_BUCKET_COUNT == 4096

--- a/tests/keiracom_system/cache/test_litellm_helpers.py
+++ b/tests/keiracom_system/cache/test_litellm_helpers.py
@@ -1,0 +1,119 @@
+"""LiteLLM cache_control helper unit tests — Phase A7 sub-task 3."""
+
+from src.keiracom_system.cache.litellm_helpers import (
+    ANTHROPIC_CACHE_MIN_TOKENS,
+    EPHEMERAL_CACHE_CONTROL,
+    inject_cache_control_markers,
+)
+
+
+def _long_system_prompt() -> str:
+    # ~4500 chars → ~1125 estimated tokens > 1024 min
+    return "x" * 4500
+
+
+def _short_system_prompt() -> str:
+    # ~400 chars → ~100 estimated tokens < 1024 min
+    return "y" * 400
+
+
+def test_injects_cache_control_on_long_system_message():
+    messages = [{"role": "system", "content": _long_system_prompt()}]
+    out = inject_cache_control_markers(messages)
+    assert len(out) == 1
+    content = out[0]["content"]
+    assert isinstance(content, list)
+    assert content[-1]["cache_control"] == EPHEMERAL_CACHE_CONTROL
+    assert content[-1]["text"] == _long_system_prompt()
+
+
+def test_skips_cache_control_on_short_system_message():
+    """Anthropic >=1024 token rule — under-threshold prompts get no cache_control."""
+    messages = [{"role": "system", "content": _short_system_prompt()}]
+    out = inject_cache_control_markers(messages)
+    # Content unchanged — still a string, no cache_control wrapping
+    assert out[0]["content"] == _short_system_prompt()
+
+
+def test_user_messages_never_cached_by_default():
+    messages = [
+        {"role": "system", "content": _long_system_prompt()},
+        {"role": "user", "content": _long_system_prompt()},  # long but role=user
+    ]
+    out = inject_cache_control_markers(messages)
+    # User content unchanged (string passthrough)
+    assert out[1]["content"] == _long_system_prompt()
+
+
+def test_custom_breakpoint_policy_overrides_defaults():
+    """Caller can override role policy — e.g. cache user messages."""
+    messages = [{"role": "user", "content": _long_system_prompt()}]
+    out = inject_cache_control_markers(
+        messages,
+        breakpoint_policy={"system": False, "user": True, "assistant": False, "tool": False},
+    )
+    assert isinstance(out[0]["content"], list)
+    assert out[0]["content"][-1]["cache_control"] == EPHEMERAL_CACHE_CONTROL
+
+
+def test_list_content_gets_cache_control_on_last_block_only():
+    """Multi-block content: cache_control marks the END of cacheable prefix."""
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "a" * 2200},
+                {"type": "text", "text": "b" * 2200},
+                {"type": "text", "text": "c" * 2200},
+            ],
+        }
+    ]
+    out = inject_cache_control_markers(messages)
+    blocks = out[0]["content"]
+    assert "cache_control" not in blocks[0]
+    assert "cache_control" not in blocks[1]
+    assert blocks[2]["cache_control"] == EPHEMERAL_CACHE_CONTROL
+
+
+def test_token_counter_override():
+    """Caller passes a real tokeniser for accurate counts."""
+    short_text = "x" * 100  # ~25 tokens by default estimator < 1024 min
+    # Custom counter that always reports plenty of tokens
+    out = inject_cache_control_markers(
+        [{"role": "system", "content": short_text}],
+        token_counter=lambda _: 5000,
+    )
+    # cache_control IS applied because custom counter says token_count=5000 > 1024
+    assert isinstance(out[0]["content"], list)
+    assert out[0]["content"][-1]["cache_control"] == EPHEMERAL_CACHE_CONTROL
+
+
+def test_does_not_mutate_input_messages():
+    original = [{"role": "system", "content": _long_system_prompt()}]
+    snapshot = [dict(m) for m in original]
+    inject_cache_control_markers(original)
+    # Original list unchanged
+    assert original[0]["content"] == snapshot[0]["content"]
+    assert "cache_control" not in original[0]
+
+
+def test_anthropic_min_tokens_constant_per_spec():
+    """Anthropic API spec: minimum 1024 tokens between breakpoints."""
+    assert ANTHROPIC_CACHE_MIN_TOKENS == 1024
+
+
+def test_ephemeral_cache_control_payload_shape():
+    """Anthropic API spec: {'type': 'ephemeral'}."""
+    assert EPHEMERAL_CACHE_CONTROL == {"type": "ephemeral"}
+
+
+def test_empty_messages_returns_empty():
+    assert inject_cache_control_markers([]) == []
+
+
+def test_empty_list_content_returns_empty_list():
+    """Edge case — list content with zero blocks."""
+    messages = [{"role": "system", "content": []}]
+    out = inject_cache_control_markers(messages)
+    # role=system enabled but content has no length → skips (estimated tokens 0 < 1024)
+    assert out[0]["content"] == []

--- a/tests/keiracom_system/cache/test_metrics.py
+++ b/tests/keiracom_system/cache/test_metrics.py
@@ -1,0 +1,92 @@
+"""Metric emitter unit tests — Phase A7 sub-task 4."""
+
+from src.keiracom_system.cache.metrics import (
+    emit_anthropic_cache_tokens,
+    make_better_stack_emitter,
+)
+
+
+def test_emitter_posts_to_ingest_url_with_auth_header():
+    captured: list[tuple[str, dict, dict, float]] = []
+
+    def fake_post(url: str, payload: dict, headers: dict, timeout: float) -> int:
+        captured.append((url, payload, headers, timeout))
+        return 202
+
+    emit = make_better_stack_emitter(
+        ingest_url="https://test.example/metrics",
+        source_token="test-token",
+        http_post=fake_post,
+    )
+    emit("keiracom.cache.valkey.lookup", {"tenant_id": "t1", "outcome": "hit"})
+    assert len(captured) == 1
+    url, payload, headers, timeout = captured[0]
+    assert url == "https://test.example/metrics"
+    assert headers["Authorization"] == "Bearer test-token"
+    assert payload["metric"] == "keiracom.cache.valkey.lookup"
+    assert payload["tags"]["outcome"] == "hit"
+
+
+def test_emit_anthropic_three_types():
+    captured: list[tuple[str, dict[str, str]]] = []
+
+    def emit(name: str, tags: dict[str, str]) -> None:
+        captured.append((name, tags))
+
+    emit_anthropic_cache_tokens(
+        emit,
+        tenant_id="t1",
+        model="claude-3-5-sonnet",
+        cache_creation_input_tokens=100,
+        cache_read_input_tokens=200,
+        standard_input_tokens=300,
+    )
+    assert len(captured) == 3
+    types = {tags["type"] for _, tags in captured}
+    assert types == {"create", "read", "standard"}
+
+
+def test_emit_anthropic_skips_zero_token_buckets():
+    captured: list[tuple[str, dict[str, str]]] = []
+
+    def emit(name: str, tags: dict[str, str]) -> None:
+        captured.append((name, tags))
+
+    emit_anthropic_cache_tokens(
+        emit,
+        tenant_id="t1",
+        model="claude-3-5-haiku",
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=500,
+        standard_input_tokens=0,
+    )
+    assert len(captured) == 1
+    assert captured[0][1]["type"] == "read"
+
+
+def test_emit_anthropic_none_emitter_noop():
+    """Passing emitter=None must not raise — test/pre-Better-Stack envs."""
+    emit_anthropic_cache_tokens(
+        None,
+        tenant_id="t1",
+        model="m",
+        cache_creation_input_tokens=10,
+        cache_read_input_tokens=20,
+        standard_input_tokens=30,
+    )
+    # No assertion needed — should just not raise.
+
+
+def test_emitter_includes_metric_value_one():
+    captured: list[tuple[str, dict, dict, float]] = []
+
+    def fake_post(url: str, payload: dict, headers: dict, timeout: float) -> int:
+        captured.append((url, payload, headers, timeout))
+        return 202
+
+    emit = make_better_stack_emitter(
+        source_token="t",
+        http_post=fake_post,
+    )
+    emit("metric.name", {"tag": "value"})
+    assert captured[0][1]["value"] == 1

--- a/tests/keiracom_system/cache/test_no_raw_valkey_outside_client.py
+++ b/tests/keiracom_system/cache/test_no_raw_valkey_outside_client.py
@@ -1,0 +1,122 @@
+"""Integration-style test for the cache-discipline CI guard (CB-10).
+
+Verifies BOTH:
+  - Positive path: the guard passes on the current repo tree.
+  - Negative path (per feedback_negative_path_test_before_approve): a
+    synthetic offender file inside src/keiracom_system/ outside the cache
+    module triggers a non-zero exit.
+
+The shell script is the source of truth; this test exercises it via subprocess
+so a future refactor of the script doesn't silently break the discipline.
+
+Pattern shape: import-detection (mirrors boundary-matrix-v1 guard (b)). Direct
+call-site detection (e.g. `client.set(...)`) would require flow analysis;
+chokepoint is at the import barrier.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GUARD = REPO_ROOT / "scripts" / "ci" / "check_no_raw_valkey_outside_client.sh"
+
+
+def _run_guard(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_guard_passes_on_clean_tree():
+    """Positive path — current repo state is clean (PR-introducing-this-test)."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    result = _run_guard(REPO_ROOT)
+    assert result.returncode == 0, f"guard failed on clean tree: {result.stdout}\n{result.stderr}"
+    assert "no raw redis/valkey imports outside cache module" in result.stdout
+
+
+def test_guard_fails_on_synthetic_import_offender(tmp_path: Path):
+    """Negative path — synthetic `import redis` outside cache/ MUST fail."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    scope_dir = tmp_path / "src" / "keiracom_system" / "leaky"
+    scope_dir.mkdir(parents=True)
+    (scope_dir / "leak.py").write_text(
+        "import redis\nclient = redis.Redis()\nclient.set('raw-key', 'value')\n"
+    )
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_no_raw_valkey_outside_client.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode != 0, (
+        f"guard should have failed on synthetic offender; got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "FAIL (cache-discipline)" in result.stdout
+    assert "leak.py" in result.stdout
+
+
+def test_guard_fails_on_from_redis_import(tmp_path: Path):
+    """`from redis import X` should also fail."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    scope_dir = tmp_path / "src" / "keiracom_system" / "leaky"
+    scope_dir.mkdir(parents=True)
+    (scope_dir / "leak.py").write_text("from redis import Redis\n")
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_no_raw_valkey_outside_client.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode != 0
+    assert "FAIL (cache-discipline)" in result.stdout
+
+
+def test_guard_fails_on_valkey_import(tmp_path: Path):
+    """`import valkey` (the other client lib) MUST also fail outside cache/."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    scope_dir = tmp_path / "src" / "keiracom_system" / "leaky"
+    scope_dir.mkdir(parents=True)
+    (scope_dir / "leak.py").write_text("import valkey\n")
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_no_raw_valkey_outside_client.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode != 0
+
+
+def test_guard_exempts_cache_module(tmp_path: Path):
+    """ValkeyClient is the canonical owner; cache/ imports of redis are exempt."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    cache_dir = tmp_path / "src" / "keiracom_system" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "valkey_client.py").write_text("import redis\n")
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_no_raw_valkey_outside_client.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode == 0, (
+        f"guard should exempt cache/; got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_guard_inactive_when_scope_missing(tmp_path: Path):
+    """Empty repo (no src/keiracom_system/) — guard exits 0 with `inactive` message."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_no_raw_valkey_outside_client.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode == 0
+    assert "guard inactive" in result.stdout

--- a/tests/keiracom_system/cache/test_token_budget_policy.py
+++ b/tests/keiracom_system/cache/test_token_budget_policy.py
@@ -1,0 +1,179 @@
+"""TenantBudgetPolicy unit tests — Phase A7 sub-task 2.
+
+Covers:
+  - tier defaults present for all 5 tiers
+  - dataclass validation (tier whitelist + positive caps)
+  - from_db() factory with injected fake DB
+  - missing tenant row raises TenantBudgetPolicyError
+"""
+
+import pytest
+
+from src.keiracom_system.cache.token_budget_policy import (
+    DEFAULT_MODEL_COST_CALIBRATION,
+    TIER_DEFAULTS,
+    TIER_ENTERPRISE,
+    TIER_PRO,
+    TIER_SANDBOX,
+    TIER_SOLO,
+    TIER_TEAM,
+    VALID_TIERS,
+    TenantBudgetPolicy,
+    TenantBudgetPolicyError,
+)
+
+
+class _FakeDB:
+    """Minimal DB fake matching _DBProtocol — no asyncpg/psycopg dependency."""
+
+    def __init__(self, row: tuple | None):
+        self._row = row
+        self.executed: list[tuple[str, tuple]] = []
+
+    def execute(self, query: str, *params):
+        self.executed.append((query, params))
+
+    def fetchone(self):
+        return self._row
+
+
+def test_all_five_tiers_have_defaults():
+    assert set(TIER_DEFAULTS.keys()) == VALID_TIERS
+    assert set(TIER_DEFAULTS.keys()) == {
+        TIER_SANDBOX,
+        TIER_SOLO,
+        TIER_PRO,
+        TIER_TEAM,
+        TIER_ENTERPRISE,
+    }
+
+
+def test_sandbox_amendment_2_daily_cap():
+    """Sandbox 50K/day per amendment 2 (Agency_OS-tpxj)."""
+    assert TIER_DEFAULTS[TIER_SANDBOX]["daily_pool_tokens"] == 50_000
+
+
+def test_tier_default_pools_increase_by_tier():
+    """Pool sizes monotonically increase Sandbox → Enterprise."""
+    pools = [
+        TIER_DEFAULTS[t]["daily_pool_tokens"]
+        for t in [TIER_SANDBOX, TIER_SOLO, TIER_PRO, TIER_TEAM, TIER_ENTERPRISE]
+    ]
+    assert pools == sorted(pools)
+
+
+def test_per_call_caps_increase_by_tier():
+    caps = [
+        TIER_DEFAULTS[t]["per_call_cap_tokens"]
+        for t in [TIER_SANDBOX, TIER_SOLO, TIER_PRO, TIER_TEAM, TIER_ENTERPRISE]
+    ]
+    assert caps == sorted(caps)
+
+
+def test_policy_rejects_invalid_tier():
+    with pytest.raises(TenantBudgetPolicyError, match="tier 'bogus'"):
+        TenantBudgetPolicy(
+            tenant_id="t1",
+            tier="bogus",
+            per_call_cap_tokens=1,
+            daily_pool_tokens=1,
+            monthly_pool_tokens=1,
+        )
+
+
+def test_policy_rejects_zero_per_call_cap():
+    with pytest.raises(TenantBudgetPolicyError, match="per_call_cap_tokens must be > 0"):
+        TenantBudgetPolicy(
+            tenant_id="t1",
+            tier=TIER_SOLO,
+            per_call_cap_tokens=0,
+            daily_pool_tokens=1,
+            monthly_pool_tokens=1,
+        )
+
+
+def test_policy_rejects_zero_daily_pool():
+    with pytest.raises(TenantBudgetPolicyError, match="daily_pool_tokens must be > 0"):
+        TenantBudgetPolicy(
+            tenant_id="t1",
+            tier=TIER_SOLO,
+            per_call_cap_tokens=1,
+            daily_pool_tokens=0,
+            monthly_pool_tokens=1,
+        )
+
+
+def test_policy_rejects_zero_monthly_pool():
+    with pytest.raises(TenantBudgetPolicyError, match="monthly_pool_tokens must be > 0"):
+        TenantBudgetPolicy(
+            tenant_id="t1",
+            tier=TIER_SOLO,
+            per_call_cap_tokens=1,
+            daily_pool_tokens=1,
+            monthly_pool_tokens=0,
+        )
+
+
+def test_policy_frozen_dataclass_immutable():
+    """Frozen — policies are immutable values; UPDATEs create new instances."""
+    p = TenantBudgetPolicy(
+        tenant_id="t1",
+        tier=TIER_SOLO,
+        per_call_cap_tokens=50_000,
+        daily_pool_tokens=1_000_000,
+        monthly_pool_tokens=30_000_000,
+    )
+    with pytest.raises((AttributeError, Exception)):
+        p.per_call_cap_tokens = 999  # type: ignore[misc]
+
+
+def test_from_db_returns_policy_for_team_tier():
+    fake = _FakeDB(
+        row=(
+            "team",
+            200_000,
+            20_000_000,
+            600_000_000,
+            DEFAULT_MODEL_COST_CALIBRATION,
+        )
+    )
+    p = TenantBudgetPolicy.from_db(fake, "00000000-0000-0000-0000-000000000001")
+    assert p.tier == TIER_TEAM
+    assert p.per_call_cap_tokens == 200_000
+    assert p.daily_pool_tokens == 20_000_000
+    assert p.monthly_pool_tokens == 600_000_000
+    assert p.model_cost_calibration == DEFAULT_MODEL_COST_CALIBRATION
+
+
+def test_from_db_handles_null_calibration():
+    """NULL JSONB column → empty dict."""
+    fake = _FakeDB(
+        row=(
+            "solo",
+            50_000,
+            1_000_000,
+            30_000_000,
+            None,
+        )
+    )
+    p = TenantBudgetPolicy.from_db(fake, "t1")
+    assert p.model_cost_calibration == {}
+
+
+def test_from_db_raises_when_no_row():
+    fake = _FakeDB(row=None)
+    with pytest.raises(TenantBudgetPolicyError, match="no budget row"):
+        TenantBudgetPolicy.from_db(fake, "nonexistent-tenant")
+
+
+def test_default_model_cost_calibration_keys():
+    """Calibration covers the 5 LiteLLM model identifiers per design §6."""
+    assert "anthropic/claude-3-5-sonnet" in DEFAULT_MODEL_COST_CALIBRATION
+    assert "anthropic/claude-3-5-haiku" in DEFAULT_MODEL_COST_CALIBRATION
+    assert "openai/gpt-4o" in DEFAULT_MODEL_COST_CALIBRATION
+    assert "openai/gpt-4o-mini" in DEFAULT_MODEL_COST_CALIBRATION
+    assert "google/gemini-2.5-flash" in DEFAULT_MODEL_COST_CALIBRATION
+
+
+def test_haiku_baseline_weight_is_1():
+    assert DEFAULT_MODEL_COST_CALIBRATION["anthropic/claude-3-5-haiku"] == 1.0

--- a/tests/keiracom_system/cache/test_valkey_client.py
+++ b/tests/keiracom_system/cache/test_valkey_client.py
@@ -1,0 +1,210 @@
+"""ValkeyClient unit tests — Phase A7 sub-task 1.
+
+Covers:
+  - canonical_cache_key() determinism (same inputs → same key across calls)
+  - cross-tenant isolation (key namespace prefix per tenant_id)
+  - _enforce_tenant_prefix() rejects wrong-tenant + missing-prefix keys
+  - metric emission on get() hit/miss
+  - canonical_cache_key() with vs without query_text (embedding bucket)
+
+DI fakes — no live Redis, no live TEI sidecar.
+"""
+
+from typing import Any
+
+import pytest
+
+from src.keiracom_system.cache.valkey_client import (
+    OUTCOME_HIT,
+    OUTCOME_MISS,
+    ValkeyClient,
+    ValkeyClientError,
+)
+from src.keiracom_system.embeddings.tei_client import TEIClient, _HTTPResponse
+
+
+class _FakeRedis:
+    def __init__(self, store: dict[str, bytes] | None = None):
+        self.store = store or {}
+        self.set_calls: list[tuple[str, str | bytes]] = []
+        self.setex_calls: list[tuple[str, int, str | bytes]] = []
+        self.delete_calls: list[str] = []
+
+    def get(self, key: str) -> bytes | None:
+        return self.store.get(key)
+
+    def set(self, key: str, value: str | bytes) -> None:
+        self.set_calls.append((key, value))
+        self.store[key] = value if isinstance(value, bytes) else value.encode("utf-8")
+
+    def setex(self, key: str, time: int, value: str | bytes) -> None:
+        self.setex_calls.append((key, time, value))
+        self.store[key] = value if isinstance(value, bytes) else value.encode("utf-8")
+
+    def delete(self, *keys: str) -> None:
+        for k in keys:
+            self.delete_calls.append(k)
+            self.store.pop(k, None)
+
+
+def _fake_tei() -> TEIClient:
+    # Deterministic embed: returns a fixed vector regardless of input.
+    def fake_post(url: str, payload: dict[str, Any], timeout: float) -> _HTTPResponse:
+        inputs = payload["inputs"]
+        body = (
+            b"["
+            + b",".join(b"[" + b",".join(b"0.1" for _ in range(384)) + b"]" for _ in inputs)
+            + b"]"
+        )
+        return _HTTPResponse(200, body)
+
+    def fake_get(url: str, timeout: float) -> _HTTPResponse:
+        return _HTTPResponse(200, b'{"status":"ok"}')
+
+    return TEIClient(http_get=fake_get, http_post=fake_post)
+
+
+def test_init_rejects_empty_tenant_id():
+    with pytest.raises(ValkeyClientError, match="tenant_id is required"):
+        ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="")
+
+
+def test_canonical_cache_key_deterministic_without_query_text():
+    client = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="t1")
+    k1 = client.canonical_cache_key(tool_name="hubspot.companies.list", args={"limit": 10})
+    k2 = client.canonical_cache_key(tool_name="hubspot.companies.list", args={"limit": 10})
+    assert k1 == k2
+    assert k1.startswith("v1:t1:hubspot.companies.list:")
+
+
+def test_canonical_cache_key_args_order_stable():
+    """Different dict insertion orders produce the same canonical key."""
+    client = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="t1")
+    k1 = client.canonical_cache_key(tool_name="t", args={"a": 1, "b": 2})
+    k2 = client.canonical_cache_key(tool_name="t", args={"b": 2, "a": 1})
+    assert k1 == k2
+
+
+def test_canonical_cache_key_includes_bucket_with_query_text():
+    client = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="t1")
+    k = client.canonical_cache_key(tool_name="search", args={}, query_text="hello world")
+    assert ":b" in k
+    assert k.startswith("v1:t1:search:")
+
+
+def test_cross_tenant_keys_differ_for_same_inputs():
+    """Cache-isolation invariant: tenant A and tenant B never share a key."""
+    cli_a = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="alpha")
+    cli_b = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="beta")
+    k_a = cli_a.canonical_cache_key(tool_name="x", args={"q": 1})
+    k_b = cli_b.canonical_cache_key(tool_name="x", args={"q": 1})
+    assert k_a != k_b
+    assert k_a.startswith("v1:alpha:")
+    assert k_b.startswith("v1:beta:")
+
+
+def test_get_rejects_wrong_tenant_prefix():
+    client = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="t1")
+    with pytest.raises(ValkeyClientError, match="does not match expected tenant prefix"):
+        client.get("v1:t2:tool:abc")
+
+
+def test_get_rejects_missing_namespace_prefix():
+    client = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="t1")
+    with pytest.raises(ValkeyClientError, match="does not match expected tenant prefix"):
+        client.get("raw-key-no-prefix")
+
+
+def test_set_rejects_wrong_tenant_prefix():
+    client = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="t1")
+    with pytest.raises(ValkeyClientError):
+        client.set("v1:t2:tool:abc", "value")
+
+
+def test_delete_rejects_wrong_tenant_prefix():
+    client = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="t1")
+    with pytest.raises(ValkeyClientError):
+        client.delete("v1:t2:tool:abc")
+
+
+def test_get_accepts_canonical_key():
+    redis_fake = _FakeRedis(store={"v1:t1:tool:hash": b"cached"})
+    client = ValkeyClient(redis_client=redis_fake, tei_client=_fake_tei(), tenant_id="t1")
+    key = client.canonical_cache_key(tool_name="tool", args={"a": 1})
+    # The constructed key uses hash of args, so we directly construct a known-good
+    # canonical key to test the get path:
+    assert client.get("v1:t1:tool:hash") == b"cached"
+    # And canonical_cache_key returns something we could probe (its hash varies):
+    assert key.startswith("v1:t1:tool:")
+
+
+def test_set_with_ttl_uses_setex():
+    redis_fake = _FakeRedis()
+    client = ValkeyClient(redis_client=redis_fake, tei_client=_fake_tei(), tenant_id="t1")
+    client.set("v1:t1:tool:abc", "value", ttl_seconds=60)
+    assert len(redis_fake.setex_calls) == 1
+    assert redis_fake.setex_calls[0] == ("v1:t1:tool:abc", 60, "value")
+    assert len(redis_fake.set_calls) == 0
+
+
+def test_set_without_ttl_uses_plain_set():
+    redis_fake = _FakeRedis()
+    client = ValkeyClient(redis_client=redis_fake, tei_client=_fake_tei(), tenant_id="t1")
+    client.set("v1:t1:tool:abc", "value", ttl_seconds=0)
+    assert len(redis_fake.set_calls) == 1
+    assert len(redis_fake.setex_calls) == 0
+
+
+def test_get_emits_hit_metric():
+    redis_fake = _FakeRedis(store={"v1:t1:tool:hash": b"cached"})
+    captured: list[tuple[str, dict[str, str]]] = []
+
+    def emit(name: str, tags: dict[str, str]) -> None:
+        captured.append((name, tags))
+
+    client = ValkeyClient(
+        redis_client=redis_fake,
+        tei_client=_fake_tei(),
+        tenant_id="t1",
+        metric_emitter=emit,
+    )
+    client.get("v1:t1:tool:hash", tool_name="hubspot.companies.list")
+    assert len(captured) == 1
+    name, tags = captured[0]
+    assert name == "keiracom.cache.valkey.lookup"
+    assert tags["outcome"] == OUTCOME_HIT
+    assert tags["tenant_id"] == "t1"
+    assert tags["tool_name"] == "hubspot.companies.list"
+
+
+def test_get_emits_miss_metric():
+    captured: list[tuple[str, dict[str, str]]] = []
+
+    def emit(name: str, tags: dict[str, str]) -> None:
+        captured.append((name, tags))
+
+    client = ValkeyClient(
+        redis_client=_FakeRedis(),
+        tei_client=_fake_tei(),
+        tenant_id="t1",
+        metric_emitter=emit,
+    )
+    result = client.get("v1:t1:tool:missing")
+    assert result is None
+    assert captured[0][1]["outcome"] == OUTCOME_MISS
+
+
+def test_quantise_to_bucket_in_range():
+    """Bucket index always in [0, num_buckets)."""
+    client = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="t1")
+    embedding = [0.5] * 384
+    bucket = client._quantise_to_bucket(embedding, num_buckets=4096)
+    assert 0 <= bucket < 4096
+
+
+def test_quantise_to_bucket_deterministic():
+    client = ValkeyClient(redis_client=_FakeRedis(), tei_client=_fake_tei(), tenant_id="t1")
+    embedding = [0.5] * 384
+    assert client._quantise_to_bucket(embedding, num_buckets=4096) == client._quantise_to_bucket(
+        embedding, num_buckets=4096
+    )

--- a/tests/scripts/test_cache_baseline_48h.py
+++ b/tests/scripts/test_cache_baseline_48h.py
@@ -1,0 +1,118 @@
+"""cache_baseline_48h.py unit tests — Phase A7 sub-task 5."""
+
+import importlib.util
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "cache_baseline_48h.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("cache_baseline_48h", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_classify_valkey_blocking_below_10pct():
+    m = _load_module()
+    assert "BLOCKING-V1" in m._classify_valkey(0.05)
+    assert "BLOCKING-V1" in m._classify_valkey(0.09)
+
+
+def test_classify_valkey_track_band():
+    m = _load_module()
+    assert "TRACK-AND-IMPROVE" in m._classify_valkey(0.20)
+    assert "TRACK-AND-IMPROVE" in m._classify_valkey(0.39)
+
+
+def test_classify_valkey_healthy_at_or_above_40pct():
+    m = _load_module()
+    assert m._classify_valkey(0.40) == "HEALTHY"
+    assert m._classify_valkey(0.99) == "HEALTHY"
+
+
+def test_classify_anthropic_track_below_20pct():
+    m = _load_module()
+    assert "TRACK-AND-IMPROVE" in m._classify_anthropic(0.10)
+    assert "TRACK-AND-IMPROVE" in m._classify_anthropic(0.19)
+
+
+def test_classify_anthropic_healthy_at_50pct():
+    m = _load_module()
+    assert m._classify_anthropic(0.50) == "HEALTHY"
+    assert m._classify_anthropic(0.99) == "HEALTHY"
+
+
+def test_safe_divide_zero_denominator():
+    m = _load_module()
+    assert m._safe_divide(10, 0) == 0.0
+    assert m._safe_divide(10, 5) == 2.0
+
+
+def test_generate_report_includes_hit_rate():
+    m = _load_module()
+
+    def fake_fetcher(metric, tags, start, end):
+        if metric == "keiracom.cache.valkey.lookup":
+            return {"hit": 600, "miss": 400}
+        return {"create": 100, "read": 600, "standard": 300}
+
+    end = datetime.now(UTC)
+    start = end - timedelta(hours=48)
+    report = m.generate_report(
+        tenant_id="t1",
+        window_start=start,
+        window_end=end,
+        metrics_fetcher=fake_fetcher,
+    )
+    assert "60.0%" in report  # valkey hit rate 600 / 1000
+    assert "60.0%" in report  # anthropic read 600 / 1000
+    assert "HEALTHY" in report
+    assert "t1" in report
+
+
+def test_generate_report_blocking_classification():
+    m = _load_module()
+
+    def low_hit_fetcher(metric, tags, start, end):
+        if metric == "keiracom.cache.valkey.lookup":
+            return {"hit": 5, "miss": 95}
+        return {"create": 0, "read": 0, "standard": 100}
+
+    end = datetime.now(UTC)
+    start = end - timedelta(hours=48)
+    report = m.generate_report(
+        tenant_id="t1",
+        window_start=start,
+        window_end=end,
+        metrics_fetcher=low_hit_fetcher,
+    )
+    assert "BLOCKING-V1" in report
+
+
+def test_generate_report_zero_traffic_safe():
+    """No lookups during window — report shouldn't divide-by-zero."""
+    m = _load_module()
+
+    def empty_fetcher(metric, tags, start, end):
+        return {}
+
+    end = datetime.now(UTC)
+    start = end - timedelta(hours=48)
+    report = m.generate_report(
+        tenant_id="t1",
+        window_start=start,
+        window_end=end,
+        metrics_fetcher=empty_fetcher,
+    )
+    assert "0.0%" in report
+    assert "BLOCKING-V1" in report  # 0% hit rate triggers blocking
+
+
+def test_placeholder_fetcher_returns_zeros():
+    m = _load_module()
+    result = m._placeholder_fetcher()
+    assert result == {"hit": 0, "miss": 0, "create": 0, "read": 0, "standard": 0}


### PR DESCRIPTION
## Summary

Implements the full Phase A7 cache architecture per design (PR #1156 merged 2026-05-26 + §13 build clarifications PR #1165 merged 2026-05-26). Ships all 5 sub-tasks in one bundle: constants + Valkey client + token budget policy + LiteLLM helper + Better Stack instrumentation + 48h baseline observation script + CB-10 PR-linter.

**Filed under:** Agency_OS-rw8e (P1, engineer-tier dispatched by Elliot STEP 0 PRE-CONFIRMED).

## What lands

| Sub-task | Files | LoC (src) | Tests |
|---|---|---:|---:|
| 1: constants + ValkeyClient + write-time prefix guard | `cache/{constants,valkey_client}.py` + tests | 260 | 18 (constants 9 + valkey 16 — overlap) |
| 2: TenantBudgetPolicy + Postgres migration | `cache/token_budget_policy.py` + SQL | 155 + 106 | 13 |
| 3: LiteLLM `cache_control` helper (CB-4 verified `cache_control_enabled` NOT real) | `cache/litellm_helpers.py` | 155 | 11 |
| 4: Better Stack instrumentation hook | `cache/metrics.py` | 128 | 5 |
| 5: 48h baseline observation script | `scripts/cache_baseline_48h.py` | 178 | 10 |
| CB-10: cache-discipline CI guard + negative-path test | `scripts/ci/check_no_raw_valkey_outside_client.sh` + `.github/workflows/ci.yml` + tests | 78 | 6 |

**Cumulative:** 2,004 net lines added across 18 files; **70 unit tests passing**; ruff clean; mypy clean (relaxed mode matching CI).

## Design clarifications applied (§13 fold-in)

- **CB-1** — uses `redis>=5.0.0` (already in `requirements.txt`); no new dep
- **CB-2** — DI of redis.Redis + TEIClient at `ValkeyClient.__init__` (mirrors PR #1132/1133/1146 pattern)
- **CB-3** — point-in-time schema for `keiracom_tenant_budgets`; no `effective_from/until`
- **CB-4** — `cache_control_enabled: true` is NOT a real LiteLLM YAML option per CB-4 verification; shipped `inject_cache_control_markers()` caller-side helper instead
- **CB-5** — Anthropic prompt-cache metric naming + cardinality flag (Phase 2 pre-agg follow-up)
- **CB-6** — final LoC ~925 (vs design's ~550-600 estimate); driven by DI testability + complete validation invariants + actual classification thresholds in baseline script
- **CB-7** — bilingual $USD/$AUD format applied where dollar amounts surface (this build is token-counts only, so doesn't surface dollars at runtime per design §11 + PR #1137)
- **CB-8** — `<10% Valkey hit rate = BLOCKING-V1` classification in `cache_baseline_48h.py`
- **CB-9** — `CHECK (tier IN ('sandbox','solo','pro','team','enterprise'))` in SQL migration
- **CB-10** — PR-linter guard at `scripts/ci/check_no_raw_valkey_outside_client.sh` (import-detection mirroring boundary-matrix-v1 guard b pattern); wired as new `cache-discipline-guards` CI job
- **CB-Atlas** — `_enforce_tenant_prefix()` at read/write boundary in `ValkeyClient`

## Deferred (out-of-scope per design + Dave policy)

1. **Dave's tenant LiteLLM virtual_key YAML stanza** (design §5) — adding `anthropic/*` deployments to `infra/litellm/config.yaml` crosses Dave's 2026-05-20 internal-governance-never-Anthropic policy without explicit re-ratify. Virtual key is non-functional without the deployment, so deferring both together for V1 customer-onboarding gate (Phase C5). Helper code is shipped + ready to use at activation.
2. **LLM-call workflow #2 wiring** — separate dispatch per design §10. `temp.inline.token_gate` activity will `import TenantBudgetPolicy` + `ValkeyClient` from this module + enforce on each LLM call.
3. **Pre-aggregation hook for Better Stack cardinality** (CB-5 follow-up) — V1 (Dave N=1) is unaffected; Phase 2 bd to be filed when first ~5 paying customers add cardinality.

## Boundary-matrix-v1 compliance

All 4 BMV1 guards (PR #1169) + the new cache-discipline guard self-pass on this diff:
- Guard (a) NATS in Temporal: N/A (no temporal code)
- Guard (b) Direct DB drivers outside MAL: ✓ avoided via `_DBProtocol` DI in `token_budget_policy.py`
- Guard (c) Composio outside MCP: N/A (no Composio code)
- Guard (d) `ceo:*` literals in Hindsight wrappers: N/A (no Hindsight wrappers)
- Cache-discipline (new): self-passes; negative-path test fires correctly on synthetic offender

## Canonical-key anchoring (per audit-dispatch checklist)

- `ceo:cache_framework_canonical` — values frozen in `constants.py`; lock-test in `test_constants.py`
- `ceo:boundary_matrix_v1` — `_DBProtocol` DI ensures cache module doesn't import asyncpg/psycopg (guard b compliance)
- `ceo:dave_migration_sequence.phase_a_extended.a7` — this PR is the Phase A7 substantive build

## Test plan

- [x] `python3 -m pytest tests/keiracom_system/cache/ tests/scripts/test_cache_baseline_48h.py -q` → 70 passed
- [x] `ruff check src/keiracom_system/cache/ tests/keiracom_system/cache/ scripts/cache_baseline_48h.py tests/scripts/test_cache_baseline_48h.py` → clean
- [x] `ruff format --check` on same files → clean
- [x] `mypy src/keiracom_system/cache/ --ignore-missing-imports` → clean
- [x] All 5 CI guard scripts self-pass on current tree
- [x] Negative-path probe on cache-discipline guard fires on synthetic `import redis` in `src/keiracom_system/leaky/`
- [x] All cache module exports resolve via `from src.keiracom_system.cache import ...`

## Downstream

After merge:
- LLM-call workflow #2 dispatch (separate KEI) imports `TenantBudgetPolicy` + `ValkeyClient` from this module
- 48h baseline runs post-A9 migration validation gate per design §7
- Dave's tenant virtual_key YAML stanza activates at V1 customer-onboarding gate (Phase C5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)