### PR TITLE
[ORION] feat(atomization): full decision-class coverage + backfill runner

### DIFF
--- a/scripts/run_atomiser_backfill.py
+++ b/scripts/run_atomiser_backfill.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""run_atomiser_backfill.py — full decision-class backfill into fleet_decisions.
+
+Production factory + runner for the decisions atomizer (TASK 2 of the
+full-coverage atomization directive). Walks every decision source via
+`decision_sources.iter_all_decision_sources` (original 4 + the e–i extension:
+ceo: decision keys, completion:KEI-*, ceo:deliberation:*, personas/*.md,
+docs/architecture/**.md) and atomizes each into the Hindsight `fleet_decisions`
+bank.
+
+Modes:
+  --dry-run (default)  Walk sources, apply the checkpoint, print per-source +
+                       totals + an $AUD cost estimate. No DB write, no LLM call.
+  --execute            Construct the production Atomizer (LiteLLMGeminiClient +
+                       AtomStore + job logger) and atomize each un-done source.
+                       Pre-flight verifies the keiracom_atomizer_jobs /
+                       keiracom_atoms tables exist; if not, exits cleanly with a
+                       pointer to the migration (no partial writes).
+
+Checkpoint: a JSONL cursor file records every processed source_ref so reruns
+skip done items. When a DB is available the cursor is also seeded from
+keiracom_atomizer_jobs (status='atomizer_done') so prior runs of the original
+directive flow are not re-atomised.
+
+Env: KEIRACOM_ATOMIZER_ENABLED=on, GEMINI_API_KEY, DATABASE_URL (all in
+/home/elliotbot/.config/agency-os/.env).
+
+Usage:
+  python3 scripts/run_atomiser_backfill.py --dry-run
+  python3 scripts/run_atomiser_backfill.py --execute   # after the migration lands
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.keiracom_system.atomization.decision_sources import (
+    DecisionSource,
+    iter_all_decision_sources,
+)
+
+log = logging.getLogger("atomiser_backfill")
+
+CURSOR_DEFAULT = Path("runtime/atomiser_backfill_cursor.jsonl")
+LOG_DEFAULT = Path("runtime/atomiser_backfill_log.jsonl")
+ATOMIZER_TABLES = ("keiracom_atomizer_jobs", "keiracom_atoms")
+
+# gemini-2.5-flash published rates (USD / 1M tokens). Estimate only — actual
+# spend is logged per-source on --execute from the LLMResponse usage.
+_USD_PER_1M_IN = 0.30
+_USD_PER_1M_OUT = 2.50
+_USD_TO_AUD = 1.55  # LAW II — 1 USD = 1.55 AUD
+_CHARS_PER_TOKEN = 4
+_OUTPUT_RATIO = 0.25  # atoms compress the source; output ≈ 25% of input tokens
+
+
+@dataclass
+class CostEstimate:
+    sources: int
+    tokens_in: int
+    tokens_out: int
+
+    @property
+    def aud(self) -> float:
+        usd = (self.tokens_in / 1e6) * _USD_PER_1M_IN + (self.tokens_out / 1e6) * _USD_PER_1M_OUT
+        return usd * _USD_TO_AUD
+
+
+def _load_cursor(path: Path) -> set[str]:
+    """Return the set of already-processed source_refs from the cursor file."""
+    done: set[str] = set()
+    if not path.is_file():
+        return done
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            done.add(json.loads(line)["source_ref"])
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return done
+
+
+def _seed_cursor_from_jobs(db: object, done: set[str]) -> set[str]:
+    """Add source_refs already atomized (keiracom_atomizer_jobs done) to the cursor."""
+    try:
+        db.execute(  # type: ignore[attr-defined]
+            "SELECT DISTINCT source_ref FROM keiracom_atomizer_jobs WHERE status = 'atomizer_done'"
+        )
+        for row in db.fetchall() or []:  # type: ignore[attr-defined]
+            done.add(str(row[0]))
+    except Exception as exc:  # noqa: BLE001 — table may not exist yet; fail-open
+        log.warning("could not seed cursor from keiracom_atomizer_jobs: %s", exc)
+    return done
+
+
+def _append_cursor(path: Path, source_ref: str, atoms: int, tokens: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"source_ref": source_ref, "atoms": atoms, "tokens": tokens}) + "\n")
+
+
+def _estimate(sources: list[DecisionSource]) -> CostEstimate:
+    tokens_in = sum(len(s.source_text) // _CHARS_PER_TOKEN for s in sources)
+    return CostEstimate(len(sources), tokens_in, int(tokens_in * _OUTPUT_RATIO))
+
+
+def _filter_done(sources: Iterable[DecisionSource], done: set[str]) -> list[DecisionSource]:
+    return [s for s in sources if s.source_ref not in done]
+
+
+def _connect_db(dsn: str | None) -> object | None:
+    """Open a psycopg connection cursor, or None when no DSN / driver."""
+    if not dsn:
+        return None
+    dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+    try:
+        import psycopg
+
+        conn = psycopg.connect(dsn, prepare_threshold=None, autocommit=True)
+        return conn.cursor()
+    except Exception as exc:  # noqa: BLE001 — dry-run can still walk file sources
+        log.warning("DB connect failed (%s) — ceo_memory sources skipped", exc)
+        return None
+
+
+def _tables_present(db: object) -> bool:
+    """True only when BOTH atomizer tables exist — pre-flight for --execute."""
+    try:
+        db.execute(  # type: ignore[attr-defined]
+            "SELECT count(*) FROM information_schema.tables WHERE table_name = ANY(%s)",
+            list(ATOMIZER_TABLES),
+        )
+        return int((db.fetchone() or [0])[0]) == len(ATOMIZER_TABLES)  # type: ignore[attr-defined]
+    except Exception as exc:  # noqa: BLE001
+        log.error("table pre-flight failed: %s", exc)
+        return False
+
+
+def run_dry(sources: list[DecisionSource]) -> int:
+    """Print every source that WOULD be atomized + the $AUD cost estimate."""
+    by_kind: dict[str, int] = {}
+    for s in sources:
+        by_kind[s.source_kind] = by_kind.get(s.source_kind, 0) + 1
+        log.info("would atomize %s [%s] %d chars", s.source_ref, s.source_kind, len(s.source_text))
+    est = _estimate(sources)
+    log.info("──────── DRY-RUN SUMMARY ────────")
+    for kind, n in sorted(by_kind.items()):
+        log.info("  %s: %d sources", kind, n)
+    log.info(
+        "TOTAL: %d sources · ~%d in + ~%d out tokens · est ~$%.2f AUD (gemini-2.5-flash)",
+        est.sources,
+        est.tokens_in,
+        est.tokens_out,
+        est.aud,
+    )
+    return 0
+
+
+def _build_atomizer():  # pragma: no cover — exercised only on --execute post-migration
+    """Construct the production decisions Atomizer (Gemini + AtomStore + jobs)."""
+    from src.keiracom_system.atomization.atom_store import AtomStore
+    from src.keiracom_system.atomization.decisions_atomizer import DecisionsAtomizer
+    from src.keiracom_system.atomization.llm_client import LiteLLMGeminiClient
+    from src.keiracom_system.embeddings.tei_client import TEIClient
+    from src.retrieval.orchestrator import FLEET_TENANT_SLUG
+
+    dsn = (os.environ.get("DATABASE_URL") or "").replace(
+        "postgresql+asyncpg://", "postgresql://", 1
+    )
+    import psycopg
+
+    cur = psycopg.connect(dsn, prepare_threshold=None, autocommit=True).cursor()
+    store = AtomStore(db=cur, tenant_id=FLEET_TENANT_SLUG, embedder=TEIClient())
+    return DecisionsAtomizer(llm=LiteLLMGeminiClient(), store=store, job_db=cur), cur
+
+
+def run_execute(sources: list[DecisionSource], cursor_path: Path) -> int:  # pragma: no cover
+    """Atomize each source for real, checkpointing after each. Pre-flight-gated."""
+    from src.keiracom_system.atomization.decisions_atomizer import (
+        DecisionsAtomizerError,
+    )
+
+    atomizer, db = _build_atomizer()
+    if not _tables_present(db):
+        log.error(
+            "BLOCKED: %s missing on the live DB. Apply supabase/migrations/"
+            "20260526_keiracom_atomization_pilot.sql before --execute. No writes attempted.",
+            " / ".join(ATOMIZER_TABLES),
+        )
+        return 2
+    n_ok = n_fail = 0
+    for s in sources:
+        try:
+            job = atomizer.atomize(s)
+            n_ok += 1
+            _append_cursor(cursor_path, s.source_ref, job.atoms_produced, 0)
+            log.info("atomized %s — %d atoms", s.source_ref, job.atoms_produced)
+        except DecisionsAtomizerError as exc:
+            n_fail += 1
+            log.warning("FAILED %s: %s", s.source_ref, exc)
+    log.info("EXECUTE SUMMARY: ok=%d fail=%d", n_ok, n_fail)
+    return 0 if n_fail == 0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--execute", action="store_true", help="atomize for real (default: dry-run)"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="explicit dry-run (the default; walk + estimate, no writes/LLM)",
+    )
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--cursor", type=Path, default=CURSOR_DEFAULT)
+    parser.add_argument("--log-level", default="INFO")
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=args.log_level, format="%(asctime)s %(levelname)s %(message)s")
+
+    if os.environ.get("KEIRACOM_ATOMIZER_ENABLED", "").lower() not in {"1", "true", "on", "yes"}:
+        log.error("KEIRACOM_ATOMIZER_ENABLED is not on — refusing to run.")
+        return 3
+
+    db = _connect_db(os.environ.get("DATABASE_URL"))
+    done = _load_cursor(args.cursor)
+    if db is not None:
+        done = _seed_cursor_from_jobs(db, done)
+    log.info("checkpoint: %d source_refs already done — will skip", len(done))
+
+    all_sources = list(iter_all_decision_sources(db=db, repo_root=args.repo_root))
+    pending = _filter_done(all_sources, done)
+    log.info("sources: %d total, %d pending after checkpoint", len(all_sources), len(pending))
+
+    if not args.execute:
+        return run_dry(pending)
+    return run_execute(pending, args.cursor)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/keiracom_system/atomization/decision_sources.py
+++ b/src/keiracom_system/atomization/decision_sources.py
@@ -36,6 +36,70 @@ DEFAULT_DECISIONS_BANK: str = "fleet_decisions"
 
 # Regex patterns used by source iterators.
 _DIRECTIVE_KEY_PATTERN = re.compile(r"^ceo:directive_(\d+)_complete$")
+
+# Full-coverage decision atomization (Dave directive: atomise everything
+# non-human-readable). A ceo: key qualifies as decision-class when its name
+# contains one of these substrings (case-insensitive).
+_CEO_DECISION_KEYWORDS: tuple[str, ...] = (
+    "ratif",
+    "locked",
+    "canonical",
+    "v1",
+    "v2",
+    "architecture",
+    "deliberation",
+    "cutover",
+    "governance",
+    "memory",
+    "atomization",
+    "comm_",
+    "spawn_context",
+)
+# Human-facing / operational keys — never decision content. Excluded by
+# substring match, plus the directive_NNN_status regex below.
+_CEO_KEY_EXCLUDE_SUBSTRINGS: tuple[str, ...] = (
+    "session_end_",
+    "diag_",
+    "heartbeat_",
+    "approval_flow",
+    "save_point_",
+    "handoff_",
+)
+_CEO_KEY_EXCLUDE_RE = re.compile(r"directive_\d+_status$")
+# A value with fewer than this many whitespace-separated tokens carries no
+# sentence — skip it (booleans, counters, status flags).
+_MIN_DECISION_WORDS = 3
+# Bare status/flag tokens that pass the word-count check only as JSON noise.
+_STATUS_FLAG_TOKENS = frozenset(
+    {"true", "false", "on", "off", "yes", "no", "null", "none", "pending", "active", "done", "ok"}
+)
+
+
+def _is_excluded_ceo_key(key: str) -> bool:
+    """True for human-facing / operational ceo: keys that are not decisions."""
+    if any(sub in key for sub in _CEO_KEY_EXCLUDE_SUBSTRINGS):
+        return True
+    return _CEO_KEY_EXCLUDE_RE.search(key) is not None
+
+
+def is_atomisable_value(value: str | None) -> bool:
+    """Skip values with no decision prose: <3 words, a bare scalar, or a status flag.
+
+    A JSON object/array value (a decision stored structured) is KEPT — only
+    scalar JSON (number/bool/null) and short status strings are dropped.
+    """
+    text = (value or "").strip()
+    if len(text.split()) < _MIN_DECISION_WORDS:
+        return False
+    if text.lower() in _STATUS_FLAG_TOKENS:
+        return False
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return True  # not JSON — plain prose with >=3 words, keep
+    return not isinstance(parsed, bool | int | float) and parsed is not None
+
+
 _V2_INVENTORY_RATIFIED_ROW_RE = re.compile(
     r"^\|\s*([a-z0-9._-]+)\s*\|.*\|\s*RATIFIED-(?:CEO|DM)\s*\|.*\|.*\|.*\|\s*$",
     re.IGNORECASE,
@@ -174,6 +238,137 @@ def iter_manual_section_13(path: Path) -> Iterable[DecisionSource]:
 
 
 # ───────────────────────────────────────────────────────────────────────
+# (e) ceo_memory decision keys — non-directive ceo: keys with decision keywords
+# ───────────────────────────────────────────────────────────────────────
+
+
+def iter_ceo_memory_decisions(db: _DBProtocol) -> Iterable[DecisionSource]:
+    """Yield non-directive ceo: keys that name a ratified decision.
+
+    A key qualifies when it is NOT a directive_NNNNN_complete key (those are
+    source (a)), is not on the human-facing exclude list, contains a decision
+    keyword, and carries an atomisable value (>=3 words, not a scalar/flag).
+    """
+    db.execute("SELECT key, value::text FROM public.ceo_memory WHERE key LIKE 'ceo:%' ORDER BY key")
+    for row in db.fetchall() or []:
+        key, value = str(row[0]), row[1]
+        if _DIRECTIVE_KEY_PATTERN.match(key):
+            continue  # source (a) — iter_ceo_memory_directives
+        if _is_excluded_ceo_key(key):
+            continue
+        if not any(kw in key.lower() for kw in _CEO_DECISION_KEYWORDS):
+            continue
+        if not is_atomisable_value(value):
+            continue
+        yield DecisionSource(
+            source_ref=f"ceo_memory:{key}",
+            source_kind="governance_doc",
+            source_text=str(value),
+        )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# (f) ceo_memory completion:KEI-* — completed engineering decisions
+# ───────────────────────────────────────────────────────────────────────
+
+
+def iter_ceo_memory_completions(db: _DBProtocol) -> Iterable[DecisionSource]:
+    """Yield completion:KEI-* keys — each a completed engineering decision + rationale."""
+    db.execute(
+        "SELECT key, value::text FROM public.ceo_memory "
+        "WHERE key LIKE 'completion:KEI-%' ORDER BY key"
+    )
+    for row in db.fetchall() or []:
+        key, value = str(row[0]), row[1]
+        if not is_atomisable_value(value):
+            continue
+        yield DecisionSource(
+            source_ref=f"ceo_memory:{key}",
+            source_kind="governance_doc",
+            source_text=str(value),
+        )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# (g) ceo:deliberation:* — concurred product deliberations
+# ───────────────────────────────────────────────────────────────────────
+
+
+def iter_ceo_memory_deliberations(db: _DBProtocol) -> Iterable[DecisionSource]:
+    """Yield ceo:deliberation:* keys — concurred product deliberation records."""
+    db.execute(
+        "SELECT key, value::text FROM public.ceo_memory "
+        "WHERE key LIKE 'ceo:deliberation:%' ORDER BY key"
+    )
+    for row in db.fetchall() or []:
+        key, value = str(row[0]), row[1]
+        if not is_atomisable_value(value):
+            continue
+        yield DecisionSource(
+            source_ref=f"ceo_memory:{key}",
+            source_kind="governance_doc",
+            source_text=str(value),
+        )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# (h) personas/*.md — agent role definitions
+# ───────────────────────────────────────────────────────────────────────
+
+
+def iter_persona_definitions(repo_root: Path = Path(".")) -> Iterable[DecisionSource]:
+    """Yield one DecisionSource per personas/*.md (agent role definitions)."""
+    pdir = repo_root / "personas"
+    if not pdir.is_dir():
+        log.warning("personas: %s not present — skipping", pdir)
+        return
+    for path in sorted(pdir.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        if not is_atomisable_value(text):
+            continue
+        yield DecisionSource(
+            source_ref=f"personas/{path.name}",
+            source_kind="governance_doc",
+            source_text=text,
+        )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# (i) docs/architecture/*.md — architecture decisions
+# ───────────────────────────────────────────────────────────────────────
+
+
+# Architecture docs already covered by a dedicated row-level iterator — skip
+# them in the whole-doc iterator to avoid double-atomising the same content.
+_ARCHITECTURE_DOCS_COVERED_ELSEWHERE: frozenset[str] = frozenset(
+    {"keiracom_architecture_v2_inventory.md"}  # source (c) iter_v2_inventory_ratified
+)
+
+
+def iter_architecture_docs(repo_root: Path = Path(".")) -> Iterable[DecisionSource]:
+    """Yield one DecisionSource per docs/architecture/**/*.md (architecture decisions).
+
+    Skips files already covered by a dedicated iterator (e.g. the V2 inventory,
+    which source (c) atomises row-by-row) so content is not double-atomised.
+    """
+    adir = repo_root / "docs" / "architecture"
+    if not adir.is_dir():
+        log.warning("architecture_docs: %s not present — skipping", adir)
+        return
+    for path in sorted(adir.rglob("*.md")):
+        if path.name in _ARCHITECTURE_DOCS_COVERED_ELSEWHERE:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if not is_atomisable_value(text):
+            continue
+        yield DecisionSource(
+            source_ref=f"docs/architecture/{path.relative_to(adir).as_posix()}",
+            source_kind="governance_doc",
+            source_text=text,
+        )
+
+
+# ───────────────────────────────────────────────────────────────────────
 # Aggregator + helpers
 # ───────────────────────────────────────────────────────────────────────
 
@@ -183,18 +378,24 @@ def iter_all_decision_sources(
     db: _DBProtocol | None = None,
     repo_root: Path = Path("."),
 ) -> Iterable[DecisionSource]:
-    """Convenience iterator — walks all 4 sources in canonical order.
+    """Convenience iterator — walks every decision source in canonical order.
 
-    `db` may be None — the ceo_memory iterator is then skipped (e.g. for
-    docs-only smoke runs).
+    Original 4 sources (a–d) + the full-coverage extension (e–i). `db` may be
+    None — the ceo_memory iterators are then skipped (e.g. for docs-only smoke
+    runs); the file-based iterators always run.
     """
     if db is not None:
         yield from iter_ceo_memory_directives(db)
+        yield from iter_ceo_memory_decisions(db)
+        yield from iter_ceo_memory_completions(db)
+        yield from iter_ceo_memory_deliberations(db)
     yield from iter_consolidated_rules(repo_root / "docs" / "governance" / "CONSOLIDATED_RULES.md")
     yield from iter_v2_inventory_ratified(
         repo_root / "docs" / "architecture" / "keiracom_architecture_v2_inventory.md"
     )
     yield from iter_manual_section_13(repo_root / "docs" / "MANUAL.md")
+    yield from iter_persona_definitions(repo_root)
+    yield from iter_architecture_docs(repo_root)
 
 
 def _split_by_heading_regex(text: str, heading_re: re.Pattern[str]) -> Iterable[tuple[str, str]]:

--- a/tests/keiracom_system/atomization/test_decision_sources_extended.py
+++ b/tests/keiracom_system/atomization/test_decision_sources_extended.py
@@ -1,0 +1,131 @@
+"""Full-coverage decision-source extension tests (e–i iterators + filters).
+
+Covers the Dave-directive extension to decision_sources.py: the ceo: decision-
+keyword iterator, completion:KEI-* / ceo:deliberation:* iterators, persona +
+architecture-doc file iterators, the human-facing exclusion list, and the
+is_atomisable_value content filter.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from src.keiracom_system.atomization import decision_sources as ds
+
+
+class FakeDB:
+    """Minimal _DBProtocol stub — answers LIKE queries from an in-memory store."""
+
+    def __init__(self, store: dict[str, str]):
+        self._store = store
+        self._rows: list[tuple[str, str]] = []
+
+    def execute(self, query: str, *params: object) -> None:
+        like = str(params[0]) if params else (re.search(r"LIKE '([^']+)'", query) or [None, "%"])[1]
+        rx = re.compile("^" + re.escape(like).replace("%", ".*") + "$")
+        self._rows = [(k, self._store[k]) for k in sorted(self._store) if rx.match(k)]
+
+    def fetchall(self) -> list[tuple[str, str]]:
+        return self._rows
+
+
+# ── is_atomisable_value ──────────────────────────────────────────────────
+
+
+def test_is_atomisable_value_rejects_short_and_scalar_and_flags():
+    assert ds.is_atomisable_value("a ratified three word") is True
+    assert ds.is_atomisable_value("too short") is False  # 2 words
+    assert ds.is_atomisable_value("true") is False
+    assert ds.is_atomisable_value("42") is False
+    assert ds.is_atomisable_value("  active  ") is False
+    assert ds.is_atomisable_value(None) is False
+    assert ds.is_atomisable_value('{"decision": "ratified the thing for good"}') is True
+    assert ds.is_atomisable_value("false") is False  # bare bool token
+
+
+def test_is_excluded_ceo_key():
+    for bad in (
+        "ceo:session_end_2026-05-28",
+        "ceo:diag_run_5",
+        "ceo:heartbeat_orion",
+        "ceo:approval_flow",
+        "ceo:save_point_3",
+        "ceo:handoff_atlas",
+        "ceo:directive_10028_status",
+    ):
+        assert ds._is_excluded_ceo_key(bad) is True, bad
+    assert ds._is_excluded_ceo_key("ceo:memory_abstraction_layer_v1") is False
+
+
+# ── ceo: decision-keyword iterator ───────────────────────────────────────
+
+
+def test_iter_ceo_memory_decisions_filters_correctly():
+    store = {
+        "ceo:memory_abstraction_layer_v1": "Ratified MAL V1 with eleven agreed positions and gates.",
+        "ceo:cutover_plan_v1": "Cutover plan ratified 2026-05-27 with phase steps enumerated.",
+        "ceo:directive_10028_complete": "should be skipped — covered by directive iterator",
+        "ceo:directive_10028_status": "active",  # excluded + short
+        "ceo:heartbeat_orion": "this contains the memory keyword but is excluded by list",
+        "ceo:random_counter": "5",  # no keyword + scalar
+        "ceo:governance_note": "x",  # keyword but <3 words → filtered
+    }
+    out = list(ds.iter_ceo_memory_decisions(FakeDB(store)))
+    refs = {s.source_ref for s in out}
+    assert refs == {
+        "ceo_memory:ceo:memory_abstraction_layer_v1",
+        "ceo_memory:ceo:cutover_plan_v1",
+    }
+    assert all(s.source_kind == "governance_doc" for s in out)
+
+
+def test_iter_ceo_memory_completions_and_deliberations():
+    store = {
+        "completion:KEI-101": "Completed the Valkey wiring with rationale and verification output.",
+        "completion:KEI-bad": "x",  # short → filtered
+        "ceo:deliberation:mal_v1": "Three deliberators concurred on the memory engine choice.",
+        "ceo:other": "not a deliberation key",
+    }
+    comps = {s.source_ref for s in ds.iter_ceo_memory_completions(FakeDB(store))}
+    delibs = {s.source_ref for s in ds.iter_ceo_memory_deliberations(FakeDB(store))}
+    assert comps == {"ceo_memory:completion:KEI-101"}
+    assert delibs == {"ceo_memory:ceo:deliberation:mal_v1"}
+
+
+# ── file iterators ───────────────────────────────────────────────────────
+
+
+def test_iter_persona_definitions(tmp_path: Path):
+    pdir = tmp_path / "personas"
+    pdir.mkdir()
+    (pdir / "orion.md").write_text("Orion is the build clone with a defined role and scope.")
+    (pdir / "empty.md").write_text("hi")  # <3 words → filtered
+    out = list(ds.iter_persona_definitions(tmp_path))
+    assert [s.source_ref for s in out] == ["personas/orion.md"]
+
+
+def test_iter_architecture_docs_recurses(tmp_path: Path):
+    adir = tmp_path / "docs" / "architecture"
+    (adir / "sub").mkdir(parents=True)
+    (adir / "top.md").write_text("Top-level architecture decision recorded for the fleet.")
+    (adir / "sub" / "nested.md").write_text("Nested architecture decision also recorded here.")
+    refs = {s.source_ref for s in ds.iter_architecture_docs(tmp_path)}
+    assert refs == {"docs/architecture/top.md", "docs/architecture/sub/nested.md"}
+
+
+def test_iter_persona_definitions_missing_dir_is_safe(tmp_path: Path):
+    assert list(ds.iter_persona_definitions(tmp_path)) == []
+
+
+# ── aggregator includes the new sources ──────────────────────────────────
+
+
+def test_iter_all_includes_extension_sources(tmp_path: Path):
+    (tmp_path / "personas").mkdir()
+    (tmp_path / "personas" / "x.md").write_text("Persona x has a role definition worth atomising.")
+    store = {"ceo:cutover_plan_v1": "Cutover plan ratified with enumerated phase steps here."}
+    out = list(ds.iter_all_decision_sources(db=FakeDB(store), repo_root=tmp_path))
+    refs = {s.source_ref for s in out}
+    assert "ceo_memory:ceo:cutover_plan_v1" in refs
+    assert "personas/x.md" in refs


### PR DESCRIPTION
## Summary

Full-coverage decision atomization (Dave directive: atomise everything non-human-readable). Two tasks.

### TASK 1 — extend `decision_sources.py` (5 new iterators + filter)
- `iter_ceo_memory_decisions` — non-directive `ceo:` keys whose name carries a decision keyword (ratif/locked/canonical/v1/v2/architecture/deliberation/cutover/governance/memory/atomization/comm_/spawn_context), minus the human-facing exclude list (session_end_/diag_/heartbeat_/`directive_NNN_status`/approval_flow/save_point_/handoff_).
- `iter_ceo_memory_completions` — `completion:KEI-*`.
- `iter_ceo_memory_deliberations` — `ceo:deliberation:*`.
- `iter_persona_definitions` — `personas/*.md`.
- `iter_architecture_docs` — `docs/architecture/**/*.md`, **excluding `keiracom_architecture_v2_inventory.md`** (already row-atomised by source (c) — prevents double-coverage).
- `is_atomisable_value()` — skips <3-word values, bare scalars (number/bool/null), and status-flag tokens.
- `iter_all_decision_sources` extended to walk a–i.

### TASK 2 — `scripts/run_atomiser_backfill.py` (production factory + runner)
- `--dry-run` (default): walks all sources, checkpoint-skips, prints per-source + totals + **$AUD cost estimate** (LAW II). No DB write / no LLM.
- `--execute`: builds the production Atomizer (`LiteLLMGeminiClient` + `AtomStore` + job logger), **pre-flight-verifies the atomizer tables exist** (exits 2 with a migration pointer if not — no partial writes), then atomizes each un-done source, logging source_ref / atoms / cost.
- **Checkpoint**: JSONL cursor file **+ seeded from `keiracom_atomizer_jobs` (status='atomizer_done')** so reruns AND the original directive flow are never re-atomised.

## Verification
- 204 atomization tests pass (incl. new `test_decision_sources_extended.py`); ruff check + format clean.
- **Live dry-run** against `ceo_memory`: **539 sources** (537 governance_doc + 2 manual), ~326K in / ~82K out tokens, **est ~$0.47 AUD** (gemini-2.5-flash).

## ⚠️ TASK 2 live run is BLOCKED (surfaced to Elliot)
`keiracom_atomizer_jobs` + `keiracom_atoms` do **not exist on the live DB** — migration `supabase/migrations/20260526_keiracom_atomization_pilot.sql` is **unapplied**. `atomize()`'s first action is `INSERT INTO keiracom_atomizer_jobs`, so the live backfill cannot write until that migration lands. `--execute` now fails cleanly (exit 2, migration pointer) instead of a cryptic error. Applying a schema migration to prod is a devops/Dave-gated action — not done unilaterally here.

**To complete TASK 2:** apply the migration, then `python3 scripts/run_atomiser_backfill.py --execute` (checkpointed, ~$0.47 AUD). I can run it the moment the migration lands.

Docs/test/script + one src module touched; no runtime service-path code changed. Branched off latest main.