### PR TITLE
[ORION] feat(relay): dispatcher-level budget ceiling gate — cutover-blocker 2 (Agency_OS-6ah2)

### DIFF
--- a/src/relay/budget_ceiling.py
+++ b/src/relay/budget_ceiling.py
@@ -1,0 +1,324 @@
+"""budget_ceiling — dispatcher-level pre-spawn budget gate (Agency_OS-6ah2).
+
+Cutover-blocker 2 / Viktor non-negotiable cutover-gate item per Dave directive
+2026-05-27. Mechanical enforcement at the dispatcher pre-spawn check: when
+daily fleet spend exceeds the Dave-set threshold (default 25 AUD/day), apply
+the policy table below.
+
+POLICY TABLE (per dispatch):
+  1. Priority tasks → spawn, BUT log overage to alerts channel
+  2. Non-priority tasks → queued to next day OR dropped with log entry
+  3. Dave direct-message tasks → ALWAYS spawn on Haiku tier; NEVER block
+     ("CEO never blocked" — non-negotiable)
+  4. --force-spawn override → spawn with logged justification, for emergencies
+
+CALL SITE: scripts/fleet_supervisor.py dispatcher pre-spawn (separate KEI
+wires this in; this module ships the gate logic + tests).
+
+DI: caller passes any DB cursor implementing _DBProtocol + an alerts emitter.
+No asyncpg/psycopg import here — matches PR #1173/#1185/#1194 DI pattern.
+
+ANCHORING:
+  - Daily fleet budget default: 25 AUD (KEIRACOM_DAILY_FLEET_BUDGET_AUD env).
+  - LAW II: 1 USD = 1.55 AUD; spend reads are AUD throughout.
+  - Bounded-spawn baseline 0.79 AUD per spawn → ~31 spawns/day default budget.
+  - Cutover readiness gate COST_TELEMETRY.budget_ceiling_firing (restated
+    2026-05-27 outbox orion-cutover-gate-verbatim-restate-resumed).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Protocol
+
+log = logging.getLogger(__name__)
+
+# Dave-set default threshold (overridable via env).
+DEFAULT_DAILY_FLEET_BUDGET_AUD: float = 25.0
+
+# Source-of-task constants — input to check_budget().
+SOURCE_DAVE_DM: str = "dave_dm"
+SOURCE_FLEET: str = "fleet"
+SOURCE_AUTOMATED: str = "automated"
+
+# Priority constants — input to check_budget().
+PRIORITY_HIGH: str = "high"
+PRIORITY_NORMAL: str = "normal"
+PRIORITY_LOW: str = "low"
+
+VALID_PRIORITIES: frozenset[str] = frozenset({PRIORITY_HIGH, PRIORITY_NORMAL, PRIORITY_LOW})
+
+# Per-dispatch acceptance criterion (d): alerts channel posts on each fire.
+# Fallback path lets the dispatcher emit even when Better Stack is unreachable.
+DEFAULT_ALERTS_JSONL: Path = Path("/tmp/keiracom_budget_alerts.jsonl")
+
+
+class BudgetDecision(Enum):
+    """The verdict returned to the dispatcher pre-spawn check."""
+
+    SPAWN_OK = "spawn_ok"
+    OVERAGE_LOG_AND_SPAWN = "overage_log_and_spawn"  # priority over budget
+    QUEUE_NEXT_DAY = "queue_next_day"  # non-priority over budget, deferred
+    DROP_WITH_LOG = "drop_with_log"  # non-priority over budget, not deferrable
+    DAVE_BYPASS = "dave_bypass"  # CEO never blocked (Haiku tier)
+    FORCE_OVERRIDE = "force_override"  # --force-spawn + justification
+
+
+@dataclass(frozen=True, kw_only=True)
+class BudgetCheckResult:
+    """Caller acts on this — decision + recommended tier + alert payload."""
+
+    decision: BudgetDecision
+    current_day_spend_aud: float
+    daily_budget_aud: float
+    recommended_tier: str | None = None  # e.g. "haiku" for Dave bypass
+    reason: str = ""
+
+
+class BudgetCeilingError(RuntimeError):
+    """Raised on invalid input only — DB / alerts failures fail-open by design."""
+
+
+class _DBProtocol(Protocol):
+    """Subset of a DB cursor used to read fleet spend. Mirrors PR #1185 + #1194 DI."""
+
+    def execute(self, query: str, *params: Any) -> Any: ...
+    def fetchone(self) -> Any: ...
+
+
+AlertEmitter = Callable[[dict[str, Any]], None]
+
+
+def fleet_spend_for_day(db: _DBProtocol, day: date) -> float:
+    """Read total fleet LLM spend in AUD for `day` from keiracom_tenant_metering.
+
+    Token counts are converted to AUD via the model_cost_calibration weight
+    (PR #1173 budget policy) — but for the pre-spawn check we use a simple
+    heuristic: bounded-spawn baseline 0.79 AUD/spawn × request_count, then
+    refined per-model at Phase 2 when provider-billing-API integration lands
+    (deferred per PR #1128 §5).
+
+    Returns 0.0 if there's no metering row for the day (fresh day, no traffic
+    yet).
+    """
+    db.execute(
+        "SELECT COALESCE(SUM(request_count), 0)::bigint AS req_count "
+        "FROM public.keiracom_tenant_metering WHERE date_utc = %s",
+        day,
+    )
+    row = db.fetchone()
+    if row is None:
+        return 0.0
+    req_count = int(row[0] or 0)
+    # Bounded-spawn baseline 0.79 AUD per spawn (anchored to the
+    # cutover-readiness-gate COST_TELEMETRY criterion). When provider-billing-
+    # API integration lands (PR #1128 §5 follow-up), this switches to actual
+    # USD→AUD conversion via the metering pipeline cost columns.
+    return float(req_count) * 0.79
+
+
+def _resolve_daily_budget_aud() -> float:
+    """Read KEIRACOM_DAILY_FLEET_BUDGET_AUD env var; fall back to default."""
+    raw = os.environ.get("KEIRACOM_DAILY_FLEET_BUDGET_AUD")
+    if raw is None or raw == "":
+        return DEFAULT_DAILY_FLEET_BUDGET_AUD
+    try:
+        return float(raw)
+    except ValueError:
+        log.warning("invalid KEIRACOM_DAILY_FLEET_BUDGET_AUD=%r — using default", raw)
+        return DEFAULT_DAILY_FLEET_BUDGET_AUD
+
+
+def _default_jsonl_alert_emitter(payload: dict[str, Any]) -> None:
+    """Fallback alerts emitter — appends JSONL to /tmp/keiracom_budget_alerts.jsonl.
+
+    Used when caller doesn't inject a Better Stack emitter. Append-only so
+    every budget firing has a reviewable audit trail even if no real alerts
+    channel is wired.
+    """
+    DEFAULT_ALERTS_JSONL.parent.mkdir(parents=True, exist_ok=True)
+    with DEFAULT_ALERTS_JSONL.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload) + "\n")
+
+
+class BudgetCeilingGate:
+    """Dispatcher pre-spawn budget gate.
+
+    Caller invokes `check_budget(...)` BEFORE every spawn. The returned
+    `BudgetCheckResult.decision` tells the dispatcher how to proceed.
+
+    Fail-open by design: DB read failure or alerts emit failure → SPAWN_OK.
+    Silently suppressing spawns on transient telemetry hiccups would be
+    worse than letting one extra spawn through.
+    """
+
+    def __init__(
+        self,
+        *,
+        db: _DBProtocol,
+        alerts_emitter: AlertEmitter | None = None,
+        daily_budget_aud: float | None = None,
+        now_provider: Callable[[], datetime] | None = None,
+    ):
+        self._db = db
+        self._alerts = alerts_emitter or _default_jsonl_alert_emitter
+        self._daily_budget = (
+            daily_budget_aud if daily_budget_aud is not None else _resolve_daily_budget_aud()
+        )
+        if self._daily_budget <= 0:
+            raise BudgetCeilingError(f"daily_budget_aud must be > 0; got {self._daily_budget}")
+        self._now = now_provider or (lambda: datetime.now(UTC))
+
+    @property
+    def daily_budget_aud(self) -> float:
+        return self._daily_budget
+
+    def check_budget(
+        self,
+        *,
+        task_priority: str,
+        source: str,
+        force_override: bool = False,
+        force_justification: str | None = None,
+        deferrable: bool = True,
+    ) -> BudgetCheckResult:
+        """Pre-spawn budget gate.
+
+        Args:
+            task_priority: "high" / "normal" / "low".
+            source: e.g. SOURCE_DAVE_DM, SOURCE_FLEET, SOURCE_AUTOMATED.
+            force_override: True when dispatcher was invoked with --force-spawn.
+            force_justification: required + non-empty when force_override=True.
+            deferrable: True if the task can wait until tomorrow (most automated
+                tasks); False for tasks that must drop-with-log on overage.
+
+        Returns:
+            BudgetCheckResult — caller acts on the decision.
+        """
+        if task_priority not in VALID_PRIORITIES:
+            raise BudgetCeilingError(
+                f"task_priority {task_priority!r} not in {sorted(VALID_PRIORITIES)}"
+            )
+
+        # 1. --force-spawn override fires FIRST. Justification required.
+        if force_override:
+            if not force_justification:
+                raise BudgetCeilingError(
+                    "force_override=True requires non-empty force_justification"
+                )
+            spend = self._safe_fleet_spend()
+            self._emit_alert(
+                {
+                    "kind": "budget_force_override",
+                    "task_priority": task_priority,
+                    "source": source,
+                    "force_justification": force_justification,
+                    "current_day_spend_aud": spend,
+                    "daily_budget_aud": self._daily_budget,
+                    "ts": self._now().isoformat(),
+                }
+            )
+            return BudgetCheckResult(
+                decision=BudgetDecision.FORCE_OVERRIDE,
+                current_day_spend_aud=spend,
+                daily_budget_aud=self._daily_budget,
+                reason=f"force-spawn override: {force_justification}",
+            )
+
+        # 2. Dave bypass — CEO never blocked. Always spawn on Haiku tier.
+        if source == SOURCE_DAVE_DM:
+            spend = self._safe_fleet_spend()
+            # We still LOG the bypass for audit, even though it always passes.
+            self._emit_alert(
+                {
+                    "kind": "budget_dave_bypass",
+                    "task_priority": task_priority,
+                    "source": source,
+                    "current_day_spend_aud": spend,
+                    "daily_budget_aud": self._daily_budget,
+                    "over_budget": spend >= self._daily_budget,
+                    "ts": self._now().isoformat(),
+                }
+            )
+            return BudgetCheckResult(
+                decision=BudgetDecision.DAVE_BYPASS,
+                current_day_spend_aud=spend,
+                daily_budget_aud=self._daily_budget,
+                recommended_tier="haiku",
+                reason="CEO never blocked (Dave direct message)",
+            )
+
+        # 3. Read current-day spend; apply policy.
+        spend = self._safe_fleet_spend()
+        over_budget = spend >= self._daily_budget
+
+        if not over_budget:
+            return BudgetCheckResult(
+                decision=BudgetDecision.SPAWN_OK,
+                current_day_spend_aud=spend,
+                daily_budget_aud=self._daily_budget,
+                reason="under daily budget",
+            )
+
+        # Over budget — branch by priority.
+        common_alert = {
+            "task_priority": task_priority,
+            "source": source,
+            "current_day_spend_aud": spend,
+            "daily_budget_aud": self._daily_budget,
+            "ts": self._now().isoformat(),
+        }
+        if task_priority == PRIORITY_HIGH:
+            self._emit_alert({**common_alert, "kind": "budget_overage_priority_spawn"})
+            return BudgetCheckResult(
+                decision=BudgetDecision.OVERAGE_LOG_AND_SPAWN,
+                current_day_spend_aud=spend,
+                daily_budget_aud=self._daily_budget,
+                reason="priority task spawned despite budget overage",
+            )
+
+        # Non-priority over budget.
+        if deferrable:
+            self._emit_alert({**common_alert, "kind": "budget_overage_queue_next_day"})
+            return BudgetCheckResult(
+                decision=BudgetDecision.QUEUE_NEXT_DAY,
+                current_day_spend_aud=spend,
+                daily_budget_aud=self._daily_budget,
+                reason="non-priority queued until next day",
+            )
+        self._emit_alert({**common_alert, "kind": "budget_overage_drop"})
+        return BudgetCheckResult(
+            decision=BudgetDecision.DROP_WITH_LOG,
+            current_day_spend_aud=spend,
+            daily_budget_aud=self._daily_budget,
+            reason="non-priority + non-deferrable dropped on overage",
+        )
+
+    # ------------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------------
+
+    def _safe_fleet_spend(self) -> float:
+        """Read fleet spend with fail-open semantics. DB error → 0.0 (treat as
+        under budget rather than blocking spawns on transient telemetry failure)."""
+        try:
+            today = self._now().date()
+            return fleet_spend_for_day(self._db, today)
+        except Exception:  # noqa: BLE001
+            log.exception("budget gate: DB read failed; treating as under budget")
+            return 0.0
+
+    def _emit_alert(self, payload: dict[str, Any]) -> None:
+        """Emit one alert event. Fail-open — alerts emit failure must not block
+        dispatch logic."""
+        try:
+            self._alerts(payload)
+        except Exception:  # noqa: BLE001
+            log.exception("budget gate: alerts emit failed (non-blocking)")

--- a/tests/relay/test_budget_ceiling.py
+++ b/tests/relay/test_budget_ceiling.py
@@ -1,0 +1,448 @@
+"""budget_ceiling unit tests — Cutover-blocker 2 (Agency_OS-6ah2).
+
+Acceptance criteria per dispatch (Dave 2026-05-27):
+  (a) pre-spawn check reads current-day spend
+  (b) policy table applied per task priority
+  (c) Dave direct messages bypass
+  (d) alerts channel posts on each fire
+  (e) verbatim tests showing budget-cap fires + override works
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from src.relay.budget_ceiling import (
+    DEFAULT_DAILY_FLEET_BUDGET_AUD,
+    PRIORITY_HIGH,
+    PRIORITY_LOW,
+    PRIORITY_NORMAL,
+    SOURCE_AUTOMATED,
+    SOURCE_DAVE_DM,
+    SOURCE_FLEET,
+    BudgetCeilingError,
+    BudgetCeilingGate,
+    BudgetDecision,
+    fleet_spend_for_day,
+)
+
+
+class _FakeDB:
+    """Minimal DB fake — records executes, serves canned fetchone."""
+
+    def __init__(self, spend_request_count: int = 0):
+        self.calls: list[tuple[str, tuple]] = []
+        self._next_one: Any = (spend_request_count,)
+
+    def execute(self, query: str, *params):
+        self.calls.append((query, params))
+
+    def fetchone(self):
+        return self._next_one
+
+    def set_request_count(self, count: int) -> None:
+        self._next_one = (count,)
+
+    def set_db_error(self) -> None:
+        # Will raise on next execute.
+        self.calls = []
+        self._raise = True
+
+        def _raising_execute(query: str, *params):
+            raise RuntimeError("simulated DB error")
+
+        self.execute = _raising_execute  # type: ignore[method-assign]
+
+
+def _fixed_now() -> datetime:
+    return datetime(2026, 5, 27, 14, 0, 0, tzinfo=UTC)
+
+
+def _gate(
+    db: _FakeDB | None = None,
+    *,
+    daily_budget_aud: float = 25.0,
+    alerts_emitter=None,
+) -> tuple[BudgetCeilingGate, list[dict]]:
+    """Build a gate + return the captured-alerts list for assertion."""
+    captured: list[dict] = []
+
+    def emit(payload):
+        captured.append(payload)
+
+    return (
+        BudgetCeilingGate(
+            db=db or _FakeDB(),
+            alerts_emitter=alerts_emitter or emit,
+            daily_budget_aud=daily_budget_aud,
+            now_provider=_fixed_now,
+        ),
+        captured,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Constants + invariants
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_default_daily_budget_is_25_aud():
+    assert DEFAULT_DAILY_FLEET_BUDGET_AUD == 25.0
+
+
+def test_gate_rejects_zero_or_negative_budget():
+    with pytest.raises(BudgetCeilingError, match="must be > 0"):
+        BudgetCeilingGate(db=_FakeDB(), daily_budget_aud=0.0)
+    with pytest.raises(BudgetCeilingError, match="must be > 0"):
+        BudgetCeilingGate(db=_FakeDB(), daily_budget_aud=-5.0)
+
+
+def test_check_budget_rejects_invalid_priority():
+    gate, _ = _gate()
+    with pytest.raises(BudgetCeilingError, match="task_priority"):
+        gate.check_budget(task_priority="bogus", source=SOURCE_FLEET)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Acceptance (a) — pre-spawn check reads current-day spend
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_fleet_spend_for_day_queries_metering_table():
+    db = _FakeDB(spend_request_count=10)
+    spend = fleet_spend_for_day(db, _fixed_now().date())
+    # 10 requests × 0.79 AUD baseline = 7.9 AUD
+    assert spend == pytest.approx(7.9)
+    query, params = db.calls[0]
+    assert "FROM public.keiracom_tenant_metering" in query
+    assert "date_utc = %s" in query
+    assert params[0] == _fixed_now().date()
+
+
+def test_fleet_spend_zero_when_no_metering_row():
+    """Empty result → 0.0 spend (fresh day, no traffic yet)."""
+
+    class _EmptyDB(_FakeDB):
+        def fetchone(self):
+            return None
+
+    spend = fleet_spend_for_day(_EmptyDB(), _fixed_now().date())
+    assert spend == 0.0
+
+
+def test_check_budget_under_budget_returns_spawn_ok():
+    # 10 requests × 0.79 = 7.9 AUD, well under 25
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=10), daily_budget_aud=25.0)
+    result = gate.check_budget(task_priority=PRIORITY_NORMAL, source=SOURCE_FLEET)
+    assert result.decision == BudgetDecision.SPAWN_OK
+    assert result.current_day_spend_aud == pytest.approx(7.9)
+    assert result.daily_budget_aud == 25.0
+    # No alert when under budget
+    assert alerts == []
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Acceptance (b) — policy table per priority
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_priority_high_over_budget_spawns_with_overage_log():
+    # 50 requests × 0.79 = 39.5 AUD > 25 budget
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=50), daily_budget_aud=25.0)
+    result = gate.check_budget(task_priority=PRIORITY_HIGH, source=SOURCE_FLEET)
+    assert result.decision == BudgetDecision.OVERAGE_LOG_AND_SPAWN
+    assert "priority task spawned despite budget overage" in result.reason
+    assert len(alerts) == 1
+    assert alerts[0]["kind"] == "budget_overage_priority_spawn"
+    assert alerts[0]["task_priority"] == PRIORITY_HIGH
+    assert alerts[0]["current_day_spend_aud"] == pytest.approx(39.5)
+
+
+def test_priority_normal_over_budget_deferrable_queues_next_day():
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=50), daily_budget_aud=25.0)
+    result = gate.check_budget(
+        task_priority=PRIORITY_NORMAL,
+        source=SOURCE_FLEET,
+        deferrable=True,
+    )
+    assert result.decision == BudgetDecision.QUEUE_NEXT_DAY
+    assert "non-priority queued until next day" in result.reason
+    assert len(alerts) == 1
+    assert alerts[0]["kind"] == "budget_overage_queue_next_day"
+
+
+def test_priority_normal_over_budget_non_deferrable_drops():
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=50), daily_budget_aud=25.0)
+    result = gate.check_budget(
+        task_priority=PRIORITY_NORMAL,
+        source=SOURCE_FLEET,
+        deferrable=False,
+    )
+    assert result.decision == BudgetDecision.DROP_WITH_LOG
+    assert "dropped on overage" in result.reason
+    assert len(alerts) == 1
+    assert alerts[0]["kind"] == "budget_overage_drop"
+
+
+def test_priority_low_over_budget_deferrable_queues_next_day():
+    """Low priority + deferrable → also queues (same path as normal+deferrable)."""
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=50), daily_budget_aud=25.0)
+    result = gate.check_budget(
+        task_priority=PRIORITY_LOW,
+        source=SOURCE_FLEET,
+        deferrable=True,
+    )
+    assert result.decision == BudgetDecision.QUEUE_NEXT_DAY
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Acceptance (c) — Dave direct messages bypass
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_dave_dm_under_budget_is_dave_bypass_with_haiku_tier():
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=10), daily_budget_aud=25.0)
+    result = gate.check_budget(task_priority=PRIORITY_HIGH, source=SOURCE_DAVE_DM)
+    assert result.decision == BudgetDecision.DAVE_BYPASS
+    assert result.recommended_tier == "haiku"
+    assert "CEO never blocked" in result.reason
+    # Audit log fired even though it passes
+    assert len(alerts) == 1
+    assert alerts[0]["kind"] == "budget_dave_bypass"
+    assert alerts[0]["over_budget"] is False
+
+
+def test_dave_dm_over_budget_still_bypasses():
+    """CEO NEVER BLOCKED — Dave DM passes even when fleet over budget."""
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=100), daily_budget_aud=25.0)
+    result = gate.check_budget(task_priority=PRIORITY_LOW, source=SOURCE_DAVE_DM)
+    assert result.decision == BudgetDecision.DAVE_BYPASS
+    assert result.recommended_tier == "haiku"
+    assert alerts[0]["over_budget"] is True
+
+
+def test_dave_dm_bypass_works_for_any_priority():
+    for priority in (PRIORITY_HIGH, PRIORITY_NORMAL, PRIORITY_LOW):
+        gate, _ = _gate(db=_FakeDB(spend_request_count=50), daily_budget_aud=25.0)
+        result = gate.check_budget(task_priority=priority, source=SOURCE_DAVE_DM)
+        assert result.decision == BudgetDecision.DAVE_BYPASS
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Acceptance (e) — --force-spawn override
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_force_override_requires_justification():
+    gate, _ = _gate(db=_FakeDB(spend_request_count=100))
+    with pytest.raises(BudgetCeilingError, match="non-empty force_justification"):
+        gate.check_budget(
+            task_priority=PRIORITY_NORMAL,
+            source=SOURCE_FLEET,
+            force_override=True,
+            force_justification=None,
+        )
+    with pytest.raises(BudgetCeilingError, match="non-empty force_justification"):
+        gate.check_budget(
+            task_priority=PRIORITY_NORMAL,
+            source=SOURCE_FLEET,
+            force_override=True,
+            force_justification="",
+        )
+
+
+def test_force_override_fires_regardless_of_budget():
+    """Even when way over budget, --force-spawn with justification fires."""
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=200), daily_budget_aud=25.0)
+    result = gate.check_budget(
+        task_priority=PRIORITY_NORMAL,
+        source=SOURCE_AUTOMATED,
+        force_override=True,
+        force_justification="emergency: bd cleanup before billing cutover",
+    )
+    assert result.decision == BudgetDecision.FORCE_OVERRIDE
+    assert "force-spawn override:" in result.reason
+    # Justification logged
+    assert len(alerts) == 1
+    assert alerts[0]["kind"] == "budget_force_override"
+    assert alerts[0]["force_justification"] == "emergency: bd cleanup before billing cutover"
+
+
+def test_force_override_takes_precedence_over_dave_bypass():
+    """If both flags fire on the same call, force-override wins (logged path)."""
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=50))
+    result = gate.check_budget(
+        task_priority=PRIORITY_HIGH,
+        source=SOURCE_DAVE_DM,
+        force_override=True,
+        force_justification="explicit operator override",
+    )
+    assert result.decision == BudgetDecision.FORCE_OVERRIDE
+    assert alerts[0]["kind"] == "budget_force_override"
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Acceptance (d) — alerts channel posts on each fire
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_alerts_emitter_called_on_priority_overage():
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=50))
+    gate.check_budget(task_priority=PRIORITY_HIGH, source=SOURCE_FLEET)
+    assert len(alerts) == 1
+
+
+def test_alerts_emitter_called_on_dave_bypass_audit():
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=10))
+    gate.check_budget(task_priority=PRIORITY_HIGH, source=SOURCE_DAVE_DM)
+    assert len(alerts) == 1
+
+
+def test_alerts_emitter_called_on_force_override():
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=0))
+    gate.check_budget(
+        task_priority=PRIORITY_NORMAL,
+        source=SOURCE_FLEET,
+        force_override=True,
+        force_justification="x",
+    )
+    assert len(alerts) == 1
+
+
+def test_alerts_emitter_not_called_under_budget_no_bypass():
+    """SPAWN_OK path doesn't fire alerts — only firings get logged."""
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=10))
+    gate.check_budget(task_priority=PRIORITY_NORMAL, source=SOURCE_FLEET)
+    assert alerts == []
+
+
+def test_alert_payload_includes_required_fields():
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=50))
+    gate.check_budget(task_priority=PRIORITY_HIGH, source=SOURCE_FLEET)
+    payload = alerts[0]
+    assert "kind" in payload
+    assert "task_priority" in payload
+    assert "source" in payload
+    assert "current_day_spend_aud" in payload
+    assert "daily_budget_aud" in payload
+    assert "ts" in payload
+    # ISO-8601 with TZ
+    assert "T" in payload["ts"]
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Fail-open — DB / alerts failures must not block dispatch logic
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_db_read_failure_treats_as_under_budget():
+    """Transient DB blip → SPAWN_OK (better one extra spawn than silent block)."""
+    db = _FakeDB()
+
+    def _raising(query, *params):
+        raise RuntimeError("simulated DB error")
+
+    db.execute = _raising  # type: ignore[method-assign]
+    gate, _ = _gate(db=db, daily_budget_aud=25.0)
+    result = gate.check_budget(task_priority=PRIORITY_NORMAL, source=SOURCE_FLEET)
+    assert result.decision == BudgetDecision.SPAWN_OK
+    assert result.current_day_spend_aud == 0.0
+
+
+def test_alerts_emitter_failure_does_not_block_decision():
+    """Alerts emit raises → decision still returned (caller never sees the throw)."""
+
+    def _raising_emit(payload):
+        raise RuntimeError("simulated alerts channel down")
+
+    gate, _ = _gate(
+        db=_FakeDB(spend_request_count=50),
+        daily_budget_aud=25.0,
+        alerts_emitter=_raising_emit,
+    )
+    result = gate.check_budget(task_priority=PRIORITY_HIGH, source=SOURCE_FLEET)
+    # Decision still computed — alerts failure swallowed
+    assert result.decision == BudgetDecision.OVERAGE_LOG_AND_SPAWN
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Env-var override
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_env_var_overrides_default_budget(monkeypatch):
+    monkeypatch.setenv("KEIRACOM_DAILY_FLEET_BUDGET_AUD", "50.0")
+    gate = BudgetCeilingGate(db=_FakeDB(), now_provider=_fixed_now)
+    assert gate.daily_budget_aud == 50.0
+
+
+def test_env_var_invalid_value_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("KEIRACOM_DAILY_FLEET_BUDGET_AUD", "not-a-number")
+    gate = BudgetCeilingGate(db=_FakeDB(), now_provider=_fixed_now)
+    assert gate.daily_budget_aud == DEFAULT_DAILY_FLEET_BUDGET_AUD
+
+
+def test_env_var_unset_uses_default(monkeypatch):
+    monkeypatch.delenv("KEIRACOM_DAILY_FLEET_BUDGET_AUD", raising=False)
+    gate = BudgetCeilingGate(db=_FakeDB(), now_provider=_fixed_now)
+    assert gate.daily_budget_aud == DEFAULT_DAILY_FLEET_BUDGET_AUD
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# End-to-end smoke: full pre-spawn sequence
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_e2e_dispatcher_flow_under_budget(monkeypatch):
+    """Pre-spawn sequence at 0 AUD spend → SPAWN_OK for any non-Dave task."""
+    monkeypatch.setenv("KEIRACOM_DAILY_FLEET_BUDGET_AUD", "25.0")
+    gate, alerts = _gate(db=_FakeDB(spend_request_count=0))
+    for priority in (PRIORITY_HIGH, PRIORITY_NORMAL, PRIORITY_LOW):
+        result = gate.check_budget(task_priority=priority, source=SOURCE_FLEET)
+        assert result.decision == BudgetDecision.SPAWN_OK
+    # No alerts under budget
+    assert alerts == []
+
+
+def test_e2e_dispatcher_flow_over_budget_full_policy():
+    """31+ spawns × 0.79 = >24.49 AUD; verify each policy branch fires correctly."""
+    # 32 requests × 0.79 = 25.28 AUD > 25 budget
+    db_over = _FakeDB(spend_request_count=32)
+
+    # Priority HIGH → OVERAGE_LOG_AND_SPAWN
+    gate_h, alerts_h = _gate(db=db_over, daily_budget_aud=25.0)
+    r_h = gate_h.check_budget(task_priority=PRIORITY_HIGH, source=SOURCE_FLEET)
+    assert r_h.decision == BudgetDecision.OVERAGE_LOG_AND_SPAWN
+
+    # Priority NORMAL + deferrable → QUEUE_NEXT_DAY
+    db_over2 = _FakeDB(spend_request_count=32)
+    gate_n, _ = _gate(db=db_over2, daily_budget_aud=25.0)
+    r_n = gate_n.check_budget(task_priority=PRIORITY_NORMAL, source=SOURCE_FLEET, deferrable=True)
+    assert r_n.decision == BudgetDecision.QUEUE_NEXT_DAY
+
+    # Priority LOW + non-deferrable → DROP_WITH_LOG
+    db_over3 = _FakeDB(spend_request_count=32)
+    gate_l, _ = _gate(db=db_over3, daily_budget_aud=25.0)
+    r_l = gate_l.check_budget(task_priority=PRIORITY_LOW, source=SOURCE_FLEET, deferrable=False)
+    assert r_l.decision == BudgetDecision.DROP_WITH_LOG
+
+    # Dave DM → DAVE_BYPASS regardless of overage
+    db_over4 = _FakeDB(spend_request_count=32)
+    gate_d, _ = _gate(db=db_over4, daily_budget_aud=25.0)
+    r_d = gate_d.check_budget(task_priority=PRIORITY_LOW, source=SOURCE_DAVE_DM)
+    assert r_d.decision == BudgetDecision.DAVE_BYPASS
+    assert r_d.recommended_tier == "haiku"
+
+    # --force-spawn → FORCE_OVERRIDE
+    db_over5 = _FakeDB(spend_request_count=32)
+    gate_f, _ = _gate(db=db_over5, daily_budget_aud=25.0)
+    r_f = gate_f.check_budget(
+        task_priority=PRIORITY_NORMAL,
+        source=SOURCE_FLEET,
+        force_override=True,
+        force_justification="emergency",
+    )
+    assert r_f.decision == BudgetDecision.FORCE_OVERRIDE


### PR DESCRIPTION
## Summary

Cutover-blocker 2 — Viktor non-negotiable cutover-gate item per Dave directive 2026-05-27. Mechanical pre-spawn enforcement of the fleet-wide daily LLM budget ceiling.

**Filed under:** Agency_OS-6ah2
**Stats:** 2 files, +772 LoC (source 324 / tests 448), **28 unit tests passing**, ruff/format/mypy clean, all 6 existing CI guards self-pass.

## Maps to cutover-readiness-gate (verbatim restated earlier this session)

- ✅ `COST_TELEMETRY.budget_ceiling_firing`
- ✅ `COST_TELEMETRY.bounded_spawn_baseline_0_79_AUD_anchored`
- ✅ `PRINCIPLE.cutover_only_at_100_pct_pre_flight` (this gate is a precondition)

## Policy table (per dispatch)

| Source | Priority | Over budget? | Decision |
|---|---|---|---|
| dave_dm | any | any | **DAVE_BYPASS** (Haiku tier, NEVER block) |
| any (with `--force-spawn`) | any | any | **FORCE_OVERRIDE** (logged justification required) |
| fleet/automated | high | yes | **OVERAGE_LOG_AND_SPAWN** |
| fleet/automated | normal/low + deferrable | yes | **QUEUE_NEXT_DAY** |
| fleet/automated | normal/low + non-deferrable | yes | **DROP_WITH_LOG** |
| any (non-Dave, non-override) | any | no | **SPAWN_OK** |

## API

```python
from src.relay.budget_ceiling import BudgetCeilingGate, BudgetDecision, SOURCE_DAVE_DM, PRIORITY_HIGH

gate = BudgetCeilingGate(db=cursor, alerts_emitter=better_stack_emit)

# Pre-spawn check
result = gate.check_budget(
    task_priority=PRIORITY_HIGH,
    source=SOURCE_DAVE_DM,
    deferrable=False,
)

if result.decision == BudgetDecision.DAVE_BYPASS:
    spawn_with_tier(result.recommended_tier)  # 'haiku'
elif result.decision in (BudgetDecision.QUEUE_NEXT_DAY, BudgetDecision.DROP_WITH_LOG):
    return  # don't spawn
else:
    spawn_normally()
```

## Acceptance criteria (all covered)

- **(a) pre-spawn check reads current-day spend** → `fleet_spend_for_day()` queries `keiracom_tenant_metering.date_utc`; bounded-spawn baseline 0.79 AUD/spawn × request_count (refined to real USD→AUD when provider-billing-API integration lands per PR #1128 §5)
- **(b) policy table applied per task priority** → `check_budget()` branches on `(priority, deferrable, over_budget)` through the 4-row policy table
- **(c) Dave direct messages bypass** → `source=SOURCE_DAVE_DM` → `DAVE_BYPASS` + `recommended_tier='haiku'` regardless of budget ("CEO never blocked" invariant locked by `test_dave_dm_over_budget_still_bypasses`)
- **(d) alerts channel posts on each fire** → `AlertEmitter` callable injected at construction; default fallback emits to `/tmp/keiracom_budget_alerts.jsonl`; every firing emits one payload with `{kind, task_priority, source, current_day_spend_aud, daily_budget_aud, ts}`
- **(e) verbatim test showing budget-cap fires + override works** → `test_e2e_dispatcher_flow_over_budget_full_policy` exercises all 4 over-budget branches + DAVE_BYPASS + FORCE_OVERRIDE in sequence

## Fail-open design

Matches PR #1199 race-check + PR #1185 atomization metering discipline:
- DB read failure → spend=0.0 treated as under budget (better one extra spawn than silent block on transient telemetry blip)
- Alerts emitter raise → swallowed; decision still returned (caller never blocks on alerts-channel-down)

## Anchoring

- **Daily budget default 25 AUD** per Dave dispatch (overridable via `KEIRACOM_DAILY_FLEET_BUDGET_AUD` env)
- **Bounded-spawn baseline 0.79 AUD per spawn** → ~31 spawns/day at default budget
- **LAW II:** 1 USD = 1.55 AUD; all spend reads + return values in AUD

## Dispatcher integration (separate KEI)

`scripts/fleet_supervisor.py` pre-spawn check wires this in. This PR ships the gate logic + tests as a standalone module so it can be reviewed + landed independently.

## Test plan

- [x] `python3 -m pytest tests/relay/test_budget_ceiling.py -q` → **28 passed in 0.17s**
- [x] `ruff check + ruff format --check` clean
- [x] `mypy src/relay/budget_ceiling.py --ignore-missing-imports` → no issues
- [x] All 6 BMV1 + cache-discipline + atom-store-discipline CI guards self-pass

## Standard PR + cross-check with Elliot before merge per dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)