### PR TITLE
[ORION] feat(dispatcher): GET /dispatcher/chain_status — live V1 chain run view

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -20,11 +20,13 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import dataclasses
+import json
 import logging
 import os
 import shlex
 import socket
 from collections.abc import AsyncGenerator
+from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
@@ -1314,3 +1316,104 @@ async def dispatcher_task_crash_retry(req: TaskCrashRetryRequest) -> dict[str, A
     except Exception:  # noqa: BLE001
         logger.exception("task_crash_retry: DB error for task=%s", req.task_id)
         return {"retry_count": -1, "reason": "exception"}
+
+
+# ---------------------------------------------------------------------------
+# /dispatcher/chain_status — live V1 chain run status + per-hop cost view
+#
+# Reads chain state from v1_chain_orchestrator's STATE_FILE (V1_CHAIN_STATE_FILE
+# env override; default /tmp/v1_chain_state.json — same path the orchestrator
+# writes to) and sums cost_usd × USD_TO_AUD per chain from
+# keiracom_spawn_attribution. Lets Dave see a chain run in progress: which
+# steps are done, what step is current, $AUD spent so far per chain.
+#
+# KNOWN SCHEMA GAP (TODO follow-up KEI):
+# keiracom_spawn_attribution has no chain_id column yet — cost is summed via
+# a source_id heuristic (matches `chain_id` or `task_id`). This will return
+# 0.0 until the attribution writer starts logging chain_id/task_id as the
+# source_id for chain spawns, OR a dedicated chain_id column lands. Similarly
+# there is no latency_ms column, so latency_ms_so_far is 0.0 for V1.
+# ---------------------------------------------------------------------------
+
+_CHAIN_STATE_FILE_ENV = "V1_CHAIN_STATE_FILE"
+_DEFAULT_CHAIN_STATE_FILE = "/tmp/v1_chain_state.json"
+# LAW II — Australia First. 1 USD = 1.55 AUD per CLAUDE.md.
+_USD_TO_AUD_RATE = 1.55
+
+
+def _load_chain_state() -> dict[str, Any]:
+    """Load v1_chain_orchestrator state from STATE_FILE.
+
+    Fail-open: returns {} on missing file, malformed JSON, or any read error —
+    the endpoint serves {"chains": []} rather than 500. State path is the
+    SAME path the orchestrator writes to (V1_CHAIN_STATE_FILE env override or
+    /tmp/v1_chain_state.json default), so this is a read of authoritative state.
+    """
+    path = Path(os.environ.get(_CHAIN_STATE_FILE_ENV, _DEFAULT_CHAIN_STATE_FILE))
+    try:
+        if not path.is_file():
+            return {}
+        loaded = json.loads(path.read_text())
+        return loaded if isinstance(loaded, dict) else {}
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.warning("chain_status: failed to load %s: %s", path, exc)
+        return {}
+
+
+async def _chain_cost_aud(chain_id: str, task_id: str) -> float:
+    """Best-effort SUM(cost_usd) × 1.55 from keiracom_spawn_attribution for one chain.
+
+    No chain_id column exists yet, so this matches via source_id ∈ {chain_id,
+    task_id}. Fail-open: returns 0.0 on DSN absent, asyncpg unavailable, DB
+    error, or no matching rows. LAW II currency: USD → AUD via USD_TO_AUD_RATE.
+    """
+    dsn = os.environ.get(_PERSONA_DSN_ENV)
+    if not dsn:
+        return 0.0
+    try:
+        import asyncpg  # noqa: PLC0415 — deferred (optional in test envs)
+
+        conn = await asyncpg.connect(dsn.replace(_ASYNCPG_DSN_SUFFIX, ""))
+        try:
+            row = await conn.fetchrow(
+                "SELECT COALESCE(SUM(cost_usd), 0)::float8 AS s "
+                "FROM public.keiracom_spawn_attribution "
+                "WHERE source_id = ANY($1::text[])",
+                [chain_id, task_id],
+            )
+        finally:
+            await conn.close()
+        return float(row["s"]) * _USD_TO_AUD_RATE if row else 0.0
+    except Exception as exc:  # noqa: BLE001 — fail-open: never 500 the status endpoint
+        logger.warning("chain_status: cost sum failed for chain=%s: %s", chain_id, exc)
+        return 0.0
+
+
+@app.get("/dispatcher/chain_status")
+async def dispatcher_chain_status() -> dict[str, Any]:
+    """Live V1 chain run status: per-chain state + per-hop cost accumulation.
+
+    Returns ``{"chains": [...]}`` — one row per active chain in STATE_FILE,
+    each carrying chain_id, current_step, steps_done, started_ts,
+    cost_aud_so_far, latency_ms_so_far. Empty list when no chains active.
+    Fail-open at every leg: state-file missing → []; DB unreachable → cost 0.0.
+    """
+    state = _load_chain_state()
+    chains: list[dict[str, Any]] = []
+    for chain_id, chain in state.items():
+        if not isinstance(chain, dict):
+            continue
+        task_id = str(chain.get("task_id") or chain_id)
+        cost_aud = await _chain_cost_aud(chain_id, task_id)
+        chains.append(
+            {
+                "chain_id": chain_id,
+                "current_step": chain.get("current_step", ""),
+                "steps_done": chain.get("steps_done", []),
+                "started_ts": float(chain.get("started_ts") or 0.0),
+                "cost_aud_so_far": cost_aud,
+                # TODO: keiracom_spawn_attribution has no latency_ms column yet.
+                "latency_ms_so_far": 0.0,
+            }
+        )
+    return {"chains": chains}

--- a/tests/dispatcher/test_chain_status.py
+++ b/tests/dispatcher/test_chain_status.py
@@ -1,0 +1,207 @@
+"""Tests for GET /dispatcher/chain_status (V1 chain live status + cost view).
+
+State source = v1_chain_orchestrator's STATE_FILE (path is monkeypatched per
+test via the V1_CHAIN_STATE_FILE env var); cost-sum DB layer is monkeypatched
+to avoid touching live Supabase. Fail-open behaviour is the key contract —
+no leg can 500 the endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from fastapi import HTTPException  # noqa: F401 — kept for parity with other dispatcher tests
+
+from src.dispatcher import main
+
+# ---------------------------------------------------------------------------
+# _load_chain_state — state-file loader (fail-open by design)
+# ---------------------------------------------------------------------------
+
+
+def test_load_chain_state_returns_empty_when_file_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("V1_CHAIN_STATE_FILE", str(tmp_path / "nope.json"))
+    assert main._load_chain_state() == {}
+
+
+def test_load_chain_state_returns_dict_when_valid(tmp_path, monkeypatch):
+    state = {
+        "c1": {"chain_id": "c1", "task_id": "t1", "current_step": "aiden_plan", "started_ts": 1.0}
+    }
+    p = tmp_path / "state.json"
+    p.write_text(json.dumps(state))
+    monkeypatch.setenv("V1_CHAIN_STATE_FILE", str(p))
+    assert main._load_chain_state() == state
+
+
+def test_load_chain_state_returns_empty_on_malformed_json(tmp_path, monkeypatch):
+    p = tmp_path / "bad.json"
+    p.write_text("{not-json")
+    monkeypatch.setenv("V1_CHAIN_STATE_FILE", str(p))
+    assert main._load_chain_state() == {}
+
+
+def test_load_chain_state_returns_empty_on_non_dict_json(tmp_path, monkeypatch):
+    """A list/string at the top level → fail-open to {} (defensive)."""
+    p = tmp_path / "list.json"
+    p.write_text("[]")
+    monkeypatch.setenv("V1_CHAIN_STATE_FILE", str(p))
+    assert main._load_chain_state() == {}
+
+
+# ---------------------------------------------------------------------------
+# _chain_cost_aud — DSN guard + USD→AUD conversion + fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_chain_cost_aud_zero_when_dsn_unset(monkeypatch):
+    monkeypatch.delenv("SUPABASE_DB_DSN", raising=False)
+    assert asyncio.run(main._chain_cost_aud("c1", "t1")) == 0.0
+
+
+def _patch_asyncpg(monkeypatch, *, fetchrow_return=None, connect_raises=None):
+    class _FakeConn:
+        async def fetchrow(self, query, *args):
+            return fetchrow_return
+
+        async def close(self):
+            pass
+
+    async def fake_connect(dsn):
+        if connect_raises is not None:
+            raise connect_raises
+        return _FakeConn()
+
+    monkeypatch.setattr("asyncpg.connect", fake_connect)
+
+
+def test_chain_cost_aud_converts_usd_sum_to_aud(monkeypatch):
+    """SUM(cost_usd) = 2.0 → 2.0 × 1.55 = 3.10 AUD (LAW II)."""
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://u:p@h/db")
+    _patch_asyncpg(monkeypatch, fetchrow_return={"s": 2.0})
+    out = asyncio.run(main._chain_cost_aud("c1", "t1"))
+    assert out == pytest.approx(3.10)
+
+
+def test_chain_cost_aud_handles_zero_sum(monkeypatch):
+    """SUM returns 0.0 (no matching rows) → 0.0 AUD."""
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://u:p@h/db")
+    _patch_asyncpg(monkeypatch, fetchrow_return={"s": 0.0})
+    assert asyncio.run(main._chain_cost_aud("c1", "t1")) == 0.0
+
+
+def test_chain_cost_aud_fail_open_on_db_error(monkeypatch):
+    """asyncpg.connect raises → 0.0, no exception escapes."""
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://u:p@h/db")
+    _patch_asyncpg(monkeypatch, connect_raises=OSError("db unreachable"))
+    assert asyncio.run(main._chain_cost_aud("c1", "t1")) == 0.0
+
+
+def test_chain_cost_aud_strips_asyncpg_suffix(monkeypatch):
+    """DSN with +asyncpg suffix is stripped before connect."""
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql+asyncpg://u:p@h/db")
+    captured: dict = {}
+
+    class _FakeConn:
+        async def fetchrow(self, query, *args):
+            captured["query"] = query
+            captured["args"] = args
+            return {"s": 1.0}
+
+        async def close(self):
+            pass
+
+    async def fake_connect(dsn):
+        captured["dsn"] = dsn
+        return _FakeConn()
+
+    monkeypatch.setattr("asyncpg.connect", fake_connect)
+
+    asyncio.run(main._chain_cost_aud("c1", "t1"))
+    assert "+asyncpg" not in captured["dsn"]
+    # source_id heuristic — query filters via ANY($1::text[]) with [chain_id, task_id].
+    assert captured["args"][0] == ["c1", "t1"]
+
+
+# ---------------------------------------------------------------------------
+# /dispatcher/chain_status route — response shape + fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_chain_status_empty_when_no_state(monkeypatch):
+    monkeypatch.setattr(main, "_load_chain_state", lambda: {})
+    resp = asyncio.run(main.dispatcher_chain_status())
+    assert resp == {"chains": []}
+
+
+def test_dispatcher_chain_status_returns_chain_row(monkeypatch):
+    """Single active chain → response carries state fields + per-hop cost."""
+    monkeypatch.setattr(
+        main,
+        "_load_chain_state",
+        lambda: {
+            "c-abc": {
+                "chain_id": "c-abc",
+                "task_id": "t-abc",
+                "current_step": "max_challenge",
+                "steps_done": ["aiden_plan"],
+                "started_ts": 1780000000.5,
+            }
+        },
+    )
+
+    async def fake_cost(chain_id, task_id):
+        return 5.50
+
+    monkeypatch.setattr(main, "_chain_cost_aud", fake_cost)
+
+    resp = asyncio.run(main.dispatcher_chain_status())
+    assert resp["chains"] == [
+        {
+            "chain_id": "c-abc",
+            "current_step": "max_challenge",
+            "steps_done": ["aiden_plan"],
+            "started_ts": 1780000000.5,
+            "cost_aud_so_far": 5.50,
+            "latency_ms_so_far": 0.0,
+        }
+    ]
+
+
+def test_dispatcher_chain_status_skips_non_dict_chain_values(monkeypatch):
+    """Defensive: a state with garbage values (e.g. legacy/corrupt) yields []
+    rather than 500."""
+    monkeypatch.setattr(main, "_load_chain_state", lambda: {"bad": "not-a-dict"})
+
+    async def fake_cost(chain_id, task_id):
+        return 0.0
+
+    monkeypatch.setattr(main, "_chain_cost_aud", fake_cost)
+
+    resp = asyncio.run(main.dispatcher_chain_status())
+    assert resp == {"chains": []}
+
+
+def test_dispatcher_chain_status_multiple_chains(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "_load_chain_state",
+        lambda: {
+            "c1": {"chain_id": "c1", "current_step": "aiden_plan", "started_ts": 1.0},
+            "c2": {"chain_id": "c2", "current_step": "atlas_safety", "started_ts": 2.0},
+        },
+    )
+
+    async def fake_cost(chain_id, task_id):
+        return {"c1": 1.0, "c2": 2.5}[chain_id]
+
+    monkeypatch.setattr(main, "_chain_cost_aud", fake_cost)
+
+    resp = asyncio.run(main.dispatcher_chain_status())
+    by_id = {c["chain_id"]: c for c in resp["chains"]}
+    assert by_id["c1"]["cost_aud_so_far"] == 1.0
+    assert by_id["c2"]["cost_aud_so_far"] == 2.5
+    assert by_id["c1"]["current_step"] == "aiden_plan"
+    assert by_id["c2"]["current_step"] == "atlas_safety"


### PR DESCRIPTION
## Summary
Per Elliot P0 dispatch. Lets Dave see active chains in progress: which steps are done, what step is current, started timestamp, **$AUD spent so far per chain**.

- **`_load_chain_state()`** — reads `v1_chain_orchestrator`'s `STATE_FILE` (`V1_CHAIN_STATE_FILE` env override; default `/tmp/v1_chain_state.json` — the *same* path the orchestrator writes to). Fail-open at every leg: missing file → `{}`; malformed JSON → `{}`; non-dict root → `{}`.
- **`_chain_cost_aud(chain_id, task_id)`** — `SUM(cost_usd) × 1.55` (LAW II USD→AUD) from `keiracom_spawn_attribution`. Reuses `_PERSONA_DSN_ENV` + `_ASYNCPG_DSN_SUFFIX` constants. Fail-open: DSN unset / `asyncpg.connect` fail / `fetchrow` error → `0.0`.
- **`GET /dispatcher/chain_status`** → `{"chains": [{chain_id, current_step, steps_done, started_ts, cost_aud_so_far, latency_ms_so_far}]}`. Empty list when no active chains.

## Pre-flight ✅
- `git log --all --oneline | grep -iE 'chain_status|chain.*status'` → empty (not shipped).
- `/tmp/v1_chain_state.json` exists, currently `{}` (no active chains right now — endpoint returns `{"chains": []}` cleanly).

## SCHEMA GAPS (documented inline + recommend follow-up KEI)
Important honest framing: the dispatch's premise that I can sum cost where `chain_id` matches doesn't hold against the current schema.
- **`keiracom_spawn_attribution` has no `chain_id` column.** Cost is matched via a `source_id ∈ {chain_id, task_id}` heuristic. This returns `0.0` today because the attribution writer doesn't log `chain_id`/`task_id` as `source_id` for chain spawns (source_id examples are slack-ts / PR-1202 / inbox-file-path). Will populate when either (a) a `chain_id` column is added to the table, or (b) the attribution writer starts logging chain context as source_id.
- **No `latency_ms` column on attribution** → `latency_ms_so_far` is hard-coded `0.0` for V1 with a TODO comment.

The endpoint's **response shape matches the dispatch verbatim** — so the contract is stable; once the schema catches up, the values populate without any shape change.

## Acceptance
- `curl http://127.0.0.1:4001/dispatcher/chain_status` returns JSON with chain state + per-hop cost accumulation ✅ (cost will be `0.0` until schema gap closes; state fields are live from STATE_FILE).

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/dispatcher/test_chain_status.py` → **13/13 passed**
- [x] Fail-open paths verified at every leg: missing state file; malformed JSON; non-dict root; non-dict per-chain values; DSN unset; DB connect error; zero-sum cost; `+asyncpg` suffix stripping
- [x] LAW II conversion verified: SUM=2.0 USD → 3.10 AUD (× 1.55)
- [x] Multi-chain response shape verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)