### PR TITLE
[ATLAS] fix(ops): openai-cost rollup — resolve tg + fail-open notify (Agency_OS-2uo8)

### DIFF
--- a/scripts/openai_cost_rollup.py
+++ b/scripts/openai_cost_rollup.py
@@ -11,6 +11,7 @@ Intended to run via systemd timer at 23:55 AEST (13:55 UTC).
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from collections import defaultdict
@@ -93,7 +94,14 @@ def send_slack_summary(summary: dict) -> None:
         f"save ${save_cost:.4f} | query-expansion ${qe_cost:.4f} "
         f"({calls} calls)"
     )
-    subprocess.run(["tg", "-g", msg], check=False)
+    # tg lives at ~/.local/bin/tg, which is NOT on the systemd --user PATH.
+    # Resolve it explicitly and fail open: a notification failure must never
+    # crash the cost rollup (check=False does NOT catch a missing binary).
+    tg_bin = shutil.which("tg") or os.path.expanduser("~/.local/bin/tg")
+    try:
+        subprocess.run([tg_bin, "-g", msg], check=False)
+    except OSError as exc:
+        print(f"warning: tg notify skipped ({exc})", file=sys.stderr)
 
 
 def main() -> None:

--- a/scripts/openai_cost_weekly.py
+++ b/scripts/openai_cost_weekly.py
@@ -10,6 +10,7 @@ Intended to run via systemd timer on Fridays at 18:00 AEST (08:00 UTC).
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from collections import defaultdict
@@ -124,7 +125,14 @@ def send_slack_summary(summary: dict) -> None:
         f"save ${save_cost:.4f} | query-expansion ${qe_cost:.4f} "
         f"({calls} total calls)"
     )
-    subprocess.run(["tg", "-g", msg], check=False)
+    # tg lives at ~/.local/bin/tg, which is NOT on the systemd --user PATH.
+    # Resolve it explicitly and fail open: a notification failure must never
+    # crash the cost rollup (check=False does NOT catch a missing binary).
+    tg_bin = shutil.which("tg") or os.path.expanduser("~/.local/bin/tg")
+    try:
+        subprocess.run([tg_bin, "-g", msg], check=False)
+    except OSError as exc:
+        print(f"warning: tg notify skipped ({exc})", file=sys.stderr)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
`openai-cost-daily.service` has been **failing (exit 1) every run for days** — a silent failure ja8d's alerting just surfaced.

**Root cause (empirical):** `openai_cost_rollup.py:96` (and `openai_cost_weekly.py:127`) call `subprocess.run(["tg", "-g", msg], check=False)`. `tg` lives at `~/.local/bin/tg`, which is **not on the systemd `--user` PATH** (`/usr/local/bin:/usr/bin:/bin:/snap/bin`). → `FileNotFoundError: 'tg'`. `check=False` only suppresses non-zero exits, **not** a missing-binary error, so the notification crash took down the whole rollup.

```
journalctl: FileNotFoundError: [Errno 2] No such file or directory: 'tg'
            openai-cost-daily.service: Main process exited, code=exited, status=1/FAILURE
```

## Fix (both scripts)
- Resolve `tg` via `shutil.which("tg")` with a `~/.local/bin/tg` fallback (so it works under systemd's PATH).
- Wrap the send in `try/except OSError` and fail open — a best-effort notification must never crash the cost rollup (matches the `notify_complete` / `save_exit_atoms` fail-open-notify convention elsewhere in the repo).

Both `openai_cost_rollup.py` and `openai_cost_weekly.py` had the identical bug; both fixed (weekly is `inactive` now but would fail next Sunday).

## Verification (local)
```
$ python3 scripts/openai_cost_rollup.py ; echo $?
SLACK_ACCESS_DENIED: callsign='atlas' blocked. Only elliot may post ...   # expected: tg RESOLVED + ran; relay is elliot-only (Dave 2026-05-19)
{ "date": "2026-05-29", "total_usd": 0.0, ... }
0                                                                          # exit 0 — fail-open works
```
- tg now resolves (no FileNotFoundError); exit 0. Under the real service (cwd = elliot worktree) the summary posts as elliot.
- `py_compile` OK. `ruff check` introduces no new violations (5 pre-existing UP017 left untouched — scope; CI lints `src/` only).

## Post-merge
On merge: pull main worktree → `systemctl --user start openai-cost-daily.service` → confirm exit 0 + reset-failed. Will verify the live service then.

## Test plan
- [ ] Post-merge: service runs exit 0; daily summary posts to the group as elliot
- [ ] `reset-failed` clears the stale failed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)