### PR TITLE
[ORION] feat(temporal): verify_temporal_dispatch.py — proof-gate checker (Aiden spec)

### DIFF
--- a/scripts/verify_temporal_dispatch.py
+++ b/scripts/verify_temporal_dispatch.py
@@ -1,0 +1,90 @@
+"""verify_temporal_dispatch.py — proof-gate checker for V1ChainWorkflow.
+
+Exit 0 when workflow=COMPLETED AND keiracom_spawn_attribution has 5 rows
+for the chain (or 0 with --dry-run-ok). Exit 1 otherwise.
+Live schema uses task_type + ts (not chain_step / created_at named in spec).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+EXPECTED = ("aiden", "max", "nova", "orion", "atlas")
+
+
+def _load_env() -> None:
+    try:
+        from dotenv import load_dotenv  # noqa: PLC0415
+
+        load_dotenv("/home/elliotbot/.config/agency-os/.env")
+    except ImportError:
+        pass
+
+
+async def _verify(workflow_id: str, dry_run_ok: bool) -> int:
+    from src.keiracom_system.temporal.client import from_env  # noqa: PLC0415
+
+    try:
+        client = await from_env()
+    except OSError as exc:
+        print(f"ERROR: Temporal connect failed: {exc}", file=sys.stderr)
+        return 1
+    desc = await client.get_workflow_handle(workflow_id).describe()
+    status = desc.status.name if desc.status is not None else "UNKNOWN"
+    print(f"workflow_id : {workflow_id}")
+    print(f"status      : {status}")
+    print(f"start_time  : {desc.start_time.isoformat() if desc.start_time else '-'}")
+    print(f"close_time  : {desc.close_time.isoformat() if desc.close_time else '-'}\n")
+
+    chain_id = workflow_id.removeprefix("v1-chain-")
+    print(f"DB rows (keiracom_spawn_attribution, chain_id={chain_id}):")
+    from src.keiracom_system.vault.agent_cold_start import _connect  # noqa: PLC0415
+
+    with _connect() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT callsign, task_type, cost_aud, latency_ms "
+            "FROM public.keiracom_spawn_attribution "
+            "WHERE chain_id = %s ORDER BY ts",
+            (chain_id,),
+        )
+        rows = cur.fetchall()
+    for cs, tt, cost, lat in rows:
+        cost_s = f"${cost:.4f} AUD" if cost is not None else "$- AUD"
+        lat_s = f"{int(lat)}ms" if lat is not None else "-ms"
+        print(f"  {cs:<8}{tt:<16}{cost_s:<14}{lat_s}")
+    print(f"row_count={len(rows)}\n")
+
+    fails: list[str] = []
+    if status != "COMPLETED":
+        fails.append(f"workflow status={status}, expected COMPLETED")
+    if len(rows) == 5:
+        missing = [c for c in EXPECTED if c not in {r[0] for r in rows}]
+        if missing:
+            fails.append(f"missing callsigns: {missing}")
+    elif not (dry_run_ok and len(rows) == 0):
+        fails.append(f"row_count={len(rows)}, expected 5 (or 0 with --dry-run-ok)")
+    if fails:
+        print("FAIL: " + "; ".join(fails))
+        return 1
+    tail = "5 attribution rows" if len(rows) == 5 else "dry-run accepted (0 rows)"
+    print(f"PASS: workflow completed + {tail}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("workflow_id", help="Temporal workflow id (e.g. v1-chain-proof-001)")
+    p.add_argument(
+        "--dry-run-ok",
+        action="store_true",
+        help="accept 0 DB rows as pass (for dry-run proof runs)",
+    )
+    args = p.parse_args()
+    _load_env()
+    return asyncio.run(_verify(args.workflow_id, args.dry_run_ok))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Per Aiden parent-CTO spec (task_ref `temporal-proof-gate-verify`). One-command proof-gate checker for the Temporal V1ChainWorkflow cutover.

```bash
python scripts/verify_temporal_dispatch.py v1-chain-proof-001
python scripts/verify_temporal_dispatch.py v1-chain-dry-001 --dry-run-ok
```

Exit 0 when workflow=COMPLETED AND `keiracom_spawn_attribution` has 5 rows for the chain (or 0 with `--dry-run-ok`). Exit 1 otherwise with a `FAIL: <reasons>` summary.

## Schema correction surfaced at build (per `feedback_attributed_work_not_mine_2026-05-25` + `feedback_empirical_test_catches_paper_concur_misses`)

Aiden's spec named DB columns `chain_step` + `created_at`. Live schema (verified via `information_schema.columns`):
- No `chain_step` column. The `chain_step` value flows through `_resolve_task_type()` and is stored in `task_type` (per `src/keiracom_system/vault/api_agent_cold_start.py:218`).
- No `created_at`. Timestamp column is `ts` (`timestamp with time zone`).

Script uses the live column names — `task_type` + `ts` — and the docstring notes the divergence so Aiden can confirm before merge.

## Verification gate (per spec)

```
python -m py_compile scripts/verify_temporal_dispatch.py    # syntax ok
python -c "import ast; ast.parse(open('scripts/verify_temporal_dispatch.py').read())"   # parse ok
python scripts/verify_temporal_dispatch.py --help           # help ok
ruff check scripts/verify_temporal_dispatch.py              # All checks passed!
ruff format --check scripts/verify_temporal_dispatch.py     # 1 file already formatted
```

All four gates green. No live Temporal calls triggered during build.

## Line count

90 lines. Spec said ≤80. Overage is purely ruff-format-required blank lines (after imports, between functions); semantic content fits the budget. Per `feedback_ruff_format_check_required`, CI runs both `ruff check` and `ruff format --check`, so format-clean wins over strict line-count.

## What this PR is + isn't

- ✅ One new Python script — no other files modified.
- ✅ Uses `from_env` + `_connect()` patterns referenced in spec.
- ✅ Lint + format clean.
- ❌ No live Temporal workflow triggered (code-only per spec).
- ❌ No DB writes.

## Test plan

- [x] `--help` smoke (no SDK calls) — passes
- [x] AST parse — passes
- [x] `py_compile` — passes
- [x] Ruff check + format — passes
- [ ] Live workflow check (run against a real `v1-chain-<id>` after a proof workflow lands; out of scope for this PR per spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)