### PR TITLE
[ATLAS] feat(concur-gate): advertise eligible reviewers in CONCUR-REQUEST stub (Agency_OS-yvlr51)

### DIFF
--- a/src/bot_common/concur_gate.py
+++ b/src/bot_common/concur_gate.py
@@ -46,6 +46,12 @@ EXECUTION_CHANNEL = "C0B3QB0K1GQ"
 # not `:` after CONCUR), and prose containing the word "concur".
 _GATE_TRIGGER = re.compile(r"\[(?:CONCUR|BLOCK):[a-z][a-z0-9_-]*\]", re.IGNORECASE)
 
+# Canonical 7-callsign roster (mirrors scripts/cache_hit_rate_ingest.py:44).
+# Used by _eligible_reviewers() when ceo:agent_health is absent (Agency_OS-yvlr51).
+_KNOWN_CALLSIGNS: frozenset[str] = frozenset(
+    {"elliot", "aiden", "max", "atlas", "orion", "scout", "nova"}
+)
+
 
 def _pending_dir(callsign: str) -> Path:
     return Path(f"/tmp/{callsign}-pending-concur")
@@ -61,6 +67,23 @@ def _topic_sha(text: str) -> str:
 _ESCALATION_SENTINEL = re.compile(
     r"\[ESCALATION-INITIATED:[a-z][a-z0-9_-]*:[A-Z]+-\d+\]", re.IGNORECASE
 )
+
+
+def _eligible_reviewers(my_callsign: str) -> list[str]:
+    """Return sorted list of peers eligible to release a CONCUR-REQUEST.
+
+    Agency_OS-yvlr51 — when ceo:agent_health is populated by the polling loop
+    (KEI-63 follow-up, not yet shipped), this filters peers by API-cap (<70%
+    weekly), idle window (<30 min), and recent HOLD/BLOCK absence. Until that
+    infrastructure exists, fallback returns ALL non-author callsigns — the
+    release lookup already accepts [CONCUR:<requester>] from any sender, so
+    advertising the full roster keeps routing unblocked when a specific peer
+    is at context cap (the V1-chain freeze scenario Dave diagnosed).
+    """
+    # TODO(yvlr51 follow-up): query ceo:agent_health via mcp-bridge supabase
+    # and filter by (weekly_cap < 70%) AND (idle_minutes < 30) AND
+    # (no_recent_hold_or_block). Fail-open to the fallback on any read error.
+    return sorted(cs for cs in _KNOWN_CALLSIGNS if cs != my_callsign.lower())
 
 
 def should_gate(text: str) -> bool:
@@ -109,8 +132,10 @@ def gate_check(
     pdir.mkdir(parents=True, exist_ok=True)
     (pdir / f"{sha}.txt").write_text(text)
     topic = text.splitlines()[0][:120]
+    eligible = ", ".join(_eligible_reviewers(my_callsign))
     replacement = (
         f"[CONCUR-REQUEST:{my_callsign.upper()}] requesting concurrence from {peer_label} on: {topic}\n"
+        f"Eligible reviewers: {eligible}\n"
         f"(held under /tmp/{my_callsign}-pending-concur/{sha}.txt; release on [CONCUR:{my_callsign}] in #execution)"
     )
     return False, replacement

--- a/tests/bot_common/test_concur_gate.py
+++ b/tests/bot_common/test_concur_gate.py
@@ -318,3 +318,41 @@ def test_topic_sha_different_inputs_different_outputs() -> None:
 def test_topic_sha_length() -> None:
     """12-char prefix of sha1."""
     assert len(concur_gate._topic_sha("anything")) == 12
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _eligible_reviewers — Agency_OS-yvlr51 routing-fix (CONCUR-REQUEST signaling)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_eligible_reviewers_fallback_when_no_agent_health() -> None:
+    """Agency_OS-yvlr51 negative path — ceo:agent_health absent → all non-author callsigns.
+
+    The polling-loop infra that populates ceo:agent_health (KEI-63 follow-up)
+    does not exist yet. The fallback MUST return the full 7-callsign roster
+    minus the author, so the CONCUR-REQUEST stub advertises every peer that
+    can validly release the gate. This is what unblocks the V1-chain
+    specific-callsign-stuck failure mode Dave diagnosed 2026-05-14.
+    """
+    result = concur_gate._eligible_reviewers("aiden")
+    expected = sorted({"elliot", "max", "atlas", "orion", "scout", "nova"})
+    assert result == expected
+    # Author always excluded, case-insensitive.
+    assert "aiden" not in concur_gate._eligible_reviewers("AIDEN")
+
+
+def test_gate_check_replacement_advertises_eligible_reviewers(tmp_path, monkeypatch) -> None:
+    """CONCUR-REQUEST stub must list eligible non-author peers in its body."""
+    monkeypatch.setattr(concur_gate, "_pending_dir", lambda cs: tmp_path / cs)
+    with patch.object(concur_gate, "has_peer_concur", return_value=False):
+        _, replacement = concur_gate.gate_check(
+            "[CONCUR:max] verified the diff", "aiden", "fake-token"
+        )
+    assert "Eligible reviewers:" in replacement
+    eligible_line = next(
+        ln for ln in replacement.splitlines() if ln.startswith("Eligible reviewers:")
+    )
+    for peer in ("elliot", "max", "atlas", "orion", "scout", "nova"):
+        assert peer in eligible_line
+    # Author not in the eligible-reviewers line itself.
+    assert "aiden" not in eligible_line


### PR DESCRIPTION
## Summary
- Agency_OS-yvlr51 Option A — pre-battery signaling fix for the V1-chain CONCUR routing-stuck failure mode Dave diagnosed 2026-05-14.
- Adds `_eligible_reviewers()` to `src/bot_common/concur_gate.py` with the `ceo:agent_health`-absent fallback: returns ALL non-author callsigns from the canonical 7-roster (elliot/aiden/max/atlas/orion/scout/nova).
- Wires the eligible list into `gate_check()`'s replacement message under a new `Eligible reviewers: ...` line so the held author + downstream readers see who can release.

## Why Option A (and not Option B)
Elliot dispatch 2026-05-30 — battery imminent, Option B (V1-chain `ROLE_FOR_STEP` ordered-fallback) is the correct long-term fix for the actual chain-freeze mechanism but invasive pre-battery; filed as a follow-up KEI.

Release semantics were already any-peer (`has_peer_concur` greps `#execution` for `[CONCUR:<requester>]` from any sender, see `concur_gate.py:77-89`). The gap was signaling: the `CONCUR-REQUEST` stub did not advertise that any non-author peer could release, so when convention routed at a specific deliberator and that deliberator hit a context cap, downstream callers had no signal that substitute peers were valid.

## Why fallback returns full roster
bd yvlr51 acceptance criteria reference a `ceo:agent_health` jsonb key populated by a 5-minute polling loop. That infrastructure does not yet exist (`grep ceo:agent_health` → 0 hits in `src/`; KEI-63 in current code scopes discovery_log deprecation, not agent health). Elliot confirmed: when the key is absent, assume all non-author callsigns eligible — don't block on infra that doesn't exist. Future weekly-cap / idle / recent-HOLD filter staged behind a TODO in `_eligible_reviewers()`.

## Out of scope (filed separately)
- V1-chain `ROLE_FOR_STEP` ordered-fallback (Option B) — actual chain-freeze fix, post-battery.
- `ceo:agent_health` polling-loop build-out — its own KEI.

## Test plan
- [x] `ruff format --check` + `ruff check` clean on both files
- [x] `pytest tests/bot_common/test_concur_gate.py` — 30 passed (28 existing + 2 new)
- [x] Negative-path test: `_eligible_reviewers("aiden")` with no `ceo:agent_health` returns the sorted 6-peer fallback
- [x] Integration test: `gate_check()` replacement contains an `Eligible reviewers: ...` line listing all non-author callsigns
- [ ] 2-of-3 deliberator NATS concur (Elliot/Aiden/Max — author-exclusion: 2-of-2 from the two non-authors)

## Files
- `src/bot_common/concur_gate.py` (+19 lines: roster, helper, replacement wiring)
- `tests/bot_common/test_concur_gate.py` (+44 lines: 2 new tests + section header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)