### PR TITLE
[SCOUT] fix(ci): update hook-assertion tests after Dave hook-kill directive 2026-05-27

### DIFF
--- a/tests/scripts/hooks/test_env_schema_validate.py
+++ b/tests/scripts/hooks/test_env_schema_validate.py
@@ -172,17 +172,22 @@ def test_script_syntax_valid() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Hook is registered FIRST in the SessionStart chain
+# Hook-kill compliance gate (Dave directive 2026-05-27)
+#
+# All .claude/settings.json hooks were removed (commit 3b6dfd224). This test
+# was originally a wiring-smoke ("env_schema_validate.sh must be FIRST in the
+# SessionStart * chain"); it now flips into a compliance gate that fails if
+# a SessionStart hook is silently re-introduced without re-ratifying the
+# directive. The script itself remains executable and is exercised by the
+# tests above — only its hook registration is forbidden.
 # ---------------------------------------------------------------------------
 
 
-def test_hook_registered_first_in_session_start_chain() -> None:
+def test_session_start_hooks_absent_per_hook_kill_directive() -> None:
     settings = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text())
-    session_start = settings["hooks"]["SessionStart"]
-    # Find the "*" matcher block — the primary chain.
-    primary = next(b for b in session_start if b.get("matcher") == "*")
-    first_cmd = primary["hooks"][0]["command"]
-    assert "env_schema_validate.sh" in first_cmd, (
-        f"env_schema_validate.sh must be FIRST in the SessionStart * chain so "
-        f"misconfigured env fails fast; got {first_cmd!r}"
+    hooks = settings.get("hooks", {})
+    assert "SessionStart" not in hooks, (
+        f"SessionStart hook re-introduced into .claude/settings.json after the "
+        f"2026-05-27 hook-kill directive; got {hooks.get('SessionStart')!r}. "
+        f"Re-ratify with Dave before restoring."
     )

--- a/tests/scripts/test_governance_hooks.py
+++ b/tests/scripts/test_governance_hooks.py
@@ -223,20 +223,25 @@ def test_module_entrypoint_swallows_exceptions():
     assert ei.value.code == 0
 
 
-# ─── settings.json wiring smoke ────────────────────────────────────────────
+# ─── settings.json hook-kill compliance gate (Dave directive 2026-05-27) ───
+#
+# All .claude/settings.json hooks were removed (commit 3b6dfd224). This was a
+# wiring-smoke ("PreToolUse must reference governance_hooks.py"); it now flips
+# into a compliance gate that fails if PreToolUse is silently re-introduced
+# without re-ratifying the directive. The governance_hooks.py module itself
+# remains importable + exercised by the unit tests above.
 
 
-def test_settings_json_contains_pretooluse_hook():
+def test_settings_json_pretooluse_hook_absent_per_hook_kill_directive():
     settings = json.loads(
         (Path(__file__).resolve().parent.parent.parent / ".claude" / "settings.json").read_text()
     )
-    assert "PreToolUse" in settings.get("hooks", {})
-    pre = settings["hooks"]["PreToolUse"]
-    assert any(
-        "governance_hooks.py" in h.get("command", "")
-        for entry in pre
-        for h in entry.get("hooks", [])
-    ), "governance_hooks.py not registered in PreToolUse"
+    hooks = settings.get("hooks", {})
+    assert "PreToolUse" not in hooks, (
+        f"PreToolUse hook re-introduced into .claude/settings.json after the "
+        f"2026-05-27 hook-kill directive; got {hooks.get('PreToolUse')!r}. "
+        f"Re-ratify with Dave before restoring."
+    )
 
 
 # ─── security guard surface (defence-in-depth) ─────────────────────────────

--- a/tests/scripts/test_session_end_hook.py
+++ b/tests/scripts/test_session_end_hook.py
@@ -213,20 +213,22 @@ def test_module_entrypoint_swallows_exceptions(monkeypatch):
     assert ei.value.code == 0
 
 
-# ─── settings.json wiring smoke ────────────────────────────────────────────
+# ─── settings.json hook-kill compliance gate (Dave directive 2026-05-27) ───
+#
+# All .claude/settings.json hooks were removed (commit 3b6dfd224). This was a
+# wiring-smoke ("SessionEnd must reference session_end_hook.py"); it now flips
+# into a compliance gate that fails if SessionEnd is silently re-introduced
+# without re-ratifying the directive. The session_end_hook module itself
+# remains importable + exercised by the unit tests above.
 
 
-def test_settings_json_contains_session_end_hook():
+def test_settings_json_session_end_hook_absent_per_hook_kill_directive():
     settings = json.loads(
         (Path(__file__).resolve().parent.parent.parent / ".claude" / "settings.json").read_text()
     )
-    assert "hooks" in settings
-    assert "SessionEnd" in settings["hooks"]
-    se = settings["hooks"]["SessionEnd"]
-    assert isinstance(se, list) and len(se) >= 1
-    # The first SessionEnd entry references our hook script
-    cmd_block = se[0]
-    assert "hooks" in cmd_block
-    assert any("session_end_hook.py" in h.get("command", "") for h in cmd_block["hooks"]), (
-        "session_end_hook.py not registered in .claude/settings.json"
+    hooks = settings.get("hooks", {})
+    assert "SessionEnd" not in hooks, (
+        f"SessionEnd hook re-introduced into .claude/settings.json after the "
+        f"2026-05-27 hook-kill directive; got {hooks.get('SessionEnd')!r}. "
+        f"Re-ratify with Dave before restoring."
     )


### PR DESCRIPTION
## Summary
- Unblocks **Backend Tests (Pytest)** — 3 stale wiring-smoke tests were asserting `.claude/settings.json` hook structure that was removed in commit `3b6dfd224` (Dave hook-kill directive, 2026-05-27) and failing every backend run.
- **Option A (preferred):** inverted each assertion into a **compliance gate** — they now fail loudly if a hook is silently re-introduced without re-ratifying the directive. Renamed accordingly.
- The underlying hook *scripts* (`env_schema_validate.sh`, `governance_hooks.py`, `session_end_hook.py`) remain importable and are still exercised by the unit tests above each compliance gate — only their **registration** in `.claude/settings.json` is now forbidden.

## Tests touched (3, scope per dispatch)
| Before | After |
|---|---|
| `test_hook_registered_first_in_session_start_chain` | `test_session_start_hooks_absent_per_hook_kill_directive` |
| `test_settings_json_contains_pretooluse_hook` | `test_settings_json_pretooluse_hook_absent_per_hook_kill_directive` |
| `test_settings_json_contains_session_end_hook` | `test_settings_json_session_end_hook_absent_per_hook_kill_directive` |

No production code changed. `.claude/settings.json` untouched.

## Test plan
- [x] All 3 named failing tests now pass against the post-hook-kill `settings.json`
- [x] Full 3-file suite (67 tests) passes locally under CI-equivalent env (`env -u CALLSIGN`)
- [ ] CI: `Backend Tests (Pytest)` green
- [ ] CI: SonarCloud QG green (no new issues — pure test rename + assertion flip)

```
env -u CALLSIGN python -m pytest \
  tests/scripts/hooks/test_env_schema_validate.py \
  tests/scripts/test_governance_hooks.py \
  tests/scripts/test_session_end_hook.py
-> 67 passed in 0.42s
```

## Notes
- 4 sandbox env-leak failures observed locally in `test_governance_hooks.py` (`test_decide_mutating_*`, `test_main_enforce_allows_when_step0_present`) are **pre-existing** and only fire when `CALLSIGN` leaks into the test env via the shell. CI doesn't set `CALLSIGN`, so unaffected. Out of dispatch scope; flagging for a follow-up KEI if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)