### PR TITLE
[ATLAS] feat(exit-cycle): add implementation_plan kind so engineering tasks capture atoms

### DIFF
--- a/src/keiracom_system/chat/exit_cycle.py
+++ b/src/keiracom_system/chat/exit_cycle.py
@@ -53,6 +53,7 @@ _VALID_KINDS = {
     "confirmed_pattern",
     "dave_approval",
     "viktor_explanation",
+    "implementation_plan",
 }
 
 CLASSIFY_SYSTEM_PROMPT = (
@@ -60,14 +61,18 @@ CLASSIFY_SYSTEM_PROMPT = (
     "it survives past an ephemeral agent that is about to exit. Return ONLY items "
     "that are one of: a ratified architectural decision ('we will use X for Y'); "
     "a confirmed pattern ('always do X when Y'); an explicit Dave approval ('yes', "
-    "'go ahead', 'confirmed' against a concrete proposal); or a Viktor explanation "
-    "of how something works. DO NOT return status updates, questions, routine task "
+    "'go ahead', 'confirmed' against a concrete proposal); a Viktor explanation "
+    "of how something works; or an implementation_plan — a concrete decision "
+    "about HOW to implement a task, where the assistant lays out a specific "
+    "approach (what was chosen, what was rejected, and why) with rationale, not "
+    "just code output. DO NOT return status updates, questions, routine task "
     "dispatches, or casual conversation. For each item give: decision_text (a "
-    "self-contained one-sentence statement of the decision/pattern/fact — written "
-    "so a future agent with no prior context understands it), topic_slug (2-5 "
-    "kebab-case words), kind (one of architectural_decision|confirmed_pattern|"
-    "dave_approval|viktor_explanation), and confidence (0.0-1.0). Return an empty "
-    "items list when nothing qualifies. Be conservative — precision over recall."
+    "self-contained one-sentence statement of the decision/pattern/fact/plan — "
+    "written so a future agent with no prior context understands it), topic_slug "
+    "(2-5 kebab-case words), kind (one of architectural_decision|"
+    "confirmed_pattern|dave_approval|viktor_explanation|implementation_plan), and "
+    "confidence (0.0-1.0). Return an empty items list when nothing qualifies. Be "
+    "conservative — precision over recall."
 )
 
 RESPONSE_SCHEMA: dict[str, Any] = {


### PR DESCRIPTION
## Summary
Dave directive 2026-05-30 via Elliot. V1 chain hops were producing `atom_ids=[]` for every engineering task. Root cause (from prior research): `_VALID_KINDS` only admitted `{architectural_decision, confirmed_pattern, dave_approval, viktor_explanation}`. The aiden_plan step DOES surface decisions — approach chosen, rejected, rationale — but Gemini was told those don't qualify.

## Changes (`src/keiracom_system/chat/exit_cycle.py`)
- `_VALID_KINDS`: adds `implementation_plan`.
- `CLASSIFY_SYSTEM_PROMPT`: extends with the new kind's definition — *"a concrete decision about HOW to implement a task, where the assistant lays out a specific approach (what was chosen, what was rejected, and why) with rationale, not just code output."*
- `RESPONSE_SCHEMA`: no change — `kind` is `type: string`; the allowlist is enforced in `_select_qualifying` (line 140) not in the schema.
- `CONFIDENCE_THRESHOLD`: kept at 0.8 — Gemini handled an `implementation_plan` example above that threshold without needing the lower kind-specific floor.

## Live verification (Gemini Flash classifier)
Sample conversation: `TASK_A_BRIEF` (docstring add) + a ~200-word aiden-style plan with approach/rejection/rationale/acceptance.

Result:
```
atom_ids: ['15c45ad6-b350-4d41-a9b0-f59122ca0197']
decisions_saved: 1
skipped_reason: None
bank: fleet_decisions
captured atom content:
  "The implementation plan for adding a one-line docstring to
   scripts/orchestrator/ops_failure_publish.py is to insert a ruff-style
   module docstring at..."
```

Existing 11 exit_cycle tests pass (none asserted exact-size of `_VALID_KINDS`). `ruff format --check` + `ruff check` clean.

## Scope
1 file, +12 / -7 net.

## Test plan
- [x] `ruff format --check` + `ruff check` clean
- [x] `pytest tests/keiracom_system/chat/test_exit_cycle.py` — 11 pass
- [x] Live Gemini classify of an aiden_plan sample → non-empty `atom_ids` + decisions_saved=1
- [ ] Elliot + Max NATS concur per author-exclusion (Atlas authored)

## Follow-up (separate PR — coming next)
PR B — prompt caching in `api_agent_cold_start` via `cache_control: {type: ephemeral}` on the system block, gated by token_count ≥ 1024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)