### PR TITLE
[ATLAS] feat(chain): v1_chain_orchestrator — first-hop dispatch + state machine (Agency_OS-zr7e.2)

### DIFF
--- a/src/keiracom_system/chain/__init__.py
+++ b/src/keiracom_system/chain/__init__.py
@@ -1,0 +1,1 @@
+"""V1 chain orchestrator package."""

--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -1,0 +1,312 @@
+"""v1_chain_orchestrator.py — per-task chain-state tracker and NATS dispatcher.
+
+V1 chain order (left to right):
+    Face → aiden_plan → max_challenge → nova_build
+                                              ↓ (parallel)
+                                    orion_spec + atlas_safety
+                                              ↓ (both done)
+                                           complete
+
+Coordination point with Orion zr7e.9 (atom_id NATS transport):
+    The envelope key ``atom_id`` carries the atom_id returned by the PRIOR
+    chain step's Atom completion signal. On the first hop (Face → Aiden) this
+    is None. Each subsequent ``advance_step`` call receives the completing
+    step's atom_id and propagates it forward in the envelope so the next agent
+    can link its work to the prior Atom. When Orion's zr7e.9 ships, the
+    subscriber loop will read ``atom_id`` from the envelope and wire it into
+    the Atom store automatically.
+
+Explicit non-goals for this PR (Agency_OS-zr7e.2):
+    - No live status-event subscriber loop — Orion's zr7e.9 atom_id publisher
+      does not exist yet; a subscriber would be misleading scaffolding.
+    - vault/agent_cold_start.py notify-suppression — Orion's zr7e.9 scope.
+    - NATS ACLs — rlfh part 1, separate PR.
+
+Usage (first-hop acceptance test):
+    chain_id = dispatch({"id": "task-1", "brief": "scaffold the auth module"})
+    # Subscribing to keiracom.dispatch.aiden will receive the envelope.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import tempfile
+import time
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+
+NATS_URL = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
+DISPATCH_SUBJECT_PATTERN = "keiracom.dispatch.{callsign}"
+STATE_FILE = Path(os.environ.get("V1_CHAIN_STATE_FILE", "/tmp/v1_chain_state.json"))
+
+CHAIN_STEPS: tuple[str, ...] = (
+    "aiden_plan",
+    "max_challenge",
+    "nova_build",
+    "orion_spec",
+    "atlas_safety",
+    "complete",
+)
+
+ROLE_FOR_STEP: dict[str, str] = {
+    "aiden_plan": "aiden",
+    "max_challenge": "max",
+    "nova_build": "nova",
+    "orion_spec": "orion",
+    "atlas_safety": "atlas",
+}
+
+# Steps whose completion fans out to multiple parallel dispatches.
+# Value = list of *next* steps to dispatch simultaneously.
+PARALLEL_AFTER_STEP: dict[str, list[str]] = {
+    "nova_build": ["orion_spec", "atlas_safety"],
+}
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_state() -> dict:
+    """Return the full state dict from STATE_FILE, or {} if absent/invalid."""
+    try:
+        if STATE_FILE.exists():
+            return json.loads(STATE_FILE.read_text())
+    except Exception as exc:  # noqa: BLE001
+        log.warning("v1_chain: failed to load state file %s: %s", STATE_FILE, exc)
+    return {}
+
+
+def _save_state(state: dict) -> None:
+    """Atomically write state to STATE_FILE (temp + os.replace)."""
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=STATE_FILE.parent, prefix=".v1_chain_state_")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(state, fh, indent=2)
+        os.replace(tmp, STATE_FILE)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+async def _publish_async(envelope: dict, role: str) -> bool:
+    """Inner async NATS publish — mirrors supervisor_wake_publish.publish_wake."""
+    subject = DISPATCH_SUBJECT_PATTERN.format(callsign=role)
+    try:
+        import nats  # lazy — keeps module collectable on CI hosts without nats-py
+    except ImportError as exc:
+        log.error("v1_chain: nats-py not installed; publish skipped (%s)", exc)
+        return False
+    payload = json.dumps(envelope).encode("utf-8")
+    nc = None
+    try:
+        nc = await nats.connect(NATS_URL, connect_timeout=5)
+    except Exception as exc:
+        log.error("v1_chain: NATS connect failed url=%s: %s", NATS_URL, exc)
+        return False
+    try:
+        await nc.publish(subject, payload)
+        await nc.flush(timeout=5)
+        log.info("v1_chain: published %d bytes to %s", len(payload), subject)
+    except Exception as exc:
+        log.error("v1_chain: publish failed subject=%s: %s", subject, exc)
+        await nc.close()
+        return False
+    await nc.close()
+    return True
+
+
+def _publish_envelope(envelope: dict, role: str) -> bool:
+    """Drive async publish via asyncio.run. Return True on success, False on any failure."""
+    try:
+        return asyncio.run(_publish_async(envelope, role))
+    except Exception as exc:  # noqa: BLE001
+        log.error("v1_chain: asyncio.run publish failed role=%s: %s", role, exc)
+        return False
+
+
+def _build_envelope(
+    task_id: str,
+    chain_id: str,
+    chain_step: str,
+    atom_id: str | None,
+    brief: str,
+    clock: Callable[[], float],
+) -> dict:
+    return {
+        "task_id": task_id,
+        "chain_id": chain_id,
+        "chain_step": chain_step,
+        "atom_id": atom_id,
+        "brief": brief,
+        "ts": clock(),
+        "from": "v1_chain_orchestrator",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def dispatch(
+    task: dict,
+    *,
+    chain_id: str | None = None,
+    clock: Callable[[], float] = time.time,
+) -> str:
+    """Begin a new V1 chain from a task dict.
+
+    Args:
+        task: Must contain at least ``id`` (or ``chain_id`` as fallback) and
+              ``brief`` (or ``description`` as fallback for the message text).
+        chain_id: Optional — generated as uuid4 hex when omitted.
+        clock: Injectable for tests.
+
+    Returns:
+        chain_id (str).
+
+    Fail-open: NATS publish errors are logged but never raised — the chain_id
+    and persisted state are returned even when NATS is unavailable.
+    """
+    cid = chain_id or uuid.uuid4().hex
+    task_id = task.get("id") or cid
+    brief = task.get("brief") or task.get("description") or ""
+
+    state = _load_state()
+    state[cid] = {
+        "chain_id": cid,
+        "task_id": task_id,
+        "brief": brief,
+        "started_ts": clock(),
+        "current_step": "aiden_plan",
+        "steps_done": [],
+        "atom_ids": {},
+        "pending": [],
+    }
+    _save_state(state)
+
+    envelope = _build_envelope(task_id, cid, "aiden_plan", None, brief, clock)
+    _publish_envelope(envelope, "aiden")  # fail-open — result not checked
+
+    return cid
+
+
+def advance_step(
+    chain_id: str,
+    completed_step: str,
+    atom_id: str,
+    *,
+    clock: Callable[[], float] = time.time,
+) -> list[dict]:
+    """Record a step completion and dispatch the next step(s).
+
+    Args:
+        chain_id: Identifies the chain in the state file.
+        completed_step: The step that just finished (e.g. "aiden_plan").
+        atom_id: The atom_id returned by the completing agent for this step.
+        clock: Injectable for tests.
+
+    Returns:
+        List of envelope dicts that were dispatched (empty list if no dispatch
+        occurred — either the chain is waiting on parallel partners, or it has
+        reached ``complete``).
+    """
+    state = _load_state()
+    entry = state.get(chain_id)
+    if entry is None:
+        log.error("v1_chain: advance_step unknown chain_id=%s", chain_id)
+        return []
+
+    # Idempotency: a repeated completion for the same step must NOT re-dispatch
+    # downstream (Max HOLD on PR #1329). State already records the first call;
+    # second call is a no-op.
+    if completed_step in entry["steps_done"]:
+        log.warning(
+            "v1_chain: advance_step duplicate completed_step=%s chain=%s — no re-dispatch",
+            completed_step,
+            chain_id,
+        )
+        return []
+
+    # Record completion of the current step.
+    entry["atom_ids"][completed_step] = atom_id
+    if completed_step not in entry["steps_done"]:
+        entry["steps_done"].append(completed_step)
+    if completed_step in entry["pending"]:
+        entry["pending"].remove(completed_step)
+
+    dispatched: list[dict] = []
+
+    if completed_step in PARALLEL_AFTER_STEP:
+        # Fan-out: dispatch all parallel next steps simultaneously.
+        next_steps = PARALLEL_AFTER_STEP[completed_step]
+        entry["pending"] = list(next_steps)
+        for next_step in next_steps:
+            role = ROLE_FOR_STEP[next_step]
+            env = _build_envelope(
+                entry["task_id"], chain_id, next_step, atom_id, entry["brief"], clock
+            )
+            _publish_envelope(env, role)
+            dispatched.append(env)
+        entry["current_step"] = next_steps[0]  # first parallel step as nominal marker
+    elif entry["pending"]:
+        # Still waiting on remaining parallel partners — no new dispatch.
+        pass
+    else:
+        # Sequential next step, or final parallel step completing.
+        _SEQ_NEXT: dict[str, str | None] = {
+            "aiden_plan": "max_challenge",
+            "max_challenge": "nova_build",
+            # nova_build is handled by PARALLEL_AFTER_STEP above
+        }
+        # Check if we've just closed a parallel set (all pending cleared).
+        parallel_steps_done = set(entry["steps_done"])
+        all_parallel_covered = all(
+            s in parallel_steps_done for group in PARALLEL_AFTER_STEP.values() for s in group
+        )
+        if all_parallel_covered and any(
+            completed_step in group for group in PARALLEL_AFTER_STEP.values()
+        ):
+            # Last parallel step completed → chain is complete.
+            entry["current_step"] = "complete"
+            entry["pending"] = []
+        elif completed_step in _SEQ_NEXT:
+            next_step = _SEQ_NEXT[completed_step]
+            if next_step is not None:
+                role = ROLE_FOR_STEP[next_step]
+                env = _build_envelope(
+                    entry["task_id"], chain_id, next_step, atom_id, entry["brief"], clock
+                )
+                _publish_envelope(env, role)
+                dispatched.append(env)
+                entry["current_step"] = next_step
+        else:
+            log.warning(
+                "v1_chain: advance_step no known next for completed_step=%s", completed_step
+            )
+
+    _save_state(state)
+    return dispatched
+
+
+# ---------------------------------------------------------------------------
+# Script entry point (manual smoke)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":  # pragma: no cover
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    import sys
+
+    brief = " ".join(sys.argv[1:]) or "test task from v1_chain_orchestrator __main__"
+    cid = dispatch({"id": "smoke-task-1", "brief": brief})
+    print(f"dispatched chain_id={cid}")

--- a/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
+++ b/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
@@ -1,0 +1,412 @@
+"""Tests for src.keiracom_system.chain.v1_chain_orchestrator.
+
+Covers:
+  - dispatch(): first-hop NATS publish + state persistence + fail-open on error
+  - advance_step(): sequential steps, parallel fan-out, partial-parallel wait,
+    and final parallel completion → complete
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import src.keiracom_system.chain.v1_chain_orchestrator as orch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_nats_module(*, connect_raises: Exception | None = None) -> types.ModuleType:
+    """Build a fake nats module that records published envelopes."""
+    published: list[tuple[str, bytes]] = []
+
+    async def _connect(*args, **kwargs):
+        if connect_raises is not None:
+            raise connect_raises
+        nc = AsyncMock()
+        nc.published = published
+
+        async def _publish(subject: str, payload: bytes):
+            published.append((subject, payload))
+
+        nc.publish = _publish
+        nc.flush = AsyncMock()
+        nc.close = AsyncMock()
+        return nc
+
+    mod = types.ModuleType("nats")
+    mod.connect = _connect
+    mod.published = published
+    return mod
+
+
+def _seed_state(tmp_path: Path, chain_id: str, entry: dict) -> None:
+    """Write a state file with a single entry for testing advance_step."""
+    state = {chain_id: entry}
+    state_file = tmp_path / "v1_chain_state.json"
+    state_file.write_text(json.dumps(state))
+
+
+# ---------------------------------------------------------------------------
+# dispatch() tests
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_first_hop_publishes_aiden_envelope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """dispatch() must publish one envelope to keiracom.dispatch.aiden."""
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        chain_id = orch.dispatch({"id": "t1", "brief": "hello"}, clock=lambda: 1.0)
+
+    assert len(fake_nats.published) == 1
+    subject, payload = fake_nats.published[0]
+    assert subject == "keiracom.dispatch.aiden"
+
+    env = json.loads(payload)
+    assert env["chain_step"] == "aiden_plan"
+    assert env["atom_id"] is None
+    assert env["brief"] == "hello"
+    assert env["task_id"] == "t1"
+    assert env["chain_id"] == chain_id
+    assert env["from"] == "v1_chain_orchestrator"
+    assert env["ts"] == 1.0
+
+
+def test_dispatch_persists_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """dispatch() must persist chain state with correct initial values."""
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        chain_id = orch.dispatch({"id": "t2", "brief": "do something"})
+
+    assert state_file.exists()
+    state = json.loads(state_file.read_text())
+    assert chain_id in state
+    entry = state[chain_id]
+    assert entry["current_step"] == "aiden_plan"
+    assert entry["steps_done"] == []
+    assert entry["atom_ids"] == {}
+
+
+def test_dispatch_fail_open_on_nats_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """dispatch() must return a chain_id and persist state even when NATS connect raises."""
+    fake_nats = _fake_nats_module(connect_raises=ConnectionRefusedError("no nats"))
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        chain_id = orch.dispatch({"id": "t3", "brief": "fail-open test"})
+
+    assert isinstance(chain_id, str) and chain_id  # did not raise
+    assert state_file.exists()
+    state = json.loads(state_file.read_text())
+    assert chain_id in state
+
+
+# ---------------------------------------------------------------------------
+# advance_step() — sequential
+# ---------------------------------------------------------------------------
+
+
+def test_advance_step_aiden_to_max(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """aiden_plan → max_challenge: one envelope to keiracom.dispatch.max."""
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    chain_id = "chain-aiden-max"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-am",
+            "brief": "plan it",
+            "started_ts": 0.0,
+            "current_step": "aiden_plan",
+            "steps_done": [],
+            "atom_ids": {},
+            "pending": [],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        envelopes = orch.advance_step(chain_id, "aiden_plan", "atom-abc", clock=lambda: 2.0)
+
+    assert len(envelopes) == 1
+    assert len(fake_nats.published) == 1
+    subject, payload = fake_nats.published[0]
+    assert subject == "keiracom.dispatch.max"
+
+    env = envelopes[0]
+    assert env["chain_step"] == "max_challenge"
+    assert env["atom_id"] == "atom-abc"
+
+    state = json.loads(state_file.read_text())
+    entry = state[chain_id]
+    assert entry["current_step"] == "max_challenge"
+    assert entry["steps_done"] == ["aiden_plan"]
+    assert entry["atom_ids"] == {"aiden_plan": "atom-abc"}
+
+
+def test_advance_step_max_to_nova(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """max_challenge → nova_build: one envelope to keiracom.dispatch.nova with max's atom."""
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    chain_id = "chain-max-nova"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-mn",
+            "brief": "build it",
+            "started_ts": 0.0,
+            "current_step": "max_challenge",
+            "steps_done": ["aiden_plan"],
+            "atom_ids": {"aiden_plan": "atom-aiden"},
+            "pending": [],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        envelopes = orch.advance_step(chain_id, "max_challenge", "atom-max", clock=lambda: 3.0)
+
+    assert len(envelopes) == 1
+    subject, payload = fake_nats.published[0]
+    assert subject == "keiracom.dispatch.nova"
+
+    env = envelopes[0]
+    assert env["chain_step"] == "nova_build"
+    assert env["atom_id"] == "atom-max"
+
+
+# ---------------------------------------------------------------------------
+# advance_step() — parallel fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_advance_step_nova_to_dual_orion_atlas(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """nova_build fans out to orion_spec + atlas_safety simultaneously."""
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    chain_id = "chain-nova-parallel"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-np",
+            "brief": "spec+safety",
+            "started_ts": 0.0,
+            "current_step": "nova_build",
+            "steps_done": ["aiden_plan", "max_challenge"],
+            "atom_ids": {"aiden_plan": "atom-a", "max_challenge": "atom-m"},
+            "pending": [],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        envelopes = orch.advance_step(chain_id, "nova_build", "atom-nova", clock=lambda: 4.0)
+
+    assert len(envelopes) == 2
+    subjects = {s for s, _ in fake_nats.published}
+    assert "keiracom.dispatch.orion" in subjects
+    assert "keiracom.dispatch.atlas" in subjects
+
+    for env in envelopes:
+        assert env["atom_id"] == "atom-nova"
+
+    state = json.loads(state_file.read_text())
+    entry = state[chain_id]
+    assert set(entry["pending"]) == {"orion_spec", "atlas_safety"}
+
+
+def test_advance_step_orion_done_waits_for_atlas(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """After orion completes, atlas is still pending — no new dispatch."""
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    chain_id = "chain-orion-wait"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-ow",
+            "brief": "waiting",
+            "started_ts": 0.0,
+            "current_step": "orion_spec",
+            "steps_done": ["aiden_plan", "max_challenge", "nova_build"],
+            "atom_ids": {
+                "aiden_plan": "a1",
+                "max_challenge": "a2",
+                "nova_build": "a3",
+            },
+            "pending": ["orion_spec", "atlas_safety"],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        envelopes = orch.advance_step(chain_id, "orion_spec", "atom-orion")
+
+    assert envelopes == []
+    assert len(fake_nats.published) == 0
+
+    state = json.loads(state_file.read_text())
+    assert state[chain_id]["pending"] == ["atlas_safety"]
+
+
+def test_advance_step_atlas_done_completes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """When atlas is last parallel partner, chain reaches complete — no dispatch."""
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    chain_id = "chain-atlas-complete"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-ac",
+            "brief": "finishing",
+            "started_ts": 0.0,
+            "current_step": "atlas_safety",
+            "steps_done": ["aiden_plan", "max_challenge", "nova_build", "orion_spec"],
+            "atom_ids": {
+                "aiden_plan": "a1",
+                "max_challenge": "a2",
+                "nova_build": "a3",
+                "orion_spec": "a4",
+            },
+            "pending": ["atlas_safety"],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        envelopes = orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
+
+    assert envelopes == []
+    assert len(fake_nats.published) == 0
+
+    state = json.loads(state_file.read_text())
+    entry = state[chain_id]
+    assert entry["current_step"] == "complete"
+    assert entry["pending"] == []
+
+
+# ─── Edge cases (Max HOLD on PR #1329) ────────────────────────────────────────
+
+
+def test_advance_step_unknown_chain_id_returns_empty_and_logs_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """Unknown chain_id: return [], log error, no NATS publish."""
+    import logging
+
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    with patch.dict("sys.modules", {"nats": fake_nats}), caplog.at_level(logging.ERROR):
+        envelopes = orch.advance_step("does-not-exist", "aiden_plan", "atom-x")
+
+    assert envelopes == []
+    assert len(fake_nats.published) == 0
+    assert "unknown chain_id=does-not-exist" in caplog.text
+
+
+def test_advance_step_duplicate_completion_no_double_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """Duplicate advance_step for the same completed_step must not re-dispatch downstream."""
+    import logging
+
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    chain_id = "chain-dup"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-dup",
+            "brief": "dup test",
+            "started_ts": 0.0,
+            "current_step": "aiden_plan",
+            "steps_done": [],
+            "atom_ids": {},
+            "pending": [],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        first = orch.advance_step(chain_id, "aiden_plan", "atom-1", clock=lambda: 1.0)
+    assert len(first) == 1
+    assert len(fake_nats.published) == 1  # max_challenge dispatched once
+    state_after_first = json.loads(state_file.read_text())[chain_id]
+
+    with patch.dict("sys.modules", {"nats": fake_nats}), caplog.at_level(logging.WARNING):
+        second = orch.advance_step(chain_id, "aiden_plan", "atom-1-again", clock=lambda: 2.0)
+
+    assert second == []
+    assert len(fake_nats.published) == 1  # NOT re-dispatched
+    assert "duplicate completed_step=aiden_plan" in caplog.text
+    # State unchanged by the second call.
+    state_after_second = json.loads(state_file.read_text())[chain_id]
+    assert state_after_second == state_after_first
+
+
+def test_advance_step_unrecognized_step_returns_empty_and_logs_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """Step not in PARALLEL_AFTER_STEP, not in _SEQ_NEXT, pending empty: [] + warning."""
+    import logging
+
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    chain_id = "chain-bogus"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-b",
+            "brief": "bogus step",
+            "started_ts": 0.0,
+            "current_step": "aiden_plan",
+            "steps_done": [],
+            "atom_ids": {},
+            "pending": [],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}), caplog.at_level(logging.WARNING):
+        envelopes = orch.advance_step(chain_id, "garbage_step", "atom-g")
+
+    assert envelopes == []
+    assert len(fake_nats.published) == 0
+    assert "no known next for completed_step=garbage_step" in caplog.text


### PR DESCRIPTION
## Summary
V1 core: per-task chain-state tracker that routes a Face-classified task through `face → aiden → max → nova(worker) → orion+atlas(reviewers) → Slack` via NATS dispatch + an `advance_step` API. **First-hop ACCEPTANCE verified live.**

## Architecture (from my own zr7e.2 research, ratified by Elliot)
- **Dispatch transport = NATS** (per-callsign bridges already enabled fleet-wide).
- **Workers** subscribe `keiracom.dispatch.<self>`; **deliberators** subscribe `keiracom.deliberation.>`.
- **Worker-first for V1 = Nova** (Orion=Aiden's worker but acts as post-Worker spec-reviewer in the V1 chain — using Orion as Worker would be self-review).
- **Atom_id passing:** canonical envelope key `atom_id` (coordination point with Orion's `zr7e.9` — they provide the NATS publish side, this orchestrator subscribes).

## Files
- `src/keiracom_system/chain/__init__.py` — new (package)
- `src/keiracom_system/chain/v1_chain_orchestrator.py` — new (270 LoC) — `dispatch()` + `advance_step()` + state-file persistence + NATS publish helper (mirrors `supervisor_wake_publish`, fail-open).
- `src/keiracom_system/chat/face.py` — `_respond` wired to call `chain_dispatch` on non-ambiguous classification (fail-open: any exception → stub reply, Face never propagates). Added `brief: str = ""` kwarg (backward-compatible).
- `tests/keiracom_system/chain/test_v1_chain_orchestrator.py` — 8 tests (first-hop, fail-open, state persistence, sequential aiden→max→nova, parallel nova→orion+atlas, pending-list gating, dual-reviewer completion).
- `tests/keiracom_system/chat/test_face.py` — 3 new face tests (dispatches on classified, ambiguous unchanged, fail-open if dispatch raises).

## Envelope (canonical)
```json
{
  "task_id": "...", "chain_id": "...", "chain_step": "aiden_plan|max_challenge|nova_build|orion_spec|atlas_safety",
  "atom_id": null | "...", "brief": "...", "ts": <float>, "from": "v1_chain_orchestrator"
}
```
Publish subject: `keiracom.dispatch.<role>` (role from `ROLE_FOR_STEP`). State JSON at `/tmp/v1_chain_state.json` (env-overridable, atomic write).

## Live acceptance (the dispatch criterion)
```
$ dispatch({'id':MARK,'brief':MARK}) → chain_id=fe395fed...
$ NATS sub keiracom.dispatch.aiden received:
{"task_id":"zr7e2-acceptance-210844","chain_id":"fe395fed...","chain_step":"aiden_plan",
 "atom_id":null,"brief":"...","ts":1780088926.62,"from":"v1_chain_orchestrator"}
$ shape checks: 8/8 PASS (chain_step, atom_id None, brief+task_id contain marker,
   chain_id, from, ts is float)
$ state file persisted: {current_step:"aiden_plan", steps_done:[], atom_ids:{}, pending:[]}
```

## Explicit out-of-scope (not bundled here)
- **Live consumer loop** (subscribe `keiracom.agent.status.>` → call `advance_step`) — deferred to **zr7e.9** (Orion's atom_id NATS publish side). API is ready; just needs an event source.
- **`notify_complete` suppression / status publish** in `agent_cold_start.py` — zr7e.9's scope.
- **Final Slack post on dual-CONCUR** — `current_step="complete"` is recorded; the Slack hop is a small follow-up.
- **NATS ACLs** — `rlfh` part 1.

## Verification
- `ruff check` + `ruff format --check` clean
- `pytest tests/keiracom_system/chain/` → **8 passed**
- `pytest tests/keiracom_system/chat/test_face.py` → **10 passed** (no existing tests broken)
- Live first-hop acceptance: **PASS** (above)

## Test plan
- [ ] Merge → run live first-hop end-to-end on the host
- [ ] Coordinate with Orion (`zr7e.9`) on the agent.status envelope contract so the live consumer loop wires cleanly
- [ ] Follow-up: final Slack post on dual-CONCUR

🤖 Generated with [Claude Code](https://claude.com/claude-code)