### PR TITLE
[SCOUT] feat(memory): Hindsight synthesize + trace + complete delete primitives (Agency_OS-ijf0)

### DIFF
--- a/keiracom_system/fleet/hindsight/smoke_wrappers.py
+++ b/keiracom_system/fleet/hindsight/smoke_wrappers.py
@@ -54,6 +54,18 @@ class FleetHindsightClient:
     def reflect(self, *, bank_id: str, query: str) -> dict[str, Any]:
         return self._post(f"/v1/default/banks/{bank_id}/reflect", {"query": query})
 
+    def delete(self, *, bank_id: str, memory_id: str) -> dict[str, Any]:
+        path = f"/v1/default/banks/{bank_id}/memories/{memory_id}"
+        req = urlrequest.Request(f"{FLEET_HINDSIGHT_BASE}{path}", method="DELETE")
+        try:
+            with urlrequest.urlopen(req, timeout=120) as resp:
+                body = resp.read().decode() or "{}"
+                return json.loads(body) if body.strip().startswith("{") else {"status": resp.status}
+        except urlerror.HTTPError as e:
+            return {"error": f"HTTP_{e.code}", "body": e.read().decode()[:500]}
+        except (urlerror.URLError, json.JSONDecodeError, TimeoutError) as e:
+            return {"error": str(e)}
+
     def _post(self, path: str, body: dict) -> Any:
         data = json.dumps(body).encode()
         req = urlrequest.Request(

--- a/src/keiracom_system/memory/wrappers/__init__.py
+++ b/src/keiracom_system/memory/wrappers/__init__.py
@@ -20,13 +20,29 @@ Exports:
 - ArtifactWrapper       — Artifact → Hindsight Experience
 - TaskContextWrapper    — TaskContext → Hindsight Observation
 - AntiPatternWrapper    — AntiPattern → Hindsight Opinion (with supersession edge)
-- compose_audit_record  — Trace primitive composition (Aiden gate D)
+- compose_audit_record  — single-reflect AuditRecord (HIPAA/legal/accounting)
 - AuditRecord           — structured audit-trail dataclass
+- synthesize            — multi-source synthesis with source-atom pointers
+- SynthesisResult       — Aiden drift-mitigated synthesis result shape
+- trace                 — provenance chain walker for a memory_id
+- ProvenanceChain       — ordered provenance chain dataclass
+- ProvenanceEvent       — single ingest/supersede event dataclass
+- complete_delete       — hard-delete primitive with audit log
+- DeleteRecord          — structured delete audit-log entry
 """
 
 from .antipattern_wrapper import AntiPatternWrapper
 from .artifact_wrapper import ArtifactWrapper
 from .decision_wrapper import DecisionWrapper
+from .primitives import (
+    DeleteRecord,
+    ProvenanceChain,
+    ProvenanceEvent,
+    SynthesisResult,
+    complete_delete,
+    synthesize,
+    trace,
+)
 from .taskcontext_wrapper import TaskContextWrapper
 from .trace_composition import AuditRecord, compose_audit_record
 
@@ -35,6 +51,13 @@ __all__ = [
     "ArtifactWrapper",
     "AuditRecord",
     "DecisionWrapper",
+    "DeleteRecord",
+    "ProvenanceChain",
+    "ProvenanceEvent",
+    "SynthesisResult",
     "TaskContextWrapper",
+    "complete_delete",
     "compose_audit_record",
+    "synthesize",
+    "trace",
 ]

--- a/src/keiracom_system/memory/wrappers/_base.py
+++ b/src/keiracom_system/memory/wrappers/_base.py
@@ -25,6 +25,8 @@ class HindsightClient(Protocol):
 
     def reflect(self, *, bank_id: str, query: str) -> dict[str, Any]: ...
 
+    def delete(self, *, bank_id: str, memory_id: str) -> dict[str, Any]: ...
+
 
 class TenantExtensionProtocol(Protocol):
     """Subset of Orion's KeiracomTenantExtension surface the wrappers need.

--- a/src/keiracom_system/memory/wrappers/primitives.py
+++ b/src/keiracom_system/memory/wrappers/primitives.py
@@ -1,0 +1,285 @@
+"""primitives.py — Synthesize / Trace / complete Delete primitives.
+
+Closes the YELLOW-3 audit gap (Aiden pre-cutover audit 2026-05-27):
+3 of 6 MAL V1 primitives (Ingest/Recall/Supersede) ship via the 4 domain
+wrappers. The remaining three are cross-cutting query primitives — they
+operate on any memory regardless of MAL node type — and live here.
+
+Canonical key (per audit-dispatch checklist `_orchestrator.md`):
+
+ceo:memory_abstraction_layer_v1 — eleven_agreed_positions #3:
+    "Six query primitives: Ingest, Recall, Synthesize, Supersede, Trace, Delete"
+
+ceo:cutover_plan_v1 — wave_1_foundation:
+    "Hindsight primitives complete (synthesize+trace+delete with source-atom
+     pointers) + atom granularity spec + tenant scoping per-callsite +
+     bounded-spawn dispatcher-kill + Go sidecar deploy + real-time invalidation"
+
+Synthesize MUST retain source-atom pointers (Aiden Phase-2 mitigation against
+synthesis drift) — `SynthesisResult.source_atom_ids` is non-empty by
+construction; empty citations fail loud rather than silently returning a
+floating answer.
+
+Trace returns the provenance chain for a memory_id — supersedes edges + the
+target's own ingest event — as an ordered `ProvenanceChain`. Distinct from
+`trace_composition.compose_audit_record` (single-reflect AuditRecord for
+HIPAA/legal-privilege/accounting one-shot audit).
+
+Complete delete = hard-delete via the engine's DELETE endpoint + structured
+`DeleteRecord` audit-log entry. The partial delete (operation valid in
+AuditRecord shape but no method to execute it) is what this primitive
+completes.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from ._base import HindsightClient, TenantExtensionProtocol
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SynthesisResult:
+    """LLM-composed synthesis with mandatory source-atom pointers.
+
+    Aiden Phase-2 drift mitigation: `source_atom_ids` must be non-empty so
+    every synthesised answer is traceable back to the ground-truth memories
+    that grounded it. Empty citations indicate the engine did not retrieve
+    supporting evidence — fail loud instead of returning a floating answer.
+    """
+
+    synthesized_answer: str
+    source_atom_ids: list[str]
+    reasoning_chain: list[dict[str, Any]] = field(default_factory=list)
+    otel_trace_id: str = ""
+    schema_version: str = "1.0"
+
+
+@dataclass(frozen=True)
+class ProvenanceEvent:
+    timestamp: str
+    event_type: str
+    actor: str
+    memory_id: str
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProvenanceChain:
+    """Ordered provenance for a target memory_id.
+
+    - `events`: ingest + supersede events ordered oldest -> newest.
+    - `supersedes`: memory_ids the target itself supersedes (from its own
+      metadata.supersedes edge).
+    - `superseded_by`: memory_ids whose metadata.supersedes == target
+      (AntiPatterns or supersession-via-evolution facts pointing at it).
+    """
+
+    target_memory_id: str
+    tenant_id: str
+    events: list[ProvenanceEvent] = field(default_factory=list)
+    supersedes: list[str] = field(default_factory=list)
+    superseded_by: list[str] = field(default_factory=list)
+    schema_version: str = "1.0"
+
+
+@dataclass(frozen=True)
+class DeleteRecord:
+    """Structured audit-log entry for a hard-delete.
+
+    `audit_purpose` mirrors the AuditRecord taxonomy so compliance pipelines
+    consume a uniform shape across single-reflect audits and delete events.
+    """
+
+    memory_id: str
+    tenant_id: str
+    actor: str
+    deleted_at: str
+    reason: str
+    audit_purpose: str = "general"
+    otel_trace_id: str = ""
+    engine_response: dict[str, Any] = field(default_factory=dict)
+    schema_version: str = "1.0"
+
+
+_VALID_AUDIT_PURPOSES = frozenset({"hipaa", "legal_privilege", "accounting", "general"})
+
+
+def synthesize(
+    *,
+    client: HindsightClient,
+    tenant_extension: TenantExtensionProtocol,
+    tenant_id: str,
+    query: str,
+) -> SynthesisResult:
+    """Compose a multi-source synthesis via Hindsight reflect with source-atom
+    pointers retained.
+
+    Fail-loud: empty `tenant_id` / `query` / zero-citation reflect raise
+    ValueError. The zero-citation guard is the Aiden drift mitigation — a
+    synthesis with no traceable atoms is exactly the failure mode V1 must
+    prevent.
+    """
+    if not tenant_id:
+        raise ValueError("tenant_id required for synthesize (BYOK boundary)")
+    if not query:
+        raise ValueError("query required for synthesize")
+    bank_id = tenant_extension.get_bank_id(tenant_id)
+    resp = client.reflect(bank_id=bank_id, query=query)
+    raw_cites = resp.get("citations", []) or resp.get("cited_memory_ids", [])
+    source_atom_ids = [c if isinstance(c, str) else str(c.get("id", "")) for c in raw_cites]
+    source_atom_ids = [c for c in source_atom_ids if c]
+    if not source_atom_ids:
+        raise ValueError(
+            "synthesize produced zero source-atom pointers — synthesis drift "
+            "guard (Aiden Phase-2 mitigation). Either no relevant memories in "
+            "bank or engine returned an ungrounded answer."
+        )
+    answer = resp.get("answer") or resp.get("synthesised_answer") or ""
+    reasoning_chain = resp.get("reasoning_chain", []) or resp.get("trace", [])
+    otel_trace_id = resp.get("otel_trace_id") or str(uuid.uuid4())
+    log.info(
+        "synthesize composed: tenant=%s atoms=%d query_len=%d",
+        tenant_id,
+        len(source_atom_ids),
+        len(query),
+    )
+    return SynthesisResult(
+        synthesized_answer=answer,
+        source_atom_ids=source_atom_ids,
+        reasoning_chain=reasoning_chain,
+        otel_trace_id=otel_trace_id,
+    )
+
+
+def trace(
+    *,
+    client: HindsightClient,
+    tenant_extension: TenantExtensionProtocol,
+    tenant_id: str,
+    memory_id: str,
+    walk_top_k: int = 20,
+) -> ProvenanceChain:
+    """Walk supersedes/superseded-by edges around a memory_id and return the
+    ordered provenance chain.
+
+    V1 implementation: a single recall query keyed on memory_id surfaces
+    memories that cite or are cited by the target via metadata.supersedes
+    edges (AntiPatternWrapper writes that key when superseding). The chain
+    is reconstructed from the returned metadata.
+    """
+    if not tenant_id:
+        raise ValueError("tenant_id required for trace (BYOK boundary)")
+    if not memory_id:
+        raise ValueError("memory_id required for trace")
+    bank_id = tenant_extension.get_bank_id(tenant_id)
+    related = client.recall(bank_id=bank_id, query=memory_id, top_k=walk_top_k)
+    events: list[ProvenanceEvent] = []
+    supersedes: list[str] = []
+    superseded_by: list[str] = []
+    for m in related:
+        if not isinstance(m, dict):
+            continue
+        meta_raw = m.get("metadata", {}) or {}
+        meta = {str(k): str(v) for k, v in meta_raw.items()}
+        mid = str(m.get("id", "") or m.get("memory_id", ""))
+        if not mid:
+            continue
+        timestamp = meta.get("timestamp") or meta.get("created_at") or ""
+        actor = meta.get("author") or meta.get("actor") or "unknown"
+        # Edge: this memory supersedes the target.
+        if meta.get("supersedes") == memory_id:
+            superseded_by.append(mid)
+            events.append(
+                ProvenanceEvent(
+                    timestamp=timestamp,
+                    event_type="supersede",
+                    actor=actor,
+                    memory_id=mid,
+                    metadata=meta,
+                )
+            )
+        # Self: the target's own ingest event + its outbound supersedes edge.
+        if mid == memory_id:
+            outbound = meta.get("supersedes")
+            if outbound:
+                supersedes.append(outbound)
+            events.append(
+                ProvenanceEvent(
+                    timestamp=timestamp,
+                    event_type="ingest",
+                    actor=actor,
+                    memory_id=mid,
+                    metadata=meta,
+                )
+            )
+    events.sort(key=lambda e: (e.timestamp, e.event_type))
+    return ProvenanceChain(
+        target_memory_id=memory_id,
+        tenant_id=tenant_id,
+        events=events,
+        supersedes=supersedes,
+        superseded_by=superseded_by,
+    )
+
+
+def complete_delete(
+    *,
+    client: HindsightClient,
+    tenant_extension: TenantExtensionProtocol,
+    tenant_id: str,
+    memory_id: str,
+    actor: str,
+    reason: str,
+    audit_purpose: str = "general",
+) -> DeleteRecord:
+    """Hard-delete a memory via the engine's DELETE endpoint and emit a
+    structured DeleteRecord for the audit log.
+
+    Fail-loud on missing tenant / memory_id / actor / reason — a delete with
+    no actor or reason is exactly the audit-trail gap regulatory verticals
+    must prevent.
+    """
+    if not tenant_id:
+        raise ValueError("tenant_id required for complete_delete (BYOK boundary)")
+    if not memory_id:
+        raise ValueError("memory_id required for complete_delete")
+    if not actor:
+        raise ValueError("actor required for complete_delete (audit-trail invariant)")
+    if not reason:
+        raise ValueError("reason required for complete_delete (audit-trail invariant)")
+    if audit_purpose not in _VALID_AUDIT_PURPOSES:
+        raise ValueError(
+            f"unknown audit_purpose {audit_purpose!r}; allowed: {sorted(_VALID_AUDIT_PURPOSES)}"
+        )
+    bank_id = tenant_extension.get_bank_id(tenant_id)
+    engine_resp = client.delete(bank_id=bank_id, memory_id=memory_id)
+    otel_trace_id = ""
+    if isinstance(engine_resp, dict):
+        otel_trace_id = str(engine_resp.get("otel_trace_id", "") or "")
+    if not otel_trace_id:
+        otel_trace_id = str(uuid.uuid4())
+    rec = DeleteRecord(
+        memory_id=memory_id,
+        tenant_id=tenant_id,
+        actor=actor,
+        deleted_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        reason=reason,
+        audit_purpose=audit_purpose,
+        otel_trace_id=otel_trace_id,
+        engine_response=engine_resp if isinstance(engine_resp, dict) else {},
+    )
+    log.info(
+        "complete_delete: tenant=%s memory=%s actor=%s purpose=%s",
+        tenant_id,
+        memory_id,
+        actor,
+        audit_purpose,
+    )
+    return rec

--- a/tests/keiracom_system/memory/wrappers/test_primitives.py
+++ b/tests/keiracom_system/memory/wrappers/test_primitives.py
@@ -1,0 +1,463 @@
+"""tests for keiracom_system.memory.wrappers.primitives — YELLOW-3 audit fix.
+
+Coverage matrix (Aiden gate-validator discipline: >=4 negatives per primitive):
+- synthesize       — 3 positive + 5 negative
+- trace            — 3 positive + 4 negative
+- complete_delete  — 2 positive + 6 negative
+- integration      — 1 end-to-end (ingest -> supersede -> trace -> delete)
+
+DB / Hindsight / TenantExtension mocked end-to-end; no live engine required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.keiracom_system.memory.wrappers import (
+    AntiPatternWrapper,
+    DecisionWrapper,
+    DeleteRecord,
+    ProvenanceChain,
+    SynthesisResult,
+    complete_delete,
+    synthesize,
+    trace,
+)
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.retain_calls: list[dict[str, Any]] = []
+        self.recall_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[dict[str, Any]] = []
+        self.reflect_resp: dict[str, Any] = {
+            "answer": "Hindsight was chosen because the spike showed favourable fit.",
+            "citations": ["mem-100", "mem-101", "mem-102"],
+            "reasoning_chain": [
+                {"step": 1, "tool": "search_observations", "result": "found 3 obs"},
+                {"step": 2, "tool": "done", "result": "answer composed"},
+            ],
+            "otel_trace_id": "trace-fake-001",
+        }
+        self.recall_resp: list[dict[str, Any]] = []
+        self.delete_resp: dict[str, Any] = {"ok": True, "otel_trace_id": "trace-del-001"}
+        self.next_memory_id = 200
+
+    def retain(self, *, bank_id: str, items: list[dict[str, Any]]) -> dict[str, Any]:
+        self.retain_calls.append({"bank_id": bank_id, "items": items})
+        ids = [f"mem-{self.next_memory_id + i}" for i, _ in enumerate(items)]
+        self.next_memory_id += len(items)
+        return {"ok": True, "memory_ids": ids}
+
+    def recall(
+        self, *, bank_id: str, query: str, tags: list[str] | None = None, top_k: int = 5
+    ) -> list[dict[str, Any]]:
+        self.recall_calls.append({"bank_id": bank_id, "query": query, "tags": tags, "top_k": top_k})
+        return list(self.recall_resp)
+
+    def reflect(self, *, bank_id: str, query: str) -> dict[str, Any]:
+        return dict(self.reflect_resp)
+
+    def delete(self, *, bank_id: str, memory_id: str) -> dict[str, Any]:
+        self.delete_calls.append({"bank_id": bank_id, "memory_id": memory_id})
+        return dict(self.delete_resp)
+
+
+class _FakeTenants:
+    def __init__(self, bank_map: dict[str, str] | None = None) -> None:
+        self.bank_map = bank_map or {"tenant-acme": "bank-acme"}
+
+    def get_bank_id(self, tenant_id: str) -> str:
+        if tenant_id not in self.bank_map:
+            raise KeyError(f"unknown tenant {tenant_id}")
+        return self.bank_map[tenant_id]
+
+
+@pytest.fixture
+def client():
+    return _FakeClient()
+
+
+@pytest.fixture
+def tenants():
+    return _FakeTenants()
+
+
+# ============== synthesize ==============
+
+
+def test_synthesize_returns_source_atom_pointers(client, tenants):
+    rec = synthesize(
+        client=client,
+        tenant_extension=tenants,
+        tenant_id="tenant-acme",
+        query="Why was Hindsight chosen?",
+    )
+    assert isinstance(rec, SynthesisResult)
+    assert rec.source_atom_ids == ["mem-100", "mem-101", "mem-102"]
+    assert rec.synthesized_answer.startswith("Hindsight was chosen")
+    assert rec.otel_trace_id == "trace-fake-001"
+    assert rec.schema_version == "1.0"
+
+
+def test_synthesize_handles_dict_citation_shape(client, tenants):
+    # Hindsight version drift: citations may be objects with id+content.
+    client.reflect_resp = {
+        "answer": "x",
+        "citations": [{"id": "obj-1", "content": "a"}, {"id": "obj-2"}],
+        "reasoning_chain": [],
+    }
+    rec = synthesize(client=client, tenant_extension=tenants, tenant_id="tenant-acme", query="x?")
+    assert rec.source_atom_ids == ["obj-1", "obj-2"]
+
+
+def test_synthesize_falls_back_to_cited_memory_ids_field(client, tenants):
+    # Older Hindsight versions used 'cited_memory_ids' not 'citations'.
+    client.reflect_resp = {
+        "synthesised_answer": "alt-answer",
+        "cited_memory_ids": ["alt-1", "alt-2"],
+        "trace": [{"x": 1}],
+    }
+    rec = synthesize(client=client, tenant_extension=tenants, tenant_id="tenant-acme", query="x?")
+    assert rec.source_atom_ids == ["alt-1", "alt-2"]
+    assert rec.synthesized_answer == "alt-answer"
+    assert rec.reasoning_chain == [{"x": 1}]
+
+
+def test_synthesize_rejects_zero_citations_aiden_drift_guard(client, tenants):
+    # Aiden Phase-2 mitigation: zero citations = synthesis drift = FAIL.
+    client.reflect_resp = {"answer": "floating answer", "citations": []}
+    with pytest.raises(ValueError, match="zero source-atom pointers"):
+        synthesize(client=client, tenant_extension=tenants, tenant_id="tenant-acme", query="x?")
+
+
+def test_synthesize_rejects_empty_tenant_id(client, tenants):
+    with pytest.raises(ValueError, match="tenant_id required"):
+        synthesize(client=client, tenant_extension=tenants, tenant_id="", query="x?")
+
+
+def test_synthesize_rejects_empty_query(client, tenants):
+    with pytest.raises(ValueError, match="query required"):
+        synthesize(client=client, tenant_extension=tenants, tenant_id="tenant-acme", query="")
+
+
+def test_synthesize_rejects_unknown_tenant(client, tenants):
+    with pytest.raises(KeyError, match="unknown tenant"):
+        synthesize(client=client, tenant_extension=tenants, tenant_id="tenant-ghost", query="x?")
+
+
+def test_synthesize_filters_empty_citation_ids(client, tenants):
+    # Defensive: a citation object with no id field must not produce empty
+    # string source-atom IDs (would defeat the drift guard).
+    client.reflect_resp = {
+        "answer": "x",
+        "citations": [{"id": "ok-1"}, {"content": "no-id"}, ""],
+        "reasoning_chain": [],
+    }
+    rec = synthesize(client=client, tenant_extension=tenants, tenant_id="tenant-acme", query="x?")
+    assert rec.source_atom_ids == ["ok-1"]
+
+
+# ============== trace ==============
+
+
+def test_trace_returns_provenance_chain_with_supersedes_edge(client, tenants):
+    # Setup: target memory mem-A is superseded by mem-B (AntiPattern with
+    # metadata.supersedes=mem-A).
+    client.recall_resp = [
+        {
+            "id": "mem-A",
+            "content": "original decision",
+            "metadata": {
+                "author": "atlas",
+                "timestamp": "2026-05-20T10:00:00Z",
+                "mal_node": "decision",
+            },
+        },
+        {
+            "id": "mem-B",
+            "content": "antipattern superseding mem-A",
+            "metadata": {
+                "author": "scout",
+                "timestamp": "2026-05-27T12:00:00Z",
+                "supersedes": "mem-A",
+                "mal_node": "antipattern",
+            },
+        },
+    ]
+    chain = trace(
+        client=client, tenant_extension=tenants, tenant_id="tenant-acme", memory_id="mem-A"
+    )
+    assert isinstance(chain, ProvenanceChain)
+    assert chain.target_memory_id == "mem-A"
+    assert chain.tenant_id == "tenant-acme"
+    assert chain.superseded_by == ["mem-B"]
+    assert chain.supersedes == []
+    assert len(chain.events) == 2
+    # Events ordered oldest -> newest
+    assert chain.events[0].event_type == "ingest"
+    assert chain.events[0].memory_id == "mem-A"
+    assert chain.events[0].actor == "atlas"
+    assert chain.events[1].event_type == "supersede"
+    assert chain.events[1].memory_id == "mem-B"
+
+
+def test_trace_captures_outbound_supersedes_on_self(client, tenants):
+    # If the target itself supersedes an earlier memory, that edge appears
+    # in chain.supersedes.
+    client.recall_resp = [
+        {
+            "id": "mem-A",
+            "metadata": {
+                "author": "scout",
+                "timestamp": "2026-05-27T11:00:00Z",
+                "supersedes": "mem-OLD",
+            },
+        }
+    ]
+    chain = trace(
+        client=client, tenant_extension=tenants, tenant_id="tenant-acme", memory_id="mem-A"
+    )
+    assert chain.supersedes == ["mem-OLD"]
+    assert chain.superseded_by == []
+
+
+def test_trace_returns_empty_chain_when_no_related_memories(client, tenants):
+    client.recall_resp = []
+    chain = trace(
+        client=client, tenant_extension=tenants, tenant_id="tenant-acme", memory_id="mem-X"
+    )
+    assert chain.target_memory_id == "mem-X"
+    assert chain.events == []
+    assert chain.supersedes == []
+    assert chain.superseded_by == []
+
+
+def test_trace_rejects_empty_tenant_id(client, tenants):
+    with pytest.raises(ValueError, match="tenant_id required"):
+        trace(client=client, tenant_extension=tenants, tenant_id="", memory_id="mem-A")
+
+
+def test_trace_rejects_empty_memory_id(client, tenants):
+    with pytest.raises(ValueError, match="memory_id required"):
+        trace(client=client, tenant_extension=tenants, tenant_id="tenant-acme", memory_id="")
+
+
+def test_trace_rejects_unknown_tenant(client, tenants):
+    with pytest.raises(KeyError):
+        trace(
+            client=client,
+            tenant_extension=tenants,
+            tenant_id="tenant-ghost",
+            memory_id="mem-A",
+        )
+
+
+def test_trace_skips_malformed_rows_without_id(client, tenants):
+    # Defensive: rows without an id field must be ignored, not crash.
+    client.recall_resp = [
+        {"content": "no id here"},
+        {"id": "mem-A", "metadata": {"author": "atlas", "timestamp": "2026-05-20T10:00:00Z"}},
+    ]
+    chain = trace(
+        client=client, tenant_extension=tenants, tenant_id="tenant-acme", memory_id="mem-A"
+    )
+    assert len(chain.events) == 1
+    assert chain.events[0].memory_id == "mem-A"
+
+
+# ============== complete_delete ==============
+
+
+def test_complete_delete_calls_engine_and_returns_record(client, tenants):
+    rec = complete_delete(
+        client=client,
+        tenant_extension=tenants,
+        tenant_id="tenant-acme",
+        memory_id="mem-X",
+        actor="scout",
+        reason="GDPR right-to-be-forgotten request",
+    )
+    assert isinstance(rec, DeleteRecord)
+    assert rec.memory_id == "mem-X"
+    assert rec.tenant_id == "tenant-acme"
+    assert rec.actor == "scout"
+    assert rec.reason == "GDPR right-to-be-forgotten request"
+    assert rec.audit_purpose == "general"
+    assert rec.otel_trace_id == "trace-del-001"
+    assert rec.schema_version == "1.0"
+    assert len(client.delete_calls) == 1
+    assert client.delete_calls[0] == {"bank_id": "bank-acme", "memory_id": "mem-X"}
+
+
+def test_complete_delete_carries_audit_purpose_hipaa(client, tenants):
+    rec = complete_delete(
+        client=client,
+        tenant_extension=tenants,
+        tenant_id="tenant-acme",
+        memory_id="mem-PHI",
+        actor="scout",
+        reason="PHI scrub per HIPAA breach response",
+        audit_purpose="hipaa",
+    )
+    assert rec.audit_purpose == "hipaa"
+
+
+def test_complete_delete_rejects_empty_tenant(client, tenants):
+    with pytest.raises(ValueError, match="tenant_id required"):
+        complete_delete(
+            client=client,
+            tenant_extension=tenants,
+            tenant_id="",
+            memory_id="mem-X",
+            actor="scout",
+            reason="r",
+        )
+
+
+def test_complete_delete_rejects_empty_memory_id(client, tenants):
+    with pytest.raises(ValueError, match="memory_id required"):
+        complete_delete(
+            client=client,
+            tenant_extension=tenants,
+            tenant_id="tenant-acme",
+            memory_id="",
+            actor="scout",
+            reason="r",
+        )
+
+
+def test_complete_delete_rejects_empty_actor_audit_invariant(client, tenants):
+    # Audit-trail invariant: a delete with no actor is forbidden.
+    with pytest.raises(ValueError, match="actor required"):
+        complete_delete(
+            client=client,
+            tenant_extension=tenants,
+            tenant_id="tenant-acme",
+            memory_id="mem-X",
+            actor="",
+            reason="r",
+        )
+
+
+def test_complete_delete_rejects_empty_reason_audit_invariant(client, tenants):
+    # Audit-trail invariant: a delete with no reason is forbidden.
+    with pytest.raises(ValueError, match="reason required"):
+        complete_delete(
+            client=client,
+            tenant_extension=tenants,
+            tenant_id="tenant-acme",
+            memory_id="mem-X",
+            actor="scout",
+            reason="",
+        )
+
+
+def test_complete_delete_rejects_unknown_audit_purpose(client, tenants):
+    with pytest.raises(ValueError, match="unknown audit_purpose"):
+        complete_delete(
+            client=client,
+            tenant_extension=tenants,
+            tenant_id="tenant-acme",
+            memory_id="mem-X",
+            actor="scout",
+            reason="r",
+            audit_purpose="marketing",
+        )
+
+
+def test_complete_delete_rejects_unknown_tenant(client, tenants):
+    with pytest.raises(KeyError):
+        complete_delete(
+            client=client,
+            tenant_extension=tenants,
+            tenant_id="tenant-ghost",
+            memory_id="mem-X",
+            actor="scout",
+            reason="r",
+        )
+
+
+def test_complete_delete_synthesises_trace_id_when_engine_omits_it(client, tenants):
+    # If the engine returns no otel_trace_id, complete_delete must still
+    # produce one so the audit log row has a non-empty correlator.
+    client.delete_resp = {"ok": True}
+    rec = complete_delete(
+        client=client,
+        tenant_extension=tenants,
+        tenant_id="tenant-acme",
+        memory_id="mem-X",
+        actor="scout",
+        reason="r",
+    )
+    assert rec.otel_trace_id  # non-empty (uuid-generated fallback)
+
+
+# ============== integration ==============
+
+
+def test_integration_ingest_supersede_trace_delete_chain(client, tenants):
+    """End-to-end: ingest a decision, write an antipattern that supersedes
+    it, trace the provenance chain, then hard-delete the original."""
+    decision_w = DecisionWrapper(client, tenants)
+    antipattern_w = AntiPatternWrapper(client, tenants)
+
+    decision_w.ingest(
+        tenant_id="tenant-acme",
+        content="Decision: pick X.",
+        metadata={"decision_ref": "DEC-1"},
+    )
+    target_id = client.retain_calls[0]["items"][0]
+    target_mem_id = "mem-200"  # first id from _FakeClient seed
+    # Note: real ID comes from retain response; we use the fake-seed value
+    # here. The wrapper layer returns it to callers in practice.
+    assert target_id["metadata"]["decision_ref"] == "DEC-1"
+
+    antipattern_w.ingest(
+        tenant_id="tenant-acme",
+        context="X was wrong",
+        failed_path="picked X under bad assumption",
+        verified_path="pick Y instead — backed by spike data",
+        supersedes_memory_id=target_mem_id,
+    )
+
+    # Set up recall response so trace finds the supersession edge.
+    client.recall_resp = [
+        {
+            "id": target_mem_id,
+            "metadata": {"author": "scout", "timestamp": "2026-05-27T10:00:00Z"},
+        },
+        {
+            "id": "mem-201",
+            "metadata": {
+                "author": "scout",
+                "timestamp": "2026-05-27T11:00:00Z",
+                "supersedes": target_mem_id,
+            },
+        },
+    ]
+    chain = trace(
+        client=client,
+        tenant_extension=tenants,
+        tenant_id="tenant-acme",
+        memory_id=target_mem_id,
+    )
+    assert chain.superseded_by == ["mem-201"]
+    assert len(chain.events) == 2
+
+    # Hard-delete the original now that supersession is in place.
+    rec = complete_delete(
+        client=client,
+        tenant_extension=tenants,
+        tenant_id="tenant-acme",
+        memory_id=target_mem_id,
+        actor="scout",
+        reason="superseded — operator-requested hard-delete",
+        audit_purpose="accounting",
+    )
+    assert rec.memory_id == target_mem_id
+    assert rec.audit_purpose == "accounting"
+    assert len(client.delete_calls) == 1
+    assert client.delete_calls[0]["memory_id"] == target_mem_id


### PR DESCRIPTION
## Summary

Closes the **YELLOW-3** gap from Aiden's pre-cutover audit (2026-05-27): 3 of 6 MAL V1 primitives shipped via the 4 domain wrappers (`ingest` / `recall` / `supersede`); the remaining three (`synthesize` / `trace` / `complete_delete`) are cross-cutting query primitives and live in `src/keiracom_system/memory/wrappers/primitives.py` alongside `trace_composition.py`.

This is **PR 1 of 4** in the Wave 1 + 2 Hindsight engineering chain (Dave-ratified 2026-05-27 all-tiers cutover gating, dual-deliberator concur Aiden + Viktor). Sequence:
1. **this PR** — synthesize + trace + complete delete primitives
2. `Agency_OS-q6ed` — real-time invalidation hooks
3. `Agency_OS-3rpe` — recency decay function
4. `Agency_OS-3g9t` — atom granularity spec + CI gate

## Changes

- **`synthesize`** — LLM-grounded reflect with mandatory source-atom pointers. `SynthesisResult.source_atom_ids` is non-empty by construction; zero citations raise `ValueError` ("synthesis drift guard" per Aiden Phase-2 mitigation against ungrounded answers). Handles both `citations` and legacy `cited_memory_ids` field shapes + both `["id"]` and `[{id,content}]` citation shapes.
- **`trace`** — walks supersedes / superseded_by edges around a `memory_id` and returns `ProvenanceChain` with timestamp-ordered `ProvenanceEvent`s. Distinct from `compose_audit_record` (single-reflect `AuditRecord` for one-shot HIPAA/legal/accounting audits).
- **`complete_delete`** — hard-delete via the engine's DELETE endpoint + structured `DeleteRecord` audit-log entry. Closes the partial gap where `delete` was a valid operation in `AuditRecord` but had no method to execute it. Audit invariants (actor + reason mandatory) fail loud.

**Protocol surface change:** `_base.HindsightClient` Protocol extends with `delete(bank_id, memory_id) -> dict`. `FleetHindsightClient` HTTP shim in `keiracom_system/fleet/hindsight/smoke_wrappers.py` implements `DELETE /v1/default/banks/{id}/memories/{memory_id}`.

## Notes — canonical key values (audit-dispatch checklist)

Per the `_orchestrator.md` audit-dispatch checklist, the worker must paste the queried canonical key value into a Notes section. Source: `public.ceo_memory.ceo:memory_abstraction_layer_v1` + `public.ceo_memory.ceo:cutover_plan_v1`.

**`ceo:memory_abstraction_layer_v1` — eleven_agreed_positions #3:**
> "Six query primitives: Ingest, Recall, Synthesize, Supersede, Trace, Delete"

**`ceo:cutover_plan_v1` — full_retrieval_tier_ratify_2026_05_27_22Z.waves.wave_1_foundation:**
> "Hindsight primitives complete (synthesize+trace+delete with source-atom pointers) + atom granularity spec + tenant scoping per-callsite + bounded-spawn dispatcher-kill + Go sidecar deploy + real-time invalidation"

**`ceo:memory_abstraction_layer_v1` — five_converged_decisions_locked.trace_primitive:**
> "V1 scope (not deferred); regulatory necessity for HIPAA/legal-privilege/audit-trail verticals"

## Test plan

- [x] Unit tests in `tests/keiracom_system/memory/wrappers/test_primitives.py`: 8 synthesize / 7 trace / 8 complete_delete / 1 integration end-to-end (ingest -> supersede -> trace -> delete chain)
- [x] All 59 wrapper tests pass (34 baseline preserved + 25 new) — zero regression in `test_wrappers.py`
- [x] Negative-path coverage: >=4 negative tests per primitive (Aiden gate-validator discipline). Includes the **zero-citation drift guard** + **audit-trail invariants** (actor + reason mandatory) + Protocol invariants (tenant + memory_id required)
- [x] `ruff check` clean; `ruff format --check` clean

```
59 passed in 0.20s
```

## Out of scope

- Live integration smoke against the fleet Hindsight instance (port 8889) — landed as a follow-up smoke run when q6ed (real-time invalidation) lands and the engine surface stabilises.
- `bd Agency_OS-q6ed` / `3rpe` / `3g9t` — separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)