### PR TITLE
[ORION] feat(dispatcher): 4-layer retrieval orchestrator wiring

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -58,7 +58,7 @@ from src.relay.budget_ceiling import (
     BudgetCeilingGate,
     BudgetDecision,
 )
-from src.retrieval import spawn_recall
+from src.retrieval import retrieval_orchestrator, spawn_recall
 from src.retrieval.workflow_recall import CHARS_PER_TOKEN, WorkflowRecallContext
 from src.utils.log_safe import scrub
 
@@ -291,6 +291,12 @@ def _recall_block(
         # (matching spawn_recall.inject_prior_context's own outer catch) still
         # yields an empty block rather than a 500.
         try:
+            # 4-layer retrieval orchestrator (RETRIEVAL_ORCHESTRATOR_4LAYER_ENABLED,
+            # default off): L1 recall → L2 rerank → L3 contradiction filter →
+            # L4 compression. Additive — when off, the existing single-layer path
+            # below runs unchanged. Both are fail-open by contract.
+            if retrieval_orchestrator.four_layer_enabled():
+                return retrieval_orchestrator.assemble_hydration_block(task_type, task_brief)
             # build_spawn_context_block = positive recall + (flag-gated) failure
             # recall. Byte-identical to the positive-only block when
             # RETRIEVAL_FAILURE_RECALL_ENABLED is off (Wave 6).

--- a/src/retrieval/compression.py
+++ b/src/retrieval/compression.py
@@ -1,0 +1,41 @@
+"""Layer 4 — compression (STUB).
+
+Position in the retrieval orchestrator: L1 semantic recall → L2 rerank →
+L3 contradiction filter → **L4 compression** → spawn hydration.
+
+Purpose (when complete): compress the assembled hydration block to the highest-
+signal content that fits the spawn token budget — extractive/semantic
+summarisation that keeps the load-bearing sentences and discards filler.
+
+▸ STATUS: STUB (`IS_STUB = True`). The real semantic compressor is in progress.
+Until it lands this applies the **honest minimal compression**: a hard clamp to
+the token budget (~4 chars/token, the same KEI-55 ceiling spawn_recall already
+enforces). This guarantees the budget invariant without pretending to do
+summarisation. **Fail-open:** any error returns the input clamped, or unchanged
+if even clamping fails — L4 must never block a spawn.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+CHARS_PER_TOKEN = 4  # belt-and-suspenders approximation, matches spawn_recall
+
+# Marks this layer as a not-yet-real stub (semantic compression pending).
+IS_STUB = True
+
+
+def compress(block: str, *, max_tokens: int) -> str:
+    """L4 stub: clamp the block to the token budget, fail-open.
+
+    Replace the body with real semantic/extractive compression when L4 lands;
+    keep the budget invariant (output never exceeds max_tokens) and the
+    fail-open contract (never raise).
+    """
+    try:
+        return block[: max_tokens * CHARS_PER_TOKEN]
+    except Exception:  # noqa: BLE001 — L4 must never block hydration
+        logger.debug("compression stub failed — returning block unchanged", exc_info=True)
+        return block

--- a/src/retrieval/contradiction_filter.py
+++ b/src/retrieval/contradiction_filter.py
@@ -1,0 +1,42 @@
+"""Layer 3 — contradiction filtering (STUB).
+
+Position in the retrieval orchestrator: L1 semantic recall → L2 rerank →
+**L3 contradiction filter** → L4 compression → spawn hydration.
+
+Purpose (when complete): drop recall results that contradict a higher-ranked or
+more-recent result — e.g. a superseded decision surfacing alongside its
+successor — so the hydration payload never feeds an ephemeral agent two
+conflicting "canonical" answers.
+
+▸ STATUS: STUB (`IS_STUB = True`). The real implementation — pairwise
+contradiction detection over recalled atoms, superseded-edge awareness from the
+decision graph — is in progress. Until it lands this is an **identity pass**:
+results are returned unchanged so the 4-layer pipeline is wired end-to-end
+without altering behaviour. **Fail-open:** any error returns the input
+untouched — L3 must never drop the whole context or block a spawn.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Marks this layer as a not-yet-real stub. Callers / tests assert on it so the
+# stub status is observable, not buried in a docstring.
+IS_STUB = True
+
+
+def filter_contradictions(results: list[str]) -> list[str]:
+    """L3 stub: return recall results unchanged (identity), fail-open.
+
+    Replace the body with real contradiction detection when L3 lands; keep the
+    fail-open contract (never raise, never return None).
+    """
+    try:
+        # TODO(L3-real): detect contradicted results (superseded edges, pairwise
+        # entailment) and drop them. Stub = identity to wire the pipeline.
+        return list(results)
+    except Exception:  # noqa: BLE001 — L3 must never block hydration
+        logger.debug("contradiction_filter stub failed — passing results through", exc_info=True)
+        return results

--- a/src/retrieval/retrieval_orchestrator.py
+++ b/src/retrieval/retrieval_orchestrator.py
@@ -1,0 +1,87 @@
+"""Retrieval Orchestrator — 4-layer spawn-hydration assembly (ratified arch).
+
+    Dispatcher → [ L1 semantic recall → L2 rerank → L3 contradiction filter →
+                   L4 compression ] → spawn hydration
+
+L1 + L2 are already built — they are the recall + cross-encoder rerank behind
+`spawn_recall.query_for_spawn` / `query_failures_for_spawn` (which call
+`agent_query.query` → `orchestrator.retrieve_with_outcome`). L3 and L4 are
+fail-open stubs (`contradiction_filter` / `compression`, both `IS_STUB = True`)
+until their real implementations land. The Graphiti doctrine graph is Phase 2
+and is deliberately NOT wired here.
+
+This module is the single assembly point that runs a query through all four
+layers and returns the hydration block an ephemeral spawn receives (placed in
+`env[AGENCY_OS_PRIOR_CONTEXT]` by `spawn_recall.inject_block`).
+
+Gated behind `RETRIEVAL_ORCHESTRATOR_4LAYER_ENABLED` (default off). When off the
+dispatcher uses the existing `spawn_recall.build_spawn_context_block` path
+unchanged — this is purely additive. Fail-open at every layer: a failure in any
+layer degrades to the content gathered so far, never an exception to the spawn.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from src.retrieval import compression, contradiction_filter, spawn_recall
+
+logger = logging.getLogger(__name__)
+
+_FOUR_LAYER_ENABLED_ENV = "RETRIEVAL_ORCHESTRATOR_4LAYER_ENABLED"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def four_layer_enabled() -> bool:
+    """True when RETRIEVAL_ORCHESTRATOR_4LAYER_ENABLED is set truthy (default off)."""
+    return os.environ.get(_FOUR_LAYER_ENABLED_ENV, "").lower() in _TRUTHY
+
+
+def assemble_hydration_block(task_type: str, task_brief: str) -> str:
+    """Run a spawn query through all 4 retrieval layers → hydration block.
+
+    L1+L2 (recall+rerank) produce the positive and negative result sets; L3
+    filters contradictions from each; the sets are formatted + combined; L4
+    compresses the combined block to the token budget. Every layer is fail-open
+    (the underlying calls swallow their own errors); the outer guard is
+    belt-and-suspenders so a catastrophic raise still yields "" rather than
+    blocking the spawn.
+    """
+    try:
+        # L1 + L2 — semantic recall + cross-encoder rerank (already built).
+        positive = spawn_recall.query_for_spawn(task_type, task_brief)
+        failures = spawn_recall.query_failures_for_spawn(task_type, task_brief)
+
+        # L3 — contradiction filter (stub, identity, fail-open).
+        positive = contradiction_filter.filter_contradictions(positive)
+        failures = contradiction_filter.filter_contradictions(failures)
+
+        # Format each set with spawn_recall's canonical block builders.
+        blocks = [
+            spawn_recall.build_prior_context_block(positive),
+            spawn_recall.build_failure_context_block(failures),
+        ]
+        combined = "\n\n".join(block for block in blocks if block)
+
+        # L4 — compression (stub, budget clamp, fail-open).
+        return compression.compress(combined, max_tokens=spawn_recall.MAX_TOKENS)
+    except Exception:  # noqa: BLE001 — 4-layer assembly must never block a spawn
+        logger.debug("4-layer hydration assembly failed — empty block", exc_info=True)
+        return ""
+
+
+def inject_hydration(spawn_kwargs: dict, *, task_type: str, task_brief: str) -> dict:
+    """Assemble the 4-layer block and inject it into the spawn env.
+
+    Fail-open: on any error returns `spawn_kwargs` unchanged (matching
+    `spawn_recall.inject_prior_context`'s contract). Reuses
+    `spawn_recall.inject_block` so the env key + empty-block handling stay
+    identical to the single-layer path.
+    """
+    try:
+        block = assemble_hydration_block(task_type, task_brief)
+        return spawn_recall.inject_block(spawn_kwargs, block)
+    except Exception:  # noqa: BLE001 — injection must never block a spawn
+        logger.debug("inject_hydration failed — spawn proceeds unchanged", exc_info=True)
+        return spawn_kwargs

--- a/tests/retrieval/test_retrieval_orchestrator.py
+++ b/tests/retrieval/test_retrieval_orchestrator.py
@@ -1,0 +1,118 @@
+"""4-layer retrieval orchestrator wiring tests.
+
+Covers the L3/L4 stubs (identity + budget-clamp, fail-open, IS_STUB marked) and
+the orchestrator that chains L1 recall → L2 rerank → L3 contradiction filter →
+L4 compression into the spawn-hydration payload. L1+L2 are mocked at the
+spawn_recall boundary so no live Hindsight is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.retrieval import (
+    compression,
+    contradiction_filter,
+    retrieval_orchestrator,
+    spawn_recall,
+)
+
+# ── L3 contradiction filter (stub) ───────────────────────────────────────
+
+
+def test_contradiction_filter_is_marked_stub_and_identity():
+    assert contradiction_filter.IS_STUB is True
+    assert contradiction_filter.filter_contradictions(["a", "b"]) == ["a", "b"]
+
+
+def test_contradiction_filter_fail_open_on_bad_input():
+    # list(None) raises inside the try → fail-open returns the input unchanged.
+    assert contradiction_filter.filter_contradictions(None) is None  # type: ignore[arg-type]
+
+
+# ── L4 compression (stub) ────────────────────────────────────────────────
+
+
+def test_compression_is_marked_stub_and_clamps_to_budget():
+    assert compression.IS_STUB is True
+    out = compression.compress("x" * 100, max_tokens=10)
+    assert out == "x" * 40  # 10 tokens * 4 chars/token
+
+
+def test_compression_leaves_under_budget_block_intact():
+    assert compression.compress("short block", max_tokens=500) == "short block"
+
+
+# ── four_layer_enabled flag ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("val,expected", [("1", True), ("on", True), ("true", True)])
+def test_four_layer_enabled_truthy(monkeypatch, val, expected):
+    monkeypatch.setenv("RETRIEVAL_ORCHESTRATOR_4LAYER_ENABLED", val)
+    assert retrieval_orchestrator.four_layer_enabled() is expected
+
+
+def test_four_layer_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("RETRIEVAL_ORCHESTRATOR_4LAYER_ENABLED", raising=False)
+    assert retrieval_orchestrator.four_layer_enabled() is False
+
+
+# ── assemble_hydration_block runs all 4 layers ───────────────────────────
+
+
+def test_assemble_runs_all_four_layers(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        spawn_recall, "query_for_spawn", lambda tt, tb: calls.append("L1L2_pos") or ["pos-hit"]
+    )
+    monkeypatch.setattr(
+        spawn_recall, "query_failures_for_spawn", lambda tt, tb: calls.append("L1L2_neg") or []
+    )
+
+    orig_filter = contradiction_filter.filter_contradictions
+    monkeypatch.setattr(
+        contradiction_filter,
+        "filter_contradictions",
+        lambda r: calls.append("L3") or orig_filter(r),
+    )
+    orig_compress = compression.compress
+    monkeypatch.setattr(
+        compression, "compress", lambda b, **kw: calls.append("L4") or orig_compress(b, **kw)
+    )
+
+    block = retrieval_orchestrator.assemble_hydration_block("build", "wire the orchestrator")
+    assert "pos-hit" in block
+    assert spawn_recall.BLOCK_HEADER in block
+    # All four layers were exercised (L1+L2 recall calls, L3 on each set, L4 once).
+    assert "L1L2_pos" in calls and "L1L2_neg" in calls
+    assert calls.count("L3") == 2 and calls.count("L4") == 1
+
+
+def test_assemble_fail_open_on_layer_error(monkeypatch):
+    def _boom(tt, tb):
+        raise RuntimeError("recall down")
+
+    monkeypatch.setattr(spawn_recall, "query_for_spawn", _boom)
+    monkeypatch.setattr(spawn_recall, "query_failures_for_spawn", lambda tt, tb: [])
+    # query_for_spawn raising propagates into assemble's outer guard → "".
+    assert retrieval_orchestrator.assemble_hydration_block("build", "x") == ""
+
+
+# ── end-to-end: a spawn receives the 4-layer payload ─────────────────────
+
+
+def test_inject_hydration_places_payload_in_spawn_env(monkeypatch):
+    monkeypatch.setattr(spawn_recall, "query_for_spawn", lambda tt, tb: ["canonical approach X"])
+    monkeypatch.setattr(spawn_recall, "query_failures_for_spawn", lambda tt, tb: [])
+    out = retrieval_orchestrator.inject_hydration({}, task_type="build", task_brief="do X")
+    payload = out["env"][spawn_recall.PRIOR_CONTEXT_ENV_KEY]
+    assert "canonical approach X" in payload
+    assert spawn_recall.BLOCK_HEADER in payload
+
+
+def test_inject_hydration_no_block_leaves_kwargs_unchanged(monkeypatch):
+    monkeypatch.setattr(spawn_recall, "query_for_spawn", lambda tt, tb: [])
+    monkeypatch.setattr(spawn_recall, "query_failures_for_spawn", lambda tt, tb: [])
+    sk = {"callsign": "test"}
+    assert retrieval_orchestrator.inject_hydration(sk, task_type="build", task_brief="x") == sk


### PR DESCRIPTION
## Summary

Wires the Retrieval Orchestrator between the dispatcher and spawn hydration, per the ratified architecture:

```
Dispatcher → [ L1 semantic recall → L2 rerank → L3 contradiction filter → L4 compression ] → spawn hydration
```

A spawned agent now receives a hydration payload assembled by all 4 layers (in `env[AGENCY_OS_PRIOR_CONTEXT]`).

- **L1 + L2 (already built):** reuse `spawn_recall.query_for_spawn` / `query_failures_for_spawn` → `agent_query.query` → `orchestrator.retrieve_with_outcome` (recall + cross-encoder rerank). No rebuild.
- **L3 `contradiction_filter.py` + L4 `compression.py` — clearly-marked fail-open STUBS** (`IS_STUB = True`): L3 is an identity pass (real impl = superseded-edge/pairwise contradiction detection, in progress); L4 is the honest minimal compression — a hard clamp to the KEI-55 token budget (real impl = semantic/extractive summarisation, in progress). Both never raise, never drop the whole context.
- **`retrieval_orchestrator.py`:** `assemble_hydration_block()` runs all 4 layers; `inject_hydration()` places the payload via `spawn_recall.inject_block`. Fail-open at every layer (outer guard → "" on catastrophic raise).
- **Wiring:** dispatcher `main._fresh_block` routes through the orchestrator behind `RETRIEVAL_ORCHESTRATOR_4LAYER_ENABLED` (default off). **Additive** — flag off = the existing single-layer path runs byte-unchanged.
- **Graphiti** (doctrine graph) is **Phase 2 — deliberately NOT wired.**

## Test plan
- [x] 12 new tests (`test_retrieval_orchestrator.py`): L3/L4 stub identity+clamp+fail-open + `IS_STUB` assertions, flag parsing, **all-4-layers-exercised**, fail-open on layer error, and **end-to-end** spawn-env payload injection.
- [x] **331 passed** across `tests/retrieval/` + `tests/dispatcher/`; ruff check + format clean on all changed files.

## ⚠️ Pre-existing failures (NOT this PR)
`tests/retrieval/test_fusion.py::test_query_async_routes_through_fusion` + `test_query_async_uses_orchestrator_when_flag_off` fail on **current main** with `NameError: name 'task_type' is not defined` at `src/retrieval/agent_query.py:430` — `query_async` passes `task_type=task_type` to `_finalize`, which has no such param (a recent Wave-5-area merge). This PR does **not** touch `agent_query.py` (verified via `git diff`); the failures reproduce on `origin/main`. Flagged separately to Elliot — it reddens CI fleet-wide and needs its own one-line fix.

## Notes
- Layer 1 is framed as "Weaviate semantic recall" in the arch doc; the live recall backend is **Hindsight** post-cutover (A3-c2 step 5-B). Functionally the same built recall — reused as-is.
- Branched off latest main.