### PR TITLE
[SCOUT] feat(dispatcher): Wave 3 spawn-time recall lifecycle hook

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -58,6 +58,7 @@ from src.relay.budget_ceiling import (
     BudgetCeilingGate,
     BudgetDecision,
 )
+from src.retrieval import spawn_recall
 
 logger = logging.getLogger(__name__)
 
@@ -199,6 +200,17 @@ attribution_enabled: bool = os.environ.get(_ATTRIBUTION_ENABLED_ENV, "").lower()
 }
 attribution_default_model: str = os.environ.get("DISPATCHER_ATTRIBUTION_MODEL", "claude-sonnet-4-6")
 
+# When True, /dispatcher/spawn fires a structured Hindsight recall before
+# spawning and injects the top-3 results into the spawn env as a
+# 'Prior context from memory' block (Wave 3 spawn-recall lifecycle hook).
+# Disabled by default in rollout phase 1; recall is fail-open regardless.
+_SPAWN_RECALL_ENABLED_ENV = "DISPATCHER_SPAWN_RECALL_ENABLED"
+spawn_recall_enabled: bool = os.environ.get(_SPAWN_RECALL_ENABLED_ENV, "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
 
 def _spawn_kwargs_source_type(sk: dict) -> str:
     """Derive source_type from spawn_kwargs per PR #1207 SOURCE_TYPES taxonomy."""
@@ -228,6 +240,19 @@ def _spawn_kwargs_task_type(sk: dict, registry_key: str) -> str:
     if str(sk.get("from") or "").lower().strip() == "dave":
         return "chat"
     return "build"
+
+
+def _spawn_kwargs_brief(sk: dict) -> str:
+    """Pull the task brief from spawn_kwargs for spawn-time recall.
+
+    Reads the canonical `brief` field first (per dispatch JSON contract),
+    then common aliases. Empty string when none present.
+    """
+    for field in ("brief", "task_brief", "summary", "text"):
+        value = str(sk.get(field) or "").strip()
+        if value:
+            return value
+    return ""
 
 
 def _emit_attribution(
@@ -538,9 +563,25 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
                 "reason": budget_result.reason,
             }
 
+    # Spawn-time recall lifecycle hook (Wave 3).
+    # Fire a structured Hindsight recall ("what failed before + canonical
+    # approach + superseded decisions") and inject the top-3 results into the
+    # spawn env as a 'Prior context from memory' block. Fail-open: recall
+    # errors never block the spawn (spawn_recall swallows internally), and the
+    # block only lands in `env` — the one context-bearing field forwarded
+    # verbatim to the backend spawn.
+    spawn_kwargs_effective = req.spawn_kwargs
+    if spawn_recall_enabled:
+        sk = req.spawn_kwargs or {}
+        spawn_kwargs_effective = spawn_recall.inject_prior_context(
+            sk,
+            task_type=_spawn_kwargs_task_type(sk, req.key),
+            task_brief=_spawn_kwargs_brief(sk),
+        )
+
     manager = SessionManager(backend=backend)
     try:
-        handle = manager.spawn(**req.spawn_kwargs)
+        handle = manager.spawn(**spawn_kwargs_effective)
     except (TmuxUnavailableError, DockerUnavailableError) as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except (SessionStartupError, ContainerStartupError, TypeError) as exc:

--- a/src/retrieval/spawn_recall.py
+++ b/src/retrieval/spawn_recall.py
@@ -1,0 +1,109 @@
+"""FILE: src/retrieval/spawn_recall.py
+PURPOSE: Wave 3 — spawn-time recall lifecycle hook.
+
+Before an ephemeral agent acts, query Hindsight for prior context about
+tasks like this one — what has failed before, the canonical approach, and
+any superseded decisions — and surface the top-3 results as a
+'Prior context from memory' block injected into the spawn's environment.
+
+Contract:
+  * query_for_spawn(task_type, task_brief) -> list[str]
+        Structured recall. Returns up to TOP_K excerpt strings; [] on any
+        error or empty corpus.
+  * build_prior_context_block(results) -> str
+        Formats results into the injectable block ("" when no results).
+  * inject_prior_context(spawn_kwargs, *, task_type, task_brief) -> dict
+        Returns a copy of spawn_kwargs with the block placed in
+        env[PRIOR_CONTEXT_ENV_KEY]; spawn_kwargs unchanged when nothing to
+        inject.
+
+Fail-open by contract: Hindsight unreachable / any error → no block, the
+spawn proceeds without recall (never blocks). Budget-capped at the KEI-55
+500-token ceiling (enforced by agent_query.query() max_tokens + a hard
+char clamp here).
+
+Out of scope (separate PRs): the cross-encoder reranker wiring, and the
+session-launch wrapper that reads PRIOR_CONTEXT_ENV_KEY and forwards it to
+the agent CLI via --append-system-prompt.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+SPAWN_RECALL_AGENT = "spawn-recall"  # agent label recorded in retrieval_events
+TOP_K = 3
+MAX_TOKENS = 500  # KEI-55 ceiling
+MAX_BLOCK_CHARS = MAX_TOKENS * 4  # ~4 chars/token belt-and-suspenders clamp
+BRIEF_PREFIX_CHARS = 100
+PRIOR_CONTEXT_ENV_KEY = "AGENCY_OS_PRIOR_CONTEXT"
+BLOCK_HEADER = "Prior context from memory (auto-recall — what failed before, canonical approach, superseded decisions):"
+
+
+def _build_query(task_type: str, task_brief: str) -> str:
+    """Structured recall query from task_type + the first 100 chars of brief."""
+    brief_head = (task_brief or "").strip()[:BRIEF_PREFIX_CHARS]
+    return (
+        f'For a {task_type or "build"} task: "{brief_head}" — what has failed '
+        "in tasks like this before, what is the canonical approach, and which "
+        "decisions have been superseded?"
+    )
+
+
+def query_for_spawn(task_type: str, task_brief: str) -> list[str]:
+    """Run a structured Hindsight recall for an about-to-spawn agent.
+
+    Returns up to TOP_K citation strings ('[source · collection] excerpt').
+    Fail-open: returns [] on any error or empty corpus so a recall outage
+    never blocks a spawn.
+    """
+    try:
+        from src.retrieval import agent_query  # lazy: keep dispatcher import light
+
+        result = agent_query.query(
+            _build_query(task_type, task_brief),
+            agent=SPAWN_RECALL_AGENT,
+            max_tokens=MAX_TOKENS,
+            k_returned=TOP_K,
+        )
+    except Exception:  # noqa: BLE001 — recall must never block a spawn
+        logger.debug("spawn recall failed — proceeding without prior context", exc_info=True)
+        return []
+    return [f"[{c.source_id} · {c.collection}] {c.excerpt}" for c in result.citations[:TOP_K]]
+
+
+def build_prior_context_block(results: list[str]) -> str:
+    """Format recall results into the injectable block, clamped to KEI-55."""
+    if not results:
+        return ""
+    lines = [BLOCK_HEADER, *(f"- {r}" for r in results)]
+    return "\n".join(lines)[:MAX_BLOCK_CHARS]
+
+
+def inject_prior_context(
+    spawn_kwargs: dict,
+    *,
+    task_type: str,
+    task_brief: str,
+) -> dict:
+    """Return spawn_kwargs with the recall block injected into env.
+
+    The block lands in env[PRIOR_CONTEXT_ENV_KEY] — the only context-bearing
+    field forwarded verbatim to the backend spawn. Fail-open: returns the
+    original spawn_kwargs unchanged on error or when there is nothing to
+    inject.
+    """
+    try:
+        block = build_prior_context_block(query_for_spawn(task_type, task_brief))
+        if not block:
+            return spawn_kwargs
+        new_kwargs = dict(spawn_kwargs)
+        env = dict(new_kwargs.get("env") or {})
+        env[PRIOR_CONTEXT_ENV_KEY] = block
+        new_kwargs["env"] = env
+        return new_kwargs
+    except Exception:  # noqa: BLE001 — injection must never block a spawn
+        logger.debug("inject_prior_context failed — spawn proceeds unchanged", exc_info=True)
+        return spawn_kwargs

--- a/tests/dispatcher/test_main_spawn_recall_wiring.py
+++ b/tests/dispatcher/test_main_spawn_recall_wiring.py
@@ -1,0 +1,154 @@
+"""Wave 3 — spawn-recall lifecycle hook wiring tests for src.dispatcher.main.
+
+Covers the /dispatcher/spawn integration of src/retrieval/spawn_recall:
+  - flag off  → no recall, spawn env untouched
+  - flag on   → recall fires, top-3 block injected into spawn env
+  - recall failure → fail-open, spawn still succeeds
+
+Mirrors tests/dispatcher/test_main_spawn_attribution_wiring.py: SessionManager
+is mocked so spawn_kwargs is never forwarded to the real backend.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.dispatcher.tmux_lifecycle import SessionHandle
+from src.retrieval import spawn_recall
+
+
+def _mock_supervisors(main_mod: Any) -> None:
+    main_mod._watchdog = MagicMock()
+    main_mod._reaper = MagicMock()
+    main_mod._reaper.health_snapshot.return_value = {
+        "tracked_tmux": 0,
+        "tracked_containers": 0,
+    }
+    main_mod._watchdog.tracked = 0
+
+
+def _make_handle() -> SessionHandle:
+    return SessionHandle(session_name="disp-test", working_dir="/tmp", command="claude")
+
+
+def _spawn(main_mod: Any, spawn_kwargs: dict) -> tuple[Any, Any]:
+    """Drive one /dispatcher/spawn call; return (response, spawn MagicMock)."""
+    _mock_supervisors(main_mod)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        resp = client.post(
+            "/dispatcher/spawn",
+            json={"backend": "tmux", "key": "k1", "spawn_kwargs": spawn_kwargs},
+        )
+        return resp, MockSM.return_value.spawn
+
+
+def _base_env(monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+    import src.dispatcher.main as main_mod
+
+    return main_mod
+
+
+# ─── flag off ────────────────────────────────────────────────────────────────
+
+
+def test_disabled_does_not_inject_prior_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    main_mod = _base_env(monkeypatch)
+    monkeypatch.setattr(main_mod, "spawn_recall_enabled", False)
+    # Guard: query_for_spawn must not even be reached when the flag is off.
+    monkeypatch.setattr(
+        main_mod.spawn_recall,
+        "query_for_spawn",
+        lambda *a, **k: pytest.fail("recall fired while disabled"),
+    )
+
+    resp, spawn = _spawn(main_mod, {"brief": "do thing"})
+
+    assert resp.status_code == 200, resp.text
+    env = spawn.call_args.kwargs.get("env") or {}
+    assert spawn_recall.PRIOR_CONTEXT_ENV_KEY not in env
+
+
+# ─── flag on ─────────────────────────────────────────────────────────────────
+
+
+def test_enabled_injects_top3_block_into_spawn_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    main_mod = _base_env(monkeypatch)
+    monkeypatch.setattr(main_mod, "spawn_recall_enabled", True)
+    monkeypatch.setattr(
+        main_mod.spawn_recall,
+        "query_for_spawn",
+        lambda task_type, task_brief: ["[D-1 · Decisions] canonical approach is X"],
+    )
+
+    resp, spawn = _spawn(main_mod, {"brief": "ship feature", "callsign": "orion"})
+
+    assert resp.status_code == 200, resp.text
+    injected = spawn.call_args.kwargs["env"][spawn_recall.PRIOR_CONTEXT_ENV_KEY]
+    assert spawn_recall.BLOCK_HEADER in injected
+    assert "canonical approach is X" in injected
+
+
+def test_enabled_passes_derived_task_type_and_brief(monkeypatch: pytest.MonkeyPatch) -> None:
+    main_mod = _base_env(monkeypatch)
+    monkeypatch.setattr(main_mod, "spawn_recall_enabled", True)
+    seen: dict[str, str] = {}
+
+    def _capture(task_type: str, task_brief: str) -> list[str]:
+        seen["task_type"] = task_type
+        seen["task_brief"] = task_brief
+        return []
+
+    monkeypatch.setattr(main_mod.spawn_recall, "query_for_spawn", _capture)
+
+    # No spawn_kwargs task_type → derived from REVIEW-PR registry key.
+    _mock_supervisors(main_mod)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        resp = client.post(
+            "/dispatcher/spawn",
+            json={
+                "backend": "tmux",
+                "key": "REVIEW-PR-1238",
+                "spawn_kwargs": {"brief": "check the hook tests"},
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert seen["task_type"] == "pr_review"
+    assert seen["task_brief"] == "check the hook tests"
+
+
+# ─── fail-open ───────────────────────────────────────────────────────────────
+
+
+def test_recall_failure_does_not_block_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    main_mod = _base_env(monkeypatch)
+    monkeypatch.setattr(main_mod, "spawn_recall_enabled", True)
+
+    def _boom(*_a: Any, **_k: Any) -> list[str]:
+        raise RuntimeError("simulated hindsight failure")
+
+    monkeypatch.setattr(main_mod.spawn_recall, "query_for_spawn", _boom)
+
+    resp, spawn = _spawn(main_mod, {"brief": "do thing"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["spawned"] is True
+    # Fail-open: no block injected, spawn proceeded.
+    env = spawn.call_args.kwargs.get("env") or {}
+    assert spawn_recall.PRIOR_CONTEXT_ENV_KEY not in env

--- a/tests/retrieval/test_spawn_recall.py
+++ b/tests/retrieval/test_spawn_recall.py
@@ -1,0 +1,145 @@
+"""Unit tests for src/retrieval/spawn_recall — Wave 3 spawn-time recall hook.
+
+Mocks agent_query.query so tests run without Hindsight / Weaviate. Locks
+the contract: structured query build, top-3 truncation, fail-open on any
+error, block formatting + KEI-55 char clamp, and env injection semantics.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.retrieval import agent_query, spawn_recall
+
+
+def _mk_result(*citations: agent_query.Citation) -> agent_query.QueryResult:
+    return agent_query.QueryResult(
+        answer="x",
+        citations=tuple(citations),
+        elapsed_ms=1,
+        bypass_rerank=True,
+    )
+
+
+def _cit(
+    source_id: str, *, collection: str = "Decisions", excerpt: str = "ex"
+) -> agent_query.Citation:
+    return agent_query.Citation(
+        source_id=source_id,
+        collection=collection,
+        score=0.9,
+        excerpt=excerpt,
+    )
+
+
+# ─── _build_query ──────────────────────────────────────────────────────────
+
+
+def test_build_query_includes_task_type_and_brief_head():
+    q = spawn_recall._build_query("pr_review", "Review PR #1238 for hook compliance")
+    assert "pr_review" in q
+    assert "Review PR #1238" in q
+    assert "failed" in q and "canonical" in q and "superseded" in q
+
+
+def test_build_query_truncates_brief_to_100_chars():
+    long_brief = "A" * 250
+    q = spawn_recall._build_query("build", long_brief)
+    assert "A" * 100 in q
+    assert "A" * 101 not in q
+
+
+def test_build_query_defaults_blank_task_type_to_build():
+    assert "For a build task" in spawn_recall._build_query("", "do thing")
+
+
+# ─── query_for_spawn ─────────────────────────────────────────────────────────
+
+
+def test_query_for_spawn_returns_formatted_citations():
+    res = _mk_result(_cit("D-1", collection="Decisions", excerpt="canonical X"))
+    with patch("src.retrieval.agent_query.query", return_value=res):
+        out = spawn_recall.query_for_spawn("build", "ship feature")
+    assert out == ["[D-1 · Decisions] canonical X"]
+
+
+def test_query_for_spawn_caps_at_top_k():
+    cits = [_cit(f"D-{i}") for i in range(10)]
+    with patch("src.retrieval.agent_query.query", return_value=_mk_result(*cits)):
+        out = spawn_recall.query_for_spawn("build", "brief")
+    assert len(out) == spawn_recall.TOP_K == 3
+
+
+def test_query_for_spawn_empty_citations_returns_empty():
+    with patch("src.retrieval.agent_query.query", return_value=_mk_result()):
+        assert spawn_recall.query_for_spawn("build", "brief") == []
+
+
+def test_query_for_spawn_fails_open_on_exception():
+    with patch("src.retrieval.agent_query.query", side_effect=RuntimeError("hindsight down")):
+        assert spawn_recall.query_for_spawn("build", "brief") == []
+
+
+def test_query_for_spawn_passes_budget_and_agent_label():
+    res = _mk_result(_cit("D-1"))
+    with patch("src.retrieval.agent_query.query", return_value=res) as mq:
+        spawn_recall.query_for_spawn("deliberation", "decide arch")
+    _, kwargs = mq.call_args
+    assert kwargs["agent"] == spawn_recall.SPAWN_RECALL_AGENT
+    assert kwargs["max_tokens"] == spawn_recall.MAX_TOKENS == 500
+    assert kwargs["k_returned"] == spawn_recall.TOP_K
+
+
+# ─── build_prior_context_block ───────────────────────────────────────────────
+
+
+def test_block_empty_for_no_results():
+    assert spawn_recall.build_prior_context_block([]) == ""
+
+
+def test_block_has_header_and_bullets():
+    block = spawn_recall.build_prior_context_block(["[D-1 · Decisions] a", "[D-2 · Keis] b"])
+    assert block.startswith(spawn_recall.BLOCK_HEADER)
+    assert "- [D-1 · Decisions] a" in block
+    assert "- [D-2 · Keis] b" in block
+
+
+def test_block_clamped_to_max_chars():
+    big = ["X" * 5000]
+    block = spawn_recall.build_prior_context_block(big)
+    assert len(block) <= spawn_recall.MAX_BLOCK_CHARS
+
+
+# ─── inject_prior_context ────────────────────────────────────────────────────
+
+
+def test_inject_adds_env_key_when_results_present():
+    with patch.object(spawn_recall, "query_for_spawn", return_value=["[D-1 · Decisions] x"]):
+        out = spawn_recall.inject_prior_context({}, task_type="build", task_brief="b")
+    assert spawn_recall.PRIOR_CONTEXT_ENV_KEY in out["env"]
+    assert "[D-1 · Decisions] x" in out["env"][spawn_recall.PRIOR_CONTEXT_ENV_KEY]
+
+
+def test_inject_preserves_existing_env_and_other_kwargs():
+    base = {"command": "claude", "env": {"EXISTING": "1"}}
+    with patch.object(spawn_recall, "query_for_spawn", return_value=["[D-1 · Decisions] x"]):
+        out = spawn_recall.inject_prior_context(base, task_type="build", task_brief="b")
+    assert out["command"] == "claude"
+    assert out["env"]["EXISTING"] == "1"
+    assert spawn_recall.PRIOR_CONTEXT_ENV_KEY in out["env"]
+    # original dict not mutated (copy semantics)
+    assert spawn_recall.PRIOR_CONTEXT_ENV_KEY not in base["env"]
+
+
+def test_inject_unchanged_when_no_results():
+    base = {"command": "claude"}
+    with patch.object(spawn_recall, "query_for_spawn", return_value=[]):
+        out = spawn_recall.inject_prior_context(base, task_type="build", task_brief="b")
+    assert out == base
+
+
+def test_inject_fails_open_on_exception():
+    base = {"command": "claude"}
+    with patch.object(spawn_recall, "query_for_spawn", side_effect=RuntimeError("boom")):
+        out = spawn_recall.inject_prior_context(base, task_type="build", task_brief="b")
+    assert out == base


### PR DESCRIPTION
## Summary
Before an ephemeral agent acts, `/dispatcher/spawn` now fires a **structured Hindsight recall** — *"what has failed in tasks like this before, the canonical approach, and which decisions have been superseded"* — and injects the top-3 results into the spawn's environment as a **`Prior context from memory`** block.

## What changed
**New module `src/retrieval/spawn_recall.py`:**
- `query_for_spawn(task_type, task_brief) -> list[str]` — builds a structured query from `task_type` + first 100 chars of brief, calls `agent_query.query` (the Hindsight-backed recall entry), returns up to top-3 citation strings.
- `build_prior_context_block(results) -> str` — formats the injectable block.
- `inject_prior_context(spawn_kwargs, *, task_type, task_brief) -> dict` — places the block in `env["AGENCY_OS_PRIOR_CONTEXT"]`.

**Wiring (`src/dispatcher/main.py`):**
- Gated behind `DISPATCHER_SPAWN_RECALL_ENABLED` (default **off**, rollout phase 1), mirroring the existing `attribution_enabled` pattern.
- `task_type` reuses `_spawn_kwargs_task_type`; brief via new `_spawn_kwargs_brief`.
- Injection runs before `manager.spawn()` via a local effective-kwargs var so downstream attribution / bounded-spawn still read the original request.

## Design note — injection seam
`spawn_kwargs` is forwarded **verbatim** to `tmux_lifecycle.spawn_session`, which has a fixed keyword-only signature (`session_name, working_dir, command, env, ready_marker`). A novel top-level key would `TypeError` in production. `env` is the one context-bearing field forwarded to the backend, so the block lands there — backend-agnostic and shell-injection-free (tmux passes `-e KEY=VAL` as argv, no shell).

## Contract honoured
- **Fail-open:** Hindsight unreachable / any error → no block, spawn proceeds. Swallowed at both `query_for_spawn` and `inject_prior_context`.
- **Budget-capped:** `agent_query` `max_tokens=500` (KEI-55) + hard 2000-char clamp.

## Out of scope (separate PRs, per dispatch)
- Cross-encoder reranker wiring.
- The session-launch wrapper that reads `AGENCY_OS_PRIOR_CONTEXT` and forwards it to the agent CLI via `--append-system-prompt` (this PR delivers the block to the spawn env; the consumer is the natural follow-up).

## Test plan
- [x] 19 new tests (15 unit + 4 wiring) pass
- [x] `tests/dispatcher/` + `tests/retrieval/` → **378 passed**, no regressions
- [x] `ruff format --check` + `ruff check` clean
- [ ] CI: Backend Tests (Pytest) green
- [ ] CI: SonarCloud QG green

```
env -u CALLSIGN python -m pytest \
  tests/retrieval/test_spawn_recall.py \
  tests/dispatcher/test_main_spawn_recall_wiring.py
-> 19 passed in 0.51s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)