### PR TITLE
[NOVA] feat(v1-chain): final #ceo post on chain complete (Agency_OS-zqni)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -1053,6 +1053,97 @@ async def dispatcher_task_complete(req: TaskCompleteRequest) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# /dispatcher/chain_complete — V1 chain final-result hook (Agency_OS-zqni)
+#
+# Called by v1_chain_orchestrator.advance_step when the chain reaches the
+# 'complete' state. Separate from /task_complete so nd3b's intermediate-step
+# suppression rule (CHAIN_STEP != 'complete' → skip) stays clean: per-step
+# notifies are gated at the worker, the single chain-result line fires here.
+# Cost is summed best-effort from keiracom_spawn_attribution (last 24h entries
+# whose source_id equals the chain's task_id), converted USD→AUD at 1.55,
+# omitted from the message if unavailable. Fail-open end to end.
+# ---------------------------------------------------------------------------
+
+
+class ChainCompleteRequest(BaseModel):
+    """V1 chain completion payload from v1_chain_orchestrator."""
+
+    task_id: str
+    chain_id: str
+    brief: str = ""
+    steps: list[str] = []
+
+
+def _lookup_chain_cost_aud(task_id: str) -> float | None:
+    """Sum cost_usd for attribution rows where source_id == task_id, ×1.55. None on miss/error.
+
+    Fail-closed: any exception or zero-sum returns None so the cost line is
+    omitted from the message rather than presenting a misleading A$0.0000.
+    """
+    try:
+        from src.keiracom_system.attribution.logger import load_attribution_last_24h
+
+        entries = load_attribution_last_24h()
+        matching = [e for e in entries if e.get("source_id") == task_id]
+        if not matching:
+            return None
+        cost_usd = sum(float(e.get("cost_usd", 0.0)) for e in matching)
+        if cost_usd <= 0:
+            return None
+        return cost_usd * 1.55  # USD→AUD per CLAUDE.md ratified rate
+    except Exception:  # noqa: BLE001 — cost lookup must never break notification
+        logger.warning("chain_complete: cost lookup failed for task=%s", task_id, exc_info=True)
+        return None
+
+
+@app.post("/dispatcher/chain_complete")
+async def dispatcher_chain_complete(req: ChainCompleteRequest) -> dict[str, Any]:
+    """Post the V1-chain completion summary to #ceo via slack_relay (Elliot's relay).
+
+    Fail-open: any error (slack_relay, cost-lookup, formatting) is logged and
+    swallowed — a notification failure must never block the chain lifecycle.
+    """
+    steps_str = (
+        " → ".join(req.steps)
+        if req.steps
+        else "aiden_plan → max_challenge → nova_build → orion_spec + atlas_safety"
+    )
+    lines = [
+        f"✅ Chain complete — {req.task_id}",
+        f"**Brief:** {req.brief or '(no brief)'}",
+        f"**Steps:** {steps_str}",
+    ]
+    cost_aud = _lookup_chain_cost_aud(req.task_id)
+    if cost_aud is not None:
+        lines.append(f"**Cost:** A${cost_aud:.4f}")
+    lines.append(f"**chain_id:** {req.chain_id}")
+    msg = "\n".join(lines)
+    try:
+        import subprocess as _sp
+        import sys as _sys
+
+        result = _sp.run(
+            [_sys.executable, _SLACK_RELAY_SCRIPT, "-c", "ceo", msg],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            env={**os.environ, "CALLSIGN": "elliot"},
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "chain_complete: slack_relay rc=%d stderr=%r",
+                result.returncode,
+                result.stderr[:200],
+            )
+            return {"notified": False, "reason": f"slack_relay rc={result.returncode}"}
+    except Exception:  # noqa: BLE001 — notification must never break the lifecycle
+        logger.exception("chain_complete: slack_relay raised for chain=%s", req.chain_id)
+        return {"notified": False, "reason": "exception"}
+    logger.info("chain_complete: notified #ceo task=%s chain=%s", req.task_id, req.chain_id)
+    return {"notified": True}
+
+
+# ---------------------------------------------------------------------------
 # /dispatcher/persona — role system-prompt lookup (persona_bank_v1)
 #
 # V1 chain roles (face/deliberator/worker/reviewer) fetch their system prompt

--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -69,58 +69,59 @@ PARALLEL_AFTER_STEP: dict[str, list[str]] = {
 
 log = logging.getLogger(__name__)
 
-# Agency_OS-zqni — final-result #ceo post path (mirrors the dispatcher's
-# task_complete hook + the consumer dead-letter notify: shell out to
-# scripts/slack_relay.py with CALLSIGN=elliot and -c ceo, fail-open).
-_SLACK_RELAY_SCRIPT = os.path.join(
-    os.environ.get("DISPATCHER_AGENT_WORKDIR", "/home/elliotbot/clawd/Agency_OS"),
-    "scripts",
-    "slack_relay.py",
-)
-_NOTIFY_TIMEOUT_S = 15
+# Agency_OS-zqni — final-result #ceo path. Architecture (Scout / Elliot ratified):
+# POST to a dedicated dispatcher endpoint /dispatcher/chain_complete (separate
+# from /task_complete so nd3b's intermediate-step suppression stays clean), the
+# dispatcher centralises cost lookup + Slack formatting + relay. Mirrors the
+# notify_complete → /task_complete urllib pattern in vault/agent_cold_start.py.
+_DISPATCHER_URL = os.environ.get("DISPATCHER_URL", "http://127.0.0.1:4001")
 
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
 
 
-def _post_final_to_ceo(entry: dict, chain_id: str) -> None:
-    """Agency_OS-zqni — one #ceo post when the V1 chain reaches ``complete``.
+def _post_chain_complete(
+    entry: dict, chain_id: str, *, dispatcher_url: str = _DISPATCHER_URL
+) -> None:
+    """Agency_OS-zqni — POST to /dispatcher/chain_complete when the chain ends.
 
-    Pairs with nd3b's notify_complete suppression (PR #1337): intermediate
-    chain hops suppress, this final post is the single result Dave sees per
-    directive. Module-level so tests can monkeypatch it.
+    Pairs with nd3b's notify_complete suppression (PR #1337): intermediate per-
+    step task_complete posts are gated off; this single chain-result line is
+    fired by the orchestrator and centralised in the dispatcher (cost lookup,
+    multi-line formatting, Slack relay). Module-level so tests can monkeypatch.
 
-    Fail-open: any error is logged and swallowed — a notify failure must NEVER
-    block advance_step or the state save.
+    Fail-open: any error logged + swallowed — a notify failure must NEVER block
+    advance_step or the state save.
     """
-    import subprocess  # noqa: PLC0415 — lazy, only the complete-transition path needs it
-    import sys  # noqa: PLC0415
+    import urllib.error  # noqa: PLC0415 — lazy, only the complete-transition path needs it
+    import urllib.request  # noqa: PLC0415
 
-    task_id = entry.get("task_id") or "?"
-    brief = entry.get("brief") or "(no brief)"
-    msg = (
-        f"✅ [V1-CHAIN] '{brief}' — complete "
-        f"(task={task_id}, chain={chain_id[:8]}). "
-        f"Steps: aiden_plan → max_challenge → nova_build → orion_spec + atlas_safety."
-    )
+    payload = json.dumps(
+        {
+            "task_id": entry.get("task_id") or "?",
+            "chain_id": chain_id,
+            "brief": entry.get("brief") or "(no brief)",
+            "steps": list(entry.get("steps_done") or []),
+        }
+    ).encode()
+    url = f"{dispatcher_url.rstrip('/')}/dispatcher/chain_complete"
     try:
-        result = subprocess.run(
-            [sys.executable, _SLACK_RELAY_SCRIPT, "-c", "ceo", msg],
-            capture_output=True,
-            text=True,
-            timeout=_NOTIFY_TIMEOUT_S,
-            env={**os.environ, "CALLSIGN": "elliot"},
-            check=False,
+        req = urllib.request.Request(
+            url, data=payload, headers={"Content-Type": "application/json"}, method="POST"
         )
-        if result.returncode != 0:
-            log.warning(
-                "v1_chain final-post: slack_relay rc=%d stderr=%r",
-                result.returncode,
-                result.stderr[:200],
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 — fixed loopback host
+            log.info(
+                "chain_complete notify: dispatcher status=%d for chain=%s", resp.status, chain_id
             )
-    except Exception:  # noqa: BLE001 — final-post failure must not break advance_step
-        log.warning("v1_chain final-post raised for chain=%s", chain_id, exc_info=True)
+    except (urllib.error.URLError, OSError):
+        log.warning(
+            "chain_complete notify: dispatcher unreachable for chain=%s", chain_id, exc_info=True
+        )
+    except Exception:  # noqa: BLE001 — must not break advance_step
+        log.warning(
+            "chain_complete notify: unexpected error for chain=%s", chain_id, exc_info=True
+        )
 
 
 def _load_state() -> dict:
@@ -330,14 +331,16 @@ def advance_step(
             entry["current_step"] = "complete"
             entry["pending"] = []
             # Agency_OS-zqni — single final #ceo post for the directive.
-            # Belt-and-suspenders fail-open: _post_final_to_ceo's internal try/except
+            # Belt-and-suspenders fail-open: _post_chain_complete's internal try/except
             # is the primary guard, but a future refactor or a test-injected fake
             # MUST NOT abort the state save here.
             try:
-                _post_final_to_ceo(entry, chain_id)
+                _post_chain_complete(entry, chain_id)
             except Exception:  # noqa: BLE001 — final-post failure must not break state save
                 log.warning(
-                    "v1_chain final-post raised at call site for chain=%s", chain_id, exc_info=True
+                    "v1_chain chain_complete raised at call site for chain=%s",
+                    chain_id,
+                    exc_info=True,
                 )
         elif completed_step in _SEQ_NEXT:
             next_step = _SEQ_NEXT[completed_step]

--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -69,9 +69,58 @@ PARALLEL_AFTER_STEP: dict[str, list[str]] = {
 
 log = logging.getLogger(__name__)
 
+# Agency_OS-zqni — final-result #ceo post path (mirrors the dispatcher's
+# task_complete hook + the consumer dead-letter notify: shell out to
+# scripts/slack_relay.py with CALLSIGN=elliot and -c ceo, fail-open).
+_SLACK_RELAY_SCRIPT = os.path.join(
+    os.environ.get("DISPATCHER_AGENT_WORKDIR", "/home/elliotbot/clawd/Agency_OS"),
+    "scripts",
+    "slack_relay.py",
+)
+_NOTIFY_TIMEOUT_S = 15
+
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _post_final_to_ceo(entry: dict, chain_id: str) -> None:
+    """Agency_OS-zqni — one #ceo post when the V1 chain reaches ``complete``.
+
+    Pairs with nd3b's notify_complete suppression (PR #1337): intermediate
+    chain hops suppress, this final post is the single result Dave sees per
+    directive. Module-level so tests can monkeypatch it.
+
+    Fail-open: any error is logged and swallowed — a notify failure must NEVER
+    block advance_step or the state save.
+    """
+    import subprocess  # noqa: PLC0415 — lazy, only the complete-transition path needs it
+    import sys  # noqa: PLC0415
+
+    task_id = entry.get("task_id") or "?"
+    brief = entry.get("brief") or "(no brief)"
+    msg = (
+        f"✅ [V1-CHAIN] '{brief}' — complete "
+        f"(task={task_id}, chain={chain_id[:8]}). "
+        f"Steps: aiden_plan → max_challenge → nova_build → orion_spec + atlas_safety."
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, _SLACK_RELAY_SCRIPT, "-c", "ceo", msg],
+            capture_output=True,
+            text=True,
+            timeout=_NOTIFY_TIMEOUT_S,
+            env={**os.environ, "CALLSIGN": "elliot"},
+            check=False,
+        )
+        if result.returncode != 0:
+            log.warning(
+                "v1_chain final-post: slack_relay rc=%d stderr=%r",
+                result.returncode,
+                result.stderr[:200],
+            )
+    except Exception:  # noqa: BLE001 — final-post failure must not break advance_step
+        log.warning("v1_chain final-post raised for chain=%s", chain_id, exc_info=True)
 
 
 def _load_state() -> dict:
@@ -280,6 +329,16 @@ def advance_step(
             # Last parallel step completed → chain is complete.
             entry["current_step"] = "complete"
             entry["pending"] = []
+            # Agency_OS-zqni — single final #ceo post for the directive.
+            # Belt-and-suspenders fail-open: _post_final_to_ceo's internal try/except
+            # is the primary guard, but a future refactor or a test-injected fake
+            # MUST NOT abort the state save here.
+            try:
+                _post_final_to_ceo(entry, chain_id)
+            except Exception:  # noqa: BLE001 — final-post failure must not break state save
+                log.warning(
+                    "v1_chain final-post raised at call site for chain=%s", chain_id, exc_info=True
+                )
         elif completed_step in _SEQ_NEXT:
             next_step = _SEQ_NEXT[completed_step]
             if next_step is not None:

--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -361,6 +361,32 @@ def advance_step(
     return dispatched
 
 
+async def _advance_step_async(
+    chain_id: str,
+    completed_step: str,
+    atom_id: str,
+    *,
+    clock: Callable[[], float] = time.time,
+) -> list[dict]:
+    """Async entrypoint for the V1 consumer loop (Atlas oevr) — Aiden HOLD fix.
+
+    Delegates to the sync advance_step via asyncio.to_thread so the completion
+    branch ALWAYS fires _post_chain_complete via the exact same code path the
+    sync caller uses. Parity-by-delegation eliminates the parallel-implementation
+    divergence bug class Aiden caught on PR #1340 — there can never be a "the
+    sync path calls _post_chain_complete but the async path forgot" failure,
+    because there is only one path.
+
+    State I/O (state file read/write) and the urllib POST in _post_chain_complete
+    are I/O-bound, so running them on a worker thread is the correct shape:
+    advance_step returns when the dispatch + state-save + chain-complete-post
+    are all done, and the event loop is not blocked during the urllib POST.
+    """
+    return await asyncio.to_thread(
+        advance_step, chain_id, completed_step, atom_id, clock=clock
+    )
+
+
 # ---------------------------------------------------------------------------
 # Script entry point (manual smoke)
 # ---------------------------------------------------------------------------

--- a/tests/dispatcher/test_chain_complete.py
+++ b/tests/dispatcher/test_chain_complete.py
@@ -1,0 +1,137 @@
+"""Tests for POST /dispatcher/chain_complete (V1 chain final-result hook, Agency_OS-zqni).
+
+No real Slack call — slack_relay subprocess and cost lookup are monkeypatched.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.dispatcher import main as dmain
+
+
+@pytest.fixture()
+def client():
+    return TestClient(dmain.app, raise_server_exceptions=True)
+
+
+def _stub_relay(monkeypatch, *, rc: int = 0, stderr: str = ""):
+    """Replace subprocess.run with a recorder + a configurable rc."""
+    captured: dict = {}
+
+    def fake_run(cmd, *, capture_output, text, timeout, env):
+        captured["cmd"] = cmd
+        captured["msg"] = cmd[-1]
+        captured["callsign"] = env.get("CALLSIGN")
+        result = MagicMock()
+        result.returncode = rc
+        result.stderr = stderr
+        return result
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Model defaults
+# ---------------------------------------------------------------------------
+
+
+def test_chain_complete_request_defaults():
+    r = dmain.ChainCompleteRequest(task_id="t-1", chain_id="c-1")
+    assert r.brief == ""
+    assert r.steps == []
+
+
+# ---------------------------------------------------------------------------
+# Endpoint — happy path with cost
+# ---------------------------------------------------------------------------
+
+
+def test_chain_complete_with_cost_posts_multiline_to_ceo(client, monkeypatch):
+    """Happy path: posts Scout's multi-line markdown with cost line, notified=True."""
+    captured = _stub_relay(monkeypatch)
+    monkeypatch.setattr(dmain, "_lookup_chain_cost_aud", lambda _tid: 0.1234)
+
+    resp = client.post(
+        "/dispatcher/chain_complete",
+        json={
+            "task_id": "t-zq",
+            "chain_id": "chain-abcdef12",
+            "brief": "wire X to Y",
+            "steps": ["aiden_plan", "max_challenge", "nova_build", "orion_spec", "atlas_safety"],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"notified": True}
+    msg = captured["msg"]
+    assert "✅ Chain complete — t-zq" in msg
+    assert "**Brief:** wire X to Y" in msg
+    assert "**Steps:** aiden_plan → max_challenge → nova_build → orion_spec → atlas_safety" in msg
+    assert "**Cost:** A$0.1234" in msg
+    assert "**chain_id:** chain-abcdef12" in msg
+    assert captured["callsign"] == "elliot"
+    assert "-c" in captured["cmd"] and "ceo" in captured["cmd"]
+
+
+def test_chain_complete_omits_cost_line_when_unavailable(client, monkeypatch):
+    """Cost lookup returns None → no 'Cost:' line in the message; still notified=True."""
+    captured = _stub_relay(monkeypatch)
+    monkeypatch.setattr(dmain, "_lookup_chain_cost_aud", lambda _tid: None)
+
+    resp = client.post(
+        "/dispatcher/chain_complete",
+        json={"task_id": "t-nocost", "chain_id": "c-nc", "brief": "no cost"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"notified": True}
+    msg = captured["msg"]
+    assert "**Cost:**" not in msg
+    assert "**chain_id:** c-nc" in msg
+
+
+# ---------------------------------------------------------------------------
+# Endpoint — fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_chain_complete_fail_open_on_slack_relay_nonzero(client, monkeypatch):
+    """slack_relay rc != 0 → notified=False but endpoint still returns 200."""
+    _stub_relay(monkeypatch, rc=2, stderr="SLACK_ACCESS_DENIED")
+    monkeypatch.setattr(dmain, "_lookup_chain_cost_aud", lambda _tid: None)
+
+    resp = client.post(
+        "/dispatcher/chain_complete",
+        json={"task_id": "t-fail", "chain_id": "c-f"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["notified"] is False
+    assert "slack_relay rc=2" in body["reason"]
+
+
+def test_lookup_chain_cost_aud_returns_none_when_no_matching_entries(monkeypatch):
+    """Cost helper returns None when there are no attribution entries for the task_id."""
+    monkeypatch.setattr(
+        "src.keiracom_system.attribution.logger.load_attribution_last_24h",
+        lambda **_kw: [],
+    )
+    assert dmain._lookup_chain_cost_aud("t-empty") is None
+
+
+def test_lookup_chain_cost_aud_sums_matching_and_converts_usd_to_aud(monkeypatch):
+    """Cost helper sums cost_usd across source_id matches and multiplies by 1.55."""
+    monkeypatch.setattr(
+        "src.keiracom_system.attribution.logger.load_attribution_last_24h",
+        lambda **_kw: [
+            {"source_id": "t-1", "cost_usd": 0.10},
+            {"source_id": "t-1", "cost_usd": 0.20},
+            {"source_id": "t-other", "cost_usd": 9.99},  # ignored
+        ],
+    )
+    out = dmain._lookup_chain_cost_aud("t-1")
+    assert out is not None
+    assert abs(out - 0.30 * 1.55) < 1e-9

--- a/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
+++ b/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
@@ -418,14 +418,14 @@ def test_advance_step_unrecognized_step_returns_empty_and_logs_warning(
 def test_advance_step_final_post_fires_on_chain_complete(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """When the last parallel partner completes, _post_final_to_ceo is called once."""
+    """When the last parallel partner completes, _post_chain_complete is called once."""
     fake_nats = _fake_nats_module()
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
     posts: list[tuple] = []
     monkeypatch.setattr(
-        orch, "_post_final_to_ceo", lambda entry, chain_id: posts.append((entry, chain_id))
+        orch, "_post_chain_complete", lambda entry, chain_id: posts.append((entry, chain_id))
     )
 
     chain_id = "chain-final-post"
@@ -472,9 +472,9 @@ def test_advance_step_intermediate_does_not_post_to_ceo(
 
     def boom_post(_entry, _chain_id):
         posts.append(True)
-        raise AssertionError("_post_final_to_ceo MUST NOT be called for intermediate steps")
+        raise AssertionError("_post_chain_complete MUST NOT be called for intermediate steps")
 
-    monkeypatch.setattr(orch, "_post_final_to_ceo", boom_post)
+    monkeypatch.setattr(orch, "_post_chain_complete", boom_post)
 
     chain_id = "chain-intermediate"
     _seed_state(
@@ -501,7 +501,7 @@ def test_advance_step_intermediate_does_not_post_to_ceo(
 def test_advance_step_final_post_failure_does_not_break_completion(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """A raising _post_final_to_ceo must NOT abort advance_step (fail-open guard)."""
+    """A raising _post_chain_complete must NOT abort advance_step (fail-open guard)."""
     fake_nats = _fake_nats_module()
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
@@ -509,7 +509,7 @@ def test_advance_step_final_post_failure_does_not_break_completion(
     def boom_post(_entry, _chain_id):
         raise RuntimeError("slack down")
 
-    monkeypatch.setattr(orch, "_post_final_to_ceo", boom_post)
+    monkeypatch.setattr(orch, "_post_chain_complete", boom_post)
 
     chain_id = "chain-failopen"
     _seed_state(
@@ -533,7 +533,7 @@ def test_advance_step_final_post_failure_does_not_break_completion(
     )
 
     with patch.dict("sys.modules", {"nats": fake_nats}):
-        # Must NOT raise even though _post_final_to_ceo blows up.
+        # Must NOT raise even though _post_chain_complete blows up.
         envelopes = orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
 
     assert envelopes == []  # no further dispatch on complete

--- a/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
+++ b/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
@@ -539,3 +539,54 @@ def test_advance_step_final_post_failure_does_not_break_completion(
     assert envelopes == []  # no further dispatch on complete
     state = json.loads(state_file.read_text())
     assert state[chain_id]["current_step"] == "complete"  # state still saved
+
+
+def test_advance_step_async_consumer_path_fires_post_chain_complete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Aiden HOLD: the consumer-loop async path MUST also fire _post_chain_complete.
+
+    Asserts the async _advance_step_async delegates through to the sync code
+    path so the chain-complete post is guaranteed to fire — eliminates the
+    parallel-implementation divergence bug class Aiden caught.
+    """
+    import asyncio
+
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    posts: list = []
+    monkeypatch.setattr(
+        orch, "_post_chain_complete", lambda entry, chain_id: posts.append((entry, chain_id))
+    )
+
+    chain_id = "chain-async-complete"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-async",
+            "brief": "async complete",
+            "started_ts": 0.0,
+            "current_step": "atlas_safety",
+            "steps_done": ["aiden_plan", "max_challenge", "nova_build", "orion_spec"],
+            "atom_ids": {
+                "aiden_plan": "a1",
+                "max_challenge": "a2",
+                "nova_build": "a3",
+                "orion_spec": "a4",
+            },
+            "pending": ["atlas_safety"],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        asyncio.run(orch._advance_step_async(chain_id, "atlas_safety", "atom-atlas"))
+
+    assert len(posts) == 1  # consumer-loop path fired the chain-complete post
+    entry, posted_chain_id = posts[0]
+    assert posted_chain_id == chain_id
+    assert entry["task_id"] == "t-async"
+    assert entry["current_step"] == "complete"

--- a/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
+++ b/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
@@ -410,3 +410,132 @@ def test_advance_step_unrecognized_step_returns_empty_and_logs_warning(
     assert envelopes == []
     assert len(fake_nats.published) == 0
     assert "no known next for completed_step=garbage_step" in caplog.text
+
+
+# ─── Final #ceo post on complete (Agency_OS-zqni) ─────────────────────────────
+
+
+def test_advance_step_final_post_fires_on_chain_complete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When the last parallel partner completes, _post_final_to_ceo is called once."""
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    posts: list[tuple] = []
+    monkeypatch.setattr(
+        orch, "_post_final_to_ceo", lambda entry, chain_id: posts.append((entry, chain_id))
+    )
+
+    chain_id = "chain-final-post"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-zq",
+            "brief": "wire X to Y",
+            "started_ts": 0.0,
+            "current_step": "atlas_safety",
+            "steps_done": ["aiden_plan", "max_challenge", "nova_build", "orion_spec"],
+            "atom_ids": {
+                "aiden_plan": "a1",
+                "max_challenge": "a2",
+                "nova_build": "a3",
+                "orion_spec": "a4",
+            },
+            "pending": ["atlas_safety"],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
+
+    assert len(posts) == 1
+    entry, posted_chain_id = posts[0]
+    assert posted_chain_id == chain_id
+    assert entry["task_id"] == "t-zq"
+    assert entry["brief"] == "wire X to Y"
+    assert entry["current_step"] == "complete"
+
+
+def test_advance_step_intermediate_does_not_post_to_ceo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Intermediate transitions (e.g. aiden_plan → max_challenge) must NOT post to #ceo."""
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    posts: list = []
+
+    def boom_post(_entry, _chain_id):
+        posts.append(True)
+        raise AssertionError("_post_final_to_ceo MUST NOT be called for intermediate steps")
+
+    monkeypatch.setattr(orch, "_post_final_to_ceo", boom_post)
+
+    chain_id = "chain-intermediate"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-int",
+            "brief": "in flight",
+            "started_ts": 0.0,
+            "current_step": "aiden_plan",
+            "steps_done": [],
+            "atom_ids": {},
+            "pending": [],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        orch.advance_step(chain_id, "aiden_plan", "atom-aiden", clock=lambda: 2.0)
+
+    assert posts == []  # final post never invoked
+
+
+def test_advance_step_final_post_failure_does_not_break_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A raising _post_final_to_ceo must NOT abort advance_step (fail-open guard)."""
+    fake_nats = _fake_nats_module()
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    def boom_post(_entry, _chain_id):
+        raise RuntimeError("slack down")
+
+    monkeypatch.setattr(orch, "_post_final_to_ceo", boom_post)
+
+    chain_id = "chain-failopen"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-fo",
+            "brief": "fail-open",
+            "started_ts": 0.0,
+            "current_step": "atlas_safety",
+            "steps_done": ["aiden_plan", "max_challenge", "nova_build", "orion_spec"],
+            "atom_ids": {
+                "aiden_plan": "a1",
+                "max_challenge": "a2",
+                "nova_build": "a3",
+                "orion_spec": "a4",
+            },
+            "pending": ["atlas_safety"],
+        },
+    )
+
+    with patch.dict("sys.modules", {"nats": fake_nats}):
+        # Must NOT raise even though _post_final_to_ceo blows up.
+        envelopes = orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
+
+    assert envelopes == []  # no further dispatch on complete
+    state = json.loads(state_file.read_text())
+    assert state[chain_id]["current_step"] == "complete"  # state still saved


### PR DESCRIPTION
## Summary
Pairs with **nd3b (PR #1337)**: intermediate hops now suppress their own `task_complete`; this PR makes the orchestrator fire the **single chain-result line** to #ceo when `advance_step` transitions `current_step` to `'complete'` — so Dave sees **one** notification per directive, at the right moment (last reviewer's atom done).

## Change
- `src/keiracom_system/chain/v1_chain_orchestrator.py::advance_step` — added one call to `_post_final_to_ceo(entry, chain_id)` in the existing "last parallel step completed → chain is complete" branch.
- New module-level `_post_final_to_ceo(entry, chain_id)` helper — shells out to `scripts/slack_relay.py -c ceo` with `CALLSIGN=elliot` (same pattern as my gl3v consumer notify + PR #1312's `task_complete` hook). Module-level so tests can monkeypatch it.
- Message: `✅ [V1-CHAIN] '<brief>' — complete (task=<task_id>, chain=<chain_id[:8]>). Steps: aiden_plan → max_challenge → nova_build → orion_spec + atlas_safety.`

## Double fail-open
- **Helper internal**: subprocess call wrapped in try/except (logs + returns on `rc != 0` or any exception).
- **Call site**: `advance_step` ALSO wraps the helper call in try/except — a test-injected raising fake (or a future helper refactor) MUST NOT block the state save. Same belt-and-suspenders pattern I used in `consumer.py::_dead_letter`.

## Cost field
Omitted per spec ("if available, else omit"). Per-spawn cost lands in `keiracom_spawn_attribution`; chain-level aggregation is a separate piece of telemetry. Can be added later without breaking the message shape.

## Coordination
- Atlas's first-hop + state machine PR #1329 (zr7e.2) is **merged** — no collision.
- Atlas's consumer loop (`oevr`) has no in-flight commits in `git log --all` — this PR lands cleanly before that work begins.

## Test plan
- [x] 3 new tests:
  - `test_advance_step_final_post_fires_on_chain_complete` — atlas_safety completion → final post called once with correct task_id/brief/chain_id; `current_step='complete'`.
  - `test_advance_step_intermediate_does_not_post_to_ceo` — aiden_plan→max_challenge transition: boom-fake asserts the helper is never invoked.
  - `test_advance_step_final_post_failure_does_not_break_completion` — raising helper does NOT abort; state still saved, `current_step='complete'`.
- [x] `pytest tests/keiracom_system/chain/test_v1_chain_orchestrator.py` → **14 passed** (11 existing + 3 new).
- [x] `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)