### PR TITLE
[SCOUT] fix(law-xv): align enforcement scripts to three-store (PR #1214 follow-up)

### DIFF
--- a/scripts/three_store_save.py
+++ b/scripts/three_store_save.py
@@ -2,11 +2,14 @@
 """
 three_store_save.py — Canonical 3-store save for directive completion (LAW XV).
 
+Amended 2026-05-27 (PR #1214 Agency_OS-uik): docs/MANUAL.md ARCHIVED;
+Supabase ceo_memory is now the sole SSOT. Drive mirror is best-effort,
+non-blocking (LAW_XV_DRIVE_MIRROR_FAIL on failure).
+
 Stores:
-  1. docs/MANUAL.md  — append entry under target SECTION
-  2. public.ceo_memory — upsert key ceo:directive_{directive}_complete
-  3. public.cis_directive_metrics — insert execution metrics row
-  4. Google Drive mirror via write_manual_mirror.py (best-effort)
+  1. public.ceo_memory — upsert key ceo:directive_{directive}_complete (PRIMARY)
+  2. public.cis_directive_metrics — insert execution metrics row
+  3. Google Drive mirror via write_manual_mirror.py (best-effort, non-blocking)
 
 Usage:
     python scripts/three_store_save.py --directive D1.8 --pr-number 329 --summary "..."
@@ -21,7 +24,7 @@ import os
 import re
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -104,12 +107,6 @@ def parse_args():
         "--summary", required=True, help='Completion summary text, or "-" to read from stdin'
     )
     parser.add_argument(
-        "--manual-section",
-        type=int,
-        default=13,
-        help="Manual section number to append entry under (default: 13)",
-    )
-    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print what would be written without writing anything",
@@ -117,75 +114,11 @@ def parse_args():
     return parser.parse_args()
 
 
-# ---------------------------------------------------------------------------
-# STORE 1 — MANUAL.md
-# ---------------------------------------------------------------------------
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-def manual_entry(directive: str, pr_number: int, summary: str, callsign: str) -> str:
-    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    tag = f"[{callsign.upper()}] " if callsign else ""
-    return f"\n### {tag}Directive {directive} (PR #{pr_number}, {date_str})\n{summary}\n"
-
-
-def save_manual(
-    directive: str,
-    pr_number: int,
-    summary: str,
-    section: int,
-    dry_run: bool,
-    callsign: str = "elliot",
-) -> bool:
-    manual_path = REPO_ROOT / "docs" / "MANUAL.md"
-    if not manual_path.exists():
-        print(f"[STORE 1/4] Manual: FAILED — docs/MANUAL.md not found at {manual_path}")
-        return False
-
-    content = manual_path.read_text()
-    lines = content.splitlines(keepends=True)
-
-    target_marker = f"## SECTION {section}"
-    target_idx = None
-    next_idx = None
-
-    for i, line in enumerate(lines):
-        if line.strip() == target_marker or line.strip().startswith(f"{target_marker} "):
-            target_idx = i
-        elif target_idx is not None and re.match(r"^## SECTION \d+", line.strip()):
-            next_idx = i
-            break
-
-    if target_idx is None:
-        print(f"[STORE 1/4] Manual: FAILED — marker '{target_marker}' not found in docs/MANUAL.md")
-        return False
-
-    entry = manual_entry(directive, pr_number, summary, callsign)
-
-    if dry_run:
-        insert_before = next_idx if next_idx is not None else len(lines)
-        print(
-            f"[DRY-RUN][STORE 1/4] Would insert before line {insert_before + 1} in docs/MANUAL.md:"
-        )
-        print("---")
-        print(entry.strip())
-        print("---")
-        return True
-
-    insert_at = next_idx if next_idx is not None else len(lines)
-    lines.insert(insert_at, entry)
-    try:
-        manual_path.write_text("".join(lines))
-        print(f"[STORE 1/4] Manual: OK — entry inserted under SECTION {section}")
-        return True
-    except Exception as exc:
-        print(f"[STORE 1/4] Manual: FAILED — {exc}")
-        return False
-
-
 # ---------------------------------------------------------------------------
-# STORE 2 — ceo_memory
+# STORE 1 — ceo_memory (PRIMARY, sole SSOT per LAW XV amended 2026-05-27)
 # ---------------------------------------------------------------------------
 
 
@@ -198,26 +131,26 @@ def save_ceo_memory(
         "directive": directive,
         "pr": pr_number,
         "summary": summary,
-        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "completed_at": datetime.now(UTC).isoformat(),
         "source": callsign,  # LAW XVII: tag write with callsign
     }
 
     if dry_run:
-        print(f"[DRY-RUN][STORE 2/4] Would upsert ceo_memory key={key!r}")
+        print(f"[DRY-RUN][STORE 1/3] Would upsert ceo_memory key={key!r}")
         print(f"  value={json.dumps(value)}")
         return True
 
     try:
         upsert_ceo_memory_key(callsign, key, value)
-        print(f"[STORE 2/4] ceo_memory: OK — key={key!r}")
+        print(f"[STORE 1/3] ceo_memory: OK — key={key!r}")
         return True
     except Exception as exc:  # noqa: BLE001
-        print(f"[STORE 2/4] ceo_memory: FAILED — {exc}")
+        print(f"[STORE 1/3] ceo_memory: FAILED — {exc}")
         return False
 
 
 # ---------------------------------------------------------------------------
-# STORE 3 — cis_directive_metrics
+# STORE 2 — cis_directive_metrics
 # ---------------------------------------------------------------------------
 
 
@@ -233,7 +166,7 @@ def save_metrics(
         directive_id = 0
         directive_ref = directive
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     row_preview = {
         "directive_id": directive_id,
         "directive_ref": directive_ref,
@@ -250,13 +183,13 @@ def save_metrics(
     }
 
     if dry_run:
-        print("[DRY-RUN][STORE 3/4] Would insert cis_directive_metrics row:")
+        print("[DRY-RUN][STORE 2/3] Would insert cis_directive_metrics row:")
         print(f"  {json.dumps(row_preview)}")
         return True
 
     dsn = _resolve_dsn()
     if not dsn:
-        print("[STORE 3/4] cis_directive_metrics: FAILED — DATABASE_URL / SUPABASE_DB_URL not set")
+        print("[STORE 2/3] cis_directive_metrics: FAILED — DATABASE_URL / SUPABASE_DB_URL not set")
         return False
 
     async def _insert() -> None:
@@ -310,29 +243,39 @@ def save_metrics(
     try:
         asyncio.run(_insert())
         print(
-            f"[STORE 3/4] cis_directive_metrics: OK — directive_ref={directive_ref!r}, directive_id={directive_id}"
+            f"[STORE 2/3] cis_directive_metrics: OK — directive_ref={directive_ref!r}, directive_id={directive_id}"
         )
         return True
     except Exception as exc:  # noqa: BLE001
-        print(f"[STORE 3/4] cis_directive_metrics: FAILED — {exc}")
+        print(f"[STORE 2/3] cis_directive_metrics: FAILED — {exc}")
         return False
 
 
 # ---------------------------------------------------------------------------
-# STORE 4 — Drive mirror (best-effort)
+# STORE 3 — Drive mirror (best-effort, non-blocking per LAW XV 2026-05-27)
 # ---------------------------------------------------------------------------
 
 
 def run_drive_mirror(dry_run: bool) -> None:
+    """Best-effort Drive mirror. Failure is LOGGED (LAW_XV_DRIVE_MIRROR_FAIL)
+    but does NOT block completion. The script-not-present case is also
+    non-blocking — Drive mirror is optional infrastructure per the amended
+    LAW XV (PR #1214, 2026-05-27)."""
     mirror_script = REPO_ROOT / "scripts" / "write_manual_mirror.py"
     if dry_run:
-        print(f"[DRY-RUN][STORE 4/4] Would run: {sys.executable} {mirror_script}")
+        print(f"[DRY-RUN][STORE 3/3] Would run: {sys.executable} {mirror_script}")
+        return
+    if not mirror_script.exists():
+        print("[STORE 3/3] Drive mirror: SKIPPED (write_manual_mirror.py not present)")
         return
     result = subprocess.run([sys.executable, str(mirror_script)], capture_output=True, text=True)
     if result.returncode == 0:
-        print("[STORE 4/4] Drive mirror: OK")
+        print("[STORE 3/3] Drive mirror: OK")
     else:
-        print(f"[STORE 4/4] Drive mirror: WARNING — exit {result.returncode}")
+        print(
+            f"[STORE 3/3] Drive mirror: LAW_XV_DRIVE_MIRROR_FAIL exit={result.returncode} "
+            "(non-blocking)"
+        )
         if result.stderr:
             print(f"  stderr: {result.stderr.strip()[:200]}")
 
@@ -352,43 +295,32 @@ def main():
 
     directive = args.directive
     pr_number = args.pr_number
-    section = args.manual_section
     dry_run = args.dry_run
     callsign = get_callsign()  # LAW XVII: fail loud on empty CALLSIGN
 
     if dry_run:
-        print(
-            f"[DRY-RUN] directive={directive!r} pr={pr_number} section={section} callsign={callsign!r}"
-        )
+        print(f"[DRY-RUN] directive={directive!r} pr={pr_number} callsign={callsign!r}")
         print()
 
     succeeded = []
 
-    # Store 1
-    ok1 = save_manual(directive, pr_number, summary, section, dry_run, callsign)
+    # Store 1 — ceo_memory (PRIMARY)
+    ok1 = save_ceo_memory(directive, pr_number, summary, dry_run, callsign)
     if ok1:
-        succeeded.append("Manual")
+        succeeded.append("ceo_memory")
     else:
         print(f"Succeeded before failure: {succeeded or 'none'}")
         sys.exit(1)
 
-    # Store 2
-    ok2 = save_ceo_memory(directive, pr_number, summary, dry_run, callsign)
+    # Store 2 — cis_directive_metrics
+    ok2 = save_metrics(directive, pr_number, summary, dry_run, callsign)
     if ok2:
-        succeeded.append("ceo_memory")
-    else:
-        print(f"Succeeded before failure: {succeeded}")
-        sys.exit(1)
-
-    # Store 3
-    ok3 = save_metrics(directive, pr_number, summary, dry_run, callsign)
-    if ok3:
         succeeded.append("cis_directive_metrics")
     else:
         print(f"Succeeded before failure: {succeeded}")
         sys.exit(1)
 
-    # Store 4 — best-effort
+    # Store 3 — Drive mirror (best-effort, non-blocking)
     run_drive_mirror(dry_run)
 
     print()

--- a/src/bot_common/session_end_gate.py
+++ b/src/bot_common/session_end_gate.py
@@ -1,19 +1,22 @@
 """session_end_gate.py — LAW XV mechanical enforcement (Outcome 2).
 
 Per Dave System Health Monitoring directive 2026-05-12 Outcome 2 + Max's spec
-ts 1778553034:
+ts 1778553034. Amended 2026-05-27 (PR #1214 Agency_OS-uik): docs/MANUAL.md
+ARCHIVED; Manual Section 13 check REMOVED from the gate. ceo_memory is the
+sole SSOT; Drive mirror is best-effort (non-blocking, not gated).
 
-  "Prevent completion claims that skip the 4-store save. Mechanical check,
-   not an instruction agents can ignore."
+  "Prevent completion claims that skip the save. Mechanical check, not an
+   instruction agents can ignore."
 
-Trigger: outbound message contains 4-store completion language. Gate then
-verifies all three queryable stores were written for the claimed directive
-within the last 5 minutes; refuses the post if any store is missing.
+Trigger: outbound message contains store-save completion language. Gate
+verifies both required stores were written for the claimed directive
+within the last 5 minutes; refuses the post if either is missing.
 
-Stores checked (matches scripts/three_store_save.py):
+Stores checked (matches scripts/three_store_save.py, post-2026-05-27 amend):
   1. ceo_memory.key == "ceo:directive_{N}_complete" with updated_at < 5min
   2. cis_directive_metrics.directive_id == N (or directive_ref contains N)
-  3. docs/MANUAL.md Section 13 entry referencing #N
+  Drive mirror is best-effort and NOT gated — failure logs
+  LAW_XV_DRIVE_MIRROR_FAIL but does not block.
 
 Mirrors verify_gate.py structure (gate_check returns (ok, blocker_reason))
 so slack_relay.py can call it identically.
@@ -29,7 +32,6 @@ import os
 import re
 import sys
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from typing import Final
 
 logger = logging.getLogger("session_end_gate")
@@ -59,10 +61,6 @@ _DIRECTIVE_NUM_RE: Final = re.compile(r"\bdirective[_#\s]+(\d+)", re.IGNORECASE)
 
 # How recently the ceo_memory row must have been updated to count as a fresh save.
 FRESH_SAVE_WINDOW = timedelta(minutes=5)
-
-MANUAL_PATH = Path("docs/MANUAL.md")
-SECTION_13_HEADER_RE: Final = re.compile(r"^##\s*SECTION\s*13\b", re.IGNORECASE | re.MULTILINE)
-SECTION_BREAK_RE: Final = re.compile(r"^##\s*SECTION\b", re.IGNORECASE | re.MULTILINE)
 
 
 def has_completion_trigger(text: str) -> bool:
@@ -151,27 +149,9 @@ def check_cis_metrics(directive_n: int) -> tuple[bool, str]:
     return False, f"cis_directive_metrics: no row for directive_id={directive_n}"
 
 
-def check_manual_section_13(directive_n: int) -> tuple[bool, str]:
-    """Returns (entry_found, reason_if_not). Searches Section 13 body only."""
-    if not MANUAL_PATH.exists():
-        return True, "(MANUAL.md missing — skipped)"
-    try:
-        content = MANUAL_PATH.read_text()
-    except OSError as exc:
-        return True, f"(MANUAL.md read failed: {exc})"
-    header_match = SECTION_13_HEADER_RE.search(content)
-    if not header_match:
-        return True, "(Section 13 header missing — skipped)"
-    section_start = header_match.end()
-    next_section = SECTION_BREAK_RE.search(content, section_start)
-    section_end = next_section.start() if next_section else len(content)
-    body = content[section_start:section_end]
-    # Look for "#N" or "directive N" or "directive_N" patterns
-    n_str = str(directive_n)
-    pattern = re.compile(rf"#{n_str}\b|\bdirective[_#\s]+{n_str}\b", re.IGNORECASE)
-    if pattern.search(body):
-        return True, ""
-    return False, f"MANUAL.md Section 13: no entry referencing #{directive_n}"
+# NOTE: check_manual_section_13 removed 2026-05-27 (PR #1214 Agency_OS-uik).
+# docs/MANUAL.md is archived; the Manual Section 13 entry is no longer a
+# gated store. Drive mirror is best-effort (non-blocking) and NOT gated.
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -180,7 +160,12 @@ def check_manual_section_13(directive_n: int) -> tuple[bool, str]:
 
 
 def gate_check(text: str, now: datetime | None = None) -> tuple[bool, str | None]:
-    """Verify all 3 queryable stores are written for any claimed-complete directive.
+    """Verify both required stores are written for any claimed-complete directive.
+
+    Required stores (per amended LAW XV 2026-05-27 PR #1214):
+      1. ceo_memory (PRIMARY SSOT)
+      2. cis_directive_metrics
+    Drive mirror is best-effort and NOT gated.
 
     Returns (ok, blocker_reason):
       - ok=True, blocker_reason=None → message can post
@@ -206,9 +191,6 @@ def gate_check(text: str, now: datetime | None = None) -> tuple[bool, str | None
     ok_cis, reason_cis = check_cis_metrics(directive_n)
     if not ok_cis:
         blockers.append(reason_cis)
-    ok_man, reason_man = check_manual_section_13(directive_n)
-    if not ok_man:
-        blockers.append(reason_man)
     if blockers:
         return False, (
             f"R_LAW_XV_BLOCKED: directive {directive_n} — "

--- a/src/governance/contracts/README.md
+++ b/src/governance/contracts/README.md
@@ -8,7 +8,7 @@ Typed schemas for governance artefacts. Pydantic v2 BaseModel + Anthropic-compat
 |---|---|---|
 | `DirectiveContract` | `directive_contract.py` | Dave-issued directive shape (intent + context + latitude + frozen_artifacts + success_criteria + scope IN/OUT + spend cap + step0 exemption + source + task_ref) |
 | `PeerReviewContract` | `peer_review_contract.py` | Bot-on-bot review verdict (concur / differ / yellow_flag) with audit evidence |
-| `CompletionClaimContract` | `completion_claim_contract.py` | `[COMPLETE:<callsign>]` claim (branch + commit + verification stdout + four-store check) |
+| `CompletionClaimContract` | `completion_claim_contract.py` | `[COMPLETE:<callsign>]` claim (branch + commit + verification stdout + three-store check) |
 
 ## How directives map to schemas
 
@@ -26,7 +26,7 @@ Clone executes
   ↓ on concur: clone writes CompletionClaimContract → outbox
 
 Parent bot reads outbox
-  ↓ verifies four_store_complete()
+  ↓ verifies three_store_complete()
   ↓ if all stores written: surface CompletionClaimContract.pr_url to Dave
   ↓ if not: dispatch follow-up to fill missing stores
 ```
@@ -58,7 +58,7 @@ parsed = DirectiveContract.model_validate(response.content[0].input)
 Run `pytest tests/governance/test_contracts.py` to verify each schema:
 - Accepts a sample Dave directive (DirectiveContract).
 - Rejects unknown fields (`extra="forbid"`).
-- Computes `four_store_complete()` correctly (CompletionClaimContract).
+- Computes `three_store_complete()` correctly (CompletionClaimContract).
 - Status enum constraints fire (PeerReviewContract).
 
 ## Phase 1 dispatch

--- a/src/governance/contracts/completion_claim_contract.py
+++ b/src/governance/contracts/completion_claim_contract.py
@@ -1,8 +1,14 @@
 """CompletionClaimContract — typed shape for a bot's completion claim.
 
-Encodes R9 Verify-Before-Claim + LAW XV Four-Store Completion + LAW XIV
+Encodes R9 Verify-Before-Claim + LAW XV Three-Store Completion + LAW XIV
 Raw Output Mandate. Every '[COMPLETE:<callsign>]' message should be
 expressible as one of these.
+
+Amended 2026-05-27 (PR #1214 Agency_OS-uik): docs/MANUAL.md ARCHIVED.
+Required stores collapsed from four to two (ceo_memory + cis_metrics);
+Drive mirror is best-effort, not gated. `stored_in_manual` field retained
+on the model for backwards-compat with serialized claims but is no longer
+checked by `three_store_complete()`.
 """
 
 from __future__ import annotations
@@ -59,7 +65,10 @@ class CompletionClaimContract(BaseModel):
         ),
     )
 
-    # LAW XV Four-Store Completion check.
+    # LAW XV Three-Store Completion check (amended 2026-05-27 PR #1214).
+    # stored_in_manual + stored_in_drive_mirror retained for serialization
+    # backwards-compat but NOT checked by three_store_complete() — Manual is
+    # archived; Drive mirror is best-effort.
     stored_in_manual: bool = Field(default=False)
     stored_in_ceo_memory: bool = Field(default=False)
     stored_in_cis_metrics: bool = Field(default=False)
@@ -83,13 +92,20 @@ class CompletionClaimContract(BaseModel):
         description="Free-form notes (deferred items, follow-ups, caveats).",
     )
 
+    def three_store_complete(self) -> bool:
+        """LAW XV check — both required stores written?
+
+        Amended 2026-05-27 (PR #1214 Agency_OS-uik): only ceo_memory +
+        cis_metrics are required. Drive mirror is best-effort (non-blocking);
+        Manual is archived. The legacy `stored_in_manual` and
+        `stored_in_drive_mirror` flags are kept on the model for serialized-
+        claim backwards-compat but NOT checked here.
+        """
+        return self.stored_in_ceo_memory and self.stored_in_cis_metrics
+
+    # Deprecated alias kept for backwards-compat with callers that still
+    # reference the four-store method name. Removes when no callers remain.
     def four_store_complete(self) -> bool:
-        """LAW XV check — all four stores written?"""
-        return all(
-            (
-                self.stored_in_manual,
-                self.stored_in_ceo_memory,
-                self.stored_in_cis_metrics,
-                self.stored_in_drive_mirror,
-            )
-        )
+        """DEPRECATED — renamed to three_store_complete in PR #1214. Forwards
+        to the new method for callers that haven't updated yet."""
+        return self.three_store_complete()

--- a/tests/bot_common/test_session_end_gate.py
+++ b/tests/bot_common/test_session_end_gate.py
@@ -142,71 +142,8 @@ def test_check_cis_metrics_missing_returns_false() -> None:
     assert "no row" in reason
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# check_manual_section_13
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-def test_check_manual_section_13_hit(monkeypatch, tmp_path) -> None:
-    manual = tmp_path / "MANUAL.md"
-    manual.write_text(
-        "# Manual\n\n"
-        "## SECTION 12 — X\nfoo\n\n"
-        "## SECTION 13 — BUILD SEQUENCE\n"
-        "| Sprint 1 | #9001 | Outcome 2 build | COMPLETE |\n\n"
-        "## SECTION 14 — Y\nbar\n"
-    )
-    monkeypatch.setattr(gate, "MANUAL_PATH", manual)
-    ok, reason = gate.check_manual_section_13(9001)
-    assert ok is True
-
-
-def test_check_manual_section_13_miss(monkeypatch, tmp_path) -> None:
-    manual = tmp_path / "MANUAL.md"
-    manual.write_text(
-        "## SECTION 13 — BUILD SEQUENCE\n"
-        "| Sprint 1 | #1234 | other | COMPLETE |\n\n"
-        "## SECTION 14 — Y\nbar\n"
-    )
-    monkeypatch.setattr(gate, "MANUAL_PATH", manual)
-    ok, reason = gate.check_manual_section_13(9001)
-    assert ok is False
-    assert "#9001" in reason
-
-
-def test_check_manual_section_13_directive_text_match(monkeypatch, tmp_path) -> None:
-    """Should also match "directive 9001" text format."""
-    manual = tmp_path / "MANUAL.md"
-    manual.write_text(
-        "## SECTION 13 — BUILD SEQUENCE\n"
-        "Per directive 9001, this was shipped.\n\n"
-        "## SECTION 14 — Y\n"
-    )
-    monkeypatch.setattr(gate, "MANUAL_PATH", manual)
-    ok, reason = gate.check_manual_section_13(9001)
-    assert ok is True
-
-
-def test_check_manual_section_13_missing_section_skipped(monkeypatch, tmp_path) -> None:
-    manual = tmp_path / "MANUAL.md"
-    manual.write_text("## SECTION 1 — X\n")  # no section 13
-    monkeypatch.setattr(gate, "MANUAL_PATH", manual)
-    ok, reason = gate.check_manual_section_13(9001)
-    assert ok is True
-    assert "skipped" in reason
-
-
-def test_check_manual_section_13_does_not_match_outside_section(monkeypatch, tmp_path) -> None:
-    """A #9001 reference in Section 12 should NOT satisfy the Section 13 check."""
-    manual = tmp_path / "MANUAL.md"
-    manual.write_text(
-        "## SECTION 12 — Notes\nSee #9001 for context.\n\n"
-        "## SECTION 13 — BUILD SEQUENCE\nUnrelated rows.\n\n"
-        "## SECTION 14 — Y\n"
-    )
-    monkeypatch.setattr(gate, "MANUAL_PATH", manual)
-    ok, _ = gate.check_manual_section_13(9001)
-    assert ok is False
+# check_manual_section_13 tests removed 2026-05-27 (PR #1214 Agency_OS-uik) —
+# docs/MANUAL.md archived; gate no longer enforces Manual Section 13.
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -235,11 +172,10 @@ def test_gate_check_trigger_but_no_directive_number_passes() -> None:
 
 
 def test_gate_check_all_stores_present_passes(monkeypatch, tmp_path) -> None:
+    """Amended 2026-05-27 (PR #1214): only ceo_memory + cis_metrics gate;
+    Manual section check removed. Both stores present → pass."""
     now = datetime(2026, 5, 12, 0, 0, 0, tzinfo=UTC)
     fresh_ts = (now - timedelta(minutes=1)).isoformat()
-    manual = tmp_path / "MANUAL.md"
-    manual.write_text("## SECTION 13 — BUILD SEQUENCE\n| Sprint X | #9001 | done | COMPLETE |\n")
-    monkeypatch.setattr(gate, "MANUAL_PATH", manual)
 
     def fake_sb_get(table: str, params: dict) -> list[dict]:
         if table == "ceo_memory":
@@ -257,9 +193,6 @@ def test_gate_check_all_stores_present_passes(monkeypatch, tmp_path) -> None:
 def test_gate_check_partial_fail_blocks(monkeypatch, tmp_path) -> None:
     """ceo_memory missing → blocked with directive number in reason."""
     now = datetime(2026, 5, 12, 0, 0, 0, tzinfo=UTC)
-    manual = tmp_path / "MANUAL.md"
-    manual.write_text("## SECTION 13 — BUILD SEQUENCE\n| #9001 | done | COMPLETE |\n")
-    monkeypatch.setattr(gate, "MANUAL_PATH", manual)
 
     def fake_sb_get(table: str, params: dict) -> list[dict]:
         if table == "ceo_memory":
@@ -277,14 +210,15 @@ def test_gate_check_partial_fail_blocks(monkeypatch, tmp_path) -> None:
     assert "three_store_save.py" in reason
 
 
-def test_gate_check_all_three_missing_lists_all_blockers(monkeypatch, tmp_path) -> None:
+def test_gate_check_all_required_stores_missing_lists_all_blockers(monkeypatch, tmp_path) -> None:
+    """Amended 2026-05-27 (PR #1214): all required stores (ceo_memory +
+    cis_metrics) missing → both listed as blockers. Manual is no longer
+    a required store and is not in the blocker list."""
     now = datetime(2026, 5, 12, 0, 0, 0, tzinfo=UTC)
-    manual = tmp_path / "MANUAL.md"
-    manual.write_text("## SECTION 13 — BUILD SEQUENCE\nnothing here\n")
-    monkeypatch.setattr(gate, "MANUAL_PATH", manual)
     with patch("src.evo.supabase_client.sb_get", _fake_sb_get_factory([])):
         ok, reason = gate.gate_check("directive 7777 complete", now=now)
     assert ok is False
     assert "ceo_memory" in reason
     assert "cis_directive_metrics" in reason
-    assert "MANUAL.md" in reason
+    # Manual is no longer gated — must NOT appear in blocker list.
+    assert "MANUAL.md" not in reason

--- a/tests/test_three_store_save.py
+++ b/tests/test_three_store_save.py
@@ -33,18 +33,8 @@ def test_callsign_empty_string_fails_loud(monkeypatch):
         tss.get_callsign()
 
 
-def test_manual_entry_tagged_with_callsign():
-    """Manual entry includes [CALLSIGN] prefix."""
-    entry = tss.manual_entry("D1.8", 329, "test summary", "elliot")
-    assert "[ELLIOT]" in entry
-    assert "D1.8" in entry
-    assert "PR #329" in entry
-
-
-def test_manual_entry_tagged_aiden():
-    """Aiden entries tagged [AIDEN]."""
-    entry = tss.manual_entry("D2.2", 999, "aiden run", "aiden")
-    assert "[AIDEN]" in entry
+# manual_entry tests removed 2026-05-27 (PR #1214 Agency_OS-uik) — docs/MANUAL.md
+# archived; three_store_save.py no longer touches the Manual.
 
 
 # ─── asyncpg migration (REST → pgbouncer-friendly direct DB) ──────────────


### PR DESCRIPTION
## Summary

**GOV-12 fix** per Aiden's post-merge audit of PR #1214 (Agency_OS-uik LAW XV flip). Runtime enforcement gates still required `docs/MANUAL.md` as Store 1 and treated Drive-mirror as blocking — contradicting the ratified three-store rule (ceo_memory primary + cis_directive_metrics + Drive-mirror best-effort).

Aiden flagged `scripts/three_store_save.py` line 141 specifically + asked me to grep broader. I found 3 gating files plus 1 typed contract that still enforced the old four-store shape.

**Filed under:** Agency_OS-uik (sibling commit; this closes the GOV-12 violation introduced by the doc-only PR #1214).

## What lands (6 files, +102/-248)

| File | Change |
|---|---|
| `scripts/three_store_save.py` | Removed `save_manual()` + `manual_entry()` + `--manual-section` arg. Renumbered ceo_memory → Store 1 (PRIMARY), cis_metrics → Store 2, Drive mirror → Store 3 (best-effort, non-blocking, logs `LAW_XV_DRIVE_MIRROR_FAIL`). All `[STORE N/4]` log labels → `[STORE N/3]`. |
| `src/bot_common/session_end_gate.py` | Removed `check_manual_section_13()` + `MANUAL_PATH` + section regexes. `gate_check()` now blocks on missing ceo_memory + cis_metrics only; Drive mirror NOT gated. |
| `src/governance/contracts/completion_claim_contract.py` | Renamed `four_store_complete()` → `three_store_complete()` (checks only ceo_memory + cis_metrics). Kept `four_store_complete()` as DEPRECATED alias forwarding to the new method for backwards-compat with `tests/governance/test_contracts.py` line 176. |
| `src/governance/contracts/README.md` | Documentation references updated. |
| `tests/test_three_store_save.py` | Removed 2 obsolete tests for `manual_entry()` (function deleted). |
| `tests/bot_common/test_session_end_gate.py` | Removed 5 obsolete `check_manual_section_13` tests. Updated 3 `gate_check` tests — removed `MANUAL_PATH` monkeypatch setup; renamed `test_gate_check_all_three_missing` → `test_gate_check_all_required_stores_missing` + assertion that MANUAL.md is NOT in blocker list. |

## Verification

```
$ python3 -m pytest tests/test_three_store_save.py tests/bot_common/test_session_end_gate.py \
    tests/scripts/test_session_end_hook.py tests/governance/test_contracts.py -q
81 passed in 0.32s

$ python3 -m ruff check scripts/three_store_save.py src/bot_common/session_end_gate.py \
    src/governance/contracts/completion_claim_contract.py tests/test_three_store_save.py \
    tests/bot_common/test_session_end_gate.py
All checks passed!

$ python3 -m ruff format --check (same files)
5 files already formatted
```

## Backwards-compat preserved

- `CompletionClaimContract.stored_in_manual` and `.stored_in_drive_mirror` fields **retained** on the Pydantic model so serialized claims from before this PR still parse. They are simply NOT checked by `three_store_complete()`.
- `four_store_complete()` method retained as DEPRECATED alias forwarding to `three_store_complete()`. `tests/governance/test_contracts.py` line 176 (which still asserts `four_store_complete() is False` against default-False flags) continues passing without modification. Future PR can clean up the alias once all callers migrate.

## Scope (per `feedback_split_orthogonal_scope`)

**In scope:** GATING enforcement that contradicted the ratified rule. The three gating paths Aiden's audit named or implied:
1. `scripts/three_store_save.py` — explicit save flow
2. `src/bot_common/session_end_gate.py` — completion-claim outbound gate (mechanical refusal of posts)
3. `src/governance/contracts/completion_claim_contract.py` — typed claim shape

**Out of scope (deliberately):**
- `scripts/session_end_check.py` — informational only (`Always 0 — informational only, never blocking` per the docstring). References docs/MANUAL.md but doesn't block on it. **Follow-up KEI candidate.**
- `scripts/session_end_hook.py` — SessionEnd hook does best-effort Drive mirror if Manual changed; non-blocking by design. Hook docstring still says "auto four-store save" but step 1 is a no-op for an archived Manual that never changes. **Follow-up KEI candidate.**
- `docs/MANUAL.md` itself — remains in repo (archived per PR #1214) as historical artefact.

## Gate alignment per CONCUR-GATE RULE

**Does this satisfy the gate?** Yes — STATE-SEPARATION criterion ("durable Temporal+Postgres + knowledge atomized pgvector + config versioned + ephemeral dies-with-spawn + cold archive recall-API-only") + GOV-12 ("Gates As Code Not Comments"). PR #1214 ratified the doc; this PR makes the runtime gate match the doc. Governance-coherent + closes the empirical-vs-ratified gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

bd: Agency_OS-uik. Closes on merge.