### PR TITLE
[SCOUT] fix(harness): poll for dispatcher session before crash-injection (Elliot diag 2026-05-30)

### DIFF
--- a/scripts/v1_battery_harness.py
+++ b/scripts/v1_battery_harness.py
@@ -288,6 +288,39 @@ def wait_for_chain_complete(chain_id: str, timeout_s: int) -> dict:
 # ─── crash injection (Agency_OS-avii test case) ───────────────────────────────
 
 
+def _wait_for_hop_session(chain_id: str, hop_step: str, timeout_s: int = 60) -> bool:
+    """Poll until the dispatcher tmux session `disp-chain-{chain_id}-{hop_step}`
+    actually exists, then return True. Returns False on timeout.
+
+    Replaces the prior fixed `time.sleep(15)` before inject_crash. Spawn overhead
+    is 20-25 s (Python cold start + first API call), so the 15 s sleep always
+    landed either pre-spawn (no session yet) or post-complete (session gone) —
+    a live mid-hop kill never landed. Elliot diagnosed 2026-05-30.
+
+    Uses time.monotonic() — pure intra-function deadline loop (the Max HOLD on
+    #1351 said monotonic is correct for intra-process duration, only the
+    cross-domain comparisons need wall-clock).
+    """
+    session_name = f"disp-chain-{chain_id}-{hop_step}"
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                ["tmux", "has-session", "-t", session_name],
+                capture_output=True,
+                timeout=3,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            # tmux subprocess hiccup — keep polling; the next iteration retries.
+            time.sleep(0.5)
+            continue
+        if result.returncode == 0:
+            return True
+        time.sleep(0.5)
+    return False
+
+
 def inject_crash(hop_step: str, chain_id: str) -> tuple[bool, str]:
     """tmux kill-session for the DISPATCHER-spawned chain-hop session.
 
@@ -551,9 +584,20 @@ def execute_run(plan: dict) -> RunResult:
     crash_hop = plan.get("crash_hop")
     crash_note = None
     if crash_hop:
-        # Allow the chain to step into the target role briefly before killing.
-        time.sleep(15)
-        ok, msg = inject_crash(crash_hop, chain_id)
+        # Wait until the dispatcher tmux session for this hop actually appears,
+        # then kill it. Fixed `time.sleep(15)` was wrong: spawn overhead is 20-25s
+        # (Python cold start + first API call), so the kill always landed either
+        # pre-spawn or post-complete — a live mid-hop kill never landed. Poll
+        # via tmux has-session (≤90s) so the kill catches the target alive.
+        # Elliot diagnosed 2026-05-30.
+        found = _wait_for_hop_session(chain_id, crash_hop, timeout_s=90)
+        if found:
+            ok, msg = inject_crash(crash_hop, chain_id)
+        else:
+            ok, msg = (
+                False,
+                f"session disp-chain-{chain_id}-{crash_hop} never appeared within 90s",
+            )
         crash_note = f"crash@{crash_hop}: {'OK' if ok else 'FAILED'} — {msg}"
         print(f"  {crash_note}", file=sys.stderr)
     # Wait for completion (or timeout).


### PR DESCRIPTION
## Problem
`scripts/v1_battery_harness.py` injected crashes via `time.sleep(15)` then `inject_crash(crash_hop, chain_id)`. Spawn overhead is 20-25s (Python cold start + first API call), so the 15s sleep always landed either pre-spawn (no dispatcher session yet) or post-complete (session already gone). **A live mid-hop kill never landed** — every crash test hit "already exited" / "no such session". The Agency_OS-avii crash-recovery scenario the harness is meant to exercise wasn't actually being exercised.

## Fix
Replace the fixed sleep with a poll on `tmux has-session -t disp-chain-{chain_id}-{hop_step}` (90s timeout) so the kill catches the target alive.

### Added helper (just above `inject_crash`)
```python
def _wait_for_hop_session(chain_id: str, hop_step: str, timeout_s: int = 60) -> bool:
    """Poll until the dispatcher tmux session `disp-chain-{chain_id}-{hop_step}`
    actually exists, then return True. Returns False on timeout."""
    session_name = f"disp-chain-{chain_id}-{hop_step}"
    deadline = time.monotonic() + timeout_s
    while time.monotonic() < deadline:
        try:
            result = subprocess.run(
                ["tmux", "has-session", "-t", session_name],
                capture_output=True, timeout=3, check=False,
            )
        except (subprocess.TimeoutExpired, OSError):
            time.sleep(0.5); continue   # tmux hiccup → keep polling
        if result.returncode == 0:
            return True
        time.sleep(0.5)
    return False
```

Pure intra-function deadline loop on `time.monotonic()` (per Max's intra-process-uses-monotonic guidance from the #1351 HOLD).

### Changed `execute_run` block
```python
if crash_hop:
    # Poll-then-inject (was: time.sleep(15); inject_crash)
    found = _wait_for_hop_session(chain_id, crash_hop, timeout_s=90)
    if found:
        ok, msg = inject_crash(crash_hop, chain_id)
    else:
        ok, msg = (False, f"session disp-chain-{chain_id}-{crash_hop} never appeared within 90s")
    crash_note = f"crash@{crash_hop}: {'OK' if ok else 'FAILED'} — {msg}"
    print(f"  {crash_note}", file=sys.stderr)
```

Surgical fix per Elliot's diagnosis. No other refactors. Signatures unchanged.

## Verification (no API calls / no chain dispatch)
- `python3 -m py_compile scripts/v1_battery_harness.py` → clean
- `python3 -m ruff check scripts/v1_battery_harness.py` → All checks passed!
- `python3 -m ruff format --check scripts/v1_battery_harness.py` → already formatted
- `python3 -c "from scripts.v1_battery_harness import _wait_for_hop_session, inject_crash"` → OK; signatures verified:
  - `_wait_for_hop_session (chain_id: str, hop_step: str, timeout_s: int = 60) -> bool`
  - `inject_crash (hop_step: str, chain_id: str) -> tuple[bool, str]`
- `python3 scripts/v1_battery_harness.py --dry-run` → pre-flight only; API-not-Max gate correctly fails; no chain dispatch

## Scope
One file, two surgical edits (+helper added above its caller; +execute_run block swap). No signature changes to any pre-existing function, no other refactors.

🤖 [SCOUT] research/diagnosis clone