### PR TITLE
[SCOUT] test(work-loop): failure-path dress rehearsal — crash/lease/retry/dead-letter (Agency_OS-avii)

### DIFF
--- a/scripts/cutover/full_chain_dress_rehearsal.py
+++ b/scripts/cutover/full_chain_dress_rehearsal.py
@@ -320,6 +320,19 @@ def classify_spawn_failure(status_code: int, body: str = "") -> str | None:  # n
     return None if 200 <= status_code < 300 else "spawn_rejected"
 
 
+def classify_failure_path(run: RunResult) -> str | None:
+    """Map a crash / dead_letter RunResult to a FAILURE_MODES entry; None on a
+    clean failure-path outcome. Symmetric with classify_spawn_failure — it ties
+    the §9 crash_unrecovered / not_dead_lettered modes to the observed run so the
+    harness reports them (P3/P4) instead of hanging. Non-failure-path run_modes
+    (cold / recall) return None."""
+    if run.run_mode == "crash":
+        return None if run.recovered else "crash_unrecovered"
+    if run.run_mode == "dead_letter":
+        return None if run.dead_lettered else "not_dead_lettered"
+    return None
+
+
 # ─── v2.0 WITNESS — live #ceo stream (Dave watches; Dave's table signs off) ───
 
 

--- a/tests/scripts/test_dress_rehearsal_failure_path.py
+++ b/tests/scripts/test_dress_rehearsal_failure_path.py
@@ -1,0 +1,264 @@
+"""Failure-path dress-rehearsal tests (Agency_OS-avii).
+
+Viktor's chain test (Agency_OS-jb4e / #1279) is happy-path only. This adds the
+FAILURE-PATH the dress rehearsal must witness, driven END-TO-END against the REAL
+work-loop consumer (fakeredis — no live Valkey) plus the harness that witnesses
+the crash / dead_letter runs:
+
+  1. crash mid-task -> 5-min lease lapses -> reconcile() reclaims the slot ->
+     retry counter increments -> dead-letter after 3 attempts.
+  2. reconcile-miss (lease still alive / already released) -> NO orphan slot.
+  3. the path STARTS at the SLACK seam (public.tasks row -> kei45 trigger ->
+     keiracom:tasks:available), NOT at the Chat hop.
+  4. the with-memory (recall) run MUST ASSERT recall >=1 relevant atom — a run
+     that surfaces 0 atoms FAILS the gate (not just "no error").
+
+#1310 unit-tests the individual mechanics; avii proves the integrated dress-
+rehearsal failure path and binds the harness seam + spec constants to the live
+consumer so an impl drift fails this gate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from fakeredis import aioredis
+
+from src.keiracom_system.work_loop import consumer as wl
+from src.keiracom_system.work_loop.consumer import WorkLoopConsumer
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "cutover" / "full_chain_dress_rehearsal.py"
+
+
+def _load_harness():
+    spec = importlib.util.spec_from_file_location("_dr_failure_path", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod  # register before exec for dataclass annotation resolution
+    spec.loader.exec_module(mod)
+    return mod
+
+
+m = _load_harness()
+
+TENANT = "t-avii"
+
+
+# ─── real-consumer harness (fakeredis; mirrors #1310 patterns) ────────────────
+
+
+def _redis():
+    return aioredis.FakeRedis(decode_responses=True)
+
+
+def _ceiling(n):
+    async def _f(_tenant_id):
+        return n
+
+    return _f
+
+
+class _Spawner:
+    """Records spawns; `result` is a bool or fn(attempt_count)->bool."""
+
+    def __init__(self, result=True):
+        self.calls: list[str] = []
+        self.result = result
+
+    async def __call__(self, task: wl.Task) -> bool:
+        self.calls.append(task.task_id)
+        return self.result(len(self.calls)) if callable(self.result) else self.result
+
+
+def _slack_seam_message(task_id: str, tenant_id: str = TENANT, **spawn_kwargs) -> str:
+    """The task message exactly as the SLACK->task-row->kei45-trigger seam
+    publishes it to keiracom:tasks:available (consumer channel) — the failure
+    path's origin, NOT a Chat-hop call. Shape matches consumer._parse."""
+    return json.dumps(
+        {
+            "task_id": task_id,
+            "tenant_id": tenant_id,
+            "backend": "container",
+            "spawn_kwargs": spawn_kwargs,
+        }
+    )
+
+
+def _consumer(r, spawner, ceiling: int = 5, **kw) -> WorkLoopConsumer:
+    return WorkLoopConsumer(valkey=r, spawn_fn=spawner, ceiling_fn=_ceiling(ceiling), **kw)
+
+
+# ─── harness RunResult builders ───────────────────────────────────────────────
+
+_GOV = {"callsign_tagged": True, "concur_count": 2, "no_linear_write": True, "claim_observed": True}
+
+
+def _hop(name, *, fired=True, bypass=False, cit="C-1", score=0.8):
+    return m.HopTrace(
+        hop=name,
+        agent=name,
+        fired=fired,
+        bypass_rerank=bypass,
+        top_citation_id=cit,
+        top_score=score,
+    )
+
+
+def _hops(useful: bool):
+    if useful:
+        return tuple(_hop(h) for h in m.HOP_AGENTS_DEFAULT)
+    return tuple(_hop(h, bypass=True, cit=None, score=0.0) for h in m.HOP_AGENTS_DEFAULT)
+
+
+def _run(*, mode, active=True, useful=True, recovered=True, dead_lettered=False, worker_retries=0):
+    return m.RunResult(
+        kei="Agency_OS-avii",
+        recall_active=active,
+        hop_traces=_hops(useful),
+        run_mode=mode,
+        pr_number=9,
+        pr_merged=True,
+        ci_passed=True,
+        governance=dict(_GOV),
+        worker_retries=worker_retries,
+        recovered=recovered,
+        dead_lettered=dead_lettered,
+    )
+
+
+def _cold_run():
+    return _run(mode="cold", active=False, useful=False, worker_retries=1)
+
+
+# ─── item 3 — the path STARTS at the SLACK seam, not Chat ─────────────────────
+
+
+def test_failure_path_starts_at_slack_seam_not_chat():
+    # The harness seed is an INSERT into public.tasks — the row the kei45 trigger
+    # turns into a keiracom:tasks:available publish (the SLACK-origin leg), NOT a
+    # Chat hop. The consumer subscribes to that SAME channel.
+    assert "public.tasks" in m.build_seed_sql()
+    assert m.TASKS_CHANNEL == wl.TASKS_CHANNEL == "keiracom:tasks:available"
+    # the seam message parses as a valid task — origin is the task row, not Chat.
+    task = wl._parse(_slack_seam_message("avii-slack-1"))
+    assert task is not None and task.task_id == "avii-slack-1"
+    # "chat" is the FIRST happy-path hop; the failure path must NOT begin there.
+    assert m.HOP_AGENTS_DEFAULT[0] == "chat"
+
+
+# ─── spec constants pinned to the live consumer (drift guard) ─────────────────
+
+
+def test_spec_constants_match_live_consumer():
+    # The avii spec names "5-min lease" and "dead-letter after 3" — pin them to
+    # the live consumer so an impl drift fails this gate.
+    assert wl.DEFAULT_LEASE_TTL_S == 300  # 5-minute slot lease
+    assert wl.DEFAULT_MAX_ATTEMPTS == 3  # dead-letter after 3 attempts
+
+
+# ─── item 1a — crash -> lease lapse -> reconcile reclaims -> loop resumes ──────
+
+
+async def test_crash_recovery_reclaims_slot_and_loop_resumes():
+    r, spawner = _redis(), _Spawner(result=True)
+    c = _consumer(r, spawner, ceiling=1)
+    # START AT SLACK SEAM: tasks arrive on keiracom:tasks:available.
+    assert await c.process_task(_slack_seam_message("avii-crash")) == "spawned"
+    await c.process_task(_slack_seam_message("avii-next"))  # overflowed at ceiling 1
+    assert spawner.calls == ["avii-crash"]
+    assert await r.exists(wl._lease_key(TENANT, "avii-crash")) == 1
+    # CRASH mid-task: no heartbeat -> the 5-min lease TTL lapses (simulated).
+    await r.delete(wl._lease_key(TENANT, "avii-crash"))
+    # RECONCILE reclaims the orphaned slot AND release pops overflow -> loop resumes.
+    assert await c.reconcile(TENANT) == 1
+    assert spawner.calls == ["avii-crash", "avii-next"]  # queued task now spawns
+    assert await r.get(wl._active_key(TENANT)) == "1"  # one live (the resumed task), not orphaned
+
+
+# ─── item 1b — retry counter increments -> dead-letter after 3 attempts ───────
+
+
+async def test_retry_increments_then_dead_letters_after_three_attempts():
+    r, spawner = _redis(), _Spawner(result=False)  # every spawn attempt fails
+    c = _consumer(r, spawner, ceiling=5)
+    # START AT SLACK SEAM.
+    await c.process_task(_slack_seam_message("avii-flaky"))
+    # retry counter increments via requeue+pop until max_attempts (3), then DLQ.
+    assert spawner.calls == ["avii-flaky", "avii-flaky", "avii-flaky"]
+    assert await r.lrange(wl.DEADLETTER_KEY, 0, -1) == [_slack_seam_message("avii-flaky")]
+    assert await r.get(wl._active_key(TENANT)) == "0"  # slot released, not orphaned
+    assert await r.llen(wl._overflow_key(TENANT)) == 0  # nothing stranded
+    assert await r.exists(wl._attempts_key("avii-flaky")) == 0  # attempts counter cleaned up
+    # the harness witnesses a dead_letter run as routed (P4) — not a hang.
+    assert m.classify_failure_path(_run(mode="dead_letter", dead_lettered=True)) is None
+
+
+# ─── item 2 — reconcile-miss -> NO orphan locked slot ─────────────────────────
+
+
+async def test_reconcile_miss_when_lease_alive_leaves_no_orphan():
+    r, spawner = _redis(), _Spawner(result=True)
+    c = _consumer(r, spawner, ceiling=5)
+    await c.process_task(_slack_seam_message("avii-live"))
+    # lease still ALIVE (agent heartbeating) -> reconcile must reclaim NOTHING.
+    assert await r.exists(wl._lease_key(TENANT, "avii-live")) == 1
+    assert await c.reconcile(TENANT) == 0  # reconcile-miss
+    assert await r.get(wl._active_key(TENANT)) == "1"  # slot intact, no spurious reclaim
+    assert await r.exists(wl._lock_key("avii-live")) == 1  # lock not orphaned/dropped
+
+
+async def test_double_release_is_idempotent_no_negative_counter():
+    r, spawner = _redis(), _Spawner(result=True)
+    c = _consumer(r, spawner, ceiling=5)
+    await c.process_task(_slack_seam_message("avii-once"))
+    await c.release_slot(TENANT, "avii-once")  # clean exit
+    assert await r.get(wl._active_key(TENANT)) == "0"
+    # a reconcile/release racing the same already-freed task must NOT drive the
+    # counter negative or leave an orphan (RELEASE_LUA SREM guard).
+    await c.release_slot(TENANT, "avii-once")
+    assert await r.get(wl._active_key(TENANT)) == "0"  # floored, never negative
+    assert await c.reconcile(TENANT) == 0  # nothing left to reclaim
+
+
+# ─── item 4 — with-memory run MUST assert recall >=1 atom (else FAIL) ─────────
+
+
+def test_with_memory_run_fails_when_recall_returns_zero_atoms():
+    # recall-active arm where every hop fired but bypassed / surfaced nothing.
+    barren = _run(mode="recall", active=True, useful=False)
+    ok, n = m.assert_recall_returned_atom(barren)
+    assert ok is False and n == 0
+    out = m.evaluate_gate(barren, _cold_run())
+    assert out.passed is False
+    assert any("0 relevant atoms" in r for r in out.reasons)  # FAIL, not silent pass
+
+
+def test_with_memory_run_passes_when_recall_returns_atom():
+    ok, n = m.assert_recall_returned_atom(_run(mode="recall", useful=True))
+    assert ok is True and n >= 1
+
+
+# ─── harness failure-path classifier (ties §9 modes to observed runs) ─────────
+
+
+def test_classify_failure_path_flags_unrecovered_crash():
+    assert m.classify_failure_path(_run(mode="crash", recovered=False)) == "crash_unrecovered"
+    assert m.classify_failure_path(_run(mode="crash", recovered=True)) is None
+    assert "crash_unrecovered" in m.FAILURE_MODES
+
+
+def test_classify_failure_path_flags_not_dead_lettered():
+    assert (
+        m.classify_failure_path(_run(mode="dead_letter", dead_lettered=False))
+        == "not_dead_lettered"
+    )
+    assert m.classify_failure_path(_run(mode="dead_letter", dead_lettered=True)) is None
+    assert "not_dead_lettered" in m.FAILURE_MODES
+
+
+def test_classify_failure_path_ignores_non_failure_runs():
+    assert m.classify_failure_path(_run(mode="cold", active=False, useful=False)) is None
+    assert m.classify_failure_path(_run(mode="recall")) is None


### PR DESCRIPTION
## Summary
Agency_OS-avii (P0). Viktor's full-chain dress rehearsal (`#1279` / `Agency_OS-jb4e`) is happy-path only. This adds the **failure-path** the rehearsal must witness, driven end-to-end against the **real** work-loop consumer (`fakeredis`, no live Valkey) + the harness — wiring into the dress-rehearsal per the spec.

Unblocked by PR #1310 (`21003bdc6` — lease reconcile + retry_count + dead-letter), now on `main`.

## What's covered (the 4 spec items)
1. **crash → lease → reconcile → retry → dead-letter**
   - `test_crash_recovery_reclaims_slot_and_loop_resumes`: spawn → crash (5-min lease lapses) → `reconcile()` reclaims the slot → the overflowed task spawns (loop *recovers*, P3). Slot freed, not orphaned.
   - `test_retry_increments_then_dead_letters_after_three_attempts`: retry counter increments via requeue+pop → **dead-letter after 3** → attempts counter cleaned up, slot released, nothing stranded (P4).
2. **reconcile-miss → no orphan slot**
   - `test_reconcile_miss_when_lease_alive_leaves_no_orphan`: live lease → `reconcile()` reclaims 0, slot + lock intact.
   - `test_double_release_is_idempotent_no_negative_counter`: double release floored, never negative (RELEASE_LUA SREM guard).
3. **starts at the SLACK seam, not Chat**
   - `test_failure_path_starts_at_slack_seam_not_chat`: origin is the `public.tasks` row → kei45 trigger → `keiracom:tasks:available` (asserted `harness.TASKS_CHANNEL == consumer.TASKS_CHANNEL`); every failure-path test consumes a `_slack_seam_message`, never a Chat-hop call.
4. **with-memory run asserts recall ≥1 atom (else FAIL)**
   - `test_with_memory_run_fails_when_recall_returns_zero_atoms`: a recall-active arm with 0 relevant atoms FAILS `evaluate_gate` (the "0 relevant atoms" reason) — not a silent pass.

Plus: `test_spec_constants_match_live_consumer` pins the spec's literal "5-min lease" / "after 3" to `consumer.DEFAULT_LEASE_TTL_S==300` / `DEFAULT_MAX_ATTEMPTS==3` (drift guard).

## Harness change
`scripts/cutover/full_chain_dress_rehearsal.py`: add `classify_failure_path(run)` — maps a crash/dead_letter `RunResult` to the §9 `crash_unrecovered` / `not_dead_lettered` modes (previously defined but unused), symmetric with `classify_spawn_failure`. So the harness *reports* the failure-path outcome (P3/P4) rather than hanging.

## Design note (faithful-to-impl, surfaced)
The impl **separates** crash-recovery (reconcile frees the slot + pops overflow) from spawn-retry (`_spawn_with_attempts` requeues failed spawns → dead-letter). `reconcile()` does **not** itself re-enqueue the crashed task. The tests assert the real semantics of each leg precisely rather than a single crash→dead-letter causal chain the code doesn't implement. #1310 unit-tests the individual mechanics; avii proves the **integrated dress-rehearsal failure path** + binds the seam/constants to the live consumer.

## Verification
- `tests/scripts/test_dress_rehearsal_failure_path.py` — **11 passed**.
- Regression: `tests/scripts/test_full_chain_dress_rehearsal.py` + `tests/keiracom_system/work_loop/` — **76 passed**.
- `ruff check` + `ruff format --check` clean on both files.

## Scope
Test-only + one small pure harness helper. No runtime/service code, no schema, no deps. Tests run hermetically (fakeredis); no live loop required.

🤖 [SCOUT] research/diagnosis clone