### PR TITLE
[SCOUT] feat(memory): recency decay on retrieval scores — tunable half-life per topology + canonical bypass (Agency_OS-3rpe)

### DIFF
--- a/src/keiracom_system/memory/recency_decay.py
+++ b/src/keiracom_system/memory/recency_decay.py
@@ -1,0 +1,268 @@
+"""recency_decay.py — exponential recency decay on retrieval scores.
+
+Wave 2 CUTOVER GATE (Dave ratify 2026-05-27, Agency_OS-3rpe): older memories
+must lose to newer at equal similarity unless they carry a canonical tag
+(ratified ceo_memory keys, governance-locked architecture facts, etc.).
+Pure math + small policy layer; no external clients.
+
+Canonical key citations (per audit-dispatch checklist `_orchestrator.md`):
+
+ceo:cutover_plan_v1 — full_retrieval_tier_ratify_2026_05_27_22Z.waves.wave_2_retrieval_core:
+    "hybrid search + cross-encoder reranker + recency decay"
+
+ceo:memory_abstraction_layer_v1 — substantive_lock:
+    "mem.topology_tier_keyed" (per-topology half-life)
+
+DESIGN — `apply_recency_decay(score, age_seconds, half_life_seconds)` is the
+pure scalar. `decay_scored_memories(memories, *, config, now=...)` applies
+the policy: per-topology half-life lookup + canonical-tag bypass + optional
+floor so decay doesn't collapse a high-similarity old memory below the
+noise threshold.
+
+Half-life table is config-injected, not hardcoded here — different deploys
+tune differently. The DEFAULT_HALF_LIVES dict below is the V1 baseline
+Dave-ratified topology->half-life mapping; production wiring may override
+per-tenant.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+SECONDS_PER_DAY = 86400
+LN_2 = math.log(2.0)
+
+
+# V1 baseline half-lives per topology (in days). Source: Dave ratify
+# 2026-05-27 (ceo:cutover_plan_v1 wave_2_retrieval_core) — values chosen so
+# fast-moving banks (KEI tracker, agent memories) decay quickly and
+# slow-moving banks (codebase, decisions) decay slowly. Tuning is empirical
+# Phase 2 work; these are starting points, not final.
+DEFAULT_HALF_LIVES: dict[str, float] = {
+    "fleet_keis": 7.0,
+    "fleet_agent_memories": 7.0,
+    "fleet_tool_calls": 3.0,
+    "fleet_session_transcripts": 3.0,
+    "fleet_discoveries": 14.0,
+    "fleet_decisions": 30.0,
+    "fleet_global_governance_patterns": 60.0,
+    "fleet_strategic_documents": 90.0,
+    "fleet_codebase": 90.0,
+    "fleet_sessions": 14.0,
+}
+
+# Tags that EXEMPT a memory from decay. Ratified ceo_memory keys + canonical
+# architecture facts must always surface — recency must not bury "Hindsight
+# was chosen as MAL engine 2026-05-24" under last week's tool-call chatter.
+DEFAULT_EXEMPT_TAGS: frozenset[str] = frozenset(
+    {"canonical", "ceo_ratified", "ratified", "governance_locked"}
+)
+
+
+@dataclass(frozen=True)
+class RecencyDecayConfig:
+    """Per-deploy recency-decay policy.
+
+    `half_lives` maps topology key -> half-life in days. Unknown topology
+    falls back to `default_half_life_days` (None = no decay applied).
+    `exempt_tags` short-circuits decay when any of these tags are present
+    on the memory.
+    `score_floor` clamps the decayed score from below so high-similarity
+    old memories don't collapse to zero (e.g. a 4-year-old decision with
+    similarity 0.95 still beats a 1-hour-old chatter with 0.10).
+    """
+
+    half_lives: dict[str, float] = field(default_factory=lambda: dict(DEFAULT_HALF_LIVES))
+    default_half_life_days: float | None = 30.0
+    exempt_tags: frozenset[str] = DEFAULT_EXEMPT_TAGS
+    score_floor: float = 0.0
+
+
+@dataclass(frozen=True)
+class ScoredMemory:
+    """Scored retrieval candidate.
+
+    `original_score` preserves the pre-decay similarity so callers can
+    inspect the delta (e.g. observability + explain-this-rank UX).
+    """
+
+    memory_id: str
+    score: float
+    original_score: float
+    age_seconds: float
+    topology: str
+    decay_applied: bool
+    exempt_reason: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def apply_recency_decay(score: float, age_seconds: float, half_life_seconds: float) -> float:
+    """Pure exponential decay: score * 2^(-age / half_life).
+
+    Equivalent to `score * exp(-ln(2) * age / half_life)`. Half-life is the
+    age at which a score halves; the curve is monotonically decreasing in age.
+    """
+    if half_life_seconds <= 0:
+        raise ValueError(f"half_life_seconds must be positive, got {half_life_seconds!r}")
+    if age_seconds < 0:
+        # A negative age (future-dated atom) is a clock-skew signal — log
+        # but do not penalise; treat as age=0.
+        log.warning("apply_recency_decay called with negative age_seconds=%s", age_seconds)
+        age_seconds = 0
+    factor = math.exp(-LN_2 * age_seconds / half_life_seconds)
+    return score * factor
+
+
+def _resolve_half_life_seconds(topology: str, config: RecencyDecayConfig) -> float | None:
+    """Look up the half-life for a topology, falling back to default."""
+    days = config.half_lives.get(topology)
+    if days is None:
+        days = config.default_half_life_days
+    if days is None:
+        return None
+    if days <= 0:
+        raise ValueError(f"half-life for topology {topology!r} must be positive days, got {days}")
+    return days * SECONDS_PER_DAY
+
+
+def _exempt_reason(tags: list[str], exempt_tags: frozenset[str]) -> str:
+    """Return the matching exempt tag if any, empty string otherwise."""
+    for t in tags:
+        if t in exempt_tags:
+            return t
+    return ""
+
+
+def _parse_atom_timestamp(value: Any) -> float | None:
+    """Best-effort parse of a memory's created_at into an epoch seconds float.
+
+    Accepts int/float (epoch), or ISO-8601 strings. Returns None on parse
+    failure — caller decides whether to skip decay (treat as fresh) or fail
+    loud.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        # ISO-8601 with optional Z. fromisoformat in 3.11+ handles 'Z'; below
+        # that, normalise.
+        s = value.rstrip("Z")
+        try:
+            dt = datetime.fromisoformat(s)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
+            return dt.timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def decay_scored_memories(
+    memories: list[dict[str, Any]],
+    *,
+    config: RecencyDecayConfig,
+    now: float | None = None,
+) -> list[ScoredMemory]:
+    """Apply the recency-decay policy to a list of scored memories.
+
+    Each memory dict must carry:
+      - `id` / `memory_id` — identifier
+      - `score` — pre-decay similarity (0.0–1.0)
+      - `created_at` / `timestamp` — atom age signal (epoch seconds or ISO-8601)
+      - `topology` / `bank` — topology key for half-life lookup
+      - `tags` — list[str] used for exempt-tag matching
+
+    Missing fields fail loud (ValueError) — silent fallback to "no decay"
+    would mask wiring bugs at the call site. The caller is expected to
+    canonicalise the upstream payload before passing in.
+    """
+    if now is None:
+        now = time.time()
+    out: list[ScoredMemory] = []
+    for raw in memories:
+        if not isinstance(raw, dict):
+            raise ValueError(f"memory entry must be dict, got {type(raw).__name__}")
+        mid = str(raw.get("id") or raw.get("memory_id") or "")
+        if not mid:
+            raise ValueError("memory entry missing id / memory_id")
+        score = raw.get("score")
+        if score is None:
+            raise ValueError(f"memory {mid!r} missing score")
+        topology = str(raw.get("topology") or raw.get("bank") or "")
+        if not topology:
+            raise ValueError(f"memory {mid!r} missing topology / bank")
+        tags_raw = raw.get("tags") or []
+        if isinstance(tags_raw, str):
+            tags = [tags_raw]
+        elif isinstance(tags_raw, (list, tuple, set)):
+            tags = [str(t) for t in tags_raw]
+        else:
+            raise ValueError(f"memory {mid!r} tags must be list/tuple/set/str")
+        exempt = _exempt_reason(tags, config.exempt_tags)
+        created_at_raw = raw.get("created_at") or raw.get("timestamp")
+        atom_epoch = _parse_atom_timestamp(created_at_raw)
+        age_seconds = max(now - atom_epoch, 0.0) if atom_epoch is not None else 0.0
+        original_score = float(score)
+        if exempt:
+            out.append(
+                ScoredMemory(
+                    memory_id=mid,
+                    score=original_score,
+                    original_score=original_score,
+                    age_seconds=age_seconds,
+                    topology=topology,
+                    decay_applied=False,
+                    exempt_reason=exempt,
+                    metadata=dict(raw.get("metadata") or {}),
+                )
+            )
+            continue
+        half_life_seconds = _resolve_half_life_seconds(topology, config)
+        if half_life_seconds is None or atom_epoch is None:
+            # No half-life configured OR no atom timestamp — pass through
+            # without decay. This is a legitimate config choice (e.g. a
+            # topology that's intentionally not aged); flag in the result
+            # so observability can detect a wiring oversight.
+            out.append(
+                ScoredMemory(
+                    memory_id=mid,
+                    score=original_score,
+                    original_score=original_score,
+                    age_seconds=age_seconds,
+                    topology=topology,
+                    decay_applied=False,
+                    exempt_reason="no_half_life" if half_life_seconds is None else "no_timestamp",
+                    metadata=dict(raw.get("metadata") or {}),
+                )
+            )
+            continue
+        decayed = apply_recency_decay(original_score, age_seconds, half_life_seconds)
+        if decayed < config.score_floor:
+            decayed = config.score_floor
+        out.append(
+            ScoredMemory(
+                memory_id=mid,
+                score=decayed,
+                original_score=original_score,
+                age_seconds=age_seconds,
+                topology=topology,
+                decay_applied=True,
+                metadata=dict(raw.get("metadata") or {}),
+            )
+        )
+    return out
+
+
+def rerank_by_decayed_score(memories: list[ScoredMemory]) -> list[ScoredMemory]:
+    """Sort scored memories by decayed score descending. Stable sort
+    preserves original relative order on ties."""
+    return sorted(memories, key=lambda m: m.score, reverse=True)

--- a/tests/keiracom_system/memory/test_recency_decay.py
+++ b/tests/keiracom_system/memory/test_recency_decay.py
@@ -1,0 +1,394 @@
+"""tests for keiracom_system.memory.recency_decay — Wave 2 CUTOVER GATE 3rpe.
+
+Coverage matrix:
+- apply_recency_decay (pure math)  — 3 positive + 3 negative
+- decay_scored_memories            — 6 positive + 5 negative
+- canonical-tag bypass             — 4 scenarios
+- rerank ordering                  — 3 scenarios
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.keiracom_system.memory.recency_decay import (
+    DEFAULT_EXEMPT_TAGS,
+    DEFAULT_HALF_LIVES,
+    SECONDS_PER_DAY,
+    RecencyDecayConfig,
+    ScoredMemory,
+    apply_recency_decay,
+    decay_scored_memories,
+    rerank_by_decayed_score,
+)
+
+# ============== apply_recency_decay (pure math) ==============
+
+
+def test_apply_recency_decay_halves_score_at_half_life():
+    # At age = half_life, score must halve (2^-1 = 0.5).
+    result = apply_recency_decay(score=1.0, age_seconds=86400, half_life_seconds=86400)
+    assert math.isclose(result, 0.5, rel_tol=1e-9)
+
+
+def test_apply_recency_decay_quarters_score_at_two_half_lives():
+    result = apply_recency_decay(score=1.0, age_seconds=172800, half_life_seconds=86400)
+    assert math.isclose(result, 0.25, rel_tol=1e-9)
+
+
+def test_apply_recency_decay_returns_original_at_age_zero():
+    result = apply_recency_decay(score=0.87, age_seconds=0, half_life_seconds=86400)
+    assert math.isclose(result, 0.87, rel_tol=1e-9)
+
+
+def test_apply_recency_decay_treats_negative_age_as_zero():
+    # Clock-skew defensive case: do not penalise a future-dated atom.
+    result = apply_recency_decay(score=0.5, age_seconds=-100, half_life_seconds=86400)
+    assert math.isclose(result, 0.5, rel_tol=1e-9)
+
+
+def test_apply_recency_decay_rejects_zero_half_life():
+    with pytest.raises(ValueError, match="half_life_seconds must be positive"):
+        apply_recency_decay(score=1.0, age_seconds=100, half_life_seconds=0)
+
+
+def test_apply_recency_decay_rejects_negative_half_life():
+    with pytest.raises(ValueError, match="half_life_seconds must be positive"):
+        apply_recency_decay(score=1.0, age_seconds=100, half_life_seconds=-86400)
+
+
+# ============== decay_scored_memories ==============
+
+
+_NOW = 2_000_000_000.0  # arbitrary fixed epoch
+
+
+def _mk_memory(
+    *,
+    memory_id: str,
+    score: float,
+    topology: str,
+    age_seconds: float = 0.0,
+    tags: list[str] | None = None,
+):
+    return {
+        "id": memory_id,
+        "score": score,
+        "topology": topology,
+        "created_at": _NOW - age_seconds,
+        "tags": tags or [],
+    }
+
+
+def test_decay_decays_score_per_topology_half_life():
+    config = RecencyDecayConfig()  # uses DEFAULT_HALF_LIVES
+    # fleet_keis half-life = 7 days. Age = 7 days. Score halves.
+    mem = _mk_memory(
+        memory_id="m1", score=1.0, topology="fleet_keis", age_seconds=7 * SECONDS_PER_DAY
+    )
+    out = decay_scored_memories([mem], config=config, now=_NOW)
+    assert len(out) == 1
+    assert out[0].decay_applied
+    assert math.isclose(out[0].score, 0.5, rel_tol=1e-9)
+    assert out[0].original_score == 1.0
+
+
+def test_decay_respects_per_topology_half_life_difference():
+    # fleet_codebase half-life = 90 days; fleet_keis = 7 days.
+    config = RecencyDecayConfig()
+    age = 14 * SECONDS_PER_DAY
+    codebase = _mk_memory(memory_id="c1", score=1.0, topology="fleet_codebase", age_seconds=age)
+    keis = _mk_memory(memory_id="k1", score=1.0, topology="fleet_keis", age_seconds=age)
+    out = decay_scored_memories([codebase, keis], config=config, now=_NOW)
+    codebase_out = next(m for m in out if m.memory_id == "c1")
+    keis_out = next(m for m in out if m.memory_id == "k1")
+    # Same age, slower-decay topology must hold higher score.
+    assert codebase_out.score > keis_out.score
+
+
+def test_decay_falls_back_to_default_half_life_for_unknown_topology():
+    config = RecencyDecayConfig(default_half_life_days=30.0)
+    mem = _mk_memory(
+        memory_id="m1",
+        score=1.0,
+        topology="unknown_topology",
+        age_seconds=30 * SECONDS_PER_DAY,
+    )
+    out = decay_scored_memories([mem], config=config, now=_NOW)
+    assert out[0].decay_applied
+    assert math.isclose(out[0].score, 0.5, rel_tol=1e-9)
+
+
+def test_decay_passes_through_when_default_half_life_is_none():
+    config = RecencyDecayConfig(half_lives={}, default_half_life_days=None)
+    mem = _mk_memory(
+        memory_id="m1",
+        score=0.7,
+        topology="unknown_topology",
+        age_seconds=30 * SECONDS_PER_DAY,
+    )
+    out = decay_scored_memories([mem], config=config, now=_NOW)
+    assert not out[0].decay_applied
+    assert out[0].exempt_reason == "no_half_life"
+    assert out[0].score == 0.7
+
+
+def test_decay_passes_through_when_atom_has_no_timestamp():
+    config = RecencyDecayConfig()
+    mem = {
+        "id": "m1",
+        "score": 0.8,
+        "topology": "fleet_keis",
+        "tags": [],
+        "created_at": None,
+    }
+    out = decay_scored_memories([mem], config=config, now=_NOW)
+    assert not out[0].decay_applied
+    assert out[0].exempt_reason == "no_timestamp"
+    assert out[0].score == 0.8
+
+
+def test_decay_applies_score_floor():
+    config = RecencyDecayConfig(score_floor=0.05)
+    # Very old atom; raw decay would drop near zero. Floor catches it.
+    mem = _mk_memory(
+        memory_id="m1", score=1.0, topology="fleet_keis", age_seconds=365 * SECONDS_PER_DAY
+    )
+    out = decay_scored_memories([mem], config=config, now=_NOW)
+    assert out[0].decay_applied
+    assert out[0].score == 0.05
+
+
+def test_decay_parses_iso_8601_created_at():
+    config = RecencyDecayConfig()
+    mem = {
+        "id": "m1",
+        "score": 1.0,
+        "topology": "fleet_keis",
+        "tags": [],
+        "created_at": "2025-01-01T00:00:00Z",
+    }
+    # now > created_at so age is positive; decay should apply.
+    out = decay_scored_memories([mem], config=config, now=_NOW)
+    assert out[0].decay_applied
+    assert out[0].score < 1.0
+
+
+# ============== Negative tests for decay_scored_memories ==============
+
+
+def test_decay_rejects_non_dict_entry():
+    config = RecencyDecayConfig()
+    with pytest.raises(ValueError, match="must be dict"):
+        decay_scored_memories(["not-a-dict"], config=config, now=_NOW)  # type: ignore[list-item]
+
+
+def test_decay_rejects_missing_id():
+    config = RecencyDecayConfig()
+    with pytest.raises(ValueError, match="missing id"):
+        decay_scored_memories(
+            [{"score": 1.0, "topology": "fleet_keis", "tags": [], "created_at": _NOW}],
+            config=config,
+            now=_NOW,
+        )
+
+
+def test_decay_rejects_missing_score():
+    config = RecencyDecayConfig()
+    with pytest.raises(ValueError, match="missing score"):
+        decay_scored_memories(
+            [{"id": "m1", "topology": "fleet_keis", "tags": [], "created_at": _NOW}],
+            config=config,
+            now=_NOW,
+        )
+
+
+def test_decay_rejects_missing_topology():
+    config = RecencyDecayConfig()
+    with pytest.raises(ValueError, match="missing topology"):
+        decay_scored_memories(
+            [{"id": "m1", "score": 1.0, "tags": [], "created_at": _NOW}],
+            config=config,
+            now=_NOW,
+        )
+
+
+def test_decay_rejects_unparseable_tags_type():
+    config = RecencyDecayConfig()
+    with pytest.raises(ValueError, match="tags must be"):
+        decay_scored_memories(
+            [
+                {
+                    "id": "m1",
+                    "score": 1.0,
+                    "topology": "fleet_keis",
+                    "tags": 42,  # not str/list/tuple/set
+                    "created_at": _NOW,
+                }
+            ],
+            config=config,
+            now=_NOW,
+        )
+
+
+def test_decay_rejects_zero_half_life_in_config():
+    config = RecencyDecayConfig(half_lives={"fleet_keis": 0.0})
+    mem = _mk_memory(memory_id="m1", score=1.0, topology="fleet_keis", age_seconds=SECONDS_PER_DAY)
+    with pytest.raises(ValueError, match="must be positive days"):
+        decay_scored_memories([mem], config=config, now=_NOW)
+
+
+# ============== Canonical-tag bypass ==============
+
+
+def test_canonical_tag_exempts_memory_from_decay():
+    config = RecencyDecayConfig()
+    mem = _mk_memory(
+        memory_id="ratified-fact",
+        score=1.0,
+        topology="fleet_decisions",
+        age_seconds=4 * 365 * SECONDS_PER_DAY,  # 4 years
+        tags=["canonical"],
+    )
+    out = decay_scored_memories([mem], config=config, now=_NOW)
+    assert not out[0].decay_applied
+    assert out[0].exempt_reason == "canonical"
+    assert out[0].score == 1.0  # original, unchanged
+
+
+def test_ceo_ratified_tag_also_exempts():
+    config = RecencyDecayConfig()
+    mem = _mk_memory(
+        memory_id="dave-ratified",
+        score=0.9,
+        topology="fleet_decisions",
+        age_seconds=365 * SECONDS_PER_DAY,
+        tags=["ceo_ratified"],
+    )
+    out = decay_scored_memories([mem], config=config, now=_NOW)
+    assert not out[0].decay_applied
+    assert out[0].score == 0.9
+
+
+def test_governance_locked_tag_also_exempts():
+    config = RecencyDecayConfig()
+    mem = _mk_memory(
+        memory_id="g1",
+        score=0.8,
+        topology="fleet_decisions",
+        age_seconds=365 * SECONDS_PER_DAY,
+        tags=["governance_locked"],
+    )
+    out = decay_scored_memories([mem], config=config, now=_NOW)
+    assert not out[0].decay_applied
+    assert out[0].score == 0.8
+
+
+def test_exempt_tags_configurable_per_deploy():
+    # Custom exempt set replaces defaults entirely.
+    config = RecencyDecayConfig(exempt_tags=frozenset({"my_canonical"}))
+    mem = _mk_memory(
+        memory_id="m1",
+        score=1.0,
+        topology="fleet_keis",
+        age_seconds=7 * SECONDS_PER_DAY,
+        tags=["canonical"],  # would exempt under defaults; not under custom
+    )
+    out = decay_scored_memories([mem], config=config, now=_NOW)
+    assert out[0].decay_applied  # default 'canonical' no longer exempt
+
+
+# ============== rerank_by_decayed_score ==============
+
+
+def test_rerank_orders_by_decayed_score_descending():
+    items = [
+        ScoredMemory(
+            memory_id="a",
+            score=0.4,
+            original_score=0.4,
+            age_seconds=0,
+            topology="x",
+            decay_applied=False,
+        ),
+        ScoredMemory(
+            memory_id="b",
+            score=0.9,
+            original_score=0.9,
+            age_seconds=0,
+            topology="x",
+            decay_applied=False,
+        ),
+        ScoredMemory(
+            memory_id="c",
+            score=0.6,
+            original_score=0.6,
+            age_seconds=0,
+            topology="x",
+            decay_applied=False,
+        ),
+    ]
+    out = rerank_by_decayed_score(items)
+    assert [m.memory_id for m in out] == ["b", "c", "a"]
+
+
+def test_rerank_demonstrates_recency_flip():
+    """Old high-similarity loses to slightly-less-similar fresh.
+
+    Acceptance test for the cutover-gate requirement: at equal-ish similarity,
+    newer must win — exactly the failure mode 3rpe fixes.
+    """
+    config = RecencyDecayConfig(half_lives={"fleet_keis": 7.0}, default_half_life_days=30.0)
+    old_high = _mk_memory(
+        memory_id="old-high",
+        score=0.95,
+        topology="fleet_keis",
+        age_seconds=21 * SECONDS_PER_DAY,  # 3 half-lives -> 0.125x
+    )
+    fresh_lower = _mk_memory(
+        memory_id="fresh-lower", score=0.6, topology="fleet_keis", age_seconds=0
+    )
+    decayed = decay_scored_memories([old_high, fresh_lower], config=config, now=_NOW)
+    ranked = rerank_by_decayed_score(decayed)
+    # Fresh wins despite originally being lower-similarity.
+    assert ranked[0].memory_id == "fresh-lower"
+    assert ranked[1].memory_id == "old-high"
+
+
+def test_rerank_preserves_canonical_bypass_at_high_age():
+    """A canonical 4-year-old memory must still beat a fresh low-similarity
+    chatter — proves the bypass + ranking interaction."""
+    config = RecencyDecayConfig()
+    canonical_old = _mk_memory(
+        memory_id="ratified",
+        score=0.95,
+        topology="fleet_decisions",
+        age_seconds=4 * 365 * SECONDS_PER_DAY,
+        tags=["canonical"],
+    )
+    fresh_chatter = _mk_memory(
+        memory_id="chatter", score=0.30, topology="fleet_keis", age_seconds=0
+    )
+    decayed = decay_scored_memories([canonical_old, fresh_chatter], config=config, now=_NOW)
+    ranked = rerank_by_decayed_score(decayed)
+    assert ranked[0].memory_id == "ratified"
+    assert ranked[0].score == 0.95
+
+
+# ============== Module-level constants sanity ==============
+
+
+def test_default_half_lives_covers_known_topologies():
+    # Regression guard: if the canonical bank list grows, the test fails so
+    # someone has to consciously pick a half-life rather than silently
+    # defaulting.
+    required = {"fleet_keis", "fleet_decisions", "fleet_codebase", "fleet_discoveries"}
+    missing = required - DEFAULT_HALF_LIVES.keys()
+    assert not missing, f"DEFAULT_HALF_LIVES missing topologies: {missing}"
+
+
+def test_default_exempt_tags_contains_canonical_and_ceo_ratified():
+    assert "canonical" in DEFAULT_EXEMPT_TAGS
+    assert "ceo_ratified" in DEFAULT_EXEMPT_TAGS


### PR DESCRIPTION
## Summary

**Wave 2 CUTOVER GATE** (Dave ratify 2026-05-27, `Agency_OS-3rpe` P0). Exponential decay on similarity score by atom age, with half-life keyed off topology and ceo-ratified / canonical-tagged atoms bypassing decay entirely. Solves the named failure mode: recency must not bury a 4-year-old ratified architecture fact under last week's tool-call chatter, but at equal-ish similarity, newer must win.

**PR 3 of 4** in the Wave 1+2 Hindsight engineering chain:
1. `Agency_OS-ijf0` — synthesize + trace + complete delete primitives ([#1228](https://github.com/Keiracom/Agency_OS/pull/1228))
2. `Agency_OS-q6ed` — real-time invalidation hooks ([#1230](https://github.com/Keiracom/Agency_OS/pull/1230))
3. **this PR** — recency decay function
4. `Agency_OS-3g9t` — atom granularity spec + CI gate

## Changes

`src/keiracom_system/memory/recency_decay.py` — pure math + small policy layer; no external clients:

- **`apply_recency_decay(score, age_seconds, half_life_seconds)`** — pure scalar `score * 2^(-age / half_life)`. Treats negative age as zero (clock-skew defensive). Rejects non-positive half-life.
- **`RecencyDecayConfig`** — `half_lives` dict (topology -> days), `default_half_life_days` fallback for unknown topologies, `exempt_tags` set for canonical bypass, `score_floor` clamp so high-similarity old memories don't collapse to zero.
- **`DEFAULT_HALF_LIVES`** — V1 baseline (Dave-ratified starting points; tuning is Phase 2 empirical work):
  - `fleet_keis` 7d, `fleet_agent_memories` 7d, `fleet_tool_calls` 3d, `fleet_session_transcripts` 3d
  - `fleet_discoveries` 14d, `fleet_sessions` 14d
  - `fleet_decisions` 30d
  - `fleet_global_governance_patterns` 60d
  - `fleet_strategic_documents` 90d, `fleet_codebase` 90d
- **`DEFAULT_EXEMPT_TAGS`** = `{canonical, ceo_ratified, ratified, governance_locked}` — atoms carrying any of these tags pass through with score unchanged.
- **`decay_scored_memories(memories, config, now=...)`** — applies policy. Fails loud on missing `id` / `score` / `topology` / wrong tags type — silent fallback would mask wiring bugs at the call site.
- **`ScoredMemory`** dataclass preserves `original_score` so observability + explain-this-rank UX can show the decay delta.
- **`rerank_by_decayed_score`** — stable sort descending.

## Acceptance tests demonstrate the named cutover-gate behaviour

- **Recency flip** (`test_rerank_demonstrates_recency_flip`): old high-similarity (0.95 score, age = 3 half-lives -> 0.125x = 0.119) loses to fresh lower-similarity (0.60 score, age 0). Fresh wins despite being originally less similar.
- **Canonical bypass at high age** (`test_rerank_preserves_canonical_bypass_at_high_age`): 4-year-old `canonical`-tagged atom with score 0.95 still beats fresh chatter at score 0.30.

## Notes — canonical key values (audit-dispatch checklist)

Source: `public.ceo_memory.ceo:cutover_plan_v1` + `public.ceo_memory.ceo:memory_abstraction_layer_v1`.

**`ceo:cutover_plan_v1` — full_retrieval_tier_ratify_2026_05_27_22Z.waves.wave_2_retrieval_core:**
> "hybrid search + cross-encoder reranker + recency decay"

**`ceo:memory_abstraction_layer_v1` — substantive_lock:**
> "mem.topology_tier_keyed" (interpreted here as per-topology half-life tuning)

## Test plan

- [x] 28 tests pass: 6 pure math / 7 decay positive / 5 decay negative / 4 canonical bypass / 3 rerank ordering / 2 constants-table sanity / 1 score-floor
- [x] Pure-math correctness: score halves at exactly age = half_life (`test_apply_recency_decay_halves_score_at_half_life`)
- [x] Per-topology half-life difference verified (`test_decay_respects_per_topology_half_life_difference`)
- [x] All exempt tags tested (`canonical`, `ceo_ratified`, `governance_locked`, custom-replacement)
- [x] Clock-skew defensive case (negative age -> treated as zero)
- [x] `ruff check` clean; `ruff format --check` clean

```
28 passed in 0.13s
```

## Out of scope (intentional)

- **Wiring into `src/retrieval/orchestrator.py` `retrieve_with_outcome`** — the call-site change that applies decay after FlashRank reranking is its own PR (orthogonal scope per `feedback_split_orthogonal_scope`). The signal-attached `ScoredMemory` shape needs a parallel `RetrievedNode` upgrade that touches the agent_query layer — better split.
- **Per-tenant override of `DEFAULT_HALF_LIVES`** — V1 deploys use the module default. Per-tenant override hooks land when tenant-config plumbing is ready.
- **Learned-decay / cohort tuning** — Phase 2 empirical work. Half-life table is config-injected so this lands cleanly later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)