### PR TITLE
[ATLAS] fix(dispatcher): GC completed tmux sessions from _spawned in reaper loop (P0 battery unblock)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -42,7 +42,7 @@ from src.dispatcher.cost_breaker import BreakerDecision, CostBreaker
 from src.dispatcher.idempotency import IdempotencyDecision, IdempotencyGate
 from src.dispatcher.interceptor_proxy import router as interceptor_router
 from src.dispatcher.physical_ceiling import check_physical_ceiling
-from src.dispatcher.reaper import Reaper
+from src.dispatcher.reaper import Reaper, _list_tmux_sessions
 from src.dispatcher.session_manager import Backend, SessionManager
 from src.dispatcher.spend_tracker import get_spend
 from src.dispatcher.tmux_lifecycle import (
@@ -581,6 +581,29 @@ async def _reaper_loop(rp: Reaper) -> None:
             result = rp.sweep()
             if result.total_reaped:
                 logger.info("KEI-213 reaper reaped %d sessions", result.total_reaped)
+            # ── _spawned GC (Elliot 2026-05-30) ──────────────────────────────
+            # Sessions exit naturally (api_agent_cold_start finishes, tmux
+            # closes) but nothing pops them from _spawned. check_physical_ceiling
+            # then sees a stale count and queues new spawns forever. Cross-
+            # reference tmux ls and pop completed entries. Watchdog tracker is
+            # unregistered alongside so /dispatcher/health stays accurate.
+            try:
+                live_sessions = _list_tmux_sessions()
+                if live_sessions is not None:
+                    live_set = set(live_sessions)
+                    dead_keys = [
+                        k
+                        for k, v in list(_spawned.items())
+                        if v.get("backend") == "tmux"
+                        and getattr(v.get("handle"), "session_name", None) not in live_set
+                    ]
+                    for k in dead_keys:
+                        _spawned.pop(k, None)
+                        if _watchdog is not None:
+                            _watchdog.unregister(k)  # safe — pops with default None
+                        logger.info("dispatcher: GC'd completed session key=%s", k)
+            except Exception:  # noqa: BLE001 — GC must not break the reaper loop
+                logger.exception("dispatcher: _spawned GC raised")
             _component_status["reaper"] = "ok"
         except asyncio.CancelledError:
             _component_status["reaper"] = "stopped"

--- a/tests/dispatcher/test_main_spawned_gc.py
+++ b/tests/dispatcher/test_main_spawned_gc.py
@@ -1,0 +1,98 @@
+"""Tests for the _spawned-dict GC inside _reaper_loop (Elliot 2026-05-30).
+
+Without this GC, sessions that exit naturally (api_agent_cold_start finishes,
+tmux closes) remain in _spawned forever. check_physical_ceiling reads
+len(_spawned) and queues new spawns despite the box being idle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.dispatcher import main as dmain
+
+
+def _spawned_entry(session_name: str, backend: str = "tmux") -> dict:
+    handle = MagicMock()
+    handle.session_name = session_name
+    return {"handle": handle, "backend": backend, "tenant_id": None}
+
+
+async def _run_one_reaper_iteration() -> None:
+    """Drive _reaper_loop through exactly one iteration then cancel.
+
+    Patches asyncio.sleep so the iteration runs immediately. The sweep call
+    is patched to a no-op since the GC path doesn't depend on its result.
+    """
+    rp = MagicMock()
+    rp.sweep.return_value = MagicMock(total_reaped=0)
+
+    real_sleep = asyncio.sleep
+
+    iterations = {"n": 0}
+
+    async def fake_sleep(_secs):
+        iterations["n"] += 1
+        if iterations["n"] >= 2:
+            # Allow at least one full body pass before cancelling.
+            raise asyncio.CancelledError
+        await real_sleep(0)
+
+    with patch.object(dmain.asyncio, "sleep", fake_sleep), pytest.raises(asyncio.CancelledError):
+        await dmain._reaper_loop(rp)
+
+
+def test_reaper_gc_removes_completed_tmux_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """tmux session listed live → keep. Not listed → pop + unregister watchdog."""
+    monkeypatch.setattr(dmain, "_spawned", {})
+    dmain._spawned["alive"] = _spawned_entry("disp-alive-session")
+    dmain._spawned["dead"] = _spawned_entry("disp-dead-session")
+
+    fake_watchdog = MagicMock()
+    monkeypatch.setattr(dmain, "_watchdog", fake_watchdog)
+
+    monkeypatch.setattr(
+        dmain, "_list_tmux_sessions", lambda: ["disp-alive-session", "other-system"]
+    )
+
+    asyncio.run(_run_one_reaper_iteration())
+
+    assert "alive" in dmain._spawned
+    assert "dead" not in dmain._spawned
+    fake_watchdog.unregister.assert_called_once_with("dead")
+
+
+def test_reaper_gc_skips_non_tmux_backends(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Container backends are NOT in the tmux ls universe — keep them
+    untouched (their lifecycle is managed by a different path)."""
+    monkeypatch.setattr(dmain, "_spawned", {})
+    dmain._spawned["k-container"] = _spawned_entry("any", backend="docker")
+    dmain._spawned["k-tmux-dead"] = _spawned_entry("disp-dead", backend="tmux")
+
+    monkeypatch.setattr(dmain, "_watchdog", MagicMock())
+    monkeypatch.setattr(dmain, "_list_tmux_sessions", lambda: [])
+
+    asyncio.run(_run_one_reaper_iteration())
+
+    assert "k-container" in dmain._spawned  # untouched
+    assert "k-tmux-dead" not in dmain._spawned  # GC'd
+
+
+def test_reaper_gc_skipped_when_tmux_ls_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_list_tmux_sessions` returning None (transient tmux probe failure) →
+    GC pass skips entirely; no entries removed (fail-safe — don't drop
+    sessions based on a None-signal)."""
+    monkeypatch.setattr(dmain, "_spawned", {})
+    dmain._spawned["k1"] = _spawned_entry("any-session")
+
+    monkeypatch.setattr(dmain, "_watchdog", MagicMock())
+    monkeypatch.setattr(dmain, "_list_tmux_sessions", lambda: None)
+
+    asyncio.run(_run_one_reaper_iteration())
+
+    assert "k1" in dmain._spawned  # preserved on None


### PR DESCRIPTION
## Summary
Sessions that exit naturally (api_agent_cold_start finishes, tmux closes) were NEVER removed from the `_spawned` dict. `check_physical_ceiling` reads `len(_spawned)` — stale count → battery chains queue forever once they breach the ceiling and never recover. P0 per Elliot dispatch 2026-05-30.

Existing cleanup paths only fired on:
- explicit `/dispatcher/terminate` (no caller in the natural-exit path), or
- `bounded_spawn_enforcer`'s `_default_terminate_cb` (only on policy violation).

## Fix (`src/dispatcher/main.py`)
- Imports `_list_tmux_sessions` from `reaper.py`.
- `_reaper_loop` runs a GC pass after `sweep()`: pops `_spawned` entries whose `backend == 'tmux'` AND `handle.session_name` is NOT in `tmux ls`. Unregisters each from the watchdog so `/dispatcher/health` stays accurate.
- Fail-safe: `_list_tmux_sessions` returning `None` (transient probe failure) → skip the GC pass; don't drop entries on a `None` signal.
- Container backends (`backend != 'tmux'`) are skipped — their lifecycle is managed by a different path.

## Tests (`tests/dispatcher/test_main_spawned_gc.py` — NEW)
- `test_reaper_gc_removes_completed_tmux_sessions`: live session kept, dead session popped + `watchdog.unregister` called.
- `test_reaper_gc_skips_non_tmux_backends`: docker/container entries untouched even when tmux ls is empty.
- `test_reaper_gc_skipped_when_tmux_ls_returns_none`: `None` signal → no GC.

3 tests pass. `ruff format --check` + `ruff check` clean.

## Live verification (chain `gc-verify-001`)
```
t+0s   watchdog.tracked=1  step=aiden_plan
t+6s   watchdog.tracked=2  step=max_challenge
t+12s  watchdog.tracked=3  step=nova_build
t+18s  watchdog.tracked=5  step=orion_spec (parallel fan-out)
t+27s  watchdog.tracked=5  step=complete
t+0s post-complete  watchdog.tracked=0  ← GC dropped to 0
```

Count climbed `0→5` during chain, dropped to `0` at the first reaper sweep post-completion. Battery can now run consecutive chains without permanently exhausting the physical ceiling.

## Scope
- `src/dispatcher/main.py`: +24 / -1 (`_list_tmux_sessions` import + GC block in `_reaper_loop`).
- `tests/dispatcher/test_main_spawned_gc.py`: new (99 lines, 3 tests).

## Author + reviewers
Author=atlas → Elliot + Max eligible reviewers per author-exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)