### PR TITLE
[NOVA] Wire vault boot auto-unseal; decouple unit from worktree (e3mq)

### DIFF
--- a/infra/systemd/agents/keiracom-vault-unseal.service
+++ b/infra/systemd/agents/keiracom-vault-unseal.service
@@ -1,18 +1,26 @@
 [Unit]
 Description=Auto-unseal the persistent Keiracom Vault on boot (P10 / bd lmce)
 Documentation=file:///home/elliotbot/clawd/Agency_OS/docs/runbooks/vault_persistence.md
-After=docker.service network-online.target
+# NB: docker.service is a SYSTEM unit and invisible to this --user manager, so we
+# do NOT order against it (it would be silently dropped). The boot race against the
+# container is handled instead by the seal-status poll loop inside the ExecStart
+# script + Restart=on-failure below.
+After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=300
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 Environment=VAULT_ADDR=http://127.0.0.1:8200
-ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/vault_auto_unseal.sh
+# Stable installed copy — deliberately NOT a git-worktree path. /home/elliotbot/clawd/
+# Agency_OS is shared by Elliot/Atlas and is frequently checked out onto feature
+# branches that don't contain this script, which would make a boot unseal fail.
+# install_vault_persistence.sh copies the canonical scripts/vault_auto_unseal.sh here.
+ExecStart=/home/elliotbot/.config/agency-os/vault_auto_unseal.sh
 # Retry a few times in case the vault container is slow to come up post-boot.
 Restart=on-failure
 RestartSec=10
-StartLimitIntervalSec=300
 StandardOutput=append:/home/elliotbot/clawd/logs/vault-unseal.log
 StandardError=append:/home/elliotbot/clawd/logs/vault-unseal.log
 

--- a/scripts/install_vault_persistence.sh
+++ b/scripts/install_vault_persistence.sh
@@ -17,10 +17,24 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VAULT_HOME="${HOME}/clawd/vault"
 UNITS_DIR="${HOME}/.config/systemd/user"
 LOG_DIR="${HOME}/clawd/logs"
+AGENCY_CFG_DIR="${HOME}/.config/agency-os"  # stable home for the boot unseal script + init keys
 
-mkdir -p "${VAULT_HOME}/config" "${VAULT_HOME}/data" "${UNITS_DIR}" "${LOG_DIR}"
-chmod 777 "${VAULT_HOME}/data"
-install -m 0644 "${REPO_DIR}/infra/vault/vault.hcl" "${VAULT_HOME}/config/vault.hcl"
+mkdir -p "${VAULT_HOME}/config" "${VAULT_HOME}/data" "${UNITS_DIR}" "${LOG_DIR}" "${AGENCY_CFG_DIR}"
+# Only meaningful on true first install (empty dir owned by us). On re-run the dir is
+# owned by the container's vault uid and this chmod is both unnecessary and not-permitted
+# — so it must be non-fatal under `set -e`.
+chmod 777 "${VAULT_HOME}/data" 2>/dev/null || true
+# First install only: once the container is running it takes ownership of the
+# bind-mounted config dir, so re-installing the hcl would fail (not-permitted) and is
+# unnecessary (the running vault is already using it). Skip if present.
+if [[ ! -f "${VAULT_HOME}/config/vault.hcl" ]]; then
+    install -m 0644 "${REPO_DIR}/infra/vault/vault.hcl" "${VAULT_HOME}/config/vault.hcl"
+fi
+
+# Copy the unseal script to a stable, worktree-independent path (the unit's ExecStart
+# targets this, NOT the repo path — see keiracom-vault-unseal.service for why).
+install -m 0755 "${REPO_DIR}/scripts/vault_auto_unseal.sh" \
+    "${AGENCY_CFG_DIR}/vault_auto_unseal.sh"
 
 if ! sg docker -c "docker ps -a --format '{{.Names}}'" | grep -qx keiracom-vault; then
     echo "starting keiracom-vault (file storage)..."


### PR DESCRIPTION
## Summary
Last gate before the reboot-test (P11). #1289/lmce *described* boot auto-unseal but it was never installed/enabled, and the unit had a latent boot-failure bug.

**Root cause:** `keiracom-vault-unseal.service` had `ExecStart=/home/elliotbot/clawd/Agency_OS/scripts/vault_auto_unseal.sh` — but that worktree is shared by Elliot/Atlas and is routinely on feature branches that don't contain the script (it's on `atlas/wave5-*` right now). On reboot the unit would fail ENOENT → vault stays **SEALED** → P10 cold-cred resolution breaks fleet-wide.

## Fixes
- **Unit `ExecStart` → stable, worktree-independent path** `~/.config/agency-os/vault_auto_unseal.sh` (beside the 0600 init keys it reads).
- Dropped `After=docker.service` (a SYSTEM unit — silently ignored by the `--user` manager; the boot race is already handled by the script's seal-status poll loop + `Restart=on-failure`). Moved `StartLimitIntervalSec` to `[Unit]`.
- `install_vault_persistence.sh`: copies the canonical `scripts/vault_auto_unseal.sh` to the stable path; made the `chmod` + `vault.hcl` install **idempotent** (they failed under `set -e` on re-run because the running container owns the bind-mounted dirs).

The container restart policy was **already `unless-stopped`** (the premise said "looks unset" — it is set), so it starts on boot; this PR fixes the unseal half.

## Verified on host (proven end-to-end, not just enabled)
```
[1] systemctl --user is-enabled keiracom-vault-unseal.service  -> enabled
    default.target.wants/keiracom-vault-unseal.service symlink present
[2] docker inspect keiracom-vault  -> RestartPolicy=unless-stopped  Cmd=[server]  running
[3] seal-test (simulates boot):
    sealed=True  -> systemctl --user restart keiracom-vault-unseal.service (re-runs fresh)
    sealed=False -> cold-resolve readback anthropic/api_key len=108  (functional)
```
Note: a manual `systemctl start` on an already-active `RemainAfterExit=yes` oneshot is a no-op; `restart` (or a real boot) re-runs ExecStart. Verified via `restart`.

## Test plan
- [x] `is-enabled` = enabled + boot symlink present
- [x] restart policy = unless-stopped
- [x] controlled seal → unit → unsealed + functional readback
- [ ] Full reboot-test (P11) — this PR is the prerequisite

🤖 Generated with [Claude Code](https://claude.com/claude-code)