### PR TITLE
[NOVA] fix(fleet_supervisor): release_already_reviewed_claims sweeper (Agency_OS-tp15)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -2,4 +2,4 @@
 {"id":"int-aed03aae","kind":"field_change","created_at":"2026-05-18T20:45:34.175593321Z","actor":"Elliot","issue_id":"Agency_OS-mwwmq0","extra":{"field":"assignee","new_value":"nova","old_value":"elliotbot"}}
 {"id":"int-6e936bc3","kind":"field_change","created_at":"2026-05-18T21:28:35.153208282Z","actor":"Elliot","issue_id":"Agency_OS-y244","extra":{"field":"assignee","new_value":"nova","old_value":""}}
 {"id":"int-264d5788","kind":"field_change","created_at":"2026-05-18T22:06:58.060339376Z","actor":"Elliot","issue_id":"Agency_OS-y52ohx","extra":{"field":"assignee","new_value":"nova","old_value":""}}
-{"id":"int-63d5a67d","kind":"field_change","created_at":"2026-05-26T13:38:26.412204901Z","actor":"Elliot","issue_id":"Agency_OS-tjni","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-e913711a","kind":"field_change","created_at":"2026-05-26T14:55:18.207779675Z","actor":"Elliot","issue_id":"Agency_OS-tp15","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -703,6 +703,71 @@ def release_merged_review_claims(conn: psycopg.Connection) -> int:
     return released
 
 
+def release_already_reviewed_claims(conn: psycopg.Connection) -> int:
+    """Release REVIEW-PR-<N> claims where the reviewer already posted [REVIEW:...].
+
+    Sibling to release_merged_review_claims: that one fires on PR state=MERGED/
+    CLOSED; this one fires on the empirical "reviewer already did the work"
+    signal — a [REVIEW:...:<callsign>] marker in PR comments. Both target the
+    same failure mode (active claim row persists → supervisor re-fires the
+    same brief every cycle), but for different lifecycle endpoints.
+
+    Anchored on this session 2026-05-26: ~10 REVIEW-PR-1179 re-trigger nudges
+    fired AFTER [REVIEW:approve:nova] posted at 12:48Z because the PR
+    remained OPEN (CI infra block) so release_merged_review_claims couldn't
+    fire, but no other path existed to release the claim.
+
+    Returns the count released. Fail-open: a gh failure on one PR is logged
+    and skipped, never aborts the sweep.
+
+    Released to status='dismissed' (same reasoning as the merged-release path —
+    no task_verifications row exists for a review claim).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, claimed_by FROM public.tasks "
+            "WHERE status = 'active' AND id LIKE 'REVIEW-PR-%' AND claimed_by IS NOT NULL"
+        )
+        rows = cur.fetchall()
+    released = 0
+    for task_id, callsign in rows:
+        m = re.match(r"REVIEW-PR-(\d+)$", task_id)
+        if not m:
+            continue
+        pr_number = int(m.group(1))
+        try:
+            comments = fetch_pr_comments(pr_number)
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            log.warning("release_already_reviewed: fetch_pr_comments %d: %s", pr_number, exc)
+            continue
+        if not _callsign_review_marker_in_comments(comments, callsign):
+            continue
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE public.tasks SET status = 'dismissed' WHERE id = %s AND status = 'active'",
+                (task_id,),
+            )
+            released += cur.rowcount
+        log.info(
+            "released review claim %s — %s already posted [REVIEW:...] on PR #%d",
+            task_id,
+            callsign,
+            pr_number,
+        )
+    if released:
+        conn.commit()
+    return released
+
+
+def _callsign_review_marker_in_comments(comments: list[dict], callsign: str) -> bool:
+    """True if any comment body carries a [REVIEW:...:<callsign>] marker."""
+    for comment in comments:
+        body = comment.get("body") or ""
+        if comment_has_review_marker(body, callsign):
+            return True
+    return False
+
+
 def get_last_tool_call(conn: psycopg.Connection, callsign: str) -> _dt.datetime | None:
     with conn.cursor() as cur:
         cur.execute(
@@ -1329,6 +1394,16 @@ def main() -> None:
         released_reviews = release_merged_review_claims(conn)
         if released_reviews:
             log.info("Released %d merged/closed review claim(s)", released_reviews)
+
+        # Release review claims where the reviewer already posted [REVIEW:...]
+        # but the PR is still OPEN (e.g. blocked on infra, awaiting other
+        # deliberators). Without this sweep, supervisor re-fires the same
+        # REVIEW-PR-N brief every cycle until the PR finally merges.
+        # Agency_OS-tp15; sibling to Agency_OS-f0qn (PR #1199 dispatch-time
+        # race pre-check).
+        released_reviewed = release_already_reviewed_claims(conn)
+        if released_reviewed:
+            log.info("Released %d already-reviewed review claim(s)", released_reviewed)
 
         phase_max = get_phase_max(conn)
         prs = list_open_prs()

--- a/tests/test_fleet_supervisor_release_reviewed.py
+++ b/tests/test_fleet_supervisor_release_reviewed.py
@@ -1,0 +1,175 @@
+"""Tests for fleet_supervisor.release_already_reviewed_claims.
+
+Sibling to test_fleet_supervisor_auto_claim_race.py. That one tests the
+dispatch-TIME race pre-check; this one tests the post-review claim sweeper
+that fires every supervisor cycle.
+
+bd: Agency_OS-tp15 (follow-up to Agency_OS-f0qn / PR #1199).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock
+
+from scripts import fleet_supervisor
+
+# ─── _callsign_review_marker_in_comments ───────────────────────────────────────
+
+
+def test_marker_helper_returns_true_when_marker_present():
+    comments = [
+        {"body": "thumbs up"},
+        {"body": "[NOVA] **[REVIEW:approve:nova]** — looks good."},
+    ]
+    assert fleet_supervisor._callsign_review_marker_in_comments(comments, "nova") is True
+
+
+def test_marker_helper_returns_true_for_hold_marker():
+    comments = [{"body": "[REVIEW:HOLD:nova] one NIT"}]
+    assert fleet_supervisor._callsign_review_marker_in_comments(comments, "nova") is True
+
+
+def test_marker_helper_returns_false_when_callsign_absent():
+    comments = [{"body": "[REVIEW:approve:atlas]"}, {"body": "other text"}]
+    assert fleet_supervisor._callsign_review_marker_in_comments(comments, "nova") is False
+
+
+def test_marker_helper_returns_false_on_empty_comments():
+    assert fleet_supervisor._callsign_review_marker_in_comments([], "nova") is False
+
+
+def test_marker_helper_handles_missing_body_field():
+    comments = [{}, {"body": None}]
+    assert fleet_supervisor._callsign_review_marker_in_comments(comments, "nova") is False
+
+
+# ─── release_already_reviewed_claims ───────────────────────────────────────────
+
+
+def _fake_conn_with_review_claims(rows: list[tuple[str, str]]) -> Any:
+    """Return a MagicMock psycopg connection scripting the SELECT result."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    cursor.fetchall.return_value = rows
+    cursor.rowcount = 1  # each UPDATE pretends to affect 1 row
+    return conn, cursor
+
+
+def test_release_skips_when_no_active_review_claims(monkeypatch):
+    conn, cursor = _fake_conn_with_review_claims(rows=[])
+    fetch_calls: list[int] = []
+    monkeypatch.setattr(
+        fleet_supervisor,
+        "fetch_pr_comments",
+        lambda n: fetch_calls.append(n) or [],
+    )
+    released = fleet_supervisor.release_already_reviewed_claims(conn)
+    assert released == 0
+    assert fetch_calls == []  # never reached fetch path
+    conn.commit.assert_not_called()
+
+
+def test_release_clears_claim_when_marker_present(monkeypatch):
+    conn, cursor = _fake_conn_with_review_claims(
+        rows=[("REVIEW-PR-1179", "nova")],
+    )
+    monkeypatch.setattr(
+        fleet_supervisor,
+        "fetch_pr_comments",
+        lambda n: [{"body": "[REVIEW:approve:nova] — done."}],
+    )
+    released = fleet_supervisor.release_already_reviewed_claims(conn)
+    assert released == 1
+    # UPDATE was issued
+    update_calls = [c for c in cursor.execute.call_args_list if "UPDATE public.tasks" in c.args[0]]
+    assert len(update_calls) == 1
+    assert update_calls[0].args[1] == ("REVIEW-PR-1179",)
+    conn.commit.assert_called_once()
+
+
+def test_release_skips_claim_when_no_marker(monkeypatch):
+    conn, cursor = _fake_conn_with_review_claims(
+        rows=[("REVIEW-PR-1200", "nova")],
+    )
+    monkeypatch.setattr(
+        fleet_supervisor,
+        "fetch_pr_comments",
+        lambda n: [{"body": "[REVIEW:approve:atlas]"}],  # different callsign
+    )
+    released = fleet_supervisor.release_already_reviewed_claims(conn)
+    assert released == 0
+    update_calls = [c for c in cursor.execute.call_args_list if "UPDATE public.tasks" in c.args[0]]
+    assert update_calls == []
+    conn.commit.assert_not_called()
+
+
+def test_release_handles_multiple_claims_independently(monkeypatch):
+    conn, cursor = _fake_conn_with_review_claims(
+        rows=[
+            ("REVIEW-PR-1100", "nova"),  # marker present → release
+            ("REVIEW-PR-1101", "nova"),  # no marker → skip
+            ("REVIEW-PR-1102", "atlas"),  # marker present → release
+        ],
+    )
+
+    def _comments(pr_number: int) -> list[dict]:
+        return {
+            1100: [{"body": "[REVIEW:approve:nova]"}],
+            1101: [{"body": "no review marker here"}],
+            1102: [{"body": "[REVIEW:HOLD:atlas]"}],
+        }[pr_number]
+
+    monkeypatch.setattr(fleet_supervisor, "fetch_pr_comments", _comments)
+    released = fleet_supervisor.release_already_reviewed_claims(conn)
+    assert released == 2
+    update_calls = [c for c in cursor.execute.call_args_list if "UPDATE public.tasks" in c.args[0]]
+    update_targets = sorted(c.args[1][0] for c in update_calls)
+    assert update_targets == ["REVIEW-PR-1100", "REVIEW-PR-1102"]
+
+
+def test_release_skips_malformed_task_id(monkeypatch):
+    """Defensive: a non-conforming REVIEW-PR-... id should be skipped, not raise."""
+    conn, cursor = _fake_conn_with_review_claims(
+        rows=[("REVIEW-PR-not-a-number", "nova")],
+    )
+    monkeypatch.setattr(fleet_supervisor, "fetch_pr_comments", lambda n: [])
+    released = fleet_supervisor.release_already_reviewed_claims(conn)
+    assert released == 0
+
+
+def test_release_fails_open_on_gh_timeout(monkeypatch):
+    """gh subprocess timeout → log + skip + continue with next claim."""
+    conn, cursor = _fake_conn_with_review_claims(
+        rows=[
+            ("REVIEW-PR-9001", "nova"),  # will timeout
+            ("REVIEW-PR-9002", "nova"),  # second one succeeds
+        ],
+    )
+
+    def _comments(pr_number: int) -> list[dict]:
+        if pr_number == 9001:
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=15)
+        return [{"body": "[REVIEW:approve:nova]"}]
+
+    monkeypatch.setattr(fleet_supervisor, "fetch_pr_comments", _comments)
+    released = fleet_supervisor.release_already_reviewed_claims(conn)
+    # 9001 skipped on timeout; 9002 released cleanly
+    assert released == 1
+
+
+def test_release_does_not_call_commit_when_zero_released(monkeypatch):
+    """commit() costs network/disk — only fire when we actually changed rows."""
+    conn, cursor = _fake_conn_with_review_claims(
+        rows=[("REVIEW-PR-1234", "nova")],
+    )
+    monkeypatch.setattr(
+        fleet_supervisor,
+        "fetch_pr_comments",
+        lambda n: [{"body": "no marker"}],
+    )
+    fleet_supervisor.release_already_reviewed_claims(conn)
+    conn.commit.assert_not_called()


### PR DESCRIPTION
## Summary

Phase 2 ops sibling to **PR #1199** (Agency_OS-f0qn). That fix is at **dispatch TIME** (pre-check before claiming); this fix is at **sweep TIME** (release stale claims every supervisor cycle).

**Anchored empirically in this session:** ~10 `REVIEW-PR-1179` re-trigger nudges fired AFTER `[REVIEW:approve:nova]` posted at 12:48Z. The PR remained OPEN (CI infra block from the GitHub bot suspension), so `release_merged_review_claims()` couldn't fire (only releases on MERGED/CLOSED). No other path existed to release the claim → supervisor re-emitted the same brief every cycle until merge. This PR adds the missing path.

**Filed under:** Agency_OS-tp15 (P2).

## Fix shape

### `scripts/fleet_supervisor.py`

New function next to `release_merged_review_claims`:
```python
def release_already_reviewed_claims(conn) -> int:
    # SELECT id, claimed_by FROM tasks WHERE status='active' AND id LIKE 'REVIEW-PR-%'
    # For each: fetch_pr_comments(N) → if [REVIEW:...:<callsign>] present
    #   UPDATE status='dismissed'
    # Fail-open on gh failures.
```

Thin helper extracted for testability:
```python
def _callsign_review_marker_in_comments(comments, callsign) -> bool:
    """True if any comment body carries a [REVIEW:...:<callsign>] marker."""
```

Wired into the supervisor main loop next to `release_merged_review_claims` with an inline comment cross-linking to PR #1199.

### `tests/test_fleet_supervisor_release_reviewed.py` — 12 tests

- 5 tests for `_callsign_review_marker_in_comments`: marker present, HOLD form, callsign absent, empty comments, missing body field
- 7 tests for `release_already_reviewed_claims`: no claims, marker present releases, no marker skips, multiple claims handled independently, malformed task_id skip, gh timeout fail-open, `commit()` not called when zero released

## Scope discipline

- **Only adds the new release path.** No changes to existing `release_merged_review_claims` or `comment_has_review_marker`.
- **Reuses existing helpers** (`fetch_pr_comments` + `comment_has_review_marker`) — no duplication.
- **Fail-open on gh failures** (matches existing fleet-supervisor pattern).
- `status='dismissed'` transition (same as merged-release path per existing helper's docstring reasoning).

## Independence from PR #1199

This PR is branched off `origin/main` directly. PR #1199 (dispatch-time race pre-check) and this PR (sweep-time release) are **complementary but can merge in any order** — they touch different functions + add different rows to the supervisor main loop.

| | PR #1199 | This PR |
|---|---|---|
| **When fires** | Dispatch time | Every supervisor cycle |
| **Prevents** | Claiming a PR that's already merged | Re-firing brief for a PR you already reviewed |
| **Function** | `fetch_pr_state()` + pre-check in `_handle_idle_no_queue` | `release_already_reviewed_claims()` sweep |

Together they close both ends of the race-claim lifecycle: don't create a stale claim in the first place (#1199), and clear stale claims that already exist (this PR).

## Verification (local)

```
$ python3 -m pytest tests/test_fleet_supervisor_release_reviewed.py -q
............                                                             [100%]
12 passed in 0.12s

$ python3 -m pytest tests/ -k fleet_supervisor -q
116 passed, 1 skipped, 6379 deselected in 10.85s
# (was 104 before this PR's new test file; +12 from these tests; no regression)

$ python3 -m ruff check scripts/fleet_supervisor.py tests/test_fleet_supervisor_release_reviewed.py
All checks passed!

$ python3 -m ruff format --check scripts/fleet_supervisor.py tests/test_fleet_supervisor_release_reviewed.py
2 files already formatted
```

All 5 boundary-matrix-v1 + cache-discipline guards self-pass.

## Cost analysis

One extra `gh pr view N --json comments` call per active `REVIEW-PR-N` claim per supervisor cycle. Bounded by in-flight review count (typically <10). ~200ms per call. Trivial vs supervisor re-firing the same brief indefinitely.

bd: Agency_OS-tp15. Closes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)