### PR TITLE
[ATLAS] feat(work-loop): call exit_cycle on agent exit — write AtomV1 atoms to Hindsight (Agency_OS-zr7e.4)

### DIFF
--- a/src/keiracom_system/vault/agent_cold_start.py
+++ b/src/keiracom_system/vault/agent_cold_start.py
@@ -201,6 +201,40 @@ def notify_complete(
         logger.exception("notify_complete: unexpected error for task=%s", task_id)
 
 
+def save_exit_atoms(task: dict, rc: int, status: str) -> None:
+    """Capture the completed task as AtomV1 atoms in Hindsight (Agency_OS-zr7e.4).
+
+    Mirrors face.py's exit-cycle: feed the task brief + completion stamp to
+    ``classify_and_save``, which writes an atom per ratified decision it detects
+    above the confidence threshold (most build tasks detect none — that is fine).
+
+    Fail-open: ``classify_and_save`` is already internally fail-open, but the
+    import, ``asyncio.run`` and any unexpected error are also swallowed here —
+    memory capture must NEVER block the task lifecycle.
+    """
+    try:
+        import asyncio
+
+        from src.keiracom_system.chat.exit_cycle import classify_and_save
+
+        brief = task.get("description") or task.get("title") or ""
+        conversation = [
+            {
+                "role": "user",
+                "content": f"Task {task['id']}: {task.get('title') or ''}\n\n{brief}".strip(),
+            },
+            {
+                "role": "assistant",
+                "content": f"Task {task['id']} completed rc={rc} (status={status}).",
+            },
+        ]
+        customer_id = int(os.environ.get("AGENT_CUSTOMER_ID", "1"))  # fleet tenant 1 = Dave
+        result = asyncio.run(classify_and_save(conversation, customer_id))
+        logger.info("save_exit_atoms: %s", getattr(result, "skipped_reason", None) or "atoms saved")
+    except Exception:  # noqa: BLE001 — never block completion on memory capture
+        logger.exception("save_exit_atoms: unexpected error for task=%s", task.get("id"))
+
+
 def run(
     *,
     resolve: Callable[..., Any] = resolve_into_env,
@@ -209,6 +243,7 @@ def run(
     agent: Callable[..., int] = run_agent,
     finalize: Callable[..., None] = finalize_task,
     notify: Callable[..., None] = notify_complete,
+    save_atoms: Callable[..., None] = save_exit_atoms,
 ) -> int:
     """Cold-start orchestration. Returns the process exit code."""
     logging.basicConfig(level=logging.INFO)
@@ -230,6 +265,7 @@ def run(
     rc = agent(compose_prompt(task))
     finalize(task_id, rc, task.get("acceptance_criteria"))
     status = "done" if rc == 0 else "blocked"
+    save_atoms(task, rc, status)  # AtomV1 memory capture (zr7e.4) — fail-open
     notify(
         task_id,
         os.environ.get("AGENT_CALLSIGN", "worker"),

--- a/tests/keiracom_system/vault/test_agent_cold_start.py
+++ b/tests/keiracom_system/vault/test_agent_cold_start.py
@@ -146,6 +146,7 @@ def _run(monkeypatch, *, task_id="t-1", fetch_ret=None, claim_ret=True, agent_rc
         claim=lambda _tid, _cs: claim_ret,
         agent=lambda _p: agent_rc,
         finalize=finalize,
+        save_atoms=lambda *a, **k: None,
     )
     return rc, finalize, calls
 
@@ -248,6 +249,7 @@ def test_run_calls_notify_after_finalize(monkeypatch):
         claim=lambda _t, _c: True,
         agent=lambda _p: 0,
         finalize=lambda *a: None,
+        save_atoms=lambda *a, **k: None,
         notify=lambda *a, **kw: notify_calls.append((a, kw)),
     )
     assert len(notify_calls) == 1
@@ -271,7 +273,65 @@ def test_run_notify_blocked_on_agent_failure(monkeypatch):
         claim=lambda _t, _c: True,
         agent=lambda _p: 2,
         finalize=lambda *a: None,
+        save_atoms=lambda *a, **k: None,
         notify=lambda *a, **kw: notify_calls.append(a),
     )
     assert notify_calls[0][3] == "blocked"
     assert notify_calls[0][4] == 2
+
+
+# ---- save_exit_atoms (AtomV1 memory capture, zr7e.4) ------------------------
+
+
+def test_run_calls_save_atoms_after_finalize_before_notify(monkeypatch):
+    """run() invokes save_atoms once, with (task, rc, status), between
+    finalize and notify."""
+    monkeypatch.setenv("AGENT_TASK_ID", "t-1")
+    monkeypatch.setattr(acs.sys, "argv", ["agent_cold_start"])
+    order = []
+    save_calls = []
+    task = {"id": "t-1", "title": "My Task", "acceptance_criteria": None}
+    acs.run(
+        resolve=lambda: None,
+        fetch=lambda _t: task,
+        claim=lambda _t, _c: True,
+        agent=lambda _p: 0,
+        finalize=lambda *a: order.append("finalize"),
+        save_atoms=lambda *a: (order.append("save"), save_calls.append(a)),
+        notify=lambda *a, **kw: order.append("notify"),
+    )
+    assert order == ["finalize", "save", "notify"]
+    assert save_calls == [(task, 0, "done")]
+
+
+def test_save_exit_atoms_builds_conversation_and_calls_classify(monkeypatch):
+    """save_exit_atoms feeds task brief + completion stamp to classify_and_save
+    with the env/default customer_id."""
+    import src.keiracom_system.chat.exit_cycle as ec
+
+    captured = {}
+
+    async def fake_classify(conversation, customer_id, **kw):
+        captured["conversation"] = conversation
+        captured["customer_id"] = customer_id
+        return MagicMock(skipped_reason=None)
+
+    monkeypatch.setattr(ec, "classify_and_save", fake_classify)
+    monkeypatch.setenv("AGENT_CUSTOMER_ID", "7")
+    acs.save_exit_atoms({"id": "t-9", "title": "Wire X", "description": "Do the thing"}, 0, "done")
+    assert captured["customer_id"] == 7
+    convo = captured["conversation"]
+    assert convo[0]["role"] == "user" and "Do the thing" in convo[0]["content"]
+    assert convo[1]["role"] == "assistant" and "rc=0" in convo[1]["content"]
+
+
+def test_save_exit_atoms_fail_open_on_classify_error(monkeypatch):
+    """An error anywhere in the capture path must be swallowed — never raises."""
+    import src.keiracom_system.chat.exit_cycle as ec
+
+    def boom(*_a, **_k):
+        raise RuntimeError("gemini exploded")
+
+    monkeypatch.setattr(ec, "classify_and_save", boom)
+    # no exception = pass
+    acs.save_exit_atoms({"id": "t-1", "title": "T", "description": "d"}, 1, "blocked")


### PR DESCRIPTION
## Summary
Wires `save_exit_atoms` into `agent_cold_start.run()` (between `finalize` and `notify`) so every ephemeral worker captures its completed task as AtomV1 atoms in Hindsight via `exit_cycle.classify_and_save` — mirroring `face.py`'s exit-cycle. Closes the most critical V1 memory gap: previously **no atoms were written**, so each spawn started with no memory of prior work.

## Design (GOV-9 verified against the dispatch)
- **Function name:** dispatch referenced `save(...)` — that's `face.py`'s local param alias; the real API is `classify_and_save` (async, `src/keiracom_system/chat/exit_cycle.py:174`). Import is correct.
- **Injectable seam** (`save_atoms=`): matches this module's "all external seams injectable for testability" convention — exit_cycle hits Gemini + Hindsight, so it must be mockable.
- **Fail-open** per dispatch: lazy import + `asyncio.run` + any error swallowed; memory capture never blocks the task lifecycle. (`classify_and_save` is already internally fail-open — this is defence-in-depth.)
- **Conversation:** task brief (title + description) as the user turn + completion stamp (`rc`/`status`) as the assistant turn.
- **customer_id:** `AGENT_CUSTOMER_ID` env, default `1` (fleet tenant = Dave), mirroring `face.py`'s `FACE_CUSTOMER_ID`. `public.tasks` has no customer column, so default 1.

## Tests
3 new (22 total pass):
- ordering: `finalize → save_atoms → notify`, called once with `(task, rc, status)`
- conversation + customer_id build (mocked `classify_and_save`)
- fail-open on classify error (no propagation)

Existing `run()` tests updated to inject a no-op `save_atoms`.

## Verification
- `ruff check` ✓ · `ruff format --check` ✓
- `pytest tests/keiracom_system/vault/test_agent_cold_start.py` → 22 passed

## Test plan
- [ ] Spawn an ephemeral worker on a decision-bearing task; confirm an AtomV1 atom lands in the Hindsight `fleet_decisions` bank (confidence > threshold)
- [ ] Confirm a routine build task logs `below_confidence_threshold`/`no_decisions_detected` and writes nothing (expected)
- [ ] Kill Gemini reachability; confirm task still completes (fail-open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)