### PR TITLE
[ATLAS] fix(ops): cover @ template instances in OnFailure drop-ins (Agency_OS-cws5)

### DIFF
--- a/scripts/install_onfailure_dropins.sh
+++ b/scripts/install_onfailure_dropins.sh
@@ -8,16 +8,22 @@
 #   [Unit]
 #   OnFailure=keiracom-ops-failure-alert@%n.service
 #
+# Template units (foo@.service) ARE covered (Agency_OS-cws5): the drop-in lands
+# in foo@.service.d/, which systemd applies to every instance foo@<x>.service.
+# When an instance fails, %n is its full unit name; the handler
+# keiracom-ops-failure-alert@%n.service passes it verbatim to the publisher via
+# %i (NOT %I — %I unescapes '-' to '/'). The resulting double-@ instance name
+# resolves correctly — verified live via --selftest.
+#
 # EXCLUSIONS (never add a drop-in to):
-#   - keiracom-ops-failure-alert@.service (the template itself)
-#   - keiracom-ops-failure-alert@*.service instances (prevents recursion)
-#   - Any template unit whose name contains '@' with empty instance (e.g. foo@.service)
+#   - keiracom-ops-failure-alert@.service + its instances (prevents recursion)
 #
 # Idempotent: re-running writes the same content without error.
 #
 # Usage:
-#   bash scripts/install_onfailure_dropins.sh           # install
-#   bash scripts/install_onfailure_dropins.sh --remove  # remove all drop-ins
+#   bash scripts/install_onfailure_dropins.sh            # install
+#   bash scripts/install_onfailure_dropins.sh --remove   # remove all drop-ins
+#   bash scripts/install_onfailure_dropins.sh --selftest # live double-@ test
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,6 +34,38 @@ DROPIN_FILENAME="00-onfailure.conf"
 REMOVE=0
 if [[ "${1:-}" == "--remove" ]]; then
     REMOVE=1
+fi
+
+# ── --selftest: live double-@ regression test (Agency_OS-cws5) ─────────────────
+# Proves a drop-in on a TEMPLATE applies to its instances AND the failing
+# instance's full unit name survives %n -> handler -> %i (no '-'->'/' corruption).
+if [[ "${1:-}" == "--selftest" ]]; then
+    install -m 0644 "${REPO_DIR}/infra/systemd/agents/keiracom-ops-failure-alert@.service" \
+        "${HOME}/.config/systemd/user/keiracom-ops-failure-alert@.service"
+    U="${HOME}/.config/systemd/user"
+    T="zz-onfail-selftest"
+    alert_log="/home/elliotbot/clawd/logs/ops-failure-alert.log"
+    printf '[Unit]\nDescription=cws5 double-@ selftest\n[Service]\nType=oneshot\nExecStart=/bin/false\n' \
+        >"${U}/${T}@.service"
+    mkdir -p "${U}/${T}@.service.d"
+    printf '[Unit]\nOnFailure=keiracom-ops-failure-alert@%%n.service\n' \
+        >"${U}/${T}@.service.d/00-onfailure.conf"
+    systemctl --user daemon-reload
+    systemctl --user start "${T}@probe.service" 2>/dev/null || true
+    sleep 4
+    st_rc=1
+    if grep -q "unit=${T}@probe.service" "$alert_log" 2>/dev/null; then
+        echo "SELFTEST PASS: alert fired with correct instance unit '${T}@probe.service'"
+        st_rc=0
+    else
+        echo "SELFTEST FAIL: no 'unit=${T}@probe.service' in $alert_log" >&2
+        echo "  (ensure keiracom-ops-failure-alert@ template + NATS are deployed)" >&2
+    fi
+    systemctl --user reset-failed "${T}@probe.service" 2>/dev/null || true
+    rm -f "${U}/${T}@.service" "${U}/${T}@.service.d/00-onfailure.conf"
+    rmdir "${U}/${T}@.service.d" 2>/dev/null || true
+    systemctl --user daemon-reload
+    exit "$st_rc"
 fi
 
 # ── Install the template unit ─────────────────────────────────────────────────
@@ -84,12 +122,8 @@ for unit_file in "${UNITS_DIR}"/*.service; do
         continue
     fi
 
-    # Skip template units (name contains '@' with empty instance, e.g. foo@.service)
-    # A concrete instance looks like foo@bar.service; a bare template is foo@.service
-    if [[ "$unit_basename" == *@.service ]]; then
-        skipped=$((skipped + 1))
-        continue
-    fi
+    # Templates (foo@.service) ARE covered: dropin_dir resolves to
+    # foo@.service.d/, which systemd applies to every instance (cws5).
 
     dropin_dir="${UNITS_DIR}/${unit_basename}.d"
     dropin_conf="${dropin_dir}/${DROPIN_FILENAME}"


### PR DESCRIPTION
## Summary
ja8d follow-up (closes the gap filed in Agency_OS-cws5): `install_onfailure_dropins.sh` skipped `*@.service` templates, so the 7 running `agent-self-claim-loop@<callsign>` instances had **no** OnFailure alert.

## Why templates are safe to cover
A drop-in in `foo@.service.d/` applies to every instance `foo@<x>.service`. The failing instance's full unit name survives the chain:
`%n` (full unit name) → handler `keiracom-ops-failure-alert@%n.service` → `%i` (verbatim — **not** `%I`, which unescapes `-`→`/`).

**Verified live** (`--selftest`): `zz-onfail-selftest@probe.service` failed → publisher logged `unit=zz-onfail-selftest@probe.service` (double-`@` + dashes intact, no corruption).

## Changes
- Remove the `*@.service` skip — templates now covered via their `.d` dir (the script already computed `<unit>.d` correctly).
- Keep the `keiracom-ops-failure-alert@` exclusion (recursion guard).
- Add `--selftest`: a self-contained live double-`@` regression test (creates a throwaway template, fails an instance, asserts the publisher saw the correct instance unit name, cleans up). Exits 0/1.

## Verification (live, deployed host-side — reversible)
```
$ bash scripts/install_onfailure_dropins.sh --selftest
SELFTEST PASS: alert fired with correct instance unit 'zz-onfail-selftest@probe.service'

$ bash scripts/install_onfailure_dropins.sh
done — wrote 100 drop-in(s), skipped 1 unit(s)   # was: 99 wrote / 2 skipped

$ systemctl --user show agent-self-claim-loop@atlas.service -p OnFailure
OnFailure=keiracom-ops-failure-alert@agent-self-claim-loop@atlas.service.service
```
`bash -n` clean. Alert template still excluded (no self-drop-in → no recursion).

## Test plan
- [ ] `--selftest` passes on a host with the alert template + NATS deployed
- [ ] Fail a real agent-self-claim-loop instance → alert in #ceo with correct unit name
- [ ] `--remove` cleanly removes template drop-ins too

🤖 Generated with [Claude Code](https://claude.com/claude-code)