### PR TITLE
[NOVA] feat(agent_os): advisory-only code flag at integration boundary (GOV-12)

### DIFF
--- a/src/integrations/agent_os.py
+++ b/src/integrations/agent_os.py
@@ -1,0 +1,78 @@
+"""
+Contract: src/integrations/agent_os.py
+Purpose: MS Agent OS integration boundary — advisory-only by default.
+Layer: integration
+Directive: agent-os-advisory-flag (GOV-12)
+
+ADVISORY_ONLY is a runtime CODE FLAG (env-driven), not a doc note.
+When True, the Agent OS evaluate() path logs + returns a verdict but
+NEVER blocks or raises. Enforcement (blocking) stays 100% in the
+Sidecar (src/governance/gatekeeper.py). Agent OS does not touch it.
+
+The check at the call site is a single boolean guard (see
+`evaluate()`), satisfying GOV-12 "gates as code not comments".
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _read_advisory_only() -> bool:
+    """Read AGENT_OS_ADVISORY_ONLY env var. Default: True (safe — never blocks)."""
+    raw = os.environ.get("AGENT_OS_ADVISORY_ONLY", "true").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+ADVISORY_ONLY: bool = _read_advisory_only()
+
+
+@dataclass(frozen=True)
+class AgentOSVerdict:
+    """Result of an Agent OS evaluation. `surfaced` = logged for ops review."""
+
+    allowed: bool
+    reason: str
+    surfaced: bool = True
+
+
+def evaluate(action: str, context: dict[str, Any] | None = None) -> AgentOSVerdict:
+    """
+    Agent OS advisory evaluation at the integration boundary.
+
+    GOV-12 enforcement: the ADVISORY_ONLY guard below is the gate. If
+    True, we log + surface a verdict and return. We do NOT raise. We do
+    NOT block. Sidecar (gatekeeper) owns blocking.
+
+    Args:
+        action: Action identifier being evaluated (e.g. "tool.bash.exec").
+        context: Optional context dict (callsign, tool args, etc.).
+
+    Returns:
+        AgentOSVerdict — advisory only when ADVISORY_ONLY is True.
+    """
+    ctx = context or {}
+    verdict = AgentOSVerdict(allowed=True, reason="advisory-stub:no-rules-loaded")
+
+    if ADVISORY_ONLY:
+        logger.info(
+            "agent_os.advisory action=%s callsign=%s verdict=%s reason=%s",
+            action,
+            ctx.get("callsign", "unknown"),
+            verdict.allowed,
+            verdict.reason,
+        )
+        return verdict
+
+    # Non-advisory path is intentionally NOT implemented here. Enforcement
+    # is the Sidecar's job (src/governance/gatekeeper.py). Reaching this
+    # branch means a misconfiguration — fail loud, do not silently block.
+    raise RuntimeError(
+        "agent_os.evaluate called with ADVISORY_ONLY=False; "
+        "enforcement belongs to the Sidecar, not Agent OS"
+    )

--- a/tests/integrations/test_agent_os_advisory.py
+++ b/tests/integrations/test_agent_os_advisory.py
@@ -1,0 +1,49 @@
+"""
+Contract: tests/integrations/test_agent_os_advisory.py
+Purpose: Verify the ADVISORY_ONLY flag at the Agent OS integration boundary.
+Layer: test
+Directive: agent-os-advisory-flag (GOV-12)
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+
+import pytest
+
+
+def _reload_with_flag(monkeypatch: pytest.MonkeyPatch, value: str | None):
+    if value is None:
+        monkeypatch.delenv("AGENT_OS_ADVISORY_ONLY", raising=False)
+    else:
+        monkeypatch.setenv("AGENT_OS_ADVISORY_ONLY", value)
+    import src.integrations.agent_os as agent_os
+
+    return importlib.reload(agent_os)
+
+
+def test_default_is_advisory_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset env defaults to advisory (safe — never blocks)."""
+    mod = _reload_with_flag(monkeypatch, None)
+    assert mod.ADVISORY_ONLY is True
+
+
+def test_advisory_evaluate_does_not_block(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """ADVISORY_ONLY=True: evaluate() logs + returns, never raises."""
+    mod = _reload_with_flag(monkeypatch, "true")
+    with caplog.at_level(logging.INFO, logger="src.integrations.agent_os"):
+        verdict = mod.evaluate("tool.bash.exec", {"callsign": "nova"})
+    assert verdict.allowed is True
+    assert verdict.surfaced is True
+    assert any("agent_os.advisory" in r.message for r in caplog.records)
+
+
+def test_non_advisory_evaluate_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ADVISORY_ONLY=False: fail loud — enforcement belongs to Sidecar."""
+    mod = _reload_with_flag(monkeypatch, "false")
+    assert mod.ADVISORY_ONLY is False
+    with pytest.raises(RuntimeError, match="Sidecar"):
+        mod.evaluate("tool.bash.exec")


### PR DESCRIPTION
## Summary

- New `src/integrations/agent_os.py`: `ADVISORY_ONLY` env-driven runtime flag at the MS Agent OS integration boundary (default `True`).
- `evaluate()` logs + returns an `AgentOSVerdict` while advisory — never blocks, never raises.
- Non-advisory path is intentionally a `RuntimeError` (fail loud). Enforcement (blocking) stays 100% in the Sidecar (`src/governance/gatekeeper.py`); Agent OS does not touch it.
- 3 tests at `tests/integrations/test_agent_os_advisory.py` covering default / advisory / non-advisory paths (all green: `3 passed in 0.32s`).

## GOV-12 compliance

The gate is **code** (boolean guard at the call site + executable tests), not a comment. Dispatch brief required this explicitly: "Gates As Code", flag must be runtime, not a doc note.

## Scope

Stub only — the brief was "the flag is the deliverable, not the full integration". Module is 78 lines. Wired in from the start so future Agent OS work has the advisory boundary already in place.

## Test plan

- [x] `pytest tests/integrations/test_agent_os_advisory.py` — 3 passed
- [x] Default env unset → `ADVISORY_ONLY=True`
- [x] `AGENT_OS_ADVISORY_ONLY=true` → `evaluate()` logs `agent_os.advisory ...` and returns `allowed=True`
- [x] `AGENT_OS_ADVISORY_ONLY=false` → `evaluate()` raises `RuntimeError("...Sidecar...")` (fail loud, no silent enforcement)

task_ref: agent-os-advisory-flag