### PR TITLE
[ORION] feat(cold-start): NATS AtomV1 handoff transport (Agency_OS-zr7e.9)

### DIFF
--- a/src/keiracom_system/vault/agent_cold_start.py
+++ b/src/keiracom_system/vault/agent_cold_start.py
@@ -38,6 +38,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Callable
@@ -58,6 +59,13 @@ _TASK_COLS = ("id", "title", "description", "priority", "acceptance_criteria")
 # failures from agent failures): 0 ok / claim-lost; 2 no task id; 3 task absent.
 RC_NO_TASK_ID = 2
 RC_TASK_ABSENT = 3
+
+# zr7e.9 — V1 chain AtomV1 handoff transport. After classify_and_save writes
+# atoms to Hindsight fleet_decisions on exit, publish each (task_id, atom_id)
+# to NATS so the next agent in the chain can recall the atom at spawn. Single
+# subject; subscribers self-route by role until chain-progression wiring lands.
+NATS_URL = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
+HANDOFF_SUBJECT = "keiracom.agent.handoff"
 
 
 def _dsn() -> str:
@@ -201,21 +209,79 @@ def notify_complete(
         logger.exception("notify_complete: unexpected error for task=%s", task_id)
 
 
+def _publish_handoff(*, task_id: str, atom_id: str, to_callsign: str = "") -> bool:
+    """zr7e.9 — publish an AtomV1 handoff pointer to NATS keiracom.agent.handoff.
+
+    Mirrors scripts/fleet_supervisor._nats_publish_state: lazy nats-py import,
+    asyncio.run(connect/publish/flush/close), fail-open warn on failure. Returns
+    True on success, False on any failure — never raises.
+
+    Payload: {task_id, atom_id, from_callsign, to_callsign, ts}. from_callsign
+    comes from AGENT_CALLSIGN (set by the dispatcher at spawn). to_callsign
+    defaults to "" — subscribers on the single keiracom.agent.handoff subject
+    self-route by their chain role until chain-progression wiring lands.
+    """
+    payload = json.dumps(
+        {
+            "task_id": task_id,
+            "atom_id": atom_id,
+            "from_callsign": os.environ.get("AGENT_CALLSIGN", ""),
+            "to_callsign": to_callsign,
+            "ts": int(time.time()),
+        }
+    ).encode()
+    try:
+        import asyncio  # noqa: PLC0415 — lazy, mirrors save_exit_atoms / fleet_supervisor
+
+        import nats.aio.client as nats_client  # noqa: PLC0415 — optional dep
+
+        async def _publish() -> None:
+            nc = nats_client.Client()
+            await nc.connect(NATS_URL, connect_timeout=2)
+            try:
+                await nc.publish(HANDOFF_SUBJECT, payload)
+                await nc.flush()
+            finally:
+                await nc.close()
+
+        asyncio.run(_publish())
+        logger.info(
+            "agent_cold_start: NATS PUBLISH %s → task_id=%s atom_id=%s",
+            HANDOFF_SUBJECT,
+            task_id,
+            atom_id,
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — fail-open: handoff must never block agent exit
+        logger.warning(
+            "agent_cold_start: NATS handoff failed (non-fatal) task_id=%s: %s",
+            task_id,
+            exc,
+        )
+        return False
+
+
 def save_exit_atoms(task: dict, rc: int, status: str) -> None:
-    """Capture the completed task as AtomV1 atoms in Hindsight (Agency_OS-zr7e.4).
+    """Capture the completed task as AtomV1 atoms in Hindsight (Agency_OS-zr7e.4),
+    then publish per-atom handoff pointers to NATS keiracom.agent.handoff (zr7e.9).
 
     Mirrors face.py's exit-cycle: feed the task brief + completion stamp to
     ``classify_and_save``, which writes an atom per ratified decision it detects
     above the confidence threshold (most build tasks detect none — that is fine).
+    For each atom_id returned, publishes (task_id, atom_id) to NATS so the next
+    agent in the V1 chain can recall the atom at spawn (L2 Hindsight recall).
 
-    Fail-open: ``classify_and_save`` is already internally fail-open, but the
-    import, ``asyncio.run`` and any unexpected error are also swallowed here —
-    memory capture must NEVER block the task lifecycle.
+    Fail-open: ``classify_and_save`` is already internally fail-open; the outer
+    try/except also swallows import / asyncio.run / unexpected errors here, and
+    ``_publish_handoff`` itself returns False rather than raising on NATS errors.
+    Memory capture + handoff must NEVER block the task lifecycle.
     """
     try:
-        import asyncio
+        import asyncio  # noqa: PLC0415 — lazy
 
-        from src.keiracom_system.chat.exit_cycle import classify_and_save
+        from src.keiracom_system.chat.exit_cycle import (  # noqa: PLC0415
+            classify_and_save,
+        )
 
         brief = task.get("description") or task.get("title") or ""
         conversation = [
@@ -230,6 +296,9 @@ def save_exit_atoms(task: dict, rc: int, status: str) -> None:
         ]
         customer_id = int(os.environ.get("AGENT_CUSTOMER_ID", "1"))  # fleet tenant 1 = Dave
         result = asyncio.run(classify_and_save(conversation, customer_id))
+        # zr7e.9 handoff publish — one NATS message per atom_id.
+        for atom_id in getattr(result, "atom_ids", None) or []:
+            _publish_handoff(task_id=str(task["id"]), atom_id=atom_id)
         logger.info("save_exit_atoms: %s", getattr(result, "skipped_reason", None) or "atoms saved")
     except Exception:  # noqa: BLE001 — never block completion on memory capture
         logger.exception("save_exit_atoms: unexpected error for task=%s", task.get("id"))

--- a/tests/keiracom_system/vault/test_agent_cold_start.py
+++ b/tests/keiracom_system/vault/test_agent_cold_start.py
@@ -314,7 +314,8 @@ def test_save_exit_atoms_builds_conversation_and_calls_classify(monkeypatch):
     async def fake_classify(conversation, customer_id, **kw):
         captured["conversation"] = conversation
         captured["customer_id"] = customer_id
-        return MagicMock(skipped_reason=None)
+        # atom_ids=[] so save_exit_atoms' zr7e.9 publish loop has nothing to send.
+        return MagicMock(skipped_reason=None, atom_ids=[])
 
     monkeypatch.setattr(ec, "classify_and_save", fake_classify)
     monkeypatch.setenv("AGENT_CUSTOMER_ID", "7")
@@ -335,3 +336,112 @@ def test_save_exit_atoms_fail_open_on_classify_error(monkeypatch):
     monkeypatch.setattr(ec, "classify_and_save", boom)
     # no exception = pass
     acs.save_exit_atoms({"id": "t-1", "title": "T", "description": "d"}, 1, "blocked")
+
+
+# ---- zr7e.9 NATS handoff publish on save_exit_atoms -------------------------
+
+
+def test_publish_handoff_publishes_correct_envelope(monkeypatch):
+    """_publish_handoff publishes to keiracom.agent.handoff with the full payload
+    and reads from_callsign from AGENT_CALLSIGN env."""
+    captured: dict = {}
+
+    class _FakeNC:
+        async def connect(self, url, connect_timeout=2):  # noqa: ARG002
+            captured["url"] = url
+
+        async def publish(self, subject, payload):
+            captured["subject"] = subject
+            captured["payload"] = payload
+
+        async def flush(self):
+            captured["flushed"] = True
+
+        async def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr("nats.aio.client.Client", lambda: _FakeNC())
+    monkeypatch.setenv("AGENT_CALLSIGN", "worker-3")
+
+    ok = acs._publish_handoff(task_id="t-42", atom_id="atom-99")
+
+    assert ok is True
+    assert captured["subject"] == acs.HANDOFF_SUBJECT == "keiracom.agent.handoff"
+    assert captured["url"] == acs.NATS_URL
+    assert captured["flushed"] is True and captured["closed"] is True
+    body = json.loads(captured["payload"].decode())
+    assert body["task_id"] == "t-42"
+    assert body["atom_id"] == "atom-99"
+    assert body["from_callsign"] == "worker-3"
+    assert body["to_callsign"] == ""  # V1 default — subscribers self-route
+    assert isinstance(body["ts"], int)
+
+
+def test_publish_handoff_fail_open_on_nats_error(monkeypatch):
+    """NATS connect failure → False, no exception escapes."""
+
+    class _BoomNC:
+        async def connect(self, url, connect_timeout=2):  # noqa: ARG002
+            raise OSError("nats unreachable")
+
+        async def publish(self, *a, **kw): ...
+        async def flush(self): ...
+        async def close(self): ...
+
+    monkeypatch.setattr("nats.aio.client.Client", lambda: _BoomNC())
+
+    assert acs._publish_handoff(task_id="t-x", atom_id="a-x") is False
+
+
+def test_save_exit_atoms_publishes_one_per_atom_id(monkeypatch):
+    """save_exit_atoms iterates result.atom_ids and calls _publish_handoff once
+    per atom, with the task_id stringified."""
+    import src.keiracom_system.chat.exit_cycle as ec
+
+    async def fake_classify(conversation, customer_id, **kw):  # noqa: ARG001
+        return MagicMock(skipped_reason=None, atom_ids=["a-1", "a-2", "a-3"])
+
+    monkeypatch.setattr(ec, "classify_and_save", fake_classify)
+
+    calls: list[dict] = []
+    monkeypatch.setattr(acs, "_publish_handoff", lambda **kw: (calls.append(kw), True)[1])
+
+    acs.save_exit_atoms({"id": "t-5", "title": "T", "description": "d"}, 0, "done")
+
+    assert [c["atom_id"] for c in calls] == ["a-1", "a-2", "a-3"]
+    assert all(c["task_id"] == "t-5" for c in calls)
+
+
+def test_save_exit_atoms_no_publish_when_no_atoms(monkeypatch):
+    """Empty atom_ids → zero publishes (no atom = no V1 handoff signal)."""
+    import src.keiracom_system.chat.exit_cycle as ec
+
+    async def fake_classify(conversation, customer_id, **kw):  # noqa: ARG001
+        return MagicMock(skipped_reason="no_decisions", atom_ids=[])
+
+    monkeypatch.setattr(ec, "classify_and_save", fake_classify)
+
+    calls: list[dict] = []
+    monkeypatch.setattr(acs, "_publish_handoff", lambda **kw: (calls.append(kw), True)[1])
+
+    acs.save_exit_atoms({"id": "t-6", "title": "T", "description": "d"}, 0, "done")
+
+    assert calls == []
+
+
+def test_save_exit_atoms_fail_open_when_publish_raises(monkeypatch):
+    """Even if _publish_handoff raises (contract says it shouldn't, but defence in
+    depth), save_exit_atoms must not propagate — outer try/except swallows it."""
+    import src.keiracom_system.chat.exit_cycle as ec
+
+    async def fake_classify(conversation, customer_id, **kw):  # noqa: ARG001
+        return MagicMock(skipped_reason=None, atom_ids=["a-1"])
+
+    def boom_publish(**_kw):
+        raise RuntimeError("publish exploded")
+
+    monkeypatch.setattr(ec, "classify_and_save", fake_classify)
+    monkeypatch.setattr(acs, "_publish_handoff", boom_publish)
+
+    # No exception escapes.
+    acs.save_exit_atoms({"id": "t-7", "title": "T", "description": "d"}, 0, "done")


### PR DESCRIPTION
## Summary
V1 chain handoff wired (**zr7e.9**, Elliot dispatch with `STEP 0 PRE-CONFIRMED` re-issued after foundations confirmed). After `save_exit_atoms` feeds the completion brief through `classify_and_save` and Hindsight writes AtomV1 atoms to `fleet_decisions` (zr7e.4 / #1318), publish each `(task_id, atom_id)` to NATS `keiracom.agent.handoff` so the next agent in the chain can recall the atom at spawn via L2 Hindsight retrieval.

- **`_publish_handoff(*, task_id, atom_id, to_callsign="")`** — mirrors `scripts/fleet_supervisor._nats_publish_state`: lazy `nats-py` import, `asyncio.run(connect/publish/flush/close)`, fail-open warn on failure (returns `bool`, never raises). Payload `{task_id, atom_id, from_callsign (AGENT_CALLSIGN env), to_callsign, ts}`. Single subject; subscribers self-route by chain role until chain-progression wiring lands (so `to_callsign` defaults to `""`).
- **`save_exit_atoms`** loops `for atom_id in (result.atom_ids or [])` and publishes one message per atom. Outer `try/except` preserves the fail-open contract: a NATS hiccup, unexpected error, or a misbehaving `_publish_handoff` never blocks the agent's task lifecycle.

## Foundations verified pre-build
- `ceo:ephemeral_capture_model_v1` IS **v2 direct-write** (Dave-ratified 2026-05-29) — supersedes the prior two-step canonical, unblocking 9goi's `exit_cycle → Hindsight` path which **#1318 (Atlas) wired in cold-start** (`save_exit_atoms` line 204+). Both my prior-HOLD blockers explicitly resolved.
- `ExitCycleResult.atom_ids: list[str]` is the canonical handle (exit_cycle.py:97).
- NATS pattern mirrored from `fleet_supervisor._nats_publish_state` (the only fleet precedent for `keiracom.agent.*` publishes).

## Acceptance
1. ✅ When a task completes in the chain, a NATS message on `keiracom.agent.handoff` carries `{task_id, atom_id}`.
2. ✅ Test catches the publish on the canonical subject with full payload (`test_publish_handoff_publishes_correct_envelope`).
3. ✅ Fail-open verified end-to-end (NATS-error → `False`; `_publish_handoff` raising → outer `save_exit_atoms` still completes).

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/keiracom_system/vault/test_agent_cold_start.py` → **27 passed** (existing preserved + 4 new for zr7e.9, 1 existing updated minimally to give `MagicMock` an explicit `atom_ids=[]`)
- [x] Fail-open paths: NATS connect error → `False`; outer envelope catches even a raising `_publish_handoff`
- [x] No-atoms case → no publish (no V1 handoff signal when nothing to hand off)
- [x] Subject + payload shape match the dispatched contract

## Pattern note
Mirrors the established `_nats_publish_state` shape exactly (the dispatch's specified pattern): lazy `nats-py` inside `try`, `asyncio.run` wrapping a short publish coroutine, `connect_timeout=2`, INFO log on success / WARN on failure. No new NATS infrastructure introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)