### PR TITLE
[ATLAS] feat(work-loop): producer bridge + consumer runner + systemd units (Agency_OS-nkc0)

### DIFF
--- a/scripts/install_work_loop.sh
+++ b/scripts/install_work_loop.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# install_work_loop.sh — Install the work-loop systemd units (Agency_OS-nkc0).
+# References: keiracom-work-loop-bridge.service + keiracom-work-loop-consumer.service
+#
+# ⚠ GATED — DO NOT RUN until the Phase-1 cutover go-live (Dave's budget-gate
+# decision). `enable --now` STARTS the self-driving loop (live auto-spawns +
+# LLM spend). The script EXISTS to satisfy the deployment contract (KEI-108:
+# every shipped unit is referenced by an installer) and to give the operator a
+# one-command install at go-live — its existence is not its execution.
+#
+# Prereqs at go-live: dispatcher running (:4001), Valkey up (:6379), and the
+# Vault bootstrap (VAULT_ADDR + VAULT_TOKEN) present in the dispatcher .env so
+# scrubbed-tmux agents resolve their creds (P10 / Agency_OS-8dvl).
+set -euo pipefail
+
+UNITS_DIR="${HOME}/.config/systemd/user"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SYSTEMD_DIR="${REPO_DIR}/systemd"
+
+mkdir -p "${UNITS_DIR}"
+
+cp "${SYSTEMD_DIR}/keiracom-work-loop-bridge.service" "${UNITS_DIR}/"
+cp "${SYSTEMD_DIR}/keiracom-work-loop-consumer.service" "${UNITS_DIR}/"
+
+systemctl --user daemon-reload
+
+# Bridge first (the producer: Postgres task_event → Valkey), then the consumer
+# (Valkey → tier-gated /dispatcher/spawn). Both Restart=always (P11 / c2xk).
+systemctl --user enable --now keiracom-work-loop-bridge.service
+systemctl --user enable --now keiracom-work-loop-consumer.service
+
+echo "work-loop bridge + consumer installed and started"

--- a/src/keiracom_system/work_loop/__main__.py
+++ b/src/keiracom_system/work_loop/__main__.py
@@ -1,0 +1,26 @@
+"""Run the work-loop consumer as a service (Agency_OS-nkc0).
+
+    python -m src.keiracom_system.work_loop
+
+Subscribes to Valkey `keiracom:tasks:available` and drives the tier-gated
+spawn loop (admit → POST /dispatcher/spawn → overflow at ceiling). Slot release
+on agent exit + crash-recovery reconcile run in the dispatcher process
+(src/dispatcher/main.py lifespan), not here — this entrypoint is just the
+subscribe→process loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from src.keiracom_system.work_loop.consumer import WorkLoopConsumer
+
+
+def main() -> None:  # pragma: no cover — process entrypoint
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(WorkLoopConsumer().run())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/keiracom_system/work_loop/bridge.py
+++ b/src/keiracom_system/work_loop/bridge.py
@@ -1,0 +1,147 @@
+"""PG→Valkey producer bridge for the work loop (Agency_OS-nkc0).
+
+The Postgres producer signal already exists: the `kei45_emit_task_event` trigger
+(migration 20260514_kei45_tasks_realtime.sql) fires `pg_notify('task_event', ...)`
+with `event_type='new_available'` when a task becomes available. Postgres can't
+publish to Valkey directly, so THIS bridge is the missing link — it LISTENs on the
+`task_event` channel, filters `new_available`, maps each event to the consumer's
+message contract, and PUBLISHes to Valkey `keiracom:tasks:available`.
+
+Phase-1 (Dave personal cutover) is single-tenant: every task publishes under
+`FLEET_TENANT_ID` (env, default `default`). Multi-tenant tenant resolution is a
+later KEI. `backend=container`; `callsign` from the task's `claimed_by`
+(fallback `worker`).
+
+Fail-open: an unparseable / non-new_available event is skipped (not published),
+never raised — one bad event must not kill the bridge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any
+
+from src.dispatcher.valkey_pool import get_valkey_client
+from src.keiracom_system.work_loop.consumer import TASKS_CHANNEL
+
+logger = logging.getLogger(__name__)
+
+PG_NOTIFY_CHANNEL = "task_event"
+NEW_AVAILABLE = "new_available"
+DEFAULT_BACKEND = "container"
+DEFAULT_CALLSIGN = "worker"
+DEFAULT_FLEET_TENANT_ID = "default"
+
+
+def _fleet_tenant_id() -> str:
+    return os.environ.get("FLEET_TENANT_ID") or DEFAULT_FLEET_TENANT_ID
+
+
+def _dsn() -> str | None:
+    dsn = os.environ.get("SUPABASE_DB_DSN") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        return None
+    return dsn.replace("postgresql+asyncpg://", "postgresql://", 1).replace(
+        "postgresql+psycopg://", "postgresql://", 1
+    )
+
+
+def task_event_to_message(payload: str | dict[str, Any], fleet_tenant_id: str) -> str | None:
+    """Map a kei45 `task_event` payload → the consumer's message JSON.
+
+    Returns None (skip) for unparseable payloads, non-`new_available` events, or
+    events missing a task id.
+    """
+    try:
+        d = payload if isinstance(payload, dict) else json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("work-loop bridge: unparseable task_event payload")
+        return None
+    if not isinstance(d, dict) or d.get("event_type") != NEW_AVAILABLE:
+        return None
+    task_id = d.get("id")
+    if not task_id:
+        return None
+    task_id = str(task_id)
+    return json.dumps(
+        {
+            "task_id": task_id,
+            "tenant_id": fleet_tenant_id,
+            "backend": DEFAULT_BACKEND,
+            "spawn_kwargs": {
+                "callsign": d.get("claimed_by") or DEFAULT_CALLSIGN,
+                "task_id": task_id,
+                "title": d.get("title"),
+                "priority": d.get("priority"),
+                "tags": d.get("tags"),
+            },
+        }
+    )
+
+
+async def publish_task_event(
+    valkey: Any,
+    payload: str | dict[str, Any],
+    fleet_tenant_id: str,
+    *,
+    channel: str = TASKS_CHANNEL,
+) -> bool:
+    """Map one `task_event` and PUBLISH it to Valkey. True if published, else False."""
+    msg = task_event_to_message(payload, fleet_tenant_id)
+    if msg is None:
+        return False
+    await valkey.publish(channel, msg)
+    return True
+
+
+async def run_bridge(  # pragma: no cover — asyncpg LISTEN wiring, exercised via publish_task_event
+    *, dsn: str | None = None, valkey: Any = None, fleet_tenant_id: str | None = None
+) -> None:
+    """LISTEN on the PG `task_event` channel → publish `new_available` to Valkey.
+
+    Runs until cancelled. The asyncpg listener callback is synchronous, so it
+    hands payloads to a queue the main coroutine drains + publishes.
+    """
+    dsn = dsn or _dsn()
+    if not dsn:
+        raise RuntimeError("work-loop bridge requires DATABASE_URL/SUPABASE_DB_DSN")
+    valkey = valkey or get_valkey_client()
+    fleet_tenant_id = fleet_tenant_id or _fleet_tenant_id()
+    from src.utils.asyncpg_connection import get_asyncpg_connection
+
+    conn = await get_asyncpg_connection(dsn)
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    def _on_notify(_conn: Any, _pid: int, _channel: str, payload: str) -> None:
+        queue.put_nowait(payload)
+
+    await conn.add_listener(PG_NOTIFY_CHANNEL, _on_notify)
+    logger.info(
+        "work-loop bridge LISTENing on PG '%s' → Valkey '%s' (fleet_tenant=%s)",
+        PG_NOTIFY_CHANNEL,
+        TASKS_CHANNEL,
+        fleet_tenant_id,
+    )
+    try:
+        while True:
+            payload = await queue.get()
+            try:
+                if await publish_task_event(valkey, payload, fleet_tenant_id):
+                    logger.info("work-loop bridge published a new_available task")
+            except Exception:  # noqa: BLE001 — one bad event never kills the bridge
+                logger.warning("work-loop bridge: publish failed", exc_info=True)
+    finally:
+        await conn.remove_listener(PG_NOTIFY_CHANNEL, _on_notify)
+        await conn.close()
+
+
+def main() -> None:  # pragma: no cover — process entrypoint
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(run_bridge())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/systemd/keiracom-work-loop-bridge.service
+++ b/systemd/keiracom-work-loop-bridge.service
@@ -22,7 +22,9 @@ EnvironmentFile=/home/elliotbot/.config/agency-os/.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS
 ExecStart=/usr/bin/python3 -B -m src.keiracom_system.work_loop.bridge
 
-Restart=on-failure
+# P11 (Agency_OS-c2xk): always restart — a long-running loop driver must never
+# stay down (Restart=always covers clean exits too, not just failures).
+Restart=always
 RestartSec=10
 
 StandardOutput=append:/home/elliotbot/clawd/logs/keiracom-work-loop-bridge.log

--- a/systemd/keiracom-work-loop-bridge.service
+++ b/systemd/keiracom-work-loop-bridge.service
@@ -1,0 +1,32 @@
+[Unit]
+# Work-loop producer bridge (Agency_OS-nkc0). LISTENs on the Postgres
+# 'task_event' channel (kei45_emit_task_event trigger) and publishes
+# new_available events to Valkey keiracom:tasks:available — the missing
+# Postgres→Valkey link that feeds the consumer.
+#
+# Singleton. Enable with:
+#   systemctl --user enable --now keiracom-work-loop-bridge.service
+#
+# NOT ENABLED AT MERGE TIME: live smoke held pending Dave's budget-gate decision
+# (same hold as the consumer unit). Land the unit; enable only after that.
+Description=Keiracom work-loop producer bridge (Postgres task_event → Valkey)
+Documentation=https://github.com/Keiracom/Agency_OS
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+ExecStart=/usr/bin/python3 -B -m src.keiracom_system.work_loop.bridge
+
+Restart=on-failure
+RestartSec=10
+
+StandardOutput=append:/home/elliotbot/clawd/logs/keiracom-work-loop-bridge.log
+StandardError=append:/home/elliotbot/clawd/logs/keiracom-work-loop-bridge.log
+
+[Install]
+WantedBy=default.target

--- a/systemd/keiracom-work-loop-consumer.service
+++ b/systemd/keiracom-work-loop-consumer.service
@@ -1,0 +1,31 @@
+[Unit]
+# Work-loop consumer service (Agency_OS-nkc0). Subscribes to Valkey
+# keiracom:tasks:available and drives the tier-gated spawn loop → /dispatcher/spawn.
+#
+# Singleton (not a per-callsign template): one consumer per node coordinates all
+# tenants via Valkey keys. Enable with:
+#   systemctl --user enable --now keiracom-work-loop-consumer.service
+#
+# NOT ENABLED AT MERGE TIME: the live smoke is held pending Dave's budget-gate
+# (uncapped per-spawn spend) decision. Land the unit; enable only after that.
+Description=Keiracom work-loop consumer (tier-gated task→spawn driver)
+Documentation=https://github.com/Keiracom/Agency_OS
+After=network-online.target
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS
+ExecStart=/usr/bin/python3 -B -m src.keiracom_system.work_loop
+
+Restart=on-failure
+RestartSec=10
+
+StandardOutput=append:/home/elliotbot/clawd/logs/keiracom-work-loop-consumer.log
+StandardError=append:/home/elliotbot/clawd/logs/keiracom-work-loop-consumer.log
+
+[Install]
+WantedBy=default.target

--- a/systemd/keiracom-work-loop-consumer.service
+++ b/systemd/keiracom-work-loop-consumer.service
@@ -21,7 +21,9 @@ EnvironmentFile=/home/elliotbot/.config/agency-os/.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS
 ExecStart=/usr/bin/python3 -B -m src.keiracom_system.work_loop
 
-Restart=on-failure
+# P11 (Agency_OS-c2xk): always restart — a long-running loop driver must never
+# stay down (Restart=always covers clean exits too, not just failures).
+Restart=always
 RestartSec=10
 
 StandardOutput=append:/home/elliotbot/clawd/logs/keiracom-work-loop-consumer.log

--- a/tests/keiracom_system/work_loop/test_bridge.py
+++ b/tests/keiracom_system/work_loop/test_bridge.py
@@ -1,0 +1,100 @@
+"""Tests for the work-loop producer bridge (Agency_OS-nkc0).
+
+`task_event_to_message` is pure (deterministic). The publish path runs against
+fakeredis with a subscriber. Payloads mirror the kei45_emit_task_event shape
+(the fake PG-notify source).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fakeredis import aioredis
+
+from src.keiracom_system.work_loop import bridge
+from src.keiracom_system.work_loop.consumer import TASKS_CHANNEL
+
+
+def _new_available(task_id: str = "T-1", claimed_by: str | None = None) -> str:
+    # Mirrors kei45_emit_task_event payload (migration 20260514_kei45_tasks_realtime.sql).
+    return json.dumps(
+        {
+            "event_type": "new_available",
+            "id": task_id,
+            "title": "do the thing",
+            "status": "available",
+            "priority": "high",
+            "claimed_by": claimed_by,
+            "tags": ["build"],
+            "op": "INSERT",
+            "at": "now",
+        }
+    )
+
+
+# --- mapping (pure) ----------------------------------------------------
+
+
+def test_maps_new_available_to_consumer_message():
+    d = json.loads(bridge.task_event_to_message(_new_available("T-1", "atlas"), "fleet-1"))
+    assert d["task_id"] == "T-1"
+    assert d["tenant_id"] == "fleet-1"
+    assert d["backend"] == bridge.DEFAULT_BACKEND  # container
+    assert d["spawn_kwargs"]["callsign"] == "atlas"  # from claimed_by
+    assert d["spawn_kwargs"]["task_id"] == "T-1"
+
+
+def test_callsign_defaults_to_worker_when_unclaimed():
+    d = json.loads(bridge.task_event_to_message(_new_available("T-2", None), "f"))
+    assert d["spawn_kwargs"]["callsign"] == bridge.DEFAULT_CALLSIGN  # worker
+
+
+@pytest.mark.parametrize("event_type", ["claimed", "completed", "unclaimed", "other"])
+def test_non_new_available_is_skipped(event_type):
+    payload = json.dumps({"event_type": event_type, "id": "T-9"})
+    assert bridge.task_event_to_message(payload, "f") is None
+
+
+def test_missing_id_is_skipped():
+    assert bridge.task_event_to_message(json.dumps({"event_type": "new_available"}), "f") is None
+
+
+def test_unparseable_payload_is_skipped():
+    assert bridge.task_event_to_message("not-json{", "f") is None
+
+
+def test_accepts_dict_payload_and_stringifies_id():
+    d = json.loads(bridge.task_event_to_message({"event_type": "new_available", "id": 7}, "f"))
+    assert d["task_id"] == "7"
+
+
+# --- publish (fakeredis) ----------------------------------------------
+
+
+async def test_publish_new_available_lands_on_channel():
+    r = aioredis.FakeRedis(decode_responses=True)
+    ps = r.pubsub()
+    await ps.subscribe(TASKS_CHANNEL)
+    published = await bridge.publish_task_event(r, _new_available("T-5", "orion"), "fleet-1")
+    assert published is True
+    got = None
+    for _ in range(5):
+        m = await ps.get_message(timeout=1)
+        if m and m.get("type") == "message":
+            got = m
+            break
+    assert got is not None, "published message never arrived on the channel"
+    body = json.loads(got["data"])
+    assert body["task_id"] == "T-5"
+    assert body["tenant_id"] == "fleet-1"
+    await ps.unsubscribe(TASKS_CHANNEL)
+    await ps.aclose()
+
+
+async def test_publish_skips_non_new_available():
+    r = aioredis.FakeRedis(decode_responses=True)
+    published = await bridge.publish_task_event(
+        r, json.dumps({"event_type": "completed", "id": "T-6"}), "f"
+    )
+    assert published is False


### PR DESCRIPTION
## Summary

Completes the self-driving loop's **missing producer half** (the consumer is #1275/#1276). Branches off `main` (depends only on #1275's consumer, already merged) — independent of #1276.

**Discovery:** the Postgres trigger already exists — `kei45_emit_task_event` (`20260514_kei45_tasks_realtime.sql`) fires `pg_notify('task_event', …)` with `event_type='new_available'`. So this is the **bridge**, not a new trigger.

## What's here

- **`bridge.py`** — async PG `LISTEN task_event` → filter `new_available` → map payload → `PUBLISH` to Valkey `keiracom:tasks:available`. Phase-1 single-tenant: `FLEET_TENANT_ID` (env, default `default`); `backend=container`; `callsign` from `claimed_by` (fallback `worker`). Fail-open — unparseable / non-`new_available` events are skipped, never raised.
- **`__main__.py`** — consumer runner entrypoint (`python -m src.keiracom_system.work_loop` → `WorkLoopConsumer().run()`).
- **`systemd/keiracom-work-loop-{consumer,bridge}.service`** — `--user` units (dispatcher pattern). **Left UNENABLED** by design.

## Design decisions (confirmed by Elliot)

`(a)` single `FLEET_TENANT_ID` for the Phase-1 Dave cutover (multi-tenant = later KEI); `backend=container`; `callsign` from `claimed_by` else `worker`.

## ⚠️ Live smoke HELD

The end-to-end smoke (publish a real task → confirm spawn) is **intentionally NOT run** and the units are **not enabled** — held per Elliot pending **Dave's per-spawn spend-cap (budget gate) decision**. This PR lands the code + units only; switch-on is a separate, gated step.

## Test plan

- [x] 11 bridge tests: mapping correctness, `new_available` filter, missing-id / unparseable skip, dict payload, **fakeredis publish round-trip on the channel** (+ fake PG-notify payloads mirroring the kei45 shape)
- [x] Full work_loop suite 26 pass; `ruff check src/` + `ruff format src/ --check` clean
- [ ] Live smoke — deferred (budget-gate hold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)