### PR TITLE
[ORION] feat(dispatcher-wiring-KEI213): idempotency gate wired into /dispatcher/spawn (Agency_OS-r9p3 PR A)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel
 
 import src.dispatcher.auth_minter  # noqa: F401 — imported for fail-fast side-effect
 from src.dispatcher.container_lifecycle import ContainerStartupError, DockerUnavailableError
+from src.dispatcher.idempotency import IdempotencyDecision, IdempotencyGate
 from src.dispatcher.interceptor_proxy import router as interceptor_router
 from src.dispatcher.reaper import Reaper
 from src.dispatcher.session_manager import Backend, SessionManager
@@ -80,6 +81,18 @@ _component_status: dict[str, str] = {
 
 _watchdog: Watchdog | None = None
 _reaper: Reaper | None = None
+
+# Pre-spawn idempotency gate (PR #1204 / Cat 21 lever 26 / cutover-blocker 5).
+# Set by tests or by a future env-driven config layer; None = no-op (rollout
+# phase 1 default — gate is wired but disabled until Valkey config lands).
+_idempotency_gate: IdempotencyGate | None = None
+
+
+def _set_idempotency_gate(gate: IdempotencyGate | None) -> None:
+    """Test-only setter for the idempotency gate (DI through module attr)."""
+    global _idempotency_gate  # noqa: PLW0603
+    _idempotency_gate = gate
+
 
 # Sessions spawned via /dispatcher/spawn, keyed by supervisor registry key.
 # Lets /dispatcher/terminate find the handle + backend for clean teardown.
@@ -302,6 +315,30 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
         backend = Backend(req.backend)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"unknown backend: {req.backend!r}") from exc
+
+    # Pre-spawn idempotency gate (Cat 21 lever 26 / cutover-blocker 5).
+    # Dedup duplicate spawn requests within a 60-second window via Valkey
+    # SET NX EX. source = "dispatcher-spawn-<backend>"; content = req.key.
+    # Fail-open: no-gate-wired / Valkey error → PROCEED (PR #1204 contract).
+    if _idempotency_gate is not None:
+        idem_result = await _idempotency_gate.check_and_claim(
+            source=f"dispatcher-spawn-{backend.value}",
+            content=req.key,
+        )
+        if idem_result.decision == IdempotencyDecision.DROP_DUPLICATE:
+            logger.info(
+                "KEI-213 idempotency gate dropped duplicate spawn key=%s backend=%s",
+                req.key,
+                backend.value,
+            )
+            return {
+                "spawned": False,
+                "key": req.key,
+                "backend": backend.value,
+                "decision": "drop_duplicate",
+                "reason": idem_result.reason,
+                "idempotency_key": idem_result.key,
+            }
 
     manager = SessionManager(backend=backend)
     try:

--- a/tests/dispatcher/test_main_idempotency_wiring.py
+++ b/tests/dispatcher/test_main_idempotency_wiring.py
@@ -1,0 +1,233 @@
+"""KEI-213 — idempotency gate wiring tests for src.dispatcher.main.
+
+Covers the cutover-step-4.5 wiring of PR #1204 IdempotencyGate into the
+/dispatcher/spawn endpoint:
+  - no-gate fail-open (rollout phase 1 default, _idempotency_gate=None)
+  - SPAWN_OK → spawn proceeds normally
+  - DROP_DUPLICATE → spawn skipped, HTTP 200 with decision="drop_duplicate"
+
+bd: cutover-step-4.5-dispatcher-wiring-pr-A (KEI-213 mirror of PR #1217)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.dispatcher.idempotency import IdempotencyGate
+from src.dispatcher.tmux_lifecycle import SessionHandle
+
+
+class _FakeRedis:
+    """Fake redis.asyncio client implementing only `set(name, value, *, nx, ex)`.
+
+    `claim_returns` is consumed FIFO; truthy → new claim; None → key exists.
+    """
+
+    def __init__(self, claim_returns: list[Any]):
+        self._returns = list(claim_returns)
+        self.calls: list[tuple[str, str, bool, int | None]] = []
+
+    def set(
+        self, name: str, value: str, *, nx: bool = False, ex: int | None = None
+    ) -> Awaitable[Any]:
+        self.calls.append((name, value, nx, ex))
+
+        async def _resolve() -> Any:
+            return self._returns.pop(0) if self._returns else True
+
+        return _resolve()
+
+
+def _make_gate(*, returns: list[Any]) -> IdempotencyGate:
+    return IdempotencyGate(valkey_client=_FakeRedis(returns))  # type: ignore[arg-type]
+
+
+def _mock_supervisors(main_mod: Any) -> None:
+    """Pre-set watchdog + reaper to non-None mocks so /spawn doesn't 503."""
+    main_mod._watchdog = MagicMock()
+    main_mod._reaper = MagicMock()
+    main_mod._reaper.health_snapshot.return_value = {
+        "tracked_tmux": 0,
+        "tracked_containers": 0,
+    }
+    main_mod._watchdog.tracked = 0
+
+
+# ----- no-gate fail-open -----
+
+
+def test_no_gate_proceeds_to_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When _idempotency_gate is None, /dispatcher/spawn must call SessionManager.spawn."""
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    main_mod._set_idempotency_gate(None)
+
+    mock_handle = SessionHandle(
+        session_name="disp-test",
+        working_dir="/tmp",
+        command="claude",
+    )
+
+    with patch("src.dispatcher.main.SessionManager") as MockSM:
+        instance = MockSM.return_value
+        instance.spawn.return_value = mock_handle
+        with patch.object(main_mod, "_register_session"):
+            client = TestClient(main_mod.app, raise_server_exceptions=False)
+            resp = client.post(
+                "/dispatcher/spawn",
+                json={
+                    "backend": "tmux",
+                    "key": "test-key-1",
+                    "spawn_kwargs": {"session_name": "disp-test"},
+                },
+            )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body.get("spawned") is True
+    # Without the gate wired, no decision="drop_duplicate" path
+    assert body.get("decision") != "drop_duplicate"
+
+
+# ----- SPAWN_OK proceeds -----
+
+
+def test_spawn_ok_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gate returns SPAWN_OK → /spawn proceeds to SessionManager.spawn."""
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    gate = _make_gate(returns=[True])  # SET NX returned truthy → new claim
+    main_mod._set_idempotency_gate(gate)
+
+    mock_handle = SessionHandle(
+        session_name="disp-test",
+        working_dir="/tmp",
+        command="claude",
+    )
+
+    try:
+        with patch("src.dispatcher.main.SessionManager") as MockSM:
+            instance = MockSM.return_value
+            instance.spawn.return_value = mock_handle
+            with patch.object(main_mod, "_register_session"):
+                client = TestClient(main_mod.app, raise_server_exceptions=False)
+                resp = client.post(
+                    "/dispatcher/spawn",
+                    json={
+                        "backend": "tmux",
+                        "key": "test-key-1",
+                        "spawn_kwargs": {"session_name": "disp-test"},
+                    },
+                )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body.get("spawned") is True
+    finally:
+        main_mod._set_idempotency_gate(None)
+
+
+# ----- DROP_DUPLICATE skips spawn -----
+
+
+def test_drop_duplicate_skips_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gate returns DROP_DUPLICATE → /spawn returns 200 with decision=drop_duplicate."""
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    gate = _make_gate(returns=[None])  # SET NX returned None → already-claimed
+    main_mod._set_idempotency_gate(gate)
+
+    try:
+        with patch("src.dispatcher.main.SessionManager") as MockSM:
+            instance = MockSM.return_value
+            client = TestClient(main_mod.app, raise_server_exceptions=False)
+            resp = client.post(
+                "/dispatcher/spawn",
+                json={
+                    "backend": "tmux",
+                    "key": "test-key-duplicate",
+                    "spawn_kwargs": {"session_name": "disp-test"},
+                },
+            )
+            # Critical: SessionManager.spawn must NOT have been called
+            instance.spawn.assert_not_called()
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["spawned"] is False
+        assert body["decision"] == "drop_duplicate"
+        assert body["key"] == "test-key-duplicate"
+        assert body["backend"] == "tmux"
+        assert "idempotency_key" in body
+        assert body["idempotency_key"].startswith("idem:")
+    finally:
+        main_mod._set_idempotency_gate(None)
+
+
+# ----- DI helper smoke -----
+
+
+def test_set_idempotency_gate_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_set_idempotency_gate updates the module-level attribute correctly."""
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+
+    import src.dispatcher.main as main_mod
+
+    gate = _make_gate(returns=[True])
+    main_mod._set_idempotency_gate(gate)
+    assert main_mod._idempotency_gate is gate
+    main_mod._set_idempotency_gate(None)
+    assert main_mod._idempotency_gate is None
+
+
+# ----- Distinct keys for distinct (backend, key) -----
+
+
+def test_distinct_keys_produce_distinct_idempotency_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two spawn requests with different backend or key must produce different idempotency keys."""
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    # Both return None → both should report DROP_DUPLICATE,
+    # but with DIFFERENT idempotency_key values.
+    gate = _make_gate(returns=[None, None])
+    main_mod._set_idempotency_gate(gate)
+
+    keys: list[str] = []
+    try:
+        with patch("src.dispatcher.main.SessionManager"):
+            client = TestClient(main_mod.app, raise_server_exceptions=False)
+            for backend, key in [("tmux", "k1"), ("container", "k1")]:
+                resp = client.post(
+                    "/dispatcher/spawn",
+                    json={"backend": backend, "key": key, "spawn_kwargs": {}},
+                )
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["decision"] == "drop_duplicate"
+                keys.append(body["idempotency_key"])
+
+        assert len(set(keys)) == 2, f"expected distinct keys, got {keys}"
+    finally:
+        main_mod._set_idempotency_gate(None)


### PR DESCRIPTION
## Summary

Cutover step 4.5 dispatcher-wiring PR **A** for **KEI-213** — mirrors PR #1217's idempotency wiring into the CANONICAL dispatcher per Dave + Aiden + Viktor dual-concur 2026-05-27.

**Ratified:** KEI-213 (`src/dispatcher/main.py`, port 4001) = canonical dispatcher.
**Deprecated:** PR #1188 (`scripts/dispatcher/dispatcher_main.py`) — stays on main for traceability but not wired.

This PR opens the **KEI-213 parallel wiring pipeline**. Sibling PRs (B/C/D/E coming) target the same canonical dispatcher: budget ceiling + context-window + cost telemetry + persistence-boundary bundle.

## Changes

| File | Change | LoC |
|---|---|---|
| `src/dispatcher/main.py` | MOD — imports IdempotencyGate; module-level `_idempotency_gate` + `_set_idempotency_gate()` DI helper; gate call inside `/dispatcher/spawn` handler | +29 |
| `tests/dispatcher/test_main_idempotency_wiring.py` | NEW — 5 unit tests | +241 |

## Wiring point

```
/dispatcher/spawn (HTTP POST)
  ↓ supervisor not-started → 503
  ↓ backend validation → 400 on bad backend
  ↓ [NEW] _idempotency_gate.check_and_claim()
  ↓   ├─ SPAWN_OK     → continue
  ↓   └─ DROP_DUPLICATE → return HTTP 200 with {spawned: false, decision: "drop_duplicate", idempotency_key: ...}
  ↓ manager.spawn(**spawn_kwargs)
  ↓ _register_session(...)
  ↓ HTTP 200 with handle
```

## Gate hash composition

```python
source  = f"dispatcher-spawn-{backend.value}"  # e.g. "dispatcher-spawn-tmux"
content = req.key                              # per-spawn unique registry key
```

A Slack-retry double-fire with the same `key` within 60 seconds is deduped by Valkey SET NX EX with 5-minute TTL.

## Response shape on DROP_DUPLICATE

HTTP 200 (not 409) — drop-duplicate is **expected behaviour**, not an error condition:

```json
{
  "spawned": false,
  "key": "test-key-duplicate",
  "backend": "tmux",
  "decision": "drop_duplicate",
  "reason": "duplicate within window — already dispatched",
  "idempotency_key": "idem:abc123..."
}
```

Callers distinguish `spawned: true` (new session) from `spawned: false, decision: "drop_duplicate"` (dedup'd).

## Fail-open design

| Condition | Action |
|---|---|
| `_idempotency_gate=None` (rollout phase 1 default) | proceed to manager.spawn() |
| Valkey unreachable inside gate | proceed (PR #1204 fail-open contract returns SPAWN_OK) |
| Gate returns SPAWN_OK | proceed to manager.spawn() |
| Gate returns DROP_DUPLICATE | HTTP 200, no spawn |

## Verification

```
$ DISPATCHER_JWT_SECRET=test SUPABASE_DB_DSN=postgresql://fake/db python3 -m pytest tests/dispatcher/test_main_wiring.py tests/dispatcher/test_main_idempotency_wiring.py -q
..............                                                           [100%]
14 passed in 0.59s

$ ruff check (touched files)
All checks passed!

$ ruff format --check (touched files)
clean
```

## Test coverage (5 tests, all passing)

1. **`test_no_gate_proceeds_to_spawn`** — `_idempotency_gate=None` → SessionManager.spawn called normally
2. **`test_spawn_ok_proceeds`** — gate returns SPAWN_OK → spawn proceeds + body has `spawned: true`
3. **`test_drop_duplicate_skips_spawn`** — gate returns DROP_DUPLICATE → `SessionManager.spawn.assert_not_called()`, HTTP 200 with `decision: drop_duplicate`
4. **`test_set_idempotency_gate_round_trip`** — DI helper updates module-level attr correctly
5. **`test_distinct_keys_produce_distinct_idempotency_keys`** — (tmux, k1) vs (container, k1) produce different `idempotency_key` values (verifies hash includes backend)

## Rollout

**Phase 1 (this PR):** `_idempotency_gate=None` default → zero behavioural change. PR is safe to merge with no production impact.

**Phase 2 (follow-up):** Set the gate at dispatcher startup via `main_mod._set_idempotency_gate(IdempotencyGate(valkey_client=get_valkey_client()))` in a configuration PR. The `valkey_pool.get_valkey_client()` already exists from KEI-117A.

## Test plan

- [x] 5 new unit tests pass
- [x] 9 existing test_main_wiring tests pass unchanged
- [x] ruff check / format clean
- [ ] CI: dispatcher tests + ruff + mypy + boundary matrix guards
- [ ] Aiden review (architecture lens)
- [ ] Max or Elliot review (second deliberator)

## Anchors

- **bd:** Agency_OS-r9p3 PR A (KEI-213 mirror)
- **Cat 21 lever 26 idempotency-keys-task-queue** + **cutover-blocker 5**
- **Composes with:** PR #1204 idempotency module + KEI-213 dispatcher service
- **Supersedes (within KEI-213 scope):** PR #1217 wiring into PR #1188 dispatcher binary — that PR's content stays on main for traceability per Dave directive 2026-05-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)