### PR TITLE
[SCOUT] feat(listener): post-cutover #ceo Haiku listener — Socket Mode spawn-per-message

### DIFF
--- a/scripts/ceo_capture_listener.py
+++ b/scripts/ceo_capture_listener.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""ceo_capture_listener.py — #ceo capture listener (Agency_OS-yku8, FINAL design).
+
+Viktor-ratified 2026-05-28. Haiku is cheap enough (~0.6¢ AUD/spawn) to classify
+every #ceo message, so there is NO Python pre-filter, NO rate limiter, and NO
+buffer file. The flow is simply:
+
+    #ceo Socket Mode event → spawn one claude-haiku-4-5 agent → agent classifies
+    → if decision/directive/ratified-architecture: write to ceo_memory via
+      src.keiracom_system.chat.exit_cycle.classify_and_save(); else exit, nothing
+      stored → agent exits.
+
+The listener is NOT an AI agent — it is a thin Socket Mode → dispatcher bridge.
+No tmux / send-keys dependency of any kind. Fail-open: a dispatcher outage or a
+bad event logs and is skipped; the listener never crashes. `slack_sdk` is
+lazy-imported so the bridge logic is unit-testable without it installed.
+
+Security: the untrusted Slack message text is handed to the spawned agent via an
+ENV var only (`CEO_CAPTURE_MESSAGE`) — it is never interpolated into the spawn
+command string (command-injection guard).
+
+Env: SLACK_BOT_TOKEN, SLACK_ENFORCER_APP_TOKEN (Socket Mode app token),
+DISPATCHER_URL (default http://127.0.0.1:4001), CEO_CAPTURE_MODEL
+(default claude-haiku-4-5 — Dave directive 2026-05-28).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("ceo_capture_listener")
+
+CEO_CHANNEL = os.environ.get("CEO_CAPTURE_CHANNEL", "C0B2PM3TV0B")
+DISPATCHER_URL = os.environ.get("DISPATCHER_URL", "http://127.0.0.1:4001").rstrip("/")
+# Tier-2 listener-agent model — claude-haiku-4-5 per Dave directive 2026-05-28.
+CAPTURE_MODEL = os.environ.get("CEO_CAPTURE_MODEL", "claude-haiku-4-5")
+CAPTURE_WORKING_DIR = os.environ.get(
+    "CEO_CAPTURE_WORKING_DIR", "/home/elliotbot/clawd/Agency_OS-john"
+)
+SPAWN_BACKEND = os.environ.get("CEO_CAPTURE_SPAWN_BACKEND", "tmux")
+CAPTURE_BRIEF = (
+    "Classify this #ceo message. Is it a ratified decision, a directive, or a "
+    "ratified architecture/'how it works' explanation? If YES: extract it as a "
+    "clean self-contained statement and write it to ceo_memory by calling "
+    "src.keiracom_system.chat.exit_cycle.classify_and_save() with a single-message "
+    "conversation. If it is NOISE (chatter, acknowledgement, a bare question): "
+    "exit with nothing stored. The message text is in the CEO_CAPTURE_MESSAGE env var."
+)
+# Agent launch command run inside the spawned session. The message is read from
+# the env var at runtime (shell expansion of the injected env) — it is NEVER
+# interpolated into this string by Python, so untrusted text cannot inject shell.
+# Override per deploy as the agent-launch mechanism settles.
+CAPTURE_COMMAND = os.environ.get(
+    "CEO_CAPTURE_COMMAND",
+    'claude -p --model "$CEO_CAPTURE_MODEL" --append-system-prompt "$CEO_CAPTURE_BRIEF" '
+    '-- "$CEO_CAPTURE_MESSAGE"',
+)
+
+
+def is_human_ceo_message(event: dict) -> bool:
+    """Event hygiene only (NOT a content filter): a top-level human text message
+    in #ceo. Bot messages + edits/joins are skipped so the listener never spawns
+    on its own fleet's posts (loop/cost guard)."""
+    if event.get("type") != "message" or event.get("bot_id") or event.get("subtype"):
+        return False
+    if event.get("channel") != CEO_CHANNEL:
+        return False
+    return bool((event.get("text") or "").strip())
+
+
+def build_spawn_request(text: str) -> dict:
+    """SpawnRequest payload for /dispatcher/spawn. The untrusted message is carried
+    in env (CEO_CAPTURE_MESSAGE) — never interpolated into the command."""
+    key = f"ceo-capture-{int(time.time() * 1000)}"
+    return {
+        "backend": SPAWN_BACKEND,
+        "key": key,
+        "spawn_kwargs": {
+            "session_name": key,
+            "callsign": "john",
+            "task_type": "capture",
+            "model": CAPTURE_MODEL,
+            "working_dir": CAPTURE_WORKING_DIR,
+            "command": CAPTURE_COMMAND,
+            "brief": CAPTURE_BRIEF,
+            "env": {
+                "CALLSIGN": "john",
+                "CEO_CAPTURE_MODEL": CAPTURE_MODEL,
+                "CEO_CAPTURE_BRIEF": CAPTURE_BRIEF,
+                "CEO_CAPTURE_MESSAGE": text,
+            },
+        },
+        "ttl_s": 600.0,
+    }
+
+
+def spawn_capture_agent(text: str) -> bool:
+    """POST the spawn request to the dispatcher. Fail-open: log + return False on error."""
+    payload = build_spawn_request(text)
+    req = urllib.request.Request(
+        f"{DISPATCHER_URL}/dispatcher/spawn",
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            ok = 200 <= resp.status < 300
+        logger.info("spawned %s capture agent key=%s ok=%s", CAPTURE_MODEL, payload["key"], ok)
+        return ok
+    except (urllib.error.URLError, OSError) as exc:
+        logger.warning("dispatcher spawn failed (%s) — listener continues", exc)
+        return False
+
+
+def handle_event(event: dict) -> str:
+    """Spawn a Haiku capture agent for one human #ceo message. Returns an action label."""
+    if not is_human_ceo_message(event):
+        return "skip"
+    return "spawned" if spawn_capture_agent(event["text"]) else "spawn_failed"
+
+
+def main() -> int:
+    from slack_sdk.socket_mode import SocketModeClient
+    from slack_sdk.socket_mode.request import SocketModeRequest
+    from slack_sdk.socket_mode.response import SocketModeResponse
+    from slack_sdk.web import WebClient
+
+    bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+    app_token = os.environ.get("SLACK_ENFORCER_APP_TOKEN", "")
+    if not bot_token or not app_token:
+        logger.error("SLACK_BOT_TOKEN and SLACK_ENFORCER_APP_TOKEN are both required")
+        return 2
+
+    def _on_request(client: SocketModeClient, req: SocketModeRequest) -> None:
+        client.send_socket_mode_response(SocketModeResponse(envelope_id=req.envelope_id))
+        if req.type != "events_api":
+            return
+        try:
+            handle_event((req.payload or {}).get("event", {}))
+        except Exception:  # noqa: BLE001 — one bad event must never kill the listener
+            logger.warning("event handling error (non-fatal)", exc_info=True)
+
+    sm = SocketModeClient(app_token=app_token, web_client=WebClient(token=bot_token))
+    sm.socket_mode_request_listeners.append(_on_request)
+    logger.info(
+        "ceo_capture_listener up — channel=%s model=%s dispatcher=%s",
+        CEO_CHANNEL,
+        CAPTURE_MODEL,
+        DISPATCHER_URL,
+    )
+    sm.connect()
+    import threading
+
+    threading.Event().wait()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/systemd/ceo-capture-listener.service
+++ b/scripts/systemd/ceo-capture-listener.service
@@ -1,0 +1,25 @@
+[Unit]
+# Post-cutover #ceo capture listener (Slack Socket Mode) — Agency_OS-yku8.
+# Replaces elliot_slack_listener for the ephemeral model: no pane, no send-keys,
+# no terminal-multiplexer dependency of any kind.
+Description=#ceo capture listener (post-cutover, Slack Socket Mode)
+After=network-online.target
+Wants=network-online.target
+# Restart-storm cap (these are [Unit] directives — ignored if placed in [Service]).
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+# Paths point at the main worktree — all fleet services run from there on latest
+# main (NOT a callsign worktree).
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/ceo_capture_listener.py
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:/home/elliotbot/clawd/logs/ceo-capture-listener.log
+StandardError=append:/home/elliotbot/clawd/logs/ceo-capture-listener.log
+
+[Install]
+WantedBy=default.target

--- a/tests/scripts/test_ceo_capture_listener.py
+++ b/tests/scripts/test_ceo_capture_listener.py
@@ -1,0 +1,142 @@
+"""Tests for scripts/ceo_capture_listener.py (Agency_OS-yku8, final design).
+
+Final design: Socket Mode → spawn one claude-haiku-4-5 agent per human #ceo
+message. No Python content pre-filter, no rate limiter, no buffer. The listener
+is a thin bridge; classification + the ceo_memory write are the spawned agent's
+job. These tests cover the bridge: event hygiene, the spawn payload (model +
+injection-safety), fail-open, and handle_event decisions.
+
+Runs without slack_sdk installed (lazy-imported in main()).
+
+Smoke note: the dispatch smoke ("substantive → write; 'ok' → no write") is an
+END-TO-END check of the Haiku agent + classify_and_save (PR #1268) + live Slack
+— not runnable hermetically and not the listener's decision. At the listener
+level BOTH substantive and 'ok' spawn (no Python filter); the write-vs-exit
+distinction is the agent's. test_smoke_* assert the listener-level behaviour.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "ceo_capture_listener.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_ceo_capture_listener", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+m = _load()
+CEO = m.CEO_CHANNEL
+
+
+def _event(text, *, bot_id=None, subtype=None, channel=CEO, etype="message"):
+    e = {"type": etype, "channel": channel, "text": text}
+    if bot_id:
+        e["bot_id"] = bot_id
+    if subtype:
+        e["subtype"] = subtype
+    return e
+
+
+# ─── event hygiene ────────────────────────────────────────────────────────────
+
+
+def test_human_ceo_message_accepted():
+    assert m.is_human_ceo_message(_event("We ratified the multi-tenancy decision.")) is True
+    assert m.is_human_ceo_message(_event("ok")) is True  # no content filter — 'ok' still qualifies
+
+
+def test_bot_subtype_wrongchannel_empty_rejected():
+    assert m.is_human_ceo_message(_event("decision", bot_id="B123")) is False
+    assert m.is_human_ceo_message(_event("x", subtype="message_changed")) is False
+    assert m.is_human_ceo_message(_event("x", channel="C_OTHER")) is False
+    assert m.is_human_ceo_message(_event("   ")) is False
+    assert m.is_human_ceo_message(_event("x", etype="reaction_added")) is False
+
+
+# ─── spawn payload ────────────────────────────────────────────────────────────
+
+
+def test_spawn_request_uses_haiku_model():
+    p = m.build_spawn_request("the decision is X")
+    assert p["spawn_kwargs"]["model"] == "claude-haiku-4-5"
+    assert p["spawn_kwargs"]["env"]["CEO_CAPTURE_MODEL"] == "claude-haiku-4-5"
+    assert p["backend"] == m.SPAWN_BACKEND
+    assert p["key"].startswith("ceo-capture-")
+    assert p["spawn_kwargs"]["callsign"] == "john"
+
+
+def test_spawn_request_carries_message_in_env_not_command():
+    """Injection guard: untrusted message lives in env only; the command references
+    it by env-var name and never contains the raw text."""
+    nasty = 'ratified"; rm -rf / #'
+    p = m.build_spawn_request(nasty)
+    sk = p["spawn_kwargs"]
+    assert sk["env"]["CEO_CAPTURE_MESSAGE"] == nasty
+    assert nasty not in sk["command"]
+    assert "rm -rf" not in sk["command"]
+    assert "$CEO_CAPTURE_MESSAGE" in sk["command"]  # referenced, not interpolated
+
+
+# ─── spawn call (fail-open) ───────────────────────────────────────────────────
+
+
+def test_spawn_true_on_2xx(monkeypatch):
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(m.urllib.request, "urlopen", lambda *a, **k: _Resp())
+    assert m.spawn_capture_agent("decision: X") is True
+
+
+def test_spawn_fails_open_when_dispatcher_down(monkeypatch):
+    def _boom(*a, **k):
+        raise m.urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(m.urllib.request, "urlopen", _boom)
+    assert m.spawn_capture_agent("decision: X") is False  # logged, not raised
+
+
+# ─── handle_event (the deterministic smoke) ───────────────────────────────────
+
+
+def test_smoke_substantive_message_spawns(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(m, "spawn_capture_agent", lambda t: captured.update(text=t) or True)
+    action = m.handle_event(_event("Decision: we will use Hindsight. Ratified by Dave."))
+    assert action == "spawned"
+    assert "Hindsight" in captured["text"]
+
+
+def test_smoke_ok_still_spawns_at_listener_level(monkeypatch):
+    """No Python pre-filter: even 'ok' spawns a Haiku agent (which then exits with
+    no write — the agent's decision, not the listener's)."""
+    calls = []
+    monkeypatch.setattr(m, "spawn_capture_agent", lambda t: calls.append(t) or True)
+    action = m.handle_event(_event("ok"))
+    assert action == "spawned"
+    assert calls == ["ok"]
+
+
+def test_bot_message_does_not_spawn(monkeypatch):
+    monkeypatch.setattr(
+        m, "spawn_capture_agent", lambda t: (_ for _ in ()).throw(AssertionError("no spawn on bot"))
+    )
+    assert m.handle_event(_event("Decision: ratified", bot_id="B0B2W7VL7T4")) == "skip"
+
+
+def test_handle_event_reports_spawn_failure(monkeypatch):
+    monkeypatch.setattr(m, "spawn_capture_agent", lambda t: False)
+    assert m.handle_event(_event("Decision: real human decision here")) == "spawn_failed"


### PR DESCRIPTION
## Summary
Agency_OS-yku8 (P1, cutover-gating). The post-cutover replacement for the tmux-injecting `elliot_slack_listener`. **Dave go-signal 2026-05-28; Viktor-ratified single-tier design.**

Flow: **#ceo Slack Socket Mode event → spawn one `claude-haiku-4-5` agent per message via `/dispatcher/spawn` → the agent does full semantic classification** and, if the message is a decision / directive / ratified architecture, writes it to `ceo_memory` via `src.keiracom_system.chat.exit_cycle.classify_and_save()`; otherwise it exits with nothing stored.

**No pre-filter** — Haiku is cheap (~0.6¢ AUD/spawn, ~$8 AUD/mo at 100 msg/day), so every #ceo message gets full classification.

## Deliverables
- **`scripts/ceo_capture_listener.py`** — thin Socket Mode → dispatcher bridge (~60 lines logic). Only event hygiene in Python (skip bot/edit/join events + wrong channel + empty) to avoid self-trigger loops — **not** a content filter. **No tmux / send-keys.** Fail-open: classify/dispatcher errors log and skip, never crash the listener. `slack_sdk` lazy-imported so the logic is unit-testable without it. **Security:** untrusted message handed to the agent via env (`CEO_CAPTURE_MESSAGE`) only — never interpolated into the spawn command.
- **`scripts/systemd/ceo-capture-listener.service`** — `Restart=on-failure`, reads `~/.config/agency-os/.env`, main-worktree paths, no tmux, `StartLimit*` correctly in `[Unit]` (`systemd-analyze verify` clean).
- **`tests/scripts/test_ceo_capture_listener.py`** — 10 tests.

## Verification (raw)
- `pytest tests/scripts/test_ceo_capture_listener.py` → **10 passed**.
- Module imports without `slack_sdk`; `ruff check` clean; `systemd-analyze verify` clean.
- Listener-level smoke: substantive message → spawn requested (message in env, model `claude-haiku-4-5`); `ok` → also spawns (no Python filter; the agent exits no-write); bot message → skipped.

## Notes
- **Supersedes PR #1269** (the same final design built during the rapid yku8 design revisions, on the older `scout/ceo-capture-listener` branch with messy 3-iteration lineage). This PR is the clean single-commit version on the dispatch-named branch — #1269 closed as superseded.
- **Dependency:** `exit_cycle.classify_and_save` (Nova PR #1268) is not merged yet — the listener references it only in the agent brief, so it ships independently, but end-to-end capture needs #1268 first.
- **Verify before deploy:** the agent-launch command default (`claude -p --model … --append-system-prompt …`) is a best guess; override via `CEO_CAPTURE_COMMAND` in the deploy env if the real launch differs. Spawn backend defaults to `tmux` (`CEO_CAPTURE_SPAWN_BACKEND=container` for fully-ephemeral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)