### PR TITLE
[ATLAS] feat(dispatcher): pass ANTHROPIC_API_KEY through to tmux spawns (V1-battery unblock)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -468,7 +468,18 @@ def _container_spawn_kwargs(key: str, sk: dict[str, Any]) -> dict[str, Any]:
 # env -i clears PATH/HOME too, so the agent command couldn't even start — these
 # NON-SECRET operational vars are re-added. Credentials (DATABASE_URL, *_API_KEY,
 # …) are deliberately NOT whitelisted → scrubbed.
-_TMUX_OPERATIONAL_PASSTHROUGH = ("PATH", "HOME", "LANG", "LC_ALL", "TERM", "USER")
+# Carve-out (Elliot 2026-05-30, V1-battery unblock): ANTHROPIC_API_KEY is in
+# the passthrough until api_agent_cold_start migrates to vault-resolved creds;
+# the Anthropic SDK reads it from os.environ at spawn time.
+_TMUX_OPERATIONAL_PASSTHROUGH = (
+    "PATH",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "TERM",
+    "USER",
+    "ANTHROPIC_API_KEY",
+)
 DEFAULT_AGENT_WORKDIR = os.environ.get(
     "DISPATCHER_AGENT_WORKDIR", "/home/elliotbot/clawd/Agency_OS"
 )


### PR DESCRIPTION
## Summary
Adds `ANTHROPIC_API_KEY` to `_TMUX_OPERATIONAL_PASSTHROUGH` in `src/dispatcher/main.py:471` per Elliot dispatch 2026-05-30. P0 V1-battery unblock.

## Why
The dispatcher uses `env -i` to scrub the tmux spawn environment, passing only the vars in `_TMUX_OPERATIONAL_PASSTHROUGH`. `api_agent_cold_start` reads `ANTHROPIC_API_KEY` directly from `os.environ`. Without the passthrough every Anthropic SDK spawn fails immediately with `'ANTHROPIC_API_KEY missing'`.

## Carve-out note
The existing comment block deliberately excludes credentials (`DATABASE_URL`, `*_API_KEY`, ...). Added an inline carve-out acknowledging this is a V1-battery exception — the Anthropic SDK can't read the key via vault cred resolution yet; until `api_agent_cold_start` migrates to that path, the key flows through this passthrough. Should be revisited post-battery.

## Verification (live)
Restarted the dispatcher with this change applied, then ran Elliot's verification command:

```
chain_id: atlas-verify-001
step: aiden_plan done: []
step: aiden_plan done: []
step: max_challenge done: ['aiden_plan']
```

The chain advanced — `aiden_plan` completed AND the consumer fired `advance_step` to dispatch `max_challenge`. End-to-end happy path proven through one full hop transition.

## Scope
- 1 logical line change in `src/dispatcher/main.py`.
- +12 / -1 net (tuple reformatted multi-line for ruff readability + 4-line carve-out comment).
- No tests added (tuple membership is a config-level invariant; the runtime verification above covers the behaviour change).

## Test plan
- [x] `ruff format --check` + `ruff check` clean
- [x] Live verification: dispatcher restarted, chain dispatch advanced through 1+ hop
- [ ] Aiden NATS concur per author-exclusion (Atlas authored — eligible reviewers Aiden + Max, or Elliot + Max)
- [ ] Elliot admin-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)