### PR TITLE
[ORION] feat(dispatcher-wiring-KEI213): spawn attribution + per-task-type wired into /dispatcher/spawn (Agency_OS-r9p3 PR D)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -45,6 +45,12 @@ from src.dispatcher.tmux_lifecycle import (
     TmuxUnavailableError,
 )
 from src.dispatcher.watchdog import Watchdog
+from src.keiracom_system.attribution.logger import (
+    SOURCE_TYPES,
+    TASK_TYPES,
+    SpawnAttributionEntry,
+    log_spawn_attribution,
+)
 from src.relay.budget_ceiling import (
     PRIORITY_NORMAL,
     SOURCE_DAVE_DM,
@@ -179,6 +185,78 @@ def _bounded_spawn_task_id(spawn_kwargs: dict[str, Any], registry_key: str) -> s
     """Pull a stable task identifier from spawn_kwargs, falling back to key."""
     explicit = str((spawn_kwargs or {}).get("task_id") or "").strip()
     return explicit or registry_key
+
+
+# Spawn-attribution emit toggle (PR #1207 / Cat 21 lever 27 / cutover-blocker 6
+# + PR #1209 / Cat 21 lever 23 / cutover-blocker 7 — per-task-type extension).
+# When True, /dispatcher/spawn emits a SpawnAttributionEntry JSONL after
+# successful register. Disabled in rollout phase 1.
+_ATTRIBUTION_ENABLED_ENV = "DISPATCHER_ATTRIBUTION_ENABLED"
+attribution_enabled: bool = os.environ.get(_ATTRIBUTION_ENABLED_ENV, "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+attribution_default_model: str = os.environ.get("DISPATCHER_ATTRIBUTION_MODEL", "claude-sonnet-4-6")
+
+
+def _spawn_kwargs_source_type(sk: dict) -> str:
+    """Derive source_type from spawn_kwargs per PR #1207 SOURCE_TYPES taxonomy."""
+    explicit = str(sk.get("source_type") or "").strip()
+    if explicit in SOURCE_TYPES:
+        return explicit
+    sender = str(sk.get("from") or "").lower().strip()
+    if sender == "dave":
+        return "slack"
+    if sender in {"cron", "scheduler"}:
+        return "cron"
+    return "inbox"
+
+
+def _spawn_kwargs_task_type(sk: dict, registry_key: str) -> str:
+    """Derive task_type from spawn_kwargs per PR #1207/#1209 TASK_TYPES taxonomy."""
+    explicit = str(sk.get("task_type") or "").lower().strip()
+    if explicit in TASK_TYPES:
+        return explicit
+    key_upper = registry_key.upper()
+    if "REVIEW-PR" in key_upper or "PR-REVIEW" in key_upper:
+        return "pr_review"
+    if "DELIBERATE" in key_upper or "DELIBERATION" in key_upper:
+        return "deliberation"
+    if key_upper.startswith("DISPATCH"):
+        return "dispatch_mgmt"
+    if str(sk.get("from") or "").lower().strip() == "dave":
+        return "chat"
+    return "build"
+
+
+def _emit_attribution(
+    *,
+    registry_key: str,
+    spawn_kwargs: dict,
+    callsign: str,
+) -> SpawnAttributionEntry | None:
+    """Emit a SpawnAttributionEntry; fail-open on telemetry exceptions."""
+    if not attribution_enabled:
+        return None
+    source_type = _spawn_kwargs_source_type(spawn_kwargs)
+    task_type = _spawn_kwargs_task_type(spawn_kwargs, registry_key)
+    try:
+        return log_spawn_attribution(
+            source_type=source_type,
+            source_id=registry_key,
+            callsign=callsign,
+            model=attribution_default_model,
+            task_type=task_type,
+        )
+    except Exception:  # noqa: BLE001 — telemetry must not block spawn
+        logger.exception(
+            "KEI-213 spawn attribution emit failed source_type=%s task_type=%s key=%s",
+            source_type,
+            task_type,
+            registry_key,
+        )
+        return None
 
 
 # Sessions spawned via /dispatcher/spawn, keyed by supervisor registry key.
@@ -504,6 +582,16 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
                 enforcement.prior.task_id if enforcement.prior else None,
                 enforcement.killed,
             )
+
+    # Spawn attribution emit (Cat 21 levers 27 + 23 / cutover-blockers 6 + 7).
+    # Fires AFTER successful register so attribution only records sessions that
+    # actually entered supervision.
+    callsign_hint = str((req.spawn_kwargs or {}).get("callsign") or "dispatcher")
+    _emit_attribution(
+        registry_key=req.key,
+        spawn_kwargs=req.spawn_kwargs or {},
+        callsign=callsign_hint,
+    )
 
     rsnap = _reaper.health_snapshot()
     response: dict[str, Any] = {

--- a/tests/dispatcher/test_main_spawn_attribution_wiring.py
+++ b/tests/dispatcher/test_main_spawn_attribution_wiring.py
@@ -1,0 +1,188 @@
+"""KEI-213 — spawn attribution + per-task-type wiring tests for src.dispatcher.main.
+
+Covers cutover-step-4.5 wiring of PR #1207 (spawn attribution) + PR #1209
+(per-task-type telemetry extension) into /dispatcher/spawn.
+
+bd: cutover-step-4.5-dispatcher-wiring-pr-D (KEI-213 mirror of PR #1220)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.dispatcher.tmux_lifecycle import SessionHandle
+
+
+def _mock_supervisors(main_mod: Any) -> None:
+    main_mod._watchdog = MagicMock()
+    main_mod._reaper = MagicMock()
+    main_mod._reaper.health_snapshot.return_value = {
+        "tracked_tmux": 0,
+        "tracked_containers": 0,
+    }
+    main_mod._watchdog.tracked = 0
+
+
+def _make_handle() -> SessionHandle:
+    return SessionHandle(session_name="disp-test", working_dir="/tmp", command="claude")
+
+
+# ----- disabled fail-open -----
+
+
+def test_disabled_no_jsonl_emit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """attribution_enabled=False → no JSONL entry written."""
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+    import src.dispatcher.main as main_mod
+
+    monkeypatch.setattr(main_mod, "attribution_enabled", False)
+    log_path = tmp_path / "spawn-attribution.jsonl"
+    monkeypatch.setattr("src.keiracom_system.attribution.logger.DEFAULT_ATTRIBUTION_LOG", log_path)
+
+    _mock_supervisors(main_mod)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        resp = client.post(
+            "/dispatcher/spawn",
+            json={"backend": "tmux", "key": "k1", "spawn_kwargs": {}},
+        )
+
+    assert resp.status_code == 200
+    assert not log_path.exists()
+
+
+# ----- enabled writes JSONL -----
+
+
+def test_enabled_writes_jsonl_after_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """attribution_enabled=True → log_spawn_attribution called after register."""
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+    import src.dispatcher.main as main_mod
+
+    monkeypatch.setattr(main_mod, "attribution_enabled", True)
+    log_path = tmp_path / "spawn-attribution.jsonl"
+    monkeypatch.setattr("src.keiracom_system.attribution.logger.DEFAULT_ATTRIBUTION_LOG", log_path)
+
+    _mock_supervisors(main_mod)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        resp = client.post(
+            "/dispatcher/spawn",
+            json={
+                "backend": "tmux",
+                "key": "REVIEW-PR-1199",
+                "spawn_kwargs": {"from": "elliot", "callsign": "orion"},
+            },
+        )
+
+    assert resp.status_code == 200
+    assert log_path.exists()
+    entry = json.loads(log_path.read_text(encoding="utf-8").strip())
+    assert entry["source_type"] == "inbox"  # from elliot → not dave/cron → inbox
+    assert entry["task_type"] == "pr_review"  # REVIEW-PR key → pr_review
+    assert entry["callsign"] == "orion"
+    assert entry["source_id"] == "REVIEW-PR-1199"
+    assert entry["model"] == "claude-sonnet-4-6"
+
+
+# ----- source_type derivation -----
+
+
+@pytest.mark.parametrize(
+    "spawn_kwargs,expected",
+    [
+        ({"source_type": "slack"}, "slack"),
+        ({"source_type": "cron"}, "cron"),
+        ({"source_type": "pr"}, "pr"),
+        ({"source_type": "unknown"}, "unknown"),
+        ({"source_type": "bogus"}, "inbox"),  # invalid → fallback
+        ({"from": "dave"}, "slack"),
+        ({"from": "cron"}, "cron"),
+        ({"from": "scheduler"}, "cron"),
+        ({}, "inbox"),
+        ({"from": "atlas"}, "inbox"),
+    ],
+)
+def test_source_type_derivation(spawn_kwargs: dict, expected: str) -> None:
+    import src.dispatcher.main as main_mod
+
+    assert main_mod._spawn_kwargs_source_type(spawn_kwargs) == expected
+
+
+# ----- task_type derivation -----
+
+
+@pytest.mark.parametrize(
+    "spawn_kwargs,registry_key,expected",
+    [
+        ({"task_type": "pr_review"}, "k1", "pr_review"),
+        ({"task_type": "deliberation"}, "k1", "deliberation"),
+        ({"task_type": "build"}, "k1", "build"),
+        ({"task_type": "chat"}, "k1", "chat"),
+        ({"task_type": "dispatch_mgmt"}, "k1", "dispatch_mgmt"),
+        ({"task_type": "bogus"}, "k1", "build"),  # invalid → fallback
+        ({}, "REVIEW-PR-1199", "pr_review"),
+        ({}, "PR-REVIEW-1199", "pr_review"),
+        ({}, "DELIBERATE-arch-v2", "deliberation"),
+        ({}, "DELIBERATION-arch-v2", "deliberation"),
+        ({}, "DISPATCH-rebase", "dispatch_mgmt"),
+        ({"from": "dave"}, "any-key", "chat"),
+        ({}, "any-key", "build"),  # default
+        ({"from": "atlas"}, "k1", "build"),
+    ],
+)
+def test_task_type_derivation(spawn_kwargs: dict, registry_key: str, expected: str) -> None:
+    import src.dispatcher.main as main_mod
+
+    assert main_mod._spawn_kwargs_task_type(spawn_kwargs, registry_key) == expected
+
+
+# ----- telemetry failure fail-open -----
+
+
+def test_telemetry_failure_does_not_block_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """log_spawn_attribution raises → spawn still succeeds with empty audit."""
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+    import src.dispatcher.main as main_mod
+
+    monkeypatch.setattr(main_mod, "attribution_enabled", True)
+
+    def _boom(**_kwargs: Any) -> None:
+        raise RuntimeError("simulated telemetry failure")
+
+    monkeypatch.setattr("src.dispatcher.main.log_spawn_attribution", _boom)
+
+    _mock_supervisors(main_mod)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        resp = client.post(
+            "/dispatcher/spawn",
+            json={"backend": "tmux", "key": "k1", "spawn_kwargs": {}},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["spawned"] is True  # spawn still completed


### PR DESCRIPTION
## Summary

Cutover step 4.5 dispatcher-wiring PR **D** for **KEI-213** — wires PR #1207 spawn-attribution + PR #1209 per-task-type telemetry into `/dispatcher/spawn` per Dave + Aiden + Viktor dual-concur 2026-05-27.

**Sibling KEI-213 PRs (parallel pipeline):**
- PR #1222 (A) — idempotency gate
- PR #1223 (B) — budget ceiling gate
- PR #1224 (C) — context-window gate (interceptor_proxy)
- This PR (D) — spawn attribution + per-task-type
- (Coming) E — wiring inventory + CI guard update

## Changes

| File | Change | LoC |
|---|---|---|
| `src/dispatcher/main.py` | MOD — imports attribution module; `attribution_enabled` toggle (env); helper fns; `_emit_attribution` call after `_register_session` | +70 |
| `tests/dispatcher/test_main_spawn_attribution_wiring.py` | NEW — 27 unit tests | +207 |

## Wiring point

```
/dispatcher/spawn (HTTP POST)
  ↓ idempotency gate (PR A) — if wired
  ↓ budget ceiling gate (PR B) — if wired
  ↓ backend validation
  ↓ manager.spawn(**spawn_kwargs)
  ↓ _register_session(...)
  ↓ [NEW] _emit_attribution(...)        ← SpawnAttributionEntry JSONL written here
  ↓ HTTP 200 response
```

Emit fires AFTER successful register so only sessions that actually entered supervision get telemetry rows.

## Source_type derivation (PR #1207 SOURCE_TYPES)

| Trigger | source_type |
|---|---|
| `spawn_kwargs.source_type` validated against frozenset | (as given) |
| `spawn_kwargs.from == "dave"` | `slack` |
| `spawn_kwargs.from in {"cron", "scheduler"}` | `cron` |
| Default | `inbox` (KEI-213 dispatcher's primary dispatch path) |

`unknown` reserved for explicit envelope ambiguity per PR #1207's "silent fallback is a bug" contract.

## Task_type derivation (PR #1207/#1209 TASK_TYPES)

| Trigger | task_type |
|---|---|
| `spawn_kwargs.task_type` validated | (as given) |
| `registry_key` contains `REVIEW-PR` or `PR-REVIEW` | `pr_review` |
| `registry_key` contains `DELIBERATE` or `DELIBERATION` | `deliberation` |
| `registry_key` starts `DISPATCH` | `dispatch_mgmt` |
| `from == "dave"` | `chat` |
| Default | `build` |

## Emitted entry fields

```python
SpawnAttributionEntry(
    ts="2026-05-27T...",
    source_type="inbox",
    source_id=req.key,             # registry key for correlation
    task_type="pr_review",         # derived per taxonomy
    callsign=spawn_kwargs.get("callsign") or "dispatcher",
    model="claude-sonnet-4-6",     # default; env override DISPATCHER_ATTRIBUTION_MODEL
)
```

Token + cost fields backfilled by PR #1202 daily ceo-rollup via ts + callsign correlation with session JSONLs.

## Fail-open design

| Condition | Action |
|---|---|
| `attribution_enabled=False` (rollout phase 1 default) | no emit, return None |
| `log_spawn_attribution` raises (invalid taxonomy / I/O) | log exception, return None — spawn still succeeds |

Telemetry must never block a spawn.

## Verification

```
$ DISPATCHER_JWT_SECRET=test SUPABASE_DB_DSN=postgresql://fake/db python3 -m pytest tests/dispatcher/test_main_spawn_attribution_wiring.py tests/dispatcher/test_main_wiring.py -q
....................................                                     [100%]
36 passed in 0.79s

$ ruff check + format (touched files, auto-fix on import sort)
All checks passed!
```

## Test coverage (27 tests)

- **`test_disabled_no_jsonl_emit`** — `attribution_enabled=False` → no JSONL written
- **`test_enabled_writes_jsonl_after_spawn`** — real `log_spawn_attribution` call with `tmp_path` monkeypatch; verifies source_type=inbox + task_type=pr_review + callsign + source_id + model
- **`test_source_type_derivation`** — 10 parametric cases (5 explicit + 3 sender-based + 2 defaults)
- **`test_task_type_derivation`** — 14 parametric cases (6 explicit + 5 key-based + 1 sender + 2 defaults)
- **`test_telemetry_failure_does_not_block_spawn`** — patched `log_spawn_attribution` raises; HTTP 200 with `spawned: true` (fail-open)

## Rollout

**Phase 1 (this PR):** `attribution_enabled=False` default → zero behavioural change.

**Phase 2 (follow-up):** Set env `DISPATCHER_ATTRIBUTION_ENABLED=1` + optional `DISPATCHER_ATTRIBUTION_MODEL`. JSONL stream lands at `DEFAULT_ATTRIBUTION_LOG` for ceo-rollup correlation.

## Test plan

- [x] 27 new unit tests pass
- [x] 9 existing test_main_wiring tests pass unchanged
- [x] ruff check / format clean
- [ ] CI: dispatcher tests + ruff + mypy + boundary matrix guards
- [ ] Aiden review (architecture lens)
- [ ] Max or Elliot review (second deliberator)

## Anchors

- **bd:** Agency_OS-r9p3 PR D (KEI-213 mirror of PR #1220)
- **Cat 21 lever 27 spawn-attribution** + **lever 23 per-task-type**
- **Cutover-blockers 6 + 7** GREEN per Dave dual-concur 2026-05-27
- **Composes with:** PR #1207 + PR #1209 + KEI-213 dispatcher
- **Bridges to:** PR #1202 daily ceo-rollup (ts + callsign correlation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)