### PR TITLE
[NOVA] docs(readme): V1 chain architecture — Chat/Deliberator/Worker/Reviewer + AtomV1 handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,28 +60,32 @@ Agents are Claude Code sessions running under fixed callsigns. Deliberation tier
 
 ## Agent loop architecture (V1 chain)
 
-The runtime execution loop — distinct from the callsign org chart above — moves a request through four roles. The roles never share in-process state: each runs as an ephemeral spawn that exits after its turn and hands off through **AtomV1 atoms** in Hindsight plus task rows in Postgres.
+The runtime execution loop — distinct from the callsign org chart above — moves every request through a fixed chain: **Face → Aiden + Max (deliberate) → Worker → Orion + Atlas (review) → done.** The roles run as separate ephemeral spawns and never share in-process state; each exits after its turn and hands off through **AtomV1 pointers** carried over NATS, with the atoms themselves living in Hindsight.
 
 ```mermaid
 flowchart LR
-    User([Dave / #ceo]) --> Chat
-    Chat[Chat / Face<br/>Haiku listener] --> Delib[Deliberator<br/>the Floor]
-    Delib -->|task rows| Worker[Worker<br/>ephemeral spawn]
-    Worker --> Reviewer[Reviewer<br/>acceptance + concur]
-    Reviewer -->|mark done| Delib
+    User([Dave / #ceo]) --> Face[Face<br/>customer-facing]
+    Face --> Aiden[Aiden<br/>deliberate]
+    Aiden --> Max[Max<br/>challenge]
+    Max -->|CONCUR| Worker[Worker<br/>execute]
+    Worker --> Orion[Orion · spec]
+    Worker --> Atlas[Atlas · safety]
+    Orion --> Gate{DUAL CONCUR}
+    Atlas --> Gate
+    Gate -->|done| Slack([Result → Slack])
     Worker -.->|AtomV1 on exit| H[(Hindsight<br/>fleet_decisions)]
-    H -.->|Layer 2 recall on spawn| Worker
+    H -.->|atom recall at spawn| Worker
 ```
 
-**Chat (Face)** — the user-facing voice. A `claude-haiku-4-5` agent spawns per `#ceo` message via Slack Socket Mode, classifies with a full LLM pass, and either records a decision (writes an AtomV1 atom to Hindsight plus a `ceo_memory` audit row) or exits on noise. Rate-capped at 10 spawns/hour via Valkey. Face and the Floor are the same entity — Face is its voice, and it always returns one recommendation, never a pros-and-cons list. Trivial commands bypass the Floor entirely.
+**Face** — the customer-facing ephemeral agent. It receives Dave's intent from Slack (a `claude-haiku-4-5` agent spawns per `#ceo` message via Socket Mode, rate-capped at 10 spawns/hour via Valkey), classifies it as *answer / dispatch / clarify*, dispatches build work to Aiden, and reports completion back to Dave. It presents one recommendation, never a pros-and-cons list.
 
-**Deliberator (the Floor)** — the multi-agent deliberation layer. It turns a request into a concurred plan (which Face presents for confirmation), forces a single recommendation on evaluative questions, resolves or escalates an agent's mid-task decisions, recalculates the task tree when a plan changes, and is the *only* authority that may mark a task done.
+**Deliberators (Aiden + Max)** — two agents that must agree before any work is dispatched. **Aiden** (Deliberator 1, architect) produces a structured KEI work plan and is biased toward action. **Max** (Deliberator 2, challenger) stress-tests that KEI and returns CONCUR or BLOCK with one sentence per gap — he will not rubber-stamp. Both must CONCUR before the Worker is dispatched.
 
-**Worker** — an ephemeral agent spawned to execute one unblocked task. The work-loop consumer watches Postgres: a `trg_tasks_unblock_dependents` trigger publishes `task_id + callsign + tenant_id` to the Valkey `keiracom:tasks:available` queue; the consumer checks the tenant's tier ceiling and, if under the concurrent-spawn limit, calls `POST /dispatcher/spawn` (overflow is requeued, never dropped; a Valkey lock prevents duplicate spawns). Each spawn is hydrated by a 4-layer context contract — L1 system prompt, L2 Hindsight recall (3–5 atoms), L3 Valkey spend gate, L4 dispatcher wiring — fail-open at every layer.
+**Worker** — the executor. It receives an atom pointer, fetches the KEI from Hindsight, builds/writes/fixes, writes an AtomV1 atom on exit, and signals the reviewers. Operationally each Worker is an ephemeral spawn off the work-loop: a Postgres `trg_tasks_unblock_dependents` trigger publishes `task_id + callsign + tenant_id` to the Valkey `keiracom:tasks:available` queue; the consumer checks the tenant's tier ceiling and, if under the concurrent-spawn limit, calls `POST /dispatcher/spawn` (overflow is requeued, never dropped; a Valkey lock prevents duplicate spawns). Each spawn is hydrated by a 4-layer context contract — L1 system prompt, L2 Hindsight recall, L3 Valkey spend gate, L4 dispatcher wiring — fail-open at every layer.
 
-**Reviewer** — verification before work is accepted. The Floor checks a completed PR against its acceptance criteria, and runtime or governance PRs additionally require 2-of-3 deliberator concur (the orchestrator-merge-after-NATS-concur pattern) before an admin squash-merge.
+**Reviewers (Orion + Atlas)** — dual concur before anything is marked complete. **Orion** (Reviewer 1, spec) verifies the output against the KEI line by line. **Atlas** (Reviewer 2, quality + safety) checks production readiness — regressions, edge cases, data integrity. Each returns CONCUR or REJECT; **both** must CONCUR before merge/completion — neither concurs alone. Runtime and governance PRs ride this same dual-concur gate (the orchestrator-merge-after-NATS-concur pattern) before an admin squash-merge.
 
-**Hand-off via AtomV1** — roles do not pass state in process. When an agent finishes, its exit cycle (`src.keiracom_system.chat.exit_cycle.classify_and_save`) writes the decision **directly** to the Hindsight `fleet_decisions` bank as an AtomV1 atom — a Gemini classifier (confidence > 0.8, max 3 atoms) is the precision gate. The next spawn picks it up through Layer 2 Hindsight recall at spawn time. Postgres carries operational state and the task-unblock triggers; Hindsight carries all knowledge. There is no intermediate store, and nothing writes automatically — write discipline at exit is the gate. An AtomV1 atom carries `trigger_condition`, `content`, `anti_pattern`, `example`, `provenance`, `supersession_edges`, and `composition_tags`. Post-cutover, `ceo_memory` is an audit log and admin target — not a pipeline step.
+**Hand-off via AtomV1 pointers** — roles do not pass state in process. An exiting agent writes its decision as an AtomV1 atom to the Hindsight `fleet_decisions` bank; NATS then carries the `task_id + atom_id` to the next agent, which recalls the atom at spawn (~100–150 tokens, no repeated preamble). Postgres carries operational state and the task-unblock triggers; Hindsight carries all knowledge — there is no intermediate store. All agent invocations run on the Anthropic API, and results return to Slack via the dispatcher `task_complete` endpoint plus `slack_relay.py`. Each role's prompt is served at spawn from the `public.persona_bank` table (5 rows — face/aiden/max/orion/atlas) via `GET /dispatcher/persona`. Post-cutover, `ceo_memory` is an audit log and admin target — not a pipeline step.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,33 @@ Agents are Claude Code sessions running under fixed callsigns. Deliberation tier
 
 ---
 
+## Agent loop architecture (V1 chain)
+
+The runtime execution loop — distinct from the callsign org chart above — moves a request through four roles. The roles never share in-process state: each runs as an ephemeral spawn that exits after its turn and hands off through **AtomV1 atoms** in Hindsight plus task rows in Postgres.
+
+```mermaid
+flowchart LR
+    User([Dave / #ceo]) --> Chat
+    Chat[Chat / Face<br/>Haiku listener] --> Delib[Deliberator<br/>the Floor]
+    Delib -->|task rows| Worker[Worker<br/>ephemeral spawn]
+    Worker --> Reviewer[Reviewer<br/>acceptance + concur]
+    Reviewer -->|mark done| Delib
+    Worker -.->|AtomV1 on exit| H[(Hindsight<br/>fleet_decisions)]
+    H -.->|Layer 2 recall on spawn| Worker
+```
+
+**Chat (Face)** — the user-facing voice. A `claude-haiku-4-5` agent spawns per `#ceo` message via Slack Socket Mode, classifies with a full LLM pass, and either records a decision (writes an AtomV1 atom to Hindsight plus a `ceo_memory` audit row) or exits on noise. Rate-capped at 10 spawns/hour via Valkey. Face and the Floor are the same entity — Face is its voice, and it always returns one recommendation, never a pros-and-cons list. Trivial commands bypass the Floor entirely.
+
+**Deliberator (the Floor)** — the multi-agent deliberation layer. It turns a request into a concurred plan (which Face presents for confirmation), forces a single recommendation on evaluative questions, resolves or escalates an agent's mid-task decisions, recalculates the task tree when a plan changes, and is the *only* authority that may mark a task done.
+
+**Worker** — an ephemeral agent spawned to execute one unblocked task. The work-loop consumer watches Postgres: a `trg_tasks_unblock_dependents` trigger publishes `task_id + callsign + tenant_id` to the Valkey `keiracom:tasks:available` queue; the consumer checks the tenant's tier ceiling and, if under the concurrent-spawn limit, calls `POST /dispatcher/spawn` (overflow is requeued, never dropped; a Valkey lock prevents duplicate spawns). Each spawn is hydrated by a 4-layer context contract — L1 system prompt, L2 Hindsight recall (3–5 atoms), L3 Valkey spend gate, L4 dispatcher wiring — fail-open at every layer.
+
+**Reviewer** — verification before work is accepted. The Floor checks a completed PR against its acceptance criteria, and runtime or governance PRs additionally require 2-of-3 deliberator concur (the orchestrator-merge-after-NATS-concur pattern) before an admin squash-merge.
+
+**Hand-off via AtomV1** — roles do not pass state in process. When an agent finishes, its exit cycle (`src.keiracom_system.chat.exit_cycle.classify_and_save`) writes the decision **directly** to the Hindsight `fleet_decisions` bank as an AtomV1 atom — a Gemini classifier (confidence > 0.8, max 3 atoms) is the precision gate. The next spawn picks it up through Layer 2 Hindsight recall at spawn time. Postgres carries operational state and the task-unblock triggers; Hindsight carries all knowledge. There is no intermediate store, and nothing writes automatically — write discipline at exit is the gate. An AtomV1 atom carries `trigger_condition`, `content`, `anti_pattern`, `example`, `provenance`, `supersession_edges`, and `composition_tags`. Post-cutover, `ceo_memory` is an audit log and admin target — not a pipeline step.
+
+---
+
 ## Quickstart
 
 Targets a fresh clone building locally in under 30 minutes.


### PR DESCRIPTION
## Summary
- Adds an **Agent loop architecture (V1 chain)** section to `README.md` documenting the runtime execution loop: **Chat (Face) → Deliberator (Floor) → Worker → Reviewer**, with hand-off via **AtomV1 atoms** in Hindsight + task rows in Postgres.
- Distinct from the existing "Agent layer" section (that is the callsign org chart; this is the runtime loop).
- Closes ceo-task-1780049037306. (Older duplicate ceo-task-1780047174462 dismissed in `public.tasks`.)

## Canonical sources (audit-dispatch checklist — query gate)
The named key `ceo:v1_chain_architecture` **does not exist**, and the fallback `ceo:directive_10029_complete` is about memory atomization, not the chain. Per the audit-dispatch checklist I sourced from the cluster of ratified `ceo_memory` keys that collectively define the V1 chain, pasted below:

- **`ceo:listener_architecture_post_cutover_ratified`** (2026-05-28): "Haiku agent spawned per #ceo message via Socket Mode. Full LLM classification. Decision→write AtomV1 to Hindsight + ceo_memory audit. Noise→exit." model `claude-haiku-4-5`; rate cap 10 spawns/hour via Valkey.
- **`strategic_doc:deliberation_floor_flow_v2`**: "Face and Floor are the same entity. 9 flows … (1) User build request — Floor deliberates, Face presents concurred plan … (4) PR pre-merge verification — Floor checks against acceptance criteria … (5) Agent completion claim — Floor is only authority to mark done … Face voice rules: always one recommendation, never pros-and-cons lists."
- **`ceo:work_loop_consumer_ratified`** (Agency_OS-s3ye, 2026-05-28): step_1 Postgres `trg_tasks_unblock_dependents` → Valkey `keiracom:tasks:available` (task_id + callsign + tenant_id); step_2 tenant tier ceiling check; step_3 `POST /dispatcher/spawn` or requeue/dead-letter; step_4 spawn→exit→triggers→next unblock. Backpressure: tier ceiling, overflow requeued, Valkey lock prevents duplicate spawns.
- **`ceo:session_2026-05-28_architecture_decisions`** (RATIFIED, Dave sign-off): two_store_model "Postgres = operational state + governance triggers. Hindsight = all knowledge (AtomV1). No intermediate store."; ephemeral_spawn_contract "4-layer context injection: L1 system prompt, L2 Hindsight recall 3-5 atoms, L3 Valkey spend gate, L4 dispatcher wiring. Fail-open every layer."; ceo_memory_role "Audit log and admin target only. Not a pipeline step."
- **`ceo:ephemeral_capture_model_v1`** (v2, 2026-05-29): "Agent writes the decision DIRECTLY to the Hindsight fleet_decisions bank as an AtomV1 atom on spawn exit (`src.keiracom_system.chat.exit_cycle.classify_and_save`). Future spawn: Hindsight Layer 2 recall retrieves atoms." Critical rule: nothing writes automatically; Gemini classifier (confidence > 0.8, max 3) is the precision gate.
- **`ceo:atomization_architecture_v1`**: AtomV1 schema fields — trigger_condition, content, anti_pattern, example, provenance, supersession_edges, composition_tags.

## ⚠ Flag for orchestrator
`ceo:v1_chain_architecture` is missing — the V1 chain is currently only defined across the 6 keys above. Recommend Dave/Elliot consider writing a consolidated `ceo:v1_chain_architecture` canonical key so future canonical-doc work has a single grounding source. Also: the existing README "Agent layer" paragraph still says state lives in Supabase `agent_memories` / Slack relay (pre-cutover) — left untouched here (out of scope); flagged as a follow-up.

## Test plan
- [ ] Mermaid diagram renders (GitHub-flavored mermaid).
- [ ] Reviewer cross-check: section claims match the cited canonical keys (deliberator cross-check per audit-dispatch checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)