### PR TITLE
[ORION] feat(retrieval): Wave 5 — cross-topology fusion recall

### DIFF
--- a/src/retrieval/__init__.py
+++ b/src/retrieval/__init__.py
@@ -16,6 +16,6 @@ sources. `citation_required=True` is the default — empty results return
 guard per KEI-55).
 """
 
-from src.retrieval.agent_query import Citation, QueryResult, query
+from src.retrieval.agent_query import Citation, QueryResult, query, query_async
 
-__all__ = ["Citation", "QueryResult", "query"]
+__all__ = ["Citation", "QueryResult", "query", "query_async"]

--- a/src/retrieval/agent_query.py
+++ b/src/retrieval/agent_query.py
@@ -13,15 +13,19 @@ natural follow-up if write latency starts mattering at scale.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import logging
 import os
 import time
+from collections.abc import Coroutine
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal, TypeVar
 
 from src.retrieval import fusion, orchestrator
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
 
 DEFAULT_COLLECTIONS: tuple[str, ...] = ("Discoveries", "Decisions", "Keis")
 DEFAULT_MAX_TOKENS = 500  # KEI-55 ceiling
@@ -170,6 +174,105 @@ def _synthesise_answer(citations: tuple[Citation, ...], max_tokens: int) -> str:
     return answer[:char_cap]
 
 
+def _run_coro_sync(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Drive a coroutine to completion from a sync caller.
+
+    Safe whether or not an event loop is already running on the current
+    thread. `query()` is a sync public API but may be invoked from inside an
+    async context (e.g. a FastAPI handler); `asyncio.run()` raises RuntimeError
+    when a loop is already running, so in that case the coroutine runs on a
+    dedicated worker thread with its own loop. Async callers should prefer
+    `query_async()` and skip this hop entirely.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
+def _fusion_outcome(
+    fused_nodes: list[orchestrator.RetrievedNode], collections: tuple[str, ...]
+) -> orchestrator.RetrievalOutcome:
+    """Wrap fused nodes in a RetrievalOutcome.
+
+    Wave 5: fusion unions ALL mapped fleet banks, so the per-call `collections`
+    slice is ignored — logged at debug so the override is traceable.
+    `bypass_rerank=True`: fusion ranks on Hindsight scores directly; the
+    cross-encoder sidecar stage is not in the fused path.
+    """
+    logger.debug(
+        "fusion enabled — `collections`=%s ignored; recalling across all mapped fleet banks",
+        collections,
+    )
+    return orchestrator.RetrievalOutcome(
+        nodes=tuple(fused_nodes),
+        bypass_rerank=True,
+        rerank_reason="fusion",
+        rerank_elapsed_ms=0,
+    )
+
+
+def _finalize(
+    outcome: orchestrator.RetrievalOutcome,
+    *,
+    agent: str,
+    text: str,
+    collections: tuple[str, ...],
+    k_initial: int,
+    k_returned: int,
+    max_tokens: int,
+    citation_required: bool,
+    started: float,
+) -> QueryResult:
+    """Shared post-recall path: citation extraction → KEI-198 top-N → event."""
+    citations = [_node_to_citation(n) for n in outcome.nodes]
+    # KEI-198 — distribution-aware citation selection.
+    # OLD shape (pre-KEI-192 audit): hard `score >= min_score` filter excluded
+    # everything when vectorizer=none collapsed all scores to 0.0 — 12/14 of the
+    # session's retrieval_events landed with top_citation_id=NULL despite
+    # k_returned=5 nodes.
+    # NEW shape: always sort + slice top-N; only drop on the all-zero sentinel
+    # when caller explicitly opted in via citation_required=True.
+    top_n: tuple[Citation, ...] = tuple(
+        sorted(citations, key=lambda c: c.score, reverse=True)[:k_returned]
+    )
+    all_zero = bool(top_n) and all(c.score == _ZERO_SCORE_SENTINEL for c in top_n)
+    if all_zero:
+        logger.warning(
+            "retrieval scores all 0.0 — vectorizer-regression sentinel (KEI-198) "
+            "agent=%s text=%s collections=%s",
+            agent,
+            text[:QUERY_TEXT_LOG_CAP],
+            collections,
+        )
+    if citation_required and all_zero:
+        answer = ""
+        emitted_citations: tuple[Citation, ...] = ()
+    else:
+        emitted_citations = top_n
+        answer = _synthesise_answer(emitted_citations, max_tokens) if top_n else ""
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    top = emitted_citations[0] if emitted_citations else None
+    _record_event(
+        agent=agent,
+        query_text=text,
+        collections=collections,
+        k_initial=k_initial,
+        k_returned=k_returned,
+        elapsed_ms=elapsed_ms,
+        bypass_rerank=outcome.bypass_rerank,
+        top_citation=top,
+    )
+    return QueryResult(
+        answer=answer,
+        citations=emitted_citations,
+        elapsed_ms=elapsed_ms,
+        bypass_rerank=outcome.bypass_rerank,
+    )
+
+
 def query(
     text: str,
     *,
@@ -216,17 +319,8 @@ def query(
     """
     started = time.monotonic()
     if fusion.fusion_enabled():
-        # Wave 5: union recall across ALL mapped fleet banks (not just the
-        # `collections` slice), deduped by content hash + ranked by score.
-        # `bypass_rerank=True` — fusion ranks on Hindsight scores directly; the
-        # cross-encoder sidecar stage is not in the fused path.
-        fused_nodes = asyncio.run(fusion.fused_recall(text, tenant=tenant_id, top_k=k_initial))
-        outcome = orchestrator.RetrievalOutcome(
-            nodes=tuple(fused_nodes),
-            bypass_rerank=True,
-            rerank_reason="fusion",
-            rerank_elapsed_ms=0,
-        )
+        fused_nodes = _run_coro_sync(fusion.fused_recall(text, tenant=tenant_id, top_k=k_initial))
+        outcome = _fusion_outcome(fused_nodes, collections)
     else:
         outcome = orchestrator.retrieve_with_outcome(
             text=text,
@@ -235,47 +329,61 @@ def query(
             k_returned=k_returned,
             tenant_id=tenant_id,
         )
-    citations = [_node_to_citation(n) for n in outcome.nodes]
-    # KEI-198 — distribution-aware citation selection.
-    # OLD shape (pre-KEI-192 audit): hard `score >= min_score` filter excluded
-    # everything when vectorizer=none collapsed all scores to 0.0 — 12/14 of the
-    # session's retrieval_events landed with top_citation_id=NULL despite
-    # k_returned=5 nodes.
-    # NEW shape: always sort + slice top-N; only drop on the all-zero sentinel
-    # when caller explicitly opted in via citation_required=True.
-    top_n: tuple[Citation, ...] = tuple(
-        sorted(citations, key=lambda c: c.score, reverse=True)[:k_returned]
-    )
-    all_zero = bool(top_n) and all(c.score == _ZERO_SCORE_SENTINEL for c in top_n)
-    if all_zero:
-        logger.warning(
-            "retrieval scores all 0.0 — vectorizer-regression sentinel (KEI-198) "
-            "agent=%s text=%s collections=%s",
-            agent,
-            text[:QUERY_TEXT_LOG_CAP],
-            collections,
-        )
-    if citation_required and all_zero:
-        answer = ""
-        emitted_citations: tuple[Citation, ...] = ()
-    else:
-        emitted_citations = top_n
-        answer = _synthesise_answer(emitted_citations, max_tokens) if top_n else ""
-    elapsed_ms = int((time.monotonic() - started) * 1000)
-    top = emitted_citations[0] if emitted_citations else None
-    _record_event(
+    return _finalize(
+        outcome,
         agent=agent,
-        query_text=text,
+        text=text,
         collections=collections,
         k_initial=k_initial,
         k_returned=k_returned,
-        elapsed_ms=elapsed_ms,
-        bypass_rerank=outcome.bypass_rerank,
-        top_citation=top,
+        max_tokens=max_tokens,
+        citation_required=citation_required,
+        started=started,
     )
-    return QueryResult(
-        answer=answer,
-        citations=emitted_citations,
-        elapsed_ms=elapsed_ms,
-        bypass_rerank=outcome.bypass_rerank,
+
+
+async def query_async(
+    text: str,
+    *,
+    agent: str,
+    collections: tuple[str, ...] = DEFAULT_COLLECTIONS,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    citation_required: bool = True,
+    min_score: float = DEFAULT_MIN_SCORE,  # noqa: ARG001 KEI-198 back-compat  # NOSONAR S1172
+    k_initial: int = orchestrator.DEFAULT_K_INITIAL,
+    k_returned: int = orchestrator.DEFAULT_K_RETURNED,
+    tenant_id: str = orchestrator.FLEET_TENANT_SLUG,
+) -> QueryResult:
+    """Async-native variant of `query()`.
+
+    Prefer this from async callers (FastAPI handlers, awaited chains): it
+    awaits `fusion.fused_recall` directly instead of bouncing the coroutine
+    through `asyncio.run()` / a worker thread, which sync `query()` must do
+    because `asyncio.run()` raises inside a running loop. The non-fusion path
+    runs the blocking Hindsight recall via `asyncio.to_thread` so the event
+    loop stays free. Argument semantics are identical to `query()`.
+    """
+    started = time.monotonic()
+    if fusion.fusion_enabled():
+        fused_nodes = await fusion.fused_recall(text, tenant=tenant_id, top_k=k_initial)
+        outcome = _fusion_outcome(fused_nodes, collections)
+    else:
+        outcome = await asyncio.to_thread(
+            orchestrator.retrieve_with_outcome,
+            text=text,
+            collections=collections,
+            k_initial=k_initial,
+            k_returned=k_returned,
+            tenant_id=tenant_id,
+        )
+    return _finalize(
+        outcome,
+        agent=agent,
+        text=text,
+        collections=collections,
+        k_initial=k_initial,
+        k_returned=k_returned,
+        max_tokens=max_tokens,
+        citation_required=citation_required,
+        started=started,
     )

--- a/src/retrieval/agent_query.py
+++ b/src/retrieval/agent_query.py
@@ -12,13 +12,14 @@ natural follow-up if write latency starts mattering at scale.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import time
 from dataclasses import dataclass
 from typing import Literal
 
-from src.retrieval import orchestrator
+from src.retrieval import fusion, orchestrator
 
 logger = logging.getLogger(__name__)
 
@@ -214,13 +215,26 @@ def query(
         `QueryResult` with answer + citations + elapsed_ms + bypass flag.
     """
     started = time.monotonic()
-    outcome = orchestrator.retrieve_with_outcome(
-        text=text,
-        collections=collections,
-        k_initial=k_initial,
-        k_returned=k_returned,
-        tenant_id=tenant_id,
-    )
+    if fusion.fusion_enabled():
+        # Wave 5: union recall across ALL mapped fleet banks (not just the
+        # `collections` slice), deduped by content hash + ranked by score.
+        # `bypass_rerank=True` — fusion ranks on Hindsight scores directly; the
+        # cross-encoder sidecar stage is not in the fused path.
+        fused_nodes = asyncio.run(fusion.fused_recall(text, tenant=tenant_id, top_k=k_initial))
+        outcome = orchestrator.RetrievalOutcome(
+            nodes=tuple(fused_nodes),
+            bypass_rerank=True,
+            rerank_reason="fusion",
+            rerank_elapsed_ms=0,
+        )
+    else:
+        outcome = orchestrator.retrieve_with_outcome(
+            text=text,
+            collections=collections,
+            k_initial=k_initial,
+            k_returned=k_returned,
+            tenant_id=tenant_id,
+        )
     citations = [_node_to_citation(n) for n in outcome.nodes]
     # KEI-198 — distribution-aware citation selection.
     # OLD shape (pre-KEI-192 audit): hard `score >= min_score` filter excluded

--- a/src/retrieval/fusion.py
+++ b/src/retrieval/fusion.py
@@ -1,0 +1,104 @@
+"""Wave 5 — cross-topology fusion recall.
+
+`fused_recall` fires a recall against EVERY mapped fleet Hindsight bank in
+parallel (`asyncio.gather` over `asyncio.to_thread`), instead of the default
+three-collection slice `agent_query.query()` uses. Results are merged,
+deduplicated by content hash (the higher-scored copy wins when the same text
+surfaces in more than one bank), and ranked by score. This prevents siloed
+context: a query that semantically spans governance + decisions +
+agent_memories + keis no longer has to pick one bank up front.
+
+Gated behind `RETRIEVAL_FUSION_ENABLED` (default False) — matches the
+`DISPATCHER_RERANKER_ENABLED` / spawn-recall flag pattern. Fail-open: a bank
+whose recall fails is dropped from the union; the surviving banks still
+return. Tenant context is validated once, fail-fast, before any HTTP — a
+wire-contract violation is never per-bank-swallowed (mirrors
+`orchestrator._gather_ann_pool`).
+
+Each bank is recalled by reusing `orchestrator._gather_ann_pool` with a
+single-collection tuple, so the Hindsight wire contract, response-shape
+parsing, and per-collection fail-open all stay defined in exactly one place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+from collections.abc import Iterable
+
+from src.retrieval import orchestrator
+from src.retrieval.orchestrator import RetrievedNode
+
+logger = logging.getLogger(__name__)
+
+_FUSION_ENABLED_ENV = "RETRIEVAL_FUSION_ENABLED"
+_TRUTHY = {"1", "true", "yes"}
+
+
+def fusion_enabled() -> bool:
+    """True when RETRIEVAL_FUSION_ENABLED is set truthy (default False)."""
+    return os.environ.get(_FUSION_ENABLED_ENV, "").lower() in _TRUTHY
+
+
+def _content_key(text: str) -> str:
+    """Stable dedup key: sha256 of whitespace-stripped content."""
+    return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
+
+
+def _merge_dedup(node_lists: Iterable[list[RetrievedNode]], top_k: int) -> list[RetrievedNode]:
+    """Union node lists, keep the higher-scored copy per content hash, rank desc."""
+    merged: dict[str, RetrievedNode] = {}
+    for nodes in node_lists:
+        for node in nodes:
+            key = _content_key(node.text)
+            existing = merged.get(key)
+            if existing is None or node.score > existing.score:
+                merged[key] = node
+    ranked = sorted(merged.values(), key=lambda n: n.score, reverse=True)
+    return ranked[:top_k]
+
+
+async def fused_recall(
+    query: str,
+    tenant: str,
+    top_k: int = orchestrator.DEFAULT_K_INITIAL,
+) -> list[RetrievedNode]:
+    """Union recall across all mapped fleet banks; dedup by content; rank by score.
+
+    Args:
+        query: Natural-language recall query.
+        tenant: Hindsight tenant slug. Validated fail-fast at the wire boundary;
+            fleet-internal callers pass `orchestrator.FLEET_TENANT_SLUG`.
+        top_k: Max nodes returned after dedup + ranking.
+
+    Returns:
+        Up to `top_k` `RetrievedNode`s, ranked by score descending. A bank that
+        fails contributes nothing; the surviving banks' nodes still return.
+    """
+    orchestrator._require_tenant_id(tenant)  # fail-fast; never per-bank-swallowed
+    collections = tuple(orchestrator.HINDSIGHT_BANK_BY_CLASS)
+    tasks = [
+        asyncio.to_thread(
+            orchestrator._gather_ann_pool,
+            query,
+            (collection,),
+            top_k,
+            None,
+            tenant_id=tenant,
+        )
+        for collection in collections
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    node_lists: list[list[RetrievedNode]] = []
+    for collection, result in zip(collections, results, strict=True):
+        if isinstance(result, BaseException):
+            logger.warning(
+                "fusion bank recall failed collection=%s — dropping from union",
+                collection,
+                exc_info=result,
+            )
+            continue
+        node_lists.append(result)
+    return _merge_dedup(node_lists, top_k)

--- a/tests/retrieval/test_fusion.py
+++ b/tests/retrieval/test_fusion.py
@@ -208,3 +208,71 @@ def test_agent_query_uses_orchestrator_when_flag_off(monkeypatch):
     )
     agent_query.query("anything", agent="orion")
     assert used == [1]
+
+
+# ---------------------------------------------------------------------------
+# Async/sync split — running-loop safety (Aiden re-review of PR #1249)
+# ---------------------------------------------------------------------------
+
+
+def _fusion_stub(monkeypatch):
+    """Enable fusion + return one canned node; silence the event recorder."""
+    monkeypatch.setenv("RETRIEVAL_FUSION_ENABLED", "1")
+    monkeypatch.setattr(agent_query, "_record_event", lambda **kw: None)
+
+    async def _fake(text, tenant, top_k=orchestrator.DEFAULT_K_INITIAL):
+        return [
+            orchestrator.RetrievedNode(
+                text="hit", score=0.9, metadata={"source_id": "X1"}, collection="Keis"
+            )
+        ]
+
+    monkeypatch.setattr(fusion, "fused_recall", _fake)
+
+
+def test_sync_query_safe_when_called_inside_running_loop(monkeypatch):
+    """The landmine: sync query() invoked from within a running event loop
+    (FastAPI handler, awaited chain) must NOT raise RuntimeError from
+    asyncio.run() — _run_coro_sync falls back to a worker thread."""
+    _fusion_stub(monkeypatch)
+
+    async def _driver():
+        # Calling the SYNC entry point from inside a running loop.
+        return agent_query.query("anything", agent="orion")
+
+    result = asyncio.run(_driver())
+    assert result.citations[0].source_id == "X1"
+
+
+def test_sync_query_works_with_no_running_loop(monkeypatch):
+    _fusion_stub(monkeypatch)
+    result = agent_query.query("anything", agent="orion")
+    assert result.citations[0].source_id == "X1"
+
+
+def test_query_async_routes_through_fusion(monkeypatch):
+    _fusion_stub(monkeypatch)
+    monkeypatch.setattr(
+        orchestrator,
+        "retrieve_with_outcome",
+        lambda **kw: pytest.fail("orchestrator path used while fusion flag on"),
+    )
+    result = asyncio.run(agent_query.query_async("anything", agent="orion"))
+    assert result.citations[0].source_id == "X1"
+
+
+def test_query_async_uses_orchestrator_when_flag_off(monkeypatch):
+    monkeypatch.delenv("RETRIEVAL_FUSION_ENABLED", raising=False)
+    monkeypatch.setattr(agent_query, "_record_event", lambda **kw: None)
+    used = []
+
+    def _spy(**kw):
+        used.append(1)
+        return orchestrator.RetrievalOutcome((), False, "empty_pool", 0)
+
+    monkeypatch.setattr(orchestrator, "retrieve_with_outcome", _spy)
+    monkeypatch.setattr(
+        fusion, "fused_recall", lambda *a, **kw: pytest.fail("fusion used while flag off")
+    )
+    asyncio.run(agent_query.query_async("anything", agent="orion"))
+    assert used == [1]

--- a/tests/retrieval/test_fusion.py
+++ b/tests/retrieval/test_fusion.py
@@ -1,0 +1,210 @@
+"""Wave 5 — cross-topology fusion recall (src/retrieval/fusion.py).
+
+Covers:
+- fusion_enabled() env parsing (default off).
+- _content_key dedup-key stability + whitespace normalisation.
+- fused_recall: unions across ALL mapped fleet banks, dedups by content hash
+  (higher score wins), ranks by score desc, honours top_k.
+- Fail-open at both layers: per-collection swallow inside _gather_ann_pool,
+  AND the gather-level isinstance(BaseException) guard.
+- Tenant context validated fail-fast before any recall fires.
+- agent_query.query() routes through fusion when the flag is on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.retrieval import agent_query, fusion, orchestrator
+
+# ---------------------------------------------------------------------------
+# fusion_enabled() — flag parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("val,expected", [("1", True), ("true", True), ("YES", True)])
+def test_fusion_enabled_truthy(monkeypatch, val, expected):
+    monkeypatch.setenv("RETRIEVAL_FUSION_ENABLED", val)
+    assert fusion.fusion_enabled() is expected
+
+
+@pytest.mark.parametrize("val", ["", "0", "false", "no", "off"])
+def test_fusion_enabled_falsy(monkeypatch, val):
+    monkeypatch.setenv("RETRIEVAL_FUSION_ENABLED", val)
+    assert fusion.fusion_enabled() is False
+
+
+def test_fusion_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("RETRIEVAL_FUSION_ENABLED", raising=False)
+    assert fusion.fusion_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# _content_key — dedup key
+# ---------------------------------------------------------------------------
+
+
+def test_content_key_stable_and_whitespace_normalised():
+    assert fusion._content_key("hello") == fusion._content_key("  hello  ")
+    assert fusion._content_key("a") != fusion._content_key("b")
+
+
+# ---------------------------------------------------------------------------
+# fused_recall — union / dedup / rank
+# ---------------------------------------------------------------------------
+
+
+def _patch_recall_by_bank(monkeypatch, by_bank):
+    """Monkeypatch orchestrator._hindsight_recall to return canned memories per bank."""
+    calls: list[str] = []
+
+    def _fake_recall(text, bank_id, *, top_k, tenant_id):
+        calls.append(bank_id)
+        return list(by_bank.get(bank_id, []))
+
+    monkeypatch.setattr(orchestrator, "_hindsight_recall", _fake_recall)
+    return calls
+
+
+def test_fused_recall_fires_every_mapped_bank(monkeypatch):
+    calls = _patch_recall_by_bank(monkeypatch, {})
+    asyncio.run(fusion.fused_recall("q", orchestrator.FLEET_TENANT_SLUG, top_k=5))
+    assert set(calls) == set(orchestrator.HINDSIGHT_BANK_BY_CLASS.values())
+
+
+def test_fused_recall_unions_and_ranks_by_score(monkeypatch):
+    _patch_recall_by_bank(
+        monkeypatch,
+        {
+            "fleet_decisions": [{"content": "dec", "score": 0.4}],
+            "fleet_keis": [{"content": "kei", "score": 0.9}],
+            "fleet_agent_memories": [{"content": "mem", "score": 0.6}],
+        },
+    )
+    out = asyncio.run(fusion.fused_recall("q", orchestrator.FLEET_TENANT_SLUG, top_k=10))
+    texts = [n.text for n in out]
+    assert texts == ["kei", "mem", "dec"]  # ranked by score desc across banks
+
+
+def test_fused_recall_dedups_by_content_keeping_higher_score(monkeypatch):
+    _patch_recall_by_bank(
+        monkeypatch,
+        {
+            "fleet_decisions": [{"content": "shared insight", "score": 0.3}],
+            "fleet_keis": [{"content": "shared insight", "score": 0.8}],
+        },
+    )
+    out = asyncio.run(fusion.fused_recall("q", orchestrator.FLEET_TENANT_SLUG, top_k=10))
+    shared = [n for n in out if n.text == "shared insight"]
+    assert len(shared) == 1
+    assert shared[0].score == pytest.approx(0.8)
+
+
+def test_fused_recall_honours_top_k(monkeypatch):
+    _patch_recall_by_bank(
+        monkeypatch,
+        {
+            "fleet_decisions": [{"content": f"d{i}", "score": i / 10} for i in range(5)],
+            "fleet_keis": [{"content": f"k{i}", "score": i / 10} for i in range(5)],
+        },
+    )
+    out = asyncio.run(fusion.fused_recall("q", orchestrator.FLEET_TENANT_SLUG, top_k=3))
+    assert len(out) == 3
+
+
+# ---------------------------------------------------------------------------
+# Fail-open — both layers
+# ---------------------------------------------------------------------------
+
+
+def test_fused_recall_fail_open_on_per_bank_recall_error(monkeypatch):
+    """A bank whose _hindsight_recall raises is swallowed by _gather_ann_pool;
+    the surviving banks still contribute to the union."""
+
+    def _flaky_recall(text, bank_id, *, top_k, tenant_id):
+        if bank_id == "fleet_decisions":
+            raise RuntimeError("simulated bank outage")
+        return [{"content": f"ok-{bank_id}", "score": 0.5}]
+
+    monkeypatch.setattr(orchestrator, "_hindsight_recall", _flaky_recall)
+    out = asyncio.run(fusion.fused_recall("q", orchestrator.FLEET_TENANT_SLUG, top_k=50))
+    texts = {n.text for n in out}
+    assert "ok-fleet_keis" in texts
+    assert not any("fleet_decisions" in t for t in texts)
+
+
+def test_fused_recall_fail_open_on_gather_level_exception(monkeypatch):
+    """If _gather_ann_pool itself raises for one collection, the gather-level
+    isinstance(BaseException) guard drops it and keeps the others."""
+    good = [orchestrator.RetrievedNode(text="survived", score=0.7, metadata={}, collection="Keis")]
+
+    def _selective_pool(text, collections, k_initial, weaviate_client, *, tenant_id):
+        (collection,) = collections
+        if collection == "Decisions":
+            raise RuntimeError("pool blew up")
+        return list(good) if collection == "Keis" else []
+
+    monkeypatch.setattr(orchestrator, "_gather_ann_pool", _selective_pool)
+    out = asyncio.run(fusion.fused_recall("q", orchestrator.FLEET_TENANT_SLUG, top_k=10))
+    assert [n.text for n in out] == ["survived"]
+
+
+# ---------------------------------------------------------------------------
+# Tenant context — fail-fast
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [None, "", "   ", "tenant/../escape"])
+def test_fused_recall_rejects_bad_tenant_before_any_recall(monkeypatch, bad):
+    called = []
+    monkeypatch.setattr(orchestrator, "_hindsight_recall", lambda *a, **kw: called.append(1) or [])
+    with pytest.raises(orchestrator.MissingTenantContextError):
+        asyncio.run(fusion.fused_recall("q", bad, top_k=5))
+    assert called == []
+
+
+# ---------------------------------------------------------------------------
+# agent_query.query() integration
+# ---------------------------------------------------------------------------
+
+
+def test_agent_query_routes_through_fusion_when_flag_on(monkeypatch):
+    monkeypatch.setenv("RETRIEVAL_FUSION_ENABLED", "1")
+    monkeypatch.setattr(agent_query, "_record_event", lambda **kw: None)
+    fused = [
+        orchestrator.RetrievedNode(
+            text="fused-hit", score=0.9, metadata={"source_id": "X1"}, collection="Keis"
+        ),
+    ]
+
+    async def _fake_fused_recall(text, tenant, top_k=orchestrator.DEFAULT_K_INITIAL):
+        return list(fused)
+
+    monkeypatch.setattr(fusion, "fused_recall", _fake_fused_recall)
+    # If fusion is wired, retrieve_with_outcome must NOT be called.
+    monkeypatch.setattr(
+        orchestrator,
+        "retrieve_with_outcome",
+        lambda **kw: pytest.fail("orchestrator path used while fusion flag on"),
+    )
+    result = agent_query.query("anything", agent="orion")
+    assert result.citations
+    assert result.citations[0].source_id == "X1"
+
+
+def test_agent_query_uses_orchestrator_when_flag_off(monkeypatch):
+    monkeypatch.delenv("RETRIEVAL_FUSION_ENABLED", raising=False)
+    monkeypatch.setattr(agent_query, "_record_event", lambda **kw: None)
+    used = []
+    monkeypatch.setattr(
+        orchestrator,
+        "retrieve_with_outcome",
+        lambda **kw: used.append(1) or orchestrator.RetrievalOutcome((), False, "empty_pool", 0),
+    )
+    monkeypatch.setattr(
+        fusion, "fused_recall", lambda *a, **kw: pytest.fail("fusion used while flag off")
+    )
+    agent_query.query("anything", agent="orion")
+    assert used == [1]


### PR DESCRIPTION
## Summary

Wave 5: a single recall query that unions across **all** mapped fleet Hindsight banks instead of hitting the default 3-collection slice one bank at a time. Prevents siloed context — a query spanning governance + decisions + agent_memories + keis no longer has to pick one bank up front.

- **New** `src/retrieval/fusion.py` — `fused_recall(query, tenant, top_k)`:
  - Fires recall against every bank in `HINDSIGHT_BANK_BY_CLASS` in parallel (`asyncio.gather` over `asyncio.to_thread`).
  - Merges, **dedupes by content hash** (sha256 of stripped text; higher-scored copy wins), ranks by score desc, slices `top_k`.
  - Reuses `orchestrator._gather_ann_pool` per single-collection so the Hindsight wire contract + response-shape parsing + per-collection fail-open stay defined in **one** place (no drift vs the parity-tested reader).
- **Feature flag** `RETRIEVAL_FUSION_ENABLED` (default `False`) — matches the `DISPATCHER_RERANKER_ENABLED` / spawn-recall rollout pattern.
- **Fail-open** at two layers: per-collection swallow inside `_gather_ann_pool`, plus a gather-level `isinstance(BaseException)` guard. A bank that errors is dropped; surviving banks still return.
- **Tenant fail-fast**: `_require_tenant_id` validated once before any HTTP — a wire-contract violation is never per-bank-swallowed (consistent with the orchestrator path; YELLOW-4 / Agency_OS-7sj6).
- **Integration**: `agent_query.query()` routes through fusion behind the flag; downstream citation extraction + distribution-aware top-N selection untouched. `bypass_rerank=True` (fusion ranks on Hindsight scores; cross-encoder sidecar is not in the fused path).

## Test plan

- [x] `tests/retrieval/test_fusion.py` — 16 new tests: flag parsing (truthy/falsy/default-off), content-key stability + whitespace normalisation, union+rank across banks, content-hash dedup keeps higher score, `top_k` honoured, fail-open (per-bank recall error AND gather-level exception), tenant fail-fast (4 bad values, asserts no recall fired), all-mapped-banks-fired, `agent_query` integration (flag-on routes through fusion, flag-off uses orchestrator).
- [x] `ruff check` + `ruff format --check` clean on all changed files.
- [x] Full `tests/retrieval/` suite: **100 passed** (no regression in agent_query / orchestrator / reranker / spawn_recall).

## Notes

- No external-service skill applies: fusion composes the already-ratified internal `orchestrator._hindsight_recall` read path (A3-c2 step 5-B cutover), not a new MCP/skill service — so no LAW XII/XIII skill update is required.
- No pre-filed bd/KEI issue for Wave 5 — flagging to Elliot for tracking.

Branched off `origin/main` (not the local shm-fix branch, which carried the un-squashed `ef7a70555`; #1247 squash-landed the same fix).