### PR TITLE
[ATLAS] feat(chat): dynamic context composer for the Chat agent (John)

### DIFF
--- a/src/keiracom_system/chat/__init__.py
+++ b/src/keiracom_system/chat/__init__.py
@@ -1,1 +1,1 @@
-"""keiracom_system.chat — John's conversation lifecycle modules."""
+"""keiracom_system.chat — John's conversation lifecycle modules (context composition + exit cycle)."""

--- a/src/keiracom_system/chat/context_composer.py
+++ b/src/keiracom_system/chat/context_composer.py
@@ -1,0 +1,200 @@
+"""Dynamic context composer for the Chat agent (John).
+
+John's spawn system prompt is intentionally minimal (identity + the spawn
+governance contract per docs/cutover/spawn_governance_template.md). What it
+needs to *answer* the current message is injected at spawn time by this module:
+classify the latest customer message, then run a Hindsight retrieval pass scoped
+to that message type, and return a bounded context block to inject.
+
+Pipeline:
+  1. Classify the message with a lightweight Gemini call (gemini-2.5-flash via
+     the LiteLLM proxy — `src.keiracom_system.atomization.llm_client`, which
+     honours the internal-vs-customer routing policy and GEMINI_API_KEY env).
+  2. Map the type to Hindsight collections and run one retrieval pass:
+       technical  → Decisions + AgentMemories
+       task       → Decisions + Keis
+       escalation → AgentMemories (this customer's prior context)
+       ambiguous  → no retrieval; return the fail-open escalate block.
+  3. Build a ≤800-token context block.
+
+Fail-open throughout (matches the retrieval-layer + spawn-governance §3
+contract): a classification failure is treated as `ambiguous`; a retrieval
+failure yields an empty block, never an exception. The classifier carries NO
+business routing rules — it labels the message into one of four abstract types;
+the actual routing rules / tier logic / escalation protocols live in Hindsight
+and are surfaced by the retrieval pass, not hardcoded here.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from src.keiracom_system.atomization.llm_client import (
+    LiteLLMGeminiClient,
+    LLMClient,
+    resolve_api_key_from_env,
+)
+from src.retrieval import agent_query
+
+logger = logging.getLogger(__name__)
+
+# gemini-2.5-flash through the LiteLLM proxy (provider-prefixed model name).
+CLASSIFIER_MODEL = "google/gemini-2.5-flash"
+
+MAX_CONTEXT_TOKENS = 800
+CHARS_PER_TOKEN = 4  # matches the repo-wide token approximation
+_MAX_BLOCK_CHARS = MAX_CONTEXT_TOKENS * CHARS_PER_TOKEN
+_HISTORY_TURNS = 5  # recent turns fed to the classifier for disambiguation
+
+AMBIGUOUS_BLOCK = "insufficient context to classify — escalate to Deliberator"
+
+# Type → Hindsight collections. Empty tuple = no retrieval (fail-open block).
+# Collection names match orchestrator.HINDSIGHT_BANK_BY_CLASS ("Keis", not "KEIs").
+_COLLECTIONS_BY_TYPE: dict[str, tuple[str, ...]] = {
+    "technical": ("Decisions", "AgentMemories"),
+    "task": ("Decisions", "Keis"),
+    "escalation": ("AgentMemories",),
+    "ambiguous": (),
+}
+
+_CLASSIFY_SCHEMA: dict[str, Any] = {
+    "name": "chat_message_classification",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "classification": {
+                "type": "string",
+                "enum": ["technical", "task", "escalation", "ambiguous"],
+            }
+        },
+        "required": ["classification"],
+        "additionalProperties": False,
+    },
+}
+
+# Abstract type definitions only — deliberately NO business routing rules.
+_CLASSIFY_INSTRUCTION = (
+    "You classify a customer message for a chat agent. Read the latest message "
+    "(recent conversation is given for context) and label it as exactly one of:\n"
+    "- technical: asks how the system/product works, its behaviour or design.\n"
+    "- task: requests that work be performed, set up, or changed.\n"
+    "- escalation: expresses dissatisfaction or urgency, or asks for a human.\n"
+    "- ambiguous: intent cannot be determined from the message.\n"
+    "Return only the classification label."
+)
+
+RetrieveFn = Callable[[str, tuple[str, ...]], Any]
+
+
+@dataclass(frozen=True)
+class ChatContextResult:
+    context_block: str
+    classification: str
+    citations: list[dict[str, Any]]
+    token_estimate: int
+
+
+def _classify(message: str, last_n_messages: Sequence[str], llm_client: LLMClient | None) -> str:
+    """Gemini classification → one of the four types. Fail-open to 'ambiguous'."""
+    try:
+        client = llm_client or LiteLLMGeminiClient(api_key=resolve_api_key_from_env())
+        history = "\n".join(last_n_messages[-_HISTORY_TURNS:]) if last_n_messages else "(none)"
+        prompt = (
+            f"{_CLASSIFY_INSTRUCTION}\n\nRecent conversation:\n{history}"
+            f"\n\nLatest message:\n{message}"
+        )
+        resp = client.call_structured(
+            model=CLASSIFIER_MODEL,
+            messages=[{"role": "user", "content": prompt}],
+            response_schema=_CLASSIFY_SCHEMA,
+            temperature=0.0,
+        )
+        label = str((resp.parsed or {}).get("classification", "")).strip().lower()
+        if label in _COLLECTIONS_BY_TYPE:
+            return label
+        logger.warning("chat classifier returned unknown label — treating as ambiguous")
+        return "ambiguous"
+    except Exception:  # noqa: BLE001 — fail-open: any classifier failure → ambiguous
+        logger.warning("chat classification failed — treating as ambiguous", exc_info=True)
+        return "ambiguous"
+
+
+def _default_retrieve(query_text: str, collections: tuple[str, ...]) -> Any:
+    """Production retrieval — one Hindsight pass over the mapped collections.
+
+    citation_required=False so the best-available context still surfaces even
+    when scores are low/zero (the chat agent wants context, not an empty block).
+    """
+    return agent_query.query(
+        query_text, agent="john", collections=collections, citation_required=False
+    )
+
+
+def _build_block(classification: str, answer: str, citations: list[dict[str, Any]]) -> str:
+    """Render the dynamic context block, hard-capped at the token budget."""
+    lines = [f"[DYNAMIC CONTEXT — {classification}]"]
+    if answer:
+        lines.append(answer)
+    if citations:
+        lines.append("")
+        lines.append("Retrieved context:")
+        lines.extend(f"- [{c['source_id']}] ({c['collection']}) {c['excerpt']}" for c in citations)
+    block = "\n".join(lines)
+    return block[:_MAX_BLOCK_CHARS]  # token budget: len(block)//4 <= 800
+
+
+def _retrieve(
+    message: str, customer_id: int, classification: str, retrieve_fn: RetrieveFn | None
+) -> tuple[str, list[dict[str, Any]]]:
+    """Run the scoped Hindsight pass. Fail-open to ('', []) on any retrieval error."""
+    collections = _COLLECTIONS_BY_TYPE[classification]
+    if not collections:
+        return "", []
+    query_text = message
+    if classification == "escalation":
+        # Bias retrieval toward this customer's prior interactions.
+        query_text = f"customer {customer_id} prior context: {message}"
+    try:
+        result = (retrieve_fn or _default_retrieve)(query_text, collections)
+    except Exception:  # noqa: BLE001 — retrieval failure → empty block, not exception
+        logger.warning("chat retrieval failed (classification=%s)", classification, exc_info=True)
+        return "", []
+    citations = [
+        {
+            "source_id": c.source_id,
+            "collection": c.collection,
+            "score": round(c.score, 3),
+            "excerpt": c.excerpt,
+        }
+        for c in result.citations
+    ]
+    return _build_block(classification, result.answer, citations), citations
+
+
+def compose_chat_context(
+    message: str,
+    customer_id: int,
+    last_n_messages: list[str],
+    *,
+    llm_client: LLMClient | None = None,
+    retrieve_fn: RetrieveFn | None = None,
+) -> ChatContextResult:
+    """Classify `message` and return the dynamic context block for John's spawn.
+
+    `llm_client` / `retrieve_fn` are injection seams for tests (mock Gemini +
+    mock Hindsight); production uses the LiteLLM Gemini client + agent_query.
+    """
+    classification = _classify(message, last_n_messages, llm_client)
+    if classification == "ambiguous":
+        block, citations = AMBIGUOUS_BLOCK, []
+    else:
+        block, citations = _retrieve(message, customer_id, classification, retrieve_fn)
+    return ChatContextResult(
+        context_block=block,
+        classification=classification,
+        citations=citations,
+        token_estimate=len(block) // CHARS_PER_TOKEN,
+    )

--- a/src/keiracom_system/chat/context_composer.py
+++ b/src/keiracom_system/chat/context_composer.py
@@ -23,12 +23,21 @@ failure yields an empty block, never an exception. The classifier carries NO
 business routing rules — it labels the message into one of four abstract types;
 the actual routing rules / tier logic / escalation protocols live in Hindsight
 and are surfaced by the retrieval pass, not hardcoded here.
+
+Two entry points for two lifecycle moments (additive, non-overlapping):
+  * `compose_chat_context` — per *message*: classify the incoming message and
+    retrieve the context block to answer it.
+  * `compose_context` — per *spawn startup*: hydrate a fresh John spawn with
+    tenant config + prior decisions/patterns before it sees any message. Async
+    + fail-open; every source degrades to empty/{} independently.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from collections.abc import Callable, Sequence
+import os
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -197,4 +206,171 @@ def compose_chat_context(
         classification=classification,
         citations=citations,
         token_estimate=len(block) // CHARS_PER_TOKEN,
+    )
+
+
+# ─────────────────────── Spawn-startup hydration ───────────────────────
+# compose_context: a SECOND, additive entry point. Where compose_chat_context
+# reacts to one message, this hydrates a fresh John spawn at startup from three
+# sources — keiracom tenant config, Hindsight prior decisions/patterns, and
+# relevant ceo_memory keys — and returns a ChatContext. Async + fail-open; the
+# three fetchers are injection seams (tests mock them).
+
+DECISIONS_COLLECTION: tuple[str, ...] = ("Decisions",)
+PATTERNS_COLLECTION: tuple[str, ...] = ("Discoveries",)  # recurring patterns / discovery log
+MAX_DECISIONS = 5
+MAX_PATTERNS = 5
+_MEMORY_TERM_MINLEN = 4
+_MEMORY_MAX_TERMS = 4
+
+TenantFetch = Callable[[int], Awaitable[dict[str, Any]]]
+MemoryFetch = Callable[[str], Awaitable[list[str]]]
+AsyncRetrieveFn = Callable[[str, tuple[str, ...]], Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class ChatContext:
+    tenant_config: dict[str, Any]
+    relevant_decisions: list[str]
+    prior_patterns: list[str]
+
+
+def _hydration_dsn() -> str | None:
+    """Resolve a plain `postgresql://` DSN for asyncpg (strip SQLAlchemy tags)."""
+    dsn = os.environ.get("SUPABASE_DB_DSN") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        return None
+    return dsn.replace("postgresql+asyncpg://", "postgresql://", 1).replace(
+        "postgresql+psycopg://", "postgresql://", 1
+    )
+
+
+async def _default_async_retrieve(query_text: str, collections: tuple[str, ...]) -> Any:
+    """Production Hindsight pass (async). citation_required=False → best-available."""
+    return await agent_query.query_async(
+        query_text,
+        agent="john",
+        collections=collections,
+        k_returned=max(MAX_DECISIONS, MAX_PATTERNS),
+        citation_required=False,
+    )
+
+
+async def _default_tenant_fetch(customer_id: int) -> dict[str, Any]:
+    """Fail-open tenant-config lookup.
+
+    SCHEMA GAP (flagged to orchestrator): the keiracom tenant tables
+    (keiracom_tenants / keiracom_tenant_budgets / dispatcher_customers) are all
+    UUID-keyed — there is no int `customer_id` column, and no
+    `max_concurrent_tasks` column anywhere. Until an int→tenant mapping exists,
+    the default cannot resolve config, so it returns {}. Callers that hold the
+    customer→tenant mapping inject `tenant_fetch`.
+    """
+    logger.info(
+        "compose_context: default tenant_fetch is a no-op for customer_id=%s — "
+        "no int customer_id→tenant mapping in schema yet; inject tenant_fetch",
+        customer_id,
+    )
+    return {}
+
+
+async def _default_memory_fetch(conversation_seed: str) -> list[str]:
+    """Recent ceo_memory keys whose key/value matches conversation terms."""
+    dsn = _hydration_dsn()
+    terms = [t for t in conversation_seed.lower().split() if len(t) >= _MEMORY_TERM_MINLEN]
+    terms = terms[:_MEMORY_MAX_TERMS]
+    if not dsn or not terms:
+        return []
+    from src.utils.asyncpg_connection import get_asyncpg_connection
+
+    patterns = [f"%{t}%" for t in terms]
+    conn = await get_asyncpg_connection(dsn)
+    try:
+        rows = await conn.fetch(
+            "SELECT key, LEFT(value::text, 160) AS preview FROM public.ceo_memory "
+            "WHERE key ILIKE ANY($1) OR value::text ILIKE ANY($1) "
+            "ORDER BY updated_at DESC LIMIT $2",
+            patterns,
+            MAX_DECISIONS,
+        )
+    finally:
+        await conn.close()
+    return [f"{r['key']} — {r['preview']}" for r in rows]
+
+
+def _citations_to_strings(result: Any) -> list[str]:
+    return [f"[{c.source_id}] {c.excerpt}" for c in (getattr(result, "citations", None) or [])]
+
+
+async def _resolve_tenant(customer_id: int, tenant_fetch: TenantFetch | None) -> dict[str, Any]:
+    try:
+        return await (tenant_fetch or _default_tenant_fetch)(customer_id) or {}
+    except Exception:  # noqa: BLE001 — fail-open: never block the spawn
+        logger.warning("compose_context: tenant_fetch failed", exc_info=True)
+        return {}
+
+
+async def _resolve_decisions(
+    seed: str, retrieve_fn: AsyncRetrieveFn | None, memory_fetch: MemoryFetch | None
+) -> list[str]:
+    """Hindsight Decisions + relevant ceo_memory keys, merged + capped. Fail-open."""
+    retrieve = retrieve_fn or _default_async_retrieve
+    mem = memory_fetch or _default_memory_fetch
+
+    async def _hindsight() -> list[str]:
+        try:
+            return _citations_to_strings(await retrieve(seed, DECISIONS_COLLECTION))
+        except Exception:  # noqa: BLE001
+            logger.warning("compose_context: decisions retrieval failed", exc_info=True)
+            return []
+
+    async def _memory() -> list[str]:
+        try:
+            return await mem(seed)
+        except Exception:  # noqa: BLE001
+            logger.warning("compose_context: ceo_memory fetch failed", exc_info=True)
+            return []
+
+    hits, mem_hits = await asyncio.gather(_hindsight(), _memory())
+    return (hits + mem_hits)[:MAX_DECISIONS]
+
+
+async def _resolve_patterns(
+    customer_id: int, seed: str, retrieve_fn: AsyncRetrieveFn | None
+) -> list[str]:
+    """Hindsight recurring patterns, biased toward this customer. Fail-open."""
+    try:
+        result = await (retrieve_fn or _default_async_retrieve)(
+            f"customer {customer_id}: {seed}", PATTERNS_COLLECTION
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("compose_context: patterns retrieval failed", exc_info=True)
+        return []
+    return _citations_to_strings(result)[:MAX_PATTERNS]
+
+
+async def compose_context(
+    customer_id: int,
+    conversation_seed: str,
+    *,
+    tenant_fetch: TenantFetch | None = None,
+    memory_fetch: MemoryFetch | None = None,
+    retrieve_fn: AsyncRetrieveFn | None = None,
+) -> ChatContext:
+    """Assemble the spawn-startup context payload for a John spawn.
+
+    Fail-open: each of the three sources degrades to empty/{} independently —
+    a failure in one never blocks the spawn. The three fetchers are injection
+    seams for tests (mock tenant config + ceo_memory + Hindsight). Retrieval is
+    capped at MAX_DECISIONS + MAX_PATTERNS for the token budget.
+    """
+    tenant_config, relevant_decisions, prior_patterns = await asyncio.gather(
+        _resolve_tenant(customer_id, tenant_fetch),
+        _resolve_decisions(conversation_seed, retrieve_fn, memory_fetch),
+        _resolve_patterns(customer_id, conversation_seed, retrieve_fn),
+    )
+    return ChatContext(
+        tenant_config=tenant_config,
+        relevant_decisions=relevant_decisions,
+        prior_patterns=prior_patterns,
     )

--- a/tests/keiracom_system/chat/test_context_composer.py
+++ b/tests/keiracom_system/chat/test_context_composer.py
@@ -1,0 +1,163 @@
+"""Unit tests for src/keiracom_system/chat/context_composer.
+
+Both external dependencies are injected: Gemini via a fake LLMClient
+(call_structured), Hindsight via a recording retrieve_fn. No live API key,
+no Weaviate/Hindsight, no LiteLLM proxy needed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.keiracom_system.atomization.llm_client import LLMResponse
+from src.keiracom_system.chat import context_composer as cc
+from src.retrieval.agent_query import Citation, QueryResult
+
+
+class _FakeLLM:
+    """Canned classifier — returns `parsed`, or raises if `boom` is set."""
+
+    def __init__(self, parsed: Any = None, *, boom: bool = False):
+        self.parsed = parsed
+        self.boom = boom
+        self.calls: list[dict] = []
+
+    def call_structured(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.boom:
+            raise RuntimeError("gemini down")
+        return LLMResponse(parsed=self.parsed, tokens_in=10, tokens_out=2, latency_ms=5, model="x")
+
+
+class _RecordingRetrieve:
+    """Records (query_text, collections); returns a canned QueryResult or raises."""
+
+    def __init__(self, result: QueryResult | None = None, *, boom: bool = False):
+        self.result = result
+        self.boom = boom
+        self.calls: list[tuple[str, tuple[str, ...]]] = []
+
+    def __call__(self, query_text: str, collections: tuple[str, ...]):
+        self.calls.append((query_text, collections))
+        if self.boom:
+            raise RuntimeError("hindsight down")
+        return self.result
+
+
+def _result(*citations: Citation, answer: str = "synthesised answer") -> QueryResult:
+    return QueryResult(answer=answer, citations=tuple(citations), elapsed_ms=1, bypass_rerank=True)
+
+
+def _cite(source_id: str = "DEC-1", collection: str = "Decisions") -> Citation:
+    return Citation(
+        source_id=source_id, collection=collection, score=0.81, excerpt="how scoring works"
+    )
+
+
+def _llm(label: str) -> _FakeLLM:
+    return _FakeLLM({"classification": label})
+
+
+# --- classification → collection routing -------------------------------
+
+
+def test_technical_routes_to_decisions_and_agent_memories():
+    retrieve = _RecordingRetrieve(_result(_cite()))
+    res = cc.compose_chat_context(
+        "how does CIS scoring work?", 42, [], llm_client=_llm("technical"), retrieve_fn=retrieve
+    )
+    assert res.classification == "technical"
+    assert retrieve.calls[0][1] == ("Decisions", "AgentMemories")
+    assert res.citations and res.citations[0]["source_id"] == "DEC-1"
+    assert "[DYNAMIC CONTEXT — technical]" in res.context_block
+    assert "how scoring works" in res.context_block
+    assert res.token_estimate == len(res.context_block) // 4
+
+
+def test_task_routes_to_decisions_and_keis():
+    retrieve = _RecordingRetrieve(_result(_cite("KEI-9", "Keis")))
+    res = cc.compose_chat_context(
+        "set up a new campaign", 7, [], llm_client=_llm("task"), retrieve_fn=retrieve
+    )
+    assert res.classification == "task"
+    assert retrieve.calls[0][1] == ("Decisions", "Keis")
+
+
+def test_escalation_routes_to_agent_memories_with_customer_context():
+    retrieve = _RecordingRetrieve(_result(_cite("MEM-3", "AgentMemories")))
+    res = cc.compose_chat_context(
+        "this is unacceptable, get me a manager",
+        99,
+        [],
+        llm_client=_llm("escalation"),
+        retrieve_fn=retrieve,
+    )
+    assert res.classification == "escalation"
+    query_text, collections = retrieve.calls[0]
+    assert collections == ("AgentMemories",)
+    assert "customer 99" in query_text  # biased toward this customer's prior context
+
+
+# --- ambiguous + fail-open ---------------------------------------------
+
+
+def test_ambiguous_returns_failopen_block_and_skips_retrieval():
+    retrieve = _RecordingRetrieve(_result(_cite()))
+    res = cc.compose_chat_context("hmm", 1, [], llm_client=_llm("ambiguous"), retrieve_fn=retrieve)
+    assert res.classification == "ambiguous"
+    assert res.context_block == cc.AMBIGUOUS_BLOCK
+    assert res.citations == []
+    assert retrieve.calls == []  # no retrieval on ambiguous
+
+
+def test_classification_failure_falls_open_to_ambiguous():
+    retrieve = _RecordingRetrieve(_result(_cite()))
+    res = cc.compose_chat_context(
+        "anything", 1, [], llm_client=_FakeLLM(boom=True), retrieve_fn=retrieve
+    )
+    assert res.classification == "ambiguous"
+    assert res.context_block == cc.AMBIGUOUS_BLOCK
+    assert retrieve.calls == []
+
+
+def test_unknown_label_falls_open_to_ambiguous():
+    res = cc.compose_chat_context(
+        "x", 1, [], llm_client=_llm("banana"), retrieve_fn=_RecordingRetrieve(_result())
+    )
+    assert res.classification == "ambiguous"
+    assert res.context_block == cc.AMBIGUOUS_BLOCK
+
+
+def test_retrieval_failure_returns_empty_block_not_exception():
+    retrieve = _RecordingRetrieve(boom=True)
+    res = cc.compose_chat_context(
+        "how does X work?", 1, [], llm_client=_llm("technical"), retrieve_fn=retrieve
+    )
+    assert res.classification == "technical"  # classified fine
+    assert res.context_block == ""  # retrieval failed → empty, no raise
+    assert res.citations == []
+
+
+# --- token budget ------------------------------------------------------
+
+
+def test_context_block_capped_at_800_tokens():
+    huge = _result(_cite(), answer="x" * 100_000)
+    res = cc.compose_chat_context(
+        "big", 1, [], llm_client=_llm("technical"), retrieve_fn=_RecordingRetrieve(huge)
+    )
+    assert len(res.context_block) // 4 <= cc.MAX_CONTEXT_TOKENS
+    assert res.token_estimate <= cc.MAX_CONTEXT_TOKENS
+
+
+def test_history_passed_to_classifier():
+    llm = _llm("technical")
+    cc.compose_chat_context(
+        "now what?",
+        1,
+        ["earlier msg A", "earlier msg B"],
+        llm_client=llm,
+        retrieve_fn=_RecordingRetrieve(_result()),
+    )
+    prompt = llm.calls[0]["messages"][0]["content"]
+    assert "earlier msg B" in prompt  # recent turns fed in for disambiguation

--- a/tests/keiracom_system/chat/test_context_composer.py
+++ b/tests/keiracom_system/chat/test_context_composer.py
@@ -161,3 +161,142 @@ def test_history_passed_to_classifier():
     )
     prompt = llm.calls[0]["messages"][0]["content"]
     assert "earlier msg B" in prompt  # recent turns fed in for disambiguation
+
+
+# ======================================================================
+# compose_context — spawn-startup hydration (async, fail-open)
+# ======================================================================
+
+
+class _AsyncRetrieve:
+    """Async Hindsight stub — records (query_text, collections); raises if boom."""
+
+    def __init__(self, result: QueryResult | None = None, *, boom: bool = False):
+        self.result = result
+        self.boom = boom
+        self.calls: list[tuple[str, tuple[str, ...]]] = []
+
+    async def __call__(self, query_text: str, collections: tuple[str, ...]):
+        self.calls.append((query_text, collections))
+        if self.boom:
+            raise RuntimeError("hindsight down")
+        return self.result
+
+
+def _async_return(value: Any):
+    async def _f(*_a, **_k):
+        return value
+
+    return _f
+
+
+def _async_raise():
+    async def _f(*_a, **_k):
+        raise RuntimeError("source down")
+
+    return _f
+
+
+def _cites(*ids: str) -> QueryResult:
+    return _result(*[_cite(i) for i in ids])
+
+
+async def test_compose_context_happy_path_assembles_three_sources():
+    res = await cc.compose_context(
+        7,
+        "how is billing tiered?",
+        tenant_fetch=_async_return({"tier": "pro", "status": "active"}),
+        memory_fetch=_async_return(["ceo:pricing — tiers locked"]),
+        retrieve_fn=_AsyncRetrieve(_cites("DEC-1")),
+    )
+    assert isinstance(res, cc.ChatContext)
+    assert res.tenant_config == {"tier": "pro", "status": "active"}
+    assert "[DEC-1] how scoring works" in res.relevant_decisions
+    assert "ceo:pricing — tiers locked" in res.relevant_decisions
+    assert res.prior_patterns  # Hindsight Discoveries pass populated it
+
+
+async def test_decisions_merge_hindsight_then_memory():
+    res = await cc.compose_context(
+        1,
+        "scoring",
+        tenant_fetch=_async_return({}),
+        memory_fetch=_async_return(["ceo:k — v"]),
+        retrieve_fn=_AsyncRetrieve(_cites("DEC-1")),
+    )
+    assert res.relevant_decisions == ["[DEC-1] how scoring works", "ceo:k — v"]
+
+
+async def test_caps_5_decisions_and_5_patterns():
+    eight = _cites(*[f"D{i}" for i in range(8)])
+    res = await cc.compose_context(
+        1,
+        "topic",
+        tenant_fetch=_async_return({}),
+        memory_fetch=_async_return([f"ceo:m{i}" for i in range(4)]),
+        retrieve_fn=_AsyncRetrieve(eight),
+    )
+    assert len(res.relevant_decisions) == cc.MAX_DECISIONS  # 8 hindsight + 4 mem → capped 5
+    assert len(res.prior_patterns) == cc.MAX_PATTERNS
+
+
+async def test_routing_and_customer_biased_patterns():
+    retrieve = _AsyncRetrieve(_cites("X"))
+    await cc.compose_context(
+        77,
+        "billing question",
+        tenant_fetch=_async_return({}),
+        memory_fetch=_async_return([]),
+        retrieve_fn=retrieve,
+    )
+    by_collection = {coll: qt for qt, coll in retrieve.calls}
+    assert ("Decisions",) in by_collection
+    assert ("Discoveries",) in by_collection
+    assert by_collection[("Discoveries",)].startswith("customer 77:")  # customer-biased
+
+
+async def test_tenant_fetch_failure_falls_open_to_empty_dict():
+    res = await cc.compose_context(
+        1,
+        "x",
+        tenant_fetch=_async_raise(),
+        memory_fetch=_async_return([]),
+        retrieve_fn=_AsyncRetrieve(_cites("DEC-1")),
+    )
+    assert res.tenant_config == {}  # fail-open, not an exception
+    assert res.relevant_decisions  # other sources unaffected
+
+
+async def test_retrieval_failure_falls_open_to_empty_lists():
+    res = await cc.compose_context(
+        1,
+        "x",
+        tenant_fetch=_async_return({"tier": "solo"}),
+        memory_fetch=_async_return(["ceo:k — v"]),
+        retrieve_fn=_AsyncRetrieve(boom=True),
+    )
+    assert res.tenant_config == {"tier": "solo"}
+    assert res.relevant_decisions == ["ceo:k — v"]  # memory still contributes
+    assert res.prior_patterns == []  # hindsight patterns failed → empty
+
+
+async def test_memory_failure_falls_open():
+    res = await cc.compose_context(
+        1,
+        "x",
+        tenant_fetch=_async_return({}),
+        memory_fetch=_async_raise(),
+        retrieve_fn=_AsyncRetrieve(_cites("DEC-1")),
+    )
+    assert res.relevant_decisions == ["[DEC-1] how scoring works"]  # hindsight only
+
+
+async def test_default_tenant_fetch_is_noop_without_db():
+    # No tenant_fetch injected → default no-op returns {} (no int→tenant mapping).
+    res = await cc.compose_context(
+        1,
+        "x",
+        memory_fetch=_async_return([]),
+        retrieve_fn=_AsyncRetrieve(_cites("DEC-1")),
+    )
+    assert res.tenant_config == {}


### PR DESCRIPTION
## Summary

`src/keiracom_system/chat/context_composer.py` — the module that, given a raw incoming customer message, classifies it and runs a scoped Hindsight retrieval pass to produce the **dynamic context block** injected into John's (the Chat agent's) spawn.

John's spawn prompt is intentionally minimal (identity + the spawn governance contract per `docs/cutover/spawn_governance_template.md`); what it needs to *answer* the current message is composed here at spawn time.

## Interface

```python
compose_chat_context(message: str, customer_id: int, last_n_messages: list[str]) -> ChatContextResult
# ChatContextResult: context_block (str), classification (str), citations (list), token_estimate (int)
```

## Pipeline

1. **Classify** with a lightweight Gemini call (`gemini-2.5-flash`) — reuses `keiracom_system.atomization.llm_client.LiteLLMGeminiClient`, which routes Gemini through the LiteLLM proxy and resolves `GEMINI_API_KEY` from env (honours the internal-vs-customer routing policy; no fresh Gemini caller written).
2. **Route by type** to Hindsight collections, one retrieval pass via `agent_query`:
   - `technical` → Decisions + AgentMemories
   - `task` → Decisions + Keis
   - `escalation` → AgentMemories (query biased to this `customer_id`'s prior context)
   - `ambiguous` → **no retrieval**; fail-open block `"insufficient context to classify — escalate to Deliberator"`

## Constraints honoured

- **Fail-open throughout:** classifier error / unknown label → `ambiguous`; retrieval error → empty block, never an exception (matches spawn-governance §3 + the retrieval-layer contract). Verified live: no `GEMINI_API_KEY` → returns `ambiguous` cleanly, no raise.
- **Token budget:** `context_block` hard-capped at 800 tokens (`len(block)//4`).
- **No hardcoded routing rules in the classifier** — it labels into 4 abstract types only; the routing rules / tier logic / escalation protocols are the *retrieved* Hindsight content, not code constants.

## Reviewer flags

- **Persona vs dispatch framing:** `personas/john.md` frames John as the **Dave-facing** "Face" (translates fleet output to the CEO), whereas this dispatch describes a **customer-facing** chat agent (`customer_id`, customer escalations). The module is agnostic to that (pure context composition), but the framing mismatch is worth Elliot/Dave reconciling — flagged, not blocked.
- **Escalation customer-scoping** is done by biasing the query text (`"customer {id} prior context: …"`). True per-customer metadata filtering on AgentMemories is a follow-up if stronger isolation is needed.

## Test plan

- [x] 9 unit tests, both deps mocked (fake `LLMClient` + recording `retrieve_fn`): per-type routing, ambiguous-skips-retrieval, classify-failure / unknown-label / retrieval-failure fail-open, 800-token cap, history-fed-to-classifier
- [x] `ruff check` + `ruff format --check` clean
- [x] Import + fail-open sanity check with no Gemini key

🤖 Generated with [Claude Code](https://claude.com/claude-code)