### PR TITLE
[ATLAS] fix(work-loop): bridge unit session-DSN override for asyncpg LISTEN (Agency_OS-nkc0)

### DIFF
--- a/systemd/keiracom-work-loop-bridge.service
+++ b/systemd/keiracom-work-loop-bridge.service
@@ -19,6 +19,13 @@ StartLimitIntervalSec=300
 [Service]
 Type=simple
 EnvironmentFile=/home/elliotbot/.config/agency-os/.env
+# Bridge-only override: a SESSION-mode DSN (:5432) so asyncpg LISTEN/NOTIFY works.
+# The Supabase TRANSACTION pooler (:6543, the .env default) silently drops LISTEN —
+# Supavisor hands a different backend per txn, so the registration is never pinned.
+# Later EnvironmentFile wins, so SUPABASE_DB_DSN here overrides the .env one for THIS
+# unit only; the global txn pooler stays the default for every other service.
+# Optional (leading '-'): absent file is non-fatal. Holds no secret — only a path.
+EnvironmentFile=-/home/elliotbot/.config/agency-os/work-loop-bridge.env
 WorkingDirectory=/home/elliotbot/clawd/Agency_OS
 ExecStart=/usr/bin/python3 -B -m src.keiracom_system.work_loop.bridge
 


### PR DESCRIPTION
## Summary
- The work-loop bridge `LISTEN`s on the Postgres `task_event` channel, but the `.env` DSN is the Supabase **transaction pooler (`:6543`)**, which silently drops `LISTEN` (Supavisor hands a different backend per transaction, so the registration is never pinned → notifies never delivered).
- Adds a **bridge-scoped** `EnvironmentFile` pointing at a session-mode DSN (`:5432`) override file, so `asyncpg LISTEN` works. Isolated to this unit only — the global txn pooler stays the default for every other service.
- The override file (`/home/elliotbot/.config/agency-os/work-loop-bridge.env`) holds the secret **off-repo**; this change is **path-only, no secrets**.
- Makes the live-smoke fix durable: without it, a future `install_work_loop.sh` re-run would revert the installed unit to the broken txn-pooler DSN.

## Context
Found + fixed during the nkc0 work-loop live smoke (2026-05-29). After this fix + applying the kei45 trigger migration to prod, the **full end-to-end smoke PASSED**: `INSERT public.tasks(status=available)` → kei45 trigger → bridge `LISTEN`(session) → Valkey publish → consumer admit (tier-gate/lock/lease) → `/dispatcher/spawn` → env-`i` scrubbed-tmux spawn (P10: bootstrap present, creds scrubbed) → clean agent exit.

## Test plan
- [x] Proved `:5432` session pooler delivers a notify via `asyncpg add_listener` + `pg_notify` round-trip; `:6543` does not.
- [x] Installed unit with this override → bridge log `work-loop bridge LISTENing on PG 'task_event'` + `published a new_available task`.
- [x] Full loop smoke spawned a scrubbed agent that exited clean.
- [ ] Reviewer: confirm later `EnvironmentFile` wins for `SUPABASE_DB_DSN` (systemd ordering) and the `-` prefix keeps an absent file non-fatal.

Note: real-agent go-live is still gated on `agent_cold_start` (Agency_OS-yhm8); the smoke used a vault-resolve probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)