### PR TITLE
[ORION] feat(chat): direct-write exit_cycle → Hindsight fleet_decisions (Path 1, Agency_OS-9goi)

### DIFF
--- a/personas/john.md
+++ b/personas/john.md
@@ -126,7 +126,7 @@ The Deliberator determines the correct tier and either dispatches directly or ro
 
 ## End-of-conversation exit cycle
 
-John is an ephemeral spawn with no persistent memory. If a conversation contained a ratified decision, a confirmed pattern, an explicit Dave approval, or a Viktor explanation, that knowledge disappears when this spawn exits — unless John writes it to `ceo_memory` before closing.
+John is an ephemeral spawn with no persistent memory. If a conversation contained a ratified decision, a confirmed pattern, an explicit Dave approval, or a Viktor explanation, that knowledge disappears when this spawn exits — unless John writes it directly to the Hindsight `fleet_decisions` bank as an AtomV1 atom before closing.
 
 **John MUST call `classify_and_save` at the end of every conversation**, regardless of whether the conversation seemed decision-heavy. The classifier (Gemini Flash, confidence > 0.8, max 3 items) decides what is worth keeping — John does not pre-filter.
 
@@ -139,9 +139,9 @@ result = await classify_and_save(
 )
 ```
 
-`classify_and_save` is **fail-open**: any Gemini or DB error returns an `ExitCycleResult` with `skipped_reason` set and never raises. John does not retry on failure and does not block conversation completion on a non-zero `skipped_reason`. Log the result at INFO level and exit.
+`classify_and_save` is **fail-open**: any Gemini or Hindsight error returns an `ExitCycleResult` with `skipped_reason` set and never raises. John does not retry on failure and does not block conversation completion on a non-zero `skipped_reason`. Log the result at INFO level and exit.
 
-**What is captured:** items with `kind` in `architectural_decision | confirmed_pattern | dave_approval | viktor_explanation`, confidence > 0.8, written to `ceo_memory` under `ceo:conversation_capture:{date}:{topic_slug}`. The atomiser promotes these to `fleet_decisions`; future John spawns retrieve them via Hindsight Layer 2 recall.
+**What is captured:** items with `kind` in `architectural_decision | confirmed_pattern | dave_approval | viktor_explanation`, confidence > 0.8, written DIRECTLY to the Hindsight `fleet_decisions` bank as AtomV1 atoms — no `ceo_memory`, no atomiser (direct-write, per `ceo:ephemeral_capture_model_v1` v2, Dave-ratified 2026-05-29). Future John spawns retrieve them via Hindsight Layer 2 recall. `ExitCycleResult` reports `decisions_saved`, `atom_ids`, and `bank`.
 
 **What is NOT captured:** status updates, questions, routine task dispatches, casual conversation. The classifier is conservative by design — precision over recall.
 

--- a/scripts/ratify_ephemeral_capture_model_v2.py
+++ b/scripts/ratify_ephemeral_capture_model_v2.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Ratify ceo:ephemeral_capture_model_v1 -> v2 (direct-write).
+
+LAW XIII currency update for Agency_OS-9goi. Dave ratified Path 1 (direct-write
+exit_cycle -> Hindsight fleet_decisions, two-step retired) on 2026-05-29. The
+canonical key still described the v1 two-step (agent -> ceo_memory -> atomiser);
+this rewrites its value so downstream agents (Nova backfill #1278, future John
+spawns) inherit the ratified model.
+
+Idempotent: re-running upserts the same value. Must be run by an allowlisted
+callsign (elliot|dave|john) per the KEI-87 ceo_memory write-guard — orion is
+NOT allowlisted, so this ships in the PR and Elliot applies it.
+
+    DATABASE_URL=... python3 scripts/ratify_ephemeral_capture_model_v2.py --callsign elliot
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from src.governance.ceo_memory_writer import upsert_ceo_memory_key
+
+KEY = "ceo:ephemeral_capture_model_v1"
+
+NEW_VALUE = {
+    "date": "2026-05-29",
+    "version": 2,
+    "description": "How decisions are captured and persist in the ephemeral model (direct-write).",
+    "ratified_by": "dave (2026-05-29) — supersedes the viktor+dave two-step v1 (2026-05-28)",
+    "capture_loop": [
+        "Decision happens in #ceo or agent work",
+        "Agent (John) writes the decision DIRECTLY to the Hindsight fleet_decisions bank as "
+        "an AtomV1 atom on spawn exit (src.keiracom_system.chat.exit_cycle.classify_and_save)",
+        "Future spawn: Hindsight Layer 2 recall retrieves atoms from fleet_decisions",
+    ],
+    "retired": (
+        "Two-step (agent -> ceo_memory -> atomiser -> fleet_decisions) is decommissioned. "
+        "exit_cycle no longer writes ceo_memory."
+    ),
+    "critical_rule": (
+        "Nothing writes automatically. John MUST call classify_and_save at every conversation "
+        "exit; the Gemini classifier (confidence > 0.8, max 3) is the precision gate. If the "
+        "agent exits without calling it, the next spawn has no knowledge. Write discipline is "
+        "the gate."
+    ),
+    "supersedes": "v1 two-step model (2026-05-28)",
+    "anchor": "Agency_OS-9goi (Orion) — LAW XIII currency update shipped with the live-writer PR",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--callsign", default="elliot", help="allowlisted writer (elliot|dave|john)"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="print the value, do not write")
+    args = parser.parse_args()
+    if args.dry_run:
+        print(json.dumps({KEY: NEW_VALUE}, indent=2))
+        return 0
+    upsert_ceo_memory_key(args.callsign, KEY, NEW_VALUE)
+    print(f"ratified {KEY} -> v2 (direct-write) as callsign={args.callsign}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/keiracom_system/atomization/hindsight_writer.py
+++ b/src/keiracom_system/atomization/hindsight_writer.py
@@ -1,0 +1,75 @@
+"""hindsight_writer.py — canonical AtomV1 → Hindsight one-source seam.
+
+SECRET_MANIFEST-style single source: the ONE place that defines (a) how an
+AtomV1 serializes into a Hindsight memory item and (b) how items are POSTed to
+a Hindsight bank. Both the live spawn-exit writer (exit_cycle, Agency_OS-9goi)
+and the historical backfill (decisions_backfill, Agency_OS-c66k / PR #1278)
+import from here so live + backfilled atoms are byte-identical in the same bank.
+
+Direct-write model (Path 1, Dave-ratified 2026-05-29, ceo:ephemeral_capture_model_v1
+v2): an agent writes an AtomV1 DIRECTLY to the Hindsight `fleet_decisions` bank on
+spawn exit — no ceo_memory, no atomiser two-step. Hindsight computes the
+embedding at ingest, so the live path needs no AtomStore / TEIClient / pgvector.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from typing import Any
+
+from src.keiracom_system.atomization.schema import AtomV1
+
+DEFAULT_BANK = "fleet_decisions"
+HINDSIGHT_BASE = os.environ.get("HINDSIGHT_BASE", "http://localhost:8889")
+HINDSIGHT_TENANT = os.environ.get("HINDSIGHT_TENANT_SLUG", "default")
+
+# (bank, items) -> None — injectable so unit tests record without a live POST.
+IngestFn = Callable[[str, list[dict[str, Any]]], None]
+
+
+def atom_to_hindsight_item(atom: AtomV1, *, source: str = "decisions_backfill") -> dict[str, Any]:
+    """Serialize an AtomV1 into a Hindsight memory item.
+
+    `source` is the only field that legitimately differs between writers —
+    "decisions_backfill" (historical) vs "live_spawn_exit" (exit_cycle). All
+    other fields are identical so the two writers are indistinguishable to
+    recall ranking.
+
+      content  = atom.content (the decision statement; what recall ranks on)
+      tags     = ["atom_v1", state:<>, schema_v<N>] + composition-tag axis values
+      metadata = the full structured atom (so retrieval keeps trigger/provenance)
+    """
+    ct = atom.composition_tags or {}
+    tags = ["atom_v1", f"state:{atom.state}", f"schema_v{atom.schema_version}"]
+    tags += [v for v in (ct.get("domain"), ct.get("concern"), ct.get("applicable_context")) if v]
+    # Hindsight metadata values MUST all be strings (PR #1130 G2; the /memories
+    # endpoint 422s on a non-string value e.g. an int schema_version).
+    metadata = {
+        "atom_id": str(atom.atom_id),
+        "tenant_id": str(atom.tenant_id),
+        "schema_version": str(atom.schema_version),
+        "state": atom.state,
+        "trigger_condition": json.dumps(atom.trigger_condition),
+        "anti_pattern": atom.anti_pattern or "",
+        "example": atom.example or "",
+        "provenance": json.dumps(atom.provenance),
+        "composition_tags": json.dumps(ct),
+        "source": source,
+    }
+    return {"content": atom.content, "tags": tags, "metadata": metadata}
+
+
+def default_hindsight_ingest(bank: str, items: list[dict[str, Any]]) -> None:
+    """POST items to the Hindsight bank (synchronous retain). Live path only."""
+    from urllib import request as urlrequest
+
+    body = json.dumps({"items": items, "async": False}).encode()
+    url = f"{HINDSIGHT_BASE}/v1/{HINDSIGHT_TENANT}/banks/{bank}/memories"
+    req = urlrequest.Request(
+        url, data=body, method="POST", headers={"Content-Type": "application/json"}
+    )
+    with urlrequest.urlopen(req, timeout=120) as resp:  # noqa: S310 — fixed internal host
+        if resp.status >= 300:
+            raise RuntimeError(f"hindsight ingest HTTP {resp.status} for bank {bank}")

--- a/src/keiracom_system/chat/exit_cycle.py
+++ b/src/keiracom_system/chat/exit_cycle.py
@@ -1,18 +1,21 @@
-"""exit_cycle.py — John's end-of-conversation decision capture.
+"""exit_cycle.py — John's end-of-conversation decision capture (direct-write).
 
 An ephemeral John spawn has no persistent memory. If a conversation contained a
 ratified decision (Viktor explained an architecture, Dave confirmed a
 direction, a pattern was established), the only way that knowledge survives to
-the next spawn is to write it to ceo_memory before this spawn exits. The
-atomiser then promotes it to fleet_decisions; future spawns retrieve it via
-Hindsight Layer 2.
+the next spawn is to write it before this spawn exits.
 
-`classify_and_save` scans a finished conversation with Gemini Flash, keeps items
-with confidence > 0.8 (max 3), and upserts each to ceo_memory under
-`ceo:conversation_capture:{date}:{topic_slug}` via the canonical KEI-87 writer.
+DIRECT-WRITE model (Path 1, Dave-ratified 2026-05-29, ceo:ephemeral_capture_model_v1
+v2): `classify_and_save` scans a finished conversation with Gemini Flash, keeps
+items with confidence > 0.8 (max 3), builds an AtomV1 decision atom from each,
+and writes it DIRECTLY to the Hindsight `fleet_decisions` bank. The old two-step
+(exit_cycle -> ceo_memory -> atomiser -> fleet_decisions) is decommissioned —
+nothing is written to ceo_memory. Future spawns retrieve atoms via Hindsight
+Layer 2 recall. Serialization is the shared one-source seam in
+`atomization.hindsight_writer` (format-matched with the historical backfill).
 
-Fail-open by contract: any Gemini or DB error skips gracefully and never blocks
-conversation completion.
+Fail-open by contract: any Gemini or Hindsight error skips gracefully and never
+blocks conversation completion.
 """
 
 from __future__ import annotations
@@ -20,16 +23,31 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
+from uuid import UUID, uuid4
+
+from src.keiracom_system.atomization.decision_sources import decision_composition_tags
+from src.keiracom_system.atomization.hindsight_writer import (
+    DEFAULT_BANK,
+    IngestFn,
+    atom_to_hindsight_item,
+    default_hindsight_ingest,
+)
+from src.keiracom_system.atomization.schema import AtomV1
 
 logger = logging.getLogger(__name__)
 
 CONFIDENCE_THRESHOLD = 0.8
 MAX_WRITES = 3
 CALLSIGN = "john"
+LIVE_SOURCE = "live_spawn_exit"
+# Fleet/system tenant — fleet_decisions is a fleet-level bank (Dave = tenant 1).
+# Mirrors SYSTEM_PIPELINE_CLIENT_ID; recall addresses the bank by the "default"
+# slug (orchestrator.FLEET_TENANT_SLUG), so this UUID is provenance metadata.
+FLEET_TENANT_UUID = UUID("00000000-0000-0000-0000-000000000001")
 _VALID_KINDS = {
     "architectural_decision",
     "confirmed_pattern",
@@ -76,11 +94,9 @@ RESPONSE_SCHEMA: dict[str, Any] = {
 @dataclass
 class ExitCycleResult:
     decisions_saved: int = 0
-    keys_written: list[str] = field(default_factory=list)
+    atom_ids: list[str] = field(default_factory=list)
+    bank: str = DEFAULT_BANK
     skipped_reason: str | None = None
-
-
-WriterFn = Callable[[str, str, dict[str, Any]], None]
 
 
 def _topic_slug(text: str) -> str:
@@ -90,12 +106,6 @@ def _topic_slug(text: str) -> str:
 
 def _render(conversation: Sequence[dict[str, Any]]) -> str:
     return "\n".join(f"{m.get('role', '?')}: {m.get('content', '')}" for m in conversation)
-
-
-def _default_writer(callsign: str, key: str, value: dict[str, Any]) -> None:
-    from src.governance.ceo_memory_writer import upsert_ceo_memory_key
-
-    upsert_ceo_memory_key(callsign, key, value)
 
 
 async def _classify(gemini_client: Any, conversation_text: str) -> list[dict[str, Any]]:
@@ -135,15 +145,30 @@ def _select_qualifying(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return qualifying[:MAX_WRITES]
 
 
-def _build_value(item: dict[str, Any], customer_id: int, captured_at: str) -> dict[str, Any]:
-    return {
-        "decision": item["decision_text"],
-        "kind": item["kind"],
-        "confidence": float(item["confidence"]),
-        "customer_id": customer_id,
-        "captured_by": "john_exit_cycle",
-        "captured_at": captured_at,
-    }
+def _build_atom(item: dict[str, Any], customer_id: int, captured_at: datetime) -> AtomV1:
+    """Map a classified decision item to a fleet decision AtomV1."""
+    date = captured_at.strftime("%Y-%m-%d")
+    return AtomV1(
+        atom_id=uuid4(),
+        tenant_id=FLEET_TENANT_UUID,
+        trigger_condition={
+            "kind": "context_predicate",
+            "params": {
+                "topic": _topic_slug(item.get("topic_slug") or item["decision_text"]),
+                "decision_kind": item["kind"],
+            },
+        },
+        content=item["decision_text"],
+        anti_pattern=None,
+        example=None,
+        provenance={
+            "source": f"{LIVE_SOURCE}:john:customer_{customer_id}",
+            "freshness": date,
+            "confidence": float(item["confidence"]),
+            "last_validated": date,
+        },
+        composition_tags=decision_composition_tags(),
+    )
 
 
 async def classify_and_save(
@@ -151,12 +176,13 @@ async def classify_and_save(
     customer_id: int,
     *,
     gemini_client: Any | None = None,
-    writer: WriterFn | None = None,
+    ingest_fn: IngestFn | None = None,
 ) -> ExitCycleResult:
-    """Detect ratified decisions in `conversation` and persist them to ceo_memory.
+    """Detect ratified decisions in `conversation` and write them as AtomV1 atoms
+    directly to the Hindsight `fleet_decisions` bank.
 
     Fail-open: returns a result with `skipped_reason` set rather than raising on
-    any classification or write failure. `gemini_client` and `writer` are
+    any classification or ingest failure. `gemini_client` and `ingest_fn` are
     injectable for testing.
     """
     if not conversation:
@@ -184,27 +210,32 @@ async def classify_and_save(
         logger.info("exit_cycle: nothing to save (%s; %d raw items)", reason, len(items))
         return ExitCycleResult(skipped_reason=reason)
 
-    write = writer or _default_writer
     now = datetime.now(UTC)
-    date = now.strftime("%Y-%m-%d")
-    saved: list[str] = []
+    hindsight_items: list[dict[str, Any]] = []
+    atom_ids: list[str] = []
     for item in qualifying:
-        key = f"ceo:conversation_capture:{date}:{_topic_slug(item.get('topic_slug') or item['decision_text'])}"
-        value = _build_value(item, customer_id, now.isoformat())
         try:
-            await asyncio.to_thread(write, CALLSIGN, key, value)
-        except Exception as exc:  # noqa: BLE001 — fail-open per write
-            logger.warning("exit_cycle: ceo_memory write failed for %s (skip): %s", key, exc)
+            atom = _build_atom(item, customer_id, now)
+        except (ValueError, KeyError) as exc:
+            logger.warning("exit_cycle: atom build failed (skip item): %s", exc)
             continue
-        saved.append(key)
-        logger.info(
-            "exit_cycle: saved %s (kind=%s conf=%.2f): %s",
-            key,
-            item["kind"],
-            float(item["confidence"]),
-            item["decision_text"][:140],
-        )
+        hindsight_items.append(atom_to_hindsight_item(atom, source=LIVE_SOURCE))
+        atom_ids.append(str(atom.atom_id))
 
-    if not saved:
-        return ExitCycleResult(skipped_reason="all_writes_failed")
-    return ExitCycleResult(decisions_saved=len(saved), keys_written=saved)
+    if not hindsight_items:
+        return ExitCycleResult(skipped_reason="all_atoms_invalid")
+
+    ingest = ingest_fn or default_hindsight_ingest
+    try:
+        await asyncio.to_thread(ingest, DEFAULT_BANK, hindsight_items)
+    except Exception as exc:  # noqa: BLE001 — fail-open; never block completion
+        logger.warning("exit_cycle: fleet_decisions ingest failed (skip): %s", exc)
+        return ExitCycleResult(skipped_reason=f"ingest_failed: {exc}")
+
+    logger.info(
+        "exit_cycle: wrote %d atom(s) to %s (kinds=%s)",
+        len(atom_ids),
+        DEFAULT_BANK,
+        [q["kind"] for q in qualifying],
+    )
+    return ExitCycleResult(decisions_saved=len(atom_ids), atom_ids=atom_ids, bank=DEFAULT_BANK)

--- a/tests/keiracom_system/atomization/test_hindsight_writer.py
+++ b/tests/keiracom_system/atomization/test_hindsight_writer.py
@@ -1,0 +1,92 @@
+"""Unit tests for the one-source AtomV1 -> Hindsight item seam.
+
+Locks the serialization format both the live writer (exit_cycle) and the
+historical backfill (decisions_backfill) must share, so atoms in the
+fleet_decisions bank are indistinguishable by writer.
+"""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+from src.keiracom_system.atomization.hindsight_writer import (
+    DEFAULT_BANK,
+    atom_to_hindsight_item,
+)
+from src.keiracom_system.atomization.schema import AtomV1
+
+
+def _atom() -> AtomV1:
+    return AtomV1(
+        atom_id=uuid4(),
+        tenant_id=uuid4(),
+        trigger_condition={"kind": "context_predicate", "params": {"topic": "recall"}},
+        content="Use Hindsight Layer 2 for cross-spawn recall.",
+        anti_pattern="Do not re-query ceo_memory at spawn time.",
+        example="A fresh spawn recalls 3-5 atoms.",
+        provenance={
+            "source": "live_spawn_exit:john:customer_42",
+            "freshness": "2026-05-29",
+            "confidence": 0.95,
+            "last_validated": "2026-05-29",
+        },
+        composition_tags={
+            "domain": "internal",
+            "concern": "compliance",
+            "applicable_context": "audit_review",
+        },
+    )
+
+
+def test_default_bank_is_fleet_decisions():
+    assert DEFAULT_BANK == "fleet_decisions"
+
+
+def test_item_shape_and_tags():
+    item = atom_to_hindsight_item(_atom(), source="live_spawn_exit")
+    assert item["content"] == "Use Hindsight Layer 2 for cross-spawn recall."
+    assert item["tags"][:3] == ["atom_v1", "state:active", "schema_v1"]
+    assert {"internal", "compliance", "audit_review"} <= set(item["tags"])
+    assert item["metadata"]["source"] == "live_spawn_exit"
+
+
+def test_metadata_carries_full_structured_atom():
+    atom = _atom()
+    item = atom_to_hindsight_item(atom, source="live_spawn_exit")
+    md = item["metadata"]
+    assert md["atom_id"] == str(atom.atom_id)
+    assert md["tenant_id"] == str(atom.tenant_id)
+    assert md["schema_version"] == "1"  # Hindsight requires string metadata values
+    assert md["state"] == "active"
+    assert all(isinstance(v, str) for v in md.values())  # 422-guard: no non-string values
+    assert json.loads(md["trigger_condition"])["kind"] == "context_predicate"
+    assert json.loads(md["provenance"])["confidence"] == 0.95
+    assert json.loads(md["composition_tags"])["domain"] == "internal"
+    assert md["anti_pattern"] == "Do not re-query ceo_memory at spawn time."
+
+
+def test_source_defaults_to_backfill():
+    # Backfill writer relies on the default so its provenance stays distinct.
+    item = atom_to_hindsight_item(_atom())
+    assert item["metadata"]["source"] == "decisions_backfill"
+
+
+def test_empty_composition_tags_only_base_tags():
+    atom = AtomV1(
+        atom_id=uuid4(),
+        tenant_id=uuid4(),
+        trigger_condition={"kind": "system_event", "params": {}},
+        content="A decision with no composition tags.",
+        anti_pattern=None,
+        example=None,
+        provenance={
+            "source": "x",
+            "freshness": "2026-05-29",
+            "confidence": 1.0,
+            "last_validated": "2026-05-29",
+        },
+    )
+    item = atom_to_hindsight_item(atom, source="live_spawn_exit")
+    assert item["tags"] == ["atom_v1", "state:active", "schema_v1"]
+    assert item["metadata"]["anti_pattern"] == ""

--- a/tests/keiracom_system/chat/test_exit_cycle.py
+++ b/tests/keiracom_system/chat/test_exit_cycle.py
@@ -1,11 +1,13 @@
-"""Unit tests for John's exit cycle — mock Gemini + mock DB writer.
+"""Unit tests for John's exit cycle — direct-write to Hindsight fleet_decisions.
 
-Uses asyncio.run so the suite needs no pytest-asyncio mode configuration.
+Mocks Gemini + an injected ingest_fn (no live Hindsight POST). Uses asyncio.run
+so the suite needs no pytest-asyncio mode configuration.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 from src.keiracom_system.chat import exit_cycle
@@ -27,21 +29,24 @@ class FakeGemini:
 
 
 def _recorder():
-    calls: list[tuple[str, str, dict]] = []
+    """Record each (bank, items) ingest batch."""
+    calls: list[tuple[str, list[dict]]] = []
 
-    def writer(callsign: str, key: str, value: dict) -> None:
-        calls.append((callsign, key, value))
+    def ingest(bank: str, items: list[dict]) -> None:
+        calls.append((bank, items))
 
-    return writer, calls
+    return ingest, calls
 
 
 def _success(items: list[dict]) -> dict[str, Any]:
     return {"f3_status": "success", "content": {"items": items}}
 
 
-def _run(conversation, *, gemini, writer, customer_id=42):
+def _run(conversation, *, gemini, ingest_fn, customer_id=42):
     return asyncio.run(
-        exit_cycle.classify_and_save(conversation, customer_id, gemini_client=gemini, writer=writer)
+        exit_cycle.classify_and_save(
+            conversation, customer_id, gemini_client=gemini, ingest_fn=ingest_fn
+        )
     )
 
 
@@ -51,7 +56,7 @@ CONVO = [
 ]
 
 
-def test_happy_path_writes_qualifying_items():
+def test_happy_path_writes_atoms_to_fleet_decisions():
     gemini = FakeGemini(
         _success(
             [
@@ -70,19 +75,29 @@ def test_happy_path_writes_qualifying_items():
             ]
         )
     )
-    writer, calls = _recorder()
-    result = _run(CONVO, gemini=gemini, writer=writer)
+    ingest, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, ingest_fn=ingest)
     assert result.decisions_saved == 2
+    assert result.bank == "fleet_decisions"
     assert result.skipped_reason is None
-    assert len(calls) == 2
-    callsign, key, value = calls[0]
-    assert callsign == "john"
-    assert key.startswith("ceo:conversation_capture:")
-    assert "hindsight-layer-2-recall" in key
-    assert value["kind"] == "architectural_decision"
-    assert value["customer_id"] == 42
-    assert value["captured_by"] == "john_exit_cycle"
-    assert result.keys_written == [c[1] for c in calls]
+    assert len(result.atom_ids) == 2
+    # All atoms land in a SINGLE batch POST to fleet_decisions.
+    assert len(calls) == 1
+    bank, items = calls[0]
+    assert bank == "fleet_decisions"
+    assert len(items) == 2
+    first = items[0]
+    assert first["content"] == "Use Hindsight Layer 2 for cross-spawn recall."
+    assert "atom_v1" in first["tags"]
+    assert "state:active" in first["tags"]
+    assert "schema_v1" in first["tags"]
+    # decision composition tags retrievable as a class
+    assert "internal" in first["tags"] and "compliance" in first["tags"]
+    assert "audit_review" in first["tags"]
+    assert first["metadata"]["source"] == "live_spawn_exit"
+    trig = json.loads(first["metadata"]["trigger_condition"])
+    assert trig["kind"] == "context_predicate"
+    assert trig["params"]["decision_kind"] == "architectural_decision"
 
 
 def test_below_confidence_threshold_skips():
@@ -98,8 +113,8 @@ def test_below_confidence_threshold_skips():
             ]
         )
     )
-    writer, calls = _recorder()
-    result = _run(CONVO, gemini=gemini, writer=writer)
+    ingest, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, ingest_fn=ingest)
     assert result.decisions_saved == 0
     assert result.skipped_reason == "below_confidence_threshold"
     assert calls == []
@@ -118,8 +133,8 @@ def test_confidence_exactly_threshold_excluded():
             ]
         )
     )
-    writer, calls = _recorder()
-    result = _run(CONVO, gemini=gemini, writer=writer)
+    ingest, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, ingest_fn=ingest)
     assert result.skipped_reason == "below_confidence_threshold"
     assert calls == []
 
@@ -135,10 +150,12 @@ def test_max_three_writes_cap():
         for i in range(5)
     ]
     gemini = FakeGemini(_success(items))
-    writer, calls = _recorder()
-    result = _run(CONVO, gemini=gemini, writer=writer)
+    ingest, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, ingest_fn=ingest)
     assert result.decisions_saved == 3
-    assert len(calls) == 3
+    assert len(calls) == 1
+    _, batch = calls[0]
+    assert len(batch) == 3
 
 
 def test_invalid_kind_filtered():
@@ -154,16 +171,16 @@ def test_invalid_kind_filtered():
             ]
         )
     )
-    writer, calls = _recorder()
-    result = _run(CONVO, gemini=gemini, writer=writer)
+    ingest, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, ingest_fn=ingest)
     assert result.skipped_reason == "below_confidence_threshold"
     assert calls == []
 
 
 def test_empty_conversation_skips_without_gemini_call():
     gemini = FakeGemini(_success([]))
-    writer, calls = _recorder()
-    result = _run([], gemini=gemini, writer=writer)
+    ingest, calls = _recorder()
+    result = _run([], gemini=gemini, ingest_fn=ingest)
     assert result.skipped_reason == "empty_conversation"
     assert gemini.calls == []
     assert calls == []
@@ -171,16 +188,16 @@ def test_empty_conversation_skips_without_gemini_call():
 
 def test_no_decisions_detected():
     gemini = FakeGemini(_success([]))
-    writer, calls = _recorder()
-    result = _run(CONVO, gemini=gemini, writer=writer)
+    ingest, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, ingest_fn=ingest)
     assert result.skipped_reason == "no_decisions_detected"
     assert calls == []
 
 
 def test_gemini_failure_is_fail_open():
     gemini = FakeGemini(raises=RuntimeError("gemini 503"))
-    writer, calls = _recorder()
-    result = _run(CONVO, gemini=gemini, writer=writer)
+    ingest, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, ingest_fn=ingest)
     assert result.decisions_saved == 0
     assert result.skipped_reason is not None
     assert result.skipped_reason.startswith("classify_failed")
@@ -189,13 +206,13 @@ def test_gemini_failure_is_fail_open():
 
 def test_gemini_non_success_status_yields_no_writes():
     gemini = FakeGemini({"f3_status": "failed", "content": {}})
-    writer, calls = _recorder()
-    result = _run(CONVO, gemini=gemini, writer=writer)
+    ingest, calls = _recorder()
+    result = _run(CONVO, gemini=gemini, ingest_fn=ingest)
     assert result.skipped_reason == "no_decisions_detected"
     assert calls == []
 
 
-def test_db_write_failure_is_fail_open():
+def test_ingest_failure_is_fail_open():
     gemini = FakeGemini(
         _success(
             [
@@ -209,50 +226,19 @@ def test_db_write_failure_is_fail_open():
         )
     )
 
-    def boom(callsign: str, key: str, value: dict) -> None:
-        raise ConnectionError("db down")
+    def boom(bank: str, items: list[dict]) -> None:
+        raise ConnectionError("hindsight down")
 
-    result = _run(CONVO, gemini=gemini, writer=boom)
+    result = _run(CONVO, gemini=gemini, ingest_fn=boom)
     assert result.decisions_saved == 0
-    assert result.skipped_reason == "all_writes_failed"
-
-
-def test_partial_write_failure_counts_successes():
-    gemini = FakeGemini(
-        _success(
-            [
-                {
-                    "decision_text": "First decision.",
-                    "topic_slug": "first",
-                    "kind": "architectural_decision",
-                    "confidence": 0.95,
-                },
-                {
-                    "decision_text": "Second decision.",
-                    "topic_slug": "second",
-                    "kind": "confirmed_pattern",
-                    "confidence": 0.95,
-                },
-            ]
-        )
-    )
-    seen: list[str] = []
-
-    def flaky(callsign: str, key: str, value: dict) -> None:
-        if "second" in key:
-            raise ConnectionError("transient")
-        seen.append(key)
-
-    result = _run(CONVO, gemini=gemini, writer=flaky)
-    assert result.decisions_saved == 1
-    assert len(result.keys_written) == 1
-    assert "first" in result.keys_written[0]
+    assert result.skipped_reason is not None
+    assert result.skipped_reason.startswith("ingest_failed")
 
 
 def test_classify_passes_response_schema_and_no_grounding():
     gemini = FakeGemini(_success([]))
-    writer, _ = _recorder()
-    _run(CONVO, gemini=gemini, writer=writer)
+    ingest, _ = _recorder()
+    _run(CONVO, gemini=gemini, ingest_fn=ingest)
     assert gemini.calls, "comprehend should have been called"
     kwargs = gemini.calls[0]
     assert kwargs["enable_grounding"] is False


### PR DESCRIPTION
## Summary
Dave-ratified **Path 1** (2026-05-29): ephemeral John spawns write ratified decisions **directly to the Hindsight `fleet_decisions` bank as AtomV1 atoms** on conversation exit. The two-step (`exit_cycle → ceo_memory → atomiser`) is retired. Fixes d0kh FAIL (Agency_OS-9goi).

## Changes
- **`src/keiracom_system/atomization/hindsight_writer.py`** (new) — the SECRET_MANIFEST-style **one-source** seam: `atom_to_hindsight_item(atom, *, source)` + `default_hindsight_ingest(bank, items)`. Lifted from Nova's `decisions_backfill.py` (#1278) so live + backfilled atoms are byte-identical. **Fixes a live 422**: Hindsight requires all metadata values to be strings (`schema_version` was an int in the original seam — paper review missed it; the live smoke caught it).
- **`src/keiracom_system/chat/exit_cycle.py`** — `classify_and_save` now: classify (Gemini) → build `AtomV1` (fleet decision composition tags, fleet/system tenant) → `atom_to_hindsight_item(source="live_spawn_exit")` → single batch ingest to `fleet_decisions`. Fail-open preserved; **no ceo_memory write**. `writer` seam → injectable `ingest_fn`.
- **`personas/john.md`** — exit-cycle call instruction updated to direct-write (John's actual call-site).
- **`scripts/ratify_ephemeral_capture_model_v2.py`** (new) — **LAW XIII** canonical-key update: rewrites `ceo:ephemeral_capture_model_v1` to v2 (direct-write). ⚠️ **orion is NOT on the ceo_memory write-guard allowlist (elliot|dave|john)** — Elliot must run: `DATABASE_URL=… PYTHONPATH=. python3 scripts/ratify_ephemeral_capture_model_v2.py --callsign elliot`.

## Verification
- **Live d0kh write** (real `classify_and_save` path → real `fleet_decisions` POST): `success=true, items_count=1`, `decisions_saved=1`, atom_id returned, `last_document_at` advanced to write time. **PASS — AtomV1 now writes live on exit.**
- Recall round-trip is subject to Hindsight **async fact-extraction** (did not surface within ~90s); the read-path orchestrator recall from `fleet_decisions` is independently tested.
- **247 tests pass** (chat + atomization + ceo-capture listener); `ruff check` + `ruff format --check` clean.

## Coordination / follow-ups
- **Nova (#1278)**: import the converter+ingest from `hindsight_writer` (delete the local copies) — the 422 string-metadata fix lives here now. Dispatch sent.
- **Cleanup**: 3 clearly-tagged test atoms were written to prod `fleet_decisions` during the live smoke (not yet deletable — pending async extraction). Flagged for purge.

Branched off latest `origin/main`. Atomizer storage tables (Nova e7km) are now live but Path 1 does not depend on them (Hindsight embeds on ingest).