### PR TITLE
[ATLAS] fix(ci): KEI-108 gate fails CLOSED on git errors (Aiden catch)

### DIFF
--- a/scripts/ci/check_operational_deployment.sh
+++ b/scripts/ci/check_operational_deployment.sh
@@ -18,10 +18,23 @@
 set -euo pipefail
 
 BASE_REF="${BASE_REF:-main}"
-git fetch --no-tags --depth=1 origin "$BASE_REF" >/dev/null 2>&1 || true
+# Non-shallow fetch: a `--depth=1` fetch left origin/${BASE_REF} with no merge-base
+# vs HEAD, so `git diff origin/${BASE_REF}...HEAD` errored "no merge base" → emitted
+# zero files → the gate exited 0 vacuously (KEI-108 false-pass Aiden caught).
+git fetch --no-tags origin "$BASE_REF" >/dev/null 2>&1 || true
+
+# FAIL CLOSED on any git error. Compute the merge-base explicitly: if it can't be
+# found (the failure mode above), the gate ERRORS — it must NEVER pass vacuously
+# on a git problem, only on a verified-clean diff.
+if ! MERGE_BASE="$(git merge-base "origin/${BASE_REF}" HEAD 2>/dev/null)"; then
+  echo "::error::KEI-108 gate cannot compute a merge-base for origin/${BASE_REF}...HEAD — failing CLOSED. The gate must never exit 0 on a git error (this was the vacuous-pass bug)." >&2
+  exit 1
+fi
 
 added_files() {
-  git diff --name-only --diff-filter=A "origin/${BASE_REF}...HEAD" -- "$@"
+  # Two-dot against the verified merge-base — equivalent to the three-dot form but
+  # guaranteed to have a base (we exited above if not).
+  git diff --name-only --diff-filter=A "${MERGE_BASE}" HEAD -- "$@"
 }
 
 fail() {


### PR DESCRIPTION
## Summary

The operational-deployment gate (**KEI-108** — "reject shipped-but-not-wired") **false-passed**. Root cause (Aiden's catch): `git fetch --no-tags --depth=1 origin <base>` left `origin/<base>` with **no merge-base** vs `HEAD`, so `git diff origin/<base>...HEAD` errored *"no merge base"* → emitted **zero** added files → the loop body never ran → the gate **exited 0 vacuously**. A genuine gap (the work-loop units shipping without an installer, #1280) sailed through; Aiden had to catch it by hand.

## Fix — fail closed on any git error

- **Non-shallow fetch** of the base (the `--depth=1` was what removed the merge-base).
- **Explicit merge-base computation**: if `git merge-base` can't find a base, the gate **`exit 1`** with a clear `::error::` — it must never treat an *unknown* diff as "0 changed files = pass."
- Diff two-dot against the **verified** merge-base.

## Test plan

- [x] `bash -n` clean
- [x] **Normal** run (`BASE_REF=main`, valid merge-base) → checks run, exits 0
- [x] **Fail-closed** run (bad/absent base, no merge-base) → **exits 1** with `::error::` (previously a silent exit 0)

Independent of the work-loop stack (CI script only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)