### PR TITLE
[ORION] fix(hindsight): raise Postgres shm_size to 1g — unblock mirror writes

### DIFF
--- a/keiracom_system/fleet/hindsight/docker-compose.yml
+++ b/keiracom_system/fleet/hindsight/docker-compose.yml
@@ -43,6 +43,11 @@ services:
     image: ghcr.io/vectorize-io/hindsight:latest
     container_name: keiracom-fleet-hindsight
     pull_policy: always
+    # Embedded Postgres needs ~534MB of shared memory for inline (async:false)
+    # embedding/extraction on a write. Docker's default /dev/shm is 64MB, so the
+    # PG shared-memory segment failed to grow → "No space left on device" → every
+    # INDEXER_HINDSIGHT_MIRROR write 500'd (Agency_OS-mzpp, 2026-05-28). 1g clears it.
+    shm_size: "1g"
     environment:
       HINDSIGHT_API_LLM_PROVIDER: openai
       HINDSIGHT_API_LLM_API_KEY: ${OPENAI_API_KEY:?OPENAI_API_KEY required — set in .env}


### PR DESCRIPTION
## Summary

Fixes the blocker found while enabling `INDEXER_HINDSIGHT_MIRROR=on` (Agency_OS-mzpp). The fleet Hindsight container's embedded Postgres ran with Docker's default 64MB `/dev/shm`; inline (`async:false`) embedding/extraction on a write needs ~534MB of PG shared memory, so the segment couldn't grow:

```
HTTP 500: could not resize shared memory segment "/PostgreSQL..." to 533794784 bytes: No space left on device
```

Every mirror write 500'd → readers were cut over to Hindsight (#1175) but new writes never landed → corpus drift (8/10 fleet banks empty, see PR #1241 baseline).

## Change

One line: `shm_size: "1g"` on the `hindsight` service in `keiracom_system/fleet/hindsight/docker-compose.yml`.

## Applied live + verified

Recreated the running container (`docker compose -p hindsight up -d --force-recreate`, **named volume preserved — no `-v`**). The live container was created from the Atlas worktree under compose project `hindsight`, so `-p hindsight` was used to target it and reuse its data volume.

- `shm_size` now `1073741824` (1GiB)
- `async:false` write → **HTTP 200** (was 500); no shm/`No space` error in docker logs
- corpus intact (existing docs still recall); `fleet_decisions` grew 2→3 as the mirror began landing writes
- Hindsight `/health` healthy ~25s after recreate
- Vault + reranker containers untouched

## Known residual (separate issue, not shm)

Some mirror writes still hit the **30s client timeout** under the indexer's 200-row backlog (slow synchronous OpenAI embedding of large rows). Not the shm fault. Follow-up candidates: raise `HINDSIGHT_TIMEOUT`, switch the mirror to `async:true`, or throttle batch size. Flagging for a follow-up KEI.

## Test plan

- [x] `docker compose config` resolves with `shm_size`
- [x] async:false write returns 200, no shm error in docker logs
- [x] corpus preserved across recreate
- [ ] Deliberator review (infra/compose change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)