### PR TITLE
[SCOUT] feat(systemd): per-callsign dispatcher template (Agency_OS-awec, §7 piece 4)

### DIFF
--- a/docs/runbooks/ephemeral_agent_dispatcher_install.md
+++ b/docs/runbooks/ephemeral_agent_dispatcher_install.md
@@ -1,0 +1,112 @@
+# Ephemeral-Agent Dispatcher — Install Runbook
+
+**Filed under:** Agency_OS-awec (§7 piece 4 of PR #1140 ephemeral-agent scoping)
+**Status:** SCAFFOLD ONLY — runtime activation gated on §7 pieces 1 + 5
+**Owner:** scout (author), Elliot (orchestrator merge)
+
+## What this is
+
+Per-callsign systemd template unit `keiracom-dispatcher@<callsign>.service`. One template file, instantiated 7 times (one per callsign: elliot / aiden / max / atlas / orion / scout / nova).
+
+This is the scaffold side of the §7 piece-4 dispatch. The template references a dispatcher binary at `scripts/dispatcher/dispatcher_main.py` which is filed as §7 piece 1 (a separate P1 KEI not yet shipped). The template installs cleanly today but **will not start until piece 1 + 5 binaries are in place** — `ExecStartPre=/usr/bin/test -x …` blocks startup until then.
+
+## Files in this PR
+
+| Path | Purpose | LoC |
+|---|---|---:|
+| `systemd/keiracom-dispatcher@.service` | template unit, instantiated by `@<callsign>` | 47 |
+| `systemd/dispatcher-env/dispatcher-<callsign>.env` × 7 | per-callsign overrides (worktree + inbox + outbox + tier) | ~12 each, 84 total |
+| `scripts/install_keiracom_dispatcher.sh` | install / uninstall script (idempotent) | ~110 |
+| `docs/runbooks/ephemeral_agent_dispatcher_install.md` | this runbook | ~80 |
+
+## Install (post-piece-1 activation)
+
+After §7 pieces 1 + 5 land (`scripts/dispatcher/dispatcher_main.py` + the spawn-with-context composer library it imports), an operator runs:
+
+```bash
+# Install template + env files + enable all 7 callsigns:
+bash scripts/install_keiracom_dispatcher.sh
+
+# OR install + enable for a subset:
+bash scripts/install_keiracom_dispatcher.sh elliot scout
+
+# OR install but don't enable yet (just stage):
+bash scripts/install_keiracom_dispatcher.sh --no-enable
+```
+
+The script:
+1. Copies the template to `~/.config/systemd/user/keiracom-dispatcher@.service`
+2. Copies per-callsign env files to `~/.config/agency-os/dispatcher-<callsign>.env`
+3. Runs `systemctl --user daemon-reload`
+4. Runs `systemctl --user enable keiracom-dispatcher@<callsign>.service` for each callsign (NOTE: `enable` not `enable --now` — the unit is enabled but not started until you `systemctl --user start ...` manually, since the binary may not exist at install time)
+
+## Start (after binaries land)
+
+Once `scripts/dispatcher/dispatcher_main.py` is in place and executable, start each callsign:
+
+```bash
+for c in elliot aiden max atlas orion scout nova; do
+    systemctl --user start keiracom-dispatcher@${c}.service
+done
+systemctl --user status keiracom-dispatcher@elliot.service  # spot-check
+```
+
+## Verify
+
+```bash
+# Check unit is loaded + enabled
+systemctl --user is-enabled keiracom-dispatcher@elliot.service     # → enabled
+
+# Check unit is running (once binary lands)
+systemctl --user is-active keiracom-dispatcher@elliot.service      # → active
+
+# Tail per-callsign log
+tail -f /home/elliotbot/clawd/logs/keiracom-dispatcher-elliot.log
+```
+
+## Uninstall
+
+```bash
+# Disable + remove for a specific callsign:
+bash scripts/install_keiracom_dispatcher.sh --uninstall elliot
+
+# Disable + remove for all 7:
+bash scripts/install_keiracom_dispatcher.sh --uninstall
+```
+
+## Why template-unit + per-callsign env files (not 7 separate units)
+
+systemd template instance units (`<name>@.service`) are the canonical pattern for "same service shape, parameterised by an instance string". One file describes the contract; 7 enablements bring 7 instances online. Saves 6× file duplication + makes a future "rename a callsign" or "add an 8th callsign" a 1-line change.
+
+Per-callsign env files capture the only things that legitimately differ per callsign:
+- `DISPATCHER_WORKTREE_PATH` (elliot's worktree is `/home/elliotbot/clawd/Agency_OS` with no suffix; the clones have `-<callsign>` suffixes)
+- `DISPATCHER_INBOX_DIR` / `DISPATCHER_OUTBOX_DIR` (per-callsign telegram-relay paths)
+- `DISPATCHER_TIER` (orchestrator / deliberator / worker / research — for piece 1's role-gating)
+
+Everything else (`CALLSIGN`, log path) derives from `%i` in the template.
+
+## Dependency graph
+
+```
+§7 piece 4 (THIS PR)         §7 piece 1 (P1 KEI, not yet filed)
+  template + env files          scripts/dispatcher/dispatcher_main.py
+        |                                |
+        +--------- ExecStartPre ---------+
+                  blocks until piece 1 ships
+
+§7 piece 5 (P1 KEI, not yet filed)
+  spawn-with-context composer library (imported by piece 1)
+        |
+        +---- imported by piece 1 binary at runtime
+```
+
+This PR is unblocked-by-design — landing it does NOT require pieces 1 or 5 to exist. Operators can install the unit + env files today; the unit will refuse to start until the binary lands.
+
+## Acceptance criteria
+
+- [x] Template `.service` file parses cleanly (manual + `systemd-analyze --user verify` post-install)
+- [x] 7 per-callsign env files exist with correct paths
+- [x] Install script is idempotent + supports `--no-enable` + `--uninstall`
+- [x] Runbook covers install / start / verify / uninstall
+- [ ] (post-pieces-1+5) `systemctl --user start keiracom-dispatcher@elliot.service` → active
+- [ ] (post-pieces-1+5) Dispatcher reads inbox JSON + spawns ephemeral Claude per design §3

--- a/scripts/install_keiracom_dispatcher.sh
+++ b/scripts/install_keiracom_dispatcher.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# install_keiracom_dispatcher.sh — Install + enable Phase A8 ephemeral-agent
+# dispatcher systemd template for one or more callsigns.
+#
+# Filed under Agency_OS-awec (§7 piece 4 of PR #1140 ephemeral-agent scoping).
+#
+# DEPENDS ON §7 pieces 1 + 5 (P1 KEIs):
+#   - Piece 1: scripts/dispatcher/dispatcher_main.py must be installed +
+#     executable at the path baked into the template's ExecStartPre.
+#   - Piece 5: spawn-with-context composer library imported by piece 1.
+#
+# If those binaries are missing, the unit will fail at ExecStartPre (test -x
+# check). This script installs the unit + env files anyway so the scaffold is
+# ready; operators run `systemctl --user start` once pieces 1+5 ship.
+#
+# Usage:
+#   install_keiracom_dispatcher.sh                    # install for all 7 callsigns
+#   install_keiracom_dispatcher.sh elliot scout       # install for specific callsigns
+#   install_keiracom_dispatcher.sh --no-enable elliot # install but don't enable
+#   install_keiracom_dispatcher.sh --uninstall elliot # disable + remove
+#
+# Idempotent: re-running copies the unit + env file fresh + reloads daemon +
+# enables if not already enabled. Safe in any bootstrap pipeline.
+
+set -euo pipefail
+
+ALL_CALLSIGNS=(elliot aiden max atlas orion scout nova)
+
+UNITS_DIR="${HOME}/.config/systemd/user"
+ENV_DIR="${HOME}/.config/agency-os"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNIT_SOURCE="${REPO_DIR}/systemd/keiracom-dispatcher@.service"
+ENV_SOURCE_DIR="${REPO_DIR}/systemd/dispatcher-env"
+
+# ----------------------------------------------------------------------------
+# Flags + arg parsing
+# ----------------------------------------------------------------------------
+do_enable=1
+do_uninstall=0
+declare -a callsigns
+
+for arg in "$@"; do
+    case "${arg}" in
+        --no-enable)
+            do_enable=0
+            ;;
+        --uninstall)
+            do_uninstall=1
+            do_enable=0
+            ;;
+        --help|-h)
+            sed -n '2,/^set -euo/p' "$0" | head -n 25
+            exit 0
+            ;;
+        -*)
+            echo "unknown flag: ${arg}" >&2
+            exit 2
+            ;;
+        *)
+            callsigns+=("${arg}")
+            ;;
+    esac
+done
+
+if [[ ${#callsigns[@]} -eq 0 ]]; then
+    callsigns=("${ALL_CALLSIGNS[@]}")
+fi
+
+# ----------------------------------------------------------------------------
+# Validation
+# ----------------------------------------------------------------------------
+if [[ ! -f "${UNIT_SOURCE}" ]]; then
+    echo "missing source unit: ${UNIT_SOURCE}" >&2
+    exit 2
+fi
+
+mkdir -p "${UNITS_DIR}" "${ENV_DIR}" /home/elliotbot/clawd/logs
+
+# ----------------------------------------------------------------------------
+# Install template unit (one file, instantiated per callsign at enable time)
+# ----------------------------------------------------------------------------
+if [[ ${do_uninstall} -eq 0 ]]; then
+    cp "${UNIT_SOURCE}" "${UNITS_DIR}/keiracom-dispatcher@.service"
+    systemctl --user daemon-reload
+fi
+
+# ----------------------------------------------------------------------------
+# Per-callsign env + enable/disable
+# ----------------------------------------------------------------------------
+for callsign in "${callsigns[@]}"; do
+    env_source="${ENV_SOURCE_DIR}/dispatcher-${callsign}.env"
+    env_dest="${ENV_DIR}/dispatcher-${callsign}.env"
+
+    if [[ ${do_uninstall} -eq 1 ]]; then
+        systemctl --user disable --now "keiracom-dispatcher@${callsign}.service" 2>/dev/null || true
+        rm -f "${env_dest}"
+        echo "uninstalled: keiracom-dispatcher@${callsign}.service"
+        continue
+    fi
+
+    if [[ ! -f "${env_source}" ]]; then
+        echo "warning: missing env file for ${callsign}: ${env_source} — skipping" >&2
+        continue
+    fi
+
+    cp "${env_source}" "${env_dest}"
+
+    if [[ ${do_enable} -eq 1 ]]; then
+        # `enable` without `--now` so we don't try to start a unit that fails
+        # at ExecStartPre until §7 piece 1 binary lands. Operator runs
+        # `systemctl --user start keiracom-dispatcher@<callsign>.service`
+        # manually once the binary is in place.
+        systemctl --user enable "keiracom-dispatcher@${callsign}.service"
+        echo "installed + enabled: keiracom-dispatcher@${callsign}.service"
+    else
+        echo "installed (not enabled): keiracom-dispatcher@${callsign}.service"
+    fi
+done
+
+if [[ ${do_uninstall} -eq 1 ]]; then
+    systemctl --user daemon-reload
+fi

--- a/systemd/dispatcher-env/dispatcher-aiden.env
+++ b/systemd/dispatcher-env/dispatcher-aiden.env
@@ -1,0 +1,9 @@
+# dispatcher-aiden.env — per-callsign override for keiracom-dispatcher@aiden.service.
+# Filed under Agency_OS-awec (§7 piece 4 of PR #1140 ephemeral-agent scoping).
+
+DISPATCHER_WORKTREE_PATH=/home/elliotbot/clawd/Agency_OS-aiden
+DISPATCHER_INBOX_DIR=/tmp/telegram-relay-aiden/inbox
+DISPATCHER_OUTBOX_DIR=/tmp/telegram-relay-aiden/outbox
+
+# Aiden is CTO / deliberator (architecture-governance lens).
+DISPATCHER_TIER=deliberator

--- a/systemd/dispatcher-env/dispatcher-atlas.env
+++ b/systemd/dispatcher-env/dispatcher-atlas.env
@@ -1,0 +1,9 @@
+# dispatcher-atlas.env — per-callsign override for keiracom-dispatcher@atlas.service.
+# Filed under Agency_OS-awec (§7 piece 4 of PR #1140 ephemeral-agent scoping).
+
+DISPATCHER_WORKTREE_PATH=/home/elliotbot/clawd/Agency_OS-atlas
+DISPATCHER_INBOX_DIR=/tmp/telegram-relay-atlas/inbox
+DISPATCHER_OUTBOX_DIR=/tmp/telegram-relay-atlas/outbox
+
+# Atlas is Elliot's engineer-tier clone (worker).
+DISPATCHER_TIER=worker

--- a/systemd/dispatcher-env/dispatcher-elliot.env
+++ b/systemd/dispatcher-env/dispatcher-elliot.env
@@ -1,0 +1,21 @@
+# dispatcher-elliot.env — per-callsign override for keiracom-dispatcher@elliot.service.
+# Filed under Agency_OS-awec (§7 piece 4 of PR #1140 ephemeral-agent scoping).
+#
+# Sourced by the template unit via EnvironmentFile=-... — `-` prefix means
+# missing-file is non-fatal, so the template still works if this file is
+# absent. The dispatcher binary (piece 1) reads these vars + falls back to
+# code-level defaults.
+
+# Elliot's worktree is the canonical Agency_OS path (no -elliot suffix —
+# elliot is the primary, the others are clones).
+DISPATCHER_WORKTREE_PATH=/home/elliotbot/clawd/Agency_OS
+
+# Per-callsign inbox dir (canonical telegram-relay path used today).
+DISPATCHER_INBOX_DIR=/tmp/telegram-relay-elliot/inbox
+
+# Per-callsign outbox dir.
+DISPATCHER_OUTBOX_DIR=/tmp/telegram-relay-elliot/outbox
+
+# Tier: elliot is the orchestrator (Phase 1.2.5 role-lock per Dave directive
+# 2026-05-12). Piece 1 may use this to gate dispatch behaviour.
+DISPATCHER_TIER=orchestrator

--- a/systemd/dispatcher-env/dispatcher-max.env
+++ b/systemd/dispatcher-env/dispatcher-max.env
@@ -1,0 +1,10 @@
+# dispatcher-max.env — per-callsign override for keiracom-dispatcher@max.service.
+# Filed under Agency_OS-awec (§7 piece 4 of PR #1140 ephemeral-agent scoping).
+
+DISPATCHER_WORKTREE_PATH=/home/elliotbot/clawd/Agency_OS-max
+DISPATCHER_INBOX_DIR=/tmp/telegram-relay-max/inbox
+DISPATCHER_OUTBOX_DIR=/tmp/telegram-relay-max/outbox
+
+# Max is CTO / deliberator (code-quality lens) + COO proxy per Dave directive
+# (Tier 0 authority; reads agent posts, briefs Dave privately).
+DISPATCHER_TIER=deliberator

--- a/systemd/dispatcher-env/dispatcher-nova.env
+++ b/systemd/dispatcher-env/dispatcher-nova.env
@@ -1,0 +1,9 @@
+# dispatcher-nova.env — per-callsign override for keiracom-dispatcher@nova.service.
+# Filed under Agency_OS-awec (§7 piece 4 of PR #1140 ephemeral-agent scoping).
+
+DISPATCHER_WORKTREE_PATH=/home/elliotbot/clawd/Agency_OS-nova
+DISPATCHER_INBOX_DIR=/tmp/telegram-relay-nova/inbox
+DISPATCHER_OUTBOX_DIR=/tmp/telegram-relay-nova/outbox
+
+# Nova is the engineer-tier overflow clone (KEI-185 third-engineer).
+DISPATCHER_TIER=worker

--- a/systemd/dispatcher-env/dispatcher-orion.env
+++ b/systemd/dispatcher-env/dispatcher-orion.env
@@ -1,0 +1,9 @@
+# dispatcher-orion.env — per-callsign override for keiracom-dispatcher@orion.service.
+# Filed under Agency_OS-awec (§7 piece 4 of PR #1140 ephemeral-agent scoping).
+
+DISPATCHER_WORKTREE_PATH=/home/elliotbot/clawd/Agency_OS-orion
+DISPATCHER_INBOX_DIR=/tmp/telegram-relay-orion/inbox
+DISPATCHER_OUTBOX_DIR=/tmp/telegram-relay-orion/outbox
+
+# Orion is Aiden's engineer-tier clone (worker).
+DISPATCHER_TIER=worker

--- a/systemd/dispatcher-env/dispatcher-scout.env
+++ b/systemd/dispatcher-env/dispatcher-scout.env
@@ -1,0 +1,10 @@
+# dispatcher-scout.env — per-callsign override for keiracom-dispatcher@scout.service.
+# Filed under Agency_OS-awec (§7 piece 4 of PR #1140 ephemeral-agent scoping).
+
+DISPATCHER_WORKTREE_PATH=/home/elliotbot/clawd/Agency_OS-scout
+DISPATCHER_INBOX_DIR=/tmp/telegram-relay-scout/inbox
+DISPATCHER_OUTBOX_DIR=/tmp/telegram-relay-scout/outbox
+
+# Scout is the research+diagnosis clone (3rd clone, no single-CTO ownership).
+# Open to dispatch from any CTO (Elliot/Aiden/Max).
+DISPATCHER_TIER=research

--- a/systemd/keiracom-dispatcher@.service
+++ b/systemd/keiracom-dispatcher@.service
@@ -1,0 +1,54 @@
+[Unit]
+# Phase A8 ephemeral-agent dispatcher template (Agency_OS-awec, §7 piece 4 from PR #1140).
+#
+# Template instance unit: enable per-callsign via:
+#   systemctl --user enable --now keiracom-dispatcher@elliot.service
+#   systemctl --user enable --now keiracom-dispatcher@aiden.service
+#   ... etc for max / atlas / orion / scout / nova
+#
+# %i = instance name (the callsign).
+#
+# DEPENDS ON §7 pieces 1 + 5 (P1 KEIs, not yet shipped at template-author time):
+#   - Piece 1: scripts/dispatcher/dispatcher_main.py — the dispatcher binary
+#   - Piece 5: spawn-with-context composer library imported by dispatcher_main
+#
+# ExecStartPre below blocks the unit from starting until the binary exists,
+# so this template is safe to land + safe to leave unenabled until pieces 1+5
+# merge. After they merge, operators run install_keiracom_dispatcher.sh which
+# enables the per-callsign instance.
+Description=Keiracom ephemeral-agent dispatcher for %i (Phase A8 piece 4)
+Documentation=https://github.com/Keiracom/Agency_OS/pull/1140
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+# Callsign from instance name; per-callsign overrides (worktree path etc.) in
+# the optional env file. `-` prefix on second EnvironmentFile = missing-file
+# is non-fatal (template can be enabled even if no per-callsign override
+# exists; sensible defaults via app code).
+Environment="CALLSIGN=%i"
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+EnvironmentFile=-/home/elliotbot/.config/agency-os/dispatcher-%i.env
+
+# Per §7 piece 1: the dispatcher binary lives at scripts/dispatcher/dispatcher_main.py
+# under the elliot worktree (canonical Agency_OS path; non-clone callsigns
+# delegate compose-logic to this single binary). Per-callsign worktree paths
+# live in the dispatcher-%i.env override (above) if a callsign needs a
+# different working directory.
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+
+ExecStartPre=/usr/bin/test -x /home/elliotbot/clawd/Agency_OS/scripts/dispatcher/dispatcher_main.py
+ExecStart=/usr/bin/python3 -B /home/elliotbot/clawd/Agency_OS/scripts/dispatcher/dispatcher_main.py --callsign %i
+
+Restart=on-failure
+RestartSec=10
+
+# Per-instance log files keep per-callsign noise separated.
+StandardOutput=append:/home/elliotbot/clawd/logs/keiracom-dispatcher-%i.log
+StandardError=append:/home/elliotbot/clawd/logs/keiracom-dispatcher-%i.log
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

§7 piece 4 from PR #1140 ephemeral-agent scoping doc. **Scaffold-only** — the template references a dispatcher binary (§7 piece 1, P1, not yet filed) which doesn't exist yet. ExecStartPre blocks the unit from starting until the binary lands.

**Filed under:** Agency_OS-awec (P2, set by Aiden, dispatched by Elliot)

## What lands

| File | Purpose | LoC |
|---|---|---:|
| `systemd/keiracom-dispatcher@.service` | template instance unit | 47 |
| `systemd/dispatcher-env/dispatcher-<callsign>.env` × 7 | per-callsign overrides | ~12 each |
| `scripts/install_keiracom_dispatcher.sh` | install/uninstall script | 110 |
| `docs/runbooks/ephemeral_agent_dispatcher_install.md` | install runbook | ~80 |

**7 callsigns:** elliot, aiden, max, atlas, orion, scout, nova.

## Design notes

- **Template-unit pattern** (1 file × 7 instances) over 7 separate units. Canonical systemd approach via `keiracom-dispatcher@<callsign>.service` syntax + `%i` substitution. Makes future callsign rename / addition a 1-line change.
- **Per-callsign env files** capture only what legitimately differs per callsign: `DISPATCHER_WORKTREE_PATH` (elliot's worktree is `/home/elliotbot/clawd/Agency_OS` with no suffix; the clones have `-<callsign>` suffixes), `DISPATCHER_INBOX_DIR`, `DISPATCHER_OUTBOX_DIR`, `DISPATCHER_TIER` (orchestrator/deliberator/worker/research).
- **Install enables without `--now`** so the unit doesn't try to start until the dispatcher binary (§7 piece 1) is in place. Operator runs `systemctl --user start keiracom-dispatcher@<callsign>.service` once piece 1 ships.
- **ExecStartPre `/usr/bin/test -x`** on the binary path — fails loud if the binary is missing, instead of running an undefined service.

## Dependency graph

```
§7 piece 4 (THIS PR)              §7 piece 1 (P1, TBD)
  template + env files               scripts/dispatcher/dispatcher_main.py
        |                                    |
        +-------- ExecStartPre --------------+
                blocks until piece 1 ships

§7 piece 5 (P1, TBD)
  spawn-with-context composer (imported by piece 1)
```

This PR is **unblocked-by-design** — landing it does NOT require pieces 1 or 5 to exist. Operators can install the unit + env files today; the unit refuses to start until the binary lands.

## Test plan

- [x] `bash -n scripts/install_keiracom_dispatcher.sh` → OK
- [x] `systemd-analyze --user verify systemd/keiracom-dispatcher@.service` → rc=0 (warnings emitted relate to pre-existing other user units, not this template)
- [x] `chmod +x` applied to install script
- [x] Template uses `%i` for callsign + log path; no other per-callsign hardcoding
- [x] Per-callsign env files cover all 7 callsigns with correct worktree paths
- [x] Install script supports `--no-enable` + `--uninstall` + subset selection
- [ ] Reviewer: spot-check `dispatcher-elliot.env` — confirm elliot's `DISPATCHER_WORKTREE_PATH` is `/home/elliotbot/clawd/Agency_OS` (no -elliot suffix) per current worktree convention
- [ ] Reviewer: confirm 7-callsign list matches IDENTITY.md/clone-architecture canonical set
- [ ] (post-piece-1+5) End-to-end smoke: `systemctl --user start keiracom-dispatcher@elliot.service` → active

## Scope discipline (per `feedback_split_orthogonal_scope`)

- DOES NOT include the dispatcher binary itself (that's §7 piece 1, separate KEI)
- DOES NOT include the spawn-with-context composer (§7 piece 5, separate KEI)
- DOES NOT include the cutover-day checklist (§7 piece 6, separate KEI)
- DOES NOT touch existing per-callsign systemd units (nova-agent.service, elliot-polling-loop.service, etc.) — those are the tmux-based agent_keepalive pattern; the ephemeral-agent dispatcher replaces them on Stage 5 cutover but that's a separate dispatch.

## CI status note

**Heads-up**: the `pull_request` CI trigger appears broken fleet-wide since ~10:21:55Z (flagged in my PR #1177 + #1178 reviews). If this PR shows no Actions runs on the status check rollup, that's why. Recommended check: `gh run list --branch scout/awec-dispatcher-systemd-templates --limit 5`. If CI does fire, expected gating checks for a systemd/scripts/docs diff: Dead Reference Guard, KEI-108, Boundary Matrix v1 Guards, Cache Discipline Guards (A7 CB-10), Migration Completeness Guard. Backend Tests/MyPy/Ruff likely skip since no Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

bd: Agency_OS-awec. Closes on merge.