### PR TITLE
[ATLAS] feat(dispatcher): Phase-1 scrubbed-tmux spawn — env -i + Vault bootstrap (Agency_OS-87ei)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -22,6 +22,7 @@ import contextlib
 import dataclasses
 import logging
 import os
+import shlex
 import socket
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -442,6 +443,74 @@ def _container_spawn_kwargs(key: str, sk: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+# Phase-1 spawn backend is scrubbed-tmux (Agency_OS-87ei): reuse the working tmux
+# spawn but run the agent under `env -i` so it inherits NO .env — only the Vault
+# bootstrap + non-secret operational vars + recall/metadata. resolve_into_env then
+# pulls every credential from Vault KV. (Container is the pre-multi-tenant
+# fast-follow; #1282/#1288 already wire its bootstrap.)
+#
+# env -i clears PATH/HOME too, so the agent command couldn't even start — these
+# NON-SECRET operational vars are re-added. Credentials (DATABASE_URL, *_API_KEY,
+# …) are deliberately NOT whitelisted → scrubbed.
+_TMUX_OPERATIONAL_PASSTHROUGH = ("PATH", "HOME", "LANG", "LC_ALL", "TERM", "USER")
+DEFAULT_AGENT_WORKDIR = os.environ.get(
+    "DISPATCHER_AGENT_WORKDIR", "/home/elliotbot/clawd/Agency_OS"
+)
+# The command run AFTER cold-start cred resolution. Defaults to the cold-start
+# entrypoint (resolve_into_env → exec the agent); referenced by string so this
+# module needs no import of Nova's kv_resolver (the entrypoint lands on #1289).
+DEFAULT_AGENT_COMMAND = os.environ.get(
+    "DISPATCHER_AGENT_COMMAND", "python3 -m src.keiracom_system.vault.agent_cold_start"
+)
+# OFF by default (rollout phase 1, matches every other dispatcher gate). When ON,
+# every tmux spawn is env-i-scrubbed. Goes live at the Phase-1 cutover; off keeps
+# existing (non-ephemeral) tmux spawns unchanged.
+_TMUX_SCRUB_ENABLED_ENV = "DISPATCHER_TMUX_SCRUB_ENABLED"
+tmux_scrub_enabled: bool = os.environ.get(_TMUX_SCRUB_ENABLED_ENV, "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
+
+def _tmux_scrubbed_command(agent_command: str, env: dict[str, str]) -> str:
+    """Wrap a command so it runs with a SCRUBBED env (P10).
+
+    ``env -i`` clears all inherited env; only ``env`` (Vault bootstrap +
+    operational passthrough + recall/metadata) is set; ``sh -c`` runs the command
+    without sourcing a profile that could re-introduce env. Credentials not in
+    ``env`` are gone — that is the no-.env-inheritance guarantee.
+    """
+    assignments = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env.items())
+    return f"env -i {assignments} sh -c {shlex.quote(agent_command)}"
+
+
+def _tmux_spawn_kwargs(key: str, sk: dict[str, Any]) -> dict[str, Any]:
+    """Translate logical spawn_kwargs → scrubbed-tmux spawn_session kwargs (87ei).
+
+    The agent process sees ONLY the Vault bootstrap, the operational passthrough,
+    and any recall/metadata — never the dispatcher's .env credentials.
+    """
+    sk = dict(sk or {})
+    session_name = sk.pop("session_name", None) or f"{TMUX_NAME_PREFIX}{key}"
+    working_dir = sk.pop("working_dir", None) or DEFAULT_AGENT_WORKDIR
+    agent_command = sk.pop("command", None) or DEFAULT_AGENT_COMMAND
+    env = dict(sk.pop("env", None) or {})  # carries the recall PRIOR_CONTEXT if injected
+    for meta_key, meta_val in sk.items():
+        if meta_val is not None:
+            env.setdefault(f"AGENT_{meta_key.upper()}", str(meta_val))
+    # Vault bootstrap (the only inherited credential surface) + non-secret operational env.
+    for passthrough in ("VAULT_ADDR", "VAULT_TOKEN", *_TMUX_OPERATIONAL_PASSTHROUGH):
+        val = os.environ.get(passthrough)
+        if val:
+            env.setdefault(passthrough, val)
+    return {
+        "session_name": session_name,
+        "working_dir": working_dir,
+        "command": _tmux_scrubbed_command(agent_command, env),
+    }
+
+
 def _norm_status(raw: str) -> str:
     """Map a watchdog/reaper status into the {'ok','degraded'} vocabulary.
 
@@ -740,6 +809,10 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
     # work-loop bridge's spawn_kwargs no longer TypeError → 400.
     if backend is Backend.CONTAINER:
         spawn_kwargs_effective = _container_spawn_kwargs(req.key, spawn_kwargs_effective)
+    elif backend is Backend.TMUX and tmux_scrub_enabled:
+        # Phase-1 scrubbed-tmux (Agency_OS-87ei): run the agent under env -i so it
+        # inherits no .env — only the Vault bootstrap; resolve_into_env does the rest.
+        spawn_kwargs_effective = _tmux_spawn_kwargs(req.key, spawn_kwargs_effective)
 
     manager = SessionManager(backend=backend)
     try:

--- a/src/keiracom_system/work_loop/bridge.py
+++ b/src/keiracom_system/work_loop/bridge.py
@@ -31,7 +31,10 @@ logger = logging.getLogger(__name__)
 
 PG_NOTIFY_CHANNEL = "task_event"
 NEW_AVAILABLE = "new_available"
-DEFAULT_BACKEND = "container"
+# Phase-1 spawn backend is scrubbed-tmux (Agency_OS-87ei, Elliot-decided): reuse
+# the working tmux spawn under env -i (no .env inheritance) — no container image
+# to build. Env-overridable so the container fast-follow flips this to "container".
+DEFAULT_BACKEND = os.environ.get("WORK_LOOP_BACKEND", "tmux")
 DEFAULT_CALLSIGN = "worker"
 DEFAULT_FLEET_TENANT_ID = "default"
 # Recall keys consumed by the dispatcher (spawn_recall): brief + task_type feed

--- a/tests/dispatcher/test_main_scrubbed_tmux.py
+++ b/tests/dispatcher/test_main_scrubbed_tmux.py
@@ -1,0 +1,50 @@
+"""Phase-1 scrubbed-tmux spawn (Agency_OS-87ei).
+
+The agent runs under `env -i` so it inherits NO .env — only the Vault bootstrap +
+non-secret operational vars + recall/metadata. resolve_into_env (Nova #1289) then
+pulls every credential from Vault KV. Gated off by default (rollout phase 1).
+"""
+
+from __future__ import annotations
+
+import src.dispatcher.main as main_mod
+
+
+def test_scrub_exposes_only_bootstrap_and_operational_not_creds(monkeypatch):
+    monkeypatch.setenv("VAULT_ADDR", "https://v:8200")
+    monkeypatch.setenv("VAULT_TOKEN", "tok")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://should-be-scrubbed")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-be-scrubbed")
+
+    out = main_mod._tmux_spawn_kwargs("k9", {"callsign": "atlas", "env": {"PRIOR_CONTEXT": "ctx"}})
+    cmd = out["command"]
+
+    assert cmd.startswith("env -i ")  # scrubs all inherited env
+    assert "VAULT_ADDR=" in cmd and "VAULT_TOKEN=" in cmd  # bootstrap present
+    assert "PATH=" in cmd  # non-secret operational passthrough (so the agent can run)
+    assert "AGENT_CALLSIGN=" in cmd  # task metadata
+    assert "PRIOR_CONTEXT=" in cmd  # recall block preserved through the scrub
+    assert "sh -c" in cmd  # runs the agent command without sourcing a profile
+    # THE P10 INVARIANT: credentials are NOT exposed to the agent process.
+    assert "DATABASE_URL" not in cmd
+    assert "ANTHROPIC_API_KEY" not in cmd
+
+
+def test_session_name_and_workdir_default_from_key_and_config():
+    out = main_mod._tmux_spawn_kwargs("k9", {})
+    assert out["session_name"] == f"{main_mod.TMUX_NAME_PREFIX}k9"
+    assert out["working_dir"]  # defaulted from config
+    assert main_mod.DEFAULT_AGENT_COMMAND in out["command"]  # cold-start entrypoint invoked
+
+
+def test_explicit_command_is_wrapped():
+    out = main_mod._tmux_spawn_kwargs("k", {"command": "claude -p run"})
+    assert "claude -p run" in out["command"]
+    assert out["command"].startswith("env -i ")
+
+
+def test_scrub_gated_off_by_default():
+    # Rollout phase 1: tmux spawns are NOT scrubbed unless explicitly enabled, so
+    # existing (non-ephemeral) tmux callers are unchanged.
+    assert main_mod.tmux_scrub_enabled is False


### PR DESCRIPTION
## Summary

Elliot-decided Phase-1 spawn backend: **scrubbed-tmux** (container = pre-multi-tenant fast-follow). Reuses the working tmux spawn — **no container image to build** — but runs the agent under **`env -i`** so it inherits **no `.env`**: only the Vault bootstrap + non-secret operational vars + recall/metadata. Nova's `resolve_into_env` (#1289) then pulls every credential from Vault KV.

> **Stacked on #1288** (dispatcher spawn-path stack). Container path (#1282/#1288) stays as the documented fast-follow — not wasted.

## What's here

- **`_tmux_scrubbed_command`** — `env -i <whitelist> sh -c <agent-cmd>`. `env -i` clears all inherited env (incl. credentials); the whitelist re-adds **only** `VAULT_ADDR`/`VAULT_TOKEN` (bootstrap) + `PATH`/`HOME`/… (non-secret operational — else the command can't even start) + recall `PRIOR_CONTEXT` + `AGENT_*` metadata. **Credentials are not whitelisted → gone.**
- **`_tmux_spawn_kwargs`** — logical spawn_kwargs → scrubbed tmux session. Agent command defaults to the cold-start entrypoint, referenced **by string** so this module needs no import of Nova's `kv_resolver`.
- **Spawn path** applies it for `backend=tmux`, **gated behind `DISPATCHER_TMUX_SCRUB_ENABLED` (default OFF)** — matches every other dispatcher gate; existing non-ephemeral tmux spawns unchanged; goes live at the Phase-1 cutover.
- **bridge `DEFAULT_BACKEND` → `tmux`** (env-overridable `WORK_LOOP_BACKEND` for the fast-follow).

## Test plan

- [x] **No-`.env`-inheritance proof** (Elliot's named ask): the scrubbed command exposes only bootstrap + operational + recall/metadata — asserts `DATABASE_URL` / `ANTHROPIC_API_KEY` are **not** present
- [x] session/workdir/command defaults; explicit command wrapped; scrub gated off by default
- [x] **359 dispatcher + work_loop tests pass — zero regression** (scrub gated off → existing tmux tests unchanged); `ruff check src/` clean

## Follow-up

The `agent_cold_start` entrypoint (calls Nova's `resolve_into_env`) lands on #1289's base (referenced by string here). **Joint live cold-auth proof** runs once Nova's persistent vault (bd lmce) is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)