### PR TITLE
[SCOUT] feat(fleet): on-box liveness checker — ground-truth per-agent status (5min cadence)

### DIFF
--- a/scripts/install_fleet_liveness_checker.sh
+++ b/scripts/install_fleet_liveness_checker.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# install_fleet_liveness_checker.sh — Install fleet liveness checker (Head of Ops directive 2026-06-02).
+# Anchored units (KEI-108 grep gate):
+#   fleet-liveness-checker.service
+#   fleet-liveness-checker.timer
+#
+# Run once on the host after the PR lands on main and `git pull` has synced
+# scripts/orchestrator/fleet_liveness_checker.py into ~/clawd/Agency_OS/.
+# The systemd unit's ExecStart resolves to the main worktree via %h macro.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UNIT_DIR="${HOME}/.config/systemd/user"
+
+mkdir -p "$UNIT_DIR"
+cp "$REPO_ROOT/systemd/fleet-liveness-checker.service" "$UNIT_DIR/"
+cp "$REPO_ROOT/systemd/fleet-liveness-checker.timer" "$UNIT_DIR/"
+
+systemctl --user daemon-reload
+systemctl --user enable --now fleet-liveness-checker.timer
+
+echo "fleet-liveness-checker.timer installed and started"

--- a/scripts/orchestrator/fleet_liveness_checker.py
+++ b/scripts/orchestrator/fleet_liveness_checker.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""fleet_liveness_checker.py — on-box ground-truth liveness probe (5min cadence).
+
+Invoked by fleet-liveness-checker.timer every 5 minutes. For each callsign
+in CALLSIGNS, probes four signals from outside the agent's own process and
+writes one row to public.fleet_liveness:
+
+  1. tmux_alive   — `tmux has-session -t <callsign>` (or <callsign>bot fallback
+                    for elliottbot / maxbot)
+  2. nats_last_publish_at — last message timestamp on
+                            keiracom.agent.status.<callsign> via NATS JetStream
+  3. backend_health — trimmed body from http://localhost:8000/health (256 chars)
+  4. active_task_id — current claimed-active task for the callsign
+
+Side effect: for every callsign with tmux_alive=True AND active_task_id IS NOT
+NULL, also updates public.tasks.heartbeat_at=NOW() — revives the heartbeat
+column as a liveness signal for agents that have not wired the per-task
+heartbeat themselves.
+
+All external calls are fail-graceful: a missing tmux session, NATS down,
+backend unreachable, or DB read error never crash the script. The timer
+keeps firing.
+
+Exit codes:
+  0 — all writes attempted (some may have failed gracefully and logged)
+  2 — fatal configuration error (DATABASE_URL unset)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from datetime import UTC, datetime
+
+logger = logging.getLogger("fleet_liveness_checker")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+CALLSIGNS = ["elliot", "aiden", "max", "atlas", "orion", "scout", "nova"]
+
+# tmux session name overrides — elliot runs in `elliottbot`, max in `maxbot`.
+TMUX_ALIASES = {"elliot": "elliottbot", "max": "maxbot"}
+
+BACKEND_HEALTH_URL = "http://localhost:8000/health"
+BACKEND_TIMEOUT_SEC = 2
+NATS_TIMEOUT_SEC = 3
+NATS_STREAM = "agent_status"
+NATS_SUBJECT_FMT = "keiracom.agent.status.{callsign}"
+HEALTH_BODY_MAX = 256
+
+_INSERT_SQL = """
+INSERT INTO public.fleet_liveness
+    (callsign, checked_at, tmux_alive, nats_last_publish_at, backend_health, active_task_id)
+VALUES (%s, NOW(), %s, %s, %s, %s)
+"""
+
+_ACTIVE_TASK_SQL = """
+SELECT id::text FROM public.tasks
+WHERE claimed_by = %s AND status = 'active'
+ORDER BY claimed_at DESC NULLS LAST
+LIMIT 1
+"""
+
+_HEARTBEAT_UPDATE_SQL = """
+UPDATE public.tasks SET heartbeat_at = NOW()
+WHERE claimed_by = %s AND status = 'active'
+"""
+
+
+def _resolve_dsn() -> str | None:
+    raw = os.environ.get("DATABASE_URL") or os.environ.get("SUPABASE_DB_URL", "")
+    if not raw:
+        return None
+    return raw.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def _probe_tmux(callsign: str) -> bool:
+    """True when tmux session exists. Tries <callsign> then <callsign>bot."""
+    if not shutil.which("tmux"):
+        return False
+    candidates = [callsign]
+    alias = TMUX_ALIASES.get(callsign)
+    if alias and alias != callsign:
+        candidates.append(alias)
+    for name in candidates:
+        try:
+            # `=<name>` forces exact-match — otherwise tmux uses prefix matching
+            # and e.g. `nova-paused` would satisfy a probe for `nova`.
+            result = subprocess.run(
+                ["tmux", "has-session", "-t", f"={name}"],
+                capture_output=True,
+                timeout=3,
+                check=False,
+            )
+            if result.returncode == 0:
+                return True
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            logger.debug("tmux probe %s failed: %s", name, exc)
+    return False
+
+
+def _probe_nats_last_publish(callsign: str) -> datetime | None:
+    """Last message timestamp on keiracom.agent.status.<callsign>, or None."""
+    if not shutil.which("nats"):
+        return None
+    subject = NATS_SUBJECT_FMT.format(callsign=callsign)
+    try:
+        result = subprocess.run(
+            ["nats", "stream", "get", NATS_STREAM, "--last-for", subject, "--json"],
+            capture_output=True,
+            timeout=NATS_TIMEOUT_SEC,
+            check=False,
+            text=True,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("nats probe %s failed: %s", subject, exc)
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    ts_raw = payload.get("time") or payload.get("timestamp")
+    if not ts_raw:
+        return None
+    try:
+        return datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _probe_backend_health() -> str | None:
+    """Trimmed response body from BACKEND_HEALTH_URL, or None on failure."""
+    if not shutil.which("curl"):
+        return None
+    try:
+        result = subprocess.run(
+            ["curl", "-sS", "-m", str(BACKEND_TIMEOUT_SEC), "-f", BACKEND_HEALTH_URL],
+            capture_output=True,
+            timeout=BACKEND_TIMEOUT_SEC + 1,
+            check=False,
+            text=True,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("backend health probe failed: %s", exc)
+        return None
+    if result.returncode != 0:
+        return None
+    body = (result.stdout or "").strip()
+    return body[:HEALTH_BODY_MAX] if body else None
+
+
+def _query_active_task(cur, callsign: str) -> str | None:
+    try:
+        cur.execute(_ACTIVE_TASK_SQL, (callsign,))
+        row = cur.fetchone()
+        return row[0] if row else None
+    except Exception as exc:  # noqa: BLE001 — fail-graceful per script contract
+        logger.warning("active-task lookup failed for %s: %s", callsign, exc)
+        return None
+
+
+def _revive_task_heartbeat(cur, callsign: str) -> None:
+    try:
+        cur.execute(_HEARTBEAT_UPDATE_SQL, (callsign,))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("heartbeat revive failed for %s: %s", callsign, exc)
+
+
+def main() -> int:
+    dsn = _resolve_dsn()
+    if not dsn:
+        print("fleet_liveness_checker: DATABASE_URL unset", file=sys.stderr)
+        return 2
+
+    try:
+        import psycopg
+    except ImportError:
+        print("fleet_liveness_checker: psycopg not installed", file=sys.stderr)
+        return 2
+
+    written = 0
+    revived = 0
+    started = datetime.now(UTC)
+
+    try:
+        with psycopg.connect(dsn, prepare_threshold=None) as conn:
+            with conn.cursor() as cur:
+                for callsign in CALLSIGNS:
+                    tmux_alive = _probe_tmux(callsign)
+                    nats_ts = _probe_nats_last_publish(callsign)
+                    health = _probe_backend_health()
+                    active_task = _query_active_task(cur, callsign)
+
+                    try:
+                        cur.execute(
+                            _INSERT_SQL,
+                            (callsign, tmux_alive, nats_ts, health, active_task),
+                        )
+                        written += 1
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("fleet_liveness insert failed for %s: %s", callsign, exc)
+                        conn.rollback()
+                        continue
+
+                    if tmux_alive and active_task:
+                        _revive_task_heartbeat(cur, callsign)
+                        revived += 1
+
+            conn.commit()
+    except Exception as exc:  # noqa: BLE001 — fail-graceful at the outer connection level
+        logger.warning("fleet_liveness_checker: DB error — fail-open: %s", exc)
+        return 0
+
+    elapsed = (datetime.now(UTC) - started).total_seconds()
+    logger.info(
+        "fleet_liveness_checker: wrote %d/%d rows, revived %d task heartbeats in %.2fs",
+        written,
+        len(CALLSIGNS),
+        revived,
+        elapsed,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/supabase/migrations/20260602_fleet_liveness.sql
+++ b/supabase/migrations/20260602_fleet_liveness.sql
@@ -1,0 +1,53 @@
+-- Fleet liveness ground-truth — on-box checker writes per-agent status every
+-- 5 minutes so the read-side fleet_check_query can score callsigns GREEN/RED.
+--
+-- Authored by SCOUT (dispatch from Elliot 2026-06-02). Sibling to
+-- fleet_heartbeat_writer (per-process 30s self-ping) and tasks.heartbeat_at
+-- (per-active-task 15min ping). This table is observability ground truth:
+-- a checker outside each agent process probes tmux + NATS + backend + DB
+-- and writes the result, so a wedged agent cannot fake liveness by
+-- pinging itself.
+
+CREATE TABLE IF NOT EXISTS public.fleet_liveness (
+    callsign             TEXT        NOT NULL,
+    checked_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    tmux_alive           BOOLEAN     NOT NULL DEFAULT FALSE,
+    nats_last_publish_at TIMESTAMPTZ,
+    backend_health       TEXT,
+    active_task_id       TEXT,
+    PRIMARY KEY (callsign, checked_at)
+);
+
+CREATE INDEX IF NOT EXISTS fleet_liveness_callsign_checked_at_desc_idx
+    ON public.fleet_liveness (callsign, checked_at DESC);
+
+COMMENT ON TABLE public.fleet_liveness IS
+    'Ground-truth per-agent liveness snapshot, written every 5 minutes by '
+    'scripts/orchestrator/fleet_liveness_checker.py. Read by fleet_check_query '
+    'to score callsigns GREEN/RED. Append-only — historical rows retained '
+    'for drift analysis.';
+
+COMMENT ON COLUMN public.fleet_liveness.tmux_alive IS
+    'TRUE when "tmux has-session -t <callsign>" (or <callsign>bot fallback) '
+    'returns 0. Outside-process check — wedged agents cannot fake this.';
+
+COMMENT ON COLUMN public.fleet_liveness.nats_last_publish_at IS
+    'Timestamp of the most recent message on keiracom.agent.status.<callsign>. '
+    'NULL when stream is empty for that callsign or NATS is unreachable.';
+
+COMMENT ON COLUMN public.fleet_liveness.backend_health IS
+    'Trimmed response body from http://localhost:8000/health (max 256 chars). '
+    'NULL on connection failure or non-2xx response.';
+
+COMMENT ON COLUMN public.fleet_liveness.active_task_id IS
+    'ID of the task currently claimed by this callsign with status=active, '
+    'or NULL when the agent is idle.';
+
+-- Seed nova into agent_profiles so personalised bd ready ordering works for
+-- the worker tier. Per dispatch — nova was omitted from the original KEI-53
+-- seed (which only covered the 6 callsigns alive at the time).
+INSERT INTO public.agent_profiles
+    (callsign, configured_model, context_tags)
+VALUES
+    ('nova', 'claude-sonnet-4-6', ARRAY['build', 'pr', 'python'])
+ON CONFLICT (callsign) DO NOTHING;

--- a/systemd/fleet-liveness-checker.service
+++ b/systemd/fleet-liveness-checker.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Agency_OS — fleet liveness ground-truth checker (5 minute cadence)
+Documentation=file://%h/clawd/Agency_OS/scripts/orchestrator/fleet_liveness_checker.py
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/agency-os/.env
+WorkingDirectory=%h/clawd/Agency_OS
+ExecStart=%h/clawd/Agency_OS/.venv/bin/python3 %h/clawd/Agency_OS/scripts/orchestrator/fleet_liveness_checker.py
+Nice=10
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=120
+
+[Install]
+WantedBy=default.target

--- a/systemd/fleet-liveness-checker.timer
+++ b/systemd/fleet-liveness-checker.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Agency_OS — fire fleet liveness checker every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30
+Persistent=true
+Unit=fleet-liveness-checker.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

New on-box liveness checker that writes ground-truth per-agent status to `public.fleet_liveness` every 5 minutes so the read-side `fleet_check_query` can score callsigns GREEN/RED without trusting agents to self-report.

Dispatch from Elliot 2026-06-02 (STEP 0 PRE-CONFIRMED). Authorised by Head of Ops.

## Changes

- **`supabase/migrations/20260602_fleet_liveness.sql`** — new `public.fleet_liveness` table (callsign, checked_at, tmux_alive, nats_last_publish_at, backend_health, active_task_id); seeds `nova` into `agent_profiles` (was missing from the KEI-53 seed).
- **`scripts/orchestrator/fleet_liveness_checker.py`** — probes tmux (with `<callsign>bot` fallback for `elliottbot`/`maxbot`), NATS JetStream `agent_status` stream, `http://localhost:8000/health`, and `tasks.claimed_by`. Writes one row per callsign per fire. Revives `tasks.heartbeat_at=NOW()` for callsigns that are tmux-alive AND have a claimed-active task. All external calls fail-graceful — NATS down / backend down / DB read error never crash the script.
- **`systemd/fleet-liveness-checker.{service,timer}`** — oneshot service + 5-min timer (`OnBootSec=2min, OnUnitActiveSec=5min, RandomizedDelaySec=30`), follows existing `systemd/` repo conventions (`%h` macros, journal output, `.venv` Python).

## Scope item 3 — `collect_agent_status.py` line 22 fix — SKIPPED

Pre-flight `git log --all --oneline -- scripts/orchestrator/collect_agent_status.py` returned empty, and a repo-wide grep found the file referenced only as a comment in `scripts/orchestrator/elliot_polling_loop.py:304` describing it as an "existing observability layer". The file does not exist in this branch or in any commit reachable from `origin/main`. Per `feedback_preflight_git_grep_before_build`, surfaced back to dispatching parent via outbox rather than fabricated. The broader dispatch objective (7-callsign coverage) is satisfied by the new `CALLSIGNS` list inside `fleet_liveness_checker.py`.

## Empirical Proof

### Positive — all 7 callsigns alive
```
$ python3 scripts/orchestrator/fleet_liveness_checker.py
2026-06-02 06:48:28,895 INFO fleet_liveness_checker: wrote 7/7 rows, revived 1 task heartbeats in 2.45s

callsign | tmux_alive | nats_ts | backend_health | active_task_id
---------+------------+---------+----------------+----------------
aiden    | True       | None    | None           | None
atlas    | True       | None    | None           | None
elliot   | True       | None    | None           | None
max      | True       | None    | None           | None
nova     | True       | None    | None           | None
orion    | True       | None    | None           | None
scout    | True       | None    | None           | REVIEW-PR-1196
```
Heartbeat revived for `scout` (the one callsign with an active claimed task), confirming the side-effect path. Backend `None` because port :8000 is not currently serving — fail-graceful path exercised. NATS `None` because the `agent_status` stream is empty (0 messages on 24h retention) — fail-graceful path exercised.

### Negative — hide `nova` session, expect `nova=FALSE`
```
$ tmux rename-session -t nova nova-paused-negtest
$ python3 scripts/orchestrator/fleet_liveness_checker.py
2026-06-02 06:49:31,696 INFO fleet_liveness_checker: wrote 7/7 rows, revived 1 task heartbeats in 2.42s

callsign | tmux_alive
---------+-----------
aiden    | True
atlas    | True
elliot   | True
max      | True
nova     | False    <-- went RED as expected
orion    | True
scout    | True
```

### Negative test caught a real bug
First run of the negative test reported `nova=True` despite the rename. Root cause: `tmux has-session -t nova` uses **prefix matching** by default and matched `nova-paused-negtest`. Fixed in commit by switching to `tmux has-session -t =nova` (exact-match prefix). Without the negative test this would have shipped silently and given false-green readings for any callsign whose session was renamed/forked.

### Recovery
```
$ tmux rename-session -t nova-paused-negtest nova
$ python3 scripts/orchestrator/fleet_liveness_checker.py
# all 7 TRUE again
```

### Systemd path
Service unit fires from `%h/clawd/Agency_OS/` (main worktree). Tested with a temporary drop-in pointing at this worktree:
```
Jun 02 06:50:22 vultr python3[1823988]: ... wrote 7/7 rows, revived 1 task heartbeats in 2.45s
Jun 02 06:50:22 vultr systemd[1293]: Finished fleet-liveness-checker.service
```
Drop-in removed. Timer is **installed but currently disabled** on the host — re-enable after merge so the path `Agency_OS/scripts/orchestrator/fleet_liveness_checker.py` resolves:
```
systemctl --user daemon-reload
systemctl --user enable --now fleet-liveness-checker.timer
```

## Proven gate

Per dispatch, the formal proof-gate cannot fire until PR #1396 (migration runner) lands. The empirical proof above is the in-PR substitute — migration applied via `DATABASE_URL_MIGRATIONS` against staging Postgres, schema verified, script ran end-to-end, negative+positive paths both executed.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] Migration applies cleanly against staging (idempotent — uses `IF NOT EXISTS` + `ON CONFLICT DO NOTHING`)
- [x] Script writes 7/7 rows + revives 1 task heartbeat in positive case
- [x] Negative case (hidden tmux session) returns tmux_alive=FALSE only for the hidden callsign
- [x] Recovery case returns to all-TRUE after restoring the session
- [x] Systemd unit fires successfully end-to-end (verified via temporary drop-in)
- [ ] Re-enable timer on host after merge — `systemctl --user enable --now fleet-liveness-checker.timer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)