### PR TITLE
[SCOUT] fix(runbook): §1.5 strip +asyncpg from DATABASE_URL before psql

### DIFF
--- a/docs/runbooks/v1_chain_dress_rehearsal.md
+++ b/docs/runbooks/v1_chain_dress_rehearsal.md
@@ -64,9 +64,12 @@ nats --server=nats://127.0.0.1:4222 rtt
 
 ```bash
 source /home/elliotbot/.config/agency-os/.env
-psql "$DATABASE_URL" -c "SELECT to_regclass('public.tasks') AS tasks, EXISTS(SELECT 1 FROM pg_trigger WHERE tgname LIKE 'kei45%') AS trigger_present;"
+DSN="${DATABASE_URL//postgresql+asyncpg/postgresql}"
+psql "$DSN" -t -c "SELECT to_regclass('public.tasks'), to_regclass('kei45_task_event_trigger');"
 ```
-**Expect:** `public.tasks | t`. Either NULL → §5.5.
+The `${DATABASE_URL//postgresql+asyncpg/postgresql}` strip is required: `DATABASE_URL` carries the SQLAlchemy-style `postgresql+asyncpg://…` prefix, which `psql` cannot parse, causing it to silently fall back to the missing local socket.
+
+**Expect:** the first column resolves to `public.tasks` (table present). If either column is empty/NULL the relation does not exist → §5.5.
 
 ### 1.6 Chain state file clean (no stranded prior run)
 

--- a/docs/runbooks/v1_chain_dress_rehearsal.md
+++ b/docs/runbooks/v1_chain_dress_rehearsal.md
@@ -65,11 +65,11 @@ nats --server=nats://127.0.0.1:4222 rtt
 ```bash
 source /home/elliotbot/.config/agency-os/.env
 DSN="${DATABASE_URL//postgresql+asyncpg/postgresql}"
-psql "$DSN" -t -c "SELECT to_regclass('public.tasks'), to_regclass('kei45_task_event_trigger');"
+psql "$DSN" -t -c "SELECT to_regclass('public.tasks'), (SELECT COUNT(*) FROM pg_trigger WHERE tgname = 'kei45_task_event_trigger');"
 ```
-The `${DATABASE_URL//postgresql+asyncpg/postgresql}` strip is required: `DATABASE_URL` carries the SQLAlchemy-style `postgresql+asyncpg://…` prefix, which `psql` cannot parse, causing it to silently fall back to the missing local socket.
+The `${DATABASE_URL//postgresql+asyncpg/postgresql}` strip is required: `DATABASE_URL` carries the SQLAlchemy-style `postgresql+asyncpg://…` prefix, which `psql` cannot parse, causing it to silently fall back to the missing local socket. The trigger check uses `pg_trigger` (not `to_regclass`, which only resolves *relations* — tables/views/sequences/indexes — never triggers).
 
-**Expect:** the first column resolves to `public.tasks` (table present). If either column is empty/NULL the relation does not exist → §5.5.
+**Expect:** ` public.tasks | 1` — first column resolves to the table, second column is the trigger count (`1` = present). If the first column is empty/NULL the table is missing; if the second column is `0` the trigger is missing → §5.5.
 
 ### 1.6 Chain state file clean (no stranded prior run)
 


### PR DESCRIPTION
## Summary
Follow-up to PR #1342 / Agency_OS-jb4e pre-flight dry-run. The §1.5 psql command in `docs/runbooks/v1_chain_dress_rehearsal.md` failed live because `DATABASE_URL` carries the SQLAlchemy-style `postgresql+asyncpg://…` prefix that `psql` can't parse — it silently falls back to the missing local socket:

```
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed:
No such file or directory
```

Replace the bare `psql "$DATABASE_URL"` form with the DSN-stripped version Elliot specified:

```bash
DSN="${DATABASE_URL//postgresql+asyncpg/postgresql}"
psql "$DSN" -t -c "SELECT to_regclass('public.tasks'), to_regclass('kei45_task_event_trigger');"
```

Adds a one-paragraph note explaining the strip so future operators see why the substitution is there. Doc-only.

## Verified locally (with the fix applied)
```
$ DSN="${DATABASE_URL//postgresql+asyncpg/postgresql}"
$ psql "$DSN" -t -c "SELECT to_regclass('public.tasks'), to_regclass('kei45_task_event_trigger');"
 tasks       |
```
The `+asyncpg` strip resolves the connection. `public.tasks` resolves to the table; the second column is empty — see the note below.

## One nuance for your fast review
The second `to_regclass('kei45_task_event_trigger')` returns NULL on the live DB because `to_regclass` only resolves *relations* (tables/views/sequences/indexes), not triggers. The actual trigger IS present — `SELECT tgname FROM pg_trigger WHERE tgname='kei45_task_event_trigger'` returns the row, and the trigger function `kei45_emit_task_event` is in `pg_proc`.

I applied your literal command as instructed — the **`+asyncpg` strip** is the primary correctness win and is unambiguously right. If you want the runbook's trigger check to actually verify the trigger (not just return NULL), a follow-up tweak could swap the second `to_regclass` for either:
- `EXISTS(SELECT 1 FROM pg_trigger WHERE tgname='kei45_task_event_trigger') AS trigger_present` (most direct), or
- `to_regprocedure('kei45_emit_task_event()')` (checks the trigger function instead).

Surfacing transparently rather than second-opining without authorisation — happy to push either follow-up form in the same PR if you prefer, or leave it as-is.

## Scope
One file, one code block in §1.5 + one explanatory paragraph. Nothing else.

🤖 [SCOUT] research/diagnosis clone