### PR TITLE
[ATLAS] feat(vault): P10 spawn-path cold-credential resolution (Agency_OS-8dvl)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -425,6 +425,15 @@ def _container_spawn_kwargs(key: str, sk: dict[str, Any]) -> dict[str, Any]:
     for meta_key, meta_val in sk.items():
         if meta_val is not None:
             env.setdefault(f"AGENT_{meta_key.upper()}", str(meta_val))
+    # P10 cold-start bootstrap (Agency_OS-8dvl): pass ONLY the Vault bootstrap into
+    # the container — the ephemeral agent resolves every other credential from
+    # Vault KV (kv_resolver.resolve_into_env, Nova #1289), with NO .env inheritance. Docker isolation
+    # means the container sees only this env dict, so these two are the entire
+    # inherited-credential surface.
+    for boot in ("VAULT_ADDR", "VAULT_TOKEN"):
+        boot_val = os.environ.get(boot)
+        if boot_val:
+            env.setdefault(boot, boot_val)
     out: dict[str, Any] = {"image": image, "name": name, "port": port, "env": env}
     if health_path is not None:
         out["health_path"] = health_path

--- a/tests/dispatcher/test_main_container_defaults.py
+++ b/tests/dispatcher/test_main_container_defaults.py
@@ -63,3 +63,24 @@ def test_image_overridable_via_env(monkeypatch):
     monkeypatch.setenv("DISPATCHER_CONTAINER_IMAGE", "custom-agent:v9")
     out = main_mod._container_spawn_kwargs("k", {"callsign": "x"})
     assert out["image"] == "custom-agent:v9"
+
+
+# --- P10 vault bootstrap injection (Agency_OS-8dvl) --------------------
+
+
+def test_vault_bootstrap_injected_into_container_env(monkeypatch):
+    monkeypatch.setenv("VAULT_ADDR", "https://v:8200")
+    monkeypatch.setenv("VAULT_TOKEN", "tok")
+    out = main_mod._container_spawn_kwargs("k", {"callsign": "atlas"})
+    assert out["env"]["VAULT_ADDR"] == "https://v:8200"
+    assert out["env"]["VAULT_TOKEN"] == "tok"
+
+
+def test_only_bootstrap_injected_not_other_dot_env_creds(monkeypatch):
+    # The container gets the Vault bootstrap ONLY — not arbitrary .env creds.
+    # This is the P10 invariant at the spawn boundary (no .env inheritance).
+    monkeypatch.setenv("VAULT_ADDR", "https://v:8200")
+    monkeypatch.setenv("VAULT_TOKEN", "tok")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://should-not-leak")
+    out = main_mod._container_spawn_kwargs("k", {"callsign": "atlas"})
+    assert "DATABASE_URL" not in out["env"]  # resolved from Vault in the container, not inherited


### PR DESCRIPTION
## Summary

The **fleet half of P10**: a container spawn with **only `VAULT_ADDR`/`VAULT_TOKEN`** resolves every other credential from Vault — **no `.env` inheritance**. Pairs with Nova's vault provisioning to make P10 PASS.

> **Stacked on #1282** (uses its container-defaults env dict). Merge order: #1280 → #1282 → this.

## What's here (4 parts, per the 8dvl scope)

1. **Bootstrap injection** — `_container_spawn_kwargs` now passes **only** `VAULT_ADDR` + `VAULT_TOKEN` into the container env. Docker isolation means that's the *entire* inherited-credential surface. Ephemeral agents are **container-only** (the work-loop bridge already emits `backend=container`, which — unlike tmux — does **not** inherit the dispatcher `.env`; that was the P10 violation).
2. **Vault KV resolver** — `kv_resolver.py`: `GET /v1/secret/data/keiracom/<path>` with `X-Vault-Token` (KV v2). **Distinct from `vault_decryptor.py`** (Transit/BYOK, category 1) — this is category 2 fleet creds (KV store), per Cat 16.
3. **Cold-start entrypoint** — `cold_start.py`: `hydrate_env` resolves `CRED_MAP` from Vault KV into the process env **before the agent runs**. Vault is canonical (overrides inherited values); per-secret fail-open; bootstrap hard-required.
4. **Tests** — the **no-`.env`-inheritance proof**: a process with only the bootstrap resolves `DATABASE_URL`/R2/API keys from (mocked) Vault; vault overrides stale inherited env; missing secret skipped-not-fatal; dispatcher asserts **only the bootstrap** (not e.g. `DATABASE_URL`) reaches the container env.

## Coordination / prerequisites

- **`CRED_MAP`** (env var → KV path) is the coordination point with **Nova's `secret/keiracom/<path>` provisioning** — seeded with known secrets (postgres, r2/s3, gemini, anthropic); finalise against her full manifest.
- The **agent container image** is still a prerequisite (flagged in #1282 — no Claude-agent image in-repo yet); the cold-start runs as the agent CMD pre-step once that image exists.

## Test plan

- [x] 34 vault + container-defaults tests pass (incl. no-`.env`-inheritance proof); `ruff check src/` + `format --check` clean
- [ ] Live P10 proof (Nova's provisioned vault + real container) — joint follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)