### PR TITLE
[ORION] feat(cold-start): suppress notify on intermediate V1-chain hops (Agency_OS-nd3b)

### DIFF
--- a/src/keiracom_system/vault/agent_cold_start.py
+++ b/src/keiracom_system/vault/agent_cold_start.py
@@ -67,6 +67,18 @@ RC_TASK_ABSENT = 3
 NATS_URL = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
 HANDOFF_SUBJECT = "keiracom.agent.handoff"
 
+# nd3b — chain-step taxonomy mirrors src.keiracom_system.chain.v1_chain_orchestrator
+# CHAIN_STEPS (aiden_plan, max_challenge, nova_build, orion_spec, atlas_safety).
+# The chain branches after nova_build → BOTH reviewers in parallel; per the
+# canonical (ceo:v1_chain_architecture) Atlas reviews AFTER Orion confirms spec,
+# so atlas_safety is the last step in time — the only one whose completion
+# warrants the #ceo task_complete post from this entrypoint. All other
+# CHAIN_STEP values are intermediate hops; suppress notify so the chain does not
+# spam #ceo with per-hop completions. (The final dual-concur result post lands
+# via zqni once both reviewers concur.) CHAIN_STEP unset = non-chain task →
+# notify as today (fail-open default; manual / pre-chain dispatches unaffected).
+_FINAL_CHAIN_STEPS: frozenset[str] = frozenset({"atlas_safety"})
+
 
 def _dsn() -> str:
     dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_DSN")
@@ -365,13 +377,24 @@ def run(
     finalize(task_id, rc, task.get("acceptance_criteria"))
     status = "done" if rc == 0 else "blocked"
     save_atoms(task, rc, status)  # AtomV1 memory capture (zr7e.4) — fail-open
-    notify(
-        task_id,
-        os.environ.get("AGENT_CALLSIGN", "worker"),
-        task.get("title") or "",
-        status,
-        rc,
-    )
+    # nd3b — suppress notify for intermediate V1-chain hops; only the final
+    # reviewer step (atlas_safety) posts to #ceo from this entrypoint. Non-chain
+    # tasks have CHAIN_STEP unset and notify as today (fail-open default).
+    chain_step = os.environ.get("CHAIN_STEP", "").strip()
+    if chain_step and chain_step not in _FINAL_CHAIN_STEPS:
+        logger.info(
+            "agent_cold_start: suppress notify for intermediate chain_step=%s task=%s",
+            chain_step,
+            task_id,
+        )
+    else:
+        notify(
+            task_id,
+            os.environ.get("AGENT_CALLSIGN", "worker"),
+            task.get("title") or "",
+            status,
+            rc,
+        )
     logger.info("agent_cold_start: task %s finished rc=%d status=%s", task_id, rc, status)
     return rc
 

--- a/tests/keiracom_system/vault/test_agent_cold_start.py
+++ b/tests/keiracom_system/vault/test_agent_cold_start.py
@@ -535,3 +535,53 @@ def test_recall_spawn_context_fail_open_returns_empty_on_error(monkeypatch):
     monkeypatch.setattr(sr, "build_spawn_context_block", boom)
 
     assert acs._recall_spawn_context({"id": "t-x", "task_type": "build"}) == ""
+
+
+# ---- nd3b notify suppression for intermediate V1-chain steps -----------------
+
+
+def _nd3b_run(monkeypatch, *, chain_step: str | None):
+    """Drive run() once with notify recorded + CHAIN_STEP set/unset as requested."""
+    monkeypatch.setenv("AGENT_TASK_ID", "t-cs")
+    monkeypatch.setattr(acs.sys, "argv", ["agent_cold_start"])
+    if chain_step is None:
+        monkeypatch.delenv("CHAIN_STEP", raising=False)
+    else:
+        monkeypatch.setenv("CHAIN_STEP", chain_step)
+    notify_calls: list = []
+    acs.run(
+        resolve=lambda: None,
+        fetch=lambda _t: {"id": "t-cs", "title": "T", "acceptance_criteria": None},
+        claim=lambda _t, _c: True,
+        agent=lambda _p: 0,
+        finalize=lambda *a: None,
+        save_atoms=lambda *a, **k: None,
+        notify=lambda *a, **kw: notify_calls.append((a, kw)),
+        spawn_recall=lambda _t: "",
+    )
+    return notify_calls
+
+
+def test_run_suppresses_notify_for_intermediate_chain_step(monkeypatch):
+    """CHAIN_STEP=intermediate hop → notify must NOT fire (no #ceo spam)."""
+    for intermediate in ("aiden_plan", "max_challenge", "nova_build", "orion_spec"):
+        notify_calls = _nd3b_run(monkeypatch, chain_step=intermediate)
+        assert notify_calls == [], f"intermediate step {intermediate!r} should suppress notify"
+
+
+def test_run_calls_notify_for_final_chain_step(monkeypatch):
+    """CHAIN_STEP=atlas_safety → notify fires (final reviewer posts to #ceo)."""
+    notify_calls = _nd3b_run(monkeypatch, chain_step="atlas_safety")
+    assert len(notify_calls) == 1
+
+
+def test_run_calls_notify_when_chain_step_unset(monkeypatch):
+    """CHAIN_STEP absent → notify fires as today (non-chain tasks unaffected)."""
+    notify_calls = _nd3b_run(monkeypatch, chain_step=None)
+    assert len(notify_calls) == 1
+
+
+def test_run_calls_notify_when_chain_step_blank(monkeypatch):
+    """CHAIN_STEP set but whitespace-only → treated as unset → notify fires."""
+    notify_calls = _nd3b_run(monkeypatch, chain_step="   ")
+    assert len(notify_calls) == 1


### PR DESCRIPTION
## Summary
`agent_cold_start` posts every task completion to `#ceo` via `notify_complete`. For V1-chain hops (Aiden plan → Max challenge → Nova build → Orion spec + Atlas safety), that would spam `#ceo` with per-hop completions; only the final reviewer should announce. **nd3b** adds a `CHAIN_STEP` env-var gate.

- **`_FINAL_CHAIN_STEPS = {"atlas_safety"}`** — mirrors the canonical taxonomy from `src.keiracom_system.chain.v1_chain_orchestrator.CHAIN_STEPS` (`aiden_plan, max_challenge, nova_build, orion_spec, atlas_safety`). Per `ceo:v1_chain_architecture`, Atlas reviews **after** Orion confirms spec — the Atlas persona's first instruction reads *"Assume Orion has confirmed the output matches the KEI"* — so `atlas_safety` is the **last step in time** and the only one whose completion should post `#ceo` from this entrypoint.
- **`run()` wraps `notify`** in a `CHAIN_STEP` gate: if env is set **and** value is **not** in `_FINAL_CHAIN_STEPS` → log + skip; otherwise notify as today. `CHAIN_STEP` unset / whitespace-only → notify (fail-open default — non-chain tasks + manual invocations are unaffected).
- The final dual-concur result post is **zqni's** territory (which `nd3b` blocks).

## Foundation
- ✅ `git log --all --oneline | grep -iE 'nd3b|notify.*suppress|chain.*step.*flag|skip.*notify|intermediate.*chain'` — nothing shipped.
- ✅ `v1_chain_orchestrator.CHAIN_STEPS` already on `main` (#1329) — labels mirrored here.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/keiracom_system/vault/test_agent_cold_start.py` → **35 passed** (31 existing preserved + 4 new for nd3b)
- [x] All 4 intermediate steps (`aiden_plan`, `max_challenge`, `nova_build`, `orion_spec`) suppress notify
- [x] `CHAIN_STEP=atlas_safety` fires notify (final-reviewer path)
- [x] `CHAIN_STEP` unset → notify fires (regression guard for non-chain tasks)
- [x] `CHAIN_STEP="   "` → treated as unset → notify fires (strip-based detection)

## Coordination
- Atlas is on **oevr** (consumer loop) per Elliot's routing. nd3b touches only the post-`save_atoms` notify call site in `run()` — no shared files with the consumer-loop work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)