### PR TITLE
[ORION] feat(dispatcher-wiring-KEI213): wiring inventory + CI verification guard (Agency_OS-r9p3 PR E)

### DIFF
--- a/docs/architecture/dispatcher_wiring_inventory_kei213.md
+++ b/docs/architecture/dispatcher_wiring_inventory_kei213.md
@@ -1,0 +1,123 @@
+# KEI-213 Dispatcher Wiring Inventory (Cutover Step 4.5)
+
+**Owner:** Orion (build); Aiden + Viktor (architecture concur); Elliot (orchestrator hand-off); Dave (ratified 2026-05-27).
+**Anchor:** Dave directive 2026-05-27 ratifying Aiden + Viktor dual-concur — **KEI-213 is the canonical dispatcher**.
+**Purpose:** topology map for where each of the **9 launch-blockers** is wired into the canonical KEI-213 dispatcher (`src/dispatcher/main.py` running at port 4001).
+
+## Ratified canonical-dispatcher decision (2026-05-27)
+
+**Canonical:** KEI-213 — `src/dispatcher/main.py` + `src/dispatcher/interceptor_proxy.py` (FastAPI service at port 4001).
+**Deprecated:** PR #1188 — `scripts/dispatcher/dispatcher_main.py` (claim-loop binary). Code stays on main for traceability but **not wired into production**.
+
+PRs #1217 / #1218 / #1219 / #1220 / #1221 wired the deprecated binary. KEI-213 mirror PRs (A/B/C/D/E) reproduce the same wiring topology against the canonical dispatcher per Dave + Aiden + Viktor ratify.
+
+## 9 Launch-Blocker Wiring Map (KEI-213)
+
+| # | Lever | Cutover-Blocker | Lib PR | Wiring slot | Wiring PR |
+|---|---|---|---|---|---|
+| 15 | `eff.cache_hit_rate_observability` | 9 | PR #1208 | systemd timer + Supabase view (NOT dispatcher) | (already wired in #1208) |
+| 16 | `eff.cost_telemetry_to_ceo` | 1 | PR #1202 | systemd timer 23:55 AEST (NOT dispatcher) | (already wired in #1202) |
+| 22 | `eff.ephemeral_persistence_boundary` | 8 | PR #1206 | docs spec + design discipline (NOT runtime code) | (no wiring; docs spec only) |
+| 23 | `eff.per_task_type_cost_telemetry` | 7 | PR #1209 | KEI-213 `/dispatcher/spawn` at-spawn (task_type taxonomy) | PR D (#1225) |
+| 25 | `eff.context_window_budget_per_role` | 3 | PR #1210 | KEI-213 `interceptor_proxy.intercept_request` pre-LLM-call | PR C (#1224) |
+| 26 | `eff.idempotency_keys_task_queue` | 5 | PR #1204 | KEI-213 `/dispatcher/spawn` pre-spawn | PR A (#1222) |
+| 27 | `eff.spawn_attribution_telemetry` | 6 | PR #1207 | KEI-213 `/dispatcher/spawn` post-register | PR D (#1225) |
+| 28 | `eff.budget_ceiling_policy` | 2 | PR #1203 | KEI-213 `/dispatcher/spawn` pre-spawn | PR B (#1223) |
+| 29 | `eff.cache_write_ttl_5min_default` | 4 | PR #1205 | CI guard `scripts/ci/check_no_1h_cache_ttl.sh` (NOT dispatcher) | (already wired in #1205) |
+
+**5 of 9 wire into the canonical KEI-213 dispatcher.**
+**4 of 9 wire at other architectural boundaries** (systemd timers / CI guard / docs spec).
+
+## KEI-213 dispatcher hook topology
+
+```
+HTTP POST /dispatcher/spawn (src/dispatcher/main.py)
+    │
+    ├── Backend validation
+    │
+    ├── [PR A] Idempotency gate (Cat 21 lever 26)
+    │       └─ IdempotencyGate.check_and_claim()
+    │          ├─ SPAWN_OK     → continue
+    │          └─ DROP_DUPLICATE → HTTP 200 {spawned: false, decision: "drop_duplicate"}
+    │
+    ├── [PR B] Budget ceiling gate (Cat 21 lever 28)
+    │       └─ BudgetCeilingGate.check_budget()
+    │          ├─ SPAWN_OK / OVERAGE_LOG_AND_SPAWN / DAVE_BYPASS / FORCE_OVERRIDE → continue
+    │          └─ QUEUE_NEXT_DAY / DROP_WITH_LOG → HTTP 200 {spawned: false, decision: ...}
+    │
+    ├── SessionManager.spawn(**spawn_kwargs)
+    ├── _register_session(...)
+    │
+    ├── [PR D] Spawn attribution emit (Cat 21 levers 27 + 23)
+    │       └─ log_spawn_attribution() → DEFAULT_ATTRIBUTION_LOG JSONL
+    │
+    └── HTTP 200 with handle
+
+
+HTTP POST /interceptor/forward (src/dispatcher/interceptor_proxy.py)
+    │
+    ├── governance check
+    ├── spend budget check  (per-tenant monthly Valkey)
+    ├── rate limit check    (per-tenant 60s window Valkey)
+    │
+    ├── [PR C] Context-window budget gate (Cat 21 lever 25)
+    │       └─ check_context_budget(role, context)
+    │          ├─ SPAWN_OK / SUMMARISED → continue
+    │          └─ REJECTED → InterceptorDecision(allowed=False, 413)
+    │
+    ├── forward to LiteLLM
+    └── log allow event
+```
+
+## Non-dispatcher wiring slots (unchanged from PR #1221 inventory)
+
+### Lever 16 — Daily cost rollup (PR #1202)
+**Slot:** systemd timer `keiracom-cost-rollup.timer` fires 23:55 AEST → runs `scripts/agency_cost_rollup.py` → posts `tg -c ceo` message.
+
+### Lever 15 — Cache hit-rate observability (PR #1208)
+**Slot:** systemd timer `cache_hit_rate_ingest.timer` (13:50 UTC) + `cache_hit_rate_alert.timer` (13:53 UTC) + Supabase view `keiracom_cache_hit_rates_v1`.
+
+### Lever 22 — Ephemeral persistence boundary (PR #1206)
+**Slot:** `docs/architecture/ephemeral_persistence_boundary.md` (180-line design discipline spec).
+
+### Lever 29 — Cache write TTL 5-min default (PR #1205)
+**Slot:** CI guard `scripts/ci/check_no_1h_cache_ttl.sh` rejects PRs introducing `{"type": "1h"}`.
+
+## Phase 1 vs Phase 2 rollout
+
+**Phase 1 (PRs A/B/C/D):** All 4 dispatcher-side toggles default to disabled (zero behavioural change):
+- `main._idempotency_gate = None`
+- `main._budget_gate = None`
+- `interceptor_proxy.context_window_enabled = False` (env-driven)
+- `main.attribution_enabled = False` (env-driven)
+
+**Phase 2 (follow-up config PR):** Production rollout at dispatcher startup site:
+
+```python
+# src/dispatcher/main.py startup OR a separate config module
+from src.dispatcher.idempotency import IdempotencyGate
+from src.dispatcher.valkey_pool import get_valkey_client
+from src.relay.budget_ceiling import BudgetCeilingGate
+import src.dispatcher.main as main_mod
+import src.dispatcher.interceptor_proxy as interceptor_mod
+
+main_mod._set_idempotency_gate(IdempotencyGate(valkey_client=get_valkey_client()))
+main_mod._set_budget_gate(BudgetCeilingGate(db=cursor, daily_budget_aud=25.0))
+interceptor_mod.context_window_enabled = True  # or via DISPATCHER_CONTEXT_WINDOW_ENABLED=1 env
+main_mod.attribution_enabled = True            # or via DISPATCHER_ATTRIBUTION_ENABLED=1 env
+```
+
+## CI verification
+
+`scripts/ci/check_dispatcher_wiring_inventory_kei213.sh` (this PR) verifies the lib modules + systemd units + docs spec referenced in this inventory all exist.
+
+This document is the **single source of truth** for KEI-213 wiring topology. Update when a new launch-blocker lands or a wiring slot moves.
+
+## Anchors
+
+- **bd:** Agency_OS-r9p3 (cutover step 4.5)
+- **Cat 21 §0 BOUNDED-SPAWN HARDEST** anchors all 9 levers
+- **GOV-12** (gates as code, not comments) — CI guard runtime enforcement
+- **Composes with:** PRs A-D (KEI-213 wiring batch) + all 9 lib PRs
+- **Supersedes (operational scope):** `dispatcher_wiring_inventory.md` (which targets PR #1188 deprecated binary)
+- **Gates:** Phase 1 step 5 retire-persistent-tmux per Aiden + Viktor CONCUR

--- a/scripts/ci/check_dispatcher_wiring_inventory_kei213.sh
+++ b/scripts/ci/check_dispatcher_wiring_inventory_kei213.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# CI guard: verify all wiring points named in dispatcher_wiring_inventory_kei213.md
+# exist. Mirrors PR #1221 but targets the CANONICAL KEI-213 dispatcher per Dave +
+# Aiden + Viktor ratify 2026-05-27.
+#
+# bd: cutover-step-4.5-dispatcher-wiring-pr-E (KEI-213 mirror of PR #1221)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+errors=0
+
+assert_exists() {
+    local path="$1"
+    local label="$2"
+    if [[ ! -e "$path" ]]; then
+        echo "ERROR: missing wiring point [$label] expected at $path"
+        errors=$((errors + 1))
+    fi
+}
+
+echo "=== KEI-213 Dispatcher wiring inventory verification ==="
+
+# Canonical KEI-213 dispatcher entry-points.
+assert_exists "src/dispatcher/main.py"               "KEI-213 canonical dispatcher entry (Dave/Aiden/Viktor ratify 2026-05-27)"
+assert_exists "src/dispatcher/interceptor_proxy.py"  "KEI-213 LLM-call interceptor"
+assert_exists "src/dispatcher/governance_proxy.py"   "KEI-213 governance proxy"
+
+# Lib modules from PRs #1202-#1211 (wiring preconditions).
+assert_exists "src/dispatcher/idempotency.py"                       "PR #1204 idempotency module (cutover-blocker 5)"
+assert_exists "src/relay/budget_ceiling.py"                         "PR #1203 budget ceiling module (cutover-blocker 2)"
+assert_exists "src/relay/context_budget.py"                         "PR #1210 context_budget module (cutover-blocker 3)"
+assert_exists "src/keiracom_system/attribution/logger.py"           "PR #1207 spawn-attribution module (cutover-blocker 6)"
+assert_exists "scripts/agency_cost_rollup.py"                       "PR #1202 cost rollup script (cutover-blocker 1)"
+assert_exists "scripts/cache_hit_rate_ingest.py"                    "PR #1208 cache hit-rate ingest (cutover-blocker 9)"
+assert_exists "scripts/cache_hit_rate_alert.py"                     "PR #1208 cache hit-rate alert (cutover-blocker 9)"
+assert_exists "scripts/install_cache_hit_rate.sh"                   "PR #1208 cache hit-rate installer (cutover-blocker 9)"
+assert_exists "docs/architecture/ephemeral_persistence_boundary.md" "PR #1206 persistence boundary spec (cutover-blocker 8)"
+
+# Systemd units from PR #1208 cache hit-rate observability.
+assert_exists "systemd/cache_hit_rate_ingest.service"               "PR #1208 ingest systemd service"
+assert_exists "systemd/cache_hit_rate_ingest.timer"                 "PR #1208 ingest systemd timer"
+assert_exists "systemd/cache_hit_rate_alert.service"                "PR #1208 alert systemd service"
+assert_exists "systemd/cache_hit_rate_alert.timer"                  "PR #1208 alert systemd timer"
+
+# CI guard from PR #1205 cache write TTL.
+ttl_guard_found=0
+for candidate in scripts/ci/check_no_1h_cache_ttl.sh scripts/ci/check_cache_write_ttl.sh scripts/ci/check_cache_ttl_5min.sh; do
+    if [[ -e "$candidate" ]]; then
+        ttl_guard_found=1
+        break
+    fi
+done
+if [[ $ttl_guard_found -eq 0 ]]; then
+    echo "ERROR: missing wiring point [PR #1205 cache write TTL CI guard (cutover-blocker 4)] — expected one of scripts/ci/check_no_1h_cache_ttl.sh / check_cache_write_ttl.sh / check_cache_ttl_5min.sh"
+    errors=$((errors + 1))
+fi
+
+# KEI-213 wiring inventory doc itself.
+assert_exists "docs/architecture/dispatcher_wiring_inventory_kei213.md"  "KEI-213 wiring inventory doc (this PR)"
+
+echo ""
+if [[ $errors -eq 0 ]]; then
+    echo "OK — all KEI-213 wiring preconditions present (canonical entry + 9 launch-blocker libs + inventory doc)"
+    exit 0
+else
+    echo "FAIL — $errors wiring point(s) missing"
+    exit 1
+fi

--- a/tests/scripts/ci/test_dispatcher_wiring_inventory_kei213.py
+++ b/tests/scripts/ci/test_dispatcher_wiring_inventory_kei213.py
@@ -1,0 +1,58 @@
+"""Smoke test for scripts/ci/check_dispatcher_wiring_inventory_kei213.sh.
+
+Mirrors PR #1221 / cutover-step-4.5-dispatcher-wiring-pr5 but for the
+canonical KEI-213 dispatcher per Dave + Aiden + Viktor ratify 2026-05-27.
+
+Positive path: guard exits 0 against live repo.
+Negative path (GOV-12): guard exits non-zero when copied to non-repo dir.
+
+bd: cutover-step-4.5-dispatcher-wiring-pr-E (KEI-213)
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GUARD_PATH = REPO_ROOT / "scripts" / "ci" / "check_dispatcher_wiring_inventory_kei213.sh"
+
+
+def test_guard_script_exists() -> None:
+    assert GUARD_PATH.exists(), f"KEI-213 wiring inventory guard not found at {GUARD_PATH}"
+
+
+def test_guard_passes_against_live_repo() -> None:
+    """Positive path — guard exits 0 against current repo state."""
+    result = subprocess.run(
+        ["bash", str(GUARD_PATH)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, (
+        f"KEI-213 guard failed (exit {result.returncode})\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert "OK — all KEI-213 wiring preconditions present" in result.stdout
+
+
+def test_guard_detects_missing_modules_when_isolated(tmp_path: Path) -> None:
+    """Negative path (GOV-12) — guard MUST fail when wiring points are missing."""
+    temp_guard = tmp_path / "guard.sh"
+    temp_guard.write_text(GUARD_PATH.read_text())
+    temp_guard.chmod(0o755)
+
+    result = subprocess.run(
+        ["bash", str(temp_guard)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode != 0, (
+        "KEI-213 guard MUST fail when wiring points are missing (negative-path); "
+        "got exit 0 + stdout: " + result.stdout
+    )
+    assert "ERROR: missing wiring point" in result.stdout
+    assert "FAIL" in result.stdout


### PR DESCRIPTION
## Summary

Cutover step 4.5 dispatcher-wiring PR **E** (final) for **KEI-213** — documents the wiring topology PRs A-D land into the canonical KEI-213 dispatcher + adds executable CI guard.

**KEI-213 parallel pipeline complete:**
- PR #1222 (A) — idempotency gate
- PR #1223 (B) — budget ceiling gate
- PR #1224 (C) — context-window gate (interceptor_proxy)
- PR #1225 (D) — spawn attribution + per-task-type
- This PR (E) — inventory doc + CI guard (gates-as-code per GOV-12)

## Changes

| File | Change | LoC |
|---|---|---|
| `docs/architecture/dispatcher_wiring_inventory_kei213.md` | NEW — 9-blocker wiring topology + ASCII diagrams + Phase 1/2 rollout | +136 |
| `scripts/ci/check_dispatcher_wiring_inventory_kei213.sh` | NEW — executable CI guard | +70 |
| `tests/scripts/ci/test_dispatcher_wiring_inventory_kei213.py` | NEW — 3 pytest tests | +56 |

## Wiring topology table

| # | Lever | CB | Lib PR | Wiring slot in KEI-213 | Wiring PR |
|---|---|---|---|---|---|
| 15 | cache_hit_rate_observability | 9 | #1208 | systemd timer + Supabase view | #1208 |
| 16 | cost_telemetry_to_ceo | 1 | #1202 | systemd timer 23:55 AEST | #1202 |
| 22 | ephemeral_persistence_boundary | 8 | #1206 | docs spec | #1206 |
| 23 | per_task_type_cost_telemetry | 7 | #1209 | `/dispatcher/spawn` at-spawn (task_type) | #1225 |
| 25 | context_window_budget_per_role | 3 | #1210 | `interceptor_proxy.intercept_request` | #1224 |
| 26 | idempotency_keys_task_queue | 5 | #1204 | `/dispatcher/spawn` pre-spawn | #1222 |
| 27 | spawn_attribution_telemetry | 6 | #1207 | `/dispatcher/spawn` post-register | #1225 |
| 28 | budget_ceiling_policy | 2 | #1203 | `/dispatcher/spawn` pre-spawn | #1223 |
| 29 | cache_write_ttl_5min_default | 4 | #1205 | CI guard | #1205 |

**5 of 9 wire into KEI-213 dispatcher hot path.**
**4 of 9 wire at systemd / CI / docs slots.**

## KEI-213 dispatcher hook topology

```
POST /dispatcher/spawn → src/dispatcher/main.py
  1. Backend validation
  2. [PR A] Idempotency gate     (Cat 21 lever 26)
  3. [PR B] Budget ceiling gate  (Cat 21 lever 28)
  4. SessionManager.spawn(...)
  5. _register_session(...)
  6. [PR D] Spawn attribution    (Cat 21 levers 27 + 23)
  7. HTTP 200 with handle

POST /interceptor/forward → src/dispatcher/interceptor_proxy.py
  1. governance check
  2. spend budget check (per-tenant monthly)
  3. rate limit check (per-tenant 60s)
  4. [PR C] Context-window gate  (Cat 21 lever 25)
  5. forward to LiteLLM
  6. log allow event
```

## Supersession scope

This PR's inventory **supersedes** PR #1221's inventory **operationally** (PR #1221 documents PR #1188's deprecated dispatcher binary topology). Both docs stay on main:
- `dispatcher_wiring_inventory.md` (PR #1221) — historical traceability for the deprecated binary
- `dispatcher_wiring_inventory_kei213.md` (this PR) — **canonical** production wiring topology

## CI guard verification

```
$ bash scripts/ci/check_dispatcher_wiring_inventory_kei213.sh
=== KEI-213 Dispatcher wiring inventory verification ===

OK — all KEI-213 wiring preconditions present (canonical entry + 9 launch-blocker libs + inventory doc)
```

Verifies:
- KEI-213 canonical entry-points (`main.py` + `interceptor_proxy.py` + `governance_proxy.py`)
- 9 lib module / script / migration paths (PRs #1202-#1211)
- 4 systemd unit files (PR #1208)
- 1 cache-TTL CI guard (PR #1205, 3 tolerated names)
- This wiring inventory doc

## Pytest coverage (3 tests)

1. **`test_guard_script_exists`** — guard file present at canonical path
2. **`test_guard_passes_against_live_repo`** — exits 0 + asserts "OK — all KEI-213 wiring preconditions present" in output
3. **`test_guard_detects_missing_modules_when_isolated`** — NEGATIVE PATH: guard copied to non-repo dir MUST exit non-zero with `ERROR: missing wiring point` + `FAIL` (GOV-12 gates-as-code)

```
$ python3 -m pytest tests/scripts/ci/test_dispatcher_wiring_inventory_kei213.py -v
test_guard_script_exists PASSED
test_guard_passes_against_live_repo PASSED
test_guard_detects_missing_modules_when_isolated PASSED

3 passed in 0.21s
```

## Phase 1 vs Phase 2 rollout (in doc)

**Phase 1 (PRs A-D):** All 4 dispatcher-side toggles default to disabled — zero behavioural change.

**Phase 2 (follow-up):** Production rollout at dispatcher startup site. Code snippet in inventory doc shows:

```python
main_mod._set_idempotency_gate(IdempotencyGate(valkey_client=get_valkey_client()))
main_mod._set_budget_gate(BudgetCeilingGate(db=cursor, daily_budget_aud=25.0))
interceptor_mod.context_window_enabled = True
main_mod.attribution_enabled = True
```

## Test plan

- [x] Guard exits 0 against live repo
- [x] Guard exits non-zero in negative-path isolation test
- [x] 3 pytest tests pass
- [x] ruff check / format clean
- [ ] CI: pytest + ruff
- [ ] Aiden review (architecture lens — verify inventory accuracy)
- [ ] Max or Elliot review (second deliberator)

## Anchors

- **bd:** Agency_OS-r9p3 PR E of E (KEI-213 cutover step 4.5 final)
- **GOV-12** gates-as-code — negative-path test proves enforcement
- **Cat 21 §0 BOUNDED-SPAWN HARDEST** + all 9 launch-blockers
- **Supersedes (operational scope):** PR #1221 (deprecated binary topology)
- **Composes with:** PRs A-D + all 9 lib PRs
- **Gates:** Phase 1 step 5 retire-persistent-tmux per Aiden + Viktor + Dave CONCUR

🤖 Generated with [Claude Code](https://claude.com/claude-code)