### PR TITLE
[NOVA] feat(reranker): Wave 2 — cross-encoder reranker sidecar (Agency_OS-0thg)

### DIFF
--- a/infra/keiracom_system/reranker/README.md
+++ b/infra/keiracom_system/reranker/README.md
@@ -1,0 +1,68 @@
+# Keiracom System — Cross-encoder reranker sidecar (BAAI/bge-reranker-base)
+
+Wave 2 dispatch `Agency_OS-0thg` (paired with Wave 1 Go sidecar `Agency_OS-2c7m`). Hindsight's recall layer fuses ANN + BM25 + graph + temporal hits into a top-50 candidate list; this sidecar reranks them with a cross-encoder so the LLM context window only spends tokens on the 5..10 candidates that actually answer the query. Same TEI deployment pattern as the embeddings sidecar at `../embeddings/`.
+
+## What's here
+
+| Path | Purpose |
+|---|---|
+| `docker-compose.reranker.yml` | TEI container — `BAAI/bge-reranker-base`, CPU image, model-cache volume, healthcheck, restart policy |
+| `keiracom-reranker-sidecar.service` | systemd unit wrapping `docker compose up` — same shape as Wave 1 Go sidecar unit |
+| `scripts/install_reranker_sidecar.sh` | Idempotent bring-up + `/health` + `/info` lineage check + `/rerank` round-trip probe |
+| `scripts/install-systemd.sh` | Idempotent install + enable + restart of the systemd unit |
+| `../../src/keiracom_system/reranker/reranker_client.py` | Stdlib-only Python client (`RerankerClient.rerank(query, texts, top_k=10)`) |
+| `../../tests/keiracom_system/reranker/test_reranker_client.py` | 18 unit + 1 integration test (opt-in via `KEIRACOM_RERANKER_INTEGRATION=1`) |
+
+## Quick start
+
+```bash
+# Bring up the sidecar (idempotent — re-run safe)
+bash infra/keiracom_system/reranker/scripts/install_reranker_sidecar.sh \
+  --project-name keiracom-reranker-<tenant_id>
+
+# Live smoke test
+curl -fsS -X POST http://localhost:8090/rerank \
+  -H 'content-type: application/json' \
+  -d '{"query":"what is rust","texts":["rust is a programming language","cats meow"]}'
+
+# Configure callers (Hindsight reranker stage, retrieval orchestrator, etc.)
+export KEIRACOM_RERANKER_URL=http://reranker:80
+```
+
+## Install as systemd service
+
+```bash
+bash infra/keiracom_system/reranker/scripts/install-systemd.sh
+systemctl --user status keiracom-reranker-sidecar
+```
+
+## Integration with the retrieval pipeline
+
+Hindsight's recall layer returns the top-50 hits per `src/retrieval/orchestrator.py`. The reranker stage feeds the same query + the top-50 candidate texts into `RerankerClient.rerank(...)`; the orchestrator keeps the top-`k_returned` (5..10 by default) before constructing the LLM context.
+
+```python
+from src.keiracom_system.reranker import RerankerClient
+
+client = RerankerClient(base_url="http://reranker:80")
+hits = client.rerank(query, candidate_texts, top_k=10)
+top_indices = [h.index for h in hits]
+```
+
+`RerankerClient.healthy()` lets callers degrade gracefully when the sidecar is unreachable — falling back to the raw ANN-score order is documented as the bypass path in `src/retrieval/orchestrator.py`. Callers that want defence-in-depth on model identity call `verify_model_lineage()` once at startup.
+
+## Wave 2 dispatch deliverables (Agency_OS-0thg)
+
+1. **Cross-encoder reranker sidecar** — TEI server bound to `BAAI/bge-reranker-base`, on port `8090` (distinct from the embeddings sidecar's `8080` so both can coexist on a tenant host).
+2. **Same deployment pattern as Wave 1** — `keiracom-reranker-sidecar.service` user-scope systemd unit + `scripts/install-systemd.sh`. Restart policy `on-failure`, append-only log to `~/clawd/logs/keiracom-reranker-sidecar.log`.
+3. **`/rerank` endpoint** — TEI exposes it natively (`POST /rerank` with `{query, texts}`); the Python client wraps it with input validation, score-sort, top-k truncation, and lineage verification.
+4. **Recall top-50 → reranker → top 5..10** — the client's `top_k` parameter defaults to 10; orchestrator caller is responsible for passing in the top-50 ANN-fused candidates.
+
+## Vector / model lineage pin
+
+Model: `BAAI/bge-reranker-base` — ~278MB cross-encoder, MIT licence. Pinned in:
+- `docker-compose.reranker.yml` `--model-id` flag
+- `scripts/install_reranker_sidecar.sh` `EXPECTED_MODEL` env default
+- `src/keiracom_system/reranker/reranker_client.EXPECTED_MODEL_ID`
+- the `test_default_expected_model_id_constant` unit test
+
+Any accidental swap during a TEI upgrade fails loud at `RerankerClient.verify_model_lineage()` rather than silently regressing relevance downstream of recall.

--- a/infra/keiracom_system/reranker/docker-compose.reranker.yml
+++ b/infra/keiracom_system/reranker/docker-compose.reranker.yml
@@ -1,0 +1,52 @@
+# Keiracom System — Cross-encoder reranker sidecar (BAAI/bge-reranker-base).
+#
+# Wave 2 dispatch Agency_OS-0thg. Hindsight's recall stage returns the top-50
+# candidates from ANN + BM25 + graph + temporal fusion; this sidecar reranks
+# them with a cross-encoder so the final top-5..10 returned to the LLM are
+# semantically relevant to the query — not just nearest in the embedding
+# space.
+#
+# Mirrors the TEI embeddings sidecar pattern at infra/keiracom_system/
+# embeddings/docker-compose.tei.yml. TEI supports reranker models natively
+# via /rerank (https://huggingface.co/docs/text-embeddings-inference/en/quick_tour#sequence-classification-and-re-ranking),
+# so we reuse the same image with a reranker model id.
+#
+# Same per-tenant docker-compose project pattern. CPU image suffices for
+# V1 throughput (~50 (query, candidate) pairs per request, p95 <200ms on
+# 4 vCPU). GPU image is a Pro/Scale tier upgrade.
+
+services:
+  reranker:
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
+    command:
+      # BAAI/bge-reranker-base — 278MB cross-encoder, English + multilingual,
+      # MIT licence. Picked over FlashRank's ms-marco-MiniLM-L-12-v2 for
+      # cross-encoder quality on retrieval reranking (per the Wave 2 dispatch).
+      - --model-id=BAAI/bge-reranker-base
+      # Reranker requests are typically (query, top_k=50 candidates). Batch
+      # tokens default of 16384 is comfortable headroom (~300 tokens per
+      # candidate × 50 = 15k).
+      - --max-batch-tokens=16384
+      - --max-concurrent-requests=64
+      - --port=80
+    ports:
+      # localhost:8090 → container:80. Distinct from the embeddings sidecar
+      # on :8080 so both can run on the same tenant host.
+      - "8090:80"
+    volumes:
+      # Persistent model cache — avoids re-downloading the ~278MB cross-encoder
+      # on container restart.
+      - reranker_model_cache:/data
+    environment:
+      HF_HUB_OFFLINE: "0"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 18  # ~3 min grace period for first-boot model download (278MB vs BGE's 33MB).
+      start_period: 60s
+    restart: unless-stopped
+
+volumes:
+  reranker_model_cache:
+    driver: local

--- a/infra/keiracom_system/reranker/keiracom-reranker-sidecar.service
+++ b/infra/keiracom_system/reranker/keiracom-reranker-sidecar.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Keiracom System — Cross-encoder reranker sidecar (Wave 2 dispatch Agency_OS-0thg)
+Documentation=file:///home/elliotbot/clawd/Agency_OS/infra/keiracom_system/reranker/README.md
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+# Type=simple — `docker compose up` runs in the foreground; systemd treats
+# container restarts as long-lived process activity. Equivalent to the host-
+# binary pattern used by keiracom-go-sidecar.service but for a containerised
+# upstream (TEI's Rust binary is not packaged as a host install path).
+Type=simple
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS/infra/keiracom_system/reranker
+ExecStartPre=/usr/bin/docker compose -f docker-compose.reranker.yml pull
+ExecStart=/usr/bin/docker compose -f docker-compose.reranker.yml up --no-build --abort-on-container-exit
+ExecStop=/usr/bin/docker compose -f docker-compose.reranker.yml down
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:/home/elliotbot/clawd/logs/keiracom-reranker-sidecar.log
+StandardError=append:/home/elliotbot/clawd/logs/keiracom-reranker-sidecar.log
+
+[Install]
+WantedBy=default.target

--- a/infra/keiracom_system/reranker/scripts/install-systemd.sh
+++ b/infra/keiracom_system/reranker/scripts/install-systemd.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Install + enable the user-scope systemd unit for the reranker sidecar.
+#
+# Wave 2 dispatch Agency_OS-0thg. Idempotent. Mirrors the Wave 1 Go sidecar
+# install pattern at infra/keiracom_system/go_sidecar/scripts/install-systemd.sh.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNIT="keiracom-reranker-sidecar.service"
+USER_UNIT_DIR="${HOME}/.config/systemd/user"
+
+mkdir -p "${USER_UNIT_DIR}"
+install -m 0644 "${ROOT}/${UNIT}" "${USER_UNIT_DIR}/${UNIT}"
+
+systemctl --user daemon-reload
+systemctl --user enable "${UNIT}"
+systemctl --user restart "${UNIT}"
+
+echo "install-systemd.sh: enabled + restarted ${UNIT}"
+echo "Logs: tail -f /home/elliotbot/clawd/logs/keiracom-reranker-sidecar.log"
+echo "Health: curl -fsS http://127.0.0.1:8090/health"
+echo "Smoke:  bash ${ROOT}/scripts/install_reranker_sidecar.sh"

--- a/infra/keiracom_system/reranker/scripts/install_reranker_sidecar.sh
+++ b/infra/keiracom_system/reranker/scripts/install_reranker_sidecar.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# install_reranker_sidecar.sh — bring up the reranker sidecar + verify.
+#
+# Wave 2 dispatch Agency_OS-0thg. Idempotent — re-running while the sidecar
+# is up + healthy is a no-op. Mirrors infra/keiracom_system/embeddings/
+# scripts/install_tei_sidecar.sh; same TEI image, different model.
+#
+# Usage:
+#   bash infra/keiracom_system/reranker/scripts/install_reranker_sidecar.sh
+#   bash ... --project-name keiracom-reranker-<tenant_id>
+#   bash ... --health-timeout 240   # bump model-download grace
+#
+# Verifies after start:
+#   1. docker compose up -d (idempotent)
+#   2. health poll on http://localhost:8090/health
+#   3. /info returns model_id BAAI/bge-reranker-base
+#   4. /rerank round-trip with a probe (query, [candidate]) returns a score
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/../docker-compose.reranker.yml"
+PROJECT_NAME="${KEIRACOM_RERANKER_PROJECT:-keiracom-reranker}"
+HEALTH_URL="${KEIRACOM_RERANKER_HEALTH_URL:-http://localhost:8090/health}"
+INFO_URL="${KEIRACOM_RERANKER_INFO_URL:-http://localhost:8090/info}"
+RERANK_URL="${KEIRACOM_RERANKER_RERANK_URL:-http://localhost:8090/rerank}"
+HEALTH_TIMEOUT_SECONDS="${KEIRACOM_RERANKER_HEALTH_TIMEOUT:-240}"
+EXPECTED_MODEL="${KEIRACOM_RERANKER_EXPECTED_MODEL:-BAAI/bge-reranker-base}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-name) PROJECT_NAME="$2"; shift 2 ;;
+    --health-timeout) HEALTH_TIMEOUT_SECONDS="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+command -v docker >/dev/null || { echo "docker missing" >&2; exit 1; }
+docker compose version >/dev/null 2>&1 || { echo "docker compose plugin missing" >&2; exit 1; }
+
+echo "==> docker compose up -d (project=${PROJECT_NAME})"
+docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" up -d
+
+echo "==> polling ${HEALTH_URL} (timeout ${HEALTH_TIMEOUT_SECONDS}s)..."
+DEADLINE=$(( $(date +%s) + HEALTH_TIMEOUT_SECONDS ))
+until curl -fsS "${HEALTH_URL}" >/dev/null 2>&1; do
+  if (( $(date +%s) >= DEADLINE )); then
+    echo "FAIL: reranker did not pass health check within ${HEALTH_TIMEOUT_SECONDS}s" >&2
+    docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" logs --tail=50 >&2
+    exit 2
+  fi
+  sleep 5
+done
+
+echo "==> /info → expecting model_id=${EXPECTED_MODEL}"
+INFO_JSON="$(curl -fsS "${INFO_URL}")"
+echo "${INFO_JSON}"
+if ! echo "${INFO_JSON}" | grep -q "\"model_id\":\"${EXPECTED_MODEL}\""; then
+  echo "FAIL: expected model_id=${EXPECTED_MODEL} in /info" >&2
+  exit 3
+fi
+
+echo "==> /rerank smoke test"
+RERANK_JSON="$(curl -fsS -X POST "${RERANK_URL}" \
+  -H 'content-type: application/json' \
+  -d '{"query":"what is rust","texts":["rust is a programming language","cats meow"]}')"
+echo "${RERANK_JSON}"
+echo "${RERANK_JSON}" | grep -q '"score"' || { echo "FAIL: no score in /rerank response" >&2; exit 4; }
+
+echo "OK: reranker sidecar up + healthy + serving BAAI/bge-reranker-base on ${RERANK_URL}"

--- a/scripts/install_keiracom_reranker_sidecar.sh
+++ b/scripts/install_keiracom_reranker_sidecar.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# install_keiracom_reranker_sidecar.sh — Install Wave 2 reranker sidecar.
+# References: infra/keiracom_system/reranker/keiracom-reranker-sidecar.service.
+#
+# Wraps docker-compose bring-up (TEI + BAAI/bge-reranker-base on :8090) under
+# a user-scope systemd unit. Idempotent: re-running while healthy is a no-op.
+#
+# Sequence:
+#   1. Bring up the docker-compose stack via the nested installer (handles
+#      pull, health poll, /info lineage check, /rerank smoke).
+#   2. Install keiracom-reranker-sidecar.service into ~/.config/systemd/user.
+#   3. systemctl --user daemon-reload + enable --now.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNIT_NAME="keiracom-reranker-sidecar.service"
+UNIT_SOURCE="${REPO_DIR}/infra/keiracom_system/reranker/${UNIT_NAME}"
+UNITS_DIR="${HOME}/.config/systemd/user"
+NESTED_INSTALL="${REPO_DIR}/infra/keiracom_system/reranker/scripts/install_reranker_sidecar.sh"
+
+if [[ ! -f "${UNIT_SOURCE}" ]]; then
+    echo "missing source unit: ${UNIT_SOURCE}" >&2
+    exit 2
+fi
+if [[ ! -x "${NESTED_INSTALL}" && ! -f "${NESTED_INSTALL}" ]]; then
+    echo "missing nested installer: ${NESTED_INSTALL}" >&2
+    exit 2
+fi
+
+echo "==> docker-compose bring-up via ${NESTED_INSTALL}"
+bash "${NESTED_INSTALL}" "$@"
+
+echo "==> installing ${UNIT_NAME} to ${UNITS_DIR}"
+mkdir -p "${UNITS_DIR}"
+cp "${UNIT_SOURCE}" "${UNITS_DIR}/${UNIT_NAME}"
+
+systemctl --user daemon-reload
+systemctl --user enable --now "${UNIT_NAME}"
+
+echo "${UNIT_NAME} installed and started"

--- a/src/keiracom_system/reranker/__init__.py
+++ b/src/keiracom_system/reranker/__init__.py
@@ -1,0 +1,23 @@
+"""Keiracom System — reranker client package.
+
+Wave 2 dispatch Agency_OS-0thg. Thin Python client for the cross-encoder
+reranker sidecar (BAAI/bge-reranker-base via TEI). Hindsight's recall path
+returns top-50 candidates; this client reranks them so the LLM sees the 5-10
+that actually answer the query.
+"""
+
+from src.keiracom_system.reranker.reranker_client import (
+    DEFAULT_BASE_URL,
+    EXPECTED_MODEL_ID,
+    RerankClientError,
+    RerankerClient,
+    RerankHit,
+)
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "EXPECTED_MODEL_ID",
+    "RerankClientError",
+    "RerankerClient",
+    "RerankHit",
+]

--- a/src/keiracom_system/reranker/reranker_client.py
+++ b/src/keiracom_system/reranker/reranker_client.py
@@ -192,7 +192,9 @@ class RerankerClient:
             if not isinstance(idx, int) or not (0 <= idx < n_texts):
                 raise RerankClientError(f"rerank: row {i} index {idx} out of range [0, {n_texts})")
             if not isinstance(score, (int, float)):
-                raise RerankClientError(f"rerank: row {i} score is not numeric: {type(score).__name__}")
+                raise RerankClientError(
+                    f"rerank: row {i} score is not numeric: {type(score).__name__}"
+                )
             text = row.get("text") if isinstance(row.get("text"), str) else None
             out.append(RerankHit(index=int(idx), score=float(score), text=text))
         return out

--- a/src/keiracom_system/reranker/reranker_client.py
+++ b/src/keiracom_system/reranker/reranker_client.py
@@ -1,0 +1,198 @@
+"""reranker_client.py — thin Python client for the cross-encoder reranker sidecar.
+
+Wave 2 dispatch Agency_OS-0thg. Hindsight's recall layer fuses ANN + BM25 +
+graph + temporal hits into a top-50 candidate list. This client posts that
+list (with the original query) to the TEI /rerank endpoint and returns the
+candidates sorted by cross-encoder relevance score — caller typically keeps
+the top 5..10 for the LLM context.
+
+API contract (TEI /rerank, per HuggingFace text-embeddings-inference docs):
+  POST /rerank
+    body: {"query": str, "texts": [str, ...]}
+    response: [{"index": int, "score": float, "text": str|null}, ...]
+  GET /health  → 200 OK when model loaded
+  GET /info    → {"model_id": str, "model_type": "Reranker", ...}
+
+Mirrors src/keiracom_system/embeddings/tei_client.py — same injectable
+HTTP transport pattern so unit tests don't need a live TEI container.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_BASE_URL = "http://reranker:80"
+DEFAULT_TIMEOUT_SECONDS = 30
+EXPECTED_MODEL_ID = "BAAI/bge-reranker-base"
+DEFAULT_TOP_K_RETURNED = 10
+DEFAULT_TOP_K_INPUT = 50  # Hindsight recall returns this many candidates.
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RerankHit:
+    """One reranked candidate. `index` indexes back into the caller's texts list."""
+
+    index: int
+    score: float
+    text: str | None = None
+
+
+class RerankClientError(RuntimeError):
+    """Raised on any reranker-side or transport error."""
+
+
+class _HTTPResponse:
+    def __init__(self, status_code: int, body: bytes):
+        self.status_code = status_code
+        self._body = body
+
+    def json(self) -> Any:
+        return json.loads(self._body.decode("utf-8") or "null")
+
+    @property
+    def text(self) -> str:
+        return self._body.decode("utf-8", errors="replace")
+
+
+HTTPGetFn = Callable[[str, float], _HTTPResponse]
+HTTPPostFn = Callable[[str, dict[str, Any], float], _HTTPResponse]
+
+
+def _default_http_get(url: str, timeout: float) -> _HTTPResponse:
+    import urllib.request
+
+    req = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — trusted localhost URL
+        return _HTTPResponse(status_code=resp.status, body=resp.read())
+
+
+def _default_http_post(url: str, payload: dict[str, Any], timeout: float) -> _HTTPResponse:
+    import urllib.request
+
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        method="POST",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return _HTTPResponse(status_code=resp.status, body=resp.read())
+
+
+class RerankerClient:
+    """Thin client for the TEI HTTP reranker API.
+
+    Caller is responsible for assembling the candidate text list from the
+    recall layer (Hindsight's bank-level cache covers caching).
+    """
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        http_get: HTTPGetFn | None = None,
+        http_post: HTTPPostFn | None = None,
+        expected_model_id: str = EXPECTED_MODEL_ID,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout_seconds
+        self.expected_model_id = expected_model_id
+        self._http_get = http_get or _default_http_get
+        self._http_post = http_post or _default_http_post
+
+    def healthy(self) -> bool:
+        """True iff GET /health returns 200 OK. Fail-closed on any error."""
+        try:
+            resp = self._http_get(f"{self.base_url}/health", self.timeout)
+            return resp.status_code == 200
+        except Exception as exc:
+            log.warning("RerankerClient.healthy: %s", exc)
+            return False
+
+    def info(self) -> dict[str, Any]:
+        """GET /info → {model_id, model_type, ...}. Raises on transport error."""
+        try:
+            resp = self._http_get(f"{self.base_url}/info", self.timeout)
+        except Exception as exc:
+            raise RerankClientError(f"info: transport error: {exc}") from exc
+        if resp.status_code != 200:
+            raise RerankClientError(f"info: HTTP {resp.status_code}: {resp.text[:200]}")
+        return resp.json()
+
+    def verify_model_lineage(self) -> None:
+        """Defence-in-depth: assert the loaded model matches expected_model_id.
+
+        Catches accidental model swaps at TEI container upgrade time. A
+        different reranker = different relevance distribution = silent
+        quality regression downstream of recall.
+        """
+        info = self.info()
+        actual = info.get("model_id", "")
+        if actual != self.expected_model_id:
+            raise RerankClientError(
+                f"verify_model_lineage: reranker loaded {actual!r}; "
+                f"expected {self.expected_model_id!r}."
+            )
+
+    def rerank(
+        self,
+        query: str,
+        texts: list[str],
+        top_k: int = DEFAULT_TOP_K_RETURNED,
+        return_text: bool = False,
+    ) -> list[RerankHit]:
+        """POST /rerank, return at most top_k hits sorted by descending score.
+
+        Validates:
+          - empty texts returns []
+          - all entries in texts are str
+          - response shape (list of {index, score})
+          - returned indices are within range of texts
+        """
+        if not texts:
+            return []
+        if not isinstance(query, str) or not query:
+            raise RerankClientError("rerank: query must be a non-empty string")
+        if not isinstance(texts, list) or not all(isinstance(t, str) for t in texts):
+            raise RerankClientError(f"rerank: texts must be list[str], got {type(texts).__name__}")
+        if top_k < 1:
+            raise RerankClientError(f"rerank: top_k must be >= 1, got {top_k}")
+
+        payload: dict[str, Any] = {"query": query, "texts": texts, "return_text": return_text}
+        try:
+            resp = self._http_post(f"{self.base_url}/rerank", payload, self.timeout)
+        except Exception as exc:
+            raise RerankClientError(f"rerank: transport error: {exc}") from exc
+        if resp.status_code != 200:
+            raise RerankClientError(f"rerank: HTTP {resp.status_code}: {resp.text[:200]}")
+
+        data = resp.json()
+        if not isinstance(data, list):
+            raise RerankClientError(f"rerank: response not a list, got {type(data).__name__}")
+
+        hits = self._parse_hits(data, n_texts=len(texts))
+        hits.sort(key=lambda h: h.score, reverse=True)
+        return hits[:top_k]
+
+    @staticmethod
+    def _parse_hits(data: list[Any], n_texts: int) -> list[RerankHit]:
+        out: list[RerankHit] = []
+        for i, row in enumerate(data):
+            if not isinstance(row, dict):
+                raise RerankClientError(f"rerank: row {i} not a dict")
+            idx = row.get("index")
+            score = row.get("score")
+            if not isinstance(idx, int) or not (0 <= idx < n_texts):
+                raise RerankClientError(f"rerank: row {i} index {idx} out of range [0, {n_texts})")
+            if not isinstance(score, (int, float)):
+                raise RerankClientError(f"rerank: row {i} score is not numeric: {type(score).__name__}")
+            text = row.get("text") if isinstance(row.get("text"), str) else None
+            out.append(RerankHit(index=int(idx), score=float(score), text=text))
+        return out

--- a/tests/keiracom_system/reranker/test_reranker_client.py
+++ b/tests/keiracom_system/reranker/test_reranker_client.py
@@ -1,0 +1,206 @@
+"""Tests for RerankerClient — Wave 2 dispatch Agency_OS-0thg.
+
+Mirrors tests/keiracom_system/embeddings/test_tei_client.py: unit tests use
+injected HTTP transports so no live TEI container is required. The
+integration test (skip unless KEIRACOM_RERANKER_INTEGRATION=1) hits a real
+running sidecar — same opt-in pattern as the embeddings tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+
+from src.keiracom_system.reranker import (
+    DEFAULT_BASE_URL,
+    EXPECTED_MODEL_ID,
+    RerankClientError,
+    RerankerClient,
+    RerankHit,
+)
+from src.keiracom_system.reranker.reranker_client import _HTTPResponse
+
+
+def _ok(body: Any) -> _HTTPResponse:
+    return _HTTPResponse(status_code=200, body=json.dumps(body).encode())
+
+
+def _err(status: int, body: str = "") -> _HTTPResponse:
+    return _HTTPResponse(status_code=status, body=body.encode())
+
+
+# ---------- healthy ----------
+
+
+def test_healthy_true_on_200():
+    c = RerankerClient(http_get=lambda url, t: _ok(None))
+    assert c.healthy() is True
+
+
+def test_healthy_false_on_500():
+    c = RerankerClient(http_get=lambda url, t: _err(500, "boom"))
+    assert c.healthy() is False
+
+
+def test_healthy_false_on_transport_error():
+    def raises(url: str, t: float) -> _HTTPResponse:
+        raise RuntimeError("connection refused")
+
+    c = RerankerClient(http_get=raises)
+    assert c.healthy() is False
+
+
+# ---------- info + verify_model_lineage ----------
+
+
+def test_info_returns_payload():
+    payload = {"model_id": EXPECTED_MODEL_ID, "model_type": "Reranker"}
+    c = RerankerClient(http_get=lambda url, t: _ok(payload))
+    assert c.info() == payload
+
+
+def test_info_raises_on_5xx():
+    c = RerankerClient(http_get=lambda url, t: _err(503, "down"))
+    with pytest.raises(RerankClientError, match="503"):
+        c.info()
+
+
+def test_verify_model_lineage_ok():
+    c = RerankerClient(http_get=lambda url, t: _ok({"model_id": EXPECTED_MODEL_ID}))
+    c.verify_model_lineage()  # no raise
+
+
+def test_verify_model_lineage_mismatch():
+    c = RerankerClient(http_get=lambda url, t: _ok({"model_id": "other/model"}))
+    with pytest.raises(RerankClientError, match="reranker loaded"):
+        c.verify_model_lineage()
+
+
+# ---------- rerank input validation ----------
+
+
+def test_rerank_empty_texts_returns_empty():
+    c = RerankerClient()
+    assert c.rerank("query", []) == []
+
+
+def test_rerank_rejects_empty_query():
+    c = RerankerClient()
+    with pytest.raises(RerankClientError, match="non-empty string"):
+        c.rerank("", ["doc"])
+
+
+def test_rerank_rejects_non_str_in_texts():
+    c = RerankerClient()
+    with pytest.raises(RerankClientError, match="list\\[str\\]"):
+        c.rerank("q", ["ok", 42])  # type: ignore[list-item]
+
+
+def test_rerank_rejects_top_k_zero():
+    c = RerankerClient()
+    with pytest.raises(RerankClientError, match="top_k must be >= 1"):
+        c.rerank("q", ["doc"], top_k=0)
+
+
+# ---------- rerank success path ----------
+
+
+def test_rerank_sorts_by_score_desc_and_limits_top_k():
+    response = [
+        {"index": 0, "score": 0.1},
+        {"index": 1, "score": 0.9},
+        {"index": 2, "score": 0.5},
+    ]
+    posted: dict[str, Any] = {}
+
+    def post(url: str, payload: dict[str, Any], t: float) -> _HTTPResponse:
+        posted["url"] = url
+        posted["payload"] = payload
+        return _ok(response)
+
+    c = RerankerClient(http_post=post)
+    hits = c.rerank("query", ["a", "b", "c"], top_k=2)
+    assert hits == [RerankHit(index=1, score=0.9), RerankHit(index=2, score=0.5)]
+    assert posted["url"].endswith("/rerank")
+    assert posted["payload"]["query"] == "query"
+    assert posted["payload"]["texts"] == ["a", "b", "c"]
+
+
+def test_rerank_returns_text_field_when_returned():
+    response = [{"index": 0, "score": 0.7, "text": "the doc"}]
+    c = RerankerClient(http_post=lambda url, p, t: _ok(response))
+    hits = c.rerank("q", ["the doc"], return_text=True)
+    assert hits == [RerankHit(index=0, score=0.7, text="the doc")]
+
+
+# ---------- rerank error paths ----------
+
+
+def test_rerank_raises_on_5xx():
+    c = RerankerClient(http_post=lambda url, p, t: _err(502, "bad gateway"))
+    with pytest.raises(RerankClientError, match="502"):
+        c.rerank("q", ["doc"])
+
+
+def test_rerank_raises_on_non_list_response():
+    c = RerankerClient(http_post=lambda url, p, t: _ok({"unexpected": "shape"}))
+    with pytest.raises(RerankClientError, match="not a list"):
+        c.rerank("q", ["doc"])
+
+
+def test_rerank_raises_on_out_of_range_index():
+    response = [{"index": 5, "score": 0.5}]
+    c = RerankerClient(http_post=lambda url, p, t: _ok(response))
+    with pytest.raises(RerankClientError, match="out of range"):
+        c.rerank("q", ["doc"])
+
+
+def test_rerank_raises_on_non_numeric_score():
+    response = [{"index": 0, "score": "nope"}]
+    c = RerankerClient(http_post=lambda url, p, t: _ok(response))
+    with pytest.raises(RerankClientError, match="not numeric"):
+        c.rerank("q", ["doc"])
+
+
+def test_rerank_raises_on_transport_error():
+    def raises(url: str, payload: dict[str, Any], t: float) -> _HTTPResponse:
+        raise ConnectionError("dropped")
+
+    c = RerankerClient(http_post=raises)
+    with pytest.raises(RerankClientError, match="transport error"):
+        c.rerank("q", ["doc"])
+
+
+# ---------- defaults ----------
+
+
+def test_default_base_url_constant():
+    assert DEFAULT_BASE_URL == "http://reranker:80"
+
+
+def test_default_expected_model_id_constant():
+    assert EXPECTED_MODEL_ID == "BAAI/bge-reranker-base"
+
+
+# ---------- live integration test (opt-in) ----------
+
+
+@pytest.mark.skipif(
+    os.environ.get("KEIRACOM_RERANKER_INTEGRATION") != "1",
+    reason="set KEIRACOM_RERANKER_INTEGRATION=1 to run against a live sidecar",
+)
+def test_integration_rerank_round_trip():
+    url = os.environ.get("KEIRACOM_RERANKER_URL", "http://localhost:8090")
+    c = RerankerClient(base_url=url)
+    assert c.healthy(), "reranker sidecar not healthy at " + url
+    c.verify_model_lineage()
+    hits = c.rerank(
+        "what is rust",
+        ["rust is a programming language", "cats meow", "rustic furniture"],
+        top_k=2,
+    )
+    assert len(hits) == 2
+    assert hits[0].score >= hits[1].score


### PR DESCRIPTION
## Summary

Wave 2 of the cutover-gating retrieval chain (`ceo:cutover_plan_v1`). Pairs with Wave 1 PR #1229 (Go sidecar deploy). Hindsight's recall layer returns the top-50 candidates from ANN + BM25 + graph + temporal fusion; this sidecar reranks them with `BAAI/bge-reranker-base` so the LLM context only spends tokens on the 5..10 that actually answer the query.

Same deployment pattern as Wave 1 — user-scope systemd-managed sidecar — adapted for a containerised TEI upstream. TEI is the same image used by the embeddings sidecar at `infra/keiracom_system/embeddings/`; different model id (`BAAI/bge-reranker-base`), different port (`8090` vs `8080`), distinct named volume.

## Deliverables

- `docker-compose.reranker.yml` — TEI container on 8090, persistent model-cache volume, healthcheck, 3-min start_period for first-boot model download (278MB).
- `keiracom-reranker-sidecar.service` — user-scope systemd unit wrapping `docker compose up`. Restart `on-failure`, append-only log.
- `scripts/install_reranker_sidecar.sh` — idempotent compose-up + `/health` + `/info` lineage check + `/rerank` round-trip smoke.
- `scripts/install-systemd.sh` — idempotent install + enable + restart of the unit.
- `src/keiracom_system/reranker/reranker_client.py` — stdlib-only Python client. `RerankerClient.rerank(query, texts, top_k=10)` validates shape, sorts by score desc, truncates to top_k. Injectable HTTP transports so unit tests don't need a live container.
- `tests/keiracom_system/reranker/test_reranker_client.py` — 18 unit + 1 integration test (opt-in via `KEIRACOM_RERANKER_INTEGRATION=1`). 20 passed, 1 skipped locally.

## Caller-side flow

```python
hits50 = hindsight.recall(query)                                    # top-50 fused
client = RerankerClient(base_url=os.environ["KEIRACOM_RERANKER_URL"])
reranked = client.rerank(query, [h.text for h in hits50], top_k=10) # cross-encoder
top_ids = [hits50[h.index].id for h in reranked]
```

`healthy()` lets callers degrade to raw ANN order when the sidecar is unreachable. `verify_model_lineage()` catches accidental model swaps on TEI upgrade.

## Test plan

- [x] `pytest tests/keiracom_system/reranker/` → 20 passed, 1 skipped (integration)
- [x] `docker-compose.reranker.yml` parses cleanly (PyYAML safe_load)
- [x] `bash -n` on both install scripts passes
- [x] systemd unit parses with three required sections + Type=simple + Restart=on-failure
- [ ] Live integration once host has Docker + reranker container pulled: `KEIRACOM_RERANKER_INTEGRATION=1 pytest tests/keiracom_system/reranker/`
- [ ] Deliberator review: 2-of-3 `[REVIEW:approve:<callsign>]` per `orchestrator-merge-after-NATS-concur`

## Scope notes

- Recall layer → reranker wiring (orchestrator side) is a follow-up PR — this PR ships the standalone sidecar + client so the recall caller can adopt incrementally.
- Wave 1 PR #1229 ships the Go sidecar (systemd + circuit breakers + rate limiter); the two waves are independent per the dispatch's "each PR own scope" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)