### PR TITLE
[ATLAS] feat(dispatcher): async-queue pending spawns instead of 503 on ceiling hit

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -900,8 +900,40 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
     # conservative DEFAULT_PHYSICAL_CEILING (never fails open to "unlimited").
     can_spawn, ceiling_reason = check_physical_ceiling(len(_spawned))
     if not can_spawn:
-        logger.warning("physical ceiling: refusing spawn key=%s — %s", req.key, ceiling_reason)
-        raise HTTPException(status_code=503, detail=ceiling_reason)
+        # Async queue (Elliot 2026-05-30): instead of immediately 503ing when
+        # the physical ceiling is hit, poll every queue_poll_s up to
+        # queue_timeout_s for a slot to free. dispatcher_spawn is an `async def`
+        # FastAPI endpoint, so `await asyncio.sleep` yields the event loop —
+        # concurrent task completions can unregister their _spawned entries and
+        # release the slot. Reads len(_spawned) live on each poll; no new state
+        # required. 503 still raised on actual timeout. Env-overridable via
+        # DISPATCHER_QUEUE_TIMEOUT_S.
+        queue_timeout_s = int(os.environ.get("DISPATCHER_QUEUE_TIMEOUT_S", "300"))
+        queue_poll_s = 5
+        import time as _time  # noqa: PLC0415 — avoid shadowing the module-level time
+
+        deadline = _time.monotonic() + queue_timeout_s
+        while not can_spawn:
+            remaining = deadline - _time.monotonic()
+            if remaining <= 0:
+                logger.warning(
+                    "physical ceiling: queue timeout key=%s after %ds — %s",
+                    req.key,
+                    queue_timeout_s,
+                    ceiling_reason,
+                )
+                raise HTTPException(
+                    status_code=503,
+                    detail=f"spawn queue timeout ({queue_timeout_s}s): {ceiling_reason}",
+                )
+            logger.info(
+                "physical ceiling: queuing spawn key=%s (%d active, %.0fs remaining)",
+                req.key,
+                len(_spawned),
+                remaining,
+            )
+            await asyncio.sleep(queue_poll_s)
+            can_spawn, ceiling_reason = check_physical_ceiling(len(_spawned))
 
     manager = SessionManager(backend=backend)
     try:

--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -908,7 +908,12 @@ async def dispatcher_spawn(req: SpawnRequest) -> dict[str, Any]:
         # release the slot. Reads len(_spawned) live on each poll; no new state
         # required. 503 still raised on actual timeout. Env-overridable via
         # DISPATCHER_QUEUE_TIMEOUT_S.
-        queue_timeout_s = int(os.environ.get("DISPATCHER_QUEUE_TIMEOUT_S", "300"))
+        # Max HOLD on PR #1361: int() on a non-numeric env value raises
+        # ValueError that would crash the spawn — fall back to default instead.
+        try:
+            queue_timeout_s = int(os.environ.get("DISPATCHER_QUEUE_TIMEOUT_S") or "300")
+        except ValueError:
+            queue_timeout_s = 300
         queue_poll_s = 5
         import time as _time  # noqa: PLC0415 — avoid shadowing the module-level time
 


### PR DESCRIPTION
## Summary
Replaces the 3-line 503-on-ceiling behavior in `dispatcher_spawn` (~line 901) with an async queue loop per Elliot dispatch 2026-05-30. When the physical ceiling is hit, poll every 5s up to `DISPATCHER_QUEUE_TIMEOUT_S` (default 300s) for a slot to free. 503 only on actual timeout.

## Why this is correct
- `dispatcher_spawn` is an `async def` FastAPI endpoint — `await asyncio.sleep` yields the event loop, so concurrent task completions (which unregister `_spawned` entries) can release the slot mid-poll.
- No new data structures — reads `len(_spawned)` live on each poll.
- Env-overridable queue timeout via `DISPATCHER_QUEUE_TIMEOUT_S`.
- Imports already present at module level (`asyncio`, `os`). `import time as _time` inside the function avoids shadowing the module-level `time` symbol per Elliot's note.

## Verification
- `ruff format --check` + `ruff check` clean.
- Dispatcher restarted with this change applied — service `active`.
- Smoke chain dispatch on the normal (ceiling-not-hit) path:
  ```
  chain_id: spawn-queue-normal
  step: max_challenge done: ['aiden_plan']
  ```
  `aiden_plan` completed → consumer fired `advance_step` → `max_challenge`, confirming the non-queue fast path remains unchanged.

The queue path itself is harder to deterministically trigger in a smoke (requires concurrent spawn near the physical ceiling), so verified by:
1. Code-path correctness — async/await semantics, live `len(_spawned)` read, exception only on timeout.
2. Restart-clean + normal-path unchanged.

## Scope
- `src/dispatcher/main.py`: 1 logical change, +34 / -2 net.

## Test plan
- [x] `ruff format --check` + `ruff check` clean
- [x] Dispatcher restart-clean + normal-path chain dispatch advances
- [ ] Elliot + Max NATS concur per author-exclusion (Atlas authored)
- [ ] Operator stress test (concurrent spawns near ceiling) on staging if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)