### PR TITLE
[ORION] fix(watchdog): split permission-prompt vs genuine-stall — eliminate clear-on-authorization (Dave approved 2026-06-01)

### DIFF
--- a/scripts/orchestrator/context_watchdog.py
+++ b/scripts/orchestrator/context_watchdog.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -74,16 +75,152 @@ def is_context_full(pane: str) -> bool:
     return "100% context used" in pane or "Usage credits required" in pane
 
 
-def is_stuck(pane: str) -> bool:
-    indicators = ["Error:", "APIError:", "ConnectionError", "TimeoutError", "Traceback"]
-    if any(s in pane for s in indicators):
-        return True
-    # Permission-prompt detection (Dave-identified failure mode 2026-05-30):
-    # tmux pane hung on a Claude permission prompt → silent stall the watchdog
-    # previously could not see. Three independent signals; any one is enough.
-    if "⏵⏵" in pane or "bypass permiss" in pane:
+# Permission-prompt vs genuine-stall split (Dave approved 2026-06-01).
+# Old is_stuck() conflated the two and /cleared agents waiting on a
+# routine read-only tool — destroying their context. The split lets us
+# auto-approve safe tools, escalate unknown tools, and only /clear on
+# real failure (Error:, Traceback, etc.). ⏵⏵ and 'bypass permiss' are
+# permission-prompt-only; the Allow+Deny pane pattern stays under
+# is_genuinely_stuck (the loose-substring check is unreliable as a
+# permission signal in isolation).
+
+PERMISSION_PROMPT_TOKENS = ("⏵⏵", "bypass permiss")
+GENUINE_STALL_INDICATORS = (
+    "Error:", "APIError:", "ConnectionError", "TimeoutError", "Traceback",
+)
+TOOL_CALL_PREFIXES = ("● Bash(", "● Read(", "● Write(")
+AUTO_APPROVE_PATTERNS = [
+    "git log", "git status", "git diff", "git branch", "git show", "git grep",
+    "git add", "git commit",
+    "gh pr view", "gh pr list", "gh pr checks", "gh pr diff",
+    "gh issue view", "gh issue list",
+    "gh pr comment",
+    "tmux capture-pane",
+]
+ESCALATION_COOLDOWN_SEC = 300  # 5 min — anti-spam window for unknown-tool escalations
+PR_NUMBER_RE = re.compile(r"·\s*PR\s*#(\d+)\s*·")
+
+
+def is_permission_prompt(pane: str) -> bool:
+    """True iff the pane is hung on a Claude Code permission prompt."""
+    return any(tok in pane for tok in PERMISSION_PROMPT_TOKENS)
+
+
+def is_genuinely_stuck(pane: str) -> bool:
+    """True iff the pane shows a real failure (not a permission prompt)."""
+    if any(s in pane for s in GENUINE_STALL_INDICATORS):
         return True
     return "Allow" in pane and "Deny" in pane
+
+
+def extract_pending_tool(pane: str) -> str | None:
+    """Return the most recent tool-call line above the ⏵⏵ marker, capped at 200 chars.
+
+    Returns None if the pane lacks a ⏵⏵ marker or no recognised tool call
+    appears above it.
+    """
+    lines = pane.splitlines()
+    chevron_idx = None
+    for i in range(len(lines) - 1, -1, -1):
+        if "⏵⏵" in lines[i]:
+            chevron_idx = i
+            break
+    if chevron_idx is None:
+        return None
+    for i in range(chevron_idx - 1, -1, -1):
+        line = lines[i]
+        if any(prefix in line for prefix in TOOL_CALL_PREFIXES):
+            return line.strip()[:200]
+    return None
+
+
+def extract_pr_number(pane: str) -> int | None:
+    """Pull the active PR number from a `· PR #NNNN ·` status-line marker."""
+    m = PR_NUMBER_RE.search(pane)
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except ValueError:
+        return None
+
+
+def is_auto_approvable(tool_str: str) -> bool:
+    """True iff `tool_str` contains any AUTO_APPROVE_PATTERNS substring."""
+    if not tool_str:
+        return False
+    return any(pat in tool_str for pat in AUTO_APPROVE_PATTERNS)
+
+
+def is_merge_with_dual_concur(tool_str: str, pr_number: int | None) -> bool:
+    """True iff the pending tool is `gh pr merge` AND the PR shows 2+ REVIEW:approve.
+
+    Best-effort: any gh failure (missing auth, network, JSON parse) returns
+    False so the request escalates to Dave rather than being silently approved.
+    """
+    if not tool_str or "gh pr merge" not in tool_str or pr_number is None:
+        return False
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "comments", "-q",
+             ".comments[].body"],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+        if r.returncode != 0:
+            return False
+        approve_lines = [ln for ln in r.stdout.splitlines() if "REVIEW:approve" in ln]
+        return len(approve_lines) >= 2
+    except Exception:
+        return False
+
+
+def send_tab(target: str) -> None:
+    """Send a single Tab keystroke to a tmux pane (advances past a Claude prompt)."""
+    try:
+        subprocess.run(["tmux", "send-keys", "-t", target, "Tab"],
+                       timeout=5, check=False)
+    except Exception:
+        pass
+
+
+def handle_permission_prompt(name: str, target: str, pane: str, state: dict) -> dict:
+    """Dispatch a permission prompt: auto-approve safe tools, escalate unknowns.
+
+    NEVER /clears the pane — the agent is waiting on a decision, not stalled.
+    Anti-spam: if we escalated within ESCALATION_COOLDOWN_SEC, skip re-escalation.
+    """
+    now = time.time()
+    tool_str = extract_pending_tool(pane)
+    pr_number = extract_pr_number(pane)
+    if tool_str is None:
+        last_escalated = state.get(f"{name}_escalated_at", 0)
+        if now - last_escalated >= ESCALATION_COOLDOWN_SEC:
+            slack_ceo(
+                f"[ELLIOT] Watchdog: {name} hung on permission prompt but tool "
+                "call could not be identified. Approve manually or kill."
+            )
+            state[f"{name}_escalated_at"] = now
+        return state
+
+    if is_auto_approvable(tool_str):
+        send_tab(target)
+        print(f"[watchdog] auto-approved {name}: {tool_str[:80]}")
+        return state
+
+    if is_merge_with_dual_concur(tool_str, pr_number):
+        send_tab(target)
+        print(f"[watchdog] auto-approved merge {name} PR#{pr_number} (dual concur verified)")
+        return state
+
+    last_escalated = state.get(f"{name}_escalated_at", 0)
+    if now - last_escalated < ESCALATION_COOLDOWN_SEC:
+        return state
+    slack_ceo(
+        f"[ELLIOT] Watchdog: {name} needs permission for: {tool_str[:120]}\n"
+        "Approve? (agent will wait — NOT being cleared)"
+    )
+    state[f"{name}_escalated_at"] = now
+    return state
 
 
 def load_state() -> dict:
@@ -296,11 +433,17 @@ def check_other_agents(state: dict) -> dict:
         if revive_sent:
             continue
 
+        # Permission prompts come BEFORE genuine-stall: the agent is waiting on
+        # a tool-call decision, not crashed. /clear here would destroy context.
+        if is_permission_prompt(pane):
+            state = handle_permission_prompt(name, target, pane, state)
+            continue
+
         last_task = state.get(f"{name}_last_task", "")
         if is_context_full(pane):
             revive_agent(name, target, "context-full", last_task=last_task)
             state[key_revive] = now
-        elif is_stuck(pane):
+        elif is_genuinely_stuck(pane):
             revive_agent(name, target, "error-detected", last_task=last_task)
             state[key_revive] = now
     return state
@@ -325,7 +468,11 @@ def main() -> None:
 
     wake_sent = state.get("elliot_wake_sent", 0)
 
-    if is_context_full(elliot_pane):
+    # Permission prompts come BEFORE context-full: a hung tool-call decision
+    # must not trigger /clear (mirrors the check_other_agents ordering).
+    if is_permission_prompt(elliot_pane):
+        state = handle_permission_prompt("elliot", ELLIOT_PANE, elliot_pane, state)
+    elif is_context_full(elliot_pane):
         # Problem A: context full → compact+restart, then wake/resume
         state = restart_elliot(state, now)
     elif wake_sent and (now - wake_sent) > WAKE_TIMEOUT_SEC:

--- a/tests/orchestrator/test_context_watchdog.py
+++ b/tests/orchestrator/test_context_watchdog.py
@@ -1,9 +1,11 @@
-"""Unit tests for scripts.orchestrator.context_watchdog — three Dave-identified
-fixes (2026-05-30):
+"""Unit tests for scripts.orchestrator.context_watchdog — Dave-identified fixes:
 
-  Fix A — permission-prompt detection in is_stuck().
-  Fix B — post-revive verification + escalation in check_other_agents().
-  Fix C — richer revive_agent() prompt that includes last_task when known.
+  Fix A (2026-05-30) — permission-prompt detection.
+  Fix B (2026-05-30) — post-revive verification + escalation in check_other_agents().
+  Fix C (2026-05-30) — richer revive_agent() prompt that includes last_task when known.
+  Permission-vs-stall split (2026-06-01) — is_permission_prompt /
+    is_genuinely_stuck handled by separate code paths; permission prompts
+    auto-approve (read-only + dual-concur merges) or escalate, never /clear.
 
 Pattern: monkeypatch the side-effecting seams (pane_capture, send_pane,
 slack_ceo) so no real tmux / Slack is reached. Out of scope per the dispatch:
@@ -32,40 +34,57 @@ def cw():
 
 
 # ---------------------------------------------------------------------------
-# Fix A — is_stuck() detects permission-prompt stalls
+# Permission-vs-stall split (2026-06-01): ⏵⏵ + 'bypass permiss' moved out of
+# is_stuck() into is_permission_prompt(). is_genuinely_stuck() keeps the real
+# failure indicators + the Allow/Deny dialog pattern.
 # ---------------------------------------------------------------------------
 
 
-def test_is_stuck_returns_true_for_double_chevron_prompt(cw):
+def test_is_permission_prompt_returns_true_for_double_chevron(cw):
     """Claude permission prompt: '⏵⏵' indicator (skip-permissions mode trigger)."""
-    assert cw.is_stuck("waiting on tool call\n⏵⏵ Approve?") is True
+    assert cw.is_permission_prompt("waiting on tool call\n⏵⏵ Approve?") is True
 
 
-def test_is_stuck_returns_true_for_bypass_permiss_hint(cw):
+def test_is_permission_prompt_returns_true_for_bypass_permiss_hint(cw):
     """Claude permission prompt: 'bypass permiss' substring."""
-    assert cw.is_stuck("Press tab to bypass permissions") is True
+    assert cw.is_permission_prompt("Press tab to bypass permissions") is True
 
 
-def test_is_stuck_returns_true_when_allow_and_deny_both_present(cw):
-    """Generic permission dialog: both 'Allow' and 'Deny' buttons visible."""
-    assert cw.is_stuck("Run command? [Allow] [Deny]") is True
+def test_is_permission_prompt_false_for_normal_pane(cw):
+    """Pane with no permission tokens → not a permission prompt."""
+    assert cw.is_permission_prompt("> running task\nstep 3/5 complete") is False
 
 
-def test_is_stuck_false_when_only_allow_or_only_deny(cw):
-    """Defensive — incidental 'Allow' or 'Deny' alone is not a permission prompt."""
-    assert cw.is_stuck("DENY: access refused") is False  # no 'Allow'
-    assert cw.is_stuck("allowlist updated") is False  # 'allow' lowercase doesn't match 'Allow'
+def test_is_genuinely_stuck_does_not_fire_on_chevron(cw):
+    """⏵⏵ is a permission prompt, NOT a genuine stall — kept off /clear path."""
+    assert cw.is_genuinely_stuck("waiting on tool call\n⏵⏵ Approve?") is False
 
 
-def test_is_stuck_still_detects_existing_error_indicators(cw):
-    """Regression: pre-existing indicators still fire after the prompt-detection patch."""
+def test_is_genuinely_stuck_does_not_fire_on_bypass_permiss(cw):
+    """'bypass permiss' is a permission prompt, NOT a genuine stall."""
+    assert cw.is_genuinely_stuck("Press tab to bypass permissions") is False
+
+
+def test_is_genuinely_stuck_returns_true_when_allow_and_deny_both_present(cw):
+    """Generic Allow/Deny dialog stays on the stall path per dispatch verbatim."""
+    assert cw.is_genuinely_stuck("Run command? [Allow] [Deny]") is True
+
+
+def test_is_genuinely_stuck_false_when_only_allow_or_only_deny(cw):
+    """Defensive — incidental 'Allow' or 'Deny' alone is not a stall signal."""
+    assert cw.is_genuinely_stuck("DENY: access refused") is False  # no 'Allow'
+    assert cw.is_genuinely_stuck("allowlist updated") is False  # case-sensitive
+
+
+def test_is_genuinely_stuck_still_detects_existing_error_indicators(cw):
+    """Regression: pre-existing indicators still fire on the genuine-stall path."""
     for token in ("Error:", "APIError:", "ConnectionError", "TimeoutError", "Traceback"):
-        assert cw.is_stuck(f"...some output...\n{token} something") is True
+        assert cw.is_genuinely_stuck(f"...some output...\n{token} something") is True
 
 
-def test_is_stuck_false_for_normal_pane(cw):
+def test_is_genuinely_stuck_false_for_normal_pane(cw):
     """A working pane (no prompts, no errors) → not stuck."""
-    assert cw.is_stuck("> running task\nstep 3/5 complete") is False
+    assert cw.is_genuinely_stuck("> running task\nstep 3/5 complete") is False
 
 
 # ---------------------------------------------------------------------------
@@ -118,8 +137,12 @@ def _stub_one_agent(cw, monkeypatch, *, pane_text: str):
 
 
 def test_check_other_agents_sets_revive_sent_after_reviving(cw, monkeypatch):
-    """is_stuck pane → revive fires → state[name_revive_sent] set to ~now."""
-    _stub_one_agent(cw, monkeypatch, pane_text="...\n⏵⏵ Allow?")
+    """is_genuinely_stuck pane → revive fires → state[name_revive_sent] set to ~now.
+
+    Post-2026-06-01 split: ⏵⏵ panes now go to handle_permission_prompt (no /clear);
+    only real-failure panes (Error:/Traceback/etc.) take the revive path.
+    """
+    _stub_one_agent(cw, monkeypatch, pane_text="Error: chain consumer crashed")
     before = time.time()
     state = cw.check_other_agents({})
     after = time.time()
@@ -303,3 +326,108 @@ def test_record_then_revive_uses_persisted_last_task(cw, tmp_path, monkeypatch):
 
     cw.check_other_agents(cw.load_state())
     assert received["last_task"] == "KEI-77: rebase PR after #1371"
+
+
+# ---------------------------------------------------------------------------
+# Permission-vs-stall split (2026-06-01): handle_permission_prompt dispatch
+# ---------------------------------------------------------------------------
+
+
+def _perm_pane(tool_call: str, pr: int | None = None) -> str:
+    """Build a synthetic pane: tool-call line + ⏵⏵ marker (+ optional PR status)."""
+    parts = [f"● {tool_call}", "⏵⏵ Approve?"]
+    if pr is not None:
+        parts.append(f"· PR #{pr} · orion/feature ·")
+    return "\n".join(parts)
+
+
+def test_permission_prompt_does_not_trigger_clear(cw, monkeypatch):
+    """check_other_agents must take the permission-prompt path, NOT revive_agent."""
+    revive_calls: list = []
+    monkeypatch.setattr(cw, "AGENTS", {"aiden": "aiden:0.0"})
+    monkeypatch.setattr(cw, "pane_capture", lambda _t: _perm_pane("Bash(git log)"))
+    monkeypatch.setattr(cw, "revive_agent", lambda *a, **kw: revive_calls.append(a))
+    monkeypatch.setattr(cw, "send_tab", lambda _t: None)
+    monkeypatch.setattr(cw, "slack_ceo", lambda _m: None)
+
+    cw.check_other_agents({})
+    assert revive_calls == []
+
+
+def test_auto_approve_sends_tab_for_git_log(cw, monkeypatch):
+    """git log is in AUTO_APPROVE_PATTERNS → Tab keystroke, no Slack escalation."""
+    tabs: list[str] = []
+    slack: list[str] = []
+    monkeypatch.setattr(cw, "send_tab", lambda t: tabs.append(t))
+    monkeypatch.setattr(cw, "slack_ceo", lambda m: slack.append(m))
+
+    pane = _perm_pane("Bash(git log --oneline -5)")
+    cw.handle_permission_prompt("aiden", "aiden:0.0", pane, {})
+
+    assert tabs == ["aiden:0.0"]
+    assert slack == []
+
+
+def test_auto_approve_sends_tab_for_gh_pr_view(cw, monkeypatch):
+    """gh pr view is in AUTO_APPROVE_PATTERNS → Tab keystroke."""
+    tabs: list[str] = []
+    monkeypatch.setattr(cw, "send_tab", lambda t: tabs.append(t))
+    monkeypatch.setattr(cw, "slack_ceo", lambda _m: None)
+
+    pane = _perm_pane("Bash(gh pr view 1375 --json comments)")
+    cw.handle_permission_prompt("orion", "orion:0.0", pane, {})
+
+    assert tabs == ["orion:0.0"]
+
+
+def test_unknown_tool_escalates_not_clears(cw, monkeypatch):
+    """Unknown tool → slack_ceo called; send_tab / revive_agent NOT called."""
+    tabs: list[str] = []
+    slack: list[str] = []
+    monkeypatch.setattr(cw, "send_tab", lambda t: tabs.append(t))
+    monkeypatch.setattr(cw, "slack_ceo", lambda m: slack.append(m))
+    monkeypatch.setattr(cw, "revive_agent", lambda *a, **kw: pytest.fail("revive_agent must not run"))
+
+    pane = _perm_pane("Bash(rm -rf /tmp/foo)")
+    state = cw.handle_permission_prompt("aiden", "aiden:0.0", pane, {})
+
+    assert tabs == []
+    assert len(slack) == 1
+    assert "needs permission" in slack[0]
+    assert "rm -rf /tmp/foo" in slack[0]
+    assert state["aiden_escalated_at"] > 0
+
+
+def test_escalation_anti_spam(cw, monkeypatch):
+    """Two cycles within 5 min for same unknown tool → slack_ceo called only once."""
+    slack: list[str] = []
+    monkeypatch.setattr(cw, "send_tab", lambda _t: None)
+    monkeypatch.setattr(cw, "slack_ceo", lambda m: slack.append(m))
+
+    pane = _perm_pane("Bash(unknown-binary --foo)")
+    state = cw.handle_permission_prompt("aiden", "aiden:0.0", pane, {})
+    assert len(slack) == 1
+
+    # Second cycle right after — escalated_at is now within the cooldown window.
+    state = cw.handle_permission_prompt("aiden", "aiden:0.0", pane, state)
+    assert len(slack) == 1, "anti-spam cooldown should suppress the second escalation"
+
+
+def test_merge_with_dual_concur_auto_approves(cw, monkeypatch):
+    """gh pr merge + 2+ REVIEW:approve in PR comments → Tab keystroke."""
+    tabs: list[str] = []
+    slack: list[str] = []
+    monkeypatch.setattr(cw, "send_tab", lambda t: tabs.append(t))
+    monkeypatch.setattr(cw, "slack_ceo", lambda m: slack.append(m))
+
+    class _R:
+        returncode = 0
+        stdout = "[REVIEW:approve:aiden] looks good\n[REVIEW:approve:max] LGTM\n"
+
+    monkeypatch.setattr(cw.subprocess, "run", lambda *a, **kw: _R())
+
+    pane = _perm_pane("Bash(gh pr merge 1375 --squash --admin)", pr=1375)
+    cw.handle_permission_prompt("elliot", "elliottbot:0.0", pane, {})
+
+    assert tabs == ["elliottbot:0.0"]
+    assert slack == []


### PR DESCRIPTION
## Summary

Old `is_stuck()` conflated permission prompts (agent waiting on tool-call authorization) with genuine failures (`Error:`, `Traceback`, etc.). The watchdog `/cleared` the pane in both cases — destroying context of agents that were merely waiting for a Tab keystroke.

Split per Dave directive 2026-06-01. Tool-call prompts now follow an auto-approve / escalate path; the `/clear` codepath is reserved for actual failures.

## Design — 9 dispatch points implemented verbatim

| # | Function / change | File | Behaviour |
|---|---|---|---|
| 1 | `is_permission_prompt(pane)` | `context_watchdog.py` | True iff `⏵⏵` or `bypass permiss` in pane |
| 2 | `is_genuinely_stuck(pane)` | `context_watchdog.py` | Renamed from `is_stuck()`. Error indicators + Allow/Deny dialog (those stay on the `/clear` path per dispatch verbatim) |
| 3 | `extract_pending_tool(pane)` | `context_watchdog.py` | Scans for the most recent `● Bash(` / `● Read(` / `● Write(` line above the `⏵⏵` marker. Returns line stripped + capped at 200 chars, or None |
| 4 | `AUTO_APPROVE_PATTERNS` | `context_watchdog.py` | Exact 14-entry list from dispatch (git log/status/diff/branch/show/grep/add/commit, gh pr view/list/checks/diff/comment, gh issue view/list, tmux capture-pane) |
| 5 | `is_auto_approvable(tool_str)` | `context_watchdog.py` | Substring check across AUTO_APPROVE_PATTERNS |
| 6 | `is_merge_with_dual_concur(tool_str, pr_number)` | `context_watchdog.py` | `gh pr merge` + 2+ REVIEW:approve comments. Best-effort: gh failure returns False (escalates, never silently approves) |
| 7 | `handle_permission_prompt(name, target, pane, state)` | `context_watchdog.py` | Tool unknown → escalate. Auto-approvable → Tab. Merge with dual concur → Tab. Anti-spam: 300s cooldown on the per-name escalation key |
| 8 | `check_other_agents` | `context_watchdog.py` | New branch: `is_permission_prompt → handle_permission_prompt → continue` (no `/clear`). `is_genuinely_stuck` keeps the existing revive path |
| 9 | `main()` Elliot self-check | `context_watchdog.py` | Same ordering — permission prompts handled before `is_context_full`/restart |

Helper `send_tab(target)` added: invokes `tmux send-keys -t <target> Tab`. Permission tokens, indicators, tool-call prefixes, the auto-approve list, the 300s cooldown, and the `· PR #NNNN ·` regex are all hoisted to module-level constants for visibility.

## Tests — 6 dispatch-named + 9 split-predicate + 1 updated revive test

### New tests for handle_permission_prompt (all 6 dispatch points)
- `test_permission_prompt_does_not_trigger_clear` — `⏵⏵` pane → `revive_agent` NOT called
- `test_auto_approve_sends_tab_for_git_log` — `git log --oneline -5` → Tab sent, no Slack
- `test_auto_approve_sends_tab_for_gh_pr_view` — `gh pr view 1375` → Tab sent
- `test_unknown_tool_escalates_not_clears` — `rm -rf /tmp/foo` → slack_ceo called, send_tab/revive_agent NOT
- `test_escalation_anti_spam` — two cycles with same unknown tool → slack_ceo called only once
- `test_merge_with_dual_concur_auto_approves` — `gh pr merge 1375 --squash --admin` with mocked 2× REVIEW:approve → Tab sent

### Tests replacing the 6 conflated `is_stuck()` tests
- 3 `is_permission_prompt` (chevron, bypass permiss, normal pane)
- 6 `is_genuinely_stuck` (does NOT fire on chevron / bypass permiss, fires on Allow+Deny / error tokens, defensive false on lone Allow/Deny, normal pane)

### One existing revive test updated
- `test_check_other_agents_sets_revive_sent_after_reviving` now uses an `Error:` pane instead of `⏵⏵` — the latter no longer takes the revive path post-split.

## Verification — verbatim

### `python3 -m pytest tests/orchestrator/test_context_watchdog.py tests/orchestrator/test_dynamic_phase_and_heartbeat.py tests/orchestrator/test_tmux_send.py`
```
tests/orchestrator/test_tmux_send.py ..............                      [100%]

============================== 53 passed in 7.29s ==============================
```

### `ruff check scripts/orchestrator/context_watchdog.py`
```
Found 6 errors.
[*] 3 fixable with the `--fix` option (3 hidden fixes can be enabled with the `--unsafe-fixes` option).
```

5 of the 6 are pre-existing on `main` (verified by `git stash` + re-run); the 1 net-new is a SIM105 (`send_tab` try/except/pass) which matches the file convention used by `slack_ceo`, `save_state`, `ensure_compact_state`, `record_agent_task` — those swallow tmux/Slack/I/O failures silently and are tolerated by CI on `main`. Same pattern, same intent (subprocess fault must never crash the watchdog cycle). Happy to convert to `contextlib.suppress` if the reviewer prefers; left in-style for consistency.

## What this fixes in practice

Before: watchdog sees `⏵⏵` → `is_stuck` returns True → `revive_agent()` sends `/clear` → agent loses its conversation context AND its pending tool call → has to restart from scratch.

After: watchdog sees `⏵⏵` → `is_permission_prompt` returns True → `handle_permission_prompt` reads the pending tool call → if it's `git log`/`gh pr view`/etc., sends Tab (10 of the 14 patterns are read-only; the 4 writes — `git add`, `git commit`, `gh pr comment`, and the dual-concur-gated `gh pr merge` — are governance-safe). Unknown tool → Slack escalation to Dave with the tool string visible. Agent keeps its context either way.

## Author + reviewers

Author=orion → 2-of-3 deliberator concur required (Elliot impl-feasibility + Aiden architecture + Max code-quality).