### PR TITLE
[SCOUT] feat(memory): atom granularity spec + CI validation gate (Agency_OS-3g9t, CUTOVER GATE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,29 @@ jobs:
         run: ./scripts/ci/check_no_raw_atom_store_outside_module.sh
 
   # ============================================
+  # Gate: Atom Granularity (Wave 1 CUTOVER GATE, Agency_OS-3g9t)
+  # ============================================
+  # Source: docs/architecture/atom_granularity_spec.md (Dave + Aiden + Viktor
+  # ratify 2026-05-27). Validates atom-shaped JSON/JSONL fixtures against the
+  # granularity spec (size bounds + single-concept heuristic + source-pointer).
+  # Runtime-enforced per GOV-12 (gate-as-code, not a comment). No-op exit 0
+  # until atom-shaped fixtures land; exit 1 on any violating atom.
+  atom-granularity-gate:
+    name: Atom Granularity Gate (Cutover)
+    runs-on: ubuntu-latest
+    needs: backend-lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Validate committed atoms against the granularity spec
+        run: python3 scripts/ci/check_atom_granularity.py --report
+
+  # ============================================
   # Guard: Composer-output isolation (atomization hard constraint)
   # ============================================
   # Source: ceo:atomization_architecture_v1 hard constraint #1 — "Composer

--- a/docs/architecture/atom_granularity_spec.md
+++ b/docs/architecture/atom_granularity_spec.md
@@ -1,0 +1,132 @@
+# Atom Granularity Spec v1
+
+**Owner:** Aiden (architecture lens) + Scout (initial draft, dispatched by Elliot 2026-05-27)
+**Status:** RATIFIED — Dave + Aiden + Viktor 2026-05-27 retrieval-design ratify
+**bd:** `Agency_OS-3g9t` — CUTOVER GATE (Wave 1 foundation, Aiden push-forward)
+**Filed under:** `docs/architecture/atom_granularity_spec.md`
+**Companion module:** `src/keiracom_system/memory/atom_granularity.py`
+**CI gate:** `scripts/ci/check_atom_granularity.py`
+
+## Canonical anchor (verbatim per audit-dispatch checklist)
+
+`ceo:cutover_plan_v1` — `full_retrieval_tier_ratify_2026_05_27_22Z.waves.wave_1_foundation`:
+
+> "Hindsight primitives complete (synthesize+trace+delete with source-atom pointers) + atom granularity spec + tenant scoping per-callsite + bounded-spawn dispatcher-kill + Go sidecar deploy + real-time invalidation"
+
+`ceo:memory_abstraction_layer_v1` — `eleven_agreed_positions #3`:
+
+> "Six query primitives: Ingest, Recall, Synthesize, Supersede, Trace, Delete"
+
+The retrieval primitives (PR #1228 / #1230 / #1234) are necessary but not sufficient. The DESIGN-2026-05-27 ratify also names atom granularity as a cutover-gating concern: "atom granularity matters as much as the retrieval pipeline". Too coarse and recall is noisy + reranker has to do too much work; too fine and one user query generates a fan-out of recall round-trips to reconstruct context.
+
+## §1 Scope
+
+**In scope:** programmatic granularity rules that every atom written to Hindsight (any wrapper — Decision / Artifact / TaskContext / AntiPattern) MUST satisfy before ingest. Cross-cuts the four MAL node types — applies uniformly to all of them.
+
+**Out of scope:**
+- Atom **schema** (field shape) — owned by `ceo:atomization_architecture_v1` + `docs/architecture/design/atomization_pilot_schema_lock_proposal.md` (Orion's atom-store schema).
+- LLM-driven atomization quality (Gemini Flash atomizer service) — Phase 2 atomization pilot scope.
+- Per-tenant override of granularity rules — Phase 2 follow-up; V1 is one rule-set fleet-wide.
+
+## §2 Granularity rules (RATIFIED V1)
+
+Every atom must satisfy ALL of the following or the validator returns `ok=False`. The CI gate fails the PR if any committed atom fixture (JSON/JSONL in scanned locations) violates the spec.
+
+### R1 — Content size bounds
+
+- **Min:** 50 characters of substantive content (after stripping whitespace).
+- **Max:** 2000 characters of substantive content.
+- **Why:** below 50 chars an atom carries less than one full thought (e.g. "yes", "Paris", a bare URL) — recall returns it without context. Above 2000 chars an atom usually contains multiple concepts and should be atomised further (R2). Token-equivalent at ~4 chars/token: roughly 12–500 tokens.
+
+### R2 — Single-concept rule
+
+Each atom should describe **one** fact, decision, observation, or anti-pattern. Heuristic checks (the validator is conservative — false negatives fine, false positives must be near-zero):
+
+- **R2.a:** content contains at most **5 sentences** (period-terminated). 6+ sentences is a strong "multi-concept" signal.
+- **R2.b:** content does not contain **more than one** of these multi-concept connectors at sentence boundaries: `". Additionally"`, `". Furthermore"`, `". Separately"`, `". On a different topic"`. One is fine — it's transitional; two or more flags as multi-concept.
+- **R2.c:** content does not contain **more than 3** distinct H2/H3 markdown headings (`## ...` / `### ...`). Document-shaped content is not atom-shaped.
+
+R2 is heuristic, not formal. The escape valve is the `single_concept_override: true` field — atoms tagged with that bypass R2 checks (audit-logged at validation site; reviewer must justify).
+
+### R3 — Source-pointer requirement
+
+Every atom must carry a non-empty `source_ref` (alias: `provenance.source`). Format is free-text but must be present + non-trivial (min 7 chars — accommodates `pr:NNNN`, `commit:7sha`, longer keys). Examples that satisfy:
+
+- `"pr:1228"` (GitHub PR)
+- `"commit:5c8c54e3e"` (git SHA)
+- `"slack:#ceo:2026-05-27T14:30Z"` (Slack channel + timestamp)
+- `"drive:1p9FAQGowy9SgwglIxtkGsMuvLsR70MJBQrCSY6Ie9ho:p3"` (Drive doc + page)
+- `"ceo:memory_abstraction_layer_v1"` (canonical ceo_memory key)
+
+Why: synthesize (`SynthesisResult.source_atom_ids`, PR #1228) only works if atoms themselves can be traced. An atom without a source pointer is a floating claim; the synthesis drift guard at the primitives layer catches the synthesis-level case, but the granularity layer must catch it earlier — at ingest.
+
+### R4 — Field-name canonicalisation
+
+The validator accepts both `source_ref` and `provenance.source` (nested dict). It does NOT accept ad-hoc field names (`origin`, `from`, `cited_from`, etc.) — canonical names only, so retrieval at the engine layer doesn't fan out on aliases.
+
+## §3 Validator API (Python)
+
+```python
+from src.keiracom_system.memory.atom_granularity import (
+    validate_atom,
+    GranularityViolation,
+    GranularityRules,
+)
+
+outcome = validate_atom(
+    {"content": "...", "source_ref": "pr:1228", "single_concept_override": False},
+    rules=GranularityRules(),  # defaults to V1 ratified
+)
+if not outcome.ok:
+    for v in outcome.violations:
+        log.error("atom %s violates %s: %s", outcome.atom_id, v.rule_id, v.detail)
+```
+
+`GranularityRules` is the policy object — same `dataclass(frozen=True)` pattern as `RecencyDecayConfig` (PR #1234). Fields:
+
+- `min_content_chars: int = 50`
+- `max_content_chars: int = 2000`
+- `max_sentences: int = 5`
+- `max_multi_concept_connectors: int = 1`
+- `max_h2_h3_headings: int = 3`
+- `min_source_ref_chars: int = 7`
+- `accepted_source_ref_keys: frozenset[str] = {"source_ref", "provenance.source"}`
+
+Tuning is Phase 2 empirical work (running the spec against the existing fleet corpus + measuring false-positive rate). V1 values are starting points.
+
+## §4 CI gate — `scripts/ci/check_atom_granularity.py`
+
+Scans configurable locations for atom-shaped JSON / JSONL files and validates each row. Exit codes mirror the existing CI gate pattern (`check_migration_manifest.py`):
+
+- **0** — all atoms pass OR no atoms found (no-op acceptable at V1; ramps up as atom-shaped fixtures are committed).
+- **1** — at least one atom violates the spec; gate FAILS.
+- **2** — config error (malformed JSON, scan location wrong).
+
+Default scan locations (override via env var `KEIRACOM_ATOM_SCAN_PATHS`):
+
+- `tests/keiracom_system/memory/fixtures/atoms/*.json` (none yet — placeholder for future test fixtures)
+- `tests/keiracom_system/memory/fixtures/atoms/*.jsonl`
+- `~/.claude/projects/-home-elliotbot-clawd-Agency-OS/memory/discovery_log.jsonl` (when present; per `CLAUDE.md` standing practice)
+
+The gate is **runtime executable**, not documentation-only (per **GOV-12 — Gates As Code**).
+
+## §5 Out-of-spec atoms — escape valves
+
+Two:
+
+1. **`single_concept_override: true`** on the atom — bypasses R2 only. R1 (size) and R3 (source) still enforced. Use case: an atom that genuinely is bigger than 5 sentences because the underlying fact is irreducible (e.g. a multi-step protocol). Reviewer must justify in the atom's metadata.
+2. **`granularity_exempt: true`** on the atom — bypasses R1, R2, R3 entirely. RARE — reserved for legacy backfill where atomising would destroy context. Reviewer + Aiden gate D approval required. Validator logs the exemption + emits a `keiracom.atom.granularity.exempt` metric.
+
+## §6 Definition of done
+
+- [x] Spec doc landed (this file).
+- [x] Programmatic validator in `src/keiracom_system/memory/atom_granularity.py`.
+- [x] CI gate in `scripts/ci/check_atom_granularity.py` — runtime executable (GOV-12).
+- [x] Test suite >=4 negatives per rule (Aiden gate-validator discipline).
+- [x] No live atom corpus required to run the validator (V1 ramps up; gate is no-op until atom-shaped fixtures land).
+
+## §7 Open questions (Phase 2)
+
+- **Tokeniser-based size bound** (use TEI BGE tokeniser instead of char count) — needs tokeniser plumbing in the validator. Phase 2.
+- **Per-topology granularity overrides** — codebase atoms (code excerpts) legitimately exceed 2000 chars; decisions are usually shorter. Phase 2 follows the same `topology->config` pattern as `recency_decay.DEFAULT_HALF_LIVES`.
+- **LLM-driven splitter** for atoms that violate R1.max — the Gemini Flash atomizer (atomization pilot Week 1) might be wired here. Phase 2.

--- a/scripts/ci/check_atom_granularity.py
+++ b/scripts/ci/check_atom_granularity.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""check_atom_granularity.py — CI gate enforcing the atom-granularity spec.
+
+Spec: docs/architecture/atom_granularity_spec.md (Agency_OS-3g9t, Wave 1
+CUTOVER GATE). Per GOV-12 ("Gates As Code, Not Comments") this is the
+runtime executable conditional, not documentation.
+
+Scans configurable locations for atom-shaped JSON / JSONL files and
+validates each row against the spec via
+`src.keiracom_system.memory.atom_granularity.validate_atom`. Mirrors the
+existing CI gate pattern (`scripts/ci/check_migration_manifest.py`):
+deterministic exit codes, --report mode for inspection, --paths to override
+scan locations.
+
+EXIT CODES:
+  0 — all atoms pass OR no atoms found in scan locations
+  1 — at least one atom violates the spec (gate FAILS)
+  2 — config error (malformed JSON, scan location wrong)
+
+USAGE:
+    python3 scripts/ci/check_atom_granularity.py
+    python3 scripts/ci/check_atom_granularity.py --report
+    python3 scripts/ci/check_atom_granularity.py --paths path1.jsonl,path2.json
+    KEIRACOM_ATOM_SCAN_PATHS=p1.jsonl:p2.json python3 scripts/ci/check_atom_granularity.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.keiracom_system.memory.atom_granularity import (  # noqa: E402
+    GranularityRules,
+    ValidationOutcome,
+    validate_atom,
+)
+
+DEFAULT_SCAN_PATHS: tuple[str, ...] = (
+    "tests/keiracom_system/memory/fixtures/atoms/*.json",
+    "tests/keiracom_system/memory/fixtures/atoms/*.jsonl",
+)
+SCAN_PATHS_ENV = "KEIRACOM_ATOM_SCAN_PATHS"
+
+
+def _resolve_paths(arg_paths: str | None) -> list[Path]:
+    """Resolve scan paths from --paths arg, env var, or defaults.
+
+    --paths beats env beats defaults. Globs are expanded against REPO_ROOT.
+    """
+    raw: list[str]
+    if arg_paths:
+        raw = [p.strip() for p in arg_paths.split(",") if p.strip()]
+    else:
+        env = os.environ.get(SCAN_PATHS_ENV, "")
+        raw = (
+            [p.strip() for p in env.replace(":", ",").split(",") if p.strip()]
+            if env
+            else list(DEFAULT_SCAN_PATHS)
+        )
+    out: list[Path] = []
+    for pattern in raw:
+        candidate = Path(pattern)
+        if candidate.is_absolute():
+            out.extend(sorted(candidate.parent.glob(candidate.name)))
+            continue
+        out.extend(sorted(REPO_ROOT.glob(pattern)))
+    return out
+
+
+def _load_atoms(path: Path) -> list[dict]:
+    """Load atoms from a JSON or JSONL file. Returns list[dict].
+
+    JSON file may be either a top-level list or a top-level dict with
+    `atoms` key. JSONL is one atom per line.
+    """
+    text = path.read_text(encoding="utf-8")
+    if path.suffix == ".jsonl":
+        out = []
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError as e:
+                raise RuntimeError(f"{path}:{line_no} JSON parse error: {e}") from e
+            if not isinstance(parsed, dict):
+                raise RuntimeError(f"{path}:{line_no} expected dict, got {type(parsed).__name__}")
+            out.append(parsed)
+        return out
+    # .json — array OR {atoms: [...]} OR {memories: [...]}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"{path} JSON parse error: {e}") from e
+    if isinstance(parsed, list):
+        return [p for p in parsed if isinstance(p, dict)]
+    if isinstance(parsed, dict):
+        for key in ("atoms", "memories", "rows"):
+            if key in parsed and isinstance(parsed[key], list):
+                return [p for p in parsed[key] if isinstance(p, dict)]
+    raise RuntimeError(
+        f"{path} unsupported JSON shape; expected list[dict] or {{atoms|memories|rows: list[dict]}}"
+    )
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _format_outcome(path: Path, idx: int, outcome: ValidationOutcome) -> str:
+    rules_listing = ", ".join(f"{v.rule_id}: {v.detail}" for v in outcome.violations)
+    return f"{_display_path(path)}[#{idx} atom_id={outcome.atom_id}] -> {rules_listing}"
+
+
+def _run(paths: list[Path], *, report: bool) -> int:
+    rules = GranularityRules()
+    total_atoms = 0
+    total_violations: list[str] = []
+    if not paths:
+        print(
+            "OK (atom-granularity): no atom-shaped fixtures found in scan paths — gate inactive.\n"
+            "Override scan paths via --paths or "
+            f"{SCAN_PATHS_ENV} env var."
+        )
+        return 0
+    for path in paths:
+        if not path.is_file():
+            continue
+        try:
+            atoms = _load_atoms(path)
+        except RuntimeError as e:
+            print(f"ERROR (atom-granularity): {e}", file=sys.stderr)
+            return 2
+        for idx, atom in enumerate(atoms):
+            total_atoms += 1
+            outcome = validate_atom(atom, rules=rules)
+            if not outcome.ok:
+                total_violations.append(_format_outcome(path, idx, outcome))
+            elif report:
+                print(
+                    f"OK {_display_path(path)}[#{idx} atom_id={outcome.atom_id}]"
+                    + (f" (exempt: {outcome.exempt_reason})" if outcome.exempt_reason else "")
+                )
+    if total_violations:
+        print(f"FAIL (atom-granularity): {len(total_violations)} atom(s) violate the spec:")
+        for line in total_violations:
+            print(f"  - {line}")
+        return 1
+    print(f"OK (atom-granularity): all {total_atoms} atom(s) pass.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0] if __doc__ else None)
+    parser.add_argument(
+        "--paths",
+        help=(
+            f"Comma-separated glob patterns (relative to repo root or absolute). "
+            f"Defaults: {','.join(DEFAULT_SCAN_PATHS)}. Env override: {SCAN_PATHS_ENV}."
+        ),
+    )
+    parser.add_argument(
+        "--report", action="store_true", help="print OK lines too, not only failures"
+    )
+    args = parser.parse_args(argv)
+    paths = _resolve_paths(args.paths)
+    return _run(paths, report=args.report)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/keiracom_system/memory/atom_granularity.py
+++ b/src/keiracom_system/memory/atom_granularity.py
@@ -1,0 +1,274 @@
+"""atom_granularity.py — programmatic validator for the atom-granularity spec.
+
+Spec: `docs/architecture/atom_granularity_spec.md` (Wave 1 CUTOVER GATE,
+Agency_OS-3g9t, Dave + Aiden + Viktor ratify 2026-05-27).
+
+Four rules every atom must satisfy or `validate_atom(...)` returns
+`ok=False` with the list of violated rule IDs:
+
+  R1 — content size bounds (50–2000 chars by default)
+  R2 — single-concept (max sentences + connector + heading heuristics)
+  R3 — source-pointer present + non-trivial
+  R4 — source-pointer field name is canonical (source_ref or provenance.source)
+
+Two escape valves:
+  - `single_concept_override: true` bypasses R2 only
+  - `granularity_exempt: true` bypasses R1/R2/R3 (Aiden gate D approval; logged)
+
+Canonical key citations (per audit-dispatch checklist `_orchestrator.md`):
+
+ceo:cutover_plan_v1 — full_retrieval_tier_ratify_2026_05_27_22Z.waves.wave_1_foundation:
+    "Hindsight primitives complete (synthesize+trace+delete with source-atom
+     pointers) + atom granularity spec + tenant scoping per-callsite + ..."
+
+ceo:memory_abstraction_layer_v1 — eleven_agreed_positions #3:
+    "Six query primitives: Ingest, Recall, Synthesize, Supersede, Trace, Delete"
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# Multi-concept connectors that strongly signal "this atom describes two
+# different things". One is usually transitional and fine; two or more is
+# a multi-concept smell. Period-terminated to anchor at sentence boundary.
+DEFAULT_MULTI_CONCEPT_CONNECTORS: tuple[str, ...] = (
+    ". Additionally",
+    ". Furthermore",
+    ". Separately",
+    ". On a different topic",
+    ". Unrelated to the above",
+    ". In other news",
+)
+
+
+@dataclass(frozen=True)
+class GranularityRules:
+    """Policy object — V1 defaults are the ratified starting points.
+
+    Production deploys override per-tenant once tenant-config plumbing is
+    ready (Phase 2). Per-topology overrides similarly Phase 2.
+    """
+
+    min_content_chars: int = 50
+    max_content_chars: int = 2000
+    max_sentences: int = 5
+    max_multi_concept_connectors: int = 1
+    max_h2_h3_headings: int = 3
+    min_source_ref_chars: int = 7
+    accepted_source_ref_keys: frozenset[str] = frozenset({"source_ref", "provenance.source"})
+    multi_concept_connectors: tuple[str, ...] = DEFAULT_MULTI_CONCEPT_CONNECTORS
+
+
+@dataclass(frozen=True)
+class GranularityViolation:
+    rule_id: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class ValidationOutcome:
+    ok: bool
+    atom_id: str
+    violations: list[GranularityViolation] = field(default_factory=list)
+    exempt_reason: str = ""
+    schema_version: str = "1.0"
+
+
+def _extract_source_ref(atom: dict[str, Any], rules: GranularityRules) -> str:
+    """Pull the source pointer from any accepted field name.
+
+    Accepts `source_ref` (string) or `provenance.source` (nested dict.source).
+    Other field names (`origin`, `from`, `cited_from`) are NOT accepted —
+    canonical names only (R4).
+    """
+    for key in rules.accepted_source_ref_keys:
+        if "." in key:
+            head, tail = key.split(".", 1)
+            nested = atom.get(head)
+            if isinstance(nested, dict):
+                v = nested.get(tail)
+                if isinstance(v, str) and v.strip():
+                    return v.strip()
+        else:
+            v = atom.get(key)
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+    return ""
+
+
+def _count_sentences(content: str) -> int:
+    """Approximate sentence count via period/?/! terminators.
+
+    Defensive: collapses repeated punctuation ("..." counted as one) so
+    code/list content doesn't inflate the count.
+    """
+    # Treat any cluster of .?! as one terminator.
+    normalised = re.sub(r"[.?!]+", ".", content)
+    parts = [p for p in normalised.split(".") if p.strip()]
+    return len(parts)
+
+
+def _count_multi_concept_connectors(content: str, connectors: tuple[str, ...]) -> int:
+    """Sum occurrences of the multi-concept connector strings."""
+    return sum(content.count(c) for c in connectors)
+
+
+def _count_h2_h3_headings(content: str) -> int:
+    """Count lines starting with ## or ### (markdown H2 / H3)."""
+    n = 0
+    for line in content.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("###") or (
+            stripped.startswith("##") and not stripped.startswith("###")
+        ):
+            n += 1
+    return n
+
+
+def validate_atom(
+    atom: dict[str, Any], *, rules: GranularityRules | None = None
+) -> ValidationOutcome:
+    """Apply the granularity spec to one atom. Returns ValidationOutcome.
+
+    Atom shape — only the relevant fields are inspected:
+      - `id` (or `atom_id` / `memory_id`) — identifier for reporting
+      - `content` — the atom payload (string)
+      - `source_ref` OR `provenance.source` — source pointer (R3/R4)
+      - `single_concept_override: bool` — R2 escape
+      - `granularity_exempt: bool` — all-rules escape (gated)
+    """
+    if not isinstance(atom, dict):
+        raise ValueError(f"atom must be dict, got {type(atom).__name__}")
+    if rules is None:
+        rules = GranularityRules()
+    atom_id = str(atom.get("id") or atom.get("atom_id") or atom.get("memory_id") or "<no-id>")
+
+    if atom.get("granularity_exempt") is True:
+        log.warning(
+            "atom %s granularity_exempt=true — bypassing all rules (Aiden gate D approval required)",
+            atom_id,
+        )
+        return ValidationOutcome(ok=True, atom_id=atom_id, exempt_reason="granularity_exempt")
+
+    content_raw = atom.get("content")
+    if not isinstance(content_raw, str):
+        return ValidationOutcome(
+            ok=False,
+            atom_id=atom_id,
+            violations=[
+                GranularityViolation(rule_id="R0", detail="content missing or not a string")
+            ],
+        )
+    content = content_raw.strip()
+    violations: list[GranularityViolation] = []
+
+    # R1 — content size bounds
+    n_chars = len(content)
+    if n_chars < rules.min_content_chars:
+        violations.append(
+            GranularityViolation(
+                rule_id="R1.min",
+                detail=f"content has {n_chars} chars; min {rules.min_content_chars}",
+            )
+        )
+    if n_chars > rules.max_content_chars:
+        violations.append(
+            GranularityViolation(
+                rule_id="R1.max",
+                detail=f"content has {n_chars} chars; max {rules.max_content_chars}",
+            )
+        )
+
+    # R2 — single-concept heuristics (skipped if override set)
+    if not atom.get("single_concept_override"):
+        n_sentences = _count_sentences(content)
+        if n_sentences > rules.max_sentences:
+            violations.append(
+                GranularityViolation(
+                    rule_id="R2.a",
+                    detail=f"content has {n_sentences} sentences; max {rules.max_sentences}",
+                )
+            )
+        n_connectors = _count_multi_concept_connectors(content, rules.multi_concept_connectors)
+        if n_connectors > rules.max_multi_concept_connectors:
+            violations.append(
+                GranularityViolation(
+                    rule_id="R2.b",
+                    detail=(
+                        f"content has {n_connectors} multi-concept connectors; "
+                        f"max {rules.max_multi_concept_connectors}"
+                    ),
+                )
+            )
+        n_headings = _count_h2_h3_headings(content)
+        if n_headings > rules.max_h2_h3_headings:
+            violations.append(
+                GranularityViolation(
+                    rule_id="R2.c",
+                    detail=(
+                        f"content has {n_headings} H2/H3 headings; "
+                        f"max {rules.max_h2_h3_headings} (document-shaped, not atom-shaped)"
+                    ),
+                )
+            )
+
+    # R3 + R4 — source-pointer present, non-trivial, canonical name
+    source_ref = _extract_source_ref(atom, rules)
+    if not source_ref:
+        # Distinguish "field missing entirely" (R4) from "field present but short" (R3).
+        any_known_field_present = any(
+            atom.get(k) for k in rules.accepted_source_ref_keys if "." not in k
+        ) or (isinstance(atom.get("provenance"), dict) and atom["provenance"].get("source"))
+        if not any_known_field_present:
+            violations.append(
+                GranularityViolation(
+                    rule_id="R4",
+                    detail=(
+                        "no canonical source-pointer field present (accepted: "
+                        f"{sorted(rules.accepted_source_ref_keys)})"
+                    ),
+                )
+            )
+        else:
+            violations.append(
+                GranularityViolation(
+                    rule_id="R3",
+                    detail=(
+                        f"source-pointer present but shorter than "
+                        f"{rules.min_source_ref_chars} chars"
+                    ),
+                )
+            )
+    elif len(source_ref) < rules.min_source_ref_chars:
+        violations.append(
+            GranularityViolation(
+                rule_id="R3",
+                detail=(
+                    f"source-pointer {source_ref!r} is {len(source_ref)} chars; "
+                    f"min {rules.min_source_ref_chars}"
+                ),
+            )
+        )
+
+    return ValidationOutcome(
+        ok=not violations,
+        atom_id=atom_id,
+        violations=violations,
+        exempt_reason="single_concept_override" if atom.get("single_concept_override") else "",
+    )
+
+
+def validate_atoms(
+    atoms: list[dict[str, Any]], *, rules: GranularityRules | None = None
+) -> list[ValidationOutcome]:
+    """Convenience batch validator — applies validate_atom to each row."""
+    if not isinstance(atoms, list):
+        raise ValueError(f"atoms must be list, got {type(atoms).__name__}")
+    return [validate_atom(a, rules=rules) for a in atoms]

--- a/tests/keiracom_system/memory/test_atom_granularity.py
+++ b/tests/keiracom_system/memory/test_atom_granularity.py
@@ -1,0 +1,315 @@
+"""tests for keiracom_system.memory.atom_granularity — Wave 1 CUTOVER GATE 3g9t.
+
+Coverage matrix (Aiden gate-validator discipline: >=4 negatives per rule):
+- R1 size bounds      — 2 positive + 4 negative
+- R2 single-concept   — 4 positive + 5 negative
+- R3 source-pointer   — 3 positive + 4 negative
+- R4 canonical fields — 2 positive + 3 negative
+- escape valves       — 4 scenarios
+- batch validator     — 2 scenarios
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.keiracom_system.memory.atom_granularity import (
+    GranularityRules,
+    ValidationOutcome,
+    validate_atom,
+    validate_atoms,
+)
+
+
+def _atom(content: str, **extras):
+    base = {"id": "atom-1", "content": content, "source_ref": "pr:1228"}
+    base.update(extras)
+    return base
+
+
+# ============== R1 — size bounds ==============
+
+
+def test_r1_atom_with_content_in_bounds_passes():
+    out = validate_atom(_atom("X" * 200))
+    assert out.ok
+    assert out.violations == []
+
+
+def test_r1_atom_at_exact_min_chars_passes():
+    out = validate_atom(_atom("X" * 50))
+    assert out.ok
+
+
+def test_r1_min_violation_below_50_chars():
+    out = validate_atom(_atom("short"))
+    assert not out.ok
+    assert any(v.rule_id == "R1.min" for v in out.violations)
+
+
+def test_r1_max_violation_above_2000_chars():
+    out = validate_atom(_atom("X" * 2001))
+    assert not out.ok
+    assert any(v.rule_id == "R1.max" for v in out.violations)
+
+
+def test_r1_strips_whitespace_before_counting():
+    # 50 X's surrounded by whitespace must pass; whitespace doesn't pad.
+    out = validate_atom(_atom("   " + "X" * 50 + "   "))
+    assert out.ok
+    out_bad = validate_atom(_atom("   " + "X" * 10 + "   "))
+    assert not out_bad.ok
+    assert any(v.rule_id == "R1.min" for v in out_bad.violations)
+
+
+def test_r1_custom_rules_can_relax_bounds():
+    rules = GranularityRules(min_content_chars=10, max_content_chars=20)
+    assert validate_atom(_atom("X" * 15), rules=rules).ok
+    assert not validate_atom(_atom("X" * 25), rules=rules).ok
+
+
+# ============== R2 — single-concept heuristics ==============
+
+
+def test_r2_atom_with_three_short_sentences_passes():
+    out = validate_atom(_atom("One sentence. Another sentence. A third short one for context."))
+    assert out.ok
+
+
+def test_r2_violation_too_many_sentences():
+    content = ". ".join(f"Statement number {i} carries enough words to count" for i in range(6))
+    out = validate_atom(_atom(content + "."))
+    assert not out.ok
+    assert any(v.rule_id == "R2.a" for v in out.violations)
+
+
+def test_r2_violation_too_many_multi_concept_connectors():
+    content = (
+        "We migrated to Hindsight as the MAL engine in V1 architecture. "
+        "Additionally, we adopted Weaviate. "
+        "Furthermore, the Valkey cache went in for tool calls."
+    )
+    out = validate_atom(_atom(content))
+    assert not out.ok
+    assert any(v.rule_id == "R2.b" for v in out.violations)
+
+
+def test_r2_single_connector_is_fine_transitional():
+    content = (
+        "We migrated to Hindsight as the MAL engine in V1 architecture. "
+        "Additionally, the wrapper layer ships in PR #1134."
+    )
+    out = validate_atom(_atom(content))
+    # One connector is transitional, not multi-concept.
+    assert out.ok or not any(v.rule_id == "R2.b" for v in out.violations)
+
+
+def test_r2_violation_too_many_h2_h3_headings():
+    content = (
+        "## Section A\n"
+        "Body lines that bring this above the fifty char min comfortably indeed.\n"
+        "## Section B\n"
+        "More body content also helping the size minimum requirement here too.\n"
+        "## Section C\n"
+        "Final body content padding so the size rule is comfortably above min.\n"
+        "## Section D\n"
+        "And one more block of body content to keep this beyond the floor."
+    )
+    out = validate_atom(_atom(content))
+    assert not out.ok
+    assert any(v.rule_id == "R2.c" for v in out.violations)
+
+
+def test_r2_collapses_repeated_punctuation_so_ellipsis_doesnt_inflate():
+    # "..." was counted as multiple sentence terminators in a naive impl;
+    # the validator must collapse repeated . to one terminator.
+    content = "First thought... second... third... fourth fact lands here."
+    out = validate_atom(_atom(content))
+    # Should NOT trigger R2.a — collapsed sentence count is <=5.
+    assert not any(v.rule_id == "R2.a" for v in out.violations)
+
+
+def test_r2_skipped_when_single_concept_override_true():
+    content = ". ".join(f"Statement number {i} carries enough words" for i in range(10)) + "."
+    out = validate_atom(_atom(content, single_concept_override=True))
+    # R2 entirely bypassed; R1 still applies but content is large enough to pass.
+    assert out.exempt_reason == "single_concept_override"
+    assert not any(v.rule_id.startswith("R2") for v in out.violations)
+
+
+def test_r2_h2_headings_caps_at_3_default():
+    content = (
+        "## A\n"
+        "Body content here that's at least fifty chars long for the size rule yes.\n"
+        "## B\n"
+        "More body content also above minimum required size for the size rule.\n"
+        "## C\n"
+        "Final body content keeping us above the minimum size requirement now ok."
+    )
+    out = validate_atom(_atom(content))
+    # 3 headings is exactly the cap; should NOT fail R2.c.
+    assert not any(v.rule_id == "R2.c" for v in out.violations)
+
+
+# ============== R3 — source-pointer non-trivial ==============
+
+
+def test_r3_pr_source_ref_passes():
+    out = validate_atom(_atom("X" * 100, source_ref="pr:1228"))
+    assert out.ok
+
+
+def test_r3_commit_sha_source_ref_passes():
+    out = validate_atom(_atom("X" * 100, source_ref="commit:5c8c54e3e"))
+    assert out.ok
+
+
+def test_r3_ceo_memory_key_source_ref_passes():
+    out = validate_atom(_atom("X" * 100, source_ref="ceo:memory_abstraction_layer_v1"))
+    assert out.ok
+
+
+def test_r3_violation_source_ref_too_short():
+    out = validate_atom(_atom("X" * 100, source_ref="pr:1"))
+    assert not out.ok
+    assert any(v.rule_id == "R3" for v in out.violations)
+
+
+def test_r3_violation_source_ref_empty_string():
+    atom = {"id": "a1", "content": "X" * 100, "source_ref": ""}
+    out = validate_atom(atom)
+    assert not out.ok
+    # Empty string is treated as "field present but trivial" or "field absent"
+    # depending on falsy check — both are violations.
+    assert any(v.rule_id in {"R3", "R4"} for v in out.violations)
+
+
+def test_r3_violation_source_ref_missing_entirely():
+    atom = {"id": "a1", "content": "X" * 100}
+    out = validate_atom(atom)
+    assert not out.ok
+    assert any(v.rule_id == "R4" for v in out.violations)
+
+
+def test_r3_provenance_source_nested_field_accepted():
+    # Alias: nested provenance.source must be accepted too.
+    atom = {
+        "id": "a1",
+        "content": "X" * 100,
+        "provenance": {"source": "drive:1p9F:p3"},
+    }
+    out = validate_atom(atom)
+    assert out.ok
+
+
+# ============== R4 — canonical field names ==============
+
+
+def test_r4_ad_hoc_field_name_origin_not_accepted():
+    atom = {"id": "a1", "content": "X" * 100, "origin": "pr:1228"}
+    out = validate_atom(atom)
+    assert not out.ok
+    assert any(v.rule_id == "R4" for v in out.violations)
+
+
+def test_r4_ad_hoc_field_name_from_not_accepted():
+    atom = {"id": "a1", "content": "X" * 100, "from": "pr:1228"}
+    out = validate_atom(atom)
+    assert not out.ok
+    assert any(v.rule_id == "R4" for v in out.violations)
+
+
+def test_r4_ad_hoc_field_name_cited_from_not_accepted():
+    atom = {"id": "a1", "content": "X" * 100, "cited_from": "pr:1228"}
+    out = validate_atom(atom)
+    assert not out.ok
+    assert any(v.rule_id == "R4" for v in out.violations)
+
+
+def test_r4_custom_rules_can_widen_accepted_keys():
+    rules = GranularityRules(accepted_source_ref_keys=frozenset({"source_ref", "origin"}))
+    atom = {"id": "a1", "content": "X" * 100, "origin": "pr:1228"}
+    out = validate_atom(atom, rules=rules)
+    assert out.ok
+
+
+# ============== Escape valves ==============
+
+
+def test_granularity_exempt_bypasses_all_rules():
+    atom = {
+        "id": "a1",
+        "content": "x",  # would fail R1
+        "origin": "weird",  # would fail R4
+        "granularity_exempt": True,
+    }
+    out = validate_atom(atom)
+    assert out.ok
+    assert out.exempt_reason == "granularity_exempt"
+    assert out.violations == []
+
+
+def test_single_concept_override_does_NOT_bypass_r1():
+    # R2 escape only — R1 and R3 still enforced.
+    atom = {"id": "a1", "content": "tiny", "source_ref": "pr:1228", "single_concept_override": True}
+    out = validate_atom(atom)
+    assert not out.ok
+    assert any(v.rule_id == "R1.min" for v in out.violations)
+
+
+def test_single_concept_override_does_NOT_bypass_r3():
+    atom = {"id": "a1", "content": "X" * 100, "single_concept_override": True}
+    out = validate_atom(atom)
+    assert not out.ok
+    assert any(v.rule_id == "R4" for v in out.violations)
+
+
+def test_granularity_exempt_logged_at_warning_level(caplog):
+    import logging
+
+    atom = {"id": "audit-bypass", "content": "x", "granularity_exempt": True}
+    with caplog.at_level(logging.WARNING):
+        validate_atom(atom)
+    assert any("granularity_exempt=true" in r.message for r in caplog.records)
+
+
+# ============== Validator-level negatives ==============
+
+
+def test_validate_atom_rejects_non_dict_input():
+    with pytest.raises(ValueError, match="atom must be dict"):
+        validate_atom("not a dict")  # type: ignore[arg-type]
+
+
+def test_validate_atom_handles_missing_content():
+    out = validate_atom({"id": "a1", "source_ref": "pr:1228"})
+    assert not out.ok
+    assert any(v.rule_id == "R0" for v in out.violations)
+
+
+def test_validate_atom_returns_outcome_dataclass():
+    out = validate_atom(_atom("X" * 100))
+    assert isinstance(out, ValidationOutcome)
+    assert out.schema_version == "1.0"
+
+
+# ============== Batch validator ==============
+
+
+def test_validate_atoms_processes_each_row():
+    outs = validate_atoms(
+        [
+            _atom("X" * 100),
+            _atom("short"),  # R1.min violation
+            _atom("X" * 100, source_ref="pr:1"),  # R3 violation
+        ]
+    )
+    assert len(outs) == 3
+    assert outs[0].ok
+    assert not outs[1].ok
+    assert not outs[2].ok
+
+
+def test_validate_atoms_rejects_non_list_input():
+    with pytest.raises(ValueError, match="atoms must be list"):
+        validate_atoms({"id": "a1"})  # type: ignore[arg-type]

--- a/tests/scripts/ci/test_check_atom_granularity.py
+++ b/tests/scripts/ci/test_check_atom_granularity.py
@@ -1,0 +1,148 @@
+"""Tests for scripts/ci/check_atom_granularity.py — the atom-granularity CI gate.
+
+Wave 1 CUTOVER GATE (Agency_OS-3g9t, Dave + Aiden + Viktor ratify 2026-05-27).
+
+The validator MODULE (`src/keiracom_system/memory/atom_granularity.py`) is
+unit-tested in `tests/keiracom_system/memory/test_atom_granularity.py`. THIS
+file tests the gate SCRIPT end-to-end — file discovery, JSON/JSONL loading,
+the three exit codes (0 pass / 1 violation / 2 config error), --report, and
+the env-var path override — via subprocess, exactly as CI invokes it. Mirrors
+the sibling pattern in `test_check_migration_manifest.py` (negative-path
+discipline: every rule gets a synthetic offender asserting the exact code).
+
+Dispatch deliverable #3 named `tests/ci/test_atom_granularity_check.py`; this
+lives at the established CI-script test home `tests/scripts/ci/` next to
+`test_check_migration_manifest.py` (the gate this one mirrors) rather than
+spawning an orphan `tests/ci/` directory.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts/ci/check_atom_granularity.py"
+
+# Synthetic fixtures.
+GOOD_ATOM = {"id": "good-1", "content": "X" * 120, "source_ref": "pr:1228"}
+BAD_ATOM = {"id": "bad-1", "content": "short", "source_ref": "pr:1228"}  # R1.min
+EXEMPT_ATOM = {"id": "ex-1", "content": "tiny", "granularity_exempt": True}
+
+
+def _run(*paths: str, report: bool = False, env: dict | None = None) -> tuple[int, str, str]:
+    args = [sys.executable, str(SCRIPT)]
+    if paths:
+        args += ["--paths", ",".join(paths)]
+    if report:
+        args.append("--report")
+    cp = subprocess.run(args, capture_output=True, text=True, timeout=30, check=False, env=env)
+    return cp.returncode, cp.stdout, cp.stderr
+
+
+def _write(path: Path, obj) -> Path:
+    path.write_text(json.dumps(obj), encoding="utf-8")
+    return path
+
+
+# ── exit codes ───────────────────────────────────────────────────────────────
+
+
+def test_no_fixtures_is_noop_exit_0(tmp_path):
+    rc, out, _ = _run(str(tmp_path / "*.json"))
+    assert rc == 0, out
+    assert "gate inactive" in out
+
+
+def test_all_atoms_pass_exit_0(tmp_path):
+    f = _write(tmp_path / "atoms.json", [GOOD_ATOM, GOOD_ATOM])
+    rc, out, _ = _run(str(f))
+    assert rc == 0, out
+
+
+def test_single_violation_exit_1(tmp_path):
+    f = _write(tmp_path / "atoms.json", [GOOD_ATOM, BAD_ATOM])
+    rc, out, _ = _run(str(f))
+    assert rc == 1
+    assert "R1.min" in out
+
+
+def test_malformed_json_exit_2(tmp_path):
+    f = tmp_path / "atoms.json"
+    f.write_text("{ not valid json", encoding="utf-8")
+    rc, _out, err = _run(str(f))
+    assert rc == 2
+    assert "ERROR" in err
+
+
+def test_unsupported_json_shape_exit_2(tmp_path):
+    f = _write(tmp_path / "atoms.json", "just a bare string")
+    rc, _out, err = _run(str(f))
+    assert rc == 2
+    assert "unsupported JSON shape" in err
+
+
+# ── JSONL handling ─────────────────────────────────────────────────────────────
+
+
+def test_jsonl_violation_exit_1(tmp_path):
+    f = tmp_path / "atoms.jsonl"
+    f.write_text(json.dumps(GOOD_ATOM) + "\n" + json.dumps(BAD_ATOM) + "\n", encoding="utf-8")
+    rc, out, _ = _run(str(f))
+    assert rc == 1
+    assert "R1.min" in out
+
+
+def test_jsonl_skips_blank_and_comment_lines_exit_0(tmp_path):
+    f = tmp_path / "atoms.jsonl"
+    f.write_text("\n  \n# a comment line\n" + json.dumps(GOOD_ATOM) + "\n", encoding="utf-8")
+    rc, out, _ = _run(str(f))
+    assert rc == 0, out
+
+
+# ── JSON wrapper shapes ─────────────────────────────────────────────────────────
+
+
+def test_json_atoms_key_wrapper_passes(tmp_path):
+    f = _write(tmp_path / "atoms.json", {"atoms": [GOOD_ATOM]})
+    rc, out, _ = _run(str(f))
+    assert rc == 0, out
+
+
+def test_json_memories_key_wrapper_detects_violation(tmp_path):
+    f = _write(tmp_path / "m.json", {"memories": [BAD_ATOM]})
+    rc, out, _ = _run(str(f))
+    assert rc == 1
+    assert "R1.min" in out
+
+
+# ── escape valve flows through the gate ─────────────────────────────────────────
+
+
+def test_granularity_exempt_atom_passes_gate(tmp_path):
+    f = _write(tmp_path / "atoms.json", [EXEMPT_ATOM])
+    rc, out, _ = _run(str(f))
+    assert rc == 0, out
+
+
+# ── --report + env-var override ─────────────────────────────────────────────────
+
+
+def test_report_mode_prints_ok_lines(tmp_path):
+    f = _write(tmp_path / "atoms.json", [GOOD_ATOM])
+    rc, out, _ = _run(str(f), report=True)
+    assert rc == 0
+    assert "OK" in out and "good-1" in out
+
+
+def test_env_var_path_override_detects_violation(tmp_path):
+    import os
+
+    f = _write(tmp_path / "atoms.json", [BAD_ATOM])
+    env = dict(os.environ)
+    env["KEIRACOM_ATOM_SCAN_PATHS"] = str(f)
+    rc, out, _ = _run(env=env)  # no --paths → env drives the scan
+    assert rc == 1
+    assert "R1.min" in out


### PR DESCRIPTION
## Summary
Wave 1 **CUTOVER GATE** (Dave + Aiden + Viktor ratify 2026-05-27, `Agency_OS-3g9t`): defines the canonical spec for what makes a good atom and enforces it in CI. Memory-quality discipline embedded in the process so the corpus can't drift toward noise.

## Deliverables
1. **`docs/architecture/atom_granularity_spec.md`** — canonical rules: **R1** size bounds (50–2000 chars), **R2** single-concept heuristic (≤5 sentences / ≤1 multi-concept connector / ≤3 H2-H3 headings), **R3** source-pointer required + non-trivial, **R4** canonical field names. Two escape valves (`single_concept_override`, `granularity_exempt`). Cites `ceo:cutover_plan_v1` + `ceo:memory_abstraction_layer_v1` per the audit-dispatch checklist.
2. **`src/keiracom_system/memory/atom_granularity.py`** — programmatic validator (`validate_atom`/`validate_atoms`, frozen `GranularityRules` policy object). Conservative heuristics: false-negatives fine, false-positives near-zero.
3. **`scripts/ci/check_atom_granularity.py`** — CI gate scanning atom-shaped JSON/JSONL. Exit **0** pass/no-op · **1** violation · **2** config error. Mirrors `check_migration_manifest.py`.
4. **`.github/workflows/ci.yml`** — `atom-granularity-gate` job so the gate actually runs in CI (**GOV-12: runtime-enforced, not a comment**). No-op until atom-shaped fixtures land; fails on any violating atom.
5. **Tests** — `tests/keiracom_system/memory/test_atom_granularity.py` (34 module unit tests, ≥4 negatives per rule) + `tests/scripts/ci/test_check_atom_granularity.py` (12 gate-SCRIPT integration tests via subprocess: synthetic pass+fail, all 3 exit codes, JSONL, wrapper shapes, `--report`, env-var override).

## Verification (raw)
- `pytest tests/keiracom_system/memory/test_atom_granularity.py tests/scripts/ci/test_check_atom_granularity.py` → **46 passed**.
- `python3 scripts/ci/check_atom_granularity.py` → `OK (atom-granularity): no atom-shaped fixtures found — gate inactive`, exit 0.
- `ruff check` + `ruff format --check` → clean on all 4 python files.
- YAML valid; `atom-granularity-gate` job registered.

## DIRECTIVE SCRUTINY — 1 gap found, resolved in-PR (GOV-10)
**Most of this work already existed as uncommitted files from an interrupted prior session on this exact KEI** (the local `scout/3g9t-atom-granularity-spec` branch had 0 commits ahead of main; the 4 files sat untracked in the worktree; `bd Agency_OS-3g9t` still OPEN/P0 — not duplicated or merged). Rather than rebuild (waste + regression risk), I **verified the existing spec + validator + module tests + check script are complete and green, then committed them**, and **added the two genuinely-missing pieces**: the gate-SCRIPT integration test (dispatch deliverable #3) and the `ci.yml` wiring that makes deliverable #2 actually fail CI.

## Path deviation (noted)
- Dispatch named the test `tests/ci/test_atom_granularity_check.py`. Placed instead at **`tests/scripts/ci/test_check_atom_granularity.py`** — the established CI-script test home, next to `test_check_migration_manifest.py` (the gate this one mirrors) — rather than spawning an orphan `tests/ci/` dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)