### PR TITLE
[ATLAS] feat(migration): A5 piece 1b — ceo_memory Hindsight HTTP executor

### DIFF
--- a/scripts/migrations/ceo_memory_hindsight_executor.py
+++ b/scripts/migrations/ceo_memory_hindsight_executor.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""ceo_memory_hindsight_executor.py — Phase A5 piece 1b HTTP executor.
+
+Consumes the per-row `_carve`-annotated JSONL emitted by piece 1a
+(`scripts/migrations/ceo_memory_carving_classifier.py`) and writes each
+MEMORY-tagged row to Hindsight via `DecisionWrapper.ingest` under Dave's
+fleet tenant_id. POLICY-tagged rows are left in Supabase ceo_memory as
+canonical policy SSOT per the dual-store resolution.
+
+Reuses `FleetHindsightClient` + `FleetTenantExtension` from
+`keiracom_system/fleet/hindsight/smoke_wrappers.py` (PR #1145).
+
+Idempotent: state file at `runtime/ceo_memory_executor_state.jsonl`
+tracks each completed `key`. Re-runs skip already-completed rows.
+
+Default is dry-run (counts only, no ingest). `--execute` is
+operator-gated. Refuses to run if input is empty (safety guard against
+running against a stale or unfiltered file).
+
+bd: Agency_OS-oq3c
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("ceo_memory_hindsight_executor")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from keiracom_system.fleet.hindsight.smoke_wrappers import (  # noqa: E402
+    FLEET_TENANT_ID,
+    FleetHindsightClient,
+    FleetTenantExtension,
+)
+from src.keiracom_system.memory.wrappers import DecisionWrapper  # noqa: E402
+
+MEMORY_CARVE_VALUE = "MEMORY"
+DEFAULT_STATE_FILE = Path("runtime/ceo_memory_executor_state.jsonl")
+
+
+def serialize_content(key: str, value: Any) -> str:
+    """Turn a ceo_memory (key, value) into a single-string content payload
+    Hindsight can index. Format: `<key>: <jsonified value>`. JSON keeps
+    nested structure recall-able under tag queries downstream."""
+    if isinstance(value, str):
+        value_repr = value
+    else:
+        value_repr = json.dumps(value, default=str, sort_keys=True)
+    return f"{key}: {value_repr}"
+
+
+def build_metadata(row: dict[str, Any]) -> dict[str, Any]:
+    """Metadata block keyed on ceo_memory row identity. Hindsight stores
+    metadata stringified per PR #1130 G2 finding; the wrappers handle the
+    stringification but we keep types loose here."""
+    return {
+        "ceo_memory_key": row.get("key", ""),
+        "source": "a5_piece_1b_backfill",
+        "carve": MEMORY_CARVE_VALUE,
+        "original_updated_at": row.get("updated_at", ""),
+    }
+
+
+def load_state(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    seen: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+            if entry.get("ok") and entry.get("key"):
+                seen.add(entry["key"])
+        except json.JSONDecodeError:
+            continue
+    return seen
+
+
+def append_state(path: Path, entry: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, default=str) + "\n")
+
+
+def filter_memory_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [r for r in rows if r.get("_carve") == MEMORY_CARVE_VALUE]
+
+
+def execute_one(
+    row: dict[str, Any],
+    *,
+    decision_wrapper: DecisionWrapper,
+) -> tuple[bool, str]:
+    """Ingest one MEMORY row via DecisionWrapper. Return (ok, info)."""
+    content = serialize_content(row.get("key", ""), row.get("value"))
+    metadata = build_metadata(row)
+    try:
+        resp = decision_wrapper.ingest(
+            tenant_id=FLEET_TENANT_ID,
+            content=content,
+            metadata=metadata,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return False, f"exception: {type(exc).__name__}: {exc}"
+    if isinstance(resp, dict) and "error" in resp:
+        return False, f"hindsight_error: {str(resp)[:200]}"
+    return True, str(resp)[:120]
+
+
+def run(
+    *,
+    input_path: Path,
+    execute: bool,
+    state_path: Path,
+    wrapper_factory: Any | None = None,
+) -> int:
+    """Read classified JSONL → filter to MEMORY → ingest each via wrapper."""
+    if not input_path.exists():
+        logger.error("input file not found: %s", input_path)
+        return 2
+    all_rows = [
+        json.loads(line)
+        for line in input_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    memory_rows = filter_memory_rows(all_rows)
+    if not memory_rows:
+        logger.error(
+            "no MEMORY-tagged rows in input — refusing to run (rerun piece 1a or "
+            "verify --input path)"
+        )
+        return 2
+    seen = load_state(state_path)
+    logger.info(
+        "input: total=%d memory=%d (skip %d non-MEMORY); state already-completed: %d",
+        len(all_rows),
+        len(memory_rows),
+        len(all_rows) - len(memory_rows),
+        len(seen),
+    )
+
+    if wrapper_factory is None:
+
+        def wrapper_factory():  # noqa: E306
+            client = FleetHindsightClient()
+            tenants = FleetTenantExtension()
+            return DecisionWrapper(client, tenants)
+
+    decision_wrapper = wrapper_factory() if execute else None
+    n_ok = n_fail = n_skip = 0
+    for row in memory_rows:
+        key = row.get("key", "")
+        if key in seen:
+            n_skip += 1
+            continue
+        if not execute:
+            logger.info("dry-run: would ingest %s", key)
+            continue
+        ok, info = execute_one(row, decision_wrapper=decision_wrapper)
+        if ok:
+            n_ok += 1
+            append_state(state_path, {"key": key, "ok": True, "info": info})
+        else:
+            n_fail += 1
+            append_state(state_path, {"key": key, "ok": False, "info": info})
+            logger.warning("ingest %s FAILED: %s", key, info)
+    logger.info(
+        "summary: memory_total=%d ok=%d fail=%d skip=%d (execute=%s)",
+        len(memory_rows),
+        n_ok,
+        n_fail,
+        n_skip,
+        execute,
+    )
+    return 0 if n_fail == 0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="JSONL emitted by ceo_memory_carving_classifier.py --export-classifications",
+    )
+    p.add_argument(
+        "--execute",
+        action="store_true",
+        help="write to Hindsight (default: dry-run)",
+    )
+    p.add_argument("--state-file", type=Path, default=DEFAULT_STATE_FILE)
+    p.add_argument("--log-level", default="INFO")
+    args = p.parse_args(argv)
+    logging.basicConfig(level=args.log_level, format="%(asctime)s %(levelname)s %(message)s")
+    return run(input_path=args.input, execute=args.execute, state_path=args.state_file)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/migrations/test_ceo_memory_hindsight_executor.py
+++ b/tests/scripts/migrations/test_ceo_memory_hindsight_executor.py
@@ -1,0 +1,217 @@
+"""Tests for Phase A5 piece 1b — ceo_memory Hindsight HTTP executor.
+
+Covers the pure-logic surface (filtering, state file roundtrip, dry-run vs
+execute control, refuses-to-run on empty MEMORY set) + the DecisionWrapper
+call shape via a stub wrapper. End-to-end HTTP path is exercised by
+operator dry-run before --execute, not re-mocked here.
+
+bd: Agency_OS-oq3c
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "migrations"))
+
+_mod = importlib.import_module("ceo_memory_hindsight_executor")
+
+
+class _SpyWrapper:
+    """Stub DecisionWrapper that records ingest calls + returns a fake resp."""
+
+    def __init__(self, *, fail_keys: set[str] | None = None) -> None:
+        self.calls: list[dict] = []
+        self.fail_keys = fail_keys or set()
+
+    def ingest(self, *, tenant_id: str, content: str, metadata: dict) -> dict:
+        self.calls.append({"tenant_id": tenant_id, "content": content, "metadata": metadata})
+        for key in self.fail_keys:
+            if key in content:
+                return {"error": "simulated-failure"}
+        return {"id": f"hindsight-{len(self.calls)}"}
+
+
+def _write_jsonl(tmp_path: Path, name: str, rows: list[dict]) -> Path:
+    path = tmp_path / name
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return path
+
+
+def test_filter_memory_rows_drops_policy_rows():
+    rows = [
+        {"key": "ceo:boundary_matrix_v1", "_carve": "POLICY"},
+        {"key": "ceo:dave_x", "_carve": "MEMORY"},
+        {"key": "ceo:memory_abstraction_v1", "_carve": "POLICY"},
+        {"key": "ceo:dave_y", "_carve": "MEMORY"},
+    ]
+    out = _mod.filter_memory_rows(rows)
+    assert len(out) == 2
+    assert {r["key"] for r in out} == {"ceo:dave_x", "ceo:dave_y"}
+
+
+def test_serialize_content_handles_string_and_dict():
+    assert _mod.serialize_content("k", "v") == "k: v"
+    out = _mod.serialize_content("k", {"a": 1, "b": [2, 3]})
+    assert out.startswith("k: ")
+    assert '"a": 1' in out
+    assert '"b": [2, 3]' in out
+
+
+def test_build_metadata_carries_key_source_carve_and_updated_at():
+    row = {"key": "ceo:dave_x", "value": "v", "updated_at": "2026-05-26T10:00:00Z"}
+    meta = _mod.build_metadata(row)
+    assert meta["ceo_memory_key"] == "ceo:dave_x"
+    assert meta["source"] == "a5_piece_1b_backfill"
+    assert meta["carve"] == "MEMORY"
+    assert meta["original_updated_at"] == "2026-05-26T10:00:00Z"
+
+
+def test_state_roundtrip_skips_seen_keys(tmp_path: Path):
+    state = tmp_path / "state.jsonl"
+    assert _mod.load_state(state) == set()
+    _mod.append_state(state, {"key": "ceo:dave_x", "ok": True, "info": "ok"})
+    _mod.append_state(state, {"key": "ceo:dave_y", "ok": False, "info": "rc=500"})
+    _mod.append_state(state, {"key": "ceo:dave_z", "ok": True, "info": "ok"})
+    assert _mod.load_state(state) == {"ceo:dave_x", "ceo:dave_z"}
+
+
+def test_execute_one_ok_path_returns_true():
+    wrapper = _SpyWrapper()
+    row = {"key": "ceo:dave_x", "value": "test", "updated_at": "2026-05-26T10:00:00Z"}
+    ok, info = _mod.execute_one(row, decision_wrapper=wrapper)
+    assert ok is True
+    assert "hindsight-1" in info
+    assert len(wrapper.calls) == 1
+    call = wrapper.calls[0]
+    assert call["tenant_id"] == _mod.FLEET_TENANT_ID
+    assert "ceo:dave_x" in call["content"]
+    assert call["metadata"]["ceo_memory_key"] == "ceo:dave_x"
+
+
+def test_execute_one_error_response_returns_false():
+    wrapper = _SpyWrapper(fail_keys={"ceo:dave_x"})
+    row = {"key": "ceo:dave_x", "value": "test"}
+    ok, info = _mod.execute_one(row, decision_wrapper=wrapper)
+    assert ok is False
+    assert "hindsight_error" in info
+
+
+def test_execute_one_exception_returns_false():
+    class _ThrowingWrapper:
+        def ingest(self, **kwargs):
+            raise ConnectionError("boom")
+
+    row = {"key": "ceo:dave_x", "value": "test"}
+    ok, info = _mod.execute_one(row, decision_wrapper=_ThrowingWrapper())
+    assert ok is False
+    assert "ConnectionError" in info
+
+
+def test_run_aborts_when_input_file_missing(tmp_path: Path):
+    rc = _mod.run(
+        input_path=tmp_path / "no-such.jsonl",
+        execute=True,
+        state_path=tmp_path / "s.jsonl",
+    )
+    assert rc == 2
+
+
+def test_run_aborts_when_no_memory_rows(tmp_path: Path):
+    src = _write_jsonl(
+        tmp_path,
+        "in.jsonl",
+        [{"key": "ceo:boundary_matrix_v1", "_carve": "POLICY"}],
+    )
+    rc = _mod.run(input_path=src, execute=True, state_path=tmp_path / "s.jsonl")
+    assert rc == 2
+
+
+def test_run_dry_run_does_not_call_wrapper(tmp_path: Path):
+    src = _write_jsonl(
+        tmp_path,
+        "in.jsonl",
+        [
+            {"key": "ceo:dave_x", "value": "v", "_carve": "MEMORY"},
+            {"key": "ceo:boundary_matrix_v1", "_carve": "POLICY"},
+        ],
+    )
+    wrapper = _SpyWrapper()
+    rc = _mod.run(
+        input_path=src,
+        execute=False,
+        state_path=tmp_path / "s.jsonl",
+        wrapper_factory=lambda: wrapper,
+    )
+    assert rc == 0
+    assert wrapper.calls == []  # dry-run skips ingest
+
+
+def test_run_execute_ingests_each_memory_row_and_writes_state(tmp_path: Path):
+    src = _write_jsonl(
+        tmp_path,
+        "in.jsonl",
+        [
+            {"key": "ceo:dave_x", "value": "vx", "_carve": "MEMORY"},
+            {"key": "ceo:boundary_matrix_v1", "_carve": "POLICY"},
+            {"key": "ceo:dave_y", "value": "vy", "_carve": "MEMORY"},
+        ],
+    )
+    wrapper = _SpyWrapper()
+    state = tmp_path / "s.jsonl"
+    rc = _mod.run(
+        input_path=src,
+        execute=True,
+        state_path=state,
+        wrapper_factory=lambda: wrapper,
+    )
+    assert rc == 0
+    assert len(wrapper.calls) == 2
+    assert {c["metadata"]["ceo_memory_key"] for c in wrapper.calls} == {"ceo:dave_x", "ceo:dave_y"}
+    assert _mod.load_state(state) == {"ceo:dave_x", "ceo:dave_y"}
+
+
+def test_run_execute_returns_one_on_any_failure(tmp_path: Path):
+    src = _write_jsonl(
+        tmp_path,
+        "in.jsonl",
+        [
+            {"key": "ceo:dave_x", "value": "vx", "_carve": "MEMORY"},
+            {"key": "ceo:dave_y", "value": "vy", "_carve": "MEMORY"},
+        ],
+    )
+    wrapper = _SpyWrapper(fail_keys={"ceo:dave_y"})
+    rc = _mod.run(
+        input_path=src,
+        execute=True,
+        state_path=tmp_path / "s.jsonl",
+        wrapper_factory=lambda: wrapper,
+    )
+    assert rc == 1
+
+
+def test_run_skips_already_completed_keys_on_rerun(tmp_path: Path):
+    src = _write_jsonl(
+        tmp_path,
+        "in.jsonl",
+        [
+            {"key": "ceo:dave_x", "value": "vx", "_carve": "MEMORY"},
+            {"key": "ceo:dave_y", "value": "vy", "_carve": "MEMORY"},
+        ],
+    )
+    state = tmp_path / "s.jsonl"
+    _mod.append_state(state, {"key": "ceo:dave_x", "ok": True, "info": "prev"})
+    wrapper = _SpyWrapper()
+    rc = _mod.run(
+        input_path=src,
+        execute=True,
+        state_path=state,
+        wrapper_factory=lambda: wrapper,
+    )
+    assert rc == 0
+    assert len(wrapper.calls) == 1  # only dave_y; dave_x already in state
+    assert wrapper.calls[0]["metadata"]["ceo_memory_key"] == "ceo:dave_y"


### PR DESCRIPTION
## Summary

Phase A5 piece 1b — HTTP executor that consumes the carving classifier output from PR #1182 (piece 1a) and writes each MEMORY-tagged `ceo_memory` row into Hindsight via `DecisionWrapper.ingest` under Dave's fleet `tenant_id`. POLICY-tagged rows stay in Supabase as canonical policy SSOT per Path (C) dual-store resolution.

## Wiring (reuses PR #1145 surface)

- **`FleetHindsightClient`** — implements the `HindsightClient` Protocol against `http://localhost:8889` (Phase A1 fleet Hindsight)
- **`FleetTenantExtension`** — maps Dave's fleet tenant UUID `00000000-0000-0000-0000-000000000001` → bank_id
- **`DecisionWrapper(client, tenants)`** — from `src/keiracom_system/memory/wrappers/` (PR #1134)
- **`FLEET_TENANT_ID`** — Dave's fleet tenant identity

The executor is a thin orchestration layer over these primitives — it does not introduce new HTTP plumbing.

## Per-row payload shape

For each MEMORY row:

```python
DecisionWrapper.ingest(
    tenant_id=FLEET_TENANT_ID,
    content=f"{row.key}: {jsonified value}",
    metadata={
        "ceo_memory_key": row.key,
        "source": "a5_piece_1b_backfill",
        "carve": "MEMORY",
        "original_updated_at": row.updated_at,
    },
)
```

Single-string content keeps Hindsight indexing simple; `ceo_memory_key` in metadata makes per-key recall trivial downstream.

## Idempotency + safety

- **State file** at `runtime/ceo_memory_executor_state.jsonl` tracks each completed `key`. Re-runs skip already-completed rows. Safe to abort and resume.
- **Default dry-run.** `--execute` is operator-gated.
- **Refuses to run** (rc=2) if input file missing OR if input has zero MEMORY rows — catches stale/unfiltered input pointed at the wrong path.
- **Per-row exception handling** — a single transient Hindsight blip is logged + recorded in the state file; doesn't abort the whole batch. Final rc=1 if any row failed, rc=0 on clean.

## CLI

```bash
python3 scripts/migrations/ceo_memory_hindsight_executor.py \
  --input <classifications.jsonl from piece 1a> \
  --execute
```

## Chain dependency

This PR's input is the JSONL emitted by **PR #1182 (piece 1a)** `--export-classifications`. PR #1182 lands first; operator pipes Supabase `ceo_memory` → piece 1a `--export-classifications` → piece 1b dry-run → operator review → piece 1b `--execute`.

## Test plan

- [x] **13 unit tests** cover: `filter_memory_rows` drops POLICY; `serialize_content` handles string + dict + nested JSON; `build_metadata` carries key + source + carve + original_updated_at; `load_state` + `append_state` roundtrip; `execute_one` ok/error/exception paths; `run` aborts on missing-input or empty-memory-set; dry-run skips wrapper calls; execute ingests each MEMORY row + writes state; rc=1 on any failure; already-completed keys skipped on rerun.
- [x] Tests use a `_SpyWrapper` stub for `DecisionWrapper` — matches the `indexer_base_hindsight_mirror` test pattern (no running Hindsight needed for unit-tests).
- [x] **Ruff:** check + format --check both clean.
- [ ] CI: pending push.

## Operator runbook (post-PR #1182 + this PR merge)

```bash
# 1. Export ceo_memory to JSONL (operator-side via Supabase MCP or psql).
psql -c "SELECT json_agg(t) FROM (SELECT key, value, updated_at FROM ceo_memory) t" \
  | python3 -c "import json,sys; [print(json.dumps(r)) for r in json.load(sys.stdin)[0]]" \
  > /tmp/ceo_memory_rows.jsonl

# 2. Carving classifier (piece 1a)
python3 scripts/migrations/ceo_memory_carving_classifier.py \
  --input /tmp/ceo_memory_rows.jsonl \
  --export-classifications /tmp/ceo_memory_classified.jsonl

# 3. Eyeball the partition (POLICY count + MEMORY count + samples)
# Verify the report makes sense per the policy-vs-memory test.

# 4. Dry-run executor (piece 1b)
python3 scripts/migrations/ceo_memory_hindsight_executor.py \
  --input /tmp/ceo_memory_classified.jsonl

# 5. Execute (idempotent + resumable)
python3 scripts/migrations/ceo_memory_hindsight_executor.py \
  --input /tmp/ceo_memory_classified.jsonl \
  --execute
```

## Closes A5 piece 1 surface

PR #1182 (piece 1a) + this PR (piece 1b) together complete **A5 piece 1** (`Agency_OS-oq3c`). Remaining A5 surface (sibling bd issues, fresh-session-pickup):
- `Agency_OS-inhl` — A5 piece 2 — pre-Hindsight snapshot backfill
- `Agency_OS-ushm` — A5 piece 3 — Drive Manual backfill
- `Agency_OS-ygxz` — A5 piece 4 — Slack `#ceo` archive backfill
- `Agency_OS-c23f` — A5 piece 5 — smoke recall validation across all 4 sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)