### PR TITLE
[SCOUT] feat(attribution): completion_status field — Phase 1 cutover gate (Agency_OS-vq7k)

### DIFF
--- a/src/keiracom_system/attribution/__init__.py
+++ b/src/keiracom_system/attribution/__init__.py
@@ -12,17 +12,21 @@ Exports:
 """
 
 from .logger import (
+    COMPLETION_STATUSES,
     SOURCE_TYPES,
     TASK_TYPES,
     SpawnAttributionEntry,
+    aggregate_by_completion_status,
     load_attribution_last_24h,
     log_spawn_attribution,
 )
 
 __all__ = [
+    "COMPLETION_STATUSES",
     "SOURCE_TYPES",
     "TASK_TYPES",
     "SpawnAttributionEntry",
+    "aggregate_by_completion_status",
     "load_attribution_last_24h",
     "log_spawn_attribution",
 ]

--- a/src/keiracom_system/attribution/logger.py
+++ b/src/keiracom_system/attribution/logger.py
@@ -22,6 +22,7 @@ Per-event JSONL row schema:
     "source_type": "slack" | "pr" | "cron" | "inbox" | "unknown",
     "source_id":   "<slack-ts>" | "PR-1202" | "agency-cost-rollup.timer" | "/tmp/telegram-relay-atlas/inbox/...json",
     "task_type":   "pr_review" | "deliberation" | "build" | "chat" | "dispatch_mgmt" | "unknown",
+    "completion_status": "success" | "fail" | "timeout" | "interrupted" | "unknown",
     "callsign":    "atlas",
     "model":       "claude-opus-4-7",
     "input_tokens": ..., "output_tokens": ..., "cache_read_tokens": ..., "cache_write_tokens": ...,
@@ -61,6 +62,17 @@ TASK_TYPES: frozenset[str] = frozenset(
     {"pr_review", "deliberation", "build", "chat", "dispatch_mgmt", "unknown"}
 )
 
+# Canonical completion_status values per Phase 1 cutover-gate dispatch
+# 2026-05-27 (Aiden CONCUR-with-clarification on Atlas's PR #1207).
+# Closes the observability gate for Dave's first-customer cutover —
+# operator can tell whether the cost was spent on work that completed,
+# a half-finished spawn, a timeout, or a user-interrupted run.
+# Same explicit-"unknown"-vs-silent-default discipline as the two
+# enumerations above.
+COMPLETION_STATUSES: frozenset[str] = frozenset(
+    {"success", "fail", "timeout", "interrupted", "unknown"}
+)
+
 
 @dataclass(frozen=True)
 class SpawnAttributionEntry:
@@ -75,6 +87,7 @@ class SpawnAttributionEntry:
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
     cost_usd: float = 0.0
+    completion_status: str = "unknown"  # one of COMPLETION_STATUSES
 
 
 class SpawnAttributionError(ValueError):
@@ -88,6 +101,7 @@ def log_spawn_attribution(
     callsign: str,
     model: str,
     task_type: str = "unknown",
+    completion_status: str = "unknown",
     input_tokens: int = 0,
     output_tokens: int = 0,
     cache_read_tokens: int = 0,
@@ -106,6 +120,11 @@ def log_spawn_attribution(
     integration land in stages — early-stage dispatchers can omit task_type
     until classification logic is built; explicit "unknown" tag is honest
     rather than misclassifying a build as a chat.
+
+    `completion_status` MUST be in COMPLETION_STATUSES. Default "unknown"
+    lets the dispatcher land before completion-classification logic is wired
+    (e.g. when the writer fires at dispatch-time before the spawn finishes).
+    Caller should re-emit / patch with the real status once the spawn ends.
     """
     if source_type not in SOURCE_TYPES:
         raise SpawnAttributionError(
@@ -114,6 +133,11 @@ def log_spawn_attribution(
     if task_type not in TASK_TYPES:
         raise SpawnAttributionError(
             f"task_type {task_type!r} not in TASK_TYPES {sorted(TASK_TYPES)}"
+        )
+    if completion_status not in COMPLETION_STATUSES:
+        raise SpawnAttributionError(
+            f"completion_status {completion_status!r} not in "
+            f"COMPLETION_STATUSES {sorted(COMPLETION_STATUSES)}"
         )
     path = log_path or DEFAULT_ATTRIBUTION_LOG
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -130,6 +154,7 @@ def log_spawn_attribution(
         cache_read_tokens=cache_read_tokens,
         cache_write_tokens=cache_write_tokens,
         cost_usd=cost_usd,
+        completion_status=completion_status,
     )
     with path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(asdict(entry)) + "\n")
@@ -206,4 +231,25 @@ def aggregate_by_task_type(entries: list[dict[str, Any]]) -> dict[str, dict[str,
     return {
         k: {"cost_usd_sum": round(v["cost_usd_sum"], 6), "spawn_count": int(v["spawn_count"])}
         for k, v in by_task.items()
+    }
+
+
+def aggregate_by_completion_status(entries: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Group attribution events by completion_status. Returns
+    {completion_status: {cost_usd_sum, spawn_count}}.
+
+    Phase 1 cutover-gate dispatch (Aiden's CONCUR-with-clarification on
+    Atlas's PR #1207) — closes the observability gate for Dave's first-
+    customer cutover. Surfaces cost-of-failure: how much spend went to
+    successful spawns vs fails vs timeouts vs interrupted runs.
+    """
+    by_status: dict[str, dict[str, float]] = {}
+    for e in entries:
+        cs = e.get("completion_status", "unknown")
+        bucket = by_status.setdefault(cs, {"cost_usd_sum": 0.0, "spawn_count": 0})
+        bucket["cost_usd_sum"] += float(e.get("cost_usd", 0.0))
+        bucket["spawn_count"] += 1
+    return {
+        k: {"cost_usd_sum": round(v["cost_usd_sum"], 6), "spawn_count": int(v["spawn_count"])}
+        for k, v in by_status.items()
     }

--- a/supabase/migrations/20260527_keiracom_spawn_attribution_completion_status.sql
+++ b/supabase/migrations/20260527_keiracom_spawn_attribution_completion_status.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- 20260527_keiracom_spawn_attribution_completion_status.sql
+--
+-- Phase 1 cutover-gate observability extension — adds completion_status
+-- column to the keiracom_spawn_attribution table (created by PR #1207's
+-- 20260527_keiracom_spawn_attribution.sql).
+--
+-- Per Aiden's CONCUR-with-clarification on PR #1207 + Elliot dispatch
+-- 2026-05-27: closes the observability gate for Dave's first-customer
+-- cutover by surfacing cost-of-failure (how much spend went to successful
+-- spawns vs fails vs timeouts vs interrupted runs).
+--
+-- Companion to src/keiracom_system/attribution/logger.py
+-- COMPLETION_STATUSES frozenset.
+--
+-- bd: Agency_OS-uik (this PR is a sibling extension, not a new KEI).
+--
+-- KEI-87 bypass: SET LOCAL agency_os.callsign = 'dave' required for
+-- public-schema table ALTER.
+-- ============================================================================
+
+SET LOCAL agency_os.callsign = 'dave';
+
+ALTER TABLE public.keiracom_spawn_attribution
+    ADD COLUMN IF NOT EXISTS completion_status TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (completion_status IN ('success', 'fail', 'timeout', 'interrupted', 'unknown'));
+
+-- Group-by-completion_status queries (cost-of-failure breakdown for the
+-- daily CEO rollup). Same shape as the existing source_type / task_type /
+-- callsign indexes from the parent migration.
+CREATE INDEX IF NOT EXISTS idx_keiracom_spawn_attribution_completion_status_ts
+    ON public.keiracom_spawn_attribution (completion_status, ts DESC);
+
+COMMENT ON COLUMN public.keiracom_spawn_attribution.completion_status IS
+    'Phase 1 cutover-gate observability — outcome of the spawn (success/fail/'
+    'timeout/interrupted/unknown). Default unknown lets dispatch-time writers '
+    'land before completion-classification logic is wired; callers should '
+    'patch with the real status once the spawn ends.';

--- a/tests/keiracom_system/attribution/test_logger.py
+++ b/tests/keiracom_system/attribution/test_logger.py
@@ -16,9 +16,11 @@ from pathlib import Path
 import pytest
 
 from src.keiracom_system.attribution import (
+    COMPLETION_STATUSES,
     SOURCE_TYPES,
     TASK_TYPES,
     SpawnAttributionEntry,
+    aggregate_by_completion_status,
     load_attribution_last_24h,
     log_spawn_attribution,
 )
@@ -284,3 +286,103 @@ def test_aggregate_by_callsign_sums_cost_and_counts_spawns():
     assert out["atlas"]["cost_usd_sum"] == 0.8
     assert out["atlas"]["spawn_count"] == 2
     assert out["elliot"]["cost_usd_sum"] == 0.1
+
+
+# ---------- completion_status (Phase 1 cutover-gate, Agency_OS-vq7k) ----------
+
+
+def test_completion_statuses_enumerated_to_five():
+    """Phase 1 cutover-gate dispatch — outcome enum locked."""
+    assert {"success", "fail", "timeout", "interrupted", "unknown"} == COMPLETION_STATUSES
+
+
+def test_log_spawn_attribution_persists_completion_status(tmp_path: Path):
+    log = tmp_path / "attr.jsonl"
+    entry = log_spawn_attribution(
+        source_type="cron",
+        source_id="some-timer",
+        callsign="scout",
+        model="claude-opus-4-7",
+        completion_status="success",
+        log_path=log,
+    )
+    assert entry.completion_status == "success"
+    raw = json.loads(log.read_text().strip())
+    assert raw["completion_status"] == "success"
+
+
+def test_log_spawn_attribution_defaults_completion_status_to_unknown(tmp_path: Path):
+    """completion_status defaults to 'unknown' when caller omits — explicit
+    unknown tag lets dispatch-time writers land before completion-classification
+    logic is wired."""
+    log = tmp_path / "attr.jsonl"
+    entry = log_spawn_attribution(
+        source_type="inbox",
+        source_id="/tmp/telegram-relay-scout/inbox/x.json",
+        callsign="scout",
+        model="claude-opus-4-7",
+        log_path=log,
+    )
+    assert entry.completion_status == "unknown"
+
+
+def test_log_spawn_attribution_rejects_unknown_completion_status(tmp_path: Path):
+    """Same discipline as source_type + task_type — silent default to a real
+    completion_status is a BUG. Unknown enum value MUST raise."""
+    log = tmp_path / "attr.jsonl"
+    with pytest.raises(SpawnAttributionError) as excinfo:
+        log_spawn_attribution(
+            source_type="cron",
+            source_id="some-timer",
+            callsign="scout",
+            model="claude-opus-4-7",
+            completion_status="partial",  # not in COMPLETION_STATUSES
+            log_path=log,
+        )
+    assert "completion_status" in str(excinfo.value)
+    # Failed call must not have written anything.
+    assert not log.exists() or log.read_text() == ""
+
+
+def test_log_spawn_attribution_accepts_all_completion_statuses(tmp_path: Path):
+    """All five enum values land cleanly."""
+    log = tmp_path / "attr.jsonl"
+    for status in sorted(COMPLETION_STATUSES):
+        log_spawn_attribution(
+            source_type="cron",
+            source_id="t",
+            callsign="scout",
+            model="claude-opus-4-7",
+            completion_status=status,
+            log_path=log,
+        )
+    lines = log.read_text().strip().splitlines()
+    statuses_written = {json.loads(line)["completion_status"] for line in lines}
+    assert statuses_written == COMPLETION_STATUSES
+
+
+def test_aggregate_by_completion_status_sums_cost_and_counts_spawns():
+    entries = [
+        {"completion_status": "success", "callsign": "atlas", "cost_usd": 0.5},
+        {"completion_status": "success", "callsign": "max", "cost_usd": 0.3},
+        {"completion_status": "fail", "callsign": "atlas", "cost_usd": 2.0},
+        {"completion_status": "timeout", "callsign": "elliot", "cost_usd": 1.0},
+        {"completion_status": "interrupted", "callsign": "scout", "cost_usd": 0.1},
+    ]
+    out = aggregate_by_completion_status(entries)
+    assert out["success"]["cost_usd_sum"] == 0.8
+    assert out["success"]["spawn_count"] == 2
+    assert out["fail"]["cost_usd_sum"] == 2.0
+    assert out["fail"]["spawn_count"] == 1
+    assert out["timeout"]["cost_usd_sum"] == 1.0
+    assert out["interrupted"]["cost_usd_sum"] == 0.1
+
+
+def test_aggregate_by_completion_status_handles_missing_fields():
+    """Missing completion_status defaults to 'unknown' in aggregation —
+    mirrors task_type / source_type behaviour."""
+    entries = [{"source_type": "slack", "callsign": "atlas", "cost_usd": 0.5}]
+    out = aggregate_by_completion_status(entries)
+    assert "unknown" in out
+    assert out["unknown"]["spawn_count"] == 1
+    assert out["unknown"]["cost_usd_sum"] == 0.5


### PR DESCRIPTION
## Summary

Per Elliot dispatch 2026-05-27 + Aiden CONCUR-with-clarification on Atlas's PR #1207. Extends the per-spawn cost-attribution JSONL with `completion_status` field. **Closes Aiden's observability gate for Dave's first-customer cutover** — operator can now tell whether spend went to successful spawns vs fails vs timeouts vs interrupted runs.

Per Aiden's CONCUR note: existing JSONL already writes `spawn_reason` (via `source_type`), `model_selected` (via `model` + `task_type`), `budget_gate_outcome` (via `source_type`). **`completion_status` closes the gap.**

**Filed under:** Agency_OS-vq7k (P1, Phase 1 cutover gate).

## Values

| Status | Meaning |
|---|---|
| `success` | Spawn completed its work cleanly |
| `fail` | Spawn errored out / hit a hard block |
| `timeout` | Spawn exceeded its hard token-time ceiling per the AGENT-SIDE gate |
| `interrupted` | User-interrupted run (Ctrl-C, /kill, etc.) |
| `unknown` | Staged-rollout default (matches `task_type` discipline — explicit unknown is honest; silent default to a real status is a BUG) |

## What lands (4 files, +190 LoC)

| File | Change |
|---|---|
| `src/keiracom_system/attribution/logger.py` | New `COMPLETION_STATUSES` frozenset + `SpawnAttributionEntry.completion_status` field + validation in `log_spawn_attribution` + new `aggregate_by_completion_status` helper |
| `src/keiracom_system/attribution/__init__.py` | Re-export `COMPLETION_STATUSES` + `aggregate_by_completion_status` |
| `supabase/migrations/20260527_keiracom_spawn_attribution_completion_status.sql` | `ALTER TABLE ADD COLUMN completion_status TEXT NOT NULL DEFAULT 'unknown'` with CHECK constraint mirroring the frozenset + new group-by-status index |
| `tests/keiracom_system/attribution/test_logger.py` | +7 tests covering enum lock, persist/default/reject paths, all-five-values, aggregator sum+count + missing-field handling |

## Test plan

- [x] `python3 -m pytest tests/keiracom_system/attribution/test_logger.py -q` → **25 passed in 0.27s** (18 pre-existing + 7 new)
- [x] `ruff check` → All checks passed
- [x] `ruff format --check` → 4 files already formatted
- [x] Negative-path tests included: `test_log_spawn_attribution_rejects_unknown_completion_status` (per `feedback_negative_path_test_before_approve`)
- [x] All-five-values smoke (`test_log_spawn_attribution_accepts_all_completion_statuses`)
- [ ] Reviewer: confirm the 5-value enum is correct (dispatch listed 4 — success/fail/timeout/interrupted; I added "unknown" per the established `task_type` staged-rollout pattern)

## Pattern consistency with PR #1207

The dispatch-time discipline established by PR #1207 is preserved exactly:
- Frozenset of canonical values (`COMPLETION_STATUSES` mirrors `SOURCE_TYPES` + `TASK_TYPES`)
- Default = `"unknown"` for staged rollout (matches `task_type` default)
- Validation raises `SpawnAttributionError` on invalid value (matches `source_type` discipline)
- Postgres CHECK constraint mirrors the frozenset (matches `task_type` migration shape)
- Group-by-status index for the daily rollup (matches existing 3 indexes)
- Aggregator helper mirrors `aggregate_by_task_type` + `aggregate_by_source_type` + `aggregate_by_callsign` exactly

## Scope discipline (per `feedback_split_orthogonal_scope`)

- Adds `completion_status` only — does NOT touch `source_type` / `task_type` / cost computation / aggregator-by-callsign
- Does NOT auto-classify `completion_status` from spawn outcome — caller responsibility (matches existing `source_type` / `task_type` discipline); classification logic is a separate dispatch
- Does NOT update `agency_cost_rollup.py` to surface `completion_status` breakdown — separate dispatch (the aggregator helper is here ready to be wired)

## Gate alignment (per CONCUR-GATE RULE)

**Does this satisfy the gate?** Yes — COST-TELEMETRY: "per-task-type attribution" now extended with completion-outcome attribution. Plus per Aiden's framing this is the named close of his observability gate for first-customer cutover. Cat 21 lever 23 LAUNCH-BLOCKER follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

bd: Agency_OS-vq7k. Closes on merge.