### PR TITLE
[ORION] feat(ci): Composer-isolation CI guard — atomization hard constraint #1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,23 @@ jobs:
       - name: No raw atom-store SQL outside atomization module
         run: ./scripts/ci/check_no_raw_atom_store_outside_module.sh
 
+  # ============================================
+  # Guard: Composer-output isolation (atomization hard constraint)
+  # ============================================
+  # Source: ceo:atomization_architecture_v1 hard constraint #1 — "Composer
+  # output never reaches agent reasoning input." Preemptive guard; inert
+  # until PR #1189 lands Composer module. Mirrors the import-scope detection
+  # pattern from BMV1 guards + cache-discipline + atom-store-discipline.
+  composer-isolation-guards:
+    name: Composer Isolation Guards (Atomization Pilot)
+    runs-on: ubuntu-latest
+    needs: backend-lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: No Composer imports outside endpoints/
+        run: ./scripts/ci/check_composer_output_never_reaches_agent_reasoning.sh
+
   backend-typecheck:
     name: Backend Type Check (MyPy)
     runs-on: ubuntu-latest

--- a/scripts/ci/check_composer_output_never_reaches_agent_reasoning.sh
+++ b/scripts/ci/check_composer_output_never_reaches_agent_reasoning.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Composer-output-never-reaches-agent-reasoning CI guard.
+#
+# Enforces the load-bearing hard constraint from ceo:atomization_architecture_v1:
+#   "Composer output never reaches agent reasoning input"
+#
+# Composer (ceo:atomization_architecture_v1 component layer #4) renders atoms
+# into USER-FACING output (chat replies, emails, voice prompts). MalRetriever
+# (component layer #3) is the agent-reasoning input path. The architecture
+# requires these paths to be ENFORCEMENTLY SEPARATE — Composer's
+# ComposedOutput must NEVER end up inside an agent's prompt.
+#
+# WHY THE HARD CONSTRAINT EXISTS (per dispatch failure-mode mitigations):
+# "Composer non-determinism breaks multi-agent reasoning (HARD CONSTRAINT)".
+# Composer can be LLM-rendered prose; if it fed agent reasoning, the
+# non-determinism would propagate and break multi-agent reasoning chains.
+#
+# DETECTION PATTERN (import-scope):
+# Composer + ComposedOutput + compose_chat_reply may ONLY be imported by:
+#   1. src/keiracom_system/atomization/composer.py itself
+#   2. src/keiracom_system/atomization/__init__.py (re-export)
+#   3. src/keiracom_system/endpoints/ (future Endpoint Translator + Dave-
+#      facing endpoint switchover — Week 2-3 dispatch per design doc §1)
+#   4. Test directories
+#
+# Anything else importing Composer is ipso facto routing user-facing output
+# into a non-endpoint code path — almost certainly into agent reasoning.
+#
+# COMPLEMENTS:
+# - The Composer's own type-level enforcement (ComposedOutput.text is str —
+#   PR #1189 test_composer_output_is_user_facing_string_only). That covers
+#   intra-module discipline; this guard covers cross-module discipline.
+# - Boundary-matrix-v1 guards (PR #1169) — same enforcement-via-import-scope
+#   pattern; lives in the same family.
+# - A7 cache-discipline (PR #1173 CB-10) — same pattern.
+# - Atom-store-discipline (PR #1185 Week 1) — same pattern.
+
+set -euo pipefail
+
+SCOPE="src/keiracom_system"
+
+if [ ! -d "$SCOPE" ]; then
+  echo "OK (composer-isolation): $SCOPE not present — guard inactive."
+  exit 0
+fi
+
+# The Composer module may not be in main yet (PR #1189 Week 2 still in
+# review). The guard is preemptive — inert until the file lands.
+if [ ! -f "$SCOPE/atomization/composer.py" ]; then
+  echo "OK (composer-isolation): Composer not yet in tree — guard inert until PR #1189 lands."
+  exit 0
+fi
+
+# Pattern: any import that pulls Composer / ComposedOutput / compose_chat_reply
+# from the atomization composer module. We match both 'from ... composer import'
+# and 'from src.keiracom_system.atomization import Composer' forms.
+PATTERN='^[[:space:]]*(from[[:space:]]+src\.keiracom_system\.atomization\.composer[[:space:]]+import|from[[:space:]]+src\.keiracom_system\.atomization[[:space:]]+import[[:space:]]+(Composer|ComposedOutput|compose_chat_reply|select_provenance_trail))'
+
+raw=$(grep -rnE --include='*.py' "$PATTERN" "$SCOPE" 2>/dev/null || true)
+
+# Exempt paths:
+#  - composer.py itself (self-reference impossible but defensive)
+#  - __init__.py re-export
+#  - endpoints/ directory (where the legitimate consumers live)
+hits=$(printf '%s\n' "$raw" \
+  | grep -v -E '^src/keiracom_system/atomization/composer.py' \
+  | grep -v -E '^src/keiracom_system/atomization/__init__.py' \
+  | grep -v -E '^src/keiracom_system/endpoints/' \
+  | grep -v -E '^[[:space:]]*$' || true)
+
+if [ -n "$hits" ]; then
+  echo "FAIL (composer-isolation): Composer / ComposedOutput / compose_chat_reply"
+  echo "imported outside src/keiracom_system/endpoints/. This violates the"
+  echo "ceo:atomization_architecture_v1 hard constraint:"
+  echo ""
+  echo "  \"Composer output never reaches agent reasoning input\""
+  echo ""
+  echo "If you need atoms for AGENT reasoning, use MalRetriever directly —"
+  echo "it's component layer #3, the canonical agent-reasoning-input path."
+  echo "Composer is component layer #4, endpoint-rendering only."
+  echo ""
+  echo "If this is a new endpoint module, move it under"
+  echo "src/keiracom_system/endpoints/ (the canonical home for the Endpoint"
+  echo "Translator + Dave-facing endpoint switchover work — Week 2-3 dispatch)."
+  echo ""
+  echo "Offending lines:"
+  echo "$hits"
+  exit 1
+fi
+
+echo "OK (composer-isolation): no Composer imports outside endpoints/."
+exit 0

--- a/tests/scripts/ci/test_composer_isolation_guard.py
+++ b/tests/scripts/ci/test_composer_isolation_guard.py
@@ -1,0 +1,153 @@
+"""Integration test for the Composer-isolation CI guard.
+
+Verifies the negative-path probe fires correctly + the positive-path
+(no Composer in tree) returns the inert message. Mirrors the pattern from
+tests/keiracom_system/cache/test_no_raw_valkey_outside_client.py (PR #1173)
+and tests/keiracom_system/atomization/test_atom_store_ci_guard.py
+(PR #1185).
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GUARD = REPO_ROOT / "scripts" / "ci" / "check_composer_output_never_reaches_agent_reasoning.sh"
+
+
+def _run_guard(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_guard_inert_when_composer_not_present(tmp_path: Path):
+    """No src/keiracom_system/ directory → guard exits 0 with 'inactive' message.
+
+    This is the current state of main (PR #1189 not yet merged), so the
+    real-tree run also hits this path.
+    """
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_composer_output_never_reaches_agent_reasoning.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode == 0
+    assert "guard inactive" in result.stdout
+
+
+def test_guard_inert_when_composer_file_missing(tmp_path: Path):
+    """src/keiracom_system/ exists but no composer.py → guard inert."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    (tmp_path / "src" / "keiracom_system" / "atomization").mkdir(parents=True)
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_composer_output_never_reaches_agent_reasoning.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode == 0
+    assert "guard inert" in result.stdout
+
+
+def test_guard_passes_on_clean_tree_with_composer(tmp_path: Path):
+    """Composer present, no offenders → guard exits 0 with clean message."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    atom_dir = tmp_path / "src" / "keiracom_system" / "atomization"
+    atom_dir.mkdir(parents=True)
+    (atom_dir / "composer.py").write_text("# stub")
+    (atom_dir / "__init__.py").write_text(
+        "from src.keiracom_system.atomization.composer import Composer"
+    )
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_composer_output_never_reaches_agent_reasoning.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode == 0
+    assert "no Composer imports outside endpoints/" in result.stdout
+
+
+def test_guard_fails_on_composer_import_in_agent_reasoning_module(tmp_path: Path):
+    """Synthetic offender: importing Composer outside endpoints/ MUST fail."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    atom_dir = tmp_path / "src" / "keiracom_system" / "atomization"
+    atom_dir.mkdir(parents=True)
+    (atom_dir / "composer.py").write_text("# stub")
+    leaky_dir = tmp_path / "src" / "keiracom_system" / "agent_reasoning"
+    leaky_dir.mkdir(parents=True)
+    (leaky_dir / "leaky.py").write_text(
+        "from src.keiracom_system.atomization.composer import Composer\n"
+    )
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_composer_output_never_reaches_agent_reasoning.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode != 0
+    assert "FAIL (composer-isolation)" in result.stdout
+    assert "agent_reasoning/leaky.py" in result.stdout
+
+
+def test_guard_fails_on_composed_output_import(tmp_path: Path):
+    """Importing ComposedOutput (the type) outside endpoints/ MUST also fail."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    atom_dir = tmp_path / "src" / "keiracom_system" / "atomization"
+    atom_dir.mkdir(parents=True)
+    (atom_dir / "composer.py").write_text("# stub")
+    leaky_dir = tmp_path / "src" / "keiracom_system" / "rogue_module"
+    leaky_dir.mkdir(parents=True)
+    (leaky_dir / "rogue.py").write_text(
+        "from src.keiracom_system.atomization import ComposedOutput\n"
+    )
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_composer_output_never_reaches_agent_reasoning.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode != 0
+
+
+def test_guard_exempts_endpoints_directory(tmp_path: Path):
+    """src/keiracom_system/endpoints/ is the canonical home — importers exempt."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    atom_dir = tmp_path / "src" / "keiracom_system" / "atomization"
+    atom_dir.mkdir(parents=True)
+    (atom_dir / "composer.py").write_text("# stub")
+    endpoints_dir = tmp_path / "src" / "keiracom_system" / "endpoints"
+    endpoints_dir.mkdir(parents=True)
+    (endpoints_dir / "chat_reply.py").write_text(
+        "from src.keiracom_system.atomization.composer import Composer\n"
+    )
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_composer_output_never_reaches_agent_reasoning.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode == 0, (
+        f"guard should exempt endpoints/; got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_guard_exempts_init_module(tmp_path: Path):
+    """__init__.py re-export of Composer is the canonical surface."""
+    if not GUARD.exists():
+        pytest.skip("guard script not present")
+    atom_dir = tmp_path / "src" / "keiracom_system" / "atomization"
+    atom_dir.mkdir(parents=True)
+    (atom_dir / "composer.py").write_text("# stub")
+    (atom_dir / "__init__.py").write_text(
+        "from src.keiracom_system.atomization.composer import Composer, ComposedOutput\n"
+    )
+    scripts_dir = tmp_path / "scripts" / "ci"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(GUARD, scripts_dir / "check_composer_output_never_reaches_agent_reasoning.sh")
+    result = _run_guard(tmp_path)
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

Preemptive CI guard enforcing `ceo:atomization_architecture_v1` hard constraint #1:

> "Composer output never reaches agent reasoning input"

Composer (component layer #4) renders atoms into **user-facing output**. MalRetriever (component layer #3) is the **agent-reasoning input path**. The architecture requires these paths to be enforcementally separate.

**Filed under:** Agency_OS-atomization-composer-isolation
**Stats:** 4 files, +262 LoC, **7 unit tests passing**, all 6 CI guards self-pass.

## Why this guard

**Without enforcement**, a future PR could:
- `from src.keiracom_system.atomization.composer import ComposedOutput`
- Pass `output.text` into an LLM `messages=[...]` call
- Break multi-agent reasoning chains via composer's non-determinism

The hard constraint exists per dispatch failure-mode mitigation: "Composer non-determinism breaks multi-agent reasoning (HARD CONSTRAINT)". This guard is the cross-module defence-in-depth complement to the type-level enforcement (`ComposedOutput.text: str`) that's locked in PR #1189 via `test_composer_output_is_user_facing_string_only`.

## Detection pattern (mirrors existing 5 guards)

Import-scope detection — same approach as BMV1 guards (PR #1169) + cache-discipline (PR #1173 CB-10) + atom-store-discipline (PR #1185):

```bash
PATTERN='^[[:space:]]*(from[[:space:]]+src\.keiracom_system\.atomization\.composer[[:space:]]+import|from[[:space:]]+src\.keiracom_system\.atomization[[:space:]]+import[[:space:]]+(Composer|ComposedOutput|compose_chat_reply|select_provenance_trail))'
```

**Exempt paths:**
- `src/keiracom_system/atomization/composer.py` (the module itself)
- `src/keiracom_system/atomization/__init__.py` (re-export)
- `src/keiracom_system/endpoints/` (Week 2-3 Endpoint Translator destination per design §1)
- Tests directory

## Preemptive — inert until PR #1189 lands

Composer module not in main yet (PR #1189 Week 2 still in review). Guard self-passes with:

```
OK (composer-isolation): Composer not yet in tree — guard inert until PR #1189 lands.
```

Activates automatically when `composer.py` appears in `src/keiracom_system/atomization/`. Same defensive shape as the existing 5 CI guards (which already use `if [ ! -d "$SCOPE" ]; then echo "guard inactive"; fi` patterns).

## What this lands

| File | Purpose | LoC |
|---|---|---:|
| `scripts/ci/check_composer_output_never_reaches_agent_reasoning.sh` | CI guard script | 92 |
| `.github/workflows/ci.yml` | New `composer-isolation-guards` job (needs: backend-lint) | +17 |
| `tests/scripts/ci/test_composer_isolation_guard.py` | 7 unit tests | 153 |
| `tests/scripts/__init__.py` + `tests/scripts/ci/__init__.py` | (test discovery) | 0 |

## Test coverage (7 tests)

| Test | Path |
|---|---|
| `test_guard_inert_when_composer_not_present` | No `src/keiracom_system/` → "guard inactive" |
| `test_guard_inert_when_composer_file_missing` | Dir exists, no composer.py → "guard inert" |
| `test_guard_passes_on_clean_tree_with_composer` | Composer present + no offenders → clean pass |
| `test_guard_fails_on_composer_import_in_agent_reasoning_module` | Synthetic offender at `agent_reasoning/leaky.py` → FAIL |
| `test_guard_fails_on_composed_output_import` | Importing `ComposedOutput` (the type) → FAIL |
| `test_guard_exempts_endpoints_directory` | `endpoints/` import → exempt |
| `test_guard_exempts_init_module` | `__init__.py` re-export → exempt |

## Verification

- [x] `python3 -m pytest tests/scripts/ci/test_composer_isolation_guard.py -q` → **7 passed in 0.17s**
- [x] `ruff check + ruff format --check` clean on test file
- [x] Real-tree guard run: inert message (Composer not yet in main)
- [x] All 6 OTHER CI guards (4 BMV1 + cache-discipline + atom-store-discipline) still self-pass
- [x] Synthetic offender probe: `agent_reasoning/leaky.py` importing Composer → FAIL with verbatim guidance pointing to MalRetriever as the correct agent-reasoning path

## Defence-in-depth layer summary

| Layer | What it enforces | Where |
|---|---|---|
| Type level | `ComposedOutput.text: str` (not consumable as agent context) | PR #1189 `test_composer_output_is_user_facing_string_only` |
| Architectural | Component layer #3 vs #4 separation | `ceo:atomization_architecture_v1` |
| **CI gate (NEW)** | **Import scope: Composer only imported by endpoints/** | **THIS PR** |
| Documentation | The hard constraint is named in design docs | PR #1178 proposal + PR #1185 commit message + PR #1189 commit message |

## Next steps

- **Once PR #1189 lands** (Week 2 substrate including Composer module), this guard automatically activates on every CI run + catches future violations at PR review time
- Future Endpoint Translator work (Week 2-3 dispatch) builds under `src/keiracom_system/endpoints/` and gets guard-exempted automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)