### PR TITLE
[ATLAS] chore(work-loop): Restart=always on the 2 loop units (Agency_OS-c2xk / P11)

### DIFF
--- a/systemd/keiracom-work-loop-bridge.service
+++ b/systemd/keiracom-work-loop-bridge.service
@@ -22,7 +22,9 @@ EnvironmentFile=/home/elliotbot/.config/agency-os/.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS
 ExecStart=/usr/bin/python3 -B -m src.keiracom_system.work_loop.bridge
 
-Restart=on-failure
+# P11 (Agency_OS-c2xk): always restart — a long-running loop driver must never
+# stay down (Restart=always covers clean exits too, not just failures).
+Restart=always
 RestartSec=10
 
 StandardOutput=append:/home/elliotbot/clawd/logs/keiracom-work-loop-bridge.log

--- a/systemd/keiracom-work-loop-consumer.service
+++ b/systemd/keiracom-work-loop-consumer.service
@@ -21,7 +21,9 @@ EnvironmentFile=/home/elliotbot/.config/agency-os/.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS
 ExecStart=/usr/bin/python3 -B -m src.keiracom_system.work_loop
 
-Restart=on-failure
+# P11 (Agency_OS-c2xk): always restart — a long-running loop driver must never
+# stay down (Restart=always covers clean exits too, not just failures).
+Restart=always
 RestartSec=10
 
 StandardOutput=append:/home/elliotbot/clawd/logs/keiracom-work-loop-consumer.log


### PR DESCRIPTION
## Summary

P11 supervisor hardening: `Restart=on-failure` → **`Restart=always`** on the work-loop **consumer** + **bridge** systemd units. A long-running loop driver must never stay down — `always` also restarts on clean exit, not just failure.

**Boot-enable** is already provided by `[Install] WantedBy=default.target` (present since #1280) — it takes effect when `systemctl enable` runs.

> **Stacked on #1280** (base `atlas/work-loop-producer-nkc0`, where the units live). Retargets to `main` on #1280 merge.

## Hold preserved

This changes the unit **files only**. The actual `systemctl enable --now` (go-live) **stays HELD** per Dave's budget-gate decision — enabling the units = flipping the loop live. Nothing is enabled or started by this PR.

## Test plan

- [x] Both units now `Restart=always` (grep-verified); `WantedBy=default.target` intact for boot-enable
- [x] Config-only (systemd units) — no code paths / tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)