### PR TITLE
[SCOUT] fix(v1_chain): activity-local httpx + max_tokens — two regressions from PR #1412

### DIFF
--- a/src/keiracom_system/temporal/v1_chain_workflow.py
+++ b/src/keiracom_system/temporal/v1_chain_workflow.py
@@ -28,7 +28,14 @@ from dataclasses import dataclass
 from datetime import timedelta
 from uuid import uuid4
 
-import httpx
+# NB: httpx is intentionally NOT imported at module-top.
+# This module defines BOTH the activity (run_chain_step) and the workflow
+# (V1ChainWorkflow). Temporal validates every workflow under a sandbox that
+# re-evaluates module imports with deterministic-only restrictions — httpx
+# transitively pulls urllib.request which the sandbox refuses, killing the
+# whole worker at startup (validates ALL workflows including
+# FleetSupervisorWorkflow). httpx is only used in the activity, which runs
+# outside the sandbox, so import it lazily inside run_chain_step instead.
 
 try:
     from temporalio import activity, workflow
@@ -64,6 +71,7 @@ _DEFAULT_INTERCEPTOR_URL = "http://127.0.0.1:4001/interceptor/forward"
 _INTERCEPTOR_TIMEOUT_S = 300.0
 _INTERCEPTOR_MODEL = "governance_tier_fast"
 _INTERCEPTOR_TIER = "starter"
+_INTERCEPTOR_MAX_TOKENS = 2000  # matches governance_tier_fast LiteLLM cap; required by /interceptor/forward schema
 
 
 @dataclass
@@ -159,6 +167,8 @@ async def run_chain_step(inp: ChainStepInput) -> ChainStepOutput:
     hb_task = asyncio.create_task(_heartbeat())
 
     try:
+        import httpx  # noqa: PLC0415 — activity-only; module-top import breaks the workflow sandbox
+
         from src.keiracom_system.vault.api_agent_cold_start import (  # noqa: PLC0415
             fetch_persona,
             insert_attribution,
@@ -177,6 +187,7 @@ async def run_chain_step(inp: ChainStepInput) -> ChainStepOutput:
             "prompt": inp.brief,
             "model": _INTERCEPTOR_MODEL,
             "tier": _INTERCEPTOR_TIER,
+            "max_tokens": _INTERCEPTOR_MAX_TOKENS,
             "messages": [
                 {"role": "system", "content": persona},
                 {"role": "user", "content": inp.brief},


### PR DESCRIPTION
## Summary

Two regressions from my own PR #1412 blocking the xjtn chain proof. Both fixed in this hotfix.

## Regression 1 — module-top `import httpx` killed worker startup

Worker died at start with:
```
RuntimeError: Failed validating workflow FleetSupervisorWorkflow
... caused by
RestrictedWorkflowAccessError: Cannot access urllib.request.Request.__mro_entries__
from inside a workflow.
```
`v1_chain_workflow.py` defines BOTH the activity (`run_chain_step`) AND the workflow (`V1ChainWorkflow`). Temporal validates every workflow in a sandbox that re-evaluates module imports with deterministic-only restrictions. `httpx` transitively pulls `urllib.request` which the sandbox refuses — worker validation crashed before any activity ran, taking down `FleetSupervisorWorkflow` AND `V1ChainWorkflow` (whole worker dead).

**Fix:** move `import httpx` inside `run_chain_step`. Activities run outside the sandbox so lazy-import in the activity body keeps module top-level sandbox-clean. Module-top comment documents the constraint so the next person doesn't undo it.

## Regression 2 — body missing required `max_tokens`

Every `/interceptor/forward` POST returned `HTTP 403 schema:max_tokens is required`. Canonical `VALID_BODY` in `tests/dispatcher/test_interceptor_proxy.py:65` includes `max_tokens`; PR #1412 omitted it.

**Fix:** add `_INTERCEPTOR_MAX_TOKENS = 2000` constant (matches `governance_tier_fast` LiteLLM cap) and include in POST body.

## Live proof after fix (scout 2026-06-03 03:20 UTC)

```
workflow_id=v1-chain-xjtn-final-001
run_id=0c1bcfa9-8c25-48c0-b279-0306cc1e550c

Worker log (verbatim):
2026-06-03 03:20:39,523 INFO httpx: HTTP Request: POST http://127.0.0.1:4001/interceptor/forward "HTTP/1.1 200 OK"
2026-06-03 03:20:45,657 INFO httpx: HTTP Request: POST http://127.0.0.1:4001/interceptor/forward "HTTP/1.1 200 OK"
2026-06-03 03:20:50,033 INFO httpx: HTTP Request: POST http://127.0.0.1:4001/interceptor/forward "HTTP/1.1 200 OK"
2026-06-03 03:20:53,990 INFO httpx: HTTP Request: POST http://127.0.0.1:4001/interceptor/forward "HTTP/1.1 200 OK"
2026-06-03 03:20:56,208 INFO httpx: HTTP Request: POST http://127.0.0.1:4001/interceptor/forward "HTTP/1.1 200 OK"
```

All 5 chain hops (`aiden_plan → max_challenge → nova_build → orion_spec ‖ atlas_safety`) completed in **17 seconds**. Zero 4xx, zero 5xx, zero exceptions. Worker stayed alive throughout (no restart loops).

## Tests

```
$ python -m pytest tests/keiracom_system/temporal/ -x -q
23 passed, 4 skipped in 0.27s
```

## Test plan

- [x] Syntax + import smoke
- [x] Existing Temporal suite passes
- [x] Worker starts cleanly (verified live)
- [x] Live xjtn-final-001 run completes 5/5 hops with HTTP 200 (verified above)
- [ ] Reviewers: aiden + max (author-exclusion → 2/2 NATS concur required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)