### PR TITLE
[MAX] fix(tests): invert 3 stale hook tests to compliance gates (hook-kill directive 2026-05-27)

### DIFF
--- a/tests/scripts/hooks/test_env_schema_validate.py
+++ b/tests/scripts/hooks/test_env_schema_validate.py
@@ -176,13 +176,10 @@ def test_script_syntax_valid() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_hook_registered_first_in_session_start_chain() -> None:
+def test_hooks_absent_per_hook_kill_directive() -> None:
+    # Compliance gate: Dave directive 2026-05-27 killed all Claude Code hooks.
     settings = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text())
-    session_start = settings["hooks"]["SessionStart"]
-    # Find the "*" matcher block — the primary chain.
-    primary = next(b for b in session_start if b.get("matcher") == "*")
-    first_cmd = primary["hooks"][0]["command"]
-    assert "env_schema_validate.sh" in first_cmd, (
-        f"env_schema_validate.sh must be FIRST in the SessionStart * chain so "
-        f"misconfigured env fails fast; got {first_cmd!r}"
+    assert "hooks" not in settings, (
+        "hooks key must be absent from .claude/settings.json per Dave directive 2026-05-27; "
+        f"found hooks: {list(settings.get('hooks', {}).keys())}"
     )

--- a/tests/scripts/test_governance_hooks.py
+++ b/tests/scripts/test_governance_hooks.py
@@ -226,17 +226,15 @@ def test_module_entrypoint_swallows_exceptions():
 # ─── settings.json wiring smoke ────────────────────────────────────────────
 
 
-def test_settings_json_contains_pretooluse_hook():
+def test_hooks_absent_per_hook_kill_directive():
+    # Compliance gate: Dave directive 2026-05-27 killed all Claude Code hooks.
     settings = json.loads(
         (Path(__file__).resolve().parent.parent.parent / ".claude" / "settings.json").read_text()
     )
-    assert "PreToolUse" in settings.get("hooks", {})
-    pre = settings["hooks"]["PreToolUse"]
-    assert any(
-        "governance_hooks.py" in h.get("command", "")
-        for entry in pre
-        for h in entry.get("hooks", [])
-    ), "governance_hooks.py not registered in PreToolUse"
+    assert "hooks" not in settings, (
+        "hooks key must be absent from .claude/settings.json per Dave directive 2026-05-27; "
+        f"found hooks: {list(settings.get('hooks', {}).keys())}"
+    )
 
 
 # ─── security guard surface (defence-in-depth) ─────────────────────────────

--- a/tests/scripts/test_session_end_hook.py
+++ b/tests/scripts/test_session_end_hook.py
@@ -216,17 +216,12 @@ def test_module_entrypoint_swallows_exceptions(monkeypatch):
 # ─── settings.json wiring smoke ────────────────────────────────────────────
 
 
-def test_settings_json_contains_session_end_hook():
+def test_hooks_absent_per_hook_kill_directive():
+    # Compliance gate: Dave directive 2026-05-27 killed all Claude Code hooks.
     settings = json.loads(
         (Path(__file__).resolve().parent.parent.parent / ".claude" / "settings.json").read_text()
     )
-    assert "hooks" in settings
-    assert "SessionEnd" in settings["hooks"]
-    se = settings["hooks"]["SessionEnd"]
-    assert isinstance(se, list) and len(se) >= 1
-    # The first SessionEnd entry references our hook script
-    cmd_block = se[0]
-    assert "hooks" in cmd_block
-    assert any("session_end_hook.py" in h.get("command", "") for h in cmd_block["hooks"]), (
-        "session_end_hook.py not registered in .claude/settings.json"
+    assert "hooks" not in settings, (
+        "hooks key must be absent from .claude/settings.json per Dave directive 2026-05-27; "
+        f"found hooks: {list(settings.get('hooks', {}).keys())}"
     )


### PR DESCRIPTION
## Summary

- Three tests in `test_env_schema_validate.py`, `test_governance_hooks.py`, and `test_session_end_hook.py` asserted that Claude Code hooks **must be registered** in `.claude/settings.json`
- Dave directive 2026-05-27 killed all hooks; Elliot's commit 3b6dfd224 removed the `hooks` key from `.claude/settings.json`
- These tests now fail in CI with `KeyError: 'hooks'` / `AssertionError: assert 'hooks' in settings`

**Fix:** Inverted all three assertions — each now asserts the `hooks` key is **absent**, turning them into compliance gates that will fail if hooks are accidentally re-introduced.

No changes to production code or `.claude/settings.json`.

## Test plan

- [x] `tests/scripts/hooks/test_env_schema_validate.py::test_hooks_absent_per_hook_kill_directive` — PASSED
- [x] `tests/scripts/test_governance_hooks.py::test_hooks_absent_per_hook_kill_directive` — PASSED
- [x] `tests/scripts/test_session_end_hook.py::test_hooks_absent_per_hook_kill_directive` — PASSED
- [x] Full test files (67 tests) — all PASSED, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)