### PR TITLE
[ATLAS] fix(harness): self-inject repo root into sys.path (Agency_OS-8t26)

### DIFF
--- a/scripts/v1_battery_harness.py
+++ b/scripts/v1_battery_harness.py
@@ -247,6 +247,12 @@ def trigger_chain_direct(
 
     Fail-open: any orch.dispatch error → (None, started, error log).
     """
+    # harness invoked as `python3 scripts/…` puts scripts/ on sys.path; insert
+    # repo root so src.* imports resolve without PYTHONPATH=. prefix (required
+    # for CI battery smoke — Agency_OS-8t26).
+    _repo_root = str(Path(__file__).resolve().parents[1])
+    if _repo_root not in sys.path:
+        sys.path.insert(0, _repo_root)
     # Lazy import — keeps the harness's stdlib-only import surface clean so the
     # --dry-run pre-flight loads on CI hosts that don't have the chain module
     # installed.


### PR DESCRIPTION
## Summary
CI battery smoke runs `python3 scripts/v1_battery_harness.py` directly, which puts `scripts/` on `sys.path` but NOT the repo root — so the lazy `from src.keiracom_system.chain import v1_chain_orchestrator` inside `trigger_chain_direct()` fails with `ModuleNotFoundError` unless the caller prefixes `PYTHONPATH=.`. Per Elliot dispatch 2026-05-30: the smoke must not depend on magic invocation.

## Fix
Two-line insert at the top of `trigger_chain_direct()`:

```python
_repo_root = str(Path(__file__).resolve().parents[1])
if _repo_root not in sys.path:
    sys.path.insert(0, _repo_root)
```

`Path` and `sys` already imported at module level — no new imports.

Idempotent: fires once on first call, no-op on subsequent calls via the `if … not in sys.path` guard.

## Verification — raw `--dry-run` output (from `/tmp` cwd, no `PYTHONPATH=`)
```
PRE-FLIGHT (API-not-Max gate):
  ✅ ANTHROPIC_API_KEY: set (108 chars, sk-* form expected)
  ✅ DISPATCHER_AGENT_COMMAND: points at api_agent_cold_start (Anthropic SDK path)
  ✅ dispatcher /health: status=ok, all components ok/green
Dry-run pre-flight passed — battery would proceed.
---python_exit: 0
```

Direct invocation simulating the actual CI failure shape (only `scripts/` on `sys.path`):
```
repo root on sys.path AFTER call: True
trigger_chain_direct returned chain_id: ff703d6c-27d6-49a5-82cd-b0f9ec635466
log: orch.dispatch ok chain_id=ff703d6c-27d6-49a5-82cd-b0f9ec635466 task_id=ff703d6c-27d6-49a5-82cd-b0f9ec635466
```

`ruff format --check` + `ruff check` clean.

## Scope
- `scripts/v1_battery_harness.py`: +6 / -0.

## Author + reviewers
Author=atlas → Elliot + Max eligible reviewers per author-exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)