### PR TITLE
[ORION] feat(atomization): Week 3 readiness — composition metering interpretation report (Agency_OS-atomization-pilot-week3-prep)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,24 @@ jobs:
       - name: No raw redis/valkey calls outside ValkeyClient
         run: ./scripts/ci/check_no_raw_valkey_outside_client.sh
 
+  # ============================================
+  # Guard: Atomization pilot atom-store discipline
+  # ============================================
+  # Source: docs/architecture/design/atomization_pilot_schema_lock_proposal.md §6
+  # (PR #1178 merged 2026-05-26). All keiracom_atoms / supersession_edges /
+  # atomizer_jobs access MUST go through AtomStore (tenant-prefix guard +
+  # frozen vocabulary checks). Complements the AtomStore._enforce_tenant_match
+  # runtime guard (defence-in-depth pattern; mirrors A7 CB-10 + BMV1 guard b).
+  atom-store-discipline-guards:
+    name: Atom Store Discipline Guards (Atomization Pilot)
+    runs-on: ubuntu-latest
+    needs: backend-lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: No raw atom-store SQL outside atomization module
+        run: ./scripts/ci/check_no_raw_atom_store_outside_module.sh
+
   backend-typecheck:
     name: Backend Type Check (MyPy)
     runs-on: ubuntu-latest

--- a/scripts/ci/check_no_raw_atom_store_outside_module.sh
+++ b/scripts/ci/check_no_raw_atom_store_outside_module.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Atomization pilot Week 1 guard — raw atom-store SQL forbidden outside the
+# canonical module. All keiracom_atoms / keiracom_atom_supersession_edges /
+# keiracom_atomizer_jobs access MUST go through AtomStore (tenant-prefix
+# guard + DI for testability + frozen vocabulary checks).
+#
+# Mirrors:
+#   - boundary-matrix-v1 guard (b) (PR #1169) — direct DB drivers outside MAL
+#   - A7 CB-10 cache-discipline (PR #1173) — raw redis outside cache/
+#
+# Scope: src/keiracom_system/ ONLY. Legacy Agency_OS BDR surface (src/pipeline/
+# etc.) does not touch keiracom_atoms — pattern would be 0 hits anyway.
+#
+# Exempt path: src/keiracom_system/atomization/ — the canonical module owner.
+#
+# Pattern: SQL keywords referencing the 3 atomization tables. Matches both
+# direct .execute("INSERT INTO keiracom_atoms...") and similar SELECT/UPDATE/
+# DELETE. The Python-source grep regex catches the verb + table-name pair on
+# the same line (the common Python query string shape).
+
+set -euo pipefail
+
+SCOPE="src/keiracom_system"
+
+if [ ! -d "$SCOPE" ]; then
+  echo "OK (atom-store-discipline): $SCOPE not present — guard inactive."
+  exit 0
+fi
+
+# Capture SQL verb + atomization table name in the same line. Tolerates leading
+# quotes and indentation. Both keiracom_atoms (base) and the _supersession_edges
+# + _atomizer_jobs suffixes are caught — they're all part of the atom-store API.
+PATTERN='(INSERT[[:space:]]+INTO[[:space:]]+keiracom_atom|UPDATE[[:space:]]+keiracom_atom|DELETE[[:space:]]+FROM[[:space:]]+keiracom_atom|FROM[[:space:]]+keiracom_atom)'
+
+raw=$(grep -rnE --include='*.py' "$PATTERN" "$SCOPE" 2>/dev/null || true)
+
+# Exempt the atomization module itself.
+hits=$(printf '%s\n' "$raw" \
+  | grep -v -E '^src/keiracom_system/atomization/' \
+  | grep -v -E '^[[:space:]]*$' || true)
+
+if [ -n "$hits" ]; then
+  echo "FAIL (atom-store-discipline): raw SQL against atomization tables found"
+  echo "outside src/keiracom_system/atomization/. All atom-store access MUST go"
+  echo "through AtomStore — the tenant-prefix guard + frozen vocabulary checks"
+  echo "depend on the module boundary. Route the call through AtomStore."
+  echo ""
+  echo "See docs/architecture/design/atomization_pilot_schema_lock_proposal.md §6."
+  echo ""
+  echo "Offending lines:"
+  echo "$hits"
+  exit 1
+fi
+
+echo "OK (atom-store-discipline): no raw atom-store SQL outside atomization module."
+exit 0

--- a/src/keiracom_system/atomization/__init__.py
+++ b/src/keiracom_system/atomization/__init__.py
@@ -1,0 +1,61 @@
+"""Keiracom atomization — Phase 10029 pilot Week 1 implementation.
+
+Per ceo:atomization_architecture_v1 (RATIFIED-CEO 2026-05-26T11:25:00Z) +
+PR #1178 schema-lock proposal. Implements the 5-component architecture:
+
+  1. Atomizer       — src.keiracom_system.atomization.atomizer
+  2. Atom Store     — src.keiracom_system.atomization.atom_store
+  3. MAL Retriever  — Week 2 dispatch (out of scope)
+  4. Composer       — Week 2 dispatch (out of scope)
+  5. Endpoint Tx    — Week 2-3 dispatch (out of scope)
+
+Feature flag (default OFF): KEIRACOM_ATOMIZER_ENABLED.
+
+Public surface re-exported for callers.
+"""
+
+from src.keiracom_system.atomization.atom_store import (
+    AtomStore,
+    AtomStoreError,
+)
+from src.keiracom_system.atomization.atomizer import (
+    Atomizer,
+    AtomizerError,
+    AtomizerJob,
+)
+from src.keiracom_system.atomization.schema import (
+    SCHEMA_VERSION,
+    VALID_COMPOSITION_TAGS,
+    VALID_RELATIONSHIP_TYPES,
+    VALID_SOURCE_KINDS,
+    VALID_STATES,
+    VALID_TRIGGER_KINDS,
+    AtomV1,
+    SupersessionEdgeV1,
+    is_valid_composition_tag,
+)
+from src.keiracom_system.atomization.verifier import (
+    Verifier,
+    VerifierError,
+    VerifierFlag,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "VALID_COMPOSITION_TAGS",
+    "VALID_RELATIONSHIP_TYPES",
+    "VALID_SOURCE_KINDS",
+    "VALID_STATES",
+    "VALID_TRIGGER_KINDS",
+    "AtomStore",
+    "AtomStoreError",
+    "AtomV1",
+    "Atomizer",
+    "AtomizerError",
+    "AtomizerJob",
+    "SupersessionEdgeV1",
+    "Verifier",
+    "VerifierError",
+    "VerifierFlag",
+    "is_valid_composition_tag",
+]

--- a/src/keiracom_system/atomization/atom_store.py
+++ b/src/keiracom_system/atomization/atom_store.py
@@ -1,0 +1,250 @@
+"""AtomStore — tenant-scoped Postgres+pgvector access for keiracom_atoms.
+
+Per-tenant store with read+write tenant-prefix guards. Mirrors the
+ValkeyClient defence-in-depth pattern from PR #1173:
+  - Constructed bound to a single tenant_id
+  - Every query filters by self._tenant_id; no caller override possible
+  - Cross-tenant reads raise AtomStoreError at the boundary
+
+Per boundary-matrix-v1 guard (b) (PR #1169) the cache module exempts
+src/keiracom_system/control_plane/ but NOT atomization/. So this module
+uses _DBProtocol DI (no asyncpg/psycopg import) — caller injects a real
+connection. Same pattern as TenantBudgetPolicy.from_db (PR #1173).
+
+Embedding is computed via TEIClient (PR #1133) — also injected so unit
+tests don't need a live TEI sidecar.
+
+CI guard scripts/ci/check_no_raw_atom_store_outside_module.sh forbids raw
+SQL against keiracom_atoms outside this module (mirrors A7 CB-10 pattern).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Protocol
+from uuid import UUID
+
+from src.keiracom_system.atomization.schema import (
+    AtomV1,
+    SupersessionEdgeV1,
+)
+from src.keiracom_system.embeddings.tei_client import TEIClient
+
+log = logging.getLogger(__name__)
+
+
+class _DBProtocol(Protocol):
+    """Subset of a DB cursor/connection we depend on for AtomStore.
+
+    Mirrors PR #1173 TenantBudgetPolicy._DBProtocol pattern — lets unit tests
+    inject a fake without importing asyncpg/psycopg inside the atomization
+    module (BMV1 guard b only exempts memory/ + control_plane/).
+    """
+
+    def execute(self, query: str, *params: Any) -> Any: ...
+    def fetchone(self) -> Any: ...
+    def fetchall(self) -> Any: ...
+
+
+class AtomStoreError(RuntimeError):
+    """Raised on any atom-store side or tenant-isolation violation."""
+
+
+class AtomStore:
+    """Per-tenant atom store.
+
+    Bound to a single tenant_id at construction. Cross-tenant access raises
+    AtomStoreError via the read/write guards.
+    """
+
+    def __init__(
+        self,
+        *,
+        db: _DBProtocol,
+        tenant_id: str | UUID,
+        embedder: TEIClient,
+    ):
+        if not tenant_id:
+            raise AtomStoreError("tenant_id is required (cross-tenant isolation invariant)")
+        self._db = db
+        self._tenant_id = str(tenant_id)
+        self._embedder = embedder
+
+    @property
+    def tenant_id(self) -> str:
+        return self._tenant_id
+
+    def _enforce_tenant_match(self, query_tenant_id: str | UUID) -> None:
+        """Reject any read/write that names a different tenant_id than the
+        store's bound tenant. Defence-in-depth read/write boundary guard."""
+        qtid = str(query_tenant_id)
+        if qtid != self._tenant_id:
+            raise AtomStoreError(
+                f"tenant_id mismatch: store bound to {self._tenant_id!r} but "
+                f"caller passed {qtid!r} — cross-tenant access forbidden"
+            )
+
+    def insert_atom(self, atom: AtomV1) -> UUID:
+        """Insert one atom into keiracom_atoms. Returns its atom_id.
+
+        Atom MUST be constructed with tenant_id matching this store's
+        tenant_id (enforced at the boundary).
+        """
+        self._enforce_tenant_match(atom.tenant_id)
+        # Compute embedding from content if not pre-supplied (defensive — atoms
+        # arriving from atomizer carry embeddings; tests may construct without).
+        embedding = atom.content_embedding or self._embedder.embed([atom.content])[0]
+        if len(embedding) != self._embedder.dimension:
+            raise AtomStoreError(
+                f"embedding dimension mismatch: got {len(embedding)}, "
+                f"expected {self._embedder.dimension}"
+            )
+        self._db.execute(
+            "INSERT INTO keiracom_atoms ("
+            "atom_id, tenant_id, trigger_condition, content, anti_pattern, "
+            "example, provenance, composition_tags, content_embedding, "
+            "schema_version, state"
+            ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "RETURNING atom_id",
+            str(atom.atom_id),
+            self._tenant_id,
+            json.dumps(atom.trigger_condition),
+            atom.content,
+            atom.anti_pattern,
+            atom.example,
+            json.dumps(atom.provenance),
+            json.dumps(atom.composition_tags),
+            self._embedding_to_pgvector(embedding),
+            atom.schema_version,
+            atom.state,
+        )
+        row = self._db.fetchone()
+        if row is None:
+            raise AtomStoreError("insert_atom: no atom_id returned from INSERT")
+        return UUID(str(row[0]))
+
+    def get_atom(self, atom_id: UUID) -> AtomV1 | None:
+        """Fetch one atom by atom_id, scoped to this store's tenant.
+
+        Returns None if not found OR atom exists but belongs to a different
+        tenant (collapsed for non-leak — caller cannot distinguish).
+        """
+        self._db.execute(
+            "SELECT atom_id, tenant_id, trigger_condition, content, "
+            "anti_pattern, example, provenance, composition_tags, "
+            "schema_version, state "
+            "FROM keiracom_atoms WHERE atom_id = %s AND tenant_id = %s",
+            str(atom_id),
+            self._tenant_id,
+        )
+        row = self._db.fetchone()
+        if row is None:
+            return None
+        return self._row_to_atom(row)
+
+    def retrieve_top_k(self, query_text: str, top_k: int = 10) -> list[AtomV1]:
+        """Cosine-similarity nearest atoms in this tenant's namespace.
+
+        Uses pgvector HNSW index on content_embedding. State filter applies —
+        only active atoms returned (superseded and cold_archive excluded).
+        """
+        if top_k <= 0:
+            raise AtomStoreError("top_k must be > 0")
+        query_embedding = self._embedder.embed([query_text])[0]
+        self._db.execute(
+            "SELECT atom_id, tenant_id, trigger_condition, content, "
+            "anti_pattern, example, provenance, composition_tags, "
+            "schema_version, state "
+            "FROM keiracom_atoms "
+            "WHERE tenant_id = %s AND state = 'active' "
+            "ORDER BY content_embedding <=> %s "
+            "LIMIT %s",
+            self._tenant_id,
+            self._embedding_to_pgvector(query_embedding),
+            int(top_k),
+        )
+        rows = self._db.fetchall() or []
+        return [self._row_to_atom(r) for r in rows]
+
+    def transition_state(self, atom_id: UUID, new_state: str) -> None:
+        """Update an atom's state column. Must be from VALID_STATES."""
+        from src.keiracom_system.atomization.schema import VALID_STATES
+
+        if new_state not in VALID_STATES:
+            raise AtomStoreError(f"new_state {new_state!r} not in {sorted(VALID_STATES)}")
+        self._db.execute(
+            "UPDATE keiracom_atoms SET state = %s WHERE atom_id = %s AND tenant_id = %s",
+            new_state,
+            str(atom_id),
+            self._tenant_id,
+        )
+
+    def insert_supersession_edge(self, edge: SupersessionEdgeV1) -> UUID:
+        """Insert a supersession edge. Both predecessor + successor MUST be
+        atoms owned by this store's tenant — enforced at boundary."""
+        self._enforce_tenant_match(edge.tenant_id)
+        # Defence-in-depth: verify both endpoint atoms exist + belong to this
+        # tenant before inserting the edge.
+        if self.get_atom(edge.predecessor_atom) is None:
+            raise AtomStoreError(
+                f"predecessor_atom {edge.predecessor_atom} not found in tenant {self._tenant_id}"
+            )
+        if self.get_atom(edge.successor_atom) is None:
+            raise AtomStoreError(
+                f"successor_atom {edge.successor_atom} not found in tenant {self._tenant_id}"
+            )
+        self._db.execute(
+            "INSERT INTO keiracom_atom_supersession_edges ("
+            "edge_id, tenant_id, predecessor_atom, successor_atom, "
+            "relationship_type, confidence"
+            ") VALUES (%s, %s, %s, %s, %s, %s) RETURNING edge_id",
+            str(edge.edge_id),
+            self._tenant_id,
+            str(edge.predecessor_atom),
+            str(edge.successor_atom),
+            edge.relationship_type,
+            float(edge.confidence),
+        )
+        row = self._db.fetchone()
+        if row is None:
+            raise AtomStoreError("insert_supersession_edge: no edge_id returned")
+        return UUID(str(row[0]))
+
+    # ------------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------------
+
+    @staticmethod
+    def _embedding_to_pgvector(embedding: list[float]) -> str:
+        """pgvector wire format: '[0.1, 0.2, ...]' string with brackets."""
+        return "[" + ",".join(repr(float(x)) for x in embedding) + "]"
+
+    @staticmethod
+    def _row_to_atom(row: Any) -> AtomV1:
+        """Build an AtomV1 from a DB row tuple in canonical column order."""
+        atom_id, tenant_id, trigger_condition, content, anti_pattern = row[:5]
+        example, provenance, composition_tags, schema_version, state = row[5:]
+        return AtomV1(
+            atom_id=UUID(str(atom_id)),
+            tenant_id=UUID(str(tenant_id)),
+            trigger_condition=_parse_jsonb(trigger_condition),
+            content=content,
+            anti_pattern=anti_pattern,
+            example=example,
+            provenance=_parse_jsonb(provenance),
+            composition_tags=_parse_jsonb(composition_tags) if composition_tags else {},
+            content_embedding=[],  # Not selected back; would re-embed on retrieve.
+            schema_version=int(schema_version),
+            state=state,
+        )
+
+
+def _parse_jsonb(value: Any) -> dict[str, Any]:
+    """Postgres JSONB columns may come back as either dict (psycopg adapts) or
+    str (raw); tolerate both."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        return json.loads(value)
+    return {}

--- a/src/keiracom_system/atomization/atomizer.py
+++ b/src/keiracom_system/atomization/atomizer.py
@@ -1,0 +1,354 @@
+"""Atomizer service — produces AtomV1 instances from source text via LLM.
+
+Per dispatch hard constraints:
+  - Gemini 2.5 Flash for the Dave pilot
+  - Temperature = 0
+  - Structured output (JSON schema-constrained)
+  - REJECTS free-text triggers via the VALID_TRIGGER_KINDS whitelist
+  - Feature flag: KEIRACOM_ATOMIZER_ENABLED=on (default off)
+
+Caller injects an LLMClient (production = LiteLLMGeminiClient; tests = fake).
+Caller also injects an AtomStore to persist the produced atoms + an embedder
+(TEIClient) for computing content_embedding.
+
+Job audit row written to keiracom_atomizer_jobs BEFORE and AFTER the LLM call
+for idempotency (re-runs of the same source_ref produce a new job row).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+from uuid import UUID, uuid4
+
+from src.keiracom_system.atomization.atom_store import AtomStore, AtomStoreError
+from src.keiracom_system.atomization.llm_client import (
+    ATOMIZER_TEMPERATURE,
+    DEFAULT_ATOMIZER_MODEL,
+    LLMClient,
+    LLMClientError,
+)
+from src.keiracom_system.atomization.schema import (
+    VALID_SOURCE_KINDS,
+    VALID_TRIGGER_KINDS,
+    AtomV1,
+)
+
+log = logging.getLogger(__name__)
+
+# Feature flag — atomizer no-op until ops explicitly enables.
+FEATURE_FLAG_ENV: str = "KEIRACOM_ATOMIZER_ENABLED"
+
+
+def is_atomizer_enabled() -> bool:
+    """Read the feature flag from env. Default OFF."""
+    return os.environ.get(FEATURE_FLAG_ENV, "off").lower() == "on"
+
+
+class AtomizerError(RuntimeError):
+    """Raised on atomizer-side errors that should HALT the job."""
+
+
+class _JobLogger(Protocol):
+    """Subset of DB calls the atomizer needs for keiracom_atomizer_jobs."""
+
+    def execute(self, query: str, *params: Any) -> Any: ...
+    def fetchone(self) -> Any: ...
+
+
+@dataclass(frozen=True, kw_only=True)
+class AtomizerJob:
+    """Audit row for one atomizer pass — mirrors keiracom_atomizer_jobs.
+
+    Created BEFORE the LLM call (status=pending) so a crash leaves the row
+    visible. Updated to atomizer_done after structured output + atom inserts.
+    """
+
+    job_id: UUID
+    tenant_id: UUID
+    source_ref: str
+    source_kind: str
+    atomizer_model: str
+    atomizer_temp: float
+    atomizer_tokens_in: int = 0
+    atomizer_tokens_out: int = 0
+    atomizer_latency_ms: int = 0
+    atoms_produced: int = 0
+    atom_ids: list[UUID] = field(default_factory=list)
+    status: str = "pending"
+
+    def __post_init__(self) -> None:
+        if self.source_kind not in VALID_SOURCE_KINDS:
+            raise AtomizerError(
+                f"source_kind {self.source_kind!r} not in {sorted(VALID_SOURCE_KINDS)}"
+            )
+
+
+# JSON schema that the atomizer prompts Gemini Flash to return.
+# Restricts trigger_condition.kind to the frozen vocabulary — Gemini's
+# structured output guarantees the response will match (Gemini enforces
+# enum constraints on its side, refusing to emit values outside the set).
+ATOMS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "name": "AtomsResponse",
+    "schema": {
+        "type": "object",
+        "required": ["atoms"],
+        "properties": {
+            "atoms": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": [
+                        "trigger_condition",
+                        "content",
+                        "provenance",
+                    ],
+                    "properties": {
+                        "trigger_condition": {
+                            "type": "object",
+                            "required": ["kind", "params"],
+                            "properties": {
+                                "kind": {
+                                    "type": "string",
+                                    "enum": sorted(VALID_TRIGGER_KINDS),
+                                },
+                                "params": {"type": "object"},
+                            },
+                        },
+                        "content": {"type": "string"},
+                        "anti_pattern": {"type": ["string", "null"]},
+                        "example": {"type": ["string", "null"]},
+                        "provenance": {
+                            "type": "object",
+                            "required": [
+                                "source",
+                                "freshness",
+                                "confidence",
+                                "last_validated",
+                            ],
+                            "properties": {
+                                "source": {"type": "string"},
+                                "freshness": {"type": "string"},
+                                "confidence": {"type": "number"},
+                                "last_validated": {"type": "string"},
+                            },
+                        },
+                        "composition_tags": {"type": "object"},
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+_SYSTEM_PROMPT = (
+    "You are an atomizer for a knowledge base. Convert the user-provided "
+    "source text into a list of atoms following the atom_schema_v1 contract. "
+    "RULES:\n"
+    "1. Each atom MUST have a structured trigger_condition with a 'kind' from "
+    f"the allowed set: {sorted(VALID_TRIGGER_KINDS)}. NEVER emit free-text "
+    "in trigger_condition.\n"
+    "2. content is a clear, self-contained statement of one piece of "
+    "knowledge.\n"
+    "3. anti_pattern (optional) names a common wrong approach.\n"
+    "4. example (optional) is a brief concrete illustration.\n"
+    "5. provenance MUST include source, freshness (ISO8601), confidence "
+    "(float 0..1), last_validated (ISO8601).\n"
+    "6. If the source text expresses multiple distinct pieces of knowledge, "
+    "emit multiple atoms rather than one bloated atom.\n"
+    "Return ONLY the JSON matching the response schema."
+)
+
+
+class Atomizer:
+    """Produce AtomV1 instances + persist them via AtomStore.
+
+    Owns the LLM call + job-row bookkeeping. Verifier is a separate component
+    called on the produced atoms (see verifier.py).
+    """
+
+    def __init__(
+        self,
+        *,
+        llm: LLMClient,
+        store: AtomStore,
+        job_db: _JobLogger,
+        model: str = DEFAULT_ATOMIZER_MODEL,
+        metric_emitter: Any = None,
+    ):
+        self._llm = llm
+        self._store = store
+        self._job_db = job_db
+        self._model = model
+        self._metric_emitter = metric_emitter
+
+    def atomize(
+        self,
+        *,
+        source_ref: str,
+        source_kind: str,
+        source_text: str,
+    ) -> AtomizerJob:
+        """Atomize a source document. Returns the job audit row.
+
+        Caller checks is_atomizer_enabled() — this method does NOT — because
+        we want test paths to drive the atomizer directly regardless of env.
+        """
+        if source_kind not in VALID_SOURCE_KINDS:
+            raise AtomizerError(f"source_kind {source_kind!r} not in {sorted(VALID_SOURCE_KINDS)}")
+        if not source_text:
+            raise AtomizerError("source_text must be non-empty")
+
+        job_id = uuid4()
+        # Insert pending job row BEFORE the LLM call (idempotency + crash-visibility).
+        self._job_db.execute(
+            "INSERT INTO keiracom_atomizer_jobs ("
+            "job_id, tenant_id, source_ref, source_kind, atomizer_model, "
+            "atomizer_temp, status"
+            ") VALUES (%s, %s, %s, %s, %s, %s, 'pending')",
+            str(job_id),
+            self._store.tenant_id,
+            source_ref,
+            source_kind,
+            self._model,
+            ATOMIZER_TEMPERATURE,
+        )
+
+        messages = [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": source_text},
+        ]
+        start = time.time()
+        try:
+            response = self._llm.call_structured(
+                model=self._model,
+                messages=messages,
+                response_schema=ATOMS_RESPONSE_SCHEMA,
+                temperature=ATOMIZER_TEMPERATURE,
+            )
+        except LLMClientError as exc:
+            self._mark_failed(job_id, reason=str(exc))
+            raise AtomizerError(f"LLM call failed for source_ref={source_ref!r}: {exc}") from exc
+        latency_ms = int((time.time() - start) * 1000)
+
+        atoms_payload = response.parsed.get("atoms") if isinstance(response.parsed, dict) else None
+        if not isinstance(atoms_payload, list):
+            self._mark_failed(job_id, reason="parsed.atoms is not a list")
+            raise AtomizerError(
+                f"atomizer returned non-list 'atoms' payload: {type(atoms_payload).__name__}"
+            )
+
+        atom_ids: list[UUID] = []
+        for raw in atoms_payload:
+            atom = self._build_atom_v1(raw)
+            try:
+                aid = self._store.insert_atom(atom)
+            except AtomStoreError as exc:
+                self._mark_failed(job_id, reason=f"insert_atom failed: {exc}")
+                raise AtomizerError(
+                    f"insert_atom failed for source_ref={source_ref!r}: {exc}"
+                ) from exc
+            atom_ids.append(aid)
+
+        # Update job row to atomizer_done with metering.
+        self._job_db.execute(
+            "UPDATE keiracom_atomizer_jobs SET "
+            "atomizer_tokens_in = %s, atomizer_tokens_out = %s, "
+            "atomizer_latency_ms = %s, atoms_produced = %s, "
+            "status = 'atomizer_done' "
+            "WHERE job_id = %s",
+            response.tokens_in,
+            response.tokens_out,
+            latency_ms,
+            len(atom_ids),
+            str(job_id),
+        )
+
+        # Emit metering metrics (no-op if emitter is None).
+        if self._metric_emitter is not None:
+            self._emit_metering(
+                tokens_in=response.tokens_in,
+                tokens_out=response.tokens_out,
+                latency_ms=latency_ms,
+                atoms_produced=len(atom_ids),
+                source_kind=source_kind,
+            )
+
+        return AtomizerJob(
+            job_id=job_id,
+            tenant_id=UUID(self._store.tenant_id),
+            source_ref=source_ref,
+            source_kind=source_kind,
+            atomizer_model=self._model,
+            atomizer_temp=ATOMIZER_TEMPERATURE,
+            atomizer_tokens_in=response.tokens_in,
+            atomizer_tokens_out=response.tokens_out,
+            atomizer_latency_ms=latency_ms,
+            atoms_produced=len(atom_ids),
+            atom_ids=atom_ids,
+            status="atomizer_done",
+        )
+
+    def _build_atom_v1(self, raw: dict[str, Any]) -> AtomV1:
+        """Construct AtomV1 from one raw atom dict in the LLM response.
+
+        Validation happens via AtomV1.__post_init__ — invalid atoms raise
+        ValueError, which bubbles up as a job failure (no partial inserts).
+        """
+        return AtomV1(
+            atom_id=uuid4(),
+            tenant_id=UUID(self._store.tenant_id),
+            trigger_condition=raw["trigger_condition"],
+            content=raw["content"],
+            anti_pattern=raw.get("anti_pattern"),
+            example=raw.get("example"),
+            provenance=raw["provenance"],
+            composition_tags=raw.get("composition_tags") or {},
+        )
+
+    def _mark_failed(self, job_id: UUID, *, reason: str) -> None:
+        """Best-effort mark a job as failed. Logged even if DB call errors."""
+        try:
+            self._job_db.execute(
+                "UPDATE keiracom_atomizer_jobs SET status = 'failed' WHERE job_id = %s",
+                str(job_id),
+            )
+        except Exception:  # noqa: BLE001
+            log.exception("failed to mark job %s as failed", job_id)
+        log.error("atomizer job %s failed: %s", job_id, reason)
+
+    def _emit_metering(
+        self,
+        *,
+        tokens_in: int,
+        tokens_out: int,
+        latency_ms: int,
+        atoms_produced: int,
+        source_kind: str,
+    ) -> None:
+        """Better Stack metrics per design §5 (atomization_pilot_schema_lock_proposal.md)."""
+        common_tags = {
+            "tenant_id": self._store.tenant_id,
+            "model": self._model,
+            "source_kind": source_kind,
+        }
+        self._metric_emitter(
+            "keiracom.atomization.atomizer.tokens",
+            dict(common_tags, type="in", count=str(tokens_in)),
+        )
+        self._metric_emitter(
+            "keiracom.atomization.atomizer.tokens",
+            dict(common_tags, type="out", count=str(tokens_out)),
+        )
+        self._metric_emitter(
+            "keiracom.atomization.atomizer.latency_ms",
+            dict(common_tags, value=str(latency_ms)),
+        )
+        self._metric_emitter(
+            "keiracom.atomization.atoms_produced",
+            dict(common_tags, count=str(atoms_produced)),
+        )

--- a/src/keiracom_system/atomization/composer.py
+++ b/src/keiracom_system/atomization/composer.py
@@ -1,0 +1,203 @@
+"""Composer — Week 2 atomization pilot.
+
+Renders retrieved atoms into human-facing output for endpoints. Per
+ceo:atomization_architecture_v1 component layer #4. The CRITICAL HARD
+CONSTRAINT: "Composer output never reaches agent reasoning input."
+
+This means: Composer's `compose_chat_reply()` output goes to the USER
+(rendered into a chat message, email, etc.). It does NOT get fed back into
+an agent's prompt. Architecturally separate from MalRetriever (which IS
+the agent-reasoning input path).
+
+Why the separation matters: Composer is non-deterministic by design (LLM-
+shaped prose; future variant: tier-aware formatting). If Composer output
+fed agent reasoning, multi-agent reasoning chains would break on the
+non-determinism. The hard constraint prevents that class of failure.
+
+Week 2 scope: chat-reply endpoint ONLY. Other endpoints (email, voice,
+SMS) are Week 2-3 dispatch via Endpoint Translator (separate module).
+
+DI: caller passes a list of RetrievalResult (from MalRetriever) + endpoint
+name. No LLM call required at this layer — atoms carry pre-validated
+content; Composer's job is rendering not generation.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from src.keiracom_system.atomization.retriever import RetrievalResult
+
+log = logging.getLogger(__name__)
+
+# Supported endpoint kinds for Week 2 (chat-reply only). Week 2-3 expansion
+# adds email + voice + sms via Endpoint Translator dispatch.
+VALID_ENDPOINTS: frozenset[str] = frozenset({"chat_reply"})
+
+# Max atoms to include in a single composed response. Bounded so a high
+# top_k retrieve doesn't produce a verbose chat reply.
+DEFAULT_MAX_ATOMS_IN_RESPONSE: int = 5
+
+# Score floor for inclusion in composed output. Lower scores indicate weaker
+# matches; surfacing them in user-facing prose is a noise risk.
+DEFAULT_MIN_SCORE_FOR_INCLUSION: float = 0.1
+
+
+class ComposerError(RuntimeError):
+    """Raised on invalid composer input."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class ComposedOutput:
+    """The rendered output + provenance trail.
+
+    `text` is the user-facing string. `atoms_used` lists the AtomV1 atom_ids
+    that contributed — useful for downstream audit + the cite-back UX.
+    """
+
+    text: str
+    endpoint: str
+    atoms_used: list[str]
+    truncated_count: int = 0
+
+
+class Composer:
+    """Render atoms to user-facing output.
+
+    Endpoint-only. Output does NOT enter agent reasoning input
+    (per atomization_architecture_v1 hard constraint).
+    """
+
+    def __init__(
+        self,
+        *,
+        max_atoms: int = DEFAULT_MAX_ATOMS_IN_RESPONSE,
+        min_score: float = DEFAULT_MIN_SCORE_FOR_INCLUSION,
+    ):
+        if max_atoms <= 0:
+            raise ComposerError("max_atoms must be > 0")
+        self._max_atoms = max_atoms
+        self._min_score = min_score
+
+    def compose_chat_reply(
+        self,
+        *,
+        atoms: list[RetrievalResult],
+        query_text: str | None = None,
+    ) -> ComposedOutput:
+        """Render retrieved atoms into a chat-reply string.
+
+        Format: a short prose preamble citing the query (if provided), then a
+        numbered list of atom contents with the anti-pattern note (if any),
+        then an example (if any).
+        """
+        return self.compose(atoms=atoms, endpoint="chat_reply", query_text=query_text)
+
+    def compose(
+        self,
+        *,
+        atoms: list[RetrievalResult],
+        endpoint: str,
+        query_text: str | None = None,
+    ) -> ComposedOutput:
+        """Generic compose for any supported endpoint.
+
+        Week 2 supports `endpoint="chat_reply"` only. Other endpoints raise
+        ComposerError until the Endpoint Translator dispatch lands (Week 2-3).
+        """
+        if endpoint not in VALID_ENDPOINTS:
+            raise ComposerError(
+                f"endpoint {endpoint!r} not in {sorted(VALID_ENDPOINTS)} — "
+                "additional endpoints land via Endpoint Translator dispatch"
+            )
+
+        # Filter by min_score + take top max_atoms
+        relevant = [r for r in atoms if r.score >= self._min_score]
+        truncated = max(0, len(relevant) - self._max_atoms)
+        relevant = relevant[: self._max_atoms]
+
+        if not relevant:
+            text = self._render_empty(query_text)
+            return ComposedOutput(
+                text=text,
+                endpoint=endpoint,
+                atoms_used=[],
+                truncated_count=0,
+            )
+
+        if endpoint == "chat_reply":
+            text = self._render_chat_reply(relevant, query_text=query_text)
+        else:
+            # Defensive — should be unreachable given VALID_ENDPOINTS gate.
+            raise ComposerError(f"endpoint {endpoint!r} unhandled")
+
+        return ComposedOutput(
+            text=text,
+            endpoint=endpoint,
+            atoms_used=[str(r.atom.atom_id) for r in relevant],
+            truncated_count=truncated,
+        )
+
+    def _render_empty(self, query_text: str | None) -> str:
+        """No atoms above threshold — return a non-hallucinating placeholder.
+
+        Per anti-hallucination discipline: if we have no high-confidence atoms,
+        the response acknowledges that rather than fabricating content. Caller
+        (the endpoint) can treat empty atoms_used as a signal to ask a
+        clarifying question OR escalate to a human.
+        """
+        if query_text:
+            return (
+                f"I don't have high-confidence knowledge matching {query_text!r}. "
+                "Could you rephrase or provide more context?"
+            )
+        return "I don't have high-confidence knowledge for that query."
+
+    def _render_chat_reply(
+        self,
+        relevant: list[RetrievalResult],
+        *,
+        query_text: str | None,
+    ) -> str:
+        """Render atoms as a numbered chat reply.
+
+        Format keeps it minimal: numbered list, one atom per item, with
+        anti_pattern called out + example shown when present.
+        """
+        lines: list[str] = []
+        if query_text and len(relevant) > 1:
+            lines.append(f"Based on what I know about {query_text!r}:")
+            lines.append("")
+
+        for idx, result in enumerate(relevant, start=1):
+            atom = result.atom
+            if len(relevant) > 1:
+                lines.append(f"{idx}. {atom.content}")
+            else:
+                lines.append(atom.content)
+            if atom.anti_pattern:
+                lines.append(f"   (Avoid: {atom.anti_pattern})")
+            if atom.example:
+                example_first_line = atom.example.split("\n", 1)[0]
+                lines.append(f"   Example: {example_first_line}")
+            if idx < len(relevant):
+                lines.append("")
+
+        return "\n".join(lines)
+
+
+def select_provenance_trail(output: ComposedOutput) -> dict[str, Any]:
+    """Build a JSON-serializable provenance dict for audit logging.
+
+    Composer output IS persisted (audit log) even though it doesn't enter
+    agent reasoning. The atoms_used list lets reviewers cross-check that
+    the user-facing prose was actually grounded in stored atoms vs invented.
+    """
+    return {
+        "endpoint": output.endpoint,
+        "atoms_used": output.atoms_used,
+        "truncated_count": output.truncated_count,
+        "text_length_chars": len(output.text),
+    }

--- a/src/keiracom_system/atomization/llm_client.py
+++ b/src/keiracom_system/atomization/llm_client.py
@@ -1,0 +1,196 @@
+"""LLMClient Protocol + Gemini adapter — atomization pilot Week 1.
+
+Lets the atomizer + verifier take any callable matching the structured-output
+contract, so unit tests inject canned responders without a Gemini API key.
+
+The real Gemini adapter routes through the existing LiteLLM proxy
+(gov.litellm_router; T0.2 substrate RUNNING per V2 inventory + PR #1156
+design + Dave's 2026-05-20 internal-vs-customer-routing policy). Internal
+governance never touches Anthropic API; customer-tier (pilot = Dave) routes
+through Gemini.
+
+API key resolution:
+  - Default: env var GEMINI_API_KEY (pre-Vault interim)
+  - Production: secret/keiracom/gemini/api_key via Vault decryptor (PR #1146)
+    — wired by atomizer's caller; not this module's concern
+
+LiteLLM endpoint: http://127.0.0.1:4000 (gov.litellm_router default port).
+Structured output: Gemini generationConfig.responseSchema passthrough.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from typing import Any, Protocol
+
+log = logging.getLogger(__name__)
+
+DEFAULT_LITELLM_BASE: str = "http://127.0.0.1:4000"  # NOSONAR S5332 loopback
+DEFAULT_TIMEOUT_SECONDS: float = 60.0
+DEFAULT_ATOMIZER_MODEL: str = "google/gemini-2.5-flash"
+DEFAULT_VERIFIER_MODEL: str = "google/gemini-2.5-pro"
+
+# Atomizer always at temperature=0 per dispatch hard constraint.
+ATOMIZER_TEMPERATURE: float = 0.0
+
+
+class LLMResponse:
+    """Structured-output response carrier — parsed JSON + raw token counts."""
+
+    def __init__(
+        self,
+        *,
+        parsed: Any,
+        tokens_in: int,
+        tokens_out: int,
+        latency_ms: int,
+        model: str,
+    ):
+        self.parsed = parsed
+        self.tokens_in = tokens_in
+        self.tokens_out = tokens_out
+        self.latency_ms = latency_ms
+        self.model = model
+
+
+class LLMClient(Protocol):
+    """Protocol matching the atomizer + verifier's LLM call signature.
+
+    Concrete adapters: LiteLLMGeminiClient (production), fakes (tests).
+    """
+
+    def call_structured(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        response_schema: dict[str, Any],
+        temperature: float = 0.0,
+    ) -> LLMResponse: ...
+
+
+class LLMClientError(RuntimeError):
+    """Raised on LLM transport or response-parse error."""
+
+
+HTTPPostFn = Callable[
+    [str, dict[str, Any], dict[str, str], float],
+    tuple[int, dict[str, Any]],
+]
+
+
+def _default_http_post(
+    url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+    timeout: float,
+) -> tuple[int, dict[str, Any]]:
+    """Stdlib urllib POST returning (status, json_body).
+
+    Atomizer/verifier failure is a runtime concern of the calling job — we
+    do NOT swallow upstream errors here (unlike the cache metric emitter).
+    """
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            return resp.status, json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        try:
+            err_body = json.loads(exc.read().decode("utf-8", errors="replace"))
+        except (json.JSONDecodeError, ValueError):
+            err_body = {"error": "non-json error body"}
+        return exc.code, err_body
+
+
+class LiteLLMGeminiClient:
+    """Production adapter — routes structured-output calls through the local
+    LiteLLM proxy (gov.litellm_router) to Gemini Flash/Pro.
+
+    DI knobs:
+      - api_key: caller resolves from env var or Vault
+      - http_post: injectable for tests / mock environments
+      - base_url: override (e.g. for tests with a fake LiteLLM)
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = DEFAULT_LITELLM_BASE,
+        http_post: HTTPPostFn | None = None,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    ):
+        if not api_key:
+            raise LLMClientError("api_key is required")
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._http_post = http_post or _default_http_post
+        self._timeout = timeout_seconds
+
+    def call_structured(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        response_schema: dict[str, Any],
+        temperature: float = 0.0,
+    ) -> LLMResponse:
+        import time
+
+        payload = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            # Gemini structured output: generationConfig.responseSchema +
+            # responseMimeType. LiteLLM passes both through transparently.
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": response_schema,
+            },
+        }
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+        start = time.time()
+        status, body = self._http_post(
+            f"{self._base_url}/v1/chat/completions",
+            payload,
+            headers,
+            self._timeout,
+        )
+        latency_ms = int((time.time() - start) * 1000)
+        if not (200 <= status < 300):
+            raise LLMClientError(f"LiteLLM {model} returned {status}: {str(body)[:300]}")
+        # OpenAI-compatible response shape (LiteLLM proxy normalises Gemini).
+        try:
+            content_str = body["choices"][0]["message"]["content"]
+            parsed = json.loads(content_str) if isinstance(content_str, str) else content_str
+            usage = body.get("usage") or {}
+            return LLMResponse(
+                parsed=parsed,
+                tokens_in=int(usage.get("prompt_tokens", 0)),
+                tokens_out=int(usage.get("completion_tokens", 0)),
+                latency_ms=latency_ms,
+                model=model,
+            )
+        except (KeyError, IndexError, json.JSONDecodeError) as exc:
+            raise LLMClientError(
+                f"LiteLLM {model} response parse failed: {exc} body={str(body)[:300]}"
+            ) from exc
+
+
+def resolve_api_key_from_env(env_var: str = "GEMINI_API_KEY") -> str:
+    """Helper for callers — pull the Gemini key from env (interim) before the
+    Vault-decryptor pathway lands per PR #1146 integration."""
+    key = os.environ.get(env_var, "")
+    if not key:
+        raise LLMClientError(f"environment variable {env_var} not set — atomizer cannot start")
+    return key

--- a/src/keiracom_system/atomization/metering_report.py
+++ b/src/keiracom_system/atomization/metering_report.py
@@ -1,0 +1,360 @@
+"""Composition metering interpretation — Week 3 readiness.
+
+Renders a Markdown report from the atomization + cache metrics emitted by:
+  - PR #1185 (Week 1) — keiracom.atomization.atomizer.* + verifier.flags
+  - PR #1189 (Week 2) — keiracom.atomization.compositions_per_task (pre-wired)
+  - PR #1173 (A7 cache) — keiracom.cache.valkey.lookup + cache.anthropic.input_tokens
+
+DESIGN — Dave starts daily use of the atomized memory system in Week 3. He
+needs a way to READ the curve and understand what it's telling him without
+having to query Better Stack himself. This report wraps the metrics into a
+classified health summary.
+
+Mirrors `scripts/cache_baseline_48h.py` (PR #1173) shape: pure function +
+classification thresholds + injected metrics_fetcher (testable; no live
+Better Stack call required in unit tests).
+
+CLASSIFICATIONS (per design § + dispatch failure-mode-mitigations):
+
+Atomization health:
+  - tokens_in/atoms_produced < 100   → ATOMIZER_NOISY (atoms too sparse; grain too fine)
+  - tokens_in/atoms_produced > 2000  → ATOMIZER_DENSE  (atoms too coarse; grain too broad)
+  - else                              → HEALTHY
+
+Verifier flag rate:
+  - blocking_flags / total_atoms > 0.10   → BLOCKING-V1 (atomizer quality regression)
+  - warning_flags / total_atoms > 0.30    → TRACK-AND-IMPROVE
+  - else                                   → HEALTHY
+
+Cache hit rate (Valkey + Anthropic) thresholds: SAME as PR #1173 cache_baseline_48h
+(<10% BLOCKING-V1; 10-40% TRACK-AND-IMPROVE; >=40% HEALTHY).
+
+Composition curve: rising trend indicates retrieval hitting context budget;
+flagged as TRACK for Week 3 — real threshold needs first-week-Dave data to
+calibrate.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+log = logging.getLogger(__name__)
+
+# Atomizer health bands.
+ATOMIZER_NOISY_MAX_TOKENS_PER_ATOM: float = 100.0
+ATOMIZER_DENSE_MIN_TOKENS_PER_ATOM: float = 2000.0
+
+# Verifier flag rate bands.
+VERIFIER_BLOCKING_THRESHOLD: float = 0.10
+VERIFIER_WARNING_THRESHOLD: float = 0.30
+
+# Cache hit rate bands — same as PR #1173 cache_baseline_48h (cross-PR consistency).
+CACHE_BLOCKING_THRESHOLD: float = 0.10
+CACHE_HEALTHY_THRESHOLD: float = 0.40
+ANTHROPIC_HEALTHY_THRESHOLD: float = 0.50
+ANTHROPIC_TRACK_THRESHOLD: float = 0.20
+
+# Metrics fetcher: caller-injected. Returns dict of metric_name -> aggregated values.
+# Signature: (metric_name, tags_filter, window_start, window_end) -> dict[str, int|float]
+MetricsFetcher = Callable[
+    [str, dict[str, str], datetime, datetime],
+    dict[str, float],
+]
+
+
+@dataclass(frozen=True, kw_only=True)
+class MeteringSummary:
+    """Aggregated metrics for one tenant + window — the report's input data."""
+
+    tenant_id: str
+    window_start: datetime
+    window_end: datetime
+
+    # Atomizer
+    atomizer_tokens_in: int = 0
+    atomizer_tokens_out: int = 0
+    atoms_produced: int = 0
+    atomizer_latency_ms_avg: float = 0.0
+
+    # Verifier
+    verifier_flags_info: int = 0
+    verifier_flags_warning: int = 0
+    verifier_flags_blocking: int = 0
+
+    # Valkey cache
+    valkey_hits: int = 0
+    valkey_misses: int = 0
+
+    # Anthropic prompt cache
+    anthropic_create_tokens: int = 0
+    anthropic_read_tokens: int = 0
+    anthropic_standard_tokens: int = 0
+
+    # Composition curve (Week 2 pre-wired)
+    compositions_per_task_avg: float = 0.0
+
+
+def classify_atomizer_grain(tokens_in: int, atoms_produced: int) -> str:
+    """Tokens-in per atom ratio — coarse / fine grain heuristic."""
+    if atoms_produced <= 0:
+        return "INSUFFICIENT_DATA (no atoms produced yet)"
+    ratio = tokens_in / atoms_produced
+    if ratio < ATOMIZER_NOISY_MAX_TOKENS_PER_ATOM:
+        return f"ATOMIZER_NOISY ({ratio:.0f} tokens/atom — atoms too sparse, grain too fine)"
+    if ratio > ATOMIZER_DENSE_MIN_TOKENS_PER_ATOM:
+        return f"ATOMIZER_DENSE ({ratio:.0f} tokens/atom — atoms too coarse, grain too broad)"
+    return f"HEALTHY ({ratio:.0f} tokens/atom — grain within band)"
+
+
+def classify_verifier_rate(blocking: int, warning: int, total_atoms: int) -> str:
+    """Verifier flag rate banding."""
+    if total_atoms <= 0:
+        return "INSUFFICIENT_DATA (no atoms verified yet)"
+    blocking_rate = blocking / total_atoms
+    warning_rate = warning / total_atoms
+    if blocking_rate > VERIFIER_BLOCKING_THRESHOLD:
+        return (
+            f"BLOCKING-V1 ({blocking_rate:.1%} blocking-flag rate — "
+            "atomizer quality regression; pause customer onboarding)"
+        )
+    if warning_rate > VERIFIER_WARNING_THRESHOLD:
+        return (
+            f"TRACK-AND-IMPROVE ({warning_rate:.1%} warning-flag rate — "
+            "human review queue volume rising)"
+        )
+    return f"HEALTHY (blocking={blocking_rate:.1%}, warning={warning_rate:.1%})"
+
+
+def classify_valkey_hit_rate(hits: int, misses: int) -> str:
+    """Valkey cache hit rate — mirrors PR #1173 cache_baseline_48h thresholds."""
+    total = hits + misses
+    if total <= 0:
+        return "INSUFFICIENT_DATA (no Valkey lookups yet)"
+    rate = hits / total
+    if rate < CACHE_BLOCKING_THRESHOLD:
+        return (
+            f"BLOCKING-V1 ({rate:.1%} hit rate — re-tune _quantise_to_bucket "
+            "and re-baseline before customer onboarding)"
+        )
+    if rate < CACHE_HEALTHY_THRESHOLD:
+        return f"TRACK-AND-IMPROVE ({rate:.1%} hit rate — flagged, non-blocking)"
+    return f"HEALTHY ({rate:.1%} hit rate)"
+
+
+def classify_anthropic_cache_rate(create: int, read: int, standard: int) -> str:
+    """Anthropic prompt-cache read-ratio banding."""
+    total = create + read + standard
+    if total <= 0:
+        return "INSUFFICIENT_DATA (no Anthropic tokens yet)"
+    read_ratio = read / total
+    if read_ratio < ANTHROPIC_TRACK_THRESHOLD:
+        return (
+            f"TRACK-AND-IMPROVE ({read_ratio:.1%} cache-read ratio — "
+            "breakpoint placement misaligned)"
+        )
+    if read_ratio < ANTHROPIC_HEALTHY_THRESHOLD:
+        return f"MARGINAL ({read_ratio:.1%} cache-read ratio — between bands)"
+    return f"HEALTHY ({read_ratio:.1%} cache-read ratio)"
+
+
+def classify_composition_curve(compositions_per_task_avg: float) -> str:
+    """Composition rate trend — Week 3 calibration starting point.
+
+    Initial bands: <2 = under-using atoms; 2-8 = healthy band; >8 = context
+    budget pressure. These need first-week-Dave data to calibrate properly —
+    flagged as PROVISIONAL until N=1-week-actual-traffic baseline exists.
+    """
+    if compositions_per_task_avg <= 0:
+        return "INSUFFICIENT_DATA (no compositions per task yet — Week 3 starts here)"
+    if compositions_per_task_avg < 2:
+        return (
+            f"UNDER_USING ({compositions_per_task_avg:.1f} comp/task — retrieval may not be firing)"
+        )
+    if compositions_per_task_avg > 8:
+        return (
+            f"CONTEXT_PRESSURE ({compositions_per_task_avg:.1f} comp/task — "
+            "atoms hitting Claude context budget; tune top_k or min_score)"
+        )
+    return f"HEALTHY-PROVISIONAL ({compositions_per_task_avg:.1f} comp/task — calibrate after first-week-Dave baseline)"
+
+
+def fetch_summary(
+    *,
+    tenant_id: str,
+    window_start: datetime,
+    window_end: datetime,
+    metrics_fetcher: MetricsFetcher,
+) -> MeteringSummary:
+    """Aggregate metrics from Better Stack (or any injected fetcher) into one summary."""
+    atomizer_tokens = metrics_fetcher(
+        "keiracom.atomization.atomizer.tokens",
+        {"tenant_id": tenant_id},
+        window_start,
+        window_end,
+    )
+    atoms_produced_m = metrics_fetcher(
+        "keiracom.atomization.atoms_produced",
+        {"tenant_id": tenant_id},
+        window_start,
+        window_end,
+    )
+    atomizer_latency = metrics_fetcher(
+        "keiracom.atomization.atomizer.latency_ms",
+        {"tenant_id": tenant_id},
+        window_start,
+        window_end,
+    )
+    verifier_flags = metrics_fetcher(
+        "keiracom.atomization.verifier.flags",
+        {"tenant_id": tenant_id},
+        window_start,
+        window_end,
+    )
+    valkey = metrics_fetcher(
+        "keiracom.cache.valkey.lookup",
+        {"tenant_id": tenant_id},
+        window_start,
+        window_end,
+    )
+    anthropic = metrics_fetcher(
+        "keiracom.cache.anthropic.input_tokens",
+        {"tenant_id": tenant_id},
+        window_start,
+        window_end,
+    )
+    compositions = metrics_fetcher(
+        "keiracom.atomization.compositions_per_task",
+        {"tenant_id": tenant_id},
+        window_start,
+        window_end,
+    )
+
+    return MeteringSummary(
+        tenant_id=tenant_id,
+        window_start=window_start,
+        window_end=window_end,
+        atomizer_tokens_in=int(atomizer_tokens.get("in", 0)),
+        atomizer_tokens_out=int(atomizer_tokens.get("out", 0)),
+        atoms_produced=int(atoms_produced_m.get("count", 0)),
+        atomizer_latency_ms_avg=float(atomizer_latency.get("avg", 0.0)),
+        verifier_flags_info=int(verifier_flags.get("info", 0)),
+        verifier_flags_warning=int(verifier_flags.get("warning", 0)),
+        verifier_flags_blocking=int(verifier_flags.get("blocking", 0)),
+        valkey_hits=int(valkey.get("hit", 0)),
+        valkey_misses=int(valkey.get("miss", 0)),
+        anthropic_create_tokens=int(anthropic.get("create", 0)),
+        anthropic_read_tokens=int(anthropic.get("read", 0)),
+        anthropic_standard_tokens=int(anthropic.get("standard", 0)),
+        compositions_per_task_avg=float(compositions.get("avg", 0.0)),
+    )
+
+
+def render_report(summary: MeteringSummary) -> str:
+    """Render a Markdown report Dave can read at a glance.
+
+    Pure function — no I/O. Caller prints OR posts to keiracom.elliot.inbox.
+    """
+    total_atoms = summary.atoms_produced
+    total_flags = (
+        summary.verifier_flags_info
+        + summary.verifier_flags_warning
+        + summary.verifier_flags_blocking
+    )
+    valkey_total = summary.valkey_hits + summary.valkey_misses
+    anthropic_total = (
+        summary.anthropic_create_tokens
+        + summary.anthropic_read_tokens
+        + summary.anthropic_standard_tokens
+    )
+
+    return f"""# Atomization Pilot — Metering Report
+
+**Tenant:** {summary.tenant_id}
+**Window:** {summary.window_start.isoformat()} → {summary.window_end.isoformat()} UTC
+**Duration:** {(summary.window_end - summary.window_start).total_seconds() / 3600:.1f} hours
+
+## Atomizer
+
+| Metric | Value |
+|---|---|
+| Atoms produced | {summary.atoms_produced:,} |
+| Tokens in | {summary.atomizer_tokens_in:,} |
+| Tokens out | {summary.atomizer_tokens_out:,} |
+| Avg latency | {summary.atomizer_latency_ms_avg:.0f} ms |
+| Grain | {classify_atomizer_grain(summary.atomizer_tokens_in, summary.atoms_produced)} |
+
+## Verifier
+
+| Metric | Value |
+|---|---|
+| Total flags | {total_flags:,} (info={summary.verifier_flags_info} warning={summary.verifier_flags_warning} blocking={summary.verifier_flags_blocking}) |
+| Total atoms | {total_atoms:,} |
+| Verifier verdict | {classify_verifier_rate(summary.verifier_flags_blocking, summary.verifier_flags_warning, total_atoms)} |
+
+## Valkey semantic cache
+
+| Metric | Value |
+|---|---|
+| Hits | {summary.valkey_hits:,} |
+| Misses | {summary.valkey_misses:,} |
+| Total lookups | {valkey_total:,} |
+| Verdict | {classify_valkey_hit_rate(summary.valkey_hits, summary.valkey_misses)} |
+
+## Anthropic prompt cache
+
+| Metric | Value |
+|---|---|
+| cache_creation_input_tokens | {summary.anthropic_create_tokens:,} |
+| cache_read_input_tokens | {summary.anthropic_read_tokens:,} |
+| standard input_tokens | {summary.anthropic_standard_tokens:,} |
+| Total | {anthropic_total:,} |
+| Verdict | {classify_anthropic_cache_rate(summary.anthropic_create_tokens, summary.anthropic_read_tokens, summary.anthropic_standard_tokens)} |
+
+## Composition curve (Week 2 pre-wired metric — calibration starts Week 3)
+
+| Metric | Value |
+|---|---|
+| Compositions per task (avg) | {summary.compositions_per_task_avg:.2f} |
+| Verdict | {classify_composition_curve(summary.compositions_per_task_avg)} |
+
+## Action
+
+- **Atomizer grain:** {classify_atomizer_grain(summary.atomizer_tokens_in, summary.atoms_produced)}
+- **Verifier:** {classify_verifier_rate(summary.verifier_flags_blocking, summary.verifier_flags_warning, total_atoms)}
+- **Valkey cache:** {classify_valkey_hit_rate(summary.valkey_hits, summary.valkey_misses)}
+- **Anthropic cache:** {classify_anthropic_cache_rate(summary.anthropic_create_tokens, summary.anthropic_read_tokens, summary.anthropic_standard_tokens)}
+- **Composition curve:** {classify_composition_curve(summary.compositions_per_task_avg)}
+
+If any verdict shows BLOCKING-V1, pause customer onboarding until the underlying gauge is back into the healthy band. TRACK-AND-IMPROVE bands are non-blocking; flag for retro / next-iteration tuning.
+
+## Honest framing
+
+- **N=1 tenant (Dave)** — Week 3 baseline. Calibration data starts here.
+- **First 3 paying customers + their first month of traffic = real calibration.** Bands above are conservative defaults pending real-traffic data.
+- **Composition curve bands are PROVISIONAL** — they were chosen pre-data; real bands need a week of Dave-actual traffic before they're load-bearing.
+"""
+
+
+def generate_report(
+    *,
+    tenant_id: str,
+    window_hours: int = 24,
+    metrics_fetcher: MetricsFetcher,
+    now: datetime | None = None,
+) -> str:
+    """End-to-end helper: fetch metrics + render report.
+
+    `now` injectable for deterministic tests; default = utcnow.
+    """
+    end = now or datetime.now(UTC)
+    start = end - timedelta(hours=window_hours)
+    summary = fetch_summary(
+        tenant_id=tenant_id,
+        window_start=start,
+        window_end=end,
+        metrics_fetcher=metrics_fetcher,
+    )
+    return render_report(summary)

--- a/src/keiracom_system/atomization/retriever.py
+++ b/src/keiracom_system/atomization/retriever.py
@@ -1,0 +1,141 @@
+"""MAL Retriever — Week 2 atomization pilot.
+
+Wraps AtomStore.retrieve_top_k with composition-tag filtering + relevance
+scoring threshold. Per ceo:atomization_architecture_v1 component layer #3,
+this is what agents call at reasoning time to recall atoms for context.
+
+NOT the same as Composer (component layer #4) — that one renders atoms for
+USER-FACING output. Retriever feeds atoms to AGENT REASONING input. The
+hard-constraint "Composer output never reaches agent reasoning input" does
+NOT apply here: Retriever IS the agent's reasoning-input path by design.
+
+DI: caller passes an `AtomStore` already bound to the right tenant. Retriever
+inherits the store's tenant isolation guarantee — no separate guard needed
+at this layer.
+
+Composition tag filtering: caller passes a dict of {domain, concern,
+applicable_context} (any subset); retrieve narrows the AtomStore.retrieve_top_k
+result to atoms matching ALL specified axes.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from src.keiracom_system.atomization.atom_store import AtomStore
+from src.keiracom_system.atomization.schema import AtomV1
+
+log = logging.getLogger(__name__)
+
+# Default similarity score threshold below which atoms are excluded. The
+# cosine-similarity score from pgvector is 1 - cosine_distance, so higher is
+# better; values <0 mean the embedding model returned a negative similarity
+# (unusual for BGE-small but defensible to bound). 0.0 = no threshold.
+DEFAULT_SCORE_THRESHOLD: float = 0.0
+
+# Maximum top_k a caller can request. Bounds the cost of a single retrieve.
+MAX_TOP_K: int = 50
+
+
+class RetrieverError(RuntimeError):
+    """Raised on invalid retriever input."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class RetrievalResult:
+    """One retrieved atom + its retrieval-time score.
+
+    Score is the cosine similarity from pgvector. AtomV1 itself does not
+    carry the score (atoms are immutable values; score is retrieval-context).
+    """
+
+    atom: AtomV1
+    score: float
+
+
+class MalRetriever:
+    """Recall top-K atoms for a query, with optional composition-tag filtering."""
+
+    def __init__(self, *, store: AtomStore):
+        self._store = store
+
+    @property
+    def tenant_id(self) -> str:
+        return self._store.tenant_id
+
+    def retrieve(
+        self,
+        *,
+        query_text: str,
+        top_k: int = 10,
+        composition_filter: dict[str, Any] | None = None,
+        score_threshold: float = DEFAULT_SCORE_THRESHOLD,
+    ) -> list[RetrievalResult]:
+        """Recall atoms matching the query.
+
+        Args:
+            query_text: natural-language search query (embedded via TEIClient
+                inside AtomStore).
+            top_k: max atoms to return. Bounded by MAX_TOP_K.
+            composition_filter: optional dict subset of {domain, concern,
+                applicable_context}; atoms must match ALL specified axes to
+                be included. Empty dict / None = no filter.
+            score_threshold: minimum cosine-similarity score to include.
+
+        Returns:
+            List of RetrievalResult ordered by descending score. May be empty
+            (no matches, no atoms in store, all below threshold, or all
+            filtered out by composition_filter).
+        """
+        if not query_text:
+            raise RetrieverError("query_text must be non-empty")
+        if top_k <= 0:
+            raise RetrieverError("top_k must be > 0")
+        if top_k > MAX_TOP_K:
+            raise RetrieverError(f"top_k {top_k} exceeds MAX_TOP_K {MAX_TOP_K}")
+
+        # AtomStore.retrieve_top_k already filters to tenant_id + state=active
+        # + cold_archive excluded. AtomStore does NOT currently return scores
+        # — Week 2 enhancement: assume atoms come back ordered by similarity
+        # and assign a placeholder score = 1.0 / (rank + 1) for now. Real
+        # cosine-similarity score wire-up is a Week 2.5 follow-up that needs
+        # AtomStore.retrieve_top_k to project the similarity column.
+        atoms = self._store.retrieve_top_k(query_text, top_k=top_k)
+        results: list[RetrievalResult] = []
+        for rank, atom in enumerate(atoms):
+            score = 1.0 / (rank + 1)  # placeholder rank-based score
+            if score < score_threshold:
+                continue
+            if composition_filter and not _matches_composition_filter(
+                atom.composition_tags, composition_filter
+            ):
+                continue
+            results.append(RetrievalResult(atom=atom, score=score))
+        return results
+
+    def retrieve_with_min_score(
+        self,
+        *,
+        query_text: str,
+        top_k: int = 10,
+        min_score: float,
+    ) -> list[RetrievalResult]:
+        """Convenience wrapper: retrieve(score_threshold=min_score)."""
+        return self.retrieve(query_text=query_text, top_k=top_k, score_threshold=min_score)
+
+
+def _matches_composition_filter(
+    atom_tags: dict[str, Any],
+    composition_filter: dict[str, Any],
+) -> bool:
+    """True iff the atom's composition_tags match ALL specified axes in the filter.
+
+    Axes not in the filter are not constrained (i.e. {"domain": "sales"}
+    matches any atom with domain=sales regardless of concern/context).
+    """
+    for axis, required_value in composition_filter.items():
+        if atom_tags.get(axis) != required_value:
+            return False
+    return True

--- a/src/keiracom_system/atomization/schema.py
+++ b/src/keiracom_system/atomization/schema.py
@@ -1,0 +1,235 @@
+"""AtomV1 dataclass + frozen vocabularies — atomization pilot Week 1.
+
+CANONICAL ANCHOR — ceo:atomization_architecture_v1 v1 (RATIFIED-CEO 2026-05-26T11:25:00Z):
+  atom_schema_v1.fields = [
+    "trigger_condition", "content", "anti_pattern", "example",
+    "provenance (source/freshness/confidence/last_validated)",
+    "supersession_edges",
+    "composition_tags (domain/concern/applicable_context)"
+  ]
+
+VOCABULARY PLACEHOLDERS — the dispatch references "288 combinations + 7
+relationship types" as Elliot's 48-hour design report deliverable. As of
+2026-05-26 11:39Z the report was not yet in the Drive Manual (queried; zero
+matches). Vocabularies below are PILOT-PLACEHOLDER values that match the
+dispatch shape (single-digit relationship-type count + domain×concern×context
+factors). REPLACE with Elliot's authored vocabulary when the report lands.
+
+The vocabulary lookup is a single-file swap — atom storage uses JSONB so a
+vocabulary swap doesn't require migration data movement, only an updated
+frozenset + a re-validation pass on existing rows (Week 2 if needed).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+# atom_schema_v1 lives at schema_version = 1 in the migration.
+SCHEMA_VERSION: int = 1
+
+# State enum — mirrors the SQL CHECK in keiracom_atoms.state.
+VALID_STATES: frozenset[str] = frozenset({"active", "superseded", "cold_archive"})
+
+# Source kind enum — mirrors the SQL CHECK in keiracom_atomizer_jobs.source_kind.
+VALID_SOURCE_KINDS: frozenset[str] = frozenset(
+    {"skill", "manual", "governance_doc", "discovery_log", "session"}
+)
+
+# Trigger condition `kind` enum — structured predicate vocabulary.
+# PLACEHOLDER per dispatch B1 — Elliot 48hr design report names the canonical
+# set. Pilot uses these 6 kinds covering the obvious base cases. The atomizer
+# REJECTS free-text triggers via this whitelist; switching the set is one-file.
+VALID_TRIGGER_KINDS: frozenset[str] = frozenset(
+    {
+        "tenant_attribute",  # e.g. tier=pro AND tenant has X integration
+        "request_shape",  # e.g. user message matches "summarize X"
+        "time_window",  # e.g. before/after a clock condition
+        "tool_invocation",  # e.g. before/after a specific tool call
+        "system_event",  # e.g. a webhook or scheduled event fires
+        "context_predicate",  # e.g. specific data structurally present
+    }
+)
+
+# Relationship-type enum for supersession edges — capped single-digit per hard
+# constraint. Pilot uses these 7 covering the deliberation shapes Atlas + I
+# have surfaced across recent PRs.
+VALID_RELATIONSHIP_TYPES: frozenset[str] = frozenset(
+    {
+        "supersedes",  # successor fully replaces predecessor
+        "refines",  # successor narrows or refines predecessor scope
+        "extends",  # successor adds to predecessor without replacing
+        "contradicts",  # successor and predecessor mutually exclude
+        "scopes",  # successor scopes predecessor to a subset
+        "deprecates",  # successor marks predecessor as obsolete-but-kept
+        "reinterprets",  # successor reframes predecessor (e.g. policy update)
+    }
+)
+
+# Composition tag axes per canonical schema field "(domain/concern/applicable_context)".
+# Each axis has 8 values → 8 × 6 × 6 = 288 combinations. PLACEHOLDER values
+# pending Elliot's report; the cardinality matches dispatch reference exactly.
+VALID_COMPOSITION_TAG_DOMAINS: frozenset[str] = frozenset(
+    {
+        "sales",
+        "support",
+        "marketing",
+        "operations",
+        "engineering",
+        "finance",
+        "legal",
+        "internal",
+    }
+)
+VALID_COMPOSITION_TAG_CONCERNS: frozenset[str] = frozenset(
+    {
+        "compliance",
+        "performance",
+        "cost",
+        "user_experience",
+        "data_quality",
+        "security",
+    }
+)
+VALID_COMPOSITION_TAG_CONTEXTS: frozenset[str] = frozenset(
+    {
+        "chat_realtime",
+        "background_job",
+        "audit_review",
+        "incident_response",
+        "onboarding",
+        "billing",
+    }
+)
+
+# Union of all valid composition tags as flat list (288 = 8 × 6 × 6).
+VALID_COMPOSITION_TAGS: frozenset[tuple[str, str, str]] = frozenset(
+    (d, c, x)
+    for d in VALID_COMPOSITION_TAG_DOMAINS
+    for c in VALID_COMPOSITION_TAG_CONCERNS
+    for x in VALID_COMPOSITION_TAG_CONTEXTS
+)
+
+# Provenance JSONB field key whitelist (per canonical schema parenthetical).
+PROVENANCE_REQUIRED_KEYS: frozenset[str] = frozenset(
+    {"source", "freshness", "confidence", "last_validated"}
+)
+
+# UUID v4 shape — used for atom_id / tenant_id / edge_id validation outside DB.
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def is_valid_uuid_str(value: str) -> bool:
+    """True iff `value` is a UUID-shaped string."""
+    return bool(_UUID_RE.match(value))
+
+
+def is_valid_composition_tag(tag: dict[str, Any]) -> bool:
+    """True iff `tag` is a `{domain, concern, applicable_context}` dict whose
+    values are all in the frozen vocabularies."""
+    if not isinstance(tag, dict):
+        return False
+    return (
+        tag.get("domain") in VALID_COMPOSITION_TAG_DOMAINS
+        and tag.get("concern") in VALID_COMPOSITION_TAG_CONCERNS
+        and tag.get("applicable_context") in VALID_COMPOSITION_TAG_CONTEXTS
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class AtomV1:
+    """In-memory representation of one atom row in keiracom_atoms.
+
+    Frozen dataclass — atoms are immutable values. Edits produce supersession
+    edges, not in-place mutations (per content-level supersession invariant).
+    """
+
+    atom_id: UUID
+    tenant_id: UUID
+    trigger_condition: dict[str, Any]
+    content: str
+    anti_pattern: str | None
+    example: str | None
+    provenance: dict[str, Any]
+    composition_tags: dict[str, Any] = field(default_factory=dict)
+    content_embedding: list[float] = field(default_factory=list)
+    schema_version: int = SCHEMA_VERSION
+    state: str = "active"
+
+    def __post_init__(self) -> None:
+        # Trigger condition: structured predicate only — reject free-text.
+        if not isinstance(self.trigger_condition, dict):
+            raise ValueError(
+                "trigger_condition must be a structured predicate dict, not "
+                f"{type(self.trigger_condition).__name__} — atomizer rejects "
+                "free-text triggers per hard constraint"
+            )
+        kind = self.trigger_condition.get("kind")
+        if kind not in VALID_TRIGGER_KINDS:
+            raise ValueError(
+                f"trigger_condition.kind {kind!r} not in {sorted(VALID_TRIGGER_KINDS)}"
+            )
+        if "params" not in self.trigger_condition or not isinstance(
+            self.trigger_condition["params"], dict
+        ):
+            raise ValueError("trigger_condition must include a 'params' dict")
+
+        # Content non-empty (also CHECK'd in DB).
+        if not self.content:
+            raise ValueError("content must be non-empty")
+
+        # Provenance required keys.
+        missing = PROVENANCE_REQUIRED_KEYS - set(self.provenance.keys())
+        if missing:
+            raise ValueError(f"provenance missing required keys: {sorted(missing)}")
+        conf = self.provenance.get("confidence")
+        if not isinstance(conf, int | float) or not (0 <= float(conf) <= 1):
+            raise ValueError(f"provenance.confidence must be a float in [0, 1]; got {conf!r}")
+
+        # Composition tags — validate against frozen vocabulary if present.
+        # Empty dict {} is allowed (some sources may not yet carry tags).
+        if self.composition_tags and not is_valid_composition_tag(self.composition_tags):
+            raise ValueError(
+                f"composition_tags {self.composition_tags!r} not in frozen vocabulary "
+                "(see schema.VALID_COMPOSITION_TAG_* sets)"
+            )
+
+        # State enum.
+        if self.state not in VALID_STATES:
+            raise ValueError(f"state {self.state!r} not in {sorted(VALID_STATES)}")
+
+        # Schema version positive int.
+        if not isinstance(self.schema_version, int) or self.schema_version < 1:
+            raise ValueError("schema_version must be a positive int")
+
+
+@dataclass(frozen=True, kw_only=True)
+class SupersessionEdgeV1:
+    """One row in keiracom_atom_supersession_edges.
+
+    Content-level only — schema migration does NOT trigger edge rewrite; it
+    triggers re-atomization with new schema_version.
+    """
+
+    edge_id: UUID
+    tenant_id: UUID
+    predecessor_atom: UUID
+    successor_atom: UUID
+    relationship_type: str
+    confidence: float
+
+    def __post_init__(self) -> None:
+        if self.predecessor_atom == self.successor_atom:
+            raise ValueError("predecessor_atom and successor_atom must differ")
+        if self.relationship_type not in VALID_RELATIONSHIP_TYPES:
+            raise ValueError(
+                f"relationship_type {self.relationship_type!r} not in "
+                f"{sorted(VALID_RELATIONSHIP_TYPES)}"
+            )
+        if not (0 <= self.confidence <= 1):
+            raise ValueError(f"confidence must be in [0, 1]; got {self.confidence!r}")

--- a/src/keiracom_system/atomization/skills_atomizer.py
+++ b/src/keiracom_system/atomization/skills_atomizer.py
@@ -1,0 +1,219 @@
+"""Skills directory atomizer — Week 2 acceptance criterion.
+
+Walks `skills/` directory (or any provided root), runs Atomizer + Verifier
+on each markdown skill file, stores atoms + edges + job rows. Dry-run by
+default; --execute flag required to write.
+
+Mirrors the operator-script pattern from PR #1172 / #1174 / #1176 hand-
+migrations (dry-run default, idempotent state-file, fail-loud on errors).
+
+State file at runtime/skills_atomization_state.jsonl records each (skill_path,
+job_id, status) so re-runs skip already-atomized skills. Safe to abort + resume.
+
+Acceptance per Elliot dispatch: "Week 2: full skills directory atomized +
+retrieval working + composer prototype." This module handles the first half;
+retriever.py + composer.py cover the second + third.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from src.keiracom_system.atomization.atomizer import Atomizer, is_atomizer_enabled
+
+log = logging.getLogger("skills_atomizer")
+
+DEFAULT_SKILLS_ROOT = Path("skills")
+DEFAULT_STATE_FILE = Path("runtime/skills_atomization_state.jsonl")
+DEFAULT_SOURCE_KIND = "skill"
+
+# Cap on file size we'll send to Gemini Flash. Skills over this are skipped
+# with a warning — atomization works on document-scale prose, not 50KB monsters.
+MAX_SKILL_BYTES: int = 50_000
+
+
+class SkillsAtomizerError(RuntimeError):
+    """Raised on operator-side errors (bad config, missing skills root, etc.)."""
+
+
+def iter_skill_files(root: Path) -> Iterable[Path]:
+    """Yield all *.md files under `root` recursively, sorted for determinism."""
+    if not root.is_dir():
+        raise SkillsAtomizerError(f"skills root {root} not a directory")
+    yield from sorted(root.rglob("*.md"))
+
+
+def load_state(path: Path) -> set[str]:
+    """Read the state file; return set of already-atomized source_refs."""
+    if not path.exists():
+        return set()
+    seen: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+            if row.get("ok") and row.get("source_ref"):
+                seen.add(row["source_ref"])
+        except json.JSONDecodeError:
+            continue
+    return seen
+
+
+def append_state(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+
+def atomize_skill(
+    *,
+    atomizer: Atomizer,
+    skill_path: Path,
+    skills_root: Path,
+) -> tuple[bool, str]:
+    """Atomize one skill file. Returns (ok, info)."""
+    content = skill_path.read_text(encoding="utf-8")
+    if len(content.encode("utf-8")) > MAX_SKILL_BYTES:
+        return False, f"skill {skill_path} exceeds MAX_SKILL_BYTES={MAX_SKILL_BYTES}"
+    # source_ref is relative to skills_root for portability.
+    try:
+        rel = skill_path.relative_to(skills_root)
+    except ValueError:
+        rel = skill_path
+    source_ref = f"skills/{rel}"
+    try:
+        job = atomizer.atomize(
+            source_ref=source_ref,
+            source_kind=DEFAULT_SOURCE_KIND,
+            source_text=content,
+        )
+        return True, f"job_id={job.job_id} atoms={job.atoms_produced}"
+    except Exception as exc:  # noqa: BLE001
+        log.warning("atomize failed for %s: %s", skill_path, exc)
+        return False, f"error: {exc}"
+
+
+def run(
+    *,
+    atomizer: Atomizer,
+    skills_root: Path,
+    state_path: Path,
+    execute: bool,
+) -> int:
+    """Walk skills/, atomize each. Returns rc=0 on clean, 1 on any failure."""
+    if not skills_root.is_dir():
+        log.error("skills_root %s missing", skills_root)
+        return 2
+
+    seen = load_state(state_path)
+    log.info("state-file already-atomized: %d", len(seen))
+
+    n_total = n_ok = n_fail = n_skip = 0
+    for skill_path in iter_skill_files(skills_root):
+        n_total += 1
+        # Compute source_ref to match what atomize_skill would generate.
+        try:
+            rel = skill_path.relative_to(skills_root)
+        except ValueError:
+            rel = skill_path
+        source_ref = f"skills/{rel}"
+
+        if source_ref in seen:
+            n_skip += 1
+            log.debug("skip already-atomized: %s", source_ref)
+            continue
+
+        if not execute:
+            log.info("dry-run: would atomize %s", source_ref)
+            continue
+
+        ok, info = atomize_skill(
+            atomizer=atomizer,
+            skill_path=skill_path,
+            skills_root=skills_root,
+        )
+        row: dict[str, Any] = {
+            "source_ref": source_ref,
+            "ok": ok,
+            "info": info,
+        }
+        append_state(state_path, row)
+        if ok:
+            n_ok += 1
+        else:
+            n_fail += 1
+            log.warning("atomize %s FAILED: %s", source_ref, info)
+
+    log.info(
+        "summary: total=%d ok=%d fail=%d skip=%d (execute=%s)",
+        n_total,
+        n_ok,
+        n_fail,
+        n_skip,
+        execute,
+    )
+    return 0 if n_fail == 0 else 1
+
+
+def _check_feature_flag_or_warn() -> None:
+    """Warn (don't fail) if KEIRACOM_ATOMIZER_ENABLED is off.
+
+    The orchestration script itself doesn't gate on the flag (Atomizer is
+    injected pre-constructed); but if ops runs this without the flag on,
+    they may be surprised that the feature-flag-aware caller won't actually
+    drive the atomization in production. Warn loudly.
+    """
+    if not is_atomizer_enabled():
+        log.warning(
+            "KEIRACOM_ATOMIZER_ENABLED is OFF — this run will execute even "
+            "though the production feature flag would block atomization. "
+            "Confirm intent before --execute."
+        )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills-root", type=Path, default=DEFAULT_SKILLS_ROOT)
+    parser.add_argument("--state-file", type=Path, default=DEFAULT_STATE_FILE)
+    parser.add_argument("--execute", action="store_true", help="atomize (default dry-run)")
+    parser.add_argument("--log-level", default="INFO")
+    return parser.parse_args()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Module-as-script entry. Atomizer must be constructed by the caller —
+    we don't import the Gemini key in this orchestration module to keep the
+    LLM dependency explicit. Callers wire up Atomizer via the production
+    bootstrap script.
+
+    For dry-run on the current repo's skills/, this module-as-script can be
+    invoked without a real Atomizer by mocking _build_atomizer in tests.
+    """
+    # Lazy-import the bootstrap so module imports don't fail without
+    # GEMINI_API_KEY set (dry-run + tests work without it).
+    args = _parse_args()
+    logging.basicConfig(level=args.log_level, format="%(asctime)s %(levelname)s %(message)s")
+    _check_feature_flag_or_warn()
+    if not args.execute:
+        # Dry-run path doesn't need an actual Atomizer; just walk + print.
+        n = sum(1 for _ in iter_skill_files(args.skills_root))
+        log.info("dry-run: %d skill files under %s", n, args.skills_root)
+        return 0
+    # Execute path needs a real Atomizer + Verifier; caller assembles via a
+    # bootstrap module (out of scope for this orchestration script).
+    log.error(
+        "--execute requires Atomizer + AtomStore + Verifier construction; "
+        "use scripts/bootstrap_atomize_skills.py instead (separate module)"
+    )
+    return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/keiracom_system/atomization/verifier.py
+++ b/src/keiracom_system/atomization/verifier.py
@@ -1,0 +1,277 @@
+"""Verifier service — second pass over atomizer output using Gemini Pro.
+
+Per dispatch failure-mode mitigation: "Legacy free-text trigger interpretation
+= Pro verifier spot-checks a sample". Verifier runs AFTER atomizer in a
+separate pass, flags issues, and updates the job row with verifier_flags.
+
+Flags are non-blocking by design — grain violation = degrade-with-flag plus
+human review queue (per dispatch hard constraint), NOT a hard reject. This
+matches the failure-mode mitigation: "Grain violation = degrade-with-flag
+plus human review queue".
+
+Verifier checks per atom:
+  1. Factual coherence — content + example + anti_pattern internally consistent
+  2. Trigger condition specificity — kind + params concrete enough to actually fire
+  3. Provenance plausibility — freshness/last_validated dates reasonable; confidence in [0,1]
+  4. Composition tags consistency — tags align with content domain
+
+Caller passes the AtomizerJob from a prior atomizer.atomize() call.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from src.keiracom_system.atomization.atom_store import AtomStore
+from src.keiracom_system.atomization.atomizer import _JobLogger
+from src.keiracom_system.atomization.llm_client import (
+    DEFAULT_VERIFIER_MODEL,
+    LLMClient,
+    LLMClientError,
+)
+from src.keiracom_system.atomization.schema import AtomV1
+
+log = logging.getLogger(__name__)
+
+
+class VerifierError(RuntimeError):
+    """Raised on verifier-side errors that should HALT the verification pass.
+
+    Per-atom flags are NOT errors — they're returned as VerifierFlag entries.
+    """
+
+
+# Severity scale — caller / human reviewer routes on this.
+SEVERITY_INFO: str = "info"
+SEVERITY_WARNING: str = "warning"
+SEVERITY_BLOCKING: str = "blocking"
+
+VALID_SEVERITIES: frozenset[str] = frozenset({SEVERITY_INFO, SEVERITY_WARNING, SEVERITY_BLOCKING})
+
+
+@dataclass(frozen=True, kw_only=True)
+class VerifierFlag:
+    """One verifier flag on one atom. Persisted in keiracom_atomizer_jobs.verifier_flags."""
+
+    atom_id: UUID
+    severity: str
+    message: str
+
+    def __post_init__(self) -> None:
+        if self.severity not in VALID_SEVERITIES:
+            raise VerifierError(f"severity {self.severity!r} not in {sorted(VALID_SEVERITIES)}")
+
+
+_VERIFIER_SYSTEM_PROMPT = (
+    "You are a verifier for atom_schema_v1 knowledge-base atoms. "
+    "Given a JSON array of atoms produced by an upstream atomizer, return a "
+    "JSON array of flags. Each flag names one issue with one atom.\n"
+    "FLAG CATEGORIES:\n"
+    "1. factual_incoherence — content + example + anti_pattern do not match\n"
+    "2. trigger_unspecific — trigger_condition.params too vague to actually fire\n"
+    "3. provenance_implausible — freshness/last_validated dates wrong OR "
+    "confidence outside reasonable range\n"
+    "4. tag_mismatch — composition_tags don't fit content domain\n"
+    "5. grain_violation — atom too coarse (mixes multiple knowledge units) OR "
+    "too fine (fragment without context)\n"
+    "SEVERITY: 'info' (FYI), 'warning' (human review), 'blocking' (do not use).\n"
+    "If an atom is fine, do NOT emit a flag for it. Return [] for clean batches.\n"
+    "Return ONLY the JSON matching the response schema."
+)
+
+
+VERIFIER_RESPONSE_SCHEMA: dict[str, Any] = {
+    "name": "VerifierFlagsResponse",
+    "schema": {
+        "type": "object",
+        "required": ["flags"],
+        "properties": {
+            "flags": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["atom_index", "category", "severity", "message"],
+                    "properties": {
+                        "atom_index": {"type": "integer"},
+                        "category": {
+                            "type": "string",
+                            "enum": [
+                                "factual_incoherence",
+                                "trigger_unspecific",
+                                "provenance_implausible",
+                                "tag_mismatch",
+                                "grain_violation",
+                            ],
+                        },
+                        "severity": {
+                            "type": "string",
+                            "enum": ["info", "warning", "blocking"],
+                        },
+                        "message": {"type": "string"},
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+class Verifier:
+    """Run Pro-tier verifier pass on a batch of atoms; update the job row.
+
+    Caller passes the atom_ids the atomizer produced. Verifier fetches them
+    from the AtomStore (re-confirming tenant ownership at the boundary), sends
+    them to Gemini Pro, and writes the flag list back to keiracom_atomizer_jobs.
+    """
+
+    def __init__(
+        self,
+        *,
+        llm: LLMClient,
+        store: AtomStore,
+        job_db: _JobLogger,
+        model: str = DEFAULT_VERIFIER_MODEL,
+        metric_emitter: Any = None,
+    ):
+        self._llm = llm
+        self._store = store
+        self._job_db = job_db
+        self._model = model
+        self._metric_emitter = metric_emitter
+
+    def verify(self, *, job_id: UUID, atom_ids: list[UUID]) -> list[VerifierFlag]:
+        """Run verifier on the atoms produced by an atomizer job.
+
+        Returns the list of flags. Empty list = clean batch.
+
+        Atoms not found (e.g. wrong tenant) are silently skipped — the
+        AtomStore tenant guard already collapses cross-tenant misses.
+        """
+        if not atom_ids:
+            self._mark_verifier_done(job_id, flags=[])
+            return []
+
+        atoms: list[AtomV1] = []
+        for aid in atom_ids:
+            atom = self._store.get_atom(aid)
+            if atom is not None:
+                atoms.append(atom)
+        if not atoms:
+            self._mark_verifier_done(job_id, flags=[])
+            return []
+
+        atom_dicts = [
+            {
+                "trigger_condition": a.trigger_condition,
+                "content": a.content,
+                "anti_pattern": a.anti_pattern,
+                "example": a.example,
+                "provenance": a.provenance,
+                "composition_tags": a.composition_tags,
+            }
+            for a in atoms
+        ]
+
+        import json as _json
+
+        messages = [
+            {"role": "system", "content": _VERIFIER_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": _json.dumps({"atoms": atom_dicts}),
+            },
+        ]
+        start = time.time()
+        try:
+            response = self._llm.call_structured(
+                model=self._model,
+                messages=messages,
+                response_schema=VERIFIER_RESPONSE_SCHEMA,
+                temperature=0.0,
+            )
+        except LLMClientError as exc:
+            log.exception("verifier LLM call failed for job %s", job_id)
+            raise VerifierError(f"verifier LLM call failed: {exc}") from exc
+        latency_ms = int((time.time() - start) * 1000)
+
+        raw_flags = response.parsed.get("flags") if isinstance(response.parsed, dict) else None
+        if not isinstance(raw_flags, list):
+            raw_flags = []
+
+        flags: list[VerifierFlag] = []
+        for rf in raw_flags:
+            try:
+                idx = int(rf["atom_index"])
+                if not 0 <= idx < len(atoms):
+                    continue
+                flags.append(
+                    VerifierFlag(
+                        atom_id=atoms[idx].atom_id,
+                        severity=rf.get("severity", SEVERITY_WARNING),
+                        message=f"{rf.get('category', 'unknown')}: {rf.get('message', '')}",
+                    )
+                )
+            except (KeyError, ValueError, VerifierError) as exc:
+                log.warning("verifier flag parse failed: %s; raw=%s", exc, rf)
+                continue
+
+        # Persist flags + verifier metering.
+        self._mark_verifier_done(
+            job_id,
+            flags=flags,
+            tokens_in=response.tokens_in,
+            tokens_out=response.tokens_out,
+            latency_ms=latency_ms,
+        )
+
+        if self._metric_emitter is not None:
+            for flag in flags:
+                self._metric_emitter(
+                    "keiracom.atomization.verifier.flags",
+                    {
+                        "tenant_id": self._store.tenant_id,
+                        "severity": flag.severity,
+                    },
+                )
+
+        return flags
+
+    def _mark_verifier_done(
+        self,
+        job_id: UUID,
+        *,
+        flags: list[VerifierFlag],
+        tokens_in: int = 0,
+        tokens_out: int = 0,
+        latency_ms: int = 0,
+    ) -> None:
+        """UPDATE the job row with verifier metering + flags JSONB."""
+        import json as _json
+
+        flag_jsonb = _json.dumps(
+            [
+                {
+                    "atom_id": str(f.atom_id),
+                    "severity": f.severity,
+                    "message": f.message,
+                }
+                for f in flags
+            ]
+        )
+        self._job_db.execute(
+            "UPDATE keiracom_atomizer_jobs SET "
+            "verifier_model = %s, verifier_tokens_in = %s, "
+            "verifier_tokens_out = %s, verifier_latency_ms = %s, "
+            "verifier_flags = %s, status = 'verifier_done' "
+            "WHERE job_id = %s",
+            self._model,
+            tokens_in,
+            tokens_out,
+            latency_ms,
+            flag_jsonb,
+            str(job_id),
+        )

--- a/supabase/migrations/20260526_keiracom_atomization_pilot.sql
+++ b/supabase/migrations/20260526_keiracom_atomization_pilot.sql
@@ -1,0 +1,204 @@
+-- ============================================================================
+-- 20260526_keiracom_atomization_pilot.sql
+--
+-- Atomization pilot Week 1 schema lock — Agency_OS-atomization-pilot-week1.
+-- Per ceo:atomization_architecture_v1 (RATIFIED-CEO 2026-05-26T11:25:00Z)
+-- + PR #1178 proposal doc (docs/architecture/design/
+-- atomization_pilot_schema_lock_proposal.md, merged 2026-05-26T11:53Z).
+--
+-- Sibling migrations:
+--   20260525_keiracom_tenant_metering.sql  (PR #1137)
+--   20260526_keiracom_tenant_budgets.sql   (PR #1173)
+--
+-- Schema (atom_schema_v1) — 7 canonical fields:
+--   trigger_condition  → JSONB (structured predicate; vocabulary frozen
+--                        at app layer via src/keiracom_system/atomization/
+--                        schema.py; rejects free-text per HARD constraint)
+--   content            → TEXT
+--   anti_pattern       → TEXT (nullable)
+--   example            → TEXT (nullable)
+--   provenance         → JSONB {source, freshness, confidence, last_validated}
+--   supersession_edges → adjacency table keiracom_atom_supersession_edges
+--   composition_tags   → JSONB {domain, concern, applicable_context};
+--                        vocabulary frozen at app layer; 288 combinations
+--                        + 7 relationship types per dispatch reference
+--
+-- Embeddings: VECTOR(384) — BGE-small-en-v1.5 via TEIClient (PR #1133).
+--
+-- Hard constraints enforced:
+--   1. Tenant-prefix guard at read+write (app layer + CI guard)
+--   2. Composition tag vocabulary frozen (app layer)
+--   3. Relationship-type vocabulary capped single-digit V1 (app layer)
+--   4. Cold archive never consumed by agents (state='cold_archive' flag;
+--      explicit recall API only — not in this migration's scope)
+--   5. Composer output never reaches agent reasoning input (enforced by
+--      separate Composer module + future CI guard; not in this schema)
+--
+-- KEI-87 bypass: SET LOCAL agency_os.callsign = 'dave' required for
+-- public-schema table creation; same pattern as PR #1137/1173.
+-- ============================================================================
+
+SET LOCAL agency_os.callsign = 'dave';
+
+-- pgvector prerequisite — fail-loud if not enabled rather than silent
+-- VECTOR-type creation failure on the table below.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_extension WHERE extname = 'vector'
+    ) THEN
+        RAISE EXCEPTION
+            'pgvector extension NOT enabled — atomization pilot requires '
+            'pgvector for VECTOR(384) embedding column. Run "CREATE EXTENSION '
+            'IF NOT EXISTS vector;" before applying this migration.';
+    END IF;
+END $$;
+
+-- ----------------------------------------------------------------------------
+-- Atom Store — primary atom table
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.keiracom_atoms (
+    atom_id            UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id          UUID         NOT NULL,
+
+    -- atom_schema_v1 7-field core (per ceo:atomization_architecture_v1)
+    trigger_condition  JSONB        NOT NULL,
+    content            TEXT         NOT NULL CHECK (length(content) > 0),
+    anti_pattern       TEXT,
+    example            TEXT,
+    provenance         JSONB        NOT NULL,
+    composition_tags   JSONB        NOT NULL DEFAULT '{}'::jsonb,
+
+    -- Embedding for retrieval (BGE-small-en-v1.5 via TEIClient PR #1133).
+    -- 384 dimensions matches DEFAULT_MODEL_DIM in tei_client.py.
+    content_embedding  VECTOR(384)  NOT NULL,
+
+    -- Atom-level metadata.
+    schema_version     SMALLINT     NOT NULL DEFAULT 1,
+    state              TEXT         NOT NULL DEFAULT 'active'
+        CHECK (state IN ('active', 'superseded', 'cold_archive')),
+
+    created_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (tenant_id) REFERENCES public.keiracom_tenants(tenant_id) ON DELETE CASCADE
+);
+
+-- Tenant isolation + state filter — every retrieval query hits this index.
+CREATE INDEX IF NOT EXISTS idx_keiracom_atoms_tenant_active
+    ON public.keiracom_atoms (tenant_id)
+    WHERE state = 'active';
+
+-- pgvector HNSW for vector similarity (cosine for BGE-small).
+CREATE INDEX IF NOT EXISTS idx_keiracom_atoms_embedding_hnsw
+    ON public.keiracom_atoms USING hnsw (content_embedding vector_cosine_ops);
+
+-- Composition tag retrieval — GIN on JSONB for tag predicate queries.
+CREATE INDEX IF NOT EXISTS idx_keiracom_atoms_composition_tags
+    ON public.keiracom_atoms USING gin (composition_tags);
+
+-- Trigger: refresh updated_at on UPDATE.
+CREATE OR REPLACE FUNCTION public.keiracom_atoms_set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_keiracom_atoms_updated_at
+    ON public.keiracom_atoms;
+
+CREATE TRIGGER trg_keiracom_atoms_updated_at
+    BEFORE UPDATE ON public.keiracom_atoms
+    FOR EACH ROW
+    EXECUTE FUNCTION public.keiracom_atoms_set_updated_at();
+
+-- ----------------------------------------------------------------------------
+-- Supersession edges (content-level only per hard constraint)
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.keiracom_atom_supersession_edges (
+    edge_id            UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id          UUID         NOT NULL,
+    predecessor_atom   UUID         NOT NULL,
+    successor_atom     UUID         NOT NULL,
+    relationship_type  TEXT         NOT NULL,
+    confidence         REAL         NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+    created_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CHECK (predecessor_atom <> successor_atom),
+
+    FOREIGN KEY (tenant_id)        REFERENCES public.keiracom_tenants(tenant_id) ON DELETE CASCADE,
+    FOREIGN KEY (predecessor_atom) REFERENCES public.keiracom_atoms(atom_id)     ON DELETE CASCADE,
+    FOREIGN KEY (successor_atom)   REFERENCES public.keiracom_atoms(atom_id)     ON DELETE CASCADE,
+
+    UNIQUE (predecessor_atom, successor_atom, relationship_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_keiracom_atom_edges_predecessor
+    ON public.keiracom_atom_supersession_edges (predecessor_atom);
+CREATE INDEX IF NOT EXISTS idx_keiracom_atom_edges_successor
+    ON public.keiracom_atom_supersession_edges (successor_atom);
+CREATE INDEX IF NOT EXISTS idx_keiracom_atom_edges_tenant
+    ON public.keiracom_atom_supersession_edges (tenant_id);
+
+-- ----------------------------------------------------------------------------
+-- Atomizer job log (metering + audit)
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.keiracom_atomizer_jobs (
+    job_id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id          UUID         NOT NULL,
+    source_ref         TEXT         NOT NULL,
+    source_kind        TEXT         NOT NULL
+        CHECK (source_kind IN ('skill', 'manual', 'governance_doc', 'discovery_log', 'session')),
+
+    atomizer_model     TEXT         NOT NULL,
+    atomizer_temp      REAL         NOT NULL DEFAULT 0
+        CHECK (atomizer_temp >= 0 AND atomizer_temp <= 2),
+    atomizer_tokens_in BIGINT       NOT NULL DEFAULT 0,
+    atomizer_tokens_out BIGINT      NOT NULL DEFAULT 0,
+    atomizer_latency_ms INTEGER     NOT NULL DEFAULT 0,
+    atoms_produced     INTEGER      NOT NULL DEFAULT 0,
+
+    verifier_model     TEXT,
+    verifier_tokens_in BIGINT,
+    verifier_tokens_out BIGINT,
+    verifier_latency_ms INTEGER,
+    verifier_flags     JSONB        NOT NULL DEFAULT '[]'::jsonb,
+
+    status             TEXT         NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'atomizer_done', 'verifier_done', 'ratified', 'failed')),
+    created_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    FOREIGN KEY (tenant_id) REFERENCES public.keiracom_tenants(tenant_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_keiracom_atomizer_jobs_tenant_status
+    ON public.keiracom_atomizer_jobs (tenant_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_keiracom_atomizer_jobs_source
+    ON public.keiracom_atomizer_jobs (source_ref);
+
+CREATE OR REPLACE FUNCTION public.keiracom_atomizer_jobs_set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_keiracom_atomizer_jobs_updated_at
+    ON public.keiracom_atomizer_jobs;
+
+CREATE TRIGGER trg_keiracom_atomizer_jobs_updated_at
+    BEFORE UPDATE ON public.keiracom_atomizer_jobs
+    FOR EACH ROW
+    EXECUTE FUNCTION public.keiracom_atomizer_jobs_set_updated_at();

--- a/tests/keiracom_system/atomization/test_atom_store.py
+++ b/tests/keiracom_system/atomization/test_atom_store.py
@@ -1,0 +1,330 @@
+"""AtomStore unit tests — tenant-prefix guard + insert/retrieve + supersession."""
+
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.keiracom_system.atomization.atom_store import AtomStore, AtomStoreError
+from src.keiracom_system.atomization.schema import (
+    AtomV1,
+    SupersessionEdgeV1,
+)
+from src.keiracom_system.embeddings.tei_client import TEIClient, _HTTPResponse
+
+
+class _FakeDB:
+    """Minimal DB fake — record executes + serve canned fetchone/fetchall."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, tuple]] = []
+        self._next_one: Any = None
+        self._next_all: list[Any] = []
+
+    def execute(self, query: str, *params):
+        self.calls.append((query, params))
+
+    def fetchone(self):
+        return self._next_one
+
+    def fetchall(self):
+        return self._next_all
+
+    def queue_fetchone(self, row: Any) -> None:
+        self._next_one = row
+
+    def queue_fetchall(self, rows: list[Any]) -> None:
+        self._next_all = rows
+
+
+def _fake_tei() -> TEIClient:
+    """TEIClient with HTTP DI — returns deterministic 384-dim vectors of 0.1."""
+
+    def fake_post(url: str, payload: dict[str, Any], timeout: float) -> _HTTPResponse:
+        n = len(payload["inputs"])
+        body = (
+            b"["
+            + b",".join(b"[" + b",".join(b"0.1" for _ in range(384)) + b"]" for _ in range(n))
+            + b"]"
+        )
+        return _HTTPResponse(200, body)
+
+    def fake_get(url: str, timeout: float) -> _HTTPResponse:
+        return _HTTPResponse(200, b'{"status": "ok"}')
+
+    return TEIClient(http_get=fake_get, http_post=fake_post)
+
+
+def _make_atom(tenant_id: UUID) -> AtomV1:
+    return AtomV1(
+        atom_id=uuid4(),
+        tenant_id=tenant_id,
+        trigger_condition={"kind": "request_shape", "params": {"q": "x"}},
+        content="test content",
+        anti_pattern=None,
+        example=None,
+        provenance={
+            "source": "test",
+            "freshness": "2026-05-26T11:00:00Z",
+            "confidence": 0.9,
+            "last_validated": "2026-05-26T11:00:00Z",
+        },
+    )
+
+
+# ----- Construction invariants ---------------------------------------------
+
+
+def test_init_rejects_empty_tenant_id():
+    with pytest.raises(AtomStoreError, match="tenant_id is required"):
+        AtomStore(db=_FakeDB(), tenant_id="", embedder=_fake_tei())
+
+
+def test_tenant_id_property():
+    tid = str(uuid4())
+    store = AtomStore(db=_FakeDB(), tenant_id=tid, embedder=_fake_tei())
+    assert store.tenant_id == tid
+
+
+# ----- Tenant-prefix guard (read/write boundary defence-in-depth) ----------
+
+
+def test_insert_atom_rejects_cross_tenant():
+    tid_a = uuid4()
+    tid_b = uuid4()
+    store = AtomStore(db=_FakeDB(), tenant_id=tid_a, embedder=_fake_tei())
+    atom = _make_atom(tid_b)  # built for tenant B
+    with pytest.raises(AtomStoreError, match="tenant_id mismatch"):
+        store.insert_atom(atom)
+
+
+def test_insert_supersession_edge_rejects_cross_tenant():
+    tid_a = uuid4()
+    tid_b = uuid4()
+    store = AtomStore(db=_FakeDB(), tenant_id=tid_a, embedder=_fake_tei())
+    edge = SupersessionEdgeV1(
+        edge_id=uuid4(),
+        tenant_id=tid_b,
+        predecessor_atom=uuid4(),
+        successor_atom=uuid4(),
+        relationship_type="supersedes",
+        confidence=0.9,
+    )
+    with pytest.raises(AtomStoreError, match="tenant_id mismatch"):
+        store.insert_supersession_edge(edge)
+
+
+# ----- insert_atom happy path + embedding computation ----------------------
+
+
+def test_insert_atom_returns_atom_id_and_invokes_execute():
+    tid = uuid4()
+    db = _FakeDB()
+    atom = _make_atom(tid)
+    db.queue_fetchone((str(atom.atom_id),))
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    returned = store.insert_atom(atom)
+    assert returned == atom.atom_id
+    assert len(db.calls) == 1
+    assert "INSERT INTO keiracom_atoms" in db.calls[0][0]
+
+
+def test_insert_atom_computes_embedding_when_absent():
+    """Atom built without content_embedding gets one computed from TEIClient."""
+    tid = uuid4()
+    db = _FakeDB()
+    atom = _make_atom(tid)
+    db.queue_fetchone((str(atom.atom_id),))
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    store.insert_atom(atom)
+    # Embedding is the 9th positional param (atom_id, tenant_id, trigger,
+    # content, anti, example, provenance, composition_tags, embedding, ...)
+    params = db.calls[0][1]
+    embedding_arg = params[8]
+    # pgvector string format
+    assert embedding_arg.startswith("[")
+    assert embedding_arg.endswith("]")
+
+
+def test_insert_atom_raises_on_no_row_returned():
+    """If RETURNING gives no row, that's an error (should never happen)."""
+    tid = uuid4()
+    db = _FakeDB()
+    db.queue_fetchone(None)
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    with pytest.raises(AtomStoreError, match="no atom_id returned"):
+        store.insert_atom(_make_atom(tid))
+
+
+# ----- get_atom + cross-tenant collapse ------------------------------------
+
+
+def test_get_atom_returns_none_when_not_found():
+    tid = uuid4()
+    db = _FakeDB()
+    db.queue_fetchone(None)
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    assert store.get_atom(uuid4()) is None
+
+
+def test_get_atom_query_includes_tenant_filter():
+    tid = uuid4()
+    db = _FakeDB()
+    db.queue_fetchone(None)
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    store.get_atom(uuid4())
+    query, params = db.calls[0]
+    assert "tenant_id = %s" in query
+    assert params[1] == str(tid)
+
+
+def test_get_atom_builds_atom_v1_from_row():
+    tid = uuid4()
+    aid = uuid4()
+    db = _FakeDB()
+    db.queue_fetchone(
+        (
+            str(aid),
+            str(tid),
+            '{"kind": "request_shape", "params": {"x": 1}}',
+            "stored content",
+            None,
+            None,
+            '{"source": "x", "freshness": "2026-05-26T11:00:00Z", '
+            '"confidence": 0.9, "last_validated": "2026-05-26T11:00:00Z"}',
+            None,
+            1,
+            "active",
+        )
+    )
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    atom = store.get_atom(aid)
+    assert atom is not None
+    assert atom.atom_id == aid
+    assert atom.content == "stored content"
+    assert atom.state == "active"
+
+
+# ----- retrieve_top_k ------------------------------------------------------
+
+
+def test_retrieve_top_k_filters_by_tenant_and_active_state():
+    tid = uuid4()
+    db = _FakeDB()
+    db.queue_fetchall([])
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    store.retrieve_top_k("anchor query", top_k=5)
+    query, params = db.calls[0]
+    assert "tenant_id = %s" in query
+    assert "state = 'active'" in query
+    assert params[0] == str(tid)
+    assert params[2] == 5
+
+
+def test_retrieve_top_k_rejects_non_positive():
+    tid = uuid4()
+    store = AtomStore(db=_FakeDB(), tenant_id=tid, embedder=_fake_tei())
+    with pytest.raises(AtomStoreError, match="top_k must be > 0"):
+        store.retrieve_top_k("x", top_k=0)
+
+
+# ----- transition_state ----------------------------------------------------
+
+
+def test_transition_state_to_cold_archive():
+    tid = uuid4()
+    db = _FakeDB()
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    store.transition_state(uuid4(), "cold_archive")
+    query, params = db.calls[0]
+    assert "UPDATE keiracom_atoms" in query
+    assert params[0] == "cold_archive"
+    assert params[2] == str(tid)  # tenant filter present
+
+
+def test_transition_state_rejects_invalid():
+    tid = uuid4()
+    store = AtomStore(db=_FakeDB(), tenant_id=tid, embedder=_fake_tei())
+    with pytest.raises(AtomStoreError, match="not in"):
+        store.transition_state(uuid4(), "_bogus")
+
+
+# ----- insert_supersession_edge --------------------------------------------
+
+
+def test_insert_supersession_edge_verifies_endpoints_exist():
+    tid = uuid4()
+    pred_id = uuid4()
+    succ_id = uuid4()
+    db = _FakeDB()
+    # First get_atom call (predecessor) → returns None
+    db.queue_fetchone(None)
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    edge = SupersessionEdgeV1(
+        edge_id=uuid4(),
+        tenant_id=tid,
+        predecessor_atom=pred_id,
+        successor_atom=succ_id,
+        relationship_type="supersedes",
+        confidence=0.9,
+    )
+    with pytest.raises(AtomStoreError, match="predecessor_atom .* not found"):
+        store.insert_supersession_edge(edge)
+
+
+def test_insert_supersession_edge_happy_path():
+    tid = uuid4()
+    pred_id = uuid4()
+    succ_id = uuid4()
+    # _MultiStubDB defined below; pred/succ rows + edge_id queued via queue_many.
+    pred_row = (
+        str(pred_id),
+        str(tid),
+        '{"kind": "request_shape", "params": {}}',
+        "pred content",
+        None,
+        None,
+        '{"source": "x", "freshness": "2026-05-26T11:00:00Z", "confidence": 0.9, "last_validated": "2026-05-26T11:00:00Z"}',
+        None,
+        1,
+        "active",
+    )
+    succ_row = (
+        str(succ_id),
+        str(tid),
+        '{"kind": "request_shape", "params": {}}',
+        "succ content",
+        None,
+        None,
+        '{"source": "x", "freshness": "2026-05-26T11:00:00Z", "confidence": 0.9, "last_validated": "2026-05-26T11:00:00Z"}',
+        None,
+        1,
+        "active",
+    )
+    edge_id = uuid4()
+
+    # _FakeDB only has 1 slot of queued fetchone. Use a custom stub instead.
+    class _MultiStubDB(_FakeDB):
+        def __init__(self):
+            super().__init__()
+            self._queue: list[Any] = []
+
+        def queue_many(self, rows: list[Any]) -> None:
+            self._queue.extend(rows)
+
+        def fetchone(self):
+            return self._queue.pop(0) if self._queue else None
+
+    db2 = _MultiStubDB()
+    db2.queue_many([pred_row, succ_row, (str(edge_id),)])
+    store = AtomStore(db=db2, tenant_id=tid, embedder=_fake_tei())
+    edge = SupersessionEdgeV1(
+        edge_id=edge_id,
+        tenant_id=tid,
+        predecessor_atom=pred_id,
+        successor_atom=succ_id,
+        relationship_type="supersedes",
+        confidence=0.9,
+    )
+    returned = store.insert_supersession_edge(edge)
+    assert returned == edge_id

--- a/tests/keiracom_system/atomization/test_atom_store_ci_guard.py
+++ b/tests/keiracom_system/atomization/test_atom_store_ci_guard.py
@@ -1,0 +1,125 @@
+"""Integration test for the atom-store-discipline CI guard.
+
+Verifies BOTH:
+  - Positive path: guard passes on the current repo tree.
+  - Negative path (per feedback_negative_path_test_before_approve): a
+    synthetic offender file inside src/keiracom_system/ outside the
+    atomization module triggers a non-zero exit.
+
+Mirrors the test pattern from tests/keiracom_system/cache/
+test_no_raw_valkey_outside_client.py (PR #1173).
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GUARD = REPO_ROOT / "scripts" / "ci" / "check_no_raw_atom_store_outside_module.sh"
+
+
+def _run_guard(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_guard_passes_on_clean_tree():
+    """Positive path — current repo (PR introducing this test) is clean."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    result = _run_guard(REPO_ROOT)
+    assert result.returncode == 0, f"guard failed on clean tree: {result.stdout}\n{result.stderr}"
+    assert "no raw atom-store SQL outside atomization module" in result.stdout
+
+
+def test_guard_fails_on_insert_outside_module(tmp_path: Path):
+    """`INSERT INTO keiracom_atoms` outside atomization/ MUST fail."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    scope_dir = tmp_path / "src" / "keiracom_system" / "leaky"
+    scope_dir.mkdir(parents=True)
+    (scope_dir / "leak.py").write_text(
+        'cursor.execute("INSERT INTO keiracom_atoms VALUES (...)")\n'
+    )
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_no_raw_atom_store_outside_module.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode != 0
+    assert "FAIL (atom-store-discipline)" in result.stdout
+    assert "leak.py" in result.stdout
+
+
+def test_guard_fails_on_select_outside_module(tmp_path: Path):
+    """`FROM keiracom_atoms` SELECT clause outside atomization/ MUST fail."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    scope_dir = tmp_path / "src" / "keiracom_system" / "reader"
+    scope_dir.mkdir(parents=True)
+    (scope_dir / "leak_read.py").write_text(
+        'cursor.execute("SELECT atom_id FROM keiracom_atoms WHERE tenant_id = %s", tid)\n'
+    )
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_no_raw_atom_store_outside_module.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode != 0
+    assert "leak_read.py" in result.stdout
+
+
+def test_guard_fails_on_supersession_edges_outside_module(tmp_path: Path):
+    """`UPDATE keiracom_atom_supersession_edges` outside atomization/ MUST fail.
+
+    Tests that the guard's pattern matches the suffix tables (supersession_edges
+    + atomizer_jobs) not just the base keiracom_atoms table.
+    """
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    scope_dir = tmp_path / "src" / "keiracom_system" / "leaky_edges"
+    scope_dir.mkdir(parents=True)
+    (scope_dir / "leak.py").write_text(
+        'db.execute("UPDATE keiracom_atom_supersession_edges SET confidence = 0")\n'
+    )
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_no_raw_atom_store_outside_module.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode != 0
+
+
+def test_guard_exempts_atomization_module(tmp_path: Path):
+    """src/keiracom_system/atomization/ is the canonical module owner — exempt."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    cache_dir = tmp_path / "src" / "keiracom_system" / "atomization"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "atom_store.py").write_text(
+        'cursor.execute("INSERT INTO keiracom_atoms VALUES (...)")\n'
+    )
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_no_raw_atom_store_outside_module.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode == 0, (
+        f"guard should exempt atomization/; got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_guard_inactive_when_scope_missing(tmp_path: Path):
+    """Empty repo (no src/keiracom_system/) — guard exits 0 with `inactive` message."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_no_raw_atom_store_outside_module.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode == 0
+    assert "guard inactive" in result.stdout

--- a/tests/keiracom_system/atomization/test_atomizer.py
+++ b/tests/keiracom_system/atomization/test_atomizer.py
@@ -1,0 +1,262 @@
+"""Atomizer unit tests — uses fake LLM client + AtomStore + job DB."""
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from src.keiracom_system.atomization.atom_store import AtomStore
+from src.keiracom_system.atomization.atomizer import (
+    ATOMS_RESPONSE_SCHEMA,
+    FEATURE_FLAG_ENV,
+    Atomizer,
+    AtomizerError,
+    is_atomizer_enabled,
+)
+from src.keiracom_system.atomization.llm_client import LLMResponse
+from src.keiracom_system.embeddings.tei_client import TEIClient, _HTTPResponse
+
+
+def _fake_tei() -> TEIClient:
+    def fake_post(url: str, payload: dict[str, Any], timeout: float) -> _HTTPResponse:
+        n = len(payload["inputs"])
+        body = (
+            b"["
+            + b",".join(b"[" + b",".join(b"0.1" for _ in range(384)) + b"]" for _ in range(n))
+            + b"]"
+        )
+        return _HTTPResponse(200, body)
+
+    def fake_get(url: str, timeout: float) -> _HTTPResponse:
+        return _HTTPResponse(200, b'{"status": "ok"}')
+
+    return TEIClient(http_get=fake_get, http_post=fake_post)
+
+
+class _FakeDB:
+    def __init__(self):
+        self.calls: list[tuple[str, tuple]] = []
+        self._next_one: Any = None
+
+    def execute(self, query: str, *params):
+        self.calls.append((query, params))
+
+    def fetchone(self):
+        return self._next_one
+
+    def fetchall(self):
+        return []
+
+    def queue_fetchone(self, row: Any) -> None:
+        self._next_one = row
+
+
+class _FakeLLM:
+    """Returns canned LLMResponse — no live LiteLLM call."""
+
+    def __init__(self, parsed: Any, *, tokens_in: int = 100, tokens_out: int = 50):
+        self.parsed = parsed
+        self.tokens_in = tokens_in
+        self.tokens_out = tokens_out
+        self.calls: list[dict] = []
+
+    def call_structured(self, **kwargs):
+        self.calls.append(kwargs)
+        return LLMResponse(
+            parsed=self.parsed,
+            tokens_in=self.tokens_in,
+            tokens_out=self.tokens_out,
+            latency_ms=42,
+            model=kwargs.get("model", "test/model"),
+        )
+
+
+def _well_formed_atom() -> dict:
+    return {
+        "trigger_condition": {"kind": "request_shape", "params": {"matches": "summarize"}},
+        "content": "When user asks to summarize, return 3 bullet points.",
+        "anti_pattern": "Returning a long paragraph instead of bullets.",
+        "example": "Q: summarize X. A: - point 1\n- point 2\n- point 3",
+        "provenance": {
+            "source": "skills/summarize.md@abc",
+            "freshness": "2026-05-26T11:00:00Z",
+            "confidence": 0.92,
+            "last_validated": "2026-05-26T11:00:00Z",
+        },
+    }
+
+
+# ----- Feature flag --------------------------------------------------------
+
+
+def test_atomizer_disabled_by_default(monkeypatch):
+    monkeypatch.delenv(FEATURE_FLAG_ENV, raising=False)
+    assert is_atomizer_enabled() is False
+
+
+def test_atomizer_enabled_when_env_on(monkeypatch):
+    monkeypatch.setenv(FEATURE_FLAG_ENV, "on")
+    assert is_atomizer_enabled() is True
+
+
+def test_atomizer_disabled_for_other_env_values(monkeypatch):
+    monkeypatch.setenv(FEATURE_FLAG_ENV, "false")
+    assert is_atomizer_enabled() is False
+
+
+# ----- Response schema lock ------------------------------------------------
+
+
+def test_response_schema_enum_locks_trigger_vocabulary():
+    """Atomizer's structured-output schema MUST enumerate VALID_TRIGGER_KINDS.
+
+    If a future PR adds a kind to the vocabulary, ATOMS_RESPONSE_SCHEMA must
+    update — otherwise Gemini refuses to emit the new kind. Test locks parity.
+    """
+    from src.keiracom_system.atomization.schema import VALID_TRIGGER_KINDS
+
+    schema_enum = set(
+        ATOMS_RESPONSE_SCHEMA["schema"]["properties"]["atoms"]["items"]["properties"][
+            "trigger_condition"
+        ]["properties"]["kind"]["enum"]
+    )
+    assert schema_enum == set(VALID_TRIGGER_KINDS)
+
+
+# ----- atomize() happy path + invariants -----------------------------------
+
+
+def _make_atomizer(parsed: Any, *, db: _FakeDB | None = None):
+    tid = uuid4()
+    db = db or _FakeDB()
+    db.queue_fetchone((str(uuid4()),))  # AtomStore INSERT returning atom_id
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    llm = _FakeLLM(parsed)
+    return Atomizer(llm=llm, store=store, job_db=db), llm, db
+
+
+def test_atomize_rejects_invalid_source_kind():
+    atomizer, _, _ = _make_atomizer({"atoms": []})
+    with pytest.raises(AtomizerError, match="source_kind"):
+        atomizer.atomize(source_ref="x", source_kind="_bogus", source_text="t")
+
+
+def test_atomize_rejects_empty_source_text():
+    atomizer, _, _ = _make_atomizer({"atoms": []})
+    with pytest.raises(AtomizerError, match="source_text must be non-empty"):
+        atomizer.atomize(source_ref="x", source_kind="skill", source_text="")
+
+
+def test_atomize_writes_pending_then_atomizer_done():
+    """Job row INSERTed pending BEFORE LLM, UPDATEd to atomizer_done AFTER."""
+    atomizer, _llm, db = _make_atomizer({"atoms": []})
+    atomizer.atomize(source_ref="skills/test.md", source_kind="skill", source_text="content")
+    # First execute: INSERT job row with status='pending'
+    assert "INSERT INTO keiracom_atomizer_jobs" in db.calls[0][0]
+    assert "'pending'" in db.calls[0][0]
+    # Final execute: UPDATE job row status='atomizer_done'
+    last = db.calls[-1][0]
+    assert "UPDATE keiracom_atomizer_jobs" in last
+    assert "atomizer_done" in last
+
+
+def test_atomize_calls_llm_at_temperature_zero():
+    atomizer, llm, _ = _make_atomizer({"atoms": []})
+    atomizer.atomize(source_ref="x", source_kind="skill", source_text="t")
+    assert llm.calls[0]["temperature"] == 0.0
+
+
+def test_atomize_invokes_atom_store_insert_per_atom():
+    """One atom in response → one INSERT INTO keiracom_atoms."""
+
+    # Multi-queue DB for the multiple fetchones needed
+    class _MultiDB(_FakeDB):
+        def __init__(self):
+            super().__init__()
+            self._q = []
+
+        def queue_many(self, rows):
+            self._q.extend(rows)
+
+        def fetchone(self):
+            return self._q.pop(0) if self._q else None
+
+    db = _MultiDB()
+    # 1 atom → 1 INSERT INTO keiracom_atoms → 1 fetchone returning atom_id
+    db.queue_many([(str(uuid4()),)])
+    tid = uuid4()
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    llm = _FakeLLM({"atoms": [_well_formed_atom()]})
+    atomizer = Atomizer(llm=llm, store=store, job_db=db)
+    job = atomizer.atomize(source_ref="x", source_kind="skill", source_text="t")
+    assert job.atoms_produced == 1
+    assert len(job.atom_ids) == 1
+    # Check that an INSERT INTO keiracom_atoms call landed in db.calls
+    atom_inserts = [c for c in db.calls if "INSERT INTO keiracom_atoms" in c[0]]
+    assert len(atom_inserts) == 1
+
+
+def test_atomize_emits_metering_when_emitter_provided():
+    """Metric emitter receives 4 metric names per atomize() call."""
+    captured: list[tuple[str, dict]] = []
+
+    def emit(name: str, tags: dict[str, str]) -> None:
+        captured.append((name, tags))
+
+    class _MultiDB(_FakeDB):
+        def __init__(self):
+            super().__init__()
+            self._q = []
+
+        def queue_many(self, rows):
+            self._q.extend(rows)
+
+        def fetchone(self):
+            return self._q.pop(0) if self._q else None
+
+    db = _MultiDB()
+    db.queue_many([(str(uuid4()),)])
+    tid = uuid4()
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    llm = _FakeLLM({"atoms": [_well_formed_atom()]})
+    atomizer = Atomizer(llm=llm, store=store, job_db=db, metric_emitter=emit)
+    atomizer.atomize(source_ref="x", source_kind="skill", source_text="t")
+    names = {n for n, _ in captured}
+    assert "keiracom.atomization.atomizer.tokens" in names
+    assert "keiracom.atomization.atomizer.latency_ms" in names
+    assert "keiracom.atomization.atoms_produced" in names
+
+
+def test_atomize_rejects_non_list_atoms_payload():
+    """If LLM returns malformed shape, job marked failed + AtomizerError raised."""
+    atomizer, _, db = _make_atomizer({"atoms": "not-a-list"})
+    with pytest.raises(AtomizerError, match="non-list 'atoms' payload"):
+        atomizer.atomize(source_ref="x", source_kind="skill", source_text="t")
+    # job row updated to 'failed'
+    failures = [c for c in db.calls if "status = 'failed'" in c[0]]
+    assert len(failures) == 1
+
+
+def test_atomize_handles_atom_with_invalid_trigger():
+    """A single malformed atom in the response raises AtomizerError + marks failed."""
+
+    class _MultiDB(_FakeDB):
+        def __init__(self):
+            super().__init__()
+            self._q = []
+
+        def queue_many(self, rows):
+            self._q.extend(rows)
+
+        def fetchone(self):
+            return self._q.pop(0) if self._q else None
+
+    bad_atom = dict(_well_formed_atom())
+    bad_atom["trigger_condition"] = {"kind": "_bogus", "params": {}}
+    db = _MultiDB()
+    tid = uuid4()
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    llm = _FakeLLM({"atoms": [bad_atom]})
+    atomizer = Atomizer(llm=llm, store=store, job_db=db)
+    with pytest.raises(ValueError, match="kind"):  # raised by AtomV1.__post_init__
+        atomizer.atomize(source_ref="x", source_kind="skill", source_text="t")

--- a/tests/keiracom_system/atomization/test_composer.py
+++ b/tests/keiracom_system/atomization/test_composer.py
@@ -1,0 +1,221 @@
+"""Composer unit tests — Week 2 atomization pilot."""
+
+from uuid import uuid4
+
+import pytest
+
+from src.keiracom_system.atomization.composer import (
+    DEFAULT_MAX_ATOMS_IN_RESPONSE,
+    DEFAULT_MIN_SCORE_FOR_INCLUSION,
+    VALID_ENDPOINTS,
+    ComposedOutput,
+    Composer,
+    ComposerError,
+    select_provenance_trail,
+)
+from src.keiracom_system.atomization.retriever import RetrievalResult
+from src.keiracom_system.atomization.schema import AtomV1
+
+
+def _make_retrieval_result(
+    *,
+    content: str,
+    score: float,
+    anti_pattern: str | None = None,
+    example: str | None = None,
+) -> RetrievalResult:
+    atom = AtomV1(
+        atom_id=uuid4(),
+        tenant_id=uuid4(),
+        trigger_condition={"kind": "request_shape", "params": {"q": "x"}},
+        content=content,
+        anti_pattern=anti_pattern,
+        example=example,
+        provenance={
+            "source": "test",
+            "freshness": "2026-05-26T11:00:00Z",
+            "confidence": 0.9,
+            "last_validated": "2026-05-26T11:00:00Z",
+        },
+    )
+    return RetrievalResult(atom=atom, score=score)
+
+
+# ---- Construction + validation --------------------------------------------
+
+
+def test_composer_rejects_zero_max_atoms():
+    with pytest.raises(ComposerError, match="max_atoms must be > 0"):
+        Composer(max_atoms=0)
+
+
+def test_compose_rejects_unknown_endpoint():
+    composer = Composer()
+    with pytest.raises(ComposerError, match="not in"):
+        composer.compose(atoms=[], endpoint="email")
+
+
+def test_valid_endpoints_chat_reply_only_week_2():
+    """Week 2 supports chat_reply only; other endpoints via Endpoint Translator."""
+    assert frozenset({"chat_reply"}) == VALID_ENDPOINTS
+
+
+# ---- Empty / no-confidence path -------------------------------------------
+
+
+def test_compose_empty_atoms_returns_non_hallucinating_placeholder():
+    composer = Composer()
+    output = composer.compose_chat_reply(atoms=[], query_text="how do I X?")
+    assert "don't have high-confidence knowledge" in output.text
+    assert "how do I X?" in output.text
+    assert output.atoms_used == []
+    assert output.endpoint == "chat_reply"
+
+
+def test_compose_no_query_text_placeholder_is_generic():
+    composer = Composer()
+    output = composer.compose_chat_reply(atoms=[], query_text=None)
+    assert "don't have high-confidence knowledge" in output.text
+
+
+def test_compose_below_min_score_treated_as_empty():
+    composer = Composer(min_score=0.5)
+    results = [_make_retrieval_result(content="low-score atom", score=0.1)]
+    output = composer.compose_chat_reply(atoms=results, query_text="q")
+    # All atoms below threshold → empty path triggers
+    assert "don't have high-confidence knowledge" in output.text
+    assert output.atoms_used == []
+
+
+# ---- Happy paths ----------------------------------------------------------
+
+
+def test_compose_single_atom_returns_content_verbatim():
+    composer = Composer()
+    results = [_make_retrieval_result(content="The answer is 42.", score=0.9)]
+    output = composer.compose_chat_reply(atoms=results, query_text="what?")
+    assert "The answer is 42." in output.text
+    assert len(output.atoms_used) == 1
+
+
+def test_compose_multi_atom_numbered_list_with_preamble():
+    composer = Composer()
+    results = [
+        _make_retrieval_result(content="First fact.", score=0.9),
+        _make_retrieval_result(content="Second fact.", score=0.8),
+        _make_retrieval_result(content="Third fact.", score=0.7),
+    ]
+    output = composer.compose_chat_reply(atoms=results, query_text="tell me")
+    # Numbered + with preamble (>1 atom)
+    assert "Based on what I know" in output.text
+    assert "1. First fact." in output.text
+    assert "2. Second fact." in output.text
+    assert "3. Third fact." in output.text
+    assert len(output.atoms_used) == 3
+
+
+def test_compose_renders_anti_pattern_when_present():
+    composer = Composer()
+    results = [
+        _make_retrieval_result(
+            content="Use bullet points for summaries.",
+            score=0.9,
+            anti_pattern="Returning a paragraph instead.",
+        )
+    ]
+    output = composer.compose_chat_reply(atoms=results, query_text="how")
+    assert "(Avoid: Returning a paragraph instead.)" in output.text
+
+
+def test_compose_renders_example_when_present():
+    composer = Composer()
+    results = [
+        _make_retrieval_result(
+            content="Summarize as bullets.",
+            score=0.9,
+            example="Q: tell me about X. A: - point 1\n- point 2",
+        )
+    ]
+    output = composer.compose_chat_reply(atoms=results, query_text="how")
+    assert "Example:" in output.text
+    assert "Q: tell me about X" in output.text
+
+
+def test_compose_renders_only_first_line_of_multiline_example():
+    composer = Composer()
+    results = [
+        _make_retrieval_result(
+            content="Atom.",
+            score=0.9,
+            example="line one\nline two\nline three",
+        )
+    ]
+    output = composer.compose_chat_reply(atoms=results)
+    assert "Example: line one" in output.text
+    # Second line of example NOT included in chat-reply rendering
+    assert "line two" not in output.text
+
+
+# ---- Truncation ------------------------------------------------------------
+
+
+def test_compose_truncates_to_max_atoms_default():
+    composer = Composer()
+    assert DEFAULT_MAX_ATOMS_IN_RESPONSE == 5
+    results = [_make_retrieval_result(content=f"atom {i}", score=0.9 - 0.01 * i) for i in range(10)]
+    output = composer.compose_chat_reply(atoms=results, query_text="q")
+    assert len(output.atoms_used) == 5
+    assert output.truncated_count == 5
+
+
+def test_compose_custom_max_atoms():
+    composer = Composer(max_atoms=2)
+    results = [_make_retrieval_result(content=f"a{i}", score=0.9) for i in range(5)]
+    output = composer.compose_chat_reply(atoms=results, query_text="q")
+    assert len(output.atoms_used) == 2
+    assert output.truncated_count == 3
+
+
+# ---- Defaults --------------------------------------------------------------
+
+
+def test_default_min_score_for_inclusion():
+    assert DEFAULT_MIN_SCORE_FOR_INCLUSION == 0.1
+
+
+# ---- Provenance trail ------------------------------------------------------
+
+
+def test_select_provenance_trail_returns_audit_dict():
+    composer = Composer()
+    results = [
+        _make_retrieval_result(content="A.", score=0.9),
+        _make_retrieval_result(content="B.", score=0.8),
+    ]
+    output = composer.compose_chat_reply(atoms=results, query_text="x")
+    trail = select_provenance_trail(output)
+    assert trail["endpoint"] == "chat_reply"
+    assert len(trail["atoms_used"]) == 2
+    assert trail["truncated_count"] == 0
+    assert trail["text_length_chars"] > 0
+
+
+# ---- Hard-constraint awareness --------------------------------------------
+
+
+def test_composer_output_is_user_facing_string_only():
+    """ComposedOutput.text MUST be a plain string for user-facing output.
+
+    Hard constraint: Composer output never reaches agent reasoning input.
+    The contract is enforced at the type level: ComposedOutput.text is str,
+    not a structured atom-list. Agents that need atoms call MalRetriever
+    directly — they don't (and can't sensibly) consume ComposedOutput.
+    """
+    composer = Composer()
+    results = [_make_retrieval_result(content="a", score=0.9)]
+    output = composer.compose_chat_reply(atoms=results)
+    assert isinstance(output, ComposedOutput)
+    assert isinstance(output.text, str)
+    # Atoms list is for audit provenance, not for agent consumption
+    assert isinstance(output.atoms_used, list)
+    assert all(isinstance(x, str) for x in output.atoms_used)

--- a/tests/keiracom_system/atomization/test_e2e_synthetic_skill.py
+++ b/tests/keiracom_system/atomization/test_e2e_synthetic_skill.py
@@ -1,0 +1,319 @@
+"""Week 1 acceptance test — synthetic skill atomized end-to-end with verifier pass.
+
+Per Elliot dispatch: "Synthetic skill atomized end-to-end with verifier pass =
+Week 1 acceptance."
+
+Uses fake LLM + fake DB so no live Gemini key + no Postgres dependency. The
+fakes return canned structured outputs matching ATOMS_RESPONSE_SCHEMA /
+VERIFIER_RESPONSE_SCHEMA — the real Gemini Flash + Pro would emit identically-
+shaped responses on real input.
+
+Locks the integration contract: atomizer→store→verifier→store→job-row
+sequence works without coupling between the components beyond the documented
+Protocol surfaces.
+"""
+
+from typing import Any
+from uuid import UUID, uuid4
+
+from src.keiracom_system.atomization.atom_store import AtomStore
+from src.keiracom_system.atomization.atomizer import Atomizer
+from src.keiracom_system.atomization.llm_client import LLMResponse
+from src.keiracom_system.atomization.verifier import Verifier
+from src.keiracom_system.embeddings.tei_client import TEIClient, _HTTPResponse
+
+SYNTHETIC_SKILL_TEXT = """\
+# /summarize skill
+
+When the user asks Keira to summarize a document, return exactly 3 bullet
+points. Each bullet should be one sentence covering one key idea.
+
+DO NOT return a paragraph — bullets only.
+
+Example:
+  Q: Summarize the Q4 results.
+  A:
+    - Revenue grew 22% year-over-year, driven by enterprise tier adoption.
+    - Operating margin expanded 4 percentage points on lower customer acquisition cost.
+    - Active customer count crossed 5,000 for the first time.
+"""
+
+
+def _fake_tei() -> TEIClient:
+    def fake_post(url, payload, timeout):
+        n = len(payload["inputs"])
+        body = (
+            b"["
+            + b",".join(b"[" + b",".join(b"0.1" for _ in range(384)) + b"]" for _ in range(n))
+            + b"]"
+        )
+        return _HTTPResponse(200, body)
+
+    def fake_get(url, timeout):
+        return _HTTPResponse(200, b'{"status": "ok"}')
+
+    return TEIClient(http_get=fake_get, http_post=fake_post)
+
+
+# Canned Gemini Flash response for the synthetic skill above.
+SYNTHETIC_ATOMIZER_PARSED = {
+    "atoms": [
+        {
+            "trigger_condition": {
+                "kind": "request_shape",
+                "params": {"intent": "summarize", "object_type": "document"},
+            },
+            "content": "When the user asks Keira to summarize a document, return exactly 3 bullet points.",
+            "anti_pattern": "Returning a paragraph instead of bullets.",
+            "example": "Q: Summarize Q4. A: - revenue grew - margin expanded - customers crossed 5000",
+            "provenance": {
+                "source": "skills/summarize.md@v1",
+                "freshness": "2026-05-26T11:00:00Z",
+                "confidence": 0.93,
+                "last_validated": "2026-05-26T11:00:00Z",
+            },
+        },
+        {
+            "trigger_condition": {
+                "kind": "context_predicate",
+                "params": {"in_response_to": "summarize_intent"},
+            },
+            "content": "Each bullet should be one sentence covering one key idea.",
+            "anti_pattern": "Multi-sentence bullets or bullets that overlap on the same idea.",
+            "example": None,
+            "provenance": {
+                "source": "skills/summarize.md@v1",
+                "freshness": "2026-05-26T11:00:00Z",
+                "confidence": 0.91,
+                "last_validated": "2026-05-26T11:00:00Z",
+            },
+        },
+    ]
+}
+
+# Canned Gemini Pro verifier response — clean batch (no flags).
+CLEAN_VERIFIER_PARSED = {"flags": []}
+
+
+class _IntegrationDB:
+    """Single DB fake used by AtomStore + Atomizer.job_db + Verifier.job_db."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, tuple]] = []
+        self._q: list[Any] = []
+
+    def execute(self, query, *params):
+        self.calls.append((query, params))
+
+    def fetchone(self):
+        return self._q.pop(0) if self._q else None
+
+    def fetchall(self):
+        return []
+
+    def queue_many(self, rows):
+        self._q.extend(rows)
+
+
+class _FakeLLM:
+    def __init__(self, parsed: Any, *, tokens_in: int = 250, tokens_out: int = 180):
+        self.parsed = parsed
+        self.tokens_in = tokens_in
+        self.tokens_out = tokens_out
+        self.calls: list[dict] = []
+
+    def call_structured(self, **kwargs):
+        self.calls.append(kwargs)
+        return LLMResponse(
+            parsed=self.parsed,
+            tokens_in=self.tokens_in,
+            tokens_out=self.tokens_out,
+            latency_ms=120,
+            model=kwargs["model"],
+        )
+
+
+def test_synthetic_skill_e2e_atomize_then_verify_clean():
+    """Week 1 acceptance: synthetic skill → 2 atoms → verifier returns 0 flags.
+
+    Sequence:
+      1. Atomizer.atomize(source_text=synthetic_skill) — Gemini Flash fake
+         returns 2 well-formed atoms. AtomStore.insert_atom invoked twice.
+         Job row UPDATE'd to atomizer_done.
+      2. Verifier.verify(job_id, atom_ids) — Gemini Pro fake returns 0 flags.
+         Job row UPDATE'd to verifier_done with verifier_flags='[]'.
+    """
+    tenant_id = UUID("00000000-0000-0000-0000-000000000001")  # Dave's tenant
+    db = _IntegrationDB()
+    # AtomStore insert flow: each insert_atom returns an atom_id via fetchone.
+    # 2 atoms = 2 fetchone results for INSERT, plus we'll need verifier-side
+    # get_atom fetchones (2 atoms read back).
+    expected_atom_ids = [uuid4(), uuid4()]
+    # Atomizer flow:
+    #  - INSERT job row (no fetchone needed)
+    #  - INSERT atom 1 → returns atom_id 1
+    #  - INSERT atom 2 → returns atom_id 2
+    #  - UPDATE job to atomizer_done (no fetchone)
+    # Verifier flow:
+    #  - get_atom(atom 1) → returns row
+    #  - get_atom(atom 2) → returns row
+    #  - LLM call
+    #  - UPDATE job to verifier_done
+    db.queue_many(
+        [
+            (str(expected_atom_ids[0]),),  # atomizer insert atom 1
+            (str(expected_atom_ids[1]),),  # atomizer insert atom 2
+            (  # verifier get_atom(atom 1)
+                str(expected_atom_ids[0]),
+                str(tenant_id),
+                '{"kind": "request_shape", "params": {"intent": "summarize"}}',
+                "atom 1 content",
+                None,
+                None,
+                '{"source": "x", "freshness": "2026-05-26T11:00:00Z", '
+                '"confidence": 0.93, "last_validated": "2026-05-26T11:00:00Z"}',
+                None,
+                1,
+                "active",
+            ),
+            (  # verifier get_atom(atom 2)
+                str(expected_atom_ids[1]),
+                str(tenant_id),
+                '{"kind": "context_predicate", "params": {}}',
+                "atom 2 content",
+                None,
+                None,
+                '{"source": "x", "freshness": "2026-05-26T11:00:00Z", '
+                '"confidence": 0.91, "last_validated": "2026-05-26T11:00:00Z"}',
+                None,
+                1,
+                "active",
+            ),
+        ]
+    )
+
+    store = AtomStore(db=db, tenant_id=tenant_id, embedder=_fake_tei())
+    atomizer_llm = _FakeLLM(SYNTHETIC_ATOMIZER_PARSED)
+    verifier_llm = _FakeLLM(CLEAN_VERIFIER_PARSED)
+
+    # Captures metrics for both atomizer + verifier emission paths
+    captured: list[tuple[str, dict]] = []
+
+    def emit(name, tags):
+        captured.append((name, tags))
+
+    atomizer = Atomizer(llm=atomizer_llm, store=store, job_db=db, metric_emitter=emit)
+    verifier = Verifier(llm=verifier_llm, store=store, job_db=db, metric_emitter=emit)
+
+    # 1. ATOMIZE
+    job = atomizer.atomize(
+        source_ref="skills/summarize.md@v1",
+        source_kind="skill",
+        source_text=SYNTHETIC_SKILL_TEXT,
+    )
+    assert job.atoms_produced == 2
+    assert len(job.atom_ids) == 2
+    assert job.status == "atomizer_done"
+    assert job.atomizer_tokens_in == 250
+    assert job.atomizer_tokens_out == 180
+
+    # 2. VERIFY
+    flags = verifier.verify(job_id=job.job_id, atom_ids=job.atom_ids)
+    assert flags == []
+
+    # SQL invariants
+    job_inserts = [c for c in db.calls if "INSERT INTO keiracom_atomizer_jobs" in c[0]]
+    assert len(job_inserts) == 1  # one job row
+    assert "'pending'" in job_inserts[0][0]
+
+    atom_inserts = [c for c in db.calls if "INSERT INTO keiracom_atoms" in c[0]]
+    assert len(atom_inserts) == 2  # 2 atoms inserted
+
+    atomizer_done_updates = [c for c in db.calls if "atomizer_done" in c[0]]
+    assert len(atomizer_done_updates) == 1
+
+    verifier_done_updates = [c for c in db.calls if "verifier_done" in c[0]]
+    assert len(verifier_done_updates) == 1
+
+    # Metric invariants — atomizer emitted 4 metric names + verifier emitted 0
+    # (no flags on a clean batch).
+    atomizer_metric_names = {
+        n for n, _ in captured if "atomization.atomizer" in n or "atomization.atoms" in n
+    }
+    assert atomizer_metric_names == {
+        "keiracom.atomization.atomizer.tokens",
+        "keiracom.atomization.atomizer.latency_ms",
+        "keiracom.atomization.atoms_produced",
+    }
+
+    verifier_metric_count = sum(1 for n, _ in captured if "atomization.verifier" in n)
+    assert verifier_metric_count == 0  # no flags → no verifier metric
+
+
+def test_synthetic_skill_e2e_with_verifier_flag():
+    """Same shape but verifier flags one atom — flag persisted, severity emitted."""
+    tenant_id = UUID("00000000-0000-0000-0000-000000000001")
+    db = _IntegrationDB()
+    expected_atom_ids = [uuid4(), uuid4()]
+    db.queue_many(
+        [
+            (str(expected_atom_ids[0]),),
+            (str(expected_atom_ids[1]),),
+            (
+                str(expected_atom_ids[0]),
+                str(tenant_id),
+                '{"kind": "request_shape", "params": {}}',
+                "atom 1",
+                None,
+                None,
+                '{"source": "x", "freshness": "2026-05-26T11:00:00Z", '
+                '"confidence": 0.9, "last_validated": "2026-05-26T11:00:00Z"}',
+                None,
+                1,
+                "active",
+            ),
+            (
+                str(expected_atom_ids[1]),
+                str(tenant_id),
+                '{"kind": "context_predicate", "params": {}}',
+                "atom 2",
+                None,
+                None,
+                '{"source": "x", "freshness": "2026-05-26T11:00:00Z", '
+                '"confidence": 0.9, "last_validated": "2026-05-26T11:00:00Z"}',
+                None,
+                1,
+                "active",
+            ),
+        ]
+    )
+    store = AtomStore(db=db, tenant_id=tenant_id, embedder=_fake_tei())
+    atomizer_llm = _FakeLLM(SYNTHETIC_ATOMIZER_PARSED)
+    verifier_parsed_with_flag = {
+        "flags": [
+            {
+                "atom_index": 1,
+                "category": "trigger_unspecific",
+                "severity": "warning",
+                "message": "context_predicate params empty",
+            }
+        ]
+    }
+    verifier_llm = _FakeLLM(verifier_parsed_with_flag)
+    captured: list[tuple[str, dict]] = []
+
+    def emit(name, tags):
+        captured.append((name, tags))
+
+    atomizer = Atomizer(llm=atomizer_llm, store=store, job_db=db, metric_emitter=emit)
+    verifier = Verifier(llm=verifier_llm, store=store, job_db=db, metric_emitter=emit)
+
+    job = atomizer.atomize(source_ref="x", source_kind="skill", source_text="t")
+    flags = verifier.verify(job_id=job.job_id, atom_ids=job.atom_ids)
+
+    assert len(flags) == 1
+    assert flags[0].severity == "warning"
+    assert "trigger_unspecific" in flags[0].message
+    # Verifier flag metric emitted
+    verifier_flag_metrics = [n for n, _ in captured if n == "keiracom.atomization.verifier.flags"]
+    assert verifier_flag_metrics == ["keiracom.atomization.verifier.flags"]

--- a/tests/keiracom_system/atomization/test_metering_report.py
+++ b/tests/keiracom_system/atomization/test_metering_report.py
@@ -1,0 +1,352 @@
+"""Composition metering interpretation tests — Week 3 readiness."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from src.keiracom_system.atomization.metering_report import (
+    ANTHROPIC_HEALTHY_THRESHOLD,
+    ANTHROPIC_TRACK_THRESHOLD,
+    ATOMIZER_DENSE_MIN_TOKENS_PER_ATOM,
+    ATOMIZER_NOISY_MAX_TOKENS_PER_ATOM,
+    CACHE_BLOCKING_THRESHOLD,
+    CACHE_HEALTHY_THRESHOLD,
+    VERIFIER_BLOCKING_THRESHOLD,
+    VERIFIER_WARNING_THRESHOLD,
+    MeteringSummary,
+    classify_anthropic_cache_rate,
+    classify_atomizer_grain,
+    classify_composition_curve,
+    classify_valkey_hit_rate,
+    classify_verifier_rate,
+    fetch_summary,
+    generate_report,
+    render_report,
+)
+
+# ---- Threshold constants lock --------------------------------------------
+
+
+def test_atomizer_grain_thresholds():
+    assert ATOMIZER_NOISY_MAX_TOKENS_PER_ATOM == 100.0
+    assert ATOMIZER_DENSE_MIN_TOKENS_PER_ATOM == 2000.0
+
+
+def test_verifier_thresholds():
+    assert VERIFIER_BLOCKING_THRESHOLD == 0.10
+    assert VERIFIER_WARNING_THRESHOLD == 0.30
+
+
+def test_cache_thresholds_match_pr1173_baseline():
+    """Cross-PR consistency: cache thresholds same as cache_baseline_48h.py."""
+    assert CACHE_BLOCKING_THRESHOLD == 0.10
+    assert CACHE_HEALTHY_THRESHOLD == 0.40
+    assert ANTHROPIC_HEALTHY_THRESHOLD == 0.50
+    assert ANTHROPIC_TRACK_THRESHOLD == 0.20
+
+
+# ---- classify_atomizer_grain ---------------------------------------------
+
+
+def test_classify_atomizer_grain_zero_atoms_insufficient_data():
+    assert "INSUFFICIENT_DATA" in classify_atomizer_grain(1000, 0)
+
+
+def test_classify_atomizer_grain_noisy_below_100_tokens_per_atom():
+    # 1000 tokens / 50 atoms = 20 tokens/atom → NOISY
+    out = classify_atomizer_grain(1000, 50)
+    assert "ATOMIZER_NOISY" in out
+    assert "too sparse" in out
+
+
+def test_classify_atomizer_grain_dense_above_2000_tokens_per_atom():
+    # 50000 tokens / 10 atoms = 5000 tokens/atom → DENSE
+    out = classify_atomizer_grain(50000, 10)
+    assert "ATOMIZER_DENSE" in out
+    assert "too coarse" in out
+
+
+def test_classify_atomizer_grain_healthy_band():
+    # 1000 tokens / 5 atoms = 200 tokens/atom → in [100, 2000] band
+    out = classify_atomizer_grain(1000, 5)
+    assert out.startswith("HEALTHY")
+
+
+# ---- classify_verifier_rate ----------------------------------------------
+
+
+def test_classify_verifier_rate_zero_atoms_insufficient_data():
+    assert "INSUFFICIENT_DATA" in classify_verifier_rate(0, 0, 0)
+
+
+def test_classify_verifier_rate_blocking_when_above_10pct():
+    # 15 blocking / 100 atoms = 15% > 10% threshold
+    out = classify_verifier_rate(blocking=15, warning=0, total_atoms=100)
+    assert "BLOCKING-V1" in out
+
+
+def test_classify_verifier_rate_track_when_warning_above_30pct():
+    # 5 blocking (5%, below blocking threshold) + 35 warning (35%, above warning) / 100
+    out = classify_verifier_rate(blocking=5, warning=35, total_atoms=100)
+    assert "TRACK-AND-IMPROVE" in out
+
+
+def test_classify_verifier_rate_healthy_band():
+    # Low rates in both buckets
+    out = classify_verifier_rate(blocking=2, warning=10, total_atoms=100)
+    assert out.startswith("HEALTHY")
+
+
+# ---- classify_valkey_hit_rate (parity with PR #1173) ---------------------
+
+
+def test_classify_valkey_hit_rate_zero_lookups_insufficient_data():
+    assert "INSUFFICIENT_DATA" in classify_valkey_hit_rate(0, 0)
+
+
+def test_classify_valkey_hit_rate_blocking_below_10pct():
+    out = classify_valkey_hit_rate(hits=5, misses=95)
+    assert "BLOCKING-V1" in out
+
+
+def test_classify_valkey_hit_rate_track_band():
+    out = classify_valkey_hit_rate(hits=20, misses=80)  # 20% hit rate
+    assert "TRACK-AND-IMPROVE" in out
+
+
+def test_classify_valkey_hit_rate_healthy_at_40_pct():
+    out = classify_valkey_hit_rate(hits=40, misses=60)  # exactly 40%
+    assert out.startswith("HEALTHY")
+
+
+# ---- classify_anthropic_cache_rate ---------------------------------------
+
+
+def test_classify_anthropic_cache_rate_zero_insufficient_data():
+    assert "INSUFFICIENT_DATA" in classify_anthropic_cache_rate(0, 0, 0)
+
+
+def test_classify_anthropic_cache_rate_below_20pct_track():
+    # read 100 / total 1000 = 10%
+    out = classify_anthropic_cache_rate(create=900, read=100, standard=0)
+    assert "TRACK-AND-IMPROVE" in out
+
+
+def test_classify_anthropic_cache_rate_marginal_band():
+    # read 300 / total 1000 = 30% (between 20% and 50%)
+    out = classify_anthropic_cache_rate(create=300, read=300, standard=400)
+    assert "MARGINAL" in out
+
+
+def test_classify_anthropic_cache_rate_healthy_at_50pct():
+    out = classify_anthropic_cache_rate(create=200, read=500, standard=300)  # 50%
+    assert out.startswith("HEALTHY")
+
+
+# ---- classify_composition_curve ------------------------------------------
+
+
+def test_classify_composition_curve_zero_insufficient_data():
+    assert "INSUFFICIENT_DATA" in classify_composition_curve(0.0)
+
+
+def test_classify_composition_curve_under_using():
+    out = classify_composition_curve(1.0)
+    assert "UNDER_USING" in out
+    assert "retrieval may not be firing" in out
+
+
+def test_classify_composition_curve_context_pressure():
+    out = classify_composition_curve(12.0)
+    assert "CONTEXT_PRESSURE" in out
+    assert "context budget" in out
+
+
+def test_classify_composition_curve_healthy_provisional():
+    out = classify_composition_curve(5.0)
+    assert "HEALTHY-PROVISIONAL" in out
+    assert "calibrate" in out
+
+
+# ---- fetch_summary ------------------------------------------------------
+
+
+def test_fetch_summary_aggregates_all_metric_families():
+    """fetch_summary calls the fetcher for each metric name + parses keys."""
+    fetcher_calls: list[tuple[str, dict[str, str]]] = []
+
+    def fake_fetcher(metric, tags, _start, _end):
+        fetcher_calls.append((metric, tags))
+        # Provide minimal canned responses per metric.
+        canned: dict[str, dict[str, float]] = {
+            "keiracom.atomization.atomizer.tokens": {"in": 500, "out": 300},
+            "keiracom.atomization.atoms_produced": {"count": 10},
+            "keiracom.atomization.atomizer.latency_ms": {"avg": 250.0},
+            "keiracom.atomization.verifier.flags": {"info": 1, "warning": 2, "blocking": 0},
+            "keiracom.cache.valkey.lookup": {"hit": 60, "miss": 40},
+            "keiracom.cache.anthropic.input_tokens": {"create": 100, "read": 600, "standard": 300},
+            "keiracom.atomization.compositions_per_task": {"avg": 4.5},
+        }
+        return canned.get(metric, {})
+
+    end = datetime.now(UTC)
+    start = end - timedelta(hours=24)
+    summary = fetch_summary(
+        tenant_id="t1",
+        window_start=start,
+        window_end=end,
+        metrics_fetcher=fake_fetcher,
+    )
+    # Verify all 7 metric families were queried.
+    queried = {m for m, _ in fetcher_calls}
+    assert "keiracom.atomization.atomizer.tokens" in queried
+    assert "keiracom.atomization.atoms_produced" in queried
+    assert "keiracom.atomization.atomizer.latency_ms" in queried
+    assert "keiracom.atomization.verifier.flags" in queried
+    assert "keiracom.cache.valkey.lookup" in queried
+    assert "keiracom.cache.anthropic.input_tokens" in queried
+    assert "keiracom.atomization.compositions_per_task" in queried
+    # Verify parsing.
+    assert summary.atomizer_tokens_in == 500
+    assert summary.atoms_produced == 10
+    assert summary.valkey_hits == 60
+    assert summary.anthropic_read_tokens == 600
+    assert summary.compositions_per_task_avg == 4.5
+
+
+def test_fetch_summary_handles_missing_keys_as_zero():
+    """If a metric returns empty dict, the summary fields default to 0."""
+
+    def empty_fetcher(*_a, **_kw):
+        return {}
+
+    end = datetime.now(UTC)
+    summary = fetch_summary(
+        tenant_id="t1",
+        window_start=end - timedelta(hours=1),
+        window_end=end,
+        metrics_fetcher=empty_fetcher,
+    )
+    assert summary.atoms_produced == 0
+    assert summary.valkey_hits == 0
+    assert summary.compositions_per_task_avg == 0.0
+
+
+# ---- render_report -------------------------------------------------------
+
+
+def _make_summary(**overrides) -> MeteringSummary:
+    base: dict[str, Any] = {
+        "tenant_id": "00000000-0000-0000-0000-000000000001",
+        "window_start": datetime(2026, 5, 26, 11, 0, tzinfo=UTC),
+        "window_end": datetime(2026, 5, 27, 11, 0, tzinfo=UTC),
+    }
+    base.update(overrides)
+    return MeteringSummary(**base)
+
+
+def test_render_report_contains_all_sections():
+    summary = _make_summary(
+        atomizer_tokens_in=1000,
+        atomizer_tokens_out=500,
+        atoms_produced=10,
+        atomizer_latency_ms_avg=200.0,
+        verifier_flags_info=1,
+        verifier_flags_warning=2,
+        verifier_flags_blocking=0,
+        valkey_hits=60,
+        valkey_misses=40,
+        anthropic_create_tokens=100,
+        anthropic_read_tokens=600,
+        anthropic_standard_tokens=300,
+        compositions_per_task_avg=4.5,
+    )
+    text = render_report(summary)
+    assert "Atomization Pilot — Metering Report" in text
+    assert "## Atomizer" in text
+    assert "## Verifier" in text
+    assert "## Valkey semantic cache" in text
+    assert "## Anthropic prompt cache" in text
+    assert "## Composition curve" in text
+    assert "## Action" in text
+    assert "## Honest framing" in text
+
+
+def test_render_report_shows_honest_n_equals_one_framing():
+    summary = _make_summary()
+    text = render_report(summary)
+    assert "N=1 tenant" in text
+    assert "PROVISIONAL" in text
+    assert "first month of traffic" in text
+
+
+def test_render_report_blocking_propagates_to_action_section():
+    summary = _make_summary(
+        atoms_produced=10,
+        verifier_flags_blocking=5,  # 50% > 10% threshold → BLOCKING-V1
+    )
+    text = render_report(summary)
+    assert "BLOCKING-V1" in text
+    assert "pause customer onboarding" in text
+
+
+def test_render_report_shows_zero_data_state():
+    """Fresh tenant — N=0 atoms, N=0 cache lookups — report still renders cleanly."""
+    summary = _make_summary()  # all defaults = zeros
+    text = render_report(summary)
+    assert "INSUFFICIENT_DATA" in text
+    # Should not crash on division-by-zero anywhere.
+
+
+def test_render_report_includes_window_duration():
+    summary = _make_summary()
+    text = render_report(summary)
+    # 24-hour window per defaults (markdown bold prefix on label)
+    assert "24.0 hours" in text
+
+
+# ---- generate_report end-to-end ------------------------------------------
+
+
+def test_generate_report_e2e():
+    """End-to-end: fetcher → summary → markdown."""
+
+    def fake_fetcher(metric, _tags, _start, _end):
+        canned = {
+            "keiracom.atomization.atomizer.tokens": {"in": 5000, "out": 2000},
+            "keiracom.atomization.atoms_produced": {"count": 25},
+            "keiracom.atomization.atomizer.latency_ms": {"avg": 300.0},
+            "keiracom.atomization.verifier.flags": {"info": 2, "warning": 3, "blocking": 0},
+            "keiracom.cache.valkey.lookup": {"hit": 80, "miss": 20},
+            "keiracom.cache.anthropic.input_tokens": {
+                "create": 500,
+                "read": 1500,
+                "standard": 1000,
+            },
+            "keiracom.atomization.compositions_per_task": {"avg": 3.5},
+        }
+        return canned.get(metric, {})
+
+    now = datetime(2026, 5, 27, 11, 0, tzinfo=UTC)
+    report = generate_report(
+        tenant_id="dave",
+        window_hours=24,
+        metrics_fetcher=fake_fetcher,
+        now=now,
+    )
+    # Markdown bold prefix on label: **Tenant:** dave
+    assert "dave" in report
+    assert "HEALTHY" in report  # at least one verdict should be healthy with these inputs
+
+
+def test_generate_report_default_window_24h():
+    """Default window_hours=24 — fetcher receives 24-hour-prior start."""
+    captured_starts: list[datetime] = []
+
+    def fake_fetcher(_metric, _tags, start, end):
+        captured_starts.append(start)
+        return {}
+
+    now = datetime(2026, 5, 27, 11, 0, tzinfo=UTC)
+    generate_report(tenant_id="dave", metrics_fetcher=fake_fetcher, now=now)
+    # All fetcher calls used the same start (24h before now)
+    assert all(s == now - timedelta(hours=24) for s in captured_starts)

--- a/tests/keiracom_system/atomization/test_retriever.py
+++ b/tests/keiracom_system/atomization/test_retriever.py
@@ -1,0 +1,253 @@
+"""MalRetriever unit tests — Week 2 atomization pilot."""
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from src.keiracom_system.atomization.retriever import (
+    DEFAULT_SCORE_THRESHOLD,
+    MAX_TOP_K,
+    MalRetriever,
+    RetrieverError,
+)
+from src.keiracom_system.atomization.schema import AtomV1
+from src.keiracom_system.embeddings.tei_client import TEIClient, _HTTPResponse
+
+
+def _fake_tei() -> TEIClient:
+    def fake_post(url, payload, timeout):
+        n = len(payload["inputs"])
+        body = (
+            b"["
+            + b",".join(b"[" + b",".join(b"0.1" for _ in range(384)) + b"]" for _ in range(n))
+            + b"]"
+        )
+        return _HTTPResponse(200, body)
+
+    def fake_get(url, timeout):
+        return _HTTPResponse(200, b'{"status": "ok"}')
+
+    return TEIClient(http_get=fake_get, http_post=fake_post)
+
+
+class _FakeStore:
+    """Drop-in AtomStore replacement returning canned atoms."""
+
+    def __init__(self, *, tenant_id: str, atoms: list[AtomV1]):
+        self._tenant_id = tenant_id
+        self._atoms = atoms
+        self.retrieve_calls: list[tuple[str, int]] = []
+
+    @property
+    def tenant_id(self) -> str:
+        return self._tenant_id
+
+    def retrieve_top_k(self, query_text: str, top_k: int = 10) -> list[AtomV1]:
+        self.retrieve_calls.append((query_text, top_k))
+        return self._atoms[:top_k]
+
+
+def _make_atom(
+    *,
+    tenant_id,
+    content: str = "test content",
+    composition_tags: dict[str, Any] | None = None,
+) -> AtomV1:
+    return AtomV1(
+        atom_id=uuid4(),
+        tenant_id=tenant_id,
+        trigger_condition={"kind": "request_shape", "params": {"x": 1}},
+        content=content,
+        anti_pattern=None,
+        example=None,
+        provenance={
+            "source": "test",
+            "freshness": "2026-05-26T11:00:00Z",
+            "confidence": 0.9,
+            "last_validated": "2026-05-26T11:00:00Z",
+        },
+        composition_tags=composition_tags or {},
+    )
+
+
+# ---- Input validation ------------------------------------------------------
+
+
+def test_retrieve_rejects_empty_query_text():
+    tid = uuid4()
+    store = _FakeStore(tenant_id=str(tid), atoms=[])
+    retriever = MalRetriever(store=store)
+    with pytest.raises(RetrieverError, match="query_text must be non-empty"):
+        retriever.retrieve(query_text="", top_k=5)
+
+
+def test_retrieve_rejects_non_positive_top_k():
+    tid = uuid4()
+    store = _FakeStore(tenant_id=str(tid), atoms=[])
+    retriever = MalRetriever(store=store)
+    with pytest.raises(RetrieverError, match="top_k must be > 0"):
+        retriever.retrieve(query_text="q", top_k=0)
+
+
+def test_retrieve_rejects_excessive_top_k():
+    tid = uuid4()
+    store = _FakeStore(tenant_id=str(tid), atoms=[])
+    retriever = MalRetriever(store=store)
+    with pytest.raises(RetrieverError, match=f"exceeds MAX_TOP_K {MAX_TOP_K}"):
+        retriever.retrieve(query_text="q", top_k=MAX_TOP_K + 1)
+
+
+# ---- Tenant + delegation ---------------------------------------------------
+
+
+def test_retriever_tenant_id_property():
+    tid = uuid4()
+    store = _FakeStore(tenant_id=str(tid), atoms=[])
+    retriever = MalRetriever(store=store)
+    assert retriever.tenant_id == str(tid)
+
+
+def test_retrieve_calls_atom_store_with_top_k():
+    tid = uuid4()
+    store = _FakeStore(tenant_id=str(tid), atoms=[])
+    retriever = MalRetriever(store=store)
+    retriever.retrieve(query_text="anchor", top_k=7)
+    assert store.retrieve_calls == [("anchor", 7)]
+
+
+# ---- Result shape + scoring ------------------------------------------------
+
+
+def test_retrieve_returns_retrieval_results_ordered_by_score():
+    tid = uuid4()
+    atoms = [_make_atom(tenant_id=tid, content=f"atom {i}") for i in range(3)]
+    store = _FakeStore(tenant_id=str(tid), atoms=atoms)
+    retriever = MalRetriever(store=store)
+    results = retriever.retrieve(query_text="anchor", top_k=3)
+    assert len(results) == 3
+    # Placeholder scoring is 1/(rank+1); should be monotonically decreasing.
+    scores = [r.score for r in results]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_retrieve_returns_empty_when_store_empty():
+    tid = uuid4()
+    store = _FakeStore(tenant_id=str(tid), atoms=[])
+    retriever = MalRetriever(store=store)
+    assert retriever.retrieve(query_text="q", top_k=5) == []
+
+
+# ---- Score threshold filter -----------------------------------------------
+
+
+def test_retrieve_filters_by_score_threshold():
+    tid = uuid4()
+    # 5 atoms → scores 1.0, 0.5, 0.333, 0.25, 0.2
+    atoms = [_make_atom(tenant_id=tid, content=f"a{i}") for i in range(5)]
+    store = _FakeStore(tenant_id=str(tid), atoms=atoms)
+    retriever = MalRetriever(store=store)
+    # Threshold 0.3 should keep ranks 0, 1, 2 (scores 1.0, 0.5, 0.333)
+    results = retriever.retrieve(query_text="q", top_k=5, score_threshold=0.3)
+    assert len(results) == 3
+
+
+def test_retrieve_with_min_score_convenience_wrapper():
+    tid = uuid4()
+    atoms = [_make_atom(tenant_id=tid, content=f"a{i}") for i in range(3)]
+    store = _FakeStore(tenant_id=str(tid), atoms=atoms)
+    retriever = MalRetriever(store=store)
+    r1 = retriever.retrieve(query_text="q", top_k=3, score_threshold=0.5)
+    r2 = retriever.retrieve_with_min_score(query_text="q", top_k=3, min_score=0.5)
+    assert len(r1) == len(r2)
+
+
+def test_default_score_threshold_does_not_filter():
+    tid = uuid4()
+    atoms = [_make_atom(tenant_id=tid) for _ in range(3)]
+    store = _FakeStore(tenant_id=str(tid), atoms=atoms)
+    retriever = MalRetriever(store=store)
+    results = retriever.retrieve(query_text="q", top_k=3)
+    # DEFAULT_SCORE_THRESHOLD=0.0 — all 3 included regardless
+    assert len(results) == 3
+    assert DEFAULT_SCORE_THRESHOLD == 0.0
+
+
+# ---- Composition-tag filter -----------------------------------------------
+
+
+def test_composition_filter_narrows_to_matching_axes():
+    tid = uuid4()
+    atom_a = _make_atom(
+        tenant_id=tid,
+        content="sales atom",
+        composition_tags={
+            "domain": "sales",
+            "concern": "compliance",
+            "applicable_context": "chat_realtime",
+        },
+    )
+    atom_b = _make_atom(
+        tenant_id=tid,
+        content="support atom",
+        composition_tags={
+            "domain": "support",
+            "concern": "compliance",
+            "applicable_context": "chat_realtime",
+        },
+    )
+    store = _FakeStore(tenant_id=str(tid), atoms=[atom_a, atom_b])
+    retriever = MalRetriever(store=store)
+    results = retriever.retrieve(query_text="q", top_k=5, composition_filter={"domain": "sales"})
+    assert len(results) == 1
+    assert results[0].atom.content == "sales atom"
+
+
+def test_composition_filter_requires_all_specified_axes():
+    tid = uuid4()
+    atom = _make_atom(
+        tenant_id=tid,
+        content="match-or-not",
+        composition_tags={
+            "domain": "sales",
+            "concern": "compliance",
+            "applicable_context": "chat_realtime",
+        },
+    )
+    store = _FakeStore(tenant_id=str(tid), atoms=[atom])
+    retriever = MalRetriever(store=store)
+    # Mismatch on `concern` — excluded.
+    results = retriever.retrieve(
+        query_text="q",
+        top_k=5,
+        composition_filter={"domain": "sales", "concern": "performance"},
+    )
+    assert results == []
+
+
+def test_composition_filter_unconstrained_axes_ignored():
+    tid = uuid4()
+    atom = _make_atom(
+        tenant_id=tid,
+        composition_tags={
+            "domain": "sales",
+            "concern": "compliance",
+            "applicable_context": "chat_realtime",
+        },
+    )
+    store = _FakeStore(tenant_id=str(tid), atoms=[atom])
+    retriever = MalRetriever(store=store)
+    # Only filter on `domain` — `concern` + `applicable_context` unconstrained.
+    results = retriever.retrieve(query_text="q", top_k=5, composition_filter={"domain": "sales"})
+    assert len(results) == 1
+
+
+def test_empty_composition_filter_no_op():
+    """Empty dict + None both behave as 'no filter'."""
+    tid = uuid4()
+    atom = _make_atom(tenant_id=tid, composition_tags={})
+    store = _FakeStore(tenant_id=str(tid), atoms=[atom])
+    retriever = MalRetriever(store=store)
+    assert len(retriever.retrieve(query_text="q", top_k=5)) == 1
+    assert len(retriever.retrieve(query_text="q", top_k=5, composition_filter={})) == 1
+    assert len(retriever.retrieve(query_text="q", top_k=5, composition_filter=None)) == 1

--- a/tests/keiracom_system/atomization/test_schema.py
+++ b/tests/keiracom_system/atomization/test_schema.py
@@ -1,0 +1,259 @@
+"""AtomV1 + frozen-vocabulary unit tests — atomization pilot Week 1."""
+
+from uuid import uuid4
+
+import pytest
+
+from src.keiracom_system.atomization.schema import (
+    PROVENANCE_REQUIRED_KEYS,
+    SCHEMA_VERSION,
+    VALID_COMPOSITION_TAG_CONCERNS,
+    VALID_COMPOSITION_TAG_CONTEXTS,
+    VALID_COMPOSITION_TAG_DOMAINS,
+    VALID_COMPOSITION_TAGS,
+    VALID_RELATIONSHIP_TYPES,
+    VALID_SOURCE_KINDS,
+    VALID_STATES,
+    VALID_TRIGGER_KINDS,
+    AtomV1,
+    SupersessionEdgeV1,
+    is_valid_composition_tag,
+    is_valid_uuid_str,
+)
+
+
+def _good_provenance() -> dict:
+    return {
+        "source": "skills/test.md@abc123",
+        "freshness": "2026-05-26T11:25:00Z",
+        "confidence": 0.85,
+        "last_validated": "2026-05-26T11:25:00Z",
+    }
+
+
+def _good_atom_kwargs() -> dict:
+    return {
+        "atom_id": uuid4(),
+        "tenant_id": uuid4(),
+        "trigger_condition": {"kind": "request_shape", "params": {"matches": "summarize"}},
+        "content": "When the user asks to summarize, return 3 bullet points.",
+        "anti_pattern": None,
+        "example": None,
+        "provenance": _good_provenance(),
+        "composition_tags": {},
+    }
+
+
+# ----- Vocabulary cardinality + identity locks -----------------------------
+
+
+def test_schema_version_is_one():
+    assert SCHEMA_VERSION == 1
+
+
+def test_valid_states_set():
+    assert frozenset({"active", "superseded", "cold_archive"}) == VALID_STATES
+
+
+def test_valid_source_kinds_set():
+    assert (
+        frozenset({"skill", "manual", "governance_doc", "discovery_log", "session"})
+        == VALID_SOURCE_KINDS
+    )
+
+
+def test_valid_trigger_kinds_six():
+    """Pilot placeholder vocabulary cardinality — 6 kinds per schema.py."""
+    assert len(VALID_TRIGGER_KINDS) == 6
+
+
+def test_valid_relationship_types_capped_single_digit():
+    """Hard constraint: relationship-type vocabulary capped single-digit V1."""
+    assert len(VALID_RELATIONSHIP_TYPES) < 10
+    assert "supersedes" in VALID_RELATIONSHIP_TYPES
+
+
+def test_composition_tags_288_combinations():
+    """Dispatch reference: 288 composition tag combinations.
+
+    Cardinality = len(domain) × len(concern) × len(context).
+    Placeholder values: 8 × 6 × 6 = 288 (matches dispatch reference exactly).
+    """
+    expected = (
+        len(VALID_COMPOSITION_TAG_DOMAINS)
+        * len(VALID_COMPOSITION_TAG_CONCERNS)
+        * len(VALID_COMPOSITION_TAG_CONTEXTS)
+    )
+    assert expected == 288
+    assert len(VALID_COMPOSITION_TAGS) == 288
+
+
+def test_provenance_required_keys():
+    """Provenance JSONB must carry source + freshness + confidence + last_validated."""
+    assert (
+        frozenset({"source", "freshness", "confidence", "last_validated"})
+        == PROVENANCE_REQUIRED_KEYS
+    )
+
+
+def test_is_valid_composition_tag_accepts_canonical():
+    tag = {
+        "domain": next(iter(VALID_COMPOSITION_TAG_DOMAINS)),
+        "concern": next(iter(VALID_COMPOSITION_TAG_CONCERNS)),
+        "applicable_context": next(iter(VALID_COMPOSITION_TAG_CONTEXTS)),
+    }
+    assert is_valid_composition_tag(tag) is True
+
+
+def test_is_valid_composition_tag_rejects_unknown_axis():
+    bad = {
+        "domain": "_not_a_domain",
+        "concern": "compliance",
+        "applicable_context": "chat_realtime",
+    }
+    assert is_valid_composition_tag(bad) is False
+
+
+def test_is_valid_uuid_str_accepts_valid():
+    assert is_valid_uuid_str("00000000-0000-0000-0000-000000000001") is True
+
+
+def test_is_valid_uuid_str_rejects_invalid():
+    assert is_valid_uuid_str("not-a-uuid") is False
+
+
+# ----- AtomV1 invariants ----------------------------------------------------
+
+
+def test_atom_v1_valid_construction():
+    atom = AtomV1(**_good_atom_kwargs())
+    assert atom.schema_version == SCHEMA_VERSION
+    assert atom.state == "active"
+
+
+def test_atom_v1_rejects_free_text_trigger():
+    """Hard constraint: atomizer rejects free-text triggers."""
+    kwargs = _good_atom_kwargs()
+    kwargs["trigger_condition"] = "when the user does X"  # string, not dict
+    with pytest.raises(ValueError, match="structured predicate dict"):
+        AtomV1(**kwargs)
+
+
+def test_atom_v1_rejects_unknown_trigger_kind():
+    kwargs = _good_atom_kwargs()
+    kwargs["trigger_condition"] = {"kind": "_bogus_kind", "params": {}}
+    with pytest.raises(ValueError, match="not in"):
+        AtomV1(**kwargs)
+
+
+def test_atom_v1_rejects_missing_trigger_params():
+    kwargs = _good_atom_kwargs()
+    kwargs["trigger_condition"] = {"kind": "request_shape"}  # no params
+    with pytest.raises(ValueError, match="params"):
+        AtomV1(**kwargs)
+
+
+def test_atom_v1_rejects_empty_content():
+    kwargs = _good_atom_kwargs()
+    kwargs["content"] = ""
+    with pytest.raises(ValueError, match="content must be non-empty"):
+        AtomV1(**kwargs)
+
+
+def test_atom_v1_rejects_missing_provenance_keys():
+    kwargs = _good_atom_kwargs()
+    kwargs["provenance"] = {"source": "x"}  # only 1 of 4 required keys
+    with pytest.raises(ValueError, match="provenance missing"):
+        AtomV1(**kwargs)
+
+
+def test_atom_v1_rejects_provenance_confidence_out_of_range():
+    kwargs = _good_atom_kwargs()
+    kwargs["provenance"]["confidence"] = 1.5
+    with pytest.raises(ValueError, match="confidence must be a float"):
+        AtomV1(**kwargs)
+
+
+def test_atom_v1_rejects_unknown_composition_tag():
+    kwargs = _good_atom_kwargs()
+    kwargs["composition_tags"] = {
+        "domain": "_unknown",
+        "concern": "compliance",
+        "applicable_context": "chat_realtime",
+    }
+    with pytest.raises(ValueError, match="composition_tags"):
+        AtomV1(**kwargs)
+
+
+def test_atom_v1_accepts_empty_composition_tags():
+    """Empty dict is allowed (some sources may not carry tags yet)."""
+    kwargs = _good_atom_kwargs()
+    kwargs["composition_tags"] = {}
+    atom = AtomV1(**kwargs)
+    assert atom.composition_tags == {}
+
+
+def test_atom_v1_rejects_unknown_state():
+    kwargs = _good_atom_kwargs()
+    kwargs["state"] = "_not_a_state"
+    with pytest.raises(ValueError, match="state"):
+        AtomV1(**kwargs)
+
+
+def test_atom_v1_is_frozen():
+    """Atoms are immutable; edits produce supersession edges."""
+    atom = AtomV1(**_good_atom_kwargs())
+    with pytest.raises((AttributeError, Exception)):
+        atom.content = "mutated"  # type: ignore[misc]
+
+
+# ----- SupersessionEdgeV1 invariants ----------------------------------------
+
+
+def test_supersession_edge_valid():
+    edge = SupersessionEdgeV1(
+        edge_id=uuid4(),
+        tenant_id=uuid4(),
+        predecessor_atom=uuid4(),
+        successor_atom=uuid4(),
+        relationship_type="supersedes",
+        confidence=0.9,
+    )
+    assert edge.relationship_type == "supersedes"
+
+
+def test_supersession_edge_rejects_same_atom():
+    aid = uuid4()
+    with pytest.raises(ValueError, match="must differ"):
+        SupersessionEdgeV1(
+            edge_id=uuid4(),
+            tenant_id=uuid4(),
+            predecessor_atom=aid,
+            successor_atom=aid,
+            relationship_type="supersedes",
+            confidence=0.9,
+        )
+
+
+def test_supersession_edge_rejects_unknown_relationship_type():
+    with pytest.raises(ValueError, match="relationship_type"):
+        SupersessionEdgeV1(
+            edge_id=uuid4(),
+            tenant_id=uuid4(),
+            predecessor_atom=uuid4(),
+            successor_atom=uuid4(),
+            relationship_type="_bogus",
+            confidence=0.9,
+        )
+
+
+def test_supersession_edge_rejects_confidence_out_of_range():
+    with pytest.raises(ValueError, match="confidence"):
+        SupersessionEdgeV1(
+            edge_id=uuid4(),
+            tenant_id=uuid4(),
+            predecessor_atom=uuid4(),
+            successor_atom=uuid4(),
+            relationship_type="supersedes",
+            confidence=1.5,
+        )

--- a/tests/keiracom_system/atomization/test_skills_atomizer.py
+++ b/tests/keiracom_system/atomization/test_skills_atomizer.py
@@ -1,0 +1,219 @@
+"""Skills directory atomizer tests — Week 2 acceptance criterion (orchestrator)."""
+
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from src.keiracom_system.atomization import skills_atomizer
+from src.keiracom_system.atomization.atomizer import AtomizerJob
+
+
+class _FakeAtomizer:
+    """Atomizer-shape fake — records each atomize() call + returns a synthetic job."""
+
+    def __init__(self, *, fail_paths: set[str] | None = None):
+        self.calls: list[dict[str, Any]] = []
+        self.fail_paths = fail_paths or set()
+
+    def atomize(self, *, source_ref: str, source_kind: str, source_text: str) -> AtomizerJob:
+        self.calls.append(
+            {"source_ref": source_ref, "source_kind": source_kind, "len": len(source_text)}
+        )
+        if source_ref in self.fail_paths:
+            raise RuntimeError(f"simulated failure for {source_ref}")
+        return AtomizerJob(
+            job_id=uuid4(),
+            tenant_id=uuid4(),
+            source_ref=source_ref,
+            source_kind=source_kind,
+            atomizer_model="test/flash",
+            atomizer_temp=0.0,
+            atoms_produced=2,
+            atom_ids=[uuid4(), uuid4()],
+            status="atomizer_done",
+        )
+
+
+def _write_skills(root: Path, files: dict[str, str]) -> None:
+    for rel_path, content in files.items():
+        path = root / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+# ---- iter_skill_files ------------------------------------------------------
+
+
+def test_iter_skill_files_yields_sorted_md_files(tmp_path: Path):
+    _write_skills(
+        tmp_path,
+        {
+            "b/SKILL.md": "B",
+            "a/SKILL.md": "A",
+            "c/IGNORE.txt": "not md",
+            "a/sub/extra.md": "subdir",
+        },
+    )
+    files = list(skills_atomizer.iter_skill_files(tmp_path))
+    rel_paths = [str(f.relative_to(tmp_path)) for f in files]
+    assert rel_paths == sorted(rel_paths)
+    # txt file excluded
+    assert all(p.endswith(".md") for p in rel_paths)
+    assert "a/SKILL.md" in rel_paths
+    assert "a/sub/extra.md" in rel_paths
+    assert "b/SKILL.md" in rel_paths
+
+
+def test_iter_skill_files_raises_on_missing_root(tmp_path: Path):
+    with pytest.raises(skills_atomizer.SkillsAtomizerError, match="not a directory"):
+        list(skills_atomizer.iter_skill_files(tmp_path / "does_not_exist"))
+
+
+# ---- State file round-trip -------------------------------------------------
+
+
+def test_state_roundtrip_only_keeps_ok_true(tmp_path: Path):
+    state = tmp_path / "state.jsonl"
+    assert skills_atomizer.load_state(state) == set()
+    skills_atomizer.append_state(state, {"source_ref": "skills/a.md", "ok": True, "info": ""})
+    skills_atomizer.append_state(state, {"source_ref": "skills/b.md", "ok": False, "info": "err"})
+    skills_atomizer.append_state(state, {"source_ref": "skills/c.md", "ok": True, "info": ""})
+    seen = skills_atomizer.load_state(state)
+    assert seen == {"skills/a.md", "skills/c.md"}
+
+
+def test_state_file_handles_corrupt_lines(tmp_path: Path):
+    state = tmp_path / "state.jsonl"
+    state.write_text(
+        '{"source_ref": "ok1", "ok": true}\n{garbled json\n{"source_ref": "ok2", "ok": true}\n',
+        encoding="utf-8",
+    )
+    seen = skills_atomizer.load_state(state)
+    assert seen == {"ok1", "ok2"}
+
+
+# ---- atomize_skill ---------------------------------------------------------
+
+
+def test_atomize_skill_happy_path(tmp_path: Path):
+    skill = tmp_path / "skills" / "x" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# Skill X\n\nDo X when Y.", encoding="utf-8")
+    fake = _FakeAtomizer()
+    ok, info = skills_atomizer.atomize_skill(
+        atomizer=fake,
+        skill_path=skill,
+        skills_root=tmp_path / "skills",
+    )
+    assert ok is True
+    assert "atoms=2" in info
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["source_ref"] == "skills/x/SKILL.md"
+    assert fake.calls[0]["source_kind"] == "skill"
+
+
+def test_atomize_skill_rejects_oversize_file(tmp_path: Path):
+    skill = tmp_path / "skills" / "huge" / "BIG.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("x" * (skills_atomizer.MAX_SKILL_BYTES + 1), encoding="utf-8")
+    fake = _FakeAtomizer()
+    ok, info = skills_atomizer.atomize_skill(
+        atomizer=fake,
+        skill_path=skill,
+        skills_root=tmp_path / "skills",
+    )
+    assert ok is False
+    assert "exceeds MAX_SKILL_BYTES" in info
+    # Did not call atomize on the oversized file
+    assert fake.calls == []
+
+
+def test_atomize_skill_returns_false_on_atomizer_exception(tmp_path: Path):
+    skill = tmp_path / "skills" / "fail.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("content", encoding="utf-8")
+    fake = _FakeAtomizer(fail_paths={"skills/fail.md"})
+    ok, info = skills_atomizer.atomize_skill(
+        atomizer=fake,
+        skill_path=skill,
+        skills_root=tmp_path / "skills",
+    )
+    assert ok is False
+    assert "simulated failure" in info
+
+
+# ---- run() — dry-run + execute paths ---------------------------------------
+
+
+def test_run_dry_run_does_not_call_atomize(tmp_path: Path):
+    skills_root = tmp_path / "skills"
+    _write_skills(skills_root, {"a.md": "A", "b.md": "B"})
+    fake = _FakeAtomizer()
+    rc = skills_atomizer.run(
+        atomizer=fake,
+        skills_root=skills_root,
+        state_path=tmp_path / "state.jsonl",
+        execute=False,
+    )
+    assert rc == 0
+    assert fake.calls == []  # dry-run skips
+
+
+def test_run_execute_atomizes_each_skill(tmp_path: Path):
+    skills_root = tmp_path / "skills"
+    _write_skills(skills_root, {"a.md": "A", "sub/b.md": "B"})
+    fake = _FakeAtomizer()
+    rc = skills_atomizer.run(
+        atomizer=fake,
+        skills_root=skills_root,
+        state_path=tmp_path / "state.jsonl",
+        execute=True,
+    )
+    assert rc == 0
+    assert len(fake.calls) == 2
+    refs = {c["source_ref"] for c in fake.calls}
+    assert refs == {"skills/a.md", "skills/sub/b.md"}
+
+
+def test_run_execute_returns_one_on_any_failure(tmp_path: Path):
+    skills_root = tmp_path / "skills"
+    _write_skills(skills_root, {"good.md": "OK", "bad.md": "BAD"})
+    fake = _FakeAtomizer(fail_paths={"skills/bad.md"})
+    rc = skills_atomizer.run(
+        atomizer=fake,
+        skills_root=skills_root,
+        state_path=tmp_path / "state.jsonl",
+        execute=True,
+    )
+    assert rc == 1
+
+
+def test_run_skips_already_atomized(tmp_path: Path):
+    skills_root = tmp_path / "skills"
+    _write_skills(skills_root, {"a.md": "A", "b.md": "B"})
+    state = tmp_path / "state.jsonl"
+    # Pre-populate state: a.md already done
+    skills_atomizer.append_state(state, {"source_ref": "skills/a.md", "ok": True, "info": ""})
+    fake = _FakeAtomizer()
+    rc = skills_atomizer.run(
+        atomizer=fake,
+        skills_root=skills_root,
+        state_path=state,
+        execute=True,
+    )
+    assert rc == 0
+    refs = [c["source_ref"] for c in fake.calls]
+    assert refs == ["skills/b.md"]  # a.md skipped
+
+
+def test_run_missing_skills_root_returns_two(tmp_path: Path):
+    fake = _FakeAtomizer()
+    rc = skills_atomizer.run(
+        atomizer=fake,
+        skills_root=tmp_path / "nonexistent",
+        state_path=tmp_path / "state.jsonl",
+        execute=True,
+    )
+    assert rc == 2

--- a/tests/keiracom_system/atomization/test_verifier.py
+++ b/tests/keiracom_system/atomization/test_verifier.py
@@ -1,0 +1,253 @@
+"""Verifier unit tests — uses fake LLM client + AtomStore + job DB."""
+
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.keiracom_system.atomization.atom_store import AtomStore
+from src.keiracom_system.atomization.llm_client import LLMResponse
+from src.keiracom_system.atomization.verifier import (
+    SEVERITY_BLOCKING,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+    VALID_SEVERITIES,
+    VERIFIER_RESPONSE_SCHEMA,
+    Verifier,
+    VerifierError,
+    VerifierFlag,
+)
+from src.keiracom_system.embeddings.tei_client import TEIClient, _HTTPResponse
+
+
+def _fake_tei() -> TEIClient:
+    def fake_post(url, payload, timeout):
+        n = len(payload["inputs"])
+        body = (
+            b"["
+            + b",".join(b"[" + b",".join(b"0.1" for _ in range(384)) + b"]" for _ in range(n))
+            + b"]"
+        )
+        return _HTTPResponse(200, body)
+
+    def fake_get(url, timeout):
+        return _HTTPResponse(200, b'{"status": "ok"}')
+
+    return TEIClient(http_get=fake_get, http_post=fake_post)
+
+
+class _MultiDB:
+    def __init__(self):
+        self.calls: list[tuple[str, tuple]] = []
+        self._q: list[Any] = []
+
+    def execute(self, query, *params):
+        self.calls.append((query, params))
+
+    def fetchone(self):
+        return self._q.pop(0) if self._q else None
+
+    def fetchall(self):
+        return []
+
+    def queue_many(self, rows):
+        self._q.extend(rows)
+
+
+class _FakeLLM:
+    def __init__(self, parsed: Any):
+        self.parsed = parsed
+        self.calls: list[dict] = []
+
+    def call_structured(self, **kwargs):
+        self.calls.append(kwargs)
+        return LLMResponse(
+            parsed=self.parsed,
+            tokens_in=100,
+            tokens_out=50,
+            latency_ms=84,
+            model=kwargs.get("model", "test/pro"),
+        )
+
+
+def _stored_atom_row(atom_id: UUID, tenant_id: UUID) -> tuple:
+    return (
+        str(atom_id),
+        str(tenant_id),
+        '{"kind": "request_shape", "params": {"q": "x"}}',
+        "stored content",
+        None,
+        None,
+        '{"source": "x", "freshness": "2026-05-26T11:00:00Z", '
+        '"confidence": 0.9, "last_validated": "2026-05-26T11:00:00Z"}',
+        None,
+        1,
+        "active",
+    )
+
+
+# ----- VerifierFlag invariants ---------------------------------------------
+
+
+def test_verifier_flag_valid():
+    f = VerifierFlag(atom_id=uuid4(), severity=SEVERITY_WARNING, message="x")
+    assert f.severity == SEVERITY_WARNING
+
+
+def test_verifier_flag_rejects_unknown_severity():
+    with pytest.raises(VerifierError, match="severity"):
+        VerifierFlag(atom_id=uuid4(), severity="_bogus", message="x")
+
+
+def test_valid_severities_three():
+    assert frozenset({SEVERITY_INFO, SEVERITY_WARNING, SEVERITY_BLOCKING}) == VALID_SEVERITIES
+
+
+# ----- Verifier behaviour --------------------------------------------------
+
+
+def _make_verifier(parsed: Any, *, db: _MultiDB | None = None):
+    tid = uuid4()
+    db = db or _MultiDB()
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    llm = _FakeLLM(parsed)
+    return Verifier(llm=llm, store=store, job_db=db), llm, db, tid
+
+
+def test_verify_empty_atom_list_returns_empty_flags():
+    verifier, _, db, _ = _make_verifier({"flags": []})
+    flags = verifier.verify(job_id=uuid4(), atom_ids=[])
+    assert flags == []
+    # Still marks verifier_done with empty flags JSON
+    update_calls = [c for c in db.calls if "verifier_done" in c[0]]
+    assert len(update_calls) == 1
+
+
+def test_verify_marks_verifier_done_on_clean_batch():
+    aid = uuid4()
+    verifier, _, db, tid = _make_verifier({"flags": []})
+    db.queue_many([_stored_atom_row(aid, tid)])
+    flags = verifier.verify(job_id=uuid4(), atom_ids=[aid])
+    assert flags == []
+    update_calls = [c for c in db.calls if "verifier_done" in c[0]]
+    assert len(update_calls) == 1
+
+
+def test_verify_persists_flag_payload():
+    """Verifier flags returned by LLM get persisted as JSONB to job row."""
+    aid = uuid4()
+    parsed = {
+        "flags": [
+            {
+                "atom_index": 0,
+                "category": "trigger_unspecific",
+                "severity": "warning",
+                "message": "params too vague",
+            }
+        ]
+    }
+    verifier, _, db, tid = _make_verifier(parsed)
+    db.queue_many([_stored_atom_row(aid, tid)])
+    flags = verifier.verify(job_id=uuid4(), atom_ids=[aid])
+    assert len(flags) == 1
+    assert flags[0].atom_id == aid
+    assert flags[0].severity == "warning"
+    assert "trigger_unspecific" in flags[0].message
+    # JSON serialized into the UPDATE call
+    update_call = next(c for c in db.calls if "verifier_done" in c[0])
+    serialized_flags = update_call[1][4]
+    assert "trigger_unspecific" in serialized_flags
+    assert "warning" in serialized_flags
+
+
+def test_verify_drops_out_of_range_atom_index():
+    """LLM might emit atom_index=99 for a 2-atom batch — silently drop, don't crash."""
+    aid = uuid4()
+    parsed = {
+        "flags": [
+            {"atom_index": 99, "category": "grain_violation", "severity": "warning", "message": "x"}
+        ]
+    }
+    verifier, _, db, tid = _make_verifier(parsed)
+    db.queue_many([_stored_atom_row(aid, tid)])
+    flags = verifier.verify(job_id=uuid4(), atom_ids=[aid])
+    assert flags == []
+
+
+def test_verify_drops_unknown_severity():
+    """Invalid severity → log warning + drop the flag."""
+    aid = uuid4()
+    parsed = {
+        "flags": [
+            {"atom_index": 0, "category": "grain_violation", "severity": "_bogus", "message": "x"}
+        ]
+    }
+    verifier, _, db, tid = _make_verifier(parsed)
+    db.queue_many([_stored_atom_row(aid, tid)])
+    flags = verifier.verify(job_id=uuid4(), atom_ids=[aid])
+    assert flags == []
+
+
+def test_verify_calls_llm_with_atom_payload():
+    """Verifier sends atoms as JSON array to the LLM."""
+    aid = uuid4()
+    verifier, llm, db, tid = _make_verifier({"flags": []})
+    db.queue_many([_stored_atom_row(aid, tid)])
+    verifier.verify(job_id=uuid4(), atom_ids=[aid])
+    user_msg = next(m for m in llm.calls[0]["messages"] if m["role"] == "user")
+    import json as _json
+
+    payload = _json.loads(user_msg["content"])
+    assert "atoms" in payload
+    assert len(payload["atoms"]) == 1
+
+
+def test_verifier_response_schema_has_severity_enum():
+    """Schema locks 3-severity vocabulary."""
+    schema_enum = set(
+        VERIFIER_RESPONSE_SCHEMA["schema"]["properties"]["flags"]["items"]["properties"][
+            "severity"
+        ]["enum"]
+    )
+    assert schema_enum == {"info", "warning", "blocking"}
+
+
+def test_verify_skips_atoms_not_in_store():
+    """If get_atom returns None (e.g. wrong tenant), the atom is silently skipped."""
+    aid_a = uuid4()
+    aid_b = uuid4()
+    verifier, _, db, tid = _make_verifier({"flags": []})
+    # First atom found, second not found (None)
+    db.queue_many([_stored_atom_row(aid_a, tid), None])
+    flags = verifier.verify(job_id=uuid4(), atom_ids=[aid_a, aid_b])
+    assert flags == []
+
+
+def test_verify_emits_metering_per_flag():
+    """Each flag → 1 keiracom.atomization.verifier.flags metric."""
+    captured: list[tuple[str, dict]] = []
+
+    def emit(name, tags):
+        captured.append((name, tags))
+
+    aid = uuid4()
+    parsed = {
+        "flags": [
+            {
+                "atom_index": 0,
+                "category": "factual_incoherence",
+                "severity": "blocking",
+                "message": "x",
+            }
+        ]
+    }
+    tid = uuid4()
+    db = _MultiDB()
+    db.queue_many([_stored_atom_row(aid, tid)])
+    store = AtomStore(db=db, tenant_id=tid, embedder=_fake_tei())
+    llm = _FakeLLM(parsed)
+    verifier = Verifier(llm=llm, store=store, job_db=db, metric_emitter=emit)
+    verifier.verify(job_id=uuid4(), atom_ids=[aid])
+    flag_metrics = [(n, t) for n, t in captured if n == "keiracom.atomization.verifier.flags"]
+    assert len(flag_metrics) == 1
+    assert flag_metrics[0][1]["severity"] == "blocking"


### PR DESCRIPTION
## Summary

Engineer-tier Week 3 prep per Elliot dispatch — "composition metering interpretation tooling so Dave can read the curve when he starts daily use." Pure-function Markdown report builder over the 7 metric families emitted by Week 1 + Week 2 + A7 cache substrate. Stacked on PR #1189 (Week 2) which stacks on PR #1185 (Week 1).

**Filed under:** Agency_OS-atomization-pilot-week3-prep
**Stats:** 2 new files, +712 LoC, **148 atomization tests passing** (74 Week 1 + 42 Week 2 + 32 Week 3 new), ruff/format/mypy clean.

## Why this PR (per Elliot dispatch directly)

> "Week 3 readiness: composition metering interpretation tooling so Dave can read the curve when he starts daily use"

When Dave starts daily use in Week 3, he needs a way to READ the curve and understand what it's telling him — without having to query Better Stack himself. This report wraps the metrics into a classified health summary Dave can paste into chat or scan at a glance.

## 5 Classifiers (all with INSUFFICIENT_DATA path for zero-traffic safety)

| Classifier | Band logic | Source |
|---|---|---|
| `classify_atomizer_grain` | NOISY <100 tokens/atom; DENSE >2000; HEALTHY band | PR #1185 atomizer metrics |
| `classify_verifier_rate` | BLOCKING-V1 >10% blocking; TRACK >30% warning | PR #1185 verifier metrics |
| `classify_valkey_hit_rate` | **SAME thresholds as PR #1173 baseline** (lock-test enforces parity) | PR #1173 cache metrics |
| `classify_anthropic_cache_rate` | TRACK <20% read; MARGINAL 20-50%; HEALTHY ≥50% | PR #1173 cache metrics |
| `classify_composition_curve` | UNDER_USING <2; HEALTHY-PROVISIONAL 2-8; CONTEXT_PRESSURE >8 | PR #1189 pre-wired metric |

## Output format

Markdown with bold-section headers + 4 metric tables + Action + Honest framing sections. Sample render-shape:

```markdown
# Atomization Pilot — Metering Report

**Tenant:** 00000000-0000-0000-0000-000000000001
**Window:** 2026-05-26T11:00:00+00:00 → 2026-05-27T11:00:00+00:00 UTC
**Duration:** 24.0 hours

## Atomizer
| Metric | Value |
|---|---|
| Atoms produced | 25 |
| Grain | HEALTHY (200 tokens/atom — grain within band) |

## Action
- **Atomizer grain:** HEALTHY (200 tokens/atom — grain within band)
- **Verifier:** HEALTHY (blocking=0.0%, warning=12.0%)
- **Valkey cache:** HEALTHY (80.0% hit rate)
- **Anthropic cache:** HEALTHY (50.0% cache-read ratio)
- **Composition curve:** HEALTHY-PROVISIONAL (3.5 comp/task — calibrate after first-week-Dave baseline)

If any verdict shows BLOCKING-V1, pause customer onboarding until ...

## Honest framing
- **N=1 tenant (Dave)** — Week 3 baseline. Calibration data starts here.
- **First 3 paying customers + their first month of traffic = real calibration.**
- **Composition curve bands are PROVISIONAL** ...
```

## Cross-PR consistency

`classify_valkey_hit_rate` thresholds explicitly mirror `scripts/cache_baseline_48h.py` (PR #1173). Test `test_cache_thresholds_match_pr1173_baseline` locks `CACHE_BLOCKING_THRESHOLD == 0.10` + `CACHE_HEALTHY_THRESHOLD == 0.40` + `ANTHROPIC_HEALTHY_THRESHOLD == 0.50` + `ANTHROPIC_TRACK_THRESHOLD == 0.20` so a future drift breaks the build.

## Honest framing (per atomization design discipline)

The report itself prints these caveats so Dave reads them at scan-time, not buried in docs:
- **N=1 tenant (Dave)** — Week 3 baseline starts here
- **First 3 paying customers + first month of traffic = real calibration**
- **Composition curve bands PROVISIONAL** — chosen pre-data; need real-traffic calibration

## Stacked-PR notice

This PR stacks on **PR #1189 (Week 2)** which stacks on **PR #1185 (Week 1)**. Merge order:
1. PR #1185 (Week 1) lands first
2. PR #1189 (Week 2) rebases + lands
3. This PR rebases + lands

All 3 PRs only ADD files, no Week 1 modifications, so rebases should be clean.

## Test plan

- [x] `python3 -m pytest tests/keiracom_system/atomization/ -q` → **148 passed**
- [x] `ruff check + ruff format --check` → clean across all 3 weeks
- [x] `mypy src/keiracom_system/atomization/ --ignore-missing-imports` → 10 source files, no issues
- [x] All 6 CI guards self-pass on diff

## Next step

- Land #1185 → #1189 → this PR (merge order)
- Week 3 actual use: when Dave is using the system, run `generate_report(tenant_id="dave", window_hours=24, metrics_fetcher=better_stack_fetcher, now=utcnow())` and post to keiracom.elliot.inbox daily
- Real calibration starts when Dave's first week of traffic lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)