### PR TITLE
[ATLAS] fix(frontend): resolve Vercel build ENOENT on (marketing) route group

### DIFF
--- a/frontend/app/(marketing)/home/page.tsx
+++ b/frontend/app/(marketing)/home/page.tsx
@@ -1,6 +1,12 @@
 /**
- * FILE: app/(marketing)/page.tsx
- * PURPOSE: Keiracom landing page root — hero section + 6 pricing tier cards.
+ * FILE: app/(marketing)/home/page.tsx
+ * PURPOSE: Keiracom landing page (served at /home) — hero section + 6 pricing tier cards.
+ *
+ * ROUTE: Moved out of route-group root to /home to resolve build conflict with
+ * app/page.tsx (current Agency OS landing also at /). Next.js silently picks one
+ * winner but Vercel's manifest post-processor still expects manifest files for
+ * the loser, causing ENOENT page_client-reference-manifest.js failures.
+ * Final URL slug TBD — Dave will decide whether this replaces / or stays at /home.
  *
  * SCAFFOLD STATUS: KEI-119
  * Sub-KEI claimers replace stub copy and add visual styling.


### PR DESCRIPTION
## Summary

- Resolves Vercel production deployment failure:
  `ENOENT: no such file or directory, lstat '/vercel/path0/frontend/.next/server/app/(marketing)/page_client-reference-manifest.js'`
- Root cause: two files both tried to serve `/`. `frontend/app/page.tsx` (Agency OS landing, `"use client"`) and `frontend/app/(marketing)/page.tsx` (KEI-119 Keiracom scaffold, server component + ISR). Next.js route-groups `(name)` add no URL segment, so a `page.tsx` inside one competes with the root `page.tsx`. Next.js 14.2.35 silently picks a winner at build time, but Vercel's post-processor still expects the manifest for the losing page → ENOENT.
- Fix (Option A from dispatch): moved the Keiracom scaffold to `frontend/app/(marketing)/home/page.tsx` so it serves `/home`. Eliminates the duplicate-route conflict. Agency OS landing keeps `/`. Final URL slug for the Keiracom landing is deferred — Dave will decide whether it replaces `/` or stays at `/home`.

Sibling routes `/about`, `/how-it-works`, `/pricing` were already non-conflicting; only the route-group-root `page.tsx` was the problem.

## Files changed

- Renamed: `frontend/app/(marketing)/page.tsx` → `frontend/app/(marketing)/home/page.tsx`
- Updated the file's header comment to reflect new path and capture the route-group conflict reason so the next reader doesn't repeat the same trap.

## Verification

- Listed every `page.tsx` under `frontend/app/` and computed each route ignoring `(group)` segments. Zero duplicate route paths after the fix. (Before the fix, `/` appeared twice.)
- `git grep` for imports of the moved file: no consumers.
- `href="/"` link audit: all 8 hits resolve correctly to `app/page.tsx` (Agency OS landing) — intentional, no breakage.
- Local `next build` not run (deps not installed in this worktree). Vercel preview build is the definitive validation gate; the structural check above shows the conflict is gone.

## Test plan

- [ ] CI green
- [ ] Vercel preview build succeeds (no ENOENT on `page_client-reference-manifest.js`)
- [ ] Vercel production deployment succeeds after merge
- [ ] `/` still serves the Agency OS landing (existing behaviour)
- [ ] `/home` serves the KEI-119 Keiracom scaffold (new behaviour, OK to be stub copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)