### PR TITLE
[NOVA] feat(work-loop): dead-letter #ceo notification (Agency_OS-gl3v)

### DIFF
--- a/src/keiracom_system/work_loop/consumer.py
+++ b/src/keiracom_system/work_loop/consumer.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
@@ -38,6 +39,17 @@ LOCK_TTL_S = 300  # dup-spawn lock; renewed alongside the lease
 ATTEMPTS_TTL_S = 3600
 DEFAULT_MAX_ATTEMPTS = 3
 DEFAULT_ALERT_THRESHOLD = 0.70  # node-level capacity alert
+
+# Dead-letter #ceo notification (Agency_OS-gl3v). A dropped task that no human
+# sees destroys solo-operation trust, so every dead-letter posts to #ceo via
+# Elliot's relay. Path mirrors the dispatcher's task_complete hook; spawned
+# agents can't post to Slack (scrubbed env), so the relay runs CALLSIGN=elliot.
+_SLACK_RELAY_SCRIPT = os.path.join(
+    os.environ.get("DISPATCHER_AGENT_WORKDIR", "/home/elliotbot/clawd/Agency_OS"),
+    "scripts",
+    "slack_relay.py",
+)
+_NOTIFY_TIMEOUT_S = 15
 
 # Atomic admission: INCR the counter iff below ceiling, take the slot lease +
 # membership in one round-trip. Returns the new count, or -1 when at ceiling.
@@ -67,6 +79,17 @@ class Task:
     tenant_id: str
     backend: str
     spawn_kwargs: dict[str, Any]
+    raw: str
+
+
+@dataclass(frozen=True)
+class DeadLetterNotice:
+    """What a dead-lettered task carries into the #ceo alert (Agency_OS-gl3v)."""
+
+    task_id: str
+    title: str
+    attempts: int
+    error: str  # cause / final error, already truncated to 200 chars
     raw: str
 
 
@@ -111,8 +134,26 @@ def _parse(raw: str) -> Task | None:
         return None
 
 
+def _extract_id_title(raw: str) -> tuple[str, str]:
+    """Best-effort task_id + title from a (possibly malformed) message.
+
+    Title lives in spawn_kwargs.title (bridge.task_event_to_message). Falls back
+    to a top-level title, then to placeholders — never raises, so a malformed
+    message still produces a human-readable notice.
+    """
+    try:
+        d = json.loads(raw)
+        task_id = str(d.get("task_id") or "unknown")
+        spawn_kwargs = d.get("spawn_kwargs") if isinstance(d.get("spawn_kwargs"), dict) else {}
+        title = str(spawn_kwargs.get("title") or d.get("title") or "(no title in message)")
+        return task_id, title
+    except (json.JSONDecodeError, TypeError, ValueError, AttributeError):
+        return "unknown", "(unparseable task message)"
+
+
 SpawnFn = Callable[[Task], Awaitable[bool]]
 CeilingFn = Callable[[str], Awaitable[int]]
+NotifyFn = Callable[[DeadLetterNotice], Awaitable[None]]
 
 
 class WorkLoopConsumer:
@@ -124,6 +165,7 @@ class WorkLoopConsumer:
         valkey: Any = None,
         spawn_fn: SpawnFn | None = None,
         ceiling_fn: CeilingFn | None = None,
+        notify_fn: NotifyFn | None = None,
         dispatcher_url: str = DEFAULT_DISPATCHER_URL,
         lease_ttl_s: int = DEFAULT_LEASE_TTL_S,
         max_attempts: int = DEFAULT_MAX_ATTEMPTS,
@@ -132,6 +174,7 @@ class WorkLoopConsumer:
         self._r = valkey or get_valkey_client()
         self._spawn_fn = spawn_fn or self._default_spawn
         self._ceiling_fn = ceiling_fn
+        self._notify_fn = notify_fn or self._default_notify
         self._dispatcher_url = dispatcher_url.rstrip("/")
         self._lease_ttl_s = lease_ttl_s
         self._max_attempts = max_attempts
@@ -190,9 +233,57 @@ class WorkLoopConsumer:
                 100 * self._alert_threshold,
             )
 
-    async def _dead_letter(self, raw: str, reason: str) -> None:
+    async def _dead_letter(self, raw: str, reason: str, *, attempts: int = 0) -> None:
         logger.error("work-loop: dead-lettering task (%s): %s", reason, raw[:200])
         await self._r.rpush(DEADLETTER_KEY, raw)
+        # Agency_OS-gl3v: alert #ceo so a dropped task is never silent. Fail-open
+        # — the dead-letter itself must complete even if notification raises.
+        task_id, title = _extract_id_title(raw)
+        notice = DeadLetterNotice(
+            task_id=task_id, title=title, attempts=attempts, error=reason[:200], raw=raw
+        )
+        try:
+            await self._notify_fn(notice)
+        except Exception:  # noqa: BLE001 — a notification failure must NEVER block dead-letter
+            logger.warning(
+                "work-loop: dead-letter notification raised for task=%s", task_id, exc_info=True
+            )
+
+    async def _default_notify(self, notice: DeadLetterNotice) -> None:
+        """Post a dead-letter alert to #ceo via slack_relay.py (CALLSIGN=elliot).
+
+        Fail-open: a non-zero relay exit or any exception is logged, never
+        raised. `-c ceo` targets #ceo explicitly (not the env default channel,
+        which #execution-drops). Mirrors the dispatcher task_complete hook.
+        """
+        msg = (
+            f"🪦 [WORK-LOOP] Task dead-lettered after {notice.attempts} attempt(s) — "
+            f"ID: {notice.task_id} · what: {notice.title} · error: {notice.error}"
+        )
+        try:
+            import subprocess
+            import sys
+
+            result = subprocess.run(
+                [sys.executable, _SLACK_RELAY_SCRIPT, "-c", "ceo", msg],
+                capture_output=True,
+                text=True,
+                timeout=_NOTIFY_TIMEOUT_S,
+                env={**os.environ, "CALLSIGN": "elliot"},
+                check=False,
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "work-loop: dead-letter slack_relay rc=%d stderr=%r",
+                    result.returncode,
+                    result.stderr[:200],
+                )
+        except Exception:  # noqa: BLE001 — notification must never block dead-letter
+            logger.warning(
+                "work-loop: dead-letter slack_relay raised for task=%s",
+                notice.task_id,
+                exc_info=True,
+            )
 
     async def process_task(self, raw: str) -> str:
         """Process one task message. Returns a status string for observability."""
@@ -223,7 +314,11 @@ class WorkLoopConsumer:
             await self._r.delete(_attempts_key(task.task_id))
             return True
         if attempts >= self._max_attempts:
-            await self._dead_letter(task.raw, f"max_attempts={attempts}")
+            await self._dead_letter(
+                task.raw,
+                f"spawn failed after {attempts} attempts (max={self._max_attempts})",
+                attempts=attempts,
+            )
             await self._r.delete(_attempts_key(task.task_id))
         else:
             await self._r.rpush(_overflow_key(task.tenant_id), task.raw)  # requeue, never drop

--- a/tests/keiracom_system/work_loop/test_consumer.py
+++ b/tests/keiracom_system/work_loop/test_consumer.py
@@ -49,7 +49,23 @@ def _msg(task_id: str, tenant_id: str = "t1", **spawn_kwargs) -> str:
     )
 
 
+async def _noop_notify(_notice: wl.DeadLetterNotice) -> None:
+    """Default test notify — keeps dead-letter tests off the live Slack relay."""
+    return None
+
+
+class _Notifier:
+    """Records dead-letter notices for assertion."""
+
+    def __init__(self) -> None:
+        self.notices: list[wl.DeadLetterNotice] = []
+
+    async def __call__(self, notice: wl.DeadLetterNotice) -> None:
+        self.notices.append(notice)
+
+
 def _consumer(r, spawner, ceiling: int, **kw) -> WorkLoopConsumer:
+    kw.setdefault("notify_fn", _noop_notify)  # never shell out to slack_relay in tests
     return WorkLoopConsumer(valkey=r, spawn_fn=spawner, ceiling_fn=_ceiling(ceiling), **kw)
 
 
@@ -123,6 +139,49 @@ async def test_malformed_message_dead_letters_without_spawn():
     assert await c.process_task("not-json{") == "deadletter:malformed"
     assert spawner.calls == []
     assert await r.lrange(wl.DEADLETTER_KEY, 0, -1) == ["not-json{"]
+
+
+# --- dead-letter #ceo notification (Agency_OS-gl3v) -------------------
+
+
+async def test_dead_letter_notifies_ceo_with_task_context():
+    """Retry-exhaustion dead-letter fires a notice carrying id, title, attempts, error."""
+    r, spawner = _redis(), _Spawner(result=False)  # every spawn fails
+    notifier = _Notifier()
+    c = _consumer(r, spawner, ceiling=5, notify_fn=notifier)
+    await c.process_task(_msg("flaky", title="Refill domain pool"))
+    assert len(notifier.notices) == 1
+    n = notifier.notices[0]
+    assert n.task_id == "flaky"
+    assert n.title == "Refill domain pool"  # pulled from spawn_kwargs.title
+    assert n.attempts == 3  # exhausted max_attempts
+    assert "3 attempts" in n.error  # final cause carried, ≤200 chars
+
+
+async def test_malformed_dead_letter_notifies_ceo():
+    """A malformed (silently-dropped) task also alerts #ceo — attempts=0."""
+    r, spawner = _redis(), _Spawner()
+    notifier = _Notifier()
+    c = _consumer(r, spawner, ceiling=5, notify_fn=notifier)
+    assert await c.process_task("not-json{") == "deadletter:malformed"
+    assert len(notifier.notices) == 1
+    n = notifier.notices[0]
+    assert n.task_id == "unknown"
+    assert n.attempts == 0
+    assert n.error == "malformed"
+
+
+async def test_dead_letter_notification_is_fail_open():
+    """A notifier that raises must NOT block the dead-letter side effects."""
+
+    async def _boom(_notice: wl.DeadLetterNotice) -> None:
+        raise RuntimeError("slack down")
+
+    r, spawner = _redis(), _Spawner(result=False)
+    c = _consumer(r, spawner, ceiling=5, notify_fn=_boom)
+    await c.process_task(_msg("flaky"))  # must not raise despite notifier blowing up
+    assert await r.lrange(wl.DEADLETTER_KEY, 0, -1) == [_msg("flaky")]  # dead-letter still happened
+    assert await r.get(wl._active_key("t1")) == "0"  # slot still released
 
 
 # --- crash recovery (lease TTL) ---------------------------------------


### PR DESCRIPTION
## Summary
When a work-loop task dead-letters, the consumer now fires a **#ceo** alert so no dropped task is silent (P1, V1-critical). Both dead-letter paths notify — retry exhaustion (`spawn fails max_attempts`) **and** a malformed message — since either is a silent drop that erodes solo-operation trust.

The alert carries: **task_id**, **title** (from `spawn_kwargs.title`, set by `bridge.task_event_to_message`), **attempt count**, and the **final cause** (truncated ≤200 chars). It posts via `scripts/slack_relay.py` with `CALLSIGN=elliot` (spawned agents run a scrubbed env and can't post to Slack directly — the relay is Elliot's, same approach as the dispatcher `task_complete` hook).

## Acceptance criteria
1. ✅ **Code path** — `WorkLoopConsumer._dead_letter()` (the single funnel for both drop sites) now calls `notify_fn`; fires on retry-exhaustion and malformed.
2. ✅ **Message content** — `DeadLetterNotice(task_id, title, attempts, error)`; default relay message: `🪦 [WORK-LOOP] Task dead-lettered after N attempt(s) — ID: <id> · what: <title> · error: <cause ≤200>`.
3. ✅ **Fail-open** — guarded twice: the default impl logs relay non-zero rc / exceptions, and `_dead_letter` wraps the `notify_fn` call in try/except → a notification failure NEVER blocks the dead-letter (rpush + slot release still happen).
4. ✅ **Test (no live Slack)** — `notify_fn` is an injectable seam; 3 new unit tests use a recording fake.

## Design notes
- **Notify path = `-c ceo`, not `-d`.** `slack_relay.py` rejects `-d`/`--dm` (`-d (DM) not supported` → `sys.exit(2)`). PR #1312 (Max, on HOLD) calls the relay with `-d` — that is its bug. I used `-c ceo` (explicit channel; avoids the `#execution`-drop on the env default). Worth confirming when #1312's fix lands.
- **Injectable seam** mirrors the existing `spawn_fn`/`ceiling_fn` pattern; production uses the default `_default_notify`, tests inject a fake (the `_consumer` helper defaults to a no-op so existing dead-letter tests never shell out).
- **"Final error" scope:** the spawn seam returns `bool`, so the consumer-level cause is the exhaustion reason (`spawn failed after N attempts`); the underlying transport error is logged in `_default_spawn`. Capturing the raw exception text would require changing the `SpawnFn` contract — out of scope here.

## Test plan
- [x] `pytest tests/keiracom_system/work_loop/` → 39 passed.
- [x] New: `test_dead_letter_notifies_ceo_with_task_context` (id/title/attempts=3/error), `test_malformed_dead_letter_notifies_ceo` (attempts=0), `test_dead_letter_notification_is_fail_open` (notifier raises → dead-letter still completes).
- [x] `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)