### PR TITLE
[ATLAS] feat(v1-chain): __main__ --consumer branch for systemd entry point (Agency_OS-zr7e)

### DIFF
--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -682,6 +682,12 @@ if __name__ == "__main__":  # pragma: no cover
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     import sys
 
-    brief = " ".join(sys.argv[1:]) or "test task from v1_chain_orchestrator __main__"
-    cid = dispatch({"id": "smoke-task-1", "brief": brief})
-    print(f"dispatched chain_id={cid}")
+    # --consumer: long-running NATS subscriber loop (systemd entry point for
+    # keiracom-v1-chain-consumer.service — Agency_OS-zr7e). All other argv
+    # forms fall through to the existing dispatch smoke for ad-hoc testing.
+    if len(sys.argv) > 1 and sys.argv[1] == "--consumer":
+        asyncio.run(run_consumer())
+    else:
+        brief = " ".join(sys.argv[1:]) or "test task from v1_chain_orchestrator __main__"
+        cid = dispatch({"id": "smoke-task-1", "brief": brief})
+        print(f"dispatched chain_id={cid}")


### PR DESCRIPTION
## Summary
Wires `v1_chain_orchestrator.run_consumer()` to a systemd-runnable entry point so `keiracom.agent.handoff` NATS envelopes are actually consumed and the V1 chain advances. Per Elliot dispatch 2026-05-30, Agency_OS-zr7e / battery unblock.

## Change
`src/keiracom_system/chain/v1_chain_orchestrator.py` — extends the `__main__` block to branch:
- `--consumer` → `asyncio.run(run_consumer())` (long-running NATS subscriber)
- any other argv → existing dispatch smoke (unchanged behavior for ad-hoc test runs)

5 lines net.

## Companion (host-only — not in this PR)
`~/.config/systemd/user/keiracom-v1-chain-consumer.service` per Elliot's verbatim template, installed on the host. Per `orchestrator-merge-after-NATS-concur`: systemd units in `~/.config/` are host-side infra, not PR-scoped. No `OnFailure=` / Drop-In `onfailure.conf` per dispatch.

## Verification (manual)
Ran `python3 -B -m src.keiracom_system.chain.v1_chain_orchestrator --consumer` from this branch's worktree against the live NATS server. Captured journal-equivalent log:

```
2026-05-30 06:45:06,492 INFO v1_chain consumer: subscribed
  keiracom.agent.handoff on nats://127.0.0.1:4222
```

Subscription fires; consumer stays in the `await asyncio.sleep(60)` loop until SIGTERM. Code path is correct.

The systemd unit was initially `enable --now` while still running against `/home/elliotbot/clawd/Agency_OS` (the main worktree, pre-merge stale code). It hit the smoke `dispatch()` else-branch and auto-restarted in a loop. Stopped + disabled until this PR merges; activation chain is then `merge → systemctl --user enable --now keiracom-v1-chain-consumer.service`.

## Test plan
- [x] `ruff format --check` + `ruff check` clean
- [x] `pytest tests/keiracom_system/chain/test_v1_chain_orchestrator.py` — 27 passed (no regressions; `__main__` block is `# pragma: no cover`)
- [x] Manual `--consumer` run from atlas worktree subscribes to `keiracom.agent.handoff`
- [ ] Aiden NATS concur per orchestrator-merge-after-NATS-concur (2-of-2 author-exclusion)
- [ ] Elliot admin-merge
- [ ] Post-merge: `systemctl --user enable --now keiracom-v1-chain-consumer.service` + verify `active (running)` + journal shows `subscribed keiracom.agent.handoff`

## Files
- `src/keiracom_system/chain/v1_chain_orchestrator.py` (+9 / -3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)