### PR TITLE
[ATLAS] fix(work-loop): fetch_task selected non-existent task_type column (yhm8)

### DIFF
--- a/src/keiracom_system/vault/agent_cold_start.py
+++ b/src/keiracom_system/vault/agent_cold_start.py
@@ -46,7 +46,9 @@ logger = logging.getLogger(__name__)
 
 AGENT_WORKDIR = os.environ.get("DISPATCHER_AGENT_WORKDIR", "/home/elliotbot/clawd/Agency_OS")
 CLAUDE_BIN = os.environ.get("CLAUDE_BIN", "claude")
-_TASK_COLS = ("id", "title", "description", "task_type", "priority", "acceptance_criteria")
+# NB: public.tasks has NO task_type column — task_type is derived from tags and
+# reaches the agent via the AGENT_TASK_TYPE env var (injected by the dispatcher).
+_TASK_COLS = ("id", "title", "description", "priority", "acceptance_criteria")
 
 # Exit codes (distinct from a claude rc so the loop can tell apart cold-start
 # failures from agent failures): 0 ok / claim-lost; 2 no task id; 3 task absent.
@@ -76,7 +78,7 @@ def fetch_task(task_id: str, *, conn: Any = None) -> dict | None:
     try:
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT id, title, description, task_type, priority, acceptance_criteria "
+                "SELECT id, title, description, priority, acceptance_criteria "
                 "FROM public.tasks WHERE id = %s",
                 (task_id,),
             )
@@ -181,6 +183,7 @@ def run(
     if task is None:
         logger.error("agent_cold_start: task %s not found", task_id)
         return RC_TASK_ABSENT
+    task["task_type"] = os.environ.get("AGENT_TASK_TYPE", "build")  # not a tasks column
     if not claim(task_id, os.environ.get("AGENT_CALLSIGN")):
         logger.warning(
             "agent_cold_start: task %s not claimable (already taken) — exiting clean", task_id

--- a/tests/keiracom_system/vault/test_agent_cold_start.py
+++ b/tests/keiracom_system/vault/test_agent_cold_start.py
@@ -42,15 +42,32 @@ def test_compose_prompt_tolerates_missing_optionals():
 
 
 def test_fetch_task_found_maps_columns():
-    conn, _ = _fake_conn(fetchone=("t-1", "Title", "Desc", "build", 2, None))
+    conn, cur = _fake_conn(fetchone=("t-1", "Title", "Desc", 2, None))
     assert acs.fetch_task("t-1", conn=conn) == {
         "id": "t-1",
         "title": "Title",
         "description": "Desc",
-        "task_type": "build",
         "priority": 2,
         "acceptance_criteria": None,
     }
+    # regression guard: public.tasks has NO task_type column — must not be selected
+    assert "task_type" not in cur.execute.call_args[0][0]
+
+
+def test_run_sets_task_type_from_env(monkeypatch):
+    # task_type is not a tasks column; it must come from the AGENT_TASK_TYPE env var.
+    monkeypatch.setenv("AGENT_TASK_ID", "t-1")
+    monkeypatch.setenv("AGENT_TASK_TYPE", "review")
+    monkeypatch.setattr(acs.sys, "argv", ["agent_cold_start"])
+    seen = {}
+    acs.run(
+        resolve=lambda: None,
+        fetch=lambda _t: {"id": "t-1", "acceptance_criteria": None},
+        claim=lambda _t, _c: True,
+        agent=lambda prompt: seen.update(prompt=prompt) or 0,
+        finalize=lambda *a: None,
+    )
+    assert "review" in seen["prompt"]  # AGENT_TASK_TYPE flowed into the prompt
 
 
 def test_fetch_task_absent_returns_none():


### PR DESCRIPTION
## Root cause (rehearsal stall)
Rehearsal task `ceo-task-1780047174462` stayed `available` and the consumer kept respawning. `agent_cold_start.fetch_task` ran `SELECT id, title, description, task_type, priority, acceptance_criteria` — but **`public.tasks` has no `task_type` column** (it's derived from `tags`). The SELECT raised `psycopg.errors.UndefinedColumn`, so `fetch_task` crashed **before** the claim step → the agent exited non-zero with its traceback going to a now-dead tmux pane → the task never claimed → the consumer retried forever.

**Not an `AGENT_TASK_ID` bug** (the earlier hypothesis): verified empirically that `AGENT_TASK_ID=ceo-task-...` *does* reach the scrubbed agent and `DATABASE_URL` resolves from vault.

## Why it wasn't caught earlier
The unit tests mocked the DB cursor, so the bad column name was never executed against the real schema. Reproducing under the real `env -i` scrub surfaced it immediately — empirical > paper review.

## Fix
- Drop `task_type` from the SELECT and `_TASK_COLS` (it's not a column).
- Source `task_type` from the `AGENT_TASK_TYPE` env var the dispatcher already injects (bridge derives it from `tags`).
- Regression guard test: asserts `task_type` is not in the SELECT.
- New test: `AGENT_TASK_TYPE` flows into the composed prompt.

## Test plan
- [x] `ruff check` clean, `ruff format --check` clean, **15 unit tests pass**.
- [x] Empirical repro under the real scrubbed env against the live task: `resolve_into_env` ✓ → `fetch_task` FOUND ✓ → claim `rowcount=1` (rolled back) ✓. Pre-claude path now works end-to-end.

## Follow-up (flagged, not in this PR)
The agent crashed **invisibly** (traceback to a dead tmux pane; task silently stuck). Recommend a diagnosability KEI: `agent_cold_start` should log to a persistent file and/or `run()` should catch fetch/claim errors with a distinct exit code, so future spawn failures are visible without live reproduction.

Unblocks Agency_OS-yhm8 go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)