### PR TITLE
[ATLAS] feat(dispatcher): inject persona_bank prompt via --append-system-prompt in agent_cold_start (KEI Agency_OS-xjtn)

### DIFF
--- a/src/keiracom_system/vault/agent_cold_start.py
+++ b/src/keiracom_system/vault/agent_cold_start.py
@@ -51,6 +51,19 @@ logger = logging.getLogger(__name__)
 AGENT_WORKDIR = os.environ.get("DISPATCHER_AGENT_WORKDIR", "/home/elliotbot/clawd/Agency_OS")
 _DISPATCHER_URL = os.environ.get("DISPATCHER_URL", "http://127.0.0.1:4001")
 CLAUDE_BIN = os.environ.get("CLAUDE_BIN", "claude")
+# xjtn — callsign → (role, variant) for /dispatcher/persona. Mirrors
+# api_agent_cold_start.CALLSIGN_TO_PERSONA so the CLI path injects the same
+# persona_bank prompt the SDK path uses. Kept local (vs imported) to avoid
+# coupling the CLI cold-start to the SDK module.
+_CALLSIGN_TO_PERSONA: dict[str, tuple[str, str]] = {
+    "aiden": ("deliberator", "aiden"),
+    "max": ("deliberator", "max"),
+    "nova": ("worker", "nova"),
+    "orion": ("reviewer", "orion"),
+    "atlas": ("reviewer", "atlas"),
+    "face": ("face", "face"),
+}
+_PERSONA_FETCH_TIMEOUT_S = 2.0
 # NB: public.tasks has NO task_type column — task_type is derived from tags and
 # reaches the agent via the AGENT_TASK_TYPE env var (injected by the dispatcher).
 _TASK_COLS = ("id", "title", "description", "priority", "acceptance_criteria")
@@ -136,9 +149,59 @@ def compose_prompt(task: dict) -> str:
     return "\n\n".join(parts)
 
 
-def run_agent(prompt: str, *, popen: Callable[..., Any] = subprocess.Popen) -> int:
-    """Spawn a fresh headless ``claude`` subprocess for this task (D2). Returns its rc."""
+def fetch_persona_prompt(
+    callsign: str | None, *, dispatcher_url: str = _DISPATCHER_URL
+) -> str | None:
+    """xjtn — GET /dispatcher/persona for this callsign; return prompt_text or None.
+
+    Fail-open by design: missing callsign, unknown mapping, network error, 4xx/5xx,
+    or empty prompt_text all return None and the caller proceeds without
+    --append-system-prompt. Bounded by _PERSONA_FETCH_TIMEOUT_S (no retry —
+    blocking the cold-start on persona fetch is a worse failure than running with
+    no persona). api_agent_cold_start.fetch_persona retries for 60s because the
+    SDK path *requires* a persona; here it is an enhancement.
+    """
+    if not callsign:
+        return None
+    mapping = _CALLSIGN_TO_PERSONA.get(callsign)
+    if mapping is None:
+        logger.warning("agent_cold_start: no persona mapping for callsign=%s", callsign)
+        return None
+    role, variant = mapping
+    url = (
+        f"{dispatcher_url.rstrip('/')}/dispatcher/persona"
+        f"?role={role}&tier=standard&variant={variant}"
+    )
+    try:
+        with urllib.request.urlopen(url, timeout=_PERSONA_FETCH_TIMEOUT_S) as resp:  # noqa: S310
+            payload = json.loads(resp.read())
+        prompt = payload.get("prompt_text")
+        if isinstance(prompt, str) and prompt.strip():
+            return prompt
+        logger.warning("agent_cold_start: persona endpoint returned empty prompt_text")
+        return None
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("agent_cold_start: persona fetch failed (fail-open): %s", exc)
+        return None
+
+
+def run_agent(
+    prompt: str,
+    *,
+    popen: Callable[..., Any] = subprocess.Popen,
+    fetch_persona: Callable[[str | None], str | None] = fetch_persona_prompt,
+) -> int:
+    """Spawn a fresh headless ``claude`` subprocess for this task (D2). Returns its rc.
+
+    xjtn: when AGENT_CALLSIGN resolves to a persona_bank entry, the prompt text
+    is appended to claude's system prompt via --append-system-prompt so the
+    worker actually inherits its role identity (Nova artifact-discipline /
+    Orion+Atlas two-phase review). Fail-open — see fetch_persona_prompt.
+    """
     cmd = [CLAUDE_BIN, "-p", prompt, "--dangerously-skip-permissions"]
+    persona_prompt = fetch_persona(os.environ.get("AGENT_CALLSIGN"))
+    if persona_prompt:
+        cmd.extend(["--append-system-prompt", persona_prompt])
     proc = popen(cmd, cwd=AGENT_WORKDIR)
     return proc.wait()
 

--- a/tests/keiracom_system/vault/test_agent_cold_start.py
+++ b/tests/keiracom_system/vault/test_agent_cold_start.py
@@ -94,10 +94,101 @@ def test_run_agent_spawns_headless_claude():
         proc.wait.return_value = 0
         return proc
 
-    rc = acs.run_agent("PROMPT", popen=fake_popen)
+    # No persona → cmd stays at the baseline four args (preserves pre-xjtn shape).
+    rc = acs.run_agent("PROMPT", popen=fake_popen, fetch_persona=lambda _cs: None)
     assert rc == 0
     assert captured["cmd"] == [acs.CLAUDE_BIN, "-p", "PROMPT", "--dangerously-skip-permissions"]
     assert captured["cwd"] == acs.AGENT_WORKDIR
+
+
+def test_run_agent_appends_persona_when_fetch_returns_prompt(monkeypatch):
+    # xjtn: when /dispatcher/persona returns a prompt for AGENT_CALLSIGN, the
+    # claude CLI is invoked with --append-system-prompt <prompt> so the worker
+    # inherits its persona_bank identity (Nova artifact-discipline etc.).
+    monkeypatch.setenv("AGENT_CALLSIGN", "nova")
+    captured = {}
+
+    def fake_popen(cmd, cwd=None):
+        captured["cmd"] = cmd
+        proc = MagicMock()
+        proc.wait.return_value = 0
+        return proc
+
+    persona = "You are NOVA, the V1 chain execution worker."
+    rc = acs.run_agent(
+        "PROMPT", popen=fake_popen, fetch_persona=lambda cs: persona if cs == "nova" else None
+    )
+    assert rc == 0
+    assert captured["cmd"] == [
+        acs.CLAUDE_BIN,
+        "-p",
+        "PROMPT",
+        "--dangerously-skip-permissions",
+        "--append-system-prompt",
+        persona,
+    ]
+
+
+def test_run_agent_fail_open_when_persona_fetch_returns_none(monkeypatch):
+    # xjtn fail-open: persona unreachable / empty must NOT block spawn — cmd
+    # keeps the baseline shape and the agent runs without a persona prefix.
+    monkeypatch.setenv("AGENT_CALLSIGN", "nova")
+    captured = {}
+
+    def fake_popen(cmd, cwd=None):
+        captured["cmd"] = cmd
+        proc = MagicMock()
+        proc.wait.return_value = 0
+        return proc
+
+    rc = acs.run_agent("PROMPT", popen=fake_popen, fetch_persona=lambda _cs: None)
+    assert rc == 0
+    assert "--append-system-prompt" not in captured["cmd"]
+    assert captured["cmd"] == [acs.CLAUDE_BIN, "-p", "PROMPT", "--dangerously-skip-permissions"]
+
+
+def test_fetch_persona_prompt_returns_none_when_callsign_unset():
+    # Direct unit: no callsign env → return None without making any network call.
+    assert acs.fetch_persona_prompt(None) is None
+    assert acs.fetch_persona_prompt("") is None
+
+
+def test_fetch_persona_prompt_returns_none_for_unknown_callsign():
+    # Unknown callsign in CALLSIGN_TO_PERSONA → log warning + return None, no fetch.
+    assert acs.fetch_persona_prompt("unknown_callsign_xyz") is None
+
+
+def test_fetch_persona_prompt_returns_prompt_on_200(monkeypatch):
+    # Happy path: dispatcher returns {prompt_text: "...", token_count: N} → prompt returned.
+    class _FakeResp:
+        def __init__(self, body):
+            self._body = body
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    body = json.dumps({"prompt_text": "PERSONA-TEXT", "token_count": 42}).encode()
+    monkeypatch.setattr(
+        acs.urllib.request,
+        "urlopen",
+        lambda *a, **kw: _FakeResp(body),  # noqa: ARG005
+    )
+    assert acs.fetch_persona_prompt("nova") == "PERSONA-TEXT"
+
+
+def test_fetch_persona_prompt_fail_open_on_network_error(monkeypatch):
+    # Network error → log warning + return None, never raise.
+    def _raise(*_a, **_kw):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(acs.urllib.request, "urlopen", _raise)
+    assert acs.fetch_persona_prompt("nova") is None
 
 
 def test_finalize_done_without_acceptance_inserts_generic_verification():
@@ -258,7 +349,9 @@ def test_notify_complete_suppressed_when_chain_step_is_intermediate(monkeypatch,
     with caplog.at_level(logging.INFO, logger="src.keiracom_system.vault.agent_cold_start"):
         acs.notify_complete("t-int", "aiden", "Plan KEI-1", "done", 0)
     assert called == []  # urlopen never invoked
-    assert any("suppressed" in rec.message and "aiden_plan" in rec.message for rec in caplog.records)
+    assert any(
+        "suppressed" in rec.message and "aiden_plan" in rec.message for rec in caplog.records
+    )
 
 
 def test_notify_complete_posts_when_chain_step_is_complete(monkeypatch):


### PR DESCRIPTION
## Summary

Wires the CLI cold-start path (`agent_cold_start.run_agent`) to the `persona_bank`. PR #1389 puts production prompts into the DB, but the `claude -p …` subprocess never inherits them. This patch fetches the persona for `AGENT_CALLSIGN` from `GET /dispatcher/persona?role=<role>&tier=standard&variant=<callsign>` and appends `--append-system-prompt <prompt>` to the claude command before exec.

KEI: **Agency_OS-xjtn** — Dave directive 2026-06-01 via Elliot dispatch.

## Why this matters

Without this wiring, the Agency_OS-xjtn proof gate cannot pass — Nova/Orion/Atlas would cold-start with no role identity, and the ~2200-token reviewer prompts would sit unused in `persona_bank` while the CLI worker behaves like a generic `claude` instance. The new prompts in #1389 only become live behaviour once the CLI worker inherits them. The SDK path (`api_agent_cold_start.py`) already does this — this PR closes the equivalent gap on the CLI path.

## Implementation

**File touched:** `src/keiracom_system/vault/agent_cold_start.py` (+65 / -2), plus matching test file.

- `fetch_persona_prompt(callsign)` helper — fail-open, **2s timeout, no retry**. Distinct from `api_agent_cold_start.fetch_persona`'s 60s retry: the SDK path *requires* a persona to run; here it is an enhancement, and blocking startup on a slow / down persona endpoint is a worse failure than running without one.
- `_CALLSIGN_TO_PERSONA` dict — local copy of the SDK path's mapping. Inlined rather than imported to avoid coupling the CLI cold-start module to the SDK cold-start module (the existing direction is SDK → CLI for `_publish_handoff` etc.; flipping it at module level would be new coupling).
- `run_agent(prompt, *, popen, fetch_persona)` — gains a `fetch_persona` injectable kwarg (default points at `fetch_persona_prompt`) so tests can stub it. Calls `fetch_persona(os.environ.get("AGENT_CALLSIGN"))` once before building cmd; conditionally appends `--append-system-prompt <prompt>` iff a non-empty string is returned.

## Fail-open paths

All return `None`, log a warning, never raise:
- `AGENT_CALLSIGN` unset / empty
- callsign not in `_CALLSIGN_TO_PERSONA` (e.g. unknown role)
- `urllib.error.URLError` / `OSError` / `json.JSONDecodeError` on fetch
- 4xx / 5xx HTTP (caught as URLError)
- persona endpoint returns no `prompt_text` or empty string

In every fail case, the claude CLI runs with the pre-xjtn 4-arg command (`[claude, -p, prompt, --dangerously-skip-permissions]`).

## Test coverage

**40 passed in 40.91s, 0 failures.** Five new tests + one updated:

| Test | Asserts |
|---|---|
| `test_run_agent_spawns_headless_claude` (updated) | with `fetch_persona=lambda _: None`, cmd stays at the pre-xjtn 4-arg baseline — back-compat guard |
| `test_run_agent_appends_persona_when_fetch_returns_prompt` | happy path: 6-arg cmd including `--append-system-prompt` + persona text |
| `test_run_agent_fail_open_when_persona_fetch_returns_none` | even with `AGENT_CALLSIGN=nova`, a `None` return drops back to the 4-arg baseline |
| `test_fetch_persona_prompt_returns_none_when_callsign_unset` | no network call attempted for `None` / `""` |
| `test_fetch_persona_prompt_returns_none_for_unknown_callsign` | warning + `None`, no fetch |
| `test_fetch_persona_prompt_returns_prompt_on_200` | returns `prompt_text` from the JSON body via stubbed `urlopen` |
| `test_fetch_persona_prompt_fail_open_on_network_error` | `OSError` surfaces as `None`, never raises |

## Verification (pre-PR)

```
$ ruff check src/keiracom_system/vault/agent_cold_start.py tests/keiracom_system/vault/test_agent_cold_start.py
All checks passed!

$ ruff format --check <same paths>
2 files already formatted

$ python3 -m pytest tests/keiracom_system/vault/test_agent_cold_start.py -x --tb=short
=========== 40 passed, 9 warnings in 40.91s ===========

$ grep -n "append-system-prompt" src/keiracom_system/vault/agent_cold_start.py
159: --append-system-prompt. Bounded by _PERSONA_FETCH_TIMEOUT_S (no retry —
197: is appended to claude's system prompt via --append-system-prompt so the
204:        cmd.extend(["--append-system-prompt", persona_prompt])
```

Confirmed `claude --append-system-prompt <prompt>` is the supported flag via `claude --help` (matches dispatch).

## Test plan

- [ ] CI green (ruff, pytest, type-check)
- [ ] Orion — spec review: `run_agent` cmd shape matches dispatch; fail-open paths cover every error class
- [ ] Elliot — orchestration review: persona fetch does not block / extend cold-start latency under normal conditions
- [ ] Post-merge dependency: PR #1389 must be merged for the dispatcher to actually return non-stub prompts; ordering does not matter for THIS PR (fail-open works against current stub or future deep prompts)
- [ ] Post-merge: live V1 chain dress rehearsal (Case A real artifact + Case B no artifact → REJECTs) — the persona injection is now wired end-to-end

## Governance

- LAW XVI — clean tree before branch.
- LAW V — patch is 67 lines added / 2 deleted in source; ~25 are code, rest are docstring / comment per codebase style. Tests add 97 lines, but every new test is ≤25 lines and the suite is the verification gate.
- LAW XVII — `[ATLAS]` on commit + PR title.
- LAW XIII — no skill change required; this is internal wiring, not a service-call pattern that downstream skills consume.

**Do NOT merge until Orion + Elliot review** per dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)