### PR TITLE
[ATLAS] fix(retrieval): tenant scoping per-callsite audit + guard (Agency_OS-7sj6)

### DIFF
--- a/scripts/orchestrator/claim_context_injector.py
+++ b/scripts/orchestrator/claim_context_injector.py
@@ -92,13 +92,22 @@ def weaviate_recall_source(kei: str, title: str, callsign: str) -> Callable[[], 
 
     def _recall() -> list[dict]:
         try:
-            from src.retrieval import agent_query  # noqa: PLC0415 — lazy import
+            from src.retrieval import (
+                agent_query,  # noqa: PLC0415 — lazy import
+                orchestrator,  # noqa: PLC0415 — lazy import
+            )
         except ImportError as exc:
             logger.debug("KEI-103 weaviate recall import failed: %s", exc)
             return []
         query_text = f"{kei}: {title}".strip() if title else kei
         try:
-            result = agent_query.query(query_text, agent=callsign or "atlas")
+            # Fleet-internal claim-context recall reads shared fleet_* banks
+            # under FLEET_TENANT_SLUG (audit fix YELLOW-4, Agency_OS-7sj6).
+            result = agent_query.query(
+                query_text,
+                agent=callsign or "atlas",
+                tenant_id=orchestrator.FLEET_TENANT_SLUG,
+            )
         except Exception as exc:  # noqa: BLE001 — fail-open
             logger.debug("KEI-103 weaviate recall query failed: %s", exc)
             return []

--- a/scripts/retrieval_smoke.py
+++ b/scripts/retrieval_smoke.py
@@ -100,6 +100,7 @@ def main(argv: list[str] | None = None) -> int:
         collections=(PROBE_COLLECTION,),
         citation_required=True,
         min_score=0.0,
+        tenant_id=orchestrator.FLEET_TENANT_SLUG,
     )
     print(f"  elapsed_ms={result.elapsed_ms}")
     print(f"  citations={len(result.citations)}")

--- a/scripts/tasks_cli.py
+++ b/scripts/tasks_cli.py
@@ -578,9 +578,15 @@ def cmd_claim(args: argparse.Namespace) -> int:
     # Fail-open: agent_query.query() has its own try/except; we re-catch
     # ImportError + anything else so a broken retrieval layer never blocks a claim.
     try:
+        from src.retrieval import orchestrator as _retrieval_orchestrator
         from src.retrieval.agent_query import query as _retrieval_query
 
-        _retrieval_query(claimed["title"], agent=claimed["claimed_by"])
+        # Fleet-internal bd-claim recall — audit fix YELLOW-4, Agency_OS-7sj6.
+        _retrieval_query(
+            claimed["title"],
+            agent=claimed["claimed_by"],
+            tenant_id=_retrieval_orchestrator.FLEET_TENANT_SLUG,
+        )
     except Exception:
         logger.debug("retrieval query for claim failed (non-fatal)", exc_info=True)
     # KEI-106 — propagate claim status to Linear via completion_sync_queue

--- a/src/retrieval/agent_query.py
+++ b/src/retrieval/agent_query.py
@@ -179,6 +179,7 @@ def query(
     min_score: float = DEFAULT_MIN_SCORE,  # noqa: ARG001 KEI-198 back-compat  # NOSONAR S1172
     k_initial: int = orchestrator.DEFAULT_K_INITIAL,
     k_returned: int = orchestrator.DEFAULT_K_RETURNED,
+    tenant_id: str = orchestrator.FLEET_TENANT_SLUG,
 ) -> QueryResult:
     """Run one retrieval query.
 
@@ -187,6 +188,15 @@ def query(
         agent: Callsign of the asking agent — recorded for observability.
         collections: Which Weaviate collections to search (default 3-tuple
             covers the most common precision-retrieval surfaces).
+        tenant_id: Hindsight tenant slug for the recall URL. Defaults to
+            `orchestrator.FLEET_TENANT_SLUG` because this entry is the
+            fleet-internal recall API; customer-facing recall goes through
+            the Decision/Artifact/TaskContext/AntiPattern wrappers in
+            src/keiracom_system/memory/wrappers/, which derive the slug
+            from the tenant_id arg per-call. The orchestrator wire boundary
+            (`_hindsight_recall`) still validates and rejects empty/invalid
+            values via `MissingTenantContextError` — audit fix YELLOW-4
+            (Agency_OS-7sj6, 2026-05-28).
         max_tokens: Response synthesis ceiling (KEI-55, 500-token default).
         citation_required: When True (default) AND all returned scores are
             exactly 0.0 (vectorizer-regression sentinel per KEI-198), return
@@ -209,6 +219,7 @@ def query(
         collections=collections,
         k_initial=k_initial,
         k_returned=k_returned,
+        tenant_id=tenant_id,
     )
     citations = [_node_to_citation(n) for n in outcome.nodes]
     # KEI-198 — distribution-aware citation selection.

--- a/src/retrieval/orchestrator.py
+++ b/src/retrieval/orchestrator.py
@@ -38,12 +38,52 @@ from src.retrieval import rerankers, weaviate_store
 
 logger = logging.getLogger(__name__)
 
-# Hindsight read endpoint — POST /v1/default/banks/{bank_id}/memories/recall
+# Hindsight read endpoint — POST /v1/{tenant_id}/banks/{bank_id}/memories/recall
 # with body {"query": str, "max_tokens": int, "top_k": int, "tags"?: list,
 # "tags_match"?: "all"|"any"}. Returns {"memories": [...]} or {"results": [...]}.
 HINDSIGHT_BASE = os.environ.get("HINDSIGHT_BASE", "http://localhost:8889")  # NOSONAR S5332 loopback
 HINDSIGHT_RECALL_TIMEOUT_SECONDS = 30.0
 HINDSIGHT_RECALL_MAX_TOKENS = 2000
+
+# Audit fix YELLOW-4 (Agency_OS-7sj6, 2026-05-28): every Hindsight recall callsite
+# must declare its tenant slug. Fleet-internal recall (shared fleet_* banks
+# under the fleet's own tenant slot) passes FLEET_TENANT_SLUG; customer recall
+# passes the customer tenant slug resolved via KeiracomTenantExtension. The
+# guard below rejects empty/None/path-traversal values at the wire boundary.
+FLEET_TENANT_SLUG = "default"
+_TENANT_SLUG_ALLOWED_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+
+
+class MissingTenantContextError(ValueError):
+    """Raised when a Hindsight recall callsite omits or invalidates tenant context.
+
+    Per Aiden pre-cutover audit 2026-05-27 (Agency_OS-7sj6): data sovereignty
+    requires every recall call to declare which tenant slot it reads from.
+    Silent fall-through to a default would risk cross-tenant inference (V1
+    eleven_agreed_positions[4]: "Collective scope: tenant-bounded only").
+    """
+
+
+def _require_tenant_id(tenant_id: str | None) -> str:
+    """Validate the tenant slug used in the Hindsight URL path.
+
+    Returns the slug unchanged on success. Raises MissingTenantContextError
+    on empty/None/non-str values, and on values containing characters that
+    are not safe for a URL path segment (defence-in-depth against path
+    traversal even though the bank_id sub-segment is also validated upstream).
+    """
+    if not tenant_id or not isinstance(tenant_id, str):
+        raise MissingTenantContextError(
+            "Hindsight recall requires an explicit tenant_id "
+            "(fleet-internal callers must pass FLEET_TENANT_SLUG)"
+        )
+    if any(ch not in _TENANT_SLUG_ALLOWED_CHARS for ch in tenant_id):
+        raise MissingTenantContextError(
+            f"tenant_id {tenant_id!r} contains characters outside the allowed "
+            "URL-path set [A-Za-z0-9_-]"
+        )
+    return tenant_id
+
 
 # Local mirror of scripts/orchestrator/indexer_base.CLASS_TO_BANK so src/
 # doesn't import from scripts/. Drift between the two is caught by
@@ -134,16 +174,24 @@ class RetrievalOutcome:
     rerank_elapsed_ms: int
 
 
-def _hindsight_recall(text: str, bank_id: str, *, top_k: int) -> list[dict[str, Any]]:
-    """POST /v1/default/banks/{bank_id}/memories/recall — returns memories list.
+def _hindsight_recall(
+    text: str, bank_id: str, *, top_k: int, tenant_id: str
+) -> list[dict[str, Any]]:
+    """POST /v1/{tenant_id}/banks/{bank_id}/memories/recall — returns memories list.
+
+    `tenant_id` is the Hindsight tenant slug (per the V1 URL contract).
+    Fleet-internal callers pass FLEET_TENANT_SLUG; customer callers pass the
+    customer slug resolved via KeiracomTenantExtension. The slug is validated
+    at the wire boundary — empty/invalid raises MissingTenantContextError.
 
     Empty list on any HTTP/JSON failure (caller logs at the call site for
     per-collection visibility).
     """
+    tenant_slug = _require_tenant_id(tenant_id)
     body = {"query": text, "max_tokens": HINDSIGHT_RECALL_MAX_TOKENS, "top_k": top_k}
     data = json.dumps(body).encode("utf-8")
     req = urlrequest.Request(
-        f"{HINDSIGHT_BASE}/v1/default/banks/{bank_id}/memories/recall",
+        f"{HINDSIGHT_BASE}/v1/{tenant_slug}/banks/{bank_id}/memories/recall",
         data=data,
         method="POST",
         headers={"Content-Type": "application/json", "Accept": "application/json"},
@@ -159,6 +207,8 @@ def _gather_ann_pool(
     collections: tuple[str, ...],
     k_initial: int,
     weaviate_client: Any,
+    *,
+    tenant_id: str,
 ) -> list[RetrievedNode]:
     """Source the ANN pool from Hindsight `/memories/recall` per collection.
 
@@ -166,7 +216,13 @@ def _gather_ann_pool(
     `retrieve_with_outcome(client=...)` signature; ignored on the Hindsight
     path. Removed entirely in the next PR (after the write-path cutover).
     A3-c2 step 5-B, Agency_OS-0zv1.
+
+    `tenant_id` is validated once upfront (fail-fast before any HTTP) and
+    forwarded to every per-collection recall. A MissingTenantContextError
+    is intentionally NOT caught inside the per-collection try/except — bad
+    tenant context is a wire-contract violation, not a per-collection hiccup.
     """
+    _require_tenant_id(tenant_id)
     del weaviate_client  # noqa: ARG001 — retained for ABI; intentional ignore
     pool: list[RetrievedNode] = []
     for collection in collections:
@@ -180,7 +236,9 @@ def _gather_ann_pool(
             )
             continue
         try:
-            memories = _hindsight_recall(text, bank_id, top_k=k_initial)
+            memories = _hindsight_recall(text, bank_id, top_k=k_initial, tenant_id=tenant_id)
+        except MissingTenantContextError:
+            raise  # wire-contract violation — never swallow
         except Exception:  # noqa: BLE001
             logger.warning("hindsight recall failed for %s", collection, exc_info=True)
             continue
@@ -208,6 +266,7 @@ def retrieve_with_outcome(
     k_returned: int = DEFAULT_K_RETURNED,
     rerank: bool = True,
     client: Any | None = None,
+    tenant_id: str,
 ) -> RetrievalOutcome:
     """Run the two-stage retrieval and surface the bypass flag verbatim.
 
@@ -215,9 +274,13 @@ def retrieve_with_outcome(
     backwards-compat but ignored — Hindsight is now the recall backend and
     does not need a Weaviate client. Removed from the signature in the next
     PR after callers stop passing it.
+
+    Audit fix YELLOW-4 (Agency_OS-7sj6, 2026-05-28): `tenant_id` is a
+    keyword-only REQUIRED arg — every caller must declare which Hindsight
+    tenant slot it reads from. Fleet-internal callers pass FLEET_TENANT_SLUG.
     """
     del client  # noqa: ARG001 — retained for ABI; intentional ignore
-    pool = _gather_ann_pool(text, collections, k_initial, weaviate_client=None)
+    pool = _gather_ann_pool(text, collections, k_initial, weaviate_client=None, tenant_id=tenant_id)
     if not pool:
         return RetrievalOutcome((), False, "empty_pool", 0)
     if not rerank:
@@ -238,6 +301,7 @@ def retrieve_nodes(
     k_initial: int = DEFAULT_K_INITIAL,
     k_returned: int = DEFAULT_K_RETURNED,
     client: Any | None = None,
+    tenant_id: str,
 ) -> tuple[RetrievedNode, ...]:
     """Backwards-compatible thin wrapper — agents that only need the node
     tuple keep calling this; agents that want the bypass flag call
@@ -248,5 +312,6 @@ def retrieve_nodes(
         k_initial=k_initial,
         k_returned=k_returned,
         client=client,
+        tenant_id=tenant_id,
     )
     return outcome.nodes

--- a/tests/retrieval/test_orchestrator_hindsight_reader.py
+++ b/tests/retrieval/test_orchestrator_hindsight_reader.py
@@ -72,7 +72,9 @@ def test_hindsight_recall_posts_to_correct_endpoint(monkeypatch):
         return _FakeResp()
 
     monkeypatch.setattr(orchestrator.urlrequest, "urlopen", _fake_urlopen)
-    out = orchestrator._hindsight_recall("anchor query", "fleet_decisions", top_k=5)
+    out = orchestrator._hindsight_recall(
+        "anchor query", "fleet_decisions", top_k=5, tenant_id=orchestrator.FLEET_TENANT_SLUG
+    )
     assert len(captured) == 1
     assert captured[0]["url"].endswith("/v1/default/banks/fleet_decisions/memories/recall")
     assert captured[0]["method"] == "POST"
@@ -94,7 +96,9 @@ def test_hindsight_recall_accepts_alt_results_key(monkeypatch):
             return b'{"results": [{"content": "y"}]}'
 
     monkeypatch.setattr(orchestrator.urlrequest, "urlopen", lambda req, timeout=None: _FakeResp())
-    out = orchestrator._hindsight_recall("q", "fleet_keis", top_k=3)
+    out = orchestrator._hindsight_recall(
+        "q", "fleet_keis", top_k=3, tenant_id=orchestrator.FLEET_TENANT_SLUG
+    )
     assert out == [{"content": "y"}]
 
 
@@ -110,7 +114,12 @@ def test_hindsight_recall_empty_response_returns_empty_list(monkeypatch):
             return b"{}"
 
     monkeypatch.setattr(orchestrator.urlrequest, "urlopen", lambda req, timeout=None: _FakeResp())
-    assert orchestrator._hindsight_recall("q", "fleet_decisions", top_k=5) == []
+    assert (
+        orchestrator._hindsight_recall(
+            "q", "fleet_decisions", top_k=5, tenant_id=orchestrator.FLEET_TENANT_SLUG
+        )
+        == []
+    )
 
 
 def test_gather_ann_pool_skips_unmapped_collection(monkeypatch):
@@ -127,8 +136,8 @@ def test_gather_ann_pool_skips_unmapped_collection(monkeypatch):
     """
     called = []
 
-    def _spy_recall(text, bank_id, *, top_k):
-        called.append(bank_id)
+    def _spy_recall(text, bank_id, *, top_k, tenant_id):
+        called.append((bank_id, tenant_id))
         return []
 
     monkeypatch.setattr(orchestrator, "_hindsight_recall", _spy_recall)
@@ -137,8 +146,9 @@ def test_gather_ann_pool_skips_unmapped_collection(monkeypatch):
         collections=("_UnmappedSentinel_NeverMapMe", "Decisions"),
         k_initial=5,
         weaviate_client=None,
+        tenant_id=orchestrator.FLEET_TENANT_SLUG,
     )
-    assert called == ["fleet_decisions"]  # Sentinel skipped, Decisions called
+    assert called == [("fleet_decisions", orchestrator.FLEET_TENANT_SLUG)]
     assert pool == []  # spy returned [] for Decisions
 
 
@@ -148,7 +158,7 @@ def test_gather_ann_pool_swallows_per_collection_failure(monkeypatch):
     didn't stop the others)."""
     calls = []
 
-    def _flaky_recall(text, bank_id, *, top_k):
+    def _flaky_recall(text, bank_id, *, top_k, tenant_id):
         calls.append(bank_id)
         if bank_id == "fleet_decisions":
             raise RuntimeError("simulated failure")
@@ -160,6 +170,7 @@ def test_gather_ann_pool_swallows_per_collection_failure(monkeypatch):
         collections=("Decisions", "Keis"),
         k_initial=5,
         weaviate_client=None,
+        tenant_id=orchestrator.FLEET_TENANT_SLUG,
     )
     assert calls == ["fleet_decisions", "fleet_keis"]
     assert len(pool) == 1
@@ -172,7 +183,7 @@ def test_gather_ann_pool_builds_retrieved_nodes_with_correct_collection_tag(monk
     as its `.collection` field so the downstream citation chain stays
     consistent with the pre-cutover identity."""
 
-    def _stub_recall(text, bank_id, *, top_k):
+    def _stub_recall(text, bank_id, *, top_k, tenant_id):
         return [
             {"content": f"from-{bank_id}-1", "score": 0.8, "metadata": {"src": bank_id}},
             {"content": f"from-{bank_id}-2", "score": 0.6, "metadata": {"src": bank_id}},
@@ -184,6 +195,7 @@ def test_gather_ann_pool_builds_retrieved_nodes_with_correct_collection_tag(monk
         collections=("Decisions", "Discoveries"),
         k_initial=5,
         weaviate_client=None,
+        tenant_id=orchestrator.FLEET_TENANT_SLUG,
     )
     assert len(pool) == 4
     collections_seen = {n.collection for n in pool}
@@ -197,7 +209,7 @@ def test_gather_ann_pool_accepts_alt_text_and_relevance_keys(monkeypatch):
     """Memories may carry `text` instead of `content` and `relevance` instead
     of `score` depending on Hindsight response shape. Both keys supported."""
 
-    def _stub_recall(text, bank_id, *, top_k):
+    def _stub_recall(text, bank_id, *, top_k, tenant_id):
         return [{"text": "alt-shape", "relevance": 0.42, "metadata": None}]
 
     monkeypatch.setattr(orchestrator, "_hindsight_recall", _stub_recall)
@@ -206,6 +218,7 @@ def test_gather_ann_pool_accepts_alt_text_and_relevance_keys(monkeypatch):
         collections=("Decisions",),
         k_initial=5,
         weaviate_client=None,
+        tenant_id=orchestrator.FLEET_TENANT_SLUG,
     )
     assert len(pool) == 1
     assert pool[0].text == "alt-shape"
@@ -219,7 +232,10 @@ def test_retrieve_with_outcome_returns_empty_pool_outcome_on_no_memories(monkeyp
     agent_query.query()'s anti-hallucination guard fires identically."""
     monkeypatch.setattr(orchestrator, "_hindsight_recall", lambda *a, **kw: [])
     outcome = orchestrator.retrieve_with_outcome(
-        "anchor", ("Decisions", "Discoveries", "Keis"), rerank=True
+        "anchor",
+        ("Decisions", "Discoveries", "Keis"),
+        rerank=True,
+        tenant_id=orchestrator.FLEET_TENANT_SLUG,
     )
     assert outcome.nodes == ()
     assert outcome.bypass_rerank is False
@@ -237,5 +253,76 @@ def test_retrieve_with_outcome_no_longer_opens_weaviate_connection(monkeypatch):
         lambda *a, **kw: connect_calls.append(1),
     )
     monkeypatch.setattr(orchestrator, "_hindsight_recall", lambda *a, **kw: [])
-    orchestrator.retrieve_with_outcome("q", ("Decisions",))
+    orchestrator.retrieve_with_outcome(
+        "q", ("Decisions",), tenant_id=orchestrator.FLEET_TENANT_SLUG
+    )
     assert connect_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Audit fix YELLOW-4 (Agency_OS-7sj6, 2026-05-28) — tenant scoping guard.
+# Locks the wire-boundary contract: every Hindsight recall must declare a
+# tenant slug; the URL embeds it; empty/invalid values raise
+# MissingTenantContextError BEFORE any HTTP request is opened.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [None, "", "   ", "tenant/../escape", "tenant with spaces", 123])
+def test_hindsight_recall_rejects_missing_or_invalid_tenant_id(monkeypatch, bad):
+    """The guard fires BEFORE urlopen — assert urlopen is never called."""
+    opened = []
+    monkeypatch.setattr(orchestrator.urlrequest, "urlopen", lambda *a, **kw: opened.append(1))
+    with pytest.raises(orchestrator.MissingTenantContextError):
+        orchestrator._hindsight_recall("q", "fleet_decisions", top_k=5, tenant_id=bad)
+    assert opened == []
+
+
+def test_hindsight_recall_url_embeds_tenant_slug(monkeypatch):
+    """Customer recall path: the slug appears as the URL's tenant path segment."""
+    captured: list[str] = []
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+        def read(self):
+            return b'{"memories": []}'
+
+    def _fake_urlopen(req, timeout=None):  # noqa: ARG001
+        captured.append(req.full_url)
+        return _FakeResp()
+
+    monkeypatch.setattr(orchestrator.urlrequest, "urlopen", _fake_urlopen)
+    orchestrator._hindsight_recall("q", "customer-bank-abc", top_k=5, tenant_id="tenant-uuid-123")
+    assert captured == [
+        f"{orchestrator.HINDSIGHT_BASE}/v1/tenant-uuid-123/banks/customer-bank-abc/memories/recall"
+    ]
+
+
+def test_gather_ann_pool_rejects_missing_tenant_id_upfront(monkeypatch):
+    """Wire-contract violations are raised, not swallowed by the per-collection
+    try/except — otherwise a malformed call would silently return empty pool."""
+    recall_called = []
+    monkeypatch.setattr(
+        orchestrator,
+        "_hindsight_recall",
+        lambda *a, **kw: recall_called.append(1) or [],
+    )
+    with pytest.raises(orchestrator.MissingTenantContextError):
+        orchestrator._gather_ann_pool(
+            text="q",
+            collections=("Decisions",),
+            k_initial=5,
+            weaviate_client=None,
+            tenant_id="",
+        )
+    assert recall_called == []
+
+
+def test_retrieve_with_outcome_requires_tenant_id_keyword():
+    """Calling without tenant_id is a TypeError at call time (keyword-only required)."""
+    with pytest.raises(TypeError):
+        orchestrator.retrieve_with_outcome("q", ("Decisions",))  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

Audit fix YELLOW-4 (Agency_OS-7sj6 — Aiden pre-cutover audit 2026-05-27). Every production Hindsight recall callsite now declares its tenant slug at the wire boundary; a runtime guard rejects empty/None/path-traversal values **before** any HTTP request opens.

## Audit findings (production Hindsight recall paths)

| Callsite | Before | After |
|---|---|---|
| `src/retrieval/orchestrator.py:_hindsight_recall` | hardcoded `/v1/default/...` URL | `tenant_id` keyword-only **REQUIRED**; URL embeds slug `/v1/{tenant_id}/...` |
| `src/retrieval/orchestrator.py:_gather_ann_pool` | no tenant arg | `tenant_id` required + validated upfront; `MissingTenantContextError` re-raised (not swallowed by per-collection try/except) |
| `src/retrieval/orchestrator.py:retrieve_with_outcome` | no tenant arg | keyword-only required |
| `src/retrieval/orchestrator.py:retrieve_nodes` | no tenant arg | keyword-only required |
| `src/retrieval/agent_query.py:query` | no tenant arg | added with default `orchestrator.FLEET_TENANT_SLUG` (this entry IS the fleet-internal API) |
| `src/keiracom_system/memory/wrappers/*_wrapper.py` | already correct | no change — wrappers already pass `tenant_id` → `bank_id` via TenantExtension |

## Guard contract (tests added)

`MissingTenantContextError` (subclass of `ValueError`) raised on:
- `None`, `""`, whitespace-only, non-str
- Any char outside `[A-Za-z0-9_-]` (path-traversal defence)

Tests (added in `tests/retrieval/test_orchestrator_hindsight_reader.py`):
- `test_hindsight_recall_rejects_missing_or_invalid_tenant_id` — parametrised over 6 bad inputs; asserts urlopen is **never called**.
- `test_hindsight_recall_url_embeds_tenant_slug` — locks the URL contract for customer slugs (`/v1/tenant-uuid-123/banks/.../recall`).
- `test_gather_ann_pool_rejects_missing_tenant_id_upfront` — validates that the guard is NOT swallowed by the per-collection try/except.
- `test_retrieve_with_outcome_requires_tenant_id_keyword` — calling without `tenant_id` is a `TypeError` at call time.

## Out of scope (separate audits)

- `scripts/orchestrator/llama_recall_engine.py` — direct Weaviate GraphQL, not Hindsight.
- `src/governance/loader.py` — Cognee subprocess; Cognee FULLY RETIRED per PR #1179.
- `scripts/migrations/*`, `scripts/research/hindsight_smoke/*`, `tests/*` — operator-gated / research / test code.

## Production callers updated

Three production callers pass `tenant_id=orchestrator.FLEET_TENANT_SLUG` explicitly (documents fleet-internal intent at the callsite):
- `scripts/orchestrator/claim_context_injector.py:weaviate_recall_source`
- `scripts/retrieval_smoke.py`
- `scripts/tasks_cli.py:cmd_claim`

## Test plan

- [x] `pytest tests/retrieval/ tests/scripts/test_claim_context_injector.py tests/scripts/orchestrator/ tests/scripts/migrations/` — **205/205 pass**.
- [x] `ruff check` + `ruff format --check` clean.
- [x] Module exports verified — `orchestrator.MissingTenantContextError` + `orchestrator.FLEET_TENANT_SLUG` importable.
- [ ] Deliberator review (Elliot impl-feasibility / Aiden architecture / Max code-quality).

## Anchor

Per ratified `ceo:memory_abstraction_layer_v1` eleven_agreed_positions[4]: "Collective scope: tenant-bounded only, never cross-tenant inference (BYOK sovereignty)." This PR closes the gap between schema-level tenant_id and per-callsite enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)