### PR TITLE
[ATLAS] feat(dispatcher): pass DATABASE_URL + SUPABASE_DB_DSN to tmux spawns (V1-battery unblock)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -468,9 +468,14 @@ def _container_spawn_kwargs(key: str, sk: dict[str, Any]) -> dict[str, Any]:
 # env -i clears PATH/HOME too, so the agent command couldn't even start — these
 # NON-SECRET operational vars are re-added. Credentials (DATABASE_URL, *_API_KEY,
 # …) are deliberately NOT whitelisted → scrubbed.
-# Carve-out (Elliot 2026-05-30, V1-battery unblock): ANTHROPIC_API_KEY is in
-# the passthrough until api_agent_cold_start migrates to vault-resolved creds;
-# the Anthropic SDK reads it from os.environ at spawn time.
+# Carve-out (Elliot 2026-05-30, V1-battery unblock): ANTHROPIC_API_KEY,
+# DATABASE_URL, and SUPABASE_DB_DSN are in the passthrough — all three are
+# Phase 1 exceptions until api_agent_cold_start migrates to vault-resolved
+# creds. The Anthropic SDK reads ANTHROPIC_API_KEY from os.environ at spawn
+# time; agent_cold_start._dsn() reads DATABASE_URL OR SUPABASE_DB_DSN for the
+# attribution INSERT connection. Without all three in the passthrough every
+# V1 chain spawn either crashes pre-API-call (no key) or silently drops the
+# attribution row (no DSN → ceiling check has nothing to sum).
 _TMUX_OPERATIONAL_PASSTHROUGH = (
     "PATH",
     "HOME",
@@ -479,6 +484,8 @@ _TMUX_OPERATIONAL_PASSTHROUGH = (
     "TERM",
     "USER",
     "ANTHROPIC_API_KEY",
+    "DATABASE_URL",
+    "SUPABASE_DB_DSN",
 )
 DEFAULT_AGENT_WORKDIR = os.environ.get(
     "DISPATCHER_AGENT_WORKDIR", "/home/elliotbot/clawd/Agency_OS"


### PR DESCRIPTION
## Summary
Same pattern as PR #1358 — extends `_TMUX_OPERATIONAL_PASSTHROUGH` with `DATABASE_URL` + `SUPABASE_DB_DSN` so `agent_cold_start._dsn()` can resolve the attribution INSERT connection from inside a dispatcher-spawned tmux agent. P0 V1-battery unblock per Elliot dispatch 2026-05-30.

## Why
Without these env vars in the passthrough, every V1 chain spawn silently drops its attribution row (no DSN → ceiling check has nothing to sum, no cost telemetry, Gate 1 effectively disabled).

## Carve-out note
Extended the existing ANTHROPIC_API_KEY carve-out comment to acknowledge all three creds are Phase 1 exceptions until `api_agent_cold_start` migrates to vault-resolved creds.

## Live verification — end-to-end V1 chain happy path

`chain_id: db-passthrough-verify`. Attribution rows from `public.keiracom_spawn_attribution`:

| Hop | Callsign | task_type | cost A$ | status |
|-----|----------|-----------|---------|--------|
| 1 | aiden | deliberation | 0.012764 | success |
| 2 | max | deliberation | 0.010091 | success |
| 3 | nova | build | 0.000967 | success |
| 4 | atlas | pr_review | 0.001669 | success |
| 5 | orion | pr_review | 0.002376 | success |

**Total A\$0.027867 | ~19s wall-clock end-to-end**

Five distinct callsigns landed attribution rows in order, all `completion_status='success'`. The V1 chain Aiden→Max→Nova→(Orion+Atlas) fully completed for the first time end-to-end. Gate 1's per-task ceiling read path is now load-bearing.

## Scope
- 2 logical entries added to `_TMUX_OPERATIONAL_PASSTHROUGH` (`DATABASE_URL` + `SUPABASE_DB_DSN`).
- 3-line extension to the existing carve-out comment.
- `src/dispatcher/main.py` only. +10 / -3 net.

## Test plan
- [x] `ruff format --check` + `ruff check` clean
- [x] Live verification: full 5-hop chain completed; attribution rows landed with valid cost_aud per hop
- [ ] Aiden NATS concur per author-exclusion (Atlas authored — eligible Aiden + Max)
- [ ] Elliot admin-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)