### PR TITLE
[ATLAS] fix(watchdog): binding_dissent wire — remove gh-pr-merge, gh-api, git-checkout from AUTO_APPROVE_PATTERNS

### DIFF
--- a/scripts/orchestrator/context_watchdog.py
+++ b/scripts/orchestrator/context_watchdog.py
@@ -90,16 +90,28 @@ GENUINE_STALL_INDICATORS = (
 )
 TOOL_CALL_PREFIXES = ("● Bash(", "● Read(", "● Write(")
 AUTO_APPROVE_PATTERNS = [
-    # git — read + routine write on feature branches
+    # git — read + routine write on feature branches.
+    # `git checkout -b` (branch creation) ONLY — NOT bare `git checkout`,
+    # which covers `git checkout -- .` (destructive working-tree reset) and
+    # `git checkout main` (silent branch switch). Max HOLD blocker #1 on
+    # PR #1385 (binding_dissent wire, Dave directive 2026-06-02).
     "git log", "git status", "git diff", "git branch", "git show", "git grep",
     "git add", "git commit", "git fetch", "git pull", "git stash", "git push",
-    "git checkout", "git rev-parse",
-    # GitHub CLI — read
+    "git checkout -b", "git rev-parse",
+    # GitHub CLI — read. `gh api ` substring REMOVED — it cannot distinguish
+    # read endpoints from write endpoints (`gh api … -X PUT/POST/DELETE` and
+    # endpoints like `/pulls/N/merge` are writes wearing a read prefix). Max
+    # HOLD blocker #2 on PR #1385.
     "gh pr view", "gh pr list", "gh pr checks", "gh pr diff",
     "gh issue view", "gh issue list",
-    "gh run view", "gh run list", "gh api ",
-    # GitHub CLI — routine write ops
-    "gh pr comment", "gh pr create", "gh pr merge",
+    "gh run view", "gh run list",
+    # GitHub CLI — routine write ops. `gh pr merge` substring REMOVED —
+    # merges land code in main and MUST gate on verified dual-concur, not on
+    # an unconditional auto-approve. The verified path lives in
+    # is_merge_with_dual_concur (PR comments must contain ≥2 REVIEW:approve
+    # before send_tab fires). Max HOLD blocker #3 + binding_dissent
+    # nucleus on PR #1385 (Dave directive 2026-06-02).
+    "gh pr comment", "gh pr create",
     # tmux read ops
     "tmux capture-pane", "tmux list-sessions", "tmux list-panes", "tmux list-windows",
     # Local scripts — diagnostic, test, lint (no external API spend)

--- a/tests/orchestrator/test_context_watchdog.py
+++ b/tests/orchestrator/test_context_watchdog.py
@@ -445,19 +445,28 @@ def test_merge_with_dual_concur_auto_approves(cw, monkeypatch):
 @pytest.mark.parametrize(
     "tool_str",
     [
-        # git — extended write ops
+        # git — extended write ops. `git checkout -b` (branch creation) is the
+        # ONLY allowed checkout form; bare `git checkout` was removed (binding_dissent
+        # nucleus, Dave 2026-06-02) because it covers destructive paths like
+        # `git checkout -- .` and silent branch switches.
         "Bash(git fetch origin main)",
         "Bash(git pull --rebase)",
         "Bash(git push -u origin atlas/feature)",
-        "Bash(git checkout origin/main -b atlas/feature)",
+        "Bash(git checkout -b nova/feature)",
         "Bash(git rev-parse HEAD)",
-        # GitHub CLI — new read ops
+        # GitHub CLI — new read ops. `gh api ` removed (binding_dissent
+        # nucleus, Dave 2026-06-02): the substring cannot distinguish read
+        # endpoints from `gh api … -X PUT/POST/DELETE` writes or write
+        # endpoints like `/pulls/N/merge`. Anything previously matched by
+        # `gh api ` is now an explicit escalation to Dave.
         "Bash(gh run view 26731207618)",
         "Bash(gh run list --workflow ci.yml --limit 5)",
-        "Bash(gh api repos/Keiracom/Agency_OS/pulls/1378)",
-        # GitHub CLI — new write ops
+        # GitHub CLI — new write ops. `gh pr merge` removed (binding_dissent
+        # nucleus, Dave 2026-06-02): merges land code in main and MUST gate
+        # on verified dual-concur via is_merge_with_dual_concur, not on a
+        # blanket auto-approve. test_merge_with_dual_concur_auto_approves
+        # is the proof that the verified path still works after this change.
         "Bash(gh pr create --title 'feat' --body '…')",
-        "Bash(gh pr merge 1234 --squash --admin)",
         # tmux — extended read ops
         "Bash(tmux list-sessions)",
         "Bash(tmux list-panes -t atlas)",
@@ -519,6 +528,25 @@ def test_auto_approve_pattern_expansion_covers_new_categories(cw, tool_str):
         # global config, NOT in the allow-list. Catches accidental "git "
         # prefix-only matches.
         "Bash(git config user.email evil@example)",
+        # ── binding_dissent nucleus (Dave 2026-06-02) ─────────────────────
+        # `gh pr merge` was removed from AUTO_APPROVE_PATTERNS because
+        # merges land code in main. The verified path is
+        # is_merge_with_dual_concur; the substring path must NOT exist.
+        # A blanket auto-approve here defeats the whole review/dissent
+        # mechanism — this test enforces that the substring is gone.
+        "Bash(gh pr merge 1234 --squash --admin)",
+        # `gh api ` was removed because the substring cannot tell read from
+        # write. `gh api … /pulls/N/merge -X PUT` is the canonical bypass —
+        # it looks like an api read but performs a merge. Must escalate.
+        "Bash(gh api repos/Keiracom/Agency_OS/pulls/1385/merge -X PUT)",
+        # Bare `git checkout` was removed because it covers
+        # `git checkout -- .` (destructive working-tree reset — discards
+        # uncommitted work). The allow-list now requires `git checkout -b`
+        # explicitly. This test pins that `--` forms still escalate.
+        "Bash(git checkout -- .)",
+        # Another bare `git checkout` form — silent branch switch can move
+        # the working tree to an arbitrary ref. Must escalate, not auto-tab.
+        "Bash(git checkout main)",
     ],
 )
 def test_auto_approve_pattern_expansion_rejects_dangerous(cw, tool_str):


### PR DESCRIPTION
## Summary

**Resolves Max HOLD on PR #1385 (blockers 1+2+medium). Implements binding_dissent nucleus component per Dave directive 2026-06-02.**

Three substrings removed from `AUTO_APPROVE_PATTERNS` in `scripts/orchestrator/context_watchdog.py`. Each removal closes a specific bypass that the merged PR #1385 left open. The verified-dual-concur path (`is_merge_with_dual_concur`) is now the **only** way `gh pr merge` prompts auto-approve — this IS the binding_dissent wire.

## The three removals

| Removed substring | Bypass it enabled | What replaces it |
|---|---|---|
| `git checkout` (bare) | `git checkout -- .` (destructive working-tree reset — discards uncommitted work); `git checkout main` (silent branch switch) | `git checkout -b` (branch creation ONLY) |
| `gh api ` | `gh api .../pulls/N/merge -X PUT` (write API endpoint disguised as a read); `gh api … -X POST / -X DELETE` | Nothing — explicit escalation to Dave |
| `gh pr merge` | Any merge of any PR auto-approves on substring match alone | Falls through to `is_merge_with_dual_concur` (lines 169-188) — calls `gh pr view <N> --json comments`; requires ≥2 `REVIEW:approve` comments before `send_tab` fires |

## Why `gh pr merge` removal IS the binding_dissent wire

Before: `is_auto_approvable("Bash(gh pr merge 1375 --squash --admin)")` → `True` (substring match) → `send_tab` immediately, dual-concur check never runs.

After: `is_auto_approvable(...)` → `False` → flow reaches `is_merge_with_dual_concur(...)` → it fetches PR comments via `gh pr view --json comments` → counts `REVIEW:approve` lines → only returns `True` if ≥2. Dissent from any deliberator (zero or one approves) → escalation to Dave, no auto-merge.

`test_merge_with_dual_concur_auto_approves` (line 418) was the existing proof that the verified path works; it **still passes** after my removal because the dual-concur fork was always the intended path, just shadowed by the broken substring shortcut.

## Test changes

In `tests/orchestrator/test_context_watchdog.py`:

**Removed from positive list** (`test_auto_approve_pattern_expansion_covers_new_categories`):
- `Bash(git checkout origin/main -b atlas/feature)` — relied on bare `git checkout` substring
- `Bash(gh api repos/Keiracom/Agency_OS/pulls/1378)` — relied on `gh api `
- `Bash(gh pr merge 1234 --squash --admin)` — relied on `gh pr merge`

**Added to positive list** (1 entry):
- `Bash(git checkout -b nova/feature)` — proves the narrowed `git checkout -b` pattern still admits safe branch creation

**Added to rejection list** (`test_auto_approve_pattern_expansion_rejects_dangerous`, 4 entries):
- `Bash(gh pr merge 1234 --squash --admin)` — binding_dissent enforcement: blanket auto-approve is gone, only dual-concur verified path can pass
- `Bash(gh api repos/Keiracom/Agency_OS/pulls/1385/merge -X PUT)` — canonical bypass form (write API endpoint disguised as a read)
- `Bash(git checkout -- .)` — destructive reset; must escalate
- `Bash(git checkout main)` — silent branch switch; must escalate

Net: -3 positive +1 positive +4 negative = **+2 test cases**, 73 → 75 total.

## Verification (verbatim)

```
$ python3 -m pytest tests/orchestrator/test_context_watchdog.py
tests/orchestrator/test_context_watchdog.py ............................ [ 37%]
...............................................                          [100%]
============================== 75 passed in 7.15s ==============================

$ ruff check src/ scripts/orchestrator/context_watchdog.py
[src/ clean]
6 pre-existing hints in scripts/orchestrator/context_watchdog.py (SIM105 ×3,
I001 ×2, F401 ×1) — verified against origin/main as predating this edit.
PR #1385 explicitly noted these are not on the CI lint path (CI runs `ruff check src/`
only — scripts/ is out of scope).

$ ruff check tests/orchestrator/test_context_watchdog.py
All checks passed!

$ ruff format --check tests/orchestrator/test_context_watchdog.py
1 file already formatted
```

## Settings.json discrepancy — surfacing not resolving

The dispatch said: *"Also fix settings.json (.claude/settings.json in repo root): remove 'Bash(gh pr merge*)' from permissions.allow list."*

Findings:
- `.claude/settings.json` (committed) has only `permissions: { defaultMode: bypassPermissions }` — no `allow` array at all.
- `.claude/settings.local.json` (gitignored — `git check-ignore` confirmed) has a `permissions.allow` array but no `Bash(gh pr merge*)` entry. It does have `Bash(git checkout *)`, which mirrors a similar concern but is a separate file under separate (host-local) state.

No settings file was modified in this PR — the dispatched key does not exist in either file. The binding enforcement on merges lives in the source patch + the dual-concur gate; the settings-permission layer was secondary defense-in-depth. Elliot — if you intended a different settings location or wanted the `Bash(git checkout *)` entry in `.claude/settings.local.json` narrowed to `Bash(git checkout -b *)`, that is a separate gitignored-file change outside this PR's scope.

## Test plan

- [ ] CI green
- [ ] Max — quality / binding_dissent check: confirm removals close blockers 1+2+medium on PR #1385; confirm `is_merge_with_dual_concur` is now the sole auto-approve path for merges
- [ ] Orion — spec review: test cases cover both positive (narrowed pattern admits safe forms) and negative (dangerous variants escalate) paths
- [ ] Elliot — orchestration: confirm whether the settings.json change was meant for a different location

## Governance

- LAW XVI — clean tree before branch (the unrelated `.claude/settings.json` stash from a prior session remains in `git stash` and is not part of this PR).
- LAW V — patch is 52 insertions / 12 deletions across 2 files. Source change is ~12 lines of code (3 substring removals + 1 narrowed), rest is comment-heavy explanation per codebase style. Tests add 5 new entries totalling ~20 lines + comments. Well-bounded.
- LAW XVII — `[ATLAS]` on commit + PR title.
- LAW XIII — no skill change; binding_dissent is internal watchdog enforcement, not a service-call pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)