### PR TITLE
[ORION] feat(personas): persona_bank — 6 ratified roles (face/aiden/max/orion/atlas/elliot)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -1050,3 +1050,75 @@ async def dispatcher_task_complete(req: TaskCompleteRequest) -> dict[str, Any]:
         return {"notified": False, "reason": "exception"}
     logger.info("task_complete: notified #ceo task=%s callsign=%s", req.task_id, req.callsign)
     return {"notified": True}
+
+
+# ---------------------------------------------------------------------------
+# /dispatcher/persona — role system-prompt lookup (persona_bank_v1)
+#
+# V1 chain roles (face/deliberator/worker/reviewer) fetch their system prompt
+# at spawn time via this endpoint instead of reading a file. Internal only —
+# no auth (the dispatcher is not exposed outside the host).
+# ---------------------------------------------------------------------------
+
+_PERSONA_DSN_ENV = "SUPABASE_DB_DSN"
+# asyncpg rejects the SQLAlchemy-style "+asyncpg" suffix; strip it before
+# connect (matches spend_tracker / reference_psycopg_supabase_pgbouncer.md).
+_ASYNCPG_DSN_SUFFIX = "+asyncpg"
+
+
+async def _fetch_persona(role: str, tier: str, variant: str | None) -> dict[str, Any] | None:
+    """Fetch one persona row from public.persona_bank.
+
+    variant=None resolves the default row (variant IS NULL). Returns
+    ``{prompt_text, token_count}`` or None on a real miss. Raises on DB
+    connectivity failure so the caller can distinguish 503 from 404.
+    """
+    dsn = os.environ.get(_PERSONA_DSN_ENV)
+    if not dsn:
+        raise RuntimeError(f"{_PERSONA_DSN_ENV} unset")
+    import asyncpg  # noqa: PLC0415 — deferred (optional in some test envs)
+
+    conn = await asyncpg.connect(dsn.replace(_ASYNCPG_DSN_SUFFIX, ""))
+    try:
+        if variant is None:
+            row = await conn.fetchrow(
+                "SELECT prompt_text, token_count FROM public.persona_bank "
+                "WHERE role = $1 AND tier = $2 AND variant IS NULL",
+                role,
+                tier,
+            )
+        else:
+            row = await conn.fetchrow(
+                "SELECT prompt_text, token_count FROM public.persona_bank "
+                "WHERE role = $1 AND tier = $2 AND variant = $3",
+                role,
+                tier,
+                variant,
+            )
+    finally:
+        await conn.close()
+    if row is None:
+        return None
+    return {"prompt_text": row["prompt_text"], "token_count": row["token_count"]}
+
+
+@app.get("/dispatcher/persona")
+async def dispatcher_persona(
+    role: str, tier: str = "standard", variant: str | None = None
+) -> dict[str, Any]:
+    """Look up a role's system prompt at spawn time (persona_bank_v1).
+
+    ``variant`` omitted resolves the default persona for the role+tier. Returns
+    404 when no persona matches and 503 when persona_bank is unreachable.
+    """
+    try:
+        persona = await _fetch_persona(role, tier, variant)
+    except Exception as exc:  # noqa: BLE001 — DB failure is 503, not a 404 miss
+        logger.warning("persona lookup failed role=%s tier=%s: %s", role, tier, exc)
+        raise HTTPException(status_code=503, detail="persona_bank unavailable") from exc
+    if persona is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"no persona for role={role} tier={tier} variant={variant}",
+        )
+    return persona

--- a/supabase/migrations/20260529_keiracom_persona_bank.sql
+++ b/supabase/migrations/20260529_keiracom_persona_bank.sql
@@ -1,0 +1,160 @@
+-- ============================================================================
+-- 20260529_keiracom_persona_bank.sql
+--
+-- persona_bank — first-class storage for agent role identities + system
+-- prompts. V1 chain (Dave -> Face -> Deliberator -> Worker -> Reviewer ->
+-- Anthropic API -> result). Each role fetches its system prompt at spawn
+-- time via a structured DB lookup (GET /dispatcher/persona) — no file reads.
+--
+-- task: persona_bank_v1 (Dave directive 2026-05-29 via Elliot dispatch,
+--       seed updated by Elliot dispatch UPDATE 2026-05-29 — Dave ratified).
+--
+-- Seed = 5 rows:
+--   face/standard            (default, variant IS NULL)
+--   deliberator/standard/aiden
+--   deliberator/standard/max
+--   reviewer/standard/atlas
+--   reviewer/standard/orion
+-- ('worker' stays a valid role for later seeding; the chain has a Worker.)
+--
+-- token_count is computed from the stored text using the repo-wide
+-- CHARS_PER_TOKEN=4 approximation (src/retrieval/workflow_recall.py): the
+-- seed uses integer-ceil( char_length / 4 ) so the dispatcher can sum prompt
+-- budgets at spawn time without re-tokenising.
+--
+-- Uniqueness: the directive specifies UNIQUE(role, tier, variant). Because
+-- Postgres treats NULLs as distinct in a plain UNIQUE, that alone would NOT
+-- stop two default rows (variant IS NULL) for the same (role, tier) — and the
+-- lookup endpoint returns the default by role+tier, so a duplicate default
+-- would make the lookup ambiguous. A partial unique index enforces exactly
+-- one default per (role, tier).
+--
+-- KEI-87 convention: SET LOCAL agency_os.callsign = 'dave' is set per the
+-- established migration pattern (covers any public-schema DDL guard); the
+-- row-level ceo_memory write-guard does not apply to this table.
+-- ============================================================================
+
+SET LOCAL agency_os.callsign = 'dave';
+
+CREATE TABLE IF NOT EXISTS public.persona_bank (
+    id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    role         TEXT         NOT NULL
+        CHECK (role IN ('face', 'deliberator', 'worker', 'reviewer')),
+    tier         TEXT         NOT NULL
+        CHECK (tier IN ('standard', 'deep')),
+    variant      TEXT,
+    token_count  INT,
+    prompt_text  TEXT         NOT NULL,
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (role, tier, variant)
+);
+
+-- Exactly one default (variant IS NULL) per (role, tier) — closes the
+-- NULL-distinct hole so the role+tier lookup is unambiguous.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_persona_bank_default
+    ON public.persona_bank (role, tier)
+    WHERE variant IS NULL;
+
+-- Lookup index for GET /dispatcher/persona?role=&tier=.
+CREATE INDEX IF NOT EXISTS idx_persona_bank_role_tier
+    ON public.persona_bank (role, tier);
+
+-- --------------------------------------------------------------------------
+-- Seed (idempotent). Two INSERTs because the default row (variant IS NULL)
+-- and the variant rows resolve to different ON CONFLICT targets: the partial
+-- unique index for NULL variants, the (role,tier,variant) constraint for the
+-- rest. Prompts are dollar-quoted ($p$) so apostrophes / em-dashes / newlines
+-- need no escaping. token_count = ceil(char_length / 4) from the stored text.
+-- --------------------------------------------------------------------------
+
+-- Default row: face/standard.
+INSERT INTO public.persona_bank (role, tier, variant, prompt_text, token_count)
+SELECT 'face', 'standard', NULL, prompt_text, (char_length(prompt_text) + 3) / 4
+FROM (VALUES (
+$p$You are the Face. You talk to Dave. That is the whole job. You do not build, deliberate, write PRs, or review code. Your job: receive Dave's intent, recall context (last 20 messages + Weaviate + Hindsight), then either answer directly, dispatch to deliberators, or ask one clarifying question. Surface task confirmations before executing. Report completions back. Voice: friendly, confident, decisive. Never expose the fleet beneath you.$p$
+)) AS seed(prompt_text)
+ON CONFLICT (role, tier) WHERE variant IS NULL DO NOTHING;
+
+-- Variant rows: deliberators (aiden, max) + reviewers (atlas, orion).
+INSERT INTO public.persona_bank (role, tier, variant, prompt_text, token_count)
+SELECT role, tier, variant, prompt_text, (char_length(prompt_text) + 3) / 4
+FROM (
+    VALUES
+        (
+            'deliberator', 'standard', 'aiden',
+$p$You are Aiden, a deliberator in the Keiracom agent chain.
+
+Your role: receive a task brief from The Face and produce a structured work plan for the Worker.
+
+How you think:
+- Break the task into the minimum viable steps
+- Identify what the Worker needs to know, and nothing more
+- Flag blockers, unknowns, and scope creep risks explicitly
+- Produce a KEI (Key Engineering Intent) — role, goal, steps, exit condition
+
+You must reach CONCUR with the second deliberator before the KEI is dispatched to a Worker. Present your plan. Listen to challenges. Update if the challenge is valid. Hold if it isn't — and say why.
+
+You do not execute. You do not review. You plan and you deliberate.
+
+Output format: structured KEI block. No prose padding. Be precise.$p$
+        ),
+        (
+            'deliberator', 'standard', 'max',
+$p$You are Max, a deliberator in the Keiracom agent chain.
+
+Your role: stress-test the work plan produced by Aiden before it reaches a Worker.
+
+How you think:
+- Read Aiden's KEI and ask: what fails here?
+- Surface edge cases, missing context, wrong assumptions, scope creep
+- If the plan is sound: say CONCUR explicitly and state why you're satisfied
+- If the plan has gaps: state the specific gap and what must change before you'll concur
+
+You are not here to slow things down. You are here to stop bad work from reaching a Worker. One bad KEI costs more than the deliberation round that catches it.
+
+You do not execute. You do not review. You challenge and you deliberate.
+
+Output format: CONCUR or BLOCK. If BLOCK — one sentence per gap, no more. Specific and actionable.$p$
+        ),
+        (
+            'reviewer', 'standard', 'atlas',
+$p$You are Atlas, a reviewer in the Keiracom agent chain.
+
+Your role: quality and safety gate. You review what Orion does not — not spec compliance, but production readiness.
+
+How you review:
+- Assume Orion has confirmed the output matches the KEI
+- Your check: is this safe to ship?
+- Look for: regressions, security risks, missing edge case handling, data integrity issues, anything that would fail under real customer load
+- If Orion has raised a REJECT, do not issue your own CONCUR until Orion re-concurs after the fix
+
+Output:
+- CONCUR: brief statement of what you verified and why it's safe
+- REJECT: specific issue, severity (P0/P1/P2), and what must change
+
+You do not deliberate. You do not execute. You protect the product.
+
+Dual concur required — your CONCUR alone does not merge. Requires Orion.$p$
+        ),
+        (
+            'reviewer', 'standard', 'orion',
+$p$You are Orion, a reviewer in the Keiracom agent chain.
+
+Your role: verify that the Worker's output matches the KEI it was given.
+
+How you review:
+- Load the KEI that was dispatched to the Worker
+- Compare the output against each step and the exit condition
+- Check: is anything missing? Is anything extra (scope creep)? Is the exit condition met?
+- Do not evaluate style, elegance, or approach — evaluate compliance
+
+Output:
+- CONCUR: state which KEI step each output element satisfies
+- REJECT: state exactly which KEI requirement is not met and what the Worker must fix
+
+You do not deliberate. You do not execute. You verify.
+
+Dual concur required — your CONCUR alone does not merge. Wait for Atlas.$p$
+        )
+) AS seed(role, tier, variant, prompt_text)
+ON CONFLICT (role, tier, variant) DO NOTHING;

--- a/supabase/migrations/20260529_keiracom_persona_bank_add_orchestrator.sql
+++ b/supabase/migrations/20260529_keiracom_persona_bank_add_orchestrator.sql
@@ -1,0 +1,43 @@
+-- ============================================================================
+-- 20260529_keiracom_persona_bank_add_orchestrator.sql
+--
+-- Follow-up to 20260529_keiracom_persona_bank.sql (already applied): add the
+-- 'orchestrator' role and seed the orchestrator/elliot persona. Kept as a
+-- separate migration because the base migration is already applied to the
+-- shared project — applied migrations are immutable; schema moves forward
+-- with a new file.
+--
+-- task: persona_bank_v1 (Elliot dispatch 2026-05-29 — Dave confirmed Elliot
+--       must be included). Total rows after this migration: 6.
+--
+-- The role CHECK is a named constraint (persona_bank_role_check); widen it to
+-- include 'orchestrator'. DROP ... IF EXISTS keeps the re-run idempotent.
+-- ============================================================================
+
+SET LOCAL agency_os.callsign = 'dave';
+
+ALTER TABLE public.persona_bank DROP CONSTRAINT IF EXISTS persona_bank_role_check;
+ALTER TABLE public.persona_bank ADD CONSTRAINT persona_bank_role_check
+    CHECK (role IN ('face', 'deliberator', 'worker', 'reviewer', 'orchestrator'));
+
+INSERT INTO public.persona_bank (role, tier, variant, prompt_text, token_count)
+SELECT 'orchestrator', 'standard', 'elliot', prompt_text, (char_length(prompt_text) + 3) / 4
+FROM (VALUES (
+$p$You are Elliot, the orchestrator of the Keiracom agent fleet.
+
+Your role: keep the V1 chain moving at all times.
+
+How you operate:
+- Watch the agent queue — no agent is idle while a P0 is open
+- Dispatch agents on unblocked work; match each KEI to the right capability
+- Review PRs through the implementation feasibility lens: does this work at runtime? does it integrate cleanly? regression risk?
+- Merge PRs after Orion + Atlas dual CONCUR (admin squash merge)
+- Surface to Dave only what requires CEO authority — cost decisions, structural changes, 3-way deliberator splits
+- Communicate with Dave in plain English, outcome-first, no jargon
+
+You do not build. You do not deliberate. You do not write code.
+You orchestrate, you merge, and you communicate.
+
+Output: dispatch instructions, merge confirmations, plain-English status to Dave. Always report what changed and what's next.$p$
+)) AS seed(prompt_text)
+ON CONFLICT (role, tier, variant) DO NOTHING;

--- a/tests/dispatcher/test_persona_lookup.py
+++ b/tests/dispatcher/test_persona_lookup.py
@@ -1,0 +1,125 @@
+"""Tests for GET /dispatcher/persona (persona_bank_v1 role-prompt lookup).
+
+No real DB — the asyncpg connection / _fetch_persona layer is monkeypatched.
+Covers the route's 200/404/503 contract plus the _fetch_persona query-branch
+(default variant IS NULL vs explicit variant) and the unset-DSN failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from src.dispatcher import main
+
+# ---------------------------------------------------------------------------
+# Route: dispatcher_persona — 200 / 404 / 503 contract
+# ---------------------------------------------------------------------------
+
+
+def test_persona_found_returns_prompt(monkeypatch):
+    """A persona match → handler returns {prompt_text, token_count} verbatim."""
+
+    async def fake_fetch(role, tier, variant):
+        return {"prompt_text": "You are a Worker.", "token_count": 5}
+
+    monkeypatch.setattr(main, "_fetch_persona", fake_fetch)
+    resp = asyncio.run(main.dispatcher_persona(role="worker", tier="standard"))
+    assert resp == {"prompt_text": "You are a Worker.", "token_count": 5}
+
+
+def test_persona_missing_returns_404(monkeypatch):
+    """No match → 404 (not a 503)."""
+
+    async def fake_fetch(role, tier, variant):
+        return None
+
+    monkeypatch.setattr(main, "_fetch_persona", fake_fetch)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(main.dispatcher_persona(role="ghost", tier="standard"))
+    assert exc.value.status_code == 404
+
+
+def test_persona_db_failure_returns_503(monkeypatch):
+    """DB connectivity failure → 503, distinct from a real 404 miss."""
+
+    async def fake_fetch(role, tier, variant):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(main, "_fetch_persona", fake_fetch)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(main.dispatcher_persona(role="worker", tier="standard"))
+    assert exc.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# _fetch_persona — DSN guard + query-branch selection
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_persona_unset_dsn_raises(monkeypatch):
+    """SUPABASE_DB_DSN unset → RuntimeError (caller maps to 503)."""
+    monkeypatch.delenv("SUPABASE_DB_DSN", raising=False)
+    with pytest.raises(RuntimeError):
+        asyncio.run(main._fetch_persona("worker", "standard", None))
+
+
+class _FakeConn:
+    def __init__(self, row, captured):
+        self._row = row
+        self._captured = captured
+
+    async def fetchrow(self, query, *args):
+        self._captured["query"] = query
+        self._captured["args"] = args
+        return self._row
+
+    async def close(self):
+        self._captured["closed"] = True
+
+
+def _patch_asyncpg(monkeypatch, row, captured):
+    async def fake_connect(dsn):
+        captured["dsn"] = dsn
+        return _FakeConn(row, captured)
+
+    monkeypatch.setattr("asyncpg.connect", fake_connect)
+
+
+def test_fetch_persona_default_variant_uses_is_null(monkeypatch):
+    """variant=None selects the default row via 'variant IS NULL' (2 bind args)."""
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql+asyncpg://u:p@h/db")
+    captured: dict = {}
+    _patch_asyncpg(monkeypatch, {"prompt_text": "P", "token_count": 1}, captured)
+
+    out = asyncio.run(main._fetch_persona("worker", "standard", None))
+
+    assert out == {"prompt_text": "P", "token_count": 1}
+    assert "variant IS NULL" in captured["query"]
+    assert captured["args"] == ("worker", "standard")
+    # +asyncpg suffix stripped before connect.
+    assert "+asyncpg" not in captured["dsn"]
+    assert captured["closed"] is True
+
+
+def test_fetch_persona_explicit_variant_binds_third_arg(monkeypatch):
+    """A named variant uses the '= $3' branch with the variant bound."""
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://u:p@h/db")
+    captured: dict = {}
+    _patch_asyncpg(monkeypatch, {"prompt_text": "P", "token_count": 1}, captured)
+
+    asyncio.run(main._fetch_persona("face", "deep", "concise"))
+
+    assert "variant = $3" in captured["query"]
+    assert captured["args"] == ("face", "deep", "concise")
+
+
+def test_fetch_persona_miss_returns_none(monkeypatch):
+    """fetchrow None → _fetch_persona returns None (route turns this into 404)."""
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://u:p@h/db")
+    captured: dict = {}
+    _patch_asyncpg(monkeypatch, None, captured)
+
+    assert asyncio.run(main._fetch_persona("worker", "standard", None)) is None


### PR DESCRIPTION
## Summary
First-class storage for agent role identities + system prompts (**persona_bank_v1**, Dave directive 2026-05-29). V1 chain roles fetch their system prompt at spawn time via a structured DB lookup — no file reads.

- **Migration** `supabase/migrations/20260529_keiracom_persona_bank.sql` — `public.persona_bank` (`id/role/tier/variant/token_count/prompt_text/created_at`, `UNIQUE(role,tier,variant)`). Partial unique index `WHERE variant IS NULL` enforces exactly one default per `(role,tier)`. `token_count = ceil(char_length/4)`.
- **Follow-up migration** `..._add_orchestrator.sql` — widens the role CHECK to include `orchestrator` + seeds `orchestrator/elliot` (base migration already applied → immutable, schema moves forward in a new file).
- **Seed (idempotent, FINAL ratified prompts):** `face/standard` (default) + `deliberator/{aiden,max}` + `reviewer/{orion,atlas}` + `orchestrator/elliot`. Orion = spec/KEI compliance, Atlas = quality/safety gate, Elliot = orchestrator.
- **Endpoint** `GET /dispatcher/persona?role=&tier=&variant=` → `{prompt_text, token_count}`; `404` on miss, `503` on DB unreachable; `variant` omitted resolves the default row.
- **Tests** — 7 unit tests (route 200/404/503 + unset-DSN guard + default-vs-variant query branch). Seed-independent (monkeypatched DB layer).
- **Applied to `jatzvazlbusedwsnqxzr`** (both migrations).

## Acceptance (live-verified)
`SELECT role, tier, variant, left(prompt_text,50) FROM public.persona_bank ORDER BY role, variant;` → **6 rows**:
| role | tier | variant | tokens |
|---|---|---|---|
| deliberator | standard | aiden | 188 |
| deliberator | standard | max | 193 |
| face | standard | _(null)_ | 110 |
| orchestrator | standard | elliot | 221 |
| reviewer | standard | atlas | 202 |
| reviewer | standard | orion | 176 |

Endpoint handler run against live DB: `face/default`, `deliberator/aiden`, `reviewer/orion`, `orchestrator/elliot` return correct prompts; `worker` + variant-less `deliberator`/`orchestrator` correctly 404.

## Scope note (GOV-9)
Original dispatch said "4 rows / `worker` lookup"; superseded by FINAL + 6th-row dispatches. `worker` kept as a valid `role` for later seeding (no row yet → 404 by design). Deliberator/reviewer/orchestrator are variant-only (no NULL-variant default → variant required on lookup).

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/dispatcher/test_persona_lookup.py` → 7 passed
- [x] dispatcher regression (`test_main_wiring`, `test_task_complete`) → 21 passed
- [x] both migrations applied + 6-row acceptance query verified live
- [x] endpoint 200/404 paths verified against live DB (incl orchestrator/elliot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)