### PR TITLE
[ATLAS] fix(infra): reliable inbox-watcher injection — verify+retry+heartbeat+no-silent-drop (jne8+swi6)

### DIFF
--- a/scripts/inbox_watcher.sh
+++ b/scripts/inbox_watcher.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# inbox_watcher.sh <callsign> — per-callsign inbox -> tmux pane dispatch injector.
+#
+# Canonical, VERSIONED source for every *-inbox-watcher.service. One parameterised
+# script replaces the 7 byte-identical-modulo-callsign host copies. Install via
+# scripts/install_inbox_watchers.sh (copies to a stable host path + points the
+# units at it — must NOT run from a git worktree, which drifts branches).
+#
+# Reliability fixes (Agency_OS-jne8 + swi6):
+#   jne8 — the bare `send-keys ... ; sleep ; C-m` did not always COMMIT (the Enter
+#          races claude's permission prompts / render). Now: after C-m, capture the
+#          input region and RETRY C-m up to MAX_COMMIT_RETRIES if the text is still
+#          sitting unsubmitted (an extra Enter on an already-empty prompt is a no-op).
+#   swi6 — the file was moved to processed/ UNCONDITIONALLY, so a non-committed
+#          dispatch was silently lost. Now: committed -> processed/, NOT committed
+#          -> failed/ (never silently dropped), and EVERY file is logged (heartbeat)
+#          so a stalled agent is detectable instead of invisible.
+set -uo pipefail
+
+CALLSIGN="${1:?usage: inbox_watcher.sh <callsign>}"
+RELAY="/tmp/telegram-relay-${CALLSIGN}"
+INBOX="$RELAY/inbox"
+PROCESSED="$RELAY/processed"
+FAILED="$RELAY/failed"
+TMUX_TARGET="${CALLSIGN}:0.0"
+LOG="/home/elliotbot/clawd/logs/inbox_watcher_${CALLSIGN}.log"
+REPO="/home/elliotbot/clawd/Agency_OS"
+MAX_COMMIT_RETRIES=3
+PROMPT_WAIT_S=30
+
+mkdir -p "$INBOX" "$PROCESSED" "$FAILED" "$(dirname "$LOG")"
+
+log() { echo "$(date -u +%FT%TZ) [$CALLSIGN] $*" | tee -a "$LOG"; }
+
+hmac_ok() {  # $1=filepath -> 0 ok / 1 reject. No secret set = accept (dev/clone).
+    [ -z "${INBOX_HMAC_SECRET:-}" ] && return 0
+    python3 -c "
+import sys; sys.path.insert(0, '$REPO')
+from src.security.inbox_hmac import verify
+ok, reason = verify('$1')
+sys.exit(0 if ok else 1)
+" 2>/dev/null
+}
+
+extract_content() {  # $1=filepath -> dispatch text on stdout
+    python3 -c "
+import json
+try:
+    d = json.load(open('$1'))
+    kind = d.get('type') or d.get('kind') or ''
+    text = d.get('brief') or d.get('summary') or d.get('text') or json.dumps(d)
+    print(f'[DISPATCH FROM {d.get(\"from\",\"unknown\")}] {text}' if kind in ('task_dispatch','status','scrutiny_and_step0') else text)
+except Exception:
+    print(open('$1').read())
+" 2>/dev/null
+}
+
+# Inject content into the pane and VERIFY it committed. 0 = committed, 1 = not.
+inject_and_verify() {
+    local content="$1" probe attempt
+    # Wait (bounded) for claude's prompt so we don't type into a mid-render pane.
+    for _ in $(seq 1 "$PROMPT_WAIT_S"); do
+        tmux capture-pane -t "$TMUX_TARGET" -p 2>/dev/null | tail -5 | grep -q '❯' && break
+        sleep 1
+    done
+    tmux send-keys -t "$TMUX_TARGET" -l "$content" 2>/dev/null || return 1
+    sleep 0.4
+    # First ~40 chars as a commit probe: before Enter it sits on the input line;
+    # after Enter the input line clears (the message renders above). If it's still
+    # on the bottom lines after C-m+settle, the Enter didn't take — retry (jne8).
+    probe="$(printf '%s' "$content" | head -c 40)"
+    for attempt in $(seq 1 "$MAX_COMMIT_RETRIES"); do
+        tmux send-keys -t "$TMUX_TARGET" C-m 2>/dev/null
+        sleep 2
+        if ! tmux capture-pane -t "$TMUX_TARGET" -p 2>/dev/null | tail -3 | grep -qF "$probe"; then
+            [ "$attempt" -gt 1 ] && log "committed on C-m retry #$attempt"
+            return 0
+        fi
+        log "C-m attempt $attempt did not commit; retrying"
+    done
+    return 1
+}
+
+log "watcher started (target=$TMUX_TARGET, inbox=$INBOX)"
+inotifywait -m -e create -e moved_to "$INBOX" --format '%f' 2>/dev/null | while read -r FILE; do
+    FILEPATH="$INBOX/$FILE"
+    [ -f "$FILEPATH" ] || continue
+    log "received: $FILE"
+
+    if ! hmac_ok "$FILEPATH"; then
+        log "HMAC REJECT -> failed/: $FILE"
+        mv "$FILEPATH" "$FAILED/REJECTED_$FILE" 2>/dev/null
+        continue
+    fi
+
+    CONTENT="$(extract_content "$FILEPATH")"
+    if [ -z "$CONTENT" ]; then
+        log "EMPTY content -> failed/: $FILE"
+        mv "$FILEPATH" "$FAILED/EMPTY_$FILE" 2>/dev/null
+        continue
+    fi
+
+    if inject_and_verify "$CONTENT"; then
+        log "injected+committed -> processed/: $FILE"
+        mv "$FILEPATH" "$PROCESSED/" 2>/dev/null
+    else
+        log "INJECTION FAILED after $MAX_COMMIT_RETRIES retries -> failed/ (NOT dropped): $FILE"
+        mv "$FILEPATH" "$FAILED/" 2>/dev/null
+    fi
+done

--- a/scripts/install_inbox_watchers.sh
+++ b/scripts/install_inbox_watchers.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# install_inbox_watchers.sh — deploy the canonical inbox_watcher.sh for every
+# callsign (Agency_OS-jne8 + swi6). Copies the VERSIONED script to a stable host
+# path (NOT a git worktree — worktrees drift branches and would break delivery on
+# checkout), rewrites each *-inbox-watcher.service to call it, reloads + restarts.
+#
+# Idempotent. Backs up any pre-existing unit before rewriting. Run after the
+# inbox_watcher.sh PR merges (or locally to deploy the fix).
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOST_SCRIPT="/home/elliotbot/clawd/scripts/inbox_watcher.sh"
+UNITS_DIR="${HOME}/.config/systemd/user"
+CALLSIGNS=(atlas orion aiden max nova scout elliot)
+
+install -m 0755 "${REPO_DIR}/scripts/inbox_watcher.sh" "$HOST_SCRIPT"
+echo "installed canonical script -> $HOST_SCRIPT"
+
+mkdir -p "$UNITS_DIR"
+for cs in "${CALLSIGNS[@]}"; do
+    unit="${UNITS_DIR}/${cs}-inbox-watcher.service"
+    [ -f "$unit" ] && cp -a "$unit" "${unit}.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+    cat > "$unit" <<UNIT
+[Unit]
+Description=${cs^^} Inbox Watcher (inbox dispatch -> tmux pane injection, jne8+swi6)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${HOST_SCRIPT} ${cs}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+UNIT
+    echo "wrote unit: ${cs}-inbox-watcher.service -> ExecStart=${HOST_SCRIPT} ${cs}"
+done
+
+systemctl --user daemon-reload
+for cs in "${CALLSIGNS[@]}"; do
+    systemctl --user enable --now "${cs}-inbox-watcher.service" >/dev/null 2>&1 || true
+    systemctl --user restart "${cs}-inbox-watcher.service"
+    echo "${cs}-inbox-watcher: $(systemctl --user is-active "${cs}-inbox-watcher.service")"
+done
+echo "done — all callsign inbox watchers on the reliable injector"


### PR DESCRIPTION
## Problem (V1-critical)
Dispatches landed in inbox/ but never reached the agent tmux pane — Atlas idle ~20 min, dispatches silently lost. Root causes in per-callsign *_inbox_watcher.sh host scripts:
- **swi6:** file mv'd to processed/ UNCONDITIONALLY after send-keys → non-committed dispatch lost; ZERO per-file logging → invisible (journald empty since May 26).
- **jne8:** bare send-keys + C-m didn't always commit (Enter races claude's prompt/render) → message sat unsubmitted.

## Fix
One versioned, parameterized `scripts/inbox_watcher.sh <callsign>` replaces the 7 identical-modulo-callsign host copies:
- **(c)** heartbeat log per file (received / injected+committed / FAILED).
- **(b/jne8)** verify the C-m committed via capture-pane + retry up to 3× (extra Enter on empty prompt is a no-op).
- **(swi6)** committed → processed/; uncommitted / HMAC-reject / empty → failed/ — never silently dropped.
- `scripts/install_inbox_watchers.sh` deploys to a stable host path (NOT a git worktree — those drift branches) + wires all 7 units; idempotent, backs up units.

## Verification
- Scratch ❯-pane: valid→processed, empty→failed, heartbeat logged.
- Real atlas pane has ❯ (fast detect; the 33s in the bash test was an artifact).
- **(d) LIVE end-to-end:** a self-test dispatch was injected into the running atlas claude pane and arrived as a user message — log `received 12:26:43 → injected+committed 12:26:45`.
- **(e)** all 7 callsign watchers active on the new injector.
- `bash -n` clean on both scripts.

## Notes for review
- jne8 is assigned to Orion in bd; Elliot dispatched jne8+swi6 to me (STEP 0 PRE-CONFIRMED) — flag for bd reconciliation.
- Host scripts were previously unversioned; this brings the canonical injector into the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)