### PR TITLE
[SCOUT] feat(retrieval): Wave 4 HyDE query expansion (feature-flagged)

### DIFF
--- a/src/retrieval/agent_query.py
+++ b/src/retrieval/agent_query.py
@@ -18,7 +18,7 @@ import time
 from dataclasses import dataclass
 from typing import Literal
 
-from src.retrieval import orchestrator
+from src.retrieval import hyde, orchestrator
 
 logger = logging.getLogger(__name__)
 
@@ -214,8 +214,13 @@ def query(
         `QueryResult` with answer + citations + elapsed_ms + bypass flag.
     """
     started = time.monotonic()
+    # HyDE query expansion (Wave 4, RETRIEVAL_HYDE_ENABLED, default off).
+    # `expand_query` fuses the raw query with a hypothetical answer document
+    # so retrieval searches the answer space; fail-open to the raw query.
+    # Observability + answer synthesis below stay on the ORIGINAL query text.
+    search_text = hyde.expand_query(text)
     outcome = orchestrator.retrieve_with_outcome(
-        text=text,
+        text=search_text,
         collections=collections,
         k_initial=k_initial,
         k_returned=k_returned,

--- a/src/retrieval/hyde.py
+++ b/src/retrieval/hyde.py
@@ -1,0 +1,104 @@
+"""FILE: src/retrieval/hyde.py
+PURPOSE: Wave 4 — HyDE (Hypothetical Document Embeddings) query expansion.
+
+HyDE improves recall by searching with a hypothetical *answer* rather than
+the raw question. We generate a one-paragraph hypothetical document that
+would answer the query, then fuse it with the original query text. That
+fused text is what flows to the retrieval backend.
+
+Embedding-path note: the live read path (orchestrator._hindsight_recall)
+sends QUERY TEXT to Hindsight, which embeds it server-side — the client
+does not compute a search vector. So HyDE here operates at the text level:
+the hypothetical becomes part of the `query` text and is embedded by the
+*same* server-side path as every normal query. This is the faithful HyDE
+realisation for a text-in retrieval backend.
+
+Contract:
+  * generate_hypothetical(query, model='claude-haiku-4-5') -> str
+        One-paragraph hypothetical answer document; "" on any error.
+  * expand_query(query, model=...) -> str
+        The search text: raw query fused with the hypothetical when HyDE is
+        enabled AND generation succeeds; the raw query otherwise.
+
+Feature-flagged: RETRIEVAL_HYDE_ENABLED (default False).
+Fail-open: any generation error → fall back to the original query, so a
+HyDE outage never degrades retrieval below the pre-HyDE baseline.
+
+Cost note: uses the raw sync Anthropic SDK (a single short Haiku call) to
+match the synchronous retrieval entry point. It deliberately does NOT route
+through src.integrations.anthropic.AnthropicClient (async + budget-tracked);
+wiring HyDE through the budget tracker is a follow-up if it ships beyond the
+default-off flag.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+HYDE_ENABLED_ENV = "RETRIEVAL_HYDE_ENABLED"
+DEFAULT_MODEL = "claude-haiku-4-5"
+MAX_TOKENS = 256
+
+_HYDE_PROMPT = (
+    "Write a single concise paragraph that could plausibly answer the question "
+    "below, as if excerpted from an internal engineering document. Write it as a "
+    "confident factual passage — do not hedge, do not say you are unsure, do not "
+    "restate the question. Question: {query}"
+)
+
+
+def hyde_enabled() -> bool:
+    """True when the RETRIEVAL_HYDE_ENABLED flag is set truthy (default off)."""
+    return os.environ.get(HYDE_ENABLED_ENV, "").lower() in {"1", "true", "yes"}
+
+
+def _get_client() -> Any:
+    """Lazily construct a sync Anthropic client (reads ANTHROPIC_API_KEY)."""
+    import anthropic  # lazy: keep retrieval import light + SDK optional
+
+    return anthropic.Anthropic()
+
+
+def generate_hypothetical(query: str, model: str = DEFAULT_MODEL) -> str:
+    """Generate a one-paragraph hypothetical answer document for `query`.
+
+    Returns "" on empty input or any error (fail-open) so callers can fall
+    back to the raw query embedding path.
+    """
+    q = (query or "").strip()
+    if not q:
+        return ""
+    try:
+        resp = _get_client().messages.create(
+            model=model,
+            max_tokens=MAX_TOKENS,
+            messages=[{"role": "user", "content": _HYDE_PROMPT.format(query=q)}],
+        )
+        for block in resp.content or []:
+            text = getattr(block, "text", "")
+            if text:
+                return text.strip()
+        return ""
+    except Exception:  # noqa: BLE001 — HyDE must never break retrieval
+        logger.debug("HyDE generation failed — falling back to raw query", exc_info=True)
+        return ""
+
+
+def expand_query(query: str, model: str = DEFAULT_MODEL) -> str:
+    """Return the text to search with.
+
+    When HyDE is enabled and generation succeeds, returns the raw query fused
+    with the hypothetical document — the original query signal is retained so
+    both ANN recall and downstream rerank stay anchored to what was asked.
+    Returns the raw query unchanged when HyDE is disabled or generation fails.
+    """
+    if not hyde_enabled():
+        return query
+    hypothetical = generate_hypothetical(query, model=model)
+    if not hypothetical:
+        return query
+    return f"{query}\n\n{hypothetical}"

--- a/src/retrieval/hyde.py
+++ b/src/retrieval/hyde.py
@@ -24,11 +24,11 @@ Feature-flagged: RETRIEVAL_HYDE_ENABLED (default False).
 Fail-open: any generation error → fall back to the original query, so a
 HyDE outage never degrades retrieval below the pre-HyDE baseline.
 
-Cost note: uses the raw sync Anthropic SDK (a single short Haiku call) to
-match the synchronous retrieval entry point. It deliberately does NOT route
-through src.integrations.anthropic.AnthropicClient (async + budget-tracked);
-wiring HyDE through the budget tracker is a follow-up if it ships beyond the
-default-off flag.
+Cost note: uses the sync Anthropic SDK (a single short Haiku call) to match
+the synchronous retrieval entry point, but routed through the budget-tracked
+gateway via ANTHROPIC_BASE_URL (Aiden HOLD, PR #1243). When the gateway is
+not configured, generation fails open to the raw query rather than making an
+untracked pay-as-you-go API call the budget-ceiling gate cannot see.
 """
 
 from __future__ import annotations
@@ -56,11 +56,30 @@ def hyde_enabled() -> bool:
     return os.environ.get(HYDE_ENABLED_ENV, "").lower() in {"1", "true", "yes"}
 
 
+ANTHROPIC_BASE_URL_ENV = "ANTHROPIC_BASE_URL"
+
+
 def _get_client() -> Any:
-    """Lazily construct a sync Anthropic client (reads ANTHROPIC_API_KEY)."""
+    """Lazily construct a sync Anthropic client routed through the gateway.
+
+    HyDE LLM calls MUST go through the budget-tracked gateway (set via
+    ANTHROPIC_BASE_URL), never the pay-as-you-go API directly — an untracked
+    direct call is invisible to the budget-ceiling gate (Aiden HOLD, PR #1243).
+
+    Raises RuntimeError when ANTHROPIC_BASE_URL is unset; generate_hypothetical
+    catches it and falls back to the raw query, so no untracked call is ever
+    made. (Passing base_url=None would silently default to the direct API —
+    that is the exact failure mode this guard prevents.)
+    """
+    base_url = os.environ.get(ANTHROPIC_BASE_URL_ENV, "").strip()
+    if not base_url:
+        raise RuntimeError(
+            f"{ANTHROPIC_BASE_URL_ENV} unset — refusing a direct/untracked Anthropic "
+            "API call; HyDE routes through the budget-tracked gateway only"
+        )
     import anthropic  # lazy: keep retrieval import light + SDK optional
 
-    return anthropic.Anthropic()
+    return anthropic.Anthropic(base_url=base_url)
 
 
 def generate_hypothetical(query: str, model: str = DEFAULT_MODEL) -> str:

--- a/tests/retrieval/test_hyde.py
+++ b/tests/retrieval/test_hyde.py
@@ -1,0 +1,156 @@
+"""Unit tests for src/retrieval/hyde — Wave 4 HyDE query expansion.
+
+Mocks the Anthropic client so tests run without an API key / network. Locks
+the contract: hypothesis generation, flag gating, fail-open fallback, and
+that the expanded (hypothetical-bearing) text reaches the retrieval/embedding
+path while observability stays on the original query.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.retrieval import agent_query, hyde, orchestrator
+
+
+def _fake_client(text: str):
+    """A stand-in Anthropic client whose messages.create returns `text`."""
+
+    class _Msgs:
+        def create(self, **_kwargs):
+            return SimpleNamespace(content=[SimpleNamespace(text=text)])
+
+    return SimpleNamespace(messages=_Msgs())
+
+
+# ─── hyde_enabled ────────────────────────────────────────────────────────────
+
+
+def test_hyde_disabled_by_default(monkeypatch):
+    monkeypatch.delenv(hyde.HYDE_ENABLED_ENV, raising=False)
+    assert hyde.hyde_enabled() is False
+
+
+def test_hyde_enabled_truthy_values(monkeypatch):
+    for val in ("1", "true", "TRUE", "yes"):
+        monkeypatch.setenv(hyde.HYDE_ENABLED_ENV, val)
+        assert hyde.hyde_enabled() is True
+    monkeypatch.setenv(hyde.HYDE_ENABLED_ENV, "no")
+    assert hyde.hyde_enabled() is False
+
+
+# ─── generate_hypothetical ───────────────────────────────────────────────────
+
+
+def test_generate_returns_paragraph():
+    with patch.object(
+        hyde, "_get_client", return_value=_fake_client("Hindsight embeds server-side.")
+    ):
+        out = hyde.generate_hypothetical("how does recall embed queries?")
+    assert out == "Hindsight embeds server-side."
+
+
+def test_generate_empty_query_returns_empty():
+    assert hyde.generate_hypothetical("") == ""
+    assert hyde.generate_hypothetical("   ") == ""
+
+
+def test_generate_fails_open_on_client_error():
+    with patch.object(hyde, "_get_client", side_effect=RuntimeError("no api key")):
+        assert hyde.generate_hypothetical("q") == ""
+
+
+def test_generate_fails_open_on_empty_content():
+    with patch.object(hyde, "_get_client", return_value=_fake_client("")):
+        assert hyde.generate_hypothetical("q") == ""
+
+
+def test_generate_passes_model_through():
+    captured = {}
+
+    class _Msgs:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(content=[SimpleNamespace(text="x")])
+
+    with patch.object(hyde, "_get_client", return_value=SimpleNamespace(messages=_Msgs())):
+        hyde.generate_hypothetical("q", model="claude-haiku-4-5")
+    assert captured["model"] == "claude-haiku-4-5"
+    assert captured["max_tokens"] == hyde.MAX_TOKENS
+
+
+# ─── expand_query ────────────────────────────────────────────────────────────
+
+
+def test_expand_returns_raw_query_when_disabled(monkeypatch):
+    monkeypatch.delenv(hyde.HYDE_ENABLED_ENV, raising=False)
+    # generate_hypothetical must not even be reached when disabled.
+    with patch.object(hyde, "generate_hypothetical", side_effect=AssertionError("should not run")):
+        assert hyde.expand_query("raw query") == "raw query"
+
+
+def test_expand_fuses_query_and_hypothetical_when_enabled(monkeypatch):
+    monkeypatch.setenv(hyde.HYDE_ENABLED_ENV, "1")
+    with patch.object(hyde, "generate_hypothetical", return_value="HYPOTHETICAL DOC"):
+        out = hyde.expand_query("raw query")
+    assert "raw query" in out  # original signal retained
+    assert "HYPOTHETICAL DOC" in out
+
+
+def test_expand_falls_back_to_raw_when_generation_fails(monkeypatch):
+    monkeypatch.setenv(hyde.HYDE_ENABLED_ENV, "1")
+    with patch.object(hyde, "generate_hypothetical", return_value=""):
+        assert hyde.expand_query("raw query") == "raw query"
+
+
+# ─── embedding-path integration via agent_query.query ────────────────────────
+
+
+def _outcome(nodes=()):
+    return orchestrator.RetrievalOutcome(
+        nodes=tuple(nodes),
+        bypass_rerank=True,
+        rerank_reason="test",
+        rerank_elapsed_ms=0,
+    )
+
+
+def test_expanded_text_reaches_retrieval_path_when_enabled(monkeypatch):
+    """The fused (hypothetical-bearing) text is what hits the recall/embedding
+    path; the raw query is what gets logged for observability."""
+    monkeypatch.setenv(hyde.HYDE_ENABLED_ENV, "1")
+    captured = {}
+
+    def _fake_retrieve(*, text, **_kwargs):
+        captured["search_text"] = text
+        return _outcome()
+
+    with (
+        patch.object(hyde, "generate_hypothetical", return_value="ANSWER PASSAGE"),
+        patch("src.retrieval.agent_query.orchestrator.retrieve_with_outcome", _fake_retrieve),
+        patch("src.retrieval.agent_query._record_event") as rec,
+    ):
+        agent_query.query("what is the canonical approach?", agent="test")
+
+    assert "ANSWER PASSAGE" in captured["search_text"]
+    assert "what is the canonical approach?" in captured["search_text"]
+    # Observability logs the ORIGINAL query, not the expansion.
+    assert rec.call_args.kwargs["query_text"] == "what is the canonical approach?"
+
+
+def test_raw_query_reaches_retrieval_path_when_disabled(monkeypatch):
+    monkeypatch.delenv(hyde.HYDE_ENABLED_ENV, raising=False)
+    captured = {}
+
+    def _fake_retrieve(*, text, **_kwargs):
+        captured["search_text"] = text
+        return _outcome()
+
+    with (
+        patch("src.retrieval.agent_query.orchestrator.retrieve_with_outcome", _fake_retrieve),
+        patch("src.retrieval.agent_query._record_event"),
+    ):
+        agent_query.query("plain query", agent="test")
+
+    assert captured["search_text"] == "plain query"

--- a/tests/retrieval/test_hyde.py
+++ b/tests/retrieval/test_hyde.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from src.retrieval import agent_query, hyde, orchestrator
 
 
@@ -78,6 +80,39 @@ def test_generate_passes_model_through():
         hyde.generate_hypothetical("q", model="claude-haiku-4-5")
     assert captured["model"] == "claude-haiku-4-5"
     assert captured["max_tokens"] == hyde.MAX_TOKENS
+
+
+# ─── gateway routing (Aiden HOLD, PR #1243) ──────────────────────────────────
+
+
+def test_get_client_requires_base_url(monkeypatch):
+    """No ANTHROPIC_BASE_URL → _get_client raises rather than constructing a
+    direct (untracked) client."""
+    monkeypatch.delenv(hyde.ANTHROPIC_BASE_URL_ENV, raising=False)
+    with pytest.raises(RuntimeError, match=hyde.ANTHROPIC_BASE_URL_ENV):
+        hyde._get_client()
+
+
+def test_get_client_routes_through_gateway_when_set(monkeypatch):
+    """ANTHROPIC_BASE_URL set → the SDK client is constructed with that base_url
+    (no real network call — the SDK constructor does not connect)."""
+    monkeypatch.setenv(hyde.ANTHROPIC_BASE_URL_ENV, "http://127.0.0.1:4000")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    client = hyde._get_client()
+    assert str(client.base_url).startswith("http://127.0.0.1:4000")
+
+
+def test_missing_base_url_degrades_gracefully_no_untracked_call(monkeypatch):
+    """The HOLD scenario: ANTHROPIC_BASE_URL absent → expand_query returns the
+    original query unchanged. No crash, and no direct Anthropic SDK client is
+    ever constructed (so the budget gate sees no untracked call)."""
+    monkeypatch.setenv(hyde.HYDE_ENABLED_ENV, "1")
+    monkeypatch.delenv(hyde.ANTHROPIC_BASE_URL_ENV, raising=False)
+
+    import anthropic
+
+    with patch.object(anthropic, "Anthropic", side_effect=AssertionError("untracked direct call")):
+        assert hyde.expand_query("raw query") == "raw query"
 
 
 # ─── expand_query ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Adds **HyDE (Hypothetical Document Embeddings)** query expansion to the retrieval read path. Before searching, generate a one-paragraph hypothetical *answer* to the query and fuse it with the raw query; the fused text is what flows to the retrieval backend, so search runs against the answer space, not just the question.

## What changed
**New module `src/retrieval/hyde.py`:**
- `generate_hypothetical(query, model='claude-haiku-4-5') -> str` — one-paragraph hypothetical answer document via the sync Anthropic SDK; `""` on any error.
- `expand_query(query, model=...) -> str` — raw query **fused** with the hypothetical when HyDE is enabled AND generation succeeds; raw query otherwise.

**Integration (`src/retrieval/agent_query.py`):**
- `query()` calls `hyde.expand_query(text)` and passes the result as the retrieve text. Observability (`retrieval_events`) + answer synthesis stay on the **original** query — only the recall/rerank search text is expanded.

## Design note — embedding path (reviewer awareness)
The dispatch describes embedding the hypothetical client-side and using it *"as the search vector."* The **live** read path (`orchestrator._hindsight_recall`) sends **query text** to Hindsight, which embeds server-side — the client computes no search vector (client-side `get_embed_model()` is write-path only, post A3-c2 cutover). So HyDE here operates at the **text level**: the hypothetical becomes part of the `query` text and is embedded by the **same server-side path** as every normal query. This is the faithful HyDE realisation for a text-in backend.

**Why fused (query + hypothetical) rather than hypothetical-only:** `retrieve_with_outcome` uses one text for both ANN recall and cross-encoder rerank. Fusing keeps the original query signal anchoring rerank, while adding the hypothetical's semantic enrichment to recall. The dispatch explicitly allows *"fused with the raw query embedding."*

## Contract
- **Feature-flagged:** `RETRIEVAL_HYDE_ENABLED` (default **False**) — zero behaviour change when off (`expand_query` returns the raw query unchanged).
- **Fail-open:** any generation error → fall back to the raw query, so a HyDE outage never degrades retrieval below the pre-HyDE baseline.

## Cost note
Uses the raw sync Anthropic SDK (one ~256-token Haiku call) to match the **synchronous** retrieval entry point; deliberately not routed through the async, budget-tracked `AnthropicClient`. Wiring HyDE through the budget tracker is a follow-up if it ships beyond the default-off flag.

## Test plan
- [x] 12 new tests (generation, flag gating, fail-open fallback, embedding-path integration) pass
- [x] `tests/retrieval/` → **77 passed**, no regressions
- [x] `ruff format --check` + `ruff check` clean
- [ ] CI: Backend Tests (Pytest) green
- [ ] CI: SonarCloud QG green

```
env -u CALLSIGN python -m pytest tests/retrieval/test_hyde.py  -> 12 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)