### PR TITLE
[ATLAS] feat(migration): A5 piece 1a — ceo_memory carving classifier (policy-vs-memory rule)

### DIFF
--- a/scripts/migrations/ceo_memory_carving_classifier.py
+++ b/scripts/migrations/ceo_memory_carving_classifier.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""ceo_memory_carving_classifier.py — Phase A5 piece 1a classification rule.
+
+Implements the policy-vs-memory carving rule that determines which
+`public.ceo_memory` rows get backfilled into Hindsight (as Dave-tenant
+memory) versus which stay in Supabase as canonical policy SSOT.
+
+Path (C) per Elliot dispatch 2026-05-26: dual-store honours BOTH
+`ceo:boundary_matrix_v1` (policy → Supabase) AND
+`ceo:dave_decisions_2026_05_26` decision_1 (backfill → Hindsight) by
+carving on the policy-vs-memory test: would this content read the same
+way for ANY tenant? Yes = POLICY (skip backfill). No (tenant-specific
+to Dave) = MEMORY (backfill via DecisionWrapper under Dave's fleet
+tenant_id).
+
+This module is the RULE only. The HTTP executor that consumes its
+classification + POSTs to Hindsight is Phase A5 piece 1b (separate PR
+per feedback_split_orthogonal_scope).
+
+bd: Agency_OS-oq3c
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from collections import Counter
+from typing import Any
+
+logger = logging.getLogger("ceo_memory_carving_classifier")
+
+POLICY = "POLICY"
+MEMORY = "MEMORY"
+
+# Meta-rule key prefixes — these are governance content that would read the
+# same way for any tenant per the policy-vs-memory test. STAY in Supabase
+# ceo_memory; do NOT backfill to Hindsight.
+POLICY_PREFIXES: tuple[str, ...] = (
+    "ceo:boundary_matrix",
+    "ceo:memory_abstraction",
+    "ceo:comm_architecture",
+    "ceo:agency_os_keiracom_separation",
+    "ceo:rule:",
+    "ceo:law",
+    "ceo:governance",
+    "ceo:cognee_retirement_posture",
+    "ceo:cognee_retirement_execution",
+    "ceo:atomization_architecture",
+    "ceo:keiracom_build_priority",
+    "ceo:memory_cutover_unblock",
+    "ceo:dave_migration_sequence",
+)
+
+# Explicitly tenant-specific key prefixes — Dave-as-tenant memory candidates.
+MEMORY_PREFIXES: tuple[str, ...] = (
+    "ceo:dave_",
+    "ceo:byok_",
+    "ceo:session_end_",
+)
+
+
+def classify_row(key: str, value: Any | None = None) -> str:  # noqa: ARG001
+    """Return POLICY or MEMORY for one ceo_memory row.
+
+    Conservative default for unknown `ceo:*` keys is POLICY — stays in
+    Supabase. Operator can override via a manual carve list downstream
+    (piece 1b consumes the classification but doesn't strictly enforce
+    it as a final-say).
+
+    `value` is currently unused but retained in the signature so future
+    rules can inspect row content (e.g. "any row whose value names a
+    tenant_id is MEMORY"). Don't break the callable signature.
+    """
+    if not key.startswith("ceo:"):
+        return MEMORY
+    if any(key.startswith(p) for p in POLICY_PREFIXES):
+        return POLICY
+    if any(key.startswith(p) for p in MEMORY_PREFIXES):
+        return MEMORY
+    if key.startswith("ceo:directive_") and key.endswith("_complete"):
+        return MEMORY
+    return POLICY
+
+
+def classify_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Apply classify_row to each row + return rows annotated with `_carve`."""
+    out = []
+    for row in rows:
+        key = row.get("key", "")
+        value = row.get("value")
+        carve = classify_row(key, value)
+        out.append({**row, "_carve": carve})
+    return out
+
+
+def report(rows: list[dict[str, Any]], *, sample_size: int = 5) -> dict[str, Any]:
+    """Build a classification report for operator review.
+
+    Includes counts by carve + sample keys per carve so the operator can
+    eyeball the partition before piece 1b ships any data to Hindsight.
+    """
+    counter: Counter[str] = Counter()
+    samples_by_carve: dict[str, list[str]] = {POLICY: [], MEMORY: []}
+    for row in rows:
+        carve = row.get("_carve", POLICY)
+        counter[carve] += 1
+        if len(samples_by_carve.get(carve, [])) < sample_size:
+            samples_by_carve.setdefault(carve, []).append(row.get("key", ""))
+    return {
+        "totals": dict(counter),
+        "samples_by_carve": samples_by_carve,
+        "memory_count": counter.get(MEMORY, 0),
+        "policy_count": counter.get(POLICY, 0),
+    }
+
+
+def load_rows_from_jsonl(path: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped:
+                rows.append(json.loads(stripped))
+    return rows
+
+
+def write_rows_to_jsonl(rows: list[dict[str, Any]], path: str) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, default=str) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--input",
+        required=True,
+        help="JSONL path with ceo_memory rows (one row per line, fields: key, value, ...)",
+    )
+    p.add_argument(
+        "--export-classifications",
+        help="JSONL output path; writes each row annotated with `_carve` for piece 1b consumption",
+    )
+    p.add_argument("--log-level", default="INFO")
+    args = p.parse_args(argv)
+    logging.basicConfig(level=args.log_level, format="%(asctime)s %(levelname)s %(message)s")
+    rows = load_rows_from_jsonl(args.input)
+    classified = classify_rows(rows)
+    rep = report(classified)
+    print(json.dumps(rep, indent=2))
+    if args.export_classifications:
+        write_rows_to_jsonl(classified, args.export_classifications)
+        logger.info("wrote %d classified rows → %s", len(classified), args.export_classifications)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/migrations/test_ceo_memory_carving_classifier.py
+++ b/tests/scripts/migrations/test_ceo_memory_carving_classifier.py
@@ -1,0 +1,145 @@
+"""Tests for the ceo_memory carving classifier (Phase A5 piece 1a).
+
+Locks the policy-vs-memory rule per Elliot dispatch 2026-05-26 Path (C):
+- POLICY → stays in Supabase ceo_memory (don't backfill to Hindsight)
+- MEMORY → tenant-specific (Dave) → backfill via DecisionWrapper
+
+bd: Agency_OS-oq3c
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "migrations"))
+
+_mod = importlib.import_module("ceo_memory_carving_classifier")
+
+
+def test_bare_key_classifies_as_memory():
+    """Pre-ceo:-convention bare keys (e.g. 'architecture_version',
+    'bu_redesign_mar25') are historical operational state about Dave's
+    BDR product → tenant-specific memory."""
+    assert _mod.classify_row("architecture_version") == _mod.MEMORY
+    assert _mod.classify_row("bu_redesign_mar25") == _mod.MEMORY
+    assert _mod.classify_row("campaign_model") == _mod.MEMORY
+
+
+def test_meta_rule_keys_classify_as_policy():
+    """boundary_matrix + memory_abstraction + comm_architecture + governance
+    laws + rule:* are governance content that would read the same way for any
+    tenant → POLICY → stays in Supabase."""
+    assert _mod.classify_row("ceo:boundary_matrix_v1") == _mod.POLICY
+    assert _mod.classify_row("ceo:memory_abstraction_layer_v1") == _mod.POLICY
+    assert _mod.classify_row("ceo:comm_architecture") == _mod.POLICY
+    assert _mod.classify_row("ceo:rule:subprocess_memory_cap") == _mod.POLICY
+    assert _mod.classify_row("ceo:agency_os_keiracom_separation_v1") == _mod.POLICY
+    assert _mod.classify_row("ceo:governance_freshness") == _mod.POLICY
+    assert _mod.classify_row("ceo:cognee_retirement_posture_2026_05_26") == _mod.POLICY
+    assert _mod.classify_row("ceo:cognee_retirement_execution_complete_2026_05_26") == _mod.POLICY
+
+
+def test_dave_prefixed_keys_classify_as_memory():
+    """ceo:dave_* are explicit Dave-tenant memory candidates."""
+    assert _mod.classify_row("ceo:dave_plain_english_preference") == _mod.MEMORY
+    assert _mod.classify_row("ceo:dave_decisions_2026_05_26") == _mod.MEMORY
+
+
+def test_byok_keys_classify_as_memory():
+    """ceo:byok_* are Dave's per-tenant API-key references."""
+    assert _mod.classify_row("ceo:byok_apollo") == _mod.MEMORY
+
+
+def test_directive_complete_keys_classify_as_memory():
+    """ceo:directive_NNNNN_complete are historical decision markers about
+    Dave's own directives → tenant memory."""
+    assert _mod.classify_row("ceo:directive_10028_complete") == _mod.MEMORY
+    assert _mod.classify_row("ceo:directive_10029_complete") == _mod.MEMORY
+
+
+def test_session_end_keys_classify_as_memory():
+    """ceo:session_end_* track Dave's own session activity."""
+    assert _mod.classify_row("ceo:session_end_2026-05-25") == _mod.MEMORY
+
+
+def test_unknown_ceo_prefixed_defaults_to_policy_conservative():
+    """Conservative default: any unrecognised ceo:* key stays in Supabase
+    (POLICY) until operator promotes it to MEMORY explicitly. Avoids
+    over-backfilling and preserves the boundary-matrix-v1 guard intent."""
+    assert _mod.classify_row("ceo:some_new_key") == _mod.POLICY
+
+
+def test_classify_rows_annotates_each_row():
+    rows = [
+        {"key": "ceo:boundary_matrix_v1", "value": {"x": 1}},
+        {"key": "ceo:dave_plain_english_preference", "value": "verbose"},
+        {"key": "architecture_version", "value": "v7"},
+    ]
+    classified = _mod.classify_rows(rows)
+    assert classified[0]["_carve"] == _mod.POLICY
+    assert classified[1]["_carve"] == _mod.MEMORY
+    assert classified[2]["_carve"] == _mod.MEMORY
+    # Original fields preserved
+    assert classified[0]["key"] == "ceo:boundary_matrix_v1"
+    assert classified[1]["value"] == "verbose"
+
+
+def test_report_counts_by_carve_with_samples():
+    rows = [
+        {"key": "ceo:boundary_matrix_v1", "_carve": _mod.POLICY},
+        {"key": "ceo:memory_abstraction_layer_v1", "_carve": _mod.POLICY},
+        {"key": "ceo:dave_x", "_carve": _mod.MEMORY},
+        {"key": "ceo:dave_y", "_carve": _mod.MEMORY},
+        {"key": "ceo:dave_z", "_carve": _mod.MEMORY},
+    ]
+    rep = _mod.report(rows, sample_size=2)
+    assert rep["policy_count"] == 2
+    assert rep["memory_count"] == 3
+    assert rep["totals"] == {_mod.POLICY: 2, _mod.MEMORY: 3}
+    assert len(rep["samples_by_carve"][_mod.POLICY]) == 2
+    assert len(rep["samples_by_carve"][_mod.MEMORY]) == 2  # sample_size cap
+
+
+def test_load_and_write_jsonl_roundtrip(tmp_path):
+    rows = [
+        {"key": "ceo:dave_x", "value": "v1"},
+        {"key": "architecture_version", "value": "v7"},
+    ]
+    src = tmp_path / "in.jsonl"
+    src.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    loaded = _mod.load_rows_from_jsonl(str(src))
+    assert loaded == rows
+    out = tmp_path / "sub" / "out.jsonl"
+    classified = _mod.classify_rows(loaded)
+    _mod.write_rows_to_jsonl(classified, str(out))
+    re_loaded = _mod.load_rows_from_jsonl(str(out))
+    assert all("_carve" in r for r in re_loaded)
+    assert re_loaded[0]["_carve"] == _mod.MEMORY  # ceo:dave_x
+    assert re_loaded[1]["_carve"] == _mod.MEMORY  # bare key
+
+
+def test_main_end_to_end_with_export(tmp_path, capsys):
+    src = tmp_path / "rows.jsonl"
+    rows = [
+        {"key": "ceo:boundary_matrix_v1", "value": {}},
+        {"key": "ceo:dave_decisions_2026_05_26", "value": {}},
+        {"key": "campaign_model", "value": "x"},
+    ]
+    src.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    out = tmp_path / "classifications.jsonl"
+    rc = _mod.main(["--input", str(src), "--export-classifications", str(out)])
+    assert rc == 0
+    captured = capsys.readouterr().out
+    rep = json.loads(captured)
+    assert rep["totals"] == {_mod.POLICY: 1, _mod.MEMORY: 2}
+    classified = _mod.load_rows_from_jsonl(str(out))
+    assert len(classified) == 3
+    assert {r["key"]: r["_carve"] for r in classified} == {
+        "ceo:boundary_matrix_v1": _mod.POLICY,
+        "ceo:dave_decisions_2026_05_26": _mod.MEMORY,
+        "campaign_model": _mod.MEMORY,
+    }


### PR DESCRIPTION
## Summary

Phase A5 piece 1a per Elliot dispatch 2026-05-26 Path (C) dual-store resolution. Implements the **carving rule** that determines which `ceo_memory` rows backfill into Hindsight (under Dave's fleet tenant via DecisionWrapper) versus which stay in Supabase as canonical policy SSOT. Honours BOTH:

- `ceo:boundary_matrix_v1` (RATIFIED-CEO 2026-05-26 CONCUR-Full Aiden+Max+Viktor) — "Cognee/Hindsight must NOT store governance policy" + policy-vs-memory test
- `ceo:dave_decisions_2026_05_26` decision_1 (ratified 2026-05-25 by Dave) — `ceo_memory` rows in the A5 backfill source list

## Scope discipline (per `feedback_split_orthogonal_scope.md`)

This PR is the **rule only**. The HTTP executor that consumes the classification + POSTs each MEMORY row to Hindsight under DecisionWrapper is **Phase A5 piece 1b** (separate PR, `Agency_OS-oq3c` follow-up, fresh-session pickup). Keeping them split:
- Lets the rule + report ship cleanly and get operator-eyeball-verified BEFORE any Hindsight data lands.
- Avoids bundling the orthogonal concerns (classification logic vs HTTP plumbing) into one PR per Dave's "non-blockers are blockers" rule applied positively.

## The carving rule (policy-vs-memory test)

> "Would this content read the same way for ANY tenant?" — Yes = POLICY (Supabase). No (tenant-specific to Dave) = MEMORY (Hindsight via DecisionWrapper under Dave's fleet tenant_id).

| Carve | Prefix / Pattern | Rationale |
|---|---|---|
| **POLICY** | `ceo:boundary_matrix*` | Meta-rule |
| **POLICY** | `ceo:memory_abstraction*` | Meta-rule |
| **POLICY** | `ceo:comm_architecture*` | Substrate architecture |
| **POLICY** | `ceo:agency_os_keiracom_separation*` | Architectural separation rule |
| **POLICY** | `ceo:rule:*`, `ceo:law*`, `ceo:governance*` | Governance laws |
| **POLICY** | `ceo:cognee_retirement_posture*` / `..._execution*` | Retirement-posture meta-state |
| **POLICY** | `ceo:atomization_architecture*` | Architecture meta-rule |
| **POLICY** | `ceo:keiracom_build_priority*`, `ceo:memory_cutover_unblock*` | Build-phase meta-rules |
| **POLICY** | `ceo:dave_migration_sequence*` | Migration meta-rule (despite the dave prefix — it's a sequence ratified for any-tenant migration) |
| **POLICY** | _conservative default for any other_ `ceo:*` | Operator promotes via manual carve list downstream |
| **MEMORY** | `ceo:dave_*` | Dave-specific preferences/decisions |
| **MEMORY** | `ceo:byok_*` | Dave's per-tenant API-key references |
| **MEMORY** | `ceo:session_end_*` | Dave's own session activity |
| **MEMORY** | `ceo:directive_NNNNN_complete` | Dave's directive history |
| **MEMORY** | bare keys (no `ceo:` prefix) | Pre-`ceo:`-convention historical BDR product operational state about Dave's situation |

## Real `ceo_memory` totals (queried via Supabase MCP)

- 920 rows total
- 569 with `ceo:` prefix (213 `ceo:directive_*_complete` + 87 `ceo:session_end_*` + 12 `ceo:dave_*` or `ceo:byok_*` + ~257 other `ceo:*`)
- 351 bare keys (pre-prefix historical)

Conservative default → ~257 unrecognised `ceo:*` keys classify as **POLICY** by design. Operator reviews per-key before piece 1b ships any data; promotions happen via manual carve list at piece 1b time.

## CLI shape

```bash
python3 scripts/migrations/ceo_memory_carving_classifier.py \
  --input <ceo_memory_rows.jsonl> \
  --export-classifications <out_path.jsonl>
```

Emits classification report (counts + samples by carve) to stdout. `--export-classifications` writes per-row `_carve`-annotated output for piece 1b consumption.

## Test plan

- [x] 11 unit tests cover: bare keys → MEMORY; meta-rule keys (8 prefixes) → POLICY; Dave-prefixed/byok/session-end/directive-complete → MEMORY; conservative default for unknown `ceo:*` → POLICY; `classify_rows` annotation preserves original fields; `report` counts + samples; JSONL roundtrip; end-to-end `main()` with `--export-classifications`.
- [x] ruff check + ruff format --check: clean.
- [ ] CI: pending push.

## Next PR (piece 1b — fresh session pickup)

- Read `ceo_memory` rows from Supabase + pipe through classifier → JSONL.
- Operator reviews the MEMORY/POLICY partition.
- For each MEMORY row: POST to Hindsight under Dave's fleet tenant bank via DecisionWrapper.
- Idempotent state file + dry-run default + refuses-to-run on missing baseline (same shape as PR #1172 Discoveries hand-migration).
- Verification: per-row round-trip recall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)