### PR TITLE
[SCOUT] feat(cutover): spawn-time template hydrator + run_agent_with_recall wiring

### DIFF
--- a/docs/cutover/spawn_governance_template.md
+++ b/docs/cutover/spawn_governance_template.md
@@ -27,7 +27,10 @@ Write nothing here that assumes the agent will exist tomorrow.
 
 *Projection of RULE 2 COORDINATE (callsign discipline + claim-before-touch).*
 
-- You are **`<CALLSIGN>`**, spawned for one task by **`<ORCHESTRATOR>`**.
+- You are **`<CALLSIGN>`**, spawned for one task by **`<ORCHESTRATOR>`**, running on model
+  **`<MODEL>`**.
+- **Deliberation lens:** `<ROLE_LENS>` — review every artefact through this lens specifically (deliberators only: elliot = implementation-feasibility, aiden = governance/architecture, max = code-quality).
+- **Specialty:** `<SPECIALTY>` — tasks routed to you assume this competence (workers only: orion = build/retrieval, atlas = memory/research, scout = research/devops, nova = build/devops).
 - Tag your callsign on **every** output: report headers, PR titles, commit trailers, review
   verdicts. An untagged output is a hard fail.
 - **Claim before you touch a shared file.** Before editing any file another agent may also be
@@ -40,6 +43,9 @@ Write nothing here that assumes the agent will exist tomorrow.
   you do not introduce yourself as a new agent.
 - You report **to your orchestrator**, never to Dave directly (`ceo:comm_architecture` —
   inter-agent traffic rides NATS / the inbox relay; only the prime channel reaches Dave).
+- **If your orchestrator is unreachable:** do not guess and do not silently halt — surface the
+  blocker inline in your output (what you were doing, what is blocked, and why) and stop. A
+  surfaced blocker is recoverable; a silent one is lost work.
 
 ---
 

--- a/scripts/hydrate_spawn_template.py
+++ b/scripts/hydrate_spawn_template.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""hydrate_spawn_template.py — stamp spawn parameters into the governance template.
+
+Reads `docs/cutover/spawn_governance_template.md` and replaces its hydration
+placeholders with the values for ONE spawn, emitting a ready-to-use system
+prompt on stdout. Stdlib only — no third-party dependencies.
+
+Hydration placeholders (UPPERCASE — stamped once at spawn time):
+    <CALLSIGN>      agent identity (orion, atlas, scout, aiden, max, elliot)
+    <ORCHESTRATOR>  who dispatched this spawn (e.g. elliot)
+    <MODEL>         the LLM model for this spawn (Viktor's requirement: model
+                    selection is hydrated in the same pass as identity/role)
+    <ROLE_LENS>     deliberators only (impl-feasibility / governance / code-quality)
+    <SPECIALTY>     workers only (build/retrieval, memory/research, ...)
+
+`<ROLE_LENS>` and `<SPECIALTY>` are mutually exclusive (deliberator XOR worker).
+A line carrying a placeholder whose value is empty is **omitted entirely** —
+so a worker's prompt has no dangling "Deliberation lens:" line and vice-versa.
+
+NOT hydrated (deliberately): lowercase / runtime placeholders inside the
+governance text such as `[CLAIM:<callsign>]`, `<path>`, `<min>` — those are
+filled by the agent itself when it posts a claim. Matching is case-sensitive
+so they survive hydration untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_TEMPLATE = REPO_ROOT / "docs" / "cutover" / "spawn_governance_template.md"
+
+SCALAR_PLACEHOLDERS = ("<CALLSIGN>", "<ORCHESTRATOR>", "<MODEL>")
+CONDITIONAL_PLACEHOLDERS = ("<ROLE_LENS>", "<SPECIALTY>")
+
+
+def hydrate(
+    template: str,
+    *,
+    callsign: str,
+    orchestrator: str,
+    model: str,
+    role_lens: str = "",
+    specialty: str = "",
+) -> str:
+    """Return `template` with every hydration placeholder stamped.
+
+    Conditional lines (those bearing <ROLE_LENS> / <SPECIALTY>) are dropped when
+    their value is empty, so the unused role/specialty line never reaches the
+    prompt.
+    """
+    out_lines: list[str] = []
+    skip_continuation = False
+    for line in template.splitlines():
+        # An omitted conditional bullet may wrap onto indented continuation
+        # lines; drop those too (until the next bullet / blank / unindented line)
+        # so no orphan fragment leaks into the prompt.
+        is_continuation = bool(line[:1].isspace() and line.strip())
+        if skip_continuation and is_continuation:
+            continue
+        skip_continuation = False
+        if "<ROLE_LENS>" in line and not role_lens:
+            skip_continuation = True
+            continue
+        if "<SPECIALTY>" in line and not specialty:
+            skip_continuation = True
+            continue
+        line = line.replace("<CALLSIGN>", callsign)
+        line = line.replace("<ORCHESTRATOR>", orchestrator)
+        line = line.replace("<MODEL>", model)
+        line = line.replace("<ROLE_LENS>", role_lens)
+        line = line.replace("<SPECIALTY>", specialty)
+        out_lines.append(line)
+    rendered = "\n".join(out_lines)
+    if template.endswith("\n"):
+        rendered += "\n"
+    return rendered
+
+
+def _assert_fully_hydrated(rendered: str) -> None:
+    """Fail loudly if any hydration placeholder survived (catches template drift
+    — e.g. a new <FOO> added to the doc but not wired here)."""
+    leftover = [p for p in SCALAR_PLACEHOLDERS + CONDITIONAL_PLACEHOLDERS if p in rendered]
+    if leftover:
+        raise SystemExit(f"hydration incomplete — placeholders remain: {', '.join(leftover)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Hydrate the spawn governance template.")
+    parser.add_argument("--callsign", required=True)
+    parser.add_argument("--orchestrator", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument(
+        "--role-lens", default="", help="deliberators only; mutually exclusive with --specialty"
+    )
+    parser.add_argument(
+        "--specialty", default="", help="workers only; mutually exclusive with --role-lens"
+    )
+    parser.add_argument("--template", default=str(DEFAULT_TEMPLATE))
+    args = parser.parse_args(argv)
+
+    if args.role_lens and args.specialty:
+        raise SystemExit(
+            "--role-lens and --specialty are mutually exclusive (a spawn is a deliberator XOR a worker)"
+        )
+    template_path = Path(args.template)
+    if not template_path.is_file():
+        raise SystemExit(f"template not found: {template_path}")
+
+    rendered = hydrate(
+        template_path.read_text(encoding="utf-8"),
+        callsign=args.callsign,
+        orchestrator=args.orchestrator,
+        model=args.model,
+        role_lens=args.role_lens,
+        specialty=args.specialty,
+    )
+    _assert_fully_hydrated(rendered)
+    sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_agent_with_recall.sh
+++ b/scripts/run_agent_with_recall.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# run_agent_with_recall.sh — assemble a spawn's FULL system prompt.
+#
+#   full system prompt = hydrated governance template  (hydrate_spawn_template.py)
+#                      +  the recall block             (AGENCY_OS_PRIOR_CONTEXT)
+#
+# Previously a spawn launched with the raw recall block alone as its context.
+# Per the cutover plan, the governance contract (docs/cutover/spawn_governance_
+# template.md) must lead the system prompt, hydrated for this specific agent;
+# the recall block (positive + failure context, injected upstream by the
+# dispatcher's spawn_recall hook into AGENCY_OS_PRIOR_CONTEXT) is appended below.
+#
+# Emits the assembled prompt on stdout — the caller forwards it to the agent CLI
+# via `--append-system-prompt "$(...)"`. Stdlib Python only; no extra deps.
+#
+# Usage:
+#   run_agent_with_recall.sh --callsign orion --orchestrator elliot \
+#       --model gemini-2.5-flash [--role-lens "..."] [--specialty "build/retrieval"]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CALLSIGN="" ORCHESTRATOR="" MODEL="" ROLE_LENS="" SPECIALTY=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --callsign)     CALLSIGN="$2"; shift 2 ;;
+    --orchestrator) ORCHESTRATOR="$2"; shift 2 ;;
+    --model)        MODEL="$2"; shift 2 ;;
+    --role-lens)    ROLE_LENS="$2"; shift 2 ;;
+    --specialty)    SPECIALTY="$2"; shift 2 ;;
+    *) echo "run_agent_with_recall.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$CALLSIGN" ] || [ -z "$ORCHESTRATOR" ] || [ -z "$MODEL" ]; then
+  echo "run_agent_with_recall.sh: --callsign, --orchestrator, and --model are required" >&2
+  exit 2
+fi
+
+HYDRATE_ARGS=(--callsign "$CALLSIGN" --orchestrator "$ORCHESTRATOR" --model "$MODEL")
+[ -n "$ROLE_LENS" ] && HYDRATE_ARGS+=(--role-lens "$ROLE_LENS")
+[ -n "$SPECIALTY" ] && HYDRATE_ARGS+=(--specialty "$SPECIALTY")
+
+GOVERNANCE="$(python3 "$SCRIPT_DIR/hydrate_spawn_template.py" "${HYDRATE_ARGS[@]}")"
+
+# Recall block is injected upstream by the dispatcher (spawn_recall) into this
+# env var. Absent (recall disabled / empty corpus) → governance prompt alone.
+RECALL="${AGENCY_OS_PRIOR_CONTEXT:-}"
+
+if [ -n "$RECALL" ]; then
+  printf '%s\n\n%s\n' "$GOVERNANCE" "$RECALL"
+else
+  printf '%s\n' "$GOVERNANCE"
+fi

--- a/tests/scripts/test_hydrate_spawn_template.py
+++ b/tests/scripts/test_hydrate_spawn_template.py
@@ -1,0 +1,180 @@
+"""Smoke + behavior tests for scripts/hydrate_spawn_template.py.
+
+The dispatch's required smoke test: hydrate for callsign=orion and assert
+`<CALLSIGN>` does not appear in the output. Plus: model/orchestrator stamped,
+worker vs deliberator line selection, mutual-exclusivity guard, runtime
+placeholders (`[CLAIM:<callsign>]`, `<path>`) preserved, and the full
+fully-hydrated assertion. Subprocess-invoked, exactly as a spawn launch runs it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "hydrate_spawn_template.py"
+
+
+def _run(*args: str) -> tuple[int, str, str]:
+    cp = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    return cp.returncode, cp.stdout, cp.stderr
+
+
+def test_smoke_orion_no_callsign_placeholder_remains():
+    """Dispatch's required smoke test."""
+    rc, out, err = _run(
+        "--callsign",
+        "orion",
+        "--orchestrator",
+        "elliot",
+        "--model",
+        "gemini-2.5-flash",
+        "--specialty",
+        "build/retrieval",
+    )
+    assert rc == 0, err
+    assert "<CALLSIGN>" not in out
+    assert "orion" in out
+
+
+def test_no_hydration_placeholders_remain_for_worker():
+    rc, out, _ = _run(
+        "--callsign",
+        "orion",
+        "--orchestrator",
+        "elliot",
+        "--model",
+        "gemini-2.5-flash",
+        "--specialty",
+        "build/retrieval",
+    )
+    assert rc == 0
+    for ph in ("<CALLSIGN>", "<ORCHESTRATOR>", "<MODEL>", "<ROLE_LENS>", "<SPECIALTY>"):
+        assert ph not in out, f"{ph} survived hydration"
+
+
+def test_scalars_are_stamped():
+    rc, out, _ = _run(
+        "--callsign",
+        "orion",
+        "--orchestrator",
+        "elliot",
+        "--model",
+        "gemini-2.5-flash",
+        "--specialty",
+        "build/retrieval",
+    )
+    assert rc == 0
+    assert "elliot" in out and "gemini-2.5-flash" in out and "build/retrieval" in out
+
+
+def test_worker_omits_deliberation_lens_line():
+    rc, out, _ = _run(
+        "--callsign",
+        "orion",
+        "--orchestrator",
+        "elliot",
+        "--model",
+        "gemini-2.5-flash",
+        "--specialty",
+        "build/retrieval",
+    )
+    assert rc == 0
+    assert "Deliberation lens:" not in out  # line dropped for a worker
+    assert "Specialty:" in out
+
+
+def test_deliberator_omits_specialty_line():
+    rc, out, _ = _run(
+        "--callsign",
+        "aiden",
+        "--orchestrator",
+        "dave",
+        "--model",
+        "claude-opus-4-6",
+        "--role-lens",
+        "governance/architecture",
+    )
+    assert rc == 0
+    assert "Specialty:" not in out  # line dropped for a deliberator
+    assert "Deliberation lens:" in out
+    assert "governance/architecture" in out
+
+
+def test_role_lens_and_specialty_are_mutually_exclusive():
+    rc, _out, err = _run(
+        "--callsign",
+        "orion",
+        "--orchestrator",
+        "elliot",
+        "--model",
+        "gemini-2.5-flash",
+        "--role-lens",
+        "code-quality",
+        "--specialty",
+        "build/retrieval",
+    )
+    assert rc != 0
+    assert "mutually exclusive" in err
+
+
+def test_runtime_placeholders_are_preserved():
+    """Lowercase / runtime placeholders inside the governance text must survive —
+    the agent fills them when it posts a claim, not the hydrator."""
+    rc, out, _ = _run(
+        "--callsign",
+        "orion",
+        "--orchestrator",
+        "elliot",
+        "--model",
+        "gemini-2.5-flash",
+        "--specialty",
+        "build/retrieval",
+    )
+    assert rc == 0
+    assert "[CLAIM:<callsign>]" in out  # runtime placeholder, NOT hydrated
+    assert "<path>" in out and "<min>" in out
+
+
+def test_missing_required_arg_errors():
+    rc, _out, err = _run("--callsign", "orion")
+    assert rc != 0
+    assert "orchestrator" in err.lower() or "required" in err.lower()
+
+
+def _load_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_hydrate_spawn_template", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_omitting_a_conditional_bullet_drops_its_wrapped_continuation_lines():
+    """Regression guard: omitting a conditional bullet must also drop its wrapped
+    continuation lines, so no orphan fragment leaks into a worker's prompt."""
+    mod = _load_module()
+    template = (
+        "- **Deliberation lens:** `<ROLE_LENS>` — review through this lens\n"
+        "  (deliberators only: elliot, aiden, max).\n"
+        "- **Specialty:** `<SPECIALTY>` — assumed competence.\n"
+    )
+    out = mod.hydrate(
+        template,
+        callsign="orion",
+        orchestrator="elliot",
+        model="gemini-2.5-flash",
+        specialty="build/retrieval",  # worker → lens bullet omitted
+    )
+    assert "Deliberation lens:" not in out
+    assert "(deliberators only:" not in out  # the wrapped continuation is gone too
+    assert "build/retrieval" in out


### PR DESCRIPTION
## Summary
`scripts/hydrate_spawn_template.py` stamps per-spawn values into the governance template, producing a ready-to-use system prompt. **Stdlib only**, no new deps.

> **Stacked on #1259** (the governance template). Base = `scout/cutover-spawn-governance-template` so this diff shows only the incremental hydrator work; it auto-retargets to `main` when #1259 merges.

## Deliverables
- **`scripts/hydrate_spawn_template.py`** — `--callsign --orchestrator --model [--role-lens] [--specialty]` → hydrated prompt on stdout.
  - `<ROLE_LENS>` / `<SPECIALTY>` are **mutually exclusive** (deliberator XOR worker); the unused line is omitted, **including any wrapped continuation** (so no orphan fragment leaks).
  - **Case-sensitive** matching: the runtime placeholders `[CLAIM:<callsign>]`, `<path>`, `<min>` survive untouched — the agent fills those when it posts a claim, not the hydrator.
  - `_assert_fully_hydrated` fails loudly if any hydration placeholder survives (catches template drift — a new `<FOO>` added to the doc but not wired here).
- **`docs/cutover/spawn_governance_template.md`** — added `<MODEL>` (Viktor: model hydrated in the same pass as identity/role), `<ROLE_LENS>` + `<SPECIALTY>` placeholders, and the **unreachable-orchestrator fallback** line in §1 (Elliot's low-severity gap: surface blocker inline + stop).
- **`scripts/run_agent_with_recall.sh`** — full system prompt = hydrated template **+** recall block (`AGENCY_OS_PRIOR_CONTEXT`, injected upstream by `spawn_recall`).
- **`tests/scripts/test_hydrate_spawn_template.py`** — 9 tests.

## Verification (raw)
- `pytest tests/scripts/test_hydrate_spawn_template.py` → **9 passed** (incl. the required smoke: hydrate `orion` → `<CALLSIGN>` absent).
- `ruff check` + `ruff format --check` → clean. `bash -n run_agent_with_recall.sh` → clean.
- End-to-end render for `orion`: identity carries `orion`/`elliot`/`gemini-2.5-flash`; Specialty line present; **no Deliberation-lens line and no orphan fragment**; `[CLAIM:<callsign>]`/`<path>`/`<min>` preserved.

## Notes / GOV-9
1. **`run_agent_with_recall.sh` did not exist** — the dispatch said "update". Created it fresh implementing the described behavior (hydrated template + recall block). Flag if a prior version was expected elsewhere.
2. **Bug caught in self-test** (not shipped): the conditional bullets were multi-line, so line-based omission leaked the wrapped "(deliberators only: …)" fragment into a worker's prompt. Fixed two ways — single-line conditional bullets **and** a continuation-drop in the hydrator — with a dedicated regression test.

## Done criteria
- [x] script exists · [x] smoke test passes · [x] `run_agent_with_recall.sh` uses it · [x] PR opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)