### PR TITLE
[ATLAS] feat(work-loop): wire release_slot into dispatcher exit hook + periodic reconcile (Agency_OS-innu)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -51,6 +51,7 @@ from src.keiracom_system.attribution.logger import (
     SpawnAttributionEntry,
     log_spawn_attribution,
 )
+from src.keiracom_system.work_loop import integration as work_loop
 from src.relay.budget_ceiling import (
     PRIORITY_NORMAL,
     SOURCE_DAVE_DM,
@@ -442,13 +443,18 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     rp_task = asyncio.create_task(_reaper_loop(_reaper), name="dispatcher-reaper")
     logger.info("KEI-213 reaper: background task started")
 
+    # Step 6 — work-loop reconcile (Agency_OS-innu): reclaim crashed-agent slots
+    # whose lease TTL lapsed (the exit hook only covers clean terminations).
+    rc_task = asyncio.create_task(work_loop.reconcile_loop(), name="work-loop-reconcile")
+    logger.info("work-loop: reconcile background task started")
+
     try:
         yield
     finally:
         # Graceful shutdown — cancel tasks and wait for clean exit
-        for task in (wd_task, rp_task):
+        for task in (wd_task, rp_task, rc_task):
             task.cancel()
-        await asyncio.gather(wd_task, rp_task, return_exceptions=True)
+        await asyncio.gather(wd_task, rp_task, rc_task, return_exceptions=True)
         logger.info("KEI-213 dispatcher: background tasks cancelled cleanly")
 
 
@@ -661,7 +667,13 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
         manager.terminate(handle)
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    _spawned[req.key] = {"handle": handle, "backend": backend}
+    _spawned[req.key] = {
+        "handle": handle,
+        "backend": backend,
+        # Retained for the work-loop exit hook (Agency_OS-innu): release the
+        # tenant slot + pop overflow on terminate. None when not a work-loop spawn.
+        "tenant_id": (req.spawn_kwargs or {}).get("tenant_id"),
+    }
 
     # Bounded-spawn enforcement (Agency_OS-gcpm / Audit RED-7).
     # Runs AFTER register so the active-slot record reflects what's actually
@@ -742,4 +754,9 @@ async def dispatcher_terminate(req: TerminateRequest) -> dict[str, Any]:
     # callsign is treated as the first task on a fresh slot, not a violation.
     if _bounded_spawn_enforcer is not None:
         _bounded_spawn_enforcer.release_spawn(req.key)
+    # Work-loop exit hook (Agency_OS-innu): free the tenant slot → pop overflow →
+    # spawn next. Fail-open inside release_on_exit; never breaks teardown.
+    tenant_id = entry.get("tenant_id")
+    if tenant_id:
+        await work_loop.release_on_exit(str(tenant_id), req.key)
     return {"terminated": True, "key": req.key, "watchdog_tracked": _watchdog.tracked}

--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -229,6 +229,21 @@ workflow_recall_enabled: bool = os.environ.get(_WORKFLOW_RECALL_ENABLED_ENV, "")
 }
 _workflow_recall = WorkflowRecallContext()
 
+# Work-loop reconcile background task (Agency_OS-innu). OFF by default — matches
+# every other dispatcher gate in rollout phase 1, and keeps the loop dormant
+# until the budget-gate go-live. CRITICAL: when ON, the lifespan starts a forever
+# loop that connects to Valkey via get_consumer(); leaving it unconditionally-on
+# made the 8 TestClient dispatcher tests await an absent Valkey in CI (hang →
+# 27-min kill), since no pytest timeout is configured (Agency_OS-28ai root cause).
+_WORK_LOOP_RECONCILE_ENABLED_ENV = "DISPATCHER_WORK_LOOP_RECONCILE_ENABLED"
+work_loop_reconcile_enabled: bool = os.environ.get(
+    _WORK_LOOP_RECONCILE_ENABLED_ENV, ""
+).lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
 
 def _spawn_kwargs_source_type(sk: dict) -> str:
     """Derive source_type from spawn_kwargs per PR #1207 SOURCE_TYPES taxonomy."""
@@ -445,16 +460,21 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Step 6 — work-loop reconcile (Agency_OS-innu): reclaim crashed-agent slots
     # whose lease TTL lapsed (the exit hook only covers clean terminations).
-    rc_task = asyncio.create_task(work_loop.reconcile_loop(), name="work-loop-reconcile")
-    logger.info("work-loop: reconcile background task started")
+    # Gated OFF by default — only runs once the loop goes live (post budget-gate);
+    # otherwise it would connect to an absent Valkey (e.g. CI) and hang (28ai).
+    background_tasks = [wd_task, rp_task]
+    if work_loop_reconcile_enabled:
+        rc_task = asyncio.create_task(work_loop.reconcile_loop(), name="work-loop-reconcile")
+        background_tasks.append(rc_task)
+        logger.info("work-loop: reconcile background task started")
 
     try:
         yield
     finally:
         # Graceful shutdown — cancel tasks and wait for clean exit
-        for task in (wd_task, rp_task, rc_task):
+        for task in background_tasks:
             task.cancel()
-        await asyncio.gather(wd_task, rp_task, rc_task, return_exceptions=True)
+        await asyncio.gather(*background_tasks, return_exceptions=True)
         logger.info("KEI-213 dispatcher: background tasks cancelled cleanly")
 
 

--- a/src/keiracom_system/work_loop/consumer.py
+++ b/src/keiracom_system/work_loop/consumer.py
@@ -261,6 +261,21 @@ class WorkLoopConsumer:
                 reclaimed += 1
         return reclaimed
 
+    async def reconcile_all(self) -> int:
+        """Reconcile every tenant with a live counter (SCAN). Returns total reclaimed.
+
+        Drives the periodic crash-recovery sweep without a caller-maintained
+        tenant list: the `active_spawns:{tenant}` keys ARE the active-tenant set.
+        """
+        total = 0
+        seen: set[str] = set()
+        async for key in self._r.scan_iter(match=f"{_active_key('')}*"):
+            tenant_id = key.rsplit(":", 1)[-1]
+            if tenant_id and tenant_id not in seen:
+                seen.add(tenant_id)
+                total += await self.reconcile(tenant_id)
+        return total
+
     async def run(self) -> None:  # pragma: no cover — long-running loop, exercised via process_task
         """Subscribe to the tasks channel and process messages until cancelled."""
         pubsub = self._r.pubsub()

--- a/src/keiracom_system/work_loop/integration.py
+++ b/src/keiracom_system/work_loop/integration.py
@@ -1,0 +1,77 @@
+"""Wire the work-loop consumer into the dispatcher lifecycle (Agency_OS-innu).
+
+Follow-up to PR #1275 (the consumer). Two seams the dispatcher calls:
+
+  * ``release_on_exit(tenant_id, task_id)`` — invoked from the dispatcher exit
+    hook (``/dispatcher/terminate``) when a spawn tears down: frees the tenant
+    slot, then the consumer pops the per-tenant overflow and spawns the next.
+  * ``reconcile_loop(interval_s)`` — a background task started in the dispatcher
+    lifespan; periodically reclaims slots whose lease TTL lapsed (crashed agents
+    that never hit the clean exit hook).
+
+A module-level consumer singleton keeps one Valkey pool + spawn path for the
+process. ``set_consumer`` is the test seam. Both entry points are fail-open —
+the dispatcher's teardown and lifespan must never break on a work-loop error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from src.keiracom_system.work_loop.consumer import WorkLoopConsumer
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RECONCILE_INTERVAL_S = 60
+
+_consumer: WorkLoopConsumer | None = None
+
+
+def get_consumer() -> WorkLoopConsumer:
+    """Lazy process-singleton consumer (real Valkey pool + dispatcher spawn)."""
+    global _consumer  # noqa: PLW0603
+    if _consumer is None:
+        _consumer = WorkLoopConsumer()
+    return _consumer
+
+
+def set_consumer(consumer: WorkLoopConsumer | None) -> None:
+    """Test seam — inject a fake/fakeredis-backed consumer (or reset to None)."""
+    global _consumer  # noqa: PLW0603
+    _consumer = consumer
+
+
+async def release_on_exit(tenant_id: str, task_id: str) -> None:
+    """Dispatcher exit-hook callback. Fail-open — never break teardown."""
+    try:
+        await get_consumer().release_slot(tenant_id, task_id)
+    except Exception:  # noqa: BLE001 — a work-loop error must not fail termination
+        logger.warning(
+            "work-loop release_on_exit failed (tenant=%s task=%s)",
+            tenant_id,
+            task_id,
+            exc_info=True,
+        )
+
+
+async def reconcile_loop(
+    interval_s: int = DEFAULT_RECONCILE_INTERVAL_S, *, iterations: int | None = None
+) -> None:
+    """Periodically reclaim crashed-agent slots until cancelled.
+
+    ``iterations`` bounds the loop for tests (None = run forever until the task
+    is cancelled by the dispatcher lifespan). Errors are swallowed so a single
+    bad sweep never kills the loop.
+    """
+    n = 0
+    while iterations is None or n < iterations:
+        try:
+            reclaimed = await get_consumer().reconcile_all()
+            if reclaimed:
+                logger.info("work-loop reconcile reclaimed %d crashed-agent slot(s)", reclaimed)
+        except Exception:  # noqa: BLE001 — one failed sweep never kills the loop
+            logger.warning("work-loop reconcile sweep failed", exc_info=True)
+        n += 1
+        if iterations is None or n < iterations:
+            await asyncio.sleep(interval_s)

--- a/tests/dispatcher/test_main_work_loop_wiring.py
+++ b/tests/dispatcher/test_main_work_loop_wiring.py
@@ -1,0 +1,56 @@
+"""Dispatcher → work-loop exit-hook wiring (Agency_OS-innu).
+
+Proves /dispatcher/terminate calls work_loop.release_on_exit with the tenant_id
+retained in the _spawned registry. release_on_exit is patched (its own behaviour
+is covered in tests/keiracom_system/work_loop/test_integration.py).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import src.dispatcher.main as main_mod
+from src.dispatcher.tmux_lifecycle import SessionHandle
+
+
+async def test_terminate_calls_release_on_exit_with_tenant_id(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(main_mod, "_watchdog", MagicMock(tracked=0))
+    monkeypatch.setattr(main_mod, "_reaper", MagicMock())
+    monkeypatch.setattr(main_mod, "_bounded_spawn_enforcer", None)
+    handle = SessionHandle(session_name="disp-x", working_dir="/tmp", command="bash")
+    main_mod._spawned["k9"] = {
+        "handle": handle,
+        "backend": main_mod.Backend("tmux"),
+        "tenant_id": "tnt",
+    }
+
+    with (
+        patch.object(main_mod, "SessionManager"),
+        patch.object(main_mod.work_loop, "release_on_exit", new=AsyncMock()) as rel,
+    ):
+        resp = await main_mod.dispatcher_terminate(main_mod.TerminateRequest(key="k9"))
+
+    assert resp["terminated"] is True
+    rel.assert_awaited_once_with("tnt", "k9")
+
+
+async def test_terminate_without_tenant_id_skips_release(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(main_mod, "_watchdog", MagicMock(tracked=0))
+    monkeypatch.setattr(main_mod, "_reaper", MagicMock())
+    monkeypatch.setattr(main_mod, "_bounded_spawn_enforcer", None)
+    handle = SessionHandle(session_name="disp-y", working_dir="/tmp", command="bash")
+    main_mod._spawned["k0"] = {
+        "handle": handle,
+        "backend": main_mod.Backend("tmux"),
+        "tenant_id": None,
+    }
+
+    with (
+        patch.object(main_mod, "SessionManager"),
+        patch.object(main_mod.work_loop, "release_on_exit", new=AsyncMock()) as rel,
+    ):
+        await main_mod.dispatcher_terminate(main_mod.TerminateRequest(key="k0"))
+
+    rel.assert_not_awaited()  # non-work-loop spawn → no release

--- a/tests/keiracom_system/work_loop/test_integration.py
+++ b/tests/keiracom_system/work_loop/test_integration.py
@@ -1,0 +1,103 @@
+"""Tests for the work-loop dispatcher integration (Agency_OS-innu).
+
+release_on_exit + reconcile_loop are driven against a fakeredis-backed real
+WorkLoopConsumer (injected via set_consumer) so the slot accounting is exercised
+end-to-end. Fail-open paths use a consumer stub that raises.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fakeredis import aioredis
+
+from src.keiracom_system.work_loop import consumer as wl
+from src.keiracom_system.work_loop import integration as integ
+from src.keiracom_system.work_loop.consumer import WorkLoopConsumer
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    yield
+    integ.set_consumer(None)
+
+
+def _ceiling(n: int):
+    async def _f(_t: str) -> int:
+        return n
+
+    return _f
+
+
+class _Spawner:
+    def __init__(self):
+        self.calls: list[str] = []
+
+    async def __call__(self, task: wl.Task) -> bool:
+        self.calls.append(task.task_id)
+        return True
+
+
+def _msg(task_id: str, tenant_id: str = "tnt") -> str:
+    return json.dumps(
+        {"task_id": task_id, "tenant_id": tenant_id, "backend": "container", "spawn_kwargs": {}}
+    )
+
+
+def _fakeredis_consumer(spawner) -> WorkLoopConsumer:
+    return WorkLoopConsumer(
+        valkey=aioredis.FakeRedis(decode_responses=True), spawn_fn=spawner, ceiling_fn=_ceiling(1)
+    )
+
+
+async def test_release_on_exit_frees_slot_and_pops_overflow():
+    spawner = _Spawner()
+    c = _fakeredis_consumer(spawner)
+    integ.set_consumer(c)
+    await c.process_task(_msg("k1"))  # spawned (ceiling 1)
+    await c.process_task(_msg("k2"))  # overflowed
+    await integ.release_on_exit("tnt", "k1")  # dispatcher exit hook
+    assert spawner.calls == ["k1", "k2"]  # next popped + spawned
+    assert await c._r.get(wl._active_key("tnt")) == "1"
+
+
+async def test_release_on_exit_is_failopen():
+    class _Boom:
+        async def release_slot(self, *_a):
+            raise RuntimeError("valkey down")
+
+    integ.set_consumer(_Boom())
+    await integ.release_on_exit("tnt", "k1")  # must not raise
+
+
+async def test_reconcile_loop_one_iteration_reclaims_expired_lease():
+    spawner = _Spawner()
+    c = _fakeredis_consumer(spawner)
+    integ.set_consumer(c)
+    await c.process_task(_msg("crashed"))
+    await c._r.delete(wl._lease_key("tnt", "crashed"))  # lease lapsed (no heartbeat)
+    await integ.reconcile_loop(interval_s=0, iterations=1)
+    assert await c._r.get(wl._active_key("tnt")) == "0"  # reclaimed
+
+
+async def test_reconcile_loop_is_failopen():
+    class _Boom:
+        async def reconcile_all(self):
+            raise RuntimeError("scan failed")
+
+    integ.set_consumer(_Boom())
+    await integ.reconcile_loop(interval_s=0, iterations=1)  # must not raise
+
+
+async def test_reconcile_all_scans_multiple_tenants():
+    spawner = _Spawner()
+    c = WorkLoopConsumer(
+        valkey=aioredis.FakeRedis(decode_responses=True), spawn_fn=spawner, ceiling_fn=_ceiling(5)
+    )
+    await c.process_task(_msg("a1", "tenant-A"))
+    await c.process_task(_msg("b1", "tenant-B"))
+    await c._r.delete(wl._lease_key("tenant-A", "a1"))
+    await c._r.delete(wl._lease_key("tenant-B", "b1"))
+    reclaimed = await c.reconcile_all()
+    assert reclaimed == 2  # both tenants swept via SCAN


### PR DESCRIPTION
## Summary

The **#1275 follow-up** (Agency_OS-innu) — closes the self-driving loop end-to-end by wiring the consumer's `release_slot` + `reconcile` into the dispatcher lifecycle.

> **Stacked on #1275.** Base is `atlas/work-loop-consumer` so the diff is isolated to this PR's changes. **Merge order: #1275 first, then this** (GitHub auto-retargets this PR to `main` once #1275 merges).

## What it does

1. **Exit hook** — `/dispatcher/terminate` now frees the tenant slot. The spawn registry retains `tenant_id` (from `spawn_kwargs`); on terminate, after the bounded-spawn release, it calls `work_loop.release_on_exit(tenant_id, key)` → `consumer.release_slot` → **DECR `active_spawns` → LPOP overflow → spawn next**.
2. **Periodic reconcile** — a **Step-6 lifespan background task** runs `consumer.reconcile_all()` every 60s (`SCAN active_spawns:* → reconcile each tenant`) to reclaim slots whose lease TTL lapsed — the **crashed-agent** path the clean exit hook can't cover. Cancelled cleanly on shutdown alongside watchdog/reaper.

## Changes

- **New** `src/keiracom_system/work_loop/integration.py` — `release_on_exit` + `reconcile_loop` + a process-singleton consumer with a `set_consumer` test seam. **Both entry points fail-open** so a work-loop error never breaks dispatcher teardown or the lifespan.
- `consumer.reconcile_all()` — SCAN-based multi-tenant crash sweep (no caller-maintained tenant list; the `active_spawns:{tenant}` keys *are* the active set).
- `dispatcher/main.py` — 3 surgical edits: import, store `tenant_id` in `_spawned`, call `release_on_exit` on terminate + start the Step-6 reconcile task.

## Reuse / scope

Reuses `dispatcher/valkey_pool` + the real `SpawnRequest`/`_spawned` contract (per #1275). I touched the shared `dispatcher/main.py` (exit hook + lifespan) — minimal + flagged. The reaper-driven (TTL) reap path is covered by `reconcile` via lease expiry rather than a per-reap callback (kept scope tight).

## Test plan

- [x] fakeredis tests (same approach as #1275): `release_on_exit` frees+pops + fail-open; `reconcile_loop` reclaims + fail-open; `reconcile_all` multi-tenant SCAN; dispatcher `terminate`→`release_on_exit` **with and without** `tenant_id`
- [x] Existing `test_terminate_removes_session_from_supervisors` still green (no regression)
- [x] `import src.dispatcher.main` clean — no import cycle
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)