### PR TITLE
[ORION] feat(dispatcher-wiring-KEI213): context-window gate wired into interceptor_proxy (Agency_OS-r9p3 PR C)

### DIFF
--- a/src/dispatcher/interceptor_proxy.py
+++ b/src/dispatcher/interceptor_proxy.py
@@ -35,6 +35,14 @@ from src.dispatcher.valkey_pool import (
     get_valkey_client,
     tenant_rl_key,
 )
+from src.relay.context_budget import (
+    DECISION_REJECTED,
+    DECISION_SPAWN_OK,
+    DECISION_SUMMARISED,
+    ROLE_BUILDER,
+    ROLE_CEILINGS,
+    check_context_budget,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +73,50 @@ SPEND_NAMESPACE_PREFIX: Final = "spend"
 RATE_WINDOW_SECONDS: Final = 60
 LITELLM_URL_ENV: Final = "LITELLM_URL"
 DEFAULT_LITELLM_URL: Final = "http://127.0.0.1:4000/v1/chat/completions"
+
+# Context-window budget gate (PR #1210 / Cat 21 lever 25 / cutover-blocker 3).
+# Disabled by default; tests + production startup enable via env or DI.
+CONTEXT_WINDOW_ENABLED_ENV: Final = "DISPATCHER_CONTEXT_WINDOW_ENABLED"
+
+# Public toggle — production reads via env at startup; tests flip directly.
+context_window_enabled: bool = os.environ.get(CONTEXT_WINDOW_ENABLED_ENV, "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
+
+def _body_to_context(body: dict) -> str:
+    """Extract a context-shaped string from an OpenAI-style chat-completion body.
+
+    Concatenates each message's role + content. Returns "" when no messages.
+    """
+    messages = body.get("messages") or []
+    if not isinstance(messages, list):
+        return ""
+    parts: list[str] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "")
+        content = msg.get("content")
+        if isinstance(content, str):
+            parts.append(f"{role}: {content}")
+        elif isinstance(content, list):
+            # OpenAI multimodal: list of content blocks; pull text fields.
+            for block in content:
+                if isinstance(block, dict) and isinstance(block.get("text"), str):
+                    parts.append(f"{role}: {block['text']}")
+    return "\n".join(parts)
+
+
+def _body_to_role(body: dict) -> str:
+    """Derive context-budget role from body; default ROLE_BUILDER for unknowns."""
+    explicit = str(body.get("dispatcher_role") or "").lower().strip()
+    if explicit in ROLE_CEILINGS:
+        return explicit
+    return ROLE_BUILDER
+
 
 # ---------------------------------------------------------------------------
 # Decisions
@@ -283,6 +335,59 @@ async def intercept_request(
             payload={"error": "rate_limit_exceeded", "tier": tier},
             headers={"Retry-After": str(RATE_WINDOW_SECONDS)},
         )
+
+    # Context-window budget gate (Cat 21 lever 25 / cutover-blocker 3).
+    # Fires AFTER governance + spend + rate-limit (cheaper checks first), BEFORE
+    # forward to LiteLLM (token-counting is the most expensive check).
+    if context_window_enabled:
+        context_str = _body_to_context(body)
+        if context_str:
+            role = _body_to_role(body)
+            try:
+                ctx_result = check_context_budget(role, context_str)
+            except Exception:  # noqa: BLE001 — fail-open per gate-layer design
+                logger.exception("KEI-213 context-window gate raised — failing open")
+                ctx_result = None
+            if ctx_result is not None and ctx_result.decision == DECISION_REJECTED:
+                await _log_event(
+                    tenant_id,
+                    "deny_context_window",
+                    f"role={role} tokens={ctx_result.initial_tokens} ceiling={ctx_result.ceiling_tokens}",
+                    model,
+                    None,
+                    None,
+                    None,
+                    _ms_since(start),
+                    insert_fn,
+                )
+                return InterceptorDecision(
+                    allowed=False,
+                    decision="deny_context_window",
+                    reason="context_window_exceeded",
+                    status_code=413,
+                    payload={
+                        "error": "context_window_exceeded",
+                        "role": role,
+                        "initial_tokens": ctx_result.initial_tokens,
+                        "ceiling_tokens": ctx_result.ceiling_tokens,
+                    },
+                )
+            if ctx_result is not None and ctx_result.decision == DECISION_SUMMARISED:
+                # Summariser fit context under ceiling — proceed with summarised body.
+                # Phase 1: no summariser wired so this branch unreachable; preserved
+                # for Phase 2 when production summariser lands.
+                logger.info(
+                    "KEI-213 context-window gate summarised context role=%s %d→%d",
+                    role,
+                    ctx_result.initial_tokens,
+                    ctx_result.final_tokens,
+                )
+            elif ctx_result is not None and ctx_result.decision == DECISION_SPAWN_OK:
+                logger.debug(
+                    "KEI-213 context-window gate passed role=%s tokens=%d",
+                    role,
+                    ctx_result.initial_tokens,
+                )
 
     try:
         result = await (forward_fn(body) if forward_fn else _forward_to_litellm(body))

--- a/tests/dispatcher/test_interceptor_context_window_wiring.py
+++ b/tests/dispatcher/test_interceptor_context_window_wiring.py
@@ -1,0 +1,202 @@
+"""KEI-213 — context-window gate wiring tests for src.dispatcher.interceptor_proxy.
+
+Covers the cutover-step-4.5 wiring of PR #1210 check_context_budget into
+intercept_request:
+  - disabled fail-open (rollout phase 1 default)
+  - empty-context fail-open (body has no messages)
+  - under-ceiling proceeds → forward called
+  - over-ceiling REJECTED → InterceptorDecision(allowed=False, deny_context_window)
+  - role derivation from body.dispatcher_role
+  - body_to_context multi-message concat
+
+bd: cutover-step-4.5-dispatcher-wiring-pr-C (KEI-213 mirror of PR #1219)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import Any
+
+import pytest
+
+from src.dispatcher import interceptor_proxy
+from src.relay.context_budget import ROLE_BUILDER, ROLE_CHAT
+
+
+async def _fake_forward(_body: dict) -> dict:
+    """Fake forward that returns a minimal allow-shaped response."""
+    return {"usage": {"prompt_tokens": 1, "completion_tokens": 1}, "cost_cents_aud": 0}
+
+
+async def _fake_insert(*_args: Any, **_kwargs: Any) -> Awaitable[None]:
+    """Fake insert_fn for the _log_event sink — no-op."""
+    return None  # type: ignore[return-value]
+
+
+def _patch_pipeline_pass_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make governance + spend + rate checks all pass so we exercise the new gate."""
+    from src.dispatcher import governance_proxy
+
+    # interceptor_proxy imported `evaluate` by-name; patch THERE, not the source module
+    monkeypatch.setattr(
+        interceptor_proxy,
+        "evaluate",
+        lambda body: governance_proxy.ProxyDecision(allowed=True, reason=None),
+    )
+
+    async def _spend_ok(*_args: Any, **_kwargs: Any) -> tuple[bool, int]:
+        return True, 0
+
+    async def _rate_ok(*_args: Any, **_kwargs: Any) -> tuple[bool, int]:
+        return True, 0
+
+    monkeypatch.setattr(interceptor_proxy, "_check_spend_budget", _spend_ok)
+    monkeypatch.setattr(interceptor_proxy, "_check_rate_limit", _rate_ok)
+
+
+# ----- disabled fail-open -----
+
+
+@pytest.mark.asyncio
+async def test_disabled_proceeds_to_forward(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When context_window_enabled=False, gate is bypassed."""
+    _patch_pipeline_pass_through(monkeypatch)
+    monkeypatch.setattr(interceptor_proxy, "context_window_enabled", False)
+
+    body = {
+        "tenant_id": "t1",
+        "model": "claude",
+        "messages": [{"role": "user", "content": "x" * 100_000}],  # huge — would reject
+    }
+    decision = await interceptor_proxy.intercept_request(
+        body, forward_fn=_fake_forward, insert_fn=_fake_insert
+    )
+    # Gate disabled → no context-window denial.
+    assert decision.allowed is True
+    assert decision.decision == "allow"
+
+
+# ----- empty-context fail-open -----
+
+
+@pytest.mark.asyncio
+async def test_empty_context_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Body without messages → gate skipped, forward called."""
+    _patch_pipeline_pass_through(monkeypatch)
+    monkeypatch.setattr(interceptor_proxy, "context_window_enabled", True)
+
+    body = {"tenant_id": "t1", "model": "claude"}  # no messages
+    decision = await interceptor_proxy.intercept_request(
+        body, forward_fn=_fake_forward, insert_fn=_fake_insert
+    )
+    assert decision.allowed is True
+    assert decision.decision == "allow"
+
+
+# ----- under-ceiling proceeds -----
+
+
+@pytest.mark.asyncio
+async def test_under_ceiling_proceeds_to_forward(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Short context → SPAWN_OK → forward called."""
+    _patch_pipeline_pass_through(monkeypatch)
+    monkeypatch.setattr(interceptor_proxy, "context_window_enabled", True)
+
+    body = {
+        "tenant_id": "t1",
+        "model": "claude",
+        "dispatcher_role": ROLE_BUILDER,
+        "messages": [{"role": "user", "content": "short message"}],
+    }
+    decision = await interceptor_proxy.intercept_request(
+        body, forward_fn=_fake_forward, insert_fn=_fake_insert
+    )
+    assert decision.allowed is True
+    assert decision.decision == "allow"
+
+
+# ----- over-ceiling REJECTED -----
+
+
+@pytest.mark.asyncio
+async def test_over_ceiling_returns_deny_context_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CHAT role ceiling 4K tokens; 60K chars > ceiling → REJECTED."""
+    _patch_pipeline_pass_through(monkeypatch)
+    monkeypatch.setattr(interceptor_proxy, "context_window_enabled", True)
+
+    body = {
+        "tenant_id": "t1",
+        "model": "claude",
+        "dispatcher_role": ROLE_CHAT,
+        "messages": [{"role": "user", "content": "x" * 60_000}],
+    }
+    decision = await interceptor_proxy.intercept_request(
+        body, forward_fn=_fake_forward, insert_fn=_fake_insert
+    )
+    assert decision.allowed is False
+    assert decision.decision == "deny_context_window"
+    assert decision.status_code == 413
+    assert decision.payload is not None
+    assert decision.payload["error"] == "context_window_exceeded"
+    assert decision.payload["role"] == ROLE_CHAT
+    assert decision.payload["initial_tokens"] > decision.payload["ceiling_tokens"]
+
+
+# ----- role derivation -----
+
+
+@pytest.mark.parametrize(
+    "body,expected_role",
+    [
+        ({"dispatcher_role": "reviewer"}, "reviewer"),
+        ({"dispatcher_role": "deliberator"}, "deliberator"),
+        ({"dispatcher_role": "builder"}, "builder"),
+        ({"dispatcher_role": "chat"}, "chat"),
+        ({"dispatcher_role": "bogus"}, ROLE_BUILDER),
+        ({}, ROLE_BUILDER),
+    ],
+)
+def test_body_to_role(body: dict, expected_role: str) -> None:
+    assert interceptor_proxy._body_to_role(body) == expected_role
+
+
+# ----- body_to_context concat -----
+
+
+def test_body_to_context_multi_message() -> None:
+    body = {
+        "messages": [
+            {"role": "system", "content": "S"},
+            {"role": "user", "content": "U"},
+            {"role": "assistant", "content": "A"},
+        ]
+    }
+    result = interceptor_proxy._body_to_context(body)
+    assert "system: S" in result
+    assert "user: U" in result
+    assert "assistant: A" in result
+
+
+def test_body_to_context_empty() -> None:
+    assert interceptor_proxy._body_to_context({}) == ""
+    assert interceptor_proxy._body_to_context({"messages": []}) == ""
+    assert interceptor_proxy._body_to_context({"messages": "not-a-list"}) == ""
+
+
+def test_body_to_context_multimodal_blocks() -> None:
+    """OpenAI multimodal: content is a list of blocks; gate pulls text fields."""
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "block 1"},
+                    {"type": "text", "text": "block 2"},
+                    {"type": "image_url", "image_url": "https://x"},  # no text → skipped
+                ],
+            }
+        ]
+    }
+    result = interceptor_proxy._body_to_context(body)
+    assert "user: block 1" in result
+    assert "user: block 2" in result


### PR DESCRIPTION
## Summary

Cutover step 4.5 dispatcher-wiring PR **C** for **KEI-213** — wires `check_context_budget` (PR #1210 / Cat 21 lever 25 / cutover-blocker 3) into `interceptor_proxy.intercept_request` per Dave + Aiden + Viktor dual-concur 2026-05-27.

**Sibling KEI-213 PRs (parallel pipeline):**
- PR #1222 (A) — idempotency gate
- PR #1223 (B) — budget ceiling gate
- This PR (C) — context-window gate (interceptor_proxy LLM-call layer)
- (Coming) D — spawn attribution + per-task-type
- (Coming) E — wiring inventory + CI guard update

## Why interceptor_proxy, not main.py

Context-window budget gates the **per-LLM-call** context size. In KEI-213 the LLM-call pipeline lives in `interceptor_proxy.intercept_request` (the governance + spend + rate + forward chain). main.py's `/dispatcher/spawn` gates the **per-session** spawn, not per-call.

## Changes

| File | Change | LoC |
|---|---|---|
| `src/dispatcher/interceptor_proxy.py` | MOD — imports check_context_budget + decision/role constants; `context_window_enabled` toggle (env-driven); `_body_to_context` + `_body_to_role` helpers; gate call between rate-limit + forward | +85 |
| `tests/dispatcher/test_interceptor_context_window_wiring.py` | NEW — 13 unit tests | +222 |

## Pipeline order

```
intercept_request(body)
  1. governance check     ← KEI-165 governance_proxy.evaluate
  2. spend budget         ← Valkey spend:<tenant>:<month>
  3. rate limit           ← Valkey rl:<tenant>:<window>
  4. [NEW] context-window ← check_context_budget(role, context) — Cat 21 lever 25
  5. forward to LiteLLM
  6. log allow event
```

Context-window fires AFTER cheaper gates (governance/spend/rate are O(1) Valkey reads) but BEFORE the LiteLLM forward (the expensive operation). Token-counting is conservatively chars/3 estimator unless production injects tiktoken.

## Per-role ceilings (PR #1210)

| Role | Token ceiling |
|---|---|
| Reviewer | 8K |
| Deliberator | 20K |
| Builder | 12K |
| Chat | 4K |

## Role derivation

```python
explicit = body.get("dispatcher_role")  # validated against ROLE_CEILINGS
return explicit if explicit in ROLE_CEILINGS else ROLE_BUILDER  # safe default
```

## Context derivation

OpenAI chat-completion shape:

```python
body["messages"] = [
    {"role": "system", "content": "..."},
    {"role": "user", "content": "..."},      # string
    {"role": "user", "content": [             # multimodal blocks
        {"type": "text", "text": "..."},
        {"type": "image_url", "image_url": "..."},  # text-only blocks counted
    ]},
]
```

Concat: `"<role>: <content>"` per message. Multimodal: pulls `text` field per block.

## REJECTED response

```json
{
  "allowed": false,
  "decision": "deny_context_window",
  "reason": "context_window_exceeded",
  "status_code": 413,
  "payload": {
    "error": "context_window_exceeded",
    "role": "chat",
    "initial_tokens": 20000,
    "ceiling_tokens": 4096
  }
}
```

HTTP 413 (Payload Too Large) is the standards-aligned status for this denial class.

## Fail-open design

| Condition | Action |
|---|---|
| `context_window_enabled=False` (rollout phase 1 default) | gate skipped, forward proceeds |
| body has no messages | gate skipped (empty context cannot be evaluated) |
| `check_context_budget` raises | log exception + treat as None (proceed) |
| Decision SPAWN_OK | proceed |
| Decision SUMMARISED (Phase 2 only) | proceed (logged) |
| Decision REJECTED | HTTP 413 with deny_context_window |

## Verification

```
$ DISPATCHER_JWT_SECRET=test SUPABASE_DB_DSN=postgresql://fake/db python3 -m pytest tests/dispatcher/test_interceptor_context_window_wiring.py -q
.............                                                            [100%]
13 passed in 0.40s

$ ruff check + format (touched files)
All checks passed!
```

## Test coverage (13 tests)

- **`test_disabled_proceeds_to_forward`** — gate disabled → forward called even on huge body
- **`test_empty_context_proceeds`** — body without messages → gate skipped
- **`test_under_ceiling_proceeds_to_forward`** — short context → SPAWN_OK
- **`test_over_ceiling_returns_deny_context_window`** — 60K chars on CHAT (4K token ceiling) → REJECTED with 413 + payload
- **`test_body_to_role`** — 6 parametric cases (4 valid + 1 invalid + 1 missing → ROLE_BUILDER default)
- **`test_body_to_context_multi_message`** — system + user + assistant concat
- **`test_body_to_context_empty`** — 3 empty-body shapes
- **`test_body_to_context_multimodal_blocks`** — OpenAI multimodal content list

## Rollout

**Phase 1 (this PR):** `context_window_enabled=False` default → zero behavioural change.

**Phase 2 (follow-up):** Set env `DISPATCHER_CONTEXT_WINDOW_ENABLED=1` at startup. Optional: inject production summariser via DI on `check_context_budget`.

## Test plan

- [x] 13 new unit tests pass
- [x] No existing tests affected (no signature changes to public intercept_request)
- [x] ruff check / format clean
- [ ] CI: dispatcher tests + ruff + mypy + boundary matrix guards
- [ ] Aiden review (architecture lens)
- [ ] Max or Elliot review (second deliberator)

## Anchors

- **bd:** Agency_OS-r9p3 PR C (KEI-213 mirror of PR #1219)
- **Cat 21 lever 25 context-window-budget-per-role** + **cutover-blocker 3**
- **Composes with:** PR #1210 context_budget module + KEI-213 interceptor_proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)