### PR TITLE
[ORION] feat(dispatcher): cost guard circuit breaker — fail-safe spend ceiling + HALT (Agency_OS-wdws)

### DIFF
--- a/src/dispatcher/cost_breaker.py
+++ b/src/dispatcher/cost_breaker.py
@@ -1,0 +1,229 @@
+"""cost_breaker — fail-SAFE dispatcher circuit breaker on fleet LLM spend (Agency_OS-wdws).
+
+The ephemeral model is per-token billing. This is the OUTER hard safety stop on
+the dispatcher spawn path: before each spawn it reads the REAL accumulated fleet
+spend (spend_tracker Valkey counters, $AUD cents) and, when a ceiling is crossed,
+HALTs new spawns and pings #ceo.
+
+Distinct from src/relay/budget_ceiling.BudgetCeilingGate (Agency_OS-6ah2), which is
+a fail-OPEN, priority-routing budget POLICY gate. This breaker is fail-SAFE: if it
+cannot read spend, it HALTs (a runaway spend leak is worse than a paused fleet).
+
+Thresholds (Dave/Elliot spec 2026-05-29, all overridable via env):
+  - daily alert  A$20  → spawn proceeds, #ceo pinged (KEIRACOM_COST_DAILY_ALERT_AUD)
+  - daily halt   A$30  → HALT new spawns + #ceo (KEIRACOM_COST_DAILY_HALT_AUD)
+  - monthly halt A$350 → HALT new spawns + #ceo (KEIRACOM_COST_MONTHLY_HALT_AUD); this
+    is Dave's hard cap. A$30/day sustained would blow A$350/mo, so the monthly
+    ceiling catches slow burn the daily tripwire misses.
+(bd Agency_OS-wdws's older "A$50/mo" note is superseded by the dispatch spec.)
+
+CEO never blocked: Dave-DM / force_override spawns BYPASS the HALT (still alerted),
+mirroring BudgetCeilingGate's non-negotiable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from src.dispatcher.spend_tracker import get_spend
+
+log = logging.getLogger(__name__)
+
+# Defaults in $AUD cents (LAW II — Australia First; spend_tracker stores cents).
+DEFAULT_DAILY_ALERT_CENTS = 2000
+DEFAULT_DAILY_HALT_CENTS = 3000
+DEFAULT_MONTHLY_HALT_CENTS = 35000
+# Operator/fleet tenant whose spend counters represent fleet spawns (Dave=tenant 1).
+DEFAULT_FLEET_TENANT_ID = 1
+# Min seconds between repeat #ceo pings at the same level (in-memory dedup).
+NOTIFY_COOLDOWN_SECONDS = 600
+
+# Task source that bypasses HALT — mirrors budget_ceiling.SOURCE_DAVE_DM.
+SOURCE_DAVE_DM = "dave_dm"
+
+DEFAULT_ALERTS_JSONL = Path("/tmp/keiracom_cost_breaker_alerts.jsonl")
+
+
+class BreakerDecision(Enum):
+    OK = "ok"  # under all ceilings
+    ALERT = "alert"  # over daily alert band (or CEO bypass over ceiling) — spawn proceeds
+    HALT = "halt"  # over a hard ceiling, or spend unreadable (fail-safe) — refuse spawn
+
+
+# Decisions that allow the spawn to proceed.
+PROCEED = frozenset({BreakerDecision.OK, BreakerDecision.ALERT})
+
+
+@dataclass(frozen=True, kw_only=True)
+class BreakerResult:
+    decision: BreakerDecision
+    daily_spend_aud: float
+    monthly_spend_aud: float
+    daily_alert_aud: float
+    daily_halt_aud: float
+    monthly_halt_aud: float
+    reason: str
+
+
+AlertEmitter = Callable[[dict[str, Any]], None]
+SpendReader = Callable[[int, str], Awaitable[int]]  # (tenant_id, period) -> $AUD cents
+
+
+class CostBreakerError(RuntimeError):
+    """Raised on invalid config only — spend/alert failures fail-safe/open by design."""
+
+
+def _env_cents(name: str, default_cents: int) -> int:
+    """Read an env var expressed in whole $AUD, return $AUD cents; default on absent/invalid."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default_cents
+    try:
+        return int(round(float(raw) * 100))
+    except ValueError:
+        log.warning("invalid %s=%r — using default %d cents", name, raw, default_cents)
+        return default_cents
+
+
+def _default_alert_emitter(payload: dict[str, Any]) -> None:
+    """Fallback #ceo alert sink — append-only JSONL audit trail. Production wires a
+    real #ceo emitter via DI; this guarantees every firing is reviewable regardless."""
+    import json
+
+    DEFAULT_ALERTS_JSONL.parent.mkdir(parents=True, exist_ok=True)
+    with DEFAULT_ALERTS_JSONL.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload) + "\n")
+
+
+class CostBreaker:
+    """Fail-SAFE pre-spawn cost circuit breaker. Call ``await check(...)`` before
+    every spawn; HALT means refuse the spawn."""
+
+    def __init__(
+        self,
+        *,
+        fleet_tenant_id: int | None = None,
+        daily_alert_cents: int | None = None,
+        daily_halt_cents: int | None = None,
+        monthly_halt_cents: int | None = None,
+        alert_emitter: AlertEmitter | None = None,
+        spend_reader: SpendReader | None = None,
+        now: Callable[[], float] | None = None,
+    ):
+        self._fleet_tenant_id = (
+            fleet_tenant_id
+            if fleet_tenant_id is not None
+            else int(os.environ.get("KEIRACOM_FLEET_TENANT_ID", DEFAULT_FLEET_TENANT_ID))
+        )
+        self._daily_alert = (
+            daily_alert_cents
+            if daily_alert_cents is not None
+            else _env_cents("KEIRACOM_COST_DAILY_ALERT_AUD", DEFAULT_DAILY_ALERT_CENTS)
+        )
+        self._daily_halt = (
+            daily_halt_cents
+            if daily_halt_cents is not None
+            else _env_cents("KEIRACOM_COST_DAILY_HALT_AUD", DEFAULT_DAILY_HALT_CENTS)
+        )
+        self._monthly_halt = (
+            monthly_halt_cents
+            if monthly_halt_cents is not None
+            else _env_cents("KEIRACOM_COST_MONTHLY_HALT_AUD", DEFAULT_MONTHLY_HALT_CENTS)
+        )
+        if min(self._daily_alert, self._daily_halt, self._monthly_halt) <= 0:
+            raise CostBreakerError("all ceilings must be > 0 cents")
+        if self._daily_halt < self._daily_alert:
+            raise CostBreakerError(
+                f"daily_halt ({self._daily_halt}) must be >= daily_alert ({self._daily_alert})"
+            )
+        self._alerts = alert_emitter or _default_alert_emitter
+        self._spend_reader = spend_reader or get_spend
+        self._now = now or time.monotonic
+        self._notified: dict[str, float] = {}
+
+    async def spend_snapshot(self) -> dict[str, float]:
+        """Expose current fleet spend in $AUD (for rehearsal cost-per-loop logging).
+        Fail-open: returns -1.0 sentinels if spend is unreadable (never raises)."""
+        try:
+            daily = await self._spend_reader(self._fleet_tenant_id, "daily")
+            monthly = await self._spend_reader(self._fleet_tenant_id, "monthly")
+        except Exception:  # noqa: BLE001 — snapshot must never raise
+            log.exception("cost breaker: spend_snapshot read failed")
+            return {"daily_spend_aud": -1.0, "monthly_spend_aud": -1.0}
+        return {"daily_spend_aud": daily / 100, "monthly_spend_aud": monthly / 100}
+
+    async def check(self, *, source: str = "fleet", force_override: bool = False) -> BreakerResult:
+        """Pre-spawn breaker. HALT = refuse spawn. Fail-SAFE: spend read error → HALT.
+        Dave-DM / force_override bypass HALT (CEO never blocked) but still alert."""
+        try:
+            daily_cents = await self._spend_reader(self._fleet_tenant_id, "daily")
+            monthly_cents = await self._spend_reader(self._fleet_tenant_id, "monthly")
+        except Exception as exc:  # noqa: BLE001 — fail-SAFE
+            log.exception("cost breaker: spend read failed — failing SAFE (HALT)")
+            res = self._result(BreakerDecision.HALT, -1, -1, f"spend_unreadable_failsafe: {exc}")
+            self._notify("halt", res)
+            return res
+
+        over_halt = daily_cents >= self._daily_halt or monthly_cents >= self._monthly_halt
+        if over_halt:
+            if source == SOURCE_DAVE_DM or force_override:
+                res = self._result(
+                    BreakerDecision.ALERT, daily_cents, monthly_cents, "over_ceiling_ceo_bypass"
+                )
+                self._notify("halt", res)
+                return res
+            res = self._result(
+                BreakerDecision.HALT, daily_cents, monthly_cents, "spend ceiling exceeded — HALT"
+            )
+            self._notify("halt", res)
+            return res
+
+        if daily_cents >= self._daily_alert:
+            res = self._result(
+                BreakerDecision.ALERT, daily_cents, monthly_cents, "daily alert threshold crossed"
+            )
+            self._notify("alert", res)
+            return res
+
+        return self._result(BreakerDecision.OK, daily_cents, monthly_cents, "under ceilings")
+
+    def _result(self, decision, daily_cents, monthly_cents, reason) -> BreakerResult:
+        return BreakerResult(
+            decision=decision,
+            daily_spend_aud=daily_cents / 100,
+            monthly_spend_aud=monthly_cents / 100,
+            daily_alert_aud=self._daily_alert / 100,
+            daily_halt_aud=self._daily_halt / 100,
+            monthly_halt_aud=self._monthly_halt / 100,
+            reason=reason,
+        )
+
+    def _notify(self, level: str, res: BreakerResult) -> None:
+        """Ping #ceo, deduped per level by cooldown. Fail-open: an alert failure
+        never changes the breaker decision."""
+        now = self._now()
+        last = self._notified.get(level)
+        if last is not None and (now - last) < NOTIFY_COOLDOWN_SECONDS:
+            return
+        self._notified[level] = now
+        try:
+            self._alerts(
+                {
+                    "kind": f"cost_breaker_{level}",
+                    "decision": res.decision.value,
+                    "daily_spend_aud": res.daily_spend_aud,
+                    "monthly_spend_aud": res.monthly_spend_aud,
+                    "daily_halt_aud": res.daily_halt_aud,
+                    "monthly_halt_aud": res.monthly_halt_aud,
+                    "reason": res.reason,
+                }
+            )
+        except Exception:  # noqa: BLE001 — alert emit must not block the breaker
+            log.exception("cost breaker: #ceo alert emit failed (non-blocking)")

--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -36,6 +36,7 @@ from src.dispatcher.bounded_spawn_enforcer import (
     BoundedSpawnEnforcer,
 )
 from src.dispatcher.container_lifecycle import ContainerStartupError, DockerUnavailableError
+from src.dispatcher.cost_breaker import BreakerDecision, CostBreaker
 from src.dispatcher.idempotency import IdempotencyDecision, IdempotencyGate
 from src.dispatcher.interceptor_proxy import router as interceptor_router
 from src.dispatcher.reaper import Reaper
@@ -127,6 +128,18 @@ def _set_budget_gate(gate: BudgetCeilingGate | None) -> None:
     """Test-only setter for the budget ceiling gate (DI through module attr)."""
     global _budget_gate  # noqa: PLW0603
     _budget_gate = gate
+
+
+# Fail-SAFE cost circuit breaker (Agency_OS-wdws). OUTER hard stop on fleet LLM
+# spend — HALTs new spawns + pings #ceo when a daily/monthly $AUD ceiling is
+# crossed. None = no-op until production startup wires one via _set_cost_breaker.
+_cost_breaker: CostBreaker | None = None
+
+
+def _set_cost_breaker(breaker: CostBreaker | None) -> None:
+    """Test-only setter for the cost circuit breaker (DI through module attr)."""
+    global _cost_breaker  # noqa: PLW0603
+    _cost_breaker = breaker
 
 
 # BudgetDecisions that allow the spawn to proceed (overage logged + Dave bypass).
@@ -749,6 +762,39 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
                 "decision": "drop_duplicate",
                 "reason": idem_result.reason,
                 "idempotency_key": idem_result.key,
+            }
+
+    # Pre-spawn cost circuit breaker (Agency_OS-wdws) — OUTER fail-SAFE hard stop.
+    # Runs BEFORE the (fail-open) budget policy gate: a HALT refuses the spawn
+    # outright. Dave-DM / force_override bypass HALT (CEO never blocked) but alert.
+    if _cost_breaker is not None:
+        cb_sk = req.spawn_kwargs or {}
+        cb_source = (
+            SOURCE_DAVE_DM
+            if (
+                str(cb_sk.get("source") or "").strip() == SOURCE_DAVE_DM
+                or str(cb_sk.get("from") or "").lower().strip() == "dave"
+            )
+            else SOURCE_FLEET
+        )
+        cb_force = bool(cb_sk.get("force_override") or cb_sk.get("force_spawn"))
+        breaker_result = await _cost_breaker.check(source=cb_source, force_override=cb_force)
+        if breaker_result.decision == BreakerDecision.HALT:
+            logger.warning(
+                "cost breaker HALT key=%s daily_aud=%.2f monthly_aud=%.2f reason=%s",
+                req.key,
+                breaker_result.daily_spend_aud,
+                breaker_result.monthly_spend_aud,
+                breaker_result.reason,
+            )
+            return {
+                "spawned": False,
+                "key": req.key,
+                "backend": backend.value,
+                "decision": "cost_halt",
+                "daily_spend_aud": breaker_result.daily_spend_aud,
+                "monthly_spend_aud": breaker_result.monthly_spend_aud,
+                "reason": breaker_result.reason,
             }
 
     # Pre-spawn budget ceiling gate (Cat 21 lever 28 / cutover-blocker 2).

--- a/tests/dispatcher/test_cost_breaker.py
+++ b/tests/dispatcher/test_cost_breaker.py
@@ -1,0 +1,131 @@
+"""Unit tests for the fail-SAFE dispatcher cost circuit breaker (Agency_OS-wdws).
+
+Injects a fake async spend_reader + recording alert_emitter — no Valkey/network.
+asyncio.run keeps the suite free of pytest-asyncio mode config.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.dispatcher.cost_breaker import (
+    BreakerDecision,
+    CostBreaker,
+    CostBreakerError,
+)
+
+
+def _reader(daily_cents: int, monthly_cents: int, *, raises: Exception | None = None):
+    async def read(tenant_id: int, period: str) -> int:
+        if raises is not None:
+            raise raises
+        return {"daily": daily_cents, "monthly": monthly_cents}[period]
+
+    return read
+
+
+def _breaker(daily_cents, monthly_cents, *, raises=None, now=None):
+    alerts: list[dict] = []
+    b = CostBreaker(
+        fleet_tenant_id=1,
+        daily_alert_cents=2000,  # A$20
+        daily_halt_cents=3000,  # A$30
+        monthly_halt_cents=35000,  # A$350
+        alert_emitter=alerts.append,
+        spend_reader=_reader(daily_cents, monthly_cents, raises=raises),
+        now=now,
+    )
+    return b, alerts
+
+
+def _check(b, **kw):
+    return asyncio.run(b.check(**kw))
+
+
+def test_under_all_ceilings_is_ok_no_alert():
+    b, alerts = _breaker(1000, 10000)  # A$10 daily, A$100 monthly
+    res = _check(b)
+    assert res.decision is BreakerDecision.OK
+    assert res.daily_spend_aud == 10.0
+    assert alerts == []
+
+
+def test_daily_alert_band_proceeds_and_alerts():
+    b, alerts = _breaker(2500, 10000)  # A$25 daily — over alert, under halt
+    res = _check(b)
+    assert res.decision is BreakerDecision.ALERT
+    assert len(alerts) == 1
+    assert alerts[0]["kind"] == "cost_breaker_alert"
+
+
+def test_daily_halt_halts_fleet_spawn():
+    b, alerts = _breaker(3000, 10000)  # A$30 daily == halt
+    res = _check(b, source="fleet")
+    assert res.decision is BreakerDecision.HALT
+    assert "ceiling" in res.reason.lower()
+    assert alerts[0]["kind"] == "cost_breaker_halt"
+
+
+def test_monthly_cap_halts_even_when_daily_low():
+    b, alerts = _breaker(500, 35000)  # A$5 daily but A$350 monthly == cap
+    res = _check(b, source="fleet")
+    assert res.decision is BreakerDecision.HALT
+    assert len(alerts) == 1
+
+
+def test_dave_dm_bypasses_halt_but_alerts():
+    b, alerts = _breaker(5000, 10000)  # A$50 daily — well over halt
+    res = _check(b, source="dave_dm")
+    assert res.decision is BreakerDecision.ALERT  # CEO never blocked
+    assert res.reason == "over_ceiling_ceo_bypass"
+    assert alerts[0]["kind"] == "cost_breaker_halt"  # still pinged
+
+
+def test_force_override_bypasses_halt():
+    b, _ = _breaker(5000, 10000)
+    res = _check(b, source="fleet", force_override=True)
+    assert res.decision is BreakerDecision.ALERT
+    assert res.reason == "over_ceiling_ceo_bypass"
+
+
+def test_spend_read_failure_fails_safe_to_halt():
+    b, alerts = _breaker(0, 0, raises=ConnectionError("valkey down"))
+    res = _check(b, source="fleet")
+    assert res.decision is BreakerDecision.HALT
+    assert "failsafe" in res.reason
+    assert alerts[0]["kind"] == "cost_breaker_halt"
+
+
+def test_alert_deduped_within_cooldown():
+    clock = {"t": 1000.0}
+    b, alerts = _breaker(2500, 10000, now=lambda: clock["t"])
+    _check(b)  # fires alert
+    _check(b)  # within cooldown — suppressed
+    assert len(alerts) == 1
+    clock["t"] += 601  # past NOTIFY_COOLDOWN_SECONDS
+    _check(b)
+    assert len(alerts) == 2
+
+
+def test_spend_snapshot_returns_aud():
+    b, _ = _breaker(2500, 12345)
+    snap = asyncio.run(b.spend_snapshot())
+    assert snap == {"daily_spend_aud": 25.0, "monthly_spend_aud": 123.45}
+
+
+def test_spend_snapshot_failopen_on_error():
+    b, _ = _breaker(0, 0, raises=RuntimeError("x"))
+    snap = asyncio.run(b.spend_snapshot())
+    assert snap["daily_spend_aud"] == -1.0
+
+
+def test_config_rejects_halt_below_alert():
+    with pytest.raises(CostBreakerError):
+        CostBreaker(daily_alert_cents=3000, daily_halt_cents=2000, monthly_halt_cents=35000)
+
+
+def test_config_rejects_nonpositive_ceiling():
+    with pytest.raises(CostBreakerError):
+        CostBreaker(daily_alert_cents=0, daily_halt_cents=3000, monthly_halt_cents=35000)

--- a/tests/dispatcher/test_main_cost_breaker_wiring.py
+++ b/tests/dispatcher/test_main_cost_breaker_wiring.py
@@ -1,0 +1,163 @@
+"""Cost circuit breaker wiring tests for src.dispatcher.main (Agency_OS-wdws).
+
+Covers the OUTER fail-SAFE breaker on /dispatcher/spawn:
+  - no breaker → spawn proceeds (None default)
+  - under ceilings → spawn proceeds
+  - HALT → spawn skipped, HTTP 200 decision=cost_halt, SessionManager.spawn not called
+  - Dave-DM bypass → spawn proceeds even over ceiling
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.dispatcher.cost_breaker import CostBreaker
+from src.dispatcher.tmux_lifecycle import SessionHandle
+
+
+def _make_breaker(daily_cents: int, monthly_cents: int = 0) -> CostBreaker:
+    async def reader(tenant_id: int, period: str) -> int:
+        return {"daily": daily_cents, "monthly": monthly_cents}[period]
+
+    return CostBreaker(
+        daily_alert_cents=2000,
+        daily_halt_cents=3000,
+        monthly_halt_cents=35000,
+        alert_emitter=lambda _p: None,
+        spend_reader=reader,
+    )
+
+
+def _mock_supervisors(main_mod: Any) -> None:
+    main_mod._watchdog = MagicMock()
+    main_mod._reaper = MagicMock()
+    main_mod._reaper.health_snapshot.return_value = {"tracked_tmux": 0, "tracked_containers": 0}
+    main_mod._watchdog.tracked = 0
+
+
+def _handle() -> SessionHandle:
+    return SessionHandle(session_name="disp-test", working_dir="/tmp", command="claude")
+
+
+def _envs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISPATCHER_JWT_SECRET", "test")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://fake/db")
+
+
+def test_no_breaker_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    _envs(monkeypatch)
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    main_mod._set_cost_breaker(None)
+    with (
+        patch("src.dispatcher.main.SessionManager") as MockSM,
+        patch.object(main_mod, "_register_session"),
+    ):
+        MockSM.return_value.spawn.return_value = _handle()
+        client = TestClient(main_mod.app, raise_server_exceptions=False)
+        resp = client.post(
+            "/dispatcher/spawn", json={"backend": "tmux", "key": "k1", "spawn_kwargs": {}}
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["spawned"] is True
+
+
+def test_under_ceiling_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    _envs(monkeypatch)
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    main_mod._set_cost_breaker(_make_breaker(daily_cents=500))  # A$5
+    try:
+        with (
+            patch("src.dispatcher.main.SessionManager") as MockSM,
+            patch.object(main_mod, "_register_session"),
+        ):
+            MockSM.return_value.spawn.return_value = _handle()
+            client = TestClient(main_mod.app, raise_server_exceptions=False)
+            resp = client.post(
+                "/dispatcher/spawn", json={"backend": "tmux", "key": "k1", "spawn_kwargs": {}}
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["spawned"] is True
+    finally:
+        main_mod._set_cost_breaker(None)
+
+
+def test_halt_skips_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    _envs(monkeypatch)
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    main_mod._set_cost_breaker(_make_breaker(daily_cents=5000))  # A$50 > A$30 halt
+    try:
+        with patch("src.dispatcher.main.SessionManager") as MockSM:
+            client = TestClient(main_mod.app, raise_server_exceptions=False)
+            resp = client.post(
+                "/dispatcher/spawn", json={"backend": "tmux", "key": "k1", "spawn_kwargs": {}}
+            )
+            MockSM.return_value.spawn.assert_not_called()
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["spawned"] is False
+        assert body["decision"] == "cost_halt"
+        assert body["daily_spend_aud"] == 50.0
+    finally:
+        main_mod._set_cost_breaker(None)
+
+
+def test_monthly_cap_halts(monkeypatch: pytest.MonkeyPatch) -> None:
+    _envs(monkeypatch)
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    main_mod._set_cost_breaker(_make_breaker(daily_cents=500, monthly_cents=40000))  # A$400/mo
+    try:
+        with patch("src.dispatcher.main.SessionManager") as MockSM:
+            client = TestClient(main_mod.app, raise_server_exceptions=False)
+            resp = client.post(
+                "/dispatcher/spawn", json={"backend": "tmux", "key": "k1", "spawn_kwargs": {}}
+            )
+            MockSM.return_value.spawn.assert_not_called()
+        assert resp.json()["decision"] == "cost_halt"
+    finally:
+        main_mod._set_cost_breaker(None)
+
+
+def test_dave_dm_bypasses_halt(monkeypatch: pytest.MonkeyPatch) -> None:
+    _envs(monkeypatch)
+    import src.dispatcher.main as main_mod
+
+    _mock_supervisors(main_mod)
+    main_mod._set_cost_breaker(_make_breaker(daily_cents=5000))  # over halt
+    try:
+        with (
+            patch("src.dispatcher.main.SessionManager") as MockSM,
+            patch.object(main_mod, "_register_session"),
+        ):
+            MockSM.return_value.spawn.return_value = _handle()
+            client = TestClient(main_mod.app, raise_server_exceptions=False)
+            resp = client.post(
+                "/dispatcher/spawn",
+                json={"backend": "tmux", "key": "k1", "spawn_kwargs": {"from": "dave"}},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["spawned"] is True  # CEO never blocked
+    finally:
+        main_mod._set_cost_breaker(None)
+
+
+def test_set_cost_breaker_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    _envs(monkeypatch)
+    import src.dispatcher.main as main_mod
+
+    breaker = _make_breaker(daily_cents=0)
+    main_mod._set_cost_breaker(breaker)
+    assert main_mod._cost_breaker is breaker
+    main_mod._set_cost_breaker(None)
+    assert main_mod._cost_breaker is None


### PR DESCRIPTION
## Summary
Per-token-billing safety for the ephemeral model. Adds an **OUTER fail-SAFE circuit breaker** on the dispatcher spawn path: reads the REAL accumulated fleet spend (existing `spend_tracker` Valkey counters, $AUD) and **HALTs new spawns + pings #ceo** when a ceiling is crossed. Gates the rehearsal (Run-B cost measurement + soak cost validation). Agency_OS-wdws.

## Two parts (per dispatch)
1. **Spend meter (mostly pre-existing):** the KEI-212 `spend_tracker` already records real token cost → `$AUD` per model-call into Valkey `spend:<tenant>:daily/monthly`. The breaker exposes `spend_snapshot()` so the rehearsal can log real cost per loop.
2. **Circuit breaker (`src/dispatcher/cost_breaker.py`, new):** `CostBreaker`
   - Daily **alert A$20** → spawn proceeds, #ceo pinged
   - Daily **halt A$30** / monthly **halt A$350** (Dave's hard cap) → **HALT** new spawns + #ceo
   - All thresholds env-overridable (`KEIRACOM_COST_DAILY_ALERT_AUD` etc.)
   - **Fail-SAFE:** spend read error → HALT ("if unsure, halt")
   - **CEO never blocked:** Dave-DM / `force_override` spawns bypass HALT (still alerted)
   - Cooldown-deduped #ceo alerts (injectable emitter; JSONL fallback)

## Wiring
`main.py`: `_cost_breaker` / `_set_cost_breaker` (DI, `None` = no-op until startup wires it), checked **before** the existing budget gate in `dispatcher_spawn`. HALT → `{"spawned": false, "decision": "cost_halt", ...}`.

## Relationship to existing infra
- `src/relay/budget_ceiling.BudgetCeilingGate` (Agency_OS-6ah2) is a **fail-OPEN priority policy** gate. This breaker is the **fail-SAFE hard stop** — complementary, not a replacement. The directive's `_budget_gate`-is-None hook is that 6ah2 gate; I added the breaker as a separate outer check rather than overloading it (different contracts).
- ⚠️ bd Agency_OS-wdws's older "A$50/mo" note is **superseded** by the dispatch spec (A$20/A$30 daily, A$350/mo). Daily-halt A$30 × 30d would exceed A$350/mo, so the **monthly cap** is the real ceiling and catches slow burn the daily tripwire misses — both dimensions HALT.

## Verification
- **18 new tests** (12 `CostBreaker` unit + 6 spawn-path wiring): OK/alert/halt bands, monthly cap, fail-safe-on-read-error→HALT, Dave/force bypass, alert dedup, `spend_snapshot`, config validation.
- Full dispatcher suite **350 pass**; `ruff check` + `ruff format --check` clean. Branched off latest `main`.

## Follow-up (out of scope)
Production startup must wire a real `CostBreaker` (and a real #ceo alert emitter) via `_set_cost_breaker` — currently `None` (no-op), matching the existing gate rollout pattern.