### PR TITLE
[ORION] feat(cold-start): L2 Hindsight spawn-context recall (Agency_OS-zr7e.5)

### DIFF
--- a/src/keiracom_system/vault/agent_cold_start.py
+++ b/src/keiracom_system/vault/agent_cold_start.py
@@ -304,6 +304,28 @@ def save_exit_atoms(task: dict, rc: int, status: str) -> None:
         logger.exception("save_exit_atoms: unexpected error for task=%s", task.get("id"))
 
 
+def _recall_spawn_context(task: dict) -> str:
+    """zr7e.5 — L2 Hindsight recall block for this task's spawn prompt.
+
+    Delegates to src.retrieval.spawn_recall.build_spawn_context_block which
+    already enforces the KEI-55 per-block context-budget cap (so we never blow
+    the agent's context window). Fail-open: returns "" on any error so the
+    spawn proceeds without prior context rather than aborting.
+    """
+    try:
+        from src.retrieval.spawn_recall import (  # noqa: PLC0415 — lazy
+            build_spawn_context_block,
+        )
+
+        return build_spawn_context_block(
+            task_type=task.get("task_type") or "build",
+            task_brief=task.get("description") or task.get("title") or "",
+        )
+    except Exception as exc:  # noqa: BLE001 — recall must never block a spawn
+        logger.warning("agent_cold_start: L2 spawn-recall failed (non-fatal): %s", exc)
+        return ""
+
+
 def run(
     *,
     resolve: Callable[..., Any] = resolve_into_env,
@@ -313,6 +335,7 @@ def run(
     finalize: Callable[..., None] = finalize_task,
     notify: Callable[..., None] = notify_complete,
     save_atoms: Callable[..., None] = save_exit_atoms,
+    spawn_recall: Callable[[dict], str] = _recall_spawn_context,
 ) -> int:
     """Cold-start orchestration. Returns the process exit code."""
     logging.basicConfig(level=logging.INFO)
@@ -331,7 +354,14 @@ def run(
             "agent_cold_start: task %s not claimable (already taken) — exiting clean", task_id
         )
         return 0  # another agent owns it; not our failure
-    rc = agent(compose_prompt(task))
+    # zr7e.5: prepend the L2 Hindsight recall block (when present) ahead of the
+    # task-centric prompt so the agent enters the chain with prior context
+    # instead of cold.
+    prompt = compose_prompt(task)
+    recall_block = spawn_recall(task)
+    if recall_block:
+        prompt = f"{recall_block}\n\n{prompt}"
+    rc = agent(prompt)
     finalize(task_id, rc, task.get("acceptance_criteria"))
     status = "done" if rc == 0 else "blocked"
     save_atoms(task, rc, status)  # AtomV1 memory capture (zr7e.4) — fail-open

--- a/tests/keiracom_system/vault/test_agent_cold_start.py
+++ b/tests/keiracom_system/vault/test_agent_cold_start.py
@@ -67,6 +67,7 @@ def test_run_sets_task_type_from_env(monkeypatch):
         claim=lambda _t, _c: True,
         agent=lambda prompt: seen.update(prompt=prompt) or 0,
         finalize=lambda *a: None,
+        spawn_recall=lambda _t: "",  # zr7e.5: no real Hindsight call
     )
     assert "review" in seen["prompt"]  # AGENT_TASK_TYPE flowed into the prompt
 
@@ -147,6 +148,7 @@ def _run(monkeypatch, *, task_id="t-1", fetch_ret=None, claim_ret=True, agent_rc
         agent=lambda _p: agent_rc,
         finalize=finalize,
         save_atoms=lambda *a, **k: None,
+        spawn_recall=lambda _t: "",  # zr7e.5: no real Hindsight call in unit tests
     )
     return rc, finalize, calls
 
@@ -299,6 +301,7 @@ def test_run_calls_save_atoms_after_finalize_before_notify(monkeypatch):
         finalize=lambda *a: order.append("finalize"),
         save_atoms=lambda *a: (order.append("save"), save_calls.append(a)),
         notify=lambda *a, **kw: order.append("notify"),
+        spawn_recall=lambda _t: "",  # zr7e.5: no real Hindsight call
     )
     assert order == ["finalize", "save", "notify"]
     assert save_calls == [(task, 0, "done")]
@@ -445,3 +448,90 @@ def test_save_exit_atoms_fail_open_when_publish_raises(monkeypatch):
 
     # No exception escapes.
     acs.save_exit_atoms({"id": "t-7", "title": "T", "description": "d"}, 0, "done")
+
+
+# ---- zr7e.5 L2 Hindsight spawn-context recall --------------------------------
+
+
+def test_run_prepends_recall_block_when_present(monkeypatch):
+    """When spawn_recall returns a non-empty block, run() prepends it to the
+    compose_prompt output before passing to the agent — separated by a blank line."""
+    monkeypatch.setenv("AGENT_TASK_ID", "t-r1")
+    monkeypatch.setattr(acs.sys, "argv", ["agent_cold_start"])
+    captured: dict = {}
+    task = {"id": "t-r1", "title": "Wire X", "description": "ship it", "acceptance_criteria": None}
+
+    acs.run(
+        resolve=lambda: None,
+        fetch=lambda _t: task,
+        claim=lambda _t, _c: True,
+        agent=lambda prompt: captured.setdefault("prompt", prompt) or 0,
+        finalize=lambda *a: None,
+        save_atoms=lambda *a, **k: None,
+        spawn_recall=lambda _t: "[PRIOR CONTEXT]\n- atom A\n- atom B",
+    )
+
+    prompt = captured["prompt"]
+    # block is first, then a blank line, then the task-centric prompt
+    assert prompt.startswith("[PRIOR CONTEXT]\n- atom A\n- atom B\n\n")
+    # compose_prompt content still present after the block
+    assert "Task ID: t-r1" in prompt and "ship it" in prompt
+
+
+def test_run_skips_block_when_recall_returns_empty(monkeypatch):
+    """Empty recall block → prompt unchanged (no leading blank lines, no header)."""
+    monkeypatch.setenv("AGENT_TASK_ID", "t-r2")
+    monkeypatch.setattr(acs.sys, "argv", ["agent_cold_start"])
+    captured: dict = {}
+    task = {"id": "t-r2", "title": "T", "description": "d", "acceptance_criteria": None}
+
+    acs.run(
+        resolve=lambda: None,
+        fetch=lambda _t: task,
+        claim=lambda _t, _c: True,
+        agent=lambda prompt: captured.setdefault("prompt", prompt) or 0,
+        finalize=lambda *a: None,
+        save_atoms=lambda *a, **k: None,
+        spawn_recall=lambda _t: "",
+    )
+
+    # First line is the worker preamble (compose_prompt start) — no recall header.
+    assert captured["prompt"].startswith("You are an ephemeral Keiracom worker agent")
+
+
+def test_recall_spawn_context_calls_build_with_task_type_and_brief(monkeypatch):
+    """_recall_spawn_context passes task_type + (description OR title fallback)
+    as task_brief, and returns the build helper's output verbatim."""
+    import src.retrieval.spawn_recall as sr
+
+    captured: dict = {}
+
+    def fake_build(*, task_type, task_brief):
+        captured["task_type"] = task_type
+        captured["task_brief"] = task_brief
+        return "BLOCK"
+
+    monkeypatch.setattr(sr, "build_spawn_context_block", fake_build)
+
+    out = acs._recall_spawn_context(
+        {"id": "t-1", "task_type": "review", "description": "desc text"}
+    )
+    assert out == "BLOCK"
+    assert captured == {"task_type": "review", "task_brief": "desc text"}
+
+    # description missing → falls back to title
+    captured.clear()
+    acs._recall_spawn_context({"id": "t-2", "task_type": "build", "title": "title text"})
+    assert captured["task_brief"] == "title text"
+
+
+def test_recall_spawn_context_fail_open_returns_empty_on_error(monkeypatch):
+    """Any error during recall → returns "", spawn proceeds without context."""
+    import src.retrieval.spawn_recall as sr
+
+    def boom(**_kw):
+        raise RuntimeError("hindsight down")
+
+    monkeypatch.setattr(sr, "build_spawn_context_block", boom)
+
+    assert acs._recall_spawn_context({"id": "t-x", "task_type": "build"}) == ""


### PR DESCRIPTION
## Summary
V1 chain context wired (**zr7e.5**, Elliot dispatch). Agents in the chain (Aiden / Max / Worker / Orion / Atlas) were spawning **cold** — no prior conversation context across hops. `agent_cold_start.run()` now prepends an **L2 Hindsight recall block** ahead of the task-centric prompt, so the spawned agent enters mid-chain with up to `MAX_BLOCK_CHARS` of prior context already in its system prompt.

- **`_recall_spawn_context(task) → str`** — lazy-imports `src.retrieval.spawn_recall.build_spawn_context_block` (the existing recall pipeline the dispatcher path already uses) and passes `task_type` + a brief that falls back `description → title → ""`. Fail-open warn on any error → returns `""` so the spawn proceeds without context rather than aborting.
- **`spawn_recall` DI seam on `run()`** — matches the existing `classify`/`save`/`notify` pattern; default = the real recall function above.
- **Prompt assembly** — `prompt = compose_prompt(task)` first, then `prompt = f"{block}\n\n{prompt}"` only when the recall block is non-empty. Empty-block path leaves the prompt **byte-identical** to pre-change behaviour (regression-safe).
- **L3 context-budget guard already covered** — `build_spawn_context_block` enforces the KEI-55 per-block context-budget cap (`MAX_BLOCK_CHARS`), so the recall payload can't blow the agent's context window. The dispatch's "summarise before injecting" requirement is satisfied by that existing clamp.

## Foundations / pre-flight
- ✅ `git log --all --oneline | grep -iE 'zr7e.5|spawn.*context|L2.*recall|hindsight.*spawn'` — nothing shipped.
- ✅ `run()` reviewed — currently injects only `compose_prompt(task)` output; no prior context.
- ✅ `spawn_recall.build_spawn_context_block(task_type, task_brief)` already returns positive + (flag-gated) failure-recall blocks, each KEI-55-clamped. Reusing it keeps backfill-vs-live atom format guarantees intact (the same recall function the dispatcher path uses).

## Acceptance
1. ✅ A spawned agent receives prior chain context in its prompt when Hindsight returns results (`test_run_prepends_recall_block_when_present`).
2. ✅ Hindsight unreachable / recall fails → spawn proceeds cold (regression-safe), fail-open verified (`test_recall_spawn_context_fail_open_returns_empty_on_error` + `test_run_skips_block_when_recall_returns_empty`).
3. ✅ CI green locally — ruff + format + 31 tests pass.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/keiracom_system/vault/test_agent_cold_start.py` → **31 passed** (existing preserved + 3 updated to inject a no-op `spawn_recall` so unit tests never reach a real Hindsight backend + 4 new for zr7e.5)
- [x] Block-present path verified: `compose_prompt` content still present after the block; block separated from prompt by a blank line
- [x] Block-empty path: prompt starts with the worker preamble — no extra blank lines, no recall header
- [x] Helper-arg path: `task_type` passes through; `task_brief` falls back `description → title`
- [x] Fail-open: helper returns `""` on `build_spawn_context_block` error → spawn proceeds without prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)