### PR TITLE
[ORION] feat(v1-chain): durable chain-complete dedup ledger (Agency_OS-wdcw)

### DIFF
--- a/src/dispatcher/main.py
+++ b/src/dispatcher/main.py
@@ -1188,13 +1188,74 @@ def _lookup_chain_cost_aud(task_id: str) -> float | None:
         return None
 
 
+def _chain_complete_already_posted(chain_id: str) -> bool:
+    """Agency_OS-wdcw — durable dedup via public.keiracom_chain_complete_posted.
+
+    Atomic INSERT ON CONFLICT DO NOTHING RETURNING chain_id. If RETURNING is
+    populated, this process won the insert lock → first post, proceed with the
+    Slack relay. If RETURNING is empty, another process / a prior run already
+    claimed → SKIP the Slack relay.
+
+    Survives dispatcher restart + NATS redeliver (replaces an in-process
+    state-file flag that was lost on restart and caused dup #ceo posts).
+    Lives in the dispatcher (not the orchestrator) per boundary_matrix_v1:
+    src/keiracom_system/ is MAL-scoped — direct psycopg is forbidden there;
+    src/dispatcher/ is the supabase-layer caller and exempt.
+
+    Fail-open: DSN unset / DB unreachable / any error → returns False so the
+    caller proceeds with the post. Posting once-too-often beats silently
+    dropping Dave's final chain-complete signal.
+    """
+    dsn = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL") or ""
+    if not dsn:
+        return False
+    # Strip SQLAlchemy +asyncpg suffix (same pattern as fleet_supervisor KEI-218).
+    dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+    try:
+        import psycopg  # noqa: PLC0415 — lazy; dispatcher psycopg is fine (control_plane scope)
+
+        with (
+            psycopg.connect(dsn, connect_timeout=5, prepare_threshold=None) as conn,
+            conn.cursor() as cur,
+        ):
+            cur.execute(
+                "INSERT INTO public.keiracom_chain_complete_posted (chain_id) "
+                "VALUES (%s) ON CONFLICT (chain_id) DO NOTHING "
+                "RETURNING chain_id",
+                (chain_id,),
+            )
+            row = cur.fetchone()
+            conn.commit()
+        # RETURNING populated → we inserted (first post). RETURNING empty →
+        # already-existed conflict → already posted, caller skips Slack.
+        return row is None
+    except Exception as exc:  # noqa: BLE001 — fail-open: posting once-too-often beats never posting
+        logger.warning(
+            "chain_complete dedup DB check failed for chain=%s (posting anyway): %s",
+            chain_id,
+            exc,
+        )
+        return False
+
+
 @app.post("/dispatcher/chain_complete")
 async def dispatcher_chain_complete(req: ChainCompleteRequest) -> dict[str, Any]:
     """Post the V1-chain completion summary to #ceo via slack_relay (Elliot's relay).
 
-    Fail-open: any error (slack_relay, cost-lookup, formatting) is logged and
-    swallowed — a notification failure must never block the chain lifecycle.
+    Receiver-side dedup (Agency_OS-wdcw): consults a Supabase ledger before
+    relaying to Slack. Catches dup sources from anywhere — NATS redeliver,
+    dispatcher restart, manual retry. Survives dispatcher restart.
+
+    Fail-open: any error (slack_relay, cost-lookup, formatting, dedup) is
+    logged and swallowed — a notification failure must never block the chain
+    lifecycle.
     """
+    if _chain_complete_already_posted(req.chain_id):
+        logger.info(
+            "chain_complete dedup: chain=%s already posted (ledger hit) — skipping Slack relay",
+            req.chain_id,
+        )
+        return {"notified": False, "reason": "deduped_already_posted"}
     steps_str = (
         " → ".join(req.steps)
         if req.steps

--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -209,6 +209,14 @@ def _post_chain_complete(
     fired by the orchestrator and centralised in the dispatcher (cost lookup,
     multi-line formatting, Slack relay). Module-level so tests can monkeypatch.
 
+    Dedup (Agency_OS-wdcw) is RECEIVER-SIDE — the dispatcher's
+    /dispatcher/chain_complete endpoint consults a Supabase ledger
+    (keiracom_chain_complete_posted) and skips the Slack relay when this
+    chain_id was already posted. Receiver-side placement catches dup sources
+    from anywhere (NATS redeliver, dispatcher restart, manual retry) AND keeps
+    psycopg out of src/keiracom_system/ per boundary_matrix_v1 (the orchestrator
+    is in the MAL-scoped tree; the dispatcher is the supabase-layer caller).
+
     Fail-open: any error logged + swallowed — a notify failure must NEVER block
     advance_step or the state save.
     """

--- a/supabase/migrations/20260530_keiracom_chain_complete_posted.sql
+++ b/supabase/migrations/20260530_keiracom_chain_complete_posted.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- 20260530_keiracom_chain_complete_posted.sql
+--
+-- Durable dedup ledger for v1_chain_orchestrator chain-complete posts.
+-- Replaces an in-process flag (lost on dispatcher restart) that allowed a
+-- triplicate / duplicate #ceo post on NATS redeliver after restart.
+--
+-- task: Agency_OS-wdcw (Pre-Phase-1 hygiene, Dave-authorised).
+--
+-- USAGE
+--   The orchestrator's _post_chain_complete attempts INSERT ON CONFLICT DO
+--   NOTHING RETURNING chain_id. If RETURNING returns the row, this is the
+--   FIRST post for the chain — proceed with the HTTP POST to
+--   /dispatcher/chain_complete. If RETURNING is empty, a concurrent / prior
+--   process already claimed → SKIP the HTTP POST. Atomic by Postgres MVCC,
+--   correct under restart + concurrent consumers.
+--
+-- KEI-87 convention: SET LOCAL agency_os.callsign = 'dave' per the
+-- established migration pattern for public-schema DDL.
+-- ============================================================================
+
+SET LOCAL agency_os.callsign = 'dave';
+
+CREATE TABLE IF NOT EXISTS public.keiracom_chain_complete_posted (
+    chain_id   TEXT         PRIMARY KEY,
+    posted_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.keiracom_chain_complete_posted IS
+    'Agency_OS-wdcw — durable dedup ledger for v1_chain_orchestrator chain-'
+    'complete posts. One row per chain_id that has been notified to #ceo. '
+    'Survives dispatcher restart; replaces the in-process complete_posted '
+    'flag (lost on restart, allowed dup posts on NATS redeliver).';

--- a/tests/dispatcher/test_chain_complete_dedup.py
+++ b/tests/dispatcher/test_chain_complete_dedup.py
@@ -1,0 +1,164 @@
+"""Agency_OS-wdcw — durable receiver-side dedup for /dispatcher/chain_complete.
+
+Lives in src/dispatcher/main.py (NOT src/keiracom_system/) so direct psycopg
+is allowed per boundary_matrix_v1 — keiracom_system is MAL-scoped, the
+dispatcher is the supabase-layer caller. Replaces the in-process state-file
+flag that PR #1364 added and was wiped on dispatcher restart.
+
+  _chain_complete_already_posted(chain_id):
+    - DSN unset → False (fail-open: no DB, no dedup gate, post proceeds)
+    - INSERT RETURNING populated → False (we won the insert; first post)
+    - INSERT RETURNING empty (conflict) → True (already posted; skip Slack)
+    - Any DB error → False (fail-open; posting once-too-often beats never posting)
+    - +asyncpg DSN suffix is stripped before connect (KEI-218 pattern)
+
+  dispatcher_chain_complete (the route):
+    - Ledger says "already posted" → no Slack relay, returns deduped reason
+    - Ledger says "first time" → Slack relay fires; subprocess.run reached
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+from src.dispatcher import main as dm
+
+# ---------------------------------------------------------------------------
+# Fake psycopg helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_psycopg(monkeypatch, *, fetchone_return, captured: dict | None = None):
+    """Patch psycopg.connect → a fake conn whose cur.fetchone returns the supplied
+    row. `captured` (if provided) gets {dsn, query, params}."""
+    cap = captured if captured is not None else {}
+
+    @contextmanager
+    def _fake_cursor():
+        cur = MagicMock()
+
+        def _execute(query, params=None):
+            cap["query"] = query
+            cap["params"] = params
+
+        cur.execute.side_effect = _execute
+        cur.fetchone.return_value = fetchone_return
+        yield cur
+
+    @contextmanager
+    def _fake_connect(dsn, **_kw):
+        cap["dsn"] = dsn
+        conn = MagicMock()
+        conn.cursor.side_effect = _fake_cursor
+        conn.commit = MagicMock()
+        yield conn
+
+    fake_module = MagicMock()
+    fake_module.connect.side_effect = _fake_connect
+    monkeypatch.setitem(__import__("sys").modules, "psycopg", fake_module)
+
+
+# ---------------------------------------------------------------------------
+# _chain_complete_already_posted — DSN guard + insert semantics + fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_already_posted_returns_false_when_dsn_unset(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    assert dm._chain_complete_already_posted("c-1") is False
+
+
+def test_already_posted_first_call_returning_row_is_false(monkeypatch):
+    """RETURNING populated → we inserted (first post) → caller proceeds."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    _fake_psycopg(monkeypatch, fetchone_return=("c-2",))
+    assert dm._chain_complete_already_posted("c-2") is False
+
+
+def test_already_posted_conflict_returning_empty_is_true(monkeypatch):
+    """RETURNING None (ON CONFLICT DO NOTHING fired) → already posted → skip."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    _fake_psycopg(monkeypatch, fetchone_return=None)
+    assert dm._chain_complete_already_posted("c-3") is True
+
+
+def test_already_posted_strips_asyncpg_suffix(monkeypatch):
+    """DSN with +asyncpg gets stripped before psycopg connect (KEI-218 pattern)."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@h/db")
+    captured: dict = {}
+    _fake_psycopg(monkeypatch, fetchone_return=("c-4",), captured=captured)
+    dm._chain_complete_already_posted("c-4")
+    assert "+asyncpg" not in captured["dsn"]
+    assert captured["dsn"] == "postgresql://u:p@h/db"
+
+
+def test_already_posted_uses_insert_on_conflict_returning(monkeypatch):
+    """SQL shape pinned: INSERT ... ON CONFLICT DO NOTHING RETURNING chain_id."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    captured: dict = {}
+    _fake_psycopg(monkeypatch, fetchone_return=("c-5",), captured=captured)
+    dm._chain_complete_already_posted("c-5")
+    assert "INSERT INTO public.keiracom_chain_complete_posted" in captured["query"]
+    assert "ON CONFLICT (chain_id) DO NOTHING" in captured["query"]
+    assert "RETURNING chain_id" in captured["query"]
+    assert captured["params"] == ("c-5",)
+
+
+def test_already_posted_fail_open_on_db_error(monkeypatch):
+    """Any psycopg error → returns False (fail-open: caller posts anyway)."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h/db")
+    fake_module = MagicMock()
+    fake_module.connect.side_effect = OSError("db unreachable")
+    monkeypatch.setitem(__import__("sys").modules, "psycopg", fake_module)
+    assert dm._chain_complete_already_posted("c-6") is False
+
+
+# ---------------------------------------------------------------------------
+# dispatcher_chain_complete route — dedup gate wires before Slack relay
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_chain_complete_skips_slack_when_ledger_says_already_posted(monkeypatch):
+    """Ledger hit → no subprocess.run; response carries deduped reason."""
+    monkeypatch.setattr(dm, "_chain_complete_already_posted", lambda _cid: True)
+
+    def explode(*a, **kw):
+        raise AssertionError("subprocess.run must NOT be called when dedup hits")
+
+    monkeypatch.setattr("subprocess.run", explode)
+
+    req = dm.ChainCompleteRequest(task_id="t-7", chain_id="c-7", brief="x", steps=[])
+    resp = asyncio.run(dm.dispatcher_chain_complete(req))
+    assert resp == {"notified": False, "reason": "deduped_already_posted"}
+
+
+def test_dispatcher_chain_complete_fires_slack_when_ledger_says_first_time(monkeypatch):
+    """Ledger says first time (False) → subprocess.run IS called with the relay cmd."""
+    monkeypatch.setattr(dm, "_chain_complete_already_posted", lambda _cid: False)
+    # avoid the cost-lookup hitting Supabase in tests
+    monkeypatch.setattr(dm, "_lookup_chain_cost_aud", lambda _tid: None)
+
+    captured: dict = {}
+
+    def fake_run(cmd, *, capture_output, text, timeout, env):  # noqa: ARG001
+        captured["cmd"] = cmd
+        captured["channel"] = cmd[cmd.index("-c") + 1] if "-c" in cmd else None
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    req = dm.ChainCompleteRequest(
+        task_id="t-8", chain_id="c-8", brief="scaffold auth", steps=["aiden_plan"]
+    )
+    resp = asyncio.run(dm.dispatcher_chain_complete(req))
+    assert resp == {"notified": True}
+    # ceo channel + the chain summary in the message
+    assert captured["channel"] == "ceo"
+    msg = captured["cmd"][-1]
+    assert "Chain complete" in msg and "c-8" in msg and "scaffold auth" in msg


### PR DESCRIPTION
## Problem
PR #1364 (Atlas) eliminated the in-process triplicate but the dedup state still lived in the local `/tmp/v1_chain_state.json`. **If the dispatcher restarts mid-chain (which WILL happen during the trial week), the flag is wiped and NATS redeliver re-posts the chain-complete message to #ceo.**

## Original CI failure (now fixed)
First version of this PR put the dedup helper in `src/keiracom_system/chain/v1_chain_orchestrator.py`. CI's **Boundary Matrix v1 Guard (b)** rejected it: *"Direct DB drivers forbidden outside MAL + control_plane"* — `src/keiracom_system/` is the MAL-scoped tree; only `src/keiracom_system/memory/` + `src/keiracom_system/control_plane/` (and two named exempt files) may import `psycopg`/`asyncpg`.

## Fix — moved dedup to the receiver side
The natural place for the dedup is the **receiver** anyway: `/dispatcher/chain_complete` is the single entry point that every dup source (NATS redeliver, restart, manual retry) flows through. `src/dispatcher/main.py` is **outside** the MAL scope, so direct `psycopg` is allowed there per the guard.

Two-birds-one-stone:
- Architecturally cleaner — receiver-side dedup catches every dup source.
- Boundary Matrix passes — orchestrator stays psycopg-free; dispatcher is the supabase-layer caller.

### Changes
- **Migration** `supabase/migrations/20260530_keiracom_chain_complete_posted.sql` — `public.keiracom_chain_complete_posted` (`chain_id TEXT PRIMARY KEY`, `posted_at TIMESTAMPTZ DEFAULT NOW()`). **Applied to `jatzvazlbusedwsnqxzr`**.
- **`_chain_complete_already_posted(chain_id)` in `src/dispatcher/main.py`** — atomic `INSERT ... ON CONFLICT (chain_id) DO NOTHING RETURNING chain_id`. RETURNING populated → we won the lock (first post); RETURNING empty → conflict → skip. Concurrency-correct under Postgres MVCC; survives dispatcher restart.
- **`/dispatcher/chain_complete`** — consults the ledger BEFORE the Slack relay; returns `{"notified": False, "reason": "deduped_already_posted"}` when ledger hits.
- **`_post_chain_complete` in the orchestrator** — docstring updated to point at the receiver-side dedup; the function itself is back to a clean HTTP POST (no psycopg in keiracom_system).

**Fail-open at every leg**: DSN unset / DB unreachable / any error → returns `False` → caller posts. Posting once-too-often is safer than silently dropping Dave's final chain-complete signal.

### Why Supabase over JetStream msg-id dedup
The chain-complete path is HTTP POST (`urllib → /dispatcher/chain_complete`), not a NATS publish. JetStream msg-id dedup only applies to JetStream-published messages, so it doesn't fit without restructuring. Supabase `INSERT ON CONFLICT` is the minimum-change durable answer.

## Raw CI-relevant output (no self-certified PASS)

**Boundary Matrix guard (the originally-failing check):**
```
$ bash scripts/ci/check_no_direct_db_outside_mal.sh
OK (b): no direct DB drivers outside MAL + control_plane.
```

**ruff + format:**
```
$ ruff check src/dispatcher/main.py src/keiracom_system/chain/v1_chain_orchestrator.py tests/dispatcher/test_chain_complete_dedup.py
All checks passed!

$ ruff format --check src/dispatcher/main.py src/keiracom_system/chain/v1_chain_orchestrator.py tests/dispatcher/test_chain_complete_dedup.py
3 files already formatted
```

**pytest (verbatim):**
```
$ python3 -m pytest tests/dispatcher/test_chain_complete_dedup.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/elliotbot/clawd/Agency_OS-orion
configfile: pytest.ini
plugins: timeout-2.4.0, asyncio-1.3.0, logfire-4.25.0, anyio-4.12.1
timeout: 300.0s
asyncio: mode=Mode.AUTO
collecting ... collected 8 items

tests/dispatcher/test_chain_complete_dedup.py::test_already_posted_returns_false_when_dsn_unset PASSED [ 12%]
tests/dispatcher/test_chain_complete_dedup.py::test_already_posted_first_call_returning_row_is_false PASSED [ 25%]
tests/dispatcher/test_chain_complete_dedup.py::test_already_posted_conflict_returning_empty_is_true PASSED [ 37%]
tests/dispatcher/test_chain_complete_dedup.py::test_already_posted_strips_asyncpg_suffix PASSED [ 50%]
tests/dispatcher/test_chain_complete_dedup.py::test_already_posted_uses_insert_on_conflict_returning PASSED [ 62%]
tests/dispatcher/test_chain_complete_dedup.py::test_already_posted_fail_open_on_db_error PASSED [ 75%]
tests/dispatcher/test_chain_complete_dedup.py::test_dispatcher_chain_complete_skips_slack_when_ledger_says_already_posted PASSED [ 87%]
tests/dispatcher/test_chain_complete_dedup.py::test_dispatcher_chain_complete_fires_slack_when_ledger_says_first_time PASSED [100%]

============================== 8 passed in 0.54s ===============================
```

## Test coverage (8 tests)
| # | Test | Asserts |
|---|---|---|
| 1 | `test_already_posted_returns_false_when_dsn_unset` | No DSN → `False` (fail-open) |
| 2 | `test_already_posted_first_call_returning_row_is_false` | RETURNING populated → `False` (we inserted; post proceeds) |
| 3 | `test_already_posted_conflict_returning_empty_is_true` | RETURNING empty → `True` (conflict; skip) |
| 4 | `test_already_posted_strips_asyncpg_suffix` | `+asyncpg` stripped before `psycopg.connect` |
| 5 | `test_already_posted_uses_insert_on_conflict_returning` | SQL shape pinned to spec |
| 6 | `test_already_posted_fail_open_on_db_error` | `OSError` → `False`, no exception escapes |
| 7 | `test_dispatcher_chain_complete_skips_slack_when_ledger_says_already_posted` | `subprocess.run` NOT called when dedup hits; response = deduped reason |
| 8 | `test_dispatcher_chain_complete_fires_slack_when_ledger_says_first_time` | Slack relay fires to `-c ceo` with the chain summary message |

## Branch HEAD: `49ac9dd52`
🤖 Generated with [Claude Code](https://claude.com/claude-code)