### PR TITLE
[NOVA] fix(kei87): add 'john' to ceo_memory write-guard allowlist

### DIFF
--- a/supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql
+++ b/supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql
@@ -20,6 +20,14 @@
 -- the gate exists so MISSING var = denied). The 'who counts as CEO' tightening
 -- is a separate follow-up so this PR can ship the mechanism without breaking
 -- existing writers mid-flight.
+--
+-- ⚠ PROD STATE (verified by Nova 2026-05-28 via pg_trigger/pg_proc query):
+-- this trigger + function are NOT YET APPLIED in the Supabase prod DB
+-- (jatzvazlbusedwsnqxzr) — there is no write-guard on ceo_memory today. Do NOT
+-- apply this migration until deployment step 1 (call-site migration to the
+-- ceo_memory_writer wrapper) is complete fleet-wide; applying it now would
+-- begin rejecting EVERY ceo:* write from any callsite that doesn't SET LOCAL
+-- agency_os.callsign to an allowlisted value — a fleet-wide write outage.
 
 CREATE OR REPLACE FUNCTION public.ceo_memory_write_guard()
 RETURNS trigger
@@ -44,8 +52,12 @@ BEGIN
     -- Per 3-way ratified spec (elliot+max+aiden 2026-05-17 ts ~1779010883):
     -- allowlist = (elliot, dave). Aiden's PR #922 review caught the prior
     -- permissive-first draft as scope-delta from ratified shape. Tightened.
-    IF caller NOT IN ('elliot', 'dave') THEN
-        RAISE EXCEPTION 'KEI-87 ceo_memory write-guard: agency_os.callsign=% is not in (elliot, dave) — refused write on key %', caller, NEW.key
+    -- 'john' added (Elliot 2026-05-28): John's exit-cycle (src/keiracom_system/
+    -- chat/exit_cycle.py, KEI-?/#1268) captures ratified decisions to ceo_memory
+    -- by design — John is an intended ceo_memory writer, so the callsign belongs
+    -- on the allowlist (masking as 'elliot' would lose attribution).
+    IF caller NOT IN ('elliot', 'dave', 'john') THEN
+        RAISE EXCEPTION 'KEI-87 ceo_memory write-guard: agency_os.callsign=% is not in (elliot, dave, john) — refused write on key %', caller, NEW.key
             USING ERRCODE = 'check_violation';
     END IF;
 


### PR DESCRIPTION
## Summary
Adds `'john'` to the KEI-87 `ceo_memory` write-guard allowlist (`elliot, dave, john`) in `supabase/migrations/20260517_kei87_ceo_memory_write_guard.sql`. John's exit-cycle (#1268) captures ratified decisions to ceo_memory **by design**, so `john` is an intended writer — masking it as `elliot` loses attribution (Elliot ratify 2026-05-28, option b).

## ⚠ Critical finding — prod is NOT what the dispatch assumed
The dispatch said the guard is "broken in prod now that #1268 is merged." I verified the live Supabase prod DB (`jatzvazlbusedwsnqxzr`) via `pg_trigger` / `pg_proc`:

```
triggers_on_ceo_memory : (none)
functions_matching     : (none)        -- no ceo_memory_write_guard function
ceo:conversation_capture:* keys : (none)
```

**The KEI-87 write-guard is NOT applied in prod.** Consequences:
- #1268's `john` writes are **not** being rejected — there is no guard. Nothing is broken in prod right now.
- **Applying this migration now would be a fleet-wide incident, not a fix**: it would begin rejecting *every* `ceo:*` write from any callsite that doesn't `SET LOCAL agency_os.callsign` to an allowlisted value. The deployment banner (step 1) requires the call-site→`ceo_memory_writer` wrapper migration to complete fleet-wide *before* applying. That migration is incomplete.

**So I did NOT modify prod.** This PR only corrects the migration source so that *whenever* the guard is deployed, `john` is allowlisted. I added a dated banner note recording the verified-unapplied prod state to prevent premature application.

## Companion fix (coordinating)
`scripts/migrations/vultr_postgres/002_triggers.sql` (Aiden's PR #1272, not yet on main) recreates the same trigger for Vultr Postgres — it needs `john` in its allowlist too. Flagged to Aiden to add it there (can't edit from a main-based branch since the file only exists on #1272's branch).

## Decision needed from Elliot
If you want the guard actually *enforced* in prod (not just allowlist-correct), that's a separate rollout: complete the call-site→wrapper migration first, then apply. I can scope that, but it's not a one-line change and I won't flip it on unilaterally given the blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)