### PR TITLE
[ATLAS] feat(chain): dispatch chain hops via /dispatcher/spawn HTTP — Option B for V1 (Agency_OS-zr7e.2 fix)

### DIFF
--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -187,11 +187,60 @@ async def _publish_async(envelope: dict, role: str) -> bool:
 
 
 def _publish_envelope(envelope: dict, role: str) -> bool:
-    """Drive async publish via asyncio.run. Return True on success, False on any failure."""
+    """Dispatch a chain hop by POSTing to /dispatcher/spawn (HTTP).
+
+    Was a NATS publish to keiracom.dispatch.<role>. Switched to /spawn
+    (architectural Option B, Elliot 2026-05-29) so each chain hop spawns a
+    fresh ephemeral agent_cold_start process:
+        spawn → agent_cold_start.run() → save_exit_atoms publishes
+        keiracom.agent.handoff → consumer's run_consumer fires advance_step
+        → next hop dispatched.
+    Closes the "persistent claude session has no handoff publisher" gap
+    (the rehearsal-blocker found via research-task pre-build).
+
+    spawn_kwargs are forwarded verbatim to SessionManager.spawn; the dispatcher
+    auto-injects each non-None key as AGENT_<KEY> (src/dispatcher/main.py
+    441-443/513-515) and pops `chain_step` first to land it as CHAIN_STEP
+    un-prefixed (qjl7's _apply_chain_step_env at 421-435), which is what
+    agent_cold_start's nd3b suppression reads.
+
+    Fail-open: any error (transport, non-2xx) logged + False returned. The
+    pure-NATS _publish_async (above) is kept for any remaining NATS-only
+    subscribers / future use.
+    """
+    import urllib.error  # noqa: PLC0415 — lazy; only the hop-dispatch path needs it
+    import urllib.request  # noqa: PLC0415
+
+    body = {
+        "backend": "tmux",  # Phase 1 scrubbed-tmux backend (Agency_OS-87ei)
+        "key": f"chain-{envelope.get('chain_id', '?')}-{envelope.get('chain_step', '?')}",
+        "spawn_kwargs": {
+            "role": role,
+            "callsign": role,  # bounded_spawn enforcer + supervisor attribution
+            "tier": "standard",
+            "variant": role,
+            "brief": envelope.get("brief", ""),
+            "chain_step": envelope.get("chain_step", ""),
+            "chain_id": envelope.get("chain_id", ""),
+            "task_id": envelope.get("task_id", ""),
+            "atom_id": envelope.get("atom_id"),
+        },
+    }
+    payload = json.dumps(body).encode()
+    url = f"{_DISPATCHER_URL.rstrip('/')}/dispatcher/spawn"
     try:
-        return asyncio.run(_publish_async(envelope, role))
+        req = urllib.request.Request(
+            url, data=payload, headers={"Content-Type": "application/json"}, method="POST"
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 — fixed loopback host
+            status = resp.status
+        log.info("v1_chain: /dispatcher/spawn role=%s key=%s status=%d", role, body["key"], status)
+        return 200 <= status < 300
+    except (urllib.error.URLError, OSError) as exc:
+        log.error("v1_chain: /dispatcher/spawn failed role=%s: %s", role, exc)
+        return False
     except Exception as exc:  # noqa: BLE001
-        log.error("v1_chain: asyncio.run publish failed role=%s: %s", role, exc)
+        log.error("v1_chain: unexpected /spawn error role=%s: %s", role, exc)
         return False
 
 

--- a/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
+++ b/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
@@ -1,7 +1,7 @@
 """Tests for src.keiracom_system.chain.v1_chain_orchestrator.
 
 Covers:
-  - dispatch(): first-hop NATS publish + state persistence + fail-open on error
+  - dispatch(): first-hop HTTP publish + state persistence + fail-open on error
   - advance_step(): sequential steps, parallel fan-out, partial-parallel wait,
     and final parallel completion → complete
 """
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import types
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -53,6 +53,25 @@ def _seed_state(tmp_path: Path, chain_id: str, entry: dict) -> None:
     state_file.write_text(json.dumps(state))
 
 
+def _capture_publishes(monkeypatch: pytest.MonkeyPatch) -> list[tuple[dict, str]]:
+    """Monkeypatch orch._publish_envelope to capture (envelope, role) pairs in
+    place of an HTTP POST. Tests use this instead of a transport-level mock so
+    they verify the orchestrator's dispatch surface, not the urllib layer.
+    The transport itself (the HTTP POST to /dispatcher/spawn) has its own
+    dedicated integration test.
+    """
+    captured: list[tuple[dict, str]] = []
+
+    def _fake_publish(envelope: dict, role: str) -> bool:
+        captured.append((envelope, role))
+        return True
+
+    monkeypatch.setattr(
+        "src.keiracom_system.chain.v1_chain_orchestrator._publish_envelope", _fake_publish
+    )
+    return captured
+
+
 # ---------------------------------------------------------------------------
 # dispatch() tests
 # ---------------------------------------------------------------------------
@@ -61,36 +80,33 @@ def _seed_state(tmp_path: Path, chain_id: str, entry: dict) -> None:
 def test_dispatch_first_hop_publishes_aiden_envelope(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """dispatch() must publish one envelope to keiracom.dispatch.aiden."""
-    fake_nats = _fake_nats_module()
+    """dispatch() must publish one envelope to aiden."""
+    captured = _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        chain_id = orch.dispatch({"id": "t1", "brief": "hello"}, clock=lambda: 1.0)
+    chain_id = orch.dispatch({"id": "t1", "brief": "hello"}, clock=lambda: 1.0)
 
-    assert len(fake_nats.published) == 1
-    subject, payload = fake_nats.published[0]
-    assert subject == "keiracom.dispatch.aiden"
+    assert len(captured) == 1
+    envelope, role = captured[0]
+    assert role == "aiden"
 
-    env = json.loads(payload)
-    assert env["chain_step"] == "aiden_plan"
-    assert env["atom_id"] is None
-    assert env["brief"] == "hello"
-    assert env["task_id"] == "t1"
-    assert env["chain_id"] == chain_id
-    assert env["from"] == "v1_chain_orchestrator"
-    assert env["ts"] == 1.0
+    assert envelope["chain_step"] == "aiden_plan"
+    assert envelope["atom_id"] is None
+    assert envelope["brief"] == "hello"
+    assert envelope["task_id"] == "t1"
+    assert envelope["chain_id"] == chain_id
+    assert envelope["from"] == "v1_chain_orchestrator"
+    assert envelope["ts"] == 1.0
 
 
 def test_dispatch_persists_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """dispatch() must persist chain state with correct initial values."""
-    fake_nats = _fake_nats_module()
+    _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        chain_id = orch.dispatch({"id": "t2", "brief": "do something"})
+    chain_id = orch.dispatch({"id": "t2", "brief": "do something"})
 
     assert state_file.exists()
     state = json.loads(state_file.read_text())
@@ -101,19 +117,20 @@ def test_dispatch_persists_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert entry["atom_ids"] == {}
 
 
-def test_dispatch_fail_open_on_nats_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """dispatch() must return a chain_id and persist state even when NATS connect raises."""
-    fake_nats = _fake_nats_module(connect_raises=ConnectionRefusedError("no nats"))
+def test_dispatch_fail_open_on_publish_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Dispatch must still return a chain_id and persist state when the
+    /dispatcher/spawn HTTP POST fails — fail-open on transport errors."""
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
-
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        chain_id = orch.dispatch({"id": "t3", "brief": "fail-open test"})
-
-    assert isinstance(chain_id, str) and chain_id  # did not raise
-    assert state_file.exists()
+    # Stub _publish_envelope to simulate HTTP failure.
+    monkeypatch.setattr(
+        "src.keiracom_system.chain.v1_chain_orchestrator._publish_envelope",
+        lambda envelope, role: False,
+    )
+    cid = orch.dispatch({"id": "fail-task", "brief": "x"})
+    assert cid  # chain_id still returned despite publish failure
     state = json.loads(state_file.read_text())
-    assert chain_id in state
+    assert "fail-task" in state  # state persisted
 
 
 # ---------------------------------------------------------------------------
@@ -122,8 +139,8 @@ def test_dispatch_fail_open_on_nats_error(tmp_path: Path, monkeypatch: pytest.Mo
 
 
 def test_advance_step_aiden_to_max(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """aiden_plan → max_challenge: one envelope to keiracom.dispatch.max."""
-    fake_nats = _fake_nats_module()
+    """aiden_plan → max_challenge: one envelope to max."""
+    captured = _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -143,13 +160,12 @@ def test_advance_step_aiden_to_max(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        envelopes = orch.advance_step(chain_id, "aiden_plan", "atom-abc", clock=lambda: 2.0)
+    envelopes = orch.advance_step(chain_id, "aiden_plan", "atom-abc", clock=lambda: 2.0)
 
     assert len(envelopes) == 1
-    assert len(fake_nats.published) == 1
-    subject, payload = fake_nats.published[0]
-    assert subject == "keiracom.dispatch.max"
+    assert len(captured) == 1
+    envelope, role = captured[0]
+    assert role == "max"
 
     env = envelopes[0]
     assert env["chain_step"] == "max_challenge"
@@ -163,8 +179,8 @@ def test_advance_step_aiden_to_max(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 
 
 def test_advance_step_max_to_nova(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """max_challenge → nova_build: one envelope to keiracom.dispatch.nova with max's atom."""
-    fake_nats = _fake_nats_module()
+    """max_challenge → nova_build: one envelope to nova with max's atom."""
+    captured = _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -184,12 +200,11 @@ def test_advance_step_max_to_nova(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        envelopes = orch.advance_step(chain_id, "max_challenge", "atom-max", clock=lambda: 3.0)
+    envelopes = orch.advance_step(chain_id, "max_challenge", "atom-max", clock=lambda: 3.0)
 
     assert len(envelopes) == 1
-    subject, payload = fake_nats.published[0]
-    assert subject == "keiracom.dispatch.nova"
+    envelope, role = captured[0]
+    assert role == "nova"
 
     env = envelopes[0]
     assert env["chain_step"] == "nova_build"
@@ -203,7 +218,7 @@ def test_advance_step_max_to_nova(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
 def test_advance_step_nova_to_dual_orion_atlas(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """nova_build fans out to orion_spec + atlas_safety simultaneously."""
-    fake_nats = _fake_nats_module()
+    captured = _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -223,13 +238,11 @@ def test_advance_step_nova_to_dual_orion_atlas(tmp_path: Path, monkeypatch: pyte
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        envelopes = orch.advance_step(chain_id, "nova_build", "atom-nova", clock=lambda: 4.0)
+    envelopes = orch.advance_step(chain_id, "nova_build", "atom-nova", clock=lambda: 4.0)
 
     assert len(envelopes) == 2
-    subjects = {s for s, _ in fake_nats.published}
-    assert "keiracom.dispatch.orion" in subjects
-    assert "keiracom.dispatch.atlas" in subjects
+    roles = {r for _, r in captured}
+    assert roles == {"orion", "atlas"}
 
     for env in envelopes:
         assert env["atom_id"] == "atom-nova"
@@ -241,7 +254,7 @@ def test_advance_step_nova_to_dual_orion_atlas(tmp_path: Path, monkeypatch: pyte
 
 def test_advance_step_orion_done_waits_for_atlas(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """After orion completes, atlas is still pending — no new dispatch."""
-    fake_nats = _fake_nats_module()
+    captured = _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -265,11 +278,10 @@ def test_advance_step_orion_done_waits_for_atlas(tmp_path: Path, monkeypatch: py
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        envelopes = orch.advance_step(chain_id, "orion_spec", "atom-orion")
+    envelopes = orch.advance_step(chain_id, "orion_spec", "atom-orion")
 
     assert envelopes == []
-    assert len(fake_nats.published) == 0
+    assert len(captured) == 0
 
     state = json.loads(state_file.read_text())
     assert state[chain_id]["pending"] == ["atlas_safety"]
@@ -277,7 +289,7 @@ def test_advance_step_orion_done_waits_for_atlas(tmp_path: Path, monkeypatch: py
 
 def test_advance_step_atlas_done_completes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """When atlas is last parallel partner, chain reaches complete — no dispatch."""
-    fake_nats = _fake_nats_module()
+    captured = _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -302,11 +314,10 @@ def test_advance_step_atlas_done_completes(tmp_path: Path, monkeypatch: pytest.M
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        envelopes = orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
+    envelopes = orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
 
     assert envelopes == []
-    assert len(fake_nats.published) == 0
+    assert len(captured) == 0
 
     state = json.loads(state_file.read_text())
     entry = state[chain_id]
@@ -320,18 +331,18 @@ def test_advance_step_atlas_done_completes(tmp_path: Path, monkeypatch: pytest.M
 def test_advance_step_unknown_chain_id_returns_empty_and_logs_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ):
-    """Unknown chain_id: return [], log error, no NATS publish."""
+    """Unknown chain_id: return [], log error, no publish."""
     import logging
 
-    fake_nats = _fake_nats_module()
+    captured = _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
-    with patch.dict("sys.modules", {"nats": fake_nats}), caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.ERROR):
         envelopes = orch.advance_step("does-not-exist", "aiden_plan", "atom-x")
 
     assert envelopes == []
-    assert len(fake_nats.published) == 0
+    assert len(captured) == 0
     assert "unknown chain_id=does-not-exist" in caplog.text
 
 
@@ -341,7 +352,7 @@ def test_advance_step_duplicate_completion_no_double_dispatch(
     """Duplicate advance_step for the same completed_step must not re-dispatch downstream."""
     import logging
 
-    fake_nats = _fake_nats_module()
+    captured = _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -361,17 +372,16 @@ def test_advance_step_duplicate_completion_no_double_dispatch(
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        first = orch.advance_step(chain_id, "aiden_plan", "atom-1", clock=lambda: 1.0)
+    first = orch.advance_step(chain_id, "aiden_plan", "atom-1", clock=lambda: 1.0)
     assert len(first) == 1
-    assert len(fake_nats.published) == 1  # max_challenge dispatched once
+    assert len(captured) == 1  # max_challenge dispatched once
     state_after_first = json.loads(state_file.read_text())[chain_id]
 
-    with patch.dict("sys.modules", {"nats": fake_nats}), caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING):
         second = orch.advance_step(chain_id, "aiden_plan", "atom-1-again", clock=lambda: 2.0)
 
     assert second == []
-    assert len(fake_nats.published) == 1  # NOT re-dispatched
+    assert len(captured) == 1  # NOT re-dispatched
     assert "duplicate completed_step=aiden_plan" in caplog.text
     # State unchanged by the second call.
     state_after_second = json.loads(state_file.read_text())[chain_id]
@@ -384,7 +394,7 @@ def test_advance_step_unrecognized_step_returns_empty_and_logs_warning(
     """Step not in PARALLEL_AFTER_STEP, not in _SEQ_NEXT, pending empty: [] + warning."""
     import logging
 
-    fake_nats = _fake_nats_module()
+    captured = _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -404,11 +414,11 @@ def test_advance_step_unrecognized_step_returns_empty_and_logs_warning(
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}), caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING):
         envelopes = orch.advance_step(chain_id, "garbage_step", "atom-g")
 
     assert envelopes == []
-    assert len(fake_nats.published) == 0
+    assert len(captured) == 0
     assert "no known next for completed_step=garbage_step" in caplog.text
 
 
@@ -419,7 +429,7 @@ def test_advance_step_final_post_fires_on_chain_complete(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """When the last parallel partner completes, _post_chain_complete is called once."""
-    fake_nats = _fake_nats_module()
+    _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -449,8 +459,7 @@ def test_advance_step_final_post_fires_on_chain_complete(
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
+    orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
 
     assert len(posts) == 1
     entry, posted_chain_id = posts[0]
@@ -464,7 +473,7 @@ def test_advance_step_intermediate_does_not_post_to_ceo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """Intermediate transitions (e.g. aiden_plan → max_challenge) must NOT post to #ceo."""
-    fake_nats = _fake_nats_module()
+    _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -492,8 +501,7 @@ def test_advance_step_intermediate_does_not_post_to_ceo(
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        orch.advance_step(chain_id, "aiden_plan", "atom-aiden", clock=lambda: 2.0)
+    orch.advance_step(chain_id, "aiden_plan", "atom-aiden", clock=lambda: 2.0)
 
     assert posts == []  # final post never invoked
 
@@ -502,7 +510,7 @@ def test_advance_step_final_post_failure_does_not_break_completion(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """A raising _post_chain_complete must NOT abort advance_step (fail-open guard)."""
-    fake_nats = _fake_nats_module()
+    _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -532,9 +540,8 @@ def test_advance_step_final_post_failure_does_not_break_completion(
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        # Must NOT raise even though _post_chain_complete blows up.
-        envelopes = orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
+    # Must NOT raise even though _post_chain_complete blows up.
+    envelopes = orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
 
     assert envelopes == []  # no further dispatch on complete
     state = json.loads(state_file.read_text())
@@ -552,7 +559,7 @@ def test_advance_step_async_consumer_path_fires_post_chain_complete(
     """
     import asyncio
 
-    fake_nats = _fake_nats_module()
+    _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
 
@@ -582,8 +589,7 @@ def test_advance_step_async_consumer_path_fires_post_chain_complete(
         },
     )
 
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        asyncio.run(orch._advance_step_async(chain_id, "atlas_safety", "atom-atlas"))
+    asyncio.run(orch._advance_step_async(chain_id, "atlas_safety", "atom-atlas"))
 
     assert len(posts) == 1  # consumer-loop path fired the chain-complete post
     entry, posted_chain_id = posts[0]
@@ -611,11 +617,10 @@ def test_dispatch_chain_id_defaults_to_task_id_when_present(
 ):
     """When task carries an id and no chain_id is passed, chain_id == task['id']
     so consumer's advance_step(chain_id=msg.task_id) resolves."""
-    fake_nats = _fake_nats_module()
+    _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        cid = orch.dispatch({"id": "task-abc-123", "brief": "x"})
+    cid = orch.dispatch({"id": "task-abc-123", "brief": "x"})
     assert cid == "task-abc-123"
     state = json.loads(state_file.read_text())
     assert "task-abc-123" in state
@@ -625,8 +630,8 @@ async def test_consumer_handle_envelope_async_advances_aiden_to_max(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """Async helper (Max HOLD shape): pass a dict, get back the list of
-    dispatched envelopes. Aiden handoff → dispatch to keiracom.dispatch.max."""
-    fake_nats = _fake_nats_module()
+    dispatched envelopes. Aiden handoff → dispatch to max."""
+    captured = _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
     chain_id = "task-cons-1"
@@ -645,14 +650,13 @@ async def test_consumer_handle_envelope_async_advances_aiden_to_max(
         },
     )
     envelope = {"task_id": chain_id, "atom_id": "atom-aiden", "from_callsign": "aiden"}
-    with patch.dict("sys.modules", {"nats": fake_nats}):
-        dispatched = await orch._consumer_handle_envelope_async(envelope)
+    dispatched = await orch._consumer_handle_envelope_async(envelope)
     assert len(dispatched) == 1
     assert dispatched[0]["chain_step"] == "max_challenge"
     assert dispatched[0]["atom_id"] == "atom-aiden"
-    assert len(fake_nats.published) == 1
-    subject, _payload = fake_nats.published[0]
-    assert subject == "keiracom.dispatch.max"
+    assert len(captured) == 1
+    env, role = captured[0]
+    assert role == "max"
 
 
 async def test_consumer_handle_envelope_async_unknown_callsign_skips(
@@ -691,3 +695,81 @@ async def test_consumer_handle_envelope_async_failopen_on_bad_envelope(
         dispatched = await orch._consumer_handle_envelope_async(None)  # type: ignore[arg-type]
     assert dispatched == []
     assert "handler error" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_publish_envelope_posts_to_dispatcher_spawn_with_correct_body(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Integration test: _publish_envelope POSTs to /dispatcher/spawn with the
+    spawn_kwargs spec'd by Elliot for Option B. Mocks urllib.urlopen + asserts:
+      - URL ends with /dispatcher/spawn
+      - body is JSON: {backend, key:<chain-<chain_id>-<chain_step>>, spawn_kwargs:{role, callsign, tier:'standard', variant, brief, chain_step, chain_id, task_id, atom_id}}
+      - returns True on 2xx
+    """
+    import json
+    import urllib.request
+
+    captured: dict = {}
+
+    class _FakeResp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            pass
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data)
+        captured["method"] = req.get_method()
+        return _FakeResp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    envelope = {
+        "task_id": "t-1",
+        "chain_id": "chain-1",
+        "chain_step": "max_challenge",
+        "atom_id": "atom-aiden",
+        "brief": "build it",
+        "ts": 1.0,
+        "from": "v1_chain_orchestrator",
+    }
+    ok = orch._publish_envelope(envelope, "max")
+
+    assert ok is True
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/dispatcher/spawn")
+    body = captured["body"]
+    assert body["backend"] == "tmux"
+    assert body["key"] == "chain-chain-1-max_challenge"
+    sk = body["spawn_kwargs"]
+    assert sk["role"] == "max"
+    assert sk["callsign"] == "max"
+    assert sk["tier"] == "standard"
+    assert sk["variant"] == "max"
+    assert sk["brief"] == "build it"
+    assert sk["chain_step"] == "max_challenge"
+    assert sk["chain_id"] == "chain-1"
+    assert sk["task_id"] == "t-1"
+    assert sk["atom_id"] == "atom-aiden"
+
+
+def test_publish_envelope_failopen_on_http_error(monkeypatch: pytest.MonkeyPatch):
+    """_publish_envelope returns False (not raises) when urlopen errors."""
+    import urllib.error
+    import urllib.request
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    ok = orch._publish_envelope({"chain_id": "x", "chain_step": "y", "brief": "z"}, "max")
+    assert ok is False


### PR DESCRIPTION
## Summary
Closes the **rehearsal-blocker** identified via the research-task pre-build: the persistent per-callsign `claude` session has no mechanism to publish `keiracom.agent.handoff`; consumer would wait forever. **Architecture decision: Option B (Elliot 2026-05-29).** Chain dispatches go via `POST /dispatcher/spawn` (HTTP) instead of NATS `keiracom.dispatch.<role>`. Each chain hop spawns a fresh ephemeral `agent_cold_start` process:

```
POST /dispatcher/spawn → tmux scrubbed session → python3 -m agent_cold_start
  → run() → save_exit_atoms publishes keiracom.agent.handoff
  → consumer.run_consumer fires advance_step → next hop dispatched
```

## Implementation

### `_publish_envelope` (was NATS → now HTTP)
- Body mirrors `work_loop/consumer.py:198-218` canonical `/dispatcher/spawn` shape:
```python
{
  "backend": "tmux",
  "key": f"chain-{chain_id}-{chain_step}",
  "spawn_kwargs": {
    "role": role,
    "callsign": role,         # bounded_spawn attribution
    "tier": "standard",
    "variant": role,
    "brief": envelope["brief"],
    "chain_step": envelope["chain_step"],
    "chain_id": envelope["chain_id"],
    "task_id": envelope["task_id"],
    "atom_id": envelope["atom_id"],
  },
}
```
- Dispatcher auto-injects `spawn_kwargs` as `AGENT_<KEY>` (`src/dispatcher/main.py:441-443+513-515`) and qjl7's `_apply_chain_step_env` pops `chain_step` first to land it as **`CHAIN_STEP` un-prefixed** (421-435) — which is what `agent_cold_start`'s nd3b suppression reads. So nd3b suppression now fires correctly for chain hops.
- Fail-open: any HTTP error (URLError, OSError, non-2xx) logged + `False` returned.
- `_publish_async` (NATS) is **kept untouched** for any remaining NATS-only subscribers / future use — per Elliot's spec.

## Tests (23 chain tests pass)

**Helper added** — `_capture_publishes(monkeypatch)` monkeypatches `_publish_envelope` to capture `(envelope, role)` pairs (cleaner than transport-level mocking; the HTTP layer has its own integration test).

**Sweep (12 tests):** old `_fake_nats_module + patch.dict("sys.modules", {"nats": ...})` pattern replaced with `_capture_publishes`; assertions updated (`subject` → `role`, `payload` → `envelope` directly).

**Fail-open rename:** `test_dispatch_fail_open_on_nats_error` → `test_dispatch_fail_open_on_publish_error` (stubs `_publish_envelope` returning False, asserts state persisted).

**NEW transport-integration tests (Elliot's acceptance):**
- `test_publish_envelope_posts_to_dispatcher_spawn_with_correct_body` — mocks `urllib.urlopen`, asserts POST URL, body shape, `backend`, `key`, and all `spawn_kwargs` fields.
- `test_publish_envelope_failopen_on_http_error` — `URLError` returns False, never raises.

## Notes
- ruff check + format clean.
- Pre-existing dispatcher failures (`test_main_spawn_recall_wiring` + `test_main_workflow_recall_wiring`, `KeyError: 'env'`) confirmed present on origin/main pre-change — not from this PR.
- Per-callsign `nats_tmux_bridge` services + `keiracom.dispatch.<role>` subject pattern stay in place but are now unused for V1 chain dispatch (Path A → Path B migration); they remain available for any non-chain use.

## Test plan
- [ ] Merge → live dress rehearsal: Face → `/dispatcher/spawn` → agent_cold_start runs Aiden → exits → handoff publish → consumer fires → next hop. Confirm chain progresses past Aiden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)