### PR TITLE
[ATLAS] fix(dispatcher): envelope → AGENT_* env auto-injection in scripts spawn path (Agency_OS-0bgt)

### DIFF
--- a/scripts/dispatcher/_spawn.py
+++ b/scripts/dispatcher/_spawn.py
@@ -20,6 +20,7 @@ bd: Agency_OS-8416
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import subprocess
 import time
@@ -46,6 +47,7 @@ def handle_envelope(
     mode: str,
     claude_bin: str | None = None,
     resume_context: Mapping[str, Any] | None = None,
+    envelope: Mapping[str, Any] | None = None,
     popen: Any = subprocess.Popen,
     clock: Any = time,
 ) -> dict[str, Any]:
@@ -85,12 +87,32 @@ def handle_envelope(
         result["mode"] = MODE_NOOP
         return result
 
+    # Agency_OS-0bgt — env-from-envelope auto-injection. Mirrors the
+    # src/dispatcher/main.py spawn_kwargs translator (lines 441-443 +
+    # 513-515): each non-None envelope field becomes AGENT_<KEY>=<value> in
+    # the spawned process env. Future-proofs the per-callsign Path A for any
+    # consumer that reads AGENT_* (e.g. an agent_cold_start invocation, or a
+    # persona-level CHAIN_STEP-aware behavior).
+    #
+    # Orion caveat (bd Agency_OS-0bgt 2026-05-29): this Path A spawns `claude`
+    # directly, NOT agent_cold_start — so the var lands in the spawned process
+    # env but the nd3b notify-suppression gate (which reads CHAIN_STEP /
+    # AGENT_CHAIN_STEP inside agent_cold_start.run) does NOT fire here. The
+    # injection is parity-friendly plumbing; full dress-rehearsal cleanliness on
+    # this path needs a separate architecture call (refactor _spawn.py to run
+    # agent_cold_start, or persona-level CHAIN_STEP awareness).
+    env = dict(os.environ)
+    if envelope:
+        for k, v in envelope.items():
+            if v is not None:
+                env.setdefault(f"AGENT_{k.upper()}", str(v))
     proc = popen(
         [binary],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        env=env,
     )
     # Write the composed prompt to stdin + close. Caller (dispatcher_main)
     # decides whether to wait() or fire-and-forget.

--- a/scripts/dispatcher/dispatcher_main.py
+++ b/scripts/dispatcher/dispatcher_main.py
@@ -112,6 +112,7 @@ def main(
             inbox_root=inbox_root,
             mode=mode,
             resume_context=resume_ctx,
+            envelope=envelope,  # Agency_OS-0bgt — env-from-envelope auto-injection
         )
     return 0
 

--- a/tests/scripts/dispatcher/test_spawn.py
+++ b/tests/scripts/dispatcher/test_spawn.py
@@ -227,3 +227,106 @@ def test_spawn_mode_handles_proc_without_stdin(tmp_path: Path):
     )
     assert result["mode"] == MODE_SPAWN
     assert result["pid"] == 9999
+
+
+# ─── envelope → AGENT_* env auto-injection (Agency_OS-0bgt) ────────────────────
+
+
+def test_spawn_mode_injects_envelope_keys_as_AGENT_env(tmp_path: Path):
+    """envelope fields → env[f'AGENT_<KEY>']=str(val); None values skipped."""
+    db = _FakeDB()
+    _seed_db_for_compose(db)
+    popen_calls: list[Any] = []
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeProc:
+        popen_calls.append((cmd, kwargs))
+        return _FakeProc()
+
+    handle_envelope(
+        callsign="nova",
+        db=db,
+        repo_root=_make_repo_root(tmp_path),
+        inbox_root=_make_inbox_root_with_one_msg(tmp_path, "nova"),
+        mode=MODE_SPAWN,
+        claude_bin="/usr/local/bin/claude",
+        envelope={
+            "chain_step": "aiden_plan",
+            "task_id": "t-42",
+            "atom_id": "atom-abc",
+            "atom_id_missing": None,  # None → skipped
+        },
+        popen=fake_popen,
+        clock=_FakeClock(),
+    )
+    _cmd, kwargs = popen_calls[0]
+    env = kwargs["env"]
+    assert env["AGENT_CHAIN_STEP"] == "aiden_plan"
+    assert env["AGENT_TASK_ID"] == "t-42"
+    assert env["AGENT_ATOM_ID"] == "atom-abc"
+    assert "AGENT_ATOM_ID_MISSING" not in env
+
+
+def test_spawn_mode_without_envelope_passes_parent_env(tmp_path: Path, monkeypatch):
+    """No envelope: env=os.environ.copy() — parent env passes through."""
+    monkeypatch.setenv("_BGT_SENTINEL_", "preserved")
+    db = _FakeDB()
+    _seed_db_for_compose(db)
+    popen_calls: list[Any] = []
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeProc:
+        popen_calls.append((cmd, kwargs))
+        return _FakeProc()
+
+    handle_envelope(
+        callsign="nova",
+        db=db,
+        repo_root=_make_repo_root(tmp_path),
+        inbox_root=_make_inbox_root_with_one_msg(tmp_path, "nova"),
+        mode=MODE_SPAWN,
+        claude_bin="/usr/local/bin/claude",
+        # envelope omitted
+        popen=fake_popen,
+        clock=_FakeClock(),
+    )
+    env = popen_calls[0][1]["env"]
+    assert env.get("_BGT_SENTINEL_") == "preserved"
+    # No AGENT_* injected from absent envelope.
+    assert not any(k.startswith("AGENT_") and k not in os_environ_AGENT_keys() for k in env)
+
+
+def os_environ_AGENT_keys() -> set[str]:
+    """Capture pre-existing AGENT_* env (so the negative assertion above only
+    excludes injection-introduced keys, not the test runner's own AGENT_* if any).
+    """
+    import os
+
+    return {k for k in os.environ if k.startswith("AGENT_")}
+
+
+def test_spawn_mode_envelope_setdefault_preserves_parent_AGENT_override(
+    tmp_path: Path, monkeypatch
+):
+    """setdefault semantics: a pre-set AGENT_* in parent env wins over envelope.
+    Idempotent / caller-override-respecting (mirrors src/dispatcher/main.py)."""
+    monkeypatch.setenv("AGENT_CHAIN_STEP", "operator_override")
+    db = _FakeDB()
+    _seed_db_for_compose(db)
+    popen_calls: list[Any] = []
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeProc:
+        popen_calls.append((cmd, kwargs))
+        return _FakeProc()
+
+    handle_envelope(
+        callsign="nova",
+        db=db,
+        repo_root=_make_repo_root(tmp_path),
+        inbox_root=_make_inbox_root_with_one_msg(tmp_path, "nova"),
+        mode=MODE_SPAWN,
+        claude_bin="/usr/local/bin/claude",
+        envelope={"chain_step": "aiden_plan"},
+        popen=fake_popen,
+        clock=_FakeClock(),
+    )
+    env = popen_calls[0][1]["env"]
+    assert env["AGENT_CHAIN_STEP"] == "operator_override"  # parent env wins


### PR DESCRIPTION
## Summary
Mirrors `src/dispatcher/main.py`'s spawn_kwargs translator (lines 441-443 + 513-515) in `scripts/dispatcher/_spawn.py` — Path A (NATS → bridge → per-callsign inbox → `claude` session). Each non-None envelope field becomes `AGENT_<KEY>=<value>` in the spawned process env.

## Implementation (per Orion's bd `Agency_OS-0bgt` research)
- `scripts/dispatcher/_spawn.py`: `+import os`, `+envelope: Mapping[str, Any] | None = None` param, `env = dict(os.environ)` + `setdefault(f"AGENT_{KEY}", str(val))` loop before popen, `+env=env` kwarg on popen.
- `scripts/dispatcher/dispatcher_main.py:108-115`: pass `envelope=envelope` to `_spawn.handle_envelope` (envelope already in scope from the `_inbox_loop.iter_claimed_envelopes` for-loop).

## ⚠️ Orion's caveat — surfaced for review (not silent)
This Path A spawns `claude` **directly**, NOT `agent_cold_start.py`. The `nd3b` notify-suppression gate lives in `agent_cold_start.run()` (reads `CHAIN_STEP` / `AGENT_CHAIN_STEP`) — that function is **not invoked** on this code path.

The injected `AGENT_*` env vars **land in the `claude` process env** but no current consumer reads them. So this PR is **functionally inert for the nd3b gate** — V1 chain hops dispatched via NATS → this path still post intermediate `#ceo` notifications.

Full dress-rehearsal cleanliness on Path A needs a **separate architecture call**:
- (a) refactor `_spawn.py` to invoke `agent_cold_start` (significant — changes the per-callsign session model), OR
- (b) persona-level `CHAIN_STEP`-awareness in the per-callsign `claude` sessions (so live agents check their env and self-suppress).

This PR ships **(i) — the parity-friendly, reversible, env-plumbing fix** Elliot dispatched. (a)/(b) belong in a follow-up KEI; the env plumbing here unblocks whichever lands.

## Tests (3 new, 9 total spawn tests pass)
- `test_spawn_mode_injects_envelope_keys_as_AGENT_env` — envelope fields auto-inject; None values skipped.
- `test_spawn_mode_without_envelope_passes_parent_env` — no envelope → parent env passes through; no AGENT_* introduced from absence.
- `test_spawn_mode_envelope_setdefault_preserves_parent_AGENT_override` — `setdefault` semantics: pre-set `AGENT_*` in parent env wins (operator override; mirrors `src/dispatcher/main.py`).

`ruff check` + `ruff format --check` clean.

## Test plan
- [ ] Merge → verify `ps -ef | grep claude` shows AGENT_CHAIN_STEP in env when V1 chain runs a hop through Path A
- [ ] File follow-up KEI: "Path A nd3b inertness — refactor _spawn.py to run agent_cold_start, OR persona-level CHAIN_STEP awareness"

🤖 Generated with [Claude Code](https://claude.com/claude-code)