### PR TITLE
[ORION] fix(ci): update hook-assertion tests after Dave hook-kill directive 2026-05-27

### DIFF
--- a/tests/scripts/hooks/test_env_schema_validate.py
+++ b/tests/scripts/hooks/test_env_schema_validate.py
@@ -176,6 +176,11 @@ def test_script_syntax_valid() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(
+    reason="Claude Code hooks removed per Dave directive 2026-05-27 (hook-kill); "
+    ".claude/settings.json no longer carries a 'hooks' key. The env_schema_validate.sh "
+    "script still exists and its behaviour is exercised by the other tests in this file."
+)
 def test_hook_registered_first_in_session_start_chain() -> None:
     settings = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text())
     session_start = settings["hooks"]["SessionStart"]

--- a/tests/scripts/test_governance_hooks.py
+++ b/tests/scripts/test_governance_hooks.py
@@ -226,6 +226,11 @@ def test_module_entrypoint_swallows_exceptions():
 # ─── settings.json wiring smoke ────────────────────────────────────────────
 
 
+@pytest.mark.xfail(
+    reason="Claude Code hooks removed per Dave directive 2026-05-27 (hook-kill); "
+    ".claude/settings.json no longer carries a 'hooks' key. The governance_hooks.py "
+    "module still exists and its behaviour is exercised by the unit tests above."
+)
 def test_settings_json_contains_pretooluse_hook():
     settings = json.loads(
         (Path(__file__).resolve().parent.parent.parent / ".claude" / "settings.json").read_text()

--- a/tests/scripts/test_session_end_hook.py
+++ b/tests/scripts/test_session_end_hook.py
@@ -216,6 +216,11 @@ def test_module_entrypoint_swallows_exceptions(monkeypatch):
 # ─── settings.json wiring smoke ────────────────────────────────────────────
 
 
+@pytest.mark.xfail(
+    reason="Claude Code hooks removed per Dave directive 2026-05-27 (hook-kill); "
+    ".claude/settings.json no longer carries a 'hooks' key. The session_end_hook.py "
+    "module still exists and its behaviour is exercised by the unit tests above."
+)
 def test_settings_json_contains_session_end_hook():
     settings = json.loads(
         (Path(__file__).resolve().parent.parent.parent / ".claude" / "settings.json").read_text()


### PR DESCRIPTION
## Summary

Three settings.json wiring smoke tests asserted the presence of hook entries in `.claude/settings.json`. Dave directive 2026-05-27 removed all Claude Code hooks; the file no longer carries a `hooks` key, so these assertions cannot pass and break Backend Tests on every PR.

Marked each with `@pytest.mark.xfail` referencing the directive:

- `tests/scripts/hooks/test_env_schema_validate.py::test_hook_registered_first_in_session_start_chain`
- `tests/scripts/test_governance_hooks.py::test_settings_json_contains_pretooluse_hook`
- `tests/scripts/test_session_end_hook.py::test_settings_json_contains_session_end_hook`

The underlying scripts (`env_schema_validate.sh`, `governance_hooks.py`, `session_end_hook.py`) still exist and are exercised by the other tests in each file — only the "is this wired into settings.json" smoke is xfailed.

## Test plan

- [x] Run the 3 affected tests in isolation: 3 xfailed ✓
- [x] Run all 3 affected files end-to-end: 64 passed, 3 xfailed in 0.46s ✓
- [ ] CI Backend Tests passes on this PR

## Out of scope

- Production code (no changes)
- `.claude/settings.json` (no changes — Dave's hook-kill directive owns that file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)