### PR TITLE
[SCOUT] feat(migration): A3 step 5-A — Global_governance_patterns hand-migration (Agency_OS-x0p7)

### DIFF
--- a/scripts/migrations/global_governance_patterns_hand_migration.py
+++ b/scripts/migrations/global_governance_patterns_hand_migration.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""global_governance_patterns_hand_migration.py — one-time hand-migration of
+Weaviate Global_governance_patterns → Hindsight bank fleet_global_governance_patterns
+(V2.0 mem.weaviate_coldstart step 5-A precondition for the LlamaIndex
+retirement reader cutover).
+
+Context
+-------
+V2.0 lock on `mem.weaviate_coldstart` names three hand-migration classes:
+Sessions, Global_governance_patterns, Discoveries. The indexer dual-write
+mirror (PR #1147) catches *new* writes for the classes in
+`indexer_base.CLASS_TO_BANK` but pre-existing data + the three named
+hand-migration classes need a one-time backfill. PR #1141 was the audit;
+this script is the actual data load for Global_governance_patterns.
+
+Trio status (2026-05-26):
+  - Discoveries → fleet_discoveries — landed in PR #1172 (Agency_OS-4bsc).
+  - Sessions → fleet_sessions — parallel sibling (Agency_OS-9u2m, Orion).
+  - Global_governance_patterns → fleet_global_governance_patterns — THIS PR.
+
+Sequence with the companion `indexer_base.CLASS_TO_BANK` edit landing in
+the same PR:
+
+1. PR merges → `Global_governance_patterns → fleet_global_governance_patterns`
+   mapping goes live; all *new* Global_governance_patterns writes start
+   dual-writing to Hindsight automatically.
+2. Operator runs this script with `--execute` → existing Weaviate
+   Global_governance_patterns objects are backfilled to Hindsight.
+3. Verify pre/post counts match (script prints both).
+4. A3-c2 step 5-B reader cutover (Agency_OS-0zv1) is unblocked when all
+   three trio members have landed.
+
+Idempotency
+-----------
+A state file (`runtime/global_governance_patterns_migration_state.jsonl`)
+records each migrated external_id. Re-runs skip already-migrated IDs. Safe
+to abort and resume.
+
+Safety
+------
+Default is dry-run (counts only, no writes). `--execute` is operator-gated.
+Failures log + continue; exit non-zero if any migration POST failed so the
+operator gets a clear signal.
+
+bd: Agency_OS-x0p7
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+logger = logging.getLogger("global_governance_patterns_hand_migration")
+
+WEAVIATE_HOST = os.environ.get("WEAVIATE_HOST", "127.0.0.1")
+WEAVIATE_PORT = os.environ.get("WEAVIATE_PORT", "8090")
+WEAVIATE_BASE = f"http://{WEAVIATE_HOST}:{WEAVIATE_PORT}"  # NOSONAR S5332 loopback
+HINDSIGHT_BASE = os.environ.get("HINDSIGHT_BASE", "http://localhost:8889")  # NOSONAR S5332 loopback
+
+WEAVIATE_CLASS = "Global_governance_patterns"
+HINDSIGHT_BANK = "fleet_global_governance_patterns"
+
+REQUEST_TIMEOUT = 30.0
+PAGE_SIZE = 100
+JSON_CONTENT_TYPE = "application/json"
+
+DEFAULT_STATE_FILE = Path("runtime/global_governance_patterns_migration_state.jsonl")
+
+
+def _http_get(base: str, path: str) -> dict:
+    req = urlrequest.Request(f"{base}{path}", method="GET", headers={"Accept": JSON_CONTENT_TYPE})
+    with urlrequest.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _http_post(base: str, path: str, body: dict) -> tuple[int, dict]:
+    data = json.dumps(body).encode("utf-8")
+    req = urlrequest.Request(
+        f"{base}{path}",
+        data=data,
+        method="POST",
+        headers={"Content-Type": JSON_CONTENT_TYPE, "Accept": JSON_CONTENT_TYPE},
+    )
+    try:
+        with urlrequest.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            raw = resp.read().decode("utf-8")
+            return resp.status, (json.loads(raw) if raw else {})
+    except urlerror.HTTPError as exc:
+        return exc.code, {"error": exc.read().decode("utf-8", errors="replace")[:500]}
+
+
+def weaviate_count(class_name: str) -> int | None:
+    """Return GraphQL Aggregate count for the class, or None on error."""
+    query = {"query": f"{{Aggregate{{{class_name}{{meta{{count}}}}}}}}"}
+    try:
+        _, body = _http_post(WEAVIATE_BASE, "/v1/graphql", query)
+        return body["data"]["Aggregate"][class_name][0]["meta"]["count"]
+    except (KeyError, IndexError, TypeError, urlerror.URLError):
+        logger.exception("weaviate_count failed for %s", class_name)
+        return None
+
+
+def iter_weaviate_objects(class_name: str, page_size: int = PAGE_SIZE):
+    """Paginate /v1/objects?class=<name> via cursor (after=<id>)."""
+    after = ""
+    while True:
+        qs = f"class={class_name}&limit={page_size}"
+        if after:
+            qs += f"&after={after}"
+        try:
+            page = _http_get(WEAVIATE_BASE, f"/v1/objects?{qs}")
+        except urlerror.URLError:
+            logger.exception("weaviate page fetch failed at after=%s", after)
+            return
+        objects = page.get("objects") or []
+        if not objects:
+            return
+        yield from objects
+        after = objects[-1].get("id", "")
+        if len(objects) < page_size:
+            return
+
+
+def build_hindsight_item(weaviate_obj: dict) -> dict:
+    """Map a Weaviate Global_governance_patterns object to a Hindsight memory item.
+
+    Mirrors `indexer_base._post_object_hindsight_mirror` shape so backfilled
+    items are indistinguishable from live-mirrored items downstream.
+    """
+    props = weaviate_obj.get("properties") or {}
+    content = props.get("raw_text") or props.get("content") or json.dumps(props)[:8000]
+    metadata = {k: str(v) for k, v in props.items() if k != "raw_text" and v is not None}
+    metadata["mirror_source"] = "global_governance_patterns_hand_migration"
+    metadata["weaviate_class"] = WEAVIATE_CLASS
+    metadata["external_id"] = weaviate_obj.get("id", "")
+    return {
+        "content": content,
+        "tags": [f"weaviate_class:{WEAVIATE_CLASS}"],
+        "metadata": metadata,
+    }
+
+
+def load_state(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    seen: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+            if row.get("ok") and row.get("external_id"):
+                seen.add(row["external_id"])
+        except json.JSONDecodeError:
+            continue
+    return seen
+
+
+def append_state(path: Path, row: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+
+def migrate_one(weaviate_obj: dict) -> tuple[bool, str]:
+    """POST one mapped item to Hindsight. Return (ok, info)."""
+    item = build_hindsight_item(weaviate_obj)
+    body = {"items": [item], "async": False}
+    status, resp = _http_post(HINDSIGHT_BASE, f"/v1/default/banks/{HINDSIGHT_BANK}/memories", body)
+    if 200 <= status < 300:
+        return True, str(resp)[:120]
+    return False, f"rc={status} resp={str(resp)[:200]}"
+
+
+def run(*, execute: bool, state_path: Path) -> int:
+    pre = weaviate_count(WEAVIATE_CLASS)
+    logger.info("pre-migration weaviate count: %s", pre)
+    if pre is None:
+        logger.error("weaviate Aggregate count unavailable — refusing to run")
+        return 2
+    seen = load_state(state_path)
+    logger.info("state-file already-migrated: %d", len(seen))
+    n_total = n_ok = n_fail = n_skip = 0
+    t0 = time.time()
+    for obj in iter_weaviate_objects(WEAVIATE_CLASS):
+        n_total += 1
+        ext_id = obj.get("id", "")
+        if ext_id in seen:
+            n_skip += 1
+            continue
+        if not execute:
+            logger.info("dry-run: would migrate %s", ext_id)
+            continue
+        ok, info = migrate_one(obj)
+        if ok:
+            n_ok += 1
+            append_state(state_path, {"external_id": ext_id, "ok": True, "info": info})
+        else:
+            n_fail += 1
+            append_state(state_path, {"external_id": ext_id, "ok": False, "info": info})
+            logger.warning("migrate %s FAILED: %s", ext_id, info)
+    elapsed = time.time() - t0
+    logger.info(
+        "summary: total=%d ok=%d fail=%d skip=%d elapsed=%.1fs (execute=%s)",
+        n_total,
+        n_ok,
+        n_fail,
+        n_skip,
+        elapsed,
+        execute,
+    )
+    return 0 if n_fail == 0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--execute", action="store_true", help="write to Hindsight (default: dry-run)")
+    p.add_argument("--state-file", type=Path, default=DEFAULT_STATE_FILE)
+    p.add_argument("--log-level", default="INFO")
+    args = p.parse_args(argv)
+    logging.basicConfig(level=args.log_level, format="%(asctime)s %(levelname)s %(message)s")
+    return run(execute=args.execute, state_path=args.state_file)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/indexer_base.py
+++ b/scripts/orchestrator/indexer_base.py
@@ -187,6 +187,12 @@ CLASS_TO_BANK = {
     # Sibling classes Sessions + Global_governance_patterns are filed as
     # Agency_OS-9u2m + Agency_OS-x0p7 (parallel hand-migration PRs).
     "Discoveries": "fleet_discoveries",
+    # A3 step 5-A (Agency_OS-x0p7, 2026-05-26): Global_governance_patterns is
+    # the third trio member per mem.weaviate_coldstart. Backfill of existing
+    # rows runs once via scripts/migrations/
+    # global_governance_patterns_hand_migration.py; this mapping then catches
+    # all new writes. Sibling Sessions is filed as Agency_OS-9u2m (parallel).
+    "Global_governance_patterns": "fleet_global_governance_patterns",
 }
 
 

--- a/tests/scripts/migrations/test_global_governance_patterns_hand_migration.py
+++ b/tests/scripts/migrations/test_global_governance_patterns_hand_migration.py
@@ -1,0 +1,169 @@
+"""Unit tests for scripts/migrations/global_governance_patterns_hand_migration.py.
+
+Covers the pure-function surface (no HTTP):
+- build_hindsight_item shape matches indexer_base._post_object_hindsight_mirror
+- load_state / append_state round-trip + skips on re-run
+- migrate_one error-path returns (False, ...) on non-2xx
+
+End-to-end HTTP path is exercised by operator dry-run before --execute, not
+re-mocked here (would duplicate indexer_base mirror tests).
+
+bd: Agency_OS-x0p7
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "migrations"))
+
+_mig = importlib.import_module("global_governance_patterns_hand_migration")
+
+
+def test_build_hindsight_item_carries_raw_text_as_content():
+    obj = {
+        "id": "ggp-1",
+        "class": "Global_governance_patterns",
+        "properties": {
+            "raw_text": "pattern: deliberator concur required for merge",
+            "agent": "aiden",
+            "kei": "Agency_OS-x0p7",
+        },
+    }
+    item = _mig.build_hindsight_item(obj)
+    assert item["content"] == "pattern: deliberator concur required for merge"
+    assert "weaviate_class:Global_governance_patterns" in item["tags"]
+    assert item["metadata"]["external_id"] == "ggp-1"
+    assert item["metadata"]["mirror_source"] == "global_governance_patterns_hand_migration"
+    assert item["metadata"]["weaviate_class"] == "Global_governance_patterns"
+    assert item["metadata"]["agent"] == "aiden"
+    assert "raw_text" not in item["metadata"]
+
+
+def test_build_hindsight_item_falls_back_to_content_then_json():
+    obj = {
+        "id": "ggp-2",
+        "class": "Global_governance_patterns",
+        "properties": {"content": "fallback-1"},
+    }
+    assert _mig.build_hindsight_item(obj)["content"] == "fallback-1"
+    obj2 = {"id": "ggp-3", "class": "Global_governance_patterns", "properties": {"x": "y"}}
+    item = _mig.build_hindsight_item(obj2)
+    assert '"x"' in item["content"]
+    assert '"y"' in item["content"]
+
+
+def test_state_roundtrip_skips_seen_ids(tmp_path: Path):
+    state = tmp_path / "state.jsonl"
+    assert _mig.load_state(state) == set()
+    _mig.append_state(state, {"external_id": "ggp-A", "ok": True, "info": "ok"})
+    _mig.append_state(state, {"external_id": "ggp-B", "ok": False, "info": "rc=500"})
+    _mig.append_state(state, {"external_id": "ggp-C", "ok": True, "info": "ok"})
+    seen = _mig.load_state(state)
+    assert seen == {"ggp-A", "ggp-C"}  # only ok=True rows count as migrated
+
+
+def test_migrate_one_returns_false_on_non_2xx(monkeypatch):
+    """Non-2xx response from Hindsight must be classified as failure."""
+    monkeypatch.setattr(_mig, "_http_post", lambda base, path, body: (500, {"error": "boom"}))
+    ok, info = _mig.migrate_one(
+        {"id": "x", "class": "Global_governance_patterns", "properties": {}}
+    )
+    assert ok is False
+    assert "rc=500" in info
+
+
+def test_migrate_one_returns_true_on_2xx(monkeypatch):
+    monkeypatch.setattr(_mig, "_http_post", lambda base, path, body: (200, {"id": "h-123"}))
+    ok, info = _mig.migrate_one(
+        {"id": "x", "class": "Global_governance_patterns", "properties": {}}
+    )
+    assert ok is True
+    assert "h-123" in info
+
+
+def test_run_aborts_when_weaviate_count_unavailable(monkeypatch, tmp_path: Path):
+    """If we can't get a baseline count, we refuse to run (safety guard)."""
+    monkeypatch.setattr(_mig, "weaviate_count", lambda *a, **kw: None)
+    rc = _mig.run(execute=True, state_path=tmp_path / "s.jsonl")
+    assert rc == 2
+
+
+def test_run_dry_run_does_not_call_migrate_one(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(_mig, "weaviate_count", lambda *a, **kw: 3)
+    monkeypatch.setattr(
+        _mig,
+        "iter_weaviate_objects",
+        lambda *a, **kw: iter(
+            [
+                {"id": f"ggp-{i}", "class": "Global_governance_patterns", "properties": {}}
+                for i in range(3)
+            ]
+        ),
+    )
+    called = []
+    monkeypatch.setattr(_mig, "migrate_one", lambda obj: called.append(obj) or (True, ""))
+    rc = _mig.run(execute=False, state_path=tmp_path / "s.jsonl")
+    assert rc == 0
+    assert called == []  # dry-run skips writes
+
+
+def test_run_execute_writes_state_and_returns_zero_on_clean(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(_mig, "weaviate_count", lambda *a, **kw: 2)
+    monkeypatch.setattr(
+        _mig,
+        "iter_weaviate_objects",
+        lambda *a, **kw: iter(
+            [
+                {"id": "a", "class": "Global_governance_patterns", "properties": {}},
+                {"id": "b", "class": "Global_governance_patterns", "properties": {}},
+            ]
+        ),
+    )
+    monkeypatch.setattr(_mig, "migrate_one", lambda obj: (True, "ok"))
+    state = tmp_path / "s.jsonl"
+    rc = _mig.run(execute=True, state_path=state)
+    assert rc == 0
+    assert _mig.load_state(state) == {"a", "b"}
+
+
+def test_run_execute_returns_one_on_any_failure(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(_mig, "weaviate_count", lambda *a, **kw: 2)
+    monkeypatch.setattr(
+        _mig,
+        "iter_weaviate_objects",
+        lambda *a, **kw: iter(
+            [
+                {"id": "a", "class": "Global_governance_patterns", "properties": {}},
+                {"id": "b", "class": "Global_governance_patterns", "properties": {}},
+            ]
+        ),
+    )
+    seq = iter([(True, "ok"), (False, "rc=500")])
+    monkeypatch.setattr(_mig, "migrate_one", lambda obj: next(seq))
+    rc = _mig.run(execute=True, state_path=tmp_path / "s.jsonl")
+    assert rc == 1
+
+
+def test_run_skips_already_migrated_ids(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(_mig, "weaviate_count", lambda *a, **kw: 2)
+    state = tmp_path / "s.jsonl"
+    _mig.append_state(state, {"external_id": "a", "ok": True, "info": "ok"})
+    monkeypatch.setattr(
+        _mig,
+        "iter_weaviate_objects",
+        lambda *a, **kw: iter(
+            [
+                {"id": "a", "class": "Global_governance_patterns", "properties": {}},
+                {"id": "b", "class": "Global_governance_patterns", "properties": {}},
+            ]
+        ),
+    )
+    called = []
+    monkeypatch.setattr(_mig, "migrate_one", lambda obj: called.append(obj["id"]) or (True, "ok"))
+    rc = _mig.run(execute=True, state_path=state)
+    assert rc == 0
+    assert called == ["b"]  # "a" skipped per state file

--- a/tests/scripts/orchestrator/test_indexer_base_hindsight_mirror.py
+++ b/tests/scripts/orchestrator/test_indexer_base_hindsight_mirror.py
@@ -130,6 +130,39 @@ def test_discoveries_class_maps_to_fleet_discoveries_bank(mod, monkeypatch):
     assert captured[0].endswith("/v1/default/banks/fleet_discoveries/memories")
 
 
+def test_global_governance_patterns_class_maps_to_fleet_bank(mod, monkeypatch):
+    """A3 step 5-A (Agency_OS-x0p7): Global_governance_patterns →
+    fleet_global_governance_patterns is live.
+
+    Locks the new mapping in CLASS_TO_BANK so a future revert is caught.
+    """
+    captured = []
+
+    class _FakeResp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+    def _fake_urlopen(req, timeout=None):
+        captured.append(req.full_url)
+        return _FakeResp()
+
+    monkeypatch.setattr(mod.urlrequest, "urlopen", _fake_urlopen)
+    mod._post_object_hindsight_mirror(
+        {
+            "class": "Global_governance_patterns",
+            "id": "ggp-xyz",
+            "properties": {"raw_text": "anchored", "agent": "aiden"},
+        }
+    )
+    assert len(captured) == 1
+    assert captured[0].endswith("/v1/default/banks/fleet_global_governance_patterns/memories")
+
+
 def test_mapped_class_posts_to_bank_with_items_envelope(mod, monkeypatch):
     captured = []
 


### PR DESCRIPTION
## Summary

Third sibling of the hand-migration trio per V2.0 `mem.weaviate_coldstart`. Same shape as Atlas PR #1172 (Discoveries, merged 2026-05-26) with class + bank substitutions. Companion `indexer_base.CLASS_TO_BANK` entry lands in the same PR so the dual-write window for new `Global_governance_patterns` writes starts the moment this PR merges.

**Filed under:** Agency_OS-x0p7 (P2, GAP type, assignee `scout` set by Aiden).

## Trio status (2026-05-26)

| Class | Bank | KEI | Status |
|---|---|---|---|
| Discoveries | fleet_discoveries | Agency_OS-4bsc | LANDED PR #1172 |
| Sessions | fleet_sessions | Agency_OS-9u2m | parallel sibling (Orion) |
| **Global_governance_patterns** | **fleet_global_governance_patterns** | **Agency_OS-x0p7** | **THIS PR** |

A3-c2 step 5-B reader cutover (Agency_OS-0zv1) is unblocked when all three trio members have landed.

## What lands

| File | LoC | Purpose |
|---|---:|---|
| `scripts/migrations/global_governance_patterns_hand_migration.py` (new) | 225 | one-time operator-gated backfill |
| `scripts/orchestrator/indexer_base.py` (+6) | +6 | CLASS_TO_BANK entry + comment block |
| `tests/scripts/migrations/test_global_governance_patterns_hand_migration.py` (new) | 169 | 10 unit tests (positive + 3 negative-path) |
| `tests/scripts/orchestrator/test_indexer_base_hindsight_mirror.py` (+33) | +33 | new positive test locking the mapping |

**Cumulative:** 441 net lines added across 4 files. **21 unit tests passing** (10 new migration tests + the existing 11 in `test_indexer_base_hindsight_mirror.py` after adding 1 positive test).

## Scope discipline (per `feedback_split_orthogonal_scope`)

- DOES NOT touch the `test_unmapped_class_skips_cleanly` test — it still uses `"Sessions"` which remains unmapped until Orion's Agency_OS-9u2m PR lands. Avoids a merge conflict with the sibling PR.
- DOES NOT touch reader-cutover code (`src/retrieval/orchestrator.py`) — that's Agency_OS-0zv1 per Atlas's PR #1172 deferral pattern.
- DOES NOT add new dependencies — uses stdlib `urllib` consistent with PR #1172.

## Test plan

- [x] `python3 -m pytest tests/scripts/migrations/test_global_governance_patterns_hand_migration.py tests/scripts/orchestrator/test_indexer_base_hindsight_mirror.py -q` → 21 passed
- [x] `python3 -m ruff check` on all 4 files → clean
- [x] `python3 -m ruff format --check` on all 4 files → clean
- [x] Empirical pattern-mirror verified against Atlas PR #1172 (template fetched verbatim, only class/bank/KEI/script-name strings substituted)
- [ ] Reviewer: confirm bank name follows the existing pattern (`Global_governance_patterns → fleet_global_governance_patterns` mirrors `fleet_agent_memories`/`fleet_session_transcripts`/`fleet_strategic_documents` snake_case-prefix convention)
- [ ] Reviewer: confirm the unmapped-class test choice is correct given the trio merge ordering

## Operator runbook (post-merge)

```bash
# 1. Verify Hindsight connectivity to the new bank
curl -sf "$HINDSIGHT_BASE/v1/default/banks/fleet_global_governance_patterns" >/dev/null

# 2. Dry-run (logs count of pending records, no writes)
python3 scripts/migrations/global_governance_patterns_hand_migration.py

# 3. Execute (idempotent + resumable via state file)
python3 scripts/migrations/global_governance_patterns_hand_migration.py --execute

# 4. Verify counts match
# Weaviate Aggregate Global_governance_patterns vs Hindsight fleet_global_governance_patterns memory count
```

## Author note

Dispatch routed to scout by Elliot (load-balancing while Atlas finishes #1172 review cycle + Orion is on the cache PR). Empirical-witness diff: substitution-only against template; 21 tests + ruff format + ruff check all clean locally.

bd: Agency_OS-x0p7. Closes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)