### PR TITLE
[ATLAS] fix(watchdog): name tool in unidentified escalations + add gh pr create to auto-approve

### DIFF
--- a/scripts/orchestrator/context_watchdog.py
+++ b/scripts/orchestrator/context_watchdog.py
@@ -94,7 +94,7 @@ AUTO_APPROVE_PATTERNS = [
     "git add", "git commit",
     "gh pr view", "gh pr list", "gh pr checks", "gh pr diff",
     "gh issue view", "gh issue list",
-    "gh pr comment",
+    "gh pr comment", "gh pr create",
     "tmux capture-pane",
 ]
 ESCALATION_COOLDOWN_SEC = 300  # 5 min — anti-spam window for unknown-tool escalations
@@ -195,9 +195,15 @@ def handle_permission_prompt(name: str, target: str, pane: str, state: dict) -> 
     if tool_str is None:
         last_escalated = state.get(f"{name}_escalated_at", 0)
         if now - last_escalated >= ESCALATION_COOLDOWN_SEC:
+            # Surface the last 3 non-empty pane lines so the recipient can
+            # judge the prompt without a tmux attach. Capped at 200 chars to
+            # stay readable in #ceo.
+            tail_lines = [ln.strip() for ln in pane.splitlines() if ln.strip()][-3:]
+            pane_tail = " | ".join(tail_lines)
             slack_ceo(
-                f"[ELLIOT] Watchdog: {name} hung on permission prompt but tool "
-                "call could not be identified. Approve manually or kill."
+                f"[ELLIOT] Watchdog: {name} — tool unidentified. "
+                f"Pane tail: {pane_tail[:200]}\n"
+                "Agent is waiting — NOT being cleared. Approve manually if needed."
             )
             state[f"{name}_escalated_at"] = now
         return state

--- a/tests/orchestrator/test_context_watchdog.py
+++ b/tests/orchestrator/test_context_watchdog.py
@@ -386,7 +386,9 @@ def test_unknown_tool_escalates_not_clears(cw, monkeypatch):
     slack: list[str] = []
     monkeypatch.setattr(cw, "send_tab", lambda t: tabs.append(t))
     monkeypatch.setattr(cw, "slack_ceo", lambda m: slack.append(m))
-    monkeypatch.setattr(cw, "revive_agent", lambda *a, **kw: pytest.fail("revive_agent must not run"))
+    monkeypatch.setattr(
+        cw, "revive_agent", lambda *a, **kw: pytest.fail("revive_agent must not run")
+    )
 
     pane = _perm_pane("Bash(rm -rf /tmp/foo)")
     state = cw.handle_permission_prompt("aiden", "aiden:0.0", pane, {})
@@ -431,3 +433,67 @@ def test_merge_with_dual_concur_auto_approves(cw, monkeypatch):
 
     assert tabs == ["elliottbot:0.0"]
     assert slack == []
+
+
+def test_auto_approve_sends_tab_for_gh_pr_create(cw, monkeypatch):
+    """gh pr create is in AUTO_APPROVE_PATTERNS → Tab keystroke, no escalation.
+
+    Routine fleet op alongside `gh pr comment` and `gh pr view` — every
+    worker opens PRs as part of normal dispatch flow, and stopping for a
+    permission prompt on each one stalls the orchestration loop.
+    """
+    tabs: list[str] = []
+    slack: list[str] = []
+    monkeypatch.setattr(cw, "send_tab", lambda t: tabs.append(t))
+    monkeypatch.setattr(cw, "slack_ceo", lambda m: slack.append(m))
+
+    pane = _perm_pane("Bash(gh pr create --title '[ATLAS] feat(x)' --body 'summary')")
+    cw.handle_permission_prompt("atlas", "atlas:0.0", pane, {})
+
+    assert tabs == ["atlas:0.0"]
+    assert slack == []
+
+
+def test_unidentified_tool_escalation_includes_pane_tail(cw, monkeypatch):
+    """When extract_pending_tool returns None, the Slack escalation must
+    surface the last 3 non-empty pane lines so the recipient can judge the
+    prompt without a tmux attach.
+
+    Failure mode this catches: a pane with a ⏵⏵ marker but no recognised
+    tool-call line above it (e.g. an unknown TUI prompt, or output the
+    parser doesn't yet recognise) producing a context-free 'tool
+    unidentified' alert.
+    """
+    slack: list[str] = []
+    monkeypatch.setattr(cw, "send_tab", lambda _t: None)
+    monkeypatch.setattr(cw, "slack_ceo", lambda m: slack.append(m))
+
+    # Pane with the chevron marker but NO `● Bash(/Read(/Write(` line above
+    # it — extract_pending_tool returns None here. Include a few blank
+    # lines to prove the test exercises the non-empty filter, not just an
+    # arbitrary tail.
+    pane = "\n".join(
+        [
+            "running deploy step",
+            "",
+            "Waiting for service registry registration…",
+            "",
+            "Approve y/N",
+            "⏵⏵ Approve?",
+        ]
+    )
+    state = cw.handle_permission_prompt("atlas", "atlas:0.0", pane, {})
+
+    assert len(slack) == 1, "exactly one escalation must fire"
+    msg = slack[0]
+    assert "tool unidentified" in msg
+    # Pane-tail contract: last 3 non-empty lines, joined with " | "
+    assert "Waiting for service registry registration" in msg
+    assert "Approve y/N" in msg
+    assert "⏵⏵ Approve?" in msg
+    assert " | " in msg
+    # Blank pane lines must NOT leak into the tail
+    assert "running deploy step" not in msg
+    # NOT being cleared semantics preserved
+    assert "NOT being cleared" in msg
+    assert state["atlas_escalated_at"] > 0


### PR DESCRIPTION
## Summary

Two small `scripts/orchestrator/context_watchdog.py` tweaks per Elliot dispatch.

### Change 1 — pane tail in unidentified-tool Slack escalation

When `extract_pending_tool()` returns `None` (a `⏵⏵` permission marker is present but no recognised `● Bash(/Read(/Write(` line appears above it), the prior Slack message was context-free:

> `[ELLIOT] Watchdog: aiden hung on permission prompt but tool call could not be identified. Approve manually or kill.`

The recipient had no signal for what was actually waiting on Dave's decision. Now the last 3 non-empty pane lines (joined with `" | "`, capped at 200 chars) get surfaced in the escalation, and "Agent is waiting — NOT being cleared" wording confirms the watchdog has paused the pane rather than auto-clearing it.

### Change 2 — `gh pr create` joins `AUTO_APPROVE_PATTERNS`

`gh pr create` sits naturally alongside `gh pr comment` + `gh pr view` in the auto-approve list. Every worker opens PRs as routine fleet ops; a permission-prompt stall on each one stalls the orchestration loop.

## Tests

Two new tests appended to `tests/orchestrator/test_context_watchdog.py`:

- **`test_auto_approve_sends_tab_for_gh_pr_create`** — mirrors the existing `test_auto_approve_sends_tab_for_gh_pr_view` pattern. Perm-pane with `Bash(gh pr create …)` triggers a Tab keystroke; no Slack escalation.
- **`test_unidentified_tool_escalation_includes_pane_tail`** — synthesises a pane with a `⏵⏵` marker and NO `● Bash(/Read(/Write(` line above. Exercises the no-tool-identified branch. Asserts:
  - all 3 non-empty pane-tail lines appear in the Slack message
  - the joiner `" | "` is present
  - blank pane lines do **not** leak into the tail (confirms the filter is non-empty, not arbitrary slice)
  - `"NOT being cleared"` wording preserved
  - the anti-spam timestamp gets stamped

## Test plan

- [x] `python3 -m pytest tests/orchestrator/test_context_watchdog.py -v` — **29 passed** (was 27, +2)
- [x] `ruff check tests/orchestrator/test_context_watchdog.py` — clean
- [x] `ruff format --check tests/orchestrator/test_context_watchdog.py` — clean
- [ ] CI confirms tests pass on the branch

## Note on pre-existing ruff hints in `context_watchdog.py`

Six ruff hints (`2× I001`, `1× F401`, `3× SIM105`) are present on the runtime script. I verified via `git stash` round-trip that they predate this edit — same six errors with and without my changes. They're not on the CI lint path (CI runs `ruff check src/` only — `scripts/` is out of scope) and cleaning them is out of scope for this dispatch. Calling them out so you can dispatch a follow-up if you want them swept.

No source files outside `scripts/orchestrator/context_watchdog.py` were touched.