### PR TITLE
[NOVA] feat(listener): wire #ceo TASK: -> public.tasks via ceo_capture_listener (evbn)

### DIFF
--- a/scripts/elliot_socket_listener.py
+++ b/scripts/elliot_socket_listener.py
@@ -14,6 +14,11 @@ Filter chain (all must pass):
   - Keep non-bot messages (Dave/human posts) — these are inboxed unconditionally
   - Channel allowlist: #execution + #ceo
 
+Special-case (Agency_OS-evbn): a human `TASK:`-prefixed message in #ceo is
+routed to ceo_capture_listener.create_task_from_message() — it inserts one
+public.tasks row (drives the kei45 work-loop, skips Linear) and is NOT inboxed
+(it is a command, not a message for Elliot).
+
 Latency: ~50-500ms (WebSocket push) vs 0.5-8s (poll). Zero polling pressure.
 
 Env:
@@ -39,6 +44,12 @@ from slack_sdk.socket_mode import SocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web import WebClient
+
+# Sibling module in scripts/ — provides the #ceo direct task-creator
+# (Agency_OS-evbn). Importing it has no heavy deps (slack_sdk is lazy-imported
+# only inside its main(); psycopg only inside create_task_from_message).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import ceo_capture_listener  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("elliot-socket-listener")
@@ -102,6 +113,19 @@ def process_event(event: dict) -> None:
     if not text:
         return
     has_bot = bool(event.get("bot_id"))
+    # Direct Slack->task creator (Agency_OS-evbn): a human 'TASK:' message in
+    # #ceo inserts one public.tasks row (drives the kei45 work-loop, skips
+    # Linear). Terminal like ceo_capture_listener.handle_event — it is a command,
+    # so it is NOT also inboxed to Elliot (avoids double-handling). Fail-open:
+    # create_task_from_message never raises.
+    if (
+        channel == ceo_capture_listener.CEO_CHANNEL
+        and not has_bot
+        and ceo_capture_listener.is_task_command(text)
+    ):
+        task_id = ceo_capture_listener.create_task_from_message(text)
+        logger.info("ceo TASK: -> task=%s", task_id or "FAILED")
+        return
     if not should_keep(text, has_bot):
         return
     write_inbox(text, sender_from(event))

--- a/tests/scripts/test_elliot_socket_listener_ceo_task.py
+++ b/tests/scripts/test_elliot_socket_listener_ceo_task.py
@@ -1,0 +1,76 @@
+"""Tests for the #ceo TASK: wiring in scripts/elliot_socket_listener.py (evbn).
+
+A human 'TASK:'-prefixed message in #ceo must call
+ceo_capture_listener.create_task_from_message() (insert a public.tasks row) and
+must NOT also be inboxed (it is a command, not a message for Elliot). Everything
+else must keep its existing inbox behavior. Bot posts and non-#ceo channels must
+NOT create tasks.
+
+create_task_from_message + write_inbox are monkeypatched — no live DB/Slack.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "elliot_socket_listener.py"
+EXEC_CHANNEL = "C0B3QB0K1GQ"  # #execution (in the allowlist, not #ceo)
+
+
+def _boom(*_a, **_k):
+    raise AssertionError("must not be called")
+
+
+@pytest.fixture(scope="module")
+def E():
+    spec = importlib.util.spec_from_file_location("_elliot_socket_listener", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _event(text, *, channel, bot_id=None):
+    e = {"type": "message", "channel": channel, "text": text}
+    if bot_id:
+        e["bot_id"] = bot_id
+    return e
+
+
+def test_human_ceo_task_creates_task_and_is_not_inboxed(E, monkeypatch):
+    created = []
+    monkeypatch.setattr(E.ceo_capture_listener, "create_task_from_message", lambda t: created.append(t) or "ceo-task-1")
+    monkeypatch.setattr(E, "write_inbox", _boom)
+    E.process_event(_event("TASK: wire the dispatcher probe", channel=E.ceo_capture_listener.CEO_CHANNEL))
+    assert created == ["TASK: wire the dispatcher probe"]
+
+
+def test_ceo_non_task_still_inboxed_and_no_task(E, monkeypatch):
+    inboxed = []
+    monkeypatch.setattr(E, "write_inbox", lambda text, sender: inboxed.append(text))
+    monkeypatch.setattr(E.ceo_capture_listener, "create_task_from_message", _boom)
+    E.process_event(_event("elliot please review the plan", channel=E.ceo_capture_listener.CEO_CHANNEL))
+    assert inboxed == ["elliot please review the plan"]
+
+
+def test_task_prefix_in_non_ceo_channel_does_not_create_task(E, monkeypatch):
+    monkeypatch.setattr(E.ceo_capture_listener, "create_task_from_message", _boom)
+    inboxed = []
+    monkeypatch.setattr(E, "write_inbox", lambda text, sender: inboxed.append(text))
+    E.process_event(_event("TASK: do x outside ceo", channel=EXEC_CHANNEL))
+    assert inboxed == ["TASK: do x outside ceo"]  # treated as a normal message
+
+
+def test_bot_task_in_ceo_does_not_create_task(E, monkeypatch):
+    monkeypatch.setattr(E.ceo_capture_listener, "create_task_from_message", _boom)
+    monkeypatch.setattr(E, "write_inbox", _boom)  # bot non-trigger msg is dropped by should_keep
+    E.process_event(_event("TASK: from a fleet bot", channel=E.ceo_capture_listener.CEO_CHANNEL, bot_id="B123"))
+
+
+def test_ceo_task_create_failure_is_non_fatal_and_not_inboxed(E, monkeypatch):
+    monkeypatch.setattr(E.ceo_capture_listener, "create_task_from_message", lambda t: None)
+    monkeypatch.setattr(E, "write_inbox", _boom)
+    E.process_event(_event("TASK: db is down", channel=E.ceo_capture_listener.CEO_CHANNEL))  # no raise


### PR DESCRIPTION
## Summary
`ceo_capture_listener.create_task_from_message()` shipped in PR #1291 (9.6 KB) but **nothing in the live path called it**. This wires it into `elliot_socket_listener.process_event`:

- A **human** `TASK:`-prefixed message in **#ceo** now calls `ceo_capture_listener.create_task_from_message(text)` → inserts one `public.tasks` row (`status='available'`, fires the kei45 work-loop trigger, skips Linear per Agency_OS-evbn).
- It is **terminal**: the TASK: message is NOT also inboxed to Elliot (mirrors `ceo_capture_listener.handle_event`, which treats TASK: as create-and-stop). This avoids Elliot double-handling a command.
- **Unaffected:** non-TASK #ceo messages still inbox as before; bot posts and non-#ceo channels never create tasks.
- **Fail-open:** `create_task_from_message` never raises (param-bound INSERT, injection-safe); the listener's never-crash ethos is preserved.

Channel gate uses `ceo_capture_listener.CEO_CHANNEL` as the single source of truth for the #ceo id.

## Claim-before-touch (intent)
`scripts/elliot_socket_listener.py` is in **Elliot's namespace**. I am editing it under direct dispatch from Elliot (2026-05-29) to wire in the evbn task-creator. Change is scoped to one guarded branch in `process_event` + a docstring note + a sibling import — no change to existing inbox/filter behavior for any non-TASK path.

## cc Atlas
**@Atlas** — this runs **in parallel with your bridge fix**. We both touch the #ceo→work-loop path: I add the listener call-site that inserts the `public.tasks` row; your bridge handles the downstream side. Flagging so we don't collide — shout if your branch also edits `elliot_socket_listener.py` or `ceo_capture_listener.py`.

## Test plan
- [x] `py_compile` clean on both scripts
- [x] 5 new wiring tests (`tests/scripts/test_elliot_socket_listener_ceo_task.py`): human TASK:→task+no-inbox, non-TASK→inbox+no-task, TASK: in #execution→no-task, bot TASK:→no-task, create-failure→non-fatal+no-inbox
- [x] Existing `tests/scripts/test_ceo_capture_listener.py` still green — **23 passed** total
- [ ] Live #ceo smoke (post a real `TASK:` and confirm a `public.tasks` row) — operator/Elliot-gated post-merge

## Review
Orchestrator-merge-after-NATS-concur: **two deliberator concurs** (of Elliot / Aiden / Max) required before Elliot admin-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)