### PR TITLE
[NOVA] feat(relay): keiracom_paused_tasks table + migration + accessor (Agency_OS-tjni)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -2,4 +2,4 @@
 {"id":"int-aed03aae","kind":"field_change","created_at":"2026-05-18T20:45:34.175593321Z","actor":"Elliot","issue_id":"Agency_OS-mwwmq0","extra":{"field":"assignee","new_value":"nova","old_value":"elliotbot"}}
 {"id":"int-6e936bc3","kind":"field_change","created_at":"2026-05-18T21:28:35.153208282Z","actor":"Elliot","issue_id":"Agency_OS-y244","extra":{"field":"assignee","new_value":"nova","old_value":""}}
 {"id":"int-264d5788","kind":"field_change","created_at":"2026-05-18T22:06:58.060339376Z","actor":"Elliot","issue_id":"Agency_OS-y52ohx","extra":{"field":"assignee","new_value":"nova","old_value":""}}
-{"id":"int-a1923eb8","kind":"field_change","created_at":"2026-05-26T13:57:06.46436364Z","actor":"Elliot","issue_id":"Agency_OS-zf5a","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-63d5a67d","kind":"field_change","created_at":"2026-05-26T13:38:26.412204901Z","actor":"Elliot","issue_id":"Agency_OS-tjni","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/relay/paused_tasks.py
+++ b/src/relay/paused_tasks.py
@@ -1,0 +1,178 @@
+"""paused_tasks — Postgres accessor for paused-pending-decision state-snapshots.
+
+Per PR #1140 §5 (resume-spawn protocol) + §7 piece #2 (this module). The
+dispatcher (PR #1188, Agency_OS-8416) writes via insert_from_envelope();
+the resume-spawn path reads via get_by_task_ref(). A sweep job (separate
+KEI) uses iter_expired() to find dead-letter candidates.
+
+bd: Agency_OS-tjni
+
+DI: caller passes any object implementing _DBProtocol (execute + fetchone +
+fetchall). Same pattern as src/relay/spawn_composer.py + scripts/dispatcher/.
+Module is asyncpg/psycopg-import-free → testable without live Supabase.
+
+Envelope shape: paused_pending_decision (per my PR #1181 envelope schema):
+  required: id, type, from, task_ref, paused_at, interim_state
+The accessor validates `task_ref` + `paused_at` + `interim_state` only; the
+HMAC + schema-type checks happen at the envelope layer (envelope_schema.py).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+# 7-day default per PR #1140 §5 line 102. Caller can override via
+# insert_from_envelope(ttl_seconds=...) for tests + per-task customisation.
+DEFAULT_TTL_SECONDS: int = 7 * 86400
+
+STATE_PENDING = "pending"
+STATE_RESUMED = "resumed"
+STATE_DEAD_LETTERED = "dead_lettered"
+
+_REQUIRED_ENVELOPE_FIELDS = frozenset({"task_ref", "paused_at", "interim_state"})
+
+
+class _DBProtocol(Protocol):
+    """Subset of a DB cursor we depend on. Mirrors PR #1184 composer + PR #1173."""
+
+    def execute(self, query: str, *params: Any) -> Any: ...
+    def fetchone(self) -> Any: ...
+    def fetchall(self) -> Any: ...
+
+
+class PausedTasksStoreError(ValueError):
+    """Raised on envelope-shape mismatch or invariant violation."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class PausedTask:
+    """Row shape from public.keiracom_paused_tasks."""
+
+    task_ref: str
+    callsign: str
+    paused_at: int  # unix-int (DB stores TIMESTAMPTZ; accessor normalises to int)
+    deadline_at: int
+    interim_state: Mapping[str, Any]
+    question: str | None
+    options: Mapping[str, Any] | None
+    state: str
+
+
+class PausedTasksStore:
+    """DB-backed paused-task lifecycle: insert (write) + get (read) + delete +
+    iter_expired (dead-letter sweep)."""
+
+    def __init__(self, *, db: _DBProtocol):
+        self._db = db
+
+    def insert_from_envelope(
+        self,
+        envelope: Mapping[str, Any],
+        callsign: str,
+        *,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ) -> None:
+        """Persist a paused_pending_decision envelope. Idempotent on task_ref.
+
+        Raises PausedTasksStoreError if required envelope fields are missing.
+        """
+        missing = _REQUIRED_ENVELOPE_FIELDS - envelope.keys()
+        if missing:
+            raise PausedTasksStoreError(f"envelope missing required fields: {sorted(missing)}")
+        if not callsign:
+            raise PausedTasksStoreError("callsign is required")
+        task_ref = envelope["task_ref"]
+        paused_at = int(envelope["paused_at"])
+        interim_state = envelope["interim_state"]
+        question = envelope.get("question")
+        options = envelope.get("options")
+        deadline_at = paused_at + ttl_seconds
+        self._db.execute(
+            """
+            INSERT INTO public.keiracom_paused_tasks (
+                task_ref, callsign, paused_at, deadline_at,
+                interim_state, question, options
+            ) VALUES (
+                $1, $2, to_timestamp($3), to_timestamp($4),
+                $5::jsonb, $6, $7::jsonb
+            )
+            ON CONFLICT (task_ref) DO UPDATE SET
+                interim_state = EXCLUDED.interim_state,
+                question = EXCLUDED.question,
+                options = EXCLUDED.options,
+                deadline_at = EXCLUDED.deadline_at,
+                state = 'pending',
+                updated_at = NOW()
+            """,
+            task_ref,
+            callsign,
+            paused_at,
+            deadline_at,
+            interim_state,
+            question,
+            options,
+        )
+
+    def get_by_task_ref(self, task_ref: str) -> PausedTask | None:
+        """Fetch a single row by task_ref. Returns None if not found."""
+        self._db.execute(
+            """
+            SELECT task_ref, callsign,
+                   EXTRACT(EPOCH FROM paused_at)::bigint,
+                   EXTRACT(EPOCH FROM deadline_at)::bigint,
+                   interim_state, question, options, state
+              FROM public.keiracom_paused_tasks
+             WHERE task_ref = $1
+            """,
+            task_ref,
+        )
+        row = self._db.fetchone()
+        return _row_to_paused_task(row) if row else None
+
+    def delete(self, task_ref: str) -> None:
+        """Remove a row by task_ref. Idempotent — no error on missing row."""
+        self._db.execute(
+            "DELETE FROM public.keiracom_paused_tasks WHERE task_ref = $1",
+            task_ref,
+        )
+
+    def mark_state(self, task_ref: str, new_state: str) -> None:
+        """Transition lifecycle state (pending → resumed | dead_lettered)."""
+        if new_state not in {STATE_PENDING, STATE_RESUMED, STATE_DEAD_LETTERED}:
+            raise PausedTasksStoreError(f"unknown state {new_state!r}")
+        self._db.execute(
+            "UPDATE public.keiracom_paused_tasks SET state = $1 WHERE task_ref = $2",
+            new_state,
+            task_ref,
+        )
+
+    def iter_expired(self, now: int) -> Iterator[PausedTask]:
+        """Yield pending rows whose deadline has elapsed (dead-letter sweep input)."""
+        self._db.execute(
+            """
+            SELECT task_ref, callsign,
+                   EXTRACT(EPOCH FROM paused_at)::bigint,
+                   EXTRACT(EPOCH FROM deadline_at)::bigint,
+                   interim_state, question, options, state
+              FROM public.keiracom_paused_tasks
+             WHERE state = 'pending' AND deadline_at < to_timestamp($1)
+            """,
+            now,
+        )
+        for row in self._db.fetchall() or []:
+            yield _row_to_paused_task(row)
+
+
+def _row_to_paused_task(row: Any) -> PausedTask:
+    return PausedTask(
+        task_ref=row[0],
+        callsign=row[1],
+        paused_at=int(row[2]),
+        deadline_at=int(row[3]),
+        interim_state=row[4] or {},
+        question=row[5],
+        options=row[6],
+        state=row[7],
+    )

--- a/supabase/migrations/20260526_keiracom_paused_tasks.sql
+++ b/supabase/migrations/20260526_keiracom_paused_tasks.sql
@@ -1,0 +1,80 @@
+-- ============================================================================
+-- 20260526_keiracom_paused_tasks.sql
+--
+-- Phase A8 ephemeral-agent paused-task persistence (PR #1140 §5 + §7 piece #2).
+-- bd: Agency_OS-tjni
+--
+-- Persists state-snapshots from `paused_pending_decision` envelopes (per my
+-- PR #1181 envelope schema, Agency_OS-wmbv) so a future resume-spawn agent
+-- can pick up where the paused agent left off. The dispatcher (PR #1188,
+-- Agency_OS-8416) is the writer; resume-spawn logic is the reader.
+--
+-- CANONICAL DESIGN — docs/architecture/ephemeral_agent_system_scoping.md
+-- §5 (state-snapshot semantics) + §7 piece #2 (this work).
+--
+-- Schema decisions:
+--   - PRIMARY KEY (task_ref) — opaque correlation key from the envelope;
+--     unique by design (one paused row per task at a time).
+--   - deadline_at = paused_at + 7 days (§5 line 102: "TTL on the row e.g.
+--     7 days → automatic cleanup + dead-letter to Elliot"). The sweep is
+--     query-driven via iter_expired() in the accessor — no native PG TTL.
+--   - state CHECK ('pending','resumed','dead_lettered') — explicit lifecycle.
+--   - Idempotent re-insert via ON CONFLICT semantics (dispatcher handles
+--     this via insert_from_envelope() — see src/relay/paused_tasks.py).
+--   - No FK to keiracom_tenants — paused-tasks are per-callsign-internal
+--     (orchestrator-level dead-letter), not per-tenant. Sibling concept
+--     to keiracom_atom_store (per-tenant) but different scope per §5.
+--
+-- KEI-87 bypass: SET LOCAL agency_os.callsign = 'dave' — same pattern as
+-- 20260526_keiracom_tenant_budgets.sql + 20260525_keiracom_tenants.sql.
+-- ============================================================================
+
+SET LOCAL agency_os.callsign = 'dave';
+
+CREATE TABLE IF NOT EXISTS public.keiracom_paused_tasks (
+    task_ref       TEXT         PRIMARY KEY
+        CHECK (length(task_ref) > 0),
+    callsign       TEXT         NOT NULL
+        CHECK (length(callsign) > 0),
+    paused_at      TIMESTAMPTZ  NOT NULL,
+    deadline_at    TIMESTAMPTZ  NOT NULL
+        CHECK (deadline_at > paused_at),
+    interim_state  JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    question       TEXT,
+    options        JSONB,
+    state          TEXT         NOT NULL DEFAULT 'pending'
+        CHECK (state IN ('pending','resumed','dead_lettered')),
+    created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- Sweep query: WHERE state = 'pending' AND deadline_at < now() — partial
+-- index on the pending-only subset keeps the dead-letter scan cheap.
+CREATE INDEX IF NOT EXISTS idx_keiracom_paused_tasks_pending_deadline
+    ON public.keiracom_paused_tasks (deadline_at)
+    WHERE state = 'pending';
+
+-- Per-callsign listing (operator + ops queries): "what is callsign X
+-- waiting on?"
+CREATE INDEX IF NOT EXISTS idx_keiracom_paused_tasks_callsign
+    ON public.keiracom_paused_tasks (callsign);
+
+-- Trigger to refresh updated_at on every UPDATE so the column tracks the
+-- last state change even when the writer forgets to set it explicitly.
+CREATE OR REPLACE FUNCTION public.keiracom_paused_tasks_set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_keiracom_paused_tasks_updated_at
+    ON public.keiracom_paused_tasks;
+
+CREATE TRIGGER trg_keiracom_paused_tasks_updated_at
+    BEFORE UPDATE ON public.keiracom_paused_tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION public.keiracom_paused_tasks_set_updated_at();

--- a/tests/test_paused_tasks.py
+++ b/tests/test_paused_tasks.py
@@ -1,0 +1,256 @@
+"""Unit tests for src/relay/paused_tasks.py.
+
+Covers PausedTasksStore: insert_from_envelope (positive + negative paths,
+idempotency, ON CONFLICT semantics), get_by_task_ref (hit + miss), delete
+(idempotent), mark_state, iter_expired.
+
+bd: Agency_OS-tjni
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.relay.paused_tasks import (
+    DEFAULT_TTL_SECONDS,
+    STATE_DEAD_LETTERED,
+    STATE_PENDING,
+    STATE_RESUMED,
+    PausedTask,
+    PausedTasksStore,
+    PausedTasksStoreError,
+    _row_to_paused_task,
+)
+
+
+class _FakeDB:
+    """Minimal _DBProtocol implementation with scripted fetch responses."""
+
+    def __init__(self) -> None:
+        self.queries: list[tuple[str, tuple[Any, ...]]] = []
+        self._next_one: Any = None
+        self._next_all: list[Any] = []
+        self._script: list[tuple[Any, list[Any]]] = []
+
+    def script(self, one: Any, all_: list[Any]) -> None:
+        self._script.append((one, all_))
+
+    def execute(self, query: str, *params: Any) -> Any:
+        self.queries.append((query, params))
+        if self._script:
+            self._next_one, self._next_all = self._script.pop(0)
+        return self
+
+    def fetchone(self) -> Any:
+        return self._next_one
+
+    def fetchall(self) -> Any:
+        return self._next_all
+
+
+_GOOD_ENVELOPE = {
+    "id": "paused_1",
+    "type": "paused_pending_decision",
+    "from": "nova",
+    "task_ref": "review-pr-N",
+    "paused_at": 1748252600,
+    "interim_state": {"notes": "waiting on Elliot"},
+}
+
+
+# ─── insert_from_envelope ──────────────────────────────────────────────────────
+
+
+def test_insert_from_envelope_writes_with_default_ttl():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db)
+    store.insert_from_envelope(_GOOD_ENVELOPE, callsign="nova")
+    assert len(db.queries) == 1
+    query, params = db.queries[0]
+    assert "INSERT INTO public.keiracom_paused_tasks" in query
+    assert "ON CONFLICT (task_ref) DO UPDATE" in query
+    # task_ref, callsign, paused_at, deadline_at = paused_at + 7d
+    assert params[0] == "review-pr-N"
+    assert params[1] == "nova"
+    assert params[2] == 1748252600
+    assert params[3] == 1748252600 + DEFAULT_TTL_SECONDS
+
+
+def test_insert_from_envelope_respects_ttl_override():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db)
+    store.insert_from_envelope(_GOOD_ENVELOPE, callsign="nova", ttl_seconds=3600)
+    _, params = db.queries[0]
+    assert params[3] == 1748252600 + 3600
+
+
+def test_insert_from_envelope_raises_on_missing_required_fields():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db)
+    with pytest.raises(PausedTasksStoreError, match="missing required fields"):
+        store.insert_from_envelope(
+            {"id": "x", "type": "paused_pending_decision", "from": "nova"},
+            callsign="nova",
+        )
+
+
+def test_insert_from_envelope_raises_on_empty_callsign():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db)
+    with pytest.raises(PausedTasksStoreError, match="callsign is required"):
+        store.insert_from_envelope(_GOOD_ENVELOPE, callsign="")
+
+
+def test_insert_from_envelope_carries_optional_question_and_options():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db)
+    envelope = {
+        **_GOOD_ENVELOPE,
+        "question": "push or override?",
+        "options": ["push", "override"],
+    }
+    store.insert_from_envelope(envelope, callsign="nova")
+    _, params = db.queries[0]
+    assert params[5] == "push or override?"  # question
+    assert params[6] == ["push", "override"]  # options
+
+
+def test_insert_from_envelope_handles_missing_optional_fields():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db)
+    store.insert_from_envelope(_GOOD_ENVELOPE, callsign="nova")
+    _, params = db.queries[0]
+    assert params[5] is None  # question absent
+    assert params[6] is None  # options absent
+
+
+# ─── get_by_task_ref ───────────────────────────────────────────────────────────
+
+
+def test_get_by_task_ref_returns_paused_task_on_hit():
+    db = _FakeDB()
+    db.script(
+        (
+            "review-pr-N",  # task_ref
+            "nova",  # callsign
+            1748252600,  # paused_at
+            1748857400,  # deadline_at
+            {"notes": "x"},  # interim_state
+            None,  # question
+            None,  # options
+            "pending",  # state
+        ),
+        [],
+    )
+    store = PausedTasksStore(db=db)
+    row = store.get_by_task_ref("review-pr-N")
+    assert isinstance(row, PausedTask)
+    assert row.task_ref == "review-pr-N"
+    assert row.callsign == "nova"
+    assert row.paused_at == 1748252600
+    assert row.state == STATE_PENDING
+
+
+def test_get_by_task_ref_returns_none_on_miss():
+    db = _FakeDB()
+    db.script(None, [])  # fetchone returns None
+    store = PausedTasksStore(db=db)
+    assert store.get_by_task_ref("ghost") is None
+
+
+# ─── delete ────────────────────────────────────────────────────────────────────
+
+
+def test_delete_executes_idempotent_query():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db)
+    store.delete("review-pr-N")
+    query, params = db.queries[0]
+    assert "DELETE FROM public.keiracom_paused_tasks" in query
+    assert params == ("review-pr-N",)
+
+
+def test_delete_missing_row_does_not_raise():
+    """The DELETE WHERE task_ref = X is idempotent at the SQL level — fake DB
+    doesn't simulate the missing-row case (no rowcount semantics needed)."""
+    db = _FakeDB()
+    store = PausedTasksStore(db=db)
+    # Should not raise even without scripting a response.
+    store.delete("never-existed")
+
+
+# ─── mark_state ────────────────────────────────────────────────────────────────
+
+
+def test_mark_state_accepts_known_states():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db)
+    for state in (STATE_PENDING, STATE_RESUMED, STATE_DEAD_LETTERED):
+        store.mark_state("review-pr-N", state)
+    assert len(db.queries) == 3
+
+
+def test_mark_state_rejects_unknown_state():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db)
+    with pytest.raises(PausedTasksStoreError, match="unknown state"):
+        store.mark_state("review-pr-N", "bogus")
+
+
+# ─── iter_expired ──────────────────────────────────────────────────────────────
+
+
+def test_iter_expired_yields_paused_task_rows():
+    db = _FakeDB()
+    db.script(
+        None,
+        [
+            (
+                "task_a",
+                "nova",
+                1748000000,
+                1748000300,  # already expired
+                {"notes": "a"},
+                None,
+                None,
+                "pending",
+            ),
+            (
+                "task_b",
+                "atlas",
+                1748000100,
+                1748000400,
+                {},
+                "q?",
+                ["yes", "no"],
+                "pending",
+            ),
+        ],
+    )
+    store = PausedTasksStore(db=db)
+    rows = list(store.iter_expired(now=1748252600))
+    assert len(rows) == 2
+    assert {r.task_ref for r in rows} == {"task_a", "task_b"}
+    assert all(r.state == STATE_PENDING for r in rows)
+    # The query is parameterised on now; verify it landed correctly.
+    query, params = db.queries[0]
+    assert "WHERE state = 'pending'" in query
+    assert params == (1748252600,)
+
+
+def test_iter_expired_empty_yields_nothing():
+    db = _FakeDB()
+    db.script(None, [])
+    store = PausedTasksStore(db=db)
+    assert list(store.iter_expired(now=1748252600)) == []
+
+
+# ─── _row_to_paused_task ───────────────────────────────────────────────────────
+
+
+def test_row_to_paused_task_normalises_null_interim_state_to_empty_dict():
+    row = ("t", "c", 1, 2, None, None, None, "pending")
+    task = _row_to_paused_task(row)
+    assert task.interim_state == {}


### PR DESCRIPTION
## Summary

PR #1140 §7 piece #2 — Postgres persistence for `paused_pending_decision` state-snapshots. The dispatcher (PR #1188, Agency_OS-8416) writes via `PausedTasksStore.insert_from_envelope()`; the resume-spawn path reads via `get_by_task_ref()`; a separate sweep job uses `iter_expired()` to dead-letter rows past their 7-day deadline.

**P1** — completes the §7 substrate layer alongside pieces 3 + 4 + 5 + 1. Identified-missing by Scout's PR #1171 audit (Agency_OS-zw3k); none of the 7 §7 follow-up KEIs were ever filed until this session.

**Filed under:** Agency_OS-tjni (P1).

## §7 substrate layer status

| Piece | PR | Status |
|---|---|---|
| **2 — paused_tasks table + accessor** | **#1190 (this PR)** | **OPEN** |
| 3 — envelope JSON schema | #1181 (Nova) | OPEN, infra-HOLD |
| 4 — per-callsign systemd template | #1180 (Scout) | OPEN, infra-HOLD |
| 5 — spawn-with-context composer | #1184 (Nova) | OPEN, infra-HOLD |
| 1 — dispatcher binary | #1188 (Nova) | OPEN, infra-HOLD |

**This PR is INDEPENDENT** — branched off `origin/main` directly, does NOT import from PR #1181 envelope_schema. Can merge in any order relative to the other 4. Envelope-shape validation is done inline (3 required field names hardcoded). Optional polish post-#1181-merge: swap inline literal for `from src.relay.envelope_schema import REQUIRED_FIELDS`.

## What lands

### `supabase/migrations/20260526_keiracom_paused_tasks.sql` (~70 LoC)

- Table `public.keiracom_paused_tasks`
- PRIMARY KEY (`task_ref`) — opaque correlation key from envelope
- CHECK constraints: non-empty `task_ref`, non-empty `callsign`, `deadline_at > paused_at`, `state ∈ ('pending','resumed','dead_lettered')`
- Partial index on `(deadline_at) WHERE state='pending'` for cheap dead-letter sweep scans
- Separate index on `(callsign)` for "what is callsign X waiting on?" operator queries
- `updated_at` trigger (mirrors `keiracom_tenant_budgets` pattern)
- `SET LOCAL agency_os.callsign='dave'` KEI-87 bypass (same as `20260526_keiracom_tenant_budgets.sql` + `20260525_keiracom_tenants.sql`)
- **No FK to `keiracom_tenants`** — paused-tasks are per-callsign-internal (orchestrator-level dead-letter, NOT per-tenant); confirmed by §5 "dead-letter to Elliot" framing

### `src/relay/paused_tasks.py` (~108 LoC)

| Public | Purpose |
|---|---|
| `DEFAULT_TTL_SECONDS = 7 * 86400` | Per §5 line 102 |
| `STATE_PENDING / STATE_RESUMED / STATE_DEAD_LETTERED` | Lifecycle constants |
| `PausedTask` (frozen dataclass) | Row shape |
| `PausedTasksStore` | DI'd `_DBProtocol` wrapper |
| `insert_from_envelope(envelope, callsign, *, ttl_seconds=...)` | Validates envelope shape; ON CONFLICT (task_ref) DO UPDATE for idempotent re-insert; raises `PausedTasksStoreError` on shape mismatch |
| `get_by_task_ref(task_ref)` | → `PausedTask \| None` |
| `delete(task_ref)` | Idempotent — no error on missing row |
| `mark_state(task_ref, new_state)` | pending → resumed \| dead_lettered |
| `iter_expired(now)` | Yields pending rows past deadline (sweep input) |

Same `_DBProtocol` DI shape as composer (PR #1184) + token_budget_policy (PR #1173). Module is asyncpg/psycopg-import-free → testable without live Supabase.

### `tests/test_paused_tasks.py` — 15 tests

Coverage:
- **insert_from_envelope (6 tests):** default TTL, TTL override, missing-field raises, empty-callsign raises, optional question + options forwarded, missing optional fields handled as None
- **get_by_task_ref (2 tests):** hit returns `PausedTask`, miss returns None
- **delete (2 tests):** executes idempotent query, missing-row no error
- **mark_state (2 tests):** accepts 3 known states, rejects unknown
- **iter_expired (2 tests):** yields rows with correct now param, empty yields nothing
- **_row_to_paused_task (1 test):** null interim_state normalised to `{}`

## Scope discipline (per `feedback_split_orthogonal_scope`)

- **NO dispatcher wiring** — PR #1188's `_envelope_route.py` currently treats `paused_pending_decision` as log+skip. Calling `PausedTasksStore.insert_from_envelope()` from that handler is a follow-up KEI (small, ~5 LoC change).
- **NO dead-letter scheduler** — `iter_expired()` returns the candidates; wiring it to a cron + Elliot-notification is separate.
- **NO resume-spawn consumer** — that's the dispatcher's RESUME action reading from `get_by_task_ref()` during `decision_response` handling; separate wiring KEI.

## Verification (local)

```
$ python3 -m pytest tests/test_paused_tasks.py -q
...............                                                          [100%]
15 passed in 0.07s

$ python3 -m ruff check src/relay/paused_tasks.py tests/test_paused_tasks.py
All checks passed!

$ python3 -m ruff format --check src/relay/paused_tasks.py tests/test_paused_tasks.py
2 files already formatted

$ python3 -m mypy src/relay/paused_tasks.py --ignore-missing-imports
Success: no issues found in 1 source file
```

All 5 boundary-matrix-v1 + cache-discipline guards self-pass:
```
$ ./scripts/ci/check_no_raw_valkey_outside_client.sh    → OK
$ ./scripts/ci/check_no_direct_db_outside_mal.sh        → OK
$ ./scripts/ci/check_no_nats_in_temporal_workflow_files.sh → OK
$ ./scripts/ci/check_no_direct_composio_outside_mcp.sh  → OK
$ ./scripts/ci/check_no_governance_policy_in_hindsight.sh → OK
```

(`src/relay/` lives outside `src/keiracom_system/` so it's also outside BMV1 + cache-discipline guard scope. Verified for completeness.)

## LoC

- **Production code:** ~108 LoC accessor + ~70 LoC SQL = **178 total** (Step 0 estimate: 50 SQL + 100 accessor = 150; came in slightly heavier due to docstrings + STATE_* constants + `mark_state` lifecycle support beyond the bare minimum)
- **Tests:** ~190 LoC across 15 functions per `feedback_negative_path_test_before_approve`

## CI expectation

PR opens during the fleet-wide GitHub bot suspension incident. CI gates may fail at `actions/checkout@v4` HTTP 403 until GitHub Support restores the account. Substance is independently verifiable via local test pass.

bd: Agency_OS-tjni. Closes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)