### PR TITLE
[ATLAS] feat(work-loop): operator-uncap — fleet tenant never gated (Agency_OS-w667)

### DIFF
--- a/src/keiracom_system/work_loop/ceilings.py
+++ b/src/keiracom_system/work_loop/ceilings.py
@@ -21,6 +21,19 @@ logger = logging.getLogger(__name__)
 TIER_DEFAULTS: dict[str, int] = {"solo": 2, "pro": 6, "scale": 20, "team": 20, "enterprise": 20}
 DEFAULT_CEILING = 2  # cost-safe fallback when tenant/tier is unknown
 
+# Operator-uncap (Agency_OS-w667): the fleet/operator runs under the
+# FLEET_TENANT_ID slug, which has NO keiracom_tenants row (that table is
+# UUID-keyed) — so it would fail-open to DEFAULT_CEILING and gate Dave-as-operator
+# at 2. Treat that slug as effectively uncapped. A real tenant_id is always a
+# UUID, so the slug uniquely identifies the operator (no collision risk).
+DEFAULT_FLEET_TENANT_ID = "default"
+FLEET_OPERATOR_CEILING = 1000
+
+
+def _fleet_tenant_id() -> str:
+    return os.environ.get("FLEET_TENANT_ID") or DEFAULT_FLEET_TENANT_ID
+
+
 TenantRow = tuple[int | None, str | None]  # (max_concurrent_tasks, tier)
 CeilingFetch = Callable[[str], Awaitable[TenantRow | None]]
 
@@ -53,7 +66,13 @@ async def _db_fetch(tenant_id: str) -> TenantRow | None:
 
 
 async def get_ceiling(tenant_id: str, *, fetch: CeilingFetch | None = None) -> int:
-    """Resolve the tenant's concurrent-spawn ceiling. Fail-open to DEFAULT_CEILING."""
+    """Resolve the tenant's concurrent-spawn ceiling. Fail-open to DEFAULT_CEILING.
+
+    The fleet/operator slug returns FLEET_OPERATOR_CEILING so Dave-as-operator is
+    never gated (Agency_OS-w667) — it has no DB row to read a ceiling from.
+    """
+    if tenant_id == _fleet_tenant_id():
+        return FLEET_OPERATOR_CEILING
     try:
         row = await (fetch or _db_fetch)(tenant_id)
     except Exception:  # noqa: BLE001 — never block the loop on a lookup error

--- a/tests/keiracom_system/work_loop/test_ceilings.py
+++ b/tests/keiracom_system/work_loop/test_ceilings.py
@@ -41,3 +41,21 @@ async def test_unknown_tier_uses_default_ceiling():
 
 async def test_lookup_failure_is_failopen_to_default():
     assert await ceilings.get_ceiling("t", fetch=_raises()) == ceilings.DEFAULT_CEILING
+
+
+# --- operator-uncap (Agency_OS-w667) -----------------------------------
+
+
+async def test_fleet_tenant_is_uncapped_without_db_lookup():
+    # The fleet slug returns FLEET_OPERATOR_CEILING via early return — fetch is
+    # never consulted (a raising fetch would surface if it were called).
+    result = await ceilings.get_ceiling(ceilings.DEFAULT_FLEET_TENANT_ID, fetch=_raises())
+    assert result == ceilings.FLEET_OPERATOR_CEILING
+    assert ceilings.FLEET_OPERATOR_CEILING > 20  # well above the highest tier ceiling
+
+
+async def test_fleet_slug_is_env_overridable(monkeypatch):
+    monkeypatch.setenv("FLEET_TENANT_ID", "fleet-x")
+    assert await ceilings.get_ceiling("fleet-x", fetch=_raises()) == ceilings.FLEET_OPERATOR_CEILING
+    # a non-fleet tenant still goes through the normal lookup
+    assert await ceilings.get_ceiling("some-uuid", fetch=_fetch((6, "pro"))) == 6


### PR DESCRIPTION
## Summary

Part 2 of w667 (operator-uncap). `ceilings.get_ceiling` now returns `FLEET_OPERATOR_CEILING` (1000, effectively uncapped) when `tenant_id == FLEET_TENANT_ID` slug.

**Why code, not a DB row:** the fleet/operator runs under the `FLEET_TENANT_ID` slug, which has **no `keiracom_tenants` row** (that table is UUID-keyed). Without this, the lookup fail-opens to `DEFAULT_CEILING=2` and **gates Dave-as-operator at 2**. A real `tenant_id` is always a UUID, so the slug uniquely identifies the operator (no collision). Slug is env-overridable (matches the bridge's `FLEET_TENANT_ID`).

## Part 1 (done, not in this PR — it's a deploy)

Applied `20260528_keiracom_max_concurrent_tasks.sql` to **live Supabase** via MCP `apply_migration` (the file was already on main + reviewed = deploy, not redesign). **Verified:** the `max_concurrent_tasks` column exists and the tier backfill landed (the one tenant is `pro` → `6`, matching solo=2/pro=6/scale=20).

## Test plan

- [x] `get_ceiling(fleet_slug)` → `FLEET_OPERATOR_CEILING` via early return, **without** consulting fetch (a raising fetch proves it isn't called)
- [x] Fleet slug env-overridable; non-fleet tenants still use the normal lookup
- [x] Existing ceiling tests unaffected (they use a non-fleet tenant id); `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)