### PR TITLE
[NOVA] fix(persona-bank): face variant NULL → 'face' for uniform chain_orchestrator lookup

### DIFF
--- a/supabase/migrations/20260529_persona_bank_face_variant_fix.sql
+++ b/supabase/migrations/20260529_persona_bank_face_variant_fix.sql
@@ -1,0 +1,24 @@
+-- 20260529_persona_bank_face_variant_fix.sql
+-- Removes the persona_bank shape asymmetry that would 404 chain_orchestrator
+-- on Face spawns. Pre-fix the face row stored variant=NULL while all other
+-- callsign rows stored variant=<callsign>; a uniform caller pattern
+-- (variant=callsign for every role) would miss face. 1-row UPDATE, idempotent.
+--
+-- Pre-fix:   (role='face', tier='standard', variant=NULL)
+-- Post-fix:  (role='face', tier='standard', variant='face')
+--
+-- After this lands every persona_bank lookup is uniform: callers always pass
+-- variant=<callsign>. The src/dispatcher/main.py::_fetch_persona handler's
+-- IS NULL branch stays (still serves any future single-variant role) but is
+-- not on the V1 chain path. UNIQUE(role,tier,variant) is preserved.
+--
+-- Idempotent: the WHERE-IS-NULL guard makes re-applies a no-op once the row
+-- has been flipped to variant='face'.
+
+BEGIN;
+
+UPDATE public.persona_bank
+SET variant = 'face'
+WHERE role = 'face' AND tier = 'standard' AND variant IS NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Pre-emptive fix before `chain_orchestrator` (Atlas, `zr7e.2`) lands. The `persona_bank` shape was asymmetric — face stored `variant=NULL` while aiden/max/orion/atlas/elliot all stored `variant=<callsign>`. A uniform caller pattern (variant=callsign for every role) would **404 on face**. Closes the gap surfaced in the gap-check from earlier today.

## Change
Single-row migration `20260529_persona_bank_face_variant_fix.sql`:
```sql
UPDATE public.persona_bank SET variant = 'face'
WHERE role='face' AND tier='standard' AND variant IS NULL;
```
- Idempotent (the IS NULL guard makes re-applies no-ops).
- `UNIQUE(role,tier,variant)` preserved.
- No schema change.

## Live result
- `psql -f` → BEGIN / UPDATE 1 / COMMIT.
- Pre-fix DB: `(face, standard, NULL)` — 10063 chars, 2515 tokens.
- Post-fix DB: `(face, standard, 'face')` — content unchanged.
- `GET ?role=face&tier=standard&variant=face` → **HTTP 200** (new canonical path).
- `GET ?role=face&tier=standard` (no variant) → 404 (expected; no callers depend on it — verified via grep before shipping).

The `_fetch_persona` handler's `IS NULL` branch stays in place (still serves any future single-variant role) but is now off the V1 chain critical path.

## Test plan
- [x] Live psql apply succeeded.
- [x] DB row verified — variant flipped.
- [x] New canonical GET returns the prompt.
- [x] Handler unit tests untouched (still cover both NULL and explicit-variant branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)