### PR TITLE
[ORION] feat(fleet_liveness): GREEN/RED/UNKNOWN status view for Dave fleet_check_query

### DIFF
--- a/supabase/migrations/20260602_fleet_liveness_status_view.sql
+++ b/supabase/migrations/20260602_fleet_liveness_status_view.sql
@@ -1,0 +1,41 @@
+-- Fleet liveness status view — Dave-gate read contract on top of Scout's
+-- append-only public.fleet_liveness history (migration
+-- 20260602_fleet_liveness.sql, commit bb1e7a950).
+--
+-- Dave's fleet_check_query is:
+--     SELECT callsign, status FROM public.fleet_liveness_status ORDER BY callsign;
+--
+-- The base table is observability ground truth — append-only with raw signals
+-- (tmux_alive, nats_last_publish_at, backend_health, active_task_id). The
+-- GREEN/RED/UNKNOWN classification belongs at the read-side so the history
+-- stays untouched and re-classification is a view swap, not a backfill.
+--
+-- Status rules:
+--   GREEN   — most-recent row has tmux_alive=TRUE AND checked_at within 10 min
+--   RED     — most-recent row has tmux_alive=FALSE AND checked_at within 10 min
+--             (agent observed dead by the checker, not just stale)
+--   UNKNOWN — most-recent row is older than 10 min (or no row at all — the
+--             callsign falls out of DISTINCT ON entirely in that case)
+--
+-- 10-min staleness window matches the 5-min checker cadence + 1 cycle of slack
+-- (a single missed run does not flip to UNKNOWN; two consecutive misses do).
+--
+-- Authored by ORION (dispatch from Elliot 2026-06-02). Sibling to Scout's
+-- 20260602_fleet_liveness.sql; does NOT modify the table.
+
+CREATE OR REPLACE VIEW public.fleet_liveness_status AS
+SELECT DISTINCT ON (callsign)
+    callsign,
+    CASE
+        WHEN tmux_alive AND checked_at > NOW() - INTERVAL '10 min' THEN 'GREEN'
+        WHEN checked_at > NOW() - INTERVAL '10 min' THEN 'RED'
+        ELSE 'UNKNOWN'
+    END AS status,
+    checked_at AS last_seen
+FROM public.fleet_liveness
+ORDER BY callsign, checked_at DESC;
+
+COMMENT ON VIEW public.fleet_liveness_status IS
+    'Latest GREEN/RED/UNKNOWN classification per callsign computed from '
+    'public.fleet_liveness. Read by Dave fleet_check_query; classification '
+    'rules in 20260602_fleet_liveness_status_view.sql header.';


### PR DESCRIPTION
Dave directive 2026-06-02 — Option A (view) selected by Elliot after pre-flight git-grep confirmed Scout had already shipped the table + checker + timer in commit `bb1e7a950`. This PR adds **only the read-side view** that maps Scout's append-only signal history to the GREEN/RED/UNKNOWN classification Dave's gate query expects.

## What this PR does

Single new file: `supabase/migrations/20260602_fleet_liveness_status_view.sql`.

```sql
CREATE OR REPLACE VIEW public.fleet_liveness_status AS
SELECT DISTINCT ON (callsign)
    callsign,
    CASE
        WHEN tmux_alive AND checked_at > NOW() - INTERVAL '10 min' THEN 'GREEN'
        WHEN checked_at > NOW() - INTERVAL '10 min' THEN 'RED'
        ELSE 'UNKNOWN'
    END AS status,
    checked_at AS last_seen
FROM public.fleet_liveness
ORDER BY callsign, checked_at DESC;
```

## What this PR does NOT do

- Does NOT modify `public.fleet_liveness` (Scout's table, append-only by design).
- Does NOT modify `scripts/orchestrator/fleet_liveness_checker.py` (Scout's 4-signal probe).
- Does NOT modify `systemd/fleet-liveness-checker.service` / `.timer` (5-min cadence).
- Does NOT apply the migration — that waits on `[MIGRATION:APPLIED:atlas]` so the `proof_gate_ledger` is in place first.
- Does NOT run the kill-one-agent proof gate — that waits on `[DISPATCHER-PROOF-DONE:scout]`.

## Status semantics

| Condition on the most-recent row per callsign | Status |
|---|---|
| `tmux_alive=TRUE` AND `checked_at > NOW() - INTERVAL '10 min'` | `GREEN` |
| `tmux_alive=FALSE` AND `checked_at > NOW() - INTERVAL '10 min'` | `RED` |
| `checked_at <= NOW() - INTERVAL '10 min'` (or no row) | `UNKNOWN` |

**Why 10 min:** Scout's checker runs every 5 min via systemd timer. The 10-min window = 1 cycle of slack — a single missed run does NOT flip to UNKNOWN, two consecutive misses do. Tunable in a later migration without re-classifying historical rows.

**Why a view (not a column):** read-side classification keeps Scout's append-only history untouched, makes any future re-classification (e.g. a 15-min window, a more nuanced RED-vs-DEGRADED split) a one-line view swap rather than a backfill + trigger rewrite.

## Verification (dry-run on staging)

```
$ mcp supabase execute_sql 'BEGIN; <view SQL>; SELECT callsign, status FROM public.fleet_liveness_status ORDER BY callsign; ROLLBACK;'
[
  {"callsign":"aiden","status":"UNKNOWN"},
  {"callsign":"atlas","status":"UNKNOWN"},
  {"callsign":"elliot","status":"UNKNOWN"},
  {"callsign":"max","status":"UNKNOWN"},
  {"callsign":"nova","status":"UNKNOWN"},
  {"callsign":"orion","status":"UNKNOWN"},
  {"callsign":"scout","status":"UNKNOWN"}
]
```

All 7 callsigns return. All currently UNKNOWN because the most-recent fleet_liveness batch at dry-run time was 35 min old (outside the 10-min freshness window — semantics correct; once the checker resumes regular cadence, healthy callsigns flip to GREEN).

## Sequencing

1. **This PR** — view migration in repo (DONE; this commit).
2. Atlas posts `[MIGRATION:APPLIED:atlas]` → I apply this migration to staging via `mcp supabase execute_sql`.
3. Post `[VIEW-BUILT:orion]` after step 2 verification (`SELECT callsign, status FROM public.fleet_liveness_status ORDER BY callsign;` returns 7 rows).
4. Scout posts `[DISPATCHER-PROOF-DONE:scout]` → run kill-one-agent proof: kill nova tmux, re-probe, verify RED, restart, verify GREEN.
5. Log to `proof_gate_ledger` with `attester=max`.
6. Post `[FLEET-LIVENESS-PROOF:orion]` with verbatim before/after/restart SELECT outputs.

Commit: `192a45c88`.