### PR TITLE
[ORION] feat(relay): A8 §7 piece 2 — paused_tasks table + migration + accessor (Agency_OS-70hb)

### DIFF
--- a/src/relay/paused_tasks_store.py
+++ b/src/relay/paused_tasks_store.py
@@ -1,0 +1,319 @@
+"""paused_tasks_store — durable-wait state accessor for ephemeral agent decisions.
+
+Per docs/architecture/ephemeral_agent_system_scoping.md §5 + §7 piece 2
+(PR #1140), Agency_OS-70hb.
+
+ROLE: when an agent pauses pending a decision_response, the dispatcher writes
+a row HERE with task_ref + question + state_snapshot. On decision_response
+arrival, dispatcher reads the row + hands the state_snapshot to the resume
+spawn (per Nova PR #1184 spawn_composer's resume-context branch). Stale rows
+(>7 days) sweep to expired + dead-letter to Elliot.
+
+DI: caller passes any DB cursor implementing _DBProtocol — no asyncpg/psycopg
+import inside this module. Production wires asyncpg; unit tests inject fakes.
+Lives in src/relay/ alongside Nova's envelope_schema.py (PR #1181) +
+redis_relay.py + relay_consumer.py.
+
+PROTOCOL (per §5):
+  1. Agent emits paused_pending_decision event → dispatcher calls
+     `PausedTasksStore.insert(task_ref, callsign, decision_target, question,
+     state_snapshot)`.
+  2. Agent terminates.
+  3. decision_response arrives → dispatcher calls
+     `PausedTasksStore.fetch(task_ref)` to retrieve state_snapshot.
+  4. Dispatcher spawns resume agent + calls `mark_resumed(task_ref)`.
+  5. Daily sweep calls `sweep_expired()` → returns expired rows for
+     dead-lettering to Elliot inbox.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+log = logging.getLogger(__name__)
+
+# Default TTL — 7 days per §5 ("e.g. 7 days"). Caller can override at insert.
+DEFAULT_TTL_DAYS: int = 7
+
+# Status enum — mirrors the SQL CHECK on paused_tasks.status.
+STATUS_ACTIVE: str = "active"
+STATUS_RESUMED: str = "resumed"
+STATUS_EXPIRED: str = "expired"
+STATUS_ABORTED: str = "aborted"
+
+VALID_STATUSES: frozenset[str] = frozenset(
+    {STATUS_ACTIVE, STATUS_RESUMED, STATUS_EXPIRED, STATUS_ABORTED}
+)
+
+
+class PausedTasksStoreError(RuntimeError):
+    """Raised on invalid input or store-side error."""
+
+
+class _DBProtocol(Protocol):
+    """Subset of DB cursor we depend on. Mirrors PR #1173 / #1185 _DBProtocol."""
+
+    def execute(self, query: str, *params: Any) -> Any: ...
+    def fetchone(self) -> Any: ...
+    def fetchall(self) -> Any: ...
+
+
+@dataclass(frozen=True, kw_only=True)
+class PausedTaskRow:
+    """In-memory representation of one paused_tasks row.
+
+    Frozen — mutations create new instances (mark_resumed etc. issue UPDATE
+    statements and re-fetch via the store rather than mutating in place).
+    """
+
+    task_ref: str
+    callsign: str
+    decision_target: str
+    question: str
+    state_snapshot: dict[str, Any]
+    status: str
+    created_at: datetime
+    expires_at: datetime
+    resumed_at: datetime | None = None
+    expired_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if not self.task_ref:
+            raise PausedTasksStoreError("task_ref must be non-empty")
+        if self.status not in VALID_STATUSES:
+            raise PausedTasksStoreError(f"status {self.status!r} not in {sorted(VALID_STATUSES)}")
+
+
+class PausedTasksStore:
+    """Durable-wait accessor for the paused_tasks table.
+
+    Caller injects a DB cursor; the store owns all SQL. No asyncpg/psycopg
+    imports inside this module (the cache + atomization layers follow the
+    same DI pattern — boundary-matrix-v1 guard b compatible even though
+    src/relay/ is outside BMV1 scope).
+    """
+
+    def __init__(self, *, db: _DBProtocol, now_provider=None):
+        self._db = db
+        # Injectable now() for deterministic tests; default = utcnow.
+        self._now = now_provider or (lambda: datetime.now(UTC))
+
+    def insert(
+        self,
+        *,
+        task_ref: str,
+        callsign: str,
+        decision_target: str,
+        question: str,
+        state_snapshot: dict[str, Any] | None = None,
+        ttl_days: int = DEFAULT_TTL_DAYS,
+    ) -> None:
+        """Write a paused_pending_decision state row.
+
+        Idempotent on task_ref via Postgres ON CONFLICT DO NOTHING — re-issuing
+        the same paused_pending_decision (e.g. dispatcher retry) doesn't
+        clobber the original timestamp + TTL window.
+        """
+        if not task_ref:
+            raise PausedTasksStoreError("task_ref must be non-empty")
+        if not callsign:
+            raise PausedTasksStoreError("callsign must be non-empty")
+        if not decision_target:
+            raise PausedTasksStoreError("decision_target must be non-empty")
+        if not question:
+            raise PausedTasksStoreError("question must be non-empty")
+        if ttl_days <= 0:
+            raise PausedTasksStoreError("ttl_days must be > 0")
+        now = self._now()
+        expires_at = now + timedelta(days=ttl_days)
+        snapshot_json = json.dumps(state_snapshot or {})
+        self._db.execute(
+            "INSERT INTO paused_tasks ("
+            "task_ref, callsign, decision_target, question, state_snapshot, "
+            "status, created_at, expires_at"
+            ") VALUES (%s, %s, %s, %s, %s, 'active', %s, %s) "
+            "ON CONFLICT (task_ref) DO NOTHING",
+            task_ref,
+            callsign,
+            decision_target,
+            question,
+            snapshot_json,
+            now,
+            expires_at,
+        )
+
+    def fetch(self, task_ref: str) -> PausedTaskRow | None:
+        """Look up by task_ref. Returns None if absent.
+
+        Used by dispatcher on decision_response arrival to retrieve the
+        state_snapshot for handoff to the resume spawn.
+        """
+        if not task_ref:
+            raise PausedTasksStoreError("task_ref must be non-empty")
+        self._db.execute(
+            "SELECT task_ref, callsign, decision_target, question, "
+            "state_snapshot, status, created_at, expires_at, resumed_at, "
+            "expired_at "
+            "FROM paused_tasks WHERE task_ref = %s",
+            task_ref,
+        )
+        row = self._db.fetchone()
+        if row is None:
+            return None
+        return self._row_to_paused_task(row)
+
+    def mark_resumed(self, task_ref: str) -> None:
+        """Flip status from active → resumed. Called when dispatcher spawns
+        the resume agent on decision_response arrival.
+        """
+        if not task_ref:
+            raise PausedTasksStoreError("task_ref must be non-empty")
+        now = self._now()
+        self._db.execute(
+            "UPDATE paused_tasks SET status = 'resumed', resumed_at = %s "
+            "WHERE task_ref = %s AND status = 'active'",
+            now,
+            task_ref,
+        )
+
+    def mark_aborted(self, task_ref: str) -> None:
+        """Flip status from active → aborted. Used when decision_response
+        carries decision='abort' (per §5 edge case)."""
+        if not task_ref:
+            raise PausedTasksStoreError("task_ref must be non-empty")
+        self._db.execute(
+            "UPDATE paused_tasks SET status = 'aborted' WHERE task_ref = %s AND status = 'active'",
+            task_ref,
+        )
+
+    def sweep_expired(self) -> list[PausedTaskRow]:
+        """TTL sweep: mark all expired-eligible rows as expired + return them.
+
+        Caller (a daily/hourly cron) iterates the returned rows and writes
+        dead-letter JSON to Elliot's inbox for review.
+
+        Atomic: SELECT + UPDATE in one transaction via UPDATE ... RETURNING.
+        """
+        now = self._now()
+        self._db.execute(
+            "UPDATE paused_tasks SET status = 'expired', expired_at = %s "
+            "WHERE status = 'active' AND expires_at <= %s "
+            "RETURNING task_ref, callsign, decision_target, question, "
+            "state_snapshot, status, created_at, expires_at, resumed_at, "
+            "expired_at",
+            now,
+            now,
+        )
+        rows = self._db.fetchall() or []
+        return [self._row_to_paused_task(r) for r in rows]
+
+    def list_by_callsign(
+        self, callsign: str, *, status: str = STATUS_ACTIVE
+    ) -> list[PausedTaskRow]:
+        """Show all paused tasks for a callsign with the given status.
+
+        Useful for "what is orion waiting on?" diagnostics or per-callsign
+        cleanup queries.
+        """
+        if status not in VALID_STATUSES:
+            raise PausedTasksStoreError(f"status {status!r} not in {sorted(VALID_STATUSES)}")
+        self._db.execute(
+            "SELECT task_ref, callsign, decision_target, question, "
+            "state_snapshot, status, created_at, expires_at, resumed_at, "
+            "expired_at "
+            "FROM paused_tasks WHERE callsign = %s AND status = %s "
+            "ORDER BY created_at DESC",
+            callsign,
+            status,
+        )
+        rows = self._db.fetchall() or []
+        return [self._row_to_paused_task(r) for r in rows]
+
+    def list_pending_for_target(self, decision_target: str) -> list[PausedTaskRow]:
+        """Show all active tasks awaiting a decision from `decision_target`.
+
+        Used by per-callsign dispatchers + the "orion is waiting on aiden"
+        operational query.
+        """
+        if not decision_target:
+            raise PausedTasksStoreError("decision_target must be non-empty")
+        self._db.execute(
+            "SELECT task_ref, callsign, decision_target, question, "
+            "state_snapshot, status, created_at, expires_at, resumed_at, "
+            "expired_at "
+            "FROM paused_tasks WHERE decision_target = %s AND status = 'active' "
+            "ORDER BY created_at ASC",
+            decision_target,
+        )
+        rows = self._db.fetchall() or []
+        return [self._row_to_paused_task(r) for r in rows]
+
+    # ------------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------------
+
+    @staticmethod
+    def _row_to_paused_task(row: Any) -> PausedTaskRow:
+        """Build a PausedTaskRow from a DB row tuple in canonical column order."""
+        task_ref, callsign, decision_target, question, state_snapshot = row[:5]
+        status, created_at, expires_at, resumed_at, expired_at = row[5:]
+        return PausedTaskRow(
+            task_ref=str(task_ref),
+            callsign=str(callsign),
+            decision_target=str(decision_target),
+            question=str(question),
+            state_snapshot=_parse_jsonb(state_snapshot),
+            status=str(status),
+            created_at=_coerce_datetime(created_at),
+            expires_at=_coerce_datetime(expires_at),
+            resumed_at=_coerce_datetime(resumed_at) if resumed_at else None,
+            expired_at=_coerce_datetime(expired_at) if expired_at else None,
+        )
+
+
+def _parse_jsonb(value: Any) -> dict[str, Any]:
+    """Postgres JSONB may come back as dict (psycopg adapts) or str (raw)."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        return json.loads(value)
+    return {}
+
+
+def _coerce_datetime(value: Any) -> datetime:
+    """Tolerate either a datetime or an ISO-format string from the DB layer."""
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        # Handle both 'Z' and offset notations.
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    raise PausedTasksStoreError(f"unexpected datetime shape: {type(value).__name__}")
+
+
+def dead_letter_payload(rows: Iterable[PausedTaskRow]) -> list[dict[str, Any]]:
+    """Render expired paused_tasks rows as JSON-serializable dicts.
+
+    Caller (the TTL sweep) writes these to Elliot's inbox at
+    /tmp/telegram-relay-elliot/inbox/paused_tasks_expired_<ts>.json so Elliot
+    can review the stale-decision queue + escalate to Dave if needed.
+
+    Empty list → no dead-letter file needed.
+    """
+    return [
+        {
+            "task_ref": r.task_ref,
+            "callsign": r.callsign,
+            "decision_target": r.decision_target,
+            "question": r.question,
+            "state_snapshot": r.state_snapshot,
+            "created_at": r.created_at.isoformat(),
+            "expires_at": r.expires_at.isoformat(),
+            "expired_at": r.expired_at.isoformat() if r.expired_at else None,
+        }
+        for r in rows
+    ]

--- a/supabase/migrations/20260526_paused_tasks.sql
+++ b/supabase/migrations/20260526_paused_tasks.sql
@@ -1,0 +1,79 @@
+-- ============================================================================
+-- 20260526_paused_tasks.sql
+--
+-- Ephemeral agent system §7 piece 2 — durable-wait state for the
+-- decision_request/decision_response handshake. Filed under Agency_OS-70hb.
+--
+-- CANONICAL DESIGN — docs/architecture/ephemeral_agent_system_scoping.md
+-- (PR #1140, MERGED 2026-05-25T05:19:04Z), §5 state-snapshot + §7 piece 2.
+--
+-- ROLE in the protocol (per §5):
+--   1. Agent reaches decision-needed → writes decision_request envelope to
+--      the deciding-party's inbox.
+--   2. Agent emits paused_pending_decision event → dispatcher writes a row
+--      HERE with task_ref + question + state_snapshot. Agent terminates.
+--   3. Decision-giver answers via decision_response envelope; dispatcher
+--      reads the row + spawns resume agent with state_snapshot.
+--   4. Dispatcher marks the row resumed.
+--   5. If no decision_response within TTL (7 days), TTL sweep marks row
+--      expired + dead-letters to Elliot inbox.
+--
+-- COMPLEMENTS — Nova PR #1181 envelope_schema.py (decision_request +
+-- decision_response + paused_pending_decision envelope types) + Nova
+-- PR #1184 spawn_composer.py (resume-context branch consuming this state).
+--
+-- KEI-87 bypass: SET LOCAL agency_os.callsign = 'dave' required for
+-- public-schema table creation (same pattern as 20260525_keiracom_*.sql).
+-- ============================================================================
+
+SET LOCAL agency_os.callsign = 'dave';
+
+CREATE TABLE IF NOT EXISTS public.paused_tasks (
+    -- Primary key + linkage
+    task_ref           TEXT         NOT NULL PRIMARY KEY,
+        -- bd ID, NATS subject, OR any caller-chosen unique identifier that
+        -- the dispatcher uses to match decision_response → paused_tasks row
+
+    -- Identity + routing
+    callsign           TEXT         NOT NULL,
+        -- The agent that paused (e.g. 'orion', 'atlas')
+    decision_target    TEXT         NOT NULL,
+        -- Who needs to decide (e.g. 'elliot', 'aiden', 'dave')
+
+    -- Payload — typically <1KB per §5
+    question           TEXT         NOT NULL,
+        -- Human-readable decision question
+    state_snapshot     JSONB        NOT NULL DEFAULT '{}'::jsonb,
+        -- Interim state needed to resume: task_ref linkage + intermediate
+        -- artifact file paths + per-§5 "whatever interim work it had
+        -- completed"
+
+    -- Lifecycle
+    status             TEXT         NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'resumed', 'expired', 'aborted')),
+    created_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    expires_at         TIMESTAMPTZ  NOT NULL,
+        -- TTL boundary; 7-day default per §5 set by accessor at insert-time.
+        -- TTL sweep job marks expired status + dead-letters to Elliot inbox.
+    resumed_at         TIMESTAMPTZ,
+        -- Set when dispatcher spawns resume agent on decision_response
+    expired_at         TIMESTAMPTZ
+        -- Set by the TTL sweep when status flips to expired
+);
+
+-- Lookup by task_ref is the dispatcher's hot path (resolve decision_response
+-- target). Primary key already provides this, but add named index for clarity.
+
+-- TTL sweep query: WHERE expires_at <= NOW() AND status = 'active'.
+-- Partial index on active rows keeps the sweep cheap.
+CREATE INDEX IF NOT EXISTS idx_paused_tasks_active_expires
+    ON public.paused_tasks (expires_at)
+    WHERE status = 'active';
+
+-- "Show me orion's paused tasks" + "show me elliot's pending decisions" —
+-- composite index for callsign + status + decision_target queries.
+CREATE INDEX IF NOT EXISTS idx_paused_tasks_callsign_status
+    ON public.paused_tasks (callsign, status);
+
+CREATE INDEX IF NOT EXISTS idx_paused_tasks_decision_target_status
+    ON public.paused_tasks (decision_target, status);

--- a/tests/relay/test_paused_tasks_store.py
+++ b/tests/relay/test_paused_tasks_store.py
@@ -1,0 +1,477 @@
+"""paused_tasks_store unit tests — A8 §7 piece 2 (Agency_OS-70hb)."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from src.relay.paused_tasks_store import (
+    DEFAULT_TTL_DAYS,
+    STATUS_ABORTED,
+    STATUS_ACTIVE,
+    STATUS_EXPIRED,
+    STATUS_RESUMED,
+    VALID_STATUSES,
+    PausedTaskRow,
+    PausedTasksStore,
+    PausedTasksStoreError,
+    dead_letter_payload,
+)
+
+
+class _FakeDB:
+    """Minimal DB fake — record executes + serve canned fetchone/fetchall."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, tuple]] = []
+        self._next_one: Any = None
+        self._next_all: list[Any] = []
+
+    def execute(self, query: str, *params):
+        self.calls.append((query, params))
+
+    def fetchone(self):
+        return self._next_one
+
+    def fetchall(self):
+        return self._next_all
+
+    def queue_fetchone(self, row: Any) -> None:
+        self._next_one = row
+
+    def queue_fetchall(self, rows: list[Any]) -> None:
+        self._next_all = rows
+
+
+def _fixed_now() -> datetime:
+    return datetime(2026, 5, 26, 13, 30, 0, tzinfo=UTC)
+
+
+def _row_tuple(
+    *,
+    task_ref: str = "Agency_OS-test",
+    callsign: str = "orion",
+    decision_target: str = "elliot",
+    question: str = "should we X?",
+    state_snapshot: Any = None,
+    status: str = "active",
+    created_at: datetime | None = None,
+    expires_at: datetime | None = None,
+    resumed_at: datetime | None = None,
+    expired_at: datetime | None = None,
+) -> tuple:
+    """Build a DB row tuple in the order returned by SELECT columns."""
+    return (
+        task_ref,
+        callsign,
+        decision_target,
+        question,
+        state_snapshot if state_snapshot is not None else "{}",
+        status,
+        created_at or _fixed_now(),
+        expires_at or (_fixed_now() + timedelta(days=DEFAULT_TTL_DAYS)),
+        resumed_at,
+        expired_at,
+    )
+
+
+# ---- Constants + enum locks ------------------------------------------------
+
+
+def test_default_ttl_is_seven_days():
+    assert DEFAULT_TTL_DAYS == 7
+
+
+def test_valid_statuses_set():
+    assert (
+        frozenset({STATUS_ACTIVE, STATUS_RESUMED, STATUS_EXPIRED, STATUS_ABORTED}) == VALID_STATUSES
+    )
+
+
+def test_status_constants():
+    assert STATUS_ACTIVE == "active"
+    assert STATUS_RESUMED == "resumed"
+    assert STATUS_EXPIRED == "expired"
+    assert STATUS_ABORTED == "aborted"
+
+
+# ---- PausedTaskRow invariants ----------------------------------------------
+
+
+def test_paused_task_row_valid():
+    row = PausedTaskRow(
+        task_ref="Agency_OS-x",
+        callsign="orion",
+        decision_target="elliot",
+        question="should we?",
+        state_snapshot={},
+        status="active",
+        created_at=_fixed_now(),
+        expires_at=_fixed_now() + timedelta(days=7),
+    )
+    assert row.task_ref == "Agency_OS-x"
+    assert row.resumed_at is None
+
+
+def test_paused_task_row_rejects_empty_task_ref():
+    with pytest.raises(PausedTasksStoreError, match="task_ref"):
+        PausedTaskRow(
+            task_ref="",
+            callsign="orion",
+            decision_target="elliot",
+            question="q",
+            state_snapshot={},
+            status="active",
+            created_at=_fixed_now(),
+            expires_at=_fixed_now() + timedelta(days=7),
+        )
+
+
+def test_paused_task_row_rejects_unknown_status():
+    with pytest.raises(PausedTasksStoreError, match="status"):
+        PausedTaskRow(
+            task_ref="x",
+            callsign="orion",
+            decision_target="elliot",
+            question="q",
+            state_snapshot={},
+            status="_bogus",
+            created_at=_fixed_now(),
+            expires_at=_fixed_now() + timedelta(days=7),
+        )
+
+
+# ---- insert() --------------------------------------------------------------
+
+
+def test_insert_validates_required_fields():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    with pytest.raises(PausedTasksStoreError, match="task_ref"):
+        store.insert(
+            task_ref="",
+            callsign="orion",
+            decision_target="elliot",
+            question="q",
+        )
+    with pytest.raises(PausedTasksStoreError, match="callsign"):
+        store.insert(
+            task_ref="x",
+            callsign="",
+            decision_target="elliot",
+            question="q",
+        )
+    with pytest.raises(PausedTasksStoreError, match="decision_target"):
+        store.insert(
+            task_ref="x",
+            callsign="orion",
+            decision_target="",
+            question="q",
+        )
+    with pytest.raises(PausedTasksStoreError, match="question"):
+        store.insert(
+            task_ref="x",
+            callsign="orion",
+            decision_target="elliot",
+            question="",
+        )
+    with pytest.raises(PausedTasksStoreError, match="ttl_days"):
+        store.insert(
+            task_ref="x",
+            callsign="orion",
+            decision_target="elliot",
+            question="q",
+            ttl_days=0,
+        )
+
+
+def test_insert_uses_default_7_day_ttl():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    store.insert(
+        task_ref="Agency_OS-x",
+        callsign="orion",
+        decision_target="elliot",
+        question="should we?",
+    )
+    query, params = db.calls[0]
+    assert "INSERT INTO paused_tasks" in query
+    assert "ON CONFLICT (task_ref) DO NOTHING" in query
+    # Params: task_ref, callsign, decision_target, question, snapshot_json,
+    # created_at (now), expires_at (now + 7d)
+    assert params[0] == "Agency_OS-x"
+    assert params[5] == _fixed_now()
+    assert params[6] == _fixed_now() + timedelta(days=DEFAULT_TTL_DAYS)
+
+
+def test_insert_custom_ttl_days():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    store.insert(
+        task_ref="x",
+        callsign="orion",
+        decision_target="elliot",
+        question="q",
+        ttl_days=14,
+    )
+    _, params = db.calls[0]
+    assert params[6] == _fixed_now() + timedelta(days=14)
+
+
+def test_insert_serializes_state_snapshot_to_jsonb():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    snapshot = {"intermediate_file": "/tmp/work.json", "step": 3}
+    store.insert(
+        task_ref="x",
+        callsign="orion",
+        decision_target="elliot",
+        question="q",
+        state_snapshot=snapshot,
+    )
+    _, params = db.calls[0]
+    import json as _json
+
+    parsed = _json.loads(params[4])
+    assert parsed == snapshot
+
+
+def test_insert_empty_snapshot_serializes_to_empty_object():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    store.insert(
+        task_ref="x",
+        callsign="orion",
+        decision_target="elliot",
+        question="q",
+        state_snapshot=None,
+    )
+    _, params = db.calls[0]
+    assert params[4] == "{}"
+
+
+# ---- fetch() ---------------------------------------------------------------
+
+
+def test_fetch_returns_none_when_absent():
+    db = _FakeDB()
+    db.queue_fetchone(None)
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    assert store.fetch("nonexistent") is None
+
+
+def test_fetch_validates_empty_task_ref():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    with pytest.raises(PausedTasksStoreError, match="task_ref"):
+        store.fetch("")
+
+
+def test_fetch_returns_paused_task_row():
+    db = _FakeDB()
+    db.queue_fetchone(_row_tuple(task_ref="Agency_OS-x", question="should we?"))
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    row = store.fetch("Agency_OS-x")
+    assert row is not None
+    assert row.task_ref == "Agency_OS-x"
+    assert row.question == "should we?"
+    assert row.status == "active"
+    assert row.callsign == "orion"
+
+
+def test_fetch_parses_state_snapshot_jsonb_string():
+    db = _FakeDB()
+    db.queue_fetchone(_row_tuple(state_snapshot='{"step": 3, "path": "/tmp/x"}'))
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    row = store.fetch("Agency_OS-test")
+    assert row.state_snapshot == {"step": 3, "path": "/tmp/x"}
+
+
+def test_fetch_parses_state_snapshot_already_dict():
+    """psycopg may adapt JSONB to dict directly — tolerate either shape."""
+    db = _FakeDB()
+    db.queue_fetchone(_row_tuple(state_snapshot={"adapted": True}))
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    row = store.fetch("Agency_OS-test")
+    assert row.state_snapshot == {"adapted": True}
+
+
+# ---- mark_resumed() --------------------------------------------------------
+
+
+def test_mark_resumed_updates_status():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    store.mark_resumed("Agency_OS-x")
+    query, params = db.calls[0]
+    assert "UPDATE paused_tasks" in query
+    assert "status = 'resumed'" in query
+    assert "resumed_at" in query
+    # Only flips if currently active (idempotency invariant)
+    assert "status = 'active'" in query
+    assert params[1] == "Agency_OS-x"
+
+
+def test_mark_resumed_validates_task_ref():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    with pytest.raises(PausedTasksStoreError, match="task_ref"):
+        store.mark_resumed("")
+
+
+# ---- mark_aborted() --------------------------------------------------------
+
+
+def test_mark_aborted_updates_status():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    store.mark_aborted("Agency_OS-x")
+    query, params = db.calls[0]
+    assert "status = 'aborted'" in query
+    assert "status = 'active'" in query  # idempotency invariant
+    assert params[0] == "Agency_OS-x"
+
+
+# ---- sweep_expired() -------------------------------------------------------
+
+
+def test_sweep_expired_returns_empty_when_no_stale_rows():
+    db = _FakeDB()
+    db.queue_fetchall([])
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    assert store.sweep_expired() == []
+
+
+def test_sweep_expired_uses_atomic_update_returning():
+    db = _FakeDB()
+    db.queue_fetchall([])
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    store.sweep_expired()
+    query, params = db.calls[0]
+    assert "UPDATE paused_tasks SET status = 'expired'" in query
+    assert "RETURNING" in query
+    assert "expires_at <= %s" in query
+    assert "status = 'active'" in query
+
+
+def test_sweep_expired_returns_paused_task_rows():
+    db = _FakeDB()
+    db.queue_fetchall(
+        [
+            _row_tuple(task_ref="A1", status="expired", expired_at=_fixed_now()),
+            _row_tuple(task_ref="A2", status="expired", expired_at=_fixed_now()),
+        ]
+    )
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    rows = store.sweep_expired()
+    assert len(rows) == 2
+    assert {r.task_ref for r in rows} == {"A1", "A2"}
+    assert all(r.status == "expired" for r in rows)
+
+
+# ---- list_by_callsign() ----------------------------------------------------
+
+
+def test_list_by_callsign_default_active():
+    db = _FakeDB()
+    db.queue_fetchall([_row_tuple(callsign="orion", task_ref="x")])
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    rows = store.list_by_callsign("orion")
+    assert len(rows) == 1
+    query, params = db.calls[0]
+    assert "WHERE callsign = %s AND status = %s" in query
+    assert params == ("orion", "active")
+
+
+def test_list_by_callsign_custom_status():
+    db = _FakeDB()
+    db.queue_fetchall([])
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    store.list_by_callsign("orion", status="resumed")
+    _, params = db.calls[0]
+    assert params == ("orion", "resumed")
+
+
+def test_list_by_callsign_rejects_invalid_status():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    with pytest.raises(PausedTasksStoreError, match="status"):
+        store.list_by_callsign("orion", status="_bogus")
+
+
+# ---- list_pending_for_target() --------------------------------------------
+
+
+def test_list_pending_for_target_filters_active_only():
+    db = _FakeDB()
+    db.queue_fetchall(
+        [
+            _row_tuple(decision_target="elliot", task_ref="x1"),
+            _row_tuple(decision_target="elliot", task_ref="x2"),
+        ]
+    )
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    rows = store.list_pending_for_target("elliot")
+    assert len(rows) == 2
+    query, params = db.calls[0]
+    assert "decision_target = %s AND status = 'active'" in query
+    assert params == ("elliot",)
+
+
+def test_list_pending_for_target_validates_empty():
+    db = _FakeDB()
+    store = PausedTasksStore(db=db, now_provider=_fixed_now)
+    with pytest.raises(PausedTasksStoreError, match="decision_target"):
+        store.list_pending_for_target("")
+
+
+# ---- dead_letter_payload() helper -----------------------------------------
+
+
+def test_dead_letter_payload_serializes_for_inbox_dump():
+    rows = [
+        PausedTaskRow(
+            task_ref="Agency_OS-stale-1",
+            callsign="orion",
+            decision_target="elliot",
+            question="should we ship?",
+            state_snapshot={"step": 3},
+            status="expired",
+            created_at=_fixed_now() - timedelta(days=8),
+            expires_at=_fixed_now() - timedelta(days=1),
+            expired_at=_fixed_now(),
+        )
+    ]
+    payload = dead_letter_payload(rows)
+    assert len(payload) == 1
+    assert payload[0]["task_ref"] == "Agency_OS-stale-1"
+    assert payload[0]["state_snapshot"] == {"step": 3}
+    # All timestamps serialized as ISO format strings
+    assert isinstance(payload[0]["created_at"], str)
+    assert isinstance(payload[0]["expired_at"], str)
+    assert "T" in payload[0]["created_at"]  # ISO format check
+
+
+def test_dead_letter_payload_handles_empty():
+    assert dead_letter_payload([]) == []
+
+
+def test_dead_letter_payload_handles_resumed_at_none():
+    """Expired rows never had resumed_at — should serialize cleanly."""
+    rows = [
+        PausedTaskRow(
+            task_ref="x",
+            callsign="orion",
+            decision_target="elliot",
+            question="q",
+            state_snapshot={},
+            status="expired",
+            created_at=_fixed_now(),
+            expires_at=_fixed_now() + timedelta(days=7),
+            expired_at=_fixed_now(),
+            resumed_at=None,
+        )
+    ]
+    payload = dead_letter_payload(rows)
+    # No KeyError on resumed_at; just absent from payload (not required)
+    assert "task_ref" in payload[0]


### PR DESCRIPTION
## Summary

A8 ephemeral foundation §7 piece 2 — `paused_tasks` Postgres table + migration + Python accessor. Per `docs/architecture/ephemeral_agent_system_scoping.md` §5 + §7 piece 2 (PR #1140 merged 2026-05-25). Engineer-tier follow-up filed in Scout's PR #1171 §6 recommendation #1 ("File the missing engineer-tier KEIs from §7").

**Filed under:** Agency_OS-70hb
**Stats:** 4 files, +875 LoC, **30 unit tests passing**, ruff/format/mypy clean, all 6 CI guards self-pass.

## Role in the durable-wait protocol (§5)

When an agent pauses pending a decision_response:

1. Agent emits `paused_pending_decision` event → dispatcher calls `PausedTasksStore.insert(task_ref, callsign, decision_target, question, state_snapshot)`
2. Agent terminates
3. `decision_response` arrives → dispatcher calls `PausedTasksStore.fetch(task_ref)` to retrieve state_snapshot
4. Dispatcher spawns resume agent + calls `mark_resumed(task_ref)`
5. Daily sweep calls `sweep_expired()` → dead-letters expired rows to Elliot inbox

## What lands

| File | Purpose | LoC |
|---|---|---:|
| `supabase/migrations/20260526_paused_tasks.sql` | Postgres schema with TTL + status enum + 3 indexes | 79 |
| `src/relay/paused_tasks_store.py` | `PausedTasksStore` + `PausedTaskRow` + `dead_letter_payload` helper | 319 |
| `tests/relay/test_paused_tasks_store.py` | 30 unit tests | 477 |
| `tests/relay/__init__.py` | (test discovery) | 0 |

## Schema decisions (per §5 + Postgres-best-practices)

- **task_ref as PRIMARY KEY** (not auto-UUID): task_ref is the natural unique identifier (bd ID / NATS subject / caller-chosen). Dispatcher's hot-path query is by-task_ref lookup. PK gives the index for free.
- **TTL via expires_at column** (not row-TTL extension): explicit timestamp + partial index on `WHERE status = 'active'` keeps sweep cheap and observable.
- **Status enum CHECK** (active/resumed/expired/aborted) — mirrors `VALID_STATUSES` frozenset in Python so drift is detectable.
- **3 indexes:** active-rows-by-expires_at (TTL sweep), (callsign, status) (per-agent query), (decision_target, status) (per-decider query).
- **JSONB for state_snapshot** — typically <1KB per §5, but JSONB lets the dispatcher carry arbitrary serializable interim state without schema changes.

## Accessor API

```python
store = PausedTasksStore(db=cursor)

# Write durable state when agent pauses
store.insert(
    task_ref="Agency_OS-orion-x42",
    callsign="orion",
    decision_target="elliot",
    question="Should we ship?",
    state_snapshot={"step": 3, "interim_file": "/tmp/work.json"},
    ttl_days=7,  # default
)

# Read on decision_response arrival
row = store.fetch("Agency_OS-orion-x42")
if row:
    # spawn resume agent with row.state_snapshot + decision
    store.mark_resumed(row.task_ref)

# Daily sweep
expired_rows = store.sweep_expired()
if expired_rows:
    dead_letter = dead_letter_payload(expired_rows)
    # caller writes to /tmp/telegram-relay-elliot/inbox/...

# Diagnostic queries
orion_active = store.list_by_callsign("orion")
elliot_pending = store.list_pending_for_target("elliot")
```

## Integration points (Nova/Scout PRs in flight)

- **Nova PR #1181** `envelope_schema.py` (MERGED) — decision_request / decision_response / paused_pending_decision envelope types are the inbox-side I/O; this store is the durable side
- **Nova PR #1184** `spawn_composer.py` resume-context branch — consumes state_snapshot from this store
- **Nova PR #1188** per-callsign dispatcher — calls `insert()` on paused_pending_decision + `fetch()` on decision_response + `mark_resumed()` after resume spawn
- **Future TTL sweep job** (separate KEI) — daily cron or Temporal workflow that invokes `sweep_expired()` + writes dead-letter JSON to Elliot inbox

## Test coverage (30 tests)

| Group | Coverage |
|---|---|
| Constants + enum locks | DEFAULT_TTL_DAYS == 7; VALID_STATUSES; status constants |
| PausedTaskRow invariants | empty task_ref + unknown status rejected |
| insert() | required-field validation + default 7-day TTL + custom ttl_days override + JSONB serialization + empty-snapshot |
| fetch() | None on absent + empty task_ref reject + row tuple → PausedTaskRow + tolerate JSONB-as-dict OR JSONB-as-string (psycopg variations) |
| mark_resumed / mark_aborted | SQL UPDATE shape + idempotency invariant (`WHERE status = 'active'`) |
| sweep_expired() | empty path + atomic UPDATE...RETURNING shape + multi-row return |
| list_by_callsign() | default-active + custom-status + invalid-status reject |
| list_pending_for_target() | status='active' filter + empty-target reject |
| dead_letter_payload() | ISO-format serialization + handles resumed_at=None |

## Test plan

- [x] `python3 -m pytest tests/relay/test_paused_tasks_store.py -q` → **30 passed in 0.14s**
- [x] `ruff check + ruff format --check` clean
- [x] `mypy --ignore-missing-imports` clean
- [x] All 5 BMV1 + cache-discipline + atom-store-discipline CI guards self-pass

## Boundary-matrix-v1 compliance

`src/relay/` is OUTSIDE `src/keiracom_system/` so BMV1 guards don't scope to this module. But the DI pattern (no asyncpg/psycopg import inside the module; `_DBProtocol` injectable) is guard-b-compatible by design — mirrors my PR #1173 cache + PR #1185 atomization pattern.

## Next steps (separate KEIs)

- Nova PR #1188 dispatcher wires this store into the decision_response routing path
- TTL sweep job (separate engineer-tier KEI) — invokes `sweep_expired()` + writes dead-letter JSON to Elliot inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)