### PR TITLE
[SCOUT] fix(infra): weaviate-backup false FAILED — tolerate tar file-changed exit on live backup

### DIFF
--- a/scripts/orchestrator/weaviate_backup.sh
+++ b/scripts/orchestrator/weaviate_backup.sh
@@ -35,7 +35,7 @@
 #   0  snapshot + prune succeeded
 #   2  data dir missing or unreadable
 #   3  backup dir creation failed
-#   4  tar exit non-zero
+#   4  tar fatal error (rc>=2) or archive missing/empty after tar
 
 set -euo pipefail
 
@@ -71,8 +71,21 @@ if ! mkdir -p "$BACKUP_DIR"; then
 fi
 
 # Snapshot (tar from data dir parent so paths are relative to the dir itself).
-tar -czf "$ARCHIVE" -C "$(dirname "$WEAVIATE_DATA_DIR")" "$(basename "$WEAVIATE_DATA_DIR")" \
-    || { echo "ERROR: tar failed (rc=$?)" >&2; exit 4; }
+# Live Weaviate compacts its LSM segments mid-backup, so tar may exit rc=1
+# ("file changed as we read it") while still writing a valid archive. Treat
+# rc<=1 with a non-empty archive as success; only a fatal tar error (rc>=2)
+# or a missing/empty archive is a real failure.
+set +e
+tar -czf "$ARCHIVE" -C "$(dirname "$WEAVIATE_DATA_DIR")" "$(basename "$WEAVIATE_DATA_DIR")"
+TAR_RC=$?
+set -e
+if [[ "$TAR_RC" -gt 1 ]] || [[ ! -s "$ARCHIVE" ]]; then
+    echo "ERROR: tar failed (rc=$TAR_RC) — fatal error or archive missing/empty" >&2
+    exit 4
+fi
+if [[ "$TAR_RC" -eq 1 ]]; then
+    echo "WARNING: tar rc=1 (files changed during live backup); archive produced, treating as success" >&2
+fi
 
 # Prune archives older than RETENTION_DAYS days (best-effort).
 find "$BACKUP_DIR" -name "weaviate-*.tar.gz" -type f \


### PR DESCRIPTION
## Summary
`weaviate-backup.service` shows `failed (status=4/NOPERMISSION)` (04:43Z + 12:40Z on 2026-05-29) despite producing a valid backup. Root cause confirmed empirically from `logs/weaviate-backup.log`:

```
tar: weaviate-data/sessiontranscripts/pzqJY016vh99: file changed as we read it
ERROR: tar failed (rc=1)
```

Live Weaviate compacts its LSM segments mid-backup, so `tar` exits **rc=1** ("file changed as we read it") while still writing a valid archive. The script mapped *any* non-zero tar exit to `exit 4`; systemd cosmetically labels exit 4 as `NOPERMISSION`. The on-disk archive `weaviate-2026-05-29.tar.gz` (1.24GB) was present the whole time — intermittent, only fires when compaction races the tar read.

## Change (scripts/orchestrator/weaviate_backup.sh)
Capture tar's real exit code (script uses `set -euo pipefail`, so `set +e`/`set -e` around tar) and branch:
- `rc >= 2` (fatal tar error) **or** archive missing/empty → real failure, `exit 4`
- `rc == 1` + non-empty archive → `WARNING`, treat as success (exit 0)
- `rc == 0` → success

**Deviation from dispatch brief (intentional):** brief said "any non-zero + archive exists → exit 0". I kept `rc>=2` as a real failure so a *fatal* tar error that leaves a truncated/corrupt archive is never silently blessed. Same line count, strictly safer.

## Verification
- `bash -n` clean.
- Deterministic decision-logic test — 6 cases all pass, incl. `rc=2 + archive → EXIT4` (fatal still fails) and `rc=1 + empty/missing → EXIT4`.
- Live run against real 2.4G data dir → `REAL RUN EXIT=0`, fresh 1.25GB archive written.

Note: the running unit (`/home/elliotbot/.config/systemd/user/weaviate-backup.service`) execs the **main** worktree copy, so `systemctl start` validation can only run *after* this merges and the main worktree pulls. Pre-merge validation was done by direct-running the fixed script with the service's env.

## Scope
Host-side infra only (one bash script, ~13 lines). No runtime/service code, no schema, no deps.

🤖 [SCOUT] research/diagnosis clone