### PR TITLE
[ATLAS] feat(retrieval): workflow-scoped recall budget (Wave 3)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -59,6 +59,7 @@ from src.relay.budget_ceiling import (
     BudgetDecision,
 )
 from src.retrieval import spawn_recall
+from src.retrieval.workflow_recall import CHARS_PER_TOKEN, WorkflowRecallContext
 
 logger = logging.getLogger(__name__)
 
@@ -211,6 +212,21 @@ spawn_recall_enabled: bool = os.environ.get(_SPAWN_RECALL_ENABLED_ENV, "").lower
     "yes",
 }
 
+# Workflow-scoped recall budget (Wave 3). A multi-step workflow spawns several
+# sessions; without this, spawn_recall re-queries Hindsight on every spawn for
+# the same workflow. When enabled AND a spawn carries a ``workflow_id``, the
+# prior-context block from spawn 1 is cached and reused by spawn 2..N — no
+# re-query (the cost + latency win). Layers ON TOP of spawn_recall: only
+# engages when spawn_recall is also on; otherwise no effect. Default OFF;
+# fail-open; 10-min TTL prevents cross-workflow bleed.
+_WORKFLOW_RECALL_ENABLED_ENV = "DISPATCHER_WORKFLOW_RECALL_ENABLED"
+workflow_recall_enabled: bool = os.environ.get(_WORKFLOW_RECALL_ENABLED_ENV, "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+_workflow_recall = WorkflowRecallContext()
+
 
 def _spawn_kwargs_source_type(sk: dict) -> str:
     """Derive source_type from spawn_kwargs per PR #1207 SOURCE_TYPES taxonomy."""
@@ -253,6 +269,44 @@ def _spawn_kwargs_brief(sk: dict) -> str:
         if value:
             return value
     return ""
+
+
+def _recall_block(
+    sk: dict[str, Any], *, task_type: str, task_brief: str
+) -> tuple[str, dict[str, Any] | None]:
+    """Produce the spawn's prior-context block, caching it per workflow_id.
+
+    Returns ``(block, workflow_recall_result)``. When workflow recall is
+    enabled AND a workflow_id is present, the block is cached so spawn 2..N in
+    the same workflow reuse spawn 1's Hindsight recall without re-querying.
+    Otherwise the block is computed fresh per spawn (Scout's #1240 behaviour)
+    and the second element is None. Fail-open throughout (spawn_recall +
+    WorkflowRecallContext both swallow errors to an empty block).
+    """
+
+    def _fresh_block() -> str:
+        # Fail-open: a recall outage must never block a spawn. query_for_spawn
+        # is fail-open by contract, but guard here too so a catastrophic raise
+        # (matching spawn_recall.inject_prior_context's own outer catch) still
+        # yields an empty block rather than a 500.
+        try:
+            return spawn_recall.build_prior_context_block(
+                spawn_recall.query_for_spawn(task_type, task_brief)
+            )
+        except Exception:  # noqa: BLE001 — recall must never block a spawn
+            logger.debug("workflow_recall: fresh block failed — no prior context", exc_info=True)
+            return ""
+
+    workflow_id = str(sk.get("workflow_id") or "").strip()
+    if not (workflow_recall_enabled and workflow_id):
+        return _fresh_block(), None
+    outcome = _workflow_recall.get_or_recall(workflow_id, _fresh_block)
+    result = {
+        "workflow_id": workflow_id,
+        "cached": outcome.cached,
+        "context_tokens": len(outcome.context) // CHARS_PER_TOKEN,
+    }
+    return outcome.context, result
 
 
 def _emit_attribution(
@@ -569,15 +623,19 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
     # spawn env as a 'Prior context from memory' block. Fail-open: recall
     # errors never block the spawn (spawn_recall swallows internally), and the
     # block only lands in `env` — the one context-bearing field forwarded
-    # verbatim to the backend spawn.
+    # verbatim to the backend spawn. When workflow recall is on + the spawn
+    # carries a workflow_id, the block is cached so sibling spawns reuse it
+    # without re-querying (see _recall_block).
     spawn_kwargs_effective = req.spawn_kwargs
+    workflow_recall_result: dict[str, Any] | None = None
     if spawn_recall_enabled:
         sk = req.spawn_kwargs or {}
-        spawn_kwargs_effective = spawn_recall.inject_prior_context(
+        block, workflow_recall_result = _recall_block(
             sk,
             task_type=_spawn_kwargs_task_type(sk, req.key),
             task_brief=_spawn_kwargs_brief(sk),
         )
+        spawn_kwargs_effective = spawn_recall.inject_block(sk, block)
 
     manager = SessionManager(backend=backend)
     try:
@@ -645,6 +703,8 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
     }
     if bounded_spawn_result is not None:
         response["bounded_spawn"] = bounded_spawn_result
+    if workflow_recall_result is not None:
+        response["workflow_recall"] = workflow_recall_result
     return response
 
 

--- a/src/retrieval/spawn_recall.py
+++ b/src/retrieval/spawn_recall.py
@@ -97,13 +97,24 @@ def inject_prior_context(
     """
     try:
         block = build_prior_context_block(query_for_spawn(task_type, task_brief))
-        if not block:
-            return spawn_kwargs
-        new_kwargs = dict(spawn_kwargs)
-        env = dict(new_kwargs.get("env") or {})
-        env[PRIOR_CONTEXT_ENV_KEY] = block
-        new_kwargs["env"] = env
-        return new_kwargs
+        return inject_block(spawn_kwargs, block)
     except Exception:  # noqa: BLE001 — injection must never block a spawn
         logger.debug("inject_prior_context failed — spawn proceeds unchanged", exc_info=True)
         return spawn_kwargs
+
+
+def inject_block(spawn_kwargs: dict, block: str) -> dict:
+    """Place an already-built prior-context block into the spawn env.
+
+    Split out from inject_prior_context so a caller that produced the block by
+    another path (e.g. a workflow-scoped cache that reuses an earlier spawn's
+    recall — see src/retrieval/workflow_recall) injects it identically. Returns
+    spawn_kwargs unchanged when block is empty.
+    """
+    if not block:
+        return spawn_kwargs
+    new_kwargs = dict(spawn_kwargs)
+    env = dict(new_kwargs.get("env") or {})
+    env[PRIOR_CONTEXT_ENV_KEY] = block
+    new_kwargs["env"] = env
+    return new_kwargs

--- a/src/retrieval/workflow_recall.py
+++ b/src/retrieval/workflow_recall.py
@@ -1,0 +1,109 @@
+"""Workflow-scoped recall context cache (Wave 3).
+
+A multi-step workflow spawns several sessions. Without sharing, each spawn
+re-recalls the same atoms — duplicate retrieval cost + latency. This caches the
+recalled context per ``workflow_id`` so spawn 2..N inherit spawn 1's recall
+result without re-querying.
+
+Bounds:
+  - Per-workflow context capped at 500 tokens (KEI-55 ceiling), using the same
+    4-chars-per-token approximation as src/retrieval/agent_query.
+  - Entries expire after 10 minutes so a later, unrelated workflow that reuses
+    an id never inherits stale context (no cross-workflow bleed).
+
+Fail-open: any error — or a missing/blank workflow_id — yields an empty context
+and never raises. The caller's spawn must always proceed.
+
+Concurrency: process-local + single-event-loop. The dispatcher runs one asyncio
+loop per process and calls get_or_recall inline (like the budget + attribution
+gates), so the plain-dict store needs no lock. recall_fn is expected to be
+cheap; if it does blocking I/O the caller should keep it fast or offload it.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+CHARS_PER_TOKEN = 4  # matches src/retrieval/agent_query token approximation
+MAX_CONTEXT_TOKENS = 500  # KEI-55 ceiling
+DEFAULT_TTL_S = 600.0  # 10 minutes — prevents cross-workflow bleed
+
+
+@dataclass
+class _Entry:
+    context: str
+    stored_at: float
+
+
+@dataclass(frozen=True)
+class RecallOutcome:
+    """Result of a get_or_recall call.
+
+    ``cached`` distinguishes a reuse (spawn 2..N — no query fired, the cost +
+    latency saving) from a fresh recall (spawn 1, or after TTL expiry).
+    """
+
+    context: str
+    cached: bool
+
+
+class WorkflowRecallContext:
+    """Per-workflow recall cache with a token cap and a TTL."""
+
+    def __init__(
+        self,
+        *,
+        ttl_s: float = DEFAULT_TTL_S,
+        max_tokens: int = MAX_CONTEXT_TOKENS,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl_s = ttl_s
+        self._char_cap = max_tokens * CHARS_PER_TOKEN
+        self._clock = clock
+        self._store: dict[str, _Entry] = {}
+
+    def get_or_recall(self, workflow_id: str | None, recall_fn: Callable[[], str]) -> RecallOutcome:
+        """Return shared context for ``workflow_id``, recalling once on miss.
+
+        Cache hit (entry present + within TTL): returns the stored context and
+        does NOT call recall_fn — this is the re-query avoidance the feature
+        exists for. Miss (absent or expired): calls recall_fn (fail-open),
+        caps to the token ceiling, stores, and returns it. A blank/absent
+        workflow_id is a no-op (empty context) — there is no scope to share in.
+        """
+        if not workflow_id:
+            return RecallOutcome(context="", cached=False)
+        now = self._clock()
+        entry = self._store.get(workflow_id)
+        if entry is not None and (now - entry.stored_at) <= self._ttl_s:
+            return RecallOutcome(context=entry.context, cached=True)
+        try:
+            recalled = recall_fn() or ""
+        except Exception:  # noqa: BLE001 — recall must never block the spawn
+            logger.exception("workflow_recall: recall_fn raised for workflow_id=%s", workflow_id)
+            return RecallOutcome(context="", cached=False)
+        context = self._cap(str(recalled))
+        self._store[workflow_id] = _Entry(context=context, stored_at=now)
+        self._evict_expired(now)
+        return RecallOutcome(context=context, cached=False)
+
+    def _cap(self, text: str) -> str:
+        return text[: self._char_cap]
+
+    def _evict_expired(self, now: float) -> None:
+        expired = [wid for wid, e in self._store.items() if (now - e.stored_at) > self._ttl_s]
+        for wid in expired:
+            del self._store[wid]
+
+    def peek(self, workflow_id: str) -> str | None:
+        """Return the stored context without recall or TTL side effects (debug/tests)."""
+        entry = self._store.get(workflow_id)
+        return entry.context if entry is not None else None
+
+    def clear(self) -> None:
+        self._store.clear()

--- a/tests/dispatcher/test_main_workflow_recall_wiring.py
+++ b/tests/dispatcher/test_main_workflow_recall_wiring.py
@@ -1,0 +1,170 @@
+"""Wave 3 — workflow-scoped recall wiring tests for src.dispatcher.main.
+
+workflow_recall layers on top of Scout's spawn_recall (#1240): when both flags
+are on and a spawn carries a workflow_id, spawn 1's prior-context block is
+cached so spawn 2..N reuse it without re-running the Hindsight query. Covers:
+default-off no-op, cache-hit reuse (query fires once), blank workflow_id no-op,
+spawn_recall-off short-circuit, env injection, and fail-open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.dispatcher.tmux_lifecycle import SessionHandle
+from src.retrieval.spawn_recall import PRIOR_CONTEXT_ENV_KEY
+
+
+def _mock_supervisors(main_mod: Any) -> None:
+    main_mod._watchdog = MagicMock()
+    main_mod._reaper = MagicMock()
+    main_mod._reaper.health_snapshot.return_value = {
+        "tracked_tmux": 0,
+        "tracked_containers": 0,
+    }
+    main_mod._watchdog.tracked = 0
+
+
+def _make_handle() -> SessionHandle:
+    return SessionHandle(session_name="disp-test", working_dir="/tmp", command="claude")
+
+
+def _spawn(client: TestClient, key: str, spawn_kwargs: dict) -> Any:
+    return client.post(
+        "/dispatcher/spawn",
+        json={"backend": "tmux", "key": key, "spawn_kwargs": spawn_kwargs},
+    )
+
+
+def _prep(monkeypatch: pytest.MonkeyPatch, *, spawn_recall: bool, workflow_recall: bool) -> Any:
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+    import src.dispatcher.main as main_mod
+
+    monkeypatch.setattr(main_mod, "spawn_recall_enabled", spawn_recall)
+    monkeypatch.setattr(main_mod, "workflow_recall_enabled", workflow_recall)
+    main_mod._workflow_recall.clear()
+    _mock_supervisors(main_mod)
+    return main_mod
+
+
+def test_disabled_workflow_recall_no_response_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """spawn_recall on, workflow_recall off → fresh recall every spawn, no cache key."""
+    main_mod = _prep(monkeypatch, spawn_recall=True, workflow_recall=False)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+        patch("src.retrieval.spawn_recall.query_for_spawn", return_value=["[a · Keis] hello"]) as q,
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        r1 = _spawn(client, "k1", {"workflow_id": "wf-1", "brief": "do x"})
+        r2 = _spawn(client, "k2", {"workflow_id": "wf-1", "brief": "do x"})
+
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert "workflow_recall" not in r1.json()
+    assert q.call_count == 2  # no cache → re-queried each spawn
+
+
+def test_spawn2_reuses_spawn1_recall(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both flags on, same workflow_id → query fires once; spawn 2 is cached."""
+    main_mod = _prep(monkeypatch, spawn_recall=True, workflow_recall=True)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+        patch(
+            "src.retrieval.spawn_recall.query_for_spawn",
+            return_value=["[DEC-7 · Decisions] ratified hybrid recall"],
+        ) as q,
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        r1 = _spawn(client, "k1", {"workflow_id": "wf-1", "brief": "step 1", "callsign": "atlas"})
+        r2 = _spawn(client, "k2", {"workflow_id": "wf-1", "brief": "step 2", "callsign": "orion"})
+
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert q.call_count == 1  # spawn 2 reused spawn 1's recall — no re-query
+    wr1, wr2 = r1.json()["workflow_recall"], r2.json()["workflow_recall"]
+    assert wr1["cached"] is False
+    assert wr2["cached"] is True
+    assert wr1["context_tokens"] > 0
+
+
+def test_blank_workflow_id_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both flags on but no workflow_id → fresh per-spawn, no cache key."""
+    main_mod = _prep(monkeypatch, spawn_recall=True, workflow_recall=True)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+        patch("src.retrieval.spawn_recall.query_for_spawn", return_value=["[a · Keis] x"]) as q,
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        r1 = _spawn(client, "k1", {"brief": "no workflow"})
+        _spawn(client, "k2", {"brief": "no workflow"})
+
+    assert "workflow_recall" not in r1.json()
+    assert q.call_count == 2  # no workflow scope → no caching
+
+
+def test_spawn_recall_off_short_circuits_workflow_recall(monkeypatch: pytest.MonkeyPatch) -> None:
+    """workflow_recall only layers on spawn_recall — off means it never engages."""
+    main_mod = _prep(monkeypatch, spawn_recall=False, workflow_recall=True)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+        patch("src.retrieval.spawn_recall.query_for_spawn") as q,
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        resp = _spawn(client, "k1", {"workflow_id": "wf-1", "brief": "x"})
+
+    assert resp.status_code == 200
+    assert "workflow_recall" not in resp.json()
+    assert q.call_count == 0  # spawn_recall off → no recall at all
+
+
+def test_cached_block_injected_into_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The reused block lands in env[PRIOR_CONTEXT_ENV_KEY] for spawn 2, same as spawn 1."""
+    main_mod = _prep(monkeypatch, spawn_recall=True, workflow_recall=True)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+        patch("src.retrieval.spawn_recall.query_for_spawn", return_value=["[a · Keis] shared"]),
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        _spawn(client, "k1", {"workflow_id": "wf-1", "brief": "s1"})
+        _spawn(client, "k2", {"workflow_id": "wf-1", "brief": "s2"})
+
+        # spawn 2's forwarded kwargs carry the cached prior-context block.
+        forwarded = MockSM.return_value.spawn.call_args.kwargs
+        assert PRIOR_CONTEXT_ENV_KEY in forwarded.get("env", {})
+        assert "shared" in forwarded["env"][PRIOR_CONTEXT_ENV_KEY]
+        # workflow_id is preserved (not stripped) in the forwarded kwargs.
+        assert forwarded["workflow_id"] == "wf-1"
+
+
+def test_recall_failure_does_not_block_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """query_for_spawn raising → spawn still succeeds, empty block (fail-open)."""
+    main_mod = _prep(monkeypatch, spawn_recall=True, workflow_recall=True)
+
+    def boom(*_a: Any, **_k: Any) -> list[str]:
+        raise RuntimeError("hindsight down")
+
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+        patch("src.retrieval.spawn_recall.query_for_spawn", side_effect=boom),
+    ):
+        MockSM.return_value.spawn.return_value = _make_handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        resp = _spawn(client, "k1", {"workflow_id": "wf-err", "brief": "x"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["spawned"] is True
+    assert resp.json()["workflow_recall"]["context_tokens"] == 0

--- a/tests/retrieval/test_workflow_recall.py
+++ b/tests/retrieval/test_workflow_recall.py
@@ -1,0 +1,129 @@
+"""Unit tests for src.retrieval.workflow_recall (Wave 3).
+
+Covers the cache semantics the dispatcher relies on: cache hit avoids
+re-query, TTL expiry forces re-query (no cross-workflow bleed), 500-token
+cap, blank workflow_id no-op, and fail-open on recall errors.
+"""
+
+from __future__ import annotations
+
+from src.retrieval.workflow_recall import (
+    CHARS_PER_TOKEN,
+    MAX_CONTEXT_TOKENS,
+    WorkflowRecallContext,
+)
+
+
+class _Clock:
+    """Manually-advanced clock for deterministic TTL tests."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, secs: float) -> None:
+        self.t += secs
+
+
+def _counting_fn(text: str) -> tuple[list[int], object]:
+    calls = [0]
+
+    def fn() -> str:
+        calls[0] += 1
+        return text
+
+    return calls, fn
+
+
+def test_first_recall_misses_then_second_hits_without_requery() -> None:
+    """The core win: spawn 2 reuses spawn 1's recall — recall_fn fires once."""
+    cache = WorkflowRecallContext()
+    calls, fn = _counting_fn("atoms for wf-1")
+
+    first = cache.get_or_recall("wf-1", fn)
+    second = cache.get_or_recall("wf-1", fn)
+
+    assert first.cached is False
+    assert first.context == "atoms for wf-1"
+    assert second.cached is True
+    assert second.context == "atoms for wf-1"
+    assert calls[0] == 1  # recall_fn called exactly once across both spawns
+
+
+def test_distinct_workflows_do_not_share() -> None:
+    cache = WorkflowRecallContext()
+    cache.get_or_recall("wf-a", lambda: "context A")
+    out_b = cache.get_or_recall("wf-b", lambda: "context B")
+    assert out_b.cached is False
+    assert out_b.context == "context B"
+    assert cache.peek("wf-a") == "context A"
+
+
+def test_ttl_expiry_forces_requery_no_stale_bleed() -> None:
+    clock = _Clock()
+    cache = WorkflowRecallContext(ttl_s=600.0, clock=clock)
+    calls, fn = _counting_fn("first")
+
+    cache.get_or_recall("wf-1", fn)
+    clock.advance(599.0)
+    mid = cache.get_or_recall("wf-1", fn)
+    assert mid.cached is True  # still within TTL
+    assert calls[0] == 1
+
+    clock.advance(2.0)  # now 601s — past the 600s TTL
+    after = cache.get_or_recall("wf-1", lambda: "fresh")
+    assert after.cached is False
+    assert after.context == "fresh"  # stale entry not served
+
+
+def test_context_capped_at_500_tokens() -> None:
+    cache = WorkflowRecallContext()
+    oversized = "x" * (MAX_CONTEXT_TOKENS * CHARS_PER_TOKEN * 3)
+    out = cache.get_or_recall("wf-big", lambda: oversized)
+    assert len(out.context) == MAX_CONTEXT_TOKENS * CHARS_PER_TOKEN
+
+
+def test_blank_workflow_id_is_noop() -> None:
+    cache = WorkflowRecallContext()
+    calls, fn = _counting_fn("never")
+    out = cache.get_or_recall("", fn)
+    assert out.context == ""
+    assert out.cached is False
+    assert calls[0] == 0  # no scope to share in → recall_fn never called
+
+    out_none = cache.get_or_recall(None, fn)
+    assert out_none.context == ""
+    assert calls[0] == 0
+
+
+def test_recall_failure_is_fail_open() -> None:
+    cache = WorkflowRecallContext()
+
+    def boom() -> str:
+        raise RuntimeError("recall backend down")
+
+    out = cache.get_or_recall("wf-err", boom)
+    assert out.context == ""
+    assert out.cached is False
+    assert cache.peek("wf-err") is None  # nothing stored on failure
+
+
+def test_recall_fn_returning_none_yields_empty() -> None:
+    cache = WorkflowRecallContext()
+    out = cache.get_or_recall("wf-none", lambda: None)  # type: ignore[arg-type,return-value]
+    assert out.context == ""
+    # Stored as empty so a subsequent spawn still hits cache (no needless re-query).
+    assert cache.peek("wf-none") == ""
+
+
+def test_expired_entries_evicted_on_write() -> None:
+    clock = _Clock()
+    cache = WorkflowRecallContext(ttl_s=10.0, clock=clock)
+    cache.get_or_recall("wf-old", lambda: "old")
+    clock.advance(20.0)
+    # Writing a new workflow sweeps the expired one.
+    cache.get_or_recall("wf-new", lambda: "new")
+    assert cache.peek("wf-old") is None
+    assert cache.peek("wf-new") == "new"


### PR DESCRIPTION
## Summary

A multi-step workflow spawns several sessions. Scout's `spawn_recall` (#1240) runs a Hindsight recall on **every** spawn — so a 5-spawn workflow re-queries the same atoms 5 times (duplicate cost + latency). This adds a **workflow-scoped cache** so spawn 2..N inherit spawn 1's prior-context block **without re-querying**.

## Design

- **New `src/retrieval/workflow_recall.py`** — `WorkflowRecallContext`, a generic TTL cache keyed by `workflow_id`. `get_or_recall(workflow_id, recall_fn)` returns the cached block on a hit (recall_fn **not** called — the saving) or recalls once on a miss. 500-token cap (KEI-55, same 4-chars/token approximation as `agent_query`); 10-minute TTL prevents cross-workflow bleed; fail-open throughout.
- **`src/dispatcher/main.py`** — layers the cache **on top of** `spawn_recall`. Engages only when `DISPATCHER_WORKFLOW_RECALL_ENABLED=1` **AND** `spawn_recall` is on **AND** the spawn carries a `workflow_id`; otherwise behaviour is exactly Scout's per-spawn path. Default **OFF**; fail-open in every path.
- **`src/retrieval/spawn_recall.py`** — extracted `inject_block(spawn_kwargs, block)` from `inject_prior_context` (DRY) so the cached block injects into `env[AGENCY_OS_PRIOR_CONTEXT]` identically to the fresh path. `inject_prior_context` behaviour is unchanged (now delegates).

## Why it layers on spawn_recall (scope note for reviewers)

The original dispatch scoped a standalone module with its own recall source. On rebasing to current `main` I found **Scout's `spawn_recall` already merged (#1240)** doing the per-spawn query. The faithful realisation of the objective ("spawn 2 inherits what spawn 1 retrieved") is to cache **that**, so this PR layers on it rather than adding a parallel recall path. The `spawn_recall.py` edit is a non-breaking DRY refactor — flagged here since it touches another callsign's merged module.

## Test plan

- [x] 8 unit tests (`test_workflow_recall.py`): cache hit/miss, TTL expiry (no stale bleed), 500-token cap, blank/None workflow_id no-op, recall-failure fail-open, expired-entry eviction.
- [x] 6 wiring tests (`test_main_workflow_recall_wiring.py`): spawn 2 reuses spawn 1 (query fires once), both-flag gating, blank-workflow_id no-op, `spawn_recall`-off short-circuit, env-block injection + workflow_id preserved, fail-open.
- [x] Regression: full dispatcher-main + `spawn_recall` suites green — **84 passed**. (Caught + fixed a fail-open regression where the non-cached path lost `inject_prior_context`'s outer exception guard.)
- [x] `ruff check` + `ruff format --check` pass.
- [ ] Deliberator review (2-of-3 NATS concur) — incl. a Scout/architecture eye on the `spawn_recall.py` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)