### PR TITLE
[ORION] feat(dispatcher): idempotency gate — cutover-blocker 5 (Agency_OS-6c2k)

### DIFF
--- a/src/dispatcher/idempotency.py
+++ b/src/dispatcher/idempotency.py
@@ -1,0 +1,235 @@
+"""idempotency — dispatcher-level dedup gate (Agency_OS-6c2k).
+
+Cutover-blocker 5 / Viktor lever 26 (Cat 21) per Dave directive 2026-05-27.
+Prevents double-execution on Slack webhook retries + transient retry-storms.
+
+ALGORITHM:
+  idempotency_key = sha256-prefix(source + content + time_window_60s_rounded)
+  → Valkey SET NX EX with 5-minute TTL
+  → if SET returned None (key already present): drop dispatch + log
+  → if SET returned OK: spawn proceeds
+
+The 60-second time window is wide enough to absorb retry storms (Slack
+typically retries within 30s; the post-OK-200 confirmation often arrives
+twice within seconds) but narrow enough that legitimate intentional resends
+("hey try again") aren't deduplicated.
+
+The 5-minute TTL is wide enough to absorb the SLACK_RETRY_TIMEOUT_SECONDS
+(currently 3 min) + a safety margin. After TTL expires, the same
+(source, content) tuple can be sent again — that's CORRECT behavior, not
+a bug; permanent dedup would block legitimate re-sends.
+
+DI: caller passes an async Redis client implementing the SET command. Use
+existing `src/dispatcher/valkey_pool.get_valkey_client()` in production;
+fakes inject in tests.
+
+KEY NAMESPACE (extends valkey_pool.py's documented contract):
+  idem:<sha256-prefix-16chars>
+
+`idem:` slots alongside `rl:` (rate-limit, KEI-117), `q:` (queues, future),
+`ses:` (sessions, future).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Protocol
+
+log = logging.getLogger(__name__)
+
+# Dispatch defaults — per dispatch.
+DEFAULT_WINDOW_SECONDS: int = 60
+DEFAULT_TTL_SECONDS: int = 300  # 5 minutes per dispatch
+IDEM_KEY_PREFIX: str = "idem:"
+KEY_HASH_LENGTH: int = 16  # sha256 prefix bytes (16 hex chars = 64 bits)
+
+
+class IdempotencyDecision(Enum):
+    """Decision returned by the gate. Caller acts on this."""
+
+    SPAWN_OK = "spawn_ok"
+    DROP_DUPLICATE = "drop_duplicate"  # key was already present → already-dispatched
+
+
+@dataclass(frozen=True, kw_only=True)
+class IdempotencyResult:
+    """Caller acts on this; the key is exposed for log + audit purposes."""
+
+    decision: IdempotencyDecision
+    key: str
+    source: str
+    window_start_unix: int
+    reason: str = ""
+
+
+class IdempotencyError(RuntimeError):
+    """Raised on invalid input only — Redis errors fail-open by design."""
+
+
+class _RedisProtocol(Protocol):
+    """Subset of redis.asyncio.Redis we depend on for the gate.
+
+    `set` with `nx=True, ex=<int>` returns None when the key already exists,
+    truthy (typically True) when the SET succeeded.
+    """
+
+    def set(
+        self,
+        name: str,
+        value: str,
+        *,
+        nx: bool = False,
+        ex: int | None = None,
+    ) -> Awaitable[Any]: ...
+
+
+# Emitter signature — caller hooks alerts/logs via this.
+LogEmitter = Callable[[dict[str, Any]], None]
+
+
+def compute_idempotency_key(
+    source: str,
+    content: str,
+    *,
+    window_seconds: int = DEFAULT_WINDOW_SECONDS,
+    now: float | None = None,
+) -> tuple[str, int]:
+    """Compute the deterministic idempotency key for a (source, content) tuple.
+
+    Returns (key, window_start_unix). The key is `idem:<sha256-prefix-16>`.
+    The window_start_unix is exposed for log payloads.
+
+    Algorithm:
+      1. Compute rounded window: `floor(ts / window_seconds) * window_seconds`
+      2. Hash `source|content|window` via SHA-256
+      3. Prefix-truncate to 16 hex chars (64 bits — collision probability
+         ~1 in 2^32 across simultaneous dispatches in a 60-second window,
+         vanishingly small at fleet scale)
+    """
+    if not source:
+        raise IdempotencyError("source must be non-empty")
+    if not content:
+        raise IdempotencyError("content must be non-empty")
+    if window_seconds <= 0:
+        raise IdempotencyError(f"window_seconds must be > 0; got {window_seconds}")
+    ts = now if now is not None else time.time()
+    window_start = (int(ts) // window_seconds) * window_seconds
+    payload = f"{source}|{content}|{window_start}".encode()
+    digest = hashlib.sha256(payload).hexdigest()[:KEY_HASH_LENGTH]
+    return f"{IDEM_KEY_PREFIX}{digest}", window_start
+
+
+def _default_log_emitter(payload: dict[str, Any]) -> None:
+    """Default emitter — log at INFO. Caller wires Better Stack / JSONL via DI."""
+    log.info("idempotency-gate: %s", payload)
+
+
+class IdempotencyGate:
+    """Dispatcher pre-spawn dedup gate.
+
+    Caller invokes `check_and_claim(...)` BEFORE every spawn. If the returned
+    decision is `SPAWN_OK`, proceed with the dispatch. If `DROP_DUPLICATE`,
+    drop silently (one log emitted via the injected emitter).
+
+    Fail-open by design: Redis transport failure → SPAWN_OK (returning
+    DROP_DUPLICATE on a transient Valkey blip would block legitimate
+    dispatches; better one extra spawn than a missed message).
+    """
+
+    def __init__(
+        self,
+        *,
+        valkey_client: _RedisProtocol,
+        window_seconds: int = DEFAULT_WINDOW_SECONDS,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        log_emitter: LogEmitter | None = None,
+        now_provider: Callable[[], float] | None = None,
+    ):
+        if window_seconds <= 0:
+            raise IdempotencyError(f"window_seconds must be > 0; got {window_seconds}")
+        if ttl_seconds <= 0:
+            raise IdempotencyError(f"ttl_seconds must be > 0; got {ttl_seconds}")
+        self._client = valkey_client
+        self._window_seconds = window_seconds
+        self._ttl_seconds = ttl_seconds
+        self._log = log_emitter or _default_log_emitter
+        self._now = now_provider or time.time
+
+    @property
+    def window_seconds(self) -> int:
+        return self._window_seconds
+
+    @property
+    def ttl_seconds(self) -> int:
+        return self._ttl_seconds
+
+    async def check_and_claim(
+        self,
+        *,
+        source: str,
+        content: str,
+    ) -> IdempotencyResult:
+        """Pre-spawn dedup gate.
+
+        Computes the deterministic key + attempts a Valkey SET NX EX. Returns
+        SPAWN_OK on successful claim (no prior dispatch in window), or
+        DROP_DUPLICATE when the key was already present (already dispatched
+        within the 60-second window).
+
+        Fail-open on Redis errors — returns SPAWN_OK so transient Valkey
+        outages don't block dispatch.
+        """
+        key, window_start = compute_idempotency_key(
+            source,
+            content,
+            window_seconds=self._window_seconds,
+            now=self._now(),
+        )
+        try:
+            # SET NX EX: returns truthy on successful new claim, None when key exists.
+            set_result = await self._client.set(key, "1", nx=True, ex=self._ttl_seconds)
+        except Exception:  # noqa: BLE001 — fail-open per design
+            log.exception("idempotency-gate: Valkey SET NX failed; failing open")
+            return IdempotencyResult(
+                decision=IdempotencyDecision.SPAWN_OK,
+                key=key,
+                source=source,
+                window_start_unix=window_start,
+                reason="valkey unreachable — fail-open SPAWN_OK",
+            )
+
+        if set_result:
+            return IdempotencyResult(
+                decision=IdempotencyDecision.SPAWN_OK,
+                key=key,
+                source=source,
+                window_start_unix=window_start,
+                reason="claimed (no prior dispatch in window)",
+            )
+
+        # set_result is None → key already exists → already dispatched.
+        try:
+            self._log(
+                {
+                    "kind": "idempotency_drop_duplicate",
+                    "key": key,
+                    "source": source,
+                    "window_start_unix": window_start,
+                    "window_seconds": self._window_seconds,
+                    "ttl_seconds": self._ttl_seconds,
+                }
+            )
+        except Exception:  # noqa: BLE001 — log failure must not block
+            log.exception("idempotency-gate: log emit failed (non-blocking)")
+        return IdempotencyResult(
+            decision=IdempotencyDecision.DROP_DUPLICATE,
+            key=key,
+            source=source,
+            window_start_unix=window_start,
+            reason="duplicate within window — already dispatched",
+        )

--- a/tests/dispatcher/test_idempotency.py
+++ b/tests/dispatcher/test_idempotency.py
@@ -1,0 +1,336 @@
+"""idempotency unit tests — cutover-blocker 5 (Agency_OS-6c2k).
+
+Acceptance criteria per dispatch (Dave 2026-05-27 / Viktor lever 26):
+  (1) idempotency_key computed deterministically from source+content
+  (2) Valkey SET NX EX with 5-minute TTL
+  (3) dispatch dropped with log when key already present
+  (4) verbatim test showing double-dispatch dedupes to single spawn
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.dispatcher.idempotency import (
+    DEFAULT_TTL_SECONDS,
+    DEFAULT_WINDOW_SECONDS,
+    IDEM_KEY_PREFIX,
+    KEY_HASH_LENGTH,
+    IdempotencyDecision,
+    IdempotencyError,
+    IdempotencyGate,
+    compute_idempotency_key,
+)
+
+
+class _FakeRedis:
+    """Async-shaped Redis fake. Records SET calls + lets tests script the
+    "key already exists" branch.
+    """
+
+    def __init__(self) -> None:
+        self.set_calls: list[dict[str, Any]] = []
+        self._existing_keys: set[str] = set()
+        self._raise_on_set: bool = False
+
+    def add_existing(self, key: str) -> None:
+        self._existing_keys.add(key)
+
+    def fail_next_set(self) -> None:
+        self._raise_on_set = True
+
+    async def set(
+        self,
+        name: str,
+        value: str,
+        *,
+        nx: bool = False,
+        ex: int | None = None,
+    ) -> Any:
+        if self._raise_on_set:
+            self._raise_on_set = False
+            raise ConnectionError("simulated Valkey transport failure")
+        self.set_calls.append({"name": name, "value": value, "nx": nx, "ex": ex})
+        if nx and name in self._existing_keys:
+            return None  # SET NX returns None when key exists
+        self._existing_keys.add(name)
+        return True
+
+
+def _fixed_now() -> float:
+    """Anchor at a unix timestamp that rounds cleanly on 60s window."""
+    return 1779854400.0  # 2026-05-27T03:20:00Z (multiple of 60)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Acceptance (1) — deterministic key from source+content
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_compute_idempotency_key_deterministic_same_inputs_same_key():
+    k1, _ = compute_idempotency_key("slack:#ceo", "ship the build", now=_fixed_now())
+    k2, _ = compute_idempotency_key("slack:#ceo", "ship the build", now=_fixed_now())
+    assert k1 == k2
+
+
+def test_compute_idempotency_key_different_source_different_key():
+    k1, _ = compute_idempotency_key("slack:#ceo", "ship the build", now=_fixed_now())
+    k2, _ = compute_idempotency_key("slack:#execution", "ship the build", now=_fixed_now())
+    assert k1 != k2
+
+
+def test_compute_idempotency_key_different_content_different_key():
+    k1, _ = compute_idempotency_key("slack:#ceo", "ship the build", now=_fixed_now())
+    k2, _ = compute_idempotency_key("slack:#ceo", "ship something else", now=_fixed_now())
+    assert k1 != k2
+
+
+def test_compute_idempotency_key_prefix_and_length():
+    """`idem:<16-hex-chars>` shape."""
+    key, _ = compute_idempotency_key("s", "c", now=_fixed_now())
+    assert key.startswith(IDEM_KEY_PREFIX)
+    digest = key[len(IDEM_KEY_PREFIX) :]
+    assert len(digest) == KEY_HASH_LENGTH
+    # All hex chars
+    int(digest, 16)
+
+
+def test_compute_idempotency_key_rounds_to_window():
+    """Timestamps within the same 60s window → same key."""
+    k1, w1 = compute_idempotency_key("s", "c", now=_fixed_now())
+    k2, w2 = compute_idempotency_key("s", "c", now=_fixed_now() + 30)
+    k3, w3 = compute_idempotency_key("s", "c", now=_fixed_now() + 59)
+    assert k1 == k2 == k3
+    assert w1 == w2 == w3
+
+
+def test_compute_idempotency_key_window_boundary_different_key():
+    """Crossing the 60s window boundary → different key."""
+    k1, w1 = compute_idempotency_key("s", "c", now=_fixed_now())
+    k2, w2 = compute_idempotency_key("s", "c", now=_fixed_now() + 60)
+    assert k1 != k2
+    assert w1 != w2
+    assert w2 - w1 == 60
+
+
+def test_compute_idempotency_key_custom_window_seconds():
+    """Caller can change the window granularity."""
+    k1, _ = compute_idempotency_key("s", "c", window_seconds=300, now=_fixed_now())
+    k2, _ = compute_idempotency_key("s", "c", window_seconds=300, now=_fixed_now() + 200)
+    assert k1 == k2  # both inside the same 5-min bucket
+
+
+def test_compute_idempotency_key_rejects_empty_source():
+    with pytest.raises(IdempotencyError, match="source must be non-empty"):
+        compute_idempotency_key("", "content", now=_fixed_now())
+
+
+def test_compute_idempotency_key_rejects_empty_content():
+    with pytest.raises(IdempotencyError, match="content must be non-empty"):
+        compute_idempotency_key("source", "", now=_fixed_now())
+
+
+def test_compute_idempotency_key_rejects_zero_window():
+    with pytest.raises(IdempotencyError, match="window_seconds must be > 0"):
+        compute_idempotency_key("s", "c", window_seconds=0, now=_fixed_now())
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Acceptance (2) — Valkey SET NX EX with 5-minute TTL
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def test_default_ttl_is_300_seconds():
+    """5-minute TTL per dispatch."""
+    assert DEFAULT_TTL_SECONDS == 300
+
+
+def test_default_window_is_60_seconds():
+    """60-second time window per dispatch."""
+    assert DEFAULT_WINDOW_SECONDS == 60
+
+
+@pytest.mark.asyncio
+async def test_check_and_claim_calls_set_nx_ex_5_minute_ttl():
+    redis = _FakeRedis()
+    gate = IdempotencyGate(valkey_client=redis, now_provider=_fixed_now)
+    result = await gate.check_and_claim(source="slack:#ceo", content="hello")
+    assert result.decision == IdempotencyDecision.SPAWN_OK
+    assert len(redis.set_calls) == 1
+    call = redis.set_calls[0]
+    assert call["nx"] is True
+    assert call["ex"] == DEFAULT_TTL_SECONDS
+    assert call["name"].startswith(IDEM_KEY_PREFIX)
+
+
+@pytest.mark.asyncio
+async def test_gate_rejects_zero_window_seconds():
+    with pytest.raises(IdempotencyError, match="window_seconds must be > 0"):
+        IdempotencyGate(valkey_client=_FakeRedis(), window_seconds=0)
+
+
+@pytest.mark.asyncio
+async def test_gate_rejects_zero_ttl_seconds():
+    with pytest.raises(IdempotencyError, match="ttl_seconds must be > 0"):
+        IdempotencyGate(valkey_client=_FakeRedis(), ttl_seconds=0)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Acceptance (3) — dispatch dropped with log when key already present
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_and_claim_drops_duplicate_when_key_present():
+    redis = _FakeRedis()
+    # Pre-seed the key as if a prior dispatch already claimed it
+    expected_key, _ = compute_idempotency_key("slack:#ceo", "hello", now=_fixed_now())
+    redis.add_existing(expected_key)
+
+    captured_logs: list[dict] = []
+    gate = IdempotencyGate(
+        valkey_client=redis,
+        now_provider=_fixed_now,
+        log_emitter=captured_logs.append,
+    )
+    result = await gate.check_and_claim(source="slack:#ceo", content="hello")
+    assert result.decision == IdempotencyDecision.DROP_DUPLICATE
+    assert "duplicate within window" in result.reason
+    # Log was emitted
+    assert len(captured_logs) == 1
+    assert captured_logs[0]["kind"] == "idempotency_drop_duplicate"
+    assert captured_logs[0]["key"] == expected_key
+    assert captured_logs[0]["source"] == "slack:#ceo"
+
+
+@pytest.mark.asyncio
+async def test_log_emit_failure_does_not_block_decision():
+    """Log emitter raising must not block the DROP_DUPLICATE return."""
+    redis = _FakeRedis()
+    expected_key, _ = compute_idempotency_key("s", "c", now=_fixed_now())
+    redis.add_existing(expected_key)
+
+    def _raising_emit(payload):
+        raise RuntimeError("simulated log channel down")
+
+    gate = IdempotencyGate(
+        valkey_client=redis,
+        now_provider=_fixed_now,
+        log_emitter=_raising_emit,
+    )
+    result = await gate.check_and_claim(source="s", content="c")
+    # Decision still returned despite emit failure
+    assert result.decision == IdempotencyDecision.DROP_DUPLICATE
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Acceptance (4) — verbatim test showing double-dispatch dedupes to single spawn
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_double_dispatch_dedupes_to_single_spawn():
+    """The canonical end-to-end test per acceptance criterion (4).
+
+    Two consecutive dispatches with the same (source, content) within the
+    60-second window → first returns SPAWN_OK, second returns DROP_DUPLICATE.
+    Verbatim:
+      - call 1: dispatch arrives → check_and_claim → SPAWN_OK → spawn fires
+      - call 2: identical retry within window → check_and_claim → DROP_DUPLICATE
+                → spawn does NOT fire
+    """
+    redis = _FakeRedis()
+    captured_logs: list[dict] = []
+    gate = IdempotencyGate(
+        valkey_client=redis,
+        now_provider=_fixed_now,
+        log_emitter=captured_logs.append,
+    )
+
+    # Dispatch 1 — webhook fires.
+    result1 = await gate.check_and_claim(
+        source="slack:#ceo:U091TGTPB9U",
+        content="Dispatch: build the Atlas review fix",
+    )
+    assert result1.decision == IdempotencyDecision.SPAWN_OK
+
+    # Dispatch 2 — webhook retry fires the SAME payload within 60s.
+    # (Slack often retries within 30s of a delayed 200.)
+    result2 = await gate.check_and_claim(
+        source="slack:#ceo:U091TGTPB9U",
+        content="Dispatch: build the Atlas review fix",
+    )
+    assert result2.decision == IdempotencyDecision.DROP_DUPLICATE
+    assert result2.key == result1.key  # same key, same window
+
+    # Drop was logged
+    assert len(captured_logs) == 1
+    assert captured_logs[0]["kind"] == "idempotency_drop_duplicate"
+
+    # Net: only ONE Valkey SET call was made
+    # (first is the claim; second is also a SET but the gate returned None — counts as 2 SET calls
+    # but only ONE spawn would have proceeded — the test verifies the DECISION)
+    spawn_ok_count = sum(
+        1 for r in [result1, result2] if r.decision == IdempotencyDecision.SPAWN_OK
+    )
+    assert spawn_ok_count == 1, "exactly one SPAWN_OK expected for double-dispatch dedup"
+
+
+@pytest.mark.asyncio
+async def test_window_boundary_resets_dedup():
+    """After the 60s window expires, the same (source, content) CAN dispatch again."""
+    redis = _FakeRedis()
+
+    now_value = [_fixed_now()]
+
+    def _now_provider():
+        return now_value[0]
+
+    gate = IdempotencyGate(valkey_client=redis, now_provider=_now_provider)
+
+    # Dispatch 1 at t=0
+    result1 = await gate.check_and_claim(source="s", content="c")
+    assert result1.decision == IdempotencyDecision.SPAWN_OK
+
+    # Move forward 61 seconds → new 60s window
+    now_value[0] += 61
+    result2 = await gate.check_and_claim(source="s", content="c")
+    assert result2.decision == IdempotencyDecision.SPAWN_OK
+    # Different keys (different window)
+    assert result2.key != result1.key
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Fail-open — Valkey transport failures must not block dispatch
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_redis_set_failure_fails_open_to_spawn_ok():
+    """ConnectionError from Valkey → SPAWN_OK (better one extra spawn than
+    missed message on transient blip)."""
+    redis = _FakeRedis()
+    redis.fail_next_set()
+    gate = IdempotencyGate(valkey_client=redis, now_provider=_fixed_now)
+    result = await gate.check_and_claim(source="s", content="c")
+    assert result.decision == IdempotencyDecision.SPAWN_OK
+    assert "fail-open" in result.reason
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Result shape invariants
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_idempotency_result_exposes_key_and_window():
+    redis = _FakeRedis()
+    gate = IdempotencyGate(valkey_client=redis, now_provider=_fixed_now)
+    result = await gate.check_and_claim(source="s", content="c")
+    assert result.key.startswith(IDEM_KEY_PREFIX)
+    assert result.source == "s"
+    # Window start aligns with the fixed_now rounded to 60s
+    expected_window = int(_fixed_now() // 60) * 60
+    assert result.window_start_unix == expected_window


### PR DESCRIPTION
## Summary

Cutover-blocker 5 — Viktor lever 26 (Cat 21) per Dave directive 2026-05-27. Prevents double-execution on Slack webhook retries + transient retry-storms via Valkey `SET NX EX` with 5-minute TTL.

**Filed under:** Agency_OS-6c2k
**Stats:** 2 files, +571 LoC (source 235 / tests 336), **21 unit tests passing**, ruff/format/mypy clean, all 6 existing CI guards self-pass.

## Maps to cutover-readiness-gate

- ✅ `INFRASTRUCTURE_SIDE.dispatcher_refactored_workflow_driven` (this gate sits in the dispatcher pre-spawn pipeline alongside PR #1203 budget ceiling)

## Algorithm

```
idempotency_key = "idem:" + sha256(source + "|" + content + "|" + window_start)[:16]
window_start    = floor(now / 60s) * 60s
→ Valkey SET NX EX 300s
  → returns truthy → SPAWN_OK (no prior dispatch in window)
  → returns None   → DROP_DUPLICATE + log emit
```

## Why these timings

- **60-second window** absorbs Slack typical retry (within 30s); narrow enough that intentional resends 90s+ later are NOT dedup'd
- **5-minute TTL** covers `SLACK_RETRY_TIMEOUT_SECONDS` (3 min) + safety margin
- **Post-TTL, same (source, content) CAN dispatch again** — correct, not a bug; permanent dedup would block legitimate re-sends

## API

```python
from src.dispatcher.idempotency import IdempotencyGate, IdempotencyDecision
from src.dispatcher.valkey_pool import get_valkey_client

async def dispatch(message):
    async with get_valkey_client() as client:
        gate = IdempotencyGate(valkey_client=client)
        result = await gate.check_and_claim(
            source=message.source,
            content=message.content,
        )
        if result.decision == IdempotencyDecision.DROP_DUPLICATE:
            return  # webhook retry — already dispatched
        spawn(message)
```

## Acceptance criteria — all covered

| # | Criterion | Test |
|---:|---|---|
| (1) | idempotency_key computed deterministically from source+content | `test_compute_idempotency_key_deterministic_same_inputs_same_key` + differential tests on source/content/window |
| (2) | Valkey SET NX EX with 5-minute TTL | `test_check_and_claim_calls_set_nx_ex_5_minute_ttl` verifies `nx=True, ex=300` via injected fake |
| (3) | dispatch dropped with log when key already present | `test_check_and_claim_drops_duplicate_when_key_present` pre-seeds key + verifies DROP_DUPLICATE + log emit |
| (4) | verbatim test showing double-dispatch dedupes to single spawn | `test_double_dispatch_dedupes_to_single_spawn` — same `(source, content)` sent twice → first SPAWN_OK, second DROP_DUPLICATE, same key, exactly one SPAWN_OK |

## Additional coverage (21 tests total)

- Window boundary reset: t=0 SPAWN_OK → t=61 SPAWN_OK (new window, new key)
- Custom window_seconds (5-min bucket) for non-default callers
- Empty source/content/zero window_seconds rejected (`IdempotencyError`)
- Log emit failure swallowed — must not block decision return
- Redis transport failure → SPAWN_OK fail-open (matches PR #1199 + PR #1203 + PR #1185 fail-open discipline)

## Key namespace

Extends `src/dispatcher/valkey_pool.py`'s documented family contract:
- `rl:` (rate-limit, KEI-117)
- `idem:` (idempotency — **THIS PR**)
- `q:` (queues — future)
- `ses:` (sessions — future)

## Verification

- [x] `python3 -m pytest tests/dispatcher/test_idempotency.py -q` → **21 passed in 0.14s**
- [x] `ruff check + ruff format --check` clean
- [x] `mypy src/dispatcher/idempotency.py --ignore-missing-imports` → no issues
- [x] All 6 BMV1 + cache-discipline + atom-store-discipline CI guards self-pass

## Dispatcher integration (separate KEI)

Wiring this gate into the dispatcher pre-spawn pipeline is a separate KEI. This PR ships the gate logic + tests as a standalone module.

## Standard PR + dual concur before merge per dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)