### PR TITLE
[ATLAS] fix(work-loop): container-defaults injection + bridge brief/task_type (Agency_OS-g9xx)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -22,6 +22,7 @@ import contextlib
 import dataclasses
 import logging
 import os
+import socket
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -377,6 +378,60 @@ _REAPER_SWEEP_INTERVAL_S = 60.0
 TMUX_NAME_PREFIX = os.environ.get("DISPATCHER_TMUX_PREFIX", "disp-")
 CONTAINER_NAME_PREFIX = os.environ.get("DISPATCHER_CONTAINER_PREFIX", "disp-")
 
+# Container spawn defaults (Agency_OS-g9xx). The work-loop bridge sends LOGICAL
+# spawn_kwargs (callsign/task_id/brief/...) that container_lifecycle.spawn_container's
+# strict signature (image/name/port/env) would TypeError on → /dispatcher/spawn 400.
+# _container_spawn_kwargs translates: image from config, name from key, port
+# allocated, all other metadata → container env (AGENT_*), alongside any recall
+# block spawn_recall.inject_block already placed in env.
+#
+# NOTE: DISPATCHER_CONTAINER_IMAGE must point at an image present on the spawn
+# host. No Claude-agent container image was found in-repo (Dockerfile.worker is a
+# Prefect worker, not an agent), and docker wasn't available to verify a built
+# tag — so the default below is a placeholder the operator MUST override/build
+# before a real container spawn succeeds (else docker run → ContainerStartupError).
+_CONTAINER_IMAGE_ENV = "DISPATCHER_CONTAINER_IMAGE"
+DEFAULT_CONTAINER_IMAGE = "keiracom-agent:latest"
+_CONTAINER_PASSTHROUGH = frozenset({"image", "name", "port", "env", "health_path", "extra_args"})
+
+
+def _container_image() -> str:
+    return os.environ.get(_CONTAINER_IMAGE_ENV) or DEFAULT_CONTAINER_IMAGE
+
+
+def _free_port() -> int:
+    """Allocate an OS-assigned free localhost port for the container's published port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _container_spawn_kwargs(key: str, sk: dict[str, Any]) -> dict[str, Any]:
+    """Translate logical spawn_kwargs → container_lifecycle.spawn_container kwargs.
+
+    image/name/port are defaulted (config / key / allocated) unless the caller
+    supplied them; every other key (task metadata) is routed into the container
+    env as an AGENT_* var, merged with any env already present (e.g. the recall
+    block from spawn_recall.inject_block). A caller that already passes a valid
+    {image, name, port[, env]} set passes through unchanged.
+    """
+    sk = dict(sk or {})
+    env = dict(sk.pop("env", None) or {})
+    image = sk.pop("image", None) or _container_image()
+    name = sk.pop("name", None) or f"{CONTAINER_NAME_PREFIX}{key}"
+    port = int(sk.pop("port", None) or _free_port())
+    health_path = sk.pop("health_path", None)
+    extra_args = sk.pop("extra_args", None)
+    for meta_key, meta_val in sk.items():
+        if meta_val is not None:
+            env.setdefault(f"AGENT_{meta_key.upper()}", str(meta_val))
+    out: dict[str, Any] = {"image": image, "name": name, "port": port, "env": env}
+    if health_path is not None:
+        out["health_path"] = health_path
+    if extra_args is not None:
+        out["extra_args"] = extra_args
+    return out
+
 
 def _norm_status(raw: str) -> str:
     """Map a watchdog/reaper status into the {'ok','degraded'} vocabulary.
@@ -670,6 +725,12 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
             task_brief=_spawn_kwargs_brief(sk),
         )
         spawn_kwargs_effective = spawn_recall.inject_block(sk, block)
+
+    # Container-defaults injection (Agency_OS-g9xx): translate logical task
+    # metadata → spawn_container's strict image/name/port/env signature so the
+    # work-loop bridge's spawn_kwargs no longer TypeError → 400.
+    if backend is Backend.CONTAINER:
+        spawn_kwargs_effective = _container_spawn_kwargs(req.key, spawn_kwargs_effective)
 
     manager = SessionManager(backend=backend)
     try:

--- a/src/keiracom_system/work_loop/bridge.py
+++ b/src/keiracom_system/work_loop/bridge.py
@@ -34,6 +34,11 @@ NEW_AVAILABLE = "new_available"
 DEFAULT_BACKEND = "container"
 DEFAULT_CALLSIGN = "worker"
 DEFAULT_FLEET_TENANT_ID = "default"
+# Recall keys consumed by the dispatcher (spawn_recall): brief + task_type feed
+# the prior-context query. Without them the recall arm queries with an empty
+# brief + default task_type. Task types per the spawn-governance §2 contract.
+KNOWN_TASK_TYPES = ("build", "review", "research", "devops")
+DEFAULT_TASK_TYPE = "build"
 
 
 def _fleet_tenant_id() -> str:
@@ -66,6 +71,9 @@ def task_event_to_message(payload: str | dict[str, Any], fleet_tenant_id: str) -
     if not task_id:
         return None
     task_id = str(task_id)
+    title = d.get("title")
+    tags = d.get("tags") if isinstance(d.get("tags"), list) else []
+    task_type = next((t for t in tags if t in KNOWN_TASK_TYPES), DEFAULT_TASK_TYPE)
     return json.dumps(
         {
             "task_id": task_id,
@@ -74,9 +82,13 @@ def task_event_to_message(payload: str | dict[str, Any], fleet_tenant_id: str) -
             "spawn_kwargs": {
                 "callsign": d.get("claimed_by") or DEFAULT_CALLSIGN,
                 "task_id": task_id,
-                "title": d.get("title"),
+                "title": title,
+                # brief + task_type feed the dispatcher's spawn_recall block so the
+                # recall-active run isn't empty (Agency_OS-g9xx).
+                "brief": title,
+                "task_type": task_type,
                 "priority": d.get("priority"),
-                "tags": d.get("tags"),
+                "tags": tags or None,
             },
         }
     )

--- a/tests/dispatcher/test_main_container_defaults.py
+++ b/tests/dispatcher/test_main_container_defaults.py
@@ -1,0 +1,65 @@
+"""Dispatcher container-defaults injection (Agency_OS-g9xx).
+
+The work-loop bridge sends LOGICAL spawn_kwargs (callsign/task_id/brief/...) that
+container_lifecycle.spawn_container's strict signature would TypeError on →
+/dispatcher/spawn 400. _container_spawn_kwargs translates them so the call is
+signature-valid (image/name/port/env), routing metadata into the container env.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import src.dispatcher.main as main_mod
+from src.dispatcher.container_lifecycle import spawn_container
+
+# Bridge-style logical kwargs that would blow up spawn_container as-is.
+_BRIDGE_KWARGS = {
+    "callsign": "atlas",
+    "task_id": "T-1",
+    "tenant_id": "fleet-1",
+    "title": "do x",
+    "brief": "do x",
+    "task_type": "build",
+    "priority": 2,
+    "tags": ["build"],
+}
+
+
+def test_output_keys_are_all_valid_spawn_container_params():
+    out = main_mod._container_spawn_kwargs("T-1", _BRIDGE_KWARGS)
+    sig = inspect.signature(spawn_container)
+    # Every produced key must be an accepted spawn_container param → no TypeError.
+    for key in out:
+        assert key in sig.parameters, f"{key} is not a spawn_container parameter"
+    assert {"image", "name", "port"} <= set(out)  # required params always present
+
+
+def test_defaults_image_name_port_and_routes_metadata_to_env():
+    out = main_mod._container_spawn_kwargs("T-1", _BRIDGE_KWARGS)
+    assert out["image"]  # defaulted from config
+    assert out["name"] == f"{main_mod.CONTAINER_NAME_PREFIX}T-1"  # name from key
+    assert isinstance(out["port"], int) and out["port"] > 0  # allocated
+    assert out["env"]["AGENT_CALLSIGN"] == "atlas"  # metadata → env
+    assert out["env"]["AGENT_TASK_TYPE"] == "build"
+    assert "callsign" not in out  # metadata is no longer a top-level kwarg
+
+
+def test_preserves_explicit_image_name_port():
+    out = main_mod._container_spawn_kwargs("k", {"image": "img:1", "name": "c1", "port": 9000})
+    assert out["image"] == "img:1"
+    assert out["name"] == "c1"
+    assert out["port"] == 9000
+
+
+def test_preserves_recall_env_and_merges_metadata():
+    sk = {"env": {"PRIOR_CONTEXT": "recall block"}, "callsign": "atlas"}
+    out = main_mod._container_spawn_kwargs("k", sk)
+    assert out["env"]["PRIOR_CONTEXT"] == "recall block"  # recall block survives
+    assert out["env"]["AGENT_CALLSIGN"] == "atlas"  # metadata merged alongside
+
+
+def test_image_overridable_via_env(monkeypatch):
+    monkeypatch.setenv("DISPATCHER_CONTAINER_IMAGE", "custom-agent:v9")
+    out = main_mod._container_spawn_kwargs("k", {"callsign": "x"})
+    assert out["image"] == "custom-agent:v9"

--- a/tests/keiracom_system/work_loop/test_bridge.py
+++ b/tests/keiracom_system/work_loop/test_bridge.py
@@ -98,3 +98,27 @@ async def test_publish_skips_non_new_available():
         r, json.dumps({"event_type": "completed", "id": "T-6"}), "f"
     )
     assert published is False
+
+
+# --- brief + task_type for the recall arm (Agency_OS-g9xx) -------------
+
+
+def test_maps_title_to_brief():
+    d = json.loads(bridge.task_event_to_message(_new_available("T-7", "atlas"), "f"))
+    assert d["spawn_kwargs"]["brief"] == "do the thing"  # title → brief (feeds spawn_recall)
+
+
+def test_task_type_from_recognized_tag():
+    payload = json.dumps(
+        {"event_type": "new_available", "id": "T-8", "title": "t", "tags": ["research", "urgent"]}
+    )
+    d = json.loads(bridge.task_event_to_message(payload, "f"))
+    assert d["spawn_kwargs"]["task_type"] == "research"
+
+
+def test_task_type_defaults_to_build_without_known_tag():
+    payload = json.dumps(
+        {"event_type": "new_available", "id": "T-9", "title": "t", "tags": ["urgent", "p0"]}
+    )
+    d = json.loads(bridge.task_event_to_message(payload, "f"))
+    assert d["spawn_kwargs"]["task_type"] == bridge.DEFAULT_TASK_TYPE  # build


### PR DESCRIPTION
## Summary

Makes the self-driving loop **actually spawn** — closes the spawn-boundary **400** I flagged for Scout's #1279 rehearsal (bridge spawn_kwargs TypeError'd against `spawn_container`).

> **Stacked on #1280** (base `atlas/work-loop-producer-nkc0`, where `bridge.py` lives). Merge order: #1280 → this. GitHub retargets to `main` once #1280 merges.

## Two fixes

**1. Container-defaults injection** (`src/dispatcher/main.py`)
`_container_spawn_kwargs` translates the bridge's *logical* spawn_kwargs (`callsign`/`task_id`/`brief`/…) into `container_lifecycle.spawn_container`'s strict signature: `image` from config, `name` from key, `port` OS-allocated, **all other metadata → container `env` as `AGENT_*` vars** (merged with any recall block `spawn_recall.inject_block` already placed in `env`). Applied in `dispatcher_spawn` for `backend=container`, after recall injection. Callers that already pass valid `image/name/port` pass through unchanged. → removes the TypeError → 400.

**2. Bridge `brief` + `task_type`** (`bridge.py`)
Maps `title→brief` and derives `task_type` from recognised tags (`build/review/research/devops`, default `build`) so the dispatcher's `spawn_recall` block isn't empty on the recall-active rehearsal arm.

## ⚠️ Image flag (Elliot's "confirm the image exists")

`DISPATCHER_CONTAINER_IMAGE` defaults to a **placeholder**. **No Claude-agent container image exists in-repo** — `Dockerfile.worker` is a *Prefect* worker (no HTTP), not an agent — and docker wasn't available here to verify a built tag. The operator **must build/set a real image on the spawn host** before a live container spawn succeeds (else `docker run` → `ContainerStartupError`). The **structural 400 is fixed regardless**; this is the remaining runtime prerequisite for the real-spawn rehearsal. (Open question worth a decision: is `container` even the right backend for Claude-agent spawns, vs `tmux`? Flagging, not deciding.)

## Test plan

- [x] `_container_spawn_kwargs`: output keys ⊆ `spawn_container` params (via `inspect.signature` — proves no TypeError), defaults image/name/port, routes metadata to `env`, preserves recall `env`, image override
- [x] Bridge `title→brief` + `task_type` derivation (recognised tag / default)
- [x] Full dispatcher + work_loop suites — **353 pass** (no regression to existing container/session tests); `ruff check src/` + `format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)