### PR TITLE
[SCOUT] feat(listener): direct Slack→task creator — TASK: #ceo message → public.tasks (Agency_OS-evbn)

### DIFF
--- a/scripts/ceo_capture_listener.py
+++ b/scripts/ceo_capture_listener.py
@@ -62,6 +62,17 @@ CAPTURE_COMMAND = os.environ.get(
     '-- "$CEO_CAPTURE_MESSAGE"',
 )
 
+# Direct Slack→task creator (Agency_OS-evbn, Dave approved 2026-05-29). A
+# 'TASK:'-prefixed #ceo message creates a public.tasks row directly; the
+# kei45_emit_task_event trigger then drives the work-loop (Atlas wire #1283:
+# id supplied, title NOT NULL, status MUST be 'available'). Skips Linear
+# entirely — the [CEO]→Linear→webhook path is dead AND writing Linear violates
+# the Linear-read-only LAW.
+TASK_PREFIX = "TASK:"
+TASK_TITLE_MAX_CHARS = 500
+# kei45 trigger fires new_available only on INSERT with this status.
+_TASK_INSERT_SQL = "INSERT INTO public.tasks (id, title, status) VALUES (%s, %s, 'available')"
+
 
 def is_human_ceo_message(event: dict) -> bool:
     """Event hygiene only (NOT a content filter): a top-level human text message
@@ -119,11 +130,59 @@ def spawn_capture_agent(text: str) -> bool:
         return False
 
 
+def is_task_command(text: str) -> bool:
+    """A 'TASK:'-prefixed #ceo message is a direct task-creation command (evbn)."""
+    return (text or "").strip().upper().startswith(TASK_PREFIX)
+
+
+def extract_task_title(text: str) -> str:
+    """Task title = the message body after the 'TASK:' prefix (trimmed + capped)."""
+    body = (text or "").strip()
+    if body.upper().startswith(TASK_PREFIX):
+        body = body[len(TASK_PREFIX) :].strip()
+    return body[:TASK_TITLE_MAX_CHARS]
+
+
+def create_task_from_message(text: str, *, dsn: str | None = None) -> str | None:
+    """INSERT one public.tasks row from a 'TASK:' message (Atlas wire #1283). The
+    kei45_emit_task_event trigger then drives the loop. Values are bound as params
+    (injection-safe); NO Linear. Returns the task id, or None on any error
+    (fail-open — task-creation failure must never crash the listener)."""
+    title = extract_task_title(text)
+    if not title:
+        logger.warning("TASK: message had no body — no task created")
+        return None
+    dsn = dsn or os.environ.get("DATABASE_URL") or os.environ.get("RETRIEVAL_EVENTS_DSN")
+    if not dsn:
+        logger.warning("no DATABASE_URL — cannot create task from #ceo TASK: message")
+        return None
+    task_id = f"ceo-task-{int(time.time() * 1000)}"
+    try:
+        import psycopg
+
+        clean = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+        with (
+            psycopg.connect(clean, prepare_threshold=None, autocommit=True) as conn,
+            conn.cursor() as cur,
+        ):
+            cur.execute(_TASK_INSERT_SQL, (task_id, title))
+        logger.info("created task %s ('%s') from #ceo TASK: message", task_id, title[:60])
+        return task_id
+    except Exception:  # noqa: BLE001 — task creation must never crash the listener
+        logger.warning("task creation failed (non-fatal)", exc_info=True)
+        return None
+
+
 def handle_event(event: dict) -> str:
-    """Spawn a Haiku capture agent for one human #ceo message. Returns an action label."""
+    """Route one human #ceo message: a 'TASK:' command creates a public.tasks row
+    (drives the work-loop); anything else spawns a Haiku capture agent. Returns an
+    action label."""
     if not is_human_ceo_message(event):
         return "skip"
-    return "spawned" if spawn_capture_agent(event["text"]) else "spawn_failed"
+    text = event["text"]
+    if is_task_command(text):
+        return "task_created" if create_task_from_message(text) else "task_create_failed"
+    return "spawned" if spawn_capture_agent(text) else "spawn_failed"
 
 
 def main() -> int:

--- a/tests/scripts/test_ceo_capture_listener.py
+++ b/tests/scripts/test_ceo_capture_listener.py
@@ -140,3 +140,63 @@ def test_bot_message_does_not_spawn(monkeypatch):
 def test_handle_event_reports_spawn_failure(monkeypatch):
     monkeypatch.setattr(m, "spawn_capture_agent", lambda t: False)
     assert m.handle_event(_event("Decision: real human decision here")) == "spawn_failed"
+
+
+# ─── direct Slack→task creator (Agency_OS-evbn) ───────────────────────────────
+
+
+def test_is_task_command_detects_prefix_case_insensitive():
+    assert m.is_task_command("TASK: wire the foo") is True
+    assert m.is_task_command("  task: lowercase works  ") is True
+    assert m.is_task_command("Decision: not a task") is False
+    assert m.is_task_command("") is False
+
+
+def test_extract_task_title_strips_prefix_and_caps():
+    assert m.extract_task_title("TASK: fix the typo in README") == "fix the typo in README"
+    assert m.extract_task_title("task:   trimmed  ") == "trimmed"
+    assert len(m.extract_task_title("TASK: " + "X" * 1000)) == m.TASK_TITLE_MAX_CHARS
+
+
+def test_task_insert_sql_is_parameterised_and_available():
+    # Atlas wire #1283: status MUST be 'available' (fires the kei45 trigger); values bound.
+    assert (
+        m._TASK_INSERT_SQL
+        == "INSERT INTO public.tasks (id, title, status) VALUES (%s, %s, 'available')"
+    )
+
+
+def test_create_task_returns_none_without_dsn(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("RETRIEVAL_EVENTS_DSN", raising=False)
+    assert m.create_task_from_message("TASK: do a thing") is None  # fail-open, no crash
+
+
+def test_create_task_returns_none_on_empty_body(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+    assert m.create_task_from_message("TASK:   ") is None  # no title → no task
+
+
+def test_handle_event_routes_task_command_to_creator(monkeypatch):
+    monkeypatch.setattr(m, "create_task_from_message", lambda t: "ceo-task-123")
+    monkeypatch.setattr(
+        m,
+        "spawn_capture_agent",
+        lambda t: (_ for _ in ()).throw(AssertionError("must not spawn a TASK:")),
+    )
+    assert m.handle_event(_event("TASK: wire the dispatcher health probe")) == "task_created"
+
+
+def test_handle_event_non_task_still_spawns_capture(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "create_task_from_message",
+        lambda t: (_ for _ in ()).throw(AssertionError("not a TASK:")),
+    )
+    monkeypatch.setattr(m, "spawn_capture_agent", lambda t: True)
+    assert m.handle_event(_event("We have ratified the multi-tenancy decision.")) == "spawned"
+
+
+def test_handle_event_reports_task_create_failure(monkeypatch):
+    monkeypatch.setattr(m, "create_task_from_message", lambda t: None)
+    assert m.handle_event(_event("TASK: something")) == "task_create_failed"


### PR DESCRIPTION
## Summary
Dave-approved (Agency_OS-evbn, 2026-05-29). Extends the #ceo listener so a **`TASK:`-prefixed** message creates a `public.tasks` row **directly** — the `kei45_emit_task_event` trigger then drives Atlas's bridge → work-loop. This is the dress-rehearsal's **Slack-origin leg**: Run-A Step-1 (Dave types a Slack message → task row in ~10s) uses this real path.

Built against **Atlas's #1283 wire interface**: `INSERT INTO public.tasks (id, title, status) VALUES (%s, %s, 'available')` — id supplied, title NOT NULL, status MUST be `'available'` (the trigger fires `new_available` only on that).

## Behaviour
- `is_task_command` / `extract_task_title` / `create_task_from_message`: parameterised INSERT (**injection-safe**), id `ceo-task-<ms>`, title from the message body (capped 500 chars).
- `handle_event` routes: `TASK:` → create task row (`task_created`); everything else → the unchanged Haiku capture spawn.
- **Skips Linear entirely** — the `[CEO]`→Linear→webhook path is dead AND writing Linear violates the **Linear-read-only LAW**. No Linear call anywhere.
- **Fail-open:** no DSN / empty body / DB error → returns None, never crashes the listener.

## Verification (raw)
- `pytest tests/scripts/test_ceo_capture_listener.py` → **18 passed** (added TASK: detection, title extraction, parameterised-SQL assertion, no-DSN + empty-body fail-open, handle_event routing — TASK: creates, non-TASK still spawns, bot skips).
- Module imports without slack_sdk/psycopg; `ruff check` + `format --check` clean.

## Notes
- The harness Slack-origin leg (un-HOLD the SEAM + a `verify_task_row_created` Run-A Step-1 assertion) is wired in a follow-up commit on the jb4e harness PR (#1279).
- Depends on Atlas's #1283 (wire interface) + the kei45 trigger being live; the creator only produces the row — the trigger/bridge/consumer carry it onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)