### PR TITLE
[SCOUT] feat(cutover): post-cutover #ceo capture listener (Agency_OS-yku8)

### DIFF
--- a/scripts/ceo_capture_listener.py
+++ b/scripts/ceo_capture_listener.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""ceo_capture_listener.py — post-cutover #ceo capture listener (Agency_OS-yku8).
+
+Replaces the tmux-injecting elliot_slack_listener for the ephemeral model. After
+cutover there is no persistent pane, so this listener has NO tmux dependency: it
+watches #ceo over Slack Socket Mode (WebSocket, real-time) and, when a human
+message carries a capture-worthy signal, fires a John capture spawn via the
+dispatcher HTTP API.
+
+Pipeline per non-bot #ceo message:
+  Stage 1 (heuristic, free): does the text contain a ratification / architecture
+    / decision signal? If not → skip.
+  Stage 2 (Gemini Flash, only if stage 1 passed): classify DECISION | ARCHITECTURE
+    | DIRECTIVE | NOISE with a confidence 0..1.
+  Decision: spawn iff label != NOISE AND confidence > threshold (0.75).
+  Cost control: at most 5 spawns/hour (Redis/Valkey counter). Over cap → skip.
+
+Fail-open by contract: Gemini, the dispatcher, or the rate-limit store being
+unreachable NEVER crashes the listener — it logs and continues. The rate-limit
+gate fails *closed* on a counter error (skip the spawn to protect the cost cap)
+while the process keeps running.
+
+Security: the untrusted Slack message text is passed to the spawned capture
+process via an ENV var only — it is never interpolated into a shell command
+(command-injection guard).
+
+The listener itself is NOT an AI agent — it is a plain Python process. Heavy
+deps (slack_sdk, google.genai, redis) are imported lazily so the classification
++ decision logic is unit-testable without them installed.
+
+Env: SLACK_BOT_TOKEN, SLACK_ENFORCER_APP_TOKEN (Socket Mode app token),
+REDIS_URL (rate-limit counter), EMBEDDING/GEMINI key via GEMINI_API_KEY,
+DISPATCHER_URL (default http://127.0.0.1:4001).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("ceo_capture_listener")
+
+CEO_CHANNEL = os.environ.get("CEO_CAPTURE_CHANNEL", "C0B2PM3TV0B")
+DISPATCHER_URL = os.environ.get("DISPATCHER_URL", "http://127.0.0.1:4001").rstrip("/")
+CONFIDENCE_THRESHOLD = float(os.environ.get("CEO_CAPTURE_CONFIDENCE_THRESHOLD", "0.75"))
+MAX_SPAWNS_PER_HOUR = int(os.environ.get("CEO_CAPTURE_MAX_SPAWNS_PER_HOUR", "5"))
+RATE_LIMIT_KEY = "ceo_capture_listener:spawns_this_hour"
+GEMINI_MODEL = os.environ.get("CEO_CAPTURE_GEMINI_MODEL", "gemini-2.5-flash")
+JOHN_WORKING_DIR = os.environ.get("CEO_CAPTURE_WORKING_DIR", "/home/elliotbot/clawd/Agency_OS-john")
+# Capture command run inside the spawned session. The message text is NOT
+# interpolated here — it is read from the CEO_CAPTURE_MESSAGE env var the
+# dispatcher injects (injection-safe). Override per deploy as the John launch
+# mechanism settles.
+DEFAULT_CAPTURE_COMMAND = (
+    'python3 -c "import os; '
+    "from src.keiracom_system.chat.exit_cycle import classify_and_save; "
+    "classify_and_save(os.environ['CEO_CAPTURE_MESSAGE'])\""
+)
+CAPTURE_COMMAND = os.environ.get("CEO_CAPTURE_COMMAND", DEFAULT_CAPTURE_COMMAND)
+# Dispatcher spawn backend. The listener itself has zero terminal-multiplexer
+# dependency (Socket Mode + HTTP only); this only selects how the *dispatcher*
+# backs the short-lived capture session. Default "tmux" matches the current
+# dispatcher + John-workspace reality; set "container" for a fully ephemeral
+# spawn once the container backend is provisioned (post-cutover target).
+SPAWN_BACKEND = os.environ.get("CEO_CAPTURE_SPAWN_BACKEND", "tmux")
+
+VALID_LABELS = ("DECISION", "ARCHITECTURE", "DIRECTIVE", "NOISE")
+
+# ─── Stage 1 — free heuristic signals ─────────────────────────────────────────
+RATIFICATION_SIGNALS = ("ratified", "confirmed", "go ahead", "approved", "locked", "canonical")
+ARCHITECTURE_SIGNALS = (
+    "the architecture is",
+    "how this works",
+    "the design is",
+    "layer",
+    "system prompt",
+)
+DECISION_SIGNALS = ("we will use", "decision:", "always do", "never do", "the rule is")
+STAGE1_SIGNALS = RATIFICATION_SIGNALS + ARCHITECTURE_SIGNALS + DECISION_SIGNALS
+
+
+def stage1_heuristic(text: str) -> bool:
+    """Free first pass: does the text carry any capture-worthy signal?"""
+    low = (text or "").lower()
+    return any(signal in low for signal in STAGE1_SIGNALS)
+
+
+def stage2_classify(text: str) -> tuple[str, float]:
+    """Gemini Flash classifier → (label, confidence). Fail-open to ('NOISE', 0.0)."""
+    prompt = (
+        "Classify this #ceo message into exactly one label: DECISION, ARCHITECTURE, "
+        "DIRECTIVE, or NOISE. DECISION = a ratified choice/rule; ARCHITECTURE = an "
+        "explanation of how the system is designed; DIRECTIVE = an instruction to act; "
+        "NOISE = chatter with no durable signal. Respond ONLY as JSON: "
+        '{"label": "<LABEL>", "confidence": <0.0-1.0>}.\n\nMessage:\n' + (text or "")
+    )
+    try:
+        from google import genai
+
+        client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+        resp = client.models.generate_content(model=GEMINI_MODEL, contents=prompt)
+        return _parse_classification(resp.text)
+    except Exception:  # noqa: BLE001 — classification must never crash the listener
+        logger.warning("stage2 Gemini classify failed — treating as NOISE", exc_info=True)
+        return ("NOISE", 0.0)
+
+
+def _parse_classification(raw: str) -> tuple[str, float]:
+    """Parse the classifier's JSON (tolerant of code-fence wrapping)."""
+    body = (
+        (raw or "").strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+    )
+    data = json.loads(body)
+    label = str(data.get("label", "NOISE")).upper().strip()
+    if label not in VALID_LABELS:
+        label = "NOISE"
+    confidence = float(data.get("confidence", 0.0))
+    return (label, max(0.0, min(1.0, confidence)))
+
+
+def classify(text: str) -> tuple[bool, str, float]:
+    """Full pipeline decision (no side effects). Returns (should_spawn, label, confidence)."""
+    if not stage1_heuristic(text):
+        return (False, "STAGE1_SKIP", 0.0)
+    label, confidence = stage2_classify(text)
+    should = label != "NOISE" and confidence > CONFIDENCE_THRESHOLD
+    return (should, label, confidence)
+
+
+# ─── Rate limit (cost control) ────────────────────────────────────────────────
+
+
+def _redis_client():
+    """Lazy redis/valkey client from REDIS_URL/VALKEY_URL, or None if unconfigured."""
+    url = os.environ.get("REDIS_URL") or os.environ.get("VALKEY_URL")
+    if not url:
+        return None
+    import redis
+
+    return redis.from_url(url, socket_timeout=3, socket_connect_timeout=3)
+
+
+def within_rate_limit() -> bool:
+    """True if under the hourly spawn cap.
+
+    No store configured → rate limiting disabled (allow + warn). Store configured
+    but errors → fail CLOSED (skip the spawn to protect the cost cap), never crash.
+    """
+    try:
+        client = _redis_client()
+    except Exception:  # noqa: BLE001
+        logger.warning("rate-limit store error — skipping spawn to protect cost cap", exc_info=True)
+        return False
+    if client is None:
+        logger.warning("REDIS_URL unset — spawn rate limiting DISABLED")
+        return True
+    try:
+        current = int(client.get(RATE_LIMIT_KEY) or 0)
+    except Exception:  # noqa: BLE001
+        logger.warning("rate-limit read failed — skipping spawn to protect cost cap", exc_info=True)
+        return False
+    if current >= MAX_SPAWNS_PER_HOUR:
+        logger.info("rate limit reached (%d/%d this hour) — skip", current, MAX_SPAWNS_PER_HOUR)
+        return False
+    return True
+
+
+def record_spawn() -> None:
+    """Increment the hourly counter after a successful spawn (sets 1h TTL on first)."""
+    try:
+        client = _redis_client()
+        if client is None:
+            return
+        new_count = client.incr(RATE_LIMIT_KEY)
+        if int(new_count) == 1:
+            client.expire(RATE_LIMIT_KEY, 3600)
+    except Exception:  # noqa: BLE001 — counter bookkeeping must never crash the listener
+        logger.warning("rate-limit increment failed (non-fatal)", exc_info=True)
+
+
+# ─── Spawn a John capture session via the dispatcher ──────────────────────────
+
+
+def build_spawn_request(message_text: str) -> dict:
+    """SpawnRequest payload for /dispatcher/spawn. The untrusted message is carried
+    in env (CEO_CAPTURE_MESSAGE) — NEVER interpolated into the command string."""
+    import time as _time
+
+    key = f"ceo-capture-{int(_time.time() * 1000)}"
+    brief = (
+        "Classify and save this #ceo message to ceo_memory: "
+        f"{message_text}. Use src.keiracom_system.chat.exit_cycle.classify_and_save()"
+    )
+    return {
+        "backend": SPAWN_BACKEND,
+        "key": key,
+        "spawn_kwargs": {
+            "session_name": key,
+            "callsign": "john",
+            "task_type": "capture",
+            "working_dir": JOHN_WORKING_DIR,
+            "command": CAPTURE_COMMAND,
+            "brief": brief,
+            "env": {"CALLSIGN": "john", "CEO_CAPTURE_MESSAGE": message_text},
+        },
+        "ttl_s": 600.0,
+    }
+
+
+def post_spawn(payload: dict) -> bool:
+    """POST the spawn request to the dispatcher. Fail-open: log + return False on any error."""
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{DISPATCHER_URL}/dispatcher/spawn",
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            ok = 200 <= resp.status < 300
+        if ok:
+            logger.info("spawned John capture session key=%s", payload.get("key"))
+        return ok
+    except (urllib.error.URLError, OSError) as exc:
+        logger.warning("dispatcher spawn unreachable (%s) — skipping, listener continues", exc)
+        return False
+
+
+# ─── Message handling ─────────────────────────────────────────────────────────
+
+
+def is_capture_candidate(event: dict) -> bool:
+    """A top-level human text message in #ceo (not a bot, edit, join, or thread noise)."""
+    if event.get("bot_id") or event.get("subtype"):
+        return False
+    if event.get("channel") != CEO_CHANNEL:
+        return False
+    return bool((event.get("text") or "").strip())
+
+
+def handle_event(event: dict) -> str:
+    """Run the pipeline for one Slack event. Returns an action label (for logs/tests)."""
+    if not is_capture_candidate(event):
+        return "skip_not_candidate"
+    text = event["text"]
+    should, label, confidence = classify(text)
+    if not should:
+        logger.info("skip [%s conf=%.2f]: %s", label, confidence, text[:80])
+        return f"skip_{label.lower()}"
+    if not within_rate_limit():
+        return "skip_rate_limit"
+    if post_spawn(build_spawn_request(text)):
+        record_spawn()
+        return "spawned"
+    return "skip_spawn_failed"
+
+
+# ─── Socket Mode runtime ──────────────────────────────────────────────────────
+
+
+def main() -> int:
+    from slack_sdk.socket_mode import SocketModeClient
+    from slack_sdk.socket_mode.request import SocketModeRequest
+    from slack_sdk.socket_mode.response import SocketModeResponse
+    from slack_sdk.web import WebClient
+
+    bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+    app_token = os.environ.get("SLACK_ENFORCER_APP_TOKEN", "")
+    if not bot_token or not app_token:
+        logger.error("SLACK_BOT_TOKEN and SLACK_ENFORCER_APP_TOKEN are both required")
+        return 2
+
+    def _on_request(client: SocketModeClient, req: SocketModeRequest) -> None:
+        client.send_socket_mode_response(SocketModeResponse(envelope_id=req.envelope_id))
+        if req.type != "events_api":
+            return
+        try:
+            event = (req.payload or {}).get("event", {})
+            if event.get("type") == "message":
+                handle_event(event)
+        except Exception:  # noqa: BLE001 — one bad event must never kill the listener
+            logger.warning("event handling error (non-fatal)", exc_info=True)
+
+    sm = SocketModeClient(app_token=app_token, web_client=WebClient(token=bot_token))
+    sm.socket_mode_request_listeners.append(_on_request)
+    logger.info(
+        "ceo_capture_listener up — channel=%s threshold=%.2f cap=%d/h dispatcher=%s",
+        CEO_CHANNEL,
+        CONFIDENCE_THRESHOLD,
+        MAX_SPAWNS_PER_HOUR,
+        DISPATCHER_URL,
+    )
+    sm.connect()
+    import threading
+
+    threading.Event().wait()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ceo_capture_listener.py
+++ b/scripts/ceo_capture_listener.py
@@ -1,36 +1,27 @@
 #!/usr/bin/env python3
-"""ceo_capture_listener.py — post-cutover #ceo capture listener (Agency_OS-yku8).
+"""ceo_capture_listener.py — #ceo capture listener (Agency_OS-yku8, FINAL design).
 
-Replaces the tmux-injecting elliot_slack_listener for the ephemeral model. After
-cutover there is no persistent pane, so this listener has NO tmux dependency: it
-watches #ceo over Slack Socket Mode (WebSocket, real-time) and, when a human
-message carries a capture-worthy signal, fires a John capture spawn via the
-dispatcher HTTP API.
+Viktor-ratified 2026-05-28. Haiku is cheap enough (~0.6¢ AUD/spawn) to classify
+every #ceo message, so there is NO Python pre-filter, NO rate limiter, and NO
+buffer file. The flow is simply:
 
-Pipeline per non-bot #ceo message:
-  Stage 1 (heuristic, free): does the text contain a ratification / architecture
-    / decision signal? If not → skip.
-  Stage 2 (Gemini Flash, only if stage 1 passed): classify DECISION | ARCHITECTURE
-    | DIRECTIVE | NOISE with a confidence 0..1.
-  Decision: spawn iff label != NOISE AND confidence > threshold (0.75).
-  Cost control: at most 5 spawns/hour (Redis/Valkey counter). Over cap → skip.
+    #ceo Socket Mode event → spawn one claude-haiku-4-5 agent → agent classifies
+    → if decision/directive/ratified-architecture: write to ceo_memory via
+      src.keiracom_system.chat.exit_cycle.classify_and_save(); else exit, nothing
+      stored → agent exits.
 
-Fail-open by contract: Gemini, the dispatcher, or the rate-limit store being
-unreachable NEVER crashes the listener — it logs and continues. The rate-limit
-gate fails *closed* on a counter error (skip the spawn to protect the cost cap)
-while the process keeps running.
+The listener is NOT an AI agent — it is a thin Socket Mode → dispatcher bridge.
+No tmux / send-keys dependency of any kind. Fail-open: a dispatcher outage or a
+bad event logs and is skipped; the listener never crashes. `slack_sdk` is
+lazy-imported so the bridge logic is unit-testable without it installed.
 
-Security: the untrusted Slack message text is passed to the spawned capture
-process via an ENV var only — it is never interpolated into a shell command
-(command-injection guard).
-
-The listener itself is NOT an AI agent — it is a plain Python process. Heavy
-deps (slack_sdk, google.genai, redis) are imported lazily so the classification
-+ decision logic is unit-testable without them installed.
+Security: the untrusted Slack message text is handed to the spawned agent via an
+ENV var only (`CEO_CAPTURE_MESSAGE`) — it is never interpolated into the spawn
+command string (command-injection guard).
 
 Env: SLACK_BOT_TOKEN, SLACK_ENFORCER_APP_TOKEN (Socket Mode app token),
-REDIS_URL (rate-limit counter), EMBEDDING/GEMINI key via GEMINI_API_KEY,
-DISPATCHER_URL (default http://127.0.0.1:4001).
+DISPATCHER_URL (default http://127.0.0.1:4001), CEO_CAPTURE_MODEL
+(default claude-haiku-4-5 — Dave directive 2026-05-28).
 """
 
 from __future__ import annotations
@@ -38,6 +29,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 import urllib.error
 import urllib.request
 
@@ -46,155 +38,46 @@ logger = logging.getLogger("ceo_capture_listener")
 
 CEO_CHANNEL = os.environ.get("CEO_CAPTURE_CHANNEL", "C0B2PM3TV0B")
 DISPATCHER_URL = os.environ.get("DISPATCHER_URL", "http://127.0.0.1:4001").rstrip("/")
-CONFIDENCE_THRESHOLD = float(os.environ.get("CEO_CAPTURE_CONFIDENCE_THRESHOLD", "0.75"))
-MAX_SPAWNS_PER_HOUR = int(os.environ.get("CEO_CAPTURE_MAX_SPAWNS_PER_HOUR", "5"))
-RATE_LIMIT_KEY = "ceo_capture_listener:spawns_this_hour"
-GEMINI_MODEL = os.environ.get("CEO_CAPTURE_GEMINI_MODEL", "gemini-2.5-flash")
-JOHN_WORKING_DIR = os.environ.get("CEO_CAPTURE_WORKING_DIR", "/home/elliotbot/clawd/Agency_OS-john")
-# Capture command run inside the spawned session. The message text is NOT
-# interpolated here — it is read from the CEO_CAPTURE_MESSAGE env var the
-# dispatcher injects (injection-safe). Override per deploy as the John launch
-# mechanism settles.
-DEFAULT_CAPTURE_COMMAND = (
-    'python3 -c "import os; '
-    "from src.keiracom_system.chat.exit_cycle import classify_and_save; "
-    "classify_and_save(os.environ['CEO_CAPTURE_MESSAGE'])\""
+# Tier-2 listener-agent model — claude-haiku-4-5 per Dave directive 2026-05-28.
+CAPTURE_MODEL = os.environ.get("CEO_CAPTURE_MODEL", "claude-haiku-4-5")
+CAPTURE_WORKING_DIR = os.environ.get(
+    "CEO_CAPTURE_WORKING_DIR", "/home/elliotbot/clawd/Agency_OS-john"
 )
-CAPTURE_COMMAND = os.environ.get("CEO_CAPTURE_COMMAND", DEFAULT_CAPTURE_COMMAND)
-# Dispatcher spawn backend. The listener itself has zero terminal-multiplexer
-# dependency (Socket Mode + HTTP only); this only selects how the *dispatcher*
-# backs the short-lived capture session. Default "tmux" matches the current
-# dispatcher + John-workspace reality; set "container" for a fully ephemeral
-# spawn once the container backend is provisioned (post-cutover target).
 SPAWN_BACKEND = os.environ.get("CEO_CAPTURE_SPAWN_BACKEND", "tmux")
-
-VALID_LABELS = ("DECISION", "ARCHITECTURE", "DIRECTIVE", "NOISE")
-
-# ─── Stage 1 — free heuristic signals ─────────────────────────────────────────
-RATIFICATION_SIGNALS = ("ratified", "confirmed", "go ahead", "approved", "locked", "canonical")
-ARCHITECTURE_SIGNALS = (
-    "the architecture is",
-    "how this works",
-    "the design is",
-    "layer",
-    "system prompt",
+CAPTURE_BRIEF = (
+    "Classify this #ceo message. Is it a ratified decision, a directive, or a "
+    "ratified architecture/'how it works' explanation? If YES: extract it as a "
+    "clean self-contained statement and write it to ceo_memory by calling "
+    "src.keiracom_system.chat.exit_cycle.classify_and_save() with a single-message "
+    "conversation. If it is NOISE (chatter, acknowledgement, a bare question): "
+    "exit with nothing stored. The message text is in the CEO_CAPTURE_MESSAGE env var."
 )
-DECISION_SIGNALS = ("we will use", "decision:", "always do", "never do", "the rule is")
-STAGE1_SIGNALS = RATIFICATION_SIGNALS + ARCHITECTURE_SIGNALS + DECISION_SIGNALS
+# Agent launch command run inside the spawned session. The message is read from
+# the env var at runtime (shell expansion of the injected env) — it is NEVER
+# interpolated into this string by Python, so untrusted text cannot inject shell.
+# Override per deploy as the agent-launch mechanism settles.
+CAPTURE_COMMAND = os.environ.get(
+    "CEO_CAPTURE_COMMAND",
+    'claude -p --model "$CEO_CAPTURE_MODEL" --append-system-prompt "$CEO_CAPTURE_BRIEF" '
+    '-- "$CEO_CAPTURE_MESSAGE"',
+)
 
 
-def stage1_heuristic(text: str) -> bool:
-    """Free first pass: does the text carry any capture-worthy signal?"""
-    low = (text or "").lower()
-    return any(signal in low for signal in STAGE1_SIGNALS)
-
-
-def stage2_classify(text: str) -> tuple[str, float]:
-    """Gemini Flash classifier → (label, confidence). Fail-open to ('NOISE', 0.0)."""
-    prompt = (
-        "Classify this #ceo message into exactly one label: DECISION, ARCHITECTURE, "
-        "DIRECTIVE, or NOISE. DECISION = a ratified choice/rule; ARCHITECTURE = an "
-        "explanation of how the system is designed; DIRECTIVE = an instruction to act; "
-        "NOISE = chatter with no durable signal. Respond ONLY as JSON: "
-        '{"label": "<LABEL>", "confidence": <0.0-1.0>}.\n\nMessage:\n' + (text or "")
-    )
-    try:
-        from google import genai
-
-        client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
-        resp = client.models.generate_content(model=GEMINI_MODEL, contents=prompt)
-        return _parse_classification(resp.text)
-    except Exception:  # noqa: BLE001 — classification must never crash the listener
-        logger.warning("stage2 Gemini classify failed — treating as NOISE", exc_info=True)
-        return ("NOISE", 0.0)
-
-
-def _parse_classification(raw: str) -> tuple[str, float]:
-    """Parse the classifier's JSON (tolerant of code-fence wrapping)."""
-    body = (
-        (raw or "").strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
-    )
-    data = json.loads(body)
-    label = str(data.get("label", "NOISE")).upper().strip()
-    if label not in VALID_LABELS:
-        label = "NOISE"
-    confidence = float(data.get("confidence", 0.0))
-    return (label, max(0.0, min(1.0, confidence)))
-
-
-def classify(text: str) -> tuple[bool, str, float]:
-    """Full pipeline decision (no side effects). Returns (should_spawn, label, confidence)."""
-    if not stage1_heuristic(text):
-        return (False, "STAGE1_SKIP", 0.0)
-    label, confidence = stage2_classify(text)
-    should = label != "NOISE" and confidence > CONFIDENCE_THRESHOLD
-    return (should, label, confidence)
-
-
-# ─── Rate limit (cost control) ────────────────────────────────────────────────
-
-
-def _redis_client():
-    """Lazy redis/valkey client from REDIS_URL/VALKEY_URL, or None if unconfigured."""
-    url = os.environ.get("REDIS_URL") or os.environ.get("VALKEY_URL")
-    if not url:
-        return None
-    import redis
-
-    return redis.from_url(url, socket_timeout=3, socket_connect_timeout=3)
-
-
-def within_rate_limit() -> bool:
-    """True if under the hourly spawn cap.
-
-    No store configured → rate limiting disabled (allow + warn). Store configured
-    but errors → fail CLOSED (skip the spawn to protect the cost cap), never crash.
-    """
-    try:
-        client = _redis_client()
-    except Exception:  # noqa: BLE001
-        logger.warning("rate-limit store error — skipping spawn to protect cost cap", exc_info=True)
+def is_human_ceo_message(event: dict) -> bool:
+    """Event hygiene only (NOT a content filter): a top-level human text message
+    in #ceo. Bot messages + edits/joins are skipped so the listener never spawns
+    on its own fleet's posts (loop/cost guard)."""
+    if event.get("type") != "message" or event.get("bot_id") or event.get("subtype"):
         return False
-    if client is None:
-        logger.warning("REDIS_URL unset — spawn rate limiting DISABLED")
-        return True
-    try:
-        current = int(client.get(RATE_LIMIT_KEY) or 0)
-    except Exception:  # noqa: BLE001
-        logger.warning("rate-limit read failed — skipping spawn to protect cost cap", exc_info=True)
+    if event.get("channel") != CEO_CHANNEL:
         return False
-    if current >= MAX_SPAWNS_PER_HOUR:
-        logger.info("rate limit reached (%d/%d this hour) — skip", current, MAX_SPAWNS_PER_HOUR)
-        return False
-    return True
+    return bool((event.get("text") or "").strip())
 
 
-def record_spawn() -> None:
-    """Increment the hourly counter after a successful spawn (sets 1h TTL on first)."""
-    try:
-        client = _redis_client()
-        if client is None:
-            return
-        new_count = client.incr(RATE_LIMIT_KEY)
-        if int(new_count) == 1:
-            client.expire(RATE_LIMIT_KEY, 3600)
-    except Exception:  # noqa: BLE001 — counter bookkeeping must never crash the listener
-        logger.warning("rate-limit increment failed (non-fatal)", exc_info=True)
-
-
-# ─── Spawn a John capture session via the dispatcher ──────────────────────────
-
-
-def build_spawn_request(message_text: str) -> dict:
+def build_spawn_request(text: str) -> dict:
     """SpawnRequest payload for /dispatcher/spawn. The untrusted message is carried
-    in env (CEO_CAPTURE_MESSAGE) — NEVER interpolated into the command string."""
-    import time as _time
-
-    key = f"ceo-capture-{int(_time.time() * 1000)}"
-    brief = (
-        "Classify and save this #ceo message to ceo_memory: "
-        f"{message_text}. Use src.keiracom_system.chat.exit_cycle.classify_and_save()"
-    )
+    in env (CEO_CAPTURE_MESSAGE) — never interpolated into the command."""
+    key = f"ceo-capture-{int(time.time() * 1000)}"
     return {
         "backend": SPAWN_BACKEND,
         "key": key,
@@ -202,65 +85,45 @@ def build_spawn_request(message_text: str) -> dict:
             "session_name": key,
             "callsign": "john",
             "task_type": "capture",
-            "working_dir": JOHN_WORKING_DIR,
+            "model": CAPTURE_MODEL,
+            "working_dir": CAPTURE_WORKING_DIR,
             "command": CAPTURE_COMMAND,
-            "brief": brief,
-            "env": {"CALLSIGN": "john", "CEO_CAPTURE_MESSAGE": message_text},
+            "brief": CAPTURE_BRIEF,
+            "env": {
+                "CALLSIGN": "john",
+                "CEO_CAPTURE_MODEL": CAPTURE_MODEL,
+                "CEO_CAPTURE_BRIEF": CAPTURE_BRIEF,
+                "CEO_CAPTURE_MESSAGE": text,
+            },
         },
         "ttl_s": 600.0,
     }
 
 
-def post_spawn(payload: dict) -> bool:
-    """POST the spawn request to the dispatcher. Fail-open: log + return False on any error."""
-    data = json.dumps(payload).encode("utf-8")
+def spawn_capture_agent(text: str) -> bool:
+    """POST the spawn request to the dispatcher. Fail-open: log + return False on error."""
+    payload = build_spawn_request(text)
     req = urllib.request.Request(
         f"{DISPATCHER_URL}/dispatcher/spawn",
-        data=data,
+        data=json.dumps(payload).encode("utf-8"),
         method="POST",
         headers={"Content-Type": "application/json"},
     )
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             ok = 200 <= resp.status < 300
-        if ok:
-            logger.info("spawned John capture session key=%s", payload.get("key"))
+        logger.info("spawned %s capture agent key=%s ok=%s", CAPTURE_MODEL, payload["key"], ok)
         return ok
     except (urllib.error.URLError, OSError) as exc:
-        logger.warning("dispatcher spawn unreachable (%s) — skipping, listener continues", exc)
+        logger.warning("dispatcher spawn failed (%s) — listener continues", exc)
         return False
-
-
-# ─── Message handling ─────────────────────────────────────────────────────────
-
-
-def is_capture_candidate(event: dict) -> bool:
-    """A top-level human text message in #ceo (not a bot, edit, join, or thread noise)."""
-    if event.get("bot_id") or event.get("subtype"):
-        return False
-    if event.get("channel") != CEO_CHANNEL:
-        return False
-    return bool((event.get("text") or "").strip())
 
 
 def handle_event(event: dict) -> str:
-    """Run the pipeline for one Slack event. Returns an action label (for logs/tests)."""
-    if not is_capture_candidate(event):
-        return "skip_not_candidate"
-    text = event["text"]
-    should, label, confidence = classify(text)
-    if not should:
-        logger.info("skip [%s conf=%.2f]: %s", label, confidence, text[:80])
-        return f"skip_{label.lower()}"
-    if not within_rate_limit():
-        return "skip_rate_limit"
-    if post_spawn(build_spawn_request(text)):
-        record_spawn()
-        return "spawned"
-    return "skip_spawn_failed"
-
-
-# ─── Socket Mode runtime ──────────────────────────────────────────────────────
+    """Spawn a Haiku capture agent for one human #ceo message. Returns an action label."""
+    if not is_human_ceo_message(event):
+        return "skip"
+    return "spawned" if spawn_capture_agent(event["text"]) else "spawn_failed"
 
 
 def main() -> int:
@@ -280,19 +143,16 @@ def main() -> int:
         if req.type != "events_api":
             return
         try:
-            event = (req.payload or {}).get("event", {})
-            if event.get("type") == "message":
-                handle_event(event)
+            handle_event((req.payload or {}).get("event", {}))
         except Exception:  # noqa: BLE001 — one bad event must never kill the listener
             logger.warning("event handling error (non-fatal)", exc_info=True)
 
     sm = SocketModeClient(app_token=app_token, web_client=WebClient(token=bot_token))
     sm.socket_mode_request_listeners.append(_on_request)
     logger.info(
-        "ceo_capture_listener up — channel=%s threshold=%.2f cap=%d/h dispatcher=%s",
+        "ceo_capture_listener up — channel=%s model=%s dispatcher=%s",
         CEO_CHANNEL,
-        CONFIDENCE_THRESHOLD,
-        MAX_SPAWNS_PER_HOUR,
+        CAPTURE_MODEL,
         DISPATCHER_URL,
     )
     sm.connect()

--- a/scripts/systemd/ceo-capture-listener.service
+++ b/scripts/systemd/ceo-capture-listener.service
@@ -1,0 +1,25 @@
+[Unit]
+# Post-cutover #ceo capture listener (Slack Socket Mode) — Agency_OS-yku8.
+# Replaces elliot_slack_listener for the ephemeral model: no pane, no send-keys,
+# no terminal-multiplexer dependency of any kind.
+Description=#ceo capture listener (post-cutover, Slack Socket Mode)
+After=network-online.target
+Wants=network-online.target
+# Restart-storm cap (these are [Unit] directives — ignored if placed in [Service]).
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+# Paths point at the main worktree — all fleet services run from there on latest
+# main (NOT a callsign worktree).
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/ceo_capture_listener.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:/home/elliotbot/clawd/logs/ceo-capture-listener.log
+StandardError=append:/home/elliotbot/clawd/logs/ceo-capture-listener.log
+
+[Install]
+WantedBy=default.target

--- a/tests/scripts/test_ceo_capture_listener.py
+++ b/tests/scripts/test_ceo_capture_listener.py
@@ -1,21 +1,24 @@
-"""Tests for scripts/ceo_capture_listener.py (Agency_OS-yku8).
+"""Tests for scripts/ceo_capture_listener.py (Agency_OS-yku8, final design).
 
-Exercises the classification pipeline, the rate-limit gate, the injection-safe
-spawn-payload builder, and the end-to-end handle_event decision — all without
-slack_sdk / google.genai / redis installed (the listener lazy-imports those, so
-the logic layer is importable + testable in hermetic CI).
+Final design: Socket Mode → spawn one claude-haiku-4-5 agent per human #ceo
+message. No Python content pre-filter, no rate limiter, no buffer. The listener
+is a thin bridge; classification + the ceo_memory write are the spawned agent's
+job. These tests cover the bridge: event hygiene, the spawn payload (model +
+injection-safety), fail-open, and handle_event decisions.
 
-The dispatch's smoke ("post a test message in #ceo, verify spawn triggered or
-correctly skipped") is realised deterministically via handle_event on synthetic
-#ceo events — no live Slack post (Scout must not post to the Dave-facing #ceo).
+Runs without slack_sdk installed (lazy-imported in main()).
+
+Smoke note: the dispatch smoke ("substantive → write; 'ok' → no write") is an
+END-TO-END check of the Haiku agent + classify_and_save (PR #1268) + live Slack
+— not runnable hermetically and not the listener's decision. At the listener
+level BOTH substantive and 'ok' spawn (no Python filter); the write-vs-exit
+distinction is the agent's. test_smoke_* assert the listener-level behaviour.
 """
 
 from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
-
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "ceo_capture_listener.py"
@@ -41,127 +44,50 @@ def _event(text, *, bot_id=None, subtype=None, channel=CEO, etype="message"):
     return e
 
 
-# ─── Stage 1 heuristic ────────────────────────────────────────────────────────
+# ─── event hygiene ────────────────────────────────────────────────────────────
 
 
-@pytest.mark.parametrize(
-    "text",
-    [
-        "This is now ratified — go ahead.",
-        "Decision: we will use Hindsight as the engine.",
-        "the architecture is a layered system prompt design",
-        "The rule is: never do X.",
-    ],
-)
-def test_stage1_passes_on_signals(text):
-    assert m.stage1_heuristic(text) is True
+def test_human_ceo_message_accepted():
+    assert m.is_human_ceo_message(_event("We ratified the multi-tenancy decision.")) is True
+    assert m.is_human_ceo_message(_event("ok")) is True  # no content filter — 'ok' still qualifies
 
 
-def test_stage1_skips_plain_chatter():
-    assert m.stage1_heuristic("thanks, looks good, talk later") is False
-    assert m.stage1_heuristic("") is False
+def test_bot_subtype_wrongchannel_empty_rejected():
+    assert m.is_human_ceo_message(_event("decision", bot_id="B123")) is False
+    assert m.is_human_ceo_message(_event("x", subtype="message_changed")) is False
+    assert m.is_human_ceo_message(_event("x", channel="C_OTHER")) is False
+    assert m.is_human_ceo_message(_event("   ")) is False
+    assert m.is_human_ceo_message(_event("x", etype="reaction_added")) is False
 
 
-# ─── classify pipeline (stage2 mocked) ────────────────────────────────────────
+# ─── spawn payload ────────────────────────────────────────────────────────────
 
 
-def test_classify_skips_stage2_when_stage1_fails(monkeypatch):
-    monkeypatch.setattr(m, "stage2_classify", lambda t: pytest.fail("stage2 must not run"))
-    should, label, conf = m.classify("just chatter, nothing here")
-    assert should is False and label == "STAGE1_SKIP" and conf == 0.0
-
-
-def test_classify_spawns_on_high_confidence_decision(monkeypatch):
-    monkeypatch.setattr(m, "stage2_classify", lambda t: ("DECISION", 0.91))
-    should, label, conf = m.classify("Decision: we will use X. ratified.")
-    assert should is True and label == "DECISION"
-
-
-def test_classify_skips_noise_even_if_confident(monkeypatch):
-    monkeypatch.setattr(m, "stage2_classify", lambda t: ("NOISE", 0.99))
-    should, _, _ = m.classify("the rule is be nice")
-    assert should is False
-
-
-def test_classify_skips_below_threshold(monkeypatch):
-    monkeypatch.setattr(m, "stage2_classify", lambda t: ("DECISION", 0.70))  # == threshold, not >
-    should, _, _ = m.classify("Decision: maybe we use X")
-    assert should is False
-
-
-# ─── _parse_classification ────────────────────────────────────────────────────
-
-
-def test_parse_handles_code_fenced_json():
-    label, conf = m._parse_classification('```json\n{"label":"ARCHITECTURE","confidence":0.8}\n```')
-    assert label == "ARCHITECTURE" and conf == pytest.approx(0.8)
-
-
-def test_parse_clamps_and_defaults_invalid_label():
-    label, conf = m._parse_classification('{"label":"WAT","confidence":1.7}')
-    assert label == "NOISE" and conf == 1.0
-
-
-# ─── rate limit ───────────────────────────────────────────────────────────────
-
-
-def test_rate_limit_disabled_when_no_store(monkeypatch):
-    monkeypatch.setattr(m, "_redis_client", lambda: None)
-    assert m.within_rate_limit() is True
-
-
-def test_rate_limit_allows_under_cap(monkeypatch):
-    class _C:
-        def get(self, k):
-            return b"2"
-
-    monkeypatch.setattr(m, "_redis_client", lambda: _C())
-    assert m.within_rate_limit() is True
-
-
-def test_rate_limit_blocks_at_cap(monkeypatch):
-    class _C:
-        def get(self, k):
-            return str(m.MAX_SPAWNS_PER_HOUR).encode()
-
-    monkeypatch.setattr(m, "_redis_client", lambda: _C())
-    assert m.within_rate_limit() is False
-
-
-def test_rate_limit_fails_closed_on_store_error(monkeypatch):
-    def _boom():
-        raise RuntimeError("redis down")
-
-    monkeypatch.setattr(m, "_redis_client", _boom)
-    assert m.within_rate_limit() is False  # protect the cost cap
-
-
-# ─── spawn payload (injection safety) ─────────────────────────────────────────
-
-
-def test_build_spawn_request_shape():
-    p = m.build_spawn_request("the rule is X")
-    assert p["backend"] == "tmux"
+def test_spawn_request_uses_haiku_model():
+    p = m.build_spawn_request("the decision is X")
+    assert p["spawn_kwargs"]["model"] == "claude-haiku-4-5"
+    assert p["spawn_kwargs"]["env"]["CEO_CAPTURE_MODEL"] == "claude-haiku-4-5"
+    assert p["backend"] == m.SPAWN_BACKEND
     assert p["key"].startswith("ceo-capture-")
     assert p["spawn_kwargs"]["callsign"] == "john"
-    assert "the rule is X" in p["spawn_kwargs"]["brief"]
 
 
-def test_build_spawn_request_is_injection_safe():
-    """Untrusted message with shell metacharacters must live ONLY in env, never in
-    the command string."""
+def test_spawn_request_carries_message_in_env_not_command():
+    """Injection guard: untrusted message lives in env only; the command references
+    it by env-var name and never contains the raw text."""
     nasty = 'ratified"; rm -rf / #'
     p = m.build_spawn_request(nasty)
     sk = p["spawn_kwargs"]
-    assert sk["env"]["CEO_CAPTURE_MESSAGE"] == nasty  # carried via env
-    assert nasty not in sk["command"]  # NOT interpolated into the shell command
+    assert sk["env"]["CEO_CAPTURE_MESSAGE"] == nasty
+    assert nasty not in sk["command"]
     assert "rm -rf" not in sk["command"]
+    assert "$CEO_CAPTURE_MESSAGE" in sk["command"]  # referenced, not interpolated
 
 
-# ─── post_spawn (fail-open) ───────────────────────────────────────────────────
+# ─── spawn call (fail-open) ───────────────────────────────────────────────────
 
 
-def test_post_spawn_true_on_2xx(monkeypatch):
+def test_spawn_true_on_2xx(monkeypatch):
     class _Resp:
         status = 200
 
@@ -172,58 +98,45 @@ def test_post_spawn_true_on_2xx(monkeypatch):
             return False
 
     monkeypatch.setattr(m.urllib.request, "urlopen", lambda *a, **k: _Resp())
-    assert m.post_spawn({"key": "k"}) is True
+    assert m.spawn_capture_agent("decision: X") is True
 
 
-def test_post_spawn_fails_open_when_dispatcher_down(monkeypatch):
+def test_spawn_fails_open_when_dispatcher_down(monkeypatch):
     def _boom(*a, **k):
         raise m.urllib.error.URLError("connection refused")
 
     monkeypatch.setattr(m.urllib.request, "urlopen", _boom)
-    assert m.post_spawn({"key": "k"}) is False  # logged, not raised
+    assert m.spawn_capture_agent("decision: X") is False  # logged, not raised
 
 
-# ─── is_capture_candidate ─────────────────────────────────────────────────────
+# ─── handle_event (the deterministic smoke) ───────────────────────────────────
 
 
-def test_candidate_rejects_bot_subtype_wrongchannel_empty():
-    assert m.is_capture_candidate(_event("hi", bot_id="B123")) is False
-    assert m.is_capture_candidate(_event("hi", subtype="message_changed")) is False
-    assert m.is_capture_candidate(_event("hi", channel="C_OTHER")) is False
-    assert m.is_capture_candidate(_event("   ")) is False
-    assert m.is_capture_candidate(_event("real human message")) is True
-
-
-# ─── handle_event — the deterministic smoke ───────────────────────────────────
-
-
-def test_smoke_capture_worthy_message_spawns(monkeypatch):
-    monkeypatch.setattr(m, "stage2_classify", lambda t: ("DECISION", 0.92))
-    monkeypatch.setattr(m, "within_rate_limit", lambda: True)
-    spawned = {}
-    monkeypatch.setattr(m, "post_spawn", lambda payload: spawned.update(payload) or True)
-    monkeypatch.setattr(m, "record_spawn", lambda: None)
-    action = m.handle_event(_event("Decision: we will use Hindsight. This is ratified."))
+def test_smoke_substantive_message_spawns(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(m, "spawn_capture_agent", lambda t: captured.update(text=t) or True)
+    action = m.handle_event(_event("Decision: we will use Hindsight. Ratified by Dave."))
     assert action == "spawned"
-    assert spawned["spawn_kwargs"]["callsign"] == "john"
+    assert "Hindsight" in captured["text"]
 
 
-def test_smoke_noise_message_skips_without_gemini(monkeypatch):
-    # No stage-1 signal → stage2 never runs → skip (free path).
-    monkeypatch.setattr(m, "stage2_classify", lambda t: pytest.fail("stage2 must not run"))
-    action = m.handle_event(_event("thanks team, great work today"))
-    assert action == "skip_stage1_skip"
+def test_smoke_ok_still_spawns_at_listener_level(monkeypatch):
+    """No Python pre-filter: even 'ok' spawns a Haiku agent (which then exits with
+    no write — the agent's decision, not the listener's)."""
+    calls = []
+    monkeypatch.setattr(m, "spawn_capture_agent", lambda t: calls.append(t) or True)
+    action = m.handle_event(_event("ok"))
+    assert action == "spawned"
+    assert calls == ["ok"]
 
 
-def test_handle_event_skips_when_rate_limited(monkeypatch):
-    monkeypatch.setattr(m, "stage2_classify", lambda t: ("DECISION", 0.95))
-    monkeypatch.setattr(m, "within_rate_limit", lambda: False)
-    monkeypatch.setattr(m, "post_spawn", lambda p: pytest.fail("must not spawn when rate-limited"))
-    action = m.handle_event(_event("Decision: ratified, we will use X"))
-    assert action == "skip_rate_limit"
+def test_bot_message_does_not_spawn(monkeypatch):
+    monkeypatch.setattr(
+        m, "spawn_capture_agent", lambda t: (_ for _ in ()).throw(AssertionError("no spawn on bot"))
+    )
+    assert m.handle_event(_event("Decision: ratified", bot_id="B0B2W7VL7T4")) == "skip"
 
 
-def test_handle_event_skips_bot_message(monkeypatch):
-    monkeypatch.setattr(m, "stage2_classify", lambda t: pytest.fail("must not classify a bot msg"))
-    action = m.handle_event(_event("Decision: ratified", bot_id="B0B2W7VL7T4"))
-    assert action == "skip_not_candidate"
+def test_handle_event_reports_spawn_failure(monkeypatch):
+    monkeypatch.setattr(m, "spawn_capture_agent", lambda t: False)
+    assert m.handle_event(_event("Decision: real human decision here")) == "spawn_failed"

--- a/tests/scripts/test_ceo_capture_listener.py
+++ b/tests/scripts/test_ceo_capture_listener.py
@@ -1,0 +1,229 @@
+"""Tests for scripts/ceo_capture_listener.py (Agency_OS-yku8).
+
+Exercises the classification pipeline, the rate-limit gate, the injection-safe
+spawn-payload builder, and the end-to-end handle_event decision — all without
+slack_sdk / google.genai / redis installed (the listener lazy-imports those, so
+the logic layer is importable + testable in hermetic CI).
+
+The dispatch's smoke ("post a test message in #ceo, verify spawn triggered or
+correctly skipped") is realised deterministically via handle_event on synthetic
+#ceo events — no live Slack post (Scout must not post to the Dave-facing #ceo).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "ceo_capture_listener.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_ceo_capture_listener", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+m = _load()
+CEO = m.CEO_CHANNEL
+
+
+def _event(text, *, bot_id=None, subtype=None, channel=CEO, etype="message"):
+    e = {"type": etype, "channel": channel, "text": text}
+    if bot_id:
+        e["bot_id"] = bot_id
+    if subtype:
+        e["subtype"] = subtype
+    return e
+
+
+# ─── Stage 1 heuristic ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "This is now ratified — go ahead.",
+        "Decision: we will use Hindsight as the engine.",
+        "the architecture is a layered system prompt design",
+        "The rule is: never do X.",
+    ],
+)
+def test_stage1_passes_on_signals(text):
+    assert m.stage1_heuristic(text) is True
+
+
+def test_stage1_skips_plain_chatter():
+    assert m.stage1_heuristic("thanks, looks good, talk later") is False
+    assert m.stage1_heuristic("") is False
+
+
+# ─── classify pipeline (stage2 mocked) ────────────────────────────────────────
+
+
+def test_classify_skips_stage2_when_stage1_fails(monkeypatch):
+    monkeypatch.setattr(m, "stage2_classify", lambda t: pytest.fail("stage2 must not run"))
+    should, label, conf = m.classify("just chatter, nothing here")
+    assert should is False and label == "STAGE1_SKIP" and conf == 0.0
+
+
+def test_classify_spawns_on_high_confidence_decision(monkeypatch):
+    monkeypatch.setattr(m, "stage2_classify", lambda t: ("DECISION", 0.91))
+    should, label, conf = m.classify("Decision: we will use X. ratified.")
+    assert should is True and label == "DECISION"
+
+
+def test_classify_skips_noise_even_if_confident(monkeypatch):
+    monkeypatch.setattr(m, "stage2_classify", lambda t: ("NOISE", 0.99))
+    should, _, _ = m.classify("the rule is be nice")
+    assert should is False
+
+
+def test_classify_skips_below_threshold(monkeypatch):
+    monkeypatch.setattr(m, "stage2_classify", lambda t: ("DECISION", 0.70))  # == threshold, not >
+    should, _, _ = m.classify("Decision: maybe we use X")
+    assert should is False
+
+
+# ─── _parse_classification ────────────────────────────────────────────────────
+
+
+def test_parse_handles_code_fenced_json():
+    label, conf = m._parse_classification('```json\n{"label":"ARCHITECTURE","confidence":0.8}\n```')
+    assert label == "ARCHITECTURE" and conf == pytest.approx(0.8)
+
+
+def test_parse_clamps_and_defaults_invalid_label():
+    label, conf = m._parse_classification('{"label":"WAT","confidence":1.7}')
+    assert label == "NOISE" and conf == 1.0
+
+
+# ─── rate limit ───────────────────────────────────────────────────────────────
+
+
+def test_rate_limit_disabled_when_no_store(monkeypatch):
+    monkeypatch.setattr(m, "_redis_client", lambda: None)
+    assert m.within_rate_limit() is True
+
+
+def test_rate_limit_allows_under_cap(monkeypatch):
+    class _C:
+        def get(self, k):
+            return b"2"
+
+    monkeypatch.setattr(m, "_redis_client", lambda: _C())
+    assert m.within_rate_limit() is True
+
+
+def test_rate_limit_blocks_at_cap(monkeypatch):
+    class _C:
+        def get(self, k):
+            return str(m.MAX_SPAWNS_PER_HOUR).encode()
+
+    monkeypatch.setattr(m, "_redis_client", lambda: _C())
+    assert m.within_rate_limit() is False
+
+
+def test_rate_limit_fails_closed_on_store_error(monkeypatch):
+    def _boom():
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(m, "_redis_client", _boom)
+    assert m.within_rate_limit() is False  # protect the cost cap
+
+
+# ─── spawn payload (injection safety) ─────────────────────────────────────────
+
+
+def test_build_spawn_request_shape():
+    p = m.build_spawn_request("the rule is X")
+    assert p["backend"] == "tmux"
+    assert p["key"].startswith("ceo-capture-")
+    assert p["spawn_kwargs"]["callsign"] == "john"
+    assert "the rule is X" in p["spawn_kwargs"]["brief"]
+
+
+def test_build_spawn_request_is_injection_safe():
+    """Untrusted message with shell metacharacters must live ONLY in env, never in
+    the command string."""
+    nasty = 'ratified"; rm -rf / #'
+    p = m.build_spawn_request(nasty)
+    sk = p["spawn_kwargs"]
+    assert sk["env"]["CEO_CAPTURE_MESSAGE"] == nasty  # carried via env
+    assert nasty not in sk["command"]  # NOT interpolated into the shell command
+    assert "rm -rf" not in sk["command"]
+
+
+# ─── post_spawn (fail-open) ───────────────────────────────────────────────────
+
+
+def test_post_spawn_true_on_2xx(monkeypatch):
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(m.urllib.request, "urlopen", lambda *a, **k: _Resp())
+    assert m.post_spawn({"key": "k"}) is True
+
+
+def test_post_spawn_fails_open_when_dispatcher_down(monkeypatch):
+    def _boom(*a, **k):
+        raise m.urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(m.urllib.request, "urlopen", _boom)
+    assert m.post_spawn({"key": "k"}) is False  # logged, not raised
+
+
+# ─── is_capture_candidate ─────────────────────────────────────────────────────
+
+
+def test_candidate_rejects_bot_subtype_wrongchannel_empty():
+    assert m.is_capture_candidate(_event("hi", bot_id="B123")) is False
+    assert m.is_capture_candidate(_event("hi", subtype="message_changed")) is False
+    assert m.is_capture_candidate(_event("hi", channel="C_OTHER")) is False
+    assert m.is_capture_candidate(_event("   ")) is False
+    assert m.is_capture_candidate(_event("real human message")) is True
+
+
+# ─── handle_event — the deterministic smoke ───────────────────────────────────
+
+
+def test_smoke_capture_worthy_message_spawns(monkeypatch):
+    monkeypatch.setattr(m, "stage2_classify", lambda t: ("DECISION", 0.92))
+    monkeypatch.setattr(m, "within_rate_limit", lambda: True)
+    spawned = {}
+    monkeypatch.setattr(m, "post_spawn", lambda payload: spawned.update(payload) or True)
+    monkeypatch.setattr(m, "record_spawn", lambda: None)
+    action = m.handle_event(_event("Decision: we will use Hindsight. This is ratified."))
+    assert action == "spawned"
+    assert spawned["spawn_kwargs"]["callsign"] == "john"
+
+
+def test_smoke_noise_message_skips_without_gemini(monkeypatch):
+    # No stage-1 signal → stage2 never runs → skip (free path).
+    monkeypatch.setattr(m, "stage2_classify", lambda t: pytest.fail("stage2 must not run"))
+    action = m.handle_event(_event("thanks team, great work today"))
+    assert action == "skip_stage1_skip"
+
+
+def test_handle_event_skips_when_rate_limited(monkeypatch):
+    monkeypatch.setattr(m, "stage2_classify", lambda t: ("DECISION", 0.95))
+    monkeypatch.setattr(m, "within_rate_limit", lambda: False)
+    monkeypatch.setattr(m, "post_spawn", lambda p: pytest.fail("must not spawn when rate-limited"))
+    action = m.handle_event(_event("Decision: ratified, we will use X"))
+    assert action == "skip_rate_limit"
+
+
+def test_handle_event_skips_bot_message(monkeypatch):
+    monkeypatch.setattr(m, "stage2_classify", lambda t: pytest.fail("must not classify a bot msg"))
+    action = m.handle_event(_event("Decision: ratified", bot_id="B0B2W7VL7T4"))
+    assert action == "skip_not_candidate"


### PR DESCRIPTION
## Summary
`scripts/ceo_capture_listener.py` — the post-cutover replacement for `elliot_slack_listener`. **No pane, no send-keys, no terminal-multiplexer dependency.** Watches #ceo (`C0B2PM3TV0B`) over Slack **Socket Mode** (WebSocket, real-time) and fires a John capture spawn via the dispatcher HTTP API when a human message carries a durable signal.

## Pipeline (per non-bot #ceo message)
1. **Stage 1 — heuristic (free):** ratification / architecture / decision signal present? No → skip (Gemini never called).
2. **Stage 2 — Gemini Flash (only if stage 1 passes):** classify `DECISION | ARCHITECTURE | DIRECTIVE | NOISE` + confidence.
3. **Decision:** spawn iff `label != NOISE` AND `confidence > 0.75`.
4. **Cost control:** ≤5 spawns/hour via Redis counter `ceo_capture_listener:spawns_this_hour` (INCR + 1h TTL).
5. **Spawn:** `POST /dispatcher/spawn` with the John capture brief.

## Robustness & security
- **Fail-open:** Gemini / dispatcher / counter unreachable → log and continue; **never crashes** the listener. The rate-limit gate fails *closed* on a counter error (skip the spawn to protect the cost cap) while the process keeps running.
- **Injection-safe:** untrusted Slack message text is passed to the spawned process via an **env var only** — never interpolated into a shell command.
- **Testable core:** `slack_sdk` / `google.genai` / `redis` are lazy-imported, so the classifier + rate-limit + decision logic is unit-tested without them installed.

## Deliverables
- `scripts/ceo_capture_listener.py`
- `scripts/systemd/ceo-capture-listener.service` — `Restart=on-failure`, reads `~/.config/agency-os/.env`, main-worktree paths, no tmux. (Fixed a latent bug copied from sibling units: `StartLimit*` belongs in `[Unit]`, not `[Service]` — `systemd-analyze verify` now clean.)
- `tests/scripts/test_ceo_capture_listener.py` — **24 tests**.

## Verification (raw)
- `pytest tests/scripts/test_ceo_capture_listener.py` → **24 passed**.
- Module imports cleanly without slack_sdk/redis/genai; `ruff check` clean; `systemd-analyze verify` clean.
- **Smoke (deterministic):** `handle_event` on a synthetic ratification message → `spawned`; on chatter → skipped *without* calling Gemini. (No live #ceo post — Scout must not post to the Dave-facing channel; the live post-and-observe is an operator step once deployed.)

## GOV-9 findings (flagged to Elliot)
1. **`src.keiracom_system.chat.exit_cycle.classify_and_save()` does not exist yet** — the listener only references it in the spawn *brief*, so the trigger layer is independently shippable, but end-to-end capture won't complete until John's capture function lands. (Listener fail-opens on the spawn response.)
2. **The "old listener" (`elliot_slack_listener.py`) is polling-based, not Socket Mode** — the real Socket Mode pattern is in `central_listener.py`, which I mirrored.
3. **systemd dir:** placed at the dispatch's literal `scripts/systemd/` path; the established convention is `./systemd/`. Trivial to relocate if preferred.
4. **Spawn backend:** `backend` defaults to `tmux` (matches current dispatcher + John-workspace reality) but is env-configurable (`CEO_CAPTURE_SPAWN_BACKEND=container`). The listener has zero tmux dependency; this only selects how the *dispatcher* backs the short-lived session. Recommend deciding tmux-vs-container for the ephemeral model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)