### PR TITLE
[ORION] fix(keepalive): bounded-spawn discipline default + --preserve-context override (Dave 2026-05-27)

### DIFF
--- a/scripts/agent_keepalive.sh
+++ b/scripts/agent_keepalive.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # agent_keepalive.sh — ExecStart wrapper for *-agent.service units (KEI-94 + KEI-140).
 #
+# BOUNDED-SPAWN DISCIPLINE — every keepalive respawn starts from zero by
+# default; no Claude conversation-context carryover. Dave directive 2026-05-27
+# governance fix: keepalive had autonomous restart authority + agents
+# respawned with accumulated context, violating the bounded-spawn principle.
+# State carryover now requires explicit --preserve-context <justification>
+# override + logged event to /tmp/keepalive_override_log.jsonl.
+#
 # Type=simple + Restart=always keep-alive for agent claude sessions. Each unit
 # blocks on this script until the tmux session terminates; systemd then
 # restarts the unit, respawning the session.
@@ -25,7 +32,12 @@
 #   so the pane recovers.
 #
 # Usage:
-#     agent_keepalive.sh <tmux_session> <callsign> <worktree>
+#     agent_keepalive.sh <tmux_session> <callsign> <worktree> [--preserve-context "<justification>"]
+#
+# Default (per Dave 2026-05-27): claude respawns FRESH on every restart.
+# Override: --preserve-context "<reason>" → uses `claude --continue` to
+# resume prior conversation; emits one JSONL event per spawn to
+# /tmp/keepalive_override_log.jsonl with timestamp + callsign + justification.
 #
 # Example unit ExecStart:
 #     ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/agent_keepalive.sh atlas atlas /home/elliotbot/clawd/Agency_OS-atlas
@@ -33,13 +45,39 @@
 # Env (optional):
 #     KEEPALIVE_POLL_SECONDS — sleep between has-session checks (default 10)
 #     KEEPALIVE_DRY         — print the resolved tmux/send-keys plan and exit 0
+#     KEEPALIVE_OVERRIDE_LOG — override JSONL log path (default /tmp/keepalive_override_log.jsonl)
 
 set -euo pipefail
 
-session="${1:?usage: agent_keepalive.sh <tmux_session> <callsign> <worktree>}"
+session="${1:?usage: agent_keepalive.sh <tmux_session> <callsign> <worktree> [--preserve-context <justification>]}"
 callsign="${2:?missing callsign}"
 worktree="${3:?missing worktree}"
 poll_seconds="${KEEPALIVE_POLL_SECONDS:-10}"
+override_log="${KEEPALIVE_OVERRIDE_LOG:-/tmp/keepalive_override_log.jsonl}"
+
+# Dave 2026-05-27 bounded-spawn discipline — fresh context by default.
+# --preserve-context "<justification>" opts INTO state carryover (claude
+# --continue). Justification is required + non-empty + persisted to JSONL.
+preserve_context=""
+preserve_justification=""
+shift 3 || true
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --preserve-context)
+            preserve_context="1"
+            preserve_justification="${2:-}"
+            if [[ -z "$preserve_justification" ]]; then
+                echo "[keepalive] --preserve-context requires a non-empty justification string" >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        *)
+            echo "[keepalive] unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
 
 if [[ ! -d "$worktree" ]]; then
     echo "[keepalive] worktree missing: $worktree" >&2
@@ -51,6 +89,33 @@ if ! command -v tmux >/dev/null 2>&1; then
     exit 2
 fi
 
+# Dave 2026-05-27 bounded-spawn — fresh context default ─────────────────────
+# Default claude invocation: NO --continue, NO --resume. Every respawn = a
+# new bounded task with zero conversation-context carryover from the prior
+# session. Each respawn re-reads CLAUDE.md + IDENTITY.md + session-start
+# hooks fresh — the only state that survives is on-disk (git, filesystem,
+# ceo_memory). This is the canonical bounded-spawn invariant.
+#
+# --preserve-context override: caller explicitly opts INTO state carryover
+# (claude --continue resumes the last session UUID). One JSONL event written
+# to $override_log per spawn cycle, carrying the justification + ts + callsign
+# so reviewers can audit when context carried forward + why.
+if [[ -n "$preserve_context" ]]; then
+    # Log the override BEFORE spawning so a crashed spawn still leaves a
+    # trail. Append-only JSONL — one event per spawn.
+    mkdir -p "$(dirname "$override_log")" 2>/dev/null || true
+    override_event=$(printf '{"ts":"%s","callsign":"%s","session":"%s","worktree":"%s","justification":%s}' \
+        "$(date -u +%FT%TZ)" "$callsign" "$session" "$worktree" \
+        "$(printf '%s' "$preserve_justification" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+    # Trailing newline appended via printf '%s\n' so $() command substitution
+    # doesn't strip it — each event lands on its own JSONL line.
+    printf '%s\n' "$override_event" >> "$override_log" 2>/dev/null || true
+    echo "[keepalive] --preserve-context override active; justification logged to $override_log" >&2
+    claude_invocation="claude --continue --dangerously-skip-permissions"
+else
+    claude_invocation="claude --dangerously-skip-permissions"
+fi
+
 # KEI-94 — in-pane respawn loop. The pane process is a `while true` shell;
 # claude runs as its child. When claude exits (clean shutdown, /clear path,
 # OOM, crash) the shell loops back, sleeps a moment to avoid a busy spawn
@@ -58,7 +123,7 @@ fi
 # pane. The tmux session survives Claude exits — no full unit restart
 # needed. systemd's Restart=always remains the outer safety net for cases
 # where the wrapper itself dies.
-claude_cmd="export CALLSIGN='$callsign' && cd '$worktree' && while true; do claude --dangerously-skip-permissions; echo \"[keepalive] claude exited at \$(date -u +%FT%TZ), respawning in 2s\" >&2; sleep 2; done"
+claude_cmd="export CALLSIGN='$callsign' && cd '$worktree' && while true; do $claude_invocation; echo \"[keepalive] claude exited at \$(date -u +%FT%TZ), respawning in 2s\" >&2; sleep 2; done"
 
 if [[ -n "${KEEPALIVE_DRY:-}" ]]; then
     echo "[keepalive] would: tmux new-session -d -s '$session' -c '$worktree'"

--- a/tests/scripts/test_agent_keepalive_bounded_spawn.py
+++ b/tests/scripts/test_agent_keepalive_bounded_spawn.py
@@ -64,22 +64,26 @@ def test_preserve_context_uses_claude_continue(tmp_path: Path):
 
 
 def test_preserve_context_writes_jsonl_event(tmp_path: Path):
+    """The worktree path must exist (script exits 2 on missing dir before
+    reaching parse logic) — use tmp_path for CI portability."""
     log_path = tmp_path / "override.jsonl"
+    worktree = tmp_path / "fake_worktree"
+    worktree.mkdir()
     result = _run_keepalive(
         "atlas",
         "atlas",
-        "/home/elliotbot/clawd/Agency_OS-atlas",
+        str(worktree),
         "--preserve-context",
         "stuck review session needs context to resume",
         override_log=log_path,
     )
-    assert result.returncode == 0
+    assert result.returncode == 0, f"unexpected exit={result.returncode}\nstderr: {result.stderr}"
     assert log_path.exists()
     content = log_path.read_text(encoding="utf-8").strip()
     event = json.loads(content)
     assert event["callsign"] == "atlas"
     assert event["session"] == "atlas"
-    assert event["worktree"] == "/home/elliotbot/clawd/Agency_OS-atlas"
+    assert event["worktree"] == str(worktree)
     assert event["justification"] == "stuck review session needs context to resume"
     assert "ts" in event
     # ISO 8601 with Z suffix
@@ -153,11 +157,15 @@ def test_unknown_argument_fails():
 # ---- Backwards compatibility — existing systemd-unit invocations ----------
 
 
-def test_existing_three_arg_invocation_unchanged():
+def test_existing_three_arg_invocation_unchanged(tmp_path: Path):
     """systemd units pass exactly 3 args (session callsign worktree). No --flag
-    must still work — Default path is fresh-context invocation."""
-    result = _run_keepalive("atlas", "atlas", "/home/elliotbot/clawd/Agency_OS-atlas")
-    assert result.returncode == 0
+    must still work — Default path is fresh-context invocation.
+
+    Worktree must exist (script exits 2 on missing dir) — tmp_path for CI."""
+    worktree = tmp_path / "fake_atlas_worktree"
+    worktree.mkdir()
+    result = _run_keepalive("atlas", "atlas", str(worktree))
+    assert result.returncode == 0, f"unexpected exit={result.returncode}\nstderr: {result.stderr}"
     # Default path
     assert "--continue" not in result.stdout
     assert "claude --dangerously-skip-permissions" in result.stdout

--- a/tests/scripts/test_agent_keepalive_bounded_spawn.py
+++ b/tests/scripts/test_agent_keepalive_bounded_spawn.py
@@ -1,0 +1,180 @@
+"""agent_keepalive.sh bounded-spawn discipline tests.
+
+Dave directive 2026-05-27: every keepalive respawn starts from zero by
+default; state carryover requires --preserve-context with logged justification.
+
+Tests use KEEPALIVE_DRY=1 to capture the resolved tmux/send-keys plan without
+actually spawning tmux or claude.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "agent_keepalive.sh"
+
+
+def _run_keepalive(
+    *args: str, override_log: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {"KEEPALIVE_DRY": "1", "PATH": "/usr/bin:/bin"}
+    if override_log is not None:
+        env["KEEPALIVE_OVERRIDE_LOG"] = str(override_log)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+# ---- Default — fresh context (no --continue) ------------------------------
+
+
+def test_default_invokes_claude_without_continue():
+    result = _run_keepalive("testsession", "testcs", "/tmp")
+    assert result.returncode == 0
+    # The send-keys plan should NOT include `--continue`
+    assert "--continue" not in result.stdout
+    # AND should include the bare claude invocation
+    assert "claude --dangerously-skip-permissions" in result.stdout
+
+
+# ---- --preserve-context override ------------------------------------------
+
+
+def test_preserve_context_uses_claude_continue(tmp_path: Path):
+    log_path = tmp_path / "override.jsonl"
+    result = _run_keepalive(
+        "testsession",
+        "testcs",
+        "/tmp",
+        "--preserve-context",
+        "operator recovery of stuck Atlas review",
+        override_log=log_path,
+    )
+    assert result.returncode == 0
+    assert "claude --continue --dangerously-skip-permissions" in result.stdout
+    # Stderr should announce the override
+    assert "--preserve-context override active" in result.stderr
+
+
+def test_preserve_context_writes_jsonl_event(tmp_path: Path):
+    log_path = tmp_path / "override.jsonl"
+    result = _run_keepalive(
+        "atlas",
+        "atlas",
+        "/home/elliotbot/clawd/Agency_OS-atlas",
+        "--preserve-context",
+        "stuck review session needs context to resume",
+        override_log=log_path,
+    )
+    assert result.returncode == 0
+    assert log_path.exists()
+    content = log_path.read_text(encoding="utf-8").strip()
+    event = json.loads(content)
+    assert event["callsign"] == "atlas"
+    assert event["session"] == "atlas"
+    assert event["worktree"] == "/home/elliotbot/clawd/Agency_OS-atlas"
+    assert event["justification"] == "stuck review session needs context to resume"
+    assert "ts" in event
+    # ISO 8601 with Z suffix
+    assert event["ts"].endswith("Z")
+
+
+def test_preserve_context_appends_not_overwrites(tmp_path: Path):
+    """Multiple respawn cycles → multiple JSONL events appended."""
+    log_path = tmp_path / "override.jsonl"
+    _run_keepalive(
+        "s1",
+        "cs1",
+        "/tmp",
+        "--preserve-context",
+        "first override",
+        override_log=log_path,
+    )
+    _run_keepalive(
+        "s2",
+        "cs2",
+        "/tmp",
+        "--preserve-context",
+        "second override",
+        override_log=log_path,
+    )
+    lines = [l for l in log_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert len(lines) == 2
+    events = [json.loads(line) for line in lines]
+    assert events[0]["justification"] == "first override"
+    assert events[1]["justification"] == "second override"
+
+
+# ---- Validation — missing / empty justification ---------------------------
+
+
+def test_preserve_context_without_justification_fails(tmp_path: Path):
+    result = _run_keepalive(
+        "testsession",
+        "testcs",
+        "/tmp",
+        "--preserve-context",
+        override_log=tmp_path / "override.jsonl",
+    )
+    assert result.returncode == 2
+    assert "non-empty justification" in result.stderr
+
+
+def test_preserve_context_with_empty_justification_fails(tmp_path: Path):
+    """--preserve-context '' → fail (empty string not a real justification)."""
+    result = _run_keepalive(
+        "testsession",
+        "testcs",
+        "/tmp",
+        "--preserve-context",
+        "",
+        override_log=tmp_path / "override.jsonl",
+    )
+    assert result.returncode == 2
+    assert "non-empty justification" in result.stderr
+
+
+# ---- Validation — unknown arg ---------------------------------------------
+
+
+def test_unknown_argument_fails():
+    result = _run_keepalive("testsession", "testcs", "/tmp", "--bogus-flag")
+    assert result.returncode == 2
+    assert "unknown argument" in result.stderr
+
+
+# ---- Backwards compatibility — existing systemd-unit invocations ----------
+
+
+def test_existing_three_arg_invocation_unchanged():
+    """systemd units pass exactly 3 args (session callsign worktree). No --flag
+    must still work — Default path is fresh-context invocation."""
+    result = _run_keepalive("atlas", "atlas", "/home/elliotbot/clawd/Agency_OS-atlas")
+    assert result.returncode == 0
+    # Default path
+    assert "--continue" not in result.stdout
+    assert "claude --dangerously-skip-permissions" in result.stdout
+
+
+# ---- Header doc anchor ----------------------------------------------------
+
+
+def test_script_header_cites_dave_directive_2026_05_27():
+    """The bounded-spawn directive anchor must be visible at the script head."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "Dave directive 2026-05-27" in text
+    assert "bounded-spawn discipline" in text
+    assert "--preserve-context" in text
+
+
+def test_script_documents_jsonl_log_path():
+    """The default JSONL log path must be discoverable in the header."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "/tmp/keepalive_override_log.jsonl" in text


### PR DESCRIPTION
## Summary

Dave directive 2026-05-27 governance fix per dispatch — V1 9-blocker set item. Closes the bounded-spawn invariant violation in `scripts/agent_keepalive.sh` where Claude respawned with accumulated conversation context via the in-pane respawn loop.

**Stats:** 2 files, +248 LoC (script +71 / test +180), **10 unit tests passing**, ruff clean, backwards-compatible with existing systemd-unit invocations.

## What changes

| Change | Behavior |
|---|---|
| **Default — fresh context** | In-pane respawn loop drops to bare `claude --dangerously-skip-permissions` (no `--continue`, no `--resume`). Every respawn = new bounded task; only on-disk state survives. |
| **--preserve-context override** | New CLI flag: `agent_keepalive.sh <session> <callsign> <worktree> --preserve-context "<justification>"` → switches to `claude --continue --dangerously-skip-permissions`. Justification required and non-empty (else exit 2). |
| **JSONL audit log** | Override invocations append one event to `/tmp/keepalive_override_log.jsonl` (overridable via `KEEPALIVE_OVERRIDE_LOG`). Justification JSON-escaped via Python so operator prose with quotes/backslashes is safe. |
| **Header doc note** | Cites Dave directive 2026-05-27 + bounded-spawn discipline + documents --preserve-context + KEEPALIVE_OVERRIDE_LOG. |

## JSONL event shape

```json
{"ts":"2026-05-27T01:31:51Z","callsign":"atlas","session":"atlas","worktree":"/home/elliotbot/clawd/Agency_OS-atlas","justification":"stuck review session needs context to resume"}
```

One event per spawn cycle, append-only.

## Backwards compatibility

**Existing systemd-unit invocations pass exactly 3 args** (`session callsign worktree`); they continue to work unchanged and land on the DEFAULT fresh-context path. **No unit files need to change.** Test `test_existing_three_arg_invocation_unchanged` locks this.

## Test coverage (10 tests, all pass)

- Default invocation: no `--continue` (fresh context)
- `--preserve-context "<justification>"`: switches to `claude --continue` + announces on stderr
- `--preserve-context`: writes JSONL event with all fields (ts/callsign/session/worktree/justification) + ts ends in 'Z'
- `--preserve-context`: appends to existing log (does not overwrite — multi-spawn auditable)
- `--preserve-context` without justification: exit 2 + clear error
- `--preserve-context` with empty justification: exit 2 + clear error
- Unknown argument: exit 2 + clear error
- 3-arg backwards-compat invocation: default fresh-context path
- Header cites Dave directive 2026-05-27 + bounded-spawn + `--preserve-context`
- Header documents `/tmp/keepalive_override_log.jsonl`

## Verification (all locally)

- [x] `python3 -m pytest tests/scripts/test_agent_keepalive_bounded_spawn.py -q` → **10 passed**
- [x] `KEEPALIVE_DRY=1` smoke tests all 4 paths (default + override-happy + missing-justification + unknown-arg) → expected outputs + exit codes
- [x] `ruff check + ruff format --check` clean on test file

## Anchor

Dave verbatim ratify 2026-05-27 — bounded-spawn discipline + no state carryover by default + explicit override with logged justification. Ships as part of V1 9-blocker set per dispatch.

## Standard PR + dual concur before merge per dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)