### PR TITLE
[ORION] fix(watchdog): detect permission-prompt stalls + verify agent task-resume

### DIFF
--- a/scripts/orchestrator/context_watchdog.py
+++ b/scripts/orchestrator/context_watchdog.py
@@ -70,7 +70,14 @@ def is_context_full(pane: str) -> bool:
 
 def is_stuck(pane: str) -> bool:
     indicators = ["Error:", "APIError:", "ConnectionError", "TimeoutError", "Traceback"]
-    return any(s in pane for s in indicators)
+    if any(s in pane for s in indicators):
+        return True
+    # Permission-prompt detection (Dave-identified failure mode 2026-05-30):
+    # tmux pane hung on a Claude permission prompt → silent stall the watchdog
+    # previously could not see. Three independent signals; any one is enough.
+    if "⏵⏵" in pane or "bypass permiss" in pane:
+        return True
+    return "Allow" in pane and "Deny" in pane
 
 
 def load_state() -> dict:
@@ -159,36 +166,79 @@ def wake_idle_elliot(state: dict, now: float) -> dict:
     return state
 
 
-def revive_agent(name: str, target: str, reason: str) -> None:
-    """Revive a non-Elliot stuck/context-full agent."""
+def revive_agent(name: str, target: str, reason: str, last_task: str = "") -> None:
+    """Revive a non-Elliot stuck/context-full agent.
+
+    `last_task` (when Elliot writes state[f"{name}_last_task"] at dispatch
+    time) tells the revived agent EXACTLY what to resume — falls back to
+    `bd ready` when blank.
+    """
     send_pane(target, "/clear", delay=3.0)
-    send_pane(target, (
-        f"REVIVED by watchdog ({reason}). Read IDENTITY.md, "
-        "check bd ready, resume last task. No paid chain runs without approval."
-    ), delay=0.5)
+    if last_task:
+        body = (
+            f"REVIVED by watchdog ({reason}). Last task: {last_task}. "
+            "Read IDENTITY.md, resume that task. "
+            "No paid chain runs without approval."
+        )
+    else:
+        body = (
+            f"REVIVED by watchdog ({reason}). Read IDENTITY.md, "
+            "check bd ready, resume last task. No paid chain runs without approval."
+        )
+    send_pane(target, body, delay=0.5)
     slack_ceo(f"[ELLIOT] Watchdog revived {name} ({reason}).")
 
 
 def check_other_agents(state: dict) -> dict:
-    """Check non-Elliot agents for context-full or stuck."""
-    revived = []
+    """Check non-Elliot agents for context-full or stuck.
+
+    Two-cycle verification for revives (Dave failure mode 2026-05-30):
+      cycle N   : detect → revive → record state[f"{name}_revive_sent"] = now.
+      cycle N+1 : if pane hash CHANGED → revive worked, clear revive_sent.
+                  if pane unchanged AND (now - revive_sent) > WAKE_TIMEOUT_SEC
+                  → escalate to #ceo + reset revive_sent (avoid spam loop).
+                  if pane unchanged AND still within timeout → wait, no re-revive.
+    Mirrors the existing Elliot escalation pattern at the top of main().
+    """
+    now = time.time()
     for name, target in AGENTS.items():
         pane = pane_capture(target)
         if not pane:
             continue
         h = pane_hash(pane)
-        key = f"{name}_last_hash"
+        key_hash = f"{name}_last_hash"
         key_ts = f"{name}_last_change"
-        prev_hash = state.get(key, "")
+        key_revive = f"{name}_revive_sent"
+        prev_hash = state.get(key_hash, "")
         if h != prev_hash:
-            state[key] = h
-            state[key_ts] = time.time()
+            state[key_hash] = h
+            state[key_ts] = now
+            # Pane moved → any prior revive worked; clear the in-flight flag.
+            state[key_revive] = 0
+
+        # Post-revive verification (Fix B). Mirrors Elliot's wake_sent check.
+        revive_sent = state.get(key_revive, 0)
+        if revive_sent and (now - revive_sent) > WAKE_TIMEOUT_SEC:
+            # Expired AND pane hash still unchanged → revive FAILED.
+            if h == state.get(key_hash, ""):
+                slack_ceo(
+                    f"[ELLIOT] Watchdog: {name} revive FAILED — pane unchanged "
+                    f"{WAKE_TIMEOUT_SEC // 60}min after restart. Task work may be lost."
+                )
+                state[key_revive] = 0  # reset to avoid spam loop
+            continue  # don't double-revive in the same cycle
+
+        # Don't re-fire revive while a prior revive is still in-flight.
+        if revive_sent:
+            continue
+
+        last_task = state.get(f"{name}_last_task", "")
         if is_context_full(pane):
-            revive_agent(name, target, "context-full")
-            revived.append(name)
+            revive_agent(name, target, "context-full", last_task=last_task)
+            state[key_revive] = now
         elif is_stuck(pane):
-            revive_agent(name, target, "error-detected")
-            revived.append(name)
+            revive_agent(name, target, "error-detected", last_task=last_task)
+            state[key_revive] = now
     return state
 
 

--- a/scripts/orchestrator/context_watchdog.py
+++ b/scripts/orchestrator/context_watchdog.py
@@ -93,6 +93,29 @@ def save_state(state: dict) -> None:
     WATCHDOG_STATE_FILE.write_text(json.dumps(state))
 
 
+def record_agent_task(name: str, task_summary: str) -> None:
+    """Persist `state[f"{name}_last_task"]` so a subsequent watchdog revive
+    can tell the agent EXACTLY what it was working on (Fix C feed, 2026-05-31).
+
+    Called by dispatch producers (sign_dispatch.py, elliot_polling_loop) right
+    after a dispatch file lands in the agent's inbox. Best-effort: any failure
+    here is silent — losing the breadcrumb degrades to the `bd ready` fallback
+    in revive_agent(), it does NOT block the dispatch itself.
+
+    The summary is squashed to a single line and capped at 240 chars to fit a
+    `tmux send-keys` line without wrapping.
+    """
+    if not name or not task_summary:
+        return
+    summary = " ".join(task_summary.split())[:240]
+    try:
+        state = load_state()
+        state[f"{name}_last_task"] = summary
+        save_state(state)
+    except Exception:
+        pass
+
+
 def slack_ceo(msg: str) -> None:
     try:
         subprocess.run([VENV_PYTHON, SLACK_RELAY, "--channel", "ceo", "--text", msg],

--- a/scripts/orchestrator/elliot_polling_loop.py
+++ b/scripts/orchestrator/elliot_polling_loop.py
@@ -1112,6 +1112,16 @@ def _write_inbox_dispatch(callsign: str, text: str) -> None:
         target.write_text(json.dumps(payload, indent=2))
     except OSError as exc:
         logger.warning("inbox write %s failed: %s", target, exc)
+        return
+
+    # Feed Fix C — record this dispatch as the agent's last_task so a future
+    # watchdog revive can resume it specifically. Best-effort; never blocks.
+    try:
+        from scripts.orchestrator.context_watchdog import record_agent_task
+
+        record_agent_task(callsign, text)
+    except Exception as exc:  # pragma: no cover — pure safety net
+        logger.warning("record_agent_task(%s) failed: %s", callsign, exc)
 
 
 def send_dispatch(channel: str, text: str) -> None:

--- a/scripts/sign_dispatch.py
+++ b/scripts/sign_dispatch.py
@@ -111,6 +111,14 @@ def main() -> int:
         file_path=str(out_path),
     )
 
+    # Feed the context-watchdog's Fix C revive prompt with the task brief so
+    # that if the target agent later wedges, the revive includes "Last task: …"
+    # instead of falling back to "check bd ready". Fail-open inside helper.
+    with contextlib.suppress(Exception):
+        from scripts.orchestrator.context_watchdog import record_agent_task
+
+        record_agent_task(args.target, args.brief)
+
     print(str(out_path))
     return 0
 

--- a/tests/orchestrator/test_context_watchdog.py
+++ b/tests/orchestrator/test_context_watchdog.py
@@ -1,0 +1,226 @@
+"""Unit tests for scripts.orchestrator.context_watchdog — three Dave-identified
+fixes (2026-05-30):
+
+  Fix A — permission-prompt detection in is_stuck().
+  Fix B — post-revive verification + escalation in check_other_agents().
+  Fix C — richer revive_agent() prompt that includes last_task when known.
+
+Pattern: monkeypatch the side-effecting seams (pane_capture, send_pane,
+slack_ceo) so no real tmux / Slack is reached. Out of scope per the dispatch:
+restart_elliot / wake_idle_elliot (Elliot-side, unchanged).
+
+Note: the dispatch named tests/session_resumption/test_watchdog.py as the
+existing file to extend, but that file tests a different module
+(src.session_resumption.watchdog — clear/sb_get/mark_stuck). These tests live
+in tests/orchestrator/ to colocate with the module under test.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+
+
+@pytest.fixture
+def cw():
+    """Fresh import of scripts.orchestrator.context_watchdog per test so
+    monkeypatched module-level attrs don't bleed between tests."""
+    mod = importlib.import_module("scripts.orchestrator.context_watchdog")
+    return importlib.reload(mod)
+
+
+# ---------------------------------------------------------------------------
+# Fix A — is_stuck() detects permission-prompt stalls
+# ---------------------------------------------------------------------------
+
+
+def test_is_stuck_returns_true_for_double_chevron_prompt(cw):
+    """Claude permission prompt: '⏵⏵' indicator (skip-permissions mode trigger)."""
+    assert cw.is_stuck("waiting on tool call\n⏵⏵ Approve?") is True
+
+
+def test_is_stuck_returns_true_for_bypass_permiss_hint(cw):
+    """Claude permission prompt: 'bypass permiss' substring."""
+    assert cw.is_stuck("Press tab to bypass permissions") is True
+
+
+def test_is_stuck_returns_true_when_allow_and_deny_both_present(cw):
+    """Generic permission dialog: both 'Allow' and 'Deny' buttons visible."""
+    assert cw.is_stuck("Run command? [Allow] [Deny]") is True
+
+
+def test_is_stuck_false_when_only_allow_or_only_deny(cw):
+    """Defensive — incidental 'Allow' or 'Deny' alone is not a permission prompt."""
+    assert cw.is_stuck("DENY: access refused") is False  # no 'Allow'
+    assert cw.is_stuck("allowlist updated") is False  # 'allow' lowercase doesn't match 'Allow'
+
+
+def test_is_stuck_still_detects_existing_error_indicators(cw):
+    """Regression: pre-existing indicators still fire after the prompt-detection patch."""
+    for token in ("Error:", "APIError:", "ConnectionError", "TimeoutError", "Traceback"):
+        assert cw.is_stuck(f"...some output...\n{token} something") is True
+
+
+def test_is_stuck_false_for_normal_pane(cw):
+    """A working pane (no prompts, no errors) → not stuck."""
+    assert cw.is_stuck("> running task\nstep 3/5 complete") is False
+
+
+# ---------------------------------------------------------------------------
+# Fix C — revive_agent prompt includes last_task when known
+# ---------------------------------------------------------------------------
+
+
+def test_revive_agent_includes_last_task_when_provided(cw, monkeypatch):
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        cw, "send_pane", lambda target, text, delay=1.5: sent.append((target, text))
+    )
+    monkeypatch.setattr(cw, "slack_ceo", lambda _msg: None)
+
+    cw.revive_agent("aiden", "aiden:0.0", "error-detected", last_task="KEI-99: chain consumer")
+
+    bodies = [t for _tg, t in sent]
+    assert "/clear" in bodies[0]
+    assert "Last task: KEI-99: chain consumer" in bodies[1]
+    assert "Read IDENTITY.md, resume that task" in bodies[1]
+
+
+def test_revive_agent_falls_back_to_bd_ready_when_last_task_blank(cw, monkeypatch):
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        cw, "send_pane", lambda target, text, delay=1.5: sent.append((target, text))
+    )
+    monkeypatch.setattr(cw, "slack_ceo", lambda _msg: None)
+
+    cw.revive_agent("aiden", "aiden:0.0", "error-detected")  # default last_task=""
+
+    body = sent[1][1]
+    assert "Last task:" not in body
+    assert "check bd ready" in body
+
+
+# ---------------------------------------------------------------------------
+# Fix B — check_other_agents tracks revive_sent + verifies on next cycle
+# ---------------------------------------------------------------------------
+
+
+def _stub_one_agent(cw, monkeypatch, *, pane_text: str):
+    """Reduce AGENTS to a single test agent + stub pane_capture to return pane_text."""
+    monkeypatch.setattr(cw, "AGENTS", {"aiden": "aiden:0.0"})
+    monkeypatch.setattr(cw, "pane_capture", lambda _target: pane_text)
+    monkeypatch.setattr(cw, "send_pane", lambda *a, **kw: None)
+    monkeypatch.setattr(cw, "slack_ceo", lambda _msg: None)
+
+
+def test_check_other_agents_sets_revive_sent_after_reviving(cw, monkeypatch):
+    """is_stuck pane → revive fires → state[name_revive_sent] set to ~now."""
+    _stub_one_agent(cw, monkeypatch, pane_text="...\n⏵⏵ Allow?")
+    before = time.time()
+    state = cw.check_other_agents({})
+    after = time.time()
+
+    assert "aiden_revive_sent" in state
+    assert before <= state["aiden_revive_sent"] <= after
+    # last_hash captured + last_change stamped
+    assert "aiden_last_hash" in state
+    assert "aiden_last_change" in state
+
+
+def test_check_other_agents_escalates_on_unchanged_pane_after_timeout(cw, monkeypatch):
+    """Next cycle: revive_sent expired AND pane hash unchanged → escalate to #ceo,
+    reset revive_sent. Does NOT re-fire revive."""
+    ceo_msgs: list[str] = []
+    send_calls: list = []
+    pane_text = "stuck pane (unchanged since last cycle)"
+    monkeypatch.setattr(cw, "AGENTS", {"aiden": "aiden:0.0"})
+    monkeypatch.setattr(cw, "pane_capture", lambda _t: pane_text)
+    monkeypatch.setattr(cw, "send_pane", lambda *a, **kw: send_calls.append(a))
+    monkeypatch.setattr(cw, "slack_ceo", lambda msg: ceo_msgs.append(msg))
+
+    prior_hash = cw.pane_hash(pane_text)  # same pane → same hash
+    state = {
+        "aiden_last_hash": prior_hash,
+        "aiden_last_change": time.time() - cw.WAKE_TIMEOUT_SEC - 60,
+        "aiden_revive_sent": time.time() - cw.WAKE_TIMEOUT_SEC - 60,  # expired
+    }
+    out = cw.check_other_agents(state)
+
+    # Escalation fired with the canonical FAILED message
+    assert any("revive FAILED" in m for m in ceo_msgs), ceo_msgs
+    assert any("aiden" in m for m in ceo_msgs)
+    # revive_sent reset to avoid spam loop
+    assert out["aiden_revive_sent"] == 0
+    # No new /clear or wake (didn't re-fire revive)
+    assert send_calls == []
+
+
+def test_check_other_agents_no_re_revive_while_in_flight(cw, monkeypatch):
+    """revive_sent is set + within timeout → skip everything (no escalation, no re-revive),
+    even if pane currently looks stuck."""
+    ceo_msgs: list[str] = []
+    send_calls: list = []
+    pane_text = "still hung\n⏵⏵ Allow?"
+    monkeypatch.setattr(cw, "AGENTS", {"aiden": "aiden:0.0"})
+    monkeypatch.setattr(cw, "pane_capture", lambda _t: pane_text)
+    monkeypatch.setattr(cw, "send_pane", lambda *a, **kw: send_calls.append(a))
+    monkeypatch.setattr(cw, "slack_ceo", lambda msg: ceo_msgs.append(msg))
+
+    prior_hash = cw.pane_hash(pane_text)
+    state = {
+        "aiden_last_hash": prior_hash,
+        "aiden_revive_sent": time.time() - 30,  # only 30s ago, within WAKE_TIMEOUT_SEC=600
+    }
+    out = cw.check_other_agents(state)
+
+    # No escalation, no new revive
+    assert ceo_msgs == []
+    assert send_calls == []
+    # revive_sent preserved (still in-flight)
+    assert out["aiden_revive_sent"] == state["aiden_revive_sent"]
+
+
+def test_check_other_agents_clears_revive_sent_when_pane_changes(cw, monkeypatch):
+    """Pane hash MOVED between cycles → revive worked → clear revive_sent flag.
+    No escalation, no re-revive."""
+    ceo_msgs: list[str] = []
+    monkeypatch.setattr(cw, "AGENTS", {"aiden": "aiden:0.0"})
+    monkeypatch.setattr(cw, "pane_capture", lambda _t: "NEW pane content after revive\nworking now")
+    monkeypatch.setattr(cw, "send_pane", lambda *a, **kw: None)
+    monkeypatch.setattr(cw, "slack_ceo", lambda msg: ceo_msgs.append(msg))
+
+    state = {
+        "aiden_last_hash": "old-hash-from-stuck-pane",
+        "aiden_revive_sent": time.time() - 30,  # still recent — would normally skip
+    }
+    out = cw.check_other_agents(state)
+
+    # Hash moved → revive_sent cleared
+    assert out["aiden_revive_sent"] == 0
+    # Hash updated to the new pane
+    assert out["aiden_last_hash"] != "old-hash-from-stuck-pane"
+    # No escalation (revive succeeded)
+    assert ceo_msgs == []
+
+
+def test_check_other_agents_passes_last_task_to_revive(cw, monkeypatch):
+    """When state carries f'{name}_last_task', revive_agent receives it."""
+    received: dict = {}
+
+    def fake_revive(name, target, reason, last_task=""):
+        received["name"] = name
+        received["reason"] = reason
+        received["last_task"] = last_task
+
+    monkeypatch.setattr(cw, "AGENTS", {"aiden": "aiden:0.0"})
+    monkeypatch.setattr(cw, "pane_capture", lambda _t: "Traceback (most recent call):\n...")
+    monkeypatch.setattr(cw, "revive_agent", fake_revive)
+
+    cw.check_other_agents({"aiden_last_task": "KEI-42: wire foo"})
+    assert received == {
+        "name": "aiden",
+        "reason": "error-detected",
+        "last_task": "KEI-42: wire foo",
+    }

--- a/tests/orchestrator/test_context_watchdog.py
+++ b/tests/orchestrator/test_context_watchdog.py
@@ -224,3 +224,80 @@ def test_check_other_agents_passes_last_task_to_revive(cw, monkeypatch):
         "reason": "error-detected",
         "last_task": "KEI-42: wire foo",
     }
+
+
+# ---------------------------------------------------------------------------
+# record_agent_task — dispatch-time feed for Fix C
+# ---------------------------------------------------------------------------
+
+
+def test_record_agent_task_writes_last_task_into_state_file(cw, tmp_path, monkeypatch):
+    """record_agent_task persists `{name}_last_task` into the watchdog state
+    file. A subsequent load_state() round-trip returns the same value."""
+    state_file = tmp_path / "watchdog-state.json"
+    monkeypatch.setattr(cw, "WATCHDOG_STATE_FILE", state_file)
+
+    cw.record_agent_task("orion", "PR #1373 — wire last_task feed")
+
+    persisted = cw.load_state()
+    assert persisted["orion_last_task"] == "PR #1373 — wire last_task feed"
+
+
+def test_record_agent_task_preserves_other_state_keys(cw, tmp_path, monkeypatch):
+    """Writing one agent's last_task must not clobber unrelated state keys
+    (e.g. another agent's revive_sent timestamp)."""
+    state_file = tmp_path / "watchdog-state.json"
+    monkeypatch.setattr(cw, "WATCHDOG_STATE_FILE", state_file)
+    cw.save_state({"atlas_revive_sent": 123.45, "atlas_last_task": "old-atlas-task"})
+
+    cw.record_agent_task("orion", "orion task")
+
+    out = cw.load_state()
+    assert out["atlas_revive_sent"] == 123.45
+    assert out["atlas_last_task"] == "old-atlas-task"
+    assert out["orion_last_task"] == "orion task"
+
+
+def test_record_agent_task_squashes_newlines_and_caps_length(cw, tmp_path, monkeypatch):
+    """Multi-line briefs collapse to one tmux-safe line; >240 chars truncated."""
+    state_file = tmp_path / "watchdog-state.json"
+    monkeypatch.setattr(cw, "WATCHDOG_STATE_FILE", state_file)
+
+    long_brief = "Task header\n\nLine two with detail.\n" + ("x" * 500)
+    cw.record_agent_task("scout", long_brief)
+
+    stored = cw.load_state()["scout_last_task"]
+    assert "\n" not in stored
+    assert len(stored) == 240
+    assert stored.startswith("Task header Line two with detail.")
+
+
+def test_record_agent_task_no_op_on_blank_inputs(cw, tmp_path, monkeypatch):
+    """Empty name OR empty task → return without touching state file."""
+    state_file = tmp_path / "watchdog-state.json"
+    monkeypatch.setattr(cw, "WATCHDOG_STATE_FILE", state_file)
+
+    cw.record_agent_task("", "real task")
+    cw.record_agent_task("orion", "")
+    assert not state_file.exists()
+
+
+def test_record_then_revive_uses_persisted_last_task(cw, tmp_path, monkeypatch):
+    """End-to-end Fix C wire: record_agent_task → check_other_agents picks up
+    the persisted last_task and passes it into revive_agent."""
+    state_file = tmp_path / "watchdog-state.json"
+    monkeypatch.setattr(cw, "WATCHDOG_STATE_FILE", state_file)
+
+    cw.record_agent_task("aiden", "KEI-77: rebase PR after #1371")
+
+    received: dict = {}
+
+    def fake_revive(name, target, reason, last_task=""):
+        received["last_task"] = last_task
+
+    monkeypatch.setattr(cw, "AGENTS", {"aiden": "aiden:0.0"})
+    monkeypatch.setattr(cw, "pane_capture", lambda _t: "...\nError: oh no")
+    monkeypatch.setattr(cw, "revive_agent", fake_revive)
+
+    cw.check_other_agents(cw.load_state())
+    assert received["last_task"] == "KEI-77: rebase PR after #1371"


### PR DESCRIPTION
## Problem (Dave-identified failure mode 2026-05-30)
The watchdog revived Aiden, posted to `#ceo`, then STOPPED — no follow-up check. Aiden's pane stalled on a permission prompt; the watchdog didn't detect it, didn't escalate, and the work was silently lost. Dave's verdict: **"session alive ≠ resumed correctly."**

## Three fixes in `scripts/orchestrator/context_watchdog.py`

### Fix A — `is_stuck()` permission-prompt detection
Adds three patterns: `'⏵⏵'`, `'bypass permiss'`, or (`'Allow'` AND `'Deny'`). Existing `Error:`/`APIError:`/`ConnectionError`/`TimeoutError`/`Traceback` indicators preserved as a regression guard.

### Fix B — post-revive verification in `check_other_agents()`
- After `revive_agent()` fires, records `state[f'{name}_revive_sent'] = now`.
- Next cycle: if pane hash CHANGED → revive worked, clear `revive_sent`.
- If unchanged AND `(now - revive_sent) > WAKE_TIMEOUT_SEC` → escalate to `#ceo` *"Watchdog: {name} revive FAILED — pane unchanged Nmin after restart. Task work may be lost."*, reset `revive_sent` to avoid spam loop.
- If unchanged AND still within timeout → wait silently (no re-revive, no escalation).
- **Mirrors the existing Elliot `wake_sent` escalation** at the top of `main()`.

### Fix C — richer `revive_agent()` prompt
New `last_task: str = ""` param. When Elliot writes `state[f'{name}_last_task']` at dispatch time, the revived agent gets:
> *REVIVED by watchdog ({reason}). Last task: {last_task}. Read IDENTITY.md, resume that task. No paid chain runs without approval.*

Falls back to the prior `bd ready` wording when blank — non-breaking for the existing call sites.

## Out of scope (per dispatch)
- `restart_elliot()` / `wake_idle_elliot()` (Elliot-side, unchanged).
- Per-agent compact-state files (larger change).

## Test file location note
Dispatch named `tests/session_resumption/test_watchdog.py`, but that file tests a different module (`src.session_resumption.watchdog` — `clear`/`sb_get`/`mark_stuck`). New tests live at **`tests/orchestrator/test_context_watchdog.py`** to colocate with the module under test.

## Raw pytest verbatim (no self-certified PASS)

```
$ python3 -m pytest tests/orchestrator/test_context_watchdog.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
collecting ... collected 13 items

tests/orchestrator/test_context_watchdog.py::test_is_stuck_returns_true_for_double_chevron_prompt PASSED [  7%]
tests/orchestrator/test_context_watchdog.py::test_is_stuck_returns_true_for_bypass_permiss_hint PASSED [ 15%]
tests/orchestrator/test_context_watchdog.py::test_is_stuck_returns_true_when_allow_and_deny_both_present PASSED [ 23%]
tests/orchestrator/test_context_watchdog.py::test_is_stuck_false_when_only_allow_or_only_deny PASSED [ 30%]
tests/orchestrator/test_context_watchdog.py::test_is_stuck_still_detects_existing_error_indicators PASSED [ 38%]
tests/orchestrator/test_context_watchdog.py::test_is_stuck_false_for_normal_pane PASSED [ 46%]
tests/orchestrator/test_context_watchdog.py::test_revive_agent_includes_last_task_when_provided PASSED [ 53%]
tests/orchestrator/test_context_watchdog.py::test_revive_agent_falls_back_to_bd_ready_when_last_task_blank PASSED [ 61%]
tests/orchestrator/test_context_watchdog.py::test_check_other_agents_sets_revive_sent_after_reviving PASSED [ 69%]
tests/orchestrator/test_context_watchdog.py::test_check_other_agents_escalates_on_unchanged_pane_after_timeout PASSED [ 76%]
tests/orchestrator/test_context_watchdog.py::test_check_other_agents_no_re_revive_while_in_flight PASSED [ 84%]
tests/orchestrator/test_context_watchdog.py::test_check_other_agents_clears_revive_sent_when_pane_changes PASSED [ 92%]
tests/orchestrator/test_context_watchdog.py::test_check_other_agents_passes_last_task_to_revive PASSED [100%]

============================== 13 passed in 0.51s ==============================
```

CI-equivalent `ruff check src/` clean. Pre-existing `scripts/orchestrator/` ruff warnings (I001 / 2× SIM105 / F841 / SIM103 on the unrelated `restart_elliot` path) left untouched per split-orthogonal-scope discipline; CI's ruff scope is `src/` only so they don't block this PR.

## Test coverage map
| # | Test | Covers |
|---|---|---|
| 1 | `test_is_stuck_returns_true_for_double_chevron_prompt` | Fix A — `⏵⏵` |
| 2 | `test_is_stuck_returns_true_for_bypass_permiss_hint` | Fix A — `bypass permiss` |
| 3 | `test_is_stuck_returns_true_when_allow_and_deny_both_present` | Fix A — Allow+Deny |
| 4 | `test_is_stuck_false_when_only_allow_or_only_deny` | Fix A — false-positive guard |
| 5 | `test_is_stuck_still_detects_existing_error_indicators` | Fix A — regression on prior indicators |
| 6 | `test_is_stuck_false_for_normal_pane` | Fix A — quiet pane unchanged |
| 7 | `test_revive_agent_includes_last_task_when_provided` | Fix C — last_task in prompt |
| 8 | `test_revive_agent_falls_back_to_bd_ready_when_last_task_blank` | Fix C — non-breaking default |
| 9 | `test_check_other_agents_sets_revive_sent_after_reviving` | Fix B — revive_sent stamped |
| 10 | `test_check_other_agents_escalates_on_unchanged_pane_after_timeout` | Fix B — escalation message + spam-loop reset |
| 11 | `test_check_other_agents_no_re_revive_while_in_flight` | Fix B — silent wait within timeout |
| 12 | `test_check_other_agents_clears_revive_sent_when_pane_changes` | Fix B — successful-revive detection |
| 13 | `test_check_other_agents_passes_last_task_to_revive` | Integration: Fix B writes state, Fix C reads it |

🤖 Generated with [Claude Code](https://claude.com/claude-code)