### PR TITLE
[ATLAS] feat(roadmap): roadmap_status renderer + CI auto-commit + ROADMAP_V2.md (Dave directive 2026-05-31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,54 @@ jobs:
         run: pytest tests/ -v --tb=short --cov=src --cov-report=term-missing
 
   # ============================================
+  # ROADMAP V2 status auto-render (Dave directive 2026-05-31)
+  # ============================================
+  # Renders the current STATUS block from public.gate_ledger into
+  # docs/ROADMAP_V2.md and auto-commits the change on push to main.
+  # Runs regardless of backend-test outcome (if: always()) — the renderer
+  # itself never breaks CI; it emits a STATUS_BLOCK_UNAVAILABLE stub on any
+  # DB / connectivity failure and exits 0.
+  roadmap-status-render:
+    name: Roadmap Status Render
+    needs: backend-test
+    runs-on: ubuntu-latest
+    if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Default GITHUB_TOKEN is enough for pushing to the same repo
+          # because permissions.contents: write is granted above.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install psycopg
+        run: pip install "psycopg[binary]"
+
+      - name: Render STATUS block into docs/ROADMAP_V2.md
+        env:
+          SUPABASE_DB_DSN: ${{ secrets.SUPABASE_DB_DSN }}
+        run: python3 scripts/roadmap_status.py --write
+
+      - name: Commit + push if changed
+        run: |
+          if git diff --quiet docs/ROADMAP_V2.md; then
+            echo "ROADMAP_V2.md unchanged — nothing to commit."
+            exit 0
+          fi
+          git config user.email "roadmap-bot@keiracom.local"
+          git config user.name "Roadmap Status Bot"
+          git add docs/ROADMAP_V2.md
+          git commit -m "chore(roadmap): auto-update STATUS block [skip ci]"
+          git push
+
+  # ============================================
   # Frontend: Lint, Type Check, Build
   # ============================================
   frontend-check:

--- a/docs/ROADMAP_V2.md
+++ b/docs/ROADMAP_V2.md
@@ -1,0 +1,154 @@
+# ROADMAP V2 — Keiracom Workforce
+
+Source of truth for V2 scope, phasing, and current status.
+Status block at the bottom is auto-rendered from `public.gate_ledger` by
+`scripts/roadmap_status.py` on every push to `main`. Do not edit the table
+inside the markers manually — your edit will be overwritten on the next push.
+
+Working name "Keiracom" is per `ceo:agency_os_keiracom_separation_v1`
+(ratified 2026-05-24). Final commercial brand TBD post-launch.
+
+---
+
+## What "done" looks like
+
+The end state is a machine a customer installs that just runs, improves
+itself from its own work, and is transparent about what it is doing.
+Off Supabase entirely. Chain on Temporal — durable execution, retries,
+audit trail. Secrets in Vault — no plaintext keys on disk. All LLM calls
+flow through LiteLLM so the customer's BYOK key, the rate caps, the
+governance gates, and the cost telemetry sit on a single chokepoint.
+Atoms capture every task boundary into Hindsight; recall over those atoms
+returns real, scoped signal rather than empty results. Nova commits its
+own work inside the activity rather than handing back a string. Stalled
+chains surface to Dave (and, post-launch, to the customer) within five
+minutes, not silently. The product repo is isolated from the fleet repo,
+so a tenant install carries nothing that the tenant should not see.
+
+---
+
+## Phases
+
+### Phase 0 — Gate mechanism (PROVEN, CLOSED 2026-05-31)
+
+- **Proof gate:** Phase 0 CI gates fire pass/fail/skip correctly; the
+  mechanism itself exists and is exercised on every push.
+- **Components:** `gate_mechanism`.
+- **Outcome:** CLOSED per Dave 2026-05-31 (CI run 26711089656 sealed the
+  proof). See `ceo:gate_skip_enforced_rule_v1` `phase_0_status`.
+
+### Phase 1 — Temporal chain
+
+- **Proof gate:** Temporal workflow + activities run end-to-end on the
+  VPS, and crash recovery is verified by killing the worker mid-chain
+  and observing automatic resume.
+- **Components:** `temporal_chain`, `dispatcher_retirement`.
+- **Sequencing:** Dave's call — riskiest-first. Temporal is both the
+  riskiest (durable execution semantics we don't yet operate) and the
+  most reversible (Supabase stays live as fallback during the build).
+  The custom dispatcher is deleted on Phase 1 pass, not before.
+
+### Phase 2 — Infrastructure migration
+
+- **Proof gate:** Supabase fully retired; Vault holds every secret;
+  LiteLLM routes every LLM call; self-hosted Postgres carries the live
+  workload.
+- **Components:** `vault_secrets`, `litellm_routing`,
+  `postgres_self_hosted`, `gate_ledger_migration` (META — this very
+  table moving with the rest of the data), `roadmap_doc_relocation`
+  (META — this doc moving to the product repo when it's carved out).
+- **Hard gate:** R2 offsite backup must be configured AND a restore must
+  be verified end-to-end **before** the first client data row crosses
+  into the self-hosted Postgres. Backup that has never been restored is
+  not a backup.
+
+### Phase 3 — Memory + atoms
+
+- **Proof gate:** Atoms write at every task boundary, and recall against
+  populated Hindsight banks returns real signal (not empty results and
+  not boilerplate).
+- **Components:** `atom_capture`, `atom_recall`.
+
+### Phase 4 — Nova + reliability
+
+- **Proof gate:** Nova commits its own work inside the workflow activity
+  (not a returned string the orchestrator has to commit on its behalf),
+  AND a stalled chain surfaces to Dave within 5 minutes.
+- **Components:** `nova_commits`, `failure_notification`.
+
+---
+
+## Decisions log
+
+### Dave's three corrections (2026-05-31)
+
+1. **Supabase scope: expanded from "chain state only" to "full platform
+   retirement".** Every table moves — `ceo_memory`, CIS, the pipeline
+   tables, client data, agent memories, chain state. Nothing stays.
+2. **Prefect stays.** The outbound sales pipeline (discovery + enrichment
+   + 4-channel outreach) keeps running on Prefect. V2 scope is the
+   agent fleet chain only.
+3. **Go sidecar stays.** Ratified at V1 launch; not in V2 scope.
+
+### SKIP → ENFORCED ON SHIP rule (Dave ratified 2026-05-31)
+
+A gate that currently skips (rc=2) is tolerated **only while** its
+component genuinely does not exist. The instant a component is supposedly
+done but its gate still skips, that is a **FAILURE**, not a pass. Applies
+to every phase, every gate, every PR. Recorded in
+`ceo:gate_skip_enforced_rule_v1`; deferred-gate obligations tracked in
+`.gates/deferred_gates.md`.
+
+### Atom capture + recall (RATIFIED)
+
+Hindsight self-hosted as the memory engine; atoms write at every task
+boundary via the Ingest primitive; recall must return real results as
+DoD for Phase 3. Phase 3 does not start until Phase 3 components are
+genuinely built — no early-promotion off paper readiness.
+
+### Dual concur on Temporal workflow definitions
+
+Any change to Temporal workflow definitions requires concur from **two**
+deliberators. Topology changes are governance-level, not routine code
+review. Standard 2-of-3 deliberator concur still applies to everything
+else.
+
+### Phase ordering — riskiest-first
+
+Temporal is Phase 1 because it's both the riskiest (we don't operate it
+yet) and the most reversible (Supabase remains live during the build,
+so a Phase 1 failure does not strand state). Each phase gates the next;
+no parallel phase execution.
+
+---
+
+## Deferred list
+
+- **KEI-198** — crash recovery spec; runs in parallel with Phase 1
+  Temporal build (so the spec hardens against what we actually
+  observe, not what we predict).
+- **`gate_atoms`** — currently SKIPPED (the `keiracom_atoms` table is
+  not yet on the CI database). Becomes ENFORCED when the atom store
+  ships (`Agency_OS-jjnq`). See `.gates/deferred_gates.md`.
+- **`gate_recall`** — currently SKIPPED (no `HINDSIGHT_URL`). Becomes
+  ENFORCED when Hindsight recall ships with populated banks
+  (`Agency_OS-rw6r`). See `.gates/deferred_gates.md`.
+- **`gate_crash_recovery`** — currently SKIPPED (no
+  `GATE_CRASH_DISPATCH_CMD`). Becomes ENFORCED when Temporal crash
+  recovery ships (`Agency_OS-jn14`). See `.gates/deferred_gates.md`.
+- **Product repo name** — `keiracom-core` (Dave confirmed); the actual
+  repo creation is deferred until Phase 2.0 carve-out.
+- **LiteLLM / claude-CLI base-URL investigation** — required **before**
+  Phase 3 coding begins, not during.
+- **Build-hop 40 min timeout** — acceptable when paired with a
+  heartbeat. A held slot at 40 min surfaces to Dave; it does not get
+  silently eaten.
+
+---
+
+## Current status
+
+<!-- STATUS_BLOCK_START -->
+<!-- auto-generated by scripts/roadmap_status.py — do not edit manually -->
+<!-- run: python3 scripts/roadmap_status.py --render to see current state -->
+<!-- STATUS_BLOCK_END -->

--- a/docs/ROADMAP_V2.md
+++ b/docs/ROADMAP_V2.md
@@ -1,7 +1,7 @@
 # ROADMAP V2 — Keiracom Workforce
 
 Source of truth for V2 scope, phasing, and current status.
-Status block at the bottom is auto-rendered from `public.gate_ledger` by
+Status block at the bottom is auto-rendered from `public.gate_roadmap` by
 `scripts/roadmap_status.py` on every push to `main`. Do not edit the table
 inside the markers manually — your edit will be overwritten on the next push.
 
@@ -54,7 +54,7 @@ so a tenant install carries nothing that the tenant should not see.
   LiteLLM routes every LLM call; self-hosted Postgres carries the live
   workload.
 - **Components:** `vault_secrets`, `litellm_routing`,
-  `postgres_self_hosted`, `gate_ledger_migration` (META — this very
+  `postgres_self_hosted`, `gate_roadmap_migration` (META — this very
   table moving with the rest of the data), `roadmap_doc_relocation`
   (META — this doc moving to the product repo when it's carved out).
 - **Hard gate:** R2 offsite backup must be configured AND a restore must

--- a/scripts/roadmap_status.py
+++ b/scripts/roadmap_status.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""roadmap_status.py — render the V2 roadmap STATUS block from public.gate_ledger.
+
+Dave directive 2026-05-31. Renders the current per-component status table that
+gets stitched into docs/ROADMAP_V2.md between the STATUS_BLOCK_START/END markers.
+
+CLI:
+  python3 scripts/roadmap_status.py --render   # stdout: markdown table
+  python3 scripts/roadmap_status.py --write    # rewrites STATUS block in ROADMAP_V2.md
+
+Failure modes:
+  - DB unreachable / query fails: emit `<!-- STATUS_BLOCK_UNAVAILABLE: <reason> -->`
+    between the markers (write) or to stdout (render). Exit 0 ALWAYS so the
+    auto-commit step in CI never breaks the build.
+  - Markers missing in target file: exit 0, print a warning to stderr, no write.
+
+Env:
+  DATABASE_URL or SUPABASE_DB_DSN — Postgres DSN. Tried in that order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ROADMAP_PATH = REPO_ROOT / "docs" / "ROADMAP_V2.md"
+
+STATUS_BLOCK_START = "<!-- STATUS_BLOCK_START -->"
+STATUS_BLOCK_END = "<!-- STATUS_BLOCK_END -->"
+
+STATUS_EMOJI = {
+    "not_started": "⬜",
+    "built": "🔨",
+    "proven": "✅",
+    "skipped": "⏭",
+    "deferred": "⏸",
+}
+
+QUERY = """
+SELECT component, phase, subphase, proof_gate, status, owner,
+       kei_link, blocker_text, last_verified
+  FROM public.gate_ledger
+ ORDER BY phase, component
+"""
+
+
+def _dsn() -> str | None:
+    raw = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_DSN") or None
+    if not raw:
+        return None
+    # Strip async driver tag — psycopg sync can't parse `postgresql+asyncpg://`.
+    # Mirrors scripts/tasks_cli.py _dsn() so the env vars are interchangeable.
+    return raw.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def _fmt_status(status: str | None) -> str:
+    if not status:
+        return "—"
+    return f"{STATUS_EMOJI.get(status, '?')} {status}"
+
+
+def _fmt_last_verified(value) -> str:
+    if value is None:
+        return "—"
+    s = str(value)
+    return s.split(".")[0].replace("T", " ")[:19] if "T" in s or " " in s else s
+
+
+def _fmt_kei(kei_link: str | None) -> str:
+    if not kei_link:
+        return "—"
+    return f"[{kei_link}]({kei_link})" if kei_link.startswith("http") else kei_link
+
+
+def _fmt_phase(phase: str | None, subphase: str | None) -> str:
+    if phase and subphase:
+        return f"{phase} / {subphase}"
+    return phase or "—"
+
+
+def _render_table(rows: list[tuple]) -> str:
+    if not rows:
+        return "_No gate_ledger rows yet — populated as components ship._"
+    header = "| Component | Phase | Status | Owner | Last Verified | Gate |"
+    sep = "| --- | --- | --- | --- | --- | --- |"
+    lines = [header, sep]
+    for (
+        component,
+        phase,
+        subphase,
+        proof_gate,
+        status,
+        owner,
+        kei_link,
+        _blocker,
+        last_verified,
+    ) in rows:
+        lines.append(
+            f"| {component or '—'} "
+            f"| {_fmt_phase(phase, subphase)} "
+            f"| {_fmt_status(status)} "
+            f"| {owner or '—'} "
+            f"| {_fmt_last_verified(last_verified)} "
+            f"| {proof_gate or _fmt_kei(kei_link)} |"
+        )
+    return "\n".join(lines)
+
+
+def _fetch_rows() -> tuple[list[tuple] | None, str | None]:
+    """Returns (rows, error_message). On success error_message is None."""
+    dsn = _dsn()
+    if not dsn:
+        return None, "DATABASE_URL / SUPABASE_DB_DSN not set"
+    try:
+        import psycopg
+    except ImportError as exc:
+        return None, f"psycopg import failed: {exc}"
+    try:
+        with psycopg.connect(dsn, connect_timeout=10) as conn, conn.cursor() as cur:
+            cur.execute(QUERY)
+            return list(cur.fetchall()), None
+    except Exception as exc:  # broad: any DB error → unavailable stub
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def render() -> str:
+    rows, err = _fetch_rows()
+    if err is not None:
+        return f"<!-- STATUS_BLOCK_UNAVAILABLE: {err} -->"
+    return _render_table(rows or [])
+
+
+def _replace_block(text: str, new_inner: str) -> tuple[str, bool]:
+    """Return (new_text, replaced?). replaced=False when markers missing."""
+    pattern = re.compile(
+        re.escape(STATUS_BLOCK_START) + r".*?" + re.escape(STATUS_BLOCK_END),
+        re.DOTALL,
+    )
+    if not pattern.search(text):
+        return text, False
+    replacement = f"{STATUS_BLOCK_START}\n{new_inner}\n{STATUS_BLOCK_END}"
+    return pattern.sub(replacement, text, count=1), True
+
+
+def write_to_roadmap(path: Path | None = None) -> int:
+    if path is None:
+        # Look up at call time so tests can monkeypatch mod.ROADMAP_PATH.
+        path = ROADMAP_PATH
+    if not path.exists():
+        print(f"WARN: {path} does not exist — nothing to write.", file=sys.stderr)
+        return 0
+    body = render()
+    text = path.read_text(encoding="utf-8")
+    new_text, replaced = _replace_block(text, body)
+    if not replaced:
+        print(
+            f"WARN: STATUS_BLOCK markers not found in {path} — nothing to write.",
+            file=sys.stderr,
+        )
+        return 0
+    if new_text != text:
+        path.write_text(new_text, encoding="utf-8")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--render", action="store_true", help="print table to stdout")
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="rewrite the STATUS block in docs/ROADMAP_V2.md",
+    )
+    args = parser.parse_args(argv)
+    if not (args.render or args.write):
+        parser.print_help(sys.stderr)
+        return 0
+    try:
+        if args.render:
+            print(render())
+        if args.write:
+            return write_to_roadmap()
+    except Exception as exc:
+        # LAST-RESORT guard: renderer failure must NEVER break CI.
+        print(f"<!-- STATUS_BLOCK_UNAVAILABLE: renderer crashed: {exc} -->", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/roadmap_status.py
+++ b/scripts/roadmap_status.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""roadmap_status.py — render the V2 roadmap STATUS block from public.gate_ledger.
+"""roadmap_status.py — render the V2 roadmap STATUS block from public.gate_roadmap.
 
 Dave directive 2026-05-31. Renders the current per-component status table that
 gets stitched into docs/ROADMAP_V2.md between the STATUS_BLOCK_START/END markers.
@@ -43,7 +43,7 @@ STATUS_EMOJI = {
 QUERY = """
 SELECT component, phase, subphase, proof_gate, status, owner,
        kei_link, blocker_text, last_verified
-  FROM public.gate_ledger
+  FROM public.gate_roadmap
  ORDER BY phase, component
 """
 
@@ -84,7 +84,7 @@ def _fmt_phase(phase: str | None, subphase: str | None) -> str:
 
 def _render_table(rows: list[tuple]) -> str:
     if not rows:
-        return "_No gate_ledger rows yet — populated as components ship._"
+        return "_No gate_roadmap rows yet — populated as components ship._"
     header = "| Component | Phase | Status | Owner | Last Verified | Gate |"
     sep = "| --- | --- | --- | --- | --- | --- |"
     lines = [header, sep]

--- a/tests/scripts/test_roadmap_status.py
+++ b/tests/scripts/test_roadmap_status.py
@@ -1,0 +1,216 @@
+"""Tests for scripts/roadmap_status.py — Dave directive 2026-05-31.
+
+Covers:
+  (1) happy path — table render with emoji status + correct column ordering.
+  (2) DB-unreachable fallback — STATUS_BLOCK_UNAVAILABLE stub, exit 0.
+  (3) --write rewrites the STATUS block between the markers in ROADMAP_V2.md.
+
+Uses monkeypatch to swap psycopg.connect for a fake connection; does NOT
+hit the live Supabase DB.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "roadmap_status.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("roadmap_status_mod", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["roadmap_status_mod"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+_SAMPLE_ROWS = [
+    (
+        "temporal_chain",
+        "Phase 1",
+        "build",
+        "gate_crash_recovery",
+        "built",
+        "atlas",
+        "Agency_OS-jn14",
+        None,
+        datetime(2026, 5, 31, 12, 34, 56, tzinfo=UTC),
+    ),
+    (
+        "atom_capture",
+        "Phase 3",
+        None,
+        "gate_atoms",
+        "not_started",
+        "orion",
+        None,
+        "table missing",
+        None,
+    ),
+]
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[tuple]) -> None:
+        self._rows = rows
+        self.last_query: str | None = None
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        return None
+
+    def execute(self, sql: str) -> None:
+        self.last_query = sql
+
+    def fetchall(self) -> list[tuple]:
+        return list(self._rows)
+
+
+class _FakeConn:
+    def __init__(self, rows: list[tuple]) -> None:
+        self._cur = _FakeCursor(rows)
+
+    def cursor(self) -> _FakeCursor:
+        return self._cur
+
+    def __enter__(self) -> _FakeConn:
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        return None
+
+
+# ─── (1) happy path ──────────────────────────────────────────────────────────
+
+
+def test_render_happy_path_emits_table_with_emoji(monkeypatch, capsys):
+    mod = _load_module()
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+
+    import psycopg
+
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: _FakeConn(_SAMPLE_ROWS))
+
+    rc = mod.main(["--render"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    # Header is intact and column ordering is locked
+    assert "| Component | Phase | Status | Owner | Last Verified | Gate |" in out
+    # Both rows render
+    assert "temporal_chain" in out
+    assert "atom_capture" in out
+    # Status emoji mapping fires for known statuses
+    assert "🔨 built" in out
+    assert "⬜ not_started" in out
+    # Phase + subphase compose correctly when both present
+    assert "Phase 1 / build" in out
+    # NULL last_verified surfaces as an em-dash rather than 'None'
+    assert "| — |" in out
+
+
+# ─── (2) DB unreachable fallback ─────────────────────────────────────────────
+
+
+def test_render_db_unreachable_emits_unavailable_stub_and_exits_zero(monkeypatch, capsys):
+    mod = _load_module()
+    # No DSN env → _fetch_rows returns an error sentinel
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_DB_DSN", raising=False)
+
+    rc = mod.main(["--render"])
+    out = capsys.readouterr().out
+
+    assert rc == 0, "renderer must NEVER non-zero — CI auto-commit relies on it"
+    assert "STATUS_BLOCK_UNAVAILABLE" in out
+    assert "DATABASE_URL" in out or "SUPABASE_DB_DSN" in out
+
+
+def test_render_psycopg_connect_error_emits_unavailable_stub(monkeypatch, capsys):
+    mod = _load_module()
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+
+    import psycopg
+
+    def _boom(*a, **kw):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(psycopg, "connect", _boom)
+
+    rc = mod.main(["--render"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "STATUS_BLOCK_UNAVAILABLE" in out
+    assert "connection refused" in out
+
+
+# ─── (3) --write rewrites STATUS block between markers ───────────────────────
+
+
+def test_write_replaces_block_between_markers(monkeypatch, tmp_path):
+    mod = _load_module()
+
+    target = tmp_path / "ROADMAP_V2.md"
+    target.write_text(
+        "# header\n\n"
+        "some narrative\n\n"
+        "## Current status\n\n"
+        f"{mod.STATUS_BLOCK_START}\n"
+        "STALE CONTENT TO REPLACE\n"
+        f"{mod.STATUS_BLOCK_END}\n"
+        "\ntrailing prose\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "ROADMAP_PATH", target)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+
+    import psycopg
+
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: _FakeConn(_SAMPLE_ROWS))
+
+    rc = mod.main(["--write"])
+    assert rc == 0
+
+    after = target.read_text(encoding="utf-8")
+    # Stale content gone
+    assert "STALE CONTENT TO REPLACE" not in after
+    # Markers preserved
+    assert mod.STATUS_BLOCK_START in after
+    assert mod.STATUS_BLOCK_END in after
+    # New table content lives between them
+    assert "temporal_chain" in after
+    assert "🔨 built" in after
+    # Surrounding prose untouched
+    assert "# header" in after
+    assert "trailing prose" in after
+
+
+def test_write_no_markers_warns_and_exits_zero(monkeypatch, tmp_path, capsys):
+    mod = _load_module()
+
+    target = tmp_path / "ROADMAP_V2.md"
+    target.write_text("# header\n\nno markers here\n", encoding="utf-8")
+    original = target.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(mod, "ROADMAP_PATH", target)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test/x")
+
+    import psycopg
+
+    monkeypatch.setattr(psycopg, "connect", lambda *a, **kw: _FakeConn(_SAMPLE_ROWS))
+
+    rc = mod.main(["--write"])
+    err = capsys.readouterr().err
+
+    assert rc == 0
+    assert "STATUS_BLOCK markers not found" in err
+    # File unchanged when markers missing — no silent corruption
+    assert target.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary

Three pieces of the V2 roadmap mechanism Dave authorised 2026-05-31:

1. **scripts/roadmap_status.py** — renders the per-component STATUS block from `public.gate_ledger` as a markdown table with status-emoji column (`not_started=⬜ built=🔨 proven=✅ skipped=⏭ deferred=⏸`). `--render` to stdout; `--write` rewrites between the `STATUS_BLOCK_START/END` markers in `docs/ROADMAP_V2.md`. Always exits 0 — DB/connectivity/query failure emits a `<!-- STATUS_BLOCK_UNAVAILABLE: <reason> -->` stub so the CI auto-commit step can never break the build.
2. **`.github/workflows/ci.yml`** — new `roadmap-status-render` job. `needs: backend-test`, `if: always() && push to main`, `permissions.contents: write`. Installs `psycopg[binary]`, runs `--write` against `SUPABASE_DB_DSN` secret, commits + pushes if the file changed (commit message includes `[skip ci]` so the auto-commit doesn't re-trigger the workflow).
3. **docs/ROADMAP_V2.md** — full narrative (what-done-looks-like, four phases each with proof-gate language, decisions log including Dave's three 2026-05-31 corrections + the SKIP→ENFORCED rule, deferred list cross-referencing `.gates/deferred_gates.md`).

bd ref: feeds the roadmap_status auto-render mechanism that goes alongside the Phase 0 → Phase 1 transition.

## Verification

### pytest tests/scripts/test_roadmap_status.py -v (verbatim)

```
configfile: pytest.ini
plugins: timeout-2.4.0, asyncio-1.3.0, logfire-4.25.0, anyio-4.12.1
timeout: 300.0s
timeout method: thread
timeout func_only: False
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collecting ... collected 5 items

tests/scripts/test_roadmap_status.py::test_render_happy_path_emits_table_with_emoji PASSED [ 20%]
tests/scripts/test_roadmap_status.py::test_render_db_unreachable_emits_unavailable_stub_and_exits_zero PASSED [ 40%]
tests/scripts/test_roadmap_status.py::test_render_psycopg_connect_error_emits_unavailable_stub PASSED [ 60%]
tests/scripts/test_roadmap_status.py::test_write_replaces_block_between_markers PASSED [ 80%]
tests/scripts/test_roadmap_status.py::test_write_no_markers_warns_and_exits_zero PASSED [100%]

============================== 5 passed in 0.14s ===============================
```

### python3 scripts/roadmap_status.py --render (verbatim — live against current Supabase)

```
<!-- STATUS_BLOCK_UNAVAILABLE: UndefinedColumn: column "component" does not exist
LINE 2: SELECT component, phase, subphase, proof_gate, status, owner...
               ^ -->
```

Exit code: 0. This is expected — the current `gate_ledger` schema is the CI-run-history schema (`id, gate_id, phase, ci_run_id, pr_number, status, evidence, recorded_at`), not the roadmap-status schema. **Orion is building the column migration in parallel** per the dispatch. The renderer will start producing real tables the moment that migration lands; no change required to this PR.

## Notes — canonical-key paste (audit-dispatch checklist compliance)

Queried at PR-write time per the dispatch:

```sql
SELECT key, value::text FROM public.ceo_memory
 WHERE key IN ('ceo:gate_skip_enforced_rule_v1',
               'ceo:agency_os_keiracom_separation_v1',
               'ceo:memory_abstraction_layer_v1');
```

**ceo:gate_skip_enforced_rule_v1** (verbatim from `value::text`, key fields only):

```
rule: SKIP→ENFORCED ON SHIP
ratified: 2026-05-31 by Dave
statement: "A gate that skips (rc=2) is tolerated ONLY while its component
            genuinely does not exist. The instant a component ships but its
            gate still skips, that is a FAILURE not a pass."
phase_0_status: CLOSED — proven 2026-05-31 CI run 26711089656
phase_1_status: OPEN — Temporal chain build starting
deferred_obligations:
  - gate_crash_recovery → Agency_OS-jn14 → Temporal crash recovery (V2 Phase 1)
  - gate_recall         → Agency_OS-rw6r → Hindsight recall (V2 Phase 5)
  - gate_atoms          → Agency_OS-jjnq → atom store (V2 Phase 5)
```

**ceo:agency_os_keiracom_separation_v1** (key claims used in the doc):

- Status: RATIFIED 2026-05-24 by Dave (4-way concur: viktor / max / aiden / elliot).
- "Keiracom = working name today (matches Dave verbatim 2026-05-24). Final commercial name TBD post-launch via market scan/competitor landscape/domain availability/brand fit. Not current priority. Architecture is rename-ready."
- Three-repo topology: fleet repo (working name `keiracom-fleet`), product repo (working name TBD, rename-ready), archive repo (preserved).
- Used in ROADMAP_V2.md preamble + the deferred-list product repo entry.

**ceo:memory_abstraction_layer_v1** (key claims used in the doc):

- Status: RATIFIED 2026-05-24 by Dave (3-way concur: elliot / viktor / aiden).
- Substantive lock: Hindsight self-hosted as engine (Vectorize.io MIT OSS); whiteboard flush through Ingest at every task boundary closes the shadow-memory hole.
- Phase 2.1 verification spike VERDICT: FAVOURABLE (completed 2026-05-24).
- Phase 2 build commit ratified 2026-05-24 — used in the ROADMAP_V2.md "Atom capture + recall (RATIFIED)" decision-log entry.

## Test plan

- [x] `python3 -m pytest tests/scripts/test_roadmap_status.py -v` — 5 passed
- [x] `ruff check scripts/roadmap_status.py tests/scripts/test_roadmap_status.py` — clean
- [x] `ruff format --check scripts/roadmap_status.py tests/scripts/test_roadmap_status.py` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML valid
- [x] Live smoke against current Supabase — emits unavailable stub, exit 0
- [ ] First push-to-main run will exercise the auto-commit path end-to-end