### PR TITLE
[ORION] feat(dispatcher): bounded-spawn kill-on-violation (Agency_OS-gcpm / Audit RED-7)

### DIFF
--- a/src/dispatcher/bounded_spawn_enforcer.py
+++ b/src/dispatcher/bounded_spawn_enforcer.py
@@ -1,0 +1,291 @@
+"""Bounded-spawn enforcement — Agency_OS-gcpm (RED-7).
+
+The bounded-spawn discipline (per ``docs/architecture/ephemeral_persistence_boundary.md``)
+is load-bearing for the dispatcher: each spawn (tmux session / container) handles
+exactly ONE task. PR #1201 keepalive enforces fresh ``claude`` respawn at the
+chokepoint, but nothing previously stopped the dispatcher itself from handing a
+second task to an already-active spawn slot — honour-system in production.
+
+This module closes that gap with kill-on-violation:
+
+  - Track ``{callsign: SpawnRecord}`` for every successful ``/dispatcher/spawn``.
+  - On the next spawn for the same callsign, classify as VIOLATION when the
+    new request carries a different task identifier than the active record.
+  - On violation: append a JSONL audit row, fire a structured alert, and kill
+    the prior spawn via the provided terminate callback.
+
+Failure mode is fail-open by design — any internal exception (audit-write
+failure, alerts emitter raise) MUST NOT block a legitimate spawn. The hard
+floor for the enforcer is: "never block a fresh task because telemetry broke".
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import os
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants — env knobs + defaults
+# ---------------------------------------------------------------------------
+
+ENFORCER_AUDIT_LOG_ENV = "DISPATCHER_BOUNDED_SPAWN_AUDIT_LOG"
+DEFAULT_AUDIT_LOG_PATH = "/tmp/bounded_spawn_violations.jsonl"
+
+# Decision names — kept stable so dashboards / alert routing can filter.
+DECISION_RECORDED = "recorded"
+DECISION_REPEAT_TASK = "repeat_task"  # same callsign + same task_id (idempotent)
+DECISION_VIOLATION = "second_task_on_active_spawn"
+
+
+@dataclasses.dataclass(frozen=True)
+class SpawnRecord:
+    """Snapshot of one active spawn slot."""
+
+    key: str
+    callsign: str
+    task_id: str
+    backend: str
+    started_at: float  # time.monotonic()
+    started_at_unix: float  # time.time() — wall clock, for audit log
+
+
+@dataclasses.dataclass(frozen=True)
+class EnforcementResult:
+    """Outcome of a ``record_spawn`` check."""
+
+    decision: str  # DECISION_*
+    reason: str
+    prior: SpawnRecord | None
+    killed: bool
+
+
+# ---------------------------------------------------------------------------
+# Terminate callback signature — injected so the enforcer is decoupled from
+# session_manager / FastAPI state. Returns True when the kill succeeded.
+# ---------------------------------------------------------------------------
+
+TerminateCallback = Callable[[str], bool]
+AlertEmitter = Callable[[dict[str, Any]], None]
+
+
+class BoundedSpawnEnforcer:
+    """One-task-per-spawn enforcement layer.
+
+    Thread-safe (lock around state mutation). Designed for module-level
+    singleton use from ``src.dispatcher.main`` plus DI in tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        terminate_cb: TerminateCallback,
+        alerts_emitter: AlertEmitter | None = None,
+        audit_log_path: str | Path | None = None,
+    ) -> None:
+        self._terminate_cb = terminate_cb
+        self._alerts_emitter = alerts_emitter or _default_alert_emitter
+        self._audit_log_path = Path(
+            audit_log_path or os.environ.get(ENFORCER_AUDIT_LOG_ENV, DEFAULT_AUDIT_LOG_PATH)
+        )
+        self._active: dict[str, SpawnRecord] = {}
+        self._lock = threading.Lock()
+
+    # -- spawn record / violation detection ---------------------------------
+
+    def record_spawn(
+        self,
+        *,
+        key: str,
+        callsign: str,
+        task_id: str,
+        backend: str,
+    ) -> EnforcementResult:
+        """Record a new spawn slot; classify against prior active record.
+
+        Returns ``EnforcementResult`` describing outcome. Callers should
+        consult ``.killed`` to know whether the prior spawn was terminated.
+        Even on violation, the new spawn is recorded as the active slot.
+        """
+        with self._lock:
+            prior = self._active.get(callsign)
+
+            if prior is None:
+                rec = self._fresh_record(key, callsign, task_id, backend)
+                self._active[callsign] = rec
+                return EnforcementResult(
+                    decision=DECISION_RECORDED,
+                    reason="new spawn slot",
+                    prior=None,
+                    killed=False,
+                )
+
+            if prior.task_id == task_id:
+                # Same callsign + same task_id = idempotent re-spawn (probably
+                # keepalive bouncing through dispatcher). Refresh start time
+                # but do not flag violation.
+                rec = self._fresh_record(key, callsign, task_id, backend)
+                self._active[callsign] = rec
+                return EnforcementResult(
+                    decision=DECISION_REPEAT_TASK,
+                    reason="same task on same callsign — idempotent",
+                    prior=prior,
+                    killed=False,
+                )
+
+            # Different task_id while prior spawn still active = VIOLATION.
+            killed = self._kill_violator(prior, new_task_id=task_id)
+            self._audit_violation(prior, new_task_id=task_id, killed=killed)
+            self._emit_alert(prior, new_task_id=task_id, killed=killed)
+            # Record the new task as the canonical active spawn.
+            self._active[callsign] = self._fresh_record(key, callsign, task_id, backend)
+            return EnforcementResult(
+                decision=DECISION_VIOLATION,
+                reason=f"second task on active spawn ({prior.task_id!r}→{task_id!r})",
+                prior=prior,
+                killed=killed,
+            )
+
+    def would_violate(self, *, callsign: str, task_id: str) -> bool:
+        """Read-only check: would a record_spawn for (callsign, task_id) violate?
+
+        Used by the interceptor_proxy / governance_proxy hook to gate model
+        calls that carry bounded-spawn metadata before they reach LiteLLM.
+        Returns True when there is an active slot for ``callsign`` whose
+        ``task_id`` differs from the supplied one.
+        """
+        with self._lock:
+            prior = self._active.get(callsign)
+            if prior is None:
+                return False
+            return prior.task_id != task_id
+
+    def release_spawn(self, key: str) -> SpawnRecord | None:
+        """Drop the active record for ``key``. Called from /dispatcher/terminate.
+
+        Returns the released record (or None if no match) for caller logging.
+        """
+        with self._lock:
+            for callsign, rec in list(self._active.items()):
+                if rec.key == key:
+                    self._active.pop(callsign, None)
+                    return rec
+            return None
+
+    def snapshot(self) -> dict[str, dict[str, Any]]:
+        """Return a JSON-safe snapshot of currently-active slots."""
+        with self._lock:
+            return {callsign: dataclasses.asdict(rec) for callsign, rec in self._active.items()}
+
+    # -- internals ----------------------------------------------------------
+
+    @staticmethod
+    def _fresh_record(key: str, callsign: str, task_id: str, backend: str) -> SpawnRecord:
+        return SpawnRecord(
+            key=key,
+            callsign=callsign,
+            task_id=task_id,
+            backend=backend,
+            started_at=time.monotonic(),
+            started_at_unix=time.time(),
+        )
+
+    def _kill_violator(self, prior: SpawnRecord, *, new_task_id: str) -> bool:
+        """Invoke the terminate callback for the violating spawn. Fail-open."""
+        try:
+            ok = bool(self._terminate_cb(prior.key))
+        except Exception:  # noqa: BLE001 — fail-open per module contract
+            logger.exception(
+                "bounded-spawn: terminate_cb raised for key=%s callsign=%s",
+                prior.key,
+                prior.callsign,
+            )
+            return False
+        if not ok:
+            logger.warning(
+                "bounded-spawn: terminate_cb returned falsy for key=%s callsign=%s new_task=%s",
+                prior.key,
+                prior.callsign,
+                new_task_id,
+            )
+        return ok
+
+    def _audit_violation(
+        self,
+        prior: SpawnRecord,
+        *,
+        new_task_id: str,
+        killed: bool,
+    ) -> None:
+        """Append a JSONL audit row. Fail-open (telemetry never blocks spawn)."""
+        row = {
+            "ts": time.time(),
+            "event": "bounded_spawn_violation",
+            "callsign": prior.callsign,
+            "prior_key": prior.key,
+            "prior_task_id": prior.task_id,
+            "prior_backend": prior.backend,
+            "prior_started_at_unix": prior.started_at_unix,
+            "prior_lifetime_s": time.monotonic() - prior.started_at,
+            "new_task_id": new_task_id,
+            "killed": killed,
+        }
+        try:
+            self._audit_log_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._audit_log_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(row) + "\n")
+        except Exception:  # noqa: BLE001 — never block spawn on audit failure
+            logger.exception(
+                "bounded-spawn: audit append failed (non-fatal) path=%s",
+                self._audit_log_path,
+            )
+
+    def _emit_alert(
+        self,
+        prior: SpawnRecord,
+        *,
+        new_task_id: str,
+        killed: bool,
+    ) -> None:
+        """Fire a structured alert. Fail-open."""
+        payload = {
+            "alert": "bounded_spawn_violation",
+            "severity": "critical",
+            "callsign": prior.callsign,
+            "prior_task_id": prior.task_id,
+            "new_task_id": new_task_id,
+            "killed": killed,
+            "prior_lifetime_s": time.monotonic() - prior.started_at,
+        }
+        try:
+            self._alerts_emitter(payload)
+        except Exception:  # noqa: BLE001 — fail-open
+            logger.exception("bounded-spawn: alerts_emitter raised (non-fatal)")
+
+
+def _default_alert_emitter(payload: dict[str, Any]) -> None:
+    """Default alerts go to logger.error so they surface in dispatcher logs.
+
+    Production wiring may inject a Better Stack / Slack relay emitter; this
+    default ensures *something* is on the wire even without that injection.
+    """
+    logger.error("bounded-spawn ALERT: %s", json.dumps(payload, default=str))
+
+
+__all__ = [
+    "DECISION_RECORDED",
+    "DECISION_REPEAT_TASK",
+    "DECISION_VIOLATION",
+    "BoundedSpawnEnforcer",
+    "EnforcementResult",
+    "SpawnRecord",
+]

--- a/src/dispatcher/interceptor_proxy.py
+++ b/src/dispatcher/interceptor_proxy.py
@@ -74,6 +74,58 @@ RATE_WINDOW_SECONDS: Final = 60
 LITELLM_URL_ENV: Final = "LITELLM_URL"
 DEFAULT_LITELLM_URL: Final = "http://127.0.0.1:4000/v1/chat/completions"
 
+# Bounded-spawn discipline hook (Agency_OS-gcpm / Audit RED-7).
+# Off by default; production startup wires the enforcer accessor below.
+# The hook fires only when the request body carries both ``bounded_spawn_callsign``
+# and ``bounded_spawn_task_id`` metadata — until the dispatcher task pipeline
+# propagates that metadata to model calls this gate is a no-op even when wired.
+_bounded_spawn_enforcer_accessor: Any | None = None
+
+
+def set_bounded_spawn_enforcer_accessor(accessor: Any | None) -> None:
+    """Inject a callable that returns the live BoundedSpawnEnforcer (or None).
+
+    Using a callable accessor instead of a direct enforcer reference keeps the
+    interceptor decoupled from ``src.dispatcher.main`` (no circular import)
+    while still letting it consult the live state at request-time.
+    """
+    global _bounded_spawn_enforcer_accessor  # noqa: PLW0603
+    _bounded_spawn_enforcer_accessor = accessor
+
+
+def _check_bounded_spawn_via_metadata(body: dict) -> str | None:
+    """Return a violation reason if request body indicates a bounded-spawn violator.
+
+    Returns None when:
+      - hook not wired (no accessor injected)
+      - body lacks bounded-spawn metadata (rollout phase)
+      - enforcer says the (callsign, task_id) pair is consistent with active slot
+
+    Returns a structured reason string when the body's task_id does not match
+    the active slot's task_id for that callsign — i.e. the model call is
+    coming from a spawn that already had its slot reassigned (violator).
+    """
+    if _bounded_spawn_enforcer_accessor is None:
+        return None
+    callsign = str(body.get("bounded_spawn_callsign") or "").strip()
+    task_id = str(body.get("bounded_spawn_task_id") or "").strip()
+    if not callsign or not task_id:
+        return None
+    try:
+        enforcer = _bounded_spawn_enforcer_accessor()
+    except Exception:  # noqa: BLE001 — fail-open
+        logger.exception("bounded-spawn accessor raised — failing open")
+        return None
+    if enforcer is None:
+        return None
+    try:
+        if enforcer.would_violate(callsign=callsign, task_id=task_id):
+            return f"bounded_spawn_violator callsign={callsign} task_id={task_id}"
+    except Exception:  # noqa: BLE001 — fail-open
+        logger.exception("bounded-spawn would_violate raised — failing open")
+    return None
+
+
 # Context-window budget gate (PR #1210 / Cat 21 lever 25 / cutover-blocker 3).
 # Disabled by default; tests + production startup enable via env or DI.
 CONTEXT_WINDOW_ENABLED_ENV: Final = "DISPATCHER_CONTEXT_WINDOW_ENABLED"
@@ -291,6 +343,31 @@ async def intercept_request(
             reason=reason,
             status_code=403,
             payload={"error": "governance_denied", "reason": reason},
+        )
+
+    # Bounded-spawn discipline hook (Agency_OS-gcpm / Audit RED-7).
+    # Rejects model calls from violator spawns whose slot was already reassigned
+    # to a different task. Only fires when body carries the metadata fields;
+    # no-op until the dispatcher task pipeline starts tagging model calls.
+    bs_violation = _check_bounded_spawn_via_metadata(body)
+    if bs_violation is not None:
+        await _log_event(
+            tenant_id,
+            "deny_bounded_spawn",
+            bs_violation,
+            model,
+            None,
+            None,
+            None,
+            _ms_since(start),
+            insert_fn,
+        )
+        return InterceptorDecision(
+            allowed=False,
+            decision="deny_bounded_spawn",
+            reason=bs_violation,
+            status_code=409,
+            payload={"error": "bounded_spawn_violation", "reason": bs_violation},
         )
 
     spend_ok, _ = await _check_spend_budget(tenant_id, tier)

--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -29,6 +29,10 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 import src.dispatcher.auth_minter  # noqa: F401 — imported for fail-fast side-effect
+from src.dispatcher.bounded_spawn_enforcer import (
+    DECISION_VIOLATION,
+    BoundedSpawnEnforcer,
+)
 from src.dispatcher.container_lifecycle import ContainerStartupError, DockerUnavailableError
 from src.dispatcher.idempotency import IdempotencyDecision, IdempotencyGate
 from src.dispatcher.interceptor_proxy import router as interceptor_router
@@ -92,6 +96,59 @@ def _set_idempotency_gate(gate: IdempotencyGate | None) -> None:
     """Test-only setter for the idempotency gate (DI through module attr)."""
     global _idempotency_gate  # noqa: PLW0603
     _idempotency_gate = gate
+
+
+# Bounded-spawn enforcer (Agency_OS-gcpm / Audit fix RED-7). Enforces the
+# one-task-per-spawn discipline (per docs/architecture/ephemeral_persistence_boundary.md).
+# None = no-op (default until production startup wires a real enforcer via
+# _set_bounded_spawn_enforcer with a terminate_cb that calls into _spawned).
+_bounded_spawn_enforcer: BoundedSpawnEnforcer | None = None
+
+
+def _set_bounded_spawn_enforcer(enforcer: BoundedSpawnEnforcer | None) -> None:
+    """Test-only setter for the bounded-spawn enforcer (DI through module attr)."""
+    global _bounded_spawn_enforcer  # noqa: PLW0603
+    _bounded_spawn_enforcer = enforcer
+
+
+def _bounded_spawn_terminate(key: str) -> bool:
+    """Default terminate callback for the enforcer — tears down via _spawned.
+
+    Returns True when the violating spawn was found + terminated; False when
+    no live entry exists for ``key`` (already torn down / never registered).
+    """
+    entry = _spawned.pop(key, None)
+    if entry is None:
+        return False
+    handle = entry["handle"]
+    try:
+        SessionManager(backend=entry["backend"]).terminate(handle)
+    except Exception:  # noqa: BLE001 — fail-open per enforcer contract
+        logger.exception("bounded-spawn: SessionManager.terminate raised for key=%s", key)
+        return False
+    if _watchdog is not None:
+        with contextlib.suppress(Exception):
+            _watchdog.unregister(key)
+    if _reaper is not None:
+        try:
+            if isinstance(handle, SessionHandle):
+                _reaper.unregister_tmux(handle.session_name)
+            else:
+                _reaper.unregister_container(handle.id)
+        except Exception:  # noqa: BLE001
+            logger.exception("bounded-spawn: reaper unregister raised for key=%s", key)
+    return True
+
+
+def _bounded_spawn_callsign(spawn_kwargs: dict[str, Any]) -> str:
+    """Pull the callsign from spawn_kwargs; default ``dispatcher`` for unlabelled."""
+    return str((spawn_kwargs or {}).get("callsign") or "dispatcher")
+
+
+def _bounded_spawn_task_id(spawn_kwargs: dict[str, Any], registry_key: str) -> str:
+    """Pull a stable task identifier from spawn_kwargs, falling back to key."""
+    explicit = str((spawn_kwargs or {}).get("task_id") or "").strip()
+    return explicit or registry_key
 
 
 # Sessions spawned via /dispatcher/spawn, keyed by supervisor registry key.
@@ -357,8 +414,36 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     _spawned[req.key] = {"handle": handle, "backend": backend}
+
+    # Bounded-spawn enforcement (Agency_OS-gcpm / Audit RED-7).
+    # Runs AFTER register so the active-slot record reflects what's actually
+    # under supervision. On violation, the prior spawn is killed in-flight;
+    # the new spawn proceeds and is recorded as the canonical active slot.
+    bounded_spawn_result: dict[str, Any] | None = None
+    if _bounded_spawn_enforcer is not None:
+        callsign = _bounded_spawn_callsign(req.spawn_kwargs or {})
+        task_id = _bounded_spawn_task_id(req.spawn_kwargs or {}, req.key)
+        enforcement = _bounded_spawn_enforcer.record_spawn(
+            key=req.key,
+            callsign=callsign,
+            task_id=task_id,
+            backend=backend.value,
+        )
+        bounded_spawn_result = {
+            "decision": enforcement.decision,
+            "killed_prior": enforcement.killed,
+        }
+        if enforcement.decision == DECISION_VIOLATION:
+            logger.error(
+                "bounded-spawn violation: callsign=%s new_task=%s prior_task=%s killed=%s",
+                callsign,
+                task_id,
+                enforcement.prior.task_id if enforcement.prior else None,
+                enforcement.killed,
+            )
+
     rsnap = _reaper.health_snapshot()
-    return {
+    response: dict[str, Any] = {
         "spawned": True,
         "key": req.key,
         "backend": backend.value,
@@ -366,6 +451,9 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
         "watchdog_tracked": _watchdog.tracked,
         "reaper_tracked": int(rsnap["tracked_tmux"]) + int(rsnap["tracked_containers"]),
     }
+    if bounded_spawn_result is not None:
+        response["bounded_spawn"] = bounded_spawn_result
+    return response
 
 
 @app.post(
@@ -390,4 +478,8 @@ async def dispatcher_terminate(req: TerminateRequest) -> dict[str, Any]:
         _reaper.unregister_tmux(handle.session_name)
     else:
         _reaper.unregister_container(handle.id)
+    # Release the bounded-spawn slot so the next legitimate spawn for this
+    # callsign is treated as the first task on a fresh slot, not a violation.
+    if _bounded_spawn_enforcer is not None:
+        _bounded_spawn_enforcer.release_spawn(req.key)
     return {"terminated": True, "key": req.key, "watchdog_tracked": _watchdog.tracked}

--- a/tests/dispatcher/test_bounded_spawn_enforcer.py
+++ b/tests/dispatcher/test_bounded_spawn_enforcer.py
@@ -1,0 +1,199 @@
+"""Unit tests for BoundedSpawnEnforcer (Agency_OS-gcpm / Audit RED-7).
+
+Covers the three classification branches:
+  - first spawn for a callsign → DECISION_RECORDED
+  - same task_id retried → DECISION_REPEAT_TASK (no kill, no audit)
+  - different task_id while prior active → DECISION_VIOLATION (kill + alert + audit)
+
+Plus negative-path coverage:
+  - terminate_cb raising → fail-open, killed=False, but new spawn still recorded
+  - audit-log path under unwritable parent → exception swallowed, decision still returned
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.dispatcher.bounded_spawn_enforcer import (
+    DECISION_RECORDED,
+    DECISION_REPEAT_TASK,
+    DECISION_VIOLATION,
+    BoundedSpawnEnforcer,
+)
+
+
+def _make_enforcer(
+    tmp_path: Path,
+    *,
+    terminate_returns: bool = True,
+    terminate_raises: bool = False,
+    alerts_emitter: MagicMock | None = None,
+) -> tuple[BoundedSpawnEnforcer, MagicMock, MagicMock]:
+    terminate_cb = MagicMock()
+    if terminate_raises:
+        terminate_cb.side_effect = RuntimeError("synthetic terminate failure")
+    else:
+        terminate_cb.return_value = terminate_returns
+    emitter = alerts_emitter or MagicMock()
+    enforcer = BoundedSpawnEnforcer(
+        terminate_cb=terminate_cb,
+        alerts_emitter=emitter,
+        audit_log_path=tmp_path / "violations.jsonl",
+    )
+    return enforcer, terminate_cb, emitter
+
+
+# ---------- happy path ----------
+
+
+def test_first_spawn_records_no_violation(tmp_path: Path) -> None:
+    enforcer, terminate_cb, emitter = _make_enforcer(tmp_path)
+    result = enforcer.record_spawn(key="k1", callsign="orion", task_id="t1", backend="tmux")
+    assert result.decision == DECISION_RECORDED
+    assert result.killed is False
+    assert result.prior is None
+    terminate_cb.assert_not_called()
+    emitter.assert_not_called()
+    assert not (tmp_path / "violations.jsonl").exists()
+
+
+def test_same_task_id_retried_is_repeat_not_violation(tmp_path: Path) -> None:
+    enforcer, terminate_cb, emitter = _make_enforcer(tmp_path)
+    enforcer.record_spawn(key="k1", callsign="orion", task_id="t1", backend="tmux")
+    # Same task arriving again (e.g. keepalive bounce) → no violation.
+    result = enforcer.record_spawn(key="k1-retry", callsign="orion", task_id="t1", backend="tmux")
+    assert result.decision == DECISION_REPEAT_TASK
+    assert result.killed is False
+    assert result.prior is not None
+    assert result.prior.task_id == "t1"
+    terminate_cb.assert_not_called()
+    emitter.assert_not_called()
+
+
+# ---------- violation path ----------
+
+
+def test_second_distinct_task_triggers_violation_kill_alert_audit(tmp_path: Path) -> None:
+    audit_path = tmp_path / "violations.jsonl"
+    enforcer, terminate_cb, emitter = _make_enforcer(tmp_path)
+    enforcer.record_spawn(key="k1", callsign="orion", task_id="t1", backend="tmux")
+    result = enforcer.record_spawn(key="k2", callsign="orion", task_id="t2", backend="tmux")
+    assert result.decision == DECISION_VIOLATION
+    assert result.killed is True
+    assert result.prior is not None
+    assert result.prior.key == "k1"
+    assert result.prior.task_id == "t1"
+    terminate_cb.assert_called_once_with("k1")
+    emitter.assert_called_once()
+    alert_payload = emitter.call_args[0][0]
+    assert alert_payload["alert"] == "bounded_spawn_violation"
+    assert alert_payload["killed"] is True
+    assert alert_payload["callsign"] == "orion"
+    assert alert_payload["prior_task_id"] == "t1"
+    assert alert_payload["new_task_id"] == "t2"
+
+    # Audit JSONL written with a row that matches the violation.
+    assert audit_path.exists()
+    rows = [json.loads(line) for line in audit_path.read_text().splitlines() if line]
+    assert len(rows) == 1
+    assert rows[0]["event"] == "bounded_spawn_violation"
+    assert rows[0]["prior_task_id"] == "t1"
+    assert rows[0]["new_task_id"] == "t2"
+    assert rows[0]["killed"] is True
+
+    # The new task is recorded as the canonical active slot.
+    snap = enforcer.snapshot()
+    assert "orion" in snap
+    assert snap["orion"]["task_id"] == "t2"
+
+
+def test_different_callsigns_do_not_cross_violate(tmp_path: Path) -> None:
+    enforcer, terminate_cb, emitter = _make_enforcer(tmp_path)
+    enforcer.record_spawn(key="a", callsign="orion", task_id="t1", backend="tmux")
+    # Different callsign + different task → separate active slot, no violation.
+    result = enforcer.record_spawn(key="b", callsign="atlas", task_id="t2", backend="tmux")
+    assert result.decision == DECISION_RECORDED
+    assert result.killed is False
+    terminate_cb.assert_not_called()
+    emitter.assert_not_called()
+    snap = enforcer.snapshot()
+    assert set(snap.keys()) == {"orion", "atlas"}
+
+
+# ---------- terminate_cb fail-open ----------
+
+
+def test_violation_with_terminate_cb_returning_false_records_killed_false(
+    tmp_path: Path,
+) -> None:
+    enforcer, terminate_cb, emitter = _make_enforcer(tmp_path, terminate_returns=False)
+    enforcer.record_spawn(key="k1", callsign="orion", task_id="t1", backend="tmux")
+    result = enforcer.record_spawn(key="k2", callsign="orion", task_id="t2", backend="tmux")
+    assert result.decision == DECISION_VIOLATION
+    assert result.killed is False
+    terminate_cb.assert_called_once_with("k1")
+    # New spawn still recorded as canonical even when prior kill failed.
+    assert enforcer.snapshot()["orion"]["task_id"] == "t2"
+
+
+def test_violation_with_terminate_cb_raising_fails_open(tmp_path: Path) -> None:
+    enforcer, terminate_cb, emitter = _make_enforcer(tmp_path, terminate_raises=True)
+    enforcer.record_spawn(key="k1", callsign="orion", task_id="t1", backend="tmux")
+    # Must not raise — fail-open contract.
+    result = enforcer.record_spawn(key="k2", callsign="orion", task_id="t2", backend="tmux")
+    assert result.decision == DECISION_VIOLATION
+    assert result.killed is False
+    emitter.assert_called_once()
+
+
+# ---------- release / snapshot ----------
+
+
+def test_release_spawn_removes_active_slot(tmp_path: Path) -> None:
+    enforcer, _terminate_cb, _emitter = _make_enforcer(tmp_path)
+    enforcer.record_spawn(key="k1", callsign="orion", task_id="t1", backend="tmux")
+    released = enforcer.release_spawn("k1")
+    assert released is not None
+    assert released.callsign == "orion"
+    assert enforcer.snapshot() == {}
+
+
+def test_release_spawn_unknown_key_returns_none(tmp_path: Path) -> None:
+    enforcer, _terminate_cb, _emitter = _make_enforcer(tmp_path)
+    assert enforcer.release_spawn("nonexistent") is None
+
+
+def test_release_then_new_task_is_fresh_not_violation(tmp_path: Path) -> None:
+    enforcer, terminate_cb, emitter = _make_enforcer(tmp_path)
+    enforcer.record_spawn(key="k1", callsign="orion", task_id="t1", backend="tmux")
+    enforcer.release_spawn("k1")
+    result = enforcer.record_spawn(key="k2", callsign="orion", task_id="t2", backend="tmux")
+    assert result.decision == DECISION_RECORDED
+    assert result.killed is False
+    terminate_cb.assert_not_called()
+    emitter.assert_not_called()
+
+
+# ---------- audit log fail-open ----------
+
+
+def test_audit_write_failure_does_not_block_violation_handling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Point at a path whose parent cannot be written (use a regular file as the dir).
+    blocker = tmp_path / "not_a_dir"
+    blocker.write_text("blocking the audit dir from being a dir")
+    enforcer = BoundedSpawnEnforcer(
+        terminate_cb=MagicMock(return_value=True),
+        alerts_emitter=MagicMock(),
+        audit_log_path=blocker / "violations.jsonl",
+    )
+    enforcer.record_spawn(key="k1", callsign="orion", task_id="t1", backend="tmux")
+    # Should not raise even though audit write will fail.
+    result = enforcer.record_spawn(key="k2", callsign="orion", task_id="t2", backend="tmux")
+    assert result.decision == DECISION_VIOLATION
+    assert result.killed is True

--- a/tests/dispatcher/test_interceptor_bounded_spawn_hook.py
+++ b/tests/dispatcher/test_interceptor_bounded_spawn_hook.py
@@ -1,0 +1,173 @@
+"""Interceptor-side bounded-spawn hook tests (Agency_OS-gcpm / Audit RED-7).
+
+Covers the per-model-call gate in src.dispatcher.interceptor_proxy that consults
+the BoundedSpawnEnforcer via the injected accessor. Body must carry both
+``bounded_spawn_callsign`` and ``bounded_spawn_task_id`` for the gate to fire.
+
+Borrows the FakeValkey stub pattern from test_interceptor_proxy.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.dispatcher.interceptor_proxy as ip
+from src.dispatcher.bounded_spawn_enforcer import BoundedSpawnEnforcer
+
+
+class _FakeValkey:
+    """Minimal in-memory async stub matching the subset of redis we touch."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, int] = {}
+
+    async def get(self, key: str) -> str | None:
+        v = self.store.get(key)
+        return str(v) if v is not None else None
+
+    async def incr(self, key: str) -> int:
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    async def incrby(self, key: str, amount: int) -> int:
+        self.store[key] = self.store.get(key, 0) + amount
+        return self.store[key]
+
+    async def expire(self, key: str, _ttl: int) -> bool:
+        return True
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.fixture
+def fake_valkey(monkeypatch: pytest.MonkeyPatch) -> _FakeValkey:
+    fake = _FakeValkey()
+    monkeypatch.setattr(ip, "get_valkey_client", lambda: fake)
+    return fake
+
+
+def _make_enforcer(tmp_path: Path) -> BoundedSpawnEnforcer:
+    return BoundedSpawnEnforcer(
+        terminate_cb=MagicMock(return_value=True),
+        alerts_emitter=MagicMock(),
+        audit_log_path=tmp_path / "v.jsonl",
+    )
+
+
+def _valid_body(**extra: object) -> dict:
+    body: dict = {
+        "tenant_id": "11111111-1111-1111-1111-111111111111",
+        "prompt": "noop prompt",
+        "max_tokens": 16,
+        "model": "claude-sonnet-4-6",
+        "tier": "starter",
+    }
+    body.update(extra)
+    return body
+
+
+async def _fake_forward(_body: dict) -> dict:
+    return {"id": "resp-1", "usage": {"prompt_tokens": 1, "completion_tokens": 1}}
+
+
+async def _no_insert(_row: dict) -> None:
+    return None
+
+
+# ---------- no accessor wired = fail-open ----------
+
+
+@pytest.mark.asyncio
+async def test_no_accessor_means_hook_is_noop(fake_valkey: _FakeValkey) -> None:
+    ip.set_bounded_spawn_enforcer_accessor(None)
+    body = _valid_body(bounded_spawn_callsign="orion", bounded_spawn_task_id="t-different")
+    decision = await ip.intercept_request(body, forward_fn=_fake_forward, insert_fn=_no_insert)
+    assert decision.allowed is True
+    assert decision.decision == "allow"
+
+
+# ---------- missing metadata = no-op even with accessor ----------
+
+
+@pytest.mark.asyncio
+async def test_missing_metadata_means_hook_is_noop(
+    fake_valkey: _FakeValkey, tmp_path: Path
+) -> None:
+    enforcer = _make_enforcer(tmp_path)
+    enforcer.record_spawn(key="k1", callsign="orion", task_id="t-current", backend="tmux")
+    ip.set_bounded_spawn_enforcer_accessor(lambda: enforcer)
+
+    try:
+        body = _valid_body()  # no bounded_spawn_* fields
+        decision = await ip.intercept_request(body, forward_fn=_fake_forward, insert_fn=_no_insert)
+        assert decision.allowed is True
+        assert decision.decision == "allow"
+    finally:
+        ip.set_bounded_spawn_enforcer_accessor(None)
+
+
+# ---------- matching metadata = allow ----------
+
+
+@pytest.mark.asyncio
+async def test_matching_metadata_allows(fake_valkey: _FakeValkey, tmp_path: Path) -> None:
+    enforcer = _make_enforcer(tmp_path)
+    enforcer.record_spawn(key="k1", callsign="orion", task_id="t-current", backend="tmux")
+    ip.set_bounded_spawn_enforcer_accessor(lambda: enforcer)
+
+    try:
+        body = _valid_body(bounded_spawn_callsign="orion", bounded_spawn_task_id="t-current")
+        decision = await ip.intercept_request(body, forward_fn=_fake_forward, insert_fn=_no_insert)
+        assert decision.allowed is True
+    finally:
+        ip.set_bounded_spawn_enforcer_accessor(None)
+
+
+# ---------- mismatched metadata = deny ----------
+
+
+@pytest.mark.asyncio
+async def test_mismatched_task_id_returns_409(fake_valkey: _FakeValkey, tmp_path: Path) -> None:
+    enforcer = _make_enforcer(tmp_path)
+    enforcer.record_spawn(key="k1", callsign="orion", task_id="t-current", backend="tmux")
+    ip.set_bounded_spawn_enforcer_accessor(lambda: enforcer)
+
+    try:
+        # Body claims to be from task t-OLD — that's a violator (orphaned) spawn.
+        body = _valid_body(bounded_spawn_callsign="orion", bounded_spawn_task_id="t-OLD")
+
+        forward_called = MagicMock()
+
+        async def _no_forward(_b: dict) -> dict:
+            forward_called()
+            return {"ok": True}
+
+        decision = await ip.intercept_request(body, forward_fn=_no_forward, insert_fn=_no_insert)
+        assert decision.allowed is False
+        assert decision.decision == "deny_bounded_spawn"
+        assert decision.status_code == 409
+        assert "bounded_spawn_violator" in (decision.reason or "")
+        forward_called.assert_not_called()
+    finally:
+        ip.set_bounded_spawn_enforcer_accessor(None)
+
+
+# ---------- accessor raising = fail-open ----------
+
+
+@pytest.mark.asyncio
+async def test_accessor_raising_fails_open(fake_valkey: _FakeValkey) -> None:
+    def _bad_accessor() -> object:
+        raise RuntimeError("synthetic accessor failure")
+
+    ip.set_bounded_spawn_enforcer_accessor(_bad_accessor)
+    try:
+        body = _valid_body(bounded_spawn_callsign="orion", bounded_spawn_task_id="anything")
+        decision = await ip.intercept_request(body, forward_fn=_fake_forward, insert_fn=_no_insert)
+        assert decision.allowed is True
+    finally:
+        ip.set_bounded_spawn_enforcer_accessor(None)

--- a/tests/dispatcher/test_main_bounded_spawn_wiring.py
+++ b/tests/dispatcher/test_main_bounded_spawn_wiring.py
@@ -1,0 +1,262 @@
+"""Wiring tests for bounded-spawn enforcer in /dispatcher/spawn + /terminate.
+
+Agency_OS-gcpm / Audit RED-7. Verifies:
+  - no-enforcer fail-open (default state)
+  - first spawn for a callsign records as new active slot
+  - second spawn for same callsign + different task_id → violation kills prior
+  - /dispatcher/terminate releases the active slot so a fresh task is not flagged
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.dispatcher.bounded_spawn_enforcer import (
+    DECISION_RECORDED,
+    DECISION_VIOLATION,
+    BoundedSpawnEnforcer,
+)
+from src.dispatcher.tmux_lifecycle import SessionHandle
+
+
+def _mock_supervisors(main_mod: Any) -> None:
+    main_mod._watchdog = MagicMock()
+    main_mod._reaper = MagicMock()
+    main_mod._reaper.health_snapshot.return_value = {
+        "tracked_tmux": 0,
+        "tracked_containers": 0,
+    }
+    main_mod._watchdog.tracked = 0
+
+
+def _make_handle(name: str = "disp-test") -> SessionHandle:
+    return SessionHandle(session_name=name, working_dir="/tmp", command="claude")
+
+
+# ---------- no enforcer = fail-open ----------
+
+
+def test_no_enforcer_spawn_proceeds_without_bounded_spawn_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    main_mod._set_bounded_spawn_enforcer(None)
+
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        resp = client.post(
+            "/dispatcher/spawn",
+            json={
+                "backend": "tmux",
+                "key": "k1",
+                "spawn_kwargs": {"callsign": "orion"},
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["spawned"] is True
+    assert "bounded_spawn" not in body
+
+
+# ---------- first spawn = recorded ----------
+
+
+def test_first_spawn_records_active_slot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    enforcer = BoundedSpawnEnforcer(
+        terminate_cb=MagicMock(return_value=True),
+        alerts_emitter=MagicMock(),
+        audit_log_path=tmp_path / "v.jsonl",
+    )
+    main_mod._set_bounded_spawn_enforcer(enforcer)
+
+    try:
+        with (
+            patch("src.dispatcher.main.SessionManager") as MockSM,
+            patch.object(main_mod, "_register_session"),
+        ):
+            MockSM.return_value.spawn.return_value = _make_handle()
+            client = TestClient(main_mod.app, raise_server_exceptions=False)
+            resp = client.post(
+                "/dispatcher/spawn",
+                json={
+                    "backend": "tmux",
+                    "key": "k1",
+                    "spawn_kwargs": {"callsign": "orion", "task_id": "t1"},
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["spawned"] is True
+        assert body["bounded_spawn"]["decision"] == DECISION_RECORDED
+        assert body["bounded_spawn"]["killed_prior"] is False
+        # Enforcer state reflects active slot.
+        snap = enforcer.snapshot()
+        assert "orion" in snap
+        assert snap["orion"]["task_id"] == "t1"
+    finally:
+        main_mod._set_bounded_spawn_enforcer(None)
+
+
+# ---------- violation path ----------
+
+
+def test_second_distinct_task_violates_kills_prior(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    terminate_mock = MagicMock(return_value=True)
+    alerts_mock = MagicMock()
+    enforcer = BoundedSpawnEnforcer(
+        terminate_cb=terminate_mock,
+        alerts_emitter=alerts_mock,
+        audit_log_path=tmp_path / "v.jsonl",
+    )
+    main_mod._set_bounded_spawn_enforcer(enforcer)
+
+    try:
+        with (
+            patch("src.dispatcher.main.SessionManager") as MockSM,
+            patch.object(main_mod, "_register_session"),
+        ):
+            MockSM.return_value.spawn.return_value = _make_handle()
+            client = TestClient(main_mod.app, raise_server_exceptions=False)
+            # First task — fresh slot.
+            r1 = client.post(
+                "/dispatcher/spawn",
+                json={
+                    "backend": "tmux",
+                    "key": "k1",
+                    "spawn_kwargs": {"callsign": "orion", "task_id": "t1"},
+                },
+            )
+            assert r1.status_code == 200, r1.text
+            # Second task — different task_id, same callsign = VIOLATION.
+            r2 = client.post(
+                "/dispatcher/spawn",
+                json={
+                    "backend": "tmux",
+                    "key": "k2",
+                    "spawn_kwargs": {"callsign": "orion", "task_id": "t2"},
+                },
+            )
+            assert r2.status_code == 200, r2.text
+        body = r2.json()
+        assert body["spawned"] is True
+        assert body["bounded_spawn"]["decision"] == DECISION_VIOLATION
+        assert body["bounded_spawn"]["killed_prior"] is True
+        terminate_mock.assert_called_once_with("k1")
+        alerts_mock.assert_called_once()
+        # New task is now the active slot.
+        assert enforcer.snapshot()["orion"]["task_id"] == "t2"
+    finally:
+        main_mod._set_bounded_spawn_enforcer(None)
+
+
+# ---------- terminate releases slot ----------
+
+
+def test_terminate_releases_slot_so_next_spawn_is_fresh(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    enforcer = BoundedSpawnEnforcer(
+        terminate_cb=MagicMock(return_value=True),
+        alerts_emitter=MagicMock(),
+        audit_log_path=tmp_path / "v.jsonl",
+    )
+    main_mod._set_bounded_spawn_enforcer(enforcer)
+
+    try:
+        handle = _make_handle()
+        # Seed _spawned manually so /terminate finds an entry.
+        with (
+            patch("src.dispatcher.main.SessionManager") as MockSM,
+            patch.object(main_mod, "_register_session"),
+        ):
+            MockSM.return_value.spawn.return_value = handle
+            client = TestClient(main_mod.app, raise_server_exceptions=False)
+            r1 = client.post(
+                "/dispatcher/spawn",
+                json={
+                    "backend": "tmux",
+                    "key": "k1",
+                    "spawn_kwargs": {"callsign": "orion", "task_id": "t1"},
+                },
+            )
+            assert r1.status_code == 200
+            assert enforcer.snapshot()["orion"]["task_id"] == "t1"
+
+            r_term = client.post(
+                "/dispatcher/terminate",
+                json={"key": "k1"},
+            )
+            assert r_term.status_code == 200, r_term.text
+            # Slot released.
+            assert enforcer.snapshot() == {}
+
+            # Now a different task on the same callsign should be RECORDED, not VIOLATION.
+            MockSM.return_value.spawn.return_value = _make_handle(name="disp-test-2")
+            r2 = client.post(
+                "/dispatcher/spawn",
+                json={
+                    "backend": "tmux",
+                    "key": "k2",
+                    "spawn_kwargs": {"callsign": "orion", "task_id": "t2"},
+                },
+            )
+            assert r2.status_code == 200, r2.text
+            assert r2.json()["bounded_spawn"]["decision"] == DECISION_RECORDED
+    finally:
+        main_mod._set_bounded_spawn_enforcer(None)
+
+
+# ---------- default terminate callback path ----------
+
+
+def test_default_terminate_callback_tears_down_via_spawned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    handle = _make_handle(name="disp-killme")
+    main_mod._spawned["killme"] = {"handle": handle, "backend": MagicMock(value="tmux")}
+
+    with patch("src.dispatcher.main.SessionManager") as MockSM:
+        MockSM.return_value.terminate = MagicMock()
+        result = main_mod._bounded_spawn_terminate("killme")
+        assert result is True
+        MockSM.return_value.terminate.assert_called_once_with(handle)
+    # The handle was removed from _spawned.
+    assert "killme" not in main_mod._spawned
+
+    # Unknown key returns False without raising.
+    assert main_mod._bounded_spawn_terminate("nope") is False


### PR DESCRIPTION
## Summary
- Closes the dispatcher-kill-on-violation gap that left bounded-spawn discipline as honour-system (Aiden pre-cutover audit 2026-05-27 — RED-7).
- New ``src/dispatcher/bounded_spawn_enforcer.py`` tracks one active task per callsign, kills + alerts + audits when a second distinct task tries to land on an active slot.
- Wired into ``/dispatcher/spawn`` (record after register) + ``/dispatcher/terminate`` (release on clean teardown).
- Lightweight read-only hook in ``interceptor_proxy`` so model calls carrying ``bounded_spawn_callsign`` + ``bounded_spawn_task_id`` body fields get 409'd if the active slot has been reassigned.

## What changed
- ``src/dispatcher/bounded_spawn_enforcer.py`` (new, ~280 lines): ``BoundedSpawnEnforcer`` with ``record_spawn`` / ``release_spawn`` / ``snapshot`` / ``would_violate``. Thread-safe singleton-style. Fail-open on every external boundary (audit write, alerts emitter, terminate cb).
- ``src/dispatcher/main.py``: module-level enforcer DI (``_set_bounded_spawn_enforcer``), default terminate cb (``_bounded_spawn_terminate``) that tears down via existing ``_spawned`` + supervisors, callsign / task_id derivation from spawn_kwargs, spawn endpoint wiring, terminate endpoint releases the slot.
- ``src/dispatcher/interceptor_proxy.py``: ``set_bounded_spawn_enforcer_accessor`` injection point + ``_check_bounded_spawn_via_metadata`` gate. Returns 409 ``deny_bounded_spawn`` for violator model calls. No-op until task metadata pipeline lands.
- 3 test files (20 new tests): unit coverage of enforcer classification + fail-open paths; FastAPI wiring of spawn/terminate; interceptor hook semantics.

## Default state
Disabled (matches idempotency / budget / attribution gate pattern). Production startup wires the real enforcer + accessor when the cutover lands.

## Test plan
- [x] ``ruff check src/dispatcher tests/dispatcher`` — all checks passed
- [x] ``ruff format --check src/dispatcher tests/dispatcher`` — clean
- [x] ``pytest tests/dispatcher/ -q`` — 277 passed (was 257; +20 new bounded-spawn tests, no regressions)
- [x] Unit suite covers: first-spawn RECORDED, same-task REPEAT, distinct-task VIOLATION (kill + alert + audit), cross-callsign isolation, terminate-cb returning False, terminate-cb raising, release + re-spawn = fresh, audit fail-open
- [x] Wiring suite covers: no-enforcer fail-open response shape, recorded response shape, violation kills prior + records new active slot, terminate releases slot
- [x] Interceptor hook suite covers: no accessor = no-op, no metadata = no-op, matching = allow, mismatched task_id = 409 deny, accessor raising = fail-open

## bd / anchor
- bd: ``Agency_OS-gcpm``
- ceo_memory anchor: ``ceo:keiracom_architecture_v2_locked`` (bounded-spawn = hardest constraint)
- Audit doc: 2026-05-27 Aiden pre-cutover audit RED-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)