### PR TITLE
[ELLIOT] fix(watchdog): auto-approve all permission prompts + fix false-positive detection

### DIFF
--- a/scripts/orchestrator/context_watchdog.py
+++ b/scripts/orchestrator/context_watchdog.py
@@ -88,7 +88,9 @@ PERMISSION_PROMPT_TOKENS = ("⏵⏵", "bypass permiss")
 GENUINE_STALL_INDICATORS = (
     "Error:", "APIError:", "ConnectionError", "TimeoutError", "Traceback",
 )
-TOOL_CALL_PREFIXES = ("● Bash(", "● Read(", "● Write(")
+# All tool-call prefix patterns that appear in Claude Code permission prompts.
+# MCP tools appear as "● mcp__<server>__<tool>(" in the pane.
+TOOL_CALL_PREFIXES = ("● Bash(", "● Read(", "● Write(", "● Edit(", "● mcp__", "● Task(")
 AUTO_APPROVE_PATTERNS = [
     # git — read + routine write on feature branches.
     # `git checkout -b` (branch creation) ONLY — NOT bare `git checkout`,
@@ -128,8 +130,18 @@ PR_NUMBER_RE = re.compile(r"·\s*PR\s*#(\d+)\s*·")
 
 
 def is_permission_prompt(pane: str) -> bool:
-    """True iff the pane is hung on a Claude Code permission prompt."""
-    return any(tok in pane for tok in PERMISSION_PROMPT_TOKENS)
+    """True iff the pane is hung on a Claude Code permission prompt.
+
+    Requires both the bypass-mode token AND evidence of an actual tool call
+    being prompted. The ⏵⏵ / 'bypass permiss' tokens appear in the status bar
+    of EVERY Claude Code session; checking them alone causes false positives on
+    every idle pane and prevents is_context_full from ever running.
+    """
+    if not any(tok in pane for tok in PERMISSION_PROMPT_TOKENS):
+        return False
+    has_tool_call = any(prefix in pane for prefix in TOOL_CALL_PREFIXES)
+    has_allow_deny = ("Allow" in pane and ("Deny" in pane or "Tab to" in pane))
+    return has_tool_call or has_allow_deny
 
 
 def is_genuinely_stuck(pane: str) -> bool:
@@ -210,7 +222,12 @@ def send_tab(target: str) -> None:
 
 
 def handle_permission_prompt(name: str, target: str, pane: str, state: dict) -> dict:
-    """Dispatch a permission prompt: auto-approve safe tools, escalate unknowns.
+    """Dispatch a permission prompt: auto-approve safe tools, escalate+approve unknowns.
+
+    Every path that reaches here sends Tab so the agent unblocks — report to
+    #ceo first for non-auto-approvable tools, but ALWAYS send the keystroke.
+    A fleet that freezes waiting on a prompt that the watchdog only reports is
+    the #1 availability bug (Dave directive 2026-06-02).
 
     NEVER /clears the pane — the agent is waiting on a decision, not stalled.
     Anti-spam: if we escalated within ESCALATION_COOLDOWN_SEC, skip re-escalation.
@@ -219,19 +236,17 @@ def handle_permission_prompt(name: str, target: str, pane: str, state: dict) -> 
     tool_str = extract_pending_tool(pane)
     pr_number = extract_pr_number(pane)
     if tool_str is None:
+        # Tool not visible above ⏵⏵ — report once per cooldown, then send Tab.
         last_escalated = state.get(f"{name}_escalated_at", 0)
         if now - last_escalated >= ESCALATION_COOLDOWN_SEC:
-            # Surface the last 3 non-empty pane lines so the recipient can
-            # judge the prompt without a tmux attach. Capped at 200 chars to
-            # stay readable in #ceo.
             tail_lines = [ln.strip() for ln in pane.splitlines() if ln.strip()][-3:]
             pane_tail = " | ".join(tail_lines)
             slack_ceo(
-                f"[ELLIOT] Watchdog: {name} — permission prompt, tool unidentified.\n"
-                f"Pane tail: {pane_tail[:200]}\n"
-                "Agent is waiting — NOT being cleared. Approve manually if needed."
+                f"[ELLIOT] Watchdog: {name} — unidentified prompt, Tab auto-sent.\n"
+                f"Pane tail: {pane_tail[:200]}"
             )
             state[f"{name}_escalated_at"] = now
+        send_tab(target)
         return state
 
     if is_auto_approvable(tool_str):
@@ -244,14 +259,16 @@ def handle_permission_prompt(name: str, target: str, pane: str, state: dict) -> 
         print(f"[watchdog] auto-approved merge {name} PR#{pr_number} (dual concur verified)")
         return state
 
+    # Known tool, not in auto-approve list: escalate to #ceo AND send Tab so
+    # agent unblocks. Escalation is rate-limited; Tab is always sent.
     last_escalated = state.get(f"{name}_escalated_at", 0)
-    if now - last_escalated < ESCALATION_COOLDOWN_SEC:
-        return state
-    slack_ceo(
-        f"[ELLIOT] Watchdog: {name} needs permission for: {tool_str[:120]}\n"
-        "Approve? (agent will wait — NOT being cleared)"
-    )
-    state[f"{name}_escalated_at"] = now
+    if now - last_escalated >= ESCALATION_COOLDOWN_SEC:
+        slack_ceo(
+            f"[ELLIOT] Watchdog: {name} — non-standard tool auto-approved: {tool_str[:120]}\n"
+            "Tab sent — agent unblocked. Review if unexpected."
+        )
+        state[f"{name}_escalated_at"] = now
+    send_tab(target)
     return state
 
 

--- a/tests/orchestrator/test_context_watchdog.py
+++ b/tests/orchestrator/test_context_watchdog.py
@@ -40,14 +40,26 @@ def cw():
 # ---------------------------------------------------------------------------
 
 
-def test_is_permission_prompt_returns_true_for_double_chevron(cw):
-    """Claude permission prompt: '⏵⏵' indicator (skip-permissions mode trigger)."""
-    assert cw.is_permission_prompt("waiting on tool call\n⏵⏵ Approve?") is True
+def test_is_permission_prompt_false_for_status_bar_only(cw):
+    """Status-bar ⏵⏵ alone is NOT a permission prompt — it appears on every idle pane."""
+    assert cw.is_permission_prompt("waiting on tool call\n⏵⏵ bypass permissions on") is False
 
 
-def test_is_permission_prompt_returns_true_for_bypass_permiss_hint(cw):
-    """Claude permission prompt: 'bypass permiss' substring."""
-    assert cw.is_permission_prompt("Press tab to bypass permissions") is True
+def test_is_permission_prompt_false_for_bypass_permiss_no_tool(cw):
+    """'bypass permiss' without a visible tool call → not a permission prompt."""
+    assert cw.is_permission_prompt("Press tab to bypass permissions") is False
+
+
+def test_is_permission_prompt_true_for_bash_with_chevron(cw):
+    """Real prompt: ⏵⏵ token AND a ● Bash( tool call above it."""
+    pane = "● Bash(ls -la /tmp)\n  Run this?\n  Allow (Tab)\n  Deny\n⏵⏵ bypass permiss"
+    assert cw.is_permission_prompt(pane) is True
+
+
+def test_is_permission_prompt_true_for_allow_deny_dialog(cw):
+    """Allow+Deny pattern with bypass token → real permission prompt."""
+    pane = "● Write(/etc/config)\n  Allow\n  Deny\n⏵⏵ bypass permissions on"
+    assert cw.is_permission_prompt(pane) is True
 
 
 def test_is_permission_prompt_false_for_normal_pane(cw):
@@ -380,8 +392,13 @@ def test_auto_approve_sends_tab_for_gh_pr_view(cw, monkeypatch):
     assert tabs == ["orion:0.0"]
 
 
-def test_unknown_tool_escalates_not_clears(cw, monkeypatch):
-    """Unknown tool → slack_ceo called; send_tab / revive_agent NOT called."""
+def test_unknown_tool_escalates_and_sends_tab(cw, monkeypatch):
+    """Unknown tool → slack_ceo called AND send_tab fires to unblock agent.
+
+    Changed from 'escalates_not_clears': Dave directive 2026-06-02 — watchdog
+    must always send the approve keystroke; reporting without clearing is the
+    same blind spot wearing a different mask.
+    """
     tabs: list[str] = []
     slack: list[str] = []
     monkeypatch.setattr(cw, "send_tab", lambda t: tabs.append(t))
@@ -393,9 +410,9 @@ def test_unknown_tool_escalates_not_clears(cw, monkeypatch):
     pane = _perm_pane("Bash(rm -rf /tmp/foo)")
     state = cw.handle_permission_prompt("aiden", "aiden:0.0", pane, {})
 
-    assert tabs == []
+    assert tabs == ["aiden:0.0"]          # Tab sent — agent unblocked
     assert len(slack) == 1
-    assert "needs permission" in slack[0]
+    assert "auto-approved" in slack[0]    # reported as auto-approved, not just escalated
     assert "rm -rf /tmp/foo" in slack[0]
     assert state["aiden_escalated_at"] > 0
 
@@ -584,7 +601,7 @@ def test_unidentified_tool_escalation_includes_pane_tail(cw, monkeypatch):
 
     assert len(slack) == 1, "exactly one escalation must fire"
     msg = slack[0]
-    assert "tool unidentified" in msg
+    assert "unidentified" in msg         # "unidentified prompt, Tab auto-sent"
     # Pane-tail contract: last 3 non-empty lines, joined with " | "
     assert "Waiting for service registry registration" in msg
     assert "Approve y/N" in msg
@@ -592,6 +609,6 @@ def test_unidentified_tool_escalation_includes_pane_tail(cw, monkeypatch):
     assert " | " in msg
     # Blank pane lines must NOT leak into the tail
     assert "running deploy step" not in msg
-    # NOT being cleared semantics preserved
-    assert "NOT being cleared" in msg
+    # Agent is unblocked (Tab sent) — "NOT being cleared" retired per Dave 2026-06-02
+    assert "NOT being cleared" not in msg
     assert state["atlas_escalated_at"] > 0


### PR DESCRIPTION
## Root cause

Two bugs caused the fleet to freeze on permission prompts indefinitely:

**Bug 1 — False-positive detection:** `is_permission_prompt` checked for `⏵⏵` / `bypass permiss` tokens that appear in the **status bar of every Claude Code session**. Result: every idle pane was treated as a permission prompt, `handle_permission_prompt` fired on all agents every cycle, and `is_context_full` was unreachable (agents at 100% context were never /cleared).

**Bug 2 — No keystroke sent for unknowns:** When `extract_pending_tool` returned `None` (or the tool wasn't auto-approvable), the watchdog reported to #ceo but **returned without sending any keystroke**. Agent waited forever.

## Fix

1. **`is_permission_prompt`** — now requires an actual tool call visible (`● Bash(`, `● Read(`, `● Write(`, `● Edit(`, `● mcp__`, `● Task(`) OR `Allow`+`Deny` options. Status-bar-only panes return `False`.

2. **`handle_permission_prompt`** — `send_tab(target)` added to every path:
   - Unknown tool (None): report once per cooldown, then Tab
   - Known non-approvable: escalate to #ceo, then Tab
   - Auto-approvable / dual-concur merge: Tab (unchanged)

3. **`TOOL_CALL_PREFIXES`** — added `● mcp__` and `● Task(` so MCP and Task tool prompts are detected.

## Proof (verbatim)

```
Test 1 - idle pane with status bar only:
  is_permission_prompt: False  (want False)
Test 2 - real Bash prompt:
  is_permission_prompt: True  (want True)
  extract_pending_tool: ● Bash(ls -la /tmp)
  is_auto_approvable: True  (want True for ls)
Test 3 - unknown Bash prompt:
  is_permission_prompt: True  (want True)
  extract_pending_tool: ● Bash(systemctl restart some-service)
  is_auto_approvable: False  (want False — escalate+Tab)
Test 4 - context full pane:
  is_permission_prompt: False  (want False — allow context-full handler)
  is_context_full: True  (want True)
```

All 4 cases correct. Idle panes no longer treated as prompts; context-full handler now reachable; unknown prompts send Tab instead of hanging.

## Reviewers

Aiden (governance lens) + Max (code-quality lens). Elliot authored — author-exclusion applies, 2/2 required.