### PR TITLE
[ATLAS] fix(test): scrubbed-tmux test invariants — reflect V1-battery carve-out + cutover (Agency_OS-qhad)

### DIFF
--- a/tests/dispatcher/test_main_scrubbed_tmux.py
+++ b/tests/dispatcher/test_main_scrubbed_tmux.py
@@ -11,11 +11,23 @@ import src.dispatcher.main as main_mod
 
 
 def test_scrub_exposes_only_bootstrap_and_operational_not_creds(monkeypatch):
+    """Scrub must still suppress arbitrary credentials inherited from the env.
+
+    V1-battery carve-out (PR #1358 ANTHROPIC_API_KEY, PR #1359 DATABASE_URL +
+    SUPABASE_DB_DSN, Elliot 2026-05-30): those three vars are now in
+    _TMUX_OPERATIONAL_PASSTHROUGH and DO appear in the spawn command until
+    api_agent_cold_start migrates to vault-resolved creds. The original
+    "no DATABASE_URL / no ANTHROPIC_API_KEY" invariant is therefore stale —
+    this test now asserts the scrub still suppresses credentials that are
+    NOT in the carve-out (using SLACK_BOT_TOKEN as the representative —
+    arbitrary non-whitelisted cred), and that the three carve-outs are
+    intentionally present.
+    """
     monkeypatch.setenv("VAULT_ADDR", "https://v:8200")
     monkeypatch.setenv("VAULT_TOKEN", "tok")
     monkeypatch.setenv("PATH", "/usr/bin")
-    monkeypatch.setenv("DATABASE_URL", "postgresql://should-be-scrubbed")
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-be-scrubbed")
+    # Non-whitelisted credential — MUST remain scrubbed.
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-should-be-scrubbed")
 
     out = main_mod._tmux_spawn_kwargs("k9", {"callsign": "atlas", "env": {"PRIOR_CONTEXT": "ctx"}})
     cmd = out["command"]
@@ -26,9 +38,9 @@ def test_scrub_exposes_only_bootstrap_and_operational_not_creds(monkeypatch):
     assert "AGENT_CALLSIGN=" in cmd  # task metadata
     assert "PRIOR_CONTEXT=" in cmd  # recall block preserved through the scrub
     assert "sh -c" in cmd  # runs the agent command without sourcing a profile
-    # THE P10 INVARIANT: credentials are NOT exposed to the agent process.
-    assert "DATABASE_URL" not in cmd
-    assert "ANTHROPIC_API_KEY" not in cmd
+    # THE P10 INVARIANT (narrowed): non-whitelisted credentials remain scrubbed.
+    assert "SLACK_BOT_TOKEN" not in cmd
+    assert "xoxb-should-be-scrubbed" not in cmd
 
 
 def test_session_name_and_workdir_default_from_key_and_config():
@@ -44,7 +56,58 @@ def test_explicit_command_is_wrapped():
     assert out["command"].startswith("env -i ")
 
 
-def test_scrub_gated_off_by_default():
-    # Rollout phase 1: tmux spawns are NOT scrubbed unless explicitly enabled, so
-    # existing (non-ephemeral) tmux callers are unchanged.
+def test_scrub_v1_battery_carve_outs_pass_through(monkeypatch):
+    """Lock the V1-battery carve-out: ANTHROPIC_API_KEY (PR #1358) +
+    DATABASE_URL + SUPABASE_DB_DSN (PR #1359) intentionally pass through
+    the scrub so api_agent_cold_start can read them at spawn time.
+
+    If these stop passing through, the V1 chain breaks (Anthropic SDK loses
+    its key; attribution INSERT loses its DSN). Hence this is a behaviour
+    invariant, not a leak — the same env vars that the prior test was
+    asserting absent are now asserted present, with a TODO to revisit when
+    vault cred resolution lands in api_agent_cold_start.
+    """
+    monkeypatch.setenv("VAULT_ADDR", "https://v:8200")
+    monkeypatch.setenv("VAULT_TOKEN", "tok")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-aud-carve-out")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://carve-out-dsn")
+    monkeypatch.setenv("SUPABASE_DB_DSN", "postgresql://carve-out-supa")
+
+    out = main_mod._tmux_spawn_kwargs("k", {"callsign": "atlas"})
+    cmd = out["command"]
+    assert "ANTHROPIC_API_KEY=" in cmd
+    assert "DATABASE_URL=" in cmd
+    assert "SUPABASE_DB_DSN=" in cmd
+
+
+def test_scrub_flag_reflects_dispatcher_tmux_scrub_enabled_env(monkeypatch):
+    """`tmux_scrub_enabled` is evaluated from `DISPATCHER_TMUX_SCRUB_ENABLED`
+    at module import time. The literal default is False (unset env) — and the
+    Phase-1 cutover has since flipped the env to `true` in production, so
+    this test exercises the parsing logic via a reload rather than asserting
+    a fixed value (the original "gated off by default" assertion went stale
+    once the cutover landed).
+    """
+    import importlib
+
+    # Capture the original value so we restore module state after the test.
+    original = main_mod.tmux_scrub_enabled
+
+    monkeypatch.delenv("DISPATCHER_TMUX_SCRUB_ENABLED", raising=False)
+    importlib.reload(main_mod)
     assert main_mod.tmux_scrub_enabled is False
+
+    monkeypatch.setenv("DISPATCHER_TMUX_SCRUB_ENABLED", "true")
+    importlib.reload(main_mod)
+    assert main_mod.tmux_scrub_enabled is True
+
+    monkeypatch.setenv("DISPATCHER_TMUX_SCRUB_ENABLED", "garbage")
+    importlib.reload(main_mod)
+    assert main_mod.tmux_scrub_enabled is False  # only 1/true/yes count
+
+    # Leave the module reflecting the originally-loaded state.
+    if original:
+        monkeypatch.setenv("DISPATCHER_TMUX_SCRUB_ENABLED", "true")
+    else:
+        monkeypatch.delenv("DISPATCHER_TMUX_SCRUB_ENABLED", raising=False)
+    importlib.reload(main_mod)


### PR DESCRIPTION
## Summary
Two tests in `tests/dispatcher/test_main_scrubbed_tmux.py` have been failing on main, causing CI noise that lets real regressions hide. Per Elliot dispatch 2026-05-30 (qhad). Test-only fix — no source changes.

## Failure 1 — `test_scrub_exposes_only_bootstrap_and_operational_not_creds`
Asserted `DATABASE_URL not in cmd` and `ANTHROPIC_API_KEY not in cmd`.

**Stale:** PRs #1358 (ANTHROPIC_API_KEY) and #1359 (DATABASE_URL + SUPABASE_DB_DSN) deliberately added those three vars to `_TMUX_OPERATIONAL_PASSTHROUGH` as documented V1-battery carve-outs — they DO appear in the spawn command until `api_agent_cold_start` migrates to vault-resolved creds.

**Fix:** narrow the assertion. The scrub still suppresses arbitrary non-whitelisted credentials; uses `SLACK_BOT_TOKEN` as the representative cred that must remain scrubbed. Docstring documents the carve-out + the migration TODO.

New companion test `test_scrub_v1_battery_carve_outs_pass_through` locks in the positive invariant — the three carve-out vars DO pass through. Any future removal (good — once vault resolution lands) turns this red and forces a synchronised update.

## Failure 2 — `test_scrub_gated_off_by_default`
Asserted `main_mod.tmux_scrub_enabled is False`.

**Stale:** `.env` carries `DISPATCHER_TMUX_SCRUB_ENABLED=true` (Phase-1 cutover landed). The flag is evaluated from env at module import time, so any environment sourcing `.env` (including CI) sees True.

**Fix:** renamed to `test_scrub_flag_reflects_dispatcher_tmux_scrub_enabled_env`; exercises the parsing via `importlib.reload` — unset → False, `"true"` → True, `"garbage"` → False. Restores original module state at the end so no downstream test sees a half-reloaded `main_mod`.

## Raw pytest output (post-fix)
```
tests/dispatcher/test_main_scrubbed_tmux.py::test_scrub_exposes_only_bootstrap_and_operational_not_creds PASSED [ 20%]
tests/dispatcher/test_main_scrubbed_tmux.py::test_session_name_and_workdir_default_from_key_and_config    PASSED [ 40%]
tests/dispatcher/test_main_scrubbed_tmux.py::test_explicit_command_is_wrapped                              PASSED [ 60%]
tests/dispatcher/test_main_scrubbed_tmux.py::test_scrub_v1_battery_carve_outs_pass_through                 PASSED [ 80%]
tests/dispatcher/test_main_scrubbed_tmux.py::test_scrub_flag_reflects_dispatcher_tmux_scrub_enabled_env    PASSED [100%]

5 passed in 0.57s
```

`ruff format --check` + `ruff check` clean.

## Scope
- `tests/dispatcher/test_main_scrubbed_tmux.py`: +71 / -8.
- No source code changes.

## Author + reviewers
Author=atlas → Elliot + Max eligible reviewers per author-exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)