### PR TITLE
[AIDEN] feat(dispatcher): physical RAM ceiling — box OOM guard (Agency_OS-cuit)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -39,6 +39,7 @@ from src.dispatcher.container_lifecycle import ContainerStartupError, DockerUnav
 from src.dispatcher.cost_breaker import BreakerDecision, CostBreaker
 from src.dispatcher.idempotency import IdempotencyDecision, IdempotencyGate
 from src.dispatcher.interceptor_proxy import router as interceptor_router
+from src.dispatcher.physical_ceiling import check_physical_ceiling
 from src.dispatcher.reaper import Reaper
 from src.dispatcher.session_manager import Backend, SessionManager
 from src.dispatcher.spend_tracker import get_spend
@@ -859,6 +860,16 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
         # Phase-1 scrubbed-tmux (Agency_OS-87ei): run the agent under env -i so it
         # inherits no .env — only the Vault bootstrap; resolve_into_env does the rest.
         spawn_kwargs_effective = _tmux_spawn_kwargs(req.key, spawn_kwargs_effective)
+
+    # Physical RAM ceiling (Agency_OS-cuit): hard box-level guard separate from the
+    # tenant tier ceiling. Applies even to the uncapped operator — the box can OOM
+    # regardless of tenant policy. Re-reads available RAM on every call so it adapts
+    # to live memory pressure. Fail-safe: if RAM is unreadable, falls back to the
+    # conservative DEFAULT_PHYSICAL_CEILING (never fails open to "unlimited").
+    can_spawn, ceiling_reason = check_physical_ceiling(len(_spawned))
+    if not can_spawn:
+        logger.warning("physical ceiling: refusing spawn key=%s — %s", req.key, ceiling_reason)
+        raise HTTPException(status_code=503, detail=ceiling_reason)
 
     manager = SessionManager(backend=backend)
     try:

--- a/src/dispatcher/physical_ceiling.py
+++ b/src/dispatcher/physical_ceiling.py
@@ -1,0 +1,101 @@
+"""physical_ceiling.py — box RAM-based hard spawn ceiling (Agency_OS-cuit).
+
+A PHYSICAL max-concurrent-spawns ceiling sized to available box RAM — separate
+from the tenant tier ceiling (which can be uncapped for the operator per #1285).
+This layer refuses a spawn if it would OOM the box, regardless of tenant tier.
+
+Priority order for ceiling resolution:
+  1. DISPATCHER_PHYSICAL_MAX_SPAWNS env — explicit operator-configured ceiling
+  2. Computed: MemAvailable // DISPATCHER_AGENT_FOOTPRINT_MB  (live /proc/meminfo)
+  3. DEFAULT_PHYSICAL_CEILING — conservative fallback when /proc/meminfo absent
+
+Fail-safe: if the RAM read fails AND no explicit ceiling is set, the fallback
+DEFAULT_PHYSICAL_CEILING (4) is used — never fail-open to "unlimited".
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_MEMINFO_PATH = Path("/proc/meminfo")
+_PHYSICAL_CEILING_ENV = "DISPATCHER_PHYSICAL_MAX_SPAWNS"
+_AGENT_FOOTPRINT_MB_ENV = "DISPATCHER_AGENT_FOOTPRINT_MB"
+
+DEFAULT_AGENT_FOOTPRINT_MB = 256
+# Conservative box-safe default when /proc/meminfo is unavailable and no
+# explicit ceiling is configured. Sized for ~1GB free / 256MB per agent.
+DEFAULT_PHYSICAL_CEILING = 4
+
+
+def _read_available_mb() -> int | None:
+    """Read MemAvailable from /proc/meminfo. Returns None on any error."""
+    try:
+        for line in _MEMINFO_PATH.read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                return int(line.split()[1]) // 1024
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def get_physical_ceiling() -> int:
+    """Resolve the physical max-concurrent-spawns ceiling for this box."""
+    explicit = os.environ.get(_PHYSICAL_CEILING_ENV, "").strip()
+    if explicit:
+        try:
+            return max(1, int(explicit))
+        except ValueError:
+            logger.warning(
+                "invalid %s=%r — ignoring, computing from RAM", _PHYSICAL_CEILING_ENV, explicit
+            )
+
+    footprint_mb = DEFAULT_AGENT_FOOTPRINT_MB
+    raw = os.environ.get(_AGENT_FOOTPRINT_MB_ENV, "").strip()
+    if raw:
+        try:
+            footprint_mb = max(1, int(raw))
+        except ValueError:
+            logger.warning(
+                "invalid %s=%r — using default %dMB",
+                _AGENT_FOOTPRINT_MB_ENV,
+                raw,
+                DEFAULT_AGENT_FOOTPRINT_MB,
+            )
+
+    available_mb = _read_available_mb()
+    if available_mb is not None:
+        ceiling = max(1, available_mb // footprint_mb)
+        logger.debug(
+            "physical ceiling: %dMB available / %dMB per agent = %d concurrent",
+            available_mb,
+            footprint_mb,
+            ceiling,
+        )
+        return ceiling
+
+    logger.warning(
+        "physical ceiling: /proc/meminfo unavailable, using conservative default %d",
+        DEFAULT_PHYSICAL_CEILING,
+    )
+    return DEFAULT_PHYSICAL_CEILING
+
+
+def check_physical_ceiling(active_count: int) -> tuple[bool, str]:
+    """Return (can_spawn, reason). False means the spawn must be refused.
+
+    Called at spawn admission with the current count of active spawns.
+    The ceiling is re-read on every call so it adapts to live RAM pressure.
+    Applies regardless of tenant tier — even the uncapped operator is bounded
+    by what the box can physically hold without OOM.
+    """
+    ceiling = get_physical_ceiling()
+    if active_count >= ceiling:
+        return False, (
+            f"physical RAM ceiling reached: {active_count}/{ceiling} active spawns "
+            f"(box OOM guard — set {_PHYSICAL_CEILING_ENV} or free RAM to raise)"
+        )
+    return True, ""

--- a/tests/dispatcher/test_physical_ceiling.py
+++ b/tests/dispatcher/test_physical_ceiling.py
@@ -1,0 +1,125 @@
+"""Tests for the physical RAM ceiling (Agency_OS-cuit)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.dispatcher import physical_ceiling as pc
+
+# --- _read_available_mb ---
+
+
+def test_reads_available_mb_from_proc_meminfo(tmp_path):
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemTotal:       16370196 kB\n"
+        "MemFree:         2299564 kB\n"
+        "MemAvailable:    4096000 kB\n"
+        "Buffers:          197352 kB\n"
+    )
+    with patch.object(pc, "_MEMINFO_PATH", meminfo):
+        assert pc._read_available_mb() == 4000  # 4096000 kB // 1024
+
+
+def test_returns_none_when_meminfo_missing(tmp_path):
+    with patch.object(pc, "_MEMINFO_PATH", tmp_path / "no_meminfo"):
+        assert pc._read_available_mb() is None
+
+
+def test_returns_none_on_malformed_meminfo(tmp_path):
+    bad = tmp_path / "meminfo"
+    bad.write_text("NotAMemInfoFile: garbage\n")
+    with patch.object(pc, "_MEMINFO_PATH", bad):
+        assert pc._read_available_mb() is None
+
+
+# --- get_physical_ceiling ---
+
+
+def test_explicit_env_takes_priority(monkeypatch, tmp_path):
+    monkeypatch.setenv(pc._PHYSICAL_CEILING_ENV, "7")
+    # Even if /proc/meminfo would give a different answer, explicit wins.
+    assert pc.get_physical_ceiling() == 7
+
+
+def test_explicit_env_clamped_to_at_least_1(monkeypatch):
+    monkeypatch.setenv(pc._PHYSICAL_CEILING_ENV, "0")
+    assert pc.get_physical_ceiling() == 1
+
+
+def test_invalid_explicit_env_falls_through_to_ram(monkeypatch, tmp_path):
+    monkeypatch.setenv(pc._PHYSICAL_CEILING_ENV, "not-a-number")
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("MemAvailable:    2048000 kB\n")  # 2000 MB
+    monkeypatch.setenv(pc._AGENT_FOOTPRINT_MB_ENV, "256")
+    with patch.object(pc, "_MEMINFO_PATH", meminfo):
+        assert pc.get_physical_ceiling() == 7  # 2000 // 256
+
+
+def test_computed_from_available_ram(monkeypatch, tmp_path):
+    monkeypatch.delenv(pc._PHYSICAL_CEILING_ENV, raising=False)
+    monkeypatch.setenv(pc._AGENT_FOOTPRINT_MB_ENV, "256")
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("MemAvailable:    1024000 kB\n")  # 1000 MB
+    with patch.object(pc, "_MEMINFO_PATH", meminfo):
+        assert pc.get_physical_ceiling() == 3  # 1000 // 256
+
+
+def test_fallback_default_when_meminfo_missing(monkeypatch, tmp_path):
+    monkeypatch.delenv(pc._PHYSICAL_CEILING_ENV, raising=False)
+    with patch.object(pc, "_MEMINFO_PATH", tmp_path / "absent"):
+        assert pc.get_physical_ceiling() == pc.DEFAULT_PHYSICAL_CEILING
+
+
+def test_custom_footprint_env(monkeypatch, tmp_path):
+    monkeypatch.delenv(pc._PHYSICAL_CEILING_ENV, raising=False)
+    monkeypatch.setenv(pc._AGENT_FOOTPRINT_MB_ENV, "512")
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("MemAvailable:    2048000 kB\n")  # 2000 MB
+    with patch.object(pc, "_MEMINFO_PATH", meminfo):
+        assert pc.get_physical_ceiling() == 3  # 2000 // 512
+
+
+# --- check_physical_ceiling ---
+
+
+def test_admits_spawn_below_ceiling(monkeypatch):
+    monkeypatch.setenv(pc._PHYSICAL_CEILING_ENV, "4")
+    ok, reason = pc.check_physical_ceiling(active_count=3)
+    assert ok is True
+    assert reason == ""
+
+
+def test_refuses_spawn_at_ceiling(monkeypatch):
+    monkeypatch.setenv(pc._PHYSICAL_CEILING_ENV, "4")
+    ok, reason = pc.check_physical_ceiling(active_count=4)
+    assert ok is False
+    assert "4/4" in reason
+    assert "OOM" in reason
+
+
+def test_refuses_spawn_above_ceiling(monkeypatch):
+    monkeypatch.setenv(pc._PHYSICAL_CEILING_ENV, "4")
+    ok, reason = pc.check_physical_ceiling(active_count=10)
+    assert ok is False
+
+
+def test_ceiling_of_one_admits_first_then_refuses(monkeypatch):
+    monkeypatch.setenv(pc._PHYSICAL_CEILING_ENV, "1")
+    ok, _ = pc.check_physical_ceiling(active_count=0)
+    assert ok is True
+    ok, reason = pc.check_physical_ceiling(active_count=1)
+    assert ok is False
+    assert "1/1" in reason
+
+
+def test_reason_includes_env_hint(monkeypatch):
+    monkeypatch.setenv(pc._PHYSICAL_CEILING_ENV, "2")
+    _, reason = pc.check_physical_ceiling(active_count=2)
+    assert pc._PHYSICAL_CEILING_ENV in reason
+
+
+def test_zero_active_always_admits(monkeypatch):
+    monkeypatch.setenv(pc._PHYSICAL_CEILING_ENV, "4")
+    ok, _ = pc.check_physical_ceiling(active_count=0)
+    assert ok is True


### PR DESCRIPTION
## Summary

Physical max-concurrent-spawns ceiling sized to available box RAM — separate from the tenant tier ceiling (which is uncapped for the operator per #1285). The dispatcher refuses a spawn with 503 if it would exceed what the box can safely hold, regardless of tenant tier.

**Why separate from tier ceiling:** the tier ceiling (#1285) is a customer-isolation policy gate (can be uncapped for the operator). This is a box-level safety gate — the OS will OOM regardless of tenant policy.

## What ships

- `src/dispatcher/physical_ceiling.py` — `check_physical_ceiling(active_count)` + `get_physical_ceiling()`:
  - Reads `MemAvailable` from `/proc/meminfo` live at admission (adapts to RAM pressure)
  - Priority: `DISPATCHER_PHYSICAL_MAX_SPAWNS` env (explicit) > computed from RAM / `DISPATCHER_AGENT_FOOTPRINT_MB` (default 256MB) > `DEFAULT_PHYSICAL_CEILING=4` (conservative fallback)
  - **Never fail-open**: if `/proc/meminfo` is unavailable AND no explicit ceiling is set, falls back to 4 — not unlimited
- `src/dispatcher/main.py` — `check_physical_ceiling(len(_spawned))` wired immediately before `manager.spawn()`, after budget gate. Returns **503** on breach (work-loop consumer can back off + retry)
- `tests/dispatcher/test_physical_ceiling.py` — 15 tests: `/proc/meminfo` read, env priority chain, RAM computation, fallback, admit/refuse boundary, env-hint in reason string

## Config

| Env | Default | Purpose |
|-----|---------|---------|
| `DISPATCHER_PHYSICAL_MAX_SPAWNS` | (computed) | Explicit ceiling override |
| `DISPATCHER_AGENT_FOOTPRINT_MB` | 256 | Per-agent RAM footprint for computation |

Box currently has ~4.2GB MemAvailable → ceiling ≈ 16 at 256MB/agent. Set `DISPATCHER_PHYSICAL_MAX_SPAWNS=4` to match the rehearsal pre-condition.

## Test plan
- [x] 15 unit tests green, ruff clean
- [ ] Elliot / Max concur
- [ ] Set `DISPATCHER_PHYSICAL_MAX_SPAWNS=4` and verify 503 on 5th spawn in integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)