### PR TITLE
[NOVA] fix(wave12-gate): 4 blocking gaps from Max re-audit

### DIFF
--- a/infra/keiracom_system/go_sidecar/cmd/sidecar/proxy_test.go
+++ b/infra/keiracom_system/go_sidecar/cmd/sidecar/proxy_test.go
@@ -176,4 +176,45 @@ func TestProxy_UnknownTenant(t *testing.T) {
 	}
 }
 
+// 8. /proxy: malformed JSON body → 400.
+func TestProxy_MalformedJSON400(t *testing.T) {
+	cfg := fixtureCfg("http://unused")
+	v, rl, bm, hc := setupSidecar(cfg)
+	h := proxyHandler(cfg, v, rl, bm, hc)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("POST", "/proxy", strings.NewReader("{not valid json")))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on malformed JSON; got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// 9. /proxy: per-tenant rate limiter returns 429 once bucket empty (mirrors the
+// /validate rate-limit test but exercises the limiter on the proxy hot path).
+func TestProxy_RateLimit429(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"result":"ok"}`))
+	}))
+	defer upstream.Close()
+	cfg := fixtureCfg(upstream.URL)
+	tA := cfg.Tenants["tenant_a"]
+	tA.RateLimit = ratelimit.Spec{RPS: 0.0001, Burst: 1}
+	cfg.Tenants["tenant_a"] = tA
+	v, rl, bm, hc := setupSidecar(cfg)
+	h := proxyHandler(cfg, v, rl, bm, hc)
+	body, _ := json.Marshal(proxyRequest{TenantID: "tenant_a", Tool: "read_file", Server: "search", Body: json.RawMessage(`{"q":"hi"}`)})
+	// first call consumes the single token and forwards to upstream
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("POST", "/proxy", bytes.NewReader(body)))
+	if rr.Code != 200 {
+		t.Fatalf("first call expected 200; got %d body=%s", rr.Code, rr.Body.String())
+	}
+	// second call — bucket empty
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("POST", "/proxy", bytes.NewReader(body)))
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("second call expected 429; got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
 var _ = io.EOF // keep io imported for future helpers

--- a/infra/keiracom_system/go_sidecar/keiracom-go-sidecar.service
+++ b/infra/keiracom_system/go_sidecar/keiracom-go-sidecar.service
@@ -23,6 +23,9 @@ PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=read-only
 ReadWritePaths=/home/elliotbot/clawd/logs
+# ExecStartPre runs scripts/build.sh which writes bin/sidecar under $HOME;
+# ProtectHome=read-only would EROFS that write on a fresh deploy without this.
+ReadWritePaths=%h/clawd/Agency_OS/infra/keiracom_system/go_sidecar/bin
 
 [Install]
 WantedBy=default.target

--- a/infra/keiracom_system/go_sidecar/scripts/install-systemd.sh
+++ b/infra/keiracom_system/go_sidecar/scripts/install-systemd.sh
@@ -13,6 +13,12 @@ USER_UNIT_DIR="${HOME}/.config/systemd/user"
 mkdir -p "${USER_UNIT_DIR}"
 install -m 0644 "${ROOT}/${UNIT}" "${USER_UNIT_DIR}/${UNIT}"
 
+# bin/ is gitignored, so it's absent on a fresh checkout. The unit whitelists
+# it via ReadWritePaths under ProtectHome=read-only; systemd fails to start a
+# unit whose ReadWritePaths target does not exist. Create it before enabling so
+# the ExecStartPre build.sh can write bin/sidecar.
+mkdir -p "${ROOT}/bin"
+
 systemctl --user daemon-reload
 systemctl --user enable "${UNIT}"
 systemctl --user restart "${UNIT}"

--- a/src/keiracom_system/reranker/reranker_client.py
+++ b/src/keiracom_system/reranker/reranker_client.py
@@ -25,7 +25,9 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-DEFAULT_BASE_URL = "http://reranker:80"
+# TEI host port. "http://reranker:80" only resolves inside the Docker network;
+# host-process callers (Hindsight) must reach the published port on localhost.
+DEFAULT_BASE_URL = "http://localhost:8090"
 DEFAULT_TIMEOUT_SECONDS = 30
 EXPECTED_MODEL_ID = "BAAI/bge-reranker-base"
 DEFAULT_TOP_K_RETURNED = 10

--- a/tests/keiracom_system/reranker/test_reranker_client.py
+++ b/tests/keiracom_system/reranker/test_reranker_client.py
@@ -53,6 +53,24 @@ def test_healthy_false_on_transport_error():
     assert c.healthy() is False
 
 
+def test_healthy_unreachable_is_not_silent(caplog):
+    """An unreachable URL must surface a clear error, not fail silently.
+
+    Host-process callers (Hindsight) only see healthy()==False; the warning
+    log is the signal that tells an operator *why* the sidecar looks down.
+    """
+
+    def raises(url: str, t: float) -> _HTTPResponse:
+        raise RuntimeError("connection refused")
+
+    c = RerankerClient(base_url="http://localhost:8090", http_get=raises)
+    with caplog.at_level("WARNING"):
+        assert c.healthy() is False
+    assert any(
+        "connection refused" in r.getMessage() and r.levelname == "WARNING" for r in caplog.records
+    ), "healthy() must log a WARNING explaining the unreachable error, not fail silently"
+
+
 # ---------- info + verify_model_lineage ----------
 
 
@@ -178,7 +196,7 @@ def test_rerank_raises_on_transport_error():
 
 
 def test_default_base_url_constant():
-    assert DEFAULT_BASE_URL == "http://reranker:80"
+    assert DEFAULT_BASE_URL == "http://localhost:8090"
 
 
 def test_default_expected_model_id_constant():


### PR DESCRIPTION
## Summary
Fixes all 4 GATE-HOLD blocking gaps from Max's Wave 1+2 re-audit, in a single PR. Wave 3 is blocked until these clear CI. No logic changes — two Go tests, one systemd sandbox path, one default-URL constant + its test.

| # | Gap | Type | Fix |
|---|-----|------|-----|
| 1 | go_sidecar `/proxy` malformed-JSON → 400 | missing test | `TestProxy_MalformedJSON400` sends invalid JSON, asserts 400 |
| 2 | go_sidecar `/proxy` rate-limit → 429 | missing test | `TestProxy_RateLimit429` empties the per-tenant token bucket on the proxy hot path (not just `/validate`), asserts 429 |
| 3 | go_sidecar systemd `ExecStartPre` EROFS | runtime bug | `ProtectHome=read-only` blocked `build.sh` writing `bin/sidecar` on fresh deploy → add `ReadWritePaths=%h/clawd/Agency_OS/infra/keiracom_system/go_sidecar/bin` |
| 4 | reranker `DEFAULT_BASE_URL` DNS-fails for host callers | runtime bug | `http://reranker:80` only resolves inside Docker; host-process callers (Hindsight) fail silently → switch to `http://localhost:8090` (TEI host port) + test that `healthy()` logs a WARNING (not silent) when unreachable |

## Verification (raw)
```
go test ./...                          → ok (9 proxy/validate tests, incl. 2 new)
pytest tests/keiracom_system/reranker  → 21 passed, 1 skipped
ruff format --check                    → 2 files already formatted
ruff check                             → All checks passed!
```

Note: gap-4 also updates the existing `test_default_base_url_constant` assertion to match the new constant (would otherwise fail).

## Reviewer ask
Max to re-review and lift GATE-HOLD on Wave 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)