### PR TITLE
[ORION] feat(face): wire Face→Aiden dispatch on classification (Agency_OS-zr7e.1)

### DIFF
--- a/src/keiracom_system/chat/face.py
+++ b/src/keiracom_system/chat/face.py
@@ -57,6 +57,13 @@ MAX_HISTORY = 5  # recent user turns fed to the classifier
 NATS_URL = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
 DISPATCH_SUBJECT = "keiracom.dispatch.aiden"
 DISPATCH_TO = "aiden"
+# Original Postgres tasks.id from the dispatcher at spawn — used as task_id so
+# Aiden's work (and downstream cost attribution per PR #1312 task_complete) can
+# be tracked back to the originating tasks row. Falls back to a fresh uuid4 in
+# manual invocations so `python3 -m ...face` still runs.
+# TODO Companion change: dispatcher must set FACE_TASK_ID=<tasks.id> in the
+# spawn env (see zr7e.5).
+FACE_TASK_ID = os.environ.get("FACE_TASK_ID")
 
 ClassifyFn = Callable[[str, int, list[str]], ChatContextResult]
 SaveFn = Callable[[list[dict[str, str]], int], Awaitable[ExitCycleResult]]
@@ -140,7 +147,7 @@ def _respond(
     if result.classification == "ambiguous":
         return "Escalating to a deliberator — not enough context to route this."
     if result.classification == "task":
-        task_id = str(uuid.uuid4())
+        task_id = FACE_TASK_ID or str(uuid.uuid4())
         if dispatch(brief=message, task_id=task_id, atom_id=None):
             return f"Dispatching to Aiden (deliberator). Briefed on: {message[:100]}"
         return "Dispatch failed — try again."

--- a/src/keiracom_system/chat/face.py
+++ b/src/keiracom_system/chat/face.py
@@ -3,15 +3,19 @@
 The Face is the Chat leg of the V1 chain:
     Dave types in Slack → Face → Deliberator → Worker → Reviewer → result back.
 
-This is the MINIMAL spawnable entrypoint (Agency_OS-ii3ucd). It:
+A 'task'-classified message triggers a NATS dispatch to Aiden (subject
+``keiracom.dispatch.aiden``) — fail-open: if NATS is unreachable the Face
+returns a human-readable retry response and the process keeps running.
+
+This is the spawnable entrypoint (Agency_OS-ii3ucd + zr7e.1 dispatch wiring).
+It:
   1. reads a brief / inbound messages,
   2. runs a message → classify → respond loop (classification via
-     context_composer.compose_chat_context), and
-  3. calls exit_cycle.classify_and_save before exit so any ratified decision in
+     context_composer.compose_chat_context),
+  3. on classification=='task', publishes {type, task_id, atom_id,
+     from_callsign, to_callsign, brief, ts} to keiracom.dispatch.aiden, and
+  4. calls exit_cycle.classify_and_save before exit so any ratified decision in
      the conversation survives the ephemeral spawn.
-
-The deliberator-spawn chain is deliberately NOT wired here — a classified message
-yields a stub routing response. That leg lands in a later directive.
 
 Spawnable:
     python3 -m src.keiracom_system.chat.face
@@ -19,17 +23,21 @@ Spawnable:
   - Further messages: piped stdin, one per line ('exit'/'quit'/EOF ends the loop).
   - customer_id: FACE_CUSTOMER_ID env (default 1 — Dave = fleet tenant 1).
 
-Fail-open: with no Gemini/Hindsight/DB creds, classification degrades to
-'ambiguous' and the exit cycle skips — the process still runs clean and exits 0.
-An interactive TTY with no brief prints a usage hint and exits 0 (never blocks).
+Fail-open: with no Gemini/Hindsight/DB/NATS creds, classification degrades to
+'ambiguous', dispatch returns False, the exit cycle skips — the process still
+runs clean and exits 0. An interactive TTY with no brief prints a usage hint
+and exits 0 (never blocks).
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import sys
+import time
+import uuid
 from collections.abc import Awaitable, Callable, Iterable
 
 from src.keiracom_system.chat.context_composer import ChatContextResult, compose_chat_context
@@ -42,8 +50,17 @@ DEFAULT_CUSTOMER_ID = 1  # Dave = fleet tenant 1
 EXIT_SENTINELS = {"exit", "quit"}
 MAX_HISTORY = 5  # recent user turns fed to the classifier
 
+# zr7e.1 — NATS dispatch transport. Aiden's nats_tmux_bridge subscribes
+# keiracom.dispatch.aiden (live per Elliot+Aiden architecture review 2026-05-29).
+# Mirrors scripts/fleet_supervisor._nats_publish_state: lazy nats-py import,
+# asyncio.run(connect/publish/flush/close), fail-open warn on failure.
+NATS_URL = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
+DISPATCH_SUBJECT = "keiracom.dispatch.aiden"
+DISPATCH_TO = "aiden"
+
 ClassifyFn = Callable[[str, int, list[str]], ChatContextResult]
 SaveFn = Callable[[list[dict[str, str]], int], Awaitable[ExitCycleResult]]
+DispatchFn = Callable[..., bool]  # (*, brief, task_id, atom_id) -> bool
 
 
 def _customer_id() -> int:
@@ -68,10 +85,65 @@ def _briefs() -> Iterable[str]:
             yield line.strip()
 
 
-def _respond(result: ChatContextResult) -> str:
-    """Stub routing response (the deliberator-spawn chain is not wired in V1)."""
+def _dispatch_to_aiden(*, brief: str, task_id: str, atom_id: str | None = None) -> bool:
+    """Publish a task_dispatch envelope to NATS keiracom.dispatch.aiden. Fail-open.
+
+    Returns True on publish success, False on any failure — no exception escapes.
+    Mirrors fleet_supervisor._nats_publish_state (lazy nats-py + asyncio.run).
+
+    atom_id is None at V1 Face dispatch (atoms are written at conversation exit,
+    not per-message); zr7e.9 will populate it once the exit_cycle pointer is the
+    handoff signal.
+    """
+    payload = json.dumps(
+        {
+            "type": "task_dispatch",
+            "task_id": task_id,
+            "atom_id": atom_id,
+            "from_callsign": CALLSIGN,
+            "to_callsign": DISPATCH_TO,
+            "brief": brief,
+            "ts": int(time.time()),
+        }
+    ).encode()
+    try:
+        import nats.aio.client as nats_client  # noqa: PLC0415 — optional dep, lazy
+
+        async def _publish() -> None:
+            nc = nats_client.Client()
+            await nc.connect(NATS_URL, connect_timeout=2)
+            try:
+                await nc.publish(DISPATCH_SUBJECT, payload)
+                await nc.flush()
+            finally:
+                await nc.close()
+
+        asyncio.run(_publish())
+        logger.info("face: NATS PUBLISH %s → task_id=%s", DISPATCH_SUBJECT, task_id)
+        return True
+    except Exception as exc:  # noqa: BLE001 — fail-open: NATS failure must never crash Face
+        logger.warning("face: NATS dispatch failed (non-fatal): %s", exc)
+        return False
+
+
+def _respond(
+    result: ChatContextResult,
+    message: str = "",
+    *,
+    dispatch: DispatchFn = _dispatch_to_aiden,
+) -> str:
+    """Compose the Face's reply; on classification=='task', dispatch to Aiden first.
+
+    Non-'task' branches keep the V1 stub routing strings (worker/reviewer spawn
+    legs land in later directives). 'task' goes to Aiden via NATS, fail-open.
+    """
     if result.classification == "ambiguous":
         return "Escalating to a deliberator — not enough context to route this."
+    if result.classification == "task":
+        task_id = str(uuid.uuid4())
+        if dispatch(brief=message, task_id=task_id, atom_id=None):
+            return f"Dispatching to Aiden (deliberator). Briefed on: {message[:100]}"
+        return "Dispatch failed — try again."
     return (
         f"Classified as '{result.classification}'. Routing to the "
         f"{result.classification} tier (spawn not yet wired — V1 Chat leg)."
@@ -83,18 +155,20 @@ def run_conversation(
     customer_id: int,
     *,
     classify: ClassifyFn = compose_chat_context,
+    dispatch: DispatchFn = _dispatch_to_aiden,
 ) -> list[dict[str, str]]:
     """Drive the classify→respond loop. Returns the full conversation transcript.
 
     `classify` is the compose_chat_context seam (fail-open by contract — it
     degrades to 'ambiguous' rather than raising), injectable for tests.
+    `dispatch` is the Face→Aiden NATS publish seam, also injectable for tests.
     """
     conversation: list[dict[str, str]] = []
     for message in messages:
         if not message or message.lower() in EXIT_SENTINELS:
             break
         history = [m["content"] for m in conversation if m["role"] == "user"][-MAX_HISTORY:]
-        reply = _respond(classify(message, customer_id, history))
+        reply = _respond(classify(message, customer_id, history), message, dispatch=dispatch)
         conversation.append({"role": "user", "content": message})
         conversation.append({"role": "assistant", "content": reply})
         print(reply, flush=True)
@@ -106,6 +180,7 @@ def run(
     briefs: Callable[[], Iterable[str]] = _briefs,
     classify: ClassifyFn = compose_chat_context,
     save: SaveFn = classify_and_save,
+    dispatch: DispatchFn = _dispatch_to_aiden,
 ) -> int:
     """Spawn orchestration: run the loop, then the exit cycle. Returns exit code."""
     logging.basicConfig(level=logging.INFO)
@@ -117,7 +192,7 @@ def run(
             "Usage: FACE_BRIEF='...' python3 -m %s  (or pipe messages on stdin)",
             __spec__.name if __spec__ else __name__,
         )
-    conversation = run_conversation(messages, customer_id, classify=classify)
+    conversation = run_conversation(messages, customer_id, classify=classify, dispatch=dispatch)
     result: ExitCycleResult = asyncio.run(save(conversation, customer_id))
     logger.info(
         "face: exit cycle — saved=%d skipped=%s bank=%s",

--- a/tests/keiracom_system/chat/test_face.py
+++ b/tests/keiracom_system/chat/test_face.py
@@ -199,3 +199,34 @@ def test_dispatch_to_aiden_fail_open_on_nats_error(monkeypatch):
 
     # Must not raise; must return False.
     assert face._dispatch_to_aiden(brief="x", task_id="t-2") is False
+
+
+def test_respond_task_uses_face_task_id_when_set(monkeypatch):
+    """FACE_TASK_ID env from the dispatcher is used as the dispatch task_id,
+    so Aiden's work is attributable back to the original Postgres tasks row
+    (PR #1312 cost-attribution path)."""
+    calls: list[dict[str, Any]] = []
+
+    def _ok(**kw: Any) -> bool:
+        calls.append(kw)
+        return True
+
+    monkeypatch.setattr(face, "FACE_TASK_ID", "t-9999")
+    reply = face._respond(_ctx("task"), "set up X", dispatch=_ok)
+    assert "Dispatching to Aiden" in reply
+    assert calls[0]["task_id"] == "t-9999"
+
+
+def test_respond_task_falls_back_to_uuid4_when_face_task_id_unset(monkeypatch):
+    """When FACE_TASK_ID is None, manual invocations still work — task_id is
+    a fresh uuid4 string."""
+    calls: list[dict[str, Any]] = []
+
+    def _ok(**kw: Any) -> bool:
+        calls.append(kw)
+        return True
+
+    monkeypatch.setattr(face, "FACE_TASK_ID", None)
+    face._respond(_ctx("task"), "x", dispatch=_ok)
+    tid = calls[0]["task_id"]
+    assert isinstance(tid, str) and len(tid) == 36 and tid.count("-") == 4

--- a/tests/keiracom_system/chat/test_face.py
+++ b/tests/keiracom_system/chat/test_face.py
@@ -53,7 +53,11 @@ def test_respond_routes_by_classification():
 
 def test_run_conversation_builds_transcript_and_passes_history():
     classify, seen = _classify("task")
-    convo = face.run_conversation(["set up X", "and Y"], 7, classify=classify)
+    # 'task' now triggers a NATS dispatch — inject a no-op so the test doesn't
+    # try to reach a real NATS server.
+    convo = face.run_conversation(
+        ["set up X", "and Y"], 7, classify=classify, dispatch=lambda **_kw: True
+    )
     # user+assistant per message
     assert [m["role"] for m in convo] == ["user", "assistant", "user", "assistant"]
     assert convo[0]["content"] == "set up X"
@@ -95,3 +99,103 @@ def test_run_returns_zero_even_when_exit_cycle_skips():
 
     rc = face.run(briefs=lambda: ["hi"], classify=_classify("technical")[0], save=_skip)
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# zr7e.1 — Face → Aiden NATS dispatch on classification == 'task'
+# ---------------------------------------------------------------------------
+
+
+def test_respond_task_dispatches_and_confirms():
+    """'task' → dispatch fires once with the brief; reply confirms the dispatch."""
+    calls: list[dict[str, Any]] = []
+
+    def _ok_dispatch(**kw: Any) -> bool:
+        calls.append(kw)
+        return True
+
+    reply = face._respond(_ctx("task"), "set up X", dispatch=_ok_dispatch)
+    assert "Dispatching to Aiden" in reply
+    assert "set up X" in reply
+    assert len(calls) == 1
+    assert calls[0]["brief"] == "set up X"
+    # task_id is a uuid4 hex-shape string (deterministic only in length/shape).
+    assert isinstance(calls[0]["task_id"], str) and len(calls[0]["task_id"]) == 36
+    assert calls[0]["atom_id"] is None  # V1: Face has no atom_id yet (zr7e.9 follows)
+
+
+def test_respond_task_dispatch_failure_returns_retry():
+    """Dispatch returning False → 'Dispatch failed — try again', never raises."""
+
+    def _fail_dispatch(**_kw: Any) -> bool:
+        return False
+
+    reply = face._respond(_ctx("task"), "do the thing", dispatch=_fail_dispatch)
+    assert reply == "Dispatch failed — try again."
+
+
+def test_respond_non_task_does_not_dispatch():
+    """Non-'task' classifications must not call dispatch (fast path, no NATS)."""
+
+    def _explode(**_kw: Any) -> bool:
+        raise AssertionError("dispatch must not be called for non-'task' classifications")
+
+    # technical, escalation, ambiguous — none should dispatch.
+    assert "technical" in face._respond(_ctx("technical"), "what is X", dispatch=_explode)
+    assert "escalation" in face._respond(_ctx("escalation"), "urgent!", dispatch=_explode)
+    assert "Escalating" in face._respond(_ctx("ambiguous"), "?", dispatch=_explode)
+
+
+def test_dispatch_to_aiden_publishes_correct_envelope(monkeypatch):
+    """_dispatch_to_aiden publishes to the canonical subject with full payload."""
+    captured: dict[str, Any] = {}
+
+    class _FakeNC:
+        async def connect(self, url, connect_timeout=2):  # noqa: ARG002 — sig match
+            captured["url"] = url
+
+        async def publish(self, subject, payload):
+            captured["subject"] = subject
+            captured["payload"] = payload
+
+        async def flush(self):
+            captured["flushed"] = True
+
+        async def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr("nats.aio.client.Client", lambda: _FakeNC())
+
+    ok = face._dispatch_to_aiden(brief="ship it", task_id="t-1", atom_id=None)
+
+    assert ok is True
+    assert captured["subject"] == face.DISPATCH_SUBJECT == "keiracom.dispatch.aiden"
+    assert captured["url"] == face.NATS_URL
+    assert captured["flushed"] is True and captured["closed"] is True
+    import json as _json
+
+    body = _json.loads(captured["payload"].decode())
+    assert body["type"] == "task_dispatch"
+    assert body["task_id"] == "t-1"
+    assert body["atom_id"] is None
+    assert body["from_callsign"] == "face"
+    assert body["to_callsign"] == "aiden"
+    assert body["brief"] == "ship it"
+    assert isinstance(body["ts"], int)
+
+
+def test_dispatch_to_aiden_fail_open_on_nats_error(monkeypatch):
+    """NATS connect/publish failure → False, no exception escapes."""
+
+    class _BoomNC:
+        async def connect(self, url, connect_timeout=2):  # noqa: ARG002
+            raise OSError("nats unreachable")
+
+        async def publish(self, *a, **kw): ...
+        async def flush(self): ...
+        async def close(self): ...
+
+    monkeypatch.setattr("nats.aio.client.Client", lambda: _BoomNC())
+
+    # Must not raise; must return False.
+    assert face._dispatch_to_aiden(brief="x", task_id="t-2") is False


### PR DESCRIPTION
## Summary
V1 chain Chat-leg dispatch (**zr7e.1**, Elliot dispatch with `STEP 0 PRE-CONFIRMED`; Aiden architecture review confirmed the 4 corrections I proposed earlier). When `context_composer` classifies a message as `task`, Face publishes a `task_dispatch` envelope to NATS `keiracom.dispatch.aiden`. Non-`task` branches keep the V1 stub routing strings.

- **`_dispatch_to_aiden(*, brief, task_id, atom_id=None) -> bool`** — mirrors `scripts/fleet_supervisor._nats_publish_state`: lazy `nats-py` import, `asyncio.run(connect/publish/flush/close)`, fail-open warn on failure. Subject `keiracom.dispatch.aiden`; payload `{type, task_id, atom_id, from_callsign='face', to_callsign='aiden', brief, ts}`.
- **`_respond()`** — `task` → dispatch; success returns `"Dispatching to Aiden (deliberator). Briefed on: {brief[:100]}"`; failure returns `"Dispatch failed — try again."` (never crashes Face). `dispatch` is a DI seam matching the existing `classify`/`save` injection pattern.
- **`atom_id` is `None` at Face dispatch** — atoms are written at conversation *exit* (`exit_cycle.classify_and_save`), not per-message. **zr7e.9** (handoff transport) will populate `atom_id` once the exit-cycle pointer becomes the handoff signal.
- **Tests** — 5 new + 7 existing preserved (1 updated to inject a no-op dispatch so it doesn't reach real NATS).

## Acceptance
1. ✅ `task`-classified message → `_dispatch_to_aiden` publishes to `keiracom.dispatch.aiden` with `{task_id, atom_id, …}`.
2. ✅ Unit test captures the publish on the canonical subject with full payload shape (`test_dispatch_to_aiden_publishes_correct_envelope`).
3. ✅ CI green locally — `ruff check`, `ruff format --check`, `pytest tests/keiracom_system/chat/test_face.py` = 12/12.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/keiracom_system/chat/test_face.py` → **12 passed** (7 existing preserved + 5 new dispatch tests)
- [x] Fail-open paths verified: NATS error → False (no exception), non-`task` classifications never call dispatch
- [x] Subject + payload shape verified against the dispatched contract

## Pattern note
Mirrors the established fleet NATS publish pattern (`fleet_supervisor._nats_publish_state` line 103+): lazy `nats-py` import inside `try`, `asyncio.run` wrapping a short publish coroutine, `connect_timeout=2`, INFO log on success / WARN log on failure. No new infrastructure introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)