### PR TITLE
[AIDEN] feat(infra): Vultr Postgres migration — operational state cutover (KEI-241)

### DIFF
--- a/scripts/migrations/vultr_postgres/001_schema.sql
+++ b/scripts/migrations/vultr_postgres/001_schema.sql
@@ -1,0 +1,292 @@
+-- =============================================================================
+-- KEI-241  Vultr Postgres Migration — Schema (DDL only, no data)
+-- Author:  [AIDEN]
+-- Date:    2026-05-28
+-- Branch:  aiden/vultr-postgres-migration
+--
+-- DO NOT APPLY until Atlas has provisioned the Vultr Postgres instance AND
+-- VULTR_POSTGRES_DSN is set in the environment.
+--
+-- Supabase remains the primary fallback store until KEI-242 (Hindsight
+-- backup/restore) completes. This file is idempotent; all objects use
+-- IF NOT EXISTS / CREATE OR REPLACE where applicable.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Hard gate: refuse to run on a standby / replica.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+    IF pg_is_in_recovery() THEN
+        RAISE EXCEPTION 'KEI-241 gate: pg_is_in_recovery() = true — this is a standby. '
+            'Run only against the primary Vultr Postgres instance.';
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Extensions
+-- ---------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";   -- gen_random_uuid()
+
+-- ---------------------------------------------------------------------------
+-- Enums (keiracom_tenants control-plane)
+-- ---------------------------------------------------------------------------
+
+DO $$ BEGIN
+    CREATE TYPE public.keiracom_tier AS ENUM ('solo', 'pro', 'scale');
+EXCEPTION WHEN duplicate_object THEN NULL; END; $$;
+
+DO $$ BEGIN
+    CREATE TYPE public.keiracom_topology AS ENUM ('A_per_vpc', 'B_shared_schema');
+EXCEPTION WHEN duplicate_object THEN NULL; END; $$;
+
+DO $$ BEGIN
+    CREATE TYPE public.keiracom_tenant_status AS ENUM (
+        'provisioning',
+        'active',
+        'suspended',
+        'deprovisioning',
+        'deleted'
+    );
+EXCEPTION WHEN duplicate_object THEN NULL; END; $$;
+
+-- ---------------------------------------------------------------------------
+-- Table: public.tasks
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.tasks (
+    id                        TEXT        PRIMARY KEY NOT NULL,
+    title                     TEXT        NOT NULL,
+    status                    TEXT        DEFAULT 'available',
+    priority                  INTEGER     DEFAULT 2,
+    claimed_by                TEXT,
+    claimed_at                TIMESTAMPTZ,
+    dependencies              TEXT[],
+    tags                      TEXT[],
+    linear_url                TEXT,
+    created_at                TIMESTAMPTZ DEFAULT NOW(),
+    updated_at                TIMESTAMPTZ DEFAULT NOW(),
+    acceptance_criteria       TEXT,
+    required_persona          VARCHAR     DEFAULT 'worker',
+    active_thread_id          UUID,
+    context_ceiling_tokens    INTEGER     DEFAULT 40000,
+    tenant_id                 TEXT        DEFAULT 'internal',
+    phase                     NUMERIC     NOT NULL DEFAULT 0,
+    claim_source              TEXT        NOT NULL DEFAULT 'manual',
+    deployment                BOOLEAN     NOT NULL DEFAULT FALSE,
+    heartbeat_at              TIMESTAMPTZ,
+    is_parent                 BOOLEAN     DEFAULT FALSE,
+    description               TEXT,
+    persona                   TEXT,
+    bd_id                     TEXT,
+    linear_synced_status      TEXT,
+    linear_create_pending     BOOLEAN     DEFAULT FALSE
+);
+
+-- Indexes on tasks
+CREATE INDEX IF NOT EXISTS tasks_available
+    ON public.tasks (priority, created_at)
+    WHERE status = 'available';
+
+-- Unique partial: one active claim per callsign (belt-and-suspenders with the
+-- block_parent_claim trigger defined in 002_triggers.sql).
+CREATE UNIQUE INDEX IF NOT EXISTS tasks_active_claim
+    ON public.tasks (claimed_by)
+    WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_tasks_bd_id
+    ON public.tasks (bd_id)
+    WHERE bd_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tasks_persona
+    ON public.tasks (persona)
+    WHERE status = 'available';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tasks_bd_id
+    ON public.tasks (bd_id)
+    WHERE bd_id IS NOT NULL;
+
+COMMENT ON TABLE public.tasks IS
+    'KEI-241 — Operational task queue migrated from Supabase. '
+    'Primary store post-KEI-242; Supabase is fallback until then.';
+
+-- ---------------------------------------------------------------------------
+-- Table: public.task_verifications
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.task_verifications (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id         TEXT        NOT NULL REFERENCES public.tasks(id) ON DELETE CASCADE,
+    verified_by     TEXT        NOT NULL,
+    behavioral_test TEXT        NOT NULL,
+    test_output     TEXT        NOT NULL,
+    created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.task_verifications IS
+    'KEI-241 — Stores evidence rows required by the verify-before-done governance trigger.';
+
+-- ---------------------------------------------------------------------------
+-- Table: public.ceo_memory
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.ceo_memory (
+    key        TEXT        PRIMARY KEY NOT NULL,
+    value      JSONB       NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    version    INTEGER     DEFAULT 1,
+    context    TEXT        NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS ceo_memory_context_idx
+    ON public.ceo_memory (context);
+
+COMMENT ON TABLE public.ceo_memory IS
+    'KEI-241 — CEO SSOT key-value store. Write-guard trigger (KEI-87) enforced '
+    'in 002_triggers.sql; only elliot/dave callsigns may write ceo:* keys.';
+
+-- ---------------------------------------------------------------------------
+-- Table: public.keiracom_tenants
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.keiracom_tenants (
+    tenant_id             UUID                          PRIMARY KEY DEFAULT gen_random_uuid(),
+    tier                  public.keiracom_tier          NOT NULL,
+    topology              public.keiracom_topology      NOT NULL,
+    llm_api_key_encrypted TEXT                          NOT NULL,
+    llm_model             TEXT                          NOT NULL,
+    embedding_dim         INTEGER                       NOT NULL DEFAULT 384,
+    schema_name           TEXT,
+    vpc_id                TEXT,
+    signup_date           TIMESTAMPTZ                   NOT NULL DEFAULT NOW(),
+    status                public.keiracom_tenant_status NOT NULL DEFAULT 'provisioning',
+    created_at            TIMESTAMPTZ                   NOT NULL DEFAULT NOW(),
+    updated_at            TIMESTAMPTZ                   NOT NULL DEFAULT NOW(),
+
+    -- Topology consistency: Topology B needs schema_name (not null) + vpc_id NULL;
+    -- Topology A needs vpc_id (not null) + schema_name NULL.
+    CONSTRAINT keiracom_tenants_topology_consistency CHECK (
+        (topology = 'B_shared_schema' AND schema_name IS NOT NULL AND vpc_id IS NULL)
+        OR (topology = 'A_per_vpc'    AND vpc_id IS NOT NULL    AND schema_name IS NULL)
+    ),
+    CONSTRAINT keiracom_tenants_embedding_dim_positive
+        CHECK (embedding_dim > 0),
+    CONSTRAINT keiracom_tenants_llm_api_key_not_blank
+        CHECK (length(llm_api_key_encrypted) > 0),
+    CONSTRAINT keiracom_tenants_llm_model_not_blank
+        CHECK (length(llm_model) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_keiracom_tenants_tier
+    ON public.keiracom_tenants (tier);
+
+-- Partial index excludes soft-deleted rows from the hot access path.
+CREATE INDEX IF NOT EXISTS idx_keiracom_tenants_status
+    ON public.keiracom_tenants (status)
+    WHERE status != 'deleted';
+
+CREATE INDEX IF NOT EXISTS idx_keiracom_tenants_signup_date
+    ON public.keiracom_tenants (signup_date DESC);
+
+COMMENT ON TABLE public.keiracom_tenants IS
+    'Keiracom System control-plane tenants table. '
+    'Tier-keyed topology per ceo:memory_abstraction_layer_v1 substantive_lock. '
+    'max_concurrent_tasks column added in 003_add_max_concurrent_tasks.sql (KEI-241).';
+
+COMMENT ON COLUMN public.keiracom_tenants.llm_api_key_encrypted IS
+    'BYOK-sovereign tenant LLM API key, encrypted at application layer before insert.';
+COMMENT ON COLUMN public.keiracom_tenants.embedding_dim IS
+    'Embedding vector dimension; default 384 matches BGE-small-en-v1.5.';
+COMMENT ON COLUMN public.keiracom_tenants.schema_name IS
+    'Topology B (shared-instance) Hindsight schema name. NULL for Topology A.';
+COMMENT ON COLUMN public.keiracom_tenants.vpc_id IS
+    'Topology A (per-tenant VPC) VPC reference. NULL for Topology B.';
+
+-- ---------------------------------------------------------------------------
+-- Table: public.keiracom_spawn_attribution
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.keiracom_spawn_attribution (
+    spawn_id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    ts                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    source_type         TEXT        NOT NULL
+                            CHECK (source_type IN ('slack', 'pr', 'cron', 'inbox', 'unknown')),
+    source_id           TEXT        NOT NULL,
+    task_type           TEXT        NOT NULL DEFAULT 'unknown'
+                            CHECK (task_type IN (
+                                'pr_review', 'deliberation', 'build', 'chat',
+                                'dispatch_mgmt', 'unknown'
+                            )),
+    callsign            TEXT        NOT NULL,
+    model               TEXT        NOT NULL,
+    input_tokens        BIGINT      NOT NULL DEFAULT 0,
+    output_tokens       BIGINT      NOT NULL DEFAULT 0,
+    cache_read_tokens   BIGINT      NOT NULL DEFAULT 0,
+    cache_write_tokens  BIGINT      NOT NULL DEFAULT 0,
+    cost_usd            NUMERIC(12, 6) NOT NULL DEFAULT 0,
+    completion_status   TEXT        NOT NULL DEFAULT 'unknown'
+);
+
+CREATE INDEX IF NOT EXISTS idx_keiracom_spawn_attribution_source_type_ts
+    ON public.keiracom_spawn_attribution (source_type, ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_keiracom_spawn_attribution_task_type_ts
+    ON public.keiracom_spawn_attribution (task_type, ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_keiracom_spawn_attribution_callsign_ts
+    ON public.keiracom_spawn_attribution (callsign, ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_keiracom_spawn_attribution_ts
+    ON public.keiracom_spawn_attribution (ts DESC);
+
+COMMENT ON TABLE public.keiracom_spawn_attribution IS
+    'KEI-241 — Per-spawn token + cost attribution. Source of truth for billing rollups.';
+
+-- ---------------------------------------------------------------------------
+-- Table: public.keiracom_paused_tasks
+-- ---------------------------------------------------------------------------
+-- Note: no surrogate PK in the Supabase live schema; (task_ref, callsign) is
+-- the natural compound key. A surrogate PK is NOT added here — exact schema
+-- match is required for the data dump/restore path.
+CREATE TABLE IF NOT EXISTS public.keiracom_paused_tasks (
+    task_ref      TEXT        NOT NULL,
+    callsign      TEXT        NOT NULL,
+    paused_at     TIMESTAMPTZ NOT NULL,
+    deadline_at   TIMESTAMPTZ NOT NULL,
+    interim_state JSONB       NOT NULL DEFAULT '{}',
+    question      TEXT,
+    options       JSONB,
+    state         TEXT        NOT NULL DEFAULT 'pending',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.keiracom_paused_tasks IS
+    'KEI-241 — Tracks tasks paused mid-execution awaiting a decision or deadline.';
+
+-- ---------------------------------------------------------------------------
+-- Table: public.completion_sync_queue
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.completion_sync_queue (
+    id              UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id         TEXT    NOT NULL REFERENCES public.tasks(id) ON DELETE CASCADE,
+    target_sink     TEXT    NOT NULL
+                        CHECK (target_sink IN ('linear', 'ceo_memory', 'drive_manual')),
+    target_status   TEXT    NOT NULL,
+    attempts        INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at TIMESTAMPTZ,
+    processed       BOOLEAN NOT NULL DEFAULT FALSE,
+    error_message   TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Worker SELECT path: unprocessed rows only, ordered by age.
+CREATE INDEX IF NOT EXISTS idx_completion_sync_queue_unprocessed
+    ON public.completion_sync_queue (created_at)
+    WHERE processed = FALSE;
+
+-- Dedupe partial index: at most one unprocessed row per (task_id, target_sink).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_completion_sync_queue_pending
+    ON public.completion_sync_queue (task_id, target_sink)
+    WHERE processed = FALSE;
+
+COMMENT ON TABLE public.completion_sync_queue IS
+    'KEI-74/KEI-241 three-store completion fan-out queue. Triggers defined in '
+    '002_triggers.sql. Worker drains via SELECT FOR UPDATE SKIP LOCKED.';

--- a/scripts/migrations/vultr_postgres/001_schema.sql
+++ b/scripts/migrations/vultr_postgres/001_schema.sql
@@ -94,10 +94,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS tasks_active_claim
     ON public.tasks (claimed_by)
     WHERE status = 'active';
 
-CREATE INDEX IF NOT EXISTS idx_tasks_bd_id
-    ON public.tasks (bd_id)
-    WHERE bd_id IS NOT NULL;
-
 CREATE INDEX IF NOT EXISTS idx_tasks_persona
     ON public.tasks (persona)
     WHERE status = 'available';

--- a/scripts/migrations/vultr_postgres/002_triggers.sql
+++ b/scripts/migrations/vultr_postgres/002_triggers.sql
@@ -1,0 +1,318 @@
+-- =============================================================================
+-- KEI-241  Vultr Postgres Migration — Governance Triggers
+-- Author:  [AIDEN]
+-- Date:    2026-05-28
+-- Branch:  aiden/vultr-postgres-migration
+--
+-- DO NOT APPLY until Atlas has provisioned the Vultr Postgres instance AND
+-- VULTR_POSTGRES_DSN is set in the environment.
+--
+-- Apply AFTER 001_schema.sql. All triggers are idempotent:
+-- DROP TRIGGER IF EXISTS precedes every CREATE TRIGGER.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Hard gate: refuse to run on a standby / replica.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+    IF pg_is_in_recovery() THEN
+        RAISE EXCEPTION 'KEI-241 gate: pg_is_in_recovery() = true — this is a standby. '
+            'Run only against the primary Vultr Postgres instance.';
+    END IF;
+END;
+$$;
+
+-- ===========================================================================
+-- Trigger 1: verify-before-done
+-- ---------------------------------------------------------------------------
+-- Blocks UPDATE tasks SET status='done' when:
+--   - acceptance_criteria IS NOT NULL AND acceptance_criteria <> ''
+--   - no task_verifications row exists for this task_id
+-- BEFORE UPDATE OF status ensures the row is never written on violation.
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION public.fn_verify_before_done()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Only fires when status is being changed TO 'done'.
+    IF NEW.status = 'done' AND OLD.status IS DISTINCT FROM 'done' THEN
+        -- Only enforced when acceptance_criteria is present and non-empty.
+        IF NEW.acceptance_criteria IS NOT NULL AND NEW.acceptance_criteria <> '' THEN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM public.task_verifications
+                WHERE task_id = NEW.id
+            ) THEN
+                RAISE EXCEPTION
+                    'verify-before-done: task % has acceptance_criteria but no '
+                    'task_verifications row. Insert a verification row before '
+                    'marking done.',
+                    NEW.id
+                USING ERRCODE = 'check_violation';
+            END IF;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_verify_before_done ON public.tasks;
+CREATE TRIGGER trg_verify_before_done
+    BEFORE UPDATE OF status ON public.tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION public.fn_verify_before_done();
+
+COMMENT ON FUNCTION public.fn_verify_before_done() IS
+    'KEI-241 — Gate: task cannot be marked done when acceptance_criteria is set '
+    'unless a task_verifications row exists. Blocks the UPDATE before it lands.';
+
+-- ===========================================================================
+-- Trigger 2: block_parent_claim
+-- ---------------------------------------------------------------------------
+-- Prevents a callsign from claiming a second active task while one is already
+-- active (excluding is_parent=true rows, which are coordination tasks).
+-- Belt-and-suspenders alongside the tasks_active_claim UNIQUE partial index —
+-- this trigger produces an explicit, actionable error message.
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION public.fn_block_parent_claim()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_existing_task_id TEXT;
+BEGIN
+    -- Only fires when a row is being claimed (status -> 'active' + claimed_by set).
+    IF NEW.status = 'active'
+       AND NEW.claimed_by IS NOT NULL
+       AND (OLD.status IS DISTINCT FROM 'active' OR OLD.claimed_by IS DISTINCT FROM NEW.claimed_by)
+    THEN
+        -- is_parent=true tasks are exempt — they are coordination umbrella tasks
+        -- that may legitimately coexist with a worker active task.
+        IF NOT COALESCE(NEW.is_parent, FALSE) THEN
+            SELECT id INTO v_existing_task_id
+            FROM public.tasks
+            WHERE claimed_by = NEW.claimed_by
+              AND status = 'active'
+              AND id <> NEW.id
+              AND NOT COALESCE(is_parent, FALSE)
+            LIMIT 1;
+
+            IF v_existing_task_id IS NOT NULL THEN
+                RAISE EXCEPTION
+                    'block_parent_claim: callsign % already has an active task (%). '
+                    'Finish or release it before claiming %.',
+                    NEW.claimed_by, v_existing_task_id, NEW.id
+                USING ERRCODE = 'check_violation';
+            END IF;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_block_parent_claim ON public.tasks;
+CREATE TRIGGER trg_block_parent_claim
+    BEFORE UPDATE ON public.tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION public.fn_block_parent_claim();
+
+COMMENT ON FUNCTION public.fn_block_parent_claim() IS
+    'KEI-241 — Prevents a callsign from holding two simultaneous active tasks. '
+    'Complements the tasks_active_claim UNIQUE partial index with a human-readable '
+    'exception. is_parent=true tasks are exempt.';
+
+-- ===========================================================================
+-- Trigger 3: KEI-87 ceo_memory write-guard (re-applied exactly)
+-- ---------------------------------------------------------------------------
+-- Only elliot and dave may write rows whose key starts with 'ceo:'.
+-- Requires agency_os.callsign session var to be SET LOCAL before the write.
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION public.ceo_memory_write_guard()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    caller TEXT;
+BEGIN
+    IF NEW.key NOT LIKE 'ceo:%' THEN
+        RETURN NEW;
+    END IF;
+    caller := current_setting('agency_os.callsign', true);
+    IF caller IS NULL OR caller = '' THEN
+        RAISE EXCEPTION
+            'KEI-87 ceo_memory write-guard: agency_os.callsign session-var must be '
+            'SET LOCAL before writing key %; missing var refused.',
+            NEW.key
+        USING ERRCODE = 'check_violation';
+    END IF;
+    IF caller NOT IN ('elliot', 'dave') THEN
+        RAISE EXCEPTION
+            'KEI-87 ceo_memory write-guard: agency_os.callsign=% is not in '
+            '(elliot, dave) — refused write on key %',
+            caller, NEW.key
+        USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ceo_memory_write_guard ON public.ceo_memory;
+CREATE TRIGGER ceo_memory_write_guard
+    BEFORE INSERT OR UPDATE ON public.ceo_memory
+    FOR EACH ROW
+    EXECUTE FUNCTION public.ceo_memory_write_guard();
+
+COMMENT ON FUNCTION public.ceo_memory_write_guard() IS
+    'KEI-87/KEI-241 — Restricts ceo:* key writes to callsigns elliot and dave. '
+    'Session var agency_os.callsign must be SET LOCAL before any ceo:* write.';
+
+-- ===========================================================================
+-- Trigger 4: Completion sync fan-out (re-applied from 20260516_completion_sync_queue.sql)
+-- ---------------------------------------------------------------------------
+-- On tasks.status -> ('done', 'cancelled') OR new task_verifications row,
+-- inserts 3 rows into completion_sync_queue (one per sink).
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION public.fn_enqueue_completion_sync(p_task_id TEXT, p_status TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO public.completion_sync_queue (task_id, target_sink, target_status)
+    SELECT p_task_id, sink, p_status
+    FROM unnest(ARRAY['linear', 'ceo_memory', 'drive_manual']::TEXT[]) AS sink
+    ON CONFLICT (task_id, target_sink) WHERE processed = FALSE
+    DO UPDATE SET updated_at = NOW();
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.trg_tasks_status_to_sync_queue()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.status IN ('done', 'cancelled') AND NEW.status IS DISTINCT FROM OLD.status THEN
+        PERFORM public.fn_enqueue_completion_sync(NEW.id, NEW.status);
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_tasks_completion_sync ON public.tasks;
+CREATE TRIGGER trg_tasks_completion_sync
+    AFTER UPDATE OF status ON public.tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION public.trg_tasks_status_to_sync_queue();
+
+CREATE OR REPLACE FUNCTION public.trg_verifications_to_sync_queue()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_status TEXT;
+BEGIN
+    SELECT status INTO v_status FROM public.tasks WHERE id = NEW.task_id;
+    IF v_status IN ('done', 'cancelled') THEN
+        PERFORM public.fn_enqueue_completion_sync(NEW.task_id, v_status);
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_verifications_completion_sync ON public.task_verifications;
+CREATE TRIGGER trg_verifications_completion_sync
+    AFTER INSERT ON public.task_verifications
+    FOR EACH ROW
+    EXECUTE FUNCTION public.trg_verifications_to_sync_queue();
+
+COMMENT ON FUNCTION public.fn_enqueue_completion_sync(TEXT, TEXT) IS
+    'KEI-74/KEI-241 — Fan-out helper: upserts 3 completion_sync_queue rows per terminal status.';
+
+-- ===========================================================================
+-- Trigger 5: Dependency auto-unblock (re-applied from 20260516_kei78_dependency_unblock.sql)
+-- ---------------------------------------------------------------------------
+-- When task X → status='done', any task Y with X in dependencies[] AND all
+-- other deps also done gets auto-flipped from blocked → available.
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION public.fn_unblock_dependents(p_task_id TEXT)
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_unblocked INT := 0;
+BEGIN
+    WITH candidate AS (
+        SELECT id, dependencies
+        FROM public.tasks
+        WHERE status = 'blocked'
+          AND dependencies IS NOT NULL
+          AND p_task_id = ANY(dependencies)
+    ),
+    satisfied AS (
+        SELECT c.id
+        FROM candidate c
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM unnest(c.dependencies) AS dep_id
+            LEFT JOIN public.tasks t ON t.id = dep_id
+            WHERE t.status IS DISTINCT FROM 'done'
+        )
+    )
+    UPDATE public.tasks
+       SET status = 'available', updated_at = NOW()
+     WHERE id IN (SELECT id FROM satisfied);
+    GET DIAGNOSTICS v_unblocked = ROW_COUNT;
+    RETURN v_unblocked;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.trg_tasks_dependency_unblock()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.status = 'done' AND NEW.status IS DISTINCT FROM OLD.status THEN
+        PERFORM public.fn_unblock_dependents(NEW.id);
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_tasks_unblock_dependents ON public.tasks;
+CREATE TRIGGER trg_tasks_unblock_dependents
+    AFTER UPDATE OF status ON public.tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION public.trg_tasks_dependency_unblock();
+
+COMMENT ON FUNCTION public.fn_unblock_dependents(TEXT) IS
+    'KEI-78/KEI-241 — Scan tasks whose dependencies[] contain p_task_id and '
+    'status=blocked; flip to available when all deps are done. Returns count.';
+
+-- ===========================================================================
+-- Trigger 6: keiracom_tenants updated_at touch (re-applied from 20260525_keiracom_tenants.sql)
+-- ===========================================================================
+
+CREATE OR REPLACE FUNCTION public.keiracom_tenants_touch_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS keiracom_tenants_touch_updated_at_tg ON public.keiracom_tenants;
+CREATE TRIGGER keiracom_tenants_touch_updated_at_tg
+    BEFORE UPDATE ON public.keiracom_tenants
+    FOR EACH ROW
+    EXECUTE FUNCTION public.keiracom_tenants_touch_updated_at();
+
+COMMENT ON FUNCTION public.keiracom_tenants_touch_updated_at() IS
+    'KEI-241 — Auto-sets updated_at on any UPDATE to keiracom_tenants.';

--- a/scripts/migrations/vultr_postgres/002_triggers.sql
+++ b/scripts/migrations/vultr_postgres/002_triggers.sql
@@ -128,8 +128,15 @@ COMMENT ON FUNCTION public.fn_block_parent_claim() IS
 -- ===========================================================================
 -- Trigger 3: KEI-87 ceo_memory write-guard (re-applied exactly)
 -- ---------------------------------------------------------------------------
--- Only elliot and dave may write rows whose key starts with 'ceo:'.
+-- Only elliot, dave, and john may write rows whose key starts with 'ceo:'.
+-- john added 2026-05-28 (Elliot-ratified): John's exit_cycle is an intended
+-- ceo_memory writer (src.keiracom_system.chat.exit_cycle, PR #1268).
 -- Requires agency_os.callsign session var to be SET LOCAL before the write.
+-- SEQUENCING NOTE: apply this trigger AFTER all ceo:* writer call-sites have
+-- been migrated to the wrapper (src.governance.ceo_memory_writer). Applying
+-- before migration completes will reject non-migrated writers. KEI-87 is not
+-- yet enforced on Supabase prod (flagged Nova 2026-05-28) — verify migration
+-- status before enabling on Vultr.
 -- ===========================================================================
 
 CREATE OR REPLACE FUNCTION public.ceo_memory_write_guard()
@@ -150,10 +157,10 @@ BEGIN
             NEW.key
         USING ERRCODE = 'check_violation';
     END IF;
-    IF caller NOT IN ('elliot', 'dave') THEN
+    IF caller NOT IN ('elliot', 'dave', 'john') THEN
         RAISE EXCEPTION
             'KEI-87 ceo_memory write-guard: agency_os.callsign=% is not in '
-            '(elliot, dave) — refused write on key %',
+            '(elliot, dave, john) — refused write on key %',
             caller, NEW.key
         USING ERRCODE = 'check_violation';
     END IF;
@@ -168,7 +175,8 @@ CREATE TRIGGER ceo_memory_write_guard
     EXECUTE FUNCTION public.ceo_memory_write_guard();
 
 COMMENT ON FUNCTION public.ceo_memory_write_guard() IS
-    'KEI-87/KEI-241 — Restricts ceo:* key writes to callsigns elliot and dave. '
+    'KEI-87/KEI-241 — Restricts ceo:* key writes to callsigns elliot, dave, john. '
+    'john added 2026-05-28 (exit_cycle PR #1268). '
     'Session var agency_os.callsign must be SET LOCAL before any ceo:* write.';
 
 -- ===========================================================================

--- a/scripts/migrations/vultr_postgres/003_add_max_concurrent_tasks.sql
+++ b/scripts/migrations/vultr_postgres/003_add_max_concurrent_tasks.sql
@@ -1,0 +1,63 @@
+-- =============================================================================
+-- KEI-241  Vultr Postgres Migration — max_concurrent_tasks column
+-- Author:  [AIDEN]
+-- Date:    2026-05-28
+-- Branch:  aiden/vultr-postgres-migration
+--
+-- DO NOT APPLY until Atlas has provisioned the Vultr Postgres instance AND
+-- VULTR_POSTGRES_DSN is set in the environment.
+--
+-- Apply AFTER 001_schema.sql and 002_triggers.sql.
+--
+-- Requirement (KEI-241): max_concurrent_tasks must be an explicit column, not
+-- derived from the tier enum. The tier enum may evolve independently of the
+-- concurrency limit; hard-coding a derivation in application code creates a
+-- hidden coupling. Storing the value per row lets overrides be applied without
+-- schema changes (e.g. enterprise trial bumps for a single tenant).
+--
+-- Defaults by tier:
+--   solo  →  2
+--   pro   →  6
+--   scale → 20
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Hard gate: refuse to run on a standby / replica.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+    IF pg_is_in_recovery() THEN
+        RAISE EXCEPTION 'KEI-241 gate: pg_is_in_recovery() = true — this is a standby. '
+            'Run only against the primary Vultr Postgres instance.';
+    END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Add column (idempotent via IF NOT EXISTS).
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.keiracom_tenants
+    ADD COLUMN IF NOT EXISTS max_concurrent_tasks INTEGER NOT NULL DEFAULT 2;
+
+COMMENT ON COLUMN public.keiracom_tenants.max_concurrent_tasks IS
+    'KEI-241 — Maximum number of simultaneous active tasks for this tenant. '
+    'Defaults: solo=2, pro=6, scale=20. May be overridden per-row for enterprise '
+    'trials without a schema change.';
+
+-- ---------------------------------------------------------------------------
+-- Seed: update existing rows to tier-appropriate defaults.
+--
+-- Rows already at the column default (2) are updated even if they happen to be
+-- solo-tier so the UPDATE is explicit and auditable. Pro and Scale rows must be
+-- bumped from the column default of 2.
+-- ---------------------------------------------------------------------------
+UPDATE public.keiracom_tenants
+   SET max_concurrent_tasks = CASE tier
+       WHEN 'solo'  THEN 2
+       WHEN 'pro'   THEN 6
+       WHEN 'scale' THEN 20
+       -- Fallback for any future tier added before this file is updated — keep
+       -- at the conservative default of 2 rather than failing.
+       ELSE 2
+   END
+WHERE TRUE;   -- explicit full-table update so the intent is unambiguous

--- a/scripts/migrations/vultr_postgres/apply.sh
+++ b/scripts/migrations/vultr_postgres/apply.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# =============================================================================
+# KEI-241  Vultr Postgres Migration — apply.sh
+# Author:  [AIDEN]
+# Date:    2026-05-28
+# Branch:  aiden/vultr-postgres-migration
+#
+# Applies schema + triggers + column migrations against the Vultr Postgres
+# instance, then dumps data from Supabase and restores it to Vultr.
+#
+# DO NOT RUN until Atlas has provisioned the Vultr Postgres instance AND
+# VULTR_POSTGRES_DSN is set in the environment.
+#
+# Hard gate: DECOMMISSION_SUPABASE=true is refused — Supabase stays as
+# fallback until KEI-242 (Hindsight backup/restore) completes.
+#
+# Usage:
+#   VULTR_POSTGRES_DSN="postgres://..." \
+#   SUPABASE_DATABASE_URL="postgres://..." \
+#   bash apply.sh
+#
+#   Optional:
+#     SKIP_DATA_DUMP=true   — run DDL only, skip pg_dump/restore
+#     DRY_RUN=true          — print commands, do not execute psql/pg_dump
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Helper: log with timestamp prefix.
+# ---------------------------------------------------------------------------
+log() {
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"
+}
+
+# ---------------------------------------------------------------------------
+# Hard gate: refuse if Supabase decommission flag is set.
+# Supabase must remain the fallback until KEI-242 completes.
+# ---------------------------------------------------------------------------
+if [[ "${DECOMMISSION_SUPABASE:-false}" == "true" ]]; then
+    echo "ERROR: DECOMMISSION_SUPABASE=true is set. Refusing to run." >&2
+    echo "Supabase stays as fallback until KEI-242 (Hindsight backup/restore) completes." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Require env vars.
+# ---------------------------------------------------------------------------
+if [[ -z "${VULTR_POSTGRES_DSN:-}" ]]; then
+    echo "ERROR: VULTR_POSTGRES_DSN is not set." >&2
+    echo "Atlas must provision the Vultr Postgres instance before apply.sh can run." >&2
+    exit 1
+fi
+
+if [[ -z "${SUPABASE_DATABASE_URL:-}" ]]; then
+    echo "ERROR: SUPABASE_DATABASE_URL is not set." >&2
+    echo "Required to pg_dump operational data from Supabase for restore to Vultr." >&2
+    exit 1
+fi
+
+DRY_RUN="${DRY_RUN:-false}"
+SKIP_DATA_DUMP="${SKIP_DATA_DUMP:-false}"
+
+# Wrapper: honour DRY_RUN for all side-effecting commands.
+run() {
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        echo "[DRY_RUN] $*"
+    else
+        "$@"
+    fi
+}
+
+log "KEI-241 Vultr Postgres migration starting."
+log "DRY_RUN=${DRY_RUN}  SKIP_DATA_DUMP=${SKIP_DATA_DUMP}"
+
+# ---------------------------------------------------------------------------
+# Step 1: Apply DDL migrations (001, 002, 003) against Vultr.
+# ---------------------------------------------------------------------------
+for migration_file in \
+    "${SCRIPT_DIR}/001_schema.sql" \
+    "${SCRIPT_DIR}/002_triggers.sql" \
+    "${SCRIPT_DIR}/003_add_max_concurrent_tasks.sql"
+do
+    log "Applying ${migration_file} ..."
+    run psql "${VULTR_POSTGRES_DSN}" \
+        --set ON_ERROR_STOP=1 \
+        --file "${migration_file}"
+    log "  done."
+done
+
+# ---------------------------------------------------------------------------
+# Step 2: Dump data from Supabase and restore to Vultr.
+#
+# Tables are listed in FK-safe order (parents before children):
+#   1. ceo_memory               — no FKs
+#   2. tasks                    — no FKs into other migrated tables
+#   3. task_verifications       — FK → tasks.id
+#   4. completion_sync_queue    — FK → tasks.id
+#   5. keiracom_tenants         — no FKs
+#   6. keiracom_spawn_attribution — no FKs
+#   7. keiracom_paused_tasks    — no FKs
+#
+# pg_dump flags:
+#   --data-only          — schema already applied; only rows needed
+#   --disable-triggers   — suppress trigger fire during restore (avoids
+#                          write-guard + verify-before-done false positives
+#                          on data that was already valid in Supabase)
+#   --no-owner           — Vultr role hierarchy may differ
+#   --no-privileges      — GRANTs re-applied separately if needed
+#   --column-inserts     — portable INSERT statements (safer across versions)
+# ---------------------------------------------------------------------------
+
+if [[ "${SKIP_DATA_DUMP}" == "true" ]]; then
+    log "SKIP_DATA_DUMP=true — skipping pg_dump/restore step."
+else
+    TABLES=(
+        "public.ceo_memory"
+        "public.tasks"
+        "public.task_verifications"
+        "public.completion_sync_queue"
+        "public.keiracom_tenants"
+        "public.keiracom_spawn_attribution"
+        "public.keiracom_paused_tasks"
+    )
+
+    # Build --table flags list.
+    TABLE_FLAGS=()
+    for tbl in "${TABLES[@]}"; do
+        TABLE_FLAGS+=("--table=${tbl}")
+    done
+
+    log "Dumping data from Supabase (${#TABLES[@]} tables) ..."
+    DUMP_FILE="$(mktemp /tmp/kei241_dump.XXXXXX.sql)"
+    # shellcheck disable=SC2064
+    trap "rm -f '${DUMP_FILE}'" EXIT
+
+    run pg_dump \
+        "${SUPABASE_DATABASE_URL}" \
+        --data-only \
+        --disable-triggers \
+        --no-owner \
+        --no-privileges \
+        --column-inserts \
+        "${TABLE_FLAGS[@]}" \
+        --file "${DUMP_FILE}"
+
+    log "Dump written to ${DUMP_FILE}."
+
+    log "Restoring data to Vultr ..."
+    run psql "${VULTR_POSTGRES_DSN}" \
+        --set ON_ERROR_STOP=1 \
+        --file "${DUMP_FILE}"
+    log "Restore complete."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: Run validation script.
+# ---------------------------------------------------------------------------
+VALIDATE_SCRIPT="${SCRIPT_DIR}/../../vultr_validate.py"
+
+if [[ -f "${VALIDATE_SCRIPT}" ]]; then
+    log "Running validation: ${VALIDATE_SCRIPT} ..."
+    run python3 "${VALIDATE_SCRIPT}"
+    log "Validation passed."
+else
+    log "WARNING: Validation script not found at ${VALIDATE_SCRIPT} — skipping."
+fi
+
+log "KEI-241 apply.sh complete."

--- a/scripts/vultr_validate.py
+++ b/scripts/vultr_validate.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+KEI-241  Vultr Postgres Migration — Validation Script
+Author:  [AIDEN]
+Date:    2026-05-28
+Branch:  aiden/vultr-postgres-migration
+
+Connects to both SUPABASE_DATABASE_URL (source) and VULTR_POSTGRES_DSN (target)
+via psycopg3, then verifies data integrity across 7 tables.
+
+Checks performed:
+  - Row count comparison for each table (source vs target).
+  - Spot-check: 3 random ceo_memory keys present on target.
+  - Spot-check: most recent 5 tasks rows have matching id+status on both.
+  - Column existence: keiracom_tenants.max_concurrent_tasks present on target.
+
+Exit codes:
+  0 — all checks PASS
+  1 — one or more FAIL
+
+Usage:
+  SUPABASE_DATABASE_URL="postgres://..." \\
+  VULTR_POSTGRES_DSN="postgres://..." \\
+  python3 scripts/vultr_validate.py [--table TABLE_NAME]
+"""
+
+import argparse
+import os
+import random
+import sys
+
+try:
+    import psycopg
+except ImportError:
+    print("ERROR: psycopg (psycopg3) not installed. Run: pip install psycopg[binary]")
+    sys.exit(2)
+
+
+# ---------------------------------------------------------------------------
+# Tables to validate. Order is FK-safe but irrelevant for read-only checks.
+# ---------------------------------------------------------------------------
+ALL_TABLES = [
+    "public.ceo_memory",
+    "public.tasks",
+    "public.task_verifications",
+    "public.completion_sync_queue",
+    "public.keiracom_tenants",
+    "public.keiracom_spawn_attribution",
+    "public.keiracom_paused_tasks",
+]
+
+# Result accumulator — (table_or_check, status, message)
+results: list[tuple[str, str, str]] = []
+
+
+def pass_(label: str, msg: str) -> None:
+    results.append((label, "PASS", msg))
+    print(f"  PASS  {label}: {msg}")
+
+
+def fail_(label: str, msg: str) -> None:
+    results.append((label, "FAIL", msg))
+    print(f"  FAIL  {label}: {msg}", file=sys.stderr)
+
+
+def warn_(label: str, msg: str) -> None:
+    results.append((label, "WARN", msg))
+    print(f"  WARN  {label}: {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Connection helpers
+# ---------------------------------------------------------------------------
+
+def connect(dsn: str, label: str) -> "psycopg.Connection":
+    try:
+        conn = psycopg.connect(dsn, autocommit=True)
+        return conn
+    except Exception as exc:
+        print(f"ERROR: Could not connect to {label}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def fetchone(conn: "psycopg.Connection", query: str, params=None):
+    with conn.cursor() as cur:
+        cur.execute(query, params or ())
+        return cur.fetchone()
+
+
+def fetchall(conn: "psycopg.Connection", query: str, params=None):
+    with conn.cursor() as cur:
+        cur.execute(query, params or ())
+        return cur.fetchall()
+
+
+# ---------------------------------------------------------------------------
+# Check: row count comparison
+# ---------------------------------------------------------------------------
+
+def check_row_count(src: "psycopg.Connection", tgt: "psycopg.Connection", table: str) -> None:
+    label = f"row_count:{table}"
+    try:
+        src_row = fetchone(src, f"SELECT COUNT(*) FROM {table}")
+        tgt_row = fetchone(tgt, f"SELECT COUNT(*) FROM {table}")
+
+        if src_row is None or tgt_row is None:
+            fail_(label, "COUNT(*) returned no row — table may not exist")
+            return
+
+        src_count = src_row[0]
+        tgt_count = tgt_row[0]
+
+        if src_count == tgt_count:
+            pass_(label, f"source={src_count}, target={tgt_count}")
+        elif tgt_count < src_count:
+            # Target has fewer rows — data loss.
+            fail_(label, f"source={src_count} > target={tgt_count} — rows missing on target")
+        else:
+            # Target has MORE rows than source — unusual but not a data loss.
+            warn_(label, f"target={tgt_count} > source={src_count} — extra rows on target (acceptable if backfilled)")
+    except Exception as exc:
+        fail_(label, f"query error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Spot-check: random ceo_memory keys on target
+# ---------------------------------------------------------------------------
+
+def check_ceo_memory_spot(src: "psycopg.Connection", tgt: "psycopg.Connection") -> None:
+    label = "spot:ceo_memory_keys"
+    try:
+        rows = fetchall(src, "SELECT key FROM public.ceo_memory ORDER BY RANDOM() LIMIT 3")
+        if not rows:
+            warn_(label, "No rows in source ceo_memory — skipping spot check")
+            return
+
+        keys = [r[0] for r in rows]
+        missing = []
+        for key in keys:
+            found = fetchone(tgt, "SELECT 1 FROM public.ceo_memory WHERE key = %s", (key,))
+            if found is None:
+                missing.append(key)
+
+        if missing:
+            fail_(label, f"Keys missing on target: {missing}")
+        else:
+            pass_(label, f"All 3 sampled keys present: {keys}")
+    except Exception as exc:
+        fail_(label, f"query error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Spot-check: most recent 5 tasks rows match on both sides
+# ---------------------------------------------------------------------------
+
+def check_tasks_spot(src: "psycopg.Connection", tgt: "psycopg.Connection") -> None:
+    label = "spot:tasks_recent_5"
+    try:
+        rows = fetchall(
+            src,
+            "SELECT id, status FROM public.tasks ORDER BY created_at DESC LIMIT 5"
+        )
+        if not rows:
+            warn_(label, "No rows in source tasks — skipping spot check")
+            return
+
+        mismatches = []
+        for task_id, src_status in rows:
+            tgt_row = fetchone(
+                tgt,
+                "SELECT status FROM public.tasks WHERE id = %s",
+                (task_id,)
+            )
+            if tgt_row is None:
+                mismatches.append(f"{task_id}: missing on target")
+            elif tgt_row[0] != src_status:
+                mismatches.append(f"{task_id}: status src={src_status!r} tgt={tgt_row[0]!r}")
+
+        if mismatches:
+            fail_(label, f"Mismatches: {mismatches}")
+        else:
+            ids = [r[0] for r in rows]
+            pass_(label, f"All 5 recent tasks match: {ids}")
+    except Exception as exc:
+        fail_(label, f"query error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Spot-check: max_concurrent_tasks column exists on target
+# ---------------------------------------------------------------------------
+
+def check_max_concurrent_tasks_column(tgt: "psycopg.Connection") -> None:
+    label = "spot:max_concurrent_tasks_column"
+    try:
+        row = fetchone(
+            tgt,
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'keiracom_tenants'
+              AND column_name = 'max_concurrent_tasks'
+            """
+        )
+        if row is not None:
+            pass_(label, "max_concurrent_tasks column exists on keiracom_tenants")
+        else:
+            fail_(label, "max_concurrent_tasks column MISSING on keiracom_tenants — run 003_add_max_concurrent_tasks.sql")
+    except Exception as exc:
+        fail_(label, f"query error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="KEI-241 Vultr Postgres validation — compares Supabase source to Vultr target."
+    )
+    parser.add_argument(
+        "--table",
+        metavar="TABLE",
+        help="Validate a single table only (e.g. public.tasks). "
+             "Skips spot-checks unless the table matches.",
+    )
+    args = parser.parse_args()
+
+    supabase_dsn = os.environ.get("SUPABASE_DATABASE_URL", "")
+    vultr_dsn = os.environ.get("VULTR_POSTGRES_DSN", "")
+
+    if not supabase_dsn:
+        print("ERROR: SUPABASE_DATABASE_URL is not set.", file=sys.stderr)
+        sys.exit(1)
+    if not vultr_dsn:
+        print("ERROR: VULTR_POSTGRES_DSN is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    print("KEI-241 Vultr Postgres validation")
+    print(f"Source: SUPABASE_DATABASE_URL (set)")
+    print(f"Target: VULTR_POSTGRES_DSN (set)")
+    print()
+
+    src_conn = connect(supabase_dsn, "Supabase (source)")
+    tgt_conn = connect(vultr_dsn, "Vultr (target)")
+
+    tables_to_check = ALL_TABLES
+    if args.table:
+        # Normalise: allow "tasks" or "public.tasks".
+        tbl = args.table if "." in args.table else f"public.{args.table}"
+        if tbl not in ALL_TABLES:
+            print(f"WARNING: {tbl} is not in the known table list — proceeding anyway.")
+        tables_to_check = [tbl]
+
+    print("--- Row count checks ---")
+    for table in tables_to_check:
+        check_row_count(src_conn, tgt_conn, table)
+
+    print()
+    print("--- Spot checks ---")
+
+    # Run spot checks if the relevant table is in scope (or no --table filter).
+    if not args.table or "ceo_memory" in args.table:
+        check_ceo_memory_spot(src_conn, tgt_conn)
+
+    if not args.table or "tasks" in args.table:
+        check_tasks_spot(src_conn, tgt_conn)
+
+    check_max_concurrent_tasks_column(tgt_conn)
+
+    src_conn.close()
+    tgt_conn.close()
+
+    # ---------------------------------------------------------------------------
+    # Summary
+    # ---------------------------------------------------------------------------
+    print()
+    total = len(results)
+    passed = sum(1 for _, s, _ in results if s == "PASS")
+    failed = sum(1 for _, s, _ in results if s == "FAIL")
+    warned = sum(1 for _, s, _ in results if s == "WARN")
+
+    print(f"=== Summary: {passed}/{total} PASS  |  {failed} FAIL  |  {warned} WARN ===")
+
+    if failed > 0:
+        print("RESULT: FAIL — migration validation did not pass.", file=sys.stderr)
+        sys.exit(1)
+
+    print("RESULT: PASS — all checks passed.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

KEI-241 P1 cutover-gating. Migration of operational state from Supabase to self-hosted Postgres on Vultr.

**Hard gate respected:** \`DECOMMISSION_SUPABASE=true\` is refused by \`apply.sh\` — Supabase stays warm as fallback until KEI-242 (Hindsight backup/restore) is confirmed end-to-end.

## Files

| File | Purpose |
|------|---------|
| \`scripts/migrations/vultr_postgres/001_schema.sql\` | 3 enums + 6 tables + all indexes, idempotent, \`pg_is_in_recovery()\` gate |
| \`scripts/migrations/vultr_postgres/002_triggers.sql\` | 6 governance triggers — verify-before-done (new), block_parent_claim (new), KEI-87 write-guard, completion-sync fan-out, dependency unblock, tenants updated_at |
| \`scripts/migrations/vultr_postgres/003_add_max_concurrent_tasks.sql\` | \`ALTER TABLE keiracom_tenants ADD COLUMN max_concurrent_tasks\` + seed (solo=2, pro=6, scale=20) |
| \`scripts/migrations/vultr_postgres/apply.sh\` | Orchestration: checks DSNs, applies 001→002→003, pg_dump --data-only in FK-safe order, runs validation |
| \`scripts/vultr_validate.py\` | Row-count + spot-check validation; exits 0 all-PASS / 1 any-FAIL |

## Prerequisites (Atlas)

\`VULTR_POSTGRES_DSN\` is not yet in env — only \`VULTR_API_KEY\` exists. Atlas must:
1. Provision the Vultr Managed Postgres instance via Vultr API
2. Add \`VULTR_POSTGRES_DSN\` to env and Railway
3. Confirm instance is writable (not standby)

\`apply.sh\` exits 1 with a clear message if \`VULTR_POSTGRES_DSN\` is unset.

## Tables migrated (FK-safe order)

\`ceo_memory\` → \`tasks\` → \`task_verifications\` → \`completion_sync_queue\` → \`keiracom_tenants\` → \`keiracom_spawn_attribution\` → \`keiracom_paused_tasks\`

## New triggers authored from spec

- **verify-before-done:** BEFORE UPDATE OF status — blocks setting status='done' when acceptance_criteria IS NOT NULL unless task_verifications row exists for the task.
- **block_parent_claim:** BEFORE UPDATE — prevents a callsign from claiming a second active task; exempts is_parent=true rows; explicit error message vs cryptic UNIQUE violation.

## Schema gap closed

\`keiracom_tenants.max_concurrent_tasks\` added as explicit column (dispatch requirement: must not be derived from tier enum). Seeds: solo=2, pro=6, scale=20. Resolves ORION GAP B on the work-loop consumer KEI.

## Test plan

- [ ] Elliot: impl-feasibility — apply.sh FK ordering, pg_dump flags, DECOMMISSION_SUPABASE guard
- [ ] Max: code-quality — vultr_validate.py exit codes, --table filter, missing-env guard; trigger edge cases (acceptance_criteria empty string, block_parent_claim is_parent exemption)
- [ ] Atlas: provision Vultr instance + run apply.sh in dry-run mode before live cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)