### PR TITLE
[NOVA] fix(chain): NATS JetStream durable consumer for keiracom.agent.handoff

### DIFF
--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -72,6 +72,19 @@ PARALLEL_AFTER_STEP: dict[str, list[str]] = {
 # from_callsign}. `chain_id == task_id` per Elliot's spec — dispatch() defaults
 # chain_id to task["id"] so state lookups by task_id resolve.
 CONSUMER_SUBJECT = "keiracom.agent.handoff"
+
+# JetStream durable consumer for keiracom.agent.handoff (Dave directive 2026-06-02
+# — NATS handoff stall fix). Core pub/sub drops messages published during
+# dispatcher downtime; a JS durable consumer with WorkQueue retention buffers
+# them until the consumer reconnects and acks. Storage=File so messages also
+# survive a NATS broker restart. Retention=WorkQueue (not Limits) so each
+# message is consumed exactly once across all consumers and removed on ack —
+# Limits would keep the message until age/size eviction, causing duplicate
+# dispatches if the consumer reset its sequence cursor.
+JS_STREAM_NAME = "agent_handoff"
+JS_CONSUMER_DURABLE = "chain-orchestrator"
+JS_DELIVER_SUBJECT = "_INBOX.chain_orch"
+
 FROM_TO_STEP: dict[str, str] = {
     "aiden": "aiden_plan",
     "max": "max_challenge",
@@ -273,7 +286,18 @@ def _save_state(state: dict) -> None:
 
 
 async def _publish_async(envelope: dict, role: str) -> bool:
-    """Inner async NATS publish — mirrors supervisor_wake_publish.publish_wake."""
+    """Inner async NATS publish — mirrors supervisor_wake_publish.publish_wake.
+
+    Publishes to keiracom.dispatch.<role>, which is NOT bound to the
+    agent_handoff JetStream — dispatch hops are routed via the
+    /dispatcher/spawn HTTP path (_publish_envelope). This NATS publisher
+    remains a core publish for any direct-NATS subscriber that may still
+    listen on dispatch.<role>. The handoff JS stream subscribes to a
+    different subject (CONSUMER_SUBJECT == keiracom.agent.handoff) — that
+    capture is by subject binding on the publisher side too: any core
+    nc.publish() to keiracom.agent.handoff is captured by the stream without
+    requiring a js.publish() call.
+    """
     subject = DISPATCH_SUBJECT_PATTERN.format(callsign=role)
     try:
         import nats  # lazy — keeps module collectable on CI hosts without nats-py
@@ -668,14 +692,118 @@ async def _consumer_handle_envelope_async(envelope: dict) -> list[dict]:
         return []
 
 
+async def _ensure_handoff_stream(js, subject: str = CONSUMER_SUBJECT) -> bool:
+    """Bind to or create the JetStream stream covering subject. Returns success bool.
+
+    Idempotent: if the stream already exists we proceed without modifying its
+    config (an operator may have tuned storage tiers manually — refusing to
+    overwrite preserves their intent). Returns False on any setup failure so
+    run_consumer can fall back to core subscribe.
+    """
+    from nats.js.api import RetentionPolicy, StorageType, StreamConfig  # noqa: PLC0415
+    from nats.js.errors import NotFoundError  # noqa: PLC0415
+
+    try:
+        await js.stream_info(JS_STREAM_NAME)
+        return True
+    except NotFoundError:
+        pass
+    except Exception as exc:  # noqa: BLE001 — fall-back to core subscribe
+        log.warning("v1_chain consumer: stream_info failed: %s", exc)
+        return False
+    try:
+        await js.add_stream(
+            config=StreamConfig(
+                name=JS_STREAM_NAME,
+                subjects=[subject],
+                retention=RetentionPolicy.WORK_QUEUE,
+                storage=StorageType.FILE,
+            )
+        )
+        log.info(
+            "v1_chain consumer: created JS stream=%s subject=%s retention=workqueue storage=file",
+            JS_STREAM_NAME,
+            subject,
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001
+        log.warning("v1_chain consumer: add_stream failed: %s", exc)
+        return False
+
+
+async def _subscribe_jetstream_durable(js, subject, handler):
+    """Create a durable push consumer + subscribe. Returns the subscription, or None on failure."""
+    from nats.js.api import AckPolicy, ConsumerConfig  # noqa: PLC0415
+
+    try:
+        sub = await js.subscribe(
+            subject=subject,
+            durable=JS_CONSUMER_DURABLE,
+            cb=handler,
+            manual_ack=True,
+            config=ConsumerConfig(
+                durable_name=JS_CONSUMER_DURABLE,
+                deliver_subject=JS_DELIVER_SUBJECT,
+                ack_policy=AckPolicy.EXPLICIT,
+            ),
+        )
+        log.info(
+            "v1_chain consumer: JS durable=%s subscribed %s deliver=%s",
+            JS_CONSUMER_DURABLE,
+            subject,
+            JS_DELIVER_SUBJECT,
+        )
+        return sub
+    except Exception as exc:  # noqa: BLE001
+        log.warning("v1_chain consumer: JS subscribe failed: %s", exc)
+        return None
+
+
+async def _dispatch_handoff_message(msg) -> None:
+    """Decode + dispatch a single NATS message. Ack on success, nak on advance failure.
+
+    Malformed payloads are acked (permanent — re-delivery would loop). Handler
+    exceptions are naked so the WorkQueue stream re-delivers. Core (non-JS)
+    subscribe path: ack/nak are no-ops because the msg object has no such methods.
+    """
+    ack_fn = getattr(msg, "ack", None)
+    nak_fn = getattr(msg, "nak", None)
+    try:
+        payload = json.loads(msg.data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        log.warning("v1_chain consumer: malformed payload: %s", exc)
+        if callable(ack_fn):
+            with contextlib.suppress(Exception):
+                await ack_fn()
+        return
+    try:
+        await _consumer_handle_envelope_async(payload)
+    except Exception:  # noqa: BLE001 — log + nak; never raise out of cb
+        log.warning("v1_chain consumer: dispatch failed; naking for redelivery", exc_info=True)
+        if callable(nak_fn):
+            with contextlib.suppress(Exception):
+                await nak_fn()
+        return
+    if callable(ack_fn):
+        with contextlib.suppress(Exception):
+            await ack_fn()
+
+
 async def run_consumer(nats_url: str | None = None) -> None:
-    """Subscribe to CONSUMER_SUBJECT and advance the chain on each handoff.
+    """Subscribe to CONSUMER_SUBJECT (durable JS consumer) and advance the chain on each handoff.
+
+    Uses a JetStream durable push consumer (stream=agent_handoff,
+    durable=chain-orchestrator, retention=WorkQueue, storage=File) so handoff
+    messages published during dispatcher downtime survive restarts and get
+    delivered when the consumer reconnects. Falls back to non-durable core
+    nc.subscribe() if JetStream is unavailable or setup fails — preserves
+    pre-fix behaviour on hosts without JS at the cost of dropped messages
+    during downtime (logged loudly).
 
     Long-running; cancellable via task.cancel() — closes the NATS connection.
-    Mirrors peer_event_ceo_relay.main() loop pattern.
     """
     try:
-        import nats  # lazy — keeps module collectable on hosts without nats-py
+        import nats  # noqa: PLC0415 — lazy; keeps module collectable without nats-py
     except ImportError as exc:
         log.error("v1_chain consumer: nats-py not installed; loop exits (%s)", exc)
         return
@@ -686,18 +814,34 @@ async def run_consumer(nats_url: str | None = None) -> None:
         log.error("v1_chain consumer: NATS connect failed url=%s: %s", url, exc)
         return
 
-    async def _handler(msg) -> None:
-        # Thin delegate (Max HOLD): bytes → dict → delegate to the async helper.
+    js_subscribed = False
+    try:
+        js = nc.jetstream()
+        if await _ensure_handoff_stream(js, CONSUMER_SUBJECT):
+            sub = await _subscribe_jetstream_durable(
+                js, CONSUMER_SUBJECT, _dispatch_handoff_message
+            )
+            js_subscribed = sub is not None
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "v1_chain consumer: JetStream setup failed (%s) — falling back to core subscribe", exc
+        )
+
+    if not js_subscribed:
+        log.warning(
+            "v1_chain consumer: durable JS unavailable — using core subscribe; "
+            "handoffs published during downtime WILL be dropped"
+        )
         try:
-            payload = json.loads(msg.data.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            log.warning("v1_chain consumer: malformed payload: %s", exc)
+            await nc.subscribe(CONSUMER_SUBJECT, cb=_dispatch_handoff_message)
+            log.info("v1_chain consumer: core-sub subscribed %s on %s", CONSUMER_SUBJECT, url)
+        except Exception as exc:  # noqa: BLE001
+            log.error("v1_chain consumer: core subscribe failed: %s", exc)
+            with contextlib.suppress(Exception):
+                await nc.close()
             return
-        await _consumer_handle_envelope_async(payload)
 
     try:
-        await nc.subscribe(CONSUMER_SUBJECT, cb=_handler)
-        log.info("v1_chain consumer: subscribed %s on %s", CONSUMER_SUBJECT, url)
         while True:
             await asyncio.sleep(60)
     finally:

--- a/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
+++ b/tests/keiracom_system/chain/test_v1_chain_orchestrator.py
@@ -1034,3 +1034,208 @@ def test_advance_step_fail_open_when_query_returns_none(
     state = json.loads(state_file.read_text())
     assert state[chain_id]["current_step"] == "max_challenge"
     assert state[chain_id].get("ceiling_tripped") is not True
+
+
+# ---------------------------------------------------------------------------
+# JetStream durable consumer (Dave directive 2026-06-02 — handoff stall fix)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAckMsg:
+    """NATS msg double exposing data + async ack/nak counters."""
+
+    def __init__(self, data: bytes):
+        self.data = data
+        self.ack_calls = 0
+        self.nak_calls = 0
+
+    async def ack(self) -> None:
+        self.ack_calls += 1
+
+    async def nak(self) -> None:
+        self.nak_calls += 1
+
+
+async def test_ensure_handoff_stream_returns_true_when_stream_exists(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If stream_info succeeds, helper returns True without calling add_stream."""
+    add_called = {"n": 0}
+
+    class _FakeJS:
+        async def stream_info(self, name: str):
+            assert name == orch.JS_STREAM_NAME
+            return object()  # success — any non-exception return
+
+        async def add_stream(self, *, config):  # pragma: no cover — should not fire
+            add_called["n"] += 1
+
+    ok = await orch._ensure_handoff_stream(_FakeJS(), orch.CONSUMER_SUBJECT)
+    assert ok is True
+    assert add_called["n"] == 0
+
+
+async def test_ensure_handoff_stream_creates_on_not_found():
+    """If stream_info raises NotFoundError, helper calls add_stream and returns True."""
+    from nats.js.errors import NotFoundError
+
+    created: dict = {}
+
+    class _FakeJS:
+        async def stream_info(self, name: str):
+            raise NotFoundError()
+
+        async def add_stream(self, *, config):
+            created["name"] = config.name
+            created["subjects"] = list(config.subjects)
+            created["retention"] = config.retention
+            created["storage"] = config.storage
+
+    ok = await orch._ensure_handoff_stream(_FakeJS(), orch.CONSUMER_SUBJECT)
+    from nats.js.api import RetentionPolicy, StorageType
+
+    assert ok is True
+    assert created["name"] == orch.JS_STREAM_NAME
+    assert created["subjects"] == [orch.CONSUMER_SUBJECT]
+    assert created["retention"] == RetentionPolicy.WORK_QUEUE
+    assert created["storage"] == StorageType.FILE
+
+
+async def test_ensure_handoff_stream_returns_false_when_add_raises():
+    """If add_stream raises, helper returns False (fall-back to core sub upstream)."""
+    from nats.js.errors import NotFoundError
+
+    class _FakeJS:
+        async def stream_info(self, name: str):
+            raise NotFoundError()
+
+        async def add_stream(self, *, config):
+            raise RuntimeError("broker rejected")
+
+    ok = await orch._ensure_handoff_stream(_FakeJS(), orch.CONSUMER_SUBJECT)
+    assert ok is False
+
+
+async def test_subscribe_jetstream_durable_passes_consumer_config():
+    """js.subscribe is called with durable + manual_ack + EXPLICIT ack policy."""
+    captured: dict = {}
+
+    class _FakeJS:
+        async def subscribe(self, *, subject, durable, cb, manual_ack, config):
+            captured["subject"] = subject
+            captured["durable"] = durable
+            captured["manual_ack"] = manual_ack
+            captured["durable_name"] = config.durable_name
+            captured["deliver_subject"] = config.deliver_subject
+            captured["ack_policy"] = config.ack_policy
+            return object()  # sub handle
+
+    async def _cb(msg):  # pragma: no cover — not invoked
+        pass
+
+    sub = await orch._subscribe_jetstream_durable(_FakeJS(), orch.CONSUMER_SUBJECT, _cb)
+    from nats.js.api import AckPolicy
+
+    assert sub is not None
+    assert captured["subject"] == orch.CONSUMER_SUBJECT
+    assert captured["durable"] == orch.JS_CONSUMER_DURABLE
+    assert captured["manual_ack"] is True
+    assert captured["durable_name"] == orch.JS_CONSUMER_DURABLE
+    assert captured["deliver_subject"] == orch.JS_DELIVER_SUBJECT
+    assert captured["ack_policy"] == AckPolicy.EXPLICIT
+
+
+async def test_subscribe_jetstream_durable_returns_none_on_failure():
+    """Subscribe failure returns None so caller can fall back to core sub."""
+
+    class _FakeJS:
+        async def subscribe(self, **kwargs):
+            raise RuntimeError("no JS")
+
+    sub = await orch._subscribe_jetstream_durable(_FakeJS(), orch.CONSUMER_SUBJECT, lambda m: None)
+    assert sub is None
+
+
+async def test_dispatch_handoff_message_acks_on_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Well-formed payload + successful handler → ack, no nak."""
+    _capture_publishes(monkeypatch)
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+    chain_id = "task-js-1"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": chain_id,
+            "brief": "x",
+            "started_ts": 0.0,
+            "current_step": "aiden_plan",
+            "steps_done": [],
+            "atom_ids": {},
+            "pending": [],
+        },
+    )
+    envelope = {"task_id": chain_id, "atom_id": "a1", "from_callsign": "aiden"}
+    msg = _FakeAckMsg(json.dumps(envelope).encode("utf-8"))
+    await orch._dispatch_handoff_message(msg)
+    assert msg.ack_calls == 1
+    assert msg.nak_calls == 0
+
+
+async def test_dispatch_handoff_message_acks_on_malformed_payload():
+    """Permanent parse failure → ack (drop), not nak (which would redeliver forever)."""
+    msg = _FakeAckMsg(b"\xff\xfe not json")
+    await orch._dispatch_handoff_message(msg)
+    assert msg.ack_calls == 1
+    assert msg.nak_calls == 0
+
+
+async def test_dispatch_handoff_message_naks_on_handler_exception(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Handler raise → nak so the WorkQueue stream redelivers; never propagates."""
+
+    async def _boom(_payload):
+        raise RuntimeError("downstream blew up")
+
+    monkeypatch.setattr(orch, "_consumer_handle_envelope_async", _boom)
+    envelope = {"task_id": "t", "atom_id": "a", "from_callsign": "aiden"}
+    msg = _FakeAckMsg(json.dumps(envelope).encode("utf-8"))
+    await orch._dispatch_handoff_message(msg)  # must NOT raise
+    assert msg.ack_calls == 0
+    assert msg.nak_calls == 1
+
+
+async def test_dispatch_handoff_message_core_subscribe_no_ack_attrs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Core-subscribe msgs have no ack/nak methods — helper must not crash."""
+    _capture_publishes(monkeypatch)
+    state_file = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_file)
+    chain_id = "task-core-1"
+    _seed_state(
+        tmp_path,
+        chain_id,
+        {
+            "chain_id": chain_id,
+            "task_id": chain_id,
+            "brief": "x",
+            "started_ts": 0.0,
+            "current_step": "aiden_plan",
+            "steps_done": [],
+            "atom_ids": {},
+            "pending": [],
+        },
+    )
+
+    class _CoreMsg:
+        def __init__(self, data: bytes):
+            self.data = data
+
+    envelope = {"task_id": chain_id, "atom_id": "a1", "from_callsign": "aiden"}
+    msg = _CoreMsg(json.dumps(envelope).encode("utf-8"))
+    await orch._dispatch_handoff_message(msg)  # must NOT crash on missing ack/nak


### PR DESCRIPTION
## Summary

- Dave directive 2026-06-02 — fixes the NATS handoff stall where messages published during dispatcher downtime were silently dropped (core `nc.subscribe`).
- `run_consumer` now uses a JetStream **durable push consumer** (`stream=agent_handoff`, `durable=chain-orchestrator`, `retention=WorkQueue`, `storage=File`, `AckPolicy=Explicit`) so handoffs buffer in the stream and replay on dispatcher reconnect.
- Fail-open: if JetStream is unavailable or stream setup fails, falls back to non-durable core `nc.subscribe()` (preserves pre-fix behaviour on hosts without JS, logged loudly so the downgrade is visible).

## Design notes

- **WorkQueue** retention (not Limits) — each message consumed exactly once across all consumers, then removed. Limits would let stale messages re-deliver on cursor reset → duplicate hop dispatches.
- **File** storage — survives a NATS broker restart, not just a consumer restart.
- **Explicit** ack — ack only after `_advance_step_async` succeeds; nak on handler exception so WorkQueue redelivers. Malformed payloads are acked (drop) — naking permanent parse failures would loop forever.
- `_publish_async` left unchanged: it publishes to `keiracom.dispatch.<role>`, a different subject from the JS-bound `keiracom.agent.handoff`. Any future publisher to the handoff subject (e.g. `vault/save_exit_atoms`) is captured automatically by subject binding — no `js.publish()` API change needed at the publisher site.

## Implementation

Helpers added in-module per dispatch constraint ("stay in `run_consumer` — do not add a separate module"):
- `_ensure_handoff_stream(js, subject)` — idempotent stream bind/create
- `_subscribe_jetstream_durable(js, subject, handler)` — durable consumer
- `_dispatch_handoff_message(msg)` — ack/nak-aware delegate that also works for core-sub msgs without ack methods

## Tests

- 9 new (38 total, all pass): stream-exists, NotFound→create, add_stream failure, subscribe config, subscribe failure, ack on success, ack on malformed payload (drop), nak on handler exception (redeliver), core-sub graceful no-attr case.
- Ruff lint + format: pass.

## Test plan

- [x] `python3 -m pytest tests/keiracom_system/chain/ -x` → 38 passed
- [x] `ruff check src/keiracom_system/chain/v1_chain_orchestrator.py tests/keiracom_system/chain/test_v1_chain_orchestrator.py` → All checks passed
- [x] `ruff format --check ...` → 2 files already formatted
- [ ] Binding review: Elliot + one other deliberator
- [ ] Manual smoke against live Temporal-paired NATS host (operator step, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)