### PR TITLE
[ATLAS] feat(relay): non-elliot tg → NATS keiracom.elliot.inbox redirect (Agency_OS-rlfh part 2)

### DIFF
--- a/scripts/slack_relay.py
+++ b/scripts/slack_relay.py
@@ -38,15 +38,11 @@ import urllib.request
 from pathlib import Path
 
 # Slack access restricted to elliot only (Dave directive 2026-05-19 — only elliot
-# may post to Slack; default channel is #ceo). Other callsigns invoking this
-# script exit 2 with a clear denial message so callers know access was blocked.
+# may post to Slack; default channel is #ceo). Resolved non-elliot callsigns are
+# REDIRECTED to NATS (keiracom.elliot.inbox) rather than being denied at import
+# time — this keeps the module import side-effect-free so the redirect can happen
+# inside main() after args are parsed (Agency_OS-rlfh part 2).
 _CALLSIGN_ENFORCE = os.environ.get("CALLSIGN", "").strip().lower()
-if _CALLSIGN_ENFORCE and _CALLSIGN_ENFORCE != "elliot":
-    sys.stderr.write(
-        f"SLACK_ACCESS_DENIED: callsign={_CALLSIGN_ENFORCE!r} blocked. "
-        f"Only elliot may post to Slack per Dave directive 2026-05-19.\n"
-    )
-    sys.exit(2)
 # Elliot's default channel is #ceo (C0B2PM3TV0B), not #execution. Override the
 # module-default SLACK_DEFAULT_CHANNEL when running as elliot and no explicit
 # channel was set in the environment.
@@ -425,8 +421,79 @@ def _maybe_escalate_to_ceo(channel: str, text: str, callsign: str) -> None:
         print(f"KEI-80 WARN: CEO escalation post failed: {exc}", file=sys.stderr)
 
 
+def _redirect_to_nats(callsign: str, channel: str, message: str) -> int:
+    """Redirect a non-elliot Slack call to NATS keiracom.elliot.inbox.
+
+    Agency_OS-rlfh part 2: non-elliot callsigns must NEVER reach Slack.
+    Instead, publish the message as an envelope on Elliot's NATS inbox
+    subject so Elliot can decide what (if anything) to forward to Slack.
+
+    Returns 0 on successful publish, 1 on any failure. Mirrors the
+    supervisor_wake_publish pattern: lazy nats import + asyncio.run.
+    """
+    subject = os.environ.get("ELLIOT_INBOX_SUBJECT", "keiracom.elliot.inbox")
+    url = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
+    envelope = {
+        "from": callsign,
+        "kind": "relay_redirect",
+        "summary": message,
+        "requested_channel": channel,
+        "ts": time.time(),
+    }
+    payload = json.dumps(envelope).encode("utf-8")
+
+    async def _publish() -> int:
+        try:
+            import nats  # lazy — keeps module importable on hosts without nats-py
+        except ImportError as exc:
+            print(
+                f"NATS_REDIRECT_ERROR: nats-py not installed; cannot redirect "
+                f"callsign={callsign!r} message to NATS ({exc})",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            # max_reconnect_attempts=1 + reconnect_time_wait=0 → single attempt,
+            # fail fast without reconnect loop (nats-py: value=0 means "never
+            # discard server" per its source; =1 means discard after 1 retry).
+            nc = await nats.connect(
+                url, connect_timeout=5, max_reconnect_attempts=1, reconnect_time_wait=0
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"NATS_REDIRECT_ERROR: connect failed url={url!r} callsign={callsign!r}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            await nc.publish(subject, payload)
+            await nc.flush(timeout=5)
+            print(
+                f"redirected tg->NATS callsign={callsign} subject={subject} chars={len(message)}",
+                file=sys.stderr,
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"NATS_REDIRECT_ERROR: publish failed subject={subject!r} callsign={callsign!r}: {exc}",
+                file=sys.stderr,
+            )
+            await nc.close()
+            return 1
+        await nc.close()
+        return 0
+
+    import asyncio
+
+    return asyncio.run(_publish())
+
+
 def main() -> int:
     channel, message = parse_args(sys.argv[1:])
+    # Agency_OS-rlfh part 2: resolved non-elliot callsigns redirect to NATS.
+    # parse_args() guarantees message is non-empty (exits 2 otherwise).
+    # This guard runs BEFORE any Slack path — non-elliot NEVER reaches Slack.
+    if CALLSIGN and CALLSIGN != "elliot":
+        return _redirect_to_nats(CALLSIGN, channel, message)
     # KEI-33 — R13 BLOCKER ESCALATION. Runs FIRST so the channel-swap is
     # visible to every downstream gate (R11 #ceo-format, KEI-80 additive
     # escalation). Redirect is a no-op for clone callsigns and for

--- a/tests/test_slack_relay_callsign_fix.py
+++ b/tests/test_slack_relay_callsign_fix.py
@@ -7,13 +7,22 @@ refuse to post to channels not in the per-callsign allowlist.
 Deliberation-layer #ceo grant (2026-05-18, PR #1027): Elliot/Aiden/Max
 may post to #ceo. Clones (atlas/orion/scout/nova) post to #execution
 only. Nova was added explicitly as a fourth clone.
+
+Agency_OS-rlfh part 2 (2026-05-29): resolved non-elliot callsigns no
+longer exit 2 with SLACK_ACCESS_DENIED at import. Instead, main()
+redirects them to NATS (keiracom.elliot.inbox). Tests below use an
+unreachable NATS address (port 1) so _redirect_to_nats returns 1
+deterministically without a live NATS server.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
+import types
+import unittest.mock as mock
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -63,20 +72,30 @@ def _build_fake_repo(tmp_path: Path, callsign: str) -> Path:
 def test_callsign_resolves_from_identity_md(tmp_path: Path) -> None:
     """No CALLSIGN env + IDENTITY.md present → resolves callsign from file.
 
-    Uses fake_repo with **CALLSIGN:** orion. Posting to #ceo from orion
-    (clone, execution-only allowlist) must produce the allowlist refusal
-    message tagged with the resolved callsign.
+    Uses fake_repo with **CALLSIGN:** orion. With Agency_OS-rlfh part 2,
+    orion is redirected to NATS instead of denied. Port 1 is unreachable so
+    _redirect_to_nats returns 1. Slack must never be reached (no
+    SLACK_ACCESS_DENIED, no allowlist refusal — just a NATS_REDIRECT_ERROR).
     """
     relay_copy = _build_fake_repo(tmp_path, "orion")
     result = subprocess.run(
         [sys.executable, str(relay_copy), "-c", CHANNEL_CEO, "test"],
-        env={"PATH": os.environ.get("PATH", ""), "SLACK_BOT_TOKEN": "fake-token"},
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "SLACK_BOT_TOKEN": "fake-token",
+            "NATS_URL": "nats://127.0.0.1:1",
+        },
         capture_output=True,
         text=True,
         timeout=10,
     )
-    assert result.returncode == 2
-    assert f"orion-relay refuses post to {CHANNEL_CEO}" in result.stderr
+    # Redirect attempted → NATS unreachable → exit 1
+    assert result.returncode == 1
+    # Must NOT carry the old denial/allowlist messages
+    assert "SLACK_ACCESS_DENIED" not in result.stderr
+    assert f"orion-relay refuses post to {CHANNEL_CEO}" not in result.stderr
+    # Must show a NATS redirect error (not a Slack API call)
+    assert "NATS_REDIRECT_ERROR" in result.stderr
 
 
 def test_callsign_unresolved_exits_2(tmp_path: Path) -> None:
@@ -147,13 +166,11 @@ def test_nova_can_post_execution() -> None:
 
 
 def test_nova_blocked_from_ceo() -> None:
-    """PR #1027 — nova is a clone; #ceo remains forbidden for clones.
+    """Agency_OS-rlfh part 2 — nova is redirected to NATS, never reaches Slack.
 
-    Superseded by the Dave 2026-05-19 Slack-access lock: when CALLSIGN is
-    set via env to any non-elliot value, slack_relay.py exits 2 at import
-    with a SLACK_ACCESS_DENIED message before the per-callsign allowlist is
-    even reached. Nova is still blocked from #ceo — the denial is now
-    broader (all channels) and the message changed.
+    Previously nova exited 2 with SLACK_ACCESS_DENIED at import. Now main()
+    redirects to NATS. Port 1 is unreachable so _redirect_to_nats returns 1.
+    Key invariants: no SLACK_ACCESS_DENIED, no Slack API call, exit 1 (not 0).
     """
     result = _run(
         env={
@@ -162,12 +179,76 @@ def test_nova_blocked_from_ceo() -> None:
             "R_LAW_XV_SKIP": "1",
             "CONCUR_GATE_SKIP": "1",
             "CALLSIGN": "nova",
+            "NATS_URL": "nats://127.0.0.1:1",
         },
         args=["-c", CHANNEL_CEO, CEO_COMPLIANT_BODY],
     )
-    assert result.returncode == 2
-    assert "SLACK_ACCESS_DENIED" in result.stderr
-    assert "callsign='nova'" in result.stderr
+    # Redirect attempted → NATS unreachable → exit 1 (not 2, not 0)
+    assert result.returncode == 1
+    # Must NOT carry the old import-time denial
+    assert "SLACK_ACCESS_DENIED" not in result.stderr
+    # Must show a NATS redirect error confirming Slack was never reached
+    assert "NATS_REDIRECT_ERROR" in result.stderr
+
+
+def test_redirect_to_nats_envelope_shape() -> None:
+    """Unit test: _redirect_to_nats publishes correct envelope shape on success.
+
+    Monkeypatches the nats module so no live NATS server is required.
+    Verifies: envelope has from==callsign, summary==message, subject matches
+    default, kind==relay_redirect, ts is a float; function returns 0.
+    """
+    import sys
+
+    # Build a fake nats module with a fake client that captures published data.
+    published: list[tuple[str, bytes]] = []
+
+    class FakeNatsClient:
+        async def publish(self, subject: str, payload: bytes) -> None:
+            published.append((subject, payload))
+
+        async def flush(self, timeout: float = 5.0) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
+
+    fake_nats = types.ModuleType("nats")
+
+    async def fake_connect(url: str, **kwargs: object) -> FakeNatsClient:
+        return FakeNatsClient()
+
+    fake_nats.connect = fake_connect  # type: ignore[attr-defined]
+
+    # Ensure CALLSIGN env is elliot so module-level resolution doesn't early-exit.
+    # _redirect_to_nats is a module-level function; we import slack_relay with
+    # CALLSIGN=elliot to avoid any side-effects, then call _redirect_to_nats directly.
+    orig_env = os.environ.copy()
+    os.environ["CALLSIGN"] = "elliot"
+    sys.modules.pop("slack_relay", None)
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    try:
+        import slack_relay  # type: ignore[import]
+        # Inject fake nats into sys.modules so the lazy import inside _redirect_to_nats finds it.
+        with mock.patch.dict(sys.modules, {"nats": fake_nats}):
+            rc = slack_relay._redirect_to_nats("orion", CHANNEL_EXECUTION, "hello from orion")
+    finally:
+        sys.modules.pop("slack_relay", None)
+        if str(REPO_ROOT / "scripts") in sys.path:
+            sys.path.remove(str(REPO_ROOT / "scripts"))
+        os.environ.clear()
+        os.environ.update(orig_env)
+
+    assert rc == 0, f"expected return 0 on success, got {rc}"
+    assert len(published) == 1, f"expected 1 publish call, got {len(published)}"
+    subject, payload_bytes = published[0]
+    assert subject == "keiracom.elliot.inbox", f"wrong subject: {subject!r}"
+    envelope = json.loads(payload_bytes.decode("utf-8"))
+    assert envelope["from"] == "orion"
+    assert envelope["summary"] == "hello from orion"
+    assert envelope["kind"] == "relay_redirect"
+    assert isinstance(envelope["ts"], float)
+    assert "requested_channel" in envelope
 
 
 def test_env_callsign_overrides_identity(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
**Part 2 of Agency_OS-rlfh.** Today a resolved non-elliot callsign invoking `slack_relay.py` is **denied** (`SLACK_ACCESS_DENIED`, exit 2). This redirects the message to NATS `keiracom.elliot.inbox` with a from-callsign envelope, so Aiden/Max/Atlas/etc can route results to Elliot (who decides what reaches Slack). Required for the V1 chain's Worker/Reviewer agents to report back without direct Slack access.

## Changes (`scripts/slack_relay.py`)
- Module guard: removed the import-time `exit(2)` for non-elliot → **import is now side-effect-free**. Kept elliot's `SLACK_DEFAULT_CHANNEL` override and the separate **unresolved-callsign `exit(2)`** guard.
- `main()`: redirect at the very top (after `parse_args`, before any Slack/escalation path) when `CALLSIGN != "elliot"`. `CALLSIGN` is always lowercased by `_resolve_callsign`, so **elliot is never wrongly redirected**.
- `_redirect_to_nats()`: builds `{from, kind:"relay_redirect", summary, requested_channel, ts}` → publishes to `keiracom.elliot.inbox` (mirrors `supervisor_wake_publish`). **Fail-closed**: any NATS error → return 1 with `NATS_REDIRECT_ERROR`; a non-elliot message **never** reaches Slack. Envelope matches `nats_to_inbox_bridge` (`from`→sender, `summary`→text).

## Verification
**Live acceptance (the dispatch criterion):**
```
$ CALLSIGN=atlas tg "rlfh-tg-shim-... via tg shim"
redirected tg->NATS callsign=atlas subject=keiracom.elliot.inbox chars=31   (exit 0)
# NATS subscriber on keiracom.elliot.inbox received:
{"from":"atlas","kind":"relay_redirect","summary":"rlfh-tg-shim-... via tg shim","requested_channel":"C0B3QB0K1GQ","ts":...}
```
Non-elliot Slack post count → **zero** (redirects, never posts). Elliot path unchanged.
- `tests/test_slack_relay_callsign_fix.py`: **8 passed** (updated the resolved-non-elliot assertions to the redirect behavior; kept unresolved→exit 2). `ruff check` clean.

## Scope note — Part 1 (NATS ACLs) deliberately excluded
rlfh part 1 (per-callsign NATS account ACLs) is **not** in this PR. NATS is currently **no-auth** (`infra/nats/nats-server.conf` has no `accounts`/`authorization` block) and every client connects bare — so ACLs are a **fleet-wide auth migration** (provision per-callsign creds → update every `nats.connect` in relay/dispatchers/bridges → coordinated cutover), not a safe single-PR change bundled with this. Surfaced to the orchestrator for staging.

## Test plan
- [ ] Merge → non-elliot `tg`/relay calls land in Elliot's inbox via the bridge
- [ ] Confirm Slack post count from non-elliot callsigns is zero in practice
- [ ] Part 1 ACLs sequenced separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)