### PR TITLE
[NOVA] fix(cognee): --once fail-closed on health-down (Agency_OS-8egh part B)

### DIFF
--- a/scripts/cognee_auto_ingest.py
+++ b/scripts/cognee_auto_ingest.py
@@ -6,7 +6,9 @@ Two modes:
   --watch : inotify-watch the governance dirs and ingest individual files on modify
 
 Uses the Cognee HTTP API via cognee_http_client to avoid the SDK lock conflict.
-Fail-open per file; logs successes + failures to stderr.
+Fail-open per file; logs successes + failures to stderr. --once is fail-CLOSED
+on infra: if Cognee health is down it ingests nothing and exits non-zero, so
+drift/cron callers see a real failure instead of a silent green no-op.
 """
 
 from __future__ import annotations
@@ -235,7 +237,13 @@ def main() -> int:
     )
     args = p.parse_args()
     if args.once:
-        run_once(batch_size=args.batch_size, settle=args.settle)
+        stats = run_once(batch_size=args.batch_size, settle=args.settle)
+        # Fail-closed: a health-down run ingested nothing, so a silent 0 would
+        # let drift alerts "self-heal" green while the facts stay stale
+        # (Agency_OS-8egh). Non-zero surfaces the infra failure to callers.
+        if stats.get("skipped_unhealthy"):
+            log.error("once aborted: cognee health down — nothing ingested")
+            return 1
         return 0
     if args.watch:
         watch_loop()

--- a/tests/scripts/test_cognee_auto_ingest_fail_closed.py
+++ b/tests/scripts/test_cognee_auto_ingest_fail_closed.py
@@ -1,0 +1,51 @@
+"""Tests for cognee_auto_ingest --once fail-closed behavior (Agency_OS-8egh).
+
+Before this fix --once always returned 0, so a drift cron would see a green
+no-op even when Cognee was down and nothing was ingested. --once must now exit
+non-zero when Cognee health is down. --watch behavior is unchanged (fail-open).
+
+No live Cognee dependency — health + targets are monkeypatched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "cognee_auto_ingest.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("cognee_auto_ingest", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["cognee_auto_ingest"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_once_returns_nonzero_when_cognee_down(mod, monkeypatch):
+    """Health down -> nothing ingested -> rc != 0 (fail-closed)."""
+    monkeypatch.setattr(mod, "cognee_health", lambda: {"status": "down", "error": "refused"})
+    monkeypatch.setattr(sys, "argv", ["cognee_auto_ingest", "--once"])
+    assert mod.main() != 0
+
+
+def test_once_returns_zero_when_healthy_and_no_targets(mod, monkeypatch):
+    """Health ready + empty target set -> clean rc 0 (no false failure)."""
+    monkeypatch.setattr(mod, "cognee_health", lambda: {"status": "ready"})
+    monkeypatch.setattr(mod, "targets", lambda: [])
+    monkeypatch.setattr(sys, "argv", ["cognee_auto_ingest", "--once"])
+    assert mod.main() == 0
+
+
+def test_run_once_flags_skipped_unhealthy(mod, monkeypatch):
+    """run_once surfaces the skipped_unhealthy sentinel main() keys off."""
+    monkeypatch.setattr(mod, "cognee_health", lambda: {"status": "down"})
+    stats = mod.run_once()
+    assert stats.get("skipped_unhealthy") is True
+    assert stats.get("ok") == 0


### PR DESCRIPTION
## Summary
- `cognee_auto_ingest.py --once` always returned `0`, even when Cognee was **down** and nothing was ingested — so a drift cron sees a green no-op while the facts stay stale.
- `main()` now returns non-zero when `run_once` reports `skipped_unhealthy` (the existing health-down sentinel). `--watch` mode and per-file fail-open are **unchanged**.
- Added a focused regression test (no live Cognee dependency).

This is **part (B)** of `Agency_OS-8egh` (Cognee drift self-heal). **Part (A)** — RAM-safe boot-enable of `cognee.service` — is intentionally NOT in this PR; it touches the systemd unit and must be coordinated with Aiden's OOM-guard (#1298) design first (Elliot dispatch 2026-05-29).

## Root cause
`run_once()` already returned `{"skipped_unhealthy": True}` on health-down, but `main()` discarded the return and hardcoded `return 0`.

## Test plan
- [x] `py_compile` clean
- [x] Live: with `cognee.service` down, `--once` now exits `1` (was `0`)
- [x] `pytest tests/scripts/test_cognee_auto_ingest_fail_closed.py` — 3 passed (health-down→rc≠0, healthy+no-targets→rc 0, `skipped_unhealthy` sentinel)
- [ ] Full ingest smoke (Cognee up) — DEFERRED until after Atlas's loop smoke clears (RAM constraint; Cognee peaks 2.6 GB vs ~3.7 GB free)

## Review
Orchestrator-merge-after-NATS-concur: needs 2-of-3 deliberator concur (Elliot / Aiden / Max) → Elliot admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)