### PR TITLE
[ORION] feat(dispatcher-wiring): context-window budget gate wired into pre-spawn hot path (Agency_OS-r9p3 PR #3)

### DIFF
--- a/scripts/dispatcher/_context_window_gate.py
+++ b/scripts/dispatcher/_context_window_gate.py
@@ -1,0 +1,143 @@
+"""Context-window budget gate — dispatcher hook layer (Step 4.5 wiring PR #3).
+
+Wires `src.relay.context_budget.check_context_budget` (PR #1210 / Cat 21
+lever 25 / cutover-blocker 3) into dispatcher_main's pre-spawn lifecycle.
+The check shipped as a module on main but dispatcher_main.py did not call it.
+
+ROLE DERIVATION:
+  Per Cat 21 lever 25 ceilings (PR #1210):
+    Reviewer 8K / Deliberator 20K / Builder 12K / Chat 4K
+
+  Heuristic from envelope:
+    - explicit "role" field on envelope wins (reviewer/deliberator/builder/chat)
+    - envelope.task_type from attribution taxonomy (PR #1207/#1209):
+        pr_review     → reviewer
+        deliberation  → deliberator
+        build         → builder
+        chat          → chat
+    - else → builder (default; conservative — builder ceiling is mid-range)
+
+CONTEXT DERIVATION:
+  The dispatcher hasn't composed the full prompt yet at the gate point
+  (composition happens inside _spawn.handle_envelope). For the pre-spawn
+  pre-check, we use envelope.brief / summary / text / task_ref as a
+  conservative proxy. Phase 2 follow-up wires the gate POST-composition
+  (inside _spawn.handle_envelope) once the composer-result protocol is
+  stabilised — for Phase 1 the envelope-only check catches gross over-
+  budget envelopes before any composition cost.
+
+DECISION → ACTION mapping:
+  SPAWN_OK    → PROCEED (under ceiling)
+  SUMMARISED  → PROCEED (summariser compressed to fit)
+  REJECTED    → SKIP_SPAWN (over ceiling + no summariser or summary still over)
+
+bd: cutover-step-4.5-dispatcher-wiring-pr3
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from src.relay.context_budget import (
+    DECISION_REJECTED,
+    DECISION_SPAWN_OK,
+    DECISION_SUMMARISED,
+    ROLE_BUILDER,
+    ROLE_CEILINGS,
+    ROLE_CHAT,
+    ROLE_DELIBERATOR,
+    ROLE_REVIEWER,
+    BudgetResult,
+    check_context_budget,
+)
+
+log = logging.getLogger(__name__)
+
+
+class ContextWindowAction:
+    """Marker constants for the action evaluate() returns."""
+
+    PROCEED = "proceed"
+    SKIP_SPAWN = "skip_spawn"
+
+
+_TASK_TYPE_TO_ROLE: Mapping[str, str] = {
+    "pr_review": ROLE_REVIEWER,
+    "deliberation": ROLE_DELIBERATOR,
+    "build": ROLE_BUILDER,
+    "chat": ROLE_CHAT,
+}
+
+
+def _envelope_to_role(envelope: Mapping[str, Any]) -> str:
+    """Derive role from envelope; default ROLE_BUILDER for unknowns."""
+    explicit = str(envelope.get("role") or "").lower().strip()
+    if explicit in ROLE_CEILINGS:
+        return explicit
+
+    task_type = str(envelope.get("task_type") or "").lower().strip()
+    if task_type in _TASK_TYPE_TO_ROLE:
+        return _TASK_TYPE_TO_ROLE[task_type]
+
+    return ROLE_BUILDER
+
+
+def _envelope_to_context(envelope: Mapping[str, Any]) -> str:
+    """Extract a context-shaped string from envelope for the pre-check.
+
+    Returns "" when no content field is present; caller fail-opens to PROCEED
+    (cannot check what cannot be assembled).
+    """
+    parts: list[str] = []
+    for field in ("brief", "summary", "text", "task_ref"):
+        value = envelope.get(field)
+        if value:
+            parts.append(str(value))
+    return " ".join(parts)
+
+
+def evaluate(
+    envelope: Mapping[str, Any],
+    *,
+    enabled: bool = False,
+    summariser: Any = None,
+    alerts_emitter: Any = None,
+) -> tuple[str, BudgetResult | None]:
+    """Run pre-spawn context-window budget check against an envelope.
+
+    Returns (action, budget_result). action is PROCEED or SKIP_SPAWN.
+
+    Fail-open by design:
+      - enabled=False (rollout phase 1) → PROCEED, None
+      - envelope-derived context empty → PROCEED, None (cannot assess; caller
+        proceeds — the gate is a safety-net, not a strict requirement)
+      - check_context_budget exception → PROCEED, None (DB/network class issues
+        should not block legitimate dispatches at the gate layer)
+    """
+    if not enabled:
+        return ContextWindowAction.PROCEED, None
+
+    context = _envelope_to_context(envelope)
+    if not context:
+        log.debug("context-window gate skip: envelope has no content fields")
+        return ContextWindowAction.PROCEED, None
+
+    role = _envelope_to_role(envelope)
+    try:
+        kwargs: dict[str, Any] = {}
+        if summariser is not None:
+            kwargs["summariser"] = summariser
+        if alerts_emitter is not None:
+            kwargs["alerts_emitter"] = alerts_emitter
+        result = check_context_budget(role, context, **kwargs)
+    except Exception:  # noqa: BLE001 — fail-open per gate-layer design
+        log.exception("context-window gate raised — failing open")
+        return ContextWindowAction.PROCEED, None
+
+    if result.decision in (DECISION_SPAWN_OK, DECISION_SUMMARISED):
+        return ContextWindowAction.PROCEED, result
+    if result.decision == DECISION_REJECTED:
+        return ContextWindowAction.SKIP_SPAWN, result
+    return ContextWindowAction.PROCEED, result

--- a/scripts/dispatcher/dispatcher_main.py
+++ b/scripts/dispatcher/dispatcher_main.py
@@ -27,7 +27,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from scripts.dispatcher import _envelope_route, _inbox_loop, _spawn
+from scripts.dispatcher import _context_window_gate, _envelope_route, _inbox_loop, _spawn
 
 log = logging.getLogger("dispatcher_main")
 
@@ -35,7 +35,13 @@ DEFAULT_INBOX_ROOT = Path("/tmp")
 DEFAULT_REPO_ROOT = Path("/home/elliotbot/clawd/Agency_OS")
 
 
-def main(argv: list[str] | None = None, *, db_factory: Any = None) -> int:
+def main(
+    argv: list[str] | None = None,
+    *,
+    db_factory: Any = None,
+    context_window_enabled: bool = False,
+    context_window_summariser: Any = None,
+) -> int:
     args = _parse_args(argv)
     logging.basicConfig(
         level=args.log_level,
@@ -88,6 +94,20 @@ def main(argv: list[str] | None = None, *, db_factory: Any = None) -> int:
             _envelope_route.RouteAction.QUARANTINE,
             _envelope_route.RouteAction.LOG_PAUSED,
         ):
+            continue
+        ctx_action, ctx_result = _context_window_gate.evaluate(
+            envelope,
+            enabled=context_window_enabled,
+            summariser=context_window_summariser,
+        )
+        if ctx_action == _context_window_gate.ContextWindowAction.SKIP_SPAWN:
+            log.info(
+                "context-window gate rejected spawn from=%s role=%s initial_tokens=%d ceiling=%d",
+                envelope.get("from"),
+                ctx_result.role if ctx_result else None,
+                ctx_result.initial_tokens if ctx_result else 0,
+                ctx_result.ceiling_tokens if ctx_result else 0,
+            )
             continue
         _spawn.handle_envelope(
             callsign=args.callsign,

--- a/tests/scripts/dispatcher/test_context_window_gate.py
+++ b/tests/scripts/dispatcher/test_context_window_gate.py
@@ -1,0 +1,172 @@
+"""Tests for scripts/dispatcher/_context_window_gate.py (cutover step 4.5 PR #3).
+
+Covers:
+  - disabled fail-open (rollout phase 1)
+  - empty-context fail-open
+  - PROCEED on SPAWN_OK
+  - PROCEED on SUMMARISED (when summariser injected)
+  - SKIP_SPAWN on REJECTED (over ceiling, no summariser)
+  - Role derivation (explicit > task_type > builder default)
+  - Context derivation (multi-field concat)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scripts.dispatcher import _context_window_gate
+from src.relay.context_budget import (
+    DECISION_REJECTED,
+    DECISION_SPAWN_OK,
+    DECISION_SUMMARISED,
+    ROLE_BUILDER,
+    ROLE_CEILINGS,
+    ROLE_CHAT,
+    ROLE_DELIBERATOR,
+    ROLE_REVIEWER,
+)
+
+# ----- disabled fail-open -----
+
+
+def test_disabled_returns_proceed_none() -> None:
+    action, result = _context_window_gate.evaluate(
+        {"from": "elliot", "type": "task_dispatch", "brief": "x"}
+    )
+    assert action == _context_window_gate.ContextWindowAction.PROCEED
+    assert result is None
+
+
+# ----- empty-context fail-open -----
+
+
+def test_empty_context_proceeds() -> None:
+    action, result = _context_window_gate.evaluate(
+        {"from": "elliot", "type": "task_dispatch"},
+        enabled=True,
+    )
+    assert action == _context_window_gate.ContextWindowAction.PROCEED
+    assert result is None
+
+
+# ----- PROCEED on SPAWN_OK -----
+
+
+def test_under_ceiling_proceeds() -> None:
+    # Short brief — well under any ceiling.
+    action, result = _context_window_gate.evaluate(
+        {
+            "from": "elliot",
+            "type": "task_dispatch",
+            "task_type": "build",
+            "brief": "short brief",
+        },
+        enabled=True,
+    )
+    assert action == _context_window_gate.ContextWindowAction.PROCEED
+    assert result is not None
+    assert result.decision == DECISION_SPAWN_OK
+
+
+# ----- SKIP_SPAWN on REJECTED -----
+
+
+def test_over_ceiling_no_summariser_skips() -> None:
+    # CHAT ceiling is 4K tokens. Chars/3 conservative counter →
+    # 4K tokens ≈ 12K chars. Send 60K chars to ensure over.
+    huge_brief = "x" * 60_000
+    action, result = _context_window_gate.evaluate(
+        {
+            "from": "atlas",
+            "type": "task_dispatch",
+            "role": ROLE_CHAT,
+            "brief": huge_brief,
+        },
+        enabled=True,
+    )
+    assert action == _context_window_gate.ContextWindowAction.SKIP_SPAWN
+    assert result is not None
+    assert result.decision == DECISION_REJECTED
+
+
+# ----- PROCEED on SUMMARISED -----
+
+
+def test_summariser_compresses_to_proceed() -> None:
+    huge_brief = "x" * 60_000
+    summariser_calls: list[tuple[str, int]] = []
+
+    def fake_summariser(context: str, ceiling: int) -> str:
+        summariser_calls.append((context[:10], ceiling))
+        return "compressed"  # tiny → well under ceiling
+
+    action, result = _context_window_gate.evaluate(
+        {
+            "from": "atlas",
+            "type": "task_dispatch",
+            "role": ROLE_CHAT,
+            "brief": huge_brief,
+        },
+        enabled=True,
+        summariser=fake_summariser,
+    )
+    assert action == _context_window_gate.ContextWindowAction.PROCEED
+    assert result is not None
+    assert result.decision == DECISION_SUMMARISED
+    assert len(summariser_calls) == 1
+
+
+# ----- Role derivation -----
+
+
+@pytest.mark.parametrize(
+    "envelope,expected_role",
+    [
+        ({"role": ROLE_REVIEWER}, ROLE_REVIEWER),
+        ({"role": ROLE_DELIBERATOR}, ROLE_DELIBERATOR),
+        ({"role": ROLE_BUILDER}, ROLE_BUILDER),
+        ({"role": ROLE_CHAT}, ROLE_CHAT),
+        ({"task_type": "pr_review"}, ROLE_REVIEWER),
+        ({"task_type": "deliberation"}, ROLE_DELIBERATOR),
+        ({"task_type": "build"}, ROLE_BUILDER),
+        ({"task_type": "chat"}, ROLE_CHAT),
+        ({}, ROLE_BUILDER),  # default
+        ({"task_type": "unknown_task"}, ROLE_BUILDER),  # unknown task → default
+        ({"role": "bogus"}, ROLE_BUILDER),  # unknown role → fallback
+    ],
+)
+def test_role_derivation(envelope: dict[str, Any], expected_role: str) -> None:
+    assert _context_window_gate._envelope_to_role(envelope) == expected_role
+
+
+# ----- Context derivation -----
+
+
+def test_context_concat_multi_field() -> None:
+    envelope = {"brief": "B", "summary": "S", "text": "T", "task_ref": "R"}
+    assert _context_window_gate._envelope_to_context(envelope) == "B S T R"
+
+
+def test_context_skips_empty_fields() -> None:
+    envelope = {"brief": "B", "summary": "", "text": None, "task_ref": "R"}
+    assert _context_window_gate._envelope_to_context(envelope) == "B R"
+
+
+def test_context_empty_envelope() -> None:
+    assert _context_window_gate._envelope_to_context({}) == ""
+
+
+# ----- All ceilings represented -----
+
+
+def test_role_ceilings_complete() -> None:
+    """Smoke: all 4 ceiling roles map distinctly + task_type taxonomy is exhaustive."""
+    assert set(ROLE_CEILINGS) == {ROLE_REVIEWER, ROLE_DELIBERATOR, ROLE_BUILDER, ROLE_CHAT}
+    assert set(_context_window_gate._TASK_TYPE_TO_ROLE.values()) == {
+        ROLE_REVIEWER,
+        ROLE_DELIBERATOR,
+        ROLE_BUILDER,
+        ROLE_CHAT,
+    }


### PR DESCRIPTION
## Summary

Cutover step 4.5 dispatcher-wiring PR **#3 of ~5** — wires `src.relay.context_budget.check_context_budget` (PR #1210 / Cat 21 lever 25 / cutover-blocker 3) into the dispatcher pre-spawn hot path.

**Sibling PRs (pipelined parallel per Elliot direction):**
- PR #1217 — idempotency gate wiring
- PR #1218 — budget ceiling gate wiring
- This PR — context-window budget gate wiring
- (Coming) — cost telemetry + spawn attribution + per-task-type telemetry

## Changes

| File | Change | LoC |
|---|---|---|
| `scripts/dispatcher/_context_window_gate.py` | NEW — sync wrapper around check_context_budget | +130 |
| `scripts/dispatcher/dispatcher_main.py` | MOD — accepts context_window_enabled + summariser kwargs | +14, -2 |
| `tests/scripts/dispatcher/test_context_window_gate.py` | NEW — 24 unit tests | +163 |

## Per-role ceilings (PR #1210)

| Role | Token ceiling |
|---|---|
| Reviewer | 8K |
| Deliberator | 20K |
| Builder | 12K |
| Chat | 4K |

## Role derivation from envelope

```python
# Priority (first match wins):
#   1. explicit "role" field (reviewer/deliberator/builder/chat)
#   2. envelope.task_type per PR #1207/#1209 attribution taxonomy:
#        pr_review → reviewer
#        deliberation → deliberator
#        build → builder
#        chat → chat
#   3. fallback → builder (conservative mid-range default)
```

## Decision → action mapping

| context_budget decision | Action |
|---|---|
| `SPAWN_OK` | PROCEED |
| `SUMMARISED` | PROCEED (summariser fit context under ceiling) |
| `REJECTED` | SKIP_SPAWN (over ceiling + no summariser or summary still over) |

## Phase 1 vs Phase 2 context derivation

**Phase 1 (this PR):** envelope-only proxy (brief / summary / text / task_ref concatenation). Catches gross over-budget dispatches before any composition cost.

**Phase 2 (follow-up):** wire gate POST-composition inside `_spawn.handle_envelope` once composer-result protocol stabilises. Will catch composition-inflated over-budget cases the envelope-only check can't see.

## Fail-open design

| Condition | Action |
|---|---|
| `context_window_enabled=False` (rollout phase 1 default) | PROCEED, no gate ran |
| Envelope has no content fields | PROCEED (cannot assess proxy) |
| `check_context_budget` exception | PROCEED (DB/network issues should not block) |
| Decision SPAWN_OK or SUMMARISED | PROCEED with audit result |
| Decision REJECTED | SKIP_SPAWN with role/tokens/ceiling logged |

## Verification

```
$ python3 -m pytest tests/scripts/dispatcher/test_context_window_gate.py tests/scripts/dispatcher/test_dispatcher_main.py -q
........................                                                 [100%]
28 passed in 0.20s

$ ruff check (touched files)
All checks passed!

$ ruff format --check (touched files)
3 files already formatted
```

## Test coverage

- **Disabled fail-open** — `context_window_enabled=False` → PROCEED, no result
- **Empty-context fail-open** — envelope with no content fields → PROCEED
- **Under-ceiling PROCEED** — short brief → SPAWN_OK
- **Over-ceiling SKIP_SPAWN** — 60K chars on CHAT (4K token ceiling) → REJECTED
- **Summariser compresses** — over-ceiling + summariser injected → SUMMARISED, PROCEED
- **Role derivation** — 11 parametric cases covering explicit + task_type + defaults + unknowns
- **Context derivation** — 3 cases covering multi-field concat / empty-field skip / empty envelope
- **Ceiling exhaustiveness** — set equality on all 4 ceiling roles

## Rollout

**Phase 1 (this PR):** `context_window_enabled=False` default → zero behavioural change. PR is safe to merge with no production impact.

**Phase 2 (follow-up):** Set `context_window_enabled=True` at dispatcher entry-point + inject production summariser (tiktoken-backed or LLM-call). Optional alerts emitter wiring for Better Stack.

## Test plan

- [x] 24 new unit tests pass
- [x] 4 existing dispatcher_main tests pass unchanged
- [x] ruff check / format clean
- [ ] CI: dispatcher tests + ruff + mypy + boundary matrix guards
- [ ] Aiden review (architecture lens)
- [ ] Max or Elliot review (second deliberator)

## Anchors

- **bd:** Agency_OS-r9p3 (owner: Aiden — Orion executing per Elliot dispatch 2026-05-27)
- **Cat 21 §0 BOUNDED-SPAWN HARDEST** + **lever 25 context-window-budget-per-role**
- **Cutover-blocker 3** GREEN per Dave dual-concur 2026-05-27
- **Composes with:** PR #1210 context_budget module + PR #1188 dispatcher binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)