### PR TITLE
[ATLAS] fix(v1-battery): extract cache tokens from Anthropic usage + bump /spawn timeout to 35s

### DIFF
--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -337,7 +337,12 @@ def _publish_envelope(envelope: dict, role: str) -> bool:
         req = urllib.request.Request(
             url, data=payload, headers={"Content-Type": "application/json"}, method="POST"
         )
-        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 — fixed loopback host
+        # 35s client timeout to accommodate dispatcher's async ceiling queue
+        # (PR #1361 — slot wait up to DISPATCHER_QUEUE_TIMEOUT_S default 300s).
+        # 35s = enough to clear one slot-wait cycle; client times out before
+        # the dispatcher's 300s ceiling timeout, so spurious queue timeouts
+        # don't masquerade as transport failures.
+        with urllib.request.urlopen(req, timeout=35) as resp:  # noqa: S310 — fixed loopback host
             status = resp.status
         log.info("v1_chain: /dispatcher/spawn role=%s key=%s status=%d", role, body["key"], status)
         return 200 <= status < 300

--- a/src/keiracom_system/vault/api_agent_cold_start.py
+++ b/src/keiracom_system/vault/api_agent_cold_start.py
@@ -193,6 +193,8 @@ def insert_attribution(
     cost_usd: float,
     cost_aud: float,
     latency_ms: float,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
     rate_limit_retries: int = 0,
     completion_status: str = "success",
     conn: Any = None,
@@ -224,8 +226,8 @@ def insert_attribution(
                     _MODEL,
                     int(input_tokens),
                     int(output_tokens),
-                    0,
-                    0,
+                    int(cache_read_tokens),
+                    int(cache_write_tokens),
                     cost_usd,
                     cost_aud,
                     latency_ms,
@@ -348,7 +350,7 @@ def call_anthropic(
     task_id: str = "",
     callsign: str = "",
     persona_token_count: int = 0,
-) -> tuple[str, int, int, int]:
+) -> tuple[str, int, int, int, int, int]:
     """Anthropic messages.create with 429/529 retry. Returns (text, in_tok, out_tok, retries).
 
     V1-battery Gate 2 (Elliot dispatch 2026-05-30 ~11:35 AEST): retry on
@@ -379,10 +381,18 @@ def call_anthropic(
                 messages=[{"role": "user", "content": brief}],
             )
             text = response.content[0].text if response.content else ""
+            # Anthropic SDK exposes cache tokens on usage when prompt caching
+            # is engaged (docs.anthropic.com/.../prompt-caching). Older SDK
+            # versions / non-caching responses omit these fields → getattr
+            # default 0. `or 0` covers an explicit None some SDK paths return.
+            cache_write_tokens = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            cache_read_tokens = getattr(response.usage, "cache_read_input_tokens", 0) or 0
             return (
                 text,
                 int(response.usage.input_tokens),
                 int(response.usage.output_tokens),
+                int(cache_read_tokens),
+                int(cache_write_tokens),
                 retries,
             )
         except anthropic.APIStatusError as exc:
@@ -454,7 +464,14 @@ def run() -> int:
 
     spawned_at = time.time()
     try:
-        text, input_tokens, output_tokens, rate_limit_retries = call_anthropic(
+        (
+            text,
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_write_tokens,
+            rate_limit_retries,
+        ) = call_anthropic(
             api_key,
             persona,
             brief,
@@ -482,15 +499,19 @@ def run() -> int:
         cost_usd=cost_usd,
         cost_aud=cost_aud,
         latency_ms=latency_ms,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
         rate_limit_retries=rate_limit_retries,
     )
 
     logger.info(
-        "api_agent_cold_start: callsign=%s chain_step=%s in=%d out=%d cost_usd=%.6f cost_aud=%.6f latency_ms=%.1f",
+        "api_agent_cold_start: callsign=%s chain_step=%s in=%d out=%d cache_r=%d cache_w=%d cost_usd=%.6f cost_aud=%.6f latency_ms=%.1f",
         callsign,
         chain_step,
         input_tokens,
         output_tokens,
+        cache_read_tokens,
+        cache_write_tokens,
         cost_usd,
         cost_aud,
         latency_ms,

--- a/tests/keiracom_system/vault/test_api_agent_cold_start.py
+++ b/tests/keiracom_system/vault/test_api_agent_cold_start.py
@@ -259,9 +259,11 @@ def test_call_anthropic_passes_model_system_brief_and_returns_text_tokens(
     fake_anthropic.Anthropic = _FakeClient
     monkeypatch.setitem(sys.modules, "anthropic", fake_anthropic)
 
-    text, in_t, out_t, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    text, in_t, out_t, cache_r, cache_w, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
 
     assert text == "Atlas safety-review verdict: looks OK."
+    # Cache fields absent on the fake usage → getattr defaults to 0.
+    assert cache_r == 0 and cache_w == 0
     assert in_t == 42 and out_t == 137
     assert retries == 0  # happy path → no rate-limit retries
     assert captured["api_key"] == "KEY"
@@ -270,6 +272,69 @@ def test_call_anthropic_passes_model_system_brief_and_returns_text_tokens(
     assert kw["max_tokens"] == aacs._MAX_TOKENS
     assert kw["system"] == "SYS"
     assert kw["messages"] == [{"role": "user", "content": "BRIEF"}]
+
+
+def test_call_anthropic_extracts_cache_tokens_from_usage(monkeypatch: pytest.MonkeyPatch):
+    """When the Anthropic response.usage exposes cache_creation_input_tokens +
+    cache_read_input_tokens, call_anthropic returns them positionally (5th + 4th
+    slots of the return tuple). This is the V1-battery cache-attribution fix —
+    previously these were dropped, so cache_hit_pct showed 0% in the harness.
+    """
+
+    class _FakeUsage:
+        input_tokens = 11
+        output_tokens = 22
+        cache_creation_input_tokens = 2544
+        cache_read_input_tokens = 1024
+
+    class _FakeContent:
+        def __init__(self, text):
+            self.text = text
+
+    class _FakeResponse:
+        content = [_FakeContent("ok")]
+        usage = _FakeUsage()
+
+    class _FakeClient:
+        def __init__(self, *, api_key):
+            self.messages = self
+
+        def create(self, **_kwargs):
+            return _FakeResponse()
+
+    fake_anthropic = types.ModuleType("anthropic")
+    fake_anthropic.Anthropic = _FakeClient
+    monkeypatch.setitem(sys.modules, "anthropic", fake_anthropic)
+
+    text, in_t, out_t, cache_r, cache_w, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    assert text == "ok"
+    assert in_t == 11 and out_t == 22
+    assert cache_r == 1024
+    assert cache_w == 2544
+    assert retries == 0
+
+
+def test_insert_attribution_writes_cache_token_columns():
+    """V1-battery fix — cache_read_tokens + cache_write_tokens kwargs land in
+    the INSERT params (no longer hardcoded zeros)."""
+    conn, cur = _fake_conn()
+    aacs.insert_attribution(
+        callsign="aiden",
+        chain_id="c-cache",
+        task_id="t-cache",
+        chain_step="aiden_plan",
+        input_tokens=11,
+        output_tokens=22,
+        cost_usd=0.0,
+        cost_aud=0.0,
+        latency_ms=1.0,
+        cache_read_tokens=1024,
+        cache_write_tokens=2544,
+        conn=conn,
+    )
+    params = cur.execute.call_args[0][1]
+    assert 1024 in params
+    assert 2544 in params
 
 
 # ---------------------------------------------------------------------------
@@ -320,7 +385,7 @@ def test_run_happy_path_writes_attribution_and_publishes_handoff(
     _publish_handoff all fire with the right args, and exit code is 0."""
     _seed_env(monkeypatch)
     monkeypatch.setattr(aacs, "fetch_persona", lambda _c: ("ATLAS_PROMPT", 500))
-    monkeypatch.setattr(aacs, "call_anthropic", lambda *_a, **_kw: ("REPLY", 100, 200, 0))
+    monkeypatch.setattr(aacs, "call_anthropic", lambda *_a, **_kw: ("REPLY", 100, 200, 0, 0, 0))
 
     insert_calls: list[dict] = []
 
@@ -377,7 +442,7 @@ def test_run_no_atoms_still_fires_one_empty_handoff(monkeypatch: pytest.MonkeyPa
     atom_id so the chain consumer still advances (no stall)."""
     _seed_env(monkeypatch)
     monkeypatch.setattr(aacs, "fetch_persona", lambda _c: ("PROMPT", 500))
-    monkeypatch.setattr(aacs, "call_anthropic", lambda *_a, **_kw: ("REPLY", 0, 0, 0))
+    monkeypatch.setattr(aacs, "call_anthropic", lambda *_a, **_kw: ("REPLY", 0, 0, 0, 0, 0))
     monkeypatch.setattr(aacs, "insert_attribution", lambda **_kw: None)
 
     async def fake_classify(*_a, **_kw):
@@ -486,7 +551,7 @@ def _install_fake_anthropic_with_statuses(
 def test_call_anthropic_retries_on_429_then_succeeds(monkeypatch: pytest.MonkeyPatch):
     """One 429 then success → returns retries=1, exponential backoff started at 1s."""
     state = _install_fake_anthropic_with_statuses(monkeypatch, [429, None])
-    text, in_t, out_t, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    text, in_t, out_t, cache_r, cache_w, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
     assert text == "OK"
     assert in_t == 10 and out_t == 20
     assert retries == 1
@@ -498,7 +563,7 @@ def test_call_anthropic_retries_on_429_then_succeeds(monkeypatch: pytest.MonkeyP
 def test_call_anthropic_retries_on_529_overloaded(monkeypatch: pytest.MonkeyPatch):
     """529 (overloaded) is in the retriable set — same path as 429."""
     state = _install_fake_anthropic_with_statuses(monkeypatch, [529, 529, None])
-    _, _, _, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    _, _, _, _, _, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
     assert retries == 2
     assert state["attempts"] == 3
     # Exponential: 1s, 2s.
@@ -508,7 +573,7 @@ def test_call_anthropic_retries_on_529_overloaded(monkeypatch: pytest.MonkeyPatc
 def test_call_anthropic_respects_retry_after_header(monkeypatch: pytest.MonkeyPatch):
     """Retry-After: 7 → backoff = 7s (overrides computed exponential)."""
     state = _install_fake_anthropic_with_statuses(monkeypatch, [429, None], retry_after_header="7")
-    _, _, _, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    _, _, _, _, _, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
     assert retries == 1
     assert state["captured_sleeps"] == [pytest.approx(7.0)]
 
@@ -520,7 +585,7 @@ def test_call_anthropic_backoff_caps_at_60s(monkeypatch: pytest.MonkeyPatch):
     # the cap kicks in by patching the base to a large value and re-running.
     monkeypatch.setattr(aacs, "_RATE_LIMIT_BASE_BACKOFF_S", 100.0)
     state = _install_fake_anthropic_with_statuses(monkeypatch, [429, 429, 429, None])
-    _, _, _, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
+    _, _, _, _, _, retries = aacs.call_anthropic("KEY", "SYS", "BRIEF")
     assert retries == 3
     # All 3 backoffs should be capped at 60s.
     assert all(s == pytest.approx(60.0) for s in state["captured_sleeps"])


### PR DESCRIPTION
## Summary
Two related V1-battery fixes in one PR per Elliot dispatch 2026-05-30.

### FIX A — `cache_read_tokens` + `cache_write_tokens` land in attribution
**Problem:** `cache_hit_pct` shows 0% in the harness even though PR #1363 proved caching engages (Aiden persona 2576 tokens, second call hits cache).

**Root cause:** `api_agent_cold_start.call_anthropic` reads `response.usage.input_tokens` + `.output_tokens` but NEVER reads `.cache_creation_input_tokens` or `.cache_read_input_tokens`. `insert_attribution` gets hardcoded `0, 0` for the two cache columns. Cache attribution silently vanishes.

**Changes in `src/keiracom_system/vault/api_agent_cold_start.py`:**
- `call_anthropic()` extracts both cache fields via `getattr(usage, ..., 0) or 0` (back-compat for older SDK / non-caching responses).
- Return tuple expands 4 → 6: `(text, in, out, cache_read, cache_write, retries)`.
- `insert_attribution()` accepts `cache_read_tokens` + `cache_write_tokens` kwargs (default 0); hardcoded `0, 0` in the params tuple replaced.
- `run()` unpacks the 6-tuple and threads cache tokens to attribution.
- Logger format includes `cache_r=%d cache_w=%d`.

### FIX B — `_publish_envelope` HTTP timeout 10s → 35s
**Problem:** Dispatcher spawn queue (PR #1361) waits up to `DISPATCHER_QUEUE_TIMEOUT_S` (default 300s) for a slot. But the orchestrator client at `urllib.request.urlopen(req, timeout=10)` gave up after 10s, returning `False` even though the dispatcher would have honoured the request 25s later. Spurious queue timeouts masquerade as transport failures.

**Change in `src/keiracom_system/chain/v1_chain_orchestrator.py:340`:**
- `urlopen(req, timeout=10)` → `urlopen(req, timeout=35)`. 35s = enough to clear one slot-wait cycle; still well below `DISPATCHER_QUEUE_TIMEOUT_S` so the dispatcher's own ceiling timeout remains authoritative.

## Live verification (Fix A — 2 consecutive aiden calls against the live dispatcher)
```
Call 1: in=11 out=40 cache_r=0    cache_w=2544 cost_aud=0.000981
Call 2: in=3  out=42 cache_r=2544 cache_w=8    cost_aud=0.000990
```

`SELECT cache_read_tokens, cache_write_tokens FROM keiracom_spawn_attribution WHERE task_id='cache-tok-verify-2'`:
```
cache_read_tokens: 2544
cache_write_tokens: 8
```

**Previously both columns would have been 0.**

## Cost-pricing note (out of scope)
`compute_cost()` still uses simple `(in + out)` pricing. Cache write surcharge (1.25× input rate) and cache read discount (0.1× input rate) are NOT yet modelled in `cost_aud`. cost_aud slightly under-reports cache writes / over-reports cache reads. Bounded — follow-up PR.

## Tests
- 59 pass: vault 30 + chain 29 (2 new vault tests + all existing).
- New: `test_call_anthropic_extracts_cache_tokens_from_usage`, `test_insert_attribution_writes_cache_token_columns`.
- `ruff format --check` + `ruff check` clean.

## Scope
- `src/keiracom_system/vault/api_agent_cold_start.py`: +18 / -7.
- `src/keiracom_system/chain/v1_chain_orchestrator.py`: +6 / -1 (timeout + comment).
- `tests/keiracom_system/vault/test_api_agent_cold_start.py`: +75 / -5 (test refactors + 2 new).

## Author + reviewers
Author=atlas → Elliot + Max eligible reviewers per author-exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)