### PR TITLE
[ATLAS] feat(v1-battery): per-task A$10 ceiling + 429/529 retry + harness columns (P0 V1-gate)

### DIFF
--- a/scripts/v1_battery_harness.py
+++ b/scripts/v1_battery_harness.py
@@ -362,7 +362,8 @@ def fetch_attribution_rows(chain_id: str, task_id: str | None) -> list[dict]:
         ):
             cur.execute(
                 "SELECT ts, source_id, callsign, model, input_tokens, output_tokens, "
-                "cache_read_tokens, cache_write_tokens, cost_usd, completion_status "
+                "cache_read_tokens, cache_write_tokens, cost_usd, completion_status, "
+                "COALESCE(rate_limit_retries, 0) "
                 "FROM public.keiracom_spawn_attribution "
                 "WHERE source_id LIKE %s "
                 "ORDER BY ts ASC",
@@ -382,6 +383,7 @@ def fetch_attribution_rows(chain_id: str, task_id: str | None) -> list[dict]:
         "cache_write_tokens",
         "cost_usd",
         "completion_status",
+        "rate_limit_retries",
     ]
     return [dict(zip(cols, r, strict=False)) for r in rows]
 
@@ -437,6 +439,21 @@ def derive_metrics(
         int((_first_mutation_ts(chain_id) or ended_ts) * 1000 - started_ts * 1000)
         if chain_id
         else None
+    )
+    # V1-battery hard-gate columns (Elliot dispatch 2026-05-30):
+    # - ceiling_tripped: per-task A$10 ceiling status from chain state.
+    # - rate_limit_429s: sum of rate_limit_retries across attribution rows.
+    out["ceiling_tripped"] = bool(entry.get("ceiling_tripped", False))
+    if out["ceiling_tripped"]:
+        breakdown = entry.get("ceiling_per_hop") or []
+        out["ceiling_breakdown"] = (
+            "; ".join(f"{h.get('chain_step', '?')}={h.get('cost_aud', 0):.4f}" for h in breakdown)
+            or "—"
+        )
+    else:
+        out["ceiling_breakdown"] = "—"
+    out["rate_limit_429s"] = (
+        sum(int(r.get("rate_limit_retries", 0) or 0) for r in attribution) if attribution else 0
     )
     return out
 
@@ -611,9 +628,9 @@ def render_markdown(results: list[RunResult], thresholds: dict) -> str:
     lines.append("")
     header = (
         "| Run | Status | chain_id | cost A$ | latency ms | in tok | out tok | "
-        "cache hit % | spawn ms | ttf ms | hops | Notes |"
+        "cache hit % | spawn ms | ttf ms | hops | ceiling_tripped | rate_limit_429s | Notes |"
     )
-    sep = "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|"
+    sep = "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---|"
     lines.append(header)
     lines.append(sep)
     for r in results:
@@ -628,12 +645,16 @@ def render_markdown(results: list[RunResult], thresholds: dict) -> str:
         }.get(verdict, verdict)
         m = r.metrics
         notes = "; ".join(reasons + r.notes) or "—"
+        ceiling_cell = (
+            f"YES ({m.get('ceiling_breakdown', '—')})" if m.get("ceiling_tripped") else "NO"
+        )
         lines.append(
             f"| {r.label} ({r.kind}) | {glyph} | `{m.get('chain_id', '—')}` | "
             f"{_fmt(m.get('cost_aud'))} | {_fmt(m.get('latency_ms'))} | "
             f"{_fmt(m.get('input_tokens'))} | {_fmt(m.get('output_tokens'))} | "
             f"{_fmt(m.get('cache_hit_pct'))} | {_fmt(m.get('spawn_overhead_ms'))} | "
-            f"{_fmt(m.get('ttf_signal_ms'))} | {_fmt(m.get('hops_attributed'))} | {notes} |"
+            f"{_fmt(m.get('ttf_signal_ms'))} | {_fmt(m.get('hops_attributed'))} | "
+            f"{ceiling_cell} | {_fmt(m.get('rate_limit_429s'))} | {notes} |"
         )
     # Aggregate verdict
     overall = (

--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -89,9 +89,114 @@ log = logging.getLogger(__name__)
 # notify_complete → /task_complete urllib pattern in vault/agent_cold_start.py.
 _DISPATCHER_URL = os.environ.get("DISPATCHER_URL", "http://127.0.0.1:4001")
 
+# V1-battery Gate 1 — per-task A$10 spend ceiling (Elliot dispatch 2026-05-30
+# ~11:35 AEST). Reads cumulative cost_aud per task_id from
+# keiracom_spawn_attribution after each hop. Complements Orion's fleet-level
+# cost_breaker (#1297 Agency_OS-wdws) — that's fleet daily/monthly aggregate at
+# /spawn time; this is per-task SUM after each hop. Both must trip to be
+# load-bearing for the V1 battery.
+_TASK_COST_CEILING_AUD = float(os.environ.get("V1_TASK_COST_CEILING_AUD", "10.00"))
+
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _query_task_cost_aud(task_id: str) -> tuple[float, list[dict]] | None:
+    """Return (sum_aud, per_hop_rows) for a task_id, or None on read failure.
+
+    V1-battery Gate 1 helper — runs the dispatch's specified SUM(cost_aud) +
+    per-hop breakdown query against public.keiracom_spawn_attribution. Per-hop
+    breakdown shape: [{callsign, chain_step, cost_aud}, ...] ordered by ts.
+
+    Returns None (not (0.0, [])) on read failure so callers can distinguish
+    "checked, no spend yet" from "couldn't check". A read failure is fail-OPEN:
+    the chain proceeds — Orion's fleet-level breaker (#1297) is the fail-SAFE
+    backstop and this gate is the per-task complement.
+    """
+    if not task_id:
+        return None
+    # Fast-fail when no DSN — keeps unit tests + CI hosts off a 10s
+    # psycopg.connect timeout. fail-OPEN per the docstring contract.
+    if not os.environ.get("DATABASE_URL"):
+        return None
+    try:
+        from src.keiracom_system.vault.agent_cold_start import _connect  # noqa: PLC0415
+    except ImportError:
+        return None
+    conn = None
+    try:
+        conn = _connect()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT callsign, task_type, cost_aud "
+                "FROM public.keiracom_spawn_attribution "
+                "WHERE task_id = %s "
+                "ORDER BY ts ASC",
+                (task_id,),
+            )
+            rows = cur.fetchall() or []
+    except Exception:  # noqa: BLE001 — fail-OPEN; fleet breaker is the fail-safe
+        log.warning(
+            "v1_chain Gate 1: cost-ceiling query failed for task=%s", task_id, exc_info=True
+        )
+        return None
+    finally:
+        if conn is not None:
+            with contextlib.suppress(Exception):
+                conn.close()
+    per_hop = [
+        {"callsign": r[0] or "?", "chain_step": r[1] or "?", "cost_aud": float(r[2] or 0)}
+        for r in rows
+    ]
+    total = sum(h["cost_aud"] for h in per_hop)
+    return total, per_hop
+
+
+def _post_ceiling_breach(
+    entry: dict,
+    chain_id: str,
+    total_aud: float,
+    per_hop: list[dict],
+    *,
+    dispatcher_url: str = _DISPATCHER_URL,
+) -> None:
+    """V1-battery Gate 1 — POST to /dispatcher/ceiling_breach when a task
+    exceeds the per-task A$10 ceiling. Fail-open identical to
+    _post_chain_complete: a notify failure must NEVER block the halt state save.
+    """
+    import urllib.error  # noqa: PLC0415 — lazy; only the breach-transition path needs it
+    import urllib.request  # noqa: PLC0415
+
+    payload = json.dumps(
+        {
+            "task_id": entry.get("task_id") or "?",
+            "chain_id": chain_id,
+            "brief": entry.get("brief") or "(no brief)",
+            "ceiling_aud": _TASK_COST_CEILING_AUD,
+            "total_aud": round(total_aud, 4),
+            "per_hop": per_hop,
+            "steps_done": list(entry.get("steps_done") or []),
+        }
+    ).encode()
+    url = f"{dispatcher_url.rstrip('/')}/dispatcher/ceiling_breach"
+    try:
+        req = urllib.request.Request(
+            url, data=payload, headers={"Content-Type": "application/json"}, method="POST"
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 — fixed loopback host
+            log.info(
+                "ceiling_breach notify: dispatcher status=%d for chain=%s total=A$%.4f",
+                resp.status,
+                chain_id,
+                total_aud,
+            )
+    except (urllib.error.URLError, OSError):
+        log.warning(
+            "ceiling_breach notify: dispatcher unreachable for chain=%s", chain_id, exc_info=True
+        )
+    except Exception:  # noqa: BLE001 — must not break halt-state save
+        log.warning("ceiling_breach notify: unexpected error for chain=%s", chain_id, exc_info=True)
 
 
 def _post_chain_complete(
@@ -360,6 +465,40 @@ def advance_step(
         entry["pending"].remove(completed_step)
 
     dispatched: list[dict] = []
+
+    # V1-battery Gate 1 — per-task A$10 ceiling. Query SUM(cost_aud) for
+    # this task_id; halt + post #ceo if exceeded. Runs BEFORE the dispatch
+    # branch so an over-ceiling task cannot fan out a new hop. fail-OPEN on
+    # read error (None) — the chain proceeds and the fleet-level breaker
+    # (#1297) remains the fail-SAFE backstop. GOV-12: this is the runtime
+    # conditional, not a comment.
+    task_id_for_query = entry.get("task_id") or chain_id
+    ceiling_result = _query_task_cost_aud(task_id_for_query)
+    if ceiling_result is not None:
+        total_aud, per_hop = ceiling_result
+        if total_aud > _TASK_COST_CEILING_AUD:
+            log.error(
+                "v1_chain Gate 1: ceiling breached chain=%s task=%s total=A$%.4f > A$%.2f — HALTING",
+                chain_id,
+                task_id_for_query,
+                total_aud,
+                _TASK_COST_CEILING_AUD,
+            )
+            entry["current_step"] = "halted_ceiling_exceeded"
+            entry["ceiling_tripped"] = True
+            entry["ceiling_total_aud"] = round(total_aud, 4)
+            entry["ceiling_per_hop"] = per_hop
+            entry["pending"] = []
+            try:
+                _post_ceiling_breach(entry, chain_id, total_aud, per_hop)
+            except Exception:  # noqa: BLE001 — must not break halt-state save
+                log.warning(
+                    "v1_chain Gate 1: ceiling_breach raised at call site for chain=%s",
+                    chain_id,
+                    exc_info=True,
+                )
+            _save_state(state)
+            return []
 
     if completed_step in PARALLEL_AFTER_STEP:
         # Fan-out: dispatch all parallel next steps simultaneously.

--- a/src/keiracom_system/vault/api_agent_cold_start.py
+++ b/src/keiracom_system/vault/api_agent_cold_start.py
@@ -78,6 +78,17 @@ CALLSIGN_TO_PERSONA: dict[str, tuple[str, str]] = {
 _PERSONA_RETRY_MAX_SECONDS = 60
 _PERSONA_RETRY_INTERVAL = 1.0
 
+# V1-battery Gate 2 — 429/529 retry (Elliot dispatch 2026-05-30 ~11:35 AEST).
+# Exponential backoff: 1s, 2s, 4s, 8s ... capped at 60s. max 4 attempts means
+# the call_anthropic_with_retry helper attempts once + 3 retries. Retry-After
+# header (when present, integer seconds) overrides backoff for that attempt.
+_RATE_LIMIT_MAX_ATTEMPTS = 4
+_RATE_LIMIT_BASE_BACKOFF_S = 1.0
+_RATE_LIMIT_MAX_BACKOFF_S = 60.0
+_OVERLOADED_STATUS_CODES: frozenset[int] = frozenset({429, 503, 529})
+_OPS_FAILURE_SUBJECT = os.environ.get("OPS_FAILURE_SUBJECT", "keiracom.ops.failure")
+_NATS_URL = os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
+
 # Exit codes
 RC_NO_AGENT_ENV = 2
 RC_PERSONA_FAILED = 3
@@ -149,6 +160,7 @@ def insert_attribution(
     cost_usd: float,
     cost_aud: float,
     latency_ms: float,
+    rate_limit_retries: int = 0,
     completion_status: str = "done",
     conn: Any = None,
 ) -> None:
@@ -167,8 +179,9 @@ def insert_attribution(
                 "INSERT INTO public.keiracom_spawn_attribution "
                 "(spawn_id, source_type, source_id, task_type, callsign, model, "
                 "input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, "
-                "cost_usd, cost_aud, latency_ms, chain_id, task_id, completion_status) "
-                "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+                "cost_usd, cost_aud, latency_ms, chain_id, task_id, "
+                "rate_limit_retries, completion_status) "
+                "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
                 (
                     str(uuid.uuid4()),
                     "v1_chain",
@@ -185,6 +198,7 @@ def insert_attribution(
                     latency_ms,
                     chain_id,
                     task_id,
+                    int(rate_limit_retries),
                     completion_status,
                 ),
             )
@@ -196,21 +210,158 @@ def insert_attribution(
                 conn.close()
 
 
-def call_anthropic(api_key: str, system: str, brief: str) -> tuple[str, int, int]:
-    """Single Anthropic messages.create call. Returns (text, input_tokens, output_tokens).
-    Raises on SDK import error or API failure (caller maps to exit code).
+def _parse_retry_after(exc: Any) -> float | None:
+    """Pull Retry-After (integer seconds) from an anthropic APIStatusError-shaped
+    exception. Returns None if absent or unparseable. Vendored here so the retry
+    loop doesn't depend on internal SDK shape changes — best-effort header read.
+    """
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None) if response is not None else None
+    if headers is None:
+        return None
+    try:
+        val = headers.get("retry-after")
+    except (AttributeError, TypeError):
+        return None
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _publish_rate_limit_exhaust(task_id: str, callsign: str, retries: int) -> None:
+    """Publish keiracom.ops.failure envelope when 429/529 retry budget exhausts.
+
+    peer_event_ceo_relay subscribes to this subject and fans rate-limit-exhaust
+    events to #ceo as visible incidents — closes the 'silent hang on rate
+    limit' failure mode the V1-battery gate dispatch called out. Fail-open: any
+    NATS error logged + swallowed; the calling chain hop has already returned
+    RC_API_FAILED so the orchestrator-side bookkeeping handles the rest.
+    """
+    import asyncio  # noqa: PLC0415 — lazy
+    import json as _json  # noqa: PLC0415
+
+    envelope = {
+        "from": "api_agent_cold_start",
+        "kind": "ops_failure",
+        "unit": f"api_agent_cold_start/{callsign or '?'}",
+        "task_id": task_id or "?",
+        "callsign": callsign or "?",
+        "retries": retries,
+        "summary": (
+            f"api_agent_cold_start: rate-limit retry budget exhausted "
+            f"(callsign={callsign or '?'}, task_id={task_id or '?'}, "
+            f"attempts={retries + 1})."
+        ),
+        "ts": time.time(),
+    }
+
+    async def _publish() -> None:
+        try:
+            import nats  # noqa: PLC0415 — lazy, optional dep
+        except ImportError as exc:
+            logger.warning(
+                "api_agent_cold_start: nats-py not installed; ops.failure skipped (%s)", exc
+            )
+            return
+        try:
+            nc = await nats.connect(_NATS_URL, connect_timeout=5)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("api_agent_cold_start: NATS connect failed: %s", exc)
+            return
+        try:
+            await nc.publish(_OPS_FAILURE_SUBJECT, _json.dumps(envelope).encode("utf-8"))
+            await nc.flush(timeout=5)
+            logger.info("api_agent_cold_start: published ops.failure for task_id=%s", task_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("api_agent_cold_start: ops.failure publish failed: %s", exc)
+        finally:
+            with contextlib.suppress(Exception):
+                await nc.close()
+
+    try:
+        asyncio.run(_publish())
+    except Exception:  # noqa: BLE001 — must never block the RC_API_FAILED exit
+        logger.exception("api_agent_cold_start: _publish_rate_limit_exhaust raised")
+
+
+def call_anthropic(
+    api_key: str,
+    system: str,
+    brief: str,
+    *,
+    task_id: str = "",
+    callsign: str = "",
+) -> tuple[str, int, int, int]:
+    """Anthropic messages.create with 429/529 retry. Returns (text, in_tok, out_tok, retries).
+
+    V1-battery Gate 2 (Elliot dispatch 2026-05-30 ~11:35 AEST): retry on
+    HTTP 429 (RateLimitError) and 529/503 (APIStatusError — overloaded /
+    unavailable). Exponential backoff: 1s base, doubled per attempt, capped at
+    60s. Max 4 attempts (1 initial + 3 retries). Retry-After header (when
+    present and parseable) overrides the computed backoff for that attempt.
+
+    On exhaust: publish a keiracom.ops.failure NATS envelope so the rate-limit
+    incident surfaces to #ceo (not a silent hang), then re-raise the last
+    APIStatusError. The run() caller maps to RC_API_FAILED.
+
+    Non-retriable APIStatusError (400 / 401 / 403 etc) re-raises immediately —
+    backoff helps overloaded servers, not bad requests.
     """
     import anthropic  # noqa: PLC0415 — optional dep
 
     client = anthropic.Anthropic(api_key=api_key)
-    response = client.messages.create(
-        model=_MODEL,
-        max_tokens=_MAX_TOKENS,
-        system=system,
-        messages=[{"role": "user", "content": brief}],
-    )
-    text = response.content[0].text if response.content else ""
-    return text, int(response.usage.input_tokens), int(response.usage.output_tokens)
+    retries = 0
+    last_exc: Exception | None = None
+    for attempt in range(_RATE_LIMIT_MAX_ATTEMPTS):
+        try:
+            response = client.messages.create(
+                model=_MODEL,
+                max_tokens=_MAX_TOKENS,
+                system=system,
+                messages=[{"role": "user", "content": brief}],
+            )
+            text = response.content[0].text if response.content else ""
+            return (
+                text,
+                int(response.usage.input_tokens),
+                int(response.usage.output_tokens),
+                retries,
+            )
+        except anthropic.APIStatusError as exc:
+            status = getattr(exc, "status_code", None)
+            if status not in _OVERLOADED_STATUS_CODES:
+                raise
+            last_exc = exc
+            if attempt == _RATE_LIMIT_MAX_ATTEMPTS - 1:
+                break  # no sleep after last attempt — fall through to exhaust
+            retry_after = _parse_retry_after(exc)
+            backoff = (
+                retry_after
+                if retry_after is not None and retry_after > 0
+                else min(
+                    _RATE_LIMIT_BASE_BACKOFF_S * (2**attempt),
+                    _RATE_LIMIT_MAX_BACKOFF_S,
+                )
+            )
+            logger.warning(
+                "api_agent_cold_start: status=%s on attempt %d/%d (callsign=%s); "
+                "backing off %.1fs (retry_after=%s)",
+                status,
+                attempt + 1,
+                _RATE_LIMIT_MAX_ATTEMPTS,
+                callsign or "?",
+                backoff,
+                retry_after,
+            )
+            time.sleep(backoff)
+            retries += 1
+    # Exhausted — surface as ops.failure and re-raise
+    _publish_rate_limit_exhaust(task_id=task_id, callsign=callsign, retries=retries)
+    assert last_exc is not None  # noqa: S101 — invariant: loop only breaks here after assignment
+    raise last_exc
 
 
 def run() -> int:
@@ -247,7 +398,9 @@ def run() -> int:
 
     spawned_at = time.time()
     try:
-        text, input_tokens, output_tokens = call_anthropic(api_key, persona, brief)
+        text, input_tokens, output_tokens, rate_limit_retries = call_anthropic(
+            api_key, persona, brief, task_id=task_id, callsign=callsign
+        )
     except ImportError:
         logger.exception("api_agent_cold_start: anthropic SDK not installed")
         return RC_SDK_MISSING
@@ -268,6 +421,7 @@ def run() -> int:
         cost_usd=cost_usd,
         cost_aud=cost_aud,
         latency_ms=latency_ms,
+        rate_limit_retries=rate_limit_retries,
     )
 
     logger.info(

--- a/supabase/migrations/20260530_keiracom_spawn_attribution_rate_limit_retries.sql
+++ b/supabase/migrations/20260530_keiracom_spawn_attribution_rate_limit_retries.sql
@@ -1,0 +1,21 @@
+-- ============================================================================
+-- 20260530_keiracom_spawn_attribution_rate_limit_retries.sql
+--
+-- V1-battery hard-gate (Agency_OS-v1-battery-hard-gates — Elliot dispatch
+-- 2026-05-30 ~11:35 AEST). Adds rate_limit_retries to keiracom_spawn_attribution
+-- so v1_battery_harness can aggregate 429/529 retry counts per chain_id.
+--
+-- Source: src/keiracom_system/vault/api_agent_cold_start.py — the retry wrapper
+-- around anthropic.messages.create returns retry_count; insert_attribution
+-- threads it into this column. Default 0 covers the no-retry happy path so the
+-- existing INSERT call sites that don't pass retry_count keep working.
+--
+-- KEI-87 bypass: SET LOCAL agency_os.callsign = 'dave' required for
+-- public-schema DDL.
+-- ============================================================================
+
+ALTER TABLE public.keiracom_spawn_attribution
+  ADD COLUMN IF NOT EXISTS rate_limit_retries INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.keiracom_spawn_attribution.rate_limit_retries IS
+  '429/529 retry attempts performed by api_agent_cold_start for this hop. 0 = first call succeeded. >0 means rate-limit pressure observed.';

--- a/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
+++ b/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
@@ -773,3 +773,157 @@ def test_publish_envelope_failopen_on_http_error(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
     ok = orch._publish_envelope({"chain_id": "x", "chain_step": "y", "brief": "z"}, "max")
     assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# V1-battery Gate 1 — per-task A$10 spend ceiling
+# (Elliot dispatch 2026-05-30 ~11:35 AEST)
+# ---------------------------------------------------------------------------
+
+
+def test_query_task_cost_aud_returns_none_on_empty_task_id():
+    """Empty task_id → None (caller treats as 'couldn't check', fail-open)."""
+    assert orch._query_task_cost_aud("") is None
+
+
+def test_advance_step_halts_when_ceiling_breached(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """SUM(cost_aud) > A$10 → chain halts: state.current_step='halted_ceiling_exceeded',
+    ceiling_tripped=True, breach posted, ZERO new dispatches.
+    """
+    captured = _capture_publishes(monkeypatch)
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    chain_id = "chain-ceiling-breach"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-runaway",
+            "brief": "runaway",
+            "started_ts": 0.0,
+            "current_step": "aiden_plan",
+            "steps_done": [],
+            "atom_ids": {},
+            "pending": [],
+        },
+    )
+
+    breach_calls: list[dict] = []
+
+    def fake_post_breach(entry, cid, total, per_hop, *, dispatcher_url=None):
+        breach_calls.append(
+            {"chain_id": cid, "total": total, "per_hop": per_hop, "task_id": entry.get("task_id")}
+        )
+
+    monkeypatch.setattr(orch, "_post_ceiling_breach", fake_post_breach)
+    # Simulate a query result over the A$10 ceiling.
+    monkeypatch.setattr(
+        orch,
+        "_query_task_cost_aud",
+        lambda _task_id: (
+            12.34,
+            [
+                {"callsign": "aiden", "chain_step": "aiden_plan", "cost_aud": 12.34},
+            ],
+        ),
+    )
+
+    envelopes = orch.advance_step(chain_id, "aiden_plan", "atom-runaway", clock=lambda: 5.0)
+
+    # Halt semantics — zero new dispatches, halt state recorded.
+    assert envelopes == []
+    assert captured == []
+    state = json.loads(state_file.read_text())
+    entry = state[chain_id]
+    assert entry["current_step"] == "halted_ceiling_exceeded"
+    assert entry["ceiling_tripped"] is True
+    assert entry["ceiling_total_aud"] == 12.34
+    assert entry["ceiling_per_hop"][0]["chain_step"] == "aiden_plan"
+    # Breach #ceo post must fire.
+    assert len(breach_calls) == 1
+    assert breach_calls[0]["chain_id"] == chain_id
+    assert breach_calls[0]["task_id"] == "t-runaway"
+
+
+def test_advance_step_proceeds_when_ceiling_not_breached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """SUM(cost_aud) ≤ A$10 → chain continues normally (one envelope to max)."""
+    captured = _capture_publishes(monkeypatch)
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    chain_id = "chain-under-ceiling"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-cheap",
+            "brief": "cheap run",
+            "started_ts": 0.0,
+            "current_step": "aiden_plan",
+            "steps_done": [],
+            "atom_ids": {},
+            "pending": [],
+        },
+    )
+    monkeypatch.setattr(
+        orch,
+        "_query_task_cost_aud",
+        lambda _task_id: (
+            0.42,
+            [{"callsign": "aiden", "chain_step": "aiden_plan", "cost_aud": 0.42}],
+        ),
+    )
+    breach_fired = []
+    monkeypatch.setattr(
+        orch,
+        "_post_ceiling_breach",
+        lambda *a, **kw: breach_fired.append(True),
+    )
+
+    envelopes = orch.advance_step(chain_id, "aiden_plan", "atom-aiden", clock=lambda: 6.0)
+
+    assert len(envelopes) == 1
+    assert len(captured) == 1
+    assert captured[0][1] == "max"
+    assert not breach_fired
+    state = json.loads(state_file.read_text())
+    entry = state[chain_id]
+    assert entry["current_step"] == "max_challenge"
+    assert entry.get("ceiling_tripped") is not True
+
+
+def test_advance_step_fail_open_when_query_returns_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Query read failure (None) → chain proceeds (fleet breaker is fail-SAFE backstop)."""
+    captured = _capture_publishes(monkeypatch)
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+    chain_id = "chain-query-fail"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-unknown",
+            "brief": "x",
+            "started_ts": 0.0,
+            "current_step": "aiden_plan",
+            "steps_done": [],
+            "atom_ids": {},
+            "pending": [],
+        },
+    )
+    monkeypatch.setattr(orch, "_query_task_cost_aud", lambda _task_id: None)
+    envelopes = orch.advance_step(chain_id, "aiden_plan", "atom-x", clock=lambda: 7.0)
+    # Fail-open: normal advance, NOT halted.
+    assert len(envelopes) == 1
+    assert len(captured) == 1
+    state = json.loads(state_file.read_text())
+    assert state[chain_id]["current_step"] == "max_challenge"
+    assert state[chain_id].get("ceiling_tripped") is not True

--- a/tests/keiracom_system/vault/test_api_agent_cold_start.py
+++ b/tests/keiracom_system/vault/test_api_agent_cold_start.py
@@ -11,7 +11,6 @@ import pytest
 
 from src.keiracom_system.vault import api_agent_cold_start as aacs
 
-
 # ---------------------------------------------------------------------------
 # CALLSIGN_TO_PERSONA mapping
 # ---------------------------------------------------------------------------
@@ -216,10 +215,11 @@ def test_call_anthropic_passes_model_system_brief_and_returns_text_tokens(
     fake_anthropic.Anthropic = _FakeClient
     monkeypatch.setitem(sys.modules, "anthropic", fake_anthropic)
 
-    text, in_t, out_t = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    text, in_t, out_t, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
 
     assert text == "Atlas safety-review verdict: looks OK."
     assert in_t == 42 and out_t == 137
+    assert retries == 0  # happy path → no rate-limit retries
     assert captured["api_key"] == "KEY"
     kw = captured["create_kwargs"]
     assert kw["model"] == aacs._MODEL
@@ -276,7 +276,7 @@ def test_run_happy_path_writes_attribution_and_publishes_handoff(
     _publish_handoff all fire with the right args, and exit code is 0."""
     _seed_env(monkeypatch)
     monkeypatch.setattr(aacs, "fetch_persona", lambda _c: "ATLAS_PROMPT")
-    monkeypatch.setattr(aacs, "call_anthropic", lambda _k, _s, _b: ("REPLY", 100, 200))
+    monkeypatch.setattr(aacs, "call_anthropic", lambda *_a, **_kw: ("REPLY", 100, 200, 0))
 
     insert_calls: list[dict] = []
 
@@ -333,7 +333,7 @@ def test_run_no_atoms_still_fires_one_empty_handoff(monkeypatch: pytest.MonkeyPa
     atom_id so the chain consumer still advances (no stall)."""
     _seed_env(monkeypatch)
     monkeypatch.setattr(aacs, "fetch_persona", lambda _c: "PROMPT")
-    monkeypatch.setattr(aacs, "call_anthropic", lambda _k, _s, _b: ("REPLY", 0, 0))
+    monkeypatch.setattr(aacs, "call_anthropic", lambda *_a, **_kw: ("REPLY", 0, 0, 0))
     monkeypatch.setattr(aacs, "insert_attribution", lambda **_kw: None)
 
     async def fake_classify(*_a, **_kw):
@@ -358,3 +358,160 @@ def test_run_no_atoms_still_fires_one_empty_handoff(monkeypatch: pytest.MonkeyPa
     # Exactly one handoff with empty atom_id — chain MUST advance.
     assert len(handoff_calls) == 1
     assert handoff_calls[0]["atom_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# V1-battery Gate 2 — 429 / 529 retry (Elliot dispatch 2026-05-30 ~11:35 AEST)
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_anthropic_with_statuses(
+    monkeypatch: pytest.MonkeyPatch,
+    statuses: list[int | None],
+    *,
+    retry_after_header: str | None = None,
+) -> dict:
+    """Build a fake anthropic module whose messages.create raises an
+    APIStatusError-shaped exception for each non-None status in `statuses`,
+    then on the first None entry returns a normal response.
+
+    Returns a dict with attempt counts so the test can assert how many calls
+    landed before success / exhaustion.
+    """
+    state = {"attempts": 0, "captured_sleeps": []}
+
+    class _FakeContent:
+        def __init__(self, text):
+            self.text = text
+
+    class _FakeUsage:
+        input_tokens = 10
+        output_tokens = 20
+
+    class _FakeResponse:
+        content = [_FakeContent("OK")]
+        usage = _FakeUsage()
+
+    class _FakeAnthropicError(Exception):
+        pass
+
+    class _FakeAPIError(_FakeAnthropicError):
+        pass
+
+    class _FakeAPIStatusError(_FakeAPIError):
+        def __init__(self, status_code: int, headers: dict | None = None):
+            super().__init__(f"http {status_code}")
+            self.status_code = status_code
+            self.response = types.SimpleNamespace(status_code=status_code, headers=headers or {})
+
+    class _FakeRateLimitError(_FakeAPIStatusError):
+        pass
+
+    class _FakeClient:
+        def __init__(self, *, api_key):
+            self.messages = self
+
+        def create(self, **_kwargs):
+            idx = state["attempts"]
+            state["attempts"] += 1
+            if idx >= len(statuses) or statuses[idx] is None:
+                return _FakeResponse()
+            status = statuses[idx]
+            headers = {"retry-after": retry_after_header} if retry_after_header else {}
+            if status == 429:
+                raise _FakeRateLimitError(429, headers)
+            raise _FakeAPIStatusError(status, headers)
+
+    fake_anthropic = types.ModuleType("anthropic")
+    fake_anthropic.Anthropic = _FakeClient
+    fake_anthropic.AnthropicError = _FakeAnthropicError
+    fake_anthropic.APIError = _FakeAPIError
+    fake_anthropic.APIStatusError = _FakeAPIStatusError
+    fake_anthropic.RateLimitError = _FakeRateLimitError
+    monkeypatch.setitem(sys.modules, "anthropic", fake_anthropic)
+
+    # Patch time.sleep so the retry waits don't actually block the test, and
+    # capture the backoff intervals for assertion.
+    def _fake_sleep(secs: float) -> None:
+        state["captured_sleeps"].append(secs)
+
+    monkeypatch.setattr(aacs.time, "sleep", _fake_sleep)
+    return state
+
+
+def test_call_anthropic_retries_on_429_then_succeeds(monkeypatch: pytest.MonkeyPatch):
+    """One 429 then success → returns retries=1, exponential backoff started at 1s."""
+    state = _install_fake_anthropic_with_statuses(monkeypatch, [429, None])
+    text, in_t, out_t, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    assert text == "OK"
+    assert in_t == 10 and out_t == 20
+    assert retries == 1
+    assert state["attempts"] == 2
+    # First retry backoff = 1.0s (base * 2**0 = 1.0).
+    assert state["captured_sleeps"] == [pytest.approx(1.0)]
+
+
+def test_call_anthropic_retries_on_529_overloaded(monkeypatch: pytest.MonkeyPatch):
+    """529 (overloaded) is in the retriable set — same path as 429."""
+    state = _install_fake_anthropic_with_statuses(monkeypatch, [529, 529, None])
+    _, _, _, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    assert retries == 2
+    assert state["attempts"] == 3
+    # Exponential: 1s, 2s.
+    assert state["captured_sleeps"] == [pytest.approx(1.0), pytest.approx(2.0)]
+
+
+def test_call_anthropic_respects_retry_after_header(monkeypatch: pytest.MonkeyPatch):
+    """Retry-After: 7 → backoff = 7s (overrides computed exponential)."""
+    state = _install_fake_anthropic_with_statuses(monkeypatch, [429, None], retry_after_header="7")
+    _, _, _, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    assert retries == 1
+    assert state["captured_sleeps"] == [pytest.approx(7.0)]
+
+
+def test_call_anthropic_backoff_caps_at_60s(monkeypatch: pytest.MonkeyPatch):
+    """Computed backoff cap is 60s — verifies the max-cap guard against runaway exponential."""
+    # 4 attempts with statuses [429, 429, 429, None]: backoffs would be 1, 2, 4
+    # (last attempt has no sleep). Cap doesn't bite here, but we can validate
+    # the cap kicks in by patching the base to a large value and re-running.
+    monkeypatch.setattr(aacs, "_RATE_LIMIT_BASE_BACKOFF_S", 100.0)
+    state = _install_fake_anthropic_with_statuses(monkeypatch, [429, 429, 429, None])
+    _, _, _, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    assert retries == 3
+    # All 3 backoffs should be capped at 60s.
+    assert all(s == pytest.approx(60.0) for s in state["captured_sleeps"])
+
+
+def test_call_anthropic_exhausts_publishes_ops_failure(monkeypatch: pytest.MonkeyPatch):
+    """4 consecutive 429s → publish_rate_limit_exhaust fires; APIStatusError re-raised."""
+    state = _install_fake_anthropic_with_statuses(monkeypatch, [429, 429, 429, 429])
+    published: list[dict] = []
+
+    def fake_publish(task_id: str, callsign: str, retries: int) -> None:
+        published.append({"task_id": task_id, "callsign": callsign, "retries": retries})
+
+    monkeypatch.setattr(aacs, "_publish_rate_limit_exhaust", fake_publish)
+
+    with pytest.raises(Exception) as excinfo:
+        aacs.call_anthropic("KEY", "SYS", "BRIEF", task_id="t-x", callsign="atlas")
+    assert getattr(excinfo.value, "status_code", None) == 429
+    assert state["attempts"] == aacs._RATE_LIMIT_MAX_ATTEMPTS == 4
+    assert len(published) == 1
+    assert published[0] == {"task_id": "t-x", "callsign": "atlas", "retries": 3}
+
+
+def test_call_anthropic_does_not_retry_non_retriable_400(monkeypatch: pytest.MonkeyPatch):
+    """400 (bad request) is not in the retriable set — immediate raise, no publish."""
+    state = _install_fake_anthropic_with_statuses(monkeypatch, [400])
+    published: list[dict] = []
+    monkeypatch.setattr(
+        aacs,
+        "_publish_rate_limit_exhaust",
+        lambda **kw: published.append(kw),
+    )
+    with pytest.raises(Exception) as excinfo:
+        aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    assert getattr(excinfo.value, "status_code", None) == 400
+    assert state["attempts"] == 1
+    assert state["captured_sleeps"] == []
+    assert published == []  # exhaust path NOT taken


### PR DESCRIPTION
## Summary
Two P0 V1-battery hard gates per Elliot dispatch 2026-05-30 ~11:35 AEST. Both are runtime-enforced (GOV-12) — not comments. The battery does not run without both verified.

### Gate 1 — per-task A$10 spend ceiling (circuit breaker)
`v1_chain_orchestrator.advance_step()` queries `keiracom_spawn_attribution` for `SUM(cost_aud)` per `task_id` after each hop. If over the ceiling (default A$10.00, env-overridable via `V1_TASK_COST_CEILING_AUD`):
1. Halt — set `current_step='halted_ceiling_exceeded'`, `ceiling_tripped=True`, store per-hop breakdown.
2. POST `/dispatcher/ceiling_breach` with the breakdown (Elliot's #ceo surface).
3. Save state, return zero new dispatches.

Fail-OPEN on read failure (`None`) — Orion's fleet-level `cost_breaker` (#1297 Agency_OS-wdws) is the fail-SAFE backstop and this is the per-task complement. Fast-fail when no `DATABASE_URL` so unit tests do not hit a 10s `psycopg.connect` timeout.

Normal runs ~A$0.05–0.20. Hitting A$10 = pathological (runaway loop / stuck retry / context explosion).

### Gate 2 — 429 / 529 retry in api_agent_cold_start
`call_anthropic()` wraps `anthropic.messages.create` in a bounded retry:
- **Retriable**: 429 (`RateLimitError`) + 503 / 529 (`APIStatusError` overloaded).
- **Backoff**: 1s base, doubled per attempt, capped at 60s.
- **Retry-After header**: respected when present and parseable.
- **Attempts**: max 4 (1 initial + 3 retries).
- **Non-retriable** `APIStatusError` (400 / 401 / 403): re-raises immediately.
- **On exhaust**: publish `keiracom.ops.failure` NATS envelope (peer_event_ceo_relay subscribes → #ceo as visible incident), then re-raise. `run()` → `RC_API_FAILED`.

Signature change: `call_anthropic(...) -> (text, in_tok, out_tok, retries)`. `retries` threaded into `insert_attribution` and the new `rate_limit_retries` column.

### Schema
`supabase/migrations/20260530_keiracom_spawn_attribution_rate_limit_retries.sql` — `ADD COLUMN IF NOT EXISTS rate_limit_retries INTEGER NOT NULL DEFAULT 0`. Default 0 keeps existing INSERT call sites working.

### Battery harness
`v1_battery_harness` now renders two new columns:
- `ceiling_tripped`: YES (with per-hop breakdown) or NO
- `rate_limit_429s`: count summed across attribution rows for the chain

Derived from chain state (`ceiling_tripped` + `ceiling_per_hop`) and attribution (`rate_limit_retries`).

## Out of scope
- Orion's fleet-level `cost_breaker.py` (#1297 Agency_OS-wdws) — complementary, untouched.
- V1 chain `ROLE_FOR_STEP` ordered-fallback — `Agency_OS-qod8`, post-battery.

## Test plan
- [x] `ruff format --check` + `ruff check` clean on all 5 modified + 1 new file
- [x] `pytest tests/keiracom_system/chain/test_v1_chain_orchestrator.py tests/keiracom_system/vault/test_api_agent_cold_start.py` — 50 passed (existing + 9 new)
- [x] Gate 1: `test_query_task_cost_aud_returns_none_on_empty_task_id`, `test_advance_step_halts_when_ceiling_breached`, `test_advance_step_proceeds_when_ceiling_not_breached`, `test_advance_step_fail_open_when_query_returns_none`
- [x] Gate 2: `test_call_anthropic_retries_on_429_then_succeeds`, `test_call_anthropic_retries_on_529_overloaded`, `test_call_anthropic_respects_retry_after_header`, `test_call_anthropic_backoff_caps_at_60s`, `test_call_anthropic_exhausts_publishes_ops_failure`, `test_call_anthropic_does_not_retry_non_retriable_400`
- [x] Harness smoke: `render_markdown` with synthetic ceiling-tripped + 429-counted rows renders correctly
- [ ] Migration applied to staging Supabase before the battery runs
- [ ] `DISPATCHER_AGENT_COMMAND` pointed at `api_agent_cold_start` (harness pre-flight enforces this)
- [ ] 2-of-3 deliberator NATS concur (Elliot / Aiden / Max — author-exclusion = 2-of-2 from non-authors)

## Files
- `src/keiracom_system/chain/v1_chain_orchestrator.py` (+96 lines: ceiling helper + breach post + advance_step wiring)
- `src/keiracom_system/vault/api_agent_cold_start.py` (+140 lines: retry wrapper + NATS publish + retry threading)
- `scripts/v1_battery_harness.py` (+24 lines: 2 new columns)
- `supabase/migrations/20260530_keiracom_spawn_attribution_rate_limit_retries.sql` (new)
- `tests/keiracom_system/chain/test_v1_chain_orchestrator.py` (+130 lines: Gate 1 tests)
- `tests/keiracom_system/vault/test_api_agent_cold_start.py` (+155 lines: Gate 2 tests + 3 signature updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)