### PR TITLE
[ATLAS] test(ci): default pytest timeout 300s/thread — fail hung tests fast (Agency_OS-28ai)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,15 @@ addopts = --ignore=docs --ignore=scripts --ignore=screenshot-to-code --ignore=te
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 
+# Global per-test timeout (pytest-timeout). 300s with the thread method so a hung
+# test — e.g. an async await on a service that's present locally but absent in CI
+# — fails fast with a traceback instead of running to the CI job kill (~27min).
+# Root cause of the #1276 pytest hang (Agency_OS-28ai): a hang had no timeout to
+# catch it. thread method handles async/C-level blocks SIGALRM can't interrupt.
+# Per-test override: @pytest.mark.timeout(N) (0 = disable).
+timeout = 300
+timeout_method = thread
+
 # Custom markers
 markers =
     integration: marks tests as integration tests


### PR DESCRIPTION
## Summary

Systemic follow-up to the #1276 pytest hang. Adds a **global per-test timeout** to `pytest.ini`:

```ini
timeout = 300
timeout_method = thread
```

`pytest-timeout` is already a declared dep. Previously there was **no default timeout**, so a hung test (e.g. an async await on a service that's present locally but **absent in CI**) ran to the **~27-min CI job kill** with no diagnostic — the exact failure mode of #1276 (Agency_OS-28ai). Now any test exceeding 300s **aborts with a traceback** pointing at the hang.

- **`thread` method** handles async / C-level blocks that SIGALRM can't interrupt — the right choice for an async-heavy suite.
- **300s** is generous vs the KEI-132 `<60s` scenario target; legitimately-slow tests can override with `@pytest.mark.timeout(N)` (0 = disable).

## Test plan

- [x] Header confirms `timeout: 300.0s` / `timeout method: thread` (pytest-timeout 2.4.0 loaded)
- [x] Sample suite runs clean under the new config
- [x] Config-only (`pytest.ini`) — no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)