### PR TITLE
[NOVA] fix(backup): postgres_dump must not leak DSN/password (KEI-243 security)

### DIFF
--- a/src/keiracom_system/backup/postgres_dump.py
+++ b/src/keiracom_system/backup/postgres_dump.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import urllib.parse
 
 from src.keiracom_system.backup.alerting import write_backup_alert
 from src.keiracom_system.backup.pipeline import timestamp, upload_and_prune
@@ -45,14 +47,34 @@ def _resolve_dsn() -> str:
     return dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
 
 
+def _redact_dsn(text: str) -> str:
+    """Strip any postgres connection string (with embedded password) from a
+    message before it is logged or written to a ceo:backup_alert row."""
+    return re.sub(r"postgres(?:ql)?(?:\+\w+)?://[^\s'\"]+", "postgresql://[REDACTED]", text)
+
+
 def _pg_dump(dsn: str, dest: str) -> None:
     if shutil.which("pg_dump") is None:
         raise RuntimeError("pg_dump not installed on host (need postgresql-client)")
+    # Pass connection via libpq env vars, NOT in argv — keeps the DB password out
+    # of the command line / process listing / CalledProcessError. A DSN in argv
+    # leaked into both the log and the ceo:backup_alert row on the first failure
+    # (server-version mismatch, 2026-05-29).
+    p = urllib.parse.urlparse(dsn)
+    env = {
+        **os.environ,
+        "PGHOST": p.hostname or "",
+        "PGPORT": str(p.port or 5432),
+        "PGUSER": urllib.parse.unquote(p.username or ""),
+        "PGPASSWORD": urllib.parse.unquote(p.password or ""),
+        "PGDATABASE": (p.path or "/postgres").lstrip("/") or "postgres",
+    }
     # -Fc custom format (compressed, parallel-restore); --no-owner/--no-acl so it
     # restores into a fresh DB without role-permission errors.
     subprocess.run(
-        ["pg_dump", "-Fc", "--no-owner", "--no-acl", "--file", dest, dsn],
+        ["pg_dump", "-Fc", "--no-owner", "--no-acl", "--file", dest],
         check=True,
+        env=env,
     )
 
 
@@ -81,8 +103,9 @@ def main() -> int:
     try:
         key = run(dry_run=args.dry_run)
     except Exception as exc:  # noqa: BLE001 — any failure → alert + non-zero exit
-        write_backup_alert("postgres_dump", str(exc))
-        logger.exception("postgres dump failed")
+        # Redact any DSN before it reaches the alert row or the log.
+        write_backup_alert("postgres_dump", _redact_dsn(str(exc)))
+        logger.error("postgres dump failed: %s", _redact_dsn(str(exc)))
         return 1
     logger.info("postgres dump complete: %s", key)
     return 0

--- a/tests/keiracom_system/backup/test_postgres_dump.py
+++ b/tests/keiracom_system/backup/test_postgres_dump.py
@@ -1,0 +1,51 @@
+"""Tests for postgres_dump credential-safety (no DSN in argv / alerts)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.keiracom_system.backup import postgres_dump as pd
+
+DSN = "postgresql://postgres.proj:s3cr3tP@ss!@aws-1.pooler.supabase.com:5432/postgres"
+
+
+def test_redact_dsn_strips_password_url():
+    msg = f"Command '['pg_dump', '-Fc', '{DSN}']' returned non-zero exit status 1."
+    red = pd._redact_dsn(msg)
+    assert "s3cr3tP@ss" not in red
+    assert "supabase.com" not in red
+    assert "[REDACTED]" in red
+
+
+def test_redact_handles_asyncpg_scheme():
+    red = pd._redact_dsn("err postgresql+asyncpg://u:pw@h:6543/db trailing")
+    assert "pw@h" not in red
+    assert "trailing" in red  # only the URL is stripped
+
+
+def test_pg_dump_passes_creds_via_env_not_argv():
+    captured = {}
+
+    def fake_run(args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs.get("env", {})
+
+    with (
+        patch.object(pd.shutil, "which", return_value="/usr/bin/pg_dump"),
+        patch.object(pd.subprocess, "run", side_effect=fake_run),
+    ):
+        pd._pg_dump(DSN, "/tmp/x.dump")
+
+    # The DSN (and password) must NOT appear anywhere in the command argv.
+    joined = " ".join(captured["args"])
+    assert DSN not in joined
+    assert "s3cr3tP@ss" not in joined
+    assert "supabase.com" not in joined
+    # Creds delivered via libpq env vars instead.
+    env = captured["env"]
+    assert env["PGHOST"] == "aws-1.pooler.supabase.com"
+    assert env["PGPORT"] == "5432"
+    assert env["PGUSER"] == "postgres.proj"
+    assert env["PGPASSWORD"] == "s3cr3tP@ss!"
+    assert env["PGDATABASE"] == "postgres"
+    assert captured["args"][:2] == ["pg_dump", "-Fc"]


### PR DESCRIPTION
## Summary
During the Agency_OS-hw13 restore-test, #1273's `postgres_dump.py` leaked the **DB password**: on the first real failure (Postgres server-version mismatch) the `pg_dump` `CalledProcessError` carried the full DSN (with password) into both the log **and** the `ceo:backup_alert:2026-05-29` ceo_memory row — because the DSN was passed as a `pg_dump` argv.

## Fix (two layers)
1. **`_pg_dump` passes creds via libpq env vars** (`PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE`) instead of the DSN in argv → the command line, process listing, and any `CalledProcessError` contain no secret.
2. **`_redact_dsn()`** strips any `postgres://` URL from the alert + log message in `main()` (defence-in-depth).

## Tests
3 unit tests (ruff clean): redaction (incl. `+asyncpg` scheme), and that `_pg_dump` delivers creds via env with **zero DSN/password in argv**.

## Already remediated live
The leaked `ceo:backup_alert:2026-05-29` row was scrubbed (verified password-gone) during the restore-test.

## Context (Agency_OS-hw13 restore-test — PASSED)
R2 token minted (Cloudflare API → S3 creds), backup round-trip SHA-256 verified, `pg_restore` into throwaway pg17 restored 175/175 public tables + real data queryable. Separately flagged: the host needs `postgresql-client-17` (host `pg_dump` is 16.x vs server 17.6) for the unattended timer pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)