### PR TITLE
[NOVA] fix(kei87): ceo_memory_writer set_config + NOT NULL context — unbreaks migration-apply-watcher

### DIFF
--- a/src/governance/ceo_memory_writer.py
+++ b/src/governance/ceo_memory_writer.py
@@ -43,8 +43,16 @@ def _require_callsign(callsign: str) -> str:
     return cs
 
 
-def upsert_ceo_memory_key(callsign: str, key: str, value: Mapping[str, Any]) -> None:
-    """Idempotent upsert into public.ceo_memory under the KEI-87 write-guard."""
+def upsert_ceo_memory_key(
+    callsign: str, key: str, value: Mapping[str, Any], *, context: str = "fleet"
+) -> None:
+    """Idempotent upsert into public.ceo_memory under the KEI-87 write-guard.
+
+    `context` is the NOT-NULL lane classifier (migration 20260524_0scg):
+    'fleet' | 'product' | 'both' | 'archive'. Defaults to 'fleet' — all current
+    callers (migration-apply-watcher debt rows, exit-cycle captures, backup
+    alerts) are fleet-internal. On conflict the existing context is preserved.
+    """
     import psycopg  # local import — keeps callers without psycopg from paying import cost
 
     cs = _require_callsign(callsign)
@@ -52,15 +60,19 @@ def upsert_ceo_memory_key(callsign: str, key: str, value: Mapping[str, Any]) -> 
     # pooler is txn-mode pgbouncer; psycopg3 cached prepared statements break on
     # first repeated execute() across pool connections.
     with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
-        cur.execute("SET LOCAL agency_os.callsign = %s", (cs,))
+        # `SET LOCAL <var> = %s` is NOT parameterizable — Postgres SET is a
+        # utility statement that rejects bind params ("syntax error at $1"),
+        # which crashed every ceo_memory write (incl. migration-apply-watcher).
+        # set_config(name, value, is_local=true) is the parameterized SET LOCAL.
+        cur.execute("SELECT set_config('agency_os.callsign', %s, true)", (cs,))
         cur.execute(
             """
-            INSERT INTO public.ceo_memory (key, value, updated_at)
-            VALUES (%s, %s::jsonb, NOW())
+            INSERT INTO public.ceo_memory (key, value, context, updated_at)
+            VALUES (%s, %s::jsonb, %s, NOW())
             ON CONFLICT (key) DO UPDATE
               SET value = EXCLUDED.value, updated_at = NOW()
             """,
-            (key, json.dumps(dict(value))),
+            (key, json.dumps(dict(value)), context),
         )
         conn.commit()
 
@@ -74,7 +86,11 @@ def update_ceo_memory_value(callsign: str, key: str, value: Mapping[str, Any]) -
     # pooler is txn-mode pgbouncer; psycopg3 cached prepared statements break on
     # first repeated execute() across pool connections.
     with psycopg.connect(_dsn(), prepare_threshold=None) as conn, conn.cursor() as cur:
-        cur.execute("SET LOCAL agency_os.callsign = %s", (cs,))
+        # `SET LOCAL <var> = %s` is NOT parameterizable — Postgres SET is a
+        # utility statement that rejects bind params ("syntax error at $1"),
+        # which crashed every ceo_memory write (incl. migration-apply-watcher).
+        # set_config(name, value, is_local=true) is the parameterized SET LOCAL.
+        cur.execute("SELECT set_config('agency_os.callsign', %s, true)", (cs,))
         cur.execute(
             "UPDATE public.ceo_memory SET value = %s::jsonb, updated_at = NOW() WHERE key = %s",
             (json.dumps(dict(value)), key),

--- a/tests/governance/test_ceo_memory_writer.py
+++ b/tests/governance/test_ceo_memory_writer.py
@@ -63,10 +63,25 @@ def test_upsert_sets_local_callsign_before_write() -> None:
     with patch("psycopg.connect", return_value=conn):
         ceo_memory_writer.upsert_ceo_memory_key("elliot", "ceo:phase_lock", {"v": 1})
     sqls = [s for s, _ in conn.cur.executed]
-    assert "SET LOCAL agency_os.callsign" in sqls[0]
+    # Must use the PARAMETERIZED set_config form — `SET LOCAL <var> = %s` is a
+    # Postgres syntax error (bind params rejected) that crashed every write.
+    assert "set_config('agency_os.callsign'" in sqls[0]
+    assert "SET LOCAL" not in sqls[0]
     assert conn.cur.executed[0][1] == ("elliot",)
     assert "INSERT INTO public.ceo_memory" in sqls[1]
+    # context is NOT NULL (migration 20260524_0scg) — must be in the INSERT.
+    assert "context" in sqls[1]
+    assert "fleet" in conn.cur.executed[1][1]
     assert conn.commits == 1
+
+
+def test_upsert_context_param_overrides_default() -> None:
+    conn = _Conn()
+    with patch("psycopg.connect", return_value=conn):
+        ceo_memory_writer.upsert_ceo_memory_key(
+            "elliot", "ceo:phase_lock", {"v": 1}, context="product"
+        )
+    assert "product" in conn.cur.executed[1][1]
 
 
 def test_update_sets_local_callsign_then_update() -> None:
@@ -74,7 +89,8 @@ def test_update_sets_local_callsign_then_update() -> None:
     with patch("psycopg.connect", return_value=conn):
         ceo_memory_writer.update_ceo_memory_value("dave", "ceo:phase_lock", {"v": 2})
     sqls = [s for s, _ in conn.cur.executed]
-    assert "SET LOCAL agency_os.callsign" in sqls[0]
+    assert "set_config('agency_os.callsign'" in sqls[0]
+    assert "SET LOCAL" not in sqls[0]
     assert conn.cur.executed[0][1] == ("dave",)
     assert "UPDATE public.ceo_memory" in sqls[1]
     assert conn.commits == 1
@@ -133,8 +149,8 @@ def test_upsert_propagates_trigger_check_violation() -> None:
     )
     with patch("psycopg.connect", return_value=conn), pytest.raises(CheckViolation):
         ceo_memory_writer.upsert_ceo_memory_key("aiden", "ceo:phase_lock", {"v": 1})
-    # SET LOCAL still executed; the exception happens on the INSERT (call 2)
-    assert any("SET LOCAL agency_os.callsign" in s for s, _ in conn.cur.executed)
+    # callsign session var still set; the exception happens on the INSERT (call 2)
+    assert any("set_config('agency_os.callsign'" in s for s, _ in conn.cur.executed)
 
 
 def test_update_propagates_trigger_check_violation() -> None:


### PR DESCRIPTION
## Summary
`upsert_ceo_memory_key` was **doubly broken**, crashing *every* `ceo:*` write — which is why `migration-apply-watcher.service` was failing (and exit-cycle captures + backup alerts would too):

1. **`SET LOCAL agency_os.callsign = %s`** — Postgres `SET` is a utility statement that rejects bind params → `syntax error at or near "$1"`. Fixed with the parameterized equivalent `SELECT set_config('agency_os.callsign', %s, true)`.
2. **INSERT omitted `context`** — migration `20260524_0scg` made `ceo_memory.context` NOT NULL → `NotNullViolation` on every insert. Added a `context` param (default `'fleet'`; lane values fleet/product/both/archive) and included it in the INSERT; `ON CONFLICT` preserves existing context.

**Why it shipped:** the unit tests asserted the literal buggy `SET LOCAL ... %s` string against a *mock* cursor (no real SQL executed). Updated to assert the `set_config` form + `context`, plus a dedicated regression guard.

## Verified live (prod)
```
upsert_ceo_memory_key('elliot','ceo:_nova_writer_smoketest',{...}) → SUCCESS (context=fleet)
migration_apply_watcher.py --dry-run → exit 0 ("no recent migration files found")
```
(temp key deleted after)

## Tests
`tests/governance/test_ceo_memory_writer.py`: 13 passed, ruff clean.

## Context
Part of Agency_OS-e7km (taken over from Max). The migration backlog this watcher was supposed to flag has been applied separately (atomization pilot, tenant metering, tenant budgets — verified live; spawn-attribution was already applied). The deployed `migration-apply-watcher.service` recovers once this merges to main and the deployed worktree updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)