### PR TITLE
[ELLIOT] fix(test): mem0 cap-warning tests — June month rollover

### DIFF
--- a/tests/governance/test_mem0_adapter.py
+++ b/tests/governance/test_mem0_adapter.py
@@ -8,6 +8,7 @@ import importlib
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
@@ -152,7 +153,7 @@ def test_cap_warning_fires_at_80_percent_add(log_path, monkeypatch, caplog):
     monkeypatch.setenv("MEM0_API_KEY", "test-key-12345")
     mod, _ = _load_mod_with_mock_client(log_path)
 
-    period = "2026-05"
+    period = datetime.now(timezone.utc).strftime("%Y-%m")
     with open(log_path, "w") as fh:
         fh.write(
             json.dumps(
@@ -179,7 +180,7 @@ def test_cap_warning_fires_at_80_percent_search(log_path, monkeypatch, caplog):
     monkeypatch.setenv("MEM0_API_KEY", "test-key-12345")
     mod, _ = _load_mod_with_mock_client(log_path)
 
-    period = "2026-05"
+    period = datetime.now(timezone.utc).strftime("%Y-%m")
     with open(log_path, "w") as fh:
         fh.write(
             json.dumps(


### PR DESCRIPTION
## Summary
- `test_cap_warning_fires_at_80_percent_add` and `test_cap_warning_fires_at_80_percent_search` hardcoded `period = "2026-05"` in log entries
- `_check_caps()` calls `get_monthly_usage()` with no period arg → defaults to `datetime.now(UTC).strftime("%Y-%m")` = `"2026-06"` in June
- No entries matched current month → no CAP WARNING emitted → both asserts failed
- Fix: compute `period` dynamically from current UTC month in both tests

## Test plan
- [x] Two previously-failing tests now pass locally (verified: `2 passed in 0.15s`)
- [x] Clean single-commit branch directly off main
- [ ] CI green on this branch

Supersedes PR #1386 (had old branch history from watchdog-resume-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)