### PR TITLE
[NOVA] fix(notify_complete): suppress intermediate chain-step #ceo posts (Agency_OS-nd3b)

### DIFF
--- a/src/keiracom_system/vault/agent_cold_start.py
+++ b/src/keiracom_system/vault/agent_cold_start.py
@@ -189,7 +189,22 @@ def notify_complete(
 
     Fail-open: any error (network, dispatcher down, Slack failure) is logged
     and swallowed — a notification failure must never block the task lifecycle.
+
+    Chain-step suppression (Agency_OS-nd3b): the v1_chain_orchestrator dispatch
+    envelope carries `chain_step` and the dispatcher injects it as the CHAIN_STEP
+    env var at spawn. Only the FINAL step (CHAIN_STEP=='complete') posts to #ceo
+    — intermediate hops (aiden_plan / max_challenge / nova_build / orion_review /
+    atlas_review) suppress to keep Dave from seeing N notifications per directive.
+    CHAIN_STEP absent preserves today's behavior (single-step legacy tasks notify).
     """
+    chain_step = os.environ.get("CHAIN_STEP")
+    if chain_step and chain_step != "complete":
+        logger.info(
+            "notify_complete: suppressed (intermediate chain_step=%s) task=%s",
+            chain_step,
+            task_id,
+        )
+        return
     payload = json.dumps(
         {"task_id": task_id, "callsign": callsign, "title": title, "status": status, "rc": rc}
     ).encode()

--- a/tests/keiracom_system/vault/test_agent_cold_start.py
+++ b/tests/keiracom_system/vault/test_agent_cold_start.py
@@ -239,6 +239,82 @@ def test_notify_complete_fail_open_on_network_error(monkeypatch):
     # no exception = pass
 
 
+# ---- chain-step suppression (Agency_OS-nd3b) -------------------------------
+
+
+def test_notify_complete_suppressed_when_chain_step_is_intermediate(monkeypatch, caplog):
+    """CHAIN_STEP set to an intermediate step → no POST (urlopen never called)."""
+    import logging
+    import urllib.request as urlreq
+
+    called: list = []
+
+    def boom_urlopen(_req, timeout):
+        called.append(True)
+        raise AssertionError("urlopen MUST NOT be called for intermediate chain steps")
+
+    monkeypatch.setenv("CHAIN_STEP", "aiden_plan")
+    monkeypatch.setattr(urlreq, "urlopen", boom_urlopen)
+    with caplog.at_level(logging.INFO, logger="src.keiracom_system.vault.agent_cold_start"):
+        acs.notify_complete("t-int", "aiden", "Plan KEI-1", "done", 0)
+    assert called == []  # urlopen never invoked
+    assert any("suppressed" in rec.message and "aiden_plan" in rec.message for rec in caplog.records)
+
+
+def test_notify_complete_posts_when_chain_step_is_complete(monkeypatch):
+    """CHAIN_STEP='complete' (final step) → posts as normal."""
+    import urllib.request as urlreq
+
+    captured: dict = {}
+
+    class _FakeResp:
+        def read(self):
+            return b'{"notified":true}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            pass
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data)
+        return _FakeResp()
+
+    monkeypatch.setenv("CHAIN_STEP", "complete")
+    monkeypatch.setattr(urlreq, "urlopen", fake_urlopen)
+    acs.notify_complete("t-fin", "atlas", "review done", "done", 0, dispatcher_url="http://h:4001")
+    assert captured["body"]["task_id"] == "t-fin"
+    assert captured["body"]["status"] == "done"
+
+
+def test_notify_complete_posts_when_chain_step_absent(monkeypatch):
+    """CHAIN_STEP unset → posts as today (backward-compat with single-step legacy tasks)."""
+    import urllib.request as urlreq
+
+    captured: dict = {}
+
+    class _FakeResp:
+        def read(self):
+            return b'{"notified":true}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            pass
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        return _FakeResp()
+
+    monkeypatch.delenv("CHAIN_STEP", raising=False)
+    monkeypatch.setattr(urlreq, "urlopen", fake_urlopen)
+    acs.notify_complete("t-legacy", "atlas", "legacy", "done", 0, dispatcher_url="http://h:4001")
+    assert captured["url"] == "http://h:4001/dispatcher/task_complete"
+
+
 def test_run_calls_notify_after_finalize(monkeypatch):
     """run() calls notify with the correct status derived from agent rc."""
     monkeypatch.setenv("AGENT_TASK_ID", "t-1")


### PR DESCRIPTION
## Summary
Closes Agency_OS-nd3b. V1 chain hops (Face → Aiden → Max → Worker → Orion + Atlas) each call `task_complete`, which posts to **#ceo** via PR #1312's dispatcher → `slack_relay` path. Pre-fix Dave would see **N notifications per directive**; post-fix he sees **ONE** — the final reviewer.

## Change
Gate at the top of `notify_complete` reads the `CHAIN_STEP` env var (injected by the dispatcher from the `v1_chain_orchestrator` envelope at spawn):

| `CHAIN_STEP` value | behavior |
|---|---|
| absent | POST as today (backward-compatible — legacy single-step tasks notify) |
| `'aiden_plan'` / `'max_challenge'` / `'nova_build'` / `'orion_review'` / `'atlas_review'` | log `suppressed` + **return** (no POST) |
| `'complete'` | POST (final step) |

Fail-open path is unchanged — the suppression is a clean early-return before any network work.

## Test plan
- [x] 3 new tests: intermediate suppressed (urlopen never called + 'suppressed' log line); `'complete'` posts; CHAIN_STEP absent posts.
- [x] `pytest tests/keiracom_system/vault/test_agent_cold_start.py` → **34 passed** (31 existing + 3 new).
- [x] `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)