### PR TITLE
[ATLAS] feat(memory): validate Hindsight hybrid recall empirically (Agency_OS-stz8)

### DIFF
--- a/docs/wave2/stz8_hybrid_recall_validation.md
+++ b/docs/wave2/stz8_hybrid_recall_validation.md
@@ -1,0 +1,82 @@
+# Agency_OS-stz8 — Hybrid Recall Validation (Path 1)
+
+**Agent:** atlas
+**Dispatched by:** elliot (PATH 1 AUTHORISED, 2026-05-28) after Aiden ARCH-CLEAR
+**KEI:** Agency_OS-stz8 — CUTOVER-GATING — Hybrid search (vector + BM25 + metadata filter) in Hindsight recall (Tier 1 #1)
+**Mandate:** LAW XIV raw-output, verbatim evidence.
+
+---
+
+## Outcome
+
+**The cutover gate is met by the deployed Hindsight service as-is. No `RecallRequest` change, no fork, no upstream PR.**
+
+Hindsight recall on the fleet instance (v0.6.2) is empirically confirmed to be **hybrid** — both a lexical/BM25 leg and a semantic/vector leg are live on the same recall endpoint. The stz8 premise ("replace pure-vector similarity with hybrid") was based on a misread: Hindsight recall was never pure-vector. It is a built-in multi-way hybrid (upstream `vectorize-io/hindsight` #708, "How We Built a 4-Way Hybrid Search System That Actually Runs in Parallel").
+
+## Why the original Option-A scope was infeasible (and abandoned)
+
+The dispatch initially scoped a `hybrid_alpha` field on `RecallRequest`, confined to `keiracom_system/fleet/hindsight/`, wired to "Weaviate's hybrid query". All three premises are false:
+
+1. **Code location.** `RecallRequest` is defined upstream in `vectorize-io/hindsight` → `hindsight-api-slim/hindsight_api/api/http.py`, baked into the `ghcr.io/vectorize-io/hindsight` image. `keiracom_system/fleet/hindsight/` holds only deploy glue (docker-compose, provisioning, smoke wrappers). A change confined there — or to our MAL wrappers — cannot add a request field the vendor API rejects.
+2. **`hybrid_alpha` does not exist.** Upstream code search for `hybrid_alpha` returns 0 results across all versions. The field name was invented.
+3. **No Weaviate.** The deployed API spec has zero `weaviate`/`vectorchord`/`bm25`/`hybrid` references; Hindsight's backend is embedded Postgres + VectorChord. Weaviate is the *legacy* store being migrated away from in Phase A3. The alpha convention quoted (0.0=BM25 / 1.0=vector) is Weaviate's, not Hindsight's.
+
+A genuine per-request alpha knob would require forking Hindsight (Option B) + a custom image — out of scope for a P0 cutover gate, and unnecessary given recall is already hybrid.
+
+## Evidence — deployed service surface
+
+```
+GET http://localhost:8889/version
+{"api_version":"0.6.2","features":{"observations":true,"mcp":true,"worker":true,"bank_config_api":true,"file_upload_api":true}}
+
+RecallRequest params (/openapi.json):
+  query, types, budget, max_tokens, trace, query_timestamp, include, tags, tags_match, tag_groups
+Spec scan: hybrid=False, bm25=False, weaviate=False, vectorchord=False
+```
+
+Latest upstream tag is **v0.7.0** (we run v0.6.2; image is `:latest` + `pull_policy: always`).
+
+## Evidence — empirical hybrid proof
+
+Harness: `scripts/research/hindsight_smoke/validate_hybrid_recall.py`. Method: ingest
+target atoms each carrying ONE rare, semantically-empty exact token (error code,
+function name, decision ID) plus distractor atoms with no such token, then recall.
+
+- **Lexical/BM25 leg:** query = the rare exact token. A token like `ENOENT_PG0_4471X`
+  carries ~zero embedding signal — a pure-vector index cannot reliably surface it.
+  Surfacing it (rank 1) proves a lexical/BM25 index is active.
+- **Semantic/vector leg:** query = a paraphrase sharing NO exact token with the
+  target. Surfacing the target proves a vector index is active.
+
+Both legs on the same bank + same endpoint == hybrid.
+
+```
+=== stz8 hybrid-recall validation against http://localhost:8889 (bank=hybrid_validation) ===
+
+[ingest] targets: {'err-code': True, 'fn-name': True, 'decision-id': True}
+
+--- LEXICAL LEG (BM25): recall by rare exact token ---
+  [error code   ] query='ENOENT_PG0_4471X' -> PASS rank=1 (n=5)
+  [function name] query='release_already_reviewed_claims_zq7' -> PASS rank=1 (n=5)
+  [decision id  ] query='DEC-STZ8-7QJ6' -> PASS rank=1 (n=5)
+
+--- SEMANTIC LEG (vector): recall by paraphrase, no shared token ---
+  [error code   ] 'what failure happened when the database storage ...' -> PASS rank=1 (n=5)
+  [function name] 'which background routine unlocks tasks that were...' -> PASS rank=2 (n=5)
+  [decision id  ] 'what was decided about proving blended search in...' -> PASS rank=1 (n=5)
+
+=== VERDICT ===
+  lexical (BM25) leg:   3/3 exact tokens surfaced at rank 1
+  semantic (vector) leg: 3/3 paraphrases surfaced the target
+  HYBRID CONFIRMED: True
+```
+
+Also confirmed: the rare tokens survive Hindsight's LLM consolidation verbatim
+(consolidated fact text retained `ENOENT_PG0_4471X` exactly), and `async:False`
+ingest is synchronous with no measurable recall lag.
+
+## Follow-ups (not blocking stz8 closure)
+
+- **Version pin.** The compose file uses `image: ...:latest` + `pull_policy: always`, so a restart silently adopts v0.7.0. For reproducibility, pinning to an explicit tag is worth a separate infra decision (own KEI). Not changed here so this validation's evidence stays tied to the version it was run against (v0.6.2).
+- **Metadata pre-filter leg.** stz8's title also mentions a structured metadata pre-filter. `RecallRequest` already supports `tags` + `tags_match` (+ `tag_groups`); the existing `run_recall_tests.py` exercises tag filtering. Hybrid + tag pre-filter together cover the gate's three named components.
+- **Cold-bank first-write race.** The first write to a freshly-created bank can 500/timeout; the harness absorbs this with a warm-up write + one ingest retry. Worth noting for any production ingest path against a new bank.

--- a/scripts/research/hindsight_smoke/validate_hybrid_recall.py
+++ b/scripts/research/hindsight_smoke/validate_hybrid_recall.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""validate_hybrid_recall.py — empirical proof that Hindsight recall is hybrid.
+
+Agency_OS-stz8 (CUTOVER-GATING — hybrid vector+BM25 atom retrieval). The stz8
+premise was "replace pure-vector similarity with hybrid". Empirical finding
+(Atlas 2026-05-28): Hindsight recall is ALREADY a multi-way hybrid (upstream
+vectorize-io/hindsight #708) — there is no per-request alpha knob in any version
+and no Weaviate path (backend is embedded Postgres + VectorChord). So the gate
+is satisfiable by VALIDATION, not by a RecallRequest schema change or a fork.
+
+This harness proves the two legs of hybrid independently:
+
+  LEXICAL LEG (BM25): ingest atoms carrying rare, semantically-empty exact tokens
+  (error code, function name, decision ID) alongside distractor atoms with no
+  such token, then recall BY the exact token. A random token like
+  "ENOENT_PG0_4471X" has ~zero embedding signal — a pure-vector index could not
+  reliably surface it. If it surfaces (ideally rank 1), BM25/lexical is active.
+
+  SEMANTIC LEG (vector): recall with a paraphrase that shares NO exact token with
+  the target atom. If the right atom surfaces, the vector leg is active.
+
+Both legs passing on the SAME bank with the SAME recall endpoint == hybrid.
+
+Run: python3 scripts/research/hindsight_smoke/validate_hybrid_recall.py
+Targets the fleet instance (port 8889), bank "hybrid_validation". Re-runnable:
+re-ingesting the same atoms is idempotent for the rank-1 assertion.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import post  # noqa: E402
+
+FLEET_BASE = "http://localhost:8889"
+BANK = "hybrid_validation"
+
+# Each target atom embeds ONE rare exact token in otherwise-generic prose.
+# The token is the kind of atomised terminology the cutover gate cares about:
+# error codes, function names, decision IDs — content pure-vector tends to miss.
+TARGETS = [
+    {
+        "id": "err-code",
+        "token": "ENOENT_PG0_4471X",
+        "kind": "error code",
+        "content": "During the fleet deploy the consolidation worker raised error "
+        "ENOENT_PG0_4471X after the volume mount failed at startup.",
+        # Paraphrase shares NO exact token with the atom — exercises the vector leg.
+        "semantic_query": "what failure happened when the database storage mount "
+        "broke during rollout?",
+    },
+    {
+        "id": "fn-name",
+        "token": "release_already_reviewed_claims_zq7",
+        "kind": "function name",
+        "content": "The fleet supervisor sweeper release_already_reviewed_claims_zq7 "
+        "frees claims that were reviewed but never closed.",
+        "semantic_query": "which background routine unlocks tasks that were checked but left open?",
+    },
+    {
+        "id": "decision-id",
+        "token": "DEC-STZ8-7QJ6",
+        "kind": "decision id",
+        "content": "Decision DEC-STZ8-7QJ6 ratified that hybrid recall is validated "
+        "empirically rather than by adding a request parameter.",
+        "semantic_query": "what was decided about proving blended search instead of "
+        "a new query field?",
+    },
+]
+
+# Distractors: same domain prose, NONE of the rare tokens. If an exact-token query
+# returns a distractor above its target, lexical ranking is weak.
+DISTRACTORS = [
+    "The deploy pipeline restarted the container after a routine image pull.",
+    "A scheduled job archived old review threads at the end of the week.",
+    "The team agreed to document the runbook before the next migration window.",
+    "Monitoring reported nominal memory usage across the fleet host overnight.",
+]
+
+
+def _ingest(content: str, ext_id: str, tags: list[str]) -> bool:
+    # One retry: the FIRST write to a cold bank can 500/timeout while the bank
+    # is being created. Retrying absorbs that race so a flake never reads as a
+    # recall failure.
+    item = {"content": content, "tags": tags, "metadata": {"external_id": ext_id}}
+    for _attempt in range(2):
+        status, _ = post(
+            f"/v1/default/banks/{BANK}/memories",
+            {"items": [item], "async": False},
+            base=FLEET_BASE,
+        )
+        if 200 <= status < 300:
+            return True
+        time.sleep(1)
+    return False
+
+
+def _recall(query: str, top_k: int = 5) -> list[dict]:
+    status, resp = post(
+        f"/v1/default/banks/{BANK}/memories/recall",
+        {"query": query, "max_tokens": 1500},
+        base=FLEET_BASE,
+    )
+    if status < 200 or status >= 300 or not isinstance(resp, dict):
+        return []
+    return (resp.get("results") or resp.get("memories") or [])[:top_k]
+
+
+def _warm_bank() -> None:
+    """Absorb the cold-bank first-write race with a throwaway write."""
+    _ingest("bank warm-up atom — ignore.", "warmup", ["hybrid_val", "warmup"])
+    time.sleep(1)
+
+
+def _rank_of(token: str, results: list[dict]) -> int:
+    """1-based rank of the first result containing token; 0 if absent."""
+    for i, r in enumerate(results, start=1):
+        text = (r.get("text") or r.get("content") or "").upper()
+        if token.upper() in text:
+            return i
+    return 0
+
+
+def main() -> int:
+    print(f"=== stz8 hybrid-recall validation against {FLEET_BASE} (bank={BANK}) ===\n")
+
+    _warm_bank()
+    ing = {t["id"]: _ingest(t["content"], t["id"], ["hybrid_val", "target"]) for t in TARGETS}
+    for i, d in enumerate(DISTRACTORS):
+        _ingest(d, f"distractor-{i}", ["hybrid_val", "distractor"])
+    print(f"[ingest] targets: {ing}")
+    if not all(ing.values()):
+        print("[ingest] ABORT — a target atom failed to ingest; cannot validate recall.")
+        return 2
+    print()
+
+    # Small settle window; the probe showed no lag, retry guards consolidation jitter.
+    time.sleep(2)
+
+    lexical_pass = 0
+    semantic_pass = 0
+
+    print("--- LEXICAL LEG (BM25): recall by rare exact token ---")
+    for t in TARGETS:
+        results = _recall(t["token"])
+        rank = _rank_of(t["token"], results)
+        ok = rank == 1
+        lexical_pass += ok
+        verdict = "PASS rank=1" if ok else (f"PARTIAL rank={rank}" if rank else "FAIL absent")
+        print(f"  [{t['kind']:<13}] query='{t['token']}' -> {verdict} (n={len(results)})")
+
+    print("\n--- SEMANTIC LEG (vector): recall by paraphrase, no shared token ---")
+    for t in TARGETS:
+        results = _recall(t["semantic_query"])
+        rank = _rank_of(t["token"], results)
+        ok = rank > 0
+        semantic_pass += ok
+        verdict = f"PASS rank={rank}" if ok else "FAIL absent"
+        print(
+            f"  [{t['kind']:<13}] '{t['semantic_query'][:48]}...' -> {verdict} (n={len(results)})"
+        )
+
+    print("\n=== VERDICT ===")
+    print(f"  lexical (BM25) leg:   {lexical_pass}/{len(TARGETS)} exact tokens surfaced at rank 1")
+    print(
+        f"  semantic (vector) leg: {semantic_pass}/{len(TARGETS)} paraphrases surfaced the target"
+    )
+    hybrid = lexical_pass == len(TARGETS) and semantic_pass >= 1
+    print(f"  HYBRID CONFIRMED: {hybrid}")
+    print(
+        "  Interpretation: rare semantically-empty tokens surfacing at rank 1 can ONLY "
+        "come from a lexical/BM25 index; paraphrase recall can only come from a vector "
+        "index. Both on one endpoint == hybrid recall is live on the deployed instance."
+    )
+    return 0 if hybrid else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the CUTOVER-GATING requirement **Agency_OS-stz8** (hybrid vector + BM25 atom retrieval in Hindsight recall) via **empirical validation** — no `RecallRequest` change, no fork, no upstream PR.

**Key finding:** Hindsight recall was never pure-vector. It is a built-in multi-way hybrid (upstream `vectorize-io/hindsight` #708). The original Option-A scope (`hybrid_alpha` field on `RecallRequest`, confined to `keiracom_system/fleet/hindsight/`, wired to "Weaviate") was infeasible on three counts:
1. `RecallRequest` is upstream vendor code (`hindsight-api-slim/hindsight_api/api/http.py`), baked into the image — not in our repo. The fleet dir is deploy glue only.
2. `hybrid_alpha` does not exist in any Hindsight version (upstream code search = 0 hits).
3. Hindsight has no Weaviate path — backend is embedded Postgres + VectorChord. Weaviate is the legacy store being migrated away from in Phase A3.

So the gate is met by proving the existing hybrid works, not by changing the schema.

## What this PR adds

- `scripts/research/hindsight_smoke/validate_hybrid_recall.py` — falsifiable harness proving both legs independently on the deployed fleet instance (v0.6.2).
- `docs/wave2/stz8_hybrid_recall_validation.md` — findings + verbatim evidence.

## Method

- **Lexical/BM25 leg:** ingest atoms carrying rare, semantically-empty exact tokens (error code / function name / decision ID) + distractors, then recall *by the exact token*. A token like `ENOENT_PG0_4471X` has ~zero embedding signal — surfacing it (rank 1) can only come from a lexical/BM25 index.
- **Semantic/vector leg:** recall by a paraphrase sharing no exact token with the target. Surfacing the target can only come from a vector index.
- Both legs on the same bank + same endpoint == hybrid.

## Verbatim result

```
--- LEXICAL LEG (BM25): recall by rare exact token ---
  [error code   ] query='ENOENT_PG0_4471X' -> PASS rank=1 (n=5)
  [function name] query='release_already_reviewed_claims_zq7' -> PASS rank=1 (n=5)
  [decision id  ] query='DEC-STZ8-7QJ6' -> PASS rank=1 (n=5)
--- SEMANTIC LEG (vector): recall by paraphrase, no shared token ---
  [error code   ] '...database storage mount broke...'   -> PASS rank=1 (n=5)
  [function name] '...routine unlocks tasks checked...'  -> PASS rank=2 (n=5)
  [decision id  ] '...blended search instead of field...'-> PASS rank=1 (n=5)
=== VERDICT ===
  lexical (BM25) leg:    3/3 exact tokens surfaced at rank 1
  semantic (vector) leg: 3/3 paraphrases surfaced the target
  HYBRID CONFIRMED: True
```

## Follow-ups (not blocking)

- Compose uses `:latest` + `pull_policy: always` → a restart silently adopts v0.7.0. Explicit version pin is worth a separate infra decision (own KEI). Not changed here so the evidence stays tied to v0.6.2.
- stz8's metadata pre-filter component is already covered by existing `tags`/`tags_match` support (exercised in `run_recall_tests.py`).

## Test plan

- [x] `ruff check` + `ruff format --check` pass on the new script
- [x] Harness runs green against deployed fleet Hindsight (EXIT=0, HYBRID CONFIRMED: True), reproducible
- [ ] Deliberator review (2-of-3 NATS concur per orchestrator-merge pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)