### PR TITLE
[ATLAS] fix(tasks-cli): pre-existing evidence validation rc=1 failures (Agency_OS-s5yo)

### DIFF
--- a/tests/scripts/test_tasks_cli_evidence.py
+++ b/tests/scripts/test_tasks_cli_evidence.py
@@ -136,15 +136,17 @@ def test_positive_valid_evidence_completes_task(mod, monkeypatch, tmp_path, caps
     ev_file = tmp_path / "evidence.json"
     ev_file.write_text(json.dumps(_VALID_EVIDENCE))
 
-    # Step sequence (post KEI-90 Gate 3 addition):
+    # Step sequence (post Agency_OS-s5yo — bd_id→UUID resolution added by 6a3a01884):
     #  execute[0] = Gate 3 SELECT deployment, claimed_by → fetchone returns (False, 'aiden')
     #  execute[1] = hash-uniqueness SELECT  → fetchall returns []  (no collision)
-    #  execute[2] = INSERT task_verifications → fetchone not called
-    #  execute[3] = UPDATE tasks RETURNING → fetchone returns the done row
+    #  execute[2] = bd_id→UUID resolution SELECT → fetchone returns (uuid,)
+    #  execute[3] = INSERT task_verifications → fetchone not called
+    #  execute[4] = UPDATE tasks RETURNING → fetchone returns the done row
     cur = MultiStepCursor(
         step_responses=[
             (False, "aiden"),  # Gate 3: deployment=False → no-op return
             [],  # hash check fetchall → no prior rows
+            ("uuid-kei-89",),  # bd_id→UUID resolve fetchone
             None,  # INSERT (no return used)
             ("KEI-89", "Gate 2 evidence test", "done"),  # UPDATE RETURNING
         ]
@@ -160,15 +162,18 @@ def test_positive_valid_evidence_completes_task(mod, monkeypatch, tmp_path, caps
     rc = mod.main(["complete", "KEI-89", "--evidence", str(ev_file)])
     assert rc == 0, capsys.readouterr().err
 
-    # Four execute calls fired: Gate 3, hash check, INSERT task_verifications,
-    # UPDATE tasks. The KEI-106 linear-sync enqueue is gone — _enqueue_linear_sync
-    # is locked to a no-op under the Linear-read-only LAW (Dave 2026-05-20).
-    assert len(cur.executed) == 4
+    # Five execute calls fired: Gate 3, hash check, bd_id→UUID resolve, INSERT
+    # task_verifications, UPDATE tasks. The KEI-106 linear-sync enqueue is gone —
+    # _enqueue_linear_sync is locked to a no-op under the Linear-read-only LAW
+    # (Dave 2026-05-20).
+    assert len(cur.executed) == 5
 
     # INSERT contained the canonical JSON as test_output param
-    insert_sql, insert_params = cur.executed[2]
+    insert_sql, insert_params = cur.executed[3]
     assert "task_verifications" in insert_sql
-    assert insert_params[1] == "KEI-89"  # task_id
+    # task_id is the resolved Supabase UUID from the bd_id→UUID lookup
+    # (Aiden's fix 6a3a01884 — bd_id strings would FK-violate task_verifications.task_id)
+    assert insert_params[1] == "uuid-kei-89"  # resolved task_id
     assert insert_params[2] == "aiden"  # verified_by
     stored_output = insert_params[4]  # test_output
     round_tripped = json.loads(stored_output)
@@ -286,6 +291,7 @@ def test_positive_evidence_path_inserts_exactly_one_verification_row(
         step_responses=[
             (False, "aiden"),  # Gate 3: deployment=False → no-op return
             [],  # hash check
+            ("uuid-kei-89",),  # bd_id→UUID resolve fetchone
             None,  # INSERT
             ("KEI-89", "Side-effect test task", "done"),  # UPDATE RETURNING
         ]
@@ -343,6 +349,7 @@ def test_positive_dict_acceptance_items_coerced_to_text(mod, monkeypatch, tmp_pa
         step_responses=[
             (False, "nova"),  # Gate 3: deployment=False → no-op return
             [],
+            ("uuid-kei-y244",),  # bd_id→UUID resolve fetchone
             None,
             ("KEI-y244", "Dict regression task", "done"),
         ]
@@ -358,7 +365,7 @@ def test_positive_dict_acceptance_items_coerced_to_text(mod, monkeypatch, tmp_pa
     rc = mod.main(["complete", "KEI-y244", "--evidence", str(ev_file)])
     assert rc == 0, capsys.readouterr().err
 
-    _, insert_params = cur.executed[2]
+    _, insert_params = cur.executed[3]
     behavioral_test_param = insert_params[3]
     assert isinstance(behavioral_test_param, str), (
         f"behavioral_test must be str (text column); got {type(behavioral_test_param).__name__}"
@@ -390,6 +397,7 @@ def test_positive_dict_acceptance_items_without_criterion_falls_back_to_json(
         step_responses=[
             (False, "nova"),  # Gate 3: deployment=False → no-op return
             [],
+            ("uuid-kei-y244b",),  # bd_id→UUID resolve fetchone
             None,
             ("KEI-y244b", "Fallback task", "done"),
         ]
@@ -405,7 +413,7 @@ def test_positive_dict_acceptance_items_without_criterion_falls_back_to_json(
     rc = mod.main(["complete", "KEI-y244b", "--evidence", str(ev_file)])
     assert rc == 0, capsys.readouterr().err
 
-    _, insert_params = cur.executed[2]
+    _, insert_params = cur.executed[3]
     behavioral_test_param = insert_params[3]
     assert isinstance(behavioral_test_param, str)
     parsed = json.loads(behavioral_test_param)


### PR DESCRIPTION
## Summary

Fix 4 pre-existing failures in `tests/scripts/test_tasks_cli_evidence.py` that have been red on main since commit `6a3a01884` ("fix(bd): resolve Beads bd_id to Supabase UUID before task_verifications INSERT").

bd ref: **Agency_OS-s5yo**

## Root cause

`6a3a01884` added a bd_id→UUID resolution `SELECT` inside `_execute_atomic_complete` before the INSERT. That made `cmd_complete` issue 5 `cur.execute()` calls instead of 4:

```
[0] Gate 3 SELECT (deployment, claimed_by)
[1] hash-uniqueness SELECT
[2] bd_id→UUID resolve SELECT     ← new
[3] INSERT task_verifications
[4] UPDATE tasks RETURNING
```

The 4 affected tests' `MultiStepCursor` had only 4 step_responses, so the `UPDATE … RETURNING` `fetchone` fell off the end of the step list → `row=None` → `cmd_complete` printed `"could not complete KEI-89 (not claimed by aiden?)"` and returned 1, failing `assert rc == 0`.

## Fix

For the 4 affected positive-path tests:
- Insert a `("uuid-…",)` step between the hash-check and the INSERT
- Bump `assert len(cur.executed) == 4` → `== 5`
- Shift `cur.executed[2]` → `cur.executed[3]` for INSERT inspection
- Update the `insert_params[1]` assertion to expect the resolved UUID rather than the input KEI string (because the INSERT now binds the resolved id, not the bd_id)

Negative-path tests (missing evidence / bad schema / hash collision) are untouched — they exit before `_execute_atomic_complete`.

## Test plan

- [x] `python3 -m pytest tests/scripts/test_tasks_cli_evidence.py -v` — all 7 pass
- [x] `ruff check tests/scripts/test_tasks_cli_evidence.py` — clean
- [x] `ruff format --check tests/scripts/test_tasks_cli_evidence.py` — clean
- [ ] CI confirms the suite is now green on this branch

Verbatim local run:
```
tests/scripts/test_tasks_cli_evidence.py::test_positive_valid_evidence_completes_task PASSED [ 14%]
tests/scripts/test_tasks_cli_evidence.py::test_negative_missing_evidence_exits_nonzero PASSED [ 28%]
tests/scripts/test_tasks_cli_evidence.py::test_negative_schema_fail_missing_required_field PASSED [ 42%]
tests/scripts/test_tasks_cli_evidence.py::test_negative_hash_collision_rejects_reuse PASSED [ 57%]
tests/scripts/test_tasks_cli_evidence.py::test_positive_evidence_path_inserts_exactly_one_verification_row PASSED [ 71%]
tests/scripts/test_tasks_cli_evidence.py::test_positive_dict_acceptance_items_coerced_to_text PASSED [ 85%]
tests/scripts/test_tasks_cli_evidence.py::test_positive_dict_acceptance_items_without_criterion_falls_back_to_json PASSED [100%]

============================== 7 passed in 0.19s ===============================
```