### PR TITLE
[ATLAS] feat(ops): OnFailure= alerting → NATS keiracom.ops.failure → #ceo (Agency_OS-ja8d)

### DIFF
--- a/infra/systemd/agents/keiracom-ops-failure-alert@.service
+++ b/infra/systemd/agents/keiracom-ops-failure-alert@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Agency OS — ops failure alert for %i (Agency_OS-ja8d)
+
+[Service]
+Type=oneshot
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS/scripts/orchestrator/ops_failure_publish.py %i
+Nice=10
+StandardOutput=append:/home/elliotbot/clawd/logs/ops-failure-alert.log
+StandardError=append:/home/elliotbot/clawd/logs/ops-failure-alert.log
+TimeoutStartSec=60

--- a/scripts/install_onfailure_dropins.sh
+++ b/scripts/install_onfailure_dropins.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# install_onfailure_dropins.sh — wire OnFailure= drop-ins for every user-scope
+# systemd service so failures publish to NATS keiracom.ops.failure (Agency_OS-ja8d).
+#
+# For every *.service unit in $UNITS_DIR this script creates a drop-in:
+#   $UNITS_DIR/<unit>.service.d/00-onfailure.conf
+# containing:
+#   [Unit]
+#   OnFailure=keiracom-ops-failure-alert@%n.service
+#
+# EXCLUSIONS (never add a drop-in to):
+#   - keiracom-ops-failure-alert@.service (the template itself)
+#   - keiracom-ops-failure-alert@*.service instances (prevents recursion)
+#   - Any template unit whose name contains '@' with empty instance (e.g. foo@.service)
+#
+# Idempotent: re-running writes the same content without error.
+#
+# Usage:
+#   bash scripts/install_onfailure_dropins.sh           # install
+#   bash scripts/install_onfailure_dropins.sh --remove  # remove all drop-ins
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNITS_DIR="${HOME}/.config/systemd/user"
+TEMPLATE_UNIT="keiracom-ops-failure-alert@.service"
+DROPIN_FILENAME="00-onfailure.conf"
+
+REMOVE=0
+if [[ "${1:-}" == "--remove" ]]; then
+    REMOVE=1
+fi
+
+# ── Install the template unit ─────────────────────────────────────────────────
+template_src="${REPO_DIR}/infra/systemd/agents/${TEMPLATE_UNIT}"
+if [[ ! -f "$template_src" ]]; then
+    echo "ERROR: template not found at $template_src" >&2
+    exit 1
+fi
+
+mkdir -p "$UNITS_DIR"
+
+if [[ "$REMOVE" -eq 1 ]]; then
+    # Remove drop-ins and the template
+    removed=0
+    for unit_file in "${UNITS_DIR}"/*.service; do
+        [[ -f "$unit_file" ]] || continue
+        unit_basename="$(basename "$unit_file")"
+        dropin_dir="${UNITS_DIR}/${unit_basename}.d"
+        dropin_conf="${dropin_dir}/${DROPIN_FILENAME}"
+        if [[ -f "$dropin_conf" ]]; then
+            rm -f "$dropin_conf"
+            echo "removed drop-in: $dropin_conf"
+            removed=$((removed + 1))
+            # Remove dir if now empty
+            if [[ -d "$dropin_dir" ]] && [[ -z "$(ls -A "$dropin_dir")" ]]; then
+                rmdir "$dropin_dir"
+            fi
+        fi
+    done
+    # Remove the template itself
+    if [[ -f "${UNITS_DIR}/${TEMPLATE_UNIT}" ]]; then
+        rm -f "${UNITS_DIR}/${TEMPLATE_UNIT}"
+        echo "removed template: ${UNITS_DIR}/${TEMPLATE_UNIT}"
+    fi
+    systemctl --user daemon-reload
+    echo "done — removed $removed drop-in(s)"
+    exit 0
+fi
+
+# ── Install mode ──────────────────────────────────────────────────────────────
+install -m 0644 "$template_src" "${UNITS_DIR}/${TEMPLATE_UNIT}"
+echo "installed template: ${UNITS_DIR}/${TEMPLATE_UNIT}"
+
+written=0
+skipped=0
+
+for unit_file in "${UNITS_DIR}"/*.service; do
+    [[ -f "$unit_file" ]] || continue
+    unit_basename="$(basename "$unit_file")"
+
+    # Skip the alert template itself and any keiracom-ops-failure-alert instances
+    if [[ "$unit_basename" == keiracom-ops-failure-alert* ]]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Skip template units (name contains '@' with empty instance, e.g. foo@.service)
+    # A concrete instance looks like foo@bar.service; a bare template is foo@.service
+    if [[ "$unit_basename" == *@.service ]]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    dropin_dir="${UNITS_DIR}/${unit_basename}.d"
+    dropin_conf="${dropin_dir}/${DROPIN_FILENAME}"
+
+    mkdir -p "$dropin_dir"
+    cat > "$dropin_conf" <<'DROPIN'
+[Unit]
+OnFailure=keiracom-ops-failure-alert@%n.service
+DROPIN
+    echo "wrote drop-in: $dropin_conf"
+    written=$((written + 1))
+done
+
+systemctl --user daemon-reload
+echo "done — wrote $written drop-in(s), skipped $skipped unit(s)"

--- a/scripts/orchestrator/ops_failure_publish.py
+++ b/scripts/orchestrator/ops_failure_publish.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""ops_failure_publish.py — publish one ops-failure envelope to NATS and exit.
+
+Called by systemd via OnFailure= on every user-scope service. Publishes a
+diagnostic envelope to keiracom.ops.failure where peer_event_ceo_relay picks
+it up and fans to Slack #ceo.
+
+NATS here is CORE pub/sub (NOT jetstream) — no stream creation needed.
+
+USAGE:
+    python3 scripts/orchestrator/ops_failure_publish.py <unit>
+    python3 scripts/orchestrator/ops_failure_publish.py --dry-run <unit>
+
+    systemd passes %i (the verbatim instance name) as the positional arg.
+    NB: %i not %I — %I unescapes '-' to '/', corrupting dashed unit names
+    (weaviate-backup.service -> weaviate/backup.service).
+
+EXIT: 0 on successful publish; 1 on NATS unavailable / publish error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+
+# nats-py is lazy-imported inside publish_failure() so this module remains
+# collectable on CI hosts where nats-py is not in the test venv.
+# Mirrors the same pattern used in supervisor_wake_publish.py (PR #1116
+# anchor — top-level import nats made test uncollectable on CI).
+
+DEFAULT_NATS_URL = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
+DEFAULT_SUBJECT = os.environ.get("OPS_FAILURE_SUBJECT", "keiracom.ops.failure")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("ops_failure_publish")
+
+
+def _gather_diagnostics(unit: str) -> tuple[str, str]:
+    """Run status + journal for `unit`. Returns (status_excerpt, journal_excerpt).
+
+    Best-effort — never raises. Any subprocess error is logged and an empty
+    string returned so the envelope can still be published.
+    """
+    status_excerpt = ""
+    journal_excerpt = ""
+
+    try:
+        r = subprocess.run(
+            ["systemctl", "--user", "status", unit, "--no-pager", "-l"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        lines = r.stdout.splitlines()
+        status_excerpt = "\n".join(lines[-15:]) if lines else r.stderr[:500]
+    except Exception as exc:  # noqa: BLE001
+        log.warning("status gather failed for %s: %s", unit, exc)
+
+    try:
+        r = subprocess.run(
+            ["journalctl", "--user", "-u", unit, "-n", "12", "--no-pager"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        journal_excerpt = r.stdout.strip()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("journal gather failed for %s: %s", unit, exc)
+
+    return status_excerpt, journal_excerpt
+
+
+def build_envelope(unit: str, now: float | None = None) -> dict:
+    """Construct the failure envelope. Pure function — testable without NATS.
+
+    Gathers diagnostics via subprocess (best-effort). Always returns a
+    publishable dict even if subprocess calls fail.
+    """
+    ts = now if now is not None else time.time()
+    status_excerpt, journal_excerpt = _gather_diagnostics(unit)
+    summary = f"{unit} entered FAILED state\n\n{status_excerpt}\n{journal_excerpt}".strip()
+    return {
+        "from": "ops-failure-alert",
+        "kind": "ops_failure",
+        "unit": unit,
+        "summary": summary,
+        "ts": ts,
+    }
+
+
+async def publish_failure(nats_url: str, subject: str, unit: str) -> int:
+    """Publish one failure envelope to NATS. Returns 0 on success, 1 on failure."""
+    try:
+        import nats  # lazy — keeps module collectable on hosts without nats-py
+    except ImportError as exc:
+        log.error("ops_failure_publish: nats-py not installed; publish skipped (%s)", exc)
+        return 1
+    envelope = build_envelope(unit)
+    payload = json.dumps(envelope).encode("utf-8")
+    try:
+        nc = await nats.connect(nats_url, connect_timeout=5)
+    except Exception as exc:
+        log.error("ops_failure_publish: NATS connect failed url=%s: %s", nats_url, exc)
+        return 1
+    try:
+        await nc.publish(subject, payload)
+        await nc.flush(timeout=5)
+        log.info(
+            "ops_failure_publish: published %d bytes to %s (unit=%s)", len(payload), subject, unit
+        )
+    except Exception as exc:
+        log.error("ops_failure_publish: publish failed subject=%s: %s", subject, exc)
+        await nc.close()
+        return 1
+    await nc.close()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("unit", help="Systemd unit name that entered failed state (%%i from OnFailure=)")
+    p.add_argument("--nats-url", default=DEFAULT_NATS_URL, help="NATS server URL")
+    p.add_argument("--subject", default=DEFAULT_SUBJECT, help="NATS subject to publish to")
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the envelope JSON without publishing (smoke check)",
+    )
+    args = p.parse_args(argv)
+    if args.dry_run:
+        print(json.dumps(build_envelope(args.unit), indent=2))
+        return 0
+    return asyncio.run(publish_failure(args.nats_url, args.subject, args.unit))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orchestrator/peer_event_ceo_relay.py
+++ b/scripts/orchestrator/peer_event_ceo_relay.py
@@ -44,7 +44,8 @@ from pathlib import Path
 import nats
 
 NATS_URL = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
-SUBJECTS = ("keiracom.elliot.inbox", "keiracom.review.>")
+OPS_FAILURE_SUBJECT = "keiracom.ops.failure"
+SUBJECTS = ("keiracom.elliot.inbox", "keiracom.review.>", OPS_FAILURE_SUBJECT)
 STATE_PATH = Path("/tmp/peer_event_ceo_relay_state.json")
 RELAY = "/home/elliotbot/clawd/Agency_OS/scripts/slack_relay.py"
 PYTHON = "/home/elliotbot/clawd/Agency_OS/.venv/bin/python3"
@@ -188,6 +189,20 @@ def _summary_to_bullets(summary: str, max_bullets: int = 5) -> str:
     return body
 
 
+def _handle_ops_failure(envelope: dict) -> None:
+    """Relay a keiracom.ops.failure event to #ceo with a per-unit throttle."""
+    unit = envelope.get("unit") or "unknown unit"
+    throttle_key = ("ops_failure", unit)
+    if _is_throttled(throttle_key):
+        log.debug("ops_failure throttled: unit=%s", unit)
+        return
+    _throttle[throttle_key] = time.time()
+    body = f"- Unit: {unit}\n" + _summary_to_bullets(
+        envelope.get("summary") or f"{unit} entered failed state", max_bullets=4
+    )
+    _post_ceo("Service failure", body)
+
+
 def _handle_envelope(subject: str, envelope: dict) -> None:
     kind = (envelope.get("kind") or "").lower()
     sender = (envelope.get("from") or "unknown").lower()
@@ -198,6 +213,10 @@ def _handle_envelope(subject: str, envelope: dict) -> None:
 
     if _is_duplicate(envelope):
         log.debug("dup skip: from=%s kind=%s", sender, kind)
+        return
+
+    if subject == OPS_FAILURE_SUBJECT or kind == "ops_failure":
+        _handle_ops_failure(envelope)
         return
 
     # Review verdicts — track approver/holder per PR, only post on flips

--- a/tests/orchestrator/test_ops_failure_alerting.py
+++ b/tests/orchestrator/test_ops_failure_alerting.py
@@ -1,0 +1,172 @@
+"""Tests for ops_failure_publish.py + peer_event_ceo_relay.py (Agency_OS-ja8d).
+
+Coverage:
+  - ops_failure_publish.build_envelope: correct keys, subprocess output in summary,
+    subprocess exception swallowed.
+  - peer_event_ceo_relay: OPS_FAILURE_SUBJECT in SUBJECTS; _handle_ops_failure
+    posts to #ceo; per-unit throttle suppresses second call; subject-based routing
+    when kind is absent.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "orchestrator"))
+
+import ops_failure_publish as ofp  # noqa: E402
+import peer_event_ceo_relay as relay  # noqa: E402
+
+# ── ops_failure_publish ───────────────────────────────────────────────────────
+
+
+def _make_completed_process(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+def test_build_envelope_required_keys():
+    """Envelope must contain from/kind/unit/summary/ts with correct values."""
+    with patch("ops_failure_publish.subprocess.run") as mock_run:
+        mock_run.return_value = _make_completed_process("some output line\n")
+        env = ofp.build_envelope("test-unit.service")
+    assert env["from"] == "ops-failure-alert"
+    assert env["kind"] == "ops_failure"
+    assert env["unit"] == "test-unit.service"
+    assert "test-unit.service" in env["summary"]
+    assert isinstance(env["ts"], float)
+    assert env["ts"] > 0
+
+
+def test_build_envelope_contains_subprocess_output():
+    """Subprocess stdout lines appear in the envelope summary."""
+    status_output = "Active: failed (Result: exit-code)\nMain PID: 1234"
+    journal_output = "May 29 10:00:00 host test-unit[1234]: ERROR: something went wrong"
+
+    call_count = 0
+
+    def side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _make_completed_process(status_output)
+        return _make_completed_process(journal_output)
+
+    with patch("ops_failure_publish.subprocess.run", side_effect=side_effect):
+        env = ofp.build_envelope("test-unit.service", now=1000.0)
+
+    assert "failed" in env["summary"]
+    assert "ERROR: something went wrong" in env["summary"]
+    assert env["ts"] == 1000.0
+
+
+def test_build_envelope_swallows_subprocess_exception():
+    """A subprocess.run raising an exception must not propagate — envelope still built."""
+    with patch("ops_failure_publish.subprocess.run", side_effect=OSError("no such binary")):
+        env = ofp.build_envelope("crash-unit.service")
+    # Must still have required keys and not raise
+    assert env["kind"] == "ops_failure"
+    assert env["unit"] == "crash-unit.service"
+    # summary may be sparse but must be a string
+    assert isinstance(env["summary"], str)
+
+
+def test_build_envelope_unit_echoed_in_summary():
+    """unit name must appear in summary regardless of subprocess content."""
+    with patch("ops_failure_publish.subprocess.run") as mock_run:
+        mock_run.return_value = _make_completed_process("")
+        env = ofp.build_envelope("my-special-unit.service")
+    assert "my-special-unit.service" in env["summary"]
+
+
+# ── peer_event_ceo_relay ──────────────────────────────────────────────────────
+
+
+def test_ops_failure_subject_in_subjects():
+    """OPS_FAILURE_SUBJECT must be present in SUBJECTS tuple."""
+    assert relay.OPS_FAILURE_SUBJECT in relay.SUBJECTS
+    assert relay.OPS_FAILURE_SUBJECT == "keiracom.ops.failure"
+
+
+def _reset_relay_state():
+    """Clear throttle + dedup dicts between sub-tests."""
+    relay._throttle.clear()
+    relay._dedup.clear()
+
+
+def test_handle_envelope_ops_failure_posts_to_ceo(monkeypatch):
+    """_handle_envelope on keiracom.ops.failure must call _post_ceo once."""
+    _reset_relay_state()
+    captured: list[tuple[str, str]] = []
+
+    def fake_post_ceo(category: str, body: str) -> None:
+        captured.append((category, body))
+
+    monkeypatch.setattr(relay, "_post_ceo", fake_post_ceo)
+
+    relay._handle_envelope(
+        "keiracom.ops.failure",
+        {
+            "kind": "ops_failure",
+            "unit": "weaviate-backup.service",
+            "summary": "weaviate-backup.service entered FAILED state\nstatus=4/NOPERMISSION",
+        },
+    )
+
+    assert len(captured) == 1
+    category, body = captured[0]
+    assert category == "Service failure"
+    assert "weaviate-backup.service" in body
+
+
+def test_handle_envelope_ops_failure_throttle(monkeypatch):
+    """Second identical unit call within cooldown must NOT call _post_ceo again."""
+    _reset_relay_state()
+    captured: list[tuple[str, str]] = []
+
+    def fake_post_ceo(category: str, body: str) -> None:
+        captured.append((category, body))
+
+    monkeypatch.setattr(relay, "_post_ceo", fake_post_ceo)
+
+    envelope_first = {
+        "kind": "ops_failure",
+        "unit": "atlas-inbox-watcher.service",
+        "summary": "atlas-inbox-watcher.service entered FAILED state\nfirst attempt",
+    }
+    envelope_second = {
+        "kind": "ops_failure",
+        "unit": "atlas-inbox-watcher.service",
+        "summary": "atlas-inbox-watcher.service entered FAILED state\nsecond attempt",
+    }
+
+    # First call — should post
+    relay._handle_envelope("keiracom.ops.failure", envelope_first)
+    assert len(captured) == 1, "first call must post to #ceo"
+
+    # Second call within cooldown (throttle set, _dedup cleared to isolate)
+    relay._dedup.clear()
+    relay._handle_envelope("keiracom.ops.failure", envelope_second)
+    assert len(captured) == 1, "second call within cooldown must be throttled"
+
+
+def test_handle_envelope_routes_by_subject_when_kind_missing(monkeypatch):
+    """Subject keiracom.ops.failure must trigger _post_ceo even with no 'kind' field."""
+    _reset_relay_state()
+    captured: list[tuple[str, str]] = []
+
+    def fake_post_ceo(category: str, body: str) -> None:
+        captured.append((category, body))
+
+    monkeypatch.setattr(relay, "_post_ceo", fake_post_ceo)
+
+    relay._handle_envelope(
+        "keiracom.ops.failure",
+        {"unit": "x.service", "summary": "x down — connection refused"},
+    )
+
+    assert len(captured) == 1
+    assert "x.service" in captured[0][1]


### PR DESCRIPTION
## Summary
Closes the silent-stale blind spot (Agency_OS-ja8d): failed user-scope services currently emit **zero** alert. The KEI-141 poller is **not running** (timer/service inactive, not-installed) and even when running only covered 5 unit-globs. `weaviate-backup.service` was failing every boot unnoticed — the live instance of this gap.

This wires **push-based** `OnFailure=` alerting:

```
failed unit ──OnFailure──▶ keiracom-ops-failure-alert@<unit>.service
                              └─▶ ops_failure_publish.py → NATS keiracom.ops.failure
                                    └─▶ peer_event_ceo_relay (extended) → Slack #ceo
```

## Files
- **`scripts/orchestrator/ops_failure_publish.py`** (new) — gathers `systemctl status` + `journalctl` for the failed unit, publishes a diagnostic envelope to `keiracom.ops.failure`. Core NATS pub/sub, mirrors `supervisor_wake_publish.py` (lazy `import nats`, fail-open diagnostics).
- **`infra/systemd/agents/keiracom-ops-failure-alert@.service`** (new) — oneshot handler template. **Uses `%i`, not `%I`** — verified `%I` unescapes `-`→`/` (`weaviate-backup.service` → `weaviate/backup.service`), which would corrupt every dashed unit name.
- **`scripts/install_onfailure_dropins.sh`** (new) — idempotent installer; drops `OnFailure=keiracom-ops-failure-alert@%n.service` on every concrete `*.service`; `--remove` reverses it; excludes the alert template (recursion guard).
- **`scripts/orchestrator/peer_event_ceo_relay.py`** (edit) — **minimal** diff: +`keiracom.ops.failure` subscription, +`_handle_ops_failure` (per-unit throttle) → `_post_ceo("Service failure", …)`.
- **`tests/orchestrator/test_ops_failure_alerting.py`** (new) — 8 tests.

## Scope notes for reviewers
- **GOV-9 correction:** the original ja8d spec said *"peer-event-ceo-relay then fans → #ceo"* — but the relay did **not** subscribe to `keiracom.ops.failure` (only `elliot.inbox` + `review.>`). That missing subscription is part (c) here.
- **CI scope:** `ruff` in CI only lints `src/`; these files live in `scripts/`/`tests/`/`infra/` (latter excluded in `ruff.toml`). Kept the relay diff minimal (no unrelated reformatting) deliberately.
- **Known limitation (follow-up filed):** the installer skips `*@.service` templates, so the **1** templated service (`agent-self-claim-loop@`) isn't covered yet — its instances need the drop-in in the template `.d` dir + a live double-`@` test. Tracked separately; not in this PR to avoid shipping an untested systemd path.

## Verification (local)
- `ruff check` + `ruff format --check` on the Python files → clean
- `pytest tests/orchestrator/test_ops_failure_alerting.py` → **8 passed**
- `ops_failure_publish.py --dry-run <unit>` → valid envelope, exit 0
- `bash -n install_onfailure_dropins.sh` → OK
- `systemd-escape -u` empirically confirmed the `%i` vs `%I` bug

## Post-merge (host deploy + acceptance gate)
Host-side deploy runs after merge (admin-bypass, reversible): `install_onfailure_dropins.sh` + install the template + restart `peer-event-ceo-relay.service`. Then the **acceptance test**: synthetically fail a non-critical service → confirm alert in #ceo within 60s. Acceptance depends on the relay change (part c) being live.

## Test plan
- [ ] Post-merge: deploy drop-ins + restart relay
- [ ] `systemctl --user start <non-critical-failing-test>.service` → alert lands in #ceo ≤60s with correct unit name + diagnostics
- [ ] `install_onfailure_dropins.sh --remove` cleanly reverses

🤖 Generated with [Claude Code](https://claude.com/claude-code)