### PR TITLE
[NOVA] feat(chat): John exit cycle — conversation capture → ceo_memory

### DIFF
--- a/src/keiracom_system/chat/__init__.py
+++ b/src/keiracom_system/chat/__init__.py
@@ -1,0 +1,1 @@
+"""keiracom_system.chat — John's conversation lifecycle modules."""

--- a/src/keiracom_system/chat/exit_cycle.py
+++ b/src/keiracom_system/chat/exit_cycle.py
@@ -1,0 +1,210 @@
+"""exit_cycle.py — John's end-of-conversation decision capture.
+
+An ephemeral John spawn has no persistent memory. If a conversation contained a
+ratified decision (Viktor explained an architecture, Dave confirmed a
+direction, a pattern was established), the only way that knowledge survives to
+the next spawn is to write it to ceo_memory before this spawn exits. The
+atomiser then promotes it to fleet_decisions; future spawns retrieve it via
+Hindsight Layer 2.
+
+`classify_and_save` scans a finished conversation with Gemini Flash, keeps items
+with confidence > 0.8 (max 3), and upserts each to ceo_memory under
+`ceo:conversation_capture:{date}:{topic_slug}` via the canonical KEI-87 writer.
+
+Fail-open by contract: any Gemini or DB error skips gracefully and never blocks
+conversation completion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CONFIDENCE_THRESHOLD = 0.8
+MAX_WRITES = 3
+CALLSIGN = "john"
+_VALID_KINDS = {
+    "architectural_decision",
+    "confirmed_pattern",
+    "dave_approval",
+    "viktor_explanation",
+}
+
+CLASSIFY_SYSTEM_PROMPT = (
+    "You extract durable institutional knowledge from a finished conversation so "
+    "it survives past an ephemeral agent that is about to exit. Return ONLY items "
+    "that are one of: a ratified architectural decision ('we will use X for Y'); "
+    "a confirmed pattern ('always do X when Y'); an explicit Dave approval ('yes', "
+    "'go ahead', 'confirmed' against a concrete proposal); or a Viktor explanation "
+    "of how something works. DO NOT return status updates, questions, routine task "
+    "dispatches, or casual conversation. For each item give: decision_text (a "
+    "self-contained one-sentence statement of the decision/pattern/fact — written "
+    "so a future agent with no prior context understands it), topic_slug (2-5 "
+    "kebab-case words), kind (one of architectural_decision|confirmed_pattern|"
+    "dave_approval|viktor_explanation), and confidence (0.0-1.0). Return an empty "
+    "items list when nothing qualifies. Be conservative — precision over recall."
+)
+
+RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "decision_text": {"type": "string"},
+                    "topic_slug": {"type": "string"},
+                    "kind": {"type": "string"},
+                    "confidence": {"type": "number"},
+                },
+                "required": ["decision_text", "topic_slug", "kind", "confidence"],
+            },
+        }
+    },
+    "required": ["items"],
+}
+
+
+@dataclass
+class ExitCycleResult:
+    decisions_saved: int = 0
+    keys_written: list[str] = field(default_factory=list)
+    skipped_reason: str | None = None
+
+
+WriterFn = Callable[[str, str, dict[str, Any]], None]
+
+
+def _topic_slug(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")
+    return slug[:48] or "untitled"
+
+
+def _render(conversation: Sequence[dict[str, Any]]) -> str:
+    return "\n".join(f"{m.get('role', '?')}: {m.get('content', '')}" for m in conversation)
+
+
+def _default_writer(callsign: str, key: str, value: dict[str, Any]) -> None:
+    from src.governance.ceo_memory_writer import upsert_ceo_memory_key
+
+    upsert_ceo_memory_key(callsign, key, value)
+
+
+async def _classify(gemini_client: Any, conversation_text: str) -> list[dict[str, Any]]:
+    """Run Gemini Flash classification; [] on any non-success or bad shape."""
+    result = await gemini_client.comprehend(
+        system_prompt=CLASSIFY_SYSTEM_PROMPT,
+        user_prompt=conversation_text,
+        enable_grounding=False,
+        response_schema=RESPONSE_SCHEMA,
+    )
+    if result.get("f3_status") != "success":
+        return []
+    content = result.get("content")
+    if not isinstance(content, dict):
+        return []
+    items = content.get("items")
+    return items if isinstance(items, list) else []
+
+
+def _select_qualifying(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep valid-kind items above the confidence floor, capped at MAX_WRITES."""
+    qualifying: list[dict[str, Any]] = []
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        try:
+            confidence = float(it.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            continue
+        if confidence <= CONFIDENCE_THRESHOLD:
+            continue
+        if it.get("kind") not in _VALID_KINDS:
+            continue
+        if not (it.get("decision_text") or "").strip():
+            continue
+        qualifying.append(it)
+    return qualifying[:MAX_WRITES]
+
+
+def _build_value(item: dict[str, Any], customer_id: int, captured_at: str) -> dict[str, Any]:
+    return {
+        "decision": item["decision_text"],
+        "kind": item["kind"],
+        "confidence": float(item["confidence"]),
+        "customer_id": customer_id,
+        "captured_by": "john_exit_cycle",
+        "captured_at": captured_at,
+    }
+
+
+async def classify_and_save(
+    conversation: list[dict[str, Any]],
+    customer_id: int,
+    *,
+    gemini_client: Any | None = None,
+    writer: WriterFn | None = None,
+) -> ExitCycleResult:
+    """Detect ratified decisions in `conversation` and persist them to ceo_memory.
+
+    Fail-open: returns a result with `skipped_reason` set rather than raising on
+    any classification or write failure. `gemini_client` and `writer` are
+    injectable for testing.
+    """
+    if not conversation:
+        return ExitCycleResult(skipped_reason="empty_conversation")
+
+    client = gemini_client
+    if client is None:
+        try:
+            from src.intelligence.gemini_client import GeminiClient
+
+            client = GeminiClient()
+        except Exception as exc:  # noqa: BLE001 — fail-open; never block completion
+            logger.warning("exit_cycle: Gemini init failed (skip): %s", exc)
+            return ExitCycleResult(skipped_reason=f"gemini_init_failed: {exc}")
+
+    try:
+        items = await _classify(client, _render(conversation))
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.warning("exit_cycle: classification failed (skip): %s", exc)
+        return ExitCycleResult(skipped_reason=f"classify_failed: {exc}")
+
+    qualifying = _select_qualifying(items)
+    if not qualifying:
+        reason = "no_decisions_detected" if not items else "below_confidence_threshold"
+        logger.info("exit_cycle: nothing to save (%s; %d raw items)", reason, len(items))
+        return ExitCycleResult(skipped_reason=reason)
+
+    write = writer or _default_writer
+    now = datetime.now(UTC)
+    date = now.strftime("%Y-%m-%d")
+    saved: list[str] = []
+    for item in qualifying:
+        key = f"ceo:conversation_capture:{date}:{_topic_slug(item.get('topic_slug') or item['decision_text'])}"
+        value = _build_value(item, customer_id, now.isoformat())
+        try:
+            await asyncio.to_thread(write, CALLSIGN, key, value)
+        except Exception as exc:  # noqa: BLE001 — fail-open per write
+            logger.warning("exit_cycle: ceo_memory write failed for %s (skip): %s", key, exc)
+            continue
+        saved.append(key)
+        logger.info(
+            "exit_cycle: saved %s (kind=%s conf=%.2f): %s",
+            key,
+            item["kind"],
+            float(item["confidence"]),
+            item["decision_text"][:140],
+        )
+
+    if not saved:
+        return ExitCycleResult(skipped_reason="all_writes_failed")
+    return ExitCycleResult(decisions_saved=len(saved), keys_written=saved)

--- a/tests/keiracom_system/chat/test_exit_cycle.py
+++ b/tests/keiracom_system/chat/test_exit_cycle.py
@@ -1,0 +1,260 @@
+"""Unit tests for John's exit cycle — mock Gemini + mock DB writer.
+
+Uses asyncio.run so the suite needs no pytest-asyncio mode configuration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from src.keiracom_system.chat import exit_cycle
+
+
+class FakeGemini:
+    """Stub GeminiClient.comprehend returning a canned result (or raising)."""
+
+    def __init__(self, result: Any = None, *, raises: Exception | None = None) -> None:
+        self._result = result
+        self._raises = raises
+        self.calls: list[dict[str, Any]] = []
+
+    async def comprehend(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+
+def _recorder():
+    calls: list[tuple[str, str, dict]] = []
+
+    def writer(callsign: str, key: str, value: dict) -> None:
+        calls.append((callsign, key, value))
+
+    return writer, calls
+
+
+def _success(items: list[dict]) -> dict[str, Any]:
+    return {"f3_status": "success", "content": {"items": items}}
+
+
+def _run(conversation, *, gemini, writer, customer_id=42):
+    return asyncio.run(
+        exit_cycle.classify_and_save(conversation, customer_id, gemini_client=gemini, writer=writer)
+    )
+
+
+CONVO = [
+    {"role": "viktor", "content": "We will use Hindsight Layer 2 for cross-spawn recall."},
+    {"role": "user", "content": "Go ahead, confirmed."},
+]
+
+
+def test_happy_path_writes_qualifying_items():
+    gemini = FakeGemini(
+        _success(
+            [
+                {
+                    "decision_text": "Use Hindsight Layer 2 for cross-spawn recall.",
+                    "topic_slug": "hindsight-layer-2-recall",
+                    "kind": "architectural_decision",
+                    "confidence": 0.95,
+                },
+                {
+                    "decision_text": "Dave confirmed the recall direction.",
+                    "topic_slug": "dave-approval-recall",
+                    "kind": "dave_approval",
+                    "confidence": 0.9,
+                },
+            ]
+        )
+    )
+    writer, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, writer=writer)
+    assert result.decisions_saved == 2
+    assert result.skipped_reason is None
+    assert len(calls) == 2
+    callsign, key, value = calls[0]
+    assert callsign == "john"
+    assert key.startswith("ceo:conversation_capture:")
+    assert "hindsight-layer-2-recall" in key
+    assert value["kind"] == "architectural_decision"
+    assert value["customer_id"] == 42
+    assert value["captured_by"] == "john_exit_cycle"
+    assert result.keys_written == [c[1] for c in calls]
+
+
+def test_below_confidence_threshold_skips():
+    gemini = FakeGemini(
+        _success(
+            [
+                {
+                    "decision_text": "Maybe use X.",
+                    "topic_slug": "maybe-x",
+                    "kind": "architectural_decision",
+                    "confidence": 0.6,
+                }
+            ]
+        )
+    )
+    writer, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, writer=writer)
+    assert result.decisions_saved == 0
+    assert result.skipped_reason == "below_confidence_threshold"
+    assert calls == []
+
+
+def test_confidence_exactly_threshold_excluded():
+    gemini = FakeGemini(
+        _success(
+            [
+                {
+                    "decision_text": "Boundary case.",
+                    "topic_slug": "boundary",
+                    "kind": "confirmed_pattern",
+                    "confidence": 0.8,
+                }
+            ]
+        )
+    )
+    writer, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, writer=writer)
+    assert result.skipped_reason == "below_confidence_threshold"
+    assert calls == []
+
+
+def test_max_three_writes_cap():
+    items = [
+        {
+            "decision_text": f"Decision number {i}.",
+            "topic_slug": f"decision-{i}",
+            "kind": "architectural_decision",
+            "confidence": 0.99,
+        }
+        for i in range(5)
+    ]
+    gemini = FakeGemini(_success(items))
+    writer, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, writer=writer)
+    assert result.decisions_saved == 3
+    assert len(calls) == 3
+
+
+def test_invalid_kind_filtered():
+    gemini = FakeGemini(
+        _success(
+            [
+                {
+                    "decision_text": "Routine status update.",
+                    "topic_slug": "status",
+                    "kind": "status_update",
+                    "confidence": 0.99,
+                }
+            ]
+        )
+    )
+    writer, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, writer=writer)
+    assert result.skipped_reason == "below_confidence_threshold"
+    assert calls == []
+
+
+def test_empty_conversation_skips_without_gemini_call():
+    gemini = FakeGemini(_success([]))
+    writer, calls = _recorder()
+    result = _run([], gemini=gemini, writer=writer)
+    assert result.skipped_reason == "empty_conversation"
+    assert gemini.calls == []
+    assert calls == []
+
+
+def test_no_decisions_detected():
+    gemini = FakeGemini(_success([]))
+    writer, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, writer=writer)
+    assert result.skipped_reason == "no_decisions_detected"
+    assert calls == []
+
+
+def test_gemini_failure_is_fail_open():
+    gemini = FakeGemini(raises=RuntimeError("gemini 503"))
+    writer, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, writer=writer)
+    assert result.decisions_saved == 0
+    assert result.skipped_reason is not None
+    assert result.skipped_reason.startswith("classify_failed")
+    assert calls == []
+
+
+def test_gemini_non_success_status_yields_no_writes():
+    gemini = FakeGemini({"f3_status": "failed", "content": {}})
+    writer, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, writer=writer)
+    assert result.skipped_reason == "no_decisions_detected"
+    assert calls == []
+
+
+def test_db_write_failure_is_fail_open():
+    gemini = FakeGemini(
+        _success(
+            [
+                {
+                    "decision_text": "Use Hindsight Layer 2.",
+                    "topic_slug": "hindsight-l2",
+                    "kind": "architectural_decision",
+                    "confidence": 0.95,
+                }
+            ]
+        )
+    )
+
+    def boom(callsign: str, key: str, value: dict) -> None:
+        raise ConnectionError("db down")
+
+    result = _run(CONVO, gemini=gemini, writer=boom)
+    assert result.decisions_saved == 0
+    assert result.skipped_reason == "all_writes_failed"
+
+
+def test_partial_write_failure_counts_successes():
+    gemini = FakeGemini(
+        _success(
+            [
+                {
+                    "decision_text": "First decision.",
+                    "topic_slug": "first",
+                    "kind": "architectural_decision",
+                    "confidence": 0.95,
+                },
+                {
+                    "decision_text": "Second decision.",
+                    "topic_slug": "second",
+                    "kind": "confirmed_pattern",
+                    "confidence": 0.95,
+                },
+            ]
+        )
+    )
+    seen: list[str] = []
+
+    def flaky(callsign: str, key: str, value: dict) -> None:
+        if "second" in key:
+            raise ConnectionError("transient")
+        seen.append(key)
+
+    result = _run(CONVO, gemini=gemini, writer=flaky)
+    assert result.decisions_saved == 1
+    assert len(result.keys_written) == 1
+    assert "first" in result.keys_written[0]
+
+
+def test_classify_passes_response_schema_and_no_grounding():
+    gemini = FakeGemini(_success([]))
+    writer, _ = _recorder()
+    _run(CONVO, gemini=gemini, writer=writer)
+    assert gemini.calls, "comprehend should have been called"
+    kwargs = gemini.calls[0]
+    assert kwargs["enable_grounding"] is False
+    assert kwargs["response_schema"] is exit_cycle.RESPONSE_SCHEMA
+    assert "viktor:" in kwargs["user_prompt"]  # roles rendered into the prompt


### PR DESCRIPTION
## Summary
`src/keiracom_system/chat/exit_cycle.py` — the module John runs at the end of every conversation to detect ratified decisions and persist them before an ephemeral spawn exits.

**Interface (as specified):**
```python
async def classify_and_save(conversation: list[dict], customer_id: int) -> ExitCycleResult
# conversation items: {role: 'user'|'assistant'|'viktor', content: str}
# ExitCycleResult: {decisions_saved: int, keys_written: list[str], skipped_reason: str | None}
```

**Flow:** Gemini Flash classifies the conversation → keeps ratified architectural decisions / confirmed patterns / Dave approvals / Viktor explanations (drops status/questions/dispatch/casual) → writes each to `ceo:conversation_capture:{date}:{topic_slug}`. The atomiser then promotes to `fleet_decisions`; future spawns retrieve via Hindsight Layer 2.

**Constraints honored:**
- ✅ Fail-open — Gemini init/classify/write errors return `skipped_reason`, never block completion.
- ✅ Confidence > 0.8 gate (Gemini returns per-item confidence).
- ✅ Max 3 writes/conversation.
- ✅ Audit logging of every save (key, kind, confidence, decision excerpt).

## Tests
12 unit tests (mock Gemini + mock DB writer), `asyncio.run` (no async-mode config needed): happy path, confidence floor (incl. exact-0.8 boundary), max-3 cap, invalid-kind filter, empty conversation, no-detection, Gemini failure (fail-open), non-success status, DB-write failure (fail-open), partial-write, and the classify call passing `response_schema` + `enable_grounding=False`. Ruff clean.

## ⚠ One deviation from the dispatch (flagging for review)
Dispatch said "use DATABASE_URL_MIGRATIONS (asyncpg)". I instead reuse the **canonical KEI-87 writer** `src/governance/ceo_memory_writer.upsert_ceo_memory_key` (psycopg + `SET LOCAL agency_os.callsign`). Reason: `ceo:*` keys are subject to the KEI-87 write-guard trigger, which the canonical writer enforces and a raw asyncpg insert would not (and would be refused once the trigger is applied on prod). Called via `asyncio.to_thread` from the async path. The writer is injectable, so swapping the backend later is a one-liner.

## Notes
- `context_composer.py` (Atlas) and `docs/cutover/spawn_governance_template.md` referenced in the dispatch do not exist yet — built against `personas/john.md` + the existing `GeminiClient` + `ceo_memory_writer` patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)