### PR TITLE
[ATLAS] fix(security): scrub CRLF in 5 CodeQL py/log-injection sinks

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -60,6 +60,7 @@ from src.relay.budget_ceiling import (
 )
 from src.retrieval import spawn_recall
 from src.retrieval.workflow_recall import CHARS_PER_TOKEN, WorkflowRecallContext
+from src.utils.log_safe import scrub
 
 logger = logging.getLogger(__name__)
 
@@ -676,8 +677,8 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
         if enforcement.decision == DECISION_VIOLATION:
             logger.error(
                 "bounded-spawn violation: callsign=%s new_task=%s prior_task=%s killed=%s",
-                callsign,
-                task_id,
+                scrub(callsign),
+                scrub(task_id),
                 enforcement.prior.task_id if enforcement.prior else None,
                 enforcement.killed,
             )

--- a/src/retrieval/agent_query.py
+++ b/src/retrieval/agent_query.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from src.retrieval import hyde, multi_query, orchestrator
+from src.utils.log_safe import scrub
 
 logger = logging.getLogger(__name__)
 
@@ -73,8 +74,11 @@ def _record_event(
     audit trail.
     """
     payload = {
-        "agent": agent,
-        "query_text": query_text[:QUERY_TEXT_LOG_CAP],
+        # scrub() neutralises CR/LF in the agent + query before they reach the
+        # log sink (CodeQL py/log-injection); the audit row stores the same
+        # single-line form. Other fields are ints/bools/fixed names — not tainted.
+        "agent": scrub(agent),
+        "query_text": scrub(query_text, QUERY_TEXT_LOG_CAP),
         "collections": list(collections),
         "k_initial": k_initial,
         "k_returned": k_returned,
@@ -254,8 +258,8 @@ def query(
         logger.warning(
             "retrieval scores all 0.0 — vectorizer-regression sentinel (KEI-198) "
             "agent=%s text=%s collections=%s",
-            agent,
-            text[:QUERY_TEXT_LOG_CAP],
+            scrub(agent),
+            scrub(text, QUERY_TEXT_LOG_CAP),
             collections,
         )
     if citation_required and all_zero:

--- a/src/retrieval/workflow_recall.py
+++ b/src/retrieval/workflow_recall.py
@@ -27,6 +27,8 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from src.utils.log_safe import scrub
+
 logger = logging.getLogger(__name__)
 
 CHARS_PER_TOKEN = 4  # matches src/retrieval/agent_query token approximation
@@ -85,7 +87,9 @@ class WorkflowRecallContext:
         try:
             recalled = recall_fn() or ""
         except Exception:  # noqa: BLE001 — recall must never block the spawn
-            logger.exception("workflow_recall: recall_fn raised for workflow_id=%s", workflow_id)
+            logger.exception(
+                "workflow_recall: recall_fn raised for workflow_id=%s", scrub(workflow_id)
+            )
             return RecallOutcome(context="", cached=False)
         context = self._cap(str(recalled))
         self._store[workflow_id] = _Entry(context=context, stored_at=now)

--- a/src/utils/log_safe.py
+++ b/src/utils/log_safe.py
@@ -1,0 +1,21 @@
+"""CRLF / log-injection scrubber for untrusted values headed to a logger.
+
+CodeQL py/log-injection flags user-controlled data reaching a logging call:
+embedded CR/LF lets an attacker forge or split log lines. ``scrub`` escapes the
+line breaks and bounds length. The ``.replace()`` of ``\\r`` and ``\\n`` is the
+barrier CodeQL's taint tracking recognises, so wrapping a tainted value in
+``scrub(...)`` at the log sink clears the finding.
+"""
+
+from __future__ import annotations
+
+LOG_VALUE_CAP = 200
+
+
+def scrub(value: object, limit: int = LOG_VALUE_CAP) -> str:
+    """Return a single-line, length-bounded string safe to log.
+
+    Coerces to ``str``, escapes CR and LF to their literal two-char forms so a
+    crafted value can't inject extra log lines, then truncates to ``limit``.
+    """
+    return str(value).replace("\r", "\\r").replace("\n", "\\n")[:limit]

--- a/tests/utils/test_log_safe.py
+++ b/tests/utils/test_log_safe.py
@@ -1,0 +1,33 @@
+"""Tests for src/utils/log_safe.scrub — the CRLF/log-injection barrier."""
+
+from __future__ import annotations
+
+from src.utils.log_safe import LOG_VALUE_CAP, scrub
+
+
+def test_escapes_newline_and_carriage_return():
+    out = scrub("line1\nline2\r\nINJECTED 200 OK")
+    assert "\n" not in out
+    assert "\r" not in out
+    assert "\\n" in out
+    assert "\\r" in out
+
+
+def test_coerces_non_str():
+    assert scrub(12345) == "12345"
+    assert scrub(None) == "None"
+
+
+def test_truncates_to_limit():
+    assert len(scrub("x" * 500)) == LOG_VALUE_CAP
+    assert len(scrub("x" * 500, limit=10)) == 10
+
+
+def test_clean_value_unchanged():
+    assert scrub("atlas") == "atlas"
+
+
+def test_crlf_attack_collapses_to_single_line():
+    # A forged second log line must not survive as an actual newline.
+    payload = "ok\nERROR fake-breach detected"
+    assert "\n" not in scrub(payload)


### PR DESCRIPTION
## Summary

Fixes the 5 CodeQL **py/log-injection** findings (error severity) named in Elliot's dispatch (alerts #994–998). User-controlled values were reaching `logger.*` calls with embedded CR/LF intact — a crafted value could forge or split log lines.

New helper **`src/utils/log_safe.scrub()`** escapes `\r`/`\n` to their literal two-char forms and bounds length. The `.replace()` of the line-break chars is the barrier CodeQL's taint tracking recognises, so wrapping a tainted value in `scrub(...)` at the sink clears the finding.

## Sinks fixed

| Alert | File | Sink | Tainted value(s) |
|-------|------|------|------------------|
| #998 | `src/retrieval/workflow_recall.py` | recall-failure `logger.exception` | `workflow_id` |
| #996 | `src/retrieval/agent_query.py` | `retrieval_event` `logger.info` | `agent`, `query_text` |
| #997 | `src/retrieval/agent_query.py` | KEI-198 all-zero-score `logger.warning` | `agent`, `text` |
| #994 | `src/dispatcher/main.py` | bounded-spawn-violation `logger.error` | `callsign` |
| #995 | `src/dispatcher/main.py` | same call | `task_id` |

For `retrieval_event`, the two tainted fields are scrubbed at payload construction, so the `public.retrieval_events` audit row stores the same single-line form (defensible for an audit log; other payload fields are ints/bools/fixed collection names — not tainted).

## Scope

The **5 alerts named in the dispatch**. There are 8 other open log-injection findings (`dispatcher/bounded_spawn_enforcer.py`, `dispatcher/interceptor_proxy.py`, more `main.py` lines) — out of scope here; the `scrub()` helper is reusable for a follow-up sweep.

> Overlap note: `agent_query.py` is also modified by PR #1250 (Wave 5). Both touch different regions (#1250: Citation/overrides wiring; this PR: log sinks) — whichever lands first, the other rebases cleanly. Flagged to Elliot.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on all touched files
- [x] `tests/utils/test_log_safe.py` — CRLF escape, non-str coercion, truncation, attack-collapse
- [x] Regression: `tests/retrieval/test_agent_query.py` + `test_workflow_recall.py` + 85 dispatcher wiring tests green
- [ ] CodeQL CI — expecting 0 log-injection findings on the 5 fixed sinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)