### PR TITLE
[ORION] feat(dispatcher): inject CHAIN_STEP env at spawn from chain envelope (Agency_OS-qjl7)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -421,6 +421,22 @@ def _free_port() -> int:
         return int(sock.getsockname()[1])
 
 
+def _apply_chain_step_env(sk: dict[str, Any], env: dict[str, Any]) -> None:
+    """qjl7 — promote spawn_kwargs['chain_step'] to env['CHAIN_STEP'] (un-prefixed).
+
+    The v1_chain_orchestrator emits envelopes with a ``chain_step`` field (e.g.
+    "aiden_plan"); the consumer hands that through as a top-level spawn_kwargs
+    key. ``agent_cold_start.run()`` reads ``CHAIN_STEP`` (not the AGENT_* form)
+    for its nd3b notify-suppression gate, so the generic metadata loop's
+    AGENT_<KEY> mapping would land it under the wrong name. Pop the key so it
+    is not double-set; ``setdefault`` keeps any caller-supplied CHAIN_STEP
+    override. Fail-open: chain_step absent → no-op; legacy spawns unchanged.
+    """
+    chain_step = sk.pop("chain_step", None)
+    if chain_step is not None:
+        env.setdefault("CHAIN_STEP", str(chain_step))
+
+
 def _container_spawn_kwargs(key: str, sk: dict[str, Any]) -> dict[str, Any]:
     """Translate logical spawn_kwargs → container_lifecycle.spawn_container kwargs.
 
@@ -437,6 +453,7 @@ def _container_spawn_kwargs(key: str, sk: dict[str, Any]) -> dict[str, Any]:
     port = int(sk.pop("port", None) or _free_port())
     health_path = sk.pop("health_path", None)
     extra_args = sk.pop("extra_args", None)
+    _apply_chain_step_env(sk, env)
     for meta_key, meta_val in sk.items():
         if meta_val is not None:
             env.setdefault(f"AGENT_{meta_key.upper()}", str(meta_val))
@@ -510,6 +527,7 @@ def _tmux_spawn_kwargs(key: str, sk: dict[str, Any]) -> dict[str, Any]:
     working_dir = sk.pop("working_dir", None) or DEFAULT_AGENT_WORKDIR
     agent_command = sk.pop("command", None) or DEFAULT_AGENT_COMMAND
     env = dict(sk.pop("env", None) or {})  # carries the recall PRIOR_CONTEXT if injected
+    _apply_chain_step_env(sk, env)
     for meta_key, meta_val in sk.items():
         if meta_val is not None:
             env.setdefault(f"AGENT_{meta_key.upper()}", str(meta_val))

--- a/tests/dispatcher/test_main_chain_step_wiring.py
+++ b/tests/dispatcher/test_main_chain_step_wiring.py
@@ -1,0 +1,103 @@
+"""qjl7 — CHAIN_STEP env injection at dispatcher spawn (chain envelope -> agent env).
+
+v1_chain_orchestrator emits envelopes with ``chain_step`` (e.g. "aiden_plan").
+The consumer hands that through as a top-level spawn_kwargs key; the dispatcher
+must promote it to ``env['CHAIN_STEP']`` so agent_cold_start's nd3b
+notify-suppression gate reads the right name. Without this wiring the generic
+metadata loop would land it under ``AGENT_CHAIN_STEP`` instead.
+"""
+
+from __future__ import annotations
+
+from src.dispatcher import main as dm
+
+# ---------------------------------------------------------------------------
+# Helper — _apply_chain_step_env
+# ---------------------------------------------------------------------------
+
+
+def test_apply_chain_step_env_sets_unprefixed_when_present():
+    """chain_step in sk → env['CHAIN_STEP']; chain_step popped from sk so it
+    won't also surface as AGENT_CHAIN_STEP downstream."""
+    sk = {"chain_step": "aiden_plan", "task_id": "t-1"}
+    env: dict[str, str] = {}
+    dm._apply_chain_step_env(sk, env)
+    assert env == {"CHAIN_STEP": "aiden_plan"}
+    assert "chain_step" not in sk  # popped
+    assert sk == {"task_id": "t-1"}  # other metadata intact
+
+
+def test_apply_chain_step_env_no_op_when_absent():
+    """No chain_step → env unchanged. Fail-open: legacy spawns must work."""
+    sk = {"task_id": "t-2"}
+    env = {"PRIOR_CONTEXT": "block"}
+    dm._apply_chain_step_env(sk, env)
+    assert env == {"PRIOR_CONTEXT": "block"}
+    assert sk == {"task_id": "t-2"}
+
+
+def test_apply_chain_step_env_caller_override_preserved():
+    """An explicit env['CHAIN_STEP'] wins over the spawn_kwargs key (setdefault)."""
+    sk = {"chain_step": "max_challenge"}
+    env = {"CHAIN_STEP": "explicit_override"}
+    dm._apply_chain_step_env(sk, env)
+    assert env["CHAIN_STEP"] == "explicit_override"
+
+
+def test_apply_chain_step_env_stringifies_non_string_value():
+    """A non-string chain_step (defensive) gets str()'d so env stays text-only."""
+    sk = {"chain_step": 7}
+    env: dict[str, str] = {}
+    dm._apply_chain_step_env(sk, env)
+    assert env["CHAIN_STEP"] == "7"
+
+
+# ---------------------------------------------------------------------------
+# Container backend — _container_spawn_kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_container_spawn_kwargs_promotes_chain_step_to_env():
+    """chain_step in spawn_kwargs → container env['CHAIN_STEP'] (un-prefixed),
+    and the generic loop does NOT also set AGENT_CHAIN_STEP."""
+    out = dm._container_spawn_kwargs(
+        "k-1",
+        {"chain_step": "aiden_plan", "callsign": "aiden", "task_id": "t-1"},
+    )
+    env = out["env"]
+    assert env.get("CHAIN_STEP") == "aiden_plan"
+    assert "AGENT_CHAIN_STEP" not in env  # not double-set under the AGENT_* prefix
+    # Other metadata still flows through with the AGENT_ prefix.
+    assert env.get("AGENT_CALLSIGN") == "aiden"
+    assert env.get("AGENT_TASK_ID") == "t-1"
+
+
+def test_container_spawn_kwargs_no_chain_step_no_env_var():
+    """Legacy spawn (no chain_step) leaves env CHAIN_STEP unset — fail-open."""
+    out = dm._container_spawn_kwargs("k-2", {"callsign": "worker", "task_id": "t-2"})
+    assert "CHAIN_STEP" not in out["env"]
+
+
+# ---------------------------------------------------------------------------
+# Tmux backend — _tmux_spawn_kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_tmux_spawn_kwargs_promotes_chain_step_into_scrubbed_command():
+    """The scrubbed-tmux command embeds env -i assignments; CHAIN_STEP=<value>
+    must be in the assignment list when chain_step is supplied."""
+    out = dm._tmux_spawn_kwargs(
+        "k-3",
+        {"chain_step": "atlas_safety", "callsign": "atlas", "task_id": "t-3"},
+    )
+    cmd = out["command"]
+    # The env -i prefix carries quoted assignments; CHAIN_STEP must land there
+    # un-prefixed (NOT as AGENT_CHAIN_STEP).
+    assert "CHAIN_STEP=atlas_safety" in cmd
+    assert "AGENT_CHAIN_STEP" not in cmd
+
+
+def test_tmux_spawn_kwargs_no_chain_step_no_env_var_in_command():
+    """Legacy tmux spawn: no chain_step → no CHAIN_STEP assignment in the command."""
+    out = dm._tmux_spawn_kwargs("k-4", {"callsign": "worker", "task_id": "t-4"})
+    assert "CHAIN_STEP=" not in out["command"]


### PR DESCRIPTION
## Summary
End-to-end wiring for the V1-chain notify-suppression gate (**qjl7**, Elliot dispatch). `v1_chain_orchestrator` emits envelopes with a `chain_step` field (e.g. `"aiden_plan"`); the consumer hands that through as a top-level `spawn_kwargs` key; until now the dispatcher's translator would land it as **`AGENT_CHAIN_STEP`** (via the generic metadata loop's `AGENT_<KEY>` mapping), which `agent_cold_start` can't read — its nd3b gate reads `CHAIN_STEP` un-prefixed. Result: chain spawns would always notify on every hop, defeating #1337.

- **`_apply_chain_step_env(sk, env)`** — shared helper: pops `sk['chain_step']` and `env.setdefault('CHAIN_STEP', str(value))`. Pop is intentional — if it stayed in `sk`, the metadata loop would also surface it as `AGENT_CHAIN_STEP`. `setdefault` preserves a caller-supplied `env` override.
- Called from **`_container_spawn_kwargs` AND `_tmux_spawn_kwargs`** right after env init and **before** the `AGENT_<KEY>` metadata loop, so both backends end up with the un-prefixed var (container: `env` dict; tmux: `env -i` assignment in the scrubbed command).
- **Fail-open**: `chain_step` absent → no-op → legacy spawns unchanged. The whole change is a no-op for non-chain dispatches.

## Foundations / pre-flight
- ✅ `git log --all --oneline | grep -iE 'chain_step.*env|CHAIN_STEP.*inject|spawn.*chain_step|envelope.*chain_step'` — nothing shipped.
- ✅ `v1_chain_orchestrator._build_envelope` carries `chain_step` (verified on `main`).
- ✅ `agent_cold_start` reads `CHAIN_STEP` un-prefixed (nd3b / #1337, on `main`).
- ✅ Both dispatcher translators rely on the same `for meta_key, meta_val in sk.items(): env.setdefault(f"AGENT_{meta_key.upper()}"…)` pattern — the helper sits just before that loop in both.

## Acceptance
1. ✅ Container spawn: `chain_step` in `spawn_kwargs` → `env['CHAIN_STEP']` (un-prefixed), NOT `AGENT_CHAIN_STEP` (`test_container_spawn_kwargs_promotes_chain_step_to_env`).
2. ✅ Tmux spawn: `env -i` command carries `CHAIN_STEP=<value>` (`test_tmux_spawn_kwargs_promotes_chain_step_into_scrubbed_command`).
3. ✅ Both backends: `chain_step` absent → no `CHAIN_STEP` set (legacy spawn behaviour preserved).

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/dispatcher/test_main_chain_step_wiring.py` → **8/8 passed** (helper alone × 4 + container path × 2 + tmux path × 2)
- [x] Dispatcher regression: 20/20 across `test_main_container_defaults` + `test_main_scrubbed_tmux` + `test_main_wiring` (one pre-existing local-shell-env failure in `test_scrub_gated_off_by_default` — `DISPATCHER_TMUX_SCRUB_ENABLED=true` is set in my local shell only; CI is clean and the test isn't touched by this change)

## V1 chain coordination
- nd3b (#1337) on main: `agent_cold_start.run()` reads `CHAIN_STEP` and suppresses `notify` on intermediate hops.
- This PR: dispatcher promotes envelope `chain_step` → env `CHAIN_STEP` so nd3b actually sees a value at spawn.
- Atlas's oevr (consumer loop) will translate handoff messages → `/dispatcher/spawn` calls with `chain_step` in spawn_kwargs.

Together these close the loop: chain orchestrator emits → consumer dispatches → dispatcher injects env → `agent_cold_start` reads env → notify-suppression fires correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)