### PR TITLE
[ATLAS] fix(v1-chain): move _post_chain_complete to event-loop wrapper — kills duplicate #ceo posts

### DIFF
--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -533,18 +533,15 @@ def advance_step(
             # Last parallel step completed → chain is complete.
             entry["current_step"] = "complete"
             entry["pending"] = []
-            # Agency_OS-zqni — single final #ceo post for the directive.
-            # Belt-and-suspenders fail-open: _post_chain_complete's internal try/except
-            # is the primary guard, but a future refactor or a test-injected fake
-            # MUST NOT abort the state save here.
-            try:
-                _post_chain_complete(entry, chain_id)
-            except Exception:  # noqa: BLE001 — final-post failure must not break state save
-                log.warning(
-                    "v1_chain chain_complete raised at call site for chain=%s",
-                    chain_id,
-                    exc_info=True,
-                )
+            # NOTE: _post_chain_complete is NOT called here — it fires from
+            # _advance_step_async (the event-loop-level wrapper) instead.
+            # asyncio.to_thread runs advance_step on a worker thread; parallel
+            # hop completions (orion_spec + atlas_safety) arriving close in
+            # time can both enter this branch before either has saved state,
+            # causing duplicate (or triplicate) #ceo posts. Moving the post to
+            # the single-threaded event loop with a `complete_posted` flag
+            # serialises it (race found 2026-05-30 Elliot, fix Agency_OS-chain-
+            # complete-post-event-loop).
         elif completed_step in _SEQ_NEXT:
             next_step = _SEQ_NEXT[completed_step]
             if next_step is not None:
@@ -571,21 +568,40 @@ async def _advance_step_async(
     *,
     clock: Callable[[], float] = time.time,
 ) -> list[dict]:
-    """Async entrypoint for the V1 consumer loop (Atlas oevr) — Aiden HOLD fix.
+    """Async entrypoint for the V1 consumer loop (Atlas oevr).
 
-    Delegates to the sync advance_step via asyncio.to_thread so the completion
-    branch ALWAYS fires _post_chain_complete via the exact same code path the
-    sync caller uses. Parity-by-delegation eliminates the parallel-implementation
-    divergence bug class Aiden caught on PR #1340 — there can never be a "the
-    sync path calls _post_chain_complete but the async path forgot" failure,
-    because there is only one path.
+    Delegates state-mutation work to advance_step on the thread pool (state
+    I/O + urllib publishes are I/O-bound), then fires _post_chain_complete
+    ONCE from the event-loop level. The post is here — not inside
+    advance_step — to serialise it: parallel hop completions (orion_spec +
+    atlas_safety) hitting the consumer back-to-back each enter advance_step
+    on separate threads, and prior to this both threads could observe
+    current_step == 'complete' before either persisted the
+    "I already posted" flag → duplicate (or triplicate) #ceo posts.
 
-    State I/O (state file read/write) and the urllib POST in _post_chain_complete
-    are I/O-bound, so running them on a worker thread is the correct shape:
-    advance_step returns when the dispatch + state-save + chain-complete-post
-    are all done, and the event loop is not blocked during the urllib POST.
+    The complete_posted flag is a re-load-check-write triple under the
+    event loop, which runs single-threaded: only one coroutine can observe
+    `complete_posted is False` and flip it, so only one post fires.
+    Race fixed 2026-05-30 (Elliot diagnosis).
     """
-    return await asyncio.to_thread(advance_step, chain_id, completed_step, atom_id, clock=clock)
+    envelopes = await asyncio.to_thread(
+        advance_step, chain_id, completed_step, atom_id, clock=clock
+    )
+    # Single-threaded serialisation point — only one coroutine wins the flip.
+    state = _load_state()
+    entry = state.get(chain_id) or {}
+    if entry.get("current_step") == "complete" and not entry.get("complete_posted"):
+        entry["complete_posted"] = True
+        _save_state(state)
+        try:
+            _post_chain_complete(entry, chain_id)
+        except Exception:  # noqa: BLE001 — final-post failure must not break completion
+            log.warning(
+                "v1_chain chain_complete raised at _advance_step_async for chain=%s",
+                chain_id,
+                exc_info=True,
+            )
+    return envelopes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
+++ b/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
@@ -425,10 +425,15 @@ def test_advance_step_unrecognized_step_returns_empty_and_logs_warning(
 # ─── Final #ceo post on complete (Agency_OS-zqni) ─────────────────────────────
 
 
-def test_advance_step_final_post_fires_on_chain_complete(
+def test_advance_step_async_final_post_fires_on_chain_complete(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """When the last parallel partner completes, _post_chain_complete is called once."""
+    """When the last parallel partner completes via _advance_step_async,
+    _post_chain_complete fires exactly once. The post lives in the async
+    wrapper now (2026-05-30 race fix) — sync advance_step no longer posts.
+    """
+    import asyncio
+
     _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
@@ -459,7 +464,7 @@ def test_advance_step_final_post_fires_on_chain_complete(
         },
     )
 
-    orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
+    asyncio.run(orch._advance_step_async(chain_id, "atlas_safety", "atom-atlas"))
 
     assert len(posts) == 1
     entry, posted_chain_id = posts[0]
@@ -467,6 +472,55 @@ def test_advance_step_final_post_fires_on_chain_complete(
     assert entry["task_id"] == "t-zq"
     assert entry["brief"] == "wire X to Y"
     assert entry["current_step"] == "complete"
+
+
+def test_advance_step_sync_path_does_not_post(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Sync advance_step MUST NOT post to #ceo — the post is now serialised in
+    _advance_step_async. Calling advance_step directly on a chain that closes
+    should mutate state but never invoke _post_chain_complete (this is the
+    duplicate-#ceo-post race fix, 2026-05-30 Elliot).
+    """
+    _capture_publishes(monkeypatch)
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    posts: list = []
+
+    def boom_post(_entry, _chain_id):
+        posts.append(True)
+        raise AssertionError("sync advance_step MUST NOT call _post_chain_complete")
+
+    monkeypatch.setattr(orch, "_post_chain_complete", boom_post)
+
+    chain_id = "chain-sync-no-post"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-sync",
+            "brief": "sync no post",
+            "started_ts": 0.0,
+            "current_step": "atlas_safety",
+            "steps_done": ["aiden_plan", "max_challenge", "nova_build", "orion_spec"],
+            "atom_ids": {
+                "aiden_plan": "a1",
+                "max_challenge": "a2",
+                "nova_build": "a3",
+                "orion_spec": "a4",
+            },
+            "pending": ["atlas_safety"],
+        },
+    )
+
+    orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
+    assert posts == []  # sync path silent — async wrapper owns the post
+
+    state = json.loads(state_file.read_text())
+    assert state[chain_id]["current_step"] == "complete"
+    # complete_posted should NOT be set by sync path either — the async
+    # wrapper writes that flag when it actually posts.
+    assert state[chain_id].get("complete_posted") is not True
 
 
 def test_advance_step_intermediate_does_not_post_to_ceo(
@@ -506,10 +560,13 @@ def test_advance_step_intermediate_does_not_post_to_ceo(
     assert posts == []  # final post never invoked
 
 
-def test_advance_step_final_post_failure_does_not_break_completion(
+def test_advance_step_async_final_post_failure_does_not_break_completion(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """A raising _post_chain_complete must NOT abort advance_step (fail-open guard)."""
+    """A raising _post_chain_complete must NOT abort _advance_step_async
+    (fail-open guard — post moved to async wrapper 2026-05-30)."""
+    import asyncio
+
     _capture_publishes(monkeypatch)
     state_file = tmp_path / "v1_chain_state.json"
     monkeypatch.setattr(orch, "STATE_FILE", state_file)
@@ -541,11 +598,61 @@ def test_advance_step_final_post_failure_does_not_break_completion(
     )
 
     # Must NOT raise even though _post_chain_complete blows up.
-    envelopes = orch.advance_step(chain_id, "atlas_safety", "atom-atlas")
+    envelopes = asyncio.run(orch._advance_step_async(chain_id, "atlas_safety", "atom-atlas"))
 
     assert envelopes == []  # no further dispatch on complete
     state = json.loads(state_file.read_text())
     assert state[chain_id]["current_step"] == "complete"  # state still saved
+    # complete_posted flag set BEFORE the raise, so a retry won't double-post.
+    assert state[chain_id].get("complete_posted") is True
+
+
+def test_advance_step_async_idempotent_post_on_repeated_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Race-safety: calling _advance_step_async twice on a chain whose state
+    already says complete (e.g. a re-delivered NATS message) must NOT post
+    twice. The complete_posted flag in chain state is the de-dup guard.
+    Anchors the triplicate-#ceo-post race fix (Elliot 2026-05-30).
+    """
+    import asyncio
+
+    _capture_publishes(monkeypatch)
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+
+    posts: list = []
+    monkeypatch.setattr(orch, "_post_chain_complete", lambda entry, cid: posts.append((entry, cid)))
+
+    chain_id = "chain-idempotent"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": "t-idem",
+            "brief": "idempotent",
+            "started_ts": 0.0,
+            "current_step": "atlas_safety",
+            "steps_done": ["aiden_plan", "max_challenge", "nova_build", "orion_spec"],
+            "atom_ids": {
+                "aiden_plan": "a1",
+                "max_challenge": "a2",
+                "nova_build": "a3",
+                "orion_spec": "a4",
+            },
+            "pending": ["atlas_safety"],
+        },
+    )
+
+    async def two_calls():
+        await orch._advance_step_async(chain_id, "atlas_safety", "atom-atlas")
+        # Second call on already-complete state — must NOT post again.
+        await orch._advance_step_async(chain_id, "atlas_safety", "atom-atlas")
+
+    asyncio.run(two_calls())
+
+    assert len(posts) == 1  # exactly one post despite two async invocations
 
 
 def test_advance_step_async_consumer_path_fires_post_chain_complete(


### PR DESCRIPTION
## Summary
Triplicate 'Chain complete' posts in #ceo on chain end. Elliot diagnosis 2026-05-30: `advance_step` runs via `asyncio.to_thread` (thread pool). Multiple threads concurrently enter the `all_parallel_covered` check before any saves state. Each sees `current_step != 'complete'` and all fire `_post_chain_complete` independently.

## Fix
Move the post out of `advance_step` (thread-pool path) and into `_advance_step_async` (event-loop path) with a `complete_posted` state-file flag. Event loop is single-threaded → load-check-write is atomic within one consumer process.

### `advance_step()` chain-complete branch
No longer calls `_post_chain_complete`. Just sets `current_step='complete'`, `pending=[]`. Comment explains the why + where the post moved to.

### `_advance_step_async()`
After `to_thread` returns, re-loads state, checks `current_step == 'complete' AND not complete_posted`. If passes: flip `complete_posted=True`, save state, fire `_post_chain_complete`. Fail-open try/except identical to the prior guard.

## Live verification
Three chains dispatched against the live dispatcher with progressively cleaner consumer environments:

| chain_id | posts in #ceo | environment |
|----------|---------------|-------------|
| race-fix-verify | 3 | orphaned PR #1357 standalone consumer + in-dispatcher consumer (cross-process race) |
| race-fix-verify-2 | 2 | `systemctl stop` of PR #1357 service — reported inactive but underlying Python process did not exit (zombie) |
| race-fix-verify-3 | **1** | `kill -9` of the zombie. Single in-dispatcher consumer. ✓ |

Chain state on the final run: `complete_posted: True`. Exactly one Slack message at ts `1780138730.627529`.

## Operational finding for Elliot
The standalone systemd consumer from PR #1357 is **redundant** with the dispatcher's in-process consumer (lifespan task at `src/dispatcher/main.py:646`). Two consumers subscribing to `keiracom.agent.handoff` create a cross-process race that no intra-process serialisation can prevent.

Recommend one of:
- **(a)** Remove PR #1357 service entirely (cleanest — duplicate work + cross-process race).
- **(b)** Fix the systemctl-stop signal handling so the standalone process actually exits on SIGTERM (currently SIGTERM is ignored or async-blocked).

This PR fixes the intra-process race. Multi-consumer duplicates need (a) or (b) separately.

## Tests
- `test_advance_step_async_final_post_fires_on_chain_complete` (renamed; drives through `_advance_step_async`)
- `test_advance_step_sync_path_does_not_post` — NEW. Sync `advance_step` is silent on chain-complete.
- `test_advance_step_async_final_post_failure_does_not_break_completion` (renamed; targets async-wrapper guard).
- `test_advance_step_async_idempotent_post_on_repeated_completion` — NEW. Calls async twice on already-complete chain; asserts exactly one post.
- Existing tests pass unchanged.

29/29 chain tests pass. `ruff format --check` + `ruff check` clean.

## Scope
- `src/keiracom_system/chain/v1_chain_orchestrator.py`: +30 / -16.
- `tests/keiracom_system/chain/test_v1_chain_orchestrator.py`: +125 / -16 (test refactors + 2 new tests).

## Author + reviewers
Author=atlas → Elliot + Max eligible reviewers per author-exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)